### PR TITLE
Update entitlement ordering in dash

### DIFF
--- a/common/djangoapps/student/views/dashboard.py
+++ b/common/djangoapps/student/views/dashboard.py
@@ -837,10 +837,11 @@ def student_dashboard(request):
         })
 
     # Gather urls for course card resume buttons.
-    resume_button_urls = _get_urls_for_resume_buttons(user, course_enrollments)
+    resume_button_urls = ['' for entitlement in course_entitlements]
+    for url in _get_urls_for_resume_buttons(user, course_enrollments):
+        resume_button_urls.append(url)
     # There must be enough urls for dashboard.html. Template creates course
     # cards for "enrollments + entitlements".
-    resume_button_urls += ['' for entitlement in course_entitlements]
     context.update({
         'resume_button_urls': resume_button_urls
     })


### PR DESCRIPTION
## [LEARNER-5556](https://openedx.atlassian.net/browse/LEARNER-5556)

### Description
Reorder entitlements and resume course links in learner dash to maintain ordering.

### Testing
- [ ] Unit tests

### Reviewers
If you've been tagged for review, please check your corresponding box once you've given the :+1:.
- [ ] Code review: @sandroroux 

FYI: @edx/educator-neem

### Post-review
- [ ] Rebase and squash commits
