### PR TITLE
Update documentation links that return 404 errors.

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -152,8 +152,7 @@ Areas of particular concern with their own detailed guidelines are:
 
 .. _Accessibility: http://edx.readthedocs.org/projects/edx-developer-guide/en/latest/conventions/accessibility.html
 .. _website accessibility policy: https://www.edx.org/accessibility
-.. _Internationalization: http://edx.readthedocs.org/projects/edx-developer-guide/en/latest/conventions/internationalization/index.html
-
+.. _Internationalization: http://edx.readthedocs.io/projects/edx-developer-guide/en/latest/internationalization/index.html
 
 Step 4: Approval by Community Manager and Product Owner
 =======================================================

--- a/README.rst
+++ b/README.rst
@@ -15,7 +15,7 @@ install edX:
    existing Ubuntu 16.04 server.
 
 .. _configuration repo: https://github.com/edx/configuration
-.. _edX Developer Stack: https://openedx.atlassian.net/wiki/display/OpenOPS/Running+Devstack
+.. _edX Developer Stack: https://github.com/edx/devstack
 .. _edX Full Stack: https://openedx.atlassian.net/wiki/display/OpenOPS/Running+Fullstack
 .. _edX Ubuntu 16.04 64-bit Installation: https://openedx.atlassian.net/wiki/display/OpenOPS/Native+Open+edX+Ubuntu+16.04+64+bit+Installation
 

--- a/docs/best_practices.rst
+++ b/docs/best_practices.rst
@@ -48,7 +48,7 @@ the `Course Blocks`_, you can load the student module data from the modulestore
 without loading the full course. Here is an `example loading the student module
 data`_ in the course outline feature.
 
-.. _Open edX Development in Confluence: https://openedx.atlassian.net/wiki/display/OpenDev/Open+edX+Development
+.. _Open edX Development in Confluence: https://openedx.atlassian.net/wiki/spaces/OpenDev/overview
 .. _Course Overviews: https://github.com/edx/edx-platform/blob/master/openedx/core/djangoapps/content/course_overviews/__init__.py
 .. _example use of course overviews: https://github.com/edx/edx-platform/blob/f81c21902eb0e8d026612b052557142ce1527153/openedx/features/course_experience/views/course_outline.py#L26
 .. _Course Blocks: https://openedx.atlassian.net/wiki/display/EDUCATOR/Course+Blocks

--- a/docs/bootstrap.rst
+++ b/docs/bootstrap.rst
@@ -11,7 +11,7 @@ master branch and to the forthcoming Hawthorn release.
 
 If you are interested in the rationale for edX choosing Bootstrap, you can
 read about the decision in `OEP-16: Adopting Bootstrap
-<https://open-edx-proposals.readthedocs.io/en/latest/oep-0016.html>`_.
+<https://open-edx-proposals.readthedocs.io/en/latest/oep-0016-bp-adopt-bootstrap.html>`_.
 
 .. highlight:: none
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -18,7 +18,7 @@ locations.
 
 .. _edx-platform docs directory: https://github.com/edx/edx-platform/tree/master/docs
 .. _Developer Documentation Index: https://openedx.atlassian.net/wiki/display/OpenDev/Developer+Documentation
-.. _Open edX Development space: https://openedx.atlassian.net/wiki/display/OpenDev/Open+edX+Development
+.. _Open edX Development space: https://openedx.atlassian.net/wiki/spaces/OpenDev/overview
 .. _Open edX ReadTheDocs: http://docs.edx.org/
 
 .. toctree::

--- a/openedx/core/djangoapps/schedules/docs/README.rst
+++ b/openedx/core/djangoapps/schedules/docs/README.rst
@@ -66,7 +66,7 @@ Glossary
    plan on removing this term from this app's code to avoid confusion.
 
 -  **Section**: From our
-   `documentation <http://edx.readthedocs.io/projects/edx-%20partner-course-staff/en/latest/developing_course/course_sections.html#what-is-a-section>`__,
+   `documentation <https://edx.readthedocs.io/projects/edx-partner-course-staff/en/latest/developing_course/course_sections.html#what-is-a-section>`__,
    “A section is the topmost category in your course. A section can
    represent a time period in your course, a chapter, or another
    organizing principle. A section contains one or more subsections.”


### PR DESCRIPTION
I was working my way through the developer steps and the first link was a 404. I updated all the links I could find that were 404 with what I think are the correct links. Thankfully most of the links are at the end of a line and I was able to use a bash one-liner to check all the URL's. 