### PR TITLE
Correct mention of old course ID format in the description for Course Authorization Bulk Email tool

### DIFF
--- a/lms/djangoapps/bulk_email/admin.py
+++ b/lms/djangoapps/bulk_email/admin.py
@@ -70,7 +70,7 @@ class CourseAuthorizationAdmin(admin.ModelAdmin):
         (None, {
             'fields': ('course_id', 'email_enabled'),
             'description': '''
-Enter a course id in the following form: Org/Course/CourseRun, eg MITx/6.002x/2012_Fall
+Enter a course id in the following form: course-v1:Org+CourseNumber+CourseRun, eg course-v1:edX+DemoX+Demo_Course
 Do not enter leading or trailing slashes. There is no need to surround the course ID with quotes.
 Validation will be performed on the course name, and if it is invalid, an error message will display.
 


### PR DESCRIPTION
This simply changes the course ID format description and provides a different example course ID for the Bulk Email -> Course Authorization flag in the lms django admin 