### PR TITLE
Bump version of edx-search

### DIFF
--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -124,7 +124,7 @@ edx-opaque-keys[django]==0.4.4
 edx-organizations==0.4.10
 edx-proctoring==1.4.0
 edx-rest-api-client==1.7.1
-edx-search==1.1.0
+edx-search==1.2.1
 edx-submissions==2.0.12
 edx-user-state-client==1.0.4
 edxval==0.1.16

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -145,7 +145,7 @@ edx-opaque-keys[django]==0.4.4
 edx-organizations==0.4.10
 edx-proctoring==1.4.0
 edx-rest-api-client==1.7.1
-edx-search==1.1.0
+edx-search==1.2.1
 edx-sphinx-theme==1.3.0
 edx-submissions==2.0.12
 edx-user-state-client==1.0.4

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -140,7 +140,7 @@ edx-opaque-keys[django]==0.4.4
 edx-organizations==0.4.10
 edx-proctoring==1.4.0
 edx-rest-api-client==1.7.1
-edx-search==1.1.0
+edx-search==1.2.1
 edx-submissions==2.0.12
 edx-user-state-client==1.0.4
 edxval==0.1.16


### PR DESCRIPTION
This PR bumps the version of ``edx-search`` to v1.2.1 to incorporate new features introduced in https://github.com/edx/edx-search/pull/49 and a corresponding fix introduced in https://github.com/edx/edx-search/pull/51

The new version now allows for quoted sections in search queries allowing for searching phrases in addition to words. 

NOTE: This cherry-picks the changes from https://github.com/edx/edx-platform/pull/18518

**Screenshots**: 
![Screenshot of search query with quotes](https://user-images.githubusercontent.com/118837/42184976-e4e93138-7e64-11e8-84ce-6b5599499182.png)

**Sandbox URL**: TBD

**Merge deadline**: Would like to get this in Hawthorn

**Testing instructions**:
See: https://github.com/edx/edx-search/pull/51

**Reviewers**
- [ ] @symbolist 
- [ ] edX reviewer[s] TBD

**Settings**
```yaml
JOURNALS_ENABLED: false
# copied from https://github.com/edx/configuration/blob/cf4d221d384ed396a3008c31487f385544ef08e7/util/jenkins/ansible-provision.sh#L328-L338
JOURNALS_URL_ROOT: "https://journals-{{ EDXAPP_LMS_BASE }}"
JOURNALS_API_URL: "https://journals-{{ EDXAPP_LMS_BASE }}/api/v1/"
JOURNALS_DISCOVERY_SERVICE_URL: "https://discovery-{{ EDXAPP_LMS_BASE }}"
JOURNALS_LMS_URL_ROOT: "https://{{ EDXAPP_LMS_BASE }}"
JOURNALS_SOCIAL_AUTH_REDIRECT_IS_HTTPS: true
JOURNALS_DISCOVERY_API_URL: "{{ JOURNALS_DISCOVERY_SERVICE_URL }}/api/v1/"
JOURNALS_DISCOVERY_JOURNALS_API_URL: "{{ JOURNALS_DISCOVERY_SERVICE_URL }}/journal/api/v1/"
JOURNALS_ECOMMERCE_BASE_URL: "{{ ECOMMERCE_ECOMMERCE_URL_ROOT }}"
JOURNALS_ECOMMERCE_API_URL: "{{ JOURNALS_ECOMMERCE_BASE_URL }}/api/v2/"
JOURNALS_ECOMMERCE_JOURNALS_API_URL: "{{ JOURNALS_ECOMMERCE_BASE_URL }}/journal/api/v1"
journals_create_demo_data: false
```