### PR TITLE
Add generate_report_data to return a readable report of student answers to capa problems

### DIFF
--- a/common/lib/capa/capa/capa_problem.py
+++ b/common/lib/capa/capa/capa_problem.py
@@ -128,7 +128,7 @@ class LoncapaProblem(object):
     Main class for capa Problems.
     """
     def __init__(self, problem_text, id, capa_system, capa_module,  # pylint: disable=redefined-builtin
-                 state=None, seed=None, minimal_init=False):
+                 state=None, seed=None, minimal_init=False, extract_tree=True):
         """
         Initializes capa Problem.
 
@@ -147,6 +147,8 @@ class LoncapaProblem(object):
                 - `done` (bool) indicates whether or not this problem is considered done
                 - `input_state` (dict) maps input_id to a dictionary that holds the state for that input
             seed (int): random number generator seed.
+            minimal_init (bool): whether to skip pre-processing student answers
+            extract_tree (bool): whether to parse the problem XML and store the HTML
 
         """
 
@@ -212,7 +214,8 @@ class LoncapaProblem(object):
                 if hasattr(response, 'late_transforms'):
                     response.late_transforms(self)
 
-            self.extracted_tree = self._extract_html(self.tree)
+            if extract_tree:
+                self.extracted_tree = self._extract_html(self.tree)
 
     def make_xml_compatible(self, tree):
         """
@@ -491,6 +494,124 @@ class LoncapaProblem(object):
             results = self.responder_answers[response]
             answer_ids.append(results.keys())
         return answer_ids
+
+    def find_question_label(self, answer_id):
+        """
+        Obtain the most relevant question text for a particular answer.
+
+        E.g. in a problem like "How much is 2+2?" "Two"/"Three"/"More than three",
+        this function returns the "How much is 2+2?" text.
+
+        It uses, in order:
+        - the question prompt, if the question has one
+        - the <p> or <label> element which precedes the choices (skipping descriptive elements)
+        - a text like "Question 5" if no other name could be found
+
+        Arguments::
+            answer_id: a string like "98e6a8e915904d5389821a94e48babcf_13_1"
+
+        Returns:
+            a string with the question text
+        """
+        _ = self.capa_system.i18n.ugettext
+        # Some questions define a prompt with this format:   >>This is a prompt<<
+        prompt = self.problem_data[answer_id].get('label')
+
+        if prompt:
+            question_text = prompt.striptags()
+        else:
+            # If no prompt, then we must look for something resembling a question ourselves
+            #
+            # We have a structure like:
+            #
+            # <p />
+            # <optionresponse id="a0effb954cca4759994f1ac9e9434bf4_2">
+            #   <optioninput id="a0effb954cca4759994f1ac9e9434bf4_3_1" />
+            # <optionresponse>
+            #
+            # Starting from  answer (the optioninput in this example) we go up and backwards
+            xml_elems = self.tree.xpath('//*[@id="' + answer_id + '"]')
+            assert len(xml_elems) == 1
+            xml_elem = xml_elems[0].getparent()
+
+            # Get the element that probably contains the question text
+            questiontext_elem = xml_elem.getprevious()
+
+            # Go backwards looking for a <p> or <label>, but skip <description> because it doesn't
+            # contain the question text.
+            #
+            # E.g if we have this:
+            #   <p /> <description /> <optionresponse /> <optionresponse />
+            #
+            # then from the first optionresponse we'll end with the <p>.
+            # If we start in the second optionresponse, we'll find another response in the way,
+            # stop early, and instead of a question we'll report "Question 2".
+            SKIP_ELEMS = ['description']
+            LABEL_ELEMS = ['p', 'label']
+            while questiontext_elem is not None and questiontext_elem.tag in SKIP_ELEMS:
+                questiontext_elem = questiontext_elem.getprevious()
+
+            if questiontext_elem is not None and questiontext_elem.tag in LABEL_ELEMS:
+                question_text = questiontext_elem.text
+            else:
+                # For instance 'd2e35c1d294b4ba0b3b1048615605d2a_2_1' contains 2,
+                # which is used in question number 1 (see example XML in comment above)
+                # There's no question 0 (question IDs start at 1, answer IDs at 2)
+                question_nr = int(answer_id.split('_')[-2]) - 1
+                question_text = _("Question {0}").format(question_nr)
+
+        return question_text
+
+    def find_answer_text(self, answer_id, current_answer):
+        """
+        Process a raw answer text to make it more meaningful.
+
+        E.g. in a choice problem like "How much is 2+2?" "Two"/"Three"/"More than three",
+        this function will transform "choice_1" (which is the internal response given by
+        many capa methods) to the human version, e.g. "More than three".
+
+        If the answers are multiple (e.g. because they're from a multiple choice problem),
+        this will join them with a comma.
+
+        If passed a normal string which is already the answer, it doesn't change it.
+
+        TODO merge with response_a11y_data?
+
+        Arguments:
+            answer_id: a string like "98e6a8e915904d5389821a94e48babcf_13_1"
+            current_answer: a data structure as found in `LoncapaProblem.student_answers`
+                which represents the best response we have until now
+
+        Returns:
+            a string with the human version of the response
+        """
+        if isinstance(current_answer, list):
+            # Multiple answers. This case happens e.g. in multiple choice problems
+            answer_text = ", ".join(
+                self.find_answer_text(answer_id, answer) for answer in current_answer
+            )
+
+        elif isinstance(current_answer, basestring) and current_answer.startswith('choice_'):
+            # Many problem (e.g. checkbox) report "choice_0" "choice_1" etc.
+            # Here we transform it
+            elems = self.tree.xpath('//*[@id="{answer_id}"]//*[@name="{choice_number}"]'.format(
+                answer_id=answer_id,
+                choice_number=current_answer
+            ))
+            assert len(elems) == 1
+            choicegroup = elems[0].getparent()
+            input_cls = inputtypes.registry.get_class_for_tag(choicegroup.tag)
+            choices_map = dict(input_cls.extract_choices(choicegroup, self.capa_system.i18n, text_only=True))
+            answer_text = choices_map[current_answer]
+
+        elif isinstance(current_answer, basestring):
+            # Already a string with the answer
+            answer_text = current_answer
+
+        else:
+            raise NotImplementedError()
+
+        return answer_text
 
     def do_targeted_feedback(self, tree):
         """

--- a/common/lib/capa/capa/inputtypes.py
+++ b/common/lib/capa/capa/inputtypes.py
@@ -518,12 +518,14 @@ class ChoiceGroup(InputTypeBase):
                 'name_array_suffix': self.suffix}
 
     @staticmethod
-    def extract_choices(element, i18n):
+    def extract_choices(element, i18n, text_only=False):
         """
         Extracts choices for a few input types, such as ChoiceGroup, RadioGroup and
         CheckboxGroup.
 
         returns list of (choice_name, choice_text) tuples
+
+        By default it will return any XML tag in the choice (e.g. <choicehint>) unless text_only=True is passed.
 
         TODO: allow order of choices to be randomized, following lon-capa spec.  Use
         "location" attribute, ie random, top, bottom.
@@ -534,7 +536,11 @@ class ChoiceGroup(InputTypeBase):
 
         for choice in element:
             if choice.tag == 'choice':
-                choices.append((choice.get("name"), stringify_children(choice)))
+                if not text_only:
+                    text = stringify_children(choice)
+                else:
+                    text = choice.text
+                choices.append((choice.get("name"), text))
             else:
                 if choice.tag != 'compoundhint':
                     msg = Text('[capa.inputtypes.extract_choices] {error_message}').format(

--- a/common/lib/capa/capa/tests/test_capa_problem.py
+++ b/common/lib/capa/capa/tests/test_capa_problem.py
@@ -4,9 +4,11 @@ Test capa problem.
 import ddt
 import textwrap
 from lxml import etree
+from mock import patch
 import unittest
 
 from capa.tests.helpers import new_loncapa_problem
+from openedx.core.djangolib.markup import HTML
 
 
 @ddt.ddt
@@ -590,3 +592,81 @@ class CAPAMultiInputProblemTest(unittest.TestCase):
             description_element = multi_inputs_group.xpath('//p[@id="{}"]'.format(description_id))
             self.assertEqual(len(description_element), 1)
             self.assertEqual(description_element[0].text, descriptions[index])
+
+
+@ddt.ddt
+class CAPAProblemReportHelpersTest(unittest.TestCase):
+    """ TestCase for CAPA methods for finding question labels and answer text """
+
+    @ddt.data(
+        ('answerid_2_1', 'label', 'label'),
+        ('answerid_2_2', 'label <some>html</some>', 'label html'),
+        ('answerid_2_2', '<more html="yes"/>label <some>html</some>', 'label html'),
+        ('answerid_2_3', None, 'Question 1'),
+        ('answerid_2_3', '', 'Question 1'),
+        ('answerid_3_3', '', 'Question 2'),
+    )
+    @ddt.unpack
+    def test_find_question_label(self, answer_id, label, stripped_label):
+        problem = new_loncapa_problem(
+            '<problem><some-problem id="{}"/></problem>'.format(answer_id)
+        )
+        mock_problem_data = {
+            answer_id: {
+                'label': HTML(label) if label else ''
+            }
+        }
+        with patch.object(problem, 'problem_data', mock_problem_data):
+            self.assertEqual(problem.find_question_label(answer_id), stripped_label)
+
+    @ddt.data(None, dict(), [None])
+    def test_find_answer_test_not_implemented(self, current_answer):
+        problem = new_loncapa_problem('<problem/>')
+        self.assertRaises(NotImplementedError, problem.find_answer_text, '', current_answer)
+
+    @ddt.data(
+        ('1_2_1', 'choice_0', 'over-suspicious'),
+        ('1_2_1', 'choice_1', 'funny'),
+        ('1_3_1', 'choice_0', 'The iPad'),
+        ('1_3_1', 'choice_2', 'The iPod'),
+        ('1_3_1', ['choice_0', 'choice_1'], 'The iPad, Napster'),
+        ('1_4_1', 'yellow', 'yellow'),
+        ('1_4_1', 'blue', 'blue'),
+    )
+    @ddt.unpack
+    def test_find_answer_text_choices(self, answer_id, choice_id, answer_text):
+        problem = new_loncapa_problem(
+            """
+            <problem>
+                <choiceresponse>
+                    <checkboxgroup label="Select the correct synonym of paranoid?">
+                        <choice correct="true">over-suspicious</choice>
+                        <choice correct="false">funny</choice>
+                    </checkboxgroup>
+                </choiceresponse>
+                <multiplechoiceresponse>
+                    <choicegroup type="MultipleChoice">
+                        <choice correct="false">The iPad</choice>
+                        <choice correct="false">Napster</choice>
+                        <choice correct="true">The iPod</choice>
+                    </choicegroup>
+                </multiplechoiceresponse>
+                <optionresponse>
+                    <optioninput options="('yellow','blue','green')" correct="blue" label="Color_1"/>
+                </optionresponse>
+            </problem>
+            """
+        )
+        self.assertEquals(problem.find_answer_text(answer_id, choice_id), answer_text)
+
+    def test_find_answer_text_textinput(self):
+        problem = new_loncapa_problem(
+            """
+            <problem>
+                <stringresponse answer="hide" type="ci">
+                    <textline size="40"/>
+                </stringresponse>
+            </problem>
+            """
+        )
+        self.assertEquals(problem.find_answer_text('1_2_1', 'hide'), 'hide')

--- a/lms/djangoapps/courseware/user_state_client.py
+++ b/lms/djangoapps/courseware/user_state_client.py
@@ -459,7 +459,7 @@ class DjangoXBlockUserStateClient(XBlockUserStateClient):
         if scope != Scope.user_state:
             raise ValueError("Only Scope.user_state is supported")
 
-        results = StudentModule.objects.filter(module_state_key=block_key)
+        results = StudentModule.objects.order_by('id').filter(module_state_key=block_key)
         p = Paginator(results, settings.USER_STATE_BATCH_SIZE)
 
         for page_number in p.page_range:
@@ -491,7 +491,7 @@ class DjangoXBlockUserStateClient(XBlockUserStateClient):
         if scope != Scope.user_state:
             raise ValueError("Only Scope.user_state is supported")
 
-        results = StudentModule.objects.filter(course_id=course_key)
+        results = StudentModule.objects.order_by('id').filter(course_id=course_key)
         if block_type:
             results = results.filter(module_type=block_type)
 


### PR DESCRIPTION
This implements `generate_report_data`, a way to get an iterator over answers to capa problems, but in a way that is easier to understand. It will be called from a celery task and offer a simple way to see what did students answer to each question.

The function is a generator which will output rows in a format like:
```
("user17", {"Question": "Your Name?", "Answer": "Alex", "Answer ID": "98e6a8e915904d5389821a94e48babcf_10_1"})
```

This report data is used in https://github.com/edx/edx-platform/pull/17776 to show an extended report of student answers accessible from LMS, which can be downloaded as a CSV file ([example CSV file](https://github.com/edx/edx-platform/files/2032494/edX_DemoX_Demo_Course_student_state_from_block-v1_edX.DemoX.Demo_Course.type.course.block.course_2018-05-22-1852.csv.txt)).



In addition, this PR fiixes the following warning in `iter_all_for_block` and `iter_all_for_course`: `UnorderedObjectListWarning: Pagination may yield inconsistent results with an unordered object_list: <class 'courseware.models.StudentModule'> QuerySet.`
 
**JIRA tickets**: None
**Project details**: This PR is part of the "Improved Problem Response Report" project, funded by Australian National University (ANU) and developed by OpenCraft.
**Discussions**: https://edxchange.opencraft.com/t/xblock-reporting-tool/191
**Dependencies**: none. It uses [iter_all_for_block](https://github.com/edx/edx-platform/pull/17698), which was already merged.
**Screenshots**: 
![some_test_report](https://user-images.githubusercontent.com/132703/40377932-ca7d8446-5dfa-11e8-952d-0a9ce6bb756d.png)

**Sandbox URL**: TBD
**Merge deadline**: None

**Testing instructions**:
  
1. Answer some problems (multiple choice, numerical input, text input, dropdown, checkbox)
2. Add answers through another user too, so that you see more variety of data
3. Get the block ID for a particular problem 
4. From lms-shell, use a code like:
```python
from xmodule.modulestore.django import modulestore
from courseware.user_state_client import DjangoXBlockUserStateClient
from opaque_keys.edx.keys import UsageKey
user_state_client = DjangoXBlockUserStateClient()

block_key = UsageKey.from_string('block-v1:edX+DemoX+Demo_Course+type@problem+block@98e6a8e915904d5389821a94e48babcf')
block = modulestore().get_item(block_key)
user_state_iterator = user_state_client.iter_all_for_block(block_key)
res = block.generate_report_data(user_state_iterator, limit_responses=None)
for (user, data) in res:
  print("On question «{description}» user {username} answered «{answer}» (answer ID {answer_id})".format(
    answer_id=data["Answer ID"],
    description=data["Question"].encode('utf-8'),
    username=user,
    answer=data["Answer"],
))
```
5. Verify that the code shows a list of all student answers to that problem
6. Verify that the question name is provided correctly
7. Verify that the answers are provided in an easy format (e.g. real answer instead of "choice_0")
8. Verify that the reported answers are the _given_ answers, not the correct answers
9. Verify that each reported answers matches the answer chosen by the users (i.e. it doesn't report the adjacent one); try the different types of problem 
10. Create more complex problems, e.g. with a prompt (it should be identified as the question), with no prompt (the last paragraph before the choices should be identified as the question), two consecutive problems (the 2nd one, without a question text, will be reported as _Question 2_), other types (with hints, description, etc.)
11. Verify that the `limit_responses` does limit the number of reported answers: try 2, 0, None
12. Test edge cases (escaping, HTML, empty things, …)
 
To ease testing this, you can also add this report to the HTML of each block in Studio, and then you'll see it directly in Studio and won't need the shell. You'll need to temporarily add to `CapaMixin.get_problem_html` something like:
```python
        if True:
            from courseware.user_state_client import DjangoXBlockUserStateClient
            user_state_client = DjangoXBlockUserStateClient()
            rep = self.descriptor.generate_report_data(user_state_client.iter_all_for_block(self.location))
            rep = list(rep)
            from pprint import pprint, pformat
            html += "<h1>report data here</h1><pre>" + pformat(rep) + "</pre>"
```
  and you need to add `USER_STATE_BATCH_SIZE` to the list of lms-imports at `cms/envs/common.py` so that it doesn't fail.

**Reviewers**
- [ ] @xitij2000 
- [ ] edX reviewer

**Author concerns**: Not implemented for all problem types, just for the basic ones (see testing instructions above).
**Settings**: None
