### PR TITLE
Remove EntitlementSupportDetails reason field

### DIFF
--- a/common/djangoapps/entitlements/migrations/0007_remove_courseentitlementsupportdetail_reason.py
+++ b/common/djangoapps/entitlements/migrations/0007_remove_courseentitlementsupportdetail_reason.py
@@ -1,0 +1,18 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('entitlements', '0006_courseentitlementsupportdetail_action'),
+    ]
+
+    operations = [
+        migrations.RemoveField(
+            model_name='courseentitlementsupportdetail',
+            name='reason',
+        ),
+    ]

--- a/common/djangoapps/entitlements/models.py
+++ b/common/djangoapps/entitlements/models.py
@@ -420,20 +420,6 @@ class CourseEntitlementSupportDetail(TimeStampedModel):
     """
     Table recording support interactions with an entitlement
     """
-    # Reasons deprecated
-    LEAVE_SESSION = 'LEAVE'
-    CHANGE_SESSION = 'CHANGE'
-    LEARNER_REQUEST_NEW = 'LEARNER_NEW'
-    COURSE_TEAM_REQUEST_NEW = 'COURSE_TEAM_NEW'
-    OTHER = 'OTHER'
-    ENTITLEMENT_SUPPORT_REASONS = (
-        (LEAVE_SESSION, u'Learner requested leave session for expired entitlement'),
-        (CHANGE_SESSION, u'Learner requested session change for expired entitlement'),
-        (LEARNER_REQUEST_NEW, u'Learner requested new entitlement'),
-        (COURSE_TEAM_REQUEST_NEW, u'Course team requested entitlement for learnerg'),
-        (OTHER, u'Other'),
-    )
-
     REISSUE = 'REISSUE'
     CREATE = 'CREATE'
     ENTITLEMENT_SUPPORT_ACTIONS = (
@@ -444,10 +430,7 @@ class CourseEntitlementSupportDetail(TimeStampedModel):
     entitlement = models.ForeignKey('entitlements.CourseEntitlement')
     support_user = models.ForeignKey(settings.AUTH_USER_MODEL)
 
-    #Deprecated: use action instead.
-    reason = models.CharField(max_length=15, choices=ENTITLEMENT_SUPPORT_REASONS)
     action = models.CharField(max_length=15, choices=ENTITLEMENT_SUPPORT_ACTIONS)
-
     comments = models.TextField(null=True)
 
     unenrolled_run = models.ForeignKey(
@@ -459,10 +442,10 @@ class CourseEntitlementSupportDetail(TimeStampedModel):
 
     def __unicode__(self):
         """Unicode representation of an Entitlement"""
-        return u'Course Entitlement Support Detail: entitlement: {}, support_user: {}, reason: {}'.format(
+        return u'Course Entitlement Support Detail: entitlement: {}, support_user: {}, action: {}'.format(
             self.entitlement,
             self.support_user,
-            self.reason,
+            self.action
         )
 
     @classmethod


### PR DESCRIPTION
EntitlementSupportDetails includes a reason field
that was not effectively serving its purpose, and has
been replaced by the action field. This removes the
reason field now that all references to the reason have
already been removed.

Learner-3925