### PR TITLE
Fix display of all words in word clouds.

### DIFF
--- a/common/lib/xmodule/xmodule/assets/word_cloud/src/js/word_cloud_main.js
+++ b/common/lib/xmodule/xmodule/assets/word_cloud/src/js/word_cloud_main.js
@@ -309,7 +309,7 @@ export default class WordCloudMain {
     .style('font-family', 'Impact')
     .style('fill', (d, i) => fill(i))
     .attr('text-anchor', 'middle')
-    .attr('transform', d => `translate(${d.x}, ${d.y})rotate(${d.rotate$})scale(${scale})`)
+    .attr('transform', d => `translate(${d.x}, ${d.y})rotate(${d.rotate})scale(${scale})`)
     .text(d => d.text);
   }
 }


### PR DESCRIPTION
## [Word cloud displays all words on top of each other EDUCATOR-3153](https://openedx.atlassian.net/browse/EDUCATOR-3153)

### Description:
This PR fixes the display of words in the word cloud that are showing on the top of each other.

### How to Test?
**Prod**
https://edge.edx.org/courses/course-v1:JAx+37+jax_37/courseware/b81073bbfb1c4d3cba7d93a318a752d3/66529a132443429aa780081cf926f661/1



**Sandbox**
https://word-cloud.sandbox.edx.org/courses/course-v1:edX+DemoX+Demo_Course/courseware/9fca584977d04885bc911ea76a9ef29e/07bc32474380492cb34f76e5f9d9a135/1?activate_block_id=block-v1%3AedX%2BDemoX%2BDemo_Course%2Btype%40vertical%2Bblock%4045c7cedb4bfe46f4a68c78787151cfb5


### Screenshot
**Before Fix**
![image](https://user-images.githubusercontent.com/7627421/42504192-6190493e-8454-11e8-990c-5ad7089b220c.png)




**After Fix**

![image](https://user-images.githubusercontent.com/7627421/42504208-6e8700ec-8454-11e8-92a5-f014db4e7276.png)


### Reviewers

If you've been tagged for review, please check your corresponding box once you've given the :+1:.
-  [x] @awaisdar001 
-  [x] @Rabia23 

### Post-review
- [x] Rebase and squash commits


