### PR TITLE
swap page names for entitlement session analytics

### DIFF
--- a/lms/static/js/learner_dashboard/views/course_entitlement_view.js
+++ b/lms/static/js/learner_dashboard/views/course_entitlement_view.js
@@ -134,7 +134,7 @@ class CourseEntitlementView extends Backbone.View {
     3) Hide the 'View Course' button to the course card.
     */
     const successIconEl = '<span class="fa fa-check" aria-hidden="true"></span>';
-    const eventPage = this.$parentEl ? 'course-dashboard' : 'program-details';
+    const eventPage = this.$parentEl ? 'program-details' : 'course-dashboard';
     const eventAction = prevSession ? 'switch' : 'new';
 
     // Emit analytics event to track user leaving current session
@@ -178,7 +178,7 @@ class CourseEntitlementView extends Backbone.View {
     4) Remove the link from the course card image and title.
     */
     // Emit analytics event to track user leaving current session
-    const eventPage = this.$parentEl ? 'course-dashboard' : 'program-details';
+    const eventPage = this.$parentEl ? 'program-details' : 'course-dashboard';
     this.trackSessionChange(eventPage, 'leave', prevSession);
 
     // With a containing backbone view, we can simply re-render the parent card


### PR DESCRIPTION
Fix for [emit ga events for user entitlement session actions](https://github.com/edx/edx-platform/pull/18120), I had the event pages (program-details and course-dashboard) swapped.

[LEARNER-3830](https://openedx.atlassian.net/browse/LEARNER-3830) and [LEARNER-3911](https://openedx.atlassian.net/browse/LEARNER-3911)