### PR TITLE
consume env var to select tox env

### DIFF
--- a/scripts/generic-ci-tests.sh
+++ b/scripts/generic-ci-tests.sh
@@ -69,15 +69,12 @@ END
 
 }
 
-if [[ $DJANGO_VERSION == '1.11' ]]; then
-    TOX="tox -r -e py27-django111 --"
-elif [[ $DJANGO_VERSION == '1.10' ]]; then
-    TOX="tox -r -e py27-django110 --"
-elif [[ $DJANGO_VERSION == '1.9' ]]; then
-    TOX="tox -r -e py27-django19 --"
+if [ -n "${TOX_ENV}" ]; then
+    TOX="tox -r -e ${TOX_ENV} --"
 else
     TOX=""
 fi
+
 PAVER_ARGS="-v"
 PARALLEL="--processes=-1"
 export SUBSET_JOB=$JOB_NAME


### PR DESCRIPTION
This is the first step in setting up CI jobs for testing with Python 3. Since there will likely be the need to test multiple versions of Python AND Django, this allows you to set an environment variable that specifies the tox environment to run with. This will allow us to easily create all of the necessary jenkins jobs to handle these permutations.