### PR TITLE
PLAT-1947 Fix bok-choy test that failed under Django 1.11

### DIFF
--- a/common/test/acceptance/pages/lms/admin.py
+++ b/common/test/acceptance/pages/lms/admin.py
@@ -1,6 +1,7 @@
 """
 Pages object for the Django's /admin/ views.
 """
+import django
 from bok_choy.page_object import PageObject
 from common.test.acceptance.pages.lms import BASE_URL
 
@@ -29,7 +30,12 @@ class ChangeUserAdminPage(PageObject):
         """
         Reads the read-only username.
         """
-        return self.q(css='.field-username p').text[0]
+        # TODO: Remove Django 1.11 upgrade shim
+        # SHIM: Get rid of this logic post-upgrade
+        if django.VERSION < (1, 11):
+            return self.q(css='.field-username p').text[0]
+        else:
+            return self.q(css='.field-username .readonly').text[0]
 
     @property
     def first_name_element(self):


### PR DESCRIPTION
Django 1.11 changed the markup used to render read-only fields in the admin interface, added a shim in one test to match.