### PR TITLE
only check access of asked-for threads

### DIFF
--- a/lms/djangoapps/discussion/views.py
+++ b/lms/djangoapps/discussion/views.py
@@ -153,10 +153,9 @@ def get_threads(request, course, user_info, discussion_id=None, per_page=THREADS
     # If not provided with a discussion id, filter threads by commentable ids
     # which are accessible to the current user.
     if discussion_id is None:
-        discussion_category_ids = set(utils.get_discussion_categories_ids(course, request.user))
         threads = [
             thread for thread in threads
-            if thread.get('commentable_id') in discussion_category_ids
+            if utils.discussion_category_id_access(course, request.user, thread.get('commentable_id'), thread)
         ]
 
     for thread in threads:

--- a/lms/djangoapps/django_comment_client/utils.py
+++ b/lms/djangoapps/django_comment_client/utils.py
@@ -110,7 +110,7 @@ def has_required_keys(xblock):
             log.debug(
                 "Required key '%s' not in discussion %s, leaving out of category map",
                 key,
-                xblock.location
+                getattr(xblock, 'location', None)
             )
             return False
     return True


### PR DESCRIPTION
# [EDUCATOR-2618](https://openedx.atlassian.net/browse/EDUCATOR-2618)

One last attempt at this before I rotate off of escalations and pass the torch to @iloveagent57 .

The big change here: instead of asking `is this thread's id in the list of visible ids`, we'll now ask `is this thread's id visible`, saving us from calculating a bunch of `has_access` calls for blocks that are not even being asked for.