### PR TITLE
Removing the ability to change a users mode to Credit using management

### DIFF
--- a/common/djangoapps/student/management/commands/change_enrollment.py
+++ b/common/djangoapps/student/management/commands/change_enrollment.py
@@ -41,7 +41,7 @@ class Command(BaseCommand):
           $ ... change_enrollment -u joe,frank,bill -c some/course/id --from audit --to honor -n
     """
 
-    enrollment_modes = ('audit', 'verified', 'honor', 'credit')
+    enrollment_modes = ('audit', 'verified', 'honor')
 
     def add_arguments(self, parser):
         parser.add_argument('-f', '--from',


### PR DESCRIPTION
command

I am reverting a change I made in a previous PR to allow this command to work for Credit.  We have discovered a need to do more including checking and updating Meta Data when moving a user's enrollment mode.  I am removing this mode until we can do more investigation.