### PR TITLE
Add template block to allow redefining the course details section in themes

### DIFF
--- a/lms/templates/courseware/course_about.html
+++ b/lms/templates/courseware/course_about.html
@@ -207,6 +207,8 @@ from six import string_types
   </%block>
 
   <div class="container">
+
+    <%block name="course_about_details">
     <div class="details">
       % if staff_access and studio_url is not None:
         <div class="wrap-instructor-info studio-view">
@@ -217,7 +219,8 @@ from six import string_types
       <div class="inner-wrapper">
         ${get_course_about_section(request, course, "overview")}
       </div>
-  </div>
+    </div>
+    </%block>
 
     <div class="course-sidebar">
       <div class="course-summary">


### PR DESCRIPTION
This PR is very similar to https://github.com/edx/edx-platform/pull/17091
It adds a `<%block>` that we needed to redefine in a theme.
The block name is prefixed with the template name to avoid clashes.

Pinging @tuchfarber (reviewer of that previous PR). Very simple PR.

**JIRA tickets**: N/A
**Discussions**: None
**Dependencies**: None
**Screenshots**:
**Sandbox URL**: None.
**Partner information**: N/A
**Deployment targets**: N/A
**Merge deadline**: None
**Testing instructions**: None required
**Author notes and concerns**: N/A
**Reviewers**
- [ ] @jcdyer 
- [ ] edX reviewer[s] TBD

**Settings**
None