### PR TITLE
TE-2545 Restrict AutoAuth for load tests

### DIFF
--- a/cms/envs/acceptance.py
+++ b/cms/envs/acceptance.py
@@ -96,6 +96,7 @@ DATABASES = {
 
 # Use the auto_auth workflow for creating users and logging them in
 FEATURES['AUTOMATIC_AUTH_FOR_TESTING'] = True
+FEATURES['RESTRICT_AUTOMATIC_AUTH'] = False
 
 # Forums are disabled in test.py to speed up unit tests, but we do not have
 # per-test control for lettuce acceptance tests.

--- a/cms/envs/bok_choy.py
+++ b/cms/envs/bok_choy.py
@@ -80,6 +80,7 @@ for log_name, log_level in LOG_OVERRIDES:
 
 # Use the auto_auth workflow for creating users and logging them in
 FEATURES['AUTOMATIC_AUTH_FOR_TESTING'] = True
+FEATURES['RESTRICT_AUTOMATIC_AUTH'] = False
 
 # Enable milestones app
 FEATURES['MILESTONES_APP'] = True

--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -304,6 +304,12 @@ FEATURES = {
     # Whether archived courses (courses with end dates in the past) should be
     # shown in Studio in a separate list.
     'ENABLE_SEPARATE_ARCHIVED_COURSES': True,
+
+    # For acceptance and load testing
+    'AUTOMATIC_AUTH_FOR_TESTING': False,
+
+    # Prevent auto auth from creating superusers or modifying existing users
+    'RESTRICT_AUTOMATIC_AUTH': True,
 }
 
 ENABLE_JASMINE = False

--- a/lms/envs/acceptance.py
+++ b/lms/envs/acceptance.py
@@ -113,6 +113,7 @@ FEATURES['ENABLE_DISCUSSION_SERVICE'] = False
 
 # Use the auto_auth workflow for creating users and logging them in
 FEATURES['AUTOMATIC_AUTH_FOR_TESTING'] = True
+FEATURES['RESTRICT_AUTOMATIC_AUTH'] = False
 
 # Enable third-party authentication
 FEATURES['ENABLE_THIRD_PARTY_AUTH'] = True

--- a/lms/envs/bok_choy.env.json
+++ b/lms/envs/bok_choy.env.json
@@ -81,6 +81,7 @@
         "PREVIEW_LMS_BASE": "preview.localhost:8003",
         "ALLOW_AUTOMATED_SIGNUPS": true,
         "AUTOMATIC_AUTH_FOR_TESTING": true,
+        "RESTRICT_AUTOMATIC_AUTH": false,
         "MODE_CREATION_FOR_TESTING": true,
         "EXPOSE_CACHE_PROGRAMS_ENDPOINT": true,
         "AUTOMATIC_VERIFY_STUDENT_IDENTITY_FOR_TESTING": true,

--- a/lms/envs/bok_choy.py
+++ b/lms/envs/bok_choy.py
@@ -146,6 +146,7 @@ FEATURES['LICENSING'] = True
 
 # Use the auto_auth workflow for creating users and logging them in
 FEATURES['AUTOMATIC_AUTH_FOR_TESTING'] = True
+FEATURES['RESTRICT_AUTOMATIC_AUTH'] = False
 
 # Open up endpoint for faking Software Secure responses
 FEATURES['ENABLE_SOFTWARE_SECURE_FAKE'] = True

--- a/lms/envs/bok_choy_docker.env.json
+++ b/lms/envs/bok_choy_docker.env.json
@@ -81,6 +81,7 @@
         "PREVIEW_LMS_BASE": "preview.localhost:8003",
         "ALLOW_AUTOMATED_SIGNUPS": true,
         "AUTOMATIC_AUTH_FOR_TESTING": true,
+        "RESTRICT_AUTOMATIC_AUTH": false,
         "MODE_CREATION_FOR_TESTING": true,
         "EXPOSE_CACHE_PROGRAMS_ENDPOINT": true,
         "AUTOMATIC_VERIFY_STUDENT_IDENTITY_FOR_TESTING": true,

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -182,8 +182,11 @@ FEATURES = {
     # Toggle to enable certificates of courses on dashboard
     'ENABLE_VERIFIED_CERTIFICATES': False,
 
-    # for load testing
+    # for acceptance and load testing
     'AUTOMATIC_AUTH_FOR_TESTING': False,
+
+    # Prevent auto auth from creating superusers or modifying existing users
+    'RESTRICT_AUTOMATIC_AUTH': True,
 
     # Toggle the availability of the shopping cart page
     'ENABLE_SHOPPING_CART': False,


### PR DESCRIPTION
Prevent the `auto_auth` URL from creating superusers or modifying existing users by default.  Many of the unit and acceptance tests require this functionality, but load tests don't (and shouldn't have it enabled).  Leaving it restricted by default in devstack as well, unless someone comes up with a really good reason why that should be enabled for a long-running server instance.