### PR TITLE
fix-i18n-issues

### DIFF
--- a/lms/templates/logout.html
+++ b/lms/templates/logout.html
@@ -7,7 +7,7 @@
     <h1>{% trans "You have signed out." %}</h1>
 
     <p style="text-align: center; margin-bottom: 20px;">
-        {% blocktrans %}
+        {% blocktrans trimmed %}
           If you are not redirected within 5 seconds, <a href="{{ target }}">click here to go to the home page</a>.
         {% endblocktrans %}
     </p>

--- a/lms/templates/wiki/includes/anonymous_blocked.html
+++ b/lms/templates/wiki/includes/anonymous_blocked.html
@@ -3,7 +3,7 @@
 {% url 'wiki:signup' as signup_url %}
 {% url 'wiki:login' as login_url %}
 {% if login_url and signup_url %}
-  {% blocktrans %}
+  {% blocktrans trimmed %}
   You need to <a href="{{ login_url }}">log in</a> or <a href="{{ signup_url }}">sign up</a> to use this function.
   {% endblocktrans %}
 {% else %}

--- a/lms/templates/wiki/includes/editor_widget.html
+++ b/lms/templates/wiki/includes/editor_widget.html
@@ -1,6 +1,6 @@
 {% load i18n %}
 <p id="hint_id_content" class="help-block">
-    {% blocktrans with start_link="<a id='cheatsheetLink' href='#cheatsheetModal' rel='leanModal'>" end_link="</a>" %}
+    {% blocktrans with start_link="<a id='cheatsheetLink' href='#cheatsheetModal' rel='leanModal'>" end_link="</a>" trimmed %}
         Markdown syntax is allowed. See the {{ start_link }}cheatsheet{{ end_link }} for help.
     {% endblocktrans %}
 </p>

--- a/openedx/core/djangoapps/schedules/templates/schedules/edx_ace/courseupdate/email/subject.txt
+++ b/openedx/core/djangoapps/schedules/templates/schedules/edx_ace/courseupdate/email/subject.txt
@@ -1,5 +1,5 @@
 {% autoescape off %}
 {% load i18n %}
 
-{% blocktrans %}Welcome to week {{ week_num }} {% endblocktrans %}
+{% blocktrans trimmed %}Welcome to week {{ week_num }} {% endblocktrans %}
 {% endautoescape %}


### PR DESCRIPTION
Removes the startline and endline characters which cause problem when compiling translations if they have duplicate value.
`i18n_tool generate
INFO:i18n.generate:Merging djangojs.po locale ar
INFO:i18n.execute:Executing in /edx/app/edxapp/edx-platform/conf/locale/ar/LC_MESSAGES ...
INFO:i18n.execute:msgcat -o merged.po djangojs-partial.po djangojs-studio.po underscore.po underscore-studio.po
WARNING:i18n.generate: 8 duplicates in /edx/app/edxapp/edx-platform/conf/locale/ar/LC_MESSAGES/djangojs.po, details in .dup file
INFO:i18n.generate:Merging django.po locale ar
INFO:i18n.execute:Executing in /edx/app/edxapp/edx-platform/conf/locale/ar/LC_MESSAGES ...
INFO:i18n.execute:msgcat -o merged.po django-partial.po django-studio.po mako.po mako-studio.po wiki.po
WARNING:i18n.generate: 25 duplicates in /edx/app/edxapp/edx-platform/conf/locale/ar/LC_MESSAGES/django.po, details in .dup file
INFO:i18n.generate:Merging djangojs.po locale es_419
INFO:i18n.execute:Executing in /edx/app/edxapp/edx-platform/conf/locale/es_419/LC_MESSAGES ...
INFO:i18n.execute:msgcat -o merged.po djangojs-partial.po djangojs-studio.po underscore.po underscore-studio.po
WARNING:i18n.generate: 8 duplicates in /edx/app/edxapp/edx-platform/conf/locale/es_419/LC_MESSAGES/djangojs.po, details in .dup file
INFO:i18n.generate:Merging django.po locale es_419
INFO:i18n.execute:Executing in /edx/app/edxapp/edx-platform/conf/locale/es_419/LC_MESSAGES ...
INFO:i18n.execute:msgcat -o merged.po django-partial.po django-studio.po mako.po mako-studio.po wiki.po
Traceback (most recent call last):
  File "/edx/app/edxapp/venvs/edxapp/bin/i18n_tool", line 11, in <module>
    sys.exit(main())
  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/i18n/main.py", line 60, in main
    return module.main()
  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/i18n/__init__.py", line 51, in __call__
    return self.run(args)
  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/i18n/generate.py", line 176, in run
    merge_files(configuration, locale, fail_if_missing=args.strict)
  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/i18n/generate.py", line 80, in merge_files
    merge(configuration, locale, target, sources, fail_if_missing)
  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/i18n/generate.py", line 59, in merge
    duplicate_entries = clean_pofile(merged_filename)
  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/i18n/generate.py", line 130, in clean_pofile
    ).encode('utf-8')
ValueError: 
  You need to <a href="%(login_url)s">log in</a> or <a href="%(signup_url)s">sign up</a> to use this function.
   starts or ends with a new line character, which is not allowed. Please fix before continuing. Source string is found in [(u'lms/templates/wiki/includes/anonymous_blocked.html', None), (u'wiki/templates/wiki/includes/anonymous_blocked.html', None)]
`