### PR TITLE
Add extra Webpack config for RequireJS compat.

### DIFF
--- a/webpack.prod.config.js
+++ b/webpack.prod.config.js
@@ -7,7 +7,7 @@ var webpack = require('webpack');
 
 var commonConfig = require('./webpack.common.config.js');
 
-module.exports = Merge.smart(commonConfig, {
+var optimizedConfig = Merge.smart(commonConfig, {
     output: {
         filename: '[name].[chunkhash].js'
     },
@@ -22,3 +22,32 @@ module.exports = Merge.smart(commonConfig, {
         new webpack.optimize.UglifyJsPlugin()
     ]
 });
+
+// requireCompatConfig only exists so that you can use RequireJS to require a
+// Webpack bundle (but try not to do that if you can help it). RequireJS knows
+// where to find named bundle output files, but doesn't know about
+// prod-optimized bundles. So we make a redundant Webpack target that exists
+// only to make a version of all the bundles without the chunkhash in the
+// filename. That way, RequireJS can always find them.
+//
+// To be clear, this is a bad hack that exists to keep RequireJS from breaking
+// for the short term. We're actively ripping RequireJS out of edx-platform
+// entirely, and requireCompatConfig can completely disappear after RequireJS is
+// gone.
+
+// Step 1: Alter the bundle output names to omit the chunkhash.
+var requireCompatConfig = Merge.smart(optimizedConfig, {
+    output: {
+        filename: '[name].js'
+    }
+})
+
+// Step 2: Remove the plugin entries that generate the webpack-stats.json files
+// that Django needs to look up resources. We never want to accidentally
+// overwrite those because it means that we'll be serving assets with shorter
+// cache times. RequireJS never looks at the webpack-stats.json file.
+requireCompatConfig.plugins = requireCompatConfig.plugins.filter(
+    plugin => !plugin.options || (plugin.options && plugin.options.filename != 'webpack-stats.json')
+);
+
+module.exports = [optimizedConfig, requireCompatConfig];


### PR DESCRIPTION
We make a mostly redundant copy of Webpack bundles for prod without chunkhashes in the file names, so that RequireJS can point to bundles without having to understand anything about Webpack's optimization. Meant to unblock EDUCATOR-2357 and PR #17518.