### PR TITLE
Remove SessionAuthenticationMiddleware from INSTALLED_APPS

### DIFF
--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -491,9 +491,6 @@ MIDDLEWARE_CLASSES = [
 
     # Instead of AuthenticationMiddleware, we use a cache-backed version
     'openedx.core.djangoapps.cache_toolbox.middleware.CacheBackedAuthenticationMiddleware',
-    # Enable SessionAuthenticationMiddleware in order to invalidate
-    # user sessions after a password change.
-    'django.contrib.auth.middleware.SessionAuthenticationMiddleware',
 
     'student.middleware.UserStandingMiddleware',
     'openedx.core.djangoapps.contentserver.middleware.StaticContentServer',

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -1246,9 +1246,6 @@ MIDDLEWARE_CLASSES = [
     # Instead of AuthenticationMiddleware, we use a cached backed version
     #'django.contrib.auth.middleware.AuthenticationMiddleware',
     'openedx.core.djangoapps.cache_toolbox.middleware.CacheBackedAuthenticationMiddleware',
-    # Enable SessionAuthenticationMiddleware in order to invalidate
-    # user sessions after a password change.
-    'django.contrib.auth.middleware.SessionAuthenticationMiddleware',
 
     'student.middleware.UserStandingMiddleware',
     'openedx.core.djangoapps.contentserver.middleware.StaticContentServer',

--- a/openedx/core/djangoapps/cache_toolbox/middleware.py
+++ b/openedx/core/djangoapps/cache_toolbox/middleware.py
@@ -120,19 +120,15 @@ class CacheBackedAuthenticationMiddleware(AuthenticationMiddleware):
 
     def _verify_session_auth(self, request):
         """
-        Ensure that the user's session hash hasn't changed. We check that
-        SessionAuthenticationMiddleware is enabled in order to match Django's
-        behavior.
+        Ensure that the user's session hash hasn't changed.
         """
-        session_auth_class = 'django.contrib.auth.middleware.SessionAuthenticationMiddleware'
-        session_auth_enabled = session_auth_class in settings.MIDDLEWARE_CLASSES
         # Auto-auth causes issues in Bok Choy tests because it resets
         # the requesting user. Since session verification is a
         # security feature, we can turn it off when auto-auth is
         # enabled since auto-auth is highly insecure and only for
         # tests.
         auto_auth_enabled = settings.FEATURES.get('AUTOMATIC_AUTH_FOR_TESTING', False)
-        if not auto_auth_enabled and session_auth_enabled and hasattr(request.user, 'get_session_auth_hash'):
+        if not auto_auth_enabled and hasattr(request.user, 'get_session_auth_hash'):
             session_hash = request.session.get(HASH_SESSION_KEY)
             if not (session_hash and constant_time_compare(session_hash, request.user.get_session_auth_hash())):
                 # The session hash has changed due to a password


### PR DESCRIPTION
PLAT-1425 - It is always on since Django 1.10 and this is just a deprecated stub which will be removed in Django 2.0. See https://docs.djangoproject.com/en/1.11/releases/1.10/#features-removed-in-1-10 