### PR TITLE
allow youtube stub to run on docker and scroll to upload button

### DIFF
--- a/cms/envs/acceptance.py
+++ b/cms/envs/acceptance.py
@@ -136,9 +136,10 @@ except ImportError:
     pass
 
 # Point the URL used to test YouTube availability to our stub YouTube server
-YOUTUBE['API'] = "http://127.0.0.1:{0}/get_youtube_api/".format(YOUTUBE_PORT)
-YOUTUBE['METADATA_URL'] = "http://127.0.0.1:{0}/test_youtube/".format(YOUTUBE_PORT)
-YOUTUBE['TEXT_API']['url'] = "127.0.0.1:{0}/test_transcripts_youtube/".format(YOUTUBE_PORT)
+YOUTUBE_HOSTNAME = os.environ.get('BOK_CHOY_HOSTNAME', '127.0.0.1')
+YOUTUBE['API'] = "http://{0}:{1}/get_youtube_api/".format(YOUTUBE_HOSTNAME, YOUTUBE_PORT)
+YOUTUBE['METADATA_URL'] = "http://{0}:{1}/test_youtube/".format(YOUTUBE_HOSTNAME, YOUTUBE_PORT)
+YOUTUBE['TEXT_API']['url'] = "{0}:{1}/test_transcripts_youtube/".format(YOUTUBE_HOSTNAME, YOUTUBE_PORT)
 YOUTUBE['TEST_TIMEOUT'] = 1500
 
 # Generate a random UUID so that different runs of acceptance tests don't break each other

--- a/cms/envs/bok_choy.py
+++ b/cms/envs/bok_choy.py
@@ -119,9 +119,10 @@ FEATURES['ENABLE_SPECIAL_EXAMS'] = True
 # Point the URL used to test YouTube availability to our stub YouTube server
 YOUTUBE_PORT = 9080
 YOUTUBE['TEST_TIMEOUT'] = 5000
-YOUTUBE['API'] = "http://127.0.0.1:{0}/get_youtube_api/".format(YOUTUBE_PORT)
-YOUTUBE['METADATA_URL'] = "http://127.0.0.1:{0}/test_youtube/".format(YOUTUBE_PORT)
-YOUTUBE['TEXT_API']['url'] = "127.0.0.1:{0}/test_transcripts_youtube/".format(YOUTUBE_PORT)
+YOUTUBE_HOSTNAME = os.environ.get('BOK_CHOY_HOSTNAME', '127.0.0.1')
+YOUTUBE['API'] = "http://{0}:{1}/get_youtube_api/".format(YOUTUBE_HOSTNAME, YOUTUBE_PORT)
+YOUTUBE['METADATA_URL'] = "http://{0}:{1}/test_youtube/".format(YOUTUBE_HOSTNAME, YOUTUBE_PORT)
+YOUTUBE['TEXT_API']['url'] = "{0}:{1}/test_transcripts_youtube/".format(YOUTUBE_HOSTNAME, YOUTUBE_PORT)
 
 FEATURES['ENABLE_COURSEWARE_INDEX'] = True
 FEATURES['ENABLE_LIBRARY_INDEX'] = True

--- a/common/test/acceptance/pages/studio/video/video.py
+++ b/common/test/acceptance/pages/studio/video/video.py
@@ -202,7 +202,7 @@ class VideoComponentPage(VideoPage):
 
         """
         language_options = self.get_drop_down_items('transcript_language', index=1)
-        language = filter(lambda x: x.get_attribute('value') == lang_code, language_options)[0]
+        language = [l for l in language_options if l.get_attribute('value') == lang_code][0]
         return language.get_attribute("disabled")
 
     @staticmethod

--- a/common/test/acceptance/pages/studio/video/video.py
+++ b/common/test/acceptance/pages/studio/video/video.py
@@ -195,7 +195,7 @@ class VideoComponentPage(VideoPage):
 
     def is_language_disabled(self, lang_code):
         """
-        Determine whether or not a lanuage is disbaled in a drop down
+        Determine whether or not a lanuage is disabled in a drop down
 
         Arguments:
             lang_code (str): two letter language code

--- a/common/test/acceptance/pages/studio/video/video.py
+++ b/common/test/acceptance/pages/studio/video/video.py
@@ -165,6 +165,18 @@ class VideoComponentPage(VideoPage):
             sync_on_notification(self)
         self.wait_for_ajax()
 
+    def scroll_to_button(self, button_name, index=0):
+        """
+        Scroll to a button specified by `button_name`
+
+        Arguments:
+            button_name (str): button name
+            index (int): query index
+
+        """
+        element = self.q(css=BUTTON_SELECTORS[button_name])[index]
+        self.browser.execute_script("arguments[0].scrollIntoView();", element)
+
     @staticmethod
     def file_path(filename):
         """
@@ -197,6 +209,7 @@ class VideoComponentPage(VideoPage):
 
         """
         asset_file_path = self.file_path(asset_filename)
+        self.scroll_to_button('upload_asset')
         self.click_button('upload_asset', index)
         self.q(css=CLASS_SELECTORS['attach_asset']).results[0].send_keys(asset_file_path)
         # Only srt format transcript files can be uploaded, If an error

--- a/common/test/acceptance/pages/studio/video/video.py
+++ b/common/test/acceptance/pages/studio/video/video.py
@@ -50,6 +50,10 @@ BUTTON_SELECTORS = {
     'collapse_link': '.collapse-action.collapse-setting',
 }
 
+DROP_DOWN_SELECTORS = {
+    'transcript_language': '.wrapper-translations-settings .list-settings .list-settings-item select'
+}
+
 DISPLAY_NAME = "Component Display Name"
 
 DEFAULT_SETTINGS = [
@@ -176,6 +180,31 @@ class VideoComponentPage(VideoPage):
         """
         element = self.q(css=BUTTON_SELECTORS[button_name])[index]
         self.browser.execute_script("arguments[0].scrollIntoView();", element)
+
+    def get_drop_down_items(self, drop_down_name, index=0):
+        """
+        Get the items from a drop down list specified by `drop_down_name`
+
+        Arguments:
+            drop_down_name (str): name of the drop down list
+            index (int): query index
+
+        """
+        drop_downs = self.q(css=DROP_DOWN_SELECTORS[drop_down_name])
+        return drop_downs[index].find_elements_by_tag_name("option")
+
+    def is_language_disabled(self, lang_code):
+        """
+        Determine whether or not a lanuage is disbaled in a drop down
+
+        Arguments:
+            lang_code (str): two letter language code
+
+        """
+        language_options =  self.get_drop_down_items('transcript_language', index=1)
+        language = filter(lambda x: x.get_attribute('value') == lang_code, language_options)[0]
+        return language.get_attribute("disabled")
+
 
     @staticmethod
     def file_path(filename):

--- a/common/test/acceptance/pages/studio/video/video.py
+++ b/common/test/acceptance/pages/studio/video/video.py
@@ -201,10 +201,9 @@ class VideoComponentPage(VideoPage):
             lang_code (str): two letter language code
 
         """
-        language_options =  self.get_drop_down_items('transcript_language', index=1)
+        language_options = self.get_drop_down_items('transcript_language', index=1)
         language = filter(lambda x: x.get_attribute('value') == lang_code, language_options)[0]
         return language.get_attribute("disabled")
-
 
     @staticmethod
     def file_path(filename):

--- a/common/test/acceptance/tests/helpers.py
+++ b/common/test/acceptance/tests/helpers.py
@@ -786,8 +786,9 @@ class YouTubeStubConfig(object):
     Configure YouTube Stub Server.
     """
 
+    YOUTUBE_HOSTNAME = os.environ.get('BOK_CHOY_HOSTNAME', '127.0.0.1')
     PORT = 9080
-    URL = 'http://127.0.0.1:{}/'.format(PORT)
+    URL = 'http://{}:{}/'.format(YOUTUBE_HOSTNAME, PORT)
 
     @classmethod
     def configure(cls, config):

--- a/common/test/acceptance/tests/video/test_studio_video_editor.py
+++ b/common/test/acceptance/tests/video/test_studio_video_editor.py
@@ -478,8 +478,7 @@ class VideoEditorTest(CMSVideoBaseTest):
         self.video.click_button('translation_add')
         self.video.select_translation_language('zh')
         self.video.click_button('translation_add')
-        self.video.select_translation_language('zh')
-        self.assertEqual(self.video.translations(), [u'zh', u''])
+        self.assertTrue(self.video.is_language_disabled('zh'))
 
     def test_table_of_contents(self):
         """

--- a/lms/envs/acceptance.py
+++ b/lms/envs/acceptance.py
@@ -188,9 +188,10 @@ XQUEUE_INTERFACE = {
 }
 
 # Point the URL used to test YouTube availability to our stub YouTube server
-YOUTUBE['API'] = "http://127.0.0.1:{0}/get_youtube_api/".format(YOUTUBE_PORT)
-YOUTUBE['METADATA_URL'] = "http://127.0.0.1:{0}/test_youtube/".format(YOUTUBE_PORT)
-YOUTUBE['TEXT_API']['url'] = "127.0.0.1:{0}/test_transcripts_youtube/".format(YOUTUBE_PORT)
+YOUTUBE_HOSTNAME = os.environ.get('BOK_CHOY_HOSTNAME', '127.0.0.1')
+YOUTUBE['API'] = "http://{0}:{1}/get_youtube_api/".format(YOUTUBE_HOSTNAME, YOUTUBE_PORT)
+YOUTUBE['METADATA_URL'] = "http://{0}:{1}/test_youtube/".format(YOUTUBE_HOSTNAME, YOUTUBE_PORT)
+YOUTUBE['TEXT_API']['url'] = "{0}:{1}/test_transcripts_youtube/".format(YOUTUBE_HOSTNAME, YOUTUBE_PORT)
 YOUTUBE['TEST_TIMEOUT'] = 1500
 
 if FEATURES.get('ENABLE_COURSEWARE_SEARCH') or \

--- a/lms/envs/bok_choy.py
+++ b/lms/envs/bok_choy.py
@@ -157,12 +157,14 @@ FEATURES['ENTRANCE_EXAMS'] = True
 
 FEATURES['ENABLE_SPECIAL_EXAMS'] = True
 
+
+YOUTUBE_HOSTNAME = os.environ.get('BOK_CHOY_HOSTNAME', '127.0.0.1')
 # Point the URL used to test YouTube availability to our stub YouTube server
 YOUTUBE_PORT = 9080
 YOUTUBE['TEST_TIMEOUT'] = 5000
-YOUTUBE['API'] = "http://127.0.0.1:{0}/get_youtube_api/".format(YOUTUBE_PORT)
-YOUTUBE['METADATA_URL'] = "http://127.0.0.1:{0}/test_youtube/".format(YOUTUBE_PORT)
-YOUTUBE['TEXT_API']['url'] = "127.0.0.1:{0}/test_transcripts_youtube/".format(YOUTUBE_PORT)
+YOUTUBE['API'] = "http://{0}:{1}/get_youtube_api/".format(YOUTUBE_HOSTNAME, YOUTUBE_PORT)
+YOUTUBE['METADATA_URL'] = "http://{0}:{1}/test_youtube/".format(YOUTUBE_HOSTNAME, YOUTUBE_PORT)
+YOUTUBE['TEXT_API']['url'] = "{0}:{1}/test_transcripts_youtube/".format(YOUTUBE_HOSTNAME, YOUTUBE_PORT)
 
 ############################# SECURITY SETTINGS ################################
 # Default to advanced security in common.py, so tests can reset here to use


### PR DESCRIPTION
Video editor tests are failing on Firefox 57 because it is now required that buttons be present on the screen to click them. This pull request adds scrolling functionality. Unfortunately, `scroll_to_element` was not working, possibly because the advanced features are in a modal, so I had to add some javascript to manage this. Also, this pull request fixes an issue drop down functionality has changed to disable already-selected languages.

In debuggin these, I needed to fix an issue in which the YouTubeStub server was starting up with a hardcoded localhost url. This was problematic now that we run the browser on a separate container, which means that it would be looking for the stub server locally. This is captured here: [https://openedx.atlassian.net/browse/PLAT-1714]. 