### PR TITLE
Fixes for courseware anonymous access.

### DIFF
--- a/common/lib/xmodule/xmodule/js/src/sequence/display.js
+++ b/common/lib/xmodule/xmodule/js/src/sequence/display.js
@@ -57,6 +57,8 @@
             this.ajaxUrl = this.el.data('ajax-url');
             this.nextUrl = this.el.data('next-url');
             this.prevUrl = this.el.data('prev-url');
+            this.savePosition = this.el.data('save-position');
+            this.showCompletion = this.el.data('show-completion');
             this.keydownHandler($(element).find('#sequence-list .tab'));
             this.base_page_title = ($('title').data('base-title') || '').trim();
             this.bind();
@@ -230,11 +232,15 @@
             if (this.position !== newPosition) {
                 if (this.position) {
                     this.mark_visited(this.position);
-                    this.update_completion(this.position);
-                    modxFullUrl = '' + this.ajaxUrl + '/goto_position';
-                    $.postWithPrefix(modxFullUrl, {
-                        position: newPosition
-                    });
+                    if (this.showCompletion) {
+                      this.update_completion(this.position);
+                    }
+                    if (this.savePosition) {
+                      modxFullUrl = '' + this.ajaxUrl + '/goto_position';
+                      $.postWithPrefix(modxFullUrl, {
+                          position: newPosition
+                      });
+                    }
                 }
 
                 // On Sequence change, fire custom event 'sequence:change' on element.

--- a/common/lib/xmodule/xmodule/seq_module.py
+++ b/common/lib/xmodule/xmodule/seq_module.py
@@ -330,7 +330,8 @@ class SequenceModule(SequenceFields, ProctoringFields, XModule):
             'next_url': context.get('next_url'),
             'prev_url': context.get('prev_url'),
             'banner_text': banner_text,
-            'disable_navigation': not self.is_user_authenticated(context),
+            'save_position': self.is_user_authenticated(context),
+            'show_completion': self.is_user_authenticated(context),
             'gated_content': self._get_gated_content_info(prereq_met, prereq_meta_info)
         }
         fragment.add_content(self.system.render_template("seq_module.html", params))

--- a/lms/djangoapps/courseware/tests/test_views.py
+++ b/lms/djangoapps/courseware/tests/test_views.py
@@ -2334,6 +2334,7 @@ class TestIndexView(ModuleStoreTestCase):
         with self.store.bulk_operations(course.id):
             chapter = ItemFactory(parent=course, category='chapter')
             section = ItemFactory(parent=chapter, category='sequential')
+            ItemFactory.create(parent=section, category='vertical', display_name="Vertical")
 
         url = reverse(
             'courseware_section',
@@ -2350,6 +2351,16 @@ class TestIndexView(ModuleStoreTestCase):
         with override_waffle_flag(waffle_flag, active=True):
             response = self.client.get(url, follow=False)
             assert response.status_code == 200
+            self.assertIn('data-save-position="false"', response.content)
+            self.assertIn('data-show-completion="false"', response.content)
+
+        user = UserFactory()
+        CourseEnrollmentFactory(user=user, course_id=course.id)
+        self.assertTrue(self.client.login(username=user.username, password='test'))
+        response = self.client.get(url, follow=False)
+        assert response.status_code == 200
+        self.assertIn('data-save-position="true"', response.content)
+        self.assertIn('data-show-completion="true"', response.content)
 
 
 @attr(shard=5)

--- a/lms/templates/seq_module.html
+++ b/lms/templates/seq_module.html
@@ -1,7 +1,12 @@
 <%page expression_filter="h"/>
 <%! from django.utils.translation import ugettext as _ %>
 
-<div id="sequence_${element_id}" class="sequence" data-id="${item_id}" data-position="${position}" data-ajax-url="${ajax_url}" data-next-url="${next_url}" data-prev-url="${prev_url}">
+<div id="sequence_${element_id}" class="sequence" data-id="${item_id}"
+     data-position="${position}" data-ajax-url="${ajax_url}"
+     data-next-url="${next_url}" data-prev-url="${prev_url}"
+     data-save-position="${'true' if save_position else 'false'}"
+     data-show-completion="${'true' if show_completion else 'false'}"
+>
   % if banner_text:
     <div class="pattern-library-shim alert alert-information subsection-header" tabindex="-1">
       <span class="pattern-library-shim icon alert-icon fa fa-info-circle" aria-hidden="true"></span>
@@ -46,8 +51,7 @@
             data-page-title="${item['page_title']}"
             data-path="${item['path']}"
             data-graded="${item['graded']}"
-            id="tab_${idx}"
-            ${"disabled=disabled" if disable_navigation else ""}>
+            id="tab_${idx}">
             <span class="icon fa seq_${item['type']}" aria-hidden="true"></span>
             % if 'complete' in item:
               <span 


### PR DESCRIPTION
https://github.com/edx/edx-platform/pull/16315 added the ability to allow anonymous access to courseware. This PR makes small adjustments to the functionality:

- The section tabs are no longer disabled. It was already possible to switch tabs with the arrows so no point in disabling them.
- The front-end no longer tries to save the tab the learner is on or to fetch completion status of the unit when switching between units since those are only applicable to logged in users and cause a "Please login" message to pop up.

Note that currently only HTML blocks work correctly with anonymous access.

**JIRA tickets**: [OSPR-2462](https://openedx.atlassian.net/browse/OSPR-2462)

**Screenshots**: N/A

**Merge deadline**: None

**Sandbox**: https://pr18344.sandbox.opencraft.hosting/courses/course-v1:edX+DemoX+Demo_Course/courseware/interactive_demonstrations/

**Reviewers**
- [ ] @xitij2000 
- [ ] edX reviewer[s] TBD
