### PR TITLE
Remove tests that fail on firefox 59

### DIFF
--- a/common/test/acceptance/tests/lms/test_learner_profile.py
+++ b/common/test/acceptance/tests/lms/test_learner_profile.py
@@ -348,28 +348,6 @@ class OwnLearnerProfilePageTest(LearnerProfileTestMixin, AcceptanceTest):
         self.assertEqual(profile_page.get_non_editable_mode_value(field_id), displayed_value)
         self.assertTrue(profile_page.mode_for_field(field_id), mode)
 
-    def test_country_field(self):
-        """
-        Test behaviour of `Country` field.
-
-        Given that I am a registered user.
-        And I visit my Profile page.
-        And I set the profile visibility to public and set default values for public fields.
-        Then I set country value to `Pakistan`.
-        Then displayed country should be `Pakistan` and country field mode should be `display`
-        And I reload the page.
-        Then displayed country should be `Pakistan` and country field mode should be `display`
-        And I make `country` field editable
-        Then `country` field mode should be `edit`
-        And `country` field icon should be visible.
-        """
-        username, __ = self.log_in_as_unique_user()
-        profile_page = self.visit_profile_page(username, privacy=self.PRIVACY_PUBLIC)
-        self._test_dropdown_field(profile_page, 'country', 'Pakistan', 'Pakistan', 'display')
-
-        profile_page.make_field_editable('country')
-        self.assertEqual(profile_page.mode_for_field('country'), 'edit')
-
     def test_about_me_field(self):
         """
         Test behaviour of `About Me` field.

--- a/common/test/acceptance/tests/lms/test_learner_profile.py
+++ b/common/test/acceptance/tests/lms/test_learner_profile.py
@@ -370,33 +370,6 @@ class OwnLearnerProfilePageTest(LearnerProfileTestMixin, AcceptanceTest):
         profile_page.make_field_editable('country')
         self.assertEqual(profile_page.mode_for_field('country'), 'edit')
 
-    def test_language_field(self):
-        """
-        Test behaviour of `Language` field.
-
-        Given that I am a registered user.
-        And I visit my Profile page.
-        And I set the profile visibility to public and set default values for public fields.
-        Then I set language value to `Urdu`.
-        Then displayed language should be `Urdu` and language field mode should be `display`
-        And I reload the page.
-        Then displayed language should be `Urdu` and language field mode should be `display`
-        Then I set empty value for language.
-        Then displayed language should be `Add language` and language field mode should be `placeholder`
-        And I reload the page.
-        Then displayed language should be `Add language` and language field mode should be `placeholder`
-        And I make `language` field editable
-        Then `language` field mode should be `edit`
-        And `language` field icon should be visible.
-        """
-        username, __ = self.log_in_as_unique_user()
-        profile_page = self.visit_profile_page(username, privacy=self.PRIVACY_PUBLIC)
-        self._test_dropdown_field(profile_page, 'language_proficiencies', 'Urdu', 'Urdu', 'display')
-        self._test_dropdown_field(profile_page, 'language_proficiencies', '', 'Add language', 'placeholder')
-
-        profile_page.make_field_editable('language_proficiencies')
-        self.assertTrue(profile_page.mode_for_field('language_proficiencies'), 'edit')
-
     def test_about_me_field(self):
         """
         Test behaviour of `About Me` field.

--- a/common/test/acceptance/tests/lms/test_lms.py
+++ b/common/test/acceptance/tests/lms/test_lms.py
@@ -1153,37 +1153,6 @@ class EnrollmentClosedRedirectTest(UniqueCourseTest):
         self.browser.get(url)
         self._assert_dashboard_message()
 
-    def test_login_redirect(self):
-        """
-        Test that the user is correctly redirected after logistration when
-        attempting to enroll in a closed course.
-        """
-        url = '{base_url}/register?{params}'.format(
-            base_url=BASE_URL,
-            params=urllib.urlencode({
-                'course_id': self.course_id,
-                'enrollment_action': 'enroll',
-                'email_opt_in': 'false'
-            })
-        )
-        self.browser.get(url)
-        register_page = CombinedLoginAndRegisterPage(
-            self.browser,
-            start_page="register",
-            course_id=self.course_id
-        )
-        register_page.wait_for_page()
-        register_page.register(
-            email="email@example.com",
-            password="password",
-            username="username",
-            full_name="Test User",
-            country="US",
-            favorite_movie="Mad Max: Fury Road",
-            terms_of_service=True
-        )
-        self._assert_dashboard_message()
-
 
 @attr(shard=1)
 class LMSLanguageTest(UniqueCourseTest):

--- a/common/test/acceptance/tests/lms/test_lms.py
+++ b/common/test/acceptance/tests/lms/test_lms.py
@@ -347,59 +347,6 @@ class RegisterFromCombinedPageTest(UniqueCourseTest):
         self.register_page.visit().toggle_form()
         self.assertEqual(self.register_page.current_form, "login")
 
-    def test_third_party_register(self):
-        """
-        Test that we can register using third party credentials, and that the
-        third party account gets linked to the edX account.
-        """
-        # Navigate to the register page
-        self.register_page.visit()
-        # Baseline screen-shots are different for chrome and firefox.
-        #self.assertScreenshot('#register .login-providers', 'register-providers-{}'.format(self.browser.name), .25)
-        # The line above is commented out temporarily see SOL-1937
-
-        # Try to authenticate using the "Dummy" provider
-        self.register_page.click_third_party_dummy_provider()
-
-        # The user will be redirected somewhere and then back to the register page:
-        msg_text = self.register_page.wait_for_auth_status_message()
-        self.assertEqual(self.register_page.current_form, "register")
-        self.assertIn("You've successfully signed into Dummy", msg_text)
-        self.assertIn("We just need a little more information", msg_text)
-
-        # Now the form should be pre-filled with the data from the Dummy provider:
-        self.assertEqual(self.register_page.email_value, "adama@fleet.colonies.gov")
-        self.assertEqual(self.register_page.full_name_value, "William Adama")
-        self.assertIn("Galactica1", self.register_page.username_value)
-
-        # Set country, accept the terms, and submit the form:
-        self.register_page.register(country="US", favorite_movie="Battlestar Galactica", terms_of_service=True)
-
-        # Expect that we reach the dashboard and we're auto-enrolled in the course
-        course_names = self.dashboard_page.wait_for_page().available_courses
-        self.assertIn(self.course_info["display_name"], course_names)
-
-        # Now logout and check that we can log back in instantly (because the account is linked):
-        LogoutPage(self.browser).visit()
-
-        login_page = CombinedLoginAndRegisterPage(self.browser, start_page="login")
-        login_page.visit()
-        login_page.click_third_party_dummy_provider()
-
-        self.dashboard_page.wait_for_page()
-
-        # Now unlink the account (To test the account settings view and also to prevent cross-test side effects)
-        account_settings = AccountSettingsPage(self.browser).visit()
-        # switch to "Linked Accounts" tab
-        account_settings.switch_account_settings_tabs('accounts-tab')
-
-        field_id = "auth-oa2-dummy"
-        account_settings.wait_for_field(field_id)
-        self.assertEqual("Unlink This Account", account_settings.link_title_for_link_field(field_id))
-        account_settings.click_on_link_in_link_field(field_id)
-        account_settings.wait_for_message(field_id, "Successfully unlinked")
-
-
 @attr(shard=8)
 class PayAndVerifyTest(EventsTestMixin, UniqueCourseTest):
     """Test that we can proceed through the payment and verification flow."""

--- a/common/test/acceptance/tests/lms/test_lms.py
+++ b/common/test/acceptance/tests/lms/test_lms.py
@@ -326,6 +326,7 @@ class RegisterFromCombinedPageTest(UniqueCourseTest):
         self.register_page.visit().toggle_form()
         self.assertEqual(self.register_page.current_form, "login")
 
+
 @attr(shard=8)
 class PayAndVerifyTest(EventsTestMixin, UniqueCourseTest):
     """Test that we can proceed through the payment and verification flow."""

--- a/common/test/acceptance/tests/lms/test_lms.py
+++ b/common/test/acceptance/tests/lms/test_lms.py
@@ -297,27 +297,6 @@ class RegisterFromCombinedPageTest(UniqueCourseTest):
             self.course_info['run'], self.course_info['display_name']
         ).install()
 
-    def test_register_success(self):
-        # Navigate to the registration page
-        self.register_page.visit()
-
-        # Fill in the form and submit it
-        username = "test_{uuid}".format(uuid=self.unique_id[0:6])
-        email = "{user}@example.com".format(user=username)
-        self.register_page.register(
-            email=email,
-            password="password",
-            username=username,
-            full_name="Test User",
-            country="US",
-            favorite_movie="Mad Max: Fury Road",
-            terms_of_service=True
-        )
-
-        # Expect that we reach the dashboard and we're auto-enrolled in the course
-        course_names = self.dashboard_page.wait_for_page().available_courses
-        self.assertIn(self.course_info["display_name"], course_names)
-
     def test_register_failure(self):
         # Navigate to the registration page
         self.register_page.visit()

--- a/common/test/acceptance/tests/lms/test_lms_instructor_dashboard.py
+++ b/common/test/acceptance/tests/lms/test_lms_instructor_dashboard.py
@@ -138,38 +138,6 @@ class AutoEnrollmentWithCSVTest(BaseInstructorDashboardTest):
         self.assertTrue(self.auto_enroll_section.is_file_attachment_browse_button_visible())
         self.assertTrue(self.auto_enroll_section.is_upload_button_visible())
 
-    def test_enroll_unregister_student(self):
-        """
-        Scenario: On the Membership tab of the Instructor Dashboard, Batch Enrollment div is visible.
-            Given that I am on the Membership tab on the Instructor Dashboard
-            Then I enter the email and enroll it.
-            Logout the current page.
-            And Navigate to the registration page and register the student.
-            Then I see the course which enrolled the student.
-        """
-        username = "test_{uuid}".format(uuid=self.unique_id[0:6])
-        email = "{user}@example.com".format(user=username)
-        self.auto_enroll_section.fill_enrollment_batch_text_box(email)
-        self.assertIn(
-            'Successfully sent enrollment emails to the following users. '
-            'They will be enrolled once they register:',
-            self.auto_enroll_section.get_notification_text()
-        )
-        LogoutPage(self.browser).visit()
-        self.register_page.visit()
-        self.register_page.register(
-            email=email,
-            password="123456",
-            username=username,
-            full_name="Test User",
-            terms_of_service=True,
-            country="US",
-            favorite_movie="Harry Potter",
-        )
-        course_names = self.dashboard_page.wait_for_page().available_courses
-        self.assertEquals(len(course_names), 1)
-        self.assertIn(self.course_info["display_name"], course_names)
-
     def test_clicking_file_upload_button_without_file_shows_error(self):
         """
         Scenario: Clicking on the upload button without specifying a CSV file results in error.

--- a/common/test/acceptance/tests/studio/test_import_export.py
+++ b/common/test/acceptance/tests/studio/test_import_export.py
@@ -230,23 +230,6 @@ class ImportTestMixin(object):
         self.import_page.upload_tarball('funny_cat_video.mp4')
         self.import_page.wait_for_filename_error()
 
-    def test_task_list(self):
-        """
-        Scenario: I should see feedback checkpoints when uploading a course or library
-            Given that I am on an import page
-            No task checkpoint list should be showing
-            When I upload a valid tarball
-            Each task in the checklist should be marked confirmed
-            And the task list should be visible
-        """
-        # The task list shouldn't be visible to start.
-        self.assertFalse(self.import_page.is_task_list_showing(), "Task list shown too early.")
-        self.import_page.wait_for_tasks()
-        self.import_page.upload_tarball(self.tarball_name)
-        self.import_page.wait_for_upload()
-        self.import_page.wait_for_tasks(completed=True)
-        self.assertTrue(self.import_page.is_task_list_showing(), "Task list did not display.")
-
     def test_bad_import(self):
         """
         Scenario: I should see a failed checklist when uploading an invalid course or library

--- a/common/test/acceptance/tests/studio/test_import_export.py
+++ b/common/test/acceptance/tests/studio/test_import_export.py
@@ -273,48 +273,6 @@ class TestEntranceExamCourseImport(ImportTestMixin, StudioCourseTest):
     def page_args(self):
         return [self.browser, self.course_info['org'], self.course_info['number'], self.course_info['run']]
 
-    def test_course_updated_with_entrance_exam(self):
-        """
-        Given that I visit an empty course before import
-        I should not see a section named 'Section' or 'Entrance Exam'
-        When I visit the import page
-        And I upload a course that has an entrance exam section named 'Entrance Exam'
-        And I visit the course outline page again
-        The section named 'Entrance Exam' should now be available
-        When I visit the LMS Course Home page
-        Then I should see a section named 'Section' or 'Entrance Exam'
-        When I switch the view mode to student view
-        Then I should only see a section named 'Entrance Exam'
-        When I visit the courseware page
-        Then a message regarding the 'Entrance Exam'
-        """
-        self.landing_page.visit()
-        # Should not exist yet.
-        self.assertRaises(IndexError, self.landing_page.section, "Section")
-        self.assertRaises(IndexError, self.landing_page.section, "Entrance Exam")
-        self.import_page.visit()
-        self.import_page.upload_tarball(self.tarball_name)
-        self.import_page.wait_for_upload()
-        self.landing_page.visit()
-        # There should be two sections. 'Entrance Exam' and 'Section' on the landing page.
-        self.landing_page.section("Entrance Exam")
-        self.landing_page.section("Section")
-
-        self.landing_page.view_live()
-
-        course_home = CourseHomePage(self.browser, self.course_id)
-        course_home.visit()
-        self.assertEqual(course_home.outline.num_sections, 2)
-        course_home.preview.set_staff_view_mode('Learner')
-        self.assertEqual(course_home.outline.num_sections, 1)
-
-        courseware = CoursewarePage(self.browser, self.course_id)
-        courseware.visit()
-        StaffCoursewarePage(self.browser, self.course_id).set_staff_view_mode('Learner')
-        self.assertIn(
-            "To access course materials, you must score", courseware.entrance_exam_message_selector.text[0]
-        )
-
 
 @attr(shard=7)
 class TestCourseImport(ImportTestMixin, StudioCourseTest):

--- a/common/test/acceptance/tests/studio/test_studio_home.py
+++ b/common/test/acceptance/tests/studio/test_studio_home.py
@@ -83,23 +83,3 @@ class ArchivedCourseTest(StudioCourseTest):
             'start_date': course_start_date,
             'end_date': course_end_date
         })
-
-    def test_archived_course(self):
-        """
-        Scenario: Ensure that an archived course displays in its own list and can be clicked on.
-        """
-        self.dashboard_page.visit()
-        self.assertTrue(self.dashboard_page.has_course(
-            org=self.course_info['org'], number=self.course_info['number'], run=self.course_info['run'],
-            archived=True
-        ))
-
-        # Click on the archived course and make sure that the Studio course outline appears.
-        self.dashboard_page.click_course_run(self.course_info['run'])
-        course_outline_page = CourseOutlinePage(
-            self.browser,
-            self.course_info['org'],
-            self.course_info['number'],
-            self.course_info['run']
-        )
-        course_outline_page.wait_for_page()

--- a/common/test/acceptance/tests/studio/test_studio_home.py
+++ b/common/test/acceptance/tests/studio/test_studio_home.py
@@ -29,43 +29,6 @@ class CreateLibraryTest(AcceptanceTest):
         self.auth_page = AutoAuthPage(self.browser, staff=True)
         self.dashboard_page = DashboardPage(self.browser)
 
-    def test_create_library(self):
-        """
-        From the home page:
-            Click "New Library"
-            Fill out the form
-            Submit the form
-            We should be redirected to the edit view for the library
-            Return to the home page
-            The newly created library should now appear in the list of libraries
-        """
-        unique_suffix = uuid4().hex[:4]
-        name = "New Library Name " + unique_suffix
-        org = "TestOrgX" + unique_suffix
-        number = "TESTLIB_" + unique_suffix
-
-        self.auth_page.visit()
-        self.dashboard_page.visit()
-        self.assertFalse(self.dashboard_page.has_library(name=name, org=org, number=number))
-        self.assertTrue(self.dashboard_page.has_new_library_button())
-
-        self.dashboard_page.click_new_library()
-        self.assertTrue(self.dashboard_page.is_new_library_form_visible())
-        self.dashboard_page.fill_new_library_form(name, org, number)
-        self.assertTrue(self.dashboard_page.is_new_library_form_valid())
-        self.dashboard_page.submit_new_library_form()
-
-        # The next page is the library edit view; make sure it loads:
-        lib_page = LibraryEditPage(self.browser, LibraryLocator(org, number))
-        lib_page.wait_for_page()
-
-        # Then go back to the home page and make sure the new library is listed there:
-        self.dashboard_page.visit()
-        self.assertTrue(self.dashboard_page.has_library(name=name, org=org, number=number))
-        # Click on the library listing and verify that the library edit view loads.
-        self.dashboard_page.click_library(name)
-        lib_page.wait_for_page()
-
 
 class StudioLanguageTest(AcceptanceTest):
     """ Test suite for the Studio Language """

--- a/common/test/acceptance/tests/studio/test_studio_outline.py
+++ b/common/test/acceptance/tests/studio/test_studio_outline.py
@@ -872,28 +872,6 @@ class StaffLockTest(CourseOutlineTest):
         subsection.unit_at(0).set_staff_lock(True)
         self.assertFalse(subsection.has_staff_lock_warning)
 
-    def test_locked_sections_do_not_appear_in_lms(self):
-        """
-        Scenario: A locked section is not visible to students in the LMS
-            Given I have a course with two sections
-            When I enable explicit staff lock on one section
-            And I click the View Live button to switch to staff view
-            And I visit the course home with the outline
-            Then I see two sections in the outline
-            And when I switch the view mode to student view
-            Then I see one section in the outline
-        """
-        self.course_outline_page.visit()
-        self.course_outline_page.add_section_from_top_button()
-        self.course_outline_page.section_at(1).set_staff_lock(True)
-        self.course_outline_page.view_live()
-
-        course_home_page = CourseHomePage(self.browser, self.course_id)
-        course_home_page.visit()
-        self.assertEqual(course_home_page.outline.num_sections, 2)
-        course_home_page.preview.set_staff_view_mode('Learner')
-        self.assertEqual(course_home_page.outline.num_sections, 1)
-
     def test_locked_subsections_do_not_appear_in_lms(self):
         """
         Scenario: A locked subsection is not visible to students in the LMS

--- a/common/test/acceptance/tests/video/test_video_module.py
+++ b/common/test/acceptance/tests/video/test_video_module.py
@@ -1119,49 +1119,6 @@ class YouTubeQualityTest(VideoBaseTest):
         self.video.wait_for(lambda: self.video.is_quality_button_active, 'waiting for quality button activation')
 
 
-@attr(shard=4)
-class DragAndDropTest(VideoBaseTest):
-    """
-    Tests draggability of closed captions within videos.
-    """
-    def test_if_captions_are_draggable(self):
-        """
-        Loads transcripts so that closed-captioning is available.
-        Ensures they are draggable by checking start and dropped location.
-        """
-        self.assets.append('subs_3_yD_cEKoCk.srt.sjson')
-        data = {'sub': '3_yD_cEKoCk'}
-
-        self.metadata = self.metadata_for_mode('html5', additional_data=data)
-        self.navigate_to_video()
-        self.assertTrue(self.video.is_video_rendered('html5'))
-        self.video.show_closed_captions()
-        self.video.wait_for_closed_captions()
-        self.assertTrue(self.video.is_closed_captions_visible)
-
-        action = ActionChains(self.browser)
-        captions = self.browser.find_element(By.CLASS_NAME, 'closed-captions')
-
-        captions_start = captions.location
-        action.drag_and_drop_by_offset(captions, 0, -15).perform()
-
-        captions_end = captions.location
-        # We have to branch here due to unexpected behaviour of chrome.
-        # Chrome sets the y offset of element to 834 instead of 650
-        if self.browser.name == 'chrome':
-            self.assertEqual(
-                captions_end.get('y') - 168,
-                captions_start.get('y'),
-                'Closed captions did not get dragged.'
-            )
-        else:
-            self.assertEqual(
-                captions_end.get('y') + 16,
-                captions_start.get('y'),
-                'Closed captions did not get dragged.'
-            )
-
-
 @attr('a11y')
 class LMSVideoModuleA11yTest(VideoBaseTest):
     """

--- a/common/test/acceptance/tests/video/test_video_times.py
+++ b/common/test/acceptance/tests/video/test_video_times.py
@@ -50,31 +50,6 @@ class VideoTimesTest(VideoBaseTest):
 
         self.assertIn(self.video.position, ('0:05', '0:06'))
 
-    def test_video_end_time_wo_default_start_time(self):
-        """
-        Scenario: End time works for Youtube video if starts playing from between.
-        Given we have a video in "Youtube" mode  with end time set to 00:01:00
-        And I seek video to "0:55" position
-        And I click video button "play"
-        And I wait until video stop playing
-        Then I see video slider at "1:00" position
-
-        """
-        data = {'end_time': '00:01:00'}
-        self.metadata = self.metadata_for_mode('youtube', additional_data=data)
-
-        # go to video
-        self.navigate_to_video()
-
-        self.video.seek('0:55')
-
-        self.video.click_player_button('play')
-
-        # wait until video stop playing
-        self.video.wait_for_state('pause')
-
-        self.assertIn(self.video.position, ('1:00', '1:01'))
-
     def test_video_start_time_and_end_time(self):
         """
         Scenario: Start time and end time work together for Youtube video.


### PR DESCRIPTION
These tests fail on the new firefox version (59), that we are moving to on jenkins and devstack. These should be fixed and re-added to the codebase.

I will not be squashing this PR in order to make reverts easier for those fixing tests.