### PR TITLE
PLAT-1943 Fix more naive datetime warnings

### DIFF
--- a/common/djangoapps/course_modes/tests/test_models.py
+++ b/common/djangoapps/course_modes/tests/test_models.py
@@ -6,12 +6,12 @@ Replace this with more appropriate tests for your application.
 """
 
 import itertools
-from datetime import datetime, timedelta
+from datetime import timedelta
 
 import ddt
-import pytz
 from django.core.exceptions import ValidationError
 from django.test import TestCase, override_settings
+from django.utils.timezone import now
 from mock import patch
 from opaque_keys.edx.locator import CourseLocator
 
@@ -31,7 +31,7 @@ class CourseModeModelTest(TestCase):
     """
     NOW = 'now'
     DATES = {
-        NOW: datetime.now(),
+        NOW: now(),
         None: None,
     }
 
@@ -133,7 +133,7 @@ class CourseModeModelTest(TestCase):
 
     def test_modes_for_course_expired(self):
         expired_mode, _status = self.create_mode('verified', 'Verified Certificate', 10)
-        expired_mode.expiration_datetime = datetime.now(pytz.UTC) + timedelta(days=-1)
+        expired_mode.expiration_datetime = now() + timedelta(days=-1)
         expired_mode.save()
         modes = CourseMode.modes_for_course(self.course_key)
         self.assertEqual([CourseMode.DEFAULT_MODE], modes)
@@ -143,7 +143,7 @@ class CourseModeModelTest(TestCase):
         modes = CourseMode.modes_for_course(self.course_key)
         self.assertEqual([mode1], modes)
 
-        expiration_datetime = datetime.now(pytz.UTC) + timedelta(days=1)
+        expiration_datetime = now() + timedelta(days=1)
         expired_mode.expiration_datetime = expiration_datetime
         expired_mode.save()
         expired_mode_value = Mode(
@@ -232,9 +232,9 @@ class CourseModeModelTest(TestCase):
         self.assertEqual(CourseMode.auto_enroll_mode(self.course_key, modes), result)
 
     def test_all_modes_for_courses(self):
-        now = datetime.now(pytz.UTC)
-        future = now + timedelta(days=1)
-        past = now - timedelta(days=1)
+        now_dt = now()
+        future = now_dt + timedelta(days=1)
+        past = now_dt - timedelta(days=1)
 
         # Unexpired, no expiration date
         CourseModeFactory.create(
@@ -430,20 +430,20 @@ class CourseModeModelTest(TestCase):
     def test_expiration_datetime_explicitly_set(self):
         """ Verify that setting the expiration_date property sets the explicit flag. """
         verified_mode, __ = self.create_mode('verified', 'Verified Certificate', 10)
-        now = datetime.now()
-        verified_mode.expiration_datetime = now
+        now_dt = now()
+        verified_mode.expiration_datetime = now_dt
 
         self.assertTrue(verified_mode.expiration_datetime_is_explicit)
-        self.assertEqual(verified_mode.expiration_datetime, now)
+        self.assertEqual(verified_mode.expiration_datetime, now_dt)
 
     def test_expiration_datetime_not_explicitly_set(self):
         """ Verify that setting the _expiration_date property does not set the explicit flag. """
         verified_mode, __ = self.create_mode('verified', 'Verified Certificate', 10)
-        now = datetime.now()
-        verified_mode._expiration_datetime = now  # pylint: disable=protected-access
+        now_dt = now()
+        verified_mode._expiration_datetime = now_dt  # pylint: disable=protected-access
 
         self.assertFalse(verified_mode.expiration_datetime_is_explicit)
-        self.assertEqual(verified_mode.expiration_datetime, now)
+        self.assertEqual(verified_mode.expiration_datetime, now_dt)
 
     def test_expiration_datetime_explicitly_set_to_none(self):
         """ Verify that setting the _expiration_date property does not set the explicit flag. """

--- a/lms/djangoapps/bulk_email/tests/test_models.py
+++ b/lms/djangoapps/bulk_email/tests/test_models.py
@@ -9,6 +9,7 @@ from django.test import TestCase
 from mock import Mock, patch
 from nose.plugins.attrib import attr
 from opaque_keys.edx.keys import CourseKey
+from pytz import UTC
 
 from bulk_email.models import (
     SEND_TO_COHORT,
@@ -74,8 +75,8 @@ class CourseEmailTest(ModuleStoreTestCase):
             CourseEmail.create(course_id, sender, to_option, subject, html_message)
 
     @ddt.data(
-        datetime.datetime(1999, 1, 1),
-        datetime.datetime(datetime.MAXYEAR, 1, 1),
+        datetime.datetime(1999, 1, 1, tzinfo=UTC),
+        datetime.datetime(datetime.MAXYEAR, 1, 1, tzinfo=UTC),
     )
     def test_track_target(self, expiration_datetime):
         """

--- a/openedx/features/course_experience/tests/views/helpers.py
+++ b/openedx/features/course_experience/tests/views/helpers.py
@@ -1,8 +1,9 @@
 """
 Test helpers for the course experience.
 """
+from datetime import timedelta
 
-import datetime
+from django.utils.timezone import now
 
 from course_modes.models import CourseMode
 
@@ -13,11 +14,11 @@ def add_course_mode(course, upgrade_deadline_expired=False):
     """
     Adds a course mode to the test course.
     """
-    upgrade_exp_date = datetime.datetime.now()
+    upgrade_exp_date = now()
     if upgrade_deadline_expired:
-        upgrade_exp_date = upgrade_exp_date - datetime.timedelta(days=21)
+        upgrade_exp_date = upgrade_exp_date - timedelta(days=21)
     else:
-        upgrade_exp_date = upgrade_exp_date + datetime.timedelta(days=21)
+        upgrade_exp_date = upgrade_exp_date + timedelta(days=21)
 
     CourseMode(
         course_id=course.id,

--- a/openedx/features/course_experience/tests/views/test_course_home.py
+++ b/openedx/features/course_experience/tests/views/test_course_home.py
@@ -10,6 +10,7 @@ from django.conf import settings
 from django.core.urlresolvers import reverse
 from django.http import QueryDict
 from django.utils.http import urlquote_plus
+from django.utils.timezone import now
 from pytz import UTC
 from waffle.models import Flag
 from waffle.testutils import override_flag
@@ -96,7 +97,7 @@ class CourseHomePageTestCase(SharedModuleStoreTestCase):
                     org='edX',
                     number='test',
                     display_name='Test Course',
-                    start=datetime.now(UTC) - timedelta(days=30),
+                    start=now() - timedelta(days=30),
                 )
                 with cls.store.bulk_operations(cls.course.id):
                     chapter = ItemFactory.create(
@@ -122,7 +123,7 @@ class CourseHomePageTestCase(SharedModuleStoreTestCase):
         """
         return CourseFactory.create(
             display_name='Test Future Course',
-            start=specific_date if specific_date else datetime.now(UTC) + timedelta(days=30),
+            start=specific_date if specific_date else now() + timedelta(days=30),
         )
 
 
@@ -487,9 +488,9 @@ class CourseHomeFragmentViewTests(ModuleStoreTestCase):
         super(CourseHomeFragmentViewTests, self).setUp()
         CommerceConfiguration.objects.create(checkout_on_ecommerce_service=True)
 
-        end = datetime.now(UTC) + timedelta(days=30)
+        end = now() + timedelta(days=30)
         self.course = CourseFactory(
-            start=datetime.now(UTC) - timedelta(days=30),
+            start=now() - timedelta(days=30),
             end=end,
         )
         self.url = course_home_url(self.course)
@@ -535,7 +536,7 @@ class CourseHomeFragmentViewTests(ModuleStoreTestCase):
         self.assert_upgrade_message_not_displayed()
 
     def test_no_upgrade_message_if_upgrade_deadline_passed(self):
-        self.verified_mode.expiration_datetime = datetime.now(UTC) - timedelta(days=20)
+        self.verified_mode.expiration_datetime = now() - timedelta(days=20)
         self.verified_mode.save()
         self.assert_upgrade_message_not_displayed()
 


### PR DESCRIPTION
This should fix a few dozen warnings in LMS shard 4, which has the highest remaining warnings count pre-Django 1.11.