### PR TITLE
Discussion moderators, TA's ,admins see the posts according to cohorts.

### DIFF
--- a/common/static/common/js/discussion/views/new_post_view.js
+++ b/common/static/common/js/discussion/views/new_post_view.js
@@ -135,6 +135,7 @@
                 },
                 'submit .forum-new-post-form': 'createPost',
                 'change .post-option-input': 'postOptionChange',
+                'change .js-group-select': 'groupOptionChange',
                 'click .cancel': 'cancel',
                 'click  .add-post-cancel': 'cancel',
                 'reset .forum-new-post-form': 'updateStyles',
@@ -146,6 +147,7 @@
             NewPostView.prototype.toggleGroupDropdown = function($target) {
                 if ($target.data('divided')) {
                     $('.js-group-select').prop('disabled', false);
+                    $('.js-group-select').val('').prop('selected', true);
                     return $('.group-selector-wrapper').removeClass('disabled');
                 } else {
                     $('.js-group-select').val('').prop('disabled', true);
@@ -255,6 +257,14 @@
             NewPostView.prototype.updateStyles = function() {
                 var self = this;
                 return setTimeout(function() { return self.$('.post-option-input').trigger('change'); }, 1);
+            };
+
+            NewPostView.prototype.groupOptionChange = function(event) {
+                var $target = $(event.target),
+                    data = $target.data();
+                this.group_name = this.$('.js-group-select option:selected').text();
+                data.divided = true;
+                this.updateVisibilityMessage($target);
             };
 
             return NewPostView;

--- a/common/static/common/js/spec/discussion/view/new_post_view_spec.js
+++ b/common/static/common/js/spec/discussion/view/new_post_view_spec.js
@@ -95,6 +95,25 @@
                 $('.post-topic').trigger('change');
                 return checkVisibility(this.view, true, false, false);
             });
+            it('visibility message changes when group is changed', function() {
+                DiscussionSpecHelper.makeModerator();
+                checkVisibility(this.view, true, false, true);
+
+                $('option:contains(Topic)').prop('selected', true);
+                $('.post-topic').trigger('change');
+                expect($('.js-group-select option:selected').text())
+                    .toEqual('All Groups');
+                expect($('.group-visibility').text().trim())
+                    .toEqual('This post will be visible only to All Groups.');
+
+                $('.js-group-select option:contains(Cohort1)').prop('selected', true);
+                $('.js-group-select').trigger('change');
+                expect($('.js-group-select option:selected').text())
+                    .toEqual('Cohort1');
+                expect($('.group-visibility').text().trim())
+                    .toEqual('This post will be visible only to Cohort1.');
+                return checkVisibility(this.view, true, false, false);
+            });
             it('allows the user to make a group selection', function() {
                 var expectedGroupId,
                     self = this;


### PR DESCRIPTION
## [Discussion moderators see "This post will be visible only to Default Group" in the "Add Post" view, even when posting in cohorts EDUCATOR-2692](https://openedx.atlassian.net/browse/EDUCATOR-2692)

### Description:
This PR fixes that when discussion moderators, TA's and admins select the cohorts from group selector, message of group selector changes according to cohorts.

### How to Test?
**Production**
 - https://courses.edx.org/courses/course-v1:AdelaideX+AnalysisX+3T2017/discussion/forum/
- Select a Topic area that is divided by cohorts.
- Select "Visible to" and any of the cohorts.
- Observe that text line will not update according to cohort name.

**Sandbox**
- https://cohorts.sandbox.edx.org/courses/course-v1:edX+DemoX+Demo_Course/discussion/forum/
- Select topic area *Video presentation style*
- Select "Visibile to" and any of the cohorts.
- Observe that text line will update according to selected cohot name.


### Test
- [x] Jasmine Test

### Screenshot
**Before Fix**
<img width="779" alt="screen shot 2018-04-16 at 2 26 33 pm" src="https://user-images.githubusercontent.com/7627421/38801528-79889a64-4183-11e8-993b-f0b4196be20a.png">


**After Fix**
<img width="780" alt="screen shot 2018-04-16 at 2 26 45 pm" src="https://user-images.githubusercontent.com/7627421/38801447-45fd11a2-4183-11e8-9433-6f57dc753271.png">

### Reviewers

If you've been tagged for review, please check your corresponding box once you've given the :+1:.
-  [x] @Rabia23 
-  [x] @sanfordstudent 

### Post-review
- [x] Rebase and squash commits


