### PR TITLE
fix outline progress

### DIFF
--- a/openedx/features/course_experience/templates/course_experience/course-outline-fragment.html
+++ b/openedx/features/course_experience/templates/course_experience/course-outline-fragment.html
@@ -39,7 +39,7 @@ course_sections = blocks.get('children')
                             id="${ section['id'] }">
                         <span class="fa fa-chevron-right ${ 'fa-rotate-90' if section_is_auto_opened else '' }" aria-hidden="true"></span>
                         <h3 class="section-title">${ section['display_name'] }</h3>
-            % if show_visual_progress and section.get('complete'):
+            % if section.get('complete'):
                             <span class="complete-checkmark fa fa-check"></span>
             % endif
                     </button>
@@ -82,7 +82,7 @@ course_sections = blocks.get('children')
                                         <span class="subsection-title">
                                             ${ subsection['display_name'] }
                                         </span>
-                    % if show_visual_progress and subsection.get('complete'):
+                    % if subsection.get('complete'):
                                         <span class="complete-checkmark fa fa-check"></span>
                     % endif
                 % endif
@@ -163,7 +163,7 @@ course_sections = blocks.get('children')
                                                     ${ vertical['display_name'] }
                                                 </span>
                                             </div>
-                        % if show_visual_progress and vertical.get('complete'):
+                        % if vertical.get('complete'):
                                                 <span class="complete-checkmark fa fa-check"></span>
                         % endif
                                         </a>

--- a/openedx/features/course_experience/tests/views/test_course_outline.py
+++ b/openedx/features/course_experience/tests/views/test_course_outline.py
@@ -384,6 +384,27 @@ class TestCourseOutlineResumeCourse(SharedModuleStoreTestCase, CompletionWaffleT
         self.assertContains(response, 'Resume Course', count=resume_count)
         return response
 
+    def test_course_home_completion(self):
+        """
+        Test that completed blocks appear checked on course home page
+        """
+        self.override_waffle_switch(True)
+
+        course = self.course
+        vertical = course.children[0].children[0].children[0]
+
+        response = self.client.get(course_home_url(course))
+        content = pq(response.content)
+        self.assertEqual(len(content('.fa-check')), 0)
+
+        self.complete_sequential(self.course, vertical)
+
+        response = self.client.get(course_home_url(course))
+        content = pq(response.content)
+
+        # vertical and its parent should be checked
+        self.assertEqual(len(content('.fa-check')), 2)
+
     def test_start_course(self):
         """
         Tests that the start course button appears when the course has never been accessed.


### PR DESCRIPTION
## [EDUCATOR-2759](https://openedx.atlassian.net/browse/EDUCATOR-2759)

### Description

`show_visual_progress`  check is removed from view. I have removed this check from template to make outline progress work. 
Test is added to ensure that a completed block should appear checked on course outline.

**Sandbox**
https://outline.sandbox.edx.org

### Reviewers
If you've been tagged for review, please check your corresponding box once you've given the :+1:.
- [x] Code review: @awaisdar001 
- [x] Code review: @Rabia23 

### Post-review
- [ ] Rebase and squash commits