### PR TITLE
PLAT-1942 Handle xmodule_django field deprecations

### DIFF
--- a/cms/djangoapps/contentstore/config/models.py
+++ b/cms/djangoapps/contentstore/config/models.py
@@ -4,8 +4,8 @@ controlling the new assets page.
 """
 from config_models.models import ConfigurationModel
 from django.db.models import BooleanField
+from opaque_keys.edx.django.models import CourseKeyField
 from six import text_type
-from openedx.core.djangoapps.xmodule_django.models import CourseKeyField
 
 
 class NewAssetsPageFlag(ConfigurationModel):

--- a/cms/djangoapps/contentstore/migrations/0002_add_assets_page_flag.py
+++ b/cms/djangoapps/contentstore/migrations/0002_add_assets_page_flag.py
@@ -4,7 +4,7 @@ from __future__ import unicode_literals
 from django.db import migrations, models
 from django.conf import settings
 import django.db.models.deletion
-import openedx.core.djangoapps.xmodule_django.models
+from opaque_keys.edx.django.models import CourseKeyField
 
 
 class Migration(migrations.Migration):
@@ -21,7 +21,7 @@ class Migration(migrations.Migration):
                 ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
                 ('change_date', models.DateTimeField(auto_now_add=True, verbose_name='Change date')),
                 ('enabled', models.BooleanField(default=False, verbose_name='Enabled')),
-                ('course_id', openedx.core.djangoapps.xmodule_django.models.CourseKeyField(max_length=255, db_index=True)),
+                ('course_id', CourseKeyField(max_length=255, db_index=True)),
                 ('changed_by', models.ForeignKey(on_delete=django.db.models.deletion.PROTECT, editable=False, to=settings.AUTH_USER_MODEL, null=True, verbose_name='Changed by')),
             ],
         ),

--- a/cms/djangoapps/xblock_config/migrations/0002_courseeditltifieldsenabledflag.py
+++ b/cms/djangoapps/xblock_config/migrations/0002_courseeditltifieldsenabledflag.py
@@ -4,8 +4,7 @@ from __future__ import unicode_literals
 import django.db.models.deletion
 from django.conf import settings
 from django.db import migrations, models
-
-import openedx.core.djangoapps.xmodule_django.models
+from opaque_keys.edx.django.models import CourseKeyField
 
 
 class Migration(migrations.Migration):
@@ -22,7 +21,7 @@ class Migration(migrations.Migration):
                 ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
                 ('change_date', models.DateTimeField(auto_now_add=True, verbose_name='Change date')),
                 ('enabled', models.BooleanField(default=False, verbose_name='Enabled')),
-                ('course_id', openedx.core.djangoapps.xmodule_django.models.CourseKeyField(max_length=255, db_index=True)),
+                ('course_id', CourseKeyField(max_length=255, db_index=True)),
                 ('changed_by', models.ForeignKey(on_delete=django.db.models.deletion.PROTECT, editable=False, to=settings.AUTH_USER_MODEL, null=True, verbose_name='Changed by')),
             ],
             options={

--- a/cms/djangoapps/xblock_config/models.py
+++ b/cms/djangoapps/xblock_config/models.py
@@ -8,7 +8,7 @@ Includes:
 from config_models.models import ConfigurationModel
 from django.db.models import TextField
 
-from openedx.core.djangoapps.xmodule_django.models import CourseKeyField
+from opaque_keys.edx.django.models import CourseKeyField
 from openedx.core.djangoapps.request_cache.middleware import request_cached
 
 

--- a/common/djangoapps/course_action_state/migrations/0001_initial.py
+++ b/common/djangoapps/course_action_state/migrations/0001_initial.py
@@ -4,8 +4,7 @@ from __future__ import unicode_literals
 import django.db.models.deletion
 from django.conf import settings
 from django.db import migrations, models
-
-from openedx.core.djangoapps.xmodule_django.models import CourseKeyField
+from opaque_keys.edx.django.models import CourseKeyField
 
 
 class Migration(migrations.Migration):

--- a/common/djangoapps/course_action_state/models.py
+++ b/common/djangoapps/course_action_state/models.py
@@ -11,9 +11,9 @@ file and check it in at the same time as your model changes. To do that,
 """
 from django.contrib.auth.models import User
 from django.db import models
+from opaque_keys.edx.django.models import CourseKeyField
 
 from course_action_state.managers import CourseActionStateManager, CourseRerunUIStateManager
-from openedx.core.djangoapps.xmodule_django.models import CourseKeyField
 
 
 class CourseActionState(models.Model):

--- a/common/djangoapps/course_modes/migrations/0001_initial.py
+++ b/common/djangoapps/course_modes/migrations/0001_initial.py
@@ -3,7 +3,7 @@ from __future__ import unicode_literals
 
 from django.db import migrations, models
 
-from openedx.core.djangoapps.xmodule_django.models import CourseKeyField
+from opaque_keys.edx.django.models import CourseKeyField
 
 
 class Migration(migrations.Migration):

--- a/common/djangoapps/course_modes/migrations/0008_course_key_field_to_foreign_key.py
+++ b/common/djangoapps/course_modes/migrations/0008_course_key_field_to_foreign_key.py
@@ -2,7 +2,7 @@
 from __future__ import unicode_literals
 
 from django.db import migrations, models
-import openedx.core.djangoapps.xmodule_django.models
+from opaque_keys.edx.django.models import CourseKeyField
 
 
 # This should only be used for migrations that have be verified to have a net-neutral sql
@@ -28,7 +28,7 @@ class Migration(migrations.Migration):
         migrations.AlterField(
             model_name='coursemode',
             name='course_id',
-            field=openedx.core.djangoapps.xmodule_django.models.CourseKeyField(max_length=255, db_index=True, verbose_name="Course", db_column='course_id'),
+            field=CourseKeyField(max_length=255, db_index=True, verbose_name="Course", db_column='course_id'),
         ),
         # Change the field name in Django to match our target field name
         migrations.RenameField(

--- a/common/djangoapps/course_modes/models.py
+++ b/common/djangoapps/course_modes/models.py
@@ -13,10 +13,10 @@ from django.db import models
 from django.db.models import Q
 from django.dispatch import receiver
 from django.utils.translation import ugettext_lazy as _
-from openedx.core.djangoapps.content.course_overviews.models import CourseOverview
-
 from opaque_keys.edx.keys import CourseKey
-from openedx.core.djangoapps.xmodule_django.models import CourseKeyField
+from opaque_keys.edx.django.models import CourseKeyField
+
+from openedx.core.djangoapps.content.course_overviews.models import CourseOverview
 from openedx.core.djangoapps.request_cache.middleware import RequestCache, ns_request_cached
 
 Mode = namedtuple('Mode',

--- a/common/djangoapps/django_comment_common/migrations/0001_initial.py
+++ b/common/djangoapps/django_comment_common/migrations/0001_initial.py
@@ -3,8 +3,7 @@ from __future__ import unicode_literals
 
 from django.conf import settings
 from django.db import migrations, models
-
-from openedx.core.djangoapps.xmodule_django.models import CourseKeyField
+from opaque_keys.edx.django.models import CourseKeyField
 
 
 class Migration(migrations.Migration):

--- a/common/djangoapps/django_comment_common/migrations/0005_coursediscussionsettings.py
+++ b/common/djangoapps/django_comment_common/migrations/0005_coursediscussionsettings.py
@@ -2,7 +2,7 @@
 from __future__ import unicode_literals
 
 from django.db import migrations, models
-import openedx.core.djangoapps.xmodule_django.models
+from opaque_keys.edx.django.models import CourseKeyField
 
 
 class Migration(migrations.Migration):
@@ -16,7 +16,7 @@ class Migration(migrations.Migration):
             name='CourseDiscussionSettings',
             fields=[
                 ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
-                ('course_id', openedx.core.djangoapps.xmodule_django.models.CourseKeyField(help_text=b'Which course are these settings associated with?', unique=True, max_length=255, db_index=True)),
+                ('course_id', CourseKeyField(help_text=b'Which course are these settings associated with?', unique=True, max_length=255, db_index=True)),
                 ('always_divide_inline_discussions', models.BooleanField(default=False)),
                 ('_divided_discussions', models.TextField(null=True, db_column=b'divided_discussions', blank=True)),
                 ('division_scheme', models.CharField(default=b'none', max_length=20, choices=[(b'none', b'None'), (b'cohort', b'Cohort'), (b'enrollment_track', b'Enrollment Track')])),

--- a/common/djangoapps/django_comment_common/models.py
+++ b/common/djangoapps/django_comment_common/models.py
@@ -8,9 +8,10 @@ from django.db import models
 from django.db.models.signals import post_save
 from django.dispatch import receiver
 from django.utils.translation import ugettext_noop
-
-from openedx.core.djangoapps.xmodule_django.models import CourseKeyField, NoneToEmptyManager
+from opaque_keys.edx.django.models import CourseKeyField
 from six import text_type
+
+from openedx.core.djangoapps.xmodule_django.models import NoneToEmptyManager
 from student.models import CourseEnrollment
 from xmodule.modulestore.django import modulestore
 from xmodule.modulestore.exceptions import ItemNotFoundError

--- a/common/djangoapps/status/migrations/0001_initial.py
+++ b/common/djangoapps/status/migrations/0001_initial.py
@@ -5,7 +5,7 @@ import django.db.models.deletion
 from django.conf import settings
 from django.db import migrations, models
 
-from openedx.core.djangoapps.xmodule_django.models import CourseKeyField
+from opaque_keys.edx.django.models import CourseKeyField
 
 
 class Migration(migrations.Migration):

--- a/common/djangoapps/status/models.py
+++ b/common/djangoapps/status/models.py
@@ -7,8 +7,7 @@ from config_models.models import ConfigurationModel
 from django.contrib import admin
 from django.core.cache import cache
 from django.db import models
-
-from openedx.core.djangoapps.xmodule_django.models import CourseKeyField
+from opaque_keys.edx.django.models import CourseKeyField
 
 
 class GlobalStatusMessage(ConfigurationModel):

--- a/common/djangoapps/student/migrations/0001_initial.py
+++ b/common/djangoapps/student/migrations/0001_initial.py
@@ -6,8 +6,7 @@ import django.utils.timezone
 import django_countries.fields
 from django.conf import settings
 from django.db import migrations, models
-
-from openedx.core.djangoapps.xmodule_django.models import CourseKeyField
+from opaque_keys.edx.django.models import CourseKeyField
 
 
 class Migration(migrations.Migration):

--- a/common/djangoapps/student/migrations/0011_course_key_field_to_foreign_key.py
+++ b/common/djangoapps/student/migrations/0011_course_key_field_to_foreign_key.py
@@ -3,7 +3,7 @@ from __future__ import unicode_literals
 
 from django.db import migrations, models
 import django.db.models.deletion
-import openedx.core.djangoapps.xmodule_django.models
+from opaque_keys.edx.django.models import CourseKeyField
 
 
 # This should only be used for migrations that have be verified to have a net-neutral sql
@@ -28,12 +28,12 @@ class Migration(migrations.Migration):
         migrations.AlterField(
             model_name='courseenrollment',
             name='course_id',
-            field=openedx.core.djangoapps.xmodule_django.models.CourseKeyField(max_length=255, db_index=True, db_column='course_id'),
+            field=CourseKeyField(max_length=255, db_index=True, db_column='course_id'),
         ),
         migrations.AlterField(
             model_name='historicalcourseenrollment',
             name='course_id',
-            field=openedx.core.djangoapps.xmodule_django.models.CourseKeyField(max_length=255, db_index=True, db_column='course_id'),
+            field=CourseKeyField(max_length=255, db_index=True, db_column='course_id'),
         ),
 
         # Rename the fields in Django to the new names that we want them to have

--- a/common/djangoapps/student/models.py
+++ b/common/djangoapps/student/models.py
@@ -41,6 +41,7 @@ from django_countries.fields import CountryField
 from edx_rest_api_client.exceptions import SlumberBaseException
 from eventtracking import tracker
 from model_utils.models import TimeStampedModel
+from opaque_keys.edx.django.models import CourseKeyField
 from opaque_keys.edx.keys import CourseKey
 from pytz import UTC
 from six import text_type
@@ -61,7 +62,7 @@ from enrollment.api import _default_course_mode
 from openedx.core.djangoapps.content.course_overviews.models import CourseOverview
 from openedx.core.djangoapps.request_cache import clear_cache, get_cache
 from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
-from openedx.core.djangoapps.xmodule_django.models import CourseKeyField, NoneToEmptyManager
+from openedx.core.djangoapps.xmodule_django.models import NoneToEmptyManager
 from track import contexts
 from util.milestones_helpers import is_entrance_exams_enabled
 from util.model_utils import emit_field_changed_events, get_changed_fields_dict

--- a/common/djangoapps/student/roles.py
+++ b/common/djangoapps/student/roles.py
@@ -8,8 +8,8 @@ from abc import ABCMeta, abstractmethod
 from collections import defaultdict
 
 from django.contrib.auth.models import User
+from opaque_keys.edx.django.models import CourseKeyField
 
-from openedx.core.djangoapps.xmodule_django.models import CourseKeyField
 from openedx.core.djangoapps.request_cache import get_cache
 from student.models import CourseAccessRole
 

--- a/common/djangoapps/util/models.py
+++ b/common/djangoapps/util/models.py
@@ -7,7 +7,7 @@ from config_models.models import ConfigurationModel
 from django.db import models
 from django.utils.text import compress_string
 
-from openedx.core.djangoapps.util.model_utils import CreatorMixin
+from opaque_keys.edx.django.models import CreatorMixin
 
 logger = logging.getLogger(__name__)  # pylint: disable=invalid-name
 

--- a/lms/djangoapps/badges/api/views.py
+++ b/lms/djangoapps/badges/api/views.py
@@ -2,13 +2,13 @@
 API views for badges
 """
 from opaque_keys import InvalidKeyError
+from opaque_keys.edx.django.models import CourseKeyField
 from opaque_keys.edx.keys import CourseKey
 from rest_framework import generics
 from rest_framework.exceptions import APIException
 
 from badges.models import BadgeAssertion
 from openedx.core.djangoapps.user_api.permissions import is_field_shared_factory
-from openedx.core.djangoapps.xmodule_django.models import CourseKeyField
 from openedx.core.lib.api.authentication import (
     OAuth2AuthenticationAllowInactiveUser,
     SessionAuthenticationAllowInactiveUser

--- a/lms/djangoapps/badges/migrations/0001_initial.py
+++ b/lms/djangoapps/badges/migrations/0001_initial.py
@@ -7,7 +7,7 @@ import badges.models
 from django.conf import settings
 import django.utils.timezone
 from model_utils import fields
-from openedx.core.djangoapps.xmodule_django.models import CourseKeyField
+from opaque_keys.edx.django.models import CourseKeyField
 
 
 class Migration(migrations.Migration):

--- a/lms/djangoapps/badges/models.py
+++ b/lms/djangoapps/badges/models.py
@@ -13,10 +13,10 @@ from jsonfield import JSONField
 from lazy import lazy
 from model_utils.models import TimeStampedModel
 from opaque_keys import InvalidKeyError
+from opaque_keys.edx.django.models import CourseKeyField
 from opaque_keys.edx.keys import CourseKey
 
 from badges.utils import deserialize_count_specs
-from openedx.core.djangoapps.xmodule_django.models import CourseKeyField
 from xmodule.modulestore.django import modulestore
 
 

--- a/lms/djangoapps/bulk_email/migrations/0001_initial.py
+++ b/lms/djangoapps/bulk_email/migrations/0001_initial.py
@@ -3,7 +3,7 @@ from __future__ import unicode_literals
 
 from django.db import migrations, models
 from django.conf import settings
-from openedx.core.djangoapps.xmodule_django.models import CourseKeyField
+from opaque_keys.edx.django.models import CourseKeyField
 
 
 class Migration(migrations.Migration):

--- a/lms/djangoapps/bulk_email/models.py
+++ b/lms/djangoapps/bulk_email/models.py
@@ -7,6 +7,7 @@ import markupsafe
 from config_models.models import ConfigurationModel
 from django.contrib.auth.models import User
 from django.db import models
+from opaque_keys.edx.django.models import CourseKeyField
 from six import text_type
 
 from course_modes.models import CourseMode
@@ -14,7 +15,6 @@ from enrollment.api import validate_course_mode
 from enrollment.errors import CourseModeNotFoundError
 from openedx.core.djangoapps.course_groups.cohorts import get_cohort_by_name
 from openedx.core.djangoapps.course_groups.models import CourseUserGroup
-from openedx.core.djangoapps.xmodule_django.models import CourseKeyField
 from openedx.core.lib.html_to_text import html_to_text
 from openedx.core.lib.mail_utils import wrap_message
 from student.roles import CourseInstructorRole, CourseStaffRole

--- a/lms/djangoapps/ccx/migrations/0001_initial.py
+++ b/lms/djangoapps/ccx/migrations/0001_initial.py
@@ -3,7 +3,7 @@ from __future__ import unicode_literals
 
 from django.db import migrations, models
 from django.conf import settings
-from openedx.core.djangoapps.xmodule_django.models import CourseKeyField, LocationKeyField
+from opaque_keys.edx.django.models import CourseKeyField, UsageKeyField
 
 
 class Migration(migrations.Migration):
@@ -17,7 +17,7 @@ class Migration(migrations.Migration):
             name='CcxFieldOverride',
             fields=[
                 ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
-                ('location', LocationKeyField(max_length=255, db_index=True)),
+                ('location', UsageKeyField(max_length=255, db_index=True)),
                 ('field', models.CharField(max_length=255)),
                 ('value', models.TextField(default=b'null')),
             ],

--- a/lms/djangoapps/ccx/models.py
+++ b/lms/djangoapps/ccx/models.py
@@ -11,9 +11,9 @@ from ccx_keys.locator import CCXLocator
 from django.contrib.auth.models import User
 from django.db import models
 from lazy import lazy
+from opaque_keys.edx.django.models import CourseKeyField, UsageKeyField
 from pytz import utc
 
-from openedx.core.djangoapps.xmodule_django.models import CourseKeyField, LocationKeyField
 from xmodule.error_module import ErrorDescriptor
 from xmodule.modulestore.django import modulestore
 
@@ -108,7 +108,7 @@ class CcxFieldOverride(models.Model):
     Field overrides for custom courses.
     """
     ccx = models.ForeignKey(CustomCourseForEdX, db_index=True)
-    location = LocationKeyField(max_length=255, db_index=True)
+    location = UsageKeyField(max_length=255, db_index=True)
     field = models.CharField(max_length=255)
 
     class Meta(object):

--- a/lms/djangoapps/certificates/api.py
+++ b/lms/djangoapps/certificates/api.py
@@ -9,6 +9,7 @@ import logging
 from django.conf import settings
 from django.core.urlresolvers import reverse
 from django.db.models import Q
+from opaque_keys.edx.django.models import CourseKeyField
 from opaque_keys.edx.keys import CourseKey
 
 from branding import api as branding_api
@@ -26,7 +27,6 @@ from lms.djangoapps.certificates.models import (
 from lms.djangoapps.certificates.queue import XQueueCertInterface
 from eventtracking import tracker
 from openedx.core.djangoapps.content.course_overviews.models import CourseOverview
-from openedx.core.djangoapps.xmodule_django.models import CourseKeyField
 from util.organizations_helpers import get_course_organization_id
 from xmodule.modulestore.django import modulestore
 

--- a/lms/djangoapps/certificates/migrations/0001_initial.py
+++ b/lms/djangoapps/certificates/migrations/0001_initial.py
@@ -9,7 +9,7 @@ import django.utils.timezone
 from badges.models import validate_badge_image
 from django.conf import settings
 from lms.djangoapps.certificates import models as cert_models
-from openedx.core.djangoapps.xmodule_django.models import CourseKeyField
+from opaque_keys.edx.django.models import CourseKeyField
 
 
 class Migration(migrations.Migration):

--- a/lms/djangoapps/certificates/migrations/0004_certificategenerationhistory.py
+++ b/lms/djangoapps/certificates/migrations/0004_certificategenerationhistory.py
@@ -5,7 +5,7 @@ from django.db import migrations, models
 import django.utils.timezone
 from django.conf import settings
 import model_utils.fields
-from openedx.core.djangoapps.xmodule_django.models import CourseKeyField
+from opaque_keys.edx.django.models import CourseKeyField
 
 
 class Migration(migrations.Migration):

--- a/lms/djangoapps/certificates/migrations/0011_certificatetemplate_alter_unique.py
+++ b/lms/djangoapps/certificates/migrations/0011_certificatetemplate_alter_unique.py
@@ -3,8 +3,8 @@ from __future__ import unicode_literals
 
 import logging
 from django.db import migrations, models
+from opaque_keys.edx.django.models import CourseKeyField
 from opaque_keys.edx.keys import CourseKey
-from openedx.core.djangoapps.xmodule_django.models import CourseKeyField
 
 log = logging.getLogger(__name__)
 

--- a/lms/djangoapps/certificates/models.py
+++ b/lms/djangoapps/certificates/models.py
@@ -61,12 +61,13 @@ from django.utils.translation import ugettext_lazy as _
 from model_utils import Choices
 from model_utils.fields import AutoCreatedField
 from model_utils.models import TimeStampedModel
+from opaque_keys.edx.django.models import CourseKeyField
 
 from badges.events.course_complete import course_badge_check
 from badges.events.course_meta import completion_check, course_group_check
 from lms.djangoapps.instructor_task.models import InstructorTask
 from openedx.core.djangoapps.signals.signals import COURSE_CERT_AWARDED
-from openedx.core.djangoapps.xmodule_django.models import CourseKeyField, NoneToEmptyManager
+from openedx.core.djangoapps.xmodule_django.models import NoneToEmptyManager
 from util.milestones_helpers import fulfill_course_milestone, is_prerequisite_courses_enabled
 
 LOGGER = logging.getLogger(__name__)

--- a/lms/djangoapps/completion/migrations/0001_initial.py
+++ b/lms/djangoapps/completion/migrations/0001_initial.py
@@ -5,9 +5,9 @@ from django.db import migrations, models
 import django.utils.timezone
 from django.conf import settings
 import model_utils.fields
+from opaque_keys.edx.django.models import CourseKeyField, UsageKeyField
 
 import lms.djangoapps.completion.models
-import openedx.core.djangoapps.xmodule_django.models
 
 # pylint: disable=ungrouped-imports
 try:
@@ -29,8 +29,8 @@ class Migration(migrations.Migration):
                 ('created', model_utils.fields.AutoCreatedField(default=django.utils.timezone.now, verbose_name='created', editable=False)),
                 ('modified', model_utils.fields.AutoLastModifiedField(default=django.utils.timezone.now, verbose_name='modified', editable=False)),
                 ('id', BigAutoField(serialize=False, primary_key=True)),
-                ('course_key', openedx.core.djangoapps.xmodule_django.models.CourseKeyField(max_length=255)),
-                ('block_key', openedx.core.djangoapps.xmodule_django.models.UsageKeyField(max_length=255)),
+                ('course_key', CourseKeyField(max_length=255)),
+                ('block_key', UsageKeyField(max_length=255)),
                 ('block_type', models.CharField(max_length=64)),
                 ('completion', models.FloatField(validators=[lms.djangoapps.completion.models.validate_percent])),
                 ('user', models.ForeignKey(to=settings.AUTH_USER_MODEL)),

--- a/lms/djangoapps/completion/models.py
+++ b/lms/djangoapps/completion/models.py
@@ -9,9 +9,9 @@ from django.core.exceptions import ValidationError
 from django.db import models, transaction, connection
 from django.utils.translation import ugettext as _
 from model_utils.models import TimeStampedModel
+from opaque_keys.edx.django.models import CourseKeyField, UsageKeyField
 from opaque_keys.edx.keys import CourseKey
 
-from openedx.core.djangoapps.xmodule_django.models import CourseKeyField, UsageKeyField
 from . import waffle
 
 # pylint: disable=ungrouped-imports

--- a/lms/djangoapps/course_goals/migrations/0001_initial.py
+++ b/lms/djangoapps/course_goals/migrations/0001_initial.py
@@ -2,8 +2,8 @@
 from __future__ import unicode_literals
 
 from django.db import migrations, models
-import openedx.core.djangoapps.xmodule_django.models
 from django.conf import settings
+from opaque_keys.edx.django.models import CourseKeyField
 
 
 class Migration(migrations.Migration):
@@ -17,7 +17,7 @@ class Migration(migrations.Migration):
             name='CourseGoal',
             fields=[
                 ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
-                ('course_key', openedx.core.djangoapps.xmodule_django.models.CourseKeyField(max_length=255, db_index=True)),
+                ('course_key', CourseKeyField(max_length=255, db_index=True)),
                 ('goal_key', models.CharField(default=b'unsure', max_length=100, choices=[(b'certify', 'Earn a certificate.'), (b'complete', 'Complete the course.'), (b'explore', 'Explore the course.'), (b'unsure', 'Not sure yet.')])),
                 ('user', models.ForeignKey(to=settings.AUTH_USER_MODEL)),
             ],

--- a/lms/djangoapps/course_goals/models.py
+++ b/lms/djangoapps/course_goals/models.py
@@ -5,7 +5,7 @@ from django.contrib.auth.models import User
 from django.db import models
 from django.dispatch import receiver
 from django.utils.translation import ugettext_lazy as _
-from openedx.core.djangoapps.xmodule_django.models import CourseKeyField
+from opaque_keys.edx.django.models import CourseKeyField
 from model_utils import Choices
 
 from .api import add_course_goal, remove_course_goal

--- a/lms/djangoapps/courseware/migrations/0001_initial.py
+++ b/lms/djangoapps/courseware/migrations/0001_initial.py
@@ -5,8 +5,8 @@ from django.db import migrations, models
 import model_utils.fields
 import django.utils.timezone
 from django.conf import settings
-from openedx.core.djangoapps.xmodule_django.models import (
-    CourseKeyField, LocationKeyField, BlockTypeKeyField
+from opaque_keys.edx.django.models import (
+    BlockTypeKeyField, CourseKeyField, UsageKeyField
 )
 
 
@@ -49,7 +49,7 @@ class Migration(migrations.Migration):
                 ('created', model_utils.fields.AutoCreatedField(default=django.utils.timezone.now, verbose_name='created', editable=False)),
                 ('modified', model_utils.fields.AutoLastModifiedField(default=django.utils.timezone.now, verbose_name='modified', editable=False)),
                 ('course_id', CourseKeyField(max_length=255, db_index=True)),
-                ('location', LocationKeyField(max_length=255, db_index=True)),
+                ('location', UsageKeyField(max_length=255, db_index=True)),
                 ('field', models.CharField(max_length=255)),
                 ('value', models.TextField(default=b'null')),
                 ('student', models.ForeignKey(to=settings.AUTH_USER_MODEL)),
@@ -60,7 +60,7 @@ class Migration(migrations.Migration):
             fields=[
                 ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
                 ('module_type', models.CharField(default=b'problem', max_length=32, db_index=True, choices=[(b'problem', b'problem'), (b'video', b'video'), (b'html', b'html'), (b'course', b'course'), (b'chapter', b'Section'), (b'sequential', b'Subsection'), (b'library_content', b'Library Content')])),
-                ('module_state_key', LocationKeyField(max_length=255, db_column=b'module_id', db_index=True)),
+                ('module_state_key', UsageKeyField(max_length=255, db_column=b'module_id', db_index=True)),
                 ('course_id', CourseKeyField(max_length=255, db_index=True)),
                 ('state', models.TextField(null=True, blank=True)),
                 ('grade', models.FloatField(db_index=True, null=True, blank=True)),
@@ -117,7 +117,7 @@ class Migration(migrations.Migration):
                 ('value', models.TextField(default=b'null')),
                 ('created', models.DateTimeField(auto_now_add=True, db_index=True)),
                 ('modified', models.DateTimeField(auto_now=True, db_index=True)),
-                ('usage_id', LocationKeyField(max_length=255, db_index=True)),
+                ('usage_id', UsageKeyField(max_length=255, db_index=True)),
             ],
         ),
         migrations.AlterUniqueTogether(

--- a/lms/djangoapps/courseware/migrations/0002_coursedynamicupgradedeadlineconfiguration_dynamicupgradedeadlineconfiguration.py
+++ b/lms/djangoapps/courseware/migrations/0002_coursedynamicupgradedeadlineconfiguration_dynamicupgradedeadlineconfiguration.py
@@ -4,7 +4,7 @@ from __future__ import unicode_literals
 from django.db import migrations, models
 from django.conf import settings
 import django.db.models.deletion
-import openedx.core.djangoapps.xmodule_django.models
+from opaque_keys.edx.django.models import CourseKeyField
 
 
 class Migration(migrations.Migration):
@@ -21,7 +21,7 @@ class Migration(migrations.Migration):
                 ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
                 ('change_date', models.DateTimeField(auto_now_add=True, verbose_name='Change date')),
                 ('enabled', models.BooleanField(default=False, verbose_name='Enabled')),
-                ('course_id', openedx.core.djangoapps.xmodule_django.models.CourseKeyField(max_length=255, db_index=True)),
+                ('course_id', CourseKeyField(max_length=255, db_index=True)),
                 ('deadline_days', models.PositiveSmallIntegerField(default=21, help_text='Number of days a learner has to upgrade after content is made available')),
                 ('opt_out', models.BooleanField(default=False, help_text='Disable the dynamic upgrade deadline for this course run.')),
                 ('changed_by', models.ForeignKey(on_delete=django.db.models.deletion.PROTECT, editable=False, to=settings.AUTH_USER_MODEL, null=True, verbose_name='Changed by')),

--- a/lms/djangoapps/courseware/models.py
+++ b/lms/djangoapps/courseware/models.py
@@ -25,7 +25,7 @@ from model_utils.models import TimeStampedModel
 from six import text_type
 
 import coursewarehistoryextended
-from openedx.core.djangoapps.xmodule_django.models import BlockTypeKeyField, CourseKeyField, LocationKeyField
+from opaque_keys.edx.django.models import BlockTypeKeyField, CourseKeyField, UsageKeyField
 
 log = logging.getLogger("edx.courseware")
 
@@ -91,7 +91,7 @@ class StudentModule(models.Model):
     module_type = models.CharField(max_length=32, choices=MODULE_TYPES, default='problem', db_index=True)
 
     # Key used to share state. This is the XBlock usage_id
-    module_state_key = LocationKeyField(max_length=255, db_index=True, db_column='module_id')
+    module_state_key = UsageKeyField(max_length=255, db_index=True, db_column='module_id')
     student = models.ForeignKey(User, db_index=True)
 
     course_id = CourseKeyField(max_length=255, db_index=True)
@@ -285,7 +285,7 @@ class XModuleUserStateSummaryField(XBlockFieldBase):
         unique_together = (('usage_id', 'field_name'),)
 
     # The definition id for the module
-    usage_id = LocationKeyField(max_length=255, db_index=True)
+    usage_id = UsageKeyField(max_length=255, db_index=True)
 
 
 class XModuleStudentPrefsField(XBlockFieldBase):
@@ -362,7 +362,7 @@ class StudentFieldOverride(TimeStampedModel):
     overrides of xblock fields on a per user basis.
     """
     course_id = CourseKeyField(max_length=255, db_index=True)
-    location = LocationKeyField(max_length=255, db_index=True)
+    location = UsageKeyField(max_length=255, db_index=True)
     student = models.ForeignKey(User, db_index=True)
 
     class Meta(object):

--- a/lms/djangoapps/grades/config/models.py
+++ b/lms/djangoapps/grades/config/models.py
@@ -5,9 +5,9 @@ controlling persistent grades.
 from config_models.models import ConfigurationModel
 from django.conf import settings
 from django.db.models import BooleanField, IntegerField, TextField
+from opaque_keys.edx.django.models import CourseKeyField
 from six import text_type
 
-from openedx.core.djangoapps.xmodule_django.models import CourseKeyField
 from openedx.core.djangoapps.request_cache.middleware import request_cached
 
 

--- a/lms/djangoapps/grades/migrations/0001_initial.py
+++ b/lms/djangoapps/grades/migrations/0001_initial.py
@@ -5,7 +5,7 @@ from django.db import migrations, models
 import coursewarehistoryextended.fields
 import django.utils.timezone
 import model_utils.fields
-from openedx.core.djangoapps.xmodule_django.models import CourseKeyField, UsageKeyField
+from opaque_keys.edx.django.models import CourseKeyField, UsageKeyField
 
 
 class Migration(migrations.Migration):

--- a/lms/djangoapps/grades/migrations/0003_coursepersistentgradesflag_persistentgradesenabledflag.py
+++ b/lms/djangoapps/grades/migrations/0003_coursepersistentgradesflag_persistentgradesenabledflag.py
@@ -4,7 +4,7 @@ from __future__ import unicode_literals
 from django.db import migrations, models
 import django.db.models.deletion
 from django.conf import settings
-from openedx.core.djangoapps.xmodule_django.models import CourseKeyField
+from opaque_keys.edx.django.models import CourseKeyField
 
 
 class Migration(migrations.Migration):

--- a/lms/djangoapps/grades/migrations/0004_visibleblocks_course_id.py
+++ b/lms/djangoapps/grades/migrations/0004_visibleblocks_course_id.py
@@ -2,8 +2,8 @@
 from __future__ import unicode_literals
 
 from django.db import migrations, models
+from opaque_keys.edx.django.models import CourseKeyField
 from opaque_keys.edx.keys import CourseKey
-from openedx.core.djangoapps.xmodule_django.models import CourseKeyField
 
 
 class Migration(migrations.Migration):

--- a/lms/djangoapps/grades/migrations/0005_multiple_course_flags.py
+++ b/lms/djangoapps/grades/migrations/0005_multiple_course_flags.py
@@ -2,7 +2,7 @@
 from __future__ import unicode_literals
 
 from django.db import migrations, models
-from openedx.core.djangoapps.xmodule_django.models import CourseKeyField
+from opaque_keys.edx.django.models import CourseKeyField
 
 
 class Migration(migrations.Migration):

--- a/lms/djangoapps/grades/migrations/0006_persistent_course_grades.py
+++ b/lms/djangoapps/grades/migrations/0006_persistent_course_grades.py
@@ -4,7 +4,7 @@ from __future__ import unicode_literals
 from django.db import migrations, models
 import django.utils.timezone
 import model_utils.fields
-from openedx.core.djangoapps.xmodule_django.models import CourseKeyField
+from opaque_keys.edx.django.models import CourseKeyField
 import coursewarehistoryextended.fields
 
 

--- a/lms/djangoapps/grades/models.py
+++ b/lms/djangoapps/grades/models.py
@@ -18,10 +18,10 @@ from django.db import models
 from django.utils.timezone import now
 from lazy import lazy
 from model_utils.models import TimeStampedModel
+from opaque_keys.edx.django.models import CourseKeyField, UsageKeyField
 from opaque_keys.edx.keys import CourseKey, UsageKey
 
 from coursewarehistoryextended.fields import UnsignedBigIntAutoField, UnsignedBigIntOneToOneField
-from openedx.core.djangoapps.xmodule_django.models import CourseKeyField, UsageKeyField
 from openedx.core.djangoapps.request_cache import get_cache
 
 import events

--- a/lms/djangoapps/instructor_task/migrations/0001_initial.py
+++ b/lms/djangoapps/instructor_task/migrations/0001_initial.py
@@ -3,7 +3,7 @@ from __future__ import unicode_literals
 
 from django.db import migrations, models
 from django.conf import settings
-from openedx.core.djangoapps.xmodule_django.models import CourseKeyField
+from opaque_keys.edx.django.models import CourseKeyField
 
 
 class Migration(migrations.Migration):

--- a/lms/djangoapps/instructor_task/models.py
+++ b/lms/djangoapps/instructor_task/models.py
@@ -24,9 +24,9 @@ from django.conf import settings
 from django.contrib.auth.models import User
 from django.core.files.base import ContentFile
 from django.db import models, transaction
+from opaque_keys.edx.django.models import CourseKeyField
 from six import text_type
 
-from openedx.core.djangoapps.xmodule_django.models import CourseKeyField
 from openedx.core.storage import get_storage
 
 logger = logging.getLogger(__name__)

--- a/lms/djangoapps/lti_provider/migrations/0001_initial.py
+++ b/lms/djangoapps/lti_provider/migrations/0001_initial.py
@@ -4,7 +4,7 @@ from __future__ import unicode_literals
 from django.db import migrations, models
 import provider.utils
 from django.conf import settings
-from openedx.core.djangoapps.xmodule_django.models import CourseKeyField, UsageKeyField
+from opaque_keys.edx.django.models import CourseKeyField, UsageKeyField
 
 
 class Migration(migrations.Migration):

--- a/lms/djangoapps/lti_provider/models.py
+++ b/lms/djangoapps/lti_provider/models.py
@@ -12,9 +12,9 @@ import logging
 
 from django.contrib.auth.models import User
 from django.db import models
+from opaque_keys.edx.django.models import CourseKeyField, UsageKeyField
 from provider.utils import short_token
 
-from openedx.core.djangoapps.xmodule_django.models import CourseKeyField, UsageKeyField
 from openedx.core.djangolib.fields import CharNullField
 
 log = logging.getLogger("edx.lti_provider")

--- a/lms/djangoapps/notes/migrations/0001_initial.py
+++ b/lms/djangoapps/notes/migrations/0001_initial.py
@@ -3,7 +3,7 @@ from __future__ import unicode_literals
 
 from django.db import migrations, models
 from django.conf import settings
-from openedx.core.djangoapps.xmodule_django.models import CourseKeyField
+from opaque_keys.edx.django.models import CourseKeyField
 
 
 class Migration(migrations.Migration):

--- a/lms/djangoapps/notes/models.py
+++ b/lms/djangoapps/notes/models.py
@@ -5,9 +5,8 @@ from django.core.exceptions import ValidationError
 from django.core.urlresolvers import reverse
 from django.db import models
 from django.utils.html import strip_tags
+from opaque_keys.edx.django.models import CourseKeyField
 from six import text_type
-
-from openedx.core.djangoapps.xmodule_django.models import CourseKeyField
 
 
 class Note(models.Model):

--- a/lms/djangoapps/shoppingcart/migrations/0001_initial.py
+++ b/lms/djangoapps/shoppingcart/migrations/0001_initial.py
@@ -6,7 +6,7 @@ import django.utils.timezone
 import django.db.models.deletion
 from django.conf import settings
 import model_utils.fields
-from openedx.core.djangoapps.xmodule_django.models import CourseKeyField
+from opaque_keys.edx.django.models import CourseKeyField
 
 
 class Migration(migrations.Migration):

--- a/lms/djangoapps/shoppingcart/models.py
+++ b/lms/djangoapps/shoppingcart/models.py
@@ -29,6 +29,7 @@ from django.utils.translation import ugettext as _
 from django.utils.translation import ugettext_lazy
 from model_utils.managers import InheritanceManager
 from model_utils.models import TimeStampedModel
+from opaque_keys.edx.django.models import CourseKeyField
 from six import text_type
 
 from course_modes.models import CourseMode
@@ -36,7 +37,6 @@ from courseware.courses import get_course_by_id
 from edxmako.shortcuts import render_to_string
 from eventtracking import tracker
 from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
-from openedx.core.djangoapps.xmodule_django.models import CourseKeyField
 from shoppingcart.pdf import PDFInvoice
 from student.models import CourseEnrollment, EnrollStatusChange
 from student.signals import UNENROLL_DONE

--- a/lms/djangoapps/survey/migrations/0001_initial.py
+++ b/lms/djangoapps/survey/migrations/0001_initial.py
@@ -5,7 +5,7 @@ from django.db import migrations, models
 import django.utils.timezone
 from django.conf import settings
 import model_utils.fields
-from openedx.core.djangoapps.xmodule_django.models import CourseKeyField
+from opaque_keys.edx.django.models import CourseKeyField
 
 
 class Migration(migrations.Migration):

--- a/lms/djangoapps/survey/models.py
+++ b/lms/djangoapps/survey/models.py
@@ -9,8 +9,8 @@ from django.core.exceptions import ValidationError
 from django.db import models
 from lxml import etree
 from model_utils.models import TimeStampedModel
+from opaque_keys.edx.django.models import CourseKeyField
 
-from openedx.core.djangoapps.xmodule_django.models import CourseKeyField
 from student.models import User
 from survey.exceptions import SurveyFormNameAlreadyExists, SurveyFormNotFound
 

--- a/lms/djangoapps/teams/migrations/0001_initial.py
+++ b/lms/djangoapps/teams/migrations/0001_initial.py
@@ -4,8 +4,8 @@ from __future__ import unicode_literals
 from django.db import migrations, models
 import django_countries.fields
 from django.conf import settings
+from opaque_keys.edx.django.models import CourseKeyField
 import student.models
-from openedx.core.djangoapps.xmodule_django.models import CourseKeyField
 
 
 class Migration(migrations.Migration):

--- a/lms/djangoapps/teams/models.py
+++ b/lms/djangoapps/teams/models.py
@@ -11,6 +11,7 @@ from django.dispatch import receiver
 from django.utils.translation import ugettext_lazy
 from django_countries.fields import CountryField
 from model_utils import FieldTracker
+from opaque_keys.edx.django.models import CourseKeyField
 
 from django_comment_common.signals import (
     comment_created,
@@ -27,7 +28,6 @@ from django_comment_common.signals import (
 )
 from lms.djangoapps.teams import TEAM_DISCUSSION_CONTEXT
 from lms.djangoapps.teams.utils import emit_team_event
-from openedx.core.djangoapps.xmodule_django.models import CourseKeyField
 from student.models import CourseEnrollment, LanguageField
 from django.utils.text import slugify
 

--- a/lms/djangoapps/verify_student/migrations/0001_initial.py
+++ b/lms/djangoapps/verify_student/migrations/0001_initial.py
@@ -7,7 +7,7 @@ import model_utils.fields
 import django.db.models.deletion
 import django.utils.timezone
 from django.conf import settings
-from openedx.core.djangoapps.xmodule_django.models import CourseKeyField
+from opaque_keys.edx.django.models import CourseKeyField
 
 
 class Migration(migrations.Migration):

--- a/lms/djangoapps/verify_student/models.py
+++ b/lms/djangoapps/verify_student/models.py
@@ -32,6 +32,7 @@ from django.utils.translation import ugettext as _
 from django.utils.translation import ugettext_lazy
 from model_utils import Choices
 from model_utils.models import StatusModel, TimeStampedModel
+from opaque_keys.edx.django.models import CourseKeyField
 
 from course_modes.models import CourseMode
 from lms.djangoapps.verify_student.ssencrypt import (
@@ -42,7 +43,6 @@ from lms.djangoapps.verify_student.ssencrypt import (
 )
 from openedx.core.djangoapps.signals.signals import LEARNER_NOW_VERIFIED
 from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
-from openedx.core.djangoapps.xmodule_django.models import CourseKeyField
 from openedx.core.djangolib.model_mixins import DeprecatedModelMixin
 from openedx.core.storage import get_storage
 

--- a/openedx/core/djangoapps/bookmarks/migrations/0001_initial.py
+++ b/openedx/core/djangoapps/bookmarks/migrations/0001_initial.py
@@ -6,7 +6,7 @@ import model_utils.fields
 import jsonfield.fields
 import django.utils.timezone
 from django.conf import settings
-from openedx.core.djangoapps.xmodule_django.models import CourseKeyField, LocationKeyField
+from opaque_keys.edx.django.models import CourseKeyField, UsageKeyField
 
 
 class Migration(migrations.Migration):
@@ -23,7 +23,7 @@ class Migration(migrations.Migration):
                 ('created', model_utils.fields.AutoCreatedField(default=django.utils.timezone.now, verbose_name='created', editable=False)),
                 ('modified', model_utils.fields.AutoLastModifiedField(default=django.utils.timezone.now, verbose_name='modified', editable=False)),
                 ('course_key', CourseKeyField(max_length=255, db_index=True)),
-                ('usage_key', LocationKeyField(max_length=255, db_index=True)),
+                ('usage_key', UsageKeyField(max_length=255, db_index=True)),
                 ('_path', jsonfield.fields.JSONField(help_text=b'Path in course tree to the block', db_column=b'path')),
                 ('user', models.ForeignKey(to=settings.AUTH_USER_MODEL)),
             ],
@@ -35,7 +35,7 @@ class Migration(migrations.Migration):
                 ('created', model_utils.fields.AutoCreatedField(default=django.utils.timezone.now, verbose_name='created', editable=False)),
                 ('modified', model_utils.fields.AutoLastModifiedField(default=django.utils.timezone.now, verbose_name='modified', editable=False)),
                 ('course_key', CourseKeyField(max_length=255, db_index=True)),
-                ('usage_key', LocationKeyField(unique=True, max_length=255, db_index=True)),
+                ('usage_key', UsageKeyField(unique=True, max_length=255, db_index=True)),
                 ('display_name', models.CharField(default=b'', max_length=255)),
                 ('_paths', jsonfield.fields.JSONField(default=[], help_text=b'All paths in course tree to the corresponding block.', db_column=b'paths')),
             ],

--- a/openedx/core/djangoapps/bookmarks/models.py
+++ b/openedx/core/djangoapps/bookmarks/models.py
@@ -7,9 +7,9 @@ from django.contrib.auth.models import User
 from django.db import models
 from jsonfield.fields import JSONField
 from model_utils.models import TimeStampedModel
+from opaque_keys.edx.django.models import CourseKeyField, UsageKeyField
 from opaque_keys.edx.keys import UsageKey
 
-from openedx.core.djangoapps.xmodule_django.models import CourseKeyField, LocationKeyField
 from xmodule.modulestore import search
 from xmodule.modulestore.django import modulestore
 from xmodule.modulestore.exceptions import ItemNotFoundError, NoPathToItem
@@ -44,7 +44,7 @@ class Bookmark(TimeStampedModel):
     """
     user = models.ForeignKey(User, db_index=True)
     course_key = CourseKeyField(max_length=255, db_index=True)
-    usage_key = LocationKeyField(max_length=255, db_index=True)
+    usage_key = UsageKeyField(max_length=255, db_index=True)
     _path = JSONField(db_column='path', help_text='Path in course tree to the block')
 
     xblock_cache = models.ForeignKey('bookmarks.XBlockCache')
@@ -192,7 +192,7 @@ class XBlockCache(TimeStampedModel):
     """
 
     course_key = CourseKeyField(max_length=255, db_index=True)
-    usage_key = LocationKeyField(max_length=255, db_index=True, unique=True)
+    usage_key = UsageKeyField(max_length=255, db_index=True, unique=True)
 
     display_name = models.CharField(max_length=255, default='')
     _paths = JSONField(

--- a/openedx/core/djangoapps/content/block_structure/migrations/0002_blockstructuremodel.py
+++ b/openedx/core/djangoapps/content/block_structure/migrations/0002_blockstructuremodel.py
@@ -3,8 +3,8 @@ from __future__ import unicode_literals
 
 from django.db import migrations, models
 import django.utils.timezone
-import openedx.core.djangoapps.xmodule_django.models
 import model_utils.fields
+from opaque_keys.edx.django.models import UsageKeyField
 import openedx.core.djangoapps.content.block_structure.models
 
 
@@ -21,7 +21,7 @@ class Migration(migrations.Migration):
                 ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
                 ('created', model_utils.fields.AutoCreatedField(default=django.utils.timezone.now, verbose_name='created', editable=False)),
                 ('modified', model_utils.fields.AutoLastModifiedField(default=django.utils.timezone.now, verbose_name='modified', editable=False)),
-                ('data_usage_key', openedx.core.djangoapps.xmodule_django.models.UsageKeyField(unique=True, max_length=255, verbose_name='Identifier of the data being collected.')),
+                ('data_usage_key', UsageKeyField(unique=True, max_length=255, verbose_name='Identifier of the data being collected.')),
                 ('data_version', models.CharField(max_length=255, null=True, verbose_name='Version of the data at the time of collection.', blank=True)),
                 ('data_edit_timestamp', models.DateTimeField(null=True, verbose_name='Edit timestamp of the data at the time of collection.', blank=True)),
                 ('transformers_schema_version', models.CharField(max_length=255, verbose_name='Representation of the schema version of the transformers used during collection.')),

--- a/openedx/core/djangoapps/content/course_overviews/migrations/0001_initial.py
+++ b/openedx/core/djangoapps/content/course_overviews/migrations/0001_initial.py
@@ -4,7 +4,7 @@ from __future__ import unicode_literals
 from django.db import migrations, models
 import django.utils.timezone
 import model_utils.fields
-from openedx.core.djangoapps.xmodule_django.models import CourseKeyField, UsageKeyField
+from opaque_keys.edx.django.models import CourseKeyField, UsageKeyField
 
 
 class Migration(migrations.Migration):

--- a/openedx/core/djangoapps/content/course_overviews/models.py
+++ b/openedx/core/djangoapps/content/course_overviews/models.py
@@ -13,6 +13,7 @@ from django.template import defaultfilters
 
 from ccx_keys.locator import CCXLocator
 from model_utils.models import TimeStampedModel
+from opaque_keys.edx.django.models import CourseKeyField, UsageKeyField
 from six import text_type
 
 from config_models.models import ConfigurationModel
@@ -25,7 +26,6 @@ from xmodule import course_metadata_utils, block_metadata_utils
 from xmodule.course_module import CourseDescriptor, DEFAULT_START_DATE
 from xmodule.error_module import ErrorDescriptor
 from xmodule.modulestore.django import modulestore
-from openedx.core.djangoapps.xmodule_django.models import CourseKeyField, UsageKeyField
 
 log = logging.getLogger(__name__)
 

--- a/openedx/core/djangoapps/content/course_overviews/tests/test_course_overviews.py
+++ b/openedx/core/djangoapps/content/course_overviews/tests/test_course_overviews.py
@@ -395,7 +395,7 @@ class CourseOverviewTestCase(CatalogIntegrationMixin, ModuleStoreTestCase):
                 # return empty str if there is no default value present. So mock it to avoid
                 # returning the empty str as primary key value. Due to empty str, model.save will do
                 # an update instead of insert which is incorrect and get exception in
-                # openedx.core.djangoapps.xmodule_django.models.OpaqueKeyField.get_prep_value
+                # opaque_keys.edx.django.models.OpaqueKeyField.get_prep_value
                 with mock.patch('django.db.models.Field.get_pk_value_on_save') as mock_get_pk_value_on_save:
 
                     mock_get_pk_value_on_save.return_value = None

--- a/openedx/core/djangoapps/content/course_structures/migrations/0001_initial.py
+++ b/openedx/core/djangoapps/content/course_structures/migrations/0001_initial.py
@@ -4,8 +4,8 @@ from __future__ import unicode_literals
 from django.db import migrations, models
 import django.utils.timezone
 import model_utils.fields
+from opaque_keys.edx.django.models import CourseKeyField
 import util.models
-from openedx.core.djangoapps.xmodule_django.models import CourseKeyField
 
 
 class Migration(migrations.Migration):

--- a/openedx/core/djangoapps/content/course_structures/models.py
+++ b/openedx/core/djangoapps/content/course_structures/models.py
@@ -6,9 +6,9 @@ import logging
 
 from collections import OrderedDict
 from model_utils.models import TimeStampedModel
+from opaque_keys.edx.django.models import CourseKeyField, UsageKey
 
 from util.models import CompressedTextField
-from openedx.core.djangoapps.xmodule_django.models import CourseKeyField, UsageKey
 
 
 logger = logging.getLogger(__name__)  # pylint: disable=invalid-name

--- a/openedx/core/djangoapps/content/course_structures/tests.py
+++ b/openedx/core/djangoapps/content/course_structures/tests.py
@@ -3,6 +3,7 @@ Course Structure Content sub-application test cases
 """
 import json
 from nose.plugins.attrib import attr
+from opaque_keys.edx.django.models import UsageKey
 
 from xmodule.modulestore.django import SignalHandler
 from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
@@ -10,7 +11,6 @@ from xmodule.modulestore.tests.factories import CourseFactory, ItemFactory
 from openedx.core.djangoapps.content.course_structures.models import CourseStructure
 from openedx.core.djangoapps.content.course_structures.signals import listen_for_course_publish
 from openedx.core.djangoapps.content.course_structures.tasks import _generate_course_structure, update_course_structure
-from openedx.core.djangoapps.xmodule_django.models import UsageKey
 
 
 class SignalDisconnectTestMixin(object):

--- a/openedx/core/djangoapps/course_groups/migrations/0001_initial.py
+++ b/openedx/core/djangoapps/course_groups/migrations/0001_initial.py
@@ -3,7 +3,7 @@ from __future__ import unicode_literals
 
 from django.db import migrations, models
 from django.conf import settings
-from openedx.core.djangoapps.xmodule_django.models import CourseKeyField
+from opaque_keys.edx.django.models import CourseKeyField
 
 
 class Migration(migrations.Migration):

--- a/openedx/core/djangoapps/course_groups/migrations/0003_auto_20170609_1455.py
+++ b/openedx/core/djangoapps/course_groups/migrations/0003_auto_20170609_1455.py
@@ -2,7 +2,7 @@
 from __future__ import unicode_literals
 
 from django.db import migrations, models
-import openedx.core.djangoapps.xmodule_django.models
+from opaque_keys.edx.django.models import CourseKeyField
 
 
 class Migration(migrations.Migration):
@@ -17,7 +17,7 @@ class Migration(migrations.Migration):
             fields=[
                 ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
                 ('email', models.CharField(db_index=True, max_length=255, blank=True)),
-                ('course_id', openedx.core.djangoapps.xmodule_django.models.CourseKeyField(max_length=255)),
+                ('course_id', CourseKeyField(max_length=255)),
                 ('course_user_group', models.ForeignKey(to='course_groups.CourseUserGroup')),
             ],
         ),

--- a/openedx/core/djangoapps/course_groups/models.py
+++ b/openedx/core/djangoapps/course_groups/models.py
@@ -10,7 +10,7 @@ from django.core.exceptions import ValidationError
 from django.db import models, transaction
 from django.db.models.signals import pre_delete
 from django.dispatch import receiver
-from openedx.core.djangoapps.xmodule_django.models import CourseKeyField
+from opaque_keys.edx.django.models import CourseKeyField
 from util.db import outer_atomic
 
 log = logging.getLogger(__name__)

--- a/openedx/core/djangoapps/credit/migrations/0001_initial.py
+++ b/openedx/core/djangoapps/credit/migrations/0001_initial.py
@@ -9,7 +9,7 @@ import django.db.models.deletion
 import django.utils.timezone
 from django.conf import settings
 import django.core.validators
-from openedx.core.djangoapps.xmodule_django.models import CourseKeyField
+from opaque_keys.edx.django.models import CourseKeyField
 
 
 class Migration(migrations.Migration):

--- a/openedx/core/djangoapps/credit/models.py
+++ b/openedx/core/djangoapps/credit/models.py
@@ -21,8 +21,8 @@ from django.utils.translation import ugettext as _
 from django.utils.translation import ugettext_lazy
 from jsonfield.fields import JSONField
 from model_utils.models import TimeStampedModel
+from opaque_keys.edx.django.models import CourseKeyField
 
-from openedx.core.djangoapps.xmodule_django.models import CourseKeyField
 from openedx.core.djangoapps.request_cache.middleware import RequestCache, ns_request_cached
 
 CREDIT_PROVIDER_ID_REGEX = r"[a-z,A-Z,0-9,\-]+"

--- a/openedx/core/djangoapps/embargo/migrations/0001_initial.py
+++ b/openedx/core/djangoapps/embargo/migrations/0001_initial.py
@@ -5,7 +5,7 @@ from django.db import migrations, models
 import django_countries.fields
 import django.db.models.deletion
 from django.conf import settings
-from openedx.core.djangoapps.xmodule_django.models import CourseKeyField
+from opaque_keys.edx.django.models import CourseKeyField
 
 
 class Migration(migrations.Migration):

--- a/openedx/core/djangoapps/embargo/models.py
+++ b/openedx/core/djangoapps/embargo/models.py
@@ -24,9 +24,10 @@ from django.utils.translation import ugettext as _
 from django.utils.translation import ugettext_lazy
 from django_countries import countries
 from django_countries.fields import CountryField
+from opaque_keys.edx.django.models import CourseKeyField
 from six import text_type
 
-from openedx.core.djangoapps.xmodule_django.models import CourseKeyField, NoneToEmptyManager
+from openedx.core.djangoapps.xmodule_django.models import NoneToEmptyManager
 
 from .exceptions import InvalidAccessPoint
 from .messages import COURSEWARE_MESSAGES, ENROLL_MESSAGES

--- a/openedx/core/djangoapps/user_api/migrations/0001_initial.py
+++ b/openedx/core/djangoapps/user_api/migrations/0001_initial.py
@@ -6,7 +6,7 @@ import django.utils.timezone
 from django.conf import settings
 import model_utils.fields
 import django.core.validators
-from openedx.core.djangoapps.xmodule_django.models import CourseKeyField
+from opaque_keys.edx.django.models import CourseKeyField
 
 
 class Migration(migrations.Migration):

--- a/openedx/core/djangoapps/user_api/models.py
+++ b/openedx/core/djangoapps/user_api/models.py
@@ -7,8 +7,8 @@ from django.db import models
 from django.db.models.signals import post_delete, post_save, pre_save
 from django.dispatch import receiver
 from model_utils.models import TimeStampedModel
+from opaque_keys.edx.django.models import CourseKeyField
 
-from openedx.core.djangoapps.xmodule_django.models import CourseKeyField
 # Currently, the "student" app is responsible for
 # accounts, profiles, enrollments, and the student dashboard.
 # We are trying to move some of this functionality into separate apps,

--- a/openedx/core/djangoapps/verified_track_content/migrations/0001_initial.py
+++ b/openedx/core/djangoapps/verified_track_content/migrations/0001_initial.py
@@ -2,7 +2,7 @@
 from __future__ import unicode_literals
 
 from django.db import migrations, models
-from openedx.core.djangoapps.xmodule_django.models import CourseKeyField
+from opaque_keys.edx.django.models import CourseKeyField
 
 
 class Migration(migrations.Migration):

--- a/openedx/core/djangoapps/verified_track_content/migrations/0003_migrateverifiedtrackcohortssetting.py
+++ b/openedx/core/djangoapps/verified_track_content/migrations/0003_migrateverifiedtrackcohortssetting.py
@@ -3,8 +3,8 @@ from __future__ import unicode_literals
 
 from django.db import migrations, models
 import django.db.models.deletion
-import openedx.core.djangoapps.xmodule_django.models
 from django.conf import settings
+from opaque_keys.edx.django.models import CourseKeyField
 
 
 class Migration(migrations.Migration):
@@ -21,8 +21,8 @@ class Migration(migrations.Migration):
                 ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
                 ('change_date', models.DateTimeField(auto_now_add=True, verbose_name='Change date')),
                 ('enabled', models.BooleanField(default=False, verbose_name='Enabled')),
-                ('old_course_key', openedx.core.djangoapps.xmodule_django.models.CourseKeyField(help_text=b'Course key for which to migrate verified track cohorts from', max_length=255)),
-                ('rerun_course_key', openedx.core.djangoapps.xmodule_django.models.CourseKeyField(help_text=b'Course key for which to migrate verified track cohorts to enrollment tracks to', max_length=255)),
+                ('old_course_key', CourseKeyField(help_text=b'Course key for which to migrate verified track cohorts from', max_length=255)),
+                ('rerun_course_key', CourseKeyField(help_text=b'Course key for which to migrate verified track cohorts to enrollment tracks to', max_length=255)),
                 ('audit_cohort_names', models.TextField(help_text=b'Comma-separated list of audit cohort names')),
                 ('changed_by', models.ForeignKey(on_delete=django.db.models.deletion.PROTECT, editable=False, to=settings.AUTH_USER_MODEL, null=True, verbose_name='Changed by')),
             ],

--- a/openedx/core/djangoapps/verified_track_content/models.py
+++ b/openedx/core/djangoapps/verified_track_content/models.py
@@ -8,6 +8,7 @@ from django.db import models
 from django.db.models.signals import post_save, pre_save
 from django.dispatch import receiver
 from django.utils.translation import ugettext_lazy
+from opaque_keys.edx.django.models import CourseKeyField
 
 from lms.djangoapps.courseware.courses import get_course_by_id
 from openedx.core.djangoapps.course_groups.cohorts import (
@@ -17,7 +18,6 @@ from openedx.core.djangoapps.course_groups.cohorts import (
     is_course_cohorted
 )
 from openedx.core.djangoapps.verified_track_content.tasks import sync_cohort_with_mode
-from openedx.core.djangoapps.xmodule_django.models import CourseKeyField
 from openedx.core.djangoapps.request_cache.middleware import RequestCache, ns_request_cached
 from student.models import CourseEnrollment
 

--- a/openedx/core/djangoapps/video_config/migrations/0001_initial.py
+++ b/openedx/core/djangoapps/video_config/migrations/0001_initial.py
@@ -4,7 +4,7 @@ from __future__ import unicode_literals
 from django.db import migrations, models
 from django.conf import settings
 import django.db.models.deletion
-import openedx.core.djangoapps.xmodule_django.models
+from opaque_keys.edx.django.models import CourseKeyField
 
 
 class Migration(migrations.Migration):
@@ -20,7 +20,7 @@ class Migration(migrations.Migration):
                 ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
                 ('change_date', models.DateTimeField(auto_now_add=True, verbose_name='Change date')),
                 ('enabled', models.BooleanField(default=False, verbose_name='Enabled')),
-                ('course_id', openedx.core.djangoapps.xmodule_django.models.CourseKeyField(max_length=255, db_index=True)),
+                ('course_id', CourseKeyField(max_length=255, db_index=True)),
                 ('changed_by', models.ForeignKey(on_delete=django.db.models.deletion.PROTECT, editable=False, to=settings.AUTH_USER_MODEL, null=True, verbose_name='Changed by')),
             ],
             options={

--- a/openedx/core/djangoapps/video_config/migrations/0002_coursevideotranscriptenabledflag_videotranscriptenabledflag.py
+++ b/openedx/core/djangoapps/video_config/migrations/0002_coursevideotranscriptenabledflag_videotranscriptenabledflag.py
@@ -4,7 +4,7 @@ from __future__ import unicode_literals
 from django.db import migrations, models
 from django.conf import settings
 import django.db.models.deletion
-import openedx.core.djangoapps.xmodule_django.models
+from opaque_keys.edx.django.models import CourseKeyField
 
 
 class Migration(migrations.Migration):
@@ -21,7 +21,7 @@ class Migration(migrations.Migration):
                 ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
                 ('change_date', models.DateTimeField(auto_now_add=True, verbose_name='Change date')),
                 ('enabled', models.BooleanField(default=False, verbose_name='Enabled')),
-                ('course_id', openedx.core.djangoapps.xmodule_django.models.CourseKeyField(max_length=255, db_index=True)),
+                ('course_id', CourseKeyField(max_length=255, db_index=True)),
                 ('changed_by', models.ForeignKey(on_delete=django.db.models.deletion.PROTECT, editable=False, to=settings.AUTH_USER_MODEL, null=True, verbose_name='Changed by')),
             ],
             options={

--- a/openedx/core/djangoapps/video_config/models.py
+++ b/openedx/core/djangoapps/video_config/models.py
@@ -3,8 +3,7 @@ Configuration models for Video XModule
 """
 from config_models.models import ConfigurationModel
 from django.db.models import BooleanField
-
-from openedx.core.djangoapps.xmodule_django.models import CourseKeyField
+from opaque_keys.edx.django.models import CourseKeyField
 
 
 class HLSPlaybackEnabledFlag(ConfigurationModel):

--- a/openedx/core/djangoapps/video_pipeline/migrations/0003_coursevideouploadsenabledbydefault_videouploadsenabledbydefault.py
+++ b/openedx/core/djangoapps/video_pipeline/migrations/0003_coursevideouploadsenabledbydefault_videouploadsenabledbydefault.py
@@ -4,7 +4,7 @@ from __future__ import unicode_literals
 from django.db import migrations, models
 from django.conf import settings
 import django.db.models.deletion
-import openedx.core.djangoapps.xmodule_django.models
+from opaque_keys.edx.django.models import CourseKeyField
 
 
 class Migration(migrations.Migration):
@@ -21,7 +21,7 @@ class Migration(migrations.Migration):
                 ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
                 ('change_date', models.DateTimeField(auto_now_add=True, verbose_name='Change date')),
                 ('enabled', models.BooleanField(default=False, verbose_name='Enabled')),
-                ('course_id', openedx.core.djangoapps.xmodule_django.models.CourseKeyField(max_length=255, db_index=True)),
+                ('course_id', CourseKeyField(max_length=255, db_index=True)),
                 ('changed_by', models.ForeignKey(on_delete=django.db.models.deletion.PROTECT, editable=False, to=settings.AUTH_USER_MODEL, null=True, verbose_name='Changed by')),
             ],
             options={

--- a/openedx/core/djangoapps/video_pipeline/models.py
+++ b/openedx/core/djangoapps/video_pipeline/models.py
@@ -5,8 +5,7 @@ from config_models.models import ConfigurationModel
 from django.contrib.auth import get_user_model
 from django.db import models
 from django.utils.translation import ugettext_lazy as _
-
-from openedx.core.djangoapps.xmodule_django.models import CourseKeyField
+from opaque_keys.edx.django.models import CourseKeyField
 
 
 class VideoPipelineIntegration(ConfigurationModel):

--- a/openedx/core/djangoapps/waffle_utils/migrations/0001_initial.py
+++ b/openedx/core/djangoapps/waffle_utils/migrations/0001_initial.py
@@ -4,8 +4,7 @@ from __future__ import unicode_literals
 import django.db.models.deletion
 from django.conf import settings
 from django.db import migrations, models
-
-import openedx.core.djangoapps.xmodule_django.models
+from opaque_keys.edx.django.models import CourseKeyField
 
 
 class Migration(migrations.Migration):
@@ -22,7 +21,7 @@ class Migration(migrations.Migration):
                 ('change_date', models.DateTimeField(auto_now_add=True, verbose_name='Change date')),
                 ('enabled', models.BooleanField(default=False, verbose_name='Enabled')),
                 ('waffle_flag', models.CharField(max_length=255, db_index=True)),
-                ('course_id', openedx.core.djangoapps.xmodule_django.models.CourseKeyField(max_length=255, db_index=True)),
+                ('course_id', CourseKeyField(max_length=255, db_index=True)),
                 ('override_choice', models.CharField(default=b'on', max_length=3, choices=[(b'on', 'Force On'), (b'off', 'Force Off')])),
                 ('changed_by', models.ForeignKey(on_delete=django.db.models.deletion.PROTECT, editable=False, to=settings.AUTH_USER_MODEL, null=True, verbose_name='Changed by')),
             ],

--- a/openedx/core/djangoapps/waffle_utils/models.py
+++ b/openedx/core/djangoapps/waffle_utils/models.py
@@ -4,10 +4,10 @@ Models for configuring waffle utils.
 from django.db.models import CharField
 from django.utils.translation import ugettext_lazy as _
 from model_utils import Choices
+from opaque_keys.edx.django.models import CourseKeyField
 from six import text_type
 
 from config_models.models import ConfigurationModel
-from openedx.core.djangoapps.xmodule_django.models import CourseKeyField
 from openedx.core.djangoapps.request_cache.middleware import request_cached
 
 

--- a/openedx/core/djangoapps/xmodule_django/models.py
+++ b/openedx/core/djangoapps/xmodule_django/models.py
@@ -4,11 +4,9 @@ Useful django models for implementing XBlock infrastructure in django.
 import logging
 import warnings
 
-from django.core.exceptions import ValidationError
 from django.db import models
-from django.db.models.lookups import IsNull
-from opaque_keys.edx.keys import BlockTypeKey, CourseKey, UsageKey
-from openedx.core.djangoapps.util.model_utils import CreatorMixin
+import opaque_keys.edx.django.models
+
 from xmodule.modulestore.django import modulestore
 
 log = logging.getLogger(__name__)
@@ -48,29 +46,7 @@ class NoneToEmptyQuerySet(models.query.QuerySet):
         return super(NoneToEmptyQuerySet, self)._filter_or_exclude(*args, **kwargs)
 
 
-def _strip_object(key):
-    """
-    Strips branch and version info if the given key supports those attributes.
-    """
-    if hasattr(key, 'version_agnostic') and hasattr(key, 'for_branch'):
-        return key.for_branch(None).version_agnostic()
-    else:
-        return key
-
-
-def _strip_value(value, lookup='exact'):
-    """
-    Helper function to remove the branch and version information from the given value,
-    which could be a single object or a list.
-    """
-    if lookup == 'in':
-        stripped_value = [_strip_object(el) for el in value]
-    else:
-        stripped_value = _strip_object(value)
-    return stripped_value
-
-
-class OpaqueKeyField(CreatorMixin, models.CharField):
+class OpaqueKeyField(opaque_keys.edx.django.models.OpaqueKeyField):
     """
     A django field for storing OpaqueKeys.
 
@@ -81,105 +57,33 @@ class OpaqueKeyField(CreatorMixin, models.CharField):
     Subclasses must specify a KEY_CLASS attribute, in which case the field will use :meth:`from_string`
     to parse the key string, and will return an instance of KEY_CLASS.
     """
-    description = "An OpaqueKey object, saved to the DB in the form of a string."
-
-    Empty = object()
-    KEY_CLASS = None
-
     def __init__(self, *args, **kwargs):
-        if self.KEY_CLASS is None:
-            raise ValueError('Must specify KEY_CLASS in OpaqueKeyField subclasses')
-
+        warnings.warn("openedx.core.djangoapps.xmodule_django.models.OpaqueKeyField is deprecated. "
+                      "Please use opaque_keys.edx.django.models.OpaqueKeyField instead.", stacklevel=2)
         super(OpaqueKeyField, self).__init__(*args, **kwargs)
 
-    def to_python(self, value):
-        if value is self.Empty or value is None:
-            return None
 
-        assert isinstance(value, (basestring, self.KEY_CLASS)), \
-            "%s is not an instance of basestring or %s" % (value, self.KEY_CLASS)
-        if value == '':
-            # handle empty string for models being created w/o fields populated
-            return None
-
-        if isinstance(value, basestring):
-            if value.endswith('\n'):
-                # An opaque key with a trailing newline has leaked into the DB.
-                # Log and strip the value.
-                log.warning(u'{}:{}:{}:to_python: Invalid key: {}. Removing trailing newline.'.format(
-                    self.model._meta.db_table,  # pylint: disable=protected-access
-                    self.name,
-                    self.KEY_CLASS.__name__,
-                    repr(value)
-                ))
-                value = value.rstrip()
-            return self.KEY_CLASS.from_string(value)
-        else:
-            return value
-
-    def get_prep_value(self, value):
-        if value is self.Empty or value is None:
-            return ''  # CharFields should use '' as their empty value, rather than None
-
-        assert isinstance(value, self.KEY_CLASS), "%s is not an instance of %s" % (value, self.KEY_CLASS)
-        serialized_key = unicode(_strip_value(value))
-        if serialized_key.endswith('\n'):
-            # An opaque key object serialized to a string with a trailing newline.
-            # Log the value - but do not modify it.
-            log.warning(u'{}:{}:{}:get_prep_value: Invalid key: {}.'.format(
-                self.model._meta.db_table,  # pylint: disable=protected-access
-                self.name,
-                self.KEY_CLASS.__name__,
-                repr(serialized_key)
-            ))
-        return serialized_key
-
-    def validate(self, value, model_instance):
-        """Validate Empty values, otherwise defer to the parent"""
-        # raise validation error if the use of this field says it can't be blank but it is
-        if not self.blank and value is self.Empty:
-            raise ValidationError(self.error_messages['blank'])
-        else:
-            return super(OpaqueKeyField, self).validate(value, model_instance)
-
-    def run_validators(self, value):
-        """Validate Empty values, otherwise defer to the parent"""
-        if value is self.Empty:
-            return
-
-        return super(OpaqueKeyField, self).run_validators(value)
-
-
-class OpaqueKeyFieldEmptyLookupIsNull(IsNull):
-    """
-    This overrides the default __isnull model filter to help enforce the special way
-    we handle null / empty values in OpaqueKeyFields.
-    """
-    def get_prep_lookup(self):
-        raise TypeError("Use this field's .Empty member rather than None or __isnull "
-                        "to query for missing objects of this type.")
-
-
-OpaqueKeyField.register_lookup(OpaqueKeyFieldEmptyLookupIsNull)
-
-
-class CourseKeyField(OpaqueKeyField):
+class CourseKeyField(opaque_keys.edx.django.models.CourseKeyField):
     """
     A django Field that stores a CourseKey object as a string.
     """
-    description = "A CourseKey object, saved to the DB in the form of a string"
-    KEY_CLASS = CourseKey
+    def __init__(self, *args, **kwargs):
+        warnings.warn("openedx.core.djangoapps.xmodule_django.models.LocationKeyField is deprecated. "
+                      "Please use opaque_keys.edx.django.models.UsageKeyField instead.", stacklevel=2)
+        super(CourseKeyField, self).__init__(*args, **kwargs)
 
 
-class UsageKeyField(OpaqueKeyField):
+class UsageKeyField(opaque_keys.edx.django.models.UsageKeyField):
     """
     A django Field that stores a UsageKey object as a string.
     """
-    description = "A Location object, saved to the DB in the form of a string"
-    KEY_CLASS = UsageKey
+    def __init__(self, *args, **kwargs):
+        warnings.warn("openedx.core.djangoapps.xmodule_django.models.UsageKeyField is deprecated. "
+                      "Please use opaque_keys.edx.django.models.UsageKeyField instead.", stacklevel=2)
+        super(UsageKeyField, self).__init__(*args, **kwargs)
 
 
-class UsageKeyWithRunField(UsageKeyField):
+class UsageKeyWithRunField(opaque_keys.edx.django.models.UsageKeyField):
     """
     Subclass of UsageKeyField that automatically fills in
     missing `run` values, for old Mongo courses.
@@ -191,18 +95,11 @@ class UsageKeyWithRunField(UsageKeyField):
         return value
 
 
-class LocationKeyField(UsageKeyField):
-    """
-    A django Field that stores a UsageKey object as a string.
-    """
-    def __init__(self, *args, **kwargs):
-        warnings.warn("LocationKeyField is deprecated. Please use UsageKeyField instead.", stacklevel=2)
-        super(LocationKeyField, self).__init__(*args, **kwargs)
-
-
-class BlockTypeKeyField(OpaqueKeyField):
+class BlockTypeKeyField(opaque_keys.edx.django.models.BlockTypeKeyField):
     """
     A django Field that stores a BlockTypeKey object as a string.
     """
-    description = "A BlockTypeKey object, saved to the DB in the form of a string."
-    KEY_CLASS = BlockTypeKey
+    def __init__(self, *args, **kwargs):
+        warnings.warn("openedx.core.djangoapps.xmodule_django.models.BlockTypeKeyField is deprecated. "
+                      "Please use opaque_keys.edx.django.models.BlockTypeKeyField instead.", stacklevel=2)
+        super(BlockTypeKeyField, self).__init__(*args, **kwargs)

--- a/requirements/edx/base_common.txt
+++ b/requirements/edx/base_common.txt
@@ -7,6 +7,6 @@
 # We plan to move edx-platform to use pip-tools soon and each target will have its
 # own requirements files built, which will remove the need for this file.
 wrapt==1.10.5
-edx-opaque-keys==0.4.1
+edx-opaque-keys==0.4.2
 requests==2.9.1
 mock==1.0.1


### PR DESCRIPTION
Handled deprecations involving `openedx.core.djangoapps.xmodule_django.models`:

* Upgraded `edx-opaque-keys` to the version which moved `OpaqueKeyField` and its subclasses there.
* Updated all imports of the fields which were moved to their new home.
* Updated all usage of the deprecated `LocationKeyField` to `UsageKeyField`.
* Left behind stubs of the moved classes with deprecation warnings, in case anything outside edx-platform and its core dependencies is still using them.

The field renames in migrations should be safe, as no information about the field class is persisted in the database and their implementations didn't change at all.