### PR TITLE
Account for Django block on DDL in transactions

### DIFF
--- a/common/djangoapps/database_fixups/migrations/0001_initial.py
+++ b/common/djangoapps/database_fixups/migrations/0001_initial.py
@@ -31,5 +31,5 @@ class Migration(migrations.Migration):
     ]
 
     operations = [
-        migrations.RunPython(add_email_uniqueness_constraint)
+        migrations.RunPython(add_email_uniqueness_constraint, atomic=False)
     ]

--- a/lms/djangoapps/coursewarehistoryextended/migrations/0001_initial.py
+++ b/lms/djangoapps/coursewarehistoryextended/migrations/0001_initial.py
@@ -53,5 +53,5 @@ class Migration(migrations.Migration):
                 'get_latest_by': 'created',
             },
         ),
-        migrations.RunPython(bump_pk_start, reverse_code=migrations.RunPython.noop),
+        migrations.RunPython(bump_pk_start, reverse_code=migrations.RunPython.noop, atomic=False),
     ]


### PR DESCRIPTION
Django 1.11 by default blocks attempts to execute DDL statements in transactions on databases that don't support rolling it back properly, as this can leave the transaction in an inconsistent state.  We have a couple of existing migrations that really can't avoid doing this (and already did it under previous Django versions), so use the documented fallback of executing those queries directly via the database connection.  See the [relevant Django ticket](https://code.djangoproject.com/ticket/27631) for details.

Our tests won't exercise this (we use SQLite for them, which can roll back DDL statements).  It'll need to be tested by creating a sandbox from scratch (which is how we found the problem in the first place) using this branch.