### PR TITLE
Stop username re-use, update retirement for multiple UserRetirementStatuses

### DIFF
--- a/common/djangoapps/student/models.py
+++ b/common/djangoapps/student/models.py
@@ -212,7 +212,14 @@ def is_username_retired(username):
         settings.RETIRED_USERNAME_FMT
     )
 
-    return User.objects.filter(username__in=list(locally_hashed_usernames)).exists()
+    # TODO: Revert to this after username capitalization issues detailed in
+    # PLAT-2276, PLAT-2277, PLAT-2278 are sorted out:
+    # return User.objects.filter(username__in=list(locally_hashed_usernames)).exists()
+
+    # Avoid circular import issues
+    from openedx.core.djangoapps.user_api.models import UserRetirementStatus
+    return User.objects.filter(username__in=list(locally_hashed_usernames)).exists() or \
+        UserRetirementStatus.objects.filter(original_username=username).exists()
 
 
 def is_email_retired(email):
@@ -293,7 +300,27 @@ def get_potentially_retired_user_by_username(username):
     """
     locally_hashed_usernames = list(get_all_retired_usernames_by_username(username))
     locally_hashed_usernames.append(username)
-    return User.objects.get(username__in=locally_hashed_usernames)
+    potential_users = User.objects.filter(username__in=locally_hashed_usernames)
+
+    # Have to disambiguate between several Users here as we could have retirees with
+    # the same username, but for case.
+    # If there's only 1 we're done, this should be the common case
+    if len(potential_users) == 1:
+        return potential_users[0]
+
+    # No user found, throw the usual error
+    if not potential_users:
+        raise User.DoesNotExist()
+
+    # If there are 2, one of two things should be true:
+    # - The user we want is un-retired and has the same case-match username
+    # - Or retired one was the case-match
+    if len(potential_users) == 2:
+        return potential_users[0] if potential_users[0].username == username else potential_users[1]
+
+    # We should have, at most, a retired username and an active one with a username
+    # differing only by case. If there are more we need to disambiguate them by hand.
+    raise Exception('Expected 1 or 2 Users, received {}'.format(text_type(potential_users)))
 
 
 def get_potentially_retired_user_by_username_and_hash(username, hashed_username):

--- a/openedx/core/djangoapps/user_api/accounts/views.py
+++ b/openedx/core/djangoapps/user_api/accounts/views.py
@@ -788,7 +788,7 @@ class AccountRetirementStatusView(ViewSet):
             retirement = None
             if len(retirements) < 1:
                 raise UserRetirementStatus.DoesNotExist()
-            elif len(retirements) > 1:
+            elif len(retirements) >= 1:
                 for r in retirements:
                     if r.original_username == username:
                         retirement = r
@@ -796,10 +796,6 @@ class AccountRetirementStatusView(ViewSet):
                 # UserRetirementStatus was found, but it was the wrong case.
                 if retirement is None:
                     raise UserRetirementStatus.DoesNotExist()
-            else:
-                if username != retirements[0].original_username:
-                    raise UserRetirementStatus.DoesNotExist()
-                retirement = retirements[0]
 
             retirement.update_state(request.data)
             return Response(status=status.HTTP_204_NO_CONTENT)

--- a/openedx/core/djangoapps/user_api/accounts/views.py
+++ b/openedx/core/djangoapps/user_api/accounts/views.py
@@ -624,9 +624,23 @@ class AccountRetirementPartnerReportView(ViewSet):
             original_username__in=usernames
         )
 
-        if len(usernames) != len(retirement_statuses):
+        # Need to de-dupe usernames that differ only by case to find the exact right match
+        retirement_statuses_clean = [rs for rs in retirement_statuses if rs.original_username in usernames]
+
+        # During a narrow window learners were able to re-use a username that had been retired if
+        # they altered the capitalization of one or more characters. Therefore we can have more
+        # than one row returned here (due to our MySQL collation being case-insensitive), and need
+        # to disambiguate them in Python, which will respect case in the comparison.
+        if len(usernames) != len(retirement_statuses_clean):
             return Response(
-                '{} original_usernames given, only {} found!'.format(len(usernames), len(retirement_statuses)),
+                '{} original_usernames given, {} found!\n'
+                'Given usernames:\n{}\n'
+                'Found UserRetirementReportingStatuses:\n{}'.format(
+                    len(usernames),
+                    len(retirement_statuses_clean),
+                    usernames,
+                    ', '.join([rs.original_username for rs in retirement_statuses_clean])
+                ),
                 status=status.HTTP_400_BAD_REQUEST
             )
 
@@ -765,7 +779,28 @@ class AccountRetirementStatusView(ViewSet):
         """
         try:
             username = request.data['username']
-            retirement = UserRetirementStatus.objects.get(original_username=username)
+            retirements = UserRetirementStatus.objects.filter(original_username=username)
+
+            # During a narrow window learners were able to re-use a username that had been retired if
+            # they altered the capitalization of one or more characters. Therefore we can have more
+            # than one row returned here (due to our MySQL collation being case-insensitive), and need
+            # to disambiguate them in Python, which will respect case in the comparison.
+            retirement = None
+            if len(retirements) < 1:
+                raise UserRetirementStatus.DoesNotExist()
+            elif len(retirements) > 1:
+                for r in retirements:
+                    if r.original_username == username:
+                        retirement = r
+                        break
+                # UserRetirementStatus was found, but it was the wrong case.
+                if retirement is None:
+                    raise UserRetirementStatus.DoesNotExist()
+            else:
+                if username != retirements[0].original_username:
+                    raise UserRetirementStatus.DoesNotExist()
+                retirement = retirements[0]
+
             retirement.update_state(request.data)
             return Response(status=status.HTTP_204_NO_CONTENT)
         except UserRetirementStatus.DoesNotExist:

--- a/openedx/core/djangoapps/user_api/models.py
+++ b/openedx/core/djangoapps/user_api/models.py
@@ -335,7 +335,22 @@ class UserRetirementStatus(TimeStampedModel):
         Can raise UserRetirementStatus.DoesNotExist or RetirementStateError, otherwise should
         return a UserRetirementStatus
         """
-        retirement = cls.objects.get(original_username=username)
+        # During a narrow window learners were able to re-use a username that had been retired if
+        # they altered the capitalization of one or more characters. Therefore we can have more
+        # than one row returned here (due to our MySQL collation being case-insensitive), and need
+        # to disambiguate them in Python, which will respect case in the comparison.
+        retirements = cls.objects.filter(original_username=username)
+
+        retirement = None
+        for r in retirements:
+            if r.original_username == username:
+                retirement = r
+                break
+
+        if retirement is None:
+            raise UserRetirementStatus.DoesNotExist('{} does not have an exact match in UserRetirementStatus. '
+                                                    '{} similar rows found.'.format(username, len(retirements)))
+
         state = retirement.current_state
 
         if state.required or state.state_name.endswith('_COMPLETE'):


### PR DESCRIPTION
A bug in username retirement hashing caused people to be able to re-create retired usernames if they used a different upper-lower case in the name. This PR blocks that from happening and fixes the downstream retirement issues caused by the possibility of having multiple retired usernames that are the same except for case.