### PR TITLE
Fixed error: ImportError: No module named notmigrations

### DIFF
--- a/common/djangoapps/util/db.py
+++ b/common/djangoapps/util/db.py
@@ -289,4 +289,4 @@ class NoOpMigrationModules(object):
         return True
 
     def __getitem__(self, item):
-        return "notmigrations"
+        return None


### PR DESCRIPTION
#### Background:
Was facing exception on running SGA xblock on master.

```python
Traceback (most recent call last):
  File "manage.py", line 121, in <module>
    execute_from_command_line([sys.argv[0]] + django_args)
  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/django/core/management/__init__.py", line 364, in execute_from_command_line
    utility.execute()
  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/django/core/management/__init__.py", line 356, in execute
    self.fetch_command(subcommand).run_from_argv(self.argv)
  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/django/core/management/commands/test.py", line 29, in run_from_argv
    super(Command, self).run_from_argv(argv)
  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/django/core/management/base.py", line 283, in run_from_argv
    self.execute(*args, **cmd_options)
  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/django/core/management/base.py", line 330, in execute
    output = self.handle(*args, **options)
  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/django/core/management/commands/test.py", line 62, in handle
    failures = test_runner.run_tests(test_labels)
  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/django/test/runner.py", line 601, in run_tests
    old_config = self.setup_databases()
  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/django/test/runner.py", line 546, in setup_databases
    self.parallel, **kwargs
  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/django/test/utils.py", line 187, in setup_databases
    serialize=connection.settings_dict.get('TEST', {}).get('SERIALIZE', True),
  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/django/db/backends/base/creation.py", line 69, in create_test_db
    run_syncdb=True,
  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/django/core/management/__init__.py", line 131, in call_command
    return command.execute(*args, **defaults)
  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/django/core/management/base.py", line 330, in execute
    output = self.handle(*args, **options)
  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/django/core/management/commands/migrate.py", line 83, in handle
    executor = MigrationExecutor(connection, self.migration_progress_callback)
  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/django/db/migrations/executor.py", line 20, in __init__
    self.loader = MigrationLoader(self.connection)
  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/django/db/migrations/loader.py", line 52, in __init__
    self.build_graph()
  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/django/db/migrations/loader.py", line 203, in build_graph
    self.load_disk()
  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/django/db/migrations/loader.py", line 82, in load_disk
    module = import_module(module_name)
  File "/usr/lib/python2.7/importlib/__init__.py", line 37, in import_module
    __import__(name)
ImportError: No module named notmigrations
```

#### solution:
picked this solution https://stackoverflow.com/questions/46002731/upgrading-to-django-1-11-4-importerror

@pdpinch @nedbat @ormsbee 
