### PR TITLE
Course outline styling

### DIFF
--- a/lms/static/sass/features/_course-experience.scss
+++ b/lms/static/sass/features/_course-experience.scss
@@ -413,11 +413,12 @@
 
 // Course outline accordion
 button.accordion-trigger, button.prerequisite-button {
-  padding: 10px 0 10px 0;
+  padding: 10px 0 10px 2px;
   border: none;
   width: 100%;
   text-align: left;
   margin: 0px;
+  background: none;
 
   .fa {
     color: $blue;


### PR DESCRIPTION
### Continuation of [EDUCATOR-2095](https://openedx.atlassian.net/browse/EDUCATOR-2095)

Some more course outline styling, including:

- Weird grey buttons in Firefox and Safari
<img width="703" alt="screen shot 2018-02-28 at 2 17 58 pm" src="https://user-images.githubusercontent.com/6182097/36807963-440a7a76-1c92-11e8-99d5-40ba5922895b.png">

- Lump in bounding box around chevron toggle button 
<img width="825" alt="screen shot 2018-02-28 at 2 17 29 pm" src="https://user-images.githubusercontent.com/6182097/36807953-3c774bc2-1c92-11e8-9f34-fcd2ddc8195e.png">

[Sandbox](https://button.sandbox.edx.org) - Check in all browsers