### PR TITLE
Double the number of bok-choy shards

### DIFF
--- a/common/test/acceptance/tests/discussion/test_discussion.py
+++ b/common/test/acceptance/tests/discussion/test_discussion.py
@@ -311,7 +311,7 @@ class DiscussionNavigationTest(BaseDiscussionTestCase):
             self.assertEqual(self.thread_page.q(css=".forum-nav-thread-title").text[0], 'dummy thread title')
 
 
-@attr(shard=2)
+@attr(shard=19)
 class DiscussionTabSingleThreadTest(BaseDiscussionTestCase, DiscussionResponsePaginationTestMixin):
     """
     Tests for the discussion page displaying a single thread

--- a/common/test/acceptance/tests/lms/test_lms.py
+++ b/common/test/acceptance/tests/lms/test_lms.py
@@ -42,7 +42,7 @@ from common.test.acceptance.tests.helpers import (
 )
 
 
-@attr(shard=8)
+@attr(shard=19)
 class ForgotPasswordPageTest(UniqueCourseTest):
     """
     Test that forgot password forms is rendered if url contains 'forgot-password-modal'
@@ -84,7 +84,7 @@ class ForgotPasswordPageTest(UniqueCourseTest):
         self.assertIn("Check Your Email", self.reset_password_page.get_success_message())
 
 
-@attr(shard=8)
+@attr(shard=19)
 class LoginFromCombinedPageTest(UniqueCourseTest):
     """Test that we can log in using the combined login/registration page.
 
@@ -277,7 +277,7 @@ class LoginFromCombinedPageTest(UniqueCourseTest):
         return (email, password)
 
 
-@attr(shard=8)
+@attr(shard=19)
 class RegisterFromCombinedPageTest(UniqueCourseTest):
     """Test that we can register a new user from the combined login/registration page. """
 
@@ -302,7 +302,7 @@ class RegisterFromCombinedPageTest(UniqueCourseTest):
         self.assertEqual(self.register_page.current_form, "login")
 
 
-@attr(shard=8)
+@attr(shard=19)
 class PayAndVerifyTest(EventsTestMixin, UniqueCourseTest):
     """Test that we can proceed through the payment and verification flow."""
     def setUp(self):

--- a/common/test/acceptance/tests/lms/test_lms_dashboard.py
+++ b/common/test/acceptance/tests/lms/test_lms_dashboard.py
@@ -141,6 +141,7 @@ class BaseLmsDashboardTestMultiple(UniqueCourseTest):
         self.dashboard_page.visit()
 
 
+@attr(shard=9)
 class LmsDashboardPageTest(BaseLmsDashboardTest):
     """ Test suite for the LMS Student Dashboard page """
 

--- a/common/test/acceptance/tests/lms/test_lms_dashboard_search.py
+++ b/common/test/acceptance/tests/lms/test_lms_dashboard_search.py
@@ -19,6 +19,8 @@ class DashboardSearchTest(AcceptanceTest):
     """
     Test dashboard search.
     """
+    shard = 7
+
     USERNAME = 'STUDENT_TESTER'
     EMAIL = 'student101@example.com'
 

--- a/common/test/acceptance/tests/lms/test_lms_edxnotes.py
+++ b/common/test/acceptance/tests/lms/test_lms_edxnotes.py
@@ -123,7 +123,7 @@ class EdxNotesTestMixin(UniqueCourseTest):
         self.edxnotes_fixture.install()
 
 
-@attr(shard=4)
+@attr(shard=18)
 class EdxNotesDefaultInteractionsTest(EdxNotesTestMixin):
     """
     Tests for creation, editing, deleting annotations inside annotatable components in LMS.

--- a/common/test/acceptance/tests/lms/test_lms_instructor_dashboard.py
+++ b/common/test/acceptance/tests/lms/test_lms_instructor_dashboard.py
@@ -113,7 +113,7 @@ class BulkEmailTest(BaseInstructorDashboardTest):
         self.send_email_page.a11y_audit.check_for_accessibility_errors()
 
 
-@attr(shard=10)
+@attr(shard=3)
 class AutoEnrollmentWithCSVTest(BaseInstructorDashboardTest):
     """
     End-to-end tests for Auto-Registration and enrollment functionality via CSV file.
@@ -982,7 +982,7 @@ class CertificatesTest(BaseInstructorDashboardTest):
         self.certificates_section.a11y_audit.check_for_accessibility_errors()
 
 
-@attr(shard=10)
+@attr(shard=20)
 class CertificateInvalidationTest(BaseInstructorDashboardTest):
     """
     Tests for Certificates functionality on instructor dashboard.
@@ -1191,7 +1191,7 @@ class CertificateInvalidationTest(BaseInstructorDashboardTest):
         self.certificates_section.a11y_audit.check_for_accessibility_errors()
 
 
-@attr(shard=10)
+@attr(shard=20)
 class EcommerceTest(BaseInstructorDashboardTest):
     """
     Bok Choy tests for the "E-Commerce" tab.

--- a/common/test/acceptance/tests/lms/test_lms_user_preview.py
+++ b/common/test/acceptance/tests/lms/test_lms_user_preview.py
@@ -17,7 +17,7 @@ from common.test.acceptance.tests.helpers import UniqueCourseTest, create_user_p
 from xmodule.partitions.partitions import ENROLLMENT_TRACK_PARTITION_ID, MINIMUM_STATIC_PARTITION_ID, Group
 
 
-@attr(shard=10)
+@attr(shard=20)
 class StaffViewTest(UniqueCourseTest):
     """
     Tests that verify the staff view.
@@ -55,7 +55,7 @@ class StaffViewTest(UniqueCourseTest):
         return staff_page
 
 
-@attr(shard=10)
+@attr(shard=20)
 class CourseWithoutContentGroupsTest(StaffViewTest):
     """
     Setup for tests that have no content restricted to specific content groups.
@@ -86,7 +86,7 @@ class CourseWithoutContentGroupsTest(StaffViewTest):
         )
 
 
-@attr(shard=10)
+@attr(shard=20)
 class StaffViewToggleTest(CourseWithoutContentGroupsTest):
     """
     Tests for the staff view toggle button.
@@ -103,7 +103,7 @@ class StaffViewToggleTest(CourseWithoutContentGroupsTest):
         self.assertFalse(course_page.has_tab('Instructor'))
 
 
-@attr(shard=10)
+@attr(shard=20)
 class StaffDebugTest(CourseWithoutContentGroupsTest):
     """
     Tests that verify the staff debug info.
@@ -324,7 +324,7 @@ class CourseWithContentGroupsTest(StaffViewTest):
             )
         )
 
-    @attr(shard=10)
+    @attr(shard=20)
     def test_staff_sees_all_problems(self):
         """
         Scenario: Staff see all problems

--- a/common/test/acceptance/tests/lms/test_problem_types.py
+++ b/common/test/acceptance/tests/lms/test_problem_types.py
@@ -167,7 +167,7 @@ class ProblemTypeTestMixin(ProblemTypeA11yTestMixin):
     can_submit_blank = False
     can_update_save_notification = True
 
-    @attr(shard=7)
+    @attr(shard=11)
     def test_answer_correctly(self):
         """
         Scenario: I can answer a problem correctly
@@ -212,7 +212,7 @@ class ProblemTypeTestMixin(ProblemTypeA11yTestMixin):
         for event in expected_events:
             self.wait_for_events(event_filter=event, number_of_matches=1)
 
-    @attr(shard=7)
+    @attr(shard=11)
     def test_answer_incorrectly(self):
         """
         Scenario: I can answer a problem incorrectly
@@ -233,7 +233,7 @@ class ProblemTypeTestMixin(ProblemTypeA11yTestMixin):
         self.wait_for_status('incorrect')
         self.problem_page.wait_incorrect_notification()
 
-    @attr(shard=7)
+    @attr(shard=11)
     def test_submit_blank_answer(self):
         """
         Scenario: I can submit a blank answer
@@ -255,7 +255,7 @@ class ProblemTypeTestMixin(ProblemTypeA11yTestMixin):
         self.problem_page.click_submit()
         self.wait_for_status('incorrect')
 
-    @attr(shard=7)
+    @attr(shard=11)
     def test_cant_submit_blank_answer(self):
         """
         Scenario: I can't submit a blank answer
@@ -271,7 +271,7 @@ class ProblemTypeTestMixin(ProblemTypeA11yTestMixin):
         )
         self.assertTrue(self.problem_page.is_submit_disabled())
 
-    @attr(shard=7)
+    @attr(shard=12)
     def test_can_show_answer(self):
         """
         Scenario: Verifies that show answer button is working as expected.
@@ -285,7 +285,7 @@ class ProblemTypeTestMixin(ProblemTypeA11yTestMixin):
         self.problem_page.click_show()
         self.problem_page.wait_for_show_answer_notification()
 
-    @attr(shard=7)
+    @attr(shard=12)
     def test_save_reaction(self):
         """
         Scenario: Verify that the save button performs as expected with problem types
@@ -319,7 +319,7 @@ class ProblemTypeTestMixin(ProblemTypeA11yTestMixin):
             self.answer_problem(correctness='incorrect')
             self.assertFalse(self.problem_page.is_save_notification_visible())
 
-    @attr(shard=7)
+    @attr(shard=12)
     def test_reset_clears_answer_and_focus(self):
         """
         Scenario: Reset will clear answers and focus on problem meta
@@ -344,7 +344,7 @@ class ProblemTypeTestMixin(ProblemTypeA11yTestMixin):
         # Answer should be reset
         self.wait_for_status('unanswered')
 
-    @attr(shard=7)
+    @attr(shard=12)
     def test_reset_shows_errors(self):
         """
         Scenario: Reset will show server errors
@@ -362,7 +362,7 @@ class ProblemTypeTestMixin(ProblemTypeA11yTestMixin):
         self.problem_page.click_reset()
         self.problem_page.wait_for_gentle_alert_notification()
 
-    @attr(shard=7)
+    @attr(shard=12)
     def test_partially_complete_notifications(self):
         """
         Scenario: If a partially correct problem is submitted the correct notification is shown
@@ -571,7 +571,6 @@ class CheckboxProblemTypeTest(CheckboxProblemTypeBase, ProblemTypeTestMixin):
     """
     Standard tests for the Checkbox Problem Type
     """
-    @attr(shard=7)
     def test_can_show_answer(self):
         """
         Scenario: Verifies that show answer button is working as expected.
@@ -632,7 +631,6 @@ class MultipleChoiceProblemTypeTest(MultipleChoiceProblemTypeBase, ProblemTypeTe
     """
     Standard tests for the Multiple Choice Problem Type
     """
-    @attr(shard=7)
     def test_can_show_answer(self):
         """
         Scenario: Verifies that show answer button is working as expected.
@@ -847,6 +845,7 @@ class NumericalProblemTypeTest(NumericalProblemTypeBase, ProblemTypeTestMixin):
     """
     Standard tests for the Numerical Problem Type
     """
+    @attr(shard=12)
     def test_error_input_gentle_alert(self):
         """
         Scenario: I can answer a problem with erroneous input and will see a gentle alert
@@ -1058,6 +1057,7 @@ class CodeProblemTypeTest(CodeProblemTypeBase, ProblemTypeTestMixin):
     """
     Standard tests for the Code Problem Type
     """
+    @attr(shard=12)
     def test_answer_incorrectly(self):
         """
         Overridden for script test because the testing grader always responds
@@ -1065,6 +1065,7 @@ class CodeProblemTypeTest(CodeProblemTypeBase, ProblemTypeTestMixin):
         """
         pass
 
+    @attr(shard=12)
     def test_submit_blank_answer(self):
         """
         Overridden for script test because the testing grader always responds
@@ -1072,6 +1073,7 @@ class CodeProblemTypeTest(CodeProblemTypeBase, ProblemTypeTestMixin):
         """
         pass
 
+    @attr(shard=12)
     def test_cant_submit_blank_answer(self):
         """
         Overridden for script test because the testing grader always responds
@@ -1079,6 +1081,7 @@ class CodeProblemTypeTest(CodeProblemTypeBase, ProblemTypeTestMixin):
         """
         pass
 
+    @attr(shard=12)
     def wait_for_status(self, status):
         """
         Overridden for script test because the testing grader always responds

--- a/common/test/acceptance/tests/lms/test_programs.py
+++ b/common/test/acceptance/tests/lms/test_programs.py
@@ -62,6 +62,7 @@ class ProgramPageBase(ProgramsConfigMixin, CatalogIntegrationMixin, UniqueCourse
         cache_programs_page.visit()
 
 
+@attr(shard=21)
 class ProgramListingPageTest(ProgramPageBase):
     """Verify user-facing behavior of the program listing page."""
     def setUp(self):

--- a/common/test/acceptance/tests/lms/test_progress_page.py
+++ b/common/test/acceptance/tests/lms/test_progress_page.py
@@ -127,7 +127,7 @@ class ProgressPageBaseTest(UniqueCourseTest):
             self.logout_page.visit()
 
 
-@attr(shard=9)
+@attr(shard=22)
 @ddt.ddt
 class PersistentGradesTest(ProgressPageBaseTest):
     """
@@ -275,7 +275,7 @@ class PersistentGradesTest(ProgressPageBaseTest):
             self.assertEqual(self._get_section_score(), (0, 2))
 
 
-@attr(shard=9)
+@attr(shard=22)
 class SubsectionGradingPolicyTest(ProgressPageBaseTest):
     """
     Tests changing a subsection's 'graded' field

--- a/common/test/acceptance/tests/lms/test_teams.py
+++ b/common/test/acceptance/tests/lms/test_teams.py
@@ -887,7 +887,6 @@ class BrowseTeamsWithinTopicTest(TeamsTabBase):
             alert.accept()
 
 
-@attr(shard=5)
 class TeamFormActions(TeamsTabBase):
     """
     Base class for create, edit, and delete team.
@@ -986,6 +985,7 @@ class TeamFormActions(TeamsTabBase):
         )
 
 
+@attr(shard=5)
 @ddt.ddt
 class CreateTeamTest(TeamFormActions):
     """
@@ -1180,6 +1180,7 @@ class CreateTeamTest(TeamFormActions):
             self.verify_and_navigate_to_create_team_page()
 
 
+@attr(shard=21)
 @ddt.ddt
 class DeleteTeamTest(TeamFormActions):
     """
@@ -1303,6 +1304,7 @@ class DeleteTeamTest(TeamFormActions):
         self.teams_page.verify_topic_team_count(0)
 
 
+@attr(shard=17)
 @ddt.ddt
 class EditTeamTest(TeamFormActions):
     """
@@ -1519,6 +1521,7 @@ class EditTeamTest(TeamFormActions):
             self.verify_and_navigate_to_edit_team_page()
 
 
+@attr(shard=17)
 @ddt.ddt
 class EditMembershipTest(TeamFormActions):
     """
@@ -1620,7 +1623,7 @@ class EditMembershipTest(TeamFormActions):
         self.edit_membership_helper(role, cancel=True)
 
 
-@attr(shard=5)
+@attr(shard=17)
 @ddt.ddt
 class TeamPageTest(TeamsTabBase):
     """Tests for viewing a specific team"""

--- a/common/test/acceptance/tests/lms/test_unicode_username_admin.py
+++ b/common/test/acceptance/tests/lms/test_unicode_username_admin.py
@@ -12,6 +12,7 @@ class UnicodeUsernameAdminTest(AcceptanceTest):
     """
     Tests if it is possible to update users with unicode usernames in the admin.
     """
+    shard = 21
 
     # The word below reads "Omar II", in Arabic. It also contains a space and
     # an Eastern Arabic Number another option is to use the Esperanto fake

--- a/common/test/acceptance/tests/studio/test_studio_accessibility_form.py
+++ b/common/test/acceptance/tests/studio/test_studio_accessibility_form.py
@@ -12,6 +12,7 @@ class AccessibilityPageTest(AcceptanceTest):
     """
     Test that a user can access the page and submit studio accessibility feedback.
     """
+    shard = 21
 
     def setUp(self):
         """

--- a/common/test/acceptance/tests/studio/test_studio_acid_xblock.py
+++ b/common/test/acceptance/tests/studio/test_studio_acid_xblock.py
@@ -12,6 +12,7 @@ class XBlockAcidBase(AcceptanceTest):
     """
     Base class for tests that verify that XBlock integration is working correctly
     """
+    shard = 21
     __test__ = False
 
     def setUp(self):

--- a/common/test/acceptance/tests/studio/test_studio_asset.py
+++ b/common/test/acceptance/tests/studio/test_studio_asset.py
@@ -10,6 +10,7 @@ from common.test.acceptance.pages.studio.asset_index import UPLOAD_FILE_DIR
 
 class AssetIndexTestStudioFrontend(StudioCourseTest):
     """Tests for the Asset index page."""
+    shard = 21
 
     def setUp(self, is_staff=False):  # pylint: disable=arguments-differ
         super(AssetIndexTestStudioFrontend, self).setUp()

--- a/common/test/acceptance/tests/studio/test_studio_bad_data.py
+++ b/common/test/acceptance/tests/studio/test_studio_bad_data.py
@@ -1,3 +1,6 @@
+"""
+Acceptance tests that ensure components with bad content do not break page.
+"""
 from base_studio_test import ContainerBase
 from common.test.acceptance.fixtures.course import XBlockFixtureDesc
 from common.test.acceptance.pages.studio.utils import verify_ordering
@@ -7,6 +10,7 @@ class BadComponentTest(ContainerBase):
     """
     Tests that components with bad content do not break the Unit page.
     """
+    shard = 21
     __test__ = False
 
     def get_bad_html_content(self):

--- a/common/test/acceptance/tests/studio/test_studio_components.py
+++ b/common/test/acceptance/tests/studio/test_studio_components.py
@@ -11,7 +11,7 @@ from common.test.acceptance.pages.studio.utils import add_component, add_compone
 from common.test.acceptance.tests.studio.base_studio_test import ContainerBase
 
 
-@attr(shard=9)
+@attr(shard=22)
 @ddt.ddt
 class AdvancedProblemComponentTest(ContainerBase):
     """
@@ -70,7 +70,7 @@ class AdvancedProblemComponentTest(ContainerBase):
         self.assertEqual(problem.name, component)
 
 
-@attr(shard=9)
+@attr(shard=22)
 class ComponentTest(ContainerBase):
     """
     Test class to add different components.

--- a/common/test/acceptance/tests/studio/test_studio_container.py
+++ b/common/test/acceptance/tests/studio/test_studio_container.py
@@ -181,7 +181,7 @@ class DeleteComponentTest(NestedVerticalTest):
         self.delete_and_verify(group_a_item_1_delete_index, expected_ordering)
 
 
-@attr(shard=1)
+@attr(shard=16)
 class EditContainerTest(NestedVerticalTest):
     """
     Tests of editing a container.
@@ -414,7 +414,11 @@ class BaseGroupConfigurationsTest(ContainerBase):
         self.assertFalse(component.has_validation_error)
 
 
+@attr(shard=21)
 class UnitAccessContainerTest(BaseGroupConfigurationsTest):
+    """
+    Tests unit level access
+    """
     GROUP_RESTRICTED_MESSAGE = 'Access to this unit is restricted to: Dogs'
 
     def _toggle_container_unit_access(self, group_ids, unit):
@@ -467,7 +471,7 @@ class UnitAccessContainerTest(BaseGroupConfigurationsTest):
         self._verify_container_unit_access_message([self.id_base + 1], self.GROUP_RESTRICTED_MESSAGE)
 
 
-@attr(shard=3)
+@attr(shard=9)
 class ContentGroupVisibilityModalTest(BaseGroupConfigurationsTest):
     """
     Tests of the visibility settings modal for components on the unit
@@ -698,7 +702,7 @@ class EnrollmentTrackVisibilityModalTest(BaseGroupConfigurationsTest):
         self.verify_component_group_visibility_messsage(self.html_component, "Audit Track")
 
 
-@attr(shard=1)
+@attr(shard=16)
 class UnitPublishingTest(ContainerBase):
     """
     Tests of the publishing control and related widgets on the Unit page.
@@ -1228,7 +1232,7 @@ class ProblemCategoryTabsTest(ContainerBase):
         self.assertEqual(page.get_category_tab_components('problem', 1), expected_components)
 
 
-@attr(shard=1)
+@attr(shard=16)
 @ddt.ddt
 class MoveComponentTest(ContainerBase):
     """

--- a/common/test/acceptance/tests/studio/test_studio_course_create.py
+++ b/common/test/acceptance/tests/studio/test_studio_course_create.py
@@ -11,7 +11,7 @@ from common.test.acceptance.pages.studio.overview import CourseOutlinePage
 from common.test.acceptance.tests.helpers import AcceptanceTest
 
 
-@attr(shard=8)
+@attr(shard=19)
 class CreateCourseTest(AcceptanceTest):
     """
     Test that we can create a new course the studio home page.

--- a/common/test/acceptance/tests/studio/test_studio_course_info.py
+++ b/common/test/acceptance/tests/studio/test_studio_course_info.py
@@ -12,6 +12,7 @@ class UsersCanAddUpdatesTest(StudioCourseTest):
     """
     Series of Bok Choy Tests to test the Course Updates page
     """
+    shard = 21
 
     def _create_and_verify_update(self, message):
         """

--- a/common/test/acceptance/tests/studio/test_studio_general.py
+++ b/common/test/acceptance/tests/studio/test_studio_general.py
@@ -26,6 +26,8 @@ class LoggedOutTest(AcceptanceTest):
     """
     Smoke test for pages in Studio that are visible when logged out.
     """
+    shard = 21
+
     def setUp(self):
         super(LoggedOutTest, self).setUp()
         self.pages = [LoginPage(self.browser), IndexPage(self.browser), SignupPage(self.browser),
@@ -45,6 +47,8 @@ class LoggedInPagesTest(AcceptanceTest):
     """
     Verify the pages in Studio that you can get to when logged in and do not have a course yet.
     """
+    shard = 21
+
     def setUp(self):
         super(LoggedInPagesTest, self).setUp()
         self.auth_page = AutoAuthPage(self.browser, staff=True)
@@ -64,6 +68,8 @@ class SignUpAndSignInTest(UniqueCourseTest):
     """
     Test studio sign-up and sign-in
     """
+    shard = 21
+
     def setUp(self):  # pylint: disable=arguments-differ
         super(SignUpAndSignInTest, self).setUp()
         self.sign_up_page = SignupPage(self.browser)
@@ -215,7 +221,7 @@ class CoursePagesTest(StudioCourseTest):
     Tests that verify the pages in Studio that you can get to when logged
     in and have a course.
     """
-
+    shard = 21
     COURSE_ID_SEPARATOR = "."
 
     def setUp(self):
@@ -267,6 +273,7 @@ class DiscussionPreviewTest(StudioCourseTest):
     """
     Tests that Inline Discussions are rendered with a custom preview in Studio
     """
+    shard = 21
 
     def setUp(self):
         super(DiscussionPreviewTest, self).setUp()

--- a/common/test/acceptance/tests/studio/test_studio_help.py
+++ b/common/test/acceptance/tests/studio/test_studio_help.py
@@ -44,7 +44,7 @@ def _get_expected_documentation_url(path):
     return url_for_help('course_author', path)
 
 
-@attr(shard=10)
+@attr(shard=20)
 class StudioHelpTest(StudioCourseTest):
     """Tests for Studio help."""
 
@@ -84,7 +84,7 @@ class StudioHelpTest(StudioCourseTest):
             )
 
 
-@attr(shard=10)
+@attr(shard=20)
 class SignInHelpTest(AcceptanceTest):
     """
     Tests help links on 'Sign In' page
@@ -115,7 +115,7 @@ class SignInHelpTest(AcceptanceTest):
         )
 
 
-@attr(shard=10)
+@attr(shard=20)
 class SignUpHelpTest(AcceptanceTest):
     """
     Tests help links on 'Sign Up' page.
@@ -146,7 +146,7 @@ class SignUpHelpTest(AcceptanceTest):
         )
 
 
-@attr(shard=10)
+@attr(shard=20)
 class HomeHelpTest(StudioCourseTest):
     """
     Tests help links on 'Home'(Courses tab) page.
@@ -195,7 +195,7 @@ class HomeHelpTest(StudioCourseTest):
         )
 
 
-@attr(shard=10)
+@attr(shard=20)
 class NewCourseHelpTest(AcceptanceTest):
     """
     Test help links while creating a new course.
@@ -248,7 +248,7 @@ class NewCourseHelpTest(AcceptanceTest):
         )
 
 
-@attr(shard=10)
+@attr(shard=20)
 class NewLibraryHelpTest(AcceptanceTest):
     """
     Test help links while creating a new library
@@ -301,7 +301,7 @@ class NewLibraryHelpTest(AcceptanceTest):
         )
 
 
-@attr(shard=10)
+@attr(shard=20)
 class LibraryTabHelpTest(AcceptanceTest):
     """
     Test help links on the library tab present at dashboard.
@@ -334,7 +334,7 @@ class LibraryTabHelpTest(AcceptanceTest):
         )
 
 
-@attr(shard=10)
+@attr(shard=20)
 class LibraryHelpTest(StudioLibraryTest):
     """
     Test help links on a Library page.
@@ -408,7 +408,7 @@ class LibraryHelpTest(StudioLibraryTest):
         )
 
 
-@attr(shard=10)
+@attr(shard=20)
 class LibraryImportHelpTest(StudioLibraryTest):
     """
     Test help links on a Library import and export pages.
@@ -456,7 +456,7 @@ class LibraryImportHelpTest(StudioLibraryTest):
         )
 
 
-@attr(shard=10)
+@attr(shard=20)
 class LibraryExportHelpTest(StudioLibraryTest):
     """
     Test help links on a Library export pages.
@@ -504,7 +504,7 @@ class LibraryExportHelpTest(StudioLibraryTest):
         )
 
 
-@attr(shard=10)
+@attr(shard=20)
 class CourseOutlineHelpTest(StudioCourseTest):
     """
     Tests help links on course outline page.
@@ -559,7 +559,7 @@ class CourseOutlineHelpTest(StudioCourseTest):
         )
 
 
-@attr(shard=10)
+@attr(shard=20)
 class CourseUpdateHelpTest(StudioCourseTest):
     """
     Test help links on Course Update page
@@ -593,7 +593,7 @@ class CourseUpdateHelpTest(StudioCourseTest):
         )
 
 
-@attr(shard=10)
+@attr(shard=20)
 class AssetIndexHelpTest(StudioCourseTest):
     """
     Test help links on Course 'Files & Uploads' page
@@ -627,7 +627,7 @@ class AssetIndexHelpTest(StudioCourseTest):
         )
 
 
-@attr(shard=10)
+@attr(shard=20)
 class CoursePagesHelpTest(StudioCourseTest):
     """
     Test help links on Course 'Pages' page
@@ -661,7 +661,7 @@ class CoursePagesHelpTest(StudioCourseTest):
         )
 
 
-@attr(shard=10)
+@attr(shard=20)
 class UploadTextbookHelpTest(StudioCourseTest):
     """
     Test help links on Course 'Textbooks' page
@@ -714,7 +714,7 @@ class UploadTextbookHelpTest(StudioCourseTest):
         )
 
 
-@attr(shard=10)
+@attr(shard=20)
 class StudioUnitHelpTest(ContainerBase):
     """
     Tests help links on Unit page.
@@ -763,7 +763,7 @@ class StudioUnitHelpTest(ContainerBase):
         )
 
 
-@attr(shard=10)
+@attr(shard=20)
 class SettingsHelpTest(StudioCourseTest):
     """
     Tests help links on Schedule and Details Settings page
@@ -799,7 +799,7 @@ class SettingsHelpTest(StudioCourseTest):
         )
 
 
-@attr(shard=10)
+@attr(shard=20)
 class GradingPageHelpTest(StudioCourseTest):
     """
     Tests help links on Grading page
@@ -835,7 +835,7 @@ class GradingPageHelpTest(StudioCourseTest):
         )
 
 
-@attr(shard=10)
+@attr(shard=20)
 class CourseTeamSettingsHelpTest(StudioCourseTest):
     """
     Tests help links on Course Team settings page
@@ -871,7 +871,7 @@ class CourseTeamSettingsHelpTest(StudioCourseTest):
         )
 
 
-@attr(shard=10)
+@attr(shard=20)
 class CourseGroupConfigurationHelpTest(StudioCourseTest):
     """
     Tests help links on course Group Configurations settings page
@@ -928,7 +928,7 @@ class CourseGroupConfigurationHelpTest(StudioCourseTest):
         )
 
 
-@attr(shard=10)
+@attr(shard=20)
 class AdvancedSettingHelpTest(StudioCourseTest):
     """
     Tests help links on course Advanced Settings page.
@@ -964,7 +964,7 @@ class AdvancedSettingHelpTest(StudioCourseTest):
         )
 
 
-@attr(shard=10)
+@attr(shard=20)
 class CertificatePageHelpTest(StudioCourseTest):
     """
     Tests help links on course Certificate settings page.
@@ -1019,7 +1019,7 @@ class CertificatePageHelpTest(StudioCourseTest):
         )
 
 
-@attr(shard=10)
+@attr(shard=20)
 class GroupExperimentConfigurationHelpTest(ContainerBase):
     """
     Tests help links on course Group Configurations settings page
@@ -1072,7 +1072,7 @@ class GroupExperimentConfigurationHelpTest(ContainerBase):
         )
 
 
-@attr(shard=10)
+@attr(shard=20)
 class ToolsImportHelpTest(StudioCourseTest):
     """
     Tests help links on tools import pages.
@@ -1127,7 +1127,7 @@ class ToolsImportHelpTest(StudioCourseTest):
         )
 
 
-@attr(shard=10)
+@attr(shard=20)
 class ToolsExportHelpTest(StudioCourseTest):
     """
     Tests help links on tools export pages.
@@ -1182,7 +1182,7 @@ class ToolsExportHelpTest(StudioCourseTest):
         )
 
 
-@attr(shard=10)
+@attr(shard=20)
 class StudioWelcomeHelpTest(AcceptanceTest):
     """
     Tests help link on 'Welcome' page ( User not logged in)

--- a/common/test/acceptance/tests/studio/test_studio_home.py
+++ b/common/test/acceptance/tests/studio/test_studio_home.py
@@ -32,6 +32,8 @@ class CreateLibraryTest(AcceptanceTest):
 
 class StudioLanguageTest(AcceptanceTest):
     """ Test suite for the Studio Language """
+    shard = 21
+
     def setUp(self):
         super(StudioLanguageTest, self).setUp()
         self.dashboard_page = DashboardPage(self.browser)

--- a/common/test/acceptance/tests/studio/test_studio_library.py
+++ b/common/test/acceptance/tests/studio/test_studio_library.py
@@ -12,7 +12,7 @@ from common.test.acceptance.pages.studio.utils import add_component
 from common.test.acceptance.tests.studio.base_studio_test import StudioLibraryTest
 
 
-@attr(shard=2)
+@attr(shard=15)
 @ddt
 class LibraryEditPageTest(StudioLibraryTest):
     """
@@ -184,7 +184,7 @@ class LibraryEditPageTest(StudioLibraryTest):
         self.assertIn("Checkboxes", problem_block.name)
 
 
-@attr(shard=2)
+@attr(shard=15)
 @ddt
 class LibraryNavigationTest(StudioLibraryTest):
     """
@@ -500,6 +500,7 @@ class LibraryNavigationTest(StudioLibraryTest):
         self.assertFalse(target_block.is_placeholder())
 
 
+@attr(shard=21)
 class LibraryUsersPageTest(StudioLibraryTest):
     """
     Test the functionality of the library "Instructor Access" page.

--- a/common/test/acceptance/tests/studio/test_studio_library_container.py
+++ b/common/test/acceptance/tests/studio/test_studio_library_container.py
@@ -17,7 +17,7 @@ SUBSECTION_NAME = 'Test Subsection'
 UNIT_NAME = 'Test Unit'
 
 
-@attr(shard=5)
+@attr(shard=17)
 @ddt.ddt
 class StudioLibraryContainerTest(StudioLibraryTest, UniqueCourseTest, TestWithSearchIndexMixin):
     """

--- a/common/test/acceptance/tests/studio/test_studio_outline.py
+++ b/common/test/acceptance/tests/studio/test_studio_outline.py
@@ -603,7 +603,7 @@ class UnitAccessTest(CourseOutlineTest):
         self.assertEqual(course_home_page.outline.num_units, 2)
 
 
-@attr(shard=3)
+@attr(shard=14)
 class StaffLockTest(CourseOutlineTest):
     """
     Feature: Sections, subsections, and units can be locked and unlocked from the course outline.
@@ -946,7 +946,7 @@ class StaffLockTest(CourseOutlineTest):
         self._remove_staff_lock_and_verify_warning(subsection, False)
 
 
-@attr(shard=3)
+@attr(shard=14)
 class EditNamesTest(CourseOutlineTest):
     """
     Feature: Click-to-edit section/subsection names
@@ -1062,7 +1062,7 @@ class EditNamesTest(CourseOutlineTest):
         self.assertTrue(self.course_outline_page.section_at(0).is_collapsed)
 
 
-@attr(shard=3)
+@attr(shard=14)
 class CreateSectionsTest(CourseOutlineTest):
     """
     Feature: Create new sections/subsections/units
@@ -1149,7 +1149,7 @@ class CreateSectionsTest(CourseOutlineTest):
         self.assertTrue(unit_page.is_inline_editing_display_name())
 
 
-@attr(shard=3)
+@attr(shard=14)
 class DeleteContentTest(CourseOutlineTest):
     """
     Feature: Deleting sections/subsections/units
@@ -1261,7 +1261,7 @@ class DeleteContentTest(CourseOutlineTest):
         self.assertTrue(self.course_outline_page.has_no_content_message)
 
 
-@attr(shard=3)
+@attr(shard=14)
 class ExpandCollapseMultipleSectionsTest(CourseOutlineTest):
     """
     Feature: Courses with multiple sections can expand and collapse all sections.
@@ -1397,7 +1397,7 @@ class ExpandCollapseMultipleSectionsTest(CourseOutlineTest):
         self.verify_all_sections(collapsed=False)
 
 
-@attr(shard=3)
+@attr(shard=14)
 class ExpandCollapseSingleSectionTest(CourseOutlineTest):
     """
     Feature: Courses with a single section can expand and collapse all sections.
@@ -1437,7 +1437,7 @@ class ExpandCollapseSingleSectionTest(CourseOutlineTest):
         self.assertFalse(self.course_outline_page.section_at(0).subsection_at(1).is_collapsed)
 
 
-@attr(shard=3)
+@attr(shard=14)
 class ExpandCollapseEmptyTest(CourseOutlineTest):
     """
     Feature: Courses with no sections initially can expand and collapse all sections after addition.
@@ -1475,7 +1475,7 @@ class ExpandCollapseEmptyTest(CourseOutlineTest):
         self.assertFalse(self.course_outline_page.section_at(0).is_collapsed)
 
 
-@attr(shard=3)
+@attr(shard=14)
 class DefaultStatesEmptyTest(CourseOutlineTest):
     """
     Feature: Misc course outline default states/actions when starting with an empty course
@@ -1500,7 +1500,7 @@ class DefaultStatesEmptyTest(CourseOutlineTest):
         self.assertTrue(self.course_outline_page.bottom_add_section_button.is_present())
 
 
-@attr(shard=3)
+@attr(shard=14)
 class DefaultStatesContentTest(CourseOutlineTest):
     """
     Feature: Misc course outline default states/actions when starting with a course with content
@@ -1525,7 +1525,7 @@ class DefaultStatesContentTest(CourseOutlineTest):
         self.assertEqual(courseware.xblock_component_type(2), 'discussion')
 
 
-@attr(shard=3)
+@attr(shard=7)
 class UnitNavigationTest(CourseOutlineTest):
     """
     Feature: Navigate to units
@@ -1546,7 +1546,7 @@ class UnitNavigationTest(CourseOutlineTest):
         unit.wait_for_page()
 
 
-@attr(shard=3)
+@attr(shard=7)
 class PublishSectionTest(CourseOutlineTest):
     """
     Feature: Publish sections.
@@ -1673,7 +1673,7 @@ class PublishSectionTest(CourseOutlineTest):
         return (section, subsection, unit)
 
 
-@attr(shard=3)
+@attr(shard=7)
 class DeprecationWarningMessageTest(CourseOutlineTest):
     """
     Feature: Verify deprecation warning message.

--- a/common/test/acceptance/tests/studio/test_studio_rerun.py
+++ b/common/test/acceptance/tests/studio/test_studio_rerun.py
@@ -19,7 +19,7 @@ class CourseRerunTest(StudioCourseTest):
     """
     Feature: Courses can be rerun
     """
-
+    shard = 21
     __test__ = True
 
     SECTION_NAME = 'Rerun Section'

--- a/common/test/acceptance/tests/studio/test_studio_settings.py
+++ b/common/test/acceptance/tests/studio/test_studio_settings.py
@@ -24,7 +24,7 @@ from common.test.acceptance.tests.helpers import create_user_partition_json, ele
 from xmodule.partitions.partitions import Group
 
 
-@attr(shard=8)
+@attr(shard=19)
 class ContentGroupConfigurationTest(StudioCourseTest):
     """
     Tests for content groups in the Group Configurations Page.
@@ -233,8 +233,11 @@ class ContentGroupConfigurationTest(StudioCourseTest):
         self.outline_page.wait_for_page()
 
 
-@attr(shard=5)
+@attr(shard=17)
 class EnrollmentTrackModeTest(StudioCourseTest):
+    """
+    Tests for the enrollment tracks section
+    """
 
     def setUp(self, is_staff=True, test_xss=True):
         super(EnrollmentTrackModeTest, self).setUp(is_staff=is_staff)
@@ -283,7 +286,7 @@ class EnrollmentTrackModeTest(StudioCourseTest):
         self.assertEqual(len(groups), 0)
 
 
-@attr(shard=8)
+@attr(shard=19)
 class AdvancedSettingsValidationTest(StudioCourseTest):
     """
     Tests for validation feature in Studio's advanced settings tab
@@ -455,7 +458,7 @@ class AdvancedSettingsValidationTest(StudioCourseTest):
         self.assertEquals(set(displayed_fields), set(expected_fields))
 
 
-@attr(shard=1)
+@attr(shard=16)
 class ContentLicenseTest(StudioCourseTest):
     """
     Tests for course-level licensing (that is, setting the license,
@@ -617,7 +620,7 @@ class StudioSubsectionSettingsA11yTest(StudioCourseTest):
         self.course_outline.a11y_audit.check_for_accessibility_errors()
 
 
-@attr(shard=1)
+@attr(shard=16)
 class StudioSettingsImageUploadTest(StudioCourseTest):
     """
     Class to test course settings image uploads.
@@ -655,7 +658,7 @@ class StudioSettingsImageUploadTest(StudioCourseTest):
         self.assertIn(file_to_upload, self.settings_page.get_uploaded_image_path('#video-thumbnail-image'))
 
 
-@attr(shard=1)
+@attr(shard=16)
 class CourseSettingsTest(StudioCourseTest):
     """
     Class to test course settings.

--- a/common/test/acceptance/tests/studio/test_studio_settings_certificates.py
+++ b/common/test/acceptance/tests/studio/test_studio_settings_certificates.py
@@ -12,7 +12,7 @@ from common.test.acceptance.tests.helpers import skip_if_browser
 from common.test.acceptance.tests.studio.base_studio_test import StudioCourseTest
 
 
-@attr(shard=8)
+@attr(shard=22)
 class CertificatesTest(StudioCourseTest):
     """
     Tests for settings/certificates Page.

--- a/common/test/acceptance/tests/studio/test_studio_split_test.py
+++ b/common/test/acceptance/tests/studio/test_studio_split_test.py
@@ -62,7 +62,7 @@ class SplitTestMixin(object):
         Promise(missing_groups_button_not_present, "Add missing groups button should not be showing.").fulfill()
 
 
-@attr(shard=2)
+@attr(shard=15)
 class SplitTest(ContainerBase, SplitTestMixin):
     """
     Tests for creating and editing split test instances in Studio.
@@ -177,7 +177,7 @@ class SplitTest(ContainerBase, SplitTestMixin):
         self.verify_groups(container, ['alpha'], [], verify_missing_groups_not_present=False)
 
 
-@attr(shard=2)
+@attr(shard=15)
 class GroupConfigurationsNoSplitTest(StudioCourseTest):
     """
     Tests how the Group Configuration page should look when the split_test module is not enabled.
@@ -202,7 +202,7 @@ class GroupConfigurationsNoSplitTest(StudioCourseTest):
         self.assertFalse(self.group_configurations_page.experiment_group_sections_present)
 
 
-@attr(shard=2)
+@attr(shard=15)
 class GroupConfigurationsTest(ContainerBase, SplitTestMixin):
     """
     Tests that Group Configurations page works correctly with previously

--- a/common/test/acceptance/tests/studio/test_studio_textbooks.py
+++ b/common/test/acceptance/tests/studio/test_studio_textbooks.py
@@ -29,7 +29,7 @@ class TextbooksTest(StudioCourseTest):
 
         self.textbook_view_page = TextbookViewPage(self.browser, self.course_id)
 
-    @attr(shard=2)
+    @attr(shard=9)
     def test_create_first_book_message(self):
         """
         Scenario: A message is displayed on the textbooks page when there are no uploaded textbooks
@@ -40,7 +40,7 @@ class TextbooksTest(StudioCourseTest):
         message = self.textbook_upload_page.get_element_text('.wrapper-content .no-textbook-content')
         self.assertIn("You haven't added any textbooks", message)
 
-    @attr(shard=2)
+    @attr(shard=9)
     def test_new_textbook_upload(self):
         """
         Scenario: View Live link for textbook is correctly populated

--- a/common/test/acceptance/tests/video/test_studio_video_module.py
+++ b/common/test/acceptance/tests/video/test_studio_video_module.py
@@ -162,7 +162,7 @@ class CMSVideoBaseTest(UniqueCourseTest):
         self.unit_page.xblocks[1].save_settings()
 
 
-@attr(shard=4)
+@attr(shard=13)
 class CMSVideoTest(CMSVideoBaseTest):
     """
     CMS Video Test Class

--- a/common/test/acceptance/tests/video/test_studio_video_transcript.py
+++ b/common/test/acceptance/tests/video/test_studio_video_transcript.py
@@ -23,7 +23,7 @@ from nose.plugins.attrib import attr
 from common.test.acceptance.tests.video.test_studio_video_module import CMSVideoBaseTest
 
 
-@attr(shard=6)
+@attr(shard=18)
 class VideoTranscriptTest(CMSVideoBaseTest):
     """
     CMS Video Transcript Test Class

--- a/common/test/acceptance/tests/video/test_video_events.py
+++ b/common/test/acceptance/tests/video/test_video_events.py
@@ -58,6 +58,7 @@ class VideoEventsTestMixin(EventsTestMixin, VideoBaseTest):
         )
 
 
+@attr(shard=21)
 class VideoEventsTest(VideoEventsTestMixin):
     """ Test video player event emission """
 
@@ -188,7 +189,7 @@ class VideoHLSEventsTest(VideoEventsTestMixin):
         self.assert_events_match(expected_events, captured_events)
 
 
-@attr(shard=8)
+@attr(shard=19)
 @ddt.ddt
 class VideoBumperEventsTest(VideoEventsTestMixin):
     """ Test bumper video event emission """

--- a/common/test/acceptance/tests/video/test_video_handout.py
+++ b/common/test/acceptance/tests/video/test_video_handout.py
@@ -8,7 +8,7 @@ from nose.plugins.attrib import attr
 from common.test.acceptance.tests.video.test_studio_video_module import CMSVideoBaseTest
 
 
-@attr(shard=5)
+@attr(shard=17)
 class VideoHandoutTest(CMSVideoBaseTest):
     """
     CMS Video Handout Test Class

--- a/common/test/acceptance/tests/video/test_video_license.py
+++ b/common/test/acceptance/tests/video/test_video_license.py
@@ -12,7 +12,7 @@ from common.test.acceptance.pages.studio.overview import CourseOutlinePage
 from common.test.acceptance.tests.studio.base_studio_test import StudioCourseTest
 
 
-@attr(shard=2)
+@attr(shard=22)
 class VideoLicenseTest(StudioCourseTest):
     """
     Tests for video module-level licensing (that is, setting the license,

--- a/common/test/acceptance/tests/video/test_video_module.py
+++ b/common/test/acceptance/tests/video/test_video_module.py
@@ -215,7 +215,7 @@ class VideoBaseTest(UniqueCourseTest):
         self.video.wait_for_video_player_render()
 
 
-@attr(shard=4)
+@attr(shard=13)
 @ddt
 class YouTubeVideoTest(VideoBaseTest):
     """ Test YouTube Video Player """
@@ -871,7 +871,7 @@ class YouTubeVideoTest(VideoBaseTest):
         execute_video_steps(tab1_video_names)
 
 
-@attr(shard=4)
+@attr(shard=13)
 class YouTubeHtml5VideoTest(VideoBaseTest):
     """ Test YouTube HTML5 Video Player """
 
@@ -889,7 +889,7 @@ class YouTubeHtml5VideoTest(VideoBaseTest):
         self.assertTrue(self.video.is_video_rendered('youtube'))
 
 
-@attr(shard=4)
+@attr(shard=19)
 class Html5VideoTest(VideoBaseTest):
     """ Test HTML5 Video Player """
 
@@ -1074,7 +1074,7 @@ class Html5VideoTest(VideoBaseTest):
         self.assertTrue(all([source in HTML5_SOURCES for source in self.video.sources]))
 
 
-@attr(shard=4)
+@attr(shard=13)
 class YouTubeQualityTest(VideoBaseTest):
     """ Test YouTube Video Quality Button """
 
@@ -1157,7 +1157,7 @@ class LMSVideoModuleA11yTest(VideoBaseTest):
         self.video.a11y_audit.check_for_accessibility_errors()
 
 
-@attr(shard=4)
+@attr(shard=11)
 class VideoPlayOrderTest(VideoBaseTest):
     """
     Test video play order with multiple videos
@@ -1201,7 +1201,7 @@ class VideoPlayOrderTest(VideoBaseTest):
         self.assertTrue(self.video.is_video_rendered('hls'))
 
 
-@attr(shard=4)
+@attr(shard=11)
 class HLSVideoTest(VideoBaseTest):
     """
     Tests related to HLS video

--- a/common/test/acceptance/tests/video/test_video_times.py
+++ b/common/test/acceptance/tests/video/test_video_times.py
@@ -6,6 +6,7 @@ from common.test.acceptance.tests.video.test_video_module import VideoBaseTest
 
 class VideoTimesTest(VideoBaseTest):
     """ Test Video Player Times """
+    shard = 21
 
     def test_video_start_time(self):
         """

--- a/common/test/acceptance/tests/xblock/test_crowdsourcehinter_problem.py
+++ b/common/test/acceptance/tests/xblock/test_crowdsourcehinter_problem.py
@@ -14,6 +14,7 @@ class CrowdsourcehinterProblemTest(UniqueCourseTest):
     """
     Test scenario for the hinter.
     """
+    shard = 21
     USERNAME = "STAFF_TESTER"
     EMAIL = "johndoe@example.com"
 

--- a/scripts/generic-ci-tests.sh
+++ b/scripts/generic-ci-tests.sh
@@ -205,11 +205,11 @@ case "$TEST_SUITE" in
                 $TOX paver test_bokchoy $PAVER_ARGS
                 ;;
 
-            [1-9]|10)
+            [1-9]|1[0-9]|2[0-1])
                 $TOX paver test_bokchoy --eval-attr="shard==$SHARD" $PAVER_ARGS
                 ;;
 
-            11|"noshard")
+            22|"noshard")
                 $TOX paver test_bokchoy --eval-attr='not shard and not a11y' $PAVER_ARGS
                 ;;
 


### PR DESCRIPTION
Doubles the number of bok-choy shards to speed-up test runs.

Note: We currently use pytest-attrib, which gives us the following option: 

> This plugin also allows to select tests based on expressions of the attributes of the class or function, and does not require the pytest.mark decorator.

Since we are trying to get off of nose, I set the shard value as an attribute of test classes in files that hadnt already been using the @attr decorator.