### PR TITLE
Allow staff to see all units when viewing the course outline.

### DIFF
--- a/lms/djangoapps/instructor_task/tests/test_tasks_helper.py
+++ b/lms/djangoapps/instructor_task/tests/test_tasks_helper.py
@@ -1041,7 +1041,7 @@ class TestProblemReportCohortedContent(TestReportMixin, ContentGroupTestCase, In
             {
                 'user': self.staff_user,
                 'enrollment_status': ENROLLED_IN_COURSE,
-                'grade': [u'0.0', u'Not Available', u'Not Available', u'Not Available', u'Not Available'],
+                'grade': [u'0.0', u'Not Attempted', u'2.0', u'Not Attempted', u'2.0'],
             },
             {
                 'user': self.alpha_user,


### PR DESCRIPTION
## [Staff view of course outline does not include all units restricted by content group EDUCATOR-2501](https://openedx.atlassian.net/browse/EDUCATOR-2501)

### Description:
This PR fixes that staff is able to view all the course outline restricted by any *Enrollment Track* or *content group*.

### How to Test?
**Production**
 - https://courses.edx.org/courses/course-v1:GTx+ISYE6501x+1T2018/course/
- As a staff View the course outline, Week 1, and see that there appears to be no content under Week 1 > Week 1 Homework (Verified MM)

**Sandbox**
https://units.sandbox.edx.org/courses/course-v1:edX+X2501+2018/course/




### Reviewers

If you've been tagged for review, please check your corresponding box once you've given the :+1:.
-  [x] @ssemenova 
-  [x] @efischer19  

### Post-review
- [x] Rebase and squash commits


