### PR TITLE
Add ModelAdmin for UserRetirementPartnerReportingStatus

### DIFF
--- a/openedx/core/djangoapps/user_api/admin.py
+++ b/openedx/core/djangoapps/user_api/admin.py
@@ -3,7 +3,7 @@ Django admin configuration pages for the user_api app
 """
 from django.contrib import admin
 
-from .models import RetirementState, UserRetirementStatus, UserRetirementRequest
+from .models import UserRetirementPartnerReportingStatus, RetirementState, UserRetirementStatus, UserRetirementRequest
 
 
 @admin.register(RetirementState)
@@ -22,7 +22,7 @@ class RetirementStateAdmin(admin.ModelAdmin):
 @admin.register(UserRetirementStatus)
 class UserRetirementStatusAdmin(admin.ModelAdmin):
     """
-    Admin interface for the UserRetirementStatusAdmin model.
+    Admin interface for the UserRetirementStatus model.
     """
     list_display = ('user', 'original_username', 'current_state', 'modified')
     list_filter = ('current_state',)
@@ -36,10 +36,54 @@ class UserRetirementStatusAdmin(admin.ModelAdmin):
 @admin.register(UserRetirementRequest)
 class UserRetirementRequestAdmin(admin.ModelAdmin):
     """
-    Admin interface for the UserRetirementRequestAdmin model.
+    Admin interface for the UserRetirementRequest model.
     """
     list_display = ('user', 'created')
     raw_id_fields = ('user',)
 
     class Meta(object):
         model = UserRetirementRequest
+
+
+@admin.register(UserRetirementPartnerReportingStatus)
+class UserRetirementPartnerReportingStatusAdmin(admin.ModelAdmin):
+    """
+    Admin interface for the UserRetirementPartnerReportingStatus model.
+    """
+    list_display = (
+        'user_id',  # See user_id() below.
+        'original_username',
+        'is_being_processed',
+        'modified',
+    )
+    list_filter = ('is_being_processed',)
+    raw_id_fields = ('user',)
+    search_fields = ('user__id', 'original_username', 'original_email', 'original_name')
+    actions = [
+        'reset_state',  # See reset_state() below.
+    ]
+
+    class Meta(object):
+        model = UserRetirementPartnerReportingStatus
+
+    def user_id(self, obj):
+        """
+        List display for the user_id field.
+
+        This is an alternative to listing the "user" field directly, since that would print the retired (hashed)
+        username which isn't super helpful.
+        """
+        return obj.user.id
+
+    def reset_state(self, request, queryset):
+        """
+        Action callback for bulk resetting is_being_processed to False (0).
+        """
+        rows_updated = queryset.update(is_being_processed=0)
+        if rows_updated == 1:
+            message_bit = "one user was"
+        else:
+            message_bit = "%s users were" % rows_updated
+        self.message_user(request, "%s successfully reset." % message_bit)
+
+    reset_state.short_description = 'Reset is_being_processed to False'


### PR DESCRIPTION
Primarily, this was added for convenient bulk moving of processing
states from True to False without having to incur the round-trip
duration of a devops support ticket (in which they run SQL on our
behalf).

---

devstack testing:

1. hovering over the bulk action after selecting two rows:
![2018-08-07-162535_1366x768_scrot](https://user-images.githubusercontent.com/85151/43800613-dcaecb8e-9a5e-11e8-978d-cd059b7c8b6e.png)
2. result after clicking Go:
![2018-08-07-162555_1366x768_scrot](https://user-images.githubusercontent.com/85151/43800612-dc9a2f12-9a5e-11e8-9e47-594c79c50846.png)