### PR TITLE
Fix contrast of button on contact us page

### DIFF
--- a/lms/static/sass/views/_support.scss
+++ b/lms/static/sass/views/_support.scss
@@ -216,12 +216,6 @@
     border: 1px solid $blue;
     border-radius: 3px;
     color: $blue;
-
-    &:hover,
-    &:focus {
-      color: $blue;
-      background-color: $mediumGrey !important;
-    }
   }
 
   .label-course {


### PR DESCRIPTION
[LEARNER-5867](https://openedx.atlassian.net/browse/LEARNER-5867)

**Description:**

"The grey background reduces contrast below 4.5. We don't add the background-changing treatment on any other buttons, so please just remove that."

**Sandbox:** https://tasawernawaz.sandbox.edx.org/support/contact_us