### PR TITLE
allow site and mode to be nullable in admin form

### DIFF
--- a/common/djangoapps/entitlements/admin.py
+++ b/common/djangoapps/entitlements/admin.py
@@ -65,6 +65,18 @@ class CourseEntitlementSupportDetailAdmin(admin.ModelAdmin):
     form = CourseEntitlementSupportDetailForm
 
 
+class CourseEntitlementPolicyForm(forms.ModelForm):
+    """ Form for creating custom course entitlement policies. """
+    def __init__(self, *args, **kwargs):
+        super(CourseEntitlementPolicyForm, self).__init__(*args, **kwargs)
+        self.fields['site'].required = False
+        self.fields['mode'].required = False
+
+    class Meta:
+        fields = '__all__'
+        model = CourseEntitlementPolicy
+
+
 @admin.register(CourseEntitlementPolicy)
 class CourseEntitlementPolicyAdmin(admin.ModelAdmin):
     """
@@ -75,3 +87,4 @@ class CourseEntitlementPolicyAdmin(admin.ModelAdmin):
                     'regain_period',
                     'mode',
                     'site')
+    form = CourseEntitlementPolicyForm


### PR DESCRIPTION
I made the site and mode fields nullable in the database but not in the admin form, which is where any creation of CourseEntitlementPolicies would likely take place.

[LEARNER-4095](https://openedx.atlassian.net/browse/LEARNER-4095)