### PR TITLE
Move authentication backend class to separate module.

### DIFF
--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -649,7 +649,9 @@ derived_collection_entry('DEFAULT_TEMPLATE_ENGINE', 'DIRS')
 
 ###############################################################################################
 
-AUTHENTICATION_BACKENDS = ['openedx.core.djangoapps.oauth_dispatch.dot_overrides.validators.EdxRateLimitedAllowAllUsersModelBackend']
+AUTHENTICATION_BACKENDS = [
+    'openedx.core.djangoapps.oauth_dispatch.dot_overrides.backends.EdxRateLimitedAllowAllUsersModelBackend'
+]
 STUDENT_FILEUPLOAD_MAX_SIZE = 4 * 1000 * 1000  # 4 MB
 MAX_FILEUPLOADS_PER_INPUT = 20
 

--- a/openedx/core/djangoapps/oauth_dispatch/dot_overrides/backends.py
+++ b/openedx/core/djangoapps/oauth_dispatch/dot_overrides/backends.py
@@ -1,0 +1,18 @@
+"""
+Custom authentication backends.
+"""
+from django.contrib.auth.backends import AllowAllUsersModelBackend as UserModelBackend
+from ratelimitbackend.backends import RateLimitMixin
+
+
+class EdxRateLimitedAllowAllUsersModelBackend(RateLimitMixin, UserModelBackend):
+    """
+    Authentication backend needed to incorporate rate limiting of login attempts - but also
+    enabling users with is_active of False in the Django auth_user model to still authenticate.
+    This is necessary for mobile users using 3rd party auth who have not activated their accounts,
+    Inactive users who use 1st party auth (username/password auth) will still fail login attempts,
+    just at a higher layer, in the login_user view.
+
+    See: https://openedx.atlassian.net/browse/TNL-4516
+    """
+    pass

--- a/openedx/core/djangoapps/oauth_dispatch/dot_overrides/validators.py
+++ b/openedx/core/djangoapps/oauth_dispatch/dot_overrides/validators.py
@@ -6,14 +6,12 @@ from __future__ import unicode_literals
 from datetime import datetime
 
 from django.contrib.auth import authenticate, get_user_model
-from django.contrib.auth.backends import AllowAllUsersModelBackend as UserModelBackend
 from django.db.models.signals import pre_save
 from django.dispatch import receiver
 from oauth2_provider.models import AccessToken
 from oauth2_provider.oauth2_validators import OAuth2Validator
 from oauth2_provider.scopes import get_scopes_backend
 from pytz import utc
-from ratelimitbackend.backends import RateLimitMixin
 
 from ..models import RestrictedApplication
 
@@ -25,19 +23,6 @@ def on_access_token_presave(sender, instance, *args, **kwargs):  # pylint: disab
     """
     if RestrictedApplication.should_expire_access_token(instance.application):
         instance.expires = datetime(1970, 1, 1, tzinfo=utc)
-
-
-class EdxRateLimitedAllowAllUsersModelBackend(RateLimitMixin, UserModelBackend):
-    """
-    Authentication backend needed to incorporate rate limiting of login attempts - but also
-    enabling users with is_active of False in the Django auth_user model to still authenticate.
-    This is necessary for mobile users using 3rd party auth who have not activated their accounts,
-    Inactive users who use 1st party auth (username/password auth) will still fail login attempts,
-    just at a higher layer, in the login_user view.
-
-    See: https://openedx.atlassian.net/browse/TNL-4516
-    """
-    pass
 
 
 class EdxOAuth2Validator(OAuth2Validator):

--- a/openedx/core/djangoapps/oauth_dispatch/dot_overrides/views.py
+++ b/openedx/core/djangoapps/oauth_dispatch/dot_overrides/views.py
@@ -69,7 +69,7 @@ class EdxOAuth2AuthorizationView(AuthorizationView):
                 uri, headers, body, status = self.create_authorization_response(
                     request=self.request, scopes=" ".join(scopes),
                     credentials=credentials, allow=True)
-                return HttpResponseUriRedirect(uri)
+                return HttpResponseUriRedirect(uri, application.get_allowed_schemes())
 
             # *** Changed the if statement that checked for require_approval to an assert.
             assert require_approval == 'auto_even_if_expired'
@@ -87,7 +87,7 @@ class EdxOAuth2AuthorizationView(AuthorizationView):
                     uri, headers, body, status = self.create_authorization_response(
                         request=self.request, scopes=" ".join(scopes),
                         credentials=credentials, allow=True)
-                    return HttpResponseUriRedirect(uri)
+                    return HttpResponseUriRedirect(uri, application.get_allowed_schemes())
 
             # render an authorization prompt so the user can approve
             # the application's requested scopes

--- a/openedx/core/djangoapps/oauth_dispatch/dot_overrides/views.py
+++ b/openedx/core/djangoapps/oauth_dispatch/dot_overrides/views.py
@@ -5,7 +5,7 @@ from __future__ import unicode_literals
 
 from oauth2_provider.exceptions import OAuthToolkitError
 from oauth2_provider.http import HttpResponseUriRedirect
-from oauth2_provider.models import get_application_model
+from oauth2_provider.models import get_access_token_model, get_application_model
 from oauth2_provider.scopes import get_scopes_backend
 from oauth2_provider.settings import oauth2_settings
 from oauth2_provider.views import AuthorizationView
@@ -73,7 +73,8 @@ class EdxOAuth2AuthorizationView(AuthorizationView):
 
             # *** Changed the if statement that checked for require_approval to an assert.
             assert require_approval == 'auto_even_if_expired'
-            tokens = request.user.accesstoken_set.filter(
+            tokens = get_access_token_model().objects.filter(
+                user=request.user,
                 application=kwargs['application'],
                 # *** Purposefully keeping this commented out code to highlight that
                 # our version of the implementation does NOT filter by expiration date.


### PR DESCRIPTION
This moves our custom authentication backend to a separate module so that we are not loading the custom validator-related code during startup.