### PR TITLE
Update query for 'Visual Completion' waffle flag.

### DIFF
--- a/lms/djangoapps/completion/waffle.py
+++ b/lms/djangoapps/completion/waffle.py
@@ -10,7 +10,6 @@ from openedx.core.djangoapps.waffle_utils import CourseWaffleFlag, WaffleFlagNam
 
 # Namespace
 WAFFLE_NAMESPACE = 'completion'
-WAFFLE_FLAG_NAMESPACE = WaffleFlagNamespace(name='completion')
 
 # Switches
 # Full name: completion.enable_completion_tracking
@@ -84,10 +83,3 @@ def visual_progress_enabled(course_key):
         return waffle_flag()[ENABLE_COURSE_VISUAL_PROGRESS].is_enabled(course_key)
 
     return True
-
-
-def site_configuration_enabled():
-    """
-    Helper function to return site-aware feature switch
-    :return: bool -> True if site enabled for visual progress tracking
-    """

--- a/openedx/features/course_experience/tests/views/test_course_outline.py
+++ b/openedx/features/course_experience/tests/views/test_course_outline.py
@@ -380,13 +380,12 @@ class TestCourseOutlineResumeCourse(SharedModuleStoreTestCase, CompletionWaffleT
         # first navigate to a sequential to make it the last accessed
         chapter = course.children[0]
         sequential = chapter.children[0]
-        vertical = sequential.children[0]
         self.visit_sequential(course, chapter, sequential)
 
         # check resume course buttons
         response = self.visit_course_home(course, resume_count=2)
         content = pq(response.content)
-        self.assertTrue(content('.action-resume-course').attr('href').endswith('/vertical/' + vertical.url_name))
+        self.assertTrue(content('.action-resume-course').attr('href').endswith('/sequential/' + sequential.url_name))
 
     @override_switch(
         '{}.{}'.format(
@@ -394,7 +393,6 @@ class TestCourseOutlineResumeCourse(SharedModuleStoreTestCase, CompletionWaffleT
         ),
         active=True
     )
-    # @patch('lms.djangoapps.completion.waffle.site_configuration_enabled')
     @patch('lms.djangoapps.completion.waffle.get_current_site')
     def test_resume_course_with_completion_api(self, get_patched_current_site):
         """

--- a/openedx/features/course_experience/utils.py
+++ b/openedx/features/course_experience/utils.py
@@ -119,6 +119,26 @@ def get_course_outline_block_tree(request, course_id):
     course_key = CourseKey.from_string(course_id)
     course_usage_key = modulestore().make_course_usage_key(course_key)
 
+    if visual_progress_enabled(course_key=course_key):
+        # Deeper query for course tree traversing/marking complete
+        # and last completed block
+        block_types_filter = [
+            'course',
+            'chapter',
+            'sequential',
+            'vertical',
+            'html',
+            'problem',
+            'video',
+            'discussion'
+        ]
+    else:
+        # Shallower query is sufficient for last accessed block
+        block_types_filter = [
+            'course',
+            'chapter',
+            'sequential'
+        ]
     all_blocks = get_blocks(
         request,
         course_usage_key,
@@ -134,16 +154,7 @@ def get_course_outline_block_tree(request, course_id):
             'show_gated_sections',
             'format'
         ],
-        block_types_filter=[
-            'course',
-            'chapter',
-            'sequential',
-            'vertical',
-            'html',
-            'problem',
-            'video',
-            'discussion'
-        ]
+        block_types_filter=block_types_filter
     )
 
     course_outline_root_block = all_blocks['blocks'].get(all_blocks['root'], None)


### PR DESCRIPTION
## [EDUCATOR-2088](https://openedx.atlassian.net/browse/EDUCATOR-2088)

### Description
Follow on work to flag deeper course query and do some cleanup (whoops)

### Testing
- [x] Unit tests

### Reviewers
If you've been tagged for review, please check your corresponding box once you've given the :+1:.
- [x] Code review: @iloveagent57 

FYI: @edx/educator-neem

### Post-review
- [x] Rebase and squash commits
