### PR TITLE
Allowing custom username suggestions for SAML identity providers

### DIFF
--- a/common/djangoapps/third_party_auth/saml.py
+++ b/common/djangoapps/third_party_auth/saml.py
@@ -14,6 +14,7 @@ from six import text_type
 from social_core.backends.saml import OID_EDU_PERSON_ENTITLEMENT, SAMLAuth, SAMLIdentityProvider
 from social_core.exceptions import AuthForbidden
 
+from .utils import update_username_suggestion
 from openedx.core.djangoapps.theming.helpers import get_current_request
 
 STANDARD_SAML_PROVIDER_KEY = 'standard_saml_provider'
@@ -176,6 +177,7 @@ class EdXSAMLIdentityProvider(SAMLIdentityProvider):
             field['name']: attributes[field['urn']][0] if field['urn'] in attributes else None
             for field in extra_field_definitions
         })
+        details = update_username_suggestion(details, self.conf)
         return details
 
     @property

--- a/common/djangoapps/third_party_auth/tests/test_utils.py
+++ b/common/djangoapps/third_party_auth/tests/test_utils.py
@@ -2,10 +2,14 @@
 Tests for third_party_auth utility functions.
 """
 import unittest
+from mock import patch
 
 from django.conf import settings
+from django.contrib.auth.models import User
+from django.test import override_settings
 from third_party_auth.tests.testutil import TestCase
-from third_party_auth.utils import user_exists
+from third_party_auth.utils import user_exists, UsernameGenerator
+
 from student.tests.factories import UserFactory
 
 
@@ -32,3 +36,145 @@ class TestUtils(TestCase):
         self.assertFalse(
             user_exists({'username': 'invalid_user'}),
         )
+
+
+@unittest.skipUnless(settings.ROOT_URLCONF == 'lms.urls', 'Test only valid in lms')
+@override_settings(FEATURES={"ENABLE_REGISTRATION_USERNAME_SUGGESTION": True})
+class UsernameGeneratorTestCase(TestCase):
+    """
+    Test the utility functions.
+    """
+    def setUp(self):
+        self.enable_saml()
+        UserFactory(username='my_self_user', email='test_user@example.com')
+        self.fullname = 'My Self User'
+
+    def test_separator(self):
+        """
+        The first step to generate a hinted username is the separator character of the
+        full name string. This test makes sure that we are generating a username replacing
+        all whitespaces by a character configured in settings or in site_configurations.
+        """
+        saml = self.configure_saml_provider(
+            enabled=True,
+            name="Saml Test",
+            idp_slug="test",
+            backend_name="saml_backend",
+            other_settings={'SEPARATOR': '.'}
+        )
+        generator = UsernameGenerator(saml.other_settings)
+        username = generator.replace_separator(self.fullname)
+        return self.assertEqual(username, "My.Self.User")
+
+    def test_generate_username_in_lowercase(self):
+        """
+        Test if the full name that comes from insert_separator method
+        it's converted in lowercase.
+        """
+        saml = self.configure_saml_provider(
+            enabled=True,
+            name="Saml Test",
+            idp_slug="test",
+            backend_name="saml_backend",
+            other_settings={'LOWER': True}
+        )
+        generator = UsernameGenerator(saml.other_settings)
+        new_username = generator.process_case('My_Self_User')
+        return self.assertEqual(new_username, 'my_self_user')
+
+    def test_generate_username_not_lowercase(self):
+        """
+        Test if the full name that comes from insert_separator method
+        is not converted in lowercase and preserves their original lowercases and
+        uppers cases.
+        """
+        saml = self.configure_saml_provider(
+            enabled=True,
+            name="Saml Test",
+            idp_slug="test",
+            backend_name="saml_backend",
+            other_settings={'LOWER': False}
+        )
+        generator = UsernameGenerator(saml.other_settings)
+        new_username = generator.process_case('My_Self_User')
+        return self.assertEqual(new_username, 'My_Self_User')
+
+    def test_generate_username_with_consecutive(self):
+        """
+        It should return a new user with a consecutive number.
+        """
+        saml = self.configure_saml_provider(
+            enabled=True,
+            name="Saml Test",
+            idp_slug="test",
+            backend_name="saml_backend",
+            other_settings={'RANDOM': False}
+        )
+        for i in range(1, 6):
+            User.objects.create(
+                username='my_self_user_{}'.format(i)
+            )
+        generator = UsernameGenerator(saml.other_settings)
+        new_username = generator.generate_username(self.fullname)
+        # We have 6 users: Five created in the loop with a consecutive
+        # number and another one that comes from initial setUp,
+        # the first has not consecutive number due to is
+        # not neccesary append an differentiator. We expect a new user with
+        # the consecutive number 6.
+        return self.assertEqual(new_username, 'my_self_user_6')
+
+    @patch('third_party_auth.utils.UsernameGenerator.get_random')
+    def test_generate_username_with_random(self, mock_random):
+        """
+        It should return a username with a random integer
+        at the end of the username generated.
+        """
+        saml = self.configure_saml_provider(
+            enabled=True,
+            name="Saml Test",
+            idp_slug="test",
+            backend_name="saml_backend",
+            other_settings={'RANDOM': True}
+        )
+        mock_random.return_value = 4589
+        generator = UsernameGenerator(saml.other_settings)
+        new_username = generator.generate_username(self.fullname)
+        return self.assertEqual(new_username, 'my_self_user_4589')
+
+    @patch('third_party_auth.utils.UsernameGenerator.get_random')
+    def test_generate_username_with_repetitive_random(self, mock_random):
+        """
+        If a random generated number is repeated, should append
+        a suffix with another random that does not exists.
+        """
+        saml = self.configure_saml_provider(
+            enabled=True,
+            name="Saml Test",
+            idp_slug="test",
+            backend_name="saml_backend",
+            other_settings={'RANDOM': True}
+        )
+        mock_random.side_effect = [4589, 9819]
+        User.objects.create(username='my_self')
+        User.objects.create(username='my_self_4589')
+        generator = UsernameGenerator(saml.other_settings)
+        new_username = generator.generate_username('My Self')
+        return self.assertEqual(new_username, 'my_self_9819')
+
+    def test_username_without_modifications(self):
+        """
+        If the provided username does not exists
+        in database, should return the username without
+        any modifications of suffix number.
+        """
+        saml = self.configure_saml_provider(
+            enabled=True,
+            name="Saml Test",
+            idp_slug="test",
+            backend_name="saml_backend",
+            other_settings={'RANDOM': True}
+        )
+        not_existing_user = 'Another Myself'
+        generator = UsernameGenerator(saml.other_settings)
+        new_username = generator.generate_username(not_existing_user)
+        return self.assertEqual(new_username, 'another_myself')

--- a/common/djangoapps/third_party_auth/utils.py
+++ b/common/djangoapps/third_party_auth/utils.py
@@ -1,8 +1,11 @@
 """
 Utility functions for third_party_auth
 """
+from random import randint
 
 from django.contrib.auth.models import User
+from django.conf import settings
+from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
 
 
 def user_exists(details):
@@ -27,3 +30,103 @@ def user_exists(details):
         return User.objects.filter(**user_queryset_filter).exists()
 
     return False
+
+
+class UsernameGenerator(object):
+    """Helper Class to generate a unique username using a basename."""
+
+    def __init__(self, generator_settings=None):
+        if not generator_settings:
+            generator_settings = {}
+
+        default_settings = {
+            'SEPARATOR': '_',
+            'LOWER': True,
+            'RANDOM': False,
+        }
+
+        self.separator_character = generator_settings.get('SEPARATOR', default_settings['SEPARATOR'])
+        self.in_lowercase = generator_settings.get('LOWER', default_settings['LOWER'])
+        self.random = generator_settings.get('RANDOM', default_settings['RANDOM'])
+
+    def replace_separator(self, basename):
+        """
+        Arguments:
+            basename (str): string representing a basename for the user.
+
+        Returns:
+            (str): a new string with blank spaces  replaced by a custom separator.
+        """
+        username = basename.replace(' ', self.separator_character)
+        return username
+
+    def process_case(self, username):
+        """
+        Arguments:
+            username (str): string representing a username for the user.
+
+        Returns:
+            (str): username in lower case if self.in_lowercase is True,
+            otherwise returns the string unmodified.
+        """
+        if self.in_lowercase:
+            return username.lower()
+        else:
+            return username
+
+    def get_random_suffix(self):
+        """
+        Returns:
+            (str): four digit random string.
+        """
+        random = "%04d" % randint(0, 9999)
+        return random
+
+    def generate_username(self, basename):
+        """
+        Arguments:
+            basename (str): string representing a username for the user.
+
+        Returns:
+            (str): A unique username based on the provided string.
+        """
+        username = self.replace_separator(basename)
+        initial_username = self.process_case(username)
+        user_exists = User.objects.filter(username=initial_username).exists()
+
+        if not user_exists:
+            new_username = initial_username
+
+        counter = 1
+        while user_exists:
+            if self.random:
+                suffix = self.get_random_suffix()
+            else:
+                suffix = counter
+
+            new_username = '{}{}{}'.format(initial_username, self.separator_character, suffix)
+            user_exists = User.objects.filter(username=new_username).exists()
+            counter += 1
+
+        return new_username
+
+
+def update_username_suggestion(details, provider_conf):
+    """
+    Arguments:
+        provider_conf (dict): dictionary containing provider configuration info.
+
+    Returns:
+        (dict): user details dict with a username suggestion.
+    """
+    if configuration_helpers.get_value(
+            'ENABLE_REGISTRATION_USERNAME_SUGGESTION',
+            settings.FEATURES.get('ENABLE_REGISTRATION_USERNAME_SUGGESTION', False)):
+
+        username_generator_settings = provider_conf.get('USERNAME_GENERATOR')
+        username_base = details['username'] or details['fullname']
+        username_generator = UsernameGenerator(username_generator_settings)
+        username = username_generator.generate_username(username_base)
+        details.update({'username': username})
+
+    return details


### PR DESCRIPTION
### Background
When registration process goes through a SAML identity provider, the corresponding username suggestion for the registration form could be already on DB.

### Description
This PR allows to suggest a valid custom username for SAML identity providers, avoiding database collision with already registered users.

### Testing instructions
1. Activate this by turning on feature flag `ENABLE_REGISTRATION_USERNAME_SUGGESTION`.
2. Configure a SAML provider.
3. Optional: Change SAML provider configuration `Advanced settings JSON` adding a `USERNAME_GENERATOR` dict to customize the username generation process.
4. Start a registration flow using the SAML provider.
5. The username suggested will be checked against DB, and changed if needed.

### Related work
Find a PR supporting the same feature for ginkgo release [here](https://github.com/open-craft/edx-platform/pull/115)

### Reviewers
- [ ]  


cc @jagonzalr @mtyaka @tomaszgy 