### PR TITLE
pass context_title and _label to LTI provider

### DIFF
--- a/common/lib/xmodule/xmodule/lti_module.py
+++ b/common/lib/xmodule/xmodule/lti_module.py
@@ -416,7 +416,6 @@ class LTIModule(LTIFields, LTI20ModuleMixin, XModule):
         #
         # This lets all plaintext through.
         sanitized_comment = bleach.clean(self.score_comment)
-        course = self.get_course()
 
         return {
             'input_fields': self.get_input_fields(),
@@ -438,8 +437,6 @@ class LTIModule(LTIFields, LTI20ModuleMixin, XModule):
             'ask_to_send_email': self.ask_to_send_email,
             'button_text': self.button_text,
             'accept_grades_past_due': self.accept_grades_past_due,
-            'context_title': course.display_name_with_default,
-            'context_label': course.display_org_with_default,
         }
 
     def get_html(self):

--- a/lms/djangoapps/courseware/tests/test_lti_integration.py
+++ b/lms/djangoapps/courseware/tests/test_lti_integration.py
@@ -46,7 +46,6 @@ class TestLTI(BaseTestXmodule):
         user_id = text_type(self.item_descriptor.xmodule_runtime.anonymous_student_id)
         hostname = self.item_descriptor.xmodule_runtime.hostname
         resource_link_id = text_type(urllib.quote('{}-{}'.format(hostname, self.item_descriptor.location.html_id())))
-        course = self.store.get_course(self.item_descriptor.course_id)
 
         sourcedId = "{context}:{resource_link}:{user_id}".format(
             context=urllib.quote(context_id),
@@ -95,8 +94,6 @@ class TestLTI(BaseTestXmodule):
             'description': self.item_descriptor.description,
             'button_text': self.item_descriptor.button_text,
             'accept_grades_past_due': self.item_descriptor.accept_grades_past_due,
-            'context_title': course.display_name_with_default,
-            'context_label': course.display_org_with_default,
         }
 
         def mocked_sign(self, *args, **kwargs):

--- a/lms/djangoapps/lti_provider/tests/test_views.py
+++ b/lms/djangoapps/lti_provider/tests/test_views.py
@@ -28,6 +28,8 @@ LTI_DEFAULT_PARAMS = {
 }
 
 LTI_OPTIONAL_PARAMS = {
+    'context_title': u'context title',
+    'context_label': u'context label',
     'lis_result_sourcedid': u'result sourcedid',
     'lis_outcome_service_url': u'outcome service URL',
     'tool_consumer_instance_guid': u'consumer instance guid'
@@ -94,6 +96,21 @@ class LtiLaunchTest(LtiTestMixin, TestCase):
         request = build_launch_request()
         views.lti_launch(request, unicode(COURSE_KEY), unicode(USAGE_KEY))
         render.assert_called_with(request, USAGE_KEY)
+
+    @patch('lti_provider.views.render_courseware')
+    @patch('lti_provider.views.store_outcome_parameters')
+    @patch('lti_provider.views.authenticate_lti_user')
+    def test_valid_launch_with_optional_params(self, _authenticate, store_params, _render):
+        """
+        Verifies that the LTI launch succeeds when passed a valid request.
+        """
+        request = build_launch_request(extra_post_data=LTI_OPTIONAL_PARAMS)
+        views.lti_launch(request, unicode(COURSE_KEY), unicode(USAGE_KEY))
+        store_params.assert_called_with(
+            dict(ALL_PARAMS.items() + LTI_OPTIONAL_PARAMS.items()),
+            request.user,
+            self.consumer
+        )
 
     @patch('lti_provider.views.render_courseware')
     @patch('lti_provider.views.store_outcome_parameters')

--- a/lms/djangoapps/lti_provider/views.py
+++ b/lms/djangoapps/lti_provider/views.py
@@ -28,8 +28,8 @@ REQUIRED_PARAMETERS = [
 ]
 
 OPTIONAL_PARAMETERS = [
-    'lis_result_sourcedid', 'lis_outcome_service_url',
-    'tool_consumer_instance_guid'
+    'context_title', 'context_label', 'lis_result_sourcedid',
+    'lis_outcome_service_url', 'tool_consumer_instance_guid'
 ]
 
 


### PR DESCRIPTION
# [EDUCATOR-2516](https://openedx.atlassian.net/browse/EDUCATOR-2516)

edx-status-bot: ignore

I've finally figured out what went wrong - the previous PR was modifying our LTI **consumer** to **send** these params when making requests; we really needed to update the **provider** to do a passthrough **return** these values if they exist on the request. I've modified the LTI Provider tests to validate this.