### PR TITLE
Border Appearing on wiki and Progress page.

### DIFF
--- a/lms/static/sass/shared/_footer-edx.scss
+++ b/lms/static/sass/shared/_footer-edx.scss
@@ -19,6 +19,14 @@ footer#footer-edx-v3 {
   padding: $baseline*0.75 0;
   border-top: 1px solid $courseware-button-border-color;
 
+  // There is a generic style similar applying div and box shadow on the wiki page of course.
+  // so disabling that design for footer in the lines below
+  .container > div {
+    border: none;
+    box-shadow: none;
+    background: inherit;
+  }
+
   .column-styles {
     position: relative;
     width: 100%;


### PR DESCRIPTION
A generic css rule like this ".container>div" is present on the wiki page.
Due to which these borders were showing around the footer on  those pages.
added a fix for that in this PR.

LEARNER-4858