### PR TITLE
Exclude the default site from UserAttribute 'created_on_site'

### DIFF
--- a/common/djangoapps/student/helpers.py
+++ b/common/djangoapps/student/helpers.py
@@ -402,9 +402,12 @@ def generate_activation_email_context(user, registration):
 def create_or_set_user_attribute_created_on_site(user, site):
     """
     Create or Set UserAttribute indicating the microsite site the user account was created on.
-    User maybe created on 'courses.edx.org', or a white-label site
+    User maybe created on 'courses.edx.org', or a white-label site. Due to the very high
+    traffic on this table we now ignore the default site (eg. 'courses.edx.org') and
+    code which comsumes this attribute should assume a 'created_on_site' which doesn't exist
+    belongs to the default site.
     """
-    if site:
+    if site and site.id != settings.SITE_ID:
         UserAttribute.set_user_attribute(user, 'created_on_site', site.domain)
 
 


### PR DESCRIPTION
This table is getting slammed and causing deadlocks, since 90% of it
is just this one setting on the default site we're going to stop saving
those and make it a default assumption going forward.