### PR TITLE
pass target branch to paver

### DIFF
--- a/scripts/jenkins-quality-diff.sh
+++ b/scripts/jenkins-quality-diff.sh
@@ -10,4 +10,4 @@ echo "Running diff quality."
 mkdir -p test_root/log/
 LOG_PREFIX=test_root/log/run_quality
 
-paver run_quality -p 100 -l $LOWER_PYLINT_THRESHOLD:$UPPER_PYLINT_THRESHOLD 2> $LOG_PREFIX.err.log > $LOG_PREFIX.out.log
+paver run_quality -b $TARGET_BRANCH -p 100 -l $LOWER_PYLINT_THRESHOLD:$UPPER_PYLINT_THRESHOLD 2> $LOG_PREFIX.err.log > $LOG_PREFIX.out.log


### PR DESCRIPTION
The $TARGET_BRANCH env var was not actually picked up by paver. This cuts down the diff-quality job on private from 45 minutes to 3.