### PR TITLE
setting xframe_options to deny

### DIFF
--- a/cms/djangoapps/contentstore/views/preview.py
+++ b/cms/djangoapps/contentstore/views/preview.py
@@ -8,6 +8,7 @@ from django.contrib.auth.decorators import login_required
 from django.urls import reverse
 from django.http import Http404, HttpResponseBadRequest
 from django.utils.translation import ugettext as _
+from django.views.decorators.clickjacking import xframe_options_exempt
 from opaque_keys.edx.keys import UsageKey
 from web_fragments.fragment import Fragment
 from xblock.django.request import django_to_webob_request, webob_to_django_response
@@ -51,6 +52,7 @@ log = logging.getLogger(__name__)
 
 
 @login_required
+@xframe_options_exempt
 def preview_handler(request, usage_key_string, handler, suffix=''):
     """
     Dispatch an AJAX action to an xblock

--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -531,8 +531,8 @@ MIDDLEWARE_CLASSES = [
     'openedx.core.djangoapps.site_configuration.middleware.SessionCookieDomainOverrideMiddleware',
 ]
 
-# Clickjacking protection can be enabled by setting this to 'DENY'
-X_FRAME_OPTIONS = 'ALLOW'
+# Clickjacking protection can be disabled by setting this to 'ALLOW'
+X_FRAME_OPTIONS = 'DENY'
 
 # Platform for Privacy Preferences header
 P3P_HEADER = 'CP="Open EdX does not have a P3P policy."'


### PR DESCRIPTION
## [EDUCATOR-3074](https://openedx.atlassian.net/browse/EDUCATOR-3074)

### Description

We are going to set xframe_option to 'DENY', for that purpose I have manually tested studio and found one function that needs to be exempted. Exemption is made by decorating that method with django's `xframe_options_exempt `. 
 This PR: https://github.com/edx/configuration/pull/4725 will deny iframe rendering on prod.

### Reviewers
- [x] @awaisdar001 
- [x] @asadazam93 

FYI: @nasthagiri 
 
### Post-review
- [x] Rebase and squash commits