### PR TITLE
ENT-960 Fix catalogs creation bug due to request data format

### DIFF
--- a/openedx/core/djangoapps/api_admin/forms.py
+++ b/openedx/core/djangoapps/api_admin/forms.py
@@ -38,8 +38,11 @@ class ApiAccessRequestForm(forms.ModelForm):
 class ViewersWidget(forms.widgets.TextInput):
     """Form widget to display a comma-separated list of usernames."""
 
-    def render(self, name, value, attrs=None):
-        return super(ViewersWidget, self).render(name, ', '.join(value), attrs)
+    def format_value(self, value):
+        """
+        Return a serialized value as it should appear when rendered in a template.
+        """
+        return ', '.join(value) if isinstance(value, list) else value
 
 
 class ViewersField(forms.Field):

--- a/openedx/core/djangoapps/api_admin/tests/test_forms.py
+++ b/openedx/core/djangoapps/api_admin/tests/test_forms.py
@@ -3,7 +3,7 @@
 import ddt
 from django.test import TestCase
 
-from openedx.core.djangoapps.api_admin.forms import ApiAccessRequestForm
+from openedx.core.djangoapps.api_admin.forms import ApiAccessRequestForm, ViewersWidget
 from openedx.core.djangoapps.api_admin.tests.utils import VALID_DATA
 from openedx.core.djangolib.testing.utils import skip_unless_lms
 
@@ -21,3 +21,25 @@ class ApiAccessFormTest(TestCase):
     def test_form_valid(self, data, is_valid):
         form = ApiAccessRequestForm(data)
         self.assertEqual(form.is_valid(), is_valid)
+
+
+@skip_unless_lms
+class ViewersWidgetTest(TestCase):
+    widget = ViewersWidget()
+
+    def test_render_value(self):
+        """
+        Verify that ViewersWidget always displays serialized value on rendering.
+        """
+        dummy_string_value = 'staff, verified'
+        input_field_name = 'viewers'
+        expected_widget_html = '<input type="text" name="{input_field_name}" value="{serialized_value}" />'.format(
+            input_field_name=input_field_name,
+            serialized_value=dummy_string_value,
+        )
+        output = self.widget.render(name=input_field_name, value=dummy_string_value)
+        self.assertEqual(expected_widget_html, output)
+
+        dummy_list_value = ['staff', 'verified']
+        output = self.widget.render(name=input_field_name, value=dummy_list_value)
+        self.assertEqual(expected_widget_html, output)

--- a/openedx/core/djangoapps/api_admin/views.py
+++ b/openedx/core/djangoapps/api_admin/views.py
@@ -178,7 +178,7 @@ class CatalogListView(CatalogApiMixin, View):
         if not form.is_valid():
             return render_to_response(self.template, self.get_context_data(client, username, form), status=400)
 
-        attrs = form.instance.attributes
+        attrs = form.cleaned_data
         catalog = client.catalogs.post(attrs)
         return redirect(reverse('api_admin:catalog-edit', kwargs={'catalog_id': catalog['id']}))
 


### PR DESCRIPTION
@asadiqbal08 @saleem-latif @georgebabey 
Initial solution: https://github.com/edx/course-discovery/pull/1401
Catalogs creation endpoint in discovery was expecting list value for viewers `'viewers': ['user_1', 'user_2']` but catalogs creation page in LMS api-admin was sending serialized value for viewers field `viewers': "['user_1, 'user_2']"`.

* Updated Catalogs creation view to expect request data in json format
* Update tests to reflect the change

**Testing Instructions:**
* Setup edx-platform with discovery service point to the branch `zub/ENT-960-fix-catalogs-creation-bug`.
* Open catalogs creation page in edx-platform `http://localhost:8000/api-admin/catalogs/`
<img width="604" alt="screen shot 2018-04-19 at 4 13 28 pm" src="https://user-images.githubusercontent.com/5072991/38988506-d4b83492-43ec-11e8-9b40-acdb6fe4c67b.png">
* Search catalogs with an existing username.
* View the catalogs list page along with catalog creation form. Provide details on the catalog creation form.
<img width="311" alt="screen shot 2018-04-19 at 4 14 00 pm" src="https://user-images.githubusercontent.com/5072991/38988530-f034b0ba-43ec-11e8-9edd-0874e59be9e6.png">
* Verify that on clicking button "Catalog Creation" the user is redirected to catalog detail page.
<img width="333" alt="screen shot 2018-04-19 at 4 14 22 pm" src="https://user-images.githubusercontent.com/5072991/38988752-d371852e-43ed-11e8-832b-4b09ddd47d10.png">

* Now repeat the step again with invalid usernames and verify that the viewers field display proper list of viewers `zubair, invalid_username` instead of bad format of list of characters `z, u, b, a, i, r, ,,  , i, n, v, a, l, i, d, _, u, s, e, r, n, a, m, e, `.
<img width="363" alt="screen shot 2018-04-20 at 4 51 41 pm" src="https://user-images.githubusercontent.com/5072991/39049920-c2c56ca2-44bc-11e8-933c-a85743c9155d.png">
