### PR TITLE
WIP - Disables themes and the course lookup for the analytics exporter

### DIFF
--- a/cms/envs/aws.py
+++ b/cms/envs/aws.py
@@ -593,4 +593,8 @@ plugin_settings.add_plugins(__name__, plugin_constants.ProjectType.CMS, plugin_c
 
 ########################## Derive Any Derived Settings  #######################
 
+# In a janky, hotfix branch, never to merge, disable comprehensive theming for
+# the analytics exporter.  See PLAT-1786
+ENABLE_COMPREHENSIVE_THEMING = False
+
 derive_settings(__name__)

--- a/lms/envs/aws.py
+++ b/lms/envs/aws.py
@@ -1094,4 +1094,8 @@ plugin_settings.add_plugins(__name__, plugin_constants.ProjectType.LMS, plugin_c
 
 ########################## Derive Any Derived Settings  #######################
 
+# In a janky, hotfix branch, never to merge, disable comprehensive theming for
+# the analytics exporter.  See PLAT-1786
+ENABLE_COMPREHENSIVE_THEMING = False
+
 derive_settings(__name__)

--- a/openedx/core/djangoapps/user_api/management/commands/email_opt_in_list.py
+++ b/openedx/core/djangoapps/user_api/management/commands/email_opt_in_list.py
@@ -109,22 +109,18 @@ class Command(BaseCommand):
         if os.path.exists(file_path):
             raise CommandError("File already exists at '{path}'".format(path=file_path))
 
-        # Retrieve all the courses for the org.
-        # If we were given a specific list of courses to include,
-        # filter out anything not in that list.
-        courses = self._get_courses_for_org(org_list)
         only_courses = options.get("courses")
 
-        if only_courses is not None:
-            only_courses = [
-                CourseKey.from_string(course_key.strip())
-                for course_key in only_courses.split(",")
-            ]
-            courses = list(set(courses) & set(only_courses))
+        if only_courses is None:
+            # Retrieve all the courses for the org.
+            # If we were given a specific list of courses to include,
+            # filter out anything not in that list.
+            courses = self._get_courses_for_org(org_list)
 
-        # Add in organizations from the course keys, to ensure
-        # we're including orgs with different capitalizations
-        org_list = list(set(org_list) | set(course.org for course in courses))
+            # Add in organizations from the course keys, to ensure we're including orgs with different capitalizations
+            org_list = list(set(org_list) | set(course.org for course in courses))
+        else:
+            courses = list(set(only_courses.split(",")))
 
         # If no courses are found, abort
         if not courses:
@@ -264,7 +260,7 @@ class Command(BaseCommand):
             row_count += 1
 
         # Log the number of rows we processed
-        LOGGER.info("Retrieved {num_rows} records.".format(num_rows=row_count))
+        LOGGER.info("Retrieved {num_rows} records for orgs {org}.".format(num_rows=row_count, org=org_aliases))
 
     def _iterate_results(self, cursor):
         """


### PR DESCRIPTION
DO NOT MERGE!

I've carried over the work done in aed/analytics-exporter-settings-hotfix into a rebased version of the platform.  At the same time I changed the flow of the Email Opt-In list export so that the module_store is not called when a list of courses is already known.  We will continue to run the exporter in production off of this branch instead of master.