### PR TITLE
LEARNER-5278: Fix Delete My Account for IE 11

### DIFF
--- a/lms/static/js/student_account/AccountsClient.js
+++ b/lms/static/js/student_account/AccountsClient.js
@@ -1,4 +1,3 @@
-import 'url-search-params-polyfill';
 import 'whatwg-fetch';
 import Cookies from 'js-cookie';
 
@@ -6,10 +5,11 @@ const deactivate = (password) => fetch('/api/user/v1/accounts/deactivate_logout/
   method: 'POST',
   credentials: 'same-origin',
   headers: {
-    'Content-Type': 'application/x-www-form-urlencoded',
+    'Content-Type': 'application/x-www-form-urlencoded; charset=UTF-8',
     'X-CSRFToken': Cookies.get('csrftoken'),
   },
-  body: new URLSearchParams({ password }),
+  // URLSearchParams + polyfill doesn't work in IE11
+  body: `password=${encodeURIComponent(password)}`,
 }).then((response) => {
   if (response.ok) {
     return response;

--- a/lms/static/js/student_account/components/StudentAccountDeletionModal.jsx
+++ b/lms/static/js/student_account/components/StudentAccountDeletionModal.jsx
@@ -1,7 +1,6 @@
 /* globals gettext */
 /* eslint-disable react/no-danger */
 import React from 'react';
-import 'whatwg-fetch';
 import PropTypes from 'prop-types';
 import { Button, Modal, Icon, InputText, StatusAlert } from '@edx/paragon/static';
 import StringUtils from 'edx-ui-toolkit/js/utils/string-utils';
@@ -46,8 +45,8 @@ class StudentAccountDeletionConfirmationModal extends React.Component {
             validationErrorDetails: '',
           }))
           .catch(error => this.failedSubmission(error))
-        ),
-      );
+      ),
+    );
   }
 
   failedSubmission(error) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -10391,11 +10391,6 @@
         }
       }
     },
-    "url-search-params-polyfill": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/url-search-params-polyfill/-/url-search-params-polyfill-3.0.0.tgz",
-      "integrity": "sha512-oRNWuBkJ/zKKK1aiBaTBZTf07zOKd0g+nJYB+vFNPO14gFjA75BaHgIJLtveWBRxI/2qff7xcTb9H6wkpTmqjg=="
-    },
     "user-home": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/user-home/-/user-home-2.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -55,7 +55,6 @@
     "uglify-js": "2.7.0",
     "underscore": "1.8.3",
     "underscore.string": "3.3.4",
-    "url-search-params-polyfill": "3.0.0",
     "webpack": "2.7.0",
     "webpack-bundle-tracker": "0.2.1",
     "webpack-merge": "4.1.1",


### PR DESCRIPTION
[LEARNER-5278](https://openedx.atlassian.net/browse/LEARNER-5218)

Currently, deleting one's account in IE 11 does not succeed, even when the password is correct.

This is due to the fact that `URLSearchParams` and it's polyfill do not work in IE11.

Replacing `URLSearchParams` with a concatentated string results in successful completion of the request.

![screen shot 2018-05-10 at 3 06 18 pm](https://user-images.githubusercontent.com/8136030/39889333-93b73b44-5465-11e8-805b-04e91e4a9014.png)

I don't know if this is a limitation of `whatwg-fetch` specifically, or if `axios` would perform better.

You can test this on my sandbox [here](https://jaebradley.sandbox.edx.org/).