### PR TITLE
Fix ff 57 failures by removing button click

### DIFF
--- a/common/test/acceptance/pages/lms/learner_profile.py
+++ b/common/test/acceptance/pages/lms/learner_profile.py
@@ -281,10 +281,6 @@ class LearnerProfilePage(FieldsMixin, PageObject):
         self.browser.execute_script('$(".upload-button-input").css("opacity",1);')
 
         self.wait_for_element_visibility('.upload-button-input', "upload button is visible")
-
-        self.browser.execute_script('$(".upload-submit").show();')
-
-        self.q(css='.upload-submit').first.click()
         self.q(css='.upload-button-input').results[0].send_keys(file_path)
         self.wait_for_ajax()
 


### PR DESCRIPTION
Fixes learner profile tests on **shard 4**.

We were trying to click a button that wasn't interactive. We don't actually need to click this button for the upload to occur, and it seems like its not part of the workflow for a student.

Fixes these 6 tests:
```
acceptance.tests.lms.test_learner_profile.OwnLearnerProfilePageTest.test_eventing_after_multiple_uploads
acceptance.tests.lms.test_learner_profile.OwnLearnerProfilePageTest.test_user_can_remove_profile_image
acceptance.tests.lms.test_learner_profile.OwnLearnerProfilePageTest.test_user_can_see_error_for_exceeding_max_file_size_limit
acceptance.tests.lms.test_learner_profile.OwnLearnerProfilePageTest.test_user_can_see_error_for_file_size_below_the_min_limit
acceptance.tests.lms.test_learner_profile.OwnLearnerProfilePageTest.test_user_can_see_error_for_wrong_file_type
acceptance.tests.lms.test_learner_profile.OwnLearnerProfilePageTest.test_user_can_upload_the_profile_image_with_success
```