### PR TITLE
Fix commonlib-unit test collection errors in xdist

### DIFF
--- a/common/lib/xmodule/xmodule/modulestore/tests/test_assetstore.py
+++ b/common/lib/xmodule/xmodule/modulestore/tests/test_assetstore.py
@@ -93,6 +93,10 @@ class TestMongoAssetMetadataStorage(TestCase):
     Tests for storing/querying course asset metadata.
     """
     shard = 1
+    XML_MODULESTORE_MAP = {
+        'XML_MODULESTORE_BUILDER': XmlModulestoreBuilder(),
+        'MIXED_MODULESTORE_BUILDER': MixedModulestoreBuilder([('xml', XmlModulestoreBuilder())])
+    }
 
     def setUp(self):
         super(TestMongoAssetMetadataStorage, self).setUp()
@@ -641,11 +645,12 @@ class TestMongoAssetMetadataStorage(TestCase):
             )
             self.assertEquals(len(asset_page), 2)
 
-    @ddt.data(XmlModulestoreBuilder(), MixedModulestoreBuilder([('xml', XmlModulestoreBuilder())]))
-    def test_xml_not_yet_implemented(self, storebuilder):
+    @ddt.data('XML_MODULESTORE_BUILDER', 'MIXED_MODULESTORE_BUILDER')
+    def test_xml_not_yet_implemented(self, storebuilderName):
         """
         Test coverage which shows that for now xml read operations are not implemented
         """
+        storebuilder = self.XML_MODULESTORE_MAP[storebuilderName]
         with storebuilder.build(contentstore=None) as (__, store):
             course_key = store.make_course_key("org", "course", "run")
             asset_key = course_key.make_asset_key('asset', 'foo.jpg')

--- a/common/lib/xmodule/xmodule/modulestore/tests/test_store_utilities.py
+++ b/common/lib/xmodule/xmodule/modulestore/tests/test_store_utilities.py
@@ -52,22 +52,21 @@ class TestUtils(unittest.TestCase):
     shard = 2
 
     ONLY_ROOTS = [
-        draft_node_constructor(Mock(), 'url1', 'vertical'),
-        draft_node_constructor(Mock(), 'url2', 'sequential'),
+        ('url1', 'vertical'),
+        ('url2', 'sequential'),
     ]
     ONLY_ROOTS_URLS = ['url1', 'url2']
 
     SOME_TREES = [
-        draft_node_constructor(Mock(), 'child_1', 'vertical_1'),
-        draft_node_constructor(Mock(), 'child_2', 'vertical_1'),
-        draft_node_constructor(Mock(), 'vertical_1', 'sequential_1'),
+        ('child_1', 'vertical_1'),
+        ('child_2', 'vertical_1'),
+        ('vertical_1', 'sequential_1'),
 
-        draft_node_constructor(Mock(), 'child_3', 'vertical_2'),
-        draft_node_constructor(Mock(), 'child_4', 'vertical_2'),
-        draft_node_constructor(Mock(), 'vertical_2', 'grandparent_vertical'),
-        draft_node_constructor(Mock(), 'grandparent_vertical', 'great_grandparent_vertical'),
+        ('child_3', 'vertical_2'),
+        ('child_4', 'vertical_2'),
+        ('vertical_2', 'grandparent_vertical'),
+        ('grandparent_vertical', 'great_grandparent_vertical'),
     ]
-
     SOME_TREES_ROOTS_URLS = ['vertical_1', 'grandparent_vertical']
 
     @ddt.data(
@@ -75,8 +74,11 @@ class TestUtils(unittest.TestCase):
         (SOME_TREES, SOME_TREES_ROOTS_URLS),
     )
     @ddt.unpack
-    def test_get_draft_subtree_roots(self, module_nodes, expected_roots_urls):
+    def test_get_draft_subtree_roots(self, node_arguments_list, expected_roots_urls):
         """tests for get_draft_subtree_roots"""
+        module_nodes = []
+        for node_args in node_arguments_list:
+            module_nodes.append(draft_node_constructor(Mock(), node_args[0], node_args[1]))
         subtree_roots_urls = [root.url for root in get_draft_subtree_roots(module_nodes)]
         # check that we return the expected urls
         self.assertEqual(set(subtree_roots_urls), set(expected_roots_urls))

--- a/common/lib/xmodule/xmodule/tests/test_xblock_wrappers.py
+++ b/common/lib/xmodule/xmodule/tests/test_xblock_wrappers.py
@@ -80,7 +80,8 @@ def flatten(class_dict):
     Flatten a dict from cls -> [fields, ...] and yields values of the form (cls, fields)
     for each entry in the dictionary value.
     """
-    for cls, fields_list in class_dict.items():
+    for cls in sorted(class_dict, key=lambda err: err.__name__):
+        fields_list = class_dict[cls]
         for fields in fields_list:
             yield (cls, fields)
 


### PR DESCRIPTION
When using remote workers with pytest-xdist, each worker collects all of the tests and compares their list with other workers before anything actually get run. Sometimes when `@ddt.data` is used in the tests, the test names end up using string representations of object parameters that include an actual memory address, which of course is going to vary from machine to machine.

This PR cleans up instances like this, to fix collection errors and get all tests running with xdist.