### PR TITLE
fix: closed caption can't move when mutiple videos in one page.

### DIFF
--- a/common/lib/xmodule/xmodule/js/src/video/09_video_caption.js
+++ b/common/lib/xmodule/xmodule/js/src/video/09_video_caption.js
@@ -1230,7 +1230,7 @@
             },
 
             listenForDragDrop: function() {
-                var captions = document.querySelector('.closed-captions');
+                var captions = this.captionDisplayEl['0'];
 
                 if (typeof Draggabilly === 'function') {
                     new Draggabilly(captions, {containment: true});


### PR DESCRIPTION
captions = document.querySelector('.closed-captions')  is global;
Look there:[https://courses.edx.org/courses/course-v1:edX+DemoX.1+2T2017/courseware/6156e0e685ee4a2ab017258108c0bccd/194bd1729fab47aba6507f737d9b90ba/1?activate_block_id=block-v1%3AedX%2BDemoX.1%2B2T2017%2Btype%40html%2Bblock%4025ad917bb5b74b088eb088baf634f050    ](url)
The closed caption  of the second video can't move.
After fix it , 
![after_fix_it](https://user-images.githubusercontent.com/34177096/41754918-3ad656b8-7607-11e8-9718-661ed180c426.gif)
