### PR TITLE
PLAT-1746: Use Django 1.11 format_lazy instead of allow_lazy

### DIFF
--- a/openedx/core/djangoapps/user_api/accounts/__init__.py
+++ b/openedx/core/djangoapps/user_api/accounts/__init__.py
@@ -2,12 +2,8 @@
 Account constants
 """
 
+from django.utils.text import format_lazy
 from django.utils.translation import ugettext_lazy as _
-
-# In Django 1.11, there's django.utils.text.format_lazy.
-from django.utils.functional import allow_lazy
-
-format_lazy = allow_lazy(lambda s, *a, **kw: s.format(*a, **kw), unicode)
 
 
 # The minimum and maximum length for the name ("full name") account field


### PR DESCRIPTION
Looks like this is the only place in the platform that uses `allow_lazy`.

See: https://github.com/edx/edx-platform/pull/16100