### PR TITLE
Site config flag for Learner Records

### DIFF
--- a/lms/djangoapps/courseware/tests/test_views.py
+++ b/lms/djangoapps/courseware/tests/test_views.py
@@ -1440,7 +1440,7 @@ class ProgressPageTests(ProgressPageBaseTests):
 
     @patch.dict(settings.FEATURES, {'ASSUME_ZERO_GRADE_IF_ABSENT_FOR_ALL_TESTS': False})
     @ddt.data(
-        (False, 45, 29),
+        (False, 45, 28),
         (True, 37, 24)
     )
     @ddt.unpack

--- a/lms/djangoapps/grades/tests/test_course_grade_factory.py
+++ b/lms/djangoapps/grades/tests/test_course_grade_factory.py
@@ -104,21 +104,21 @@ class TestCourseGradeFactory(GradeTestBase):
         with self.assertNumQueries(2):
             _assert_read(expected_pass=True, expected_percent=0.5)  # updated to grade of .5
 
-        num_queries = 7
+        num_queries = 6
         with self.assertNumQueries(num_queries), mock_get_score(1, 4):
             grade_factory.update(self.request.user, self.course, force_update_subsections=False)
 
         with self.assertNumQueries(2):
             _assert_read(expected_pass=True, expected_percent=0.5)  # NOT updated to grade of .25
 
-        num_queries = 21
+        num_queries = 20
         with self.assertNumQueries(num_queries), mock_get_score(2, 2):
             grade_factory.update(self.request.user, self.course, force_update_subsections=True)
 
         with self.assertNumQueries(2):
             _assert_read(expected_pass=True, expected_percent=1.0)  # updated to grade of 1.0
 
-        num_queries = 24
+        num_queries = 23
         with self.assertNumQueries(num_queries), mock_get_score(0, 0):  # the subsection now is worth zero
             grade_factory.update(self.request.user, self.course, force_update_subsections=True)
 

--- a/openedx/core/djangoapps/credentials/docs/site_config.rst
+++ b/openedx/core/djangoapps/credentials/docs/site_config.rst
@@ -1,0 +1,15 @@
+Site Configuration
+==================
+
+These are the site configuration flags that affect Credentials features.
+
+ENABLE_CREDENTIALS_RECORDS
+--------------------------
+
+Controls whether the LMS integrates with the Learner Records feature in Credentials. Specifically, this turns on some web buttons that link to a learner's record on the Credentials IDA and enables some data being passed to Credentials related to those records.
+
+If you have had this disabled and decide to enable it, you will need to backpopulate the data that was not sent while the feature was disabled. Look into running the ``notify_credentials`` management command.
+
+Note that Credentials has a similar site config option that you'll want to keep in sync with this setting.
+
+Default is ``True``.

--- a/openedx/core/djangoapps/credentials/models.py
+++ b/openedx/core/djangoapps/credentials/models.py
@@ -96,6 +96,9 @@ class CredentialsApiConfig(ConfigurationModel):
         # Temporarily disable this feature while we work on it
         if not STUDENT_RECORDS_FLAG.is_enabled():
             return None
+        # Not every site wants the Learner Records feature, so we allow opting out.
+        if not helpers.get_value('ENABLE_LEARNER_RECORDS', True):
+            return None
         root = helpers.get_value('CREDENTIALS_PUBLIC_SERVICE_URL', settings.CREDENTIALS_PUBLIC_SERVICE_URL)
         return urljoin(root, '/records/')
 

--- a/openedx/core/djangoapps/credentials/tests/test_signals.py
+++ b/openedx/core/djangoapps/credentials/tests/test_signals.py
@@ -10,7 +10,7 @@ from lms.djangoapps.grades.course_grade_factory import CourseGradeFactory
 from lms.djangoapps.grades.tests.utils import mock_passing_grade
 from openedx.core.djangoapps.catalog.tests.factories import CourseFactory, CourseRunFactory, ProgramFactory
 from openedx.core.djangoapps.credentials.signals import is_course_run_in_a_program, send_grade_if_interesting
-from openedx.core.djangoapps.site_configuration.tests.factories import SiteFactory
+from openedx.core.djangoapps.site_configuration.tests.factories import SiteConfigurationFactory, SiteFactory
 from openedx.core.djangolib.testing.utils import skip_unless_lms
 from student.tests.factories import UserFactory
 from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
@@ -22,6 +22,11 @@ SIGNALS_MODULE = 'openedx.core.djangoapps.credentials.signals'
 
 @ddt.ddt
 @skip_unless_lms
+@mock.patch(
+    'openedx.core.djangoapps.credentials.models.CredentialsApiConfig.is_learner_issuance_enabled',
+    new_callable=mock.PropertyMock,
+    return_value=True,
+)
 @mock.patch(SIGNALS_MODULE + '.send_grade_to_credentials')
 @mock.patch(SIGNALS_MODULE + '.is_course_run_in_a_program')
 class TestCredentialsSignalsSendGrade(TestCase):
@@ -42,7 +47,7 @@ class TestCredentialsSignalsSendGrade(TestCase):
     )
     @ddt.unpack
     def test_send_grade_if_right_cert(self, called, mode, status, mock_is_course_run_in_a_program,
-                                      mock_send_grade_to_credentials):
+                                      mock_send_grade_to_credentials, _mock_is_learner_issuance_enabled):
         mock_is_course_run_in_a_program.return_value = True
 
         # Test direct send
@@ -60,19 +65,20 @@ class TestCredentialsSignalsSendGrade(TestCase):
         send_grade_if_interesting(self.user, self.key, None, None, 'A', 1.0)
         self.assertIs(mock_send_grade_to_credentials.delay.called, called)
 
-    def test_send_grade_missing_cert(self, _, mock_send_grade_to_credentials):
+    def test_send_grade_missing_cert(self, _, mock_send_grade_to_credentials, _mock_is_learner_issuance_enabled):
         send_grade_if_interesting(self.user, self.key, None, None, 'A', 1.0)
         self.assertFalse(mock_send_grade_to_credentials.delay.called)
 
     @ddt.data([True], [False])
     @ddt.unpack
     def test_send_grade_if_in_a_program(self, in_program, mock_is_course_run_in_a_program,
-                                        mock_send_grade_to_credentials):
+                                        mock_send_grade_to_credentials, _mock_is_learner_issuance_enabled):
         mock_is_course_run_in_a_program.return_value = in_program
         send_grade_if_interesting(self.user, self.key, 'verified', 'downloadable', 'A', 1.0)
         self.assertIs(mock_send_grade_to_credentials.delay.called, in_program)
 
-    def test_send_grade_queries_grade(self, mock_is_course_run_in_a_program, mock_send_grade_to_credentials):
+    def test_send_grade_queries_grade(self, mock_is_course_run_in_a_program, mock_send_grade_to_credentials,
+                                      _mock_is_learner_issuance_enabled):
         mock_is_course_run_in_a_program.return_value = True
 
         with mock_passing_grade('B', 0.81):
@@ -83,8 +89,33 @@ class TestCredentialsSignalsSendGrade(TestCase):
         mock_send_grade_to_credentials.delay.reset_mock()
 
     @mock.patch.dict(settings.FEATURES, {'ASSUME_ZERO_GRADE_IF_ABSENT_FOR_ALL_TESTS': False})
-    def test_send_grade_without_grade(self, mock_is_course_run_in_a_program, mock_send_grade_to_credentials):
+    def test_send_grade_without_grade(self, mock_is_course_run_in_a_program, mock_send_grade_to_credentials,
+                                      _mock_is_learner_issuance_enabled):
         mock_is_course_run_in_a_program.return_value = True
+        send_grade_if_interesting(self.user, self.key, 'verified', 'downloadable', None, None)
+        self.assertFalse(mock_send_grade_to_credentials.delay.called)
+
+    def test_send_grade_without_issuance_enabled(self, _mock_is_course_run_in_a_program,
+                                                 mock_send_grade_to_credentials, mock_is_learner_issuance_enabled):
+        mock_is_learner_issuance_enabled.return_value = False
+        send_grade_if_interesting(self.user, self.key, 'verified', 'downloadable', None, None)
+        self.assertTrue(mock_is_learner_issuance_enabled.called)
+        self.assertFalse(mock_send_grade_to_credentials.delay.called)
+
+    def test_send_grade_records_enabled(self, _mock_is_course_run_in_a_program, mock_send_grade_to_credentials,
+                                        _mock_is_learner_issuance_enabled):
+        site_config = SiteConfigurationFactory.create(
+            values={'course_org_filter': [self.key.org]},
+        )
+
+        # Correctly sent
+        send_grade_if_interesting(self.user, self.key, 'verified', 'downloadable', None, None)
+        self.assertTrue(mock_send_grade_to_credentials.delay.called)
+        mock_send_grade_to_credentials.delay.reset_mock()
+
+        # Correctly not sent
+        site_config.values['ENABLE_LEARNER_RECORDS'] = False
+        site_config.save()
         send_grade_if_interesting(self.user, self.key, 'verified', 'downloadable', None, None)
         self.assertFalse(mock_send_grade_to_credentials.delay.called)
 

--- a/openedx/core/djangoapps/programs/signals.py
+++ b/openedx/core/djangoapps/programs/signals.py
@@ -6,6 +6,7 @@ import logging
 from django.dispatch import receiver
 
 from openedx.core.djangoapps.signals.signals import COURSE_CERT_AWARDED, COURSE_CERT_CHANGED
+from openedx.core.djangoapps.site_configuration import helpers
 
 LOGGER = logging.getLogger(__name__)
 
@@ -82,6 +83,11 @@ def handle_course_cert_changed(sender, user, course_key, mode, status, **kwargs)
 
     # Avoid scheduling new tasks if certification is disabled.
     if not CredentialsApiConfig.current().is_learner_issuance_enabled:
+        return
+
+    # Avoid scheduling new tasks if learner records are disabled for this site (right now, course certs are only
+    # used for learner records -- when that changes, we can remove this bit and always send course certs).
+    if not helpers.get_value_for_org(course_key.org, 'ENABLE_LEARNER_RECORDS', True):
         return
 
     # schedule background task to process

--- a/openedx/core/djangoapps/programs/tests/test_signals.py
+++ b/openedx/core/djangoapps/programs/tests/test_signals.py
@@ -6,14 +6,16 @@ from django.test import TestCase
 from nose.plugins.attrib import attr
 import mock
 
+from opaque_keys.edx.keys import CourseKey
 from student.tests.factories import UserFactory
 
 from openedx.core.djangoapps.signals.signals import COURSE_CERT_AWARDED, COURSE_CERT_CHANGED
 from openedx.core.djangoapps.programs.signals import handle_course_cert_awarded, handle_course_cert_changed
+from openedx.core.djangoapps.site_configuration.tests.factories import SiteConfigurationFactory
 from openedx.core.djangolib.testing.utils import skip_unless_lms
 
 TEST_USERNAME = 'test-user'
-TEST_COURSE_KEY = 'test-course'
+TEST_COURSE_KEY = CourseKey.from_string('course-v1:edX+test_course+1')
 
 
 @attr(shard=2)
@@ -92,6 +94,10 @@ class CertChangedReceiverTest(TestCase):
     Tests for the `handle_course_cert_changed` signal handler function.
     """
 
+    def setUp(self):
+        super(CertChangedReceiverTest, self).setUp()
+        self.user = UserFactory.create(username=TEST_USERNAME)
+
     @property
     def signal_kwargs(self):
         """
@@ -99,8 +105,8 @@ class CertChangedReceiverTest(TestCase):
         """
         return dict(
             sender=self.__class__,
-            user=UserFactory.create(username=TEST_USERNAME),
-            course_key='test-course',
+            user=self.user,
+            course_key=TEST_COURSE_KEY,
             mode='test-mode',
             status='test-status',
         )
@@ -115,7 +121,7 @@ class CertChangedReceiverTest(TestCase):
         known to take place inside the function.
         """
         COURSE_CERT_CHANGED.send(**self.signal_kwargs)
-        self.assertEqual(mock_is_learner_issuance_enabled.call_count, 1)
+        self.assertEqual(mock_is_learner_issuance_enabled.call_count, 2)
 
     def test_credentials_disabled(self, mock_is_learner_issuance_enabled, mock_task):
         """
@@ -137,4 +143,22 @@ class CertChangedReceiverTest(TestCase):
 
         self.assertEqual(mock_is_learner_issuance_enabled.call_count, 1)
         self.assertEqual(mock_task.call_count, 1)
-        self.assertEqual(mock_task.call_args[0], (TEST_USERNAME, TEST_COURSE_KEY))
+        self.assertEqual(mock_task.call_args[0], (TEST_USERNAME, str(TEST_COURSE_KEY)))
+
+    def test_records_enabled(self, mock_is_learner_issuance_enabled, mock_task):
+        mock_is_learner_issuance_enabled.return_value = True
+
+        site_config = SiteConfigurationFactory.create(
+            values={'course_org_filter': ['edX']},
+        )
+
+        # Correctly sent
+        handle_course_cert_changed(**self.signal_kwargs)
+        self.assertTrue(mock_task.called)
+        mock_task.reset_mock()
+
+        # Correctly not sent
+        site_config.values['ENABLE_LEARNER_RECORDS'] = False
+        site_config.save()
+        handle_course_cert_changed(**self.signal_kwargs)
+        self.assertFalse(mock_task.called)


### PR DESCRIPTION
Allow site admins to disable integration for the Learner Records feature in Credentials.

Trying a new site config documentation idea, in consultation with Nimisha and Jeremy Bowman.

Oh, and I decided to also not send grades if "learner_issuance" is disabled. That means no certs, which means no need for grades.

https://openedx.atlassian.net/browse/LEARNER-5987