### PR TITLE
Assign new sailthru var upon signup.

### DIFF
--- a/lms/djangoapps/email_marketing/signals.py
+++ b/lms/djangoapps/email_marketing/signals.py
@@ -3,6 +3,7 @@ This module contains signals needed for email integration
 """
 import datetime
 import logging
+from random import randint
 
 import crum
 from django.conf import settings
@@ -210,6 +211,7 @@ def _create_sailthru_user_vars(user, profile, registration=None):
 
     if registration:
         sailthru_vars['activation_key'] = registration.activation_key
+        sailthru_vars['signupNumber'] = randint(0, 9)
 
     return sailthru_vars
 

--- a/lms/djangoapps/email_marketing/tests/test_signals.py
+++ b/lms/djangoapps/email_marketing/tests/test_signals.py
@@ -483,6 +483,7 @@ class EmailMarketingTests(TestCase):
         email_marketing_register_user(None, user=self.user, registration=self.registration)
         self.assertTrue(mock_update_user.called)
         self.assertEqual(mock_update_user.call_args[0][0]['activation_key'], self.registration.activation_key)
+        self.assertLessEqual(mock_update_user.call_args[0][0]['signupNumber'], 9)
 
     @patch('lms.djangoapps.email_marketing.tasks.update_user.delay')
     def test_register_user_no_request(self, mock_update_user):


### PR DESCRIPTION
In SailThru, randomly set a var value of 0-9 on each user upon signup.

LEARNER-4177

![screenshot from 2018-02-16 19-06-36](https://user-images.githubusercontent.com/2851134/36311982-da21eea6-134e-11e8-9ff0-c8621d0ee3ca.png)
