### PR TITLE
Course visibility options

### DIFF
--- a/cms/djangoapps/models/settings/course_metadata.py
+++ b/cms/djangoapps/models/settings/course_metadata.py
@@ -9,6 +9,8 @@ from xblock.fields import Scope
 from xblock_django.models import XBlockStudioConfigurationFlag
 from xmodule.modulestore.django import modulestore
 
+from openedx.features.course_experience import COURSE_ENABLE_ANONYMOUS_ACCESS_FLAG
+
 
 class CourseMetadata(object):
     '''
@@ -63,7 +65,7 @@ class CourseMetadata(object):
     ]
 
     @classmethod
-    def filtered_list(cls):
+    def filtered_list(cls, course_key=None):
         """
         Filter fields based on feature flag, i.e. enabled, disabled.
         """
@@ -117,6 +119,10 @@ class CourseMetadata(object):
         if not XBlockStudioConfigurationFlag.is_enabled():
             filtered_list.append('allow_unsupported_xblocks')
 
+        # Do not show "Course Visibility For Unauthenticated Students" in Studio Advanced Settings
+        # if the enable_anonymous_access flag is not enabled
+        if not COURSE_ENABLE_ANONYMOUS_ACCESS_FLAG.is_enabled(course_key=course_key):
+            filtered_list.append('course_visibility')
         return filtered_list
 
     @classmethod
@@ -128,7 +134,7 @@ class CourseMetadata(object):
         result = {}
         metadata = cls.fetch_all(descriptor)
         for key, value in metadata.iteritems():
-            if key in cls.filtered_list():
+            if key in cls.filtered_list(descriptor.id):
                 continue
             result[key] = value
         return result
@@ -163,7 +169,7 @@ class CourseMetadata(object):
 
         Ensures none of the fields are in the blacklist.
         """
-        filtered_list = cls.filtered_list()
+        filtered_list = cls.filtered_list(descriptor.id)
         # Don't filter on the tab attribute if filter_tabs is False.
         if not filter_tabs:
             filtered_list.remove("tabs")
@@ -199,7 +205,7 @@ class CourseMetadata(object):
             errors: list of error objects
             result: the updated course metadata or None if error
         """
-        filtered_list = cls.filtered_list()
+        filtered_list = cls.filtered_list(descriptor.id)
         if not filter_tabs:
             filtered_list.remove("tabs")
 

--- a/cms/djangoapps/models/settings/course_metadata.py
+++ b/cms/djangoapps/models/settings/course_metadata.py
@@ -9,7 +9,7 @@ from xblock.fields import Scope
 from xblock_django.models import XBlockStudioConfigurationFlag
 from xmodule.modulestore.django import modulestore
 
-from openedx.features.course_experience import COURSE_ENABLE_ANONYMOUS_ACCESS_FLAG
+from openedx.features.course_experience import COURSE_ENABLE_UNENROLLED_ACCESS_FLAG
 
 
 class CourseMetadata(object):
@@ -121,7 +121,7 @@ class CourseMetadata(object):
 
         # Do not show "Course Visibility For Unauthenticated Students" in Studio Advanced Settings
         # if the enable_anonymous_access flag is not enabled
-        if not COURSE_ENABLE_ANONYMOUS_ACCESS_FLAG.is_enabled(course_key=course_key):
+        if not COURSE_ENABLE_UNENROLLED_ACCESS_FLAG.is_enabled(course_key=course_key):
             filtered_list.append('course_visibility')
         return filtered_list
 

--- a/common/lib/xmodule/xmodule/course_module.py
+++ b/common/lib/xmodule/xmodule/course_module.py
@@ -44,6 +44,10 @@ DEFAULT_COURSE_VISIBILITY_IN_CATALOG = getattr(
 
 DEFAULT_MOBILE_AVAILABLE = getattr(settings, 'DEFAULT_MOBILE_AVAILABLE', False)
 
+COURSE_VISIBILITY_PRIVATE = 'private'
+COURSE_VISIBILITY_PREVIEW = 'preview'
+COURSE_VISIBILITY_PUBLIC = 'public'
+
 
 class StringOrDate(Date):
     def from_json(self, value):
@@ -812,6 +816,21 @@ class CourseFields(object):
         help=_("Specify what student can learn from the course."),
         default=[],
         scope=Scope.settings
+    )
+
+    course_visibility = String(
+        display_name=_("Course Visibility For Unauthenticated Students"),
+        help=_(
+            "Defines the access permissions for unauthenticated users. This can be set to one of three values: "
+            "'private' (default visibility, only allowed for enrolled students), 'preview' (allow access to course "
+            "outline) and 'public' (allow full-access to course material)."
+        ),
+        default=COURSE_VISIBILITY_PRIVATE,
+        scope=Scope.settings,
+        values=[
+            {"display_name": _("private"), "value": COURSE_VISIBILITY_PRIVATE},
+            {"display_name": _("preview"), "value": COURSE_VISIBILITY_PREVIEW},
+            {"display_name": _("public"), "value": COURSE_VISIBILITY_PUBLIC}]
     )
 
     """

--- a/lms/djangoapps/course_api/blocks/transformers/milestones.py
+++ b/lms/djangoapps/course_api/blocks/transformers/milestones.py
@@ -144,7 +144,10 @@ class MilestonesAndSpecialExamsTransformer(BlockStructureTransformer):
 
         """
         course_key = block_structure.root_block_usage_key.course_key
-        user_can_skip_entrance_exam = EntranceExamConfiguration.user_can_skip_entrance_exam(usage_info.user, course_key)
+        user_can_skip_entrance_exam = False
+        if usage_info.user.is_authenticated:
+            user_can_skip_entrance_exam = EntranceExamConfiguration.user_can_skip_entrance_exam(
+                usage_info.user, course_key)
         required_content = milestones_helpers.get_required_content(course_key, usage_info.user)
 
         if not required_content:

--- a/lms/djangoapps/courseware/tests/test_views.py
+++ b/lms/djangoapps/courseware/tests/test_views.py
@@ -58,13 +58,13 @@ from openedx.core.djangoapps.content.course_overviews.models import CourseOvervi
 from openedx.core.djangoapps.crawlers.models import CrawlersConfig
 from openedx.core.djangoapps.credit.api import set_credit_requirements
 from openedx.core.djangoapps.credit.models import CreditCourse, CreditProvider
-from openedx.core.djangoapps.waffle_utils import CourseWaffleFlag, WaffleFlagNamespace
 from openedx.core.djangoapps.waffle_utils.testutils import WAFFLE_TABLES, override_waffle_flag
 from openedx.core.djangolib.testing.utils import get_mock_request
 from openedx.core.lib.gating import api as gating_api
 from openedx.core.lib.tests import attr
 from openedx.core.lib.url_utils import quote_slashes
-from openedx.features.course_experience import COURSE_OUTLINE_PAGE_FLAG, UNIFIED_COURSE_TAB_FLAG
+from openedx.features.course_experience import COURSE_OUTLINE_PAGE_FLAG, UNIFIED_COURSE_TAB_FLAG, \
+    COURSE_ENABLE_ANONYMOUS_ACCESS_FLAG
 from openedx.features.enterprise_support.tests.mixins.enterprise import EnterpriseTestConsentRequired
 from student.models import CourseEnrollment
 from student.tests.factories import TEST_PASSWORD, AdminFactory, CourseEnrollmentFactory, UserFactory
@@ -2265,7 +2265,6 @@ class TestIndexView(ModuleStoreTestCase):
     """
     Tests of the courseware.views.index view.
     """
-    SEO_WAFFLE_FLAG = CourseWaffleFlag(WaffleFlagNamespace(name='seo'), 'enable_anonymous_courseware_access')
 
     @XBlock.register_temp_plugin(ViewCheckerBlock, 'view_checker')
     @ddt.data(ModuleStoreEnum.Type.mongo, ModuleStoreEnum.Type.split)
@@ -2335,8 +2334,17 @@ class TestIndexView(ModuleStoreTestCase):
         )
         self.assertIn("Activate Block ID: test_block_id", response.content)
 
-    def test_anonymous_access(self):
-        course = CourseFactory()
+    @ddt.data(
+        [False, 'private', 302],
+        [False, 'preview', 302],
+        [False, 'public', 302],
+        [True, 'private', 302],
+        [True, 'preview', 302],
+        [True, 'public', 200],
+    )
+    @ddt.unpack
+    def test_anonymous_access(self, waffle_override, course_visibility, expected_status):
+        course = CourseFactory(course_visibility=course_visibility)
         with self.store.bulk_operations(course.id):
             chapter = ItemFactory(parent=course, category='chapter')
             section = ItemFactory(parent=chapter, category='sequential')
@@ -2350,15 +2358,10 @@ class TestIndexView(ModuleStoreTestCase):
                 'section': section.url_name,
             }
         )
-        response = self.client.get(url, follow=False)
-        assert response.status_code == 302
 
-        waffle_flag = CourseWaffleFlag(WaffleFlagNamespace(name='seo'), 'enable_anonymous_courseware_access')
-        with override_waffle_flag(waffle_flag, active=True):
+        with override_waffle_flag(COURSE_ENABLE_ANONYMOUS_ACCESS_FLAG, active=waffle_override):
             response = self.client.get(url, follow=False)
-            assert response.status_code == 200
-            self.assertIn('data-save-position="false"', response.content)
-            self.assertIn('data-show-completion="false"', response.content)
+            assert response.status_code == expected_status
 
         user = UserFactory()
         CourseEnrollmentFactory(user=user, course_id=course.id)

--- a/lms/djangoapps/courseware/tests/test_views.py
+++ b/lms/djangoapps/courseware/tests/test_views.py
@@ -64,7 +64,7 @@ from openedx.core.lib.gating import api as gating_api
 from openedx.core.lib.tests import attr
 from openedx.core.lib.url_utils import quote_slashes
 from openedx.features.course_experience import COURSE_OUTLINE_PAGE_FLAG, UNIFIED_COURSE_TAB_FLAG, \
-    COURSE_ENABLE_ANONYMOUS_ACCESS_FLAG
+    COURSE_ENABLE_UNENROLLED_ACCESS_FLAG
 from openedx.features.enterprise_support.tests.mixins.enterprise import EnterpriseTestConsentRequired
 from student.models import CourseEnrollment
 from student.tests.factories import TEST_PASSWORD, AdminFactory, CourseEnrollmentFactory, UserFactory
@@ -2335,15 +2335,15 @@ class TestIndexView(ModuleStoreTestCase):
         self.assertIn("Activate Block ID: test_block_id", response.content)
 
     @ddt.data(
-        [False, 'private', 302],
-        [False, 'preview', 302],
-        [False, 'public', 302],
-        [True, 'private', 302],
-        [True, 'preview', 302],
-        [True, 'public', 200],
+        [False, 'private', False],
+        [False, 'preview', False],
+        [False, 'public', False],
+        [True, 'private', False],
+        [True, 'preview', False],
+        [True, 'public', True],
     )
     @ddt.unpack
-    def test_anonymous_access(self, waffle_override, course_visibility, expected_status):
+    def test_anonymous_unenrolled_access(self, waffle_override, course_visibility, allow_unenrolled):
         course = CourseFactory(course_visibility=course_visibility)
         with self.store.bulk_operations(course.id):
             chapter = ItemFactory(parent=course, category='chapter')
@@ -2359,13 +2359,21 @@ class TestIndexView(ModuleStoreTestCase):
             }
         )
 
-        with override_waffle_flag(COURSE_ENABLE_ANONYMOUS_ACCESS_FLAG, active=waffle_override):
+        # Test anonymous access
+        with override_waffle_flag(COURSE_ENABLE_UNENROLLED_ACCESS_FLAG, active=waffle_override):
             response = self.client.get(url, follow=False)
-            assert response.status_code == expected_status
+            assert response.status_code == 200 if allow_unenrolled else 302
 
         user = UserFactory()
-        CourseEnrollmentFactory(user=user, course_id=course.id)
         self.assertTrue(self.client.login(username=user.username, password='test'))
+
+        # Test unenrolled access
+        with override_waffle_flag(COURSE_ENABLE_UNENROLLED_ACCESS_FLAG, active=waffle_override):
+            response = self.client.get(url, follow=False)
+            assert response.status_code == 200 if allow_unenrolled else 302
+
+        # Test enrolled access
+        CourseEnrollmentFactory(user=user, course_id=course.id)
         response = self.client.get(url, follow=False)
         assert response.status_code == 200
         self.assertIn('data-save-position="true"', response.content)

--- a/lms/djangoapps/courseware/views/index.py
+++ b/lms/djangoapps/courseware/views/index.py
@@ -35,10 +35,11 @@ from openedx.core.djangoapps.util.user_messages import PageLevelMessages
 from openedx.core.djangoapps.waffle_utils import WaffleSwitchNamespace
 from openedx.core.djangolib.markup import HTML, Text
 from openedx.features.course_experience import COURSE_OUTLINE_PAGE_FLAG, default_course_url_name, \
-    COURSE_ENABLE_ANONYMOUS_ACCESS_FLAG
+    COURSE_ENABLE_UNENROLLED_ACCESS_FLAG
 from openedx.features.course_experience.views.course_sock import CourseSockFragmentView
 from openedx.features.enterprise_support.api import data_sharing_consent_required
 from shoppingcart.models import CourseRegistrationCode
+from student.models import CourseEnrollment
 from student.views import is_course_blocked
 from util.views import ensure_valid_course_key
 from xmodule.modulestore.django import modulestore
@@ -69,8 +70,8 @@ class CoursewareIndex(View):
     """
 
     @cached_property
-    def enable_anonymous_courseware_access(self):
-        return COURSE_ENABLE_ANONYMOUS_ACCESS_FLAG.is_enabled(self.course_key)
+    def enable_unenrolled_courseware_access(self):
+        return COURSE_ENABLE_UNENROLLED_ACCESS_FLAG.is_enabled(self.course_key)
 
     @method_decorator(ensure_csrf_cookie)
     @method_decorator(cache_control(no_cache=True, no_store=True, must_revalidate=True))
@@ -96,8 +97,8 @@ class CoursewareIndex(View):
             position (unicode): position in module, eg of <sequential> module
         """
         self.course_key = CourseKey.from_string(course_id)
-
-        if not (request.user.is_authenticated or self.enable_anonymous_courseware_access):
+        is_enrolled = CourseEnrollment.is_enrolled(request.user, self.course_key)
+        if not (is_enrolled or self.enable_unenrolled_courseware_access):
             return redirect_to_login(request.get_full_path())
 
         self.original_chapter_url_name = chapter
@@ -116,9 +117,9 @@ class CoursewareIndex(View):
                 self.course = get_course_with_access(
                     request.user, 'load', self.course_key,
                     depth=CONTENT_DEPTH,
-                    check_if_enrolled=not self.enable_anonymous_courseware_access,
+                    check_if_enrolled=not self.enable_unenrolled_courseware_access,
                 )
-                if not (request.user.is_authenticated or self.course.course_visibility == 'public'):
+                if not (is_enrolled or self.course.course_visibility == 'public'):
                     return redirect_to_login(request.get_full_path())
 
                 self.is_staff = has_access(request.user, 'staff', self.course)

--- a/lms/static/sass/features/_course-experience.scss
+++ b/lms/static/sass/features/_course-experience.scss
@@ -368,6 +368,7 @@
 
             list-style-type: none;
 
+            span.outline-item,
             a.outline-item {
               display: flex;
               justify-content: space-between;

--- a/openedx/features/course_experience/__init__.py
+++ b/openedx/features/course_experience/__init__.py
@@ -43,6 +43,10 @@ LATEST_UPDATE_FLAG = CourseWaffleFlag(WAFFLE_FLAG_NAMESPACE, 'latest_update')
 # Waffle flag to enable the use of Bootstrap for course experience pages
 USE_BOOTSTRAP_FLAG = CourseWaffleFlag(WAFFLE_FLAG_NAMESPACE, 'use_bootstrap', flag_undefined_default=True)
 
+# Waffle flag to enable anonymous access to a course
+SEO_WAFFLE_FLAG_NAMESPACE = WaffleFlagNamespace(name='seo')
+COURSE_ENABLE_ANONYMOUS_ACCESS_FLAG = CourseWaffleFlag(SEO_WAFFLE_FLAG_NAMESPACE, 'enable_anonymous_courseware_access')
+
 
 def course_home_page_title(course):  # pylint: disable=unused-argument
     """

--- a/openedx/features/course_experience/__init__.py
+++ b/openedx/features/course_experience/__init__.py
@@ -45,7 +45,7 @@ USE_BOOTSTRAP_FLAG = CourseWaffleFlag(WAFFLE_FLAG_NAMESPACE, 'use_bootstrap', fl
 
 # Waffle flag to enable anonymous access to a course
 SEO_WAFFLE_FLAG_NAMESPACE = WaffleFlagNamespace(name='seo')
-COURSE_ENABLE_ANONYMOUS_ACCESS_FLAG = CourseWaffleFlag(SEO_WAFFLE_FLAG_NAMESPACE, 'enable_anonymous_courseware_access')
+COURSE_ENABLE_UNENROLLED_ACCESS_FLAG = CourseWaffleFlag(SEO_WAFFLE_FLAG_NAMESPACE, 'enable_unenrolled_courseware_access')
 
 
 def course_home_page_title(course):  # pylint: disable=unused-argument

--- a/openedx/features/course_experience/templates/course_experience/course-outline-fragment.html
+++ b/openedx/features/course_experience/templates/course_experience/course-outline-fragment.html
@@ -51,7 +51,7 @@ course_sections = blocks.get('children')
                 completed_prereqs = gated_content[subsection['id']]['completed_prereqs'] if gated_subsection else False
                 subsection_is_auto_opened = subsection.get('resume_block') is True
                 %>
-                      <li class="subsection accordion ${ 'current' if subsection['resume_block'] else '' }">
+                      <li class="subsection accordion ${ 'current' if subsection.get('resume_block') else '' }">
                 % if gated_subsection and not completed_prereqs:
                                 <a href="${ subsection['lms_web_url'] }">
                                     <button class="subsection-text prerequisite-button"
@@ -152,9 +152,13 @@ course_sections = blocks.get('children')
                                 >
                     % for vertical in subsection.get('children', []):
                                     <li class="vertical outline-item focusable">
+                                    % if enable_links:
                                         <a class="outline-item focusable"
                                             href="${ vertical['lms_web_url'] }"
                                             id="${ vertical['id'] }">
+                                    % else:
+                                        <span class="outline-item">
+                                    % endif
                                             <div class="vertical-details">
                                               <div class="vertical-title">
                                                 ${ vertical['display_name'] }
@@ -163,7 +167,11 @@ course_sections = blocks.get('children')
                         % if vertical.get('complete'):
                                                 <span class="complete-checkmark fa fa-check"></span>
                         % endif
+                                    % if enable_links:
                                         </a>
+                                    % else:
+                                        </span>
+                                    % endif
                                     </li>
                     % endfor
                                 </ol>

--- a/openedx/features/course_experience/tests/views/test_course_home.py
+++ b/openedx/features/course_experience/tests/views/test_course_home.py
@@ -25,7 +25,7 @@ from openedx.features.course_experience import (
     SHOW_REVIEWS_TOOL_FLAG,
     SHOW_UPGRADE_MSG_ON_COURSE_HOME,
     UNIFIED_COURSE_TAB_FLAG,
-    COURSE_ENABLE_ANONYMOUS_ACCESS_FLAG)
+    COURSE_ENABLE_UNENROLLED_ACCESS_FLAG)
 from student.models import CourseEnrollment
 from student.tests.factories import UserFactory
 from util.date_utils import strftime_localized
@@ -223,8 +223,13 @@ class TestCourseHomePageAccess(CourseHomePageTestCase):
         [True, 'private', CourseUserType.ANONYMOUS, 'You must be enrolled in the course to see course content.'],
         [True, 'preview', CourseUserType.ANONYMOUS, 'You must be enrolled in the course to see course content.'],
         [True, 'public', CourseUserType.ANONYMOUS, 'You must be enrolled in the course to see course content.'],
-        [False, 'private', CourseUserType.ENROLLED, None],
         [False, 'private', CourseUserType.UNENROLLED, 'You must be enrolled in the course to see course content.'],
+        [False, 'preview', CourseUserType.UNENROLLED, 'You must be enrolled in the course to see course content.'],
+        [False, 'public', CourseUserType.UNENROLLED, 'You must be enrolled in the course to see course content.'],
+        [True, 'private', CourseUserType.UNENROLLED, 'You must be enrolled in the course to see course content.'],
+        [True, 'preview', CourseUserType.UNENROLLED, 'You must be enrolled in the course to see course content.'],
+        [True, 'public', CourseUserType.UNENROLLED, 'You must be enrolled in the course to see course content.'],
+        [False, 'private', CourseUserType.ENROLLED, None],
         [False, 'private', CourseUserType.UNENROLLED_STAFF,
          'You must be enrolled in the course to see course content.'],
     )
@@ -235,7 +240,7 @@ class TestCourseHomePageAccess(CourseHomePageTestCase):
         # Render the course home page
         with mock.patch('xmodule.course_module.CourseDescriptor.course_visibility', course_visibility):
             # Test access with anonymous flag and course visibility
-            with override_waffle_flag(COURSE_ENABLE_ANONYMOUS_ACCESS_FLAG, enable_anonymous_access):
+            with override_waffle_flag(COURSE_ENABLE_UNENROLLED_ACCESS_FLAG, enable_anonymous_access):
                 url = course_home_url(self.course)
                 response = self.client.get(url)
 

--- a/openedx/features/course_experience/utils.py
+++ b/openedx/features/course_experience/utils.py
@@ -135,10 +135,11 @@ def get_course_outline_block_tree(request, course_id):
         'poll',
         'word_cloud'
     ]
+    user = request.user if request.user and request.user.is_authenticated else None
     all_blocks = get_blocks(
         request,
         course_usage_key,
-        user=request.user,
+        user=user,
         nav_depth=3,
         requested_fields=[
             'children',
@@ -156,13 +157,14 @@ def get_course_outline_block_tree(request, course_id):
     course_outline_root_block = all_blocks['blocks'].get(all_blocks['root'], None)
     if course_outline_root_block:
         populate_children(course_outline_root_block, all_blocks['blocks'])
-        set_last_accessed_default(course_outline_root_block)
 
-        mark_blocks_completed(
-            block=course_outline_root_block,
-            user=request.user,
-            course_key=course_key
-        )
+        if request.user.is_authenticated:
+            set_last_accessed_default(course_outline_root_block)
+            mark_blocks_completed(
+                block=course_outline_root_block,
+                user=request.user,
+                course_key=course_key
+            )
     return course_outline_root_block
 
 

--- a/openedx/features/course_experience/utils.py
+++ b/openedx/features/course_experience/utils.py
@@ -135,11 +135,10 @@ def get_course_outline_block_tree(request, course_id):
         'poll',
         'word_cloud'
     ]
-    user = request.user if request.user and request.user.is_authenticated else None
     all_blocks = get_blocks(
         request,
         course_usage_key,
-        user=user,
+        user=request.user,
         nav_depth=3,
         requested_fields=[
             'children',

--- a/openedx/features/course_experience/utils.py
+++ b/openedx/features/course_experience/utils.py
@@ -7,6 +7,7 @@ from lms.djangoapps.course_api.blocks.api import get_blocks
 from lms.djangoapps.course_blocks.utils import get_student_module_as_dict
 from opaque_keys.edx.keys import CourseKey
 from openedx.core.djangoapps.request_cache.middleware import request_cached
+from student.models import CourseEnrollment
 from xmodule.modulestore.django import modulestore
 
 
@@ -157,7 +158,7 @@ def get_course_outline_block_tree(request, course_id):
     if course_outline_root_block:
         populate_children(course_outline_root_block, all_blocks['blocks'])
 
-        if request.user.is_authenticated:
+        if CourseEnrollment.is_enrolled(request.user, course_key):
             set_last_accessed_default(course_outline_root_block)
             mark_blocks_completed(
                 block=course_outline_root_block,

--- a/openedx/features/course_experience/views/course_home.py
+++ b/openedx/features/course_experience/views/course_home.py
@@ -29,7 +29,8 @@ from openedx.features.course_experience.course_tools import CourseToolsPluginMan
 from student.models import CourseEnrollment
 from util.views import ensure_valid_course_key
 
-from .. import LATEST_UPDATE_FLAG, SHOW_UPGRADE_MSG_ON_COURSE_HOME, USE_BOOTSTRAP_FLAG
+from .. import LATEST_UPDATE_FLAG, SHOW_UPGRADE_MSG_ON_COURSE_HOME, USE_BOOTSTRAP_FLAG, \
+    COURSE_ENABLE_ANONYMOUS_ACCESS_FLAG
 from ..utils import get_course_outline_block_tree, get_resume_block
 from .course_dates import CourseDatesFragmentView
 from .course_home_messages import CourseHomeMessageFragmentView
@@ -120,8 +121,23 @@ class CourseHomeFragmentView(EdxFragmentView):
             'is_enrolled': enrollment is not None,
             'is_staff': has_access(request.user, 'staff', course_key),
         }
+
+        allow_anonymous = COURSE_ENABLE_ANONYMOUS_ACCESS_FLAG.is_enabled(course_key)
+        allow_public = allow_anonymous and course.course_visibility == 'public'
+        allow_preview = allow_anonymous and course.course_visibility == 'preview'
+
+        # Set all the fragments
+        outline_fragment = None
+        update_message_fragment = None
+        course_sock_fragment = None
+        has_visited_course = None
+        resume_course_url = None
+        handouts_html = None
+
         if user_access['is_enrolled'] or user_access['is_staff']:
-            outline_fragment = CourseOutlineFragmentView().render_to_fragment(request, course_id=course_id, **kwargs)
+            outline_fragment = CourseOutlineFragmentView().render_to_fragment(
+                request, course_id=course_id, **kwargs
+            )
             if LATEST_UPDATE_FLAG.is_enabled(course_key):
                 update_message_fragment = LatestUpdateFragmentView().render_to_fragment(
                     request, course_id=course_id, **kwargs
@@ -132,21 +148,17 @@ class CourseHomeFragmentView(EdxFragmentView):
                 )
             course_sock_fragment = CourseSockFragmentView().render_to_fragment(request, course=course, **kwargs)
             has_visited_course, resume_course_url = self._get_resume_course_info(request, course_id)
+            handouts_html = self._get_course_handouts(request, course)
+        elif allow_preview or allow_public:
+            outline_fragment = CourseOutlineFragmentView().render_to_fragment(
+                request, course_id=course_id, enable_anonymous_access=True, **kwargs
+            )
+            course_sock_fragment = CourseSockFragmentView().render_to_fragment(request, course=course, **kwargs)
         else:
             # Redirect the user to the dashboard if they are not enrolled and
             # this is a course that does not support direct enrollment.
             if not can_self_enroll_in_course(course_key):
                 raise CourseAccessRedirect(reverse('dashboard'))
-
-            # Set all the fragments
-            outline_fragment = None
-            update_message_fragment = None
-            course_sock_fragment = None
-            has_visited_course = None
-            resume_course_url = None
-
-        # Get the handouts
-        handouts_html = self._get_course_handouts(request, course)
 
         # Get the course tools enabled for this user and course
         course_tools = CourseToolsPluginManager.get_enabled_course_tools(request, course_key)

--- a/openedx/features/course_experience/views/course_home.py
+++ b/openedx/features/course_experience/views/course_home.py
@@ -30,7 +30,7 @@ from student.models import CourseEnrollment
 from util.views import ensure_valid_course_key
 
 from .. import LATEST_UPDATE_FLAG, SHOW_UPGRADE_MSG_ON_COURSE_HOME, USE_BOOTSTRAP_FLAG, \
-    COURSE_ENABLE_ANONYMOUS_ACCESS_FLAG
+    COURSE_ENABLE_UNENROLLED_ACCESS_FLAG
 from ..utils import get_course_outline_block_tree, get_resume_block
 from .course_dates import CourseDatesFragmentView
 from .course_home_messages import CourseHomeMessageFragmentView
@@ -122,9 +122,9 @@ class CourseHomeFragmentView(EdxFragmentView):
             'is_staff': has_access(request.user, 'staff', course_key),
         }
 
-        allow_anonymous = COURSE_ENABLE_ANONYMOUS_ACCESS_FLAG.is_enabled(course_key)
-        allow_public = allow_anonymous and course.course_visibility == 'public'
-        allow_preview = allow_anonymous and course.course_visibility == 'preview'
+        allow_unenrolled = COURSE_ENABLE_UNENROLLED_ACCESS_FLAG.is_enabled(course_key)
+        allow_public = allow_unenrolled and course.course_visibility == 'public'
+        allow_preview = allow_unenrolled and course.course_visibility == 'preview'
 
         # Set all the fragments
         outline_fragment = None

--- a/openedx/features/course_experience/views/course_outline.py
+++ b/openedx/features/course_experience/views/course_outline.py
@@ -47,7 +47,9 @@ class CourseOutlineFragmentView(EdxFragmentView):
         if not course_block_tree:
             return None
 
-        enable_links = request.user.is_authenticated or (
+        is_enrolled = CourseEnrollment.is_enrolled(request.user, course_key)
+
+        enable_links = is_enrolled or (
             kwargs['enable_anonymous_access'] and course.course_visibility == 'public')
 
         context = {


### PR DESCRIPTION
This PR adds the course setting `course visibility` in CMS to allow preview and public access.

This requires the course waffle flag `enable_anonymous_access`.

**Feature description** based on [this PR](https://github.com/edx/edx-platform/pull/18134#issuecomment-394012584https://github.com/edx/edx-platform/pull/18134#issuecomment-394012584)

Settings / Options
Thinking through potential combinations of settings and override concerns for authors I might suggest a minor change to what you suggested above.

Course Visibility Default Setting: Public, Preview Only, Private
Public: Course outline and all units are available by default publicly, unless a subsection or unit is forced to be private.
Preview Only: Only the course outline is available publicly but content pages are locked / gated with a message explaining that users must log in to access the content.
Private: Our current default, but anybody who attempts to access specific content pages is redirected to the course home page (current behavior.)

**Sandbox URL**:
    [LMS](https://pr18537.sandbox.opencraft.hosting/)
    [CMS](https://studio-pr18537.sandbox.opencraft.hosting/)

    The staff user for these have superuser rights

**Testing instructions**:

1. Either logout or open a private browsing window and navigate to the demo course.
2. Make sure the outline isn't displayed and accessing a unit redirects to login.
3. Enable `seo.enable_anonymous_acess` waffle flag to the course and make sure the `Course Visibility For Unauthenticated Students` setting appear for the course in Studio.
4. Make sure the outline isn't displayed and accessing a unit redirects to login.
5. Change the `Course Visibility For Unauthenticated Students` advanced setting for the course to `preview`.
6. Make sure the outline is displayed without links or handouts.
7. Change the `Course Visibility For Unauthenticated Students` advanced setting for the course to `public`.
8. Refresh the course outline in the private browsing session and make sure the course outline is displayed with links.
9. Navigate to a unit and check it displays, even with broken blocks.
10. Disable the course waffle flag and make sure the course visibility setting doesn't shown up in advanced course settings.

**Author notes and concerns**:

1. Public access must be supported on XBlocks as well, so most will be broken for now.

**Reviewers**
- [x] @symbolist 
- [ ] edX reviewer[s]
