### PR TITLE
Exclude enterprise learners from the welcome email.

### DIFF
--- a/lms/djangoapps/email_marketing/signals.py
+++ b/lms/djangoapps/email_marketing/signals.py
@@ -14,6 +14,7 @@ from celery.exceptions import TimeoutError
 from course_modes.models import CourseMode
 from email_marketing.models import EmailMarketingConfiguration
 from openedx.core.djangoapps.waffle_utils import WaffleSwitchNamespace
+from openedx.features.enterprise_support import api as enterprise_api
 from lms.djangoapps.email_marketing.tasks import update_user, update_user_email, get_email_cookies_via_sailthru
 from openedx.core.djangoapps.lang_pref import LANGUAGE_KEY
 from student.cookies import CREATE_LOGON_COOKIE
@@ -212,6 +213,9 @@ def _create_sailthru_user_vars(user, profile, registration=None):
     if registration:
         sailthru_vars['activation_key'] = registration.activation_key
         sailthru_vars['signupNumber'] = randint(0, 9)
+
+    enterprise_learner_data = enterprise_api.get_enterprise_learner_data(site=_get_current_site(), user=user)
+    sailthru_vars['is_enterprise_learner'] = bool(enterprise_learner_data)
 
     return sailthru_vars
 

--- a/lms/djangoapps/email_marketing/tasks.py
+++ b/lms/djangoapps/email_marketing/tasks.py
@@ -96,8 +96,8 @@ def update_user(self, sailthru_vars, email, site=None, new_user=False, activatio
         return
 
     # if activating user, send welcome email
-    if activation and email_config.sailthru_welcome_template and is_default_site(site) and not \
-            sailthru_vars.get('is_enterprise_learner'):
+    if (activation and email_config.sailthru_welcome_template and is_default_site(site) and
+            not sailthru_vars.get('is_enterprise_learner')):
 
         scheduled_datetime = datetime.utcnow() + timedelta(seconds=email_config.welcome_email_send_delay)
         try:


### PR DESCRIPTION
Stop sending welcome email to enterprise learners upon activation.

LEARNER-3649