### PR TITLE
Make recalculate_course_and_subsection_grades_for_user task logged.

### DIFF
--- a/lms/djangoapps/grades/tasks.py
+++ b/lms/djangoapps/grades/tasks.py
@@ -117,6 +117,7 @@ def compute_grades_for_course(course_key, offset, batch_size, **kwargs):  # pyli
 
 @task(
     bind=True,
+    base=LoggedPersistOnFailureTask,
     time_limit=SUBSECTION_GRADE_TIMEOUT_SECONDS,
     max_retries=2,
     default_retry_delay=RETRY_DELAY_SECONDS,


### PR DESCRIPTION
Very minor change - just makes a new task use `LoggedPersistOnFailureTask` the base task class, so that we get a little more logging information (like the kwargs it was submitted with) and also get a DB record on task failure.