### PR TITLE
Bump edx-ace version

### DIFF
--- a/requirements/edx/base.in
+++ b/requirements/edx/base.in
@@ -64,7 +64,7 @@ django-waffle==0.12.0
 django-webpack-loader               # Used to wire webpack bundles into the django asset pipeline
 djangorestframework-jwt
 dogapi==1.2.1                       # Python bindings to Datadog's API, for metrics gathering
-edx-ace==0.1.8
+edx-ace==0.1.9
 edx-analytics-data-api-client
 edx-ccx-keys
 edx-celeryutils

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -107,7 +107,7 @@ dm.xmlsec.binding==1.3.3  # via python-saml
 docopt==0.6.2
 docutils==0.14            # via botocore
 dogapi==1.2.1
-edx-ace==0.1.8
+edx-ace==0.1.9
 edx-analytics-data-api-client==0.14.4
 edx-ccx-keys==0.2.1
 edx-celeryutils==0.2.7

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -127,7 +127,7 @@ dm.xmlsec.binding==1.3.3
 docopt==0.6.2
 docutils==0.14
 dogapi==1.2.1
-edx-ace==0.1.8
+edx-ace==0.1.9
 edx-analytics-data-api-client==0.14.4
 edx-ccx-keys==0.2.1
 edx-celeryutils==0.2.7

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -122,7 +122,7 @@ dm.xmlsec.binding==1.3.3
 docopt==0.6.2
 docutils==0.14
 dogapi==1.2.1
-edx-ace==0.1.8
+edx-ace==0.1.9
 edx-analytics-data-api-client==0.14.4
 edx-ccx-keys==0.2.1
 edx-celeryutils==0.2.7


### PR DESCRIPTION
Version bump to use https://github.com/edx/edx-ace/pull/31

Using this as the example on how to bump https://github.com/edx/edx-platform/commit/3a64dad8cfbea0f1541e9a7cee19b58aec893d78#diff-651eb6d7a35f48a733edd7d396b4dbd5