### PR TITLE
Upgrade SFE, use built files, and allow development via SFE docker container

### DIFF
--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -1363,6 +1363,8 @@ XBLOCK_SETTINGS = {
     }
 }
 
+STUDIO_FRONTEND_CONTAINER_URL = None
+
 ################################ Settings for Credit Course Requirements ################################
 # Initial delay used for retrying tasks.
 # Additional retries use longer delays.

--- a/cms/templates/accessibility.html
+++ b/cms/templates/accessibility.html
@@ -24,7 +24,7 @@
 <div class="wrapper-content wrapper">
      <div class="content">
         <div class="content-primary">
-            <div id="root"></div>
+            <div id="root" class="SFE"></div>
             <%static:studiofrontend entry="accessibilityPolicy">
             {
               "lang": "${language_code | n, js_escaped_string}",

--- a/cms/templates/accessibility.html
+++ b/cms/templates/accessibility.html
@@ -12,13 +12,20 @@
 
 <%namespace name='static' file='static_content.html'/>
 
+<%block name="header_extras">
+    % if not settings.STUDIO_FRONTEND_CONTAINER_URL:
+        <link rel="stylesheet" type="text/css" href="${static.url('common/css/vendor/vendor.min.css')}" />
+        <link rel="stylesheet" type="text/css" href="${static.url('common/css/vendor/accessibilityPolicy.min.css')}" />
+    % endif
+</%block>
+
 <%block name="content">
 
 <div class="wrapper-content wrapper">
      <div class="content">
         <div class="content-primary">
             <div id="root"></div>
-            <%static:studiofrontend page="AccessibilityPage">
+            <%static:studiofrontend entry="accessibilityPolicy">
             {
               "lang": "${language_code | n, js_escaped_string}",
             }

--- a/cms/templates/asset_index.html
+++ b/cms/templates/asset_index.html
@@ -13,11 +13,18 @@
 <%namespace name='static' file='static_content.html'/>
 
 <%block name="header_extras">
-    % for template_name in ["asset"]:
-    <script type="text/template" id="${template_name}-tpl">
-        <%static:include path="js/${template_name}.underscore" />
-    </script>
-    % endfor
+    % if waffle_flag_enabled:
+        % if not settings.STUDIO_FRONTEND_CONTAINER_URL:
+            <link rel="stylesheet" type="text/css" href="${static.url('common/css/vendor/vendor.min.css')}" />
+            <link rel="stylesheet" type="text/css" href="${static.url('common/css/vendor/assets.min.css')}" />
+        % endif
+    % else:
+        % for template_name in ["asset"]:
+        <script type="text/template" id="${template_name}-tpl">
+            <%static:include path="js/${template_name}.underscore" />
+        </script>
+        % endfor
+    % endif
 </%block>
 
 % if not waffle_flag_enabled:

--- a/cms/templates/asset_index.html
+++ b/cms/templates/asset_index.html
@@ -27,18 +27,18 @@
     % endif
 </%block>
 
-% if not waffle_flag_enabled:
 <%block name="requirejs">
-    require(["js/factories/asset_index"], function (AssetIndexFactory) {
-        AssetIndexFactory({
-          assetCallbackUrl: "${asset_callback_url|n, js_escaped_string}",
-          uploadChunkSizeInMBs: ${chunk_size_in_mbs|n, dump_js_escaped_json},
-          maxFileSizeInMBs: ${max_file_size_in_mbs|n, dump_js_escaped_json},
-          maxFileSizeRedirectUrl: "${max_file_size_redirect_url|n, js_escaped_string}"
-        });
-    });
+    % if not waffle_flag_enabled:
+            require(["js/factories/asset_index"], function (AssetIndexFactory) {
+                AssetIndexFactory({
+                  assetCallbackUrl: "${asset_callback_url|n, js_escaped_string}",
+                  uploadChunkSizeInMBs: ${chunk_size_in_mbs|n, dump_js_escaped_json},
+                  maxFileSizeInMBs: ${max_file_size_in_mbs|n, dump_js_escaped_json},
+                  maxFileSizeRedirectUrl: "${max_file_size_redirect_url|n, js_escaped_string}"
+                });
+            });
+    % endif
 </%block>
-% endif
 
 <%block name="content">
 

--- a/cms/templates/asset_index.html
+++ b/cms/templates/asset_index.html
@@ -85,9 +85,6 @@
                     }
                 }
             </%static:studiofrontend>
-            <div class="ui-loading">
-                <p><span class="spin"><span class="icon fa fa-refresh" aria-hidden="true"></span></span> <span class="copy">${_("Loading")}</span></p>
-            </div>
         % else:
             <div class="content-primary">
                 <div class="wrapper-assets"></div>

--- a/cms/templates/asset_index.html
+++ b/cms/templates/asset_index.html
@@ -65,7 +65,7 @@
     <div class="content">
         <%static:optional_include_mako file="asset_index_content_header.html" />
         % if waffle_flag_enabled:
-            <%static:studiofrontend page="AssetsPage">
+            <%static:studiofrontend entry="assets">
                 {
                     "lang": "${language_code | n, js_escaped_string}",
                     "course": {

--- a/common/djangoapps/pipeline_mako/templates/static_content.html
+++ b/common/djangoapps/pipeline_mako/templates/static_content.html
@@ -89,7 +89,8 @@ engine = Engine(dirs=settings.DEFAULT_TEMPLATE_ENGINE['DIRS'])
 source, template_path = Loader(engine).load_template_source(path)
 %>${source | n, decode.utf8}</%def>
 
-<%def name="studiofrontend(page)">
+<%def name="studiofrontend(entry)">
+>>>>>>> 2b8c5a14e8... Fix integration of accessibility policy page
     <%doc>
         Loads a studio-frontend page, with the necessary context. Context is expected
         as a dictionary in the body of this tag.
@@ -107,11 +108,11 @@ source, template_path = Loader(engine).load_template_source(path)
     </script>
     <div id="root"></div>
     % if settings.STUDIO_FRONTEND_CONTAINER_URL:
-        <script type="text/javascript" src="${settings.STUDIO_FRONTEND_CONTAINER_URL}/assets.js"></script>
+        <script type="text/javascript" src="${settings.STUDIO_FRONTEND_CONTAINER_URL}/${entry}.js"></script>
     % else:
         <script type="text/javascript" src="${url('common/js/vendor/manifest.min.js')}"></script>
         <script type="text/javascript" src="${url('common/js/vendor/vendor.min.js')}"></script>
-        <script type="text/javascript" src="${url('common/js/vendor/assets.min.js')}"></script>
+        <script type="text/javascript" src="${url('common/js/vendor/{}.min.js'.format(entry))}"></script>
     % endif
 </%def>
 

--- a/common/djangoapps/pipeline_mako/templates/static_content.html
+++ b/common/djangoapps/pipeline_mako/templates/static_content.html
@@ -90,7 +90,6 @@ source, template_path = Loader(engine).load_template_source(path)
 %>${source | n, decode.utf8}</%def>
 
 <%def name="studiofrontend(entry)">
->>>>>>> 2b8c5a14e8... Fix integration of accessibility policy page
     <%doc>
         Loads a studio-frontend page, with the necessary context. Context is expected
         as a dictionary in the body of this tag.

--- a/common/djangoapps/pipeline_mako/templates/static_content.html
+++ b/common/djangoapps/pipeline_mako/templates/static_content.html
@@ -106,7 +106,13 @@ source, template_path = Loader(engine).load_template_source(path)
       var studioContext = ${ body | n, decode.utf8};
     </script>
     <div id="root"></div>
-    ${HTML(render_bundle(page))}
+    % if settings.STUDIO_FRONTEND_CONTAINER_URL:
+        <script type="text/javascript" src="${settings.STUDIO_FRONTEND_CONTAINER_URL}/assets.js"></script>
+    % else:
+        <script type="text/javascript" src="${url('common/js/vendor/manifest.min.js')}"></script>
+        <script type="text/javascript" src="${url('common/js/vendor/vendor.min.js')}"></script>
+        <script type="text/javascript" src="${url('common/js/vendor/assets.min.js')}"></script>
+    % endif
 </%def>
 
 <%def name="webpack(entry, extension=None, config='DEFAULT', attrs='')">

--- a/common/djangoapps/pipeline_mako/templates/static_content.html
+++ b/common/djangoapps/pipeline_mako/templates/static_content.html
@@ -106,7 +106,7 @@ source, template_path = Loader(engine).load_template_source(path)
     <script type="text/javascript" id='courseContext'>
       var studioContext = ${ body | n, decode.utf8};
     </script>
-    <div id="root"></div>
+    <div id="root" class="SFE"></div>
     % if settings.STUDIO_FRONTEND_CONTAINER_URL:
         <script type="text/javascript" src="${settings.STUDIO_FRONTEND_CONTAINER_URL}/${entry}.js"></script>
     % else:

--- a/lms/static/js/accessible_components/StatusBarAlert.jsx
+++ b/lms/static/js/accessible_components/StatusBarAlert.jsx
@@ -4,7 +4,7 @@ Wrapper for React/Paragon accessible status bar
 
 import React from 'react';
 import ReactDOM from 'react-dom';
-import StatusAlert from '@edx/paragon/src/StatusAlert/index.jsx';
+import { StatusAlert } from '@edx/paragon/static';
 
 export class StatusAlertRenderer {
   constructor(message, selector, afterselector) {

--- a/lms/templates/wiki/base.html
+++ b/lms/templates/wiki/base.html
@@ -13,6 +13,8 @@
   {% stylesheet 'style-course-vendor' %}
   {% stylesheet 'style-course' %}
 
+	<link rel="stylesheet" type="text/css" href="{% static 'paragon/static/paragon.min.css' %}" />
+
   <script type="text/javascript">
     function ajaxError(){}
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -62,9 +62,9 @@
       }
     },
     "@edx/studio-frontend": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/@edx/studio-frontend/-/studio-frontend-0.9.0.tgz",
-      "integrity": "sha512-fL6JoWQ/taysnFDqMnyJIUuqNTF1nPNojMIJsVyUdMFFhuo1fU5LjS9pOHsF1Zu2uCXoURrGPkCf1Yw+gzQYDA==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@edx/studio-frontend/-/studio-frontend-1.0.2.tgz",
+      "integrity": "sha512-GAZtUTxdd8w1/bpbIx7fYoa2HDtrrI6b85vTA21qWf30NaWLFMFRAOzFWwAAfjKV5UPJSsFhxZnZjB3S3tzPYQ==",
       "requires": {
         "@edx/edx-bootstrap": "0.4.3",
         "@edx/paragon": "2.0.1",
@@ -8291,7 +8291,7 @@
         "lodash": "4.17.4",
         "lodash-es": "4.17.4",
         "loose-envify": "1.3.1",
-        "symbol-observable": "1.1.0"
+        "symbol-observable": "1.2.0"
       }
     },
     "redux-devtools-extension": {
@@ -9987,9 +9987,9 @@
       }
     },
     "symbol-observable": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.1.0.tgz",
-      "integrity": "sha512-dQoid9tqQ+uotGhuTKEY11X4xhyYePVnqGSoSm3OGKh2E8LZ6RPULp1uXTctk33IeERlrRJYoVSBglsL05F5Uw=="
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.2.0.tgz",
+      "integrity": "sha512-e900nM8RRtGhlV36KGEU9k65K3mPb1WV70OdjfxlG2EAuM1noi/E/BaW/uMhL7bPEssK8QV57vN3esixjUvcXQ=="
     },
     "table": {
       "version": "4.0.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -62,9 +62,9 @@
       }
     },
     "@edx/studio-frontend": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@edx/studio-frontend/-/studio-frontend-1.0.2.tgz",
-      "integrity": "sha512-GAZtUTxdd8w1/bpbIx7fYoa2HDtrrI6b85vTA21qWf30NaWLFMFRAOzFWwAAfjKV5UPJSsFhxZnZjB3S3tzPYQ==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@edx/studio-frontend/-/studio-frontend-1.2.0.tgz",
+      "integrity": "sha512-y3XSsn665MvoD1QtyRFx+vkUW22iQajPawK1KXCtn4Qz/SFut6Yt52gHOftOtE7CREYOWwlUBS77TNQz+YqQLA==",
       "requires": {
         "@edx/edx-bootstrap": "0.4.3",
         "@edx/paragon": "2.0.1",
@@ -78,6 +78,8 @@
         "react": "16.2.0",
         "react-dom": "16.2.0",
         "react-dropzone": "4.2.7",
+        "react-intl": "2.4.0",
+        "react-intl-translations-manager": "5.0.1",
         "react-paginate": "5.0.0",
         "react-redux": "5.0.6",
         "redux": "3.7.2",
@@ -142,7 +144,7 @@
     "abbrev": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
-      "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q=="
+      "integrity": "sha1-+PLIh60Qv2f2NPAFtph/7TF5qsg="
     },
     "accepts": {
       "version": "1.3.3",
@@ -280,7 +282,7 @@
     "aproba": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
-      "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw=="
+      "integrity": "sha1-aALmJk79GMeQobDVF/DyYnvyyUo="
     },
     "are-we-there-yet": {
       "version": "1.1.4",
@@ -348,7 +350,7 @@
     "arr-flatten": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
-      "integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg=="
+      "integrity": "sha1-NgSLv/TntH4TZkQxbJlmnqWukfE="
     },
     "array-differ": {
       "version": "1.0.0",
@@ -432,7 +434,7 @@
     "asn1.js": {
       "version": "4.9.2",
       "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-4.9.2.tgz",
-      "integrity": "sha512-b/OsSjvWEo8Pi8H0zsDd2P6Uqo2TK2pH8gNLSJtNLM2Db0v2QaAZ0pBQJXVjAn4gBuugeVDr7s63ZogpUIwWDg==",
+      "integrity": "sha1-gRfvT37YfNj4kES1v/l6wkOhbJo=",
       "requires": {
         "bn.js": "4.11.8",
         "inherits": "2.0.3",
@@ -1228,7 +1230,7 @@
     "babylon": {
       "version": "6.18.0",
       "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.18.0.tgz",
-      "integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ=="
+      "integrity": "sha1-ry87iPpvXB5MY00aD46sT1WzleM="
     },
     "backbone": {
       "version": "1.3.3",
@@ -1273,7 +1275,7 @@
     "base64-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.2.1.tgz",
-      "integrity": "sha512-dwVUVIXsBZXwTuwnXI9RK8sBmgq09NDHzyR9SAph9eqk76gKK2JSQmZARC2zRC81JC2QTtxD0ARU5qTS25gIGw=="
+      "integrity": "sha1-qRlH2h9KUW6jjltOwOw3c2deCIY="
     },
     "base64id": {
       "version": "1.0.0",
@@ -1357,7 +1359,7 @@
     "bn.js": {
       "version": "4.11.8",
       "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.8.tgz",
-      "integrity": "sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA=="
+      "integrity": "sha1-LN4J617jQfSEdGuwMJsyU7GxRC8="
     },
     "body-parser": {
       "version": "1.18.2",
@@ -1491,7 +1493,7 @@
     "browserify-zlib": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.2.0.tgz",
-      "integrity": "sha512-Z942RysHXmJrhqk88FmKBVq/v5tqmSkDz7p54G/MGyjMnCFFnC79XWNbg+Vta8W6Wb2qtSZTSxIGkJrRpCFEiA==",
+      "integrity": "sha1-KGlFnZqjviRf6P4sofRuLn9U1z8=",
       "requires": {
         "pako": "1.0.6"
       }
@@ -1702,7 +1704,7 @@
     "cipher-base": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.4.tgz",
-      "integrity": "sha512-Kkht5ye6ZGmwv40uUDZztayT2ThLQGfnj/T71N/XzeZeo3nf8foyW7zGTsPYkEya3m5f3cAypH+qe7YOrM1U2Q==",
+      "integrity": "sha1-h2Dk7MJy9MNjUy+SbYdKriwTl94=",
       "requires": {
         "inherits": "2.0.3",
         "safe-buffer": "5.1.1"
@@ -1717,7 +1719,7 @@
     "clap": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/clap/-/clap-1.2.3.tgz",
-      "integrity": "sha512-4CoL/A3hf90V3VIEjeuhSvlGFEHKzOz+Wfc2IVZc+FaUgU0ZQafJTP49fvnULipOPcAfqhyI2duwQyns6xqjYA==",
+      "integrity": "sha1-TzZ0WzIAhJJVf0ZBLWbVDLmbzlE=",
       "requires": {
         "chalk": "1.1.3"
       }
@@ -1883,7 +1885,7 @@
     "color-convert": {
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.1.tgz",
-      "integrity": "sha512-mjGanIiwQJskCC18rPR6OmrZ6fm2Lc7PeGFYwCmy5J34wC6F1PzdGL6xeMfmgicfYcNLGuVFA3WzXtIDCQSZxQ==",
+      "integrity": "sha1-wSYRB66y8pTr/+ye2eytUppgl+0=",
       "requires": {
         "color-name": "1.1.3"
       }
@@ -2044,7 +2046,7 @@
     "content-type": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.4.tgz",
-      "integrity": "sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA==",
+      "integrity": "sha1-4TjMdeBAxyexlm/l5fjJruJW/js=",
       "dev": true
     },
     "convert-source-map": {
@@ -2079,7 +2081,7 @@
     "cosmiconfig": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-3.1.0.tgz",
-      "integrity": "sha512-zedsBhLSbPBms+kE7AH4vHg6JsKDz6epSv2/+5XHs8ILHlgDciSJfSWf8sX9aQ52Jb7KI7VswUTsLpR/G0cr2Q==",
+      "integrity": "sha1-ZAqUv5hH8yGABAPNJzr2BmXHM5c=",
       "dev": true,
       "requires": {
         "is-directory": "0.3.1",
@@ -2091,13 +2093,13 @@
         "esprima": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.0.tgz",
-          "integrity": "sha512-oftTcaMu/EGrEIu904mWteKIv8vMuOgGYo7EhVJJN00R/EED9DCua/xxHRdYnKtcECzVg7xOWhflvJMnqcFZjw==",
+          "integrity": "sha1-RJnt3NERDgshi6zy+n9/WfVcqAQ=",
           "dev": true
         },
         "js-yaml": {
           "version": "3.10.0",
           "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.10.0.tgz",
-          "integrity": "sha512-O2v52ffjLa9VeM43J4XocZE//WT9N0IiwDa3KSHH7Tu8CtH+1qM8SIZvnsTh6v+4yFy5KUY3BHUVwjpfAWsjIA==",
+          "integrity": "sha1-LnhEFka9RoLpY/IrbpKCPDCcYtw=",
           "dev": true,
           "requires": {
             "argparse": "1.0.9",
@@ -2178,7 +2180,7 @@
     "crypto-browserify": {
       "version": "3.12.0",
       "resolved": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.12.0.tgz",
-      "integrity": "sha512-fz4spIh+znjO2VjL+IdhEpRJ3YN6sMzITSBijk6FK2UvTqruSQW+/cCZTSNsMiZNvUeq0CqurF+dAbyiGOY6Wg==",
+      "integrity": "sha1-OWz58xN/A+S45TLFj2mCVOAPgOw=",
       "requires": {
         "browserify-cipher": "1.0.0",
         "browserify-sign": "4.0.4",
@@ -2363,7 +2365,7 @@
     "debug": {
       "version": "2.6.9",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "integrity": "sha1-XRKFFd8TT/Mn6QpMk/Tgd6U2NB8=",
       "requires": {
         "ms": "2.0.0"
       }
@@ -2482,7 +2484,7 @@
     "diff": {
       "version": "3.4.0",
       "resolved": "https://registry.npmjs.org/diff/-/diff-3.4.0.tgz",
-      "integrity": "sha512-QpVuMTEoJMF7cKzi6bvWhRulU1fZqZnvyVQgNhPaxxuTYwyjn/j1v9falseQ/uXWwPnO56RBfwtg4h/EQXmucA==",
+      "integrity": "sha1-sdhVB9rzlkgo3lSzfQ1zumfdpWw=",
       "dev": true
     },
     "diffie-hellman": {
@@ -2732,7 +2734,7 @@
     "emoji-regex": {
       "version": "6.5.1",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-6.5.1.tgz",
-      "integrity": "sha512-PAHp6TxrCy7MGMFidro8uikr+zlJJKJ/Q6mm2ExZ7HwkyR9lSVFfE3kt36qcwa24BQL7y0G9axycGjK1A/0uNQ==",
+      "integrity": "sha1-m66pKbFVVlwR6kHGYm6qZc75ksI=",
       "dev": true
     },
     "emojis-list": {
@@ -3176,7 +3178,7 @@
         "string-width": {
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+          "integrity": "sha1-q5Pyeo3BPSjKyBXEYhQ6bZASrp4=",
           "dev": true,
           "requires": {
             "is-fullwidth-code-point": "2.0.0",
@@ -3226,7 +3228,7 @@
     "eslint-config-airbnb-base": {
       "version": "11.3.2",
       "resolved": "https://registry.npmjs.org/eslint-config-airbnb-base/-/eslint-config-airbnb-base-11.3.2.tgz",
-      "integrity": "sha512-/fhjt/VqzBA2SRsx7ErDtv6Ayf+XLw9LIOqmpBuHFCVwyJo2EtzGWMB9fYRFBoWWQLxmNmCpenNiH0RxyeS41w==",
+      "integrity": "sha1-hwOxGr48iKx+wrdFt/31LgCuaAo=",
       "dev": true,
       "requires": {
         "eslint-restricted-globals": "0.1.1"
@@ -3374,7 +3376,7 @@
     "eslint-module-utils": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.1.1.tgz",
-      "integrity": "sha512-jDI/X5l/6D1rRD/3T43q8Qgbls2nq5km5KSqiwlyUbGo5+04fXhMKdCPhjwbqAa6HXWaMxj8Q4hQDIh7IadJQw==",
+      "integrity": "sha1-q67IJBd2E7ipWymWOeG2+s9HNEk=",
       "dev": true,
       "requires": {
         "debug": "2.6.9",
@@ -3390,7 +3392,7 @@
     "eslint-plugin-import": {
       "version": "2.8.0",
       "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.8.0.tgz",
-      "integrity": "sha512-Rf7dfKJxZ16QuTgVv1OYNxkZcsu/hULFnC+e+w0Gzi6jMC3guQoWQgxYxc54IDRinlb6/0v5z/PxxIKmVctN+g==",
+      "integrity": "sha1-+htu8x/LPFAcCYWcG4bx/FuYaJQ=",
       "dev": true,
       "requires": {
         "builtin-modules": "1.1.1",
@@ -3483,7 +3485,7 @@
     "eslint-plugin-jsx-a11y": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/eslint-plugin-jsx-a11y/-/eslint-plugin-jsx-a11y-5.1.1.tgz",
-      "integrity": "sha512-5I9SpoP7gT4wBFOtXT8/tXNPYohHBVfyVfO17vkbC7r9kEIxYJF12D3pKqhk8+xnk12rfxKClS3WCFpVckFTPQ==",
+      "integrity": "sha1-XJa7UYbKFOlNsQlf9Zs+K9lAabE=",
       "dev": true,
       "requires": {
         "aria-query": "0.7.0",
@@ -3527,7 +3529,7 @@
     "espree": {
       "version": "3.5.2",
       "resolved": "https://registry.npmjs.org/espree/-/espree-3.5.2.tgz",
-      "integrity": "sha512-sadKeYwaR/aJ3stC2CdvgXu1T16TdYN+qwCpcWbMnGJ8s0zNWemzrvb2GbD4OhmJ/fwpJjudThAlLobGbWZbCQ==",
+      "integrity": "sha1-dWrai5eenc/NswqtjRqTBKkF4co=",
       "dev": true,
       "requires": {
         "acorn": "5.3.0",
@@ -3593,7 +3595,7 @@
     "evp_bytestokey": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/evp_bytestokey/-/evp_bytestokey-1.0.3.tgz",
-      "integrity": "sha512-/f2Go4TognH/KvCISP7OUsHn85hT9nUkxxA9BEWxFn+Oj9o8ZNLm/40hdlgSLyuOimsrTKLUMEorQexp/aPQeA==",
+      "integrity": "sha1-f8vbGY3HGVlDLv4ThCaE4FJaywI=",
       "requires": {
         "md5.js": "1.3.4",
         "safe-buffer": "5.1.1"
@@ -3728,7 +3730,7 @@
         "async": {
           "version": "2.6.0",
           "resolved": "https://registry.npmjs.org/async/-/async-2.6.0.tgz",
-          "integrity": "sha512-xAfGg1/NTLBBKlHFmnd7PlmUW9KhVQIUuSrYem9xzFUZy13ScvtyGGejaae9iAVRiRq9+Cx7DPFaAAhCpyxyPw==",
+          "integrity": "sha1-YaKau2/MAm/qd+VtHG7FOnlZUfQ=",
           "requires": {
             "lodash": "4.17.4"
           }
@@ -4078,7 +4080,7 @@
     "function-bind": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
+      "integrity": "sha1-pWiZ0+o8m6uHS7l3O3xe3pL0iV0="
     },
     "gauge": {
       "version": "2.7.4",
@@ -4144,7 +4146,7 @@
     "glob": {
       "version": "7.1.2",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
-      "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+      "integrity": "sha1-wZyd+aAocC1nhhI4SmVSQExjbRU=",
       "requires": {
         "fs.realpath": "1.0.0",
         "inflight": "1.0.6",
@@ -4174,7 +4176,7 @@
     "globals": {
       "version": "9.18.0",
       "resolved": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz",
-      "integrity": "sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ=="
+      "integrity": "sha1-qjiWs+abSH8X4x7SFD1pqOMMLYo="
     },
     "globby": {
       "version": "7.1.1",
@@ -4463,7 +4465,7 @@
     "hosted-git-info": {
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.5.0.tgz",
-      "integrity": "sha512-pNgbURSuab90KbTqvRPsseaTxOJCZBD0a7t+haSN33piP9cCM4l0CqdzAif2hUqm716UovKB2ROmiabGAKVXyg=="
+      "integrity": "sha1-bWDjSzq7yDEwYsO3mO+NkBoHrzw="
     },
     "html-comment-regex": {
       "version": "1.1.1",
@@ -4588,7 +4590,7 @@
         "ansi-styles": {
           "version": "3.2.0",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
-          "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
+          "integrity": "sha1-wVm41b4PnlpvNG2rlPFs4CIWG4g=",
           "requires": {
             "color-convert": "1.9.1"
           }
@@ -4596,7 +4598,7 @@
         "chalk": {
           "version": "2.3.0",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.0.tgz",
-          "integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
+          "integrity": "sha1-tepI78nBeT3MybR2fJORTT8tUro=",
           "requires": {
             "ansi-styles": "3.2.0",
             "escape-string-regexp": "1.0.5",
@@ -4631,7 +4633,7 @@
         "source-map": {
           "version": "0.6.1",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+          "integrity": "sha1-dHIq8y6WFOnCh6jQu95IteLxomM="
         },
         "supports-color": {
           "version": "5.1.0",
@@ -4651,7 +4653,7 @@
     "ignore": {
       "version": "3.3.7",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.7.tgz",
-      "integrity": "sha512-YGG3ejvBNHRqu0559EOxxNFihD0AjpvHlC/pdGKd3X3ofe+CoJkYazwNJYTNebqpPKN+VVQbh4ZFn1DivMNuHA==",
+      "integrity": "sha1-YSKJv7PCIOGGpYEYYY1b6MG6sCE=",
       "dev": true
     },
     "imports-loader": {
@@ -4744,6 +4746,32 @@
       "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.1.0.tgz",
       "integrity": "sha1-ftGxQQxqDg94z5XTuEQMY/eLhhQ="
     },
+    "intl-format-cache": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/intl-format-cache/-/intl-format-cache-2.1.0.tgz",
+      "integrity": "sha1-BKNp/sv61tpgBbrh8UMzMy3PkxY="
+    },
+    "intl-messageformat": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/intl-messageformat/-/intl-messageformat-2.2.0.tgz",
+      "integrity": "sha1-NFvNRt5jC3aDMwwuUhd/9eq0hPw=",
+      "requires": {
+        "intl-messageformat-parser": "1.4.0"
+      }
+    },
+    "intl-messageformat-parser": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/intl-messageformat-parser/-/intl-messageformat-parser-1.4.0.tgz",
+      "integrity": "sha1-tD1FqXRoytvkQzHXS7Ho3qRPwHU="
+    },
+    "intl-relativeformat": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/intl-relativeformat/-/intl-relativeformat-2.1.0.tgz",
+      "integrity": "sha1-AQ8RBYAiUfQKxH0OPhogE0iiVd8=",
+      "requires": {
+        "intl-messageformat": "2.2.0"
+      }
+    },
     "invariant": {
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.2.tgz",
@@ -4822,7 +4850,7 @@
     "is-buffer": {
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
-      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
+      "integrity": "sha1-76ouqdqg16suoTqXsritUf776L4="
     },
     "is-builtin-module": {
       "version": "1.0.0",
@@ -4966,7 +4994,7 @@
     "is-plain-object": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
-      "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
+      "integrity": "sha1-LBY7P6+xtgbZ0Xko8FwqHDjgdnc=",
       "requires": {
         "isobject": "3.0.1"
       }
@@ -5335,7 +5363,7 @@
     "json-loader": {
       "version": "0.5.7",
       "resolved": "https://registry.npmjs.org/json-loader/-/json-loader-0.5.7.tgz",
-      "integrity": "sha512-QLPs8Dj7lnf3e3QYS1zkCo+4ZwqOiF9d/nZnYozTISxXWCfNs9yuky5rJw4/W34s7POaNlbZmQGaB5NiXCbP4w=="
+      "integrity": "sha1-3KFKcCNf+C8KyaOr62DTN6NlGF0="
     },
     "json-parse-better-errors": {
       "version": "1.0.1",
@@ -5702,9 +5730,9 @@
       "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4="
     },
     "lodash-es": {
-      "version": "4.17.4",
-      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.4.tgz",
-      "integrity": "sha1-3MHXVS4VCgZABzupyzHXDwMpUOc="
+      "version": "4.17.5",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.5.tgz",
+      "integrity": "sha512-Ez3ONp3TK9gX1HYKp6IhetcVybD+2F+Yp6GS9dfH8ue6EOCEzQtQEh4K0FYWBP9qLv+lzeQAYXw+3ySfxyZqkw=="
     },
     "lodash._basecopy": {
       "version": "3.0.1",
@@ -5896,7 +5924,7 @@
     "log-symbols": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-2.1.0.tgz",
-      "integrity": "sha512-zLeLrzMA1A2vRF1e/0Mo+LNINzi6jzBylHj5WqvQ/WK/5WCZt8si9SyN4p9llr/HRYvVR1AoXHRHl4WTHyQAzQ==",
+      "integrity": "sha1-81+mDieIMrU43E3dy7R4pF0+O+Y=",
       "dev": true,
       "requires": {
         "chalk": "2.3.0"
@@ -5905,7 +5933,7 @@
         "ansi-styles": {
           "version": "3.2.0",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
-          "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
+          "integrity": "sha1-wVm41b4PnlpvNG2rlPFs4CIWG4g=",
           "dev": true,
           "requires": {
             "color-convert": "1.9.1"
@@ -5914,7 +5942,7 @@
         "chalk": {
           "version": "2.3.0",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.0.tgz",
-          "integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
+          "integrity": "sha1-tepI78nBeT3MybR2fJORTT8tUro=",
           "dev": true,
           "requires": {
             "ansi-styles": "3.2.0",
@@ -6109,7 +6137,7 @@
         "readable-stream": {
           "version": "2.3.3",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
-          "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
+          "integrity": "sha1-No8lEtefnUb9/HE0mueHi7weuVw=",
           "requires": {
             "core-util-is": "1.0.2",
             "inherits": "2.0.3",
@@ -6123,7 +6151,7 @@
         "string_decoder": {
           "version": "1.0.3",
           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-          "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+          "integrity": "sha1-D8Z9fBQYJd6UKC3VNr7GubzoYKs=",
           "requires": {
             "safe-buffer": "5.1.1"
           }
@@ -6215,7 +6243,7 @@
     "minimatch": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "integrity": "sha1-UWbihkV/AzBgZL5Ul+jbsMPTIIM=",
       "requires": {
         "brace-expansion": "1.1.8"
       }
@@ -6323,7 +6351,7 @@
     "node-fetch": {
       "version": "1.7.3",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
-      "integrity": "sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==",
+      "integrity": "sha1-mA9vcthSEaU0fGsrwYxbhMPrR+8=",
       "requires": {
         "encoding": "0.1.12",
         "is-stream": "1.1.0"
@@ -6359,7 +6387,7 @@
     "node-libs-browser": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/node-libs-browser/-/node-libs-browser-2.1.0.tgz",
-      "integrity": "sha512-5AzFzdoIMb89hBGMZglEegffzgRg+ZFoUmisQ8HI4j1KDdpx13J0taNp2y9xPbur6W61gepGDDotGBVQ7mfUCg==",
+      "integrity": "sha1-X5QmPUBPbkR2fXJpAf/wVHjWAN8=",
       "requires": {
         "assert": "1.4.1",
         "browserify-zlib": "0.2.0",
@@ -6394,7 +6422,7 @@
         "readable-stream": {
           "version": "2.3.3",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
-          "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
+          "integrity": "sha1-No8lEtefnUb9/HE0mueHi7weuVw=",
           "requires": {
             "core-util-is": "1.0.2",
             "inherits": "2.0.3",
@@ -6408,7 +6436,7 @@
         "string_decoder": {
           "version": "1.0.3",
           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-          "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+          "integrity": "sha1-D8Z9fBQYJd6UKC3VNr7GubzoYKs=",
           "requires": {
             "safe-buffer": "5.1.1"
           }
@@ -6470,7 +6498,7 @@
     "normalize-package-data": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
-      "integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
+      "integrity": "sha1-EvlaMH1YNSB1oEkHuErIvpisAS8=",
       "requires": {
         "hosted-git-info": "2.5.0",
         "is-builtin-module": "1.0.0",
@@ -6744,7 +6772,7 @@
     "pako": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.6.tgz",
-      "integrity": "sha512-lQe48YPsMJAig+yngZ87Lus+NF+3mtu7DVOBu6b/gHO1YpKwIj5AWjZ/TOS7i46HD/UixzWb1zeWDZfGZ3iYcg=="
+      "integrity": "sha1-AQEhG6pwxLykoPY/Igbpe3368lg="
     },
     "parse-asn1": {
       "version": "5.1.0",
@@ -6876,7 +6904,7 @@
     "pbkdf2": {
       "version": "3.0.14",
       "resolved": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.0.14.tgz",
-      "integrity": "sha512-gjsZW9O34fm0R7PaLHRJmLLVfSoesxztjPjE9o6R+qtVJij90ltg1joIovN9GKrRW3t1PzhDDG3UMEMFfZ+1wA==",
+      "integrity": "sha1-o14TxkeZsGzhUyD0WcIw5o5zut4=",
       "requires": {
         "create-hash": "1.1.3",
         "create-hmac": "1.1.6",
@@ -7091,7 +7119,7 @@
     "postcss-less": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/postcss-less/-/postcss-less-1.1.3.tgz",
-      "integrity": "sha512-WS0wsQxRm+kmN8wEYAGZ3t4lnoNfoyx9EJZrhiPR1K0lMHR0UNWnz52Ya5QRXChHtY75Ef+kDc05FpnBujebgw==",
+      "integrity": "sha1-aTBSUnG/441Xk9M6wJwaVGuHu1E=",
       "dev": true,
       "requires": {
         "postcss": "5.2.18"
@@ -7268,7 +7296,7 @@
         "ansi-styles": {
           "version": "3.2.0",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
-          "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
+          "integrity": "sha1-wVm41b4PnlpvNG2rlPFs4CIWG4g=",
           "requires": {
             "color-convert": "1.9.1"
           }
@@ -7276,7 +7304,7 @@
         "chalk": {
           "version": "2.3.0",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.0.tgz",
-          "integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
+          "integrity": "sha1-tepI78nBeT3MybR2fJORTT8tUro=",
           "requires": {
             "ansi-styles": "3.2.0",
             "escape-string-regexp": "1.0.5",
@@ -7311,7 +7339,7 @@
         "source-map": {
           "version": "0.6.1",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+          "integrity": "sha1-dHIq8y6WFOnCh6jQu95IteLxomM="
         },
         "supports-color": {
           "version": "5.1.0",
@@ -7515,7 +7543,7 @@
     "postcss-reporter": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/postcss-reporter/-/postcss-reporter-5.0.0.tgz",
-      "integrity": "sha512-rBkDbaHAu5uywbCR2XE8a25tats3xSOsGNx6mppK6Q9kSFGKc/FyAzfci+fWM2l+K402p1D0pNcfDGxeje5IKg==",
+      "integrity": "sha1-oUF3/RNCgp0pFlPyeG79ZxEDMsM=",
       "dev": true,
       "requires": {
         "chalk": "2.3.0",
@@ -7527,7 +7555,7 @@
         "ansi-styles": {
           "version": "3.2.0",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
-          "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
+          "integrity": "sha1-wVm41b4PnlpvNG2rlPFs4CIWG4g=",
           "dev": true,
           "requires": {
             "color-convert": "1.9.1"
@@ -7536,7 +7564,7 @@
         "chalk": {
           "version": "2.3.0",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.0.tgz",
-          "integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
+          "integrity": "sha1-tepI78nBeT3MybR2fJORTT8tUro=",
           "dev": true,
           "requires": {
             "ansi-styles": "3.2.0",
@@ -7575,7 +7603,7 @@
         "source-map": {
           "version": "0.6.1",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "integrity": "sha1-dHIq8y6WFOnCh6jQu95IteLxomM=",
           "dev": true
         },
         "supports-color": {
@@ -7607,7 +7635,7 @@
         "ansi-styles": {
           "version": "3.2.0",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
-          "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
+          "integrity": "sha1-wVm41b4PnlpvNG2rlPFs4CIWG4g=",
           "dev": true,
           "requires": {
             "color-convert": "1.9.1"
@@ -7616,7 +7644,7 @@
         "chalk": {
           "version": "2.3.0",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.0.tgz",
-          "integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
+          "integrity": "sha1-tepI78nBeT3MybR2fJORTT8tUro=",
           "dev": true,
           "requires": {
             "ansi-styles": "3.2.0",
@@ -7655,7 +7683,7 @@
         "source-map": {
           "version": "0.6.1",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "integrity": "sha1-dHIq8y6WFOnCh6jQu95IteLxomM=",
           "dev": true
         },
         "supports-color": {
@@ -7756,7 +7784,7 @@
         "ansi-styles": {
           "version": "3.2.0",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
-          "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
+          "integrity": "sha1-wVm41b4PnlpvNG2rlPFs4CIWG4g=",
           "dev": true,
           "requires": {
             "color-convert": "1.9.1"
@@ -7765,7 +7793,7 @@
         "chalk": {
           "version": "2.3.0",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.0.tgz",
-          "integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
+          "integrity": "sha1-tepI78nBeT3MybR2fJORTT8tUro=",
           "dev": true,
           "requires": {
             "ansi-styles": "3.2.0",
@@ -7804,7 +7832,7 @@
         "source-map": {
           "version": "0.6.1",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "integrity": "sha1-dHIq8y6WFOnCh6jQu95IteLxomM=",
           "dev": true
         },
         "supports-color": {
@@ -7883,7 +7911,7 @@
     "private": {
       "version": "0.1.8",
       "resolved": "https://registry.npmjs.org/private/-/private-0.1.8.tgz",
-      "integrity": "sha512-VvivMrbvd2nKkiG38qjULzlc+4Vx4wm/whI9pQD35YrARNnhxeiRktSOhSukRLFNlzg6Br/cJPet5J/u19r/mg=="
+      "integrity": "sha1-I4Hts2ifelPWUxkAYPz4ItLzaP8="
     },
     "process": {
       "version": "0.11.10",
@@ -7904,7 +7932,7 @@
     "promise": {
       "version": "7.3.1",
       "resolved": "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
-      "integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==",
+      "integrity": "sha1-BktyYCsY+Q8pGSuLG8QY/9Hr078=",
       "requires": {
         "asap": "2.0.6"
       }
@@ -7984,7 +8012,7 @@
     "randomatic": {
       "version": "1.1.7",
       "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.7.tgz",
-      "integrity": "sha512-D5JUjPyJbaJDkuAazpVnSfVkLlpeO3wDlPROTMLGKG1zMFNFRgrciKo1ltz/AzNTkqE0HzDx655QOL51N06how==",
+      "integrity": "sha1-x6vpzIuHwLqodrGf3oP9RkeX44w=",
       "requires": {
         "is-number": "3.0.0",
         "kind-of": "4.0.0"
@@ -8110,6 +8138,61 @@
       "resolved": "https://registry.npmjs.org/react-element-proptypes/-/react-element-proptypes-1.0.0.tgz",
       "integrity": "sha1-ygpafBYk646CrQjqeIzfyWvBpRc="
     },
+    "react-intl": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/react-intl/-/react-intl-2.4.0.tgz",
+      "integrity": "sha1-ZsFNyd+ac7L7v71gIXJugKYT6xU=",
+      "requires": {
+        "intl-format-cache": "2.1.0",
+        "intl-messageformat": "2.2.0",
+        "intl-relativeformat": "2.1.0",
+        "invariant": "2.2.2"
+      }
+    },
+    "react-intl-translations-manager": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/react-intl-translations-manager/-/react-intl-translations-manager-5.0.1.tgz",
+      "integrity": "sha512-8W0m7LrcxB/K5xJa1yQDMnmfMpFGaV3tDBd2sMJCvdQUgJt5HjjkAwwuslCHOEVBguP9XwX0oABRPrBXfP3XhQ==",
+      "requires": {
+        "chalk": "2.3.0",
+        "glob": "7.1.2",
+        "json-stable-stringify": "1.0.1",
+        "mkdirp": "0.5.1"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
+          "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
+          "requires": {
+            "color-convert": "1.9.1"
+          }
+        },
+        "chalk": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.0.tgz",
+          "integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
+          "requires": {
+            "ansi-styles": "3.2.0",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "4.5.0"
+          }
+        },
+        "has-flag": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
+          "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE="
+        },
+        "supports-color": {
+          "version": "4.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
+          "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
+          "requires": {
+            "has-flag": "2.0.0"
+          }
+        }
+      }
+    },
     "react-paginate": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/react-paginate/-/react-paginate-5.0.0.tgz",
@@ -8133,7 +8216,7 @@
         "hoist-non-react-statics": "2.3.1",
         "invariant": "2.2.2",
         "lodash": "4.17.4",
-        "lodash-es": "4.17.4",
+        "lodash-es": "4.17.5",
         "loose-envify": "1.3.1",
         "prop-types": "15.6.0"
       }
@@ -8201,7 +8284,7 @@
         "readable-stream": {
           "version": "2.3.3",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
-          "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
+          "integrity": "sha1-No8lEtefnUb9/HE0mueHi7weuVw=",
           "requires": {
             "core-util-is": "1.0.2",
             "inherits": "2.0.3",
@@ -8215,7 +8298,7 @@
         "string_decoder": {
           "version": "1.0.3",
           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-          "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+          "integrity": "sha1-D8Z9fBQYJd6UKC3VNr7GubzoYKs=",
           "requires": {
             "safe-buffer": "5.1.1"
           }
@@ -8289,7 +8372,7 @@
       "integrity": "sha512-pNqnf9q1hI5HHZRBkj3bAngGZW/JMCmexDlOxw4XagXY2o1327nHH54LoTjiPJ0gizoqPDRqWyX/00g0hD6w+A==",
       "requires": {
         "lodash": "4.17.4",
-        "lodash-es": "4.17.4",
+        "lodash-es": "4.17.5",
         "loose-envify": "1.3.1",
         "symbol-observable": "1.2.0"
       }
@@ -8317,7 +8400,7 @@
     "regenerator-transform": {
       "version": "0.10.1",
       "resolved": "https://registry.npmjs.org/regenerator-transform/-/regenerator-transform-0.10.1.tgz",
-      "integrity": "sha512-PJepbvDbuK1xgIgnau7Y90cwaAmO/LCLMI2mPvaXq2heGMR3aWW5/BQvYrhJ8jgmQjXewXvBjzfqKcVOmhjZ6Q==",
+      "integrity": "sha1-HkmWg3Ix2ot/PPQRTXG1aRoGgN0=",
       "requires": {
         "babel-runtime": "6.26.0",
         "babel-types": "6.26.0",
@@ -8536,7 +8619,7 @@
     "resolve": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.5.0.tgz",
-      "integrity": "sha512-hgoSGrc3pjzAPHNBg+KnFcK2HwlHTs/YrAGUr6qgTVUZmXv1UEXXl0bZNBKMA9fud6lRYFdPGz0xXxycPzmmiw==",
+      "integrity": "sha1-HwmsznlsmnYlefMbLBzEw83fnzY=",
       "dev": true,
       "requires": {
         "path-parse": "1.0.5"
@@ -8586,7 +8669,7 @@
     "rtlcss": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/rtlcss/-/rtlcss-2.2.1.tgz",
-      "integrity": "sha512-JjQ5DlrmwiItAjlmhoxrJq5ihgZcE0wMFxt7S17bIrt4Lw0WwKKFk+viRhvodB/0falyG/5fiO043ZDh6/aqTw==",
+      "integrity": "sha1-+FN+QVUggWawXhiYAhMZNvzv0p4=",
       "requires": {
         "chalk": "2.3.0",
         "findup": "0.1.5",
@@ -8598,7 +8681,7 @@
         "ansi-styles": {
           "version": "3.2.0",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
-          "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
+          "integrity": "sha1-wVm41b4PnlpvNG2rlPFs4CIWG4g=",
           "requires": {
             "color-convert": "1.9.1"
           }
@@ -8606,7 +8689,7 @@
         "chalk": {
           "version": "2.3.0",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.0.tgz",
-          "integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
+          "integrity": "sha1-tepI78nBeT3MybR2fJORTT8tUro=",
           "requires": {
             "ansi-styles": "3.2.0",
             "escape-string-regexp": "1.0.5",
@@ -8641,7 +8724,7 @@
         "source-map": {
           "version": "0.6.1",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+          "integrity": "sha1-dHIq8y6WFOnCh6jQu95IteLxomM="
         },
         "supports-color": {
           "version": "4.5.0",
@@ -8671,7 +8754,7 @@
     "safe-buffer": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
-      "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg=="
+      "integrity": "sha1-iTMSr2myEj3vcfV4iQAWce6yyFM="
     },
     "samsam": {
       "version": "1.1.2",
@@ -8692,7 +8775,7 @@
     "sass-loader": {
       "version": "6.0.6",
       "resolved": "https://registry.npmjs.org/sass-loader/-/sass-loader-6.0.6.tgz",
-      "integrity": "sha512-c3/Zc+iW+qqDip6kXPYLEgsAu2lf4xz0EZDplB7EmSUMda12U1sGJPetH55B/j9eu0bTtKzKlNPWWyYC7wFNyQ==",
+      "integrity": "sha1-6dXmwfFV+qMqSybXqbcQfCJeQPk=",
       "requires": {
         "async": "2.6.0",
         "clone-deep": "0.3.0",
@@ -8704,7 +8787,7 @@
         "async": {
           "version": "2.6.0",
           "resolved": "https://registry.npmjs.org/async/-/async-2.6.0.tgz",
-          "integrity": "sha512-xAfGg1/NTLBBKlHFmnd7PlmUW9KhVQIUuSrYem9xzFUZy13ScvtyGGejaae9iAVRiRq9+Cx7DPFaAAhCpyxyPw==",
+          "integrity": "sha1-YaKau2/MAm/qd+VtHG7FOnlZUfQ=",
           "requires": {
             "lodash": "4.17.4"
           }
@@ -8906,7 +8989,7 @@
     "slice-ansi": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-1.0.0.tgz",
-      "integrity": "sha512-POqxBK6Lb3q6s047D/XsDVNPnF9Dl8JSaqe9h9lURl0OdNqy/ujDrOiIHtsqXMGbWWTIomRzAMaTyawAU//Reg==",
+      "integrity": "sha1-BE8aSdiEL/MHqta1Be0Xi9lQE00=",
       "dev": true,
       "requires": {
         "is-fullwidth-code-point": "2.0.0"
@@ -9080,7 +9163,7 @@
     "source-list-map": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/source-list-map/-/source-list-map-2.0.0.tgz",
-      "integrity": "sha512-I2UmuJSRr/T8jisiROLU3A3ltr+swpniSmNPI4Ml3ZCX6tVnDsuZzK7F2hl5jTqbZBWCEKlj5HRQiPExXLgE8A=="
+      "integrity": "sha1-qqR0A/eyRakvvJfqCPJQ1gh+0IU="
     },
     "source-map": {
       "version": "0.5.7",
@@ -9121,7 +9204,7 @@
     "specificity": {
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/specificity/-/specificity-0.3.2.tgz",
-      "integrity": "sha512-Nc/QN/A425Qog7j9aHmwOrlwX2e7pNI47ciwxwy4jOlvbbMHkNNJchit+FX+UjF3IAdiaaV5BKeWuDUnws6G1A==",
+      "integrity": "sha1-meZRHs7vD42bV5JJN6rCyxPRPEI=",
       "dev": true
     },
     "sprintf-js": {
@@ -9166,7 +9249,7 @@
     "statuses": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.4.0.tgz",
-      "integrity": "sha512-zhSCtt8v2NDrRlPQpCNtw/heZLtfUDqxBM1udqikb/Hbk52LK4nQSwr10u77iopCW5LsyHpuXS0GnEc48mLeew==",
+      "integrity": "sha1-u3PURtonlhBu/MG2AaJT1sRr0Ic=",
       "dev": true
     },
     "stdout-stream": {
@@ -9185,7 +9268,7 @@
         "readable-stream": {
           "version": "2.3.3",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
-          "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
+          "integrity": "sha1-No8lEtefnUb9/HE0mueHi7weuVw=",
           "requires": {
             "core-util-is": "1.0.2",
             "inherits": "2.0.3",
@@ -9199,7 +9282,7 @@
         "string_decoder": {
           "version": "1.0.3",
           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-          "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+          "integrity": "sha1-D8Z9fBQYJd6UKC3VNr7GubzoYKs=",
           "requires": {
             "safe-buffer": "5.1.1"
           }
@@ -9264,7 +9347,7 @@
         "readable-stream": {
           "version": "2.3.3",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
-          "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
+          "integrity": "sha1-No8lEtefnUb9/HE0mueHi7weuVw=",
           "requires": {
             "core-util-is": "1.0.2",
             "inherits": "2.0.3",
@@ -9278,7 +9361,7 @@
         "string_decoder": {
           "version": "1.0.3",
           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-          "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+          "integrity": "sha1-D8Z9fBQYJd6UKC3VNr7GubzoYKs=",
           "requires": {
             "safe-buffer": "5.1.1"
           }
@@ -9422,7 +9505,7 @@
     "style-loader": {
       "version": "0.18.2",
       "resolved": "https://registry.npmjs.org/style-loader/-/style-loader-0.18.2.tgz",
-      "integrity": "sha512-WPpJPZGUxWYHWIUMNNOYqql7zh85zGmr84FdTVWq52WTIkqlW9xSxD3QYWi/T31cqn9UNSsietVEgGn2aaSCzw==",
+      "integrity": "sha1-zDFFmvvNbYC3Ig7lSykan9Zv9es=",
       "requires": {
         "loader-utils": "1.1.0",
         "schema-utils": "0.3.0"
@@ -9502,7 +9585,7 @@
         "ansi-styles": {
           "version": "3.2.0",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
-          "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
+          "integrity": "sha1-wVm41b4PnlpvNG2rlPFs4CIWG4g=",
           "dev": true,
           "requires": {
             "color-convert": "1.9.1"
@@ -9542,7 +9625,7 @@
         "chalk": {
           "version": "2.3.0",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.0.tgz",
-          "integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
+          "integrity": "sha1-tepI78nBeT3MybR2fJORTT8tUro=",
           "dev": true,
           "requires": {
             "ansi-styles": "3.2.0",
@@ -9564,7 +9647,7 @@
         "debug": {
           "version": "3.1.0",
           "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "integrity": "sha1-W7WgZyYotkFJVmuhaBnmFRjGcmE=",
           "dev": true,
           "requires": {
             "ms": "2.0.0"
@@ -9725,13 +9808,13 @@
         "source-map": {
           "version": "0.6.1",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "integrity": "sha1-dHIq8y6WFOnCh6jQu95IteLxomM=",
           "dev": true
         },
         "string-width": {
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+          "integrity": "sha1-q5Pyeo3BPSjKyBXEYhQ6bZASrp4=",
           "dev": true,
           "requires": {
             "is-fullwidth-code-point": "2.0.0",
@@ -9785,7 +9868,7 @@
     "stylelint-config-recommended-scss": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/stylelint-config-recommended-scss/-/stylelint-config-recommended-scss-2.0.0.tgz",
-      "integrity": "sha512-DUIW3daRl5EAyU4ZR6xfPa+bqV5wDccS7X1je6Enes9edpbmWUBR/5XLfDPnjMJgqOe2QwqwaE/qnG4lXID9rg==",
+      "integrity": "sha1-P0SzOK+zv1tr2e663UaO7ydxOSI=",
       "dev": true,
       "requires": {
         "stylelint-config-recommended": "1.0.0"
@@ -9794,7 +9877,7 @@
     "stylelint-config-standard": {
       "version": "17.0.0",
       "resolved": "https://registry.npmjs.org/stylelint-config-standard/-/stylelint-config-standard-17.0.0.tgz",
-      "integrity": "sha512-G8jMZ0KsaVH7leur9XLZVhwOBHZ2vdbuJV8Bgy0ta7/PpBhEHo6fjVDaNchyCGXB5sRcWVq6O9rEU/MvY9cQDQ==",
+      "integrity": "sha1-QhA6CQBU7io93p7K7VXl1NnQWfw=",
       "dev": true,
       "requires": {
         "stylelint-config-recommended": "1.0.0"
@@ -9803,7 +9886,7 @@
     "stylelint-formatter-pretty": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/stylelint-formatter-pretty/-/stylelint-formatter-pretty-1.0.3.tgz",
-      "integrity": "sha512-Jg39kL6kkjUrdKIiHwwz/fbElcF5dOS48ZhvGrEJeWijUbmY1yudclfXv9H61eBqKKu0E33nfez2r0G4EvPtFA==",
+      "integrity": "sha1-prQ8PzoTIGvft3fQ2ozvxsdsNsM=",
       "dev": true,
       "requires": {
         "ansi-escapes": "2.0.0",
@@ -9843,7 +9926,7 @@
         "string-width": {
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+          "integrity": "sha1-q5Pyeo3BPSjKyBXEYhQ6bZASrp4=",
           "dev": true,
           "requires": {
             "is-fullwidth-code-point": "2.0.0",
@@ -9890,7 +9973,7 @@
     "sugarss": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/sugarss/-/sugarss-1.0.1.tgz",
-      "integrity": "sha512-3qgLZytikQQEVn1/FrhY7B68gPUUGY3R1Q1vTiD5xT+Ti1DP/8iZuwFet9ONs5+bmL8pZoDQ6JrQHVgrNlK6mA==",
+      "integrity": "sha1-voJtkAPg8kdzX5I2XcP9fxuunkQ=",
       "dev": true,
       "requires": {
         "postcss": "6.0.16"
@@ -9899,7 +9982,7 @@
         "ansi-styles": {
           "version": "3.2.0",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
-          "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
+          "integrity": "sha1-wVm41b4PnlpvNG2rlPFs4CIWG4g=",
           "dev": true,
           "requires": {
             "color-convert": "1.9.1"
@@ -9908,7 +9991,7 @@
         "chalk": {
           "version": "2.3.0",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.0.tgz",
-          "integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
+          "integrity": "sha1-tepI78nBeT3MybR2fJORTT8tUro=",
           "dev": true,
           "requires": {
             "ansi-styles": "3.2.0",
@@ -9947,7 +10030,7 @@
         "source-map": {
           "version": "0.6.1",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "integrity": "sha1-dHIq8y6WFOnCh6jQu95IteLxomM=",
           "dev": true
         },
         "supports-color": {
@@ -9994,7 +10077,7 @@
     "table": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/table/-/table-4.0.2.tgz",
-      "integrity": "sha512-UUkEAPdSGxtRpiV9ozJ5cMTtYiqz7Ni1OGqLXRCynrvzdtR1p+cfOWe2RJLwvUG8hNanaSRjecIqwOjqeatDsA==",
+      "integrity": "sha1-ozRHN1OR52atNNNIbm4q7chNLjY=",
       "dev": true,
       "requires": {
         "ajv": "5.5.2",
@@ -10020,7 +10103,7 @@
         "ansi-styles": {
           "version": "3.2.0",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
-          "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
+          "integrity": "sha1-wVm41b4PnlpvNG2rlPFs4CIWG4g=",
           "dev": true,
           "requires": {
             "color-convert": "1.9.1"
@@ -10029,7 +10112,7 @@
         "chalk": {
           "version": "2.3.0",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.0.tgz",
-          "integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
+          "integrity": "sha1-tepI78nBeT3MybR2fJORTT8tUro=",
           "dev": true,
           "requires": {
             "ansi-styles": "3.2.0",
@@ -10052,7 +10135,7 @@
         "string-width": {
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+          "integrity": "sha1-q5Pyeo3BPSjKyBXEYhQ6bZASrp4=",
           "dev": true,
           "requires": {
             "is-fullwidth-code-point": "2.0.0",
@@ -10129,7 +10212,7 @@
         "readable-stream": {
           "version": "2.3.3",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
-          "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
+          "integrity": "sha1-No8lEtefnUb9/HE0mueHi7weuVw=",
           "requires": {
             "core-util-is": "1.0.2",
             "inherits": "2.0.3",
@@ -10143,7 +10226,7 @@
         "string_decoder": {
           "version": "1.0.3",
           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-          "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+          "integrity": "sha1-D8Z9fBQYJd6UKC3VNr7GubzoYKs=",
           "requires": {
             "safe-buffer": "5.1.1"
           }
@@ -10166,7 +10249,7 @@
     "tmp": {
       "version": "0.0.33",
       "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
-      "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
+      "integrity": "sha1-bTQzWIl2jSGyvNoKonfO07G/rfk=",
       "dev": true,
       "requires": {
         "os-tmpdir": "1.0.2"
@@ -10678,7 +10761,7 @@
         "async": {
           "version": "2.6.0",
           "resolved": "https://registry.npmjs.org/async/-/async-2.6.0.tgz",
-          "integrity": "sha512-xAfGg1/NTLBBKlHFmnd7PlmUW9KhVQIUuSrYem9xzFUZy13ScvtyGGejaae9iAVRiRq9+Cx7DPFaAAhCpyxyPw==",
+          "integrity": "sha1-YaKau2/MAm/qd+VtHG7FOnlZUfQ=",
           "requires": {
             "lodash": "4.17.4"
           }
@@ -10879,7 +10962,7 @@
     "webpack-merge": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/webpack-merge/-/webpack-merge-4.1.1.tgz",
-      "integrity": "sha512-geQsZ86YkXOVOjvPC5yv3JSNnL6/X3Kzh935AQ/gJNEYXEfJDQFu/sdFuktS9OW2JcH/SJec8TGfRdrpHshH7A==",
+      "integrity": "sha1-8Rl6Cpc+acb77rbWWCGaqMDBNVU=",
       "requires": {
         "lodash": "4.17.4"
       }
@@ -10896,7 +10979,7 @@
         "source-map": {
           "version": "0.6.1",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+          "integrity": "sha1-dHIq8y6WFOnCh6jQu95IteLxomM="
         }
       }
     },
@@ -10935,7 +11018,7 @@
     "wide-align": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.2.tgz",
-      "integrity": "sha512-ijDLlyQ7s6x1JgCLur53osjm/UXUYD9+0PbYKrBsYisYXzCxN+HC3mYDNy/dWdmf3AwqwU3CXwDCvsNgGK1S0w==",
+      "integrity": "sha1-Vx4PGwYEY268DfwhsDObvjE0FxA=",
       "requires": {
         "string-width": "1.0.2"
       }
@@ -11004,7 +11087,7 @@
     "xml2js": {
       "version": "0.4.19",
       "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.19.tgz",
-      "integrity": "sha512-esZnJZJOiJR9wWKMyuvSE1y6Dq5LCuJanqhxslH2bxM6duahNZ+HMpCLhBQGZkbX6xRf8x1Y2eJlgt2q3qo49Q==",
+      "integrity": "sha1-aGwg8hMgnpSr8NG88e+qKRx4J6c=",
       "dev": true,
       "requires": {
         "sax": "1.2.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -62,9 +62,9 @@
       }
     },
     "@edx/studio-frontend": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@edx/studio-frontend/-/studio-frontend-1.2.0.tgz",
-      "integrity": "sha512-y3XSsn665MvoD1QtyRFx+vkUW22iQajPawK1KXCtn4Qz/SFut6Yt52gHOftOtE7CREYOWwlUBS77TNQz+YqQLA==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@edx/studio-frontend/-/studio-frontend-1.2.1.tgz",
+      "integrity": "sha512-/ASKSb2r0MuA2ebg5h3uwE3bJsriKFOkMjT0ILgUWTVdE0mmZ7zX9ucQQ6rVICnThfehpfmPqRIoQfK+qgXyoA==",
       "requires": {
         "@edx/edx-bootstrap": "0.4.3",
         "@edx/paragon": "2.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -62,9 +62,9 @@
       }
     },
     "@edx/studio-frontend": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@edx/studio-frontend/-/studio-frontend-1.2.1.tgz",
-      "integrity": "sha512-/ASKSb2r0MuA2ebg5h3uwE3bJsriKFOkMjT0ILgUWTVdE0mmZ7zX9ucQQ6rVICnThfehpfmPqRIoQfK+qgXyoA==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@edx/studio-frontend/-/studio-frontend-1.2.2.tgz",
+      "integrity": "sha512-WDzsuUU5C3V0UJrmoKff+L9pNwVUO1xwavwXtVZKONi0By4iSc0tMXFOgXsz4+92OVIxCJcRN10AEwjynK/8Dg==",
       "requires": {
         "@edx/edx-bootstrap": "0.4.3",
         "@edx/paragon": "2.0.1",
@@ -8154,7 +8154,7 @@
       "resolved": "https://registry.npmjs.org/react-intl-translations-manager/-/react-intl-translations-manager-5.0.1.tgz",
       "integrity": "sha512-8W0m7LrcxB/K5xJa1yQDMnmfMpFGaV3tDBd2sMJCvdQUgJt5HjjkAwwuslCHOEVBguP9XwX0oABRPrBXfP3XhQ==",
       "requires": {
-        "chalk": "2.3.0",
+        "chalk": "2.3.1",
         "glob": "7.1.2",
         "json-stable-stringify": "1.0.1",
         "mkdirp": "0.5.1"
@@ -8169,26 +8169,26 @@
           }
         },
         "chalk": {
-          "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.0.tgz",
-          "integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.1.tgz",
+          "integrity": "sha512-QUU4ofkDoMIVO7hcx1iPTISs88wsO8jA92RQIm4JAwZvFGGAV2hSAA1NX7oVj2Ej2Q6NDTcRDjPTFrMCRZoJ6g==",
           "requires": {
             "ansi-styles": "3.2.0",
             "escape-string-regexp": "1.0.5",
-            "supports-color": "4.5.0"
+            "supports-color": "5.2.0"
           }
         },
         "has-flag": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
-          "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE="
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
         },
         "supports-color": {
-          "version": "4.5.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
-          "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.2.0.tgz",
+          "integrity": "sha512-F39vS48la4YvTZUPVeTqsjsFNrvcMwrV3RLZINsmHo+7djCvuUzSIeXOnZ5hmjef4bajL1dNccN+tg5XAliO5Q==",
           "requires": {
-            "has-flag": "2.0.0"
+            "has-flag": "3.0.0"
           }
         }
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -62,9 +62,9 @@
       }
     },
     "@edx/studio-frontend": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/@edx/studio-frontend/-/studio-frontend-1.2.3.tgz",
-      "integrity": "sha512-u4ADtq/i69e7E9hUIY5juGT9y6oH6kTqbq5Uczc7i/fT8RnNJfQgxgoFzLXtJXfyqQ7CHeuk5OrJrpSxEDfHZA==",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@edx/studio-frontend/-/studio-frontend-1.2.4.tgz",
+      "integrity": "sha512-R0EDQ4K4d1uhef82756DZ59Zd1yzrctXQ8hclzg1Qq47YxrK8sBP7SeJhAFHduQ0maBQJI4eST+VdC0Qc39J2Q==",
       "requires": {
         "@edx/edx-bootstrap": "0.4.3",
         "@edx/paragon": "2.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -62,9 +62,9 @@
       }
     },
     "@edx/studio-frontend": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@edx/studio-frontend/-/studio-frontend-1.2.4.tgz",
-      "integrity": "sha512-R0EDQ4K4d1uhef82756DZ59Zd1yzrctXQ8hclzg1Qq47YxrK8sBP7SeJhAFHduQ0maBQJI4eST+VdC0Qc39J2Q==",
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/@edx/studio-frontend/-/studio-frontend-1.2.5.tgz",
+      "integrity": "sha512-t9S0Hgs7rckiEWz4iGY2v7Ly+2eONpFgSdg3EnsRt3zopE+bm+IMornIuKcV+b7lpHg7nrSgw9/iJY1rJ1ANqA==",
       "requires": {
         "@edx/edx-bootstrap": "0.4.3",
         "@edx/paragon": "2.0.1",
@@ -80,7 +80,7 @@
         "react-dropzone": "4.2.8",
         "react-intl": "2.4.0",
         "react-intl-translations-manager": "5.0.1",
-        "react-paginate": "5.0.0",
+        "react-paginate": "5.1.0",
         "react-redux": "5.0.6",
         "redux": "3.7.2",
         "redux-devtools-extension": "2.13.2",
@@ -481,9 +481,19 @@
       "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
     },
     "attr-accept": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/attr-accept/-/attr-accept-1.1.0.tgz",
-      "integrity": "sha1-tc01In8WOTWo8d4Q7T66FpQfa+Y="
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/attr-accept/-/attr-accept-1.1.1.tgz",
+      "integrity": "sha512-s0iErRnsYv078cW2Iy2Ty+PGGQdvoztSe+OXbDYPpZ3bKXYxbNptTPt+NW89Dge/3lukNfr0tUgoFIgfmSYuiQ==",
+      "requires": {
+        "core-js": "1.2.2"
+      },
+      "dependencies": {
+        "core-js": {
+          "version": "1.2.2",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.2.tgz",
+          "integrity": "sha1-9F7t5SSFV5tgJsioYoRyufeWDK4="
+        }
+      }
     },
     "autoprefixer": {
       "version": "6.7.7",
@@ -8129,7 +8139,7 @@
       "resolved": "https://registry.npmjs.org/react-dropzone/-/react-dropzone-4.2.8.tgz",
       "integrity": "sha512-L/q6ySfhdG9Md3P21jFumzlm92TxRT0FtYX6G793Nf8bt7Fzpwx6gJsPk0idV094koj/Y5vRpp0q9+e0bdsjxw==",
       "requires": {
-        "attr-accept": "1.1.0",
+        "attr-accept": "1.1.1",
         "prop-types": "15.6.0"
       }
     },
@@ -8194,9 +8204,9 @@
       }
     },
     "react-paginate": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/react-paginate/-/react-paginate-5.0.0.tgz",
-      "integrity": "sha512-wqTX4OATbMH9AWCBZbEj7fE5Ks7OHOyfyq2J6S/GnHfe1t2jh3ond1LUuddsYr4csMXAiY1aBPy54EwWP5fX2w==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/react-paginate/-/react-paginate-5.1.0.tgz",
+      "integrity": "sha1-m+5fqUmIEgQteD8YGxygQ7V7haU=",
       "requires": {
         "classnames": "2.2.5",
         "prop-types": "15.6.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -62,9 +62,9 @@
       }
     },
     "@edx/studio-frontend": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/@edx/studio-frontend/-/studio-frontend-1.2.2.tgz",
-      "integrity": "sha512-WDzsuUU5C3V0UJrmoKff+L9pNwVUO1xwavwXtVZKONi0By4iSc0tMXFOgXsz4+92OVIxCJcRN10AEwjynK/8Dg==",
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@edx/studio-frontend/-/studio-frontend-1.2.3.tgz",
+      "integrity": "sha512-u4ADtq/i69e7E9hUIY5juGT9y6oH6kTqbq5Uczc7i/fT8RnNJfQgxgoFzLXtJXfyqQ7CHeuk5OrJrpSxEDfHZA==",
       "requires": {
         "@edx/edx-bootstrap": "0.4.3",
         "@edx/paragon": "2.0.1",
@@ -77,7 +77,7 @@
         "prop-types": "15.6.0",
         "react": "16.2.0",
         "react-dom": "16.2.0",
-        "react-dropzone": "4.2.7",
+        "react-dropzone": "4.2.8",
         "react-intl": "2.4.0",
         "react-intl-translations-manager": "5.0.1",
         "react-paginate": "5.0.0",
@@ -8125,9 +8125,9 @@
       }
     },
     "react-dropzone": {
-      "version": "4.2.7",
-      "resolved": "https://registry.npmjs.org/react-dropzone/-/react-dropzone-4.2.7.tgz",
-      "integrity": "sha512-BGEc/UtG0rHBEZjAkGsajPRO85d842LWeaP4CINHvXrSNyKp7Tq7s699NyZwWYHahvXaUNZzNJ17JMrfg5sxVg==",
+      "version": "4.2.8",
+      "resolved": "https://registry.npmjs.org/react-dropzone/-/react-dropzone-4.2.8.tgz",
+      "integrity": "sha512-L/q6ySfhdG9Md3P21jFumzlm92TxRT0FtYX6G793Nf8bt7Fzpwx6gJsPk0idV094koj/Y5vRpp0q9+e0bdsjxw==",
       "requires": {
         "attr-accept": "1.1.0",
         "prop-types": "15.6.0"

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "dependencies": {
     "@edx/edx-bootstrap": "0.4.3",
     "@edx/paragon": "1.7.1",
-    "@edx/studio-frontend": "1.0.2",
+    "@edx/studio-frontend": "1.2.0",
     "babel-core": "6.26.0",
     "babel-loader": "6.4.1",
     "babel-plugin-transform-class-properties": "6.24.1",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "dependencies": {
     "@edx/edx-bootstrap": "0.4.3",
     "@edx/paragon": "1.7.1",
-    "@edx/studio-frontend": "0.9.0",
+    "@edx/studio-frontend": "1.0.2",
     "babel-core": "6.26.0",
     "babel-loader": "6.4.1",
     "babel-plugin-transform-class-properties": "6.24.1",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "dependencies": {
     "@edx/edx-bootstrap": "0.4.3",
     "@edx/paragon": "1.7.1",
-    "@edx/studio-frontend": "1.2.1",
+    "@edx/studio-frontend": "1.2.2",
     "babel-core": "6.26.0",
     "babel-loader": "6.4.1",
     "babel-plugin-transform-class-properties": "6.24.1",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "dependencies": {
     "@edx/edx-bootstrap": "0.4.3",
     "@edx/paragon": "1.7.1",
-    "@edx/studio-frontend": "1.2.0",
+    "@edx/studio-frontend": "1.2.1",
     "babel-core": "6.26.0",
     "babel-loader": "6.4.1",
     "babel-plugin-transform-class-properties": "6.24.1",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "dependencies": {
     "@edx/edx-bootstrap": "0.4.3",
     "@edx/paragon": "1.7.1",
-    "@edx/studio-frontend": "1.2.4",
+    "@edx/studio-frontend": "1.2.5",
     "babel-core": "6.26.0",
     "babel-loader": "6.4.1",
     "babel-plugin-transform-class-properties": "6.24.1",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "dependencies": {
     "@edx/edx-bootstrap": "0.4.3",
     "@edx/paragon": "1.7.1",
-    "@edx/studio-frontend": "1.2.2",
+    "@edx/studio-frontend": "1.2.3",
     "babel-core": "6.26.0",
     "babel-loader": "6.4.1",
     "babel-plugin-transform-class-properties": "6.24.1",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "dependencies": {
     "@edx/edx-bootstrap": "0.4.3",
     "@edx/paragon": "1.7.1",
-    "@edx/studio-frontend": "1.2.3",
+    "@edx/studio-frontend": "1.2.4",
     "babel-core": "6.26.0",
     "babel-loader": "6.4.1",
     "babel-plugin-transform-class-properties": "6.24.1",

--- a/pavelib/assets.py
+++ b/pavelib/assets.py
@@ -50,6 +50,7 @@ COMMON_LOOKUP_PATHS = [
 
 # A list of NPM installed libraries that should be copied into the common
 # static directory.
+# If string ends with '/' then all file in the directory will be copied.
 NPM_INSTALLED_LIBRARIES = [
     'backbone.paginator/lib/backbone.paginator.js',
     'backbone/backbone.js',
@@ -64,20 +65,7 @@ NPM_INSTALLED_LIBRARIES = [
     'requirejs/require.js',
     'underscore.string/dist/underscore.string.js',
     'underscore/underscore.js',
-    '@edx/studio-frontend/dist/manifest.min.js',
-    '@edx/studio-frontend/dist/manifest.min.js.map',
-    '@edx/studio-frontend/dist/vendor.min.js',
-    '@edx/studio-frontend/dist/vendor.min.js.map',
-    '@edx/studio-frontend/dist/vendor.min.css',
-    '@edx/studio-frontend/dist/vendor.min.css.map',
-    '@edx/studio-frontend/dist/assets.min.js',
-    '@edx/studio-frontend/dist/assets.min.js.map',
-    '@edx/studio-frontend/dist/assets.min.css',
-    '@edx/studio-frontend/dist/assets.min.css.map',
-    '@edx/studio-frontend/dist/accessibilityPolicy.min.js',
-    '@edx/studio-frontend/dist/accessibilityPolicy.min.js.map',
-    '@edx/studio-frontend/dist/accessibilityPolicy.min.css',
-    '@edx/studio-frontend/dist/accessibilityPolicy.min.css.map',
+    '@edx/studio-frontend/dist/',
     'which-country/index.js'
 ]
 
@@ -655,7 +643,11 @@ def process_npm_assets():
         """
         Copies a vendor library to the shared vendor directory.
         """
-        library_path = 'node_modules/{library}'.format(library=library)
+        if library.startswith('node_modules/'):
+            library_path = library
+        else:
+            library_path = 'node_modules/{library}'.format(library=library)
+
         if library.endswith('.css') or library.endswith('.css.map'):
             vendor_dir = NPM_CSS_VENDOR_DIRECTORY
         else:
@@ -667,6 +659,17 @@ def process_npm_assets():
             ))
         elif not skip_if_missing:
             raise Exception('Missing vendor file {library_path}'.format(library_path=library_path))
+
+    def copy_vendor_library_dir(library_dir, skip_if_missing=False):
+        """
+        Copies all vendor libraries in directory to the shared vendor directory.
+        """
+        library_dir_path = 'node_modules/{library_dir}'.format(library_dir=library_dir)
+        print('Copying vendor library dir: {}'.format(library_dir_path))
+        if os.path.exists(library_dir_path):
+            for dirpath, dirnames, filenames in os.walk(library_dir_path):
+                for filename in filenames:
+                    copy_vendor_library(os.path.join(dirpath, filename))
 
     # Skip processing of the libraries if this is just a dry run
     if tasks.environment.dry_run:
@@ -681,7 +684,10 @@ def process_npm_assets():
     # Copy each file to the vendor directory, overwriting any existing file.
     print("Copying vendor files into static directory")
     for library in NPM_INSTALLED_LIBRARIES:
-        copy_vendor_library(library)
+        if library.endswith('/'):
+            copy_vendor_library_dir(library)
+        else:
+            copy_vendor_library(library)
 
     # Copy over each developer library too if they have been installed
     print("Copying developer vendor files into static directory")

--- a/pavelib/assets.py
+++ b/pavelib/assets.py
@@ -64,6 +64,20 @@ NPM_INSTALLED_LIBRARIES = [
     'requirejs/require.js',
     'underscore.string/dist/underscore.string.js',
     'underscore/underscore.js',
+    '@edx/studio-frontend/dist/manifest.min.js',
+    '@edx/studio-frontend/dist/manifest.min.js.map',
+    '@edx/studio-frontend/dist/vendor.min.js',
+    '@edx/studio-frontend/dist/vendor.min.js.map',
+    '@edx/studio-frontend/dist/vendor.min.css',
+    '@edx/studio-frontend/dist/vendor.min.css.map',
+    '@edx/studio-frontend/dist/assets.min.js',
+    '@edx/studio-frontend/dist/assets.min.js.map',
+    '@edx/studio-frontend/dist/assets.min.css',
+    '@edx/studio-frontend/dist/assets.min.css.map',
+    '@edx/studio-frontend/dist/accessibilityPolicy.min.js',
+    '@edx/studio-frontend/dist/accessibilityPolicy.min.js.map',
+    '@edx/studio-frontend/dist/accessibilityPolicy.min.css',
+    '@edx/studio-frontend/dist/accessibilityPolicy.min.css.map',
     'which-country/index.js'
 ]
 

--- a/pavelib/assets.py
+++ b/pavelib/assets.py
@@ -667,9 +667,9 @@ def process_npm_assets():
         library_dir_path = 'node_modules/{library_dir}'.format(library_dir=library_dir)
         print('Copying vendor library dir: {}'.format(library_dir_path))
         if os.path.exists(library_dir_path):
-            for dirpath, dirnames, filenames in os.walk(library_dir_path):
+            for dirpath, _, filenames in os.walk(library_dir_path):
                 for filename in filenames:
-                    copy_vendor_library(os.path.join(dirpath, filename))
+                    copy_vendor_library(os.path.join(dirpath, filename), skip_if_missing=skip_if_missing)
 
     # Skip processing of the libraries if this is just a dry run
     if tasks.environment.dry_run:

--- a/webpack.common.config.js
+++ b/webpack.common.config.js
@@ -22,10 +22,8 @@ module.exports = {
 
     entry: {
         // Studio
-        AssetsPage: './node_modules/@edx/studio-frontend/src/index.jsx',
         Import: './cms/static/js/features/import/factories/import.js',
         CourseOrLibraryListing: './cms/static/js/features_jsx/studio/CourseOrLibraryListing.jsx',
-        AccessibilityPage: './node_modules/@edx/studio-frontend/src/accessibilityIndex.jsx',
         'js/pages/login': './cms/static/js/pages/login.js',
 
         // LMS
@@ -127,7 +125,6 @@ module.exports = {
             {
                 test: /\.(js|jsx)$/,
                 include: [
-                    /studio-frontend/,
                     /paragon/
                 ],
                 use: 'babel-loader'

--- a/webpack.dev.config.js
+++ b/webpack.dev.config.js
@@ -26,7 +26,6 @@ module.exports = Merge.smart(commonConfig, {
             {
                 test: /(.scss|.css)$/,
                 include: [
-                    /studio-frontend/,
                     /paragon/,
                     /font-awesome/
                 ],

--- a/webpack.prod.config.js
+++ b/webpack.prod.config.js
@@ -3,13 +3,7 @@
 'use strict';
 
 var Merge = require('webpack-merge');
-var path = require('path');
 var webpack = require('webpack');
-
-var ExtractTextPlugin = require('extract-text-webpack-plugin');
-var extractSass = new ExtractTextPlugin({
-    filename: 'css/[name].[contenthash].css'
-});
 
 var commonConfig = require('./webpack.common.config.js');
 
@@ -26,35 +20,5 @@ module.exports = Merge.smart(commonConfig, {
             minimize: true
         }),
         new webpack.optimize.UglifyJsPlugin()
-    ],
-    module: {
-        rules: [
-            {
-                test: /(.scss|.css)$/,
-                include: [
-                    /paragon/,
-                    /font-awesome/
-                ],
-                use: extractSass.extract({
-                    use: [{
-                        loader: 'css-loader',
-                        options: {
-                            modules: true,
-                            localIdentName: '[name]__[local]___[hash:base64:5]'
-                        }
-                    }, {
-                        loader: 'sass-loader',
-                        options: {
-                            data: '$base-rem-size: 0.625; @import "paragon-reset";',
-                            includePaths: [
-                                path.join(__dirname, './node_modules/@edx/paragon/src/utils'),
-                                path.join(__dirname, './node_modules/')
-                            ]
-                        }
-                    }],
-                    fallback: 'style-loader'
-                })
-            }
-        ]
-    }
+    ]
 });

--- a/webpack.prod.config.js
+++ b/webpack.prod.config.js
@@ -19,7 +19,6 @@ module.exports = Merge.smart(commonConfig, {
     },
     devtool: false,
     plugins: [
-        new ExtractTextPlugin('node_modules/@edx/studio-frontend/dist/studio-frontend.min.css'),
         new webpack.DefinePlugin({
             'process.env.NODE_ENV': JSON.stringify('production')
         }),
@@ -33,7 +32,6 @@ module.exports = Merge.smart(commonConfig, {
             {
                 test: /(.scss|.css)$/,
                 include: [
-                    /studio-frontend/,
                     /paragon/,
                     /font-awesome/
                 ],


### PR DESCRIPTION
Instead of building studio-frontend inside of edx-platform's webpack, just copy the built /dist files checked into the studio-frontend's NPM release to a Django static folder. This will give more control over to studio-frontend and remove the duplicated webpack config between the two repos.

Also, this PR allows developers to load static files from the studio-frontend webpack-dev-server so we have hot-reloading and so we don't have to constantly copy files around to test inside the Studio shell.

See the studio-frontend PR: https://github.com/edx/studio-frontend/pull/112

Wiki page explaining this approach: https://openedx.atlassian.net/wiki/spaces/FEDX/pages/548766004/Studio-Frontend+Developing+Frontend+Separate+from+Platform