### PR TITLE
TE-2583 Avoid redundant bok-choy DB setup steps

### DIFF
--- a/pavelib/database.py
+++ b/pavelib/database.py
@@ -91,14 +91,16 @@ def update_local_bokchoy_db_from_s3(options):
     fingerprint = fingerprint_bokchoy_db_files(MIGRATION_OUTPUT_FILES, ALL_DB_FILES)
     fingerprints_match = does_fingerprint_on_disk_match(fingerprint)
 
+    # Calculating the fingerprint already reset the DB, so we don't need to
+    # do it again (hence use_existing_db=True below)
     if fingerprints_match:
-        print ("DB cache files match the current migrations.")
-        reset_test_db(BOKCHOY_DB_FILES, update_cache_files=False)
+        print("DB cache files match the current migrations.")
+        reset_test_db(BOKCHOY_DB_FILES, update_cache_files=False, use_existing_db=True)
 
     elif is_fingerprint_in_bucket(fingerprint, CACHE_BUCKET_NAME):
-        print ("Found updated bokchoy db files at S3.")
+        print("Found updated bokchoy db files at S3.")
         refresh_bokchoy_db_cache_from_s3(fingerprint, CACHE_BUCKET_NAME, BOKCHOY_DB_FILES)
-        reset_test_db(BOKCHOY_DB_FILES, update_cache_files=False)
+        reset_test_db(BOKCHOY_DB_FILES, update_cache_files=False, use_existing_db=True)
 
     else:
         msg = "{} {} {}".format(
@@ -106,8 +108,8 @@ def update_local_bokchoy_db_from_s3(options):
             "Loading the bokchoy db files from disk",
             "and running migrations."
         )
-        print (msg)
-        reset_test_db(BOKCHOY_DB_FILES, update_cache_files=True)
+        print(msg)
+        reset_test_db(BOKCHOY_DB_FILES, update_cache_files=True, use_existing_db=True)
         # Check one last time to see if the fingerprint is present in
         # the s3 bucket. This could occur because the bokchoy job is
         # sharded and running the same task in parallel

--- a/pavelib/paver_tests/test_database.py
+++ b/pavelib/paver_tests/test_database.py
@@ -115,7 +115,7 @@ class TestPaverDatabaseTasks(MockS3Mixin, TestCase):
             self.assertFalse(_mock_get_file.called)
         calls = [
             call('{}/scripts/reset-test-db.sh --calculate_migrations'.format(Env.REPO_ROOT)),
-            call('{}/scripts/reset-test-db.sh'.format(Env.REPO_ROOT))
+            call('{}/scripts/reset-test-db.sh --use-existing-db'.format(Env.REPO_ROOT))
         ]
         _mock_sh.assert_has_calls(calls)
 
@@ -156,7 +156,7 @@ class TestPaverDatabaseTasks(MockS3Mixin, TestCase):
             )
         calls = [
             call('{}/scripts/reset-test-db.sh --calculate_migrations'.format(Env.REPO_ROOT)),
-            call('{}/scripts/reset-test-db.sh'.format(Env.REPO_ROOT))
+            call('{}/scripts/reset-test-db.sh --use-existing-db'.format(Env.REPO_ROOT))
         ]
         _mock_sh.assert_has_calls(calls)
 
@@ -184,7 +184,7 @@ class TestPaverDatabaseTasks(MockS3Mixin, TestCase):
         database.update_local_bokchoy_db_from_s3()  # pylint: disable=no-value-for-parameter
         calls = [
             call('{}/scripts/reset-test-db.sh --calculate_migrations'.format(Env.REPO_ROOT)),
-            call('{}/scripts/reset-test-db.sh --rebuild_cache'.format(Env.REPO_ROOT))
+            call('{}/scripts/reset-test-db.sh --rebuild_cache --use-existing-db'.format(Env.REPO_ROOT))
         ]
         _mock_sh.assert_has_calls(calls)
 

--- a/pavelib/utils/db_utils.py
+++ b/pavelib/utils/db_utils.py
@@ -30,7 +30,7 @@ def remove_files_from_folder(files, folder):
             continue
 
 
-def reset_test_db(db_cache_files, update_cache_files=True):
+def reset_test_db(db_cache_files, update_cache_files=True, use_existing_db=False):
     """
     Reset the bokchoy test db for a new test run
 
@@ -41,6 +41,8 @@ def reset_test_db(db_cache_files, update_cache_files=True):
     cmd = '{}/scripts/reset-test-db.sh'.format(Env.REPO_ROOT)
     if update_cache_files:
         cmd = '{} --rebuild_cache'.format(cmd)
+    if use_existing_db:
+        cmd = '{} --use-existing-db'.format(cmd)
     sh(cmd)
     verify_files_exist(db_cache_files)
 


### PR DESCRIPTION
Made a couple of fixes to the DB setup process for bok-choy tests:

* Don't load the filesystem schema cache before listing the migrations that need to be applied; this increases the set of possible keys in S3, and duplicates work that will be done again later anyway.
* Don't drop the database again after calculating the needed migrations fingerprint; that was just done.

Now the setup sequence looks something like this:

```
---> pavelib.utils.test.suites.bokchoy_suite.reset_test_database
---> pavelib.database.update_local_bokchoy_db_from_s3
---> pavelib.prereqs.install_prereqs
---> pavelib.prereqs.install_node_prereqs
Node prereqs unchanged, skipping...
---> pavelib.prereqs.install_python_prereqs
---> pavelib.prereqs.uninstall_python_packages
NO_PYTHON_UNINSTALL is set. No attempts will be made to uninstall old Python libs.
Python prereqs unchanged, skipping...
pip freeze > /edx/app/edxapp/edx-platform/test_root/log/pip_freeze.log
You are using pip version 9.0.3, however version 10.0.1 is available.
You should consider upgrading via the 'pip install --upgrade pip' command.
/edx/app/edxapp/edx-platform/scripts/reset-test-db.sh --calculate_migrations
Issuing a reset_db command to the default bok_choy MySQL database.
2018-07-02 16:25:49,834 INFO 3152 [root] reset_db.py:88 - Executing... "DROP DATABASE IF EXISTS `edxtest`"
2018-07-02 16:25:52,381 INFO 3152 [root] reset_db.py:90 - Executing... "CREATE DATABASE `edxtest` CHARACTER SET utf8"
Issuing a reset_db command to the student_module_history bok_choy MySQL database.
2018-07-02 16:26:16,199 INFO 3265 [root] reset_db.py:88 - Executing... "DROP DATABASE IF EXISTS `student_module_history_test`"
2018-07-02 16:26:16,211 INFO 3265 [root] reset_db.py:90 - Executing... "CREATE DATABASE `student_module_history_test` CHARACTER SET utf8"
Calculating migrations for fingerprinting.
Calculating migrations for fingerprinting.
Verifying that all files needed to compute the fingerprint exist.
Computing the fingerprint.
The fingerprint for bokchoy db files is: ecbfe0d38106df40a57937c765a426605b43d8dd
Did not find updated bokchoy db files at S3. Loading the bokchoy db files from disk and running migrations.
/edx/app/edxapp/edx-platform/scripts/reset-test-db.sh --rebuild_cache --use-existing-db
Loading the schema from the filesystem into the default MySQL DB.
Loading the fixture data from the filesystem into the default MySQL DB.
Installed 1736 object(s) from 1 fixture(s)
Loading the migration data from the filesystem into the default MySQL DB.
Loading the schema from the filesystem into the student_module_history MySQL DB.
Loading the fixture data from the filesystem into the student_module_history MySQL DB.
...
```