### PR TITLE
TE-2632 Fix site fixture domains for devstack bok-choy tests

### DIFF
--- a/openedx/core/djangoapps/util/management/commands/update_fixtures.py
+++ b/openedx/core/djangoapps/util/management/commands/update_fixtures.py
@@ -1,0 +1,31 @@
+# -*- coding: utf-8 -*-
+"""
+Django management command to update the loaded test fixtures as necessary for
+the current test environment.  Currently just sets an appropriate domain for
+each Site fixture.
+"""
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+import os
+
+from django.contrib.sites.models import Site
+from django.core.management.base import BaseCommand
+
+
+class Command(BaseCommand):
+    """
+    update_fixtures management command
+    """
+
+    help = "Update fixtures to match the current test environment."
+
+    def handle(self, *args, **options):
+        if 'BOK_CHOY_HOSTNAME' in os.environ:
+            # Fix the Site fixture domains so third party auth tests work correctly
+            host = os.environ['BOK_CHOY_HOSTNAME']
+            cms_port = os.environ['BOK_CHOY_CMS_PORT']
+            lms_port = os.environ['BOK_CHOY_LMS_PORT']
+            cms_domain = '{}:{}'.format(host, cms_port)
+            Site.objects.filter(name='cms').update(domain=cms_domain)
+            lms_domain = '{}:{}'.format(host, lms_port)
+            Site.objects.filter(name='lms').update(domain=lms_domain)

--- a/openedx/core/djangoapps/util/tests/test_update_fixtures.py
+++ b/openedx/core/djangoapps/util/tests/test_update_fixtures.py
@@ -1,0 +1,43 @@
+# -*- coding: utf-8 -*-
+"""
+Tests of the update_fixtures management command for bok-choy test database
+initialization.
+"""
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+import os
+
+import pytest
+from django.contrib.sites.models import Site
+from django.core.management import call_command
+
+
+@pytest.fixture(scope='function')
+def sites(db):  # pylint: disable=unused-argument
+    Site.objects.create(name='cms', domain='localhost:8031')
+    Site.objects.create(name='lms', domain='localhost:8003')
+
+
+def test_localhost(db, monkeypatch, sites):  # pylint: disable=redefined-outer-name,unused-argument
+    monkeypatch.delitem(os.environ, 'BOK_CHOY_HOSTNAME', raising=False)
+    call_command('update_fixtures')
+    assert Site.objects.get(name='cms').domain == 'localhost:8031'
+    assert Site.objects.get(name='lms').domain == 'localhost:8003'
+
+
+def test_devstack_cms(db, monkeypatch, sites):  # pylint: disable=redefined-outer-name,unused-argument
+    monkeypatch.setitem(os.environ, 'BOK_CHOY_HOSTNAME', 'edx.devstack.cms')
+    monkeypatch.setitem(os.environ, 'BOK_CHOY_CMS_PORT', '18031')
+    monkeypatch.setitem(os.environ, 'BOK_CHOY_LMS_PORT', '18003')
+    call_command('update_fixtures')
+    assert Site.objects.get(name='cms').domain == 'edx.devstack.cms:18031'
+    assert Site.objects.get(name='lms').domain == 'edx.devstack.cms:18003'
+
+
+def test_devstack_lms(db, monkeypatch, sites):  # pylint: disable=redefined-outer-name,unused-argument
+    monkeypatch.setitem(os.environ, 'BOK_CHOY_HOSTNAME', 'edx.devstack.lms')
+    monkeypatch.setitem(os.environ, 'BOK_CHOY_CMS_PORT', '18031')
+    monkeypatch.setitem(os.environ, 'BOK_CHOY_LMS_PORT', '18003')
+    call_command('update_fixtures')
+    assert Site.objects.get(name='cms').domain == 'edx.devstack.lms:18031'
+    assert Site.objects.get(name='lms').domain == 'edx.devstack.lms:18003'

--- a/pavelib/utils/test/suites/bokchoy_suite.py
+++ b/pavelib/utils/test/suites/bokchoy_suite.py
@@ -88,6 +88,24 @@ def load_courses(options):
 
 
 @task
+@timed
+def update_fixtures():
+    """
+    Use the correct domain for the current test environment in each Site
+    fixture.  This currently differs between devstack cms, devstack lms,
+    and Jenkins.
+    """
+    msg = colorize('green', "Updating the Site fixture domains...")
+    print msg
+
+    sh(
+        " ./manage.py lms --settings={settings} update_fixtures".format(
+            settings=Env.SETTINGS
+        )
+    )
+
+
+@task
 @cmdopts([BOKCHOY_IMPORTS_DIR, BOKCHOY_IMPORTS_DIR_DEPR, PA11Y_FETCH_COURSE])
 @timed
 def get_test_course(options):
@@ -142,7 +160,7 @@ def reset_test_database():
 
 
 @task
-@needs(['reset_test_database', 'clear_mongo', 'load_bok_choy_data', 'load_courses'])
+@needs(['reset_test_database', 'clear_mongo', 'load_bok_choy_data', 'load_courses', 'update_fixtures'])
 @might_call('start_servers')
 @cmdopts([BOKCHOY_FASTTEST], share_with=['start_servers'])
 @timed
@@ -236,6 +254,7 @@ class BokChoyTestSuite(TestSuite):
         else:
             # load data in db_fixtures
             load_bok_choy_data()  # pylint: disable=no-value-for-parameter
+            update_fixtures()
 
         msg = colorize('green', "Confirming servers have started...")
         print msg


### PR DESCRIPTION
The JSON fixture for Sites in bok-choy tests assumes that the base browser URL is on localhost, which works for Jenkins but is incorrect when running the tests in the devstack cms or lms containers.  Added another setup step which makes sure these domains are correct, fixing 5 tests involving third party authentication which were previously broken on devstack (including the ones captured in [TE-2633](https://openedx.atlassian.net/browse/TE-2633)).