### PR TITLE
Drag and drop xblock completion not showing in course outline.

### DIFF
--- a/openedx/features/course_experience/utils.py
+++ b/openedx/features/course_experience/utils.py
@@ -128,7 +128,8 @@ def get_course_outline_block_tree(request, course_id):
         'html',
         'problem',
         'video',
-        'discussion'
+        'discussion',
+        'drag-and-drop-v2'
     ]
     all_blocks = get_blocks(
         request,


### PR DESCRIPTION
## [EDUCATOR 2506](https://openedx.atlassian.net/browse/EDUCATOR-2506)

Drag and drop completion was not showing in the course outline, because the method to get the course outline blocktree did not check for xblocks of type "drag-and-drop-v2", and was thus never marking them complete in the returned tree.