### PR TITLE
TE-2527 Move test and dev dependencies out of base.in

### DIFF
--- a/cms/djangoapps/contentstore/tests/test_course_listing.py
+++ b/cms/djangoapps/contentstore/tests/test_course_listing.py
@@ -6,7 +6,6 @@ import random
 
 import ddt
 from ccx_keys.locator import CCXLocator
-from chrono import Timer
 from django.conf import settings
 from django.test import RequestFactory
 from mock import Mock, patch

--- a/common/lib/xmodule/xmodule/modulestore/tests/test_mongo.py
+++ b/common/lib/xmodule/xmodule/modulestore/tests/test_mongo.py
@@ -36,7 +36,6 @@ from xmodule.contentstore.mongo import MongoContentStore
 
 from nose.tools import assert_in
 from xmodule.exceptions import NotFoundError
-from git.test.lib.asserts import assert_not_none
 from xmodule.x_module import XModuleMixin
 from xmodule.modulestore.mongo.base import as_draft
 from xmodule.modulestore.tests.mongo_connection import MONGO_PORT_NUM, MONGO_HOST
@@ -56,6 +55,13 @@ ASSET_COLLECTION = 'assetstore'
 FS_ROOT = DATA_DIR  # TODO (vshnayder): will need a real fs_root for testing load_item
 DEFAULT_CLASS = 'xmodule.raw_module.RawDescriptor'
 RENDER_TEMPLATE = lambda t_n, d, ctx=None, nsp='main': ''
+
+
+def assert_not_none(actual):
+    """
+    verify that item is None
+    """
+    assert actual is not None
 
 
 class ReferenceTestXBlock(XModuleMixin):

--- a/common/lib/xmodule/xmodule/modulestore/tests/utils.py
+++ b/common/lib/xmodule/xmodule/modulestore/tests/utils.py
@@ -5,16 +5,13 @@ import random
 
 from contextlib import contextmanager, nested
 from importlib import import_module
-from opaque_keys.edx.keys import UsageKey
 from path import Path as path
 from shutil import rmtree
 from tempfile import mkdtemp
 from unittest import TestCase
 
-from xblock.fields import XBlockMixin
 from xmodule.x_module import XModuleMixin
 from xmodule.contentstore.mongo import MongoContentStore
-from xmodule.modulestore import ModuleStoreEnum
 from xmodule.modulestore.draft_and_published import ModuleStoreDraftAndPublished
 from xmodule.modulestore.edit_info import EditInfoMixin
 from xmodule.modulestore.inheritance import InheritanceMixin
@@ -25,6 +22,7 @@ from xmodule.modulestore.split_mongo.split_draft import DraftVersioningModuleSto
 from xmodule.modulestore.tests.factories import ItemFactory
 from xmodule.modulestore.tests.mongo_connection import MONGO_PORT_NUM, MONGO_HOST
 from xmodule.modulestore.xml import XMLModuleStore
+from xmodule.modulestore.xml_importer import LocationMixin
 from xmodule.tests import DATA_DIR
 
 
@@ -72,27 +70,6 @@ def mock_tab_from_json(tab_dict):
     with plugin errors.
     """
     return tab_dict
-
-
-class LocationMixin(XBlockMixin):
-    """
-    Adds a `location` property to an :class:`XBlock` so it is more compatible
-    with old-style :class:`XModule` API. This is a simplified version of
-    :class:`XModuleMixin`.
-    """
-    @property
-    def location(self):
-        """ Get the UsageKey of this block. """
-        return self.scope_ids.usage_id
-
-    @location.setter
-    def location(self, value):
-        """ Set the UsageKey of this block. """
-        assert isinstance(value, UsageKey)
-        self.scope_ids = self.scope_ids._replace(
-            def_id=value,
-            usage_id=value,
-        )
 
 
 class MixedSplitTestCase(TestCase):

--- a/common/lib/xmodule/xmodule/modulestore/xml_importer.py
+++ b/common/lib/xmodule/xmodule/modulestore/xml_importer.py
@@ -30,6 +30,7 @@ import json
 import re
 from lxml import etree
 
+from xblock.fields import XBlockMixin
 from xmodule.library_tools import LibraryToolsService
 from xmodule.modulestore.xml import XMLModuleStore, LibraryXMLModuleStore, ImportSystem
 from xblock.runtime import KvsFieldData, DictKeyValueStore
@@ -48,13 +49,33 @@ from xmodule.modulestore.exceptions import DuplicateCourseError
 from xmodule.modulestore.mongo.base import MongoRevisionKey
 from xmodule.modulestore import ModuleStoreEnum
 from xmodule.modulestore.store_utilities import draft_node_constructor, get_draft_subtree_roots
-from xmodule.modulestore.tests.utils import LocationMixin
 from xmodule.util.misc import escape_invalid_characters
 
 
 log = logging.getLogger(__name__)
 
 DEFAULT_STATIC_CONTENT_SUBDIR = 'static'
+
+
+class LocationMixin(XBlockMixin):
+    """
+    Adds a `location` property to an :class:`XBlock` so it is more compatible
+    with old-style :class:`XModule` API. This is a simplified version of
+    :class:`XModuleMixin`.
+    """
+    @property
+    def location(self):
+        """ Get the UsageKey of this block. """
+        return self.scope_ids.usage_id
+
+    @location.setter
+    def location(self, value):
+        """ Set the UsageKey of this block. """
+        assert isinstance(value, UsageKey)
+        self.scope_ids = self.scope_ids._replace(
+            def_id=value,
+            usage_id=value,
+        )
 
 
 class StaticContentImporter:

--- a/common/lib/xmodule/xmodule/partitions/partitions_service.py
+++ b/common/lib/xmodule/xmodule/partitions/partitions_service.py
@@ -13,8 +13,6 @@ from xmodule.modulestore.django import modulestore
 
 log = logging.getLogger(__name__)
 
-
-# settings will not be available when running nosetests.
 FEATURES = getattr(settings, 'FEATURES', {})
 
 

--- a/common/lib/xmodule/xmodule/partitions/tests/test_partitions.py
+++ b/common/lib/xmodule/xmodule/partitions/tests/test_partitions.py
@@ -546,7 +546,6 @@ class TestGetCourseUserPartitions(PartitionServiceBaseClass):
 
     def setUp(self):
         super(TestGetCourseUserPartitions, self).setUp()
-        # django.conf.settings is not available when nosetests are run
         TestGetCourseUserPartitions._enable_enrollment_track_partition(True)
 
     @staticmethod

--- a/pavelib/utils/test/utils.py
+++ b/pavelib/utils/test/utils.py
@@ -10,7 +10,10 @@ from paver.easy import cmdopts, sh, task
 from pavelib.utils.envs import Env
 from pavelib.utils.timer import timed
 
-from bok_choy.browser import browser
+try:
+    from bok_choy.browser import browser
+except ImportError:
+    browser = None
 
 MONGO_PORT_NUM = int(os.environ.get('EDXAPP_TEST_MONGO_PORT', '27017'))
 MINIMUM_FIREFOX_VERSION = 28.0

--- a/requirements/edx/base.in
+++ b/requirements/edx/base.in
@@ -25,13 +25,13 @@
 
 analytics-python==1.1.0             # Used for Segment analytics
 attrs==17.2.0                       # Reduces boilerplate code involving class attributes
-Babel==1.3                          # Internationalization utilities
-beautifulsoup4==4.1.3               # Library for extracting data from HTML and XML files
-bleach==1.4                         # Allowed-list-based HTML sanitizing library that escapes or strips markup and attributes
+Babel==1.3                          # Internationalization utilities, used for date formatting in a few places
+bleach==1.4                         # Allowed-list-based HTML sanitizing library that escapes or strips markup and attributes; used for capa and LTI
 boto==2.39.0                        # Deprecated version of the AWS SDK; we should stop using this
 boto3==1.4.8                        # Amazon Web Services SDK for Python
 botocore==1.8.17                    # via boto3, s3transfer
 celery==3.1.25                      # Asynchronous task execution library
+ddt==0.8.0                          # via xblock-drag-and-drop-v2 (which probably shouldn't require it)
 defusedxml==0.4.1                   # XML bomb protection for common XML parsers
 Django==1.11.12                     # Web application framework
 django-babel-underscore             # underscore template extractor for django-babel (internationalization utilities)
@@ -39,6 +39,7 @@ django-birdcage                     # CSRF token forwards compatibility for the 
 django-config-models==0.1.8         # Configuration models for Django allowing config management with auditing
 django-cors-headers==2.1.0          # Used to allow to configure CORS headers for cross-domain requests
 django-countries==4.6.1             # Country data for Django forms and model fields
+django-crum                         # Middleware that stores the current request and user in thread local storage
 django-fernet-fields                # via edx-enterprise (should be added to its setup.py)
 django-filter==1.0.4                # Allows users to filter Django querysets dynamically
 django-ipware==1.1.0                # Get the client's real IP address
@@ -61,9 +62,7 @@ django-user-tasks
 django-waffle==0.12.0
 django-webpack-loader==0.4.1
 djangorestframework-jwt
-docutils
 dogapi==1.2.1                       # Python bindings to Datadog's API, for metrics gathering
-enum34==1.1.6
 edx-ace
 edx-analytics-data-api-client
 edx-ccx-keys
@@ -71,7 +70,6 @@ edx-celeryutils
 edx-completion
 edx-django-release-util             # Release utils for the edx release pipeline
 edx-drf-extensions
-edx-i18n-tools
 edx-django-oauth2-provider==1.2.5
 edx-django-sites-extensions==2.3.1
 edx-enterprise
@@ -84,15 +82,14 @@ edx-search
 edx-submissions
 edx-user-state-client
 edxval
-enum34
+enum34==1.1.6                       # Backport of Enum from Python 3.4+
 event-tracking
 feedparser==5.1.3
 firebase-token-generator==1.3.2
 fs==2.0.18
 fs-s3fs==0.1.8
 futures ; python_version == "2.7"   # via django-pipeline, python-swift-client, s3transfer
-GitPython==0.3.2.RC1
-glob2==0.3
+glob2==0.3                          # Enhanced glob module, used in openedx.core.lib.rooted_paths
 gunicorn==0.17.4
 help-tokens
 html5lib==0.999                     # HTML parser, used for capa problems
@@ -104,17 +101,18 @@ Markdown                            # Convert text markup to HTML; used in capa 
 mongoengine==0.10.0                 # Object-document mapper for MongoDB, used in the LMS dashboard
 MySQL-python                        # Driver for the default production relational database
 newrelic                            # New Relic agent for performance monitoring
+nodeenv==1.1.1                      # Utility for managing Node.js environments; we use this for deployments and testing
 numpy==1.6.2                        # Fast numeric array computation, used in some problem types
 oauthlib==2.0.1                     # OAuth specification support for authenticating via LTI or other Open edX services
 pdfminer                            # Used in shoppingcart for extracting/parsing pdf text
 piexif==1.0.2                       # Exif image metadata manipulation, used in the profile_images app
 Pillow==3.4                         # Image manipulation library; used for course assets, profile images, invoice PDFs, etc.
-polib==1.0.3                        # Library for manipulating gettext translation files, used to test paver i18n commands
 py2neo                              # Used to communicate with Neo4j, which is used internally for modulestore inspection
+PyContracts==1.7.1
 pycountry==1.20
 pycryptodomex==3.4.7
-pygments==2.2.0
-pygraphviz==1.1
+pygments==2.2.0                     # Used to support colors in paver command output
+pygraphviz==1.1                     # No longer in use?  Optional dependency of networkx, from edx-sandbox/shared.in
 pyjwkest==1.3.2
 # TODO Replace PyJWT usage with pyjwkest
 PyJWT==1.5.2
@@ -124,66 +122,25 @@ python-dateutil==2.4
 python-Levenshtein
 python-openid
 python-saml
-pyuca==1.1
+pyuca==1.1                          # For more accurate sorting of translated country names in django-countries
 reportlab==3.1.44                   # Used for shopping cart's pdf invoice/receipt generation
 social-auth-app-django==1.2.0
 social-auth-core==1.4.0
-pysrt==0.4.7
+pysrt==0.4.7                        # Support for SubRip subtitle files, used in the video XModule
 pytz==2016.10                       # Time zone information database
 PyYAML                              # Used to parse XModule resource templates
 redis==2.10.6                       # celery task broker
-requests-oauthlib==0.6.1
+requests-oauthlib==0.6.1            # Simplifies use of OAuth via the requests library, used for CCX and LTI
 rules                               # Django extension for rules-based authorization checks
-s3transfer==0.1.12
 sailthru-client==2.2.3              # For Sailthru integration
-Shapely==1.2.16
-singledispatch==3.4.0.2
-six
-sorl-thumbnail==12.3
-sortedcontainers==0.9.2
-stevedore
-sure==1.2.3
-unicodecsv
+Shapely==1.2.16                     # Geometry library, used for image click regions in capa
+six                                 # Utilities for supporting Python 2 & 3 in the same codebase
+sorl-thumbnail==12.3                # Image thumbnail management
+sortedcontainers==0.9.2             # Provides SortedListWithKey, used for lists of XBlock assets
+stevedore                           # Support for runtime plugins, used for XBlocks and edx-platform Django app plugins
+unicodecsv                          # Easier support for CSV files with unicode text
 user-util                           # Functionality for retiring users (GDPR compliance)
 web-fragments                       # Provides the ability to render fragments of web pages
 XBlock==1.1.1                       # Courseware component architecture
 xblock-review                       # XBlock which displays problems from earlier in the course for ungraded retries
-xmltodict==0.4.1
-zendesk
-
-# Move these to development.in?
-django-debug-toolbar==1.8           # A set of panels that display debug information about the current request/response
-sphinx==1.1.3                       # Documentation builder
-sphinx_rtd_theme==0.1.5             # Documentation theme; should replace with edx-sphinx-theme
-transifex-client==0.12.1            # Command-line interface for the Transifex localization service
-
-# Move these to testing.in?
-before_after==0.1.3
-bok-choy
-chrono
-cssselect==0.9.1                    # via pyquery
-ddt==0.8.0
-django-crum
-django_nose==1.4.1
-factory_boy==2.8.1
-flaky
-freezegun==0.3.8
-httpretty                           # Library for mocking HTTP requests, used in many tests
-moto==0.3.1
-needle
-nodeenv==1.1.1
-nose
-nose-exclude
-nose-faulthandler
-nose-ignore-docstring
-nose-randomly==1.2.0
-nose-xunitmp==0.3.2
-pep8==1.5.7
-PyContracts==1.7.1
-pyquery==1.2.9
-python-subunit==0.0.16
-radon==1.3.2
-selenium
-splinter==0.5.4
-testfixtures==4.5.0
-testtools==0.9.34
+zendesk                             # Python API for the Zendesk customer support system

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -13,7 +13,6 @@
 git+https://github.com/solashirai/crowdsourcehinter.git@518605f0a95190949fe77bd39158450639e2e1dc#egg=crowdsourcehinter-xblock==0.1
 git+https://github.com/mitodl/django-cas.git@afac57bc523f145ae826f4ed3d4fa8b2c86c5364#egg=django-cas==2.1.1
 git+https://github.com/edx/django-celery.git@756cb57aad765cb2b0d37372c1855b8f5f37e6b0#egg=django-celery==3.2.1+edx.2
-git+https://github.com/hmarr/django-debug-toolbar-mongo.git@b0686a76f1ce3532088c4aee6e76b9abe61cc808#egg=django-debug-toolbar-mongo==0.1.10
 git+https://github.com/edx/django-oauth-plus.git@01ec2a161dfc3465f9d35b9211ae790177418316#egg=django-oauth-plus==2.2.9.edx-1
 git+https://github.com/edx/django-openid-auth.git@0.15.1#egg=django-openid-auth==0.15.1
 git+https://github.com/jazzband/django-pipeline.git@d068a019169c9de5ee20ece041a6dea236422852#egg=django-pipeline==1.5.3
@@ -24,7 +23,6 @@ git+https://github.com/edx/django-rest-framework.git@1ceda7c086fddffd1c440cc8685
 -e git+https://github.com/edx/DoneXBlock.git@01a14f3bd80ae47dd08cdbbe2f88f3eb88d00fba#egg=done-xblock
 -e git+https://github.com/jazkarta/edx-jsme.git@690dbf75441fa91c7c4899df0b83d77f7deb5458#egg=edx-jsme
 git+https://github.com/mitodl/edx-sga.git@6b2f7aa2a18206023c8407e2c46f86d4b4c3ac96#egg=edx-sga==0.8.0
-git+https://github.com/edx/lettuce.git@31b0dfd865766243e9b563ec65fae9122edf7975#egg=lettuce==0.2.23+edx.1
 git+https://github.com/edx/xblock-lti-consumer.git@v1.1.7#egg=lti_consumer-xblock==1.1.7
 git+https://github.com/edx/MongoDBProxy.git@25b99097615bda06bd7cdfe5669ed80dc2a7fed0#egg=MongoDBProxy==0.1.0
 -e .
@@ -53,28 +51,21 @@ argparse==1.4.0
 asn1crypto==0.24.0
 attrs==17.2.0
 babel==1.3
-beautifulsoup4==4.1.3
 beautifulsoup==3.2.1      # via pynliner
-before_after==0.1.3
 billiard==3.3.0.23        # via celery
 bleach==1.4
-bok-choy==0.7.2
 boto3==1.4.8
 boto==2.39.0
 botocore==1.8.17
 celery==3.1.25
 cffi==1.11.5
 charade==1.0.3            # via pysrt
-chrono==1.0.2
-click==6.7                # via flask, user-util
-colorama==0.3.9           # via radon
+click==6.7                # via user-util
 cryptography==2.1.4
-cssselect==0.9.1
 cssutils==1.0.2           # via pynliner
 ddt==0.8.0
 decorator==4.3.0          # via dogapi, pycontracts
 defusedxml==0.4.1
-dicttoxml==1.7.4          # via moto
 django-appconf==1.0.2     # via django-statici18n
 django-babel-underscore==0.5.2
 django-babel==0.6.2       # via django-babel-underscore
@@ -85,7 +76,6 @@ django-config-models==0.1.8
 django-cors-headers==2.1.0
 django-countries==4.6.1
 django-crum==0.7.2
-django-debug-toolbar==1.8
 django-fernet-fields==0.5
 django-filter==1.0.4
 django-ipware==1.1.0
@@ -110,12 +100,11 @@ django-user-tasks==0.1.5
 django-waffle==0.12.0
 django-webpack-loader==0.4.1
 django==1.11.12
-django_nose==1.4.1
 djangorestframework-jwt==1.11.0
 djangorestframework-xml==1.3.0  # via edx-enterprise
 dm.xmlsec.binding==1.3.3  # via python-saml
 docopt==0.6.2
-docutils==0.14
+docutils==0.14            # via botocore
 dogapi==1.2.1
 edx-ace==0.1.6
 edx-analytics-data-api-client==0.14.4
@@ -141,35 +130,22 @@ edxval==0.1.13
 elasticsearch==1.9.0      # via edx-search
 enum34==1.1.6
 event-tracking==0.2.4
-extras==1.0.0             # via python-subunit, testtools
-factory_boy==2.8.1
-faker==0.8.13             # via factory-boy
-faulthandler==3.0         # via nose-faulthandler
 feedparser==5.1.3
 firebase-token-generator==1.3.2
-flaky==3.4.0
-flask==0.12.2             # via moto
-freezegun==0.3.8
 fs-s3fs==0.1.8
 fs==2.0.18
 future==0.16.0            # via pyjwkest
 futures==3.2.0 ; python_version == "2.7"
-fuzzywuzzy==0.16.0
-gitdb==0.6.4              # via gitpython
-gitpython==0.3.2.rc1
 glob2==0.3
 gunicorn==0.17.4
 hash-ring==1.3.1          # via django-memcached-hashring
 help-tokens==1.0.3
 html5lib==0.999
 httplib2==0.11.3          # via oauth2, zendesk
-httpretty==0.8.14
 idna==2.6
 ipaddr==2.1.11
 ipaddress==1.0.22
 isodate==0.6.0            # via python-saml
-itsdangerous==0.24        # via flask
-jinja2==2.10              # via flask, moto, sphinx
 jmespath==0.9.3           # via boto3, botocore
 jsondiff==1.1.1           # via edx-enterprise
 jsonfield==2.0.2
@@ -181,25 +157,16 @@ loremipsum==1.0.5
 lxml==3.8.0
 mailsnake==1.6.2
 mako==1.0.2
-mando==0.3.3              # via radon
 markdown==2.6.11
 markey==0.8               # via django-babel-underscore
 markupsafe==1.0
 mock==1.0.1
 mongoengine==0.10.0
-moto==0.3.1
 mysql-python==1.2.5
-needle==0.5.0
 networkx==1.7
 newrelic==3.2.0.91
 nltk==3.2.5
 nodeenv==1.1.1
-nose-exclude==0.5.0
-nose-faulthandler==0.1
-nose-ignore-docstring==0.2
-nose-randomly==1.2.0
-nose-xunitmp==0.3.2
-nose==1.3.7
 numpy==1.6.2
 oauth2==1.9.0.post1
 oauthlib==2.0.1
@@ -208,10 +175,9 @@ pathtools==0.1.2
 paver==1.3.4
 pbr==4.0.2
 pdfminer==20140328
-pep8==1.5.7
 piexif==1.0.2
 pillow==3.4.0
-polib==1.0.3
+polib==1.1.0              # via edx-i18n-tools
 psutil==1.2.1
 py2neo==3.1.2
 pycontracts==1.7.1
@@ -225,61 +191,43 @@ pyjwt==1.5.2
 pymongo==2.9.1
 pynliner==0.5.2
 pyparsing==2.2.0
-pyquery==1.2.9
 pysrt==0.4.7
 python-dateutil==2.4.0
 python-levenshtein==0.12.0
 python-memcached==1.48
-python-mimeparse==1.6.0   # via testtools
 python-openid==2.2.5
 python-saml==2.4.0
-python-subunit==0.0.16
 python-swiftclient==3.5.0
 pytz==2016.10
 pyuca==1.1
 pyyaml==3.12
-radon==1.3.2
 redis==2.10.6
 reportlab==3.1.44
 requests-oauthlib==0.6.1
 requests==2.9.1
 rules==1.3
-s3transfer==0.1.12
+s3transfer==0.1.13        # via boto3
 sailthru-client==2.2.3
 scipy==0.14.0
-selenium==3.11.0
 shapely==1.2.16
 shortuuid==0.5.0          # via edx-django-oauth2-provider
 simplejson==3.13.2        # via dogapi, mailsnake, sailthru-client, zendesk
-singledispatch==3.4.0.2
 six==1.11.0
 slumber==0.7.1            # via edx-rest-api-client
-smmap==0.9.0              # via gitdb
 social-auth-app-django==1.2.0
 social-auth-core==1.4.0
 sorl-thumbnail==12.3
 sortedcontainers==0.9.2
-sphinx==1.1.3
-sphinx_rtd_theme==0.1.5
-splinter==0.5.4
-sqlparse==0.2.4           # via django-debug-toolbar
 stevedore==1.10.0
-sure==1.2.3
 sympy==0.7.1
-testfixtures==4.5.0
-testtools==0.9.34
-text-unidecode==1.2       # via faker
-transifex-client==0.12.1
 unicodecsv==0.14.1
-urllib3==1.22             # via elasticsearch, transifex-client
+urllib3==1.22             # via elasticsearch
 user-util==0.1.3
 voluptuous==0.11.1
 watchdog==0.8.3
 web-fragments==0.2.2
 webob==1.8.1              # via xblock
-werkzeug==0.14.1          # via flask
 wrapt==1.10.5
 xblock-review==1.1.5
 xblock==1.1.1
-xmltodict==0.4.1
 zendesk==1.1.1

--- a/requirements/edx/development.in
+++ b/requirements/edx/development.in
@@ -10,7 +10,13 @@
 -r testing.txt                      # Dependencies for running the various test suites
 
 click                               # Used for perf_tests utilities in modulestore
+django-debug-toolbar==1.8           # A set of panels that display debug information about the current request/response
+edx-sphinx-theme                    # Documentation theme
 pyinotify                           # More efficient checking for runserver reload trigger events
+sphinx                              # Developer documentation builder
 
 # Performance timer used in modulestore/perf_tests/test_asset_import_export.py
 -e git+https://github.com/doctoryes/code_block_timer.git@f3d0629f086bcc649c3c77f4bc5b9c2c8172c3bf#egg=code_block_timer
+
+# The officially released version of django-debug-toolbar-mongo doesn't support DJDT 1.x. This commit does.
+-e git+https://github.com/hmarr/django-debug-toolbar-mongo.git@b0686a76f1ce3532088c4aee6e76b9abe61cc808#egg=django-debug-toolbar-mongo==0.1.10

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -45,6 +45,7 @@ git+https://github.com/edx-solutions/xblock-drag-and-drop-v2@2.1.5#egg=xblock-dr
 git+https://github.com/open-craft/xblock-poll@7ba819b968fe8faddb78bb22e1fe7637005eb414#egg=xblock-poll==1.2.7
 git+https://github.com/edx/xblock-utils.git@v1.0.5#egg=xblock-utils==1.0.5
 -e common/lib/xmodule
+alabaster==0.7.10         # via sphinx
 amqp==1.4.9
 analytics-python==1.1.0
 anyjson==0.3.3
@@ -69,7 +70,6 @@ botocore==1.8.17
 celery==3.1.25
 cffi==1.11.5
 charade==1.0.3
-chrono==1.0.2
 click-log==0.1.8
 click==6.7
 colorama==0.3.9
@@ -119,7 +119,6 @@ django-user-tasks==0.1.5
 django-waffle==0.12.0
 django-webpack-loader==0.4.1
 django==1.11.12
-django_nose==1.4.1
 djangorestframework-jwt==1.11.0
 djangorestframework-xml==1.3.0
 dm.xmlsec.binding==1.3.3
@@ -135,7 +134,7 @@ edx-django-oauth2-provider==1.2.5
 edx-django-release-util==0.3.1
 edx-django-sites-extensions==2.3.1
 edx-drf-extensions==1.2.5
-edx-enterprise==0.67.4
+edx-enterprise==0.67.5
 edx-i18n-tools==0.4.4
 edx-lint==0.5.4
 edx-milestones==0.1.13
@@ -145,6 +144,7 @@ edx-organizations==0.4.10
 edx-proctoring==1.3.9
 edx-rest-api-client==1.7.1
 edx-search==1.1.0
+edx-sphinx-theme==1.3.0
 edx-submissions==2.0.12
 edx-user-state-client==1.0.4
 edxval==0.1.13
@@ -155,11 +155,9 @@ execnet==1.5.0
 extras==1.0.0
 factory_boy==2.8.1
 faker==0.8.13
-faulthandler==3.0
 feedparser==5.1.3
 firebase-token-generator==1.3.2
 first==2.0.1
-flaky==3.4.0
 flask==0.12.2
 freezegun==0.3.8
 fs-s3fs==0.1.8
@@ -167,8 +165,6 @@ fs==2.0.18
 future==0.16.0
 futures==3.2.0 ; python_version == "2.7"
 fuzzywuzzy==0.16.0
-gitdb==0.6.4
-gitpython==0.3.2.rc1
 glob2==0.3
 gunicorn==0.17.4
 hash-ring==1.3.1
@@ -177,6 +173,7 @@ html5lib==0.999
 httplib2==0.11.3
 httpretty==0.8.14
 idna==2.6
+imagesize==1.0.0          # via sphinx
 incremental==17.5.0
 inflect==0.2.5
 ipaddr==2.1.11
@@ -212,16 +209,12 @@ networkx==1.7
 newrelic==3.2.0.91
 nltk==3.2.5
 nodeenv==1.1.1
-nose-exclude==0.5.0
-nose-faulthandler==0.1
-nose-ignore-docstring==0.2
-nose-randomly==1.2.0
-nose-xunitmp==0.3.2
 nose==1.3.7
 numpy==1.6.2
 oauth2==1.9.0.post1
 oauthlib==2.0.1
 pa11ycrawler==1.6.2
+packaging==17.1           # via sphinx
 parsel==1.4.0
 path.py==8.2.1
 pathtools==0.1.2
@@ -231,9 +224,9 @@ pdfminer==20140328
 pep8==1.5.7
 piexif==1.0.2
 pillow==3.4.0
-pip-tools==1.11.0
+pip-tools==2.0.1
 pluggy==0.6.0
-polib==1.0.3
+polib==1.1.0
 psutil==1.2.1
 py2neo==3.1.2
 py==1.5.3
@@ -286,7 +279,7 @@ reportlab==3.1.44
 requests-oauthlib==0.6.1
 requests==2.9.1
 rules==1.3
-s3transfer==0.1.12
+s3transfer==0.1.13
 sailthru-client==2.2.3
 scipy==0.14.0
 scrapy==1.1.2
@@ -295,18 +288,18 @@ service-identity==17.0.0
 shapely==1.2.16
 shortuuid==0.5.0
 simplejson==3.13.2
-singledispatch==3.4.0.2
+singledispatch==3.4.0.3
 six==1.11.0
 slumber==0.7.1
-smmap==0.9.0
+snowballstemmer==1.2.1    # via sphinx
 social-auth-app-django==1.2.0
 social-auth-core==1.4.0
 sorl-thumbnail==12.3
 sortedcontainers==0.9.2
-sphinx==1.1.3
-sphinx_rtd_theme==0.1.5
+sphinx==1.7.2
+sphinxcontrib-websupport==1.0.1  # via sphinx
 splinter==0.5.4
-sqlparse==0.2.4
+sqlparse==0.2.4           # via django-debug-toolbar
 stevedore==1.10.0
 sure==1.2.3
 sympy==0.7.1
@@ -317,6 +310,7 @@ tox-battery==0.5.1
 tox==2.8.2
 transifex-client==0.12.1
 twisted==16.6.0
+typing==3.6.4             # via sphinx
 unicodecsv==0.14.1
 urllib3==1.22
 urlobject==2.4.3

--- a/requirements/edx/github.in
+++ b/requirements/edx/github.in
@@ -71,18 +71,12 @@
 -e git+https://github.com/mitodl/django-cas.git@afac57bc523f145ae826f4ed3d4fa8b2c86c5364#egg=django-cas==2.1.1
 -e git+https://github.com/dgrtwo/ParsePy.git@7949b9f754d1445eff8e8f20d0e967b9a6420639#egg=parse_rest
 
-# The officially released version of django-debug-toolbar-mongo doesn't support DJDT 1.x. This commit does.
--e git+https://github.com/hmarr/django-debug-toolbar-mongo.git@b0686a76f1ce3532088c4aee6e76b9abe61cc808#egg=django-debug-toolbar-mongo==0.1.10
-
 # Forked to get Django 1.10+ compat that is in origin BitBucket repo, without an official build.
 # This can go away when we update auth to not use django-rest-framework-oauth
 -e git+https://github.com/edx/django-oauth-plus.git@01ec2a161dfc3465f9d35b9211ae790177418316#egg=django-oauth-plus==2.2.9.edx-1
 
 # NOTE (CCB): This must remain. There is one commit on the upstream repo that has not been released to PyPI.
 -e git+https://github.com/edx/rfc6266.git@v0.0.5-edx#egg=rfc6266==0.0.5-edx
-
-# Used for testing
--e git+https://github.com/edx/lettuce.git@31b0dfd865766243e9b563ec65fae9122edf7975#egg=lettuce==0.2.23+edx.1
 
 # Why a DRF fork? See: https://openedx.atlassian.net/browse/PLAT-1581
 -e git+https://github.com/edx/django-rest-framework.git@1ceda7c086fddffd1c440cc86856441bbf0bd9cb#egg=djangorestframework==3.6.3

--- a/requirements/edx/pip-tools.txt
+++ b/requirements/edx/pip-tools.txt
@@ -7,5 +7,5 @@
 
 click==6.7                # via pip-tools
 first==2.0.1              # via pip-tools
-pip-tools==1.11.0
+pip-tools==2.0.1
 six==1.11.0               # via pip-tools

--- a/requirements/edx/testing.in
+++ b/requirements/edx/testing.in
@@ -14,17 +14,44 @@
 -r base.txt               # Core edx-platform production dependencies
 -r coverage.txt           # Utilities for calculating test coverage
 
+beautifulsoup4==4.1.3     # Library for extracting data from HTML and XML files
+before_after==0.1.3       # Syntactic sugar for mock, only used in one test case, not Python 3 compatible
+bok-choy                  # Framework for browser automation tests, based on selenium
+cssselect==0.9.1          # Used to extract HTML fragments via CSS selectors in 2 test cases and pyquery
+ddt==0.8.0                # Run a test case multiple times with different input; used in many, many of our tests
+edx-i18n-tools            # Commands for developers and translators to extract, compile and validate translations
 edx-lint==0.5.4           # pylint extensions for Open edX repositories
+factory_boy==2.8.1        # Library for creating test fixtures, used in many tests
+freezegun==0.3.8          # Allows tests to mock the output of assorted datetime module functions
+httpretty                 # Library for mocking HTTP requests, used in many tests
 isort==4.2.5              # For checking and fixing the order of imports
+moto==0.3.1               # Lets tests mock AWS access via the boto library
+nose                      # Former test runner, we're still using some utility functions from it
 pa11ycrawler              # Python crawler (using Scrapy) that uses Pa11y to check accessibility of pages as it crawls
+pep8==1.5.7               # Checker for compliance with the Python style guide (PEP 8)
+polib                     # Library for manipulating gettext translation files, used to test paver i18n commands
 pylint-django==0.7.2      # via edx-lint
+pyquery==1.2.9            # jQuery-like API for retrieving fragments of HTML and XML files in tests
 pysqlite                  # DB-API 2.0 interface for SQLite 3.x (used as the relational database for most tests)
 pytest==3.1.3             # Testing framework
 pytest-attrib             # Select tests based on attributes
 pytest-catchlog           # pytest plugin to catch log messages; merged into pytest 3.3.0
 pytest-cov                # pytest plugin for measuring code coverage
-pytest-django             # Django support for pytest
+pytest-django==3.1.2      # Django support for pytest
 pytest-randomly==1.2.1    # pytest plugin to randomly order tests
 pytest-xdist==1.20.0      # Parallel execution of tests on multiple CPU cores or hosts
+python-subunit==0.0.16    # via lettuce
+radon==1.3.2              # Calculates cyclomatic complexity of Python code (code quality utility)
+selenium                  # Browser automation library, used for acceptance tests
+singledispatch            # Backport of functools.singledispatch from Python 3.4+, used in tests of XBlock rendering
+splinter==0.5.4           # Browser driver used by lettuce
+sure==1.2.3               # via lettuce
+testfixtures==4.5.0       # Provides a LogCapture utility used by several tests
+testtools==0.9.34         # via python-subunit
 tox==2.8.2                # virtualenv management for tests
 tox-battery               # Makes tox aware of requirements file changes
+transifex-client==0.12.1  # Command-line interface for the Transifex localization service
+xmltodict==0.4.1          # via moto
+
+# Deprecated acceptance testing framework
+-e git+https://github.com/edx/lettuce.git@31b0dfd865766243e9b563ec65fae9122edf7975#egg=lettuce==0.2.23+edx.1

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -13,7 +13,6 @@
 git+https://github.com/solashirai/crowdsourcehinter.git@518605f0a95190949fe77bd39158450639e2e1dc#egg=crowdsourcehinter-xblock==0.1
 git+https://github.com/mitodl/django-cas.git@afac57bc523f145ae826f4ed3d4fa8b2c86c5364#egg=django-cas==2.1.1
 git+https://github.com/edx/django-celery.git@756cb57aad765cb2b0d37372c1855b8f5f37e6b0#egg=django-celery==3.2.1+edx.2
-git+https://github.com/hmarr/django-debug-toolbar-mongo.git@b0686a76f1ce3532088c4aee6e76b9abe61cc808#egg=django-debug-toolbar-mongo==0.1.10
 git+https://github.com/edx/django-oauth-plus.git@01ec2a161dfc3465f9d35b9211ae790177418316#egg=django-oauth-plus==2.2.9.edx-1
 git+https://github.com/edx/django-openid-auth.git@0.15.1#egg=django-openid-auth==0.15.1
 git+https://github.com/jazzband/django-pipeline.git@d068a019169c9de5ee20ece041a6dea236422852#egg=django-pipeline==1.5.3
@@ -68,10 +67,9 @@ botocore==1.8.17
 celery==3.1.25
 cffi==1.11.5
 charade==1.0.3
-chrono==1.0.2
 click-log==0.1.8          # via edx-lint
 click==6.7
-colorama==0.3.9
+colorama==0.3.9           # via radon
 configparser==3.5.0       # via pylint
 constantly==15.1.0        # via twisted
 coverage==4.2
@@ -81,7 +79,7 @@ cssutils==1.0.2
 ddt==0.8.0
 decorator==4.3.0
 defusedxml==0.4.1
-dicttoxml==1.7.4
+dicttoxml==1.7.4          # via moto
 diff-cover==0.9.8
 django-appconf==1.0.2
 django-babel-underscore==0.5.2
@@ -93,7 +91,6 @@ django-config-models==0.1.8
 django-cors-headers==2.1.0
 django-countries==4.6.1
 django-crum==0.7.2
-django-debug-toolbar==1.8
 django-fernet-fields==0.5
 django-filter==1.0.4
 django-ipware==1.1.0
@@ -117,7 +114,6 @@ django-storages==1.4.1
 django-user-tasks==0.1.5
 django-waffle==0.12.0
 django-webpack-loader==0.4.1
-django_nose==1.4.1
 djangorestframework-jwt==1.11.0
 djangorestframework-xml==1.3.0
 dm.xmlsec.binding==1.3.3
@@ -133,7 +129,7 @@ edx-django-oauth2-provider==1.2.5
 edx-django-release-util==0.3.1
 edx-django-sites-extensions==2.3.1
 edx-drf-extensions==1.2.5
-edx-enterprise==0.67.4
+edx-enterprise==0.67.5
 edx-i18n-tools==0.4.4
 edx-lint==0.5.4
 edx-milestones==0.1.13
@@ -150,22 +146,18 @@ elasticsearch==1.9.0
 enum34==1.1.6
 event-tracking==0.2.4
 execnet==1.5.0            # via pytest-xdist
-extras==1.0.0
+extras==1.0.0             # via python-subunit, testtools
 factory_boy==2.8.1
-faker==0.8.13
-faulthandler==3.0
+faker==0.8.13             # via factory-boy
 feedparser==5.1.3
 firebase-token-generator==1.3.2
-flaky==3.4.0
-flask==0.12.2
+flask==0.12.2             # via moto
 freezegun==0.3.8
 fs-s3fs==0.1.8
 fs==2.0.18
 future==0.16.0
 futures==3.2.0 ; python_version == "2.7"
 fuzzywuzzy==0.16.0
-gitdb==0.6.4
-gitpython==0.3.2.rc1
 glob2==0.3
 gunicorn==0.17.4
 hash-ring==1.3.1
@@ -180,7 +172,7 @@ ipaddr==2.1.11
 ipaddress==1.0.22
 isodate==0.6.0
 isort==4.2.5
-itsdangerous==0.24
+itsdangerous==0.24        # via flask
 jinja2-pluralize==0.3.0
 jinja2==2.10
 jmespath==0.9.3
@@ -195,7 +187,7 @@ loremipsum==1.0.5
 lxml==3.8.0
 mailsnake==1.6.2
 mako==1.0.2
-mando==0.3.3
+mando==0.3.3              # via radon
 markdown==2.6.11
 markey==0.8
 markupsafe==1.0
@@ -204,16 +196,11 @@ mock==1.0.1
 mongoengine==0.10.0
 moto==0.3.1
 mysql-python==1.2.5
-needle==0.5.0
+needle==0.5.0             # via bok-choy
 networkx==1.7
 newrelic==3.2.0.91
 nltk==3.2.5
 nodeenv==1.1.1
-nose-exclude==0.5.0
-nose-faulthandler==0.1
-nose-ignore-docstring==0.2
-nose-randomly==1.2.0
-nose-xunitmp==0.3.2
 nose==1.3.7
 numpy==1.6.2
 oauth2==1.9.0.post1
@@ -229,7 +216,7 @@ pep8==1.5.7
 piexif==1.0.2
 pillow==3.4.0
 pluggy==0.6.0             # via tox
-polib==1.0.3
+polib==1.1.0
 psutil==1.2.1
 py2neo==3.1.2
 py==1.5.3                 # via pytest, pytest-catchlog, tox
@@ -266,7 +253,7 @@ pytest==3.1.3
 python-dateutil==2.4.0
 python-levenshtein==0.12.0
 python-memcached==1.48
-python-mimeparse==1.6.0
+python-mimeparse==1.6.0   # via testtools
 python-openid==2.2.5
 python-saml==2.4.0
 python-subunit==0.0.16
@@ -281,7 +268,7 @@ reportlab==3.1.44
 requests-oauthlib==0.6.1
 requests==2.9.1
 rules==1.3
-s3transfer==0.1.12
+s3transfer==0.1.13
 sailthru-client==2.2.3
 scipy==0.14.0
 scrapy==1.1.2             # via pa11ycrawler
@@ -290,24 +277,20 @@ service-identity==17.0.0  # via scrapy
 shapely==1.2.16
 shortuuid==0.5.0
 simplejson==3.13.2
-singledispatch==3.4.0.2
+singledispatch==3.4.0.3
 six==1.11.0
 slumber==0.7.1
-smmap==0.9.0
 social-auth-app-django==1.2.0
 social-auth-core==1.4.0
 sorl-thumbnail==12.3
 sortedcontainers==0.9.2
-sphinx==1.1.3
-sphinx_rtd_theme==0.1.5
 splinter==0.5.4
-sqlparse==0.2.4
 stevedore==1.10.0
 sure==1.2.3
 sympy==0.7.1
 testfixtures==4.5.0
 testtools==0.9.34
-text-unidecode==1.2
+text-unidecode==1.2       # via faker
 tox-battery==0.5.1
 tox==2.8.2
 transifex-client==0.12.1
@@ -322,7 +305,7 @@ w3lib==1.19.0             # via parsel, scrapy
 watchdog==0.8.3
 web-fragments==0.2.2
 webob==1.8.1
-werkzeug==0.14.1
+werkzeug==0.14.1          # via flask
 wrapt==1.10.5
 xblock-review==1.1.5
 xblock==1.1.1

--- a/scripts/circle-ci-tests.sh
+++ b/scripts/circle-ci-tests.sh
@@ -37,11 +37,11 @@ if [ "$CIRCLE_NODE_TOTAL" == "1" ] ; then
     echo "via the CircleCI UI and adjust scripts/circle-ci-tests.sh to match."
 
     echo "Running tests for common/lib/ and pavelib/"
-    paver test_lib --with-flaky --cov-args="-p" --with-xunitmp || EXIT=1
+    paver test_lib --cov-args="-p" || EXIT=1
     echo "Running python tests for Studio"
-    paver test_system -s cms --with-flaky --cov-args="-p" --with-xunitmp || EXIT=1
+    paver test_system -s cms --cov-args="-p" || EXIT=1
     echo "Running python tests for lms"
-    paver test_system -s lms --with-flaky --cov-args="-p" --with-xunitmp || EXIT=1
+    paver test_system -s lms --cov-args="-p" || EXIT=1
 
     exit $EXIT
 else
@@ -78,15 +78,15 @@ else
             ;;
 
         1)  # run all of the lms unit tests
-            paver test_system -s lms --with-flaky --cov-args="-p" --with-xunitmp
+            paver test_system -s lms --cov-args="-p"
             ;;
 
         2)  # run all of the cms unit tests
-            paver test_system -s cms --with-flaky --cov-args="-p" --with-xunitmp
+            paver test_system -s cms --cov-args="-p"
             ;;
 
         3)  # run the commonlib unit tests
-            paver test_lib --with-flaky --cov-args="-p" --with-xunitmp
+            paver test_lib --cov-args="-p"
             ;;
 
         *)

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,19 +1,3 @@
-[nosetests]
-logging-clear-handlers=1
-with-ignore-docstrings=1
-exclude-dir=lms/envs
-            cms/envs
-
-# Without this flag, nose adds /lib directories to the path,
-# which shadows the xblock library (among other things)
-no-path-adjustment=1
-
-process-timeout=300
-
-# Uncomment the following lines to open pdb when a test fails
-#nocapture=1
-#pdb=1
-
 [tool:pytest]
 DJANGO_SETTINGS_MODULE = lms.envs.test
 addopts = --nomigrations --reuse-db --durations=20


### PR DESCRIPTION
Removed some now-unused dependencies and moved others that are only used for testing and/or development into more appropriate requirements files.  This should reduce the number of packages installed for stage and production deployments by 52.  Worth special mentions:

* Only one class was being imported from `chrono`, and that wasn't being used.
* `GitPython` had previously been used for a now-gone cms app, and was only still being used for a single trivial assertion function.
* We no longer use nose to run tests, so I removed the associated plugins and configuration.
* Updated the CircleCI test script to work with the pytest-based paver test commands.