### PR TITLE
EDUCATOR-2774 add new condition for cert eligible column in grade report

### DIFF
--- a/lms/djangoapps/certificates/models.py
+++ b/lms/djangoapps/certificates/models.py
@@ -570,12 +570,13 @@ def certificate_info_for_user(user, course_id, grade, user_is_whitelisted, user_
     """
     certificate_is_delivered = 'N'
     certificate_type = 'N/A'
-    eligible_for_certificate = 'Y' if (user_is_whitelisted or grade is not None) and user.profile.allow_certificate \
-        else 'N'
-
     status = certificate_status(user_certificate)
-    can_have_certificate = CourseOverview.get_from_id(course_id).may_certify()
     certificate_generated = status['status'] == CertificateStatuses.downloadable
+    can_have_certificate = CourseOverview.get_from_id(course_id).may_certify()
+
+    eligible_for_certificate = 'Y' if (user_is_whitelisted or grade is not None or certificate_generated) \
+        and user.profile.allow_certificate else 'N'
+
     if certificate_generated and can_have_certificate:
         certificate_is_delivered = 'Y'
         certificate_type = status['mode']

--- a/lms/djangoapps/certificates/tests/tests.py
+++ b/lms/djangoapps/certificates/tests/tests.py
@@ -90,7 +90,9 @@ class CertificatesModelTest(ModuleStoreTestCase, MilestonesTestCaseMixin):
         {'allow_certificate': True, 'whitelisted': True, 'grade': None, 'output': ['Y', 'Y', 'honor']},
         {'allow_certificate': True, 'whitelisted': False, 'grade': 0.9, 'output': ['Y', 'Y', 'honor']},
         {'allow_certificate': False, 'whitelisted': True, 'grade': 0.8, 'output': ['N', 'Y', 'honor']},
-        {'allow_certificate': False, 'whitelisted': None, 'grade': 0.8, 'output': ['N', 'Y', 'honor']}
+        {'allow_certificate': False, 'whitelisted': None, 'grade': 0.8, 'output': ['N', 'Y', 'honor']},
+        {'allow_certificate': True, 'whitelisted': None, 'grade': None, 'output': ['Y', 'Y', 'honor']},
+        {'allow_certificate': False, 'whitelisted': True, 'grade': None, 'output': ['N', 'Y', 'honor']}
     )
     def test_certificate_info_for_user_when_grade_changes(self, allow_certificate, whitelisted, grade, output):
         """


### PR DESCRIPTION
# [EDUCATOR-2774](https://openedx.atlassian.net/browse/EDUCATOR-2774)

### Description

If the learners did pass, earned a certificate, and then stopped passing, they should retain their certificates and `Certificate Eligible` column will appear with a `Y` value in the grade report.

### Reviewers
If you've been tagged for review, please check your corresponding box once you've given the :+1:.
- [x] Code review: @efischer19 
- [x] Code review: @awaisdar001 

### Post-review
- [x] Rebase and squash commits