### PR TITLE
Finalize rate limit for enrollment API

### DIFF
--- a/common/djangoapps/enrollment/__init__.py
+++ b/common/djangoapps/enrollment/__init__.py
@@ -1,10 +1,3 @@
 """
 Enrollment API helpers and settings
 """
-from openedx.core.djangoapps.waffle_utils import (WaffleSwitch, WaffleSwitchNamespace)
-
-WAFFLE_SWITCH_NAMESPACE = WaffleSwitchNamespace(name='enrollment_api_rate_limit')
-
-USE_RATE_LIMIT_400_FOR_STAFF_FOR_ENROLLMENT_API = WaffleSwitch(WAFFLE_SWITCH_NAMESPACE, 'staff_rate_limit_400')
-USE_RATE_LIMIT_100_FOR_STAFF_FOR_ENROLLMENT_API = WaffleSwitch(WAFFLE_SWITCH_NAMESPACE, 'staff_rate_limit_100')
-USE_RATE_LIMIT_40_FOR_ENROLLMENT_API = WaffleSwitch(WAFFLE_SWITCH_NAMESPACE, 'rate_limit_40')

--- a/common/djangoapps/enrollment/views.py
+++ b/common/djangoapps/enrollment/views.py
@@ -12,11 +12,6 @@ from django.utils.decorators import method_decorator
 from edx_rest_framework_extensions.authentication import JwtAuthentication
 from enrollment import api
 from enrollment.errors import CourseEnrollmentError, CourseEnrollmentExistsError, CourseModeNotFoundError
-from enrollment import (
-    USE_RATE_LIMIT_100_FOR_STAFF_FOR_ENROLLMENT_API,
-    USE_RATE_LIMIT_40_FOR_ENROLLMENT_API,
-    USE_RATE_LIMIT_400_FOR_STAFF_FOR_ENROLLMENT_API,
-)
 from opaque_keys import InvalidKeyError
 from opaque_keys.edx.keys import CourseKey
 
@@ -81,34 +76,14 @@ class ApiKeyPermissionMixIn(object):
 
 class EnrollmentUserThrottle(UserRateThrottle, ApiKeyPermissionMixIn):
     """Limit the number of requests users can make to the enrollment API."""
-    # TODO: After confirming that reducing the throttle is successful, remove
-    # and clean up waffles. The rate limit has been increased over the course
-    # of a few months to account for unnecessary calls from the ecommerce
-    # service. These calls are no longer made and the plan is to set the
-    # rate limit back to its original state. LEARNER-5148
 
+    # To see how the staff rate limit was selected, see https://github.com/edx/edx-platform/pull/18360
     THROTTLE_RATES = {
         'user': '40/minute',
-        'staff': '2000/minute',
+        'staff': '120/minute',
     }
 
     def allow_request(self, request, view):
-        if USE_RATE_LIMIT_400_FOR_STAFF_FOR_ENROLLMENT_API.is_enabled():
-            self.THROTTLE_RATES = {
-                'user': '40/minute',
-                'staff': '400/minute',
-            }
-        elif USE_RATE_LIMIT_100_FOR_STAFF_FOR_ENROLLMENT_API.is_enabled():
-            self.THROTTLE_RATES = {
-                'user': '40/minute',
-                'staff': '100/minute',
-            }
-        elif USE_RATE_LIMIT_40_FOR_ENROLLMENT_API.is_enabled():
-            self.THROTTLE_RATES = {
-                'user': '40/minute',
-                'staff': '40/minute',
-            }
-
         # Use a special scope for staff to allow for a separate throttle rate
         user = request.user
         if user.is_authenticated and (user.is_staff or user.is_superuser):


### PR DESCRIPTION
https://openedx.atlassian.net/browse/LEARNER-5166

1. Staff rate limit set to 400/minute. After a few hours, no notable issues observed.
2. Staff rate limit set to 100/minute. After a few hours, no notable issues observed. 
3. Staff rate limit set to 40/minute. After half a day, the spike in 429 were observed in the below. This spike also happened to line up with an unrelated outage so this may have been an anomaly. Another theory proposed was that the 429 may have been triggered by bulk enrollments. 

![screenshot from 2018-06-12 13-26-04](https://user-images.githubusercontent.com/7101723/41306445-2ed43d8c-6e44-11e8-967c-e23b09f892d3.png)
Splunk output looking for 429s on the enrollment API for the time period for steps 1-4.

4. Staff rate limit set to 100/minute after the spike settled down.

![screenshot from 2018-06-12 13-29-06](https://user-images.githubusercontent.com/7101723/41306618-aedb2004-6e44-11e8-8a8e-41b60fb90058.png)
Splunk output looking for 429s on the enrollment API for the time period after step 4.

5. This PR is finalizing the rate limit to 120/minute. Slightly higher than the settings (100/minute) in the screenshot above.

@jmyatt FYI