### PR TITLE
Change DELETE to POST to deal with slumber limitations.

### DIFF
--- a/openedx/core/djangoapps/user_api/accounts/tests/test_retirement_views.py
+++ b/openedx/core/djangoapps/user_api/accounts/tests/test_retirement_views.py
@@ -326,7 +326,7 @@ class TestPartnerReportingCleanup(ModuleStoreTestCase):
         self.course_awesome_org = CourseFactory(org='awesome_org')
         self.headers = build_jwt_headers(self.test_superuser)
         self.headers['content_type'] = "application/json"
-        self.url = reverse('accounts_retirement_partner_report')
+        self.url = reverse('accounts_retirement_partner_report_cleanup')
         self.maxDiff = None
 
     def create_partner_reporting_statuses(self, is_being_processed=True, num=2):
@@ -351,7 +351,7 @@ class TestPartnerReportingCleanup(ModuleStoreTestCase):
 
     def assert_status_and_count(self, statuses, remaining_count, expected_status=status.HTTP_204_NO_CONTENT):
         """
-        Performs a test client DELETE against the retirement reporting cleanup endpoint. It generates
+        Performs a test client POST against the retirement reporting cleanup endpoint. It generates
         the JSON of usernames to clean up based on the given list of UserRetirementPartnerReportingStatuses,
         asserts that the given number of UserRetirementPartnerReportingStatus rows are still in the database
         after the operation, and asserts that the given expected_status HTTP status code is returned.
@@ -359,7 +359,7 @@ class TestPartnerReportingCleanup(ModuleStoreTestCase):
         usernames = [{'original_username': u.original_username} for u in statuses]
 
         data = json.dumps(usernames)
-        response = self.client.delete(self.url, data=data, **self.headers)
+        response = self.client.post(self.url, data=data, **self.headers)
         print(response)
         print(response.content)
 

--- a/openedx/core/djangoapps/user_api/accounts/views.py
+++ b/openedx/core/djangoapps/user_api/accounts/views.py
@@ -605,7 +605,7 @@ class AccountRetirementPartnerReportView(ViewSet):
 
     def retirement_partner_cleanup(self, request):
         """
-        DELETE /api/user/v1/accounts/retirement_partner_report/
+        POST /api/user/v1/accounts/retirement_partner_report_cleanup/
 
         [{'original_username': 'user1'}, {'original_username': 'user2'}, ...]
 

--- a/openedx/core/djangoapps/user_api/urls.py
+++ b/openedx/core/djangoapps/user_api/urls.py
@@ -35,8 +35,11 @@ ACCOUNT_DETAIL = AccountViewSet.as_view({
 
 PARTNER_REPORT = AccountRetirementPartnerReportView.as_view({
     'post': 'retirement_partner_report',
-    'put': 'retirement_partner_status_create',
-    'delete': 'retirement_partner_cleanup'
+    'put': 'retirement_partner_status_create'
+})
+
+PARTNER_REPORT_CLEANUP = AccountRetirementPartnerReportView.as_view({
+    'post': 'retirement_partner_cleanup'
 })
 
 RETIREMENT_QUEUE = AccountRetirementStatusView.as_view({
@@ -113,6 +116,11 @@ urlpatterns = [
         r'^v1/accounts/retirement_partner_report/$',
         PARTNER_REPORT,
         name='accounts_retirement_partner_report'
+    ),
+    url(
+        r'^v1/accounts/retirement_partner_report_cleanup/$',
+        PARTNER_REPORT_CLEANUP,
+        name='accounts_retirement_partner_report_cleanup'
     ),
     url(
         r'^v1/accounts/retirement_queue/$',


### PR DESCRIPTION
In tubular in edx_api.py, the edx-rest-api-client is used which is built on slumber. Unfortunately, the current slumber implementation of DELETE is not fully baked. The method does not allow a caller to pass a `data` parameter down into the requests module:

https://github.com/samgiles/slumber/blob/master/slumber/__init__.py#L176

I've changed the reporting cleanup endpoint to be a different URL and use a POST method, which works much better. Accompanying tubular changes will be merged after this PR merges - they are here: https://github.com/edx/tubular/pull/256