### PR TITLE
Youngstrom/fix new window failures

### DIFF
--- a/common/test/acceptance/pages/studio/container.py
+++ b/common/test/acceptance/pages/studio/container.py
@@ -8,6 +8,7 @@ from bok_choy.promise import EmptyPromise, Promise
 from common.test.acceptance.pages.common.utils import click_css, confirm_prompt
 from common.test.acceptance.pages.studio import BASE_URL
 from common.test.acceptance.pages.studio.utils import HelpMixin, type_in_codemirror
+from common.test.acceptance.tests.helpers import click_and_wait_for_window
 
 
 class ContainerPage(PageObject, HelpMixin):
@@ -224,7 +225,7 @@ class ContainerPage(PageObject, HelpMixin):
 
         Switches the browser to the newly opened LMS window.
         """
-        self.q(css='.button-view').first.click()
+        click_and_wait_for_window(self, self.q(css='.button-view').first)
         self._switch_to_lms()
 
     def verify_publish_title(self, expected_title):

--- a/common/test/acceptance/pages/studio/overview.py
+++ b/common/test/acceptance/pages/studio/overview.py
@@ -291,16 +291,16 @@ class CourseOutlineContainer(CourseOutlineItem):
                 self._bounded_selector(self.ADD_BUTTON_SELECTOR), 'Toggle control is present'
             )
             css_element = self._bounded_selector(self.ADD_BUTTON_SELECTOR)
-            add_button = self.q(css=css_element).first.results # pylint: disable=no-member
-            self.scroll_to_element(css_element) # pylint: disable=no-member
+            add_button = self.q(css=css_element).first.results  # pylint: disable=no-member
+            self.scroll_to_element(css_element)  # pylint: disable=no-member
             return add_button and add_button[0].is_displayed()
 
         currently_expanded = subsection_expanded()
 
         # Need to click slightly off-center in order for the click to be recognized.
         css_element = self._bounded_selector('.ui-toggle-expansion .fa')
-        self.scroll_to_element(css_element) # pylint: disable=no-member
-        ele = self.browser.find_element_by_css_selector(css_element) # pylint: disable=no-member
+        self.scroll_to_element(css_element)  # pylint: disable=no-member
+        ele = self.browser.find_element_by_css_selector(css_element)  # pylint: disable=no-member
         ActionChains(self.browser).move_to_element_with_offset(ele, 8, 8).click().perform()  # pylint: disable=no-member
         self.wait_for_element_presence(self._bounded_selector(self.ADD_BUTTON_SELECTOR), 'Subsection is expanded')
 
@@ -319,7 +319,7 @@ class CourseOutlineContainer(CourseOutlineItem):
         Return whether this outline item is currently collapsed.
         """
         css_element = self._bounded_selector('')
-        self.scroll_to_element(css_element) # pylint: disable=no-member
+        self.scroll_to_element(css_element)  # pylint: disable=no-member
         return "is-collapsed" in self.q(css=css_element).first.attrs("class")[0]  # pylint: disable=no-member
 
 

--- a/common/test/acceptance/pages/studio/utils.py
+++ b/common/test/acceptance/pages/studio/utils.py
@@ -7,7 +7,7 @@ from selenium.webdriver.common.action_chains import ActionChains
 from selenium.webdriver.common.keys import Keys
 
 from common.test.acceptance.pages.common.utils import click_css, sync_on_notification
-from common.test.acceptance.tests.helpers import wait_for_help_window
+from common.test.acceptance.tests.helpers import click_and_wait_for_window
 
 NAV_HELP_NOT_SIGNED_IN_CSS = '.nav-item.nav-not-signedin-help a'
 NAV_HELP_CSS = '.nav-item.nav-account-help a'
@@ -290,7 +290,7 @@ class HelpMixin(object):
             element_css = NAV_HELP_NOT_SIGNED_IN_CSS
 
         help_element = self.q(css=element_css).results[0]
-        wait_for_help_window(self, help_element)
+        click_and_wait_for_window(self, help_element)
         return help_element
 
     def get_side_bar_help_element_and_click_help(self, as_list_item=False, index=-1):
@@ -315,5 +315,5 @@ class HelpMixin(object):
             element_css = SIDE_BAR_HELP_CSS
 
         help_element = self.q(css=element_css).results[index]
-        wait_for_help_window(self, help_element)
+        click_and_wait_for_window(self, help_element)
         return help_element

--- a/common/test/acceptance/tests/helpers.py
+++ b/common/test/acceptance/tests/helpers.py
@@ -848,6 +848,23 @@ class YouTubeStubConfig(object):
             return {}
 
 
+def click_and_wait_for_window(page, element):
+    """
+    To avoid a race condition, click an element that launces a new window, and
+    wait for that window to launch.
+    To check this, make sure the number of window_handles increases by one.
+
+    Arguments:
+    page (PageObject): Page object to perform method on
+    element (WebElement): Clickable element that triggers the new window to open
+    """
+    num_windows = len(page.browser.window_handles)
+    element.click()
+    WebDriverWait(page.browser, 10).until(
+        lambda driver: len(driver.window_handles) > num_windows
+    )
+
+
 def create_user_partition_json(partition_id, name, description, groups, scheme="random"):
     """
     Helper method to create user partition JSON. If scheme is not supplied, "random" is used.
@@ -859,18 +876,6 @@ def create_user_partition_json(partition_id, name, description, groups, scheme="
     return UserPartition(
         partition_id, name, description, groups, MockScheme()
     ).to_json()
-
-
-def wait_for_help_window(page, help_element):
-    """
-    To avoid a race condition, wait for the help window to launch.
-    To check this, make sure the number of window_handles increases by one.
-    """
-    num_windows = len(page.browser.window_handles)
-    help_element.click()
-    WebDriverWait(page.browser, 10).until(
-        lambda driver: len(driver.window_handles) > num_windows
-    )
 
 
 def assert_nav_help_link(test, page, href, signed_in=True, close_window=True):

--- a/common/test/acceptance/tests/lms/test_lms_help.py
+++ b/common/test/acceptance/tests/lms/test_lms_help.py
@@ -10,7 +10,7 @@ from common.test.acceptance.tests.studio.base_studio_test import ContainerBase
 from common.test.acceptance.tests.helpers import (
     assert_opened_help_link_is_correct,
     url_for_help,
-    wait_for_help_window
+    click_and_wait_for_window
 )
 
 
@@ -33,7 +33,7 @@ class TestCohortHelp(ContainerBase, CohortTestMixin):
         """
         help_element = self.cohort_management.get_cohort_help_element()
         self.assertEqual(help_element.text, "What does this mean?")
-        wait_for_help_window(self, help_element)
+        click_and_wait_for_window(self, help_element)
         assert_opened_help_link_is_correct(self, href)
 
     def test_manual_cohort_help(self):
@@ -98,5 +98,5 @@ class InstructorDashboardHelp(BaseInstructorDashboardTest):
         """
         href = url_for_help('course_author', '/CA_instructor_dash_help.html')
         help_element = self.instructor_dashboard_page.get_help_element()
-        wait_for_help_window(self, help_element)
+        click_and_wait_for_window(self, help_element)
         assert_opened_help_link_is_correct(self, href)


### PR DESCRIPTION
Refactor the changes I made for the help tests to be more general so we can use the helper function to fix these flaky tests.

Fixes:
```
acceptance.tests.studio.test_studio_container.UnitPublishingTest.test_view_live_after_publish
acceptance.tests.studio.test_studio_container.UnitPublishingTest.test_view_live_changes
acceptance.tests.studio.test_studio_split_test.GroupConfigurationsTest.test_split_test_LMS_staff_view 
```

And the quality failures I introduced last PR...