### PR TITLE
Use get or create rather than create

### DIFF
--- a/openedx/core/djangoapps/course_groups/cohorts.py
+++ b/openedx/core/djangoapps/course_groups/cohorts.py
@@ -256,10 +256,17 @@ def get_cohort(user, course_key, assign=True, use_cached=False):
             else:
                 course_user_group = get_random_cohort(course_key)
 
-            membership = CohortMembership.objects.create(
+            membership, created = CohortMembership.objects.get_or_create(
                 user=user,
                 course_user_group=course_user_group,
             )
+            if not created:
+                # EDUCATOR-2549: Adding temporary log to test if we hit a situation where user already has
+                # a member ship group.
+                log.info(
+                    "COHORT_MEMBERSHIP_FOUND: Membership found %s for course %s and user %s",
+                    membership.course_user_group, course_key, user.id
+                )
 
             return cache.setdefault(cache_key, membership.course_user_group)
     except IntegrityError as integrity_error:


### PR DESCRIPTION
## 'ErrorDescriptorWithMixins' object has no attribute 'id'
Right now, the `CohortMembership.objects.create( **params )` is failing for a duplicate integrity error. I have updated the code to use `get_or_create`. I also added a temporary log which should be removed after confirmation that the specific scenario has been hit. 

### Expected log
`COHORT_MEMBERSHIP_FOUND: Membership found {Cohort_Name} for course {Course_Key} and user {UserID}`
[EDUCATOR-2549](https://openedx.atlassian.net/browse/EDUCATOR-2549)
