### PR TITLE
Fix reporting drop down menu on data-download instructor dashboard.

### DIFF
--- a/lms/static/sass/course/instructor/_instructor_2.scss
+++ b/lms/static/sass/course/instructor/_instructor_2.scss
@@ -1541,6 +1541,7 @@
       background: white;
       padding: 5px;
       box-shadow: 0 3px 6px rgba(0, 0, 0, 0.16), 0 3px 6px rgba(0, 0, 0, 0.23);
+      z-index: 2;
     }
 
     input {


### PR DESCRIPTION
## [EDUCATOR-3327](https://openedx.atlassian.net/browse/EDUCATOR-3327)

### Description:
This PR fixes the display of Section Problem Reporting Drop Down menu that is hidden behind the report list

### How to Test?
**Prod Edge**
1. Go to Data Download
https://edge.edx.org/courses/course-v1:UQx+UQACADEMICINTEGRITY+2018/instructor#view-data_download 
2. Scroll down to find the button "Select a section or problem".
3. Click on the button.
4. Observe the drop-down menu being covered by the list of file component below.



**Sandbox**
https://menu.sandbox.edx.org/courses/course-v1:edX+DemoX+Demo_Course/instructor#view-data_download


### Screenshot
**Before Fix**
<img width="1206" alt="screen shot 2018-08-15 at 4 19 02 pm" src="https://user-images.githubusercontent.com/7627421/44145983-0d9e98d4-a0a7-11e8-8a69-be871b7bb3e0.png">





**After Fix**
<img width="1205" alt="screen shot 2018-08-15 at 4 19 25 pm" src="https://user-images.githubusercontent.com/7627421/44145990-15da80f8-a0a7-11e8-8018-7f9ef6ed23cc.png">



### Reviewers

If you've been tagged for review, please check your corresponding box once you've given the :+1:.
-  [x] @awaisdar001 
-  [x] @asadazam93 

### Post-review
- [x] Rebase and squash commits


