### PR TITLE
Styling fix for Course Outline subsection label

### DIFF
--- a/lms/static/sass/features/_course-experience.scss
+++ b/lms/static/sass/features/_course-experience.scss
@@ -344,6 +344,7 @@
           margin: 0 0 0 35px;
 
           .subsection-title {
+            display: inline-block;
             margin: 0;
             font-weight: $font-regular;
             margin-left: $baseline - 2;


### PR DESCRIPTION
Currently the subsection icon + label are on separate lines due to a missing display rule on the subsection-title. 

(meant to realize 3rd AC of this original ticket: https://openedx.atlassian.net/browse/EDUCATOR-2535)

**Current Behavior**
![image](https://user-images.githubusercontent.com/2023680/42289923-5f5c23d6-7f90-11e8-94f5-13e605269ffd.png)


**With Change:**
![image](https://user-images.githubusercontent.com/2023680/42289907-4d7dd04c-7f90-11e8-9621-86b0fbace53b.png)
