### PR TITLE
WIP: Consolidate Authentication declarations

### DIFF
--- a/cms/djangoapps/api/v1/views/course_runs.py
+++ b/cms/djangoapps/api/v1/views/course_runs.py
@@ -1,13 +1,12 @@
 from django.conf import settings
 from django.http import Http404
-from edx_rest_framework_extensions.authentication import JwtAuthentication
 from opaque_keys.edx.keys import CourseKey
 from rest_framework import parsers, permissions, status, viewsets
-from rest_framework.authentication import SessionAuthentication
 from rest_framework.decorators import detail_route
 from rest_framework.response import Response
 
 from contentstore.views.course import _accessible_courses_iter, get_course_and_check_access
+from openedx.core.lib.api.view_utils import view_auth_classes
 from ..serializers.course_runs import (
     CourseRunCreateSerializer,
     CourseRunImageSerializer,
@@ -17,10 +16,9 @@ from ..serializers.course_runs import (
 
 
 # pylint: disable=unused-argument
+@view_auth_classes(permission_classes=(permissions.IsAdminUser,))
 class CourseRunViewSet(viewsets.GenericViewSet):
-    authentication_classes = (JwtAuthentication, SessionAuthentication,)
     lookup_value_regex = settings.COURSE_KEY_REGEX
-    permission_classes = (permissions.IsAdminUser,)
     serializer_class = CourseRunSerializer
 
     def get_object(self):

--- a/lms/djangoapps/bulk_enroll/views.py
+++ b/lms/djangoapps/bulk_enroll/views.py
@@ -2,7 +2,6 @@
 API views for Bulk Enrollment
 """
 import json
-from edx_rest_framework_extensions.authentication import JwtAuthentication
 from rest_framework import status
 from rest_framework.response import Response
 from rest_framework.views import APIView
@@ -10,12 +9,13 @@ from rest_framework.views import APIView
 from bulk_enroll.serializers import BulkEnrollmentSerializer
 from enrollment.views import EnrollmentUserThrottle
 from instructor.views.api import students_update_enrollment
-from openedx.core.lib.api.authentication import OAuth2Authentication
 from openedx.core.lib.api.permissions import IsStaff
+from openedx.core.lib.api.view_utils import view_auth_classes
 from util.disable_rate_limit import can_disable_rate_limit
 
 
 @can_disable_rate_limit
+@view_auth_classes(permission_classes=(IsStaff,))
 class BulkEnrollView(APIView):
     """
     **Use Case**
@@ -53,8 +53,6 @@ class BulkEnrollView(APIView):
         enrollment)
     """
 
-    authentication_classes = JwtAuthentication, OAuth2Authentication
-    permission_classes = IsStaff,
     throttle_classes = EnrollmentUserThrottle,
 
     def post(self, request):

--- a/lms/djangoapps/certificates/apis/v0/views.py
+++ b/lms/djangoapps/certificates/apis/v0/views.py
@@ -1,19 +1,19 @@
 """ API v0 views. """
 import logging
 
-from edx_rest_framework_extensions.authentication import JwtAuthentication
 from opaque_keys import InvalidKeyError
 from opaque_keys.edx.keys import CourseKey
 from rest_framework.generics import GenericAPIView
-from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
 
 from lms.djangoapps.certificates.api import get_certificate_for_user
-from openedx.core.lib.api import authentication, permissions
+from openedx.core.lib.api.view_utils import view_auth_classes
+
 
 log = logging.getLogger(__name__)
 
 
+@view_auth_classes(is_user_in_url=True)
 class CertificatesDetailView(GenericAPIView):
     """
         **Use Case**
@@ -68,16 +68,6 @@ class CertificatesDetailView(GenericAPIView):
                 "grade": "0.98"
             }
     """
-
-    authentication_classes = (
-        authentication.OAuth2AuthenticationAllowInactiveUser,
-        authentication.SessionAuthenticationAllowInactiveUser,
-        JwtAuthentication,
-    )
-    permission_classes = (
-        IsAuthenticated,
-        permissions.IsUserInUrlOrStaff
-    )
 
     def get(self, request, username, course_id):
         """

--- a/lms/djangoapps/commerce/api/v0/tests/test_views.py
+++ b/lms/djangoapps/commerce/api/v0/tests/test_views.py
@@ -102,10 +102,10 @@ class BasketsViewTests(EnrollmentEventTestMixin, UserMixin, ModuleStoreTestCase)
 
     def test_login_required(self):
         """
-        The view should return HTTP 403 status if the user is not logged in.
+        The view should return HTTP 401 status if the user is not logged in.
         """
         self.client.logout()
-        self.assertEqual(403, self._post_to_view().status_code)
+        self.assertEqual(401, self._post_to_view().status_code)
 
     @ddt.data('delete', 'get', 'put')
     def test_post_required(self, method):

--- a/lms/djangoapps/commerce/api/v0/views.py
+++ b/lms/djangoapps/commerce/api/v0/views.py
@@ -13,11 +13,10 @@ from six import text_type
 from course_modes.models import CourseMode
 from courseware import courses
 from enrollment.api import add_enrollment
-from enrollment.views import EnrollmentCrossDomainSessionAuth
 from openedx.core.djangoapps.commerce.utils import ecommerce_api_client
 from openedx.core.djangoapps.embargo import api as embargo_api
 from openedx.core.djangoapps.user_api.preferences.api import update_email_opt_in
-from openedx.core.lib.api.authentication import OAuth2AuthenticationAllowInactiveUser
+from openedx.core.lib.api.view_utils import view_auth_classes
 from student.models import CourseEnrollment
 from util.json_request import JsonResponse
 
@@ -28,12 +27,9 @@ log = logging.getLogger(__name__)
 SAILTHRU_CAMPAIGN_COOKIE = 'sailthru_bid'
 
 
+@view_auth_classes()
 class BasketsView(APIView):
     """ Creates a basket with a course seat and enrolls users. """
-
-    # LMS utilizes User.user_is_active to indicate email verification, not whether an account is active. Sigh!
-    authentication_classes = (EnrollmentCrossDomainSessionAuth, OAuth2AuthenticationAllowInactiveUser)
-    permission_classes = (IsAuthenticated,)
 
     def _is_data_valid(self, request):
         """

--- a/lms/djangoapps/course_goals/views.py
+++ b/lms/djangoapps/course_goals/views.py
@@ -8,10 +8,10 @@ from django.conf import settings
 from django.db.models.signals import post_save
 from django.dispatch import receiver
 from django.http import JsonResponse
-from edx_rest_framework_extensions.authentication import JwtAuthentication
 from eventtracking import tracker
 from opaque_keys.edx.keys import CourseKey
 from openedx.core.lib.api.permissions import IsStaffOrOwner
+from openedx.core.lib.api.view_utils import view_auth_classes
 from rest_framework import permissions, serializers, viewsets, status
 from rest_framework.authentication import SessionAuthentication
 from rest_framework.response import Response
@@ -34,6 +34,7 @@ class CourseGoalSerializer(serializers.ModelSerializer):
         fields = ('user', 'course_key', 'goal_key')
 
 
+@view_auth_classes(permission_classes=(IsStaffOrOwner,))
 class CourseGoalViewSet(viewsets.ModelViewSet):
     """
     API calls to create and update a course goal.
@@ -52,8 +53,6 @@ class CourseGoalViewSet(viewsets.ModelViewSet):
     Returns Http400 response if the course_key does not map to a known
     course or if the goal_key does not map to a valid goal key.
     """
-    authentication_classes = (JwtAuthentication, SessionAuthentication,)
-    permission_classes = (permissions.IsAuthenticated, IsStaffOrOwner,)
     queryset = CourseGoal.objects.all()
     serializer_class = CourseGoalSerializer
 

--- a/lms/djangoapps/course_structure_api/v0/views.py
+++ b/lms/djangoapps/course_structure_api/v0/views.py
@@ -4,14 +4,10 @@ import logging
 
 from django.conf import settings
 from django.http import Http404
-from edx_rest_framework_extensions.authentication import JwtAuthentication
 from opaque_keys.edx.keys import CourseKey
-from rest_framework.authentication import SessionAuthentication
 from rest_framework.exceptions import AuthenticationFailed
 from rest_framework.generics import RetrieveAPIView, ListAPIView
-from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
-from rest_framework_oauth.authentication import OAuth2Authentication
 from xmodule.modulestore.django import modulestore
 
 from course_structure_api.v0 import serializers
@@ -19,18 +15,18 @@ from courseware import courses
 from courseware.access import has_access
 from openedx.core.djangoapps.content.course_structures.api.v0 import api, errors
 from openedx.core.lib.exceptions import CourseNotFoundError
+from openedx.core.lib.api.view_utils import view_auth_classes
 from student.roles import CourseInstructorRole, CourseStaffRole
 
 log = logging.getLogger(__name__)
 
 
+@view_auth_classes()
 class CourseViewMixin(object):
     """
     Mixin for views dealing with course content. Also handles authorization and authentication.
     """
     lookup_field = 'course_id'
-    authentication_classes = (JwtAuthentication, OAuth2Authentication, SessionAuthentication,)
-    permission_classes = (IsAuthenticated,)
 
     def get_course_or_404(self):
         """

--- a/lms/djangoapps/experiments/tests/test_views.py
+++ b/lms/djangoapps/experiments/tests/test_views.py
@@ -215,20 +215,20 @@ class ExperimentKeyValueViewSetTests(APITestCase):
         """ Staff access is required for write operations. """
         url = reverse('api_experiments:v0:key_value-list')
 
+        user = UserFactory()
+        self.client.login(username=user.username, password=UserFactory._DEFAULT_PASSWORD)
+
         response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
 
         response = self.client.post(url, {})
-        self.assertEqual(response.status_code, 401)
+        self.assertEqual(response.status_code, 403)
 
         instance = ExperimentKeyValueFactory()
         url = reverse('api_experiments:v0:key_value-detail', kwargs={'pk': instance.id})
 
         response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
-
-        user = UserFactory(is_staff=False)
-        self.client.login(username=user.username, password=UserFactory._DEFAULT_PASSWORD)
 
         response = self.client.put(url, {})
         self.assertEqual(response.status_code, 403)

--- a/lms/djangoapps/experiments/views.py
+++ b/lms/djangoapps/experiments/views.py
@@ -1,7 +1,6 @@
 from django.contrib.auth import get_user_model
 from django.db import transaction
 from django_filters.rest_framework import DjangoFilterBackend
-from edx_rest_framework_extensions.authentication import JwtAuthentication
 from rest_framework import permissions, viewsets
 from rest_framework.decorators import list_route
 from rest_framework.response import Response
@@ -9,16 +8,15 @@ from rest_framework.response import Response
 from experiments import filters, serializers
 from experiments.models import ExperimentData, ExperimentKeyValue
 from experiments.permissions import IsStaffOrOwner, IsStaffOrReadOnly
-from openedx.core.lib.api.authentication import SessionAuthenticationAllowInactiveUser
+from openedx.core.lib.api.view_utils import view_auth_classes
 
 User = get_user_model()  # pylint: disable=invalid-name
 
 
+@view_auth_classes(permission_classes=(IsStaffOrOwner,))
 class ExperimentDataViewSet(viewsets.ModelViewSet):
-    authentication_classes = (JwtAuthentication, SessionAuthenticationAllowInactiveUser,)
     filter_backends = (DjangoFilterBackend,)
     filter_class = filters.ExperimentDataFilter
-    permission_classes = (permissions.IsAuthenticated, IsStaffOrOwner,)
     queryset = ExperimentData.objects.all()
     serializer_class = serializers.ExperimentDataSerializer
     _cached_users = {}
@@ -82,11 +80,10 @@ class ExperimentDataViewSet(viewsets.ModelViewSet):
             return Response(serializer.data)
 
 
+@view_auth_classes(permission_classes=(IsStaffOrReadOnly,))
 class ExperimentKeyValueViewSet(viewsets.ModelViewSet):
-    authentication_classes = (JwtAuthentication, SessionAuthenticationAllowInactiveUser,)
     filter_backends = (DjangoFilterBackend,)
     filter_class = filters.ExperimentKeyValueFilter
-    permission_classes = (IsStaffOrReadOnly,)
     queryset = ExperimentKeyValue.objects.all()
     serializer_class = serializers.ExperimentKeyValueSerializer
 

--- a/lms/djangoapps/mobile_api/decorators.py
+++ b/lms/djangoapps/mobile_api/decorators.py
@@ -58,4 +58,4 @@ def mobile_view(is_user=False):
     """
     Function and class decorator that abstracts the authentication and permission checks for mobile api views.
     """
-    return view_auth_classes(is_user)
+    return view_auth_classes(is_user_in_url=is_user)

--- a/openedx/core/djangoapps/api_admin/api/v1/views.py
+++ b/openedx/core/djangoapps/api_admin/api/v1/views.py
@@ -3,17 +3,15 @@ API Views.
 """
 from django_filters.rest_framework import DjangoFilterBackend
 
-from edx_rest_framework_extensions.authentication import JwtAuthentication
-from rest_framework.authentication import SessionAuthentication
-from rest_framework.permissions import IsAuthenticated
 from rest_framework.generics import ListAPIView
-from rest_framework_oauth.authentication import OAuth2Authentication
 
 from openedx.core.djangoapps.api_admin.api.v1 import serializers as api_access_serializers
 from openedx.core.djangoapps.api_admin.models import ApiAccessRequest
 from openedx.core.djangoapps.api_admin.api.filters import IsOwnerOrStaffFilterBackend
+from openedx.core.lib.api.view_utils import view_auth_classes
 
 
+@view_auth_classes()
 class ApiAccessRequestView(ListAPIView):
     """
     Return `API Access Requests` in the form of a paginated list.
@@ -49,8 +47,6 @@ class ApiAccessRequestView(ListAPIView):
             "previous": null
         }
     """
-    authentication_classes = (JwtAuthentication, OAuth2Authentication, SessionAuthentication,)
-    permission_classes = (IsAuthenticated, )
     serializer_class = api_access_serializers.ApiAccessRequestSerializer
     filter_backends = (IsOwnerOrStaffFilterBackend, DjangoFilterBackend)
 

--- a/openedx/core/djangoapps/cors_csrf/authentication.py
+++ b/openedx/core/djangoapps/cors_csrf/authentication.py
@@ -8,28 +8,25 @@ from rest_framework import authentication
 from .helpers import is_cross_domain_request_allowed, skip_cross_domain_referer_check
 
 
-class SessionAuthenticationCrossDomainCsrf(authentication.SessionAuthentication):
+class SessionAuthenticationCorsCSRFMixin(object):
     """
-    Session authentication that skips the referer check over secure connections.
+    Session authentication Mixin that skips the referer check over secure connections.
 
     Django Rest Framework's `SessionAuthentication` class calls Django's
     CSRF middleware implementation directly, which bypasses the middleware
     stack.
 
-    This version of `SessionAuthentication` performs the same workaround
+    This Mixin for `SessionAuthentication` performs the same workaround
     as `CorsCSRFMiddleware` to skip the referer check for whitelisted
     domains over a secure connection.  See `cors_csrf.middleware` for
     more information.
-
-    Since this subclass overrides only the `enforce_csrf()` method,
-    it can be mixed in with other `SessionAuthentication` subclasses.
     """
     # TODO: Remove Django 1.11 upgrade shim
     # SHIM: Call new process_request in Django 1.11 to process CSRF token in cookie.
     def _process_enforce_csrf(self, request):
         if django.VERSION >= (1, 11):
             CsrfViewMiddleware().process_request(request)
-        return super(SessionAuthenticationCrossDomainCsrf, self).enforce_csrf(request)
+        return super(SessionAuthenticationCorsCSRFMixin, self).enforce_csrf(request)
 
     def enforce_csrf(self, request):
         """

--- a/openedx/core/djangoapps/cors_csrf/tests/test_authentication.py
+++ b/openedx/core/djangoapps/cors_csrf/tests/test_authentication.py
@@ -7,14 +7,19 @@ from django.test.utils import override_settings
 from django.test.client import RequestFactory
 from django.conf import settings
 
+from rest_framework.authentication import SessionAuthentication
 from rest_framework.exceptions import PermissionDenied
 
-from ..authentication import SessionAuthenticationCrossDomainCsrf
+from ..authentication import SessionAuthenticationCorsCSRFMixin
 
 
 # A class to pass into django.middleware.csrf.get_token() so we can easily get a valid CSRF token to use.
 class FakeRequest(object):
     META = {}
+
+
+class CrossDomainSessionAuthentication(SessionAuthenticationCorsCSRFMixin, SessionAuthentication):
+    pass
 
 
 class CrossDomainAuthTest(TestCase):
@@ -25,7 +30,7 @@ class CrossDomainAuthTest(TestCase):
 
     def setUp(self):
         super(CrossDomainAuthTest, self).setUp()
-        self.auth = SessionAuthenticationCrossDomainCsrf()
+        self.auth = CrossDomainSessionAuthentication()
         self.csrf_token = get_token(FakeRequest())
 
     def test_perform_csrf_referer_check(self):

--- a/openedx/core/djangoapps/user_api/verification_api/views.py
+++ b/openedx/core/djangoapps/user_api/verification_api/views.py
@@ -1,19 +1,16 @@
 """ Verification API v1 views. """
 from django.http import Http404
-from edx_rest_framework_extensions.authentication import JwtAuthentication
-from rest_framework.authentication import SessionAuthentication
 from rest_framework.generics import RetrieveAPIView
-from rest_framework_oauth.authentication import OAuth2Authentication
 
 from lms.djangoapps.verify_student.models import SoftwareSecurePhotoVerification
 from openedx.core.djangoapps.user_api.serializers import SoftwareSecurePhotoVerificationSerializer
 from openedx.core.lib.api.permissions import IsStaffOrOwner
+from openedx.core.lib.api.view_utils import view_auth_classes
 
 
+@view_auth_classes(permission_classes=(IsStaffOrOwner,))
 class PhotoVerificationStatusView(RetrieveAPIView):
     """ PhotoVerificationStatus detail endpoint. """
-    authentication_classes = (JwtAuthentication, OAuth2Authentication, SessionAuthentication,)
-    permission_classes = (IsStaffOrOwner,)
     serializer_class = SoftwareSecurePhotoVerificationSerializer
 
     def get_object(self):

--- a/openedx/core/lib/api/authentication.py
+++ b/openedx/core/lib/api/authentication.py
@@ -8,6 +8,7 @@ from provider.oauth2 import models as dop_models
 from rest_framework.exceptions import AuthenticationFailed
 from rest_framework.authentication import SessionAuthentication
 from rest_framework_oauth.authentication import OAuth2Authentication
+from openedx.core.djangoapps.cors_csrf.authentication import SessionAuthenticationCorsCSRFMixin
 
 
 OAUTH2_TOKEN_ERROR = u'token_error'
@@ -20,7 +21,7 @@ OAUTH2_TOKEN_ERROR_NOT_PROVIDED = u'token_not_provided'
 log = logging.getLogger(__name__)
 
 
-class SessionAuthenticationAllowInactiveUser(SessionAuthentication):
+class SessionAuthenticationAllowInactiveUser(SessionAuthenticationCorsCSRFMixin, SessionAuthentication):
     """Ensure that the user is logged in, but do not require the account to be active.
 
     We use this in the special case that a user has created an account,

--- a/openedx/core/lib/api/view_utils.py
+++ b/openedx/core/lib/api/view_utils.py
@@ -18,7 +18,7 @@ from openedx.core.lib.api.authentication import (
     OAuth2AuthenticationAllowInactiveUser,
     SessionAuthenticationAllowInactiveUser
 )
-from openedx.core.lib.api.permissions import IsUserInUrl
+from openedx.core.lib.api.permissions import IsUserInUrlOrStaff
 
 
 class DeveloperErrorViewMixin(object):
@@ -84,7 +84,16 @@ class ExpandableFieldViewMixin(object):
         return result
 
 
-def view_auth_classes(is_user=False, is_authenticated=True):
+BASE_AUTHENTICATION_CLASSES = (
+    JwtAuthentication,
+    OAuth2AuthenticationAllowInactiveUser,
+    SessionAuthenticationAllowInactiveUser,
+)
+
+BASE_PERMISSION_CLASSES = ()
+
+
+def view_auth_classes(is_user_in_url=False, is_authenticated=True, permission_classes=None):
     """
     Function and class decorator that abstracts the authentication and permission checks for api views.
     """
@@ -93,16 +102,14 @@ def view_auth_classes(is_user=False, is_authenticated=True):
         Requires either OAuth2 or Session-based authentication.
         If is_user is True, also requires username in URL matches the request user.
         """
-        func_or_class.authentication_classes = (
-            JwtAuthentication,
-            OAuth2AuthenticationAllowInactiveUser,
-            SessionAuthenticationAllowInactiveUser
-        )
-        func_or_class.permission_classes = ()
+        func_or_class.authentication_classes = BASE_AUTHENTICATION_CLASSES
+        func_or_class.permission_classes = BASE_PERMISSION_CLASSES
+        if permission_classes:
+            func_or_class.permission_classes += permission_classes
         if is_authenticated:
             func_or_class.permission_classes += (IsAuthenticated,)
-        if is_user:
-            func_or_class.permission_classes += (IsUserInUrl,)
+        if is_user_in_url:
+            func_or_class.permission_classes += (IsUserInUrlOrStaff,)
         return func_or_class
     return _decorator
 


### PR DESCRIPTION
This PR is intended to be a [runway](http://www.scaledagileframework.com/architectural-runway/) for [incoming work related to enforcing OAuth scopes](https://github.com/edx/edx-platform/blob/master/openedx/core/djangoapps/oauth_dispatch/docs/decisions/0006-enforce-scopes-in-LMS-APIs.rst).

This PR updates our endpoints to use a common python decorator for declaring required `Authentication`/`Permission` classes.   It updates only those endpoints that use `JwtAuthentication`.  Eventually, we will want to update all endpoints so we can standardize on a single mechanism.

This is needed because the Django framework doesn't allow us to configure `Permission` classes that *must* be enforced by all endpoints.  Although it supports a [DEFAULT_PERMISSION_CLASSES](http://www.django-rest-framework.org/api-guide/permissions/#setting-the-permission-policy) setting, any endpoint can choose to override and not use the defaults.  By having a common decorator, we can include/update authentication/permission classes for all participating endpoints.

The PR makes use of the `view_auth_classes` decorator that already existed in `openedx/core/lib/api/view_utils.py`.