### PR TITLE
EDUCATOR-2461 Schedules: don't yield an email on loop exception

### DIFF
--- a/openedx/core/djangoapps/schedules/resolvers.py
+++ b/openedx/core/djangoapps/schedules/resolvers.py
@@ -357,21 +357,21 @@ class CourseUpdateResolver(BinnedSchedulesBaseResolver):
                         user, week_num, enrollment.course_id
                     )
                 )
-                continue
+                # continue to the next schedule, don't yield an email for this one
+            else:
+                template_context.update({
+                    'course_name': schedule.enrollment.course.display_name,
+                    'course_url': _get_trackable_course_home_url(enrollment.course_id),
 
-            template_context.update({
-                'course_name': schedule.enrollment.course.display_name,
-                'course_url': _get_trackable_course_home_url(enrollment.course_id),
+                    'week_num': week_num,
+                    'week_highlights': week_highlights,
 
-                'week_num': week_num,
-                'week_highlights': week_highlights,
+                    # This is used by the bulk email optout policy
+                    'course_ids': [str(enrollment.course_id)],
+                })
+                template_context.update(_get_upsell_information_for_schedule(user, schedule))
 
-                # This is used by the bulk email optout policy
-                'course_ids': [str(enrollment.course_id)],
-            })
-            template_context.update(_get_upsell_information_for_schedule(user, schedule))
-
-            yield (user, schedule.enrollment.course.closest_released_language, template_context)
+                yield (user, schedule.enrollment.course.closest_released_language, template_context)
 
 
 def _get_trackable_course_home_url(course_id):

--- a/openedx/core/djangoapps/schedules/resolvers.py
+++ b/openedx/core/djangoapps/schedules/resolvers.py
@@ -357,6 +357,7 @@ class CourseUpdateResolver(BinnedSchedulesBaseResolver):
                         user, week_num, enrollment.course_id
                     )
                 )
+                continue
 
             template_context.update({
                 'course_name': schedule.enrollment.course.display_name,


### PR DESCRIPTION
Learners are receiving weekly highlights from the wrong course. I believe this is because of this missing continue in the exception catch that I accidentally removed in [this commit](https://github.com/edx/edx-platform/commit/3425502a2323f33943f9178db2f63f4a52b9a4a9#diff-09b1435214f4cf13caf272864ec5f7c7R359). Without the continue, the template is being filled and the email is sent with the old value of `weekly_highlights` from the previous iteration of the loop which could be from a completely different course and user.

