### PR TITLE
Fix inconsistency progress between Unit and Course Outline.

### DIFF
--- a/openedx/features/course_experience/utils.py
+++ b/openedx/features/course_experience/utils.py
@@ -91,7 +91,10 @@ def get_course_outline_block_tree(request, course_id):
                 if block['children'][idx]['resume_block'] is True:
                     block['resume_block'] = True
 
-            if len([child['complete'] for child in block['children'] if child['complete']]) == len(block['children']):
+            completable_blocks = [child for child in block['children']
+                                  if child['type'] != 'discussion']
+            if len([child['complete'] for child in block['children']
+                    if child['complete']]) == len(completable_blocks):
                 block['complete'] = True
 
     def mark_last_accessed(user, course_key, block):


### PR DESCRIPTION
## [Inconsistency Progress indicator between Unit and Course Outline  EDUCATOR-2825](https://openedx.atlassian.net/browse/EDUCATOR-2825)

### Description:
This PR fixes that if discussion module is in the units then it shows the completion mark on course outline page.

### How to Test?
**Production**
 - Go to https://courses.edx.org/courses/course-v1:BUx+QD502x+1T2018/courseware/8652b7c02f46419b8e61c7108616c0d0/2154da952492498d917d94a16c981dc0/1?activate_block_id=block-v1%3ABUx%2BQD502x%2B1T2018%2Btype%40vertical%2Bblock%40e69018e6746e4ac9930bdf17ecddaf10 
2. Solve the problem
3. Observe checkbox on the course navigation
4. Back to the course outline https://courses.edx.org/courses/course-v1:BUx+QD502x+1T2018/course/
5. Press: "Collapse All" 
6. Search for "The Digital Age" title
7. The checkbox is not visible.


**Sandbox**
1. https://outline.sandbox.edx.org/courses/course-v1:edX+DemoX+Demo_Course/courseware/interactive_demonstrations/basic_questions/2?activate_block_id=block-v1%3AedX%2BDemoX%2BDemo_Course%2Btype%40vertical%2Bblock%4047dbd5f836544e61877a483c0b75606c
2. Solve the problem
3. Go to https://outline.sandbox.edx.org/courses/course-v1:edX+DemoX+Demo_Course/course/
4. observe that completion checkbox is visible.


### Screenshot
**Before Fix**
<img width="807" alt="screen shot 2018-05-07 at 3 32 59 pm" src="https://user-images.githubusercontent.com/7627421/39700658-6ae15614-5217-11e8-8cde-269f4bbbc156.png">


**After Fix**
<img width="831" alt="screen shot 2018-05-07 at 3 33 17 pm" src="https://user-images.githubusercontent.com/7627421/39700660-6d25d0e4-5217-11e8-8382-0a0b7b6ef658.png">

### Reviewers

If you've been tagged for review, please check your corresponding box once you've given the :+1:.
-  [x] @iloveagent57 
-  [x] @awaisdar001 

### Post-review
- [x] Rebase and squash commits


