### PR TITLE
Bump up node install timeout and add verbose

### DIFF
--- a/scripts/jenkins-common.sh
+++ b/scripts/jenkins-common.sh
@@ -7,7 +7,7 @@ source $HOME/jenkins_env
 NODE_ENV_DIR=$HOME/nenv
 NODE_VERSION=8.9.3
 
-NODE_INSTALL_COMMAND="nodeenv --node=$NODE_VERSION --prebuilt $NODE_ENV_DIR --force"
+NODE_INSTALL_COMMAND="nodeenv --node=$NODE_VERSION --prebuilt $NODE_ENV_DIR --force --verbose"
 
 # Clear the mongo database
 # Note that this prevents us from running jobs in parallel on a single worker.
@@ -40,7 +40,7 @@ rm -rf $NODE_ENV_DIR
 # Occasionally, the command to install node hangs. We need to catch that and retry.
 # Note that this will retry even if the command itself fails.
 WAIT_COUNT=0
-until timeout 30s $NODE_INSTALL_COMMAND || [ $WAIT_COUNT -eq 2 ]; do
+until timeout 60s $NODE_INSTALL_COMMAND || [ $WAIT_COUNT -eq 2 ]; do
     echo "re-trying to install node version..."
     sleep 2
     WAIT_COUNT=$((WAIT_COUNT+1))


### PR DESCRIPTION
We are seeing a lot of failures caused by timing out from the node install command, potentially due to an npm related issue.

Bumping the timeout for now and increasing verbosity to help debug any more issues.