### PR TITLE
Remove PRUNE_OLD_VERSIONS waffle flag

### DIFF
--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -1977,10 +1977,8 @@ BLOCK_STRUCTURES_SETTINGS = dict(
     # Maximum number of retries per task.
     TASK_MAX_RETRIES=5,
 
-    # Backend storage
-    # STORAGE_CLASS='storages.backends.s3boto.S3BotoStorage',
-    # STORAGE_KWARGS=dict(bucket='nim-beryl-test'),
-    # DIRECTORY_PREFIX='/modeltest/',
+    # Backend storage options
+    PRUNING_ACTIVE=False,
 )
 
 ################################ Bulk Email ###################################

--- a/lms/envs/test.py
+++ b/lms/envs/test.py
@@ -368,6 +368,8 @@ FILE_UPLOAD_HANDLERS = [
     'django.core.files.uploadhandler.TemporaryFileUploadHandler',
 ]
 
+BLOCK_STRUCTURES_SETTINGS['PRUNING_ACTIVE'] = True
+
 ########################### Server Ports ###################################
 
 # These ports are carefully chosen so that if the browser needs to

--- a/openedx/core/djangoapps/content/block_structure/config/__init__.py
+++ b/openedx/core/djangoapps/content/block_structure/config/__init__.py
@@ -15,7 +15,6 @@ WAFFLE_NAMESPACE = u'block_structure'
 INVALIDATE_CACHE_ON_PUBLISH = u'invalidate_cache_on_publish'
 STORAGE_BACKING_FOR_CACHE = u'storage_backing_for_cache'
 RAISE_ERROR_WHEN_NOT_FOUND = u'raise_error_when_not_found'
-PRUNE_OLD_VERSIONS = u'prune_old_versions'
 
 
 def waffle():

--- a/openedx/core/djangoapps/content/block_structure/models.py
+++ b/openedx/core/djangoapps/content/block_structure/models.py
@@ -226,7 +226,7 @@ class BlockStructureModel(TimeStampedModel):
         """
         Deletes previous file versions for data_usage_key.
         """
-        if not config.waffle().is_enabled(config.PRUNE_OLD_VERSIONS):
+        if not settings.BLOCK_STRUCTURES_SETTINGS.get('PRUNING_ACTIVE', False):
             return
 
         if num_to_keep is None:


### PR DESCRIPTION
# [EDUCATOR-499](https://openedx.atlassian.net/browse/EDUCATOR-499)

Moving this value from a waffle flag to a more standard Open edX Option; defaults to `False` with opt-in allowed via a simple boolean setting.

configuration/internal PRs to follow shortly