### PR TITLE
Upgrade django-pipeline to 1.6.14, fix up settings and usages

### DIFF
--- a/cms/djangoapps/pipeline_js/views.py
+++ b/cms/djangoapps/pipeline_js/views.py
@@ -15,7 +15,7 @@ def get_xmodule_urls():
     """
     Returns a list of the URLs to hit to grab all the XModule JS
     """
-    pipeline_js_settings = settings.PIPELINE_JS["module-js"]
+    pipeline_js_settings = settings.PIPELINE["JAVASCRIPT"]["module-js"]
     if settings.DEBUG:
         paths = [path.replace(".coffee", ".js") for path in pipeline_js_settings["source_filenames"]]
     else:

--- a/cms/envs/acceptance.py
+++ b/cms/envs/acceptance.py
@@ -147,5 +147,5 @@ SECRET_KEY = uuid.uuid4().hex
 
 ############################### PIPELINE #######################################
 
-PIPELINE_ENABLED = False
+PIPELINE['PIPELINE_ENABLED'] = False
 REQUIRE_DEBUG = True

--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -142,6 +142,7 @@ from openedx.core.djangoapps.theming.helpers_dirs import (
 )
 from openedx.core.lib.license import LicenseMixin
 from openedx.core.lib.derived import derived, derived_collection_entry
+from openedx.core.lib.rooted_paths import rooted_glob
 from openedx.core.release import doc_version
 
 ############################ FEATURE CONFIGURATION #############################
@@ -660,33 +661,6 @@ COURSE_IMPORT_EXPORT_STORAGE = 'django.core.files.storage.FileSystemStorage'
 EMBARGO_SITE_REDIRECT_URL = None
 
 ############################### PIPELINE #######################################
-
-PIPELINE_ENABLED = True
-
-STATICFILES_STORAGE = 'openedx.core.storage.ProductionStorage'
-
-# List of finder classes that know how to find static files in various locations.
-# Note: the pipeline finder is included to be able to discover optimized files
-STATICFILES_FINDERS = [
-    'openedx.core.djangoapps.theming.finders.ThemeFilesFinder',
-    'django.contrib.staticfiles.finders.FileSystemFinder',
-    'django.contrib.staticfiles.finders.AppDirectoriesFinder',
-    'openedx.core.lib.xblock_pipeline.finder.XBlockPipelineFinder',
-    'pipeline.finders.PipelineFinder',
-]
-
-# Don't use compression by default
-PIPELINE_CSS_COMPRESSOR = None
-PIPELINE_JS_COMPRESSOR = 'pipeline.compressors.uglifyjs.UglifyJSCompressor'
-
-# Don't wrap JavaScript as there is code that depends upon updating the global namespace
-PIPELINE_DISABLE_WRAPPER = True
-
-# Specify the UglifyJS binary to use
-PIPELINE_UGLIFYJS_BINARY = 'node_modules/.bin/uglifyjs'
-
-from openedx.core.lib.rooted_paths import rooted_glob
-
 PIPELINE_CSS = {
     'style-vendor': {
         'source_filenames': [
@@ -801,12 +775,29 @@ PIPELINE_JS = {
     },
 }
 
-PIPELINE_COMPILERS = (
-    'pipeline.compilers.coffee.CoffeeScriptCompiler',
-)
+PIPELINE = {
+    'PIPELINE_ENABLED': True,
+    'STYLESHEETS': PIPELINE_CSS,
+    'CSS_COMPRESSOR': None,
+    'JAVASCRIPT': PIPELINE_JS,
+    'JS_COMPRESSOR': None,
+    'DISABLE_WRAPPER': True,
+    'UGLIFYJS_BINARY': 'node_modules/.bin/uglifyjs',
+    'YUI_BINARY': 'yui-compressor',
+    'COMPILERS': ['pipeline.compilers.coffee.CoffeeScriptCompiler'],
+}
 
-PIPELINE_CSS_COMPRESSOR = None
-PIPELINE_JS_COMPRESSOR = None
+STATICFILES_STORAGE = 'openedx.core.storage.ProductionStorage'
+
+# List of finder classes that know how to find static files in various locations.
+# Note: the pipeline finder is included to be able to discover optimized files
+STATICFILES_FINDERS = [
+    'openedx.core.djangoapps.theming.finders.ThemeFilesFinder',
+    'django.contrib.staticfiles.finders.FileSystemFinder',
+    'django.contrib.staticfiles.finders.AppDirectoriesFinder',
+    'openedx.core.lib.xblock_pipeline.finder.XBlockPipelineFinder',
+    'pipeline.finders.PipelineFinder',
+]
 
 STATICFILES_IGNORE_PATTERNS = (
     "*.py",
@@ -833,8 +824,6 @@ STATICFILES_IGNORE_PATTERNS = (
     "xmodule_js",
     "common_static",
 )
-
-PIPELINE_YUI_BINARY = 'yui-compressor'
 
 ################################# DJANGO-REQUIRE ###############################
 

--- a/cms/envs/devstack.py
+++ b/cms/envs/devstack.py
@@ -38,7 +38,7 @@ FEATURES['PREVIEW_LMS_BASE'] = "preview." + LMS_BASE
 ########################### PIPELINE #################################
 
 # Skip packaging and optimization in development
-PIPELINE_ENABLED = False
+PIPELINE['PIPELINE_ENABLED'] = False
 STATICFILES_STORAGE = 'openedx.core.storage.DevelopmentStorage'
 
 # Revert to the default set of finders as we don't want the production pipeline

--- a/common/djangoapps/pipeline_mako/__init__.py
+++ b/common/djangoapps/pipeline_mako/__init__.py
@@ -10,7 +10,7 @@ from django.contrib.staticfiles.storage import staticfiles_storage
 
 
 def compressed_css(package_name, raw=False):
-    package = settings.PIPELINE_CSS.get(package_name, {})
+    package = settings.STYLESHEETS.get(package_name, {})
     if package:
         package = {package_name: package}
     packager = Packager(css_packages=package, js_packages={})
@@ -44,7 +44,7 @@ def render_individual_css(package, paths, raw=False):
 
 
 def compressed_js(package_name):
-    package = settings.PIPELINE_JS.get(package_name, {})
+    package = settings.JAVASCRIPT.get(package_name, {})
     if package:
         package = {package_name: package}
     packager = Packager(css_packages={}, js_packages=package)

--- a/common/djangoapps/pipeline_mako/templates/static_content.html
+++ b/common/djangoapps/pipeline_mako/templates/static_content.html
@@ -49,24 +49,24 @@ except:
   <%
       rtl_group = '{}-rtl'.format(group)
 
-      if get_language_bidi() and rtl_group in settings.PIPELINE_CSS:
+      if get_language_bidi() and rtl_group in settings.PIPELINE['STYLESHEETS']:
         group = rtl_group
   %>
 
-  % if settings.PIPELINE_ENABLED:
+  % if settings.PIPELINE['PIPELINE_ENABLED']:
     ${compressed_css(group, raw=raw) | n, decode.utf8}
   % else:
-    % for filename in settings.PIPELINE_CSS[group]['source_filenames']:
+    % for filename in settings.PIPELINE['STYLESHEETS'][group]['source_filenames']:
       <link rel="stylesheet" href="${staticfiles_storage.url(filename.replace('.scss', '.css'))}${"?raw" if raw else ""}" type="text/css" media="all" / >
     % endfor
   %endif
 </%def>
 
 <%def name='js(group)'>
-  % if settings.PIPELINE_ENABLED:
+  % if settings.PIPELINE['PIPELINE_ENABLED']:
     ${compressed_js(group) | n, decode.utf8}
   % else:
-    % for filename in settings.PIPELINE_JS[group]['source_filenames']:
+    % for filename in settings.PIPELINE['JAVASCRIPT'][group]['source_filenames']:
       <script type="text/javascript" src="${staticfiles_storage.url(filename.replace('.coffee', '.js'))}"></script>
     % endfor
   %endif

--- a/common/djangoapps/pipeline_mako/tests/test_render.py
+++ b/common/djangoapps/pipeline_mako/tests/test_render.py
@@ -1,5 +1,6 @@
 """ Tests for rendering functions in the mako pipeline. """
 
+from copy import copy
 from unittest import skipUnless
 
 import ddt
@@ -96,6 +97,8 @@ class PipelineRenderTest(TestCase):
             self.assertIn(u'lms-base-application.js', js_include)
 
         # Verify that multiple JS files are rendered with the pipeline disabled
-        with self.settings(PIPELINE_ENABLED=False):
+        tmp_pipeline = copy(settings.PIPELINE)
+        tmp_pipeline['PIPELINE_ENABLED'] = False
+        with self.settings(PIPELINE=tmp_pipeline):
             js_include = compressed_js('base_application')
             self.assertIn(u'/static/js/src/logger.js', js_include)

--- a/common/djangoapps/pipeline_mako/tests/test_render.py
+++ b/common/djangoapps/pipeline_mako/tests/test_render.py
@@ -76,7 +76,9 @@ class PipelineRenderTest(TestCase):
         Verify the behavior of compressed_css, with the pipeline
         both enabled and disabled.
         """
-        with self.settings(PIPELINE_ENABLED=pipeline_enabled):
+        tmp_pipeline = copy(settings.PIPELINE)
+        tmp_pipeline['PIPELINE_ENABLED'] = pipeline_enabled
+        with self.settings(PIPELINE=tmp_pipeline):
             # Verify the default behavior
             css_include = compressed_css('style-main-v1')
             self.assertIn(u'lms-main-v1.css', css_include)
@@ -92,12 +94,13 @@ class PipelineRenderTest(TestCase):
         both enabled and disabled.
         """
         # Verify that a single JS file is rendered with the pipeline enabled
-        with self.settings(PIPELINE_ENABLED=True):
+        tmp_pipeline = copy(settings.PIPELINE)
+        tmp_pipeline['PIPELINE_ENABLED'] = True
+        with self.settings(PIPELINE=tmp_pipeline):
             js_include = compressed_js('base_application')
             self.assertIn(u'lms-base-application.js', js_include)
 
         # Verify that multiple JS files are rendered with the pipeline disabled
-        tmp_pipeline = copy(settings.PIPELINE)
         tmp_pipeline['PIPELINE_ENABLED'] = False
         with self.settings(PIPELINE=tmp_pipeline):
             js_include = compressed_js('base_application')

--- a/lms/djangoapps/branding/views.py
+++ b/lms/djangoapps/branding/views.py
@@ -114,7 +114,7 @@ def _footer_css_urls(request, package_name):
     # to identify the CSS file name(s) to include in the footer.
     # We then construct an absolute URI so that external sites (such as the marketing site)
     # can locate the assets.
-    package = settings.PIPELINE_CSS.get(package_name, {})
+    package = settings.PIPELINE['STYLESHEETS'].get(package_name, {})
     paths = [package['output_filename']] if not settings.DEBUG else package['source_filenames']
     return [
         _footer_static_url(request, path)

--- a/lms/envs/acceptance.py
+++ b/lms/envs/acceptance.py
@@ -204,8 +204,7 @@ import uuid
 SECRET_KEY = uuid.uuid4().hex
 
 ############################### PIPELINE #######################################
-
-PIPELINE_ENABLED = False
+PIPELINE['PIPELINE_ENABLED'] = False
 
 # We want to make sure that any new migrations are run
 # see https://groups.google.com/forum/#!msg/django-developers/PWPj3etj3-U/kCl6pMsQYYoJ

--- a/lms/envs/bok_choy.py
+++ b/lms/envs/bok_choy.py
@@ -69,7 +69,7 @@ MEDIA_ROOT = TEST_ROOT / "uploads"
 WEBPACK_LOADER['DEFAULT']['STATS_FILE'] = TEST_ROOT / "staticfiles" / "lms" / "webpack-stats.json"
 
 # Don't use compression during tests
-PIPELINE_JS_COMPRESSOR = None
+PIPELINE['JS_COMPRESSOR'] = None
 
 ################################# CELERY ######################################
 

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -42,6 +42,7 @@ from openedx.core.djangoapps.theming.helpers_dirs import (
     get_theme_base_dirs_from_settings
 )
 from openedx.core.lib.derived import derived, derived_collection_entry
+from openedx.core.lib.rooted_paths import rooted_glob
 from openedx.core.release import doc_version
 from xmodule.modulestore.modulestore_settings import update_module_store_settings
 from xmodule.modulestore.edit_info import EditInfoMixin
@@ -1351,32 +1352,6 @@ X_FRAME_OPTIONS = 'ALLOW'
 P3P_HEADER = 'CP="Open EdX does not have a P3P policy."'
 
 ############################### PIPELINE #######################################
-
-PIPELINE_ENABLED = True
-
-STATICFILES_STORAGE = 'openedx.core.storage.ProductionStorage'
-
-# List of finder classes that know how to find static files in various locations.
-# Note: the pipeline finder is included to be able to discover optimized files
-STATICFILES_FINDERS = [
-    'openedx.core.djangoapps.theming.finders.ThemeFilesFinder',
-    'django.contrib.staticfiles.finders.FileSystemFinder',
-    'django.contrib.staticfiles.finders.AppDirectoriesFinder',
-    'openedx.core.lib.xblock_pipeline.finder.XBlockPipelineFinder',
-    'pipeline.finders.PipelineFinder',
-]
-
-PIPELINE_CSS_COMPRESSOR = None
-PIPELINE_JS_COMPRESSOR = 'pipeline.compressors.uglifyjs.UglifyJSCompressor'
-
-# Don't wrap JavaScript as there is code that depends upon updating the global namespace
-PIPELINE_DISABLE_WRAPPER = True
-
-# Specify the UglifyJS binary to use
-PIPELINE_UGLIFYJS_BINARY = 'node_modules/.bin/uglifyjs'
-
-from openedx.core.lib.rooted_paths import rooted_glob
-
 courseware_js = (
     [
         'coffee/src/' + pth + '.js'
@@ -1719,7 +1694,6 @@ PIPELINE_CSS = {
     },
 }
 
-
 separately_bundled_js = set(courseware_js + discussion_js + notes_js + instructor_dash_js)
 common_js = sorted(set(rooted_glob(COMMON_ROOT / 'static', 'coffee/src/**/*.js')) - separately_bundled_js)
 xblock_runtime_js = [
@@ -1820,6 +1794,27 @@ PIPELINE_JS = {
     }
 }
 
+PIPELINE = {
+    'PIPELINE_ENABLED': True,
+    'STYLESHEETS': PIPELINE_CSS,
+    'CSS_COMPRESSOR': None,
+    'JAVASCRIPT': PIPELINE_JS,
+    'JS_COMPRESSOR': 'pipeline.compressors.uglifyjs.UglifyJSCompressor',
+    'DISABLE_WRAPPER': True,
+    'UGLIFYJS_BINARY': 'node_modules/.bin/uglifyjs',
+}
+
+STATICFILES_STORAGE = 'openedx.core.storage.ProductionStorage'
+
+# List of finder classes that know how to find static files in various locations.
+# Note: the pipeline finder is included to be able to discover optimized files
+STATICFILES_FINDERS = [
+    'openedx.core.djangoapps.theming.finders.ThemeFilesFinder',
+    'django.contrib.staticfiles.finders.FileSystemFinder',
+    'django.contrib.staticfiles.finders.AppDirectoriesFinder',
+    'openedx.core.lib.xblock_pipeline.finder.XBlockPipelineFinder',
+    'pipeline.finders.PipelineFinder',
+]
 
 STATICFILES_IGNORE_PATTERNS = (
     "*.py",
@@ -1845,7 +1840,6 @@ STATICFILES_IGNORE_PATTERNS = (
     # Symlinks used by js-test-tool
     "xmodule_js",
 )
-
 
 ################################# DJANGO-REQUIRE ###############################
 

--- a/lms/envs/devstack.py
+++ b/lms/envs/devstack.py
@@ -93,8 +93,8 @@ def should_show_debug_toolbar(request):
         return False
     return True
 
-########################### PIPELINE #################################
 
+########################### PIPELINE #################################
 STATICFILES_STORAGE = 'openedx.core.storage.DevelopmentStorage'
 
 # Revert to the default set of finders as we don't want the production pipeline
@@ -104,19 +104,12 @@ STATICFILES_FINDERS = [
     'django.contrib.staticfiles.finders.AppDirectoriesFinder',
 ]
 
-
-PIPELINE_ENABLED = False
-# Disable JavaScript compression in development
-PIPELINE_JS_COMPRESSOR = None
-PIPELINE_SASS_ARGUMENTS = '--debug-info'
-
-PIPELINE['PIPELINE_ENABLED'] = PIPELINE_ENABLED
-PIPELINE['JS_COMPRESSOR'] = PIPELINE_JS_COMPRESSOR
-PIPELINE['SASS_ARGUMENTS'] = PIPELINE_SASS_ARGUMENTS
+PIPELINE['PIPELINE_ENABLED'] = False
+PIPELINE['JS_COMPRESSOR'] = None
+PIPELINE['SASS_ARGUMENTS'] = '--debug-info'
 
 # Whether to run django-require in debug mode.
 REQUIRE_DEBUG = DEBUG
-
 
 # Load development webpack donfiguration
 WEBPACK_CONFIG_PATH = 'webpack.dev.config.js'

--- a/lms/envs/devstack.py
+++ b/lms/envs/devstack.py
@@ -95,7 +95,6 @@ def should_show_debug_toolbar(request):
 
 ########################### PIPELINE #################################
 
-PIPELINE_ENABLED = False
 STATICFILES_STORAGE = 'openedx.core.storage.DevelopmentStorage'
 
 # Revert to the default set of finders as we don't want the production pipeline
@@ -105,13 +104,19 @@ STATICFILES_FINDERS = [
     'django.contrib.staticfiles.finders.AppDirectoriesFinder',
 ]
 
+
+PIPELINE_ENABLED = False
 # Disable JavaScript compression in development
 PIPELINE_JS_COMPRESSOR = None
+PIPELINE_SASS_ARGUMENTS = '--debug-info'
+
+PIPELINE['PIPELINE_ENABLED'] = PIPELINE_ENABLED
+PIPELINE['JS_COMPRESSOR'] = PIPELINE_JS_COMPRESSOR
+PIPELINE['SASS_ARGUMENTS'] = PIPELINE_SASS_ARGUMENTS
 
 # Whether to run django-require in debug mode.
 REQUIRE_DEBUG = DEBUG
 
-PIPELINE_SASS_ARGUMENTS = '--debug-info'
 
 # Load development webpack donfiguration
 WEBPACK_CONFIG_PATH = 'webpack.dev.config.js'

--- a/lms/envs/test.py
+++ b/lms/envs/test.py
@@ -150,10 +150,7 @@ STATICFILES_DIRS += [
 STATICFILES_STORAGE = 'pipeline.storage.NonPackagingPipelineStorage'
 
 # Don't use compression during tests
-PIPELINE_JS_COMPRESSOR = None
-
-PIPELINE['JS_COMPRESSOR'] = PIPELINE_JS_COMPRESSOR
-
+PIPELINE['JS_COMPRESSOR'] = None
 
 update_module_store_settings(
     MODULESTORE,

--- a/lms/envs/test.py
+++ b/lms/envs/test.py
@@ -152,6 +152,9 @@ STATICFILES_STORAGE = 'pipeline.storage.NonPackagingPipelineStorage'
 # Don't use compression during tests
 PIPELINE_JS_COMPRESSOR = None
 
+PIPELINE['JS_COMPRESSOR'] = PIPELINE_JS_COMPRESSOR
+
+
 update_module_store_settings(
     MODULESTORE,
     module_store_options={

--- a/openedx/core/djangoapps/plugin_api/views.py
+++ b/openedx/core/djangoapps/plugin_api/views.py
@@ -27,10 +27,10 @@ class EdxFragmentView(FragmentView):
 
         Respects `PIPELINE_ENABLED` setting.
         """
-        if settings.PIPELINE_ENABLED:
-            return [settings.PIPELINE_CSS[group]['output_filename']]
+        if settings.PIPELINE['PIPELINE_ENABLED']:
+            return [settings.PIPELINE['STYLESHEETS'][group]['output_filename']]
         else:
-            return settings.PIPELINE_CSS[group]['source_filenames']
+            return settings.PIPELINE['STYLESHEETS'][group]['source_filenames']
 
     @staticmethod
     def get_js_dependencies(group):
@@ -39,10 +39,10 @@ class EdxFragmentView(FragmentView):
 
         Respects `PIPELINE_ENABLED` setting.
         """
-        if settings.PIPELINE_ENABLED:
-            return [settings.PIPELINE_JS[group]['output_filename']]
+        if settings.PIPELINE['PIPELINE_ENABLED']:
+            return [settings.PIPELINE['JAVASCRIPT'][group]['output_filename']]
         else:
-            return settings.PIPELINE_JS[group]['source_filenames']
+            return settings.PIPELINE['JAVASCRIPT'][group]['source_filenames']
 
     def vendor_js_dependencies(self):
         """

--- a/openedx/core/djangoapps/theming/storage.py
+++ b/openedx/core/djangoapps/theming/storage.py
@@ -376,7 +376,7 @@ class ThemePipelineMixin(PipelineMixin):
         themes = get_themes()
 
         for theme in themes:
-            css_packages = self.get_themed_packages(theme.theme_dir_name, settings.PIPELINE_CSS)
+            css_packages = self.get_themed_packages(theme.theme_dir_name, settings.PIPELINE['STYLESHEETS'])
 
             from pipeline.packager import Packager
             packager = Packager(storage=self, css_packages=css_packages)

--- a/openedx/core/lib/tests/test_xblock_utils.py
+++ b/openedx/core/lib/tests/test_xblock_utils.py
@@ -3,9 +3,11 @@ Tests for xblock_utils.py
 """
 from __future__ import absolute_import, unicode_literals
 
+from copy import copy
 import uuid
 
 import ddt
+from django.conf import settings
 from django.test.client import RequestFactory
 from nose.plugins.attrib import attr
 from web_fragments.fragment import Fragment
@@ -194,7 +196,11 @@ class TestXblockUtils(SharedModuleStoreTestCase):
                 'output_filename': "combined.css"
             }
         }
-        with self.settings(PIPELINE_ENABLED=pipeline_enabled, PIPELINE_CSS=pipeline_css):
+
+        tmp_pipeline = copy(settings.PIPELINE)
+        tmp_pipeline['PIPELINE_ENABLED'] = pipeline_enabled
+        tmp_pipeline['STYLESHEETS'] = pipeline_css
+        with self.settings(PIPELINE=tmp_pipeline):
             css_dependencies = get_css_dependencies("style-group")
             self.assertEqual(css_dependencies, expected_css_dependencies)
 
@@ -213,6 +219,10 @@ class TestXblockUtils(SharedModuleStoreTestCase):
                 'output_filename': "combined.js"
             }
         }
-        with self.settings(PIPELINE_ENABLED=pipeline_enabled, PIPELINE_JS=pipeline_js):
+
+        tmp_pipeline = copy(settings.PIPELINE)
+        tmp_pipeline['PIPELINE_ENABLED'] = pipeline_enabled
+        tmp_pipeline['JAVASCRIPT'] = pipeline_js
+        with self.settings(PIPELINE=tmp_pipeline):
             js_dependencies = get_js_dependencies("js-group")
             self.assertEqual(js_dependencies, expected_js_dependencies)

--- a/openedx/core/lib/xblock_builtin/__init__.py
+++ b/openedx/core/lib/xblock_builtin/__init__.py
@@ -13,10 +13,10 @@ def get_css_dependencies(group):
 
     Respects `PIPELINE_ENABLED` setting.
     """
-    if settings.PIPELINE_ENABLED:
-        return [settings.PIPELINE_CSS[group]['output_filename']]
+    if settings.PIPELINE['PIPELINE_ENABLED']:
+        return [settings.PIPELINE['STYLESHEETS'][group]['output_filename']]
     else:
-        return settings.PIPELINE_CSS[group]['source_filenames']
+        return settings.PIPELINE['STYLESHEETS'][group]['source_filenames']
 
 
 def get_js_dependencies(group):
@@ -25,7 +25,7 @@ def get_js_dependencies(group):
 
     Respects `PIPELINE_ENABLED` setting.
     """
-    if settings.PIPELINE_ENABLED:
-        return [settings.PIPELINE_JS[group]['output_filename']]
+    if settings.PIPELINE['PIPELINE_ENABLED']:
+        return [settings.PIPELINE['JAVASCRIPT'][group]['output_filename']]
     else:
-        return settings.PIPELINE_JS[group]['source_filenames']
+        return settings.PIPELINE['JAVASCRIPT'][group]['source_filenames']

--- a/openedx/core/lib/xblock_utils/__init__.py
+++ b/openedx/core/lib/xblock_utils/__init__.py
@@ -463,7 +463,7 @@ def xblock_local_resource_url(block, uri):
     as a static asset which will use a CDN in production.
     """
     xblock_class = getattr(block.__class__, 'unmixed_class', block.__class__)
-    if settings.PIPELINE_ENABLED or not settings.REQUIRE_DEBUG:
+    if settings.PIPELINE['PIPELINE_ENABLED'] or not settings.REQUIRE_DEBUG:
         return staticfiles_storage.url('xblock/resources/{package_name}/{path}'.format(
             package_name=xblock_resource_pkg(xblock_class),
             path=uri

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -28,6 +28,7 @@ django-ipware==1.1.0
 django-model-utils==3.0.0
 django-mptt>=0.8.6,<0.9
 django-oauth-toolkit==0.12.0
+django-pipeline==1.6.14
 django-pyfs==2.0
 django-ratelimit==1.1.0
 django-sekizai>=0.10

--- a/requirements/edx/github.txt
+++ b/requirements/edx/github.txt
@@ -55,7 +55,6 @@
 # Python libraries to install directly from github
 
 # Third-party:
-git+https://github.com/jazzband/django-pipeline.git@d068a019169c9de5ee20ece041a6dea236422852#egg=django-pipeline==1.5.3
 -e git+https://github.com/edx/django-wiki.git@v0.0.17#egg=django-wiki
 git+https://github.com/edx/django-openid-auth.git@0.14#egg=django-openid-auth==0.14
 git+https://github.com/edx/MongoDBProxy.git@25b99097615bda06bd7cdfe5669ed80dc2a7fed0#egg=MongoDBProxy==0.1.0


### PR DESCRIPTION
This work brings our use of django-pipeline up to current and removes a github PyPI dependency. It looks like the dependency only existed because the 1.5.3 package had not yet been released to PyPI at the time of development.