### PR TITLE
Adjust default of Course Landing Experience to use expected platform …

### DIFF
--- a/lms/djangoapps/discussion/config/__init__.py
+++ b/lms/djangoapps/discussion/config/__init__.py
@@ -8,4 +8,4 @@ from openedx.core.djangoapps.waffle_utils import WaffleFlag, WaffleFlagNamespace
 WAFFLE_FLAG_NAMESPACE = WaffleFlagNamespace(name='edx_discussions')
 
 # Waffle flag to enable the use of Bootstrap
-USE_BOOTSTRAP_FLAG = WaffleFlag(WAFFLE_FLAG_NAMESPACE, 'use_bootstrap')
+USE_BOOTSTRAP_FLAG = WaffleFlag(WAFFLE_FLAG_NAMESPACE, 'use_bootstrap', flag_undefined_default=True)

--- a/openedx/features/learner_profile/__init__.py
+++ b/openedx/features/learner_profile/__init__.py
@@ -11,3 +11,6 @@ WAFFLE_FLAG_NAMESPACE = WaffleFlagNamespace(name='learner_profile')
 # Waffle flag for showing a message about the new profile features.
 # TODO: LEARNER-2554: 09/2017: Remove flag once message is no longer needed.
 SHOW_PROFILE_MESSAGE = WaffleFlag(WAFFLE_FLAG_NAMESPACE, 'show_message')
+
+# Waffle flag to show achievements on the learner profile.
+SHOW_ACHIEVEMENTS_FLAG = WaffleFlag(WAFFLE_FLAG_NAMESPACE, 'show_achievements', flag_undefined_default=True)


### PR DESCRIPTION
…defaults

Setting defaults for waffle flags to true.
default=true for use_bootstrap in discussions app
default=true for show_achievements in learner profile app

https://openedx.atlassian.net/browse/LEARNER-5509