### PR TITLE
Define xss-linter rules on linter classes

### DIFF
--- a/scripts/xsslint/tests/test_main.py
+++ b/scripts/xsslint/tests/test_main.py
@@ -10,9 +10,8 @@ from unittest import TestCase
 import mock
 
 from xsslint.linters import JavaScriptLinter, MakoTemplateLinter, PythonLinter, UnderscoreTemplateLinter
-from xsslint.main import _lint
+from xsslint.main import _lint, _build_ruleset
 from xsslint.reporting import SummaryResults
-from xsslint.rules import Rules
 
 
 class TestXSSLinter(TestCase):
@@ -32,6 +31,11 @@ class TestXSSLinter(TestCase):
         patcher = mock.patch('xsslint.main.is_skip_dir', return_value=False)
         patcher.start()
         self.addCleanup(patcher.stop)
+
+        self.out = StringIO()
+        self.template_linters = self._build_linters()
+        self.ruleset = _build_ruleset(self.template_linters)
+        self.summary_results = SummaryResults(self.ruleset)
 
     def patch_is_valid_directory(self, linter_class):
         """
@@ -57,42 +61,39 @@ class TestXSSLinter(TestCase):
         """
         Tests the top-level linting with default options.
         """
-        out = StringIO()
-        summary_results = SummaryResults()
-
         _lint(
             'scripts/xsslint/tests/templates',
-            template_linters=self._build_linters(),
+            template_linters=self.template_linters,
             options={
                 'list_files': False,
                 'verbose': False,
                 'rule_totals': False,
                 'skip_dirs': ()
             },
-            summary_results=summary_results,
-            out=out,
+            summary_results=self.summary_results,
+            out=self.out,
         )
 
-        output = out.getvalue()
+        output = self.out.getvalue()
         # Assert violation details are displayed.
-        self.assertIsNotNone(re.search('test\.html.*{}'.format(Rules.mako_missing_default.rule_id), output))
-        self.assertIsNotNone(re.search('test\.coffee.*{}'.format(Rules.javascript_concat_html.rule_id), output))
-        self.assertIsNotNone(re.search('test\.coffee.*{}'.format(Rules.underscore_not_escaped.rule_id), output))
-        self.assertIsNotNone(re.search('test\.js.*{}'.format(Rules.javascript_concat_html.rule_id), output))
-        self.assertIsNotNone(re.search('test\.js.*{}'.format(Rules.underscore_not_escaped.rule_id), output))
+        self.assertIsNotNone(re.search('test\.html.*{}'.format(self.ruleset.mako_missing_default.rule_id), output))
+        self.assertIsNotNone(re.search('test\.coffee.*{}'.format(self.ruleset.javascript_concat_html.rule_id), output))
+        self.assertIsNotNone(re.search('test\.coffee.*{}'.format(self.ruleset.underscore_not_escaped.rule_id), output))
+        self.assertIsNotNone(re.search('test\.js.*{}'.format(self.ruleset.javascript_concat_html.rule_id), output))
+        self.assertIsNotNone(re.search('test\.js.*{}'.format(self.ruleset.underscore_not_escaped.rule_id), output))
         lines_with_rule = 0
         lines_without_rule = 0  # Output with verbose setting only.
         for underscore_match in re.finditer('test\.underscore:.*\n', output):
-            if re.search(Rules.underscore_not_escaped.rule_id, underscore_match.group()) is not None:
+            if re.search(self.ruleset.underscore_not_escaped.rule_id, underscore_match.group()) is not None:
                 lines_with_rule += 1
             else:
                 lines_without_rule += 1
         self.assertGreaterEqual(lines_with_rule, 1)
         self.assertEquals(lines_without_rule, 0)
-        self.assertIsNone(re.search('test\.py.*{}'.format(Rules.python_parse_error.rule_id), output))
-        self.assertIsNotNone(re.search('test\.py.*{}'.format(Rules.python_wrap_html.rule_id), output))
+        self.assertIsNone(re.search('test\.py.*{}'.format(self.ruleset.python_parse_error.rule_id), output))
+        self.assertIsNotNone(re.search('test\.py.*{}'.format(self.ruleset.python_wrap_html.rule_id), output))
         # Assert no rule totals.
-        self.assertIsNone(re.search('{}:\s*{} violations'.format(Rules.python_parse_error.rule_id, 0), output))
+        self.assertIsNone(re.search('{}:\s*{} violations'.format(self.ruleset.python_parse_error.rule_id, 0), output))
         # Assert final total
         self.assertIsNotNone(re.search('{} violations total'.format(7), output))
 
@@ -100,34 +101,31 @@ class TestXSSLinter(TestCase):
         """
         Tests the top-level linting with verbose option.
         """
-        out = StringIO()
-        summary_results = SummaryResults()
-
         _lint(
             'scripts/xsslint/tests/templates',
-            template_linters=self._build_linters(),
+            template_linters=self.template_linters,
             options={
                 'list_files': False,
                 'verbose': True,
                 'rule_totals': False,
                 'skip_dirs': ()
             },
-            summary_results=summary_results,
-            out=out,
+            summary_results=self.summary_results,
+            out=self.out,
         )
 
-        output = out.getvalue()
+        output = self.out.getvalue()
         lines_with_rule = 0
         lines_without_rule = 0  # Output with verbose setting only.
         for underscore_match in re.finditer('test\.underscore:.*\n', output):
-            if re.search(Rules.underscore_not_escaped.rule_id, underscore_match.group()) is not None:
+            if re.search(self.ruleset.underscore_not_escaped.rule_id, underscore_match.group()) is not None:
                 lines_with_rule += 1
             else:
                 lines_without_rule += 1
         self.assertGreaterEqual(lines_with_rule, 1)
         self.assertGreaterEqual(lines_without_rule, 1)
         # Assert no rule totals.
-        self.assertIsNone(re.search('{}:\s*{} violations'.format(Rules.python_parse_error.rule_id, 0), output))
+        self.assertIsNone(re.search('{}:\s*{} violations'.format(self.ruleset.python_parse_error.rule_id, 0), output))
         # Assert final total
         self.assertIsNotNone(re.search('{} violations total'.format(7), output))
 
@@ -135,55 +133,50 @@ class TestXSSLinter(TestCase):
         """
         Tests the top-level linting with rule totals option.
         """
-        out = StringIO()
-        summary_results = SummaryResults()
-
         _lint(
             'scripts/xsslint/tests/templates',
-            template_linters=self._build_linters(),
+            template_linters=self.template_linters,
             options={
                 'list_files': False,
                 'verbose': False,
                 'rule_totals': True,
                 'skip_dirs': ()
             },
-            summary_results=summary_results,
-            out=out,
+            summary_results=self.summary_results,
+            out=self.out,
         )
 
-        output = out.getvalue()
-        self.assertIsNotNone(re.search('test\.py.*{}'.format(Rules.python_wrap_html.rule_id), output))
+        output = self.out.getvalue()
+        self.assertIsNotNone(re.search('test\.py.*{}'.format(self.ruleset.python_wrap_html.rule_id), output))
 
         # Assert totals output.
-        self.assertIsNotNone(re.search('{}:\s*{} violations'.format(Rules.python_parse_error.rule_id, 0), output))
-        self.assertIsNotNone(re.search('{}:\s*{} violations'.format(Rules.python_wrap_html.rule_id, 1), output))
+        self.assertIsNotNone(re.search('{}:\s*{} violations'.format(self.ruleset.python_parse_error.rule_id, 0), output))
+        self.assertIsNotNone(re.search('{}:\s*{} violations'.format(self.ruleset.python_wrap_html.rule_id, 1), output))
         self.assertIsNotNone(re.search('{} violations total'.format(7), output))
 
     def test_lint_with_list_files(self):
         """
         Tests the top-level linting with list files option.
         """
-        out = StringIO()
-        summary_results = SummaryResults()
         _lint(
             'scripts/xsslint/tests/templates',
-            template_linters=self._build_linters(),
+            template_linters=self.template_linters,
             options={
                 'list_files': True,
                 'verbose': False,
                 'rule_totals': False,
                 'skip_dirs': ()
             },
-            summary_results=summary_results,
-            out=out,
+            summary_results=self.summary_results,
+            out=self.out,
         )
 
-        output = out.getvalue()
+        output = self.out.getvalue()
         # Assert file with rule is not output.
-        self.assertIsNone(re.search('test\.py.*{}'.format(Rules.python_wrap_html.rule_id), output))
+        self.assertIsNone(re.search('test\.py.*{}'.format(self.ruleset.python_wrap_html.rule_id), output))
         # Assert file is output.
         self.assertIsNotNone(re.search('test\.py', output))
 
         # Assert no totals.
-        self.assertIsNone(re.search('{}:\s*{} violations'.format(Rules.python_parse_error.rule_id, 0), output))
+        self.assertIsNone(re.search('{}:\s*{} violations'.format(self.ruleset.python_parse_error.rule_id, 0), output))
         self.assertIsNone(re.search('{} violations total'.format(7), output))

--- a/scripts/xsslint/xsslint/linters.py
+++ b/scripts/xsslint/xsslint/linters.py
@@ -6,10 +6,10 @@ import os
 import re
 import textwrap
 
+from xsslint import visitors
 from xsslint.reporting import ExpressionRuleViolation, FileResults, RuleViolation
-from xsslint.rules import Rules
+from xsslint.rules import RuleSet
 from xsslint.utils import Expression, ParseString, StringLines, is_skip_dir
-from xsslint.visitors import AllNodeVisitor, HtmlStringVisitor, OuterFormatVisitor
 
 
 class BaseLinter(object):
@@ -194,6 +194,11 @@ class UnderscoreTemplateLinter(BaseLinter):
     """
     The linter for Underscore.js template files.
     """
+
+    ruleset = RuleSet(
+        underscore_not_escaped='underscore-not-escaped',
+    )
+
     def __init__(self, skip_dirs=None):
         """
         Init method.
@@ -250,7 +255,7 @@ class UnderscoreTemplateLinter(BaseLinter):
         for expression in expressions:
             if not self._is_safe_unescaped_expression(expression):
                 results.violations.append(ExpressionRuleViolation(
-                    Rules.underscore_not_escaped, expression
+                    self.ruleset.underscore_not_escaped, expression
                 ))
 
     def _is_safe_unescaped_expression(self, expression):
@@ -309,12 +314,24 @@ class JavaScriptLinter(BaseLinter):
 
     LINE_COMMENT_DELIM = "//"
 
+    ruleset = RuleSet(
+        javascript_jquery_append='javascript-jquery-append',
+        javascript_jquery_prepend='javascript-jquery-prepend',
+        javascript_jquery_insertion='javascript-jquery-insertion',
+        javascript_jquery_insert_into_target='javascript-jquery-insert-into-target',
+        javascript_jquery_html='javascript-jquery-html',
+        javascript_concat_html='javascript-concat-html',
+        javascript_escape='javascript-escape',
+        javascript_interpolate='javascript-interpolate',
+    )
+
     def __init__(self, underscore_linter, javascript_skip_dirs=None, coffeescript_skip_dirs=None):
         """
         Init method.
         """
         super(JavaScriptLinter, self).__init__()
         self.underscore_linter = underscore_linter
+        self.ruleset = self.ruleset + self.underscore_linter.ruleset
         self._skip_javascript_dirs = javascript_skip_dirs or ()
         self._skip_coffeescript_dirs = coffeescript_skip_dirs or ()
 
@@ -361,28 +378,28 @@ class JavaScriptLinter(BaseLinter):
         no_caller_check = None
         no_argument_check = None
         self._check_jquery_function(
-            file_contents, "append", Rules.javascript_jquery_append, no_caller_check,
+            file_contents, "append", self.ruleset.javascript_jquery_append, no_caller_check,
             self._is_jquery_argument_safe, results
         )
         self._check_jquery_function(
-            file_contents, "prepend", Rules.javascript_jquery_prepend, no_caller_check,
+            file_contents, "prepend", self.ruleset.javascript_jquery_prepend, no_caller_check,
             self._is_jquery_argument_safe, results
         )
         self._check_jquery_function(
             file_contents, "unwrap|wrap|wrapAll|wrapInner|after|before|replaceAll|replaceWith",
-            Rules.javascript_jquery_insertion, no_caller_check, self._is_jquery_argument_safe, results
+            self.ruleset.javascript_jquery_insertion, no_caller_check, self._is_jquery_argument_safe, results
         )
         self._check_jquery_function(
             file_contents, "appendTo|prependTo|insertAfter|insertBefore",
-            Rules.javascript_jquery_insert_into_target, self._is_jquery_insert_caller_safe, no_argument_check, results
+            self.ruleset.javascript_jquery_insert_into_target, self._is_jquery_insert_caller_safe, no_argument_check, results
         )
         self._check_jquery_function(
-            file_contents, "html", Rules.javascript_jquery_html, no_caller_check,
+            file_contents, "html", self.ruleset.javascript_jquery_html, no_caller_check,
             self._is_jquery_html_argument_safe, results
         )
         self._check_javascript_interpolate(file_contents, results)
         self._check_javascript_escape(file_contents, results)
-        self._check_concat_with_html(file_contents, Rules.javascript_concat_html, results)
+        self._check_concat_with_html(file_contents, self.ruleset.javascript_concat_html, results)
         self.underscore_linter.check_underscore_file_is_safe(file_contents, results)
         results.prepare_results(file_contents, line_comment_delim=self.LINE_COMMENT_DELIM)
 
@@ -430,7 +447,7 @@ class JavaScriptLinter(BaseLinter):
         regex = re.compile(r"(?<!StringUtils).interpolate\(")
         for function_match in regex.finditer(file_contents):
             expression = self._get_expression_for_function(file_contents, function_match)
-            results.violations.append(ExpressionRuleViolation(Rules.javascript_interpolate, expression))
+            results.violations.append(ExpressionRuleViolation(self.ruleset.javascript_interpolate, expression))
 
     def _check_javascript_escape(self, file_contents, results):
         """
@@ -447,7 +464,7 @@ class JavaScriptLinter(BaseLinter):
         regex = regex = re.compile(r"(?<!_).escape\(")
         for function_match in regex.finditer(file_contents):
             expression = self._get_expression_for_function(file_contents, function_match)
-            results.violations.append(ExpressionRuleViolation(Rules.javascript_escape, expression))
+            results.violations.append(ExpressionRuleViolation(self.ruleset.javascript_escape, expression))
 
     def _check_jquery_function(self, file_contents, function_names, rule, is_caller_safe, is_argument_safe, results):
         """
@@ -459,7 +476,7 @@ class JavaScriptLinter(BaseLinter):
             function_names: A pipe delimited list of names of the functions
                 (e.g. "wrap|after|before").
             rule: The name of the rule to use for validation errors (e.g.
-                Rules.javascript_jquery_append).
+                self.ruleset.javascript_jquery_append).
             is_caller_safe: A function to test if caller of the JQuery function
                 is safe.
             is_argument_safe: A function to test if the argument passed to the
@@ -697,6 +714,14 @@ class PythonLinter(BaseLinter):
 
     LINE_COMMENT_DELIM = "#"
 
+    ruleset = RuleSet(
+        python_parse_error='python-parse-error',
+        python_custom_escape='python-custom-escape',
+
+        # The Visitor classes are python-specific and should be moved into the PythonLinter once they have
+        # been decoupled from the MakoTemplateLinter.
+    ) + visitors.ruleset
+
     def __init__(self, skip_dirs=None):
         """
         Init method.
@@ -756,7 +781,7 @@ class PythonLinter(BaseLinter):
         # different assumptions.
         if root_node is not None:
             # check format() rules that can be run on outer-most format() calls
-            visitor = OuterFormatVisitor(file_contents, results)
+            visitor = visitors.OuterFormatVisitor(file_contents, results)
             visitor.visit(root_node)
         results.prepare_results(file_contents, line_comment_delim=self.LINE_COMMENT_DELIM)
 
@@ -773,7 +798,7 @@ class PythonLinter(BaseLinter):
         """
         if root_node is not None:
             # check illegal concatenation and interpolation
-            visitor = AllNodeVisitor(python_code, results)
+            visitor = visitors.AllNodeVisitor(python_code, results)
             visitor.visit(root_node)
         # check rules parse with regex
         self._check_custom_escape(python_code, results)
@@ -801,7 +826,7 @@ class PythonLinter(BaseLinter):
                 line_start_index = lines.line_number_to_start_index(e.lineno)
                 expression = Expression(line_start_index + e.offset)
             results.violations.append(ExpressionRuleViolation(
-                Rules.python_parse_error, expression
+                self.ruleset.python_parse_error, expression
             ))
             return None
 
@@ -846,7 +871,7 @@ class PythonLinter(BaseLinter):
         for match in re.finditer("(<.*&lt;|&lt;.*<)", file_contents):
             expression = Expression(match.start(), match.end())
             results.violations.append(ExpressionRuleViolation(
-                Rules.python_custom_escape, expression
+                self.ruleset.python_custom_escape, expression
             ))
 
 
@@ -856,6 +881,25 @@ class MakoTemplateLinter(BaseLinter):
     """
     LINE_COMMENT_DELIM = "##"
 
+    ruleset = RuleSet(
+        mako_missing_default='mako-missing-default',
+        mako_multiple_page_tags='mako-multiple-page-tags',
+        mako_unparseable_expression='mako-unparseable-expression',
+        mako_unwanted_html_filter='mako-unwanted-html-filter',
+        mako_invalid_html_filter='mako-invalid-html-filter',
+        mako_invalid_js_filter='mako-invalid-js-filter',
+        mako_js_missing_quotes='mako-js-missing-quotes',
+        mako_js_html_string='mako-js-html-string',
+        mako_html_entities='mako-html-entities',
+        mako_unknown_context='mako-unknown-context',
+
+        # NOTE The MakoTemplateLinter directly checks for python_wrap_html and directly
+        # instantiates Visitor instances to check for python issues. This logic should
+        # be moved into the PythonLinter. The MakoTemplateLinter should only check for
+        # Mako-specific issues.
+        python_wrap_html='python-wrap-html',
+    ) + visitors.ruleset
+
     def __init__(self, javascript_linter, python_linter, skip_dirs=None):
         """
         Init method.
@@ -863,6 +907,7 @@ class MakoTemplateLinter(BaseLinter):
         super(MakoTemplateLinter, self).__init__()
         self.javascript_linter = javascript_linter
         self.python_linter = python_linter
+        self.ruleset = self.ruleset + self.javascript_linter.ruleset + self.python_linter.ruleset
         self._skip_mako_dirs = skip_dirs or ()
 
     def process_file(self, directory, file_name):
@@ -986,18 +1031,18 @@ class MakoTemplateLinter(BaseLinter):
         page_tag_count = self._get_page_tag_count(mako_template)
         # check if there are too many page expressions
         if 2 <= page_tag_count:
-            results.violations.append(RuleViolation(Rules.mako_multiple_page_tags))
+            results.violations.append(RuleViolation(self.ruleset.mako_multiple_page_tags))
             return False
         # make sure there is exactly 1 page expression, excluding commented out
         # page expressions, before proceeding
         elif page_tag_count != 1:
-            results.violations.append(RuleViolation(Rules.mako_missing_default))
+            results.violations.append(RuleViolation(self.ruleset.mako_missing_default))
             return False
         # check that safe by default (h filter) is turned on
         page_h_filter_regex = re.compile('<%page[^>]*expression_filter=(?:"h"|\'h\')[^>]*/>')
         page_match = page_h_filter_regex.search(mako_template)
         if not page_match:
-            results.violations.append(RuleViolation(Rules.mako_missing_default))
+            results.violations.append(RuleViolation(self.ruleset.mako_missing_default))
         return page_match
 
     def _check_mako_expressions(self, mako_template, has_page_default, results):
@@ -1019,7 +1064,7 @@ class MakoTemplateLinter(BaseLinter):
         for expression in expressions:
             if expression.end_index is None:
                 results.violations.append(ExpressionRuleViolation(
-                    Rules.mako_unparseable_expression, expression
+                    self.ruleset.mako_unparseable_expression, expression
                 ))
                 continue
 
@@ -1128,16 +1173,16 @@ class MakoTemplateLinter(BaseLinter):
         self.python_linter.check_python_code_is_safe(python_code, root_node, python_results)
         # Check mako expression specific Python rules.
         if root_node is not None:
-            visitor = HtmlStringVisitor(python_code, python_results, True)
+            visitor = visitors.HtmlStringVisitor(python_code, python_results, True)
             visitor.visit(root_node)
             for unsafe_html_string_node in visitor.unsafe_html_string_nodes:
                 python_results.violations.append(ExpressionRuleViolation(
-                    Rules.python_wrap_html, visitor.node_to_expression(unsafe_html_string_node)
+                    self.ruleset.python_wrap_html, visitor.node_to_expression(unsafe_html_string_node)
                 ))
             if has_page_default:
                 for over_escaped_entity_string_node in visitor.over_escaped_entity_string_nodes:
                     python_results.violations.append(ExpressionRuleViolation(
-                        Rules.mako_html_entities, visitor.node_to_expression(over_escaped_entity_string_node)
+                        self.ruleset.mako_html_entities, visitor.node_to_expression(over_escaped_entity_string_node)
                     ))
         python_results.prepare_results(python_code, line_comment_delim=self.LINE_COMMENT_DELIM)
         self._shift_and_add_violations(python_results, start_offset, results)
@@ -1183,7 +1228,7 @@ class MakoTemplateLinter(BaseLinter):
         """
         if context == 'unknown':
             results.violations.append(ExpressionRuleViolation(
-                Rules.mako_unknown_context, expression
+                self.ruleset.mako_unknown_context, expression
             ))
             return
 
@@ -1202,7 +1247,7 @@ class MakoTemplateLinter(BaseLinter):
         if filters_match is None:
             if context == 'javascript':
                 results.violations.append(ExpressionRuleViolation(
-                    Rules.mako_invalid_js_filter, expression
+                    self.ruleset.mako_invalid_js_filter, expression
                 ))
             return
         filters = filters_match.group(1).replace(" ", "").split(",")
@@ -1215,14 +1260,14 @@ class MakoTemplateLinter(BaseLinter):
                     # suppress this violation if the page default hasn't been set,
                     # otherwise the template might get less safe
                     results.violations.append(ExpressionRuleViolation(
-                        Rules.mako_unwanted_html_filter, expression
+                        self.ruleset.mako_unwanted_html_filter, expression
                     ))
             elif filters == ['n', 'strip_all_tags_but_br']:
                 # {x | n,  strip_all_tags_but_br} is valid in html context
                 pass
             else:
                 results.violations.append(ExpressionRuleViolation(
-                    Rules.mako_invalid_html_filter, expression
+                    self.ruleset.mako_invalid_html_filter, expression
                 ))
         elif context == 'javascript':
             self._check_js_expression_not_with_html(mako_template, expression, results)
@@ -1234,7 +1279,7 @@ class MakoTemplateLinter(BaseLinter):
                 self._check_js_string_expression_in_quotes(mako_template, expression, results)
             else:
                 results.violations.append(ExpressionRuleViolation(
-                    Rules.mako_invalid_js_filter, expression
+                    self.ruleset.mako_invalid_js_filter, expression
                 ))
 
     def _check_js_string_expression_in_quotes(self, mako_template, expression, results):
@@ -1250,7 +1295,7 @@ class MakoTemplateLinter(BaseLinter):
         parse_string = self._find_string_wrapping_expression(mako_template, expression)
         if parse_string is None:
             results.violations.append(ExpressionRuleViolation(
-                Rules.mako_js_missing_quotes, expression
+                self.ruleset.mako_js_missing_quotes, expression
             ))
 
     def _check_js_expression_not_with_html(self, mako_template, expression, results):
@@ -1266,7 +1311,7 @@ class MakoTemplateLinter(BaseLinter):
         parse_string = self._find_string_wrapping_expression(mako_template, expression)
         if parse_string is not None and re.search('[<>]', parse_string.string) is not None:
             results.violations.append(ExpressionRuleViolation(
-                Rules.mako_js_html_string, expression
+                self.ruleset.mako_js_html_string, expression
             ))
 
     def _find_string_wrapping_expression(self, mako_template, expression):

--- a/scripts/xsslint/xsslint/reporting.py
+++ b/scripts/xsslint/xsslint/reporting.py
@@ -6,7 +6,6 @@ from __future__ import print_function
 import os
 import re
 
-from xsslint.rules import Rules
 from xsslint.utils import StringLines
 
 
@@ -238,13 +237,16 @@ class SummaryResults(object):
     Contains the summary results for all violations.
     """
 
-    def __init__(self):
+    def __init__(self, ruleset):
         """
         Init method.
+
+        Arguments:
+            ruleset: A RuleSet object containing all of the possible Rules.
         """
         self.total_violations = 0
         self.totals_by_rule = dict.fromkeys(
-            [rule.rule_id for rule in Rules.__members__.values()], 0
+            [rule.rule_id for rule in ruleset.rules.values()], 0
         )
 
     def add_violation(self, violation):

--- a/scripts/xsslint/xsslint/rules.py
+++ b/scripts/xsslint/xsslint/rules.py
@@ -1,39 +1,22 @@
-from enum import Enum
-
-
-class Rules(Enum):
-    """
-    An Enum of each rule which the linter will check.
-    """
-    # IMPORTANT: Do not edit without also updating the docs:
-    # - http://edx.readthedocs.org/projects/edx-developer-guide/en/latest/conventions/preventing_xss.html#xss-linter
-    mako_missing_default = 'mako-missing-default'
-    mako_multiple_page_tags = 'mako-multiple-page-tags'
-    mako_unparseable_expression = 'mako-unparseable-expression'
-    mako_unwanted_html_filter = 'mako-unwanted-html-filter'
-    mako_invalid_html_filter = 'mako-invalid-html-filter'
-    mako_invalid_js_filter = 'mako-invalid-js-filter'
-    mako_js_missing_quotes = 'mako-js-missing-quotes'
-    mako_js_html_string = 'mako-js-html-string'
-    mako_html_entities = 'mako-html-entities'
-    mako_unknown_context = 'mako-unknown-context'
-    underscore_not_escaped = 'underscore-not-escaped'
-    javascript_jquery_append = 'javascript-jquery-append'
-    javascript_jquery_prepend = 'javascript-jquery-prepend'
-    javascript_jquery_insertion = 'javascript-jquery-insertion'
-    javascript_jquery_insert_into_target = 'javascript-jquery-insert-into-target'
-    javascript_jquery_html = 'javascript-jquery-html'
-    javascript_concat_html = 'javascript-concat-html'
-    javascript_escape = 'javascript-escape'
-    javascript_interpolate = 'javascript-interpolate'
-    python_concat_html = 'python-concat-html'
-    python_custom_escape = 'python-custom-escape'
-    python_deprecated_display_name = 'python-deprecated-display-name'
-    python_requires_html_or_text = 'python-requires-html-or-text'
-    python_close_before_format = 'python-close-before-format'
-    python_wrap_html = 'python-wrap-html'
-    python_interpolate_html = 'python-interpolate-html'
-    python_parse_error = 'python-parse-error'
-
+class Rule(object):
     def __init__(self, rule_id):
         self.rule_id = rule_id
+
+    def __eq__(self, other):
+        return self.rule_id == other.rule_id
+
+
+class RuleSet(object):
+    def __init__(self, **kwargs):
+        self.rules = {}
+        for k, v in kwargs.items():
+            self.rules[k] = Rule(v)
+
+    def __getattr__(self, attr_name):
+        return self.rules[attr_name]
+
+    def __add__(self, other):
+        result = self.__class__()
+        result.rules.update(self.rules)
+        result.rules.update(other.rules)
+        return result


### PR DESCRIPTION
Refactors the XSS Linter so that linting rules are defined on the the individual linter classes instead of on the global Rules enum. This will make it possible to extend the XSS-linter with custom linter classes for different file types that can report on different types of rules violations. It also makes it possible for us to begin moving the xss-linter into it's own repository incrementally. 

