### PR TITLE
Set max page size for get courses

### DIFF
--- a/lms/djangoapps/course_api/views.py
+++ b/lms/djangoapps/course_api/views.py
@@ -234,6 +234,7 @@ class CourseListView(DeveloperErrorViewMixin, ListAPIView):
     pagination_class = NamespacedPageNumberPagination
     serializer_class = CourseSerializer
     throttle_classes = CourseListUserThrottle,
+    max_page_size = 100
 
     # Return all the results, 10K is the maximum allowed value for ElasticSearch.
     # We should use 0 after upgrading to 1.1+:


### PR DESCRIPTION
https://openedx.atlassian.net/browse/LEARNER-5566
https://openedx.atlassian.net/browse/LEARNER-5584

There is currently no max page size for retrieving courses. There are about 7k courses. We do not want a 7k course query when fetching only 1 is already slow.

FYI @feanil 