### PR TITLE
update cookie policy banner package to 1.1.7

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,9 +5,9 @@
   "requires": true,
   "dependencies": {
     "@edx/cookie-policy-banner": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/@edx/cookie-policy-banner/-/cookie-policy-banner-1.1.6.tgz",
-      "integrity": "sha512-uiK+jhncxzfncgoRT4H4Y5bj5yUMKPsPqtCdVXBN3a8DGcCMZMedNA73q+hpsioVSJGijRYloR1sm+zlkjgQsg==",
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/@edx/cookie-policy-banner/-/cookie-policy-banner-1.1.7.tgz",
+      "integrity": "sha512-Zzyg8LHjWFQrc8xMR3vJEMgKtMiHdiZ8BuwnLFhc4AUsVVzIBIYsbgSf7gXr4XC+0WRcT4uoKcMaTJ5xitWaHw==",
       "requires": {
         "@edx/edx-bootstrap": "0.4.3",
         "@edx/paragon": "2.6.4",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "edx",
   "version": "0.1.0",
   "dependencies": {
-    "@edx/cookie-policy-banner": "1.1.6",
+    "@edx/cookie-policy-banner": "1.1.7",
     "@edx/edx-bootstrap": "0.4.3",
     "@edx/paragon": "2.6.4",
     "@edx/studio-frontend": "1.9.9",


### PR DESCRIPTION
[LEARNER-5271](https://openedx.atlassian.net/browse/LEARNER-5271)

[@edx/cookie-policy-banner#17](https://github.com/edx/cookie-policy-banner/pull/17) (and the subsequently released `v1.1.7`) fixed some minor copy issues associated with the cookie policy banner.

Updating the package here to reflect these copy changes.