### PR TITLE
i18n-fix

### DIFF
--- a/conf/locale/config.yaml
+++ b/conf/locale/config.yaml
@@ -120,7 +120,17 @@ ignore_dirs:
     - lms/static/js/i18n
     - cms/static/js/i18n
     # Directories with 3rd party apps.
-    - src
+    - src/acid-xblock
+    - src/code-block-timer
+    - src/codejail
+    - src/django-wiki
+    - src/done-xblock
+    - src/edx-jsme
+    - src/parse-rest
+    - src/pygeoip
+    - src/pystache-custom
+    - src/rate-xblock
+    - src/xblock-google-drive
 
 
 # Third-party installed apps that we also extract strings from.  When adding a


### PR DESCRIPTION
src ignore sub directries with same name. So includes 3rd party apps folders to make sure does not ignore some folder we want to add. 