### PR TITLE
Add port to activation link to keep it from failing on devstack.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -289,3 +289,4 @@ Rabia Iftikhar <rabiaiftikhar2392@gmail.com>
 Matt Tuchfarber <mtuchfarber@edx.org>
 Stuart Young <syoung@edx.org>
 Michael Youngstrom <myoungstrom@edx.org>
+Sahar Markovich <sahar.markovich@gmail.com>

--- a/cms/envs/devstack.py
+++ b/cms/envs/devstack.py
@@ -14,6 +14,7 @@ USER_TASKS_ARTIFACT_STORAGE = COURSE_IMPORT_EXPORT_STORAGE
 DEBUG = True
 USE_I18N = True
 DEFAULT_TEMPLATE_ENGINE['OPTIONS']['debug'] = DEBUG
+SITE_NAME = 'localhost:8001'
 HTTPS = 'off'
 
 ################################ LOGGERS ######################################


### PR DESCRIPTION
This value was defined in lms but not in cms. I discovered this when testing the user account activation link and finding it unable to activate my account on devstack. This change adds the port which fixes the user account activation link in Studio.

cc @stvstnfrd 