### PR TITLE
Campus.il - Adding sensitive data warning

### DIFF
--- a/conf/locale/ar/LC_MESSAGES/django.po
+++ b/conf/locale/ar/LC_MESSAGES/django.po
@@ -19516,6 +19516,12 @@ msgstr ""
 msgid "Show Email Task History"
 msgstr "إظهار سجل كافة مهمات البريد الإلكتروني "
 
+#: lms/templates/instructor/instructor_dashboard_2/sensitive_data_download_msg.txt
+msgid ""
+"Contains information protected under the Protection of Privacy Law - the "
+"wrongful transgressor commits an offense"
+msgstr "يحوي معلومات محمية بموجب قانون حماية الخصوصية - المخالف يعاقب"
+
 #: lms/templates/instructor/instructor_dashboard_2/set_course_mode_price_modal.html
 msgid "Set Course Mode Price"
 msgstr "تحديد سعر وضعية المساق"

--- a/conf/locale/en/LC_MESSAGES/django.po
+++ b/conf/locale/en/LC_MESSAGES/django.po
@@ -17797,6 +17797,12 @@ msgstr ""
 msgid "Show Email Task History"
 msgstr ""
 
+#: lms/templates/instructor/instructor_dashboard_2/sensitive_data_download_msg.txt
+msgid ""
+"Contains information protected under the Protection of Privacy Law - the "
+"wrongful transgressor commits an offense"
+msgstr ""
+
 #: lms/templates/instructor/instructor_dashboard_2/set_course_mode_price_modal.html
 msgid "Set Course Mode Price"
 msgstr ""

--- a/conf/locale/he/LC_MESSAGES/django.po
+++ b/conf/locale/he/LC_MESSAGES/django.po
@@ -19010,6 +19010,12 @@ msgstr ""
 msgid "Show Email Task History"
 msgstr "הראה היסטורית משימות דואר אלקטרוני "
 
+#: lms/templates/instructor/instructor_dashboard_2/sensitive_data_download_msg.txt
+msgid ""
+"Contains information protected under the Protection of Privacy Law - the "
+"wrongful transgressor commits an offense"
+msgstr "מכיל מידע מוגן לפי חוק הגנת הפרטיות - המוסר שלא כדין עובר עביר"
+
 #: lms/templates/instructor/instructor_dashboard_2/set_course_mode_price_modal.html
 msgid "Set Course Mode Price"
 msgstr "קבע מצב מחיר הקורס"

--- a/lms/djangoapps/instructor/views/api.py
+++ b/lms/djangoapps/instructor/views/api.py
@@ -80,6 +80,7 @@ from lms.djangoapps.instructor.views.instructor_task_helpers import extract_emai
 from lms.djangoapps.instructor_task.api import submit_override_score
 from lms.djangoapps.instructor_task.api_helper import AlreadyRunningError, QueueConnectionError
 from lms.djangoapps.instructor_task.models import ReportStore
+from lms.djangoapps.instructor_task.tasks_helper.utils import SensitiveMessageOnReports
 from openedx.core.djangoapps.content.course_overviews.models import CourseOverview
 from openedx.core.djangoapps.course_groups.cohorts import is_course_cohorted
 from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
@@ -1851,7 +1852,9 @@ def get_anon_ids(request, course_id):  # pylint: disable=unused-argument
         writer = csv.writer(response, dialect='excel', quotechar='"', quoting=csv.QUOTE_ALL)
         # In practice, there should not be non-ascii data in this query,
         # but trying to do the right thing anyway.
-        encoded = [text_type(s).encode('utf-8') for s in header]
+        encoded = [unicode(s).encode('utf-8') for s in header]
+        disclaimer = SensitiveMessageOnReports()
+        disclaimer.csv_direct(writer)
         writer.writerow(encoded)
         for row in rows:
             encoded = [text_type(s).encode('utf-8') for s in row]

--- a/lms/djangoapps/instructor_analytics/csvs.py
+++ b/lms/djangoapps/instructor_analytics/csvs.py
@@ -8,6 +8,8 @@ import csv
 
 from django.http import HttpResponse
 
+from lms.djangoapps.instructor_task.tasks_helper.utils import SensitiveMessageOnReports
+
 
 def create_csv_response(filename, header, datarows):
     """
@@ -27,6 +29,9 @@ def create_csv_response(filename, header, datarows):
         dialect='excel',
         quotechar='"',
         quoting=csv.QUOTE_ALL)
+
+    disclaimer = SensitiveMessageOnReports()
+    disclaimer.csv_direct(csvwriter)
 
     encoded_header = [unicode(s).encode('utf-8') for s in header]
     csvwriter.writerow(encoded_header)

--- a/lms/djangoapps/instructor_task/tasks_helper/utils.py
+++ b/lms/djangoapps/instructor_task/tasks_helper/utils.py
@@ -39,6 +39,7 @@ def upload_csv_to_report_store(rows, csv_name, course_id, timestamp, config_name
         course_prefix=course_filename_prefix_generator(course_id),
         csv_name=csv_name,
         timestamp_str=timestamp.strftime("%Y-%m-%d-%H%M")
+    )
 
     disclaimer = SensitiveMessageOnReports()
     if disclaimer.should_msg_be_displayed:
@@ -60,8 +61,8 @@ def tracker_emit(report_name):
 
 class SensitiveMessageOnReports(object):
     """
-    Adds a sensitive data message to the reports if the flag
-    DISPLAY_SENSITIVE_DATA_MSG_FOR_DOWNLOADS is enabled.
+    Adds a sensitive data message to the reports if the waffle switch
+    display_sensitive_data_msg_for_downloads is enabled.
 
     Due to reports being generated in different ways, each one handles their own way:
         1. Using the CSV library directly.
@@ -70,8 +71,8 @@ class SensitiveMessageOnReports(object):
     """
 
     def __init__(self):
-            self.should_msg_be_displayed = waffle.switch_is_active('display_sensitive_data_msg_for_downloads')
-        
+        self.should_msg_be_displayed = waffle.switch_is_active('display_sensitive_data_msg_for_downloads')
+
     def csv_direct(self, writer):
         """
         Writes the row immediately in the CSV.

--- a/lms/djangoapps/instructor_task/tests/test_tasks_helper.py
+++ b/lms/djangoapps/instructor_task/tests/test_tasks_helper.py
@@ -48,6 +48,7 @@ from xmodule.modulestore import ModuleStoreEnum
 from xmodule.modulestore.tests.django_utils import SharedModuleStoreTestCase
 from xmodule.modulestore.tests.factories import CourseFactory, ItemFactory, check_mongo_calls
 from xmodule.partitions.partitions import Group, UserPartition
+from waffle.testutils import override_switch
 
 import openedx.core.djangoapps.user_api.course_tag.api as course_tag_api
 from lms.djangoapps.certificates.models import CertificateStatuses, GeneratedCertificate
@@ -2747,7 +2748,7 @@ class SensitiveMessageTestCase(TestCase):
         template_name = "instructor/instructor_dashboard_2/sensitive_data_download_msg.txt"
         render_mock.assert_called_once_with(template_name, None)
 
-    @override_settings(FEATURES={"DISPLAY_SENSITIVE_DATA_MSG_FOR_DOWNLOADS":True})
+    @override_switch('display_sensitive_data_msg_for_downloads',active=True)
     @patch("instructor_task.tasks_helper.utils.SensitiveMessageOnReports.process_message")
     def test_build_csv_directly_with_flag(self, process_message_mock):
         """

--- a/lms/djangoapps/instructor_task/tests/test_tasks_helper.py
+++ b/lms/djangoapps/instructor_task/tests/test_tasks_helper.py
@@ -15,7 +15,6 @@ import urllib
 from contextlib import contextmanager
 from datetime import datetime, timedelta
 
-import csv
 import ddt
 import unicodecsv
 from capa.tests.response_xml_factory import MultipleChoiceResponseXMLFactory

--- a/lms/djangoapps/instructor_task/tests/test_tasks_helper.py
+++ b/lms/djangoapps/instructor_task/tests/test_tasks_helper.py
@@ -414,7 +414,7 @@ class TestInstructorGradeReport(InstructorGradeReportTestCase):
 
         RequestCache.clear_request_cache()
 
-        expected_query_count = 43
+        expected_query_count = 44
         with patch('lms.djangoapps.instructor_task.tasks_helper.runner._get_current_task'):
             with check_mongo_calls(mongo_count):
                 with self.assertNumQueries(expected_query_count):
@@ -2739,17 +2739,17 @@ class SensitiveMessageTestCase(TestCase):
     def setUp(self):
         self.reports = SensitiveMessageOnReports()
 
-    @patch("instructor_task.tasks_helper.utils.render_to_string")
+    @patch('lms.djangoapps.instructor_task.tasks_helper.utils.render_to_string')
     def test_process_message(self, render_mock):
         """
         Verify if the template is rendering the content.
         """
         self.reports.process_message()
-        template_name = "instructor/instructor_dashboard_2/sensitive_data_download_msg.txt"
+        template_name = 'instructor/instructor_dashboard_2/sensitive_data_download_msg.txt'
         render_mock.assert_called_once_with(template_name, None)
 
-    @override_switch('display_sensitive_data_msg_for_downloads',active=True)
-    @patch("instructor_task.tasks_helper.utils.SensitiveMessageOnReports.process_message")
+    @override_switch('display_sensitive_data_msg_for_downloads', active=True)
+    @patch('lms.djangoapps.instructor_task.tasks_helper.utils.SensitiveMessageOnReports.process_message')
     def test_build_csv_directly_with_flag(self, process_message_mock):
         """
         Verify if the CSV is built directly with CSV library and the message
@@ -2766,7 +2766,7 @@ class SensitiveMessageTestCase(TestCase):
         process_message_mock.assert_called_with()
         rows.assert_called()
 
-    @patch("instructor_task.tasks_helper.utils.SensitiveMessageOnReports.process_message")
+    @patch('lms.djangoapps.instructor_task.tasks_helper.utils.SensitiveMessageOnReports.process_message')
     def test_build_csv_with_report_store(self, process_message_mock):
         """
         Verify if the template is being called when the CSV will be built with

--- a/lms/static/sass/course/instructor/_instructor_2.scss
+++ b/lms/static/sass/course/instructor/_instructor_2.scss
@@ -315,6 +315,25 @@
   }
 }
 
+.data-disclaimer-modal {
+  color:#555 !important;
+  background-color: #f5f5f5;
+  padding: 60px !important;
+  line-height: 1.9;
+  line-height: 1.9;
+
+  .inner-wrapper {
+    border: none !important;
+    box-shadow: none !important;
+  }
+}
+ 
+.modal_close {
+  position: absolute;
+  display: block;
+  z-index: 2;
+}
+
 // elements - general
 // --------------------
 .idash-section {

--- a/lms/static/sass/course/instructor/_instructor_2.scss
+++ b/lms/static/sass/course/instructor/_instructor_2.scss
@@ -251,7 +251,7 @@
     @include margin-left(1px);
     @include font-size(14);
 
-    font-family: verdana,arial,sans-serif;
+    font-family: verdana, arial, sans-serif;
     color: #333;
 
     .slick-cell {
@@ -316,10 +316,9 @@
 }
 
 .data-disclaimer-modal {
-  color:#555 !important;
+  color: #555 !important;
   background-color: #f5f5f5;
   padding: 60px !important;
-  line-height: 1.9;
   line-height: 1.9;
 
   .inner-wrapper {

--- a/lms/static/sass/course/instructor/_instructor_2.scss
+++ b/lms/static/sass/course/instructor/_instructor_2.scss
@@ -327,7 +327,7 @@
     box-shadow: none !important;
   }
 }
- 
+
 .modal_close {
   position: absolute;
   display: block;

--- a/lms/templates/instructor/instructor_dashboard_2/data_download.html
+++ b/lms/templates/instructor/instructor_dashboard_2/data_download.html
@@ -1,8 +1,32 @@
+<%namespace name='static' file='/static_content.html'/>
 <%page args="section_data" expression_filter="h"/>
 <%!
 from django.utils.translation import ugettext as _
 from openedx.core.djangolib.markup import HTML, Text
+import waffle
 %>
+
+% if waffle.switch_is_active('display_sensitive_data_msg_for_downloads'):
+  
+  <%static:require_module_async module_name="js/vendor/jquery.leanModal" class_name="leanModal">
+  
+    $('[data-section="data_download"]').click(function(){
+        $( 'a[rel*=leanModal]' ).leanModal({ top : 200, closeButton: ".modal_close" });
+        $( "#sensitive-data" ).click();
+    });
+  
+   </%static:require_module_async>
+  
+  <a href="#sensitive-data-modal" id="sensitive-data" style="display:none" rel="leanModal"></a>
+  
+  <div aria-hidden="true" role="dialog" tabindex="-1" class="modal data-disclaimer-modal" id="sensitive-data-modal">
+    <div class="inner-wrapper" style="margin-bottom: 20px;">
+    <%include file="sensitive_data_download_msg.txt"/>
+    </div>
+    <input type="button" class="modal_close" value="${_('OK')}" href="#">
+  </div>
+  
+% endif
 
 <div class="data-download-container action-type-container">
   <div class="request-response-error msg msg-error copy" id="data-request-response-error"></div>

--- a/lms/templates/instructor/instructor_dashboard_2/sensitive_data_download_msg.txt
+++ b/lms/templates/instructor/instructor_dashboard_2/sensitive_data_download_msg.txt
@@ -1,0 +1,4 @@
+<%!
+from django.utils.translation import ugettext as _
+%>
+${_("Contains information protected under the Protection of Privacy Law - the wrongful transgressor commits an offense")}


### PR DESCRIPTION
### Background - Description
In order to protect personal information, this PR adds a sensitive data warning message when users click on the Instructor Data Download tab and also adds a header for every generated report.

### Testing instructions
1. Activate this by enabling `display_sensitive_data_msg_for_downloads` waffle switch .
2. As a instructor for the course go to `data download tab` or generate a report.

### Screenshots
![pasted image at 2018_06_08 11_44 am](https://user-images.githubusercontent.com/1813634/41321517-f05dc0ac-6e69-11e8-8c40-aabf136392d9.png)



cc @jagonzalr @mtyaka @tomaszgy 