### PR TITLE
Fix css issues on oauth authorization page to make it responsive

### DIFF
--- a/lms/static/sass/views/_oauth2.scss
+++ b/lms/static/sass/views/_oauth2.scss
@@ -17,9 +17,8 @@
 // For the django-oauth-toolkit Authorization view
 .wrapper-authorize {
   background: $white;
-  width: 60%;
-  padding-right: 140px;
-  padding-left: 140px;
+  padding-right: $baseline/2;
+  padding-left: $baseline/2;
   font-family: $font-family-sans-serif;
 
   h1 {


### PR DESCRIPTION
[LEARNER-4068](https://openedx.atlassian.net/browse/LEARNER-4068)

@arizzitano has gave her input on the ticket that if page is responsive no need to change and use flexbox.

**Sandbox:** https://tasawernawaz.sandbox.edx.org

**How to test:** https://github.com/edx/edx-platform/blob/master/openedx/core/djangoapps/oauth_dispatch/docs/how_tos/testing_manually.rst

