### PR TITLE
Silence deprecation warnings

### DIFF
--- a/cms/djangoapps/contentstore/api/views.py
+++ b/cms/djangoapps/contentstore/api/views.py
@@ -35,7 +35,7 @@ class CourseImportExportViewMixin(DeveloperErrorViewMixin):
         Ensures that the user is authenticated (e.g. not an AnonymousUser)
         """
         super(CourseImportExportViewMixin, self).perform_authentication(request)
-        if request.user.is_anonymous():
+        if request.user.is_anonymous:
             raise AuthenticationFailed
 
 

--- a/cms/djangoapps/contentstore/views/public.py
+++ b/cms/djangoapps/contentstore/views/public.py
@@ -24,7 +24,7 @@ def signup(request):
     Display the signup form.
     """
     csrf_token = csrf(request)['csrf_token']
-    if request.user.is_authenticated():
+    if request.user.is_authenticated:
         return redirect('/course/')
     if settings.FEATURES.get('AUTH_USE_CERTIFICATES_IMMEDIATE_SIGNUP'):
         # Redirect to course to login to process their certificate if SSL is enabled
@@ -68,7 +68,7 @@ def login_page(request):
 
 def howitworks(request):
     "Proxy view"
-    if request.user.is_authenticated():
+    if request.user.is_authenticated:
         return redirect('/home/')
     else:
         return render_to_response('howitworks.html', {})

--- a/cms/templates/base.html
+++ b/cms/templates/base.html
@@ -110,7 +110,7 @@ from openedx.core.release import RELEASE_LINE
         </div>
       </main>
 
-      % if user.is_authenticated():
+      % if user.is_authenticated:
         <%include file="widgets/sock.html" args="online_help_token=online_help_token" />
       % endif
       <%include file="widgets/footer.html" />
@@ -142,7 +142,7 @@ from openedx.core.release import RELEASE_LINE
         }
       </script>
     % endif
-    % if user.is_authenticated():
+    % if user.is_authenticated:
       <%static:invoke_page_bundle page_name='js/sock'/>
     % endif
     <%block name='page_bundle'>

--- a/cms/templates/widgets/header.html
+++ b/cms/templates/widgets/header.html
@@ -190,7 +190,7 @@
         <nav class="user-language-selector" aria-label="${_('Language preference')}">
           <form action="/i18n/setlang/" method="post" class="settings-language-form" id="language-settings-form">
               <input type="hidden" id="csrf_token" name="csrfmiddlewaretoken" value="${csrf_token}">
-              % if user.is_authenticated():
+              % if user.is_authenticated:
               <input title="preference api" type="hidden" id="preference-api-url" class="url-endpoint" value="${reverse('preferences_api', kwargs={'username': user.username})}" data-user-is-authenticated="true">
               % else:
               <input title="session update url" type="hidden" id="update-session-url" class="url-endpoint" value="${reverse('session_language')}" data-user-is-authenticated="false">
@@ -210,7 +210,7 @@
         </nav>
       % endif
       % endif
-      % if user.is_authenticated():
+      % if user.is_authenticated:
       <nav class="nav-account nav-is-signedin nav-dd ui-right" aria-label="${_('Account')}">
         <h2 class="sr-only">${_("Account Navigation")}</h2>
         <ol>

--- a/cms/templates/widgets/segment-io-footer.html
+++ b/cms/templates/widgets/segment-io-footer.html
@@ -4,7 +4,7 @@
 % if settings.CMS_SEGMENT_KEY:
     <!-- begin segment footer -->
     <script type="text/javascript">
-    % if user.is_authenticated():
+    % if user.is_authenticated:
         // We can't use JQuery's on load method because it
         // screws up RequireJS' JQuery initialization.
         var onLoadCallback = function() {

--- a/common/djangoapps/django_comment_common/models.py
+++ b/common/djangoapps/django_comment_common/models.py
@@ -137,7 +137,7 @@ def permission_blacked_out(course, role_names, permission_name):
 
 def all_permissions_for_user_in_course(user, course_id):  # pylint: disable=invalid-name
     """Returns all the permissions the user has in the given course."""
-    if not user.is_authenticated():
+    if not user.is_authenticated:
         return {}
 
     course = modulestore().get_course(course_id)

--- a/common/djangoapps/enrollment/views.py
+++ b/common/djangoapps/enrollment/views.py
@@ -106,7 +106,7 @@ class EnrollmentUserThrottle(UserRateThrottle, ApiKeyPermissionMixIn):
     def allow_request(self, request, view):
         # Use a special scope for staff to allow for a separate throttle rate
         user = request.user
-        if user.is_authenticated() and (user.is_staff or user.is_superuser):
+        if user.is_authenticated and (user.is_staff or user.is_superuser):
             self.scope = 'staff'
             self.rate = self.get_rate()
             self.num_requests, self.duration = self.parse_rate(self.rate)

--- a/common/djangoapps/student/auth.py
+++ b/common/djangoapps/student/auth.py
@@ -164,7 +164,7 @@ def _check_caller_authority(caller, role):
     :param caller: a user
     :param role: an AccessRole
     """
-    if not (caller.is_authenticated() and caller.is_active):
+    if not (caller.is_authenticated and caller.is_active):
         raise PermissionDenied
     # superuser
     if GlobalStaff().has_user(caller):

--- a/common/djangoapps/student/roles.py
+++ b/common/djangoapps/student/roles.py
@@ -124,7 +124,7 @@ class GlobalStaff(AccessRole):
 
     def add_users(self, *users):
         for user in users:
-            if user.is_authenticated() and user.is_active:
+            if user.is_authenticated and user.is_active:
                 user.is_staff = True
                 user.save()
 
@@ -167,7 +167,7 @@ class RoleBase(AccessRole):
         Return:
             bool identifying if user has that particular role or not
         """
-        if check_user_activation and not (user.is_authenticated() and user.is_active):
+        if check_user_activation and not (user.is_authenticated and user.is_active):
             return False
 
         # pylint: disable=protected-access
@@ -186,7 +186,7 @@ class RoleBase(AccessRole):
         # legit get updated.
         from student.models import CourseAccessRole
         for user in users:
-            if user.is_authenticated() and user.is_active and not self.has_user(user):
+            if user.is_authenticated and user.is_active and not self.has_user(user):
                 entry = CourseAccessRole(user=user, role=self._role_name, course_id=self.course_key, org=self.org)
                 entry.save()
                 if hasattr(user, '_roles'):
@@ -372,7 +372,7 @@ class UserBasedRole(object):
         """
         Return whether the role's user has the configured role access to the passed course
         """
-        if not (self.user.is_authenticated() and self.user.is_active):
+        if not (self.user.is_authenticated and self.user.is_active):
             return False
 
         # pylint: disable=protected-access
@@ -385,7 +385,7 @@ class UserBasedRole(object):
         """
         Grant this object's user the object's role for the supplied courses
         """
-        if self.user.is_authenticated() and self.user.is_active:
+        if self.user.is_authenticated and self.user.is_active:
             for course_key in course_keys:
                 entry = CourseAccessRole(user=self.user, role=self.role, course_id=course_key, org=course_key.org)
                 entry.save()

--- a/common/djangoapps/student/tests/test_authz.py
+++ b/common/djangoapps/student/tests/test_authz.py
@@ -113,7 +113,10 @@ class CreatorGroupTest(TestCase):
 
     def test_add_user_to_group_requires_authenticated(self):
         with self.assertRaises(PermissionDenied):
-            with mock.patch('django.contrib.auth.models.User.is_authenticated') as mock_is_auth:
+            with mock.patch(
+                'django.contrib.auth.models.User.is_authenticated',
+                new_callable=mock.PropertyMock
+            ) as mock_is_auth:
                 mock_is_auth.return_value = False
                 add_users(self.admin, CourseCreatorRole(), self.user)
 
@@ -129,7 +132,10 @@ class CreatorGroupTest(TestCase):
 
     def test_remove_user_from_group_requires_authenticated(self):
         with self.assertRaises(PermissionDenied):
-            with mock.patch('django.contrib.auth.models.User.is_authenticated') as mock_is_auth:
+            with mock.patch(
+                'django.contrib.auth.models.User.is_authenticated',
+                new_callable=mock.PropertyMock
+            ) as mock_is_auth:
                 mock_is_auth.return_value = False
                 remove_users(self.admin, CourseCreatorRole(), self.user)
 

--- a/common/djangoapps/student/views/login.py
+++ b/common/djangoapps/student/views/login.py
@@ -514,7 +514,7 @@ def signin_user(request):
         return external_auth_response
     # Determine the URL to redirect to following login:
     redirect_to = get_next_url_for_login_page(request)
-    if request.user.is_authenticated():
+    if request.user.is_authenticated:
         return redirect(redirect_to)
 
     third_party_auth_error = None

--- a/common/djangoapps/student/views/management.py
+++ b/common/djangoapps/student/views/management.py
@@ -203,7 +203,7 @@ def register_user(request, extra_context=None):
     """
     # Determine the URL to redirect to following login:
     redirect_to = get_next_url_for_login_page(request)
-    if request.user.is_authenticated():
+    if request.user.is_authenticated:
         return redirect(redirect_to)
 
     external_auth_response = external_auth_register(request)
@@ -352,7 +352,7 @@ def change_enrollment(request, check_access=True):
     user = request.user
 
     # Ensure the user is authenticated
-    if not user.is_authenticated():
+    if not user.is_authenticated:
         return HttpResponseForbidden()
 
     # Ensure we received a course_id
@@ -1020,7 +1020,7 @@ def activate_account(request, key):
             # Success message for logged in users.
             message = _('{html_start}Success{html_end} You have activated your account.')
 
-            if not request.user.is_authenticated():
+            if not request.user.is_authenticated:
                 # Success message for logged out users
                 message = _(
                     '{html_start}Success! You have activated your account.{html_end}'
@@ -1054,7 +1054,7 @@ def activate_account_studio(request, key):
             {'csrf': csrf(request)['csrf_token']}
         )
     else:
-        user_logged_in = request.user.is_authenticated()
+        user_logged_in = request.user.is_authenticated
         already_active = True
         if not registration.user.is_active:
             if waffle().is_enabled(PREVENT_AUTH_USER_WRITES):

--- a/common/djangoapps/third_party_auth/pipeline.py
+++ b/common/djangoapps/third_party_auth/pipeline.py
@@ -626,7 +626,7 @@ def set_logged_in_cookies(backend=None, user=None, strategy=None, auth_entry=Non
     to the next pipeline step.
 
     """
-    if not is_api(auth_entry) and user is not None and user.is_authenticated():
+    if not is_api(auth_entry) and user is not None and user.is_authenticated:
         request = strategy.request if strategy else None
         # n.b. for new users, user.is_active may be False at this point; set the cookie anyways.
         if request is not None:

--- a/common/djangoapps/util/cache.py
+++ b/common/djangoapps/util/cache.py
@@ -53,7 +53,7 @@ def cache_if_anonymous(*get_parameters):
             # If that page is cached the authentication doesn't
             # happen, so we disable the cache when that feature is enabled.
             if (
-                not request.user.is_authenticated() and
+                not request.user.is_authenticated and
                 not settings.FEATURES['AUTH_USE_CERTIFICATES']
             ):
                 # Use the cache. The same view accessed through different domain names may

--- a/common/djangoapps/util/milestones_helpers.py
+++ b/common/djangoapps/util/milestones_helpers.py
@@ -215,7 +215,7 @@ def get_required_content(course_key, user):
     if settings.FEATURES.get('MILESTONES_APP'):
         course_run_id = unicode(course_key)
 
-        if user.is_authenticated():
+        if user.is_authenticated:
             # Get all of the outstanding milestones for this course, for this user
             try:
 

--- a/common/djangoapps/util/views.py
+++ b/common/djangoapps/util/views.py
@@ -248,7 +248,7 @@ def _get_zendesk_custom_field_context(request, **kwargs):
         return context
 
     context["course_id"] = course_id
-    if not request.user.is_authenticated():
+    if not request.user.is_authenticated:
         return context
 
     enrollment = CourseEnrollment.get_enrollment(request.user, CourseKey.from_string(course_id))
@@ -388,7 +388,7 @@ def get_feedback_form_context(request):
 
     context["additional_info"] = {}
 
-    if request.user.is_authenticated():
+    if request.user.is_authenticated:
         context["realname"] = request.user.profile.name
         context["email"] = request.user.email
         context["additional_info"]["username"] = request.user.username
@@ -432,7 +432,7 @@ def submit_feedback(request):
 
     required_fields = ["subject", "details"]
 
-    if not request.user.is_authenticated():
+    if not request.user.is_authenticated:
         required_fields += ["name", "email"]
 
     required_field_errs = {
@@ -445,7 +445,7 @@ def submit_feedback(request):
         if field not in request.POST or not request.POST[field]:
             return build_error_response(400, field, required_field_errs[field])
 
-    if not request.user.is_authenticated():
+    if not request.user.is_authenticated:
         try:
             validate_email(request.POST["email"])
         except ValidationError:

--- a/common/djangoapps/xblock_django/user_service.py
+++ b/common/djangoapps/xblock_django/user_service.py
@@ -61,7 +61,7 @@ class DjangoXBlockUserService(UserService):
         """
         xblock_user = XBlockUser(is_current_user=True)
 
-        if django_user is not None and django_user.is_authenticated():
+        if django_user is not None and django_user.is_authenticated:
             # This full_name is dependent on edx-platform's profile implementation
             if hasattr(django_user, 'profile'):
                 full_name = django_user.profile.name

--- a/common/test/test_sites/test_site/templates/static_templates/faq.html
+++ b/common/test/test_sites/test_site/templates/static_templates/faq.html
@@ -136,6 +136,6 @@ from django.core.urlresolvers import reverse
   </section>
 </section>
 
-%if user.is_authenticated():
+%if user.is_authenticated:
 <%include file="../signup_modal.html" />
 %endif

--- a/lms/djangoapps/branding/views.py
+++ b/lms/djangoapps/branding/views.py
@@ -33,7 +33,7 @@ def index(request):
     """
     Redirects to main page -- info page if user authenticated, or marketing if not
     """
-    if request.user.is_authenticated():
+    if request.user.is_authenticated:
         # Only redirect to dashboard if user has
         # courses in his/her dashboard. Otherwise UX is a bit cryptic.
         # In this case, we want to have the user stay on a course catalog

--- a/lms/djangoapps/certificates/views/xqueue.py
+++ b/lms/djangoapps/certificates/views/xqueue.py
@@ -39,7 +39,7 @@ def request_certificate(request):
     then if and only if they pass, do they get a certificate issued.
     """
     if request.method == "POST":
-        if request.user.is_authenticated():
+        if request.user.is_authenticated:
             username = request.user.username
             student = User.objects.get(username=username)
             course_key = CourseKey.from_string(request.POST.get('course_id'))

--- a/lms/djangoapps/commerce/api/v1/permissions.py
+++ b/lms/djangoapps/commerce/api/v1/permissions.py
@@ -19,9 +19,9 @@ class ApiKeyOrModelPermission(BasePermission):
 class IsAuthenticatedOrActivationOverridden(BasePermission):
     """ Considers the account activation override switch when determining the authentication status of the user """
     def has_permission(self, request, view):
-        if not request.user.is_authenticated() and is_account_activation_requirement_disabled():
+        if not request.user.is_authenticated and is_account_activation_requirement_disabled():
             try:
                 request.user = User.objects.get(id=request.session._session_cache['_auth_user_id'])
             except DoesNotExist:
                 pass
-        return request.user.is_authenticated()
+        return request.user.is_authenticated

--- a/lms/djangoapps/commerce/api/v1/views.py
+++ b/lms/djangoapps/commerce/api/v1/views.py
@@ -73,7 +73,7 @@ class OrderView(APIView):
         """ HTTP handler. """
         # If the account activation requirement is disabled for this installation, override the
         # anonymous user object attached to the request with the actual user object (if it exists)
-        if not request.user.is_authenticated() and is_account_activation_requirement_disabled():
+        if not request.user.is_authenticated and is_account_activation_requirement_disabled():
             try:
                 request.user = User.objects.get(id=request.session._session_cache['_auth_user_id'])
             except User.DoesNotExist:

--- a/lms/djangoapps/commerce/utils.py
+++ b/lms/djangoapps/commerce/utils.py
@@ -85,7 +85,7 @@ class EcommerceService(object):
             Boolean
         """
         user_is_active = user.is_active or is_account_activation_requirement_disabled()
-        allow_user = user_is_active or user.is_anonymous()
+        allow_user = user_is_active or user.is_anonymous
         return allow_user and self.config.checkout_on_ecommerce_service
 
     def payment_page_url(self):

--- a/lms/djangoapps/course_goals/api.py
+++ b/lms/djangoapps/course_goals/api.py
@@ -41,7 +41,7 @@ def get_course_goal(user, course_key):
 
     If the user is anonymous or a course goal does not exist, returns None.
     """
-    if user.is_anonymous():
+    if user.is_anonymous:
         return None
 
     course_goals = models.CourseGoal.objects.filter(user=user, course_key=course_key)

--- a/lms/djangoapps/course_wiki/middleware.py
+++ b/lms/djangoapps/course_wiki/middleware.py
@@ -48,7 +48,7 @@ class WikiAccessMiddleware(object):
             return
 
         # wiki pages are login required
-        if not request.user.is_authenticated():
+        if not request.user.is_authenticated:
             return redirect(reverse('signin_user'), next=request.path)
 
         course_id = course_id_from_url(request.path)

--- a/lms/djangoapps/courseware/access.py
+++ b/lms/djangoapps/courseware/access.py
@@ -201,7 +201,7 @@ def _can_view_courseware_with_prerequisites(user, course):  # pylint: disable=in
     return (
         _is_prerequisites_disabled()
         or _has_staff_access_to_descriptor(user, course, course.id)
-        or user.is_anonymous()
+        or user.is_anonymous
         or _has_fulfilled_prerequisites(user, [course.id])
     )
 
@@ -250,7 +250,7 @@ def _can_enroll_courselike(user, courselike):
 
     # If using a registration method to restrict enrollment (e.g., Shibboleth)
     if settings.FEATURES.get('RESTRICT_ENROLL_BY_REG_METHOD') and enrollment_domain:
-        if user is not None and user.is_authenticated() and \
+        if user is not None and user.is_authenticated and \
                 ExternalAuthMap.objects.filter(user=user, external_domain=enrollment_domain):
             debug("Allow: external_auth of " + enrollment_domain)
             reg_method_ok = True
@@ -263,7 +263,7 @@ def _can_enroll_courselike(user, courselike):
     # they may enroll, except if the CEA has already been used by a different user.
     # Note that as dictated by the legacy database schema, the filter call includes
     # a `course_id` kwarg which requires a CourseKey.
-    if user is not None and user.is_authenticated():
+    if user is not None and user.is_authenticated:
         cea = CourseEnrollmentAllowed.objects.filter(email=user.email, course_id=course_key).first()
         if cea and cea.valid_for_user(user):
             return ACCESS_GRANTED
@@ -667,7 +667,7 @@ def _has_access_to_course(user, access_level, course_key):
 
     access_level = string, either "staff" or "instructor"
     """
-    if user is None or (not user.is_authenticated()):
+    if user is None or (not user.is_authenticated):
         debug("Deny: no user or anon user")
         return ACCESS_DENIED
 

--- a/lms/djangoapps/courseware/context_processor.py
+++ b/lms/djangoapps/courseware/context_processor.py
@@ -31,7 +31,7 @@ def user_timezone_locale_prefs(request):
             'user_timezone': None,
             'user_language': None,
         }
-        if hasattr(request, 'user') and request.user.is_authenticated():
+        if hasattr(request, 'user') and request.user.is_authenticated:
             try:
                 user_preferences = get_user_preferences(request.user)
             except (UserNotFound, UserAPIInternalError):

--- a/lms/djangoapps/courseware/entrance_exams.py
+++ b/lms/djangoapps/courseware/entrance_exams.py
@@ -29,7 +29,7 @@ def user_can_skip_entrance_exam(user, course):
     """
     if not course_has_entrance_exam(course):
         return True
-    if not user.is_authenticated():
+    if not user.is_authenticated:
         return False
     if has_access(user, 'staff', course):
         return True
@@ -47,7 +47,7 @@ def user_has_passed_entrance_exam(user, course):
     """
     if not course_has_entrance_exam(course):
         return True
-    if not user.is_authenticated():
+    if not user.is_authenticated:
         return False
     return get_entrance_exam_content(user, course) is None
 

--- a/lms/djangoapps/courseware/middleware.py
+++ b/lms/djangoapps/courseware/middleware.py
@@ -27,7 +27,7 @@ class CacheCourseIdMiddleware(object):
         """
         Add a course_id to user request session.
         """
-        if request.user.is_authenticated():
+        if request.user.is_authenticated:
             match = COURSE_REGEX.match(request.build_absolute_uri())
             course_id = None
             if match:

--- a/lms/djangoapps/courseware/model_data.py
+++ b/lms/djangoapps/courseware/model_data.py
@@ -728,7 +728,7 @@ class FieldDataCache(object):
         """
         Add all `descriptors` to this FieldDataCache.
         """
-        if self.user.is_authenticated():
+        if self.user.is_authenticated:
             self.scorable_locations.update(desc.location for desc in descriptors if desc.has_score)
             for scope, fields in self._fields_to_cache(descriptors).items():
                 if scope not in self.cache:
@@ -815,7 +815,7 @@ class FieldDataCache(object):
         Raises: KeyError if key isn't found in the cache
         """
 
-        if key.scope.user == UserScope.ONE and not self.user.is_anonymous():
+        if key.scope.user == UserScope.ONE and not self.user.is_anonymous:
             # If we're getting user data, we expect that the key matches the
             # user we were constructed for.
             assert key.user_id == self.user.id
@@ -842,7 +842,7 @@ class FieldDataCache(object):
         by_scope = defaultdict(dict)
         for key, value in kv_dict.iteritems():
 
-            if key.scope.user == UserScope.ONE and not self.user.is_anonymous():
+            if key.scope.user == UserScope.ONE and not self.user.is_anonymous:
                 # If we're getting user data, we expect that the key matches the
                 # user we were constructed for.
                 assert key.user_id == self.user.id
@@ -875,7 +875,7 @@ class FieldDataCache(object):
         if self.read_only:
             return
 
-        if key.scope.user == UserScope.ONE and not self.user.is_anonymous():
+        if key.scope.user == UserScope.ONE and not self.user.is_anonymous:
             # If we're getting user data, we expect that the key matches the
             # user we were constructed for.
             assert key.user_id == self.user.id
@@ -896,7 +896,7 @@ class FieldDataCache(object):
         Returns: bool
         """
 
-        if key.scope.user == UserScope.ONE and not self.user.is_anonymous():
+        if key.scope.user == UserScope.ONE and not self.user.is_anonymous:
             # If we're getting user data, we expect that the key matches the
             # user we were constructed for.
             assert key.user_id == self.user.id
@@ -916,7 +916,7 @@ class FieldDataCache(object):
 
         Returns: datetime if there was a modified date, or None otherwise
         """
-        if key.scope.user == UserScope.ONE and not self.user.is_anonymous():
+        if key.scope.user == UserScope.ONE and not self.user.is_anonymous:
             # If we're getting user data, we expect that the key matches the
             # user we were constructed for.
             assert key.user_id == self.user.id

--- a/lms/djangoapps/courseware/module_render.py
+++ b/lms/djangoapps/courseware/module_render.py
@@ -582,7 +582,7 @@ def get_module_system_for_user(
         Returns:
             nothing (but the side effect is that module is re-bound to real_user)
         """
-        if user.is_authenticated():
+        if user.is_authenticated:
             err_msg = ("rebind_noauth_module_to_user can only be called from a module bound to "
                        "an anonymous user")
             log.error(err_msg)
@@ -943,10 +943,10 @@ def handle_xblock_callback(request, course_id, usage_id, handler, suffix=None):
     """
     # NOTE (CCB): Allow anonymous GET calls (e.g. for transcripts). Modifying this view is simpler than updating
     # the XBlocks to use `handle_xblock_callback_noauth`...which is practically identical to this view.
-    if request.method != 'GET' and not request.user.is_authenticated():
+    if request.method != 'GET' and not request.user.is_authenticated:
         return HttpResponseForbidden()
 
-    request.user.known = request.user.is_authenticated()
+    request.user.known = request.user.is_authenticated
 
     try:
         course_key = CourseKey.from_string(course_id)
@@ -1119,7 +1119,7 @@ def xblock_view(request, course_id, usage_id, view_name):
                  " see FEATURES['ENABLE_XBLOCK_VIEW_ENDPOINT']")
         raise Http404
 
-    if not request.user.is_authenticated():
+    if not request.user.is_authenticated:
         raise PermissionDenied
 
     try:

--- a/lms/djangoapps/courseware/tabs.py
+++ b/lms/djangoapps/courseware/tabs.py
@@ -19,7 +19,7 @@ class EnrolledTab(CourseTab):
     """
     @classmethod
     def is_enabled(cls, course, user=None):
-        return user and user.is_authenticated() and \
+        return user and user.is_authenticated and \
             bool(CourseEnrollment.is_enrolled(user, course.id) or has_access(user, 'staff', course, course.id))
 
 
@@ -119,7 +119,7 @@ class TextbookTabsBase(CourseTab):
 
     @classmethod
     def is_enabled(cls, course, user=None):
-        return user is None or user.is_authenticated()
+        return user is None or user.is_authenticated
 
     @classmethod
     def items(cls, course):

--- a/lms/djangoapps/courseware/tests/test_views.py
+++ b/lms/djangoapps/courseware/tests/test_views.py
@@ -512,9 +512,9 @@ class ViewsTestCase(ModuleStoreTestCase):
             self.assertEqual(EcommerceService().is_enabled(AnonymousUser()), False)
 
     def test_user_groups(self):
-        # depreciated function
+        # deprecated function
         mock_user = MagicMock()
-        mock_user.is_authenticated.return_value = False
+        type(mock_user).is_authenticated = PropertyMock(return_value=False)
         self.assertEqual(views.user_groups(mock_user), [])
 
     def test_get_redirect_url(self):

--- a/lms/djangoapps/courseware/user_state_client.py
+++ b/lms/djangoapps/courseware/user_state_client.py
@@ -265,7 +265,7 @@ class DjangoXBlockUserStateClient(XBlockUserStateClient):
         else:
             user = User.objects.get(username=username)
 
-        if user.is_anonymous():
+        if user.is_anonymous:
             # Anonymous users cannot be persisted to the database, so let's just use
             # what we have.
             return

--- a/lms/djangoapps/courseware/views/index.py
+++ b/lms/djangoapps/courseware/views/index.py
@@ -97,7 +97,7 @@ class CoursewareIndex(View):
         """
         self.course_key = CourseKey.from_string(course_id)
 
-        if not (request.user.is_authenticated() or self.enable_anonymous_courseware_access):
+        if not (request.user.is_authenticated or self.enable_anonymous_courseware_access):
             return redirect_to_login(request.get_full_path())
 
         self.original_chapter_url_name = chapter
@@ -156,7 +156,7 @@ class CoursewareIndex(View):
                 self._save_positions()
                 self._prefetch_and_bind_section()
 
-        if not request.user.is_authenticated():
+        if not request.user.is_authenticated:
             qs = urllib.urlencode({
                 'course_id': self.course_key,
                 'enrollment_action': 'enroll',
@@ -218,7 +218,7 @@ class CoursewareIndex(View):
         """
         redeemed_registration_codes = []
 
-        if self.request.user.is_authenticated():
+        if self.request.user.is_authenticated:
             self.real_user = User.objects.prefetch_related("groups").get(id=self.real_user.id)
             redeemed_registration_codes = CourseRegistrationCode.objects.filter(
                 course_id=self.course_key,
@@ -255,7 +255,7 @@ class CoursewareIndex(View):
         """
         language_preference = settings.LANGUAGE_CODE
 
-        if self.request.user.is_authenticated():
+        if self.request.user.is_authenticated:
             language_preference = get_user_preference(self.real_user, LANGUAGE_KEY)
 
         return language_preference
@@ -484,12 +484,12 @@ class CoursewareIndex(View):
 
         # NOTE (CCB): Pull the position from the URL for un-authenticated users. Otherwise, pull the saved
         # state from the data store.
-        position = None if self.request.user.is_authenticated() else self.position
+        position = None if self.request.user.is_authenticated else self.position
         section_context = {
             'activate_block_id': self.request.GET.get('activate_block_id'),
             'requested_child': self.request.GET.get("child"),
             'progress_url': reverse('progress', kwargs={'course_id': unicode(self.course_key)}),
-            'user_authenticated': self.request.user.is_authenticated(),
+            'user_authenticated': self.request.user.is_authenticated,
             'position': position,
         }
         if previous_of_active_section:

--- a/lms/djangoapps/courseware/views/views.py
+++ b/lms/djangoapps/courseware/views/views.py
@@ -185,7 +185,7 @@ def user_groups(user):
     """
     TODO (vshnayder): This is not used. When we have a new plan for groups, adjust appropriately.
     """
-    if not user.is_authenticated():
+    if not user.is_authenticated:
         return []
 
     # TODO: Rewrite in Django
@@ -335,7 +335,7 @@ def course_info(request, course_id):
         # LEARNER-1697: Transition banner messages to new Course Home (DONE)
         # if user is not enrolled in a course then app will show enroll/get register link inside course info page.
         user_is_enrolled = CourseEnrollment.is_enrolled(user, course.id)
-        show_enroll_banner = request.user.is_authenticated() and not user_is_enrolled
+        show_enroll_banner = request.user.is_authenticated and not user_is_enrolled
 
         # If the user is not enrolled but this is a course that does not support
         # direct enrollment then redirect them to the dashboard.
@@ -358,7 +358,7 @@ def course_info(request, course_id):
         # Construct the dates fragment
         dates_fragment = None
 
-        if request.user.is_authenticated():
+        if request.user.is_authenticated:
             # TODO: LEARNER-611: Remove enable_course_home_improvements
             if SelfPacedConfiguration.current().enable_course_home_improvements:
                 # Shared code with the new Course Home (DONE)
@@ -520,7 +520,7 @@ class CourseTabView(EdxFragmentView):
         """
         Register messages to be shown to the user if they have limited access.
         """
-        if request.user.is_anonymous():
+        if request.user.is_anonymous:
             PageLevelMessages.register_warning_message(
                 request,
                 Text(_("To see course content, {sign_in_link} or {register_link}.")).format(
@@ -677,7 +677,7 @@ def registered_for_course(course, user):
     """
     if user is None:
         return False
-    if user.is_authenticated():
+    if user.is_authenticated:
         return CourseEnrollment.is_enrolled(user, course.id)
     else:
         return False
@@ -785,7 +785,7 @@ def course_about(request, course_id):
 
         _is_shopping_cart_enabled = is_shopping_cart_enabled()
         if _is_shopping_cart_enabled:
-            if request.user.is_authenticated():
+            if request.user.is_authenticated:
                 cart = shoppingcart.models.Order.get_cart_for_user(request.user)
                 in_cart = shoppingcart.models.PaidCourseRegistration.contained_in_order(cart, course_key) or \
                     shoppingcart.models.CourseRegCodeItem.contained_in_order(cart, course_key)
@@ -1360,7 +1360,7 @@ def generate_user_cert(request, course_id):
 
     """
 
-    if not request.user.is_authenticated():
+    if not request.user.is_authenticated:
         log.info(u"Anon user trying to generate certificate for %s", course_id)
         return HttpResponseBadRequest(
             _('You must be signed in to {platform_name} to create a certificate.').format(

--- a/lms/djangoapps/django_comment_client/base/views.py
+++ b/lms/djangoapps/django_comment_client/base/views.py
@@ -752,7 +752,7 @@ def upload(request, course_id):  # ajax upload file to a question or answer
     try:
         # TODO authorization
         #may raise exceptions.PermissionDenied
-        #if request.user.is_anonymous():
+        #if request.user.is_anonymous:
         #    msg = _('Sorry, anonymous users cannot upload files')
         #    raise exceptions.PermissionDenied(msg)
 

--- a/lms/djangoapps/edxnotes/plugins.py
+++ b/lms/djangoapps/edxnotes/plugins.py
@@ -30,7 +30,7 @@ class EdxNotesTab(EnrolledTab):
         if not settings.FEATURES.get("ENABLE_EDXNOTES") or is_harvard_notes_enabled(course):
             return False
 
-        if user and not user.is_authenticated():
+        if user and not user.is_authenticated:
             return False
 
         return course.edxnotes

--- a/lms/djangoapps/experiments/utils.py
+++ b/lms/djangoapps/experiments/utils.py
@@ -32,7 +32,7 @@ def check_and_get_upgrade_link_and_date(user, enrollment=None, course=None):
     if enrollment is None:
         enrollment = CourseEnrollment.get_enrollment(user, course.id)
 
-    if user.is_authenticated() and verified_upgrade_link_is_valid(enrollment):
+    if user.is_authenticated and verified_upgrade_link_is_valid(enrollment):
         return (
             verified_upgrade_deadline_link(user, course),
             enrollment.upgrade_deadline

--- a/lms/djangoapps/grades/api/views.py
+++ b/lms/djangoapps/grades/api/views.py
@@ -105,7 +105,7 @@ class GradeViewMixin(DeveloperErrorViewMixin):
         Ensures that the user is authenticated (e.g. not an AnonymousUser), unless DEBUG mode is enabled.
         """
         super(GradeViewMixin, self).perform_authentication(request)
-        if request.user.is_anonymous():
+        if request.user.is_anonymous:
             raise AuthenticationFailed
 
 

--- a/lms/djangoapps/learner_dashboard/programs.py
+++ b/lms/djangoapps/learner_dashboard/programs.py
@@ -39,7 +39,7 @@ class ProgramsFragmentView(EdxFragmentView):
             mobile_only = False
 
         programs_config = kwargs.get('programs_config') or ProgramsApiConfig.current()
-        if not programs_config.enabled or not user.is_authenticated():
+        if not programs_config.enabled or not user.is_authenticated:
             raise Http404
 
         meter = ProgramProgressMeter(request.site, user, mobile_only=mobile_only)
@@ -76,7 +76,7 @@ class ProgramDetailsFragmentView(EdxFragmentView):
     def render_to_fragment(self, request, program_uuid, **kwargs):
         """View details about a specific program."""
         programs_config = kwargs.get('programs_config') or ProgramsApiConfig.current()
-        if not programs_config.enabled or not request.user.is_authenticated():
+        if not programs_config.enabled or not request.user.is_authenticated:
             raise Http404
 
         meter = ProgramProgressMeter(request.site, request.user, uuid=program_uuid)

--- a/lms/djangoapps/lti_provider/tests/test_users.py
+++ b/lms/djangoapps/lti_provider/tests/test_users.py
@@ -116,7 +116,7 @@ class AuthenticateLtiUserTest(TestCase):
     def test_authentication_with_authenticated_user(self, create_user, switch_user):
         lti_user = self.create_lti_user_model()
         self.request.user = lti_user.edx_user
-        assert self.request.user.is_authenticated()
+        assert self.request.user.is_authenticated
         users.authenticate_lti_user(self.request, self.lti_user_id, self.lti_consumer)
         self.assertFalse(create_user.called)
         self.assertFalse(switch_user.called)
@@ -133,7 +133,7 @@ class AuthenticateLtiUserTest(TestCase):
     def test_authentication_with_wrong_user(self, create_user, switch_user):
         lti_user = self.create_lti_user_model()
         self.request.user = self.old_user
-        assert self.request.user.is_authenticated()
+        assert self.request.user.is_authenticated
         users.authenticate_lti_user(self.request, self.lti_user_id, self.lti_consumer)
         self.assertFalse(create_user.called)
         switch_user.assert_called_with(self.request, lti_user, self.lti_consumer)

--- a/lms/djangoapps/lti_provider/tests/test_users.py
+++ b/lms/djangoapps/lti_provider/tests/test_users.py
@@ -8,7 +8,7 @@ from django.contrib.auth.models import User
 from django.core.exceptions import PermissionDenied
 from django.test import TestCase
 from django.test.client import RequestFactory
-from mock import MagicMock, patch
+from mock import MagicMock, patch, PropertyMock
 
 import lti_provider.users as users
 from lti_provider.models import LtiConsumer, LtiUser
@@ -124,7 +124,7 @@ class AuthenticateLtiUserTest(TestCase):
     def test_authentication_with_unauthenticated_user(self, create_user, switch_user):
         lti_user = self.create_lti_user_model()
         self.request.user = lti_user.edx_user
-        with patch('django.contrib.auth.models.User.is_authenticated') as mock_is_auth:
+        with patch('django.contrib.auth.models.User.is_authenticated', new_callable=PropertyMock) as mock_is_auth:
             mock_is_auth.return_value = False
             users.authenticate_lti_user(self.request, self.lti_user_id, self.lti_consumer)
             self.assertFalse(create_user.called)

--- a/lms/djangoapps/lti_provider/users.py
+++ b/lms/djangoapps/lti_provider/users.py
@@ -35,7 +35,7 @@ def authenticate_lti_user(request, lti_user_id, lti_consumer):
         # This is the first time that the user has been here. Create an account.
         lti_user = create_lti_user(lti_user_id, lti_consumer)
 
-    if not (request.user.is_authenticated() and
+    if not (request.user.is_authenticated and
             request.user == lti_user.edx_user):
         # The user is not authenticated, or is logged in as somebody else.
         # Switch them to the LTI user

--- a/lms/djangoapps/notification_prefs/views.py
+++ b/lms/djangoapps/notification_prefs/views.py
@@ -123,7 +123,7 @@ def ajax_enable(request):
     user, this has no effect. Otherwise, a preference is created with the
     unsubscribe token (an encryption of the username) as the value.username
     """
-    if not request.user.is_authenticated():
+    if not request.user.is_authenticated:
         raise PermissionDenied
 
     enable_notifications(request.user)
@@ -139,7 +139,7 @@ def ajax_disable(request):
     This view should be invoked by an AJAX POST call. It returns status 204
     (no content) or an error.
     """
-    if not request.user.is_authenticated():
+    if not request.user.is_authenticated:
         raise PermissionDenied
 
     delete_user_preference(request.user, NOTIFICATION_PREF_KEY)
@@ -155,7 +155,7 @@ def ajax_status(request):
     This view should be invoked by an AJAX GET call. It returns status 200,
     with a JSON-formatted payload, or an error.
     """
-    if not request.user.is_authenticated():
+    if not request.user.is_authenticated:
         raise PermissionDenied
 
     qs = UserPreference.objects.filter(

--- a/lms/djangoapps/shoppingcart/context_processor.py
+++ b/lms/djangoapps/shoppingcart/context_processor.py
@@ -23,7 +23,7 @@ def user_has_cart_context_processor(request):
         """
         return (
             # user is logged in and
-            request.user.is_authenticated() and
+            request.user.is_authenticated and
             # do we have the feature turned on
             is_shopping_cart_enabled() and
             # does the user actually have a cart (optimized query to prevent creation of a cart when not needed)

--- a/lms/djangoapps/shoppingcart/models.py
+++ b/lms/djangoapps/shoppingcart/models.py
@@ -170,7 +170,7 @@ class Order(models.Model):
         If a item_type is passed in, then we check to see if the cart has at least one of
         those types of OrderItems
         """
-        if not user.is_authenticated():
+        if not user.is_authenticated:
             return False
         cart = cls.get_cart_for_user(user)
 

--- a/lms/djangoapps/shoppingcart/views.py
+++ b/lms/djangoapps/shoppingcart/views.py
@@ -106,7 +106,7 @@ def add_course_to_cart(request, course_id):
     """
 
     assert isinstance(course_id, basestring)
-    if not request.user.is_authenticated():
+    if not request.user.is_authenticated:
         log.info(u"Anon user trying to add course %s to cart", course_id)
         return HttpResponseForbidden(_('You must be logged-in to add to a shopping cart'))
     cart = Order.get_cart_for_user(request.user)

--- a/lms/djangoapps/student_account/views.py
+++ b/lms/djangoapps/student_account/views.py
@@ -76,7 +76,7 @@ def login_and_registration_form(request, initial_mode="login"):
     # Determine the URL to redirect to following login/registration/third_party_auth
     redirect_to = get_next_url_for_login_page(request)
     # If we're already logged in, redirect to the dashboard
-    if request.user.is_authenticated():
+    if request.user.is_authenticated:
         return redirect(redirect_to)
 
     # Retrieve the form descriptions from the user API
@@ -206,12 +206,12 @@ def password_change_request_handler(request):
 
     user = request.user
     # Prefer logged-in user's email
-    email = user.email if user.is_authenticated() else request.POST.get('email')
+    email = user.email if user.is_authenticated else request.POST.get('email')
 
     if email:
         try:
             request_password_change(email, request.is_secure())
-            user = user if user.is_authenticated() else User.objects.get(email=email)
+            user = user if user.is_authenticated else User.objects.get(email=email)
             destroy_oauth_tokens(user)
         except UserNotFound:
             AUDIT_LOG.info("Invalid password reset attempt")

--- a/lms/djangoapps/support/views/contact_us.py
+++ b/lms/djangoapps/support/views/contact_us.py
@@ -31,7 +31,7 @@ class ContactUsView(View):
             current_site_name = current_site_name.replace(".", "_")
             tags.append("site_name_{site}".format(site=current_site_name))
 
-        if request.user.is_authenticated():
+        if request.user.is_authenticated:
             context['course_id'] = request.session.get('course_id', '')
             context['user_enrollments'] = CourseEnrollment.enrollments_for_user_with_overviews_preload(request.user)
             enterprise_learner_data = enterprise_api.get_enterprise_learner_data(user=request.user)

--- a/lms/djangoapps/survey/models.py
+++ b/lms/djangoapps/survey/models.py
@@ -182,7 +182,7 @@ class SurveyAnswer(TimeStampedModel):
         Returns whether a user has any answers for a given SurveyForm for a course
         This can be used to determine if a user has taken a CourseSurvey.
         """
-        if user.is_anonymous():
+        if user.is_anonymous:
             return False
         return SurveyAnswer.objects.filter(form=form, user=user).exists()
 

--- a/lms/djangoapps/survey/utils.py
+++ b/lms/djangoapps/survey/utils.py
@@ -27,7 +27,7 @@ def is_survey_required_and_unanswered(user, course_descriptor):
         return False
 
     # anonymous users do not need to answer the survey
-    if user.is_anonymous():
+    if user.is_anonymous:
         return False
 
     # course staff do not need to answer survey

--- a/lms/templates/certificates/valid.html
+++ b/lms/templates/certificates/valid.html
@@ -2,7 +2,7 @@
 <%inherit file="accomplishment-base.html" />
 <%! from django.utils.translation import ugettext as _ %>
 
-% if user.is_authenticated() and user.id == int(accomplishment_user_id):
+% if user.is_authenticated and user.id == int(accomplishment_user_id):
 <%include file="_accomplishment-banner.html" />
 % endif
 <%include file="_accomplishment-introduction.html" />

--- a/lms/templates/courseware/course_about.html
+++ b/lms/templates/courseware/course_about.html
@@ -123,7 +123,7 @@ from six import string_types
         </div>
 
         <div class="main-cta">
-        %if user.is_authenticated() and registered:
+        %if user.is_authenticated and registered:
           %if show_courseware_link:
             <a href="${course_target}">
           %endif
@@ -152,7 +152,7 @@ from six import string_types
           <span class="register disabled">${_("Enrollment is Closed")}</span>
         %elif can_add_course_to_cart:
           <%
-          if user.is_authenticated():
+          if user.is_authenticated:
             reg_href = "#"
             reg_element_id = "add_to_cart_post"
           else:

--- a/lms/templates/courseware/courseware.html
+++ b/lms/templates/courseware/courseware.html
@@ -94,7 +94,7 @@ from openedx.features.course_experience import course_home_page_title, COURSE_OU
     var $$course_id = "${course.id | n, js_escaped_string}";
   </script>
 
-  % if not request.user.is_authenticated():
+  % if not request.user.is_authenticated:
       <script type="text/javascript">
         // Disable discussions
         $('.xblock-student_view-discussion button.discussion-show').attr('disabled', true);

--- a/lms/templates/courseware/info.html
+++ b/lms/templates/courseware/info.html
@@ -76,7 +76,7 @@ from openedx.core.djangolib.markup import HTML, Text
         % endif
       </div>
       <div class="info-wrapper">
-      % if user.is_authenticated():
+      % if user.is_authenticated:
         <section class="updates">
           % if studio_url is not None and masquerade and masquerade.role == 'staff':
             <div class="wrap-instructor-info studio-view">

--- a/lms/templates/courseware/syllabus.html
+++ b/lms/templates/courseware/syllabus.html
@@ -18,7 +18,7 @@ from courseware.courses import get_course_syllabus_section
   <div class="syllabus_wrapper">
     <div class="syllabus">
         <h1>${_("Syllabus")}</h1>
-        % if user.is_authenticated():
+        % if user.is_authenticated:
         ${get_course_syllabus_section(course, 'syllabus')}
         % else:
         ${get_course_syllabus_section(course, 'guest_syllabus')}

--- a/lms/templates/discussion/_discussion_inline.html
+++ b/lms/templates/discussion/_discussion_inline.html
@@ -13,7 +13,7 @@ from openedx.core.djangolib.js_utils import js_escaped_string
     data-user-create-comment="${json_dumps(can_create_comment)}"
     data-user-create-subcomment="${json_dumps(can_create_subcomment)}"
     data-read-only="${'false' if can_create_thread else 'true'}">
-    % if not user.is_authenticated():
+    % if not user.is_authenticated:
         <div class="page-banner">
             <div class="alert alert-warning" role="alert">
                 <span class="icon icon-alert fa fa fa-warning" aria-hidden="true"></span>
@@ -32,7 +32,7 @@ from openedx.core.djangolib.js_utils import js_escaped_string
     </div>
     <button class="discussion-show btn"
         data-discussion-id="${discussion_id}"
-        ${"disabled=disabled" if not user.is_authenticated() else ""}>
+        ${"disabled=disabled" if not user.is_authenticated else ""}>
         <span class="button-text">${_("Show Discussion")}</span>
     </button>
 

--- a/lms/templates/header/header.html
+++ b/lms/templates/header/header.html
@@ -47,7 +47,7 @@ from openedx.features.course_experience import ENABLE_GDPR_COMPAT_FLAG
             <span class="line"></span>
             <span class="line"></span>
         </div>
-        % if user.is_authenticated():
+        % if user.is_authenticated:
             <%include file="navbar-authenticated.html" args="online_help_token=online_help_token"/>
         % else:
             <%include file="navbar-not-authenticated.html" args="online_help_token=online_help_token"/>
@@ -76,7 +76,7 @@ from openedx.features.course_experience import ENABLE_GDPR_COMPAT_FLAG
     % if len(languages) > 1:
         <form action="/i18n/setlang/" method="post" class="settings-language-form" id="language-settings-form">
             <input type="hidden" id="csrf_token" name="csrfmiddlewaretoken" value="${csrf_token}">
-            % if user.is_authenticated():
+            % if user.is_authenticated:
                 <input title="preference api" type="hidden" class="url-endpoint" value="${reverse('preferences_api', kwargs={'username': user.username})}" data-user-is-authenticated="true">
             % else:
                 <input title="session update url" type="hidden" class="url-endpoint" value="${reverse('session_language')}" data-user-is-authenticated="false">

--- a/lms/templates/help_modal.html
+++ b/lms/templates/help_modal.html
@@ -93,7 +93,7 @@ from xmodule.tabs import CourseTabList
           <div class="feedback-form-error" aria-live="polite">
               <div id="feedback_error" class="modal-form-error" tabindex="-1"></div>
           </div>
-    % if not user.is_authenticated():
+    % if not user.is_authenticated:
           <label data-field="name" for="feedback_form_name">${_('Name')}*</label>
           <input name="name" type="text" id="feedback_form_name" required>
           <label data-field="email" for="feedback_form_email">${_('E-mail')}*</label>
@@ -241,7 +241,7 @@ $(document).ready(function() {
             return option;
         };
 
-    % if user.is_authenticated():
+    % if user.is_authenticated:
         userAuthenticated = true;
     % endif
 

--- a/lms/templates/navigation/navigation.html
+++ b/lms/templates/navigation/navigation.html
@@ -41,7 +41,7 @@ from openedx.core.djangoapps.lang_pref.api import header_language_selector_is_en
       <button class="navbar-toggler navbar-toggler-right mt-2" type="button" data-toggle="collapse" data-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
         <span class="navbar-toggler-icon"></span>
       </button>
-      % if user.is_authenticated():
+      % if user.is_authenticated:
         <%include file="navbar-authenticated.html" args="online_help_token=online_help_token"/>
       % else:
         <%include file="navbar-not-authenticated.html" args="online_help_token=online_help_token"/>
@@ -52,7 +52,7 @@ from openedx.core.djangoapps.lang_pref.api import header_language_selector_is_en
   <header id="global-navigation" class="header-global ${"slim" if course else ""}" >
     <nav class="wrapper-header" aria-label="${_('Global')}">
       <%include file="navbar-logo-header.html" args="online_help_token=online_help_token"/>
-      % if user.is_authenticated():
+      % if user.is_authenticated:
         <%include file="navbar-authenticated.html" args="online_help_token=online_help_token"/>
       % else:
         <%include file="navbar-not-authenticated.html" args="online_help_token=online_help_token"/>
@@ -64,7 +64,7 @@ from openedx.core.djangoapps.lang_pref.api import header_language_selector_is_en
             <li class="primary">
               <form action="/i18n/setlang/" method="post" class="settings-language-form" id="language-settings-form">
                 <input type="hidden" id="csrf_token" name="csrfmiddlewaretoken" value="${csrf_token}">
-                % if user.is_authenticated():
+                % if user.is_authenticated:
                   <input title="preference api" type="hidden" class="url-endpoint" value="${reverse('preferences_api', kwargs={'username': user.username})}" data-user-is-authenticated="true">
                 % else:
                   <input title="session update url" type="hidden" class="url-endpoint" value="${reverse('session_language')}" data-user-is-authenticated="false">

--- a/lms/templates/support/contact_us.html
+++ b/lms/templates/support/contact_us.html
@@ -39,7 +39,7 @@ from openedx.core.djangolib.js_utils import js_escaped_string, dump_js_escaped_j
             'supportEmail': "${support_email | n, js_escaped_string}",
         }
 
-        % if user.is_authenticated():
+        % if user.is_authenticated:
             context['user'] = {
                 'username': "${user.username | n, js_escaped_string}",
                 'email': "${user.email | n, js_escaped_string}",

--- a/lms/templates/widgets/segment-io-footer.html
+++ b/lms/templates/widgets/segment-io-footer.html
@@ -4,7 +4,7 @@
 % if settings.LMS_SEGMENT_KEY:
     <!-- begin segment footer -->
     <script type="text/javascript">
-    % if user.is_authenticated():
+    % if user.is_authenticated:
         $(window).load(function() {
             analytics.identify(
                 "${ user.id | n, js_escaped_string }",

--- a/openedx/core/djangoapps/bookmarks/api.py
+++ b/openedx/core/djangoapps/bookmarks/api.py
@@ -60,7 +60,7 @@ def get_bookmarks(user, course_key=None, fields=None, serialized=True):
     Returns:
          List of dicts if serialized is True else queryset.
     """
-    if user.is_authenticated():
+    if user.is_authenticated:
         bookmarks_queryset = Bookmark.objects.filter(user=user)
 
         if course_key:

--- a/openedx/core/djangoapps/cache_toolbox/middleware.py
+++ b/openedx/core/djangoapps/cache_toolbox/middleware.py
@@ -9,7 +9,7 @@ avoid querying the database for a ``User`` instance in each request.
 Whilst the built-in ``AuthenticationMiddleware`` mechanism will only obtain the
 ``User`` instance when it is required, the vast majority of sites will do so on
 every page to render "Logged in as 'X'" text as well to evaluate the result of
-``user.is_authenticated()`` and ``user.is_superuser`` to provide conditional
+``user.is_authenticated`` and ``user.is_superuser`` to provide conditional
 functionality.
 
 This middleware eliminates the cost of retrieving this ``User`` instance by

--- a/openedx/core/djangoapps/contentserver/middleware.py
+++ b/openedx/core/djangoapps/contentserver/middleware.py
@@ -255,7 +255,7 @@ class StaticContentServer(object):
         if not self.is_content_locked(content):
             return True
 
-        if not hasattr(request, "user") or not request.user.is_authenticated():
+        if not hasattr(request, "user") or not request.user.is_authenticated:
             return False
 
         if not request.user.is_staff:

--- a/openedx/core/djangoapps/dark_lang/middleware.py
+++ b/openedx/core/djangoapps/dark_lang/middleware.py
@@ -116,7 +116,7 @@ class DarkLangMiddleware(object):
         """
         Check the user's dark language setting in the session and apply it
         """
-        auth_user = request.user.is_authenticated()
+        auth_user = request.user.is_authenticated
         preview_lang = None
         if auth_user:
             # Get the request user's dark lang preference

--- a/openedx/core/djangoapps/dark_lang/views.py
+++ b/openedx/core/djangoapps/dark_lang/views.py
@@ -80,7 +80,7 @@ class PreviewLanguageFragmentView(EdxFragmentView):
         """
         if not DarkLangConfig.current().enabled:
             return False
-        return user and not user.is_anonymous()
+        return user and not user.is_anonymous
 
     def _set_preview_language(self, request):
         """

--- a/openedx/core/djangoapps/external_auth/views.py
+++ b/openedx/core/djangoapps/external_auth/views.py
@@ -401,7 +401,7 @@ def ssl_login_shortcut(func):
             return func(*args, **kwargs)
         request = args[0]
 
-        if request.user and request.user.is_authenticated():  # don't re-authenticate
+        if request.user and request.user.is_authenticated:  # don't re-authenticate
             return func(*args, **kwargs)
 
         cert = ssl_get_cert_from_request(request)
@@ -484,7 +484,7 @@ def cas_login(request, next_page=None, required=False):
 
     ret = django_cas_login(request, next_page, required)
 
-    if request.user.is_authenticated():
+    if request.user.is_authenticated:
         user = request.user
         UserProfile.objects.get_or_create(
             user=user,

--- a/openedx/core/djangoapps/lang_pref/middleware.py
+++ b/openedx/core/djangoapps/lang_pref/middleware.py
@@ -29,7 +29,7 @@ class LanguagePreferenceMiddleware(object):
         """
         cookie_lang = request.COOKIES.get(settings.LANGUAGE_COOKIE, None)
         if cookie_lang:
-            if request.user.is_authenticated():
+            if request.user.is_authenticated:
                 set_user_preference(request.user, LANGUAGE_KEY, cookie_lang)
             else:
                 request._anonymous_user_cookie_lang = cookie_lang
@@ -57,7 +57,7 @@ class LanguagePreferenceMiddleware(object):
         if hasattr(request, 'user'):
             current_user = getattr(request.user, 'real_user', request.user)
 
-        if current_user and current_user.is_authenticated():
+        if current_user and current_user.is_authenticated:
             anonymous_cookie_lang = getattr(request, '_anonymous_user_cookie_lang', None)
             if anonymous_cookie_lang:
                 user_pref = anonymous_cookie_lang

--- a/openedx/core/djangoapps/programs/utils.py
+++ b/openedx/core/djangoapps/programs/utils.py
@@ -572,7 +572,7 @@ class ProgramDataExtender(object):
 
         if is_learner_eligible_for_one_click_purchase:
             courses = self.data['courses']
-            if not self.user.is_anonymous():
+            if not self.user.is_anonymous:
                 courses = self._filter_out_courses_with_enrollments(courses)
                 courses = self._filter_out_courses_with_entitlements(courses)
 
@@ -606,7 +606,7 @@ class ProgramDataExtender(object):
             try:
                 api_user = self.user
                 is_anonymous = False
-                if not self.user.is_authenticated():
+                if not self.user.is_authenticated:
                     user = get_user_model()
                     service_user = user.objects.get(username=settings.ECOMMERCE_SERVICE_WORKER_USERNAME)
                     api_user = service_user
@@ -787,7 +787,7 @@ class ProgramMarketingDataExtender(ProgramDataExtender):
         pass
 
     def _attach_course_run_upgrade_url(self, run_mode):
-        if not self.user.is_anonymous():
+        if not self.user.is_anonymous:
             super(ProgramMarketingDataExtender, self)._attach_course_run_upgrade_url(run_mode)
         else:
             run_mode['upgrade_url'] = None

--- a/openedx/core/djangoapps/session_inactivity_timeout/middleware.py
+++ b/openedx/core/djangoapps/session_inactivity_timeout/middleware.py
@@ -24,7 +24,7 @@ class SessionInactivityTimeout(object):
         """
         Standard entry point for processing requests in Django
         """
-        if not hasattr(request, "user") or not request.user.is_authenticated():
+        if not hasattr(request, "user") or not request.user.is_authenticated:
             #Can't log out if not logged in
             return
 

--- a/openedx/core/djangoapps/theming/views.py
+++ b/openedx/core/djangoapps/theming/views.py
@@ -30,7 +30,7 @@ def user_can_preview_themes(user):
     """
     Returns true if the specified user is allowed to preview themes.
     """
-    if not user or user.is_anonymous():
+    if not user or user.is_anonymous:
         return False
 
     # In development mode, all users can preview themes
@@ -46,7 +46,7 @@ def get_user_preview_site_theme(request):
     Returns the preview site for the current user, or None if not set.
     """
     user = request.user
-    if not user or user.is_anonymous():
+    if not user or user.is_anonymous:
         return None
     preview_site_name = get_user_preference(user, PREVIEW_SITE_THEME_PREFERENCE_KEY)
     if not preview_site_name:

--- a/openedx/core/djangoapps/user_api/helpers.py
+++ b/openedx/core/djangoapps/user_api/helpers.py
@@ -482,7 +482,7 @@ def shim_student_view(view_func, check_logged_in=False):
         # the request through authentication middleware.
         is_authenticated = (
             getattr(request, 'user', None) is not None
-            and request.user.is_authenticated()
+            and request.user.is_authenticated
         )
         if check_logged_in and not is_authenticated:
             # If we get a 403 status code from the student view

--- a/openedx/core/djangoapps/user_api/middleware.py
+++ b/openedx/core/djangoapps/user_api/middleware.py
@@ -35,7 +35,7 @@ class UserTagsEventContextMiddleware(object):
         if course_id:
             context['course_id'] = course_id
 
-            if request.user.is_authenticated():
+            if request.user.is_authenticated:
                 context['course_user_tags'] = dict(
                     UserCourseTag.objects.filter(
                         user=request.user.pk,

--- a/openedx/core/djangoapps/util/tests/test_user_utils.py
+++ b/openedx/core/djangoapps/util/tests/test_user_utils.py
@@ -14,7 +14,7 @@ class SystemUserTestCase(unittest.TestCase):
 
     def test_system_user_is_anonymous(self):
         self.assertIsInstance(self.sysuser, AnonymousUser)
-        self.assertTrue(self.sysuser.is_anonymous())
+        self.assertTrue(self.sysuser.is_anonymous)
         self.assertIsNone(self.sysuser.id)
 
     def test_system_user_has_custom_unicode_representation(self):

--- a/openedx/core/lib/api/authentication.py
+++ b/openedx/core/lib/api/authentication.py
@@ -58,7 +58,7 @@ class SessionAuthenticationAllowInactiveUser(SessionAuthentication):
         # This is where regular `SessionAuthentication` checks that the user is active.
         # We have removed that check in this implementation.
         # But we added a check to prevent anonymous users since we require a logged-in account.
-        if not user or user.is_anonymous():
+        if not user or user.is_anonymous:
             return None
 
         self.enforce_csrf(request)

--- a/openedx/core/lib/xblock_builtin/xblock_discussion/xblock_discussion/__init__.py
+++ b/openedx/core/lib/xblock_builtin/xblock_discussion/xblock_discussion/__init__.py
@@ -173,7 +173,7 @@ class DiscussionXBlock(XBlock, StudioEditableXBlockMixin, XmlParserMixin):
 
         login_msg = ''
 
-        if not self.django_user.is_authenticated():
+        if not self.django_user.is_authenticated:
             qs = urllib.urlencode({
                 'course_id': self.course_key,
                 'enrollment_action': 'enroll',

--- a/openedx/features/course_experience/views/course_dates.py
+++ b/openedx/features/course_experience/views/course_dates.py
@@ -48,7 +48,7 @@ class CourseDatesFragmentMobileView(CourseDatesFragmentView):
     template_name = 'course_experience/mobile/course-dates-fragment.html'
 
     def get(self, request, *args, **kwargs):
-        if not request.user.is_authenticated():
+        if not request.user.is_authenticated:
             raise Http404
 
         return super(CourseDatesFragmentMobileView, self).get(request, *args, **kwargs)

--- a/openedx/features/course_experience/views/course_home.py
+++ b/openedx/features/course_experience/views/course_home.py
@@ -116,7 +116,7 @@ class CourseHomeFragmentView(EdxFragmentView):
         # Unenrolled users who are not course or global staff are given only a subset.
         enrollment = CourseEnrollment.get_enrollment(request.user, course_key)
         user_access = {
-            'is_anonymous': request.user.is_anonymous(),
+            'is_anonymous': request.user.is_anonymous,
             'is_enrolled': enrollment is not None,
             'is_staff': has_access(request.user, 'staff', course_key),
         }

--- a/openedx/features/enterprise_support/api.py
+++ b/openedx/features/enterprise_support/api.py
@@ -238,7 +238,7 @@ class EnterpriseApiClient(object):
                 a response. This exception is raised for both connection timeout and read timeout.
 
         """
-        if not user.is_authenticated():
+        if not user.is_authenticated:
             return None
 
         api_resource_name = 'enterprise-learner'
@@ -362,7 +362,7 @@ def enterprise_customer_from_cache(request=None, uuid=None):
         enterprise_customer = cache.get(cache_key)
 
     # Check if it's cached in the session.
-    if not enterprise_customer and request and request.user.is_authenticated():
+    if not enterprise_customer and request and request.user.is_authenticated:
         enterprise_customer = request.session.get('enterprise_customer')
 
     return enterprise_customer
@@ -379,7 +379,7 @@ def enterprise_customer_from_api(request):
         # from the EnterpriseCustomer API.
         enterprise_api_client = (
             EnterpriseApiClient(user=request.user)
-            if request.user.is_authenticated()
+            if request.user.is_authenticated
             else EnterpriseApiServiceClient()
         )
 
@@ -422,7 +422,7 @@ def enterprise_customer_uuid_for_request(request):
             settings.ENTERPRISE_CUSTOMER_COOKIE_NAME
         )
 
-    if not enterprise_customer_uuid and request.user.is_authenticated():
+    if not enterprise_customer_uuid and request.user.is_authenticated:
         # If there's no way to get an Enterprise UUID for the request, check to see
         # if there's already an Enterprise attached to the requesting user on the backend.
         learner_data = get_enterprise_learner_data(request.user)

--- a/openedx/features/enterprise_support/middleware.py
+++ b/openedx/features/enterprise_support/middleware.py
@@ -25,5 +25,5 @@ class EnterpriseMiddleware(object):
         """
         Fill the request with Enterprise-related content.
         """
-        if 'enterprise_customer' not in request.session and request.user.is_authenticated():
+        if 'enterprise_customer' not in request.session and request.user.is_authenticated:
             request.session['enterprise_customer'] = api.enterprise_customer_for_request(request)


### PR DESCRIPTION
https://docs.djangoproject.com/en/1.11/releases/1.10/#using-user-is-authenticated-and-user-is-anonymous-as-methods

These warnings are polluting jenkins runs, can they be changed super easily? Throwing this up to see what (if anything) fails.

This is just a fresh checkout of master after running the following commands:
```
git grep -l 'is_authenticated()' | xargs sed -i '' -e 's/is_authenticated()/is_authenticated/g'
git grep -l 'is_anonymous()' | xargs sed -i '' -e 's/is_anonymous()/is_anonymous/g'
```