### PR TITLE
ENT-1052 discount by enterprise catalog

### DIFF
--- a/lms/djangoapps/commerce/tests/test_utils.py
+++ b/lms/djangoapps/commerce/tests/test_utils.py
@@ -145,6 +145,38 @@ class EcommerceServiceTests(TestCase):
             )
         self.assertEqual(url, expected_url)
 
+    @override_settings(ECOMMERCE_PUBLIC_URL_ROOT='http://ecommerce_url')
+    @ddt.data(
+        {
+            'skus': ['TESTSKU'],
+            'enterprise_catalog_uuid': None
+        },
+        {
+            'skus': ['TESTSKU'],
+            'enterprise_catalog_uuid': '6eca3efb-f3a0-4c08-806f-c6e6b65d61cb'
+        },
+    )
+    @ddt.unpack
+    def test_get_checkout_page_url_with_enterprise_catalog_uuid(self, skus, enterprise_catalog_uuid):
+        """ Verify the checkout page URL is properly constructed and returned. """
+        url = EcommerceService().get_checkout_page_url(
+            *skus,
+            enterprise_customer_catalog_uuid=enterprise_catalog_uuid
+        )
+        config = CommerceConfiguration.current()
+
+        query = {'sku': skus}
+        if enterprise_catalog_uuid:
+            query.update({'enterprise_customer_catalog_uuid': enterprise_catalog_uuid})
+
+        expected_url = '{root}{basket_url}?{skus}'.format(
+            basket_url=config.basket_checkout_page,
+            root=settings.ECOMMERCE_PUBLIC_URL_ROOT,
+            skus=urlencode(query, doseq=True),
+        )
+
+        self.assertEqual(url, expected_url)
+
 
 @unittest.skipUnless(settings.ROOT_URLCONF == 'lms.urls', 'Test only valid in lms')
 class RefundUtilMethodTests(ModuleStoreTestCase):

--- a/lms/djangoapps/commerce/utils.py
+++ b/lms/djangoapps/commerce/utils.py
@@ -111,9 +111,14 @@ class EcommerceService(object):
             http://localhost:8002/basket/add/?sku=5H3HG5&sku=57FHHD&bundle=3bdf1dd1-49be-4a15-9145-38901f578c5a
         """
         program_uuid = kwargs.get('program_uuid')
-        url = '{checkout_page_path}?{skus}'.format(
+        enterprise_catalog_uuid = kwargs.get('enterprise_customer_catalog_uuid')
+        query_params = {'sku': skus}
+        if enterprise_catalog_uuid:
+            query_params.update({'enterprise_customer_catalog_uuid': enterprise_catalog_uuid})
+
+        url = '{checkout_page_path}?{query_params}'.format(
             checkout_page_path=self.get_absolute_ecommerce_url(self.config.basket_checkout_page),
-            skus=urlencode({'sku': skus}, doseq=True),
+            query_params=urlencode(query_params, doseq=True),
         )
         if program_uuid:
             url = '{url}&bundle={program_uuid}'.format(

--- a/lms/djangoapps/verify_student/views.py
+++ b/lms/djangoapps/verify_student/views.py
@@ -518,7 +518,10 @@ class PayAndVerifyView(View):
             # is enabled redirect him to the ecommerce checkout page.
             ecommerce_service = EcommerceService()
             if ecommerce_service.is_enabled(user):
-                url = ecommerce_service.get_checkout_page_url(sku)
+                url = ecommerce_service.get_checkout_page_url(
+                    sku,
+                    enterprise_customer_catalog_uuid=self.request.GET.get('enterprise_customer_catalog_uuid')
+                )
 
         # Redirect if necessary, otherwise implicitly return None
         if url is not None:

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -116,7 +116,7 @@ edx-django-oauth2-provider==1.2.5
 edx-django-release-util==0.3.1
 edx-django-sites-extensions==2.3.1
 edx-drf-extensions==1.5.2
-edx-enterprise==0.70.1
+edx-enterprise==0.70.3
 edx-i18n-tools==0.4.5
 edx-milestones==0.1.13
 edx-oauth2-provider==1.2.2

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -136,7 +136,7 @@ edx-django-oauth2-provider==1.2.5
 edx-django-release-util==0.3.1
 edx-django-sites-extensions==2.3.1
 edx-drf-extensions==1.5.2
-edx-enterprise==0.70.1
+edx-enterprise==0.70.3
 edx-i18n-tools==0.4.5
 edx-lint==0.5.5
 edx-milestones==0.1.13

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -131,7 +131,7 @@ edx-django-oauth2-provider==1.2.5
 edx-django-release-util==0.3.1
 edx-django-sites-extensions==2.3.1
 edx-drf-extensions==1.5.2
-edx-enterprise==0.70.1
+edx-enterprise==0.70.3
 edx-i18n-tools==0.4.5
 edx-lint==0.5.5
 edx-milestones==0.1.13


### PR DESCRIPTION
@asadiqbal08 @saleem-latif @muhammad-ammar @irfanuddinahmad @georgebabey 
**Description:** Add/Show discount for enterprise learners by provided valid enterprise catalog UUID.

**JIRA:** [ENT-1052](https://openedx.atlassian.net/browse/ENT-1052)

**Remaining tasks:** Unittests

**Dependencies:**
1. edx-enterprise: https://github.com/edx/edx-enterprise/pull/333
2. Ecommerce: https://github.com/edx/ecommerce/pull/1830

**Merge deadline:** 29 Jun 2018

**Installation instructions:**  

1. Checkout edx-platform to this branch `zub/ENT-1052-discount-by-enterprise-catalog`.
2. Install `edx-enterprise` from branch `zub/ENT-1052-discount-by-enterprise-catalog` in `edx-platform`.
3. Checkout ecommerce to branch `zub/ENT-1052-discount-by-enterprise-catalog`.
4. In ecommerce django admin (admin/waffle/switch/) verify following waffle flags:
```
force_anonymous_user_response_for_basket_calculate = False
enable_enterprise_offers = True
enable_enterprise_on_runtime = True
```

**Testing instructions:**
1. Create an enterprise with 2 catalogs with a verified course (both catalogs should have this verified course)
2. For catalog A, create enterprise offer with 100% discount.
3. For catalog B, create enterprise offer with 15% discount.
4. Now access the enterprise course enrollment URL with the `UUID` of catalog A, i.e. `http://zubair.localhost:8000/enterprise/72416e52-8c77-4860-9584-15e5b06220fb/course/course-v1:edX+TEST_01+2016_R1/enroll/?enterprise_customer_catalog_uuid=a113c7e2-13ac-46ae-9e24-b75bf7c0058d`
5. Verify that learner sees 100 discount on verified seat for verified course
6. Clicking on 'Continue' button (after consenting) user is redirect to courseware page after automatic enrollment (100% discount).
7. Now access the enterprise course enrollment URL with the `UUID` of catalog B, i.e. `http://zubair.localhost:8000/enterprise/72416e52-8c77-4860-9584-15e5b06220fb/course/course-v1:edX+TEST_01+2016_R1/enroll/?enterprise_customer_catalog_uuid=6eca3efb-f3a0-4c08-806f-c6e6b65d61cb`
8. Verify that learner sees 15 discount on verified seat for verified course
9. Clicking on 'Continue' button (after consenting) user is redirect to basket page with 15% discount applied by the learner's enterprise.