### PR TITLE
Refactor retirement endpoints to isolate Sailthru and respect boundaries

### DIFF
--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -1098,7 +1098,7 @@ INSTALLED_APPS = [
     # by installed apps.
     'oauth_provider',
     'courseware',
-    'survey',
+    'survey.apps.SurveyConfig',
     'lms.djangoapps.verify_student.apps.VerifyStudentConfig',
     'completion',
 

--- a/lms/djangoapps/email_marketing/signals.py
+++ b/lms/djangoapps/email_marketing/signals.py
@@ -16,7 +16,7 @@ from six import text_type
 import third_party_auth
 from course_modes.models import CourseMode
 from email_marketing.models import EmailMarketingConfiguration
-from openedx.core.djangoapps.user_api.accounts.signals import USER_RETIRE_MAILINGS
+from openedx.core.djangoapps.user_api.accounts.signals import USER_RETIRE_THIRD_PARTY_MAILINGS
 from openedx.core.djangoapps.waffle_utils import WaffleSwitchNamespace
 from lms.djangoapps.email_marketing.tasks import update_user, update_user_email, get_email_cookies_via_sailthru
 from openedx.core.djangoapps.lang_pref import LANGUAGE_KEY
@@ -263,7 +263,7 @@ def _log_sailthru_api_call_time(time_before_call):
              delta_sailthru_api_call_time.microseconds / 1000)
 
 
-@receiver(USER_RETIRE_MAILINGS)
+@receiver(USER_RETIRE_THIRD_PARTY_MAILINGS)
 def force_unsubscribe_all(sender, **kwargs):  # pylint: disable=unused-argument
     """
     Synchronously(!) unsubscribes the given user from all Sailthru email lists.

--- a/lms/djangoapps/survey/apps.py
+++ b/lms/djangoapps/survey/apps.py
@@ -1,0 +1,19 @@
+"""
+Survey Application Configuration
+"""
+
+from django.apps import AppConfig
+
+
+class SurveyConfig(AppConfig):
+    """
+    Application Configuration for survey.
+    """
+    name = 'survey'
+    verbose_name = 'Student Surveys'
+
+    def ready(self):
+        """
+        Connect signal handlers.
+        """
+        from . import signals  # pylint: disable=unused-variable

--- a/lms/djangoapps/survey/signals.py
+++ b/lms/djangoapps/survey/signals.py
@@ -1,0 +1,17 @@
+"""
+Signal handlers for the survey app
+"""
+from django.dispatch.dispatcher import receiver
+
+from openedx.core.djangoapps.user_api.accounts.signals import USER_RETIRE_LMS_MISC
+
+from survey.models import SurveyAnswer
+
+
+@receiver(USER_RETIRE_LMS_MISC)
+def _listen_for_lms_retire(sender, **kwargs):  # pylint: disable=unused-argument
+    """
+    Listener for the USER_RETIRE_LMS_MISC signal, just does the SurveyAnswer retirement
+    """
+    user = kwargs.get('user')
+    SurveyAnswer.retire_user(user.id)

--- a/lms/djangoapps/survey/tests/test_signals.py
+++ b/lms/djangoapps/survey/tests/test_signals.py
@@ -1,0 +1,50 @@
+"""
+Test signal handlers for the survey app
+"""
+
+from openedx.core.djangoapps.user_api.accounts.tests.retirement_helpers import fake_retirement
+from student.tests.factories import UserFactory
+from survey.models import SurveyAnswer
+from survey.tests.factories import SurveyAnswerFactory
+from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
+
+from lms.djangoapps.survey.signals import _listen_for_lms_retire
+
+
+class SurveyRetireSignalTests(ModuleStoreTestCase):
+    """
+    Test the _listen_for_lms_retire signal
+    """
+    shard = 4
+
+    def test_success_answers_exist(self):
+        """
+        Basic success path for users that have answers in the table
+        """
+        answer = SurveyAnswerFactory(field_value="test value")
+
+        _listen_for_lms_retire(sender=self.__class__, user=answer.user)
+
+        # All values for this user should now be empty string
+        self.assertFalse(SurveyAnswer.objects.filter(user=answer.user).exclude(field_value='').exists())
+
+    def test_success_no_answers(self):
+        """
+        Basic success path for users who have no answers, should simply not error
+        """
+        user = UserFactory()
+        _listen_for_lms_retire(sender=self.__class__, user=user)
+
+    def test_idempotent(self):
+        """
+        Tests that re-running a retirement multiple times does not throw an error
+        """
+        answer = SurveyAnswerFactory(field_value="test value")
+
+        # Run twice to make sure no errors are raised
+        _listen_for_lms_retire(sender=self.__class__, user=answer.user)
+        fake_retirement(answer.user)
+        _listen_for_lms_retire(sender=self.__class__, user=answer.user)
+
+        # All values for this user should still be here and just be an empty string
+        self.assertFalse(SurveyAnswer.objects.filter(user=answer.user).exclude(field_value='').exists())

--- a/lms/djangoapps/verify_student/signals.py
+++ b/lms/djangoapps/verify_student/signals.py
@@ -4,9 +4,10 @@ Signal handler for setting default course verification dates
 from django.core.exceptions import ObjectDoesNotExist
 from django.dispatch.dispatcher import receiver
 
+from openedx.core.djangoapps.user_api.accounts.signals import USER_RETIRE_LMS_CRITICAL
 from xmodule.modulestore.django import SignalHandler, modulestore
 
-from .models import VerificationDeadline
+from .models import SoftwareSecurePhotoVerification, VerificationDeadline
 
 
 @receiver(SignalHandler.course_published)
@@ -23,3 +24,9 @@ def _listen_for_course_publish(sender, course_key, **kwargs):  # pylint: disable
                 VerificationDeadline.set_deadline(course_key, course.end)
         except ObjectDoesNotExist:
             VerificationDeadline.set_deadline(course_key, course.end)
+
+
+@receiver(USER_RETIRE_LMS_CRITICAL)
+def _listen_for_lms_retire(sender, **kwargs):  # pylint: disable=unused-argument
+    user = kwargs.get('user')
+    SoftwareSecurePhotoVerification.retire_user(user.id)

--- a/lms/djangoapps/verify_student/tests/test_signals.py
+++ b/lms/djangoapps/verify_student/tests/test_signals.py
@@ -6,8 +6,11 @@ from datetime import datetime, timedelta
 
 from pytz import UTC
 
-from lms.djangoapps.verify_student.models import VerificationDeadline
-from lms.djangoapps.verify_student.signals import _listen_for_course_publish
+from lms.djangoapps.verify_student.models import SoftwareSecurePhotoVerification, VerificationDeadline
+from lms.djangoapps.verify_student.signals import _listen_for_course_publish, _listen_for_lms_retire
+from lms.djangoapps.verify_student.tests.factories import SoftwareSecurePhotoVerificationFactory
+from openedx.core.djangoapps.user_api.accounts.tests.retirement_helpers import fake_retirement
+from student.tests.factories import UserFactory
 from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
 from xmodule.modulestore.tests.factories import CourseFactory
 
@@ -48,3 +51,55 @@ class VerificationDeadlineSignalTest(ModuleStoreTestCase):
         actual_deadline = VerificationDeadline.deadline_for_course(self.course.id)
         self.assertNotEqual(actual_deadline, self.course.end)
         self.assertEqual(actual_deadline, deadline)
+
+
+class RetirementSignalTest(ModuleStoreTestCase):
+    """
+    Tests for the VerificationDeadline signal
+    """
+    shard = 4
+
+    def _create_entry(self):
+        """
+        Helper method to create and return a SoftwareSecurePhotoVerification with appropriate data
+        """
+        name = 'Test Name'
+        face_url = 'https://test.invalid'
+        id_url = 'https://test2.invalid'
+        key = 'test+key'
+        user = UserFactory()
+        return SoftwareSecurePhotoVerificationFactory(
+            user=user,
+            name=name,
+            face_image_url=face_url,
+            photo_id_image_url=id_url,
+            photo_id_key=key
+        )
+
+    def test_retire_success(self):
+        verification = self._create_entry()
+        _listen_for_lms_retire(sender=self.__class__, user=verification.user)
+
+        ver_obj = SoftwareSecurePhotoVerification.objects.get(user=verification.user)
+
+        # All values for this user should now be empty string
+        for field in ('name', 'face_image_url', 'photo_id_image_url', 'photo_id_key'):
+            self.assertEqual('', getattr(ver_obj, field))
+
+    def test_retire_success_no_entries(self):
+        user = UserFactory()
+        _listen_for_lms_retire(sender=self.__class__, user=user)
+
+    def test_idempotent(self):
+        verification = self._create_entry()
+
+        # Run this twice to make sure there are no errors raised 2nd time through
+        _listen_for_lms_retire(sender=self.__class__, user=verification.user)
+        fake_retirement(verification.user)
+        _listen_for_lms_retire(sender=self.__class__, user=verification.user)
+
+        ver_obj = SoftwareSecurePhotoVerification.objects.get(user=verification.user)
+
+        # All values for this user should now be empty string
+        for field in ('name', 'face_image_url', 'photo_id_image_url', 'photo_id_key'):
+            self.assertEqual('', getattr(ver_obj, field))

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -2204,7 +2204,7 @@ INSTALLED_APPS = [
     'social_django',
 
     # Surveys
-    'survey',
+    'survey.apps.SurveyConfig',
 
     'lms.djangoapps.lms_xblock.apps.LMSXBlockConfig',
 

--- a/openedx/core/djangoapps/user_api/accounts/signals.py
+++ b/openedx/core/djangoapps/user_api/accounts/signals.py
@@ -4,4 +4,14 @@ Django Signal related functionality for user_api accounts
 
 from django.dispatch import Signal
 
+# Signal to retire a user from third party mailing services, such as Sailthru.
+USER_RETIRE_THIRD_PARTY_MAILINGS = Signal(providing_args=["user"])
+
+# Signal to retire a user from LMS-initiated mailings (course mailings, etc)
 USER_RETIRE_MAILINGS = Signal(providing_args=["user"])
+
+# Signal to retire LMS critical information
+USER_RETIRE_LMS_CRITICAL = Signal(providing_args=["user"])
+
+# Signal to retire LMS misc information
+USER_RETIRE_LMS_MISC = Signal(providing_args=["user"])

--- a/openedx/core/djangoapps/user_api/accounts/tests/retirement_helpers.py
+++ b/openedx/core/djangoapps/user_api/accounts/tests/retirement_helpers.py
@@ -1,0 +1,166 @@
+"""
+Helpers for testing retirement functionality
+"""
+import datetime
+
+import pytz
+from django.test import TestCase
+from social_django.models import UserSocialAuth
+
+from enrollment import api
+from openedx.core.djangoapps.user_api.models import (
+    RetirementState,
+    UserRetirementStatus
+)
+from student.models import (
+    get_retired_username_by_username,
+    get_retired_email_by_email,
+)
+from student.tests.factories import UserFactory
+
+from ..views import AccountRetirementView
+
+
+class RetirementTestCase(TestCase):
+    """
+    Test case with a helper methods for retirement
+    """
+    @classmethod
+    def setUpClass(cls):
+        super(RetirementTestCase, cls).setUpClass()
+        cls.setup_states()
+
+    @staticmethod
+    def setup_states():
+        """
+        Create basic states that mimic our current understanding of the retirement process
+        """
+        default_states = [
+            ('PENDING', 1, False, True),
+            ('LOCKING_ACCOUNT', 20, False, False),
+            ('LOCKING_COMPLETE', 30, False, False),
+            ('RETIRING_CREDENTIALS', 40, False, False),
+            ('CREDENTIALS_COMPLETE', 50, False, False),
+            ('RETIRING_ECOM', 60, False, False),
+            ('ECOM_COMPLETE', 70, False, False),
+            ('RETIRING_FORUMS', 80, False, False),
+            ('FORUMS_COMPLETE', 90, False, False),
+            ('RETIRING_EMAIL_LISTS', 100, False, False),
+            ('EMAIL_LISTS_COMPLETE', 110, False, False),
+            ('RETIRING_ENROLLMENTS', 120, False, False),
+            ('ENROLLMENTS_COMPLETE', 130, False, False),
+            ('RETIRING_NOTES', 140, False, False),
+            ('NOTES_COMPLETE', 150, False, False),
+            ('RETIRING_LMS', 160, False, False),
+            ('LMS_COMPLETE', 170, False, False),
+            ('ADDING_TO_PARTNER_QUEUE', 180, False, False),
+            ('PARTNER_QUEUE_COMPLETE', 190, False, False),
+            ('ERRORED', 200, True, True),
+            ('ABORTED', 210, True, True),
+            ('COMPLETE', 220, True, True),
+        ]
+
+        for name, ex, dead, req in default_states:
+            RetirementState.objects.create(
+                state_name=name,
+                state_execution_order=ex,
+                is_dead_end_state=dead,
+                required=req
+            )
+
+    def _create_retirement(self, state, create_datetime=None):
+        """
+        Helper method to create a RetirementStatus with useful defaults
+        """
+        if create_datetime is None:
+            create_datetime = datetime.datetime.now(pytz.UTC) - datetime.timedelta(days=8)
+
+        user = UserFactory()
+        return UserRetirementStatus.objects.create(
+            user=user,
+            original_username=user.username,
+            original_email=user.email,
+            original_name=user.profile.name,
+            retired_username=get_retired_username_by_username(user.username),
+            retired_email=get_retired_email_by_email(user.email),
+            current_state=state,
+            last_state=state,
+            responses="",
+            created=create_datetime,
+            modified=create_datetime
+        )
+
+    def _retirement_to_dict(self, retirement, all_fields=False):
+        """
+        Return a dict format of this model to a consistent format for serialization, removing the long text field
+        `responses` for performance reasons.
+        """
+        retirement_dict = {
+            u'id': retirement.id,
+            u'user': {
+                u'id': retirement.user.id,
+                u'username': retirement.user.username,
+                u'email': retirement.user.email,
+                u'profile': {
+                    u'id': retirement.user.profile.id,
+                    u'name': retirement.user.profile.name
+                },
+            },
+            u'original_username': retirement.original_username,
+            u'original_email': retirement.original_email,
+            u'original_name': retirement.original_name,
+            u'retired_username': retirement.retired_username,
+            u'retired_email': retirement.retired_email,
+            u'current_state': {
+                u'id': retirement.current_state.id,
+                u'state_name': retirement.current_state.state_name,
+                u'state_execution_order': retirement.current_state.state_execution_order,
+            },
+            u'last_state': {
+                u'id': retirement.last_state.id,
+                u'state_name': retirement.last_state.state_name,
+                u'state_execution_order': retirement.last_state.state_execution_order,
+            },
+            u'created': retirement.created,
+            u'modified': retirement.modified
+        }
+
+        if all_fields:
+            retirement_dict['responses'] = retirement.responses
+
+        return retirement_dict
+
+    def _create_users_all_states(self):
+        return [self._create_retirement(state) for state in RetirementState.objects.all()]
+
+    def _get_non_dead_end_states(self):
+        return [state for state in RetirementState.objects.filter(is_dead_end_state=False)]
+
+    def _get_dead_end_states(self):
+        return [state for state in RetirementState.objects.filter(is_dead_end_state=True)]
+
+
+def fake_retirement(user):
+    """
+    Makes an attempt to put user for the given user into a "COMPLETED"
+    retirement state by faking important parts of retirement.
+
+    Use to test idempotency for retirement API calls. Since there are many
+    configurable retirement steps this is only a "best guess" and may need
+    additional changes added to more accurately reflect post-retirement state.
+    """
+    # Deactivate / logout and hash username & email
+    UserSocialAuth.objects.filter(user_id=user.id).delete()
+    user.first_name = ''
+    user.last_name = ''
+    user.is_active = False
+    user.username = get_retired_username_by_username(user.username)
+    user.email = get_retired_email_by_email(user.email)
+    user.set_unusable_password()
+    user.save()
+
+    # Clear profile
+    AccountRetirementView.clear_pii_from_userprofile(user)
+
+    # Unenroll from all courses
+    api.unenroll_user_from_all_courses(user.username)

--- a/openedx/core/djangoapps/user_api/accounts/views.py
+++ b/openedx/core/djangoapps/user_api/accounts/views.py
@@ -27,27 +27,24 @@ from rest_framework.parsers import JSONParser
 from rest_framework.response import Response
 from rest_framework.views import APIView
 from rest_framework.viewsets import ViewSet
-from six import text_type
+from six import iteritems, text_type
 from social_django.models import UserSocialAuth
 from wiki.models import ArticleRevision
 from wiki.models.pluginbase import RevisionPluginRevision
 
 from entitlements.models import CourseEntitlement
-from lms.djangoapps.verify_student.models import SoftwareSecurePhotoVerification
 from openedx.core.djangoapps.ace_common.template_context import get_base_template_context
 from openedx.core.djangoapps.api_admin.models import ApiAccessRequest
 from openedx.core.djangoapps.credit.models import CreditRequirementStatus, CreditRequest
 from openedx.core.djangoapps.course_groups.models import UnregisteredLearnerCohortAssignments
 from openedx.core.djangoapps.profile_images.images import remove_profile_images
 from openedx.core.djangoapps.user_api.accounts.image_helpers import get_profile_image_names, set_has_profile_image
-from openedx.core.djangoapps.user_api.preferences.api import update_email_opt_in
 from openedx.core.djangolib.oauth2_retirement_utils import retire_dot_oauth2_models, retire_dop_oauth2_models
 from openedx.core.lib.api.authentication import (
     OAuth2AuthenticationAllowInactiveUser,
     SessionAuthenticationAllowInactiveUser
 )
 from openedx.core.lib.api.parsers import MergePatchParser
-from survey.models import SurveyAnswer
 from student.models import (
     CourseEnrollment,
     ManualEnrollmentAudit,
@@ -76,7 +73,12 @@ from ..models import (
 from .api import get_account_settings, update_account_settings
 from .permissions import CanDeactivateUser, CanRetireUser
 from .serializers import UserRetirementPartnerReportSerializer, UserRetirementStatusSerializer
-from .signals import USER_RETIRE_MAILINGS
+from .signals import (
+    USER_RETIRE_LMS_CRITICAL,
+    USER_RETIRE_LMS_MISC,
+    USER_RETIRE_MAILINGS,
+    USER_RETIRE_THIRD_PARTY_MAILINGS
+)
 from ..message_types import DeletionNotificationMessage
 
 log = logging.getLogger(__name__)
@@ -338,7 +340,8 @@ class AccountDeactivationView(APIView):
 class AccountRetireMailingsView(APIView):
     """
     Part of the retirement API, accepts POSTs to unsubscribe a user
-    from all email lists.
+    from all EXTERNAL email lists (ex: Sailthru). LMS email subscriptions
+    are handled in the LMS retirement endpoints.
     """
     authentication_classes = (JwtAuthentication, )
     permission_classes = (permissions.IsAuthenticated, CanRetireUser)
@@ -347,10 +350,9 @@ class AccountRetireMailingsView(APIView):
         """
         POST /api/user/v1/accounts/{username}/retire_mailings/
 
-        Allows an administrative user to take the following actions
-        on behalf of an LMS user:
-        -  Update UserOrgTags to opt the user out of org emails
-        -  Call Sailthru API to force opt-out the user from all email lists
+        Fires the USER_RETIRE_THIRD_PARTY_MAILINGS signal, currently the
+        only receiver is email_marketing to force opt-out the user from
+        externally managed email lists.
         """
         username = request.data['username']
 
@@ -358,13 +360,9 @@ class AccountRetireMailingsView(APIView):
             retirement = UserRetirementStatus.get_retirement_for_retirement_action(username)
 
             with transaction.atomic():
-                # Take care of org emails first, using the existing API for consistency
-                for preference in UserOrgTag.objects.filter(user=retirement.user, key='email-optin'):
-                    update_email_opt_in(retirement.user, preference.org, False)
-
                 # This signal allows lms' email_marketing and other 3rd party email
-                # providers to unsubscribe the user as well
-                USER_RETIRE_MAILINGS.send(
+                # providers to unsubscribe the user
+                USER_RETIRE_THIRD_PARTY_MAILINGS.send(
                     sender=self.__class__,
                     email=retirement.original_email,
                     new_email=retirement.retired_email,
@@ -766,8 +764,18 @@ class LMSAccountRetirementView(ViewSet):
             CreditRequest.retire_user(retirement.original_username, retirement.retired_username)
             ApiAccessRequest.retire_user(retirement.user)
             CreditRequirementStatus.retire_user(retirement.user.username)
-            SurveyAnswer.retire_user(retirement.user.id)
 
+            # This signal allows code in higher points of LMS to retire the user as necessary
+            USER_RETIRE_LMS_MISC.send(sender=self.__class__, user=retirement.user)
+
+            # This signal allows code in higher points of LMS to unsubscribe the user
+            # from various types of mailings.
+            USER_RETIRE_MAILINGS.send(
+                sender=self.__class__,
+                email=retirement.original_email,
+                new_email=retirement.retired_email,
+                user=retirement.user
+            )
         except UserRetirementStatus.DoesNotExist:
             return Response(status=status.HTTP_404_NOT_FOUND)
         except RetirementStateError as exc:
@@ -796,7 +804,7 @@ class AccountRetirementView(ViewSet):
         }
 
         Retires the user with the given username.  This includes
-        retiring this username, the associates email address, and
+        retiring this username, the associated email address, and
         any other PII associated with this user.
         """
         username = request.data['username']
@@ -821,13 +829,15 @@ class AccountRetirementView(ViewSet):
             self.retire_entitlement_support_detail(user)
 
             # Retire misc. models that may contain PII of this user
-            SoftwareSecurePhotoVerification.retire_user(user.id)
             PendingEmailChange.delete_by_user_value(user, field='user')
             UserOrgTag.delete_by_user_value(user, field='user')
 
             # Retire any objects linked to the user via their original email
             CourseEnrollmentAllowed.delete_by_user_value(original_email, field='email')
             UnregisteredLearnerCohortAssignments.delete_by_user_value(original_email, field='email')
+
+            # This signal allows code in higher points of LMS to retire the user as necessary
+            USER_RETIRE_LMS_CRITICAL.send(sender=self.__class__, user=user)
 
             user.first_name = ''
             user.last_name = ''
@@ -849,7 +859,7 @@ class AccountRetirementView(ViewSet):
         For the given user, sets all of the user's profile fields to some retired value.
         This also deletes all ``SocialLink`` objects associated with this user's profile.
         """
-        for model_field, value_to_assign in USER_PROFILE_PII.iteritems():
+        for model_field, value_to_assign in iteritems(USER_PROFILE_PII):
             setattr(user.profile, model_field, value_to_assign)
 
         user.profile.save()


### PR DESCRIPTION
- Change retire mailings endpoint to use new USER_RETIRE_THIRD_PARTY_MAILINGS signal, currently only used by Sailthru retirement
- Move USER_RETIRE_MAILINGS signal firing to the LMS misc endpoint
- Remove duplicate clearing of UserOrgTags
- Remove LMS imports in openedx/core and update usage to use new USER_RETIRE_LMS_CRITICAL and USER_RETIRE_LMS_MISC signals
- Add testing for new signal handlers and app registration for the LMS survey app