### PR TITLE
Fixing textline CSS issue

### DIFF
--- a/common/lib/xmodule/xmodule/css/capa/display.scss
+++ b/common/lib/xmodule/xmodule/css/capa/display.scss
@@ -847,6 +847,7 @@ div.problem {
         .status-icon {
           &::after {
             content: '';
+            display: inline-block;
           }
         }
       }


### PR DESCRIPTION
This PR aims to fix a CSS issue with the styling of textline displays for text input and numerical/formula input problems.

Current state with an inline prompt and trailing_text parameter, before submission:

![screen shot 2018-08-14 at 12 09 57 pm](https://user-images.githubusercontent.com/6232546/44125820-abb1cde8-a002-11e8-9d6f-5fcda1b87e61.png)

Note how the equations on either side are out of line.

After submission:

![screen shot 2018-08-14 at 12 10 08 pm](https://user-images.githubusercontent.com/6232546/44125838-c65088d8-a002-11e8-9ea5-9307360c5db7.png)

Note how the equations on either side are in line.

This is fixed by changing how an empty status symbol is displayed, as shown in the following.

![screen shot 2018-08-14 at 4 54 30 pm](https://user-images.githubusercontent.com/6232546/44125860-e324f688-a002-11e8-85f6-daa8a77329d3.png)

This PR adds this one-line CSS fix to the relevant scss file.

For testing purposes, here is the relevant XML to generate this example problem:

```xml
<problem>
  <p style="display:inline">[mathjaxinline]|\mathbf{B}| =[/mathjaxinline] </p>
  <numericalresponse inline="1" answer="1">
    <textline inline="1" trailing_text="[mathjaxinline]\mathrm{T}[/mathjaxinline]"/>
  </numericalresponse>
</problem>
```

For some reason, the display is fine in Studio, but not in LMS.

Mentions: @pdpinch @itsbenweeks