### PR TITLE
Renamed contentstore waffle namespace to "studio"

### DIFF
--- a/cms/djangoapps/contentstore/config/waffle.py
+++ b/cms/djangoapps/contentstore/config/waffle.py
@@ -5,7 +5,7 @@ waffle switches for the contentstore app.
 from openedx.core.djangoapps.waffle_utils import WaffleSwitchNamespace
 
 # Namespace
-WAFFLE_NAMESPACE = u'accessibility'
+WAFFLE_NAMESPACE = u'studio'
 
 # Switches
 ENABLE_ACCESSIBILITY_POLICY_PAGE = u'enable_policy_page'
@@ -13,6 +13,6 @@ ENABLE_ACCESSIBILITY_POLICY_PAGE = u'enable_policy_page'
 
 def waffle():
     """
-    Returns the namespaced, cached, audited Waffle class for Accessibility Accomodation Request Page.
+    Returns the namespaced, cached, audited Waffle class for Studio pages.
     """
-    return WaffleSwitchNamespace(name=WAFFLE_NAMESPACE, log_prefix=u'Accessibility: ')
+    return WaffleSwitchNamespace(name=WAFFLE_NAMESPACE, log_prefix=u'Studio: ')

--- a/common/test/db_fixtures/waffle_flags.json
+++ b/common/test/db_fixtures/waffle_flags.json
@@ -19,7 +19,7 @@
         "pk": 1,
         "model": "waffle.switch",
         "fields": {
-            "name": "accessibility.enable_policy_page",
+            "name": "studio.enable_policy_page",
             "active": true
         }
     }


### PR DESCRIPTION
We are adding another waffle switch in Studio, and this PR generalizes the waffle namespace from "accessibility" to "studio". Before this PR merges, we'll need to activate the renamed switch in prod environment.

Please review @edx/educator-dahlia.