### PR TITLE
mark email sent events as non-interactions

### DIFF
--- a/lms/djangoapps/discussion/tasks.py
+++ b/lms/djangoapps/discussion/tasks.py
@@ -85,7 +85,8 @@ def _track_notification_sent(message, context):
         'uuid': unicode(message.uuid),
         'send_uuid': unicode(message.send_uuid),
         'thread_id': context['thread_id'],
-        'thread_created_at': date.deserialize(context['thread_created_at'])
+        'thread_created_at': date.deserialize(context['thread_created_at']),
+        'nonInteraction': 1,
     }
     analytics.track(
         user_id=context['thread_author_id'],

--- a/lms/djangoapps/discussion/tests/test_tasks.py
+++ b/lms/djangoapps/discussion/tests/test_tasks.py
@@ -298,6 +298,8 @@ class TaskTestCase(ModuleStoreTestCase):
             for key, entry in test_props.items():
                 setattr(message, key, entry)
 
+            test_props['nonInteraction'] = True
+
             with mock.patch('analytics.track') as mock_analytics_track:
                 _track_notification_sent(message, context)
                 mock_analytics_track.assert_called_once_with(

--- a/openedx/core/djangoapps/schedules/tasks.py
+++ b/openedx/core/djangoapps/schedules/tasks.py
@@ -216,6 +216,7 @@ def _track_message_sent(site, user, msg):
         'language': msg.language,
         'uuid': unicode(msg.uuid),
         'send_uuid': unicode(msg.send_uuid),
+        'nonInteraction': 1,
     }
     course_ids = msg.context.get('course_ids', [])
     properties['num_courses'] = len(course_ids)


### PR DESCRIPTION
This should fix the issue that causes us to see a massive spike in "users" in google analytics at the time we send out all of these emails.

See segment docs here: https://segment.com/docs/destinations/google-analytics/#non-interaction-events