### PR TITLE
Only get program certs from credentials

### DIFF
--- a/openedx/core/djangoapps/credentials/tests/factories.py
+++ b/openedx/core/djangoapps/credentials/tests/factories.py
@@ -28,4 +28,4 @@ class UserCredential(DictFactoryBase):
     status = 'awarded'
     uuid = factory.Faker('uuid4')
     certificate_url = factory.Faker('url')
-    credential = factory.LazyFunction(partial(generate_instances, ProgramCredential, count=1))
+    credential = ProgramCredential()

--- a/openedx/core/djangoapps/credentials/tests/test_utils.py
+++ b/openedx/core/djangoapps/credentials/tests/test_utils.py
@@ -68,3 +68,22 @@ class TestGetCredentials(CredentialsApiConfigMixin, CacheIsolationTestCase):
         self.assertEqual(kwargs['querystring'], querystring)
 
         self.assertEqual(actual, expected)
+
+    def test_programs_only(self, mock_get_edx_api_data):
+        expected = factories.UserCredential.create_batch(3)
+        expected[0]['credential'] = factories.CourseCredential()
+        mock_get_edx_api_data.return_value = expected
+
+        actual = get_credentials(self.user, programs_only=True)
+
+        mock_get_edx_api_data.assert_called_once()
+        call = mock_get_edx_api_data.mock_calls[0]
+        __, __, kwargs = call
+
+        querystring = {
+            'username': self.user.username,
+            'status': 'awarded',
+        }
+        self.assertEqual(kwargs['querystring'], querystring)
+
+        self.assertEqual(actual, expected[1:])

--- a/openedx/core/djangoapps/credentials/utils.py
+++ b/openedx/core/djangoapps/credentials/utils.py
@@ -31,7 +31,7 @@ def get_credentials_api_client(user):
     return EdxRestApiClient(CredentialsApiConfig.current().internal_api_url, jwt=jwt)
 
 
-def get_credentials(user, program_uuid=None):
+def get_credentials(user, program_uuid=None, programs_only=False):
     """
     Given a user, get credentials earned from the credentials service.
 
@@ -40,6 +40,7 @@ def get_credentials(user, program_uuid=None):
 
     Keyword Arguments:
         program_uuid (str): UUID of the program whose credential to retrieve.
+        programs_only (bool): Whether to only return program-level credentials
 
     Returns:
         list of dict, representing credentials returned by the Credentials
@@ -58,6 +59,11 @@ def get_credentials(user, program_uuid=None):
     cache_key = credential_configuration.CACHE_KEY + '.' + user.username if use_cache else None
     api = get_credentials_api_client(user)
 
-    return get_edx_api_data(
+    credentials = get_edx_api_data(
         credential_configuration, 'credentials', api=api, querystring=querystring, cache_key=cache_key
     )
+
+    if programs_only:
+        credentials = filter(lambda cred: 'program_uuid' in cred['credential'], credentials)
+
+    return credentials

--- a/openedx/core/djangoapps/programs/tasks/v1/tasks.py
+++ b/openedx/core/djangoapps/programs/tasks/v1/tasks.py
@@ -75,9 +75,8 @@ def get_certified_programs(student):
 
     """
     certified_programs = []
-    for credential in get_credentials(student):
-        if 'program_uuid' in credential['credential']:
-            certified_programs.append(credential['credential']['program_uuid'])
+    for credential in get_credentials(student, programs_only=True):
+        certified_programs.append(credential['credential']['program_uuid'])
     return certified_programs
 
 

--- a/openedx/core/djangoapps/programs/utils.py
+++ b/openedx/core/djangoapps/programs/utils.py
@@ -673,7 +673,7 @@ def get_certificates(user, extended_program):
                 # We only want one certificate per course to be returned.
                 break
 
-    program_credentials = get_credentials(user, program_uuid=extended_program['uuid'])
+    program_credentials = get_credentials(user, program_uuid=extended_program['uuid'], programs_only=True)
     # only include a program certificate if a certificate is available for every course
     if program_credentials and (len(certificates) == len(extended_program['courses'])):
         enabled_force_program_cert_auth = configuration_helpers.get_value(


### PR DESCRIPTION
Allow our utility function to filter out course certs when asking Credentials for a list of certificates. This way once we start handing back course certs, the LMS won't be surprised by assumptions about what the credentials service will give back.