### PR TITLE
EDUCATOR-2753 | Add calls to retire secondary user data to the /accounts/retire endpoint

### DIFF
--- a/lms/djangoapps/survey/tests/factories.py
+++ b/lms/djangoapps/survey/tests/factories.py
@@ -1,0 +1,21 @@
+# pylint:disable=missing-docstring
+import factory
+
+from student.tests.factories import UserFactory
+from survey.models import SurveyAnswer, SurveyForm
+
+
+class SurveyFormFactory(factory.DjangoModelFactory):
+    class Meta(object):
+        model = SurveyForm
+
+    name = 'Test Survey Form'
+    form = '<form>First name:<input type="text" name="firstname"/></form>'
+
+
+class SurveyAnswerFactory(factory.DjangoModelFactory):
+    class Meta(object):
+        model = SurveyAnswer
+
+    user = factory.SubFactory(UserFactory)
+    form = factory.SubFactory(SurveyFormFactory)

--- a/openedx/core/djangoapps/credit/tests/factories.py
+++ b/openedx/core/djangoapps/credit/tests/factories.py
@@ -8,7 +8,14 @@ import factory
 from factory.fuzzy import FuzzyText
 import pytz
 
-from openedx.core.djangoapps.credit.models import CreditProvider, CreditEligibility, CreditCourse, CreditRequest
+from openedx.core.djangoapps.credit.models import (
+    CreditProvider,
+    CreditEligibility,
+    CreditCourse,
+    CreditRequest,
+    CreditRequirement,
+    CreditRequirementStatus,
+)
 from util.date_utils import to_timestamp
 
 
@@ -18,6 +25,21 @@ class CreditCourseFactory(factory.DjangoModelFactory):
 
     course_key = FuzzyText(prefix='fake.org/', suffix='/fake.run')
     enabled = True
+
+
+class CreditRequirementFactory(factory.DjangoModelFactory):
+    class Meta(object):
+        model = CreditRequirement
+
+    course = factory.SubFactory(CreditCourseFactory)
+
+
+class CreditRequirementStatusFactory(factory.DjangoModelFactory):
+    class Meta(object):
+        model = CreditRequirementStatus
+
+    requirement = factory.SubFactory(CreditRequirementFactory)
+    status = CreditRequirementStatus.REQUIREMENT_STATUS_CHOICES[0][0]
 
 
 class CreditProviderFactory(factory.DjangoModelFactory):

--- a/openedx/core/djangoapps/user_api/accounts/tests/test_views.py
+++ b/openedx/core/djangoapps/user_api/accounts/tests/test_views.py
@@ -28,6 +28,7 @@ from integrated_channels.sap_success_factors.models import (
 )
 import mock
 from nose.plugins.attrib import attr
+from opaque_keys.edx.keys import CourseKey
 import pytest
 import pytz
 from rest_framework import status
@@ -37,6 +38,8 @@ from social_django.models import UserSocialAuth
 
 from entitlements.models import CourseEntitlementSupportDetail
 from entitlements.tests.factories import CourseEntitlementFactory
+from lms.djangoapps.verify_student.tests.factories import SoftwareSecurePhotoVerificationFactory
+from openedx.core.djangoapps.course_groups.models import CourseUserGroup, UnregisteredLearnerCohortAssignments
 from openedx.core.djangoapps.site_configuration.tests.factories import SiteFactory
 from openedx.core.djangoapps.user_api.accounts import ACCOUNT_VISIBILITY_PREF_KEY
 from openedx.core.djangoapps.user_api.accounts.signals import USER_RETIRE_MAILINGS
@@ -45,6 +48,7 @@ from openedx.core.djangoapps.user_api.preferences.api import set_user_preference
 from openedx.core.djangolib.testing.utils import CacheIsolationTestCase, skip_unless_lms
 from openedx.core.lib.token_utils import JwtBuilder
 from student.models import (
+    CourseEnrollmentAllowed,
     PendingEmailChange,
     SocialLink,
     UserProfile,
@@ -54,12 +58,16 @@ from student.models import (
 from student.tests.factories import (
     TEST_PASSWORD,
     ContentTypeFactory,
+    CourseEnrollmentAllowedFactory,
+    PendingEmailChangeFactory,
     PermissionFactory,
     SuperuserFactory,
     UserFactory
 )
+
 from .. import ALL_USERS_VISIBILITY, PRIVATE_VISIBILITY
 from ..views import AccountRetirementView, USER_PROFILE_PII
+from ...tests.factories import UserOrgTagFactory
 
 TEST_PROFILE_IMAGE_UPLOADED_AT = datetime.datetime(2002, 1, 9, 15, 43, 1, tzinfo=pytz.UTC)
 
@@ -1677,6 +1685,26 @@ class TestAccountRetirementPost(RetirementTestCase):
             comments='A comment containing potential PII.'
         )
 
+        # Misc. setup
+        self.photo_verification = SoftwareSecurePhotoVerificationFactory.create(user=self.test_user)
+        PendingEmailChangeFactory.create(user=self.test_user)
+        UserOrgTagFactory.create(user=self.test_user, key='foo', value='bar')
+        UserOrgTagFactory.create(user=self.test_user, key='cat', value='dog')
+
+        CourseEnrollmentAllowedFactory.create(email=self.original_email)
+
+        self.course_key = CourseKey.from_string('course-v1:edX+DemoX+Demo_Course')
+        self.cohort = CourseUserGroup.objects.create(
+            name="TestCohort",
+            course_id=self.course_key,
+            group_type=CourseUserGroup.COHORT
+        )
+        self.cohort_assignment = UnregisteredLearnerCohortAssignments.objects.create(
+            course_user_group=self.cohort,
+            course_id=self.course_key,
+            email=self.original_email
+        )
+
         # setup for doing POST from test client
         self.headers = self.build_jwt_headers(self.test_superuser)
         self.headers['content_type'] = "application/json"
@@ -1770,6 +1798,13 @@ class TestAccountRetirementPost(RetirementTestCase):
         self._sapsf_audit_assertions()
         self._pending_enterprise_customer_user_assertions()
         self._entitlement_support_detail_assertions()
+
+        self._photo_verification_assertions()
+        self.assertFalse(PendingEmailChange.objects.filter(user=self.test_user).exists())
+        self.assertFalse(UserOrgTag.objects.filter(user=self.test_user).exists())
+
+        self.assertFalse(CourseEnrollmentAllowed.objects.filter(email=self.original_email).exists())
+        self.assertFalse(UnregisteredLearnerCohortAssignments.objects.filter(email=self.original_email).exists())
 
     def test_deletes_pii_from_user_profile(self):
         for model_field, value_to_assign in USER_PROFILE_PII.iteritems():
@@ -1866,3 +1901,12 @@ class TestAccountRetirementPost(RetirementTestCase):
         """
         self.entitlement_support_detail.refresh_from_db()
         self.assertEqual('', self.entitlement_support_detail.comments)
+
+    def _photo_verification_assertions(self):
+        """
+        Helper method for asserting that ``SoftwareSecurePhotoVerification`` objects are retired.
+        """
+        self.photo_verification.refresh_from_db()
+        self.assertEqual(self.test_user, self.photo_verification.user)
+        for field in ('name', 'face_image_url', 'photo_id_image_url', 'photo_id_key'):
+            self.assertEqual('', getattr(self.photo_verification, field))


### PR DESCRIPTION
https://openedx.atlassian.net/browse/EDUCATOR-2753

Note: The SurveyFormFactory/SurveyAnswerFactory and CreditRequirementFactory/CreditRequirementStatusFactory aren't used directly in this PR - I wrote them prematurely, but they will actually end up being used for another ticket we're working on.