### PR TITLE
OSPR: Improve Course Modes configuration

### DIFF
--- a/cms/djangoapps/contentstore/views/tests/test_item.py
+++ b/cms/djangoapps/contentstore/views/tests/test_item.py
@@ -384,7 +384,7 @@ class GetItemTest(ItemTest):
                 "scheme": "enrollment_track",
                 "groups": [
                     {
-                        "id": settings.COURSE_ENROLLMENT_MODES["audit"],
+                        "id": settings.COURSE_ENROLLMENT_MODES["audit"]["id"],
                         "name": "Audit",
                         "selected": False,
                         "deleted": False,

--- a/cms/envs/aws.py
+++ b/cms/envs/aws.py
@@ -594,6 +594,9 @@ RETIREMENT_SERVICE_WORKER_USERNAME = ENV_TOKENS.get(
 )
 RETIREMENT_STATES = ENV_TOKENS.get('RETIREMENT_STATES', RETIREMENT_STATES)
 
+############## Settings for Course Enrollment Modes ######################
+COURSE_ENROLLMENT_MODES = ENV_TOKENS.get('COURSE_ENROLLMENT_MODES', COURSE_ENROLLMENT_MODES)
+
 ####################### Plugin Settings ##########################
 
 from openedx.core.djangoapps.plugins import plugin_settings, constants as plugin_constants

--- a/common/djangoapps/course_modes/admin.py
+++ b/common/djangoapps/course_modes/admin.py
@@ -1,3 +1,4 @@
+import six
 from django import forms
 from django.conf import settings
 from django.contrib import admin
@@ -23,7 +24,7 @@ from openedx.core.lib.courses import clean_course_id
 from util.date_utils import get_time_display
 from xmodule.modulestore.django import modulestore
 
-COURSE_MODE_SLUG_CHOICES = [(mode_slug, mode_slug) for mode_slug in settings.COURSE_ENROLLMENT_MODES]
+COURSE_MODE_SLUG_CHOICES = [(key, enrollment_mode['display_name']) for key, enrollment_mode in six.iteritems(settings.COURSE_ENROLLMENT_MODES)]
 
 
 class CourseModeForm(forms.ModelForm):

--- a/lms/envs/aws.py
+++ b/lms/envs/aws.py
@@ -1093,6 +1093,9 @@ RETIREMENT_SERVICE_WORKER_USERNAME = ENV_TOKENS.get(
 )
 RETIREMENT_STATES = ENV_TOKENS.get('RETIREMENT_STATES', RETIREMENT_STATES)
 
+############## Settings for Course Enrollment Modes ######################
+COURSE_ENROLLMENT_MODES = ENV_TOKENS.get('COURSE_ENROLLMENT_MODES', COURSE_ENROLLMENT_MODES)
+
 ############################### Plugin Settings ###############################
 
 from openedx.core.djangoapps.plugins import plugin_settings, constants as plugin_constants

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -3361,12 +3361,42 @@ BASE_COOKIE_DOMAIN = 'localhost'
 
 ############## Settings for Course Enrollment Modes ######################
 COURSE_ENROLLMENT_MODES = {
-    "audit": 1,
-    "verified": 2,
-    "professional": 3,
-    "no-id-professional": 4,
-    "credit": 5,
-    "honor": 6,
+    "audit": {
+        "id": 1,
+        "slug": "audit",
+        "display_name": _("Audit"),
+        "min_price": 0
+    },
+    "verified": {
+        "id": 2,
+        "slug": "verified",
+        "display_name": _("Verified"),
+        "min_price": 0
+    },
+    "professional": {
+        "id": 3,
+        "slug": "professional",
+        "display_name": _("Professional"),
+        "min_price": 0
+    },
+    "no-id-professional": {
+        "id": 4,
+        "slug": "no-id-professional",
+        "display_name": _("No-Id-Professional"),
+        "min_price": 0
+    },
+    "credit": {
+        "id": 5,
+        "slug": "credit",
+        "display_name": _("Credit"),
+        "min_price": 0
+    },
+    "honor": {
+        "id": 6,
+        "slug": "honor",
+        "display_name": _("Honor"),
+        "min_price": 0
+    },
 }
 
 ############## Settings for the Discovery App ######################

--- a/openedx/core/djangoapps/verified_track_content/management/commands/swap_from_auto_track_cohort_pilot.py
+++ b/openedx/core/djangoapps/verified_track_content/management/commands/swap_from_auto_track_cohort_pilot.py
@@ -197,9 +197,9 @@ class Command(BaseCommand):
                 # Add the enrollment track ids to a group access array
                 enrollment_track_group_access = []
                 if set_audit_enrollment_track:
-                    enrollment_track_group_access.append(settings.COURSE_ENROLLMENT_MODES['audit'])
+                    enrollment_track_group_access.append(settings.COURSE_ENROLLMENT_MODES['audit']['id'])
                 if set_verified_enrollment_track:
-                    enrollment_track_group_access.append(settings.COURSE_ENROLLMENT_MODES['verified'])
+                    enrollment_track_group_access.append(settings.COURSE_ENROLLMENT_MODES['verified']['id'])
 
                 # If there are no errors, and either the audit track, or verified
                 #  track needed an update, set the access, update and publish

--- a/openedx/core/djangoapps/verified_track_content/partition_scheme.py
+++ b/openedx/core/djangoapps/verified_track_content/partition_scheme.py
@@ -45,7 +45,7 @@ class EnrollmentTrackUserPartition(UserPartition):
             return []
 
         return [
-            Group(ENROLLMENT_GROUP_IDS[mode.slug], unicode(mode.name))
+            Group(ENROLLMENT_GROUP_IDS[mode.slug]["id"], unicode(mode.name))
             for mode in CourseMode.modes_for_course(course_key, include_expired=True)
         ]
 
@@ -100,7 +100,7 @@ class EnrollmentTrackPartitionScheme(object):
                 course_mode = CourseMode.verified_mode_for_course(course_key, include_expired=True)
             if not course_mode:
                 course_mode = CourseMode.DEFAULT_MODE
-            return Group(ENROLLMENT_GROUP_IDS[course_mode.slug], unicode(course_mode.name))
+            return Group(ENROLLMENT_GROUP_IDS[course_mode.slug]["id"], unicode(course_mode.name))
         else:
             return None
 

--- a/openedx/core/djangoapps/verified_track_content/tests/test_partition_scheme.py
+++ b/openedx/core/djangoapps/verified_track_content/tests/test_partition_scheme.py
@@ -69,7 +69,7 @@ class EnrollmentTrackUserPartitionTest(SharedModuleStoreTestCase):
         with group IDs associated with cohort and random user partitions).
         """
         for mode in ENROLLMENT_GROUP_IDS:
-            self.assertLess(ENROLLMENT_GROUP_IDS[mode], MINIMUM_STATIC_PARTITION_ID)
+            self.assertLess(ENROLLMENT_GROUP_IDS[mode]['id'], MINIMUM_STATIC_PARTITION_ID)
 
     @staticmethod
     def get_group_by_name(partition, name):


### PR DESCRIPTION
This PR adds more configurable fields to the `COURSE_ENROLLMENT_MODES` variable defined in `lms/envs/comon.py`. It keeps already defined integer values as `id`.

* Before:
```
COURSE_ENROLLMENT_MODES = {
    "audit": 1,
    "verified": 2,
    "professional": 3,
    "no-id-professional": 4,
    "credit": 5,
    "honor": 6,
}
```
* After:
```
COURSE_ENROLLMENT_MODES = {
    "audit": {"id": 1, "slug": "audit", "display_name": _("Audit"), "min_price": 0},
    "verified": {"id": 2, "slug": "verified", "display_name": _("Verified"), "min_price": 0},
    "professional": {"id": 3, "slug": "professional", "display_name": _("Professional"), "min_price": 0},
    "no-id-professional": {"id": 4, "slug": "no-id-professional", "display_name": _("No-Id-Professional"), "min_price": 0},
    "credit": {"id": 5, "slug": "credit", "display_name": _("Credit"), "min_price": 0},
    "honor": {"id": 6, "slug": "honor", "display_name": _("Honor"), "min_price": 0},
 }
```
One of the uses of this feature is to show a more friendly name in Django admin panel when creating a new Course Mode.

I've added the option to override the default values in `lms/envs/aws.py`. For example, in case we don't want admin users to create other than audit and honor course modes, we just need to add to the `server-vars.yml` file:
```
EDXAPP_ENV_EXTRA:
  COURSE_ENROLLMENT_MODES:
    audit:
      id: 1
      slug: "audit"
      display_name: "Gratuito"
      min_price: 0
    honor:
      id: 2
      slug: "honor"
      display_name: "Credencial"
      min_price: 15
```
And update configuration and edx-platform.
To test it, go to django admin panel and try to create a new course mode. In the mode slug section, you should only see the options defined in the `COURSE_ENROLLMENT_MODES` variable.
