### PR TITLE
Add mismatched parenthesis detection to formula parsing

### DIFF
--- a/common/lib/calc/calc/calc.py
+++ b/common/lib/calc/calc/calc.py
@@ -100,6 +100,13 @@ class UndefinedVariable(Exception):
     pass
 
 
+class UnmatchedParenthesis(Exception):
+    """
+    Indicate when a student inputs a formula with mismatched parentheses.
+    """
+    pass
+
+
 def lower_dict(input_dict):
     """
     Convert all keys in a dictionary to lowercase; keep their original values.
@@ -249,6 +256,7 @@ def evaluator(variables, functions, math_expr, case_sensitive=False):
         return float('nan')
 
     # Parse the tree.
+    check_parens(math_expr)
     math_interpreter = ParseAugmenter(math_expr, case_sensitive)
     math_interpreter.parse_algebra()
 
@@ -276,6 +284,30 @@ def evaluator(variables, functions, math_expr, case_sensitive=False):
     }
 
     return math_interpreter.reduce_tree(evaluate_actions)
+
+
+def check_parens(formula):
+    """
+    Check that any open parentheses are closed
+
+    Otherwise, raise an UnmatchedParenthesis exception
+    """
+    count = 0
+    delta = {
+        '(': +1,
+        ')': -1
+    }
+    for index, char in enumerate(formula):
+        if char in delta:
+            count += delta[char]
+            if count < 0:
+                msg = "Invalid Input: A closing parenthesis was found after segment " + \
+                      "{}, but there is no matching opening parenthesis before it."
+                raise UnmatchedParenthesis(msg.format(formula[0:index]))
+    if count > 0:
+        msg = "Invalid Input: Parentheses are unmatched. " + \
+              "{} parentheses were opened but never closed."
+        raise UnmatchedParenthesis(msg.format(count))
 
 
 class ParseAugmenter(object):

--- a/common/lib/calc/calc/tests/test_calc.py
+++ b/common/lib/calc/calc/tests/test_calc.py
@@ -554,3 +554,12 @@ class EvaluatorTest(unittest.TestCase):
             calc.evaluator({'r1': 5}, {}, "r1+r2")
         with self.assertRaisesRegexp(calc.UndefinedVariable, 'r1 r3'):
             calc.evaluator(variables, {}, "r1*r3", case_sensitive=True)
+
+    def test_mismatched_parens(self):
+        """
+        Check to see if the evaluator catches mismatched parens
+        """
+        with self.assertRaisesRegexp(calc.UnmatchedParenthesis, 'opened but never closed'):
+            calc.evaluator({}, {}, "(1+2")
+        with self.assertRaisesRegexp(calc.UnmatchedParenthesis, 'no matching opening parenthesis'):
+            calc.evaluator({}, {}, "(1+2))")


### PR DESCRIPTION
This PR applies to formula input problems (both formularesponse and numericalresponse). As part of the parsing, it detects if there are mismatched parentheses, and supplies a meaningful error message to students. This is particularly helpful with long expressions.

Before:

* Invalid input: Could not parse '(1+x' as a formula
* Invalid input: Could not parse '(1+x))' as a formula

After:
* Invalid Input: Parentheses are unmatched. 1 parentheses were opened but never closed.
* Invalid Input: A closing parenthesis was found after segment (1+x), but there is no matching opening parenthesis before it.