### PR TITLE
TE-2665 Install xblock-utils from PyPI

### DIFF
--- a/requirements/edx-sandbox/base.txt
+++ b/requirements/edx-sandbox/base.txt
@@ -17,6 +17,7 @@ futures==3.2.0            # via tornado
 idna==2.7
 ipaddress==1.0.22
 lxml==3.8.0
+markupsafe==1.0
 matplotlib==1.3.1
 networkx==1.7
 nltk==3.3.0

--- a/requirements/edx-sandbox/shared.txt
+++ b/requirements/edx-sandbox/shared.txt
@@ -15,6 +15,7 @@ enum34==1.1.6             # via cryptography
 idna==2.7                 # via cryptography
 ipaddress==1.0.22         # via cryptography
 lxml==3.8.0
+markupsafe==1.0
 networkx==1.7
 nltk==3.3.0
 numpy==1.6.2

--- a/requirements/edx/base.in
+++ b/requirements/edx/base.in
@@ -146,4 +146,5 @@ user-util                           # Functionality for retiring users (GDPR com
 web-fragments                       # Provides the ability to render fragments of web pages
 XBlock                              # Courseware component architecture
 xblock-review                       # XBlock which displays problems from earlier in the course for ungraded retries
+xblock-utils                        # Provides utilities used by the Discussion XBlock
 zendesk                             # Python API for the Zendesk customer support system

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -38,7 +38,6 @@ git+https://github.com/edx/RecommenderXBlock.git@1.3.1#egg=recommender-xblock==1
 git+https://github.com/edx-solutions/xblock-drag-and-drop-v2@v2.1.6#egg=xblock-drag-and-drop-v2==2.1.6
 -e git+https://github.com/edx-solutions/xblock-google-drive.git@138e6fa0bf3a2013e904a085b9fed77dab7f3f21#egg=xblock-google-drive
 git+https://github.com/open-craft/xblock-poll@add89e14558c30f3c8dc7431e5cd6536fff6d941#egg=xblock-poll==1.5.1
-git+https://github.com/edx/xblock-utils.git@v1.1.1#egg=xblock-utils==1.1.1
 -e common/lib/xmodule
 amqp==1.4.9               # via kombu
 analytics-python==1.1.0
@@ -168,7 +167,7 @@ mock==1.0.1
 mongoengine==0.10.0
 mysql-python==1.2.5
 networkx==1.7
-newrelic==3.4.0.95
+newrelic==4.0.0.99
 nltk==3.3.0
 nodeenv==1.1.1
 numpy==1.6.2
@@ -178,7 +177,7 @@ openapi-codec==1.3.2      # via django-rest-swagger
 path.py==8.2.1
 pathtools==0.1.2
 paver==1.3.4
-pbr==4.1.1
+pbr==4.2.0
 pdfminer==20140328
 piexif==1.0.2
 pillow==3.4.0
@@ -202,7 +201,7 @@ python-levenshtein==0.12.0
 python-memcached==1.48
 python-openid==2.2.5
 python-saml==2.4.0
-python-swiftclient==3.5.0
+python-swiftclient==3.6.0
 pytz==2016.10
 pyuca==1.1
 pyyaml==3.13
@@ -239,5 +238,6 @@ web-fragments==0.2.2
 webob==1.8.2              # via xblock
 wrapt==1.10.5
 xblock-review==1.1.5
+xblock-utils==1.2.0
 xblock==1.2.1
 zendesk==1.1.1

--- a/requirements/edx/coverage.txt
+++ b/requirements/edx/coverage.txt
@@ -6,7 +6,7 @@
 #
 coverage==4.2
 diff-cover==0.9.8
-inflect==0.3.1            # via jinja2-pluralize
+inflect==1.0.0            # via jinja2-pluralize
 jinja2-pluralize==0.3.0   # via diff-cover
 jinja2==2.10              # via diff-cover, jinja2-pluralize
 markupsafe==1.0           # via jinja2

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -41,7 +41,6 @@ git+https://github.com/edx/RecommenderXBlock.git@1.3.1#egg=recommender-xblock==1
 git+https://github.com/edx-solutions/xblock-drag-and-drop-v2@v2.1.6#egg=xblock-drag-and-drop-v2==2.1.6
 -e git+https://github.com/edx-solutions/xblock-google-drive.git@138e6fa0bf3a2013e904a085b9fed77dab7f3f21#egg=xblock-google-drive
 git+https://github.com/open-craft/xblock-poll@add89e14558c30f3c8dc7431e5cd6536fff6d941#egg=xblock-poll==1.5.1
-git+https://github.com/edx/xblock-utils.git@v1.1.1#egg=xblock-utils==1.1.1
 -e common/lib/xmodule
 alabaster==0.7.11         # via sphinx
 amqp==1.4.9
@@ -183,7 +182,7 @@ httpretty==0.9.5
 idna==2.7
 imagesize==1.0.0          # via sphinx
 incremental==17.5.0
-inflect==0.3.1
+inflect==1.0.0
 ipaddr==2.1.11
 ipaddress==1.0.22
 isodate==0.6.0
@@ -218,7 +217,7 @@ moto==0.3.1
 mysql-python==1.2.5
 needle==0.5.0
 networkx==1.7
-newrelic==3.4.0.95
+newrelic==4.0.0.99
 nltk==3.3.0
 nodeenv==1.1.1
 nose==1.3.7
@@ -232,7 +231,7 @@ parsel==1.5.0
 path.py==8.2.1
 pathtools==0.1.2
 paver==1.3.4
-pbr==4.1.1
+pbr==4.2.0
 pdfminer==20140328
 piexif==1.0.2
 pillow==3.4.0
@@ -243,7 +242,7 @@ psutil==1.2.1
 py2neo==3.1.2
 py==1.5.4
 pyasn1-modules==0.2.2
-pyasn1==0.4.3
+pyasn1==0.4.4
 pycodestyle==2.3.1
 pycontracts==1.7.1
 pycountry==1.20
@@ -272,7 +271,7 @@ pytest-cov==2.5.1
 pytest-django==3.1.2
 pytest-forked==0.2
 pytest-randomly==1.2.3
-pytest-xdist==1.22.2
+pytest-xdist==1.22.4
 pytest==3.6.3
 python-dateutil==2.4.0
 python-levenshtein==0.12.0
@@ -282,7 +281,7 @@ python-openid==2.2.5
 python-saml==2.4.0
 python-slugify==1.2.5
 python-subunit==1.3.0
-python-swiftclient==3.5.0
+python-swiftclient==3.6.0
 pytz==2016.10
 pyuca==1.1
 pyyaml==3.13
@@ -348,6 +347,7 @@ webob==1.8.2
 werkzeug==0.14.1
 wrapt==1.10.5
 xblock-review==1.1.5
+xblock-utils==1.2.0
 xblock==1.2.1
 xmltodict==0.11.0
 zendesk==1.1.1

--- a/requirements/edx/github.in
+++ b/requirements/edx/github.in
@@ -94,7 +94,6 @@
 -e git+https://github.com/solashirai/crowdsourcehinter.git@518605f0a95190949fe77bd39158450639e2e1dc#egg=crowdsourcehinter-xblock==0.1
 -e git+https://github.com/edx/RateXBlock.git@367e19c0f6eac8a5f002fd0f1559555f8e74bfff#egg=rate-xblock
 -e git+https://github.com/edx/DoneXBlock.git@01a14f3bd80ae47dd08cdbbe2f88f3eb88d00fba#egg=done-xblock
--e git+https://github.com/edx/xblock-utils.git@v1.1.1#egg=xblock-utils==1.1.1
 -e git+https://github.com/edx-solutions/xblock-google-drive.git@138e6fa0bf3a2013e904a085b9fed77dab7f3f21#egg=xblock-google-drive
 -e git+https://github.com/edx/xblock-lti-consumer.git@v1.1.8#egg=lti_consumer-xblock==1.1.8
 

--- a/requirements/edx/paver.txt
+++ b/requirements/edx/paver.txt
@@ -14,7 +14,7 @@ mock==1.0.1
 path.py==8.2.1
 pathtools==0.1.2          # via watchdog
 paver==1.3.4
-pbr==4.1.1                # via stevedore
+pbr==4.2.0                # via stevedore
 psutil==1.2.1
 pymongo==2.9.1
 python-memcached==1.48

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -39,7 +39,6 @@ git+https://github.com/edx/RecommenderXBlock.git@1.3.1#egg=recommender-xblock==1
 git+https://github.com/edx-solutions/xblock-drag-and-drop-v2@v2.1.6#egg=xblock-drag-and-drop-v2==2.1.6
 -e git+https://github.com/edx-solutions/xblock-google-drive.git@138e6fa0bf3a2013e904a085b9fed77dab7f3f21#egg=xblock-google-drive
 git+https://github.com/open-craft/xblock-poll@add89e14558c30f3c8dc7431e5cd6536fff6d941#egg=xblock-poll==1.5.1
-git+https://github.com/edx/xblock-utils.git@v1.1.1#egg=xblock-utils==1.1.1
 -e common/lib/xmodule
 amqp==1.4.9
 analytics-python==1.1.0
@@ -175,7 +174,7 @@ httplib2==0.11.3
 httpretty==0.9.5
 idna==2.7
 incremental==17.5.0       # via twisted
-inflect==0.3.1
+inflect==1.0.0
 ipaddr==2.1.11
 ipaddress==1.0.22
 isodate==0.6.0
@@ -209,7 +208,7 @@ moto==0.3.1
 mysql-python==1.2.5
 needle==0.5.0             # via bok-choy
 networkx==1.7
-newrelic==3.4.0.95
+newrelic==4.0.0.99
 nltk==3.3.0
 nodeenv==1.1.1
 nose==1.3.7
@@ -223,7 +222,7 @@ parsel==1.5.0             # via scrapy
 path.py==8.2.1
 pathtools==0.1.2
 paver==1.3.4
-pbr==4.1.1
+pbr==4.2.0
 pdfminer==20140328
 piexif==1.0.2
 pillow==3.4.0
@@ -233,7 +232,7 @@ psutil==1.2.1
 py2neo==3.1.2
 py==1.5.4                 # via pytest, tox
 pyasn1-modules==0.2.2     # via service-identity
-pyasn1==0.4.3             # via pyasn1-modules, service-identity
+pyasn1==0.4.4             # via pyasn1-modules, service-identity
 pycodestyle==2.3.1
 pycontracts==1.7.1
 pycountry==1.20
@@ -261,7 +260,7 @@ pytest-cov==2.5.1
 pytest-django==3.1.2
 pytest-forked==0.2        # via pytest-xdist
 pytest-randomly==1.2.3
-pytest-xdist==1.22.2
+pytest-xdist==1.22.4
 pytest==3.6.3
 python-dateutil==2.4.0
 python-levenshtein==0.12.0
@@ -271,7 +270,7 @@ python-openid==2.2.5
 python-saml==2.4.0
 python-slugify==1.2.5     # via transifex-client
 python-subunit==1.3.0
-python-swiftclient==3.5.0
+python-swiftclient==3.6.0
 pytz==2016.10
 pyuca==1.1
 pyyaml==3.13
@@ -330,6 +329,7 @@ webob==1.8.2
 werkzeug==0.14.1          # via flask
 wrapt==1.10.5
 xblock-review==1.1.5
+xblock-utils==1.2.0
 xblock==1.2.1
 xmltodict==0.11.0         # via moto
 zendesk==1.1.1


### PR DESCRIPTION
Switch xblock-utils from a GitHub installation to pulling from the new PyPI release.  Also upgrades a few other packages which don't have any concerning items in the changelogs.