### PR TITLE
Revert "Fix PDF cert gereration/regeneration and URLs."

### DIFF
--- a/lms/djangoapps/certificates/api.py
+++ b/lms/djangoapps/certificates/api.py
@@ -154,7 +154,7 @@ def generate_user_certificates(student, course_key, course=None, insecure=False,
     if not course:
         course = modulestore().get_course(course_key, depth=0)
 
-    generate_pdf = not has_any_active_web_certificate(course)
+    generate_pdf = not has_html_certificates_enabled(course)
 
     cert = xqueue.add_cert(
         student,
@@ -206,7 +206,7 @@ def regenerate_user_certificates(student, course_key, course=None,
     if not course:
         course = modulestore().get_course(course_key, depth=0)
 
-    generate_pdf = not has_any_active_web_certificate(course)
+    generate_pdf = not has_html_certificates_enabled(course)
     log.info(
         "Started regenerating certificates for user %s in course %s with generate_pdf status: %s",
         student.username, unicode(course_key), generate_pdf
@@ -448,18 +448,11 @@ def get_certificate_url(user_id=None, course_id=None, uuid=None):
     if not course:
         return url
 
-    if has_html_certificates_enabled(course) and has_any_active_web_certificate(course):
+    if has_html_certificates_enabled(course):
         url = _certificate_html_url(user_id, course_id, uuid)
     else:
         url = _certificate_download_url(user_id, course_id)
     return url
-
-
-def has_any_active_web_certificate(course):
-    if hasattr(course, 'has_any_active_web_certificate'):
-        return course.has_any_active_web_certificate
-
-    return get_active_web_certificate(course)
 
 
 def get_active_web_certificate(course, is_preview_mode=None):

--- a/lms/djangoapps/certificates/tests/test_api.py
+++ b/lms/djangoapps/certificates/tests/test_api.py
@@ -457,21 +457,6 @@ class CertificateGetTests(SharedModuleStoreTestCase):
         """
         Test the get_certificate_url with a web cert course
         """
-        certificates = [
-            {
-                'id': 1,
-                'name': 'Test Certificate Name',
-                'description': 'Test Certificate Description',
-                'course_title': 'tes_course_title',
-                'signatories': [],
-                'version': 1,
-                'is_active': True
-            }
-        ]
-        self.web_cert_course.certificates = {'certificates': certificates}
-        self.web_cert_course.save()
-        self.store.update_item(self.web_cert_course, self.student.id)
-
         expected_url = reverse(
             'certificates:render_cert_by_uuid',
             kwargs=dict(certificate_uuid=self.uuid)
@@ -570,6 +555,7 @@ class GenerateUserCertificatesTest(EventTestMixin, WebCertificateTestMixin, Modu
         will trigger an update to the certificate if the user has since
         verified.
         """
+        self._setup_course_certificate()
         # generate certificate with unverified status.
         GeneratedCertificateFactory.create(
             user=self.student,

--- a/lms/djangoapps/certificates/tests/test_views.py
+++ b/lms/djangoapps/certificates/tests/test_views.py
@@ -295,11 +295,11 @@ class MicrositeCertificatesViewsTests(ModuleStoreTestCase):
 
         config = self._certificate_html_view_configuration(configuration_string=test_configuration_string)
         self.assertEquals(config.configuration, test_configuration_string)
-        self._add_course_certificates(count=1, signatory_count=2)
         test_url = get_certificate_url(
             user_id=self.user.id,
             course_id=unicode(self.course.id)
         )
+        self._add_course_certificates(count=1, signatory_count=2)
         response = self.client.get(test_url, HTTP_HOST=settings.MICROSITE_TEST_HOSTNAME)
         self.assertIn('platform_microsite', response.content)
 
@@ -329,11 +329,11 @@ class MicrositeCertificatesViewsTests(ModuleStoreTestCase):
         }"""
         config = self._certificate_html_view_configuration(configuration_string=test_configuration_string)
         self.assertEquals(config.configuration, test_configuration_string)
-        self._add_course_certificates(count=1, signatory_count=2)
         test_url = get_certificate_url(
             user_id=self.user.id,
             course_id=unicode(self.course.id)
         )
+        self._add_course_certificates(count=1, signatory_count=2)
         response = self.client.get(test_url, HTTP_HOST=settings.MICROSITE_TEST_HOSTNAME)
         self.assertIn('edX', response.content)
         self.assertNotIn('platform_microsite', response.content)

--- a/lms/djangoapps/certificates/tests/test_webview_views.py
+++ b/lms/djangoapps/certificates/tests/test_webview_views.py
@@ -984,6 +984,19 @@ class CertificatesViewsTests(CommonCertificatesTestCase):
         self.assertIn(date, response.content)
 
     @override_settings(FEATURES=FEATURES_WITH_CERTS_ENABLED)
+    def test_render_html_view_invalid_certificate_configuration(self):
+        self.course.cert_html_view_enabled = True
+        self.course.save()
+        self.store.update_item(self.course, self.user.id)
+
+        test_url = get_certificate_url(
+            user_id=self.user.id,
+            course_id=unicode(self.course.id)
+        )
+        response = self.client.get(test_url)
+        self.assertIn("Invalid Certificate", response.content)
+
+    @override_settings(FEATURES=FEATURES_WITH_CERTS_ENABLED)
     def test_render_500_view_invalid_certificate_configuration(self):
         self._add_course_certificates(count=1, signatory_count=2)
         CertificateHtmlViewConfiguration.objects.all().update(enabled=False)

--- a/lms/djangoapps/courseware/tests/test_views.py
+++ b/lms/djangoapps/courseware/tests/test_views.py
@@ -1337,7 +1337,7 @@ class ProgressPageTests(ProgressPageBaseTests):
             user=self.user,
             course_id=self.course.id,
             status=CertificateStatuses.downloadable,
-            download_url="",
+            download_url="http://www.example.com/certificate.pdf",
             mode='verified'
         )
 

--- a/lms/djangoapps/courseware/views/views.py
+++ b/lms/djangoapps/courseware/views/views.py
@@ -1016,7 +1016,7 @@ def _downloadable_certificate_message(course, cert_downloadable_status):
                     course_id=course.id, uuid=cert_downloadable_status['uuid']
                 )
             )
-        elif not cert_downloadable_status['download_url']:
+        else:
             return GENERATING_CERT_DATA
 
     return _downloadable_cert_data(download_url=cert_downloadable_status['download_url'])

--- a/lms/djangoapps/mobile_api/users/tests.py
+++ b/lms/djangoapps/mobile_api/users/tests.py
@@ -296,18 +296,6 @@ class TestUserEnrollmentCertificates(UrlResetMixin, MobileAPITestCase, Milestone
             mode_slug=CourseMode.HONOR,
         )
         self.login_and_enroll()
-        certificates = [
-            {
-                'id': 1,
-                'name': 'Test Certificate Name',
-                'description': 'Test Certificate Description',
-                'course_title': 'tes_course_title',
-                'signatories': [],
-                'version': 1,
-                'is_active': True
-            }
-        ]
-        self.course.certificates = {'certificates': certificates}
         self.course.cert_html_view_enabled = True
         self.store.update_item(self.course, self.user.id)
 

--- a/openedx/core/djangoapps/programs/tests/test_utils.py
+++ b/openedx/core/djangoapps/programs/tests/test_utils.py
@@ -1006,20 +1006,6 @@ class TestProgramDataExtender(ModuleStoreTestCase):
         Verify that the student's run mode certificate is included,
         when available.
         """
-        certificates = [
-            {
-                'id': 1,
-                'name': 'Test Certificate Name',
-                'description': 'Test Certificate Description',
-                'course_title': 'tes_course_title',
-                'signatories': [],
-                'version': 1,
-                'is_active': True
-            }
-        ]
-        self.course.certificates = {'certificates': certificates}
-        self.course = self.update_course(self.course, self.user.id)
-
         test_uuid = uuid.uuid4().hex
         mock_get_cert_data.return_value = {'uuid': test_uuid} if is_uuid_available else {}
         mock_html_certs_enabled.return_value = True


### PR DESCRIPTION
Reverts edx/edx-platform#18285

We no longer generate PDF certificates, so no need for this fix.
See LEARNER-5945 for more details.