### PR TITLE
Only notify credentials of course certs

### DIFF
--- a/openedx/core/djangoapps/credentials/management/commands/notify_credentials.py
+++ b/openedx/core/djangoapps/credentials/management/commands/notify_credentials.py
@@ -25,7 +25,7 @@ from pytz import UTC
 from lms.djangoapps.certificates.models import GeneratedCertificate
 from lms.djangoapps.grades.models import PersistentCourseGrade
 from openedx.core.djangoapps.credentials.signals import handle_cert_change, send_grade_if_interesting
-from openedx.core.djangoapps.programs.signals import handle_course_cert_awarded, handle_course_cert_changed
+from openedx.core.djangoapps.programs.signals import handle_course_cert_changed
 
 
 log = logging.getLogger(__name__)
@@ -182,7 +182,6 @@ class Command(BaseCommand):
                 'mode': cert.mode,
                 'status': cert.status,
             }
-            handle_course_cert_awarded(**signal_args)
             handle_course_cert_changed(**signal_args)
             handle_cert_change(**signal_args)
 

--- a/openedx/core/djangoapps/credentials/management/commands/tests/test_notify_credentials.py
+++ b/openedx/core/djangoapps/credentials/management/commands/tests/test_notify_credentials.py
@@ -90,13 +90,11 @@ class TestNotifyCredentials(TestCase):
 
     @mock.patch(COMMAND_MODULE + '.handle_cert_change')
     @mock.patch(COMMAND_MODULE + '.send_grade_if_interesting')
-    @mock.patch(COMMAND_MODULE + '.handle_course_cert_awarded')
     @mock.patch(COMMAND_MODULE + '.handle_course_cert_changed')
-    def test_hand_off(self, mock_grade_cert_change, mock_grade_interesting, mock_program_awarded, mock_program_changed):
+    def test_hand_off(self, mock_grade_cert_change, mock_grade_interesting, mock_program_changed):
         call_command(Command(), '--start-date', '2017-02-01')
         self.assertEqual(mock_grade_cert_change.call_count, 2)
         self.assertEqual(mock_grade_interesting.call_count, 2)
-        self.assertEqual(mock_program_awarded.call_count, 2)
         self.assertEqual(mock_program_changed.call_count, 2)
 
     @mock.patch(COMMAND_MODULE + '.time')


### PR DESCRIPTION
When notifying credentials of cert/grade changes using
notify_credentials, don't worry about signaling for program cert
awards. (A) We don't need that functionality right now when
backpopulating credentials records, and (B) we have other management
commands for that anyway.