### PR TITLE
Loosen login lockout text check

### DIFF
--- a/cms/djangoapps/contentstore/tests/tests.py
+++ b/cms/djangoapps/contentstore/tests/tests.py
@@ -223,7 +223,7 @@ class AuthTestCase(ContentStoreTestCase):
             data = parse_json(resp)
             self.assertFalse(data['success'])
             self.assertIn(
-                'This account has been temporarily locked due to excessive login failures. Try again later.',
+                'This account has been temporarily locked due to excessive login failures.',
                 data['value']
             )
 


### PR DESCRIPTION
On our fork at Stanford, we override the template for the login lockout
to provide additional information. This means that the second sentence
here, `Try again later.` does not immediately follow the first in our
rendering. As a result, this test fails for us.

Instead, by checking for the most important part of the message
(the first sentence), we're able to ensure that:
- the user is still locked out
- the lockout message is shown on the template
- the test does not fail unnecessarily