### PR TITLE
Update iframe allowances for chrome v64

### DIFF
--- a/lms/templates/lti.html
+++ b/lms/templates/lti.html
@@ -48,6 +48,7 @@ from django.utils.translation import ugettext as _
             allowfullscreen="true"
             webkitallowfullscreen="true"
             mozallowfullscreen="true"
+            allow="microphone *; camera *; midi *; geolocation *; encrypted-media *"
         ></iframe>
     % endif
 % elif not hide_launch:

--- a/requirements/edx/github.txt
+++ b/requirements/edx/github.txt
@@ -96,7 +96,7 @@ git+https://github.com/edx/edx-milestones.git@v0.1.11#egg=edx-milestones==0.1.11
 git+https://github.com/edx/xblock-utils.git@v1.0.5#egg=xblock-utils==1.0.5
 -e git+https://github.com/edx-solutions/xblock-google-drive.git@138e6fa0bf3a2013e904a085b9fed77dab7f3f21#egg=xblock-google-drive
 git+https://github.com/edx/edx-user-state-client.git@1.0.2#egg=edx-user-state-client==1.0.2
-git+https://github.com/edx/xblock-lti-consumer.git@v1.1.6#egg=lti_consumer-xblock==1.1.6
+git+https://github.com/edx/xblock-lti-consumer.git@v1.1.7#egg=lti_consumer-xblock==1.1.7
 # This is here because all of the other XBlocks are located here. However, it is published to PyPI and will be installed that way
 xblock-review==1.1.4
 git+https://github.com/edx/edx-analytics-data-api-client.git@0.13.0#egg=edx-analytics-data-api-client==0.13.0


### PR DESCRIPTION
## [EDUCATOR-2273](https://openedx.atlassian.net/browse/EDUCATOR-2273)

### Description
Due to a chrome update some of our LTI blocks are broken in chrome. See documentation here: https://dev.chromium.org/Home/chromium-security/deprecating-permissions-in-cross-origin-iframes
**This PR is blocked by: https://github.com/edx/xblock-lti-consumer/pull/37**

### Reviewers
If you've been tagged for review, please check your corresponding box once you've given the :+1:.
- [x] Code review: @awaisdar001 
- [x] Code review: @efischer19   

FYI: @edx/educator-escalation 

### Post-review
- [ ] Rebase and squash commits