### PR TITLE
WL-1435 Experimental bok-choy version

### DIFF
--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -171,7 +171,7 @@ sqlparse>=0.2.0,<0.3.0
 
 # Used for testing
 before_after==0.1.3
-bok-choy==0.7.1
+# bok-choy==0.7.1
 chrono==1.0.2
 ddt==0.8.0
 django-crum==0.7.2

--- a/requirements/edx/github.txt
+++ b/requirements/edx/github.txt
@@ -106,3 +106,9 @@ git+https://github.com/edx/xblock-lti-consumer.git@v1.1.7#egg=lti_consumer-xbloc
 git+https://github.com/mitodl/edx-sga.git@6b2f7aa2a18206023c8407e2c46f86d4b4c3ac96#egg=edx-sga==0.8.0
 git+https://github.com/open-craft/xblock-poll@7ba819b968fe8faddb78bb22e1fe7637005eb414#egg=xblock-poll==1.2.7
 git+https://github.com/edx-solutions/xblock-drag-and-drop-v2@2.1.5#egg=xblock-drag-and-drop-v2==2.1.5
+
+
+# Install bok-choy with experimental page_wait from branch
+
+git+https://github.com/edx/bok-choy.git@f42dfd48759ee5bc4f0166239fa48eda48e2d207#egg=bok-choy
+


### PR DESCRIPTION
Recently we have seen a lot of e2e and microsites test failures with the following message

BrokenPromise: Promise not satisfied: The document and all sub-resources have finished loading.

Upon investigating we found out that on stage the page is loaded but somehow the third party requests(there are a lot of requests sent to optimizely, google analytics etc.) get stuck and since the wait for page relies on the document.readyState to become "complete" it throws and error and the test is considered as failure.

I have used an experimental approach where we added an additional check if document does not reach the ready state, instead of throwing error we check if document.readyState="interactive", if so we continue with the test instead of throwing error.

This approach can take care of these errors where page is loaded but error is raised due to some third party call getting stuck.

Here is a reference to the ticket with details about it
WL-1435

This PR is to make sure that new approach does not break anything in platform