### PR TITLE
Proposal: Add extra information to certificates

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -114,3 +114,4 @@ security@edx.org.
 
 .. _individual contributor agreement: http://open.edx.org/sites/default/files/wysiwyg/individual-contributor-agreement.pdf
 .. _CONTRIBUTING: https://github.com/edx/edx-platform/blob/master/CONTRIBUTING.rst
+


### PR DESCRIPTION
@nedbat Following an advice from your e-mail, I'm creating a proposal PR. The proposal's description has been included [in the Confluence page](https://openedx.atlassian.net/wiki/spaces/OpenDev/pages/649887770/Adding+extra+information+to+certificates).

Thanks in advance for reviewing that!