### PR TITLE
Added credit as an option to change_enrollment command

### DIFF
--- a/common/djangoapps/student/management/commands/change_enrollment.py
+++ b/common/djangoapps/student/management/commands/change_enrollment.py
@@ -41,7 +41,7 @@ class Command(BaseCommand):
           $ ... change_enrollment -u joe,frank,bill -c some/course/id --from audit --to honor -n
     """
 
-    enrollment_modes = ('audit', 'verified', 'honor')
+    enrollment_modes = ('audit', 'verified', 'honor', 'credit')
 
     def add_arguments(self, parser):
         parser.add_argument('-f', '--from',


### PR DESCRIPTION
PR to add the credit mode to the Change Enrollment Management command.  This will allow for the manual migration of users to the Credit mode.  This should be used if attempts to complete fulfillment have failed from ecommerce.

[LEARNER-5145]