### PR TITLE
[ENT-996] Upgrade edx-enterprise to 0.68.4.

### DIFF
--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -117,7 +117,7 @@ edx-django-oauth2-provider==1.2.5
 edx-django-release-util==0.3.1
 edx-django-sites-extensions==2.3.1
 edx-drf-extensions==1.2.5
-edx-enterprise==0.68.3
+edx-enterprise==0.68.4
 edx-i18n-tools==0.4.5
 edx-milestones==0.1.13
 edx-oauth2-provider==1.2.2

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -136,7 +136,7 @@ edx-django-oauth2-provider==1.2.5
 edx-django-release-util==0.3.1
 edx-django-sites-extensions==2.3.1
 edx-drf-extensions==1.2.5
-edx-enterprise==0.68.3
+edx-enterprise==0.68.4
 edx-i18n-tools==0.4.5
 edx-lint==0.5.5
 edx-milestones==0.1.13

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -131,7 +131,7 @@ edx-django-oauth2-provider==1.2.5
 edx-django-release-util==0.3.1
 edx-django-sites-extensions==2.3.1
 edx-drf-extensions==1.2.5
-edx-enterprise==0.68.3
+edx-enterprise==0.68.4
 edx-i18n-tools==0.4.5
 edx-lint==0.5.5
 edx-milestones==0.1.13


### PR DESCRIPTION
Is for https://github.com/edx/edx-enterprise/pull/314.

Note https://github.com/edx/edx-platform/pull/18214#issuecomment-389658354 -- I did this manually.