### PR TITLE
Update fix_ungraded_certs to Django 1.11 spec

### DIFF
--- a/lms/djangoapps/certificates/management/commands/fix_ungraded_certs.py
+++ b/lms/djangoapps/certificates/management/commands/fix_ungraded_certs.py
@@ -2,7 +2,6 @@
 Management command which fixes ungraded certificates for students
 """
 import logging
-from optparse import make_option
 
 from django.core.management.base import BaseCommand
 
@@ -23,24 +22,23 @@ class Command(BaseCommand):
     and grade them.
     """
 
-    option_list = BaseCommand.option_list + (
-        make_option(
+    def add_arguments(self, parser):
+        parser.add_argument(
             '-n',
             '--noop',
             action='store_true',
             dest='noop',
             default=False,
             help="Print but do not update the GeneratedCertificate table"
-        ),
-        make_option(
+        )
+        parser.add_argument(
             '-c',
             '--course',
             metavar='COURSE_ID',
             dest='course',
             default=False,
             help='Grade ungraded users for this course'
-        ),
-    )
+        )
 
     def handle(self, *args, **options):
         course_id = options['course']

--- a/lms/djangoapps/certificates/management/commands/tests/test_fix_ungraded_certs.py
+++ b/lms/djangoapps/certificates/management/commands/tests/test_fix_ungraded_certs.py
@@ -1,0 +1,17 @@
+"""
+Extremely basic tests for the fix_ungraded_certs command
+"""
+import pytest
+
+from django.core.management import call_command
+
+
+def test_fix_ungraded_certs_help(capsys):
+    """
+    Basic test to see if the command will parse and get args
+    """
+    with pytest.raises(SystemExit):
+        call_command('fix_ungraded_certs', '--help')
+
+    out, err = capsys.readouterr()  # pylint: disable=unused-variable
+    assert "COURSE_ID" in out


### PR DESCRIPTION
Upgraded command to work with Django 1.11 and added a basic test to make sure it at least can import and execute help to prevent missing things like this in the future.