### PR TITLE
TE-2586 Add missing time zone data to bok-choy fixtures

### DIFF
--- a/common/test/db_fixtures/bulk_email_flag.json
+++ b/common/test/db_fixtures/bulk_email_flag.json
@@ -5,7 +5,7 @@
         "fields": {
             "enabled": true,
             "require_course_email_auth": false,
-            "change_date": "2016-05-01"
+            "change_date": "2016-05-01T00:00:00Z"
         }
     }
 ]

--- a/common/test/db_fixtures/commerce_config.json
+++ b/common/test/db_fixtures/commerce_config.json
@@ -4,7 +4,7 @@
     "model": "commerce.commerceconfiguration",
     "fields": {
       "enabled": 1,
-      "change_date": "2016-04-21 10:19:32.034856"
+      "change_date": "2016-04-21 10:19:32.034856Z"
     }
   }
 ]

--- a/common/test/db_fixtures/grades.json
+++ b/common/test/db_fixtures/grades.json
@@ -5,7 +5,7 @@
         "fields": {
             "enabled": true,
             "enabled_for_all_courses": true,
-            "change_date": "2016-09-01"
+            "change_date": "2016-09-01T00:00:00Z"
         }
     }
 ]

--- a/common/test/db_fixtures/xblock_configuration.json
+++ b/common/test/db_fixtures/xblock_configuration.json
@@ -6,7 +6,7 @@
             "name": "poll",
             "enabled": true,
             "deprecated": true,
-            "change_date": "2016-07-06"
+            "change_date": "2016-07-06T00:00:00Z"
         }
     },
     {
@@ -16,7 +16,7 @@
             "name": "survey",
             "enabled": true,
             "deprecated": true,
-            "change_date": "2016-07-06"
+            "change_date": "2016-07-06T00:00:00Z"
         }
     }
 ]


### PR DESCRIPTION
Fixed the following warnings that appeared when running `paver load_bok_choy_data`:

```
2018-07-02 13:50:25,512 WARNING 489 [py.warnings] __init__.py:1451 - /edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/django/db/models/fields/__init__.py:1451: RuntimeWarning: DateTimeField BulkEmailFlag.change_date received a naive datetime (2016-05-01 00:00:00) while time zone support is active.
  RuntimeWarning)

2018-07-02 13:50:25,778 WARNING 489 [py.warnings] __init__.py:1451 - /edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/django/db/models/fields/__init__.py:1451: RuntimeWarning: DateTimeField CommerceConfiguration.change_date received a naive datetime (2016-04-21 10:19:32.034856) while time zone support is active.
  RuntimeWarning)

2018-07-02 13:50:25,915 WARNING 489 [py.warnings] __init__.py:1451 - /edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/django/db/models/fields/__init__.py:1451: RuntimeWarning: DateTimeField PersistentGradesEnabledFlag.change_date received a naive datetime (2016-09-01 00:00:00) while time zone support is active.
  RuntimeWarning)

2018-07-02 13:50:26,070 WARNING 489 [py.warnings] __init__.py:1451 - /edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/django/db/models/fields/__init__.py:1451: RuntimeWarning: DateTimeField XBlockConfiguration.change_date received a naive datetime (2016-07-06 00:00:00) while time zone support is active.
  RuntimeWarning)
```