### PR TITLE
Add in studio third_party_auth

### DIFF
--- a/cms/djangoapps/contentstore/views/public.py
+++ b/cms/djangoapps/contentstore/views/public.py
@@ -8,11 +8,14 @@ from django.shortcuts import redirect
 from django.views.decorators.clickjacking import xframe_options_deny
 from django.views.decorators.csrf import ensure_csrf_cookie
 
+import third_party_auth
 from edxmako.shortcuts import render_to_response
 from openedx.core.djangoapps.external_auth.views import redirect_with_get, ssl_get_cert_from_request, ssl_login_shortcut
 from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
 from waffle.decorators import waffle_switch
 from contentstore.config import waffle
+from student.helpers import auth_pipeline_urls
+from third_party_auth import pipeline, provider
 
 __all__ = ['signup', 'login_page', 'howitworks', 'accessibility']
 
@@ -31,7 +34,28 @@ def signup(request):
         # and registration is disabled.
         return redirect_with_get('login', request.GET, False)
 
-    return render_to_response('register.html', {'csrf': csrf_token})
+    context = {
+        'csrf': csrf_token,
+        'email': '',
+        'name': '',
+        'running_pipeline': None,
+        'pipeline_urls': auth_pipeline_urls(pipeline.AUTH_ENTRY_REGISTER, redirect_url=reverse("home")),
+        'selected_provider': '',
+        'username': '',
+    }
+
+    # If third-party auth is enabled, prepopulate the form with data from the
+    # selected provider.
+    if third_party_auth.is_enabled() and pipeline.running(request):
+        running_pipeline = pipeline.get(request)
+        current_provider = provider.Registry.get_from_pipeline(running_pipeline)
+        if current_provider is not None:
+            overrides = current_provider.get_register_form_data(running_pipeline.get('kwargs'))
+            overrides['running_pipeline'] = running_pipeline
+            overrides['selected_provider'] = current_provider
+            context.update(overrides)
+
+    return render_to_response('register.html', context)
 
 
 @ssl_login_shortcut

--- a/cms/envs/aws.py
+++ b/cms/envs/aws.py
@@ -462,6 +462,21 @@ SESSION_INACTIVITY_TIMEOUT_IN_SECONDS = AUTH_TOKENS.get("SESSION_INACTIVITY_TIME
 ##### X-Frame-Options response header settings #####
 X_FRAME_OPTIONS = ENV_TOKENS.get('X_FRAME_OPTIONS', X_FRAME_OPTIONS)
 
+##### Third-party auth options ################################################
+if FEATURES.get('ENABLE_THIRD_PARTY_AUTH'):
+    tmp_backends = ENV_TOKENS.get('THIRD_PARTY_AUTH_BACKENDS', [
+        'social_core.backends.google.GoogleOAuth2',
+        'social_core.backends.linkedin.LinkedinOAuth2',
+        'social_core.backends.facebook.FacebookOAuth2',
+        'social_core.backends.azuread.AzureADOAuth2',
+    ])
+
+    AUTHENTICATION_BACKENDS = list(tmp_backends) + list(AUTHENTICATION_BACKENDS)
+    del tmp_backends
+
+    # The reduced session expiry time during the third party login pipeline. (Value in seconds)
+    SOCIAL_AUTH_PIPELINE_TIMEOUT = ENV_TOKENS.get('SOCIAL_AUTH_PIPELINE_TIMEOUT', 600)
+
 ##### ADVANCED_SECURITY_CONFIG #####
 ADVANCED_SECURITY_CONFIG = ENV_TOKENS.get('ADVANCED_SECURITY_CONFIG', {})
 

--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -985,6 +985,7 @@ INSTALLED_APPS = [
 
     # edX Video Pipeline integration
     'openedx.core.djangoapps.video_pipeline',
+    'third_party_auth',
 
     # For CMS
     'contentstore.apps.ContentstoreConfig',

--- a/cms/static/js/factories/register.js
+++ b/cms/static/js/factories/register.js
@@ -1,6 +1,8 @@
 define(['jquery', 'jquery.cookie'], function($) {
     'use strict';
-    return function() {
+    return function(options) {
+        var $registerForm = $('form#register_form');
+
         $('form :input')
             .focus(function() {
                 $('label[for="' + this.id + '"]').addClass('is-focused');
@@ -9,7 +11,7 @@ define(['jquery', 'jquery.cookie'], function($) {
                 $('label').removeClass('is-focused');
             });
 
-        $('form#register_form').submit(function(event) {
+        $registerForm.submit(function(event) {
             event.preventDefault();
             var submit_data = $('#register_form').serialize();
 
@@ -21,10 +23,15 @@ define(['jquery', 'jquery.cookie'], function($) {
                 notifyOnError: false,
                 data: submit_data,
                 success: function(json) {
-                    location.href = '/course/';
+                    if (json.redirect_url) {
+                        location.href = json.redirect_url;
+                    } else {
+                        location.href = '/course/';
+                    }
                 },
                 error: function(jqXHR, textStatus, errorThrown) {
                     var json = $.parseJSON(jqXHR.responseText);
+                    $('body').show();
                     $('#register_error').html(json.value).stop().addClass('is-shown');
                 }
             });
@@ -55,5 +62,10 @@ define(['jquery', 'jquery.cookie'], function($) {
                 }
             });
         });
+
+        if (options.autoSubmitRegForm) {
+            $('body').hide();
+            $registerForm.submit();
+        }
     };
 });

--- a/cms/static/sass/partials/cms/theme/_variables-v1.scss
+++ b/cms/static/sass/partials/cms/theme/_variables-v1.scss
@@ -303,3 +303,10 @@ $state-danger-bg: #f2dede !default;
 $state-danger-border: darken($state-danger-bg, 5%) !default;
 
 $text-dark-black-blue: #2c3e50;
+
+// social platforms
+$twitter-blue: #55acee;
+$facebook-blue: #3b5998;
+$linkedin-blue: #0077b5;
+$google-red: #d73924;
+$microsoft-black: #000;

--- a/cms/static/sass/views/_account.scss
+++ b/cms/static/sass/views/_account.scss
@@ -71,6 +71,154 @@
       padding: $baseline ($baseline*1.5);
       background: $white;
 
+      .login-providers {
+        text-align: center;
+        $third-party-button-height: ($baseline*1.75);
+
+        .login-provider {
+          @extend %btn-secondary-grey-outline;
+          @extend %t-action4;
+
+          @include padding(0, 0, 0, $baseline*2);
+          @include text-align(left);
+
+          position: relative;
+          margin-right: ($baseline/4);
+          margin-bottom: ($baseline/4);
+          border-color: $gray-l3;
+          width: $baseline*6.5;
+          height: $third-party-button-height;
+          text-shadow: none;
+          text-transform: none;
+
+          .icon {
+            @extend %sso-icon;
+
+            @include left(0);
+
+            position: absolute;
+            top: -1px;
+            width: 30px;
+            bottom: -1px;
+            background: $blue-d3;
+            line-height: $third-party-button-height;
+            text-align: center;
+            color: $white;
+          }
+
+          span {
+            color: inherit;
+          }
+
+          &:hover,
+          &:focus {
+            background-image: none;
+
+            .icon {
+              top: 0;
+              bottom: 0;
+              line-height: ($third-party-button-height - 2px);
+            }
+          }
+
+          &.button-oa2-google-oauth2 {
+            color: $google-red;
+
+            .icon {
+              background: $google-red;
+            }
+
+            &:hover,
+            &:focus {
+              background-color: $google-red;
+              border: 1px solid #a5382b;
+              color: $white;
+            }
+          }
+
+          &.button-oa2-facebook {
+            color: $facebook-blue;
+
+            .icon {
+              background: $facebook-blue;
+            }
+
+            &:hover,
+            &:focus {
+              background-color: $facebook-blue;
+              border: 1px solid #263a62;
+              color: $white;
+            }
+          }
+
+          &.button-oa2-linkedin-oauth2 {
+            color: $linkedin-blue;
+
+            .icon {
+              background: $linkedin-blue;
+            }
+
+            &:hover,
+            &:focus {
+              background-color: $linkedin-blue;
+              border: 1px solid #06527d;
+              color: $white;
+            }
+          }
+
+          &.button-oa2-azuread-oauth2 {
+            color: $microsoft-black;
+
+            .icon {
+              background: $microsoft-black;
+            }
+
+            &:hover,
+            &:focus {
+              background-color: $microsoft-black;
+              border: 1px solid $microsoft-black;
+              color: $white;
+            }
+          }
+
+        }
+      }
+
+      .section-title {
+        position: relative;
+        margin: $baseline 0 ($baseline/2);
+
+        &.lines {
+          margin-bottom: $baseline;
+          margin-top: $baseline;
+          text-align: center;
+
+          &::after {
+            position: absolute;
+            left: 0;
+            top: ($baseline/2);
+            width: 100%;
+            height: 1px;
+            background: $gray-l3;
+            content: '';
+            z-index: 5;
+          }
+
+          .text {
+            position: relative;
+            top: -2px; // Aligns center of text with center of line (CR)
+            z-index: 6;
+            padding: 0 $baseline;
+            background: $white;
+          }
+        }
+
+        h2 {
+          text-align: center;
+          text-transform: none;
+        }
+      }
+
       .form-actions {
         margin-top: $baseline;
 

--- a/cms/templates/login.html
+++ b/cms/templates/login.html
@@ -6,6 +6,10 @@
 from django.core.urlresolvers import reverse
 from django.utils.translation import ugettext as _
 from openedx.core.djangolib.js_utils import js_escaped_string
+import third_party_auth
+from third_party_auth import provider, pipeline
+
+providers = provider.Registry.displayed_for_login()
 %>
 <%block name="title">${_("Sign In")}</%block>
 <%block name="bodyclass">not-signedin view-signin</%block>
@@ -23,7 +27,7 @@ from openedx.core.djangolib.js_utils import js_escaped_string
 
     <article class="content-primary" role="main">
       <form id="login_form" method="post" action="login_post" onsubmit="return false;">
-
+        % if not static.get_value('ONLY_THIRD_PARTY_AUTH', settings.FEATURES.get('ONLY_THIRD_PARTY_AUTH', False)):
         <fieldset>
           <legend class="sr">${_("Required Information to Sign In to {studio_name}").format(studio_name=settings.STUDIO_NAME)}</legend>
           <input type="hidden" name="csrfmiddlewaretoken" value="${ csrf }" />
@@ -48,6 +52,35 @@ from openedx.core.djangolib.js_utils import js_escaped_string
 
         <!-- no honor code for CMS, but need it because we're using the lms student object -->
         <input name="honor_code" type="checkbox" value="true" checked="true" hidden="true">
+        % endif
+
+        % if third_party_auth.is_enabled() and providers:
+        <div class="login-providers">
+          % if not static.get_value('ONLY_THIRD_PARTY_AUTH', settings.FEATURES.get('ONLY_THIRD_PARTY_AUTH', False)):
+          <div class="section-title lines">
+            <h3>
+              <span class="text">${_("or sign in with")}</span>
+            </h3>
+          </div>
+          % endif
+
+          % for enabled in providers:
+          <button type="button"
+                  class="button button-primary button-${enabled.provider_id} login-provider login-${enabled.provider_id}"
+                  onclick="thirdPartySignin(event, '${pipeline.get_login_url(enabled.provider_id, pipeline.AUTH_ENTRY_LOGIN, redirect_url=reverse("home"))}');">
+            <div class="icon fa ${enabled.icon_class if enabled.icon_class else ''}" aria-hidden="true">
+              % if enabled.icon_image:
+              <img class="icon-image" src="${enabled.icon_image.url}" alt="${enabled.name} icon" />
+              % endif
+            </div>
+            <span aria-hidden="true">${enabled.name}</span>
+            <span class="sr">${_("Sign in with {}".format(enabled.name))}</span>
+          </button>
+          % endfor
+
+        </div>
+        % endif
+
       </form>
     </article>
   </section>
@@ -58,4 +91,13 @@ from openedx.core.djangolib.js_utils import js_escaped_string
   <%static:invoke_page_bundle page_name="js/pages/login" class_name="LoginFactory">
     "${reverse('homepage') | n, js_escaped_string}"
   </%static:invoke_page_bundle>
+</%block>
+
+<%block name="jsextra">
+  <script type="text/javascript">
+    function thirdPartySignin(event, url) {
+      event.preventDefault();
+      window.location.href = url;
+    }
+  </script>
 </%block>

--- a/cms/templates/register.html
+++ b/cms/templates/register.html
@@ -1,8 +1,14 @@
+<%namespace name='static' file='/static_content.html'/>
 <%inherit file="base.html" />
 <%def name="online_help_token()"><% return "register" %></%def>
 <%!
+import third_party_auth
 from django.utils.translation import ugettext as _
 from django.core.urlresolvers import reverse
+from openedx.core.djangolib.js_utils import dump_js_escaped_json
+from third_party_auth import provider, pipeline
+
+providers = provider.Registry.displayed_for_login()
 %>
 
 <%block name="title">${_("Sign Up")}</%block>
@@ -21,6 +27,39 @@ from django.core.urlresolvers import reverse
 
     <article class="content-primary" role="main">
       <form id="register_form" method="post">
+
+        % if third_party_auth.is_enabled() and providers and not running_pipeline:
+        <div class="login-providers">
+          <div class="section-title lines">
+              <h3>
+                  <span class="text">${_("Create an account using")}</span>
+              </h3>
+          </div>
+          % for enabled in providers:
+          <button type="button"
+                  class="button button-primary button-${enabled.provider_id} login-provider register-${enabled.provider_id}"
+                  onclick="thirdPartySignin(event, '${pipeline_urls.get(enabled.provider_id, "")}');">
+            <div class="icon fa ${enabled.icon_class if enabled.icon_class else ''}" aria-hidden="true">
+              % if enabled.icon_image:
+              <img class="icon-image" src="${enabled.icon_image.url}" alt="${enabled.name} icon"  />
+              % endif
+            </div>
+            <span aria-hidden="true">${enabled.name}</span>
+            <span class="sr">${_("Create account using {}".format(enabled.name))}</span>
+          </button>
+          % endfor
+        </div>
+
+        % if not static.get_value('ONLY_THIRD_PARTY_AUTH', settings.FEATURES.get('ONLY_THIRD_PARTY_AUTH', False)):
+        <div class="section-title lines">
+          <h3>
+            <span class="text">${_("or create a new one here")}</span>
+          </h3>
+        </div>
+        % endif
+        % endif
+
+        % if not static.get_value('ONLY_THIRD_PARTY_AUTH', settings.FEATURES.get('ONLY_THIRD_PARTY_AUTH', False)) or running_pipeline:
         <div id="register_error" name="register_error" class="message message-status message-status error">
         </div>
 
@@ -31,23 +70,23 @@ from django.core.urlresolvers import reverse
             <li class="field text required" id="field-email">
               <label for="email">${_("E-mail")}</label>
               ## Translators: This is the placeholder text for a field that requests an email address.
-              <input id="email" type="email" name="email" placeholder="${_("example: username@domain.com")}" />
+              <input id="email" type="email" name="email" placeholder="${_("example: username@domain.com")}" value="${email}"/>
             </li>
 
             <li class="field text required" id="field-name">
               <label for="name">${_("Full Name")}</label>
               ## Translators: This is the placeholder text for a field that requests the user's full name.
-              <input id="name" type="text" name="name" placeholder="${_("example: Jane Doe")}" />
+              <input id="name" type="text" name="name" placeholder="${_("example: Jane Doe")}" value="${name}"/>
             </li>
 
             <li class="field text required" id="field-username">
               <label for="username">${_("Public Username")}</label>
               ## Translators: This is the placeholder text for a field that asks the user to pick a username
-              <input id="username" type="text" name="username" placeholder="${_("example: JaneDoe")}" />
+              <input id="username" type="text" name="username" placeholder="${_("example: JaneDoe")}" value="${username}" />
               <span class="tip tip-stacked">${_("This will be used in public discussions with your courses and in our edX101 support forums")}</span>
             </li>
 
-            <li class="field text required" id="field-password">
+            <li class="field text required ${'is-hidden' if running_pipeline else ''}" id="field-password">
               <label for="password">${_("Password")}</label>
               <input id="password" type="password" name="password" />
               <span id="password_error" class="tip tip-error hidden" role="alert"></span>
@@ -66,7 +105,7 @@ from django.core.urlresolvers import reverse
             </li>
 
             <li class="field checkbox required" id="field-tos">
-              <input id="tos" name="terms_of_service" type="checkbox" value="true" />
+              <input id="tos" name="terms_of_service" type="checkbox" value="true" ${'checked' if running_pipeline else ''} />
               <label for="tos">
                 ${_("I agree to the {a_start} Terms of Service {a_end}").format(a_start='<a data-rel="edx.org" href="{}">'.format(marketing_link('TOS')), a_end="</a>")}
               </label>
@@ -80,6 +119,8 @@ from django.core.urlresolvers import reverse
 
         <!-- no honor code for CMS, but need it because we're using the lms student object -->
         <input name="honor_code" type="checkbox" value="true" checked="true" hidden="true">
+        % endif
+
       </form>
     </article>
 
@@ -111,6 +152,18 @@ from django.core.urlresolvers import reverse
 
 <%block name="requirejs">
     require(["js/factories/register"], function (RegisterFactory) {
-        RegisterFactory();
+        var options = {
+          autoSubmitRegForm: ${selected_provider and selected_provider.skip_registration_form | n, dump_js_escaped_json}
+        }
+        RegisterFactory(options);
     });
+</%block>
+
+<%block name="jsextra">
+  <script type="text/javascript">
+    function thirdPartySignin(event, url) {
+      event.preventDefault();
+      window.location.href = url;
+    }
+  </script>
 </%block>

--- a/cms/urls.py
+++ b/cms/urls.py
@@ -71,7 +71,9 @@ urlpatterns = [
     url(r'^$', contentstore.views.howitworks, name='homepage'),
     url(r'^howitworks$', contentstore.views.howitworks, name='howitworks'),
     url(r'^signup$', contentstore.views.signup, name='signup'),
+    url(r'^register$', contentstore.views.signup),
     url(r'^signin$', contentstore.views.login_page, name='login'),
+    url(r'^login$', contentstore.views.login_page),
     url(r'^request_course_creator$', contentstore.views.request_course_creator, name='request_course_creator'),
     url(r'^course_team/{}(?:/(?P<email>.+))?$'.format(COURSELIKE_KEY_PATTERN),
         contentstore.views.course_team_handler, name='course_team_handler'),
@@ -218,6 +220,13 @@ if settings.FEATURES.get('CERTIFICATES_HTML_VIEW'):
             certificates_detail_handler, name='certificates_detail_handler'),
         url(r'^certificates/{}$'.format(settings.COURSE_KEY_PATTERN),
             certificates_list_handler, name='certificates_list_handler')
+    ]
+
+# Third-party auth.
+if settings.FEATURES.get('ENABLE_THIRD_PARTY_AUTH'):
+    urlpatterns += [
+        url(r'', include('third_party_auth.urls')),
+        url(r'api/third_party_auth/', include('third_party_auth.api.urls')),
     ]
 
 # Maintenance Dashboard

--- a/common/djangoapps/third_party_auth/tests/test_decorators.py
+++ b/common/djangoapps/third_party_auth/tests/test_decorators.py
@@ -48,11 +48,12 @@ class TestXFrameWhitelistDecorator(TestCase):
         (None, 'DENY')
     )
     def test_x_frame_options(self, url, expected_result):
-        request = self.construct_request(url)
+        with self.settings(FEATURES={'ENABLE_THIRD_PARTY_AUTH': True}):
+            request = self.construct_request(url)
 
-        response = mock_view(request)
+            response = mock_view(request)
 
-        self.assertEqual(response['X-Frame-Options'], expected_result)
+            self.assertEqual(response['X-Frame-Options'], expected_result)
 
     @ddt.data('http://localhost/login', 'http://not-a-real-domain.com', None)
     def test_feature_flag_off(self, url):


### PR DESCRIPTION
<p><strong>Description:</strong> shares third-party auth backends usage to the CMS (similar to the LMS flow).</p>
<p><strong>Background</strong>: currently, there is a very convenient feature to perform authentication via social services (like LinkedIn, Azure services, etc.). But it is present in LMS exclusively. For some reason it is not available in Studio. Till now.<br>
This patch is intended to share this convenience to CMS app too.</p>
<p><strong>LMS Updates</strong>: none.</p>
<p><strong>CMS Updates</strong>:</p>
<ul>
<li><code>cms/envs/common.py</code> - 'third_party_auth' app is registred;</li>
<li><code>cms/urls.py</code> - urls are extended under feature-flag;</li>
<li><code>cms/envs/aws.py</code> - AUTHENTICATION_BACKENDS extended under feature-flag with 3rd-party-auth backends:
<ul>
<li>google,</li>
<li>linkedin,</li>
<li>facebook,</li>
<li>azuread;</li>
</ul>
</li>
<li>frontend (styles, template, js): auth form is adapted (see screenshots):
<ul>
<li>to show social buttons,</li>
<li>to perform auth redirect logic,</li>
<li>to prepopulate form with auth-backend data;</li>
</ul>
</li>
</ul>
<p><strong>Configuration instructions:</strong><br>
In order to enable third-party-auth feature in the CMS, corresponding feature-flag must be set to <code>true</code> (in addition, <a href="http://edx.readthedocs.io/projects/edx-installing-configuring-and-running/en/latest/configuration/tpa/tpa_integrate_open/tpa_oauth.html" rel="nofollow">auth backend(s) must be configured</a>, as well:</p>
<pre><code>cms config:

'FEATURES.ENABLE_THIRD_PARTY_AUTH' - bool, optional, default=false
</code></pre>
<p>To ensure feature is enabled one should look at the login (sign in) / register (sign up) page - additional social buttons must be presented:</p>
<p><a href="https://camo.githubusercontent.com/ab29e53f4907aecffa888311969b59d7529f1ae3/68747470733a2f2f636f6e74656e742e73637265656e636173742e636f6d2f75736572732f566f6c6f64796d7972426572676d616e2f666f6c646572732f536e616769742f6d656469612f32646339346264362d333134372d346338382d626136302d6639643338316566613761342f323031382d30352d32315f31332d31332d34352e706e67" target="_blank"><img style="max-width:100%;" alt="signIn page" src="https://camo.githubusercontent.com/ab29e53f4907aecffa888311969b59d7529f1ae3/68747470733a2f2f636f6e74656e742e73637265656e636173742e636f6d2f75736572732f566f6c6f64796d7972426572676d616e2f666f6c646572732f536e616769742f6d656469612f32646339346264362d333134372d346338382d626136302d6639643338316566613761342f323031382d30352d32315f31332d31332d34352e706e67" data-canonical-src="https://content.screencast.com/users/VolodymyrBergman/folders/Snagit/media/2dc94bd6-3147-4c88-ba60-f9d381efa7a4/2018-05-21_13-13-45.png"></a></p>
<p><a href="https://drive.google.com/file/d/1lvr27vvf8GfY-3_JPmny75wdnNyTuEiE/view" rel="nofollow"><em>signIn page</em></a></p>
<p><a href="https://camo.githubusercontent.com/e89ad00012421782eda6ea80169a90599f0a649c/68747470733a2f2f636f6e74656e742e73637265656e636173742e636f6d2f75736572732f566f6c6f64796d7972426572676d616e2f666f6c646572732f536e616769742f6d656469612f33343234623566372d323630392d346534612d616165352d3237376662336432616530642f323031382d30352d32315f31332d32312d35392e706e67" target="_blank"><img style="max-width:100%;" alt="singUp page" src="https://camo.githubusercontent.com/e89ad00012421782eda6ea80169a90599f0a649c/68747470733a2f2f636f6e74656e742e73637265656e636173742e636f6d2f75736572732f566f6c6f64796d7972426572676d616e2f666f6c646572732f536e616769742f6d656469612f33343234623566372d323630392d346534612d616165352d3237376662336432616530642f323031382d30352d32315f31332d32312d35392e706e67" data-canonical-src="https://content.screencast.com/users/VolodymyrBergman/folders/Snagit/media/3424b5f7-2609-4e4a-aae5-277fb3d2ae0d/2018-05-21_13-21-59.png"></a></p>
<p><a href="https://drive.google.com/file/d/14uorlT0hIF-jbLOBANPNvoZx1_f-z1ce/view" rel="nofollow"><em>singUp page</em></a></p>
<p>There is one extra feature-flag:</p>
<pre><code>cms config:

'FEATURES.ONLY_THIRD_PARTY_AUTH' - bool, optional, default=false
</code></pre>
<p>In addition to 3rd-party-auth feature it disables main register/login form (only social buttons are presented):</p>
<p><a href="https://camo.githubusercontent.com/2b2b3cebe0615c89aba3d70a4fb3e3dfddf5d15e/68747470733a2f2f636f6e74656e742e73637265656e636173742e636f6d2f75736572732f566f6c6f64796d7972426572676d616e2f666f6c646572732f536e616769742f6d656469612f62616137613966392d613662342d343236302d626166612d3563663739363062613139372f323031382d30352d32315f31332d32342d31372e706e67" target="_blank"><img style="max-width:100%;" alt="social auth only" src="https://camo.githubusercontent.com/2b2b3cebe0615c89aba3d70a4fb3e3dfddf5d15e/68747470733a2f2f636f6e74656e742e73637265656e636173742e636f6d2f75736572732f566f6c6f64796d7972426572676d616e2f666f6c646572732f536e616769742f6d656469612f62616137613966392d613662342d343236302d626166612d3563663739363062613139372f323031382d30352d32315f31332d32342d31372e706e67" data-canonical-src="https://content.screencast.com/users/VolodymyrBergman/folders/Snagit/media/baa7a9f9-a6b4-4260-bafa-5cf7960ba197/2018-05-21_13-24-17.png"></a></p>
<p><a href="https://drive.google.com/file/d/1_Tt8xmkKGkHSPe1ueHNkUuyddEeiXLOe/edit" rel="nofollow"><em>social auth only</em></a></p>
<p><strong>Author concerns:</strong></p>
<ul>
<li><a href="https://github.com/raccoongang/edx-platform/blob/481845a661012925abfe6b1578b53be3777db46c/cms/urls.py#L74">cms login/register urls duplication</a>:</li>
</ul>
<blockquote>
<p>because of how <a href="https://github.com/edx/edx-platform/blob/master/common/djangoapps/third_party_auth/pipeline.py#L105-L106">third_party_auth app is implemented</a> we have to add urls with specific notation which in fact duplicate those ones are already presented in CMS.</p>
</blockquote>
      </td>