### PR TITLE
PLAT-1945 Better management command ergonomics

### DIFF
--- a/lms/djangoapps/course_wiki/plugins/markdownedx/mdx_mathjax.py
+++ b/lms/djangoapps/course_wiki/plugins/markdownedx/mdx_mathjax.py
@@ -27,5 +27,5 @@ class MathJaxExtension(markdown.Extension):
         md.inlinePatterns.add('mathjax', MathJaxPattern(), '<escape')
 
 
-def makeExtension(configs=None):
-    return MathJaxExtension(configs)
+def makeExtension(**kwargs):
+    return MathJaxExtension(**kwargs)

--- a/lms/djangoapps/course_wiki/plugins/markdownedx/mdx_video.py
+++ b/lms/djangoapps/course_wiki/plugins/markdownedx/mdx_video.py
@@ -142,7 +142,7 @@ version = "0.1.6"
 
 
 class VideoExtension(markdown.Extension):
-    def __init__(self, configs):
+    def __init__(self, **kwargs):
         self.config = {
             'bliptv_width': ['480', 'Width for Blip.tv videos'],
             'bliptv_height': ['300', 'Height for Blip.tv videos'],
@@ -163,8 +163,7 @@ class VideoExtension(markdown.Extension):
         }
 
         # Override defaults with user settings
-        for key, value in configs:
-            self.setConfig(key, value)
+        super(VideoExtension, self).__init__(**kwargs)
 
     def add_inline(self, md, name, klass, re):  # pylint: disable=invalid-name
         """Adds the inline link"""
@@ -285,15 +284,12 @@ def flash_object(url, width, height):
     param.set('name', 'allowFullScreen')
     param.set('value', 'true')
     obj.append(param)
-    #param = etree.Element('param')
-    #param.set('name', 'allowScriptAccess')
-    #param.set('value', 'sameDomain')
-    #obj.append(param)
     return obj
 
 
-def makeExtension(configs=None):
-    return VideoExtension(configs=configs)
+def makeExtension(**kwargs):
+    return VideoExtension(**kwargs)
+
 
 if __name__ == "__main__":
     import doctest

--- a/lms/djangoapps/course_wiki/plugins/markdownedx/wiki_plugin.py
+++ b/lms/djangoapps/course_wiki/plugins/markdownedx/wiki_plugin.py
@@ -12,8 +12,8 @@ class ExtendMarkdownPlugin(BasePlugin):
     """
 
     markdown_extensions = [
-        mdx_mathjax.MathJaxExtension(configs={}),
-        mdx_video.VideoExtension(configs={}),
+        mdx_mathjax.MathJaxExtension(),
+        mdx_video.VideoExtension(),
     ]
 
 plugin_registry.register(ExtendMarkdownPlugin)

--- a/manage.py
+++ b/manage.py
@@ -43,7 +43,7 @@ def parse_args():
     lms.add_argument(
         '--settings',
         help="Which django settings module to use under lms.envs. If not provided, the DJANGO_SETTINGS_MODULE "
-             "environment variable will be used if it is set, otherwise it will default to lms.envs.dev")
+             "environment variable will be used if it is set, otherwise it will default to lms.envs.devstack_docker")
     lms.add_argument(
         '--service-variant',
         choices=['lms', 'lms-xml', 'lms-preview'],
@@ -57,7 +57,7 @@ def parse_args():
     lms.set_defaults(
         help_string=lms.format_help(),
         settings_base='lms/envs',
-        default_settings='lms.envs.dev',
+        default_settings='lms.envs.devstack_docker',
         startup='lms.startup',
     )
 
@@ -70,7 +70,7 @@ def parse_args():
     cms.add_argument(
         '--settings',
         help="Which django settings module to use under cms.envs. If not provided, the DJANGO_SETTINGS_MODULE "
-             "environment variable will be used if it is set, otherwise it will default to cms.envs.dev")
+             "environment variable will be used if it is set, otherwise it will default to cms.envs.devstack_docker")
     cms.add_argument('-h', '--help', action='store_true', help='show this help message and exit')
     cms.add_argument(
         '--contracts',
@@ -80,7 +80,7 @@ def parse_args():
     cms.set_defaults(
         help_string=cms.format_help(),
         settings_base='cms/envs',
-        default_settings='cms.envs.dev',
+        default_settings='cms.envs.devstack_docker',
         service_variant='cms',
         startup='cms.startup',
     )

--- a/openedx/core/lib/logsettings.py
+++ b/openedx/core/lib/logsettings.py
@@ -115,6 +115,15 @@ def log_python_warnings():
     each test case.
     """
     warnings.simplefilter('default')
+    warnings.filterwarnings('ignore', 'Not importing directory ')
     warnings.filterwarnings('ignore', 'Setting _field_data is deprecated')
     warnings.filterwarnings('ignore', 'Setting _field_data via the constructor is deprecated')
+    try:
+        # There are far too many of these deprecation warnings in startup to output for every management command;
+        # suppress them until we've fixed at least the most common ones as reported by the test suite
+        from django.utils.deprecation import RemovedInDjango20Warning, RemovedInDjango21Warning
+        warnings.simplefilter('ignore', RemovedInDjango20Warning)
+        warnings.simplefilter('ignore', RemovedInDjango21Warning)
+    except ImportError:
+        pass
     logging.captureWarnings(True)

--- a/requirements/edx/github.txt
+++ b/requirements/edx/github.txt
@@ -50,7 +50,7 @@
 
 # Third-party:
 git+https://github.com/jazzband/django-pipeline.git@d068a019169c9de5ee20ece041a6dea236422852#egg=django-pipeline==1.5.3
--e git+https://github.com/edx/django-wiki.git@v0.0.16#egg=django-wiki
+-e git+https://github.com/edx/django-wiki.git@v0.0.17#egg=django-wiki
 git+https://github.com/edx/django-openid-auth.git@0.14#egg=django-openid-auth==0.14
 git+https://github.com/edx/MongoDBProxy.git@25b99097615bda06bd7cdfe5669ed80dc2a7fed0#egg=MongoDBProxy==0.1.0
 git+https://github.com/edx/nltk.git@2.0.6#egg=nltk==2.0.6


### PR DESCRIPTION
* Switched the default settings in `manage.py` from the no-longer-existing `dev` to `devstack_docker`
* Updated our Markdown extensions to no longer use a deprecated initialization pattern (which currently outputs a warning on every management command execution)
* Upgraded django-wiki to a version which fixes a similar issue with its Markdown extension (see https://github.com/edx/django-wiki/pull/32 for details)
* Suppress the `RemovedInDjango20Warning` and `RemovedInDjango21Warning` deprecation warnings in management commands until we can whittle them down to a reasonable volume.  They're still enabled in tests, since we seem to have the counts there down to a level that Jenkins can cope with.
* Suppress `ImportError`s regarding missing `__init__.py` files in a few different packages, again only for management commands; it's not worth repeating these over and over on the console until we try fixing them in test runs.