### PR TITLE
updated header active tab border color

### DIFF
--- a/lms/static/sass/_header.scss
+++ b/lms/static/sass/_header.scss
@@ -120,6 +120,7 @@
             &.active,
             &:hover {
               border-bottom-style: solid;
+              border-bottom-color: theme-color("primary");
             }
 
             &:hover {


### PR DESCRIPTION
Currently, the active tab color is hidden and is only shown on hover. This change shows the active tab as active using the primary theme color for the bottom border. 

**Currently:** 
![image](https://user-images.githubusercontent.com/2023680/42385433-c67bfbb0-810a-11e8-8133-4d1e4fec8a29.png)

**With Change:** 
![screenshot-courses edx org-2018 07 06-11-02-40](https://user-images.githubusercontent.com/2023680/42386079-7f33b002-810c-11e8-995c-a7e173837796.png)
