### PR TITLE
PLAT-1976 Add waffle switch to block auth_user write attempts

### DIFF
--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -987,7 +987,7 @@ INSTALLED_APPS = [
     'openedx.core.djangoapps.contentserver',
     'course_creators',
     'openedx.core.djangoapps.external_auth',
-    'student',  # misleading name due to sharing with lms
+    'student.apps.StudentConfig',  # misleading name due to sharing with lms
     'openedx.core.djangoapps.course_groups',  # not used in cms (yet), but tests run
     'xblock_config.apps.XBlockConfig',
 

--- a/common/djangoapps/student/apps.py
+++ b/common/djangoapps/student/apps.py
@@ -1,0 +1,20 @@
+"""
+Configuration for the ``student`` Django application.
+"""
+from __future__ import absolute_import
+
+from django.apps import AppConfig
+from django.contrib.auth.signals import user_logged_in
+
+
+class StudentConfig(AppConfig):
+    """
+    Default configuration for the ``student`` application.
+    """
+    name = 'student'
+
+    def ready(self):
+        from django.contrib.auth.models import update_last_login as django_update_last_login
+        user_logged_in.disconnect(django_update_last_login)
+        from .signals.receivers import update_last_login
+        user_logged_in.connect(update_last_login)

--- a/common/djangoapps/student/signals/receivers.py
+++ b/common/djangoapps/student/signals/receivers.py
@@ -1,0 +1,19 @@
+"""
+Signal receivers for the "student" application.
+"""
+from __future__ import absolute_import
+
+from django.utils import timezone
+
+from openedx.core.djangoapps.user_api.config.waffle import PREVENT_AUTH_USER_WRITES, waffle
+
+
+def update_last_login(sender, user, **kwargs):  # pylint: disable=unused-argument
+    """
+    Replacement for Django's ``user_logged_in`` signal handler that knows not
+    to attempt updating the ``last_login`` field when we're trying to avoid
+    writes to the ``auth_user`` table while running a migration.
+    """
+    if not waffle().is_enabled(PREVENT_AUTH_USER_WRITES):
+        user.last_login = timezone.now()
+        user.save(update_fields=['last_login'])

--- a/common/djangoapps/student/tests/test_activate_account.py
+++ b/common/djangoapps/student/tests/test_activate_account.py
@@ -9,6 +9,7 @@ from mock import patch
 
 from edxmako.shortcuts import render_to_string
 from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
+from openedx.core.djangoapps.user_api.config.waffle import PREVENT_AUTH_USER_WRITES, SYSTEM_MAINTENANCE_MSG, waffle
 from student.models import Registration
 from student.tests.factories import UserFactory
 
@@ -199,3 +200,14 @@ class TestActivateAccount(TestCase):
         response = self.client.get(reverse('activate', args=[uuid4().hex]), follow=True)
         self.assertRedirects(response, login_page_url)
         self.assertContains(response, 'Your account could not be activated')
+
+    def test_account_activation_prevent_auth_user_writes(self):
+        login_page_url = "{login_url}?next={redirect_url}".format(
+            login_url=reverse('signin_user'),
+            redirect_url=reverse('dashboard'),
+        )
+        with waffle().override(PREVENT_AUTH_USER_WRITES, True):
+            response = self.client.get(reverse('activate', args=[self.registration.activation_key]), follow=True)
+            self.assertRedirects(response, login_page_url)
+            self.assertContains(response, SYSTEM_MAINTENANCE_MSG)
+            assert not self.user.is_active

--- a/common/djangoapps/student/tests/test_reset_password.py
+++ b/common/djangoapps/student/tests/test_reset_password.py
@@ -22,6 +22,7 @@ from provider.oauth2 import models as dop_models
 
 from openedx.core.djangoapps.oauth_dispatch.tests import factories as dot_factories
 from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
+from openedx.core.djangoapps.user_api.config.waffle import PREVENT_AUTH_USER_WRITES, SYSTEM_MAINTENANCE_MSG, waffle
 from openedx.core.djangolib.testing.utils import CacheIsolationTestCase
 from student.tests.factories import UserFactory
 from student.tests.test_email import mock_render_to_string
@@ -280,6 +281,18 @@ class ResetPasswordTests(EventTestMixin, CacheIsolationTestCase):
         # the user is not marked as active.
         self.assertEqual(resp.status_code, 200)
         self.assertFalse(User.objects.get(pk=self.user.pk).is_active)
+
+    def test_password_reset_prevent_auth_user_writes(self):
+        with waffle().override(PREVENT_AUTH_USER_WRITES, True):
+            url = reverse(
+                "password_reset_confirm",
+                kwargs={"uidb36": self.uidb36, "token": self.token}
+            )
+            for request in [self.request_factory.get(url), self.request_factory.post(url)]:
+                response = password_reset_confirm_wrapper(request, self.uidb36, self.token)
+                assert response.context_data['err_msg'] == SYSTEM_MAINTENANCE_MSG
+                self.user.refresh_from_db()
+                assert not self.user.is_active
 
     @override_settings(PASSWORD_MIN_LENGTH=2)
     @override_settings(PASSWORD_MAX_LENGTH=10)

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -2116,7 +2116,7 @@ INSTALLED_APPS = [
 
     # Our courseware
     'courseware',
-    'student',
+    'student.apps.StudentConfig',
 
     'static_template_view',
     'staticbook',

--- a/lms/templates/email_change_failed.html
+++ b/lms/templates/email_change_failed.html
@@ -8,7 +8,11 @@
     <h1 class="invalid">${_("E-mail change failed")}</h1>
     <hr class="horizontal-divider">
 
+    % if err_msg is not UNDEFINED:
+    <p>${err_msg}</p>
+    % else:
     <p>${_("We were unable to send a confirmation email to {email}").format(email=email)}</p>
+    % endif
 
     <p>${_('Go back to the {link_start}home page{link_end}.').format(link_start='<a href="/">', link_end='</a>')}</p>
   </section>

--- a/openedx/core/djangoapps/user_api/config/waffle.py
+++ b/openedx/core/djangoapps/user_api/config/waffle.py
@@ -1,0 +1,21 @@
+"""
+Waffle flags and switches to change user API functionality.
+"""
+from __future__ import absolute_import
+
+from django.utils.translation import ugettext_lazy as _
+
+from openedx.core.djangoapps.waffle_utils import WaffleSwitchNamespace
+
+SYSTEM_MAINTENANCE_MSG = _(u'System maintenance in progress. Please try again later.')
+WAFFLE_NAMESPACE = u'user_api'
+
+# Switches
+PREVENT_AUTH_USER_WRITES = u'prevent_auth_user_writes'
+
+
+def waffle():
+    """
+    Returns the namespaced, cached, audited Waffle class for user_api.
+    """
+    return WaffleSwitchNamespace(name=WAFFLE_NAMESPACE, log_prefix=u'UserAPI: ')


### PR DESCRIPTION
For the Django 1.11 upgrade, we need to run a migration on the `auth_user` table which will block writes to it for an estimated 10-30 minutes.  This would normally result in many of our gunicorn workers getting tied up waiting for write locks, so this PR adds a waffle switch which prevents most such write attempts, usually opting to instead fail immediately with an appropriate error message.  The plan is to enable this switch just before running the migration and disable it again immediately afterwards.  The switch causes the following actions to fail and inform the user that system maintenance is in progress:

* Registration of a new user account
* Activating a user account from an emailed link
* Confirming a password change
* Confirming a change of email address

Additionally, user logins don't update the `auth_user.last_login` timestamp while the switch is active.

Django 2.0 introduced another migration that changes the length of a field in `auth_user`, so we will probably need to use this switch again in the future.