### PR TITLE
Fix due date display format according to set in advanced settings.

### DIFF
--- a/lms/static/js/dateutil_factory.js
+++ b/lms/static/js/dateutil_factory.js
@@ -28,16 +28,29 @@
         var displayDatetime;
         var isValid;
         var transform;
+        var dueDateFormat;
+        var dateFormat;
+
+        dueDateFormat = Object.freeze({
+            '%Y-%d-%m': 'YYYY, D MMM HH[:]mm z', // example: 2018, 01 Jan 15:30 UTC
+            '%m-%d-%Y': 'MMM D, YYYY HH[:]mm z', // example: Jan 01, 2018 15:30 UTC
+            '%d-%m-%Y': 'D MMM YYYY HH[:]mm z', // example: 01 Jan, 2018 15:30 UTC
+            '%Y-%m-%d': 'YYYY, MMM D HH[:]mm z' // example: 2018, Jan 01 15:30 UTC
+        });
 
         transform = function(iterationKey) {
             var context;
             $(iterationKey).each(function() {
                 if (isValid($(this).data('datetime'))) {
+                    dateFormat = DateUtils.dateFormatEnum[$(this).data('format')];
+                    if (typeof dateFormat === 'undefined') {
+                        dateFormat = dueDateFormat[$(this).data('format')];
+                    }
                     context = {
                         datetime: $(this).data('datetime'),
                         timezone: $(this).data('timezone'),
                         language: $(this).data('language'),
-                        format: DateUtils.dateFormatEnum[$(this).data('format')]
+                        format: dateFormat
                     };
                     displayDatetime = stringHandler(
                         localizedTime(context),

--- a/openedx/features/course_experience/templates/course_experience/course-outline-fragment-new.html
+++ b/openedx/features/course_experience/templates/course_experience/course-outline-fragment-new.html
@@ -112,6 +112,7 @@ from openedx.core.djangolib.markup import HTML, Text
                                                         class="localized-datetime subtitle-name"
                                                         data-datetime="${subsection.get('due')}"
                                                         data-string="${data_string}"
+                                                        data-format= "${due_date_display_format}"
                                                         data-timezone="${user_timezone}"
                                                         data-language="${user_language}"
                                                     ></span>
@@ -122,6 +123,7 @@ from openedx.core.djangolib.markup import HTML, Text
                                                 <span
                                                     class="localized-datetime subtitle-name"
                                                     data-datetime="${subsection.get('due')}"
+                                                    data-format= "${due_date_display_format}"
                                                     data-string="${data_string}"
                                                     data-timezone="${user_timezone}"
                                                     data-language="${user_language}"

--- a/openedx/features/course_experience/templates/course_experience/course-outline-fragment-old.html
+++ b/openedx/features/course_experience/templates/course_experience/course-outline-fragment-old.html
@@ -95,6 +95,7 @@ from openedx.core.djangolib.markup import HTML, Text
                                                         <span
                                                             class="localized-datetime subtitle-name"
                                                             data-datetime="${subsection.get('due')}"
+                                                            data-format= "${due_date_display_format}"
                                                             data-string="${data_string}"
                                                             data-timezone="${user_timezone}"
                                                             data-language="${user_language}"
@@ -106,6 +107,7 @@ from openedx.core.djangolib.markup import HTML, Text
                                                     <span
                                                         class="localized-datetime subtitle-name"
                                                         data-datetime="${subsection.get('due')}"
+                                                        data-format= "${due_date_display_format}"
                                                         data-string="${data_string}"
                                                         data-timezone="${user_timezone}"
                                                         data-language="${user_language}"

--- a/openedx/features/course_experience/views/course_outline.py
+++ b/openedx/features/course_experience/views/course_outline.py
@@ -19,6 +19,7 @@ from openedx.features.course_experience import waffle as course_experience_waffl
 from student.models import CourseEnrollment
 
 from util.milestones_helpers import get_course_content_milestones
+from xmodule.modulestore.django import modulestore
 from ..utils import get_course_outline_block_tree, get_resume_block
 
 
@@ -36,6 +37,7 @@ class CourseOutlineFragmentView(EdxFragmentView):
         """
         course_key = CourseKey.from_string(course_id)
         course_overview = get_course_overview_with_access(request.user, 'load', course_key, check_if_enrolled=True)
+        course = modulestore().get_course(course_key)
 
         course_block_tree = get_course_outline_block_tree(request, course_id)
         if not course_block_tree:
@@ -51,7 +53,8 @@ class CourseOutlineFragmentView(EdxFragmentView):
             'csrf': csrf(request)['csrf_token'],
             'course': course_overview,
             'blocks': course_block_tree,
-            'show_visual_progress': show_visual_progress
+            'show_visual_progress': show_visual_progress,
+            'due_date_display_format': course.due_date_display_format,
         }
 
         # TODO: EDUCATOR-2283 Remove this check when the waffle flag is turned on in production


### PR DESCRIPTION
## [Due Date Display Format Broken EDUCATOR-2436](https://openedx.atlassian.net/browse/EDUCATOR-2436)

### Description:
This PR fixes that if `Due Date Display Format` is having a value in advanced settings then all the due dates displayed according to this format.

### How to Test?
**stage**
 - Go to the course https://courses.stage.edx.org/courses/course-v1:edx+aishaq+2016/course/
- See the date is `Homework due Apr 30, 2018 07:00 PKT`
- Go to the Advanced Settings https://studio.stage.edx.org/settings/advanced/course-v1:edx+aishaq+2016
- Date format is *`%Y-%m-%d`*

**Sandbox**
- https://due-date.sandbox.edx.org/courses/course-v1:edX+DemoX+Demo_Course/course/
- Advanced settings link: https://studio-due-date.sandbox.edx.org/settings/advanced/course-v1:edX+DemoX+Demo_Course


### Reviewers

If you've been tagged for review, please check your corresponding box once you've given the :+1:.
-  [x] @yro 
-  [x] @fysheets 
### Post-review
- [x] Rebase and squash commits


