### PR TITLE
Fix discussion blackout date pasrsing.

### DIFF
--- a/common/lib/xmodule/xmodule/course_module.py
+++ b/common/lib/xmodule/xmodule/course_module.py
@@ -1273,12 +1273,17 @@ class CourseDescriptor(CourseFields, SequenceDescriptor, LicenseMixin):
         Get a list of dicts with start and end fields with datetime values from
         the discussion_blackouts setting
         """
+
+        blackout_dates = self.discussion_blackouts
         date_proxy = Date()
+        if blackout_dates and type(blackout_dates[0]) not in (list, tuple):
+            blackout_dates = [blackout_dates]
+
         try:
             ret = [
                 {"start": date_proxy.from_json(start), "end": date_proxy.from_json(end)}
                 for start, end
-                in filter(None, self.discussion_blackouts)
+                in filter(None, blackout_dates)
             ]
             for blackout in ret:
                 if not blackout["start"] or not blackout["end"]:
@@ -1287,7 +1292,7 @@ class CourseDescriptor(CourseFields, SequenceDescriptor, LicenseMixin):
         except (TypeError, ValueError):
             log.info(
                 "Error parsing discussion_blackouts %s for course %s",
-                self.discussion_blackouts,
+                blackout_dates,
                 self.id
             )
             return []


### PR DESCRIPTION
### Description
Studio's helping text to define discussion blackout dates is as follows. 
> Enter pairs of dates between which students cannot post to discussion forums. Inside the provided brackets, enter an additional set of square brackets surrounding each pair of dates you add. Format each pair of dates as ["YYYY-MM-DD", "YYYY-MM-DD"]. To specify times as well as dates, format each pair as ["YYYY-MM-DDTHH:MM", "YYYY-MM-DDTHH:MM"]. Be sure to include the "T" between the date and time. For example, an entry defining two blackout periods looks like this, including the outer pair of square brackets: [["2015-09-15", "2015-09-21"], ["2015-10-01", "2015-10-08"]] 

Observe the two patterns.
**One Date Set:** `["YYYY-MM-DD", "YYYY-MM-DD"]` => `list of two strings`
**Two Dates Set:** `[["2015-09-15", "2015-09-21"], ["2015-10-01", "2015-10-08"]] ` => `list of list of two strings`

The code handles two dates set perfectly, and we have tests for these scenarios as well but we didn't have any scenario for one date set (Just added it now). I will add a sandbox link for testing tomorrow. 

# Sanbox
https://awaisdar001.sandbox.edx.org/courses/course-v1:edX+DemoX+Demo_Course/course/
[EDUCATOR-3260](https://openedx.atlassian.net/browse/EDUCATOR-3260)

# How to test?
## Test 1
1. Login with staff
2. Open discussion Forum: https://awaisdar001.sandbox.edx.org/courses/course-v1:edX+DemoX+Demo_Course/discussion/forum/
3. Verify you can see "Add Post" Button
4. Open Studio Advance Settings (https://studio-awaisdar001.sandbox.edx.org/settings/advanced/course-v1:edX+DemoX+Demo_Course) and change the "Blackout Dates" from `[]` to `["2018-05-16T23:59", "2040-12-31T23:59"]` active blackout date.
5. Verify you should **not be able to** see "Add Post" button anymore.  (https://awaisdar001.sandbox.edx.org/courses/course-v1:edX+DemoX+Demo_Course/discussion/forum/)

## Test 2
6. Change the date to multi date `[["2016-05-16T23:59", "2017-12-31T23:59"], ["2018-05-16T23:59", "2019-12-31T23:59"]]` to active blackout dates. 
7. Verify you still **donot** see the button. 

## Test 3
8. Change the date to  `["2016-05-16T23:59", "2017-12-31T23:59"]` inactive blackout date. 
9. Verify that you **do see** "Add Post" button. 

## Test 4
10. Change the date to multi date `[["2016-05-16T23:59", "2017-12-31T23:59"], ["2018-01-16T23:59", "2018-02-31T23:59"]]` to inactive blackout date. 
11. Verify that you **do see** "Add Post" button. 

# Verify Production
1. Go to : https://studio.edx.org/settings/advanced/course-v1:HarvardX+PH526x+1T2018
2. Verify the dates are set so there shouldn't be "Add Post" Button.
3. Enroll in the course
4. Verify you see "Add Post" button even setting active blackout dates. (https://courses.edx.org/courses/course-v1:HarvardX+PH526x+1T2018/discussion/forum/)