### PR TITLE
EDUCATOR-2120 allow Community TA to see all discussion posts regardless of cohort and enrollment track

### DIFF
--- a/lms/djangoapps/discussion/views.py
+++ b/lms/djangoapps/discussion/views.py
@@ -149,7 +149,6 @@ def get_threads(request, course, user_info, discussion_id=None, per_page=THREADS
             )
         )
     )
-
     paginated_results = cc.Thread.search(query_params)
     threads = paginated_results.collection
 
@@ -248,6 +247,7 @@ def forum_form_discussion(request, course_key):
     Renders the main Discussion page, potentially filtered by a search query
     """
     course = get_course_with_access(request.user, 'load', course_key, check_if_enrolled=True)
+    request.user.is_community_ta = utils.is_user_community_ta(request.user, course.id)
     if request.is_ajax():
         user = cc.User.from_django_user(request.user)
         user_info = user.to_dict()
@@ -292,7 +292,7 @@ def single_thread(request, course_key, discussion_id, thread_id):
     Depending on the HTTP headers, we'll adjust our response accordingly.
     """
     course = get_course_with_access(request.user, 'load', course_key, check_if_enrolled=True)
-
+    request.user.is_community_ta = utils.is_user_community_ta(request.user, course.id)
     if request.is_ajax():
         cc_user = cc.User.from_django_user(request.user)
         user_info = cc_user.to_dict()
@@ -350,7 +350,6 @@ def _find_thread(request, course, discussion_id, thread_id):
         )
     except cc.utils.CommentClientRequestError:
         return None
-
     # Verify that the student has access to this thread if belongs to a course discussion module
     thread_context = getattr(thread, "context", "course")
     if thread_context == "course" and not utils.discussion_category_id_access(course, request.user, discussion_id):

--- a/lms/djangoapps/instructor_task/tests/test_tasks_helper.py
+++ b/lms/djangoapps/instructor_task/tests/test_tasks_helper.py
@@ -1191,7 +1191,7 @@ class TestProblemReportCohortedContent(TestReportMixin, ContentGroupTestCase, In
         with patch('lms.djangoapps.instructor_task.tasks_helper.runner._get_current_task'):
             result = ProblemGradeReport.generate(None, None, self.course.id, None, 'graded')
             self.assertDictContainsSubset(
-                {'action_name': 'graded', 'attempted': 4, 'succeeded': 4, 'failed': 0}, result
+                {'action_name': 'graded', 'attempted': 5, 'succeeded': 5, 'failed': 0}, result
             )
         problem_names = [u'Homework 1: Subsection - Problem0', u'Homework 1: Subsection - Problem1']
         header_row = [u'Student ID', u'Email', u'Username', u'Enrollment Status', u'Grade']
@@ -1218,6 +1218,11 @@ class TestProblemReportCohortedContent(TestReportMixin, ContentGroupTestCase, In
                 'user': self.non_cohorted_user,
                 'enrollment_status': ENROLLED_IN_COURSE,
                 'grade': [u'0.0', u'Not Available', u'Not Available', u'Not Available', u'Not Available'],
+            },
+            {
+                'user': self.community_ta,
+                'enrollment_status': ENROLLED_IN_COURSE,
+                'grade': [u'0.0', u'Not Attempted', u'2.0', u'Not Available', u'Not Available'],
             },
         ]
 

--- a/openedx/core/djangoapps/util/testing.py
+++ b/openedx/core/djangoapps/util/testing.py
@@ -3,6 +3,8 @@
 from datetime import datetime
 from pytz import UTC
 
+from django_comment_common.models import Role
+from django_comment_common.utils import seed_permissions_roles
 from openedx.core.djangoapps.course_groups.models import CourseUserGroupPartitionGroup
 from openedx.core.djangoapps.course_groups.tests.helpers import CohortFactory
 from openedx.core.djangoapps.user_api.tests.factories import UserCourseTagFactory
@@ -50,17 +52,27 @@ class ContentGroupTestCase(ModuleStoreTestCase):
             discussion_topics={}
         )
 
+        seed_permissions_roles(self.course.id)
+
         self.staff_user = UserFactory.create(is_staff=True)
         self.alpha_user = UserFactory.create()
         self.beta_user = UserFactory.create()
         self.non_cohorted_user = UserFactory.create()
-        for user in [self.staff_user, self.alpha_user, self.beta_user, self.non_cohorted_user]:
+        self.community_ta = UserFactory.create(username="community_ta")
+        self.community_ta.roles.add(Role.objects.get(name="Community TA", course_id=self.course.id))
+        for user in [
+            self.staff_user,
+            self.alpha_user,
+            self.beta_user,
+            self.non_cohorted_user,
+            self.community_ta
+        ]:
             CourseEnrollmentFactory.create(user=user, course_id=self.course.id)
 
         alpha_cohort = CohortFactory(
             course_id=self.course.id,
             name='Cohort Alpha',
-            users=[self.alpha_user]
+            users=[self.alpha_user, self.community_ta]
         )
         beta_cohort = CohortFactory(
             course_id=self.course.id,


### PR DESCRIPTION
# [EDUCATOR-2120](https://openedx.atlassian.net/browse/EDUCATOR-2120)

### Description
In the past, Community TA's can see discussion posts in their assigned cohort or enrollment track. Now they can see all posts regardless of cohort and enrollment track.

### How to Test?

**Sandbox** 

1. Login into sandbox https://edu-2120-community-ta.sandbox.edx.org/ as Honor User.
2. Go to https://edu-2120-community-ta.sandbox.edx.org/courses/course-v1:edx+CS111+T12018/discussion/forum/. Click on `All Discussions`.
3. See `Honor User` (community TA) can see all the posts.

### Testing
- [x] Unit test


### Reviewers
If you've been tagged for review, please check your corresponding box once you've given the :+1:.
- [x] Code review: @awaisdar001 
- [x] Code review: @noraiz-anwar  

### Post-review
- [x] Rebase and squash commits