### PR TITLE
Fail js tests if dirty package-lock

### DIFF
--- a/pavelib/quality.py
+++ b/pavelib/quality.py
@@ -303,7 +303,10 @@ def run_complexity():
 
 
 @task
-@needs('pavelib.prereqs.install_node_prereqs')
+@needs(
+    'pavelib.prereqs.install_node_prereqs',
+    'pavelib.utils.test.utils.ensure_clean_package_lock',
+)
 @cmdopts([
     ("limit=", "l", "limit for number of acceptable violations"),
 ])

--- a/pavelib/utils/test/utils.py
+++ b/pavelib/utils/test/utils.py
@@ -33,6 +33,18 @@ def clean_test_files():
     sh("rm -rf /tmp/mako_[cl]ms")
 
 
+@task
+@timed
+def ensure_clean_package_lock():
+    """
+    Ensure no untracked changes have been made in the current git context.
+    """
+    sh("""
+      git diff --name-only --exit-code package-lock.json ||
+      (echo \"Dirty package-lock.json, run 'npm install' and commit the generated changes\" && exit 1)
+    """)
+
+
 def clean_dir(directory):
     """
     Delete all the files from the specified directory.


### PR DESCRIPTION
# [EDUCATOR-2422](https://openedx.atlassian.net/browse/EDUCATOR-2422)

Checks for a dirty package-lock ~~while~~before running ~~js~~eslint tests.

@edx/educator-dahlia 

Initial attempt mistakenly checked after a mocked `npm install`, new approach is to make the package-lock check a prerequisite of running eslint tests.