### PR TITLE
Further downgrade gunicorn.

### DIFF
--- a/requirements/edx/base.in
+++ b/requirements/edx/base.in
@@ -91,7 +91,7 @@ fs==2.0.18
 fs-s3fs==0.1.8
 futures ; python_version == "2.7"   # via django-pipeline, python-swift-client, s3transfer
 glob2==0.3                          # Enhanced glob module, used in openedx.core.lib.rooted_paths
-gunicorn==18.0
+gunicorn==17.5
 help-tokens
 html5lib==0.999                     # HTML parser, used for capa problems
 ipaddr==2.1.11                      # Ip network support for Embargo feature

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -139,7 +139,7 @@ fs==2.0.18
 future==0.16.0            # via pyjwkest
 futures==3.2.0 ; python_version == "2.7"
 glob2==0.3
-gunicorn==18.0
+gunicorn==17.5
 hash-ring==1.3.1          # via django-memcached-hashring
 help-tokens==1.0.3
 html5lib==0.999

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -174,7 +174,7 @@ future==0.16.0
 futures==3.2.0 ; python_version == "2.7"
 fuzzywuzzy==0.16.0
 glob2==0.3
-gunicorn==18.0
+gunicorn==17.5
 hash-ring==1.3.1
 help-tokens==1.0.3
 html5lib==0.999

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -167,7 +167,7 @@ future==0.16.0
 futures==3.2.0 ; python_version == "2.7"
 fuzzywuzzy==0.16.0
 glob2==0.3
-gunicorn==18.0
+gunicorn==17.5
 hash-ring==1.3.1
 help-tokens==1.0.3
 html5lib==0.999


### PR DESCRIPTION
18.0 seems to be doing a different thing with REMOTE_ADDR.

Putting this back to the last working version in production.