### PR TITLE
EDUCATOR-3055 clear the enrollment dates for the rerun of the course 

### DIFF
--- a/cms/djangoapps/contentstore/tests/test_course_create_rerun.py
+++ b/cms/djangoapps/contentstore/tests/test_course_create_rerun.py
@@ -1,7 +1,7 @@
 """
 Test view handler for rerun (and eventually create)
 """
-from datetime import datetime
+import datetime
 
 import ddt
 from django.urls import reverse
@@ -37,12 +37,19 @@ class TestCourseListing(ModuleStoreTestCase):
         self.client = AjaxEnabledTestClient()
         self.client.login(username=self.user.username, password='test')
         self.course_create_rerun_url = reverse('course_handler')
+        self.course_start = datetime.datetime.utcnow()
+        self.course_end = self.course_start + datetime.timedelta(days=30)
+        self.enrollment_start = self.course_start - datetime.timedelta(days=7)
+        self.enrollment_end = self.course_end - datetime.timedelta(days=14)
         source_course = CourseFactory.create(
             org='origin',
             number='the_beginning',
             run='first',
             display_name='the one and only',
-            start=datetime.utcnow()
+            start=self.course_start,
+            end=self.course_end,
+            enrollment_start=self.enrollment_start,
+            enrollment_end=self.enrollment_end
         )
         self.source_course_key = source_course.id
 
@@ -70,8 +77,12 @@ class TestCourseListing(ModuleStoreTestCase):
         dest_course_key = CourseKey.from_string(data['destination_course_key'])
 
         self.assertEqual(dest_course_key.run, 'copy')
+        source_course = self.store.get_course(self.source_course_key)
         dest_course = self.store.get_course(dest_course_key)
         self.assertEqual(dest_course.start, CourseFields.start.default)
+        self.assertEqual(dest_course.end, source_course.end)
+        self.assertEqual(dest_course.enrollment_start, None)
+        self.assertEqual(dest_course.enrollment_end, None)
 
     @ddt.data(ModuleStoreEnum.Type.mongo, ModuleStoreEnum.Type.split)
     def test_newly_created_course_has_web_certs_enabled(self, store):

--- a/cms/djangoapps/contentstore/views/course.py
+++ b/cms/djangoapps/contentstore/views/course.py
@@ -914,6 +914,8 @@ def rerun_course(user, source_course_key, org, number, run, fields, async=True):
 
     # Clear the fields that must be reset for the rerun
     fields['advertised_start'] = None
+    fields['enrollment_start'] = None
+    fields['enrollment_end'] = None
     fields['video_upload_pipeline'] = {}
 
     json_fields = json.dumps(fields, cls=EdxJSONEncoder)


### PR DESCRIPTION
# [EDUCATOR-3055](https://openedx.atlassian.net/browse/EDUCATOR-3055)

### Description
In the past, Studio copies the data of enrollment date fields into the current course run from the previous course run when creating rerun of the course. Now it will not copy the enrollment date fields.

### How to Test?

**Stage** 

1. Login into stage https://studio.stage.edx.org/home/
2. Set the enrollment dates in the current course.
3. Click on `Re-run Course` button.
4. Observe that new course has enrollment dates of the previous course.

**Sandbox** 

1. Login into sandbox https://studio-rabia23.sandbox.edx.org/home
2. Set the enrollment dates in the current course.
3. Click on `Re-run Course` button.
4. Observe that new course doesn't have enrollment dates.

### Testing
- [x] Unit test


### Reviewers
If you've been tagged for review, please check your corresponding box once you've given the :+1:.
- [x] Code review: @noraiz-anwar 
- [x] Code review: @asadazam93 

### Post-review
- [x] Rebase and squash commits
