### PR TITLE
Properly handle errors in award program certificates

### DIFF
--- a/openedx/core/djangoapps/programs/tasks/v1/tests/test_tasks.py
+++ b/openedx/core/djangoapps/programs/tasks/v1/tests/test_tasks.py
@@ -292,6 +292,42 @@ class AwardProgramCertificatesTestCase(CatalogIntegrationMixin, CredentialsApiCo
         self.assertEqual(mock_get_certified_programs.call_count, 2)
         self.assertEqual(mock_award_program_certificate.call_count, 1)
 
+    def test_retry_on_credentials_api_429_error(
+        self,
+        mock_get_completed_programs,
+        mock_get_certified_programs,  # pylint: disable=unused-argument
+        mock_award_program_certificate,
+    ):
+        """
+        Verify that a 429 error causes the task to fail and then retry.
+        """
+        mock_get_completed_programs.return_value = [1, 2]
+        mock_award_program_certificate.side_effect = self._make_side_effect(
+            [exceptions.HttpClientError('Client Error 429: http://example-endpoint/'), None]
+        )
+
+        tasks.award_program_certificates.delay(self.student.username).get()
+
+        self.assertEqual(mock_award_program_certificate.call_count, 3)
+
+    def test_no_retry_oncredentials_api_404_error(
+        self,
+        mock_get_completed_programs,
+        mock_get_certified_programs,  # pylint: disable=unused-argument
+        mock_award_program_certificate,
+    ):
+        """
+        Verify that a 404 error causes the task to fail but there is no retry.
+        """
+        mock_get_completed_programs.return_value = [1, 2]
+        mock_award_program_certificate.side_effect = self._make_side_effect(
+            [exceptions.HttpNotFoundError(), None]
+        )
+
+        tasks.award_program_certificates.delay(self.student.username).get()
+
+        self.assertEqual(mock_award_program_certificate.call_count, 2)
+
     def test_no_retry_on_credentials_api_not_found_errors(
         self,
         mock_get_completed_programs,
@@ -301,7 +337,7 @@ class AwardProgramCertificatesTestCase(CatalogIntegrationMixin, CredentialsApiCo
         mock_get_completed_programs.return_value = [1, 2]
         mock_get_certified_programs.side_effect = [[], [2]]
         mock_award_program_certificate.side_effect = self._make_side_effect(
-            [exceptions.HttpClientError(), None]
+            [exceptions.HttpClientError('Client Error 418: http://example-endpoint/'), None]
         )
 
         tasks.award_program_certificates.delay(self.student.username).get()


### PR DESCRIPTION
LEARNER-6004

Just handling 429 separately right now.  Wanted to get this up so we could see if this was an acceptable strategy for now, although I don't like it.