### PR TITLE
get transcript util

### DIFF
--- a/cms/djangoapps/contentstore/tests/test_transcripts_utils.py
+++ b/cms/djangoapps/contentstore/tests/test_transcripts_utils.py
@@ -755,6 +755,7 @@ class TestGetTranscript(SharedModuleStoreTestCase):
         }
 
         self.srt_mime_type = transcripts_utils.Transcript.mime_types[transcripts_utils.Transcript.SRT]
+        self.sjson_mime_type = transcripts_utils.Transcript.mime_types[transcripts_utils.Transcript.SJSON]
 
         self.user = UserFactory.create()
         self.vertical = ItemFactory.create(category='vertical', parent_location=self.course.location)
@@ -808,7 +809,7 @@ class TestGetTranscript(SharedModuleStoreTestCase):
         )
 
         self.assertEqual(content, self.subs[language])
-        self.assertEqual(filename, 'video_101.srt')
+        self.assertEqual(filename, 'en_video_101.srt')
         self.assertEqual(mimetype, self.srt_mime_type)
 
     def test_get_transcript_from_content_store_for_ur(self):
@@ -820,12 +821,13 @@ class TestGetTranscript(SharedModuleStoreTestCase):
         content, filename, mimetype = transcripts_utils.get_transcript(
             self.course.id,
             self.video.location.block_id,
-            language
+            language,
+            output_format=transcripts_utils.Transcript.SJSON
         )
 
         self.assertEqual(json.loads(content), json.loads(self.subs[language]))
-        self.assertEqual(filename, 'ur_subs_video_101.srt.srt')
-        self.assertEqual(mimetype, self.srt_mime_type)
+        self.assertEqual(filename, 'ur_video_101.sjson')
+        self.assertEqual(mimetype, self.sjson_mime_type)
 
     @patch(
         'openedx.core.djangoapps.video_config.models.VideoTranscriptEnabledFlag.feature_enabled',

--- a/cms/djangoapps/contentstore/tests/test_transcripts_utils.py
+++ b/cms/djangoapps/contentstore/tests/test_transcripts_utils.py
@@ -723,6 +723,7 @@ class TestVideoIdsInfo(unittest.TestCase):
         actual_result = transcripts_utils.get_video_ids_info(edx_video_id, youtube_id_1_0, html5_sources)
         self.assertEqual(actual_result, expected_result)
 
+
 @ddt.ddt
 class TestGetTranscript(SharedModuleStoreTestCase):
     """Tests for `get_transcript` function."""

--- a/cms/djangoapps/contentstore/views/transcripts_ajax.py
+++ b/cms/djangoapps/contentstore/views/transcripts_ajax.py
@@ -163,14 +163,17 @@ def download_transcripts(request):
         log.debug('transcripts are supported only for video" modules.')
         raise Http404
 
-    content, filename, mimetype = get_transcript(
-        item.location.course_key,
-        block_id=item.location.block_id,
-        lang=u'en'
-    )
+    try:
+        content, filename, mimetype = get_transcript(
+            item.location.course_key,
+            block_id=item.location.block_id,
+            lang=u'en'
+        )
+    except NotFoundError:
+        raise Http404
 
     # Construct an HTTP response
-    response = HttpResponse(content, content_type='application/x-subrip; charset=utf-8')
+    response = HttpResponse(content, content_type=mimetype)
     response['Content-Disposition'] = 'attachment; filename="{filename}"'.format(filename=filename)
     return response
 

--- a/cms/djangoapps/contentstore/views/transcripts_ajax.py
+++ b/cms/djangoapps/contentstore/views/transcripts_ajax.py
@@ -149,9 +149,6 @@ def download_transcripts(request):
 
     Raises Http404 if unsuccessful.
     """
-    # locator = request.GET.get('locator')
-    # subs_id = request.GET.get('subs_id')
-
     if not request.GET.get('locator'):
         log.debug('GET data without "locator" property.')
         raise Http404
@@ -166,7 +163,6 @@ def download_transcripts(request):
         log.debug('transcripts are supported only for video" modules.')
         raise Http404
 
-    # import pdb; pdb.set_trace()
     content, filename, mimetype = get_transcript(
         item.location.course_key,
         block_id=item.location.block_id,
@@ -177,40 +173,6 @@ def download_transcripts(request):
     response = HttpResponse(content, content_type='application/x-subrip; charset=utf-8')
     response['Content-Disposition'] = 'attachment; filename="{filename}"'.format(filename=filename)
     return response
-
-    # try:
-    #     if not subs_id:
-    #         raise NotFoundError
-
-    #     filename = subs_id
-    #     content_location = StaticContent.compute_location(
-    #         item.location.course_key,
-    #         'subs_{filename}.srt.sjson'.format(filename=filename),
-    #     )
-    #     input_format = Transcript.SJSON
-    #     transcript_content = contentstore().find(content_location).data
-    # except NotFoundError:
-    #     # Try searching in VAL for the transcript as a last resort
-    #     transcript = None
-    #     if is_val_transcript_feature_enabled_for_course(item.location.course_key):
-    #         transcript = get_video_transcript_content(edx_video_id=item.edx_video_id, language_code=u'en')
-
-    #     if not transcript:
-    #         raise Http404
-
-    #     name_and_extension = os.path.splitext(transcript['file_name'])
-    #     filename, input_format = name_and_extension[0], name_and_extension[1][1:]
-    #     transcript_content = transcript['content']
-
-    # # convert sjson content into srt format.
-    # transcript_content = Transcript.convert(transcript_content, input_format=input_format, output_format=Transcript.SRT)
-    # if not transcript_content:
-    #     raise Http404
-
-    # # Construct an HTTP response
-    # response = HttpResponse(transcript_content, content_type='application/x-subrip; charset=utf-8')
-    # response['Content-Disposition'] = 'attachment; filename="{filename}.srt"'.format(filename=filename)
-    # return response
 
 
 @login_required

--- a/cms/djangoapps/contentstore/views/transcripts_ajax.py
+++ b/cms/djangoapps/contentstore/views/transcripts_ajax.py
@@ -39,6 +39,7 @@ from xmodule.video_module.transcripts_utils import (
     Transcript,
     TranscriptsRequestValidationException,
     youtube_video_transcript_name,
+    get_transcript,
 )
 from xmodule.video_module.transcripts_model_utils import (
     is_val_transcript_feature_enabled_for_course
@@ -148,9 +149,10 @@ def download_transcripts(request):
 
     Raises Http404 if unsuccessful.
     """
-    locator = request.GET.get('locator')
-    subs_id = request.GET.get('subs_id')
-    if not locator:
+    # locator = request.GET.get('locator')
+    # subs_id = request.GET.get('subs_id')
+
+    if not request.GET.get('locator'):
         log.debug('GET data without "locator" property.')
         raise Http404
 
@@ -164,39 +166,51 @@ def download_transcripts(request):
         log.debug('transcripts are supported only for video" modules.')
         raise Http404
 
-    try:
-        if not subs_id:
-            raise NotFoundError
-
-        filename = subs_id
-        content_location = StaticContent.compute_location(
-            item.location.course_key,
-            'subs_{filename}.srt.sjson'.format(filename=filename),
-        )
-        input_format = Transcript.SJSON
-        transcript_content = contentstore().find(content_location).data
-    except NotFoundError:
-        # Try searching in VAL for the transcript as a last resort
-        transcript = None
-        if is_val_transcript_feature_enabled_for_course(item.location.course_key):
-            transcript = get_video_transcript_content(edx_video_id=item.edx_video_id, language_code=u'en')
-
-        if not transcript:
-            raise Http404
-
-        name_and_extension = os.path.splitext(transcript['file_name'])
-        filename, input_format = name_and_extension[0], name_and_extension[1][1:]
-        transcript_content = transcript['content']
-
-    # convert sjson content into srt format.
-    transcript_content = Transcript.convert(transcript_content, input_format=input_format, output_format=Transcript.SRT)
-    if not transcript_content:
-        raise Http404
+    # import pdb; pdb.set_trace()
+    content, filename, mimetype = get_transcript(
+        item.location.course_key,
+        block_id=item.location.block_id,
+        lang=u'en'
+    )
 
     # Construct an HTTP response
-    response = HttpResponse(transcript_content, content_type='application/x-subrip; charset=utf-8')
-    response['Content-Disposition'] = 'attachment; filename="{filename}.srt"'.format(filename=filename)
+    response = HttpResponse(content, content_type='application/x-subrip; charset=utf-8')
+    response['Content-Disposition'] = 'attachment; filename="{filename}"'.format(filename=filename)
     return response
+
+    # try:
+    #     if not subs_id:
+    #         raise NotFoundError
+
+    #     filename = subs_id
+    #     content_location = StaticContent.compute_location(
+    #         item.location.course_key,
+    #         'subs_{filename}.srt.sjson'.format(filename=filename),
+    #     )
+    #     input_format = Transcript.SJSON
+    #     transcript_content = contentstore().find(content_location).data
+    # except NotFoundError:
+    #     # Try searching in VAL for the transcript as a last resort
+    #     transcript = None
+    #     if is_val_transcript_feature_enabled_for_course(item.location.course_key):
+    #         transcript = get_video_transcript_content(edx_video_id=item.edx_video_id, language_code=u'en')
+
+    #     if not transcript:
+    #         raise Http404
+
+    #     name_and_extension = os.path.splitext(transcript['file_name'])
+    #     filename, input_format = name_and_extension[0], name_and_extension[1][1:]
+    #     transcript_content = transcript['content']
+
+    # # convert sjson content into srt format.
+    # transcript_content = Transcript.convert(transcript_content, input_format=input_format, output_format=Transcript.SRT)
+    # if not transcript_content:
+    #     raise Http404
+
+    # # Construct an HTTP response
+    # response = HttpResponse(transcript_content, content_type='application/x-subrip; charset=utf-8')
+    # response['Content-Disposition'] = 'attachment; filename="{filename}.srt"'.format(filename=filename)
+    # return response
 
 
 @login_required

--- a/common/lib/xmodule/xmodule/video_module/transcripts_utils.py
+++ b/common/lib/xmodule/xmodule/video_module/transcripts_utils.py
@@ -15,6 +15,8 @@ from opaque_keys.edx.locator import BlockUsageLocator
 from HTMLParser import HTMLParser
 from six import text_type
 
+from django.http import Http404
+
 from xmodule.modulestore.django import modulestore
 from xmodule.exceptions import NotFoundError
 from xmodule.contentstore.content import StaticContent
@@ -870,10 +872,19 @@ class VideoTranscriptsMixin(object):
             "transcripts": transcripts,
         }
 
-from django.http import Http404, HttpResponse
 
 def get_transcript(course_id, block_id, lang=None):
+    """
+    Get video transcript from content store or edx-val.
 
+    Arguments:
+        course_id (CourseLocator): course identifier
+        block_id (unicode): a unique identifier for an item in modulestore
+        lang (unicode): transcript language
+
+    Returns:
+        tuple containing content, filename, mimetype
+    """
     usage_key = BlockUsageLocator(course_id, block_type='video', block_id=block_id)
     video_descriptor = modulestore().get_item(usage_key)
     feature_enabled = is_val_transcript_feature_enabled_for_course(usage_key.course_key)
@@ -898,8 +909,3 @@ def get_transcript(course_id, block_id, lang=None):
         raise Http404(u"Transcript not found for {}, lang: {}".format(block_id, lang))
 
     return content, filename.encode('utf-8'), mimetype
-
-    # response = HttpResponse(content, content_type=mimetype)
-    # response['Content-Disposition'] = 'attachment; filename="{}"'.format(filename.encode('utf-8'))
-
-    # return response

--- a/common/lib/xmodule/xmodule/video_module/transcripts_utils.py
+++ b/common/lib/xmodule/xmodule/video_module/transcripts_utils.py
@@ -15,8 +15,6 @@ from opaque_keys.edx.locator import BlockUsageLocator
 from HTMLParser import HTMLParser
 from six import text_type
 
-from django.http import Http404
-
 from xmodule.modulestore.django import modulestore
 from xmodule.exceptions import NotFoundError
 from xmodule.contentstore.content import StaticContent
@@ -898,7 +896,7 @@ def get_transcript(course_id, block_id, lang=None):
             transcript = get_video_transcript_content(video_descriptor.edx_video_id, lang)
 
         if not transcript:
-            raise Http404(u'Transcript not found for {}, lang: {}'.format(block_id, lang))
+            raise NotFoundError(u'Transcript not found for {}, lang: {}'.format(block_id, lang))
 
         transcript_conversion_props = dict(transcript, output_format=Transcript.SRT)
         transcript = convert_video_transcript(**transcript_conversion_props)
@@ -906,6 +904,6 @@ def get_transcript(course_id, block_id, lang=None):
         content = transcript['content']
         mimetype = Transcript.mime_types[Transcript.SRT]
     except KeyError:
-        raise Http404(u"Transcript not found for {}, lang: {}".format(block_id, lang))
+        raise NotFoundError(u"Transcript not found for {}, lang: {}".format(block_id, lang))
 
     return content, filename.encode('utf-8'), mimetype

--- a/common/lib/xmodule/xmodule/video_module/video_handlers.py
+++ b/common/lib/xmodule/xmodule/video_module/video_handlers.py
@@ -31,6 +31,7 @@ from .transcripts_utils import (
     TranscriptException,
     TranscriptsGenerationException,
     youtube_speed_dict,
+    get_transcript,
 )
 from .transcripts_model_utils import (
     is_val_transcript_feature_enabled_for_course
@@ -319,47 +320,68 @@ class VideoStudentViewHandlers(object):
 
         elif dispatch == 'download':
             lang = request.GET.get('lang', None)
+
+            from django.http import Http404
+
+            # import pdb; pdb.set_trace()
             try:
-                transcript_content, transcript_filename, transcript_mime_type = self.get_transcript(
-                    transcripts, transcript_format=self.transcript_download_format, lang=lang
+                content, filename, mimetype = get_transcript(
+                    self.course_id, block_id=self.location.block_id, lang=lang
                 )
-            except (KeyError, UnicodeDecodeError):
+            except Http404:
                 return Response(status=404)
-            except (ValueError, NotFoundError):
-                response = Response(status=404)
-                # Check for transcripts in edx-val as a last resort if corresponding feature is enabled.
-                if feature_enabled:
-                    # Make sure the language is set.
-                    if not lang:
-                        lang = self.get_default_transcript_language(transcripts)
 
-                    transcript = get_video_transcript_content(edx_video_id=self.edx_video_id, language_code=lang)
-                    if transcript:
-                        transcript_conversion_props = dict(transcript, output_format=self.transcript_download_format)
-                        transcript = convert_video_transcript(**transcript_conversion_props)
-                        response = Response(
-                            transcript['content'],
-                            headerlist=[
-                                ('Content-Disposition', 'attachment; filename="{filename}"'.format(
-                                    filename=transcript['filename']
-                                )),
-                                ('Content-Language', lang),
-                            ],
-                            charset='utf8',
-                        )
-                        response.content_type = Transcript.mime_types[self.transcript_download_format]
+            response = Response(
+                content,
+                headerlist=[
+                    ('Content-Disposition', 'attachment; filename="{}"'.format(filename)),
+                    ('Content-Language', self.transcript_language),
+                ],
+                charset='utf8'
+            )
+            response.content_type = mimetype
 
-                return response
-            else:
-                response = Response(
-                    transcript_content,
-                    headerlist=[
-                        ('Content-Disposition', 'attachment; filename="{}"'.format(transcript_filename.encode('utf8'))),
-                        ('Content-Language', self.transcript_language),
-                    ],
-                    charset='utf8'
-                )
-                response.content_type = transcript_mime_type
+            # try:
+            #     transcript_content, transcript_filename, transcript_mime_type = self.get_transcript(
+            #         transcripts, transcript_format=self.transcript_download_format, lang=lang
+            #     )
+            # except (KeyError, UnicodeDecodeError):
+            #     return Response(status=404)
+            # except (ValueError, NotFoundError):
+            #     response = Response(status=404)
+            #     # Check for transcripts in edx-val as a last resort if corresponding feature is enabled.
+            #     if feature_enabled:
+            #         # Make sure the language is set.
+            #         if not lang:
+            #             lang = self.get_default_transcript_language(transcripts)
+
+            #         transcript = get_video_transcript_content(edx_video_id=self.edx_video_id, language_code=lang)
+            #         if transcript:
+            #             transcript_conversion_props = dict(transcript, output_format=self.transcript_download_format)
+            #             transcript = convert_video_transcript(**transcript_conversion_props)
+            #             response = Response(
+            #                 transcript['content'],
+            #                 headerlist=[
+            #                     ('Content-Disposition', 'attachment; filename="{filename}"'.format(
+            #                         filename=transcript['filename']
+            #                     )),
+            #                     ('Content-Language', lang),
+            #                 ],
+            #                 charset='utf8',
+            #             )
+            #             response.content_type = Transcript.mime_types[self.transcript_download_format]
+
+            #     return response
+            # else:
+            #     response = Response(
+            #         transcript_content,
+            #         headerlist=[
+            #             ('Content-Disposition', 'attachment; filename="{}"'.format(transcript_filename.encode('utf8'))),
+            #             ('Content-Language', self.transcript_language),
+            #         ],
+            #         charset='utf8'
+            #     )
+            #     response.content_type = transcript_mime_type
 
         elif dispatch.startswith('available_translations'):
 

--- a/common/lib/xmodule/xmodule/video_module/video_handlers.py
+++ b/common/lib/xmodule/xmodule/video_module/video_handlers.py
@@ -326,7 +326,7 @@ class VideoStudentViewHandlers(object):
                 content, filename, mimetype = get_transcript(
                     self.course_id, block_id=self.location.block_id, lang=lang
                 )
-            except (Http404, UnicodeDecodeError):
+            except (NotFoundError, UnicodeDecodeError):
                 return Response(status=404)
 
             response = Response(

--- a/common/lib/xmodule/xmodule/video_module/video_handlers.py
+++ b/common/lib/xmodule/xmodule/video_module/video_handlers.py
@@ -11,6 +11,7 @@ import os
 
 import six
 from django.utils.timezone import now
+from django.http import Http404
 from webob import Response
 
 from xblock.core import XBlock
@@ -321,14 +322,11 @@ class VideoStudentViewHandlers(object):
         elif dispatch == 'download':
             lang = request.GET.get('lang', None)
 
-            from django.http import Http404
-
-            # import pdb; pdb.set_trace()
             try:
                 content, filename, mimetype = get_transcript(
                     self.course_id, block_id=self.location.block_id, lang=lang
                 )
-            except Http404:
+            except (Http404, UnicodeDecodeError):
                 return Response(status=404)
 
             response = Response(
@@ -340,48 +338,6 @@ class VideoStudentViewHandlers(object):
                 charset='utf8'
             )
             response.content_type = mimetype
-
-            # try:
-            #     transcript_content, transcript_filename, transcript_mime_type = self.get_transcript(
-            #         transcripts, transcript_format=self.transcript_download_format, lang=lang
-            #     )
-            # except (KeyError, UnicodeDecodeError):
-            #     return Response(status=404)
-            # except (ValueError, NotFoundError):
-            #     response = Response(status=404)
-            #     # Check for transcripts in edx-val as a last resort if corresponding feature is enabled.
-            #     if feature_enabled:
-            #         # Make sure the language is set.
-            #         if not lang:
-            #             lang = self.get_default_transcript_language(transcripts)
-
-            #         transcript = get_video_transcript_content(edx_video_id=self.edx_video_id, language_code=lang)
-            #         if transcript:
-            #             transcript_conversion_props = dict(transcript, output_format=self.transcript_download_format)
-            #             transcript = convert_video_transcript(**transcript_conversion_props)
-            #             response = Response(
-            #                 transcript['content'],
-            #                 headerlist=[
-            #                     ('Content-Disposition', 'attachment; filename="{filename}"'.format(
-            #                         filename=transcript['filename']
-            #                     )),
-            #                     ('Content-Language', lang),
-            #                 ],
-            #                 charset='utf8',
-            #             )
-            #             response.content_type = Transcript.mime_types[self.transcript_download_format]
-
-            #     return response
-            # else:
-            #     response = Response(
-            #         transcript_content,
-            #         headerlist=[
-            #             ('Content-Disposition', 'attachment; filename="{}"'.format(transcript_filename.encode('utf8'))),
-            #             ('Content-Language', self.transcript_language),
-            #         ],
-            #         charset='utf8'
-            #     )
-            #     response.content_type = transcript_mime_type
 
         elif dispatch.startswith('available_translations'):
 

--- a/lms/djangoapps/courseware/tests/test_video_handlers.py
+++ b/lms/djangoapps/courseware/tests/test_video_handlers.py
@@ -435,7 +435,10 @@ class TestTranscriptDownloadDispatch(TestVideo):
         response = self.item.transcript(request=request, dispatch='download')
         self.assertEqual(response.status, '404 Not Found')
 
-    @patch('xmodule.video_module.transcripts_utils.VideoTranscriptsMixin.get_transcript', return_value=('Subs!', 'test_filename.srt', 'application/x-subrip; charset=utf-8'))
+    @patch(
+        'xmodule.video_module.transcripts_utils.VideoTranscriptsMixin.get_transcript',
+        return_value=('Subs!', 'test_filename.srt', 'application/x-subrip; charset=utf-8')
+    )
     def test_download_srt_exist(self, __):
         request = Request.blank('/download')
         response = self.item.transcript(request=request, dispatch='download')
@@ -443,7 +446,10 @@ class TestTranscriptDownloadDispatch(TestVideo):
         self.assertEqual(response.headers['Content-Type'], 'application/x-subrip; charset=utf-8')
         self.assertEqual(response.headers['Content-Language'], 'en')
 
-    @patch('xmodule.video_module.transcripts_utils.VideoTranscriptsMixin.get_transcript', return_value=('Subs!', 'txt', 'text/plain; charset=utf-8'))
+    @patch(
+        'xmodule.video_module.transcripts_utils.VideoTranscriptsMixin.get_transcript',
+        return_value=('Subs!', 'txt', 'text/plain; charset=utf-8')
+    )
     def test_download_txt_exist(self, __):
         self.item.transcript_format = 'txt'
         request = Request.blank('/download')
@@ -460,7 +466,10 @@ class TestTranscriptDownloadDispatch(TestVideo):
         with self.assertRaises(NotFoundError):
             self.item.get_transcript(transcripts)
 
-    @patch('xmodule.video_module.transcripts_utils.VideoTranscriptsMixin.get_transcript', return_value=('Subs!', u"塞.srt", 'application/x-subrip; charset=utf-8'))
+    @patch(
+        'xmodule.video_module.transcripts_utils.VideoTranscriptsMixin.get_transcript',
+        return_value=('Subs!', u"塞.srt", 'application/x-subrip; charset=utf-8')
+    )
     def test_download_non_en_non_ascii_filename(self, __):
         request = Request.blank('/download')
         response = self.item.transcript(request=request, dispatch='download')

--- a/lms/djangoapps/courseware/tests/test_video_handlers.py
+++ b/lms/djangoapps/courseware/tests/test_video_handlers.py
@@ -21,7 +21,7 @@ from xmodule.contentstore.django import contentstore
 from xmodule.exceptions import NotFoundError
 from xmodule.modulestore import ModuleStoreEnum
 from xmodule.modulestore.django import modulestore
-from xmodule.video_module.transcripts_utils import TranscriptException, TranscriptsGenerationException
+from xmodule.video_module.transcripts_utils import TranscriptException, TranscriptsGenerationException, Transcript
 from xmodule.x_module import STUDENT_VIEW
 
 from .helpers import BaseTestXmodule
@@ -436,7 +436,7 @@ class TestTranscriptDownloadDispatch(TestVideo):
         self.assertEqual(response.status, '404 Not Found')
 
     @patch(
-        'xmodule.video_module.transcripts_utils.VideoTranscriptsMixin.get_transcript',
+        'xmodule.video_module.video_handlers.get_transcript',
         return_value=('Subs!', 'test_filename.srt', 'application/x-subrip; charset=utf-8')
     )
     def test_download_srt_exist(self, __):
@@ -447,7 +447,7 @@ class TestTranscriptDownloadDispatch(TestVideo):
         self.assertEqual(response.headers['Content-Language'], 'en')
 
     @patch(
-        'xmodule.video_module.transcripts_utils.VideoTranscriptsMixin.get_transcript',
+        'xmodule.video_module.video_handlers.get_transcript',
         return_value=('Subs!', 'txt', 'text/plain; charset=utf-8')
     )
     def test_download_txt_exist(self, __):
@@ -467,8 +467,8 @@ class TestTranscriptDownloadDispatch(TestVideo):
             self.item.get_transcript(transcripts)
 
     @patch(
-        'xmodule.video_module.transcripts_utils.VideoTranscriptsMixin.get_transcript',
-        return_value=('Subs!', u"塞.srt", 'application/x-subrip; charset=utf-8')
+        'xmodule.video_module.transcripts_utils.get_transcript_for_video',
+        return_value=(Transcript.SRT, u"塞", 'Subs!')
     )
     def test_download_non_en_non_ascii_filename(self, __):
         request = Request.blank('/download')
@@ -623,6 +623,7 @@ class TestTranscriptTranslationGetDispatch(TestVideo):
                 u'\u041f\u0440\u0438\u0432\u0456\u0442, edX \u0432\u0456\u0442\u0430\u0454 \u0432\u0430\u0441.'
             ]
         }
+
         self.assertDictEqual(json.loads(response.body), calculated_0_75)
         # 1_5 will be generated from 1_0
         self.item.youtube_id_1_5 = '1_5'

--- a/lms/djangoapps/courseware/tests/test_video_handlers.py
+++ b/lms/djangoapps/courseware/tests/test_video_handlers.py
@@ -435,7 +435,7 @@ class TestTranscriptDownloadDispatch(TestVideo):
         response = self.item.transcript(request=request, dispatch='download')
         self.assertEqual(response.status, '404 Not Found')
 
-    @patch('xmodule.video_module.VideoModule.get_transcript', return_value=('Subs!', 'test_filename.srt', 'application/x-subrip; charset=utf-8'))
+    @patch('xmodule.video_module.transcripts_utils.VideoTranscriptsMixin.get_transcript', return_value=('Subs!', 'test_filename.srt', 'application/x-subrip; charset=utf-8'))
     def test_download_srt_exist(self, __):
         request = Request.blank('/download')
         response = self.item.transcript(request=request, dispatch='download')
@@ -443,7 +443,7 @@ class TestTranscriptDownloadDispatch(TestVideo):
         self.assertEqual(response.headers['Content-Type'], 'application/x-subrip; charset=utf-8')
         self.assertEqual(response.headers['Content-Language'], 'en')
 
-    @patch('xmodule.video_module.VideoModule.get_transcript', return_value=('Subs!', 'txt', 'text/plain; charset=utf-8'))
+    @patch('xmodule.video_module.transcripts_utils.VideoTranscriptsMixin.get_transcript', return_value=('Subs!', 'txt', 'text/plain; charset=utf-8'))
     def test_download_txt_exist(self, __):
         self.item.transcript_format = 'txt'
         request = Request.blank('/download')
@@ -460,7 +460,7 @@ class TestTranscriptDownloadDispatch(TestVideo):
         with self.assertRaises(NotFoundError):
             self.item.get_transcript(transcripts)
 
-    @patch('xmodule.video_module.VideoModule.get_transcript', return_value=('Subs!', u"塞.srt", 'application/x-subrip; charset=utf-8'))
+    @patch('xmodule.video_module.transcripts_utils.VideoTranscriptsMixin.get_transcript', return_value=('Subs!', u"塞.srt", 'application/x-subrip; charset=utf-8'))
     def test_download_non_en_non_ascii_filename(self, __):
         request = Request.blank('/download')
         response = self.item.transcript(request=request, dispatch='download')

--- a/lms/djangoapps/mobile_api/video_outlines/views.py
+++ b/lms/djangoapps/mobile_api/video_outlines/views.py
@@ -118,11 +118,13 @@ class VideoTranscripts(generics.RetrieveAPIView):
 
     @mobile_course_access()
     def get(self, request, course, *args, **kwargs):
-        content, filename, mimetype = get_transcript(
-            course.id,
-            block_id=kwargs['block_id'],
-            lang=kwargs['lang']
-        )
+        block_id = kwargs['block_id']
+        lang = kwargs['lang']
+
+        try:
+            content, filename, mimetype = get_transcript(course.id, block_id, lang)
+        except NotFoundError:
+            raise Http404(u'Transcript not found for {}, lang: {}'.format(block_id, lang))
 
         response = HttpResponse(content, content_type=mimetype)
         response['Content-Disposition'] = 'attachment; filename="{}"'.format(filename)

--- a/lms/djangoapps/mobile_api/video_outlines/views.py
+++ b/lms/djangoapps/mobile_api/video_outlines/views.py
@@ -118,11 +118,7 @@ class VideoTranscripts(generics.RetrieveAPIView):
 
     @mobile_course_access()
     def get(self, request, course, *args, **kwargs):
-        # block_id = kwargs['block_id']
-        # lang = kwargs['lang']
-
-        # import pdb; pdb.set_trace()
-        content, filename, mimetype =  get_transcript(
+        content, filename, mimetype = get_transcript(
             course.id,
             block_id=kwargs['block_id'],
             lang=kwargs['lang']
@@ -132,31 +128,3 @@ class VideoTranscripts(generics.RetrieveAPIView):
         response['Content-Disposition'] = 'attachment; filename="{}"'.format(filename)
 
         return response
-
-        # usage_key = BlockUsageLocator(course.id, block_type='video', block_id=block_id)
-        # video_descriptor = modulestore().get_item(usage_key)
-        # feature_enabled = is_val_transcript_feature_enabled_for_course(usage_key.course_key)
-        # try:
-        #     transcripts = video_descriptor.get_transcripts_info(include_val_transcripts=feature_enabled)
-        #     content, filename, mimetype = video_descriptor.get_transcript(transcripts, lang=lang)
-        # except (ValueError, NotFoundError):
-        #     # Fallback mechanism for edx-val transcripts
-        #     transcript = None
-        #     if feature_enabled:
-        #         transcript = get_video_transcript_content(video_descriptor.edx_video_id, lang)
-
-        #     if not transcript:
-        #         raise Http404(u'Transcript not found for {}, lang: {}'.format(block_id, lang))
-
-        #     transcript_conversion_props = dict(transcript, output_format=Transcript.SRT)
-        #     transcript = convert_video_transcript(**transcript_conversion_props)
-        #     filename = transcript['filename']
-        #     content = transcript['content']
-        #     mimetype = Transcript.mime_types[Transcript.SRT]
-        # except KeyError:
-        #     raise Http404(u"Transcript not found for {}, lang: {}".format(block_id, lang))
-
-        # response = HttpResponse(content, content_type=mimetype)
-        # response['Content-Disposition'] = 'attachment; filename="{}"'.format(filename.encode('utf-8'))
-
-        # return response

--- a/lms/djangoapps/mobile_api/video_outlines/views.py
+++ b/lms/djangoapps/mobile_api/video_outlines/views.py
@@ -21,6 +21,7 @@ from xmodule.video_module.transcripts_utils import (
     convert_video_transcript,
     get_video_transcript_content,
     Transcript,
+    get_transcript,
 )
 from xmodule.video_module.transcripts_model_utils import (
     is_val_transcript_feature_enabled_for_course
@@ -117,33 +118,45 @@ class VideoTranscripts(generics.RetrieveAPIView):
 
     @mobile_course_access()
     def get(self, request, course, *args, **kwargs):
-        block_id = kwargs['block_id']
-        lang = kwargs['lang']
+        # block_id = kwargs['block_id']
+        # lang = kwargs['lang']
 
-        usage_key = BlockUsageLocator(course.id, block_type='video', block_id=block_id)
-        video_descriptor = modulestore().get_item(usage_key)
-        feature_enabled = is_val_transcript_feature_enabled_for_course(usage_key.course_key)
-        try:
-            transcripts = video_descriptor.get_transcripts_info(include_val_transcripts=feature_enabled)
-            content, filename, mimetype = video_descriptor.get_transcript(transcripts, lang=lang)
-        except (ValueError, NotFoundError):
-            # Fallback mechanism for edx-val transcripts
-            transcript = None
-            if feature_enabled:
-                transcript = get_video_transcript_content(video_descriptor.edx_video_id, lang)
-
-            if not transcript:
-                raise Http404(u'Transcript not found for {}, lang: {}'.format(block_id, lang))
-
-            transcript_conversion_props = dict(transcript, output_format=Transcript.SRT)
-            transcript = convert_video_transcript(**transcript_conversion_props)
-            filename = transcript['filename']
-            content = transcript['content']
-            mimetype = Transcript.mime_types[Transcript.SRT]
-        except KeyError:
-            raise Http404(u"Transcript not found for {}, lang: {}".format(block_id, lang))
+        # import pdb; pdb.set_trace()
+        content, filename, mimetype =  get_transcript(
+            course.id,
+            block_id=kwargs['block_id'],
+            lang=kwargs['lang']
+        )
 
         response = HttpResponse(content, content_type=mimetype)
-        response['Content-Disposition'] = 'attachment; filename="{}"'.format(filename.encode('utf-8'))
+        response['Content-Disposition'] = 'attachment; filename="{}"'.format(filename)
 
         return response
+
+        # usage_key = BlockUsageLocator(course.id, block_type='video', block_id=block_id)
+        # video_descriptor = modulestore().get_item(usage_key)
+        # feature_enabled = is_val_transcript_feature_enabled_for_course(usage_key.course_key)
+        # try:
+        #     transcripts = video_descriptor.get_transcripts_info(include_val_transcripts=feature_enabled)
+        #     content, filename, mimetype = video_descriptor.get_transcript(transcripts, lang=lang)
+        # except (ValueError, NotFoundError):
+        #     # Fallback mechanism for edx-val transcripts
+        #     transcript = None
+        #     if feature_enabled:
+        #         transcript = get_video_transcript_content(video_descriptor.edx_video_id, lang)
+
+        #     if not transcript:
+        #         raise Http404(u'Transcript not found for {}, lang: {}'.format(block_id, lang))
+
+        #     transcript_conversion_props = dict(transcript, output_format=Transcript.SRT)
+        #     transcript = convert_video_transcript(**transcript_conversion_props)
+        #     filename = transcript['filename']
+        #     content = transcript['content']
+        #     mimetype = Transcript.mime_types[Transcript.SRT]
+        # except KeyError:
+        #     raise Http404(u"Transcript not found for {}, lang: {}".format(block_id, lang))
+
+        # response = HttpResponse(content, content_type=mimetype)
+        # response['Content-Disposition'] = 'attachment; filename="{}"'.format(filename.encode('utf-8'))
+
+        # return response


### PR DESCRIPTION
@Qubad786 This is ready for review. I am currently further refactoring the `get_transcript` util further so that we can use it in `/translation/[language_id] dispatch` in `video_handlers.py`. But I think we can merge current changes and do the further refactoring in a separate PR.