### PR TITLE
Change default cert status for self-paced courses to 'unavailable'

### DIFF
--- a/common/djangoapps/student/helpers.py
+++ b/common/djangoapps/student/helpers.py
@@ -488,7 +488,7 @@ def _cert_info(user, course_overview, cert_status):
     }
 
     certificate_earned_but_not_available_status = 'certificate_earned_but_not_available'
-    default_status = 'processing'
+    default_status = 'unavailable' if course_overview.self_paced else 'processing'
 
     default_info = {
         'status': default_status,

--- a/common/djangoapps/student/tests/tests.py
+++ b/common/djangoapps/student/tests/tests.py
@@ -77,6 +77,7 @@ class CourseEndingTest(TestCase):
         course = Mock(
             end_of_course_survey_url=survey_url,
             certificates_display_behavior='end',
+            self_paced=False,
             id=CourseLocator(org="x", course="y", run="z"),
         )
 
@@ -172,7 +173,7 @@ class CourseEndingTest(TestCase):
         )
 
         # Test a course that doesn't have a survey specified
-        course2 = Mock(end_of_course_survey_url=None, id=CourseLocator(org="a", course="b", run="c"))
+        course2 = Mock(end_of_course_survey_url=None, self_paced=False, id=CourseLocator(org="a", course="b", run="c"))
         cert_status = {
             'status': 'notpassing', 'grade': '0.67',
             'download_url': download_url, 'mode': 'honor'
@@ -215,6 +216,33 @@ class CourseEndingTest(TestCase):
             }
         )
 
+        course_self_paced = Mock(self_paced=True, id=CourseLocator(org="n", course="m", run="o"))
+        cert_status = None
+        self.assertEqual(
+            _cert_info(user, course_self_paced, cert_status),
+            {
+                'status': 'unavailable',
+                'show_survey_button': False,
+                'can_unenroll': True,
+            }
+        )
+
+        cert_status = {
+            'status': 'unavailable',
+            'mode': 'honor',
+        }
+        self.assertEqual(
+            _cert_info(user, course_self_paced, cert_status),
+            {
+                'status': 'unavailable',
+                'show_survey_button': False,
+                'can_unenroll': True,
+                'linked_in_url': None,
+                'mode': 'honor',
+            }
+
+        )
+
     @ddt.data(
         (0.70, 0.60),
         (0.60, 0.70),
@@ -237,6 +265,7 @@ class CourseEndingTest(TestCase):
         course = Mock(
             end_of_course_survey_url=survey_url,
             certificates_display_behavior='end',
+            self_paced=False,
             id=CourseLocator(org="x", course="y", run="z"),
         )
 
@@ -271,6 +300,7 @@ class CourseEndingTest(TestCase):
         course = Mock(
             end_of_course_survey_url=survey_url,
             certificates_display_behavior='end',
+            self_paced=False,
             id=CourseLocator(org="x", course="y", run="z"),
         )
         cert_status = {'status': 'generating', 'mode': 'honor'}


### PR DESCRIPTION
_Upstreaming an internal feature from @Appsembler https://github.com/appsembler/edx-platform/pull/185._

Dashboard currently shows "Final course details are being wrapped up at this time. Your final standing will be available shortly." below courses for which a student has not requested or received a certificate.  This makes sense if the course has ended and grading is in progress, but not for open-ended courses (courses with no end date).  

The course advanced setting, `certificate_display_behavior` must be set to either `early_no_info` or `early_with_info` for open-ended courses to display anything at all on the dashboard, so changing that setting would not have solved this issue. 

This changes the default certificate status for these courses from 'processing' to 'unavailable', so that no message will be displayed.  

### TODO:

 - [ ] Product feedback from edX about open-ended courses. See [@bryanlandia's comment](https://github.com/edx/edx-platform/pull/17667#issuecomment-373887903) bellow.