### PR TITLE
reorder 0017_auto_20180327_1631 to be after the other 0017

### DIFF
--- a/common/djangoapps/third_party_auth/migrations/0018_auto_20180327_1631.py
+++ b/common/djangoapps/third_party_auth/migrations/0018_auto_20180327_1631.py
@@ -7,7 +7,7 @@ from django.db import migrations, models
 class Migration(migrations.Migration):
 
     dependencies = [
-        ('third_party_auth', '0016_auto_20180130_0938'),
+        ('third_party_auth', '0017_remove_icon_class_image_secondary_fields'),
     ]
 
     operations = [


### PR DESCRIPTION
The migration 0017_remove_icon_class_image_secondary_fields was in
conflict with 0017_auto_20180327_1631, so we bump the latter to 0018.