### PR TITLE
Stop using our fork of paver and use PyPI

### DIFF
--- a/requirements/edx/paver.txt
+++ b/requirements/edx/paver.txt
@@ -1,5 +1,5 @@
 # Requirements to run and test Paver
-git+https://github.com/jzoldak/paver.git@b72ccd7b638c1e07105d04f670170b3a37095d10#egg=Paver==1.2.4a
+paver==1.3.4
 libsass==0.10.0
 markupsafe
 -r base_common.txt


### PR DESCRIPTION
The problem we were having with paver 1.2.4 has been fixed and so we can go back to using the mainline paver now.

https://openedx.atlassian.net/browse/TE-2387

https://github.com/paver/paver/blob/master/docs/source/changelog.rst