### PR TITLE
Change waffle flag for enrollment throttle to switch

### DIFF
--- a/common/djangoapps/enrollment/__init__.py
+++ b/common/djangoapps/enrollment/__init__.py
@@ -1,10 +1,10 @@
 """
 Enrollment API helpers and settings
 """
-from openedx.core.djangoapps.waffle_utils import (WaffleFlag, WaffleFlagNamespace)
+from openedx.core.djangoapps.waffle_utils import (WaffleSwitch, WaffleSwitchNamespace)
 
-WAFFLE_FLAG_NAMESPACE = WaffleFlagNamespace(name='enrollment_api_rate_limit')
+WAFFLE_SWITCH_NAMESPACE = WaffleSwitchNamespace(name='enrollment_api_rate_limit')
 
-USE_RATE_LIMIT_400_FOR_STAFF_FOR_ENROLLMENT_API = WaffleFlag(WAFFLE_FLAG_NAMESPACE, 'staff_rate_limit_400')
-USE_RATE_LIMIT_100_FOR_STAFF_FOR_ENROLLMENT_API = WaffleFlag(WAFFLE_FLAG_NAMESPACE, 'staff_rate_limit_100')
-USE_RATE_LIMIT_40_FOR_ENROLLMENT_API = WaffleFlag(WAFFLE_FLAG_NAMESPACE, 'rate_limit_40')
+USE_RATE_LIMIT_400_FOR_STAFF_FOR_ENROLLMENT_API = WaffleSwitch(WAFFLE_SWITCH_NAMESPACE, 'staff_rate_limit_400')
+USE_RATE_LIMIT_100_FOR_STAFF_FOR_ENROLLMENT_API = WaffleSwitch(WAFFLE_SWITCH_NAMESPACE, 'staff_rate_limit_100')
+USE_RATE_LIMIT_40_FOR_ENROLLMENT_API = WaffleSwitch(WAFFLE_SWITCH_NAMESPACE, 'rate_limit_40')

--- a/common/djangoapps/enrollment/views.py
+++ b/common/djangoapps/enrollment/views.py
@@ -87,28 +87,28 @@ class EnrollmentUserThrottle(UserRateThrottle, ApiKeyPermissionMixIn):
     # service. These calls are no longer made and the plan is to set the
     # rate limit back to its original state. LEARNER-5148
 
-    if USE_RATE_LIMIT_400_FOR_STAFF_FOR_ENROLLMENT_API.is_enabled():
-        THROTTLE_RATES = {
-            'user': '40/minute',
-            'staff': '400/minute',
-        }
-    elif USE_RATE_LIMIT_100_FOR_STAFF_FOR_ENROLLMENT_API.is_enabled():
-        THROTTLE_RATES = {
-            'user': '40/minute',
-            'staff': '100/minute',
-        }
-    elif USE_RATE_LIMIT_40_FOR_ENROLLMENT_API.is_enabled():
-        THROTTLE_RATES = {
-            'user': '40/minute',
-            'staff': '40/minute',
-        }
-    else:
-        THROTTLE_RATES = {
-            'user': '40/minute',
-            'staff': '2000/minute',
-        }
+    THROTTLE_RATES = {
+        'user': '40/minute',
+        'staff': '2000/minute',
+    }
 
     def allow_request(self, request, view):
+        if USE_RATE_LIMIT_400_FOR_STAFF_FOR_ENROLLMENT_API.is_enabled():
+            self.THROTTLE_RATES = {
+                'user': '40/minute',
+                'staff': '400/minute',
+            }
+        elif USE_RATE_LIMIT_100_FOR_STAFF_FOR_ENROLLMENT_API.is_enabled():
+            self.THROTTLE_RATES = {
+                'user': '40/minute',
+                'staff': '100/minute',
+            }
+        elif USE_RATE_LIMIT_40_FOR_ENROLLMENT_API.is_enabled():
+            self.THROTTLE_RATES = {
+                'user': '40/minute',
+                'staff': '40/minute',
+            }
+
         # Use a special scope for staff to allow for a separate throttle rate
         user = request.user
         if user.is_authenticated and (user.is_staff or user.is_superuser):


### PR DESCRIPTION
Change waffle flag for enrollment throttle to switch.

This also removes the warnings of trying to add a waffle flag that depends on requests to a method that isn't a request. 

https://openedx.atlassian.net/browse/LEARNER-5520