### PR TITLE
Send all update_aggregators task to LMS.

### DIFF
--- a/cms/celery.py
+++ b/cms/celery.py
@@ -36,6 +36,7 @@ class Router(AlternateEnvironmentRouter):
         """
         # The tasks below will be routed to the default lms queue.
         return {
+            'completion_aggregator.tasks.update_aggregators': 'lms',
             'openedx.core.djangoapps.content.block_structure.tasks.update_course_in_cache': 'lms',
             'openedx.core.djangoapps.content.block_structure.tasks.update_course_in_cache_v2': 'lms',
         }


### PR DESCRIPTION
Completion aggregators need to be updated when a course is updated.  Unfortunately, the task doesn't work when run in the CMS.  This sends the task to the LMS's task queues, so it will run in a working environment.


**JIRA tickets**: TBD

**Dependencies**: This change has no effect unless the openedx-completion-aggregator plug-in app is installed. 

**Screenshots**: None

**Sandbox URL**: None

**Merge deadline**: None

**Testing instructions**:

See open-craft/openedx-completion-aggregator#6 for testing instructions.

**Author notes and concerns**:

We would like to be able to do this without edx-platform needing to be aware of our app.  A couple alternatives:

1. There could be a way to specify this on the task.  Perhaps a decorator like `@require_task_environment('lms')` that would then inject this into a registry.
2. Perhaps even better, but more work-intensive, would be to provide a way for the LMS to be notified whenever Studio published an update to a course.  

**Reviewers**
- [x] @ciuin 
- [x] edX reviewer[s] TBD
