### PR TITLE
Bump edx-completion to 0.1.1

### DIFF
--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -54,9 +54,9 @@ edx-lint==0.5.4
 git+https://github.com/cpennington/pylint-django@fix-field-inference-during-monkey-patching#egg=pylint-django==0.0
 
 enum34==1.1.6
+edx-completion==0.1.1
 edx-django-oauth2-provider==1.2.5
 edx-django-sites-extensions==2.3.1
-edx-completion==0.0.11
 edx-enterprise==0.66.1
 edx-milestones==0.1.13
 edx-oauth2-provider==1.2.2


### PR DESCRIPTION
Fixes https://openedx.atlassian.net/browse/EDUCATOR-2540 with a not terrible query.