### PR TITLE
TE-2630 Fix discussions bok-choy tests in devstack

### DIFF
--- a/cms/envs/bok_choy_docker.env.json
+++ b/cms/envs/bok_choy_docker.env.json
@@ -55,7 +55,7 @@
         }
     },
     "COMMENTS_SERVICE_KEY": "password",
-    "COMMENTS_SERVICE_URL": "http://edx.devstack.forum:4567",
+    "COMMENTS_SERVICE_URL": "http://edx.devstack.studio:4567",
     "CONTACT_EMAIL": "info@example.com",
     "DEFAULT_FEEDBACK_EMAIL": "feedback@example.com",
     "DEFAULT_FROM_EMAIL": "registration@example.com",

--- a/cms/envs/bok_choy_docker.py
+++ b/cms/envs/bok_choy_docker.py
@@ -10,6 +10,8 @@ CMS_BASE = '{}:{}'.format(os.environ['BOK_CHOY_HOSTNAME'], os.environ['BOK_CHOY_
 LMS_BASE = '{}:{}'.format(os.environ['BOK_CHOY_HOSTNAME'], os.environ['BOK_CHOY_LMS_PORT'])
 LMS_ROOT_URL = 'http://{}'.format(LMS_BASE)
 
+COMMENTS_SERVICE_URL = 'http://{}:4567'.format(os.environ['BOK_CHOY_HOSTNAME'])
+
 # Docker does not support the syslog socket at /dev/log. Rely on the console.
 LOGGING['handlers']['local'] = LOGGING['handlers']['tracking'] = {
     'class': 'logging.NullHandler',

--- a/common/test/acceptance/fixtures/__init__.py
+++ b/common/test/acceptance/fixtures/__init__.py
@@ -18,7 +18,7 @@ XQUEUE_STUB_URL = os.environ.get('xqueue_url', 'http://localhost:8040')
 ORA_STUB_URL = os.environ.get('ora_url', 'http://localhost:8041')
 
 # Get the URL of the comments service stub used in the test
-COMMENTS_STUB_URL = os.environ.get('comments_url', 'http://localhost:4567')
+COMMENTS_STUB_URL = os.environ.get('comments_url', 'http://{}:4567'.format(HOSTNAME))
 
 # Get the URL of the EdxNotes service stub used in the test
 EDXNOTES_STUB_URL = os.environ.get('edxnotes_url', 'http://localhost:8042')

--- a/lms/envs/bok_choy_docker.env.json
+++ b/lms/envs/bok_choy_docker.env.json
@@ -55,7 +55,7 @@
         }
     },
     "COMMENTS_SERVICE_KEY": "password",
-    "COMMENTS_SERVICE_URL": "http://edx.devstack.forum:4567",
+    "COMMENTS_SERVICE_URL": "http://edx.devstack.lms:4567",
     "CONTACT_EMAIL": "info@example.com",
     "DEFAULT_FEEDBACK_EMAIL": "feedback@example.com",
     "DEFAULT_FROM_EMAIL": "registration@example.com",

--- a/lms/envs/bok_choy_docker.py
+++ b/lms/envs/bok_choy_docker.py
@@ -10,6 +10,8 @@ CMS_BASE = '{}:{}'.format(os.environ['BOK_CHOY_HOSTNAME'], os.environ['BOK_CHOY_
 LMS_BASE = '{}:{}'.format(os.environ['BOK_CHOY_HOSTNAME'], os.environ['BOK_CHOY_LMS_PORT'])
 LMS_ROOT_URL = 'http://{}'.format(LMS_BASE)
 
+COMMENTS_SERVICE_URL = 'http://{}:4567'.format(os.environ['BOK_CHOY_HOSTNAME'])
+
 # Docker does not support the syslog socket at /dev/log. Rely on the console.
 LOGGING['handlers']['local'] = LOGGING['handlers']['tracking'] = {
     'class': 'logging.NullHandler',


### PR DESCRIPTION
Fix 45 failing discussions-related bok-choy tests in devstack by correcting the URL the browser needs to use to access the stub discussions server.