### PR TITLE
Move to the latest python newrelic agent.

### DIFF
--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -150,7 +150,7 @@ watchdog==0.8.3
 
 # Metrics gathering and monitoring
 dogapi==1.2.1
-newrelic==2.106.1.88
+newrelic==3.2.0.91
 
 # Used for documentation gathering
 sphinx==1.1.3


### PR DESCRIPTION
The biggest things from the [changelog](https://docs.newrelic.com/docs/release-notes/agent-release-notes/python-release-notes) below.

```
This release of the Python agent removes previously deprecated APIs, makes SSL communication with New Relic mandatory, and updates support for aiohttp middleware.

Deprecations
The following deprecated  APIs have been removed:

transaction (use current_transaction)
name_transaction (use set_transaction_name)
Application.record_metric (use Application.record_custom_metric)
Application.record_metrics (use Application.record_custom_metrics)
Transaction.notice_error (use Transaction.record_exception)
Transaction.record_metric (use Transaction.record_custom_metric)
Transaction.name_transaction (use Transaction.set_transaction_name)

New Deprecation:
Deprecate Transaction.add_user_attribute(use Transaction.add_custom_parameter)

SSL connections to New Relic are now mandatory
```

I verified that we're note using these deprecated endpoints:
```
~/src/edx-platform$ ag name_transaction
~/src/edx-platform$ ag record_metric
~/src/edx-platform$ ag record_metrics
~/src/edx-platform$ ag notice_error
```

For the change from transaction to current_transaction, I verified this as well but it was more complicated than a quick grep.