### PR TITLE
add typeset operation in mathjax queue on response list render

### DIFF
--- a/common/static/common/js/discussion/views/discussion_thread_view.js
+++ b/common/static/common/js/discussion/views/discussion_thread_view.js
@@ -317,6 +317,7 @@
                 if (options.focusAddedResponse) {
                     this.focusToTheAddedResponse(view.el);
                 }
+                DiscussionUtil.typesetMathJax(view.$el.find('.js-response-list'));
             };
 
             DiscussionThreadView.prototype.renderAddResponseButton = function() {

--- a/common/static/common/js/discussion/views/thread_response_view.js
+++ b/common/static/common/js/discussion/views/thread_response_view.js
@@ -177,6 +177,7 @@
                 });
                 this.commentViews.push(view);
                 this.focusToTheCommentResponse(view.$el.closest('.forum-response'));
+                DiscussionUtil.typesetMathJax(view.$el.find('.response-body'));
                 return view;
             };
 


### PR DESCRIPTION
## [EDUCATOR-848](https://openedx.atlassian.net/browse/EDUCATOR-848)

### Description

**_Math Processing Error_** is an intermittent failure. Main factor involved in it is processing time of browser (quicker the browser, more chances of error) . While rendering responses and comments, we add `Typeset` (operation responsible for mathjax rendering) in response/comment views separately. This `Typeset` is placed in a queue and sometimes tries to render response/comment before these views are embedded in HTML.
I have observed that, this error does not reproduce when my local machine is low on memory. As soon as memory is freed and browser start running smoothly, error is reproduced.
A recommended fix for this issue is to add `Typeset` in queue at places where we are sure that all views (to be mathjaxed) are embedded in page.

### Sandbox
- [ ] [mathjax.sandbox.edx.org](https://mathjax.sandbox.edx.org/courses/course-v1:edX+DemoX+Demo_Course/discussion/forum/i4x-edx-eiorguegnru-course-foobarbaz/threads/5b755159b4191f2316000000)

### Reviewers
- [ ] @awaisdar001 
- [ ] @asadazam93 