### PR TITLE
ENT-908: Hide SSO related messages on login page if user is not in the SSO pipeline.

### DIFF
--- a/lms/templates/student_account/login.underscore
+++ b/lms/templates/student_account/login.underscore
@@ -1,14 +1,15 @@
 <div class="js-form-feedback" aria-live="assertive" tabindex="-1">
 </div>
 
-<% if ( context.createAccountOption !== false && !context.syncLearnerProfileData && !context.enterpriseName) { %>
+<% if ( context.createAccountOption !== false && !context.syncLearnerProfileData && !(context.enterpriseName && context.currentProvider) ) { %>
 <div class="toggle-form">
     <span class="text"><%- gettext("First time here?") %></span>
     <a href="#login" class="form-toggle" data-type="register"><%- gettext("Create an Account.") %></a>
 </div>
 <% } %>
 
-<% if (context.enterpriseName) { %>
+<% // Hide SSO related messages if we are not in the SSO pipeline.  %>
+<% if (context.enterpriseName && context.currentProvider) { %>
     <% if (context.pipelineUserDetails && context.pipelineUserDetails.email) { %>
         <h2><%- gettext("Sign in to continue learning as {email}").replace("{email}", context.pipelineUserDetails.email) %></h2>
     <% } else { %>


### PR DESCRIPTION
**JIRA Ticket:** [ENT-908](https://openedx.atlassian.net/browse/ENT-908)

__Description:__
SSO related messages were appearing on the login page even though the learners coming in from an enterprise coupon were not inside SSO and there the enterprise customer did not have any associated identity provider. This PR fixes that issue.

__Testing Instructions:__
1. Go to Django admin portal to [manage enterprise customer](https://business.sandbox.edx.org/admin/enterprise/enterprisecustomer/) and add a new enterprise customer. Make sure to leave the `Identity Provider:` drop down empty so that no identity provider is associated.
2. Go to [ecommerce coupon creation page](http://ecommerce-business.sandbox.edx.org/coupons) and create a new coupon. 
3. Fill in the required fields for the coupon and make sure to select the newly create enterprise customer for `Enterprise Customer:` dropdown.
4. After creating the coupon, download vouchers CSV by clicking `Download` button under `Download Voucher(s):` section.
5. Make sure you are logged out of E-Commerce and LMS and then copy the voucher redemption URL from CSV file and open it in the browser.
6. Click on the `Checkout` button, you will be redirected to LMS login page.
7. Make sure SSO related messaging does not appear on the login page.