### PR TITLE
Fix inconsistency b/w unit & course outline for word_cloud completion.

### DIFF
--- a/openedx/features/course_experience/utils.py
+++ b/openedx/features/course_experience/utils.py
@@ -132,7 +132,8 @@ def get_course_outline_block_tree(request, course_id):
         'video',
         'discussion',
         'drag-and-drop-v2',
-        'poll'
+        'poll',
+        'word_cloud'
     ]
     all_blocks = get_blocks(
         request,


### PR DESCRIPTION
## [Word cloud 'completion' checkmark doesn't update the course outline completion checkmark EDUCATOR-2969](https://openedx.atlassian.net/browse/EDUCATOR-2969)

### Description:
This PR fixes that if word_cloud module is in the units then it shows the completion mark on course outline page.

### How to Test?
**stage**
 1. Go to https://courses.stage.edx.org/courses/course-v1:edx+aishaq+1T2017/courseware/3332dc355d814e43b162dc5326391b76/1d481de1cd17465d9fe2aff690852166/?child=first
2. View as learner *aishaq*
3. Observe checkbox on the course navigation
4. Back to the course outline https://courses.stage.edx.org/courses/course-v1:edx+aishaq+1T2017/course/
5. Press: "Collapse All" 
6. Search for "work cloud" title
7. The checkbox is not visible.


**Sandbox**

1. Go to https://word-cloud.sandbox.edx.org/courses/course-v1:edX+DemoX+Demo_Course/courseware/50479ff092e740dc875dbfa19937bed7/2252bdaed924400d89111ae9c86d41ff/1?activate_block_id=block-v1%3AedX%2BDemoX%2BDemo_Course%2Btype%40vertical%2Bblock%409ef901f16a25470297c5e79e79f920b1
2. Solve the problem
3. Go to https://word-cloud.sandbox.edx.org/courses/course-v1:edX+DemoX+Demo_Course/course/
4. Press: "Collapse All"
5. Search for "word cloud" title 
6. observe that completion checkbox is visible.

### Screenshot
**Before Fix**
<img width="846" alt="screen shot 2018-05-24 at 10 52 59 pm" src="https://user-images.githubusercontent.com/7627421/40502718-412d7d7a-5fa5-11e8-8cc8-c3490f52de96.png">



**After Fix**
<img width="835" alt="screen shot 2018-05-24 at 10 51 17 pm" src="https://user-images.githubusercontent.com/7627421/40502669-1f228fe0-5fa5-11e8-858e-ceb9264b2a0b.png">


### Reviewers

If you've been tagged for review, please check your corresponding box once you've given the :+1:.
-  [x] @fysheets 
-  [x] @Rabia23 

### Post-review
- [x] Rebase and squash commits


