### PR TITLE
update edx-proctoring version from 1.3.9 to 1.4.0.

### DIFF
--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -121,7 +121,7 @@ edx-milestones==0.1.13
 edx-oauth2-provider==1.2.2
 edx-opaque-keys[django]==0.4.4
 edx-organizations==0.4.10
-edx-proctoring==1.3.9
+edx-proctoring==1.4.0
 edx-rest-api-client==1.7.1
 edx-search==1.1.0
 edx-submissions==2.0.12


### PR DESCRIPTION
Jira Tickets: 
https://openedx.atlassian.net/browse/EDUCATOR-2748

Diff of proctoring tags:
https://github.com/edx/edx-proctoring/compare/1.3.9...1.4.0

edx-proctoring PR link:
https://github.com/edx/edx-proctoring/pull/430

edx-proctoring release PR link:
https://github.com/edx/edx-proctoring/pull/431

cc: @awaisdar001 