### PR TITLE
fix-topic-select-wdith

### DIFF
--- a/lms/static/sass/discussion/views/_create-edit-post.scss
+++ b/lms/static/sass/discussion/views/_create-edit-post.scss
@@ -170,6 +170,10 @@
     height: 40px;
   }
 
+  .post-topic.field-input {
+    width: 100%;
+  }
+
   .post-option {
     box-sizing: border-box;
     display: inline-block;


### PR DESCRIPTION
It is a simple fix, just need someone in educator to take a look.

[EDUCATOR-2358](https://openedx.atlassian.net/browse/EDUCATOR-2358)

# Discussion forum is broken by long topic header
## Description
Defining long discussion subcategories broke the discussion topic drop-down

## Reproduce
1. Create an inline discussion in studio
2. Edit the discussion and add the following text in the `Subcategory` input box. 
```
In late 2017, NPR cited a study findings that CEOs who invest in CSR risk their jobs. Similarly, Professor Frumkin has stated in this course that firm leaders who want to engage in CSR must justify it financially for board approval. What specific benefits have built firms' solid case for CSR? Speak from your own experience, and/or share a link with further details.  http://www.npr.org/2017/10/31/561041293/study-ceos-who-invest-in-social-responsibility-initiatives-risk-their-jobs
```
3. View Discussion tab on LMS
4. Click `Add Post` button and verify the topic drop down is not broken.


## Sandbox
[https://awaisdar001.sandbox.edx.org/courses/course-v1:edX+DemoX+Demo_Course/discussion/forum/](https://awaisdar001.sandbox.edx.org/)



## Before
<img width="1177" alt="screen shot 2018-02-21 at 12 20 00 pm" src="https://user-images.githubusercontent.com/4252738/36477283-64381d14-1722-11e8-80af-f526d84a115f.png">

## After
<img width="867" alt="screen shot 2018-02-21 at 4 12 35 pm" src="https://user-images.githubusercontent.com/4252738/36477315-82b41662-1722-11e8-9b60-67b4e03112bf.png">

