### PR TITLE
Move requirements of local packages to the global requirements

### DIFF
--- a/common/lib/calc/setup.py
+++ b/common/lib/calc/setup.py
@@ -4,9 +4,4 @@ setup(
     name="calc",
     version="0.2",
     packages=["calc"],
-    install_requires=[
-        "pyparsing==2.0.7",
-        "numpy==1.6.2",
-        "scipy==0.14.0",
-    ],
 )

--- a/common/lib/capa/setup.py
+++ b/common/lib/capa/setup.py
@@ -4,9 +4,4 @@ setup(
     name="capa",
     version="0.1",
     packages=find_packages(exclude=["tests"]),
-    install_requires=[
-        "setuptools",
-        "lxml",
-        "pytz"
-    ],
 )

--- a/common/lib/chem/setup.py
+++ b/common/lib/chem/setup.py
@@ -4,10 +4,4 @@ setup(
     name="chem",
     version="0.1.2",
     packages=["chem"],
-    install_requires=[
-        "pyparsing==2.0.7",
-        "numpy==1.6.2",
-        "scipy==0.14.0",
-        "nltk==3.2.5",
-    ],
 )

--- a/common/lib/dogstats/setup.py
+++ b/common/lib/dogstats/setup.py
@@ -4,7 +4,4 @@ setup(
     name="dogstats_wrapper",
     version="0.1",
     packages=["dogstats_wrapper"],
-    install_requires=[
-        "dogapi",
-    ],
 )

--- a/common/lib/safe_lxml/setup.py
+++ b/common/lib/safe_lxml/setup.py
@@ -8,8 +8,4 @@ setup(
     name="safe_lxml",
     version="1.0",
     packages=["safe_lxml"],
-    install_requires=[
-        "lxml",
-        "defusedxml"
-    ],
 )

--- a/common/lib/symmath/setup.py
+++ b/common/lib/symmath/setup.py
@@ -4,7 +4,4 @@ setup(
     name="symmath",
     version="0.2",
     packages=["symmath"],
-    install_requires=[
-        "sympy==0.7.1",
-    ],
 )

--- a/common/lib/xmodule/setup.py
+++ b/common/lib/xmodule/setup.py
@@ -49,14 +49,6 @@ setup(
     name="XModule",
     version="0.1.1",
     packages=find_packages(exclude=["tests"]),
-    install_requires=[
-        'setuptools',
-        'docopt',
-        'capa',
-        'path.py',
-        'webob',
-        'edx-opaque-keys>=0.4.0,<1.0.0',
-    ],
     package_data={
         'xmodule': ['js/module/*'],
     },

--- a/openedx/core/lib/xblock_builtin/xblock_discussion/setup.py
+++ b/openedx/core/lib/xblock_builtin/xblock_discussion/setup.py
@@ -23,9 +23,6 @@ setup(
     name='xblock-discussion',
     version='0.1',
     description='XBlock - Discussion',
-    install_requires=[
-        'XBlock',
-    ],
     entry_points={
         'xblock.v1': [
             'discussion = xblock_discussion:DiscussionXBlock'

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -40,6 +40,7 @@ django-method-override==0.1.0
 django-user-tasks==0.1.5
 django-waffle==0.12.0
 djangorestframework-jwt==1.11.0
+docopt==0.6.2
 docutils==0.14
 enum34==1.1.6
 edx-ace==0.1.6
@@ -128,6 +129,7 @@ unicodecsv==0.14.1
 django-require==1.0.11
 django-webpack-loader==0.4.1
 pyuca==1.1
+webob==1.7.4
 zendesk==1.1.1
 
 # XBlocks


### PR DESCRIPTION
# What

The purpose of this PR is to move all Python dependencies listed in submodules to the global requirements.

# Why

Initially, the idea for this change was an attempt to speed-up installation in a Docker dev environment.
When building the Docker image, the installation of dependencies is done early in the Dockerfile so that the layer is cached and doesn't need to be reinstalled each time we change a line in the code base. Thanks to this commit, we can build images for our dev and staging environments in a pair of seconds versus minutes before.

This is not vital nor very important but we thought we should submit this PR because we also feel that it might be better for consistency to keep all requirements in one place. For example, you will see in the commit that, out of all the requirements expressed in the submodules setup.py files, only 2 were not already covered in global requirements.
