### PR TITLE
add delay in score recalculation on enrollment update

### DIFF
--- a/common/djangoapps/student/models.py
+++ b/common/djangoapps/student/models.py
@@ -103,6 +103,7 @@ UNENROLLED_TO_ENROLLED = 'from unenrolled to enrolled'
 ALLOWEDTOENROLL_TO_UNENROLLED = 'from allowed to enroll to enrolled'
 UNENROLLED_TO_UNENROLLED = 'from unenrolled to unenrolled'
 DEFAULT_TRANSITION_STATE = 'N/A'
+SCORE_RECALCULATION_DELAY_ON_ENROLLMENT_UPDATE = 30
 
 TRANSITION_STATES = (
     (UNENROLLED_TO_ALLOWEDTOENROLL, UNENROLLED_TO_ALLOWEDTOENROLL),
@@ -1342,7 +1343,15 @@ class CourseEnrollment(models.Model):
             # Only emit mode change events when the user's enrollment
             # mode has changed from its previous setting
             self.emit_event(EVENT_NAME_ENROLLMENT_MODE_CHANGED)
-            ENROLLMENT_TRACK_UPDATED.send(sender=None, user=self.user, course_key=self.course_id)
+            # this signal is meant to trigger a score recalculation celery task,
+            # `countdown` is added to celery task as delay so that cohort is duly updated
+            # before starting score recalculation
+            ENROLLMENT_TRACK_UPDATED.send(
+                sender=None,
+                user=self.user,
+                course_key=self.course_id,
+                countdown=SCORE_RECALCULATION_DELAY_ON_ENROLLMENT_UPDATE
+            )
 
     def send_signal(self, event, cost=None, currency=None):
         """

--- a/lms/djangoapps/grades/signals/handlers.py
+++ b/lms/djangoapps/grades/signals/handlers.py
@@ -241,12 +241,13 @@ def recalculate_course_grade_only(sender, course, course_structure, user, **kwar
 
 @receiver(ENROLLMENT_TRACK_UPDATED)
 @receiver(COHORT_MEMBERSHIP_UPDATED)
-def recalculate_course_and_subsection_grades(sender, user, course_key, **kwargs):
+def recalculate_course_and_subsection_grades(sender, user, course_key, countdown=None, **kwargs):  # pylint: disable=unused-argument
     """
     Updates a saved course grade, forcing the subsection grades
     from which it is calculated to update along the way.
     """
     recalculate_course_and_subsection_grades_for_user.apply_async(
+        countdown=countdown,
         kwargs=dict(
             user_id=user.id,
             course_key=six.text_type(course_key)


### PR DESCRIPTION
## [EDUCATOR-2773](https://openedx.atlassian.net/browse/EDUCATOR-2773)

### Description

Score is recalculated when enrollment of learner is changed. For courses which use verified track cohorting, we need to make sure that cohort is duly updated before recalculating learner's score. 

**An impact example:**
One know impact of recalculating score (on enrollment update from audit to verified) with previous cohort is firing of `COURSE_GRADE_CHANGED` signal (learner is passing course while being in Audit cohort, cohort is not updated to Verified yet) which eventually generates certificate (certificate auto generated as learner is in verified track) unexpectedly.

A 30 second delay is added in recalculation task to achieve purpose.

### Sandbox
- [ ] https://certificate.sandbox.edx.org/


I have created a test course https://certificate.sandbox.edx.org/courses/course-v1:arbisoft+c100+2018/course/ which is 

- Have audit and verified mode.
- Verified track cohorted.
- Auto certificate generation is enabled.
- Content is divided in audit and verified cohorts

User 'verified' is photo verified in this sandbox.

Super user credentials are (to check admin if needed) :
username : noraiz
password : edx

### Reviewers
- [ ] @sanfordstudent 
- [ ] @awaisdar001 
 
### Post-review
- [ ] Rebase and squash commits