### PR TITLE
Remove tests that are flaky with firefox 59

### DIFF
--- a/common/test/acceptance/tests/lms/test_learner_profile.py
+++ b/common/test/acceptance/tests/lms/test_learner_profile.py
@@ -348,41 +348,6 @@ class OwnLearnerProfilePageTest(LearnerProfileTestMixin, AcceptanceTest):
         self.assertEqual(profile_page.get_non_editable_mode_value(field_id), displayed_value)
         self.assertTrue(profile_page.mode_for_field(field_id), mode)
 
-    def test_about_me_field(self):
-        """
-        Test behaviour of `About Me` field.
-
-        Given that I am a registered user.
-        And I visit my Profile page.
-        And I set the profile visibility to public and set default values for public fields.
-        Then I set about me value to `ThisIsIt`.
-        Then displayed about me should be `ThisIsIt` and about me field mode should be `display`
-        And I reload the page.
-        Then displayed about me should be `ThisIsIt` and about me field mode should be `display`
-        Then I set empty value for about me.
-        Then displayed about me should be `Tell other edX learners a little about yourself: where you live,
-        what your interests are, why you're taking courses on edX, or what you hope to learn.` and about me
-        field mode should be `placeholder`
-        And I reload the page.
-        Then displayed about me should be `Tell other edX learners a little about yourself: where you live,
-        what your interests are, why you're taking courses on edX, or what you hope to learn.` and about me
-        field mode should be `placeholder`
-        And I make `about me` field editable
-        Then `about me` field mode should be `edit`
-        """
-        placeholder_value = (
-            "Tell other learners a little about yourself: where you live, what your interests are, "
-            "why you're taking courses, or what you hope to learn."
-        )
-
-        username, __ = self.log_in_as_unique_user()
-        profile_page = self.visit_profile_page(username, privacy=self.PRIVACY_PUBLIC)
-        self._test_textarea_field(profile_page, 'bio', 'ThisIsIt', 'ThisIsIt', 'display')
-        self._test_textarea_field(profile_page, 'bio', '', placeholder_value, 'placeholder')
-
-        profile_page.make_field_editable('bio')
-        self.assertTrue(profile_page.mode_for_field('bio'), 'edit')
-
     def test_birth_year_not_set(self):
         """
         Verify message if birth year is not set.

--- a/common/test/acceptance/tests/lms/test_lms.py
+++ b/common/test/acceptance/tests/lms/test_lms.py
@@ -297,31 +297,6 @@ class RegisterFromCombinedPageTest(UniqueCourseTest):
             self.course_info['run'], self.course_info['display_name']
         ).install()
 
-    def test_register_failure(self):
-        # Navigate to the registration page
-        self.register_page.visit()
-
-        # Enter a blank for the username field, which is required
-        # Don't agree to the terms of service / honor code.
-        # Don't specify a country code, which is required.
-        # Don't specify a favorite movie.
-        username = "test_{uuid}".format(uuid=self.unique_id[0:6])
-        email = "{user}@example.com".format(user=username)
-        self.register_page.register(
-            email=email,
-            password="password",
-            username="",
-            full_name="Test User",
-            terms_of_service=False
-        )
-
-        # Verify that the expected errors are displayed.
-        errors = self.register_page.wait_for_errors()
-        self.assertIn(u'Please enter your Public Username.', errors)
-        self.assertIn(u'You must agree to the édX Terms of Service and Honor Code', errors)
-        self.assertIn(u'Select your country or region of residence.', errors)
-        self.assertIn(u'Please tell us your favorite movie.', errors)
-
     def test_toggle_to_login_form(self):
         self.register_page.visit().toggle_form()
         self.assertEqual(self.register_page.current_form, "login")

--- a/common/test/acceptance/tests/lms/test_lms_user_preview.py
+++ b/common/test/acceptance/tests/lms/test_lms_user_preview.py
@@ -414,23 +414,6 @@ class CourseWithContentGroupsTest(StaffViewTest):
         add_cohort_with_student("Cohort Beta", "beta", student_b_username)
         cohort_management_page.wait_for_ajax()
 
-    @attr(shard=3)
-    def test_as_specific_student(self):
-        student_a_username = 'tass_student_a'
-        student_b_username = 'tass_student_b'
-        AutoAuthPage(self.browser, username=student_a_username, course_id=self.course_id, no_login=True).visit()
-        AutoAuthPage(self.browser, username=student_b_username, course_id=self.course_id, no_login=True).visit()
-        self.create_cohorts_and_assign_students(student_a_username, student_b_username)
-
-        # Masquerade as learner in alpha cohort:
-        course_page = self._goto_staff_page()
-        course_page.set_staff_view_mode_specific_student(student_a_username)
-        verify_expected_problem_visibility(self, course_page, [self.alpha_text, self.audit_text, self.everyone_text])
-
-        # Masquerade as learner in beta cohort:
-        course_page.set_staff_view_mode_specific_student(student_b_username)
-        verify_expected_problem_visibility(self, course_page, [self.beta_text, self.audit_text, self.everyone_text])
-
     @attr('a11y')
     def test_course_page(self):
         """

--- a/common/test/acceptance/tests/studio/test_import_export.py
+++ b/common/test/acceptance/tests/studio/test_import_export.py
@@ -172,16 +172,6 @@ class ImportTestMixin(object):
         self.import_page.upload_tarball(self.tarball_name)
         self.import_page.wait_for_upload()
 
-    def test_landing_url(self):
-        """
-        Scenario: When uploading a library or course, a link appears for me to view the changes.
-            Given that I upload a library or course
-            A button will appear that contains the URL to the library or course's main page
-        """
-        self.import_page.upload_tarball(self.tarball_name)
-        self.import_page.wait_for_upload()
-        self.assertEqual(self.import_page.finished_target_url(), self.landing_page.url)
-
     def test_bad_import(self):
         """
         Scenario: I should see a failed checklist when uploading an invalid course or library

--- a/common/test/acceptance/tests/studio/test_import_export.py
+++ b/common/test/acceptance/tests/studio/test_import_export.py
@@ -172,45 +172,6 @@ class ImportTestMixin(object):
         self.import_page.upload_tarball(self.tarball_name)
         self.import_page.wait_for_upload()
 
-    def test_import_timestamp(self):
-        """
-        Scenario: I perform a course / library import
-            On import success, the page displays a UTC timestamp previously not visible
-            And if I refresh the page, the timestamp is still displayed
-        """
-        self.assertFalse(self.import_page.is_timestamp_visible())
-
-        # Get the time when the import has started.
-        # import_page timestamp is in (MM/DD/YYYY at HH:mm) so replacing (second, microsecond) to
-        # keep the comparison consistent
-        upload_start_time = datetime.utcnow().replace(microsecond=0, second=0)
-        self.import_page.upload_tarball(self.tarball_name)
-        self.import_page.wait_for_upload()
-
-        # Get the time when the import has finished.
-        # import_page timestamp is in (MM/DD/YYYY at HH:mm) so replacing (second, microsecond) to
-        # keep the comparison consistent
-        upload_finish_time = datetime.utcnow().replace(microsecond=0, second=0)
-
-        import_timestamp = self.import_page.parsed_timestamp
-        self.import_page.wait_for_timestamp_visible()
-
-        # Verify that 'import_timestamp' is between start and finish upload time
-        self.assertLessEqual(
-            upload_start_time,
-            import_timestamp,
-            "Course import timestamp should be upload_start_time <= import_timestamp <= upload_end_time"
-        )
-        self.assertGreaterEqual(
-            upload_finish_time,
-            import_timestamp,
-            "Course import timestamp should be upload_start_time <= import_timestamp <= upload_end_time"
-        )
-
-        self.import_page.visit()
-        self.import_page.wait_for_tasks(completed=True)
-        self.import_page.wait_for_timestamp_visible()
-
     def test_landing_url(self):
         """
         Scenario: When uploading a library or course, a link appears for me to view the changes.

--- a/common/test/acceptance/tests/studio/test_import_export.py
+++ b/common/test/acceptance/tests/studio/test_import_export.py
@@ -212,25 +212,6 @@ class TestCourseImport(ImportTestMixin, StudioCourseTest):
     def page_args(self):
         return [self.browser, self.course_info['org'], self.course_info['number'], self.course_info['run']]
 
-    def test_course_updated(self):
-        """
-        Given that I visit an empty course before import
-        I should not see a section named 'Section'
-        When I visit the import page
-        And I upload a course that has a section named 'Section'
-        And I visit the course outline page again
-        The section named 'Section' should now be available
-        """
-        self.landing_page.visit()
-        # Should not exist yet.
-        self.assertRaises(IndexError, self.landing_page.section, "Section")
-        self.import_page.visit()
-        self.import_page.upload_tarball(self.tarball_name)
-        self.import_page.wait_for_upload()
-        self.landing_page.visit()
-        # There's a section named 'Section' in the tarball.
-        self.landing_page.section("Section")
-
     def test_header(self):
         """
         Scenario: I should see the correct text when importing a course.

--- a/common/test/acceptance/tests/studio/test_import_export.py
+++ b/common/test/acceptance/tests/studio/test_import_export.py
@@ -254,27 +254,6 @@ class TestLibraryImport(ImportTestMixin, StudioLibraryTest):
     def page_args(self):
         return [self.browser, self.library_key]
 
-    def test_library_updated(self):
-        """
-        Given that I visit an empty library
-        No XBlocks should be shown
-        When I visit the import page
-        And I upload a library that contains three XBlocks
-        And I visit the library page
-        Three XBlocks should be shown
-        """
-        self.landing_page.visit()
-        self.landing_page.wait_until_ready()
-        # No items should be in the library to start.
-        self.assertEqual(len(self.landing_page.xblocks), 0)
-        self.import_page.visit()
-        self.import_page.upload_tarball(self.tarball_name)
-        self.import_page.wait_for_upload()
-        self.landing_page.visit()
-        self.landing_page.wait_until_ready()
-        # There are three blocks in the tarball.
-        self.assertEqual(len(self.landing_page.xblocks), 3)
-
     def test_header(self):
         """
         Scenario: I should see the correct text when importing a library.

--- a/common/test/acceptance/tests/studio/test_import_export.py
+++ b/common/test/acceptance/tests/studio/test_import_export.py
@@ -161,17 +161,6 @@ class ImportTestMixin(object):
         """
         return []
 
-    def test_upload(self):
-        """
-        Scenario: I want to upload a course or library for import.
-            Given that I have a library or course to import into
-            And I have a valid .tar.gz file containing data to replace it with
-            I can select the file and upload it
-            And the page will give me confirmation that it uploaded successfully
-        """
-        self.import_page.upload_tarball(self.tarball_name)
-        self.import_page.wait_for_upload()
-
     def test_bad_import(self):
         """
         Scenario: I should see a failed checklist when uploading an invalid course or library

--- a/common/test/acceptance/tests/studio/test_import_export.py
+++ b/common/test/acceptance/tests/studio/test_import_export.py
@@ -221,15 +221,6 @@ class ImportTestMixin(object):
         self.import_page.wait_for_upload()
         self.assertEqual(self.import_page.finished_target_url(), self.landing_page.url)
 
-    def test_bad_filename_error(self):
-        """
-        Scenario: I should be reprimanded for trying to upload something that isn't a .tar.gz file.
-            Given that I select a file that is an .mp4 for upload
-            An error message will appear
-        """
-        self.import_page.upload_tarball('funny_cat_video.mp4')
-        self.import_page.wait_for_filename_error()
-
     def test_bad_import(self):
         """
         Scenario: I should see a failed checklist when uploading an invalid course or library

--- a/common/test/acceptance/tests/studio/test_import_export.py
+++ b/common/test/acceptance/tests/studio/test_import_export.py
@@ -250,34 +250,6 @@ class TestCourseImport(ImportTestMixin, StudioCourseTest):
         """
         self.assertEqual(self.import_page.header_text, 'Course Import')
 
-    def test_multiple_course_import_message(self):
-        """
-        Given that I visit an empty course before import
-        When I visit the import page
-        And I upload a course with file name 2015.lzdwNM.tar.gz
-        Then timestamp is visible after course is updated successfully
-        And then I create a new course
-        When I visit the import page of this new course
-        Then timestamp is not visible
-        """
-        self.import_page.visit()
-        self.import_page.upload_tarball(self.tarball_name)
-        self.import_page.wait_for_upload()
-        self.assertTrue(self.import_page.is_timestamp_visible())
-
-        # Create a new course and visit the import page
-        self.course_info = {
-            'org': 'orgX',
-            'number': self.unique_id + '_2',
-            'run': 'test_run_2',
-            'display_name': 'Test Course 2' + self.unique_id
-        }
-        self.install_course_fixture()
-        self.import_page = self.import_page_class(*self.page_args())
-        self.import_page.visit()
-        # As this is new course which is never import so timestamp should not present
-        self.assertFalse(self.import_page.is_timestamp_visible())
-
 
 @attr(shard=7)
 class TestLibraryImport(ImportTestMixin, StudioLibraryTest):

--- a/common/test/acceptance/tests/studio/test_import_export.py
+++ b/common/test/acceptance/tests/studio/test_import_export.py
@@ -161,18 +161,6 @@ class ImportTestMixin(object):
         """
         return []
 
-    def test_bad_import(self):
-        """
-        Scenario: I should see a failed checklist when uploading an invalid course or library
-            Given that I am on an import page
-            And I upload a tarball with a broken XML file
-            The tasks should be confirmed up until the 'Updating' task
-            And the 'Updating' task should be marked failed
-            And the remaining tasks should not be marked as started
-        """
-        self.import_page.upload_tarball(self.bad_tarball_name)
-        self.import_page.wait_for_tasks(fail_on='Updating')
-
 
 @attr(shard=7)
 class TestEntranceExamCourseImport(ImportTestMixin, StudioCourseTest):

--- a/common/test/acceptance/tests/studio/test_studio_outline.py
+++ b/common/test/acceptance/tests/studio/test_studio_outline.py
@@ -602,45 +602,6 @@ class UnitAccessTest(CourseOutlineTest):
         staff_page.wait_for_page()
         self.assertEqual(course_home_page.outline.num_units, 2)
 
-    def test_restricted_sections_for_enrollment_track_users_in_lms(self):
-        """
-        Verify that those who are in an enrollment track with access to a restricted unit are able
-        to see that unit in lms, and those who are in an enrollment track without access to a restricted
-        unit are not able to see that unit in lms
-        """
-        # Add just 1 enrollment track to verify the enrollment option isn't available in the modal
-        add_enrollment_course_modes(self.browser, self.course_id, ["audit"])
-        self.course_outline_page.visit()
-        self.course_outline_page.expand_all_subsections()
-        unit = self.course_outline_page.section_at(0).subsection_at(0).unit_at(0)
-        enrollment_select_options = unit.get_enrollment_select_options()
-        self.assertFalse('Enrollment Track Groups' in enrollment_select_options)
-
-        # Add the additional enrollment track so the unit access toggles should now be available
-        add_enrollment_course_modes(self.browser, self.course_id, ["verified"])
-        self.course_outline_page.visit()
-        self.course_outline_page.expand_all_subsections()
-        unit = self.course_outline_page.section_at(0).subsection_at(0).unit_at(0)
-        unit.toggle_unit_access('Enrollment Track Groups', [1])  # Hard coded 1 for audit ID
-        self.course_outline_page.view_live()
-
-        course_home_page = CourseHomePage(self.browser, self.course_id)
-        course_home_page.visit()
-        course_home_page.resume_course_from_header()
-        self.assertEqual(course_home_page.outline.num_units, 2)
-
-        # Test for a user without additional content available
-        staff_page = StaffCoursewarePage(self.browser, self.course_id)
-        staff_page.set_staff_view_mode('Learner in Verified')
-        staff_page.wait_for_page()
-        self.assertEqual(course_home_page.outline.num_units, 1)
-
-        # Test for a user with additional content available
-        staff_page = StaffCoursewarePage(self.browser, self.course_id)
-        staff_page.set_staff_view_mode('Learner in Audit')
-        staff_page.wait_for_page()
-        self.assertEqual(course_home_page.outline.num_units, 2)
-
 
 @attr(shard=3)
 class StaffLockTest(CourseOutlineTest):

--- a/common/test/acceptance/tests/studio/test_studio_outline.py
+++ b/common/test/acceptance/tests/studio/test_studio_outline.py
@@ -872,27 +872,6 @@ class StaffLockTest(CourseOutlineTest):
         subsection.unit_at(0).set_staff_lock(True)
         self.assertFalse(subsection.has_staff_lock_warning)
 
-    def test_locked_subsections_do_not_appear_in_lms(self):
-        """
-        Scenario: A locked subsection is not visible to students in the LMS
-            Given I have a course with two subsections
-            When I enable explicit staff lock on one subsection
-            And I click the View Live button to switch to staff view
-            And I visit the course home with the outline
-            Then I see two subsections in the outline
-            And when I switch the view mode to student view
-            Then I see one subsection in the outline
-        """
-        self.course_outline_page.visit()
-        self.course_outline_page.section_at(0).subsection_at(1).set_staff_lock(True)
-        self.course_outline_page.view_live()
-
-        course_home_page = CourseHomePage(self.browser, self.course_id)
-        course_home_page.visit()
-        self.assertEqual(course_home_page.outline.num_subsections, 2)
-        course_home_page.preview.set_staff_view_mode('Learner')
-        self.assertEqual(course_home_page.outline.num_subsections, 1)
-
     def test_toggling_staff_lock_on_section_does_not_publish_draft_units(self):
         """
         Scenario: Locking and unlocking a section will not publish its draft units


### PR DESCRIPTION
These tests are all flaky on firefox 59, which we are moving to on jenkins and devstack.

I am not squashing this PR to making reverting easier when these get fixed.