### PR TITLE
Fix that when usage key none is not raise error.

### DIFF
--- a/common/lib/xmodule/xmodule/seq_module.py
+++ b/common/lib/xmodule/xmodule/seq_module.py
@@ -212,6 +212,8 @@ class SequenceModule(SequenceFields, ProctoringFields, XModule):
             completion_service = self.runtime.service(self, 'completion')
 
             usage_key = data.get('usage_key', None)
+            if not usage_key:
+                return None
             item = self.get_child(UsageKey.from_string(usage_key))
             if not item:
                 return None

--- a/common/lib/xmodule/xmodule/tests/test_sequence.py
+++ b/common/lib/xmodule/xmodule/tests/test_sequence.py
@@ -296,3 +296,15 @@ class SequenceBlockTestCase(XModuleXmlImportTest):
             self.assertIsNot(completion_return, None)
             self.assertTrue('complete' in completion_return)
             self.assertEqual(completion_return['complete'], True)
+
+    def test_handle_ajax_get_completion_return_none(self):
+        """
+        Test that the completion data is returned successfully None
+        when usage key is None through ajax call
+        """
+        usage_key = None
+        completion_return = self.sequence_3_1.handle_ajax(
+            'get_completion',
+            {'usage_key': usage_key}
+        )
+        self.assertIs(completion_return, None)


### PR DESCRIPTION
## [EDUCATOR-2726](https://openedx.atlassian.net/browse/EDUCATOR-2726)

### Description
This PR fixes that when usage key is None it would raise an error on the backend.

### Test
- [x] unit test

### Reviewers
If you've been tagged for review, please check your corresponding box once you've given the :+1:.
- [x] @asadazam93 
- [x] @awaisdar001 
### Post-review
- [x] Rebase and squash commits
