### PR TITLE
EDUCATOR-2419 No upgrade deadline for professional courses

### DIFF
--- a/common/djangoapps/student/models.py
+++ b/common/djangoapps/student/models.py
@@ -1726,7 +1726,7 @@ class CourseEnrollment(models.Model):
                 log.debug('Schedules: Returning None since dynamic upgrade deadline has already passed.')
                 return None
 
-            if self.verified_mode is None:
+            if self.verified_mode is None or CourseMode.is_professional_mode(self.verified_mode):
                 log.debug('Schedules: Returning None for dynamic upgrade deadline since the course does not have a '
                           'verified mode.')
                 return None

--- a/common/djangoapps/student/tests/test_models.py
+++ b/common/djangoapps/student/tests/test_models.py
@@ -179,3 +179,21 @@ class CourseEnrollmentTests(SharedModuleStoreTestCase):
         ScheduleFactory(enrollment=enrollment)
         self.assertIsNotNone(enrollment.schedule)
         self.assertEqual(enrollment.upgrade_deadline, course_upgrade_deadline)
+
+    @skip_unless_lms
+    def test_upgrade_deadline_with_schedule_and_professional_mode(self):
+        """
+        Deadline should be None for courses with professional mode.
+
+        Regression test for EDUCATOR-2419.
+        """
+        course = CourseFactory(self_paced=True)
+        CourseModeFactory(
+            course_id=course.id,
+            mode_slug=CourseMode.PROFESSIONAL,
+        )
+        enrollment = CourseEnrollmentFactory(course_id=course.id, mode=CourseMode.AUDIT)
+        DynamicUpgradeDeadlineConfiguration.objects.create(enabled=True)
+        ScheduleFactory(enrollment=enrollment)
+        self.assertIsNotNone(enrollment.schedule)
+        self.assertIsNone(enrollment.upgrade_deadline)


### PR DESCRIPTION
CourseMode.PROFESSIONAL is technically a verified type of CourseMode, but we really wanted to return a date in this function ONLY for CourseMode.VERIFIED.

FYI: @waheedahmed @attiyaIshaque @mulby 