### PR TITLE
upgrade cookie policy banner version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,9 +5,9 @@
   "requires": true,
   "dependencies": {
     "@edx/cookie-policy-banner": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@edx/cookie-policy-banner/-/cookie-policy-banner-1.1.3.tgz",
-      "integrity": "sha512-MIrtCbJj7CZdW+FQ1hLaNcbqbgcoalxIRobBfgYiLa3oaBnmMh3IkwsYUsYz4hjvzXrUQvL+FsJqq/RB8SAZlg==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@edx/cookie-policy-banner/-/cookie-policy-banner-1.1.5.tgz",
+      "integrity": "sha512-V4gjU5Wu0cZFBN1uj0NGO7drHeFune9JaMDzlj5KCXzV9a9OGpqMg3elzKus4LRKJMxHF+qjxIxgUNv2Oro90Q==",
       "requires": {
         "@edx/edx-bootstrap": "0.4.3",
         "@edx/paragon": "2.6.4",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "edx",
   "version": "0.1.0",
   "dependencies": {
-    "@edx/cookie-policy-banner": "^1.1.3",
+    "@edx/cookie-policy-banner": "1.1.5",
     "@edx/edx-bootstrap": "0.4.3",
     "@edx/paragon": "2.6.4",
     "@edx/studio-frontend": "1.7.3",


### PR DESCRIPTION
[@edx/cookie-policy-banner#15](https://github.com/edx/cookie-policy-banner/pull/15) added prefixes to the cookie names like `extra-edx-cookie-policy-viewed` so that there wouldn't be unexpected behavior due to unscoped cookie names across multiple environments (for example, if `localhost`, `stage`, and `prod` all set a cookie with the same name).
