### PR TITLE
OSPR-2352 | Support for theming .underscore files

### DIFF
--- a/common/djangoapps/pipeline_mako/templates/static_content.html
+++ b/common/djangoapps/pipeline_mako/templates/static_content.html
@@ -86,7 +86,13 @@ except:
 from django.conf import settings
 from django.template.engine import Engine
 from django.template.loaders.filesystem import Loader
-engine = Engine(dirs=settings.DEFAULT_TEMPLATE_ENGINE['DIRS'])
+from openedx.core.djangoapps.theming.helpers import get_current_theme
+dirs = settings.DEFAULT_TEMPLATE_ENGINE['DIRS']
+theme = get_current_theme()
+if theme:
+    dirs = list(dirs)
+    dirs.insert(0, theme.path / 'templates')
+engine = Engine(dirs=dirs)
 source, template_path = Loader(engine).load_template_source(path)
 %>${source | n, decode.utf8}</%def>
 


### PR DESCRIPTION
## OSPR

### Description

Making the include function used to support static .underscore templates support comprehensive_theming.

Currently for any feature using front-end rendering, the platform in the mako templates does `<%static:include path="template_name.underscore" />`. Overriding this template on the theme has no effect. That is exactly what this PR addresses.

This is particularly difficult when a theme tries to make changes to the combined login and registration pages.

### How to Test?

Use the regular instructions to activate a theme, override a `.underscore` template. See the changes on your site.

### Sandbox
There is a sandbox showcasing the changes in this PR
[https://pr17955.sandbox.opencraft.hosting](https://pr17955.sandbox.opencraft.hosting)

The theme that is being used is a [concept-theme](https://github.com/felipemontoya/openedx-concept-theme-underscore) that only modifies the `edx-platform/underscore-theme/lms/templates/student_account/login.underscore` template.
On the sandbox you can go to [/login](https://pr17955.sandbox.opencraft.hosting/login)

### Reviewers
If you've been tagged for review, please check your corresponding box once you've given the :+1:.

- [x] Code review: @diegomillan
- [x] Code review: Someone from edX


- - -
**Settings**
```yaml
EDXAPP_COMPREHENSIVE_THEME_DIRS:
  - '/edx/app/edxapp/themes/underscore-theme/edx-platform/'
EDXAPP_DEFAULT_SITE_THEME: underscore-theme
edxapp_theme_name: underscore-theme
edxapp_theme_source_repo: https://github.com/felipemontoya/openedx-concept-theme-underscore.git
edxapp_theme_version: master
COMMON_USER_INFO:
- github: true
  name: felipemontoya
  type: admin
- github: true
  name: itsjeyd
  type: admin
```