### PR TITLE
Allow `@` in username in Staff Debug interface

### DIFF
--- a/common/djangoapps/student/models.py
+++ b/common/djangoapps/student/models.py
@@ -2276,7 +2276,7 @@ def get_user_by_username_or_email(username_or_email):
     username_or_email = strip_if_string(username_or_email)
     # there should be one user with either username or email equal to username_or_email
     user = User.objects.get(Q(email=username_or_email) | Q(username=username_or_email))
-    if user is not None and user.username == username_or_email:
+    if user.username == username_or_email:
         UserRetirementRequest = apps.get_model('user_api', 'UserRetirementRequest')
         if UserRetirementRequest.has_user_requested_retirement(user):
             raise User.DoesNotExist

--- a/common/djangoapps/student/models.py
+++ b/common/djangoapps/student/models.py
@@ -2269,9 +2269,11 @@ def get_user_by_username_or_email(username_or_email):
         retired, or the user is in the process of being retired.
     """
     username_or_email = strip_if_string(username_or_email)
+    user = None
     if '@' in username_or_email:
-        user = User.objects.get(email=username_or_email)
-    else:
+        user = User.objects.filter(email=username_or_email).first()
+
+    if user is None:
         user = User.objects.get(username=username_or_email)
         UserRetirementRequest = apps.get_model('user_api', 'UserRetirementRequest')
         if UserRetirementRequest.has_user_requested_retirement(user):

--- a/lms/djangoapps/instructor/tests/test_tools.py
+++ b/lms/djangoapps/instructor/tests/test_tools.py
@@ -8,6 +8,7 @@ import unittest
 
 import mock
 import six
+from django.contrib.auth.models import User
 from django.test import TestCase
 from django.test.utils import override_settings
 from pytz import UTC
@@ -357,3 +358,31 @@ def msk_from_problem_urlname(course_id, urlname, block_type='problem'):
         urlname = urlname[:-4]
 
     return course_id.make_usage_key(block_type, urlname)
+
+
+@attr(shard=1)
+class TestStudentFromIdentifier(TestCase):
+    """
+    Test get_student_from_identifier()
+    """
+    def setUp(self):
+        """
+        Fixtures
+        """
+        super(TestStudentFromIdentifier, self).setUp()
+        self.students = [
+            UserFactory.create(username='foo@touchstone'),  # a student with character `@` in user name
+            UserFactory.create()
+        ]
+
+    def test_valid_student_id(self):
+        for student in self.students:
+            assert student == tools.get_student_from_identifier(student.username)
+
+    def test_valid_student_email(self):
+        for student in self.students:
+            assert student == tools.get_student_from_identifier(student.email)
+
+    def test_invalid_student_id(self):
+        with self.assertRaises(User.DoesNotExist):
+            assert tools.get_student_from_identifier("invalid")

--- a/lms/djangoapps/instructor/tests/test_tools.py
+++ b/lms/djangoapps/instructor/tests/test_tools.py
@@ -389,6 +389,9 @@ class TestStudentFromIdentifier(TestCase):
         with self.assertRaises(MultipleObjectsReturned):
             tools.get_student_from_identifier(self.duplicate_user_name.username)
 
+        # can get student with alternative identifier, in this case email.
+        assert self.duplicate_user_name == tools.get_student_from_identifier(self.duplicate_user_name.email)
+
     def test_student_email_has_conflict_with_others_username(self):
         """
         An edge case where there is a user A with email example: foo@touchstone.com and
@@ -396,6 +399,9 @@ class TestStudentFromIdentifier(TestCase):
         """
         with self.assertRaises(MultipleObjectsReturned):
             tools.get_student_from_identifier(self.duplicate_email.email)
+
+        # can get student with alternative identifier, in this case username.
+        assert self.duplicate_email == tools.get_student_from_identifier(self.duplicate_email.username)
 
     def test_invalid_student_id(self):
         """Test with invalid identifier"""

--- a/lms/djangoapps/instructor/tests/test_tools.py
+++ b/lms/djangoapps/instructor/tests/test_tools.py
@@ -370,8 +370,8 @@ class TestStudentFromIdentifier(TestCase):
     def setUpClass(cls):
         super(TestStudentFromIdentifier, cls).setUpClass()
         cls.valid_student = UserFactory.create(username='baz@touchstone')
-        cls.duplicate_email = UserFactory.create(email='foo@touchstone.com')
-        cls.duplicate_user_name = UserFactory.create(username='foo@touchstone.com')
+        cls.student_conflicting_email = UserFactory.create(email='foo@touchstone.com')
+        cls.student_conflicting_username = UserFactory.create(username='foo@touchstone.com')
 
     def test_valid_student_id(self):
         """Test with valid username"""
@@ -387,10 +387,12 @@ class TestStudentFromIdentifier(TestCase):
         there is user B with email example: foo@touchstone.com
         """
         with self.assertRaises(MultipleObjectsReturned):
-            tools.get_student_from_identifier(self.duplicate_user_name.username)
+            tools.get_student_from_identifier(self.student_conflicting_username.username)
 
         # can get student with alternative identifier, in this case email.
-        assert self.duplicate_user_name == tools.get_student_from_identifier(self.duplicate_user_name.email)
+        assert self.student_conflicting_username == tools.get_student_from_identifier(
+            self.student_conflicting_username.email
+        )
 
     def test_student_email_has_conflict_with_others_username(self):
         """
@@ -398,10 +400,12 @@ class TestStudentFromIdentifier(TestCase):
         there is user B with username example: foo@touchstone.com
         """
         with self.assertRaises(MultipleObjectsReturned):
-            tools.get_student_from_identifier(self.duplicate_email.email)
+            tools.get_student_from_identifier(self.student_conflicting_email.email)
 
         # can get student with alternative identifier, in this case username.
-        assert self.duplicate_email == tools.get_student_from_identifier(self.duplicate_email.username)
+        assert self.student_conflicting_email == tools.get_student_from_identifier(
+            self.student_conflicting_email.username
+        )
 
     def test_invalid_student_id(self):
         """Test with invalid identifier"""

--- a/lms/djangoapps/instructor/views/api.py
+++ b/lms/djangoapps/instructor/views/api.py
@@ -18,7 +18,12 @@ import time
 import unicodecsv
 from django.conf import settings
 from django.contrib.auth.models import User
-from django.core.exceptions import ObjectDoesNotExist, PermissionDenied, ValidationError
+from django.core.exceptions import (
+    MultipleObjectsReturned,
+    ObjectDoesNotExist,
+    PermissionDenied,
+    ValidationError
+)
 from django.core.mail.message import EmailMessage
 from django.core.urlresolvers import reverse
 from django.core.validators import validate_email
@@ -153,6 +158,8 @@ def common_exceptions_400(func):
             return func(request, *args, **kwargs)
         except User.DoesNotExist:
             message = _('User does not exist.')
+        except MultipleObjectsReturned:
+            message = _('Found a conflict with given identifier. Please try an alternative identifier')
         except (AlreadyRunningError, QueueConnectionError) as err:
             message = unicode(err)
 


### PR DESCRIPTION
### What are the relevant tickets?
fixes https://github.com/mitodl/edx-platform/issues/76
fixes https://github.com/mitodl/edx-platform/issues/75

#### What's this PR do?
It allows to query users who have special characters like `@` in user name, before this PR edX code on consider an identifier as email if it has `@` in it.

#### How should this be manually tested?
- enable feature flag `ENABLE_UNICODE_USERNAME: true` in lms.env.json and cms.env.json
- register new student with `@` in there user name
- login with this student and attempt a problem in course
- login as staff and try to reset user score or reset state. Use user name of student instead of email. It should work

@pdpinch
  
<img width="1099" alt="screen shot 2018-02-28 at 7 54 00 pm" src="https://user-images.githubusercontent.com/10431250/36794070-26b19732-1cc1-11e8-933d-ce79f4a93ec7.png">
