### PR TITLE
Send password requirements to mobile

### DIFF
--- a/openedx/core/djangoapps/user_api/api.py
+++ b/openedx/core/djangoapps/user_api/api.py
@@ -415,14 +415,24 @@ class RegistrationFormFactory(object):
         # meant to hold the user's password.
         password_label = _(u"Password")
 
+        restrictions = {}
+
+        if settings.FEATURES.get('ENFORCE_PASSWORD_POLICY', False):
+            complexities = getattr(settings, 'PASSWORD_COMPLEXITY', {})
+            for key, value in complexities.iteritems():
+                api_key = key.lower().replace(' ', '_')
+                restrictions[api_key] = value
+
+        restrictions.update({
+            "min_length": password_min_length(),
+            "max_length": password_max_length(),
+        })
+
         form_desc.add_field(
             "password",
             label=password_label,
             field_type="password",
-            restrictions={
-                "min_length": password_min_length(),
-                "max_length": password_max_length(),
-            },
+            restrictions=restrictions,
             required=required
         )
 

--- a/openedx/core/djangoapps/user_api/helpers.py
+++ b/openedx/core/djangoapps/user_api/helpers.py
@@ -125,7 +125,8 @@ class FormDescription(object):
 
     ALLOWED_RESTRICTIONS = {
         "text": ["min_length", "max_length"],
-        "password": ["min_length", "max_length"],
+        "password": ["min_length", "max_length", "upper", "lower", "digits", "punctuation", "non_ascii", "words",
+                     "numeric", "alphabetic"],
         "email": ["min_length", "max_length", "readonly"],
     }
 

--- a/openedx/core/djangoapps/user_api/tests/test_views.py
+++ b/openedx/core/djangoapps/user_api/tests/test_views.py
@@ -1062,6 +1062,39 @@ class RegistrationViewTest(ThirdPartyAuthTestMixin, UserAPITestCase):
             }
         )
 
+    @override_settings(PASSWORD_COMPLEXITY={'NON ASCII': 1, 'UPPER': 3})
+    def test_register_form_password_complexity(self):
+        no_extra_fields_setting = {}
+
+        # Without enabling password policy
+        self._assert_reg_field(
+            no_extra_fields_setting,
+            {
+                u'name': u'password',
+                u'label': u'Password',
+                u'restrictions': {
+                    'min_length': password_min_length(),
+                    'max_length': password_max_length(),
+                },
+            }
+        )
+
+        # Now with an enabled password policy
+        with mock.patch.dict(settings.FEATURES, {'ENFORCE_PASSWORD_POLICY': True}):
+            self._assert_reg_field(
+                no_extra_fields_setting,
+                {
+                    u'name': u'password',
+                    u'label': u'Password',
+                    u'restrictions': {
+                        'min_length': password_min_length(),
+                        'max_length': password_max_length(),
+                        'non_ascii': 1,
+                        'upper': 3,
+                    },
+                }
+            )
+
     @override_settings(REGISTRATION_EXTENSION_FORM='openedx.core.djangoapps.user_api.tests.test_helpers.TestCaseForm')
     def test_extension_form_fields(self):
         no_extra_fields_setting = {}


### PR DESCRIPTION
We have a registration endpoint that sends all the information the mobile
app needs to render a form, including password requirements. But it wasn't
sending complexity information before (e.g. 1 uppercase letter).

Now it does!