### PR TITLE
Remove flaky bok-choy tests

### DIFF
--- a/common/test/acceptance/tests/lms/test_bookmarks.py
+++ b/common/test/acceptance/tests/lms/test_bookmarks.py
@@ -585,45 +585,6 @@ class BookmarksTest(BookmarksTestMixin):
             total_pages=2
         )
 
-    def test_bookmarked_unit_accessed_event(self):
-        """
-        Scenario: Bookmark events are emitted with correct data when we access/visit a bookmarked unit.
-
-        Given that I am a registered user
-        And I visit my courseware page
-        And I have bookmarked a unit
-        When I click on bookmarked unit
-        Then `edx.course.bookmark.accessed` event is emitted
-        """
-        self.setup_test(num_chapters=1)
-        self.reset_event_tracking()
-
-        # create expected event data
-        xblocks = self.course_fixture.get_nested_xblocks(category="vertical")
-        event_data = [
-            {
-                'event': {
-                    'bookmark_id': '{},{}'.format(self.USERNAME, xblocks[0].locator),
-                    'component_type': xblocks[0].category,
-                    'component_usage_id': xblocks[0].locator,
-                }
-            }
-        ]
-        self.bookmark_units(num_units=1)
-        self.bookmarks_page.visit()
-
-        self._verify_pagination_info(
-            bookmark_count_on_current_page=1,
-            header_text='Showing 1 out of 1 total',
-            previous_button_enabled=False,
-            next_button_enabled=False,
-            current_page_number=1,
-            total_pages=1
-        )
-
-        self.bookmarks_page.click_bookmarked_block(0)
-        self.verify_event_data('edx.bookmark.accessed', event_data)
-
 
 @attr('a11y')
 class BookmarksA11yTests(BookmarksTestMixin):

--- a/common/test/acceptance/tests/lms/test_lms.py
+++ b/common/test/acceptance/tests/lms/test_lms.py
@@ -762,33 +762,6 @@ class VisibleToStaffOnlyTest(UniqueCourseTest):
         self.course_home_page = CourseHomePage(self.browser, self.course_id)
         self.courseware_page = CoursewarePage(self.browser, self.course_id)
 
-    def test_visible_to_staff(self):
-        """
-        Scenario: All content is visible for a user marked is_staff (different from course staff)
-            Given some of the course content has been marked 'visible_to_staff_only'
-            And I am logged on with an account marked 'is_staff'
-            Then I can see all course content
-        """
-        AutoAuthPage(self.browser, username="STAFF_TESTER", email="johndoe_staff@example.com",
-                     course_id=self.course_id, staff=True).visit()
-
-        self.course_home_page.visit()
-        self.assertEqual(3, len(self.course_home_page.outline.sections['Test Section']))
-
-        self.course_home_page.outline.go_to_section("Test Section", "Subsection With Locked Unit")
-        self.courseware_page.wait_for_page()
-        self.assertEqual([u'Locked Unit', u'Unlocked Unit'], self.courseware_page.nav.sequence_items)
-
-        self.course_home_page.visit()
-        self.course_home_page.outline.go_to_section("Test Section", "Unlocked Subsection")
-        self.courseware_page.wait_for_page()
-        self.assertEqual([u'Test Unit'], self.courseware_page.nav.sequence_items)
-
-        self.course_home_page.visit()
-        self.course_home_page.outline.go_to_section("Test Section", "Locked Subsection")
-        self.courseware_page.wait_for_page()
-        self.assertEqual([u'Test Unit'], self.courseware_page.nav.sequence_items)
-
     def test_visible_to_student(self):
         """
         Scenario: Content marked 'visible_to_staff_only' is not visible for students in the course

--- a/common/test/acceptance/tests/lms/test_lms_courseware.py
+++ b/common/test/acceptance/tests/lms/test_lms_courseware.py
@@ -293,25 +293,6 @@ class ProctoredExamTest(UniqueCourseTest):
         self.courseware_page.visit()
         self.assertEqual(self.courseware_page.has_submitted_exam_message(), hide_after_due)
 
-    def test_masquerade_visibility_override(self):
-        """
-        Given that a timed exam problem exists in the course
-        And a student has taken that exam
-        And that exam is hidden to the student
-        And I am a staff user masquerading as the student
-        Then I should be able to see the exam content
-        """
-        self._setup_and_take_timed_exam()
-
-        LogoutPage(self.browser).visit()
-        auto_auth(self.browser, "STAFF_TESTER", "staff101@example.com", True, self.course_id)
-        self.courseware_page.visit()
-        staff_page = StaffCoursewarePage(self.browser, self.course_id)
-        self.assertEqual(staff_page.staff_view_mode, 'Staff')
-
-        staff_page.set_staff_view_mode_specific_student(self.USERNAME)
-        self.assertFalse(self.courseware_page.has_submitted_exam_message())
-
     def test_field_visiblity_with_all_exam_types(self):
         """
         Given that I am a staff member

--- a/common/test/acceptance/tests/lms/test_programs.py
+++ b/common/test/acceptance/tests/lms/test_programs.py
@@ -95,22 +95,6 @@ class ProgramListingPageTest(ProgramPageBase):
         self.assertTrue(self.listing_page.is_sidebar_present)
         self.assertFalse(self.listing_page.are_cards_present)
 
-    def test_enrollments_and_programs(self):
-        """
-        Verify that cards appear when the user has enrollments
-        which are included in at least one active program.
-        """
-        self.auth()
-
-        program = self.create_program()
-        self.stub_catalog_api(programs=[program])
-        self.cache_programs()
-
-        self.listing_page.visit()
-
-        self.assertTrue(self.listing_page.is_sidebar_present)
-        self.assertTrue(self.listing_page.are_cards_present)
-
 
 @attr('a11y')
 class ProgramListingPageA11yTest(ProgramPageBase):

--- a/common/test/acceptance/tests/studio/test_studio_outline.py
+++ b/common/test/acceptance/tests/studio/test_studio_outline.py
@@ -602,46 +602,6 @@ class UnitAccessTest(CourseOutlineTest):
         staff_page.wait_for_page()
         self.assertEqual(course_home_page.outline.num_units, 2)
 
-    def test_restricted_sections_for_enrollment_track_users_in_lms(self):
-        """
-        Verify that those who are in an enrollment track with access to a restricted unit are able
-        to see that unit in lms, and those who are in an enrollment track without access to a restricted
-        unit are not able to see that unit in lms
-        """
-        # Add just 1 enrollment track to verify the enrollment option isn't available in the modal
-        add_enrollment_course_modes(self.browser, self.course_id, ["audit"])
-        self.course_outline_page.visit()
-        self.course_outline_page.expand_all_subsections()
-        unit = self.course_outline_page.section_at(0).subsection_at(0).unit_at(0)
-        enrollment_select_options = unit.get_enrollment_select_options()
-        self.assertFalse('Enrollment Track Groups' in enrollment_select_options)
-
-        # Add the additional enrollment track so the unit access toggles should now be available
-        add_enrollment_course_modes(self.browser, self.course_id, ["verified"])
-        self.course_outline_page.visit()
-        self.course_outline_page.expand_all_subsections()
-        unit = self.course_outline_page.section_at(0).subsection_at(0).unit_at(0)
-        unit.toggle_unit_access('Enrollment Track Groups', [1])  # Hard coded 1 for audit ID
-        self.course_outline_page.view_live()
-
-        course_home_page = CourseHomePage(self.browser, self.course_id)
-        course_home_page.visit()
-        course_home_page.wait_for_page()
-        course_home_page.resume_course_from_header()
-        self.assertEqual(course_home_page.outline.num_units, 2)
-
-        # Test for a user without additional content available
-        staff_page = StaffCoursewarePage(self.browser, self.course_id)
-        staff_page.set_staff_view_mode('Learner in Verified')
-        staff_page.wait_for_page()
-        self.assertEqual(course_home_page.outline.num_units, 1)
-
-        # Test for a user with additional content available
-        staff_page = StaffCoursewarePage(self.browser, self.course_id)
-        staff_page.set_staff_view_mode('Learner in Audit')
-        staff_page.wait_for_page()
-        self.assertEqual(course_home_page.outline.num_units, 2)
-
 
 @attr(shard=14)
 class StaffLockTest(CourseOutlineTest):
@@ -719,28 +679,6 @@ class StaffLockTest(CourseOutlineTest):
         self.course_outline_page.expand_all_subsections()
         unit = self.course_outline_page.section_at(0).subsection_at(0).unit_at(0)
         self._toggle_lock_on_unlocked_item(unit)
-
-    def test_locked_subsections_do_not_appear_in_lms(self):
-        """
-        Scenario: A locked subsection is not visible to students in the LMS
-            Given I have a course with two subsections
-            When I enable explicit staff lock on one subsection
-            And I click the View Live button to switch to staff view
-            And I visit the course home with the outline
-            Then I see two subsections in the outline
-            And when I switch the view mode to student view
-            Then I see one subsection in the outline
-        """
-        self.course_outline_page.visit()
-        self.course_outline_page.section_at(0).subsection_at(1).set_staff_lock(True)
-        self.course_outline_page.view_live()
-
-        course_home_page = CourseHomePage(self.browser, self.course_id)
-        course_home_page.visit()
-        course_home_page.wait_for_page()
-        self.assertEqual(course_home_page.outline.num_subsections, 2)
-        course_home_page.preview.set_staff_view_mode('Learner')
-        self.assertEqual(course_home_page.outline.num_subsections, 1)
 
     def test_subsections_can_be_locked(self):
         """

--- a/common/test/acceptance/tests/video/test_studio_video_editor.py
+++ b/common/test/acceptance/tests/video/test_studio_video_editor.py
@@ -223,61 +223,6 @@ class VideoEditorTest(CMSVideoBaseTest):
         uk_unicode_text = "Привіт, edX вітає вас.".decode('utf-8')
         self.assertTrue(self.video.download_translation('uk', uk_unicode_text))
 
-    def test_translations_remove_works_w_saving(self):
-        """
-        Scenario: Translations removing works correctly w/ preliminary saving
-        Given I have created a Video component
-        And I edit the component
-        And I open tab "Advanced"
-        And I upload transcript files:
-          |lang_code|filename               |
-          |uk       |uk_transcripts.srt     |
-          |zh       |chinese_transcripts.srt|
-        And I save changes
-        Then when I view the video it does show the captions
-        And I see "Привіт, edX вітає вас." text in the captions
-        And video language menu has "uk, zh" translations
-        And I edit the component
-        And I open tab "Advanced"
-        And I see translations for "uk, zh"
-        Then I remove translation for "uk" language code
-        And I save changes
-        Then when I view the video it does show the captions
-        And I see "好 各位同学" text in the captions
-        And I edit the component
-        And I open tab "Advanced"
-        And I see translations for "zh"
-        Then I remove translation for "zh" language code
-        And I save changes
-        Then when I view the video it does not show the captions
-        """
-        self._create_video_component()
-        self.edit_component()
-        self.open_advanced_tab()
-        self.video.upload_translation('uk_transcripts.srt', 'uk')
-        self.video.upload_translation('chinese_transcripts.srt', 'zh')
-        self.save_unit_settings()
-        self.assertTrue(self.video.is_captions_visible())
-        unicode_text = "Привіт, edX вітає вас.".decode('utf-8')
-        self.assertIn(unicode_text, self.video.captions_text)
-        self.assertEqual(self.video.caption_languages.keys(), ['zh', 'uk'])
-        self.edit_component()
-        self.open_advanced_tab()
-        self.assertEqual(self.video.translations(), ['zh', 'uk'])
-        self.video.remove_translation('uk')
-        confirm_prompt(self.video)
-        self.save_unit_settings()
-        self.assertTrue(self.video.is_captions_visible())
-        unicode_text = "好 各位同学".decode('utf-8')
-        self.assertIn(unicode_text, self.video.captions_text)
-        self.edit_component()
-        self.open_advanced_tab()
-        self.assertEqual(self.video.translations(), ['zh'])
-        self.video.remove_translation('zh')
-        confirm_prompt(self.video)
-        self.save_unit_settings()
-        self.assertFalse(self.video.is_captions_visible())
-
     def test_translations_remove_works_wo_saving(self):
         """
         Scenario: Translations removing works correctly w/o preliminary saving


### PR DESCRIPTION
Bok-choy has been failing a lot lately on master builds. There's no point in keeping these flaky tests if we're just going to ignore them.

In the past 30 builds we've seen these flaky tests fail:

```
(7 times) acceptance.tests.studio.test_studio_outline.UnitAccessTest.test_restricted_sections_for_enrollment_track_users_in_lms 

(3 times) acceptance.tests.lms.test_bookmarks.BookmarksTest.test_bookmarked_unit_accessed_event

(2 times) acceptance.tests.studio.test_studio_outline.StaffLockTest.test_locked_subsections_do_not_appear_in_lms

acceptance.tests.lms.test_lms_courseware.ProctoredExamTest.test_masquerade_visibility_override

acceptance.tests.video.test_studio_video_editor.VideoEditorTest.test_translations_remove_works_w_saving

acceptance.tests.lms.test_lms.VisibleToStaffOnlyTest.test_visible_to_staff

acceptance.tests.lms.test_programs.ProgramListingPageTest.test_enrollments_and_programs
```