### PR TITLE
Remove reference to reason field, add action field

### DIFF
--- a/common/djangoapps/entitlements/admin.py
+++ b/common/djangoapps/entitlements/admin.py
@@ -58,7 +58,6 @@ class CourseEntitlementSupportDetailAdmin(admin.ModelAdmin):
     """
     list_display = ('entitlement',
                     'support_user',
-                    'reason',
                     'comments',
                     'unenrolled_run')
     raw_id_fields = ('unenrolled_run', 'support_user',)

--- a/common/djangoapps/entitlements/migrations/0006_courseentitlementsupportdetail_action.py
+++ b/common/djangoapps/entitlements/migrations/0006_courseentitlementsupportdetail_action.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('entitlements', '0005_courseentitlementsupportdetail'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='courseentitlementsupportdetail',
+            name='action',
+            field=models.CharField(default='CREATE', max_length=15, choices=[(b'REISSUE', b'Re-issue entitlement'), (b'CREATE', b'Create new entitlement')]),
+            preserve_default=False,
+        ),
+    ]

--- a/common/djangoapps/entitlements/models.py
+++ b/common/djangoapps/entitlements/models.py
@@ -420,6 +420,7 @@ class CourseEntitlementSupportDetail(TimeStampedModel):
     """
     Table recording support interactions with an entitlement
     """
+    # Reasons deprecated
     LEAVE_SESSION = 'LEAVE'
     CHANGE_SESSION = 'CHANGE'
     LEARNER_REQUEST_NEW = 'LEARNER_NEW'
@@ -432,10 +433,21 @@ class CourseEntitlementSupportDetail(TimeStampedModel):
         (COURSE_TEAM_REQUEST_NEW, u'Course team requested entitlement for learnerg'),
         (OTHER, u'Other'),
     )
+
+    REISSUE = 'REISSUE'
+    CREATE = 'CREATE'
+    ENTITLEMENT_SUPPORT_ACTIONS = (
+        (REISSUE, 'Re-issue entitlement'),
+        (CREATE, 'Create new entitlement'),
+    )
+
     entitlement = models.ForeignKey('entitlements.CourseEntitlement')
     support_user = models.ForeignKey(settings.AUTH_USER_MODEL)
 
+    #Deprecated: use action instead.
     reason = models.CharField(max_length=15, choices=ENTITLEMENT_SUPPORT_REASONS)
+    action = models.CharField(max_length=15, choices=ENTITLEMENT_SUPPORT_ACTIONS)
+
     comments = models.TextField(null=True)
 
     unenrolled_run = models.ForeignKey(


### PR DESCRIPTION
As work progressed on entitlement support tool,
additional clarity around the entitlement support
detail fields was needed, this adds the action field
at a later point the reason field will be removed

Learner-3925