### PR TITLE
bump enterprise version to 0.65.6

### DIFF
--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -56,7 +56,7 @@ git+https://github.com/cpennington/pylint-django@fix-field-inference-during-monk
 enum34==1.1.6
 edx-django-oauth2-provider==1.2.5
 edx-django-sites-extensions==2.3.0
-edx-enterprise==0.65.3
+edx-enterprise==0.65.6
 edx-milestones==0.1.13
 edx-oauth2-provider==1.2.2
 edx-organizations==0.4.9


### PR DESCRIPTION
@asadiqbal08 @saleem-latif 

**Here is the list of changes for enterprise:**
* Add functionality in enterprise django admin for transmitting courses metadata related to a specific enterprise.
* Remove custom method `select_renderer` for enterprise API view `EnterpriseCustomerCatalogViewSet`.
* Indicate when a course is no longer open for enrollment by updating course title for transmit courses metadata (Need to update).


Here is the commits list from version `0.65.3` to `0.65.6`: https://github.com/edx/edx-enterprise/compare/0.65.3...0.65.6