### PR TITLE
PLAT-2028 - Create mailing list retirement API endpoint

### DIFF
--- a/lms/djangoapps/bulk_email/signals.py
+++ b/lms/djangoapps/bulk_email/signals.py
@@ -1,0 +1,25 @@
+"""
+Signal handlers for the bulk_email app
+"""
+
+from django.dispatch import receiver
+
+from student.models import CourseEnrollment
+from openedx.core.djangoapps.user_api.accounts.signals import USER_RETIRE_MAILINGS
+
+from .models import Optout
+
+
+@receiver(USER_RETIRE_MAILINGS)
+def force_optout_all(sender, **kwargs):  # pylint: disable=unused-argument
+    """
+    When a user is retired from all mailings this method will create an Optout
+    row for any courses they may be enrolled in.
+    """
+    user = kwargs.get('user', None)
+
+    if not user:
+        raise TypeError('Expected a User type, but received None.')
+
+    for enrollment in CourseEnrollment.objects.filter(user=user):
+        Optout.objects.get_or_create(user=user, course_id=enrollment.course.id)

--- a/lms/djangoapps/bulk_email/tests/test_signals.py
+++ b/lms/djangoapps/bulk_email/tests/test_signals.py
@@ -1,0 +1,87 @@
+"""
+Unit tests for student optouts from course email
+"""
+import json
+
+from django.core import mail
+from django.core.management import call_command
+from django.core.urlresolvers import reverse
+from mock import Mock, patch
+from nose.plugins.attrib import attr
+from six import text_type
+
+from bulk_email.models import BulkEmailFlag, Optout
+from bulk_email.signals import force_optout_all
+from student.tests.factories import AdminFactory, CourseEnrollmentFactory, UserFactory
+from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
+from xmodule.modulestore.tests.factories import CourseFactory
+
+
+@attr(shard=1)
+@patch('bulk_email.models.html_to_text', Mock(return_value='Mocking CourseEmail.text_message', autospec=True))
+class TestOptoutCourseEmailsBySignal(ModuleStoreTestCase):
+    """
+    Tests that the force_optout_all signal receiver opts the user out of course emails
+    """
+    def setUp(self):
+        super(TestOptoutCourseEmailsBySignal, self).setUp()
+        self.course = CourseFactory.create(run='testcourse1', display_name="Test Course Title")
+        self.instructor = AdminFactory.create()
+        self.student = UserFactory.create()
+        self.enrollment = CourseEnrollmentFactory.create(user=self.student, course_id=self.course.id)
+
+        # load initial content (since we don't run migrations as part of tests):
+        call_command("loaddata", "course_email_template.json")
+
+        self.client.login(username=self.student.username, password="test")
+
+        self.send_mail_url = reverse('send_email', kwargs={'course_id': text_type(self.course.id)})
+        self.success_content = {
+            'course_id': text_type(self.course.id),
+            'success': True,
+        }
+        BulkEmailFlag.objects.create(enabled=True, require_course_email_auth=False)
+
+    def test_optout_row_created_on_signal(self):
+        """
+        Make sure the correct row is created for a user enrolled in a course
+        """
+        force_optout_all(sender=self.__class__, user=self.student)
+        self.assertEqual(Optout.objects.filter(user=self.student, course_id=self.course.id).count(), 1)
+
+    def send_test_email(self):
+        """
+        Navigate to the instructor dash's email view to send bulk email
+        """
+        # Pull up email view on instructor dashboard
+        url = reverse('instructor_dashboard', kwargs={'course_id': text_type(self.course.id)})
+        response = self.client.get(url)
+        email_section = '<div class="vert-left send-email" id="section-send-email">'
+
+        # If this fails, it is likely because BulkEmailFlag.is_enabled() is set to False
+        self.assertIn(email_section, response.content)
+
+        test_email = {
+            'action': 'Send email',
+            'send_to': '["myself", "staff", "learners"]',
+            'subject': 'test subject for all',
+            'message': 'test message for all'
+        }
+        response = self.client.post(self.send_mail_url, test_email)
+        self.assertEquals(json.loads(response.content), self.success_content)
+
+    def test_optout_course(self):
+        """
+        Make sure student does not receive course email after being opted out
+        """
+        # Use the signal receiver to for the opt-out
+        force_optout_all(sender=self.__class__, user=self.student)
+
+        # Try to send a bulk course email
+        self.client.login(username=self.instructor.username, password="test")
+        self.send_test_email()
+
+        # Assert that self.student.email not in mail.to, outbox should only contain "myself" target
+        self.assertEqual(len(mail.outbox), 1)
+        self.assertEqual(len(mail.outbox[0].to), 1)
+        self.assertEqual(mail.outbox[0].to[0], self.instructor.email)

--- a/lms/djangoapps/email_marketing/signals.py
+++ b/lms/djangoapps/email_marketing/signals.py
@@ -6,14 +6,17 @@ import logging
 from random import randint
 
 import crum
+from celery.exceptions import TimeoutError
 from django.conf import settings
 from django.dispatch import receiver
+from sailthru.sailthru_client import SailthruClient
 from sailthru.sailthru_error import SailthruClientError
-from celery.exceptions import TimeoutError
+from six import text_type
 
 import third_party_auth
 from course_modes.models import CourseMode
 from email_marketing.models import EmailMarketingConfiguration
+from openedx.core.djangoapps.user_api.accounts.signals import USER_RETIRE_MAILINGS
 from openedx.core.djangoapps.waffle_utils import WaffleSwitchNamespace
 from lms.djangoapps.email_marketing.tasks import update_user, update_user_email, get_email_cookies_via_sailthru
 from openedx.core.djangoapps.lang_pref import LANGUAGE_KEY
@@ -94,10 +97,10 @@ def add_email_marketing_cookies(sender, response=None, user=None,
         _log_sailthru_api_call_time(time_before_call)
 
     except TimeoutError as exc:
-        log.error("Timeout error while attempting to obtain cookie from Sailthru: %s", unicode(exc))
+        log.error("Timeout error while attempting to obtain cookie from Sailthru: %s", text_type(exc))
         return response
     except SailthruClientError as exc:
-        log.error("Exception attempting to obtain cookie from Sailthru: %s", unicode(exc))
+        log.error("Exception attempting to obtain cookie from Sailthru: %s", text_type(exc))
         return response
     except Exception:
         log.error("Exception Connecting to celery task for %s", user.email)
@@ -226,7 +229,7 @@ def _create_sailthru_user_vars(user, profile, registration=None):
 
         if profile.year_of_birth:
             sailthru_vars['year_of_birth'] = profile.year_of_birth
-        sailthru_vars['country'] = unicode(profile.country.code)
+        sailthru_vars['country'] = text_type(profile.country.code)
 
     if registration:
         sailthru_vars['activation_key'] = registration.activation_key
@@ -258,3 +261,43 @@ def _log_sailthru_api_call_time(time_before_call):
              time_before_call.isoformat(' '),
              time_after_call.isoformat(' '),
              delta_sailthru_api_call_time.microseconds / 1000)
+
+
+@receiver(USER_RETIRE_MAILINGS)
+def force_unsubscribe_all(sender, **kwargs):  # pylint: disable=unused-argument
+    """
+    Synchronously(!) unsubscribes the given user from all Sailthru email lists.
+
+    In the future this could be moved to a Celery task, however this is currently
+    only used as part of user retirement, where we need a very reliable indication
+    of success or failure.
+
+    Args:
+        user(User): Django model of type returned from get_user_model()
+    Returns:
+        None
+    """
+    user = kwargs.get('user', None)
+
+    if not user:
+        raise TypeError('Expected a User type, but received None.')
+
+    email_config = EmailMarketingConfiguration.current()
+    if not email_config.enabled:
+        return
+
+    sailthru_parms = {"id": user.email, "keys": {"optout_email": "all"}}
+
+    try:
+        sailthru_client = SailthruClient(email_config.sailthru_key, email_config.sailthru_secret)
+        sailthru_response = sailthru_client.api_post("user", sailthru_parms)
+    except SailthruClientError as exc:
+        error_msg = "Exception attempting to opt-out user %s from Sailthru - %s" % (user.email, text_type(exc))
+        log.error(error_msg)
+        raise Exception(error_msg)
+
+    if not sailthru_response.is_ok():
+        error = sailthru_response.get_error()
+        error_msg = "Error attempting to opt-out user %s from Sailthru - %s" % (user.email, error.get_message())
+        log.error(error_msg)
+        raise Exception(error_msg)

--- a/openedx/core/djangoapps/user_api/accounts/signals.py
+++ b/openedx/core/djangoapps/user_api/accounts/signals.py
@@ -1,0 +1,7 @@
+"""
+Django Signal related functionality for user_api accounts
+"""
+
+from django.dispatch import Signal
+
+USER_RETIRE_MAILINGS = Signal(providing_args=["user"])

--- a/openedx/core/djangoapps/user_api/urls.py
+++ b/openedx/core/djangoapps/user_api/urls.py
@@ -6,7 +6,7 @@ from django.conf import settings
 from django.conf.urls import url
 
 from ..profile_images.views import ProfileImageView
-from .accounts.views import AccountDeactivationView, AccountViewSet
+from .accounts.views import AccountDeactivationView, AccountRetireMailingsView, AccountViewSet
 from .preferences.views import PreferencesDetailView, PreferencesView
 from .verification_api.views import PhotoVerificationStatusView
 from .validation.views import RegistrationValidationView
@@ -49,6 +49,11 @@ urlpatterns = [
         r'^v1/accounts/{}/deactivate/$'.format(settings.USERNAME_PATTERN),
         AccountDeactivationView.as_view(),
         name='accounts_deactivation'
+    ),
+    url(
+        r'^v1/accounts/{}/retire_mailings/$'.format(settings.USERNAME_PATTERN),
+        AccountRetireMailingsView.as_view(),
+        name='accounts_retire_mailings'
     ),
     url(
         r'^v1/accounts/{}/verification_status/$'.format(settings.USERNAME_PATTERN),


### PR DESCRIPTION
- Removes "email-optin" UserOrgTags for the user
- Creates and uses a new "UserRetireMailingsSignal" signal
- Creates and uses a new "CanRetireUser" permission
- Creates and uses a new setting "RETIREMENT_SERVICE_WORKER_USERNAME"
- Creates a signal handler to globally opt-out the user from Sailthru