### PR TITLE
Encodes staff profile names as they can be unicode

### DIFF
--- a/lms/djangoapps/dashboard/sysadmin.py
+++ b/lms/djangoapps/dashboard/sysadmin.py
@@ -559,7 +559,7 @@ class Staffing(SysadminDashboardView):
                 for role in roles:
                     for user in role(course.id).users_with_role():
                         datum = [course.id, role, user.username, user.email,
-                                 user.profile.name]
+                                 user.profile.name.encode('utf-8')]
                         data.append(datum)
             header = [_('course_id'),
                       _('role'), _('username'),


### PR DESCRIPTION
We (Stanford) recently found a unicode bug on the `Staff/Instructor Download` page of the sysadmin dashboard.

Steps to reproduce (Assuming an instructor has a non-ASCII unicode character in their Profile Name):

- Sign in to lagunita.stanford.edu
- Click “Sysadmin”
- Click “Staffing and Enrollment”
- Click “Download staff and instructor list (csv file)” button
- See 500 error

The fix is pretty simple, just encode the name as 'utf-8' before generating the CSV.