### PR TITLE
Return expected Dict when Discovery API fails or returns nothing

### DIFF
--- a/openedx/core/djangoapps/catalog/utils.py
+++ b/openedx/core/djangoapps/catalog/utils.py
@@ -282,6 +282,7 @@ def get_course_runs_for_course(course_uuid):
             api=api,
             cache_key=cache_key if catalog_integration.is_cache_enabled else None,
             long_term_cache=True,
+            many=False
         )
         return data.get('course_runs', [])
     else:


### PR DESCRIPTION
Bug fix to ensure the type returned from the api client is the expected type.