### PR TITLE
Call count() when you want a count.

### DIFF
--- a/lms/djangoapps/grades/tasks.py
+++ b/lms/djangoapps/grades/tasks.py
@@ -140,7 +140,7 @@ def recalculate_course_and_subsection_grades_for_user(self, **kwargs):  # pylint
     course_key = CourseKey.from_string(course_key_str)
 
     # Hotfix to address LEARNER-5123, to be removed later
-    visible_blocks_count = VisibleBlocks.objects.filter(course_id=course_key)
+    visible_blocks_count = VisibleBlocks.objects.filter(course_id=course_key).count()
     if visible_blocks_count > MAX_VISIBLE_BLOCKS_ALLOWED:
         message = '{} has too many VisibleBlocks to recalculate grades for {}'
         raise Exception(message.format(course_key_str, user_id))

--- a/lms/djangoapps/grades/tests/test_tasks.py
+++ b/lms/djangoapps/grades/tests/test_tasks.py
@@ -486,7 +486,7 @@ class RecalculateGradesForUserTest(HasCourseWithProblemsMixin, ModuleStoreTestCa
         self.set_up_course()
         CourseEnrollment.enroll(self.user, self.course.id)
         self.original_max_visible_blocks_allowed = tasks.MAX_VISIBLE_BLOCKS_ALLOWED
-        tasks.MAX_VISIBLE_BLOCKS_ALLOWED = 1
+        tasks.MAX_VISIBLE_BLOCKS_ALLOWED = -1
 
     def tearDown(self):
         super(RecalculateGradesForUserTest, self).tearDown()

--- a/openedx/core/djangoapps/api_admin/models.py
+++ b/openedx/core/djangoapps/api_admin/models.py
@@ -80,6 +80,30 @@ class ApiAccessRequest(TimeStampedModel):
         except cls.DoesNotExist:
             return None
 
+    @classmethod
+    def retire_user(cls, user):
+        """
+        Retires the user's API acccess request table for GDPR
+
+        Arguments:
+            user (User): The user linked to the data to retire in the model.
+
+        Returns:
+            True: If the user has a linked data in the model and retirement is successful
+            False: user has no linked data in the model.
+        """
+        try:
+            retire_target = cls.objects.get(user=user)
+        except cls.DoesNotExist:
+            return False
+        else:
+            retire_target.website = ''
+            retire_target.company_address = ''
+            retire_target.company_name = ''
+            retire_target.reason = ''
+            retire_target.save()
+            return True
+
     def approve(self):
         """Approve this request."""
         log.info('Approving API request from user [%s].', self.user.id)

--- a/openedx/core/djangoapps/api_admin/tests/test_models.py
+++ b/openedx/core/djangoapps/api_admin/tests/test_models.py
@@ -64,6 +64,19 @@ class ApiAccessRequestTests(TestCase):
         self.assertIn(self.request.website, request_unicode)  # pylint: disable=no-member
         self.assertIn(self.request.status, request_unicode)
 
+    def test_retire_user_success(self):
+        retire_result = self.request.retire_user(self.user)
+        self.assertTrue(retire_result)
+        self.assertEqual(self.request.company_address, '')
+        self.assertEqual(self.request.company_name, '')
+        self.assertEqual(self.request.website, '')
+        self.assertEqual(self.request.reason, '')
+
+    def test_retire_user_do_not_exist(self):
+        user2 = UserFactory()
+        retire_result = self.request.retire_user(user2)
+        self.assertFalse(retire_result)
+
 
 class ApiAccessConfigTests(TestCase):
 

--- a/openedx/core/djangoapps/user_api/accounts/tests/test_views.py
+++ b/openedx/core/djangoapps/user_api/accounts/tests/test_views.py
@@ -1112,7 +1112,8 @@ class TestDeactivateLogout(RetirementTestCase):
     def build_post(self, password):
         return {'password': password}
 
-    def test_user_can_deactivate_self(self):
+    @mock.patch('openedx.core.djangolib.oauth2_retirement_utils')
+    def test_user_can_deactivate_self(self, retirement_utils_mock):
         """
         Verify a user calling the deactivation endpoint logs out the user, deletes all their SSO tokens,
         and creates a user retirement row.
@@ -1128,6 +1129,9 @@ class TestDeactivateLogout(RetirementTestCase):
         self.assertEqual(list(UserSocialAuth.objects.filter(user=self.test_user)), [])
         self.assertEqual(list(Registration.objects.filter(user=self.test_user)), [])
         self.assertEqual(len(UserRetirementStatus.objects.filter(user_id=self.test_user.id)), 1)
+        # these retirement utils are tested elsewhere; just make sure we called them
+        retirement_utils_mock.retire_dop_oauth2_models.assertCalledWith(self.test_user)
+        retirement_utils_mock.retire_dot_oauth2_models.assertCalledWith(self.test_user)
         # make sure the user cannot log in
         self.assertFalse(self.client.login(username=self.test_user.username, password=self.test_password))
 

--- a/openedx/core/djangoapps/user_api/accounts/views.py
+++ b/openedx/core/djangoapps/user_api/accounts/views.py
@@ -32,6 +32,7 @@ from openedx.core.djangoapps.course_groups.models import UnregisteredLearnerCoho
 from openedx.core.djangoapps.profile_images.images import remove_profile_images
 from openedx.core.djangoapps.user_api.accounts.image_helpers import get_profile_image_names, set_has_profile_image
 from openedx.core.djangoapps.user_api.preferences.api import update_email_opt_in
+from openedx.core.djangolib.oauth2_retirement_utils import retire_dop_oauth2_models, retire_dot_oauth2_models
 from openedx.core.lib.api.authentication import (
     OAuth2AuthenticationAllowInactiveUser,
     SessionAuthenticationAllowInactiveUser
@@ -417,6 +418,9 @@ class DeactivateLogoutView(APIView):
                 # Remove the activation keys sent by email to the user for account activation.
                 Registration.objects.filter(user=request.user).delete()
                 # Add user to retirement queue.
+                # Delete OAuth tokens associated with the user.
+                retire_dop_oauth2_models(request.user)
+                retire_dot_oauth2_models(request.user)
                 # Log the user out.
                 logout(request)
             return Response(status=status.HTTP_204_NO_CONTENT)

--- a/openedx/core/djangoapps/user_api/accounts/views.py
+++ b/openedx/core/djangoapps/user_api/accounts/views.py
@@ -401,6 +401,7 @@ class DeactivateLogoutView(APIView):
             if verify_user_password_response.status_code != status.HTTP_204_NO_CONTENT:
                 return verify_user_password_response
             with transaction.atomic():
+                UserRetirementStatus.create_retirement(request.user)
                 # Unlink LMS social auth accounts
                 UserSocialAuth.objects.filter(user_id=request.user.id).delete()
                 # Change LMS password & email
@@ -411,7 +412,6 @@ class DeactivateLogoutView(APIView):
                 # Remove the activation keys sent by email to the user for account activation.
                 Registration.objects.filter(user=request.user).delete()
                 # Add user to retirement queue.
-                UserRetirementStatus.create_retirement(request.user)
                 # Log the user out.
                 logout(request)
             return Response(status=status.HTTP_204_NO_CONTENT)


### PR DESCRIPTION
We're currently not re-grading for students in _any_ course when they change enrollment tracks, because I forgot to chain a `.count()` to the end of a `filter()`.
```
lms.djangoapps.grades.tasks.recalculate_course_and_subsection_grades_for_user
exceptions:Exception
course-v1:HarvardMedGlobalAcademy+WL_E2E+2018 has too many VisibleBlocks to recalculate grades for 5203243  2:13 PM  2:17 PM
```