### PR TITLE
Reshard python unittests

### DIFF
--- a/cms/djangoapps/contentstore/tests/test_contentstore.py
+++ b/cms/djangoapps/contentstore/tests/test_contentstore.py
@@ -92,6 +92,8 @@ class ImportRequiredTestCases(ContentStoreTestCase):
     """
     Tests which legitimately need to import a course
     """
+    shard = 1
+
     def test_no_static_link_rewrites_on_import(self):
         course_items = import_course_from_xml(
             self.store, self.user.id, TEST_DATA_DIR, ['toy'], create_if_not_present=True
@@ -609,6 +611,8 @@ class MiscCourseTests(ContentStoreTestCase):
     """
     Tests that rely on the toy courses.
     """
+    shard = 1
+
     def setUp(self):
         super(MiscCourseTests, self).setUp()
         # save locs not items b/c the items won't have the subsequently created children in them until refetched
@@ -1157,6 +1161,7 @@ class ContentStoreTest(ContentStoreTestCase):
     """
     Tests for the CMS ContentStore application.
     """
+    shard = 1
     duplicate_course_error = ("There is already a course defined with the same organization and course number. "
                               "Please change either organization or course number to be unique.")
 
@@ -1805,6 +1810,7 @@ class ContentStoreTest(ContentStoreTestCase):
 
 class MetadataSaveTestCase(ContentStoreTestCase):
     """Test that metadata is correctly cached and decached."""
+    shard = 1
 
     def setUp(self):
         super(MetadataSaveTestCase, self).setUp()
@@ -1866,6 +1872,8 @@ class RerunCourseTest(ContentStoreTestCase):
     """
     Tests for Rerunning a course via the view handler
     """
+    shard = 1
+
     def setUp(self):
         super(RerunCourseTest, self).setUp()
         self.destination_course_data = {
@@ -2108,6 +2116,8 @@ class ContentLicenseTest(ContentStoreTestCase):
     """
     Tests around content licenses
     """
+    shard = 1
+
     def test_course_license_export(self):
         content_store = contentstore()
         root_dir = path(mkdtemp_clean())
@@ -2146,6 +2156,8 @@ class EntryPageTestCase(TestCase):
     """
     Tests entry pages that aren't specific to a course.
     """
+    shard = 1
+
     def setUp(self):
         super(EntryPageTestCase, self).setUp()
         self.client = AjaxEnabledTestClient()
@@ -2180,6 +2192,7 @@ class SigninPageTestCase(TestCase):
     important to make sure that the script is functional independently of any
     other script.
     """
+    shard = 1
 
     def test_csrf_token_is_present_in_form(self):
         # Expected html:

--- a/cms/djangoapps/contentstore/tests/test_course_settings.py
+++ b/cms/djangoapps/contentstore/tests/test_course_settings.py
@@ -41,6 +41,8 @@ class CourseSettingsEncoderTest(CourseTestCase):
     """
     Tests for CourseSettingsEncoder.
     """
+    shard = 1
+
     def test_encoder(self):
         details = CourseDetails.fetch(self.course.id)
         jsondetails = json.dumps(details, cls=CourseSettingsEncoder)
@@ -87,6 +89,8 @@ class CourseDetailsViewTest(CourseTestCase, MilestonesTestCaseMixin):
     """
     Tests for modifying content on the first course settings page (course dates, overview, etc.).
     """
+    shard = 1
+
     def alter_field(self, url, details, field, val):
         """
         Change the one field to the given value and then invoke the update post to see if it worked.
@@ -435,6 +439,8 @@ class CourseGradingTest(CourseTestCase):
     """
     Tests for the course settings grading page.
     """
+    shard = 1
+
     def test_initial_grader(self):
         test_grader = CourseGradingModel(self.course)
         self.assertIsNotNone(test_grader.graders)
@@ -769,6 +775,8 @@ class CourseMetadataEditingTest(CourseTestCase):
     """
     Tests for CourseMetadata.
     """
+    shard = 1
+
     def setUp(self):
         CourseTestCase.setUp(self)
         self.fullcourse = CourseFactory.create()
@@ -1158,6 +1166,8 @@ class CourseGraderUpdatesTest(CourseTestCase):
     """
     Test getting, deleting, adding, & updating graders
     """
+    shard = 1
+
     def setUp(self):
         """Compute the url to use in tests"""
         super(CourseGraderUpdatesTest, self).setUp()
@@ -1223,6 +1233,8 @@ class CourseEnrollmentEndFieldTest(CourseTestCase):
     Base class to test the enrollment end fields in the course settings details view in Studio
     when using marketing site flag and global vs non-global staff to access the page.
     """
+    shard = 1
+
     NOT_EDITABLE_HELPER_MESSAGE = "Contact your edX partner manager to update these settings."
     NOT_EDITABLE_DATE_WRAPPER = "<div class=\"field date is-not-editable\" id=\"field-enrollment-end-date\">"
     NOT_EDITABLE_TIME_WRAPPER = "<div class=\"field time is-not-editable\" id=\"field-enrollment-end-time\">"

--- a/cms/djangoapps/contentstore/tests/test_courseware_index.py
+++ b/cms/djangoapps/contentstore/tests/test_courseware_index.py
@@ -185,6 +185,7 @@ class MixedWithOptionsTestCase(MixedSplitTestCase):
 @ddt.ddt
 class TestCoursewareSearchIndexer(MixedWithOptionsTestCase):
     """ Tests the operation of the CoursewareSearchIndexer """
+    shard = 1
 
     WORKS_WITH_STORES = (ModuleStoreEnum.Type.mongo, ModuleStoreEnum.Type.split)
 
@@ -605,6 +606,7 @@ class TestCoursewareSearchIndexer(MixedWithOptionsTestCase):
 @ddt.ddt
 class TestLargeCourseDeletions(MixedWithOptionsTestCase):
     """ Tests to excerise deleting items from a course """
+    shard = 1
 
     WORKS_WITH_STORES = (ModuleStoreEnum.Type.mongo, ModuleStoreEnum.Type.split)
 
@@ -688,6 +690,7 @@ class TestTaskExecution(SharedModuleStoreTestCase):
     being present, which allows us to ensure that when the listener is
     executed, it is done as expected.
     """
+    shard = 1
 
     @classmethod
     def setUpClass(cls):
@@ -782,6 +785,7 @@ class TestTaskExecution(SharedModuleStoreTestCase):
 @ddt.ddt
 class TestLibrarySearchIndexer(MixedWithOptionsTestCase):
     """ Tests the operation of the CoursewareSearchIndexer """
+    shard = 1
 
     # libraries work only with split, so do library indexer
     WORKS_WITH_STORES = (ModuleStoreEnum.Type.split, )
@@ -955,6 +959,8 @@ class GroupConfigurationSearchMongo(CourseTestCase, MixedWithOptionsTestCase):
     """
     Tests indexing of content groups on course modules using mongo modulestore.
     """
+    shard = 1
+
     MODULESTORE = TEST_DATA_MONGO_MODULESTORE
     INDEX_NAME = CoursewareSearchIndexer.INDEX_NAME
 

--- a/cms/djangoapps/contentstore/tests/test_libraries.py
+++ b/cms/djangoapps/contentstore/tests/test_libraries.py
@@ -36,6 +36,8 @@ class LibraryTestCase(ModuleStoreTestCase):
     """
     Common functionality for content libraries tests
     """
+    shard = 1
+
     def setUp(self):
         super(LibraryTestCase, self).setUp()
 
@@ -148,6 +150,8 @@ class TestLibraries(LibraryTestCase):
     """
     High-level tests for libraries
     """
+    shard = 1
+
     @ddt.data(
         (2, 1, 1),
         (2, 2, 2),
@@ -480,6 +484,8 @@ class TestLibraryAccess(SignalDisconnectTestMixin, LibraryTestCase):
     """
     Test Roles and Permissions related to Content Libraries
     """
+    shard = 1
+
     def setUp(self):
         """ Create a library, staff user, and non-staff user """
         super(TestLibraryAccess, self).setUp()
@@ -813,6 +819,8 @@ class TestOverrides(LibraryTestCase):
     """
     Test that overriding block Scope.settings fields from a library in a specific course works
     """
+    shard = 1
+
     def setUp(self):
         super(TestOverrides, self).setUp()
         self.original_display_name = "A Problem Block"
@@ -997,6 +1005,8 @@ class TestIncompatibleModuleStore(LibraryTestCase):
     """
     Tests for proper validation errors with an incompatible course modulestore.
     """
+    shard = 1
+
     def setUp(self):
         super(TestIncompatibleModuleStore, self).setUp()
         # Create a course in an incompatible modulestore.

--- a/cms/djangoapps/contentstore/views/tests/test_certificates.py
+++ b/cms/djangoapps/contentstore/views/tests/test_certificates.py
@@ -106,6 +106,7 @@ class CertificatesBaseTestCase(object):
     """
     Mixin with base test cases for the certificates.
     """
+    shard = 1
 
     def _remove_ids(self, content):
         """
@@ -199,6 +200,8 @@ class CertificatesListHandlerTestCase(
     """
     Test cases for certificates_list_handler.
     """
+    shard = 1
+
     def setUp(self):
         """
         Set up CertificatesListHandlerTestCase.
@@ -425,6 +428,7 @@ class CertificatesDetailHandlerTestCase(
     """
     Test cases for CertificatesDetailHandlerTestCase.
     """
+    shard = 1
 
     _id = 0
 

--- a/cms/djangoapps/contentstore/views/tests/test_course_index.py
+++ b/cms/djangoapps/contentstore/views/tests/test_course_index.py
@@ -42,6 +42,8 @@ class TestCourseIndex(CourseTestCase):
     """
     Unit tests for getting the list of courses and the course outline.
     """
+    shard = 1
+
     def setUp(self):
         """
         Add a course with odd characters in the fields
@@ -315,6 +317,8 @@ class TestCourseIndexArchived(CourseTestCase):
     """
     Unit tests for testing the course index list when there are archived courses.
     """
+    shard = 1
+
     NOW = datetime.datetime.now(pytz.utc)
     DAY = datetime.timedelta(days=1)
     YESTERDAY = NOW - DAY
@@ -426,6 +430,7 @@ class TestCourseOutline(CourseTestCase):
     """
     Unit tests for the course outline.
     """
+    shard = 1
     ENABLED_SIGNALS = ['course_published']
 
     def setUp(self):
@@ -633,6 +638,7 @@ class TestCourseReIndex(CourseTestCase):
     """
     Unit tests for the course outline.
     """
+    shard = 1
     SUCCESSFUL_RESPONSE = _("Course has been successfully reindexed.")
 
     ENABLED_SIGNALS = ['course_published']

--- a/cms/djangoapps/contentstore/views/tests/test_group_configurations.py
+++ b/cms/djangoapps/contentstore/views/tests/test_group_configurations.py
@@ -168,6 +168,8 @@ class GroupConfigurationsBaseTestCase(object):
     """
     Mixin with base test cases for the group configurations.
     """
+    shard = 1
+
     def _remove_ids(self, content):
         """
         Remove ids from the response. We cannot predict IDs, because they're
@@ -240,6 +242,8 @@ class GroupConfigurationsListHandlerTestCase(CourseTestCase, GroupConfigurations
     """
     Test cases for group_configurations_list_handler.
     """
+    shard = 1
+
     def _url(self):
         """
         Return url for the handler.
@@ -331,6 +335,7 @@ class GroupConfigurationsDetailHandlerTestCase(CourseTestCase, GroupConfiguratio
     Test cases for group_configurations_detail_handler.
     """
 
+    shard = 1
     ID = 0
 
     def _url(self, cid=-1):
@@ -634,6 +639,8 @@ class GroupConfigurationsUsageInfoTestCase(CourseTestCase, HelperMethods):
     """
     Tests for usage information of configurations and content groups.
     """
+    shard = 1
+
     def _get_user_partition(self, scheme):
         """
         Returns the first user partition with the specified scheme.
@@ -1066,6 +1073,8 @@ class GroupConfigurationsValidationTestCase(CourseTestCase, HelperMethods):
     """
     Tests for validation in Group Configurations.
     """
+    shard = 1
+
     @patch('xmodule.split_test_module.SplitTestDescriptor.validate_split_test')
     def verify_validation_add_usage_info(self, expected_result, mocked_message, mocked_validation_messages):
         """

--- a/cms/djangoapps/contentstore/views/tests/test_item.py
+++ b/cms/djangoapps/contentstore/views/tests/test_item.py
@@ -125,6 +125,7 @@ class ItemTest(CourseTestCase):
 @ddt.ddt
 class GetItemTest(ItemTest):
     """Tests for '/xblock' GET url."""
+    shard = 1
 
     def _get_preview(self, usage_key, data=None):
         """ Makes a request to xblock preview handler """
@@ -469,6 +470,8 @@ class GetItemTest(ItemTest):
 @ddt.ddt
 class DeleteItem(ItemTest):
     """Tests for '/xblock' DELETE url."""
+    shard = 1
+
     @ddt.data(ModuleStoreEnum.Type.mongo, ModuleStoreEnum.Type.split)
     def test_delete_static_page(self, store):
         course = CourseFactory.create(default_store=store)
@@ -485,6 +488,8 @@ class TestCreateItem(ItemTest):
     """
     Test the create_item handler thoroughly
     """
+    shard = 1
+
     def test_create_nicely(self):
         """
         Try the straightforward use cases
@@ -660,6 +665,8 @@ class TestDuplicateItem(ItemTest, DuplicateHelper):
     """
     Test the duplicate method.
     """
+    shard = 1
+
     def setUp(self):
         """ Creates the test course structure and a few components to 'duplicate'. """
         super(TestDuplicateItem, self).setUp()
@@ -766,6 +773,8 @@ class TestMoveItem(ItemTest):
     """
     Tests for move item.
     """
+    shard = 1
+
     def setUp(self):
         """
         Creates the test course structure to build course outline tree.
@@ -1317,6 +1326,8 @@ class TestDuplicateItemWithAsides(ItemTest, DuplicateHelper):
     """
     Test the duplicate method for blocks with asides.
     """
+    shard = 1
+
     MODULESTORE = TEST_DATA_SPLIT_MODULESTORE
 
     def setUp(self):
@@ -1379,6 +1390,8 @@ class TestEditItemSetup(ItemTest):
     """
     Setup for xblock update tests.
     """
+    shard = 1
+
     def setUp(self):
         """ Creates the test course structure and a couple problems to 'edit'. """
         super(TestEditItemSetup, self).setUp()
@@ -1409,6 +1422,8 @@ class TestEditItem(TestEditItemSetup):
     """
     Test xblock update.
     """
+    shard = 1
+
     def test_delete_field(self):
         """
         Sending null in for a field 'deletes' it
@@ -1848,6 +1863,7 @@ class TestEditItemSplitMongo(TestEditItemSetup):
     """
     Tests for EditItem running on top of the SplitMongoModuleStore.
     """
+    shard = 1
     MODULESTORE = TEST_DATA_SPLIT_MODULESTORE
 
     def test_editing_view_wrappers(self):
@@ -1869,6 +1885,8 @@ class TestEditSplitModule(ItemTest):
     """
     Tests around editing instances of the split_test module.
     """
+    shard = 1
+
     def setUp(self):
         super(TestEditSplitModule, self).setUp()
         self.user = UserFactory()
@@ -2090,6 +2108,8 @@ class TestEditSplitModule(ItemTest):
 
 @ddt.ddt
 class TestComponentHandler(TestCase):
+    shard = 1
+
     def setUp(self):
         super(TestComponentHandler, self).setUp()
 
@@ -2150,6 +2170,7 @@ class TestComponentTemplates(CourseTestCase):
     """
     Unit tests for the generation of the component templates for a course.
     """
+    shard = 1
 
     def setUp(self):
         super(TestComponentTemplates, self).setUp()
@@ -2385,6 +2406,8 @@ class TestXBlockInfo(ItemTest):
     """
     Unit tests for XBlock's outline handling.
     """
+    shard = 1
+
     def setUp(self):
         super(TestXBlockInfo, self).setUp()
         user_id = self.user.id
@@ -2731,6 +2754,8 @@ class TestLibraryXBlockInfo(ModuleStoreTestCase):
     """
     Unit tests for XBlock Info for XBlocks in a content library
     """
+    shard = 1
+
     def setUp(self):
         super(TestLibraryXBlockInfo, self).setUp()
         user_id = self.user.id
@@ -2780,6 +2805,8 @@ class TestLibraryXBlockCreation(ItemTest):
     """
     Tests the adding of XBlocks to Library
     """
+    shard = 1
+
     def test_add_xblock(self):
         """
         Verify we can add an XBlock to a Library.
@@ -2816,6 +2843,7 @@ class TestXBlockPublishingInfo(ItemTest):
     """
     Unit tests for XBlock's outline handling.
     """
+    shard = 1
     FIRST_SUBSECTION_PATH = [0]
     FIRST_UNIT_PATH = [0, 0]
     SECOND_UNIT_PATH = [0, 1]

--- a/cms/djangoapps/contentstore/views/tests/test_videos.py
+++ b/cms/djangoapps/contentstore/views/tests/test_videos.py
@@ -63,6 +63,8 @@ class VideoUploadTestBase(object):
     """
     Test cases for the video upload feature
     """
+    shard = 1
+
     def get_url_for_course_key(self, course_key, kwargs=None):
         """Return video handler URL for the given course"""
         return reverse_course_url(self.VIEW_NAME, course_key, kwargs)
@@ -172,6 +174,8 @@ class VideoUploadTestMixin(VideoUploadTestBase):
     """
     Test cases for the video upload feature
     """
+    shard = 1
+
     def test_anon_user(self):
         self.client.logout()
         response = self.client.get(self.url)
@@ -211,6 +215,7 @@ class VideoUploadTestMixin(VideoUploadTestBase):
 @override_settings(VIDEO_UPLOAD_PIPELINE={"BUCKET": "test_bucket", "ROOT_PATH": "test_root"})
 class VideosHandlerTestCase(VideoUploadTestMixin, CourseTestCase):
     """Test cases for the main video upload endpoint"""
+    shard = 1
 
     VIEW_NAME = 'videos_handler'
 
@@ -658,6 +663,7 @@ class VideoImageTestCase(VideoUploadTestBase, CourseTestCase):
     """
     Tests for video image.
     """
+    shard = 1
 
     VIEW_NAME = "video_images_handler"
 
@@ -966,6 +972,7 @@ class TranscriptPreferencesTestCase(VideoUploadTestBase, CourseTestCase):
     """
     Tests for video transcripts preferences.
     """
+    shard = 1
 
     VIEW_NAME = 'transcript_preferences_handler'
 
@@ -1277,6 +1284,7 @@ class TranscriptPreferencesTestCase(VideoUploadTestBase, CourseTestCase):
 @override_settings(VIDEO_UPLOAD_PIPELINE={"BUCKET": "test_bucket", "ROOT_PATH": "test_root"})
 class VideoUrlsCsvTestCase(VideoUploadTestMixin, CourseTestCase):
     """Test cases for the CSV download endpoint for video uploads"""
+    shard = 1
 
     VIEW_NAME = "video_encodings_download"
 

--- a/common/djangoapps/course_modes/tests/test_views.py
+++ b/common/djangoapps/course_modes/tests/test_views.py
@@ -30,7 +30,7 @@ from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
 from xmodule.modulestore.tests.factories import CourseFactory
 
 
-@attr(shard=3)
+@attr(shard=5)
 @ddt.ddt
 @unittest.skipUnless(settings.ROOT_URLCONF == 'lms.urls', 'Test only valid in lms')
 class CourseModeViewTest(CatalogIntegrationMixin, UrlResetMixin, ModuleStoreTestCase, CourseCatalogServiceMockMixin):

--- a/common/djangoapps/pipeline_mako/tests/test_render.py
+++ b/common/djangoapps/pipeline_mako/tests/test_render.py
@@ -13,6 +13,7 @@ from pipeline_mako import compressed_css, compressed_js, render_require_js_path_
 
 class RequireJSPathOverridesTest(TestCase):
     """Test RequireJS path overrides. """
+    shard = 7
 
     OVERRIDES = {
         'jquery': 'common/js/vendor/jquery.js',
@@ -43,6 +44,7 @@ class RequireJSPathOverridesTest(TestCase):
 @ddt.ddt
 class PipelineRenderTest(TestCase):
     """Test individual pipeline rendering functions. """
+    shard = 7
 
     @classmethod
     def setUpClass(cls):

--- a/common/djangoapps/pipeline_mako/tests/test_static_content.py
+++ b/common/djangoapps/pipeline_mako/tests/test_static_content.py
@@ -9,6 +9,7 @@ from edxmako.shortcuts import render_to_string
 
 class TestStaticContent(unittest.TestCase):
     """Tests for static_content.html"""
+    shard = 7
 
     def test_optional_include_mako(self):
         out = render_to_string("test_optional_include_mako.html", {})

--- a/common/lib/xmodule/xmodule/assetstore/tests/test_asset_xml.py
+++ b/common/lib/xmodule/xmodule/assetstore/tests/test_asset_xml.py
@@ -2,10 +2,10 @@
 Test for asset XML generation / parsing.
 """
 
+import unittest
 from path import Path as path
 from lxml import etree
 from contracts import ContractNotRespected
-import unittest
 
 from opaque_keys.edx.locator import CourseLocator
 from xmodule.assetstore import AssetMetadata
@@ -16,6 +16,8 @@ class TestAssetXml(unittest.TestCase):
     """
     Tests for storing/querying course asset metadata.
     """
+    shard = 1
+
     def setUp(self):
         super(TestAssetXml, self).setUp()
 

--- a/common/lib/xmodule/xmodule/modulestore/tests/test_abstraction.py
+++ b/common/lib/xmodule/xmodule/modulestore/tests/test_abstraction.py
@@ -10,6 +10,7 @@ class AbstractionTest(TestCase):
     """
     Tests that the ModuleStore objects are properly abstracted
     """
+    shard = 1
 
     def test_cant_instantiate_abstract_class(self):
         self.assertRaises(TypeError, ModuleStoreRead)  # Cannot be instantiated due to explicit abstraction

--- a/common/lib/xmodule/xmodule/modulestore/tests/test_asides.py
+++ b/common/lib/xmodule/xmodule/modulestore/tests/test_asides.py
@@ -28,6 +28,8 @@ class TestAsidesXmlStore(TestCase):
     """
     Test Asides sourced from xml store
     """
+    shard = 1
+
     @patch('xmodule.modulestore.xml.ImportSystem.applicable_aside_types', lambda self, block: ['test_aside'])
     @XBlockAside.register_temp_plugin(AsideTestType, 'test_aside')
     def test_xml_aside(self):

--- a/common/lib/xmodule/xmodule/modulestore/tests/test_assetstore.py
+++ b/common/lib/xmodule/xmodule/modulestore/tests/test_assetstore.py
@@ -62,6 +62,8 @@ class TestSortedAssetList(unittest.TestCase):
     """
     Tests the SortedAssetList class.
     """
+    shard = 1
+
     def setUp(self):
         super(TestSortedAssetList, self).setUp()
         asset_list = [dict(zip(AssetStoreTestData.asset_fields, asset)) for asset in AssetStoreTestData.all_asset_data]
@@ -89,6 +91,8 @@ class TestMongoAssetMetadataStorage(TestCase):
     """
     Tests for storing/querying course asset metadata.
     """
+    shard = 1
+
     def setUp(self):
         super(TestMongoAssetMetadataStorage, self).setUp()
         self.addTypeEqualityFunc(datetime, self._compare_datetimes)

--- a/common/lib/xmodule/xmodule/modulestore/tests/test_contentstore.py
+++ b/common/lib/xmodule/xmodule/modulestore/tests/test_contentstore.py
@@ -30,6 +30,7 @@ class TestContentstore(unittest.TestCase):
     """
     Test the methods in contentstore.mongo using deprecated and non-deprecated keys
     """
+    shard = 2
 
     # don't use these 2 class vars as they restore behavior once the tests are done
     asset_deprecated = None

--- a/common/lib/xmodule/xmodule/modulestore/tests/test_cross_modulestore_import_export.py
+++ b/common/lib/xmodule/xmodule/modulestore/tests/test_cross_modulestore_import_export.py
@@ -42,6 +42,7 @@ COURSE_DATA_NAMES = (
 EXPORTED_COURSE_DIR_NAME = u'exported_source_course'
 
 
+@attr(shard=2)
 @ddt.ddt
 @attr('mongo')
 class CrossStoreXMLRoundtrip(CourseComparisonTest, PartitionTestCase):

--- a/common/lib/xmodule/xmodule/modulestore/tests/test_libraries.py
+++ b/common/lib/xmodule/xmodule/modulestore/tests/test_libraries.py
@@ -21,6 +21,8 @@ class TestLibraries(MixedSplitTestCase):
     Test for libraries.
     Mostly tests code found throughout split mongo, but also tests library_root_xblock.py
     """
+    shard = 2
+
     def test_create_library(self):
         """
         Test that we can create a library, and see how many mongo calls it uses to do so.

--- a/common/lib/xmodule/xmodule/modulestore/tests/test_modulestore_settings.py
+++ b/common/lib/xmodule/xmodule/modulestore/tests/test_modulestore_settings.py
@@ -19,6 +19,7 @@ class ModuleStoreSettingsMigration(TestCase):
     """
     Tests for the migration code for the module store settings
     """
+    shard = 2
 
     OLD_CONFIG = {
         "default": {

--- a/common/lib/xmodule/xmodule/modulestore/tests/test_mongo.py
+++ b/common/lib/xmodule/xmodule/modulestore/tests/test_mongo.py
@@ -78,6 +78,7 @@ class TestMongoModuleStoreBase(TestCase):
     '''
     Basic setup for all tests
     '''
+    shard = 2
     # Explicitly list the courses to load (don't want the big one)
     courses = ['toy', 'simple', 'simple_with_draft', 'test_unicode']
 
@@ -181,6 +182,7 @@ class TestMongoModuleStoreBase(TestCase):
 
 class TestMongoModuleStore(TestMongoModuleStoreBase):
     '''Module store tests'''
+    shard = 2
 
     @classmethod
     def add_asset_collection(cls, doc_store_config):
@@ -750,6 +752,7 @@ class TestMongoModuleStoreWithNoAssetCollection(TestMongoModuleStore):
     '''
     Tests a situation where no asset_collection is specified.
     '''
+    shard = 2
 
     @classmethod
     def add_asset_collection(cls, doc_store_config):
@@ -782,6 +785,7 @@ class TestMongoKeyValueStore(TestCase):
     """
     Tests for MongoKeyValueStore.
     """
+    shard = 2
 
     def setUp(self):
         super(TestMongoKeyValueStore, self).setUp()

--- a/common/lib/xmodule/xmodule/modulestore/tests/test_mongo_call_count.py
+++ b/common/lib/xmodule/xmodule/modulestore/tests/test_mongo_call_count.py
@@ -5,7 +5,7 @@ when using the Split modulestore.
 
 from tempfile import mkdtemp
 from shutil import rmtree
-from unittest import skip
+from unittest import TestCase, skip
 import ddt
 from django.test import TestCase
 
@@ -28,6 +28,7 @@ class CountMongoCallsXMLRoundtrip(TestCase):
     """
     This class exists to test XML import and export to/from Split.
     """
+    shard = 2
 
     def setUp(self):
         super(CountMongoCallsXMLRoundtrip, self).setUp()
@@ -88,6 +89,7 @@ class CountMongoCallsCourseTraversal(TestCase):
     Tests the number of Mongo calls made when traversing a course tree from the top course root
     to the leaf nodes.
     """
+    shard = 2
 
     def _traverse_blocks_in_course(self, course, access_all_block_fields):
         """

--- a/common/lib/xmodule/xmodule/modulestore/tests/test_publish.py
+++ b/common/lib/xmodule/xmodule/modulestore/tests/test_publish.py
@@ -25,6 +25,7 @@ from xmodule.modulestore.tests.utils import (
 )
 
 
+@attr(shard=1)
 @attr('mongo')
 class TestPublish(SplitWMongoCourseBootstrapper):
     """
@@ -114,8 +115,7 @@ class TestPublish(SplitWMongoCourseBootstrapper):
         #      compute inheritance
         #   15 get published vert
         #   16-18 get ancestor chain
-        #   19 compute inheritance
-        #   20-22 get draft and published vert, compute parent
+        #   19 compute inheritance #   20-22 get draft and published vert, compute parent
         # Sends:
         #   delete the subtree of drafts (1 call),
         #   update the published version of each node in subtree (4 calls),
@@ -157,6 +157,7 @@ class TestPublish(SplitWMongoCourseBootstrapper):
         self.assertTrue(self.draft_mongo.has_item(other_child_loc), "Oops, lost moved item")
 
 
+@attr(shard=1)
 class DraftPublishedOpTestCourseSetup(unittest.TestCase):
     """
     This class exists to test XML import and export between different modulestore
@@ -271,6 +272,7 @@ class DraftPublishedOpTestCourseSetup(unittest.TestCase):
         super(DraftPublishedOpTestCourseSetup, self).setUp()
 
 
+@attr(shard=1)
 class OLXFormatChecker(unittest.TestCase):
     """
     Examines the on-disk course export to verify that specific items are present/missing
@@ -643,6 +645,7 @@ class DraftPublishedOpBaseTestSetup(OLXFormatChecker, DraftPublishedOpTestCourse
         self.export_dir = self._make_new_export_dir_name()
 
 
+@attr(shard=1)
 @ddt.ddt
 class ElementalPublishingTests(DraftPublishedOpBaseTestSetup):
     """
@@ -817,6 +820,7 @@ class ElementalPublishingTests(DraftPublishedOpBaseTestSetup):
             self.assertOLXIsDraftOnly(block_list_untouched)
 
 
+@attr(shard=1)
 @ddt.ddt
 class ElementalUnpublishingTests(DraftPublishedOpBaseTestSetup):
     """
@@ -936,6 +940,7 @@ class ElementalUnpublishingTests(DraftPublishedOpBaseTestSetup):
                 self.unpublish(block_list_to_unpublish)
 
 
+@attr(shard=1)
 @ddt.ddt
 class ElementalDeleteItemTests(DraftPublishedOpBaseTestSetup):
     """
@@ -1133,6 +1138,7 @@ class ElementalDeleteItemTests(DraftPublishedOpBaseTestSetup):
             self.assertOLXIsDeleted(block_list_draft_children)
 
 
+@attr(shard=1)
 @ddt.ddt
 class ElementalConvertToDraftTests(DraftPublishedOpBaseTestSetup):
     """
@@ -1190,6 +1196,7 @@ class ElementalConvertToDraftTests(DraftPublishedOpBaseTestSetup):
                 raise Exception("Must test either Old Mongo or Split modulestore!")
 
 
+@attr(shard=1)
 @ddt.ddt
 class ElementalRevertToPublishedTests(DraftPublishedOpBaseTestSetup):
     """

--- a/common/lib/xmodule/xmodule/modulestore/tests/test_semantics.py
+++ b/common/lib/xmodule/xmodule/modulestore/tests/test_semantics.py
@@ -43,6 +43,7 @@ class DirectOnlyCategorySemantics(PureModulestoreTestCase):
     Verify the behavior of Direct Only items
     blocks intended to store snippets of course content.
     """
+    shard = 1
 
     __test__ = False
 
@@ -415,6 +416,7 @@ class TestSplitDirectOnlyCategorySemantics(DirectOnlyCategorySemantics):
     """
     Verify DIRECT_ONLY_CATEGORY semantics against the SplitMongoModulestore.
     """
+    shard = 1
     MODULESTORE = SPLIT_MODULESTORE_SETUP
     __test__ = True
 
@@ -449,5 +451,6 @@ class TestMongoDirectOnlyCategorySemantics(DirectOnlyCategorySemantics):
     """
     Verify DIRECT_ONLY_CATEGORY semantics against the MongoModulestore
     """
+    shard = 1
     MODULESTORE = MongoModulestoreBuilder()
     __test__ = True

--- a/common/lib/xmodule/xmodule/modulestore/tests/test_split_copy_from_template.py
+++ b/common/lib/xmodule/xmodule/modulestore/tests/test_split_copy_from_template.py
@@ -15,6 +15,8 @@ class TestSplitCopyTemplate(MixedSplitTestCase):
     """
     Test for split's copy_from_template method.
     """
+    shard = 2
+
     @ddt.data(
         LibraryFactory,
         CourseFactory,

--- a/common/lib/xmodule/xmodule/modulestore/tests/test_split_migrator.py
+++ b/common/lib/xmodule/xmodule/modulestore/tests/test_split_migrator.py
@@ -13,6 +13,7 @@ from xmodule.modulestore.split_migrator import SplitMigrator
 from xmodule.modulestore.tests.test_split_w_old_mongo import SplitWMongoCourseBootstrapper
 
 
+@attr(shard=2)
 @attr('mongo')
 class TestMigration(SplitWMongoCourseBootstrapper):
     """

--- a/common/lib/xmodule/xmodule/modulestore/tests/test_split_modulestore.py
+++ b/common/lib/xmodule/xmodule/modulestore/tests/test_split_modulestore.py
@@ -42,6 +42,7 @@ BRANCH_NAME_DRAFT = ModuleStoreEnum.BranchName.draft
 BRANCH_NAME_PUBLISHED = ModuleStoreEnum.BranchName.published
 
 
+@attr(shard=2)
 @attr('mongo')
 class SplitModuleTest(unittest.TestCase):
     '''
@@ -568,6 +569,7 @@ class SplitModuleTest(unittest.TestCase):
                 return element
 
 
+@attr(shard=2)
 class TestHasChildrenAtDepth(SplitModuleTest):
     """Test the has_children_at_depth method of XModuleMixin. """
 
@@ -605,6 +607,7 @@ class TestHasChildrenAtDepth(SplitModuleTest):
         self.assertFalse(ch3.has_children_at_depth(1))
 
 
+@attr(shard=2)
 @ddt.ddt
 class SplitModuleCourseTests(SplitModuleTest):
     '''
@@ -935,6 +938,7 @@ class SplitModuleCourseTests(SplitModuleTest):
         self.assertEqual(root_block_key.block_id, "course")
 
 
+@attr(shard=2)
 class TestCourseStructureCache(SplitModuleTest):
     """Tests for the CourseStructureCache"""
 
@@ -1008,6 +1012,7 @@ class TestCourseStructureCache(SplitModuleTest):
         )
 
 
+@attr(shard=2)
 class SplitModuleItemTests(SplitModuleTest):
     '''
     Item read tests including inheritance
@@ -1270,6 +1275,7 @@ def version_agnostic(children):
     return [child.version_agnostic() for child in children]
 
 
+@attr(shard=2)
 class TestItemCrud(SplitModuleTest):
     """
     Test create update and delete of items
@@ -1762,6 +1768,7 @@ class TestItemCrud(SplitModuleTest):
             store.delete_course(refetch_course.id, user)
 
 
+@attr(shard=2)
 class TestCourseCreation(SplitModuleTest):
     """
     Test create_course
@@ -1960,6 +1967,7 @@ class TestCourseCreation(SplitModuleTest):
                     self.assertEqual(fetched_modified.advertised_start, modified_course.advertised_start)
 
 
+@attr(shard=2)
 class TestInheritance(SplitModuleTest):
     """
     Test the metadata inheritance mechanism.
@@ -2035,6 +2043,7 @@ class TestInheritance(SplitModuleTest):
 #         self.assertTrue(parented_problem.visible_to_staff_only)
 
 
+@attr(shard=2)
 class TestPublish(SplitModuleTest):
     """
     Test the publishing api
@@ -2210,6 +2219,7 @@ class TestPublish(SplitModuleTest):
         self.assertEqual(source_block_keys, dest_block_keys)
 
 
+@attr(shard=2)
 class TestSchema(SplitModuleTest):
     """
     Test the db schema (and possibly eventually migrations?)

--- a/common/lib/xmodule/xmodule/modulestore/tests/test_split_modulestore_bulk_operations.py
+++ b/common/lib/xmodule/xmodule/modulestore/tests/test_split_modulestore_bulk_operations.py
@@ -14,6 +14,8 @@ from opaque_keys.edx.locator import CourseLocator
 
 
 class TestBulkWriteMixin(unittest.TestCase):
+    shard = 2
+
     def setUp(self):
         super(TestBulkWriteMixin, self).setUp()
         self.bulk = SplitBulkWriteMixin()
@@ -54,6 +56,8 @@ class TestBulkWriteMixinClosed(TestBulkWriteMixin):
     """
     Tests of the bulk write mixin when bulk operations aren't active.
     """
+    shard = 2
+
     @ddt.data('deadbeef1234' * 2, u'deadbeef1234' * 2, ObjectId())
     def test_no_bulk_read_structure(self, version_guid):
         # Reading a structure when no bulk operation is active should just call
@@ -296,6 +300,8 @@ class TestBulkWriteMixinFindMethods(TestBulkWriteMixin):
     """
     Tests of BulkWriteMixin methods for finding many structures or indexes
     """
+    shard = 2
+
     def test_no_bulk_find_matching_course_indexes(self):
         branch = Mock(name='branch')
         search_targets = MagicMock(name='search_targets')
@@ -572,6 +578,8 @@ class TestBulkWriteMixinOpen(TestBulkWriteMixin):
     """
     Tests of the bulk write mixin when bulk write operations are open
     """
+    shard = 2
+
     def setUp(self):
         super(TestBulkWriteMixinOpen, self).setUp()
         self.bulk._begin_bulk_operation(self.course_key)

--- a/common/lib/xmodule/xmodule/modulestore/tests/test_split_mongo_mongo_connection.py
+++ b/common/lib/xmodule/xmodule/modulestore/tests/test_split_mongo_mongo_connection.py
@@ -7,6 +7,8 @@ from xmodule.exceptions import HeartbeatFailure
 
 class TestHeartbeatFailureException(unittest.TestCase):
     """ Test that a heartbeat failure is thrown at the appropriate times """
+    shard = 2
+
     @patch('pymongo.MongoClient')
     @patch('pymongo.database.Database')
     def test_heartbeat_raises_exception_when_connection_alive_is_false(self, *calls):

--- a/common/lib/xmodule/xmodule/modulestore/tests/test_store_utilities.py
+++ b/common/lib/xmodule/xmodule/modulestore/tests/test_store_utilities.py
@@ -49,6 +49,7 @@ class TestUtils(unittest.TestCase):
                 /        \
             child_3    child_4
     """
+    shard = 2
 
     ONLY_ROOTS = [
         draft_node_constructor(Mock(), 'url1', 'vertical'),

--- a/common/lib/xmodule/xmodule/modulestore/tests/test_xml.py
+++ b/common/lib/xmodule/xmodule/modulestore/tests/test_xml.py
@@ -32,6 +32,8 @@ class TestXMLModuleStore(TestCase):
     """
     Test around the XML modulestore
     """
+    shard = 2
+
     @patch('xmodule.tabs.CourseTabList.initialize_default', Mock())
     def test_unicode_chars_in_xml_content(self):
         # edX/full/6.002_Spring_2012 has non-ASCII chars, and during

--- a/common/lib/xmodule/xmodule/modulestore/tests/test_xml_importer.py
+++ b/common/lib/xmodule/xmodule/modulestore/tests/test_xml_importer.py
@@ -126,6 +126,7 @@ class RemapNamespaceTest(ModuleStoreNoSettings):
     """
     Test that remapping the namespace from import to the actual course location.
     """
+    shard = 2
 
     def setUp(self):
         """
@@ -274,6 +275,7 @@ class UpdateLocationTest(ModuleStoreNoSettings):
     """
     Test that updating location preserves "is_set_on" status on fields
     """
+    shard = 2
     CONTENT_FIELDS = ['test_content_field', 'test_mutable_content_field']
     SETTINGS_FIELDS = ['test_settings_field', 'test_mutable_settings_field']
     CHILDREN_FIELDS = ['children']
@@ -341,6 +343,8 @@ class UpdateLocationTest(ModuleStoreNoSettings):
 
 
 class StaticContentImporterTest(unittest.TestCase):
+    shard = 2
+
     def setUp(self):
         self.course_data_path = path('/path')
         self.mocked_content_store = mock.Mock()

--- a/common/lib/xmodule/xmodule/partitions/tests/test_partitions.py
+++ b/common/lib/xmodule/xmodule/partitions/tests/test_partitions.py
@@ -19,6 +19,8 @@ from xmodule.partitions.partitions_service import (
 
 class TestGroup(TestCase):
     """Test constructing groups"""
+    shard = 2
+
     def test_construct(self):
         test_id = 10
         name = "Grendel"
@@ -119,6 +121,7 @@ class MockEnrollmentTrackUserPartitionScheme(MockUserPartitionScheme):
 
 class PartitionTestCase(TestCase):
     """Base class for test cases that require partitions"""
+    shard = 2
     TEST_ID = 0
     TEST_NAME = "Mock Partition"
     TEST_DESCRIPTION = "for testing purposes"
@@ -174,6 +177,7 @@ class PartitionTestCase(TestCase):
 
 class TestUserPartition(PartitionTestCase):
     """Test constructing UserPartitions"""
+    shard = 2
 
     def test_construct(self):
         user_partition = UserPartition(
@@ -454,6 +458,8 @@ class TestPartitionService(PartitionServiceBaseClass):
     """
     Test getting a user's group out of a partition
     """
+    shard = 2
+
     def test_get_user_group_id_for_partition(self):
         # assign the first group to be returned
         user_partition_id = self.user_partition.id
@@ -543,6 +549,7 @@ class TestGetCourseUserPartitions(PartitionServiceBaseClass):
     """
     Test the helper method get_all_partitions_for_course.
     """
+    shard = 2
 
     def setUp(self):
         super(TestGetCourseUserPartitions, self).setUp()

--- a/common/lib/xmodule/xmodule/tests/__init__.py
+++ b/common/lib/xmodule/xmodule/tests/__init__.py
@@ -177,6 +177,8 @@ def mock_render_template(*args, **kwargs):
 
 
 class ModelsTest(unittest.TestCase):
+    shard = 1
+
     def test_load_class(self):
         vc = XModuleDescriptor.load_class('video')
         vc_str = "<class 'xmodule.video_module.video_module.VideoDescriptor'>"
@@ -185,6 +187,7 @@ class ModelsTest(unittest.TestCase):
 
 class LogicTest(unittest.TestCase):
     """Base class for testing xmodule logic."""
+    shard = 1
     descriptor_class = None
     raw_field_data = {}
 
@@ -400,6 +403,7 @@ class CourseComparisonTest(BulkAssertionTest):
     """
     Mixin that has methods for comparing courses for equality.
     """
+    shard = 1
 
     def setUp(self):
         super(CourseComparisonTest, self).setUp()

--- a/common/lib/xmodule/xmodule/tests/test_annotatable_module.py
+++ b/common/lib/xmodule/xmodule/tests/test_annotatable_module.py
@@ -14,6 +14,7 @@ from . import get_test_system
 
 
 class AnnotatableModuleTestCase(unittest.TestCase):
+    shard = 1
     sample_xml = '''
         <annotatable display_name="Iliad">
             <instructions>Read the text.</instructions>

--- a/common/lib/xmodule/xmodule/tests/test_annotator_mixin.py
+++ b/common/lib/xmodule/xmodule/tests/test_annotator_mixin.py
@@ -12,6 +12,7 @@ class HelperFunctionTest(unittest.TestCase):
     """
     Tests to ensure that the following helper functions work for the annotation tool
     """
+    shard = 1
     sample_xml = '''
         <annotatable>
             <instructions><p>Helper Test Instructions.</p></instructions>

--- a/common/lib/xmodule/xmodule/tests/test_annotator_token.py
+++ b/common/lib/xmodule/xmodule/tests/test_annotator_token.py
@@ -10,6 +10,8 @@ class TokenRetriever(unittest.TestCase):
     """
     Tests to make sure that when passed in a username and secret token, that it will be encoded correctly
     """
+    shard = 1
+
     def test_token(self):
         """
         Test for the token generator. Give an a random username and secret token,

--- a/common/lib/xmodule/xmodule/tests/test_bulk_assertions.py
+++ b/common/lib/xmodule/xmodule/tests/test_bulk_assertions.py
@@ -48,6 +48,7 @@ CONTEXT_FAILING_ASSERTIONS = (
 
 @ddt.ddt
 class TestBulkAssertionTestCase(BulkAssertionTest):
+    shard = 1
 
     # We have to use assertion methods from the base UnitTest class,
     # so we make a number of super calls that skip BulkAssertionTest.

--- a/common/lib/xmodule/xmodule/tests/test_capa_module.py
+++ b/common/lib/xmodule/xmodule/tests/test_capa_module.py
@@ -182,6 +182,7 @@ if submission[0] == '':
 
 @ddt.ddt
 class CapaModuleTest(unittest.TestCase):
+    shard = 1
 
     def setUp(self):
         super(CapaModuleTest, self).setUp()
@@ -2002,6 +2003,7 @@ class CapaModuleTest(unittest.TestCase):
 
 @ddt.ddt
 class CapaDescriptorTest(unittest.TestCase):
+    shard = 1
 
     sample_checkbox_problem_xml = textwrap.dedent("""
         <problem>
@@ -2797,6 +2799,8 @@ class CapaDescriptorTest(unittest.TestCase):
 
 
 class ComplexEncoderTest(unittest.TestCase):
+    shard = 1
+
     def test_default(self):
         """
         Check that complex numbers can be encoded into JSON.
@@ -2811,6 +2815,7 @@ class TestProblemCheckTracking(unittest.TestCase):
     """
     Ensure correct tracking information is included in events emitted during problem checks.
     """
+    shard = 1
 
     def setUp(self):
         super(TestProblemCheckTracking, self).setUp()

--- a/common/lib/xmodule/xmodule/tests/test_conditional.py
+++ b/common/lib/xmodule/xmodule/tests/test_conditional.py
@@ -145,6 +145,7 @@ class ConditionalModuleBasicTest(unittest.TestCase):
     Make sure that conditional module works, using mocks for
     other modules.
     """
+    shard = 1
 
     def setUp(self):
         super(ConditionalModuleBasicTest, self).setUp()
@@ -217,6 +218,8 @@ class ConditionalModuleXmlTest(unittest.TestCase):
     """
     Make sure ConditionalModule works, by loading data in from an XML-defined course.
     """
+    shard = 1
+
     @staticmethod
     def get_system(load_error_modules=True):
         '''Get a dummy system'''
@@ -379,6 +382,7 @@ class ConditionalModuleStudioTest(XModuleXmlImportTest):
     """
     Unit tests for how conditional test interacts with Studio.
     """
+    shard = 1
 
     def setUp(self):
         super(ConditionalModuleStudioTest, self).setUp()

--- a/common/lib/xmodule/xmodule/tests/test_conditional_logic.py
+++ b/common/lib/xmodule/xmodule/tests/test_conditional_logic.py
@@ -7,6 +7,7 @@ from . import LogicTest
 
 class ConditionalModuleTest(LogicTest):
     """Logic tests for Conditional Xmodule."""
+    shard = 1
     descriptor_class = ConditionalDescriptor
 
     def test_ajax_request(self):

--- a/common/lib/xmodule/xmodule/tests/test_content.py
+++ b/common/lib/xmodule/xmodule/tests/test_content.py
@@ -100,6 +100,8 @@ class MockImage(Mock):
 
 @ddt.ddt
 class ContentTest(unittest.TestCase):
+    shard = 1
+
     def test_thumbnail_none(self):
         # We had a bug where a thumbnail location of None was getting transformed into a Location tuple, with
         # all elements being None. It is important that the location be just None for rendering.

--- a/common/lib/xmodule/xmodule/tests/test_course_metadata_utils.py
+++ b/common/lib/xmodule/xmodule/tests/test_course_metadata_utils.py
@@ -37,6 +37,7 @@ class CourseMetadataUtilsTestCase(TestCase):
     """
     Tests for course_metadata_utils.
     """
+    shard = 1
 
     def setUp(self):
         """

--- a/common/lib/xmodule/xmodule/tests/test_course_module.py
+++ b/common/lib/xmodule/xmodule/tests/test_course_module.py
@@ -26,6 +26,8 @@ _NEXT_WEEK = _TODAY + timedelta(days=7)
 
 
 class CourseFieldsTestCase(unittest.TestCase):
+    shard = 1
+
     def test_default_start_date(self):
         self.assertEqual(
             xmodule.course_module.CourseFields.start.default,
@@ -95,6 +97,7 @@ def get_dummy_course(start, announcement=None, is_new=None, advertised_start=Non
 
 class HasEndedMayCertifyTestCase(unittest.TestCase):
     """Double check the semantics around when to finalize courses."""
+    shard = 1
 
     def setUp(self):
         super(HasEndedMayCertifyTestCase, self).setUp()
@@ -145,6 +148,7 @@ class HasEndedMayCertifyTestCase(unittest.TestCase):
 
 class CourseSummaryHasEnded(unittest.TestCase):
     """ Test for has_ended method when end date is missing timezone information. """
+    shard = 1
 
     def test_course_end(self):
         test_course = get_dummy_course("2012-01-01T12:00")
@@ -156,6 +160,7 @@ class CourseSummaryHasEnded(unittest.TestCase):
 @ddt.ddt
 class IsNewCourseTestCase(unittest.TestCase):
     """Make sure the property is_new works on courses"""
+    shard = 1
 
     def setUp(self):
         super(IsNewCourseTestCase, self).setUp()
@@ -259,6 +264,8 @@ class IsNewCourseTestCase(unittest.TestCase):
 
 
 class DiscussionTopicsTestCase(unittest.TestCase):
+    shard = 1
+
     def test_default_discussion_topics(self):
         d = get_dummy_course('2012-12-02T12:00')
         self.assertEqual({'General': {'id': 'i4x-test_org-test_course-course-test'}}, d.discussion_topics)
@@ -268,6 +275,7 @@ class TeamsConfigurationTestCase(unittest.TestCase):
     """
     Tests for the configuration of teams and the helper methods for accessing them.
     """
+    shard = 1
 
     def setUp(self):
         super(TeamsConfigurationTestCase, self).setUp()
@@ -336,6 +344,7 @@ class TeamsConfigurationTestCase(unittest.TestCase):
 
 class SelfPacedTestCase(unittest.TestCase):
     """Tests for self-paced courses."""
+    shard = 1
 
     def setUp(self):
         super(SelfPacedTestCase, self).setUp()
@@ -347,6 +356,8 @@ class SelfPacedTestCase(unittest.TestCase):
 
 class BypassHomeTestCase(unittest.TestCase):
     """Tests for setting which allows course home to be bypassed."""
+    shard = 1
+
     def setUp(self):
         super(BypassHomeTestCase, self).setUp()
         self.course = get_dummy_course('2012-12-02T12:00')
@@ -364,6 +375,7 @@ class CourseDescriptorTestCase(unittest.TestCase):
     class definitely isn't a comprehensive test case for CourseDescriptor, as
     writing a such a test case was out of the scope of the PR.
     """
+    shard = 1
 
     def setUp(self):
         """

--- a/common/lib/xmodule/xmodule/tests/test_delay_between_attempts.py
+++ b/common/lib/xmodule/xmodule/tests/test_delay_between_attempts.py
@@ -124,6 +124,7 @@ class XModuleQuizAttemptsDelayTest(unittest.TestCase):
     """
     Class to test delay between quiz attempts.
     """
+    shard = 1
 
     def create_and_check(self,
                          num_attempts=None,

--- a/common/lib/xmodule/xmodule/tests/test_editing_module.py
+++ b/common/lib/xmodule/xmodule/tests/test_editing_module.py
@@ -17,6 +17,7 @@ log = logging.getLogger(__name__)
 
 class TabsEditingDescriptorTestCase(unittest.TestCase):
     """ Testing TabsEditingDescriptor"""
+    shard = 1
 
     def setUp(self):
         super(TabsEditingDescriptorTestCase, self).setUp()

--- a/common/lib/xmodule/xmodule/tests/test_error_module.py
+++ b/common/lib/xmodule/xmodule/tests/test_error_module.py
@@ -16,6 +16,8 @@ from xblock.test.tools import unabc
 
 class SetupTestErrorModules(unittest.TestCase):
     """Common setUp for use in ErrorModule tests."""
+    shard = 1
+
     def setUp(self):
         super(SetupTestErrorModules, self).setUp()
         self.system = get_test_system()
@@ -29,6 +31,8 @@ class TestErrorModule(SetupTestErrorModules):
     """
     Tests for ErrorModule and ErrorDescriptor
     """
+    shard = 1
+
     def test_error_module_xml_rendering(self):
         descriptor = ErrorDescriptor.from_xml(
             self.valid_xml,
@@ -62,6 +66,8 @@ class TestNonStaffErrorModule(SetupTestErrorModules):
     """
     Tests for NonStaffErrorModule and NonStaffErrorDescriptor
     """
+    shard = 1
+
     def test_non_staff_error_module_create(self):
         descriptor = NonStaffErrorDescriptor.from_xml(
             self.valid_xml,
@@ -121,6 +127,8 @@ class TestErrorModuleConstruction(unittest.TestCase):
     """
     Test that error module construction happens correctly
     """
+    shard = 1
+
     def setUp(self):
         # pylint: disable=abstract-class-instantiated
         super(TestErrorModuleConstruction, self).setUp()

--- a/common/lib/xmodule/xmodule/tests/test_export.py
+++ b/common/lib/xmodule/xmodule/tests/test_export.py
@@ -62,6 +62,7 @@ class RoundTripTestCase(unittest.TestCase):
     And we compare original import with second import (after export).
     Thus we make sure that export and import work properly.
     """
+    shard = 1
 
     def setUp(self):
         super(RoundTripTestCase, self).setUp()
@@ -152,6 +153,8 @@ class TestEdxJsonEncoder(unittest.TestCase):
     """
     Tests for xml_exporter.EdxJSONEncoder
     """
+    shard = 1
+
     def setUp(self):
         super(TestEdxJsonEncoder, self).setUp()
 

--- a/common/lib/xmodule/xmodule/tests/test_fields.py
+++ b/common/lib/xmodule/xmodule/tests/test_fields.py
@@ -10,6 +10,7 @@ from xmodule.timeinfo import TimeInfo
 
 
 class DateTest(unittest.TestCase):
+    shard = 1
     date = Date()
 
     def compare_dates(self, dt1, dt2, expected_delta):
@@ -122,6 +123,7 @@ class DateTest(unittest.TestCase):
 
 
 class TimedeltaTest(unittest.TestCase):
+    shard = 1
     delta = Timedelta()
 
     def test_from_json(self):
@@ -156,6 +158,8 @@ class TimedeltaTest(unittest.TestCase):
 
 
 class TimeInfoTest(unittest.TestCase):
+    shard = 1
+
     def test_time_info(self):
         due_date = datetime.datetime(2000, 4, 14, 10, tzinfo=UTC)
         grace_pd_string = '1 day 12 hours 59 minutes 59 seconds'
@@ -167,6 +171,7 @@ class TimeInfoTest(unittest.TestCase):
 
 
 class RelativeTimeTest(unittest.TestCase):
+    shard = 1
 
     delta = RelativeTime()
 

--- a/common/lib/xmodule/xmodule/tests/test_graders.py
+++ b/common/lib/xmodule/xmodule/tests/test_graders.py
@@ -19,6 +19,7 @@ class GradesheetTest(unittest.TestCase):
     """
     Tests the aggregate_scores method
     """
+    shard = 1
 
     def test_weighted_grading(self):
         scores = []
@@ -81,6 +82,7 @@ class GraderTest(unittest.TestCase):
     """
     Tests grader implementations
     """
+    shard = 1
 
     empty_gradesheet = {
     }
@@ -330,6 +332,8 @@ class ShowCorrectnessTest(unittest.TestCase):
     """
     Tests the correctness_available method
     """
+    shard = 1
+
     def setUp(self):
         super(ShowCorrectnessTest, self).setUp()
 

--- a/common/lib/xmodule/xmodule/tests/test_html_module.py
+++ b/common/lib/xmodule/xmodule/tests/test_html_module.py
@@ -32,6 +32,7 @@ class HtmlModuleCourseApiTestCase(unittest.TestCase):
     """
     Test the HTML XModule's student_view_data method.
     """
+    shard = 1
 
     @ddt.data(
         dict(),
@@ -83,6 +84,7 @@ class HtmlModuleCourseApiTestCase(unittest.TestCase):
 
 class HtmlModuleSubstitutionTestCase(unittest.TestCase):
     descriptor = Mock()
+    shard = 1
 
     def test_substitution_works(self):
         sample_xml = '''%%USER_ID%%'''
@@ -115,6 +117,7 @@ class HtmlDescriptorIndexingTestCase(unittest.TestCase):
     """
     Make sure that HtmlDescriptor can format data for indexing as expected.
     """
+    shard = 1
 
     def test_index_dictionary_simple_html_module(self):
         sample_xml = '''
@@ -207,6 +210,8 @@ class CourseInfoModuleTestCase(unittest.TestCase):
     """
     Make sure that CourseInfoModule renders updates properly.
     """
+    shard = 1
+
     def test_updates_render(self):
         """
         Tests that a course info module will render its updates, even if they are malformed.

--- a/common/lib/xmodule/xmodule/tests/test_imageannotation.py
+++ b/common/lib/xmodule/xmodule/tests/test_imageannotation.py
@@ -41,6 +41,7 @@ class ImageAnnotationModuleTestCase(unittest.TestCase):
             </json>
         </annotatable>
     '''
+    shard = 1
 
     def setUp(self):
         """

--- a/common/lib/xmodule/xmodule/tests/test_import.py
+++ b/common/lib/xmodule/xmodule/tests/test_import.py
@@ -63,6 +63,8 @@ class DummySystem(ImportSystem):
 
 class BaseCourseTestCase(TestCase):
     '''Make sure module imports work properly, including for malformed inputs'''
+    shard = 1
+
     @staticmethod
     def get_system(load_error_modules=True, library=False):
         '''Get a dummy system'''
@@ -95,6 +97,7 @@ class PureXBlockImportTest(BaseCourseTestCase):
     """
     Tests of import pure XBlocks (not XModules) from xml
     """
+    shard = 1
 
     def assert_xblocks_are_good(self, block):
         """Assert a number of conditions that must be true for `block` to be good."""
@@ -122,6 +125,7 @@ class PureXBlockImportTest(BaseCourseTestCase):
 
 
 class ImportTestCase(BaseCourseTestCase):
+    shard = 1
     date = Date()
 
     def test_fallback(self):

--- a/common/lib/xmodule/xmodule/tests/test_import_static.py
+++ b/common/lib/xmodule/xmodule/tests/test_import_static.py
@@ -10,6 +10,8 @@ from xmodule.tests import DATA_DIR
 
 class IgnoredFilesTestCase(unittest.TestCase):
     "Tests for ignored files"
+    shard = 1
+
     def test_ignore_tilde_static_files(self):
         course_dir = DATA_DIR / "tilde"
         course_id = CourseLocator("edX", "tilde", "Fall_2012")

--- a/common/lib/xmodule/xmodule/tests/test_library_content.py
+++ b/common/lib/xmodule/xmodule/tests/test_library_content.py
@@ -71,6 +71,7 @@ class LibraryContentModuleTestMixin(object):
     """
     Basic unit tests for LibraryContentModule
     """
+    shard = 1
     problem_types = [
         ["multiplechoiceresponse"], ["optionresponse"], ["optionresponse", "coderesponse"],
         ["coderesponse", "optionresponse"]
@@ -323,6 +324,8 @@ class TestLibraryContentRender(LibraryContentTest):
     """
     Rendering unit tests for LibraryContentModule
     """
+    shard = 1
+
     def test_preview_view(self):
         """ Test preview view rendering """
         self.lc_block.refresh_children()
@@ -347,6 +350,8 @@ class TestLibraryContentAnalytics(LibraryContentTest):
     """
     Test analytics features of LibraryContentModule
     """
+    shard = 1
+
     def setUp(self):
         super(TestLibraryContentAnalytics, self).setUp()
         self.publisher = Mock()

--- a/common/lib/xmodule/xmodule/tests/test_library_root.py
+++ b/common/lib/xmodule/xmodule/tests/test_library_root.py
@@ -24,6 +24,8 @@ class TestLibraryRoot(MixedSplitTestCase):
     """
     Basic unit tests for LibraryRoot (library_root_xblock.py)
     """
+    shard = 1
+
     def test_library_author_view(self):
         """
         Test that LibraryRoot.author_view can run and includes content from its

--- a/common/lib/xmodule/xmodule/tests/test_library_tools.py
+++ b/common/lib/xmodule/xmodule/tests/test_library_tools.py
@@ -11,6 +11,7 @@ class LibraryToolsServiceTest(MixedSplitTestCase):
     """
     Tests for library service.
     """
+    shard = 1
 
     def setUp(self):
         super(LibraryToolsServiceTest, self).setUp()

--- a/common/lib/xmodule/xmodule/tests/test_lti20_unit.py
+++ b/common/lib/xmodule/xmodule/tests/test_lti20_unit.py
@@ -13,6 +13,7 @@ from . import LogicTest
 
 class LTI20RESTResultServiceTest(LogicTest):
     """Logic tests for LTI module. LTI2.0 REST ResultService"""
+    shard = 1
     descriptor_class = LTIDescriptor
 
     def setUp(self):

--- a/common/lib/xmodule/xmodule/tests/test_lti_unit.py
+++ b/common/lib/xmodule/xmodule/tests/test_lti_unit.py
@@ -20,6 +20,7 @@ from . import LogicTest
 
 class LTIModuleTest(LogicTest):
     """Logic tests for LTI module."""
+    shard = 1
     descriptor_class = LTIDescriptor
 
     def setUp(self):

--- a/common/lib/xmodule/xmodule/tests/test_mako_module.py
+++ b/common/lib/xmodule/xmodule/tests/test_mako_module.py
@@ -8,6 +8,7 @@ from xmodule.mako_module import MakoModuleDescriptor
 
 class MakoModuleTest(TestCase):
     """ Test MakoModuleDescriptor """
+    shard = 1
 
     def test_render_template_check(self):
         mock_system = Mock()

--- a/common/lib/xmodule/xmodule/tests/test_mongo_utils.py
+++ b/common/lib/xmodule/xmodule/tests/test_mongo_utils.py
@@ -18,6 +18,8 @@ class MongoUtilsTests(TestCase):
     """
     Tests for methods exposed in mongo_utils
     """
+    shard = 1
+
     @ddt.data(
         ('PRIMARY', 'primary', ReadPreference.PRIMARY),
         ('SECONDARY_PREFERRED', 'secondaryPreferred', ReadPreference.SECONDARY_PREFERRED),

--- a/common/lib/xmodule/xmodule/tests/test_poll.py
+++ b/common/lib/xmodule/xmodule/tests/test_poll.py
@@ -9,6 +9,7 @@ from .test_import import DummySystem
 
 class PollModuleTest(LogicTest):
     """Logic tests for Poll Xmodule."""
+    shard = 1
     descriptor_class = PollDescriptor
     raw_field_data = {
         'poll_answers': {'Yes': 1, 'Dont_know': 0, 'No': 0},

--- a/common/lib/xmodule/xmodule/tests/test_progress.py
+++ b/common/lib/xmodule/xmodule/tests/test_progress.py
@@ -15,6 +15,7 @@ class ProgressTest(unittest.TestCase):
     ''' Test that basic Progress objects work.  A Progress represents a
     fraction between 0 and 1.
     '''
+    shard = 1
     not_started = Progress(0, 17)
     part_done = Progress(2, 6)
     half_done = Progress(3, 6)
@@ -117,6 +118,8 @@ class ProgressTest(unittest.TestCase):
 class ModuleProgressTest(unittest.TestCase):
     ''' Test that get_progress() does the right thing for the different modules
     '''
+    shard = 1
+
     def test_xmodule_default(self):
         '''Make sure default get_progress exists, returns None'''
         xmod = x_module.XModule(Mock(), get_test_system(), DictFieldData({'location': 'a://b/c/d/e'}), Mock())

--- a/common/lib/xmodule/xmodule/tests/test_randomize_module.py
+++ b/common/lib/xmodule/xmodule/tests/test_randomize_module.py
@@ -23,6 +23,7 @@ _NEXT_WEEK = _TODAY + timedelta(days=7)
 
 class RandomizeModuleTestCase(unittest.TestCase):
     """Make sure the randomize module works"""
+    shard = 1
 
     def setUp(self):
         """

--- a/common/lib/xmodule/xmodule/tests/test_resource_templates.py
+++ b/common/lib/xmodule/xmodule/tests/test_resource_templates.py
@@ -10,6 +10,8 @@ class ResourceTemplatesTests(unittest.TestCase):
     """
     Tests for xmodule.x_module.ResourceTemplates
     """
+    shard = 1
+
     def test_templates(self):
         expected = set([
             'latex_html.yaml',

--- a/common/lib/xmodule/xmodule/tests/test_sequence.py
+++ b/common/lib/xmodule/xmodule/tests/test_sequence.py
@@ -24,6 +24,8 @@ class SequenceBlockTestCase(XModuleXmlImportTest):
     """
     Base class for tests of Sequence Module.
     """
+    shard = 1
+
     def setUp(self):
         super(SequenceBlockTestCase, self).setUp()
 

--- a/common/lib/xmodule/xmodule/tests/test_services.py
+++ b/common/lib/xmodule/xmodule/tests/test_services.py
@@ -37,6 +37,7 @@ class DummyUnexpected(object):
 @ddt.ddt
 class TestSettingsService(TestCase):
     """ Test SettingsService """
+    shard = 1
 
     xblock_setting_key1 = 'dummy_block'
     xblock_setting_key2 = 'other_dummy_block'
@@ -98,6 +99,8 @@ class TestConfigurationService(TestCase):
     """
     Tests for ConfigurationService
     """
+    shard = 1
+
     def test_given_unexpected_class_throws_value_error(self):
         """
         Test that instantiating ConfigurationService raises exception on passing

--- a/common/lib/xmodule/xmodule/tests/test_split_test_module.py
+++ b/common/lib/xmodule/xmodule/tests/test_split_test_module.py
@@ -27,6 +27,8 @@ class SplitTestUtilitiesTest(PartitionTestCase):
     """
     Tests for utility methods related to split_test module.
     """
+    shard = 1
+
     def test_split_user_partitions(self):
         """
         Tests the get_split_user_partitions helper method.
@@ -123,6 +125,7 @@ class SplitTestModuleLMSTest(SplitTestModuleTest):
     """
     Test the split test module
     """
+    shard = 1
 
     @ddt.data((0, 'split_test_cond0'), (1, 'split_test_cond1'))
     @ddt.unpack
@@ -182,6 +185,7 @@ class SplitTestModuleStudioTest(SplitTestModuleTest):
     """
     Unit tests for how split test interacts with Studio.
     """
+    shard = 1
 
     @patch('xmodule.split_test_module.SplitTestDescriptor.group_configuration_url', return_value='http://example.com')
     def test_render_author_view(self, group_configuration_url):

--- a/common/lib/xmodule/xmodule/tests/test_stringify.py
+++ b/common/lib/xmodule/xmodule/tests/test_stringify.py
@@ -7,6 +7,7 @@ from xmodule.stringify import stringify_children
 
 
 def test_stringify():
+    shard = 1
     text = 'Hi <div x="foo">there <span>Bruce</span><b>!</b></div>'
     html = '''<html a="b" foo="bar">{0}</html>'''.format(text)
     xml = etree.fromstring(html)
@@ -15,6 +16,7 @@ def test_stringify():
 
 
 def test_stringify_again():
+    shard = 1
     html = r"""<html name="Voltage Source Answer" >A voltage source is non-linear!
 <div align="center">
     <img src="/static/images/circuits/voltage-source.png"/>

--- a/common/lib/xmodule/xmodule/tests/test_studio_editable.py
+++ b/common/lib/xmodule/xmodule/tests/test_studio_editable.py
@@ -10,6 +10,8 @@ class StudioEditableModuleTestCase(BaseVerticalBlockTest):
     """
     Class containing StudioEditableModule tests.
     """
+    shard = 1
+
     def test_render_reorderable_children(self):
         """
         Test the behavior of render_reorderable_children.

--- a/common/lib/xmodule/xmodule/tests/test_textannotation.py
+++ b/common/lib/xmodule/xmodule/tests/test_textannotation.py
@@ -26,6 +26,7 @@ class TextAnnotationModuleTestCase(unittest.TestCase):
             </p>
         </annotatable>
     '''
+    shard = 1
 
     def setUp(self):
         """

--- a/common/lib/xmodule/xmodule/tests/test_util_duedate.py
+++ b/common/lib/xmodule/xmodule/tests/test_util_duedate.py
@@ -11,6 +11,7 @@ class TestGetExtendedDueDate(unittest.TestCase):
     """
     Test `get_extended_due_date` function.
     """
+    shard = 1
 
     def call_fut(self, node):
         """

--- a/common/lib/xmodule/xmodule/tests/test_utils_django.py
+++ b/common/lib/xmodule/xmodule/tests/test_utils_django.py
@@ -8,6 +8,8 @@ class UtilDjangoTests(TestCase):
     """
     Tests for methods exposed in util/django
     """
+    shard = 1
+
     def test_get_current_request(self):
         """
         Since we are running outside of Django assert that get_current_request returns None

--- a/common/lib/xmodule/xmodule/tests/test_utils_escape_html_characters.py
+++ b/common/lib/xmodule/xmodule/tests/test_utils_escape_html_characters.py
@@ -7,6 +7,7 @@ class UtilHtmlEscapeTests(TestCase):
     """
     Tests for methods exposed in util/misc
     """
+    shard = 1
 
     final_content = " This is a paragraph. "
 

--- a/common/lib/xmodule/xmodule/tests/test_validation.py
+++ b/common/lib/xmodule/xmodule/tests/test_validation.py
@@ -13,6 +13,7 @@ class StudioValidationMessageTest(unittest.TestCase):
     """
     Tests for `ValidationMessage`
     """
+    shard = 1
 
     def test_bad_parameters(self):
         """
@@ -72,6 +73,8 @@ class StudioValidationTest(unittest.TestCase):
     """
     Tests for `StudioValidation` class.
     """
+    shard = 1
+
     def test_copy(self):
         validation = Validation("id")
         validation.add(ValidationMessage(ValidationMessage.ERROR, u"Error message"))

--- a/common/lib/xmodule/xmodule/tests/test_vertical.py
+++ b/common/lib/xmodule/xmodule/tests/test_vertical.py
@@ -106,6 +106,8 @@ class VerticalBlockTestCase(BaseVerticalBlockTest):
     """
     Tests for the VerticalBlock.
     """
+    shard = 1
+
     def assert_bookmark_info_in(self, content):
         """
         Assert content has all the bookmark info.

--- a/common/lib/xmodule/xmodule/tests/test_video.py
+++ b/common/lib/xmodule/xmodule/tests/test_video.py
@@ -120,6 +120,7 @@ class _MockValCannotCreateError(Exception):
 
 class VideoModuleTest(LogicTest):
     """Logic tests for Video Xmodule."""
+    shard = 1
     descriptor_class = VideoDescriptor
 
     raw_field_data = {
@@ -201,6 +202,8 @@ class VideoDescriptorTestBase(unittest.TestCase):
     """
     Base class for tests for VideoDescriptor
     """
+    shard = 1
+
     def setUp(self):
         super(VideoDescriptorTestBase, self).setUp()
         self.descriptor = instantiate_descriptor()
@@ -225,6 +228,8 @@ class TestCreateYoutubeString(VideoDescriptorTestBase):
     """
     Checks that create_youtube_string correcty extracts information from Video descriptor.
     """
+    shard = 1
+
     def test_create_youtube_string(self):
         """
         Test that Youtube ID strings are correctly created when writing back out to XML.
@@ -251,6 +256,8 @@ class TestCreateYouTubeUrl(VideoDescriptorTestBase):
     """
     Tests for helper method `create_youtube_url`.
     """
+    shard = 1
+
     def test_create_youtube_url_unicode(self):
         """
         Test that passing unicode to `create_youtube_url` doesn't throw
@@ -264,6 +271,8 @@ class VideoDescriptorImportTestCase(TestCase):
     """
     Make sure that VideoDescriptor can import an old XML-based video correctly.
     """
+    shard = 1
+
     def assert_attributes_equal(self, video, attrs):
         """
         Assert that `video` has the correct attributes. `attrs` is a map of {metadata_field: value}.
@@ -692,6 +701,8 @@ class VideoExportTestCase(VideoDescriptorTestBase):
     """
     Make sure that VideoDescriptor can export itself to XML correctly.
     """
+    shard = 1
+
     def setUp(self):
         super(VideoExportTestCase, self).setUp()
         self.temp_dir = mkdtemp()
@@ -834,6 +845,7 @@ class VideoDescriptorStudentViewDataTestCase(unittest.TestCase):
     """
     Make sure that VideoDescriptor returns the expected student_view_data.
     """
+    shard = 1
 
     VIDEO_URL_1 = 'http://www.example.com/source_low.mp4'
     VIDEO_URL_2 = 'http://www.example.com/source_med.mp4'
@@ -977,6 +989,8 @@ class VideoDescriptorIndexingTestCase(unittest.TestCase):
     """
     Make sure that VideoDescriptor can format data for indexing as expected.
     """
+    shard = 1
+
     def test_video_with_no_subs_index_dictionary(self):
         """
         Test index dictionary of a video module without subtitles.

--- a/common/lib/xmodule/xmodule/tests/test_videoannotation.py
+++ b/common/lib/xmodule/xmodule/tests/test_videoannotation.py
@@ -20,6 +20,7 @@ class VideoAnnotationModuleTestCase(unittest.TestCase):
             <instructions><p>Video Test Instructions.</p></instructions>
         </annotatable>
     '''
+    shard = 1
     sample_sourceurl = "http://video-js.zencoder.com/oceans-clip.mp4"
     sample_youtubeurl = "http://www.youtube.com/watch?v=yxLIu-scR9Y"
 

--- a/common/lib/xmodule/xmodule/tests/test_word_cloud.py
+++ b/common/lib/xmodule/xmodule/tests/test_word_cloud.py
@@ -8,6 +8,7 @@ from . import LogicTest
 
 class WordCloudModuleTest(LogicTest):
     """Logic tests for Word Cloud Xmodule."""
+    shard = 1
     descriptor_class = WordCloudDescriptor
     raw_field_data = {
         'all_words': {'cat': 10, 'dog': 5, 'mom': 1, 'dad': 2},

--- a/common/lib/xmodule/xmodule/tests/test_xblock_wrappers.py
+++ b/common/lib/xmodule/xmodule/tests/test_xblock_wrappers.py
@@ -263,6 +263,7 @@ class XBlockWrapperTestMixin(object):
     You can create an actual test case by inheriting from this class and UnitTest,
     and implement skip_if_invalid and check_property.
     """
+    shard = 1
 
     def skip_if_invalid(self, descriptor_cls):
         """
@@ -321,6 +322,8 @@ class TestStudentView(XBlockWrapperTestMixin, TestCase):
     """
     This tests that student_view and XModule.get_html produce the same results.
     """
+    shard = 1
+
     def skip_if_invalid(self, descriptor_cls):
         pure_xblock_class = issubclass(descriptor_cls, XBlock) and not issubclass(descriptor_cls, XModuleDescriptor)
         if pure_xblock_class:
@@ -344,6 +347,8 @@ class TestStudioView(XBlockWrapperTestMixin, TestCase):
     """
     This tests that studio_view and XModuleDescriptor.get_html produce the same results
     """
+    shard = 1
+
     def skip_if_invalid(self, descriptor_cls):
         if descriptor_cls in NOT_STUDIO_EDITABLE:
             raise SkipTest(descriptor_cls.__name__ + " is not editable in studio")
@@ -368,6 +373,7 @@ class TestXModuleHandler(TestCase):
     """
     Tests that the xmodule_handler function correctly wraps handle_ajax
     """
+    shard = 1
 
     def setUp(self):
         super(TestXModuleHandler, self).setUp()
@@ -408,6 +414,8 @@ class TestXmlExport(XBlockWrapperTestMixin, TestCase):
     """
     This tests that XModuleDescriptor.export_course_to_xml and add_xml_to_node produce the same results.
     """
+    shard = 1
+
     def skip_if_invalid(self, descriptor_cls):
         if descriptor_cls.add_xml_to_node != XModuleDescriptor.add_xml_to_node:
             raise SkipTest(descriptor_cls.__name__ + " implements add_xml_to_node")

--- a/common/lib/xmodule/xmodule/tests/test_xml_module.py
+++ b/common/lib/xmodule/xmodule/tests/test_xml_module.py
@@ -65,6 +65,7 @@ class InheritingFieldDataTest(unittest.TestCase):
     """
     Tests of InheritingFieldData.
     """
+    shard = 1
 
     class TestableInheritingXBlock(XmlDescriptor):
         """
@@ -228,6 +229,8 @@ class InheritingFieldDataTest(unittest.TestCase):
 
 
 class EditableMetadataFieldsTest(unittest.TestCase):
+    shard = 1
+
     def test_display_name_field(self):
         editable_fields = self.get_xml_editable_fields(DictFieldData({}))
         # Tests that the xblock fields (currently tags and name) get filtered out.
@@ -370,6 +373,8 @@ class EditableMetadataFieldsTest(unittest.TestCase):
 
 class TestSerialize(unittest.TestCase):
     """ Tests the serialize, method, which is not dependent on type. """
+    shard = 1
+
     def test_serialize(self):
         assert_equals('null', serialize_field(None))
         assert_equals('-2', serialize_field(-2))
@@ -389,6 +394,8 @@ class TestSerialize(unittest.TestCase):
 
 
 class TestDeserialize(unittest.TestCase):
+    shard = 1
+
     def assertDeserializeEqual(self, expected, arg):
         """
         Asserts the result of deserialize_field.
@@ -412,6 +419,7 @@ class TestDeserialize(unittest.TestCase):
 class TestDeserializeInteger(TestDeserialize):
     """ Tests deserialize as related to Integer type. """
 
+    shard = 1
     field_type = Integer
 
     def test_deserialize(self):
@@ -436,6 +444,7 @@ class TestDeserializeInteger(TestDeserialize):
 
 class TestDeserializeFloat(TestDeserialize):
     """ Tests deserialize as related to Float type. """
+    shard = 1
 
     field_type = Float
 
@@ -459,6 +468,7 @@ class TestDeserializeFloat(TestDeserialize):
 
 class TestDeserializeBoolean(TestDeserialize):
     """ Tests deserialize as related to Boolean type. """
+    shard = 1
 
     field_type = Boolean
 
@@ -484,6 +494,7 @@ class TestDeserializeBoolean(TestDeserialize):
 
 class TestDeserializeString(TestDeserialize):
     """ Tests deserialize as related to String type. """
+    shard = 1
 
     field_type = String
 
@@ -502,6 +513,7 @@ class TestDeserializeString(TestDeserialize):
 
 class TestDeserializeAny(TestDeserialize):
     """ Tests deserialize as related to Any type. """
+    shard = 1
 
     field_type = Any
 
@@ -518,6 +530,7 @@ class TestDeserializeAny(TestDeserialize):
 
 class TestDeserializeList(TestDeserialize):
     """ Tests deserialize as related to List type. """
+    shard = 1
 
     field_type = List
 
@@ -535,6 +548,7 @@ class TestDeserializeList(TestDeserialize):
 
 class TestDeserializeDate(TestDeserialize):
     """ Tests deserialize as related to Date type. """
+    shard = 1
 
     field_type = Date
 
@@ -546,6 +560,7 @@ class TestDeserializeDate(TestDeserialize):
 
 class TestDeserializeTimedelta(TestDeserialize):
     """ Tests deserialize as related to Timedelta type. """
+    shard = 1
 
     field_type = Timedelta
 
@@ -563,6 +578,7 @@ class TestDeserializeTimedelta(TestDeserialize):
 
 class TestDeserializeRelativeTime(TestDeserialize):
     """ Tests deserialize as related to Timedelta type. """
+    shard = 1
 
     field_type = RelativeTime
 
@@ -584,6 +600,7 @@ class TestDeserializeRelativeTime(TestDeserialize):
 
 
 class TestXmlAttributes(XModuleXmlImportTest):
+    shard = 1
 
     def test_unknown_attribute(self):
         assert_false(hasattr(CourseDescriptor, 'unknown_attr'))

--- a/common/lib/xmodule/xmodule/tests/xml/test_inheritance.py
+++ b/common/lib/xmodule/xmodule/tests/xml/test_inheritance.py
@@ -12,6 +12,8 @@ class TestInheritedFieldParsing(XModuleXmlImportTest):
     Test that inherited fields work correctly when parsing XML
 
     """
+    shard = 2
+
     def test_null_string(self):
         # Test that the string inherited fields are passed through 'deserialize_field',
         # which converts the string "null" to the python value None

--- a/common/lib/xmodule/xmodule/tests/xml/test_policy.py
+++ b/common/lib/xmodule/xmodule/tests/xml/test_policy.py
@@ -12,6 +12,8 @@ class TestPolicy(XModuleXmlImportTest):
     """
     Tests that policy json files import correctly when loading xml
     """
+    shard = 2
+
     def test_no_attribute_mapping(self):
         # Policy files are json, and thus the values aren't passed through 'deserialize_field'
         # Therefor, the string 'null' is passed unchanged to the Float field, which will trigger

--- a/lms/djangoapps/badges/backends/tests/test_badgr_backend.py
+++ b/lms/djangoapps/badges/backends/tests/test_badgr_backend.py
@@ -35,6 +35,8 @@ class BadgrBackendTestCase(ModuleStoreTestCase, EventTrackingTestCase):
     """
     Tests the BadgeHandler object
     """
+    shard = 4
+
     def setUp(self):
         """
         Create a course and user to test with.

--- a/lms/djangoapps/badges/events/tests/test_course_complete.py
+++ b/lms/djangoapps/badges/events/tests/test_course_complete.py
@@ -13,6 +13,8 @@ class CourseCompleteTestCase(ModuleStoreTestCase):
     """
     Tests for the course completion helper functions.
     """
+    shard = 4
+
     def setUp(self, **kwargs):
         super(CourseCompleteTestCase, self).setUp()
         # Need key to be deterministic to test slugs.

--- a/lms/djangoapps/badges/events/tests/test_course_meta.py
+++ b/lms/djangoapps/badges/events/tests/test_course_meta.py
@@ -21,6 +21,8 @@ class CourseEnrollmentBadgeTest(ModuleStoreTestCase):
     """
     Tests the event which awards badges based on number of courses a user is enrolled in.
     """
+    shard = 4
+
     def setUp(self):
         super(CourseEnrollmentBadgeTest, self).setUp()
         self.badge_classes = [
@@ -72,6 +74,8 @@ class CourseCompletionBadgeTest(ModuleStoreTestCase):
     """
     Tests the event which awards badges based on the number of courses completed.
     """
+    shard = 4
+
     def setUp(self, **kwargs):
         super(CourseCompletionBadgeTest, self).setUp()
         self.badge_classes = [
@@ -130,6 +134,8 @@ class CourseGroupBadgeTest(ModuleStoreTestCase):
     """
     Tests the event which awards badges when a user completes a set of courses.
     """
+    shard = 4
+
     def setUp(self):
         super(CourseGroupBadgeTest, self).setUp()
         self.badge_classes = [

--- a/lms/djangoapps/branding/tests/test_api.py
+++ b/lms/djangoapps/branding/tests/test_api.py
@@ -14,6 +14,7 @@ from edxmako.shortcuts import marketing_link
 
 class TestHeader(TestCase):
     """Test API end-point for retrieving the header. """
+    shard = 4
 
     def test_cdn_urls_for_logo(self):
         # Ordinarily, we'd use `override_settings()` to override STATIC_URL,
@@ -41,6 +42,7 @@ class TestHeader(TestCase):
 
 
 class TestFooter(TestCase):
+    shard = 4
     maxDiff = None
     """Test retrieving the footer. """
     @mock.patch.dict('django.conf.settings.FEATURES', {'ENABLE_MKTG_SITE': True})

--- a/lms/djangoapps/branding/tests/test_views.py
+++ b/lms/djangoapps/branding/tests/test_views.py
@@ -22,6 +22,7 @@ from student.tests.factories import UserFactory
 @ddt.ddt
 class TestFooter(TestCase):
     """Test API end-point for retrieving the footer. """
+    shard = 4
 
     def setUp(self):
         """Clear the configuration cache. """
@@ -283,6 +284,7 @@ class TestFooter(TestCase):
 
 class TestIndex(SiteMixin, TestCase):
     """ Test the index view """
+    shard = 4
 
     def setUp(self):
         """ Set up a user """

--- a/lms/djangoapps/bulk_email/tests/test_tasks.py
+++ b/lms/djangoapps/bulk_email/tests/test_tasks.py
@@ -73,7 +73,7 @@ def my_update_subtask_status(entry_id, current_task_id, new_subtask_status):
         update_subtask_status(entry_id, current_task_id, new_subtask_status)
 
 
-@attr(shard=3)
+@attr(shard=5)
 @patch('bulk_email.models.html_to_text', Mock(return_value='Mocking CourseEmail.text_message', autospec=True))
 class TestBulkEmailInstructorTask(InstructorTaskCourseTestCase):
     """Tests instructor task that send bulk email."""

--- a/lms/djangoapps/bulk_enroll/tests/test_views.py
+++ b/lms/djangoapps/bulk_enroll/tests/test_views.py
@@ -31,6 +31,7 @@ class BulkEnrollmentTest(ModuleStoreTestCase, LoginEnrollmentTestCase, APITestCa
     """
     Test the bulk enrollment endpoint
     """
+    shard = 4
 
     USERNAME = "Bob"
     EMAIL = "bob@example.com"

--- a/lms/djangoapps/ccx/api/v0/tests/test_views.py
+++ b/lms/djangoapps/ccx/api/v0/tests/test_views.py
@@ -161,7 +161,7 @@ class CcxRestApiTest(CcxTestCase, APITestCase):
         self.assertEqual(expected_field_errors, resp_dict_error)
 
 
-@attr(shard=1)
+@attr(shard=9)
 @ddt.ddt
 class CcxListTest(CcxRestApiTest):
     """
@@ -872,7 +872,7 @@ class CcxListTest(CcxRestApiTest):
             self.assertEqual(course_user, ccx_user)
 
 
-@attr(shard=1)
+@attr(shard=9)
 @ddt.ddt
 class CcxDetailTest(CcxRestApiTest):
     """

--- a/lms/djangoapps/ccx/tests/test_ccx_modulestore.py
+++ b/lms/djangoapps/ccx/tests/test_ccx_modulestore.py
@@ -17,6 +17,7 @@ from xmodule.modulestore.tests.factories import CourseFactory, ItemFactory
 class TestCCXModulestoreWrapper(SharedModuleStoreTestCase):
     """tests for a modulestore wrapped by CCXModulestoreWrapper
     """
+    shard = 7
     MODULESTORE = TEST_DATA_SPLIT_MODULESTORE
 
     @classmethod

--- a/lms/djangoapps/ccx/tests/test_field_override_performance.py
+++ b/lms/djangoapps/ccx/tests/test_field_override_performance.py
@@ -37,7 +37,7 @@ from xmodule.modulestore.tests.utils import ProceduralCourseTestMixin
 QUERY_COUNT_TABLE_BLACKLIST = WAFFLE_TABLES
 
 
-@attr(shard=3)
+@attr(shard=7)
 @mock.patch.dict(
     'django.conf.settings.FEATURES',
     {

--- a/lms/djangoapps/ccx/tests/test_models.py
+++ b/lms/djangoapps/ccx/tests/test_models.py
@@ -18,7 +18,7 @@ from .factories import CcxFactory
 
 
 @ddt.ddt
-@attr(shard=1)
+@attr(shard=7)
 class TestCCX(ModuleStoreTestCase):
     """Unit tests for the CustomCourseForEdX model
     """

--- a/lms/djangoapps/ccx/tests/test_overrides.py
+++ b/lms/djangoapps/ccx/tests/test_overrides.py
@@ -23,7 +23,7 @@ from xmodule.modulestore.tests.django_utils import TEST_DATA_SPLIT_MODULESTORE, 
 from xmodule.modulestore.tests.factories import CourseFactory, ItemFactory
 
 
-@attr(shard=1)
+@attr(shard=7)
 @override_settings(
     XBLOCK_FIELD_DATA_WRAPPERS=['lms.djangoapps.courseware.field_overrides:OverrideModulestoreFieldData.wrap'],
     MODULESTORE_FIELD_OVERRIDE_PROVIDERS=['ccx.overrides.CustomCoursesForEdxOverrideProvider'],

--- a/lms/djangoapps/ccx/tests/test_tasks.py
+++ b/lms/djangoapps/ccx/tests/test_tasks.py
@@ -29,6 +29,7 @@ class TestSendCCXCoursePublished(ModuleStoreTestCase):
     """
     Unit tests for the send ccx course published task
     """
+    shard = 7
     MODULESTORE = TEST_DATA_SPLIT_MODULESTORE
 
     ENABLED_SIGNALS = ['course_published']

--- a/lms/djangoapps/ccx/tests/test_utils.py
+++ b/lms/djangoapps/ccx/tests/test_utils.py
@@ -22,7 +22,7 @@ from xmodule.modulestore.tests.django_utils import TEST_DATA_SPLIT_MODULESTORE, 
 from xmodule.modulestore.tests.factories import CourseFactory
 
 
-@attr(shard=1)
+@attr(shard=7)
 class TestGetCCXFromCCXLocator(ModuleStoreTestCase):
     """Verify that get_ccx_from_ccx_locator functions properly"""
     MODULESTORE = TEST_DATA_SPLIT_MODULESTORE

--- a/lms/djangoapps/ccx/tests/test_views.py
+++ b/lms/djangoapps/ccx/tests/test_views.py
@@ -167,7 +167,7 @@ class TestAdminAccessCoachDashboard(CcxTestCase, LoginEnrollmentTestCase):
         self.assertEqual(response.status_code, 403)
 
 
-@attr(shard=1)
+@attr(shard=7)
 @override_settings(
     XBLOCK_FIELD_DATA_WRAPPERS=['lms.djangoapps.courseware.field_overrides:OverrideModulestoreFieldData.wrap'],
     MODULESTORE_FIELD_OVERRIDE_PROVIDERS=['ccx.overrides.CustomCoursesForEdxOverrideProvider'],
@@ -282,7 +282,7 @@ class TestCCXProgressChanges(CcxTestCase, LoginEnrollmentTestCase):
         self.assert_progress_summary(ccx_course_key, due)
 
 
-@attr(shard=1)
+@attr(shard=7)
 @ddt.ddt
 class TestCoachDashboard(CcxTestCase, LoginEnrollmentTestCase):
     """
@@ -828,7 +828,7 @@ class TestCoachDashboard(CcxTestCase, LoginEnrollmentTestCase):
         )
 
 
-@attr(shard=1)
+@attr(shard=7)
 class TestCoachDashboardSchedule(CcxTestCase, LoginEnrollmentTestCase, ModuleStoreTestCase):
     """
     Tests of the CCX Coach Dashboard which need to modify the course content.
@@ -970,7 +970,7 @@ def patched_get_children(self, usage_key_filter=None):
     return list(iter_children())
 
 
-@attr(shard=1)
+@attr(shard=7)
 @override_settings(
     XBLOCK_FIELD_DATA_WRAPPERS=['lms.djangoapps.courseware.field_overrides:OverrideModulestoreFieldData.wrap'],
     MODULESTORE_FIELD_OVERRIDE_PROVIDERS=['ccx.overrides.CustomCoursesForEdxOverrideProvider'],

--- a/lms/djangoapps/certificates/apis/v0/tests/test_views.py
+++ b/lms/djangoapps/certificates/apis/v0/tests/test_views.py
@@ -24,6 +24,7 @@ class CertificatesRestApiTest(SharedModuleStoreTestCase, APITestCase):
     """
     Test for the Certificates REST APIs
     """
+    shard = 4
     now = timezone.now()
 
     @classmethod

--- a/lms/djangoapps/certificates/tests/test_services.py
+++ b/lms/djangoapps/certificates/tests/test_services.py
@@ -13,6 +13,8 @@ class CertificateServiceTests(ModuleStoreTestCase):
     """
     Tests for the Certificate service
     """
+    shard = 4
+
     def setUp(self):
         super(CertificateServiceTests, self).setUp()
         self.service = CertificateService()

--- a/lms/djangoapps/certificates/tests/test_signals.py
+++ b/lms/djangoapps/certificates/tests/test_signals.py
@@ -26,6 +26,7 @@ class SelfGeneratedCertsSignalTest(ModuleStoreTestCase):
     """
     Tests for enabling/disabling self-generated certificates according to course-pacing.
     """
+    shard = 4
     ENABLED_SIGNALS = ['course_published']
 
     def setUp(self):
@@ -53,6 +54,8 @@ class WhitelistGeneratedCertificatesTest(ModuleStoreTestCase):
     """
     Tests for whitelisted student auto-certificate generation
     """
+    shard = 4
+
     def setUp(self):
         super(WhitelistGeneratedCertificatesTest, self).setUp()
         self.course = CourseFactory.create(self_paced=True)
@@ -132,6 +135,8 @@ class PassingGradeCertsTest(ModuleStoreTestCase):
     """
     Tests for certificate generation task firing on passing grade receipt
     """
+    shard = 4
+
     def setUp(self):
         super(PassingGradeCertsTest, self).setUp()
         self.course = CourseFactory.create(
@@ -221,6 +226,8 @@ class LearnerTrackChangeCertsTest(ModuleStoreTestCase):
     """
     Tests for certificate generation task firing on learner verification
     """
+    shard = 4
+
     def setUp(self):
         super(LearnerTrackChangeCertsTest, self).setUp()
         self.course_one = CourseFactory.create(self_paced=True)
@@ -302,6 +309,7 @@ class CertificateGenerationTaskTest(ModuleStoreTestCase):
     """
     Tests for certificate generation task.
     """
+    shard = 4
 
     def setUp(self):
         super(CertificateGenerationTaskTest, self).setUp()

--- a/lms/djangoapps/certificates/tests/test_support_views.py
+++ b/lms/djangoapps/certificates/tests/test_support_views.py
@@ -26,6 +26,7 @@ class CertificateSupportTestCase(ModuleStoreTestCase):
     """
     Base class for tests of the certificate support views.
     """
+    shard = 4
 
     SUPPORT_USERNAME = "support"
     SUPPORT_EMAIL = "support@example.com"
@@ -91,6 +92,8 @@ class CertificateSearchTests(CertificateSupportTestCase):
     """
     Tests for the certificate search end-point used by the support team.
     """
+    shard = 4
+
     def setUp(self):
         """
         Create a course
@@ -226,6 +229,7 @@ class CertificateRegenerateTests(CertificateSupportTestCase):
     """
     Tests for the certificate regeneration end-point used by the support team.
     """
+    shard = 4
 
     def setUp(self):
         """
@@ -408,6 +412,7 @@ class CertificateGenerateTests(CertificateSupportTestCase):
     """
     Tests for the certificate generation end-point used by the support team.
     """
+    shard = 4
 
     def setUp(self):
         """

--- a/lms/djangoapps/certificates/tests/test_tasks.py
+++ b/lms/djangoapps/certificates/tests/test_tasks.py
@@ -9,6 +9,8 @@ from student.tests.factories import UserFactory
 
 @ddt.ddt
 class GenerateUserCertificateTest(TestCase):
+    shard = 4
+
     @patch('lms.djangoapps.certificates.tasks.generate_user_certificates')
     @patch('lms.djangoapps.certificates.tasks.User.objects.get')
     def test_generate_user_certs(self, user_get_mock, generate_user_certs_mock):

--- a/lms/djangoapps/class_dashboard/tests/test_dashboard_data.py
+++ b/lms/djangoapps/class_dashboard/tests/test_dashboard_data.py
@@ -32,7 +32,7 @@ from xmodule.modulestore.tests.factories import CourseFactory, ItemFactory
 USER_COUNT = 11
 
 
-@attr(shard=1)
+@attr(shard=6)
 class TestGetProblemGradeDistribution(SharedModuleStoreTestCase):
     """
     Tests related to class_dashboard/dashboard_data.py

--- a/lms/djangoapps/commerce/api/v1/tests/test_models.py
+++ b/lms/djangoapps/commerce/api/v1/tests/test_models.py
@@ -10,6 +10,8 @@ from ..models import Course
 @ddt.ddt
 class CourseTests(TestCase):
     """ Tests for Course model. """
+    shard = 4
+
     def setUp(self):
         super(CourseTests, self).setUp()
         self.course = Course('a/b/c', [])

--- a/lms/djangoapps/commerce/api/v1/tests/test_serializers.py
+++ b/lms/djangoapps/commerce/api/v1/tests/test_serializers.py
@@ -6,6 +6,7 @@ from ..serializers import serializers, validate_course_id
 
 class CourseValidatorTests(TestCase):
     """ Tests for Course Validator method. """
+    shard = 4
 
     def test_validate_course_id_with_non_existent_course(self):
         """ Verify a validator checking non-existent courses."""

--- a/lms/djangoapps/commerce/management/commands/tests/test_configure_commerce.py
+++ b/lms/djangoapps/commerce/management/commands/tests/test_configure_commerce.py
@@ -11,6 +11,8 @@ class TestCommerceConfigurationCommand(TestCase):
     """
     Test django management command for enabling commerce configuration.
     """
+    shard = 4
+
     def test_commerce_configuration(self):
         """
         Test that commerce configuration is created properly.

--- a/lms/djangoapps/commerce/tests/test_signals.py
+++ b/lms/djangoapps/commerce/tests/test_signals.py
@@ -37,6 +37,7 @@ class TestRefundSignal(TestCase):
     """
     Exercises logic triggered by the REFUND_ORDER signal.
     """
+    shard = 4
 
     def setUp(self):
         super(TestRefundSignal, self).setUp()

--- a/lms/djangoapps/commerce/tests/test_utils.py
+++ b/lms/djangoapps/commerce/tests/test_utils.py
@@ -35,6 +35,8 @@ def update_commerce_config(enabled=False, checkout_page='/test_basket/add/'):
 
 class AuditLogTests(TestCase):
     """Tests of the commerce audit logging helper."""
+    shard = 4
+
     @patch('openedx.core.lib.log_utils.log')
     def test_log_message(self, mock_log):
         """Verify that log messages are constructed correctly."""
@@ -49,6 +51,7 @@ class AuditLogTests(TestCase):
 @ddt.ddt
 class EcommerceServiceTests(TestCase):
     """Tests for the EcommerceService helper class."""
+    shard = 4
 
     def setUp(self):
         self.request_factory = RequestFactory()
@@ -145,6 +148,8 @@ class EcommerceServiceTests(TestCase):
 
 @unittest.skipUnless(settings.ROOT_URLCONF == 'lms.urls', 'Test only valid in lms')
 class RefundUtilMethodTests(ModuleStoreTestCase):
+    shard = 4
+
     def setUp(self):
         super(RefundUtilMethodTests, self).setUp()
         self.user = UserFactory()

--- a/lms/djangoapps/course_api/blocks/tests/test_api.py
+++ b/lms/djangoapps/course_api/blocks/tests/test_api.py
@@ -26,6 +26,8 @@ class TestGetBlocks(SharedModuleStoreTestCase):
     """
     Tests for the get_blocks function
     """
+    shard = 4
+
     @classmethod
     def setUpClass(cls):
         super(TestGetBlocks, cls).setUpClass()
@@ -113,6 +115,8 @@ class TestGetBlocksQueryCountsBase(SharedModuleStoreTestCase):
     """
     Base for the get_blocks tests.
     """
+    shard = 4
+
     ENABLED_SIGNALS = ['course_published']
 
     def setUp(self):
@@ -144,6 +148,8 @@ class TestGetBlocksQueryCounts(TestGetBlocksQueryCountsBase):
     """
     Tests query counts for the get_blocks function.
     """
+    shard = 4
+
     @ddt.data(
         *product(
             (ModuleStoreEnum.Type.mongo, ModuleStoreEnum.Type.split),
@@ -197,6 +203,8 @@ class TestQueryCountsWithIndividualOverrideProvider(TestGetBlocksQueryCountsBase
     """
     Tests query counts for the get_blocks function when IndividualStudentOverrideProvider is set.
     """
+    shard = 4
+
     @ddt.data(
         *product(
             (ModuleStoreEnum.Type.mongo, ModuleStoreEnum.Type.split),

--- a/lms/djangoapps/course_api/blocks/tests/test_forms.py
+++ b/lms/djangoapps/course_api/blocks/tests/test_forms.py
@@ -22,6 +22,8 @@ class TestBlockListGetForm(FormTestMixin, SharedModuleStoreTestCase):
     """
     Tests for BlockListGetForm
     """
+    shard = 4
+
     FORM_CLASS = BlockListGetForm
 
     @classmethod

--- a/lms/djangoapps/course_api/blocks/tests/test_serializers.py
+++ b/lms/djangoapps/course_api/blocks/tests/test_serializers.py
@@ -20,6 +20,8 @@ class TestBlockSerializerBase(SharedModuleStoreTestCase):
     """
     Base class for testing BlockSerializer and BlockDictSerializer
     """
+    shard = 4
+
     @classmethod
     def setUpClass(cls):
         super(TestBlockSerializerBase, cls).setUpClass()
@@ -151,6 +153,7 @@ class TestBlockSerializer(TestBlockSerializerBase):
     """
     Tests the BlockSerializer class, which returns a list of blocks.
     """
+    shard = 4
 
     def create_serializer(self, context=None):
         """
@@ -192,6 +195,7 @@ class TestBlockDictSerializer(TestBlockSerializerBase):
     """
     Tests the BlockDictSerializer class, which returns a dict of blocks key-ed by its block_key.
     """
+    shard = 4
 
     def create_serializer(self, context=None):
         """

--- a/lms/djangoapps/course_api/blocks/tests/test_views.py
+++ b/lms/djangoapps/course_api/blocks/tests/test_views.py
@@ -21,6 +21,7 @@ class TestBlocksView(SharedModuleStoreTestCase):
     """
     Test class for BlocksView
     """
+    shard = 4
     requested_fields = ['graded', 'format', 'student_view_multi_device', 'children', 'not_a_field', 'due']
     BLOCK_TYPES_WITH_STUDENT_VIEW_DATA = ['video', 'discussion', 'html']
 
@@ -250,6 +251,8 @@ class TestBlocksInCourseView(TestBlocksView):  # pylint: disable=test-inherits-t
     """
     Test class for BlocksInCourseView
     """
+    shard = 4
+
     def setUp(self):
         super(TestBlocksInCourseView, self).setUp()
         self.url = reverse('blocks_in_course')

--- a/lms/djangoapps/course_api/blocks/transformers/tests/test_block_completion.py
+++ b/lms/djangoapps/course_api/blocks/transformers/tests/test_block_completion.py
@@ -41,6 +41,7 @@ class BlockCompletionTransformerTestCase(TransformerRegistryTestMixin, Completio
     """
     Tests behaviour of BlockCompletionTransformer
     """
+    shard = 4
     TRANSFORMER_CLASS_TO_TEST = BlockCompletionTransformer
     COMPLETION_TEST_VALUE = 0.4
 

--- a/lms/djangoapps/course_api/blocks/transformers/tests/test_block_counts.py
+++ b/lms/djangoapps/course_api/blocks/transformers/tests/test_block_counts.py
@@ -14,6 +14,8 @@ class TestBlockCountsTransformer(ModuleStoreTestCase):
     """
     Test behavior of BlockCountsTransformer
     """
+    shard = 4
+
     def setUp(self):
         super(TestBlockCountsTransformer, self).setUp()
         self.course_key = SampleCourseFactory.create().id

--- a/lms/djangoapps/course_api/blocks/transformers/tests/test_block_depth.py
+++ b/lms/djangoapps/course_api/blocks/transformers/tests/test_block_depth.py
@@ -19,6 +19,8 @@ class BlockDepthTransformerTestCase(TestCase, ChildrenMapTestMixin):
     """
     Test behavior of BlockDepthTransformer
     """
+    shard = 4
+
     @ddt.data(
         (0, [], [], []),
         (0, ChildrenMapTestMixin.SIMPLE_CHILDREN_MAP, [[], [], [], [], []], [1, 2, 3, 4]),

--- a/lms/djangoapps/course_api/blocks/transformers/tests/test_navigation.py
+++ b/lms/djangoapps/course_api/blocks/transformers/tests/test_navigation.py
@@ -21,6 +21,7 @@ class BlockNavigationTransformerTestCase(TestCase, ChildrenMapTestMixin):
     """
     Course-agnostic test class for testing the Navigation transformer.
     """
+    shard = 4
 
     @ddt.data(
         (0, 0, [], []),
@@ -71,6 +72,7 @@ class BlockNavigationTransformerCourseTestCase(ModuleStoreTestCase):
     Uses SampleCourseFactory and Modulestore to test the Navigation transformer,
     specifically to test enforcement of the hide_from_toc field
     """
+    shard = 4
 
     def test_hide_from_toc(self):
         course_key = SampleCourseFactory.create().id

--- a/lms/djangoapps/course_api/blocks/transformers/tests/test_student_view.py
+++ b/lms/djangoapps/course_api/blocks/transformers/tests/test_student_view.py
@@ -16,6 +16,8 @@ class TestStudentViewTransformer(ModuleStoreTestCase):
     """
     Test proper behavior for StudentViewTransformer
     """
+    shard = 4
+
     def setUp(self):
         super(TestStudentViewTransformer, self).setUp()
         self.course_key = ToyCourseFactory.create().id

--- a/lms/djangoapps/course_api/tests/test_api.py
+++ b/lms/djangoapps/course_api/tests/test_api.py
@@ -22,6 +22,8 @@ class CourseApiTestMixin(CourseApiFactoryMixin):
     """
     Establish basic functionality for Course API tests
     """
+    shard = 4
+
     @classmethod
     def setUpClass(cls):
         super(CourseApiTestMixin, cls).setUpClass()
@@ -56,6 +58,8 @@ class TestGetCourseDetail(CourseDetailTestMixin, SharedModuleStoreTestCase):
     """
     Test course_detail api function
     """
+    shard = 4
+
     @classmethod
     def setUpClass(cls):
         super(TestGetCourseDetail, cls).setUpClass()
@@ -90,6 +94,8 @@ class CourseListTestMixin(CourseApiTestMixin):
     """
     Common behavior for list_courses tests
     """
+    shard = 4
+
     def _make_api_call(self, requesting_user, specified_user, org=None, filter_=None):
         """
         Call the list_courses api endpoint to get information about
@@ -112,6 +118,7 @@ class TestGetCourseList(CourseListTestMixin, SharedModuleStoreTestCase):
     """
     Test the behavior of the `list_courses` api function.
     """
+    shard = 4
     ENABLED_SIGNALS = ['course_published']
 
     @classmethod
@@ -154,6 +161,7 @@ class TestGetCourseListMultipleCourses(CourseListTestMixin, ModuleStoreTestCase)
     Test the behavior of the `list_courses` api function (with tests that
     modify the courseware).
     """
+    shard = 4
     ENABLED_SIGNALS = ['course_published']
 
     def setUp(self):
@@ -212,6 +220,7 @@ class TestGetCourseListExtras(CourseListTestMixin, ModuleStoreTestCase):
     Tests of course_list api function that require alternative configurations
     of created courses.
     """
+    shard = 4
     ENABLED_SIGNALS = ['course_published']
 
     @classmethod

--- a/lms/djangoapps/course_api/tests/test_forms.py
+++ b/lms/djangoapps/course_api/tests/test_forms.py
@@ -21,6 +21,8 @@ class UsernameTestMixin(object):
     """
     Tests the username Form field.
     """
+    shard = 4
+
     def test_no_user_param_anonymous_access(self):
         self.set_up_data(AnonymousUser())
         self.form_data.pop('username')
@@ -37,6 +39,7 @@ class TestCourseListGetForm(FormTestMixin, UsernameTestMixin, SharedModuleStoreT
     """
     Tests for CourseListGetForm
     """
+    shard = 4
     FORM_CLASS = CourseListGetForm
 
     @classmethod
@@ -102,6 +105,7 @@ class TestCourseDetailGetForm(FormTestMixin, UsernameTestMixin, SharedModuleStor
     """
     Tests for CourseDetailGetForm
     """
+    shard = 4
     FORM_CLASS = CourseDetailGetForm
 
     @classmethod

--- a/lms/djangoapps/course_api/tests/test_permissions.py
+++ b/lms/djangoapps/course_api/tests/test_permissions.py
@@ -16,6 +16,7 @@ class ViewCoursesForUsernameTestCase(CourseApiFactoryMixin, TestCase):
     Any user should be able to view their own courses, and staff users
     should be able to view anyone's courses.
     """
+    shard = 4
 
     @classmethod
     def setUpClass(cls):

--- a/lms/djangoapps/course_api/tests/test_views.py
+++ b/lms/djangoapps/course_api/tests/test_views.py
@@ -52,7 +52,7 @@ class CourseApiTestViewMixin(CourseApiFactoryMixin):
         return response
 
 
-@attr(shard=3)
+@attr(shard=9)
 class CourseListViewTestCase(CourseApiTestViewMixin, SharedModuleStoreTestCase):
     """
     Test responses returned from CourseListView.
@@ -101,6 +101,7 @@ class CourseListViewTestCase(CourseApiTestViewMixin, SharedModuleStoreTestCase):
         self.verify_response()
 
 
+@attr(shard=9)
 class CourseListViewTestCaseMultipleCourses(CourseApiTestViewMixin, ModuleStoreTestCase):
     """
     Test responses returned from CourseListView (with tests that modify the
@@ -162,6 +163,7 @@ class CourseListViewTestCaseMultipleCourses(CourseApiTestViewMixin, ModuleStoreT
             )
 
 
+@attr(shard=9)
 class CourseDetailViewTestCase(CourseApiTestViewMixin, SharedModuleStoreTestCase):
     """
     Test responses returned from CourseDetailView.
@@ -229,6 +231,7 @@ class CourseDetailViewTestCase(CourseApiTestViewMixin, SharedModuleStoreTestCase
         self.assertEquals(response.status_code, 400)
 
 
+@attr(shard=9)
 @override_settings(ELASTIC_FIELD_MAPPINGS={
     'start_date': {'type': 'date'},
     'enrollment_start': {'type': 'date'},

--- a/lms/djangoapps/course_blocks/transformers/tests/test_library_content.py
+++ b/lms/djangoapps/course_blocks/transformers/tests/test_library_content.py
@@ -26,6 +26,7 @@ class ContentLibraryTransformerTestCase(CourseStructureTestCase):
     """
     ContentLibraryTransformer Test
     """
+    shard = 4
     TRANSFORMER_CLASS_TO_TEST = ContentLibraryTransformer
 
     def setUp(self):

--- a/lms/djangoapps/course_blocks/transformers/tests/test_load_override_data.py
+++ b/lms/djangoapps/course_blocks/transformers/tests/test_load_override_data.py
@@ -30,6 +30,8 @@ class TestOverrideDataTransformer(ModuleStoreTestCase):
     """
     Test proper behavior for OverrideDataTransformer
     """
+    shard = 4
+
     @classmethod
     def setUpClass(cls):
         super(TestOverrideDataTransformer, cls).setUpClass()

--- a/lms/djangoapps/course_goals/tests/test_api.py
+++ b/lms/djangoapps/course_goals/tests/test_api.py
@@ -22,6 +22,8 @@ class TestCourseGoalsAPI(EventTrackingTestCase, SharedModuleStoreTestCase):
     """
     Testing the Course Goals API.
     """
+    shard = 4
+
     def setUp(self):
         # Create a course with a verified track
         super(TestCourseGoalsAPI, self).setUp()

--- a/lms/djangoapps/course_wiki/tests/test_tab.py
+++ b/lms/djangoapps/course_wiki/tests/test_tab.py
@@ -13,6 +13,7 @@ from xmodule.modulestore.tests.factories import CourseFactory
 
 class WikiTabTestCase(ModuleStoreTestCase):
     """Test cases for Wiki Tab."""
+    shard = 4
 
     def setUp(self):
         super(WikiTabTestCase, self).setUp()

--- a/lms/djangoapps/courseware/tests/test_access.py
+++ b/lms/djangoapps/courseware/tests/test_access.py
@@ -729,7 +729,7 @@ class UserRoleTestCase(TestCase):
         )
 
 
-@attr(shard=3)
+@attr(shard=5)
 @ddt.ddt
 class CourseOverviewAccessTestCase(ModuleStoreTestCase):
     """

--- a/lms/djangoapps/courseware/tests/test_comprehensive_theming.py
+++ b/lms/djangoapps/courseware/tests/test_comprehensive_theming.py
@@ -12,6 +12,7 @@ from openedx.core.lib.tempdir import create_symlink, delete_symlink, mkdtemp_cle
 
 class TestComprehensiveTheming(TestCase):
     """Test comprehensive theming."""
+    shard = 4
 
     def setUp(self):
         super(TestComprehensiveTheming, self).setUp()

--- a/lms/djangoapps/courseware/tests/test_context_processor.py
+++ b/lms/djangoapps/courseware/tests/test_context_processor.py
@@ -14,6 +14,8 @@ class UserPrefContextProcessorUnitTest(ModuleStoreTestCase):
     """
     Unit test for courseware context_processor
     """
+    shard = 4
+
     def setUp(self):
         super(UserPrefContextProcessorUnitTest, self).setUp()
 

--- a/lms/djangoapps/courseware/tests/test_credit_requirements.py
+++ b/lms/djangoapps/courseware/tests/test_credit_requirements.py
@@ -21,6 +21,7 @@ class ProgressPageCreditRequirementsTest(SharedModuleStoreTestCase):
     """
     Tests for credit requirement display on the progress page.
     """
+    shard = 4
 
     USERNAME = "bob"
     PASSWORD = "test"

--- a/lms/djangoapps/courseware/tests/test_discussion_xblock.py
+++ b/lms/djangoapps/courseware/tests/test_discussion_xblock.py
@@ -31,6 +31,7 @@ class TestDiscussionXBlock(XModuleRenderingTestBase):
     Base class for tests
     """
 
+    shard = 4
     PATCH_DJANGO_USER = True
 
     def setUp(self):
@@ -84,6 +85,7 @@ class TestGetDjangoUser(TestDiscussionXBlock):
     Tests for the django_user property.
     """
 
+    shard = 4
     PATCH_DJANGO_USER = False
 
     def setUp(self):
@@ -121,6 +123,7 @@ class TestViews(TestDiscussionXBlock):
     """
     Tests for student_view and author_view.
     """
+    shard = 4
 
     def setUp(self):
         """
@@ -207,6 +210,7 @@ class TestTemplates(TestDiscussionXBlock):
     """
     Tests rendering of templates.
     """
+    shard = 4
 
     def test_has_permission(self):
         """
@@ -252,6 +256,7 @@ class TestXBlockInCourse(SharedModuleStoreTestCase):
     """
     Test the discussion xblock as rendered in the course and course API.
     """
+    shard = 4
 
     @classmethod
     def setUpClass(cls):
@@ -375,6 +380,7 @@ class TestXBlockQueryLoad(SharedModuleStoreTestCase):
     """
     Test the number of queries executed when rendering the XBlock.
     """
+    shard = 4
 
     def test_permissions_query_load(self):
         """

--- a/lms/djangoapps/courseware/tests/test_group_access.py
+++ b/lms/djangoapps/courseware/tests/test_group_access.py
@@ -50,7 +50,7 @@ def resolve_attrs(test_method):
     return _wrapper
 
 
-@attr(shard=2)
+@attr(shard=7)
 @ddt.ddt
 class GroupAccessTestCase(ModuleStoreTestCase):
     """

--- a/lms/djangoapps/courseware/tests/test_self_paced_overrides.py
+++ b/lms/djangoapps/courseware/tests/test_self_paced_overrides.py
@@ -23,6 +23,7 @@ class SelfPacedDateOverrideTest(ModuleStoreTestCase):
     """
     Tests for self-paced due date overrides.
     """
+    shard = 4
 
     def setUp(self):
         self.reset_setting_cache_variables()

--- a/lms/djangoapps/courseware/tests/test_submitting_problems.py
+++ b/lms/djangoapps/courseware/tests/test_submitting_problems.py
@@ -335,7 +335,7 @@ class TestCourseGrades(TestSubmittingProblems):
         self._verify_grade(expected_problem_score=(0.0, 1.0), expected_hw_grade=(0.0, 1.0))
 
 
-@attr(shard=3)
+@attr(shard=9)
 @ddt.ddt
 class TestCourseGrader(TestSubmittingProblems):
     """
@@ -752,7 +752,7 @@ class TestCourseGrader(TestSubmittingProblems):
         self.assertEqual(req_status[0]["status"], 'satisfied')
 
 
-@attr(shard=1)
+@attr(shard=9)
 class ProblemWithUploadedFilesTest(TestSubmittingProblems):
     """Tests of problems with uploaded files."""
     # Tell Django to clean out all databases, not just default
@@ -807,7 +807,7 @@ class ProblemWithUploadedFilesTest(TestSubmittingProblems):
         self.assertItemsEqual(kwargs['files'].keys(), filenames.split())
 
 
-@attr(shard=1)
+@attr(shard=9)
 class TestPythonGradedResponse(TestSubmittingProblems):
     """
     Check that we can submit a schematic and custom response, and it answers properly.
@@ -1058,7 +1058,7 @@ class TestPythonGradedResponse(TestSubmittingProblems):
         self._check_ireset(name)
 
 
-@attr(shard=1)
+@attr(shard=9)
 class TestConditionalContent(TestSubmittingProblems):
     """
     Check that conditional content works correctly with grading.

--- a/lms/djangoapps/courseware/tests/test_user_state_client.py
+++ b/lms/djangoapps/courseware/tests/test_user_state_client.py
@@ -19,6 +19,7 @@ class TestDjangoUserStateClient(UserStateClientTestBase, ModuleStoreTestCase):
     Tests of the DjangoUserStateClient backend.
     It reuses all tests from :class:`~UserStateClientTestBase`.
     """
+    shard = 4
     __test__ = True
     # Tell Django to clean out all databases, not just default
     multi_db = True

--- a/lms/djangoapps/courseware/tests/test_video_mongo.py
+++ b/lms/djangoapps/courseware/tests/test_video_mongo.py
@@ -67,7 +67,7 @@ I am overwatch.
 TRANSCRIPT_FILE_SJSON_DATA = """{\n   "start": [10],\n   "end": [100],\n   "text": ["Hi, welcome to edxval."]\n}"""
 
 
-@attr(shard=1)
+@attr(shard=7)
 class TestVideoYouTube(TestVideo):
     METADATA = {}
 
@@ -132,7 +132,7 @@ class TestVideoYouTube(TestVideo):
         )
 
 
-@attr(shard=1)
+@attr(shard=7)
 class TestVideoNonYouTube(TestVideo):
     """Integration tests: web client + mongo."""
     DATA = """
@@ -214,7 +214,7 @@ class TestVideoNonYouTube(TestVideo):
         )
 
 
-@attr(shard=1)
+@attr(shard=7)
 @ddt.ddt
 class TestGetHtmlMethod(BaseTestXmodule):
     '''
@@ -990,7 +990,7 @@ class TestGetHtmlMethod(BaseTestXmodule):
         self.assertIn("\'poster\': \'null\'", context)
 
 
-@attr(shard=1)
+@attr(shard=7)
 class TestVideoCDNRewriting(BaseTestXmodule):
     """
     Tests for Video CDN.
@@ -1047,7 +1047,7 @@ class TestVideoCDNRewriting(BaseTestXmodule):
         self.assertIsNone(rewrite_video_url("", ""))
 
 
-@attr(shard=1)
+@attr(shard=7)
 @ddt.ddt
 class TestVideoDescriptorInitialization(BaseTestXmodule):
     """
@@ -1206,7 +1206,7 @@ class TestVideoDescriptorInitialization(BaseTestXmodule):
         self.assertEqual(context['transcripts_basic_tab_metadata']['video_url']['value'], video_url)
 
 
-@attr(shard=1)
+@attr(shard=7)
 @ddt.ddt
 class TestEditorSavedMethod(BaseTestXmodule):
     """
@@ -1523,7 +1523,7 @@ class TestVideoDescriptorStudentViewJson(TestCase):
         self.assertDictEqual(student_view_response['transcripts'], {self.TEST_LANGUAGE: self.transcript_url})
 
 
-@attr(shard=1)
+@attr(shard=7)
 @ddt.ddt
 class VideoDescriptorTest(TestCase, VideoDescriptorTestBase):
     """

--- a/lms/djangoapps/courseware/tests/test_views.py
+++ b/lms/djangoapps/courseware/tests/test_views.py
@@ -82,7 +82,7 @@ from xmodule.modulestore.tests.factories import CourseFactory, ItemFactory, chec
 QUERY_COUNT_TABLE_BLACKLIST = WAFFLE_TABLES
 
 
-@attr(shard=1)
+@attr(shard=5)
 class TestJumpTo(ModuleStoreTestCase):
     """
     Check the jumpto link for a course.
@@ -193,7 +193,7 @@ class TestJumpTo(ModuleStoreTestCase):
         self.assertEqual(response.status_code, 404)
 
 
-@attr(shard=2)
+@attr(shard=5)
 @ddt.ddt
 class IndexQueryTestCase(ModuleStoreTestCase):
     """
@@ -235,7 +235,7 @@ class IndexQueryTestCase(ModuleStoreTestCase):
                 self.assertEqual(response.status_code, 200)
 
 
-@attr(shard=2)
+@attr(shard=5)
 @ddt.ddt
 class ViewsTestCase(ModuleStoreTestCase):
     """
@@ -950,7 +950,7 @@ class ViewsTestCase(ModuleStoreTestCase):
             self.assertContains(response, test)
 
 
-@attr(shard=2)
+@attr(shard=5)
 # Patching 'lms.djangoapps.courseware.views.views.get_programs' would be ideal,
 # but for some unknown reason that patch doesn't seem to be applied.
 @patch('openedx.core.djangoapps.catalog.utils.cache')
@@ -992,7 +992,7 @@ class TestProgramMarketingView(SharedModuleStoreTestCase):
         self.assertEqual(response.status_code, 200)
 
 
-@attr(shard=1)
+@attr(shard=5)
 # setting TIME_ZONE_DISPLAYED_FOR_DEADLINES explicitly
 @override_settings(TIME_ZONE_DISPLAYED_FOR_DEADLINES="UTC")
 class BaseDueDateTests(ModuleStoreTestCase):
@@ -1085,6 +1085,7 @@ class TestProgressDueDate(BaseDueDateTests):
 
 
 # TODO: LEARNER-71: Delete entire TestAccordionDueDate class
+@attr(shard=5)
 class TestAccordionDueDate(BaseDueDateTests):
     """
     Test that the accordion page displays due dates correctly
@@ -1124,7 +1125,7 @@ class TestAccordionDueDate(BaseDueDateTests):
         super(TestAccordionDueDate, self).test_format_none()
 
 
-@attr(shard=1)
+@attr(shard=5)
 class StartDateTests(ModuleStoreTestCase):
     """
     Test that start dates are properly localized and displayed on the student
@@ -1166,7 +1167,7 @@ class StartDateTests(ModuleStoreTestCase):
 
 
 # pylint: disable=protected-access, no-member
-@attr(shard=1)
+@attr(shard=5)
 class ProgressPageBaseTests(ModuleStoreTestCase):
     """
     Base class for progress page tests.
@@ -1224,6 +1225,7 @@ class ProgressPageBaseTests(ModuleStoreTestCase):
 
 
 # pylint: disable=protected-access, no-member
+@attr(shard=5)
 @ddt.ddt
 class ProgressPageTests(ProgressPageBaseTests):
     """
@@ -1781,6 +1783,7 @@ class ProgressPageTests(ProgressPageBaseTests):
 
 
 # pylint: disable=protected-access, no-member
+@attr(shard=5)
 @ddt.ddt
 class ProgressPageShowCorrectnessTests(ProgressPageBaseTests):
     """
@@ -2059,7 +2062,7 @@ class ProgressPageShowCorrectnessTests(ProgressPageBaseTests):
         self.assert_progress_page_show_grades(resp, show_correctness, due_date, graded, show_grades, 1, 1, .5)
 
 
-@attr(shard=1)
+@attr(shard=5)
 class VerifyCourseKeyDecoratorTests(TestCase):
     """
     Tests for the ensure_valid_course_key decorator.
@@ -2085,7 +2088,7 @@ class VerifyCourseKeyDecoratorTests(TestCase):
         self.assertFalse(mocked_view.called)
 
 
-@attr(shard=1)
+@attr(shard=5)
 class GenerateUserCertTests(ModuleStoreTestCase):
     """
     Tests for the view function Generated User Certs
@@ -2249,7 +2252,7 @@ class ViewCheckerBlock(XBlock):
         return result
 
 
-@attr(shard=1)
+@attr(shard=5)
 @ddt.ddt
 class TestIndexView(ModuleStoreTestCase):
     """
@@ -2348,6 +2351,7 @@ class TestIndexView(ModuleStoreTestCase):
             assert response.status_code == 200
 
 
+@attr(shard=5)
 @ddt.ddt
 class TestIndexViewWithVerticalPositions(ModuleStoreTestCase):
     """
@@ -2414,6 +2418,7 @@ class TestIndexViewWithVerticalPositions(ModuleStoreTestCase):
         self._assert_correct_position(resp, expected_position)
 
 
+@attr(shard=5)
 class TestIndexViewWithGating(ModuleStoreTestCase, MilestonesTestCaseMixin):
     """
     Test the index view for a course with gated content
@@ -2466,6 +2471,7 @@ class TestIndexViewWithGating(ModuleStoreTestCase, MilestonesTestCaseMixin):
         self.assertIn("Content Locked", response.content)
 
 
+@attr(shard=5)
 class TestRenderXBlock(RenderXBlockTestMixin, ModuleStoreTestCase):
     """
     Tests for the courseware.render_xblock endpoint.
@@ -2508,6 +2514,7 @@ class TestRenderXBlockSelfPaced(TestRenderXBlock):
         return options
 
 
+@attr(shard=5)
 class TestIndexViewCrawlerStudentStateWrites(SharedModuleStoreTestCase):
     """
     Ensure that courseware index requests do not trigger student state writes.
@@ -2587,7 +2594,7 @@ class TestIndexViewCrawlerStudentStateWrites(SharedModuleStoreTestCase):
         self.assertEqual(response.status_code, 200)
 
 
-@attr(shard=1)
+@attr(shard=5)
 class EnterpriseConsentTestCase(EnterpriseTestConsentRequired, ModuleStoreTestCase):
     """
     Ensure that the Enterprise Data Consent redirects are in place only when consent is required.
@@ -2617,6 +2624,7 @@ class EnterpriseConsentTestCase(EnterpriseTestConsentRequired, ModuleStoreTestCa
             self.verify_consent_required(self.client, url)
 
 
+@attr(shard=5)
 @ddt.ddt
 class AccessUtilsTestCase(ModuleStoreTestCase):
     """

--- a/lms/djangoapps/discussion/tests/test_signals.py
+++ b/lms/djangoapps/discussion/tests/test_signals.py
@@ -8,6 +8,8 @@ from openedx.core.djangoapps.waffle_utils.testutils import override_waffle_flag
 
 
 class SendMessageHandlerTestCase(TestCase):
+    shard = 4
+
     def setUp(self):
         self.sender = mock.Mock()
         self.user = mock.Mock()

--- a/lms/djangoapps/discussion/tests/test_tasks.py
+++ b/lms/djangoapps/discussion/tests/test_tasks.py
@@ -69,6 +69,8 @@ def make_mock_responder(subscribed_thread_ids=None, thread_data=None, comment_da
 
 @ddt.ddt
 class TaskTestCase(ModuleStoreTestCase):
+    shard = 4
+
     @classmethod
     @mock.patch.dict("django.conf.settings.FEATURES", {"ENABLE_DISCUSSION_SERVICE": True})
     def setUpClass(cls):

--- a/lms/djangoapps/discussion/tests/test_views.py
+++ b/lms/djangoapps/discussion/tests/test_views.py
@@ -68,6 +68,7 @@ QUERY_COUNT_TABLE_BLACKLIST = WAFFLE_TABLES
 
 
 class ViewsExceptionTestCase(UrlResetMixin, ModuleStoreTestCase):
+    shard = 4
 
     @patch.dict("django.conf.settings.FEATURES", {"ENABLE_DISCUSSION_SERVICE": True})
     def setUp(self):
@@ -275,6 +276,7 @@ class PartialDictMatcher(object):
 
 @patch('requests.request', autospec=True)
 class SingleThreadTestCase(ForumsEnableMixin, ModuleStoreTestCase):
+    shard = 4
 
     CREATE_USER = False
 
@@ -393,6 +395,7 @@ class SingleThreadQueryCountTestCase(ForumsEnableMixin, ModuleStoreTestCase):
     Ensures the number of modulestore queries and number of sql queries are
     independent of the number of responses retrieved for a given discussion thread.
     """
+    shard = 4
     MODULESTORE = TEST_DATA_MONGO_MODULESTORE
 
     def setUp(self):
@@ -473,6 +476,8 @@ class SingleThreadQueryCountTestCase(ForumsEnableMixin, ModuleStoreTestCase):
 
 @patch('requests.request', autospec=True)
 class SingleCohortedThreadTestCase(CohortedTestCase):
+    shard = 4
+
     def _create_mock_cohorted_thread(self, mock_request):
         self.mock_text = "dummy content"
         self.mock_thread_id = "test_thread_id"
@@ -536,6 +541,8 @@ class SingleCohortedThreadTestCase(CohortedTestCase):
 
 @patch('lms.lib.comment_client.utils.requests.request', autospec=True)
 class SingleThreadAccessTestCase(CohortedTestCase):
+    shard = 4
+
     def call_view(self, mock_request, commentable_id, user, group_id, thread_group_id=None, pass_group_id=True):
         thread_id = "test_thread_id"
         mock_request.side_effect = make_mock_request_impl(
@@ -623,6 +630,7 @@ class SingleThreadAccessTestCase(CohortedTestCase):
 
 @patch('lms.lib.comment_client.utils.requests.request', autospec=True)
 class SingleThreadGroupIdTestCase(CohortedTestCase, GroupIdAssertionMixin):
+    shard = 4
     cs_endpoint = "/threads/dummy_thread_id"
 
     def call_view(self, mock_request, commentable_id, user, group_id, pass_group_id=True, is_ajax=False):
@@ -670,6 +678,7 @@ class SingleThreadGroupIdTestCase(CohortedTestCase, GroupIdAssertionMixin):
 
 @patch('requests.request', autospec=True)
 class SingleThreadContentGroupTestCase(ForumsEnableMixin, UrlResetMixin, ContentGroupTestCase):
+    shard = 4
 
     @patch.dict("django.conf.settings.FEATURES", {"ENABLE_DISCUSSION_SERVICE": True})
     def setUp(self):
@@ -780,6 +789,8 @@ class SingleThreadContentGroupTestCase(ForumsEnableMixin, UrlResetMixin, Content
 
 @patch('lms.lib.comment_client.utils.requests.request', autospec=True)
 class InlineDiscussionContextTestCase(ForumsEnableMixin, ModuleStoreTestCase):
+    shard = 4
+
     def setUp(self):
         super(InlineDiscussionContextTestCase, self).setUp()
         self.course = CourseFactory.create()
@@ -820,6 +831,7 @@ class InlineDiscussionGroupIdTestCase(
         CohortedTopicGroupIdTestMixin,
         NonCohortedTopicGroupIdTestMixin
 ):
+    shard = 4
     cs_endpoint = "/threads"
 
     def setUp(self):
@@ -867,6 +879,7 @@ class InlineDiscussionGroupIdTestCase(
 
 @patch('lms.lib.comment_client.utils.requests.request', autospec=True)
 class ForumFormDiscussionGroupIdTestCase(CohortedTestCase, CohortedTopicGroupIdTestMixin):
+    shard = 4
     cs_endpoint = "/threads"
 
     def call_view(self, mock_request, commentable_id, user, group_id, pass_group_id=True, is_ajax=False):
@@ -913,6 +926,7 @@ class ForumFormDiscussionGroupIdTestCase(CohortedTestCase, CohortedTopicGroupIdT
 
 @patch('lms.lib.comment_client.utils.requests.request', autospec=True)
 class UserProfileDiscussionGroupIdTestCase(CohortedTestCase, CohortedTopicGroupIdTestMixin):
+    shard = 4
     cs_endpoint = "/active_threads"
 
     def call_view_for_profiled_user(
@@ -1074,6 +1088,7 @@ class UserProfileDiscussionGroupIdTestCase(CohortedTestCase, CohortedTopicGroupI
 
 @patch('lms.lib.comment_client.utils.requests.request', autospec=True)
 class FollowedThreadsDiscussionGroupIdTestCase(CohortedTestCase, CohortedTopicGroupIdTestMixin):
+    shard = 4
     cs_endpoint = "/subscribed_threads"
 
     def call_view(self, mock_request, commentable_id, user, group_id, pass_group_id=True):
@@ -1111,6 +1126,8 @@ class FollowedThreadsDiscussionGroupIdTestCase(CohortedTestCase, CohortedTopicGr
 
 @patch('lms.lib.comment_client.utils.requests.request', autospec=True)
 class InlineDiscussionTestCase(ForumsEnableMixin, ModuleStoreTestCase):
+    shard = 4
+
     def setUp(self):
         super(InlineDiscussionTestCase, self).setUp()
 
@@ -1156,6 +1173,7 @@ class InlineDiscussionTestCase(ForumsEnableMixin, ModuleStoreTestCase):
 
 @patch('requests.request', autospec=True)
 class UserProfileTestCase(ForumsEnableMixin, UrlResetMixin, ModuleStoreTestCase):
+    shard = 4
 
     TEST_THREAD_TEXT = 'userprofile-test-text'
     TEST_THREAD_ID = 'userprofile-test-thread-id'
@@ -1285,6 +1303,7 @@ class UserProfileTestCase(ForumsEnableMixin, UrlResetMixin, ModuleStoreTestCase)
 
 @patch('requests.request', autospec=True)
 class CommentsServiceRequestHeadersTestCase(ForumsEnableMixin, UrlResetMixin, ModuleStoreTestCase):
+    shard = 4
 
     CREATE_USER = False
 
@@ -1351,6 +1370,7 @@ class CommentsServiceRequestHeadersTestCase(ForumsEnableMixin, UrlResetMixin, Mo
 
 
 class InlineDiscussionUnicodeTestCase(ForumsEnableMixin, SharedModuleStoreTestCase, UnicodeTestMixin):
+    shard = 4
 
     @classmethod
     def setUpClass(cls):
@@ -1384,6 +1404,8 @@ class InlineDiscussionUnicodeTestCase(ForumsEnableMixin, SharedModuleStoreTestCa
 
 
 class ForumFormDiscussionUnicodeTestCase(ForumsEnableMixin, SharedModuleStoreTestCase, UnicodeTestMixin):
+    shard = 4
+
     @classmethod
     def setUpClass(cls):
         # pylint: disable=super-method-not-called
@@ -1417,6 +1439,8 @@ class ForumFormDiscussionUnicodeTestCase(ForumsEnableMixin, SharedModuleStoreTes
 @ddt.ddt
 @patch('lms.lib.comment_client.utils.requests.request', autospec=True)
 class ForumDiscussionXSSTestCase(ForumsEnableMixin, UrlResetMixin, ModuleStoreTestCase):
+    shard = 4
+
     @patch.dict("django.conf.settings.FEATURES", {"ENABLE_DISCUSSION_SERVICE": True})
     def setUp(self):
         super(ForumDiscussionXSSTestCase, self).setUp()
@@ -1470,6 +1494,7 @@ class ForumDiscussionXSSTestCase(ForumsEnableMixin, UrlResetMixin, ModuleStoreTe
 
 
 class ForumDiscussionSearchUnicodeTestCase(ForumsEnableMixin, SharedModuleStoreTestCase, UnicodeTestMixin):
+    shard = 4
 
     @classmethod
     def setUpClass(cls):
@@ -1506,6 +1531,7 @@ class ForumDiscussionSearchUnicodeTestCase(ForumsEnableMixin, SharedModuleStoreT
 
 
 class SingleThreadUnicodeTestCase(ForumsEnableMixin, SharedModuleStoreTestCase, UnicodeTestMixin):
+    shard = 4
 
     @classmethod
     def setUpClass(cls):
@@ -1539,6 +1565,7 @@ class SingleThreadUnicodeTestCase(ForumsEnableMixin, SharedModuleStoreTestCase, 
 
 
 class UserProfileUnicodeTestCase(ForumsEnableMixin, SharedModuleStoreTestCase, UnicodeTestMixin):
+    shard = 4
 
     @classmethod
     def setUpClass(cls):
@@ -1571,6 +1598,7 @@ class UserProfileUnicodeTestCase(ForumsEnableMixin, SharedModuleStoreTestCase, U
 
 
 class FollowedThreadsUnicodeTestCase(ForumsEnableMixin, SharedModuleStoreTestCase, UnicodeTestMixin):
+    shard = 4
 
     @classmethod
     def setUpClass(cls):
@@ -1607,6 +1635,7 @@ class EnrollmentTestCase(ForumsEnableMixin, ModuleStoreTestCase):
     Tests for the behavior of views depending on if the student is enrolled
     in the course
     """
+    shard = 4
 
     @patch.dict("django.conf.settings.FEATURES", {"ENABLE_DISCUSSION_SERVICE": True})
     def setUp(self):
@@ -1629,6 +1658,7 @@ class EnterpriseConsentTestCase(EnterpriseTestConsentRequired, ForumsEnableMixin
     """
     Ensure that the Enterprise Data Consent redirects are in place only when consent is required.
     """
+    shard = 4
     CREATE_USER = False
 
     @patch.dict("django.conf.settings.FEATURES", {"ENABLE_DISCUSSION_SERVICE": True})
@@ -1671,6 +1701,7 @@ class EnterpriseConsentTestCase(EnterpriseTestConsentRequired, ForumsEnableMixin
 
 
 class DividedDiscussionsTestCase(CohortViewsTestCase):
+    shard = 4
 
     def create_divided_discussions(self):
         """
@@ -1711,6 +1742,7 @@ class CourseDiscussionTopicsTestCase(DividedDiscussionsTestCase):
     """
     Tests the `divide_discussion_topics` view.
     """
+    shard = 4
 
     def test_non_staff(self):
         """
@@ -1766,6 +1798,8 @@ class CourseDiscussionsHandlerTestCase(DividedDiscussionsTestCase):
     """
     Tests the course_discussion_settings_handler
     """
+    shard = 4
+
     def get_expected_response(self):
         """
         Returns the static response dict.
@@ -1924,6 +1958,7 @@ class DefaultTopicIdGetterTestCase(ModuleStoreTestCase):
     """
     Tests the `_get_discussion_default_topic_id` helper.
     """
+    shard = 4
 
     def test_no_default_topic(self):
         discussion_topics = {
@@ -1956,6 +1991,7 @@ class ThreadViewedEventTestCase(EventTestMixin, ForumsEnableMixin, UrlResetMixin
     """
     Forum thread views are expected to launch analytics events. Test these here.
     """
+    shard = 4
 
     CATEGORY_ID = 'i4x-edx-discussion-id'
     CATEGORY_NAME = 'Discussion 1'

--- a/lms/djangoapps/discussion_api/tests/test_api.py
+++ b/lms/djangoapps/discussion_api/tests/test_api.py
@@ -100,7 +100,7 @@ def _create_course_and_cohort_with_user_role(course_is_cohorted, user, role_name
     return [cohort_course, cohort]
 
 
-@attr(shard=2)
+@attr(shard=8)
 @mock.patch.dict("django.conf.settings.FEATURES", {"ENABLE_DISCUSSION_SERVICE": True})
 class GetCourseTest(ForumsEnableMixin, UrlResetMixin, SharedModuleStoreTestCase):
     """Test for get_course"""
@@ -147,7 +147,7 @@ class GetCourseTest(ForumsEnableMixin, UrlResetMixin, SharedModuleStoreTestCase)
         )
 
 
-@attr(shard=2)
+@attr(shard=8)
 @ddt.ddt
 @mock.patch.dict("django.conf.settings.FEATURES", {"ENABLE_DISCUSSION_SERVICE": True})
 class GetCourseTestBlackouts(ForumsEnableMixin, UrlResetMixin, ModuleStoreTestCase):
@@ -191,7 +191,7 @@ class GetCourseTestBlackouts(ForumsEnableMixin, UrlResetMixin, ModuleStoreTestCa
         self.assertEqual(result["blackouts"], [])
 
 
-@attr(shard=2)
+@attr(shard=8)
 @mock.patch.dict("django.conf.settings.FEATURES", {"DISABLE_START_DATES": False})
 @mock.patch.dict("django.conf.settings.FEATURES", {"ENABLE_DISCUSSION_SERVICE": True})
 class GetCourseTopicsTest(ForumsEnableMixin, UrlResetMixin, ModuleStoreTestCase):
@@ -565,7 +565,7 @@ class GetCourseTopicsTest(ForumsEnableMixin, UrlResetMixin, ModuleStoreTestCase)
         )
 
 
-@attr(shard=2)
+@attr(shard=8)
 @ddt.ddt
 @mock.patch.dict("django.conf.settings.FEATURES", {"ENABLE_DISCUSSION_SERVICE": True})
 class GetThreadListTest(ForumsEnableMixin, CommentsServiceMockMixin, UrlResetMixin, SharedModuleStoreTestCase):
@@ -983,7 +983,7 @@ class GetThreadListTest(ForumsEnableMixin, CommentsServiceMockMixin, UrlResetMix
         self.assertIn("order_direction", assertion.exception.message_dict)
 
 
-@attr(shard=2)
+@attr(shard=8)
 @ddt.ddt
 @mock.patch.dict("django.conf.settings.FEATURES", {"ENABLE_DISCUSSION_SERVICE": True})
 class GetCommentListTest(ForumsEnableMixin, CommentsServiceMockMixin, SharedModuleStoreTestCase):
@@ -1417,7 +1417,7 @@ class GetCommentListTest(ForumsEnableMixin, CommentsServiceMockMixin, SharedModu
             self.get_comment_list(thread, endorsed=True, page=2, page_size=10)
 
 
-@attr(shard=2)
+@attr(shard=8)
 @ddt.ddt
 @disable_signal(api, 'thread_created')
 @disable_signal(api, 'thread_voted')
@@ -1429,6 +1429,7 @@ class CreateThreadTest(
         SharedModuleStoreTestCase,
         MockSignalHandlerMixin
 ):
+    """Tests for create_thread"""
     LONG_TITLE = (
         'Lorem ipsum dolor sit amet, consectetuer adipiscing elit. '
         'Aenean commodo ligula eget dolor. Aenean massa. Cum sociis '
@@ -1468,7 +1469,6 @@ class CreateThreadTest(
         'nonummy metus.'
     )
 
-    """Tests for create_thread"""
     @classmethod
     def setUpClass(cls):
         super(CreateThreadTest, cls).setUpClass()
@@ -1721,7 +1721,7 @@ class CreateThreadTest(
             create_thread(self.request, data)
 
 
-@attr(shard=2)
+@attr(shard=8)
 @ddt.ddt
 @disable_signal(api, 'comment_created')
 @disable_signal(api, 'comment_voted')
@@ -1987,7 +1987,7 @@ class CreateCommentTest(
             create_comment(self.request, data)
 
 
-@attr(shard=2)
+@attr(shard=8)
 @ddt.ddt
 @disable_signal(api, 'thread_edited')
 @disable_signal(api, 'thread_voted')
@@ -2368,7 +2368,7 @@ class UpdateThreadTest(
         )
 
 
-@attr(shard=2)
+@attr(shard=8)
 @ddt.ddt
 @disable_signal(api, 'comment_edited')
 @disable_signal(api, 'comment_voted')
@@ -2771,7 +2771,7 @@ class UpdateCommentTest(
             )
 
 
-@attr(shard=2)
+@attr(shard=8)
 @ddt.ddt
 @disable_signal(api, 'thread_deleted')
 @mock.patch.dict("django.conf.settings.FEATURES", {"ENABLE_DISCUSSION_SERVICE": True})
@@ -2909,7 +2909,7 @@ class DeleteThreadTest(
             self.assertTrue(expected_error)
 
 
-@attr(shard=2)
+@attr(shard=8)
 @ddt.ddt
 @disable_signal(api, 'comment_deleted')
 @mock.patch.dict("django.conf.settings.FEATURES", {"ENABLE_DISCUSSION_SERVICE": True})
@@ -3066,7 +3066,7 @@ class DeleteCommentTest(
             self.assertTrue(expected_error)
 
 
-@attr(shard=2)
+@attr(shard=8)
 @ddt.ddt
 @mock.patch.dict("django.conf.settings.FEATURES", {"ENABLE_DISCUSSION_SERVICE": True})
 class RetrieveThreadTest(

--- a/lms/djangoapps/discussion_api/tests/test_forms.py
+++ b/lms/djangoapps/discussion_api/tests/test_forms.py
@@ -15,6 +15,8 @@ from openedx.core.djangoapps.util.test_forms import FormTestMixin
 
 class PaginationTestMixin(object):
     """A mixin for testing forms with pagination fields"""
+    shard = 8
+
     def test_missing_page(self):
         self.form_data.pop("page")
         self.assert_field_value("page", 1)
@@ -39,6 +41,7 @@ class PaginationTestMixin(object):
 @ddt.ddt
 class ThreadListGetFormTest(FormTestMixin, PaginationTestMixin, TestCase):
     """Tests for ThreadListGetForm"""
+    shard = 8
     FORM_CLASS = ThreadListGetForm
 
     def setUp(self):
@@ -165,6 +168,7 @@ class ThreadListGetFormTest(FormTestMixin, PaginationTestMixin, TestCase):
 @ddt.ddt
 class CommentListGetFormTest(FormTestMixin, PaginationTestMixin, TestCase):
     """Tests for CommentListGetForm"""
+    shard = 8
     FORM_CLASS = CommentListGetForm
 
     def setUp(self):

--- a/lms/djangoapps/discussion_api/tests/test_pagination.py
+++ b/lms/djangoapps/discussion_api/tests/test_pagination.py
@@ -11,6 +11,8 @@ from discussion_api.tests.utils import make_paginated_api_response
 
 class PaginationSerializerTest(TestCase):
     """Tests for PaginationSerializer"""
+    shard = 8
+
     def do_case(self, objects, page_num, num_pages, expected):
         """
         Make a dummy request, and assert that get_paginated_data with the given

--- a/lms/djangoapps/discussion_api/tests/test_permissions.py
+++ b/lms/djangoapps/discussion_api/tests/test_permissions.py
@@ -30,6 +30,7 @@ def _get_context(requester_id, is_requester_privileged, is_cohorted=False, threa
     }
 
 
+@attr(shard=8)
 @ddt.ddt
 class GetInitializableFieldsTest(ModuleStoreTestCase):
     """Tests for get_*_initializable_fields"""
@@ -66,7 +67,7 @@ class GetInitializableFieldsTest(ModuleStoreTestCase):
         self.assertEqual(actual, expected)
 
 
-@attr(shard=3)
+@attr(shard=8)
 @ddt.ddt
 class GetEditableFieldsTest(ModuleStoreTestCase):
     """Tests for get_editable_fields"""
@@ -105,6 +106,7 @@ class GetEditableFieldsTest(ModuleStoreTestCase):
         self.assertEqual(actual, expected)
 
 
+@attr(shard=8)
 @ddt.ddt
 class CanDeleteTest(ModuleStoreTestCase):
     """Tests for can_delete"""

--- a/lms/djangoapps/discussion_api/tests/test_render.py
+++ b/lms/djangoapps/discussion_api/tests/test_render.py
@@ -16,6 +16,8 @@ def _add_p_tags(raw_body):
 @ddt.ddt
 class RenderBodyTest(TestCase):
     """Tests for render_body"""
+    shard = 8
+
     def test_empty(self):
         self.assertEqual(render_body(""), "")
 

--- a/lms/djangoapps/discussion_api/tests/test_serializers.py
+++ b/lms/djangoapps/discussion_api/tests/test_serializers.py
@@ -31,8 +31,12 @@ from xmodule.modulestore.tests.django_utils import SharedModuleStoreTestCase
 from xmodule.modulestore.tests.factories import CourseFactory
 
 
+@attr(shard=6)
 @ddt.ddt
 class SerializerTestMixin(ForumsEnableMixin, CommentsServiceMockMixin, UrlResetMixin):
+    """
+    Test Mixin for Serializer tests
+    """
     @classmethod
     @mock.patch.dict("django.conf.settings.FEATURES", {"ENABLE_DISCUSSION_SERVICE": True})
     def setUpClass(cls):
@@ -132,7 +136,7 @@ class SerializerTestMixin(ForumsEnableMixin, CommentsServiceMockMixin, UrlResetM
         self.assertEqual(serialized["voted"], True)
 
 
-@attr(shard=3)
+@attr(shard=6)
 @ddt.ddt
 class ThreadSerializerSerializationTest(SerializerTestMixin, SharedModuleStoreTestCase):
     """Tests for ThreadSerializer serialization."""
@@ -234,6 +238,7 @@ class ThreadSerializerSerializationTest(SerializerTestMixin, SharedModuleStoreTe
         self.assertNotIn("response_count", serialized)
 
 
+@attr(shard=6)
 @ddt.ddt
 class CommentSerializerTest(SerializerTestMixin, SharedModuleStoreTestCase):
     """Tests for CommentSerializer."""
@@ -393,6 +398,7 @@ class CommentSerializerTest(SerializerTestMixin, SharedModuleStoreTestCase):
         self.assertEqual(serialized["children"][1]["children"][0]["parent_id"], "test_child_2")
 
 
+@attr(shard=6)
 @ddt.ddt
 class ThreadSerializerDeserializationTest(
         ForumsEnableMixin,
@@ -602,6 +608,7 @@ class ThreadSerializerDeserializationTest(
         )
 
 
+@attr(shard=6)
 @ddt.ddt
 class CommentSerializerDeserializationTest(ForumsEnableMixin, CommentsServiceMockMixin, SharedModuleStoreTestCase):
     """Tests for ThreadSerializer deserialization."""

--- a/lms/djangoapps/discussion_api/tests/test_views.py
+++ b/lms/djangoapps/discussion_api/tests/test_views.py
@@ -124,6 +124,7 @@ class DiscussionAPIViewTestMixin(ForumsEnableMixin, CommentsServiceMockMixin, Ur
         self.test_basic()
 
 
+@attr(shard=8)
 @mock.patch.dict("django.conf.settings.FEATURES", {"ENABLE_DISCUSSION_SERVICE": True})
 class CourseViewTest(DiscussionAPIViewTestMixin, ModuleStoreTestCase):
     """Tests for CourseView"""
@@ -158,6 +159,7 @@ class CourseViewTest(DiscussionAPIViewTestMixin, ModuleStoreTestCase):
         )
 
 
+@attr(shard=8)
 @httpretty.activate
 @mock.patch.dict("django.conf.settings.FEATURES", {"ENABLE_DISCUSSION_SERVICE": True})
 class RetireViewTest(DiscussionAPIViewTestMixin, ModuleStoreTestCase):
@@ -230,6 +232,7 @@ class RetireViewTest(DiscussionAPIViewTestMixin, ModuleStoreTestCase):
         pass
 
 
+@attr(shard=8)
 @ddt.ddt
 @mock.patch.dict("django.conf.settings.FEATURES", {"ENABLE_DISCUSSION_SERVICE": True})
 class CourseTopicsViewTest(DiscussionAPIViewTestMixin, ModuleStoreTestCase):
@@ -384,7 +387,7 @@ class CourseTopicsViewTest(DiscussionAPIViewTestMixin, ModuleStoreTestCase):
         )
 
 
-@attr(shard=3)
+@attr(shard=8)
 @ddt.ddt
 @httpretty.activate
 @mock.patch.dict("django.conf.settings.FEATURES", {"ENABLE_DISCUSSION_SERVICE": True})
@@ -725,6 +728,7 @@ class ThreadViewSetListTest(DiscussionAPIViewTestMixin, ModuleStoreTestCase, Pro
         self.assertEqual({}, response_thread['users'])
 
 
+@attr(shard=8)
 @httpretty.activate
 @disable_signal(api, 'thread_created')
 @mock.patch.dict("django.conf.settings.FEATURES", {"ENABLE_DISCUSSION_SERVICE": True})
@@ -789,7 +793,7 @@ class ThreadViewSetCreateTest(DiscussionAPIViewTestMixin, ModuleStoreTestCase):
         self.assertEqual(response_data, expected_response_data)
 
 
-@attr(shard=3)
+@attr(shard=8)
 @ddt.ddt
 @httpretty.activate
 @disable_signal(api, 'thread_edited')
@@ -947,6 +951,7 @@ class ThreadViewSetPartialUpdateTest(DiscussionAPIViewTestMixin, ModuleStoreTest
         )
 
 
+@attr(shard=8)
 @httpretty.activate
 @disable_signal(api, 'thread_deleted')
 @mock.patch.dict("django.conf.settings.FEATURES", {"ENABLE_DISCUSSION_SERVICE": True})
@@ -982,7 +987,7 @@ class ThreadViewSetDeleteTest(DiscussionAPIViewTestMixin, ModuleStoreTestCase):
         self.assertEqual(response.status_code, 404)
 
 
-@attr(shard=3)
+@attr(shard=8)
 @ddt.ddt
 @httpretty.activate
 @mock.patch.dict("django.conf.settings.FEATURES", {"ENABLE_DISCUSSION_SERVICE": True})
@@ -1357,6 +1362,7 @@ class CommentViewSetListTest(DiscussionAPIViewTestMixin, ModuleStoreTestCase, Pr
             self.assertNotIn(response_comment['endorsed_by'], response_users)
 
 
+@attr(shard=8)
 @httpretty.activate
 @disable_signal(api, 'comment_deleted')
 @mock.patch.dict("django.conf.settings.FEATURES", {"ENABLE_DISCUSSION_SERVICE": True})
@@ -1399,6 +1405,7 @@ class CommentViewSetDeleteTest(DiscussionAPIViewTestMixin, ModuleStoreTestCase):
         self.assertEqual(response.status_code, 404)
 
 
+@attr(shard=8)
 @httpretty.activate
 @disable_signal(api, 'comment_created')
 @mock.patch.dict("django.conf.settings.FEATURES", {"ENABLE_DISCUSSION_SERVICE": True})
@@ -1487,6 +1494,7 @@ class CommentViewSetCreateTest(DiscussionAPIViewTestMixin, ModuleStoreTestCase):
         self.assertEqual(response.status_code, 403)
 
 
+@attr(shard=8)
 @ddt.ddt
 @disable_signal(api, 'comment_edited')
 @mock.patch.dict("django.conf.settings.FEATURES", {"ENABLE_DISCUSSION_SERVICE": True})
@@ -1606,6 +1614,7 @@ class CommentViewSetPartialUpdateTest(DiscussionAPIViewTestMixin, ModuleStoreTes
         self.assertEqual(response.status_code, 400)
 
 
+@attr(shard=8)
 @httpretty.activate
 @mock.patch.dict("django.conf.settings.FEATURES", {"ENABLE_DISCUSSION_SERVICE": True})
 class ThreadViewSetRetrieveTest(DiscussionAPIViewTestMixin, ModuleStoreTestCase, ProfileImageTestMixin):
@@ -1657,6 +1666,7 @@ class ThreadViewSetRetrieveTest(DiscussionAPIViewTestMixin, ModuleStoreTestCase,
         self.assertEqual(expected_profile_data, response_users[self.user.username])
 
 
+@attr(shard=8)
 @httpretty.activate
 @mock.patch.dict("django.conf.settings.FEATURES", {"ENABLE_DISCUSSION_SERVICE": True})
 class CommentViewSetRetrieveTest(DiscussionAPIViewTestMixin, ModuleStoreTestCase, ProfileImageTestMixin):

--- a/lms/djangoapps/django_comment_client/tests/mock_cs_server/test_mock_cs_server.py
+++ b/lms/djangoapps/django_comment_client/tests/mock_cs_server/test_mock_cs_server.py
@@ -13,6 +13,7 @@ class MockCommentServiceServerTest(unittest.TestCase):
     A mock version of the Comment Service server that listens on a local
     port and responds with pre-defined grade messages.
     '''
+    shard = 4
 
     def setUp(self):
         super(MockCommentServiceServerTest, self).setUp()

--- a/lms/djangoapps/email_marketing/tests/test_signals.py
+++ b/lms/djangoapps/email_marketing/tests/test_signals.py
@@ -69,6 +69,7 @@ class EmailMarketingTests(TestCase):
     """
     Tests for the EmailMarketing signals and tasks classes.
     """
+    shard = 4
 
     def setUp(self):
         update_email_marketing_config(enabled=False)
@@ -657,6 +658,7 @@ class SailthruTests(TestCase):
     """
     Tests for the Sailthru tasks class.
     """
+    shard = 4
 
     def setUp(self):
         super(SailthruTests, self).setUp()

--- a/lms/djangoapps/experiments/tests/test_views.py
+++ b/lms/djangoapps/experiments/tests/test_views.py
@@ -18,6 +18,7 @@ CROSS_DOMAIN_REFERER = 'https://ecommerce.edx.org'
 
 
 class ExperimentDataViewSetTests(APITestCase):
+    shard = 4
 
     def assert_data_created_for_user(self, user, method='post', status=201):
         url = reverse('api_experiments:v0:data-list')
@@ -313,6 +314,8 @@ class ExperimentCrossDomainTests(APITestCase):
 
 
 class ExperimentKeyValueViewSetTests(APITestCase):
+    shard = 4
+
     def test_permissions(self):
         """ Staff access is required for write operations. """
         url = reverse('api_experiments:v0:key_value-list')

--- a/lms/djangoapps/gating/tests/test_signals.py
+++ b/lms/djangoapps/gating/tests/test_signals.py
@@ -14,6 +14,8 @@ class TestHandleScoreChanged(ModuleStoreTestCase):
     """
     Test case for handle_score_changed django signal handler
     """
+    shard = 4
+
     def setUp(self):
         super(TestHandleScoreChanged, self).setUp()
         self.course = CourseFactory.create(org='TestX', number='TS01', run='2016_Q1')

--- a/lms/djangoapps/grades/api/tests/test_views.py
+++ b/lms/djangoapps/grades/api/tests/test_views.py
@@ -63,6 +63,7 @@ class CurrentGradeViewTest(SharedModuleStoreTestCase, APITestCase):
         }
     }
     """
+    shard = 4
     MODULESTORE = TEST_DATA_SPLIT_MODULESTORE
 
     @classmethod
@@ -309,6 +310,7 @@ class GradingPolicyTestMixin(object):
     """
     Mixin class for Grading Policy tests
     """
+    shard = 4
     view_name = None
 
     def setUp(self):
@@ -447,6 +449,7 @@ class CourseGradingPolicyTests(GradingPolicyTestMixin, SharedModuleStoreTestCase
     """
     Tests for CourseGradingPolicy view.
     """
+    shard = 4
     view_name = 'grades_api:course_grading_policy'
 
     raw_grader = [
@@ -498,6 +501,7 @@ class CourseGradingPolicyMissingFieldsTests(GradingPolicyTestMixin, SharedModule
     """
     Tests for CourseGradingPolicy view when fields are missing.
     """
+    shard = 4
     view_name = 'grades_api:course_grading_policy'
 
     # Raw grader with missing keys

--- a/lms/djangoapps/grades/config/tests/test_models.py
+++ b/lms/djangoapps/grades/config/tests/test_models.py
@@ -21,6 +21,8 @@ class PersistentGradesFeatureFlagTests(TestCase):
     Tests the behavior of the feature flags for persistent grading.
     These are set via Django admin settings.
     """
+    shard = 4
+
     def setUp(self):
         super(PersistentGradesFeatureFlagTests, self).setUp()
         self.course_id_1 = CourseLocator(org="edx", course="course", run="run")

--- a/lms/djangoapps/grades/management/commands/tests/test_compute_grades.py
+++ b/lms/djangoapps/grades/management/commands/tests/test_compute_grades.py
@@ -31,6 +31,7 @@ class TestComputeGrades(SharedModuleStoreTestCase):
     """
     Tests compute_grades management command.
     """
+    shard = 4
     num_users = 3
     num_courses = 5
 

--- a/lms/djangoapps/grades/management/commands/tests/test_recalculate_subsection_grades.py
+++ b/lms/djangoapps/grades/management/commands/tests/test_recalculate_subsection_grades.py
@@ -25,6 +25,8 @@ class TestRecalculateSubsectionGrades(HasCourseWithProblemsMixin, ModuleStoreTes
     """
     Tests recalculate subsection grades management command.
     """
+    shard = 4
+
     def setUp(self):
         super(TestRecalculateSubsectionGrades, self).setUp()
         self.command = recalculate_subsection_grades.Command()

--- a/lms/djangoapps/grades/tests/integration/test_access.py
+++ b/lms/djangoapps/grades/tests/integration/test_access.py
@@ -21,6 +21,7 @@ class GradesAccessIntegrationTest(ProblemSubmissionTestMixin, SharedModuleStoreT
     """
     Tests integration between grading and block access.
     """
+    shard = 4
     ENABLED_SIGNALS = ['course_published']
 
     @classmethod

--- a/lms/djangoapps/grades/tests/integration/test_events.py
+++ b/lms/djangoapps/grades/tests/integration/test_events.py
@@ -24,6 +24,7 @@ class GradesEventIntegrationTest(ProblemSubmissionTestMixin, SharedModuleStoreTe
     Tests integration between the eventing in various layers
     of the grading infrastructure.
     """
+    shard = 4
     ENABLED_SIGNALS = ['course_published']
 
     @classmethod

--- a/lms/djangoapps/grades/tests/integration/test_problems.py
+++ b/lms/djangoapps/grades/tests/integration/test_problems.py
@@ -25,6 +25,7 @@ class TestMultipleProblemTypesSubsectionScores(SharedModuleStoreTestCase):
     """
     Test grading of different problem types.
     """
+    shard = 4
 
     SCORED_BLOCK_COUNT = 7
     ACTUAL_TOTAL_POSSIBLE = 17.0
@@ -98,6 +99,7 @@ class TestVariedMetadata(ProblemSubmissionTestMixin, ModuleStoreTestCase):
     Test that changing the metadata on a block has the desired effect on the
     persisted score.
     """
+    shard = 4
     default_problem_metadata = {
         u'graded': True,
         u'weight': 2.5,
@@ -205,6 +207,8 @@ class TestWeightedProblems(SharedModuleStoreTestCase):
     """
     Test scores and grades with various problem weight values.
     """
+    shard = 4
+
     @classmethod
     def setUpClass(cls):
         super(TestWeightedProblems, cls).setUpClass()

--- a/lms/djangoapps/grades/tests/test_course_data.py
+++ b/lms/djangoapps/grades/tests/test_course_data.py
@@ -16,6 +16,7 @@ class CourseDataTest(ModuleStoreTestCase):
     """
     Simple tests to ensure CourseData works as advertised.
     """
+    shard = 4
 
     def setUp(self):
         super(CourseDataTest, self).setUp()

--- a/lms/djangoapps/grades/tests/test_course_grade.py
+++ b/lms/djangoapps/grades/tests/test_course_grade.py
@@ -23,6 +23,8 @@ class ZeroGradeTest(GradeTestBase):
     Tests ZeroCourseGrade (and, implicitly, ZeroSubsectionGrade)
     functionality.
     """
+    shard = 4
+
     @ddt.data(True, False)
     def test_zero(self, assume_zero_enabled):
         """
@@ -68,6 +70,8 @@ class TestScoreForModule(SharedModuleStoreTestCase):
                    (2/5) (3/5) (0/1)   -   (1/3)   -   (3/10)
 
     """
+    shard = 4
+
     @classmethod
     def setUpClass(cls):
         super(TestScoreForModule, cls).setUpClass()

--- a/lms/djangoapps/grades/tests/test_models.py
+++ b/lms/djangoapps/grades/tests/test_models.py
@@ -32,6 +32,8 @@ class BlockRecordListTestCase(TestCase):
     """
     Verify the behavior of BlockRecordList, particularly around edge cases
     """
+    shard = 4
+
     def setUp(self):
         super(BlockRecordListTestCase, self).setUp()
         self.course_key = CourseLocator(
@@ -88,6 +90,8 @@ class BlockRecordTest(GradesModelTestCase):
     """
     Test the BlockRecord model.
     """
+    shard = 4
+
     def test_creation(self):
         """
         Tests creation of a BlockRecord.
@@ -126,6 +130,8 @@ class VisibleBlocksTest(GradesModelTestCase):
     """
     Test the VisibleBlocks model.
     """
+    shard = 4
+
     def _create_block_record_list(self, blocks):
         """
         Creates and returns a BlockRecordList for the given blocks.
@@ -193,6 +199,8 @@ class PersistentSubsectionGradeTest(GradesModelTestCase):
     """
     Test the PersistentSubsectionGrade model.
     """
+    shard = 4
+
     def setUp(self):
         super(PersistentSubsectionGradeTest, self).setUp()
         self.usage_key = BlockUsageLocator(
@@ -324,6 +332,8 @@ class PersistentCourseGradesTest(GradesModelTestCase):
     """
     Tests the PersistentCourseGrade model.
     """
+    shard = 4
+
     def setUp(self):
         super(PersistentCourseGradesTest, self).setUp()
         self.params = {

--- a/lms/djangoapps/grades/tests/test_scores.py
+++ b/lms/djangoapps/grades/tests/test_scores.py
@@ -52,6 +52,7 @@ class TestScoredBlockTypes(TestCase):
     """
     Tests for the possibly_scored function.
     """
+    shard = 4
     possibly_scored_block_types = {
         'course', 'chapter', 'sequential', 'vertical',
         'library_content', 'split_test', 'conditional', 'library', 'randomize',
@@ -77,6 +78,7 @@ class TestGetScore(TestCase):
     """
     Tests for get_score
     """
+    shard = 4
     display_name = 'test_name'
     location = 'test_location'
 
@@ -229,6 +231,8 @@ class TestWeightedScore(TestCase):
     """
     Tests the helper method: weighted_score
     """
+    shard = 4
+
     @ddt.data(
         (0, 0, 1),
         (5, 0, 0),
@@ -269,6 +273,8 @@ class TestInternalGetGraded(TestCase):
     """
     Tests the internal helper method: _get_explicit_graded
     """
+    shard = 4
+
     def _create_block(self, explicit_graded_value):
         """
         Creates and returns a minimal BlockData object with the give value
@@ -308,6 +314,8 @@ class TestInternalGetScoreFromBlock(TestCase):
     """
     Tests the internal helper method: _get_score_from_persisted_or_latest_block
     """
+    shard = 4
+
     def _create_block(self, raw_possible):
         """
         Creates and returns a minimal BlockData object with the give value

--- a/lms/djangoapps/grades/tests/test_services.py
+++ b/lms/djangoapps/grades/tests/test_services.py
@@ -29,6 +29,8 @@ class GradesServiceTests(ModuleStoreTestCase):
     """
     Tests for the Grades service
     """
+    shard = 4
+
     def setUp(self):
         super(GradesServiceTests, self).setUp()
         self.service = GradesService()

--- a/lms/djangoapps/grades/tests/test_signals.py
+++ b/lms/djangoapps/grades/tests/test_signals.py
@@ -90,6 +90,7 @@ class ScoreChangedSignalRelayTest(TestCase):
     This ensures that listeners in the LMS only have to handle one type
     of signal for all scoring events regardless of their origin.
     """
+    shard = 4
     SIGNALS = {
         'score_set': score_set,
         'score_reset': score_reset,

--- a/lms/djangoapps/grades/tests/test_subsection_grade.py
+++ b/lms/djangoapps/grades/tests/test_subsection_grade.py
@@ -7,6 +7,7 @@ from ddt import data, ddt, unpack
 
 @ddt
 class SubsectionGradeTest(GradeTestBase):
+    shard = 4
 
     @data((50, 100, .50), (59.49, 100, .59), (59.51, 100, .60), (59.50, 100, .60), (60.5, 100, .60))
     @unpack

--- a/lms/djangoapps/grades/tests/test_subsection_grade_factory.py
+++ b/lms/djangoapps/grades/tests/test_subsection_grade_factory.py
@@ -19,6 +19,7 @@ class TestSubsectionGradeFactory(ProblemSubmissionTestMixin, GradeTestBase):
     persistent grades are functioning as expected, and that the flag to
     enable saving subsection grades blocks/enables that feature as expected.
     """
+    shard = 4
 
     def assert_grade(self, grade, expected_earned, expected_possible):
         """

--- a/lms/djangoapps/grades/tests/test_tasks.py
+++ b/lms/djangoapps/grades/tests/test_tasks.py
@@ -136,6 +136,7 @@ class RecalculateSubsectionGradeTest(HasCourseWithProblemsMixin, ModuleStoreTest
     """
     Ensures that the recalculate subsection grade task functions as expected when run.
     """
+    shard = 4
     ENABLED_SIGNALS = ['course_published', 'pre_publish']
 
     def setUp(self):
@@ -431,6 +432,7 @@ class ComputeGradesForCourseTest(HasCourseWithProblemsMixin, ModuleStoreTestCase
     """
     Test compute_grades_for_course_v2 task.
     """
+    shard = 4
 
     ENABLED_SIGNALS = ['course_published', 'pre_publish']
 

--- a/lms/djangoapps/grades/tests/test_transformer.py
+++ b/lms/djangoapps/grades/tests/test_transformer.py
@@ -26,6 +26,7 @@ class GradesTransformerTestCase(CourseStructureTestCase):
     """
     Verify behavior of the GradesTransformer
     """
+    shard = 4
 
     TRANSFORMER_CLASS_TO_TEST = GradesTransformer
 
@@ -397,6 +398,7 @@ class MultiProblemModulestoreAccessTestCase(CourseStructureTestCase, SharedModul
     """
     Test mongo usage in GradesTransformer.
     """
+    shard = 4
 
     TRANSFORMER_CLASS_TO_TEST = GradesTransformer
 

--- a/lms/djangoapps/instructor/tests/test_api.py
+++ b/lms/djangoapps/instructor/tests/test_api.py
@@ -268,7 +268,7 @@ def view_queue_connection_error(request):  # pylint: disable=unused-argument
     raise QueueConnectionError()
 
 
-@attr(shard=1)
+@attr(shard=5)
 @ddt.ddt
 class TestCommonExceptions400(TestCase):
     """
@@ -321,7 +321,7 @@ class TestCommonExceptions400(TestCase):
         self.assertIn('Error occured. Please try again later', resp.content)
 
 
-@attr(shard=1)
+@attr(shard=5)
 @ddt.ddt
 class TestEndpointHttpMethods(SharedModuleStoreTestCase, LoginEnrollmentTestCase):
     """
@@ -376,7 +376,7 @@ class TestEndpointHttpMethods(SharedModuleStoreTestCase, LoginEnrollmentTestCase
         )
 
 
-@attr(shard=1)
+@attr(shard=5)
 @patch('bulk_email.models.html_to_text', Mock(return_value='Mocking CourseEmail.text_message', autospec=True))
 class TestInstructorAPIDenyLevels(SharedModuleStoreTestCase, LoginEnrollmentTestCase):
     """
@@ -615,7 +615,7 @@ class TestInstructorAPIDenyLevels(SharedModuleStoreTestCase, LoginEnrollmentTest
             )
 
 
-@attr(shard=1)
+@attr(shard=5)
 @patch.dict(settings.FEATURES, {'ALLOW_AUTOMATED_SIGNUPS': True})
 class TestInstructorAPIBulkAccountCreationAndEnrollment(SharedModuleStoreTestCase, LoginEnrollmentTestCase):
     """
@@ -1028,7 +1028,7 @@ class TestInstructorAPIBulkAccountCreationAndEnrollment(SharedModuleStoreTestCas
             self.assertEqual(enrollment.enrollment.mode, CourseMode.DEFAULT_SHOPPINGCART_MODE_SLUG)
 
 
-@attr(shard=1)
+@attr(shard=5)
 @ddt.ddt
 class TestInstructorAPIEnrollment(SharedModuleStoreTestCase, LoginEnrollmentTestCase):
     """
@@ -1774,7 +1774,7 @@ class TestInstructorAPIEnrollment(SharedModuleStoreTestCase, LoginEnrollmentTest
         return response
 
 
-@attr(shard=1)
+@attr(shard=5)
 @ddt.ddt
 class TestInstructorAPIBulkBetaEnrollment(SharedModuleStoreTestCase, LoginEnrollmentTestCase):
     """
@@ -2104,7 +2104,7 @@ class TestInstructorAPIBulkBetaEnrollment(SharedModuleStoreTestCase, LoginEnroll
         )
 
 
-@attr(shard=1)
+@attr(shard=5)
 class TestInstructorAPILevelsAccess(SharedModuleStoreTestCase, LoginEnrollmentTestCase):
     """
     Test endpoints whereby instructors can change permissions
@@ -2346,7 +2346,7 @@ class TestInstructorAPILevelsAccess(SharedModuleStoreTestCase, LoginEnrollmentTe
             self.assertNotIn(rolename, user_roles)
 
 
-@attr(shard=1)
+@attr(shard=5)
 @ddt.ddt
 @patch.dict('django.conf.settings.FEATURES', {'ENABLE_PAID_COURSE_REGISTRATION': True})
 class TestInstructorAPILevelsDataDump(SharedModuleStoreTestCase, LoginEnrollmentTestCase):
@@ -3217,7 +3217,7 @@ class TestInstructorAPILevelsDataDump(SharedModuleStoreTestCase, LoginEnrollment
         self.assertEqual(response.status_code, 400)
 
 
-@attr(shard=1)
+@attr(shard=5)
 class TestInstructorAPIRegradeTask(SharedModuleStoreTestCase, LoginEnrollmentTestCase):
     """
     Test endpoints whereby instructors can change student grades.
@@ -3381,7 +3381,7 @@ class TestInstructorAPIRegradeTask(SharedModuleStoreTestCase, LoginEnrollmentTes
         self.assertEqual(response.status_code, 400)
 
 
-@attr(shard=1)
+@attr(shard=5)
 @patch.dict(settings.FEATURES, {'ENTRANCE_EXAMS': True})
 @ddt.ddt
 class TestEntranceExamInstructorAPIRegradeTask(SharedModuleStoreTestCase, LoginEnrollmentTestCase):
@@ -3663,7 +3663,7 @@ class TestEntranceExamInstructorAPIRegradeTask(SharedModuleStoreTestCase, LoginE
         self.assertContains(response, message)
 
 
-@attr(shard=1)
+@attr(shard=5)
 @patch('bulk_email.models.html_to_text', Mock(return_value='Mocking CourseEmail.text_message', autospec=True))
 class TestInstructorSendEmail(SiteMixin, SharedModuleStoreTestCase, LoginEnrollmentTestCase):
     """
@@ -3802,7 +3802,7 @@ class MockCompletionInfo(object):
         return False, 'Task Errored In Some Way'
 
 
-@attr(shard=1)
+@attr(shard=5)
 class TestInstructorAPITaskLists(SharedModuleStoreTestCase, LoginEnrollmentTestCase):
     """
     Test instructor task list endpoint.
@@ -3972,7 +3972,7 @@ class TestInstructorAPITaskLists(SharedModuleStoreTestCase, LoginEnrollmentTestC
         self.assertEqual(actual_tasks, expected_tasks)
 
 
-@attr(shard=1)
+@attr(shard=5)
 @patch.object(lms.djangoapps.instructor_task.api, 'get_instructor_task_history', autospec=True)
 class TestInstructorEmailContentList(SharedModuleStoreTestCase, LoginEnrollmentTestCase):
     """
@@ -4106,7 +4106,7 @@ class TestInstructorEmailContentList(SharedModuleStoreTestCase, LoginEnrollmentT
         self.assertDictEqual(expected_info, returned_info)
 
 
-@attr(shard=1)
+@attr(shard=5)
 class TestInstructorAPIHelpers(TestCase):
     """ Test helpers for instructor.api """
 
@@ -4160,7 +4160,7 @@ def get_extended_due(course, unit, user):
         return None
 
 
-@attr(shard=1)
+@attr(shard=5)
 class TestDueDateExtensions(SharedModuleStoreTestCase, LoginEnrollmentTestCase):
     """
     Test data dumps for reporting.
@@ -4329,8 +4329,12 @@ class TestDueDateExtensions(SharedModuleStoreTestCase, LoginEnrollmentTestCase):
                 self.user1.profile.name, self.user1.username)})
 
 
-@attr(shard=1)
+@attr(shard=5)
 class TestDueDateExtensionsDeletedDate(ModuleStoreTestCase, LoginEnrollmentTestCase):
+    """
+    Tests for deleting due date extensions
+    """
+
     def setUp(self):
         """
         Fixtures.
@@ -4437,7 +4441,7 @@ class TestDueDateExtensionsDeletedDate(ModuleStoreTestCase, LoginEnrollmentTestC
         )
 
 
-@attr(shard=1)
+@attr(shard=5)
 class TestCourseIssuedCertificatesData(SharedModuleStoreTestCase):
     """
     Test data dumps for issued certificates.
@@ -4548,7 +4552,7 @@ class TestCourseIssuedCertificatesData(SharedModuleStoreTestCase):
         )
 
 
-@attr(shard=1)
+@attr(shard=5)
 @override_settings(REGISTRATION_CODE_LENGTH=8)
 class TestCourseRegistrationCodes(SharedModuleStoreTestCase):
     """
@@ -5011,7 +5015,7 @@ class TestCourseRegistrationCodes(SharedModuleStoreTestCase):
         self.assertTrue(body.startswith(EXPECTED_COUPON_CSV_HEADER))
 
 
-@attr(shard=1)
+@attr(shard=5)
 class TestBulkCohorting(SharedModuleStoreTestCase):
     """
     Test adding users to cohorts in bulk via CSV upload.

--- a/lms/djangoapps/instructor/tests/test_enrollment_store_provider.py
+++ b/lms/djangoapps/instructor/tests/test_enrollment_store_provider.py
@@ -37,6 +37,7 @@ class TestBaseNotificationDataProvider(TestCase):
     """
     Cover the EnrollmentReportProvider class
     """
+    shard = 4
 
     def test_cannot_create_instance(self):
         """

--- a/lms/djangoapps/instructor_analytics/tests/test_csvs.py
+++ b/lms/djangoapps/instructor_analytics/tests/test_csvs.py
@@ -8,6 +8,7 @@ from instructor_analytics.csvs import create_csv_response, format_dictlist, form
 
 class TestAnalyticsCSVS(TestCase):
     """ Test analytics rendering of csv files."""
+    shard = 4
 
     def test_create_csv_response_nodata(self):
         header = ['Name', 'Email']
@@ -39,6 +40,7 @@ class TestAnalyticsCSVS(TestCase):
 
 class TestAnalyticsFormatDictlist(TestCase):
     """ Test format_dictlist method """
+    shard = 4
 
     def test_format_dictlist(self):
         dictlist = [
@@ -83,6 +85,8 @@ class TestAnalyticsFormatDictlist(TestCase):
 
 class TestAnalyticsFormatInstances(TestCase):
     """ test format_instances method """
+    shard = 4
+
     class TestDataClass(object):
         """ Test class to generate objects for format_instances """
         def __init__(self):

--- a/lms/djangoapps/instructor_analytics/tests/test_distributions.py
+++ b/lms/djangoapps/instructor_analytics/tests/test_distributions.py
@@ -11,6 +11,7 @@ from student.tests.factories import UserFactory
 
 class TestAnalyticsDistributions(TestCase):
     '''Test analytics distribution gathering.'''
+    shard = 4
 
     def setUp(self):
         super(TestAnalyticsDistributions, self).setUp()
@@ -74,6 +75,7 @@ class TestAnalyticsDistributions(TestCase):
 
 class TestAnalyticsDistributionsNoData(TestCase):
     '''Test analytics distribution gathering.'''
+    shard = 4
 
     def setUp(self):
         super(TestAnalyticsDistributionsNoData, self).setUp()

--- a/lms/djangoapps/instructor_task/management/commands/tests/test_fail_old_tasks.py
+++ b/lms/djangoapps/instructor_task/management/commands/tests/test_fail_old_tasks.py
@@ -16,6 +16,7 @@ class TestFailOldQueueingTasksCommand(InstructorTaskTestCase):
     """
     Tests for the `fail_old_tasks` management command
     """
+    shard = 4
 
     def setUp(self):
         super(TestFailOldQueueingTasksCommand, self).setUp()

--- a/lms/djangoapps/instructor_task/tests/test_base.py
+++ b/lms/djangoapps/instructor_task/tests/test_base.py
@@ -303,6 +303,8 @@ class TestReportMixin(object):
     """
     Cleans up after tests that place files in the reports directory.
     """
+    shard = 4
+
     def setUp(self):
 
         def clean_up_tmpdir():

--- a/lms/djangoapps/instructor_task/tests/test_models.py
+++ b/lms/djangoapps/instructor_task/tests/test_models.py
@@ -20,6 +20,8 @@ class ReportStoreTestMixin(object):
     """
     Mixin for report store tests.
     """
+    shard = 4
+
     def setUp(self):
         super(ReportStoreTestMixin, self).setUp()
         self.course_id = CourseLocator(org="testx", course="coursex", run="runx")
@@ -119,6 +121,8 @@ class TestS3ReportStorage(MockS3Mixin, TestCase):
     Test the S3ReportStorage to make sure that configuration overrides from settings.FINANCIAL_REPORTS
     are used instead of default ones.
     """
+    shard = 4
+
     def test_financial_report_overrides(self):
         """
         Test that CUSTOM_DOMAIN from FINANCIAL_REPORTS is used to construct file url. instead of domain defined via

--- a/lms/djangoapps/instructor_task/tests/test_subtasks.py
+++ b/lms/djangoapps/instructor_task/tests/test_subtasks.py
@@ -13,6 +13,7 @@ from student.models import CourseEnrollment
 
 class TestSubtasks(InstructorTaskCourseTestCase):
     """Tests for subtasks."""
+    shard = 4
 
     def setUp(self):
         super(TestSubtasks, self).setUp()

--- a/lms/djangoapps/instructor_task/tests/test_views.py
+++ b/lms/djangoapps/instructor_task/tests/test_views.py
@@ -21,6 +21,7 @@ class InstructorTaskReportTest(InstructorTaskTestCase):
     """
     Tests view methods that involve the reporting of status for background tasks.
     """
+    shard = 4
 
     def _get_instructor_task_status(self, task_id):
         """Returns status corresponding to task_id via api method."""

--- a/lms/djangoapps/learner_dashboard/tests/test_programs.py
+++ b/lms/djangoapps/learner_dashboard/tests/test_programs.py
@@ -31,6 +31,7 @@ PROGRAMS_UTILS_MODULE = 'openedx.core.djangoapps.programs.utils'
 @mock.patch(PROGRAMS_UTILS_MODULE + '.get_programs')
 class TestProgramListing(ProgramsApiConfigMixin, SharedModuleStoreTestCase):
     """Unit tests for the program listing page."""
+    shard = 4
     maxDiff = None
     password = 'test'
     url = reverse_lazy('program_listing_view')
@@ -177,6 +178,7 @@ class TestProgramListing(ProgramsApiConfigMixin, SharedModuleStoreTestCase):
 @override_switch('student_records', True)
 class TestProgramDetails(ProgramsApiConfigMixin, CatalogIntegrationMixin, SharedModuleStoreTestCase):
     """Unit tests for the program details page."""
+    shard = 4
     program_uuid = str(uuid4())
     password = 'test'
     url = reverse_lazy('program_details_view', kwargs={'program_uuid': program_uuid})

--- a/lms/djangoapps/learner_dashboard/tests/test_utils.py
+++ b/lms/djangoapps/learner_dashboard/tests/test_utils.py
@@ -13,6 +13,8 @@ class TestUtils(TestCase):
     """
     The test case class covering the all the utils functions
     """
+    shard = 4
+
     @ddt.data('path1/', '/path1/path2/', '/', '')
     def test_strip_course_id(self, path):
         """

--- a/lms/djangoapps/lms_xblock/test/test_runtime.py
+++ b/lms/djangoapps/lms_xblock/test/test_runtime.py
@@ -52,6 +52,7 @@ class BlockMock(Mock):
 
 class TestHandlerUrl(TestCase):
     """Test the LMS handler_url"""
+    shard = 4
 
     def setUp(self):
         super(TestHandlerUrl, self).setUp()
@@ -117,6 +118,7 @@ class TestHandlerUrl(TestCase):
 
 class TestUserServiceAPI(TestCase):
     """Test the user service interface"""
+    shard = 4
 
     def setUp(self):
         super(TestUserServiceAPI, self).setUp()
@@ -167,6 +169,7 @@ class TestUserServiceAPI(TestCase):
 @ddt
 class TestBadgingService(ModuleStoreTestCase):
     """Test the badging service interface"""
+    shard = 4
 
     def setUp(self):
         super(TestBadgingService, self).setUp()
@@ -232,6 +235,7 @@ class TestBadgingService(ModuleStoreTestCase):
 
 class TestI18nService(ModuleStoreTestCase):
     """ Test ModuleI18nService """
+    shard = 4
 
     def setUp(self):
         """ Setting up tests """

--- a/lms/djangoapps/lti_provider/management/commands/tests/test_resend_lti_scores.py
+++ b/lms/djangoapps/lti_provider/management/commands/tests/test_resend_lti_scores.py
@@ -19,6 +19,7 @@ class CommandArgsTestCase(TestCase):
     """
     Test management command parses arguments properly.
     """
+    shard = 4
 
     def _get_arg_parser(self):
         """
@@ -45,6 +46,7 @@ class CommandExecutionTestCase(SharedModuleStoreTestCase):
     """
     Test `manage.py resend_lti_scores` command.
     """
+    shard = 4
 
     @classmethod
     def setUpClass(cls):

--- a/lms/djangoapps/lti_provider/tests/test_outcomes.py
+++ b/lms/djangoapps/lti_provider/tests/test_outcomes.py
@@ -18,6 +18,7 @@ class StoreOutcomeParametersTest(TestCase):
     """
     Tests for the store_outcome_parameters method in outcomes.py
     """
+    shard = 4
 
     def setUp(self):
         super(StoreOutcomeParametersTest, self).setUp()
@@ -132,6 +133,7 @@ class SignAndSendReplaceResultTest(TestCase):
     """
     Tests for the sign_and_send_replace_result method in outcomes.py
     """
+    shard = 4
 
     def setUp(self):
         super(SignAndSendReplaceResultTest, self).setUp()
@@ -183,6 +185,7 @@ class XmlHandlingTest(TestCase):
     Tests for the generate_replace_result_xml and check_replace_result_response
     methods in outcomes.py
     """
+    shard = 4
 
     response_xml = """
         <imsx_POXEnvelopeResponse xmlns = "http://www.imsglobal.org/services/ltiv1p1/xsd/imsoms_v1p0">
@@ -295,6 +298,8 @@ class TestAssignmentsForProblem(ModuleStoreTestCase):
     """
     Test cases for the assignments_for_problem method in outcomes.py
     """
+    shard = 4
+
     def setUp(self):
         super(TestAssignmentsForProblem, self).setUp()
         self.user = UserFactory.create()

--- a/lms/djangoapps/lti_provider/tests/test_signature_validator.py
+++ b/lms/djangoapps/lti_provider/tests/test_signature_validator.py
@@ -27,6 +27,7 @@ class ClientKeyValidatorTest(TestCase):
     """
     Tests for the check_client_key method in the SignatureValidator class.
     """
+    shard = 4
 
     def setUp(self):
         super(ClientKeyValidatorTest, self).setUp()
@@ -57,6 +58,7 @@ class NonceValidatorTest(TestCase):
     """
     Tests for the check_nonce method in the SignatureValidator class.
     """
+    shard = 4
 
     def setUp(self):
         super(NonceValidatorTest, self).setUp()
@@ -88,6 +90,8 @@ class SignatureValidatorTest(TestCase):
     to check message signatures. Note that these tests mock out the library
     itself, since we assume it to be correct.
     """
+    shard = 4
+
     def setUp(self):
         super(SignatureValidatorTest, self).setUp()
         self.lti_consumer = get_lti_consumer()

--- a/lms/djangoapps/lti_provider/tests/test_tasks.py
+++ b/lms/djangoapps/lti_provider/tests/test_tasks.py
@@ -71,6 +71,8 @@ class SendLeafOutcomeTest(BaseOutcomeTest):
     """
     Tests for the send_leaf_outcome method in tasks.py
     """
+    shard = 4
+
     @ddt.data(
         (2.0, 2.0, 1.0),
         (2.0, 0.0, 0.0),
@@ -91,6 +93,8 @@ class SendCompositeOutcomeTest(BaseOutcomeTest):
     """
     Tests for the send_composite_outcome method in tasks.py
     """
+    shard = 4
+
     def setUp(self):
         super(SendCompositeOutcomeTest, self).setUp()
         self.descriptor = MagicMock()

--- a/lms/djangoapps/lti_provider/tests/test_users.py
+++ b/lms/djangoapps/lti_provider/tests/test_users.py
@@ -19,6 +19,7 @@ class UserManagementHelperTest(TestCase):
     """
     Tests for the helper functions in users.py
     """
+    shard = 4
 
     def setUp(self):
         super(UserManagementHelperTest, self).setUp()
@@ -77,6 +78,8 @@ class AuthenticateLtiUserTest(TestCase):
     """
     Tests for the authenticate_lti_user function in users.py
     """
+    shard = 4
+
     def setUp(self):
         super(AuthenticateLtiUserTest, self).setUp()
         self.lti_consumer = LtiConsumer(
@@ -143,6 +146,7 @@ class CreateLtiUserTest(TestCase):
     """
     Tests for the create_lti_user function in users.py
     """
+    shard = 4
 
     def setUp(self):
         super(CreateLtiUserTest, self).setUp()
@@ -180,6 +184,7 @@ class LtiBackendTest(TestCase):
     """
     Tests for the authentication backend that authenticates LTI users.
     """
+    shard = 4
 
     def setUp(self):
         super(LtiBackendTest, self).setUp()

--- a/lms/djangoapps/mobile_api/tests/test_context_processor.py
+++ b/lms/djangoapps/mobile_api/tests/test_context_processor.py
@@ -12,6 +12,7 @@ class MobileContextProcessorTests(TestCase):
     """
     Tests for the configuration context processor.
     """
+    shard = 4
 
     def test_is_from_mobile_app(self):
         """

--- a/lms/djangoapps/mobile_api/tests/test_decorator.py
+++ b/lms/djangoapps/mobile_api/tests/test_decorator.py
@@ -14,6 +14,8 @@ class TestMobileAPIDecorators(TestCase):
     """
     Basic tests for mobile api decorators to ensure they retain the docstrings.
     """
+    shard = 4
+
     @ddt.data(mobile_view, mobile_course_access)
     def test_function_decorator(self, decorator):
         @decorator()

--- a/lms/djangoapps/mobile_api/tests/test_middleware.py
+++ b/lms/djangoapps/mobile_api/tests/test_middleware.py
@@ -19,6 +19,7 @@ class TestAppVersionUpgradeMiddleware(CacheIsolationTestCase):
     """
     Tests for version based app upgrade middleware
     """
+    shard = 4
 
     ENABLED_CACHES = ['default']
 

--- a/lms/djangoapps/mobile_api/tests/test_milestones.py
+++ b/lms/djangoapps/mobile_api/tests/test_milestones.py
@@ -20,6 +20,7 @@ class MobileAPIMilestonesMixin(object):
     the mobile api will appropriately block content until the milestone is
     fulfilled.
     """
+    shard = 4
 
     ALLOW_ACCESS_TO_MILESTONE_COURSE = False  # pylint: disable=invalid-name
 

--- a/lms/djangoapps/mobile_api/tests/test_mobile_platform.py
+++ b/lms/djangoapps/mobile_api/tests/test_mobile_platform.py
@@ -12,6 +12,8 @@ class TestMobilePlatform(TestCase):
     """
     Tests for platform against mobile app request
     """
+    shard = 4
+
     @ddt.data(
         ("edX/org.edx.mobile (0.1.5; OS Version 9.2 (Build 13C75))", "iOS", "0.1.5"),
         ("edX/org.edx.mobile (1.01.1; OS Version 9.2 (Build 13C75))", "iOS", "1.01.1"),

--- a/lms/djangoapps/mobile_api/tests/test_model.py
+++ b/lms/djangoapps/mobile_api/tests/test_model.py
@@ -15,6 +15,8 @@ class TestAppVersionConfigModel(TestCase):
     """
     Tests for app version configuration model
     """
+    shard = 4
+
     def set_app_version_config(self):
         """ Creates configuration data for platform versions """
         AppVersionConfig(platform="ios", version="1.1.1", expire_at=None, enabled=True).save()
@@ -88,6 +90,7 @@ class TestMobileApiConfig(TestCase):
     """
     Tests MobileAPIConfig
     """
+    shard = 4
 
     def test_video_profile_list(self):
         """Check that video_profiles config is returned in order as a list"""

--- a/lms/djangoapps/mobile_api/users/tests.py
+++ b/lms/djangoapps/mobile_api/users/tests.py
@@ -37,7 +37,7 @@ from .. import errors
 from .serializers import CourseEnrollmentSerializer
 
 
-@attr(shard=2)
+@attr(shard=9)
 class TestUserDetailApi(MobileAPITestCase, MobileAuthUserTestMixin):
     """
     Tests for /api/mobile/v0.5/users/<user_name>...
@@ -52,7 +52,7 @@ class TestUserDetailApi(MobileAPITestCase, MobileAuthUserTestMixin):
         self.assertEqual(response.data['email'], self.user.email)
 
 
-@attr(shard=2)
+@attr(shard=9)
 class TestUserInfoApi(MobileAPITestCase, MobileAuthTestMixin):
     """
     Tests for /api/mobile/v0.5/my_user_info
@@ -68,7 +68,7 @@ class TestUserInfoApi(MobileAPITestCase, MobileAuthTestMixin):
         self.assertIn(self.username, response['location'])
 
 
-@attr(shard=2)
+@attr(shard=9)
 @ddt.ddt
 @override_settings(MKTG_URLS={'ROOT': 'dummy-root'})
 class TestUserEnrollmentApi(UrlResetMixin, MobileAPITestCase, MobileAuthUserTestMixin,
@@ -304,7 +304,7 @@ class TestUserEnrollmentApi(UrlResetMixin, MobileAPITestCase, MobileAuthUserTest
             self.assertEqual(entry['course']['org'], 'edX')
 
 
-@attr(shard=2)
+@attr(shard=9)
 class CourseStatusAPITestCase(MobileAPITestCase):
     """
     Base test class for /api/mobile/v0.5/users/<user_name>/course_status_info/{course_id}
@@ -339,7 +339,7 @@ class CourseStatusAPITestCase(MobileAPITestCase):
         )
 
 
-@attr(shard=2)
+@attr(shard=9)
 class TestCourseStatusGET(CourseStatusAPITestCase, MobileAuthUserTestMixin,
                           MobileCourseAccessTestMixin, MilestonesTestCaseMixin):
     """
@@ -359,7 +359,7 @@ class TestCourseStatusGET(CourseStatusAPITestCase, MobileAuthUserTestMixin,
         )
 
 
-@attr(shard=2)
+@attr(shard=9)
 class TestCourseStatusPATCH(CourseStatusAPITestCase, MobileAuthUserTestMixin,
                             MobileCourseAccessTestMixin, MilestonesTestCaseMixin):
     """
@@ -463,7 +463,7 @@ class TestCourseStatusPATCH(CourseStatusAPITestCase, MobileAuthUserTestMixin,
         )
 
 
-@attr(shard=2)
+@attr(shard=9)
 @patch.dict(settings.FEATURES, {'ENABLE_MKTG_SITE': True})
 @override_settings(MKTG_URLS={'ROOT': 'dummy-root'})
 class TestCourseEnrollmentSerializer(MobileAPITestCase, MilestonesTestCaseMixin):

--- a/lms/djangoapps/mobile_api/video_outlines/tests.py
+++ b/lms/djangoapps/mobile_api/video_outlines/tests.py
@@ -203,7 +203,7 @@ class TestVideoAPIMixin(object):
         return sub_block_a, sub_block_b
 
 
-@attr(shard=2)
+@attr(shard=9)
 class TestNonStandardCourseStructure(MobileAPITestCase, TestVideoAPIMixin, MilestonesTestCaseMixin):
     """
     Tests /api/mobile/v0.5/video_outlines/courses/{course_id} with no course set
@@ -413,7 +413,7 @@ class TestNonStandardCourseStructure(MobileAPITestCase, TestVideoAPIMixin, Miles
         )
 
 
-@attr(shard=2)
+@attr(shard=9)
 @ddt.ddt
 class TestVideoSummaryList(TestVideoAPITestCase, MobileAuthTestMixin, MobileCourseAccessTestMixin,
                            TestVideoAPIMixin, MilestonesTestCaseMixin):
@@ -944,7 +944,7 @@ class TestVideoSummaryList(TestVideoAPITestCase, MobileAuthTestMixin, MobileCour
         self.assertItemsEqual(course_outline[0]['summary']['transcripts'].keys(), expected_transcripts)
 
 
-@attr(shard=2)
+@attr(shard=9)
 class TestTranscriptsDetail(TestVideoAPITestCase, MobileAuthTestMixin, MobileCourseAccessTestMixin,
                             TestVideoAPIMixin, MilestonesTestCaseMixin):
     """

--- a/lms/djangoapps/oauth2_handler/tests.py
+++ b/lms/djangoapps/oauth2_handler/tests.py
@@ -15,6 +15,7 @@ from xmodule.modulestore.tests.factories import CourseFactory, check_mongo_calls
 
 
 class BaseTestMixin(ModuleStoreTestCase):
+    shard = 6
     profile = None
     ENABLED_SIGNALS = ['course_published']
 
@@ -31,6 +32,8 @@ class BaseTestMixin(ModuleStoreTestCase):
 
 
 class IDTokenTest(BaseTestMixin, IDTokenTestCase):
+    shard = 6
+
     def setUp(self):
         super(IDTokenTest, self).setUp()
 
@@ -144,6 +147,8 @@ class IDTokenTest(BaseTestMixin, IDTokenTestCase):
 
 
 class UserInfoTest(BaseTestMixin, UserInfoTestCase):
+    shard = 6
+
     def setUp(self):
         super(UserInfoTest, self).setUp()
         # create another course in the DB that only global staff have access to

--- a/lms/djangoapps/rss_proxy/tests/test_models.py
+++ b/lms/djangoapps/rss_proxy/tests/test_models.py
@@ -8,6 +8,7 @@ from rss_proxy.models import WhitelistedRssUrl
 
 class WhitelistedRssUrlTests(TestCase):
     """ Tests for the rss_proxy.WhitelistedRssUrl model """
+    shard = 4
 
     def setUp(self):
         super(WhitelistedRssUrlTests, self).setUp()

--- a/lms/djangoapps/rss_proxy/tests/test_views.py
+++ b/lms/djangoapps/rss_proxy/tests/test_views.py
@@ -10,6 +10,7 @@ from rss_proxy.models import WhitelistedRssUrl
 
 class RssProxyViewTests(TestCase):
     """ Tests for the rss_proxy views """
+    shard = 4
 
     def setUp(self):
         super(RssProxyViewTests, self).setUp()

--- a/lms/djangoapps/shoppingcart/management/tests/test_retire_order.py
+++ b/lms/djangoapps/shoppingcart/management/tests/test_retire_order.py
@@ -13,6 +13,8 @@ from xmodule.modulestore.tests.factories import CourseFactory
 
 class TestRetireOrder(ModuleStoreTestCase):
     """Test the retire_order command"""
+    shard = 4
+
     def setUp(self):
         super(TestRetireOrder, self).setUp()
 

--- a/lms/djangoapps/shoppingcart/processors/tests/test_CyberSource.py
+++ b/lms/djangoapps/shoppingcart/processors/tests/test_CyberSource.py
@@ -66,6 +66,7 @@ def fake_site(name, default=None):  # pylint: disable=unused-argument
     CC_PROCESSOR=TEST_CC_PROCESSOR
 )
 class CyberSourceTests(TestCase):
+    shard = 4
 
     def test_override_settings(self):
         self.assertEqual(settings.CC_PROCESSOR['CyberSource']['MERCHANT_ID'], 'edx_test')

--- a/lms/djangoapps/shoppingcart/processors/tests/test_CyberSource2.py
+++ b/lms/djangoapps/shoppingcart/processors/tests/test_CyberSource2.py
@@ -34,6 +34,7 @@ class CyberSource2Test(TestCase):
     to be configured a certain way.
 
     """
+    shard = 4
 
     COST = "10.00"
     CALLBACK_URL = "/test_callback_url"

--- a/lms/djangoapps/shoppingcart/tests/test_configuration_overrides.py
+++ b/lms/djangoapps/shoppingcart/tests/test_configuration_overrides.py
@@ -18,6 +18,8 @@ class TestOrderHistoryOnSiteDashboard(SiteMixin, ModuleStoreTestCase):
     """
     Test for dashboard order history site configuration overrides.
     """
+    shard = 4
+
     def setUp(self):
         super(TestOrderHistoryOnSiteDashboard, self).setUp()
 

--- a/lms/djangoapps/shoppingcart/tests/test_context_processor.py
+++ b/lms/djangoapps/shoppingcart/tests/test_context_processor.py
@@ -17,6 +17,8 @@ class UserCartContextProcessorUnitTest(ModuleStoreTestCase):
     """
     Unit test for shoppingcart context_processor
     """
+    shard = 4
+
     def setUp(self):
         super(UserCartContextProcessorUnitTest, self).setUp()
 

--- a/lms/djangoapps/shoppingcart/tests/test_payment_fake.py
+++ b/lms/djangoapps/shoppingcart/tests/test_payment_fake.py
@@ -16,6 +16,7 @@ class PaymentFakeViewTest(TestCase):
     Test that the fake payment view interacts
     correctly with the shopping cart.
     """
+    shard = 4
 
     def setUp(self):
         super(PaymentFakeViewTest, self).setUp()

--- a/lms/djangoapps/shoppingcart/tests/test_pdf.py
+++ b/lms/djangoapps/shoppingcart/tests/test_pdf.py
@@ -40,6 +40,8 @@ class TestPdfFile(unittest.TestCase):
     """
     Unit test cases for pdf file generation
     """
+    shard = 4
+
     def setUp(self):
         super(TestPdfFile, self).setUp()
 

--- a/lms/djangoapps/shoppingcart/tests/test_reports.py
+++ b/lms/djangoapps/shoppingcart/tests/test_reports.py
@@ -31,6 +31,7 @@ class ReportTypeTests(ModuleStoreTestCase):
     """
     Tests for the models used to generate certificate status reports
     """
+    shard = 4
     FIVE_MINS = datetime.timedelta(minutes=5)
 
     @patch('student.models.CourseEnrollment.refund_cutoff_date')
@@ -164,6 +165,7 @@ class ItemizedPurchaseReportTest(ModuleStoreTestCase):
     """
     Tests for the models used to generate itemized purchase reports
     """
+    shard = 4
     FIVE_MINS = datetime.timedelta(minutes=5)
     TEST_ANNOTATION = u'Ba\xfc\u5305'
 

--- a/lms/djangoapps/static_template_view/tests/test_views.py
+++ b/lms/djangoapps/static_template_view/tests/test_views.py
@@ -10,6 +10,7 @@ from openedx.core.djangoapps.site_configuration.tests.test_util import with_site
 
 class MarketingSiteViewTests(TestCase):
     """ Tests for the marketing site views """
+    shard = 4
 
     def _test_view(self, view_name, mimetype):
         """

--- a/lms/djangoapps/student_account/test/test_views.py
+++ b/lms/djangoapps/student_account/test/test_views.py
@@ -291,7 +291,7 @@ class StudentAccountUpdateTest(CacheIsolationTestCase, UrlResetMixin):
         self.assertFalse(dop_refresh_token.objects.filter(user=user).exists())
 
 
-@attr(shard=3)
+@attr(shard=7)
 @ddt.ddt
 class StudentAccountLoginAndRegistrationTest(ThirdPartyAuthTestMixin, UrlResetMixin, ModuleStoreTestCase):
     """ Tests for the student account views that update the user's account information. """

--- a/lms/djangoapps/support/tests/test_refund.py
+++ b/lms/djangoapps/support/tests/test_refund.py
@@ -26,6 +26,8 @@ class RefundTests(ModuleStoreTestCase):
     """
     Tests for the manual refund page
     """
+    shard = 4
+
     def setUp(self):
         super(RefundTests, self).setUp()
 

--- a/lms/djangoapps/survey/tests/test_models.py
+++ b/lms/djangoapps/survey/tests/test_models.py
@@ -19,6 +19,8 @@ class SurveyModelsTests(TestCase):
     """
     All tests for the Survey models.py file
     """
+    shard = 4
+
     def setUp(self):
         """
         Set up the test data used in the specific tests

--- a/lms/djangoapps/survey/tests/test_utils.py
+++ b/lms/djangoapps/survey/tests/test_utils.py
@@ -17,6 +17,8 @@ class SurveyModelsTests(ModuleStoreTestCase):
     """
     All tests for the utils.py file
     """
+    shard = 4
+
     def setUp(self):
         """
         Set up the test data used in the specific tests

--- a/lms/djangoapps/survey/tests/test_views.py
+++ b/lms/djangoapps/survey/tests/test_views.py
@@ -18,6 +18,8 @@ class SurveyViewsTests(ModuleStoreTestCase):
     """
     All tests for the views.py file
     """
+    shard = 4
+
     def setUp(self):
         """
         Set up the test data used in the specific tests

--- a/lms/djangoapps/teams/management/commands/tests/test_reindex_course_team.py
+++ b/lms/djangoapps/teams/management/commands/tests/test_reindex_course_team.py
@@ -21,6 +21,7 @@ class ReindexCourseTeamTest(SharedModuleStoreTestCase):
     """
     Tests for the ReindexCourseTeam command
     """
+    shard = 4
 
     def setUp(self):
         """

--- a/lms/djangoapps/teams/tests/test_models.py
+++ b/lms/djangoapps/teams/tests/test_models.py
@@ -35,6 +35,7 @@ COURSE_KEY2 = CourseKey.from_string('edx/history/2')
 @ddt.ddt
 class TeamMembershipTest(SharedModuleStoreTestCase):
     """Tests for the TeamMembership model."""
+    shard = 4
 
     def setUp(self):
         """
@@ -117,6 +118,7 @@ class TeamMembershipTest(SharedModuleStoreTestCase):
 @ddt.ddt
 class TeamSignalsTest(EventTestMixin, SharedModuleStoreTestCase):
     """Tests for handling of team-related signals."""
+    shard = 4
 
     SIGNALS = {
         'thread_created': thread_created,

--- a/lms/djangoapps/teams/tests/test_serializers.py
+++ b/lms/djangoapps/teams/tests/test_serializers.py
@@ -33,6 +33,7 @@ class MembershipSerializerTestCase(SerializerTestCase):
     """
     Tests for the membership serializer.
     """
+    shard = 4
 
     def setUp(self):
         super(MembershipSerializerTestCase, self).setUp()
@@ -71,6 +72,8 @@ class TopicSerializerTestCase(SerializerTestCase):
     Tests for the `TopicSerializer`, which should serialize team count data for
     a single topic.
     """
+    shard = 4
+
     def test_topic_with_no_team_count(self):
         """
         Verifies that the `TopicSerializer` correctly displays a topic with a
@@ -119,6 +122,8 @@ class BaseTopicSerializerTestCase(SerializerTestCase):
     """
     Base class for testing the two paginated topic serializers.
     """
+    shard = 4
+
     __test__ = False
     PAGE_SIZE = 5
     # Extending test classes should specify their serializer class.
@@ -174,6 +179,7 @@ class BulkTeamCountTopicSerializerTestCase(BaseTopicSerializerTestCase):
     Tests for the `BulkTeamCountTopicSerializer`, which should serialize team_count
     data for many topics with constant time SQL queries.
     """
+    shard = 4
     __test__ = True
     serializer = BulkTeamCountTopicSerializer
 

--- a/lms/djangoapps/teams/tests/test_views.py
+++ b/lms/djangoapps/teams/tests/test_views.py
@@ -36,6 +36,7 @@ from .factories import LAST_ACTIVITY_AT, CourseTeamFactory
 @attr(shard=1)
 class TestDashboard(SharedModuleStoreTestCase):
     """Tests for the Teams dashboard."""
+    shard = 6
     test_password = "test"
 
     NUM_TOPICS = 10
@@ -200,6 +201,7 @@ class TestDashboard(SharedModuleStoreTestCase):
 class TeamAPITestCase(APITestCase, SharedModuleStoreTestCase):
     """Base class for Team API test cases."""
 
+    shard = 6
     test_password = 'password'
 
     @classmethod
@@ -546,6 +548,7 @@ class TeamAPITestCase(APITestCase, SharedModuleStoreTestCase):
 @ddt.ddt
 class TestListTeamsAPI(EventTestMixin, TeamAPITestCase):
     """Test cases for the team listing API endpoint."""
+    shard = 6
 
     def setUp(self):  # pylint: disable=arguments-differ
         super(TestListTeamsAPI, self).setUp('lms.djangoapps.teams.utils.tracker')
@@ -724,6 +727,7 @@ class TestListTeamsAPI(EventTestMixin, TeamAPITestCase):
 @ddt.ddt
 class TestCreateTeamAPI(EventTestMixin, TeamAPITestCase):
     """Test cases for the team creation endpoint."""
+    shard = 6
 
     def setUp(self):  # pylint: disable=arguments-differ
         super(TestCreateTeamAPI, self).setUp('lms.djangoapps.teams.utils.tracker')
@@ -896,6 +900,7 @@ class TestCreateTeamAPI(EventTestMixin, TeamAPITestCase):
 @ddt.ddt
 class TestDetailTeamAPI(TeamAPITestCase):
     """Test cases for the team detail endpoint."""
+    shard = 6
 
     @ddt.data(
         (None, 401),
@@ -935,6 +940,7 @@ class TestDetailTeamAPI(TeamAPITestCase):
 @ddt.ddt
 class TestDeleteTeamAPI(EventTestMixin, TeamAPITestCase):
     """Test cases for the team delete endpoint."""
+    shard = 6
 
     def setUp(self):  # pylint: disable=arguments-differ
         super(TestDeleteTeamAPI, self).setUp('lms.djangoapps.teams.utils.tracker')
@@ -985,6 +991,7 @@ class TestDeleteTeamAPI(EventTestMixin, TeamAPITestCase):
 @ddt.ddt
 class TestUpdateTeamAPI(EventTestMixin, TeamAPITestCase):
     """Test cases for the team update endpoint."""
+    shard = 6
 
     def setUp(self):  # pylint: disable=arguments-differ
         super(TestUpdateTeamAPI, self).setUp('lms.djangoapps.teams.utils.tracker')
@@ -1061,6 +1068,7 @@ class TestUpdateTeamAPI(EventTestMixin, TeamAPITestCase):
 @ddt.ddt
 class TestListTopicsAPI(TeamAPITestCase):
     """Test cases for the topic listing endpoint."""
+    shard = 6
 
     @ddt.data(
         (None, 401),
@@ -1180,6 +1188,7 @@ class TestListTopicsAPI(TeamAPITestCase):
 @ddt.ddt
 class TestDetailTopicAPI(TeamAPITestCase):
     """Test cases for the topic detail endpoint."""
+    shard = 6
 
     @ddt.data(
         (None, 401),
@@ -1218,6 +1227,7 @@ class TestDetailTopicAPI(TeamAPITestCase):
 @ddt.ddt
 class TestListMembershipAPI(TeamAPITestCase):
     """Test cases for the membership list endpoint."""
+    shard = 6
 
     @ddt.data(
         (None, 401),
@@ -1317,6 +1327,7 @@ class TestListMembershipAPI(TeamAPITestCase):
 @ddt.ddt
 class TestCreateMembershipAPI(EventTestMixin, TeamAPITestCase):
     """Test cases for the membership creation endpoint."""
+    shard = 6
 
     def setUp(self):  # pylint: disable=arguments-differ
         super(TestCreateMembershipAPI, self).setUp('lms.djangoapps.teams.utils.tracker')
@@ -1415,6 +1426,7 @@ class TestCreateMembershipAPI(EventTestMixin, TeamAPITestCase):
 @ddt.ddt
 class TestDetailMembershipAPI(TeamAPITestCase):
     """Test cases for the membership detail endpoint."""
+    shard = 6
 
     @ddt.data(
         (None, 401),
@@ -1481,6 +1493,7 @@ class TestDetailMembershipAPI(TeamAPITestCase):
 @ddt.ddt
 class TestDeleteMembershipAPI(EventTestMixin, TeamAPITestCase):
     """Test cases for the membership deletion endpoint."""
+    shard = 6
 
     def setUp(self):  # pylint: disable=arguments-differ
         super(TestDeleteMembershipAPI, self).setUp('lms.djangoapps.teams.utils.tracker')
@@ -1541,6 +1554,7 @@ class TestDeleteMembershipAPI(EventTestMixin, TeamAPITestCase):
 
 class TestElasticSearchErrors(TeamAPITestCase):
     """Test that the Team API is robust to Elasticsearch connection errors."""
+    shard = 6
 
     ES_ERROR = ConnectionError('N/A', 'connection error', {})
 

--- a/lms/djangoapps/tests/test_utils.py
+++ b/lms/djangoapps/tests/test_utils.py
@@ -11,6 +11,8 @@ from opaque_keys.edx.keys import CourseKey, UsageKey
 
 @ddt.ddt
 class UtilsTests(TestCase):
+    shard = 4
+
     @ddt.data(
         ['edX/DemoX/Demo_Course', CourseKey.from_string('edX/DemoX/Demo_Course'), CourseKey],
         ['course-v1:edX+DemoX+Demo_Course', CourseKey.from_string('course-v1:edX+DemoX+Demo_Course'), CourseKey],

--- a/lms/djangoapps/verify_student/management/commands/tests/test_verify_student.py
+++ b/lms/djangoapps/verify_student/management/commands/tests/test_verify_student.py
@@ -27,6 +27,7 @@ class TestVerifyStudentCommand(MockS3Mixin, TestCase):
     """
     Tests for django admin commands in the verify_student module
     """
+    shard = 4
 
     def setUp(self):
         super(TestVerifyStudentCommand, self).setUp()

--- a/lms/djangoapps/verify_student/tests/test_fake_software_secure.py
+++ b/lms/djangoapps/verify_student/tests/test_fake_software_secure.py
@@ -32,6 +32,8 @@ class SoftwareSecureFakeViewDisabledTest(SoftwareSecureFakeViewTest):
     Test the fake software secure response when feature flag
     'ENABLE_SOFTWARE_SECURE_FAKE' is not enabled.
     """
+    shard = 4
+
     def setUp(self):
         super(SoftwareSecureFakeViewDisabledTest, self).setUp(enable_software_secure_fake=False)
 
@@ -52,6 +54,8 @@ class SoftwareSecureFakeViewEnabledTest(SoftwareSecureFakeViewTest):
     Test the fake software secure response when feature flag
     'ENABLE_SOFTWARE_SECURE_FAKE' is enabled.
     """
+    shard = 4
+
     def setUp(self):
         super(SoftwareSecureFakeViewEnabledTest, self).setUp(enable_software_secure_fake=True)
 

--- a/lms/djangoapps/verify_student/tests/test_integration.py
+++ b/lms/djangoapps/verify_student/tests/test_integration.py
@@ -15,6 +15,7 @@ class TestProfEdVerification(ModuleStoreTestCase):
     """
     Integration test for professional ed verification, including course mode selection.
     """
+    shard = 4
 
     # Choose an uncommon number for the price so we can search for it on the page
     MIN_PRICE = 1438

--- a/lms/djangoapps/verify_student/tests/test_models.py
+++ b/lms/djangoapps/verify_student/tests/test_models.py
@@ -129,6 +129,7 @@ class TestVerification(TestCase):
 @patch('lms.djangoapps.verify_student.models.requests.post', new=mock_software_secure_post)
 @ddt.ddt
 class TestPhotoVerification(TestVerification, MockS3Mixin, ModuleStoreTestCase):
+    shard = 4
 
     def setUp(self):
         super(TestPhotoVerification, self).setUp()
@@ -390,6 +391,7 @@ class VerificationDeadlineTest(CacheIsolationTestCase):
     """
     Tests for the VerificationDeadline model.
     """
+    shard = 4
 
     ENABLED_CACHES = ['default']
 

--- a/lms/djangoapps/verify_student/tests/test_services.py
+++ b/lms/djangoapps/verify_student/tests/test_services.py
@@ -33,6 +33,7 @@ class TestIDVerificationService(MockS3Mixin, ModuleStoreTestCase):
     """
     Tests for IDVerificationService.
     """
+    shard = 4
 
     def test_user_is_verified(self):
         """

--- a/lms/djangoapps/verify_student/tests/test_signals.py
+++ b/lms/djangoapps/verify_student/tests/test_signals.py
@@ -16,6 +16,7 @@ class VerificationDeadlineSignalTest(ModuleStoreTestCase):
     """
     Tests for the VerificationDeadline signal
     """
+    shard = 4
 
     def setUp(self):
         super(VerificationDeadlineSignalTest, self).setUp()

--- a/lms/djangoapps/verify_student/tests/test_utils.py
+++ b/lms/djangoapps/verify_student/tests/test_utils.py
@@ -27,6 +27,7 @@ class TestVerifyStudentUtils(unittest.TestCase):
     """
     Tests for utility functions in verify_student.
     """
+    shard = 4
 
     def test_verification_for_datetime(self):
         user = UserFactory.create()

--- a/lms/djangoapps/verify_student/tests/test_views.py
+++ b/lms/djangoapps/verify_student/tests/test_views.py
@@ -1101,6 +1101,7 @@ class TestPayAndVerifyView(UrlResetMixin, ModuleStoreTestCase, XssTestMixin):
         self.assertNotEqual(httpretty.last_request().headers, {})
 
 
+@attr(shard=2)
 class CheckoutTestMixin(object):
     """
     Mixin implementing test methods that should behave identically regardless

--- a/lms/lib/courseware_search/test/test_lms_filter_generator.py
+++ b/lms/lib/courseware_search/test/test_lms_filter_generator.py
@@ -12,6 +12,7 @@ from xmodule.modulestore.tests.factories import CourseFactory, ItemFactory
 
 class LmsSearchFilterGeneratorTestCase(ModuleStoreTestCase):
     """ Tests for search result processor """
+    shard = 5
 
     def build_courses(self):
         """

--- a/lms/lib/courseware_search/test/test_lms_result_processor.py
+++ b/lms/lib/courseware_search/test/test_lms_result_processor.py
@@ -9,6 +9,7 @@ from xmodule.modulestore.tests.factories import CourseFactory, ItemFactory
 
 class LmsSearchResultProcessorTestCase(ModuleStoreTestCase):
     """ Test case class to test search result processor """
+    shard = 5
 
     def build_course(self):
         """

--- a/lms/lib/tests/test_utils.py
+++ b/lms/lib/tests/test_utils.py
@@ -11,6 +11,8 @@ class LmsUtilsTest(ModuleStoreTestCase):
     """
     Tests for the LMS utility functions
     """
+    shard = 4
+
     def setUp(self):
         """
         Setup a dummy course content.

--- a/lms/lib/xblock/test/test_mixin.py
+++ b/lms/lib/xblock/test/test_mixin.py
@@ -64,6 +64,7 @@ class LmsXBlockMixinTestCase(ModuleStoreTestCase):
         self.store.update_item(block, 1)
 
 
+@attr(shard=5)
 class XBlockValidationTest(LmsXBlockMixinTestCase):
     """
     Unit tests for XBlock validation
@@ -273,6 +274,7 @@ class XBlockValidationTest(LmsXBlockMixinTestCase):
         )
 
 
+@attr(shard=5)
 class OpenAssessmentBlockMixinTestCase(ModuleStoreTestCase):
     """
     Tests for OpenAssessmentBlock mixin.
@@ -295,7 +297,7 @@ class OpenAssessmentBlockMixinTestCase(ModuleStoreTestCase):
         self.assertTrue(self.open_assessment.has_score)
 
 
-@attr(shard=3)
+@attr(shard=5)
 @ddt.ddt
 class XBlockGetParentTest(LmsXBlockMixinTestCase):
     """
@@ -388,7 +390,7 @@ def ddt_named(parent, child):
     return args
 
 
-@attr(shard=3)
+@attr(shard=5)
 @ddt.ddt
 class XBlockMergedGroupAccessTest(LmsXBlockMixinTestCase):
     """

--- a/lms/tests.py
+++ b/lms/tests.py
@@ -21,6 +21,7 @@ class LmsModuleTests(TestCase):
     """
     Tests for lms module itself.
     """
+    shard = 5
 
     def test_new_mimetypes(self):
         extensions = ['eot', 'otf', 'ttf', 'woff']
@@ -33,6 +34,7 @@ class TemplateLookupTests(TestCase):
     """
     Tests for TemplateLookup.
     """
+    shard = 5
 
     def test_add_lookup_to_main(self):
         """Test that any template directories added are not cleared when microsites are enabled."""
@@ -50,6 +52,8 @@ class TemplateLookupTests(TestCase):
 @patch.dict('django.conf.settings.FEATURES', {'ENABLE_FEEDBACK_SUBMISSION': True})
 class HelpModalTests(ModuleStoreTestCase):
     """Tests for the help modal"""
+    shard = 5
+
     def setUp(self):
         super(HelpModalTests, self).setUp()
         self.course = CourseFactory.create()

--- a/openedx/core/djangoapps/bookmarks/tests/test_api.py
+++ b/openedx/core/djangoapps/bookmarks/tests/test_api.py
@@ -37,7 +37,7 @@ class BookmarkApiEventTestMixin(object):
         self.assertFalse(mock_tracker.called)  # pylint: disable=maybe-no-member
 
 
-@attr(shard=2)
+@attr(shard=9)
 @ddt.ddt
 @skip_unless_lms
 @pytest.mark.django111_expected_failure

--- a/openedx/core/djangoapps/bookmarks/tests/test_models.py
+++ b/openedx/core/djangoapps/bookmarks/tests/test_models.py
@@ -225,7 +225,7 @@ class BookmarksTestsBase(ModuleStoreTestCase):
             self.assertEqual(bookmark_data['path'], bookmark.path)
 
 
-@attr(shard=2)
+@attr(shard=9)
 @ddt.ddt
 @skip_unless_lms
 class BookmarkModelTests(BookmarksTestsBase):
@@ -417,7 +417,7 @@ class BookmarkModelTests(BookmarksTestsBase):
             self.assertEqual(bookmark.path, [])
 
 
-@attr(shard=2)
+@attr(shard=9)
 @ddt.ddt
 class XBlockCacheModelTest(ModuleStoreTestCase):
     """

--- a/openedx/core/djangoapps/bookmarks/tests/test_services.py
+++ b/openedx/core/djangoapps/bookmarks/tests/test_services.py
@@ -11,7 +11,7 @@ from ..services import BookmarksService
 from .test_models import BookmarksTestsBase
 
 
-@attr(shard=2)
+@attr(shard=9)
 @skip_unless_lms
 @pytest.mark.django111_expected_failure
 class BookmarksServiceTests(BookmarksTestsBase):

--- a/openedx/core/djangoapps/bookmarks/tests/test_tasks.py
+++ b/openedx/core/djangoapps/bookmarks/tests/test_tasks.py
@@ -12,7 +12,7 @@ from ..tasks import _calculate_course_xblocks_data, _update_xblocks_cache
 from .test_models import BookmarksTestsBase
 
 
-@attr(shard=2)
+@attr(shard=9)
 @ddt.ddt
 @pytest.mark.django111_expected_failure
 class XBlockCacheTaskTests(BookmarksTestsBase):

--- a/openedx/core/djangoapps/bookmarks/tests/test_views.py
+++ b/openedx/core/djangoapps/bookmarks/tests/test_views.py
@@ -63,7 +63,7 @@ class BookmarksViewsTestsBase(BookmarksTestsBase, BookmarkApiEventTestMixin):
         return response
 
 
-@attr(shard=2)
+@attr(shard=9)
 @ddt.ddt
 @skip_unless_lms
 @pytest.mark.django111_expected_failure
@@ -369,7 +369,7 @@ class BookmarksListViewTests(BookmarksViewsTestsBase):
         )
 
 
-@attr(shard=2)
+@attr(shard=9)
 @ddt.ddt
 @skip_unless_lms
 @pytest.mark.django111_expected_failure

--- a/openedx/core/djangoapps/schedules/management/commands/tests/test_send_course_update.py
+++ b/openedx/core/djangoapps/schedules/management/commands/tests/test_send_course_update.py
@@ -32,6 +32,7 @@ from xmodule.modulestore.tests.factories import CourseFactory, ItemFactory
     "Can't test schedules if the app isn't installed",
 )
 class TestSendCourseUpdate(ScheduleUpsellTestMixin, ScheduleSendEmailTestMixin, ModuleStoreTestCase):
+    shard = 6
     __test__ = True
 
     # pylint: disable=protected-access

--- a/openedx/core/djangoapps/schedules/management/commands/tests/test_send_email_base_command.py
+++ b/openedx/core/djangoapps/schedules/management/commands/tests/test_send_email_base_command.py
@@ -16,6 +16,8 @@ from openedx.core.djangolib.testing.utils import CacheIsolationTestCase, skip_un
 @skipUnless('openedx.core.djangoapps.schedules.apps.SchedulesConfig' in settings.INSTALLED_APPS,
             "Can't test schedules if the app isn't installed")
 class TestSendEmailBaseCommand(CacheIsolationTestCase):
+    shard = 6
+
     def setUp(self):
         self.command = SendEmailBaseCommand()
         self.site = SiteFactory()

--- a/openedx/core/djangoapps/schedules/management/commands/tests/test_send_recurring_nudge.py
+++ b/openedx/core/djangoapps/schedules/management/commands/tests/test_send_recurring_nudge.py
@@ -24,6 +24,7 @@ from openedx.core.djangolib.testing.utils import skip_unless_lms, CacheIsolation
     "Can't test schedules if the app isn't installed",
 )
 class TestSendRecurringNudge(ScheduleUpsellTestMixin, ScheduleSendEmailTestMixin, CacheIsolationTestCase):
+    shard = 6
     __test__ = True
 
     # pylint: disable=protected-access

--- a/openedx/core/djangoapps/schedules/management/commands/tests/test_send_upgrade_reminder.py
+++ b/openedx/core/djangoapps/schedules/management/commands/tests/test_send_upgrade_reminder.py
@@ -31,6 +31,7 @@ LOG = logging.getLogger(__name__)
 @skipUnless('openedx.core.djangoapps.schedules.apps.SchedulesConfig' in settings.INSTALLED_APPS,
             "Can't test schedules if the app isn't installed")
 class TestUpgradeReminder(ScheduleSendEmailTestMixin, CacheIsolationTestCase):
+    shard = 6
     __test__ = True
 
     resolver = resolvers.UpgradeReminderResolver

--- a/openedx/tests/xblock_integration/test_crowdsource_hinter.py
+++ b/openedx/tests/xblock_integration/test_crowdsource_hinter.py
@@ -134,7 +134,7 @@ class TestCrowdsourceHinter(SharedModuleStoreTestCase, LoginEnrollmentTestCase):
         self.assert_request_status_code(200, self.course_url)
 
 
-@attr(shard=1)
+@attr(shard=6)
 class TestHinterFunctions(TestCrowdsourceHinter):
     """
     Check that the essential functions of the hinter work as expected.

--- a/openedx/tests/xblock_integration/test_recommender.py
+++ b/openedx/tests/xblock_integration/test_recommender.py
@@ -196,7 +196,7 @@ class TestRecommender(SharedModuleStoreTestCase, LoginEnrollmentTestCase):
         self.assert_request_status_code(200, self.course_url)
 
 
-@attr(shard=1)
+@attr(shard=6)
 class TestRecommenderCreateFromEmpty(TestRecommender):
     """
     Check whether we can add resources to an empty database correctly
@@ -223,7 +223,7 @@ class TestRecommenderCreateFromEmpty(TestRecommender):
                 self.assert_request_status_code(200, self.course_url)
 
 
-@attr(shard=1)
+@attr(shard=6)
 class TestRecommenderResourceBase(TestRecommender):
     """Base helper class for tests with resources."""
     def setUp(self):
@@ -256,7 +256,7 @@ class TestRecommenderResourceBase(TestRecommender):
         return resource
 
 
-@attr(shard=1)
+@attr(shard=6)
 class TestRecommenderWithResources(TestRecommenderResourceBase):
     """
     Check whether we can add/edit/flag/export resources correctly
@@ -421,7 +421,7 @@ class TestRecommenderWithResources(TestRecommenderResourceBase):
         self.assert_request_status_code(200, self.course_url)
 
 
-@attr(shard=1)
+@attr(shard=6)
 @ddt
 class TestRecommenderVoteWithResources(TestRecommenderResourceBase):
     """
@@ -535,7 +535,7 @@ class TestRecommenderVoteWithResources(TestRecommenderResourceBase):
         self.check_event_response_by_key('handle_vote', resource, 'newVotes', test_case['new_votes'])
 
 
-@attr(shard=1)
+@attr(shard=6)
 @ddt
 class TestRecommenderStaffFeedbackWithResources(TestRecommenderResourceBase):
     """
@@ -630,7 +630,7 @@ class TestRecommenderStaffFeedbackWithResources(TestRecommenderResourceBase):
         self.check_event_response_by_http_status(test_case['handler'], resource, test_case['status'])
 
 
-@attr(shard=1)
+@attr(shard=6)
 @ddt
 class TestRecommenderFileUploading(TestRecommender):
     """

--- a/openedx/tests/xblock_integration/test_review_xblock.py
+++ b/openedx/tests/xblock_integration/test_review_xblock.py
@@ -191,7 +191,7 @@ class TestReviewXBlock(SharedModuleStoreTestCase, LoginEnrollmentTestCase):
         self.enroll(course, verify=True)
 
 
-@attr(shard=1)
+@attr(shard=6)
 @ddt.ddt
 class TestReviewFunctions(TestReviewXBlock):
     """

--- a/pavelib/tests.py
+++ b/pavelib/tests.py
@@ -133,6 +133,10 @@ def test_system(options, passthrough_options):
         help="Run against which Django version (1.8, 1.9, 1.10, -or- 1.11)."
     ),
     make_option(
+        "--eval-attr", dest="eval_attr",
+        help="Only run tests matching given attribute expression."
+    ),
+    make_option(
         '-c', '--cov-args', default='',
         help='adds as args to coverage for the test run'
     ),

--- a/pavelib/utils/test/suites/pytest_suite.py
+++ b/pavelib/utils/test/suites/pytest_suite.py
@@ -211,6 +211,7 @@ class LibTestSuite(PytestSuite):
         super(LibTestSuite, self).__init__(*args, **kwargs)
         self.append_coverage = kwargs.get('append_coverage', False)
         self.test_id = kwargs.get('test_id', self.root)
+        self.eval_attr = kwargs.get('eval_attr', None)
 
     @property
     def cmd(self):
@@ -234,6 +235,8 @@ class LibTestSuite(PytestSuite):
             cmd.append("--verbose")
         if self.disable_capture:
             cmd.append("-s")
+        if self.eval_attr:
+            cmd.append("-a '{}'".format(self.eval_attr))
         cmd.append(self.test_id)
 
         return self._under_coverage_cmd(cmd)

--- a/scripts/generic-ci-tests.sh
+++ b/scripts/generic-ci-tests.sh
@@ -144,23 +144,7 @@ case "$TEST_SUITE" in
         exit $EXIT
         ;;
 
-    "lms-unit")
-        case "$SHARD" in
-            "all"|[1-4]|"noshard")
-                $TOX bash scripts/unit-tests.sh
-                ;;
-            *)
-                # If no shard is specified, rather than running all tests, create an empty xunit file. This is a
-                # backwards compatibility feature. If a new shard (e.g., shard n) is introduced in the build
-                # system, but the tests are called with the old code, then builds will not fail because the
-                # code is out of date. Instead, there will be an instantly-passing shard.
-                mkdir -p reports/lms
-                emptyxunit "lms/nosetests"
-                ;;
-        esac
-        ;;
-
-    "cms-unit"|"commonlib-unit")
+    "lms-unit"|"cms-unit"|"commonlib-unit")
         $TOX bash scripts/unit-tests.sh
         ;;
 

--- a/scripts/unit-tests.sh
+++ b/scripts/unit-tests.sh
@@ -44,20 +44,64 @@ case "${TEST_SUITE}" in
             "all")
                 paver test_system -s lms --disable_capture ${PAVER_ARGS} ${PARALLEL} 2> lms-tests.log
                 ;;
-            [1-3])
+            [1-9])
                 paver test_system -s lms --disable_capture --eval-attr="shard==$SHARD" ${PAVER_ARGS} ${PARALLEL} 2> lms-tests.${SHARD}.log
                 ;;
-            4|"noshard")
-                paver test_system -s lms --disable_capture --eval-attr='not shard' ${PAVER_ARGS} ${PARALLEL} 2> lms-tests.4.log
+            10|"noshard")
+                paver test_system -s lms --disable_capture --eval-attr='not shard' ${PAVER_ARGS} ${PARALLEL} 2> lms-tests.10.log
+                ;;
+            *)
+                # If no shard is specified, rather than running all tests, create an empty xunit file. This is a
+                # backwards compatibility feature. If a new shard (e.g., shard n) is introduced in the build
+                # system, but the tests are called with the old code, then builds will not fail because the
+                # code is out of date. Instead, there will be an instantly-passing shard.
+                mkdir -p reports/lms
+                emptyxunit "lms/nosetests"
                 ;;
         esac
         ;;
 
     "cms-unit")
-        paver test_system -s cms --disable_capture ${PAVER_ARGS} 2> cms-tests.log
+        case "$SHARD" in
+            "all")
+                paver test_system -s cms --disable_capture ${PAVER_ARGS} 2> cms-tests.log
+                ;;
+            1)
+                paver test_system -s cms --disable_capture --eval-attr="shard==$SHARD" ${PAVER_ARGS} 2> cms-tests.${SHARD}.log
+                ;;
+            2|"noshard")
+                paver test_system -s cms --disable_capture --eval-attr='not shard' ${PAVER_ARGS} 2> cms-tests.2.log
+                ;;
+            *)
+                # If no shard is specified, rather than running all tests, create an empty xunit file. This is a
+                # backwards compatibility feature. If a new shard (e.g., shard n) is introduced in the build
+                # system, but the tests are called with the old code, then builds will not fail because the
+                # code is out of date. Instead, there will be an instantly-passing shard.
+                mkdir -p reports/cms
+                emptyxunit "cms/nosetests"
+                ;;
+        esac
         ;;
 
     "commonlib-unit")
-        paver test_lib --disable_capture ${PAVER_ARGS} 2> common-tests.log
+        case "$SHARD" in
+            "all")
+                paver test_lib --disable_capture ${PAVER_ARGS} 2> common-tests.log
+                ;;
+            [1-2])
+                paver test_lib -l common/lib/xmodule --disable_capture --eval-attr="shard==$SHARD" ${PAVER_ARGS} 2> common-tests.${SHARD}.log
+                ;;
+            3|"noshard")
+                paver test_lib --disable_capture --eval-attr='not shard' ${PAVER_ARGS} 2> common-tests.3.log
+                ;;
+            *)
+                # If no shard is specified, rather than running all tests, create an empty xunit file. This is a
+                # backwards compatibility feature. If a new shard (e.g., shard n) is introduced in the build
+                # system, but the tests are called with the old code, then builds will not fail because the
+                # code is out of date. Instead, there will be an instantly-passing shard.
+                mkdir -p reports/common
+                emptyxunit "common/nosetests"
+                ;;
+        esac
         ;;
 esac


### PR DESCRIPTION
In order to bring test times down, add additional lms, cms and commonlib shards.

Tested on test-jenkins. See: https://test-jenkins.testeng.edx.org/job/edx-platform-python-unittests-pr/43539/

See also:
* https://github.com/edx/jenkins-job-dsl/pull/339
* https://github.com/edx/testeng-ci/pull/145