### PR TITLE
updated vertical alignment for learner profile menu

### DIFF
--- a/lms/static/sass/features/_learner-profile.scss
+++ b/lms/static/sass/features/_learner-profile.scss
@@ -295,11 +295,12 @@
       .u-field-account_privacy {
         @extend .container;
 
+        display: table-cell;
         border: none;
         box-shadow: none;
         padding: 0;
         margin: 0;
-        display: table-cell;
+        vertical-align: middle;
 
         @media (max-width: $learner-profile-container-flex) { // Switch to map-get($grid-breakpoints,md) for bootstrap
           max-width: calc(100% - 40px);


### PR DESCRIPTION
Minor css rule update to align message on learner profile menu bar

Before Changes:
![image](https://user-images.githubusercontent.com/2023680/42517669-47487b26-842e-11e8-970d-0e4bc429ddd8.png)


With Changes
![image](https://user-images.githubusercontent.com/2023680/42517645-3391e888-842e-11e8-9606-a9653af11e6f.png)
