### PR TITLE
Fixes error caused by invalid Anonymous User passed to a view.

### DIFF
--- a/openedx/core/djangoapps/user_api/tests/test_views.py
+++ b/openedx/core/djangoapps/user_api/tests/test_views.py
@@ -2499,6 +2499,18 @@ class UpdateEmailOptInTestCase(UserAPITestCase, SharedModuleStoreTestCase):
         )
         self.assertEquals(preference.value, u"True")
 
+    def test_update_email_opt_in_anonymous_user(self):
+        """
+        Test that an anonymous user gets 403 response when
+        updating email optin preference.
+        """
+        self.client.logout()
+        response = self.client.post(self.url, {
+            "course_id": unicode(self.course.id),
+            "email_opt_in": u"True"
+        })
+        self.assertEqual(response.status_code, 403)
+
     def test_update_email_opt_with_invalid_course_key(self):
         """
         Test that with invalid key it returns bad request

--- a/openedx/core/djangoapps/user_api/views.py
+++ b/openedx/core/djangoapps/user_api/views.py
@@ -14,6 +14,7 @@ from opaque_keys.edx.keys import CourseKey
 from rest_framework import authentication, generics, status, viewsets
 from rest_framework.exceptions import ParseError
 from rest_framework.views import APIView
+from rest_framework.permissions import IsAuthenticated
 from six import text_type
 
 import accounts
@@ -256,6 +257,7 @@ class PreferenceUsersListView(generics.ListAPIView):
 class UpdateEmailOptInPreference(APIView):
     """View for updating the email opt in preference. """
     authentication_classes = (SessionAuthenticationAllowInactiveUser,)
+    permission_classes = (IsAuthenticated,)
 
     @method_decorator(require_post_params(["course_id", "email_opt_in"]))
     @method_decorator(ensure_csrf_cookie)


### PR DESCRIPTION
This patch would fix the case when an anonymous object is
getting passed to view causing "TypeError: int() argument must
be a string or a number, not 'AnonymousUser'" exception. Applying a
permission class would force user to be an authenticated
user otherwise would get a 403 response.

LEARNER-4162