### PR TITLE
TE-2560 Generate quality results XML files

### DIFF
--- a/pavelib/utils/envs.py
+++ b/pavelib/utils/envs.py
@@ -54,6 +54,7 @@ class Env(object):
     # Reports Directory
     REPORT_DIR = REPO_ROOT / 'reports'
     METRICS_DIR = REPORT_DIR / 'metrics'
+    QUALITY_DIR = REPORT_DIR / 'quality_junitxml'
 
     # Generic log dir
     GEN_LOG_DIR = REPO_ROOT / "test_root" / "log"

--- a/scripts/generic-ci-tests.sh
+++ b/scripts/generic-ci-tests.sh
@@ -63,7 +63,7 @@ function emptyxunit {
     cat > reports/$1.xml <<END
 <?xml version="1.0" encoding="UTF-8"?>
 <testsuite name="$1" tests="1" errors="0" failures="0" skip="0">
-<testcase classname="$1" name="$1" time="0.604"></testcase>
+<testcase classname="pavelib.quality" name="$1" time="0.604"></testcase>
 </testsuite>
 END
 
@@ -143,7 +143,7 @@ case "$TEST_SUITE" in
 
         # Need to create an empty test result so the post-build
         # action doesn't fail the build.
-        emptyxunit "quality"
+        emptyxunit "stub"
         exit $EXIT
         ;;
 


### PR DESCRIPTION
Add results files for each quality check in JUnit XML format.  These will be used to let Jenkins determine which checks failed, and list any failing checks (along with the failure messages produced by paver) directly on the summary page of each quality job.

There's still an extra dummy results XML file being generated for the quality checks in `generic-ci-tests.sh`; I'm leaving that in place until after we've updated the Jenkins job configurations to look for the new files also.