### PR TITLE
scroll to transcript button

### DIFF
--- a/common/test/acceptance/pages/lms/video/video.py
+++ b/common/test/acceptance/pages/lms/video/video.py
@@ -93,6 +93,18 @@ class VideoPage(PageObject):
         video_selector = '{0}'.format(CSS_CLASS_NAMES['video_container'])
         self.wait_for_element_presence(video_selector, 'Video is initialized')
 
+    def scroll_to_button(self, button_name, index=0):
+        """
+        Scroll to a button specified by `button_name`
+
+        Arguments:
+            button_name (str): button name
+            index (int): query index
+
+        """
+        element = self.q(css=VIDEO_BUTTONS[button_name])[index]
+        self.browser.execute_script("arguments[0].scrollIntoView();", element)
+
     @wait_for_js
     def wait_for_video_player_render(self, autoplay=False):
         """
@@ -661,6 +673,7 @@ class VideoPage(PageObject):
         time.sleep(1)
 
         # mouse over to transcript button
+        self.scroll_to_button("transcript_button")
         cc_button_selector = self.get_element_selector(VIDEO_BUTTONS["transcript_button"])
         element_to_hover_over = self.q(css=cc_button_selector).results[0]
         ActionChains(self.browser).move_to_element(element_to_hover_over).perform()

--- a/common/test/acceptance/pages/lms/video/video.py
+++ b/common/test/acceptance/pages/lms/video/video.py
@@ -480,6 +480,7 @@ class VideoPage(PageObject):
 
         """
         # mouse over to video speed button
+        self.scroll_to_button('speed')
         speed_menu_selector = self.get_element_selector(VIDEO_BUTTONS['speed'])
         element_to_hover_over = self.q(css=speed_menu_selector).results[0]
         hover = ActionChains(self.browser).move_to_element(element_to_hover_over)


### PR DESCRIPTION
Needed to scroll down before being able to over the transcript selector.

This fixes the following tests:
* acceptance.tests.video.test_video_module.YouTubeVideoTest.test_simplified_and_traditional_chinese_transcripts
* acceptance.tests.video.test_video_module.YouTubeVideoTest.test_video_component_stores_speed_correctly_for_multiple_videos
* acceptance.tests.video.test_video_module.YouTubeVideoTest.test_video_has_correct_transcript

Similar to: https://github.com/edx/edx-platform/pull/17645