### PR TITLE
LEARNER-4676: Increase the Throttle on the enrollments API to allow ecommerce to re…

### DIFF
--- a/common/djangoapps/enrollment/views.py
+++ b/common/djangoapps/enrollment/views.py
@@ -74,9 +74,12 @@ class ApiKeyPermissionMixIn(object):
 
 class EnrollmentUserThrottle(UserRateThrottle, ApiKeyPermissionMixIn):
     """Limit the number of requests users can make to the enrollment API."""
+    # The staff Throttle rate is currently being adjusted to meet the needs of the eCommerce API calls.
+    # This should be reviewed for performance and we should determine the optimum throttle for the needs of this API.
+    # https://openedx.atlassian.net/wiki/spaces/LEARNER/pages/645923004/eCommerce+Guild
     THROTTLE_RATES = {
         'user': '40/minute',
-        'staff': '1200/minute',
+        'staff': '2000/minute',  # Decided on by looking at number of API calls to the Enrollment API from Staff users
     }
 
     def allow_request(self, request, view):


### PR DESCRIPTION
…quest more frequently

Currently the throttle on the enrollments api is being reached by calls from ecommerce.  I would like to raise this cap so that ecommerce will be able to get the required data.

https://openedx.atlassian.net/browse/LEARNER-4676
