### PR TITLE
Remove Completion's usage of Course Structures API

### DIFF
--- a/requirements/edx-sandbox/base.txt
+++ b/requirements/edx-sandbox/base.txt
@@ -16,7 +16,7 @@ cryptography==2.1.4
 enum34==1.1.6
 futures==3.2.0            # via tornado
 idna==2.6
-ipaddress==1.0.19
+ipaddress==1.0.22
 lxml==3.8.0
 matplotlib==1.3.1
 networkx==1.7

--- a/requirements/edx-sandbox/shared.txt
+++ b/requirements/edx-sandbox/shared.txt
@@ -14,7 +14,7 @@ cffi==1.11.5              # via cryptography
 cryptography==2.1.4
 enum34==1.1.6             # via cryptography
 idna==2.6                 # via cryptography
-ipaddress==1.0.19         # via cryptography
+ipaddress==1.0.22         # via cryptography
 lxml==3.8.0
 networkx==1.7
 nltk==3.2.5

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -72,7 +72,7 @@ cryptography==2.1.4
 cssselect==0.9.1
 cssutils==1.0.2           # via pynliner
 ddt==0.8.0
-decorator==4.2.1          # via dogapi, pycontracts
+decorator==4.3.0          # via dogapi, pycontracts
 defusedxml==0.4.1
 dicttoxml==1.7.4          # via moto
 django-appconf==1.0.2     # via django-statici18n
@@ -121,7 +121,7 @@ edx-ace==0.1.6
 edx-analytics-data-api-client==0.14.4
 edx-ccx-keys==0.2.1
 edx-celeryutils==0.2.7
-edx-completion==0.1.5
+edx-completion==0.1.6
 edx-django-oauth2-provider==1.2.5
 edx-django-release-util==0.3.1
 edx-django-sites-extensions==2.3.1
@@ -166,7 +166,7 @@ httplib2==0.11.3          # via oauth2, zendesk
 httpretty==0.8.14
 idna==2.6
 ipaddr==2.1.11
-ipaddress==1.0.19
+ipaddress==1.0.22
 isodate==0.6.0            # via python-saml
 itsdangerous==0.24        # via flask
 jinja2==2.10              # via flask, moto, sphinx

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -80,7 +80,7 @@ cryptography==2.1.4
 cssselect==0.9.1
 cssutils==1.0.2
 ddt==0.8.0
-decorator==4.2.1
+decorator==4.3.0
 defusedxml==0.4.1
 dicttoxml==1.7.4
 diff-cover==0.9.8
@@ -130,7 +130,7 @@ edx-ace==0.1.6
 edx-analytics-data-api-client==0.14.4
 edx-ccx-keys==0.2.1
 edx-celeryutils==0.2.7
-edx-completion==0.1.5
+edx-completion==0.1.6
 edx-django-oauth2-provider==1.2.5
 edx-django-release-util==0.3.1
 edx-django-sites-extensions==2.3.1
@@ -180,7 +180,7 @@ idna==2.6
 incremental==17.5.0
 inflect==0.2.5
 ipaddr==2.1.11
-ipaddress==1.0.19
+ipaddress==1.0.22
 isodate==0.6.0
 isort==4.2.5
 itsdangerous==0.24
@@ -313,7 +313,7 @@ sympy==0.7.1
 testfixtures==4.5.0
 testtools==0.9.34
 text-unidecode==1.2
-tox-battery==0.5
+tox-battery==0.5.1
 tox==2.8.2
 transifex-client==0.12.1
 twisted==16.6.0

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -79,7 +79,7 @@ cryptography==2.1.4
 cssselect==0.9.1
 cssutils==1.0.2
 ddt==0.8.0
-decorator==4.2.1
+decorator==4.3.0
 defusedxml==0.4.1
 dicttoxml==1.7.4
 diff-cover==0.9.8
@@ -128,7 +128,7 @@ edx-ace==0.1.6
 edx-analytics-data-api-client==0.14.4
 edx-ccx-keys==0.2.1
 edx-celeryutils==0.2.7
-edx-completion==0.1.5
+edx-completion==0.1.6
 edx-django-oauth2-provider==1.2.5
 edx-django-release-util==0.3.1
 edx-django-sites-extensions==2.3.1
@@ -177,7 +177,7 @@ idna==2.6
 incremental==17.5.0       # via twisted
 inflect==0.2.5
 ipaddr==2.1.11
-ipaddress==1.0.19
+ipaddress==1.0.22
 isodate==0.6.0
 isort==4.2.5
 itsdangerous==0.24
@@ -308,7 +308,7 @@ sympy==0.7.1
 testfixtures==4.5.0
 testtools==0.9.34
 text-unidecode==1.2
-tox-battery==0.5
+tox-battery==0.5.1
 tox==2.8.2
 transifex-client==0.12.1
 twisted==16.6.0           # via pa11ycrawler, scrapy


### PR DESCRIPTION
Upgrades `completion` library to version 0.1.6, which removes its dependency on the deprecated Course Structures API.