### PR TITLE
Yro/EDUCATOR 2700

### DIFF
--- a/lms/djangoapps/verify_student/models.py
+++ b/lms/djangoapps/verify_student/models.py
@@ -33,6 +33,7 @@ from django.utils.translation import ugettext_lazy
 from model_utils import Choices
 from model_utils.models import StatusModel, TimeStampedModel
 from opaque_keys.edx.django.models import CourseKeyField
+from openedx.core.djangolib.model_mixins import DeletableByUserValue
 
 from lms.djangoapps.verify_student.ssencrypt import (
     encrypt_and_encode,
@@ -235,7 +236,7 @@ class SSOVerification(IDVerificationAttempt):
 models.signals.post_save.connect(post_save_id_verification, sender=SSOVerification)
 
 
-class PhotoVerification(IDVerificationAttempt):
+class PhotoVerification(IDVerificationAttempt, DeletableByUserValue):
     """
     Each PhotoVerification represents a Student's attempt to establish
     their identity by uploading a photo of themselves and a picture ID. An

--- a/lms/djangoapps/verify_student/tests/test_models.py
+++ b/lms/djangoapps/verify_student/tests/test_models.py
@@ -330,6 +330,27 @@ class TestPhotoVerification(TestVerification, MockS3Mixin, ModuleStoreTestCase):
             self.assertIsNotNone(fourth_result)
             self.assertEqual(fourth_result, first_result)
 
+    def test_retire_user(self):
+        user = UserFactory.create()
+        user.profile.name = u"Enrique"
+
+        attempt = SoftwareSecurePhotoVerification(user=user)
+        attempt.mark_ready()
+        attempt.status = "submitted"
+        attempt.photo_id_image_url = "https://example.com/test/image/img.jpg"
+        attempt.face_image_url = "https://example.com/test/face/img.jpg"
+        attempt.approve()
+
+        # Before Delete
+        assert_equals(attempt.name, user.profile.name)
+        assert_equals(attempt.photo_id_image_url, 'https://example.com/test/image/img.jpg')
+        assert_equals(attempt.face_image_url, 'https://example.com/test/face/img.jpg')
+
+        # Attempt
+        self.assertTrue(SoftwareSecurePhotoVerification.delete_by_user_value(user, "user"))
+        # Reattempt
+        self.assertFalse(SoftwareSecurePhotoVerification.delete_by_user_value(user, "user"))
+
 
 class SSOVerificationTest(TestVerification):
     """


### PR DESCRIPTION
## [EDUCATOR-2700](https://openedx.atlassian.net/browse/EDUCATOR-2700)

### Description
Delete PII from SoftwareSecurePhotoVerification as a part of GDPR Phase I via mixin class.

### Testing
- [ ] Unit tests

### Reviewers
If you've been tagged for review, please check your corresponding box once you've given the :+1:.
- [ ] Code review: @sanfordstudent 

FYI: @edx/educator-neem

### Post-review
- [ ] Rebase and squash commits


