### PR TITLE
LEARNER-5123 | Visible Blocks improvements

### DIFF
--- a/lms/djangoapps/grades/tasks.py
+++ b/lms/djangoapps/grades/tasks.py
@@ -27,7 +27,6 @@ from .config.waffle import DISABLE_REGRADE_ON_POLICY_CHANGE, waffle
 from .constants import ScoreDatabaseTableEnum
 from .course_grade_factory import CourseGradeFactory
 from .exceptions import DatabaseNotReadyError
-from .models import VisibleBlocks
 from .services import GradesService
 from .signals.signals import SUBSECTION_SCORE_CHANGED
 from .subsection_grade_factory import SubsectionGradeFactory
@@ -41,7 +40,6 @@ KNOWN_RETRY_ERRORS = (  # Errors we expect occasionally, should be resolved on r
     ValidationError,
     DatabaseNotReadyError,
 )
-MAX_VISIBLE_BLOCKS_ALLOWED = 50000
 RECALCULATE_GRADE_DELAY_SECONDS = 2  # to prevent excessive _has_db_updated failures. See TNL-6424.
 RETRY_DELAY_SECONDS = 30
 SUBSECTION_GRADE_TIMEOUT_SECONDS = 300
@@ -138,12 +136,6 @@ def recalculate_course_and_subsection_grades_for_user(self, **kwargs):  # pylint
 
     user = User.objects.get(id=user_id)
     course_key = CourseKey.from_string(course_key_str)
-
-    # Hotfix to address LEARNER-5123, to be removed later
-    visible_blocks_count = VisibleBlocks.objects.filter(course_id=course_key)
-    if visible_blocks_count > MAX_VISIBLE_BLOCKS_ALLOWED:
-        message = '{} has too many VisibleBlocks to recalculate grades for {}'
-        raise Exception(message.format(course_key_str, user_id))
 
     previous_course_grade = CourseGradeFactory().read(user, course_key=course_key)
     if previous_course_grade and previous_course_grade.attempted:

--- a/lms/djangoapps/grades/tests/test_course_grade_factory.py
+++ b/lms/djangoapps/grades/tests/test_course_grade_factory.py
@@ -97,56 +97,28 @@ class TestCourseGradeFactory(GradeTestBase):
         with self.assertNumQueries(2), mock_get_score(1, 2):
             _assert_read(expected_pass=False, expected_percent=0)  # start off with grade of 0
 
-        # TODO: Remove Django 1.11 upgrade shim
-        # SHIM: Django 1.11 results in a few more SAVEPOINTs due to:
-        # https://github.com/django/django/commit/d44afd88#diff-5b0dda5eb9a242c15879dc9cd2121379L485
-        if django.VERSION >= (1, 11):
-            num_queries = 37
-        else:
-            num_queries = 29
-
+        num_queries = 40
         with self.assertNumQueries(num_queries), mock_get_score(1, 2):
             grade_factory.update(self.request.user, self.course, force_update_subsections=True)
 
         with self.assertNumQueries(2):
             _assert_read(expected_pass=True, expected_percent=0.5)  # updated to grade of .5
 
-        # TODO: Remove Django 1.11 upgrade shim
-        # SHIM: Django 1.11 results in a few more SAVEPOINTs due to:
-        # https://github.com/django/django/commit/d44afd88#diff-5b0dda5eb9a242c15879dc9cd2121379L485
-        if django.VERSION >= (1, 11):
-            num_queries = 6
-        else:
-            num_queries = 4
-
+        num_queries = 6
         with self.assertNumQueries(num_queries), mock_get_score(1, 4):
             grade_factory.update(self.request.user, self.course, force_update_subsections=False)
 
         with self.assertNumQueries(2):
             _assert_read(expected_pass=True, expected_percent=0.5)  # NOT updated to grade of .25
 
-        # TODO: Remove Django 1.11 upgrade shim
-        # SHIM: Django 1.11 results in a few more SAVEPOINTs due to:
-        # https://github.com/django/django/commit/d44afd88#diff-5b0dda5eb9a242c15879dc9cd2121379L485
-        if django.VERSION >= (1, 11):
-            num_queries = 20
-        else:
-            num_queries = 12
-
+        num_queries = 20
         with self.assertNumQueries(num_queries), mock_get_score(2, 2):
             grade_factory.update(self.request.user, self.course, force_update_subsections=True)
 
         with self.assertNumQueries(2):
             _assert_read(expected_pass=True, expected_percent=1.0)  # updated to grade of 1.0
 
-        # TODO: Remove Django 1.11 upgrade shim
-        # SHIM: Django 1.11 results in a few more SAVEPOINTs due to:
-        # https://github.com/django/django/commit/d44afd88#diff-5b0dda5eb9a242c15879dc9cd2121379L485
-        if django.VERSION >= (1, 11):
-            num_queries = 20
-        else:
-            num_queries = 12
-
+        num_queries = 23
         with self.assertNumQueries(num_queries), mock_get_score(0, 0):  # the subsection now is worth zero
             grade_factory.update(self.request.user, self.course, force_update_subsections=True)
 

--- a/lms/djangoapps/grades/tests/test_models.py
+++ b/lms/djangoapps/grades/tests/test_models.py
@@ -132,11 +132,16 @@ class VisibleBlocksTest(GradesModelTestCase):
     """
     shard = 4
 
-    def _create_block_record_list(self, blocks):
+    def setUp(self):
+        super(VisibleBlocksTest, self).setUp()
+        self.user_id = 12345
+
+    def _create_block_record_list(self, blocks, user_id=None):
         """
         Creates and returns a BlockRecordList for the given blocks.
         """
-        return VisibleBlocks.cached_get_or_create(BlockRecordList.from_list(blocks, self.course_key))
+        block_record_list = BlockRecordList.from_list(blocks, self.course_key)
+        return VisibleBlocks.cached_get_or_create(user_id or self.user_id, block_record_list)
 
     def test_creation(self):
         """

--- a/lms/djangoapps/grades/tests/test_scores.py
+++ b/lms/djangoapps/grades/tests/test_scores.py
@@ -61,10 +61,7 @@ class TestScoredBlockTypes(TestCase):
     }
 
     def test_block_types_possibly_scored(self):
-        self.assertSetEqual(
-            self.possibly_scored_block_types,
-            scores._block_types_possibly_scored()
-        )
+        self.assertTrue(self.possibly_scored_block_types.issubset(scores._block_types_possibly_scored()))
 
     def test_possibly_scored(self):
         course_key = CourseLocator(u'org', u'course', u'run')


### PR DESCRIPTION
https://openedx.atlassian.net/browse/LEARNER-5123
https://openedx.atlassian.net/browse/OPS-3111

* Cache VisibleBlocks per course AND user, only fetch the ones the user needs for subsection scoring.
* Removes the hotfix bandaid we applied yesterday that blocked courses with too many VisibleBlocks from getting grades recalculated.