### PR TITLE
Feanil/update rfc6266 parser

### DIFF
--- a/cms/djangoapps/contentstore/views/videos.py
+++ b/cms/djangoapps/contentstore/views/videos.py
@@ -9,7 +9,7 @@ from datetime import datetime, timedelta
 from pytz import UTC
 from uuid import uuid4
 
-import rfc6266
+import rfc6266_parser
 from boto import s3
 from django.conf import settings
 from django.contrib.auth.decorators import login_required
@@ -458,7 +458,7 @@ def video_encodings_download(request, course_key_string):
     # listing for videos uploaded through Studio
     filename = _("{course}_video_urls").format(course=course.id.course)
     # See https://tools.ietf.org/html/rfc6266#appendix-D
-    response["Content-Disposition"] = rfc6266.build_header(
+    response["Content-Disposition"] = rfc6266_parser.build_header(
         filename + ".csv",
         filename_compat="video_urls.csv"
     )

--- a/requirements/edx-sandbox/base.txt
+++ b/requirements/edx-sandbox/base.txt
@@ -4,7 +4,6 @@
 #
 #    make upgrade
 #
-
 common/lib/calc
 common/lib/chem
 common/lib/sandbox-packages

--- a/requirements/edx-sandbox/shared.txt
+++ b/requirements/edx-sandbox/shared.txt
@@ -4,7 +4,6 @@
 #
 #    make upgrade
 #
-
 -e common/lib/calc
 -e common/lib/chem
 -e common/lib/sandbox-packages

--- a/requirements/edx/base.in
+++ b/requirements/edx/base.in
@@ -125,6 +125,7 @@ python-openid
 python-saml==2.4.0
 pyuca==1.1                          # For more accurate sorting of translated country names in django-countries
 reportlab==3.1.44                   # Used for shopping cart's pdf invoice/receipt generation
+rfc6266-parser                      # Used to generate Content-Disposition headers.
 social-auth-app-django==1.2.0
 social-auth-core==1.4.0
 pysrt==0.4.7                        # Support for SubRip subtitle files, used in the video XModule

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -4,7 +4,6 @@
 #
 #    make upgrade
 #
-
 -e git+https://github.com/edx/acid-block.git@e46f9cda8a03e121a00c7e347084d142d22ebfb7#egg=acid-xblock
 -e common/lib/calc
 -e common/lib/capa
@@ -32,7 +31,6 @@ git+https://github.com/edx/edx-ora2.git@2.1.16#egg=ora2==2.1.16
 -e git+https://github.com/dementrock/pystache_custom.git@776973740bdaad83a3b029f96e415a7d1e8bec2f#egg=pystache_custom-dev
 -e git+https://github.com/edx/RateXBlock.git@367e19c0f6eac8a5f002fd0f1559555f8e74bfff#egg=rate-xblock
 git+https://github.com/edx/RecommenderXBlock.git@1.3#egg=recommender-xblock==1.3
-git+https://github.com/edx/rfc6266.git@v0.0.5-edx#egg=rfc6266==0.0.5-edx
 -e common/lib/safe_lxml
 -e common/lib/sandbox-packages
 -e common/lib/symmath
@@ -156,7 +154,7 @@ jsondiff==1.1.1           # via edx-enterprise
 jsonfield==2.0.2
 kombu==3.0.37             # via celery
 lazy==1.1
-lepl==5.1.3
+lepl==5.1.3               # via rfc6266-parser
 libsass==0.10.0
 loremipsum==1.0.5
 lxml==3.8.0
@@ -211,6 +209,7 @@ redis==2.10.6
 reportlab==3.1.44
 requests-oauthlib==0.6.1
 requests==2.9.1
+rfc6266-parser==0.0.5.post2
 rules==1.3
 s3transfer==0.1.13        # via boto3
 sailthru-client==2.2.3

--- a/requirements/edx/coverage.txt
+++ b/requirements/edx/coverage.txt
@@ -4,7 +4,6 @@
 #
 #    make upgrade
 #
-
 coverage==4.2
 diff-cover==0.9.8
 inflect==0.3.1            # via jinja2-pluralize

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -4,7 +4,6 @@
 #
 #    make upgrade
 #
-
 -e git+https://github.com/edx/acid-block.git@e46f9cda8a03e121a00c7e347084d142d22ebfb7#egg=acid-xblock
 -e common/lib/calc
 -e common/lib/capa
@@ -35,7 +34,6 @@ git+https://github.com/edx/edx-ora2.git@2.1.16#egg=ora2==2.1.16
 -e git+https://github.com/dementrock/pystache_custom.git@776973740bdaad83a3b029f96e415a7d1e8bec2f#egg=pystache_custom-dev
 -e git+https://github.com/edx/RateXBlock.git@367e19c0f6eac8a5f002fd0f1559555f8e74bfff#egg=rate-xblock
 git+https://github.com/edx/RecommenderXBlock.git@1.3#egg=recommender-xblock==1.3
-git+https://github.com/edx/rfc6266.git@v0.0.5-edx#egg=rfc6266==0.0.5-edx
 -e common/lib/safe_lxml
 -e common/lib/sandbox-packages
 -e common/lib/symmath
@@ -55,6 +53,7 @@ argh==0.26.2
 argparse==1.4.0
 asn1crypto==0.24.0
 astroid==1.5.2
+atomicwrites==1.1.5
 attrs==17.4.0
 babel==1.3
 backports.functools-lru-cache==1.5
@@ -63,7 +62,7 @@ beautifulsoup==3.2.1
 before-after==1.0.1
 billiard==3.3.0.23
 bleach==1.4
-bok-choy==0.7.2
+bok-choy==0.7.3
 boto3==1.4.8
 boto==2.39.0
 botocore==1.8.17
@@ -271,7 +270,7 @@ pytest-django==3.1.2
 pytest-forked==0.2
 pytest-randomly==1.2.3
 pytest-xdist==1.22.2
-pytest==3.5.1
+pytest==3.6.0
 python-dateutil==2.4.0
 python-levenshtein==0.12.0
 python-memcached==1.48
@@ -290,6 +289,7 @@ redis==2.10.6
 reportlab==3.1.44
 requests-oauthlib==0.6.1
 requests==2.9.1
+rfc6266-parser==0.0.5.post2
 rules==1.3
 s3transfer==0.1.13
 sailthru-client==2.2.3

--- a/requirements/edx/github.in
+++ b/requirements/edx/github.in
@@ -75,9 +75,6 @@
 # This can go away when we update auth to not use django-rest-framework-oauth
 -e git+https://github.com/edx/django-oauth-plus.git@01ec2a161dfc3465f9d35b9211ae790177418316#egg=django-oauth-plus==2.2.9.edx-1
 
-# NOTE (CCB): This must remain. There is one commit on the upstream repo that has not been released to PyPI.
--e git+https://github.com/edx/rfc6266.git@v0.0.5-edx#egg=rfc6266==0.0.5-edx
-
 # Why a DRF fork? See: https://openedx.atlassian.net/browse/PLAT-1581
 -e git+https://github.com/edx/django-rest-framework.git@1ceda7c086fddffd1c440cc86856441bbf0bd9cb#egg=djangorestframework==3.6.3
 

--- a/requirements/edx/paver.txt
+++ b/requirements/edx/paver.txt
@@ -4,7 +4,6 @@
 #
 #    make upgrade
 #
-
 argh==0.26.2              # via watchdog
 argparse==1.4.0           # via stevedore
 edx-opaque-keys==0.4.4

--- a/requirements/edx/pip-tools.txt
+++ b/requirements/edx/pip-tools.txt
@@ -4,7 +4,6 @@
 #
 #    make upgrade
 #
-
 click==6.7                # via pip-tools
 first==2.0.1              # via pip-tools
 pip-tools==2.0.2

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -4,7 +4,6 @@
 #
 #    make upgrade
 #
-
 -e git+https://github.com/edx/acid-block.git@e46f9cda8a03e121a00c7e347084d142d22ebfb7#egg=acid-xblock
 -e common/lib/calc
 -e common/lib/capa
@@ -33,7 +32,6 @@ git+https://github.com/edx/edx-ora2.git@2.1.16#egg=ora2==2.1.16
 -e git+https://github.com/dementrock/pystache_custom.git@776973740bdaad83a3b029f96e415a7d1e8bec2f#egg=pystache_custom-dev
 -e git+https://github.com/edx/RateXBlock.git@367e19c0f6eac8a5f002fd0f1559555f8e74bfff#egg=rate-xblock
 git+https://github.com/edx/RecommenderXBlock.git@1.3#egg=recommender-xblock==1.3
-git+https://github.com/edx/rfc6266.git@v0.0.5-edx#egg=rfc6266==0.0.5-edx
 -e common/lib/safe_lxml
 -e common/lib/sandbox-packages
 -e common/lib/symmath
@@ -52,6 +50,7 @@ argh==0.26.2
 argparse==1.4.0
 asn1crypto==0.24.0
 astroid==1.5.2            # via edx-lint, pylint, pylint-celery, pylint-plugin-utils
+atomicwrites==1.1.5       # via pytest
 attrs==17.4.0
 babel==1.3
 backports.functools-lru-cache==1.5  # via astroid, pylint
@@ -60,7 +59,7 @@ beautifulsoup==3.2.1
 before-after==1.0.1
 billiard==3.3.0.23
 bleach==1.4
-bok-choy==0.7.2
+bok-choy==0.7.3
 boto3==1.4.8
 boto==2.39.0
 botocore==1.8.17
@@ -260,7 +259,7 @@ pytest-django==3.1.2
 pytest-forked==0.2        # via pytest-xdist
 pytest-randomly==1.2.3
 pytest-xdist==1.22.2
-pytest==3.5.1
+pytest==3.6.0
 python-dateutil==2.4.0
 python-levenshtein==0.12.0
 python-memcached==1.48
@@ -279,6 +278,7 @@ redis==2.10.6
 reportlab==3.1.44
 requests-oauthlib==0.6.1
 requests==2.9.1
+rfc6266-parser==0.0.5.post2
 rules==1.3
 s3transfer==0.1.13
 sailthru-client==2.2.3


### PR DESCRIPTION
The other version on PyPI hasn't been updated in forever so we started using our own fork.  Now there is a fork on PyPI that is being updated.   Let's use that instead.