### PR TITLE
TE-2631 Fix notes bok-choy tests in devstack

### DIFF
--- a/cms/envs/bok_choy_docker.py
+++ b/cms/envs/bok_choy_docker.py
@@ -11,6 +11,7 @@ LMS_BASE = '{}:{}'.format(os.environ['BOK_CHOY_HOSTNAME'], os.environ['BOK_CHOY_
 LMS_ROOT_URL = 'http://{}'.format(LMS_BASE)
 
 COMMENTS_SERVICE_URL = 'http://{}:4567'.format(os.environ['BOK_CHOY_HOSTNAME'])
+EDXNOTES_PUBLIC_API = 'http://{}:8042/api/v1'.format(os.environ['BOK_CHOY_HOSTNAME'])
 
 # Docker does not support the syslog socket at /dev/log. Rely on the console.
 LOGGING['handlers']['local'] = LOGGING['handlers']['tracking'] = {

--- a/common/test/acceptance/fixtures/__init__.py
+++ b/common/test/acceptance/fixtures/__init__.py
@@ -21,7 +21,7 @@ ORA_STUB_URL = os.environ.get('ora_url', 'http://localhost:8041')
 COMMENTS_STUB_URL = os.environ.get('comments_url', 'http://{}:4567'.format(HOSTNAME))
 
 # Get the URL of the EdxNotes service stub used in the test
-EDXNOTES_STUB_URL = os.environ.get('edxnotes_url', 'http://localhost:8042')
+EDXNOTES_STUB_URL = os.environ.get('edxnotes_url', 'http://{}:8042'.format(HOSTNAME))
 
 # Get the URL of the Catalog service stub used in the test
 CATALOG_STUB_URL = os.environ.get('catalog_url', 'http://localhost:8091')

--- a/lms/envs/bok_choy_docker.py
+++ b/lms/envs/bok_choy_docker.py
@@ -11,6 +11,7 @@ LMS_BASE = '{}:{}'.format(os.environ['BOK_CHOY_HOSTNAME'], os.environ['BOK_CHOY_
 LMS_ROOT_URL = 'http://{}'.format(LMS_BASE)
 
 COMMENTS_SERVICE_URL = 'http://{}:4567'.format(os.environ['BOK_CHOY_HOSTNAME'])
+EDXNOTES_PUBLIC_API = 'http://{}:8042/api/v1'.format(os.environ['BOK_CHOY_HOSTNAME'])
 
 # Docker does not support the syslog socket at /dev/log. Rely on the console.
 LOGGING['handlers']['local'] = LOGGING['handlers']['tracking'] = {


### PR DESCRIPTION
Fixed 9 failing bok-choy tests in devstack by using the correct URL for the browser to be able to access the notes service stub.