### PR TITLE
Video player seek issue

### DIFF
--- a/common/lib/xmodule/xmodule/js/src/video/03_video_player.js
+++ b/common/lib/xmodule/xmodule/js/src/video/03_video_player.js
@@ -447,7 +447,6 @@ function(HTML5Video, HTML5HLSVideo, Resizer, HLS, _, Time) {
         this.videoPlayer.goToStartTime = false;
 
         this.videoPlayer.seekTo(time);
-        this.trigger('videoProgressSlider.focusSlider');
 
         this.el.trigger('seek', [time, oldTime, type]);
     }


### PR DESCRIPTION
 The embedded video player does not allow the screen reader user to seek forwards / backwards within the time with the keyboard as you could in the past. If you tab to play a video and press spacebar or enter, you formerly would be able to press left / right arrow to move slightly forward or backward in time, but this no longer works correctly; it will move 1 second back / forward, then you need to press tab again to refocus and move another 1 second. Other keyboard access seems to be equivalent and we suspect a slight error in the Javascript is causing this and needs to be fixed.

[EDUCATOR-3034](https://openedx.atlassian.net/browse/EDUCATOR-3034)

FYI -- @wittjeff