### PR TITLE
Convert date to lower if language is spainish.

### DIFF
--- a/openedx/core/djangoapps/schedules/management/commands/tests/upsell_base.py
+++ b/openedx/core/djangoapps/schedules/management/commands/tests/upsell_base.py
@@ -93,5 +93,5 @@ class ScheduleUpsellTestMixin(object):
 
         self.assertEqual(
             message.context['user_schedule_upgrade_deadline_time'],
-            u'8 de Agosto de 2017',
+            u'8 de agosto de 2017',
         )

--- a/openedx/core/djangolib/tests/test_translation_utils.py
+++ b/openedx/core/djangolib/tests/test_translation_utils.py
@@ -1,0 +1,60 @@
+# -*- coding: utf-8 -*-
+"""
+Tests for openedx.core.djangolib.translation_utils
+"""
+
+import unittest
+
+import datetime
+import ddt
+
+from openedx.core.djangolib.translation_utils import translate_date
+
+
+@ddt.ddt
+class TranslateDateTest(unittest.TestCase):
+    """Test that we can convert the date object into a string with translation."""
+
+    @ddt.data(
+        (datetime.datetime(2018, 1, 21), u'21 de enero de 2018'),
+        (datetime.datetime(2018, 2, 21), u'21 de febrero de 2018'),
+        (datetime.datetime(2018, 3, 21), u'21 de marzo de 2018'),
+        (datetime.datetime(2018, 4, 21), u'21 de abril de 2018'),
+        (datetime.datetime(2018, 5, 21), u'21 de mayo de 2018'),
+        (datetime.datetime(2018, 6, 21), u'21 de junio de 2018'),
+        (datetime.datetime(2018, 7, 21), u'21 de julio de 2018'),
+        (datetime.datetime(2018, 8, 21), u'21 de agosto de 2018'),
+        (datetime.datetime(2018, 9, 21), u'21 de septiembre de 2018'),
+        (datetime.datetime(2018, 10, 21), u'21 de octubre de 2018'),
+        (datetime.datetime(2018, 11, 21), u'21 de noviembre de 2018'),
+        (datetime.datetime(2018, 12, 21), u'21 de diciembre de 2018'),
+    )
+    @ddt.unpack
+    def test_date_translate_in_spanish(self, date_to_translate, expected_translated_date):
+        """
+        Tests that date is correctly translating in spanish language
+        """
+        date_in_spanish = translate_date(date_to_translate, 'es')
+        self.assertEqual(date_in_spanish, expected_translated_date)
+
+    @ddt.data(
+        (datetime.datetime(2018, 1, 21), u'Jan. 21, 2018'),
+        (datetime.datetime(2018, 2, 21), u'Feb. 21, 2018'),
+        (datetime.datetime(2018, 3, 21), u'March 21, 2018'),
+        (datetime.datetime(2018, 4, 21), u'April 21, 2018'),
+        (datetime.datetime(2018, 5, 21), u'May 21, 2018'),
+        (datetime.datetime(2018, 6, 21), u'June 21, 2018'),
+        (datetime.datetime(2018, 7, 21), u'July 21, 2018'),
+        (datetime.datetime(2018, 8, 21), u'Aug. 21, 2018'),
+        (datetime.datetime(2018, 9, 21), u'Sept. 21, 2018'),
+        (datetime.datetime(2018, 10, 21), u'Oct. 21, 2018'),
+        (datetime.datetime(2018, 11, 21), u'Nov. 21, 2018'),
+        (datetime.datetime(2018, 12, 21), u'Dec. 21, 2018'),
+    )
+    @ddt.unpack
+    def test_date_translate_to_default_language(self, date_to_translate, expected_translated_date):
+        """
+        Tests that date is correctly translating to default when language is not specified.
+        """
+        date_in_spanish = translate_date(date_to_translate, language=None)
+        self.assertEqual(date_in_spanish, expected_translated_date)

--- a/openedx/core/djangolib/translation_utils.py
+++ b/openedx/core/djangolib/translation_utils.py
@@ -8,13 +8,22 @@ def translate_date(date, language, date_format='DATE_FORMAT'):
     its value for the given language.  Both the format of the date
     as well as its values (i.e., name of the Month) are translated.
 
+    If language is Spainish, then the entire date string is returned in
+    lowercase. This is used to work around a bug in the Spanish django
+    month translations.
+    See EDUCATOR-2328 for more details.
+
     For example:
         date = datetime.datetime(2017, 12, 23)
         date_in_spanish = translate_date(date, 'es')
-        assert date_in_spanish = '12 de Deciembre de 2017'
+        assert date_in_spanish == '23 de deciembre de 2017'
     """
     with override(language):
-        return dateformat.format(
+        formatted_date = dateformat.format(
             date,
             get_format(date_format, lang=language, use_l10n=True),
+
         )
+        if language and language.startswith('es'):
+            formatted_date = formatted_date.lower()
+        return formatted_date


### PR DESCRIPTION
Django's Spanish date formatting uses uppercase months, but Spanish speakers expect lowercase months. Workaround Django's current behavior by calling `lower()` on a formatted string if the language is `Spanish`. 

[EDUCATOR-2328](https://openedx.atlassian.net/browse/EDUCATOR-2328)

There can be several alternative ways of doing this, but I think this is the least invasive and the easiest to undo when/if Django fixes itself.