### PR TITLE
Clean up enrollment rate limit waffles

### DIFF
--- a/common/djangoapps/enrollment/__init__.py
+++ b/common/djangoapps/enrollment/__init__.py
@@ -1,9 +1,0 @@
-"""
-Enrollment API helpers and settings
-"""
-from openedx.core.djangoapps.waffle_utils import (WaffleFlag, WaffleFlagNamespace)
-
-WAFFLE_FLAG_NAMESPACE = WaffleFlagNamespace(name='enrollment_api_rate_limit')
-
-REDUCE_RATE_LIMIT_FOR_STAFF_FOR_ENROLLMENT_API = WaffleFlag(WAFFLE_FLAG_NAMESPACE, 'reduce_staff_rate_limit')
-USE_UNIVERSAL_RATE_LIMIT_FOR_ENROLLMENT_API = WaffleFlag(WAFFLE_FLAG_NAMESPACE, 'use_universal_rate_limit')

--- a/common/djangoapps/enrollment/views.py
+++ b/common/djangoapps/enrollment/views.py
@@ -12,8 +12,6 @@ from django.utils.decorators import method_decorator
 from edx_rest_framework_extensions.authentication import JwtAuthentication
 from enrollment import api
 from enrollment.errors import CourseEnrollmentError, CourseEnrollmentExistsError, CourseModeNotFoundError
-from enrollment import REDUCE_RATE_LIMIT_FOR_STAFF_FOR_ENROLLMENT_API, \
-    USE_UNIVERSAL_RATE_LIMIT_FOR_ENROLLMENT_API
 from opaque_keys import InvalidKeyError
 from opaque_keys.edx.keys import CourseKey
 
@@ -78,28 +76,7 @@ class ApiKeyPermissionMixIn(object):
 
 class EnrollmentUserThrottle(UserRateThrottle, ApiKeyPermissionMixIn):
     """Limit the number of requests users can make to the enrollment API."""
-    # TODO: After confirming that reducing the throttle is successful, remove
-    # and clean up waffles. The rate limit has been increased over the course
-    # of a few months to account for unnecessary calls from the ecommerce
-    # service. These calls are no longer made and the plan is to set the
-    # rate limit back to its original state. LEARNER-5148
-
-    # Current rate limit
-    THROTTLE_RATES = {
-        'user': '40/minute',
-        'staff': '2000/minute',
-    }
-
-    # Less aggressive reduction in throttle limit. This should not be necessary
-    if REDUCE_RATE_LIMIT_FOR_STAFF_FOR_ENROLLMENT_API.is_enabled():
-        THROTTLE_RATES = {
-            'user': '40/minute',
-            'staff': '400/minute',
-        }
-
-    # Original rate Limit before rate limit increases.
-    if USE_UNIVERSAL_RATE_LIMIT_FOR_ENROLLMENT_API.is_enabled():
-        rate = '40/minute'
+    rate = '40/minute'
 
     def allow_request(self, request, view):
         # Use a special scope for staff to allow for a separate throttle rate


### PR DESCRIPTION
https://openedx.atlassian.net/browse/LEARNER-5038
* https://openedx.atlassian.net/browse/LEARNER-5167
* https://openedx.atlassian.net/browse/LEARNER-5166

I've confirmed that there are no staff users exceeding the rate limit over the past week.

This PR is the corrected implementation of https://github.com/edx/edx-platform/pull/18163