### PR TITLE
upgrade reportlab and pillow

### DIFF
--- a/requirements/edx/base.in
+++ b/requirements/edx/base.in
@@ -107,7 +107,7 @@ numpy==1.6.2                        # Fast numeric array computation, used in so
 oauthlib==2.0.1                     # OAuth specification support for authenticating via LTI or other Open edX services
 pdfminer                            # Used in shoppingcart for extracting/parsing pdf text
 piexif==1.0.2                       # Exif image metadata manipulation, used in the profile_images app
-Pillow==3.4                         # Image manipulation library; used for course assets, profile images, invoice PDFs, etc.
+Pillow                              # Image manipulation library; used for course assets, profile images, invoice PDFs, etc.
 py2neo<4.0.0                       # Used to communicate with Neo4j, which is used internally for modulestore inspection
 PyContracts==1.7.1
 pycountry==1.20
@@ -124,7 +124,7 @@ python-Levenshtein
 python-openid
 python-saml==2.4.0
 pyuca==1.1                          # For more accurate sorting of translated country names in django-countries
-reportlab==3.1.44                   # Used for shopping cart's pdf invoice/receipt generation
+reportlab                           # Used for shopping cart's pdf invoice/receipt generation
 rest-condition                      # DRF's recommendation for supporting complex permissions
 rfc6266-parser                      # Used to generate Content-Disposition headers.
 social-auth-app-django

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -117,14 +117,14 @@ edx-django-release-util==0.3.1
 edx-django-sites-extensions==2.3.1
 edx-django-utils==0.3.0   # via edx-drf-extensions
 edx-drf-extensions==1.6.1
-edx-enterprise==0.72.4
+edx-enterprise==0.72.5
 edx-i18n-tools==0.4.6
 edx-milestones==0.1.13
 edx-oauth2-provider==1.2.2
 edx-opaque-keys[django]==0.4.4
 edx-organizations==0.4.10
 edx-proctoring==1.4.0
-edx-rest-api-client==1.8.0
+edx-rest-api-client==1.8.2
 edx-search==1.2.1
 edx-submissions==2.0.12
 edx-user-state-client==1.0.4
@@ -181,7 +181,7 @@ paver==1.3.4
 pbr==4.2.0
 pdfminer==20140328
 piexif==1.0.2
-pillow==3.4.0
+pillow==5.2.0
 polib==1.1.0              # via edx-i18n-tools
 psutil==1.2.1
 py2neo==3.1.2
@@ -207,7 +207,7 @@ pytz==2016.10
 pyuca==1.1
 pyyaml==3.13
 redis==2.10.6
-reportlab==3.1.44
+reportlab==3.5.4
 requests-oauthlib==0.6.1
 requests==2.9.1
 rest-condition==1.0.3

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -137,7 +137,7 @@ edx-django-release-util==0.3.1
 edx-django-sites-extensions==2.3.1
 edx-django-utils==0.3.0
 edx-drf-extensions==1.6.1
-edx-enterprise==0.72.4
+edx-enterprise==0.72.5
 edx-i18n-tools==0.4.6
 edx-lint==0.5.5
 edx-milestones==0.1.13
@@ -145,7 +145,7 @@ edx-oauth2-provider==1.2.2
 edx-opaque-keys[django]==0.4.4
 edx-organizations==0.4.10
 edx-proctoring==1.4.0
-edx-rest-api-client==1.8.0
+edx-rest-api-client==1.8.2
 edx-search==1.2.1
 edx-sphinx-theme==1.3.0
 edx-submissions==2.0.12
@@ -227,7 +227,7 @@ oauth2==1.9.0.post1
 oauthlib==2.0.1
 openapi-codec==1.3.2
 pa11ycrawler==1.6.2
-packaging==17.1
+packaging==17.1           # via sphinx
 parsel==1.5.0
 path.py==8.2.1
 pathtools==0.1.2
@@ -235,7 +235,7 @@ paver==1.3.4
 pbr==4.2.0
 pdfminer==20140328
 piexif==1.0.2
-pillow==3.4.0
+pillow==5.2.0
 pip-tools==2.0.2
 pluggy==0.6.0
 polib==1.1.0
@@ -289,7 +289,7 @@ pyyaml==3.13
 queuelib==1.5.0
 radon==2.2.0
 redis==2.10.6
-reportlab==3.1.44
+reportlab==3.5.4
 requests-oauthlib==0.6.1
 requests==2.9.1
 rest-condition==1.0.3
@@ -326,7 +326,7 @@ testtools==2.3.0
 text-unidecode==1.2
 tincan==0.0.5
 tox-battery==0.5.1
-tox==3.1.3
+tox==3.2.1
 traceback2==1.4.0
 transifex-client==0.13.4
 twisted==16.6.0

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -132,7 +132,7 @@ edx-django-release-util==0.3.1
 edx-django-sites-extensions==2.3.1
 edx-django-utils==0.3.0
 edx-drf-extensions==1.6.1
-edx-enterprise==0.72.4
+edx-enterprise==0.72.5
 edx-i18n-tools==0.4.6
 edx-lint==0.5.5
 edx-milestones==0.1.13
@@ -140,7 +140,7 @@ edx-oauth2-provider==1.2.2
 edx-opaque-keys[django]==0.4.4
 edx-organizations==0.4.10
 edx-proctoring==1.4.0
-edx-rest-api-client==1.8.0
+edx-rest-api-client==1.8.2
 edx-search==1.2.1
 edx-submissions==2.0.12
 edx-user-state-client==1.0.4
@@ -218,7 +218,6 @@ oauth2==1.9.0.post1
 oauthlib==2.0.1
 openapi-codec==1.3.2
 pa11ycrawler==1.6.2
-packaging==17.1           # via tox
 parsel==1.5.0             # via scrapy
 path.py==8.2.1
 pathtools==0.1.2
@@ -226,7 +225,7 @@ paver==1.3.4
 pbr==4.2.0
 pdfminer==20140328
 piexif==1.0.2
-pillow==3.4.0
+pillow==5.2.0
 pluggy==0.6.0             # via pytest, tox
 polib==1.1.0
 psutil==1.2.1
@@ -278,7 +277,7 @@ pyyaml==3.13
 queuelib==1.5.0           # via scrapy
 radon==2.2.0
 redis==2.10.6
-reportlab==3.1.44
+reportlab==3.5.4
 requests-oauthlib==0.6.1
 requests==2.9.1
 rest-condition==1.0.3
@@ -310,7 +309,7 @@ testtools==2.3.0          # via fixtures, python-subunit
 text-unidecode==1.2       # via faker
 tincan==0.0.5
 tox-battery==0.5.1
-tox==3.1.3
+tox==3.2.1
 traceback2==1.4.0         # via testtools, unittest2
 transifex-client==0.13.4
 twisted==16.6.0           # via pa11ycrawler, scrapy


### PR DESCRIPTION
This is related to [https://openedx.atlassian.net/browse/INCR-15](url). In order to upgrade reportlab, I also had to remove the pinned version of pillow since the latest version of reportlab needs pillow >=4.0.0