### PR TITLE
Replace main tag with div to compliance HTML5 standard

### DIFF
--- a/openedx/features/course_experience/templates/course_experience/course-home-fragment.html
+++ b/openedx/features/course_experience/templates/course_experience/course-home-fragment.html
@@ -80,7 +80,7 @@ from openedx.features.portfolio_project import INCLUDE_PORTFOLIO_UPSELL_MODAL
         </div>
     </header>
     <div class="page-content">
-        <main class="page-content-main">
+        <div class="page-content-main">
             % if course_home_message_fragment:
                 ${HTML(course_home_message_fragment.body_html())}
             % endif
@@ -94,7 +94,7 @@ from openedx.features.portfolio_project import INCLUDE_PORTFOLIO_UPSELL_MODAL
             % if outline_fragment:
                 ${HTML(outline_fragment.body_html())}
             % endif
-        </main>
+        </div>
         <aside class="page-content-secondary course-sidebar">
             % if has_goal_permission:
                 <div class="section section-goals ${'' if current_goal else 'hidden'}">

--- a/openedx/features/course_experience/templates/course_experience/course-outline-fragment-old.html
+++ b/openedx/features/course_experience/templates/course_experience/course-outline-fragment-old.html
@@ -12,7 +12,7 @@ from django.utils.translation import ugettext as _
 from openedx.core.djangolib.markup import HTML, Text
 %>
 
-<main role="main" class="course-outline" id="main" tabindex="-1">
+<main class="course-outline" id="main" aria-label="Content" tabindex="-1">
     % if blocks.get('children'):
         <ol class="block-tree">
             % for section in blocks.get('children'):


### PR DESCRIPTION
## [LEARNER-4233](https://openedx.atlassian.net/browse/LEARNER-4233)

### Description
Course outline page uses two main tags that violates modern HTML5 standard that recommends only single main tag on a webpage.To make it compliance with modern standard the enclosing main tag is replaced with div which will improve accessibility.