### PR TITLE
Gate access to the CourseEnrollmentAdmin view with a waffle switch

### DIFF
--- a/common/djangoapps/student/__init__.py
+++ b/common/djangoapps/student/__init__.py
@@ -1,0 +1,8 @@
+"""
+Student app helpers and settings
+"""
+from openedx.core.djangoapps.waffle_utils import WaffleSwitchNamespace
+
+
+# Namespace for student app waffle switches
+STUDENT_WAFFLE_NAMESPACE = WaffleSwitchNamespace(name='student')

--- a/common/djangoapps/student/tests/test_admin_views.py
+++ b/common/djangoapps/student/tests/test_admin_views.py
@@ -1,6 +1,8 @@
 """
 Tests student admin.py
 """
+import ddt
+from waffle.testutils import override_switch
 from django.contrib.admin.sites import AdminSite
 from django.contrib.auth.models import User
 from django.urls import reverse
@@ -8,7 +10,7 @@ from django.test import TestCase
 from mock import Mock
 
 from student.admin import UserAdmin
-from student.tests.factories import UserFactory
+from student.tests.factories import CourseEnrollmentFactory, UserFactory
 from xmodule.modulestore.tests.django_utils import SharedModuleStoreTestCase
 from xmodule.modulestore.tests.factories import CourseFactory
 
@@ -186,3 +188,49 @@ class AdminUserPageTest(TestCase):
         request = Mock()
         user = Mock()
         self.assertIn('username', self.admin.get_readonly_fields(request, user))
+
+
+@ddt.ddt
+class CourseEnrollmentAdminTest(SharedModuleStoreTestCase):
+    """
+    Unit tests for the CourseEnrollmentAdmin view.
+    """
+    ADMIN_URLS = (
+        ('get', reverse('admin:student_courseenrollment_add')),
+        ('get', reverse('admin:student_courseenrollment_changelist')),
+        ('get', reverse('admin:student_courseenrollment_change', args=(1,))),
+        ('get', reverse('admin:student_courseenrollment_delete', args=(1,))),
+        ('post', reverse('admin:student_courseenrollment_add')),
+        ('post', reverse('admin:student_courseenrollment_changelist')),
+        ('post', reverse('admin:student_courseenrollment_change', args=(1,))),
+        ('post', reverse('admin:student_courseenrollment_delete', args=(1,))),
+    )
+
+    def setUp(self):
+        super(CourseEnrollmentAdminTest, self).setUp()
+        self.user = UserFactory.create(is_staff=True, is_superuser=True)
+        self.client.login(username=self.user.username, password='test')
+        CourseEnrollmentFactory(
+            user=self.user,
+            course_id=CourseFactory().id,  # pylint: disable=no-member
+        )
+
+    @ddt.data(*ADMIN_URLS)
+    @ddt.unpack
+    def test_view_disabled(self, method, url):
+        """
+        All CourseEnrollmentAdmin views are disabled by default.
+        """
+        response = getattr(self.client, method)(url)
+        self.assertEqual(response.status_code, 403)
+
+    @override_switch('student.coursenrollment.admin', active=True)
+    @ddt.data(*ADMIN_URLS)
+    @ddt.unpack
+    def test_view_enabled(self, method, url):
+        """
+        Ensure CourseEnrollmentAdmin views can be enabled with the waffle flag.
+        """
+        self.client.login(username=self.user.username, password='test')
+        response = getattr(self.client, method)(url)
+        self.assertEqual(response.status_code, 200)

--- a/common/djangoapps/student/tests/test_admin_views.py
+++ b/common/djangoapps/student/tests/test_admin_views.py
@@ -2,14 +2,13 @@
 Tests student admin.py
 """
 import ddt
-from waffle.testutils import override_switch
 from django.contrib.admin.sites import AdminSite
 from django.contrib.auth.models import User
 from django.urls import reverse
 from django.test import TestCase
 from mock import Mock
 
-from student.admin import UserAdmin
+from student.admin import COURSE_ENROLLMENT_ADMIN_SWITCH, UserAdmin
 from student.tests.factories import CourseEnrollmentFactory, UserFactory
 from xmodule.modulestore.tests.django_utils import SharedModuleStoreTestCase
 from xmodule.modulestore.tests.factories import CourseFactory
@@ -224,13 +223,12 @@ class CourseEnrollmentAdminTest(SharedModuleStoreTestCase):
         response = getattr(self.client, method)(url)
         self.assertEqual(response.status_code, 403)
 
-    @override_switch('student.coursenrollment.admin', active=True)
     @ddt.data(*ADMIN_URLS)
     @ddt.unpack
     def test_view_enabled(self, method, url):
         """
-        Ensure CourseEnrollmentAdmin views can be enabled with the waffle flag.
+        Ensure CourseEnrollmentAdmin views can be enabled with the waffle switch.
         """
-        self.client.login(username=self.user.username, password='test')
-        response = getattr(self.client, method)(url)
+        with COURSE_ENROLLMENT_ADMIN_SWITCH.override(active=True):
+            response = getattr(self.client, method)(url)
         self.assertEqual(response.status_code, 200)


### PR DESCRIPTION
This change reinstates the CourseEnrollmentAdmin views when the waffle switch `student.courseenrollment_admin` is present and active.

This view was disabled for performance reasons by https://github.com/edx/edx-platform/pull/17775

**JIRA tickets**: [OSPR-2531](https://openedx.atlassian.net/browse/OSPR-2531)

**Discussions**: https://github.com/edx/edx-platform/pull/17477#issuecomment-393992363

**Dependencies**: None

**Sandbox URL**: (provisioning)

* LMS: https://pr18638.sandbox.opencraft.hosting/
* Studio: https://studio-pr18638.sandbox.opencraft.hosting/

**Merge deadline**: ASAP -- aiming to get into Hawthorn CC @nedbat 

**Testing instructions**:

1. Login to the Django Admin using a superuser (on the sandbox, use `staff` / `edx`).
1. Note that the [Student administration module](https://pr18638.sandbox.opencraft.hosting/admin/student/) does not show a link to the Course enrollments list.
1. Note that visiting these URLs results in a 403:
   * [Course enrollment list](https://pr18638.sandbox.opencraft.hosting/admin/student/courseenrollment/)
   * [Course enrollment add](https://pr18638.sandbox.opencraft.hosting/admin/student/courseenrollment/add/)
   * [Course enrollment change](https://pr18638.sandbox.opencraft.hosting/admin/student/courseenrollment/1/change/)
   * [Course enrollment delete](https://pr18638.sandbox.opencraft.hosting/admin/student/courseenrollment/1/delete/)
1. Add and activate a [waffle switch](https://pr18638.sandbox.opencraft.hosting/admin/waffle/switch/), named `student.courseenrollment_admin`.
1. Re-visit the above course enrollment links, and see that they are now accessible.
1. De-activate the added [waffle switch](https://pr18638.sandbox.opencraft.hosting/admin/waffle/switch/), named `student.courseenrollment_admin`, and ensure that access to the course enrollment views is denied again.

**Reviewers**
- [ ] OpenCraft TBD
- [ ] edX reviewer[s] TBD -- CC @robrap @jdmulloy 