### PR TITLE
Changed 'instructor' django app to follow plugin pattern

### DIFF
--- a/lms/djangoapps/instructor/apps.py
+++ b/lms/djangoapps/instructor/apps.py
@@ -5,13 +5,33 @@ Instructor Application Configuration
 from django.apps import AppConfig
 from django.conf import settings
 from edx_proctoring.runtime import set_runtime_service
+from openedx.core.constants import COURSE_ID_PATTERN
+from openedx.core.djangoapps.plugins.constants import ProjectType, SettingsType, PluginURLs, PluginSettings
 
 
 class InstructorConfig(AppConfig):
     """
-    Default configuration for the "lms.djangoapps.instructor" Django application.
+    Application Configuration for Instructor.
     """
     name = u'lms.djangoapps.instructor'
+
+    plugin_app = {
+        PluginURLs.CONFIG: {
+            ProjectType.LMS: {
+                PluginURLs.NAMESPACE: u'',
+                PluginURLs.REGEX: u'courses/{}/instructor/api/'.format(COURSE_ID_PATTERN),
+                PluginURLs.RELATIVE_PATH: u'views.api_urls',
+            }
+        },
+        PluginSettings.CONFIG: {
+            ProjectType.LMS: {
+                SettingsType.DEVSTACK: {PluginSettings.RELATIVE_PATH: u'settings.devstack'},
+                SettingsType.AWS: {PluginSettings.RELATIVE_PATH: u'settings.aws'},
+                SettingsType.COMMON: {PluginSettings.RELATIVE_PATH: u'settings.common'},
+                SettingsType.TEST: {PluginSettings.RELATIVE_PATH: u'settings.test'},
+            }
+        }
+    }
 
     def ready(self):
         if settings.FEATURES.get('ENABLE_SPECIAL_EXAMS'):

--- a/lms/djangoapps/instructor/settings/aws.py
+++ b/lms/djangoapps/instructor/settings/aws.py
@@ -1,0 +1,20 @@
+"""AWS environment variables unique to the instructor plugin."""
+import warnings
+
+
+def plugin_settings(settings):
+    """Settings for the instructor plugin."""
+    # Analytics Dashboard
+    settings.ANALYTICS_DASHBOARD_URL = settings.ENV_TOKENS.get(
+        "ANALYTICS_DASHBOARD_URL", settings.ANALYTICS_DASHBOARD_URL
+    )
+    settings.ANALYTICS_DASHBOARD_NAME = settings.ENV_TOKENS.get(
+        "ANALYTICS_DASHBOARD_NAME", settings.ANALYTICS_DASHBOARD_NAME
+    )
+    # Backward compatibility for deprecated feature names
+    if 'ENABLE_S3_GRADE_DOWNLOADS' in settings.FEATURES:
+        warnings.warn(
+            "'ENABLE_S3_GRADE_DOWNLOADS' is deprecated. Please use 'ENABLE_GRADE_DOWNLOADS' instead",
+            DeprecationWarning,
+        )
+        settings.FEATURES['ENABLE_GRADE_DOWNLOADS'] = settings.FEATURES['ENABLE_S3_GRADE_DOWNLOADS']

--- a/lms/djangoapps/instructor/settings/common.py
+++ b/lms/djangoapps/instructor/settings/common.py
@@ -1,0 +1,42 @@
+"""Common environment variables unique to the instructor plugin."""
+from django.utils.translation import ugettext_lazy as _
+
+
+def plugin_settings(settings):
+    """Settings for the instructor plugin."""
+    ### Analytics Dashboard (Insights) settings
+    settings.ANALYTICS_DASHBOARD_URL = ""
+    settings.ANALYTICS_DASHBOARD_NAME = _('Your Platform Insights')
+    settings.FEATURES.update({
+        # Enable display of enrollment counts in instructor dash, analytics section
+        'DISPLAY_ANALYTICS_ENROLLMENTS': True,
+
+        # Display the 'Analytics' tab in the instructor dashboard for CCX courses.
+        # Note: This has no effect unless ANALYTICS_DASHBOARD_URL is already set,
+        #       because without that setting, the tab does not show up for any courses.
+        'ENABLE_CCX_ANALYTICS_DASHBOARD_URL': False,
+
+        # Disable instructor dash buttons for downloading course data
+        # when enrollment exceeds this number
+        'MAX_ENROLLMENT_INSTR_BUTTONS': 200,
+
+        # Grade calculation started from the instructor dashboard will write grades
+        # CSV files to the configured storage backend and give links for downloads.
+        'ENABLE_GRADE_DOWNLOADS': False,
+
+        # Give course staff unrestricted access to grade downloads (if set to False,
+        # only edX superusers can perform the downloads)
+        'ALLOW_COURSE_STAFF_GRADE_DOWNLOADS': False,
+
+        # Show a section in the membership tab of the instructor dashboard
+        # to allow an upload of a CSV file that contains a list of new accounts to create
+        # and register for course.
+        'ALLOW_AUTOMATED_SIGNUPS': False,
+
+        # Batch-Generated Certificates from Instructor Dashboard
+        'CERTIFICATES_INSTRUCTOR_GENERATION': False,
+
+        # Whether to check the "Notify users by email" checkbox in the batch enrollment form
+        # in the instructor dashboard.
+        'BATCH_ENROLLMENT_NOTIFY_USERS_DEFAULT': True,
+    })

--- a/lms/djangoapps/instructor/settings/devstack.py
+++ b/lms/djangoapps/instructor/settings/devstack.py
@@ -1,0 +1,8 @@
+"""Devstack environment variables unique to the instructor plugin."""
+
+
+def plugin_settings(settings):
+    """Settings for the instructor plugin."""
+    # Set this to the dashboard URL in order to display the link from the
+    # dashboard to the Analytics Dashboard.
+    settings.ANALYTICS_DASHBOARD_URL = None

--- a/lms/djangoapps/instructor/settings/test.py
+++ b/lms/djangoapps/instructor/settings/test.py
@@ -1,0 +1,8 @@
+"""Test suite environment variables unique to the instructor plugin."""
+
+
+def plugin_settings(settings):
+    """Settings for the instructor plugin."""
+    # Enable this feature for course staff grade downloads, to enable acceptance tests
+    settings.FEATURES['ENABLE_GRADE_DOWNLOADS'] = True
+    settings.FEATURES['ALLOW_COURSE_STAFF_GRADE_DOWNLOADS'] = True

--- a/lms/envs/aws.py
+++ b/lms/envs/aws.py
@@ -19,7 +19,6 @@ Common traits:
 
 import datetime
 import json
-import warnings
 
 import dateutil
 
@@ -188,14 +187,6 @@ LMS_INTERNAL_ROOT_URL = ENV_TOKENS.get('LMS_INTERNAL_ROOT_URL', LMS_ROOT_URL)
 ENV_FEATURES = ENV_TOKENS.get('FEATURES', {})
 for feature, value in ENV_FEATURES.items():
     FEATURES[feature] = value
-
-# Backward compatibility for deprecated feature names
-if 'ENABLE_S3_GRADE_DOWNLOADS' in FEATURES:
-    warnings.warn(
-        "'ENABLE_S3_GRADE_DOWNLOADS' is deprecated. Please use 'ENABLE_GRADE_DOWNLOADS' instead",
-        DeprecationWarning,
-    )
-    FEATURES['ENABLE_GRADE_DOWNLOADS'] = FEATURES['ENABLE_S3_GRADE_DOWNLOADS']
 
 CMS_BASE = ENV_TOKENS.get('CMS_BASE', 'studio.edx.org')
 
@@ -583,10 +574,6 @@ DATADOG.update(ENV_TOKENS.get("DATADOG", {}))
 # TODO: deprecated (compatibility with previous settings)
 if 'DATADOG_API' in AUTH_TOKENS:
     DATADOG['api_key'] = AUTH_TOKENS['DATADOG_API']
-
-# Analytics Dashboard
-ANALYTICS_DASHBOARD_URL = ENV_TOKENS.get("ANALYTICS_DASHBOARD_URL", ANALYTICS_DASHBOARD_URL)
-ANALYTICS_DASHBOARD_NAME = ENV_TOKENS.get("ANALYTICS_DASHBOARD_NAME", ANALYTICS_DASHBOARD_NAME)
 
 # Analytics API
 ANALYTICS_API_KEY = AUTH_TOKENS.get("ANALYTICS_API_KEY", ANALYTICS_API_KEY)

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -200,20 +200,8 @@ FEATURES = {
     # Automatically approve student identity verification attempts
     'AUTOMATIC_VERIFY_STUDENT_IDENTITY_FOR_TESTING': False,
 
-    # Disable instructor dash buttons for downloading course data
-    # when enrollment exceeds this number
-    'MAX_ENROLLMENT_INSTR_BUTTONS': 200,
-
-    # Grade calculation started from the instructor dashboard will write grades
-    # CSV files to the configured storage backend and give links for downloads.
-    'ENABLE_GRADE_DOWNLOADS': False,
-
     # whether to use password policy enforcement or not
     'ENFORCE_PASSWORD_POLICY': True,
-
-    # Give course staff unrestricted access to grade downloads (if set to False,
-    # only edX superusers can perform the downloads)
-    'ALLOW_COURSE_STAFF_GRADE_DOWNLOADS': False,
 
     'ENABLED_PAYMENT_REPORTS': [
         "refund_report",
@@ -274,14 +262,6 @@ FEATURES = {
     # Enable organizational email opt-in
     'ENABLE_MKTG_EMAIL_OPT_IN': False,
 
-    # Show a section in the membership tab of the instructor dashboard
-    # to allow an upload of a CSV file that contains a list of new accounts to create
-    # and register for course.
-    'ALLOW_AUTOMATED_SIGNUPS': False,
-
-    # Enable display of enrollment counts in instructor dash, analytics section
-    'DISPLAY_ANALYTICS_ENROLLMENTS': True,
-
     # Show the mobile app links in the footer
     'ENABLE_FOOTER_MOBILE_APP_LINKS': False,
 
@@ -324,9 +304,6 @@ FEATURES = {
 
     # Certificates Web/HTML Views
     'CERTIFICATES_HTML_VIEW': False,
-
-    # Batch-Generated Certificates from Instructor Dashboard
-    'CERTIFICATES_INSTRUCTOR_GENERATION': False,
 
     # Course discovery feature
     'ENABLE_COURSE_DISCOVERY': False,
@@ -378,11 +355,6 @@ FEATURES = {
     # making multiple queries.
     'ENABLE_READING_FROM_MULTIPLE_HISTORY_TABLES': True,
 
-    # Display the 'Analytics' tab in the instructor dashboard for CCX courses.
-    # Note: This has no effect unless ANALYTICS_DASHBOARD_URL is already set,
-    #       because without that setting, the tab does not show up for any courses.
-    'ENABLE_CCX_ANALYTICS_DASHBOARD_URL': False,
-
     # Set this to False to facilitate cleaning up invalid xml from your modulestore.
     'ENABLE_XBLOCK_XML_VALIDATION': True,
 
@@ -405,10 +377,6 @@ FEATURES = {
 
     # Allow users to change their email address.
     'ALLOW_EMAIL_ADDRESS_CHANGE': True,
-
-    # Whether to check the "Notify users by email" checkbox in the batch enrollment form
-    # in the instructor dashboard.
-    'BATCH_ENROLLMENT_NOTIFY_USERS_DEFAULT': True,
 
     # Whether the bulk enrollment view is enabled.
     'ENABLE_BULK_ENROLLMENT_VIEW': False,
@@ -2125,7 +2093,6 @@ INSTALLED_APPS = [
     'util',
     'lms.djangoapps.certificates.apps.CertificatesConfig',
     'dashboard',
-    'lms.djangoapps.instructor.apps.InstructorConfig',
     'lms.djangoapps.instructor_task',
     'openedx.core.djangoapps.course_groups',
     'bulk_email',
@@ -2966,10 +2933,6 @@ ADVANCED_SECURITY_CONFIG = {}
 ### External auth usage -- prefixes for ENROLLMENT_DOMAIN
 SHIBBOLETH_DOMAIN_PREFIX = 'shib:'
 OPENID_DOMAIN_PREFIX = 'openid:'
-
-### Analytics Dashboard (Insights) settings
-ANALYTICS_DASHBOARD_URL = ""
-ANALYTICS_DASHBOARD_NAME = _('Your Platform Insights')
 
 ### Analytics API
 ANALYTICS_API_KEY = ""

--- a/lms/envs/devstack.py
+++ b/lms/envs/devstack.py
@@ -41,12 +41,6 @@ for log_name, log_level in LOG_OVERRIDES:
 
 EMAIL_BACKEND = 'django.core.mail.backends.console.EmailBackend'
 
-########################## ANALYTICS TESTING ########################
-
-# Set this to the dashboard URL in order to display the link from the
-# dashboard to the Analytics Dashboard.
-ANALYTICS_DASHBOARD_URL = None
-
 ############################ PYFS XBLOCKS SERVICE #############################
 # Set configuration for Django pyfilesystem
 

--- a/lms/envs/test.py
+++ b/lms/envs/test.py
@@ -71,10 +71,6 @@ FEATURES['ENABLE_SHOPPING_CART'] = True
 
 FEATURES['ENABLE_VERIFIED_CERTIFICATES'] = True
 
-# Enable this feature for course staff grade downloads, to enable acceptance tests
-FEATURES['ENABLE_GRADE_DOWNLOADS'] = True
-FEATURES['ALLOW_COURSE_STAFF_GRADE_DOWNLOADS'] = True
-
 # Toggles embargo on for testing
 FEATURES['EMBARGO'] = True
 

--- a/lms/urls.py
+++ b/lms/urls.py
@@ -483,11 +483,6 @@ urlpatterns += [
         name='set_course_mode_price',
     ),
     url(
-        r'^courses/{}/instructor/api/'.format(
-            settings.COURSE_ID_PATTERN,
-        ),
-        include('lms.djangoapps.instructor.views.api_urls')),
-    url(
         r'^courses/{}/remove_coupon$'.format(
             settings.COURSE_ID_PATTERN,
         ),

--- a/openedx/core/constants.py
+++ b/openedx/core/constants.py
@@ -1,5 +1,5 @@
 """
-Constants that are relevant all of Open edX
+Constants that are relevant to all of Open edX
 """
 # These are standard regexes for pulling out info like course_ids, usage_ids, etc.
 # They are used so that URLs with deprecated-format strings still work.

--- a/setup.py
+++ b/setup.py
@@ -71,9 +71,9 @@ setup(
             "plugins = openedx.core.djangoapps.plugins.apps:PluginsConfig",
             "schedules = openedx.core.djangoapps.schedules.apps:SchedulesConfig",
             "theming = openedx.core.djangoapps.theming.apps:ThemingConfig",
-            "instructor = lms.djangoapps.instructor.apps:InstructorConfig",
             "bookmarks = openedx.core.djangoapps.bookmarks.apps:BookmarksConfig",
             "zendesk_proxy = openedx.core.djangoapps.zendesk_proxy.apps:ZendeskProxyConfig",
+            "instructor = lms.djangoapps.instructor.apps:InstructorConfig",
         ],
         "cms.djangoapp": [
             "ace_common = openedx.core.djangoapps.ace_common.apps:AceCommonConfig",


### PR DESCRIPTION
This PR changes the LMS `instructor` app to follow the the Django App Plugin pattern introduced in [this PR](https://github.com/edx/edx-platform/pull/17093). This can be manually tested by running through any/all functionality provided by the instructor dashboard.