### PR TITLE
Add bundle key to program purchase button

### DIFF
--- a/lms/djangoapps/commerce/tests/test_utils.py
+++ b/lms/djangoapps/commerce/tests/test_utils.py
@@ -110,16 +110,36 @@ class EcommerceServiceTests(TestCase):
         self.assertEqual(url, expected_url)
 
     @override_settings(ECOMMERCE_PUBLIC_URL_ROOT='http://ecommerce_url')
-    @ddt.data(['TESTSKU'], ['TESTSKU1', 'TESTSKU2', 'TESTSKU3'])
-    def test_get_checkout_page_url(self, skus):
+    @ddt.data(
+        {
+            'skus': ['TESTSKU']
+        },
+        {
+            'skus': ['TESTSKU1', 'TESTSKU2', 'TESTSKU3']
+        },
+        {
+            'skus': ['TESTSKU'],
+            'program_uuid': '12345678-9012-3456-7890-123456789012'
+        },
+        {
+            'skus': ['TESTSKU1', 'TESTSKU2', 'TESTSKU3'],
+            'program_uuid': '12345678-9012-3456-7890-123456789012'
+        }
+    )
+    def test_get_checkout_page_url(self, skus, program_uuid=None):
         """ Verify the checkout page URL is properly constructed and returned. """
-        url = EcommerceService().get_checkout_page_url(*skus)
+        url = EcommerceService().get_checkout_page_url(*skus, program_uuid=program_uuid)
         config = CommerceConfiguration.current()
         expected_url = '{root}{basket_url}?{skus}'.format(
             basket_url=config.MULTIPLE_ITEMS_BASKET_PAGE_URL,
             root=settings.ECOMMERCE_PUBLIC_URL_ROOT,
             skus=urlencode({'sku': skus}, doseq=True),
         )
+        if program_uuid:
+            expected_url = '{expected_url}&basket={program_uuid}'.format(
+                expected_url=expected_url,
+                program_uuid=program_uuid
+            )
         self.assertEqual(url, expected_url)
 
 

--- a/lms/djangoapps/commerce/utils.py
+++ b/lms/djangoapps/commerce/utils.py
@@ -96,22 +96,31 @@ class EcommerceService(object):
         """
         return self.get_absolute_ecommerce_url(self.config.single_course_checkout_page)
 
-    def get_checkout_page_url(self, *skus):
+    def get_checkout_page_url(self, *skus, **kwargs):
         """ Construct the URL to the ecommerce checkout page and include products.
 
         Args:
             skus (list): List of SKUs associated with products to be added to basket
+            program_uuid (string): The UUID of the program, if applicable
 
         Returns:
             Absolute path to the ecommerce checkout page showing basket that contains specified products.
 
         Example:
             http://localhost:8002/basket/add/?sku=5H3HG5&sku=57FHHD
+            http://localhost:8002/basket/add/?sku=5H3HG5&sku=57FHHD&bundle=3bdf1dd1-49be-4a15-9145-38901f578c5a
         """
-        return '{checkout_page_path}?{skus}'.format(
+        program_uuid = kwargs.get('program_uuid')
+        url = '{checkout_page_path}?{skus}'.format(
             checkout_page_path=self.get_absolute_ecommerce_url(self.config.MULTIPLE_ITEMS_BASKET_PAGE_URL),
             skus=urlencode({'sku': skus}, doseq=True),
         )
+        if program_uuid:
+            url = '{url}&bundle={program_uuid}'.format(
+                url=url,
+                program_uuid=program_uuid
+            )
+        return url
 
     def upgrade_url(self, user, course_key):
         """

--- a/lms/djangoapps/courseware/views/views.py
+++ b/lms/djangoapps/courseware/views/views.py
@@ -896,7 +896,7 @@ def program_marketing(request, program_uuid):
     context = {'program': program}
 
     if program.get('is_learner_eligible_for_one_click_purchase') and skus:
-        context['buy_button_href'] = ecommerce_service.get_checkout_page_url(*skus)
+        context['buy_button_href'] = ecommerce_service.get_checkout_page_url(*skus, program_uuid=program_uuid)
 
     context['uses_bootstrap'] = True
 


### PR DESCRIPTION
In order for a program to be tracked as a bundle in ecommerce and GA
a bundle key must be added to the basket URL. This adds that key to
the purchase button on the program marketing page.