### PR TITLE
Added waffle switch for files & uploads search UI

### DIFF
--- a/cms/djangoapps/contentstore/config/waffle.py
+++ b/cms/djangoapps/contentstore/config/waffle.py
@@ -9,6 +9,7 @@ WAFFLE_NAMESPACE = u'studio'
 
 # Switches
 ENABLE_ACCESSIBILITY_POLICY_PAGE = u'enable_policy_page'
+ENABLE_ASSETS_SEARCH = u'enable_assets_search'
 
 
 def waffle():

--- a/cms/templates/asset_index.html
+++ b/cms/templates/asset_index.html
@@ -6,6 +6,7 @@
   from django.utils.translation import ugettext as _
   from openedx.core.djangolib.markup import HTML, Text
   from openedx.core.djangolib.js_utils import js_escaped_string, dump_js_escaped_json
+  from cms.djangoapps.contentstore.config.waffle import waffle, ENABLE_ASSETS_SEARCH
 %>
 <%block name="title">${_("Files & Uploads")}</%block>
 <%block name="bodyclass">is-signedin course uploads view-uploads</%block>
@@ -82,6 +83,9 @@
                     },
                     "upload_settings": {
                         "max_file_size_in_mbs": ${max_file_size_in_mbs|n, dump_js_escaped_json}
+                    },
+                    "search_settings": {
+                        "enabled": ${waffle().is_enabled(ENABLE_ASSETS_SEARCH) | n, dump_js_escaped_json}
                     }
                 }
             </%static:studiofrontend>


### PR DESCRIPTION
This adds `studio.enable_assets_search` as a waffle switch and passes the setting to studio-frontend defined in the interface in https://github.com/edx/studio-frontend/pull/132.

@edx/educator-dahlia please review!