### PR TITLE
Fix SVG text tag html transformation

### DIFF
--- a/common/lib/capa/capa/capa_problem.py
+++ b/common/lib/capa/capa/capa_problem.py
@@ -855,7 +855,8 @@ class LoncapaProblem(object):
             if item_xhtml is not None:
                 tree.append(item_xhtml)
 
-        if tree.tag in html_transforms:
+        # Do not transform in case of text element wrapped under svg element.
+        if tree.tag in html_transforms and not (tree.tag == 'text' and problemtree.getparent().tag == 'svg'):
             tree.tag = html_transforms[problemtree.tag]['tag']
         else:
             # copy attributes over if not innocufying


### PR DESCRIPTION
### Description
This fixes the issue when `<text>` tag is wrapped under the `<svg>` element, the `<text>` is transformed into span.

HTML transformation for `<text>` is only skipped if the SVG is the direct parent of the text element.

### Sandbox
https://svgtexthtmltranform.sandbox.edx.org/courses/course-v1:edX+DemoX+Demo_Course/jump_to/block-v1:edX+DemoX+Demo_Course+type@vertical+block@vertical_0270f6de40fc