### PR TITLE
ENT-959: Deleted SAML Identity provider appears in the Enterprise customer IdPs list.

### DIFF
--- a/common/djangoapps/third_party_auth/admin.py
+++ b/common/djangoapps/third_party_auth/admin.py
@@ -66,7 +66,7 @@ class SAMLProviderConfigAdmin(KeyedConfigurationModelAdmin):
         """
         with transaction.atomic():
             for obj in queryset:
-                self.model.objects.filter(pk=obj.pk).update(archived=True)
+                self.model.objects.filter(pk=obj.pk).update(archived=True, enabled=False)
         self.message_user(request, _("Deleted the selected configuration(s)."))
 
     def get_list_display(self, request):


### PR DESCRIPTION
__JIRA Ticket:__ [ENT-959](https://openedx.atlassian.net/browse/ENT-959)
__Description:__
If the admin deletes an IdP from SAML Provider Configuration model, it still appears in the Enterprise customer Identity providers list. 
We just need to show the available IdPs in the Enterprise customer IdPs drop down.

__Testing Instructions:__
1. Login to Django admin.
2. Navigate to [Provider Configuration (SAML IdPs)](https://business.sandbox.edx.org/admin/third_party_auth/samlproviderconfig/).
3. Select and IdP from the list and delete the selected IdP configuration.
4. Navigate to [Enterprise Customer](https://business.sandbox.edx.org/admin/enterprise/enterprisecustomer/).
5. Click "Add Enterprise Customer" button.
6. Click on the enterprise customer Identity provider drop down and view.
7. Make sure deleted SAML Idp does not appear in the enterprise customer IdPs list.