### PR TITLE
PLAT-1917 Stop using deprecated Location and AssetLocation

### DIFF
--- a/cms/djangoapps/contentstore/tests/test_core_caching.py
+++ b/cms/djangoapps/contentstore/tests/test_core_caching.py
@@ -3,7 +3,7 @@ Tests core caching facilities.
 """
 
 from django.test import TestCase
-from opaque_keys.edx.locations import Location
+from opaque_keys.edx.locator import AssetLocator, CourseLocator
 
 from openedx.core.djangoapps.contentserver.caching import del_cached_content, get_cached_content, set_cached_content
 
@@ -24,9 +24,9 @@ class CachingTestCase(TestCase):
     """
     Tests for https://edx.lighthouseapp.com/projects/102637/tickets/112-updating-asset-does-not-refresh-the-cached-copy
     """
-    unicodeLocation = Location(u'c4x', u'mitX', u'800', u'run', u'thumbnail', u'monsters.jpg')
+    unicodeLocation = AssetLocator(CourseLocator(u'c4x', u'mitX', u'800'), u'thumbnail', u'monsters.jpg')
     # Note that some of the parts are strings instead of unicode strings
-    nonUnicodeLocation = Location('c4x', u'mitX', u'800', u'run', 'thumbnail', 'monsters.jpg')
+    nonUnicodeLocation = AssetLocator(CourseLocator('c4x', u'mitX', u'800'), 'thumbnail', 'monsters.jpg')
     mockAsset = Content(unicodeLocation, 'my content')
 
     def test_put_and_get(self):

--- a/cms/djangoapps/contentstore/views/course.py
+++ b/cms/djangoapps/contentstore/views/course.py
@@ -21,7 +21,7 @@ from django.views.decorators.csrf import ensure_csrf_cookie
 from django.views.decorators.http import require_GET, require_http_methods
 from opaque_keys import InvalidKeyError
 from opaque_keys.edx.keys import CourseKey
-from opaque_keys.edx.locations import Location
+from opaque_keys.edx.locator import BlockUsageLocator
 from openedx.core.djangoapps.content.course_overviews.models import CourseOverview
 from openedx.core.djangoapps.waffle_utils import WaffleSwitchNamespace
 from six import text_type
@@ -1371,7 +1371,7 @@ def assign_textbook_id(textbook, used_ids=()):
     Return an ID that can be assigned to a textbook
     and doesn't match the used_ids
     """
-    tid = Location.clean(textbook["tab_title"])
+    tid = BlockUsageLocator.clean(textbook["tab_title"])
     if not tid[0].isdigit():
         # stick a random digit in front
         tid = random.choice(string.digits) + tid

--- a/cms/djangoapps/contentstore/views/tests/test_item.py
+++ b/cms/djangoapps/contentstore/views/tests/test_item.py
@@ -11,7 +11,7 @@ from django.test.client import RequestFactory
 from mock import Mock, PropertyMock, patch
 from opaque_keys import InvalidKeyError
 from opaque_keys.edx.keys import CourseKey, UsageKey
-from opaque_keys.edx.locations import Location
+from opaque_keys.edx.locator import BlockUsageLocator, CourseLocator
 from pyquery import PyQuery
 from pytz import UTC
 from web_fragments.fragment import Fragment
@@ -2106,7 +2106,7 @@ class TestComponentHandler(TestCase):
         self.descriptor = self.modulestore.return_value.get_item.return_value
 
         self.usage_key_string = unicode(
-            Location('dummy_org', 'dummy_course', 'dummy_run', 'dummy_category', 'dummy_name')
+            BlockUsageLocator(CourseLocator('dummy_org', 'dummy_course', 'dummy_run'), 'dummy_category', 'dummy_name')
         )
 
         self.user = UserFactory()

--- a/common/lib/xmodule/xmodule/modulestore/tests/factories.py
+++ b/common/lib/xmodule/xmodule/modulestore/tests/factories.py
@@ -18,7 +18,7 @@ from mock import patch
 from nose.tools import assert_less_equal, assert_greater_equal
 import dogstats_wrapper as dog_stats_api
 
-from opaque_keys.edx.locations import Location
+from opaque_keys.edx.locator import BlockUsageLocator
 from opaque_keys.edx.keys import UsageKey
 from xblock.core import XBlock
 from xmodule.modulestore import prefer_xmodules, ModuleStoreEnum
@@ -116,7 +116,7 @@ class CourseFactory(XModuleFactory):
         # because the factory provides a default 'number' arg, prefer the non-defaulted 'course' arg if any
         number = kwargs.pop('course', kwargs.pop('number', None))
         store = kwargs.pop('modulestore')
-        name = kwargs.get('name', kwargs.get('run', Location.clean(kwargs.get('display_name'))))
+        name = kwargs.get('name', kwargs.get('run', BlockUsageLocator.clean(kwargs.get('display_name'))))
         run = kwargs.pop('run', name)
         user_id = kwargs.pop('user_id', ModuleStoreEnum.UserID.test)
         emit_signals = kwargs.pop('emit_signals', False)

--- a/common/lib/xmodule/xmodule/modulestore/tests/test_xml_importer.py
+++ b/common/lib/xmodule/xmodule/modulestore/tests/test_xml_importer.py
@@ -6,7 +6,6 @@ from opaque_keys.edx.locator import BlockUsageLocator, CourseLocator
 from xblock.fields import String, Scope, ScopeIds, List
 from xblock.runtime import Runtime, KvsFieldData, DictKeyValueStore
 from xmodule.x_module import XModuleMixin
-from opaque_keys.edx.locations import Location
 from xmodule.modulestore import ModuleStoreEnum
 from xmodule.modulestore.inheritance import InheritanceMixin
 from xmodule.modulestore.xml_importer import (
@@ -141,7 +140,7 @@ class RemapNamespaceTest(ModuleStoreNoSettings):
     def test_remap_namespace_native_xblock(self):
 
         # Set the XBlock's location
-        self.xblock.location = Location("org", "import", "run", "category", "stubxblock")
+        self.xblock.location = BlockUsageLocator(CourseLocator("org", "import", "run"), "category", "stubxblock")
 
         # Explicitly set the content and settings fields
         self.xblock.test_content_field = "Explicitly set"
@@ -180,13 +179,13 @@ class RemapNamespaceTest(ModuleStoreNoSettings):
     def test_remap_namespace_native_xblock_default_values(self):
 
         # Set the XBlock's location
-        self.xblock.location = Location("org", "import", "run", "category", "stubxblock")
+        self.xblock.location = BlockUsageLocator(CourseLocator("org", "import", "run"), "category", "stubxblock")
 
         # Do NOT set any values, so the fields should use the defaults
         self.xblock.save()
 
         # Remap the namespace
-        target_location_namespace = Location("org", "course", "run", "category", "stubxblock")
+        target_location_namespace = BlockUsageLocator(CourseLocator("org", "course", "run"), "category", "stubxblock")
         new_version = _update_and_import_module(
             self.xblock,
             modulestore(),
@@ -214,11 +213,11 @@ class RemapNamespaceTest(ModuleStoreNoSettings):
     def test_remap_namespace_native_xblock_inherited_values(self):
 
         # Set the XBlock's location
-        self.xblock.location = Location("org", "import", "run", "category", "stubxblock")
+        self.xblock.location = BlockUsageLocator(CourseLocator("org", "import", "run"), "category", "stubxblock")
         self.xblock.save()
 
         # Remap the namespace
-        target_location_namespace = Location("org", "course", "run", "category", "stubxblock")
+        target_location_namespace = BlockUsageLocator(CourseLocator("org", "course", "run"), "category", "stubxblock")
         new_version = _update_and_import_module(
             self.xblock,
             modulestore(),
@@ -242,7 +241,7 @@ class RemapNamespaceTest(ModuleStoreNoSettings):
         # TypeError.
 
         # Set the XBlock's location
-        self.xblock.location = Location("org", "import", "run", "category", "stubxblock")
+        self.xblock.location = BlockUsageLocator(CourseLocator("org", "import", "run"), "category", "stubxblock")
         # Explicitly set the content field
         self.xblock.test_content_field = ['Explicitly set']
         self.xblock.save()
@@ -305,7 +304,7 @@ class UpdateLocationTest(ModuleStoreNoSettings):
     def test_update_locations_native_xblock(self):
         """ Update locations updates location and keeps values and "is_set_on" status """
         # Set the XBlock's location
-        self.xblock.location = Location("org", "import", "run", "category", "stubxblock")
+        self.xblock.location = BlockUsageLocator(CourseLocator("org", "import", "run"), "category", "stubxblock")
 
         # Explicitly set the content, settings and children fields
         self.xblock.test_content_field = 'Explicitly set'

--- a/common/lib/xmodule/xmodule/modulestore/xml.py
+++ b/common/lib/xmodule/xmodule/modulestore/xml.py
@@ -27,7 +27,6 @@ from xmodule.modulestore.xml_exporter import DEFAULT_CONTENT_FIELDS
 from xmodule.modulestore import ModuleStoreEnum, ModuleStoreReadBase, LIBRARY_ROOT, COURSE_ROOT
 from xmodule.tabs import CourseTabList
 from opaque_keys.edx.keys import CourseKey
-from opaque_keys.edx.locations import Location
 from opaque_keys.edx.locator import CourseLocator, LibraryLocator, BlockUsageLocator
 
 from xblock.field_data import DictFieldData
@@ -106,8 +105,8 @@ class ImportSystem(XMLParsingSystem, MakoDescriptorSystem):
                 # Things to try to get a name, in order  (key, cleaning function, remove key after reading?)
                 lookups = [('url_name', id, False),
                            ('slug', id, True),
-                           ('name', Location.clean, False),
-                           ('display_name', Location.clean, False)]
+                           ('name', BlockUsageLocator.clean, False),
+                           ('display_name', BlockUsageLocator.clean, False)]
 
                 url_name = None
                 for key, clean, remove in lookups:
@@ -533,7 +532,7 @@ class XMLModuleStore(ModuleStoreReadBase):
                         )
                     )
 
-                    url_name = Location.clean(course_data.get('name'))
+                    url_name = BlockUsageLocator.clean(course_data.get('name'))
                     tracker("'name' is deprecated for module xml.  Please use "
                             "display_name and url_name.")
                 else:

--- a/common/lib/xmodule/xmodule/tests/test_annotatable_module.py
+++ b/common/lib/xmodule/xmodule/tests/test_annotatable_module.py
@@ -8,7 +8,7 @@ from mock import Mock
 from xblock.field_data import DictFieldData
 from xblock.fields import ScopeIds
 from xmodule.annotatable_module import AnnotatableModule
-from opaque_keys.edx.locations import Location
+from opaque_keys.edx.locator import BlockUsageLocator, CourseLocator
 
 from . import get_test_system
 
@@ -37,7 +37,7 @@ class AnnotatableModuleTestCase(unittest.TestCase):
             Mock(),
             get_test_system(),
             DictFieldData({'data': self.sample_xml}),
-            ScopeIds(None, None, None, Location('org', 'course', 'run', 'category', 'name', None))
+            ScopeIds(None, None, None, BlockUsageLocator(CourseLocator('org', 'course', 'run'), 'category', 'name'))
         )
 
     def test_annotation_data_attr(self):

--- a/common/lib/xmodule/xmodule/tests/test_capa_module.py
+++ b/common/lib/xmodule/xmodule/tests/test_capa_module.py
@@ -28,7 +28,7 @@ from capa.responsetypes import (StudentInputError, LoncapaProblemError,
                                 ResponseError)
 from capa.xqueue_interface import XQueueInterface
 from xmodule.capa_module import CapaModule, CapaDescriptor, ComplexEncoder
-from opaque_keys.edx.locations import Location
+from opaque_keys.edx.locator import BlockUsageLocator, CourseLocator
 from xblock.field_data import DictFieldData
 from xblock.fields import ScopeIds
 from xblock.scorable import Score
@@ -101,13 +101,11 @@ class CapaFactory(object):
 
             attempts: also added to instance state.  Will be converted to an int.
         """
-        location = Location(
-            "edX",
-            "capa_test",
-            "2012_Fall",
+        location = BlockUsageLocator(
+            CourseLocator("edX", "capa_test", "2012_Fall", deprecated=True),
             "problem",
             "SampleProblem{0}".format(cls.next_num()),
-            None
+            deprecated=True,
         )
         if xml is None:
             xml = cls.sample_problem_xml

--- a/common/lib/xmodule/xmodule/tests/test_conditional.py
+++ b/common/lib/xmodule/xmodule/tests/test_conditional.py
@@ -10,8 +10,7 @@ from xblock.field_data import DictFieldData
 from xblock.fields import ScopeIds
 from xmodule.error_module import NonStaffErrorDescriptor
 from opaque_keys.edx.keys import CourseKey
-from opaque_keys.edx.locations import Location
-from opaque_keys.edx.locator import BlockUsageLocator
+from opaque_keys.edx.locator import BlockUsageLocator, CourseLocator
 from xmodule.modulestore.xml import ImportSystem, XMLModuleStore, CourseLocationManager
 from xmodule.conditional_module import ConditionalDescriptor
 from xmodule.tests import DATA_DIR, get_test_system, get_test_descriptor_system
@@ -65,7 +64,8 @@ class ConditionalFactory(object):
         descriptor_system = get_test_descriptor_system()
 
         # construct source descriptor and module:
-        source_location = Location("edX", "conditional_test", "test_run", "problem", "SampleProblem", None)
+        source_location = BlockUsageLocator(CourseLocator("edX", "conditional_test", "test_run", deprecated=True),
+                                            "problem", "SampleProblem", deprecated=True)
         if source_is_error_module:
             # Make an error descriptor and module
             source_descriptor = NonStaffErrorDescriptor.from_xml(
@@ -111,7 +111,8 @@ class ConditionalFactory(object):
         system.descriptor_runtime = descriptor_system
 
         # construct conditional module:
-        cond_location = Location("edX", "conditional_test", "test_run", "conditional", "SampleConditional", None)
+        cond_location = BlockUsageLocator(CourseLocator("edX", "conditional_test", "test_run", deprecated=True),
+                                          "conditional", "SampleConditional", deprecated=True)
         field_data = DictFieldData({
             'data': '<conditional/>',
             'conditional_attr': 'attempted',
@@ -245,7 +246,7 @@ class ConditionalModuleXmlTest(unittest.TestCase):
         print "id: ", course.id
 
         def inner_get_module(descriptor):
-            if isinstance(descriptor, Location):
+            if isinstance(descriptor, BlockUsageLocator):
                 location = descriptor
                 descriptor = self.modulestore.get_item(location, depth=None)
             descriptor.xmodule_runtime = get_test_system()
@@ -255,7 +256,8 @@ class ConditionalModuleXmlTest(unittest.TestCase):
 
         # edx - HarvardX
         # cond_test - ER22x
-        location = Location("HarvardX", "ER22x", "2013_Spring", "conditional", "condone")
+        location = BlockUsageLocator(CourseLocator("HarvardX", "ER22x", "2013_Spring", deprecated=True),
+                                     "conditional", "condone", deprecated=True)
 
         def replace_urls(text, staticfiles_prefix=None, replace_prefix='/static/', course_namespace=None):
             return text
@@ -308,7 +310,8 @@ class ConditionalModuleXmlTest(unittest.TestCase):
         via generating UsageKeys from the values in xml_attributes['sources']
         """
         dummy_system = Mock()
-        dummy_location = Location("edX", "conditional_test", "test_run", "conditional", "SampleConditional", None)
+        dummy_location = BlockUsageLocator(CourseLocator("edX", "conditional_test", "test_run"),
+                                           "conditional", "SampleConditional")
         dummy_scope_ids = ScopeIds(None, None, dummy_location, dummy_location)
         dummy_field_data = DictFieldData({
             'data': '<conditional/>',
@@ -329,7 +332,8 @@ class ConditionalModuleXmlTest(unittest.TestCase):
 
     def test_conditional_module_parse_sources(self):
         dummy_system = Mock()
-        dummy_location = Location("edX", "conditional_test", "test_run", "conditional", "SampleConditional", None)
+        dummy_location = BlockUsageLocator(CourseLocator("edX", "conditional_test", "test_run"),
+                                           "conditional", "SampleConditional")
         dummy_scope_ids = ScopeIds(None, None, dummy_location, dummy_location)
         dummy_field_data = DictFieldData({
             'data': '<conditional/>',

--- a/common/lib/xmodule/xmodule/tests/test_content.py
+++ b/common/lib/xmodule/xmodule/tests/test_content.py
@@ -9,7 +9,7 @@ from path import Path as path
 from xmodule.contentstore.content import StaticContent, StaticContentStream
 from xmodule.contentstore.content import ContentStore
 from opaque_keys.edx.keys import CourseKey
-from opaque_keys.edx.locations import AssetLocation
+from opaque_keys.edx.locator import AssetLocator, CourseLocator
 from xmodule.static_content import _write_js, _list_descriptors
 
 SAMPLE_STRING = """
@@ -118,11 +118,12 @@ class ContentTest(unittest.TestCase):
     @ddt.unpack
     def test_generate_thumbnail_image(self, original_filename, thumbnail_filename):
         content_store = ContentStore()
-        content = Content(AssetLocation(u'mitX', u'800', u'ignore_run', u'asset', original_filename), None)
+        content = Content(AssetLocator(CourseLocator(u'mitX', u'800', u'ignore_run'), u'asset', original_filename),
+                          None)
         (thumbnail_content, thumbnail_file_location) = content_store.generate_thumbnail(content)
         self.assertIsNone(thumbnail_content)
         self.assertEqual(
-            AssetLocation(u'mitX', u'800', u'ignore_run', u'thumbnail', thumbnail_filename),
+            AssetLocator(CourseLocator(u'mitX', u'800', u'ignore_run'), u'thumbnail', thumbnail_filename),
             thumbnail_file_location
         )
 
@@ -134,7 +135,8 @@ class ContentTest(unittest.TestCase):
         image_class_mock.open.return_value = mock_image
 
         content_store = ContentStore()
-        content = Content(AssetLocation(u'mitX', u'800', u'ignore_run', u'asset', "monsters.jpg"), "image/jpeg")
+        content = Content(AssetLocator(CourseLocator(u'mitX', u'800', u'ignore_run'), u'asset', "monsters.jpg"),
+                          "image/jpeg")
         content.data = 'mock data'
         content_store.generate_thumbnail(content)
         self.assertTrue(image_class_mock.open.called, "Image.open not called")
@@ -146,12 +148,13 @@ class ContentTest(unittest.TestCase):
         content_store = ContentStore()
         content_store.save = Mock()
         thumbnail_filename = u'test.svg'
-        content = Content(AssetLocation(u'mitX', u'800', u'ignore_run', u'asset', u'test.svg'), 'image/svg+xml')
+        content = Content(AssetLocator(CourseLocator(u'mitX', u'800', u'ignore_run'), u'asset', u'test.svg'),
+                          'image/svg+xml')
         content.data = 'mock svg file'
         (thumbnail_content, thumbnail_file_location) = content_store.generate_thumbnail(content)
         self.assertEqual(thumbnail_content.data.read(), b'mock svg file')
         self.assertEqual(
-            AssetLocation(u'mitX', u'800', u'ignore_run', u'thumbnail', thumbnail_filename),
+            AssetLocator(CourseLocator(u'mitX', u'800', u'ignore_run'), u'thumbnail', thumbnail_filename),
             thumbnail_file_location
         )
 
@@ -162,14 +165,16 @@ class ContentTest(unittest.TestCase):
             CourseKey.from_string('mitX/400/ignore'), 'subs__1eo_jXvZnE .srt.sjson'
         )
         self.assertEqual(
-            AssetLocation(u'mitX', u'400', u'ignore', u'asset', u'subs__1eo_jXvZnE_.srt.sjson', None),
+            AssetLocator(CourseLocator(u'mitX', u'400', u'ignore', deprecated=True),
+                         u'asset', u'subs__1eo_jXvZnE_.srt.sjson'),
             asset_location
         )
 
     def test_get_location_from_path(self):
         asset_location = StaticContent.get_location_from_path(u'/c4x/a/b/asset/images_course_image.jpg')
         self.assertEqual(
-            AssetLocation(u'a', u'b', None, u'asset', u'images_course_image.jpg', None),
+            AssetLocator(CourseLocator(u'a', u'b', None, deprecated=True),
+                         u'asset', u'images_course_image.jpg', deprecated=True),
             asset_location
         )
 

--- a/common/lib/xmodule/xmodule/tests/test_delay_between_attempts.py
+++ b/common/lib/xmodule/xmodule/tests/test_delay_between_attempts.py
@@ -15,7 +15,7 @@ from mock import Mock
 
 import xmodule
 from xmodule.capa_module import CapaModule
-from opaque_keys.edx.locations import Location
+from opaque_keys.edx.locator import BlockUsageLocator, CourseLocator
 from xblock.field_data import DictFieldData
 from xblock.fields import ScopeIds
 from xblock.scorable import Score
@@ -85,7 +85,8 @@ class CapaFactoryWithDelay(object):
         """
         Optional parameters here are cut down to what we actually use vs. the regular CapaFactory.
         """
-        location = Location("edX", "capa_test", "run", "problem", "SampleProblem{0}".format(cls.next_num()))
+        location = BlockUsageLocator(CourseLocator('edX', 'capa_test', 'run', deprecated=True),
+                                     'problem', 'SampleProblem{0}'.format(cls.next_num()), deprecated=True)
         field_data = {'data': cls.sample_problem_xml}
 
         if max_attempts is not None:

--- a/common/lib/xmodule/xmodule/tests/test_editing_module.py
+++ b/common/lib/xmodule/xmodule/tests/test_editing_module.py
@@ -5,7 +5,7 @@ import logging
 
 from mock import Mock
 from pkg_resources import resource_string
-from opaque_keys.edx.locations import Location
+from opaque_keys.edx.locator import BlockUsageLocator, CourseLocator
 from xmodule.editing_module import TabsEditingDescriptor
 from xblock.field_data import DictFieldData
 from xblock.fields import ScopeIds
@@ -55,7 +55,9 @@ class TabsEditingDescriptorTestCase(unittest.TestCase):
         TabsEditingDescriptor.tabs = self.tabs
         self.descriptor = system.construct_xblock_from_class(
             TabsEditingDescriptor,
-            scope_ids=ScopeIds(None, None, None, Location('org', 'course', 'run', 'category', 'name', 'revision')),
+            scope_ids=ScopeIds(None, None, None,
+                               BlockUsageLocator(CourseLocator('org', 'course', 'run', branch='revision'),
+                                                 'category', 'name')),
             field_data=DictFieldData({}),
         )
 

--- a/common/lib/xmodule/xmodule/tests/test_error_module.py
+++ b/common/lib/xmodule/xmodule/tests/test_error_module.py
@@ -5,8 +5,7 @@ import unittest
 from xmodule.tests import get_test_system
 from xmodule.error_module import ErrorDescriptor, ErrorModule, NonStaffErrorDescriptor
 from xmodule.modulestore.xml import CourseLocationManager
-from opaque_keys.edx.locator import CourseLocator
-from opaque_keys.edx.locations import Location
+from opaque_keys.edx.locator import BlockUsageLocator, CourseLocator
 from xmodule.x_module import XModuleDescriptor, XModule, STUDENT_VIEW
 from mock import MagicMock, Mock, patch
 from xblock.runtime import Runtime, IdReader
@@ -129,7 +128,8 @@ class TestErrorModuleConstruction(unittest.TestCase):
         self.descriptor = BrokenDescriptor(
             TestRuntime(Mock(spec=IdReader), field_data),
             field_data,
-            ScopeIds(None, None, None, Location('org', 'course', 'run', 'broken', 'name', None))
+            ScopeIds(None, None, None,
+                     BlockUsageLocator(CourseLocator('org', 'course', 'run'), 'broken', 'name'))
         )
         self.descriptor.xmodule_runtime = TestRuntime(Mock(spec=IdReader), field_data)
         self.descriptor.xmodule_runtime.error_descriptor_class = ErrorDescriptor

--- a/common/lib/xmodule/xmodule/tests/test_export.py
+++ b/common/lib/xmodule/xmodule/tests/test_export.py
@@ -20,7 +20,7 @@ from xblock.core import XBlock
 from xblock.fields import String, Scope, Integer
 from xblock.test.tools import blocks_are_equivalent
 
-from opaque_keys.edx.locations import Location
+from opaque_keys.edx.locator import BlockUsageLocator, CourseLocator
 from xmodule.modulestore import EdxJSONEncoder
 from xmodule.modulestore.xml import XMLModuleStore
 from xmodule.tests import DATA_DIR
@@ -171,10 +171,10 @@ class TestEdxJsonEncoder(unittest.TestCase):
         self.null_utc_tz = NullTZ()
 
     def test_encode_location(self):
-        loc = Location('org', 'course', 'run', 'category', 'name', None)
+        loc = BlockUsageLocator(CourseLocator('org', 'course', 'run'), 'category', 'name')
         self.assertEqual(text_type(loc), self.encoder.default(loc))
 
-        loc = Location('org', 'course', 'run', 'category', 'name', 'version')
+        loc = BlockUsageLocator(CourseLocator('org', 'course', 'run', branch='version'), 'category', 'name')
         self.assertEqual(text_type(loc), self.encoder.default(loc))
 
     def test_encode_naive_datetime(self):

--- a/common/lib/xmodule/xmodule/tests/test_import.py
+++ b/common/lib/xmodule/xmodule/tests/test_import.py
@@ -12,7 +12,7 @@ from pytz import UTC
 from six import text_type
 
 from xmodule.xml_module import is_pointer_tag
-from opaque_keys.edx.locations import Location
+from opaque_keys.edx.locator import BlockUsageLocator, CourseLocator
 from xmodule.modulestore import only_xmodules
 from xmodule.modulestore.xml import ImportSystem, XMLModuleStore, LibraryXMLModuleStore
 from xmodule.modulestore.inheritance import compute_inherited_metadata
@@ -482,12 +482,14 @@ class ImportTestCase(BaseCourseTestCase):
 
         modulestore = XMLModuleStore(DATA_DIR, source_dirs=['toy'])
 
-        location_tab_syllabus = Location("edX", "toy", "2012_Fall", "static_tab", "syllabus", None)
+        location_tab_syllabus = BlockUsageLocator(CourseLocator("edX", "toy", "2012_Fall", deprecated=True),
+                                                  "static_tab", "syllabus", deprecated=True)
         toy_tab_syllabus = modulestore.get_item(location_tab_syllabus)
         self.assertEqual(toy_tab_syllabus.display_name, 'Syllabus')
         self.assertEqual(toy_tab_syllabus.course_staff_only, False)
 
-        location_tab_resources = Location("edX", "toy", "2012_Fall", "static_tab", "resources", None)
+        location_tab_resources = BlockUsageLocator(CourseLocator("edX", "toy", "2012_Fall", deprecated=True),
+                                                   "static_tab", "resources", deprecated=True)
         toy_tab_resources = modulestore.get_item(location_tab_resources)
         self.assertEqual(toy_tab_resources.display_name, 'Resources')
         self.assertEqual(toy_tab_resources.course_staff_only, True)
@@ -502,9 +504,11 @@ class ImportTestCase(BaseCourseTestCase):
 
         modulestore = XMLModuleStore(DATA_DIR, source_dirs=['toy', 'two_toys'])
 
-        location = Location("edX", "toy", "2012_Fall", "video", "Welcome", None)
+        location = BlockUsageLocator(CourseLocator("edX", "toy", "2012_Fall", deprecated=True),
+                                     "video", "Welcome", deprecated=True)
         toy_video = modulestore.get_item(location)
-        location_two = Location("edX", "toy", "TT_2012_Fall", "video", "Welcome", None)
+        location_two = BlockUsageLocator(CourseLocator("edX", "toy", "TT_2012_Fall", deprecated=True),
+                                         "video", "Welcome", deprecated=True)
         two_toy_video = modulestore.get_item(location_two)
         self.assertEqual(toy_video.youtube_id_1_0, "p2Q6BrNhdh8")
         self.assertEqual(two_toy_video.youtube_id_1_0, "p2Q6BrNhdh9")

--- a/common/lib/xmodule/xmodule/tests/test_xblock_wrappers.py
+++ b/common/lib/xmodule/xmodule/tests/test_xblock_wrappers.py
@@ -25,7 +25,7 @@ from xblock.field_data import DictFieldData
 from xblock.fields import ScopeIds
 from xblock.core import XBlock
 
-from opaque_keys.edx.locations import Location
+from opaque_keys.edx.locator import BlockUsageLocator, CourseLocator
 
 from xmodule.x_module import ModuleSystem, XModule, XModuleDescriptor, DescriptorSystem, STUDENT_VIEW, STUDIO_VIEW
 from xmodule.annotatable_module import AnnotatableDescriptor
@@ -188,7 +188,7 @@ class LeafDescriptorFactory(Factory):
 
     @lazy_attribute
     def location(self):
-        return Location('org', 'course', 'run', 'category', self.url_name, None)
+        return BlockUsageLocator(CourseLocator('org', 'course', 'run'), 'category', self.url_name)
 
     @lazy_attribute
     def block_type(self):

--- a/lms/djangoapps/class_dashboard/dashboard_data.py
+++ b/lms/djangoapps/class_dashboard/dashboard_data.py
@@ -6,7 +6,7 @@ import json
 from django.db.models import Count
 from django.utils.translation import ugettext as _
 
-from opaque_keys.edx.locations import Location
+from opaque_keys.edx.locator import BlockUsageLocator
 from six import text_type
 
 from courseware import models
@@ -435,7 +435,7 @@ def get_students_opened_subsection(request, csv=False):
     If 'csv' is True, returns a header array, and an array of arrays in the format:
     student names, usernames for CSV download.
     """
-    module_state_key = Location.from_string(request.GET.get('module_id'))
+    module_state_key = BlockUsageLocator.from_string(request.GET.get('module_id'))
     csv = request.GET.get('csv')
 
     # Query for "opened a subsection" students
@@ -487,7 +487,7 @@ def get_students_problem_grades(request, csv=False):
     If 'csv' is True, returns a header array, and an array of arrays in the format:
     student names, usernames, grades, percents for CSV download.
     """
-    module_state_key = Location.from_string(request.GET.get('module_id'))
+    module_state_key = BlockUsageLocator.from_string(request.GET.get('module_id'))
     csv = request.GET.get('csv')
 
     # Query for "problem grades" students

--- a/lms/djangoapps/courseware/tests/test_views.py
+++ b/lms/djangoapps/courseware/tests/test_views.py
@@ -23,7 +23,7 @@ from milestones.tests.utils import MilestonesTestCaseMixin
 from mock import MagicMock, PropertyMock, create_autospec, patch
 from nose.plugins.attrib import attr
 from opaque_keys.edx.keys import CourseKey
-from opaque_keys.edx.locations import Location
+from opaque_keys.edx.locator import BlockUsageLocator, CourseLocator
 from pytz import UTC
 from six import text_type
 from web_fragments.fragment import Fragment
@@ -187,7 +187,8 @@ class TestJumpTo(ModuleStoreTestCase):
         self.assertRedirects(response, expected_redirect_url(expected), status_code=302, target_status_code=302)
 
     def test_jumpto_id_invalid_location(self):
-        location = Location('edX', 'toy', 'NoSuchPlace', None, None, None)
+        location = BlockUsageLocator(CourseLocator('edX', 'toy', 'NoSuchPlace', deprecated=True),
+                                     None, None, deprecated=True)
         jumpto_url = '{0}/{1}/jump_to_id/{2}'.format('/courses', unicode(self.course_key), unicode(location))
         response = self.client.get(jumpto_url)
         self.assertEqual(response.status_code, 404)


### PR DESCRIPTION
The deprecated classes had already been turned into subclasses of their replacements, so there wasn't much to change here.  The main caveats:

* The constructors of the new classes take slightly different arguments; I just adjusted usage to perform the same mapping to the new constructors that the deprecated classes were performing internally anyway.
* The old classes always created deprecated locators, the new ones create new-style locators by default.  Most of the time switching to the new style had no real impact, but there are some tests using fixtures with deprecated locators which needed to be told explicitly to use that style with the new constructors.
* `test_core_caching.py` was using block locators to test asset locator behavior, which seems like a mistake; fixed this to use the appropriate locator type.