### PR TITLE
EDUCATOR-2224 Discussion Topic with no posts have message.

### DIFF
--- a/common/static/common/js/discussion/views/discussion_thread_list_view.js
+++ b/common/static/common/js/discussion/views/discussion_thread_list_view.js
@@ -223,6 +223,10 @@
                     $content = this.renderThread(thread);
                     this.$('.forum-nav-thread-list').append($content);
                 }
+                if (this.$('.forum-nav-thread-list li').length === 0) {
+                    this.clearSearchAlerts();
+                    this.addSearchAlert(gettext('There are no posts in this topic yet.'));
+                }
                 this.showMetadataAccordingToSort();
                 this.renderMorePages();
                 this.trigger('threads:rendered');
@@ -450,7 +454,8 @@
 
             DiscussionThreadListView.prototype.retrieveFirstPage = function(event) {
                 this.collection.current_page = 0;
-                this.collection.reset();
+                this.$('.forum-nav-thread-list').empty();
+                this.collection.models = [];
                 return this.loadMorePages(event);
             };
 
@@ -507,6 +512,7 @@
                         var message, noResponseMsg;
                         if (textStatus === 'success') {
                             self.collection.reset(response.discussion_data);
+                            self.clearSearchAlerts();
                             Content.loadContentInfos(response.annotated_content_info);
                             self.collection.current_page = response.page;
                             self.collection.pages = response.num_pages;
@@ -533,8 +539,11 @@
                                 self.addSearchAlert(message);
                             } else if (response.discussion_data.length === 0) {
                                 self.addSearchAlert(gettext('No posts matched your query.'));
+                                self.displayedCollection.models = [];
                             }
-                            self.displayedCollection.reset(self.collection.models);
+                            if (self.collection.models.length !== 0) {
+                                self.displayedCollection.reset(self.collection.models);
+                            }
                             if (text) {
                                 return self.searchForUser(text);
                             }

--- a/common/static/common/js/spec/discussion/view/discussion_thread_list_view_spec.js
+++ b/common/static/common/js/spec/discussion/view/discussion_thread_list_view_spec.js
@@ -484,6 +484,8 @@
 
             it('renders and removes search alerts', function() {
                 var bar, foo;
+                testAlertMessages(['There are no posts in this topic yet.']);
+                this.view.clearSearchAlerts();
                 testAlertMessages([]);
                 foo = this.view.addSearchAlert('foo');
                 testAlertMessages(['foo']);
@@ -497,6 +499,8 @@
 
             it('renders search alert with custom class', function() {
                 var messages;
+                testAlertMessages(['There are no posts in this topic yet.']);
+                this.view.clearSearchAlerts();
                 testAlertMessages([]);
 
                 this.view.addSearchAlert('foo', 'custom-class');
@@ -517,6 +521,7 @@
 
 
             it('clears all search alerts', function() {
+                this.view.clearSearchAlerts();
                 this.view.addSearchAlert('foo');
                 this.view.addSearchAlert('bar');
                 this.view.addSearchAlert('baz');
@@ -553,13 +558,13 @@
 
             it('adds a search alert when an alternate term was searched', function() {
                 testCorrection(this.view, 'foo');
-                expect(this.view.addSearchAlert.calls.count()).toEqual(1);
+                expect(this.view.addSearchAlert.calls.count()).toEqual(2);
                 return expect(this.view.addSearchAlert.calls.mostRecent().args[0]).toMatch(/foo/);
             });
 
             it('does not add a search alert when no alternate term was searched', function() {
                 testCorrection(this.view, null);
-                expect(this.view.addSearchAlert.calls.count()).toEqual(1);
+                expect(this.view.addSearchAlert.calls.count()).toEqual(2);
                 return expect(this.view.addSearchAlert.calls.mostRecent().args[0]).toMatch(/no posts matched/i);
             });
 

--- a/common/test/acceptance/tests/discussion/test_discussion.py
+++ b/common/test/acceptance/tests/discussion/test_discussion.py
@@ -1354,6 +1354,7 @@ class DiscussionSearchAlertTest(UniqueCourseTest):
 
     @attr(shard=2)
     def test_rewrite_dismiss(self):
+        self.page.dismiss_alert_message("There are no posts in this topic yet.")
         self.setup_corrected_text("foo")
         self.page.perform_search()
         self.check_search_alert_messages(["foo"])
@@ -1362,6 +1363,7 @@ class DiscussionSearchAlertTest(UniqueCourseTest):
 
     @attr(shard=2)
     def test_new_search(self):
+        self.page.dismiss_alert_message("There are no posts in this topic yet.")
         self.setup_corrected_text("foo")
         self.page.perform_search()
         self.check_search_alert_messages(["foo"])
@@ -1376,6 +1378,7 @@ class DiscussionSearchAlertTest(UniqueCourseTest):
 
     @attr(shard=2)
     def test_rewrite_and_user(self):
+        self.page.dismiss_alert_message("There are no posts in this topic yet.")
         self.setup_corrected_text("foo")
         self.page.perform_search(self.SEARCHED_USERNAME)
         self.check_search_alert_messages(["foo", self.SEARCHED_USERNAME])


### PR DESCRIPTION
## [Discussion Topic with no post looks broken EDUCATOR-2224](https://openedx.atlassian.net/browse/EDUCATOR-2224)

### Description:
This PR fixes that when there is no posts in the topic it would shows a message *There are no posts in this topic yet.*.

### How to Test?
**Production**
 - Go to the discussion url : https://courses.edx.org/courses/course-v1:Microsoft+DAT206x+1T2018/discussion/forum/
-  Click on one of the later Topics, until you find a blank one.

**Sandbox**
https://attiyaishaque.sandbox.edx.org/courses/course-v1:edX+DemoX+Demo_Course/discussion/forum/

**Screenshots** 

**Before fix**
<img width="1265" alt="screen shot 2018-02-06 at 3 39 04 pm" src="https://user-images.githubusercontent.com/7627421/35855092-01f2360a-0b54-11e8-8415-cdba1dcdc403.png">
**After fix**
<img width="1264" alt="screen shot 2018-02-06 at 3 35 44 pm" src="https://user-images.githubusercontent.com/7627421/35855106-0d2a0084-0b54-11e8-8fa8-e14cc5360c54.png">



### Reviewers

If you've been tagged for review, please check your corresponding box once you've given the :+1:.
-  [x] @Rabia23 
-  [x] @schenedx 

### Post-review
- [x] Rebase and squash commits


