### PR TITLE
Upgrade DOT to 1.1.2 and add paver warning.

### DIFF
--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -650,7 +650,9 @@ derived_collection_entry('DEFAULT_TEMPLATE_ENGINE', 'DIRS')
 
 ###############################################################################################
 
-AUTHENTICATION_BACKENDS = ['openedx.core.djangoapps.oauth_dispatch.dot_overrides.validators.EdxRateLimitedAllowAllUsersModelBackend']
+AUTHENTICATION_BACKENDS = [
+    'openedx.core.djangoapps.oauth_dispatch.dot_overrides.backends.EdxRateLimitedAllowAllUsersModelBackend'
+]
 STUDENT_FILEUPLOAD_MAX_SIZE = 4 * 1000 * 1000  # 4 MB
 MAX_FILEUPLOADS_PER_INPUT = 20
 

--- a/openedx/core/djangoapps/oauth_dispatch/dot_overrides/backends.py
+++ b/openedx/core/djangoapps/oauth_dispatch/dot_overrides/backends.py
@@ -1,0 +1,18 @@
+"""
+Custom authentication backends.
+"""
+from django.contrib.auth.backends import AllowAllUsersModelBackend as UserModelBackend
+from ratelimitbackend.backends import RateLimitMixin
+
+
+class EdxRateLimitedAllowAllUsersModelBackend(RateLimitMixin, UserModelBackend):
+    """
+    Authentication backend needed to incorporate rate limiting of login attempts - but also
+    enabling users with is_active of False in the Django auth_user model to still authenticate.
+    This is necessary for mobile users using 3rd party auth who have not activated their accounts,
+    Inactive users who use 1st party auth (username/password auth) will still fail login attempts,
+    just at a higher layer, in the login_user view.
+
+    See: https://openedx.atlassian.net/browse/TNL-4516
+    """
+    pass

--- a/openedx/core/djangoapps/oauth_dispatch/dot_overrides/validators.py
+++ b/openedx/core/djangoapps/oauth_dispatch/dot_overrides/validators.py
@@ -6,14 +6,12 @@ from __future__ import unicode_literals
 from datetime import datetime
 
 from django.contrib.auth import authenticate, get_user_model
-from django.contrib.auth.backends import AllowAllUsersModelBackend as UserModelBackend
 from django.db.models.signals import pre_save
 from django.dispatch import receiver
 from oauth2_provider.models import AccessToken
 from oauth2_provider.oauth2_validators import OAuth2Validator
 from oauth2_provider.scopes import get_scopes_backend
 from pytz import utc
-from ratelimitbackend.backends import RateLimitMixin
 
 from ..models import RestrictedApplication
 
@@ -25,19 +23,6 @@ def on_access_token_presave(sender, instance, *args, **kwargs):  # pylint: disab
     """
     if RestrictedApplication.should_expire_access_token(instance.application):
         instance.expires = datetime(1970, 1, 1, tzinfo=utc)
-
-
-class EdxRateLimitedAllowAllUsersModelBackend(RateLimitMixin, UserModelBackend):
-    """
-    Authentication backend needed to incorporate rate limiting of login attempts - but also
-    enabling users with is_active of False in the Django auth_user model to still authenticate.
-    This is necessary for mobile users using 3rd party auth who have not activated their accounts,
-    Inactive users who use 1st party auth (username/password auth) will still fail login attempts,
-    just at a higher layer, in the login_user view.
-
-    See: https://openedx.atlassian.net/browse/TNL-4516
-    """
-    pass
 
 
 class EdxOAuth2Validator(OAuth2Validator):

--- a/openedx/core/djangoapps/oauth_dispatch/dot_overrides/views.py
+++ b/openedx/core/djangoapps/oauth_dispatch/dot_overrides/views.py
@@ -5,7 +5,7 @@ from __future__ import unicode_literals
 
 from oauth2_provider.exceptions import OAuthToolkitError
 from oauth2_provider.http import HttpResponseUriRedirect
-from oauth2_provider.models import get_application_model
+from oauth2_provider.models import get_access_token_model, get_application_model
 from oauth2_provider.scopes import get_scopes_backend
 from oauth2_provider.settings import oauth2_settings
 from oauth2_provider.views import AuthorizationView
@@ -69,11 +69,12 @@ class EdxOAuth2AuthorizationView(AuthorizationView):
                 uri, headers, body, status = self.create_authorization_response(
                     request=self.request, scopes=" ".join(scopes),
                     credentials=credentials, allow=True)
-                return HttpResponseUriRedirect(uri)
+                return HttpResponseUriRedirect(uri, application.get_allowed_schemes())
 
             # *** Changed the if statement that checked for require_approval to an assert.
             assert require_approval == 'auto_even_if_expired'
-            tokens = request.user.accesstoken_set.filter(
+            tokens = get_access_token_model().objects.filter(
+                user=request.user,
                 application=kwargs['application'],
                 # *** Purposefully keeping this commented out code to highlight that
                 # our version of the implementation does NOT filter by expiration date.
@@ -86,7 +87,7 @@ class EdxOAuth2AuthorizationView(AuthorizationView):
                     uri, headers, body, status = self.create_authorization_response(
                         request=self.request, scopes=" ".join(scopes),
                         credentials=credentials, allow=True)
-                    return HttpResponseUriRedirect(uri)
+                    return HttpResponseUriRedirect(uri, application.get_allowed_schemes())
 
             # render an authorization prompt so the user can approve
             # the application's requested scopes

--- a/openedx/core/djangoapps/oauth_dispatch/tests/test_views.py
+++ b/openedx/core/djangoapps/oauth_dispatch/tests/test_views.py
@@ -613,36 +613,39 @@ class TestRevokeTokenView(AccessTokenLoginMixin, _DispatchingViewTestCase):  # p
             'token': token,
         }
 
-    def _assert_refresh_token_invalidated(self):
+    def assert_refresh_token_status_code(self, refresh_token, expected_status_code):
         """
-        Asserts that oauth assigned refresh_token is not valid
+        Asserts the status code using oauth assigned refresh_token
         """
         response = self.client.post(
             self.access_token_url,
-            self.access_token_post_body_with_refresh_token(self.refresh_token)
+            self.access_token_post_body_with_refresh_token(refresh_token)
         )
-        self.assertEqual(response.status_code, 401)
+        self.assertEqual(response.status_code, expected_status_code)
 
-    def verify_revoke_token(self, token):
+    def revoke_token(self, token):
         """
-        Verifies access of token before and after revoking
+        Revokes the passed access or refresh token
         """
-        self._assert_access_token_is_valid()
-
         response = self.client.post(self.revoke_token_url, self.revoke_token_post_body(token))
         self.assertEqual(response.status_code, 200)
 
-        self._assert_access_token_invalidated()
-        self._assert_refresh_token_invalidated()
-
     def test_revoke_refresh_token_dot(self):
         """
-        Tests invalidation/revoke of user tokens against refresh token for django-oauth-toolkit
+        Tests invalidation/revoke of refresh token for django-oauth-toolkit
         """
-        self.verify_revoke_token(self.refresh_token)
+        self.assert_refresh_token_status_code(self.refresh_token, expected_status_code=200)
+
+        self.revoke_token(self.refresh_token)
+
+        self.assert_refresh_token_status_code(self.refresh_token, expected_status_code=401)
 
     def test_revoke_access_token_dot(self):
         """
         Tests invalidation/revoke of user access token for django-oauth-toolkit
         """
-        self.verify_revoke_token(self.access_token)
+        self._assert_access_token_is_valid(self.access_token)
+
+        self.revoke_token(self.access_token)
+
+        self._assert_access_token_invalidated(self.access_token)

--- a/pavelib/prereqs.py
+++ b/pavelib/prereqs.py
@@ -309,9 +309,20 @@ def install_prereqs():
         install_node_prereqs()
     install_python_prereqs()
     log_installed_python_prereqs()
+    print_devstack_warning()
 
 
 def log_installed_python_prereqs():
     """  Logs output of pip freeze for debugging. """
     sh("pip freeze > {}".format(Env.GEN_LOG_DIR + "/pip_freeze.log"))
     return
+
+
+def print_devstack_warning():  # pylint: disable=missing-docstring
+    if Env.USING_DOCKER:  # pragma: no cover
+        print "********************************************************************************"
+        print "* WARNING: Mac users should run this from both the lms and studio shells"
+        print "* in docker devstack to avoid startup errors that kill your CPU."
+        print "* For more details, see:"
+        print "* https://github.com/edx/devstack#docker-is-using-lots-of-cpu-time-when-it-should-be-idle"
+        print "********************************************************************************"

--- a/pavelib/prereqs.py
+++ b/pavelib/prereqs.py
@@ -318,7 +318,7 @@ def log_installed_python_prereqs():
     return
 
 
-def print_devstack_warning():  # pylint: disable=missing-docstring
+def print_devstack_warning():
     if Env.USING_DOCKER:  # pragma: no cover
         print "********************************************************************************"
         print "* WARNING: Mac users should run this from both the lms and studio shells"

--- a/requirements/edx/base.in
+++ b/requirements/edx/base.in
@@ -47,7 +47,7 @@ django-method-override==0.1.0
 django-model-utils==3.0.0
 django-mptt>=0.8.6,<0.9
 django-mysql
-django-oauth-toolkit==0.12.0
+django-oauth-toolkit<1.2            # Provides oAuth2 capabilities for Django. 1.2+ requires Django 2 and Python 3.5
 django-pyfs
 django-ratelimit
 django-ratelimit-backend==1.1.1
@@ -104,11 +104,11 @@ MySQL-python                        # Driver for the default production relation
 newrelic                            # New Relic agent for performance monitoring
 nodeenv==1.1.1                      # Utility for managing Node.js environments; we use this for deployments and testing
 numpy==1.6.2                        # Fast numeric array computation, used in some problem types
-oauthlib==2.0.1                     # OAuth specification support for authenticating via LTI or other Open edX services
+oauthlib                            # OAuth specification support for authenticating via LTI or other Open edX services
 pdfminer                            # Used in shoppingcart for extracting/parsing pdf text
 piexif==1.0.2                       # Exif image metadata manipulation, used in the profile_images app
 Pillow==3.4                         # Image manipulation library; used for course assets, profile images, invoice PDFs, etc.
-py2neo<4.0.0                       # Used to communicate with Neo4j, which is used internally for modulestore inspection
+py2neo<4.0.0                        # Used to communicate with Neo4j, which is used internally for modulestore inspection
 PyContracts==1.7.1
 pycountry==1.20
 pycryptodomex==3.4.7
@@ -133,7 +133,7 @@ pysrt==0.4.7                        # Support for SubRip subtitle files, used in
 pytz==2016.10                       # Time zone information database
 PyYAML                              # Used to parse XModule resource templates
 redis==2.10.6                       # celery task broker
-requests-oauthlib==0.6.1            # Simplifies use of OAuth via the requests library, used for CCX and LTI
+requests-oauthlib                   # Simplifies use of OAuth via the requests library, used for CCX and LTI
 rules                               # Django extension for rules-based authorization checks
 sailthru-client==2.2.3              # For Sailthru integration
 Shapely==1.2.16                     # Geometry library, used for image click regions in capa

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -56,8 +56,10 @@ boto3==1.4.8
 boto==2.39.0
 botocore==1.8.17
 celery==3.1.25
+certifi==2018.4.16
 cffi==1.11.5
 charade==1.0.3            # via pysrt
+chardet==3.0.4
 click==6.7                # via user-util
 coreapi==2.3.3            # via django-rest-swagger, openapi-codec
 coreschema==0.0.4         # via coreapi
@@ -69,7 +71,6 @@ defusedxml==0.4.1
 django-appconf==1.0.2     # via django-statici18n
 django-babel-underscore==0.5.2
 django-babel==0.6.2       # via django-babel-underscore
-django-braces==1.13.0     # via django-oauth-toolkit
 django-classy-tags==0.8.0  # via django-sekizai
 django-config-models==0.1.8
 django-cors-headers==2.1.0
@@ -84,7 +85,7 @@ django-model-utils==3.0.0
 django-mptt==0.8.7
 django-multi-email-field==0.5.1  # via edx-enterprise
 django-mysql==2.3.0
-django-oauth-toolkit==0.12.0
+django-oauth-toolkit==1.1.2
 django-object-actions==0.10.0  # via edx-enterprise
 django-pyfs==2.0
 django-ratelimit-backend==1.1.1
@@ -172,7 +173,7 @@ nltk==3.3.0
 nodeenv==1.1.1
 numpy==1.6.2
 oauth2==1.9.0.post1
-oauthlib==2.0.1
+oauthlib==2.1.0
 openapi-codec==1.3.2      # via django-rest-swagger
 path.py==8.2.1
 pathtools==0.1.2
@@ -207,8 +208,8 @@ pyuca==1.1
 pyyaml==3.13
 redis==2.10.6
 reportlab==3.1.44
-requests-oauthlib==0.6.1
-requests==2.9.1
+requests-oauthlib==1.0.0
+requests==2.19.1
 rest-condition==1.0.3
 rfc6266-parser==0.0.5.post2
 rules==1.3
@@ -229,7 +230,7 @@ stevedore==1.10.0
 sympy==0.7.1
 unicodecsv==0.14.1
 uritemplate==3.0.0        # via coreapi
-urllib3==1.23             # via elasticsearch
+urllib3==1.23
 user-util==0.1.3
 voluptuous==0.11.1
 watchdog==0.8.3

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -67,8 +67,10 @@ boto3==1.4.8
 boto==2.39.0
 botocore==1.8.17
 celery==3.1.25
+certifi==2018.4.16
 cffi==1.11.5
 charade==1.0.3
+chardet==3.0.4
 click-log==0.1.8
 click==6.7
 colorama==0.3.9
@@ -88,7 +90,6 @@ diff-cover==0.9.8
 django-appconf==1.0.2
 django-babel-underscore==0.5.2
 django-babel==0.6.2
-django-braces==1.13.0
 django-classy-tags==0.8.0
 django-config-models==0.1.8
 django-cors-headers==2.1.0
@@ -104,7 +105,7 @@ django-model-utils==3.0.0
 django-mptt==0.8.7
 django-multi-email-field==0.5.1
 django-mysql==2.3.0
-django-oauth-toolkit==0.12.0
+django-oauth-toolkit==1.1.2
 django-object-actions==0.10.0
 django-pyfs==2.0
 django-ratelimit-backend==1.1.1
@@ -223,7 +224,7 @@ nodeenv==1.1.1
 nose==1.3.7
 numpy==1.6.2
 oauth2==1.9.0.post1
-oauthlib==2.0.1
+oauthlib==2.1.0
 openapi-codec==1.3.2
 pa11ycrawler==1.6.2
 packaging==17.1
@@ -289,8 +290,8 @@ queuelib==1.5.0
 radon==2.2.0
 redis==2.10.6
 reportlab==3.1.44
-requests-oauthlib==0.6.1
-requests==2.9.1
+requests-oauthlib==1.0.0
+requests==2.19.1
 rest-condition==1.0.3
 rfc6266-parser==0.0.5.post2
 rules==1.3

--- a/requirements/edx/paver.in
+++ b/requirements/edx/paver.in
@@ -17,7 +17,7 @@ paver                               # Build, distribution and deployment scripti
 psutil==1.2.1                       # Library for retrieving information on running processes and system utilization
 pymongo==2.9.1                      # via edx-opaque-keys
 python-memcached==1.48              # Python interface to the memcached memory cache daemon
-requests==2.9.1                     # Simple interface for making HTTP requests
+requests                            # Simple interface for making HTTP requests
 stevedore==1.10.0                   # via edx-opaque-keys
 watchdog                            # Used in paver watch_assets
 wrapt==1.10.5                       # Decorator utilities used in the @timed paver task decorator

--- a/requirements/edx/paver.txt
+++ b/requirements/edx/paver.txt
@@ -6,7 +6,10 @@
 #
 argh==0.26.2              # via watchdog
 argparse==1.4.0           # via stevedore
+certifi==2018.4.16        # via requests
+chardet==3.0.4            # via requests
 edx-opaque-keys==0.4.4
+idna==2.7                 # via requests
 lazy==1.1
 libsass==0.10.0
 markupsafe==1.0
@@ -19,8 +22,9 @@ psutil==1.2.1
 pymongo==2.9.1
 python-memcached==1.48
 pyyaml==3.13              # via watchdog
-requests==2.9.1
+requests==2.19.1
 six==1.11.0               # via edx-opaque-keys, libsass, paver, stevedore
 stevedore==1.10.0
+urllib3==1.23             # via requests
 watchdog==0.8.3
 wrapt==1.10.5

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -64,8 +64,10 @@ boto3==1.4.8
 boto==2.39.0
 botocore==1.8.17
 celery==3.1.25
+certifi==2018.4.16
 cffi==1.11.5
 charade==1.0.3
+chardet==3.0.4
 click-log==0.1.8          # via edx-lint
 click==6.7
 colorama==0.3.9           # via radon
@@ -85,7 +87,6 @@ diff-cover==0.9.8
 django-appconf==1.0.2
 django-babel-underscore==0.5.2
 django-babel==0.6.2
-django-braces==1.13.0
 django-classy-tags==0.8.0
 django-config-models==0.1.8
 django-cors-headers==2.1.0
@@ -100,7 +101,7 @@ django-model-utils==3.0.0
 django-mptt==0.8.7
 django-multi-email-field==0.5.1
 django-mysql==2.3.0
-django-oauth-toolkit==0.12.0
+django-oauth-toolkit==1.1.2
 django-object-actions==0.10.0
 django-pyfs==2.0
 django-ratelimit-backend==1.1.1
@@ -214,7 +215,7 @@ nodeenv==1.1.1
 nose==1.3.7
 numpy==1.6.2
 oauth2==1.9.0.post1
-oauthlib==2.0.1
+oauthlib==2.1.0
 openapi-codec==1.3.2
 pa11ycrawler==1.6.2
 packaging==17.1           # via tox
@@ -278,8 +279,8 @@ queuelib==1.5.0           # via scrapy
 radon==2.2.0
 redis==2.10.6
 reportlab==3.1.44
-requests-oauthlib==0.6.1
-requests==2.9.1
+requests-oauthlib==1.0.0
+requests==2.19.1
 rest-condition==1.0.3
 rfc6266-parser==0.0.5.post2
 rules==1.3


### PR DESCRIPTION
- Upgrade DOT to 1.1.2 to hopefully resolve some db lock issues.
- Add paver warning to help people avoid CPU issue in devstack.

Tasks required before merge:
- [x] Update reference to fork or updated DOT tag (1.1.3?)
- [x] Squash and rebase.