### PR TITLE
set x_frame_option to deny in lms common env

### DIFF
--- a/lms/djangoapps/branding/tests/test_page.py
+++ b/lms/djangoapps/branding/tests/test_page.py
@@ -72,22 +72,22 @@ class AnonymousIndexPageTest(ModuleStoreTestCase):
         response = self.client.get('/')
         self.assertEqual(response.status_code, 200)
 
+    @override_settings(X_FRAME_OPTIONS='ALLOW')
     def test_allow_x_frame_options(self):
         """
         Check the x-frame-option response header
         """
 
-        # check to see that the default setting is to ALLOW iframing
+        # check to see that the override value is honored
         resp = self.client.get('/')
         self.assertEquals(resp['X-Frame-Options'], 'ALLOW')
 
-    @override_settings(X_FRAME_OPTIONS='DENY')
     def test_deny_x_frame_options(self):
         """
         Check the x-frame-option response header
         """
 
-        # check to see that the override value is honored
+        # check to see that the default setting is to DENY iframing
         resp = self.client.get('/')
         self.assertEquals(resp['X-Frame-Options'], 'DENY')
 

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -1302,8 +1302,8 @@ MIDDLEWARE_CLASSES = [
     'openedx.core.djangoapps.site_configuration.middleware.SessionCookieDomainOverrideMiddleware',
 ]
 
-# Clickjacking protection can be enabled by setting this to 'DENY'
-X_FRAME_OPTIONS = 'ALLOW'
+# Clickjacking protection can be disbaled by setting this to 'ALLOW'
+X_FRAME_OPTIONS = 'DENY'
 
 # Platform for Privacy Preferences header
 P3P_HEADER = 'CP="Open EdX does not have a P3P policy."'


### PR DESCRIPTION
## [EDUCATOR-3074](https://openedx.atlassian.net/browse/)

### Description

Setting x_frame_options to 'DENY' in common lms environment. This is one of the work required in mentioned ticket. Prod configuration for lms has been changed in another configuration PR.


### Reviewers
- [x] @awaisdar001 
- [x] @asadazam93 
 
### Post-review
- [ ] Rebase and squash commits