### PR TITLE
Do not update correct_map if state is invalid (EDUCATOR-3016)

### DIFF
--- a/common/lib/capa/capa/correctmap.py
+++ b/common/lib/capa/capa/correctmap.py
@@ -91,8 +91,11 @@ class CorrectMap(object):
         # empty current dict
         self.__init__()
 
+        if not correct_map:
+            return
+
         # create new dict entries
-        if correct_map and not isinstance(correct_map.values()[0], dict):
+        if not isinstance(correct_map.values()[0], dict):
             # special migration
             for k in correct_map:
                 self.set(k, correctness=correct_map[k])

--- a/common/lib/capa/capa/tests/test_correctmap.py
+++ b/common/lib/capa/capa/tests/test_correctmap.py
@@ -215,3 +215,13 @@ class CorrectMapTest(unittest.TestCase):
         for invalid in invalid_list:
             with self.assertRaises(Exception):
                 self.cmap.update(invalid)
+
+    def test_set_none_state(self):
+        """
+        Test that if an invalid state is set to correct map, the state does not
+        update at all.
+        """
+        invalid_list = [None, "", False, 0]
+        for invalid in invalid_list:
+            self.cmap.set_dict(invalid)
+            self.assertEqual(self.cmap.get_dict(), {})


### PR DESCRIPTION
This is simple fix When the `correct_map` is invalid, do not iterate and try to update the correct map.
[EDUCATOR-3016](https://openedx.atlassian.net/browse/EDUCATOR-3016)

Reproducing this issue sandbox and stage is difficult. I believe the test and change is simple enough and can be reviewed without reproducing. 


**Fixes**
```
Jun 18 08:51:15 ip-10-2-71-33 [service_variant=lms][celery.worker.job][env:prod-edx-edxapp] ERROR [ip-10-2-71-33  1939] [log.py:282] - Task lms.djangoapps.instructor_task.tasks.calculate_problem_responses_csv[1968e99f-406c-47d5-8c89-345fee3a9f2b] raised unexpected: TypeError("'NoneType' object is not iterable",)
Traceback (most recent call last):
  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/celery/app/trace.py", line 240, in trace_task
    R = retval = fun(*args, **kwargs)
  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/newrelic/hooks/application_celery.py", line 85, in wrapper
    return wrapped(*args, **kwargs)
  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/celery/app/trace.py", line 438, in __protected_call__
    return self.run(*args, **kwargs)
  File "/edx/app/edxapp/edx-platform/lms/djangoapps/instructor_task/tasks.py", line 171, in calculate_problem_responses_csv
    return run_main_task(entry_id, task_fn, action_name)
  File "/edx/app/edxapp/edx-platform/lms/djangoapps/instructor_task/tasks_helper/runner.py", line 113, in run_main_task
    task_progress = task_fcn(entry_id, course_id, task_input, action_name)
  File "/edx/app/edxapp/edx-platform/lms/djangoapps/instructor_task/tasks_helper/grades.py", line 667, in generate
    usage_key_str=problem_location
  File "/edx/app/edxapp/edx-platform/lms/djangoapps/instructor_task/tasks_helper/grades.py", line 628, in _build_student_data
    block.generate_report_data(user_state_iterator, max_count)
  File "/edx/app/edxapp/edx-platform/common/lib/xmodule/xmodule/capa_module.py", line 380, in generate_report_data
    extract_tree=False,
  File "/edx/app/edxapp/edx-platform/common/lib/capa/capa/capa_problem.py", line 172, in __init__
    self.correct_map.set_dict(state['correct_map'])
  File "/edx/app/edxapp/edx-platform/common/lib/capa/capa/correctmap.py", line 100, in set_dict
    for k in correct_map:
TypeError: 'NoneType' object is not iterable
```

