### PR TITLE
[ENT-962] Add Enterprise middleware that injects customer data.

### DIFF
--- a/common/djangoapps/enrollment/tests/test_views.py
+++ b/common/djangoapps/enrollment/tests/test_views.py
@@ -33,6 +33,7 @@ from openedx.core.djangoapps.embargo.test_utils import restrict_course
 from openedx.core.djangoapps.user_api.models import UserOrgTag
 from openedx.core.lib.django_test_client_utils import get_absolute_url
 from openedx.core.lib.token_utils import JwtBuilder
+from openedx.features.enterprise_support.tests import FAKE_ENTERPRISE_CUSTOMER
 from openedx.features.enterprise_support.tests.mixins.enterprise import EnterpriseServiceMockMixin
 from student.models import CourseEnrollment
 from student.roles import CourseStaffRole
@@ -932,7 +933,8 @@ class EnrollmentTest(EnrollmentTestMixin, ModuleStoreTestCase, APITestCase, Ente
     @httpretty.activate
     @override_settings(ENTERPRISE_SERVICE_WORKER_USERNAME='enterprise_worker',
                        FEATURES=dict(ENABLE_ENTERPRISE_INTEGRATION=True))
-    def test_enterprise_course_enrollment_with_ec_uuid(self):
+    @patch('openedx.features.enterprise_support.api.enterprise_customer_from_api')
+    def test_enterprise_course_enrollment_with_ec_uuid(self, mock_enterprise_customer_from_api):
         """Verify that the enrollment completes when the EnterpriseCourseEnrollment creation succeeds. """
         UserFactory.create(
             username='enterprise_worker',
@@ -949,6 +951,7 @@ class EnrollmentTest(EnrollmentTestMixin, ModuleStoreTestCase, APITestCase, Ente
             'course_id': unicode(self.course.id),
             'ec_uuid': 'this-is-a-real-uuid'
         }
+        mock_enterprise_customer_from_api.return_value = FAKE_ENTERPRISE_CUSTOMER
         self.mock_enterprise_course_enrollment_post_api()
         self.mock_consent_missing(**consent_kwargs)
         self.mock_consent_post(**consent_kwargs)

--- a/common/djangoapps/util/views.py
+++ b/common/djangoapps/util/views.py
@@ -454,8 +454,8 @@ def submit_feedback(request):
     success = False
     context = get_feedback_form_context(request)
 
-    #Update the tag info with 'enterprise_learner' if the user belongs to an enterprise customer.
-    enterprise_learner_data = enterprise_api.get_enterprise_learner_data(site=request.site, user=request.user)
+    # Update the tag info with 'enterprise_learner' if the user belongs to an enterprise customer.
+    enterprise_learner_data = enterprise_api.get_enterprise_learner_data(user=request.user)
     if enterprise_learner_data:
         context["tags"]["learner_type"] = "enterprise_learner"
 

--- a/lms/djangoapps/support/views/contact_us.py
+++ b/lms/djangoapps/support/views/contact_us.py
@@ -33,7 +33,7 @@ class ContactUsView(View):
 
         if request.user.is_authenticated():
             context['user_enrollments'] = CourseEnrollment.enrollments_for_user_with_overviews_preload(request.user)
-            enterprise_learner_data = enterprise_api.get_enterprise_learner_data(site=request.site, user=request.user)
+            enterprise_learner_data = enterprise_api.get_enterprise_learner_data(user=request.user)
             if enterprise_learner_data:
                 tags.append('enterprise_learner')
 

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -1275,8 +1275,6 @@ MIDDLEWARE_CLASSES = [
     # Must be after DarkLangMiddleware.
     'django.middleware.locale.LocaleMiddleware',
 
-    # 'debug_toolbar.middleware.DebugToolbarMiddleware',
-
     'django_comment_client.utils.ViewNameMiddleware',
     'codejail.django_integration.ConfigureCodeJailMiddleware',
 
@@ -1297,6 +1295,9 @@ MIDDLEWARE_CLASSES = [
     'openedx.core.djangoapps.theming.middleware.CurrentSiteThemeMiddleware',
 
     'waffle.middleware.WaffleMiddleware',
+
+    # Inserts Enterprise content.
+    'openedx.features.enterprise_support.middleware.EnterpriseMiddleware',
 
     # This must be last
     'openedx.core.djangoapps.site_configuration.middleware.SessionCookieDomainOverrideMiddleware',

--- a/lms/urls.py
+++ b/lms/urls.py
@@ -143,7 +143,7 @@ urlpatterns = [
 
 # TODO: This needs to move to a separate urls.py once the student_account and
 # student views below find a home together
-if settings.FEATURES['ENABLE_COMBINED_LOGIN_REGISTRATION']:
+if settings.FEATURES.get('ENABLE_COMBINED_LOGIN_REGISTRATION'):
     # Backwards compatibility with old URL structure, but serve the new views
     urlpatterns += [
         url(r'^login$', student_account_views.login_and_registration_form,
@@ -158,12 +158,12 @@ else:
         url(r'^register$', student_views.register_user, name='register_user'),
     ]
 
-if settings.FEATURES['ENABLE_MOBILE_REST_API']:
+if settings.FEATURES.get('ENABLE_MOBILE_REST_API'):
     urlpatterns += [
         url(r'^api/mobile/v0.5/', include('mobile_api.urls')),
     ]
 
-if settings.FEATURES['ENABLE_OPENBADGES']:
+if settings.FEATURES.get('ENABLE_OPENBADGES'):
     urlpatterns += [
         url(r'^api/badges/v1/', include('badges.api.urls', app_name='badges', namespace='badges_api')),
     ]
@@ -174,7 +174,7 @@ urlpatterns += [
 
 
 # sysadmin dashboard, to see what courses are loaded, to delete & load courses
-if settings.FEATURES['ENABLE_SYSADMIN_DASHBOARD']:
+if settings.FEATURES.get('ENABLE_SYSADMIN_DASHBOARD'):
     urlpatterns += [
         url(r'^sysadmin/', include('dashboard.sysadmin_urls')),
     ]
@@ -675,7 +675,7 @@ urlpatterns += [
     ),
 ]
 
-if settings.FEATURES['ENABLE_TEAMS']:
+if settings.FEATURES.get('ENABLE_TEAMS'):
     # Teams endpoints
     urlpatterns += [
         url(
@@ -831,7 +831,7 @@ if settings.FEATURES.get('RESTRICT_ENROLL_BY_REG_METHOD'):
             external_auth_views.course_specific_register, name='course-specific-register'),
     ]
 
-if configuration_helpers.get_value('ENABLE_BULK_ENROLLMENT_VIEW', settings.FEATURES['ENABLE_BULK_ENROLLMENT_VIEW']):
+if configuration_helpers.get_value('ENABLE_BULK_ENROLLMENT_VIEW', settings.FEATURES.get('ENABLE_BULK_ENROLLMENT_VIEW')):
     urlpatterns += [
         url(r'^api/bulk_enroll/v1/', include('bulk_enroll.urls')),
     ]
@@ -994,7 +994,7 @@ urlpatterns += [
 ]
 
 # Custom courses on edX (CCX) URLs
-if settings.FEATURES['CUSTOM_COURSES_EDX']:
+if settings.FEATURES.get('CUSTOM_COURSES_EDX'):
     urlpatterns += [
         url(r'^courses/{}/'.format(settings.COURSE_ID_PATTERN),
             include('ccx.urls')),

--- a/openedx/features/enterprise_support/middleware.py
+++ b/openedx/features/enterprise_support/middleware.py
@@ -1,0 +1,29 @@
+"""
+Middleware for the Enterprise feature.
+
+The Enterprise feature must be turned on for this middleware to have any effect.
+"""
+
+from django.core.exceptions import MiddlewareNotUsed
+
+from openedx.features.enterprise_support import api
+
+
+class EnterpriseMiddleware(object):
+    """
+    Middleware that adds Enterprise-related content to the request.
+    """
+
+    def __init__(self):
+        """
+        We don't need to use this middleware if the Enterprise feature isn't enabled.
+        """
+        if not api.enterprise_enabled():
+            raise MiddlewareNotUsed()
+
+    def process_request(self, request):
+        """
+        Fill the request with Enterprise-related content.
+        """
+        if 'enterprise_customer' not in request.session and request.user.is_authenticated():
+            request.session['enterprise_customer'] = api.enterprise_customer_for_request(request)

--- a/openedx/features/enterprise_support/tests/__init__.py
+++ b/openedx/features/enterprise_support/tests/__init__.py
@@ -1,0 +1,23 @@
+"""
+Things commonly needed in Enterprise tests.
+"""
+
+from django.conf import settings
+
+FEATURES_WITH_ENTERPRISE_ENABLED = settings.FEATURES.copy()
+FEATURES_WITH_ENTERPRISE_ENABLED['ENABLE_ENTERPRISE_INTEGRATION'] = True
+
+FAKE_ENTERPRISE_CUSTOMER = {
+    'active': True,
+    'branding_configuration': None,
+    'catalog': None,
+    'enable_audit_enrollment': False,
+    'enable_data_sharing_consent': False,
+    'enforce_data_sharing_consent': 'at_enrollment',
+    'enterprise_customer_entitlements': [],
+    'identity_provider': None,
+    'name': 'EnterpriseCustomer',
+    'replace_sensitive_sso_username': True,
+    'site': {'domain': 'example.com', 'name': 'example.com'},
+    'uuid': '1cbf230f-f514-4a05-845e-d57b8e29851c'
+}

--- a/openedx/features/enterprise_support/tests/mixins/enterprise.py
+++ b/openedx/features/enterprise_support/tests/mixins/enterprise.py
@@ -10,6 +10,8 @@ from django.core.cache import cache
 from django.core.urlresolvers import reverse
 from django.test import SimpleTestCase
 
+from openedx.features.enterprise_support.tests import FAKE_ENTERPRISE_CUSTOMER
+
 
 class EnterpriseServiceMockMixin(object):
     """
@@ -177,7 +179,8 @@ class EnterpriseServiceMockMixin(object):
                                 'enterprise_customer': enterprise_customer_uuid,
                                 'entitlement_id': entitlement_id
                             }
-                        ]
+                        ],
+                        'replace_sensitive_sso_username': True,
                     },
                     'user_id': 5,
                     'user': {
@@ -220,6 +223,7 @@ class EnterpriseTestConsentRequired(SimpleTestCase):
     Mixin to help test the data_sharing_consent_required decorator.
     """
 
+    @mock.patch('openedx.features.enterprise_support.api.enterprise_customer_from_api')
     @mock.patch('openedx.features.enterprise_support.api.enterprise_customer_uuid_for_request')
     @mock.patch('openedx.features.enterprise_support.api.reverse')
     @mock.patch('openedx.features.enterprise_support.api.enterprise_enabled')
@@ -232,6 +236,7 @@ class EnterpriseTestConsentRequired(SimpleTestCase):
             mock_enterprise_enabled,
             mock_reverse,
             mock_enterprise_customer_uuid_for_request,
+            mock_enterprise_customer_from_api,
             status_code=200,
     ):
         """
@@ -247,6 +252,7 @@ class EnterpriseTestConsentRequired(SimpleTestCase):
         mock_reverse.side_effect = mock_consent_reverse
         mock_enterprise_enabled.return_value = True
         mock_enterprise_customer_uuid_for_request.return_value = 'fake-uuid'
+        mock_enterprise_customer_from_api.return_value = FAKE_ENTERPRISE_CUSTOMER
         # Ensure that when consent is necessary, the user is redirected to the consent page.
         mock_consent_necessary.return_value = True
         response = client.get(url)

--- a/openedx/features/enterprise_support/tests/test_api.py
+++ b/openedx/features/enterprise_support/tests/test_api.py
@@ -2,8 +2,6 @@
 Test the enterprise support APIs.
 """
 
-import unittest
-
 import ddt
 import httpretty
 import mock
@@ -15,7 +13,7 @@ from django.http import HttpResponseRedirect
 from django.test.utils import override_settings
 
 from consent.models import DataSharingConsent
-from openedx.core.djangolib.testing.utils import CacheIsolationTestCase
+from openedx.core.djangolib.testing.utils import CacheIsolationTestCase, skip_unless_lms
 from openedx.features.enterprise_support.api import (
     ConsentApiClient,
     ConsentApiServiceClient,
@@ -30,14 +28,11 @@ from openedx.features.enterprise_support.api import (
     insert_enterprise_pipeline_elements,
     enterprise_enabled,
 )
+from openedx.features.enterprise_support.tests import FEATURES_WITH_ENTERPRISE_ENABLED
 from openedx.features.enterprise_support.tests.factories import EnterpriseCustomerUserFactory
 from openedx.features.enterprise_support.tests.mixins.enterprise import EnterpriseServiceMockMixin
 from openedx.features.enterprise_support.utils import get_cache_key
 from student.tests.factories import UserFactory
-
-
-FEATURES_WITH_ENTERPRISE_ENABLED = settings.FEATURES.copy()
-FEATURES_WITH_ENTERPRISE_ENABLED['ENABLE_ENTERPRISE_INTEGRATION'] = True
 
 
 class MockEnrollment(mock.MagicMock):
@@ -51,7 +46,7 @@ class MockEnrollment(mock.MagicMock):
 
 @ddt.ddt
 @override_settings(FEATURES=FEATURES_WITH_ENTERPRISE_ENABLED)
-@unittest.skipUnless(settings.ROOT_URLCONF == 'lms.urls', 'Test only valid in lms')
+@skip_unless_lms
 class TestEnterpriseApi(EnterpriseServiceMockMixin, CacheIsolationTestCase):
     """
     Test enterprise support APIs.

--- a/openedx/features/enterprise_support/tests/test_middleware.py
+++ b/openedx/features/enterprise_support/tests/test_middleware.py
@@ -1,0 +1,66 @@
+"""
+Tests for Enterprise middleware.
+"""
+
+import mock
+
+from django.core.urlresolvers import reverse
+from django.test import TestCase
+from django.test.utils import override_settings
+
+from openedx.core.djangolib.testing.utils import skip_unless_lms
+from openedx.features.enterprise_support.tests import (
+    FAKE_ENTERPRISE_CUSTOMER, FEATURES_WITH_ENTERPRISE_ENABLED,
+    factories
+)
+from student.tests.factories import UserFactory
+
+
+@override_settings(FEATURES=FEATURES_WITH_ENTERPRISE_ENABLED)
+@skip_unless_lms
+class EnterpriseMiddlewareTest(TestCase):
+    """
+    Test for `EnterpriseMiddleware`.
+    """
+
+    def setUp(self):
+        """Initiate commonly needed objects."""
+        super(EnterpriseMiddlewareTest, self).setUp()
+
+        # Customer & Learner details.
+        self.user = UserFactory.create(username='username', password='password')
+        self.enterprise_customer = FAKE_ENTERPRISE_CUSTOMER
+        self.enterprise_learner = factories.EnterpriseCustomerUserFactory(user_id=self.user.id)
+
+        # Request details.
+        self.client.login(username='username', password='password')
+        self.dashboard = reverse('dashboard')
+
+        # Mocks.
+        patcher = mock.patch('openedx.features.enterprise_support.api.enterprise_customer_from_api')
+        self.mock_enterprise_customer_from_api = patcher.start()
+        self.mock_enterprise_customer_from_api.return_value = self.enterprise_customer
+        self.addCleanup(patcher.stop)
+
+    def test_anonymous_user(self):
+        """The `enterprise_customer` is not set in the session if the user is anonymous."""
+        self.client.logout()
+        self.client.get(self.dashboard)
+        assert self.client.session.get('enterprise_customer') is None
+
+    def test_enterprise_customer(self):
+        """The `enterprise_customer` gets set in the session."""
+        self.client.get(self.dashboard)
+        assert self.client.session.get('enterprise_customer') == self.enterprise_customer
+
+    def test_enterprise_customer_cached(self):
+        """The middleware doesn't attempt to refill `enterprise_customer` if it already exists in the session."""
+        assert not self.mock_enterprise_customer_from_api.called
+
+        # First call populates the session by calling the API.
+        self.client.get(self.dashboard)
+        assert self.mock_enterprise_customer_from_api.call_count == 1
+
+        # Second same call has no need to call the API because the session already contains the data.
+        self.client.get(self.dashboard)
+        assert self.mock_enterprise_customer_from_api.call_count == 1

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -115,13 +115,13 @@ edx-django-oauth2-provider==1.2.5
 edx-django-release-util==0.3.1
 edx-django-sites-extensions==2.3.1
 edx-drf-extensions==1.2.5
-edx-enterprise==0.67.5
+edx-enterprise==0.67.6
 edx-i18n-tools==0.4.4
 edx-milestones==0.1.13
 edx-oauth2-provider==1.2.2
 edx-opaque-keys[django]==0.4.4
 edx-organizations==0.4.10
-edx-proctoring==1.3.9
+edx-proctoring==1.4.0
 edx-rest-api-client==1.7.1
 edx-search==1.1.0
 edx-submissions==2.0.12

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -134,14 +134,14 @@ edx-django-oauth2-provider==1.2.5
 edx-django-release-util==0.3.1
 edx-django-sites-extensions==2.3.1
 edx-drf-extensions==1.2.5
-edx-enterprise==0.67.5
+edx-enterprise==0.67.6
 edx-i18n-tools==0.4.4
 edx-lint==0.5.4
 edx-milestones==0.1.13
 edx-oauth2-provider==1.2.2
 edx-opaque-keys[django]==0.4.4
 edx-organizations==0.4.10
-edx-proctoring==1.3.9
+edx-proctoring==1.4.0
 edx-rest-api-client==1.7.1
 edx-search==1.1.0
 edx-sphinx-theme==1.3.0
@@ -328,4 +328,4 @@ xblock-review==1.1.5
 xblock==1.1.1
 xmltodict==0.4.1
 zendesk==1.1.1
-zope.interface==4.4.3
+zope.interface==4.5.0

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -129,14 +129,14 @@ edx-django-oauth2-provider==1.2.5
 edx-django-release-util==0.3.1
 edx-django-sites-extensions==2.3.1
 edx-drf-extensions==1.2.5
-edx-enterprise==0.67.5
+edx-enterprise==0.67.6
 edx-i18n-tools==0.4.4
 edx-lint==0.5.4
 edx-milestones==0.1.13
 edx-oauth2-provider==1.2.2
 edx-opaque-keys[django]==0.4.4
 edx-organizations==0.4.10
-edx-proctoring==1.3.9
+edx-proctoring==1.4.0
 edx-rest-api-client==1.7.1
 edx-search==1.1.0
 edx-submissions==2.0.12
@@ -311,4 +311,4 @@ xblock-review==1.1.5
 xblock==1.1.1
 xmltodict==0.4.1
 zendesk==1.1.1
-zope.interface==4.4.3     # via twisted
+zope.interface==4.5.0     # via twisted


### PR DESCRIPTION
To fix the performance issues from #17910, we cache the needed Enterprise Customer data into the user's session through a custom middleware.

The middleware can be used for many Enterprise-related purposes now, too.

*Testing instructions*:

1. Create a customer with the `replace_sensitive_sso_username` field enabled.
2. Go into incognito on your browser.
3. Make a new user.
4. Login and make sure you see the proper username on the top-right corner and the progress page.
3. Link that user to the customer you created in step 1.
4. Go to any page and see that username in the top-right corner is the generic enterprise username, including on the progress page.
5. Disable `replace_sensitive_sso_username` on the customer and see that you _still_ have a modified name -- this means the data is being cached in the session.
6. Delete the link between your user and the customer, and see that you _still_ have a modified name -- this means the data is being cached in the session.
7. Log out and log back in, and notice your username is back to normal -- the auth session has been refreshed, and the updated data from steps 5 & 6 means you aren't linked anymore to a customer requiring SSO username replacement.