### PR TITLE
LEARNER-4431: Add new waffle flag for toggling GDPR work.

### DIFF
--- a/openedx/features/course_experience/__init__.py
+++ b/openedx/features/course_experience/__init__.py
@@ -43,6 +43,10 @@ LATEST_UPDATE_FLAG = CourseWaffleFlag(WAFFLE_FLAG_NAMESPACE, 'latest_update')
 # Waffle flag to enable the use of Bootstrap for course experience pages
 USE_BOOTSTRAP_FLAG = CourseWaffleFlag(WAFFLE_FLAG_NAMESPACE, 'use_bootstrap', flag_undefined_default=True)
 
+#Waffle flag to control whether or not the the site shows GDPR updates.
+# TODO: Delete as part of LEARNER-4422
+ENABLE_GDPR_COMPAT_FLAG = CourseWaffleFlag(WAFFLE_FLAG_NAMESPACE, 'gdpr')
+
 
 def course_home_page_title(course):  # pylint: disable=unused-argument
     """


### PR DESCRIPTION
No controls for enterprise/microsites as of right now. We will add them once we better understand the requirements for those controls.