### PR TITLE
Add alignment options to the TinyMCE platform plugin

### DIFF
--- a/cms/djangoapps/contentstore/features/html-editor.py
+++ b/cms/djangoapps/contentstore/features/html-editor.py
@@ -167,6 +167,10 @@ def check_toolbar_buttons(step):
         'forecolor',
         # This is our custom "code style" button, which uses an image instead of a class.
         'none',
+        'alignleft',
+        'aligncenter',
+        'alignright',
+        'alignjustify',
         'bullist',
         'numlist',
         'outdent',

--- a/common/lib/xmodule/xmodule/js/src/html/edit.coffee
+++ b/common/lib/xmodule/xmodule/js/src/html/edit.coffee
@@ -83,6 +83,7 @@ class @HTMLEditingDescriptor
         image_advtab: true,
         # We may want to add "styleselect" when we collect all styles used throughout the LMS
         toolbar: "formatselect | fontselect | bold italic underline forecolor wrapAsCode | " +
+          "alignleft aligncenter alignright alignjustify | " +
           "bullist numlist outdent indent blockquote | link unlink " +
           "#{if @new_image_modal then 'insertImage' else 'image'} | code",
         block_formats: interpolate("%(paragraph)s=p;%(preformatted)s=pre;%(heading3)s=h3;%(heading4)s=h4;%(heading5)s=h5;%(heading6)s=h6", {


### PR DESCRIPTION
Will allow users of the plugin to left/center/right/justify align the content within the TinyMCE editor. 