### PR TITLE
Remove CourseStructure usage in CourseGraph

### DIFF
--- a/openedx/core/djangoapps/content/block_structure/signals.py
+++ b/openedx/core/djangoapps/content/block_structure/signals.py
@@ -14,7 +14,7 @@ from .tasks import update_course_in_cache_v2
 
 
 @receiver(SignalHandler.course_published)
-def _update_block_structure_on_course_publish(sender, course_key, **kwargs):  # pylint: disable=unused-argument
+def update_block_structure_on_course_publish(sender, course_key, **kwargs):  # pylint: disable=unused-argument
     """
     Catches the signal that a course has been published in the module
     store and creates/updates the corresponding cache entry.

--- a/openedx/core/djangoapps/content/block_structure/tests/test_signals.py
+++ b/openedx/core/djangoapps/content/block_structure/tests/test_signals.py
@@ -11,7 +11,7 @@ from xmodule.modulestore.tests.factories import CourseFactory
 
 from ..api import get_block_structure_manager
 from ..config import INVALIDATE_CACHE_ON_PUBLISH, waffle
-from ..signals import _update_block_structure_on_course_publish
+from ..signals import update_block_structure_on_course_publish
 from .helpers import is_course_in_block_structure_cache
 
 
@@ -78,5 +78,5 @@ class CourseBlocksSignalTest(ModuleStoreTestCase):
     @ddt.unpack
     @patch('openedx.core.djangoapps.content.block_structure.tasks.update_course_in_cache_v2.apply_async')
     def test_update_only_for_courses(self, key, expect_update_called, mock_update):
-        _update_block_structure_on_course_publish(sender=None, course_key=key)
+        update_block_structure_on_course_publish(sender=None, course_key=key)
         self.assertEqual(mock_update.called, expect_update_called)

--- a/openedx/core/djangoapps/coursegraph/tasks.py
+++ b/openedx/core/djangoapps/coursegraph/tasks.py
@@ -135,11 +135,16 @@ def get_course_last_published(course_key):
         was published.
     """
     # Import is placed here to avoid model import at project startup.
-    from openedx.core.djangoapps.content.course_structures.models import CourseStructure
+    from xmodule.modulestore.django import modulestore
+    from openedx.core.djangoapps.content.block_structure.models import BlockStructureModel
+    from openedx.core.djangoapps.content.block_structure.exceptions import BlockStructureNotFound
+
+    store = modulestore()
+    course_usage_key = store.make_course_usage_key(course_key)
     try:
-        structure = CourseStructure.objects.get(course_id=course_key)
+        structure = BlockStructureModel.get(course_usage_key)
         course_last_published_date = six.text_type(structure.modified)
-    except CourseStructure.DoesNotExist:
+    except BlockStructureNotFound:
         course_last_published_date = None
 
     return course_last_published_date


### PR DESCRIPTION
The course_structures module is deprecated and we are targeting removal of it from the edx-platform codebase. This PR removes its usage from coursegraph.  Information from `BlockStructures` is used instead.