### PR TITLE
Update newrelic agent.

### DIFF
--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -147,7 +147,7 @@ watchdog==0.8.3
 
 # Metrics gathering and monitoring
 dogapi==1.2.1
-newrelic==2.86.3.70
+newrelic==2.104.0.86
 
 # Used for documentation gathering
 sphinx==1.1.3


### PR DESCRIPTION
Move to the latest minor version of the NR plugin because 3.x removes some deprecated functions.