### PR TITLE
add missing maintenance banner settings

### DIFF
--- a/lms/envs/aws.py
+++ b/lms/envs/aws.py
@@ -1091,6 +1091,9 @@ COMPLETION_BY_VIEWING_DELAY_MS = ENV_TOKENS.get('COMPLETION_BY_VIEWING_DELAY_MS'
 ############### Settings for django-fernet-fields ##################
 FERNET_KEYS = AUTH_TOKENS.get('FERNET_KEYS', FERNET_KEYS)
 
+################# Settings for the maintenance banner #################
+MAINTENANCE_BANNER_TEXT = ENV_TOKENS.get('MAINTENANCE_BANNER_TEXT', None)
+
 ############################### Plugin Settings ###############################
 
 from openedx.core.djangoapps.plugins import plugin_settings, constants as plugin_constants

--- a/openedx/core/djangoapps/util/maintenance_banner.py
+++ b/openedx/core/djangoapps/util/maintenance_banner.py
@@ -35,9 +35,9 @@ def add_maintenance_banner(func):
     @wraps(func)
     def _decorated(request, *args, **kwargs):  # pylint: disable=missing-docstring
         if waffle().is_enabled(DISPLAY_MAINTENANCE_WARNING):
-            if hasattr(settings, 'EDXAPP_MAINTENANCE_BANNER_TEXT') and settings.EDXAPP_MAINTENANCE_BANNER_TEXT:
+            if hasattr(settings, 'MAINTENANCE_BANNER_TEXT') and settings.MAINTENANCE_BANNER_TEXT:
                 # The waffle switch is enabled and the banner text is defined
                 # and non-empty.  We can now register the message:
-                PageLevelMessages.register_warning_message(request, settings.EDXAPP_MAINTENANCE_BANNER_TEXT)
+                PageLevelMessages.register_warning_message(request, settings.MAINTENANCE_BANNER_TEXT)
         return func(request, *args, **kwargs)
     return _decorated


### PR DESCRIPTION
@doctoryes I remember you reminding me in the last PR to add this setting, but somehow I thought you were referring to the edx-internal yaml file.  Of course this is also necessary.