### PR TITLE
increase limit for staff users

### DIFF
--- a/common/djangoapps/enrollment/views.py
+++ b/common/djangoapps/enrollment/views.py
@@ -76,7 +76,7 @@ class EnrollmentUserThrottle(UserRateThrottle, ApiKeyPermissionMixIn):
     """Limit the number of requests users can make to the enrollment API."""
     THROTTLE_RATES = {
         'user': '40/minute',
-        'staff': '600/minute',
+        'staff': '1200/minute',
     }
 
     def allow_request(self, request, view):


### PR DESCRIPTION
Increased purchases is causing rate limit errors.  Need to up the limit so ecommerce can get leaner enrollments.
