### PR TITLE
LEARNER-5185 Fix bug in cert generation for passing users who become approved

### DIFF
--- a/lms/djangoapps/certificates/signals.py
+++ b/lms/djangoapps/certificates/signals.py
@@ -83,6 +83,7 @@ def _listen_for_id_verification_status_changed(sender, user, **kwargs):  # pylin
     user_enrollments = CourseEnrollment.enrollments_for_user(user=user)
     grade_factory = CourseGradeFactory()
     expected_verification_status = IDVerificationService.user_status(user)
+    expected_verification_status = expected_verification_status['status']
     for enrollment in user_enrollments:
         if grade_factory.read(user=user, course=enrollment.course_overview).passed:
             if fire_ungenerated_certificate_task(user, enrollment.course_id, expected_verification_status):
@@ -93,7 +94,7 @@ def _listen_for_id_verification_status_changed(sender, user, **kwargs):  # pylin
                 log.info(message.format(
                     user=user.id,
                     course=enrollment.course_id,
-                    status=expected_verification_status['status']
+                    status=expected_verification_status
                 ))
 
 

--- a/lms/djangoapps/certificates/tasks.py
+++ b/lms/djangoapps/certificates/tasks.py
@@ -32,6 +32,15 @@ def generate_certificate(self, **kwargs):
     expected_verification_status = kwargs.pop('expected_verification_status', None)
     if expected_verification_status:
         actual_verification_status = IDVerificationService.user_status(student)
+        actual_verification_status = actual_verification_status['status']
         if expected_verification_status != actual_verification_status:
+            logger.warn('Expected verification status {expected} '
+                        'differs from actual verification status {actual} '
+                        'for user {user} in course {course}'.format(
+                            expected=expected_verification_status,
+                            actual=actual_verification_status,
+                            user=student.id,
+                            course=course_key
+                        ))
             raise self.retry(kwargs=original_kwargs)
     generate_user_certificates(student=student, course_key=course_key, **kwargs)

--- a/lms/djangoapps/certificates/tests/test_signals.py
+++ b/lms/djangoapps/certificates/tests/test_signals.py
@@ -15,7 +15,7 @@ from lms.djangoapps.certificates.models import (
 from lms.djangoapps.certificates.signals import fire_ungenerated_certificate_task, CERTIFICATE_DELAY_SECONDS
 from lms.djangoapps.grades.course_grade_factory import CourseGradeFactory
 from lms.djangoapps.grades.tests.utils import mock_passing_grade
-from lms.djangoapps.verify_student.models import SoftwareSecurePhotoVerification
+from lms.djangoapps.verify_student.models import IDVerificationAttempt, SoftwareSecurePhotoVerification
 from openedx.core.djangoapps.certificates.config import waffle
 from student.tests.factories import CourseEnrollmentFactory, UserFactory
 from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
@@ -263,17 +263,12 @@ class LearnerTrackChangeCertsTest(ModuleStoreTestCase):
                     status='submitted'
                 )
                 attempt.approve()
-                expected_verification_status = {
-                    'status': 'approved',
-                    'error': '',
-                    'should_display': True,
-                }
                 mock_generate_certificate_apply_async.assert_called_with(
                     countdown=CERTIFICATE_DELAY_SECONDS,
                     kwargs={
                         'student': unicode(self.user_one.id),
                         'course_key': unicode(self.course_one.id),
-                        'expected_verification_status': unicode(expected_verification_status),
+                        'expected_verification_status': IDVerificationAttempt.STATUS.approved,
                     }
                 )
 
@@ -289,17 +284,12 @@ class LearnerTrackChangeCertsTest(ModuleStoreTestCase):
                     status='submitted'
                 )
                 attempt.approve()
-                expected_verification_status = {
-                    'status': 'approved',
-                    'error': '',
-                    'should_display': True,
-                }
                 mock_generate_certificate_apply_async.assert_called_with(
                     countdown=CERTIFICATE_DELAY_SECONDS,
                     kwargs={
                         'student': unicode(self.user_two.id),
                         'course_key': unicode(self.course_two.id),
-                        'expected_verification_status': unicode(expected_verification_status),
+                        'expected_verification_status': IDVerificationAttempt.STATUS.approved,
                     }
                 )
 

--- a/lms/djangoapps/certificates/tests/test_tasks.py
+++ b/lms/djangoapps/certificates/tests/test_tasks.py
@@ -4,6 +4,7 @@ from mock import call, patch
 from opaque_keys.edx.keys import CourseKey
 
 from lms.djangoapps.certificates.tasks import generate_certificate
+from lms.djangoapps.verify_student.models import IDVerificationAttempt
 from student.tests.factories import UserFactory
 
 
@@ -47,16 +48,10 @@ class GenerateUserCertificateTest(TestCase):
         course_key = 'course-v1:edX+CS101+2017_T2'
         student = UserFactory()
 
-        expected_verification_status = {
-            'status': 'approved',
-            'error': '',
-            'should_display': True,
-        }
-
         kwargs = {
             'student': student.id,
             'course_key': course_key,
-            'expected_verification_status': expected_verification_status,
+            'expected_verification_status': IDVerificationAttempt.STATUS.approved
         }
 
         user_status_mock.side_effect = [


### PR DESCRIPTION
Because of the way async tasks pass arguments, we were passing in a string of a dictionary
that contained the id verification status but checking it against a dictionary in the
task's function, which was causing errors for generating certificates for passing users
whose id verification status changes to approved after they are passing.