### PR TITLE
Fix broken link in comment

### DIFF
--- a/common/lib/xmodule/setup.py
+++ b/common/lib/xmodule/setup.py
@@ -61,7 +61,7 @@ setup(
         'xmodule': ['js/module/*'],
     },
 
-    # See http://guide.python-distribute.org/creation.html#entry-points
+    # See http://setuptools.readthedocs.io/en/latest/setuptools.html#dynamic-discovery-of-services-and-plugins
     # for a description of entry_points
     entry_points={
         'xblock.v1': XMODULES + XBLOCKS,


### PR DESCRIPTION
It looks like the old link no longer works, when I clicked on it it redirects to a spam site. I replaced it with a new link to the setuptools docs