### PR TITLE
Catch HttpError thrown by Python Social Auth.

### DIFF
--- a/common/djangoapps/third_party_auth/tests/test_middleware.py
+++ b/common/djangoapps/third_party_auth/tests/test_middleware.py
@@ -1,0 +1,42 @@
+"""
+Tests for third party auth middleware
+"""
+import mock
+from django.contrib.messages.middleware import MessageMiddleware
+from django.http import HttpResponse
+from django.test.client import RequestFactory
+from requests.exceptions import HTTPError
+
+from openedx.core.djangolib.testing.utils import skip_unless_lms
+from third_party_auth.middleware import ExceptionMiddleware
+from third_party_auth.tests.testutil import TestCase
+from student.helpers import get_next_url_for_login_page
+
+
+class ThirdPartyAuthMiddlewareTestCase(TestCase):
+    """Tests that ExceptionMiddleware is correctly redirected"""
+
+    @skip_unless_lms
+    @mock.patch('django.conf.settings.MESSAGE_STORAGE', 'django.contrib.messages.storage.cookie.CookieStorage')
+    def test_http_exception_redirection(self):
+        """
+        Test ExceptionMiddleware is correctly redirected to login page
+        when PSA raises HttpError exception.
+        """
+
+        request = RequestFactory().get("dummy_url")
+        next_url = get_next_url_for_login_page(request)
+        login_url = '/login?next=' + next_url
+        request.META['HTTP_REFERER'] = 'http://example.com:8000/login'
+        exception = HTTPError()
+        exception.response = HttpResponse(status=502)
+
+        # Add error message for error in auth pipeline
+        MessageMiddleware().process_request(request)
+        response = ExceptionMiddleware().process_exception(
+            request, exception
+        )
+        target_url = response.url
+
+        self.assertEqual(response.status_code, 302)
+        self.assertTrue(target_url.endswith(login_url))


### PR DESCRIPTION
This patch enables catching HttpError exception raised
by PSA because of any issue caused at client/server.
Further it redirects user to login page with a
message about the error.

LEARNER-4344