### PR TITLE
Fix lms and studio help button tests

### DIFF
--- a/common/test/acceptance/pages/lms/instructor_dashboard.py
+++ b/common/test/acceptance/pages/lms/instructor_dashboard.py
@@ -21,11 +21,11 @@ class InstructorDashboardPage(CoursePage):
     def is_browser_on_page(self):
         return self.q(css='div.instructor-dashboard-wrapper-2').present
 
-    def click_help(self):
+    def get_help_element(self):
         """
-        Clicks the general Help button in the header.
+        Returns the general Help button in the header.
         """
-        self.q(css='.help-link').first.click()
+        return self.q(css='.help-link').first
 
     def select_membership(self):
         """
@@ -272,16 +272,14 @@ class CohortManagementSection(PageObject):
     select_content_group_button_css = '.cohort-management-details-association-course input.radio-yes'
     assignment_type_buttons_css = '.cohort-management-assignment-type-settings input'
 
-    def get_cohort_help_element_and_click_help(self):
+    def get_cohort_help_element(self):
         """
-        Clicks help link and returns it. Specifically, clicks 'What does it mean'
+        Returns the help element ('What does it mean')
 
         Returns:
             help_element (WebElement): help link element
         """
-        help_element = self.q(css=self.cohort_help_css).results[0]
-        help_element.click()
-        return help_element
+        return self.q(css=self.cohort_help_css).results[0]
 
     def is_browser_on_page(self):
         """

--- a/common/test/acceptance/pages/studio/utils.py
+++ b/common/test/acceptance/pages/studio/utils.py
@@ -7,6 +7,7 @@ from selenium.webdriver.common.action_chains import ActionChains
 from selenium.webdriver.common.keys import Keys
 
 from common.test.acceptance.pages.common.utils import click_css, sync_on_notification
+from common.test.acceptance.tests.helpers import wait_for_help_window
 
 NAV_HELP_NOT_SIGNED_IN_CSS = '.nav-item.nav-not-signedin-help a'
 NAV_HELP_CSS = '.nav-item.nav-account-help a'
@@ -288,8 +289,9 @@ class HelpMixin(object):
         else:
             element_css = NAV_HELP_NOT_SIGNED_IN_CSS
 
-        self.q(css=element_css).first.click()
-        return self.q(css=element_css).results[0]
+        help_element = self.q(css=element_css).results[0]
+        wait_for_help_window(self, help_element)
+        return help_element
 
     def get_side_bar_help_element_and_click_help(self, as_list_item=False, index=-1):
         """
@@ -313,5 +315,5 @@ class HelpMixin(object):
             element_css = SIDE_BAR_HELP_CSS
 
         help_element = self.q(css=element_css).results[index]
-        help_element.click()
+        wait_for_help_window(self, help_element)
         return help_element

--- a/common/test/acceptance/tests/helpers.py
+++ b/common/test/acceptance/tests/helpers.py
@@ -427,6 +427,7 @@ def assert_opened_help_link_is_correct(test, url):
         url (str): url to verify.
     """
     test.browser.switch_to_window(test.browser.window_handles[-1])
+    WebDriverWait(test.browser, 10).until(lambda driver: driver.current_url != "about:blank")
     # Assert that url in the browser is the same.
     test.assertEqual(url, test.browser.current_url)
     # Check that the URL loads. Can't do this in the browser because it might
@@ -858,6 +859,18 @@ def create_user_partition_json(partition_id, name, description, groups, scheme="
     return UserPartition(
         partition_id, name, description, groups, MockScheme()
     ).to_json()
+
+
+def wait_for_help_window(page, help_element):
+    """
+    To avoid a race condition, wait for the help window to launch.
+    To check this, make sure the number of window_handles increases by one.
+    """
+    num_windows = len(page.browser.window_handles)
+    help_element.click()
+    WebDriverWait(page.browser, 10).until(
+        lambda driver: len(driver.window_handles) > num_windows
+    )
 
 
 def assert_nav_help_link(test, page, href, signed_in=True, close_window=True):

--- a/common/test/acceptance/tests/lms/test_lms_help.py
+++ b/common/test/acceptance/tests/lms/test_lms_help.py
@@ -5,9 +5,13 @@ Test Help links in LMS
 from common.test.acceptance.fixtures.course import CourseFixture
 from common.test.acceptance.pages.lms.instructor_dashboard import InstructorDashboardPage
 from common.test.acceptance.tests.discussion.helpers import CohortTestMixin
-from common.test.acceptance.tests.helpers import assert_opened_help_link_is_correct, url_for_help
 from common.test.acceptance.tests.lms.test_lms_instructor_dashboard import BaseInstructorDashboardTest
 from common.test.acceptance.tests.studio.base_studio_test import ContainerBase
+from common.test.acceptance.tests.helpers import (
+    assert_opened_help_link_is_correct,
+    url_for_help,
+    wait_for_help_window
+)
 
 
 class TestCohortHelp(ContainerBase, CohortTestMixin):
@@ -27,8 +31,9 @@ class TestCohortHelp(ContainerBase, CohortTestMixin):
         Arguments:
             href (str): Help url
         """
-        actual_link = self.cohort_management.get_cohort_help_element_and_click_help()
-        self.assertEqual(actual_link.text, "What does this mean?")
+        help_element = self.cohort_management.get_cohort_help_element()
+        self.assertEqual(help_element.text, "What does this mean?")
+        wait_for_help_window(self, help_element)
         assert_opened_help_link_is_correct(self, href)
 
     def test_manual_cohort_help(self):
@@ -92,5 +97,6 @@ class InstructorDashboardHelp(BaseInstructorDashboardTest):
         Then I see help about the instructor dashboard in a new tab
         """
         href = url_for_help('course_author', '/CA_instructor_dash_help.html')
-        self.instructor_dashboard_page.click_help()
+        help_element = self.instructor_dashboard_page.get_help_element()
+        wait_for_help_window(self, help_element)
         assert_opened_help_link_is_correct(self, href)


### PR DESCRIPTION
**The Problem:**
The tests were clicking the help button, then trying to get the url of the new window too quickly, so it was returning 'about:blank'

**The Solution:**
Ensure that we allow the window time to actually open, and load enough to the point where we can get its url.

Let me know if there's a more preferred method for these waits.