### PR TITLE
Fixes a11y contrast of records button on learner profile page

### DIFF
--- a/lms/static/sass/features/_learner-profile.scss
+++ b/lms/static/sass/features/_learner-profile.scss
@@ -277,6 +277,8 @@
         button {
           @extend %btn-secondary-blue-outline;
           margin-top: 1em;
+          background: $blue;
+          color: #fff;
         }
       }
 


### PR DESCRIPTION
The current contrast between the gray banner and and "View My Records" button is too low for a11y standards.  I changed the color of the button to account for this.  One note though is that the account settings link which still does not meet the required contrast.

https://openedx.atlassian.net/browse/LEARNER-5976

**before:**
![image](https://user-images.githubusercontent.com/9636457/43660115-05e306f4-972c-11e8-97d8-159ecb85cd5f.png)


**after:**
![image](https://user-images.githubusercontent.com/9636457/43660124-0af76ec8-972c-11e8-96cf-86c7a0f2a5af.png)