### PR TITLE
Revert Watch assets on specific system

### DIFF
--- a/pavelib/assets.py
+++ b/pavelib/assets.py
@@ -234,7 +234,7 @@ def get_system_sass_dirs(system):
     return dirs
 
 
-def get_watcher_dirs(theme_dirs=None, themes=None, system=None):
+def get_watcher_dirs(theme_dirs=None, themes=None):
     """
     Return sass directories that need to be added to sass watcher.
 
@@ -252,43 +252,24 @@ def get_watcher_dirs(theme_dirs=None, themes=None, system=None):
             '/edx/app/edxapp/edx-platform/themes/red-theme/cms/static/sass/partials',
         ]
 
-        >> get_watcher_dirs('/edx/app/edx-platform/themes', ['red-theme'], lms)
-        [
-            'common/static',
-            'common/static/sass',
-            'lms/static/sass',
-            'lms/static/sass/partials',
-            '/edx/app/edxapp/edx-platform/themes/red-theme/lms/static/sass',
-            '/edx/app/edxapp/edx-platform/themes/red-theme/lms/static/sass/partials',
-        ]
-
     Parameters:
         theme_dirs (list): list of theme base directories.
-        themes (list): list containing names of themes.
-        system (str): the system for which the assets are watched.
+        themes (list): list containing names of themes
     Returns:
         (list): dirs that need to be added to sass watchers.
     """
     dirs = []
     dirs.extend(COMMON_LOOKUP_PATHS)
-    systems = list(system) if system else ALL_SYSTEMS
-
     if theme_dirs and themes:
         # Register sass watchers for all the given themes
         themes = get_theme_paths(themes=themes, theme_dirs=theme_dirs)
         for theme in themes:
-            system_dirs = []
-            for sys in systems:
-                system_dirs.extend(get_sass_directories(sys, theme))
-            for _dir in system_dirs:
+            for _dir in get_sass_directories('lms', theme) + get_sass_directories('cms', theme):
                 dirs.append(_dir['sass_source_dir'])
                 dirs.extend(_dir['lookup_paths'])
 
-    # Register sass watchers for systems
-    system_dirs = []
-    for sys in systems:
-            system_dirs.extend(get_sass_directories(sys))
-    for _dir in system_dirs + get_common_sass_directories():
+    # Register sass watchers for lms and cms
+    for _dir in get_sass_directories('lms') + get_sass_directories('cms') + get_common_sass_directories():
         dirs.append(_dir['sass_source_dir'])
         dirs.extend(_dir['lookup_paths'])
 
@@ -899,8 +880,7 @@ def listfy(data):
     ('background', 'b', 'Background mode'),
     ('theme-dirs=', '-td', 'The themes dir containing all themes (defaults to None)'),
     ('themes=', '-t', 'The themes to add sass watchers for (defaults to None)'),
-    ('wait=', '-w', 'How long to pause between filesystem scans.'),
-    ('system=', 's', 'The system to watch sass for (defaults to all)')
+    ('wait=', '-w', 'How long to pause between filesystem scans.')
 ])
 @timed
 def watch_assets(options):
@@ -913,7 +893,6 @@ def watch_assets(options):
 
     themes = get_parsed_option(options, 'themes')
     theme_dirs = get_parsed_option(options, 'theme_dirs', [])
-    system = get_parsed_option(options, 'system')
 
     default_wait = [unicode(DEFAULT_OBSERVER_TIMEOUT)]
     wait = float(get_parsed_option(options, 'wait', default_wait)[0])
@@ -924,7 +903,7 @@ def watch_assets(options):
     else:
         theme_dirs = [path(_dir) for _dir in theme_dirs]
 
-    sass_directories = get_watcher_dirs(theme_dirs, themes, system=system)
+    sass_directories = get_watcher_dirs(theme_dirs, themes)
     observer = Observer(timeout=wait)
 
     CoffeeScriptWatcher().register(observer)

--- a/pavelib/paver_tests/test_assets.py
+++ b/pavelib/paver_tests/test_assets.py
@@ -275,34 +275,6 @@ class TestPaverWatchAssetTasks(TestCase):
                     self.assertIsInstance(sass_watcher_args[1], list)
                     self.assertItemsEqual(sass_watcher_args[1], self.expected_sass_directories)
 
-    def test_watch_lms_assets(self):
-        """
-        Test the Paver watch asset tasks with LMS system.
-        """
-        expected_sass_directories = [
-            path('lms/static/sass/partials'),
-            path('lms/static/sass'),
-            path('lms/static/certificates/sass')
-        ]
-
-        with patch('pavelib.assets.SassWatcher.register') as mock_register, \
-                patch('pavelib.assets.Observer.start'), \
-                patch('pavelib.assets.execute_webpack_watch') as mock_webpack:
-                    call_task(
-                        'pavelib.assets.watch_assets',
-                        options={
-                            "background": True,
-                            "system": 'lms',
-                        },
-                    )
-                    self.assertEqual(mock_register.call_count, 2)
-                    self.assertEqual(mock_webpack.call_count, 1)
-
-                    sass_watcher_args = mock_register.call_args_list[0][0]
-                    self.assertIsInstance(sass_watcher_args[0], Observer)
-                    self.assertIsInstance(sass_watcher_args[1], list)
-                    self.assertItemsEqual(sass_watcher_args[1], expected_sass_directories)
-
 
 @ddt.ddt
 class TestCollectAssets(PaverTestCase):


### PR DESCRIPTION
Reverts edx/edx-platform#17697

This OSPR didnt run PR tests and is causing a django upgrade test failure.

https://build.testeng.edx.org/view/django-upgrade-master-tests/job/edx-platform-django-upgrade-unittests-master/282/testReport/junit/pavelib.paver_tests.test_assets/TestPaverWatchAssetTasks/test_watch_lms_assets/