### PR TITLE
Upgrade edx-ora2 to 2.1.17

### DIFF
--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -25,7 +25,7 @@ git+https://github.com/mitodl/edx-sga.git@6b2f7aa2a18206023c8407e2c46f86d4b4c3ac
 git+https://github.com/edx/xblock-lti-consumer.git@v1.1.8#egg=lti_consumer-xblock==1.1.8
 git+https://github.com/edx/MongoDBProxy.git@25b99097615bda06bd7cdfe5669ed80dc2a7fed0#egg=MongoDBProxy==0.1.0
 -e .
-git+https://github.com/edx/edx-ora2.git@2.1.16#egg=ora2==2.1.16
+git+https://github.com/edx/edx-ora2.git@2.1.17#egg=ora2==2.1.17
 -e git+https://github.com/dgrtwo/ParsePy.git@7949b9f754d1445eff8e8f20d0e967b9a6420639#egg=parse_rest
 -e git+https://github.com/appliedsec/pygeoip.git@95e69341cebf5a6a9fbf7c4f5439d458898bdc3b#egg=pygeoip
 -e git+https://github.com/dementrock/pystache_custom.git@776973740bdaad83a3b029f96e415a7d1e8bec2f#egg=pystache_custom-dev

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -28,7 +28,7 @@ git+https://github.com/edx/lettuce.git@7a04591c78ac56dac3eb3e91ca94b15cce844133#
 git+https://github.com/edx/xblock-lti-consumer.git@v1.1.8#egg=lti_consumer-xblock==1.1.8
 git+https://github.com/edx/MongoDBProxy.git@25b99097615bda06bd7cdfe5669ed80dc2a7fed0#egg=MongoDBProxy==0.1.0
 -e .
-git+https://github.com/edx/edx-ora2.git@2.1.16#egg=ora2==2.1.16
+git+https://github.com/edx/edx-ora2.git@2.1.17#egg=ora2==2.1.17
 -e git+https://github.com/dgrtwo/ParsePy.git@7949b9f754d1445eff8e8f20d0e967b9a6420639#egg=parse_rest
 -e git+https://github.com/appliedsec/pygeoip.git@95e69341cebf5a6a9fbf7c4f5439d458898bdc3b#egg=pygeoip
 -e git+https://github.com/dementrock/pystache_custom.git@776973740bdaad83a3b029f96e415a7d1e8bec2f#egg=pystache_custom-dev

--- a/requirements/edx/github.in
+++ b/requirements/edx/github.in
@@ -89,7 +89,7 @@
 # Our libraries:
 -e git+https://github.com/edx/codejail.git@a320d43ce6b9c93b17636b2491f724d9e433be47#egg=codejail
 -e git+https://github.com/edx/acid-block.git@e46f9cda8a03e121a00c7e347084d142d22ebfb7#egg=acid-xblock
--e git+https://github.com/edx/edx-ora2.git@2.1.16#egg=ora2==2.1.16
+-e git+https://github.com/edx/edx-ora2.git@2.1.17#egg=ora2==2.1.17
 -e git+https://github.com/edx/RecommenderXBlock.git@1.3#egg=recommender-xblock==1.3
 -e git+https://github.com/solashirai/crowdsourcehinter.git@518605f0a95190949fe77bd39158450639e2e1dc#egg=crowdsourcehinter-xblock==0.1
 -e git+https://github.com/edx/RateXBlock.git@367e19c0f6eac8a5f002fd0f1559555f8e74bfff#egg=rate-xblock

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -26,7 +26,7 @@ git+https://github.com/edx/lettuce.git@7a04591c78ac56dac3eb3e91ca94b15cce844133#
 git+https://github.com/edx/xblock-lti-consumer.git@v1.1.8#egg=lti_consumer-xblock==1.1.8
 git+https://github.com/edx/MongoDBProxy.git@25b99097615bda06bd7cdfe5669ed80dc2a7fed0#egg=MongoDBProxy==0.1.0
 -e .
-git+https://github.com/edx/edx-ora2.git@2.1.16#egg=ora2==2.1.16
+git+https://github.com/edx/edx-ora2.git@2.1.17#egg=ora2==2.1.17
 -e git+https://github.com/dgrtwo/ParsePy.git@7949b9f754d1445eff8e8f20d0e967b9a6420639#egg=parse_rest
 -e git+https://github.com/appliedsec/pygeoip.git@95e69341cebf5a6a9fbf7c4f5439d458898bdc3b#egg=pygeoip
 -e git+https://github.com/dementrock/pystache_custom.git@776973740bdaad83a3b029f96e415a7d1e8bec2f#egg=pystache_custom-dev


### PR DESCRIPTION
Contains i18n updates, addresses [EDUCATOR-2685](https://openedx.atlassian.net/browse/EDUCATOR-2685)

[diff of changes included](https://github.com/edx/edx-ora2/compare/2.1.16...2.1.17)