### PR TITLE
Run tests from scripts directory in CI

### DIFF
--- a/pavelib/utils/envs.py
+++ b/pavelib/utils/envs.py
@@ -208,6 +208,7 @@ class Env(object):
         if dir_name.isdir() and not dir_name.endswith(IGNORED_TEST_DIRS):
             LIB_TEST_DIRS.append(path("common/lib") / item.basename())
     LIB_TEST_DIRS.append(path("pavelib/paver_tests"))
+    LIB_TEST_DIRS.append(path("scripts/xsslint/tests"))
 
     # Directory for i18n test reports
     I18N_REPORT_DIR = REPORT_DIR / 'i18n'


### PR DESCRIPTION
Adds scripts/xsslint/tests dir to paver's `LIB_TEST_DIRS` so that they can be run in CI.