### PR TITLE
use library summary to fetch metadata

### DIFF
--- a/common/lib/xmodule/xmodule/library_tools.py
+++ b/common/lib/xmodule/xmodule/library_tools.py
@@ -177,5 +177,5 @@ class LibraryToolsService(object):
         """
         return [
             (lib.location.library_key.replace(version_guid=None, branch=None), lib.display_name)
-            for lib in self.store.get_libraries()
+            for lib in self.store.get_library_summaries()
         ]

--- a/common/lib/xmodule/xmodule/tests/test_library_tools.py
+++ b/common/lib/xmodule/xmodule/tests/test_library_tools.py
@@ -1,0 +1,35 @@
+"""
+Tests for library tools service.
+"""
+from mock import patch
+from xmodule.library_tools import LibraryToolsService
+from xmodule.modulestore.tests.factories import LibraryFactory
+from xmodule.modulestore.tests.utils import MixedSplitTestCase
+
+
+class LibraryToolsServiceTest(MixedSplitTestCase):
+    """
+    Tests for library service.
+    """
+
+    def setUp(self):
+        super(LibraryToolsServiceTest, self).setUp()
+
+        self.tools = LibraryToolsService(self.store)
+
+    def test_list_available_libraries(self):
+        """
+        Test listing of libraries.
+        """
+        _ = LibraryFactory.create(modulestore=self.store)
+        all_libraries = self.tools.list_available_libraries()
+        self.assertTrue(all_libraries)
+        self.assertEqual(len(all_libraries), 1)
+
+    @patch('xmodule.modulestore.split_mongo.split.SplitMongoModuleStore.get_library_summaries')
+    def test_list_available_libraries_fetch(self, mock_get_library_summaries):
+        """
+        Test that library list is compiled using light weight library summary objects.
+        """
+        _ = self.tools.list_available_libraries()
+        self.assertTrue(mock_get_library_summaries.called)


### PR DESCRIPTION

## [EDUCATOR-2546](https://openedx.atlassian.net/browse/EDUCATOR-2546)

### Description

Edit view of `Randomized Content Block` takes about 10-30 seconds to load. One costly operation is to fetch and load all libraries to list (display names) in editor view. In this PR costly `get_libraries()` call is replaced by `get_library_summaries()`.

### How to Test?

Delay can be observed in any `Randomized Content Block` component of courses on prod. 
To observe, press EDIT on any component of vertical https://studio.edx.org/container/block-v1:ASUx+ECN212x+2181B+type@vertical+block@8fafa5cb53d74bff8e66f83cda143d7f.
### Reviewers
If you've been tagged for review, please check your corresponding box once you've given the :+1:.
- [x] Code review: @awaisdar001 
- [x] Code review: @Rabia23 

FYI: Tag anyone who might be interested in this PR here.

### Post-review
- [ ] Rebase and squash commits