### PR TITLE
Adds redirect middleware to Studio

### DIFF
--- a/cms/djangoapps/contentstore/views/tests/test_course_index.py
+++ b/cms/djangoapps/contentstore/views/tests/test_course_index.py
@@ -392,13 +392,13 @@ class TestCourseIndexArchived(CourseTestCase):
 
     @ddt.data(
         # Staff user has course staff access
-        (True, 'staff', None, 3, 17),
-        (False, 'staff', None, 3, 17),
+        (True, 'staff', None, 3, 18),
+        (False, 'staff', None, 3, 18),
         # Base user has global staff access
-        (True, 'user', ORG, 3, 17),
-        (False, 'user', ORG, 3, 17),
-        (True, 'user', None, 3, 17),
-        (False, 'user', None, 3, 17),
+        (True, 'user', ORG, 3, 18),
+        (False, 'user', ORG, 3, 18),
+        (True, 'user', None, 3, 18),
+        (False, 'user', None, 3, 18),
     )
     @ddt.unpack
     def test_separate_archived_courses(self, separate_archived_courses, username, org, mongo_queries, sql_queries):

--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -461,6 +461,9 @@ MIDDLEWARE_CLASSES = [
     _csrf_middleware,
     'django.contrib.sites.middleware.CurrentSiteMiddleware',
 
+    # Allows us to define redirects via Django admin
+    'django_sites_extensions.middleware.RedirectMiddleware',
+
     # Instead of SessionMiddleware, we use a more secure version
     # 'django.contrib.sessions.middleware.SessionMiddleware',
     'openedx.core.djangoapps.safe_sessions.middleware.SafeSessionMiddleware',


### PR DESCRIPTION
[Django redirect middleware exists in the LMS](https://github.com/open-craft/edx-platform/blob/ea0c79c7e3c44a62827e6c82104462e3ca94c724/lms/envs/common.py#L1273-L1274) but not Studio, so this change rectifies this.

We use Django redirects in Studio to let the LMS-configured SSO operate for Studio signin/signup links.

**JIRA issues:** [OSPR-2252](https://openedx.atlassian.net/browse/OSPR-2252)

**Merge deadline:** None

**Sandbox URL**:

* LMS: https://pr17507.sandbox.opencraft.hosting/
* Studio: https://studio-pr17507.sandbox.opencraft.hosting/

**Testing instructions**

The `staff` user has superuser privileges on the sandbox.

* In LMS (or CMS) Django Admin, ensure there is a [Site entry for the studio site URL](https://pr17507.sandbox.opencraft.hosting/admin/sites/site/2/).
* Create a Redirect using the studio Site entry.
  E.g., [`/studio-home -> /home`](https://pr17507.sandbox.opencraft.hosting/admin/redirects/redirect/1/).
* Test to ensure this redirect works as expected.
  e.g., [/studio-home](https://studio-pr17507.sandbox.opencraft.hosting/studio-home)

**Reviewer**
- [x] @smarnach 
- [ ] edX Reviewer TBD