### PR TITLE
EDUCAOTR-2870: move oauth token retirement to deactivation endpoint

### DIFF
--- a/openedx/core/djangoapps/user_api/accounts/tests/test_views.py
+++ b/openedx/core/djangoapps/user_api/accounts/tests/test_views.py
@@ -1112,7 +1112,8 @@ class TestDeactivateLogout(RetirementTestCase):
     def build_post(self, password):
         return {'password': password}
 
-    def test_user_can_deactivate_self(self):
+    @mock.patch('openedx.core.djangolib.oauth2_retirement_utils')
+    def test_user_can_deactivate_self(self, retirement_utils_mock):
         """
         Verify a user calling the deactivation endpoint logs out the user, deletes all their SSO tokens,
         and creates a user retirement row.
@@ -1128,6 +1129,9 @@ class TestDeactivateLogout(RetirementTestCase):
         self.assertEqual(list(UserSocialAuth.objects.filter(user=self.test_user)), [])
         self.assertEqual(list(Registration.objects.filter(user=self.test_user)), [])
         self.assertEqual(len(UserRetirementStatus.objects.filter(user_id=self.test_user.id)), 1)
+        # these retirement utils are tested elsewhere; just make sure we called them
+        retirement_utils_mock.retire_dop_oauth2_models.assertCalledWith(self.test_user)
+        retirement_utils_mock.retire_dot_oauth2_models.assertCalledWith(self.test_user)
         # make sure the user cannot log in
         self.assertFalse(self.client.login(username=self.test_user.username, password=self.test_password))
 

--- a/openedx/core/djangoapps/user_api/accounts/views.py
+++ b/openedx/core/djangoapps/user_api/accounts/views.py
@@ -32,6 +32,7 @@ from openedx.core.djangoapps.course_groups.models import UnregisteredLearnerCoho
 from openedx.core.djangoapps.profile_images.images import remove_profile_images
 from openedx.core.djangoapps.user_api.accounts.image_helpers import get_profile_image_names, set_has_profile_image
 from openedx.core.djangoapps.user_api.preferences.api import update_email_opt_in
+from openedx.core.djangolib.oauth2_retirement_utils import retire_dop_oauth2_models, retire_dot_oauth2_models
 from openedx.core.lib.api.authentication import (
     OAuth2AuthenticationAllowInactiveUser,
     SessionAuthenticationAllowInactiveUser
@@ -417,6 +418,9 @@ class DeactivateLogoutView(APIView):
                 # Remove the activation keys sent by email to the user for account activation.
                 Registration.objects.filter(user=request.user).delete()
                 # Add user to retirement queue.
+                # Delete OAuth tokens associated with the user.
+                retire_dop_oauth2_models(request.user)
+                retire_dot_oauth2_models(request.user)
                 # Log the user out.
                 logout(request)
             return Response(status=status.HTTP_204_NO_CONTENT)


### PR DESCRIPTION
Uses the previously-implemented OAuth retirement helpers to ensure that users do not remain logged in on mobile once they've asked to be deleted.