### PR TITLE
APPROACH #1 Remove uses of course_structures djangoapp from django_comment_client code.

### DIFF
--- a/lms/djangoapps/django_comment_client/base/event_transformers.py
+++ b/lms/djangoapps/django_comment_client/base/event_transformers.py
@@ -10,7 +10,7 @@ from opaque_keys.edx.locator import CourseLocator
 
 from django_comment_client.base.views import add_truncated_title_to_event_data
 from django_comment_client.permissions import get_team
-from django_comment_client.utils import get_cached_discussion_id_map_by_course_id
+from django_comment_client.utils import get_discussion_id_map_by_course_id
 from track.transformers import EventTransformer, EventTransformerRegistry
 from track.views.segmentio import (
     BI_SCREEN_VIEWED_EVENT_NAME,
@@ -125,7 +125,7 @@ class ForumThreadViewedEventTransformer(EventTransformer):
 
         # If in a category, add category name and ID
         if course_id and commentable_id and user:
-            id_map = get_cached_discussion_id_map_by_course_id(course_id, [commentable_id], user)
+            id_map = get_discussion_id_map_by_course_id(course_id, user)
             if commentable_id in id_map:
                 self.event['category_name'] = id_map[commentable_id]['title']
                 self.event['category_id'] = commentable_id

--- a/lms/djangoapps/django_comment_client/base/views.py
+++ b/lms/djangoapps/django_comment_client/base/views.py
@@ -27,7 +27,7 @@ from django_comment_client.utils import (
     discussion_category_id_access,
     get_ability,
     get_annotated_content_info,
-    get_cached_discussion_id_map,
+    get_discussion_id_map,
     get_group_id_for_comments_service,
     get_user_group_ids,
     is_comment_too_deep,
@@ -72,7 +72,7 @@ def track_forum_event(request, event_name, course, obj, data, id_map=None):
         data.update(team_id=team.team_id)
 
     if id_map is None:
-        id_map = get_cached_discussion_id_map(course, [commentable_id], user)
+        id_map = get_discussion_id_map(course, user)
     if commentable_id in id_map:
         data['category_name'] = id_map[commentable_id]["title"]
         data['category_id'] = commentable_id


### PR DESCRIPTION
The course_structures module is deprecated and we are targeting removal of it from the edx-platform codebase. This PR removes a course_structures model call from the django_comment_client code by removing the caching shim that was put in place to make use of the course_structures cache.

This rolls back some optimizations made in this [commit](https://github.com/edx/edx-platform/commit/6704e17afdfc235c47e166c377ff27fb65aee922), but based on the commit comment it sounds like undoing these optimizations is a fair trade off for getting rid of the course_structures code.

**UPDATE:** Based on the test failures, the above statement about this being a fair trade off may be incorrect. See [APPROACH #2](https://github.com/edx/edx-platform/pull/17950) for a possible better option for refactoring out course_structures.