### PR TITLE
make use of to_locale in studiofrontend templating

### DIFF
--- a/common/djangoapps/pipeline_mako/helpers/studiofrontend.py
+++ b/common/djangoapps/pipeline_mako/helpers/studiofrontend.py
@@ -3,19 +3,20 @@ Contains code that gets run inside our mako template
 Debugging python-in-mako is terrible, so we've moved the actual code out to its own file
 """
 from django.conf import settings
+from django.utils.translation import to_locale
 
 
-def load_sfe_i18n_messages(locale):
+def load_sfe_i18n_messages(language):
     """
     Loads i18n data from studio-frontend's published files.
     """
     messages = "{}"
 
-    if locale != 'en':
+    if language != 'en':
         # because en is the default, studio-frontend will have it loaded by default
         messages_path = "{base}/studio-frontend/dist/i18n/messages/{locale}.json".format(
             base=settings.STATIC_ROOT_BASE,
-            locale=locale.replace('-', '_')  # files from Transifex use _, platform follows RFC-5646 and uses -
+            locale=to_locale(language)
         )
         with open(messages_path) as inputfile:
             messages = inputfile.read()


### PR DESCRIPTION
Shout-outs to @dsjen for noticing this error, and @fysheets for noticing that django code handles it seamlessly. @edx/educator-dahlia 

We just needed to make use of the `to_locale` utility function, documentation here: https://docs.djangoproject.com/en/1.11/ref/utils/