### PR TITLE
EDUCATOR-2428 add acceptance criteria for certificate delivered column in grade report

### DIFF
--- a/lms/djangoapps/certificates/models.py
+++ b/lms/djangoapps/certificates/models.py
@@ -66,6 +66,7 @@ from opaque_keys.edx.django.models import CourseKeyField
 from badges.events.course_complete import course_badge_check
 from badges.events.course_meta import completion_check, course_group_check
 from lms.djangoapps.instructor_task.models import InstructorTask
+from openedx.core.djangoapps.content.course_overviews.models import CourseOverview
 from openedx.core.djangoapps.signals.signals import COURSE_CERT_AWARDED
 from openedx.core.djangoapps.xmodule_django.models import NoneToEmptyManager
 from util.milestones_helpers import fulfill_course_milestone, is_prerequisite_courses_enabled
@@ -563,7 +564,7 @@ def certificate_status(generated_certificate):
         return {'status': CertificateStatuses.unavailable, 'mode': GeneratedCertificate.MODES.honor, 'uuid': None}
 
 
-def certificate_info_for_user(user, grade, user_is_whitelisted, user_certificate):
+def certificate_info_for_user(user, course_id, grade, user_is_whitelisted, user_certificate):
     """
     Returns the certificate info for a user for grade report.
     """
@@ -573,8 +574,9 @@ def certificate_info_for_user(user, grade, user_is_whitelisted, user_certificate
         else 'N'
 
     status = certificate_status(user_certificate)
+    can_have_certificate = CourseOverview.get_from_id(course_id).may_certify()
     certificate_generated = status['status'] == CertificateStatuses.downloadable
-    if certificate_generated:
+    if certificate_generated and can_have_certificate:
         certificate_is_delivered = 'Y'
         certificate_type = status['mode']
 

--- a/lms/djangoapps/instructor_task/tasks_helper/grades.py
+++ b/lms/djangoapps/instructor_task/tasks_helper/grades.py
@@ -401,6 +401,7 @@ class CourseGradeReport(object):
         is_whitelisted = user.id in bulk_certs.whitelisted_user_ids
         certificate_info = certificate_info_for_user(
             user,
+            context.course_id,
             course_grade.letter_grade,
             is_whitelisted,
             bulk_certs.certificates_by_user.get(user.id),

--- a/lms/djangoapps/instructor_task/tests/test_tasks_helper.py
+++ b/lms/djangoapps/instructor_task/tests/test_tasks_helper.py
@@ -12,7 +12,7 @@ import os
 import shutil
 import tempfile
 import urllib
-from datetime import datetime
+from datetime import datetime, timedelta
 
 import ddt
 import unicodecsv
@@ -396,7 +396,7 @@ class TestInstructorGradeReport(InstructorGradeReportTestCase):
 
         RequestCache.clear_request_cache()
 
-        expected_query_count = 36
+        expected_query_count = 41
         with patch('lms.djangoapps.instructor_task.tasks_helper.runner._get_current_task'):
             with check_mongo_calls(mongo_count):
                 with self.assertNumQueries(expected_query_count):
@@ -1809,12 +1809,19 @@ class TestGradeReport(TestReportMixin, InstructorTaskModuleTestCase):
 @patch('lms.djangoapps.instructor_task.tasks_helper.misc.DefaultStorage', new=MockDefaultStorage)
 class TestGradeReportEnrollmentAndCertificateInfo(TestReportMixin, InstructorTaskModuleTestCase):
     """
-    Test that grade report has correct user enrolment, verification, and certificate information.
+    Test that grade report has correct user enrollment, verification, and certificate information.
     """
     def setUp(self):
         super(TestGradeReportEnrollmentAndCertificateInfo, self).setUp()
 
-        self.initialize_course()
+        today = datetime.now(UTC)
+        course_factory_kwargs = {
+            'start': today - timedelta(days=30),
+            'end': today - timedelta(days=2),
+            'certificate_available_date': today - timedelta(days=1)
+        }
+
+        self.initialize_course(course_factory_kwargs)
 
         self.create_problem()
 


### PR DESCRIPTION
# [EDUCATOR-2428](https://openedx.atlassian.net/browse/EDUCATOR-2428)

### Description
In the current scenario, if the learner has successfully earned the certificate then `Certificates Delivered` column appears with a 'Y' value in the grade report regardless of the `Certificates Available Date` set in Studio. This misleads the course teams that learners can access their certificates before the `Certificates Available Date` they've set in Studio. This PR checks the acceptance criteria for computing `Certificates Delivered` column.

### Reviewers
If you've been tagged for review, please check your corresponding box once you've given the :+1:.
- [x] Code review: @ssemenova  
- [x] Code review: @efischer19 

### Post-review
- [x] Rebase and squash commits