### PR TITLE
EDUCATOR-2802 Different LMS api endpoint to finish GDPR retirement for the user

### DIFF
--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -966,6 +966,7 @@ INSTALLED_APPS = [
     # Standard apps
     'django.contrib.auth',
     'django.contrib.contenttypes',
+    'django.contrib.humanize',
     'django.contrib.redirects',
     'django.contrib.sessions',
     'django.contrib.sites',
@@ -979,6 +980,9 @@ INSTALLED_APPS = [
 
     # Common views
     'openedx.core.djangoapps.common_views',
+
+    # API access administration
+    'openedx.core.djangoapps.api_admin',
 
     # History tables
     'simple_history',
@@ -1045,7 +1049,13 @@ INSTALLED_APPS = [
     # Dark-launching languages
     'openedx.core.djangoapps.dark_lang',
 
+    #
     # User preferences
+    'wiki',
+    'django_notify',
+    'course_wiki',  # Our customizations
+    'mptt',
+    'sekizai',
     'openedx.core.djangoapps.user_api',
     'django_openid_auth',
 

--- a/cms/envs/test.py
+++ b/cms/envs/test.py
@@ -317,9 +317,6 @@ SECRET_KEY = '85920908f28904ed733fe576320db18cabd7b6cd'
 INSTALLED_APPS.append('openedx.core.djangoapps.ccxcon.apps.CCXConnectorConfig')
 FEATURES['CUSTOM_COURSES_EDX'] = True
 
-# API access management -- needed for simple-history to run.
-INSTALLED_APPS.append('openedx.core.djangoapps.api_admin')
-
 ########################## VIDEO IMAGE STORAGE ############################
 VIDEO_IMAGE_SETTINGS = dict(
     VIDEO_IMAGE_MAX_BYTES=2 * 1024 * 1024,    # 2 MB

--- a/openedx/core/djangoapps/user_api/urls.py
+++ b/openedx/core/djangoapps/user_api/urls.py
@@ -12,7 +12,8 @@ from .accounts.views import (
     AccountRetirementStatusView,
     AccountRetirementView,
     AccountViewSet,
-    DeactivateLogoutView
+    DeactivateLogoutView,
+    LMSAccountRetirementView
 )
 from .preferences.views import PreferencesDetailView, PreferencesView
 from .verification_api.views import IDVerificationStatusView
@@ -47,6 +48,9 @@ RETIREMENT_POST = AccountRetirementView.as_view({
     'post': 'post',
 })
 
+RETIREMENT_LMS_POST = LMSAccountRetirementView.as_view({
+    'post': 'post',
+})
 
 urlpatterns = [
     url(
@@ -103,6 +107,11 @@ urlpatterns = [
         r'^v1/accounts/retire/$',
         RETIREMENT_POST,
         name='accounts_retire'
+    ),
+    url(
+        r'^v1/accounts/retire_misc/$',
+        RETIREMENT_LMS_POST,
+        name='accounts_retire_misc'
     ),
     url(
         r'^v1/accounts/update_retirement_status/$',

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -16,7 +16,7 @@ git+https://github.com/edx/django-celery.git@756cb57aad765cb2b0d37372c1855b8f5f3
 git+https://github.com/edx/django-oauth-plus.git@01ec2a161dfc3465f9d35b9211ae790177418316#egg=django-oauth-plus==2.2.9.edx-1
 git+https://github.com/edx/django-openid-auth.git@0.15.1#egg=django-openid-auth==0.15.1
 git+https://github.com/jazzband/django-pipeline.git@d068a019169c9de5ee20ece041a6dea236422852#egg=django-pipeline==1.5.3
--e git+https://github.com/edx/django-wiki.git@v0.0.17#egg=django-wiki
+-e git+https://github.com/edx/django-wiki.git@v0.0.18#egg=django-wiki
 git+https://github.com/edx/django-rest-framework-oauth.git@0a43e8525f1e3048efe4bc70c03de308a277197c#egg=djangorestframework-oauth==1.1.1
 git+https://github.com/edx/django-rest-framework.git@1ceda7c086fddffd1c440cc86856441bbf0bd9cb#egg=djangorestframework==3.6.3
 -e common/lib/dogstats

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -18,7 +18,7 @@ git+https://github.com/hmarr/django-debug-toolbar-mongo.git@b0686a76f1ce3532088c
 git+https://github.com/edx/django-oauth-plus.git@01ec2a161dfc3465f9d35b9211ae790177418316#egg=django-oauth-plus==2.2.9.edx-1
 git+https://github.com/edx/django-openid-auth.git@0.15.1#egg=django-openid-auth==0.15.1
 git+https://github.com/jazzband/django-pipeline.git@d068a019169c9de5ee20ece041a6dea236422852#egg=django-pipeline==1.5.3
--e git+https://github.com/edx/django-wiki.git@v0.0.17#egg=django-wiki
+-e git+https://github.com/edx/django-wiki.git@v0.0.18#egg=django-wiki
 git+https://github.com/edx/django-rest-framework-oauth.git@0a43e8525f1e3048efe4bc70c03de308a277197c#egg=djangorestframework-oauth==1.1.1
 git+https://github.com/edx/django-rest-framework.git@1ceda7c086fddffd1c440cc86856441bbf0bd9cb#egg=djangorestframework==3.6.3
 -e common/lib/dogstats

--- a/requirements/edx/github.in
+++ b/requirements/edx/github.in
@@ -62,7 +62,7 @@
 
 # Third-party:
 -e git+https://github.com/jazzband/django-pipeline.git@d068a019169c9de5ee20ece041a6dea236422852#egg=django-pipeline==1.5.3
--e git+https://github.com/edx/django-wiki.git@v0.0.17#egg=django-wiki
+-e git+https://github.com/edx/django-wiki.git@v0.0.18#egg=django-wiki
 -e git+https://github.com/edx/django-openid-auth.git@0.15.1#egg=django-openid-auth==0.15.1
 -e git+https://github.com/edx/MongoDBProxy.git@25b99097615bda06bd7cdfe5669ed80dc2a7fed0#egg=MongoDBProxy==0.1.0
 -e git+https://github.com/dementrock/pystache_custom.git@776973740bdaad83a3b029f96e415a7d1e8bec2f#egg=pystache_custom-dev

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -16,7 +16,7 @@ git+https://github.com/edx/django-celery.git@756cb57aad765cb2b0d37372c1855b8f5f3
 git+https://github.com/edx/django-oauth-plus.git@01ec2a161dfc3465f9d35b9211ae790177418316#egg=django-oauth-plus==2.2.9.edx-1
 git+https://github.com/edx/django-openid-auth.git@0.15.1#egg=django-openid-auth==0.15.1
 git+https://github.com/jazzband/django-pipeline.git@d068a019169c9de5ee20ece041a6dea236422852#egg=django-pipeline==1.5.3
--e git+https://github.com/edx/django-wiki.git@v0.0.17#egg=django-wiki
+-e git+https://github.com/edx/django-wiki.git@v0.0.18#egg=django-wiki
 git+https://github.com/edx/django-rest-framework-oauth.git@0a43e8525f1e3048efe4bc70c03de308a277197c#egg=djangorestframework-oauth==1.1.1
 git+https://github.com/edx/django-rest-framework.git@1ceda7c086fddffd1c440cc86856441bbf0bd9cb#egg=djangorestframework==3.6.3
 -e common/lib/dogstats


### PR DESCRIPTION
edx-status-bot: ignore

[EDUCATOR-2802:](https://openedx.atlassian.net/browse/EDUCATOR-2802) Different LMS endpoint to finish GDPR retirement.