### PR TITLE
[edxnotes] use the correct url and update the API params

### DIFF
--- a/lms/djangoapps/edxnotes/helpers.py
+++ b/lms/djangoapps/edxnotes/helpers.py
@@ -131,12 +131,12 @@ def delete_all_notes_for_user(user):
     Raises:
         EdxNotesServiceUnavailable - when notes api is not found/misconfigured.
     """
-    url = get_internal_endpoint()
+    url = get_internal_endpoint('annotations')
     headers = {
         "x-annotator-auth-token": get_edxnotes_id_token(user),
     }
     data = {
-        "user_id": anonymous_id_for_user(user, None)
+        "user": anonymous_id_for_user(user, None)
     }
     try:
         response = requests.delete(

--- a/lms/djangoapps/edxnotes/tests.py
+++ b/lms/djangoapps/edxnotes/tests.py
@@ -543,12 +543,12 @@ class EdxNotesHelpersTest(ModuleStoreTestCase):
         mock_get_id_token.return_value = "test_token"
         helpers.delete_all_notes_for_user(self.user)
         mock_delete.assert_called_with(
-            url='http://example.com/',
+            url='http://example.com/annotations/',
             headers={
                 'x-annotator-auth-token': 'test_token'
             },
             data={
-                'user_id': 'anonymous_id'
+                'user': 'anonymous_id'
             },
             timeout=(settings.EDXNOTES_CONNECT_TIMEOUT, settings.EDXNOTES_READ_TIMEOUT)
         )


### PR DESCRIPTION
This is really two separate things:

1. Fix the notes retirement endpoint to generate the correct notes API
url "/api/v1/annotations/" rather than the nonexistent "/api/v1/".

2. Update the API params to use "user" rather than "user_id".  This
depends on another PR in edx/edx-notes-api to make the corresponding
change on the API side.  This is required because "user" is the
hard-coded key that the permissions class uses to check the JWT token
user.

---

Related to https://github.com/edx/edx-notes-api/pull/59

### Testing

Tested with the brand-spankin-new devstack notes service!