### PR TITLE
scroll to field before filling

### DIFF
--- a/common/test/acceptance/pages/studio/video/video.py
+++ b/common/test/acceptance/pages/studio/video/video.py
@@ -164,6 +164,7 @@ class VideoComponentPage(VideoPage):
             index (int): query index
 
         """
+        self.scroll_to_button(button_name, index)
         self.q(css=BUTTON_SELECTORS[button_name]).nth(index).click()
         if require_notification:
             sync_on_notification(self)


### PR DESCRIPTION
Fixes the test:
```
common/test/acceptance/tests/video/test_studio_video_transcript.py
```
on shard 6