### PR TITLE
Use my personal email instead of QRF's

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -178,7 +178,7 @@ Alasdair Swan <aswan@edx.org>
 Paul Medlock-Walton <paulmw@mit.edu>
 Henry Tareque <henry.tareque@gmail.com>
 Eugeny Kolpakov <eugeny.kolpakov@gmail.com>
-Omar Al-Ithawi <oithawi@qrf.org>
+Omar Al-Ithawi <i@omardo.com>
 Louis Pilfold <louis@lpil.uk>
 Akiva Leffert <akiva@edx.org>
 Mike Bifulco <mbifulco@aquent.com>


### PR DESCRIPTION
I no longer work at QRF, but still contribute here.