### PR TITLE
Disallow registration when the proposed email is retired

### DIFF
--- a/common/djangoapps/student/forms.py
+++ b/common/djangoapps/student/forms.py
@@ -19,6 +19,7 @@ from django.core.validators import RegexValidator, slug_re
 
 from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
 from openedx.core.djangoapps.user_api import accounts as accounts_settings
+from openedx.core.djangoapps.user_api.accounts.utils import email_exists
 from student.models import CourseEnrollmentAllowed
 from util.password_policy_validators import password_max_length, password_min_length, validate_password
 
@@ -294,7 +295,7 @@ class AccountCreationForm(forms.Form):
                 # reject the registration.
                 if not CourseEnrollmentAllowed.objects.filter(email=email).exists():
                     raise ValidationError(_("Unauthorized email address."))
-        if User.objects.filter(email__iexact=email).exists():
+        if email_exists(email):
             raise ValidationError(
                 _(
                     "It looks like {email} belongs to an existing account. Try again with a different email address."

--- a/common/djangoapps/student/forms.py
+++ b/common/djangoapps/student/forms.py
@@ -19,8 +19,7 @@ from django.core.validators import RegexValidator, slug_re
 
 from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
 from openedx.core.djangoapps.user_api import accounts as accounts_settings
-from openedx.core.djangoapps.user_api.accounts.utils import email_exists
-from student.models import CourseEnrollmentAllowed
+from student.models import CourseEnrollmentAllowed, email_exists_or_retired
 from util.password_policy_validators import password_max_length, password_min_length, validate_password
 
 
@@ -295,7 +294,7 @@ class AccountCreationForm(forms.Form):
                 # reject the registration.
                 if not CourseEnrollmentAllowed.objects.filter(email=email).exists():
                     raise ValidationError(_("Unauthorized email address."))
-        if email_exists(email):
+        if email_exists_or_retired(email):
             raise ValidationError(
                 _(
                     "It looks like {email} belongs to an existing account. Try again with a different email address."

--- a/common/djangoapps/student/helpers.py
+++ b/common/djangoapps/student/helpers.py
@@ -48,7 +48,8 @@ from student.models import (
     Registration,
     UserAttribute,
     UserProfile,
-    unique_id_for_user
+    unique_id_for_user,
+    email_exists_or_retired
 )
 
 
@@ -652,7 +653,7 @@ def do_create_account(form, custom_form=None):
                 USERNAME_EXISTS_MSG_FMT.format(username=proposed_username),
                 field="username"
             )
-        elif User.objects.filter(email=user.email):
+        elif email_exists_or_retired(user.email):
             raise AccountValidationError(
                 _("An account with the Email '{email}' already exists.").format(email=user.email),
                 field="email"

--- a/common/djangoapps/student/models.py
+++ b/common/djangoapps/student/models.py
@@ -215,6 +215,19 @@ def is_username_retired(username):
     return User.objects.filter(username__in=list(locally_hashed_usernames)).exists()
 
 
+def is_email_retired(email):
+    """
+    Checks to see if the given email has been previously retired
+    """
+    locally_hashed_emails = user_util.get_all_retired_emails(
+        email,
+        settings.RETIRED_USER_SALTS,
+        settings.RETIRED_EMAIL_FMT
+    )
+
+    return User.objects.filter(email__in=list(locally_hashed_emails)).exists()
+
+
 def get_retired_username_by_username(username):
     """
     If a UserRetirementStatus object with an original_username matching the given username exists,

--- a/common/djangoapps/student/models.py
+++ b/common/djangoapps/student/models.py
@@ -228,6 +228,13 @@ def is_email_retired(email):
     return User.objects.filter(email__in=list(locally_hashed_emails)).exists()
 
 
+def email_exists_or_retired(email):
+    """
+    Check an email against the User model for existence.
+    """
+    return User.objects.filter(email=email).exists() or is_email_retired(email)
+
+
 def get_retired_username_by_username(username):
     """
     If a UserRetirementStatus object with an original_username matching the given username exists,
@@ -2246,18 +2253,30 @@ class CourseAccessRole(models.Model):
 #### Helper methods for use from python manage.py shell and other classes.
 
 
+def strip_if_string(value):
+    if isinstance(value, six.string_types):
+        return value.strip()
+    return value
+
+
 def get_user_by_username_or_email(username_or_email):
     """
     Return a User object, looking up by email if username_or_email contains a
     '@', otherwise by username.
 
     Raises:
-        User.DoesNotExist is lookup fails.
+        User.DoesNotExist if no user object can be found, the user was
+        retired, or the user is in the process of being retired.
     """
+    username_or_email = strip_if_string(username_or_email)
     if '@' in username_or_email:
-        return User.objects.get(email=username_or_email)
+        user = User.objects.get(email=username_or_email)
     else:
-        return User.objects.get(username=username_or_email)
+        user = User.objects.get(username=username_or_email)
+        UserRetirementRequest = apps.get_model('user_api', 'UserRetirementRequest')
+        if UserRetirementRequest.has_user_requested_retirement(user):
+            raise User.DoesNotExist
+    return user
 
 
 def get_user(email):

--- a/common/djangoapps/student/signals/receivers.py
+++ b/common/djangoapps/student/signals/receivers.py
@@ -11,7 +11,10 @@ from student.helpers import (
     AccountValidationError,
     USERNAME_EXISTS_MSG_FMT
 )
-from student.models import is_username_retired
+from student.models import (
+    is_email_retired,
+    is_username_retired,
+)
 
 
 def update_last_login(sender, user, **kwargs):  # pylint: disable=unused-argument
@@ -45,4 +48,11 @@ def on_user_updated(sender, instance, **kwargs):  # pylint: disable=unused-argum
             raise AccountValidationError(
                 USERNAME_EXISTS_MSG_FMT.format(username=instance.username),
                 field="username"
+            )
+
+        # Check for a retired email.
+        if is_email_retired(instance.email):
+            raise AccountValidationError(
+                EMAIL_EXISTS_MSG_FMT.format(username=instance.email),
+                field="email"
             )

--- a/common/djangoapps/student/tests/test_retirement.py
+++ b/common/djangoapps/student/tests/test_retirement.py
@@ -17,7 +17,8 @@ from student.models import (
     get_potentially_retired_user_by_username_and_hash,
     get_retired_email_by_email,
     get_retired_username_by_username,
-    is_username_retired
+    is_username_retired,
+    is_email_retired
 )
 from student.tests.factories import UserFactory
 
@@ -130,6 +131,29 @@ def test_is_username_retired_not_retired():
     """
     user = UserFactory()
     assert not is_username_retired(user.username)
+
+
+def test_is_email_retired_is_retired():
+    """
+    Check functionality of is_email_retired when email is retired
+    """
+    user = UserFactory()
+    original_email = user.email
+    retired_email = get_retired_email_by_email(user.email)
+
+    # Fake email retirement.
+    user.email = retired_email
+    user.save()
+
+    assert is_email_retired(original_email)
+
+
+def test_is_email_retired_not_retired():
+    """
+    Check functionality of is_email_retired when email is not retired
+    """
+    user = UserFactory()
+    assert not is_email_retired(user.email)
 
 
 def test_get_retired_email():

--- a/common/djangoapps/student/views/management.py
+++ b/common/djangoapps/student/views/management.py
@@ -95,6 +95,7 @@ from student.models import (
     UserSignupSource,
     UserStanding,
     create_comments_service_user,
+    username_or_email_exists_or_retired,
 )
 from student.signals import REFUND_ORDER
 from student.tasks import send_activation_email
@@ -1251,7 +1252,7 @@ def validate_new_email(user, new_email):
     if new_email == user.email:
         raise ValueError(_('Old email is the same as the new email.'))
 
-    if User.objects.filter(email=new_email).count() != 0:
+    if username_or_email_exists_or_retired(new_email):
         raise ValueError(_('An account with this e-mail already exists.'))
 
 

--- a/common/djangoapps/student/views/management.py
+++ b/common/djangoapps/student/views/management.py
@@ -95,7 +95,7 @@ from student.models import (
     UserSignupSource,
     UserStanding,
     create_comments_service_user,
-    username_or_email_exists_or_retired,
+    email_exists_or_retired,
 )
 from student.signals import REFUND_ORDER
 from student.tasks import send_activation_email
@@ -1252,7 +1252,7 @@ def validate_new_email(user, new_email):
     if new_email == user.email:
         raise ValueError(_('Old email is the same as the new email.'))
 
-    if username_or_email_exists_or_retired(new_email):
+    if email_exists_or_retired(new_email):
         raise ValueError(_('An account with this e-mail already exists.'))
 
 

--- a/lms/djangoapps/ccx/api/v0/views.py
+++ b/lms/djangoapps/ccx/api/v0/views.py
@@ -430,6 +430,12 @@ class CCXListView(GenericAPIView):
             )
 
         try:
+            # Retired users should effectively appear to not exist when
+            # attempts are made to modify them, so a direct User model email
+            # lookup is sufficient here.  This corner case relies on the fact
+            # that we scramble emails immediately during user lock-out.  Of
+            # course, the normal cases are that the email just never existed,
+            # or it is currently associated with an active account.
             coach = User.objects.get(email=valid_input['coach_email'])
         except User.DoesNotExist:
             return Response(

--- a/lms/djangoapps/instructor/enrollment.py
+++ b/lms/djangoapps/instructor/enrollment.py
@@ -27,7 +27,12 @@ from lms.djangoapps.grades.signals.signals import PROBLEM_RAW_SCORE_CHANGED
 from openedx.core.djangoapps.lang_pref import LANGUAGE_KEY
 from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
 from openedx.core.djangoapps.user_api.models import UserPreference
-from student.models import CourseEnrollment, CourseEnrollmentAllowed, anonymous_id_for_user
+from student.models import (
+    CourseEnrollment,
+    CourseEnrollmentAllowed,
+    anonymous_id_for_user,
+    is_email_retired,
+)
 from submissions import api as sub_api  # installed from the edx-submissions repository
 from submissions.models import score_set
 from track.event_transaction_utils import (
@@ -44,6 +49,9 @@ log = logging.getLogger(__name__)
 class EmailEnrollmentState(object):
     """ Store the complete enrollment state of an email in a class """
     def __init__(self, course_id, email):
+        # N.B. retired users are not a concern here because they should be
+        # handled at a higher level (i.e. in enroll_email).  Besides, this
+        # class creates readonly objects.
         exists_user = User.objects.filter(email=email).exists()
         if exists_user:
             user = User.objects.get(email=email)
@@ -142,7 +150,7 @@ def enroll_email(course_id, student_email, auto_enroll=False, email_students=Fal
             email_params['email_address'] = student_email
             email_params['full_name'] = previous_state.full_name
             send_mail_to_student(student_email, email_params, language=language)
-    else:
+    elif not is_email_retired(student_email):
         cea, _ = CourseEnrollmentAllowed.objects.get_or_create(course_id=course_id, email=student_email)
         cea.auto_enroll = auto_enroll
         cea.save()

--- a/lms/djangoapps/instructor/views/api.py
+++ b/lms/djangoapps/instructor/views/api.py
@@ -16,6 +16,7 @@ import StringIO
 import time
 
 import unicodecsv
+from django.apps import apps
 from django.conf import settings
 from django.contrib.auth.models import User
 from django.core.exceptions import ObjectDoesNotExist, PermissionDenied, ValidationError
@@ -376,6 +377,7 @@ def register_and_enroll_students(request, course_id):  # pylint: disable=too-man
                 row_errors.append({
                     'username': username, 'email': email, 'response': _('Invalid email {email_address}.').format(email_address=email)})
             else:
+                UserRetirementStatus = apps.get_model('user_api', 'UserRetirementStatus')
                 if User.objects.filter(email=email).exists():
                     # Email address already exists. assume it is the correct user
                     # and just register the user in the course and send an enrollment email.
@@ -412,6 +414,20 @@ def register_and_enroll_students(request, course_id):  # pylint: disable=too-man
                             state_transition=UNENROLLED_TO_ENROLLED,
                         )
                         enroll_email(course_id=course_id, student_email=email, auto_enroll=True, email_students=True, email_params=email_params)
+                elif (UserRetirementStatus.objects
+                                          .select_related('current_state')
+                                          .filter(original_email=email)
+                                          .exclude(current_state__state_name='COMPLETE')
+                                          .exists()):
+                        # Somebody is attempting to enroll a user who has initiated retirement but still exists in
+                        # general.  Simply block these attempts.
+                        general_errors.append({
+                            'username': '',
+                            'email': '',
+                            'response': _('Invalid email {email_address}.').format(email_address=email),
+                        })
+                        log.warning(u'Email address %s is associated with a user which has initiated account retirement, ' +
+                                    u'so course enrollment was blocked.', email)
                 else:
                     # This email does not yet exist, so we need to create a new account
                     # If username already exists in the database, then create_and_enroll_user

--- a/lms/djangoapps/instructor/views/tools.py
+++ b/lms/djangoapps/instructor/views/tools.py
@@ -9,8 +9,9 @@ from django.http import HttpResponseBadRequest
 from pytz import UTC
 from django.utils.translation import ugettext as _
 from opaque_keys.edx.keys import UsageKey
-from six import text_type
+from six import text_type, string_types
 
+from student.models import get_user_by_username_or_email
 from courseware.field_overrides import disable_overrides
 from courseware.models import StudentFieldOverride
 from courseware.student_field_overrides import clear_override_for_user, get_override_for_user, override_field_for_user
@@ -50,7 +51,7 @@ def handle_dashboard_error(view):
 
 
 def strip_if_string(value):
-    if isinstance(value, basestring):
+    if isinstance(value, string_types):
         return value.strip()
     return value
 
@@ -61,14 +62,12 @@ def get_student_from_identifier(unique_student_identifier):
 
     Returns the student object associated with `unique_student_identifier`
 
-    Raises User.DoesNotExist if no user object can be found.
+    Raises User.DoesNotExist if no user object can be found, the user was
+    retired, or the user is in the process of being retired.
+
+    DEPRECATED: use student.models.get_user_by_username_or_email instead.
     """
-    unique_student_identifier = strip_if_string(unique_student_identifier)
-    if "@" in unique_student_identifier:
-        student = User.objects.get(email=unique_student_identifier)
-    else:
-        student = User.objects.get(username=unique_student_identifier)
-    return student
+    return get_user_by_username_or_email(unique_student_identifier)
 
 
 def require_student_from_identifier(unique_student_identifier):

--- a/lms/djangoapps/lms_migration/management/commands/create_user.py
+++ b/lms/djangoapps/lms_migration/management/commands/create_user.py
@@ -18,7 +18,7 @@ from django.core.management.base import BaseCommand
 from pytz import UTC
 
 from openedx.core.djangoapps.external_auth.models import ExternalAuthMap
-from student.models import Registration, UserProfile
+from student.models import Registration, UserProfile, email_exists_or_retired
 
 
 class MyCompleter(object):  # Custom completer
@@ -95,7 +95,7 @@ class Command(BaseCommand):
 
             while True:
                 email = raw_input('email: ')
-                if User.objects.filter(email=email):
+                if email_exists_or_retired(email):
                     print "email %s already taken" % email
                 else:
                     break

--- a/openedx/core/djangoapps/user_api/accounts/api.py
+++ b/openedx/core/djangoapps/user_api/accounts/api.py
@@ -21,6 +21,7 @@ from util.password_policy_validators import validate_password
 
 from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
 from openedx.core.djangoapps.user_api import errors, accounts, forms, helpers
+from openedx.core.djangoapps.user_api.accounts.utils import email_exists
 from openedx.core.djangoapps.user_api.config.waffle import PREVENT_AUTH_USER_WRITES, SYSTEM_MAINTENANCE_MSG, waffle
 from openedx.core.djangoapps.user_api.errors import (
     AccountUpdateError,
@@ -692,7 +693,7 @@ def _validate_email_doesnt_exist(email):
     :return: None
     :raises: errors.AccountEmailAlreadyExists
     """
-    if email is not None and User.objects.filter(email=email).exists():
+    if email is not None and email_exists(email):
         raise errors.AccountEmailAlreadyExists(_(accounts.EMAIL_CONFLICT_MSG).format(email_address=email))
 
 

--- a/openedx/core/djangoapps/user_api/accounts/api.py
+++ b/openedx/core/djangoapps/user_api/accounts/api.py
@@ -13,7 +13,7 @@ from django.core.validators import validate_email, ValidationError
 from django.http import HttpResponseForbidden
 from six import text_type
 
-from student.models import User, UserProfile, Registration
+from student.models import User, UserProfile, Registration, email_exists_or_retired
 from student import forms as student_forms
 from student import views as student_views
 from util.model_utils import emit_setting_changed_event
@@ -21,7 +21,6 @@ from util.password_policy_validators import validate_password
 
 from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
 from openedx.core.djangoapps.user_api import errors, accounts, forms, helpers
-from openedx.core.djangoapps.user_api.accounts.utils import email_exists
 from openedx.core.djangoapps.user_api.config.waffle import PREVENT_AUTH_USER_WRITES, SYSTEM_MAINTENANCE_MSG, waffle
 from openedx.core.djangoapps.user_api.errors import (
     AccountUpdateError,
@@ -693,7 +692,7 @@ def _validate_email_doesnt_exist(email):
     :return: None
     :raises: errors.AccountEmailAlreadyExists
     """
-    if email is not None and email_exists(email):
+    if email is not None and email_exists_or_retired(email):
         raise errors.AccountEmailAlreadyExists(_(accounts.EMAIL_CONFLICT_MSG).format(email_address=email))
 
 

--- a/openedx/core/djangoapps/user_api/accounts/utils.py
+++ b/openedx/core/djangoapps/user_api/accounts/utils.py
@@ -15,7 +15,6 @@ from completion import waffle as completion_waffle
 from completion.models import BlockCompletion
 from openedx.core.djangoapps.site_configuration.models import SiteConfiguration
 from openedx.core.djangoapps.theming.helpers import get_config_value_from_site_or_settings, get_current_site
-from student.models import is_email_retired
 from xmodule.modulestore.django import modulestore
 from xmodule.modulestore.exceptions import ItemNotFoundError
 
@@ -193,10 +192,3 @@ def generate_password(length=12, chars=string.letters + string.digits):
     password += choice(string.letters)
     password += ''.join([choice(chars) for _i in xrange(length - 2)])
     return password
-
-
-def email_exists(email):
-    """
-    Check an email against the User model for existence.
-    """
-    return User.objects.filter(email=email).exists() or is_email_retired(email)

--- a/openedx/core/djangoapps/user_api/accounts/utils.py
+++ b/openedx/core/djangoapps/user_api/accounts/utils.py
@@ -6,7 +6,6 @@ import re
 import string
 from urlparse import urlparse
 
-from django.apps import apps
 from django.conf import settings
 from django.contrib.auth.models import User
 from django.utils.translation import ugettext as _
@@ -16,6 +15,7 @@ from completion import waffle as completion_waffle
 from completion.models import BlockCompletion
 from openedx.core.djangoapps.site_configuration.models import SiteConfiguration
 from openedx.core.djangoapps.theming.helpers import get_config_value_from_site_or_settings, get_current_site
+from student.models import is_email_retired
 from xmodule.modulestore.django import modulestore
 from xmodule.modulestore.exceptions import ItemNotFoundError
 
@@ -197,25 +197,6 @@ def generate_password(length=12, chars=string.letters + string.digits):
 
 def email_exists(email):
     """
-    Check an email against the User and UserRetirementStatus models for
-    existence.
+    Check an email against the User model for existence.
     """
-    exists = False
-    # Normal case, check users in the auth_user table.
-    if User.objects.filter(email=email).exists():
-        exists = True
-    else:
-        # Handle case where another user with the same email address has
-        # initiated retirement (account deletion), but they are still in
-        # the retirement queue in any state which is not COMPLETE.
-        UserRetirementStatus = apps.get_model('user_api', 'UserRetirementStatus')
-        try:
-            if (UserRetirementStatus.objects
-                                    .select_related('current_state')
-                                    .filter(original_email=email)
-                                    .exclude(current_state__state_name='COMPLETE')
-                                    .exists()):
-                exists = True
-        except UserRetirementStatus.DoesNotExist:
-            pass
-    return exists
+    return User.objects.filter(email=email).exists() or is_email_retired(email)


### PR DESCRIPTION
Our learner retirement implementation shall NOT allow re-use of email addresses corresponding to retired or retiring users.

Addresses EDUCATOR-2824 aka. PLAT-2117