### PR TITLE
Update list of supported browsers

### DIFF
--- a/common/lib/xmodule/xmodule/templates/about/overview.yaml
+++ b/common/lib/xmodule/xmodule/templates/about/overview.yaml
@@ -41,7 +41,7 @@ data: |
         <h2>Frequently Asked Questions</h2>
         <article class="response">
           <h3>What web browser should I use?</h3>
-          <p>The Open edX platform works best with current versions of Chrome, Firefox or Safari, or with Internet Explorer version 9 and above.</p>
+          <p>The Open edX platform works best with current versions of Chrome, Edge, Firefox, Internet Explorer, or Safari.</p>
           <p>See our <a href="http://edx.readthedocs.org/projects/open-edx-learner-guide/en/latest/front_matter/browsers.html">list of supported browsers</a> for the most up-to-date information.</p>
         </article>
 


### PR DESCRIPTION
Update the list of supported browsers in the example xblock "about" page template.

I don't see a reason to call out the version of IE specifically, since we say we support the current version. IE has one current version (11) that's been out for 5 years and won't see another release.