### PR TITLE
Add CourseFields.other_course_settings to store custom fields

### DIFF
--- a/cms/djangoapps/contentstore/tests/test_course_settings.py
+++ b/cms/djangoapps/contentstore/tests/test_course_settings.py
@@ -949,6 +949,22 @@ class CourseMetadataEditingTest(CourseTestCase):
         )
         self.assertNotIn('edxnotes', test_model)
 
+    @patch.dict(settings.FEATURES, {'ENABLE_OTHER_COURSE_SETTINGS': True})
+    def test_othercoursesettings_present(self):
+        """
+        If feature flag ENABLE_OTHER_COURSE_SETTINGS is on, show the setting in Advanced Settings.
+        """
+        test_model = CourseMetadata.fetch(self.fullcourse)
+        self.assertIn('other_course_settings', test_model)
+
+    @patch.dict(settings.FEATURES, {'ENABLE_OTHER_COURSE_SETTINGS': False})
+    def test_othercoursesettings_not_present(self):
+        """
+        If feature flag ENABLE_OTHER_COURSE_SETTINGS is off, don't show the setting at all in Advanced Settings.
+        """
+        test_model = CourseMetadata.fetch(self.fullcourse)
+        self.assertNotIn('other_course_settings', test_model)
+
     def test_allow_unsupported_xblocks(self):
         """
         allow_unsupported_xblocks is only shown in Advanced Settings if

--- a/cms/djangoapps/models/settings/course_metadata.py
+++ b/cms/djangoapps/models/settings/course_metadata.py
@@ -78,6 +78,10 @@ class CourseMetadata(object):
         if not settings.FEATURES.get('ENABLE_EDXNOTES'):
             filtered_list.append('edxnotes')
 
+        # Do not show video auto advance if the feature is disabled
+        if not settings.FEATURES.get('ENABLE_OTHER_COURSE_SETTINGS'):
+            filtered_list.append('other_course_settings')
+
         # Do not show video_upload_pipeline if the feature is disabled.
         if not settings.FEATURES.get('ENABLE_VIDEO_UPLOAD_PIPELINE'):
             filtered_list.append('video_upload_pipeline')

--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -236,6 +236,10 @@ FEATURES = {
     # in sync with the one in lms/envs/common.py
     'ENABLE_EDXNOTES': False,
 
+    # Show a new field in "Advanced settings" that can store custom data about a
+    # course and that can be read from themes
+    'ENABLE_OTHER_COURSE_SETTINGS': False,
+
     # Enable support for content libraries. Note that content libraries are
     # only supported in courses using split mongo.
     'ENABLE_CONTENT_LIBRARIES': True,

--- a/common/lib/xmodule/xmodule/course_module.py
+++ b/common/lib/xmodule/xmodule/course_module.py
@@ -853,6 +853,15 @@ class CourseFields(object):
         ),
         scope=Scope.settings, default=False
     )
+    other_course_settings = Dict(
+        display_name=_("Other Course Settings"),
+        help=_(
+            "Any additional information about the course that the platform needs or that allows integration with "
+            "external systems such as CRM software. Enter a dictionary of values in JSON format, such as "
+            "{ \"my_custom_setting\": \"value\", \"other_setting\": \"value\" }"
+        ),
+        scope=Scope.settings
+    )
 
 
 class CourseModule(CourseFields, SequenceModule):  # pylint: disable=abstract-method


### PR DESCRIPTION
This adds a field to the "advanced settings" page of each course that allows the user to store additional metadata about the course, in a JSON dictionary, without requiring updating the platform code.

The idea is that this field can hold metadata like "ID of the course in external system", course difficulty, or other instance-specific metadata about the course that needs to be available to the theme, CRM software, a marketing site, ecommerce, or other external systems.

The new field is protected by a feature flag which is `False` by default, so it won't show up in Studio unless you enable the flag.

**JIRA tickets**: None
**Discussions**: None
**Dependencies**: None
**Screenshots**: None
**Sandbox URL**: TBD
**Merge deadline**: None

**Testing instructions**:

1. Add a setting under `FEATURES` in `cms.env.json`: `"ENABLE_OTHER_COURSE_SETTINGS": true`
2. In Studio, go to „advanced settings“, you'll see „Other Course Settings“. Fill it with e.g. `{"program_code": "XX1", "institution": "edX"}`
3. In a theme, use `course.other_course_settings` to access this value. E.g.
```
 <%
program_code = course.other_course_settings.get('program_code')
￼%>
${program_code}
```
4. Change `ENABLE_OTHER_COURSE_SETTINGS` to false, and check that it hides the field

**Reviewers**
- [x] @bradenmacdonald 
- [ ] edX's

**Author concerns**: None
**Settings**: None