### PR TITLE
correct check for enrollment

### DIFF
--- a/openedx/core/djangoapps/catalog/utils.py
+++ b/openedx/core/djangoapps/catalog/utils.py
@@ -393,7 +393,7 @@ def get_fulfillable_course_runs_for_entitlement(entitlement, course_runs):
             user=entitlement.user,
             course_id=course_id
         )
-        is_enrolled_in_mode = user_enrollment_mode == entitlement.mode
+        is_enrolled_in_mode = is_active and (user_enrollment_mode == entitlement.mode)
         if is_course_run_entitlement_fulfillable(course_id, entitlement, search_time):
             if (is_enrolled_in_mode and
                     entitlement.enrollment_course_run and

--- a/openedx/core/djangoapps/catalog/utils.py
+++ b/openedx/core/djangoapps/catalog/utils.py
@@ -389,13 +389,17 @@ def get_fulfillable_course_runs_for_entitlement(entitlement, course_runs):
     search_time = datetime.datetime.now(UTC)
     for course_run in course_runs:
         course_id = CourseKey.from_string(course_run.get('key'))
-        is_enrolled = CourseEnrollment.is_enrolled(entitlement.user, course_id)
+        (user_enrollment_mode, is_active) = CourseEnrollment.enrollment_mode_for_user(
+            user=entitlement.user,
+            course_id=course_id
+        )
+        is_enrolled_in_mode = user_enrollment_mode == entitlement.mode
         if is_course_run_entitlement_fulfillable(course_id, entitlement, search_time):
-            if (is_enrolled and
+            if (is_enrolled_in_mode and
                     entitlement.enrollment_course_run and
                     course_id == entitlement.enrollment_course_run.course_id):
                 enrollable_sessions.append(course_run)
-            elif not is_enrolled:
+            elif not is_enrolled_in_mode:
                 enrollable_sessions.append(course_run)
 
     enrollable_sessions.sort(key=lambda session: session.get('start'))


### PR DESCRIPTION
Bug fix that will only show course sessions that are not already enrolled in for the same mode as the entitlement.  Audit enrolled sessions should still show.