### PR TITLE
Pin pylint-plugin-utils until we move to python 3.

### DIFF
--- a/requirements/edx/testing.in
+++ b/requirements/edx/testing.in
@@ -22,6 +22,8 @@ cssselect                 # Used to extract HTML fragments via CSS selectors in 
 ddt                       # Run a test case multiple times with different input; used in many, many of our tests
 edx-i18n-tools>=0.4.5     # Commands for developers and translators to extract, compile and validate translations
 edx-lint                  # pylint extensions for Open edX repositories
+pylint-plugin-utils==0.3  # required by edx-lint and pinned explicitly here because newer versions don't guarantee python 2 support.
+                          # can be removed when we get to python 3
 factory_boy==2.8.1        # Library for creating test fixtures, used in many tests
 freezegun                 # Allows tests to mock the output of assorted datetime module functions
 httpretty                 # Library for mocking HTTP requests, used in many tests

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -244,7 +244,7 @@ pyjwkest==1.3.2
 pyjwt==1.5.2
 pylint-celery==0.3        # via edx-lint
 pylint-django==0.7.2      # via edx-lint
-pylint-plugin-utils==0.3  # via pylint-celery, pylint-django
+pylint-plugin-utils==0.3
 pylint==1.7.1             # via edx-lint, pylint-celery, pylint-django, pylint-plugin-utils
 pymongo==2.9.1
 pynliner==0.5.2


### PR DESCRIPTION
the plugin has abandonned support for python 2 so functionality is not
gauranteed in future upgrades.