### PR TITLE
 Fix disabled login/register buttons after failed attempt 

### DIFF
--- a/lms/templates/login.html
+++ b/lms/templates/login.html
@@ -100,7 +100,7 @@ from third_party_auth import provider, pipeline
         $submitButton.
           removeClass('is-disabled').
           attr('aria-disabled', false).
-          removeProp('disabled').
+          prop('disabled', false).
           html("${_('Log into My {platform_name} Account').format(platform_name=platform_name)} <span class='orn-plus'>+</span> ${_('Access My Courses')}");
       }
       else {

--- a/lms/templates/register.html
+++ b/lms/templates/register.html
@@ -85,7 +85,7 @@ import calendar
         $submitButton.
           removeClass('is-disabled').
           attr('aria-disabled', false).
-          removeProp('disabled').
+          prop('disabled', false).
           html("${_('Create My {platform_name} Account').format(platform_name=platform_name)}");
       }
       else {


### PR DESCRIPTION
In the login window, when the user enters a wrong email or password, the
"Log into my ... account" button used to remain disabled, which was very
confusing for users.

Steps to reproduce:
- Go to /login
- Type wrong email/password combination
- Press "Log into..." button

Similarly, users could not click the "register button after a failed
register attempt. For example, this occurred to users with an invalid
email address, such as "fooatgmaildotcom".

I think it would make sense if we also merged this to open-release/ginkgo-master and (eventually) open-release/ficus-master.

This issue affects many people: https://community.bitnami.com/t/sign-in-or-register-button-disappears/48981/6
Kudos to @Rudolf for the peanut butter https://twitter.com/regisb/status/984320445011898368