### PR TITLE
Refactor retirement endpoints to isolate Sailthru and respect boundaries

### DIFF
--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -1096,7 +1096,7 @@ INSTALLED_APPS = [
     # by installed apps.
     'oauth_provider',
     'courseware',
-    'survey',
+    'survey.apps.SurveyConfig',
     'lms.djangoapps.verify_student.apps.VerifyStudentConfig',
     'completion',
 

--- a/lms/djangoapps/email_marketing/signals.py
+++ b/lms/djangoapps/email_marketing/signals.py
@@ -16,7 +16,7 @@ from six import text_type
 import third_party_auth
 from course_modes.models import CourseMode
 from email_marketing.models import EmailMarketingConfiguration
-from openedx.core.djangoapps.user_api.accounts.signals import USER_RETIRE_MAILINGS
+from openedx.core.djangoapps.user_api.accounts.signals import USER_RETIRE_THIRD_PARTY_MAILINGS
 from openedx.core.djangoapps.waffle_utils import WaffleSwitchNamespace
 from lms.djangoapps.email_marketing.tasks import update_user, update_user_email, get_email_cookies_via_sailthru
 from openedx.core.djangoapps.lang_pref import LANGUAGE_KEY
@@ -263,7 +263,7 @@ def _log_sailthru_api_call_time(time_before_call):
              delta_sailthru_api_call_time.microseconds / 1000)
 
 
-@receiver(USER_RETIRE_MAILINGS)
+@receiver(USER_RETIRE_THIRD_PARTY_MAILINGS)
 def force_unsubscribe_all(sender, **kwargs):  # pylint: disable=unused-argument
     """
     Synchronously(!) unsubscribes the given user from all Sailthru email lists.

--- a/lms/djangoapps/survey/apps.py
+++ b/lms/djangoapps/survey/apps.py
@@ -1,0 +1,19 @@
+"""
+Survey Application Configuration
+"""
+
+from django.apps import AppConfig
+
+
+class SurveyConfig(AppConfig):
+    """
+    Application Configuration for survey.
+    """
+    name = 'survey'
+    verbose_name = 'Student Surveys'
+
+    def ready(self):
+        """
+        Connect signal handlers.
+        """
+        from . import signals  # pylint: disable=unused-variable

--- a/lms/djangoapps/survey/signals.py
+++ b/lms/djangoapps/survey/signals.py
@@ -1,0 +1,14 @@
+"""
+Signal handlers for the survey app
+"""
+from django.dispatch.dispatcher import receiver
+
+from openedx.core.djangoapps.user_api.accounts.signals import USER_RETIRE_LMS_MISC
+
+from survey.models import SurveyAnswer
+
+
+@receiver(USER_RETIRE_LMS_MISC)
+def _listen_for_lms_retire(sender, **kwargs):  # pylint: disable=unused-argument
+    user = kwargs.get('user')
+    SurveyAnswer.retire_user(user.id)

--- a/lms/djangoapps/survey/tests/test_signals.py
+++ b/lms/djangoapps/survey/tests/test_signals.py
@@ -1,0 +1,47 @@
+"""
+Test signal handlers for the survey app
+"""
+
+from student.tests.factories import UserFactory
+from survey.models import SurveyAnswer
+from survey.tests.factories import SurveyAnswerFactory
+from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
+
+from ..signals import _listen_for_lms_retire
+
+
+class SurveyRetireSignalTests(ModuleStoreTestCase):
+    """
+    Test the _listen_for_lms_retire signal
+    """
+    shard = 4
+
+    def setUp(self):
+        """
+        Set up the test data used in the specific tests
+        """
+        super(SurveyRetireSignalTests, self).setUp()
+
+    def test_success_answers_exist(self):
+        answer = SurveyAnswerFactory(field_value="test value")
+
+        _listen_for_lms_retire(sender=self.__class__, user=answer.user)
+
+        # All values for this user should now be empty string
+        self.assertFalse(SurveyAnswer.objects.filter(user=answer.user).exclude(field_value='').exists())
+
+    def test_success_no_answers(self):
+        user = UserFactory()
+
+        # All we care about is that this does not throw an error
+        _listen_for_lms_retire(sender=self.__class__, user=user)
+
+    def test_idempotent(self):
+        answer = SurveyAnswerFactory(field_value="test value")
+
+        # Run twice to make sure no errors are raised
+        _listen_for_lms_retire(sender=self.__class__, user=answer.user)
+        _listen_for_lms_retire(sender=self.__class__, user=answer.user)
+
+        # All values for this user should still be empty string
+        self.assertFalse(SurveyAnswer.objects.filter(user=answer.user).exclude(field_value='').exists())

--- a/lms/djangoapps/verify_student/signals.py
+++ b/lms/djangoapps/verify_student/signals.py
@@ -4,9 +4,10 @@ Signal handler for setting default course verification dates
 from django.core.exceptions import ObjectDoesNotExist
 from django.dispatch.dispatcher import receiver
 
+from openedx.core.djangoapps.user_api.accounts.signals import USER_RETIRE_LMS_CRITICAL
 from xmodule.modulestore.django import SignalHandler, modulestore
 
-from .models import VerificationDeadline
+from .models import SoftwareSecurePhotoVerification, VerificationDeadline
 
 
 @receiver(SignalHandler.course_published)
@@ -23,3 +24,9 @@ def _listen_for_course_publish(sender, course_key, **kwargs):  # pylint: disable
                 VerificationDeadline.set_deadline(course_key, course.end)
         except ObjectDoesNotExist:
             VerificationDeadline.set_deadline(course_key, course.end)
+
+
+@receiver(USER_RETIRE_LMS_CRITICAL)
+def _listen_for_lms_retire(sender, **kwargs):  # pylint: disable=unused-argument
+    user = kwargs.get('user')
+    SoftwareSecurePhotoVerification.retire_user(user.id)

--- a/lms/djangoapps/verify_student/tests/test_signals.py
+++ b/lms/djangoapps/verify_student/tests/test_signals.py
@@ -6,8 +6,10 @@ from datetime import datetime, timedelta
 
 from pytz import UTC
 
-from lms.djangoapps.verify_student.models import VerificationDeadline
-from lms.djangoapps.verify_student.signals import _listen_for_course_publish
+from lms.djangoapps.verify_student.models import SoftwareSecurePhotoVerification, VerificationDeadline
+from lms.djangoapps.verify_student.signals import _listen_for_course_publish, _listen_for_lms_retire
+from lms.djangoapps.verify_student.tests.factories import SoftwareSecurePhotoVerificationFactory
+from student.tests.factories import UserFactory
 from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
 from xmodule.modulestore.tests.factories import CourseFactory
 
@@ -48,3 +50,54 @@ class VerificationDeadlineSignalTest(ModuleStoreTestCase):
         actual_deadline = VerificationDeadline.deadline_for_course(self.course.id)
         self.assertNotEqual(actual_deadline, self.course.end)
         self.assertEqual(actual_deadline, deadline)
+
+
+class RetirementSignalTest(ModuleStoreTestCase):
+    """
+    Tests for the VerificationDeadline signal
+    """
+    shard = 4
+
+    def setUp(self):
+        super(RetirementSignalTest, self).setUp()
+
+    def _create_entry(self):
+        name = 'Test Name'
+        face_url = 'https://test.invalid'
+        id_url = 'https://test2.invalid'
+        key = 'test+key'
+        user = UserFactory()
+        return SoftwareSecurePhotoVerificationFactory(
+            user=user,
+            name=name,
+            face_image_url=face_url,
+            photo_id_image_url=id_url,
+            photo_id_key=key
+        )
+
+    def test_retire_success(self):
+        verification = self._create_entry()
+        _listen_for_lms_retire(sender=self.__class__, user=verification.user)
+
+        ver_obj = SoftwareSecurePhotoVerification.objects.get(user=verification.user)
+
+        # All values for this user should now be empty string
+        for field in ('name', 'face_image_url', 'photo_id_image_url', 'photo_id_key'):
+            self.assertEqual('', getattr(ver_obj, field))
+
+    def test_retire_success_no_entries(self):
+        user = UserFactory()
+        _listen_for_lms_retire(sender=self.__class__, user=user)
+
+    def test_idempotent(self):
+        verification = self._create_entry()
+
+        # Run this twice to make sure there are no errors raised 2nd time through
+        _listen_for_lms_retire(sender=self.__class__, user=verification.user)
+        _listen_for_lms_retire(sender=self.__class__, user=verification.user)
+
+        ver_obj = SoftwareSecurePhotoVerification.objects.get(user=verification.user)
+
+        # All values for this user should now be empty string
+        for field in ('name', 'face_image_url', 'photo_id_image_url', 'photo_id_key'):
+            self.assertEqual('', getattr(ver_obj, field))

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -2208,7 +2208,7 @@ INSTALLED_APPS = [
     'social_django',
 
     # Surveys
-    'survey',
+    'survey.apps.SurveyConfig',
 
     'lms.djangoapps.lms_xblock.apps.LMSXBlockConfig',
 

--- a/openedx/core/djangoapps/user_api/accounts/signals.py
+++ b/openedx/core/djangoapps/user_api/accounts/signals.py
@@ -4,4 +4,14 @@ Django Signal related functionality for user_api accounts
 
 from django.dispatch import Signal
 
+# Signal to retire a user from third party mailing services, such as Sailthru.
+USER_RETIRE_THIRD_PARTY_MAILINGS = Signal(providing_args=["user"])
+
+# Signal to retire a user from LMS-initiated mailings (course mailings, etc)
 USER_RETIRE_MAILINGS = Signal(providing_args=["user"])
+
+# Signal to retire LMS critical information
+USER_RETIRE_LMS_CRITICAL = Signal(providing_args=["user"])
+
+# Signal to retire LMS misc information
+USER_RETIRE_LMS_MISC = Signal(providing_args=["user"])

--- a/openedx/core/djangoapps/user_api/accounts/tests/test_views.py
+++ b/openedx/core/djangoapps/user_api/accounts/tests/test_views.py
@@ -8,6 +8,8 @@ import hashlib
 import json
 import unittest
 
+from six import iteritems
+
 from consent.models import DataSharingConsent
 import ddt
 from django.conf import settings
@@ -43,7 +45,6 @@ from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
 
 from entitlements.models import CourseEntitlementSupportDetail
 from entitlements.tests.factories import CourseEntitlementFactory
-from lms.djangoapps.verify_student.tests.factories import SoftwareSecurePhotoVerificationFactory
 from openedx.core.djangoapps.api_admin.models import ApiAccessRequest
 from openedx.core.djangoapps.credit.models import (
     CreditRequirementStatus, CreditRequest, CreditCourse, CreditProvider, CreditRequirement
@@ -51,12 +52,11 @@ from openedx.core.djangoapps.credit.models import (
 from openedx.core.djangoapps.course_groups.models import CourseUserGroup, UnregisteredLearnerCohortAssignments
 from openedx.core.djangoapps.site_configuration.tests.factories import SiteFactory
 from openedx.core.djangoapps.user_api.accounts import ACCOUNT_VISIBILITY_PREF_KEY
-from openedx.core.djangoapps.user_api.accounts.signals import USER_RETIRE_MAILINGS
+from openedx.core.djangoapps.user_api.accounts.signals import USER_RETIRE_THIRD_PARTY_MAILINGS
 from openedx.core.djangoapps.user_api.models import RetirementState, UserRetirementStatus, UserPreference, UserOrgTag
 from openedx.core.djangoapps.user_api.preferences.api import set_user_preference
 from openedx.core.djangolib.testing.utils import CacheIsolationTestCase, skip_unless_lms
 from openedx.core.lib.token_utils import JwtBuilder
-from survey.models import SurveyAnswer
 from student.models import (
     CourseEnrollment,
     CourseEnrollmentAllowed,
@@ -1190,9 +1190,6 @@ class TestAccountRetireMailings(RetirementTestCase):
         self.retirement = self._create_retirement(retiring_email_lists)
         self.test_user = self.retirement.user
 
-        UserOrgTag.objects.create(user=self.test_user, key='email-optin', org="foo", value="True")
-        UserOrgTag.objects.create(user=self.test_user, key='email-optin', org="bar", value="True")
-
         self.url = reverse('accounts_retire_mailings')
 
     def build_jwt_headers(self, user):
@@ -1208,18 +1205,13 @@ class TestAccountRetireMailings(RetirementTestCase):
     def build_post(self, user):
         return {'username': user.username}
 
-    def assert_status_and_tag_count(self, headers, expected_status=status.HTTP_204_NO_CONTENT, expected_tag_count=2,
-                                    expected_tag_value="False", expected_content=None):
+    def assert_status(self, headers, expected_status=status.HTTP_204_NO_CONTENT, expected_content=None):
         """
         Helper function for making a request to the retire subscriptions endpoint, and asserting the status.
         """
         response = self.client.post(self.url, self.build_post(self.test_user), **headers)
 
         self.assertEqual(response.status_code, expected_status)
-
-        # Check that the expected number of tags with the correct value exist
-        tag_count = UserOrgTag.objects.filter(user=self.test_user, value=expected_tag_value).count()
-        self.assertEqual(tag_count, expected_tag_count)
 
         if expected_content:
             self.assertEqual(response.content.strip('"'), expected_content)
@@ -1229,15 +1221,7 @@ class TestAccountRetireMailings(RetirementTestCase):
         Verify a user's subscriptions are retired when a superuser posts to the retire subscriptions endpoint.
         """
         headers = self.build_jwt_headers(self.test_superuser)
-        self.assert_status_and_tag_count(headers)
-
-    def test_superuser_retires_user_subscriptions_no_orgtags(self):
-        """
-        Verify the call succeeds when the user doesn't have any org tags.
-        """
-        UserOrgTag.objects.all().delete()
-        headers = self.build_jwt_headers(self.test_superuser)
-        self.assert_status_and_tag_count(headers, expected_tag_count=0)
+        self.assert_status(headers)
 
     def test_unauthorized_rejection(self):
         """
@@ -1246,7 +1230,7 @@ class TestAccountRetireMailings(RetirementTestCase):
         headers = self.build_jwt_headers(self.test_user)
 
         # User should still have 2 "True" subscriptions.
-        self.assert_status_and_tag_count(headers, expected_status=status.HTTP_403_FORBIDDEN, expected_tag_value="True")
+        self.assert_status(headers, expected_status=status.HTTP_403_FORBIDDEN)
 
     def test_signal_failure(self):
         """
@@ -1258,17 +1242,12 @@ class TestAccountRetireMailings(RetirementTestCase):
         mock_handler.side_effect = Exception("Tango")
 
         try:
-            USER_RETIRE_MAILINGS.connect(mock_handler)
+            USER_RETIRE_THIRD_PARTY_MAILINGS.connect(mock_handler)
 
             # User should still have 2 "True" subscriptions.
-            self.assert_status_and_tag_count(
-                headers,
-                expected_status=status.HTTP_500_INTERNAL_SERVER_ERROR,
-                expected_tag_value="True",
-                expected_content="Tango"
-            )
+            self.assert_status(headers, expected_status=status.HTTP_500_INTERNAL_SERVER_ERROR, expected_content="Tango")
         finally:
-            USER_RETIRE_MAILINGS.disconnect(mock_handler)
+            USER_RETIRE_THIRD_PARTY_MAILINGS.disconnect(mock_handler)
 
 
 @unittest.skipUnless(settings.ROOT_URLCONF == 'lms.urls', 'Account APIs are only supported in LMS')
@@ -1708,7 +1687,6 @@ class TestAccountRetirementPost(RetirementTestCase):
         )
 
         # Misc. setup
-        self.photo_verification = SoftwareSecurePhotoVerificationFactory.create(user=self.test_user)
         PendingEmailChangeFactory.create(user=self.test_user)
         UserOrgTagFactory.create(user=self.test_user, key='foo', value='bar')
         UserOrgTagFactory.create(user=self.test_user, key='cat', value='dog')
@@ -1798,10 +1776,10 @@ class TestAccountRetirementPost(RetirementTestCase):
             'is_active': False,
             'username': self.retired_username,
         }
-        for field, expected_value in expected_user_values.iteritems():
+        for field, expected_value in iteritems(expected_user_values):
             self.assertEqual(expected_value, getattr(self.test_user, field))
 
-        for field, expected_value in USER_PROFILE_PII.iteritems():
+        for field, expected_value in iteritems(USER_PROFILE_PII):
             self.assertEqual(expected_value, getattr(self.test_user.profile, field))
 
         self.assertIsNone(self.test_user.profile.profile_image_uploaded_at)
@@ -1829,7 +1807,7 @@ class TestAccountRetirementPost(RetirementTestCase):
         self.assertFalse(UnregisteredLearnerCohortAssignments.objects.filter(email=self.original_email).exists())
 
     def test_deletes_pii_from_user_profile(self):
-        for model_field, value_to_assign in USER_PROFILE_PII.iteritems():
+        for model_field, value_to_assign in iteritems(USER_PROFILE_PII):
             if value_to_assign == '':
                 value = 'foo'
             else:
@@ -1838,7 +1816,7 @@ class TestAccountRetirementPost(RetirementTestCase):
 
         AccountRetirementView.clear_pii_from_userprofile(self.test_user)
 
-        for model_field, value_to_assign in USER_PROFILE_PII.iteritems():
+        for model_field, value_to_assign in iteritems(USER_PROFILE_PII):
             self.assertEqual(value_to_assign, getattr(self.test_user.profile, model_field))
 
         social_links = SocialLink.objects.filter(
@@ -1924,15 +1902,6 @@ class TestAccountRetirementPost(RetirementTestCase):
         self.entitlement_support_detail.refresh_from_db()
         self.assertEqual('', self.entitlement_support_detail.comments)
 
-    def _photo_verification_assertions(self):
-        """
-        Helper method for asserting that ``SoftwareSecurePhotoVerification`` objects are retired.
-        """
-        self.photo_verification.refresh_from_db()
-        self.assertEqual(self.test_user, self.photo_verification.user)
-        for field in ('name', 'face_image_url', 'photo_id_image_url', 'photo_id_key'):
-            self.assertEqual('', getattr(self.photo_verification, field))
-
 
 @unittest.skipUnless(settings.ROOT_URLCONF == 'lms.urls', 'Account APIs are only supported in LMS')
 class TestLMSAccountRetirementPost(RetirementTestCase, ModuleStoreTestCase):
@@ -1996,9 +1965,6 @@ class TestLMSAccountRetirementPost(RetirementTestCase, ModuleStoreTestCase):
             reason=self.pii_standin,
         )
 
-        # SurveyAnswer setup
-        SurveyAnswer.objects.create(user=self.test_user, field_value=self.pii_standin, form_id=0)
-
         # other setup
         PendingNameChange.objects.create(user=self.test_user, new_name=self.pii_standin, rationale=self.pii_standin)
         PasswordHistory.objects.create(user=self.test_user, password=self.pii_standin)
@@ -2052,4 +2018,3 @@ class TestLMSAccountRetirementPost(RetirementTestCase, ModuleStoreTestCase):
         self.assertEqual(retired_api_access_request.company_address, '')
         self.assertEqual(retired_api_access_request.company_name, '')
         self.assertEqual(retired_api_access_request.reason, '')
-        self.assertEqual(SurveyAnswer.objects.get(user=self.test_user).field_value, '')


### PR DESCRIPTION
- Change retire mailings endpoint to use new USER_RETIRE_THIRD_PARTY_MAILINGS signal, currently only used by Sailthru retirement
- Move USER_RETIRE_MAILINGS signal firing to the LMS misc endpoint
- Remove duplicate clearing of UserOrgTags
- Remove LMS imports in openedx/core and update usage to use new USER_RETIRE_LMS_CRITICAL and USER_RETIRE_LMS_MISC signals
- Add testing for new signal handlers and app registration for the LMS survey app