### PR TITLE
fetch poll component to check for completion

### DIFF
--- a/openedx/features/course_experience/utils.py
+++ b/openedx/features/course_experience/utils.py
@@ -128,7 +128,8 @@ def get_course_outline_block_tree(request, course_id):
         'problem',
         'video',
         'discussion',
-        'drag-and-drop-v2'
+        'drag-and-drop-v2',
+        'poll'
     ]
     all_blocks = get_blocks(
         request,


### PR DESCRIPTION

## [EDUCATOR-2682](https://openedx.atlassian.net/browse/EDUCATOR-2682)

### Description

In course outline, blocks of course content are fetched to check for completion status. We have specified what blocks to filter. 'poll' was not included in list of blocks to be fetched. In this PR 'poll' is added in list so that completion status of units containing polls can be shown on course outline.   

