### PR TITLE
permit staff role to rescore, override and delete problem scores for individual learners

### DIFF
--- a/lms/djangoapps/courseware/module_render.py
+++ b/lms/djangoapps/courseware/module_render.py
@@ -688,13 +688,11 @@ def get_module_system_for_user(
             # the result would always be "False".
             masquerade_settings = user.real_user.masquerade_settings
             del user.real_user.masquerade_settings
-            instructor_access = bool(has_access(user.real_user, 'instructor', descriptor, course_id))
             user.real_user.masquerade_settings = masquerade_settings
         else:
             staff_access = has_access(user, 'staff', descriptor, course_id)
-            instructor_access = bool(has_access(user, 'instructor', descriptor, course_id))
         if staff_access:
-            block_wrappers.append(partial(add_staff_markup, user, instructor_access, disable_staff_debug_info))
+            block_wrappers.append(partial(add_staff_markup, user, disable_staff_debug_info))
 
     # These modules store data using the anonymous_student_id as a key.
     # To prevent loss of data, we will continue to provide old modules with

--- a/lms/templates/staff_problem_info.html
+++ b/lms/templates/staff_problem_info.html
@@ -80,7 +80,6 @@ ${block_content}
         <button type="button" class="btn-link staff-debug-reset">${_('Reset Learner\'s Attempts to Zero')}</button>
         |
         % endif
-        % if has_instructor_access:
         <button type="button" class="btn-link staff-debug-sdelete">${_('Delete Learner\'s State')}</button>
         % if can_rescore_problem:
         |
@@ -91,7 +90,6 @@ ${block_content}
         % endif
         % if can_override_problem_score:
         <button type="button" class="btn-link staff-debug-override-score">${_('Override Score')}</button>
-        % endif
         % endif
         ]
       </div>

--- a/openedx/core/lib/xblock_utils/__init__.py
+++ b/openedx/core/lib/xblock_utils/__init__.py
@@ -288,8 +288,8 @@ def sanitize_html_id(html_id):
     return sanitized_html_id
 
 
-@contract(user=User, has_instructor_access=bool, block=XBlock, view=basestring, frag=Fragment, context="dict|None")
-def add_staff_markup(user, has_instructor_access, disable_staff_debug_info, block, view, frag, context):  # pylint: disable=unused-argument
+@contract(user=User, block=XBlock, view=basestring, frag=Fragment, context="dict|None")
+def add_staff_markup(user, disable_staff_debug_info, block, view, frag, context):  # pylint: disable=unused-argument
     """
     Updates the supplied module with a new get_html function that wraps
     the output of the old get_html function with additional information
@@ -383,7 +383,6 @@ def add_staff_markup(user, has_instructor_access, disable_staff_debug_info, bloc
         'render_histogram': render_histogram,
         'block_content': frag.content,
         'is_released': is_released,
-        'has_instructor_access': has_instructor_access,
         'can_reset_attempts': 'attempts' in block.fields,
         'can_rescore_problem': hasattr(block, 'rescore'),
         'can_override_problem_score': isinstance(block, ScorableXBlockMixin),


### PR DESCRIPTION
## [EDUCATOR-2587](https://openedx.atlassian.net/browse/EDUCATOR-2587)

### Description

This PR grants following permissions to users with 'staff' role.

- Rescore a problem
- Delete a learner's state of a component
- Override score of a problem

Note that users with 'staff' role can perform these operations for individual learners only.
### Sandbox
- [ ] https://access.sandbox.edx.org

### Reviewers
- [x] @awaisdar001 
- [x] @Rabia23 
  
### Post-review
- [ ] Rebase and squash commits