### PR TITLE
Fix styling of button on certificate & membership page.

### DIFF
--- a/lms/static/sass/course/instructor/_instructor_2.scss
+++ b/lms/static/sass/course/instructor/_instructor_2.scss
@@ -168,7 +168,7 @@
 
       position: relative;
       display: inline-block;
-      width: 250px;
+      width: 265px;
       vertical-align: middle;
       border: 1px solid $lightGrey1;
       background: $white;
@@ -177,7 +177,7 @@
     }
 
     .file-browse {
-      @include margin-left(-4px);
+      @include margin-left(-5px);
 
       display: inline-block;
       position: absolute;
@@ -185,6 +185,9 @@
       left: 0;
       width: 100%;
       overflow: hidden;
+      padding: 0;
+      border: none;
+      background: transparent;
 
       .browse {
         @include button(simple, $primary);

--- a/lms/templates/instructor/instructor_dashboard_2/membership.html
+++ b/lms/templates/instructor/instructor_dashboard_2/membership.html
@@ -69,7 +69,7 @@ from openedx.core.djangolib.markup import HTML, Text
 %if static.get_value('ALLOW_AUTOMATED_SIGNUPS', settings.FEATURES.get('ALLOW_AUTOMATED_SIGNUPS', False)):
 <hr class="divider" />
 
-  <div class="auto_enroll auto_enroll_csv">
+  <div class="auto_enroll auto_enroll_csv membership-section">
     <h3 class="hd hd-3">${_("Register/Enroll Students")}</h3>
     <p>${_("To register and enroll a list of users in this course, choose a CSV file that contains the following columns in this exact order: email, username, name, and country. Please include one student per row and do not include any headers, footers, or blank lines.")}</p>
     <form id="student-auto-enroll-form" method="post" action="${ section_data['upload_student_csv_button_url'] }" enctype="multipart/form-data">


### PR DESCRIPTION
## [Bulk Certificate Exception Button Styling is broken EDUCATOR-2719](https://openedx.atlassian.net/browse/EDUCATOR-2719)

### Description:
This PR fixes that the styling of a button on certificate page and membership page of instructor dashboard

### How to Test?
**Stage**
 - Go to the instructor of the course page
- Click on the certificate tab

### Screenshot
**Before Fix**
<img width="718" alt="screen shot 2018-04-17 at 12 40 00 pm" src="https://user-images.githubusercontent.com/7627421/38855415-d6f53e14-423c-11e8-929b-677a0d5690f1.png">



**After Fix**
**_On Certificate Tab_**
<img width="779" alt="screen shot 2018-04-17 at 12 19 46 pm" src="https://user-images.githubusercontent.com/7627421/38855477-fc9e4e08-423c-11e8-8d2a-5f275fc71389.png">

**_On Membership Tab_**
<img width="779" alt="screen shot 2018-04-17 at 12 20 28 pm" src="https://user-images.githubusercontent.com/7627421/38855511-170edbcc-423d-11e8-9ab1-86632e0fb65e.png">

### Reviewers

If you've been tagged for review, please check your corresponding box once you've given the :+1:.
-  [x] @AlasdairSwan 
-  [x] @Rabia23 

### Post-review
- [x] Rebase and squash commits


