### PR TITLE
Only get program certs from credentials

### DIFF
--- a/openedx/core/djangoapps/credentials/tests/factories.py
+++ b/openedx/core/djangoapps/credentials/tests/factories.py
@@ -28,4 +28,4 @@ class UserCredential(DictFactoryBase):
     status = 'awarded'
     uuid = factory.Faker('uuid4')
     certificate_url = factory.Faker('url')
-    credential = factory.LazyFunction(partial(generate_instances, ProgramCredential, count=1))
+    credential = ProgramCredential()

--- a/openedx/core/djangoapps/credentials/tests/test_utils.py
+++ b/openedx/core/djangoapps/credentials/tests/test_utils.py
@@ -72,3 +72,17 @@ class TestGetCredentials(CredentialsApiConfigMixin, CacheIsolationTestCase):
         self.assertEqual(kwargs['cache_key'], cache_key)
 
         self.assertEqual(actual, expected)
+
+    def test_type_filter(self, mock_get_edx_api_data):
+        get_credentials(self.user, credential_type='program')
+
+        mock_get_edx_api_data.assert_called_once()
+        call = mock_get_edx_api_data.mock_calls[0]
+        __, __, kwargs = call
+
+        querystring = {
+            'username': self.user.username,
+            'status': 'awarded',
+            'type': 'program',
+        }
+        self.assertEqual(kwargs['querystring'], querystring)

--- a/openedx/core/djangoapps/credentials/utils.py
+++ b/openedx/core/djangoapps/credentials/utils.py
@@ -31,7 +31,7 @@ def get_credentials_api_client(user):
     return EdxRestApiClient(CredentialsApiConfig.current().internal_api_url, jwt=jwt)
 
 
-def get_credentials(user, program_uuid=None):
+def get_credentials(user, program_uuid=None, credential_type=None):
     """
     Given a user, get credentials earned from the credentials service.
 
@@ -40,6 +40,7 @@ def get_credentials(user, program_uuid=None):
 
     Keyword Arguments:
         program_uuid (str): UUID of the program whose credential to retrieve.
+        credential_type (str): Which type of credentials to return (course-run or program)
 
     Returns:
         list of dict, representing credentials returned by the Credentials
@@ -51,6 +52,9 @@ def get_credentials(user, program_uuid=None):
 
     if program_uuid:
         querystring['program_uuid'] = program_uuid
+
+    if credential_type:
+        querystring['type'] = credential_type
 
     # Bypass caching for staff users, who may be generating credentials and
     # want to see them displayed immediately.

--- a/openedx/core/djangoapps/programs/tasks/v1/tasks.py
+++ b/openedx/core/djangoapps/programs/tasks/v1/tasks.py
@@ -75,9 +75,8 @@ def get_certified_programs(student):
 
     """
     certified_programs = []
-    for credential in get_credentials(student):
-        if 'program_uuid' in credential['credential']:
-            certified_programs.append(credential['credential']['program_uuid'])
+    for credential in get_credentials(student, credential_type='program'):
+        certified_programs.append(credential['credential']['program_uuid'])
     return certified_programs
 
 

--- a/openedx/core/djangoapps/programs/tasks/v1/tests/test_tasks.py
+++ b/openedx/core/djangoapps/programs/tasks/v1/tests/test_tasks.py
@@ -79,11 +79,11 @@ class GetAwardedCertificateProgramsTestCase(TestCase):
         student = UserFactory(username='test-username')
         mock_get_credentials.return_value = [
             self.make_credential_result(status='awarded', credential={'program_uuid': 1}),
-            self.make_credential_result(status='awarded', credential={'course_id': 2}),
         ]
 
         result = tasks.get_certified_programs(student)
         self.assertEqual(mock_get_credentials.call_args[0], (student,))
+        self.assertEqual(mock_get_credentials.call_args[1], {'credential_type': 'program'})
         self.assertEqual(result, [1])
 
 

--- a/openedx/core/djangoapps/programs/utils.py
+++ b/openedx/core/djangoapps/programs/utils.py
@@ -673,7 +673,7 @@ def get_certificates(user, extended_program):
                 # We only want one certificate per course to be returned.
                 break
 
-    program_credentials = get_credentials(user, program_uuid=extended_program['uuid'])
+    program_credentials = get_credentials(user, program_uuid=extended_program['uuid'], credential_type='program')
     # only include a program certificate if a certificate is available for every course
     if program_credentials and (len(certificates) == len(extended_program['courses'])):
         enabled_force_program_cert_auth = configuration_helpers.get_value(


### PR DESCRIPTION
Allow our utility function to filter out course certs when asking Credentials for a list of certificates. This way once we start handing back course certs, the LMS won't be surprised by assumptions about what the credentials service will give back.