### PR TITLE
INCR-18 Upgrade django-config-models for Python 3 support

### DIFF
--- a/requirements/edx/base.in
+++ b/requirements/edx/base.in
@@ -35,7 +35,7 @@ ddt==0.8.0                          # via xblock-drag-and-drop-v2 (which probabl
 defusedxml==0.4.1                   # XML bomb protection for common XML parsers
 Django==1.11.14                     # Web application framework
 django-babel-underscore             # underscore template extractor for django-babel (internationalization utilities)
-django-config-models==0.1.8         # Configuration models for Django allowing config management with auditing
+django-config-models                # Configuration models for Django allowing config management with auditing
 django-cors-headers==2.1.0          # Used to allow to configure CORS headers for cross-domain requests
 django-countries==4.6.1             # Country data for Django forms and model fields
 django-crum                         # Middleware that stores the current request and user in thread local storage

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -71,7 +71,7 @@ django-babel-underscore==0.5.2
 django-babel==0.6.2       # via django-babel-underscore
 django-braces==1.13.0     # via django-oauth-toolkit
 django-classy-tags==0.8.0  # via django-sekizai
-django-config-models==0.1.8
+django-config-models==0.2.0
 django-cors-headers==2.1.0
 django-countries==4.6.1
 django-crum==0.7.2
@@ -123,7 +123,7 @@ edx-oauth2-provider==1.2.2
 edx-opaque-keys[django]==0.4.4
 edx-organizations==0.4.10
 edx-proctoring==1.4.0
-edx-rest-api-client==1.7.1
+edx-rest-api-client==1.7.2
 edx-search==1.2.1
 edx-submissions==2.0.12
 edx-user-state-client==1.0.4
@@ -167,7 +167,7 @@ mock==1.0.1
 mongoengine==0.10.0
 mysql-python==1.2.5
 networkx==1.7
-newrelic==3.2.2.94
+newrelic==3.4.0.95
 nltk==3.3.0
 nodeenv==1.1.1
 numpy==1.6.2

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -90,7 +90,7 @@ django-babel-underscore==0.5.2
 django-babel==0.6.2
 django-braces==1.13.0
 django-classy-tags==0.8.0
-django-config-models==0.1.8
+django-config-models==0.2.0
 django-cors-headers==2.1.0
 django-countries==4.6.1
 django-crum==0.7.2
@@ -144,7 +144,7 @@ edx-oauth2-provider==1.2.2
 edx-opaque-keys[django]==0.4.4
 edx-organizations==0.4.10
 edx-proctoring==1.4.0
-edx-rest-api-client==1.7.1
+edx-rest-api-client==1.7.2
 edx-search==1.2.1
 edx-sphinx-theme==1.3.0
 edx-submissions==2.0.12
@@ -156,7 +156,7 @@ event-tracking==0.2.4
 execnet==1.5.0
 extras==1.0.0
 factory_boy==2.8.1
-faker==0.8.16
+faker==0.8.17
 feedparser==5.1.3
 firebase-token-generator==1.3.2
 first==2.0.1
@@ -217,7 +217,7 @@ moto==0.3.1
 mysql-python==1.2.5
 needle==0.5.0
 networkx==1.7
-newrelic==3.2.2.94
+newrelic==3.4.0.95
 nltk==3.3.0
 nodeenv==1.1.1
 nose==1.3.7
@@ -324,7 +324,7 @@ testfixtures==6.2.0
 testtools==2.3.0
 text-unidecode==1.2
 tox-battery==0.5.1
-tox==3.1.1
+tox==3.1.2
 traceback2==1.4.0
 transifex-client==0.13.4
 twisted==16.6.0

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -87,7 +87,7 @@ django-babel-underscore==0.5.2
 django-babel==0.6.2
 django-braces==1.13.0
 django-classy-tags==0.8.0
-django-config-models==0.1.8
+django-config-models==0.2.0
 django-cors-headers==2.1.0
 django-countries==4.6.1
 django-crum==0.7.2
@@ -139,7 +139,7 @@ edx-oauth2-provider==1.2.2
 edx-opaque-keys[django]==0.4.4
 edx-organizations==0.4.10
 edx-proctoring==1.4.0
-edx-rest-api-client==1.7.1
+edx-rest-api-client==1.7.2
 edx-search==1.2.1
 edx-submissions==2.0.12
 edx-user-state-client==1.0.4
@@ -150,7 +150,7 @@ event-tracking==0.2.4
 execnet==1.5.0            # via pytest-xdist
 extras==1.0.0             # via python-subunit, testtools
 factory_boy==2.8.1
-faker==0.8.16             # via factory-boy
+faker==0.8.17             # via factory-boy
 feedparser==5.1.3
 firebase-token-generator==1.3.2
 fixtures==3.0.0           # via testtools
@@ -208,7 +208,7 @@ moto==0.3.1
 mysql-python==1.2.5
 needle==0.5.0             # via bok-choy
 networkx==1.7
-newrelic==3.2.2.94
+newrelic==3.4.0.95
 nltk==3.3.0
 nodeenv==1.1.1
 nose==1.3.7
@@ -308,7 +308,7 @@ testfixtures==6.2.0
 testtools==2.3.0          # via fixtures, python-subunit
 text-unidecode==1.2       # via faker
 tox-battery==0.5.1
-tox==3.1.1
+tox==3.1.2
 traceback2==1.4.0         # via testtools, unittest2
 transifex-client==0.13.4
 twisted==16.6.0           # via pa11ycrawler, scrapy


### PR DESCRIPTION
Upgrade django-config-models to take advantage of the work done in INCR-18 to make it support Python 3.  Pulls in a few other upgrades which seem pretty harmless based on their changelogs.