### PR TITLE
Learn About Verified Certificates button on course outline page needs a focus indicator

### DIFF
--- a/lms/static/sass/features/_course-sock.scss
+++ b/lms/static/sass/features/_course-sock.scss
@@ -27,6 +27,7 @@
     cursor: pointer;
 
     &.active,
+    &:focus,
     &:hover {
       color: theme-color("success");
       background-color: theme-color("inverse");


### PR DESCRIPTION
Learn About Verified Certificates button on course outline page needs a focus indicator

Example: https://courses.edx.org/courses/course-v1:HarvardX+GSD1x+1T2017/course/

Pressing tab key until focus is on the Learn About Verified Certificates button. There is no visible focus indicator. This PR is to fix the issue.