### PR TITLE
wait for uploads in bokchoy test to avoid popup hang

### DIFF
--- a/common/test/acceptance/tests/studio/test_import_export.py
+++ b/common/test/acceptance/tests/studio/test_import_export.py
@@ -218,6 +218,7 @@ class ImportTestMixin(object):
             A button will appear that contains the URL to the library or course's main page
         """
         self.import_page.upload_tarball(self.tarball_name)
+        self.import_page.wait_for_upload()
         self.assertEqual(self.import_page.finished_target_url(), self.landing_page.url)
 
     def test_bad_filename_error(self):
@@ -242,6 +243,7 @@ class ImportTestMixin(object):
         self.assertFalse(self.import_page.is_task_list_showing(), "Task list shown too early.")
         self.import_page.wait_for_tasks()
         self.import_page.upload_tarball(self.tarball_name)
+        self.import_page.wait_for_upload()
         self.import_page.wait_for_tasks(completed=True)
         self.assertTrue(self.import_page.is_task_list_showing(), "Task list did not display.")
 


### PR DESCRIPTION
A few of the course import tests were hanging indefinitely when run with Firefox 57. A javascript alert was causing a pop to lose browser focus, most likely because we were asserting on something that was available before the upload had finished. This just waits for the upload to finish before actually testing that the uploaded course is available.