### PR TITLE
EDUCATOR-2231 remove course run enrollment dates references from studio

### DIFF
--- a/cms/djangoapps/api/v1/serializers/course_runs.py
+++ b/cms/djangoapps/api/v1/serializers/course_runs.py
@@ -29,8 +29,8 @@ class CourseAccessRoleSerializer(serializers.ModelSerializer):
 class CourseRunScheduleSerializer(serializers.Serializer):
     start = serializers.DateTimeField()
     end = serializers.DateTimeField()
-    enrollment_start = serializers.DateTimeField(allow_null=True)
-    enrollment_end = serializers.DateTimeField(allow_null=True)
+    enrollment_start = serializers.DateTimeField(allow_null=True, required=False)
+    enrollment_end = serializers.DateTimeField(allow_null=True, required=False)
 
 
 class CourseRunTeamSerializer(serializers.Serializer):

--- a/cms/djangoapps/api/v1/tests/test_serializers/test_course_runs.py
+++ b/cms/djangoapps/api/v1/tests/test_serializers/test_course_runs.py
@@ -16,39 +16,46 @@ from ...serializers.course_runs import CourseRunSerializer
 @ddt.ddt
 class CourseRunSerializerTests(ModuleStoreTestCase):
 
-    @ddt.data(
-        ('instructor_paced', False),
-        ('self_paced', True),
-    )
-    @ddt.unpack
-    def test_data(self, expected_pacing_type, self_paced):
-        start = datetime.datetime.now(pytz.UTC)
-        end = start + datetime.timedelta(days=30)
-        enrollment_start = start - datetime.timedelta(days=7)
-        enrollment_end = end - datetime.timedelta(days=14)
+    def setUp(self):
+        super(CourseRunSerializerTests, self).setUp()
 
-        course = CourseFactory(
-            start=start,
-            end=end,
+        self.course_start = datetime.datetime.now(pytz.UTC)
+        self.course_end = self.course_start + datetime.timedelta(days=30)
+
+        self.request = RequestFactory().get('')
+
+    def setup_course(self, self_paced, enrollment_start=None, enrollment_end=None):
+        return CourseFactory(
+            start=self.course_start,
+            end=self.course_end,
+            self_paced=self_paced,
             enrollment_start=enrollment_start,
-            enrollment_end=enrollment_end,
-            self_paced=self_paced
+            enrollment_end=enrollment_end
         )
+
+    def setup_course_user_roles(self, course):
+        """
+        get course staff and instructor roles user
+        """
         instructor = UserFactory()
         CourseInstructorRole(course.id).add_users(instructor)
         staff = UserFactory()
         CourseStaffRole(course.id).add_users(staff)
 
-        request = RequestFactory().get('')
-        serializer = CourseRunSerializer(course, context={'request': request})
-        expected = {
+        return instructor, staff
+
+    def get_expected_course_data(
+        self, course, enrollment_start, enrollment_end,
+        instructor, staff, expected_pacing_type
+    ):
+        return {
             'id': str(course.id),
             'title': course.display_name,
             'schedule': {
-                'start': serialize_datetime(start),
-                'end': serialize_datetime(end),
-                'enrollment_start': serialize_datetime(enrollment_start),
-                'enrollment_end': serialize_datetime(enrollment_end),
+                'start': serialize_datetime(self.course_start),
+                'end': serialize_datetime(self.course_end),
+                'enrollment_start': enrollment_start,
+                'enrollment_end': enrollment_end,
             },
             'team': [
                 {
@@ -61,8 +68,50 @@ class CourseRunSerializerTests(ModuleStoreTestCase):
                 },
             ],
             'images': {
-                'card_image': request.build_absolute_uri(course_image_url(course)),
+                'card_image': self.request.build_absolute_uri(course_image_url(course)),
             },
             'pacing_type': expected_pacing_type,
         }
-        assert serializer.data == expected
+
+    @ddt.data(
+        ('instructor_paced', False),
+        ('self_paced', True),
+    )
+    @ddt.unpack
+    def test_data_with_enrollment_dates(self, expected_pacing_type, self_paced):
+        """
+        Verify that CourseRunSerializer serializes the course object.
+        """
+
+        enrollment_start = self.course_start - datetime.timedelta(days=7)
+        enrollment_end = self.course_end - datetime.timedelta(days=14)
+        course = self.setup_course(self_paced, enrollment_start, enrollment_end)
+        instructor, staff = self.setup_course_user_roles(course)
+        serializer = CourseRunSerializer(course, context={'request': self.request})
+
+        expected_course_data = self.get_expected_course_data(
+            course, serialize_datetime(enrollment_start), serialize_datetime(enrollment_end),
+            instructor, staff, expected_pacing_type
+        )
+
+        assert serializer.data == expected_course_data
+
+    @ddt.data(
+        ('instructor_paced', False),
+        ('self_paced', True),
+    )
+    @ddt.unpack
+    def test_data_without_enrollment_dates(self, expected_pacing_type, self_paced):
+        """
+        Verify that CourseRunSerializer serializes the course object without enrollment
+        start and end dates.
+        """
+        course = self.setup_course(self_paced)
+        instructor, staff = self.setup_course_user_roles(course)
+        serializer = CourseRunSerializer(course, context={'request': self.request})
+
+        expected_course_data = self.get_expected_course_data(
+            course, None, None, instructor, staff, expected_pacing_type
+        )
+
+        assert serializer.data == expected_course_data


### PR DESCRIPTION
## [EDUCATOR-2231](https://openedx.atlassian.net/browse/EDUCATOR-2231)

### Description
This PR removes all the reference to the enrollment dates columns.

Related discovery PR: https://github.com/edx/course-discovery/pull/1350

### Reviewers
If you've been tagged for review, please check your corresponding box once you've given the :+1:.
- [x]  @schenedx 
- [x]  @awaisdar001 

### Post-review
- [x] Rebase and squash commits