### PR TITLE
fix: closed caption can't move when mutiple videos in one page.

### DIFF
--- a/common/lib/xmodule/xmodule/js/src/video/09_video_caption.js
+++ b/common/lib/xmodule/xmodule/js/src/video/09_video_caption.js
@@ -1222,7 +1222,8 @@
             },
 
             listenForDragDrop: function() {
-                var captions = document.querySelector('.closed-captions'),
+                //var captions = document.querySelector('.closed-captions'),
+                var captions = this.captionDisplayEl['0'],
                     draggable;
 
                 if (typeof Draggabilly === 'function') {


### PR DESCRIPTION
captions = document.querySelector('.closed-captions')  is global