### PR TITLE
update edx-completion version from 0.1.7 to 0.1.8.

### DIFF
--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -111,7 +111,7 @@ edx-ace==0.1.8
 edx-analytics-data-api-client==0.14.4
 edx-ccx-keys==0.2.1
 edx-celeryutils==0.2.7
-edx-completion==0.1.7
+edx-completion==0.1.8
 edx-django-oauth2-provider==1.3.3
 edx-django-release-util==0.3.1
 edx-django-sites-extensions==2.3.1


### PR DESCRIPTION
Jira Tickets: 
https://openedx.atlassian.net/browse/EDUCATOR-3030

Diff of proctoring tags:
https://github.com/edx/completion/compare/0.1.7...0.1.8

edx-proctoring PR link:
https://github.com/edx/completion/pull/20

edx-proctoring release PR link:
https://github.com/edx/completion/pull/21

cc: @awaisdar001 