### PR TITLE
move global status messages to the user notificatio area

### DIFF
--- a/common/djangoapps/status/migrations/0002_update_help_text.py
+++ b/common/djangoapps/status/migrations/0002_update_help_text.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('status', '0001_initial'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='globalstatusmessage',
+            name='message',
+            field=models.TextField(help_text=b'<p>The contents of this field will be displayed as a warning banner on all views.</p><p>To override the banner message for a specific course, refer to the Course Message configuration. Course Messages will only work if the global status message is enabled, so if you only want to add a banner to specific courses without adding a global status message, you should add a global status message with <strong>empty</strong> message text.</p><p>Finally, disable the global status message by adding another empty message with "enabled" unchecked.</p>', null=True, blank=True),
+        ),
+    ]

--- a/common/djangoapps/status/models.py
+++ b/common/djangoapps/status/models.py
@@ -14,7 +14,16 @@ class GlobalStatusMessage(ConfigurationModel):
     """
     Model that represents the current status message.
     """
-    message = models.TextField(blank=True, null=True)
+    message = models.TextField(
+        blank=True,
+        null=True,
+        help_text='<p>The contents of this field will be displayed as a warning banner on all views.</p>'
+                  '<p>To override the banner message for a specific course, refer to the Course Message configuration. '
+                  'Course Messages will only work if the global status message is enabled, so if you only want to add '
+                  'a banner to specific courses without adding a global status message, you should add a global status '
+                  'message with <strong>empty</strong> message text.</p>'
+                  '<p>Finally, disable the global status message by adding another empty message with "enabled" '
+                  'unchecked.</p>')
 
     def full_message(self, course_key):
         """ Returns the full status message, including any course-specific status messages. """
@@ -26,7 +35,7 @@ class GlobalStatusMessage(ConfigurationModel):
         if course_key:
             try:
                 course_home_message = self.coursemessage_set.get(course_key=course_key)
-                # Don't add the message if course_home_message is blank.
+                # Don't override the message if course_home_message is blank.
                 if course_home_message:
                     msg = u"{} <br /> {}".format(msg, course_home_message.message)
             except CourseMessage.DoesNotExist:
@@ -41,7 +50,7 @@ class GlobalStatusMessage(ConfigurationModel):
 
 class CourseMessage(models.Model):
     """
-    Model that allows the user to specify messages for individual courses.
+    Model that allows the administrator to specify banner messages for individual courses.
 
     This is not a ConfigurationModel because using it's not designed to support multiple configurations at once,
     which would be problematic if separate courses need separate error messages.

--- a/lms/templates/header/header.html
+++ b/lms/templates/header/header.html
@@ -13,8 +13,6 @@ from openedx.core.djangolib.markup import HTML, Text
 
 # App that handles subdomain specific branding
 from branding import api as branding_api
-# app that handles site status messages
-from status.status import get_site_status_msg
 from openedx.core.djangoapps.lang_pref.api import header_language_selector_is_enabled, released_languages
 %>
 
@@ -29,21 +27,6 @@ from openedx.core.djangoapps.lang_pref.api import header_language_selector_is_en
     </%static:require_module>
     </%block>
 % endif
-
-<%block>
-<%
-course_id = course.id if course else None
-site_status_msg = get_site_status_msg(course_id)
-%>
-% if site_status_msg:
-  <div class="site-status">
-    <div class="inner-wrapper">
-      <span class="icon fa fa-warning" aria-hidden="true"></span>
-      <p>${site_status_msg}</p>
-    </div>
-  </div>
-% endif
-</%block>
 
 <header class="global-header ${'slim' if course else ''}">
     <div class="main-header">

--- a/lms/templates/navigation/navigation.html
+++ b/lms/templates/navigation/navigation.html
@@ -17,8 +17,6 @@ from openedx.core.djangolib.markup import HTML, Text
 
 # App that handles subdomain specific branding
 from branding import api as branding_api
-# app that handles site status messages
-from status.status import get_site_status_msg
 from openedx.core.djangoapps.lang_pref.api import header_language_selector_is_enabled, released_languages
 %>
 
@@ -35,26 +33,6 @@ from openedx.core.djangoapps.lang_pref.api import header_language_selector_is_en
     </%static:require_module>
     </%block>
 % endif
-
-<%block>
-<%
-try:
-    course_id = course.id
-except:
-    # can't figure out a better way to get at a possibly-defined course var
-    course_id = None
-site_status_msg = get_site_status_msg(course_id)
-%>
-% if site_status_msg:
-<div class="site-status">
-  <div class="inner-wrapper">
-    <span class="icon fa fa-warning"></span>
-    <p>${site_status_msg}</p>
-  </div>
-</div>
-% endif
-</%block>
-
 
 % if uses_bootstrap:
   <header class="navigation-container header-global ${'slim' if course else ''}">

--- a/lms/templates/page_banner.html
+++ b/lms/templates/page_banner.html
@@ -7,11 +7,19 @@
 <%!
 from django.utils.translation import ugettext as _
 from openedx.core.djangolib.markup import HTML
-from openedx.core.djangoapps.util.user_messages import PageLevelMessages
+from openedx.core.djangoapps.util.user_messages import PageLevelMessages, UserMessage, UserMessageType
+# app that handles site status messages
+from status.status import get_site_status_msg
 %>
 
 <%
 banner_messages = list(PageLevelMessages.user_messages(request))
+
+# insert the global status message
+course_id = course.id if course else None
+site_status_message = get_site_status_msg(course_id)
+if site_status_message:
+    banner_messages.insert(0, UserMessage(UserMessageType.WARNING, site_status_message))
 %>
 
 % if banner_messages:


### PR DESCRIPTION
The existing global status message banner appears above the nav bar and is subject to broken styling on some pages:

![2018-03-26-111248_1365x379_scrot](https://user-images.githubusercontent.com/85151/37915999-c2be7ee8-30e8-11e8-88a7-05247ff644da.png)
![2018-03-26-113108_1365x323_scrot](https://user-images.githubusercontent.com/85151/37916187-38eb8610-30e9-11e8-9b85-601875b92d66.png)

This change puts the banner together with other user messages for a more consistent experience:

![2018-03-26-113318_1365x337_scrot](https://user-images.githubusercontent.com/85151/37916319-8399b3d0-30e9-11e8-8953-acf83370c353.png)

