### PR TITLE
Add context to 'enroll' word

### DIFF
--- a/conf/locale/en/LC_MESSAGES/django.po
+++ b/conf/locale/en/LC_MESSAGES/django.po
@@ -11663,9 +11663,14 @@ msgstr ""
 msgid "You should Register before trying to access the Unit"
 msgstr ""
 
-#: lms/templates/enroll_staff.html lms/templates/ccx/enrollment.html
 #: lms/templates/courseware/course_about.html
+msgctxt "self"
+msgid "Enroll"
+msgstr ""
+
+#: lms/templates/enroll_staff.html lms/templates/ccx/enrollment.html
 #: lms/templates/instructor/instructor_dashboard_2/membership.html
+msgctxt "someone"
 msgid "Enroll"
 msgstr ""
 

--- a/lms/templates/ccx/enrollment.html
+++ b/lms/templates/ccx/enrollment.html
@@ -1,6 +1,7 @@
 <%page expression_filter="h"/>
 <%!
 from django.utils.translation import ugettext as _
+from django.utils.translation import pgettext
 from openedx.core.djangolib.markup import HTML, Text
 %>
 
@@ -53,7 +54,7 @@ from openedx.core.djangolib.markup import HTML, Text
   </div>
 
   <div>
-    <input type="submit" name="enrollment-button" class="enrollment-button" value="${_("Enroll")}">
+    <input type="submit" name="enrollment-button" class="enrollment-button" value="${pgettext('someone','Enroll')}">
     <input type="submit" name="enrollment-button" class="enrollment-button" value="${_("Unenroll")}">
   </div>
   <div class="request-response"></div>

--- a/lms/templates/courseware/course_about.html
+++ b/lms/templates/courseware/course_about.html
@@ -1,6 +1,7 @@
 <%namespace name='static' file='../static_content.html'/>
 <%!
 from django.utils.translation import ugettext as _
+from django.utils.translation import pgettext
 from django.core.urlresolvers import reverse
 from courseware.courses import get_course_about_section
 from django.conf import settings
@@ -336,12 +337,12 @@ from six import string_types
   <div style="display: none;">
     <form id="class_enroll_form" method="post" data-remote="true" action="${reverse('change_enrollment')}">
       <fieldset class="enroll_fieldset">
-        <legend class="sr">${_("Enroll")}</legend>
+        <legend class="sr">${pgettext("self","Enroll")}</legend>
         <input name="course_id" type="hidden" value="${course.id | h}">
         <input name="enrollment_action" type="hidden" value="enroll">
       </fieldset>
       <div class="submit">
-        <input name="submit" type="submit" value="${_('enroll')}">
+        <input name="submit" type="submit" value="${pgettext('self','enroll')}">
       </div>
     </form>
   </div>

--- a/lms/templates/enroll_staff.html
+++ b/lms/templates/enroll_staff.html
@@ -3,6 +3,7 @@
 <%namespace name='static' file='static_content.html'/>
 <%!
     from django.utils.translation import ugettext as _
+    from django.utils.translation import pgettext
     from courseware.courses import get_course_about_section
 %>
 
@@ -30,7 +31,7 @@
                             <input type="hidden" name="csrfmiddlewaretoken" value="${ csrftoken }"/>
                             <div class="main-cta">
                                 <button class="register" name="enroll" type="submit"
-                                        value="${_('Enroll')}">${_('Enroll')}<span
+                                        value="${pgettext('self','Enroll')}">${pgettext('self','Enroll')}<span
                                         class="sr">${course.display_name_with_default}</span></button>
                                 <button class="register" name="dont_enroll" type="submit"
                                         value="${_('Don\'t enroll')}">${_('Don\'t enroll')}<span

--- a/lms/templates/instructor/instructor_dashboard_2/membership.html
+++ b/lms/templates/instructor/instructor_dashboard_2/membership.html
@@ -2,6 +2,7 @@
 <%namespace name='static' file='/static_content.html'/>
 <%!
 from django.utils.translation import ugettext as _
+from django.utils.translation import pgettext
 from openedx.core.djangolib.markup import HTML, Text
 %>
 <fieldset class="batch-enrollment membership-section">
@@ -49,7 +50,7 @@ from openedx.core.djangolib.markup import HTML, Text
         </label>
     </div>
     <div>
-        <input type="button" name="enrollment-button" class="enrollment-button" value="${_("Enroll")}" data-endpoint="${ section_data['enroll_button_url'] }" data-action="enroll" >
+        <input type="button" name="enrollment-button" class="enrollment-button" value="${pgettext('someone','Enroll')}" data-endpoint="${ section_data['enroll_button_url'] }" data-action="enroll" >
         <input type="button" name="enrollment-button" class="enrollment-button" value="${_("Unenroll")}" data-endpoint="${ section_data['unenroll_button_url'] }" data-action="unenroll" >
     </div>
     <div class="request-response"></div>


### PR DESCRIPTION
[OSPR-2221 ](https://openedx.atlassian.net/browse/OSPR-2221)

The `enroll` word can have a different context in different languages. For example when you enroll someone or when you enroll yourself. This PR address this issue by using `pgettext` on the templates that have this word.

### Reviewers
- [ ] Code review: @tomaszgy  
- [ ] Code review: @pomegranited 

cc @nedbat  

