### PR TITLE
Change usages of is_safe_url to use new allowed_hosts instead of host

### DIFF
--- a/common/djangoapps/student/helpers.py
+++ b/common/djangoapps/student/helpers.py
@@ -330,7 +330,7 @@ def get_redirect_to(request):
     # get information about a user on edx.org. In any such case drop the parameter.
     if redirect_to:
         mime_type, _ = mimetypes.guess_type(redirect_to, strict=False)
-        if not http.is_safe_url(redirect_to, host=request.get_host()):
+        if not http.is_safe_url(redirect_to, allowed_hosts={request.get_host()}):
             log.warning(
                 u'Unsafe redirect parameter detected after login page: %(redirect_to)r',
                 {"redirect_to": redirect_to}

--- a/common/djangoapps/student/views/login.py
+++ b/common/djangoapps/student/views/login.py
@@ -747,7 +747,7 @@ class LogoutView(TemplateView):
         """
         target_url = self.request.GET.get('redirect_url')
 
-        if target_url and is_safe_url(target_url, self.request.META.get('HTTP_HOST')):
+        if target_url and is_safe_url(target_url, allowed_hosts={self.request.META.get('HTTP_HOST')}):
             return target_url
         else:
             return self.default_target

--- a/openedx/core/djangoapps/external_auth/views.py
+++ b/openedx/core/djangoapps/external_auth/views.py
@@ -556,7 +556,7 @@ def _safe_postlogin_redirect(redirect_to, safehost, default_redirect='/'):
     @param safehost: which host is safe to redirect to
     @return: an HttpResponseRedirect
     """
-    if is_safe_url(url=redirect_to, host=safehost):
+    if is_safe_url(url=redirect_to, allowed_hosts={safehost}):
         return redirect(redirect_to)
     return redirect(default_redirect)
 


### PR DESCRIPTION
"host" parameter is deprecated and throws a warning