### PR TITLE
Downgrade `gunicorn` and run `make upgrade`

### DIFF
--- a/requirements/edx/base.in
+++ b/requirements/edx/base.in
@@ -142,7 +142,7 @@ sorl-thumbnail==12.3                # Image thumbnail management
 sortedcontainers==0.9.2             # Provides SortedListWithKey, used for lists of XBlock assets
 stevedore                           # Support for runtime plugins, used for XBlocks and edx-platform Django app plugins
 unicodecsv                          # Easier support for CSV files with unicode text
-user-util                           # Functionality for retiring users (GDPR compliance)
+user-util==0.1.4                    # Functionality for retiring users (GDPR compliance)
 web-fragments                       # Provides the ability to render fragments of web pages
 XBlock                              # Courseware component architecture
 xblock-review                       # XBlock which displays problems from earlier in the course for ungraded retries

--- a/requirements/edx/base.in
+++ b/requirements/edx/base.in
@@ -91,7 +91,7 @@ fs==2.0.18
 fs-s3fs==0.1.8
 futures ; python_version == "2.7"   # via django-pipeline, python-swift-client, s3transfer
 glob2==0.3                          # Enhanced glob module, used in openedx.core.lib.rooted_paths
-gunicorn==19.2.1
+gunicorn==18.0
 help-tokens
 html5lib==0.999                     # HTML parser, used for capa problems
 ipaddr==2.1.11                      # Ip network support for Embargo feature

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -232,7 +232,7 @@ tincan==0.0.5             # via edx-enterprise
 unicodecsv==0.14.1
 uritemplate==3.0.0        # via coreapi
 urllib3==1.23             # via elasticsearch
-user-util==0.1.5
+user-util==0.1.4
 voluptuous==0.11.5
 watchdog==0.8.3
 web-fragments==0.2.2

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -139,7 +139,7 @@ fs==2.0.18
 future==0.16.0            # via pyjwkest
 futures==3.2.0 ; python_version == "2.7"
 glob2==0.3
-gunicorn==19.2.1
+gunicorn==18.0
 hash-ring==1.3.1          # via django-memcached-hashring
 help-tokens==1.0.3
 html5lib==0.999
@@ -232,7 +232,7 @@ tincan==0.0.5             # via edx-enterprise
 unicodecsv==0.14.1
 uritemplate==3.0.0        # via coreapi
 urllib3==1.23             # via elasticsearch
-user-util==0.1.4
+user-util==0.1.5
 voluptuous==0.11.5
 watchdog==0.8.3
 web-fragments==0.2.2

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -337,7 +337,7 @@ unittest2==1.1.0
 uritemplate==3.0.0
 urllib3==1.23
 urlobject==2.4.3
-user-util==0.1.5
+user-util==0.1.4
 virtualenv==16.0.0
 voluptuous==0.11.5
 vulture==0.29

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -174,7 +174,7 @@ future==0.16.0
 futures==3.2.0 ; python_version == "2.7"
 fuzzywuzzy==0.16.0
 glob2==0.3
-gunicorn==19.2.1
+gunicorn==18.0
 hash-ring==1.3.1
 help-tokens==1.0.3
 html5lib==0.999
@@ -337,7 +337,7 @@ unittest2==1.1.0
 uritemplate==3.0.0
 urllib3==1.23
 urlobject==2.4.3
-user-util==0.1.4
+user-util==0.1.5
 virtualenv==16.0.0
 voluptuous==0.11.5
 vulture==0.29

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -320,7 +320,7 @@ unittest2==1.1.0          # via testtools
 uritemplate==3.0.0
 urllib3==1.23
 urlobject==2.4.3          # via pa11ycrawler
-user-util==0.1.5
+user-util==0.1.4
 virtualenv==16.0.0        # via tox
 voluptuous==0.11.5
 w3lib==1.19.0             # via parsel, scrapy

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -167,7 +167,7 @@ future==0.16.0
 futures==3.2.0 ; python_version == "2.7"
 fuzzywuzzy==0.16.0
 glob2==0.3
-gunicorn==19.2.1
+gunicorn==18.0
 hash-ring==1.3.1
 help-tokens==1.0.3
 html5lib==0.999
@@ -320,7 +320,7 @@ unittest2==1.1.0          # via testtools
 uritemplate==3.0.0
 urllib3==1.23
 urlobject==2.4.3          # via pa11ycrawler
-user-util==0.1.4
+user-util==0.1.5
 virtualenv==16.0.0        # via tox
 voluptuous==0.11.5
 w3lib==1.19.0             # via parsel, scrapy


### PR DESCRIPTION
There is a breaking change in gunicorn 19 which changes
the behavior of the `REMOTE_ADDR` request meta info. It
no longer correctly passes through the value of X-Forwarded-For
if that header is present.

This resulted in making anything that looked at this attribute
think that all requests were coming from 127.0.0.1

This broke the django-ratelimit-backend library which relies on
this feature to determine if a user has had too many login attempts.