### PR TITLE
Notes retirement endpoint should require trailing slash

### DIFF
--- a/lms/djangoapps/edxnotes/api_urls.py
+++ b/lms/djangoapps/edxnotes/api_urls.py
@@ -6,5 +6,5 @@ from django.conf.urls import url
 from edxnotes import views
 
 urlpatterns = [
-    url(r"^retire_user$", views.RetireUserView.as_view(), name="edxnotes_retire_user"),
+    url(r"^retire_user/$", views.RetireUserView.as_view(), name="edxnotes_retire_user"),
 ]


### PR DESCRIPTION
This is because we already require trailing slashes on most of the rest
of the retirement endpoints, which are called via slumber which appends
the trailing slash by default.