### PR TITLE
Create GDPR test user management command fix for optional arguments

### DIFF
--- a/openedx/core/djangoapps/user_api/management/commands/create_user_gdpr_testing.py
+++ b/openedx/core/djangoapps/user_api/management/commands/create_user_gdpr_testing.py
@@ -44,19 +44,16 @@ class Command(BaseCommand):
     def add_arguments(self, parser):
         parser.add_argument(
             '-u', '--username',
-            nargs=1,
             required=False,
             help='Username'
         )
         parser.add_argument(
             '-e', '--email',
-            nargs=1,
             required=False,
             help='Email'
         )
         parser.add_argument(
             '-c', '--course',
-            nargs=1,
             required=False,
             help='Course UUID'
         )
@@ -72,6 +69,7 @@ class Command(BaseCommand):
 
         user, __ = User.objects.get_or_create(
             username=username,
+            email=email
         )
         user_info = {
             'email': email,


### PR DESCRIPTION
The command wasn't receiving some arguments correctly because of the "nargs". Also added email into the "get_or_create" for a user because it has a ~ unique constraint ~.