### PR TITLE
Update the entitlement fulfilment logic to work with enrollment end

### DIFF
--- a/common/djangoapps/entitlements/tests/test_utils.py
+++ b/common/djangoapps/entitlements/tests/test_utils.py
@@ -139,6 +139,20 @@ class TestCourseRunFulfillableForEntitlement(ModuleStoreTestCase):
 
         assert is_course_run_entitlement_fulfillable(course_overview.id, entitlement)
 
+    def test_course_run_fulfillable_enrollment_ended_upgrade_open(self):
+        course_overview = self.create_course(
+            start_from_now=-3,
+            end_from_now=2,
+            enrollment_start_from_now=-2,
+            enrollment_end_from_now=-1,
+        )
+
+        entitlement = CourseEntitlementFactory.create(mode=CourseMode.VERIFIED)
+        # Enroll User in the Course, but do not update the entitlement
+        CourseEnrollmentFactory.create(user=entitlement.user, course_id=course_overview.id)
+
+        assert is_course_run_entitlement_fulfillable(course_overview.id, entitlement)
+
     def test_course_run_not_fulfillable_upgrade_ended(self):
         course_overview = self.create_course(
             start_from_now=-3,

--- a/common/djangoapps/student/models.py
+++ b/common/djangoapps/student/models.py
@@ -1270,7 +1270,7 @@ class CourseEnrollment(models.Model):
 
         Args:
             user (User): The user associated with the enrollment.
-            course_id (CourseKey): The key of the course associated with the enrollment.
+            course_key (CourseKey): The key of the course associated with the enrollment.
 
         Returns:
             Course enrollment object or None

--- a/lms/djangoapps/support/static/support/jsx/entitlements/components/EntitlementForm/index.jsx
+++ b/lms/djangoapps/support/static/support/jsx/entitlements/components/EntitlementForm/index.jsx
@@ -94,6 +94,7 @@ class EntitlementForm extends React.Component {
             { label: '--', value: '' },
             { label: 'Verified', value: 'verified' },
             { label: 'Professional', value: 'professional' },
+            { label: 'No ID Professional', value: 'no-id-professional' },
           ]}
           onChange={this.handleModeChange}
         />


### PR DESCRIPTION
[LEARNER-5275]

    Update the entitlement fulfillment logic to work for users who have
    enrolled, enrollment window has closed, but upgrade window is still
    open. These users should be able to use that existing enrollment on their course
    entitlement.