### PR TITLE
change toxenv checking in ci script

### DIFF
--- a/scripts/generic-ci-tests.sh
+++ b/scripts/generic-ci-tests.sh
@@ -69,10 +69,16 @@ END
 
 }
 
-if [ -n "${TOX_ENV}" ]; then
+# if specified tox environment is supported, prepend paver commands
+# with tox env invocation
+if [ -z ${TOX_ENV+x} ] || [[ ${TOX_ENV} == 'null' ]]; then
+    TOX=""
+elif tox -l |grep -q "${TOX_ENV}"; then
     TOX="tox -r -e ${TOX_ENV} --"
 else
-    TOX=""
+    echo "${TOX_ENV} is not currently supported. Please review the"
+    echo "tox.ini file to see which environments are supported"
+    exit 1
 fi
 
 PAVER_ARGS="-v"


### PR DESCRIPTION
I had thought I could pass an empty string through the build flow plugin and to this script, but the plugin passes it as 'null'. 