### PR TITLE
s/django.core.urlresolvers/django.urls/g

### DIFF
--- a/cms/djangoapps/api/v1/tests/test_views/test_course_runs.py
+++ b/cms/djangoapps/api/v1/tests/test_views/test_course_runs.py
@@ -3,7 +3,7 @@ import datetime
 import ddt
 import pytz
 from django.core.files.uploadedfile import SimpleUploadedFile
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.test import RequestFactory
 from opaque_keys.edx.keys import CourseKey
 from openedx.core.lib.courses import course_image_url

--- a/cms/djangoapps/cms_user_tasks/signals.py
+++ b/cms/djangoapps/cms_user_tasks/signals.py
@@ -5,7 +5,7 @@ from __future__ import absolute_import, print_function, unicode_literals
 
 import logging
 
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.dispatch import receiver
 from user_tasks.models import UserTaskArtifact
 from user_tasks.signals import user_task_stopped

--- a/cms/djangoapps/cms_user_tasks/tests.py
+++ b/cms/djangoapps/cms_user_tasks/tests.py
@@ -12,7 +12,7 @@ from boto.exception import NoAuthHandlerFound
 from django.conf import settings
 from django.contrib.auth.models import User
 from django.core import mail
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.test import override_settings
 from rest_framework.test import APITestCase
 from user_tasks.models import UserTaskArtifact, UserTaskStatus

--- a/cms/djangoapps/contentstore/api/tests/test_views.py
+++ b/cms/djangoapps/contentstore/api/tests/test_views.py
@@ -8,7 +8,7 @@ import tempfile
 from datetime import datetime
 from urllib import urlencode
 
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from path import Path as path
 from mock import patch
 from rest_framework import status

--- a/cms/djangoapps/contentstore/courseware_index.py
+++ b/cms/djangoapps/contentstore/courseware_index.py
@@ -7,7 +7,7 @@ from abc import ABCMeta, abstractmethod
 from datetime import timedelta
 
 from django.conf import settings
-from django.core.urlresolvers import resolve
+from django.urls import resolve
 from django.utils.translation import ugettext as _
 from django.utils.translation import ugettext_lazy
 from search.search_engine_base import SearchEngine

--- a/cms/djangoapps/contentstore/tests/test_course_create_rerun.py
+++ b/cms/djangoapps/contentstore/tests/test_course_create_rerun.py
@@ -4,7 +4,7 @@ Test view handler for rerun (and eventually create)
 from datetime import datetime
 
 import ddt
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.test.client import RequestFactory
 from mock import patch
 from opaque_keys.edx.keys import CourseKey

--- a/cms/djangoapps/contentstore/tests/test_request_event.py
+++ b/cms/djangoapps/contentstore/tests/test_request_event.py
@@ -1,6 +1,6 @@
 """Tests for CMS's requests to logs"""
 import mock
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.test import TestCase
 
 from contentstore.views.helpers import event as cms_user_track

--- a/cms/djangoapps/contentstore/tests/tests.py
+++ b/cms/djangoapps/contentstore/tests/tests.py
@@ -11,7 +11,7 @@ from ddt import data, ddt, unpack
 from django.conf import settings
 from django.contrib.auth.models import User
 from django.core.cache import cache
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.test import TestCase
 from django.test.utils import override_settings
 from freezegun import freeze_time

--- a/cms/djangoapps/contentstore/utils.py
+++ b/cms/djangoapps/contentstore/utils.py
@@ -6,7 +6,7 @@ import logging
 from datetime import datetime
 
 from django.conf import settings
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.utils.translation import ugettext as _
 from opaque_keys.edx.keys import CourseKey, UsageKey
 from pytz import UTC

--- a/cms/djangoapps/contentstore/views/course.py
+++ b/cms/djangoapps/contentstore/views/course.py
@@ -14,7 +14,7 @@ from ccx_keys.locator import CCXLocator
 from django.conf import settings
 from django.contrib.auth.decorators import login_required
 from django.core.exceptions import PermissionDenied, ValidationError
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.http import Http404, HttpResponse, HttpResponseBadRequest, HttpResponseNotFound
 from django.shortcuts import redirect
 from django.utils.translation import ugettext as _

--- a/cms/djangoapps/contentstore/views/preview.py
+++ b/cms/djangoapps/contentstore/views/preview.py
@@ -5,7 +5,7 @@ from functools import partial
 
 from django.conf import settings
 from django.contrib.auth.decorators import login_required
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.http import Http404, HttpResponseBadRequest
 from django.utils.translation import ugettext as _
 from opaque_keys.edx.keys import UsageKey

--- a/cms/djangoapps/contentstore/views/public.py
+++ b/cms/djangoapps/contentstore/views/public.py
@@ -3,7 +3,7 @@ Public views
 """
 from django.conf import settings
 from django.template.context_processors import csrf
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.shortcuts import redirect
 from django.views.decorators.clickjacking import xframe_options_deny
 from django.views.decorators.csrf import ensure_csrf_cookie

--- a/cms/djangoapps/contentstore/views/tests/test_item.py
+++ b/cms/djangoapps/contentstore/views/tests/test_item.py
@@ -4,7 +4,7 @@ from datetime import datetime, timedelta
 
 import ddt
 from django.conf import settings
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.http import Http404
 from django.test import TestCase
 from django.test.client import RequestFactory

--- a/cms/djangoapps/contentstore/views/tests/test_organizations.py
+++ b/cms/djangoapps/contentstore/views/tests/test_organizations.py
@@ -1,7 +1,7 @@
 """Tests covering the Organizations listing on the Studio home."""
 import json
 
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.test import TestCase
 from mock import patch
 

--- a/cms/djangoapps/contentstore/views/tests/test_transcript_settings.py
+++ b/cms/djangoapps/contentstore/views/tests/test_transcript_settings.py
@@ -5,7 +5,7 @@ from io import BytesIO
 from mock import Mock, patch, ANY
 
 from django.test.testcases import TestCase
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from edxval import api
 
 from contentstore.tests.utils import CourseTestCase

--- a/cms/djangoapps/contentstore/views/tests/test_transcripts.py
+++ b/cms/djangoapps/contentstore/views/tests/test_transcripts.py
@@ -10,7 +10,7 @@ import textwrap
 from uuid import uuid4
 
 from django.conf import settings
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.test.utils import override_settings
 from edxval.api import create_video
 from opaque_keys.edx.keys import UsageKey

--- a/cms/djangoapps/contentstore/views/videos.py
+++ b/cms/djangoapps/contentstore/views/videos.py
@@ -15,7 +15,7 @@ from django.conf import settings
 from django.contrib.auth.decorators import login_required
 from django.contrib.staticfiles.storage import staticfiles_storage
 from django.core.files.images import get_image_dimensions
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.http import HttpResponse, HttpResponseNotFound
 from django.utils.translation import ugettext as _
 from django.utils.translation import ugettext_noop

--- a/cms/djangoapps/course_creators/tests/test_views.py
+++ b/cms/djangoapps/course_creators/tests/test_views.py
@@ -5,7 +5,7 @@ Tests course_creators.views.py.
 import mock
 from django.contrib.auth.models import User
 from django.core.exceptions import PermissionDenied
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.test import TestCase
 
 from course_creators.views import (

--- a/cms/djangoapps/maintenance/tests.py
+++ b/cms/djangoapps/maintenance/tests.py
@@ -5,7 +5,7 @@ import json
 
 import ddt
 from django.conf import settings
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 
 from contentstore.management.commands.utils import get_course_versions
 from student.tests.factories import AdminFactory, UserFactory

--- a/cms/lib/xblock/runtime.py
+++ b/cms/lib/xblock/runtime.py
@@ -2,7 +2,7 @@
 XBlock runtime implementations for edX Studio
 """
 
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 
 
 def handler_url(block, handler_name, suffix='', query='', thirdparty=False):

--- a/cms/templates/accessibility.html
+++ b/cms/templates/accessibility.html
@@ -2,7 +2,7 @@
 <%inherit file="base.html" />
 <%def name="online_help_token()"><% return "accessibility" %></%def>
 <%!
-  from django.core.urlresolvers import reverse
+  from django.urls import reverse
   from django.utils.translation import ugettext as _
   from openedx.core.djangolib.markup import HTML, Text
   from openedx.core.djangolib.js_utils import js_escaped_string, dump_js_escaped_json

--- a/cms/templates/asset_index.html
+++ b/cms/templates/asset_index.html
@@ -2,7 +2,7 @@
 <%inherit file="base.html" />
 <%def name="online_help_token()"><% return "files" %></%def>
 <%!
-  from django.core.urlresolvers import reverse
+  from django.urls import reverse
   from django.utils.translation import ugettext as _
   from openedx.core.djangolib.markup import HTML, Text
   from openedx.core.djangolib.js_utils import js_escaped_string, dump_js_escaped_json

--- a/cms/templates/course-create-rerun.html
+++ b/cms/templates/course-create-rerun.html
@@ -3,7 +3,7 @@
 <%def name="online_help_token()"><% return "course_rerun" %></%def>
 <%!
 from django.utils.translation import ugettext as _
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from openedx.core.djangolib.js_utils import js_escaped_string
 %>
 

--- a/cms/templates/edit-tabs.html
+++ b/cms/templates/edit-tabs.html
@@ -4,7 +4,7 @@
 <%namespace name='static' file='static_content.html'/>
 <%!
   from django.utils.translation import ugettext as _
-  from django.core.urlresolvers import reverse
+  from django.urls import reverse
   from xmodule.tabs import StaticTab
   from openedx.core.djangolib.js_utils import js_escaped_string
 %>

--- a/cms/templates/error.html
+++ b/cms/templates/error.html
@@ -2,7 +2,7 @@
 <%inherit file="base.html" />
 <%!
 from django.utils.translation import ugettext as _
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.conf import settings
 %>
 <%block name="bodyclass">error</%block>

--- a/cms/templates/export_git.html
+++ b/cms/templates/export_git.html
@@ -3,7 +3,7 @@
 <%namespace name='static' file='static_content.html'/>
 
 <%!
-  from django.core.urlresolvers import reverse
+  from django.urls import reverse
   from django.utils.translation import ugettext as _
 %>
 <%block name="title">${_("Export Course to Git")}</%block>

--- a/cms/templates/howitworks.html
+++ b/cms/templates/howitworks.html
@@ -3,7 +3,7 @@
 <%def name="online_help_token()"><% return "welcome" %></%def>
 <%namespace name='static' file='static_content.html'/>
 <%!
-  from django.core.urlresolvers import reverse
+  from django.urls import reverse
   from django.utils.translation import ugettext as _
   from openedx.core.djangolib.markup import HTML, Text
 %>

--- a/cms/templates/html_error.html
+++ b/cms/templates/html_error.html
@@ -1,5 +1,5 @@
 <%! from django.utils.translation import ugettext as _ %>
-<%! from django.core.urlresolvers import reverse %>
+<%! from django.urls import reverse %>
 
 <%block name="content">
   <div class="wrapper wrapper-alert wrapper-alert-error is-shown">

--- a/cms/templates/login.html
+++ b/cms/templates/login.html
@@ -3,7 +3,7 @@
 <%inherit file="base.html" />
 <%def name="online_help_token()"><% return "login" %></%def>
 <%!
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.utils.translation import ugettext as _
 from openedx.core.djangolib.js_utils import js_escaped_string
 %>

--- a/cms/templates/maintenance/base.html
+++ b/cms/templates/maintenance/base.html
@@ -3,7 +3,7 @@
 <%def name='online_help_token()'><% return 'maintenance' %></%def>
 <%namespace name='static' file='../static_content.html'/>
 <%!
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.utils.translation import ugettext as _
 %>
 <%block name="content">

--- a/cms/templates/maintenance/container.html
+++ b/cms/templates/maintenance/container.html
@@ -2,7 +2,7 @@
 <%inherit file="base.html" />
 <%namespace name='static' file='../static_content.html'/>
 <%!
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from openedx.core.djangolib.js_utils import js_escaped_string
 %>
 <%block name="title">${view['name']}</%block>

--- a/cms/templates/maintenance/index.html
+++ b/cms/templates/maintenance/index.html
@@ -3,7 +3,7 @@
 <%namespace name='static' file='../static_content.html'/>
 <%!
 from django.utils.translation import ugettext as _
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 %>
 <%block name="title">${_('Maintenance Dashboard')}</%block>
 <%block name="viewcontent">

--- a/cms/templates/manage_users.html
+++ b/cms/templates/manage_users.html
@@ -1,7 +1,7 @@
 <%inherit file="base.html" />
 <%!
 from django.utils.translation import ugettext as _
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 
 from openedx.core.djangolib.js_utils import (
     dump_js_escaped_json, js_escaped_string

--- a/cms/templates/manage_users_lib.html
+++ b/cms/templates/manage_users_lib.html
@@ -1,7 +1,7 @@
 <%inherit file="base.html" />
 <%!
 from django.utils.translation import ugettext as _
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 
 from openedx.core.djangolib.js_utils import (
     dump_js_escaped_json, js_escaped_string

--- a/cms/templates/register.html
+++ b/cms/templates/register.html
@@ -2,7 +2,7 @@
 <%def name="online_help_token()"><% return "register" %></%def>
 <%!
 from django.utils.translation import ugettext as _
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 %>
 
 <%block name="title">${_("Sign Up")}</%block>

--- a/cms/templates/registration/activation_complete.html
+++ b/cms/templates/registration/activation_complete.html
@@ -1,7 +1,7 @@
 <%inherit file="../base.html" />
 <%!
 from django.utils.translation import ugettext as _
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 %>
 
 <%namespace name='static' file='../static_content.html'/>

--- a/cms/templates/registration/activation_invalid.html
+++ b/cms/templates/registration/activation_invalid.html
@@ -3,7 +3,7 @@
 <%namespace name='static' file='../static_content.html'/>
 <%!
 from django.utils.translation import ugettext as _
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from openedx.core.djangolib.markup import HTML, Text
 %>
 

--- a/cms/templates/widgets/footer.html
+++ b/cms/templates/widgets/footer.html
@@ -1,6 +1,6 @@
 <%!
 from django.utils.translation import ugettext as _
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from datetime import datetime
 from django.conf import settings
 import pytz

--- a/cms/templates/widgets/header.html
+++ b/cms/templates/widgets/header.html
@@ -2,7 +2,7 @@
 <%namespace name='static' file='../static_content.html'/>
 <%!
   from django.conf import settings
-  from django.core.urlresolvers import reverse
+  from django.urls import reverse
   from django.utils.translation import ugettext as _
   from openedx.core.djangoapps.lang_pref.api import header_language_selector_is_enabled, released_languages
 %>

--- a/cms/templates/widgets/user_dropdown.html
+++ b/cms/templates/widgets/user_dropdown.html
@@ -2,7 +2,7 @@
 <%namespace name='static' file='../static_content.html'/>
 <%!
   from django.conf import settings
-  from django.core.urlresolvers import reverse
+  from django.urls import reverse
   from django.utils.translation import ugettext as _
   from student.roles import GlobalStaff
 %>

--- a/common/djangoapps/course_modes/tests/test_admin.py
+++ b/common/djangoapps/course_modes/tests/test_admin.py
@@ -6,7 +6,7 @@ from datetime import datetime, timedelta
 
 import ddt
 from django.conf import settings
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from pytz import UTC, timezone
 
 from course_modes.admin import CourseModeForm

--- a/common/djangoapps/course_modes/tests/test_views.py
+++ b/common/djangoapps/course_modes/tests/test_views.py
@@ -11,7 +11,7 @@ import freezegun
 import httpretty
 import pytz
 from django.conf import settings
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from mock import patch
 from nose.plugins.attrib import attr
 

--- a/common/djangoapps/course_modes/views.py
+++ b/common/djangoapps/course_modes/views.py
@@ -9,7 +9,7 @@ import urllib
 import waffle
 from babel.dates import format_datetime
 from django.contrib.auth.decorators import login_required
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.db import transaction
 from django.http import HttpResponse, HttpResponseBadRequest
 from django.shortcuts import redirect

--- a/common/djangoapps/edxmako/shortcuts.py
+++ b/common/djangoapps/edxmako/shortcuts.py
@@ -16,7 +16,7 @@ import logging
 from urlparse import urljoin
 
 from django.conf import settings
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.http import HttpResponse
 from django.template import engines
 

--- a/common/djangoapps/edxmako/tests.py
+++ b/common/djangoapps/edxmako/tests.py
@@ -2,7 +2,7 @@ import unittest
 
 import ddt
 from django.conf import settings
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.http import HttpResponse
 from django.test import TestCase
 from django.test.client import RequestFactory

--- a/common/djangoapps/enrollment/tests/test_views.py
+++ b/common/djangoapps/enrollment/tests/test_views.py
@@ -13,7 +13,7 @@ from django.conf import settings
 from django.core.cache import cache
 from django.core.exceptions import ImproperlyConfigured
 from django.core.handlers.wsgi import WSGIRequest
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.test import Client
 from django.test.utils import override_settings
 from mock import patch

--- a/common/djangoapps/entitlements/api/v1/tests/test_views.py
+++ b/common/djangoapps/entitlements/api/v1/tests/test_views.py
@@ -8,7 +8,7 @@ from courseware.models import (
     DynamicUpgradeDeadlineConfiguration
 )
 from django.conf import settings
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.utils.timezone import now
 from mock import patch
 from opaque_keys.edx.locator import CourseKey

--- a/common/djangoapps/microsite_configuration/tests/backends/test_filebased.py
+++ b/common/djangoapps/microsite_configuration/tests/backends/test_filebased.py
@@ -6,7 +6,7 @@ from mock import patch
 
 from django.test import TestCase
 from django.conf import settings
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 
 from microsite_configuration.backends.base import (
     BaseMicrositeBackend,

--- a/common/djangoapps/student/cookies.py
+++ b/common/djangoapps/student/cookies.py
@@ -9,7 +9,7 @@ import time
 import six
 from django.conf import settings
 from django.contrib.auth.models import User
-from django.core.urlresolvers import NoReverseMatch, reverse
+from django.urls import NoReverseMatch, reverse
 from django.dispatch import Signal
 from django.utils.http import cookie_date
 

--- a/common/djangoapps/student/forms.py
+++ b/common/djangoapps/student/forms.py
@@ -12,7 +12,7 @@ from django.contrib.auth.models import User
 from django.contrib.auth.tokens import default_token_generator
 from django.contrib.sites.models import Site
 from django.core.exceptions import ValidationError
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.core.validators import RegexValidator, slug_re
 from django.forms import widgets
 from django.utils.http import int_to_base36

--- a/common/djangoapps/student/helpers.py
+++ b/common/djangoapps/student/helpers.py
@@ -11,7 +11,7 @@ from datetime import datetime
 import django
 from django.conf import settings
 from django.core.exceptions import PermissionDenied
-from django.core.urlresolvers import NoReverseMatch, reverse
+from django.urls import NoReverseMatch, reverse
 from django.core.validators import ValidationError
 from django.contrib.auth import load_backend
 from django.contrib.auth.models import User

--- a/common/djangoapps/student/tests/test_activate_account.py
+++ b/common/djangoapps/student/tests/test_activate_account.py
@@ -3,7 +3,7 @@ import unittest
 from uuid import uuid4
 
 from django.conf import settings
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.test import TestCase, override_settings
 from mock import patch
 

--- a/common/djangoapps/student/tests/test_admin_views.py
+++ b/common/djangoapps/student/tests/test_admin_views.py
@@ -3,7 +3,7 @@ Tests student admin.py
 """
 from django.contrib.admin.sites import AdminSite
 from django.contrib.auth.models import User
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.test import TestCase
 from mock import Mock
 

--- a/common/djangoapps/student/tests/test_bulk_email_settings.py
+++ b/common/djangoapps/student/tests/test_bulk_email_settings.py
@@ -7,7 +7,7 @@ Course Auth is turned on.
 import unittest
 
 from django.conf import settings
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 
 # This import is for an lms djangoapp.
 # Its testcases are only run under lms.

--- a/common/djangoapps/student/tests/test_certificates.py
+++ b/common/djangoapps/student/tests/test_certificates.py
@@ -6,7 +6,7 @@ import datetime
 import ddt
 import mock
 from django.conf import settings
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.test.utils import override_settings
 from mock import patch
 from pytz import UTC

--- a/common/djangoapps/student/tests/test_configuration_overrides.py
+++ b/common/djangoapps/student/tests/test_configuration_overrides.py
@@ -5,7 +5,7 @@ import json
 
 import mock
 from django.contrib.auth.models import User
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.test import TestCase
 
 from student.models import UserSignupSource

--- a/common/djangoapps/student/tests/test_cookies.py
+++ b/common/djangoapps/student/tests/test_cookies.py
@@ -3,7 +3,7 @@ from __future__ import unicode_literals
 
 import six
 from django.conf import settings
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.test import RequestFactory
 
 from openedx.core.djangoapps.user_api.accounts.utils import retrieve_last_sitewide_block_completed

--- a/common/djangoapps/student/tests/test_create_account.py
+++ b/common/djangoapps/student/tests/test_create_account.py
@@ -10,7 +10,7 @@ import mock
 import pytz
 from django.conf import settings
 from django.contrib.auth.models import AnonymousUser, User
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.test import TestCase, TransactionTestCase
 from django.test.client import RequestFactory
 from django.test.utils import override_settings

--- a/common/djangoapps/student/tests/test_credit.py
+++ b/common/djangoapps/student/tests/test_credit.py
@@ -7,7 +7,7 @@ import unittest
 import ddt
 import pytz
 from django.conf import settings
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.test.utils import override_settings
 from mock import patch
 

--- a/common/djangoapps/student/tests/test_email.py
+++ b/common/djangoapps/student/tests/test_email.py
@@ -5,7 +5,7 @@ import unittest
 from django.conf import settings
 from django.contrib.auth.models import User
 from django.core import mail
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.db import transaction
 from django.http import HttpResponse
 from django.test import override_settings, TransactionTestCase

--- a/common/djangoapps/student/tests/test_enrollment.py
+++ b/common/djangoapps/student/tests/test_enrollment.py
@@ -5,7 +5,7 @@ import unittest
 
 import ddt
 from django.conf import settings
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from mock import patch
 from nose.plugins.attrib import attr
 

--- a/common/djangoapps/student/tests/test_helpers.py
+++ b/common/djangoapps/student/tests/test_helpers.py
@@ -5,7 +5,7 @@ import logging
 import ddt
 from django.conf import settings
 from django.contrib.sessions.middleware import SessionMiddleware
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.test import TestCase
 from django.test.client import RequestFactory
 from django.test.utils import override_settings

--- a/common/djangoapps/student/tests/test_login.py
+++ b/common/djangoapps/student/tests/test_login.py
@@ -8,7 +8,7 @@ import httpretty
 from django.conf import settings
 from django.contrib.auth.models import User
 from django.core.cache import cache
-from django.core.urlresolvers import NoReverseMatch, reverse
+from django.urls import NoReverseMatch, reverse
 from django.http import HttpResponse, HttpResponseBadRequest
 from django.test import TestCase
 from django.test.client import Client

--- a/common/djangoapps/student/tests/test_login_registration_forms.py
+++ b/common/djangoapps/student/tests/test_login_registration_forms.py
@@ -4,7 +4,7 @@ import urllib
 
 import ddt
 from django.conf import settings
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from mock import patch
 
 from third_party_auth.tests.testutil import ThirdPartyAuthTestMixin

--- a/common/djangoapps/student/tests/test_long_username_email.py
+++ b/common/djangoapps/student/tests/test_long_username_email.py
@@ -2,7 +2,7 @@
 
 import json
 
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.test import TestCase
 
 from openedx.core.djangoapps.user_api.accounts import USERNAME_BAD_LENGTH_MSG

--- a/common/djangoapps/student/tests/test_password_policy.py
+++ b/common/djangoapps/student/tests/test_password_policy.py
@@ -7,7 +7,7 @@ from importlib import import_module
 
 from django.conf import settings
 from django.contrib.auth.models import AnonymousUser
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.test import TestCase
 from django.test.client import RequestFactory
 from django.test.utils import override_settings

--- a/common/djangoapps/student/tests/test_recent_enrollments.py
+++ b/common/djangoapps/student/tests/test_recent_enrollments.py
@@ -6,7 +6,7 @@ import unittest
 
 import ddt
 from django.conf import settings
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.utils.timezone import now
 from nose.plugins.attrib import attr
 from opaque_keys.edx import locator

--- a/common/djangoapps/student/tests/test_refunds.py
+++ b/common/djangoapps/student/tests/test_refunds.py
@@ -11,7 +11,7 @@ import pytz
 # Explicitly import the cache from ConfigurationModel so we can reset it after each test
 from config_models.models import cache
 from django.conf import settings
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.test.client import Client
 from django.test.utils import override_settings
 from mock import patch

--- a/common/djangoapps/student/tests/test_reset_password.py
+++ b/common/djangoapps/student/tests/test_reset_password.py
@@ -12,7 +12,7 @@ from django.contrib.auth.models import User
 from django.contrib.auth.tokens import default_token_generator
 from django.core.cache import cache
 from django.core import mail
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.test.client import RequestFactory
 from django.test.utils import override_settings
 from django.utils.http import int_to_base36

--- a/common/djangoapps/student/tests/test_retirement.py
+++ b/common/djangoapps/student/tests/test_retirement.py
@@ -7,7 +7,7 @@ import ddt
 from django.apps import apps
 from django.conf import settings
 from django.contrib.auth.models import User
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.test import TestCase
 import pytest
 

--- a/common/djangoapps/student/tests/test_userstanding.py
+++ b/common/djangoapps/student/tests/test_userstanding.py
@@ -5,7 +5,7 @@ that students with disabled accounts are unable to access the courseware.
 import unittest
 
 from django.conf import settings
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.test import Client, TestCase
 
 from student.models import UserStanding

--- a/common/djangoapps/student/tests/test_verification_status.py
+++ b/common/djangoapps/student/tests/test_verification_status.py
@@ -4,7 +4,7 @@ from datetime import datetime, timedelta
 
 import ddt
 from django.conf import settings
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.test import override_settings
 from mock import patch
 from nose.plugins.attrib import attr

--- a/common/djangoapps/student/tests/test_views.py
+++ b/common/djangoapps/student/tests/test_views.py
@@ -10,7 +10,7 @@ from datetime import timedelta
 import ddt
 from completion.test_utils import submit_completions_for_testing, CompletionWaffleTestMixin
 from django.conf import settings
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.test import RequestFactory, TestCase
 from django.test.utils import override_settings
 from django.utils.timezone import now

--- a/common/djangoapps/student/tests/tests.py
+++ b/common/djangoapps/student/tests/tests.py
@@ -12,7 +12,7 @@ import pytz
 from config_models.models import cache
 from django.conf import settings
 from django.contrib.auth.models import AnonymousUser, User
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.test import TestCase, override_settings
 from django.test.client import Client
 from markupsafe import escape

--- a/common/djangoapps/student/views/dashboard.py
+++ b/common/djangoapps/student/views/dashboard.py
@@ -11,7 +11,7 @@ from completion.utilities import get_key_to_last_completed_course_block
 from django.conf import settings
 from django.contrib import messages
 from django.contrib.auth.decorators import login_required
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.shortcuts import redirect
 from django.utils.translation import ugettext as _
 from django.views.decorators.csrf import ensure_csrf_cookie

--- a/common/djangoapps/student/views/login.py
+++ b/common/djangoapps/student/views/login.py
@@ -18,7 +18,7 @@ from django.contrib.auth import authenticate, load_backend, login as django_logi
 from django.contrib.auth.decorators import login_required
 from django.contrib.auth.models import AnonymousUser, User
 from django.core.exceptions import ObjectDoesNotExist, PermissionDenied
-from django.core.urlresolvers import NoReverseMatch, reverse, reverse_lazy
+from django.urls import NoReverseMatch, reverse, reverse_lazy
 from django.core.validators import ValidationError, validate_email
 from django.http import Http404, HttpResponse, HttpResponseBadRequest, HttpResponseForbidden
 from django.shortcuts import redirect

--- a/common/djangoapps/student/views/management.py
+++ b/common/djangoapps/student/views/management.py
@@ -20,7 +20,7 @@ from django.contrib.auth.decorators import login_required
 from django.contrib.auth.models import AnonymousUser, User
 from django.contrib.auth.views import password_reset_confirm
 from django.core import mail
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.core.validators import ValidationError, validate_email
 from django.db import transaction
 from django.db.models.signals import post_save

--- a/common/djangoapps/third_party_auth/admin.py
+++ b/common/djangoapps/third_party_auth/admin.py
@@ -5,7 +5,7 @@ Admin site configuration for third party authentication
 from config_models.admin import KeyedConfigurationModelAdmin
 from django import forms
 from django.contrib import admin
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.db import DatabaseError, transaction
 from django.utils.translation import ugettext_lazy as _
 

--- a/common/djangoapps/third_party_auth/api/tests/test_views.py
+++ b/common/djangoapps/third_party_auth/api/tests/test_views.py
@@ -5,7 +5,7 @@ Tests for the Third Party Auth REST API
 import unittest
 
 import ddt
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.http import QueryDict
 from mock import patch
 from provider.constants import CONFIDENTIAL

--- a/common/djangoapps/third_party_auth/decorators.py
+++ b/common/djangoapps/third_party_auth/decorators.py
@@ -4,7 +4,6 @@ Decorators that can be used to interact with third_party_auth.
 from functools import wraps
 
 from django.conf import settings
-from django.core.urlresolvers import reverse
 from django.shortcuts import redirect
 from django.utils.decorators import available_attrs
 

--- a/common/djangoapps/third_party_auth/pipeline.py
+++ b/common/djangoapps/third_party_auth/pipeline.py
@@ -70,7 +70,7 @@ import analytics
 from django.conf import settings
 from django.contrib.auth.models import User
 from django.core.mail.message import EmailMessage
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.http import HttpResponseBadRequest
 from django.shortcuts import redirect
 import social_django

--- a/common/djangoapps/third_party_auth/tests/specs/base.py
+++ b/common/djangoapps/third_party_auth/tests/specs/base.py
@@ -14,7 +14,7 @@ from django.contrib import auth
 from django.contrib.auth import models as auth_models
 from django.contrib.messages.storage import fallback
 from django.contrib.sessions.backends import cache
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.test import utils as django_utils
 from django.conf import settings as django_settings
 from social_core import actions, exceptions

--- a/common/djangoapps/third_party_auth/tests/specs/test_google.py
+++ b/common/djangoapps/third_party_auth/tests/specs/test_google.py
@@ -3,7 +3,7 @@ import base64
 import hashlib
 import hmac
 from django.conf import settings
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 import json
 from mock import patch
 from openedx.tests.util import expected_redirect_url

--- a/common/djangoapps/third_party_auth/tests/specs/test_lti.py
+++ b/common/djangoapps/third_party_auth/tests/specs/test_lti.py
@@ -5,7 +5,7 @@ import unittest
 import django
 from django.conf import settings
 from django.contrib.auth.models import User
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from oauthlib.oauth1.rfc5849 import Client, SIGNATURE_TYPE_BODY
 from openedx.tests.util import expected_redirect_url
 from third_party_auth.tests import testutil

--- a/common/djangoapps/third_party_auth/tests/test_admin.py
+++ b/common/djangoapps/third_party_auth/tests/test_admin.py
@@ -5,7 +5,7 @@ import unittest
 
 from django.contrib.admin.sites import AdminSite
 from django.core.files.uploadedfile import SimpleUploadedFile
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.forms import models
 
 from student.tests.factories import UserFactory

--- a/common/djangoapps/third_party_auth/views.py
+++ b/common/djangoapps/third_party_auth/views.py
@@ -2,7 +2,7 @@
 Extra views required for SSO
 """
 from django.conf import settings
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.http import Http404, HttpResponse, HttpResponseNotAllowed, HttpResponseServerError
 from django.shortcuts import redirect, render
 from django.views.decorators.csrf import csrf_exempt

--- a/common/djangoapps/track/tests/test_logs.py
+++ b/common/djangoapps/track/tests/test_logs.py
@@ -3,7 +3,7 @@ import unittest
 
 import mock
 from django.conf import settings
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.test import TestCase
 
 from track.models import TrackingLog

--- a/common/djangoapps/util/testing.py
+++ b/common/djangoapps/util/testing.py
@@ -6,7 +6,7 @@ import json
 import sys
 
 from django.conf import settings
-from django.core.urlresolvers import clear_url_caches, resolve
+from django.urls import clear_url_caches, resolve
 from django.test import TestCase
 from mock import patch
 

--- a/common/djangoapps/util/url.py
+++ b/common/djangoapps/util/url.py
@@ -6,7 +6,7 @@ import sys
 from importlib import import_module
 
 from django.conf import settings
-from django.core.urlresolvers import set_urlconf
+from django.urls import set_urlconf
 
 
 def reload_django_url_config():

--- a/common/test/test-theme/cms/templates/login.html
+++ b/common/test/test-theme/cms/templates/login.html
@@ -4,7 +4,7 @@
 <%inherit file="base.html" />
 <%def name="online_help_token()"><% return "login" %></%def>
 <%!
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.utils.translation import ugettext as _
 from openedx.core.djangolib.js_utils import js_escaped_string
 %>

--- a/common/test/test_sites/test_site/templates/courseware/tabs.html
+++ b/common/test/test_sites/test_site/templates/courseware/tabs.html
@@ -2,7 +2,7 @@
 <%namespace name='static' file='/static_content.html'/>
 <%!
  from django.utils.translation import ugettext as _
- from django.core.urlresolvers import reverse
+ from django.urls import reverse
  %>
 <%page args="tab_list, active_page, default_tab, tab_image" expression_filter="h" />
 

--- a/common/test/test_sites/test_site/templates/emails/confirm_email_change.txt
+++ b/common/test/test_sites/test_site/templates/emails/confirm_email_change.txt
@@ -1,4 +1,4 @@
-<%! from django.core.urlresolvers import reverse %>
+<%! from django.urls import reverse %>
 <%! from django.conf import settings %>
 <%! from edxmako.shortcuts import render_to_string, marketing_link %>
 

--- a/common/test/test_sites/test_site/templates/footer.html
+++ b/common/test/test_sites/test_site/templates/footer.html
@@ -2,7 +2,7 @@
 <%page expression_filter="h"/>
 <%namespace name='static' file='static_content.html'/>
 <%!
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.utils.translation import ugettext as _
 %>
 

--- a/common/test/test_sites/test_site/templates/login-sidebar.html
+++ b/common/test/test_sites/test_site/templates/login-sidebar.html
@@ -1,7 +1,7 @@
 <%page expression_filter="h"/>
 <%!
 from django.utils.translation import ugettext as _ 
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 %>
 
 <header>

--- a/common/test/test_sites/test_site/templates/register-sidebar.html
+++ b/common/test/test_sites/test_site/templates/register-sidebar.html
@@ -1,7 +1,7 @@
 <%page expression_filter="h"/>
 <%!
 from django.utils.translation import ugettext as _ 
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 %>
 <%namespace file='../../main.html' import="login_query"/>
 <%namespace name='static' file='../../static_content.html'/>

--- a/common/test/test_sites/test_site/templates/static_templates/about.html
+++ b/common/test/test_sites/test_site/templates/static_templates/about.html
@@ -1,5 +1,5 @@
 <%page expression_filter="h"/>
-<%! from django.core.urlresolvers import reverse %>
+<%! from django.urls import reverse %>
 <%namespace name='static' file='../../../static_content.html'/>
 
 <%inherit file="../../../main.html" />

--- a/common/test/test_sites/test_site/templates/static_templates/contact.html
+++ b/common/test/test_sites/test_site/templates/static_templates/contact.html
@@ -3,7 +3,7 @@
 <%namespace name='static' file='../static_content.html'/>
 <%!
 from django.utils.translation import ugettext as _
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 %>
 
 <%block name="title"><title>${_("Contact {platform_name}").format(platform_name=settings.PLATFORM_NAME)}</title></%block>

--- a/common/test/test_sites/test_site/templates/static_templates/faq.html
+++ b/common/test/test_sites/test_site/templates/static_templates/faq.html
@@ -3,7 +3,7 @@
 <%namespace name='static' file='../static_content.html'/>
 <%!
 from django.utils.translation import ugettext as _
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 %>
 
 <%block name="title"><title>${_("FAQ")}</title></%block>

--- a/common/test/test_sites/test_site/templates/static_templates/tos.html
+++ b/common/test/test_sites/test_site/templates/static_templates/tos.html
@@ -3,7 +3,7 @@
 <%namespace name='static' file='../static_content.html'/>
 <%!
 from django.utils.translation import ugettext as _
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 %>
 
 <%block name="pagetitle">${_("Terms of Service")}</%block>

--- a/lms/djangoapps/badges/events/course_complete.py
+++ b/lms/djangoapps/badges/events/course_complete.py
@@ -4,7 +4,7 @@ Helper functions for the course complete event that was originally included with
 import hashlib
 import logging
 
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.utils.text import slugify
 from django.utils.translation import ugettext_lazy as _
 

--- a/lms/djangoapps/branding/api.py
+++ b/lms/djangoapps/branding/api.py
@@ -17,7 +17,7 @@ import urlparse
 
 from django.conf import settings
 from django.contrib.staticfiles.storage import staticfiles_storage
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.utils.translation import ugettext as _
 
 from branding.models import BrandingApiConfig

--- a/lms/djangoapps/branding/tests/test_api.py
+++ b/lms/djangoapps/branding/tests/test_api.py
@@ -4,7 +4,7 @@ from __future__ import unicode_literals
 
 import mock
 from django.conf import settings
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.test import TestCase
 from django.test.utils import override_settings
 

--- a/lms/djangoapps/branding/tests/test_page.py
+++ b/lms/djangoapps/branding/tests/test_page.py
@@ -5,7 +5,7 @@ import datetime
 
 from django.conf import settings
 from django.contrib.auth.models import AnonymousUser
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.http import HttpResponseRedirect
 from django.test.client import RequestFactory
 from django.test.utils import override_settings

--- a/lms/djangoapps/branding/tests/test_views.py
+++ b/lms/djangoapps/branding/tests/test_views.py
@@ -8,7 +8,7 @@ import mock
 from config_models.models import cache
 from django.conf import settings
 from django.contrib.auth.models import User
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.test import TestCase
 
 from branding.models import BrandingApiConfig

--- a/lms/djangoapps/branding/views.py
+++ b/lms/djangoapps/branding/views.py
@@ -5,7 +5,7 @@ import urllib
 from django.conf import settings
 from django.contrib.staticfiles.storage import staticfiles_storage
 from django.core.cache import cache
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.db import transaction
 from django.http import Http404, HttpResponse
 from django.shortcuts import redirect

--- a/lms/djangoapps/bulk_email/tasks.py
+++ b/lms/djangoapps/bulk_email/tasks.py
@@ -30,7 +30,7 @@ from django.conf import settings
 from django.contrib.auth.models import User
 from django.core.mail import EmailMultiAlternatives, get_connection
 from django.core.mail.message import forbid_multi_line_headers
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.utils.translation import override as override_language
 from django.utils.translation import ugettext as _
 from markupsafe import escape

--- a/lms/djangoapps/bulk_email/tests/test_course_optout.py
+++ b/lms/djangoapps/bulk_email/tests/test_course_optout.py
@@ -6,7 +6,7 @@ import json
 
 from django.core import mail
 from django.core.management import call_command
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from mock import Mock, patch
 from nose.plugins.attrib import attr
 from six import text_type

--- a/lms/djangoapps/bulk_email/tests/test_email.py
+++ b/lms/djangoapps/bulk_email/tests/test_email.py
@@ -11,7 +11,7 @@ from django.conf import settings
 from django.core import mail
 from django.core.mail.message import forbid_multi_line_headers
 from django.core.management import call_command
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.test.utils import override_settings
 from django.utils.translation import get_language
 from markupsafe import escape

--- a/lms/djangoapps/bulk_email/tests/test_err_handling.py
+++ b/lms/djangoapps/bulk_email/tests/test_err_handling.py
@@ -10,7 +10,7 @@ import ddt
 from celery.states import RETRY, SUCCESS  # pylint: disable=no-name-in-module, import-error
 from django.conf import settings
 from django.core.management import call_command
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.db import DatabaseError
 from mock import Mock, patch
 from nose.plugins.attrib import attr

--- a/lms/djangoapps/bulk_email/tests/test_signals.py
+++ b/lms/djangoapps/bulk_email/tests/test_signals.py
@@ -5,7 +5,7 @@ import json
 
 from django.core import mail
 from django.core.management import call_command
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from mock import Mock, patch
 from nose.plugins.attrib import attr
 from six import text_type

--- a/lms/djangoapps/bulk_enroll/tests/test_views.py
+++ b/lms/djangoapps/bulk_enroll/tests/test_views.py
@@ -6,7 +6,7 @@ import json
 from django.conf import settings
 from django.contrib.auth.models import User
 from django.core import mail
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.test.utils import override_settings
 from rest_framework.test import APIRequestFactory, APITestCase, force_authenticate
 

--- a/lms/djangoapps/ccx/api/v0/tests/test_views.py
+++ b/lms/djangoapps/ccx/api/v0/tests/test_views.py
@@ -14,7 +14,7 @@ import mock
 from ccx_keys.locator import CCXLocator
 from django.conf import settings
 from django.contrib.auth.models import User
-from django.core.urlresolvers import Resolver404, resolve, reverse
+from django.urls import Resolver404, resolve, reverse
 from django.utils.timezone import now
 from nose.plugins.attrib import attr
 from oauth2_provider import models as dot_models

--- a/lms/djangoapps/ccx/tests/test_views.py
+++ b/lms/djangoapps/ccx/tests/test_views.py
@@ -9,7 +9,7 @@ import urlparse
 import ddt
 from ccx_keys.locator import CCXLocator
 from django.conf import settings
-from django.core.urlresolvers import resolve, reverse
+from django.urls import resolve, reverse
 from django.test import RequestFactory
 from django.test.utils import override_settings
 from pytz import UTC

--- a/lms/djangoapps/ccx/utils.py
+++ b/lms/djangoapps/ccx/utils.py
@@ -11,7 +11,7 @@ from smtplib import SMTPException
 import pytz
 from django.contrib.auth.models import User
 from django.core.exceptions import ValidationError
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.core.validators import validate_email
 from django.utils.translation import ugettext as _
 

--- a/lms/djangoapps/ccx/views.py
+++ b/lms/djangoapps/ccx/views.py
@@ -14,7 +14,7 @@ from ccx_keys.locator import CCXLocator
 from django.conf import settings
 from django.contrib import messages
 from django.contrib.auth.models import User
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.db import transaction
 from django.http import Http404, HttpResponse, HttpResponseForbidden
 from django.shortcuts import redirect

--- a/lms/djangoapps/certificates/api.py
+++ b/lms/djangoapps/certificates/api.py
@@ -7,7 +7,7 @@ rather than importing Django models directly.
 import logging
 
 from django.conf import settings
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.db.models import Q
 from opaque_keys.edx.django.models import CourseKeyField
 from opaque_keys.edx.keys import CourseKey

--- a/lms/djangoapps/certificates/apis/v0/tests/test_views.py
+++ b/lms/djangoapps/certificates/apis/v0/tests/test_views.py
@@ -3,7 +3,7 @@ Tests for the Certificate REST APIs.
 """
 from datetime import datetime, timedelta
 
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.utils import timezone
 from freezegun import freeze_time
 from oauth2_provider import models as dot_models

--- a/lms/djangoapps/certificates/queue.py
+++ b/lms/djangoapps/certificates/queue.py
@@ -6,7 +6,7 @@ from uuid import uuid4
 
 import lxml.html
 from django.conf import settings
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.test.client import RequestFactory
 from lxml.etree import ParserError, XMLSyntaxError
 from requests.auth import HTTPBasicAuth

--- a/lms/djangoapps/certificates/tests/test_api.py
+++ b/lms/djangoapps/certificates/tests/test_api.py
@@ -8,7 +8,7 @@ from datetime import datetime
 from datetime import timedelta
 from config_models.models import cache
 from django.conf import settings
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.test import RequestFactory, TestCase
 from django.test.utils import override_settings
 from django.utils import timezone

--- a/lms/djangoapps/certificates/tests/test_support_views.py
+++ b/lms/djangoapps/certificates/tests/test_support_views.py
@@ -6,7 +6,7 @@ import json
 
 import ddt
 from django.conf import settings
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.test.utils import override_settings
 from opaque_keys.edx.keys import CourseKey
 

--- a/lms/djangoapps/certificates/tests/test_views.py
+++ b/lms/djangoapps/certificates/tests/test_views.py
@@ -7,7 +7,7 @@ import ddt
 import datetime
 from django.conf import settings
 from django.core.cache import cache
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.test.client import Client
 from django.test.utils import override_settings
 from nose.plugins.attrib import attr

--- a/lms/djangoapps/certificates/tests/test_webview_views.py
+++ b/lms/djangoapps/certificates/tests/test_webview_views.py
@@ -8,7 +8,7 @@ from urllib import urlencode
 from uuid import uuid4
 
 from django.conf import settings
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.test.client import Client, RequestFactory
 from django.test.utils import override_settings
 from django.utils import translation

--- a/lms/djangoapps/class_dashboard/tests/test_dashboard_data.py
+++ b/lms/djangoapps/class_dashboard/tests/test_dashboard_data.py
@@ -4,7 +4,7 @@ Tests for class dashboard (Metrics tab in instructor dashboard)
 
 import json
 
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.test.client import RequestFactory
 from mock import patch
 from nose.plugins.attrib import attr

--- a/lms/djangoapps/commerce/api/v0/tests/test_views.py
+++ b/lms/djangoapps/commerce/api/v0/tests/test_views.py
@@ -8,7 +8,7 @@ import ddt
 import mock
 import pytz
 from django.conf import settings
-from django.core.urlresolvers import reverse, reverse_lazy
+from django.urls import reverse, reverse_lazy
 from django.test import TestCase
 from django.test.utils import override_settings
 from edx_rest_api_client import exceptions

--- a/lms/djangoapps/commerce/api/v0/views.py
+++ b/lms/djangoapps/commerce/api/v0/views.py
@@ -2,7 +2,7 @@
 import logging
 
 from courseware import courses
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from edx_rest_api_client import exceptions
 from opaque_keys import InvalidKeyError
 from opaque_keys.edx.keys import CourseKey

--- a/lms/djangoapps/commerce/api/v1/tests/test_views.py
+++ b/lms/djangoapps/commerce/api/v1/tests/test_views.py
@@ -7,7 +7,7 @@ import ddt
 import pytz
 from django.conf import settings
 from django.contrib.auth.models import Permission
-from django.core.urlresolvers import reverse, reverse_lazy
+from django.urls import reverse, reverse_lazy
 from django.test import TestCase
 from django.test.utils import override_settings
 from edx_rest_api_client import exceptions

--- a/lms/djangoapps/commerce/tests/test_views.py
+++ b/lms/djangoapps/commerce/tests/test_views.py
@@ -4,7 +4,7 @@ import json
 
 import ddt
 import mock
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from nose.plugins.attrib import attr
 
 from course_modes.models import CourseMode

--- a/lms/djangoapps/commerce/utils.py
+++ b/lms/djangoapps/commerce/utils.py
@@ -8,7 +8,7 @@ import requests
 import waffle
 from django.conf import settings
 from django.contrib.auth import get_user_model
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.utils.translation import ugettext as _
 
 from openedx.core.djangoapps.commerce.utils import ecommerce_api_client, is_commerce_service_configured

--- a/lms/djangoapps/course_api/blocks/tests/test_views.py
+++ b/lms/djangoapps/course_api/blocks/tests/test_views.py
@@ -6,7 +6,7 @@ from string import join
 from urllib import urlencode
 from urlparse import urlunparse
 
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from opaque_keys.edx.locator import CourseLocator
 
 from student.models import CourseEnrollment

--- a/lms/djangoapps/course_api/serializers.py
+++ b/lms/djangoapps/course_api/serializers.py
@@ -4,7 +4,7 @@ Course API Serializers.  Representing course catalog data
 
 import urllib
 
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from rest_framework import serializers
 
 from openedx.core.djangoapps.models.course_details import CourseDetails

--- a/lms/djangoapps/course_api/tests/test_views.py
+++ b/lms/djangoapps/course_api/tests/test_views.py
@@ -3,7 +3,7 @@ Tests for Course API views.
 """
 from hashlib import md5
 
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.test import RequestFactory
 from django.test.utils import override_settings
 from nose.plugins.attrib import attr

--- a/lms/djangoapps/course_goals/tests/test_api.py
+++ b/lms/djangoapps/course_goals/tests/test_api.py
@@ -4,7 +4,7 @@ Unit tests for course_goals.api methods.
 import mock
 
 from django.contrib.auth.models import User
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.test.utils import override_settings
 from lms.djangoapps.course_goals.models import CourseGoal
 from rest_framework.test import APIClient

--- a/lms/djangoapps/course_wiki/tests/tests.py
+++ b/lms/djangoapps/course_wiki/tests/tests.py
@@ -2,7 +2,7 @@
 Tests for course wiki
 """
 
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from mock import patch
 from nose.plugins.attrib import attr
 from six import text_type

--- a/lms/djangoapps/courseware/courses.py
+++ b/lms/djangoapps/courseware/courses.py
@@ -21,7 +21,7 @@ from courseware.date_summary import (
 from courseware.model_data import FieldDataCache
 from courseware.module_render import get_module
 from django.conf import settings
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.http import Http404, QueryDict
 from enrollment.api import get_course_enrollment_details
 from edxmako.shortcuts import render_to_string

--- a/lms/djangoapps/courseware/date_summary.py
+++ b/lms/djangoapps/courseware/date_summary.py
@@ -9,7 +9,7 @@ import datetime
 from babel.dates import format_timedelta
 
 from django.conf import settings
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.utils.formats import date_format
 from django.utils.functional import cached_property
 from django.utils.translation import get_language, to_locale, ugettext_lazy

--- a/lms/djangoapps/courseware/features/common.py
+++ b/lms/djangoapps/courseware/features/common.py
@@ -7,7 +7,7 @@ import time
 from logging import getLogger
 
 from django.contrib.auth.models import User
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from lettuce import step, world
 from lettuce.django import django_url
 

--- a/lms/djangoapps/courseware/module_render.py
+++ b/lms/djangoapps/courseware/module_render.py
@@ -15,7 +15,7 @@ from django.contrib.auth.models import User
 from django.core.cache import cache
 from django.template.context_processors import csrf
 from django.core.exceptions import PermissionDenied
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.http import Http404, HttpResponse, HttpResponseForbidden
 from django.views.decorators.csrf import csrf_exempt
 from edx_proctoring.services import ProctoringService

--- a/lms/djangoapps/courseware/tests/helpers.py
+++ b/lms/djangoapps/courseware/tests/helpers.py
@@ -5,7 +5,7 @@ import json
 
 from django.contrib import messages
 from django.contrib.auth.models import User
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.test import TestCase
 from django.test.client import Client, RequestFactory
 from six import text_type

--- a/lms/djangoapps/courseware/tests/test_about.py
+++ b/lms/djangoapps/courseware/tests/test_about.py
@@ -6,7 +6,7 @@ import ddt
 import pytz
 from ccx_keys.locator import CCXLocator
 from django.conf import settings
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.test.utils import override_settings
 from milestones.tests.utils import MilestonesTestCaseMixin
 from mock import patch

--- a/lms/djangoapps/courseware/tests/test_access.py
+++ b/lms/djangoapps/courseware/tests/test_access.py
@@ -9,7 +9,7 @@ import ddt
 import pytz
 from ccx_keys.locator import CCXLocator
 from django.contrib.auth.models import User
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.test import TestCase
 from django.test.client import RequestFactory
 from milestones.tests.utils import MilestonesTestCaseMixin

--- a/lms/djangoapps/courseware/tests/test_course_info.py
+++ b/lms/djangoapps/courseware/tests/test_course_info.py
@@ -5,7 +5,7 @@ Test the course_info xblock
 import ddt
 import mock
 from django.conf import settings
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.http import QueryDict
 from django.test.utils import override_settings
 

--- a/lms/djangoapps/courseware/tests/test_course_survey.py
+++ b/lms/djangoapps/courseware/tests/test_course_survey.py
@@ -6,7 +6,7 @@ from collections import OrderedDict
 from copy import deepcopy
 
 from django.contrib.auth.models import User
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from nose.plugins.attrib import attr
 
 from common.test.utils import XssTestMixin

--- a/lms/djangoapps/courseware/tests/test_courses.py
+++ b/lms/djangoapps/courseware/tests/test_courses.py
@@ -9,7 +9,7 @@ import ddt
 import mock
 import pytz
 from django.conf import settings
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.test.client import RequestFactory
 from django.test.utils import override_settings
 from nose.plugins.attrib import attr

--- a/lms/djangoapps/courseware/tests/test_credit_requirements.py
+++ b/lms/djangoapps/courseware/tests/test_credit_requirements.py
@@ -4,7 +4,7 @@ Tests for credit requirement display on the progress page.
 
 import ddt
 from django.conf import settings
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from mock import patch
 
 from course_modes.models import CourseMode

--- a/lms/djangoapps/courseware/tests/test_date_summary.py
+++ b/lms/djangoapps/courseware/tests/test_date_summary.py
@@ -5,7 +5,7 @@ from datetime import datetime, timedelta
 import ddt
 import waffle
 from django.contrib.messages.middleware import MessageMiddleware
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.test import RequestFactory
 from freezegun import freeze_time
 from mock import patch

--- a/lms/djangoapps/courseware/tests/test_discussion_xblock.py
+++ b/lms/djangoapps/courseware/tests/test_discussion_xblock.py
@@ -11,7 +11,7 @@ import uuid
 
 import ddt
 import mock
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from web_fragments.fragment import Fragment
 from xblock.field_data import DictFieldData
 

--- a/lms/djangoapps/courseware/tests/test_entrance_exam.py
+++ b/lms/djangoapps/courseware/tests/test_entrance_exam.py
@@ -1,7 +1,7 @@
 """
 Tests use cases related to LMS Entrance Exam behavior, such as gated content access (TOC)
 """
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.test.client import RequestFactory
 from mock import Mock, patch
 

--- a/lms/djangoapps/courseware/tests/test_i18n.py
+++ b/lms/djangoapps/courseware/tests/test_i18n.py
@@ -7,7 +7,7 @@ import re
 
 from django.conf import settings
 from django.contrib.auth.models import User
-from django.core.urlresolvers import reverse, reverse_lazy
+from django.urls import reverse, reverse_lazy
 from django.test import TestCase
 from django.test.client import Client
 from django.utils import translation

--- a/lms/djangoapps/courseware/tests/test_lti_integration.py
+++ b/lms/djangoapps/courseware/tests/test_lti_integration.py
@@ -7,7 +7,7 @@ from collections import OrderedDict
 import mock
 import pytest
 from django.conf import settings
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 
 import oauthlib
 from courseware.tests.helpers import BaseTestXmodule

--- a/lms/djangoapps/courseware/tests/test_masquerade.py
+++ b/lms/djangoapps/courseware/tests/test_masquerade.py
@@ -6,7 +6,7 @@ import pickle
 from datetime import datetime
 
 from django.conf import settings
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.test import TestCase
 from mock import patch
 from pytz import UTC

--- a/lms/djangoapps/courseware/tests/test_microsites.py
+++ b/lms/djangoapps/courseware/tests/test_microsites.py
@@ -6,7 +6,7 @@ import pytest
 from bs4 import BeautifulSoup
 from contextlib import contextmanager
 from django.conf import settings
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.test.utils import override_settings
 from mock import patch
 from nose.plugins.attrib import attr

--- a/lms/djangoapps/courseware/tests/test_module_render.py
+++ b/lms/djangoapps/courseware/tests/test_module_render.py
@@ -15,7 +15,7 @@ from completion.models import BlockCompletion
 from completion import waffle as completion_waffle
 from django.conf import settings
 from django.contrib.auth.models import AnonymousUser
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.http import Http404, HttpResponse
 from django.test.client import RequestFactory
 from django.test.utils import override_settings

--- a/lms/djangoapps/courseware/tests/test_navigation.py
+++ b/lms/djangoapps/courseware/tests/test_navigation.py
@@ -4,7 +4,7 @@ This test file will run through some LMS test scenarios regarding access and nav
 import time
 
 from django.conf import settings
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.test.utils import override_settings
 from mock import patch
 from nose.plugins.attrib import attr

--- a/lms/djangoapps/courseware/tests/test_password_history.py
+++ b/lms/djangoapps/courseware/tests/test_password_history.py
@@ -8,7 +8,7 @@ from uuid import uuid4
 import ddt
 from django.contrib.auth.models import User
 from django.contrib.auth.tokens import default_token_generator
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.test.utils import override_settings
 from django.utils import timezone
 from django.utils.http import int_to_base36

--- a/lms/djangoapps/courseware/tests/test_split_module.py
+++ b/lms/djangoapps/courseware/tests/test_split_module.py
@@ -1,7 +1,7 @@
 """
 Test for split test XModule
 """
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from mock import MagicMock
 from nose.plugins.attrib import attr
 from six import text_type

--- a/lms/djangoapps/courseware/tests/test_submitting_problems.py
+++ b/lms/djangoapps/courseware/tests/test_submitting_problems.py
@@ -12,7 +12,7 @@ from textwrap import dedent
 import ddt
 from django.conf import settings
 from django.contrib.auth.models import User
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.test import TestCase
 from django.test.client import RequestFactory
 from django.utils.timezone import now

--- a/lms/djangoapps/courseware/tests/test_tabs.py
+++ b/lms/djangoapps/courseware/tests/test_tabs.py
@@ -4,7 +4,7 @@ Test cases for tabs.
 
 import pytest
 from django.contrib.auth.models import AnonymousUser
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.http import Http404
 from milestones.tests.utils import MilestonesTestCaseMixin
 from mock import MagicMock, Mock, patch

--- a/lms/djangoapps/courseware/tests/test_view_authentication.py
+++ b/lms/djangoapps/courseware/tests/test_view_authentication.py
@@ -1,7 +1,7 @@
 import datetime
 
 import pytz
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from mock import patch
 from nose.plugins.attrib import attr
 from six import text_type

--- a/lms/djangoapps/courseware/tests/test_views.py
+++ b/lms/djangoapps/courseware/tests/test_views.py
@@ -13,7 +13,7 @@ from uuid import uuid4
 import ddt
 from django.conf import settings
 from django.contrib.auth.models import AnonymousUser
-from django.core.urlresolvers import reverse, reverse_lazy
+from django.urls import reverse, reverse_lazy
 from django.http import Http404, HttpResponseBadRequest
 from django.test import TestCase
 from django.test.client import Client, RequestFactory

--- a/lms/djangoapps/courseware/tests/tests.py
+++ b/lms/djangoapps/courseware/tests/tests.py
@@ -5,7 +5,7 @@ from textwrap import dedent
 from unittest import TestCase
 
 import mock
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from nose.plugins.attrib import attr
 from opaque_keys.edx.keys import CourseKey
 from six import text_type

--- a/lms/djangoapps/courseware/url_helpers.py
+++ b/lms/djangoapps/courseware/url_helpers.py
@@ -3,7 +3,7 @@ Module to define url helpers functions
 """
 from urllib import urlencode
 
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 
 from xmodule.modulestore.django import modulestore
 from xmodule.modulestore.search import navigation_index, path_to_location

--- a/lms/djangoapps/courseware/views/index.py
+++ b/lms/djangoapps/courseware/views/index.py
@@ -10,7 +10,7 @@ import urllib
 from django.conf import settings
 from django.contrib.auth.models import User
 from django.contrib.auth.views import redirect_to_login
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.http import Http404
 from django.template.context_processors import csrf
 from django.utils.decorators import method_decorator

--- a/lms/djangoapps/courseware/views/views.py
+++ b/lms/djangoapps/courseware/views/views.py
@@ -12,7 +12,7 @@ from django.conf import settings
 from django.contrib.auth.decorators import login_required
 from django.contrib.auth.models import AnonymousUser, User
 from django.core.exceptions import PermissionDenied
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.db import transaction
 from django.db.models import Q
 from django.http import Http404, HttpResponse, HttpResponseBadRequest, HttpResponseForbidden

--- a/lms/djangoapps/dashboard/tests/test_sysadmin.py
+++ b/lms/djangoapps/dashboard/tests/test_sysadmin.py
@@ -11,7 +11,7 @@ from uuid import uuid4
 
 import mongoengine
 from django.conf import settings
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.test.client import Client
 from django.test.utils import override_settings
 from pytz import UTC

--- a/lms/djangoapps/discussion/templates/discussion/discussion_board_fragment.html
+++ b/lms/djangoapps/discussion/templates/discussion/discussion_board_fragment.html
@@ -8,7 +8,7 @@
 import json
 from django.utils.translation import ugettext as _
 from django.template.defaultfilters import escapejs
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 
 from django_comment_client.permissions import has_permission
 from openedx.core.djangolib.js_utils import dump_js_escaped_json, js_escaped_string

--- a/lms/djangoapps/discussion/templates/discussion/discussion_profile_page.html
+++ b/lms/djangoapps/discussion/templates/discussion/discussion_profile_page.html
@@ -8,7 +8,7 @@
 import json
 from django.utils.translation import ugettext as _, ungettext
 from django.template.defaultfilters import escapejs
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 
 from django_comment_client.permissions import has_permission
 from openedx.core.djangolib.js_utils import dump_js_escaped_json, js_escaped_string

--- a/lms/djangoapps/discussion/tests/test_views.py
+++ b/lms/djangoapps/discussion/tests/test_views.py
@@ -3,7 +3,7 @@ import logging
 from datetime import datetime
 
 import ddt
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.http import Http404
 from django.test.client import Client, RequestFactory
 from django.test.utils import override_settings

--- a/lms/djangoapps/discussion/views.py
+++ b/lms/djangoapps/discussion/views.py
@@ -10,7 +10,7 @@ from django.contrib.auth.decorators import login_required
 from django.contrib.auth.models import User
 from django.contrib.staticfiles.storage import staticfiles_storage
 from django.template.context_processors import csrf
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.http import Http404, HttpResponseServerError
 from django.shortcuts import render_to_response
 from django.template.loader import render_to_string

--- a/lms/djangoapps/discussion_api/api.py
+++ b/lms/djangoapps/discussion_api/api.py
@@ -7,7 +7,7 @@ from urllib import urlencode
 from urlparse import urlunparse
 
 from django.core.exceptions import ValidationError
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.http import Http404
 from enum import Enum
 from opaque_keys import InvalidKeyError

--- a/lms/djangoapps/discussion_api/serializers.py
+++ b/lms/djangoapps/discussion_api/serializers.py
@@ -6,7 +6,7 @@ from urlparse import urlunparse
 
 from django.contrib.auth.models import User as DjangoUser
 from django.core.exceptions import ValidationError
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from rest_framework import serializers
 
 from discussion_api.permissions import NON_UPDATABLE_COMMENT_FIELDS, NON_UPDATABLE_THREAD_FIELDS, get_editable_fields

--- a/lms/djangoapps/discussion_api/tests/test_views.py
+++ b/lms/djangoapps/discussion_api/tests/test_views.py
@@ -10,7 +10,7 @@ from urlparse import urlparse
 import ddt
 import httpretty
 import mock
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from nose.plugins.attrib import attr
 from pytz import UTC
 from rest_framework.parsers import JSONParser

--- a/lms/djangoapps/django_comment_client/base/event_transformers.py
+++ b/lms/djangoapps/django_comment_client/base/event_transformers.py
@@ -2,7 +2,7 @@
 Transformers for Discussion-related events.
 """
 from django.contrib.auth.models import User
-from django.core.urlresolvers import reverse, NoReverseMatch
+from django.urls import reverse, NoReverseMatch
 
 from eventtracking.processors.exceptions import EventEmissionExit
 from opaque_keys import InvalidKeyError

--- a/lms/djangoapps/django_comment_client/base/tests.py
+++ b/lms/djangoapps/django_comment_client/base/tests.py
@@ -9,7 +9,7 @@ import ddt
 import pytest
 from django.contrib.auth.models import User
 from django.core.management import call_command
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.test.client import RequestFactory
 from eventtracking.processors.exceptions import EventEmissionExit
 from mock import ANY, Mock, patch

--- a/lms/djangoapps/django_comment_client/tests/test_utils.py
+++ b/lms/djangoapps/django_comment_client/tests/test_utils.py
@@ -6,7 +6,7 @@ import ddt
 import mock
 import pytest
 
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.test import RequestFactory, TestCase
 from mock import Mock, patch
 from nose.plugins.attrib import attr

--- a/lms/djangoapps/django_comment_client/utils.py
+++ b/lms/djangoapps/django_comment_client/utils.py
@@ -5,7 +5,7 @@ from datetime import datetime
 
 from django.conf import settings
 from django.contrib.auth.models import User
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.db import connection
 from django.http import HttpResponse
 from pytz import UTC

--- a/lms/djangoapps/edxnotes/helpers.py
+++ b/lms/djangoapps/edxnotes/helpers.py
@@ -13,7 +13,7 @@ import requests
 from dateutil.parser import parse as dateutil_parse
 from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.utils.translation import ugettext as _
 from opaque_keys.edx.keys import UsageKey
 from provider.oauth2.models import Client

--- a/lms/djangoapps/edxnotes/tests.py
+++ b/lms/djangoapps/edxnotes/tests.py
@@ -13,7 +13,7 @@ import jwt
 from django.conf import settings
 from django.contrib.auth.models import AnonymousUser
 from django.core.exceptions import ImproperlyConfigured
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.test.client import RequestFactory
 from django.test.utils import override_settings
 from edx_oauth2_provider.tests.factories import ClientFactory

--- a/lms/djangoapps/edxnotes/views.py
+++ b/lms/djangoapps/edxnotes/views.py
@@ -6,7 +6,7 @@ import logging
 
 from django.conf import settings
 from django.contrib.auth.decorators import login_required
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.http import Http404, HttpResponse
 from django.views.decorators.http import require_GET
 from opaque_keys.edx.keys import CourseKey

--- a/lms/djangoapps/experiments/tests/test_views.py
+++ b/lms/djangoapps/experiments/tests/test_views.py
@@ -3,7 +3,7 @@ import unittest
 
 from django.conf import settings
 from django.core.handlers.wsgi import WSGIRequest
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.test.utils import override_settings
 from mock import patch
 from rest_framework.test import APITestCase

--- a/lms/djangoapps/grades/api/tests/test_views.py
+++ b/lms/djangoapps/grades/api/tests/test_views.py
@@ -5,7 +5,7 @@ from datetime import datetime
 from urllib import urlencode
 
 import ddt
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from edx_oauth2_provider.tests.factories import AccessTokenFactory, ClientFactory
 from mock import patch
 from opaque_keys import InvalidKeyError

--- a/lms/djangoapps/grades/api/v1/tests/test_views.py
+++ b/lms/djangoapps/grades/api/v1/tests/test_views.py
@@ -4,7 +4,7 @@ Tests for v1 views
 from datetime import datetime
 import ddt
 
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from mock import MagicMock, patch
 from opaque_keys import InvalidKeyError
 from pytz import UTC

--- a/lms/djangoapps/instructor/enrollment.py
+++ b/lms/djangoapps/instructor/enrollment.py
@@ -12,7 +12,7 @@ import pytz
 from django.conf import settings
 from django.contrib.auth.models import User
 from django.core.mail import send_mail
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.utils.translation import override as override_language
 from six import text_type
 

--- a/lms/djangoapps/instructor/tests/test_api.py
+++ b/lms/djangoapps/instructor/tests/test_api.py
@@ -16,7 +16,7 @@ from django.conf import settings
 from django.contrib.auth.models import User
 from django.core import mail
 from django.core.files.uploadedfile import SimpleUploadedFile
-from django.core.urlresolvers import reverse as django_reverse
+from django.urls import reverse as django_reverse
 from django.http import HttpRequest, HttpResponse
 from django.test import RequestFactory, TestCase
 from django.test.utils import override_settings

--- a/lms/djangoapps/instructor/tests/test_api_email_localization.py
+++ b/lms/djangoapps/instructor/tests/test_api_email_localization.py
@@ -4,7 +4,7 @@ Unit tests for the localization of emails sent by instructor.api methods.
 """
 
 from django.core import mail
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.test.utils import override_settings
 from nose.plugins.attrib import attr
 from six import text_type

--- a/lms/djangoapps/instructor/tests/test_certificates.py
+++ b/lms/djangoapps/instructor/tests/test_certificates.py
@@ -11,7 +11,7 @@ from config_models.models import cache
 from django.conf import settings
 from django.core.exceptions import ObjectDoesNotExist
 from django.core.files.uploadedfile import SimpleUploadedFile
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.test.utils import override_settings
 from nose.plugins.attrib import attr
 

--- a/lms/djangoapps/instructor/tests/test_ecommerce.py
+++ b/lms/djangoapps/instructor/tests/test_ecommerce.py
@@ -5,7 +5,7 @@ Unit tests for Ecommerce feature flag in new instructor dashboard.
 import datetime
 
 import pytz
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from nose.plugins.attrib import attr
 from six import text_type
 

--- a/lms/djangoapps/instructor/tests/test_email.py
+++ b/lms/djangoapps/instructor/tests/test_email.py
@@ -5,7 +5,7 @@ non-Mongo backed courses, regardless of email feature flag, and
 that the view is conditionally available when Course Auth is turned on.
 """
 
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from nose.plugins.attrib import attr
 from opaque_keys.edx.keys import CourseKey
 from six import text_type

--- a/lms/djangoapps/instructor/tests/test_proctoring.py
+++ b/lms/djangoapps/instructor/tests/test_proctoring.py
@@ -4,7 +4,7 @@ Unit tests for Edx Proctoring feature flag in new instructor dashboard.
 
 import ddt
 from django.conf import settings
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from mock import patch
 from nose.plugins.attrib import attr
 from six import text_type

--- a/lms/djangoapps/instructor/tests/test_registration_codes.py
+++ b/lms/djangoapps/instructor/tests/test_registration_codes.py
@@ -3,7 +3,7 @@ Test for the registration code status information.
 """
 import json
 
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.test.utils import override_settings
 from django.utils.translation import ugettext as _
 from nose.plugins.attrib import attr

--- a/lms/djangoapps/instructor/tests/test_spoc_gradebook.py
+++ b/lms/djangoapps/instructor/tests/test_spoc_gradebook.py
@@ -2,7 +2,7 @@
 Tests of the instructor dashboard spoc gradebook
 """
 
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from nose.plugins.attrib import attr
 from six import text_type
 

--- a/lms/djangoapps/instructor/tests/views/test_instructor_dashboard.py
+++ b/lms/djangoapps/instructor/tests/views/test_instructor_dashboard.py
@@ -6,7 +6,7 @@ import datetime
 import ddt
 from django.conf import settings
 from django.contrib.sites.models import Site
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.test.client import RequestFactory
 from django.test.utils import override_settings
 from mock import patch

--- a/lms/djangoapps/instructor/views/api.py
+++ b/lms/djangoapps/instructor/views/api.py
@@ -25,7 +25,7 @@ from django.core.exceptions import (
     ValidationError
 )
 from django.core.mail.message import EmailMessage
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.core.validators import validate_email
 from django.db import IntegrityError, transaction
 from django.http import HttpResponse, HttpResponseBadRequest, HttpResponseForbidden, HttpResponseNotFound

--- a/lms/djangoapps/instructor/views/gradebook_api.py
+++ b/lms/djangoapps/instructor/views/gradebook_api.py
@@ -5,7 +5,7 @@ which is currently use by ccx and instructor apps.
 import math
 
 from django.contrib.auth.models import User
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.db import transaction
 from django.views.decorators.cache import cache_control
 from opaque_keys.edx.keys import CourseKey

--- a/lms/djangoapps/instructor/views/instructor_dashboard.py
+++ b/lms/djangoapps/instructor/views/instructor_dashboard.py
@@ -9,7 +9,7 @@ import uuid
 import pytz
 from django.conf import settings
 from django.contrib.auth.decorators import login_required
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.http import Http404, HttpResponseServerError
 from django.utils.html import escape
 from django.utils.translation import ugettext as _

--- a/lms/djangoapps/instructor/views/registration_codes.py
+++ b/lms/djangoapps/instructor/views/registration_codes.py
@@ -3,7 +3,7 @@ E-commerce Tab Instructor Dashboard Query Registration Code Status.
 """
 import logging
 
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.utils.translation import ugettext as _
 from django.views.decorators.cache import cache_control
 from django.views.decorators.http import require_GET, require_POST

--- a/lms/djangoapps/instructor_analytics/basic.py
+++ b/lms/djangoapps/instructor_analytics/basic.py
@@ -10,7 +10,7 @@ from django.conf import settings
 from django.contrib.auth.models import User
 from django.core.exceptions import ObjectDoesNotExist
 from django.core.serializers.json import DjangoJSONEncoder
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.db.models import Count, Q
 from edx_proctoring.api import get_exam_violation_report
 from opaque_keys.edx.keys import UsageKey

--- a/lms/djangoapps/instructor_analytics/tests/test_basic.py
+++ b/lms/djangoapps/instructor_analytics/tests/test_basic.py
@@ -6,7 +6,7 @@ import datetime
 import json
 
 import pytz
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.db.models import Q
 from edx_proctoring.api import create_exam
 from edx_proctoring.models import ProctoredExamStudentAttempt

--- a/lms/djangoapps/instructor_task/tests/test_base.py
+++ b/lms/djangoapps/instructor_task/tests/test_base.py
@@ -12,7 +12,7 @@ from uuid import uuid4
 import unicodecsv
 from celery.states import FAILURE, SUCCESS
 from django.contrib.auth.models import User
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from mock import Mock, patch
 from opaque_keys.edx.locations import Location
 from opaque_keys.edx.keys import CourseKey

--- a/lms/djangoapps/instructor_task/tests/test_integration.py
+++ b/lms/djangoapps/instructor_task/tests/test_integration.py
@@ -13,7 +13,7 @@ from collections import namedtuple
 import ddt
 from celery.states import FAILURE, SUCCESS
 from django.contrib.auth.models import User
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from mock import patch
 from nose.plugins.attrib import attr
 from six import text_type

--- a/lms/djangoapps/instructor_task/tests/test_tasks_helper.py
+++ b/lms/djangoapps/instructor_task/tests/test_tasks_helper.py
@@ -22,7 +22,7 @@ from course_modes.models import CourseMode
 from course_modes.tests.factories import CourseModeFactory
 from courseware.tests.factories import InstructorFactory
 from django.conf import settings
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.test.utils import override_settings
 from freezegun import freeze_time
 from instructor_analytics.basic import UNAVAILABLE, list_problem_responses

--- a/lms/djangoapps/learner_dashboard/programs.py
+++ b/lms/djangoapps/learner_dashboard/programs.py
@@ -6,7 +6,7 @@ import json
 from django.http import Http404
 from django.template.loader import render_to_string
 from django.utils.translation import get_language_bidi
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 
 from web_fragments.fragment import Fragment
 

--- a/lms/djangoapps/learner_dashboard/tests/test_programs.py
+++ b/lms/djangoapps/learner_dashboard/tests/test_programs.py
@@ -10,7 +10,7 @@ from uuid import uuid4
 import mock
 from bs4 import BeautifulSoup
 from django.conf import settings
-from django.core.urlresolvers import reverse, reverse_lazy
+from django.urls import reverse, reverse_lazy
 from django.test import override_settings
 
 from lms.envs.test import CREDENTIALS_PUBLIC_SERVICE_URL

--- a/lms/djangoapps/lms_xblock/runtime.py
+++ b/lms/djangoapps/lms_xblock/runtime.py
@@ -3,7 +3,7 @@ Module implementing `xblock.runtime.Runtime` functionality for the LMS
 """
 from completion.services import CompletionService
 from django.conf import settings
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 import xblock.reference.plugins
 
 from badges.service import BadgingService

--- a/lms/djangoapps/lti_provider/tests/test_views.py
+++ b/lms/djangoapps/lti_provider/tests/test_views.py
@@ -3,7 +3,7 @@ Tests for the LTI provider views
 """
 
 import pytest
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.test import TestCase
 from django.test.client import RequestFactory
 from mock import MagicMock, patch

--- a/lms/djangoapps/mobile_api/testutils.py
+++ b/lms/djangoapps/mobile_api/testutils.py
@@ -14,7 +14,7 @@ Test utilities for mobile API tests:
 import ddt
 import datetime
 from django.conf import settings
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.utils import timezone
 from mock import patch
 from opaque_keys.edx.keys import CourseKey

--- a/lms/djangoapps/notes/models.py
+++ b/lms/djangoapps/notes/models.py
@@ -2,7 +2,7 @@ import json
 
 from django.contrib.auth.models import User
 from django.core.exceptions import ValidationError
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.db import models
 from django.utils.html import strip_tags
 from opaque_keys.edx.django.models import CourseKeyField

--- a/lms/djangoapps/notes/tests.py
+++ b/lms/djangoapps/notes/tests.py
@@ -6,7 +6,7 @@ import json
 
 from django.contrib.auth.models import User
 from django.core.exceptions import ValidationError
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.test import RequestFactory, TestCase
 from django.test.client import Client
 from mock import Mock, patch

--- a/lms/djangoapps/notification_prefs/tests.py
+++ b/lms/djangoapps/notification_prefs/tests.py
@@ -2,7 +2,7 @@ import json
 
 from django.contrib.auth.models import AnonymousUser
 from django.core.exceptions import PermissionDenied
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.http import Http404
 from django.test import TestCase
 from django.test.client import RequestFactory

--- a/lms/djangoapps/rss_proxy/tests/test_views.py
+++ b/lms/djangoapps/rss_proxy/tests/test_views.py
@@ -1,7 +1,7 @@
 """
 Tests for the rss_proxy views
 """
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.test import TestCase
 from mock import Mock, patch
 

--- a/lms/djangoapps/shoppingcart/api.py
+++ b/lms/djangoapps/shoppingcart/api.py
@@ -1,7 +1,7 @@
 """
 API for for getting information about the user's shopping cart.
 """
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 
 from shoppingcart.models import OrderItem
 from xmodule.modulestore.django import ModuleI18nService

--- a/lms/djangoapps/shoppingcart/models.py
+++ b/lms/djangoapps/shoppingcart/models.py
@@ -20,7 +20,7 @@ from django.contrib.auth.models import User
 from django.core.exceptions import ObjectDoesNotExist
 from django.core.mail import send_mail
 from django.core.mail.message import EmailMessage
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.db import models, transaction
 from django.db.models import Count, F, Q, Sum
 from django.db.models.signals import post_delete, post_save

--- a/lms/djangoapps/shoppingcart/tests/test_configuration_overrides.py
+++ b/lms/djangoapps/shoppingcart/tests/test_configuration_overrides.py
@@ -2,7 +2,7 @@
 """
 Dashboard with Shopping Cart History tests with configuration overrides.
 """
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from mock import patch
 
 from course_modes.models import CourseMode

--- a/lms/djangoapps/shoppingcart/tests/test_models.py
+++ b/lms/djangoapps/shoppingcart/tests/test_models.py
@@ -15,7 +15,7 @@ from django.conf import settings
 from django.contrib.auth.models import AnonymousUser
 from django.core import mail
 from django.core.mail.message import EmailMessage
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.db import DatabaseError
 from django.test import TestCase
 from django.test.utils import override_settings

--- a/lms/djangoapps/shoppingcart/tests/test_views.py
+++ b/lms/djangoapps/shoppingcart/tests/test_views.py
@@ -15,7 +15,7 @@ from django.contrib.auth.models import Group, User
 from django.contrib.messages.storage.fallback import FallbackStorage
 from django.core import mail
 from django.core.cache import cache
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.http import HttpRequest
 from django.test import TestCase
 from django.test.utils import override_settings

--- a/lms/djangoapps/shoppingcart/views.py
+++ b/lms/djangoapps/shoppingcart/views.py
@@ -8,7 +8,7 @@ from config_models.decorators import require_config
 from django.conf import settings
 from django.contrib.auth.decorators import login_required
 from django.contrib.auth.models import Group
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.db.models import Q
 from django.http import (
     Http404,

--- a/lms/djangoapps/static_template_view/tests/test_views.py
+++ b/lms/djangoapps/static_template_view/tests/test_views.py
@@ -2,7 +2,7 @@
 Tests for static templates
 """
 from django.conf import settings
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.test import TestCase
 
 from openedx.core.djangoapps.site_configuration.tests.test_util import with_site_configuration_context

--- a/lms/djangoapps/staticbook/tests.py
+++ b/lms/djangoapps/staticbook/tests.py
@@ -6,7 +6,7 @@ import textwrap
 
 import mock
 import requests
-from django.core.urlresolvers import NoReverseMatch, reverse
+from django.urls import NoReverseMatch, reverse
 from six import text_type
 
 from student.tests.factories import CourseEnrollmentFactory, UserFactory

--- a/lms/djangoapps/student_account/test/test_views.py
+++ b/lms/djangoapps/student_account/test/test_views.py
@@ -17,7 +17,7 @@ from django.contrib.messages.middleware import MessageMiddleware
 from django.contrib.sessions.middleware import SessionMiddleware
 from django.core import mail
 from django.core.files.uploadedfile import SimpleUploadedFile
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.http import HttpRequest
 from django.test import TestCase
 from django.test.client import RequestFactory

--- a/lms/djangoapps/student_account/views.py
+++ b/lms/djangoapps/student_account/views.py
@@ -10,7 +10,7 @@ from django.contrib import messages
 from django.contrib.auth import get_user_model
 from django.contrib.auth.decorators import login_required
 from django.contrib.sites.models import Site
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.http import HttpRequest, HttpResponse, HttpResponseBadRequest, HttpResponseForbidden
 from django.shortcuts import redirect
 from django.utils.translation import ugettext as _

--- a/lms/djangoapps/support/tests/test_views.py
+++ b/lms/djangoapps/support/tests/test_views.py
@@ -11,7 +11,7 @@ from datetime import datetime, timedelta
 import ddt
 import pytest
 from django.contrib.auth.models import User
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.db.models import signals
 from nose.plugins.attrib import attr
 from pytz import UTC

--- a/lms/djangoapps/support/views/enrollments.py
+++ b/lms/djangoapps/support/views/enrollments.py
@@ -2,7 +2,7 @@
 Support tool for changing course enrollments.
 """
 from django.contrib.auth.models import User
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.db import transaction
 from django.db.models import Q
 from django.http import HttpResponseBadRequest

--- a/lms/djangoapps/support/views/index.py
+++ b/lms/djangoapps/support/views/index.py
@@ -1,7 +1,7 @@
 """
 Index view for the support app.
 """
-from django.core.urlresolvers import reverse_lazy
+from django.urls import reverse_lazy
 from django.utils.translation import ugettext_lazy as _
 
 from edxmako.shortcuts import render_to_response

--- a/lms/djangoapps/support/views/manage_user.py
+++ b/lms/djangoapps/support/views/manage_user.py
@@ -2,7 +2,7 @@
 Support tool for disabling user accounts.
 """
 from django.contrib.auth import get_user_model
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.db.models import Q
 from django.utils.decorators import method_decorator
 from django.utils.translation import ugettext as _

--- a/lms/djangoapps/survey/tests/test_views.py
+++ b/lms/djangoapps/survey/tests/test_views.py
@@ -5,7 +5,7 @@ Python tests for the Survey views
 import json
 from collections import OrderedDict
 
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.test.client import Client
 
 from student.tests.factories import UserFactory

--- a/lms/djangoapps/survey/views.py
+++ b/lms/djangoapps/survey/views.py
@@ -7,7 +7,7 @@ import logging
 
 from django.conf import settings
 from django.contrib.auth.decorators import login_required
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.http import HttpResponse, HttpResponseNotFound, HttpResponseRedirect
 from django.utils.html import escape
 from django.views.decorators.http import require_POST

--- a/lms/djangoapps/teams/tests/test_views.py
+++ b/lms/djangoapps/teams/tests/test_views.py
@@ -9,7 +9,7 @@ import pytest
 import pytz
 from dateutil import parser
 from django.conf import settings
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.db.models.signals import post_save
 from django.utils import translation
 from elasticsearch.exceptions import ConnectionError

--- a/lms/djangoapps/verify_student/models.py
+++ b/lms/djangoapps/verify_student/models.py
@@ -25,7 +25,7 @@ from django.contrib.contenttypes.fields import GenericForeignKey
 from django.contrib.contenttypes.models import ContentType
 from django.core.cache import cache
 from django.core.files.base import ContentFile
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.db import models
 from django.dispatch import receiver
 from django.utils.functional import cached_property

--- a/lms/djangoapps/verify_student/services.py
+++ b/lms/djangoapps/verify_student/services.py
@@ -6,7 +6,7 @@ import logging
 
 from itertools import chain
 from django.conf import settings
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.utils.translation import ugettext as _
 
 from course_modes.models import CourseMode

--- a/lms/djangoapps/verify_student/tests/fake_software_secure.py
+++ b/lms/djangoapps/verify_student/tests/fake_software_secure.py
@@ -4,7 +4,7 @@ Fake Software Secure page for use in acceptance tests.
 
 from django.conf import settings
 from django.contrib.auth.decorators import login_required
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.utils.decorators import method_decorator
 from django.views.generic.base import View
 

--- a/lms/djangoapps/verify_student/tests/test_integration.py
+++ b/lms/djangoapps/verify_student/tests/test_integration.py
@@ -2,7 +2,7 @@
 Integration tests of the payment flow, including course mode selection.
 """
 
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 
 from course_modes.tests.factories import CourseModeFactory
 from student.models import CourseEnrollment

--- a/lms/djangoapps/verify_student/tests/test_views.py
+++ b/lms/djangoapps/verify_student/tests/test_views.py
@@ -18,7 +18,7 @@ import requests
 from bs4 import BeautifulSoup
 from django.conf import settings
 from django.core import mail
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.test import TestCase
 from django.test.client import Client, RequestFactory
 from django.test.utils import override_settings

--- a/lms/djangoapps/verify_student/views.py
+++ b/lms/djangoapps/verify_student/views.py
@@ -13,7 +13,7 @@ from django.conf import settings
 from django.contrib.auth.decorators import login_required
 from django.contrib.staticfiles.storage import staticfiles_storage
 from django.core.mail import send_mail
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.db import transaction
 from django.http import Http404, HttpResponse, HttpResponseBadRequest
 from django.shortcuts import redirect

--- a/lms/lib/courseware_search/lms_result_processor.py
+++ b/lms/lib/courseware_search/lms_result_processor.py
@@ -3,7 +3,7 @@ This file contains implementation override of SearchResultProcessor which will a
     * Blends in "location" property
     * Confirms user access to object
 """
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from opaque_keys.edx.keys import CourseKey, UsageKey
 from search.result_processor import SearchResultProcessor
 

--- a/lms/templates/api_admin/catalogs/edit.html
+++ b/lms/templates/api_admin/catalogs/edit.html
@@ -2,7 +2,7 @@
 <%page expression_filter="h"/>
 <%inherit file="../../main.html"/>
 <%!
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.utils.translation import ugettext as _
 %>
 

--- a/lms/templates/api_admin/catalogs/list.html
+++ b/lms/templates/api_admin/catalogs/list.html
@@ -2,7 +2,7 @@
 <%page expression_filter="h"/>
 <%inherit file="../../main.html"/>
 <%!
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.utils.translation import ugettext as _
 %>
 

--- a/lms/templates/api_admin/catalogs/search.html
+++ b/lms/templates/api_admin/catalogs/search.html
@@ -2,7 +2,7 @@
 <%page expression_filter="h"/>
 <%inherit file="../../main.html"/>
 <%!
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.utils.translation import ugettext as _
 %>
 

--- a/lms/templates/api_admin/terms_of_service.html
+++ b/lms/templates/api_admin/terms_of_service.html
@@ -2,7 +2,7 @@
 <%page expression_filter="h"/>
 <%inherit file="../main.html"/>
 <%!
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.utils.translation import ugettext as _
 %>
 

--- a/lms/templates/bookmark_button.html
+++ b/lms/templates/bookmark_button.html
@@ -1,7 +1,7 @@
 <%page expression_filter="h" args="bookmark_id, is_bookmarked" />
 
 <%!
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.utils.translation import ugettext as _
 %>
 

--- a/lms/templates/calculator/toggle_calculator.html
+++ b/lms/templates/calculator/toggle_calculator.html
@@ -2,7 +2,7 @@
 
 <%!
 from django.utils.translation import ugettext as _
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from openedx.core.djangolib.markup import HTML, Text
 %>
 

--- a/lms/templates/ccx/coach_dashboard.html
+++ b/lms/templates/ccx/coach_dashboard.html
@@ -3,7 +3,7 @@
 <%namespace name='static' file='/static_content.html'/>
 <%!
 from django.utils.translation import ugettext as _
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from openedx.core.djangolib.js_utils import (
     dump_js_escaped_json, js_escaped_string
 )

--- a/lms/templates/class_dashboard/all_section_metrics.js
+++ b/lms/templates/class_dashboard/all_section_metrics.js
@@ -1,7 +1,7 @@
 <%page args="id_opened_prefix, id_grade_prefix, id_attempt_prefix, id_tooltip_prefix, course_id, allSubsectionTooltipArr, allProblemTooltipArr, **kwargs"/>
 <%!
   import json
-  from django.core.urlresolvers import reverse
+  from django.urls import reverse
   from six import text_type
 %>
 

--- a/lms/templates/conditional_module.html
+++ b/lms/templates/conditional_module.html
@@ -1,5 +1,5 @@
 <%!
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.utils.translation import ugettext as _
 from six import text_type
 %>

--- a/lms/templates/course.html
+++ b/lms/templates/course.html
@@ -2,7 +2,7 @@
 <%namespace name='static' file='static_content.html'/>
 <%!
 from django.utils.translation import ugettext as _
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from six import text_type
 %>
 <%page args="course" expression_filter="h"/>

--- a/lms/templates/course_modes/choose.html
+++ b/lms/templates/course_modes/choose.html
@@ -2,7 +2,7 @@
 <%inherit file="../main.html" />
 <%!
 from django.utils.translation import ugettext as _
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from openedx.core.djangolib.js_utils import js_escaped_string
 from openedx.core.djangolib.markup import HTML, Text
 %>

--- a/lms/templates/courseware/accordion.html
+++ b/lms/templates/courseware/accordion.html
@@ -1,7 +1,7 @@
 <%page expression_filter="h"/>
 <%namespace name='static' file='../static_content.html'/>
 <%!
-    from django.core.urlresolvers import reverse
+    from django.urls import reverse
     from django.utils.translation import ugettext as _
     from django.conf import settings
     from openedx.core.djangolib.markup import HTML, Text

--- a/lms/templates/courseware/course_about.html
+++ b/lms/templates/courseware/course_about.html
@@ -2,7 +2,7 @@
 <%!
 from django.utils.translation import ugettext as _
 from django.utils.translation import pgettext
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from courseware.courses import get_course_about_section
 from django.conf import settings
 from six import text_type

--- a/lms/templates/courseware/course_about_sidebar_header.html
+++ b/lms/templates/courseware/course_about_sidebar_header.html
@@ -3,7 +3,7 @@
 import urllib
 
 from django.utils.translation import ugettext as _
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.conf import settings
 from six import text_type
 %>

--- a/lms/templates/courseware/course_navigation.html
+++ b/lms/templates/courseware/course_navigation.html
@@ -6,7 +6,7 @@
 <%!
 from courseware.tabs import get_course_tab_list
 from django.conf import settings
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.utils.translation import ugettext as _
 %>
 

--- a/lms/templates/courseware/courseware.html
+++ b/lms/templates/courseware/courseware.html
@@ -6,7 +6,7 @@
 import waffle
 
 from django.conf import settings
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.utils.translation import ugettext as _
 
 from edxnotes.helpers import is_feature_enabled as is_edxnotes_enabled

--- a/lms/templates/courseware/gradebook.html
+++ b/lms/templates/courseware/gradebook.html
@@ -2,7 +2,7 @@
 <%namespace name='static' file='/static_content.html'/>
 <%!
 from django.utils.translation import ugettext as _
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from six import text_type
 %>
 

--- a/lms/templates/courseware/info.html
+++ b/lms/templates/courseware/info.html
@@ -6,7 +6,7 @@
 from datetime import datetime
 from pytz import timezone, utc
 
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.utils.translation import ugettext as _
 
 from courseware.courses import get_course_info_section, get_course_date_blocks

--- a/lms/templates/courseware/program_marketing.html
+++ b/lms/templates/courseware/program_marketing.html
@@ -5,7 +5,7 @@
 <%!
 from datetime import datetime
 
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.utils.translation import ugettext as _
 from mako import exceptions
 

--- a/lms/templates/courseware/progress.html
+++ b/lms/templates/courseware/progress.html
@@ -7,7 +7,7 @@ from course_modes.models import CourseMode
 from lms.djangoapps.certificates.models import CertificateStatuses
 from django.utils.translation import ugettext as _
 from openedx.core.djangolib.markup import HTML, Text
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.conf import settings
 from django.utils.http import urlquote_plus
 from six import text_type

--- a/lms/templates/courseware/tabs.html
+++ b/lms/templates/courseware/tabs.html
@@ -3,7 +3,7 @@
 <%namespace name='static' file='/static_content.html'/>
 <%!
  from django.utils.translation import ugettext as _
- from django.core.urlresolvers import reverse
+ from django.urls import reverse
  %>
 <%page args="tab_list, active_page, default_tab, tab_image" expression_filter="h" />
 

--- a/lms/templates/dashboard.html
+++ b/lms/templates/dashboard.html
@@ -5,7 +5,7 @@
 <%!
 import pytz
 from datetime import datetime, timedelta
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.utils.translation import ugettext as _
 from django.template import RequestContext
 from entitlements.models import CourseEntitlement

--- a/lms/templates/dashboard/_dashboard_course_listing.html
+++ b/lms/templates/dashboard/_dashboard_course_listing.html
@@ -5,7 +5,7 @@ import urllib
 
 from django.utils.translation import ugettext as _
 from django.utils.translation import ungettext
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from course_modes.models import CourseMode
 from course_modes.helpers import enrollment_mode_display
 from openedx.core.djangolib.js_utils import dump_js_escaped_json, js_escaped_string

--- a/lms/templates/dashboard/_dashboard_entitlement_actions.html
+++ b/lms/templates/dashboard/_dashboard_entitlement_actions.html
@@ -2,7 +2,7 @@
 
 <%!
 from django.utils.translation import ugettext as _
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 %>
 
 <%

--- a/lms/templates/dashboard/_dashboard_status_verification.html
+++ b/lms/templates/dashboard/_dashboard_status_verification.html
@@ -1,7 +1,7 @@
 <%page expression_filter="h"/>
 <%namespace name='static' file='../static_content.html'/>
 <%!
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.utils.translation import ugettext as _
 %>
 

--- a/lms/templates/edxnotes/toggle_notes.html
+++ b/lms/templates/edxnotes/toggle_notes.html
@@ -1,7 +1,7 @@
 <%page args="course" expression_filter="h"/>
 <%!
 from django.utils.translation import ugettext as _
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from openedx.core.djangolib.js_utils import dump_js_escaped_json, js_escaped_string
 %>
 <%namespace name='static' file='/static_content.html'/>

--- a/lms/templates/email_change_successful.html
+++ b/lms/templates/email_change_successful.html
@@ -1,7 +1,7 @@
 <%inherit file="main.html" />
 <%!
 from django.utils.translation import ugettext as _
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 %>
 
 <section class="container activation">

--- a/lms/templates/emails/confirm_email_change.txt
+++ b/lms/templates/emails/confirm_email_change.txt
@@ -1,4 +1,4 @@
-<%! from django.core.urlresolvers import reverse %>
+<%! from django.urls import reverse %>
 <%! from django.utils.translation import ugettext as _ %>
 <%! from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers %>
 <%! from edxmako.shortcuts import render_to_string, marketing_link %>

--- a/lms/templates/financial-assistance/financial-assistance.html
+++ b/lms/templates/financial-assistance/financial-assistance.html
@@ -1,6 +1,6 @@
 <%inherit file="../main.html"/>
 <%
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.utils.translation import ugettext as _
 
 from edxmako.shortcuts import marketing_link

--- a/lms/templates/footer.html
+++ b/lms/templates/footer.html
@@ -1,7 +1,7 @@
 ## mako
 <%page expression_filter="h"/>
 <%!
-  from django.core.urlresolvers import reverse
+  from django.urls import reverse
   from django.utils.translation import ugettext as _
   from branding.api import get_footer
   from openedx.core.djangoapps.lang_pref.api import footer_language_selector_is_enabled

--- a/lms/templates/forgot_password_modal.html
+++ b/lms/templates/forgot_password_modal.html
@@ -2,7 +2,7 @@
 
 <%!
 from django.utils.translation import ugettext as _
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 %>
 
 <section id="forgot-password-modal" class="modal" role="dialog" tabindex="-1" aria-label="${_('Password Reset')}">

--- a/lms/templates/header/brand.html
+++ b/lms/templates/header/brand.html
@@ -5,7 +5,7 @@
 <%namespace name='static' file='/static_content.html'/>
 
 <%!
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.utils.translation import ugettext as _
 from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
 

--- a/lms/templates/header/header.html
+++ b/lms/templates/header/header.html
@@ -5,7 +5,7 @@
 <%namespace name='static' file='../static_content.html'/>
 <%namespace file='../main.html' import="login_query"/>
 <%!
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.utils.translation import ugettext as _
 
 from lms.djangoapps.ccx.overrides import get_current_ccx

--- a/lms/templates/header/navbar-authenticated.html
+++ b/lms/templates/header/navbar-authenticated.html
@@ -5,7 +5,7 @@
 <%namespace name='static' file='../static_content.html'/>
 <%namespace file='../main.html' import="login_query"/>
 <%!
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.utils.translation import ugettext as _
 from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
 %>

--- a/lms/templates/header/navbar-logo-header.html
+++ b/lms/templates/header/navbar-logo-header.html
@@ -4,7 +4,7 @@
 
 <%namespace name='static' file='../static_content.html'/>
 <%!
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.utils.translation import ugettext as _
 from lms.djangoapps.ccx.overrides import get_current_ccx
 from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers

--- a/lms/templates/header/navbar-not-authenticated.html
+++ b/lms/templates/header/navbar-not-authenticated.html
@@ -6,7 +6,7 @@
 <%namespace file='../main.html' import="login_query"/>
 
 <%!
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.utils.translation import ugettext as _
 from six import text_type
 %>

--- a/lms/templates/header/user_dropdown.html
+++ b/lms/templates/header/user_dropdown.html
@@ -3,7 +3,7 @@
 <%namespace name='static' file='static_content.html'/>
 
 <%!
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.utils.translation import ugettext as _
 
 from openedx.core.djangoapps.user_api.accounts.image_helpers import get_profile_image_urls_for_user

--- a/lms/templates/help_modal.html
+++ b/lms/templates/help_modal.html
@@ -6,7 +6,7 @@ from datetime import datetime
 import pytz
 from django.conf import settings
 from django.utils.translation import ugettext as _
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from openedx.core.djangolib.js_utils import js_escaped_string
 from openedx.core.djangolib.markup import HTML, Text
 from xmodule.tabs import CourseTabList

--- a/lms/templates/index.html
+++ b/lms/templates/index.html
@@ -3,7 +3,7 @@
 <%namespace name='static' file='static_content.html'/>
 <%!
 from django.utils.translation import ugettext as _
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 
 from openedx.core.djangolib.markup import HTML, Text
 %>

--- a/lms/templates/instructor/instructor_dashboard_2/add_coupon_modal.html
+++ b/lms/templates/instructor/instructor_dashboard_2/add_coupon_modal.html
@@ -1,7 +1,7 @@
 <%page args="section_data" expression_filter="h"/>
 <%!
 from django.utils.translation import ugettext as _
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 %>
 <section id="add-coupon-modal" class="modal" role="dialog" tabindex="-1" aria-labelledby="header-coupon-code">
     <h2 id="header-coupon-code" class="hd hd-2">${_("Add Coupon Code")}</h2>

--- a/lms/templates/instructor/instructor_dashboard_2/edit_coupon_modal.html
+++ b/lms/templates/instructor/instructor_dashboard_2/edit_coupon_modal.html
@@ -1,7 +1,7 @@
 <%page args="section_data" expression_filter="h"/>
 <%!
 from django.utils.translation import ugettext as _
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 %>
 <section id="edit-coupon-modal" class="modal" role="dialog" tabindex="-1" aria-labelledby="header-edit-coupon-code">
     <h2 id="header-edit-coupon-code" class="hd hd-2">${_("Edit Coupon Code")}</h2>

--- a/lms/templates/instructor/instructor_dashboard_2/generate_registarion_codes_modal.html
+++ b/lms/templates/instructor/instructor_dashboard_2/generate_registarion_codes_modal.html
@@ -1,7 +1,7 @@
 <%page args="section_data" expression_filter="h"/>
 <%!
 from django.utils.translation import ugettext as _
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 %>
 <section id="registration_code_generation_modal" class="modal" role="dialog" tabindex="-1" aria-labelledby="header-registration-code">
     <h2 id="header-registration-code" class="hd hd-2">${_("Generate Registration Code Modal")}</h2>

--- a/lms/templates/instructor/instructor_dashboard_2/instructor_dashboard_2.html
+++ b/lms/templates/instructor/instructor_dashboard_2/instructor_dashboard_2.html
@@ -4,7 +4,7 @@
 <%def name="online_help_token()"><% return "instructor" %></%def>
 <%!
 from django.utils.translation import ugettext as _
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from openedx.core.djangolib.markup import HTML
 %>
 <%block name="bodyclass">view-in-course view-instructordash</%block>

--- a/lms/templates/instructor/instructor_dashboard_2/invalidate_registration_code_modal.html
+++ b/lms/templates/instructor/instructor_dashboard_2/invalidate_registration_code_modal.html
@@ -1,6 +1,6 @@
 <%page args="section_data" expression_filter="h"/>
 <%! from django.utils.translation import ugettext as _ %>
-<%! from django.core.urlresolvers import reverse %>
+<%! from django.urls import reverse %>
 <section id="invalidate_registration_code_modal" class="modal" role="dialog" tabindex="-1" aria-labelledby="header-enrollment-code-status">
     <h2 id="header-enrollment-code-status" class="hd hd-2">${_("Enrollment Code Status")}</h2>
   <div class="inner-wrapper">

--- a/lms/templates/instructor/instructor_dashboard_2/set_course_mode_price_modal.html
+++ b/lms/templates/instructor/instructor_dashboard_2/set_course_mode_price_modal.html
@@ -1,7 +1,7 @@
 <%page args="section_data" expression_filter="h"/>
 <%!
 from django.utils.translation import ugettext as _
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 %>
 <section id="set-course-mode-price-modal" class="modal" role="dialog" tabindex="-1" aria-labelledby="header-course-price">
     <h2 id="header-course-price" class="hd hd-2">${_("Set Course Mode Price")}</h2>

--- a/lms/templates/login-sidebar.html
+++ b/lms/templates/login-sidebar.html
@@ -1,6 +1,6 @@
 <%!
 from django.utils.translation import ugettext as _
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 %>
 
 <header>

--- a/lms/templates/login.html
+++ b/lms/templates/login.html
@@ -2,7 +2,7 @@
 <%namespace name='static' file='static_content.html'/>
 
 <%!
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.utils.translation import ugettext as _
 import third_party_auth
 from third_party_auth import provider, pipeline

--- a/lms/templates/main.html
+++ b/lms/templates/main.html
@@ -14,7 +14,7 @@
 <% online_help_token = self.online_help_token() if hasattr(self, 'online_help_token') else None %>
 <%!
 from branding import api as branding_api
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.utils.http import urlquote_plus
 from django.utils.translation import ugettext as _
 from django.utils.translation import get_language_bidi

--- a/lms/templates/manage_user_standing.html
+++ b/lms/templates/manage_user_standing.html
@@ -1,7 +1,7 @@
 <%inherit file="main.html" />
 
 <%!
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.utils.translation import ugettext as _
 %>
 

--- a/lms/templates/modal/_modal-settings-language.html
+++ b/lms/templates/modal/_modal-settings-language.html
@@ -1,7 +1,7 @@
 <%namespace name='static' file='../static_content.html'/>
 <%!
 from django.utils.translation import ugettext as _
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 %>
 
 <section id="change_language" class="modal modal-settings-language" aria-hidden="true">

--- a/lms/templates/navigation/bootstrap/navbar-authenticated.html
+++ b/lms/templates/navigation/bootstrap/navbar-authenticated.html
@@ -5,7 +5,7 @@
 <%namespace name='static' file='../../static_content.html'/>
 <%namespace file='../../main.html' import="login_query"/>
 <%!
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.utils.translation import ugettext as _
 %>
 

--- a/lms/templates/navigation/navbar-authenticated.html
+++ b/lms/templates/navigation/navbar-authenticated.html
@@ -5,7 +5,7 @@
 <%namespace name='static' file='../static_content.html'/>
 <%namespace file='../main.html' import="login_query"/>
 <%!
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.utils.translation import ugettext as _
 %>
 

--- a/lms/templates/navigation/navbar-logo-header.html
+++ b/lms/templates/navigation/navbar-logo-header.html
@@ -4,7 +4,7 @@
 
 <%namespace name='static' file='../static_content.html'/>
 <%!
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.utils.translation import ugettext as _
 from lms.djangoapps.ccx.overrides import get_current_ccx
 from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers

--- a/lms/templates/navigation/navbar-not-authenticated.html
+++ b/lms/templates/navigation/navbar-not-authenticated.html
@@ -5,7 +5,7 @@
 <%namespace name='static' file='../static_content.html'/>
 <%namespace file='../main.html' import="login_query"/>
 <%!
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.utils.translation import ugettext as _
 from six import text_type
 %>

--- a/lms/templates/navigation/navigation.html
+++ b/lms/templates/navigation/navigation.html
@@ -9,7 +9,7 @@
 <%namespace name='static' file='../static_content.html'/>
 <%namespace file='../main.html' import="login_query"/>
 <%!
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.utils.translation import ugettext as _
 
 from lms.djangoapps.ccx.overrides import get_current_ccx

--- a/lms/templates/notes.html
+++ b/lms/templates/notes.html
@@ -5,7 +5,7 @@ ${static.css(group='style-vendor-tinymce-skin', raw=True)}
 ${static.css(group='style-xmodule-annotations', raw=True)}
 <%!
 from django.utils.translation import ugettext as _
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 %>
 
 <%block name="headextra">

--- a/lms/templates/provider/authorize.html
+++ b/lms/templates/provider/authorize.html
@@ -5,7 +5,7 @@
 <%!
 from django.utils.translation import ugettext as _
 from provider.templatetags.scope import scopes
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from openedx.core.djangolib.markup import HTML, Text
 %>
 

--- a/lms/templates/register-shib.html
+++ b/lms/templates/register-shib.html
@@ -3,7 +3,7 @@
 <%namespace file='main.html' import="login_query"/>
 <%!
 from django.utils.translation import ugettext as _
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.utils import html
 from django_countries import countries
 from student.models import UserProfile

--- a/lms/templates/register-sidebar.html
+++ b/lms/templates/register-sidebar.html
@@ -1,7 +1,7 @@
 <%page expression_filter="h"/>
 <%!
 from django.utils.translation import ugettext as _
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 %>
 <%namespace file='main.html' import="login_query"/>
 <%namespace name='static' file='static_content.html'/>

--- a/lms/templates/register.html
+++ b/lms/templates/register.html
@@ -3,7 +3,7 @@
 <%namespace file='main.html' import="login_query"/>
 <%!
 from django.utils.translation import ugettext as _
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.utils import html
 from django_countries import countries
 from student.models import UserProfile

--- a/lms/templates/resubscribe.html
+++ b/lms/templates/resubscribe.html
@@ -1,5 +1,5 @@
 <%!
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.utils.translation import ugettext as _
 from django.conf import settings
 %>

--- a/lms/templates/shoppingcart/billing_details.html
+++ b/lms/templates/shoppingcart/billing_details.html
@@ -1,7 +1,7 @@
 <%inherit file="shopping_cart_flow.html" />
 <%!
 from django.utils.translation import ugettext as _
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 %>
 
 <%block name="billing_details_highlight"><li class="active" >${_('Billing Details')}</li></%block>

--- a/lms/templates/shoppingcart/download_report.html
+++ b/lms/templates/shoppingcart/download_report.html
@@ -1,7 +1,7 @@
 <%inherit file="../main.html" />
 <%!
 from django.utils.translation import ugettext as _
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.conf import settings
 %>
 

--- a/lms/templates/shoppingcart/error.html
+++ b/lms/templates/shoppingcart/error.html
@@ -1,7 +1,7 @@
 <%inherit file="../main.html" />
 <%!
 from django.utils.translation import ugettext as _
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 %>
 <%block name="pagetitle">${_("Payment Error")}</%block>
 

--- a/lms/templates/shoppingcart/receipt.html
+++ b/lms/templates/shoppingcart/receipt.html
@@ -4,7 +4,7 @@
 <%!
 from django.utils.translation import ugettext as _
 from django.utils.translation import ungettext
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from markupsafe import escape
 from openedx.core.lib.courses import course_image_url
 %>

--- a/lms/templates/shoppingcart/registration_code_receipt.html
+++ b/lms/templates/shoppingcart/registration_code_receipt.html
@@ -1,6 +1,6 @@
 <%!
 from django.utils.translation import ugettext as _
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from six import text_type
 from openedx.core.lib.courses import course_image_url
 from openedx.features.course_experience import course_home_url_name

--- a/lms/templates/shoppingcart/registration_code_redemption.html
+++ b/lms/templates/shoppingcart/registration_code_redemption.html
@@ -1,6 +1,6 @@
 <%!
 from django.utils.translation import ugettext as _
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from openedx.core.lib.courses import course_image_url
 %>
 <%inherit file="../main.html" />

--- a/lms/templates/shoppingcart/shopping_cart.html
+++ b/lms/templates/shoppingcart/shopping_cart.html
@@ -2,7 +2,7 @@
 <%block name="review_highlight">class="active"</%block>
 
 <%!
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from edxmako.shortcuts import marketing_link
 from django.utils.translation import ugettext as _
 from django.utils.translation import ungettext

--- a/lms/templates/signup_modal.html
+++ b/lms/templates/signup_modal.html
@@ -1,7 +1,7 @@
 <%namespace name='static' file='static_content.html'/>
 <%!
 from django.conf import settings
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django_countries import countries
 from student.models import UserProfile
 from datetime import date

--- a/lms/templates/student_account/account_settings.html
+++ b/lms/templates/student_account/account_settings.html
@@ -3,7 +3,7 @@
 <%!
 import json
 
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.conf import settings
 from django.utils.translation import ugettext as _
 

--- a/lms/templates/support/certificates.html
+++ b/lms/templates/support/certificates.html
@@ -1,5 +1,5 @@
 <%!
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.utils.translation import ugettext as _
 %>
 <%namespace name='static' file='../static_content.html'/>

--- a/lms/templates/support/contact_us.html
+++ b/lms/templates/support/contact_us.html
@@ -1,7 +1,7 @@
 <%page expression_filter="h"/>
 
 <%!
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.utils.translation import ugettext as _
 
 from openedx.core.djangolib.js_utils import js_escaped_string, dump_js_escaped_json

--- a/lms/templates/support/index.html
+++ b/lms/templates/support/index.html
@@ -1,6 +1,6 @@
 ## mako
 <%!
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.utils.translation import ugettext as _
 %>
 <%namespace name='static' file='../static_content.html'/>

--- a/lms/templates/survey/survey.html
+++ b/lms/templates/survey/survey.html
@@ -3,7 +3,7 @@
 <%namespace name='static' file='../static_content.html'/>
 <%!
 from django.utils.translation import ugettext as _
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.utils import html
 from openedx.core.djangolib.markup import Text, HTML
 %>

--- a/lms/templates/sysadmin_dashboard.html
+++ b/lms/templates/sysadmin_dashboard.html
@@ -1,7 +1,7 @@
 <%inherit file="/main.html" />
 <%namespace name='static' file='/static_content.html'/>
 <%!
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.utils.translation import ugettext as _
 %>
 

--- a/lms/templates/sysadmin_dashboard_gitlogs.html
+++ b/lms/templates/sysadmin_dashboard_gitlogs.html
@@ -1,6 +1,6 @@
 <%inherit file="/main.html" />
 <%!
-    from django.core.urlresolvers import reverse
+    from django.urls import reverse
     from django.utils.translation import ugettext as _
     from django.utils.timezone import utc as UTC
     from util.date_utils import get_time_display, DEFAULT_DATE_TIME_FORMAT

--- a/lms/templates/unsubscribe.html
+++ b/lms/templates/unsubscribe.html
@@ -1,7 +1,7 @@
 <%page expression_filter="h"/>
 <%!
 from openedx.core.djangolib.markup import HTML, Text
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.utils.translation import ugettext as _
 from django.conf import settings
 %>

--- a/lms/templates/user_dropdown.html
+++ b/lms/templates/user_dropdown.html
@@ -3,7 +3,7 @@
 <%namespace name='static' file='static_content.html'/>
 
 <%!
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.utils.translation import ugettext as _
 
 from openedx.core.djangoapps.user_api.accounts.image_helpers import get_profile_image_urls_for_user

--- a/lms/templates/verify_student/reverify_not_allowed.html
+++ b/lms/templates/verify_student/reverify_not_allowed.html
@@ -1,7 +1,7 @@
 <%page expression_filter="h"/>
 <%!
     from django.utils.translation import ugettext as _
-    from django.core.urlresolvers import reverse
+    from django.urls import reverse
 %>
 
 <%inherit file="../main.html" />

--- a/lms/templates/wiki/includes/article_menu.html
+++ b/lms/templates/wiki/includes/article_menu.html
@@ -1,7 +1,7 @@
 ## mako
 <%page expression_filter="h"/>
 <%!
-  from django.core.urlresolvers import reverse
+  from django.urls import reverse
   from django.utils.translation import ugettext as _
   from openedx.core.djangolib.markup import HTML, Text
   from wiki.core.permissions import can_change_permissions

--- a/lms/templates/wiki/includes/breadcrumbs.html
+++ b/lms/templates/wiki/includes/breadcrumbs.html
@@ -1,7 +1,7 @@
 ## mako
 <%page expression_filter="h"/>
 <%!
-  from django.core.urlresolvers import reverse
+  from django.urls import reverse
   from django.utils.translation import ugettext as _
 %>
 

--- a/lms/tests.py
+++ b/lms/tests.py
@@ -3,7 +3,7 @@
 import logging
 import mimetypes
 
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.test import TestCase
 from mock import patch
 from six import text_type

--- a/openedx/core/djangoapps/ace_common/template_context.py
+++ b/openedx/core/djangoapps/ace_common/template_context.py
@@ -2,7 +2,7 @@
 Context dictionary for templates that use the ace_common base template.
 """
 from django.conf import settings
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 
 from edxmako.shortcuts import marketing_link
 from openedx.core.djangoapps.theming.helpers import get_config_value_from_site_or_settings

--- a/openedx/core/djangoapps/api_admin/admin.py
+++ b/openedx/core/djangoapps/api_admin/admin.py
@@ -1,7 +1,7 @@
 """Admin views for API managment."""
 from config_models.admin import ConfigurationModelAdmin
 from django.contrib import admin
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.utils.translation import ugettext as _
 
 from openedx.core.djangoapps.api_admin.models import ApiAccessConfig, ApiAccessRequest

--- a/openedx/core/djangoapps/api_admin/decorators.py
+++ b/openedx/core/djangoapps/api_admin/decorators.py
@@ -1,7 +1,7 @@
 """Decorators for API access management."""
 from functools import wraps
 
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.http import HttpResponseNotFound
 from django.shortcuts import redirect
 

--- a/openedx/core/djangoapps/api_admin/models.py
+++ b/openedx/core/djangoapps/api_admin/models.py
@@ -8,7 +8,7 @@ from django.conf import settings
 from django.contrib.auth.models import User
 from django.contrib.sites.models import Site
 from django.core.mail import send_mail
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.db import models
 from django.db.models.signals import post_save, pre_save
 from django.dispatch import receiver

--- a/openedx/core/djangoapps/api_admin/tests/test_views.py
+++ b/openedx/core/djangoapps/api_admin/tests/test_views.py
@@ -5,7 +5,7 @@ import json
 import ddt
 import httpretty
 from django.conf import settings
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.test import TestCase
 from django.test.utils import override_settings
 from oauth2_provider.models import get_application_model

--- a/openedx/core/djangoapps/api_admin/views.py
+++ b/openedx/core/djangoapps/api_admin/views.py
@@ -3,7 +3,7 @@ import logging
 
 from django.conf import settings
 from django.contrib.sites.shortcuts import get_current_site
-from django.core.urlresolvers import reverse, reverse_lazy
+from django.urls import reverse, reverse_lazy
 from django.http.response import JsonResponse
 from django.shortcuts import redirect
 from django.views.generic import View

--- a/openedx/core/djangoapps/api_admin/widgets.py
+++ b/openedx/core/djangoapps/api_admin/widgets.py
@@ -2,7 +2,7 @@
 
 import django
 from django.conf import settings
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.forms.utils import flatatt
 from django.forms.widgets import CheckboxInput
 from django.utils.encoding import force_text

--- a/openedx/core/djangoapps/auth_exchange/tests/test_views.py
+++ b/openedx/core/djangoapps/auth_exchange/tests/test_views.py
@@ -11,7 +11,7 @@ import unittest
 
 import ddt
 from django.conf import settings
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.test import TestCase
 import httpretty
 import provider.constants

--- a/openedx/core/djangoapps/bookmarks/tests/test_views.py
+++ b/openedx/core/djangoapps/bookmarks/tests/test_views.py
@@ -7,7 +7,7 @@ import urllib
 import ddt
 import pytest
 from django.conf import settings
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from mock import patch
 from nose.plugins.attrib import attr
 from rest_framework.test import APIClient

--- a/openedx/core/djangoapps/cache_toolbox/tests/test_middleware.py
+++ b/openedx/core/djangoapps/cache_toolbox/tests/test_middleware.py
@@ -1,6 +1,6 @@
 """Tests for cached authentication middleware."""
 from django.contrib.auth.models import User
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.test import TestCase
 from mock import patch
 

--- a/openedx/core/djangoapps/cors_csrf/tests/test_views.py
+++ b/openedx/core/djangoapps/cors_csrf/tests/test_views.py
@@ -4,7 +4,7 @@ import json
 import unittest
 
 from django.conf import settings
-from django.core.urlresolvers import NoReverseMatch, reverse
+from django.urls import NoReverseMatch, reverse
 from django.test import TestCase
 
 import ddt

--- a/openedx/core/djangoapps/course_groups/views.py
+++ b/openedx/core/djangoapps/course_groups/views.py
@@ -9,7 +9,7 @@ from django.contrib.auth.decorators import login_required
 from django.contrib.auth.models import User
 from django.core.exceptions import ValidationError
 from django.core.paginator import EmptyPage, Paginator
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.db import transaction
 from django.http import Http404, HttpResponseBadRequest
 from django.utils.translation import ugettext

--- a/openedx/core/djangoapps/credit/email_utils.py
+++ b/openedx/core/djangoapps/credit/email_utils.py
@@ -15,7 +15,7 @@ from django.contrib.auth.models import User
 from django.contrib.staticfiles import finders
 from django.core.cache import cache
 from django.core.mail import EmailMessage, SafeMIMEText
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.utils.translation import ugettext as _
 
 from edxmako.shortcuts import render_to_string

--- a/openedx/core/djangoapps/credit/tests/test_views.py
+++ b/openedx/core/djangoapps/credit/tests/test_views.py
@@ -12,7 +12,7 @@ import json
 import ddt
 import pytz
 from django.conf import settings
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.test import TestCase, Client
 from django.test.utils import override_settings
 from edx_oauth2_provider.tests.factories import AccessTokenFactory, ClientFactory

--- a/openedx/core/djangoapps/embargo/middleware.py
+++ b/openedx/core/djangoapps/embargo/middleware.py
@@ -30,7 +30,7 @@ import re
 
 from django.conf import settings
 from django.core.exceptions import MiddlewareNotUsed
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.shortcuts import redirect
 from ipware.ip import get_ip
 

--- a/openedx/core/djangoapps/embargo/models.py
+++ b/openedx/core/djangoapps/embargo/models.py
@@ -17,7 +17,7 @@ import logging
 import ipaddr
 from config_models.models import ConfigurationModel
 from django.core.cache import cache
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.db import models
 from django.db.models.signals import post_delete, post_save
 from django.utils.translation import ugettext as _

--- a/openedx/core/djangoapps/embargo/test_utils.py
+++ b/openedx/core/djangoapps/embargo/test_utils.py
@@ -3,7 +3,7 @@ import contextlib
 
 import mock
 from django.core.cache import cache
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 
 import pygeoip
 

--- a/openedx/core/djangoapps/embargo/tests/test_middleware.py
+++ b/openedx/core/djangoapps/embargo/tests/test_middleware.py
@@ -6,7 +6,7 @@ from mock import patch
 from nose.plugins.attrib import attr
 import ddt
 
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.conf import settings
 from django.core.cache import cache as django_cache
 

--- a/openedx/core/djangoapps/embargo/tests/test_views.py
+++ b/openedx/core/djangoapps/embargo/tests/test_views.py
@@ -4,7 +4,7 @@ import ddt
 import mock
 import pygeoip
 
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.conf import settings
 from mock import patch
 

--- a/openedx/core/djangoapps/external_auth/login_and_register.py
+++ b/openedx/core/djangoapps/external_auth/login_and_register.py
@@ -5,7 +5,7 @@ This module contains legacy code originally from `student.views`.
 import re
 
 from django.conf import settings
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.shortcuts import redirect
 from opaque_keys.edx.keys import CourseKey
 from six import text_type

--- a/openedx/core/djangoapps/external_auth/tests/test_openid_provider.py
+++ b/openedx/core/djangoapps/external_auth/tests/test_openid_provider.py
@@ -12,7 +12,7 @@ from django.conf import settings
 from django.test import TestCase, LiveServerTestCase
 from django.core.cache import cache
 from django.test.utils import override_settings
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.test.client import RequestFactory
 from unittest import skipUnless
 

--- a/openedx/core/djangoapps/external_auth/tests/test_shib.py
+++ b/openedx/core/djangoapps/external_auth/tests/test_shib.py
@@ -16,7 +16,7 @@ from django.http import HttpResponseRedirect
 from django.test import TestCase
 from django.test.client import RequestFactory, Client as DjangoTestClient
 from django.test.utils import override_settings
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.contrib.auth.models import AnonymousUser, User
 from openedx.core.djangoapps.external_auth.models import ExternalAuthMap
 from openedx.core.djangoapps.external_auth.views import (

--- a/openedx/core/djangoapps/external_auth/tests/test_ssl.py
+++ b/openedx/core/djangoapps/external_auth/tests/test_ssl.py
@@ -11,7 +11,7 @@ from django.conf import settings
 from django.contrib.auth import SESSION_KEY
 from django.contrib.auth.models import AnonymousUser, User
 from django.contrib.sessions.middleware import SessionMiddleware
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.test.client import Client
 from django.test.client import RequestFactory
 from django.test.utils import override_settings

--- a/openedx/core/djangoapps/external_auth/views.py
+++ b/openedx/core/djangoapps/external_auth/views.py
@@ -17,7 +17,7 @@ from django.conf import settings
 from django.contrib.auth import REDIRECT_FIELD_NAME, authenticate, login
 from django.contrib.auth.models import User
 from django.core.exceptions import ValidationError
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.core.validators import validate_email
 from django.db import transaction
 from django.http import HttpResponse, HttpResponseForbidden, HttpResponseRedirect

--- a/openedx/core/djangoapps/heartbeat/tests/test_heartbeat.py
+++ b/openedx/core/djangoapps/heartbeat/tests/test_heartbeat.py
@@ -3,7 +3,7 @@ Test the heartbeat
 """
 import json
 
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.db.utils import DatabaseError
 from django.test.client import Client
 from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase

--- a/openedx/core/djangoapps/lang_pref/tests/test_middleware.py
+++ b/openedx/core/djangoapps/lang_pref/tests/test_middleware.py
@@ -8,7 +8,7 @@ import mock
 import ddt
 from django.conf import settings
 from django.test import TestCase
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.test.client import RequestFactory
 from django.http import HttpResponse
 from django.contrib.sessions.middleware import SessionMiddleware

--- a/openedx/core/djangoapps/lang_pref/tests/test_views.py
+++ b/openedx/core/djangoapps/lang_pref/tests/test_views.py
@@ -4,7 +4,7 @@ Tests: lang pref views
 import json
 from django.test import TestCase
 from django.test.client import RequestFactory
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from student.tests.factories import UserFactory
 from django.utils.translation import LANGUAGE_SESSION_KEY
 from django.contrib.sessions.middleware import SessionMiddleware

--- a/openedx/core/djangoapps/oauth_dispatch/tests/test_client_credentials.py
+++ b/openedx/core/djangoapps/oauth_dispatch/tests/test_client_credentials.py
@@ -5,7 +5,7 @@ import json
 import unittest
 
 from django.conf import settings
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.test import TestCase
 from edx_oauth2_provider.tests.factories import ClientFactory
 from oauth2_provider.models import Application

--- a/openedx/core/djangoapps/oauth_dispatch/tests/test_views.py
+++ b/openedx/core/djangoapps/oauth_dispatch/tests/test_views.py
@@ -9,7 +9,7 @@ import ddt
 import httpretty
 from Cryptodome.PublicKey import RSA
 from django.conf import settings
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.test import RequestFactory, TestCase, override_settings
 from oauth2_provider import models as dot_models
 

--- a/openedx/core/djangoapps/oauth_dispatch/views.py
+++ b/openedx/core/djangoapps/oauth_dispatch/views.py
@@ -10,7 +10,7 @@ import json
 
 from Cryptodome.PublicKey import RSA
 from django.conf import settings
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.http import JsonResponse
 from django.views.generic import View
 from edx_oauth2_provider import views as dop_views  # django-oauth2-provider views

--- a/openedx/core/djangoapps/profile_images/tests/test_views.py
+++ b/openedx/core/djangoapps/profile_images/tests/test_views.py
@@ -6,7 +6,7 @@ import datetime
 from nose.plugins.attrib import attr
 from pytz import UTC
 
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.http import HttpResponse
 
 import ddt

--- a/openedx/core/djangoapps/programs/tests/test_utils.py
+++ b/openedx/core/djangoapps/programs/tests/test_utils.py
@@ -10,7 +10,7 @@ import httpretty
 import mock
 import pytest
 from django.conf import settings
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.test import TestCase
 from django.test.utils import override_settings
 from nose.plugins.attrib import attr

--- a/openedx/core/djangoapps/programs/utils.py
+++ b/openedx/core/djangoapps/programs/utils.py
@@ -11,7 +11,7 @@ from dateutil.parser import parse
 from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.core.cache import cache
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.utils.functional import cached_property
 from edx_rest_api_client.exceptions import SlumberBaseException
 from opaque_keys.edx.keys import CourseKey

--- a/openedx/core/djangoapps/schedules/admin.py
+++ b/openedx/core/djangoapps/schedules/admin.py
@@ -3,7 +3,7 @@ import functools
 from django.contrib import admin
 from django import forms
 from django.db.models import F
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.utils.translation import ugettext_lazy as _
 from openedx.core.djangolib.markup import HTML
 

--- a/openedx/core/djangoapps/schedules/resolvers.py
+++ b/openedx/core/djangoapps/schedules/resolvers.py
@@ -6,7 +6,7 @@ import attr
 from django.conf import settings
 from django.contrib.auth.models import User
 from django.contrib.staticfiles.templatetags.staticfiles import static
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.db.models import F, Q
 
 from edx_ace.recipient_resolver import RecipientResolver

--- a/openedx/core/djangoapps/service_status/test.py
+++ b/openedx/core/djangoapps/service_status/test.py
@@ -2,7 +2,7 @@
 
 import json
 
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.test.client import Client
 import unittest
 

--- a/openedx/core/djangoapps/theming/tests/test_theme_style_overrides.py
+++ b/openedx/core/djangoapps/theming/tests/test_theme_style_overrides.py
@@ -2,7 +2,7 @@
 Tests for comprehensive themes.
 """
 from django.conf import settings
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.test import TestCase
 from django.contrib import staticfiles
 

--- a/openedx/core/djangoapps/user_api/accounts/serializers.py
+++ b/openedx/core/djangoapps/user_api/accounts/serializers.py
@@ -8,7 +8,7 @@ from rest_framework import serializers
 from django.contrib.auth.models import User
 from django.conf import settings
 from django.core.exceptions import ObjectDoesNotExist
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from six import text_type
 
 from lms.djangoapps.badges.utils import badges_enabled

--- a/openedx/core/djangoapps/user_api/accounts/tests/test_views.py
+++ b/openedx/core/djangoapps/user_api/accounts/tests/test_views.py
@@ -15,7 +15,7 @@ from django.contrib.auth.models import User
 from django.contrib.sites.models import Site
 from django.core import mail
 from django.core.cache import cache
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.test import TestCase
 from django.test.testcases import TransactionTestCase
 from django.test.utils import override_settings

--- a/openedx/core/djangoapps/user_api/api.py
+++ b/openedx/core/djangoapps/user_api/api.py
@@ -3,7 +3,7 @@ import crum
 
 from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.utils.translation import ugettext as _
 from django_countries import countries
 

--- a/openedx/core/djangoapps/user_api/preferences/tests/test_views.py
+++ b/openedx/core/djangoapps/user_api/preferences/tests/test_views.py
@@ -7,7 +7,7 @@ import ddt
 import json
 from mock import patch
 
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.test.testcases import TransactionTestCase
 from rest_framework.test import APIClient
 from student.tests.factories import UserFactory, TEST_PASSWORD

--- a/openedx/core/djangoapps/user_api/tests/test_views.py
+++ b/openedx/core/djangoapps/user_api/tests/test_views.py
@@ -10,7 +10,7 @@ import mock
 from django.conf import settings
 from django.contrib.auth.models import User
 from django.core import mail
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.test.client import RequestFactory
 from django.test.testcases import TransactionTestCase
 from django.test.utils import override_settings

--- a/openedx/core/djangoapps/user_api/validation/tests/test_views.py
+++ b/openedx/core/djangoapps/user_api/validation/tests/test_views.py
@@ -8,7 +8,7 @@ import unittest
 import ddt
 from django.conf import settings
 from django.contrib.auth.models import User
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from six import text_type
 
 from openedx.core.djangoapps.user_api import accounts

--- a/openedx/core/djangoapps/user_api/verification_api/tests/test_views.py
+++ b/openedx/core/djangoapps/user_api/verification_api/tests/test_views.py
@@ -6,7 +6,7 @@ import freezegun
 import json
 
 from django.conf import settings
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.test import TestCase
 from django.test.utils import override_settings
 

--- a/openedx/core/djangoapps/zendesk_proxy/tests/test_v0_views.py
+++ b/openedx/core/djangoapps/zendesk_proxy/tests/test_v0_views.py
@@ -3,7 +3,7 @@ import json
 from copy import deepcopy
 
 import ddt
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.test.utils import override_settings
 from mock import MagicMock, patch
 

--- a/openedx/core/djangoapps/zendesk_proxy/tests/test_v1_views.py
+++ b/openedx/core/djangoapps/zendesk_proxy/tests/test_v1_views.py
@@ -3,7 +3,7 @@ import json
 from copy import deepcopy
 
 import ddt
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.test.utils import override_settings
 from mock import MagicMock, patch
 

--- a/openedx/core/lib/gating/api.py
+++ b/openedx/core/lib/gating/api.py
@@ -5,7 +5,7 @@ import json
 import logging
 
 from django.contrib.auth.models import User
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.utils.translation import ugettext as _
 
 from completion.models import BlockCompletion

--- a/openedx/core/lib/xblock_builtin/xblock_discussion/xblock_discussion/__init__.py
+++ b/openedx/core/lib/xblock_builtin/xblock_discussion/xblock_discussion/__init__.py
@@ -6,7 +6,7 @@ import logging
 import urllib
 
 from django.contrib.staticfiles.storage import staticfiles_storage
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.utils.translation import get_language_bidi
 from xblock.completable import XBlockCompletionMode
 from xblock.core import XBlock

--- a/openedx/core/lib/xblock_utils/__init__.py
+++ b/openedx/core/lib/xblock_utils/__init__.py
@@ -14,7 +14,7 @@ from contracts import contract
 
 from django.conf import settings
 from django.contrib.staticfiles.storage import staticfiles_storage
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from pytz import UTC
 from django.utils.html import escape
 from django.contrib.auth.models import User

--- a/openedx/features/course_bookmarks/plugins.py
+++ b/openedx/features/course_bookmarks/plugins.py
@@ -3,7 +3,7 @@ Platform plugins to support course bookmarks.
 """
 
 from courseware.access import has_access
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.utils.translation import ugettext as _
 from openedx.features.course_experience.course_tools import CourseTool
 from student.models import CourseEnrollment

--- a/openedx/features/course_bookmarks/views/course_bookmarks.py
+++ b/openedx/features/course_bookmarks/views/course_bookmarks.py
@@ -4,7 +4,7 @@ Views to show a course's bookmarks.
 
 from django.contrib.auth.decorators import login_required
 from django.template.context_processors import csrf
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.shortcuts import render_to_response
 from django.template.loader import render_to_string
 from django.utils.decorators import method_decorator

--- a/openedx/features/course_experience/plugins.py
+++ b/openedx/features/course_experience/plugins.py
@@ -3,7 +3,7 @@ Platform plugins to support the course experience.
 
 This includes any locally defined CourseTools.
 """
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.utils.translation import ugettext as _
 
 from courseware.courses import get_course_by_id

--- a/openedx/features/course_experience/templates/course_experience/course-home-fragment.html
+++ b/openedx/features/course_experience/templates/course_experience/course-home-fragment.html
@@ -9,7 +9,7 @@ import json
 from django.conf import settings
 from django.utils.translation import ugettext as _
 from django.template.defaultfilters import escapejs
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 
 from django_comment_client.permissions import has_permission
 from openedx.core.djangolib.js_utils import dump_js_escaped_json, js_escaped_string

--- a/openedx/features/course_experience/tests/views/test_course_dates.py
+++ b/openedx/features/course_experience/tests/views/test_course_dates.py
@@ -2,7 +2,7 @@
 Tests for course dates fragment.
 """
 from datetime import timedelta, datetime
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 
 from student.tests.factories import UserFactory
 from xmodule.modulestore import ModuleStoreEnum

--- a/openedx/features/course_experience/tests/views/test_course_home.py
+++ b/openedx/features/course_experience/tests/views/test_course_home.py
@@ -7,7 +7,7 @@ from datetime import datetime, timedelta
 import ddt
 import mock
 from django.conf import settings
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.http import QueryDict
 from django.utils.http import urlquote_plus
 from django.utils.timezone import now

--- a/openedx/features/course_experience/tests/views/test_course_outline.py
+++ b/openedx/features/course_experience/tests/views/test_course_outline.py
@@ -9,7 +9,7 @@ from completion import waffle
 from completion.models import BlockCompletion
 from completion.test_utils import CompletionWaffleTestMixin
 from django.contrib.sites.models import Site
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.test import override_settings
 from mock import Mock, patch
 from six import text_type

--- a/openedx/features/course_experience/tests/views/test_course_updates.py
+++ b/openedx/features/course_experience/tests/views/test_course_updates.py
@@ -2,7 +2,7 @@
 Tests for the course updates page.
 """
 from courseware.courses import get_course_info_usage_key
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from openedx.core.djangoapps.waffle_utils.testutils import WAFFLE_TABLES
 from openedx.features.course_experience.views.course_updates import STATUS_VISIBLE
 from student.models import CourseEnrollment

--- a/openedx/features/course_experience/tests/views/test_welcome_message.py
+++ b/openedx/features/course_experience/tests/views/test_welcome_message.py
@@ -2,7 +2,7 @@
 Tests for course welcome messages.
 """
 import ddt
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 
 from student.models import CourseEnrollment
 from student.tests.factories import UserFactory

--- a/openedx/features/course_experience/views/course_home.py
+++ b/openedx/features/course_experience/views/course_home.py
@@ -2,7 +2,7 @@
 Views for the course home page.
 """
 
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.template.context_processors import csrf
 from django.template.loader import render_to_string
 from django.utils.decorators import method_decorator

--- a/openedx/features/course_experience/views/course_reviews.py
+++ b/openedx/features/course_experience/views/course_reviews.py
@@ -3,7 +3,7 @@ Fragment for rendering the course reviews panel
 """
 from django.conf import settings
 from django.contrib.auth.decorators import login_required
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.template.loader import render_to_string
 from django.utils.decorators import method_decorator
 from django.views.decorators.cache import cache_control

--- a/openedx/features/course_experience/views/course_updates.py
+++ b/openedx/features/course_experience/views/course_updates.py
@@ -5,7 +5,7 @@ from datetime import datetime
 
 from django.contrib.auth.decorators import login_required
 from django.template.context_processors import csrf
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.template.loader import render_to_string
 from django.utils.decorators import method_decorator
 from django.views.decorators.cache import cache_control

--- a/openedx/features/course_experience/views/welcome_message.py
+++ b/openedx/features/course_experience/views/welcome_message.py
@@ -2,7 +2,7 @@
 View logic for handling course welcome messages.
 """
 
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.http import HttpResponse, HttpResponseBadRequest
 from django.template.loader import render_to_string
 from django.views.decorators.csrf import ensure_csrf_cookie

--- a/openedx/features/course_search/templates/course_search/course-search-fragment.html
+++ b/openedx/features/course_search/templates/course_search/course-search-fragment.html
@@ -10,7 +10,7 @@ import waffle
 from django.conf import settings
 from django.utils.translation import ugettext as _
 from django.template.defaultfilters import escapejs
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 
 from django_comment_client.permissions import has_permission
 from openedx.core.djangolib.js_utils import dump_js_escaped_json, js_escaped_string

--- a/openedx/features/course_search/views/course_search.py
+++ b/openedx/features/course_search/views/course_search.py
@@ -4,7 +4,7 @@ Views for the course search page.
 
 from django.contrib.auth.decorators import login_required
 from django.template.context_processors import csrf
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.template.loader import render_to_string
 from django.utils.decorators import method_decorator
 from django.views.decorators.cache import cache_control

--- a/openedx/features/enterprise_support/api.py
+++ b/openedx/features/enterprise_support/api.py
@@ -7,7 +7,7 @@ from functools import wraps
 from django.conf import settings
 from django.contrib.auth.models import User
 from django.core.cache import cache
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.shortcuts import redirect
 from django.template.loader import render_to_string
 from django.utils.http import urlencode

--- a/openedx/features/enterprise_support/tests/mixins/enterprise.py
+++ b/openedx/features/enterprise_support/tests/mixins/enterprise.py
@@ -7,7 +7,7 @@ import mock
 import httpretty
 from django.conf import settings
 from django.core.cache import cache
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.test import SimpleTestCase
 
 from openedx.features.enterprise_support.tests import FAKE_ENTERPRISE_CUSTOMER

--- a/openedx/features/enterprise_support/tests/test_api.py
+++ b/openedx/features/enterprise_support/tests/test_api.py
@@ -8,7 +8,7 @@ import mock
 from django.conf import settings
 from django.contrib.auth.models import User
 from django.core.cache import cache
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.http import HttpResponseRedirect
 from django.test.utils import override_settings
 

--- a/openedx/features/enterprise_support/tests/test_middleware.py
+++ b/openedx/features/enterprise_support/tests/test_middleware.py
@@ -4,7 +4,7 @@ Tests for Enterprise middleware.
 
 import mock
 
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.test import TestCase
 from django.test.utils import override_settings
 

--- a/openedx/features/learner_analytics/views.py
+++ b/openedx/features/learner_analytics/views.py
@@ -12,7 +12,7 @@ from analyticsclient.client import Client
 from django.conf import settings
 from django.contrib.auth.decorators import login_required
 from django.core.cache import cache
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.http import Http404
 from django.shortcuts import render_to_response
 from django.utils.decorators import method_decorator

--- a/openedx/features/learner_profile/templates/learner_profile/learner_profile.html
+++ b/openedx/features/learner_profile/templates/learner_profile/learner_profile.html
@@ -7,7 +7,7 @@
 
 <%!
 import json
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.utils.translation import ugettext as _
 from openedx.core.djangolib.js_utils import dump_js_escaped_json
 from openedx.core.djangolib.markup import HTML

--- a/openedx/features/learner_profile/tests/views/test_learner_profile.py
+++ b/openedx/features/learner_profile/tests/views/test_learner_profile.py
@@ -9,7 +9,7 @@ from lms.djangoapps.certificates.tests.factories import GeneratedCertificateFact
 from lms.envs.test import CREDENTIALS_PUBLIC_SERVICE_URL
 from course_modes.models import CourseMode
 from django.conf import settings
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.test.client import RequestFactory
 from lms.djangoapps.certificates.api import is_passing_status
 from opaque_keys.edx.locator import CourseLocator

--- a/openedx/features/learner_profile/views/learner_profile.py
+++ b/openedx/features/learner_profile/views/learner_profile.py
@@ -5,7 +5,7 @@ from django.conf import settings
 from django.contrib.auth.decorators import login_required
 from django.contrib.staticfiles.storage import staticfiles_storage
 from django.core.exceptions import ObjectDoesNotExist
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.http import Http404
 from django.shortcuts import render_to_response
 from django.utils.translation import ugettext as _

--- a/openedx/tests/completion_integration/test_views.py
+++ b/openedx/tests/completion_integration/test_views.py
@@ -5,7 +5,7 @@ Test models, managers, and validators.
 from completion import waffle
 from completion.test_utils import CompletionWaffleTestMixin
 import ddt
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from rest_framework.test import APIClient
 
 from student.tests.factories import UserFactory, CourseEnrollmentFactory

--- a/openedx/tests/xblock_integration/test_crowdsource_hinter.py
+++ b/openedx/tests/xblock_integration/test_crowdsource_hinter.py
@@ -5,7 +5,7 @@ import json
 import unittest
 
 from django.conf import settings
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from nose.plugins.attrib import attr
 from six import text_type
 

--- a/openedx/tests/xblock_integration/test_recommender.py
+++ b/openedx/tests/xblock_integration/test_recommender.py
@@ -10,7 +10,7 @@ import unittest
 from copy import deepcopy
 
 from django.conf import settings
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 
 from ddt import data, ddt
 from lms.djangoapps.courseware.tests.factories import GlobalStaffFactory

--- a/openedx/tests/xblock_integration/test_review_xblock.py
+++ b/openedx/tests/xblock_integration/test_review_xblock.py
@@ -6,7 +6,7 @@ import unittest
 
 from django.conf import settings
 from django.contrib.auth.models import User
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from nose.plugins.attrib import attr
 
 from lms.djangoapps.courseware.tests.factories import GlobalStaffFactory

--- a/openedx/tests/xblock_integration/xblock_testcase.py
+++ b/openedx/tests/xblock_integration/xblock_testcase.py
@@ -46,7 +46,7 @@ import mock
 import pytz
 from bs4 import BeautifulSoup
 from django.conf import settings
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from xblock.plugin import Plugin
 
 import lms.djangoapps.lms_xblock.runtime

--- a/themes/edx.org/cms/templates/widgets/sock.html
+++ b/themes/edx.org/cms/templates/widgets/sock.html
@@ -1,7 +1,7 @@
 <%page expression_filter="h" args="online_help_token"/>
 <%!
 from django.utils.translation import ugettext as _
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 %>
 <div class="wrapper-sock wrapper">
   <ul class="list-actions list-cta">

--- a/themes/edx.org/lms/templates/course_modes/choose.html
+++ b/themes/edx.org/lms/templates/course_modes/choose.html
@@ -3,7 +3,7 @@
 <%namespace name='static' file='/static_content.html'/>
 <%!
 from django.utils.translation import ugettext as _
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from opaque_keys.edx.keys import CourseKey
 from openedx.core.djangolib.js_utils import js_escaped_string
 from openedx.core.djangolib.markup import HTML, Text

--- a/themes/edx.org/lms/templates/dashboard.html
+++ b/themes/edx.org/lms/templates/dashboard.html
@@ -11,7 +11,7 @@ from django.utils import timezone
 from django.utils.translation import ugettext as _
 from django.template import RequestContext
 from third_party_auth import pipeline
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from util.date_utils import strftime_localized
 from opaque_keys.edx.keys import CourseKey
 from openedx.core.djangoapps.content.course_overviews.models import CourseOverview

--- a/themes/edx.org/lms/templates/header/navbar-authenticated.html
+++ b/themes/edx.org/lms/templates/header/navbar-authenticated.html
@@ -5,7 +5,7 @@
 <%namespace name='static' file='../static_content.html'/>
 <%namespace file='../main.html' import="login_query"/>
 <%!
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.utils.translation import ugettext as _
 from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
 %>

--- a/themes/edx.org/lms/templates/header/navbar-not-authenticated.html
+++ b/themes/edx.org/lms/templates/header/navbar-not-authenticated.html
@@ -6,7 +6,7 @@
 <%namespace file='../main.html' import="login_query"/>
 
 <%!
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.utils.translation import ugettext as _
 from six import text_type
 %>

--- a/themes/red-theme/cms/templates/login.html
+++ b/themes/red-theme/cms/templates/login.html
@@ -4,7 +4,7 @@
 <%inherit file="base.html" />
 <%def name="online_help_token()"><% return "login" %></%def>
 <%!
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.utils.translation import ugettext as _
 %>
 <%block name="title">${_("Sign In")}</%block>

--- a/themes/red-theme/lms/templates/footer.html
+++ b/themes/red-theme/lms/templates/footer.html
@@ -1,7 +1,7 @@
 ## mako
 <%namespace name='static' file='static_content.html'/>
 <%!
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.utils.translation import ugettext as _
 from django.conf import settings
 

--- a/themes/stanford-style/lms/templates/footer.html
+++ b/themes/stanford-style/lms/templates/footer.html
@@ -1,7 +1,7 @@
 ## mako
 <%!
   from datetime import date
-  from django.core.urlresolvers import reverse
+  from django.urls import reverse
   from django.utils.translation import ugettext as _
   from openedx.core.djangoapps.lang_pref.api import footer_language_selector_is_enabled
 %>

--- a/themes/stanford-style/lms/templates/register-shib.html
+++ b/themes/stanford-style/lms/templates/register-shib.html
@@ -1,7 +1,7 @@
 <%inherit file="main.html" />
 <%!
 from django.utils.translation import ugettext as _
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from openedx.core.djangolib.js_utils import js_escaped_string
 %>
 

--- a/themes/stanford-style/lms/templates/register-sidebar.html
+++ b/themes/stanford-style/lms/templates/register-sidebar.html
@@ -1,6 +1,6 @@
 <%!
 from django.utils.translation import ugettext as _
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 %>
 <%namespace file='main.html' import="login_query"/>
 


### PR DESCRIPTION
Django 1.10 deprecation fix for Hackathon XIX
Addresses [PLAT-1397](https://openedx.atlassian.net/browse/PLAT-1397)

Fix made by checking out master, then running the following (on my Mac):
`git grep -l 'django.core.urlresolvers' | xargs sed -i '' -e 's/django.core.urlresolvers/django.urls/g'`