### PR TITLE
Campus.il - Incomplete profile notification feature

### DIFF
--- a/common/djangoapps/student/tests/test_views.py
+++ b/common/djangoapps/student/tests/test_views.py
@@ -657,6 +657,14 @@ class StudentDashboardTests(SharedModuleStoreTestCase, MilestonesTestCaseMixin, 
             response = self.client.get(reverse('dashboard'))
             self.assertIn('Your profile has missing fields!', response.content)
 
+            # Now run the case when the user has filled the required fields
+            self.user.profile.gender = 'm'
+            self.user.profile.city = 'Test City'
+            self.user.profile.year_of_birth = 1111
+            self.user.profile.save()
+            response = self.client.get(reverse('dashboard'))
+            self.assertNotIn('Your profile has missing fields!', response.content)
+
     @patch('student.views.dashboard.waffle.switch_is_active')
     def test_hide_incomplete_profile_alert(self, mock_switch_is_active):
         """

--- a/lms/djangoapps/learner_dashboard/tests/test_utils.py
+++ b/lms/djangoapps/learner_dashboard/tests/test_utils.py
@@ -1,11 +1,15 @@
 """
 Unit test module covering utils module
 """
-
+from datetime import date, datetime
 import ddt
+import pytz
+from django.contrib.auth.models import User
 from django.test import TestCase
 
 from lms.djangoapps.learner_dashboard import utils
+from openedx.core.djangoapps.site_configuration.tests.test_util import with_site_configuration
+from student.models import UserProfile
 
 
 @ddt.ddt
@@ -23,3 +27,58 @@ class TestUtils(TestCase):
         """
         actual = utils.strip_course_id(path + unicode(utils.FAKE_COURSE_KEY))
         self.assertEqual(actual, path)
+
+
+class DisclaimerIncompleteFieldsTestCase(TestCase):
+    """
+    Test cases to display or not the reminder alert if a user
+    has left some required fields in blank after n days.
+    """
+
+    def setUp(self):
+        self.user = User.objects.create(
+            username='my_self_user',
+            date_joined=date(2016, 3, 1)
+        )
+        self.user_profile = UserProfile.objects.create(
+            user_id=self.user.id,
+            year_of_birth=1989
+        )
+
+    @with_site_configuration(configuration={"DAYS_PASSED_TO_ALERT_PROFILE_INCOMPLETION": 5})
+    @with_site_configuration(configuration={"FIELDS_TO_CHECK_PROFILE_COMPLETION": ['gender', 'city', 'year_of_birth']})
+    def test_showing_alert(self):
+        """
+        Test the case when the alert should be displayed
+        """
+        display_alert = utils.display_incomplete_profile_notification(self.user_profile)
+        return self.assertEqual(display_alert, True)
+
+    @with_site_configuration(configuration={"DAYS_PASSED_TO_ALERT_PROFILE_INCOMPLETION": 10})
+    @with_site_configuration(configuration={"FIELDS_TO_CHECK_PROFILE_COMPLETION": ['year_of_birth']})
+    def test_not_showing_alert(self):
+        """
+        Test the case when the alert should not be displayed
+        """
+        display_alert = utils.display_incomplete_profile_notification(self.user_profile)
+        return self.assertEqual(display_alert, False)
+
+    @with_site_configuration(configuration={"DAYS_PASSED_TO_ALERT_PROFILE_INCOMPLETION": 5})
+    @with_site_configuration(configuration={"FIELDS_TO_CHECK_PROFILE_COMPLETION": []})
+    def test_not_showing_alert_no_fields(self):
+        """
+        Test a case when the alert should not be displayed.
+        """
+        display_alert = utils.display_incomplete_profile_notification(self.user_profile)
+        return self.assertEqual(display_alert, False)
+
+    @with_site_configuration(configuration={"DAYS_PASSED_TO_ALERT_PROFILE_INCOMPLETION": 5})
+    @with_site_configuration(configuration={"FIELDS_TO_CHECK_PROFILE_COMPLETION": []})
+    def test_not_showing_alert_invalid_period(self):
+        """
+        Test a case when the alert should not be displayed.
+        """
+        current = datetime.now(pytz.utc)
+        User.objects.filter(username='my_self_user').update(date_joined=current)
+        display_alert = utils.display_incomplete_profile_notification(self.user_profile)
+        return self.assertEqual(display_alert, False)

--- a/lms/djangoapps/learner_dashboard/utils.py
+++ b/lms/djangoapps/learner_dashboard/utils.py
@@ -1,7 +1,13 @@
 """
 The utility methods and functions to help the djangoapp logic
 """
+from datetime import datetime
+
 from opaque_keys.edx.keys import CourseKey
+import pytz
+
+from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
+from student.models import UserProfile
 
 FAKE_COURSE_KEY = CourseKey.from_string('course-v1:fake+course+run')
 
@@ -13,3 +19,29 @@ def strip_course_id(path):
     """
     course_id = unicode(FAKE_COURSE_KEY)
     return path.split(course_id)[0]
+
+
+def display_incomplete_profile_notification(request):
+    """
+    Utility function to return if the incomplete profile
+    notification should be displayed or not
+    """
+    days_passed_threshold = configuration_helpers.get_value(
+        'DAYS_PASSED_TO_ALERT_PROFILE_INCOMPLETION',
+        7,
+    )
+    user_profile = UserProfile.objects.get(user_id=request.user.id)
+    joined = user_profile.user.date_joined
+    current = datetime.now(pytz.utc)
+    delta = current - joined
+
+    if delta.days > days_passed_threshold:
+        additional_fields = configuration_helpers.get_value(
+            'FIELDS_TO_CHECK_PROFILE_COMPLETION',
+            [],
+        )
+        for field_name in additional_fields:
+            if not getattr(user_profile, field_name, None):
+                return True
+
+    return False

--- a/lms/templates/dashboard.html
+++ b/lms/templates/dashboard.html
@@ -238,6 +238,12 @@ from student.models import CourseEnrollment
           </div>
         %endif
 
+        %if display_incomplete_profile_message:
+          <div class="sidebar-notification">
+            <%include file="${static.get_template_path('learner_dashboard/_dashboard_incomplete_profile_notification.html')}" />
+          </div>
+        %endif
+
         % if settings.FEATURES.get('ENABLE_DASHBOARD_SEARCH'):
           <div id="dashboard-search-bar" class="search-bar dashboard-search-bar" role="search" aria-label="Dashboard">
             <form class="search-form">

--- a/lms/templates/learner_dashboard/_dashboard_incomplete_profile_notification.html
+++ b/lms/templates/learner_dashboard/_dashboard_incomplete_profile_notification.html
@@ -1,0 +1,19 @@
+<%page expression_filter="h"/>
+<%!
+from django.utils.translation import ugettext as _
+from openedx.core.djangolib.markup import HTML, Text
+%>
+<div class="profile-sidebar" role="region" aria-labelledby="account-activation-title">
+  <div class="user-info">
+    <ul>
+      <li class="status status-verification warning" aria-labelledby="status-title" tabindex="-1">
+        <span id="status-title" class="title status-title">
+          <i class="fa fa-exclamation-circle" aria-hidden="true"></i>
+          <span class="sr">${_("Your profile has missing fields!")}</span>
+          ${_("Your profile has missing fields!")}
+        </span>
+        <p class="status-note">${ incomplete_profile_message | n, decode.utf8 }</p>
+      </li>
+    </ul>
+  </div>
+</div>


### PR DESCRIPTION
**Description:**  This PR adds the capability to display an incomplete profile notification to learners, given that optional registration fields are missing. 

**Testing instructions:**

1. Add a waffle switch `enable_incomplete_profile_notification` and enable it.
2. Add a site configuration variable `FIELDS_TO_CHECK_PROFILE_COMPLETION`. For  example `FIELDS_TO_CHECK_PROFILE_COMPLETION : ['gender', 'city']` , to check that 'gender' and 'city' should be filled.  
3. (Optional) add a site configuration variable `DAYS_PASSED_TO_ALERT_PROFILE_INCOMPLETION`. For example `DAYS_PASSED_TO_ALERT_PROFILE_INCOMPLETION : 10`, to check for the condition 10 days after user sign up. 
4. Sign in as a learner into lms.
5. Go to dashboard page.

**Sandbox:**
LMS:  https://pr18463.sandbox.opencraft.hosting/
Email for testing: `audit@example.com` , Password: `edx`

**Screenshots:**

![alert_missing](https://user-images.githubusercontent.com/1813634/41878918-cef6bea4-789c-11e8-82a6-cba29156b53d.png)


**Merge checklist:**
- [ ] CI build is green

