### PR TITLE
Protection for when there is no CourseOverview data available.

### DIFF
--- a/common/djangoapps/entitlements/tests/test_utils.py
+++ b/common/djangoapps/entitlements/tests/test_utils.py
@@ -3,6 +3,7 @@ Test entitlements utilities
 """
 
 from datetime import timedelta
+from opaque_keys.edx.keys import CourseKey
 
 from django.conf import settings
 from django.utils.timezone import now
@@ -20,13 +21,13 @@ if settings.ROOT_URLCONF == 'lms.urls':
 
 
 @skip_unless_lms
-class TestCourseRunFullfillableForEntitlement(ModuleStoreTestCase):
+class TestCourseRunFulfillableForEntitlement(ModuleStoreTestCase):
     """
     Tests for the utility function is_course_run_entitlement_fulfillable
     """
 
     def setUp(self):
-        super(TestCourseRunFullfillableForEntitlement, self).setUp()
+        super(TestCourseRunFulfillableForEntitlement, self).setUp()
 
         self.user = UserFactory(is_staff=True)
         self.client.login(username=self.user.username, password=TEST_PASSWORD)
@@ -54,7 +55,7 @@ class TestCourseRunFullfillableForEntitlement(ModuleStoreTestCase):
         )
         return course_overview
 
-    def test_course_run_fullfillble(self):
+    def test_course_run_fulfillable(self):
         course_overview = self.create_course(
             start_from_now=-2,
             end_from_now=2,
@@ -66,7 +67,15 @@ class TestCourseRunFullfillableForEntitlement(ModuleStoreTestCase):
 
         assert is_course_run_entitlement_fulfillable(course_overview.id, entitlement)
 
-    def test_course_run_not_fullfillable_run_ended(self):
+    def test_course_run_missing_overview_not_fulfillable(self):
+        entitlement = CourseEntitlementFactory.create(mode=CourseMode.VERIFIED)
+
+        assert not is_course_run_entitlement_fulfillable(
+            CourseKey.from_string('course-v1:edx+FakeCourse+3T2017'),
+            entitlement
+        )
+
+    def test_course_run_not_fulfillable_run_ended(self):
         course_overview = self.create_course(
             start_from_now=-3,
             end_from_now=-1,
@@ -78,7 +87,7 @@ class TestCourseRunFullfillableForEntitlement(ModuleStoreTestCase):
 
         assert not is_course_run_entitlement_fulfillable(course_overview.id, entitlement)
 
-    def test_course_run_not_fullfillable_enroll_period_ended(self):
+    def test_course_run_not_fulfillable_enroll_period_ended(self):
         course_overview = self.create_course(
             start_from_now=-3,
             end_from_now=2,
@@ -90,7 +99,7 @@ class TestCourseRunFullfillableForEntitlement(ModuleStoreTestCase):
 
         assert not is_course_run_entitlement_fulfillable(course_overview.id, entitlement)
 
-    def test_course_run_fullfillable_user_enrolled(self):
+    def test_course_run_fulfillable_user_enrolled(self):
         course_overview = self.create_course(
             start_from_now=-3,
             end_from_now=2,
@@ -104,7 +113,7 @@ class TestCourseRunFullfillableForEntitlement(ModuleStoreTestCase):
 
         assert is_course_run_entitlement_fulfillable(course_overview.id, entitlement)
 
-    def test_course_run_not_fullfillable_upgrade_ended(self):
+    def test_course_run_not_fulfillable_upgrade_ended(self):
         course_overview = self.create_course(
             start_from_now=-3,
             end_from_now=2,

--- a/common/djangoapps/entitlements/utils.py
+++ b/common/djangoapps/entitlements/utils.py
@@ -1,3 +1,7 @@
+"""
+Utility methods for the entitlement application.
+"""
+
 import logging
 
 from django.utils import timezone
@@ -24,9 +28,9 @@ def is_course_run_entitlement_fulfillable(course_run_key, entitlement, compare_d
     Returns:
         bool: True if the Course Run is fullfillable for the CourseEntitlement.
     """
-    course_overview = CourseOverview.get_from_id(course_run_key)
-
-    if not course_overview:
+    try:
+        course_overview = CourseOverview.get_from_id(course_run_key)
+    except CourseOverview.DoesNotExist:
         log.error(('There is no CourseOverview entry available for {course_run_id}, '
                    'course run cannot be applied to entitlement').format(
             course_run_id=str(course_run_key)

--- a/common/djangoapps/entitlements/utils.py
+++ b/common/djangoapps/entitlements/utils.py
@@ -1,7 +1,11 @@
+import logging
+
 from django.utils import timezone
 
 from course_modes.models import CourseMode
 from openedx.core.djangoapps.content.course_overviews.models import CourseOverview
+
+log = logging.getLogger("common.entitlements.utils")
 
 
 def is_course_run_entitlement_fulfillable(course_run_key, entitlement, compare_date=timezone.now()):
@@ -21,6 +25,13 @@ def is_course_run_entitlement_fulfillable(course_run_key, entitlement, compare_d
         bool: True if the Course Run is fullfillable for the CourseEntitlement.
     """
     course_overview = CourseOverview.get_from_id(course_run_key)
+
+    if not course_overview:
+        log.error(('There is no CourseOverview entry available for {course_run_id}, '
+                   'course run cannot be applied to entitlement').format(
+            course_run_id=str(course_run_key)
+        ))
+        return False
 
     # Verify that the course is still running
     run_start = course_overview.start


### PR DESCRIPTION
Small PR to add in protection for when a Course Overview object is not available for a given Course Run.  