### PR TITLE
use anonymous user ID when calling the edxnotes retirement endpoint

### DIFF
--- a/lms/djangoapps/edxnotes/helpers.py
+++ b/lms/djangoapps/edxnotes/helpers.py
@@ -121,11 +121,11 @@ def send_request(user, course_id, page, page_size, path="", text=None):
     return response
 
 
-def delete_all_notes_for_user(user, user_id):
+def delete_all_notes_for_user(user):
     """
-    helper method to delete all notes for a user_id, as part of GDPR compliance
+    helper method to delete all notes for a user, as part of GDPR compliance
 
-    :param user_id: The user object associated with the deleted notes
+    :param user: The user object associated with the deleted notes
     :return: response (requests) object
 
     Raises:
@@ -136,7 +136,7 @@ def delete_all_notes_for_user(user, user_id):
         "x-annotator-auth-token": get_edxnotes_id_token(user),
     }
     data = {
-        "user_id": user_id
+        "user_id": anonymous_id_for_user(user, None)
     }
     try:
         response = requests.delete(

--- a/lms/djangoapps/edxnotes/views.py
+++ b/lms/djangoapps/edxnotes/views.py
@@ -256,7 +256,7 @@ class RetireUserView(APIView):
         username = request.data['username']
         try:
             retirement = UserRetirementStatus.get_retirement_for_retirement_action(username)
-            delete_all_notes_for_user(retirement.user, retirement.user.id)
+            delete_all_notes_for_user(retirement.user)
         except UserRetirementStatus.DoesNotExist:
             return Response(status=status.HTTP_404_NOT_FOUND)
         except RetirementStateError as exc:


### PR DESCRIPTION
I was thrown off by the function signature of delete_all_notes_for_user taking a user_id but not explaining that it's in fact an anonymous user id (according to the model definition in the edx-notes-api repo).  I simplified it to just take a django User object, and put the anonymous user magic within.

Testing this has been a bear, without loadtest being available.  I'll look into deploying notes in my devstack, but honestly I think it'll be faster to let this hit stage and test there since we're currently the only consumers of this endpoint.