### PR TITLE
Fixed tests that are flaky with firefox 59.

### DIFF
--- a/common/test/acceptance/pages/lms/login_and_register.py
+++ b/common/test/acceptance/pages/lms/login_and_register.py
@@ -218,7 +218,7 @@ class CombinedLoginAndRegisterPage(PageObject):
         if password:
             self.q(css="#register-password").fill(password)
         if country:
-            self.q(css="#register-country option[value='{country}']".format(country=country)).click()
+            self.q(css="#register-country").results[0].send_keys(country)
         if favorite_movie:
             self.q(css="#register-favorite_movie").fill(favorite_movie)
         if terms_of_service:
@@ -335,6 +335,8 @@ class CombinedLoginAndRegisterPage(PageObject):
         def _check_func():
             """Return success status and any errors that occurred."""
             errors = self.errors
+            if not errors:
+                self.q(css=".register-button").click()
             return (bool(errors), errors)
         return Promise(_check_func, "Errors are visible").fulfill()
 

--- a/common/test/acceptance/tests/lms/test_lms.py
+++ b/common/test/acceptance/tests/lms/test_lms.py
@@ -297,6 +297,31 @@ class RegisterFromCombinedPageTest(UniqueCourseTest):
             self.course_info['run'], self.course_info['display_name']
         ).install()
 
+    def test_register_failure(self):
+        # Navigate to the registration page
+        self.register_page.visit()
+
+        # Enter a blank for the username field, which is required
+        # Don't agree to the terms of service / honor code.
+        # Don't specify a country code, which is required.
+        # Don't specify a favorite movie.
+        username = "test_{uuid}".format(uuid=self.unique_id[0:6])
+        email = "{user}@example.com".format(user=username)
+        self.register_page.register(
+            email=email,
+            password="password",
+            username="",
+            full_name="Test User",
+            terms_of_service=False
+        )
+        # Verify that the expected errors are displayed.
+        errors = self.register_page.wait_for_errors()
+        self.assertIn(u'Please enter your Public Username.', errors)
+        self.assertIn(u'You must agree to the édX Terms of Service and Honor Code',
+                      errors)
+        self.assertIn(u'Select your country or region of residence.', errors)
+        self.assertIn(u'Please tell us your favorite movie.', errors)
+
     def test_toggle_to_login_form(self):
         self.register_page.visit().toggle_form()
         self.assertEqual(self.register_page.current_form, "login")

--- a/common/test/acceptance/tests/lms/test_lms_instructor_dashboard.py
+++ b/common/test/acceptance/tests/lms/test_lms_instructor_dashboard.py
@@ -138,6 +138,38 @@ class AutoEnrollmentWithCSVTest(BaseInstructorDashboardTest):
         self.assertTrue(self.auto_enroll_section.is_file_attachment_browse_button_visible())
         self.assertTrue(self.auto_enroll_section.is_upload_button_visible())
 
+    def test_enroll_unregister_student(self):
+        """
+        Scenario: On the Membership tab of the Instructor Dashboard, Batch Enrollment div is visible.
+            Given that I am on the Membership tab on the Instructor Dashboard
+            Then I enter the email and enroll it.
+            Logout the current page.
+            And Navigate to the registration page and register the student.
+            Then I see the course which enrolled the student.
+        """
+        username = "test_{uuid}".format(uuid=self.unique_id[0:6])
+        email = "{user}@example.com".format(user=username)
+        self.auto_enroll_section.fill_enrollment_batch_text_box(email)
+        self.assertIn(
+            'Successfully sent enrollment emails to the following users. '
+            'They will be enrolled once they register:',
+            self.auto_enroll_section.get_notification_text()
+        )
+        LogoutPage(self.browser).visit()
+        self.register_page.visit()
+        self.register_page.register(
+            email=email,
+            password="123456",
+            username=username,
+            full_name="Test User",
+            terms_of_service=True,
+            country="US",
+            favorite_movie="Harry Potter",
+        )
+        course_names = self.dashboard_page.wait_for_page().available_courses
+        self.assertEquals(len(course_names), 1)
+        self.assertIn(self.course_info["display_name"], course_names)
+
     def test_clicking_file_upload_button_without_file_shows_error(self):
         """
         Scenario: Clicking on the upload button without specifying a CSV file results in error.


### PR DESCRIPTION
These tests `test_register_failure`, `test_enroll_unregister_student` are all flaky on firefox 59, I have fixed both tests in my PR. 
https://openedx.atlassian.net/browse/EDUCATOR-2563
https://openedx.atlassian.net/browse/EDUCATOR-2572