### PR TITLE
Fix IE11 not loading Video Uploads

### DIFF
--- a/cms/static/js/views/baseview.js
+++ b/cms/static/js/views/baseview.js
@@ -32,6 +32,15 @@ define(['jquery', 'underscore', 'backbone', 'gettext', 'js/utils/handle_iframe_b
                 if (this.options) {
                     options = _.extend({}, _.result(this, 'options'), options);
                 }
+
+                // trunc is not available in IE, and it provides polyfill for it.
+                // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/trunc
+                if (!Math.trunc) {
+                    Math.trunc = function(v) {
+                        v = +v;
+                        return (v - v % 1)   ||   (!isFinite(v) || v === 0 ? v : v < 0 ? -0 : 0);
+                    };
+                }
                 this.options = options;
 
                 var _this = this;

--- a/cms/static/js/views/baseview.js
+++ b/cms/static/js/views/baseview.js
@@ -37,8 +37,8 @@ define(['jquery', 'underscore', 'backbone', 'gettext', 'js/utils/handle_iframe_b
                 // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/trunc
                 if (!Math.trunc) {
                     Math.trunc = function(v) {
-                        v = +v;
-                        return (v - v % 1)   ||   (!isFinite(v) || v === 0 ? v : v < 0 ? -0 : 0);
+                        v = +v;  // eslint-disable-line no-param-reassign
+                        return (v - v % 1) || (!isFinite(v) || v === 0 ? v : v < 0 ? -0 : 0);
                     };
                 }
                 this.options = options;


### PR DESCRIPTION
## Video List failing to display in IE11
### Description 
The following shows that `trunc` is not available in IE, and provides a polyfill for it.
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/trunc

### sandbox
https://studio-video.sandbox.edx.org/videos/course-v1:edX+DemoX+Demo_Course

[EDUCATOR-2591](https://openedx.atlassian.net/browse/EDUCATOR-2591)

FYI -- @muhammad-ammar 