### PR TITLE
Entrance exam test bug fixes

### DIFF
--- a/common/test/acceptance/pages/common/__init__.py
+++ b/common/test/acceptance/pages/common/__init__.py
@@ -2,7 +2,7 @@ import os
 
 HOSTNAME = os.environ.get('BOK_CHOY_HOSTNAME', 'localhost')
 CMS_PORT = os.environ.get('BOK_CHOY_CMS_PORT', 8031)
-LMS_PORT = os.environ.get('BOK_CHOY_CMS_PORT', 8003)
+LMS_PORT = os.environ.get('BOK_CHOY_LMS_PORT', 8003)
 
 # Get the URL of the instance under test
 BASE_URL = os.environ.get('test_url', 'http://{}:{}'.format(HOSTNAME, LMS_PORT))

--- a/common/test/acceptance/pages/studio/settings.py
+++ b/common/test/acceptance/pages/studio/settings.py
@@ -260,18 +260,21 @@ class SettingsPage(CoursePage):
         Set the entrance exam requirement via the checkbox.
         """
         checkbox = self.entrance_exam_field
+        # Wait for license section to load before interacting with the checkbox to avoid race condition
+        self.wait_for_element_presence('div.wrapper-license', 'License section present')
         selected = checkbox.is_selected()
+        self.scroll_to_element('#entrance-exam-enabled')
         if required and not selected:
             checkbox.click()
-            self.wait_for_element_visibility(
+            self.wait_for_element_presence(
                 '#entrance-exam-minimum-score-pct',
-                'Entrance exam minimum score percent is visible'
+                'Entrance exam minimum score percent is present'
             )
         if not required and selected:
             checkbox.click()
-            self.wait_for_element_invisibility(
+            self.wait_for_element_absence(
                 '#entrance-exam-minimum-score-pct',
-                'Entrance exam minimum score percent is invisible'
+                'Entrance exam minimum score percent is absent'
             )
 
     def save_changes(self, wait_for_confirmation=True):

--- a/common/test/acceptance/tests/lms/test_lms.py
+++ b/common/test/acceptance/tests/lms/test_lms.py
@@ -1010,7 +1010,7 @@ class EntranceExamTest(UniqueCourseTest):
 
         # visit course settings page and set/enabled entrance exam for that course.
         self.settings_page.visit()
-        self.settings_page.entrance_exam_field.click()
+        self.settings_page.require_entrance_exam()
         self.settings_page.save_changes()
 
         # Logout and login as a student.
@@ -1047,7 +1047,7 @@ class EntranceExamTest(UniqueCourseTest):
 
         # visit course settings page and set/enabled entrance exam for that course.
         self.settings_page.visit()
-        self.settings_page.entrance_exam_field.click()
+        self.settings_page.require_entrance_exam()
         self.settings_page.save_changes()
 
         # Logout and login as a student.


### PR DESCRIPTION
The biggest hurdle here was that the license section at the bottom doesn't load right away, and if the checkbox gets clicked before that happens, it doesn't remain "checked" and the test times out. Adding a wait fixes that race condition.

Fixes:
Shard 1:
```
acceptance.tests.lms.test_lms.EntranceExamTest.test_entrance_exam_section
acceptance.tests.lms.test_lms.EntranceExamTest.test_entrance_exam_section_2
```
Shard 4:
```
acceptance.tests.studio.test_studio_settings_details.SettingsMilestonesTest.test_entrance_exam_has_unit_button
```