### PR TITLE
Change paver timing log naming structure

### DIFF
--- a/scripts/jenkins-common.sh
+++ b/scripts/jenkins-common.sh
@@ -59,7 +59,8 @@ echo "npm version is `npm --version`"
 
 # Log any paver or ansible command timing
 TIMESTAMP=$(date +%s)
-export PAVER_TIMER_LOG="test_root/log/timing.paver.$TIMESTAMP.log"
+SHARD_NUM=${SHARD:="all"}
+export PAVER_TIMER_LOG="test_root/log/timing.paver.$TEST_SUITE.$SHARD_NUM.log"
 export ANSIBLE_TIMER_LOG="test_root/log/timing.ansible.$TIMESTAMP.log"
 
 echo "This node is `curl http://169.254.169.254/latest/meta-data/hostname`"


### PR DESCRIPTION
Right now the only unique identifier is the time stamp, but this can sometimes cause collisions which results in lost data. Let's use the test suite and shard name instead to guarantee a unique file name for all timing logs. If it's a freestyle job, we'll stick to using "all" as we do in the generic-ci script.

The new naming structure will still meet the splunkforwarder wildcards.

```
- source: '/var/lib/jenkins/jobs/edx-platform-*/builds/*/archive/.../test_root/log/timing.*.log'
...
- source: '/var/lib/jenkins/jobs/edx-platform-*/builds/*/archive/test_root/log/timing.*.log'
```