### PR TITLE
Remove NPM install for unittest runs

### DIFF
--- a/pavelib/prereqs.py
+++ b/pavelib/prereqs.py
@@ -305,7 +305,8 @@ def install_prereqs():
         print NO_PREREQ_MESSAGE
         return
 
-    install_node_prereqs()
+    if not str2bool(os.environ.get('SKIP_NPM_INSTALL', 'False')):
+        install_node_prereqs()
     install_python_prereqs()
     log_installed_python_prereqs()
 

--- a/scripts/unit-tests.sh
+++ b/scripts/unit-tests.sh
@@ -31,6 +31,7 @@ set -e
 
 PAVER_ARGS="-v"
 PARALLEL="--processes=-1"
+export SKIP_NPM_INSTALL="True"
 
 # Skip re-installation of Python prerequisites inside a tox execution.
 if [[ -n "$TOXENV" ]]; then

--- a/tox.ini
+++ b/tox.ini
@@ -42,6 +42,7 @@ passenv =
     SELENIUM_HOST
     SELENIUM_PORT
     SHARD
+    SKIP_NPM_INSTALL
     TEST_SUITE
 deps =
     django18: Django>=1.8,<1.9


### PR DESCRIPTION
Should shave off a couple minutes, and slightly reduce our the risk of npm rate limiting errors we've been seeing.