### PR TITLE
ENT-894 Upgrade python-saml package

### DIFF
--- a/requirements/edx/post.txt
+++ b/requirements/edx/post.txt
@@ -9,4 +9,4 @@
 # resolution of this dependency during compilation. So we need to install
 # python-saml only after lxml has been successfully installed. 
 
-python-saml==2.2.1
+python-saml==2.4.0


### PR DESCRIPTION
We are upgrading to pull in a fix for a security vulnerability that was recently disclosed by OneLogin.