### PR TITLE
Revert "EDUCATOR-2540 | Bump edx-completion to 0.1.0"

### DIFF
--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -56,7 +56,7 @@ git+https://github.com/cpennington/pylint-django@fix-field-inference-during-monk
 enum34==1.1.6
 edx-django-oauth2-provider==1.2.5
 edx-django-sites-extensions==2.3.0
-edx-completion==0.1.0
+edx-completion==0.0.11
 edx-enterprise==0.66.0
 edx-milestones==0.1.13
 edx-oauth2-provider==1.2.2


### PR DESCRIPTION
This reverts commit 20647b57fbe02b929edc8444a7ecc3c5e7a86a26.

The latest version of edx-completion has a raw SQL query with a JOIN that is not performant at production scale.  This rolls back to the previous version of edx-completion.