### PR TITLE
Switch Jenkinsfile to use pytest-xdist

### DIFF
--- a/pavelib/paver_tests/test_paver_pytest_cmds.py
+++ b/pavelib/paver_tests/test_paver_pytest_cmds.py
@@ -1,0 +1,163 @@
+"""
+Tests for the pytest paver commands themselves.
+Run just this test with: paver test_lib -t pavelib/paver_tests/test_paver_pytest_cmds.py
+"""
+import unittest
+import os
+import ddt
+
+from pavelib.utils.test.suites import SystemTestSuite, LibTestSuite
+from pavelib.utils.envs import Env
+
+
+XDIST_TESTING_IP_ADDRESS_LIST = '0.0.0.1,0.0.0.2,0.0.0.3'
+
+
+@ddt.ddt
+class TestPaverPytestCmd(unittest.TestCase):
+    """
+    Test Paver pytest commands
+    """
+
+    def _expected_command(self, root, test_id, pytestSubclass, run_under_coverage=True,
+                          processes=0, xdist_ip_addresses=None):
+        """
+        Returns the command that is expected to be run for the given test spec
+        and store.
+        """
+        report_dir = Env.REPORT_DIR / root
+        shard = os.environ.get('SHARD')
+        if shard:
+            report_dir = report_dir / 'shard_' + shard
+
+        expected_statement = [
+            "python",
+            "-Wd",
+            "-m",
+            "pytest"
+        ]
+        if pytestSubclass == "SystemTestSuite":
+            expected_statement.append("--ds={}".format('{}.envs.{}'.format(root, Env.TEST_SETTINGS)))
+        expected_statement.append("--junitxml={}".format(report_dir / "nosetests.xml"))
+
+        if xdist_ip_addresses:
+            expected_statement.append('--dist=loadscope')
+            for ip in xdist_ip_addresses.split(','):
+                if processes <= 0:
+                    processes = 1
+
+                if pytestSubclass == "SystemTestSuite":
+                    django_env_var_cmd = "export DJANGO_SETTINGS_MODULE={}.envs.test".format(root)
+                elif pytestSubclass == "LibTestSuite":
+                    if 'pavelib/paver_tests' in test_id:
+                        django_env_var_cmd = "export DJANGO_SETTINGS_MODULE={}.envs.test".format(root)
+                    else:
+                        django_env_var_cmd = "export DJANGO_SETTINGS_MODULE='openedx.tests.settings'"
+
+                xdist_string = '--tx {}*ssh="ubuntu@{} -o StrictHostKeyChecking=no"' \
+                               '//python="source /edx/app/edxapp/edxapp_env; {}; python"' \
+                               '//chdir="/edx/app/edxapp/edx-platform"' \
+                               .format(processes, ip, django_env_var_cmd)
+                expected_statement.append(xdist_string)
+            for rsync_dir in Env.rsync_dirs():
+                expected_statement.append('--rsyncdir {}'.format(rsync_dir))
+        else:
+            if processes == -1:
+                expected_statement.append('-n auto')
+                expected_statement.append('--dist=loadscope')
+            elif processes != 0:
+                expected_statement.append('-n {}'.format(processes))
+                expected_statement.append('--dist=loadscope')
+
+        expected_statement.extend([
+            "-p no:randomly",
+            test_id
+        ])
+
+        if run_under_coverage:
+            if xdist_ip_addresses:
+                for module in Env.covered_modules():
+                    expected_statement.append('--cov')
+                    expected_statement.append(module)
+            else:
+                expected_statement.append('--cov')
+            expected_statement.append('--cov-report=')
+        return expected_statement
+
+    @ddt.data('lms', 'cms')
+    def test_SystemTestSuite_suites(self, system):
+        test_id = 'tests'
+        suite = SystemTestSuite(system, test_id=test_id)
+        assert suite.cmd == self._expected_command(system, test_id, "SystemTestSuite")
+
+    @ddt.data('lms', 'cms')
+    def test_SystemTestSuite_auto_processes(self, system):
+        test_id = 'tests'
+        suite = SystemTestSuite(system, test_id=test_id, processes=-1)
+        assert suite.cmd == self._expected_command(system, test_id, "SystemTestSuite", processes=-1)
+
+    @ddt.data('lms', 'cms')
+    def test_SystemTestSuite_multi_processes(self, system):
+        test_id = 'tests'
+        suite = SystemTestSuite(system, test_id=test_id, processes=3)
+        assert suite.cmd == self._expected_command(system, test_id, "SystemTestSuite", processes=3)
+
+    @ddt.data('lms', 'cms')
+    def test_SystemTestSuite_with_xdist(self, system):
+        test_id = 'tests'
+        suite = SystemTestSuite(system, test_id=test_id, xdist_ip_addresses=XDIST_TESTING_IP_ADDRESS_LIST)
+        assert suite.cmd == self._expected_command(system, test_id, "SystemTestSuite",
+                                                   xdist_ip_addresses=XDIST_TESTING_IP_ADDRESS_LIST)
+
+    @ddt.data('lms', 'cms')
+    def test_SystemTestSuite_with_xdist_multi_processes(self, system):
+        test_id = 'tests'
+        suite = SystemTestSuite(system, test_id=test_id, processes=2, xdist_ip_addresses=XDIST_TESTING_IP_ADDRESS_LIST)
+        assert suite.cmd == self._expected_command(system, test_id, "SystemTestSuite", processes=2,
+                                                   xdist_ip_addresses=XDIST_TESTING_IP_ADDRESS_LIST)
+
+    @ddt.data('lms', 'cms')
+    def test_SystemTestSuite_with_xdist_negative_processes(self, system):
+        test_id = 'tests'
+        suite = SystemTestSuite(system, test_id=test_id, processes=-1, xdist_ip_addresses=XDIST_TESTING_IP_ADDRESS_LIST)
+        assert suite.cmd == self._expected_command(system, test_id, "SystemTestSuite", processes=-1,
+                                                   xdist_ip_addresses=XDIST_TESTING_IP_ADDRESS_LIST)
+
+    @ddt.data('common/lib/xmodule', 'pavelib/paver_tests')
+    def test_LibTestSuite_suites(self, system):
+        test_id = 'tests'
+        suite = LibTestSuite(system, test_id=test_id)
+        assert suite.cmd == self._expected_command(system, test_id, "LibTestSuite")
+
+    @ddt.data('common/lib/xmodule', 'pavelib/paver_tests')
+    def test_LibTestSuite_auto_processes(self, system):
+        test_id = 'tests'
+        suite = LibTestSuite(system, test_id=test_id, processes=-1)
+        assert suite.cmd == self._expected_command(system, test_id, "LibTestSuite", processes=-1)
+
+    @ddt.data('common/lib/xmodule', 'pavelib/paver_tests')
+    def test_LibTestSuite_multi_processes(self, system):
+        test_id = 'tests'
+        suite = LibTestSuite(system, test_id=test_id, processes=3)
+        assert suite.cmd == self._expected_command(system, test_id, "LibTestSuite", processes=3)
+
+    @ddt.data('common/lib/xmodule', 'pavelib/paver_tests')
+    def test_LibTestSuite_with_xdist(self, system):
+        test_id = 'tests'
+        suite = LibTestSuite(system, test_id=test_id, xdist_ip_addresses=XDIST_TESTING_IP_ADDRESS_LIST)
+        assert suite.cmd == self._expected_command(system, test_id, "LibTestSuite",
+                                                   xdist_ip_addresses=XDIST_TESTING_IP_ADDRESS_LIST)
+
+    @ddt.data('common/lib/xmodule', 'pavelib/paver_tests')
+    def test_LibTestSuite_with_xdist_multi_processes(self, system):
+        test_id = 'tests'
+        suite = LibTestSuite(system, test_id=test_id, processes=2, xdist_ip_addresses=XDIST_TESTING_IP_ADDRESS_LIST)
+        assert suite.cmd == self._expected_command(system, test_id, "LibTestSuite", processes=2,
+                                                   xdist_ip_addresses=XDIST_TESTING_IP_ADDRESS_LIST)
+
+    @ddt.data('common/lib/xmodule', 'pavelib/paver_tests')
+    def test_LibTestSuite_with_xdist_negative_processes(self, system):
+        test_id = 'tests'
+        suite = LibTestSuite(system, test_id=test_id, processes=-1, xdist_ip_addresses=XDIST_TESTING_IP_ADDRESS_LIST)
+        assert suite.cmd == self._expected_command(system, test_id, "LibTestSuite", processes=-1,
+                                                   xdist_ip_addresses=XDIST_TESTING_IP_ADDRESS_LIST)

--- a/pavelib/tests.py
+++ b/pavelib/tests.py
@@ -72,7 +72,7 @@ __test__ = False  # do not collect
     make_option(
         '--xdist_ip_addresses',
         dest='xdist_ip_addresses',
-        help="Space separated string of ip addresses to shard tests to via xdist."
+        help="Comma separated string of ip addresses to shard tests to via xdist."
     )
 ], share_with=['pavelib.utils.test.utils.clean_reports_dir'])
 @PassthroughTask
@@ -160,8 +160,10 @@ def test_system(options, passthrough_options):
     make_option(
         '--xdist_ip_addresses',
         dest='xdist_ip_addresses',
-        help="Space separated string of ip addresses to shard tests to via xdist."
-    )
+        help="Comma separated string of ip addresses to shard tests to via xdist."
+    ),
+    make_option('-p', '--processes', dest='processes', default=0, help='number of processes to use running tests'),
+    make_option('-r', '--randomize', action='store_true', help='run the tests in a random order'),
 ], share_with=['pavelib.utils.test.utils.clean_reports_dir'])
 @PassthroughTask
 @timed

--- a/scripts/xdist/prepare_xdist_nodes.sh
+++ b/scripts/xdist/prepare_xdist_nodes.sh
@@ -1,16 +1,16 @@
 #!/bin/bash
 set -e
 
+echo "Spinning up xdist containers with pytest_container_manager.py"
 python scripts/xdist/pytest_container_manager.py -a up -n ${XDIST_NUM_TASKS} \
 -t ${XDIST_CONTAINER_TASK_NAME} \
 -s ${XDIST_CONTAINER_SUBNET} \
 -sg ${XDIST_CONTAINER_SECURITY_GROUP}
 
 ip_list=$(<pytest_task_ips.txt)
-
-for ip in $ip_list
+for ip in $(echo $ip_list | sed "s/,/ /g")
 do
-    container_reqs_cmd="ssh ubuntu@$ip 'cd /edx/app/edxapp/edx-platform;
+    container_reqs_cmd="ssh -o StrictHostKeyChecking=no ubuntu@$ip 'cd /edx/app/edxapp/edx-platform;
     git pull -q; git checkout -q ${XDIST_GIT_BRANCH};
     source /edx/app/edxapp/edxapp_env; pip install -qr requirements/edx/testing.txt' & "
 

--- a/scripts/xdist/terminate_xdist_nodes.sh
+++ b/scripts/xdist/terminate_xdist_nodes.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+set -e
+
+if [ -f pytest_task_arns.txt ]; then
+    echo "Terminating xdist containers with pytest_container_manager.py"
+    xdist_task_arns=$(<pytest_task_arns.txt)
+    python scripts/xdist/pytest_container_manager.py -a down --task_arns ${xdist_task_arns}
+else
+    echo "File: pytest_task_arns.txt not found"
+fi

--- a/tox.ini
+++ b/tox.ini
@@ -51,6 +51,7 @@ passenv =
     XDIST_CONTAINER_TASK_NAME
     XDIST_GIT_BRANCH
     XDIST_NUM_TASKS
+    XDIST_REMOTE_NUM_PROCESSES
 deps =
     django18: Django>=1.8,<1.9
     django19: Django>=1.9,<1.10


### PR DESCRIPTION
This PR moves our Jenkinsfile from running our standard manually-sharded python unittests, over to pytest-xdist.

* I generally kept how we call the tests the same, so that the config is basically just setting environment variables, and there wasn't a need to repeat a ton of code.

* Switched from expecting a space delimited string to commas for `xdist_ip_addresses`. With spaces, I was having difficulties with bash when adding `xdist_ip_addresses` to `PAVER_ARGS`

* It looks like (potentially due to a bug in pytest-django) the command line argument for django environment does not propagate to remote xdist workers, so I explicitly set the `DJANGO_SETTINGS_MODULE` in the call to the remote machines. Since the `LibTestSuite` runs tests for both `common/lib/` and `pavelib/`, there needs to be a little extra logic there.

* I've seen a lot of `Different tests were collected between gw0 and gw2` errors, mainly for commonlib tests. I believe this is from the `@ddt.data` decorator being populated with unordered data structures: https://github.com/pytest-dev/pytest-xdist/issues/149