### PR TITLE
updated correct map when new score is calculated

### DIFF
--- a/common/lib/xmodule/xmodule/tests/test_capa_module.py
+++ b/common/lib/xmodule/xmodule/tests/test_capa_module.py
@@ -1095,31 +1095,35 @@ class CapaModuleTest(unittest.TestCase):
     def test_rescore_problem_additional_correct(self):
         # make sure it also works when new correct answer has been added
         module = CapaFactory.create(attempts=0)
+        answer_id = CapaFactory.answer_key()
 
-        # Simulate that all answers are marked correct, no matter
-        # what the input is, by patching CorrectMap.is_correct()
-        with patch('capa.correctmap.CorrectMap.is_correct') as mock_is_correct:
-                mock_is_correct.return_value = True
+        # Check the problem
+        get_request_dict = {CapaFactory.input_key(): '1'}
+        result = module.submit_problem(get_request_dict)
 
-                # Check the problem
-                get_request_dict = {CapaFactory.input_key(): '1'}
-                result = module.submit_problem(get_request_dict)
-
-        # Expect that the problem is marked correct
-        self.assertEqual(result['success'], 'correct')
+        # Expect that the problem is marked incorrect and user didn't earn score
+        self.assertEqual(result['success'], 'incorrect')
+        self.assertEqual(module.get_score(), (0, 1))
+        self.assertEqual(module.correct_map[answer_id]['correctness'], 'incorrect')
         # Expect that the number of attempts is incremented
         self.assertEqual(module.attempts, 1)
-        self.assertEqual(module.get_score(), (1, 1))
 
-        # Simulate that after adding a new correct answer the new calculated score is (0,1)
-        # by patching CapaMixin.calculate_score()
-        # In case of rescore with only_if_higher=True it should not update score of module
-        # if previous score was higher
-        with patch('xmodule.capa_base.CapaMixin.calculate_score') as mock_calculate_score:
-            mock_calculate_score.return_value = Score(raw_earned=0, raw_possible=1)
-            module.rescore(only_if_higher=True)
-        self.assertEqual(module.get_score(), (1, 1))
+        # Simulate that after making an incorrect answer to the correct answer
+        # the new calculated score is (1,1)
+        # by patching CorrectMap.is_correct() and NumericalResponse.get_staff_ans()
+        # In case of rescore with only_if_higher=True it should update score of module
+        # if previous score was lower
 
+        with patch('capa.correctmap.CorrectMap.is_correct') as mock_is_correct:
+            mock_is_correct.return_value = True
+            module.set_score(module.score_from_lcp())
+            with patch('capa.responsetypes.NumericalResponse.get_staff_ans') as get_staff_ans:
+                get_staff_ans.return_value = 1 + 0j
+                module.rescore(only_if_higher=True)
+
+        # Expect that the problem is marked correct and user earned the score
+        self.assertEqual(module.get_score(), (1, 1))
+        self.assertEqual(module.correct_map[answer_id]['correctness'], 'correct')
         # Expect that the number of attempts is not incremented
         self.assertEqual(module.attempts, 1)
 


### PR DESCRIPTION
# [EDUCATOR-1932](https://openedx.atlassian.net/browse/EDUCATOR-1932)

### Description
This PR updates the correct map of the problem when new score is calculated.

### How to Test?
**Production**

- Go to https://courses.edx.org/courses/course-v1:ASUx+TGM505x+2T2017/courseware/b4a455082cc043578176e7fa42e7128e/5b4a0b178df5405f860cfb568525066b/?activate_block_id=block-v1%3AASUx%2BTGM505x%2B2T2017%2Btype%40sequential%2Bblock%405b4a0b178df5405f860cfb568525066b
- View the course as user 'APreddy'
- After rescoring, multiple choice problem with the question "According to the article, The Greek Crisis: Many Lessons for All, one of the causes of Greece’s financial crisis was:" shows the incorrect red X.

**Sandbox**

- Go to https://rabia23.sandbox.edx.org/courses/course-v1:edX+DemoX+Demo_Course/courseware/d8a715d909384b15bab2c458abeb7708/8b693b6f803f4db38eeae28f0ab9cf8e/1?activate_block_id=block-v1%3AedX%2BDemoX%2BDemo_Course%2Btype%40vertical%2Bblock%409fdea04a6f504bf6be914f966bf1fce4
- View the course as user 'audit'
- After rescoring, problem shows the correct green checkmark.

**Screenshots**

Before Fix
<img width="1125" alt="screen shot 2018-04-17 at 5 41 26 pm" src="https://user-images.githubusercontent.com/13939335/38870304-db7379b8-4266-11e8-9f70-b8ee790c476e.png">

After Fix
<img width="1165" alt="screen shot 2018-04-17 at 5 41 40 pm" src="https://user-images.githubusercontent.com/13939335/38870312-e2dbeb5e-4266-11e8-8775-203f0e1ed2f9.png">

### Test
- [x] Unit Test

### Reviewers
If you've been tagged for review, please check your corresponding box once you've given the :+1:.
- [x] Code review: @sanfordstudent   
- [x] Code review: @attiyaIshaque 

### Post-review
- [x] Rebase and squash commits