### PR TITLE
Fix validation error when letter grade is None.

### DIFF
--- a/openedx/core/djangoapps/credentials/signals.py
+++ b/openedx/core/djangoapps/credentials/signals.py
@@ -67,7 +67,7 @@ def send_grade_if_interesting(user, course_run_key, mode, status, letter_grade, 
     # Grab grades if we don't have them in hand
     if letter_grade is None or percent_grade is None:
         grade = CourseGradeFactory().read(user, course_key=course_run_key, create_if_needed=False)
-        if grade is None:
+        if grade is None or grade.letter_grade is None:
             return
         letter_grade = grade.letter_grade
         percent_grade = grade.percent

--- a/openedx/core/djangoapps/credentials/tests/test_signals.py
+++ b/openedx/core/djangoapps/credentials/tests/test_signals.py
@@ -88,6 +88,18 @@ class TestCredentialsSignalsSendGrade(TestCase):
         send_grade_if_interesting(self.user, self.key, 'verified', 'downloadable', None, None)
         self.assertFalse(mock_send_grade_to_credentials.delay.called)
 
+    @mock.patch.dict(settings.FEATURES, {'ASSUME_ZERO_GRADE_IF_ABSENT_FOR_ALL_TESTS': False})
+    def test_send_grade_without_letter_grade(self, mock_is_course_run_in_a_program, mock_send_grade_to_credentials):
+        """
+        Verify that when letter grade is None it wouldn'y send grade data
+        """
+        mock_is_course_run_in_a_program.return_value = True
+        with mock.patch(
+                'lms.djangoapps.grades.course_grade_factory.CourseGradeFactory.read',
+                return_value=mock.Mock(percent=0, letter_grade=None)):
+            send_grade_if_interesting(self.user, self.key, 'verified', 'downloadable', None, None)
+            self.assertFalse(mock_send_grade_to_credentials.delay.called)
+
 
 @skip_unless_lms
 @mock.patch(SIGNALS_MODULE + '.get_programs')


### PR DESCRIPTION
### [EDUCATOR-3179](https://openedx.atlassian.net/browse/EDUCATOR-3179)

I have fixed that when the letter grade is `None` it shouldn't send any grade data to the credentials service.
https://github.com/edx/edx-platform/blob/f9db6b22e0a965d686d206c11973627e24b013f8/openedx/core/djangoapps/credentials/signals.py#L70-L70
 @iloveagent57 I have changed this line. Can you please review it?

@mikix Seems like you have recently worked on the grading. Can you please acknowloedge this condition is correct or not? Or we should use an other way to resolve this validation error?

CC: @awaisdar001 
