### PR TITLE
Fix screen reader issue on profile page.

### DIFF
--- a/lms/static/sass/features/_learner-profile.scss
+++ b/lms/static/sass/features/_learner-profile.scss
@@ -371,6 +371,7 @@
       @extend %t-ultrastrong;
 
       display: inline-block;
+      color: #222;
     }
 
     .subheader {

--- a/openedx/features/learner_profile/templates/learner_profile/learner_profile.html
+++ b/openedx/features/learner_profile/templates/learner_profile/learner_profile.html
@@ -36,7 +36,7 @@ from openedx.core.djangolib.markup import HTML
             </div>
             % if own_profile:
                 <div class="profile-header">
-                    <div class="header">${_("My Profile")}</div>
+                    <h2 class="header">${_("My Profile")}</h2>
                     <div class="subheader">
                         ${_('Build out your profile to personalize your identity on {platform_name}.').format(
                             platform_name=platform_name,


### PR DESCRIPTION
### [EDUCATOR-3209](https://openedx.atlassian.net/browse/EDUCATOR-3209)

Fix accessibility issue on the profile page. change div to h2.

@wittjeff can you please review?

FYI: @fysheets 


After fix:
<img width="579" alt="screen shot 2018-07-19 at 2 30 32 pm" src="https://user-images.githubusercontent.com/7627421/42934405-8906dcea-8b60-11e8-99d7-977346f291f1.png">
