### PR TITLE
Enable mode-specific course entitlement policy

### DIFF
--- a/common/djangoapps/entitlements/admin.py
+++ b/common/djangoapps/entitlements/admin.py
@@ -1,10 +1,11 @@
 """Admin forms for Course Entitlements"""
 from django import forms
 from django.contrib import admin
-
 from opaque_keys import InvalidKeyError
 from opaque_keys.edx.keys import CourseKey
+
 from xmodule.modulestore.django import modulestore
+
 from .models import CourseEntitlement, CourseEntitlementPolicy, CourseEntitlementSupportDetail
 
 
@@ -72,4 +73,5 @@ class CourseEntitlementPolicyAdmin(admin.ModelAdmin):
     list_display = ('expiration_period',
                     'refund_period',
                     'regain_period',
+                    'mode',
                     'site')

--- a/common/djangoapps/entitlements/migrations/0008_auto_20180328_1107.py
+++ b/common/djangoapps/entitlements/migrations/0008_auto_20180328_1107.py
@@ -1,0 +1,24 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('entitlements', '0007_change_expiration_period_default'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='courseentitlementpolicy',
+            name='mode',
+            field=models.CharField(max_length=32, null=True, choices=[(None, b'---------'), (b'verified', b'verified'), (b'professional', b'professional')]),
+        ),
+        migrations.AlterField(
+            model_name='courseentitlementpolicy',
+            name='site',
+            field=models.ForeignKey(to='sites.Site', null=True),
+        ),
+    ]


### PR DESCRIPTION
Add a mode field to the CourseEntitlementPolicy model and set the CourseEntitlement policy to the appropriate CourseEntitlementPolicy object at creation.

[LEARNER-4095](https://openedx.atlassian.net/browse/LEARNER-4095)