### PR TITLE
stop using deprecated single item basket view

### DIFF
--- a/common/djangoapps/course_modes/tests/test_views.py
+++ b/common/djangoapps/course_modes/tests/test_views.py
@@ -136,7 +136,7 @@ class CourseModeViewTest(CatalogIntegrationMixin, UrlResetMixin, ModuleStoreTest
         # Configure whether we're upgrading or not
         url = reverse('course_modes_choose', args=[unicode(prof_course.id)])
         response = self.client.get(url)
-        self.assertRedirects(response, 'http://testserver/basket/add/?sku=TEST', fetch_redirect_response=False)
+        self.assertRedirects(response, 'http://testserver/test_basket/add/?sku=TEST', fetch_redirect_response=False)
         ecomm_test_utils.update_commerce_config(enabled=False)
 
     @httpretty.activate

--- a/lms/djangoapps/commerce/management/commands/tests/test_configure_commerce.py
+++ b/lms/djangoapps/commerce/management/commands/tests/test_configure_commerce.py
@@ -24,7 +24,7 @@ class TestCommerceConfigurationCommand(TestCase):
 
         self.assertTrue(commerce_configuration.enabled)
         self.assertTrue(commerce_configuration.checkout_on_ecommerce_service)
-        self.assertEqual(commerce_configuration.single_course_checkout_page, "/basket/single-item/")
+        self.assertEqual(commerce_configuration.basket_checkout_page, "/basket/add/")
         self.assertEqual(commerce_configuration.cache_ttl, 0)
 
         # Verify commerce configuration can be disabled from command

--- a/lms/djangoapps/commerce/migrations/0007_auto_20180313_0609.py
+++ b/lms/djangoapps/commerce/migrations/0007_auto_20180313_0609.py
@@ -1,0 +1,23 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('commerce', '0006_auto_20170424_1734'),
+    ]
+
+    operations = [
+        migrations.RemoveField(
+            model_name='commerceconfiguration',
+            name='single_course_checkout_page',
+        ),
+        migrations.AddField(
+            model_name='commerceconfiguration',
+            name='basket_checkout_page',
+            field=models.CharField(default=b'/basket/add/', help_text='Path to course(s) checkout page hosted by the E-Commerce service.', max_length=255),
+        ),
+    ]

--- a/lms/djangoapps/commerce/models.py
+++ b/lms/djangoapps/commerce/models.py
@@ -16,17 +16,16 @@ class CommerceConfiguration(ConfigurationModel):
     CACHE_KEY = 'commerce.api.data'
     DEFAULT_RECEIPT_PAGE_URL = '/checkout/receipt/?order_number='
     DEFAULT_ORDER_DASHBOARD_URL = '/dashboard/orders/'
-    MULTIPLE_ITEMS_BASKET_PAGE_URL = '/basket/add/'
 
     checkout_on_ecommerce_service = models.BooleanField(
         default=False,
         help_text=_('Use the checkout page hosted by the E-Commerce service.')
     )
 
-    single_course_checkout_page = models.CharField(
+    basket_checkout_page = models.CharField(
         max_length=255,
-        default='/basket/single-item/',
-        help_text=_('Path to single course checkout page hosted by the E-Commerce service.')
+        default='/basket/add/',
+        help_text=_('Path to course(s) checkout page hosted by the E-Commerce service.')
     )
     cache_ttl = models.PositiveIntegerField(
         verbose_name=_('Cache Time To Live'),

--- a/lms/djangoapps/commerce/tests/test_utils.py
+++ b/lms/djangoapps/commerce/tests/test_utils.py
@@ -25,11 +25,11 @@ if settings.ROOT_URLCONF == 'lms.urls':
     from entitlements.tests.factories import CourseEntitlementFactory
 
 
-def update_commerce_config(enabled=False, checkout_page='/test_basket/'):
+def update_commerce_config(enabled=False, checkout_page='/test_basket/add/'):
     """ Enable / Disable CommerceConfiguration model """
     CommerceConfiguration.objects.create(
         checkout_on_ecommerce_service=enabled,
-        single_course_checkout_page=checkout_page,
+        basket_checkout_page=checkout_page,
     )
 
 
@@ -131,7 +131,7 @@ class EcommerceServiceTests(TestCase):
         url = EcommerceService().get_checkout_page_url(*skus, program_uuid=program_uuid)
         config = CommerceConfiguration.current()
         expected_url = '{root}{basket_url}?{skus}'.format(
-            basket_url=config.MULTIPLE_ITEMS_BASKET_PAGE_URL,
+            basket_url=config.basket_checkout_page,
             root=settings.ECOMMERCE_PUBLIC_URL_ROOT,
             skus=urlencode({'sku': skus}, doseq=True),
         )

--- a/lms/djangoapps/commerce/utils.py
+++ b/lms/djangoapps/commerce/utils.py
@@ -92,9 +92,9 @@ class EcommerceService(object):
         """ Return the URL for the checkout page.
 
         Example:
-            http://localhost:8002/basket/single_item/
+            http://localhost:8002/basket/add/
         """
-        return self.get_absolute_ecommerce_url(self.config.single_course_checkout_page)
+        return self.get_absolute_ecommerce_url(self.config.basket_checkout_page)
 
     def get_checkout_page_url(self, *skus, **kwargs):
         """ Construct the URL to the ecommerce checkout page and include products.
@@ -112,7 +112,7 @@ class EcommerceService(object):
         """
         program_uuid = kwargs.get('program_uuid')
         url = '{checkout_page_path}?{skus}'.format(
-            checkout_page_path=self.get_absolute_ecommerce_url(self.config.MULTIPLE_ITEMS_BASKET_PAGE_URL),
+            checkout_page_path=self.get_absolute_ecommerce_url(self.config.basket_checkout_page),
             skus=urlencode({'sku': skus}, doseq=True),
         )
         if program_uuid:

--- a/lms/djangoapps/courseware/tests/test_date_summary.py
+++ b/lms/djangoapps/courseware/tests/test_date_summary.py
@@ -307,7 +307,7 @@ class CourseDateSummaryTest(SharedModuleStoreTestCase):
         CourseEnrollmentFactory(course_id=course.id, user=user, mode=CourseMode.VERIFIED)
 
         block = VerifiedUpgradeDeadlineDate(course, user)
-        self.assertEqual(block.link, '{}?sku={}'.format(configuration.MULTIPLE_ITEMS_BASKET_PAGE_URL, sku))
+        self.assertEqual(block.link, '{}?sku={}'.format(configuration.basket_checkout_page, sku))
 
     ## CertificateAvailableDate
     @waffle.testutils.override_switch('certificates.auto_certificate_generation', True)

--- a/lms/djangoapps/courseware/tests/test_views.py
+++ b/lms/djangoapps/courseware/tests/test_views.py
@@ -481,7 +481,7 @@ class ViewsTestCase(ModuleStoreTestCase):
         #      (1) shopping cart is enabled and the user is not logged in
         #      (2) shopping cart is enabled and the user is logged in
         href = '<a href="{uri_stem}?sku={sku}" class="add-to-cart">'.format(
-            uri_stem=configuration.MULTIPLE_ITEMS_BASKET_PAGE_URL,
+            uri_stem=configuration.basket_checkout_page,
             sku=sku,
         )
 

--- a/lms/djangoapps/verify_student/tests/test_views.py
+++ b/lms/djangoapps/verify_student/tests/test_views.py
@@ -148,7 +148,7 @@ class TestPayAndVerifyView(UrlResetMixin, ModuleStoreTestCase, XssTestMixin):
             content_type="application/json",
         )
         configuration = CommerceConfiguration.objects.create(checkout_on_ecommerce_service=True)
-        checkout_page = configuration.MULTIPLE_ITEMS_BASKET_PAGE_URL
+        checkout_page = configuration.basket_checkout_page
         checkout_page += "?utm_source=test"
         httpretty.register_uri(httpretty.GET, "{}{}".format(TEST_PUBLIC_URL_ROOT, checkout_page))
 

--- a/openedx/core/djangoapps/programs/tests/test_utils.py
+++ b/openedx/core/djangoapps/programs/tests/test_utils.py
@@ -825,7 +825,7 @@ class TestProgramDataExtender(ModuleStoreTestCase):
     """Tests of the program data extender utility class."""
     maxDiff = None
     sku = 'abc123'
-    checkout_path = '/basket/add'
+    checkout_path = '/basket/add/'
     instructors = {
         'instructors': [
             {


### PR DESCRIPTION
[LEARNER-4428](https://openedx.atlassian.net/browse/LEARNER-4428)

This PR will remove the usage of deprecated [BasketSingleItemView](https://github.com/edx/ecommerce/blob/4cfb8c902b84af23584f7a535a421781fb5decd7/ecommerce/extensions/basket/views.py#L46)

You can test payment flow on the following sandbox course.
**Sandbox course:** https://tasawernawaz.sandbox.edx.org/courses/course-v1:edX+Test101+course/course/
