### PR TITLE
Reduce rate limit for enrollment api

### DIFF
--- a/common/djangoapps/enrollment/__init__.py
+++ b/common/djangoapps/enrollment/__init__.py
@@ -1,0 +1,9 @@
+"""
+Enrollment API helpers and settings
+"""
+from openedx.core.djangoapps.waffle_utils import (WaffleFlag, WaffleFlagNamespace)
+
+WAFFLE_FLAG_NAMESPACE = WaffleFlagNamespace(name='enrollment_api_rate_limit')
+
+REDUCE_RATE_LIMIT_FOR_STAFF_FOR_ENROLLMENT_API = WaffleFlag(WAFFLE_FLAG_NAMESPACE, 'reduce_staff_rate_limit')
+USE_UNIVERSAL_RATE_LIMIT_FOR_ENROLLMENT_API = WaffleFlag(WAFFLE_FLAG_NAMESPACE, 'use_universal_rate_limit')


### PR DESCRIPTION
https://openedx.atlassian.net/browse/LEARNER-5101

We no longer need the rate limit for staff users. 

Below is the splunk query of the excessive "marketing_site_worker" calls since today. On April 23rd,  https://github.com/edx/ecommerce/pull/1720 was released, we no longer made excessive enrollment api calls from ecommerce to LMS.  
<img width="1069" alt="screen shot 2018-05-01 at 10 23 29 am" src="https://user-images.githubusercontent.com/7101723/39476781-3bd2bc14-4d2b-11e8-90f1-054e64ffcdba.png">

