### PR TITLE
Support for anonymous_view

### DIFF
--- a/common/lib/xmodule/xmodule/course_module.py
+++ b/common/lib/xmodule/xmodule/course_module.py
@@ -44,6 +44,10 @@ DEFAULT_COURSE_VISIBILITY_IN_CATALOG = getattr(
 
 DEFAULT_MOBILE_AVAILABLE = getattr(settings, 'DEFAULT_MOBILE_AVAILABLE', False)
 
+COURSE_VISIBILITY_PRIVATE = 'private'
+COURSE_VISIBILITY_PUBLIC_OUTLINE = 'public_outline'
+COURSE_VISIBILITY_PUBLIC = 'public'
+
 
 class StringOrDate(Date):
     def from_json(self, value):
@@ -812,6 +816,21 @@ class CourseFields(object):
         help=_("Specify what student can learn from the course."),
         default=[],
         scope=Scope.settings
+    )
+
+    course_visibility = String(
+        display_name=_("Course Visibility For Unenrolled Learners"),
+        help=_(
+            "Defines the access permissions for unenrolled learners. This can be set to one of three values: "
+            "'private' (default visibility, only allowed for enrolled students), 'public_outline' "
+            "(allow access to course outline) and 'public' (allow access to both outline and course content)."
+        ),
+        default=COURSE_VISIBILITY_PRIVATE,
+        scope=Scope.settings,
+        values=[
+            {"display_name": _("private"), "value": COURSE_VISIBILITY_PRIVATE},
+            {"display_name": _("public_outline"), "value": COURSE_VISIBILITY_PUBLIC_OUTLINE},
+            {"display_name": _("public"), "value": COURSE_VISIBILITY_PUBLIC}]
     )
 
     """

--- a/common/lib/xmodule/xmodule/html_module.py
+++ b/common/lib/xmodule/xmodule/html_module.py
@@ -79,6 +79,13 @@ class HtmlBlock(object):
         """
         return Fragment(self.get_html())
 
+    @XBlock.supports("multi_device")
+    def public_view(self, context):
+        """
+        Returns a fragment that contains the html for the preview view
+        """
+        return self.student_view(context)
+
     def student_view_data(self, context=None):  # pylint: disable=unused-argument
         """
         Return a JSON representation of the student_view of this XBlock.

--- a/common/lib/xmodule/xmodule/tests/helpers.py
+++ b/common/lib/xmodule/xmodule/tests/helpers.py
@@ -32,10 +32,19 @@ class StubUserService(UserService):
     """
     Stub UserService for testing the sequence module.
     """
+
+    def __init__(self, is_anonymous=False, **kwargs):
+        self.is_anonymous = is_anonymous
+        super(StubUserService, self).__init__(**kwargs)
+
     def get_current_user(self):
         """
         Implements abstract method for getting the current user.
         """
         user = XBlockUser()
-        user.opt_attrs['edx-platform.username'] = 'bilbo'
+        if self.is_anonymous:
+            user.opt_attrs['edx-platform.username'] = 'anonymous'
+            user.opt_attrs['edx-platform.is_authenticated'] = False
+        else:
+            user.opt_attrs['edx-platform.username'] = 'bilbo'
         return user

--- a/common/lib/xmodule/xmodule/tests/test_html_module.py
+++ b/common/lib/xmodule/xmodule/tests/test_html_module.py
@@ -11,6 +11,7 @@ from xblock.fields import ScopeIds
 from xmodule.html_module import CourseInfoModule, HtmlDescriptor, HtmlModule
 
 from . import get_test_descriptor_system, get_test_system
+from ..x_module import PUBLIC_VIEW, STUDENT_VIEW
 
 
 def instantiate_descriptor(**field_data):
@@ -80,6 +81,22 @@ class HtmlModuleCourseApiTestCase(unittest.TestCase):
         module_system = get_test_system()
         module = HtmlModule(descriptor, module_system, field_data, Mock())
         self.assertEqual(module.student_view_data(), dict(enabled=True, html=html))
+
+    @ddt.data(
+        STUDENT_VIEW,
+        PUBLIC_VIEW,
+    )
+    def test_student_preview_view(self, view):
+        """
+        Ensure that student_view and public_view renders correctly.
+        """
+        html = '<p>This is a test</p>'
+        descriptor = Mock()
+        field_data = DictFieldData({'data': html})
+        module_system = get_test_system()
+        module = HtmlModule(descriptor, module_system, field_data, Mock())
+        rendered = module_system.render(module, view, {}).content
+        self.assertIn(html, rendered)
 
 
 class HtmlModuleSubstitutionTestCase(unittest.TestCase):

--- a/common/lib/xmodule/xmodule/vertical_block.py
+++ b/common/lib/xmodule/xmodule/vertical_block.py
@@ -17,7 +17,7 @@ from xmodule.progress import Progress
 from xmodule.seq_module import SequenceFields
 from xmodule.studio_editable import StudioEditableBlock
 from xmodule.util.xmodule_django import add_webpack_to_fragment
-from xmodule.x_module import STUDENT_VIEW, XModuleFields
+from xmodule.x_module import STUDENT_VIEW, PUBLIC_VIEW, XModuleFields
 from xmodule.xml_module import XmlParserMixin
 
 import webpack_loader.utils
@@ -45,9 +45,9 @@ class VerticalBlock(SequenceFields, XModuleFields, StudioEditableBlock, XmlParse
 
     show_in_read_only_mode = True
 
-    def student_view(self, context):
+    def _student_or_public_view(self, context, view):
         """
-        Renders the student view of the block in the LMS.
+        Renders the requested view type of the block in the LMS.
         """
         fragment = Fragment()
         contents = []
@@ -57,12 +57,14 @@ class VerticalBlock(SequenceFields, XModuleFields, StudioEditableBlock, XmlParse
         else:
             child_context = {}
 
-        if 'bookmarked' not in child_context:
-            bookmarks_service = self.runtime.service(self, 'bookmarks')
-            child_context['bookmarked'] = bookmarks_service.is_bookmarked(usage_key=self.location),  # pylint: disable=no-member
-        if 'username' not in child_context:
-            user_service = self.runtime.service(self, 'user')
-            child_context['username'] = user_service.get_current_user().opt_attrs['edx-platform.username']
+        if view == STUDENT_VIEW:
+            if 'bookmarked' not in child_context:
+                bookmarks_service = self.runtime.service(self, 'bookmarks')
+                child_context['bookmarked'] = bookmarks_service.is_bookmarked(
+                    usage_key=self.location),  # pylint: disable=no-member
+            if 'username' not in child_context:
+                user_service = self.runtime.service(self, 'user')
+                child_context['username'] = user_service.get_current_user().opt_attrs['edx-platform.username']
 
         child_blocks = self.get_display_items()
 
@@ -82,7 +84,7 @@ class VerticalBlock(SequenceFields, XModuleFields, StudioEditableBlock, XmlParse
                 child_block_context['wrap_xblock_data'] = {
                     'mark-completed-on-view-after-delay': complete_on_view_delay
                 }
-            rendered_child = child.render(STUDENT_VIEW, child_block_context)
+            rendered_child = child.render(view, child_block_context)
             fragment.add_fragment_resources(rendered_child)
 
             contents.append({
@@ -90,19 +92,38 @@ class VerticalBlock(SequenceFields, XModuleFields, StudioEditableBlock, XmlParse
                 'content': rendered_child.content
             })
 
-        fragment.add_content(self.system.render_template('vert_module.html', {
+        fragment_context = {
             'items': contents,
             'xblock_context': context,
             'unit_title': self.display_name_with_default if not is_child_of_vertical else None,
-            'show_bookmark_button': child_context.get('show_bookmark_button', not is_child_of_vertical),
-            'bookmarked': child_context['bookmarked'],
-            'bookmark_id': u"{},{}".format(child_context['username'], unicode(self.location)),  # pylint: disable=no-member
-        }))
+        }
+
+        if view == STUDENT_VIEW:
+            fragment_context.update({
+                'show_bookmark_button': child_context.get('show_bookmark_button', not is_child_of_vertical),
+                'bookmarked': child_context['bookmarked'],
+                'bookmark_id': u"{},{}".format(
+                    child_context['username'], unicode(self.location)),  # pylint: disable=no-member
+            })
+
+        fragment.add_content(self.system.render_template('vert_module.html', fragment_context))
 
         add_webpack_to_fragment(fragment, 'VerticalStudentView')
         fragment.initialize_js('VerticalStudentView')
 
         return fragment
+
+    def student_view(self, context):
+        """
+        Renders the student view of the block in the LMS.
+        """
+        return self._student_or_public_view(context, STUDENT_VIEW)
+
+    def public_view(self, context):
+        """
+        Renders the anonymous view of the block in the LMS.
+        """
+        return self._student_or_public_view(context, PUBLIC_VIEW)
 
     def author_view(self, context):
         """

--- a/common/lib/xmodule/xmodule/x_module.py
+++ b/common/lib/xmodule/xmodule/x_module.py
@@ -39,6 +39,8 @@ from opaque_keys.edx.asides import AsideUsageKeyV2, AsideDefinitionKeyV2
 from xmodule.exceptions import UndefinedContext
 import dogstats_wrapper as dog_stats_api
 
+from openedx.core.djangolib.markup import HTML
+
 log = logging.getLogger(__name__)
 
 XMODULE_METRIC_NAME = 'edxapp.xmodule'
@@ -55,6 +57,10 @@ DEPRECATION_VSCOMPAT_EVENT = 'deprecation.vscompat'
 # the XBlock also implements author_view.
 STUDENT_VIEW = 'student_view'
 
+# This is the view that will be rendered to display the XBlock in the LMS for unenrolled learners.
+# Implementations of this view should assume that a user and user data are not available.
+PUBLIC_VIEW = 'public_view'
+
 # An optional view of the XBlock similar to student_view, but with possible inline
 # editing capabilities. This view differs from studio_view in that it should be as similar to student_view
 # as possible. When previewing XBlocks within Studio, Studio will prefer author_view to student_view.
@@ -65,8 +71,9 @@ AUTHOR_VIEW = 'author_view'
 STUDIO_VIEW = 'studio_view'
 
 # Views that present a "preview" view of an xblock (as opposed to an editing view).
-PREVIEW_VIEWS = [STUDENT_VIEW, AUTHOR_VIEW]
+PREVIEW_VIEWS = [STUDENT_VIEW, PUBLIC_VIEW, AUTHOR_VIEW]
 
+DEFAULT_PUBLIC_VIEW_MESSAGE = u'Please enroll to view this content.'
 
 # Make '_' a no-op so we can scrape strings. Using lambda instead of
 #  `django.utils.translation.ugettext_noop` because Django cannot be imported in this file
@@ -757,6 +764,17 @@ class XModuleMixin(XModuleFields, XBlock):
 
         return metadata_field_editor_info
 
+    def public_view(self, _context):
+        """
+        Default message for blocks that don't implement public_view
+        """
+        alert_html = HTML(
+            u'<div class="page-banner"><div class="alert alert-warning">'
+            u'<span class="icon icon-alert fa fa fa-warning" aria-hidden="true"></span>'
+            u'<div class="message-content">{}</div></div></div>'
+        )
+        return Fragment(alert_html.format(DEFAULT_PUBLIC_VIEW_MESSAGE))
+
 
 class ProxyAttribute(object):
     """
@@ -1220,6 +1238,7 @@ class XModuleDescriptor(HTMLSnippet, ResourceTemplates, XModuleMixin):
     get_score = module_attr('get_score')
     handle_ajax = module_attr('handle_ajax')
     student_view = module_attr(STUDENT_VIEW)
+    public_view = module_attr(PUBLIC_VIEW)
     get_child_descriptors = module_attr('get_child_descriptors')
     xmodule_handler = module_attr('xmodule_handler')
 

--- a/common/lib/xmodule/xmodule/x_module.py
+++ b/common/lib/xmodule/xmodule/x_module.py
@@ -383,6 +383,7 @@ class XModuleMixin(XModuleFields, XBlock):
         migrate and test switching to display_name_with_default, which is no
         longer escaped.
         """
+        # xss-lint: disable=python-deprecated-display-name
         return block_metadata_utils.display_name_with_default_escaped(self)
 
     @property
@@ -488,6 +489,7 @@ class XModuleMixin(XModuleFields, XBlock):
         if self.has_children:
             return sum((child.get_content_titles() for child in self.get_children()), [])
         else:
+            # xss-lint: disable=python-deprecated-display-name
             return [self.display_name_with_default_escaped]
 
     def get_children(self, usage_id_filter=None, usage_key_filter=None):  # pylint: disable=arguments-differ
@@ -870,6 +872,7 @@ class XModule(HTMLSnippet, XModuleMixin):
         self._runtime = value
 
     def __unicode__(self):
+        # xss-lint: disable=python-wrap-html
         return u'<x_module(id={0})>'.format(self.id)
 
     def handle_ajax(self, _dispatch, _data):

--- a/lms/djangoapps/course_api/blocks/transformers/milestones.py
+++ b/lms/djangoapps/course_api/blocks/transformers/milestones.py
@@ -8,6 +8,7 @@ from django.conf import settings
 from edx_proctoring.api import get_attempt_status_summary
 from edx_proctoring.exceptions import ProctoredExamNotFoundException
 
+from student.models import CourseEnrollment
 from openedx.core.djangoapps.content.block_structure.transformer import (
     BlockStructureTransformer,
 )
@@ -144,7 +145,11 @@ class MilestonesAndSpecialExamsTransformer(BlockStructureTransformer):
 
         """
         course_key = block_structure.root_block_usage_key.course_key
-        user_can_skip_entrance_exam = EntranceExamConfiguration.user_can_skip_entrance_exam(usage_info.user, course_key)
+        user_can_skip_entrance_exam = False
+        is_enrolled = CourseEnrollment.is_enrolled(usage_info.user, course_key)
+        if is_enrolled:
+            user_can_skip_entrance_exam = EntranceExamConfiguration.user_can_skip_entrance_exam(
+                usage_info.user, course_key)
         required_content = milestones_helpers.get_required_content(course_key, usage_info.user)
 
         if not required_content:

--- a/lms/djangoapps/course_api/blocks/transformers/tests/test_milestones.py
+++ b/lms/djangoapps/course_api/blocks/transformers/tests/test_milestones.py
@@ -162,7 +162,7 @@ class MilestonesTransformerTestCase(CourseStructureTestCase, MilestonesTestCaseM
         self.course.enable_subsection_gating = True
         self.setup_gated_section(self.blocks[gated_block_ref], self.blocks[gating_block_ref])
 
-        with self.assertNumQueries(6):
+        with self.assertNumQueries(7):
             self.get_blocks_and_check_against_expected(self.user, expected_blocks_before_completion)
 
         # clear the request cache to simulate a new request
@@ -175,7 +175,7 @@ class MilestonesTransformerTestCase(CourseStructureTestCase, MilestonesTestCaseM
             self.user,
         )
 
-        with self.assertNumQueries(6):
+        with self.assertNumQueries(7):
             self.get_blocks_and_check_against_expected(self.user, self.ALL_BLOCKS_EXCEPT_SPECIAL)
 
     def test_staff_access(self):

--- a/lms/djangoapps/courseware/tests/test_views.py
+++ b/lms/djangoapps/courseware/tests/test_views.py
@@ -58,20 +58,24 @@ from openedx.core.djangoapps.content.course_overviews.models import CourseOvervi
 from openedx.core.djangoapps.crawlers.models import CrawlersConfig
 from openedx.core.djangoapps.credit.api import set_credit_requirements
 from openedx.core.djangoapps.credit.models import CreditCourse, CreditProvider
-from openedx.core.djangoapps.waffle_utils import CourseWaffleFlag, WaffleFlagNamespace
 from openedx.core.djangoapps.waffle_utils.testutils import WAFFLE_TABLES, override_waffle_flag
 from openedx.core.djangolib.testing.utils import get_mock_request
 from openedx.core.lib.gating import api as gating_api
 from openedx.core.lib.tests import attr
 from openedx.core.lib.url_utils import quote_slashes
 from openedx.features.course_duration_limits.config import CONTENT_TYPE_GATING_FLAG
-from openedx.features.course_experience import COURSE_OUTLINE_PAGE_FLAG, UNIFIED_COURSE_TAB_FLAG
+from openedx.features.course_experience import (
+    COURSE_ENABLE_UNENROLLED_ACCESS_FLAG,
+    COURSE_OUTLINE_PAGE_FLAG,
+    UNIFIED_COURSE_TAB_FLAG,
+)
 from openedx.features.enterprise_support.tests.mixins.enterprise import EnterpriseTestConsentRequired
 from student.models import CourseEnrollment
 from student.tests.factories import TEST_PASSWORD, AdminFactory, CourseEnrollmentFactory, UserFactory
 from util.tests.test_date_utils import fake_pgettext, fake_ugettext
 from util.url import reload_django_url_config
 from util.views import ensure_valid_course_key
+from xmodule.course_module import COURSE_VISIBILITY_PRIVATE, COURSE_VISIBILITY_PUBLIC_OUTLINE, COURSE_VISIBILITY_PUBLIC
 from xmodule.graders import ShowCorrectness
 from xmodule.modulestore import ModuleStoreEnum
 from xmodule.modulestore.django import modulestore
@@ -2269,7 +2273,6 @@ class TestIndexView(ModuleStoreTestCase):
     """
     Tests of the courseware.views.index view.
     """
-    SEO_WAFFLE_FLAG = CourseWaffleFlag(WaffleFlagNamespace(name='seo'), 'enable_anonymous_courseware_access')
 
     @XBlock.register_temp_plugin(ViewCheckerBlock, 'view_checker')
     @ddt.data(ModuleStoreEnum.Type.mongo, ModuleStoreEnum.Type.split)
@@ -2339,12 +2342,23 @@ class TestIndexView(ModuleStoreTestCase):
         )
         self.assertIn("Activate Block ID: test_block_id", response.content)
 
-    def test_anonymous_access(self):
-        course = CourseFactory()
+    @ddt.data(
+        [False, COURSE_VISIBILITY_PRIVATE, 302],
+        [False, COURSE_VISIBILITY_PUBLIC_OUTLINE, 302],
+        [False, COURSE_VISIBILITY_PUBLIC, 302],
+        [True, COURSE_VISIBILITY_PRIVATE, 302],
+        [True, COURSE_VISIBILITY_PUBLIC_OUTLINE, 302],
+        [True, COURSE_VISIBILITY_PUBLIC, 200],
+    )
+    @ddt.unpack
+    def test_unenrolled_access(self, waffle_override, course_visibility, expected_status):
+        course = CourseFactory(course_visibility=course_visibility)
         with self.store.bulk_operations(course.id):
             chapter = ItemFactory(parent=course, category='chapter')
             section = ItemFactory(parent=chapter, category='sequential')
-            ItemFactory.create(parent=section, category='vertical', display_name="Vertical")
+            vertical = ItemFactory.create(parent=section, category='vertical', display_name="Vertical")
+            ItemFactory.create(parent=vertical, category='html', display_name='HTML block')
+            ItemFactory.create(parent=vertical, category='video', display_name='Video')
 
         url = reverse(
             'courseware_section',
@@ -2354,23 +2368,29 @@ class TestIndexView(ModuleStoreTestCase):
                 'section': section.url_name,
             }
         )
-        response = self.client.get(url, follow=False)
-        assert response.status_code == 302
 
-        waffle_flag = CourseWaffleFlag(WaffleFlagNamespace(name='seo'), 'enable_anonymous_courseware_access')
-        with override_waffle_flag(waffle_flag, active=True):
+        with override_waffle_flag(COURSE_ENABLE_UNENROLLED_ACCESS_FLAG, active=waffle_override):
+            response = self.client.get(url, follow=False)
+            assert response.status_code == expected_status
+            if expected_status == 200:  # Public access is available
+                self.assertIn('data-save-position="false"', response.content)
+                self.assertIn('data-show-completion="false"', response.content)
+                self.assertIn('xblock-public_view-sequential', response.content)
+                self.assertIn('xblock-public_view-vertical', response.content)
+                self.assertIn('xblock-public_view-html', response.content)
+                self.assertIn('xblock-public_view-video', response.content)
+
+            user = UserFactory()
+            self.assertTrue(self.client.login(username=user.username, password='test'))
+            response = self.client.get(url, follow=False)
+            # Logged in but unenrolled learners get the same behaviour as anonymous learners.
+            assert response.status_code == expected_status
+
+            CourseEnrollmentFactory(user=user, course_id=course.id)
             response = self.client.get(url, follow=False)
             assert response.status_code == 200
-            self.assertIn('data-save-position="false"', response.content)
-            self.assertIn('data-show-completion="false"', response.content)
-
-        user = UserFactory()
-        CourseEnrollmentFactory(user=user, course_id=course.id)
-        self.assertTrue(self.client.login(username=user.username, password='test'))
-        response = self.client.get(url, follow=False)
-        assert response.status_code == 200
-        self.assertIn('data-save-position="true"', response.content)
-        self.assertIn('data-show-completion="true"', response.content)
+            self.assertIn('data-save-position="true"', response.content)
+            self.assertIn('data-show-completion="true"', response.content)
 
 
 @attr(shard=5)

--- a/lms/djangoapps/courseware/views/index.py
+++ b/lms/djangoapps/courseware/views/index.py
@@ -24,6 +24,8 @@ from opaque_keys.edx.keys import CourseKey
 from web_fragments.fragment import Fragment
 
 from edxmako.shortcuts import render_to_response, render_to_string
+
+from student.models import CourseEnrollment
 from lms.djangoapps.courseware.exceptions import CourseAccessRedirect
 from lms.djangoapps.experiments.utils import get_experiment_user_metadata_context
 from lms.djangoapps.gating.api import get_entrance_exam_score_ratio, get_entrance_exam_usage_key
@@ -32,16 +34,19 @@ from openedx.core.djangoapps.crawlers.models import CrawlersConfig
 from openedx.core.djangoapps.lang_pref import LANGUAGE_KEY
 from openedx.core.djangoapps.user_api.preferences.api import get_user_preference
 from openedx.core.djangoapps.util.user_messages import PageLevelMessages
-from openedx.core.djangoapps.waffle_utils import WaffleSwitchNamespace, WaffleFlagNamespace, CourseWaffleFlag
+from openedx.core.djangoapps.waffle_utils import WaffleSwitchNamespace
 from openedx.core.djangolib.markup import HTML, Text
-from openedx.features.course_experience import COURSE_OUTLINE_PAGE_FLAG, default_course_url_name
+from openedx.features.course_experience import (
+    COURSE_OUTLINE_PAGE_FLAG, default_course_url_name, COURSE_ENABLE_UNENROLLED_ACCESS_FLAG
+)
 from openedx.features.course_experience.views.course_sock import CourseSockFragmentView
 from openedx.features.enterprise_support.api import data_sharing_consent_required
 from shoppingcart.models import CourseRegistrationCode
 from student.views import is_course_blocked
 from util.views import ensure_valid_course_key
 from xmodule.modulestore.django import modulestore
-from xmodule.x_module import STUDENT_VIEW
+from xmodule.course_module import COURSE_VISIBILITY_PUBLIC
+from xmodule.x_module import PUBLIC_VIEW, STUDENT_VIEW
 from .views import CourseTabView
 from ..access import has_access
 from ..access_utils import check_course_open_for_learner
@@ -68,9 +73,8 @@ class CoursewareIndex(View):
     """
 
     @cached_property
-    def enable_anonymous_courseware_access(self):
-        waffle_flag = CourseWaffleFlag(WaffleFlagNamespace(name='seo'), 'enable_anonymous_courseware_access')
-        return waffle_flag.is_enabled(self.course_key)
+    def enable_unenrolled_access(self):
+        return COURSE_ENABLE_UNENROLLED_ACCESS_FLAG.is_enabled(self.course_key)
 
     @method_decorator(ensure_csrf_cookie)
     @method_decorator(cache_control(no_cache=True, no_store=True, must_revalidate=True))
@@ -97,7 +101,7 @@ class CoursewareIndex(View):
         """
         self.course_key = CourseKey.from_string(course_id)
 
-        if not (request.user.is_authenticated or self.enable_anonymous_courseware_access):
+        if not (request.user.is_authenticated or self.enable_unenrolled_access):
             return redirect_to_login(request.get_full_path())
 
         self.original_chapter_url_name = chapter
@@ -116,8 +120,16 @@ class CoursewareIndex(View):
                 self.course = get_course_with_access(
                     request.user, 'load', self.course_key,
                     depth=CONTENT_DEPTH,
-                    check_if_enrolled=not self.enable_anonymous_courseware_access,
+                    check_if_enrolled=False,
                 )
+                is_enrolled = CourseEnrollment.is_enrolled(request.user, self.course_key)
+                if is_enrolled:
+                    self.view = STUDENT_VIEW
+                elif self.enable_unenrolled_access and self.course.course_visibility == COURSE_VISIBILITY_PUBLIC:
+                    self.view = PUBLIC_VIEW
+                else:
+                    raise CourseAccessRedirect(reverse('about_course', args=[unicode(self.course_key)]))
+
                 self.is_staff = has_access(request.user, 'staff', self.course)
                 self._setup_masquerade_for_effective_user()
                 return self.render(request)
@@ -435,7 +447,9 @@ class CoursewareIndex(View):
                 table_of_contents['previous_of_active_section'],
                 table_of_contents['next_of_active_section'],
             )
-            courseware_context['fragment'] = self.section.render(STUDENT_VIEW, section_context)
+
+            courseware_context['fragment'] = self.section.render(self.view, section_context)
+
             if self.section.position and self.section.has_children:
                 self._add_sequence_title_to_context(courseware_context)
 

--- a/lms/static/sass/course/courseware/_courseware.scss
+++ b/lms/static/sass/course/courseware/_courseware.scss
@@ -139,7 +139,8 @@ html.video-fullscreen {
       word-break: break-word;
       margin: 0 auto;
 
-      &.xblock-student_view-vertical {
+      &.xblock-student_view-vertical,
+      &.xblock-public_view-vertical {
         max-width: $text-width-readability-max;
       }
     }
@@ -581,7 +582,8 @@ html.video-fullscreen {
         padding: 0 0 15px;
       }
 
-      .vert > .xblock-student_view.is-hidden {
+      .vert > .xblock-student_view.is-hidden,
+      .vert > .xblock-public_view.is-hidden {
         display: none;
         border-bottom: 0;
         margin-bottom: 0;
@@ -594,7 +596,8 @@ html.video-fullscreen {
       }
     }
 
-    section.xblock-student_view-wrapper div.vert-mod > div {
+    section.xblock-student_view-wrapper div.vert-mod > div,
+    section.xblock-public_view-wrapper div.vert-mod > div {
       border-bottom: none;
     }
 

--- a/openedx/features/course_experience/__init__.py
+++ b/openedx/features/course_experience/__init__.py
@@ -43,6 +43,10 @@ LATEST_UPDATE_FLAG = CourseWaffleFlag(WAFFLE_FLAG_NAMESPACE, 'latest_update')
 # Waffle flag to enable the use of Bootstrap for course experience pages
 USE_BOOTSTRAP_FLAG = CourseWaffleFlag(WAFFLE_FLAG_NAMESPACE, 'use_bootstrap', flag_undefined_default=True)
 
+# Waffle flag to enable anonymous access to a course
+SEO_WAFFLE_FLAG_NAMESPACE = WaffleFlagNamespace(name='seo')
+COURSE_ENABLE_UNENROLLED_ACCESS_FLAG = CourseWaffleFlag(SEO_WAFFLE_FLAG_NAMESPACE, 'enable_anonymous_courseware_access')
+
 
 def course_home_page_title(course):  # pylint: disable=unused-argument
     """

--- a/openedx/features/course_experience/templates/course_experience/course-outline-fragment.html
+++ b/openedx/features/course_experience/templates/course_experience/course-outline-fragment.html
@@ -51,7 +51,7 @@ course_sections = blocks.get('children')
                 completed_prereqs = gated_content[subsection['id']]['completed_prereqs'] if gated_subsection else False
                 subsection_is_auto_opened = subsection.get('resume_block') is True
                 %>
-                      <li class="subsection accordion ${ 'current' if subsection['resume_block'] else '' }">
+                      <li class="subsection accordion ${ 'current' if subsection.get('resume_block') else '' }">
                 % if gated_subsection and not completed_prereqs:
                                 <a href="${ subsection['lms_web_url'] }">
                                     <button class="subsection-text prerequisite-button"
@@ -153,7 +153,11 @@ course_sections = blocks.get('children')
                     % for vertical in subsection.get('children', []):
                                     <li class="vertical outline-item focusable">
                                         <a class="outline-item focusable"
-                                            href="${ vertical['lms_web_url'] }"
+                                            % if enable_links:
+                                                href="${ vertical['lms_web_url'] }"
+                                            % else:
+                                                aria-disabled="true"
+                                            % endif
                                             id="${ vertical['id'] }">
                                             <div class="vertical-details">
                                               <div class="vertical-title">

--- a/openedx/features/course_experience/tests/views/test_course_home.py
+++ b/openedx/features/course_experience/tests/views/test_course_home.py
@@ -27,11 +27,13 @@ from openedx.features.course_duration_limits.config import CONTENT_TYPE_GATING_F
 from openedx.features.course_experience import (
     SHOW_REVIEWS_TOOL_FLAG,
     SHOW_UPGRADE_MSG_ON_COURSE_HOME,
-    UNIFIED_COURSE_TAB_FLAG
+    UNIFIED_COURSE_TAB_FLAG,
+    COURSE_ENABLE_UNENROLLED_ACCESS_FLAG,
 )
 from student.models import CourseEnrollment
 from student.tests.factories import UserFactory
 from util.date_utils import strftime_localized
+from xmodule.course_module import COURSE_VISIBILITY_PRIVATE, COURSE_VISIBILITY_PUBLIC_OUTLINE, COURSE_VISIBILITY_PUBLIC
 from xmodule.modulestore import ModuleStoreEnum
 from xmodule.modulestore.tests.django_utils import CourseUserType, ModuleStoreTestCase, SharedModuleStoreTestCase
 from xmodule.modulestore.tests.factories import CourseFactory, ItemFactory, check_mongo_calls
@@ -222,37 +224,56 @@ class TestCourseHomePageAccess(CourseHomePageTestCase):
 
     @override_waffle_flag(SHOW_REVIEWS_TOOL_FLAG, active=True)
     @ddt.data(
-        [CourseUserType.ANONYMOUS, 'To see course content'],
-        [CourseUserType.ENROLLED, None],
-        [CourseUserType.UNENROLLED, 'You must be enrolled in the course to see course content.'],
-        [CourseUserType.UNENROLLED_STAFF, 'You must be enrolled in the course to see course content.'],
+        [False, COURSE_VISIBILITY_PRIVATE, CourseUserType.ANONYMOUS, True],
+        [False, COURSE_VISIBILITY_PUBLIC_OUTLINE, CourseUserType.ANONYMOUS, True],
+        [False, COURSE_VISIBILITY_PUBLIC, CourseUserType.ANONYMOUS, True],
+        [False, COURSE_VISIBILITY_PRIVATE, CourseUserType.ENROLLED, False],
+        [False, COURSE_VISIBILITY_PRIVATE, CourseUserType.UNENROLLED, True],
+        [False, COURSE_VISIBILITY_PRIVATE, CourseUserType.UNENROLLED_STAFF, True],
+        [True, COURSE_VISIBILITY_PRIVATE, CourseUserType.ANONYMOUS, True],
+        [True, COURSE_VISIBILITY_PUBLIC_OUTLINE, CourseUserType.ANONYMOUS, True],
+        [True, COURSE_VISIBILITY_PUBLIC, CourseUserType.ANONYMOUS, True],
+        [True, COURSE_VISIBILITY_PRIVATE, CourseUserType.UNENROLLED, True],
+        [True, COURSE_VISIBILITY_PUBLIC_OUTLINE, CourseUserType.UNENROLLED, True],
+        [True, COURSE_VISIBILITY_PUBLIC, CourseUserType.UNENROLLED, True],
     )
     @ddt.unpack
-    def test_home_page(self, user_type, expected_message):
+    def test_home_page(self, enable_unenrolled_access, course_visibility, user_type, expected_message):
         self.create_user_for_course(self.course, user_type)
 
         # Render the course home page
-        url = course_home_url(self.course)
-        response = self.client.get(url)
+        with mock.patch('xmodule.course_module.CourseDescriptor.course_visibility', course_visibility):
+            # Test access with anonymous flag and course visibility
+            with override_waffle_flag(COURSE_ENABLE_UNENROLLED_ACCESS_FLAG, enable_unenrolled_access):
+                url = course_home_url(self.course)
+                response = self.client.get(url)
 
         # Verify that the course tools and dates are always shown
         self.assertContains(response, 'Course Tools')
         self.assertContains(response, 'Today is')
 
-        # Verify that the outline, start button, course sock, and welcome message
+        # Verify that start button, course sock, and welcome message
         # are only shown to enrolled users.
         is_enrolled = user_type is CourseUserType.ENROLLED
         is_unenrolled_staff = user_type is CourseUserType.UNENROLLED_STAFF
-        expected_count = 1 if (is_enrolled or is_unenrolled_staff) else 0
-        self.assertContains(response, TEST_CHAPTER_NAME, count=expected_count)
-        self.assertContains(response, 'Start Course', count=expected_count)
+        expected_welcome = 1 if (is_enrolled or is_unenrolled_staff) else 0
+        self.assertContains(response, 'Start Course', count=expected_welcome)
         self.assertContains(response, 'Learn About Verified Certificate', count=(1 if is_enrolled else 0))
-        self.assertContains(response, TEST_WELCOME_MESSAGE, count=expected_count)
+        self.assertContains(response, TEST_WELCOME_MESSAGE, count=expected_welcome)
+
+        # Verify the outline is shown to enrolled users, unenrolled_staff and anonymous users if allowed
+        is_public = course_visibility == COURSE_VISIBILITY_PUBLIC and enable_unenrolled_access
+        is_public_outline = course_visibility == COURSE_VISIBILITY_PUBLIC_OUTLINE and enable_unenrolled_access
+        expected_chapter = 1 if (is_public or is_public_outline) else expected_welcome
+        self.assertContains(response, TEST_CHAPTER_NAME, count=expected_chapter)
 
         # Verify that the expected message is shown to the user
+        self.assertContains(
+            response, 'To see course content', count=1 if user_type is CourseUserType.ANONYMOUS else 0
+        )
         self.assertContains(response, '<div class="user-messages">', count=1 if expected_message else 0)
         if expected_message:
-            self.assertContains(response, expected_message)
+            self.assertContains(response, 'You must be enrolled in the course to see course content.')
 
     @override_waffle_flag(UNIFIED_COURSE_TAB_FLAG, active=False)
     @override_waffle_flag(SHOW_REVIEWS_TOOL_FLAG, active=True)

--- a/openedx/features/course_experience/utils.py
+++ b/openedx/features/course_experience/utils.py
@@ -11,10 +11,12 @@ from xmodule.modulestore.django import modulestore
 
 
 @request_cached()
-def get_course_outline_block_tree(request, course_id):
+def get_course_outline_block_tree(request, course_id, user=None):
     """
     Returns the root block of the course outline, with children as blocks.
     """
+
+    assert user is None or user.is_authenticated
 
     def populate_children(block, all_blocks):
         """
@@ -156,13 +158,13 @@ def get_course_outline_block_tree(request, course_id):
     course_outline_root_block = all_blocks['blocks'].get(all_blocks['root'], None)
     if course_outline_root_block:
         populate_children(course_outline_root_block, all_blocks['blocks'])
-        set_last_accessed_default(course_outline_root_block)
-
-        mark_blocks_completed(
-            block=course_outline_root_block,
-            user=request.user,
-            course_key=course_key
-        )
+        if user:
+            set_last_accessed_default(course_outline_root_block)
+            mark_blocks_completed(
+                block=course_outline_root_block,
+                user=request.user,
+                course_key=course_key
+            )
     return course_outline_root_block
 
 

--- a/openedx/features/course_experience/views/course_home.py
+++ b/openedx/features/course_experience/views/course_home.py
@@ -28,8 +28,11 @@ from openedx.core.djangoapps.util.maintenance_banner import add_maintenance_bann
 from openedx.features.course_experience.course_tools import CourseToolsPluginManager
 from student.models import CourseEnrollment
 from util.views import ensure_valid_course_key
+from xmodule.course_module import COURSE_VISIBILITY_PUBLIC_OUTLINE, COURSE_VISIBILITY_PUBLIC
 
-from .. import LATEST_UPDATE_FLAG, SHOW_UPGRADE_MSG_ON_COURSE_HOME, USE_BOOTSTRAP_FLAG
+from .. import (
+    LATEST_UPDATE_FLAG, SHOW_UPGRADE_MSG_ON_COURSE_HOME, USE_BOOTSTRAP_FLAG, COURSE_ENABLE_UNENROLLED_ACCESS_FLAG
+)
 from ..utils import get_course_outline_block_tree, get_resume_block
 from .course_dates import CourseDatesFragmentView
 from .course_home_messages import CourseHomeMessageFragmentView
@@ -83,7 +86,7 @@ class CourseHomeFragmentView(EdxFragmentView):
                 otherwise the URL of the course root.
 
         """
-        course_outline_root_block = get_course_outline_block_tree(request, course_id)
+        course_outline_root_block = get_course_outline_block_tree(request, course_id, request.user)
         resume_block = get_resume_block(course_outline_root_block) if course_outline_root_block else None
         has_visited_course = bool(resume_block)
         if resume_block:
@@ -117,11 +120,26 @@ class CourseHomeFragmentView(EdxFragmentView):
         enrollment = CourseEnrollment.get_enrollment(request.user, course_key)
         user_access = {
             'is_anonymous': request.user.is_anonymous,
-            'is_enrolled': enrollment is not None,
+            'is_enrolled': enrollment and enrollment.is_active,
             'is_staff': has_access(request.user, 'staff', course_key),
         }
+
+        allow_anonymous = COURSE_ENABLE_UNENROLLED_ACCESS_FLAG.is_enabled(course_key)
+        allow_public = allow_anonymous and course.course_visibility == COURSE_VISIBILITY_PUBLIC
+        allow_public_outline = allow_anonymous and course.course_visibility == COURSE_VISIBILITY_PUBLIC_OUTLINE
+
+        # Set all the fragments
+        outline_fragment = None
+        update_message_fragment = None
+        course_sock_fragment = None
+        has_visited_course = None
+        resume_course_url = None
+        handouts_html = None
+
         if user_access['is_enrolled'] or user_access['is_staff']:
-            outline_fragment = CourseOutlineFragmentView().render_to_fragment(request, course_id=course_id, **kwargs)
+            outline_fragment = CourseOutlineFragmentView().render_to_fragment(
+                request, course_id=course_id, **kwargs
+            )
             if LATEST_UPDATE_FLAG.is_enabled(course_key):
                 update_message_fragment = LatestUpdateFragmentView().render_to_fragment(
                     request, course_id=course_id, **kwargs
@@ -132,21 +150,17 @@ class CourseHomeFragmentView(EdxFragmentView):
                 )
             course_sock_fragment = CourseSockFragmentView().render_to_fragment(request, course=course, **kwargs)
             has_visited_course, resume_course_url = self._get_resume_course_info(request, course_id)
+            handouts_html = self._get_course_handouts(request, course)
+        elif allow_public_outline or allow_public:
+            outline_fragment = CourseOutlineFragmentView().render_to_fragment(
+                request, course_id=course_id, user_is_enrolled=False, **kwargs
+            )
+            course_sock_fragment = CourseSockFragmentView().render_to_fragment(request, course=course, **kwargs)
         else:
             # Redirect the user to the dashboard if they are not enrolled and
             # this is a course that does not support direct enrollment.
             if not can_self_enroll_in_course(course_key):
                 raise CourseAccessRedirect(reverse('dashboard'))
-
-            # Set all the fragments
-            outline_fragment = None
-            update_message_fragment = None
-            course_sock_fragment = None
-            has_visited_course = None
-            resume_course_url = None
-
-        # Get the handouts
-        handouts_html = self._get_course_handouts(request, course)
 
         # Get the course tools enabled for this user and course
         course_tools = CourseToolsPluginManager.get_enabled_course_tools(request, course_key)

--- a/openedx/features/course_experience/views/course_outline.py
+++ b/openedx/features/course_experience/views/course_outline.py
@@ -18,6 +18,7 @@ from openedx.core.djangoapps.plugin_api.views import EdxFragmentView
 from student.models import CourseEnrollment
 
 from util.milestones_helpers import get_course_content_milestones
+from xmodule.course_module import COURSE_VISIBILITY_PUBLIC
 from xmodule.modulestore.django import modulestore
 from ..utils import get_course_outline_block_tree, get_resume_block
 
@@ -30,15 +31,19 @@ class CourseOutlineFragmentView(EdxFragmentView):
     Course outline fragment to be shown in the unified course view.
     """
 
-    def render_to_fragment(self, request, course_id=None, page_context=None, **kwargs):
+    def render_to_fragment(self, request, course_id, user_is_enrolled=True, **kwargs):  # pylint: disable=arguments-differ
         """
         Renders the course outline as a fragment.
         """
         course_key = CourseKey.from_string(course_id)
-        course_overview = get_course_overview_with_access(request.user, 'load', course_key, check_if_enrolled=True)
+        course_overview = get_course_overview_with_access(
+            request.user, 'load', course_key, check_if_enrolled=user_is_enrolled
+        )
         course = modulestore().get_course(course_key)
 
-        course_block_tree = get_course_outline_block_tree(request, course_id)
+        course_block_tree = get_course_outline_block_tree(
+            request, course_id, request.user if user_is_enrolled else None
+        )
         if not course_block_tree:
             return None
 
@@ -46,10 +51,12 @@ class CourseOutlineFragmentView(EdxFragmentView):
             'csrf': csrf(request)['csrf_token'],
             'course': course_overview,
             'due_date_display_format': course.due_date_display_format,
-            'blocks': course_block_tree
+            'blocks': course_block_tree,
+            'enable_links': user_is_enrolled or course.course_visibility == COURSE_VISIBILITY_PUBLIC,
         }
 
-        resume_block = get_resume_block(course_block_tree)
+        resume_block = get_resume_block(course_block_tree) if user_is_enrolled else None
+
         if not resume_block:
             self.mark_first_unit_to_resume(course_block_tree)
 


### PR DESCRIPTION
This PR is part of a series of work to improve the ability for unenrolled (including anonymous) users to access parts of the course outline and course content. The proposal for this work was discussed in https://github.com/edx/edx-platform/pull/18134.

The PR includes the following changes:
- When the course waffle flag enable_anonymous_access is enabled a Course Advanced Setting "Course Visibility For Unenrolled Learners". The default value for this setting is `private` but it can also be changed to `preview` and `public`.
- If it is set to `private` or the waffle flag is not enabled the course works like it does now.
- If it is set to `preview` the course outline becomes accessible to unenrolled users.
- If it is set to `public` both the course outline and courseware become accessible to unenrolled users.
- A new XBlock view `preview_view` has been added to the sequential, vertical and html blocks. When an unenrolled user visits courseware, this view is used instead of `student_view`. If a block does not implement this a default message is shown. Support to video block will be added in a future PR.

Sandbox (standard user accounts are available):
- [Course set to public](https://pr18720.sandbox.opencraft.hosting/courses/course-v1:OpenCraft+CA101+2018_S2/course/)
- [Course set to preview](https://pr18720.sandbox.opencraft.hosting/courses/course-v1:OpenCraft+Preview+2018_3/course/)