### PR TITLE
Deprecate YT for existing courses

### DIFF
--- a/cms/djangoapps/contentstore/views/tests/test_videos.py
+++ b/cms/djangoapps/contentstore/views/tests/test_videos.py
@@ -14,7 +14,6 @@ import dateutil.parser
 import ddt
 import pytz
 from django.conf import settings
-from django.core.files.uploadedfile import UploadedFile
 from django.test.utils import override_settings
 from edxval.api import (
     create_profile,
@@ -37,7 +36,7 @@ from contentstore.views.videos import (
 from contentstore.views.videos import KEY_EXPIRATION_IN_SECONDS, StatusDisplayStrings, convert_video_status
 from xmodule.modulestore.tests.factories import CourseFactory
 
-from openedx.core.djangoapps.video_pipeline.config.waffle import DEPRECATE_YOUTUBE
+from openedx.core.djangoapps.video_pipeline.config.waffle import waffle_flags, DEPRECATE_YOUTUBE
 from openedx.core.djangoapps.profile_images.tests.helpers import make_image_file
 from openedx.core.djangoapps.waffle_utils.models import WaffleFlagCourseOverrideModel
 
@@ -583,8 +582,9 @@ class VideosHandlerTestCase(VideoUploadTestMixin, CourseTestCase):
         # expected args to be passed to `set_metadata`.
         expected_args = ('course_video_upload_token', self.test_token)
 
+        DEPRECATE_YOUTUBE_FLAG = waffle_flags()[DEPRECATE_YOUTUBE]
         with patch.object(WaffleFlagCourseOverrideModel, 'override_value', return_value=data['course_override']):
-            with override_flag(DEPRECATE_YOUTUBE, active=data['global_waffle']):
+            with override_flag(DEPRECATE_YOUTUBE_FLAG.namespaced_flag_name, active=data['global_waffle']):
                 response = self.client.post(
                     self.url,
                     json.dumps({'files': [file_data]}),

--- a/common/lib/xmodule/xmodule/video_module/video_module.py
+++ b/common/lib/xmodule/xmodule/video_module/video_module.py
@@ -15,18 +15,16 @@ Examples of html5 videos for manual testing:
 import copy
 import json
 import logging
-import random
 from collections import defaultdict, OrderedDict
 from operator import itemgetter
 
 from pkg_resources import resource_string
 
 from django.conf import settings
-from django.utils.functional import cached_property
 from lxml import etree
 from opaque_keys.edx.locator import AssetLocator
 from openedx.core.djangoapps.video_config.models import HLSPlaybackEnabledFlag
-from openedx.core.djangoapps.waffle_utils import WaffleFlagNamespace, CourseWaffleFlag
+from openedx.core.djangoapps.video_pipeline.config.waffle import waffle_flags, DEPRECATE_YOUTUBE
 from openedx.core.lib.cache_utils import memoize_in_request_cache
 from openedx.core.lib.license import LicenseMixin
 from xblock.completable import XBlockCompletionMode
@@ -46,7 +44,6 @@ from xmodule.xml_module import deserialize_field, is_pointer_tag, name_to_pathna
 from .bumper_utils import bumperize
 from .transcripts_utils import (
     get_html5_ids,
-    get_video_ids_info,
     Transcript,
     VideoTranscriptsMixin,
     clean_video_id,
@@ -99,12 +96,6 @@ log = logging.getLogger(__name__)
 # Make '_' a no-op so we can scrape strings. Using lambda instead of
 #  `django.utils.translation.ugettext_noop` because Django cannot be imported in this file
 _ = lambda text: text
-
-# Waffle flags namespace for videos
-WAFFLE_VIDEOS_NAMESPACE = 'videos'
-
-# Waffle flag to enable/disable hls as primary playback
-DEPRECATE_YOUTUBE = 'deprecate_youtube'
 
 EXPORT_IMPORT_COURSE_DIR = u'course'
 EXPORT_IMPORT_STATIC_DIR = u'static'
@@ -189,7 +180,7 @@ class VideoModule(VideoFields, VideoTranscriptsMixin, VideoStudentViewHandlers, 
         sorted_languages = OrderedDict(sorted_languages)
         return track_url, transcript_language, sorted_languages
 
-    @cached_property
+    @property
     def youtube_deprecated(self):
         """
         Return True if youtube is deprecated and hls as primary playback is enabled else False
@@ -198,11 +189,9 @@ class VideoModule(VideoFields, VideoTranscriptsMixin, VideoStudentViewHandlers, 
         if not HLSPlaybackEnabledFlag.feature_enabled(self.location.course_key):
             return False
 
-        # check if hls as primary playback is enabled for this course
-        return CourseWaffleFlag(
-            WaffleFlagNamespace(name=WAFFLE_VIDEOS_NAMESPACE),
-            DEPRECATE_YOUTUBE
-        ).is_enabled(self.location.course_key)
+        # check if youtube has been deprecated and hls as primary playback
+        # is enabled for this course
+        return waffle_flags()[DEPRECATE_YOUTUBE].is_enabled(self.location.course_key)
 
     def prioritize_hls(self, youtube_streams, html5_sources):
         """

--- a/lms/djangoapps/courseware/tests/test_video_mongo.py
+++ b/lms/djangoapps/courseware/tests/test_video_mongo.py
@@ -35,6 +35,7 @@ from path import Path as path
 
 from openedx.core.lib.tests import attr
 from openedx.core.djangoapps.waffle_utils.models import WaffleFlagCourseOverrideModel
+from openedx.core.djangoapps.video_pipeline.config.waffle import waffle_flags, DEPRECATE_YOUTUBE
 from waffle.testutils import override_flag
 from xmodule.contentstore.content import StaticContent
 from xmodule.exceptions import NotFoundError
@@ -48,8 +49,6 @@ from xmodule.video_module.transcripts_utils import Transcript, save_to_store, su
 from xmodule.video_module.video_module import (
     EXPORT_IMPORT_COURSE_DIR,
     EXPORT_IMPORT_STATIC_DIR,
-    DEPRECATE_YOUTUBE,
-    WAFFLE_VIDEOS_NAMESPACE,
 )
 from xmodule.x_module import STUDENT_VIEW
 
@@ -61,8 +60,6 @@ MODULESTORES = {
     ModuleStoreEnum.Type.mongo: TEST_DATA_MONGO_MODULESTORE,
     ModuleStoreEnum.Type.split: TEST_DATA_SPLIT_MODULESTORE,
 }
-
-DEPRECATE_YOUTUBE_FLAG = '{}.{}'.format(WAFFLE_VIDEOS_NAMESPACE, DEPRECATE_YOUTUBE)
 
 TRANSCRIPT_FILE_SRT_DATA = u"""
 1
@@ -1057,8 +1054,9 @@ class TestGetHtmlMethod(BaseTestXmodule):
         video_xml = '<video display_name="Video" edx_video_id="12345-67890" youtube_id_1_0="{}">[]</video>'.format(
             data['youtube']
         )
+        DEPRECATE_YOUTUBE_FLAG = waffle_flags()[DEPRECATE_YOUTUBE]
         with patch.object(WaffleFlagCourseOverrideModel, 'override_value', return_value=data['course_override']):
-            with override_flag(DEPRECATE_YOUTUBE_FLAG, active=data['waffle_enabled']):
+            with override_flag(DEPRECATE_YOUTUBE_FLAG.namespaced_flag_name, active=data['waffle_enabled']):
                 self.initialize_module(data=video_xml, metadata=metadata)
                 context = self.item_descriptor.render(STUDENT_VIEW).content
                 self.assertIn('"prioritizeHls": {}'.format(data['result']), context)

--- a/openedx/core/djangoapps/video_pipeline/config/waffle.py
+++ b/openedx/core/djangoapps/video_pipeline/config/waffle.py
@@ -1,0 +1,24 @@
+"""
+This module contains configuration settings via waffle flags
+for the Video Pipeline app.
+"""
+from openedx.core.djangoapps.waffle_utils import WaffleFlagNamespace, CourseWaffleFlag
+
+# Videos Namespace
+WAFFLE_NAMESPACE = 'videos'
+
+# Waffle flag telling whether youtube is deprecated.
+DEPRECATE_YOUTUBE = 'deprecate_youtube'
+
+
+def waffle_flags():
+    """
+    Returns the namespaced, cached, audited Waffle flags dictionary for Videos.
+    """
+    namespace = WaffleFlagNamespace(name=WAFFLE_NAMESPACE, log_prefix=u'Videos: ')
+    return {
+        DEPRECATE_YOUTUBE: CourseWaffleFlag(
+            waffle_namespace=namespace,
+            flag_name=DEPRECATE_YOUTUBE
+        )
+    }


### PR DESCRIPTION
## [EDUCATOR-3110](https://openedx.atlassian.net/browse/EDUCATOR-3110) 

This can be done by switching to the "new video workflow" for existing YT courses.