### PR TITLE
Use s3 db cache on devstack

### DIFF
--- a/pavelib/utils/db_utils.py
+++ b/pavelib/utils/db_utils.py
@@ -125,11 +125,17 @@ def does_fingerprint_on_disk_match(fingerprint):
 
 def is_fingerprint_in_bucket(fingerprint, bucket_name):
     """
-    Test if a zip file matching the given fingerprint is present within an s3 bucket
+    Test if a zip file matching the given fingerprint is present within an s3 bucket.
+    If there is any issue reaching the bucket, show the exception but continue by
+    returning False
     """
     zipfile_name = '{}.tar.gz'.format(fingerprint)
-    conn = boto.connect_s3(anon=True)
-    bucket = conn.get_bucket(bucket_name)
+    try:
+        conn = boto.connect_s3(anon=True)
+        bucket = conn.get_bucket(bucket_name)
+    except Exception as e:  # pylint: disable=broad-except
+        print("Exception caught trying to reach S3 bucket {}: {}".format(bucket_name, e))
+        return False
     key = boto.s3.key.Key(bucket=bucket, name=zipfile_name)
     return key.exists()
 

--- a/pavelib/utils/test/suites/bokchoy_suite.py
+++ b/pavelib/utils/test/suites/bokchoy_suite.py
@@ -136,14 +136,9 @@ def reset_test_database():
     """
     Reset the database used by the bokchoy tests.
 
-    If the tests are being run on Jenkins, use the database cache automation
-    defined in pavelib/database.py
-    If not, reset the test database and apply migrations
+    Use the database cache automation defined in pavelib/database.py
     """
-    if os.environ.get('USER', None) == 'jenkins':
-        update_local_bokchoy_db_from_s3()  # pylint: disable=no-value-for-parameter
-    else:
-        sh("{}/scripts/reset-test-db.sh --migrations".format(Env.REPO_ROOT))
+    update_local_bokchoy_db_from_s3()  # pylint: disable=no-value-for-parameter
 
 
 @task


### PR DESCRIPTION
This change allows users on devstack to utilize the s3 database cache. If the local cache is not up to date, we check to see if the desired fingerprint is in the s3 bucket: https://github.com/edx/edx-platform/blob/5b1a2625485835314bb4ccfbce0e33ee486f5188/pavelib/database.py#L98 . This code change catches any connection errors that might happen from a lack of internet connection. We print the error but continue on, using the local cache and applying any necessary migrations.