### PR TITLE
Create the retire_user method on ApiAccessRequest model

### DIFF
--- a/openedx/core/djangoapps/api_admin/models.py
+++ b/openedx/core/djangoapps/api_admin/models.py
@@ -80,6 +80,30 @@ class ApiAccessRequest(TimeStampedModel):
         except cls.DoesNotExist:
             return None
 
+    @classmethod
+    def retire_user(cls, user):
+        """
+        Retires the user's API acccess request table for GDPR
+
+        Arguments:
+            user (User): The user linked to the data to retire in the model.
+
+        Returns:
+            True: If the user has a linked data in the model and retirement is successful
+            False: user has no linked data in the model.
+        """
+        try:
+            retire_target = cls.objects.get(user=user)
+        except cls.DoesNotExist:
+            return False
+        else:
+            retire_target.website = ''
+            retire_target.company_address = ''
+            retire_target.company_name = ''
+            retire_target.reason = ''
+            retire_target.save()
+            return True
+
     def approve(self):
         """Approve this request."""
         log.info('Approving API request from user [%s].', self.user.id)

--- a/openedx/core/djangoapps/api_admin/tests/test_models.py
+++ b/openedx/core/djangoapps/api_admin/tests/test_models.py
@@ -64,6 +64,19 @@ class ApiAccessRequestTests(TestCase):
         self.assertIn(self.request.website, request_unicode)  # pylint: disable=no-member
         self.assertIn(self.request.status, request_unicode)
 
+    def test_retire_user_success(self):
+        retire_result = self.request.retire_user(self.user)
+        self.assertTrue(retire_result)
+        self.assertEqual(self.request.company_address, '')
+        self.assertEqual(self.request.company_name, '')
+        self.assertEqual(self.request.website, '')
+        self.assertEqual(self.request.reason, '')
+
+    def test_retire_user_do_not_exist(self):
+        user2 = UserFactory()
+        retire_result = self.request.retire_user(user2)
+        self.assertFalse(retire_result)
+
 
 class ApiAccessConfigTests(TestCase):
 


### PR DESCRIPTION
@edx/educator-neem Please code review
This change is to expose the method to remove the linked ApiAccessRequest data according to user. Part of the GDPR