### PR TITLE
Yro/EDUCATOR 2644

### DIFF
--- a/lms/djangoapps/edxnotes/views.py
+++ b/lms/djangoapps/edxnotes/views.py
@@ -24,7 +24,7 @@ from edxnotes.helpers import (
     get_course_position,
     get_edxnotes_id_token,
     get_notes,
-    is_feature_enabled
+    is_feature_enabled,
 )
 from util.json_request import JsonResponse, JsonResponseBadRequest
 


### PR DESCRIPTION
## [EDUCATOR 2644](https://openedx.atlassian.net/browse/EDUCATOR-2644)

### Description
Add LMS endpoint for Notes API ‘delete user PII’ as a part of GDPR work.

### Testing
- [ ] Unit tests

### Reviewers
If you've been tagged for review, please check your corresponding box once you've given the :+1:.
- [ ] Code review: @sanfordstudent 

FYI: @edx/educator-neem

### Post-review
- [ ] Rebase and squash commits

