### PR TITLE
This resolves VPC-122 and OPS-56

### DIFF
--- a/cms/envs/aws.py
+++ b/cms/envs/aws.py
@@ -159,6 +159,7 @@ ALLOWED_HOSTS = [
 ]
 
 LOG_DIR = ENV_TOKENS['LOG_DIR']
+DATA_DIR = ENV_TOKENS.get('DATA_DIR', DATA_DIR)
 
 CACHES = ENV_TOKENS['CACHES']
 # Cache used for location mapping -- called many times with the same key/value

--- a/lms/envs/aws.py
+++ b/lms/envs/aws.py
@@ -324,6 +324,7 @@ WIKI_ENABLED = ENV_TOKENS.get('WIKI_ENABLED', WIKI_ENABLED)
 
 local_loglevel = ENV_TOKENS.get('LOCAL_LOGLEVEL', 'INFO')
 LOG_DIR = ENV_TOKENS['LOG_DIR']
+DATA_DIR = ENV_TOKENS.get('DATA_DIR', DATA_DIR)
 
 LOGGING = get_logger_config(LOG_DIR,
                             logging_env=ENV_TOKENS['LOGGING_ENV'],


### PR DESCRIPTION
I'll put it in configuration later, but why didn't we allow this years
ago?  The goal is to store the data dir in /edx/var/edxapp not in
/edx/app/edxapp.