### PR TITLE
WIP: Old Mongo Migration

### DIFF
--- a/cms/djangoapps/contentstore/management/commands/course_info.py
+++ b/cms/djangoapps/contentstore/management/commands/course_info.py
@@ -1,0 +1,38 @@
+"""
+"""
+from django.contrib.auth.models import User
+from django.core.management.base import BaseCommand, CommandError
+from opaque_keys import InvalidKeyError
+from opaque_keys.edx.keys import CourseKey
+
+from contentstore.management.commands.utils import user_from_str
+from xmodule.modulestore import ModuleStoreEnum
+from xmodule.modulestore.django import modulestore
+from xmodule.modulestore.split_migrator import SplitMigrator
+
+from student.roles import CourseInstructorRole
+
+
+class Command(BaseCommand):
+    """
+    Get course information from different modulestores
+    """
+
+    help = "Migrate a course from old-Mongo to split-Mongo, but keep the existing Course Key."
+
+    def add_arguments(self, parser):
+        parser.add_argument('course_key')
+
+    def handle(self, *args, **options):
+        course_key = CourseKey.from_string(options['course_key'])
+
+        split_modulestore=modulestore()._get_modulestore_by_type(ModuleStoreEnum.Type.split)
+        source_modulestore=modulestore()._get_modulestore_by_type(ModuleStoreEnum.Type.mongo)
+
+        print "From Old Mongo"
+        print "--------------"
+        print source_modulestore.get_course(course_key)
+        print "\n"
+        print "From Split"
+        print "----------"
+        print split_modulestore.get_course(course_key)

--- a/cms/djangoapps/contentstore/management/commands/course_info.py
+++ b/cms/djangoapps/contentstore/management/commands/course_info.py
@@ -11,7 +11,7 @@ from xmodule.modulestore.django import modulestore
 from xmodule.modulestore.split_migrator import SplitMigrator
 
 from student.roles import CourseInstructorRole
-
+from pprint import PrettyPrinter
 
 class Command(BaseCommand):
     """
@@ -29,10 +29,26 @@ class Command(BaseCommand):
         split_modulestore=modulestore()._get_modulestore_by_type(ModuleStoreEnum.Type.split)
         source_modulestore=modulestore()._get_modulestore_by_type(ModuleStoreEnum.Type.mongo)
 
+        pp = PrettyPrinter()
+
         print "From Old Mongo"
         print "--------------"
-        print source_modulestore.get_course(course_key)
+        old_mongo_course = source_modulestore.get_course(course_key)
+        if old_mongo_course is not None:
+            old_mongo_fields = {
+                field_name: field.read_from(old_mongo_course)
+                for field_name, field in old_mongo_course.fields.items()
+                if field.is_set_on(old_mongo_course)
+            }
+            print pp.pprint(old_mongo_fields)
         print "\n"
         print "From Split"
         print "----------"
-        print split_modulestore.get_course(course_key)
+        split_course = split_modulestore.get_course(course_key)
+        if split_course is not None:
+            split_fields = {
+                field_name: field.read_from(split_course)
+                for field_name, field in split_course.fields.items()
+                if field.is_set_on(split_course)
+            }
+            print pp.pprint(split_fields)

--- a/cms/djangoapps/contentstore/management/commands/delete_from_split.py
+++ b/cms/djangoapps/contentstore/management/commands/delete_from_split.py
@@ -1,0 +1,38 @@
+"""
+Django management command to migrate a course from the old Mongo modulestore
+to the new split-Mongo modulestore.
+"""
+from django.contrib.auth.models import User
+from django.core.management.base import BaseCommand, CommandError
+from opaque_keys import InvalidKeyError
+from opaque_keys.edx.keys import CourseKey
+
+from contentstore.management.commands.utils import user_from_str
+from xmodule.modulestore import ModuleStoreEnum
+from xmodule.modulestore.django import modulestore
+from xmodule.modulestore.split_migrator import SplitMigrator
+
+from contentstore.utils import delete_course
+from student.roles import CourseInstructorRole
+
+
+class Command(BaseCommand):
+    """
+    Migrate a course from old-Mongo to split-Mongo. It reuses the old course id except where overridden.
+    """
+
+    help = "Delete a Course from Split"
+
+    def add_arguments(self, parser):
+        parser.add_argument('course_key')
+
+    def handle(self, *args, **options):
+        course_key = CourseKey.from_string(options['course_key'])
+        instructor_role = CourseInstructorRole(course_key=course_key)
+        instructor = instructor_role.users_with_role()[0]
+
+        split_modulestore=modulestore()._get_modulestore_by_type(ModuleStoreEnum.Type.split)
+        with split_modulestore.bulk_operations(course_key):
+            split_modulestore.delete_course(course_key, instructor.id)
+
+        print "Course {} deleted from Split Modulestore".format(course_key)

--- a/cms/djangoapps/contentstore/management/commands/migrate_to_split_keep_id.py
+++ b/cms/djangoapps/contentstore/management/commands/migrate_to_split_keep_id.py
@@ -1,0 +1,38 @@
+"""
+Django management command to migrate a course from the old Mongo modulestore
+to the new split-Mongo modulestore.
+"""
+from django.contrib.auth.models import User
+from django.core.management.base import BaseCommand, CommandError
+from opaque_keys import InvalidKeyError
+from opaque_keys.edx.keys import CourseKey
+
+from contentstore.management.commands.utils import user_from_str
+from xmodule.modulestore import ModuleStoreEnum
+from xmodule.modulestore.django import modulestore
+from xmodule.modulestore.split_migrator import SplitMigrator
+
+from student.roles import CourseInstructorRole
+
+
+class Command(BaseCommand):
+    """
+    Migrate a course from old-Mongo to split-Mongo. It reuses the old course id except where overridden.
+    """
+
+    help = "Migrate a course from old-Mongo to split-Mongo, but keep the existing Course Key."
+
+    def add_arguments(self, parser):
+        parser.add_argument('course_key')
+
+    def handle(self, *args, **options):
+        course_key = CourseKey.from_string(options['course_key'])
+        instructor_role = CourseInstructorRole(course_key=course_key)
+        instructor = instructor_role.users_with_role()[0]
+
+        migrator = SplitMigrator(
+            split_modulestore=modulestore()._get_modulestore_by_type(ModuleStoreEnum.Type.split),
+            source_modulestore=modulestore()._get_modulestore_by_type(ModuleStoreEnum.Type.mongo),
+        )
+
+        migrator.migrate_with_same_course_key(course_key, instructor.id)

--- a/cms/djangoapps/contentstore/views/component.py
+++ b/cms/djangoapps/contentstore/views/component.py
@@ -105,6 +105,10 @@ def container_handler(request, usage_key_string):
 
         try:
             usage_key = UsageKey.from_string(usage_key_string)
+#            if usage_key.course_key.run is None:
+#                new_course_key = usage_key.course_key.replace(run='2018')
+#                usage_key = usage_key.map_into_course(new_course_key)
+
         except InvalidKeyError:  # Raise Http404 on invalid 'usage_key_string'
             raise Http404
         with modulestore().bulk_operations(usage_key.course_key):

--- a/common/lib/xmodule/xmodule/modulestore/mixed.py
+++ b/common/lib/xmodule/xmodule/modulestore/mixed.py
@@ -201,6 +201,8 @@ class MixedModuleStore(ModuleStoreDraftAndPublished, ModuleStoreWriteBase):
 
         If locator is None, returns the first (ordered) store as the default
         """
+        import pudb; pu.db
+
         if locator is not None:
             locator = self._clean_locator_for_mapping(locator)
             mapping = self.mappings.get(locator, None)

--- a/common/lib/xmodule/xmodule/modulestore/mixed.py
+++ b/common/lib/xmodule/xmodule/modulestore/mixed.py
@@ -201,22 +201,21 @@ class MixedModuleStore(ModuleStoreDraftAndPublished, ModuleStoreWriteBase):
 
         If locator is None, returns the first (ordered) store as the default
         """
-        # import pudb; pu.db
-
         if locator is not None:
             locator = self._clean_locator_for_mapping(locator)
-            mapping = self.mappings.get(locator, None)
-            if mapping is not None:
-                return mapping
+            # mapping = self.mappings.get(locator, None)
+            # if mapping is not None:
+            #     return mapping
+            # else:
+
+            if isinstance(locator, LibraryLocator):
+                has_locator = lambda store: hasattr(store, 'has_library') and store.has_library(locator)
             else:
-                if isinstance(locator, LibraryLocator):
-                    has_locator = lambda store: hasattr(store, 'has_library') and store.has_library(locator)
-                else:
-                    has_locator = lambda store: store.has_course(locator)
-                for store in self.modulestores:
-                    if has_locator(store):
-                        self.mappings[locator] = store
-                        return store
+                has_locator = lambda store: store.has_course(locator)
+            for store in self.modulestores:
+                if has_locator(store):
+                    # self.mappings[locator] = store
+                    return store
 
         # return the default store
         return self.default_modulestore
@@ -391,6 +390,8 @@ class MixedModuleStore(ModuleStoreDraftAndPublished, ModuleStoreWriteBase):
 
         :param course_key: must be a CourseKey
         """
+        # import pudb; pu.db
+
         assert isinstance(course_key, CourseKey)
         store = self._get_modulestore_for_courselike(course_key)
         try:
@@ -822,6 +823,7 @@ class MixedModuleStore(ModuleStoreDraftAndPublished, ModuleStoreWriteBase):
         """
         store = self._verify_modulestore_support(location.course_key, 'revert_to_published')
         return store.revert_to_published(location, user_id)
+
 
     def close_all_connections(self):
         """

--- a/common/lib/xmodule/xmodule/modulestore/mixed.py
+++ b/common/lib/xmodule/xmodule/modulestore/mixed.py
@@ -236,6 +236,7 @@ class MixedModuleStore(ModuleStoreDraftAndPublished, ModuleStoreWriteBase):
         Some course_keys are used without runs. This function calls the corresponding
         fill_in_run function on the appropriate modulestore.
         """
+        # import pudb; pu.db
         store = self._get_modulestore_for_courselike(course_key)
         if not hasattr(store, 'fill_in_run'):
             return course_key

--- a/common/lib/xmodule/xmodule/modulestore/mixed.py
+++ b/common/lib/xmodule/xmodule/modulestore/mixed.py
@@ -201,7 +201,7 @@ class MixedModuleStore(ModuleStoreDraftAndPublished, ModuleStoreWriteBase):
 
         If locator is None, returns the first (ordered) store as the default
         """
-        import pudb; pu.db
+        # import pudb; pu.db
 
         if locator is not None:
             locator = self._clean_locator_for_mapping(locator)

--- a/common/lib/xmodule/xmodule/modulestore/split_migrator.py
+++ b/common/lib/xmodule/xmodule/modulestore/split_migrator.py
@@ -35,6 +35,7 @@ class SplitMigrator(object):
             raise ItemNotFoundError(unicode(course_key))
 
         with self.split_modulestore.bulk_operations(course_key):
+            # Create the course (copies the root node)
             new_course = self.split_modulestore.create_course_with_key(
                 course_key,
                 user_id,
@@ -43,7 +44,14 @@ class SplitMigrator(object):
                 extra_branches=[ModuleStoreEnum.BranchName.draft],
                 skip_auto_publish=True,
             )
-            print new_course
+
+#        with self.split_modulestore.bulk_operations(course_key):
+            self._copy_published_modules_to_course_same_course_key(
+                new_course, course_key, user_id,
+            )
+
+        import pudb; pu.db
+        self.split_modulestore.publish(new_course.location, user_id)
 
 
     def _get_fields(self, block):
@@ -52,6 +60,46 @@ class SplitMigrator(object):
             for field_name, field in block.fields.items()
             if field.is_set_on(block)
         }
+
+
+    def _copy_published_modules_to_course_same_course_key(self, new_course, course_key, user_id, **kwargs):
+        """
+        Copy all of the modules from the 'direct' version of the course to the new split course.
+        """
+        course_version_locator = new_course.id.version_agnostic()
+
+        for module in self.source_modulestore.get_items(
+            course_key, revision=ModuleStoreEnum.RevisionOption.published_only, **kwargs
+        ):
+            # Don't copy the root course node again.
+            if module.location.block_type != 'course':
+                # create split_xblock using split.create_item
+                # NOTE: the below auto populates the children when it migrates the parent; so,
+                # it doesn't need the parent as the first arg. That is, it translates and populates
+                # the 'children' field as it goes.
+                _new_module = self.split_modulestore.create_item(
+                    user_id,
+                    course_version_locator,
+                    module.location.block_type,
+                    block_id=module.location.block_id,
+                    fields = self._get_fields(module),
+                    #fields=self._get_fields(
+                    #    module, course_version_locator, new_course.location.block_id
+                    #),
+                    skip_auto_publish=True,
+                    **kwargs
+                )
+        # after done w/ published items, add version for DRAFT pointing to the published structure
+        index_info = self.split_modulestore.get_course_index_info(course_version_locator)
+        versions = index_info['versions']
+        versions[ModuleStoreEnum.BranchName.draft] = versions[ModuleStoreEnum.BranchName.published]
+        self.split_modulestore.update_course_index(course_version_locator, index_info)
+
+        # clean up orphans in published version: in old mongo, parents pointed to the union of their published and draft
+        # children which meant some pointers were to non-existent locations in 'direct'
+        # self.split_modulestore.fix_not_found(course_version_locator, user_id)
+
+        # self.split_modulestore.publish(course)
 
 
     def migrate_mongo_course(

--- a/common/lib/xmodule/xmodule/modulestore/split_migrator.py
+++ b/common/lib/xmodule/xmodule/modulestore/split_migrator.py
@@ -44,13 +44,11 @@ class SplitMigrator(object):
                 extra_branches=[ModuleStoreEnum.BranchName.draft],
                 skip_auto_publish=True,
             )
-
-#        with self.split_modulestore.bulk_operations(course_key):
             self._copy_published_modules_to_course_same_course_key(
                 new_course, course_key, user_id,
             )
 
-        import pudb; pu.db
+#        import pudb; pu.db
         self.split_modulestore.publish(new_course.location, user_id)
 
 
@@ -93,7 +91,9 @@ class SplitMigrator(object):
         index_info = self.split_modulestore.get_course_index_info(course_version_locator)
         versions = index_info['versions']
         versions[ModuleStoreEnum.BranchName.draft] = versions[ModuleStoreEnum.BranchName.published]
+
         self.split_modulestore.update_course_index(course_version_locator, index_info)
+        self.split_modulestore.add_old_mongo_mapping(course_key)
 
         # clean up orphans in published version: in old mongo, parents pointed to the union of their published and draft
         # children which meant some pointers were to non-existent locations in 'direct'

--- a/common/lib/xmodule/xmodule/modulestore/split_mongo/mongo_connection.py
+++ b/common/lib/xmodule/xmodule/modulestore/split_mongo/mongo_connection.py
@@ -320,15 +320,6 @@ class MongoConnection(object):
             }
         )
 
-#    def has_old_mongo_mapping(self, course_key):
-#        if not course_key.deprecated:
-#            return False
-#
-#        query = {
-#
-#        }
-
-
     def delete_old_mongo_mapping(self, course_key):
         query = {
             'org': course_key.org,

--- a/common/lib/xmodule/xmodule/modulestore/split_mongo/mongo_connection.py
+++ b/common/lib/xmodule/xmodule/modulestore/split_mongo/mongo_connection.py
@@ -304,6 +304,12 @@ class MongoConnection(object):
         self.structures = self.database[collection + '.structures']
         self.definitions = self.database[collection + '.definitions']
 
+        # We'll sometimes receive requests for courses without a run because
+        # we're handling courses that have been migrated from the old
+        # modulestore. We use this collection to fill in the run info since in
+        # Split it's otherwise ambiguous.
+        self.old_mongo_mapping = self.database[collection + '.old_mongo_mapping']
+
     def heartbeat(self):
         """
         Check that the db is reachable.
@@ -451,6 +457,19 @@ class MongoConnection(object):
                     for key_attr in ('org', 'course', 'run')
                 }
             return self.course_index.find_one(query)
+
+    def get_course_key_with_run(self, course_key_without_run):
+        return course_key_without_run.replace(run='2018')
+
+#        if course_key_without_run.run is not None:
+#            return course_key_without_run
+#
+#        query = {
+#            'org' = course_key_without_run.org,
+#            'course' = course_key_without_run.course,
+#        }
+#        mapping_entry = self.old_mongo_mapping.find_one(query)
+#        return course_key_without_run.replace(run=mapping_entry['run'])
 
     def find_matching_course_indexes(
             self,

--- a/common/lib/xmodule/xmodule/modulestore/split_mongo/split.py
+++ b/common/lib/xmodule/xmodule/modulestore/split_mongo/split.py
@@ -1989,7 +1989,7 @@ class SplitMongoModuleStore(SplitBulkWriteMixin, ModuleStoreWriteBase):
         """
         Internal code for creating a course or library
         """
-        import pudb; pu.db;
+        # import pudb; pu.db;
 
         index = self.get_course_index(locator, ignore_case=True)
         if index is not None:

--- a/common/lib/xmodule/xmodule/modulestore/split_mongo/split.py
+++ b/common/lib/xmodule/xmodule/modulestore/split_mongo/split.py
@@ -1161,12 +1161,17 @@ class SplitMongoModuleStore(SplitBulkWriteMixin, ModuleStoreWriteBase):
         Note: we return the course_id instead of a boolean here since the found course may have
            a different id than the given course_id when ignore_case is True.
         """
-        if not isinstance(course_id, CourseLocator) or course_id.deprecated:
-            # The supplied CourseKey is of the wrong type, so it can't possibly be stored in this modulestore.
-            return False
+        # if not isinstance(course_id, CourseLocator) or course_id.deprecated:
+        #     # The supplied CourseKey is of the wrong type, so it can't possibly be stored in this modulestore.
+        #     return False
+
 
         course_index = self.get_course_index(course_id, ignore_case)
-        return CourseLocator(course_index['org'], course_index['course'], course_index['run'], course_id.branch) if course_index else None
+
+        # TODO: Is this safe? Why do we allow ignore_case? That can't possibly work the way we want it to. Wah.
+#        return CourseLocator(course_index['org'], course_index['course'], course_index['run'], course_id.branch) if course_index else None
+        return course_id
+
 
     def has_library(self, library_id, ignore_case=False, **kwargs):
         """
@@ -1213,9 +1218,9 @@ class SplitMongoModuleStore(SplitBulkWriteMixin, ModuleStoreWriteBase):
             descendants.
         raises InsufficientSpecificationError or ItemNotFoundError
         """
-        if not isinstance(usage_key, BlockUsageLocator) or usage_key.deprecated:
-            # The supplied UsageKey is of the wrong type, so it can't possibly be stored in this modulestore.
-            raise ItemNotFoundError(usage_key)
+#        if not isinstance(usage_key, BlockUsageLocator) or usage_key.deprecated:
+#            # The supplied UsageKey is of the wrong type, so it can't possibly be stored in this modulestore.
+#            raise ItemNotFoundError(usage_key)
 
         with self.bulk_operations(usage_key.course_key):
             course = self._lookup_course(usage_key.course_key)

--- a/common/lib/xmodule/xmodule/modulestore/split_mongo/split.py
+++ b/common/lib/xmodule/xmodule/modulestore/split_mongo/split.py
@@ -747,6 +747,8 @@ class SplitMongoModuleStore(SplitBulkWriteMixin, ModuleStoreWriteBase):
         self.db_connection.delete_old_mongo_mapping(course_key)
 
     def fill_in_run(self, course_key):
+        """We try to fill in the run, but if we return without a run, it means
+        we don't have it in the old mongo mapping."""
         if course_key.run is not None:
             return course_key
 
@@ -2816,7 +2818,7 @@ class SplitMongoModuleStore(SplitBulkWriteMixin, ModuleStoreWriteBase):
         # this is the only real delete in the system. should it do something else?
         log.info(u"deleting course from split-mongo: %s", course_key)
 
-        import pudb; pu.db
+        # import pudb; pu.db
         self.delete_course_index(course_key)
         if course_key.deprecated:
             self.delete_old_mongo_mapping(course_key)

--- a/common/lib/xmodule/xmodule/modulestore/split_mongo/split.py
+++ b/common/lib/xmodule/xmodule/modulestore/split_mongo/split.py
@@ -1194,9 +1194,9 @@ class SplitMongoModuleStore(SplitBulkWriteMixin, ModuleStoreWriteBase):
         the course or the block w/in the course do not exist for the given version.
         raises InsufficientSpecificationError if the usage_key does not id a block
         """
-        if not isinstance(usage_key, BlockUsageLocator) or usage_key.deprecated:
-            # The supplied UsageKey is of the wrong type, so it can't possibly be stored in this modulestore.
-            return False
+        #if not isinstance(usage_key, BlockUsageLocator) or usage_key.deprecated:
+        #    # The supplied UsageKey is of the wrong type, so it can't possibly be stored in this modulestore.
+        #    return False
 
         if usage_key.block_id is None:
             raise InsufficientSpecificationError(usage_key)
@@ -1257,9 +1257,9 @@ class SplitMongoModuleStore(SplitBulkWriteMixin, ModuleStoreWriteBase):
                 False - if we want only those items which are in the course tree. This would ensure no orphans are
                 fetched.
         """
-        if not isinstance(course_locator, CourseKey) or course_locator.deprecated:
-            # The supplied courselike key is of the wrong type, so it can't possibly be stored in this modulestore.
-            return []
+        #if not isinstance(course_locator, CourseKey) or course_locator.deprecated:
+        #    # The supplied courselike key is of the wrong type, so it can't possibly be stored in this modulestore.
+        #    return []
 
         course = self._lookup_course(course_locator)
         items = []
@@ -1396,9 +1396,9 @@ class SplitMongoModuleStore(SplitBulkWriteMixin, ModuleStoreWriteBase):
 
         :param locator: BlockUsageLocator restricting search scope
         """
-        if not isinstance(locator, BlockUsageLocator) or locator.deprecated:
-            # The supplied locator is of the wrong type, so it can't possibly be stored in this modulestore.
-            raise ItemNotFoundError(locator)
+        #if not isinstance(locator, BlockUsageLocator) or locator.deprecated:
+        #    # The supplied locator is of the wrong type, so it can't possibly be stored in this modulestore.
+        #    raise ItemNotFoundError(locator)
 
         course = self._lookup_course(locator.course_key)
         all_parent_ids = self._get_parents_from_structure(BlockKey.from_usage_key(locator), course.structure)
@@ -1458,9 +1458,9 @@ class SplitMongoModuleStore(SplitBulkWriteMixin, ModuleStoreWriteBase):
             'edited_on': when the course was originally created
         }
         """
-        if not isinstance(course_key, CourseLocator) or course_key.deprecated:
-            # The supplied CourseKey is of the wrong type, so it can't possibly be stored in this modulestore.
-            raise ItemNotFoundError(course_key)
+        #if not isinstance(course_key, CourseLocator) or course_key.deprecated:
+        #    # The supplied CourseKey is of the wrong type, so it can't possibly be stored in this modulestore.
+        #    raise ItemNotFoundError(course_key)
 
         if not (course_key.course and course_key.run and course_key.org):
             return None
@@ -1479,9 +1479,9 @@ class SplitMongoModuleStore(SplitBulkWriteMixin, ModuleStoreWriteBase):
             'edited_on': when the change was made
         }
         """
-        if not isinstance(course_key, CourseLocator) or course_key.deprecated:
-            # The supplied CourseKey is of the wrong type, so it can't possibly be stored in this modulestore.
-            raise ItemNotFoundError(course_key)
+        #if not isinstance(course_key, CourseLocator) or course_key.deprecated:
+        #    # The supplied CourseKey is of the wrong type, so it can't possibly be stored in this modulestore.
+        #    raise ItemNotFoundError(course_key)
 
         course = self._lookup_course(course_key).structure
         return {
@@ -1501,9 +1501,9 @@ class SplitMongoModuleStore(SplitBulkWriteMixin, ModuleStoreWriteBase):
             'edited_on': when the change was made
         }
         """
-        if not isinstance(definition_locator, DefinitionLocator) or definition_locator.deprecated:
-            # The supplied locator is of the wrong type, so it can't possibly be stored in this modulestore.
-            raise ItemNotFoundError(definition_locator)
+        #if not isinstance(definition_locator, DefinitionLocator) or definition_locator.deprecated:
+        #    # The supplied locator is of the wrong type, so it can't possibly be stored in this modulestore.
+        #    raise ItemNotFoundError(definition_locator)
 
         definition = self.db_connection.get_definition(definition_locator.definition_id, course_context)
         if definition is None:
@@ -1517,9 +1517,9 @@ class SplitMongoModuleStore(SplitBulkWriteMixin, ModuleStoreWriteBase):
         next versions, these do include those created for other courses.
         :param course_locator:
         """
-        if not isinstance(course_locator, CourseLocator) or course_locator.deprecated:
-            # The supplied CourseKey is of the wrong type, so it can't possibly be stored in this modulestore.
-            raise ItemNotFoundError(course_locator)
+        #if not isinstance(course_locator, CourseLocator) or course_locator.deprecated:
+        #    # The supplied CourseKey is of the wrong type, so it can't possibly be stored in this modulestore.
+        #    raise ItemNotFoundError(course_locator)
 
         if version_history_depth < 1:
             return None
@@ -1977,8 +1977,6 @@ class SplitMongoModuleStore(SplitBulkWriteMixin, ModuleStoreWriteBase):
             fields=fields,
             skip_auto_publish=skip_auto_publish
         )
-        print "Courselike: {}".format(courselike)
-
         return courselike
 
     def _create_courselike(
@@ -2677,9 +2675,9 @@ class SplitMongoModuleStore(SplitBulkWriteMixin, ModuleStoreWriteBase):
         change to this item, it raises a VersionConflictError unless force is True. In the force case, it forks
         the course but leaves the head pointer where it is (this change will not be in the course head).
         """
-        if not isinstance(usage_locator, BlockUsageLocator) or usage_locator.deprecated:
-            # The supplied UsageKey is of the wrong type, so it can't possibly be stored in this modulestore.
-            raise ItemNotFoundError(usage_locator)
+        #if not isinstance(usage_locator, BlockUsageLocator) or usage_locator.deprecated:
+        #    # The supplied UsageKey is of the wrong type, so it can't possibly be stored in this modulestore.
+        #    raise ItemNotFoundError(usage_locator)
 
         with self.bulk_operations(usage_locator.course_key):
             original_structure = self._lookup_course(usage_locator.course_key).structure

--- a/whichms.py
+++ b/whichms.py
@@ -1,0 +1,8 @@
+from opaque_keys.edx.keys import CourseKey
+from xmodule.modulestore.django import modulestore
+
+course_key = CourseKey.from_string("edX/MODULESTORE_100/2018")
+m = modulestore()
+course = m.get_course(course_key)
+print course
+


### PR DESCRIPTION
# Motivation

* Migrate hundreds of courses off of Old Mongo without having to chase down course teams, delete courses, and somehow preserve student data.
* Make it easy for the community to move over as well!
* Simplify the code base by deleting Old Mongo Modulestore as well as the Mixed Modulestore proxy – ONE MODULESTORE!
* Speed up tests!
* Optimization opportunities, once everything is in split (sub-tree caching)
* Cost reduction: Split mostly uses Mongo as a KV-store. Once everything is on Split, we can talk about swapping out the KV-store entirely for something cheaper like S3 (and help us get rid of MongoDB altogether – one less moving piece).

# Status

The code works for the most common use cases, though there is some issue with bulk operations when doing writes in Studio – the writes go through, but it throws an error along the way. There's an issue with returning the correct key type from get_courses noted in the last section of this doc. I haven't had the chance to test against the import/export use case, or see if it chokes on unusual course structures.

The nice thing is that we don't have to fix everything at once. We can do a gradual rollout where we transition courses in batches, and see what kinds of problems arise. Many of these courses aren't really being used any more, so it gives us the opportunity to test this in a straightforward way. We can also rollback any given course to its old-mongo version with a management command. So the key is to keep the footprint as small as possible and make sure we're not introducing bugs into Split to accommodate this.

This is work that's going to have a long tail, but I think we can have a production-ready initial version of this with a couple of weeks of dev time that we can start running courses through.

# Next Steps

- [ ] Fix remaining Studio bulk operation write error (I kinda took a hammer to this to try things out – needs cleanup).
- [ ] Test the import/export use case.
- [ ] Find some low-traffic candidate courses we can start porting over.
- [ ] Test performance – I'm guessing that we'll want to request-cache the old_mongo_mapping lookup.
- [ ] General refactoring. It's not a big PR, but it was a long series of experiments, so naming and organization could be better.

# Implementation notes

Commands, assuming your old mongo course is `edX/MODULESTORE_100/2018`:

```
python manage.py cms --settings=devstack_docker migrate_to_split_keep_id edX/MODULESTORE_100/2018
python manage.py cms --settings=devstack_docker course_info edX/MODULESTORE_100/2018
python manage.py cms --settings=devstack_docker delete_from_split edX/MODULESTORE_100/2018
```

* New MongoDB collection to support a mapping of Old Mongo courses we've moved into Split (`old_mongo_mapping`).
* No other changes to the serialized Split data model should be needed.
* Need to run the `ensure_indexes` management command as part of rolling this out, or we won't have the unique constraint that's necessary for the old_mongo_mapping collection.
* One of the key points is that deprecated key types can still have version information attached to them (to support Split's storage model), even if they don't serialize that version information by default. This is important in that it allows the modulestore to add information to the deprecated course keys that it needs without changing how they serialize for the purposes of student state in CSM, log entries, enrollment, etc.
* In some cases, the split modulestore creates keys from data it already has, and in this case it will internally create non-deprecated keys. I hope this doesn't get too confusing. Note that Split never serializes the opaque key value as a string – it always pulls the individual pieces out and writes them into docs. If it's necessary to create the correct type of course_key, we can examine `old_mongo_mapping` and make that decision. I don't know if it would make it more or less complicated to make sure it's always creating the right kind of key internally.
* There is a chance of namespace collision if you have a course with identical org, course, and run information (or differing only by case) between the old mongo and split mongo stores. I think that handling this case gracefully significantly raises the complexity, and that we should avoid it.
* In order to create old mongo courses in devstack, you have to modify the config value for the mixed modulestore (in lms.auth.json and cms.auth.json) and put the old mongo modulestore first in the list. That will make it the default and allow you to create Old Mongo courses in Studio.
* Mixed Modulestore will search for courses in config-specified order, so the way the PR is now, you have to switch your devstack config back to prefer split in order to test the migration code.
* The rollout of this can be gradual. We can land pieces of this code before porting courses over. We can port courses over without porting all the tests. etc.
* The original course is untouched. If you migrate a course to split and then delete that course from split, the original course will be served to users again.

# Things that need to be dealt with

* We're going to have to update a massive number of tests when we go to actually remove the old mongo code.
* We'll probably want to have multiple Open edX release cycles for getting rid of Old Mongo: 1 cycle to introduce it and get community feedback (Hawthorn? I-release?); 1 cycle to put it on death-watch once we think we've got the migration corner cases worked out; 1 cycle where we formally remove it.
* We currently copy the published content from Old Mongo into Split for both the draft and published branches of the new course. Because it was easier. This might be acceptable, or we might need to also bring along the draft version.
* `get_courses()` for Split still returns new-style IDs. We can change this to look at the new lookup collection we created (old_mongo_mapping).
* `_get_modulestore_for_courselike` caches which modulestore has which course in a mapping dict. I just removed this so rollback would work. But we should check perf implications.
* bulk operations is a little broken for writes in Studio. Probably because of course_keys that aren't matching because old/new or run/no-run differences?
* This causes an error when initially doing an edit, but the edit still goes through. I don't really understand this yet.
