### PR TITLE
Fixed tests that are flaky on fireFox 59

### DIFF
--- a/common/test/acceptance/tests/lms/test_lms.py
+++ b/common/test/acceptance/tests/lms/test_lms.py
@@ -297,6 +297,27 @@ class RegisterFromCombinedPageTest(UniqueCourseTest):
             self.course_info['run'], self.course_info['display_name']
         ).install()
 
+    def test_register_success(self):
+        # Navigate to the registration page
+        self.register_page.visit()
+
+        # Fill in the form and submit it
+        username = "test_{uuid}".format(uuid=self.unique_id[0:6])
+        email = "{user}@example.com".format(user=username)
+        self.register_page.register(
+            email=email,
+            password="password",
+            username=username,
+            full_name="Test User",
+            country="US",
+            favorite_movie="Mad Max: Fury Road",
+            terms_of_service=True
+        )
+
+        # Expect that we reach the dashboard and we're auto-enrolled in the course
+        course_names = self.dashboard_page.wait_for_page().available_courses
+        self.assertIn(self.course_info["display_name"], course_names)
+
     def test_register_failure(self):
         # Navigate to the registration page
         self.register_page.visit()
@@ -325,6 +346,58 @@ class RegisterFromCombinedPageTest(UniqueCourseTest):
     def test_toggle_to_login_form(self):
         self.register_page.visit().toggle_form()
         self.assertEqual(self.register_page.current_form, "login")
+
+    def test_third_party_register(self):
+        """
+        Test that we can register using third party credentials, and that the
+        third party account gets linked to the edX account.
+        """
+        # Navigate to the register page
+        self.register_page.visit()
+        # Baseline screen-shots are different for chrome and firefox.
+        #self.assertScreenshot('#register .login-providers', 'register-providers-{}'.format(self.browser.name), .25)
+        # The line above is commented out temporarily see SOL-1937
+
+        # Try to authenticate using the "Dummy" provider
+        self.register_page.click_third_party_dummy_provider()
+
+        # The user will be redirected somewhere and then back to the register page:
+        msg_text = self.register_page.wait_for_auth_status_message()
+        self.assertEqual(self.register_page.current_form, "register")
+        self.assertIn("You've successfully signed into Dummy", msg_text)
+        self.assertIn("We just need a little more information", msg_text)
+
+        # Now the form should be pre-filled with the data from the Dummy provider:
+        self.assertEqual(self.register_page.email_value, "adama@fleet.colonies.gov")
+        self.assertEqual(self.register_page.full_name_value, "William Adama")
+        self.assertIn("Galactica1", self.register_page.username_value)
+
+        # Set country, accept the terms, and submit the form:
+        self.register_page.register(country="US", favorite_movie="Battlestar Galactica", terms_of_service=True)
+
+        # Expect that we reach the dashboard and we're auto-enrolled in the course
+        course_names = self.dashboard_page.wait_for_page().available_courses
+        self.assertIn(self.course_info["display_name"], course_names)
+
+        # Now logout and check that we can log back in instantly (because the account is linked):
+        LogoutPage(self.browser).visit()
+
+        login_page = CombinedLoginAndRegisterPage(self.browser, start_page="login")
+        login_page.visit()
+        login_page.click_third_party_dummy_provider()
+
+        self.dashboard_page.wait_for_page()
+
+        # Now unlink the account (To test the account settings view and also to prevent cross-test side effects)
+        account_settings = AccountSettingsPage(self.browser).visit()
+        # switch to "Linked Accounts" tab
+        account_settings.switch_account_settings_tabs('accounts-tab')
+
+        field_id = "auth-oa2-dummy"
+        account_settings.wait_for_field(field_id)
+        self.assertEqual("Unlink This Account", account_settings.link_title_for_link_field(field_id))
+        account_settings.click_on_link_in_link_field(field_id)
+        account_settings.wait_for_message(field_id, "Successfully unlinked")
 
 
 @attr(shard=19)

--- a/common/test/acceptance/tests/studio/test_studio_outline.py
+++ b/common/test/acceptance/tests/studio/test_studio_outline.py
@@ -895,6 +895,29 @@ class StaffLockTest(CourseOutlineTest):
         subsection.unit_at(0).set_staff_lock(True)
         self.assertFalse(subsection.has_staff_lock_warning)
 
+    def test_locked_sections_do_not_appear_in_lms(self):
+        """
+        Scenario: A locked section is not visible to students in the LMS
+            Given I have a course with two sections
+            When I enable explicit staff lock on one section
+            And I click the View Live button to switch to staff view
+            And I visit the course home with the outline
+            Then I see two sections in the outline
+            And when I switch the view mode to student view
+            Then I see one section in the outline
+        """
+        self.course_outline_page.visit()
+        self.course_outline_page.add_section_from_top_button()
+        self.course_outline_page.section_at(1).set_staff_lock(True)
+        self.course_outline_page.view_live()
+
+        course_home_page = CourseHomePage(self.browser, self.course_id)
+        course_home_page.visit()
+        course_home_page.wait_for_page()
+        self.assertEqual(course_home_page.outline.num_sections, 2)
+        course_home_page.preview.set_staff_view_mode('Learner')
+        self.assertEqual(course_home_page.outline.num_sections, 1)
+
     def test_toggling_staff_lock_on_section_does_not_publish_draft_units(self):
         """
         Scenario: Locking and unlocking a section will not publish its draft units


### PR DESCRIPTION
These tests `test_register_success ` and `test_third_party_register ` are flaky on firefox 59. I have fixed both tests in my PR. The tests are not more falky because of this fix in my prevoius PR #18218. 
https://github.com/edx/edx-platform/blob/468f9e421299fc85edbd84dede49809a90b3f841/common/test/acceptance/pages/lms/login_and_register.py#L221

### https://openedx.atlassian.net/browse/EDUCATOR-2558
### https://openedx.atlassian.net/browse/EDUCATOR-2559


and fixed `test_locked_sections_do_not_appear_in_lms ` test in which i have added **`wait_for_page()`**

### https://openedx.atlassian.net/browse/EDUCATOR-2555