### PR TITLE
Rate limiting registration form validation end point.

### DIFF
--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -2333,6 +2333,7 @@ REST_FRAMEWORK = {
     'DEFAULT_THROTTLE_RATES': {
         'user': '60/minute',
         'service_user': '120/minute',
+        'registration_validation': '30/minute',
     },
 }
 

--- a/lms/envs/test.py
+++ b/lms/envs/test.py
@@ -574,6 +574,11 @@ ACTIVATION_EMAIL_FROM_ADDRESS = 'test_activate@edx.org'
 
 TEMPLATES[0]['OPTIONS']['debug'] = True
 
+########################### DRF default throttle rates ############################
+# Increasing rates to enable test cases hitting registration view succesfully.
+# Lower rate is causing view to get blocked, causing test case failure.
+REST_FRAMEWORK['DEFAULT_THROTTLE_RATES']['registration_validation'] = '100/minute'
+
 ########################## VIDEO TRANSCRIPTS STORAGE ############################
 VIDEO_TRANSCRIPTS_SETTINGS = dict(
     VIDEO_TRANSCRIPTS_MAX_BYTES=3 * 1024 * 1024,    # 3 MB


### PR DESCRIPTION
This patch would ratelimit registration form validation
endpoint for anonymous user based on his/her ip.

LEARNER-3810