### PR TITLE
Update to latest 2.x which includes a security fix.

### DIFF
--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -148,7 +148,7 @@ watchdog==0.8.3
 
 # Metrics gathering and monitoring
 dogapi==1.2.1
-newrelic==2.104.0.86
+newrelic==2.106.1.88
 
 # Used for documentation gathering
 sphinx==1.1.3


### PR DESCRIPTION
Changelog: https://docs.newrelic.com/docs/release-notes/agent-release-notes/python-release-notes

Python Agent 2.106.1.88 - Wednesday, March 7, 2018 Download 

- This release of the Python agent includes a fix for security bulletin nr18-07.

Python Agent 2.106.0.87 - Wednesday, February 28, 2018 Download 
- This release of the Python agent adds support for AIOHTTP version 3.
  - Improved AIOHTTP Support
  - Support for AIOHTTP 3
