### PR TITLE
reorder env sourcing in a11y script

### DIFF
--- a/scripts/accessibility-tests.sh
+++ b/scripts/accessibility-tests.sh
@@ -15,6 +15,9 @@ set -e
 #
 ###############################################################################
 
+echo "Setting up for accessibility tests..."
+source scripts/jenkins-common.sh
+
 # if specified tox environment is supported, prepend paver commands
 # with tox env invocation
 if [ -z ${TOX_ENV+x} ] || [[ ${TOX_ENV} == 'null' ]]; then
@@ -26,9 +29,6 @@ else
     echo "tox.ini file to see which environments are supported"
     exit 1
 fi
-
-echo "Setting up for accessibility tests..."
-source scripts/jenkins-common.sh
 
 echo "Running explicit accessibility tests..."
 SELENIUM_BROWSER=phantomjs $TOX paver test_a11y


### PR DESCRIPTION
I had missed the fact that since the a11y jobs don't use scripts/all-tests.sh, they don't have a virtualenv loaded, and the call to tox fails. This fixes that issue