### PR TITLE
scroll to course on dashboard

### DIFF
--- a/common/test/acceptance/pages/studio/index.py
+++ b/common/test/acceptance/pages/studio/index.py
@@ -83,6 +83,13 @@ class DashboardPage(PageObject, HelpMixin):
         # Clicking on course with run will trigger an ajax event
         self.wait_for_ajax()
 
+    def scroll_to_course(self, course_key):
+        """
+        Scroll down to the course element
+        """
+        element = '[data-course-key*="{}"]'.format(course_key)
+        self.scroll_to_element(element)
+
     def has_new_library_button(self):
         """
         (bool) is the "New Library" button present?

--- a/common/test/acceptance/tests/studio/test_studio_rerun.py
+++ b/common/test/acceptance/tests/studio/test_studio_rerun.py
@@ -70,6 +70,7 @@ class CourseRerunTest(StudioCourseTest):
         updated_course_info = course_info[0] + "+" + course_info[1] + "+" + course_info[2]
 
         self.dashboard_page.visit()
+        self.dashboard_page.scroll_to_course(course_info[1])
         self.dashboard_page.create_rerun(updated_course_info)
 
         rerun_page = CourseRerunPage(self.browser, *course_info)


### PR DESCRIPTION
The course to rerun is occasionally further down on the page, and it seems actionchains w/ marionette need to be within the viewport