### PR TITLE
EDUCATOR-3030 upgrade edx-completion version from 0.1.7 to 0.1.8.

### DIFF
--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -111,7 +111,7 @@ edx-ace==0.1.8
 edx-analytics-data-api-client==0.14.4
 edx-ccx-keys==0.2.1
 edx-celeryutils==0.2.7
-edx-completion==0.1.7
+edx-completion==0.1.8
 edx-django-oauth2-provider==1.3.3
 edx-django-release-util==0.3.1
 edx-django-sites-extensions==2.3.1

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -131,7 +131,7 @@ edx-ace==0.1.8
 edx-analytics-data-api-client==0.14.4
 edx-ccx-keys==0.2.1
 edx-celeryutils==0.2.7
-edx-completion==0.1.7
+edx-completion==0.1.8
 edx-django-oauth2-provider==1.3.3
 edx-django-release-util==0.3.1
 edx-django-sites-extensions==2.3.1
@@ -324,7 +324,7 @@ testfixtures==6.2.0
 testtools==2.3.0
 text-unidecode==1.2
 tox-battery==0.5.1
-tox==3.1.0
+tox==3.1.1
 traceback2==1.4.0
 transifex-client==0.13.4
 twisted==16.6.0

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -126,7 +126,7 @@ edx-ace==0.1.8
 edx-analytics-data-api-client==0.14.4
 edx-ccx-keys==0.2.1
 edx-celeryutils==0.2.7
-edx-completion==0.1.7
+edx-completion==0.1.8
 edx-django-oauth2-provider==1.3.3
 edx-django-release-util==0.3.1
 edx-django-sites-extensions==2.3.1
@@ -308,7 +308,7 @@ testfixtures==6.2.0
 testtools==2.3.0          # via fixtures, python-subunit
 text-unidecode==1.2       # via faker
 tox-battery==0.5.1
-tox==3.1.0
+tox==3.1.1
 traceback2==1.4.0         # via testtools, unittest2
 transifex-client==0.13.4
 twisted==16.6.0           # via pa11ycrawler, scrapy


### PR DESCRIPTION
Jira Tickets: 
https://openedx.atlassian.net/browse/EDUCATOR-3030

Diff of proctoring tags:
https://github.com/edx/completion/compare/0.1.7...0.1.8

edx-proctoring PR link:
https://github.com/edx/completion/pull/20

edx-proctoring release PR link:
https://github.com/edx/completion/pull/21

cc: @awaisdar001 / @iloveagent57 