### PR TITLE
ENT-955: Fixed 500 error when adding viewers to catalog.

### DIFF
--- a/openedx/core/djangoapps/api_admin/views.py
+++ b/openedx/core/djangoapps/api_admin/views.py
@@ -218,7 +218,7 @@ class CatalogEditView(CatalogApiMixin, View):
             response = client.catalogs(catalog_id).get()
             catalog = Catalog(attributes=response)
             return render_to_response(self.template_name, self.get_context_data(catalog, form, client), status=400)
-        catalog = client.catalogs(catalog_id).patch(form.instance.attributes)
+        catalog = client.catalogs(catalog_id).patch(form.cleaned_data)
         return redirect(reverse('api_admin:catalog-edit', kwargs={'catalog_id': catalog['id']}))
 
 


### PR DESCRIPTION
__Description:__
This PR fixes the issue where 500 error is returned by the LMS when attempting to add a "viewer" to a Discovery Service catalog.

__JIRA Ticket:__ [ENT-955](https://openedx.atlassian.net/browse/ENT-955)

__Testing Instructions:__
1. Open catalog API Admin page at https://business.sandbox.edx.org/api-admin/catalogs/1/
2. Update **Viewers** with a comma-separated list of usernames e.g. `staff, verified`
3. Make sure catalog is updated successfully without any errors.