### PR TITLE
APROACH #3: Remove use of course_structures djangoapp from django_comment_client code.

### DIFF
--- a/lms/djangoapps/django_comment_client/utils.py
+++ b/lms/djangoapps/django_comment_client/utils.py
@@ -169,14 +169,11 @@ def get_cached_discussion_key(course_id, discussion_id):
     map is cached but does not contain discussion_id, returns None. If the discussion id map is not cached for course,
     raises a DiscussionIdMapIsNotCached exception.
     """
-    try:
-        mapping = CourseStructure.objects.get(course_id=course_id).discussion_id_map
-        if not mapping:
-            raise DiscussionIdMapIsNotCached()
-
-        return mapping.get(discussion_id)
-    except CourseStructure.DoesNotExist:
+    discussion_settings = get_course_discussion_settings(course_id)
+    if discussion_settings.discussions_id_map is None:
         raise DiscussionIdMapIsNotCached()
+
+    return discussion_settings.discussions_id_map.get(discussion_id)
 
 
 def get_cached_discussion_id_map(course, discussion_ids, user):


### PR DESCRIPTION
The course_structures module is deprecated and we are targeting removal of it from the edx-platform codebase. This PR removes a course_structures model call from the django_comment_client code which was being used to retrieve the discussion xblock usage key given the discussion ID. The code has been modified to pull the discussions id map from the `CourseDiscussionSettings` model instead.

This PR depends on the following PRs:
https://github.com/edx/edx-platform/pull/18020
https://github.com/edx/edx-platform/pull/18019
https://github.com/edx/edx-platform/pull/18029