### PR TITLE
PLAT-1949 Less cluttered management command output

### DIFF
--- a/common/lib/capa/capa/tests/helpers.py
+++ b/common/lib/capa/capa/tests/helpers.py
@@ -1,7 +1,7 @@
 """Tools for helping with testing capa."""
 
 import gettext
-from path import path  # pylint: disable=no-name-in-module
+from path import Path
 import os
 import os.path
 
@@ -23,7 +23,7 @@ def get_template(template_name):
     Return template for a capa inputtype.
     """
     return TemplateLookup(
-        directories=[path(__file__).dirname().dirname() / 'templates'],
+        directories=[Path(__file__).dirname().dirname() / 'templates'],
         default_filters=['decode.utf8']
     ).get_template(template_name)
 

--- a/lms/djangoapps/courseware/tests/test_comprehensive_theming.py
+++ b/lms/djangoapps/courseware/tests/test_comprehensive_theming.py
@@ -3,7 +3,7 @@
 from django.conf import settings
 from django.contrib import staticfiles
 from django.test import TestCase
-from path import path  # pylint: disable=no-name-in-module
+from path import Path
 
 import edxmako
 from openedx.core.djangoapps.theming.tests.test_util import with_comprehensive_theme
@@ -37,14 +37,14 @@ class TestComprehensiveTheming(TestCase):
         # of test.
 
         # Make a temp directory as a theme.
-        themes_dir = path(mkdtemp_clean())
+        themes_dir = Path(mkdtemp_clean())
         tmp_theme = "temp_theme"
         template_dir = themes_dir / tmp_theme / "lms/templates"
         template_dir.makedirs()
         with open(template_dir / "footer.html", "w") as footer:
             footer.write("<footer>TEMPORARY THEME</footer>")
 
-        dest_path = path(settings.COMPREHENSIVE_THEME_DIRS[0]) / tmp_theme
+        dest_path = Path(settings.COMPREHENSIVE_THEME_DIRS[0]) / tmp_theme
         create_symlink(themes_dir / tmp_theme, dest_path)
 
         edxmako.paths.add_lookup('main', themes_dir, prepend=True)

--- a/lms/djangoapps/discussion/views.py
+++ b/lms/djangoapps/discussion/views.py
@@ -4,7 +4,6 @@ Views handling read (GET) requests for the Discussion tab and inline discussions
 
 import logging
 from functools import wraps
-from sets import Set
 
 from django.conf import settings
 from django.contrib.auth.decorators import login_required
@@ -727,9 +726,7 @@ class DiscussionBoardFragmentView(EdxFragmentView):
         works in conjunction with the Django pipeline to ensure that in development mode
         the files are loaded individually, but in production just the single bundle is loaded.
         """
-        dependencies = Set()
-        dependencies.update(self.get_js_dependencies('discussion_vendor'))
-        return list(dependencies)
+        return list(set(self.get_js_dependencies('discussion_vendor')))
 
     def js_dependencies(self):
         """

--- a/openedx/core/djangoapps/plugins/plugin_apps.py
+++ b/openedx/core/djangoapps/plugins/plugin_apps.py
@@ -17,5 +17,5 @@ def get_apps(project_type):
         for app_config in registry.get_app_configs(project_type)
         if getattr(app_config, constants.PLUGIN_APP_CLASS_ATTRIBUTE_NAME, None) is not None
     ]
-    log.info(u'Plugin Apps: Found %s', plugin_apps)
+    log.debug(u'Plugin Apps: Found %s', plugin_apps)
     return plugin_apps

--- a/openedx/core/djangoapps/plugins/plugin_settings.py
+++ b/openedx/core/djangoapps/plugins/plugin_settings.py
@@ -23,7 +23,7 @@ def _iter_plugins(project_type, settings_type):
     for app_config in registry.get_app_configs(project_type):
         settings_config = _get_config(app_config, project_type, settings_type)
         if settings_config is None:
-            log.info(
+            log.debug(
                 u'Plugin Apps [Settings]: Did NOT find %s for %s and %s',
                 app_config.name,
                 project_type,
@@ -33,7 +33,7 @@ def _iter_plugins(project_type, settings_type):
 
         plugin_settings_path = utils.get_module_path(app_config, settings_config, constants.PluginSettings)
 
-        log.info(u'Plugin Apps [Settings]: Found %s for %s and %s', app_config.name, project_type, settings_type)
+        log.debug(u'Plugin Apps [Settings]: Found %s for %s and %s', app_config.name, project_type, settings_type)
         yield utils.import_module(plugin_settings_path)
 
 

--- a/openedx/core/djangoapps/plugins/plugin_signals.py
+++ b/openedx/core/djangoapps/plugins/plugin_signals.py
@@ -29,13 +29,13 @@ def _iter_plugins(project_type):
     for app_config in registry.get_app_configs(project_type):
         signals_config = _get_config(app_config, project_type)
         if signals_config is None:
-            log.info(u'Plugin Apps [Signals]: Did NOT find %s for %s', app_config.name, project_type)
+            log.debug(u'Plugin Apps [Signals]: Did NOT find %s for %s', app_config.name, project_type)
             continue
 
         signals_module_path = utils.get_module_path(app_config, signals_config, constants.PluginSignals)
         signals_module = utils.import_module(signals_module_path)
 
-        log.info(
+        log.debug(
             u'Plugin Apps [Signals]: Found %s with %d receiver(s) for %s',
             app_config.name,
             len(signals_config.get(constants.PluginSignals.RECEIVERS, [])),

--- a/openedx/core/djangoapps/plugins/plugin_urls.py
+++ b/openedx/core/djangoapps/plugins/plugin_urls.py
@@ -31,13 +31,13 @@ def _iter_plugins(project_type):
     for app_config in registry.get_app_configs(project_type):
         url_config = _get_config(app_config, project_type)
         if url_config is None:
-            log.info(u'Plugin Apps [URLs]: Did NOT find %s for %s', app_config.name, project_type)
+            log.debug(u'Plugin Apps [URLs]: Did NOT find %s for %s', app_config.name, project_type)
             continue
 
         urls_module_path = utils.get_module_path(app_config, url_config, constants.PluginURLs)
         url_config[constants.PluginURLs.NAMESPACE] = url_config.get(constants.PluginURLs.NAMESPACE, app_config.name)
 
-        log.info(
+        log.debug(
             u'Plugin Apps [URLs]: Found %s with namespace %s for %s',
             app_config.name,
             url_config[constants.PluginURLs.NAMESPACE],


### PR DESCRIPTION
Reduce clutter in management command output by demoting some of the `plugins` app logging and fixing a deprecation warning.  Also fixed a couple of deprecation warnings in tests due to outdated usage of the `path.py` package.