### PR TITLE
Pass program UUID as resource_id to generate unique cache key.

### DIFF
--- a/lms/static/sass/views/_program-details.scss
+++ b/lms/static/sass/views/_program-details.scss
@@ -312,7 +312,6 @@
     .program-heading-message {
       font-weight: 300;
     }
-
   }
 
   .course-enroll-view {

--- a/openedx/core/djangoapps/credentials/tests/test_utils.py
+++ b/openedx/core/djangoapps/credentials/tests/test_utils.py
@@ -46,6 +46,7 @@ class TestGetCredentials(CredentialsApiConfigMixin, CacheIsolationTestCase):
             'status': 'awarded',
         }
         self.assertEqual(kwargs['querystring'], querystring)
+        self.assertIsNone(kwargs['resource_id'])
 
         self.assertEqual(actual, expected)
 
@@ -66,5 +67,6 @@ class TestGetCredentials(CredentialsApiConfigMixin, CacheIsolationTestCase):
             'program_uuid': program_uuid,
         }
         self.assertEqual(kwargs['querystring'], querystring)
+        self.assertEqual(kwargs['resource_id'], program_uuid)
 
         self.assertEqual(actual, expected)

--- a/openedx/core/djangoapps/credentials/utils.py
+++ b/openedx/core/djangoapps/credentials/utils.py
@@ -59,5 +59,10 @@ def get_credentials(user, program_uuid=None):
     api = get_credentials_api_client(user)
 
     return get_edx_api_data(
-        credential_configuration, 'credentials', api=api, querystring=querystring, cache_key=cache_key
+        credential_configuration,
+        'credentials',
+        api=api,
+        resource_id=program_uuid,
+        querystring=querystring,
+        cache_key=cache_key
     )


### PR DESCRIPTION
Without program UUID cache key was same every time for single learner on multiple programs and getting the same data from cache.

LEARNER-5373

@edx/learner-spartans Please review.