### PR TITLE
Fix VisibleBlock.bulk_get_or_create method

### DIFF
--- a/lms/djangoapps/grades/models.py
+++ b/lms/djangoapps/grades/models.py
@@ -220,8 +220,8 @@ class VisibleBlocks(models.Model):
         only for those that aren't already created.
         """
         cached_records = cls.bulk_read(user_id, course_key)
-        non_existent_brls = {brl.hash_value for brl in block_record_lists if brl.hash_value not in cached_records}
-        cls.bulk_create(user_id, course_key, non_existent_brls)
+        non_existent_brls = {brl for brl in block_record_lists if brl.hash_value not in cached_records}
+        return cls.bulk_create(user_id, course_key, non_existent_brls)
 
     @classmethod
     def _initialize_cache(cls, user_id, course_key):


### PR DESCRIPTION
I was trying out the gradebook feature earlier today on my devstack and ran into a `'str' obj has no method 'json_value'` error, which came from the `VisibleBlocks.bulk_create()` method.  I couldn't reproduce this in stage (or prod) and found no instances of this error message in splunk.  I think we're not hitting this code path due to the visible blocks cache prefetching we do, but I haven't quite been able to prove that.  In any case, when we hit this code path, there definitely is a bug, and this PR fixes it.