### PR TITLE
Aggregator integration tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -54,7 +54,7 @@ upgrade: ## update the pip requirements files to use the latest releases satisfy
 	pip-compile -v --no-emit-trusted-host --no-index --upgrade -o requirements/edx/development.txt requirements/edx/development.in
 	# Post process all of the files generated above to work around open pip-tools issues
 	scripts/post-pip-compile.sh \
-        requirements/edx/pip-tools.txt \
+	    requirements/edx/pip-tools.txt \
 	    requirements/edx/coverage.txt \
 	    requirements/edx/paver.txt \
 	    requirements/edx-sandbox/shared.txt \

--- a/common/lib/xmodule/xmodule/library_content_module.py
+++ b/common/lib/xmodule/xmodule/library_content_module.py
@@ -17,6 +17,7 @@ from web_fragments.fragment import Fragment
 from webob import Response
 from xblock.core import XBlock
 from xblock.fields import Integer, List, Scope, String
+from xblock.completable import XBlockCompletionMode
 
 from capa.responsetypes import registry
 from xmodule.studio_editable import StudioEditableDescriptor, StudioEditableModule
@@ -64,6 +65,9 @@ class LibraryContentFields(object):
     # Please note the display_name of each field below is used in
     # common/test/acceptance/pages/studio/library.py:StudioLibraryContentXBlockEditModal
     # to locate input elements - keep synchronized
+
+    completion_mode = XBlockCompletionMode.AGGREGATOR
+
     display_name = String(
         display_name=_("Display Name"),
         help=_("The display name for this component."),

--- a/common/test/acceptance/pages/lms/completion_aggregate.py
+++ b/common/test/acceptance/pages/lms/completion_aggregate.py
@@ -1,0 +1,55 @@
+# -*- coding: utf-8 -*-
+"""
+Module for Completion Aggregate API page
+"""
+
+import json
+
+from bok_choy.page_object import PageObject
+from common.test.acceptance.pages.lms import BASE_URL
+
+
+class CompletionAggregatePage(PageObject):
+    """
+    Visit this page to view the completion aggregate data list.
+    """
+    def __init__(self, browser, username=None, course_id=None):
+        """Initialize the page.
+
+        Arguments:
+            browser (Browser): The browser instance.
+            username: username of the user for which we want the completion aggregate
+            course_id: course key of the course
+        """
+        super(CompletionAggregatePage, self).__init__(browser)
+        self.username = username
+        self.course_id = course_id
+        self.aggregate_list_dict = None
+
+    @property
+    def url(self):
+        """
+        Construct a URL to the page
+        """
+        url = BASE_URL + '/completion-aggregator/v1/course/'
+
+        if self.course_id:
+            url = url + self.course_id + '/'
+
+        if self.username:
+            url = url + '?username=' + self.username
+
+        return url
+
+    def is_browser_on_page(self):
+
+        body = self.q(css='BODY').text[0]
+        try:
+            self.aggregate_list_dict = json.loads(body)
+            return 'results' in self.aggregate_list_dict
+
+        except ValueError:
+            return False
+
+    def get_completion_data(self):
+        return self.aggregate_list_dict['results'][0]['completion']

--- a/common/test/acceptance/tests/lms/test_lms_completion_aggregator.py
+++ b/common/test/acceptance/tests/lms/test_lms_completion_aggregator.py
@@ -1,0 +1,212 @@
+# -*- coding: utf-8 -*-
+"""
+End-to-end tests for the LMS that test the completion aggregates as the learner progresses in the course
+"""
+from contextlib import contextmanager
+
+from common.test.acceptance.fixtures.course import CourseFixture, XBlockFixtureDesc
+from common.test.acceptance.pages.common.logout import LogoutPage
+from common.test.acceptance.pages.lms.completion_aggregate import CompletionAggregatePage
+from common.test.acceptance.pages.lms.courseware import CoursewarePage
+from common.test.acceptance.pages.lms.instructor_dashboard import InstructorDashboardPage
+from common.test.acceptance.pages.lms.problem import ProblemPage
+from common.test.acceptance.pages.studio.overview import CourseOutlinePage as StudioCourseOutlinePage
+from common.test.acceptance.pages.studio.utils import drag
+from common.test.acceptance.tests.helpers import UniqueCourseTest, auto_auth, create_multiple_choice_problem
+
+
+class CompletionAggregatorTest(UniqueCourseTest):
+    """
+    Class for Completion Aggregator tests.
+    """
+    USERNAME = "STUDENT_TESTER"
+    EMAIL = "student101@example.com"
+    SECTION_NAME = 'Test Section 1'
+    SUBSECTION_NAME = 'Test Subsection 1'
+    UNIT1_NAME = 'Test Unit 1'
+    UNIT2_NAME = 'Test Unit 2'
+    UNIT3_NAME = 'Test Unit 3'
+    UNIT4_NAME = 'Test Unit 4'
+    UNIT5_NAME = 'Test Unit 5'
+    UNIT6_NAME = 'Test Unit 6'
+    UNIT7_NAME = 'Test Unit 7'
+    UNIT8_NAME = 'Test Unit 8'
+    PROBLEM1_NAME = 'Test Problem 1'
+    PROBLEM2_NAME = 'Test Problem 2'
+    PROBLEM3_NAME = 'Test Problem 3'
+    PROBLEM4_NAME = 'Test Problem 4'
+    PROBLEM5_NAME = 'Test Problem 5'
+    PROBLEM6_NAME = 'Test Problem 6'
+    PROBLEM7_NAME = 'Test Problem 7'
+    PROBLEM8_NAME = 'Test Problem 8'
+
+    def setUp(self):
+        super(CompletionAggregatorTest, self).setUp()
+        self.courseware_page = CoursewarePage(self.browser, self.course_id)
+        self.problem_page = ProblemPage(self.browser)
+        self.logout_page = LogoutPage(self.browser)
+        self.instructor_dashboard_page = InstructorDashboardPage(self.browser, self.course_id)
+        self.completion_aggregation_list_page = CompletionAggregatePage(self.browser)
+        self.completion_aggregation_detail_page = CompletionAggregatePage(self.browser, course_id=self.course_id)
+        self.completion_aggregation_student_detail_page = CompletionAggregatePage(self.browser,
+                                                                                  course_id=self.course_id,
+                                                                                  username=self.USERNAME)
+
+        self.studio_course_outline = StudioCourseOutlinePage(
+            self.browser,
+            self.course_info['org'],
+            self.course_info['number'],
+            self.course_info['run']
+        )
+
+        # Install a course with problems
+        self.course_fix = CourseFixture(
+            self.course_info['org'],
+            self.course_info['number'],
+            self.course_info['run'],
+            self.course_info['display_name']
+        )
+
+        self.problem1 = create_multiple_choice_problem(self.PROBLEM1_NAME)
+        self.problem2 = create_multiple_choice_problem(self.PROBLEM2_NAME)
+        self.problem3 = create_multiple_choice_problem(self.PROBLEM3_NAME)
+        self.problem4 = create_multiple_choice_problem(self.PROBLEM4_NAME)
+        self.problem5 = create_multiple_choice_problem(self.PROBLEM5_NAME)
+        self.problem6 = create_multiple_choice_problem(self.PROBLEM6_NAME)
+        self.problem7 = create_multiple_choice_problem(self.PROBLEM7_NAME)
+        self.problem8 = create_multiple_choice_problem(self.PROBLEM8_NAME)
+
+        self.course_fix.add_children(
+            XBlockFixtureDesc('chapter', self.SECTION_NAME).add_children(
+                XBlockFixtureDesc('sequential', self.SUBSECTION_NAME).add_children(
+                    XBlockFixtureDesc('vertical', self.UNIT1_NAME).add_children(self.problem1),
+                    XBlockFixtureDesc('vertical', self.UNIT2_NAME).add_children(self.problem2),
+                    XBlockFixtureDesc('vertical', self.UNIT3_NAME).add_children(self.problem3),
+                    XBlockFixtureDesc('vertical', self.UNIT4_NAME).add_children(self.problem4)
+                ),
+                XBlockFixtureDesc('sequential', self.SUBSECTION_NAME).add_children(
+                    XBlockFixtureDesc('vertical', self.UNIT5_NAME).add_children(self.problem5),
+                    XBlockFixtureDesc('vertical', self.UNIT6_NAME).add_children(self.problem6),
+                    XBlockFixtureDesc('vertical', self.UNIT7_NAME).add_children(self.problem7),
+                    XBlockFixtureDesc('vertical', self.UNIT8_NAME).add_children(self.problem8)
+                )
+            )
+        ).install()
+
+        # Auto-auth register for the course.
+        auto_auth(self.browser, self.USERNAME, self.EMAIL, False, self.course_id)
+
+    def _answer_problem(self, problem_number, choice):
+        """
+        Submit the given choice for the problem.
+        """
+        self.courseware_page.go_to_sequential_position(problem_number)
+        self.problem_page.click_choice('choice_choice_{}'.format(choice))
+        self.problem_page.click_submit()
+
+    def _get_completion_aggregate_detail(self):
+        """
+        Return the completion aggregate data
+        """
+        self.completion_aggregation_student_detail_page.visit()
+        return self.completion_aggregation_student_detail_page.get_completion_data()
+
+    @contextmanager
+    def _logged_in_session(self, staff=False):
+        """
+        Ensure that the user is logged in and out appropriately at the beginning
+        and end of the current test.
+        """
+        self.logout_page.visit()
+        try:
+            if staff:
+                auto_auth(self.browser, "STAFF_TESTER", "staff101@example.com", True, self.course_id)
+            else:
+                auto_auth(self.browser, self.USERNAME, self.EMAIL, False, self.course_id)
+            yield
+        finally:
+            self.logout_page.visit()
+
+    def _delete_unit(self):
+        """
+        Deletes the first unit of the first subsection of the first section.
+        """
+        self.studio_course_outline.visit()
+        self.studio_course_outline.section_at(0).subsection_at(0).expand_subsection()
+        self.studio_course_outline.section_at(0).subsection_at(0).unit_at(0).delete()
+
+    def _drag_unit_to_other_subsection(self):
+        """
+        Moves Unit 7 from subsection 2 to subsection 1.
+        """
+        self.studio_course_outline.visit()
+        self.studio_course_outline.expand_all_subsections()
+        drag(self.studio_course_outline, 4, 6)
+        self.studio_course_outline.section(self.SECTION_NAME).publish()
+
+    def test_aggregate_increases_with_attempts(self):
+        """
+        Tests that attempting the problems increments the completion.
+
+        Scenario: Check that completion aggregates change when problems are attempted.
+            Given that I am enrolled in a course with 2 subsections with 4 units+problems each.
+            When I answer the second problem
+            Then my completion aggregate should show 8 possible, 1 earned and 1/8 percent.
+            When I answer the second problem
+            Then my completion aggregate should show 8 possible, 2 earned and 2/8 percent.
+        """
+        with self._logged_in_session(staff=False):
+            self.courseware_page.visit()
+            self._answer_problem(problem_number=1, choice=2)
+
+        with self._logged_in_session(staff=True):
+            completion_data = self._get_completion_aggregate_detail()
+            self.assertAlmostEqual(completion_data['possible'], 8.0)
+            self.assertAlmostEqual(completion_data['earned'], 1.0)
+            self.assertAlmostEqual(completion_data['percent'], 1.0 / 8.0)
+
+        with self._logged_in_session(staff=False):
+            self.courseware_page.visit()
+            self._answer_problem(problem_number=2, choice=2)
+
+        with self._logged_in_session(staff=True):
+            completion_data = self._get_completion_aggregate_detail()
+            self.assertAlmostEqual(completion_data['possible'], 8.0)
+            self.assertAlmostEqual(completion_data['earned'], 2.0)
+            self.assertAlmostEqual(completion_data['percent'], 2.0 / 8.0)
+
+    def test_completion_aggregates_delete_unit(self):
+        """
+        Tests that deleting a unit changes the totals and aggregates.
+
+        Scenario: Check that completion aggregates change when problems are attempted.
+            Given that I am enrolled in a course with 2 subsections with 4 units+problems each.
+            When I answer the second problem
+            Then my completion aggregate should show 8 possible, 1 earned and 1/8 percent.
+            When the staff changes the course and deletes the first problem
+            And that leaves a total of 7 problems and changes the indexes of the problems
+            When I answer the second problem (which was previously the third problem)
+            Then my completion aggregate should show 7 possible, 2 earned and 2/7 percent.
+        """
+        with self._logged_in_session(staff=False):
+            self.courseware_page.visit()
+            self._answer_problem(problem_number=2, choice=2)
+
+        with self._logged_in_session(staff=True):
+            completion_data = self._get_completion_aggregate_detail()
+            self.assertAlmostEqual(completion_data['possible'], 8.0)
+            self.assertAlmostEqual(completion_data['earned'], 1.0)
+            self.assertAlmostEqual(completion_data['percent'], 1.0 / 8.0)
+
+        with self._logged_in_session(staff=True):
+            self._delete_unit()
+
+        with self._logged_in_session(staff=False):
+            self.courseware_page.visit()
+            self._answer_problem(problem_number=2, choice=2)
+
+        with self._logged_in_session(staff=True):
+            completion_data = self._get_completion_aggregate_detail()
+            self.assertAlmostEqual(completion_data['possible'], 7.0)
+            self.assertAlmostEqual(completion_data['earned'], 2.0)
+            self.assertAlmostEqual(completion_data['percent'], 2.0 / 7.0)

--- a/common/test/db_fixtures/waffle_flags.json
+++ b/common/test/db_fixtures/waffle_flags.json
@@ -16,6 +16,23 @@
         }
     },
     {
+        "pk": 3,
+        "model": "waffle.flag",
+        "fields": {
+            "name": "course_experience.gdpr",
+            "everyone": false
+	}
+    },
+    {
+        "pk": 4,
+        "model": "waffle.flag",
+        "fields": {
+            "name": "studio.enable_checklists_quality",
+            "staff": true,
+            "superusers": true
+        }
+    },
+    {
         "pk": 1,
         "model": "waffle.switch",
         "fields": {
@@ -27,33 +44,16 @@
         "pk": 2,
         "model": "waffle.switch",
         "fields": {
-            "name": "completion.enable_completion_tracking",
-            "active": true
-        }
-    },
-    {
-        "pk": 3,
-        "model": "waffle.flag",
-        "fields": {
-            "name": "course_experience.gdpr",
-            "everyone": false
-        }
-    },
-    {
-        "pk": 4,
-        "model": "waffle.switch",
-        "fields": {
             "name": "studio.enable_checklists_page",
             "active": true
         }
     },
     {
-        "pk": 5,
-        "model": "waffle.flag",
+        "pk": 3,
+        "model": "waffle.switch",
         "fields": {
-            "name": "studio.enable_checklists_quality",
-            "staff": true,
-            "superusers": true
+            "name": "completion.enable_completion_tracking",
+            "active": true
         }
     }
 ]

--- a/lms/djangoapps/instructor_task/tests/test_tasks_helper.py
+++ b/lms/djangoapps/instructor_task/tests/test_tasks_helper.py
@@ -381,7 +381,7 @@ class TestInstructorGradeReport(InstructorGradeReportTestCase):
         self._verify_cell_data_for_user(verified_user.username, course.id, 'Certificate Eligible', 'Y', num_rows=2)
 
     @ddt.data(
-        (ModuleStoreEnum.Type.mongo, 4),
+        (ModuleStoreEnum.Type.mongo, 2),
         (ModuleStoreEnum.Type.split, 3),
     )
     @ddt.unpack

--- a/lms/envs/bok_choy.env.json
+++ b/lms/envs/bok_choy.env.json
@@ -56,6 +56,7 @@
     },
     "COMMENTS_SERVICE_KEY": "password",
     "COMMENTS_SERVICE_URL": "http://localhost:4567",
+    "COMPLETION_AGGREGATOR_BLOCK_TYPES": ["course", "chapter"],
     "CONTACT_EMAIL": "info@example.com",
     "DEFAULT_FEEDBACK_EMAIL": "feedback@example.com",
     "DEFAULT_FROM_EMAIL": "registration@example.com",

--- a/openedx/tests/completion_aggregator_integration/test_creation.py
+++ b/openedx/tests/completion_aggregator_integration/test_creation.py
@@ -1,0 +1,382 @@
+"""
+Test creation of aggregate completions when a user works through a course.
+"""
+
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+from datetime import timedelta
+import logging
+
+from completion.models import BlockCompletion
+from completion.test_utils import CompletionWaffleTestMixin
+from completion_aggregator.models import Aggregator
+from django.utils import timezone
+import pytest
+
+
+from course_modes.models import CourseMode
+from openedx.core.djangolib.testing.utils import skip_unless_lms
+from student.models import CourseEnrollment
+from student.tests.factories import UserFactory
+from xmodule.library_tools import LibraryToolsService
+from xmodule.modulestore import ModuleStoreEnum
+from xmodule.modulestore.tests.django_utils import TEST_DATA_SPLIT_MODULESTORE, SharedModuleStoreTestCase
+from xmodule.modulestore.tests.factories import CourseFactory, ItemFactory, LibraryFactory
+from xmodule.partitions.partitions import ENROLLMENT_TRACK_PARTITION_ID
+from xmodule.partitions import partitions_service
+
+log = logging.getLogger(__name__)
+
+
+class _BaseTestCase(CompletionWaffleTestMixin, SharedModuleStoreTestCase):
+    """
+    Common functionality for Aggregator tests.
+    """
+    def setUp(self):
+        super(_BaseTestCase, self).setUp()
+        self.override_waffle_switch(True)
+        self.user = UserFactory.create()
+
+    def submit_completion_with_user(self, user, item, completion):
+        return BlockCompletion.objects.submit_completion(
+            user=user,
+            course_key=self.course_key,
+            block_key=item.location,
+            completion=completion,
+        )
+
+    def submit_completion_for(self, item, completion):
+        return self.submit_completion_with_user(self.user, item, completion)
+
+    def aggregator_for(self, item, user=None):
+        """
+        Return the aggregator for the given item, or raise an Aggregator.DoesNotExist
+        """
+        qs = Aggregator.objects.all()
+        if user:
+            qs = qs.filter(user=user)
+        return qs.get(block_key=item.location)
+
+    def assert_expected_values(self, values_map, user=None):
+        for item in values_map:
+            if values_map[item]:
+                agg = self.aggregator_for(item, user=user)
+                self.assertEqual((agg.earned, agg.possible), values_map[item])
+            else:
+                with pytest.raises(Aggregator.DoesNotExist):
+                    self.aggregator_for(item, user=user)
+
+
+class DAGTestCase(_BaseTestCase):
+    """
+    Test that aggregators are created and updated properly for earned BlockCompletions.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        super(DAGTestCase, cls).setUpClass()
+        cls.course = CourseFactory.create()
+        cls.course_key = cls.course.id
+        with cls.store.bulk_operations(cls.course.id):
+            cls.chapter = ItemFactory.create(
+                parent=cls.course,
+                category="chapter",
+            )
+            cls.sequential = ItemFactory.create(
+                parent=cls.chapter,
+                category='sequential',
+            )
+            cls.vertical1 = ItemFactory.create(parent=cls.sequential, category='vertical')
+            cls.vertical2 = ItemFactory.create(parent=cls.sequential, category='vertical')
+            cls.problems = [
+                ItemFactory.create(parent=cls.vertical1, category="problem"),
+                ItemFactory.create(parent=cls.vertical1, category="problem"),
+                ItemFactory.create(parent=cls.vertical1, category="problem"),
+                ItemFactory.create(parent=cls.vertical1, category="problem"),
+            ]
+            cls.multiparent_problem = ItemFactory.create(parent=cls.vertical1, category="problem")
+            cls.vertical2.children.append(cls.multiparent_problem.location)
+            creator = UserFactory()
+            cls.store.update_item(cls.vertical2, creator.id)
+            cls.store.update_item(cls.course, creator.id)
+
+    @skip_unless_lms
+    def test_marking_blocks_complete(self):
+        self.submit_completion_for(self.problems[0], 0.75)
+        self.assert_expected_values({
+            self.vertical1: (0.75, 5.0),
+            self.vertical2: (0.0, 1.0),
+            self.sequential: (0.75, 6.0),
+            self.chapter: (0.75, 6.0),
+        })
+
+    @skip_unless_lms
+    def test_dag_block_values_summed(self):
+        self.submit_completion_for(self.multiparent_problem, 1.0)
+        self.assert_expected_values({
+            self.vertical1: (1.0, 5.0),
+            self.vertical2: (1.0, 1.0),
+            self.sequential: (2.0, 6.0),
+            self.chapter: (2.0, 6.0),
+        })
+
+    @skip_unless_lms
+    def test_modify_existing_completion(self):
+        """
+        After updating already-existing completion values, the new values take
+        effect, and existing aggregators still exist, even if they are empty.
+        """
+        self.submit_completion_for(self.problems[2], 0.8)
+        self.submit_completion_for(self.multiparent_problem, 0.25)
+        self.submit_completion_for(self.problems[2], 0.5)
+        self.submit_completion_for(self.multiparent_problem, 0.0)
+        self.assert_expected_values({
+            self.vertical1: (0.5, 5.0),
+            self.vertical2: (0.0, 1.0),
+            self.sequential: (0.5, 6.0),
+            self.chapter: (0.5, 6.0),
+        })
+
+    @skip_unless_lms
+    def test_multiple_users(self):
+        self.submit_completion_with_user(self.user, self.problems[2], 1.0)
+        self.submit_completion_with_user(self.user, self.multiparent_problem, 0.5)
+
+        user2 = UserFactory.create()
+        self.submit_completion_with_user(user2, self.problems[0], 1.0)
+        self.submit_completion_with_user(user2, self.problems[1], 1.0)
+        self.submit_completion_with_user(user2, self.problems[2], 1.0)
+        self.submit_completion_with_user(user2, self.problems[3], 1.0)
+
+        self.assert_expected_values({
+            self.vertical1: (1.5, 5.0),
+            self.vertical2: (0.5, 1.0),
+            self.sequential: (2.0, 6.0),
+            self.chapter: (2.0, 6.0),
+        }, user=self.user)
+
+        self.assert_expected_values({
+            self.vertical1: (4.0, 5.0),
+            self.vertical2: (0.0, 1.0),
+            self.sequential: (4.0, 6.0),
+            self.chapter: (4.0, 6.0),
+        }, user=user2)
+
+
+class HiddenContentTestCase(_BaseTestCase):
+    """
+    Test that hidden content is still counted in aggregators
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        super(HiddenContentTestCase, cls).setUpClass()
+        cls.course = CourseFactory.create()
+        cls.course_key = cls.course.id
+        with cls.store.bulk_operations(cls.course.id):
+            cls.chapter = ItemFactory.create(
+                parent=cls.course,
+                category="chapter",
+            )
+            cls.sequential = ItemFactory.create(
+                parent=cls.chapter,
+                category='sequential',
+                due=timezone.now() - timedelta(days=1),
+                hide_after_due=True,
+            )
+            cls.vertical = ItemFactory.create(parent=cls.sequential, category='vertical')
+            cls.htmlblock = ItemFactory.create(parent=cls.vertical, category="html")
+
+    @skip_unless_lms
+    def test_hidden_content_still_calculated(self):
+        self.submit_completion_for(self.htmlblock, 1.0)
+        self.assert_expected_values({
+            self.vertical: (1.0, 1.0),
+            self.sequential: (1.0, 1.0),
+            self.chapter: (1.0, 1.0),
+        })
+
+
+class LibraryTestCase(_BaseTestCase):
+    """
+    Test handling of library content by completion infrastructure.
+    """
+
+    MODULESTORE = TEST_DATA_SPLIT_MODULESTORE
+
+    @classmethod
+    def setUpClass(cls):
+
+        super(LibraryTestCase, cls).setUpClass()
+
+        cls.library = LibraryFactory.create(modulestore=cls.store)
+        creator = UserFactory()
+
+        cls.library_blocks = [
+            ItemFactory.create(
+                category="html",
+                parent=cls.library,
+                parent_location=cls.library.location,
+                publish_item=False,
+                user_id=creator.id,
+                modulestore=cls.store,
+            ) for _ in range(3)
+        ]
+        cls.libtools = LibraryToolsService(cls.store)
+        cls.store.update_item(cls.library, creator.id)
+
+        with cls.store.branch_setting(ModuleStoreEnum.Branch.draft_preferred, None):
+            cls.course = CourseFactory.create(modulestore=cls.store)
+            cls.course_key = cls.course.id
+
+            with cls.store.bulk_operations(cls.course_key, emit_signals=False):
+                cls.chapter = ItemFactory.create(
+                    parent=cls.course,
+                    parent_location=cls.course.location,
+                    category="chapter",
+                    modulestore=cls.store,
+                    publish_item=False,
+                )
+                cls.sequential = ItemFactory.create(
+                    parent=cls.chapter,
+                    parent_location=cls.chapter.location,
+                    category='sequential',
+                    modulestore=cls.store,
+                    publish_item=False,
+                )
+                cls.vertical = ItemFactory.create(
+                    parent=cls.sequential,
+                    parent_location=cls.sequential.location,
+                    category='vertical',
+                    modulestore=cls.store,
+                    publish_item=False,
+                )
+
+                cls.lc_block = ItemFactory.create(
+                    category="library_content",
+                    parent=cls.vertical,
+                    parent_location=cls.vertical.location,
+                    max_count=2,
+                    source_library_id=unicode(cls.library.location.library_key),
+                    modulestore=cls.store,
+                )
+                # copy children from library to content block (LibaryContentDescriptor.tools.update_children?)
+                cls.store.update_item(cls.course, creator.id)
+                cls.store.update_item(cls.lc_block, creator.id)
+
+    def setUp(self):
+        super(LibraryTestCase, self).setUp()
+        self.lc_block = self._refresh_children(self.lc_block)
+        self.in_course_blocks = [self.store.get_item(child) for child in self.lc_block.children]
+
+    def _refresh_children(self, lib_content_block):
+        """
+        Refresh the set of children on the library content block, then
+        fetch a new copy from the modulestore.
+        """
+        self.libtools.update_children(lib_content_block, self.user.id)
+        return self.store.get_item(lib_content_block.location)
+
+    @skip_unless_lms
+    def test_completing_library_content(self):
+        for block in self.in_course_blocks:
+            self.submit_completion_for(block, 0.75)
+        self.assert_expected_values({
+            self.vertical: (1.5, 2.0),
+            self.chapter: (1.5, 2.0),
+        })
+
+
+class EnrollmentTrackTestCase(_BaseTestCase):
+    """
+    Test that completion aggregates for blocks that are available to the user's
+    enrollment track only.
+    """
+    @classmethod
+    def setUpClass(cls):
+        super(EnrollmentTrackTestCase, cls).setUpClass()
+        cls.course = CourseFactory.create()
+        cls.course_key = cls.course.id
+        CourseMode.objects.create(course_id=cls.course_key, mode_slug=CourseMode.AUDIT, mode_display_name='Audit')
+        CourseMode.objects.create(
+            course_id=cls.course_key,
+            mode_slug=CourseMode.VERIFIED,
+            mode_display_name='Verified',
+            min_price=1.5,
+        )
+
+        cls.partitions = partitions_service.get_all_partitions_for_course(cls.course)
+        verified_track_partition_id = 2  # This is determined by the order CourseMode objects are created.
+        with cls.store.bulk_operations(cls.course.id):
+            cls.chapter = ItemFactory.create(
+                parent=cls.course,
+                category="chapter",
+            )
+            cls.vertical1 = ItemFactory.create(
+                parent=cls.chapter,
+                category="vertical",
+                group_access={ENROLLMENT_TRACK_PARTITION_ID: [verified_track_partition_id]},
+            )
+
+            cls.vertical2 = ItemFactory.create(
+                parent=cls.chapter,
+                category="vertical",
+            )
+            cls.problem1 = ItemFactory.create(
+                parent=cls.vertical1,
+                category="problem",
+            )
+            cls.problem2 = ItemFactory.create(
+                parent=cls.vertical2,
+                category="problem",
+            )
+            cls.problem3 = ItemFactory.create(
+                parent=cls.vertical2,
+                category="problem",
+                group_access={ENROLLMENT_TRACK_PARTITION_ID: [verified_track_partition_id]},
+            )
+
+    def setUp(self):
+        super(EnrollmentTrackTestCase, self).setUp()
+        self.audit_user = UserFactory.create(username='audituser')
+        self.verified_enrollment = CourseEnrollment.enroll(self.user, self.course_key, mode='verified')
+        self.audit_enrollment = CourseEnrollment.enroll(self.audit_user, self.course_key, mode='audit')
+
+    @skip_unless_lms
+    def test_user_on_track(self):
+        self.submit_completion_with_user(self.user, self.problem1, 1.0)
+        self.submit_completion_with_user(self.user, self.problem2, 0.5)
+        self.submit_completion_with_user(self.user, self.problem3, 0.25)
+        self.assert_expected_values({
+            self.vertical1: (1.0, 1.0),
+            self.vertical2: (0.75, 2.0),
+            self.chapter: (1.75, 3.0),
+        }, user=self.user)
+
+    @skip_unless_lms
+    def test_user_off_track(self):
+        self.submit_completion_with_user(self.audit_user, self.problem2, 1.0)
+        self.assert_expected_values({
+            self.vertical2: (1.0, 1.0),
+            self.chapter: (1.0, 1.0),
+        }, user=self.audit_user)
+
+    @skip_unless_lms
+    def test_user_upgrades(self):
+        self.submit_completion_with_user(self.audit_user, self.problem2, 1.0)
+        self.audit_enrollment.update_enrollment(mode='verified')
+        self.assert_expected_values({
+            self.vertical2: (1.0, 2.0),
+            self.chapter: (1.0, 3.0),
+        }, user=self.audit_user)
+
+    @skip_unless_lms
+    def test_user_leaves_track(self):
+        self.submit_completion_with_user(self.user, self.problem1, 1.0)
+        self.submit_completion_with_user(self.user, self.problem2, 0.5)
+        self.submit_completion_with_user(self.user, self.problem3, 0.25)
+        self.verified_enrollment.update_enrollment(mode='audit')
+        self.assert_expected_values({
+            self.vertical2: (0.5, 1.0),
+            self.chapter: (0.5, 1.0),
+        }, user=self.user)

--- a/requirements/edx-sandbox/base.txt
+++ b/requirements/edx-sandbox/base.txt
@@ -4,10 +4,10 @@
 #
 #    make upgrade
 #
-common/lib/calc
-common/lib/chem
-common/lib/sandbox-packages
-common/lib/symmath
+-e common/lib/calc
+-e common/lib/chem
+-e common/lib/sandbox-packages
+-e common/lib/symmath
 asn1crypto==0.24.0
 backports-abc==0.5        # via tornado
 cffi==1.11.5

--- a/requirements/edx/base.in
+++ b/requirements/edx/base.in
@@ -106,6 +106,7 @@ newrelic                            # New Relic agent for performance monitoring
 nodeenv==1.1.1                      # Utility for managing Node.js environments; we use this for deployments and testing
 numpy==1.6.2                        # Fast numeric array computation, used in some problem types
 oauthlib                            # OAuth specification support for authenticating via LTI or other Open edX services
+openedx-completion-aggregator
 pdfminer                            # Used in shoppingcart for extracting/parsing pdf text
 piexif==1.0.2                       # Exif image metadata manipulation, used in the profile_images app
 Pillow                              # Image manipulation library; used for course assets, profile images, invoice PDFs, etc.

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -177,6 +177,7 @@ numpy==1.6.2
 oauth2==1.9.0.post1
 oauthlib==2.1.0
 openapi-codec==1.3.2      # via django-rest-swagger
+openedx-completion-aggregator==1.2
 path.py==8.2.1
 pathtools==0.1.2
 paver==1.3.4

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -225,6 +225,7 @@ numpy==1.6.2
 oauth2==1.9.0.post1
 oauthlib==2.1.0
 openapi-codec==1.3.2
+openedx-completion-aggregator==1.2
 pa11ycrawler==1.6.2
 packaging==18.0           # via sphinx
 parsel==1.5.1
@@ -267,7 +268,7 @@ pyquery==1.4.0
 pysqlite==2.8.3
 pysrt==0.4.7
 pytest-attrib==0.1.3
-pytest-cov==2.5.1
+pytest-cov==2.6.0
 pytest-django==3.1.2
 pytest-forked==0.2
 pytest-randomly==1.2.3

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -217,6 +217,7 @@ numpy==1.6.2
 oauth2==1.9.0.post1
 oauthlib==2.1.0
 openapi-codec==1.3.2
+openedx-completion-aggregator==1.2
 pa11ycrawler==1.6.2
 parsel==1.5.1             # via scrapy
 path.py==8.2.1
@@ -256,7 +257,7 @@ pyquery==1.4.0
 pysqlite==2.8.3
 pysrt==0.4.7
 pytest-attrib==0.1.3
-pytest-cov==2.5.1
+pytest-cov==2.6.0
 pytest-django==3.1.2
 pytest-forked==0.2        # via pytest-xdist
 pytest-randomly==1.2.3


### PR DESCRIPTION

These are tests to make sure that the aggregator works in context with edx-platform.  We won't merge this into master until we are ready to turn on aggregation, but we want to have this branch available so we can test that aggregation works in the broader context of edx-platform (with modulestore and other integration points fully exercised).

**JIRA tickets**: OSPR-2304, OC-3572

**Discussions**: Architecture discussed extensively on the wiki and in meetings, then the revised proposal was presented to the Arch Council on Oct. 21 and given thumbs up.

**Dependencies**: None

**Screenshots**:N/A

**Sandbox URL**: On request

**Merge deadline**: None

**Testing instructions**:

1. Check out the branch.
2. Create and enable the waffle switch  `completion.enable_completion_tracking`.
2. Run `paver install_prereqs`.
3. `paver test_system -s lms -t openedx/tests/completion_integration_tests.py` should pass.
4. `paver test_system -s cms -t openedx/tests/completion_integration_tests.py` should run 0 tests.

**Author notes and concerns**:

"2" seems to be the value for the verified track partition group based on trial and error (and seeing another place that uses "1" to mean "Audit", but I'm not sure how I'm supposed to know that.  I'd love to replace that with a constant from somewhere, but I'm not sure it exists.

**Reviewers**
- [x] Firefighter @pomegranited or @smarnach 
- [ ] edX reviewer[s] TBD

**Settings**
None