### PR TITLE
Fix refundable status for audit orders

### DIFF
--- a/common/djangoapps/enrollment/tests/test_views.py
+++ b/common/djangoapps/enrollment/tests/test_views.py
@@ -1019,6 +1019,23 @@ class EnrollmentTest(EnrollmentTestMixin, ModuleStoreTestCase, APITestCase, Ente
         self.assertEqual(enrollment.mode, mode)
         self.assertEqual(enrollment.attributes.get(namespace='order', name='order_number').value, order_number)
 
+        # Updating an enrollment should update attributes (for audit mode enrollments also)
+        order_number = 'EDX-3000'
+        enrollment_attributes = [{
+            'namespace': 'order',
+            'name': 'order_number',
+            'value': order_number,
+        }]
+        self.assert_enrollment_status(
+            as_server=True,
+            mode='audit',
+            enrollment_attributes=enrollment_attributes
+        )
+        enrollment.refresh_from_db()
+        self.assertTrue(enrollment.is_active)
+        self.assertEqual(enrollment.mode, mode)
+        self.assertEqual(enrollment.attributes.get(namespace='order', name='order_number').value, order_number)
+
 
 @unittest.skipUnless(settings.ROOT_URLCONF == 'lms.urls', 'Test only valid in lms')
 class EnrollmentEmbargoTest(EnrollmentTestMixin, UrlResetMixin, ModuleStoreTestCase):

--- a/common/djangoapps/enrollment/views.py
+++ b/common/djangoapps/enrollment/views.py
@@ -691,13 +691,16 @@ class EnrollmentListView(APIView, ApiKeyPermissionMixIn):
             mode_changed = enrollment and mode is not None and enrollment['mode'] != mode
             active_changed = enrollment and is_active is not None and enrollment['is_active'] != is_active
             missing_attrs = []
+            audit_with_order = False
             if enrollment_attributes:
                 actual_attrs = [
                     u"{namespace}:{name}".format(**attr)
                     for attr in enrollment_attributes
                 ]
                 missing_attrs = set(REQUIRED_ATTRIBUTES.get(mode, [])) - set(actual_attrs)
-            if has_api_key_permissions and (mode_changed or active_changed):
+                audit_with_order = mode == 'audit' and 'order:order_number' in actual_attrs
+            # Remove audit_with_order when no longer needed - implemented for REV-141
+            if has_api_key_permissions and (mode_changed or active_changed or audit_with_order):
                 if mode_changed and active_changed and not is_active:
                     # if the requester wanted to deactivate but specified the wrong mode, fail
                     # the request (on the assumption that the requester had outdated information


### PR DESCRIPTION
I think this works based on what I have seen locally. However, this seems like a quite complex bit of code, so I would appreciate review

Refund status function will only be true if the enrollment attribute table has an order number for the enrollment
https://github.com/edx/edx-platform/blob/master/common/djangoapps/student/models.py#L1751

That attribute is only populated by the ecommerce enrollment fulfillment module which makes a post to the enrollment api
https://github.com/edx/ecommerce/blob/master/ecommerce/extensions/fulfillment/modules.py#L310

However, currently the enrollment api does not update the enrollment with the attribute if the enrollment already exists due to the logic being changed here (probably because the assumption is that it only needs to be updated in situations where the mode or active flag has changed)