### PR TITLE
[ENT-986] Update edx-enterprise to 0.68.6.

### DIFF
--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -118,7 +118,7 @@ edx-django-oauth2-provider==1.2.5
 edx-django-release-util==0.3.1
 edx-django-sites-extensions==2.3.1
 edx-drf-extensions==1.2.5
-edx-enterprise==0.68.5
+edx-enterprise==0.68.6
 edx-i18n-tools==0.4.5
 edx-milestones==0.1.13
 edx-oauth2-provider==1.2.2

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -137,7 +137,7 @@ edx-django-oauth2-provider==1.2.5
 edx-django-release-util==0.3.1
 edx-django-sites-extensions==2.3.1
 edx-drf-extensions==1.2.5
-edx-enterprise==0.68.5
+edx-enterprise==0.68.6
 edx-i18n-tools==0.4.5
 edx-lint==0.5.5
 edx-milestones==0.1.13

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -132,7 +132,7 @@ edx-django-oauth2-provider==1.2.5
 edx-django-release-util==0.3.1
 edx-django-sites-extensions==2.3.1
 edx-drf-extensions==1.2.5
-edx-enterprise==0.68.5
+edx-enterprise==0.68.6
 edx-i18n-tools==0.4.5
 edx-lint==0.5.5
 edx-milestones==0.1.13


### PR DESCRIPTION
This will fail to pass until https://github.com/edx/edx-enterprise/pull/315 is merged and on pypi.