### PR TITLE
Remove unused pytest markers for Django 1.11 upgrade

### DIFF
--- a/common/djangoapps/util/tests/test_db.py
+++ b/common/djangoapps/util/tests/test_db.py
@@ -217,7 +217,6 @@ class GenerateIntIdTestCase(TestCase):
             self.assertIn(int_id, list(set(range(minimum, maximum + 1)) - used_ids))
 
 
-@pytest.mark.django111_expected_failure
 class MigrationTests(TestCase):
     """
     Tests for migrations.

--- a/lms/djangoapps/badges/tests/test_models.py
+++ b/lms/djangoapps/badges/tests/test_models.py
@@ -43,7 +43,6 @@ class BadgeImageConfigurationTest(TestCase):
         tmp_path = Path(TEST_DATA_ROOT / 'course_complete_badges')
         Path.rmtree_p(tmp_path)
 
-    @pytest.mark.django111_expected_failure
     def test_no_double_default(self):
         """
         Verify that creating two configurations as default is not permitted.

--- a/lms/djangoapps/certificates/tests/test_cert_management.py
+++ b/lms/djangoapps/certificates/tests/test_cert_management.py
@@ -139,7 +139,6 @@ class ResubmitErrorCertificatesTest(CertificateManagementTest):
         with self.assertRaisesRegexp(CommandError, invalid_key):
             call_command(self.command, course_key_list=[invalid_key])
 
-    @pytest.mark.django111_expected_failure
     def test_course_does_not_exist(self):
         phantom_course = CourseLocator(org='phantom', course='phantom', run='phantom')
         self._create_cert(phantom_course, self.user, 'error')

--- a/lms/djangoapps/courseware/tests/test_lti_integration.py
+++ b/lms/djangoapps/courseware/tests/test_lti_integration.py
@@ -190,7 +190,6 @@ class TestLTIModuleListing(SharedModuleStoreTestCase):
             response = self.client.get(lti_rest_endpoints_url)
             self.assertEqual(404, response.status_code)
 
-    @pytest.mark.django111_expected_failure
     def test_lti_rest_listing(self):
         """tests that the draft lti module is part of the endpoint response"""
         request = mock.Mock()

--- a/lms/djangoapps/courseware/tests/test_microsites.py
+++ b/lms/djangoapps/courseware/tests/test_microsites.py
@@ -136,7 +136,6 @@ class TestSites(SharedModuleStoreTestCase, LoginEnrollmentTestCase):
         self.assertNotContains(resp, 'This is a Test Site footer')
 
     @override_settings(SITE_NAME=settings.MICROSITE_TEST_HOSTNAME)
-    @pytest.mark.django111_expected_failure
     def test_site_homepage_course_max(self):
         """
         Verify that the number of courses displayed on the homepage honors

--- a/lms/djangoapps/courseware/tests/test_module_render.py
+++ b/lms/djangoapps/courseware/tests/test_module_render.py
@@ -241,7 +241,6 @@ class ModuleRenderTestCase(SharedModuleStoreTestCase, LoginEnrollmentTestCase):
         # note if the URL mapping changes then this assertion will break
         self.assertIn('/courses/' + text_type(self.course_key) + '/jump_to_id/vertical_test', html)
 
-    @pytest.mark.django111_expected_failure
     def test_xqueue_callback_success(self):
         """
         Test for happy-path xqueue_callback

--- a/lms/djangoapps/courseware/tests/test_tabs.py
+++ b/lms/djangoapps/courseware/tests/test_tabs.py
@@ -693,7 +693,6 @@ class CourseTabListTestCase(TabListTestCase):
             # get tab by id
             self.assertEquals(xmodule_tabs.CourseTabList.get_tab_by_id(self.course.tabs, tab.tab_id), tab)
 
-    @pytest.mark.django111_expected_failure
     def test_course_tabs_staff_only(self):
         """
         Tests the static tabs that available only for instructor
@@ -725,7 +724,6 @@ class CourseTabListTestCase(TabListTestCase):
 
 
 @attr(shard=1)
-@pytest.mark.django111_expected_failure
 class ProgressTestCase(TabTestCase):
     """Test cases for Progress Tab."""
 
@@ -756,7 +754,6 @@ class ProgressTestCase(TabTestCase):
 
 
 @attr(shard=1)
-@pytest.mark.django111_expected_failure
 class StaticTabTestCase(TabTestCase):
     """Test cases for Static Tab."""
 
@@ -776,7 +773,6 @@ class StaticTabTestCase(TabTestCase):
 
 
 @attr(shard=1)
-@pytest.mark.django111_expected_failure
 class CourseInfoTabTestCase(TabTestCase):
     """Test cases for the course info tab."""
     def setUp(self):
@@ -805,7 +801,6 @@ class CourseInfoTabTestCase(TabTestCase):
 
 
 @attr(shard=1)
-@pytest.mark.django111_expected_failure
 class DiscussionLinkTestCase(TabTestCase):
     """Test cases for discussion link tab."""
 

--- a/lms/djangoapps/django_comment_client/base/tests.py
+++ b/lms/djangoapps/django_comment_client/base/tests.py
@@ -77,7 +77,6 @@ class MockRequestSetupMixin(object):
 
 @attr(shard=2)
 @patch('lms.lib.comment_client.utils.requests.request', autospec=True)
-@pytest.mark.django111_expected_failure
 class CreateThreadGroupIdTestCase(
         MockRequestSetupMixin,
         CohortedTestCase,
@@ -498,7 +497,6 @@ class ViewsTestCase(
         with self.assert_discussion_signals('thread_created'):
             self.create_thread_helper(mock_request)
 
-    @pytest.mark.django111_expected_failure
     def test_create_thread_standalone(self, mock_request):
         team = CourseTeamFactory.create(
             name="A Team",
@@ -1412,7 +1410,6 @@ class CreateSubCommentUnicodeTestCase(
 @disable_signal(views, 'comment_created')
 @disable_signal(views, 'comment_voted')
 @disable_signal(views, 'comment_deleted')
-@pytest.mark.django111_expected_failure
 class TeamsPermissionsTestCase(ForumsEnableMixin, UrlResetMixin, SharedModuleStoreTestCase, MockRequestSetupMixin):
     # Most of the test points use the same ddt data.
     # args: user, commentable_id, status_code
@@ -1879,7 +1876,6 @@ class ForumEventTestCase(ForumsEnableMixin, SharedModuleStoreTestCase, MockReque
         {'comment_id': 'dummy_comment_id'}
     ))
     @ddt.unpack
-    @pytest.mark.django111_expected_failure
     def test_team_events(self, view_name, event_name, view_data, view_kwargs, mock_request, mock_emit):
         user = self.student
         team = CourseTeamFactory.create(discussion_topic_id=TEAM_COMMENTABLE_ID)

--- a/lms/djangoapps/django_comment_client/tests/test_utils.py
+++ b/lms/djangoapps/django_comment_client/tests/test_utils.py
@@ -68,7 +68,6 @@ class DictionaryTestCase(TestCase):
 
 
 @attr(shard=1)
-@pytest.mark.django111_expected_failure
 class AccessUtilsTestCase(ModuleStoreTestCase):
     """
     Base testcase class for access and roles for the

--- a/lms/djangoapps/lti_provider/tests/test_views.py
+++ b/lms/djangoapps/lti_provider/tests/test_views.py
@@ -182,7 +182,6 @@ class LtiLaunchTest(LtiTestMixin, TestCase):
 
 
 @attr(shard=3)
-@pytest.mark.django111_expected_failure
 class LtiLaunchTestRender(LtiTestMixin, RenderXBlockTestMixin, ModuleStoreTestCase):
     """
     Tests for the rendering returned by lti_launch view.

--- a/lms/djangoapps/student_account/test/test_views.py
+++ b/lms/djangoapps/student_account/test/test_views.py
@@ -598,7 +598,6 @@ class StudentAccountLoginAndRegistrationTest(ThirdPartyAuthTestMixin, UrlResetMi
         ('register_user', 'register'),
     )
     @ddt.unpack
-    @pytest.mark.django111_expected_failure
     def test_hinted_login_dialog_disabled(self, url_name, auth_entry):
         """Test that the dialog doesn't show up for hinted logins when disabled. """
         self.google_provider.skip_hinted_login_dialog = True
@@ -642,7 +641,6 @@ class StudentAccountLoginAndRegistrationTest(ThirdPartyAuthTestMixin, UrlResetMi
         ('register_user', 'register'),
     )
     @ddt.unpack
-    @pytest.mark.django111_expected_failure
     def test_settings_tpa_hinted_login_dialog_disabled(self, url_name, auth_entry):
         """Test that the dialog doesn't show up for hinted logins when disabled via settings.THIRD_PARTY_AUTH_HINT. """
         self.google_provider.skip_hinted_login_dialog = True

--- a/lms/djangoapps/support/tests/test_views.py
+++ b/lms/djangoapps/support/tests/test_views.py
@@ -115,7 +115,6 @@ class SupportViewAccessTests(SupportViewTestCase):
         ))
     ))
     @ddt.unpack
-    @pytest.mark.django111_expected_failure
     def test_access(self, url_name, role, has_access):
         if role is not None:
             role().add_users(self.user)

--- a/lms/djangoapps/teams/tests/test_views.py
+++ b/lms/djangoapps/teams/tests/test_views.py
@@ -5,7 +5,6 @@ import unittest
 from datetime import datetime
 
 import ddt
-import pytest
 import pytz
 from dateutil import parser
 from django.conf import settings
@@ -81,7 +80,6 @@ class TestDashboard(SharedModuleStoreTestCase):
         response = self.client.get(self.teams_url)
         self.assertEqual(404, response.status_code)
 
-    @pytest.mark.django111_expected_failure
     def test_not_enrolled_staff(self):
         """
         Verifies that a user with global access who is not enrolled in the course can access the team dashboard.
@@ -92,7 +90,6 @@ class TestDashboard(SharedModuleStoreTestCase):
         response = staff_client.get(self.teams_url)
         self.assertContains(response, "TeamsTabFactory", status_code=200)
 
-    @pytest.mark.django111_expected_failure
     def test_enrolled_not_staff(self):
         """
         Verifies that a user without global access who is enrolled in the course can access the team dashboard.

--- a/openedx/core/djangoapps/bookmarks/tests/test_api.py
+++ b/openedx/core/djangoapps/bookmarks/tests/test_api.py
@@ -2,7 +2,6 @@
 Tests for bookmarks api.
 """
 import ddt
-import pytest
 from mock import patch
 from nose.plugins.attrib import attr
 
@@ -40,7 +39,6 @@ class BookmarkApiEventTestMixin(object):
 @attr(shard=9)
 @ddt.ddt
 @skip_unless_lms
-@pytest.mark.django111_expected_failure
 class BookmarksAPITests(BookmarkApiEventTestMixin, BookmarksTestsBase):
     """
     These tests cover the parts of the API methods.

--- a/openedx/core/djangoapps/bookmarks/tests/test_models.py
+++ b/openedx/core/djangoapps/bookmarks/tests/test_models.py
@@ -6,7 +6,6 @@ from contextlib import contextmanager
 
 import ddt
 import mock
-import pytest
 import pytz
 from freezegun import freeze_time
 from nose.plugins.attrib import attr
@@ -265,7 +264,6 @@ class BookmarkModelTests(BookmarksTestsBase):
         (ModuleStoreEnum.Type.split, 'html_1', ['chapter_1', 'sequential_2', 'vertical_2'], 2),
     )
     @ddt.unpack
-    @pytest.mark.django111_expected_failure
     def test_path_and_queries_on_create(self, store_type, block_to_bookmark, ancestors_attrs, expected_mongo_calls):
         """
         In case of mongo, 1 query is used to fetch the block, and 2
@@ -289,7 +287,6 @@ class BookmarkModelTests(BookmarksTestsBase):
         self.assertIsNotNone(bookmark.xblock_cache)
         self.assertEqual(bookmark.xblock_cache.paths, [])
 
-    @pytest.mark.django111_expected_failure
     def test_create_bookmark_success(self):
         """
         Tests creation of bookmark.
@@ -312,7 +309,6 @@ class BookmarkModelTests(BookmarksTestsBase):
         self.assertNotEqual(bookmark, bookmark3)
         self.assert_bookmark_model_is_valid(bookmark3, bookmark_data_different_user)
 
-    @pytest.mark.django111_expected_failure
     def test_create_bookmark_successfully_with_display_name_none(self):
         """
         Tests creation of bookmark with display_name None.
@@ -331,7 +327,6 @@ class BookmarkModelTests(BookmarksTestsBase):
     )
     @ddt.unpack
     @mock.patch('openedx.core.djangoapps.bookmarks.models.Bookmark.get_path')
-    @pytest.mark.django111_expected_failure
     def test_path(self, seconds_delta, paths, get_path_call_count, mock_get_path):
 
         block_path = [PathItem(UsageKey.from_string(EXAMPLE_USAGE_KEY_1), '1')]
@@ -369,7 +364,6 @@ class BookmarkModelTests(BookmarksTestsBase):
         (ModuleStoreEnum.Type.split, 2, 4, 2),
     )
     @ddt.unpack
-    @pytest.mark.django111_expected_failure
     def test_get_path_queries(self, store_type, children_per_block, depth, expected_mongo_calls):
         """
         In case of mongo, 2 queries are used by path_to_location(), and then
@@ -388,7 +382,6 @@ class BookmarkModelTests(BookmarksTestsBase):
             path = Bookmark.get_path(block.location)
             self.assertEqual(len(path), depth - 2)
 
-    @pytest.mark.django111_expected_failure
     def test_get_path_in_case_of_exceptions(self):
 
         user = UserFactory.create()

--- a/openedx/core/djangoapps/bookmarks/tests/test_services.py
+++ b/openedx/core/djangoapps/bookmarks/tests/test_services.py
@@ -2,7 +2,6 @@
 Tests for bookmark services.
 """
 
-import pytest
 from nose.plugins.attrib import attr
 from opaque_keys.edx.keys import UsageKey
 
@@ -13,7 +12,6 @@ from .test_models import BookmarksTestsBase
 
 @attr(shard=9)
 @skip_unless_lms
-@pytest.mark.django111_expected_failure
 class BookmarksServiceTests(BookmarksTestsBase):
     """
     Tests the Bookmarks service.

--- a/openedx/core/djangoapps/bookmarks/tests/test_tasks.py
+++ b/openedx/core/djangoapps/bookmarks/tests/test_tasks.py
@@ -2,7 +2,6 @@
 Tests for tasks.
 """
 import ddt
-import pytest
 from nose.plugins.attrib import attr
 
 from xmodule.modulestore import ModuleStoreEnum
@@ -14,7 +13,6 @@ from .test_models import BookmarksTestsBase
 
 @attr(shard=9)
 @ddt.ddt
-@pytest.mark.django111_expected_failure
 class XBlockCacheTaskTests(BookmarksTestsBase):
     """
     Test the XBlockCache model.

--- a/openedx/core/djangoapps/bookmarks/tests/test_views.py
+++ b/openedx/core/djangoapps/bookmarks/tests/test_views.py
@@ -5,7 +5,6 @@ import json
 import urllib
 
 import ddt
-import pytest
 from django.conf import settings
 from django.core.urlresolvers import reverse
 from mock import patch
@@ -66,7 +65,6 @@ class BookmarksViewsTestsBase(BookmarksTestsBase, BookmarkApiEventTestMixin):
 @attr(shard=9)
 @ddt.ddt
 @skip_unless_lms
-@pytest.mark.django111_expected_failure
 class BookmarksListViewTests(BookmarksViewsTestsBase):
     """
     This contains the tests for GET & POST methods of bookmark.views.BookmarksListView class
@@ -372,7 +370,6 @@ class BookmarksListViewTests(BookmarksViewsTestsBase):
 @attr(shard=9)
 @ddt.ddt
 @skip_unless_lms
-@pytest.mark.django111_expected_failure
 class BookmarksDetailViewTests(BookmarksViewsTestsBase):
     """
     This contains the tests for GET & DELETE methods of bookmark.views.BookmarksDetailView class

--- a/openedx/core/djangoapps/credit/tests/test_api.py
+++ b/openedx/core/djangoapps/credit/tests/test_api.py
@@ -7,7 +7,6 @@ import json
 import ddt
 import httpretty
 import mock
-import pytest
 import pytz
 from django.contrib.auth.models import User
 from django.core import mail
@@ -206,7 +205,6 @@ class CreditApiTestBase(ModuleStoreTestCase):
 @attr(shard=2)
 @skip_unless_lms
 @ddt.ddt
-@pytest.mark.django111_expected_failure
 class CreditRequirementApiTests(CreditApiTestBase):
     """
     Test Python API for credit requirements and eligibility.

--- a/openedx/core/djangoapps/programs/tests/test_utils.py
+++ b/openedx/core/djangoapps/programs/tests/test_utils.py
@@ -8,7 +8,6 @@ from copy import deepcopy
 import ddt
 import httpretty
 import mock
-import pytest
 from django.conf import settings
 from django.core.urlresolvers import reverse
 from django.test import TestCase
@@ -55,7 +54,6 @@ UTILS_MODULE = 'openedx.core.djangoapps.programs.utils'
 @attr(shard=2)
 @skip_unless_lms
 @mock.patch(UTILS_MODULE + '.get_programs')
-@pytest.mark.django111_expected_failure
 class TestProgramProgressMeter(TestCase):
     """Tests of the program progress utility class."""
     def setUp(self):

--- a/openedx/core/djangoapps/user_api/accounts/tests/test_views.py
+++ b/openedx/core/djangoapps/user_api/accounts/tests/test_views.py
@@ -31,7 +31,6 @@ from integrated_channels.sap_success_factors.models import (
 import mock
 from nose.plugins.attrib import attr
 from opaque_keys.edx.keys import CourseKey
-import pytest
 import pytz
 from rest_framework import status
 from rest_framework.test import APIClient, APITestCase
@@ -352,7 +351,6 @@ class TestAccountsAPI(CacheIsolationTestCase, UserAPITestCase):
     # This is needed when testing CMS as the patching is still executed even though the
     # suite is skipped.
     @mock.patch.dict(getattr(settings, "ACCOUNT_VISIBILITY_CONFIGURATION", {}), {"default_visibility": "all_users"})
-    @pytest.mark.django111_expected_failure
     def test_get_account_different_user_visible(self):
         """
         Test that a client (logged in) can only get the shareable fields for a different user.
@@ -368,7 +366,6 @@ class TestAccountsAPI(CacheIsolationTestCase, UserAPITestCase):
     # This is needed when testing CMS as the patching is still executed even though the
     # suite is skipped.
     @mock.patch.dict(getattr(settings, "ACCOUNT_VISIBILITY_CONFIGURATION", {}), {"default_visibility": "private"})
-    @pytest.mark.django111_expected_failure
     def test_get_account_different_user_private(self):
         """
         Test that a client (logged in) can only get the shareable fields for a different user.
@@ -390,7 +387,6 @@ class TestAccountsAPI(CacheIsolationTestCase, UserAPITestCase):
         ("staff_client", "staff_user", ALL_USERS_VISIBILITY),
     )
     @ddt.unpack
-    @pytest.mark.django111_expected_failure
     def test_get_account_private_visibility(self, api_client, requesting_username, preference_visibility):
         """
         Test the return from GET based on user visibility setting.
@@ -669,7 +665,6 @@ class TestAccountsAPI(CacheIsolationTestCase, UserAPITestCase):
         {'full': 50, 'medium': 30, 'small': 10},
         clear=True
     )
-    @pytest.mark.django111_expected_failure
     def test_patch_email(self):
         """
         Test that the user can request an email change through the accounts API.

--- a/openedx/core/lib/api/tests/test_authentication.py
+++ b/openedx/core/lib/api/tests/test_authentication.py
@@ -12,7 +12,6 @@ from collections import namedtuple
 from datetime import timedelta
 
 import ddt
-import pytest
 from django.conf import settings
 from django.conf.urls import include, url
 from django.contrib.auth.models import User
@@ -77,7 +76,6 @@ urlpatterns = [
 @attr(shard=2)
 @ddt.ddt
 @unittest.skipUnless(settings.FEATURES.get("ENABLE_OAUTH2_PROVIDER"), "OAuth2 not enabled")
-@pytest.mark.django111_expected_failure
 @override_settings(ROOT_URLCONF=__name__)
 class OAuth2Tests(TestCase):
     """OAuth 2.0 authentication"""


### PR DESCRIPTION
PLAT-1880 - we added these marks to help with the 1.11 upgrade, but found a better testing solution and never actually used them.