### PR TITLE
Import factories/base.js when using webpack to fix nav

### DIFF
--- a/cms/static/js/factories/library.js
+++ b/cms/static/js/factories/library.js
@@ -5,6 +5,7 @@ import * as PagedContainerPage from 'js/views/pages/paged_container';
 import * as LibraryContainerView from 'js/views/library_container';
 import * as ComponentTemplates from 'js/collections/component_template';
 import * as xmoduleLoader from 'xmodule';
+import './base';
 import 'cms/js/main';
 import 'xblock/cms.runtime.v1';
 

--- a/cms/static/js/factories/textbooks.js
+++ b/cms/static/js/factories/textbooks.js
@@ -2,6 +2,7 @@ import * as gettext from 'gettext';
 import * as Section from 'js/models/section';
 import * as TextbookCollection from 'js/collections/textbook';
 import * as ListTextbooksView from 'js/views/list_textbooks';
+import './base';
 
 'use strict';
 export default function TextbooksFactory(textbooksJson) {


### PR DESCRIPTION
factories/base.js is the library responsible for enabling the Studio nav
menu. When using webpack, we need to be sure to import it specifically,
because the webpack imports override the React code that pulls it in
on most pages.

[EDUCATOR-3150]