### PR TITLE
Stop doing pointless things

### DIFF
--- a/lms/djangoapps/discussion/tests/test_views.py
+++ b/lms/djangoapps/discussion/tests/test_views.py
@@ -1140,16 +1140,6 @@ class InlineDiscussionTestCase(ForumsEnableMixin, ModuleStoreTestCase):
             request, text_type(self.course.id), self.discussion1.discussion_id
         )
 
-    def verify_response(self, response):
-        """Verifies that the response contains the appropriate courseware_url and courseware_title"""
-        self.assertEqual(response.status_code, 200)
-        response_data = json.loads(response.content)
-        expected_courseware_title = 'Chapter / Discussion1'
-        self.assertEqual(response_data["discussion_data"][0]["courseware_title"], expected_courseware_title)
-
-    def test_courseware_data(self, mock_request):
-        self.verify_response(self.send_request(mock_request))
-
     def test_context(self, mock_request):
         team = CourseTeamFactory(
             name='Team Name',
@@ -1162,7 +1152,6 @@ class InlineDiscussionTestCase(ForumsEnableMixin, ModuleStoreTestCase):
 
         response = self.send_request(mock_request)
         self.assertEqual(mock_request.call_args[1]['params']['context'], ThreadContext.STANDALONE)
-        self.verify_response(response)
 
 
 @patch('requests.request', autospec=True)

--- a/lms/djangoapps/discussion/views.py
+++ b/lms/djangoapps/discussion/views.py
@@ -217,8 +217,6 @@ def inline_discussion(request, course_key, discussion_id):
             group_names_by_id
         ) for thread in threads
     ]
-    with function_trace("add_courseware_context"):
-        add_courseware_context(threads, course, request.user)
 
     return utils.JsonResponse({
         'is_commentable_divided': is_commentable_divided(course_key, discussion_id),


### PR DESCRIPTION
# [EDUCATOR-2618](https://openedx.atlassian.net/browse/EDUCATOR-2618)

I... I just don't even know what to say anymore.

This function call is terrible in the case of rendering inline discussions for a heavily CCX divided course. Reasoning:
- [`add_courseware_context` calls `get_cached_discussion_id_map`](https://github.com/edx/edx-platform/blob/239177a5f543f2d2beb263e1501299af8acf181d/lms/djangoapps/django_comment_client/utils.py#L697-L701)
- `get_cached_discussion_id_map` (sidebar: why tee eff does this use the `@request_cached` decorator under the covers *and* do some weird exception handling? That makes no sense at all! Just pick one or the other!) will call `has_access` on every visible discussion [as seen here](https://github.com/edx/edx-platform/blob/239177a5f543f2d2beb263e1501299af8acf181d/lms/djangoapps/django_comment_client/utils.py#L196)
- `has_access` calls down into `_has_access_descriptor` [here](https://github.com/edx/edx-platform/blob/1f5c94d9b60ec1a4c3b65e244a5b54f7ac371372/lms/djangoapps/courseware/access.py#L153)
- [`_has_access_descriptor` returns a dispatched map containing `can_load`](https://github.com/edx/edx-platform/blob/1f5c94d9b60ec1a4c3b65e244a5b54f7ac371372/lms/djangoapps/courseware/access.py#L511-L517) for the `"load"` checker ([remember, that's the one we want here](https://github.com/edx/edx-platform/blob/239177a5f543f2d2beb263e1501299af8acf181d/lms/djangoapps/django_comment_client/utils.py#L196)).
- [`can_load` calls `_has_group_access`](https://github.com/edx/edx-platform/blob/1f5c94d9b60ec1a4c3b65e244a5b54f7ac371372/lms/djangoapps/courseware/access.py#L496) - you should be hearing alarm bells internally at this point
- [`_has_group_access` is generally terrible for our purposes, doing each of these steps **per discussion thread**](https://github.com/edx/edx-platform/blob/1f5c94d9b60ec1a4c3b65e244a5b54f7ac371372/lms/djangoapps/courseware/access.py#L402-L470)
  - `resolve the partition IDs in group_access to actual partition objects`
    - fun fact: [this function](https://github.com/edx/edx-platform/blob/1f5c94d9b60ec1a4c3b65e244a5b54f7ac371372/lms/djangoapps/courseware/access.py#L428) is called once per partition, and the for loop it calls [is extra dumb](https://github.com/edx/edx-platform/blob/366cc044be0285c300f7bc8de4809de2f83e6263/lms/djangoapps/lms_xblock/mixin.py#L150-L152)
  - `resolve the group IDs specified within each partition`
  - `look up the user's group for each partition`
  - `check that the user has a satisfactory group assignment`

"But surely all that work is worthwhile!", you may say. Yes, maybe we could optimize it further to be slightly non-terrible, I'm sure we could make "check access for all of these blocks at once using a bulk query" happen.

On the other hand, `add_courseware_context` only adds two variables, `courseware_title` and `courseware_url`. I wonder where those are used, maybe we can stub something cheaper to evaluate into those variables.
- [They're used in this template, guarded by `if mode=="tab"`](https://github.com/edx/edx-platform/blob/61316c3807cbc5aecedb29abec6f21dfdf2b358e/common/static/common/templates/discussion/thread-show.underscore#L56)
- Inline discussions [use `mode="inline"`](https://github.com/edx/edx-platform/blob/239177a5f543f2d2beb263e1501299af8acf181d/common/static/common/js/discussion/views/discussion_inline_view.js#L150), ever since https://github.com/edx/edx-platform/pull/14026/commits/54a9db776dad29449165252a3ca814a8a3b86e6a merged.

So the end result is that we've been wasting all this time in inefficient permissions checks to determine whether or not to include a value that is never used in this context.

I'm going to go take a walk outside.