### PR TITLE
Allow scrolling after insert/edit image in Studio

### DIFF
--- a/common/lib/xmodule/xmodule/js/src/html/edit.js
+++ b/common/lib/xmodule/xmodule/js/src/html/edit.js
@@ -1289,8 +1289,9 @@
 
     HTMLEditingDescriptor.prototype.editImageSubmit = function(event) {
       if (event.detail) {
-        return this.saveImageFromModal(event.detail);
+        this.saveImageFromModal(event.detail);
       }
+      return this.closeImageModal();
     };
 
     HTMLEditingDescriptor.prototype.editLink = function(data) {


### PR DESCRIPTION
[EDUCATOR-2971](https://openedx.atlassian.net/browse/EDUCATOR-2971)

The scroll lock class `modal-open` is removed from the body when the
EditImageModal is closed using the "Close" or "X" button, but not when the
"Insert Image" button is clicked. The submit button handler now calls the
`closeImageModal` handler too so that the `modal-open` class is removed after
inserting or editing an image.

@edx/educator-dahlia 