### PR TITLE
Remove flaky content library test.

### DIFF
--- a/common/test/acceptance/tests/studio/test_studio_help.py
+++ b/common/test/acceptance/tests/studio/test_studio_help.py
@@ -344,26 +344,6 @@ class LibraryHelpTest(StudioLibraryTest):
         self.library_page = LibraryPage(self.browser, self.library_key)
         self.library_user_page = LibraryUsersPage(self.browser, self.library_key)
 
-    def test_library_content_nav_help(self):
-        """
-        Scenario: Help link in navigation bar is working on content
-        library page(click a library on the Library list page).
-        Given that I am on the content library page(click a library on the Library list page).
-        And I want help about the process
-        And I click the 'Help' in the navigation bar
-        Then Help link should open.
-        And help url should be correct
-        """
-        self.library_page.visit()
-        expected_url = _get_expected_documentation_url('/course_components/libraries.html')
-
-        # Assert that help link is correct.
-        assert_nav_help_link(
-            test=self,
-            page=self.library_page,
-            href=expected_url
-        )
-
     def test_library_content_side_bar_help(self):
         """
         Scenario: Help link in sidebar links is working on


### PR DESCRIPTION
This test failed on commit 7083797c5414d0cdd267534ae220934dc4646648 even though
that change has nothing to do with the content library.

Failing Test Run: https://build.testeng.edx.org/job/edx-platform-bok-choy-master/9014/
Pasing Test Run: https://build.testeng.edx.org/job/edx-platform-bok-choy-master/9015/

This test should probably not even exist.  It's a test on the nav help of a pretty low use feature.  It is not worth the resources of a bok-choy test in my opinion.  Though I am not on the relevant delivery team so I'll leave it up to them on whether or not to close the relevant ticket: https://openedx.atlassian.net/browse/EDUCATOR-3142