### PR TITLE
Bok choy tests for the account deletion flow

### DIFF
--- a/common/test/acceptance/pages/lms/account_settings.py
+++ b/common/test/acceptance/pages/lms/account_settings.py
@@ -78,3 +78,24 @@ class AccountSettingsPage(FieldsMixin, PageObject):
         order detail link or not.
         """
         return self.q(css='.u-field-{} .u-field-{}'.format(field_id, 'link')).visible
+
+    @property
+    def is_delete_button_visible(self):
+        self.scroll_to_element('#account-deletion-container')
+        return self.q(css='#delete-account-btn').visible
+
+    def click_delete_button(self):
+        self.q(css="#delete-account-btn").click()
+
+    @property
+    def is_delete_modal_visible(self):
+        return self.q(css='.delete-confirmation-wrapper').visible
+
+    def delete_confirm_button_enabled(self):
+        return self.q(css='.paragon__modal-footer .paragon__btn')[0].is_enabled()
+
+    def click_delete_confirm_button(self):
+        return self.q(css='.paragon__modal-footer .paragon__btn')[0].click()
+
+    def fill_in_password_field(self, password):
+        self.q(css='#asInput1').fill(password)

--- a/common/test/acceptance/tests/lms/test_account_settings.py
+++ b/common/test/acceptance/tests/lms/test_account_settings.py
@@ -24,7 +24,7 @@ class AccountSettingsTestMixin(EventsTestMixin, AcceptanceTest):
     USER_SETTINGS_CHANGED_EVENT_NAME = 'edx.user.settings.changed'
     ACCOUNT_SETTINGS_REFERER = u"/account/settings"
 
-    def visit_account_settings_page(self):
+    def visit_account_settings_page(self, gdpr=False):
         """
         Visit the account settings page for the current user, and store the page instance
         as self.account_settings_page.
@@ -33,13 +33,23 @@ class AccountSettingsTestMixin(EventsTestMixin, AcceptanceTest):
         self.account_settings_page = AccountSettingsPage(self.browser)
         self.account_settings_page.visit()
         self.account_settings_page.wait_for_ajax()
+        # TODO: LEARNER-4422 - delete when we clean up flags
+        if gdpr:
+            self.account_settings_page.browser.get(self.browser.current_url + "?course_experience.gdpr=1")
+            self.account_settings_page.wait_for_page()
 
-    def log_in_as_unique_user(self, email=None, full_name=None):
+    def log_in_as_unique_user(self, email=None, full_name=None, password=None):
         """
         Create a unique user and return the account's username and id.
         """
         username = "test_{uuid}".format(uuid=self.unique_id[0:6])
-        auto_auth_page = AutoAuthPage(self.browser, username=username, email=email, full_name=full_name).visit()
+        auto_auth_page = AutoAuthPage(
+            self.browser,
+            username=username,
+            email=email,
+            full_name=full_name,
+            password=password
+        ).visit()
         user_id = auto_auth_page.get_user_id()
         return username, user_id
 
@@ -525,6 +535,40 @@ class AccountSettingsPageTest(AccountSettingsTestMixin, AcceptanceTest):
             )
 
         self.assertTrue(self.account_settings_page.order_button_is_visible('order-Edx-123'))
+
+
+class AccountSettingsDeleteAccountTest(AccountSettingsTestMixin, AcceptanceTest):
+    """
+    Tests for the account deletion workflow.
+    """
+    def setUp(self):
+        """
+        Initialize account and pages.
+        """
+        super(AccountSettingsDeleteAccountTest, self).setUp()
+        self.full_name = FULL_NAME
+        self.social_link = ''
+        self.password = 'password'
+        self.username, self.user_id = self.log_in_as_unique_user(full_name=self.full_name, password=self.password)
+        self.visit_account_settings_page(gdpr=True)
+
+    def test_button_visible(self):
+        self.assertTrue(
+            self.account_settings_page.is_delete_button_visible
+        )
+
+    def test_delete_modal(self):
+        self.account_settings_page.click_delete_button()
+        self.assertTrue(
+            self.account_settings_page.is_delete_modal_visible
+        )
+        self.assertFalse(
+            self.account_settings_page.delete_confirm_button_enabled()
+        )
+        self.account_settings_page.fill_in_password_field(self.password)
+        self.assertTrue(
+            self.account_settings_page.delete_confirm_button_enabled()
+        )
 
 
 @attr('a11y')

--- a/common/test/db_fixtures/waffle_flags.json
+++ b/common/test/db_fixtures/waffle_flags.json
@@ -22,5 +22,13 @@
             "name": "studio.enable_policy_page",
             "active": true
         }
+    },
+    {
+        "pk": 3,
+        "model": "waffle.flag",
+        "fields": {
+            "name": "course_experience.gdpr",
+            "everyone": false
+        }
     }
 ]

--- a/lms/djangoapps/student_account/views.py
+++ b/lms/djangoapps/student_account/views.py
@@ -468,7 +468,8 @@ def account_settings(request):
         GET /account/settings
 
     """
-    return render_to_response('student_account/account_settings.html', account_settings_context(request))
+    context = account_settings_context(request)
+    return render_to_response('student_account/account_settings.html', context)
 
 
 @login_required


### PR DESCRIPTION
FYI @AlasdairSwan 

Currently this does not support the deletion portion of the workflow due to the need for the `RetirementState` enum to be populated during set up of the database.