### PR TITLE
Fix Nav on CMS Textbook 

### DIFF
--- a/cms/templates/textbooks.html
+++ b/cms/templates/textbooks.html
@@ -27,10 +27,12 @@ CMS.URL.LMS_BASE = "${settings.LMS_BASE}"
 </script>
 </%block>
 
-<%block name="page_bundle">
-  <%static:invoke_page_bundle page_name="js/pages/textbooks" class_name="TextbooksFactory">
-     ${textbooks | n, dump_js_escaped_json}
-  </%static:invoke_page_bundle>
+<%block name="requirejs">
+    require(["js/factories/textbooks"], function (TextbooksFactory) {
+        TextbooksFactory(
+            ${textbooks | n, dump_js_escaped_json}
+        );
+    });
 </%block>
 
 <%block name="content">


### PR DESCRIPTION
Fix the `Textbook` page Navigation did not work.

**Sandbox** :https://studio-awaisdar001.sandbox.edx.org/textbooks/course-v1:edX+DemoX+Demo_Course