### PR TITLE
Fix incorrect message feedback in discussion feature.

### DIFF
--- a/common/static/common/js/discussion/views/discussion_thread_list_view.js
+++ b/common/static/common/js/discussion/views/discussion_thread_list_view.js
@@ -414,6 +414,7 @@
 
             DiscussionThreadListView.prototype.chooseFilter = function() {
                 this.filter = $('.forum-nav-filter-main-control :selected').val();
+                this.clearSearchAlerts();
                 return this.retrieveFirstPage();
             };
 

--- a/common/static/common/js/spec/discussion/view/discussion_thread_list_view_spec.js
+++ b/common/static/common/js/spec/discussion/view/discussion_thread_list_view_spec.js
@@ -233,6 +233,19 @@
             });
         });
 
+        it('filter should clear search alert when alternate term was searched', function() {
+            var filterval = 'unread';
+            expectFilter(filterval);
+            this.view.$('.forum-nav-filter-main-control').val(filterval);
+            expect($('.search-alert .message').text())
+                .toEqual('There are no posts in this topic yet.');
+
+            filterval = 'all';
+            expectFilter(filterval);
+            this.view.$('.forum-nav-filter-main-control').val(filterval).change();
+            expect($('.search-alert .message').text()).toEqual('');
+        });
+
         describe('group selector', function() {
             it('should not be visible to students', function() {
                 return expect(this.view.$('.forum-nav-filter-cohort-control:visible')).not.toExist();


### PR DESCRIPTION
## [Discussion Feature Showing Incorrect Message Feedback EDUCATOR-2520](https://openedx.atlassian.net/browse/EDUCATOR-2520)

### Description:
This PR fixes that when there is post in a topic it wouldn't show a message *There are no posts in this topic yet.*.

### How to Test?
**Production**
 - Go to the discussion url: https://courses.edx.org/courses/course-v1:MITx+8.05.1x+1T2018/discussion/forum/d-ex1-3/threads/5aa9da9284452a085d0025b5
-  Click “All Discussions” 
- Click on all posts so that they are marked as read 
-  Use the dropdown to filter Unread posts 
- You receive the expected behavior of “There are no posts in this topic yet.”
- Now using the dropdown navigate back to All posts and the expected behavior is for the “There are no posts in this topic yet. ” to disappear, but it persists. 

**Sandbox**
https://discussion.sandbox.edx.org/courses/course-v1:edX+DemoX+Demo_Course/discussion/forum/


**Testing**
- [x] Jasmine Test


### Reviewers

If you've been tagged for review, please check your corresponding box once you've given the :+1:.
-  [x] @Rabia23 
-  [x] @asadazam93 

### Post-review
- [x] Rebase and squash commits


