### PR TITLE
LEARNER-5989 Update eligible student record modes

### DIFF
--- a/openedx/core/djangoapps/credentials/signals.py
+++ b/openedx/core/djangoapps/credentials/signals.py
@@ -17,7 +17,7 @@ log = getLogger(__name__)
 
 
 # "interesting" here means "credentials will want to know about it"
-INTERESTING_MODES = CourseMode.VERIFIED_MODES + CourseMode.CREDIT_MODES
+INTERESTING_MODES = CourseMode.CREDIT_ELIGIBLE_MODES + CourseMode.CREDIT_MODES
 INTERESTING_STATUSES = [
     CertificateStatuses.notpassing,
     CertificateStatuses.downloadable,


### PR DESCRIPTION
Include no-id-professional as an interesting mode to credentials