### PR TITLE
Remove deprecated make_option from certificates management commands

### DIFF
--- a/lms/djangoapps/certificates/management/commands/cert_whitelist.py
+++ b/lms/djangoapps/certificates/management/commands/cert_whitelist.py
@@ -4,8 +4,6 @@ user/course
 """
 from __future__ import print_function
 
-from optparse import make_option
-
 from django.contrib.auth.models import User
 from django.core.management.base import BaseCommand, CommandError
 from opaque_keys.edx.keys import CourseKey
@@ -53,25 +51,28 @@ class Command(BaseCommand):
 
     """
 
-    option_list = BaseCommand.option_list + (
-        make_option('-a', '--add',
-                    metavar='USER',
-                    dest='add',
-                    default=False,
-                    help='user or list of users to add to the certificate whitelist'),
-
-        make_option('-d', '--del',
-                    metavar='USER',
-                    dest='del',
-                    default=False,
-                    help='user or list of users to remove from the certificate whitelist'),
-
-        make_option('-c', '--course-id',
-                    metavar='COURSE_ID',
-                    dest='course_id',
-                    default=False,
-                    help="course id to query"),
-    )
+    def add_arguments(self, parser):
+        parser.add_argument(
+            '-a', '--add',
+            metavar='USER',
+            dest='add',
+            default=False,
+            help='user or list of users to add to the certificate whitelist'
+        )
+        parser.add_argument(
+            '-d', '--del',
+            metavar='USER',
+            dest='del',
+            default=False,
+            help='user or list of users to remove from the certificate whitelist'
+        )
+        parser.add_argument(
+            '-c', '--course-id',
+            metavar='COURSE_ID',
+            dest='course_id',
+            default=False,
+            help="course id to query"
+        )
 
     def handle(self, *args, **options):
         course_id = options['course_id']

--- a/lms/djangoapps/certificates/management/commands/gen_cert_report.py
+++ b/lms/djangoapps/certificates/management/commands/gen_cert_report.py
@@ -2,8 +2,6 @@
 Generate a report of certificate statuses
 """
 
-from optparse import make_option
-
 from django.contrib.auth.models import User
 from django.core.management.base import BaseCommand, CommandError
 from django.db.models import Count
@@ -37,16 +35,16 @@ class Command(BaseCommand):
 
     """
 
-    option_list = BaseCommand.option_list + (
-        make_option('-c', '--course',
-                    metavar='COURSE_ID',
-                    dest='course',
-                    default=None,
-                    help='Only generate for COURSE_ID'),
-    )
+    def add_arguments(self, parser):
+        parser.add_argument(
+            '-c', '--course',
+            metavar='COURSE_ID',
+            dest='course',
+            default=None,
+            help='Only generate for COURSE_ID'
+        )
 
     def handle(self, *args, **options):
-
         # Find all courses that have ended
 
         if options['course']:

--- a/lms/djangoapps/certificates/management/commands/tests/test_cert_whitelist.py
+++ b/lms/djangoapps/certificates/management/commands/tests/test_cert_whitelist.py
@@ -1,0 +1,17 @@
+"""
+Extremely basic tests for the cert_whitelist command
+"""
+import pytest
+
+from django.core.management import call_command
+
+
+def test_cert_whitelist_help(capsys):
+    """
+    Basic test to see if the command will parse and get args
+    """
+    with pytest.raises(SystemExit):
+        call_command('cert_whitelist', '--help')
+
+    out, err = capsys.readouterr()  # pylint: disable=unused-variable
+    assert "COURSE_ID" in out

--- a/lms/djangoapps/certificates/management/commands/tests/test_gen_cert_report.py
+++ b/lms/djangoapps/certificates/management/commands/tests/test_gen_cert_report.py
@@ -1,0 +1,17 @@
+"""
+Extremely basic tests for the gen_cert_report command
+"""
+import pytest
+
+from django.core.management import call_command
+
+
+def test_cert_report_help(capsys):
+    """
+    Basic test to see if the command will parse and get args
+    """
+    with pytest.raises(SystemExit):
+        call_command('gen_cert_report', '--help')
+
+    out, err = capsys.readouterr()  # pylint: disable=unused-variable
+    assert "COURSE_ID" in out


### PR DESCRIPTION
These commands were not Django 1.11 compliant, this should fix that and add some rudimentary tests to make sure they at least can import and run help.