### PR TITLE
Register schedule signal handlers for course start change in CMS

### DIFF
--- a/openedx/core/djangoapps/schedules/apps.py
+++ b/openedx/core/djangoapps/schedules/apps.py
@@ -12,7 +12,13 @@ class SchedulesConfig(AppConfig):
             ProjectType.LMS: {
                 PluginSignals.RECEIVERS: [{
                     PluginSignals.RECEIVER_FUNC_NAME: u'update_schedules_on_course_start_changed',
-                    PluginSignals.SIGNAL_PATH: u'openedx.core.djangoapps.content.course_overviews.signals.COURSE_START_DATE_CHANGED',
+                    PluginSignals.SIGNAL_PATH: u'openedx.core.djangoapps.content.course_overviews.signals.COURSE_START_DATE_CHANGED',  # pylint: disable=line-too-long
+                }]
+            },
+            ProjectType.CMS: {
+                PluginSignals.RECEIVERS: [{
+                    PluginSignals.RECEIVER_FUNC_NAME: u'update_schedules_on_course_start_changed',
+                    PluginSignals.SIGNAL_PATH: u'openedx.core.djangoapps.content.course_overviews.signals.COURSE_START_DATE_CHANGED',  # pylint: disable=line-too-long
                 }]
             },
         },

--- a/openedx/core/djangoapps/schedules/signals.py
+++ b/openedx/core/djangoapps/schedules/signals.py
@@ -55,8 +55,8 @@ def create_schedule(sender, **kwargs):  # pylint: disable=unused-argument
 
 def update_schedules_on_course_start_changed(sender, updated_course_overview, previous_start_date, **kwargs):
     """
-    Updates all course schedules if course hasn't started yet and
-    the updated start date is still in the future.
+    Updates all course schedules start and upgrade_deadline dates based off of
+    the new course overview start date.
     """
     upgrade_deadline = _calculate_upgrade_deadline(
         updated_course_overview.id,


### PR DESCRIPTION
While investigating [EDUCATOR-2338](https://openedx.atlassian.net/browse/EDUCATOR-2338), we found out that the `openedx.core.djangoapps.schedules.tasks.update_course_schedules` task wasn't getting sent in response to a CourseOverview start date change in the CMS.

I tested this on a sandbox before and after this change by going to the settings page in a course in Studio and changing the start date. With the change, I see messages about the `Task openedx.core.djangoapps.schedules.tasks.update_course_schedules` in the logs `/edx/var/log/cms/edx.log` and `/edx/var/log/supervisor/cms_default_1-stderr.log` and the schedules for a course are updated to the new start date. Without this change, I don't see log messages for the task and schedules are not updated.