### PR TITLE
move Create Entitlement button up and shrink username search bar

### DIFF
--- a/lms/djangoapps/support/static/support/jsx/entitlements/components/Main/Main.jsx
+++ b/lms/djangoapps/support/static/support/jsx/entitlements/components/Main/Main.jsx
@@ -7,7 +7,7 @@ import EntitlementSupportTableContainer from '../Table/EntitlementSupportTableCo
 import EntitlementFormContainer from '../EntitlementForm/container.jsx';
 
 const Main = props => (
-  <div>
+  <div className="entitlement-support-wrapper">
     <StatusAlert
       alertType="danger"
       dialog={props.errorMessage}
@@ -28,15 +28,17 @@ const Main = props => (
 const MainContent = (props) => {
   if (props.isFormOpen) {
     return <EntitlementFormContainer />;
-  } 
+  }
   return (
     <div>
-      <SearchContainer />
-      <Button
-        className={['btn', 'btn-primary']}
-        label="Create New Entitlement"
-        onClick={props.openCreationForm}
-      />
+      <div className="actions">
+        <SearchContainer />
+        <Button
+          className={['btn', 'btn-primary']}
+          label="Create New Entitlement"
+          onClick={props.openCreationForm}
+        />
+      </div>
       <EntitlementSupportTableContainer ecommerceUrl={props.ecommerceUrl} />
     </div>
   );

--- a/lms/djangoapps/support/static/support/jsx/entitlements/components/Search/Search.jsx
+++ b/lms/djangoapps/support/static/support/jsx/entitlements/components/Search/Search.jsx
@@ -24,7 +24,7 @@ class Search extends React.Component {
 
   render() {
     return (
-      <form onSubmit={this.handleSubmit}>
+      <form onSubmit={this.handleSubmit} className="col-md-3 search-form">
         <InputText
           name="username"
           label="Search by Username"

--- a/lms/static/sass/bootstrap/lms-main.scss
+++ b/lms/static/sass/bootstrap/lms-main.scss
@@ -27,6 +27,7 @@ $static-path: '../..';
 
 // Individual Pages
 @import "views/program-marketing-page";
+@import "views/entitlement-support-page";
 
 // Responsive Design
 @import '../header';

--- a/lms/static/sass/views/_entitlement-support-page.scss
+++ b/lms/static/sass/views/_entitlement-support-page.scss
@@ -1,0 +1,13 @@
+.entitlement-support-wrapper {
+  div.actions {
+    display: flex;
+    justify-content: space-between;
+    flex-wrap: wrap;
+    align-items: center;
+  }
+
+  form.search-form {
+    padding-left: 0;
+    padding-right: 0;
+  }
+}


### PR DESCRIPTION
<img width="1193" alt="04-10-2018" src="https://user-images.githubusercontent.com/10751012/38566493-caa001b6-3cb1-11e8-961c-a11f3f5e6ff6.png">

* Created a new SASS file for custom styling on the entitlement support page that is compatible with its base Bootstrap styling and imported added it to lms-main imports so that it is included in `entitlement.html`'s style imports
* Created a wrapper class for entitlement support page styling
* Wrapped support page entitlement header and Create Entitlement button in a flexbox
* Added Bootstrap class to entitlement support page's user search form to confine it to 3 columns worth of space on mid-sized screens
* Removed Bootstrap's default padding on the search form for alignment and sizing preference

[LEARNER-4893](https://openedx.atlassian.net/browse/LEARNER-4893)