### PR TITLE
switch to library tab failures

### DIFF
--- a/common/test/acceptance/pages/common/__init__.py
+++ b/common/test/acceptance/pages/common/__init__.py
@@ -2,7 +2,7 @@ import os
 
 HOSTNAME = os.environ.get('BOK_CHOY_HOSTNAME', 'localhost')
 CMS_PORT = os.environ.get('BOK_CHOY_CMS_PORT', 8031)
-LMS_PORT = os.environ.get('BOK_CHOY_CMS_PORT', 8003)
+LMS_PORT = os.environ.get('BOK_CHOY_LMS_PORT', 8003)
 
 # Get the URL of the instance under test
 BASE_URL = os.environ.get('test_url', 'http://{}:{}'.format(HOSTNAME, LMS_PORT))

--- a/common/test/acceptance/pages/studio/index.py
+++ b/common/test/acceptance/pages/studio/index.py
@@ -246,8 +246,9 @@ class DashboardPage(PageObject, HelpMixin):
         Click the tab to display the available libraries, and return detail of them.
         """
         # Workaround Selenium/Firefox bug: `.text` property is broken on invisible elements
-        self.wait_for_element_presence('#course-index-tabs .libraries-tab', "Libraries tab")
-        self.q(css='#course-index-tabs .libraries-tab').click()
+        library_tab_css = '#course-index-tabs .libraries-tab'
+        self.wait_for_element_presence(library_tab_css, "Libraries tab")
+        self.q(css=library_tab_css).click()
         if self.q(css='.list-notices.libraries-tab').present:
             # No libraries are available.
             self.wait_for_element_presence('.libraries-tab .new-library-button', "new library tab")

--- a/common/test/acceptance/pages/studio/index.py
+++ b/common/test/acceptance/pages/studio/index.py
@@ -246,16 +246,17 @@ class DashboardPage(PageObject, HelpMixin):
         Click the tab to display the available libraries, and return detail of them.
         """
         # Workaround Selenium/Firefox bug: `.text` property is broken on invisible elements
-        self.q(css='#course-index-tabs .libraries-tab a').click()
+        self.wait_for_element_presence('#course-index-tabs .libraries-tab', "Libraries tab")
+        self.q(css='#course-index-tabs .libraries-tab').click()
         if self.q(css='.list-notices.libraries-tab').present:
             # No libraries are available.
-            self.wait_for_element_visibility('.libraries-tab .new-library-button', "Switch to library tab")
+            self.wait_for_element_presence('.libraries-tab .new-library-button', "new library tab")
             return []
         div2info = lambda element: {
             'name': element.find_element_by_css_selector('.course-title').text,
+            'link_element': element.find_element_by_css_selector('.course-title'),
             'org': element.find_element_by_css_selector('.course-org .value').text,
             'number': element.find_element_by_css_selector('.course-num .value').text,
-            'link_element': element.find_element_by_css_selector('a.library-link'),
             'url': element.find_element_by_css_selector('a.library-link').get_attribute('href'),
         }
         self.wait_for_element_visibility('.libraries li.course-item', "Switch to library tab")


### PR DESCRIPTION
The link element wasn't clickable based on what was being returned. Instead we need to return the course title element. We should also make sure elemenets are present before clicking on them. I've noticed some weird flakiness(?) where assuring that things are visible still allows race conditions.