### PR TITLE
VAL version bump

### DIFF
--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -137,7 +137,7 @@ edx-rest-api-client==1.7.1
 edx-search==1.1.0
 edx-submissions==2.0.12
 edx-user-state-client==1.0.4
-edxval==0.1.12
+edxval==0.1.13
 elasticsearch==1.9.0      # via edx-search
 enum34==1.1.6
 event-tracking==0.2.4


### PR DESCRIPTION
VAL bump version from `0.1.12` to `0.1.13`.

This is required for https://github.com/edx/edx-platform/pull/17589