### PR TITLE
Remove Studio Assets Search Waffle & Add test

### DIFF
--- a/cms/djangoapps/contentstore/config/waffle.py
+++ b/cms/djangoapps/contentstore/config/waffle.py
@@ -9,7 +9,6 @@ WAFFLE_NAMESPACE = u'studio'
 
 # Switches
 ENABLE_ACCESSIBILITY_POLICY_PAGE = u'enable_policy_page'
-ENABLE_ASSETS_SEARCH = u'enable_assets_search'
 
 
 def waffle():

--- a/cms/templates/asset_index.html
+++ b/cms/templates/asset_index.html
@@ -6,7 +6,6 @@
   from django.utils.translation import ugettext as _
   from openedx.core.djangolib.markup import HTML, Text
   from openedx.core.djangolib.js_utils import js_escaped_string, dump_js_escaped_json
-  from cms.djangoapps.contentstore.config.waffle import waffle, ENABLE_ASSETS_SEARCH
 %>
 <%block name="title">${_("Files & Uploads")}</%block>
 <%block name="bodyclass">is-signedin course uploads view-uploads</%block>
@@ -49,9 +48,6 @@
                 },
                 "upload_settings": {
                     "max_file_size_in_mbs": ${max_file_size_in_mbs|n, dump_js_escaped_json}
-                },  
-                "search_settings": {   
-                    "enabled": ${waffle().is_enabled(ENABLE_ASSETS_SEARCH) | n, dump_js_escaped_json}
                 }
             }
         </%static:studiofrontend>

--- a/common/test/acceptance/pages/studio/asset_index.py
+++ b/common/test/acceptance/pages/studio/asset_index.py
@@ -78,6 +78,11 @@ class AssetIndexPageStudioFrontend(CoursePage):
         return self.q(css='.pagination').present
 
     @wait_for_js
+    def is_search_element_on_page(self):
+        """Checks that search bar is on the page."""
+        return self.q(css="[name='search']").present
+
+    @wait_for_js
     def is_status_alert_element_on_page(self):
         """Checks that status alert is hidden on page."""
         return all([

--- a/common/test/acceptance/tests/studio/test_studio_asset.py
+++ b/common/test/acceptance/tests/studio/test_studio_asset.py
@@ -35,6 +35,7 @@ class AssetIndexTestStudioFrontend(StudioCourseTest):
         assert self.assert_sortable_table_heading_elements_exist()
         assert self.assert_status_element_exists()
         assert self.assert_pagination_element_exists()
+        assert self.assert_search_element_exists()
 
     def assert_page_without_filter_results_elements_load(self):
         """Make sure correct elements are on page for a filter with no results."""
@@ -42,6 +43,7 @@ class AssetIndexTestStudioFrontend(StudioCourseTest):
         assert not self.assert_table_exists()
         assert not self.assert_sortable_table_heading_elements_exist()
         assert not self.assert_pagination_element_exists()
+        assert not self.assert_search_element_exists()
 
         assert self.assert_status_element_exists()
         assert self.assert_type_filter_exists()
@@ -76,6 +78,10 @@ class AssetIndexTestStudioFrontend(StudioCourseTest):
     def assert_pagination_element_exists(self):
         """Make sure pagination element is on the page."""
         return self.asset_page.is_pagination_element_on_page() is True
+
+    def assert_search_element_exists(self):
+        """Make sure search element is on the page."""
+        return self.asset_page.is_search_element_on_page() is True
 
     def assert_no_results_headings_exist(self):
         """Make sure headings with text for no results is on the page."""

--- a/package-lock.json
+++ b/package-lock.json
@@ -62,9 +62,9 @@
       }
     },
     "@edx/studio-frontend": {
-      "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/@edx/studio-frontend/-/studio-frontend-1.7.1.tgz",
-      "integrity": "sha512-BTpTMD55HgSOvVojMcZs6xa4gGjAx2Zw5jPykUkP1yU/HwORCSU088jGy4Fnluxf155Vk3PF2ggm1sBLX15ztQ==",
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/@edx/studio-frontend/-/studio-frontend-1.7.2.tgz",
+      "integrity": "sha512-L4KeY5XZzzEl0/qt6P7WXFnSCB98JAMGP47sHDY+b0lEv5gvi25YDN2JCuAZHqXWEk6SBbUudK2dvVxHwj9lnQ==",
       "requires": {
         "@edx/edx-bootstrap": "0.4.3",
         "@edx/paragon": "2.5.3",
@@ -83,7 +83,6 @@
         "react-paginate": "5.2.2",
         "react-redux": "5.0.7",
         "react-transition-group": "2.3.0",
-        "reactifex": "0.0.2",
         "reactstrap": "4.8.0",
         "redux": "3.7.2",
         "redux-devtools-extension": "2.13.2",
@@ -7504,7 +7503,7 @@
     },
     "onetime": {
       "version": "1.1.0",
-      "resolved": "http://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
       "integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k=",
       "dev": true
     },
@@ -8842,11 +8841,6 @@
         "prop-types": "15.6.0",
         "warning": "3.0.0"
       }
-    },
-    "reactifex": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/reactifex/-/reactifex-0.0.2.tgz",
-      "integrity": "sha512-h4kBLr2U/W/Iw/uxkmwIhChu3BhaGYWfG0WdZkPHuwfPOzhsTTogrThX9ebdq2YE+ueKLRiiAxqBlRhgj8XhSQ=="
     },
     "reactstrap": {
       "version": "4.8.0",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "dependencies": {
     "@edx/edx-bootstrap": "0.4.3",
     "@edx/paragon": "2.5.6",
-    "@edx/studio-frontend": "1.7.1",
+    "@edx/studio-frontend": "1.7.2",
     "babel-core": "6.26.0",
     "babel-loader": "6.4.1",
     "babel-plugin-transform-class-properties": "6.24.1",


### PR DESCRIPTION
## [EDUCATOR-2652](https://openedx.atlassian.net/browse/EDUCATOR-2652)

The search bar on the new assets page will be available always, remove waffle to toggle functionality. Also add test to validate search bar's appearance on page.