### PR TITLE
Include original state in learner response report

### DIFF
--- a/cms/djangoapps/contentstore/tasks.py
+++ b/cms/djangoapps/contentstore/tasks.py
@@ -185,7 +185,7 @@ def async_migrate_transcript(self, course_key, **kwargs):   # pylint: disable=un
 
             sub_tasks = []
             video_location = unicode(video.location)
-            for lang in all_transcripts.keys():
+            for lang in all_transcripts:
                 sub_tasks.append(async_migrate_transcript_subtask.s(
                     video_location, revision, lang, force_update, **kwargs
                 ))

--- a/cms/static/sass/views/_video-upload.scss
+++ b/cms/static/sass/views/_video-upload.scss
@@ -1,5 +1,6 @@
 .view-video-uploads {
-  .content-primary, .content-supplementary {
+  .content-primary,
+  .content-supplementary {
     @include box-sizing(border-box);
   }
 
@@ -8,6 +9,7 @@
       @extend %t-copy;
 
       vertical-align: bottom;
+
       @include margin-right($baseline/45);
     }
   }
@@ -18,11 +20,11 @@
   }
 
   .button-link {
-    background:none;
-    border:none;
-    padding:0;
+    background: none;
+    border: none;
+    padding: 0;
     color: $ui-link-color;
-    cursor:pointer
+    cursor: pointer;
   }
 
   .video-transcripts-wrapper {
@@ -41,8 +43,8 @@
     margin-top: ($baseline/2);
 
     .transcript-upload-status-container {
-
-      .video-transcript-detail-status, .more-details-action {
+      .video-transcript-detail-status,
+      .more-details-action {
         @include font-size(12);
         @include line-height(12);
         @include margin-left($baseline/4);
@@ -72,9 +74,9 @@
     width: 352px;
     transition: all 0.3s ease;
     background-color: $white;
-    -webkit-box-shadow: -3px 0px 3px 0px rgba(153,153,153,0.3);
-    -moz-box-shadow: -3px 0px 3px 0px rgba(153,153,153,0.3);
-    box-shadow: -3px 0px 3px 0px rgba(153,153,153,0.3);
+    -webkit-box-shadow: -3px 0 3px 0 rgba(153, 153, 153, 0.3);
+    -moz-box-shadow: -3px 0 3px 0 rgba(153, 153, 153, 0.3);
+    box-shadow: -3px 0 3px 0 rgba(153, 153, 153, 0.3);
 
     .action-close-wrapper {
       .action-close-course-video-settings {
@@ -84,19 +86,21 @@
         border: transparent;
         height: ($baseline*2.4);
         color: $text-dark-black-blue;
+
         @include font-size(16);
         @include text-align(left);
       }
     }
 
     .course-video-settings-wrapper {
-      margin-top: ($baseline*1.60);
+      margin-top: ($baseline*1.6);
       padding: ($baseline) ($baseline*0.8);
 
       .course-video-settings-title {
         color: $black-t4;
         margin: ($baseline*1.6) 0 ($baseline*0.8) 0;
         font-weight: font-weight(semi-bold);
+
         @include font-size(24);
       }
 
@@ -105,7 +109,9 @@
         margin-bottom: ($baseline*0.8);
         max-height: ($baseline*2.4);
         color: $black;
+
         @include font-size(16);
+
         .icon {
           @include margin-right($baseline/4);
         }
@@ -123,6 +129,7 @@
 
       .organization-credentials-content {
         margin-top: ($baseline*1.6);
+
         .org-credentials-wrapper input {
           width: 65%;
           margin-top: ($baseline*0.8);
@@ -132,15 +139,18 @@
 
       .transcript-preferance-wrapper {
         margin-top: ($baseline*1.6);
+
         .icon.fa-info-circle {
           @include margin-left($baseline*0.75);
         }
       }
+
       .transcript-preferance-wrapper.error .transcript-preferance-label {
         color: $color-error;
       }
 
-      .error-info, .error-icon .fa-info-circle {
+      .error-info,
+      .error-icon .fa-info-circle {
         color: $color-error;
       }
 
@@ -150,13 +160,18 @@
       }
 
       .transcript-preferance-label {
-        color: $black-t4;
         @include font-size(15);
+
+        color: $black-t4;
         font-weight: font-weight(semi-bold);
         display: block;
       }
 
-      .transcript-provider-group, .transcript-turnaround, .transcript-fidelity, .video-source-language, .selected-transcript-provider {
+      .transcript-provider-group,
+      .transcript-turnaround,
+      .transcript-fidelity,
+      .video-source-language,
+      .selected-transcript-provider {
         margin-top: ($baseline*0.8);
       }
 
@@ -167,17 +182,22 @@
       }
 
       .transcript-provider-group {
-        input[type=radio]  {
+        input[type=radio] {
           margin: 0 ($baseline/2);
         }
+
         label {
           font-weight: normal;
           color: $black-t4;
+
           @include font-size(15);
         }
       }
 
-      .transcript-turnaround-wrapper, .transcript-fidelity-wrapper, .video-source-language-wrapper, .transcript-languages-wrapper {
+      .transcript-turnaround-wrapper,
+      .transcript-fidelity-wrapper,
+      .video-source-language-wrapper,
+      .transcript-languages-wrapper {
         display: none;
       }
 
@@ -187,36 +207,46 @@
 
       .transcript-languages-container .languages-container {
         margin-top: ($baseline*0.8);
+
         .transcript-language-container {
           padding: ($baseline/4);
           background-color: $gray-l6;
           border-top: solid 1px $gray-l4;
           border-bottom: solid 1px $gray-l4;
+
           .remove-language-action {
             display: inline-block;
+
             @include float(right);
           }
         }
       }
+
       .transcript-language-menu-container {
         margin-top: ($baseline*0.8);
+
         .add-language-action {
           display: inline-block;
+
           .action-add-language {
             @include margin-left($baseline/4);
           }
+
           .error-info {
             display: inline-block;
           }
         }
       }
-      .transcript-language-menu, .video-source-language {
+
+      .transcript-language-menu,
+      .video-source-language {
         width: 60%;
       }
     }
 
     .transcription-account-details {
       margin-top: ($baseline*0.8);
+
       span {
         @include font-size(15);
       }
@@ -233,8 +263,10 @@
 
     .course-video-settings-footer {
       margin-top: ($baseline*1.6);
+
       .last-updated-text {
         @include font-size(12);
+
         display: block;
         margin-top: ($baseline/2);
       }
@@ -279,11 +311,11 @@
       }
 
       &:hover .upload-text-link {
-        text-decoration:underline;
+        text-decoration: underline;
       }
 
-      .fa-cloud-upload{
-        font-size:7em;
+      .fa-cloud-upload {
+        font-size: 7em;
         vertical-align: top;
 
         @include margin-right(0.1em);
@@ -300,8 +332,8 @@
 
         .video-uploads-header {
           font-size: 1.5em;
-          margin-bottom: .25em;
-          font-weight: 600
+          margin-bottom: 0.25em;
+          font-weight: 600;
         }
 
         .video-max-file-size-text {
@@ -335,12 +367,14 @@
           font-size: 90%;
         }
 
-        .video-detail-status, .more-details-action {
+        .video-detail-status,
+        .more-details-action {
           @include font-size(12);
           @include line-height(12);
         }
 
-        .more-details-action, .upload-failure {
+        .more-details-action,
+        .upload-failure {
           display: none;
         }
 
@@ -393,7 +427,8 @@
             background-color: $color-error;
           }
 
-          .more-details-action, .upload-failure {
+          .more-details-action,
+          .upload-failure {
             display: inline-block;
             color: $color-error;
           }
@@ -458,11 +493,13 @@
         width: 17%;
       }
 
-      .thumbnail-col, .video-id-col {
+      .thumbnail-col,
+      .video-id-col {
         width: 15%;
       }
 
-      .date-col, .status-col {
+      .date-col,
+      .status-col {
         width: 10%;
       }
 
@@ -532,7 +569,8 @@
       &:hover,
       &:focus,
       &.focused {
-        img, .video-duration {
+        img,
+        .video-duration {
           @include transition(all 0.3s linear);
 
           opacity: 0.1;
@@ -592,7 +630,7 @@
       position: absolute;
       text-align: center;
       top: 50%;
-      left: 5px;;
+      left: 5px;
       right: 5px;
 
       @include transform(translateY(-50%));

--- a/common/lib/capa/capa/capa_problem.py
+++ b/common/lib/capa/capa/capa_problem.py
@@ -495,6 +495,27 @@ class LoncapaProblem(object):
             answer_ids.append(results.keys())
         return answer_ids
 
+    def find_correct_answer_text(self, answer_id):
+        """
+        Returns the correct answer(s) for the provided answer_id as a single string.
+
+        Arguments::
+            answer_id (str): a string like "98e6a8e915904d5389821a94e48babcf_13_1"
+
+        Returns:
+            str: A string containing the answer or multiple answers separated by commas.
+        """
+        xml_elements = self.tree.xpath('//*[@id="' + answer_id + '"]')
+        if not xml_elements:
+            return
+        xml_element = xml_elements[0]
+        answer_text = xml_element.xpath('@answer')
+        if answer_text:
+            return answer_id[0]
+        if xml_element.tag == 'optioninput':
+            return xml_element.xpath('@correct')[0]
+        return ', '.join(xml_element.xpath('*[@correct="true"]/text()'))
+
     def find_question_label(self, answer_id):
         """
         Obtain the most relevant question text for a particular answer.

--- a/common/lib/capa/capa/tests/test_capa_problem.py
+++ b/common/lib/capa/capa/tests/test_capa_problem.py
@@ -659,6 +659,44 @@ class CAPAProblemReportHelpersTest(unittest.TestCase):
         )
         self.assertEquals(problem.find_answer_text(answer_id, choice_id), answer_text)
 
+    @ddt.data(
+        # Test for ChoiceResponse
+        ('1_2_1', 'over-suspicious'),
+        # Test for MultipleChoiceResponse
+        ('1_3_1', 'The iPad, Napster'),
+        # Test for OptionResponse
+        ('1_4_1', 'blue'),
+    )
+    @ddt.unpack
+    def test_find_correct_answer_text_choices(self, answer_id, answer_text):
+        """
+        Verify that ``find_correct_answer_text`` can find the correct answer for
+        ChoiceResponse, MultipleChoiceResponse and OptionResponse problems.
+        """
+        problem = new_loncapa_problem(
+            """
+            <problem>
+                <choiceresponse>
+                    <checkboxgroup label="Select the correct synonym of paranoid?">
+                        <choice correct="true">over-suspicious</choice>
+                        <choice correct="false">funny</choice>
+                    </checkboxgroup>
+                </choiceresponse>
+                <multiplechoiceresponse>
+                    <choicegroup type="MultipleChoice">
+                        <choice correct="true">The iPad</choice>
+                        <choice correct="true">Napster</choice>
+                        <choice correct="false">The iPod</choice>
+                    </choicegroup>
+                </multiplechoiceresponse>
+                <optionresponse>
+                    <optioninput options="('yellow','blue','green')" correct="blue" label="Color_1"/>
+                </optionresponse>
+            </problem>
+            """
+        )
+        self.assertEquals(problem.find_correct_answer_text(answer_id), answer_text)
+
     def test_find_answer_text_textinput(self):
         problem = new_loncapa_problem(
             """

--- a/common/lib/xmodule/xmodule/capa_module.py
+++ b/common/lib/xmodule/xmodule/capa_module.py
@@ -393,13 +393,17 @@ class CapaDescriptor(CapaFields, RawDescriptor):
 
                 question_text = lcp.find_question_label(answer_id)
                 answer_text = lcp.find_answer_text(answer_id, current_answer=orig_answers)
+                correct_answer_text = lcp.find_correct_answer_text(answer_id)
 
                 count += 1
-                yield (user_state.username, {
+                report = {
                     _("Answer ID"): answer_id,
                     _("Question"): question_text,
                     _("Answer"): answer_text,
-                })
+                }
+                if correct_answer_text is not None:
+                    report[_("Correct Answer")] = correct_answer_text
+                yield (user_state.username, report)
 
     # Proxy to CapaModule for access to any of its attributes
     answer_available = module_attr('answer_available')

--- a/lms/djangoapps/instructor_task/tests/test_tasks_helper.py
+++ b/lms/djangoapps/instructor_task/tests/test_tasks_helper.py
@@ -598,6 +598,7 @@ class TestProblemResponsesReport(TestReportMixin, InstructorTaskModuleTestCase):
             'title': 'Problem1',
             'Answer ID': 'i4x-edx-1_23x-problem-Problem1_2_1',
             'Answer': 'Option 1',
+            'Correct Answer': u'Option 1',
             'Question': u'The correct answer is Option 1',
         }, student_data[0])
         self.assertIn('state', student_data[0])

--- a/lms/djangoapps/instructor_task/tests/test_tasks_helper.py
+++ b/lms/djangoapps/instructor_task/tests/test_tasks_helper.py
@@ -36,10 +36,15 @@ from shoppingcart.models import (
     Invoice,
     InvoiceTransaction,
     Order,
-    PaidCourseRegistration
+    PaidCourseRegistration,
 )
 from six import text_type
-from student.models import ALLOWEDTOENROLL_TO_ENROLLED, CourseEnrollment, CourseEnrollmentAllowed, ManualEnrollmentAudit
+from student.models import (
+    ALLOWEDTOENROLL_TO_ENROLLED,
+    CourseEnrollment,
+    CourseEnrollmentAllowed,
+    ManualEnrollmentAudit,
+)
 from student.tests.factories import CourseEnrollmentFactory, UserFactory
 from survey.models import SurveyAnswer, SurveyForm
 from xmodule.modulestore import ModuleStoreEnum
@@ -57,24 +62,24 @@ from lms.djangoapps.instructor_task.tasks_helper.enrollments import (
     upload_enrollment_report,
     upload_exec_summary_report,
     upload_may_enroll_csv,
-    upload_students_csv
+    upload_students_csv,
 )
 from lms.djangoapps.instructor_task.tasks_helper.grades import (
     ENROLLED_IN_COURSE,
     NOT_ENROLLED_IN_COURSE,
     CourseGradeReport,
     ProblemGradeReport,
-    ProblemResponses
+    ProblemResponses,
 )
 from lms.djangoapps.instructor_task.tasks_helper.misc import (
     cohort_students_and_upload,
     upload_course_survey_report,
-    upload_ora2_data
+    upload_ora2_data,
 )
 from lms.djangoapps.instructor_task.tests.test_base import (
     InstructorTaskCourseTestCase,
     InstructorTaskModuleTestCase,
-    TestReportMixin
+    TestReportMixin,
 )
 from lms.djangoapps.teams.tests.factories import CourseTeamFactory, CourseTeamMembershipFactory
 from lms.djangoapps.verify_student.tests.factories import SoftwareSecurePhotoVerificationFactory
@@ -481,6 +486,7 @@ class TestProblemResponsesReport(TestReportMixin, InstructorTaskModuleTestCase):
     Tests that generation of CSV files listing student answers to a
     given problem works.
     """
+
     def setUp(self):
         super(TestProblemResponsesReport, self).setUp()
         self.initialize_course()
@@ -510,7 +516,7 @@ class TestProblemResponsesReport(TestReportMixin, InstructorTaskModuleTestCase):
             student = self.create_student('student{}'.format(ctr))
             self.submit_student_answer(student.username, u'Problem1', ['Option 1'])
 
-        student_data = ProblemResponses._build_student_data(
+        student_data, _ = ProblemResponses._build_student_data(
             user_id=self.instructor.id,
             course_key=self.course.id,
             usage_key_str=str(self.course.location),
@@ -530,7 +536,7 @@ class TestProblemResponsesReport(TestReportMixin, InstructorTaskModuleTestCase):
         problem = self.define_option_problem(u'Problem1')
         self.submit_student_answer(self.student.username, u'Problem1', ['Option 1'])
         with self._remove_capa_report_generator():
-            student_data = ProblemResponses._build_student_data(
+            student_data, _ = ProblemResponses._build_student_data(
                 user_id=self.instructor.id,
                 course_key=self.course.id,
                 usage_key_str=str(problem.location),
@@ -552,11 +558,12 @@ class TestProblemResponsesReport(TestReportMixin, InstructorTaskModuleTestCase):
         ``generate_report_data`` method works as expected.
         """
         self.define_option_problem(u'Problem1')
-        state = {'some': 'state'}
+        self.submit_student_answer(self.student.username, u'Problem1', ['Option 1'])
+        state = {'some': 'state', 'more': 'state!'}
         mock_generate_report_data.return_value = iter([
             ('student', state),
         ])
-        student_data = ProblemResponses._build_student_data(
+        student_data, _ = ProblemResponses._build_student_data(
             user_id=self.instructor.id,
             course_key=self.course.id,
             usage_key_str=str(self.course.location),
@@ -567,7 +574,8 @@ class TestProblemResponsesReport(TestReportMixin, InstructorTaskModuleTestCase):
             'location': 'test_course > Section > Subsection > Problem1',
             'block_key': 'i4x://edx/1.23x/problem/Problem1',
             'title': 'Problem1',
-            'state': state,
+            'some': 'state',
+            'more': 'state!',
         }, student_data[0])
 
     def test_build_student_data_for_block_with_real_generate_report_data(self):
@@ -577,7 +585,7 @@ class TestProblemResponsesReport(TestReportMixin, InstructorTaskModuleTestCase):
         """
         self.define_option_problem(u'Problem1')
         self.submit_student_answer(self.student.username, u'Problem1', ['Option 1'])
-        student_data = ProblemResponses._build_student_data(
+        student_data, _ = ProblemResponses._build_student_data(
             user_id=self.instructor.id,
             course_key=self.course.id,
             usage_key_str=str(self.course.location),
@@ -588,12 +596,11 @@ class TestProblemResponsesReport(TestReportMixin, InstructorTaskModuleTestCase):
             'location': 'test_course > Section > Subsection > Problem1',
             'block_key': 'i4x://edx/1.23x/problem/Problem1',
             'title': 'Problem1',
-            'state': {
-                'Answer ID': 'i4x-edx-1_23x-problem-Problem1_2_1',
-                'Answer': 'Option 1',
-                'Question': u'The correct answer is Option 1'
-            },
+            'Answer ID': 'i4x-edx-1_23x-problem-Problem1_2_1',
+            'Answer': 'Option 1',
+            'Question': u'The correct answer is Option 1',
         }, student_data[0])
+        self.assertIn('state', student_data[0])
 
     @patch('lms.djangoapps.instructor_task.tasks_helper.grades.list_problem_responses')
     @patch('xmodule.capa_module.CapaDescriptor.generate_report_data', create=True)
@@ -624,11 +631,14 @@ class TestProblemResponsesReport(TestReportMixin, InstructorTaskModuleTestCase):
         with patch('lms.djangoapps.instructor_task.tasks_helper.runner._get_current_task'):
             with patch('lms.djangoapps.instructor_task.tasks_helper.grades'
                        '.ProblemResponses._build_student_data') as mock_build_student_data:
-                mock_build_student_data.return_value = [
-                    {'username': 'user0', 'state': u'state0'},
-                    {'username': 'user1', 'state': u'state1'},
-                    {'username': 'user2', 'state': u'state2'},
-                ]
+                mock_build_student_data.return_value = (
+                    [
+                        {'username': 'user0', 'state': u'state0'},
+                        {'username': 'user1', 'state': u'state1'},
+                        {'username': 'user2', 'state': u'state2'},
+                    ],
+                    ['username', 'state']
+                )
                 result = ProblemResponses.generate(
                     None, None, self.course.id, task_input, 'calculated'
                 )
@@ -1620,7 +1630,10 @@ class TestCohortStudents(TestReportMixin, InstructorTaskCourseTestCase):
         self.cohort_2 = CohortFactory(course_id=self.course.id, name='Cohort 2')
         self.student_1 = self.create_student(username=u'student_1\xec', email='student_1@example.com')
         self.student_2 = self.create_student(username='student_2', email='student_2@example.com')
-        self.csv_header_row = ['Cohort Name', 'Exists', 'Learners Added', 'Learners Not Found', 'Invalid Email Addresses', 'Preassigned Learners']
+        self.csv_header_row = [
+            'Cohort Name', 'Exists', 'Learners Added', 'Learners Not Found',
+            'Invalid Email Addresses', 'Preassigned Learners',
+        ]
 
     def _cohort_students_and_upload(self, csv_data):
         """


### PR DESCRIPTION
A [previous enhancement](https://github.com/edx/edx-platform/pull/17776) to the learner response report removed the original state parameter in favour of a cleaner state. This work restores the original state while still including the original enhancements. 

Also in this PR:
- The data provided by the xblock report generator is now available in columns in the final CSV instead of as a JSON string in a single column. 
- For certain kinds of problems the correct answer is also included in the final report under the "Correct Answer" column.  

**JIRA tickets**: https://openedx.atlassian.net/browse/EDUCATOR-3143

**Sandbox URL**: (deprovisioned)

**Testing instructions**:
Run included tests with: 
``pytest lms/djangoapps/instructor_task/tests/test_tasks_helper.py::TestProblemResponsesReport``

**Sample Output**:


username | block_key | title | Question | Answer | state | location | Answer ID
-- | -- | -- | -- | -- | -- | -- | --
edx | block-v1:edX+DemoX+Demo_Course+type@problem+block@c554538a57664fac80783b99d9d6da7c | Pointing on a Picture | Which animal is a kitten? | [529,186] | {"correct_map": {"c554538a57664fac80783b99d9d6da7c_2_1": {"hint": "", "hintmode": null, "correctness": "correct", "msg": "", "answervariable": null, "npoints": null, "queuestate": null}}, "input_state": {"c554538a57664fac80783b99d9d6da7c_2_1": {}}, "last_submission_time": "2018-07-03T18:40:53Z", "attempts": 1, "score": {"raw_earned": 1, "raw_possible": 1}, "done": true, "student_answers": {"c554538a57664fac80783b99d9d6da7c_2_1": "[529,186]"}, "seed": 1} | Homework - Question Styles > Pointing on a Picture > Pointing on a Picture | c554538a57664fac80783b99d9d6da7c_2_1
edx | block-v1:edX+DemoX+Demo_Course+type@problem+block@d2e35c1d294b4ba0b3b1048615605d2a | Drag and Drop | Question 1 | [{"2":[430,178.0833282470703]},{"3":[190,162.0833282470703]},{"5":[25,141.0833282470703]},{"6":[281,154.0833282470703]},{"9":[548,206.0833282470703]}] | {"score": {"raw_possible": 1, "raw_earned": 0}, "correct_map": {"d2e35c1d294b4ba0b3b1048615605d2a_2_1": {"hint": "", "hintmode": null, "correctness": "incorrect", "msg": "", "answervariable": null, "npoints": 0, "queuestate": null}}, "input_state": {"d2e35c1d294b4ba0b3b1048615605d2a_2_1": {}}, "last_submission_time": "2018-07-03T18:41:08Z", "attempts": 1, "seed": 1, "done": true, "student_answers": {"d2e35c1d294b4ba0b3b1048615605d2a_2_1": "[{\"2\":[430,178.0833282470703]},{\"3\":[190,162.0833282470703]},{\"5\":[25,141.0833282470703]},{\"6\":[281,154.0833282470703]},{\"9\":[548,206.0833282470703]}]"}} | Homework - Question Styles > Drag and Drop > Drag and Drop | d2e35c1d294b4ba0b3b1048615605d2a_2_1
edx | block-v1:edX+DemoX+Demo_Course+type@problem+block@a0effb954cca4759994f1ac9e9434bf4 | Multiple Choice Questions | Which piece of furniture is built for sitting? | a chair | {"correct_map": {"a0effb954cca4759994f1ac9e9434bf4_4_1": {"hint": "", "hintmode": null, "correctness": "correct", "msg": "", "answervariable": null, "npoints": null, "queuestate": null}, "a0effb954cca4759994f1ac9e9434bf4_2_1": {"hint": "", "hintmode": null, "correctness": "incorrect", "msg": "", "answervariable": null, "npoints": null, "queuestate": null}, "a0effb954cca4759994f1ac9e9434bf4_3_1": {"hint": "", "hintmode": null, "correctness": "correct", "msg": "", "answervariable": null, "npoints": null, "queuestate": null}}, "input_state": {"a0effb954cca4759994f1ac9e9434bf4_4_1": {}, "a0effb954cca4759994f1ac9e9434bf4_2_1": {}, "a0effb954cca4759994f1ac9e9434bf4_3_1": {}}, "last_submission_time": "2018-07-03T18:41:13Z", "attempts": 3, "score": {"raw_possible": 3, "raw_earned": 2}, "done": true, "student_answers": {"a0effb954cca4759994f1ac9e9434bf4_4_1": ["choice_0", "choice_2"], "a0effb954cca4759994f1ac9e9434bf4_2_1": "yellow", "a0effb954cca4759994f1ac9e9434bf4_3_1": "choice_2"}, "seed": 1} | Homework - Question Styles > Multiple Choice Questions > Multiple Choice Questions | a0effb954cca4759994f1ac9e9434bf4_3_1
edx | block-v1:edX+DemoX+Demo_Course+type@problem+block@Sample_Algebraic_Problem | Mathematical Expressions | Question 1 | A*x^2 + sqrt(y) | {"correct_map": {"Sample_Algebraic_Problem_2_1": {"hint": "", "hintmode": null, "correctness": "correct", "msg": "", "answervariable": null, "npoints": null, "queuestate": null}}, "input_state": {"Sample_Algebraic_Problem_2_1": {}}, "last_submission_time": "2018-07-03T18:42:00Z", "attempts": 1, "score": {"raw_earned": 1, "raw_possible": 1}, "done": true, "student_answers": {"Sample_Algebraic_Problem_2_1": "A*x^2 + sqrt(y)", "Sample_Algebraic_Problem_2_1_dynamath": "<math xmlns=\"http://www.w3.org/1998/Math/MathML\">\r\n  <mstyle displaystyle=\"true\">\r\n    <mi>A</mi>\r\n    <mo>&#x22C5;</mo>\r\n    <msup>\r\n      <mi>x</mi>\r\n      <mn>2</mn>\r\n    </msup>\r\n    <mo>+</mo>\r\n    <msqrt>\r\n      <mrow>\r\n        <mi>y</mi>\r\n      </mrow>\r\n    </msqrt>\r\n  </mstyle>\r\n</math>"}, "seed": 1} | Homework - Question Styles > Mathematical Expressions > Mathematical Expressions | Sample_Algebraic_Problem_2_1
edx | block-v1:edX+DemoX+Demo_Course+type@problem+block@Sample_ChemFormula_Problem | Chemical Equations |   |   | {"score": {"raw_earned": 0, "raw_possible": 1}, "seed": 1, "input_state": {"Sample_ChemFormula_Problem_2_1": {}}} | Homework - Question Styles > Chemical Equations > Chemical Equations |  
edx | block-v1:edX+DemoX+Demo_Course+type@problem+block@75f9562c77bc4858b61f907bb810d974 | Numerical Input |   |   | {"score": {"raw_earned": 0, "raw_possible": 3}, "seed": 1, "input_state": {"75f9562c77bc4858b61f907bb810d974_2_1": {}, "75f9562c77bc4858b61f907bb810d974_3_1": {}, "75f9562c77bc4858b61f907bb810d974_4_1": {}}} | Homework - Question Styles > Numerical Input > Numerical Input |  
edx | block-v1:edX+DemoX+Demo_Course+type@problem+block@0d759dee4f9d459c8956136dbde55f02 | Text Input |   |   | {"score": {"raw_earned": 0, "raw_possible": 1}, "seed": 1, "input_state": {"0d759dee4f9d459c8956136dbde55f02_2_1": {}}} | Homework - Question Styles > Text input > Text Input |  


**Reviewers**
- [ ] @bradenmacdonald 
- [ ] edX reviewer[s] TBD

**Settings**
```yaml
JOURNALS_ENABLED: false
# copied from https://github.com/edx/configuration/blob/cf4d221d384ed396a3008c31487f385544ef08e7/util/jenkins/ansible-provision.sh#L328-L338
JOURNALS_URL_ROOT: "https://journals-{{ EDXAPP_LMS_BASE }}"
JOURNALS_API_URL: "https://journals-{{ EDXAPP_LMS_BASE }}/api/v1/"
JOURNALS_DISCOVERY_SERVICE_URL: "https://discovery-{{ EDXAPP_LMS_BASE }}"
JOURNALS_LMS_URL_ROOT: "https://{{ EDXAPP_LMS_BASE }}"
JOURNALS_SOCIAL_AUTH_REDIRECT_IS_HTTPS: true
JOURNALS_DISCOVERY_API_URL: "{{ JOURNALS_DISCOVERY_SERVICE_URL }}/api/v1/"
JOURNALS_DISCOVERY_JOURNALS_API_URL: "{{ JOURNALS_DISCOVERY_SERVICE_URL }}/journal/api/v1/"
JOURNALS_ECOMMERCE_BASE_URL: "{{ ECOMMERCE_ECOMMERCE_URL_ROOT }}"
JOURNALS_ECOMMERCE_API_URL: "{{ JOURNALS_ECOMMERCE_BASE_URL }}/api/v2/"
JOURNALS_ECOMMERCE_JOURNALS_API_URL: "{{ JOURNALS_ECOMMERCE_BASE_URL }}/journal/api/v1"
journals_create_demo_data: false

xqueue_source_repo: https://github.com/edx/xqueue
xqueue_version: master
CERTS_REPO: https://github.com/edx/edx-certificates
certs_version: master
```