### PR TITLE
Fix styling of navtabs.

### DIFF
--- a/lms/static/sass/_header.scss
+++ b/lms/static/sass/_header.scss
@@ -11,6 +11,7 @@
   border-bottom: 1px solid theme-color("primary");
   box-shadow: 0 1px 5px 0 rgba(0, 0, 0, 0.1);
   background: theme-color("inverse");
+  line-height: 1.5;
 
   /*
     Logo and course identification block
@@ -102,7 +103,7 @@
             font-weight: $font-weight-normal;
             display: inline-block;
             margin-bottom: -1*$baseline/2;
-            border-bottom: 4px hidden theme-color("dark");
+            border-bottom: 4px solid transparent;
             cursor: pointer;
 
             &.active,

--- a/lms/templates/header/navbar-authenticated.html
+++ b/lms/templates/header/navbar-authenticated.html
@@ -39,13 +39,13 @@ from openedx.core.djangoapps.site_configuration import helpers as configuration_
     % endif
     % if show_explore_courses:
       <div class="mobile-nav-item hidden-mobile nav-item nav-tab">
-        <a class="btn" href="${marketing_link('COURSES')}">${_('Discover New')}</a>
+        <a class="tab-nav-link" href="${marketing_link('COURSES')}">${_('Discover New')}</a>
       </div>
     % endif
     % if show_sysadmin_dashboard:
-      <div class="mobile-nav-item hidden-mobile nav-item">
+      <div class="mobile-nav-item hidden-mobile nav-item nav-tab">
         ## Translators: This is short for "System administration".
-        <a class="btn" href="${reverse('sysadmin')}">${_("Sysadmin")}</a>
+        <a class="tab-nav-link" href="${reverse('sysadmin')}">${_("Sysadmin")}</a>
       </div>
     % endif
   </div>
@@ -67,5 +67,3 @@ from openedx.core.djangoapps.site_configuration import helpers as configuration_
     <%include file="user_dropdown.html"/>
   </div>
 </div>
-
-


### PR DESCRIPTION
**Description:**
This PR fixes styling issues of nav-tabs in navigation header.

**Screenshots:**

##### Extending header on tab hover

###### Before:
![d985d3f9-bdfa-4f4c-ye18-c662327f4406](https://user-images.githubusercontent.com/10139760/38050966-0d00055e-32cd-11e8-8d43-22e9fcceba75.gif)

###### After
![9554bfe4-5b5f-4f7b-y095-c7e5a9468b07](https://user-images.githubusercontent.com/10139760/38050960-03f31c1c-32cd-11e8-8330-46499cde9e0e.gif)

##### Inconsistent styling of tabs of header

###### Before:
<img width="1397" alt="screen shot 2018-03-28 at 8 48 56 pm" src="https://user-images.githubusercontent.com/10139760/38051047-5ff1a006-32cd-11e8-9b17-f6bb79d22a55.png">

<img width="1400" alt="screen shot 2018-03-28 at 9 18 05 pm" src="https://user-images.githubusercontent.com/10139760/38051107-97b56932-32cd-11e8-9fd6-5ee4395572f2.png">

###### After:
<img width="1398" alt="screen shot 2018-03-28 at 8 49 40 pm" src="https://user-images.githubusercontent.com/10139760/38051052-66058d7c-32cd-11e8-961e-3ae7d4e364b0.png">

<img width="1402" alt="screen shot 2018-03-28 at 9 18 27 pm" src="https://user-images.githubusercontent.com/10139760/38051112-9c4d4910-32cd-11e8-9a5f-47c4061d049a.png">

**Sandbox URL**: https://hawthorn-beta.sandbox.opencraft.hosting

**Merge deadline**: If possible, soon so that it makes it to Hawthorn.

**Testing instructions:**

1. Log in as `staff@example.com`.
2. Go to _edX Demonstration Course_ (follow [this link](https://hawthorn-beta.sandbox.opencraft.hosting/courses/course-v1:edX+DemoX+Demo_Course/course/)).
3. See issues fixed as in the screenshots above (e.g. visit `Discussion`  and `Wiki` tabs).

**Reviewers:**
- [x] @clemente 
- [ ] edX reviewer - TBD


Signed-off-by: Tomasz Gargas <tomasz@opencraft.com>