### PR TITLE
Add VNC info to platform testing docs

### DIFF
--- a/docs/testing.rst
+++ b/docs/testing.rst
@@ -139,6 +139,28 @@ Note -
 
     paver -h
 
+Connecting to Browser
+~~~~~~~~~~~~~~~~~~~~~
+
+If you want to see the browser being automated for JavaScript or bok-choy tests,
+you can connect to the container running it via VNC.
+
++------------------------+----------------------+
+| Browser                | VNC connection       |
++========================+======================+
+| Firefox (Default)      | vnc://0.0.0.0:25900  |
++------------------------+----------------------+
+| Chrome (via Selenium)  | vnc://0.0.0.0:15900  |
++------------------------+----------------------+
+
+On macOS, enter the VNC connection string in Safari to connect via VNC. The VNC
+passwords for both browsers are randomly generated and logged at container
+startup, and can be found by running ``make vnc-passwords``.
+
+Most tests are run in Firefox by default.  To use Chrome for tests that normally
+use Firefox instead, prefix the test command with
+``SELENIUM_BROWSER=chrome SELENIUM_HOST=edx.devstack.chrome``.
+
 Running Python Unit tests
 -------------------------
 


### PR DESCRIPTION
Add VNC connection information to testing docs. These currently live in the [Devstack README](https://github.com/edx/devstack/blob/master/README.rst#connecting-to-browser), and when testing locally mean that folks need to visit two separate docs to get the system set up.