### PR TITLE
[ENT-924] Replace sensitive SSO usernames with generic Enterprise displayname

### DIFF
--- a/common/djangoapps/util/views.py
+++ b/common/djangoapps/util/views.py
@@ -455,7 +455,7 @@ def submit_feedback(request):
     context = get_feedback_form_context(request)
 
     #Update the tag info with 'enterprise_learner' if the user belongs to an enterprise customer.
-    enterprise_learner_data = enterprise_api.get_enterprise_learner_data(site=request.site, user=request.user)
+    enterprise_learner_data = enterprise_api.get_enterprise_learner_data(request.user)
     if enterprise_learner_data:
         context["tags"]["learner_type"] = "enterprise_learner"
 

--- a/lms/djangoapps/course_wiki/tests/tests.py
+++ b/lms/djangoapps/course_wiki/tests/tests.py
@@ -205,10 +205,14 @@ class WikiRedirectTestCase(EnterpriseTestConsentRequired, LoginEnrollmentTestCas
         self.assertEqual(resp.status_code, 200)
 
     @patch.dict("django.conf.settings.FEATURES", {'ALLOW_WIKI_ROOT_ACCESS': True})
-    def test_consent_required(self):
+    @patch('openedx.features.enterprise_support.api.enterprise_customer_for_request')
+    def test_consent_required(self, mock_enterprise_customer_for_request):
         """
         Test that enterprise data sharing consent is required when enabled for the various courseware views.
         """
+        # ENT-924: Temporary solution to replace sensitive SSO usernames.
+        mock_enterprise_customer_for_request.return_value = None
+
         # Public wikis can be accessed by non-enrolled users, and so direct access is not gated by the consent page
         course = CourseFactory.create()
         course.allow_public_wiki_access = False

--- a/lms/djangoapps/courseware/tests/test_course_info.py
+++ b/lms/djangoapps/courseware/tests/test_course_info.py
@@ -68,12 +68,16 @@ class CourseInfoTestCase(EnterpriseTestConsentRequired, LoginEnrollmentTestCase,
         self.assertNotIn("You are not currently enrolled in this course", resp.content)
 
     # TODO: LEARNER-611: If this is only tested under Course Info, does this need to move?
-    def test_redirection_missing_enterprise_consent(self):
+    @mock.patch('openedx.features.enterprise_support.api.enterprise_customer_for_request')
+    def test_redirection_missing_enterprise_consent(self, mock_enterprise_customer_for_request):
         """
         Verify that users viewing the course info who are enrolled, but have not provided
         data sharing consent, are first redirected to a consent page, and then, once they've
         provided consent, are able to view the course info.
         """
+        # ENT-924: Temporary solution to replace sensitive SSO usernames.
+        mock_enterprise_customer_for_request.return_value = None
+
         self.setup_user()
         self.enroll(self.course)
 

--- a/lms/djangoapps/courseware/tests/test_views.py
+++ b/lms/djangoapps/courseware/tests/test_views.py
@@ -2596,10 +2596,14 @@ class EnterpriseConsentTestCase(EnterpriseTestConsentRequired, ModuleStoreTestCa
         CourseOverview.load_from_module_store(self.course.id)
         CourseEnrollmentFactory(user=self.user, course_id=self.course.id)
 
-    def test_consent_required(self):
+    @patch('openedx.features.enterprise_support.api.enterprise_customer_for_request')
+    def test_consent_required(self, mock_enterprise_customer_for_request):
         """
         Test that enterprise data sharing consent is required when enabled for the various courseware views.
         """
+        # ENT-924: Temporary solution to replace sensitive SSO usernames.
+        mock_enterprise_customer_for_request.return_value = None
+
         course_id = unicode(self.course.id)
         for url in (
                 reverse("courseware", kwargs=dict(course_id=course_id)),

--- a/lms/djangoapps/discussion/tests/test_views.py
+++ b/lms/djangoapps/discussion/tests/test_views.py
@@ -1659,10 +1659,14 @@ class EnterpriseConsentTestCase(EnterpriseTestConsentRequired, ForumsEnableMixin
 
         self.addCleanup(translation.deactivate)
 
-    def test_consent_required(self, mock_request):
+    @patch('openedx.features.enterprise_support.api.enterprise_customer_for_request')
+    def test_consent_required(self, mock_enterprise_customer_for_request, mock_request):
         """
         Test that enterprise data sharing consent is required when enabled for the various discussion views.
         """
+        # ENT-924: Temporary solution to replace sensitive SSO usernames.
+        mock_enterprise_customer_for_request.return_value = None
+
         thread_id = 'dummy'
         course_id = unicode(self.course.id)
         mock_request.side_effect = make_mock_request_impl(course=self.course, text='dummy', thread_id=thread_id)

--- a/lms/djangoapps/support/views/contact_us.py
+++ b/lms/djangoapps/support/views/contact_us.py
@@ -33,7 +33,7 @@ class ContactUsView(View):
 
         if request.user.is_authenticated():
             context['user_enrollments'] = CourseEnrollment.enrollments_for_user_with_overviews_preload(request.user)
-            enterprise_learner_data = enterprise_api.get_enterprise_learner_data(site=request.site, user=request.user)
+            enterprise_learner_data = enterprise_api.get_enterprise_learner_data(request.user)
             if enterprise_learner_data:
                 tags.append('enterprise_learner')
 

--- a/lms/templates/courseware/progress.html
+++ b/lms/templates/courseware/progress.html
@@ -11,7 +11,14 @@ from django.core.urlresolvers import reverse
 from django.conf import settings
 from django.utils.http import urlquote_plus
 from six import text_type
+
+from openedx.features.enterprise_support.utils import get_enterprise_learner_generic_name
 %>
+
+<%
+username = get_enterprise_learner_generic_name(request) or student.username
+%>
+
 <%block name="bodyclass">view-in-course view-progress</%block>
 
 <%block name="headextra">
@@ -54,7 +61,7 @@ from six import text_type
                 </div>
                 % endif
                 <h2 class="hd hd-2 progress-certificates-title">
-                    ${_("Course Progress for Student '{username}' ({email})").format(username=student.username, email=student.email)}
+                    ${_("Course Progress for Student '{username}' ({email})").format(username=username, email=student.email)}
                 </h2>
 
                 <div class="wrapper-msg wrapper-auto-cert">

--- a/lms/templates/header/user_dropdown.html
+++ b/lms/templates/header/user_dropdown.html
@@ -2,32 +2,29 @@
 <%page expression_filter="h"/>
 <%namespace name='static' file='static_content.html'/>
 
-## This template should not use the target student's details when masquerading, see TNL-4895
-<%
-self.real_user = getattr(user, 'real_user', user)
-%>
-
 <%!
 from django.core.urlresolvers import reverse
 from django.utils.translation import ugettext as _
 
 from openedx.core.djangoapps.user_api.accounts.image_helpers import get_profile_image_urls_for_user
 from openedx.core.djangoapps.user_api.accounts.utils import retrieve_last_sitewide_block_completed
-
+from openedx.features.enterprise_support.utils import get_enterprise_learner_generic_name
 %>
 
 <%
-    profile_image_url = get_profile_image_urls_for_user(self.real_user)['medium']
-    username = self.real_user.username
-    resume_block = retrieve_last_sitewide_block_completed(username)
+## This template should not use the target student's details when masquerading, see TNL-4895
+self.real_user = getattr(user, 'real_user', user)
+profile_image_url = get_profile_image_urls_for_user(self.real_user)['medium']
+username = self.real_user.username
+resume_block = retrieve_last_sitewide_block_completed(username)
+displayname = get_enterprise_learner_generic_name(request) or username
 %>
-
 
 <div class="nav-item hidden-mobile">
     <a href="${reverse('dashboard')}" class="menu-title">
         <img class="user-image-frame" src="${profile_image_url}" alt="">
         <span class="sr-only">${_("Dashboard for:")}</span>
-        <span class="username">${username}</span>
+        <span class="username">${displayname}</span>
     </a>
 </div>
 <div class="nav-item hidden-mobile nav-item-dropdown" tabindex="-1">

--- a/lms/templates/user_dropdown.html
+++ b/lms/templates/user_dropdown.html
@@ -2,19 +2,21 @@
 <%page expression_filter="h"/>
 <%namespace name='static' file='static_content.html'/>
 
-## This template should not use the target student's details when masquerading, see TNL-4895
-<%
-self.real_user = getattr(user, 'real_user', user)
-username = self.real_user.username
-profile_image_url = get_profile_image_urls_for_user(self.real_user)['medium']
-%>
-
 <%!
 from django.core.urlresolvers import reverse
 from django.utils.translation import ugettext as _
 
 from openedx.core.djangoapps.user_api.accounts.image_helpers import get_profile_image_urls_for_user
+from openedx.features.enterprise_support.utils import get_enterprise_learner_generic_name
 %>
+
+<%
+## This template should not use the target student's details when masquerading, see TNL-4895
+self.real_user = getattr(user, 'real_user', user)
+username = get_enterprise_learner_generic_name(request) or self.real_user.username
+profile_image_url = get_profile_image_urls_for_user(self.real_user)['medium']
+%>
+
 % if uses_bootstrap:
     <div class="nav-item nav-item-hidden-collapsed container">
         <div class="nav align-items-center">

--- a/openedx/features/enterprise_support/tests/mixins/enterprise.py
+++ b/openedx/features/enterprise_support/tests/mixins/enterprise.py
@@ -220,6 +220,7 @@ class EnterpriseTestConsentRequired(SimpleTestCase):
     Mixin to help test the data_sharing_consent_required decorator.
     """
 
+    @mock.patch('openedx.features.enterprise_support.utils.get_enterprise_learner_generic_name')
     @mock.patch('openedx.features.enterprise_support.api.enterprise_customer_uuid_for_request')
     @mock.patch('openedx.features.enterprise_support.api.reverse')
     @mock.patch('openedx.features.enterprise_support.api.enterprise_enabled')
@@ -232,6 +233,7 @@ class EnterpriseTestConsentRequired(SimpleTestCase):
             mock_enterprise_enabled,
             mock_reverse,
             mock_enterprise_customer_uuid_for_request,
+            mock_get_enterprise_learner_generic_name,
             status_code=200,
     ):
         """
@@ -243,6 +245,9 @@ class EnterpriseTestConsentRequired(SimpleTestCase):
             if args[0] == 'grant_data_sharing_permissions':
                 return '/enterprise/grant_data_sharing_permissions'
             return reverse(*args, **kwargs)
+
+        # ENT-924: Temporary solution to replace sensitive SSO usernames.
+        mock_get_enterprise_learner_generic_name.return_value = ''
 
         mock_reverse.side_effect = mock_consent_reverse
         mock_enterprise_enabled.return_value = True

--- a/openedx/features/enterprise_support/utils.py
+++ b/openedx/features/enterprise_support/utils.py
@@ -220,3 +220,20 @@ def update_account_settings_context_for_enterprise(context, enterprise_customer)
             enterprise_context['sync_learner_profile_data'] = identity_provider.sync_learner_profile_data
 
     context.update(enterprise_context)
+
+
+def get_enterprise_learner_generic_name(request):
+    """
+    Get a generic name concatenating the Enterprise Customer name and 'Learner'.
+
+    ENT-924: Temporary solution for hiding potentially sensitive SSO names.
+    When a more complete solution is put in place, delete this function and all of its uses.
+    """
+    # Prevent a circular import. This function makes sense to be in this module though. And see function description.
+    from openedx.features.enterprise_support.api import enterprise_customer_for_request
+    enterprise_customer = enterprise_customer_for_request(request)
+    return (
+        enterprise_customer['name'] + 'Learner'
+        if enterprise_customer and enterprise_customer['replace_sensitive_sso_username']
+        else ''
+    )

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -57,7 +57,7 @@ enum34==1.1.6
 edx-completion==0.1.5
 edx-django-oauth2-provider==1.2.5
 edx-django-sites-extensions==2.3.1
-edx-enterprise==0.67.3
+edx-enterprise==0.67.4
 edx-milestones==0.1.13
 edx-oauth2-provider==1.2.2
 edx-organizations==0.4.9


### PR DESCRIPTION
(This is contract work for edX).

This PR replaces sensitive SSO usernames of Enterprise learners associated with Enterprise Customers who are configured to perform the replacement.

The replacement occurs only in a few places:

- Top-right corner in header (near user dropdown)
- Progress page

A more complete solution is in the works.

Requires https://github.com/edx/edx-enterprise/pull/303 to work.

*Testing Instructions*:

1. Install the version of edx-enterprise from https://github.com/edx/edx-enterprise/pull/303
2. Configure an Enterprise Customer to use the new flag added in https://github.com/edx/edx-enterprise/pull/303.
3. Create a new user.
4. Go to the progress page and notice that you see your username as it should be, including in the top-right corner in the header.
5. Link that user to the above configured Enterprise Customer.
6. Do the same as step 4 but notice your name should now be something like `enterprise_customer.name + 'Learner'`, i.e. 'EnterpriseLearner'.
7. Unlink and do step 4 again and notice it's back to normal.