### PR TITLE
Upgrades to avoid sure install bug

### DIFF
--- a/requirements/edx-sandbox/base.txt
+++ b/requirements/edx-sandbox/base.txt
@@ -4,6 +4,7 @@
 #
 #    make upgrade
 #
+
 common/lib/calc
 common/lib/chem
 common/lib/sandbox-packages
@@ -11,7 +12,7 @@ common/lib/symmath
 asn1crypto==0.24.0
 backports-abc==0.5        # via tornado
 cffi==1.11.5
-cryptography==2.1.4
+cryptography==2.2.2
 enum34==1.1.6
 futures==3.2.0            # via tornado
 idna==2.6

--- a/requirements/edx-sandbox/shared.in
+++ b/requirements/edx-sandbox/shared.in
@@ -7,7 +7,7 @@
 #   * confirm that it has no system requirements beyond what we already install
 #   * run "make upgrade" to update the detailed requirements files
 
-cryptography==2.1.4                 # Implementations of assorted cryptography algorithms
+cryptography                        # Implementations of assorted cryptography algorithms
 lxml==3.8.0                         # XML parser
 networkx==1.7                       # Utilities for creating, manipulating, and studying network graphs
 nltk                                # Natural language processing; used by the chem package

--- a/requirements/edx-sandbox/shared.txt
+++ b/requirements/edx-sandbox/shared.txt
@@ -4,13 +4,14 @@
 #
 #    make upgrade
 #
+
 -e common/lib/calc
 -e common/lib/chem
 -e common/lib/sandbox-packages
 -e common/lib/symmath
 asn1crypto==0.24.0        # via cryptography
 cffi==1.11.5              # via cryptography
-cryptography==2.1.4
+cryptography==2.2.2
 enum34==1.1.6             # via cryptography
 idna==2.6                 # via cryptography
 ipaddress==1.0.22         # via cryptography

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -4,6 +4,7 @@
 #
 #    make upgrade
 #
+
 -e git+https://github.com/edx/acid-block.git@e46f9cda8a03e121a00c7e347084d142d22ebfb7#egg=acid-xblock
 -e common/lib/calc
 -e common/lib/capa
@@ -62,7 +63,7 @@ charade==1.0.3            # via pysrt
 click==6.7                # via user-util
 coreapi==2.3.3            # via django-rest-swagger, openapi-codec
 coreschema==0.0.4         # via coreapi
-cryptography==2.1.4
+cryptography==2.2.2
 cssutils==1.0.2           # via pynliner
 ddt==0.8.0
 decorator==4.3.0          # via dogapi, pycontracts
@@ -168,7 +169,7 @@ mock==1.0.1
 mongoengine==0.10.0
 mysql-python==1.2.5
 networkx==1.7
-newrelic==3.2.0.91
+newrelic==3.2.1.93
 nltk==3.3.0
 nodeenv==1.1.1
 numpy==1.6.2

--- a/requirements/edx/coverage.txt
+++ b/requirements/edx/coverage.txt
@@ -4,6 +4,7 @@
 #
 #    make upgrade
 #
+
 coverage==4.2
 diff-cover==0.9.8
 inflect==0.3.1            # via jinja2-pluralize

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -4,6 +4,7 @@
 #
 #    make upgrade
 #
+
 -e git+https://github.com/edx/acid-block.git@e46f9cda8a03e121a00c7e347084d142d22ebfb7#egg=acid-xblock
 -e common/lib/calc
 -e common/lib/capa
@@ -77,7 +78,7 @@ constantly==15.1.0
 coreapi==2.3.3
 coreschema==0.0.4
 coverage==4.2
-cryptography==2.1.4
+cryptography==2.2.2
 cssselect==1.0.3
 cssutils==1.0.2
 ddt==0.8.0
@@ -215,7 +216,7 @@ moto==0.3.1
 mysql-python==1.2.5
 needle==0.5.0
 networkx==1.7
-newrelic==3.2.0.91
+newrelic==3.2.1.93
 nltk==3.3.0
 nodeenv==1.1.1
 nose==1.3.7
@@ -259,7 +260,7 @@ pylint-plugin-utils==0.2.6
 pylint==1.7.1
 pymongo==2.9.1
 pynliner==0.5.2
-pyopenssl==17.5.0
+pyopenssl==18.0.0
 pyparsing==2.2.0
 pyquery==1.4.0
 pysqlite==2.8.3
@@ -313,7 +314,7 @@ sphinxcontrib-websupport==1.0.1  # via sphinx
 splinter==0.8.0
 sqlparse==0.2.4           # via django-debug-toolbar
 stevedore==1.10.0
-sure==1.4.10
+sure==1.4.11
 sympy==0.7.1
 testfixtures==6.0.2
 testtools==2.3.0
@@ -331,7 +332,7 @@ uritemplate==3.0.0
 urllib3==1.22
 urlobject==2.4.3
 user-util==0.1.3
-virtualenv==15.2.0
+virtualenv==16.0.0
 voluptuous==0.11.1
 w3lib==1.19.0
 watchdog==0.8.3

--- a/requirements/edx/paver.txt
+++ b/requirements/edx/paver.txt
@@ -4,6 +4,7 @@
 #
 #    make upgrade
 #
+
 argh==0.26.2              # via watchdog
 argparse==1.4.0           # via stevedore
 edx-opaque-keys==0.4.4

--- a/requirements/edx/pip-tools.txt
+++ b/requirements/edx/pip-tools.txt
@@ -4,6 +4,7 @@
 #
 #    make upgrade
 #
+
 click==6.7                # via pip-tools
 first==2.0.1              # via pip-tools
 pip-tools==2.0.2

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -4,6 +4,7 @@
 #
 #    make upgrade
 #
+
 -e git+https://github.com/edx/acid-block.git@e46f9cda8a03e121a00c7e347084d142d22ebfb7#egg=acid-xblock
 -e common/lib/calc
 -e common/lib/capa
@@ -74,7 +75,7 @@ constantly==15.1.0        # via twisted
 coreapi==2.3.3
 coreschema==0.0.4
 coverage==4.2
-cryptography==2.1.4
+cryptography==2.2.2
 cssselect==1.0.3
 cssutils==1.0.2
 ddt==0.8.0
@@ -207,7 +208,7 @@ moto==0.3.1
 mysql-python==1.2.5
 needle==0.5.0             # via bok-choy
 networkx==1.7
-newrelic==3.2.0.91
+newrelic==3.2.1.93
 nltk==3.3.0
 nodeenv==1.1.1
 nose==1.3.7
@@ -248,7 +249,7 @@ pylint-plugin-utils==0.2.6  # via pylint-celery, pylint-django
 pylint==1.7.1             # via edx-lint, pylint-celery, pylint-django, pylint-plugin-utils
 pymongo==2.9.1
 pynliner==0.5.2
-pyopenssl==17.5.0         # via scrapy, service-identity
+pyopenssl==18.0.0         # via scrapy, service-identity
 pyparsing==2.2.0
 pyquery==1.4.0
 pysqlite==2.8.3
@@ -297,7 +298,7 @@ sorl-thumbnail==12.3
 sortedcontainers==0.9.2
 splinter==0.8.0
 stevedore==1.10.0
-sure==1.4.10
+sure==1.4.11
 sympy==0.7.1
 testfixtures==6.0.2
 testtools==2.3.0          # via fixtures, python-subunit
@@ -314,7 +315,7 @@ uritemplate==3.0.0
 urllib3==1.22
 urlobject==2.4.3          # via pa11ycrawler
 user-util==0.1.3
-virtualenv==15.2.0        # via tox
+virtualenv==16.0.0        # via tox
 voluptuous==0.11.1
 w3lib==1.19.0             # via parsel, scrapy
 watchdog==0.8.3


### PR DESCRIPTION
`sure` 1.4.10 had a bug that would sometimes prevent installation: https://github.com/gabrielfalcao/sure/issues/144 .  Also pulling in some new releases that came out during the PyCon sprints.

cryptography changelog:

```
2.2.2 - 2018-03-27
~~~~~~~~~~~~~~~~~~

* Updated Windows, macOS, and ``manylinux1`` wheels to be compiled with
  OpenSSL 1.1.0h.

2.2.1 - 2018-03-20
~~~~~~~~~~~~~~~~~~

* Reverted a change to ``GeneralNames`` which prohibited having zero elements,
  due to breakages.
* Fixed a bug in
  :func:`~cryptography.hazmat.primitives.keywrap.aes_key_unwrap_with_padding`
  that caused it to raise ``InvalidUnwrap`` when key length modulo 8 was
  zero.

2.2 - 2018-03-19
~~~~~~~~~~~~~~~~

* **BACKWARDS INCOMPATIBLE:** Support for Python 2.6 has been dropped.
* Resolved a bug in ``HKDF`` that incorrectly constrained output size.
* Added :class:`~cryptography.hazmat.primitives.asymmetric.ec.BrainpoolP256R1`,
  :class:`~cryptography.hazmat.primitives.asymmetric.ec.BrainpoolP384R1`, and
  :class:`~cryptography.hazmat.primitives.asymmetric.ec.BrainpoolP512R1` to
  support inter-operating with systems like German smart meters.
* Added token rotation support to :doc:`Fernet </fernet>` with
  :meth:`~cryptography.fernet.MultiFernet.rotate`.
* Fixed a memory leak in
  :func:`~cryptography.hazmat.primitives.asymmetric.ec.derive_private_key`.
* Added support for AES key wrapping with padding via
  :func:`~cryptography.hazmat.primitives.keywrap.aes_key_wrap_with_padding`
  and
  :func:`~cryptography.hazmat.primitives.keywrap.aes_key_unwrap_with_padding`
  .
* Allow loading DSA keys with 224 bit ``q``.
```

newrelic changelog:

```
Python Agent 3.2.1.93
Wednesday, May 16, 2018 - 15:30
Download
Notes

This release of the Python agent contains various bug fixes.

The agent can be installed using easy_install/pip/distribute via the Python Package Index or can be downloaded directly from the New Relic download site .
Bug Fixes

    Do not run explain plans for psycopg2 connections using the async_ kwarg

    As "async" is now a keyword in Python 3.7, psycopg2 now allows "async_" as an alias for its "async" kwarg for psycopg2.connect as of psycopg2 v2.7.4. Previously, explain plans were attempted for these connections and a traceback would be seen in the logs. This has now been fixed.

    Fix traceback when using callbacks as partials in pika consumers

    When passing a callback that is a functools partial to pika channel consumers, a traceback occurred in some instances. This issue has now been fixed.

    cx_Oracle database calls that use SessionPool objects were not recorded

    When using the cx_Oracle SessionPool interace, database transactions made through the acquired pool connection may not have been reported. Database transactions that using connections generated by SessionPool are now reported as expected.

    SQL targets for call statements may contain a period

    For a SQL command like CALL foo.bar(:baz), APM would show metrics under the target name foo instead of the full name foo.bar. This has been fixed.
```

pyopenssl changelog:

```
18.0.0 (2018-05-16)
-------------------

Backward-incompatible changes:
^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
- The minimum ``cryptography`` version is now 2.2.1.
- Support for Python 2.6 has been dropped.

Deprecations:
^^^^^^^^^^^^^
*none*

Changes:
^^^^^^^^
- Added ``Connection.get_certificate`` to retrieve the local certificate.
  `#733 <https://github.com/pyca/pyopenssl/pull/733>`_
- ``OpenSSL.SSL.Connection`` now sets ``SSL_MODE_AUTO_RETRY`` by default.
  `#753 <https://github.com/pyca/pyopenssl/pull/753>`_
- Added ``Context.set_tlsext_use_srtp`` to enable negotiation of SRTP keying material.
  `#734 <https://github.com/pyca/pyopenssl/pull/734>`_
```

sure changelog:

```
## [v1.4.11]
### Fixed
- Reading the version dinamically was causing import errors that caused error when installing package. Refs #144
```

virtualenv changelog:

```
16.0.0 (2018-05-16)
-------------------
* Drop support for Python 2.6.
* Upgrade pip to 10.0.1.
* Upgrade setuptools to 39.1.0.
* Upgrade wheel to 0.31.1.
```