### PR TITLE
Fix transcripts migrations command – celery chord, logging

### DIFF
--- a/cms/djangoapps/contentstore/management/commands/tests/test_migrate_transcripts.py
+++ b/cms/djangoapps/contentstore/management/commands/tests/test_migrate_transcripts.py
@@ -227,20 +227,20 @@ class TestMigrateTranscripts(ModuleStoreTestCase):
             (
                 'cms.djangoapps.contentstore.tasks', 'INFO',
                 (u'[Transcript Migration] [video-transcript-will-be-migrated] '
-                 u'[video={}] [edx_video_id=test_edx_video_id] '
+                 u'[revision=rev-opt-published-only] [video={}] [edx_video_id=test_edx_video_id] '
                  u'[language_code=hr]'.format(self.video_descriptor.location))
             ),
             (
                 'cms.djangoapps.contentstore.tasks', 'INFO',
                 (u'[Transcript Migration] [video-transcript-will-be-migrated] '
-                 u'[video={}] [edx_video_id=test_edx_video_id] '
+                 u'[revision=rev-opt-published-only] [video={}] [edx_video_id=test_edx_video_id] '
                  u'[language_code=ge]'.format(self.video_descriptor.location))
             ),
             (
                 'cms.djangoapps.contentstore.tasks', 'INFO',
                 (u'[Transcript Migration] [transcripts-migration-tasks-submitted] '
                  u'[transcripts_count=2] [course={}] '
-                 u'[video={}]'.format(course_id, self.video_descriptor.location))
+                 u'[revision=rev-opt-published-only] [video={}]'.format(course_id, self.video_descriptor.location))
             )
         )
 
@@ -264,20 +264,20 @@ class TestMigrateTranscripts(ModuleStoreTestCase):
             (
                 'cms.djangoapps.contentstore.tasks', 'INFO',
                 (u'[Transcript Migration] [transcripts-migration-process-started-for-video-transcript] '
-                 u'[video={}] [edx_video_id=test_edx_video_id_2] '
+                 u'[revision=rev-opt-published-only] [video={}] [edx_video_id=test_edx_video_id_2] '
                  u'[language_code=ge]'.format(self.video_descriptor_2.location))
             ),
             (
                 'cms.djangoapps.contentstore.tasks', 'ERROR',
                 (u'[Transcript Migration] [video-transcript-migration-failed-with-known-exc] '
-                 u'[video={}] [edx_video_id=test_edx_video_id_2] '
+                 u'[revision=rev-opt-published-only] [video={}] [edx_video_id=test_edx_video_id_2] '
                  u'[language_code=ge]'.format(self.video_descriptor_2.location))
             ),
             (
                 'cms.djangoapps.contentstore.tasks', 'INFO',
                 (u'[Transcript Migration] [transcripts-migration-tasks-submitted] '
                  u'[transcripts_count=1] [course={}] '
-                 u'[video={}]'.format(course_id, self.video_descriptor_2.location))
+                 u'[revision=rev-opt-published-only] [video={}]'.format(course_id, self.video_descriptor_2.location))
             )
         )
 

--- a/cms/djangoapps/contentstore/management/commands/tests/test_migrate_transcripts.py
+++ b/cms/djangoapps/contentstore/management/commands/tests/test_migrate_transcripts.py
@@ -219,28 +219,29 @@ class TestMigrateTranscripts(ModuleStoreTestCase):
         """
         course_id = unicode(self.course.id)
         expected_log = (
-            (LOGGER_NAME,
-             'INFO',
-             u'[Transcript Migration] process for course {} started. Migrating transcripts from 1 videos.'.format(
-                 course_id
-             )),
-            (LOGGER_NAME,
-             'INFO',
-             u'[Transcript Migration] Migrating 2 transcripts for course {}.'.format(course_id)),
-            (LOGGER_NAME,
-             'INFO',
-             u'[Transcript Migration] Result: Language hr transcript of video test_edx_video_id will be migrated'),
-            (LOGGER_NAME,
-             'INFO',
-             u'[Transcript Migration] Result: Language ge transcript of video test_edx_video_id will be migrated'),
-            (LOGGER_NAME,
-             'INFO',
-             u'[Transcript Migration] task submission for course {} ended.'.format(
-                 course_id
-             )),
-            (LOGGER_NAME,
-             'INFO',
-             "[Transcript Migration] Result: None")
+            (
+                'cms.djangoapps.contentstore.tasks', 'INFO',
+                (u'[Transcript Migration] [video-transcripts-migration-process-started-for-course] '
+                 u'[course={}]'.format(course_id))
+            ),
+            (
+                'cms.djangoapps.contentstore.tasks', 'INFO',
+                (u'[Transcript Migration] [video-transcript-will-be-migrated] '
+                 u'[video={}] [edx_video_id=test_edx_video_id] '
+                 u'[language_code=hr]'.format(self.video_descriptor.location))
+            ),
+            (
+                'cms.djangoapps.contentstore.tasks', 'INFO',
+                (u'[Transcript Migration] [video-transcript-will-be-migrated] '
+                 u'[video={}] [edx_video_id=test_edx_video_id] '
+                 u'[language_code=ge]'.format(self.video_descriptor.location))
+            ),
+            (
+                'cms.djangoapps.contentstore.tasks', 'INFO',
+                (u'[Transcript Migration] [transcripts-migration-tasks-submitted] '
+                 u'[transcripts_count=2] [course={}] '
+                 u'[video={}]'.format(course_id, self.video_descriptor.location))
+            )
         )
 
         with LogCapture(LOGGER_NAME, level=logging.INFO) as logger:
@@ -255,32 +256,29 @@ class TestMigrateTranscripts(ModuleStoreTestCase):
         """
         course_id = unicode(self.course_2.id)
         expected_log = (
-            (LOGGER_NAME,
-             'INFO',
-             u'[Transcript Migration] process for course {} started. Migrating transcripts from 1 videos.'.format(
-                 course_id
-             )),
-            (LOGGER_NAME,
-             'INFO',
-             u'[Transcript Migration] Migrating 1 transcripts for course {}.'.format(course_id)),
-            (LOGGER_NAME,
-             'INFO',
-             u'[Transcript migration] migration process is started for video [test_edx_video_id_2] language [ge].'),
-            (LOGGER_NAME,
-             'ERROR',
-             u"[Transcript migration] transcript migration failed for video [test_edx_video_id_2] and language [ge]."),
-            (LOGGER_NAME,
-             'INFO',
-             "[Transcript Migration] Result: Failed: language ge of video test_edx_video_id_2 with exception "
-             "No transcript for `ge` language"),
-            (LOGGER_NAME,
-             'INFO',
-             u'[Transcript Migration] task submission for course {} ended.'.format(
-                 course_id
-             )),
-            (LOGGER_NAME,
-             'INFO',
-             "[Transcript Migration] Result: None")
+            (
+                'cms.djangoapps.contentstore.tasks', 'INFO',
+                (u'[Transcript Migration] [video-transcripts-migration-process-started-for-course] '
+                 u'[course={}]'.format(course_id))
+            ),
+            (
+                'cms.djangoapps.contentstore.tasks', 'INFO',
+                (u'[Transcript Migration] [transcripts-migration-process-started-for-video-transcript] '
+                 u'[video={}] [edx_video_id=test_edx_video_id_2] '
+                 u'[language_code=ge]'.format(self.video_descriptor_2.location))
+            ),
+            (
+                'cms.djangoapps.contentstore.tasks', 'ERROR',
+                (u'[Transcript Migration] [video-transcript-migration-failed-with-known-exc] '
+                 u'[video={}] [edx_video_id=test_edx_video_id_2] '
+                 u'[language_code=ge]'.format(self.video_descriptor_2.location))
+            ),
+            (
+                'cms.djangoapps.contentstore.tasks', 'INFO',
+                (u'[Transcript Migration] [transcripts-migration-tasks-submitted] '
+                 u'[transcripts_count=1] [course={}] '
+                 u'[video={}]'.format(course_id, self.video_descriptor_2.location))
+            )
         )
 
         with LogCapture(LOGGER_NAME, level=logging.INFO) as logger:


### PR DESCRIPTION
## [EDUCATOR-3100](https://openedx.atlassian.net/browse/EDUCATOR-3100)
- Fix celery-chord/groups issues
- Improve logging for Splunk reports generation
- Migrate transcripts for video components in both draft as well as published structures
- Add revision for richer logging, update video blocks on relevant branches