### PR TITLE
Mark blocks completed on view in render_xblock view.

### DIFF
--- a/common/lib/xmodule/xmodule/assets/vertical/public/js/vertical_student_view.js
+++ b/common/lib/xmodule/xmodule/assets/vertical/public/js/vertical_student_view.js
@@ -9,7 +9,6 @@
 // navigates back within a given sequential) to protect against duplicate calls
 // to the server.
 
-
 var SEEN_COMPLETABLES = new Set();
 
 window.VerticalStudentView = function(runtime, element) {
@@ -25,46 +24,7 @@ window.VerticalStudentView = function(runtime, element) {
             apiUrl: $bookmarkButtonElement.data('bookmarksApiUrl')
         });
     });
-    RequireJS.require(['bundles/ViewedEvent'], function() {
-        var tracker, vertical, viewedAfter;
-        var completableBlocks = [];
-        var vertModDivs = element.getElementsByClassName('vert-mod');
-        if (vertModDivs.length === 0) {
-            return;
-        }
-        vertical = vertModDivs[0];
-        $(element).find('.vert').each(function(idx, block) {
-            if (block.dataset.completableByViewing !== undefined) {
-                completableBlocks.push(block);
-            }
-        });
-        if (completableBlocks.length > 0) {
-            viewedAfter = parseInt(vertical.dataset.completionDelayMs, 10);
-            if (!(viewedAfter >= 0)) {
-                // parseInt will return NaN if it fails to parse, which is not >= 0.
-                viewedAfter = 5000;
-            }
-            tracker = new ViewedEventTracker(completableBlocks, viewedAfter);
-            tracker.addHandler(function(block, event) {
-                var blockKey = block.dataset.id;
-
-                if (blockKey && !SEEN_COMPLETABLES.has(blockKey)) {
-                    if (event.elementHasBeenViewed) {
-                        $.ajax({
-                            type: 'POST',
-                            url: runtime.handlerUrl(element, 'publish_completion'),
-                            data: JSON.stringify({
-                                block_key: blockKey,
-                                completion: 1.0
-                            })
-                        }).then(
-                            function() {
-                                SEEN_COMPLETABLES.add(blockKey);
-                            }
-                        );
-                    }
-                }
-            });
-        }
+    RequireJS.require(['bundles/CompletionOnViewService'], function() {
+        markBlocksCompletedOnViewIfNeeded(runtime, element);
     });
 };

--- a/common/lib/xmodule/xmodule/vertical_block.py
+++ b/common/lib/xmodule/xmodule/vertical_block.py
@@ -8,13 +8,9 @@ from copy import copy
 import logging
 
 from lxml import etree
-from opaque_keys.edx.keys import UsageKey
 import six
 from web_fragments.fragment import Fragment
-from xblock.completable import XBlockCompletionMode
 from xblock.core import XBlock
-from xblock.exceptions import JsonHandlerError
-
 
 from xmodule.mako_module import MakoTemplateBlockBase
 from xmodule.progress import Progress
@@ -29,19 +25,6 @@ log = logging.getLogger(__name__)
 # HACK: This shouldn't be hard-coded to two types
 # OBSOLETE: This obsoletes 'type'
 CLASS_PRIORITY = ['video', 'problem']
-
-
-def is_completable_by_viewing(block):
-    """
-    Returns True if the block can by completed by viewing it.
-
-    This is true of any non-customized, non-scorable, completable block.
-    """
-    return (
-        getattr(block, 'completion_mode', XBlockCompletionMode.COMPLETABLE) == XBlockCompletionMode.COMPLETABLE
-        and not getattr(block, 'has_custom_completion', False)
-        and not block.has_score
-    )
 
 
 @XBlock.needs('user', 'bookmarks')
@@ -59,34 +42,6 @@ class VerticalBlock(SequenceFields, XModuleFields, StudioEditableBlock, XmlParse
     has_children = True
 
     show_in_read_only_mode = True
-
-    def get_completable_by_viewing(self, completion_service):
-        """
-        Return a set of descendent blocks that this vertical still needs to
-        mark complete upon viewing.
-
-        Completed blocks are excluded to reduce network traffic from clients.
-        """
-        if completion_service is None:
-            return set()
-        if not completion_service.completion_tracking_enabled():
-            return set()
-        # pylint: disable=no-member
-        blocks = {block.location for block in self.get_display_items() if is_completable_by_viewing(block)}
-        # pylint: enable=no-member
-
-        # Exclude completed blocks to reduce traffic from client.
-        completions = completion_service.get_completions(blocks)
-        return {six.text_type(block_key) for block_key in blocks if completions[block_key] < 1.0}
-
-    def get_completion_delay_ms(self, completion_service):
-        """
-        Do not mark blocks as complete until they have been visible to the user
-        for the returned amount of time (in milliseconds).
-        """
-        if completion_service is None:
-            return 0
-        return completion_service.get_completion_by_viewing_delay_ms()
 
     def student_view(self, context):
         """
@@ -107,14 +62,25 @@ class VerticalBlock(SequenceFields, XModuleFields, StudioEditableBlock, XmlParse
             user_service = self.runtime.service(self, 'user')
             child_context['username'] = user_service.get_current_user().opt_attrs['edx-platform.username']
 
+        child_blocks = self.get_display_items()
+
+        child_blocks_to_complete_on_view = set()
         completion_service = self.runtime.service(self, 'completion')
+        if completion_service and completion_service.completion_tracking_enabled():
+            child_blocks_to_complete_on_view = completion_service.blocks_to_mark_complete_on_view(child_blocks)
+            complete_on_view_delay = completion_service.get_complete_on_view_delay_ms()
 
         child_context['child_of_vertical'] = True
         is_child_of_vertical = context.get('child_of_vertical', False)
 
         # pylint: disable=no-member
-        for child in self.get_display_items():
-            rendered_child = child.render(STUDENT_VIEW, child_context)
+        for child in child_blocks:
+            child_block_context = copy(child_context)
+            if child in child_blocks_to_complete_on_view:
+                child_block_context['wrap_xblock_data'] = {
+                    'mark-completed-on-view-after-delay': complete_on_view_delay
+                }
+            rendered_child = child.render(STUDENT_VIEW, child_block_context)
             fragment.add_fragment_resources(rendered_child)
 
             contents.append({
@@ -129,8 +95,6 @@ class VerticalBlock(SequenceFields, XModuleFields, StudioEditableBlock, XmlParse
             'show_bookmark_button': child_context.get('show_bookmark_button', not is_child_of_vertical),
             'bookmarked': child_context['bookmarked'],
             'bookmark_id': u"{},{}".format(child_context['username'], unicode(self.location)),  # pylint: disable=no-member
-            'watched_completable_blocks': self.get_completable_by_viewing(completion_service),
-            'completion_delay_ms': self.get_completion_delay_ms(completion_service),
         }))
 
         fragment.add_javascript_url(self.runtime.local_resource_url(self, 'public/js/vertical_student_view.js'))
@@ -231,29 +195,3 @@ class VerticalBlock(SequenceFields, XModuleFields, StudioEditableBlock, XmlParse
         xblock_body["content_type"] = "Sequence"
 
         return xblock_body
-
-    def find_descendent(self, block_key):
-        """
-        Return the descendent block with the given block key if it exists.
-
-        Otherwise return None.
-        """
-        for block in self.get_display_items():  # pylint: disable=no-member
-            if block.location == block_key:
-                return block
-
-    @XBlock.json_handler
-    def publish_completion(self, data, suffix=''):  # pylint: disable=unused-argument
-        """
-        Publish data from the front end.
-        """
-        block_key = UsageKey.from_string(data.pop('block_key')).map_into_course(self.course_id)
-        block = self.find_descendent(block_key)
-        if block is None:
-            message = "Invalid block: {} not found in {}"
-            raise JsonHandlerError(400, message.format(block_key, self.location))  # pylint: disable=no-member
-        elif not is_completable_by_viewing(block):
-            message = "Invalid block type: {} in block {} not configured for completion by viewing"
-            raise JsonHandlerError(400, message.format(type(block), block_key))
-        self.runtime.publish(block, "completion", data)
-        return {'result': 'ok'}

--- a/common/test/acceptance/pages/lms/completion.py
+++ b/common/test/acceptance/pages/lms/completion.py
@@ -1,0 +1,26 @@
+# -*- coding: utf-8 -*-
+"""
+Mixins for completion.
+"""
+
+
+class CompletionOnViewMixin(object):
+    """
+    Methods for testing completion on view.
+    """
+
+    def xblock_components_mark_completed_on_view_value(self):
+        """
+        Return the xblock components data-mark-completed-on-view-after-delay value.
+        """
+        return self.q(css=self.xblock_component_selector).attrs('data-mark-completed-on-view-after-delay')
+
+    def wait_for_xblock_component_to_be_marked_completed_on_view(self, index=0):
+        """
+        Wait for xblock component to be marked completed on view.
+
+        Arguments
+            index (int): index of block to wait on. (default is 0)
+        """
+        self.wait_for(lambda: (self.xblock_components_mark_completed_on_view_value()[index] == '0'),
+                      'Waiting for xblock to be marked completed on view.')

--- a/common/test/acceptance/pages/lms/courseware.py
+++ b/common/test/acceptance/pages/lms/courseware.py
@@ -8,11 +8,13 @@ from bok_choy.page_object import PageObject, unguarded
 from bok_choy.promise import EmptyPromise
 from selenium.webdriver.common.action_chains import ActionChains
 
+from common.test.acceptance.pages.lms import BASE_URL
 from common.test.acceptance.pages.lms.bookmarks import BookmarksPage
+from common.test.acceptance.pages.lms.completion import CompletionOnViewMixin
 from common.test.acceptance.pages.lms.course_page import CoursePage
 
 
-class CoursewarePage(CoursePage):
+class CoursewarePage(CoursePage, CompletionOnViewMixin):
     """
     Course info.
     """
@@ -587,3 +589,25 @@ class CourseNavPage(PageObject):
         # reload the same page with the course_outline_page flag
         self.browser.get(self.browser.current_url + "&course_experience.course_outline_page=1")
         self.wait_for_page()
+
+
+class RenderXBlockPage(PageObject, CompletionOnViewMixin):
+    """
+    render_xblock page.
+    """
+
+    xblock_component_selector = '.xblock'
+
+    def __init__(self, browser, block_id):
+        super(RenderXBlockPage, self).__init__(browser)
+        self.block_id = block_id
+
+    @property
+    def url(self):
+        """
+        Construct a URL to the page within the course.
+        """
+        return BASE_URL + "/xblock/" + self.block_id
+
+    def is_browser_on_page(self):
+        return self.q(css='.course-content').present

--- a/common/test/db_fixtures/waffle_flags.json
+++ b/common/test/db_fixtures/waffle_flags.json
@@ -24,6 +24,14 @@
         }
     },
     {
+        "pk": 2,
+        "model": "waffle.switch",
+        "fields": {
+            "name": "completion.enable_completion_tracking",
+            "active": true
+        }
+    },
+    {
         "pk": 3,
         "model": "waffle.flag",
         "fields": {

--- a/lms/djangoapps/courseware/testutils.py
+++ b/lms/djangoapps/courseware/testutils.py
@@ -105,6 +105,11 @@ class RenderXBlockTestMixin(object):
                 category='html',
                 data="<p>Test HTML Content<p>"
             )
+            self.problem_block = ItemFactory.create(
+                parent=self.vertical_block,
+                category='problem',
+                display_name='Problem'
+            )
         CourseOverview.load_from_module_store(self.course.id)
 
         # block_name_to_be_tested can be `html_block` or `vertical_block`.
@@ -150,9 +155,9 @@ class RenderXBlockTestMixin(object):
         return response
 
     @ddt.data(
-        ('vertical_block', ModuleStoreEnum.Type.mongo, 10),
+        ('vertical_block', ModuleStoreEnum.Type.mongo, 11),
         ('vertical_block', ModuleStoreEnum.Type.split, 6),
-        ('html_block', ModuleStoreEnum.Type.mongo, 11),
+        ('html_block', ModuleStoreEnum.Type.mongo, 12),
         ('html_block', ModuleStoreEnum.Type.split, 6),
     )
     @ddt.unpack

--- a/lms/djangoapps/courseware/views/views.py
+++ b/lms/djangoapps/courseware/views/views.py
@@ -1472,6 +1472,15 @@ def render_xblock(request, usage_key_string, check_if_enrolled=True):
         student_view_context = request.GET.dict()
         student_view_context['show_bookmark_button'] = False
 
+        enable_completion_on_view_service = False
+        completion_service = block.runtime.service(block, 'completion')
+        if completion_service and completion_service.completion_tracking_enabled():
+            if completion_service.blocks_to_mark_complete_on_view({block}):
+                enable_completion_on_view_service = True
+                student_view_context['wrap_xblock_data'] = {
+                    'mark-completed-on-view-after-delay': completion_service.get_complete_on_view_delay_ms()
+                }
+
         context = {
             'fragment': block.render('student_view', context=student_view_context),
             'course': course,
@@ -1480,6 +1489,7 @@ def render_xblock(request, usage_key_string, check_if_enrolled=True):
             'disable_header': True,
             'disable_footer': True,
             'disable_window_wrap': True,
+            'enable_completion_on_view_service': enable_completion_on_view_service,
             'staff_access': bool(has_access(request.user, 'staff', course)),
             'xqa_server': settings.FEATURES.get('XQA_SERVER', 'http://your_xqa_server.com'),
         }

--- a/lms/envs/bok_choy.py
+++ b/lms/envs/bok_choy.py
@@ -239,6 +239,10 @@ if RELEASE_LINE == "master":
 
 WAFFLE_OVERRIDE = True
 
+############## Settings for Completion API #########################
+
+COMPLETION_BY_VIEWING_DELAY_MS = 1000
+
 #####################################################################
 # Lastly, see if the developer has any local overrides.
 try:

--- a/lms/static/completion/js/CompletionOnViewService.js
+++ b/lms/static/completion/js/CompletionOnViewService.js
@@ -1,0 +1,42 @@
+import { ViewedEventTracker } from './ViewedEvent';
+
+const completedBlocksKeys = new Set();
+
+export function markBlocksCompletedOnViewIfNeeded(runtime, containerElement) {
+  const blockElements = $(containerElement).find(
+    '.xblock-student_view[data-mark-completed-on-view-after-delay]',
+  ).get();
+
+  if (blockElements.length > 0) {
+    const tracker = new ViewedEventTracker();
+
+    blockElements.forEach((blockElement) => {
+      const markCompletedOnViewAfterDelay = parseInt(
+        blockElement.dataset.markCompletedOnViewAfterDelay, 10,
+      );
+      if (markCompletedOnViewAfterDelay >= 0) {
+        tracker.addElement(blockElement, markCompletedOnViewAfterDelay);
+      }
+    });
+
+    tracker.addHandler((blockElement, event) => {
+      const blockKey = blockElement.dataset.usageId;
+      if (blockKey && !completedBlocksKeys.has(blockKey)) {
+        if (event.elementHasBeenViewed) {
+          $.ajax({
+            type: 'POST',
+            url: runtime.handlerUrl(blockElement, 'publish_completion'),
+            data: JSON.stringify({
+              completion: 1.0,
+            }),
+          }).then(
+            () => {
+              completedBlocksKeys.add(blockKey);
+              blockElement.dataset.markCompletedOnViewAfterDelay = 0;
+            },
+          );
+        }
+      }
+    });
+  }
+}

--- a/lms/static/completion/js/ViewedEvent.js
+++ b/lms/static/completion/js/ViewedEvent.js
@@ -107,22 +107,22 @@ export class ViewedEventTracker {
    * *   hasBeenViewed (bool): true if all the conditions for being
    *     considered "viewed" have been met.
    */
-  constructor(elements, viewedAfterMs) {
-    this.viewedAfterMs = viewedAfterMs;
+  constructor() {
     this.elementViewings = new Set();
     this.handlers = [];
-
-    this.interval = undefined;
-    elements.forEach((el) => {
-      this.elementViewings.add(
-        new ElementViewing(
-          el,
-          viewedAfterMs,
-          (element, event) => this.callHandlers(element, event),
-        ),
-      );
-    });
     this.registerDomHandlers();
+  }
+
+  /** Add an element to track.  */
+  addElement(element, viewedAfterMs) {
+    this.elementViewings.add(
+     new ElementViewing(
+       element,
+       viewedAfterMs,
+       (el, event) => this.callHandlers(el, event),
+      ),
+    );
+    this.updateVisible();
   }
 
   /** Register a new handler to be called when an element has been viewed.  */

--- a/lms/static/completion/js/spec/ViewedEvent_spec.js
+++ b/lms/static/completion/js/spec/ViewedEvent_spec.js
@@ -13,7 +13,10 @@ describe('ViewedTracker', () => {
 
   it('calls the handlers when an element is viewed', () => {
     document.body.innerHTML = '<div id="d1"></div><div id="d2"></div><div id="d3"></div>';
-    const tracker = new ViewedEventTracker(Array.from(document.getElementsByTagName('div')), 1000);
+    const tracker = new ViewedEventTracker();
+    for (const element of document.getElementsByTagName('div')) {
+      tracker.addElement(element, 1000);
+    }
     const handlerSpy = jasmine.createSpy('handlerSpy');
     tracker.addHandler(handlerSpy);
     const elvIter = tracker.elementViewings.values();

--- a/lms/static/js/courseware.js
+++ b/lms/static/js/courseware.js
@@ -14,7 +14,15 @@
     };
 
     Courseware.prototype.render = function() {
-      XBlock.initializeBlocks($('.course-content'));
+      var courseContentElement = $('.course-content')[0];
+      var blocks = XBlock.initializeBlocks(courseContentElement);
+
+      if (courseContentElement.dataset.enableCompletionOnViewService === 'true') {
+        RequireJS.require(['bundles/CompletionOnViewService'], function() {
+            markBlocksCompletedOnViewIfNeeded(blocks[0].runtime, courseContentElement);
+        });
+      }
+
       return $('.course-content .histogram').each(function() {
         var error, histg, id;
         id = $(this).attr('id').replace(/histogram_/, '');

--- a/lms/templates/courseware/courseware-chromeless.html
+++ b/lms/templates/courseware/courseware-chromeless.html
@@ -70,7 +70,13 @@ ${HTML(fragment.foot_html())}
 </%block>
 
 <div class="course-wrapper chromeless">
-  <section class="course-content" id="course-content">
+  <section class="course-content" id="course-content"\
+    % if enable_completion_on_view_service:
+      data-enable-completion-on-view-service="true" \
+    % else:
+      data-enable-completion-on-view-service="false" \
+    % endif
+  >
       <main id="main" tabindex="-1" aria-label="Content">
         ${HTML(fragment.body_html())}
       </main>

--- a/lms/templates/vert_module.html
+++ b/lms/templates/vert_module.html
@@ -8,17 +8,9 @@
     <%include file='bookmark_button.html' args="bookmark_id=bookmark_id, is_bookmarked=bookmarked"/>
 % endif
 
-<div class="vert-mod" \
-  % if completion_delay_ms is not None:
-    data-completion-delay-ms="${completion_delay_ms}" \
-  % endif
-    >
+<div class="vert-mod">
 % for idx, item in enumerate(items):
-  <div class="vert vert-${idx}" data-id="${item['id']}" \
-    % if item['id'] in watched_completable_blocks:
-      data-completable-by-viewing=True \
-    % endif
-      >
+  <div class="vert vert-${idx}" data-id="${item['id']}">
     ${HTML(item['content'])}
   </div>
 % endfor

--- a/openedx/core/lib/tests/test_xblock_utils.py
+++ b/openedx/core/lib/tests/test_xblock_utils.py
@@ -100,7 +100,7 @@ class TestXblockUtils(SharedModuleStoreTestCase):
             block=course,
             view='baseview',
             frag=fragment,
-            context=None,
+            context={"wrap_xblock_data": {"custom-attribute": "custom-value"}},
             usage_id_serializer=lambda usage_id: quote_slashes(unicode(usage_id)),
             request_token=uuid.uuid1().get_hex()
         )
@@ -109,6 +109,7 @@ class TestXblockUtils(SharedModuleStoreTestCase):
         self.assertIn('data-runtime-class="TestRuntime"', test_wrap_output.content)
         self.assertIn(data_usage_id, test_wrap_output.content)
         self.assertIn('<h1>Test!</h1>', test_wrap_output.content)
+        self.assertIn('data-custom-attribute="custom-value"', test_wrap_output.content)
         self.assertEqual(test_wrap_output.resources[0].data, u'body {background-color:red;}')
         self.assertEqual(test_wrap_output.resources[1].data, 'alert("Hi!");')
 

--- a/openedx/core/lib/xblock_utils/__init__.py
+++ b/openedx/core/lib/xblock_utils/__init__.py
@@ -92,6 +92,9 @@ def wrap_xblock(
     data = {}
     data.update(extra_data)
 
+    if context:
+        data.update(context.get('wrap_xblock_data', {}))
+
     css_classes = [
         'xblock',
         'xblock-{}'.format(markupsafe.escape(view)),

--- a/openedx/tests/completion_integration/test_services.py
+++ b/openedx/tests/completion_integration/test_services.py
@@ -36,6 +36,10 @@ class CompletionServiceTestCase(CompletionWaffleTestMixin, SharedModuleStoreTest
                 parent=cls.sequence,
                 category='vertical',
             )
+            cls.html = ItemFactory.create(
+                parent=cls.vertical,
+                category='html',
+            )
             cls.problem = ItemFactory.create(
                 parent=cls.vertical,
                 category="problem",
@@ -70,6 +74,13 @@ class CompletionServiceTestCase(CompletionWaffleTestMixin, SharedModuleStoreTest
         self.completion_service = CompletionService(self.user, self.course_key)
 
         # Proper completions for the given runtime
+        BlockCompletion.objects.submit_completion(
+            user=self.user,
+            course_key=self.course_key,
+            block_key=self.html.location,
+            completion=1.0,
+        )
+
         for idx, block_key in enumerate(self.block_keys[0:3]):
             BlockCompletion.objects.submit_completion(
                 user=self.user,
@@ -148,3 +159,12 @@ class CompletionServiceTestCase(CompletionWaffleTestMixin, SharedModuleStoreTest
             self.completion_service.vertical_is_complete(self.vertical),
             False,
         )
+
+    def test_can_mark_block_complete_on_view(self):
+
+        self.assertEqual(self.completion_service.can_mark_block_complete_on_view(self.course), False)
+        self.assertEqual(self.completion_service.can_mark_block_complete_on_view(self.chapter), False)
+        self.assertEqual(self.completion_service.can_mark_block_complete_on_view(self.sequence), False)
+        self.assertEqual(self.completion_service.can_mark_block_complete_on_view(self.vertical), False)
+        self.assertEqual(self.completion_service.can_mark_block_complete_on_view(self.html), True)
+        self.assertEqual(self.completion_service.can_mark_block_complete_on_view(self.problem), False)

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -111,7 +111,7 @@ edx-ace==0.1.8
 edx-analytics-data-api-client==0.14.4
 edx-ccx-keys==0.2.1
 edx-celeryutils==0.2.7
-edx-completion==0.1.6
+edx-completion==0.1.7
 edx-django-oauth2-provider==1.2.5
 edx-django-release-util==0.3.1
 edx-django-sites-extensions==2.3.1

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -131,7 +131,7 @@ edx-ace==0.1.8
 edx-analytics-data-api-client==0.14.4
 edx-ccx-keys==0.2.1
 edx-celeryutils==0.2.7
-edx-completion==0.1.6
+edx-completion==0.1.7
 edx-django-oauth2-provider==1.2.5
 edx-django-release-util==0.3.1
 edx-django-sites-extensions==2.3.1

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -126,7 +126,7 @@ edx-ace==0.1.8
 edx-analytics-data-api-client==0.14.4
 edx-ccx-keys==0.2.1
 edx-celeryutils==0.2.7
-edx-completion==0.1.6
+edx-completion==0.1.7
 edx-django-oauth2-provider==1.2.5
 edx-django-release-util==0.3.1
 edx-django-sites-extensions==2.3.1

--- a/webpack.common.config.js
+++ b/webpack.common.config.js
@@ -40,7 +40,7 @@ module.exports = {
         ProgramDetailsFactory: './lms/static/js/learner_dashboard/program_details_factory.js',
         ProgramListFactory: './lms/static/js/learner_dashboard/program_list_factory.js',
         UnenrollmentFactory: './lms/static/js/learner_dashboard/unenrollment_factory.js',
-        ViewedEvent: './lms/static/completion/js/ViewedEvent.js',
+        CompletionOnViewService: './lms/static/completion/js/CompletionOnViewService.js',
 
         // Features
         CourseGoals: './openedx/features/course_experience/static/course_experience/js/CourseGoals.js',


### PR DESCRIPTION
Webviews in mobile apps do not encapsulate leaf-blocks in html for vertical blocks. Instead, they use the "chromeless-courseware" `render_xblock` view. This PR adds this missing completion functionality to `render_xblock` view.

Part of [Completion API](https://openedx.atlassian.net/wiki/spaces/OpenDev/pages/162247762/Completion+API) work.
Previous PR: https://github.com/edx/edx-platform/pull/16234.

**JIRA tickets**: [OSPR-2441](https://openedx.atlassian.net/browse/OSPR-2441)

**Screenshots**: No change to UI.

**Sandbox URL**: https://pr18273.sandbox.opencraft.hosting/

**Merge deadline**: None

**Testing instructions**:

1. In `/admin/waffle/switch/` add and activate `completion.enable_completion_tracking` to turn on completion tracking.
2. Complete on view tracking happens when the user is visiting courseware pages and when the `render_xblock` view is displayed in the mobile apps.
3. To test courseware pages, visit a course section. When a vertical, which has XBlocks to which this completion strategy is applicable (e.g. html XBlock), is viewed the first time, a `publish_completion` ajax call is made to the server for each child XBlock when it has been viewed from start to end for 5 seconds.
4. To test `render_xblock` view, visit a url of the form `/xblock/<block_id>`. If this completion strategy is applicable to the XBlock, a `publish_completion` ajax call is made to the server when it is viewed for the first time from start to end for 5 seconds.
5. To help with testing, completion data can be reset via the following steps:
```
 ./manage.py lms shell
from completion.models import BlockCompletion
BlockCompletion.objects.all().delete()
```

**Reviewers**
- [x] @pomegranited 
- [x] @staubina or @iloveagent57 
