### PR TITLE
Fixed override due date by limiting scope to selected users

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -208,7 +208,7 @@ Phil McGachey <phil_mcgachey@harvard.edu>
 Sri Harsha Pamu <kmitharsha@gmail.com>
 Cris Ewing <cris@crisewing.com>
 Carlos de La Guardia <carlos@jazkarta.com>
-Amir Qayyum Khan <amir.qayyum@arbisoft.com>
+Amir Qayyum Khan <amir.qayyum.khan@gmail.com>
 Jolyon Bloomfield <jolyon@mit.edu>
 Kyle McCormick <kylemccor@gmail.com>
 Jim Cai <jimcai@stanford.edu>

--- a/lms/djangoapps/course_api/blocks/api.py
+++ b/lms/djangoapps/course_api/blocks/api.py
@@ -59,7 +59,7 @@ def get_blocks(
     include_gated_sections = 'show_gated_sections' in requested_fields
 
     if user is not None:
-        transformers += course_blocks_api.get_course_block_access_transformers()
+        transformers += course_blocks_api.get_course_block_access_transformers(user)
         transformers += [MilestonesAndSpecialExamsTransformer(
             include_special_exams=include_special_exams,
             include_gated_sections=include_gated_sections)]

--- a/lms/djangoapps/course_api/blocks/tests/test_serializers.py
+++ b/lms/djangoapps/course_api/blocks/tests/test_serializers.py
@@ -44,7 +44,7 @@ class TestBlockSerializerBase(SharedModuleStoreTestCase):
             requested_student_view_data=['video'],
         )
         self.transformers = BlockStructureTransformers(
-            get_course_block_access_transformers() + [blocks_api_transformer]
+            get_course_block_access_transformers(self.user) + [blocks_api_transformer]
         )
         self.block_structure = get_course_blocks(
             self.user,

--- a/lms/djangoapps/course_blocks/api.py
+++ b/lms/djangoapps/course_blocks/api.py
@@ -21,10 +21,15 @@ def has_individual_student_override_provider():
     return INDIVIDUAL_STUDENT_OVERRIDE_PROVIDER in getattr(settings, 'FIELD_OVERRIDE_PROVIDERS', ())
 
 
-def get_course_block_access_transformers():
+def get_course_block_access_transformers(user):
     """
     Default list of transformers for manipulating course block structures
     based on the user's access to the course blocks.
+
+    Arguments:
+        user (django.contrib.auth.models.User) - User object for
+            which the block structure is to be transformed.
+
     """
     course_block_access_transformers = [
         library_content.ContentLibraryTransformer(),
@@ -33,7 +38,7 @@ def get_course_block_access_transformers():
         visibility.VisibilityTransformer(),
     ]
     if has_individual_student_override_provider():
-        course_block_access_transformers += [load_override_data.OverrideDataTransformer()]
+        course_block_access_transformers += [load_override_data.OverrideDataTransformer(user)]
 
     return course_block_access_transformers
 
@@ -75,7 +80,7 @@ def get_course_blocks(
             access.
     """
     if not transformers:
-        transformers = BlockStructureTransformers(get_course_block_access_transformers())
+        transformers = BlockStructureTransformers(get_course_block_access_transformers(user))
     transformers.usage_info = CourseUsageInfo(starting_block_usage_key.course_key, user)
 
     return get_block_structure_manager(starting_block_usage_key.course_key).get_transformed(


### PR DESCRIPTION
#### What are the relevant tickets?
fixes https://github.com/mitodl/edx-platform/issues/82

#### What's this PR do?
The issue was that if staff overrides due date of a specific student it changes due date for all students. We fixed this issue by limiting scope of overriding to selected learners. 

### How should this be manually tested?
- create a course
- set due date of subsection
- open lms and enroll 3 users to course.
- open lms/instructor/extensions and override date for one course lets say learner audit.
- and then check due date of that section for all three learners

<img width="1223" alt="screen shot 2018-03-13 at 6 49 49 pm" src="https://user-images.githubusercontent.com/10431250/37346963-955f0ddc-26f2-11e8-80df-bf946cbdf355.png">

@pdpinch 

- Audit:
<img width="1270" alt="screen shot 2018-03-13 at 7 00 02 pm" src="https://user-images.githubusercontent.com/10431250/37346913-73ad3484-26f2-11e8-864e-c913b5c445e2.png">

- honor:
<img width="912" alt="screen shot 2018-03-13 at 6 59 46 pm" src="https://user-images.githubusercontent.com/10431250/37346935-83b9ba50-26f2-11e8-8167-4914673d0732.png">

- submit button is also working:
<img width="1084" alt="screen shot 2018-03-13 at 6 49 58 pm" src="https://user-images.githubusercontent.com/10431250/37346988-aaab69d8-26f2-11e8-9d32-a451d11158e1.png">


