### PR TITLE
Fix update_discussions_map to run during Studio publish

### DIFF
--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -581,6 +581,9 @@ MODULESTORE = {
         }
     }
 }
+# How many seconds should we wait before assuming a course publish has made it
+# to the MongoDB secondaries (and is therefore safe to read).
+MODULESTORE_PUBLISH_SIGNAL_DELAY = 30
 
 # Modulestore-level field override providers. These field override providers don't
 # require student context.

--- a/common/djangoapps/django_comment_common/models.py
+++ b/common/djangoapps/django_comment_common/models.py
@@ -17,6 +17,7 @@ from student.models import CourseEnrollment
 from xmodule.modulestore.django import modulestore
 from xmodule.modulestore.exceptions import ItemNotFoundError
 
+
 FORUM_ROLE_ADMINISTRATOR = ugettext_noop('Administrator')
 FORUM_ROLE_MODERATOR = ugettext_noop('Moderator')
 FORUM_ROLE_GROUP_MODERATOR = ugettext_noop('Group Moderator')

--- a/common/djangoapps/django_comment_common/signals.py
+++ b/common/djangoapps/django_comment_common/signals.py
@@ -1,7 +1,11 @@
 # pylint: disable=invalid-name
 """Signals related to the comments service."""
+from django.conf import settings
+from django.dispatch import Signal, receiver
+from opaque_keys.edx.locator import LibraryLocator
+from django_comment_common import tasks
+from xmodule.modulestore.django import SignalHandler
 
-from django.dispatch import Signal
 
 thread_created = Signal(providing_args=['user', 'post'])
 thread_edited = Signal(providing_args=['user', 'post'])
@@ -14,3 +18,22 @@ comment_edited = Signal(providing_args=['user', 'post'])
 comment_voted = Signal(providing_args=['user', 'post'])
 comment_deleted = Signal(providing_args=['user', 'post'])
 comment_endorsed = Signal(providing_args=['user', 'post'])
+
+
+@receiver(SignalHandler.course_published)
+def update_discussions_on_course_publish(sender, course_key, **kwargs):  # pylint: disable=unused-argument
+    """
+    Catches the signal that a course has been published in the module
+    store and creates/updates the corresponding cache entry.
+    Ignores publish signals from content libraries.
+    """
+    if isinstance(course_key, LibraryLocator):
+        return
+
+    context = {
+        'course_id': unicode(course_key),
+    }
+    tasks.update_discussions_map.apply_async(
+        args=[context],
+        countdown=settings.MODULESTORE_PUBLISH_SIGNAL_DELAY,
+    )

--- a/common/djangoapps/django_comment_common/tasks.py
+++ b/common/djangoapps/django_comment_common/tasks.py
@@ -1,0 +1,24 @@
+from celery import task
+from celery_utils.logged_task import LoggedTask
+from opaque_keys.edx.keys import CourseKey
+from django_comment_common.utils import (
+    get_discussion_xblocks_by_course_id, set_course_discussion_settings
+)
+
+
+@task(base=LoggedTask)
+def update_discussions_map(context):
+    """
+    Updates the mapping between discussion_id to discussion block usage key
+    for all discussion blocks in the given course.
+
+    context is a dict that contains:
+        course_id (string): identifier of the course
+    """
+    course_key = CourseKey.from_string(context['course_id'])
+    discussion_blocks = get_discussion_xblocks_by_course_id(course_key)
+    discussions_id_map = {
+        discussion_block.discussion_id: unicode(discussion_block.location)
+        for discussion_block in discussion_blocks
+    }
+    set_course_discussion_settings(course_key, discussions_id_map=discussions_id_map)

--- a/common/djangoapps/django_comment_common/tasks.py
+++ b/common/djangoapps/django_comment_common/tasks.py
@@ -21,4 +21,5 @@ def update_discussions_map(context):
         discussion_block.discussion_id: unicode(discussion_block.location)
         for discussion_block in discussion_blocks
     }
+#    import pudb; pu.db
     set_course_discussion_settings(course_key, discussions_id_map=discussions_id_map)

--- a/common/djangoapps/django_comment_common/utils.py
+++ b/common/djangoapps/django_comment_common/utils.py
@@ -113,7 +113,7 @@ def are_permissions_roles_seeded(course_id):
     return True
 
 
-@request_cached
+#@request_cached
 def get_course_discussion_settings(course_key):
     try:
         course_discussion_settings = CourseDiscussionSettings.objects.get(course_id=course_key)

--- a/common/djangoapps/django_comment_common/utils.py
+++ b/common/djangoapps/django_comment_common/utils.py
@@ -114,9 +114,9 @@ def are_permissions_roles_seeded(course_id):
 
 
 def get_course_discussion_settings(course_key):
-    cache = get_cache('get_course_discussion_settings')
-    if course_key in cache:
-        return cache[course_key]
+    #cache = get_cache('get_course_discussion_settings')
+    #if course_key in cache:
+    #    return cache[course_key]
 
     try:
         course_discussion_settings = CourseDiscussionSettings.objects.get(course_id=course_key)
@@ -132,7 +132,7 @@ def get_course_discussion_settings(course_key):
             }
         )
 
-    cache[course_key] = course_discussion_settings
+    # cache[course_key] = course_discussion_settings
 
     return course_discussion_settings
 
@@ -167,8 +167,8 @@ def set_course_discussion_settings(course_key, **kwargs):
             setattr(course_discussion_settings, field, kwargs[field])
 
     course_discussion_settings.save()
-    cache = get_cache('get_course_discussion_settings')
-    cache.pop(course_key, None)  # Remove settings cache entry
+    #cache = get_cache('get_course_discussion_settings')
+    #cache.pop(course_key, None)  # Remove settings cache entry
 
     return course_discussion_settings
 

--- a/lms/djangoapps/discussion/apps.py
+++ b/lms/djangoapps/discussion/apps.py
@@ -12,7 +12,7 @@ from openedx.core.djangoapps.plugins.constants import ProjectType, SettingsType,
 
 class DiscussionConfig(AppConfig):
     """
-    Application Configuration for Grades.
+    Application Configuration for Discussions.
     """
 
     name = u'lms.djangoapps.discussion'
@@ -22,12 +22,12 @@ class DiscussionConfig(AppConfig):
                 PluginURLs.NAMESPACE: u'',
                 PluginURLs.REGEX: r'^courses/{}/discussion/forum/'.format(COURSE_ID_PATTERN),
                 PluginURLs.RELATIVE_PATH: u'urls',
-            }
+            },
         },
         PluginSettings.CONFIG: {
             ProjectType.LMS: {
                 SettingsType.COMMON: {PluginSettings.RELATIVE_PATH: u'settings.common'},
-            }
+            },
         }
     }
 

--- a/lms/djangoapps/discussion/signals/handlers.py
+++ b/lms/djangoapps/discussion/signals/handlers.py
@@ -11,32 +11,12 @@ from lms.djangoapps.discussion import tasks
 from opaque_keys.edx.locator import LibraryLocator
 from openedx.core.djangoapps.site_configuration.models import SiteConfiguration
 from openedx.core.djangoapps.theming.helpers import get_current_site
-from xmodule.modulestore.django import SignalHandler
 
 
 log = logging.getLogger(__name__)
 
 
 ENABLE_FORUM_NOTIFICATIONS_FOR_SITE_KEY = 'enable_forum_notifications'
-
-
-@receiver(SignalHandler.course_published)
-def update_discussions_on_course_publish(sender, course_key, **kwargs):  # pylint: disable=unused-argument
-    """
-    Catches the signal that a course has been published in the module
-    store and creates/updates the corresponding cache entry.
-    Ignores publish signals from content libraries.
-    """
-    if isinstance(course_key, LibraryLocator):
-        return
-
-    context = {
-        'course_id': unicode(course_key),
-    }
-    tasks.update_discussions_map.apply_async(
-        args=[context],
-        countdown=settings.DISCUSSION_SETTINGS['COURSE_PUBLISH_TASK_DELAY'],
-    )
 
 
 @receiver(signals.comment_created)

--- a/lms/djangoapps/discussion/tasks.py
+++ b/lms/djangoapps/discussion/tasks.py
@@ -48,7 +48,7 @@ def update_discussions_map(context):
         discussion_block.discussion_id: unicode(discussion_block.location)
         for discussion_block in discussion_blocks
     }
-    set_course_discussion_settings(course_key, discussions_id_map=discussions_id_map)
+    # set_course_discussion_settings(course_key, discussions_id_map=discussions_id_map)
 
 
 class ResponseNotification(BaseMessageType):

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -874,6 +874,9 @@ MODULESTORE = {
         }
     }
 }
+# How many seconds should we wait before assuming a course publish has made it
+# to the MongoDB secondaries (and is therefore safe to read).
+MODULESTORE_PUBLISH_SIGNAL_DELAY = 30
 
 #################### Python sandbox ############################################
 


### PR DESCRIPTION
>     Move update_discussions_map to django_comment_common
> 
>     The task to update the mapping of inline discussion XBlocks to
>     discussion_ids was originally implemented in an LMS-only process, and
>     did not properly catch a course_published signal from Studio. I tried
>     to enable the Discussions app in Studio (it's a pluggable Django app),
>     but this resulted in difficult to debug bok choy errors around cohorts.
> 
>     This commit moves the task into django_comment_common, which is also
>     where the model it's altering is located. It is possible to just move
>     the listener to django_comment_common and keep the task in LMS and
>     bridge the two with routing, but I thought that would be unnecessarily
>     confusing.