### PR TITLE
Create a new random.Random instance when selecting from library content blocks

### DIFF
--- a/common/lib/xmodule/xmodule/library_content_module.py
+++ b/common/lib/xmodule/xmodule/library_content_module.py
@@ -176,7 +176,8 @@ class LibraryContentModule(LibraryContentFields, XModule, StudioEditableModule):
             pool = valid_block_keys - selected
             if mode == "random":
                 num_to_add = min(len(pool), num_to_add)
-                added_block_keys = set(random.sample(pool, num_to_add))
+                rand = random.Random()
+                added_block_keys = set(rand.sample(pool, num_to_add))
                 # We now have the correct n random children to show for this user.
             else:
                 raise NotImplementedError("Unsupported mode.")


### PR DESCRIPTION
https://openedx.atlassian.net/browse/EDUCATOR-1290

The above bug is likely being caused by one of two conditions:
* The shared `random` module `Random` instance is getting into a state such that sampling is returning the same item most of the time.
* Something is causing the population being sampled to not contain all valid items.

We don't know which of these conditions is driving the observed bug behavior.  This PR addresses the first condition, and should eliminate it as a path of investigation if we see this in a future course run.  It creates a new `random.Random` instance before sampling the library content problem blocks and calls `sample()` on the population from that instance.