### PR TITLE
TE-2689 Remove useless pylint suppressions part 1

### DIFF
--- a/lms/djangoapps/ccx/api/v0/tests/test_views.py
+++ b/lms/djangoapps/ccx/api/v0/tests/test_views.py
@@ -313,8 +313,8 @@ class CcxListTest(CcxRestApiTest):
         """
         # there are no CCX courses
         resp = self.client.get(self.list_url_master_course, {}, HTTP_AUTHORIZATION=getattr(self, auth_attr))
-        self.assertIn('count', resp.data)  # pylint: disable=no-member
-        self.assertEqual(resp.data['count'], 0)  # pylint: disable=no-member
+        self.assertIn('count', resp.data)
+        self.assertEqual(resp.data['count'], 0)
 
         # create few ccx courses
         num_ccx = 10
@@ -322,10 +322,10 @@ class CcxListTest(CcxRestApiTest):
             self.make_ccx()
         resp = self.client.get(self.list_url_master_course, {}, HTTP_AUTHORIZATION=getattr(self, auth_attr))
         self.assertEqual(resp.status_code, status.HTTP_200_OK)
-        self.assertIn('count', resp.data)  # pylint: disable=no-member
-        self.assertEqual(resp.data['count'], num_ccx)  # pylint: disable=no-member
-        self.assertIn('results', resp.data)  # pylint: disable=no-member
-        self.assertEqual(len(resp.data['results']), num_ccx)  # pylint: disable=no-member
+        self.assertIn('count', resp.data)
+        self.assertEqual(resp.data['count'], num_ccx)
+        self.assertIn('results', resp.data)
+        self.assertEqual(len(resp.data['results']), num_ccx)
 
     @ddt.data(*AUTH_ATTRS)
     def test_get_sorted_list(self, auth_attr):
@@ -349,9 +349,9 @@ class CcxListTest(CcxRestApiTest):
         url = '{0}&order_by=display_name'.format(self.list_url_master_course)
         resp = self.client.get(url, {}, HTTP_AUTHORIZATION=getattr(self, auth_attr))
         self.assertEqual(resp.status_code, status.HTTP_200_OK)
-        self.assertEqual(len(resp.data['results']), num_ccx)  # pylint: disable=no-member
+        self.assertEqual(len(resp.data['results']), num_ccx)
         # the display_name should be sorted as "Title CCX x", "Title CCX y", "Title CCX z"
-        for num, ccx in enumerate(resp.data['results']):  # pylint: disable=no-member
+        for num, ccx in enumerate(resp.data['results']):
             self.assertEqual(title_str.format(string.ascii_lowercase[-(num_ccx - num)]), ccx['display_name'])
 
         # add sort order desc
@@ -359,7 +359,7 @@ class CcxListTest(CcxRestApiTest):
         resp = self.client.get(url, {}, HTTP_AUTHORIZATION=getattr(self, auth_attr))
         # the only thing I can check is that the display name is in alphabetically reversed order
         # in the same way when the field has been updated above, so with the id asc
-        for num, ccx in enumerate(resp.data['results']):  # pylint: disable=no-member
+        for num, ccx in enumerate(resp.data['results']):
             self.assertEqual(title_str.format(string.ascii_lowercase[-(num + 1)]), ccx['display_name'])
 
     @ddt.data(*AUTH_ATTRS)
@@ -376,34 +376,34 @@ class CcxListTest(CcxRestApiTest):
         # get first page
         resp = self.client.get(self.list_url_master_course, {}, HTTP_AUTHORIZATION=getattr(self, auth_attr))
         self.assertEqual(resp.status_code, status.HTTP_200_OK)
-        self.assertEqual(resp.data['count'], num_ccx)  # pylint: disable=no-member
-        self.assertEqual(resp.data['num_pages'], num_pages)  # pylint: disable=no-member
-        self.assertEqual(resp.data['current_page'], 1)  # pylint: disable=no-member
-        self.assertEqual(resp.data['start'], 0)  # pylint: disable=no-member
-        self.assertIsNotNone(resp.data['next'])  # pylint: disable=no-member
-        self.assertIsNone(resp.data['previous'])  # pylint: disable=no-member
+        self.assertEqual(resp.data['count'], num_ccx)
+        self.assertEqual(resp.data['num_pages'], num_pages)
+        self.assertEqual(resp.data['current_page'], 1)
+        self.assertEqual(resp.data['start'], 0)
+        self.assertIsNotNone(resp.data['next'])
+        self.assertIsNone(resp.data['previous'])
 
         # get a page in the middle
         url = '{0}&page=24'.format(self.list_url_master_course)
         resp = self.client.get(url, {}, HTTP_AUTHORIZATION=getattr(self, auth_attr))
         self.assertEqual(resp.status_code, status.HTTP_200_OK)
-        self.assertEqual(resp.data['count'], num_ccx)  # pylint: disable=no-member
-        self.assertEqual(resp.data['num_pages'], num_pages)  # pylint: disable=no-member
-        self.assertEqual(resp.data['current_page'], 24)  # pylint: disable=no-member
-        self.assertEqual(resp.data['start'], (resp.data['current_page'] - 1) * page_size)  # pylint: disable=no-member
-        self.assertIsNotNone(resp.data['next'])  # pylint: disable=no-member
-        self.assertIsNotNone(resp.data['previous'])  # pylint: disable=no-member
+        self.assertEqual(resp.data['count'], num_ccx)
+        self.assertEqual(resp.data['num_pages'], num_pages)
+        self.assertEqual(resp.data['current_page'], 24)
+        self.assertEqual(resp.data['start'], (resp.data['current_page'] - 1) * page_size)
+        self.assertIsNotNone(resp.data['next'])
+        self.assertIsNotNone(resp.data['previous'])
 
         # get last page
         url = '{0}&page={1}'.format(self.list_url_master_course, num_pages)
         resp = self.client.get(url, {}, HTTP_AUTHORIZATION=getattr(self, auth_attr))
         self.assertEqual(resp.status_code, status.HTTP_200_OK)
-        self.assertEqual(resp.data['count'], num_ccx)  # pylint: disable=no-member
-        self.assertEqual(resp.data['num_pages'], num_pages)  # pylint: disable=no-member
-        self.assertEqual(resp.data['current_page'], num_pages)  # pylint: disable=no-member
-        self.assertEqual(resp.data['start'], (resp.data['current_page'] - 1) * page_size)  # pylint: disable=no-member
-        self.assertIsNone(resp.data['next'])  # pylint: disable=no-member
-        self.assertIsNotNone(resp.data['previous'])  # pylint: disable=no-member
+        self.assertEqual(resp.data['count'], num_ccx)
+        self.assertEqual(resp.data['num_pages'], num_pages)
+        self.assertEqual(resp.data['current_page'], num_pages)
+        self.assertEqual(resp.data['start'], (resp.data['current_page'] - 1) * page_size)
+        self.assertIsNone(resp.data['next'])
+        self.assertIsNotNone(resp.data['previous'])
 
         # last page + 1
         url = '{0}&page={1}'.format(self.list_url_master_course, num_pages + 1)
@@ -765,14 +765,14 @@ class CcxListTest(CcxRestApiTest):
         self.assertEqual(resp.status_code, status.HTTP_201_CREATED)
         # check if the response has at least the same data of the request
         for key, val in data.iteritems():
-            self.assertEqual(resp.data.get(key), val)  # pylint: disable=no-member
-        self.assertIn('ccx_course_id', resp.data)  # pylint: disable=no-member
+            self.assertEqual(resp.data.get(key), val)
+        self.assertIn('ccx_course_id', resp.data)
         # check that the new CCX actually exists
-        course_key = CourseKey.from_string(resp.data.get('ccx_course_id'))  # pylint: disable=no-member
+        course_key = CourseKey.from_string(resp.data.get('ccx_course_id'))
         ccx_course = CustomCourseForEdX.objects.get(pk=course_key.ccx)
         self.assertEqual(
             unicode(CCXLocator.from_course_locator(ccx_course.course.id, ccx_course.id)),
-            resp.data.get('ccx_course_id')  # pylint: disable=no-member
+            resp.data.get('ccx_course_id')
         )
         # check that the coach user has coach role on the master course
         coach_role_on_master_course = CourseCcxCoachRole(self.master_course_key)
@@ -784,7 +784,7 @@ class CcxListTest(CcxRestApiTest):
         )
         # check that an email has been sent to the coach
         self.assertEqual(len(outbox), 1)
-        self.assertIn(self.coach.email, outbox[0].recipients())  # pylint: disable=no-member
+        self.assertIn(self.coach.email, outbox[0].recipients())
 
     @ddt.data(
         ('auth', True),
@@ -798,7 +798,7 @@ class CcxListTest(CcxRestApiTest):
         Test the creation of a CCX on user's active states.
         """
         self.app_user.is_active = user_is_active
-        self.app_user.save()  # pylint: disable=no-member
+        self.app_user.save()
 
         data = {
             'master_course_id': self.master_course_key_str,
@@ -830,7 +830,7 @@ class CcxListTest(CcxRestApiTest):
         }
         resp = self.client.post(self.list_url, data, format='json', HTTP_AUTHORIZATION=getattr(self, auth_attr))
         self.assertEqual(resp.status_code, status.HTTP_201_CREATED)
-        self.assertEqual(resp.data.get('course_modules'), chapters)  # pylint: disable=no-member
+        self.assertEqual(resp.data.get('course_modules'), chapters)
 
     @ddt.data(*AUTH_ATTRS)
     def test_post_list_staff_master_course_in_ccx(self, auth_attr):
@@ -849,11 +849,11 @@ class CcxListTest(CcxRestApiTest):
         self.assertEqual(resp.status_code, status.HTTP_201_CREATED)
         # check that only one email has been sent and it is to to the coach
         self.assertEqual(len(outbox), 1)
-        self.assertIn(self.coach.email, outbox[0].recipients())  # pylint: disable=no-member
+        self.assertIn(self.coach.email, outbox[0].recipients())
 
         list_staff_master_course = list_with_level(self.course, 'staff')
         list_instructor_master_course = list_with_level(self.course, 'instructor')
-        course_key = CourseKey.from_string(resp.data.get('ccx_course_id'))  # pylint: disable=no-member
+        course_key = CourseKey.from_string(resp.data.get('ccx_course_id'))
         with ccx_course_cm(course_key) as course_ccx:
             list_staff_ccx_course = list_with_level(course_ccx, 'staff')
             list_instructor_ccx_course = list_with_level(course_ccx, 'instructor')
@@ -1095,15 +1095,15 @@ class CcxDetailTest(CcxRestApiTest):
         """
         resp = self.client.get(self.detail_url, {}, HTTP_AUTHORIZATION=getattr(self, auth_attr))
         self.assertEqual(resp.status_code, status.HTTP_200_OK)
-        self.assertEqual(resp.data.get('ccx_course_id'), self.ccx_key_str)  # pylint: disable=no-member
-        self.assertEqual(resp.data.get('display_name'), self.ccx.display_name)  # pylint: disable=no-member
+        self.assertEqual(resp.data.get('ccx_course_id'), self.ccx_key_str)
+        self.assertEqual(resp.data.get('display_name'), self.ccx.display_name)
         self.assertEqual(
-            resp.data.get('max_students_allowed'),  # pylint: disable=no-member
-            self.ccx.max_student_enrollments_allowed  # pylint: disable=no-member
+            resp.data.get('max_students_allowed'),
+            self.ccx.max_student_enrollments_allowed
         )
         self.assertEqual(resp.data.get('coach_email'), self.ccx.coach.email)  # pylint: disable=no-member
-        self.assertEqual(resp.data.get('master_course_id'), unicode(self.ccx.course_id))  # pylint: disable=no-member
-        self.assertItemsEqual(resp.data.get('course_modules'), self.master_course_chapters)  # pylint: disable=no-member
+        self.assertEqual(resp.data.get('master_course_id'), unicode(self.ccx.course_id))
+        self.assertItemsEqual(resp.data.get('course_modules'), self.master_course_chapters)
 
     @ddt.data(*AUTH_ATTRS)
     def test_delete_detail(self, auth_attr):
@@ -1115,7 +1115,7 @@ class CcxDetailTest(CcxRestApiTest):
         self.assertGreater(CourseEnrollment.objects.filter(course_id=self.ccx_key).count(), 0)
         resp = self.client.delete(self.detail_url, {}, HTTP_AUTHORIZATION=getattr(self, auth_attr))
         self.assertEqual(resp.status_code, status.HTTP_204_NO_CONTENT)
-        self.assertIsNone(resp.data)  # pylint: disable=no-member
+        self.assertIsNone(resp.data)
         # the CCX does not exist any more
         with self.assertRaises(CustomCourseForEdX.DoesNotExist):
             CustomCourseForEdX.objects.get(id=self.ccx.id)
@@ -1238,9 +1238,9 @@ class CcxDetailTest(CcxRestApiTest):
         An empty patch does not modify anything
         """
         display_name = self.ccx.display_name
-        max_students_allowed = self.ccx.max_student_enrollments_allowed  # pylint: disable=no-member
+        max_students_allowed = self.ccx.max_student_enrollments_allowed
         coach_email = self.ccx.coach.email  # pylint: disable=no-member
-        ccx_structure = self.ccx.structure  # pylint: disable=no-member
+        ccx_structure = self.ccx.structure
         resp = self.client.patch(self.detail_url, {}, format='json', HTTP_AUTHORIZATION=getattr(self, auth_attr))
         self.assertEqual(resp.status_code, status.HTTP_204_NO_CONTENT)
         ccx = CustomCourseForEdX.objects.get(id=self.ccx.id)
@@ -1319,7 +1319,7 @@ class CcxDetailTest(CcxRestApiTest):
         )
         # check that an email has been sent to the coach
         self.assertEqual(len(outbox), 1)
-        self.assertIn(new_coach.email, outbox[0].recipients())  # pylint: disable=no-member
+        self.assertIn(new_coach.email, outbox[0].recipients())
 
     @ddt.data(*AUTH_ATTRS)
     def test_patch_detail_modules(self, auth_attr):
@@ -1369,7 +1369,7 @@ class CcxDetailTest(CcxRestApiTest):
         Test patch ccx course on user's active state.
         """
         self.app_user.is_active = user_is_active
-        self.app_user.save()  # pylint: disable=no-member
+        self.app_user.save()
 
         chapters = self.master_course_chapters[0:1]
         data = {'course_modules': chapters * 3}
@@ -1393,7 +1393,7 @@ class CcxDetailTest(CcxRestApiTest):
         Test for deleting a ccx course on user's active state.
         """
         self.app_user.is_active = user_is_active
-        self.app_user.save()  # pylint: disable=no-member
+        self.app_user.save()
 
         # check that there are overrides
         self.assertGreater(CcxFieldOverride.objects.filter(ccx=self.ccx).count(), 0)
@@ -1404,7 +1404,7 @@ class CcxDetailTest(CcxRestApiTest):
             self.assertEqual(resp.status_code, status.HTTP_403_FORBIDDEN)
         else:
             self.assertEqual(resp.status_code, status.HTTP_204_NO_CONTENT)
-            self.assertIsNone(resp.data)  # pylint: disable=no-member
+            self.assertIsNone(resp.data)
             # the CCX does not exist any more
             with self.assertRaises(CustomCourseForEdX.DoesNotExist):
                 CustomCourseForEdX.objects.get(id=self.ccx.id)

--- a/lms/djangoapps/ccx/overrides.py
+++ b/lms/djangoapps/ccx/overrides.py
@@ -195,7 +195,7 @@ def clear_override_for_ccx(ccx, block, name):
         pass
 
 
-def clear_ccx_field_info_from_ccx_map(ccx, block, name):  # pylint: disable=invalid-name
+def clear_ccx_field_info_from_ccx_map(ccx, block, name):
     """
     Remove field information from ccx overrides mapping dictionary
     """

--- a/lms/djangoapps/ccx/tests/test_models.py
+++ b/lms/djangoapps/ccx/tests/test_models.py
@@ -63,7 +63,7 @@ class TestCCX(ModuleStoreTestCase):
         """
         expected = datetime.now(utc)
         self.set_ccx_override('start', expected)
-        actual = self.ccx.start  # pylint: disable=no-member
+        actual = self.ccx.start
         diff = expected - actual
         self.assertLess(abs(diff.total_seconds()), 1)
 
@@ -75,20 +75,20 @@ class TestCCX(ModuleStoreTestCase):
             # these statements are used entirely to demonstrate the
             # instance-level caching of these values on CCX objects. The
             # check_mongo_calls context is the point here.
-            self.ccx.start  # pylint: disable=pointless-statement, no-member
+            self.ccx.start  # pylint: disable=pointless-statement
         with check_mongo_calls(0):
-            self.ccx.start  # pylint: disable=pointless-statement, no-member
+            self.ccx.start  # pylint: disable=pointless-statement
 
     def test_ccx_due_without_override(self):
         """verify that due returns None when the field has not been set"""
-        actual = self.ccx.due  # pylint: disable=no-member
+        actual = self.ccx.due
         self.assertIsNone(actual)
 
     def test_ccx_due_is_correct(self):
         """verify that the due datetime for a ccx is correctly retrieved"""
         expected = datetime.now(utc)
         self.set_ccx_override('due', expected)
-        actual = self.ccx.due  # pylint: disable=no-member
+        actual = self.ccx.due
         diff = expected - actual
         self.assertLess(abs(diff.total_seconds()), 1)
 
@@ -100,9 +100,9 @@ class TestCCX(ModuleStoreTestCase):
             # these statements are used entirely to demonstrate the
             # instance-level caching of these values on CCX objects. The
             # check_mongo_calls context is the point here.
-            self.ccx.due  # pylint: disable=pointless-statement, no-member
+            self.ccx.due  # pylint: disable=pointless-statement
         with check_mongo_calls(0):
-            self.ccx.due  # pylint: disable=pointless-statement, no-member
+            self.ccx.due  # pylint: disable=pointless-statement
 
     def test_ccx_has_started(self):
         """verify that a ccx marked as starting yesterday has started"""
@@ -110,7 +110,7 @@ class TestCCX(ModuleStoreTestCase):
         delta = timedelta(1)
         then = now - delta
         self.set_ccx_override('start', then)
-        self.assertTrue(self.ccx.has_started())  # pylint: disable=no-member
+        self.assertTrue(self.ccx.has_started())
 
     def test_ccx_has_not_started(self):
         """verify that a ccx marked as starting tomorrow has not started"""
@@ -118,7 +118,7 @@ class TestCCX(ModuleStoreTestCase):
         delta = timedelta(1)
         then = now + delta
         self.set_ccx_override('start', then)
-        self.assertFalse(self.ccx.has_started())  # pylint: disable=no-member
+        self.assertFalse(self.ccx.has_started())
 
     def test_ccx_has_ended(self):
         """verify that a ccx that has a due date in the past has ended"""
@@ -126,7 +126,7 @@ class TestCCX(ModuleStoreTestCase):
         delta = timedelta(1)
         then = now - delta
         self.set_ccx_override('due', then)
-        self.assertTrue(self.ccx.has_ended())  # pylint: disable=no-member
+        self.assertTrue(self.ccx.has_ended())
 
     def test_ccx_has_not_ended(self):
         """verify that a ccx that has a due date in the future has not eneded
@@ -135,11 +135,11 @@ class TestCCX(ModuleStoreTestCase):
         delta = timedelta(1)
         then = now + delta
         self.set_ccx_override('due', then)
-        self.assertFalse(self.ccx.has_ended())  # pylint: disable=no-member
+        self.assertFalse(self.ccx.has_ended())
 
     def test_ccx_without_due_date_has_not_ended(self):
         """verify that a ccx without a due date has not ended"""
-        self.assertFalse(self.ccx.has_ended())  # pylint: disable=no-member
+        self.assertFalse(self.ccx.has_ended())
 
     def test_ccx_max_student_enrollment_correct(self):
         """
@@ -147,15 +147,15 @@ class TestCCX(ModuleStoreTestCase):
         """
         expected = 200
         self.set_ccx_override('max_student_enrollments_allowed', expected)
-        actual = self.ccx.max_student_enrollments_allowed  # pylint: disable=no-member
+        actual = self.ccx.max_student_enrollments_allowed
         self.assertEqual(expected, actual)
 
     def test_structure_json_default_empty(self):
         """
         By default structure_json does not contain anything
         """
-        self.assertEqual(self.ccx.structure_json, None)  # pylint: disable=no-member
-        self.assertEqual(self.ccx.structure, None)  # pylint: disable=no-member
+        self.assertEqual(self.ccx.structure_json, None)
+        self.assertEqual(self.ccx.structure, None)
 
     def test_structure_json(self):
         """
@@ -172,12 +172,12 @@ class TestCCX(ModuleStoreTestCase):
             coach=self.coach,
             structure_json=json_struct
         )
-        self.assertEqual(ccx.structure_json, json_struct)  # pylint: disable=no-member
-        self.assertEqual(ccx.structure, dummy_struct)  # pylint: disable=no-member
+        self.assertEqual(ccx.structure_json, json_struct)
+        self.assertEqual(ccx.structure, dummy_struct)
 
     def test_locator_property(self):
         """
         Verify that the locator helper property returns a correct CCXLocator
         """
-        locator = self.ccx.locator  # pylint: disable=no-member
+        locator = self.ccx.locator
         self.assertEqual(self.ccx.id, long(locator.ccx))

--- a/lms/djangoapps/ccx/tests/test_views.py
+++ b/lms/djangoapps/ccx/tests/test_views.py
@@ -229,7 +229,7 @@ class TestCCXProgressChanges(CcxTestCase, LoginEnrollmentTestCase):
         progress_page_response = self.client.get(
             reverse('progress', kwargs={'course_id': ccx_course_key})
         )
-        grade_summary = progress_page_response.mako_context['courseware_summary']  # pylint: disable=no-member
+        grade_summary = progress_page_response.mako_context['courseware_summary']
         chapter = grade_summary[0]
         section = chapter['sections'][0]
         progress_page_due_date = section.due.strftime("%Y-%m-%d %H:%M")
@@ -250,7 +250,7 @@ class TestCCXProgressChanges(CcxTestCase, LoginEnrollmentTestCase):
         url = reverse('ccx_coach_dashboard', kwargs={'course_id': ccx_course_key})
         response = self.client.get(url)
 
-        schedule = json.loads(response.mako_context['schedule'])  # pylint: disable=no-member
+        schedule = json.loads(response.mako_context['schedule'])
         self.assertEqual(len(schedule), 1)
 
         unhide(schedule[0])
@@ -375,7 +375,7 @@ class TestCoachDashboard(CcxTestCase, LoginEnrollmentTestCase):
 
         response = self.client.post(url, {'name': ccx_name})
         self.assertEqual(response.status_code, 302)
-        url = response.get('location')  # pylint: disable=no-member
+        url = response.get('location')
         response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
 
@@ -473,7 +473,7 @@ class TestCoachDashboard(CcxTestCase, LoginEnrollmentTestCase):
             'ccx_coach_dashboard',
             kwargs={'course_id': CCXLocator.from_course_locator(self.course.id, ccx.id)})
         response = self.client.get(url)
-        schedule = json.loads(response.mako_context['schedule'])  # pylint: disable=no-member
+        schedule = json.loads(response.mako_context['schedule'])
 
         self.assertEqual(len(schedule), 2)
         self.assertEqual(schedule[0]['hidden'], False)
@@ -587,7 +587,7 @@ class TestCoachDashboard(CcxTestCase, LoginEnrollmentTestCase):
             kwargs={'course_id': course_id}
         )
         response = self.client.get(coach_dashboard_url)
-        schedule = json.loads(response.mako_context['schedule'])  # pylint: disable=no-member
+        schedule = json.loads(response.mako_context['schedule'])
         response = self.client.post(
             save_ccx_url, json.dumps(schedule), content_type='application/json'
         )
@@ -900,7 +900,7 @@ class TestCoachDashboardSchedule(CcxTestCase, LoginEnrollmentTestCase, ModuleSto
         response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
         # the schedule contains chapters
-        chapters = json.loads(response.mako_context['schedule'])  # pylint: disable=no-member
+        chapters = json.loads(response.mako_context['schedule'])
         sequentials = flatten([chapter.get('children', []) for chapter in chapters])
         verticals = flatten([sequential.get('children', []) for sequential in sequentials])
         # check that the numbers of nodes at different level are the expected ones
@@ -1073,8 +1073,8 @@ class TestCCXGrades(FieldOverrideTestMixin, SharedModuleStoreTestCase, LoginEnro
         response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
         # Max number of student per page is one.  Patched setting MAX_STUDENTS_PER_PAGE_GRADE_BOOK = 1
-        self.assertEqual(len(response.mako_context['students']), 1)  # pylint: disable=no-member
-        student_info = response.mako_context['students'][0]  # pylint: disable=no-member
+        self.assertEqual(len(response.mako_context['students']), 1)
+        student_info = response.mako_context['students'][0]
         self.assertEqual(student_info['grade_summary']['percent'], 0.5)
         self.assertEqual(student_info['grade_summary']['grade_breakdown'].values()[0]['percent'], 0.5)
         self.assertEqual(len(student_info['grade_summary']['section_breakdown']), 4)
@@ -1120,7 +1120,7 @@ class TestCCXGrades(FieldOverrideTestMixin, SharedModuleStoreTestCase, LoginEnro
         )
         response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
-        grades = response.mako_context['grade_summary']  # pylint: disable=no-member
+        grades = response.mako_context['grade_summary']
         self.assertEqual(grades['percent'], 0.5)
         self.assertEqual(grades['grade_breakdown'].values()[0]['percent'], 0.5)
         self.assertEqual(len(grades['section_breakdown']), 4)

--- a/lms/djangoapps/courseware/access.py
+++ b/lms/djangoapps/courseware/access.py
@@ -177,7 +177,7 @@ def has_staff_access_to_preview_mode(user, course_key):
     return has_admin_access_to_course or is_masquerading_as_student(user, course_key)
 
 
-def _can_view_courseware_with_prerequisites(user, course):  # pylint: disable=invalid-name
+def _can_view_courseware_with_prerequisites(user, course):
     """
     Checks if a user has access to a course based on its prerequisites.
 
@@ -623,7 +623,7 @@ def _dispatch(table, action, user, obj):
         type(obj), action))
 
 
-def _adjust_start_date_for_beta_testers(user, descriptor, course_key):  # pylint: disable=invalid-name
+def _adjust_start_date_for_beta_testers(user, descriptor, course_key):
     """
     If user is in a beta test group, adjust the start date by the appropriate number of
     days.
@@ -716,7 +716,7 @@ def administrative_accesses_to_course_for_user(user, course_key):
     return global_staff, staff_access, instructor_access
 
 
-def _has_instructor_access_to_descriptor(user, descriptor, course_key):  # pylint: disable=invalid-name
+def _has_instructor_access_to_descriptor(user, descriptor, course_key):
     """Helper method that checks whether the user has staff access to
     the course of the location.
 

--- a/lms/djangoapps/courseware/access_response.py
+++ b/lms/djangoapps/courseware/access_response.py
@@ -100,7 +100,7 @@ class StartDateError(AccessError):
             user_message = _("Course has not started")
         else:
             developer_message = "Course does not start until {}".format(start_date)
-            user_message = _("Course does not start until {}"  # pylint: disable=translation-of-non-string
+            user_message = _("Course does not start until {}"
                              .format("{:%B %d, %Y}".format(start_date)))
         super(StartDateError, self).__init__(error_code, developer_message, user_message)
 

--- a/lms/djangoapps/courseware/masquerade.py
+++ b/lms/djangoapps/courseware/masquerade.py
@@ -162,7 +162,7 @@ def is_masquerading_as_student(user, course_key):
     return get_masquerade_role(user, course_key) == 'student'
 
 
-def is_masquerading_as_specific_student(user, course_key):  # pylint: disable=invalid-name
+def is_masquerading_as_specific_student(user, course_key):
     """
     Returns whether the user is a staff member masquerading as a specific student.
     """

--- a/lms/djangoapps/courseware/models.py
+++ b/lms/djangoapps/courseware/models.py
@@ -270,7 +270,6 @@ class XBlockFieldBase(models.Model):
     modified = models.DateTimeField(auto_now=True, db_index=True)
 
     def __unicode__(self):
-        # pylint: disable=protected-access
         keys = [field.name for field in self._meta.get_fields() if field.name not in ('created', 'modified')]
         return u'{}<{!r}'.format(self.__class__.__name__, {key: getattr(self, key) for key in keys})
 
@@ -352,7 +351,7 @@ class OfflineComputedGradeLog(models.Model):
     nstudents = models.IntegerField(default=0)
 
     def __unicode__(self):
-        return "[OCGLog] %s: %s" % (text_type(self.course_id), self.created)  # pylint: disable=no-member
+        return "[OCGLog] %s: %s" % (text_type(self.course_id), self.created)
 
 
 class StudentFieldOverride(TimeStampedModel):

--- a/lms/djangoapps/courseware/module_render.py
+++ b/lms/djangoapps/courseware/module_render.py
@@ -391,7 +391,7 @@ def get_module_for_descriptor(user, request, descriptor, field_data_cache, cours
 
 def get_module_system_for_user(
         user,
-        student_data,  # TODO  # pylint: disable=too-many-statements
+        student_data,  # TODO
         # Arguments preceding this comment have user binding, those following don't
         descriptor,
         course_id,
@@ -797,7 +797,7 @@ def get_module_system_for_user(
 
 # TODO: Find all the places that this method is called and figure out how to
 # get a loaded course passed into it
-def get_module_for_descriptor_internal(user, descriptor, student_data, course_id,  # pylint: disable=invalid-name
+def get_module_for_descriptor_internal(user, descriptor, student_data, course_id,
                                        track_function, xqueue_callback_url_prefix, request_token,
                                        position=None, wrap_xmodule_display=True, grade_bucket_type=None,
                                        static_asset_path='', user_location=None, disable_staff_debug_info=False,

--- a/lms/djangoapps/courseware/tests/test_credit_requirements.py
+++ b/lms/djangoapps/courseware/tests/test_credit_requirements.py
@@ -157,7 +157,7 @@ class ProgressPageCreditRequirementsTest(SharedModuleStoreTestCase):
     def test_credit_requirements_on_progress_page(self, enrollment_mode, is_requirement_displayed):
         """Test the progress table is only displayed to the verified and credit students."""
         self.enrollment.mode = enrollment_mode
-        self.enrollment.save()  # pylint: disable=no-member
+        self.enrollment.save()
 
         response = self._get_progress_page()
         # Verify the requirements are shown only if the user is in a credit-eligible mode.

--- a/lms/djangoapps/courseware/tests/test_discussion_xblock.py
+++ b/lms/djangoapps/courseware/tests/test_discussion_xblock.py
@@ -367,8 +367,8 @@ class TestXBlockInCourse(SharedModuleStoreTestCase):
         }
         response = self.client.get(url, query_params)
         self.assertEquals(response.status_code, 200)
-        self.assertEquals(response.data['root'], unicode(self.course_usage_key))  # pylint: disable=no-member
-        for block_key_string, block_data in response.data['blocks'].iteritems():  # pylint: disable=no-member
+        self.assertEquals(response.data['root'], unicode(self.course_usage_key))
+        for block_key_string, block_data in response.data['blocks'].iteritems():
             block_key = deserialize_usage_key(block_key_string, self.course_key)
             self.assertEquals(block_data['id'], block_key_string)
             self.assertEquals(block_data['type'], block_key.block_type)

--- a/lms/djangoapps/courseware/tests/test_entrance_exam.py
+++ b/lms/djangoapps/courseware/tests/test_entrance_exam.py
@@ -141,7 +141,7 @@ class EntranceExamTestCases(LoginEnrollmentTestCase, ModuleStoreTestCase, Milest
 
         self.anonymous_user = AnonymousUserFactory()
         self.request = get_mock_request(UserFactory())
-        modulestore().update_item(self.course, self.request.user.id)  # pylint: disable=no-member
+        modulestore().update_item(self.course, self.request.user.id)
 
         self.client.login(username=self.request.user.username, password="test")
         CourseEnrollment.enroll(self.request.user, self.course.id)
@@ -311,7 +311,7 @@ class EntranceExamTestCases(LoginEnrollmentTestCase, ModuleStoreTestCase, Milest
         """
         minimum_score_pct = 29
         self.course.entrance_exam_minimum_score_pct = float(minimum_score_pct) / 100
-        modulestore().update_item(self.course, self.request.user.id)  # pylint: disable=no-member
+        modulestore().update_item(self.course, self.request.user.id)
 
         # answer the problem so it results in only 20% correct.
         answer_entrance_exam_problem(self.course, self.request, self.problem_1, value=1, max_value=5)

--- a/lms/djangoapps/courseware/tests/test_group_access.py
+++ b/lms/djangoapps/courseware/tests/test_group_access.py
@@ -43,7 +43,7 @@ def resolve_attrs(test_method):
     replaces them with the resolved values of those attributes in the method
     call.
     """
-    def _wrapper(self, *args):  # pylint: disable=missing-docstring
+    def _wrapper(self, *args):
         new_args = [getattr(self, arg) for arg in args]
         return test_method(self, *new_args)
     return _wrapper

--- a/lms/djangoapps/courseware/tests/test_module_render.py
+++ b/lms/djangoapps/courseware/tests/test_module_render.py
@@ -393,7 +393,7 @@ class ModuleRenderTestCase(SharedModuleStoreTestCase, LoginEnrollmentTestCase):
         )
 
         # grab what _field_data was originally set to
-        original_field_data = descriptor._field_data  # pylint: disable=protected-access, no-member
+        original_field_data = descriptor._field_data  # pylint: disable=protected-access
 
         render.get_module_for_descriptor(
             self.mock_user, request, descriptor, field_data_cache, course.id, course=course
@@ -401,7 +401,7 @@ class ModuleRenderTestCase(SharedModuleStoreTestCase, LoginEnrollmentTestCase):
 
         # check that _unwrapped_field_data is the same as the original
         # _field_data, but now _field_data as been reset.
-        # pylint: disable=protected-access, no-member
+        # pylint: disable=protected-access
         self.assertIs(descriptor._unwrapped_field_data, original_field_data)
         self.assertIsNot(descriptor._unwrapped_field_data, descriptor._field_data)
 
@@ -417,19 +417,19 @@ class ModuleRenderTestCase(SharedModuleStoreTestCase, LoginEnrollmentTestCase):
             )
 
         # _field_data should now be wrapped by LmsFieldData
-        # pylint: disable=protected-access, no-member
+        # pylint: disable=protected-access
         self.assertIsInstance(descriptor._field_data, LmsFieldData)
 
         # the LmsFieldData should now wrap OverrideFieldData
         self.assertIsInstance(
-            # pylint: disable=protected-access, no-member
+            # pylint: disable=protected-access
             descriptor._field_data._authored_data._source,
             OverrideFieldData
         )
 
         # the OverrideFieldData should point to the original unwrapped field_data
         self.assertIs(
-            # pylint: disable=protected-access, no-member
+            # pylint: disable=protected-access
             descriptor._field_data._authored_data._source.fallback,
             descriptor._unwrapped_field_data
         )
@@ -1476,13 +1476,13 @@ class JsonInitDataTest(ModuleStoreTestCase):
         mock_request.user = mock_user
         course = CourseFactory()
         descriptor = ItemFactory(category='withjson', parent=course)
-        field_data_cache = FieldDataCache([course, descriptor], course.id, mock_user)   # pylint: disable=no-member
+        field_data_cache = FieldDataCache([course, descriptor], course.id, mock_user)
         module = render.get_module_for_descriptor(
             mock_user,
             mock_request,
             descriptor,
             field_data_cache,
-            course.id,                          # pylint: disable=no-member
+            course.id,
             course=course
         )
         html = module.render(STUDENT_VIEW).content
@@ -2125,7 +2125,7 @@ class TestEventPublishing(ModuleStoreTestCase, LoginEnrollmentTestCase):
         request.user = self.mock_user
         course = CourseFactory()
         descriptor = ItemFactory(category=block_type, parent=course)
-        field_data_cache = FieldDataCache([course, descriptor], course.id, self.mock_user)  # pylint: disable=no-member
+        field_data_cache = FieldDataCache([course, descriptor], course.id, self.mock_user)
         block = render.get_module(self.mock_user, request, descriptor.location, field_data_cache)
 
         event_type = 'event_type'
@@ -2242,7 +2242,7 @@ class TestFilteredChildren(SharedModuleStoreTestCase):
         super(TestFilteredChildren, cls).setUpClass()
         cls.course = CourseFactory.create()
 
-    # pylint: disable=attribute-defined-outside-init, no-member
+    # pylint: disable=attribute-defined-outside-init
     def setUp(self):
         super(TestFilteredChildren, self).setUp()
         self.users = {number: UserFactory() for number in USER_NUMBERS}
@@ -2391,7 +2391,6 @@ class TestDisabledXBlockTypes(ModuleStoreTestCase):
     """
     Tests that verify disabled XBlock types are not loaded.
     """
-    # pylint: disable=no-member
     def setUp(self):
         super(TestDisabledXBlockTypes, self).setUp()
         XBlockConfiguration(name='video', enabled=False).save()

--- a/lms/djangoapps/courseware/tests/test_navigation.py
+++ b/lms/djangoapps/courseware/tests/test_navigation.py
@@ -28,7 +28,6 @@ class TestNavigation(SharedModuleStoreTestCase, LoginEnrollmentTestCase):
 
     @classmethod
     def setUpClass(cls):
-        #  pylint: disable=super-method-not-called
         with super(TestNavigation, cls).setUpClassAndTestData():
             cls.test_course = CourseFactory.create()
             cls.test_course_proctored = CourseFactory.create()

--- a/lms/djangoapps/courseware/tests/test_split_module.py
+++ b/lms/djangoapps/courseware/tests/test_split_module.py
@@ -167,7 +167,6 @@ class TestSplitTestVert(SplitTestBase):
 
     def setUp(self):
         # We define problem compenents that we need but don't explicitly call elsewhere.
-        # pylint: disable=unused-variable
         super(TestSplitTestVert, self).setUp()
 
         c0_url = self.course.id.make_usage_key("vertical", "split_test_cond0")
@@ -236,7 +235,6 @@ class TestVertSplitTestVert(SplitTestBase):
 
     def setUp(self):
         # We define problem compenents that we need but don't explicitly call elsewhere.
-        # pylint: disable=unused-variable
         super(TestVertSplitTestVert, self).setUp()
 
         vert1 = ItemFactory.create(

--- a/lms/djangoapps/courseware/tests/test_views.py
+++ b/lms/djangoapps/courseware/tests/test_views.py
@@ -48,7 +48,7 @@ from lms.djangoapps.certificates.models import (
 )
 from lms.djangoapps.certificates.tests.factories import CertificateInvalidationFactory, GeneratedCertificateFactory
 from lms.djangoapps.commerce.models import CommerceConfiguration
-from lms.djangoapps.commerce.utils import EcommerceService  # pylint: disable=import-error
+from lms.djangoapps.commerce.utils import EcommerceService
 from lms.djangoapps.grades.config.waffle import waffle as grades_waffle
 from lms.djangoapps.grades.config.waffle import ASSUME_ZERO_GRADE_IF_ABSENT
 from openedx.core.djangoapps.catalog.tests.factories import CourseFactory as CatalogCourseFactory
@@ -317,7 +317,7 @@ class ViewsTestCase(ModuleStoreTestCase):
         url = reverse('courseware', kwargs={'course_id': unicode(self.course_key)})
         response = self.client.get(url)
         self.assertEqual(response.status_code, 302)
-        response = self.client.get(response.url)  # pylint: disable=no-member
+        response = self.client.get(response.url)
         self.assertNotIn(unicode(self.problem.location), response.content.decode("utf-8"))
         self.assertIn(unicode(self.problem2.location), response.content.decode("utf-8"))
 
@@ -920,7 +920,7 @@ class ViewsTestCase(ModuleStoreTestCase):
         self.assertEqual(response.status_code, 200)
 
         self.course.bypass_home = True
-        self.store.update_item(self.course, self.user.id)  # pylint: disable=no-member
+        self.store.update_item(self.course, self.user.id)
         self.assertTrue(self.course.bypass_home)
 
         response = self.client.get(reverse('info', args=[course_id]), HTTP_REFERER=reverse('dashboard'))
@@ -965,7 +965,7 @@ class TestProgramMarketingView(SharedModuleStoreTestCase):
         super(TestProgramMarketingView, cls).setUpClass()
 
         modulestore_course = CourseFactory()
-        course_run = CourseRunFactory(key=unicode(modulestore_course.id))  # pylint: disable=no-member
+        course_run = CourseRunFactory(key=unicode(modulestore_course.id))
         course = CatalogCourseFactory(course_runs=[course_run])
 
         cls.data = ProgramFactory(
@@ -1167,7 +1167,6 @@ class StartDateTests(ModuleStoreTestCase):
         self.assertContains(response, "2013-09-16T07:17:28+0000")
 
 
-# pylint: disable=protected-access, no-member
 @attr(shard=5)
 class ProgressPageBaseTests(ModuleStoreTestCase):
     """
@@ -1225,7 +1224,7 @@ class ProgressPageBaseTests(ModuleStoreTestCase):
         return resp
 
 
-# pylint: disable=protected-access, no-member
+# pylint: disable=protected-access
 @attr(shard=5)
 @ddt.ddt
 class ProgressPageTests(ProgressPageBaseTests):
@@ -1783,7 +1782,6 @@ class ProgressPageTests(ProgressPageBaseTests):
         }
 
 
-# pylint: disable=protected-access, no-member
 @attr(shard=5)
 @ddt.ddt
 class ProgressPageShowCorrectnessTests(ProgressPageBaseTests):
@@ -2135,8 +2133,8 @@ class GenerateUserCertTests(ModuleStoreTestCase):
             self.assertEqual(resp.status_code, 200)
 
             # Verify Google Analytics event fired after generating certificate
-            mock_tracker.track.assert_called_once_with(  # pylint: disable=no-member
-                self.student.id,  # pylint: disable=no-member
+            mock_tracker.track.assert_called_once_with(
+                self.student.id,
                 'edx.bi.user.certificate.generate',
                 {
                     'category': 'certificates',
@@ -2716,7 +2714,6 @@ class TestIndexViewCrawlerStudentStateWrites(SharedModuleStoreTestCase):
     def setUpClass(cls):
         """Set up the simplest course possible."""
         # setUpClassAndTestData() already calls setUpClass on SharedModuleStoreTestCase
-        # pylint: disable=super-method-not-called
         with super(TestIndexViewCrawlerStudentStateWrites, cls).setUpClassAndTestData():
             cls.course = CourseFactory.create()
             with cls.store.bulk_operations(cls.course.id):

--- a/lms/djangoapps/courseware/tests/tests.py
+++ b/lms/djangoapps/courseware/tests/tests.py
@@ -45,7 +45,7 @@ class ActivateLoginTest(LoginEnrollmentTestCase):
         has 'is_from_log_out' attribute set to true.
         """
         response = self.client.get(reverse('logout'))
-        self.assertTrue(getattr(response.wsgi_request, 'is_from_logout', False))  # pylint: disable=no-member
+        self.assertTrue(getattr(response.wsgi_request, 'is_from_logout', False))
 
 
 class PageLoaderTestCase(LoginEnrollmentTestCase):

--- a/lms/djangoapps/courseware/testutils.py
+++ b/lms/djangoapps/courseware/testutils.py
@@ -1,7 +1,6 @@
 """
 Common test utilities for courseware functionality
 """
-# pylint: disable=attribute-defined-outside-init
 
 from abc import ABCMeta, abstractmethod
 from datetime import datetime, timedelta

--- a/lms/djangoapps/courseware/views/views.py
+++ b/lms/djangoapps/courseware/views/views.py
@@ -197,13 +197,13 @@ def user_groups(user):
     cache_expiration = 60 * 60  # one hour
 
     # Kill caching on dev machines -- we switch groups a lot
-    group_names = cache.get(key)  # pylint: disable=no-member
+    group_names = cache.get(key)
     if settings.DEBUG:
         group_names = None
 
     if group_names is None:
         group_names = [u.name for u in UserTestGroup.objects.filter(users=user)]
-        cache.set(key, group_names, cache_expiration)  # pylint: disable=no-member
+        cache.set(key, group_names, cache_expiration)
 
     return group_names
 
@@ -1413,7 +1413,7 @@ def generate_user_cert(request, course_id):
         return HttpResponse()
 
 
-def _track_successful_certificate_generation(user_id, course_id):  # pylint: disable=invalid-name
+def _track_successful_certificate_generation(user_id, course_id):
     """
     Track a successful certificate generation event.
 
@@ -1616,7 +1616,7 @@ def financial_assistance_form(request):
     enrolled_courses = get_financial_aid_courses(user)
     incomes = ['Less than $5,000', '$5,000 - $10,000', '$10,000 - $15,000', '$15,000 - $20,000', '$20,000 - $25,000']
     annual_incomes = [
-        {'name': _(income), 'value': income} for income in incomes  # pylint: disable=translation-of-non-string
+        {'name': _(income), 'value': income} for income in incomes
     ]
     return render_to_response('financial-assistance/apply.html', {
         'header_text': FINANCIAL_ASSISTANCE_HEADER,

--- a/lms/djangoapps/django_comment_client/base/__init__.py
+++ b/lms/djangoapps/django_comment_client/base/__init__.py
@@ -1,2 +1,2 @@
 # This import registers the ForumThreadViewedEventTransformer
-import event_transformers  # pylint: disable=unused-import
+import event_transformers  # pylint: disable=relative-import

--- a/lms/djangoapps/django_comment_client/base/tests.py
+++ b/lms/djangoapps/django_comment_client/base/tests.py
@@ -237,15 +237,15 @@ class ViewsTestCaseMixin(object):
         with patch('student.models.cc.User.save'):
             uname = 'student'
             email = 'student@edx.org'
-            self.password = 'test'  # pylint: disable=attribute-defined-outside-init
+            self.password = 'test'
 
             # Create the user and make them active so we can log them in.
-            self.student = User.objects.create_user(uname, email, self.password)  # pylint: disable=attribute-defined-outside-init
+            self.student = User.objects.create_user(uname, email, self.password)
             self.student.is_active = True
             self.student.save()
 
             # Add a discussion moderator
-            self.moderator = UserFactory.create(password=self.password)  # pylint: disable=attribute-defined-outside-init
+            self.moderator = UserFactory.create(password=self.password)
 
             # Enroll the student in the course
             CourseEnrollmentFactory(user=self.student,
@@ -435,7 +435,6 @@ class ViewsTestCase(
 
     @classmethod
     def setUpClass(cls):
-        # pylint: disable=super-method-not-called
         with super(ViewsTestCase, cls).setUpClassAndTestData():
             cls.course = CourseFactory.create(
                 org='MITx', course='999',
@@ -464,15 +463,15 @@ class ViewsTestCase(
         with patch('student.models.cc.User.save'):
             uname = 'student'
             email = 'student@edx.org'
-            self.password = 'test'  # pylint: disable=attribute-defined-outside-init
+            self.password = 'test'
 
             # Create the user and make them active so we can log them in.
-            self.student = User.objects.create_user(uname, email, self.password)  # pylint: disable=attribute-defined-outside-init
+            self.student = User.objects.create_user(uname, email, self.password)
             self.student.is_active = True
             self.student.save()
 
             # Add a discussion moderator
-            self.moderator = UserFactory.create(password=self.password)  # pylint: disable=attribute-defined-outside-init
+            self.moderator = UserFactory.create(password=self.password)
 
             # Enroll the student in the course
             CourseEnrollmentFactory(user=self.student,
@@ -1074,7 +1073,6 @@ class ViewPermissionsTestCase(ForumsEnableMixin, UrlResetMixin, SharedModuleStor
 
     @classmethod
     def setUpClass(cls):
-        # pylint: disable=super-method-not-called
         with super(ViewPermissionsTestCase, cls).setUpClassAndTestData():
             cls.course = CourseFactory.create()
 
@@ -1186,7 +1184,6 @@ class CreateThreadUnicodeTestCase(
 
     @classmethod
     def setUpClass(cls):
-        # pylint: disable=super-method-not-called
         with super(CreateThreadUnicodeTestCase, cls).setUpClassAndTestData():
             cls.course = CourseFactory.create()
 
@@ -1229,7 +1226,6 @@ class UpdateThreadUnicodeTestCase(
 
     @classmethod
     def setUpClass(cls):
-        # pylint: disable=super-method-not-called
         with super(UpdateThreadUnicodeTestCase, cls).setUpClassAndTestData():
             cls.course = CourseFactory.create()
 
@@ -1272,7 +1268,6 @@ class CreateCommentUnicodeTestCase(
 
     @classmethod
     def setUpClass(cls):
-        # pylint: disable=super-method-not-called
         with super(CreateCommentUnicodeTestCase, cls).setUpClassAndTestData():
             cls.course = CourseFactory.create()
 
@@ -1320,7 +1315,6 @@ class UpdateCommentUnicodeTestCase(
 
     @classmethod
     def setUpClass(cls):
-        # pylint: disable=super-method-not-called
         with super(UpdateCommentUnicodeTestCase, cls).setUpClassAndTestData():
             cls.course = CourseFactory.create()
 
@@ -1361,7 +1355,6 @@ class CreateSubCommentUnicodeTestCase(
     """
     @classmethod
     def setUpClass(cls):
-        # pylint: disable=super-method-not-called
         with super(CreateSubCommentUnicodeTestCase, cls).setUpClassAndTestData():
             cls.course = CourseFactory.create()
 
@@ -1443,7 +1436,6 @@ class TeamsPermissionsTestCase(ForumsEnableMixin, UrlResetMixin, SharedModuleSto
 
     @classmethod
     def setUpClass(cls):
-        # pylint: disable=super-method-not-called
         with super(TeamsPermissionsTestCase, cls).setUpClassAndTestData():
             teams_configuration = {
                 'topics': [{'id': "topic_id", 'name': 'Solar Power', 'description': 'Solar power is hot'}]
@@ -1754,7 +1746,6 @@ class ForumEventTestCase(ForumsEnableMixin, SharedModuleStoreTestCase, MockReque
     """
     @classmethod
     def setUpClass(cls):
-        # pylint: disable=super-method-not-called
         with super(ForumEventTestCase, cls).setUpClassAndTestData():
             cls.course = CourseFactory.create()
 
@@ -1936,7 +1927,6 @@ class UsersEndpointTestCase(ForumsEnableMixin, SharedModuleStoreTestCase, MockRe
 
     @classmethod
     def setUpClass(cls):
-        # pylint: disable=super-method-not-called
         with super(UsersEndpointTestCase, cls).setUpClassAndTestData():
             cls.course = CourseFactory.create()
 

--- a/lms/djangoapps/django_comment_client/base/views.py
+++ b/lms/djangoapps/django_comment_client/base/views.py
@@ -100,7 +100,7 @@ def track_created_event(request, event_name, course, obj, data):
     track_forum_event(request, event_name, course, obj, data)
 
 
-def add_truncated_title_to_event_data(event_data, full_title):  # pylint: disable=invalid-name
+def add_truncated_title_to_event_data(event_data, full_title):
     event_data['title_truncated'] = (len(full_title) > TRACKING_MAX_FORUM_TITLE)
     event_data['title'] = full_title[:TRACKING_MAX_FORUM_TITLE]
 

--- a/lms/djangoapps/django_comment_client/tests/group_id.py
+++ b/lms/djangoapps/django_comment_client/tests/group_id.py
@@ -169,7 +169,7 @@ class NonCohortedTopicGroupIdTestMixin(GroupIdAssertionMixin):
     def test_team_discussion_id_not_cohorted(self, mock_request):
         team = CourseTeamFactory(course_id=self.course.id)
 
-        team.add_user(self.student)  # pylint: disable=no-member
+        team.add_user(self.student)
         self.call_view(mock_request, team.discussion_topic_id, self.student, None)
 
         self._assert_comments_service_called_without_group_id(mock_request)

--- a/lms/djangoapps/django_comment_client/tests/test_utils.py
+++ b/lms/djangoapps/django_comment_client/tests/test_utils.py
@@ -419,7 +419,7 @@ class CategoryMapTestCase(CategoryMapTestMixin, ModuleStoreTestCase):
             "Topic C": {"id": "Topic_C"}
         }
 
-        def check_cohorted_topics(expected_ids):  # pylint: disable=missing-docstring
+        def check_cohorted_topics(expected_ids):
             self.assert_category_map_equals(
                 {
                     "entries": {
@@ -1327,7 +1327,7 @@ class IsCommentableDividedTestCase(ModuleStoreTestCase):
         course = modulestore().get_course(self.toy_course_key)
         self.assertFalse(cohorts.is_course_cohorted(course.id))
 
-        def to_id(name):  # pylint: disable=missing-docstring
+        def to_id(name):
             return topic_name_to_id(course, name)
 
         config_course_cohorts(

--- a/lms/djangoapps/django_comment_client/utils.py
+++ b/lms/djangoapps/django_comment_client/utils.py
@@ -128,7 +128,7 @@ def has_required_keys(xblock):
     return True
 
 
-def get_accessible_discussion_xblocks(course, user, include_all=False):  # pylint: disable=invalid-name
+def get_accessible_discussion_xblocks(course, user, include_all=False):
     """
     Return a list of all valid discussion xblocks in this course that
     are accessible to the given user.
@@ -198,7 +198,7 @@ def get_cached_discussion_id_map(course, discussion_ids, user):
     return get_cached_discussion_id_map_by_course_id(course.id, discussion_ids, user)
 
 
-def get_cached_discussion_id_map_by_course_id(course_id, discussion_ids, user):  # pylint: disable=invalid-name
+def get_cached_discussion_id_map_by_course_id(course_id, discussion_ids, user):
     """
     Returns a dict mapping discussion_ids to respective discussion xblock metadata if it is cached and visible to the
     user. If not, returns the result of get_discussion_id_map
@@ -227,7 +227,7 @@ def get_discussion_id_map(course, user):
     return get_discussion_id_map_by_course_id(course.id, user)
 
 
-def get_discussion_id_map_by_course_id(course_id, user):  # pylint: disable=invalid-name
+def get_discussion_id_map_by_course_id(course_id, user):
     """
     Transform the list of this course's discussion xblocks (visible to a given user) into a dictionary of metadata keyed
     by discussion_id.
@@ -397,7 +397,7 @@ def get_discussion_category_map(course, user, divided_only_if_explicit=False, ex
             if node[level]["start_date"] > category_start_date:
                 node[level]["start_date"] = category_start_date
 
-        divide_all_inline_discussions = (  # pylint: disable=invalid-name
+        divide_all_inline_discussions = (
             not divided_only_if_explicit and discussion_settings.always_divide_inline_discussions
         )
         dupe_counters = defaultdict(lambda: 0)  # counts the number of times we see each title

--- a/lms/djangoapps/instructor_task/api.py
+++ b/lms/djangoapps/instructor_task/api.py
@@ -80,7 +80,7 @@ def get_instructor_task_history(course_id, usage_key=None, student=None, task_ty
     return instructor_tasks.order_by('-id')
 
 
-def get_entrance_exam_instructor_task_history(course_id, usage_key=None, student=None):  # pylint: disable=invalid-name
+def get_entrance_exam_instructor_task_history(course_id, usage_key=None, student=None):
     """
     Returns a query of InstructorTask objects of historical tasks for a given course,
     that optionally match an entrance exam and student if present.
@@ -94,7 +94,7 @@ def get_entrance_exam_instructor_task_history(course_id, usage_key=None, student
 
 
 # Disabling invalid-name because this fn name is longer than 30 chars.
-def submit_rescore_problem_for_student(request, usage_key, student, only_if_higher=False):  # pylint: disable=invalid-name
+def submit_rescore_problem_for_student(request, usage_key, student, only_if_higher=False):
     """
     Request a problem to be rescored as a background task.
 
@@ -138,7 +138,7 @@ def submit_override_score(request, usage_key, student, score):
     return submit_task(request, task_type, task_class, usage_key.course_key, task_input, task_key)
 
 
-def submit_rescore_problem_for_all_students(request, usage_key, only_if_higher=False):  # pylint: disable=invalid-name
+def submit_rescore_problem_for_all_students(request, usage_key, only_if_higher=False):
     """
     Request a problem to be rescored as a background task.
 
@@ -162,7 +162,7 @@ def submit_rescore_problem_for_all_students(request, usage_key, only_if_higher=F
     return submit_task(request, task_type, task_class, usage_key.course_key, task_input, task_key)
 
 
-def submit_rescore_entrance_exam_for_student(request, usage_key, student=None, only_if_higher=False):  # pylint: disable=invalid-name
+def submit_rescore_entrance_exam_for_student(request, usage_key, student=None, only_if_higher=False):
     """
     Request entrance exam problems to be re-scored as a background task.
 
@@ -321,7 +321,7 @@ def submit_bulk_course_email(request, course_key, email_id):
     return submit_task(request, task_type, task_class, course_key, task_input, task_key)
 
 
-def submit_calculate_problem_responses_csv(request, course_key, problem_location):  # pylint: disable=invalid-name
+def submit_calculate_problem_responses_csv(request, course_key, problem_location):
     """
     Submits a task to generate a CSV file containing all student
     answers to a given problem.
@@ -374,7 +374,7 @@ def submit_calculate_students_features_csv(request, course_key, features):
     return submit_task(request, task_type, task_class, course_key, task_input, task_key)
 
 
-def submit_detailed_enrollment_features_csv(request, course_key):  # pylint: disable=invalid-name
+def submit_detailed_enrollment_features_csv(request, course_key):
     """
     Submits a task to generate a CSV containing detailed enrollment info.
 
@@ -431,7 +431,7 @@ def submit_course_survey_report(request, course_key):
     return submit_task(request, task_type, task_class, course_key, task_input, task_key)
 
 
-def submit_proctored_exam_results_report(request, course_key):  # pylint: disable=invalid-name
+def submit_proctored_exam_results_report(request, course_key):
     """
     Submits a task to generate a HTML File containing the executive summary report.
 
@@ -471,7 +471,7 @@ def submit_export_ora2_data(request, course_key):
     return submit_task(request, task_type, task_class, course_key, task_input, task_key)
 
 
-def generate_certificates_for_students(request, course_key, student_set=None, specific_student_id=None):  # pylint: disable=invalid-name
+def generate_certificates_for_students(request, course_key, student_set=None, specific_student_id=None):
     """
     Submits a task to generate certificates for given students enrolled in the course.
 

--- a/lms/djangoapps/instructor_task/api_helper.py
+++ b/lms/djangoapps/instructor_task/api_helper.py
@@ -370,7 +370,7 @@ def check_entrance_exam_problems_for_rescoring(exam_key):  # pylint: disable=inv
         raise NotImplementedError(msg)
 
 
-def encode_problem_and_student_input(usage_key, student=None):  # pylint: disable=invalid-name
+def encode_problem_and_student_input(usage_key, student=None):
     """
     Encode optional usage_key and optional student into task_key and task_input values.
 
@@ -393,7 +393,7 @@ def encode_problem_and_student_input(usage_key, student=None):  # pylint: disabl
     return task_input, task_key
 
 
-def encode_entrance_exam_and_student_input(usage_key, student=None):  # pylint: disable=invalid-name
+def encode_entrance_exam_and_student_input(usage_key, student=None):
     """
     Encode usage_key and optional student into task_key and task_input values.
 

--- a/lms/djangoapps/instructor_task/tasks.py
+++ b/lms/djangoapps/instructor_task/tasks.py
@@ -54,7 +54,7 @@ from lms.djangoapps.instructor_task.tasks_helper.runner import run_main_task
 TASK_LOG = logging.getLogger('edx.celery.task')
 
 
-@task(base=BaseInstructorTask)  # pylint: disable=not-callable
+@task(base=BaseInstructorTask)
 def rescore_problem(entry_id, xmodule_instance_args):
     """Rescores a problem in a course, for all students or one specific student.
 
@@ -81,7 +81,7 @@ def rescore_problem(entry_id, xmodule_instance_args):
     return run_main_task(entry_id, visit_fcn, action_name)
 
 
-@task(base=BaseInstructorTask)  # pylint: disable=not-callable
+@task(base=BaseInstructorTask)
 def override_problem_score(entry_id, xmodule_instance_args):
     """
     Overrides a specific learner's score on a problem.
@@ -94,7 +94,7 @@ def override_problem_score(entry_id, xmodule_instance_args):
     return run_main_task(entry_id, visit_fcn, action_name)
 
 
-@task(base=BaseInstructorTask)  # pylint: disable=not-callable
+@task(base=BaseInstructorTask)
 def reset_problem_attempts(entry_id, xmodule_instance_args):
     """Resets problem attempts to zero for a particular problem for all students in a course.
 
@@ -116,7 +116,7 @@ def reset_problem_attempts(entry_id, xmodule_instance_args):
     return run_main_task(entry_id, visit_fcn, action_name)
 
 
-@task(base=BaseInstructorTask)  # pylint: disable=not-callable
+@task(base=BaseInstructorTask)
 def delete_problem_state(entry_id, xmodule_instance_args):
     """Deletes problem state entirely for all students on a particular problem in a course.
 
@@ -138,7 +138,7 @@ def delete_problem_state(entry_id, xmodule_instance_args):
     return run_main_task(entry_id, visit_fcn, action_name)
 
 
-@task(base=BaseInstructorTask)  # pylint: disable=not-callable
+@task(base=BaseInstructorTask)
 def send_bulk_course_email(entry_id, _xmodule_instance_args):
     """Sends emails to recipients enrolled in a course.
 
@@ -159,7 +159,7 @@ def send_bulk_course_email(entry_id, _xmodule_instance_args):
     return run_main_task(entry_id, visit_fcn, action_name)
 
 
-@task(base=BaseInstructorTask, routing_key=settings.GRADES_DOWNLOAD_ROUTING_KEY)  # pylint: disable=not-callable
+@task(base=BaseInstructorTask, routing_key=settings.GRADES_DOWNLOAD_ROUTING_KEY)
 def calculate_problem_responses_csv(entry_id, xmodule_instance_args):
     """
     Compute student answers to a given problem and upload the CSV to
@@ -171,7 +171,7 @@ def calculate_problem_responses_csv(entry_id, xmodule_instance_args):
     return run_main_task(entry_id, task_fn, action_name)
 
 
-@task(base=BaseInstructorTask, routing_key=settings.GRADES_DOWNLOAD_ROUTING_KEY)  # pylint: disable=not-callable
+@task(base=BaseInstructorTask, routing_key=settings.GRADES_DOWNLOAD_ROUTING_KEY)
 def calculate_grades_csv(entry_id, xmodule_instance_args):
     """
     Grade a course and push the results to an S3 bucket for download.
@@ -187,7 +187,7 @@ def calculate_grades_csv(entry_id, xmodule_instance_args):
     return run_main_task(entry_id, task_fn, action_name)
 
 
-@task(base=BaseInstructorTask, routing_key=settings.GRADES_DOWNLOAD_ROUTING_KEY)  # pylint: disable=not-callable
+@task(base=BaseInstructorTask, routing_key=settings.GRADES_DOWNLOAD_ROUTING_KEY)
 def calculate_problem_grade_report(entry_id, xmodule_instance_args):
     """
     Generate a CSV for a course containing all students' problem
@@ -204,7 +204,7 @@ def calculate_problem_grade_report(entry_id, xmodule_instance_args):
     return run_main_task(entry_id, task_fn, action_name)
 
 
-@task(base=BaseInstructorTask)  # pylint: disable=not-callable
+@task(base=BaseInstructorTask)
 def calculate_students_features_csv(entry_id, xmodule_instance_args):
     """
     Compute student profile information for a course and upload the
@@ -216,7 +216,7 @@ def calculate_students_features_csv(entry_id, xmodule_instance_args):
     return run_main_task(entry_id, task_fn, action_name)
 
 
-@task(base=BaseInstructorTask)  # pylint: disable=not-callable
+@task(base=BaseInstructorTask)
 def enrollment_report_features_csv(entry_id, xmodule_instance_args):
     """
     Compute student profile information for a course and upload the
@@ -228,7 +228,7 @@ def enrollment_report_features_csv(entry_id, xmodule_instance_args):
     return run_main_task(entry_id, task_fn, action_name)
 
 
-@task(base=BaseInstructorTask)  # pylint: disable=not-callable
+@task(base=BaseInstructorTask)
 def exec_summary_report_csv(entry_id, xmodule_instance_args):
     """
     Compute executive summary report for a course and upload the
@@ -240,7 +240,7 @@ def exec_summary_report_csv(entry_id, xmodule_instance_args):
     return run_main_task(entry_id, task_fn, action_name)
 
 
-@task(base=BaseInstructorTask)  # pylint: disable=not-callable
+@task(base=BaseInstructorTask)
 def course_survey_report_csv(entry_id, xmodule_instance_args):
     """
     Compute the survey report for a course and upload the
@@ -252,7 +252,7 @@ def course_survey_report_csv(entry_id, xmodule_instance_args):
     return run_main_task(entry_id, task_fn, action_name)
 
 
-@task(base=BaseInstructorTask)  # pylint: disable=not-callable
+@task(base=BaseInstructorTask)
 def proctored_exam_results_csv(entry_id, xmodule_instance_args):
     """
     Compute proctored exam results report for a course and upload the
@@ -263,7 +263,7 @@ def proctored_exam_results_csv(entry_id, xmodule_instance_args):
     return run_main_task(entry_id, task_fn, action_name)
 
 
-@task(base=BaseInstructorTask)  # pylint: disable=not-callable
+@task(base=BaseInstructorTask)
 def calculate_may_enroll_csv(entry_id, xmodule_instance_args):
     """
     Compute information about invited students who have not enrolled
@@ -276,7 +276,7 @@ def calculate_may_enroll_csv(entry_id, xmodule_instance_args):
     return run_main_task(entry_id, task_fn, action_name)
 
 
-@task(base=BaseInstructorTask, routing_key=settings.GRADES_DOWNLOAD_ROUTING_KEY)  # pylint: disable=not-callable
+@task(base=BaseInstructorTask, routing_key=settings.GRADES_DOWNLOAD_ROUTING_KEY)
 def generate_certificates(entry_id, xmodule_instance_args):
     """
     Grade students and generate certificates.
@@ -292,7 +292,7 @@ def generate_certificates(entry_id, xmodule_instance_args):
     return run_main_task(entry_id, task_fn, action_name)
 
 
-@task(base=BaseInstructorTask)  # pylint: disable=not-callable
+@task(base=BaseInstructorTask)
 def cohort_students(entry_id, xmodule_instance_args):
     """
     Cohort students in bulk, and upload the results.
@@ -304,7 +304,7 @@ def cohort_students(entry_id, xmodule_instance_args):
     return run_main_task(entry_id, task_fn, action_name)
 
 
-@task(base=BaseInstructorTask)  # pylint: disable=not-callable
+@task(base=BaseInstructorTask)
 def export_ora2_data(entry_id, xmodule_instance_args):
     """
     Generate a CSV of ora2 responses and push it to S3.

--- a/lms/djangoapps/instructor_task/tasks_helper/certs.py
+++ b/lms/djangoapps/instructor_task/tasks_helper/certs.py
@@ -120,7 +120,7 @@ def students_require_certificate(course_id, enrolled_students, statuses_to_regen
         return list(set(enrolled_students) - set(students_already_have_certs))
 
 
-def invalidate_generated_certificates(course_id, enrolled_students, certificate_statuses):  # pylint: disable=invalid-name
+def invalidate_generated_certificates(course_id, enrolled_students, certificate_statuses):
     """
     Invalidate generated certificates for all enrolled students in the given course having status in
     'certificate_statuses'.

--- a/lms/djangoapps/instructor_task/tasks_helper/misc.py
+++ b/lms/djangoapps/instructor_task/tasks_helper/misc.py
@@ -87,7 +87,7 @@ def upload_course_survey_report(_xmodule_instance_args, _entry_id, course_id, _t
     return task_progress.update_task_state(extra_meta=current_step)
 
 
-def upload_proctored_exam_results_report(_xmodule_instance_args, _entry_id, course_id, _task_input, action_name):  # pylint: disable=invalid-name
+def upload_proctored_exam_results_report(_xmodule_instance_args, _entry_id, course_id, _task_input, action_name):
     """
     For a given `course_id`, generate a CSV file containing
     information about proctored exam results, and store using a `ReportStore`.

--- a/lms/djangoapps/instructor_task/tests/test_tasks_helper.py
+++ b/lms/djangoapps/instructor_task/tests/test_tasks_helper.py
@@ -1425,14 +1425,14 @@ class TestCourseSurveyReport(TestReportMixin, InstructorTaskCourseTestCase):
         report_store = ReportStore.from_config(config_name='GRADES_DOWNLOAD')
         header_row = ",".join(['User ID', 'User Name', 'Email', self.question1, self.question2, self.question3])
         student1_row = ",".join([
-            str(self.student1.id),  # pylint: disable=no-member
+            str(self.student1.id),
             self.student1.username,
             self.student1.email,
             self.answer1,
             self.answer2
         ])
         student2_row = ",".join([
-            str(self.student2.id),  # pylint: disable=no-member
+            str(self.student2.id),
             self.student2.username,
             self.student2.email,
             self.answer3,
@@ -2734,7 +2734,6 @@ class TestInstructorOra2Report(SharedModuleStoreTestCase):
                 ) as mock_store_rows:
                     return_val = upload_ora2_data(None, None, self.course.id, None, 'generated')
 
-                    # pylint: disable=maybe-no-member
                     timestamp_str = datetime.now(UTC).strftime('%Y-%m-%d-%H%M')
                     course_id_string = urllib.quote(text_type(self.course.id).replace('/', '_'))
                     filename = u'{}_ORA_data_{}.csv'.format(course_id_string, timestamp_str)

--- a/lms/djangoapps/instructor_task/views.py
+++ b/lms/djangoapps/instructor_task/views.py
@@ -124,7 +124,7 @@ def get_task_completion_info(instructor_task):
         log.warning(fmt.format(instructor_task.task_id, instructor_task.task_output))
         return (succeeded, _("No progress status information available"))
 
-    action_name = _(task_output['action_name'])    # pylint: disable=translation-of-non-string
+    action_name = _(task_output['action_name'])
     num_attempted = task_output['attempted']
     num_total = task_output['total']
 


### PR DESCRIPTION
Remove all the warning suppression comments that pylint now claims are redundant from each of the following Django apps:

* `ccx`
* `courseware`
* `django_comment_client`
* `instructor_task`