### PR TITLE
Refactored XBlockAside rendering and added support for student view

### DIFF
--- a/cms/djangoapps/contentstore/views/component.py
+++ b/cms/djangoapps/contentstore/views/component.py
@@ -9,7 +9,6 @@ from django.http import Http404, HttpResponseBadRequest
 from django.utils.translation import ugettext as _
 from django.views.decorators.http import require_GET
 from opaque_keys import InvalidKeyError
-from opaque_keys.edx.asides import AsideUsageKeyV1, AsideUsageKeyV2
 from opaque_keys.edx.keys import UsageKey
 from xblock.core import XBlock
 from xblock.django.request import django_to_webob_request, webob_to_django_response
@@ -17,10 +16,11 @@ from xblock.exceptions import NoSuchHandlerError
 from xblock.plugin import PluginMissingError
 from xblock.runtime import Mixologist
 
-from contentstore.utils import get_lms_link_for_item, get_xblock_aside_instance, reverse_course_url
+from contentstore.utils import get_lms_link_for_item, reverse_course_url
 from contentstore.views.helpers import get_parent_xblock, is_unit, xblock_type_display_name
 from contentstore.views.item import StudioEditModuleRuntime, add_container_page_publishing_info, create_xblock_info
 from edxmako.shortcuts import render_to_response
+from openedx.core.lib.xblock_utils import is_xblock_aside, get_aside_from_xblock
 from student.auth import has_course_author_access
 from xblock_django.api import authorable_xblocks, disabled_xblocks
 from xblock_django.models import XBlockStudioConfigurationFlag
@@ -440,22 +440,23 @@ def component_handler(request, usage_key_string, handler, suffix=''):
         :class:`django.http.HttpResponse`: The response from the handler, converted to a
             django response
     """
-
     usage_key = UsageKey.from_string(usage_key_string)
+
     # Let the module handle the AJAX
     req = django_to_webob_request(request)
 
-    asides = []
-
     try:
-        if isinstance(usage_key, (AsideUsageKeyV1, AsideUsageKeyV2)):
+        if is_xblock_aside(usage_key):
+            # Get the descriptor for the block being wrapped by the aside (not the aside itself)
             descriptor = modulestore().get_item(usage_key.usage_key)
-            aside_instance = get_xblock_aside_instance(usage_key)
-            asides = [aside_instance] if aside_instance else []
+            aside_instance = get_aside_from_xblock(descriptor, usage_key.aside_type)
+            aside_instance.runtime = StudioEditModuleRuntime(request.user)
+            asides = [aside_instance]
             resp = aside_instance.handle(handler, req, suffix)
         else:
             descriptor = modulestore().get_item(usage_key)
             descriptor.xmodule_runtime = StudioEditModuleRuntime(request.user)
+            asides = []
             resp = descriptor.handle(handler, req, suffix)
     except NoSuchHandlerError:
         log.info("XBlock %s attempted to access missing handler %r", descriptor, handler, exc_info=True)

--- a/common/static/common/js/xblock/core.js
+++ b/common/static/common/js/xblock/core.js
@@ -11,6 +11,9 @@
         } else {
             selector = '.' + blockClass;
         }
+        // After an element is initialized, a class is added to it. To avoid repeat initialization, no
+        // elements with that class should be selected.
+        selector += ':not(.xblock-initialized)';
         return $(element).immediateDescendents(selector).map(function(idx, elem) {
             return initializer(elem, requestToken);
         }).toArray();
@@ -112,6 +115,7 @@
         initializeAside: function(element) {
             var blockUsageId = $(element).data('block-id');
             var blockElement = $(element).siblings('[data-usage-id="' + blockUsageId + '"]')[0];
+
             return constructBlock(element, [blockElement, initArgs(element)]);
         },
 

--- a/lms/djangoapps/courseware/module_render.py
+++ b/lms/djangoapps/courseware/module_render.py
@@ -61,7 +61,9 @@ from openedx.core.lib.xblock_utils import (
     replace_course_urls,
     replace_jump_to_id_urls,
     replace_static_urls,
-    wrap_xblock
+    wrap_xblock,
+    is_xblock_aside,
+    get_aside_from_xblock,
 )
 from student.models import anonymous_id_for_user, user_by_anonymous_id
 from student.roles import CourseBetaTesterRole
@@ -1053,7 +1055,15 @@ def _invoke_xblock_handler(request, course_id, usage_id, handler, suffix, course
     set_custom_metrics_for_course_key(course_key)
 
     with modulestore().bulk_operations(course_key):
-        instance, tracking_context = get_module_by_usage_id(request, course_id, usage_id, course=course)
+        usage_key = UsageKey.from_string(usage_id)
+        if is_xblock_aside(usage_key):
+            # Get the usage key for the block being wrapped by the aside (not the aside itself)
+            block_usage_key = usage_key.usage_key
+        else:
+            block_usage_key = usage_key
+        instance, tracking_context = get_module_by_usage_id(
+            request, course_id, unicode(block_usage_key), course=course
+        )
 
         # Name the transaction so that we can view XBlock handlers separately in
         # New Relic. The suffix is necessary for XModule handlers because the
@@ -1066,7 +1076,14 @@ def _invoke_xblock_handler(request, course_id, usage_id, handler, suffix, course
         req = django_to_webob_request(request)
         try:
             with tracker.get_tracker().context(tracking_context_name, tracking_context):
-                resp = instance.handle(handler, req, suffix)
+                if is_xblock_aside(usage_key):
+                    # In this case, 'instance' is the XBlock being wrapped by the aside, so
+                    # the actual aside instance needs to be retrieved in order to invoke its
+                    # handler method.
+                    handler_instance = get_aside_from_xblock(instance, usage_key.aside_type)
+                else:
+                    handler_instance = instance
+                resp = handler_instance.handle(handler, req, suffix)
                 if suffix == 'problem_check' \
                         and course \
                         and getattr(course, 'entrance_exam_enabled', False) \

--- a/openedx/core/lib/xblock_utils/__init__.py
+++ b/openedx/core/lib/xblock_utils/__init__.py
@@ -24,6 +24,7 @@ from web_fragments.fragment import Fragment
 from xblock.core import XBlock
 from xblock.exceptions import InvalidScopeError
 from xblock.scorable import ScorableXBlockMixin
+from opaque_keys.edx.asides import AsideUsageKeyV1, AsideUsageKeyV2
 
 from xmodule.seq_module import SequenceModule
 from xmodule.vertical_block import VerticalBlock
@@ -500,3 +501,31 @@ def xblock_resource_pkg(block):
         return module_name
 
     return module_name.rsplit('.', 1)[0]
+
+
+def is_xblock_aside(usage_key):
+    """
+    Returns True if the given usage key is for an XBlock aside
+
+    Args:
+        usage_key (opaque_keys.edx.keys.UsageKey): A usage key
+
+    Returns:
+        bool: Whether or not the usage key is an aside key type
+    """
+    return isinstance(usage_key, (AsideUsageKeyV1, AsideUsageKeyV2))
+
+
+def get_aside_from_xblock(xblock, aside_type):
+    """
+    Gets an instance of an XBlock aside from the XBlock that it's decorating. This also
+    configures the aside instance with the runtime and fields of the given XBlock.
+
+    Args:
+        xblock (xblock.core.XBlock): The XBlock that the desired aside is decorating
+        aside_type (str): The aside type
+
+    Returns:
+        xblock.core.XBlockAside: Instance of an xblock aside
+    """
+    return xblock.runtime.get_aside_of_type(xblock, aside_type)


### PR DESCRIPTION
**This PR is not merge-ready.** I opened this for a sanity-check on some features we're working on over at MIT ODL. The goal of this work is to get the `XBlockAside` student view working and to make the runtime available to the aside instance (just as it is for normal XBlock instances)