### PR TITLE
Add 10 seconds delay to avoid exception

### DIFF
--- a/lms/djangoapps/grades/tasks.py
+++ b/lms/djangoapps/grades/tasks.py
@@ -41,7 +41,7 @@ KNOWN_RETRY_ERRORS = (  # Errors we expect occasionally, should be resolved on r
     DatabaseNotReadyError,
 )
 RECALCULATE_GRADE_DELAY_SECONDS = 2  # to prevent excessive _has_db_updated failures. See TNL-6424.
-RETRY_DELAY_SECONDS = 30
+RETRY_DELAY_SECONDS = 40
 SUBSECTION_GRADE_TIMEOUT_SECONDS = 300
 
 


### PR DESCRIPTION
 Update the initial try delay to reduce the occurrence of this `DatabaseNotReadyError` due to replica lag.
[EDUCATOR-3004](https://openedx.atlassian.net/browse/EDUCATOR-3004)

Review: @iloveagent57 / @sanfordstudent 