### PR TITLE
Fix some deprecation warnings.

### DIFF
--- a/cms/lib/xblock/authoring_mixin.py
+++ b/cms/lib/xblock/authoring_mixin.py
@@ -6,8 +6,7 @@ import logging
 
 from django.conf import settings
 from web_fragments.fragment import Fragment
-from xblock.core import XBlock
-from xblock.fields import XBlockMixin
+from xblock.core import XBlock, XBlockMixin
 
 log = logging.getLogger(__name__)
 

--- a/common/djangoapps/student/models.py
+++ b/common/djangoapps/student/models.py
@@ -49,7 +49,6 @@ from six import text_type
 from slumber.exceptions import HttpClientError, HttpServerError
 from user_util import user_util
 
-import dogstats_wrapper as dog_stats_api
 import lms.lib.comment_client as cc
 from student.signals import UNENROLL_DONE, ENROLL_STATUS_CHANGE, ENROLLMENT_TRACK_UPDATED
 from lms.djangoapps.certificates.models import GeneratedCertificate
@@ -1334,26 +1333,11 @@ class CourseEnrollment(models.Model):
         if activation_changed:
             if self.is_active:
                 self.emit_event(EVENT_NAME_ENROLLMENT_ACTIVATED)
-
-                dog_stats_api.increment(
-                    "common.student.enrollment",
-                    tags=[u"org:{}".format(self.course_id.org),
-                          u"offering:{}".format(self.course_id.offering),
-                          u"mode:{}".format(self.mode)]
-                )
-
             else:
                 UNENROLL_DONE.send(sender=None, course_enrollment=self, skip_refund=skip_refund)
-
                 self.emit_event(EVENT_NAME_ENROLLMENT_DEACTIVATED)
                 self.send_signal(EnrollStatusChange.unenroll)
 
-                dog_stats_api.increment(
-                    "common.student.unenrollment",
-                    tags=[u"org:{}".format(self.course_id.org),
-                          u"offering:{}".format(self.course_id.offering),
-                          u"mode:{}".format(self.mode)]
-                )
         if mode_changed:
             # Only emit mode change events when the user's enrollment
             # mode has changed from its previous setting

--- a/common/lib/xmodule/xmodule/modulestore/edit_info.py
+++ b/common/lib/xmodule/xmodule/modulestore/edit_info.py
@@ -1,7 +1,7 @@
 """
 Access methods to get EditInfo for xblocks
 """
-from xblock.fields import XBlockMixin
+from xblock.core import XBlockMixin
 from abc import ABCMeta, abstractmethod
 
 

--- a/common/lib/xmodule/xmodule/modulestore/inheritance.py
+++ b/common/lib/xmodule/xmodule/modulestore/inheritance.py
@@ -6,7 +6,8 @@ from __future__ import absolute_import
 from django.conf import settings
 
 from xmodule.partitions.partitions import UserPartition
-from xblock.fields import Scope, Boolean, String, Float, XBlockMixin, Dict, Integer, List
+from xblock.core import XBlockMixin
+from xblock.fields import Scope, Boolean, String, Float, Dict, Integer, List
 from xblock.runtime import KeyValueStore, KvsFieldData
 from xmodule.fields import Date, Timedelta
 from ..course_metadata_utils import DEFAULT_START_DATE

--- a/common/lib/xmodule/xmodule/modulestore/xml_importer.py
+++ b/common/lib/xmodule/xmodule/modulestore/xml_importer.py
@@ -20,37 +20,38 @@ Modulestore virtual   |          XML physical (draft, published)
              (a, a)   |  (a, a) | (x, a) | (x, x) | (x, y) | (a, x)
              (a, b)   |  (a, b) | (x, b) | (x, x) | (x, y) | (a, x)
 """
-import logging
-from abc import abstractmethod
-from opaque_keys.edx.locator import LibraryLocator
-import os
-import mimetypes
-from path import Path as path
 import json
+import logging
+import mimetypes
+import os
 import re
-from lxml import etree
+from abc import abstractmethod
 
-from xblock.fields import XBlockMixin
-from xmodule.library_tools import LibraryToolsService
-from xmodule.modulestore.xml import XMLModuleStore, LibraryXMLModuleStore, ImportSystem
-from xblock.runtime import KvsFieldData, DictKeyValueStore
-from xmodule.x_module import XModuleDescriptor, XModuleMixin
-from opaque_keys.edx.keys import UsageKey
-from xblock.fields import Scope, Reference, ReferenceList, ReferenceValueDict
-from xmodule.contentstore.content import StaticContent
-from .inheritance import own_metadata
-from xmodule.errortracker import make_error_tracker
-from .store_utilities import rewrite_nonportable_content_links
 import xblock
-from xmodule.tabs import CourseTabList
+from lxml import etree
+from opaque_keys.edx.keys import UsageKey
+from opaque_keys.edx.locator import LibraryLocator
+from path import Path as path
+from xblock.core import XBlockMixin
+from xblock.fields import Reference, ReferenceList, ReferenceValueDict, Scope
+from xblock.runtime import DictKeyValueStore, KvsFieldData
+
 from xmodule.assetstore import AssetMetadata
+from xmodule.contentstore.content import StaticContent
+from xmodule.errortracker import make_error_tracker
+from xmodule.library_tools import LibraryToolsService
+from xmodule.modulestore import ModuleStoreEnum
 from xmodule.modulestore.django import ASSET_IGNORE_REGEX
 from xmodule.modulestore.exceptions import DuplicateCourseError
 from xmodule.modulestore.mongo.base import MongoRevisionKey
-from xmodule.modulestore import ModuleStoreEnum
 from xmodule.modulestore.store_utilities import draft_node_constructor, get_draft_subtree_roots
+from xmodule.modulestore.xml import ImportSystem, LibraryXMLModuleStore, XMLModuleStore
+from xmodule.tabs import CourseTabList
 from xmodule.util.misc import escape_invalid_characters
+from xmodule.x_module import XModuleDescriptor, XModuleMixin
 
+from .inheritance import own_metadata
+from .store_utilities import rewrite_nonportable_content_links
 
 log = logging.getLogger(__name__)
 

--- a/lms/djangoapps/lms_xblock/mixin.py
+++ b/lms/djangoapps/lms_xblock/mixin.py
@@ -4,8 +4,8 @@ Namespace that defines fields common to all blocks used in the LMS
 
 #from django.utils.translation import ugettext_noop as _
 from lazy import lazy
-from xblock.core import XBlock
-from xblock.fields import Boolean, Dict, Scope, String, XBlockMixin
+from xblock.core import XBlock, XBlockMixin
+from xblock.fields import Boolean, Dict, Scope, String
 from xblock.validation import ValidationMessage
 
 from lms.lib.utils import is_unit
@@ -30,14 +30,16 @@ NONSENSICAL_ACCESS_RESTRICTION = _(u"This component's access settings contradict
 
 
 class GroupAccessDict(Dict):
-    """Special Dict class for serializing the group_access field"""
-    def from_json(self, access_dict):
-        if access_dict is not None:
-            return {int(k): access_dict[k] for k in access_dict}
+    """
+    Special Dict class for serializing the group_access field.
+    """
+    def from_json(self, value):
+        if value is not None:
+            return {int(k): value[k] for k in value}
 
-    def to_json(self, access_dict):
-        if access_dict is not None:
-            return {unicode(k): access_dict[k] for k in access_dict}
+    def to_json(self, value):
+        if value is not None:
+            return {unicode(k): value[k] for k in value}
 
 
 @XBlock.needs('partitions')
@@ -118,7 +120,7 @@ class LmsBlockMixin(XBlockMixin):
 
         merged_access = parent.merged_group_access.copy()
         if self.group_access is not None:
-            for partition_id, group_ids in self.group_access.items():
+            for partition_id, group_ids in self.group_access.items():  # pylint: disable=no-member
                 if group_ids:  # skip if the "local" group_access for this partition is None or empty.
                     if partition_id in merged_access:
                         if merged_access[partition_id] is False:
@@ -179,13 +181,12 @@ class LmsBlockMixin(XBlockMixin):
         component_group_access = self.group_access
 
         for user_partition_id, parent_group_ids in parent_group_access.iteritems():
-            component_group_ids = component_group_access.get(user_partition_id)
+            component_group_ids = component_group_access.get(user_partition_id)  # pylint: disable=no-member
             if component_group_ids:
                 return parent_group_ids and not set(component_group_ids).issubset(set(parent_group_ids))
             else:
                 return not component_group_access
-        else:
-            return False
+        return False
 
     def validate(self):
         """
@@ -197,7 +198,7 @@ class LmsBlockMixin(XBlockMixin):
         has_invalid_groups = False
         block_is_unit = is_unit(self)
 
-        for user_partition_id, group_ids in self.group_access.iteritems():
+        for user_partition_id, group_ids in self.group_access.iteritems():  # pylint: disable=no-member
             try:
                 user_partition = self._get_user_partition(user_partition_id)
             except NoSuchUserPartitionError:

--- a/openedx/core/lib/license/mixin.py
+++ b/openedx/core/lib/license/mixin.py
@@ -1,7 +1,8 @@
 """
 License mixin for XBlocks and XModules
 """
-from xblock.fields import Scope, String, XBlockMixin
+from xblock.core import XBlockMixin
+from xblock.fields import Scope, String
 
 # Make '_' a no-op so we can scrape strings. Using lambda instead of
 #  `django.utils.translation.ugettext_noop` because Django cannot be imported in this file


### PR DESCRIPTION
Specifically, the ones below that happen during tests:

```
openedx/core/djangoapps/user_api/accounts/tests/test_retirement_views.py::TestPartnerReportingList::test_only_users_in_processing
  /edx/app/edxapp/edx-platform/common/djangoapps/student/models.py:1341: DeprecationWarning: Offering is no longer a supported property of Locator. Please use the course and run properties.
    u"offering:{}".format(self.course_id.offering),

openedx/core/djangoapps/user_api/accounts/tests/test_retirement_views.py::TestPartnerReportingCleanup::test_does_not_delete_users_in_process
  /edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/xblock/mixins.py:371: DeprecationWarning: Please use xblock.core.XBlockMixin
    super(HierarchyMixin, self).__init__(**kwargs)
```