### PR TITLE
Find html files of django-wiki under templates directory

### DIFF
--- a/conf/locale/babel_third_party.cfg
+++ b/conf/locale/babel_third_party.cfg
@@ -2,7 +2,7 @@
 [python: **.py]
 input_encoding = utf-8
 
-[django: **/template/**.html]
+[django: **/templates/**.html]
 input_encoding = utf-8
 
 [reactjs: **.jsx]


### PR DESCRIPTION
It seems that this file is used only for wiki translation. so we can make changes directly. but if I'm wrong then we have to clone this file, change and use the new one for extracting wiki translatable strings.