### PR TITLE
Auto-open first unit in course outline if user has no completion data

### DIFF
--- a/openedx/features/course_experience/utils.py
+++ b/openedx/features/course_experience/utils.py
@@ -162,3 +162,20 @@ def get_course_outline_block_tree(request, course_id):
         else:
             mark_last_accessed(request.user, course_key, course_outline_root_block)
     return course_outline_root_block
+
+
+def get_resume_block(block):
+    """
+    Gets the deepest block marked as 'resume_block'.
+
+    """
+    if not block['resume_block']:
+        return None
+    if not block.get('children'):
+        return block
+
+    for child in block['children']:
+        resume_block = get_resume_block(child)
+        if resume_block:
+            return resume_block
+    return block

--- a/openedx/features/course_experience/views/course_home.py
+++ b/openedx/features/course_experience/views/course_home.py
@@ -29,7 +29,7 @@ from student.models import CourseEnrollment
 from util.views import ensure_valid_course_key
 
 from .. import LATEST_UPDATE_FLAG, SHOW_UPGRADE_MSG_ON_COURSE_HOME, USE_BOOTSTRAP_FLAG
-from ..utils import get_course_outline_block_tree
+from ..utils import get_course_outline_block_tree, get_resume_block
 from .course_dates import CourseDatesFragmentView
 from .course_home_messages import CourseHomeMessageFragmentView
 from .course_outline import CourseOutlineFragmentView
@@ -81,23 +81,6 @@ class CourseHomeFragmentView(EdxFragmentView):
                 otherwise the URL of the course root.
 
         """
-
-        def get_resume_block(block):
-            """
-            Gets the deepest block marked as 'resume_block'.
-
-            """
-            if not block['resume_block']:
-                return None
-            if not block.get('children'):
-                return block
-
-            for child in block['children']:
-                resume_block = get_resume_block(child)
-                if resume_block:
-                    return resume_block
-            return block
-
         course_outline_root_block = get_course_outline_block_tree(request, course_id)
         resume_block = get_resume_block(course_outline_root_block) if course_outline_root_block else None
         has_visited_course = bool(resume_block)


### PR DESCRIPTION
### Continuation of [EDUCATOR-2095](https://openedx.atlassian.net/browse/EDUCATOR-2095)

If a user has no completion data, the course outline should auto-open to the first unit in the course.

[Sandbox](https://sofiya2.sandbox.edx.org/courses/course-v1:edX+DemoX+Demo_Course/course/) - Sign in as staff