### PR TITLE
Security Patch to for Ginkgo on Recommender XBlock

### DIFF
--- a/requirements/edx/github.txt
+++ b/requirements/edx/github.txt
@@ -78,7 +78,7 @@ git+https://github.com/edx/edx-ora2.git@1.4.6#egg=ora2==1.4.6
 -e git+https://github.com/edx/edx-submissions.git@2.0.0#egg=edx-submissions==2.0.0
 git+https://github.com/edx/ease.git@release-2015-07-14#egg=ease==0.1.3
 git+https://github.com/edx/edx-val.git@0.0.13#egg=edxval==0.0.13
-git+https://github.com/edx/RecommenderXBlock.git@0e744b393cf1f8b886fe77bc697e7d9d78d65cd6#egg=recommender-xblock==1.2
+git+https://github.com/edx/RecommenderXBlock.git@2c5e36fbf6f7577a517115df60bdb0cf7e2e17ed#egg=recommender-xblock==1.3.1
 git+https://github.com/solashirai/crowdsourcehinter.git@518605f0a95190949fe77bd39158450639e2e1dc#egg=crowdsourcehinter-xblock==0.1
 -e git+https://github.com/edx/RateXBlock.git@367e19c0f6eac8a5f002fd0f1559555f8e74bfff#egg=rate-xblock
 -e git+https://github.com/edx/DoneXBlock.git@01a14f3bd80ae47dd08cdbbe2f88f3eb88d00fba#egg=done-xblock


### PR DESCRIPTION
Upgrade the version of Recommender XBlock so it closes an XSS security hole.