### PR TITLE
Enhance learner response report feature

### DIFF
--- a/lms/djangoapps/instructor_analytics/basic.py
+++ b/lms/djangoapps/instructor_analytics/basic.py
@@ -406,7 +406,7 @@ def coupon_codes_features(features, coupons_list, course_id):
     return [extract_coupon(coupon, features) for coupon in coupons_list]
 
 
-def list_problem_responses(course_key, problem_location):
+def list_problem_responses(course_key, problem_location, limit_responses=None):
     """
     Return responses to a given problem as a dict.
 
@@ -421,7 +421,10 @@ def list_problem_responses(course_key, problem_location):
     where `state` represents a student's response to the problem
     identified by `problem_location`.
     """
-    problem_key = UsageKey.from_string(problem_location)
+    if isinstance(problem_location, UsageKey):
+        problem_key = problem_location
+    else:
+        problem_key = UsageKey.from_string(problem_location)
     # Are we dealing with an "old-style" problem location?
     run = problem_key.run
     if not run:
@@ -434,6 +437,8 @@ def list_problem_responses(course_key, problem_location):
         module_state_key=problem_key
     )
     smdat = smdat.order_by('student')
+    if limit_responses is not None:
+        smdat = smdat[:limit_responses]
 
     return [
         {'username': response.student.username, 'state': response.state}

--- a/lms/djangoapps/instructor_task/api.py
+++ b/lms/djangoapps/instructor_task/api.py
@@ -330,7 +330,7 @@ def submit_calculate_problem_responses_csv(request, course_key, problem_location
     """
     task_type = 'problem_responses_csv'
     task_class = calculate_problem_responses_csv
-    task_input = {'problem_location': problem_location}
+    task_input = {'problem_location': problem_location, 'user_id': request.user.pk}
     task_key = ""
 
     return submit_task(request, task_type, task_class, course_key, task_input, task_key)

--- a/lms/djangoapps/instructor_task/tasks_helper/grades.py
+++ b/lms/djangoapps/instructor_task/tasks_helper/grades.py
@@ -604,9 +604,9 @@ class ProblemResponses(object):
         student_data = []
         max_count = settings.FEATURES.get('MAX_PROBLEM_RESPONSES_COUNT')
         for title, path, block_key in cls._build_problem_list(course_blocks, problem_key):
-            # Sequential blocks are filtered out since they include position state
-            # which isn't useful in this report.
-            if block_key.block_type == 'sequential':
+            # Chapter and sequential blocks are filtered out since they include state
+            # which isn't useful for this report.
+            if block_key.block_type in ('sequential', 'chapter'):
                 continue
             responses = list_problem_responses(course_id, block_key, max_count)
             student_data += responses

--- a/lms/djangoapps/instructor_task/tasks_helper/grades.py
+++ b/lms/djangoapps/instructor_task/tasks_helper/grades.py
@@ -580,9 +580,10 @@ class ProblemResponses(object):
                 response['title'] = title
                 response['location'] = ' > '.join(path)
                 response['block_id'] = block.block_id
-            max_count -= len(problem_responses)
-            if max_count <= 0:
-                break
+            if max_count is not None:
+                max_count -= len(problem_responses)
+                if max_count <= 0:
+                    break
 
         return student_data
 

--- a/lms/djangoapps/instructor_task/tasks_helper/grades.py
+++ b/lms/djangoapps/instructor_task/tasks_helper/grades.py
@@ -562,7 +562,7 @@ class ProblemResponses(object):
             if block.block_type == 'problem':
                 yield display_name, path, block
             else:
-                for result in ProblemResponses._build_problem_list(course_blocks, block, path + [display_name]):
+                for result in cls._build_problem_list(course_blocks, block, path + [display_name]):
                     yield result
 
     @classmethod
@@ -573,7 +573,7 @@ class ProblemResponses(object):
 
         student_data = []
         max_count = settings.FEATURES.get('MAX_PROBLEM_RESPONSES_COUNT')
-        for title, path, block in ProblemResponses._build_problem_list(course_blocks, problem_key):
+        for title, path, block in cls._build_problem_list(course_blocks, problem_key):
             problem_responses = list_problem_responses(course_id, block, max_count)
             student_data += problem_responses
             for response in problem_responses:
@@ -587,7 +587,6 @@ class ProblemResponses(object):
 
         return student_data
 
-
     @classmethod
     def generate(cls, _xmodule_instance_args, _entry_id, course_id, task_input, action_name):
         """
@@ -600,11 +599,12 @@ class ProblemResponses(object):
         task_progress = TaskProgress(action_name, num_reports, start_time)
         current_step = {'step': 'Calculating students answers to problem'}
         task_progress.update_task_state(extra_meta=current_step)
+        problem_location = task_input.get('problem_location')
 
         # Compute result table and format it
         student_data = cls._build_student_data(user_id=task_input.get('user_id'),
                                                course_id=course_id,
-                                               problem_location=task_input.get('problem_location'))
+                                               problem_location=problem_location)
 
         features = ['username', 'title', 'location', 'block_id', 'state']
         header, rows = format_dictlist(student_data, features)

--- a/lms/djangoapps/instructor_task/tasks_helper/grades.py
+++ b/lms/djangoapps/instructor_task/tasks_helper/grades.py
@@ -577,13 +577,8 @@ class ProblemResponses(object):
 
         for block in course_blocks.get_children(root):
             display_name = course_blocks.get_xblock_field(block, 'display_name')
-            # Sequential blocks are filtered out since they include position state
-            # which isn't useful in this report.
-            if block.block_type != 'sequential':
-                yield display_name, path, block
-            else:
-                for result in cls._build_problem_list(course_blocks, block, path + [display_name]):
-                    yield result
+            for result in cls._build_problem_list(course_blocks, block, path + [display_name]):
+                yield result
 
     @classmethod
     def _build_student_data(cls, user_id, course_id, problem_location):
@@ -609,6 +604,10 @@ class ProblemResponses(object):
         student_data = []
         max_count = settings.FEATURES.get('MAX_PROBLEM_RESPONSES_COUNT')
         for title, path, block_key in cls._build_problem_list(course_blocks, problem_key):
+            # Sequential blocks are filtered out since they include position state
+            # which isn't useful in this report.
+            if block_key.block_type == 'sequential':
+                continue
             responses = list_problem_responses(course_id, block_key, max_count)
             student_data += responses
             for response in responses:

--- a/lms/djangoapps/instructor_task/tasks_helper/grades.py
+++ b/lms/djangoapps/instructor_task/tasks_helper/grades.py
@@ -566,7 +566,7 @@ class ProblemResponses(object):
             path (List[str]): The list of display names for the parent of root block
 
         Yields:
-            Tuple[str, List[str], UsageKey]: tuple of a blocks display name, path, and
+            Tuple[str, List[str], UsageKey]: tuple of a block's display name, path, and
                 usage key
         """
         display_name = course_blocks.get_xblock_field(root, 'display_name')
@@ -588,8 +588,8 @@ class ProblemResponses(object):
 
         Arguments:
             user_id (int): The user id for the user generating the report
-            course_id (UsageKey): The UsageKey for the course whose report is
-                being generated
+            course_id (CourseKey): The ``CourseKey`` for the course whose report
+                is being generated
             problem_location (str): The generated report will include this
                 block and it child blocks.
 

--- a/lms/djangoapps/instructor_task/tasks_helper/grades.py
+++ b/lms/djangoapps/instructor_task/tasks_helper/grades.py
@@ -576,7 +576,7 @@ class ProblemResponses(object):
         Generate a list of problem responses for all problem under the
         ``problem_location`` root.
         """
-        problem_key = UsageKey.from_string(problem_location)
+        problem_key = UsageKey.from_string(problem_location).map_into_course(course_id)
         user = get_user_model().objects.get(pk=user_id)
         course_blocks = get_course_blocks(user, problem_key)
 

--- a/lms/djangoapps/instructor_task/tasks_helper/grades.py
+++ b/lms/djangoapps/instructor_task/tasks_helper/grades.py
@@ -562,8 +562,7 @@ class ProblemResponses(object):
         display_name = course_blocks.get_xblock_field(root, 'display_name')
         if path is None:
             path = [display_name]
-        if root.block_type == 'problem':
-            yield display_name, path, root
+        yield display_name, path, root
         for block in course_blocks.get_children(root):
             display_name = course_blocks.get_xblock_field(block, 'display_name')
             if block.block_type == 'problem':

--- a/lms/djangoapps/instructor_task/tasks_helper/grades.py
+++ b/lms/djangoapps/instructor_task/tasks_helper/grades.py
@@ -594,11 +594,12 @@ class ProblemResponses(object):
             for response in problem_responses:
                 response['title'] = title
                 response['location'] = ' > '.join(path)
+                response['block_id'] = block.block_id
             max_count -= len(problem_responses)
             if max_count <= 0:
                 break
 
-        features = ['username', 'title', 'location', 'state']
+        features = ['username', 'title', 'location', 'block_id', 'state']
         header, rows = format_dictlist(student_data, features)
 
         task_progress.attempted = task_progress.succeeded = len(rows)

--- a/lms/djangoapps/instructor_task/tasks_helper/grades.py
+++ b/lms/djangoapps/instructor_task/tasks_helper/grades.py
@@ -620,12 +620,15 @@ class ProblemResponses(object):
                 # Blocks can implement the generate_report_data method to provide their own
                 # human-readable formatting for user state.
                 if hasattr(block, 'generate_report_data'):
-                    user_state_iterator = user_state_client.iter_all_for_block(block_key)
-                    responses = [
-                        {'username': username, 'state': state}
-                        for username, state in
-                        block.generate_report_data(user_state_iterator, max_count)
-                    ]
+                    try:
+                        user_state_iterator = user_state_client.iter_all_for_block(block_key)
+                        responses = [
+                            {'username': username, 'state': state}
+                            for username, state in
+                            block.generate_report_data(user_state_iterator, max_count)
+                        ]
+                    except NotImplementedError:
+                        responses = list_problem_responses(course_key, block_key, max_count)
                 else:
                     responses = list_problem_responses(course_key, block_key, max_count)
 

--- a/lms/djangoapps/instructor_task/tasks_helper/grades.py
+++ b/lms/djangoapps/instructor_task/tasks_helper/grades.py
@@ -17,6 +17,7 @@ from six import text_type
 
 from course_blocks.api import get_course_blocks
 from courseware.courses import get_course_by_id
+from courseware.user_state_client import DjangoXBlockUserStateClient
 from instructor_analytics.basic import list_problem_responses
 from instructor_analytics.csvs import format_dictlist
 from lms.djangoapps.certificates.models import CertificateWhitelist, GeneratedCertificate, certificate_info_for_user
@@ -581,43 +582,64 @@ class ProblemResponses(object):
                 yield result
 
     @classmethod
-    def _build_student_data(cls, user_id, course_id, problem_location):
+    def _build_student_data(cls, user_id, course_key, usage_key_str):
         """
         Generate a list of problem responses for all problem under the
         ``problem_location`` root.
 
         Arguments:
             user_id (int): The user id for the user generating the report
-            course_id (CourseKey): The ``CourseKey`` for the course whose report
+            course_key (CourseKey): The ``CourseKey`` for the course whose report
                 is being generated
-            problem_location (str): The generated report will include this
+            usage_key_str (str): The generated report will include this
                 block and it child blocks.
 
         Returns:
               List[Dict]: Returns a list of dictionaries containing the student
                 data which will be included in the final csv.
         """
-        problem_key = UsageKey.from_string(problem_location).map_into_course(course_id)
+        usage_key = UsageKey.from_string(usage_key_str).map_into_course(course_key)
         user = get_user_model().objects.get(pk=user_id)
-        course_blocks = get_course_blocks(user, problem_key)
+        course_blocks = get_course_blocks(user, usage_key)
 
         student_data = []
         max_count = settings.FEATURES.get('MAX_PROBLEM_RESPONSES_COUNT')
-        for title, path, block_key in cls._build_problem_list(course_blocks, problem_key):
-            # Chapter and sequential blocks are filtered out since they include state
-            # which isn't useful for this report.
-            if block_key.block_type in ('sequential', 'chapter'):
-                continue
-            responses = list_problem_responses(course_id, block_key, max_count)
-            student_data += responses
-            for response in responses:
-                response['title'] = title
-                response['location'] = ' > '.join(path)
-                response['block_key'] = str(block_key)
-            if max_count is not None:
-                max_count -= len(responses)
-                if max_count <= 0:
-                    break
+
+        store = modulestore()
+        user_state_client = DjangoXBlockUserStateClient()
+
+        with store.bulk_operations(course_key):
+            for title, path, block_key in cls._build_problem_list(course_blocks, usage_key):
+                # Chapter and sequential blocks are filtered out since they include state
+                # which isn't useful for this report.
+                if block_key.block_type in ('sequential', 'chapter'):
+                    continue
+
+                block = store.get_item(block_key)
+
+                # Blocks can implement the generate_report_data method to provide their own
+                # human-readable formatting for user state.
+                if hasattr(block, 'generate_report_data'):
+                    user_state_iterator = user_state_client.iter_all_for_block(block_key)
+                    responses = [
+                        {'username': username, 'state': state}
+                        for username, state in
+                        block.generate_report_data(user_state_iterator, max_count)
+                    ]
+                else:
+                    responses = list_problem_responses(course_key, block_key, max_count)
+
+                student_data += responses
+                for response in responses:
+                    response['title'] = title
+                    # A human-readable location for the current block
+                    response['location'] = ' > '.join(path)
+                    # A machine-friendly location for the current block
+                    response['block_key'] = str(block_key)
+                if max_count is not None:
+                    max_count -= len(responses)
+                    if max_count <= 0:
+                        break
 
         return student_data
 
@@ -638,8 +660,8 @@ class ProblemResponses(object):
         # Compute result table and format it
         student_data = cls._build_student_data(
             user_id=task_input.get('user_id'),
-            course_id=course_id,
-            problem_location=problem_location
+            course_key=course_id,
+            usage_key_str=problem_location
         )
 
         features = ['username', 'title', 'location', 'block_key', 'state']

--- a/lms/djangoapps/instructor_task/tests/test_base.py
+++ b/lms/djangoapps/instructor_task/tests/test_base.py
@@ -233,12 +233,12 @@ class InstructorTaskModuleTestCase(InstructorTaskCourseTestCase):
         factory = OptionResponseXMLFactory()
         factory_args = self._option_problem_factory_args()
         problem_xml = factory.build_xml(**factory_args)
-        ItemFactory.create(parent_location=parent.location,
-                           parent=parent,
-                           category="problem",
-                           display_name=problem_url_name,
-                           data=problem_xml,
-                           **kwargs)
+        return ItemFactory.create(parent_location=parent.location,
+                                  parent=parent,
+                                  category="problem",
+                                  display_name=problem_url_name,
+                                  data=problem_xml,
+                                  **kwargs)
 
     def redefine_option_problem(self, problem_url_name, correct_answer=OPTION_1, num_inputs=1, num_responses=2):
         """Change the problem definition so the answer is Option 2"""

--- a/lms/djangoapps/instructor_task/tests/test_tasks_helper.py
+++ b/lms/djangoapps/instructor_task/tests/test_tasks_helper.py
@@ -470,7 +470,6 @@ class TestProblemResponsesReport(TestReportMixin, InstructorTaskModuleTestCase):
     def setUp(self):
         super(TestProblemResponsesReport, self).setUp()
         self.initialize_course()
-        # self.course = CourseFactory.create()
         self.instructor = self.create_instructor('instructor')
         self.student = self.create_student('student')
 
@@ -481,9 +480,11 @@ class TestProblemResponsesReport(TestReportMixin, InstructorTaskModuleTestCase):
             student = self.create_student('student{}'.format(ctr))
             self.submit_student_answer(student.username, u'Problem1', ['Option 1'])
 
-        student_data = ProblemResponses._build_student_data(user_id=self.instructor.id,
-                                                            course_id=self.course.id,
-                                                            problem_location=str(self.course.location))
+        student_data = ProblemResponses._build_student_data(
+            user_id=self.instructor.id,
+            course_id=self.course.id,
+            problem_location=str(self.course.location),
+        )
 
         self.assertEquals(len(student_data), 4)
 
@@ -491,19 +492,24 @@ class TestProblemResponsesReport(TestReportMixin, InstructorTaskModuleTestCase):
         self.define_option_problem(u'Problem1')
         self.submit_student_answer(self.student.username, u'Problem1', ['Option 1'])
 
-        student_data = ProblemResponses._build_student_data(user_id=self.instructor.id,
-                                                            course_id=self.course.id,
-                                                            problem_location=str(self.course.location))
+        student_data = ProblemResponses._build_student_data(
+            user_id=self.instructor.id,
+            course_id=self.course.id,
+            problem_location=str(self.course.location),
+        )
         self.assertEquals(len(student_data), 1)
         self.assertDictContainsSubset({
             'username': 'student',
-            'location': 'test_course > Section > Subsection',
-            'block_id': 'Problem1',
+            'location': 'test_course > Section > Subsection > Problem1',
+            'block_key': 'i4x://edx/1.23x/problem/Problem1',
             'title': 'Problem1',
         }, student_data[0])
 
     def test_success(self):
-        task_input = {'problem_location': str(self.course.location), 'user_id': self.instructor.id}
+        task_input = {
+            'problem_location': str(self.course.location),
+            'user_id': self.instructor.id
+        }
         with patch('lms.djangoapps.instructor_task.tasks_helper.runner._get_current_task'):
             with patch('lms.djangoapps.instructor_task.tasks_helper.grades'
                        '.ProblemResponses._build_student_data') as patched_data_source:
@@ -512,7 +518,9 @@ class TestProblemResponsesReport(TestReportMixin, InstructorTaskModuleTestCase):
                     {'username': 'user1', 'state': u'state1'},
                     {'username': 'user2', 'state': u'state2'},
                 ]
-                result = ProblemResponses.generate(None, None, self.course.id, task_input, 'calculated')
+                result = ProblemResponses.generate(
+                    None, None, self.course.id, task_input, 'calculated'
+                )
         report_store = ReportStore.from_config(config_name='GRADES_DOWNLOAD')
         links = report_store.links_for(self.course.id)
 

--- a/lms/djangoapps/instructor_task/tests/test_tasks_helper.py
+++ b/lms/djangoapps/instructor_task/tests/test_tasks_helper.py
@@ -461,6 +461,7 @@ class TestTeamGradeReport(InstructorGradeReportTestCase):
         self._verify_cell_data_for_user(self.student2.username, self.course.id, 'Team Name', team2.name)
 
 
+# pylint: disable=protected-access
 class TestProblemResponsesReport(TestReportMixin, InstructorTaskModuleTestCase):
     """
     Tests that generation of CSV files listing student answers to a

--- a/lms/djangoapps/instructor_task/tests/test_tasks_helper.py
+++ b/lms/djangoapps/instructor_task/tests/test_tasks_helper.py
@@ -24,8 +24,8 @@ from django.conf import settings
 from django.core.urlresolvers import reverse
 from django.test.utils import override_settings
 from freezegun import freeze_time
-from instructor_analytics.basic import UNAVAILABLE
-from mock import MagicMock, Mock, patch
+from instructor_analytics.basic import UNAVAILABLE, list_problem_responses
+from mock import MagicMock, Mock, patch, ANY
 from nose.plugins.attrib import attr
 from pytz import UTC
 from shoppingcart.models import (
@@ -473,8 +473,25 @@ class TestProblemResponsesReport(TestReportMixin, InstructorTaskModuleTestCase):
         self.instructor = self.create_instructor('instructor')
         self.student = self.create_student('student')
 
-    @patch.dict("django.conf.settings.FEATURES", {"MAX_PROBLEM_RESPONSES_COUNT": 4})
+    # Can be used once CapaDescriptor gets ``generate_report_data`` method.
+    # @contextmanager
+    # def _remove_report_generator(self):
+    #     """
+    #     Temporarily removes the generate_report_data method so we can test
+    #     report generation when it's absent.
+    #     """
+    #     from xmodule.capa_module import CapaDescriptor
+    #     generate_report_data = CapaDescriptor.generate_report_data
+    #     del CapaDescriptor.generate_report_data
+    #     yield
+    #     CapaDescriptor.generate_report_data = generate_report_data
+
+    @patch.dict('django.conf.settings.FEATURES', {'MAX_PROBLEM_RESPONSES_COUNT': 4})
     def test_build_student_data_limit(self):
+        """
+        Ensure that the _build_student_data method respects the global setting for
+        maximum responses to return in a report.
+        """
         self.define_option_problem(u'Problem1')
         for ctr in range(5):
             student = self.create_student('student{}'.format(ctr))
@@ -482,20 +499,28 @@ class TestProblemResponsesReport(TestReportMixin, InstructorTaskModuleTestCase):
 
         student_data = ProblemResponses._build_student_data(
             user_id=self.instructor.id,
-            course_id=self.course.id,
-            problem_location=str(self.course.location),
+            course_key=self.course.id,
+            usage_key_str=str(self.course.location),
         )
 
         self.assertEquals(len(student_data), 4)
 
-    def test_build_student_data(self):
+    @patch(
+        'lms.djangoapps.instructor_task.tasks_helper.grades.list_problem_responses',
+        wraps=list_problem_responses
+    )
+    def test_build_student_data_for_block_without_generate_report_data(self, mock_list_problem_responses):
+        """
+        Ensure that building student data for a block the doesn't have the
+        ``generate_report_data`` method works as expected.
+        """
         self.define_option_problem(u'Problem1')
         self.submit_student_answer(self.student.username, u'Problem1', ['Option 1'])
 
         student_data = ProblemResponses._build_student_data(
             user_id=self.instructor.id,
-            course_id=self.course.id,
-            problem_location=str(self.course.location),
+            course_key=self.course.id,
+            usage_key_str=str(self.course.location),
         )
         self.assertEquals(len(student_data), 1)
         self.assertDictContainsSubset({
@@ -503,6 +528,33 @@ class TestProblemResponsesReport(TestReportMixin, InstructorTaskModuleTestCase):
             'location': 'test_course > Section > Subsection > Problem1',
             'block_key': 'i4x://edx/1.23x/problem/Problem1',
             'title': 'Problem1',
+        }, student_data[0])
+        self.assertIn('state', student_data[0])
+        mock_list_problem_responses.assert_called_with(self.course.id, ANY, ANY)
+
+    @patch('xmodule.capa_module.CapaDescriptor.generate_report_data', create=True)
+    def test_build_student_data_for_block_with_generate_report_data(self, mock_generate_report_data):
+        """
+        Ensure that building student data for a block that supports the
+        ``generate_report_data`` method works as expected.
+        """
+        self.define_option_problem(u'Problem1')
+        state = {'some': 'state'}
+        mock_generate_report_data.return_value = iter([
+            ('student', state),
+        ])
+        student_data = ProblemResponses._build_student_data(
+            user_id=self.instructor.id,
+            course_key=self.course.id,
+            usage_key_str=str(self.course.location),
+        )
+        self.assertEquals(len(student_data), 1)
+        self.assertDictContainsSubset({
+            'username': 'student',
+            'location': 'test_course > Section > Subsection > Problem1',
+            'block_key': 'i4x://edx/1.23x/problem/Problem1',
+            'title': 'Problem1',
+            'state': state,
         }, student_data[0])
 
     def test_success(self):
@@ -512,8 +564,8 @@ class TestProblemResponsesReport(TestReportMixin, InstructorTaskModuleTestCase):
         }
         with patch('lms.djangoapps.instructor_task.tasks_helper.runner._get_current_task'):
             with patch('lms.djangoapps.instructor_task.tasks_helper.grades'
-                       '.ProblemResponses._build_student_data') as patched_data_source:
-                patched_data_source.return_value = [
+                       '.ProblemResponses._build_student_data') as mock_build_student_data:
+                mock_build_student_data.return_value = [
                     {'username': 'user0', 'state': u'state0'},
                     {'username': 'user1', 'state': u'state1'},
                     {'username': 'user2', 'state': u'state2'},

--- a/lms/djangoapps/instructor_task/tests/test_tasks_helper.py
+++ b/lms/djangoapps/instructor_task/tests/test_tasks_helper.py
@@ -557,6 +557,27 @@ class TestProblemResponsesReport(TestReportMixin, InstructorTaskModuleTestCase):
             'state': state,
         }, student_data[0])
 
+    @patch('lms.djangoapps.instructor_task.tasks_helper.grades.list_problem_responses')
+    @patch('xmodule.capa_module.CapaDescriptor.generate_report_data', create=True)
+    def test_build_student_data_for_block_with_generate_report_data_not_implemented(
+            self,
+            mock_generate_report_data,
+            mock_list_problem_responses,
+    ):
+        """
+        Ensure that if ``generate_report_data`` raises a NotImplementedError,
+        the report falls back to the alternative method.
+        """
+        problem = self.define_option_problem(u'Problem1')
+        mock_generate_report_data.side_effect = NotImplementedError
+        ProblemResponses._build_student_data(
+            user_id=self.instructor.id,
+            course_key=self.course.id,
+            usage_key_str=str(problem.location),
+        )
+        mock_generate_report_data.assert_called_with(ANY, ANY)
+        mock_list_problem_responses.assert_called_with(self.course.id, ANY, ANY)
+
     def test_success(self):
         task_input = {
             'problem_location': str(self.course.location),

--- a/lms/djangoapps/instructor_task/tests/test_tasks_helper.py
+++ b/lms/djangoapps/instructor_task/tests/test_tasks_helper.py
@@ -12,6 +12,7 @@ import os
 import shutil
 import tempfile
 import urllib
+from contextlib import contextmanager
 from datetime import datetime, timedelta
 
 import ddt
@@ -473,18 +474,17 @@ class TestProblemResponsesReport(TestReportMixin, InstructorTaskModuleTestCase):
         self.instructor = self.create_instructor('instructor')
         self.student = self.create_student('student')
 
-    # Can be used once CapaDescriptor gets ``generate_report_data`` method.
-    # @contextmanager
-    # def _remove_report_generator(self):
-    #     """
-    #     Temporarily removes the generate_report_data method so we can test
-    #     report generation when it's absent.
-    #     """
-    #     from xmodule.capa_module import CapaDescriptor
-    #     generate_report_data = CapaDescriptor.generate_report_data
-    #     del CapaDescriptor.generate_report_data
-    #     yield
-    #     CapaDescriptor.generate_report_data = generate_report_data
+    @contextmanager
+    def _remove_capa_report_generator(self):
+        """
+        Temporarily removes the generate_report_data method so we can test
+        report generation when it's absent.
+        """
+        from xmodule.capa_module import CapaDescriptor
+        generate_report_data = CapaDescriptor.generate_report_data
+        del CapaDescriptor.generate_report_data
+        yield
+        CapaDescriptor.generate_report_data = generate_report_data
 
     @patch.dict('django.conf.settings.FEATURES', {'MAX_PROBLEM_RESPONSES_COUNT': 4})
     def test_build_student_data_limit(self):
@@ -514,18 +514,18 @@ class TestProblemResponsesReport(TestReportMixin, InstructorTaskModuleTestCase):
         Ensure that building student data for a block the doesn't have the
         ``generate_report_data`` method works as expected.
         """
-        self.define_option_problem(u'Problem1')
+        problem = self.define_option_problem(u'Problem1')
         self.submit_student_answer(self.student.username, u'Problem1', ['Option 1'])
-
-        student_data = ProblemResponses._build_student_data(
-            user_id=self.instructor.id,
-            course_key=self.course.id,
-            usage_key_str=str(self.course.location),
-        )
+        with self._remove_capa_report_generator():
+            student_data = ProblemResponses._build_student_data(
+                user_id=self.instructor.id,
+                course_key=self.course.id,
+                usage_key_str=str(problem.location),
+            )
         self.assertEquals(len(student_data), 1)
         self.assertDictContainsSubset({
             'username': 'student',
-            'location': 'test_course > Section > Subsection > Problem1',
+            'location': 'Problem1',
             'block_key': 'i4x://edx/1.23x/problem/Problem1',
             'title': 'Problem1',
         }, student_data[0])
@@ -533,7 +533,7 @@ class TestProblemResponsesReport(TestReportMixin, InstructorTaskModuleTestCase):
         mock_list_problem_responses.assert_called_with(self.course.id, ANY, ANY)
 
     @patch('xmodule.capa_module.CapaDescriptor.generate_report_data', create=True)
-    def test_build_student_data_for_block_with_generate_report_data(self, mock_generate_report_data):
+    def test_build_student_data_for_block_with_mock_generate_report_data(self, mock_generate_report_data):
         """
         Ensure that building student data for a block that supports the
         ``generate_report_data`` method works as expected.
@@ -555,6 +555,31 @@ class TestProblemResponsesReport(TestReportMixin, InstructorTaskModuleTestCase):
             'block_key': 'i4x://edx/1.23x/problem/Problem1',
             'title': 'Problem1',
             'state': state,
+        }, student_data[0])
+
+    def test_build_student_data_for_block_with_real_generate_report_data(self):
+        """
+        Ensure that building student data for a block that supports the
+        ``generate_report_data`` method works as expected.
+        """
+        self.define_option_problem(u'Problem1')
+        self.submit_student_answer(self.student.username, u'Problem1', ['Option 1'])
+        student_data = ProblemResponses._build_student_data(
+            user_id=self.instructor.id,
+            course_key=self.course.id,
+            usage_key_str=str(self.course.location),
+        )
+        self.assertEquals(len(student_data), 1)
+        self.assertDictContainsSubset({
+            'username': 'student',
+            'location': 'test_course > Section > Subsection > Problem1',
+            'block_key': 'i4x://edx/1.23x/problem/Problem1',
+            'title': 'Problem1',
+            'state': {
+                'Answer ID': 'i4x-edx-1_23x-problem-Problem1_2_1',
+                'Answer': 'Option 1',
+                'Question': u'The correct answer is Option 1'
+            },
         }, student_data[0])
 
     @patch('lms.djangoapps.instructor_task.tasks_helper.grades.list_problem_responses')

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -206,6 +206,9 @@ FEATURES = {
     # Automatically approve student identity verification attempts
     'AUTOMATIC_VERIFY_STUDENT_IDENTITY_FOR_TESTING': False,
 
+    # Maximum number of rows to include in the csv file for downloading problem responses.
+    'MAX_PROBLEM_RESPONSES_COUNT': 5000,
+
     # whether to use password policy enforcement or not
     'ENFORCE_PASSWORD_POLICY': True,
 


### PR DESCRIPTION
The reports generated by "Download a CSV of problem responses" can be quite useful for instructors. This PR enhances that feature in a number of ways. 
1. It enables instructors to generate a report for multiple problems at once, by providing the location of a vertical, sequential, or even course. 
   * The related PR #17824 adds a UI to simplify selecting this location instead of needing to check the debug info.

2. It includes some additional data in the report, such as a human-readable location in the block (for e.g. "Example Week 1: Getting Started > Homework - Question Styles > Pointing on a Picture") along with the block id and title of the block

3. It can use the block's own report generator implemented in ``generate_report_data`` if available to get a better, more human-readable report. Blocks can implement how to extract the best human-readable user state in this method and return the data as a tuple of (username, readable-state). 
   * The related PR #17948 adds support for this method for some Capa problem types.

**Project details**:
This PR is part of the "Improved Problem Response Report" project, funded by Australian National University (ANU) and developed by OpenCraft

**JIRA tickets**: [OSPR-2316](https://openedx.atlassian.net/browse/OSPR-2316)

**Discussions**: https://edxchange.opencraft.com/t/xblock-reporting-tool/191

**Sandbox URL**:
* LMS: https://pr17776.sandbox.opencraft.hosting/
* Studio: https://studio-pr17776.sandbox.opencraft.hosting/

**Merge deadline**: None

**Testing instructions**:
The changes can be tested with:
 ```bash
pytest -q lms/djangoapps/instructor_task/tests/test_tasks_helper.py::TestProblemResponsesReport
```

**Reviewers**
- [x] @bradenmacdonald 
- [x] @symbolist 
- [ ] edX reviewer[s] TBD
