### PR TITLE
WL-1616: Use custom theming.get_current_site method instead of Site.objects.get_current

### DIFF
--- a/common/djangoapps/student/forms.py
+++ b/common/djangoapps/student/forms.py
@@ -10,7 +10,6 @@ from django.contrib.auth.forms import PasswordResetForm
 from django.contrib.auth.hashers import UNUSABLE_PASSWORD_PREFIX
 from django.contrib.auth.models import User
 from django.contrib.auth.tokens import default_token_generator
-from django.contrib.sites.models import Site
 from django.core.exceptions import ValidationError
 from django.urls import reverse
 from django.core.validators import RegexValidator, slug_re
@@ -23,6 +22,7 @@ from edx_ace.recipient import Recipient
 from openedx.core.djangoapps.ace_common.template_context import get_base_template_context
 from openedx.core.djangoapps.lang_pref import LANGUAGE_KEY
 from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
+from openedx.core.djangoapps.theming.helpers import get_current_site
 from openedx.core.djangoapps.user_api import accounts as accounts_settings
 from openedx.core.djangoapps.user_api.preferences.api import get_user_preference
 from student.message_types import PasswordReset
@@ -64,7 +64,7 @@ class PasswordResetFormNoActive(PasswordResetForm):
         user.
         """
         for user in self.users_cache:
-            site = Site.objects.get_current()
+            site = get_current_site()
             message_context = get_base_template_context(site)
 
             message_context.update({

--- a/lms/djangoapps/student_account/views.py
+++ b/lms/djangoapps/student_account/views.py
@@ -9,7 +9,6 @@ from django.conf import settings
 from django.contrib import messages
 from django.contrib.auth import get_user_model
 from django.contrib.auth.decorators import login_required
-from django.contrib.sites.models import Site
 from django.urls import reverse
 from django.http import HttpRequest, HttpResponse, HttpResponseBadRequest, HttpResponseForbidden
 from django.shortcuts import redirect
@@ -31,7 +30,7 @@ from openedx.core.djangoapps.external_auth.login_and_register import register as
 from openedx.core.djangoapps.lang_pref.api import all_languages, released_languages
 from openedx.core.djangoapps.programs.models import ProgramsApiConfig
 from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
-from openedx.core.djangoapps.theming.helpers import is_request_in_themed_site
+from openedx.core.djangoapps.theming.helpers import is_request_in_themed_site, get_current_site
 from openedx.core.djangoapps.user_api.accounts.api import request_password_change
 from openedx.core.djangoapps.user_api.api import (
     RegistrationFormFactory,
@@ -228,7 +227,7 @@ def password_change_request_handler(request):
             if configuration_helpers.get_value('ENABLE_PASSWORD_RESET_FAILURE_EMAIL',
                                                settings.FEATURES['ENABLE_PASSWORD_RESET_FAILURE_EMAIL']):
 
-                site = Site.objects.get_current()
+                site = get_current_site()
                 message_context = get_base_template_context(site)
 
                 message_context.update({


### PR DESCRIPTION
This PR has changes to use custom `theming.get_current_site` method instead of django's `Site.objects.get_current`. This would allow us to get site based on current request instead of pulling site using `SITE_ID` setting. Once appropriate site is detected we would be able to pass appropriate context to password reset emails.
@bill-filler @tuchfarber could you please review?