### PR TITLE
Upgrade using pip-tools.

### DIFF
--- a/requirements/edx-sandbox/base.txt
+++ b/requirements/edx-sandbox/base.txt
@@ -4,7 +4,6 @@
 #
 #    make upgrade
 #
-
 common/lib/calc
 common/lib/chem
 common/lib/sandbox-packages
@@ -25,7 +24,7 @@ nose==1.3.7               # via matplotlib
 numpy==1.6.2
 pycparser==2.18
 pyparsing==2.2.0
-python-dateutil==2.7.2    # via matplotlib
+python-dateutil==2.7.3    # via matplotlib
 scipy==0.14.0
 singledispatch==3.4.0.3   # via tornado
 six==1.11.0

--- a/requirements/edx-sandbox/shared.txt
+++ b/requirements/edx-sandbox/shared.txt
@@ -4,7 +4,6 @@
 #
 #    make upgrade
 #
-
 -e common/lib/calc
 -e common/lib/chem
 -e common/lib/sandbox-packages

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -4,7 +4,6 @@
 #
 #    make upgrade
 #
-
 -e git+https://github.com/edx/acid-block.git@e46f9cda8a03e121a00c7e347084d142d22ebfb7#egg=acid-xblock
 -e common/lib/calc
 -e common/lib/capa
@@ -179,7 +178,7 @@ openapi-codec==1.3.2      # via django-rest-swagger
 path.py==8.2.1
 pathtools==0.1.2
 paver==1.3.4
-pbr==4.0.2
+pbr==4.0.3
 pdfminer==20140328
 piexif==1.0.2
 pillow==3.4.0
@@ -217,7 +216,7 @@ sailthru-client==2.2.3
 scipy==0.14.0
 shapely==1.2.16
 shortuuid==0.5.0          # via edx-django-oauth2-provider
-simplejson==3.14.0        # via django-rest-swagger, dogapi, mailsnake, sailthru-client, zendesk
+simplejson==3.15.0        # via django-rest-swagger, dogapi, mailsnake, sailthru-client, zendesk
 six==1.11.0
 slumber==0.7.1            # via edx-rest-api-client
 social-auth-app-django==1.2.0

--- a/requirements/edx/coverage.txt
+++ b/requirements/edx/coverage.txt
@@ -4,7 +4,6 @@
 #
 #    make upgrade
 #
-
 coverage==4.2
 diff-cover==0.9.8
 inflect==0.3.1            # via jinja2-pluralize

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -4,7 +4,6 @@
 #
 #    make upgrade
 #
-
 -e git+https://github.com/edx/acid-block.git@e46f9cda8a03e121a00c7e347084d142d22ebfb7#egg=acid-xblock
 -e common/lib/calc
 -e common/lib/capa
@@ -157,7 +156,7 @@ event-tracking==0.2.4
 execnet==1.5.0
 extras==1.0.0
 factory_boy==2.8.1
-faker==0.8.13
+faker==0.8.15
 feedparser==5.1.3
 firebase-token-generator==1.3.2
 first==2.0.1
@@ -230,7 +229,7 @@ parsel==1.4.0
 path.py==8.2.1
 pathtools==0.1.2
 paver==1.3.4
-pbr==4.0.2
+pbr==4.0.3
 pdfminer==20140328
 piexif==1.0.2
 pillow==3.4.0
@@ -299,7 +298,7 @@ selenium==3.12.0
 service-identity==17.0.0
 shapely==1.2.16
 shortuuid==0.5.0
-simplejson==3.14.0
+simplejson==3.15.0
 singledispatch==3.4.0.3
 six==1.11.0
 slumber==0.7.1
@@ -314,7 +313,7 @@ sphinxcontrib-websupport==1.0.1  # via sphinx
 splinter==0.8.0
 sqlparse==0.2.4           # via django-debug-toolbar
 stevedore==1.10.0
-sure==1.4.9
+sure==1.4.10
 sympy==0.7.1
 testfixtures==6.0.2
 testtools==2.3.0

--- a/requirements/edx/paver.txt
+++ b/requirements/edx/paver.txt
@@ -4,7 +4,6 @@
 #
 #    make upgrade
 #
-
 argh==0.26.2              # via watchdog
 argparse==1.4.0           # via stevedore
 edx-opaque-keys==0.4.4
@@ -15,7 +14,7 @@ mock==1.0.1
 path.py==8.2.1
 pathtools==0.1.2          # via watchdog
 paver==1.3.4
-pbr==4.0.2                # via stevedore
+pbr==4.0.3                # via stevedore
 psutil==1.2.1
 pymongo==2.9.1
 python-memcached==1.48

--- a/requirements/edx/pip-tools.txt
+++ b/requirements/edx/pip-tools.txt
@@ -4,7 +4,6 @@
 #
 #    make upgrade
 #
-
 click==6.7                # via pip-tools
 first==2.0.1              # via pip-tools
 pip-tools==2.0.2

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -4,7 +4,6 @@
 #
 #    make upgrade
 #
-
 -e git+https://github.com/edx/acid-block.git@e46f9cda8a03e121a00c7e347084d142d22ebfb7#egg=acid-xblock
 -e common/lib/calc
 -e common/lib/capa
@@ -132,7 +131,7 @@ edx-django-oauth2-provider==1.2.5
 edx-django-release-util==0.3.1
 edx-django-sites-extensions==2.3.1
 edx-drf-extensions==1.2.5
-edx-enterprise==0.68.1
+edx-enterprise==0.68.3
 edx-i18n-tools==0.4.5
 edx-lint==0.5.5
 edx-milestones==0.1.13
@@ -151,7 +150,7 @@ event-tracking==0.2.4
 execnet==1.5.0            # via pytest-xdist
 extras==1.0.0             # via python-subunit, testtools
 factory_boy==2.8.1
-faker==0.8.13             # via factory-boy
+faker==0.8.15             # via factory-boy
 feedparser==5.1.3
 firebase-token-generator==1.3.2
 fixtures==3.0.0           # via testtools
@@ -221,7 +220,7 @@ parsel==1.4.0             # via scrapy
 path.py==8.2.1
 pathtools==0.1.2
 paver==1.3.4
-pbr==4.0.2
+pbr==4.0.3
 pdfminer==20140328
 piexif==1.0.2
 pillow==3.4.0
@@ -288,7 +287,7 @@ selenium==3.12.0
 service-identity==17.0.0  # via scrapy
 shapely==1.2.16
 shortuuid==0.5.0
-simplejson==3.14.0
+simplejson==3.15.0
 singledispatch==3.4.0.3
 six==1.11.0
 slumber==0.7.1
@@ -298,7 +297,7 @@ sorl-thumbnail==12.3
 sortedcontainers==0.9.2
 splinter==0.8.0
 stevedore==1.10.0
-sure==1.4.9
+sure==1.4.10
 sympy==0.7.1
 testfixtures==6.0.2
 testtools==2.3.0          # via fixtures, python-subunit


### PR DESCRIPTION
# python-dateutils
```
Version 2.7.3 (2018-05-09)
==========================

Data updates
------------

- Update tzdata to 2018e. (gh pr #710)


Bugfixes
--------

- Fixed an issue where decimal.Decimal would cast `NaN` or infinite value in a
  parser.parse, which will raise decimal.Decimal-specific errors. Reported and
  fixed by @amureki (gh issue #662, gh pr #679).
- Fixed a ValueError being thrown if tzinfos call explicity returns ``None``.
  Reported by @pganssle (gh issue #661) Fixed by @parsethis (gh pr #681)
- Fixed incorrect parsing of certain dates earlier than 100 AD when repesented
  in the form "%B.%Y.%d", e.g. "December.0031.30". (gh issue #687, pr #700)
- Fixed a bug where automatically generated DTSTART was naive even if a
  specified UNTIL had a time zone. Automatically generated DTSTART will now
  take on the timezone of an UNTIL date, if provided. Reported by @href (gh
  issue #652). Fixed by @absreim (gh pr #693).
```

# pbr
```
Don’t poke in pip for requests
Fix builddoc with sphinx <= 1.6
```

# simplejson
```

Version 3.15.0 released 2018-05-12

* Clean up the C code
  https://github.com/simplejson/simplejson/pull/220
* Bypass the decode() method in bytes subclasses
  https://github.com/simplejson/simplejson/pull/219
* Support builds without cStringIO
  https://github.com/simplejson/simplejson/pull/217
* Allow to disable serializing bytes by default in Python 3
  https://github.com/simplejson/simplejson/pull/216
* Simplify the compatibility code
  https://github.com/simplejson/simplejson/pull/215
* Fix tests in Python 2.5
  https://github.com/simplejson/simplejson/pull/214
```
