### PR TITLE
LEARNER-5434: Add a configuration option for deleting student accounts.

### DIFF
--- a/common/test/acceptance/tests/lms/test_account_settings.py
+++ b/common/test/acceptance/tests/lms/test_account_settings.py
@@ -196,7 +196,11 @@ class AccountSettingsPageTest(AccountSettingsTestMixin, AcceptanceTest):
                     'Facebook Link',
                     'LinkedIn Link',
                 ]
-            }
+            },
+            {
+                'title': 'Delete My Account',
+                'fields': []
+            },
         ]
 
         self.assertEqual(self.account_settings_page.sections_structure(), expected_sections_structure)

--- a/lms/djangoapps/student_account/views.py
+++ b/lms/djangoapps/student_account/views.py
@@ -568,6 +568,9 @@ def account_settings_context(request):
         'show_program_listing': ProgramsApiConfig.is_enabled(),
         'show_dashboard_tabs': True,
         'order_history': user_orders,
+        'enable_account_deletion': configuration_helpers.get_value(
+            'ENABLE_ACCOUNT_DELETION', settings.FEATURES.get('ENABLE_ACCOUNT_DELETION', False)
+        ),
         'extended_profile_fields': _get_extended_profile_fields(),
     }
 

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -402,6 +402,9 @@ FEATURES = {
 
     # Set this to true to make API docs available at /api-docs/.
     'ENABLE_API_DOCS': False,
+
+    # Whether to display the account deletion section the account settings page
+    'ENABLE_ACCOUNT_DELETION': True,
 }
 
 # Settings for the course reviews tool template and identification key, set either to None to disable course reviews

--- a/lms/static/js/student_account/views/account_settings_factory.js
+++ b/lms/static/js/student_account/views/account_settings_factory.js
@@ -27,6 +27,7 @@
             enterpriseReadonlyAccountFields,
             edxSupportUrl,
             extendedProfileFields,
+            displayAccountDeletion,
             enableGDPRFlag
         ) {
             var $accountSettingsElement, userAccountModel, userPreferencesModel, aboutSectionsData,
@@ -292,7 +293,7 @@
             aboutSectionsData.push(socialFields);
 
             // Add account deletion fields
-            if (enableGDPRFlag) {
+            if (displayAccountDeletion) {
                 accountDeletionFields = {
                     title: gettext('Delete My Account'),
                     fields: [],

--- a/lms/templates/student_account/account_settings.html
+++ b/lms/templates/student_account/account_settings.html
@@ -48,6 +48,7 @@ from openedx.features.course_experience import ENABLE_GDPR_COMPAT_FLAG
         enterpriseReadonlyAccountFields = ${ enterprise_readonly_account_fields | n, dump_js_escaped_json },
         edxSupportUrl = '${ edx_support_url | n, js_escaped_string }',
         extendedProfileFields = ${ extended_profile_fields | n, dump_js_escaped_json },
+        displayAccountDeletion = ${ enable_account_deletion | n, dump_js_escaped_json};
         enableGDPRFlag = ${ ENABLE_GDPR_COMPAT_FLAG.is_enabled_without_course_context() | n, dump_js_escaped_json };
 
     AccountSettingsFactory(
@@ -68,6 +69,7 @@ from openedx.features.course_experience import ENABLE_GDPR_COMPAT_FLAG
         enterpriseReadonlyAccountFields,
         edxSupportUrl,
         extendedProfileFields,
+        displayAccountDeletion,
         enableGDPRFlag
     );
 </%static:require_module>


### PR DESCRIPTION
Moving this configuration to rely on this setting entirely. The removal of the GDPR flag entirely will be completed as part of [LEARNER-5384](https://openedx.atlassian.net/browse/LEARNER-5384).

FYI @ColeLRogers so that you can see the changes i'm making.