### PR TITLE
update api request form

### DIFF
--- a/openedx/core/djangoapps/api_admin/forms.py
+++ b/openedx/core/djangoapps/api_admin/forms.py
@@ -15,15 +15,15 @@ class ApiAccessRequestForm(forms.ModelForm):
         model = ApiAccessRequest
         fields = ('company_name', 'website', 'company_address', 'reason', 'terms_of_service')
         labels = {
-            'company_name': _('Company Name'),
-            'company_address': _('Company Address'),
+            'company_name': _('Organization Name'),
+            'company_address': _('Organization Address'),
             'reason': _('Describe what your application does.'),
         }
         help_texts = {
             'reason': None,
-            'website': _("The URL of your company's website."),
-            'company_name': _('The name of your company.'),
-            'company_address': _('The contact address of your company.'),
+            'website': _("The URL of your organization's website."),
+            'company_name': _('The name of your organization.'),
+            'company_address': _('The contact address of your organization.'),
         }
         widgets = {
             'company_address': forms.Textarea()

--- a/openedx/core/djangoapps/api_admin/widgets.py
+++ b/openedx/core/djangoapps/api_admin/widgets.py
@@ -33,7 +33,9 @@ class TermsOfServiceCheckboxInput(CheckboxInput):
 
         # Translators: link_start and link_end are HTML tags for a link to the terms of service.
         # platform_name is the name of this Open edX installation.
-        label = _('I, and my company, accept the {link_start}{platform_name} API Terms of Service{link_end}.').format(
+        label = _(
+            'I, and my organization, accept the {link_start}{platform_name} API Terms of Service{link_end}.'
+        ).format(
             platform_name=configuration_helpers.get_value('PLATFORM_NAME', settings.PLATFORM_NAME),
             link_start='<a href="{url}" target="_blank">'.format(url=reverse('api_admin:api-tos')),
             link_end='</a>',


### PR DESCRIPTION
[ENT-989](https://openedx.atlassian.net/browse/ENT-989)

**Testing instructions:**

NOTE: I have tried to verify the changes with `staff` user but page redirects to `https://business.sandbox.edx.org/api-admin/status`, so I have created a new user to verify the changes.

1. Go to edX api request access at `https://business.sandbox.edx.org/api-admin/`
2. You can see that all `company` references are replaced with `organization`

