### PR TITLE
add script to detect dead code

### DIFF
--- a/requirements/edx/development.in
+++ b/requirements/edx/development.in
@@ -17,6 +17,7 @@ edx-sphinx-theme                    # Documentation theme
 pyinotify                           # More efficient checking for runserver reload trigger events
 snakefood                           # Lists dependencies between Python modules, used in scripts/dependencies/*
 sphinx                              # Developer documentation builder
+vulture                             # Detects possible dead/unused code, used in scripts/find-dead-code.sh
 
 # Performance timer used in modulestore/perf_tests/test_asset_import_export.py
 -e git+https://github.com/doctoryes/code_block_timer.git@f3d0629f086bcc649c3c77f4bc5b9c2c8172c3bf#egg=code_block_timer

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -334,6 +334,7 @@ urlobject==2.4.3
 user-util==0.1.3
 virtualenv==16.0.0
 voluptuous==0.11.1
+vulture==0.26
 w3lib==1.19.0
 watchdog==0.8.3
 web-fragments==0.2.2

--- a/scripts/vulture/find-dead-code.sh
+++ b/scripts/vulture/find-dead-code.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+set -e
+
+############################################################################
+#
+# find-dead-code.sh
+#
+# This script analyzes the edx-platform for dead code instances using
+# vulture, a static analysis tool that ranks potential unused code using
+# the following confidence scores:
+# - 100% = completely unreachable code: code that follows return, continue
+#          or raise statements, or code that cannot logically be run, i.e.
+#          a condition that can never be True
+# - 90%  = unused imports within a file
+# - 60%  = unused code: code that has no reference in the code base, aside
+#          from definition
+#
+# This script will output a list of dead-code instances with their
+# confidence scores, in descending order of the size of the instance
+# (in lines). This in turn can be used to clean up the edx-platform.
+# However, you shouldn't automatically delete code reported back from
+# vulture. It can report false positives. Often it's not the case that
+# code is truly dead, but has been referenced incorrectly (spelling)
+# elsewhere in the code base, most likely in a refactor. Another example
+# of code that will be interpreted as dead by vulture is anything that
+# is used in a template (which is not considered in the analysis).
+#
+# Therefore, the results of this script should be used as a jumping off
+# point for investigating potential dead code removal
+#
+############################################################################
+
+OUTPUT_DIR="reports/vulture"
+mkdir -p ${OUTPUT_DIR}
+OUTPUT_FILE=${OUTPUT_DIR}/vulture-report.txt
+echo '' > $OUTPUT_FILE
+# exclude test code from analysis, as it isn't explicitly called by other
+# code. Additionally, application code that is only called by tests 
+# should be considered dead
+EXCLUSIONS='/test,/acceptance,cms/envs,lms/envs,/terrain,migrations/,signals.py'
+MIN_CONFIDENCE=90
+# paths to the code on which to run the analysis
+CODE_PATHS='cms common lms openedx'
+WHITELIST_PATH="$(dirname "${BASH_SOURCE[0]}")/whitelist.py"
+echo "Checking for dead code in the following paths: $CODE_PATHS"
+echo "Results can be found in $OUTPUT_FILE"
+vulture $CODE_PATHS $WHITELIST_PATH --exclude $EXCLUSIONS \
+--min-confidence $MIN_CONFIDENCE \
+--sort-by-size |tac > $OUTPUT_FILE

--- a/scripts/vulture/whitelist.py
+++ b/scripts/vulture/whitelist.py
@@ -1,0 +1,13 @@
+#!/bin/env python
+
+# Vulture often detects false positives when analyzing a code
+# base. If there are particular things you wish to ignore,
+# add them below. This file is consumed by
+# scripts/dead_code/find-dead-code.sh
+
+from vulture.whitelist_utils import Whitelist
+
+view_whitelilst = Whitelist()
+
+# Example:
+# view_whitelist.name_of_function_to_whitelist


### PR DESCRIPTION
This adds a script to run vulture on the main code paths in the platform, excluding tests. At a later date, we may want to run this specifically *on* tests to clean up that section of the code.

One source of false positives that can arrise in the analysis is in templated html files. As far as I can see, there are three options for dealing with this:
* Accept that templates are a source of false positives and keep that in mind when doing dead code analysis
* Do some fancy grepping/python after running vulture to negate results when they are referenced in templates
* Look into ways of getting vulture to look at Mako/Jinja templates

I admit the third option would be a fun challenge, but odds are we want to do either the first or second option, due to the fact that we have no idea how often we plan on running this. Thoughts?