### PR TITLE
Fixes unnecessary error reporting by screen reader

### DIFF
--- a/lms/static/js/student_account/views/RegisterView.js
+++ b/lms/static/js/student_account/views/RegisterView.js
@@ -327,8 +327,10 @@
                         error = isCheckbox ? '' : decisions.validation_decisions[name];
 
                     if (hasError && this.negativeValidationEnabled) {
+                        this.addValidationErrorMsgForScreenReader($el);
                         this.renderLiveValidationError($el, $label, $requiredTextLabel, $icon, $errorTip, error);
                     } else if (this.positiveValidationEnabled) {
+                        this.removeValidationErrorMsgForScreenReader($el);
                         this.renderLiveValidationSuccess($el, $label, $requiredTextLabel, $icon, $errorTip);
                     }
                 },
@@ -339,6 +341,16 @@
 
                 getIcon: function($el) {
                     return $('#' + $el.attr('id') + '-validation-icon');
+                },
+
+                addValidationErrorMsgForScreenReader: function($el) {
+                    var $validation_node =  this.$form.find('#' + $el.attr('id') + '-validation-error');
+                    $validation_node.find('.sr-only').text('ERROR:');
+                },
+
+                removeValidationErrorMsgForScreenReader: function($el) {
+                    var $validation_node =  this.$form.find('#' + $el.attr('id') + '-validation-error');
+                    $validation_node.find('.sr-only').text('');
                 },
 
                 getErrorTip: function($el) {

--- a/lms/templates/student_account/form_field.underscore
+++ b/lms/templates/student_account/form_field.underscore
@@ -39,7 +39,7 @@
             <% }); %>
         </select>
         <span id="<%- form %>-<%- name %>-validation-error" class="tip error" aria-live="assertive">
-            <span class="sr-only">ERROR: </span>
+            <span class="sr-only"></span>
             <span id="<%- form %>-<%- name %>-validation-error-msg"></span>
         </span>
         <% if ( instructions ) { %> <span class="tip tip-input" id="<%- form %>-<%- name %>-desc"><%- instructions %></span><% } %>
@@ -65,7 +65,7 @@
             } %>
             <% if ( required ) { %> aria-required="true" required<% } %>></textarea>
         <span id="<%- form %>-<%- name %>-validation-error" class="tip error" aria-live="assertive">
-            <span class="sr-only">ERROR: </span>
+            <span class="sr-only"></span>
             <span id="<%- form %>-<%- name %>-validation-error-msg"></span>
         </span>
         <% if ( instructions ) { %> <span class="tip tip-input" id="<%- form %>-<%- name %>-desc"><%- instructions %></span><% } %>
@@ -126,7 +126,7 @@
         <% } %>
 
         <span id="<%- form %>-<%- name %>-validation-error" class="tip error" aria-live="assertive">
-            <span class="sr-only">ERROR: </span>
+            <span class="sr-only"></span>
             <span id="<%- form %>-<%- name %>-validation-error-msg"></span>
         </span>
         <% if ( instructions ) { %> <span class="tip tip-input" id="<%- form %>-<%- name %>-desc"><%- instructions %></span><% } %>


### PR DESCRIPTION
This patch would inject error message dynamically for
screen readers only when there is an error state. In
normal flow screen reader would not be reporting any
errors to users.

LEARNER-5865