### PR TITLE
TE-2702 Update Read the Docs links to HTTPS

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,5 +1,5 @@
 We don't maintain a detailed changelog.  For details of changes, please see
 either the `edX Release Notes`_ or the `GitHub commit history`_.
 
-.. _edX Release Notes: http://edx.readthedocs.org/projects/edx-release-notes/en/latest/
+.. _edX Release Notes: https://edx.readthedocs.org/projects/edx-release-notes/en/latest/
 .. _GitHub commit history: https://github.com/edx/edx-platform/commits/master

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -6,7 +6,7 @@ Contributions to Open edX are very welcome, and strongly encouraged! We've
 put together `some documentation that describes our contribution process`_,
 but here's a step-by-step guide that should help you get started.
 
-.. _some documentation that describes our contribution process: http://edx.readthedocs.org/projects/edx-developer-guide/en/latest/process/index.html
+.. _some documentation that describes our contribution process: https://edx.readthedocs.org/projects/edx-developer-guide/en/latest/process/index.html
 
 Step 0: Join the Conversation
 =============================
@@ -138,7 +138,7 @@ requests must meet in order to be reviewed by a core committer. These requiremen
 include things like documentation and passing tests: see the
 `contributor documentation`_ page for the full list.
 
-.. _contributor documentation: http://edx.readthedocs.org/projects/edx-developer-guide/en/latest/process/contributor.html
+.. _contributor documentation: https://edx.readthedocs.org/projects/edx-developer-guide/en/latest/process/contributor.html
 
 
 Areas of particular concern with their own detailed guidelines are:
@@ -150,9 +150,9 @@ Areas of particular concern with their own detailed guidelines are:
   around the world.
 
 
-.. _Accessibility: http://edx.readthedocs.org/projects/edx-developer-guide/en/latest/conventions/accessibility.html
+.. _Accessibility: https://edx.readthedocs.org/projects/edx-developer-guide/en/latest/conventions/accessibility.html
 .. _website accessibility policy: https://www.edx.org/accessibility
-.. _Internationalization: http://edx.readthedocs.io/projects/edx-developer-guide/en/latest/internationalization/index.html
+.. _Internationalization: https://edx.readthedocs.io/projects/edx-developer-guide/en/latest/internationalization/index.html
 
 Step 4: Approval by Community Manager and Product Owner
 =======================================================

--- a/cms/celery.py
+++ b/cms/celery.py
@@ -2,7 +2,7 @@
 Import celery, load its settings from the django settings
 and auto discover tasks in all installed django apps.
 
-Taken from: http://celery.readthedocs.org/en/latest/django/first-steps-with-django.html
+Taken from: https://celery.readthedocs.org/en/latest/django/first-steps-with-django.html
 """
 from __future__ import absolute_import
 

--- a/cms/envs/bok_choy.py
+++ b/cms/envs/bok_choy.py
@@ -145,8 +145,8 @@ LMS_ROOT_URL = "http://localhost:8000"
 if RELEASE_LINE == "master":
     # On master, acceptance tests use edX books, not the default Open edX books.
     HELP_TOKENS_BOOKS = {
-        'learner': 'http://edx.readthedocs.io/projects/edx-guide-for-students',
-        'course_author': 'http://edx.readthedocs.io/projects/edx-partner-course-staff',
+        'learner': 'https://edx.readthedocs.io/projects/edx-guide-for-students',
+        'course_author': 'https://edx.readthedocs.io/projects/edx-partner-course-staff',
     }
 
 ########################## VIDEO TRANSCRIPTS STORAGE ############################

--- a/cms/templates/js/add-xblock-component-support-legend.underscore
+++ b/cms/templates/js/add-xblock-component-support-legend.underscore
@@ -1,7 +1,7 @@
 <% if (support_legend.show_legend) { %>
     <span class="support-documentation">
         <a class="support-documentation-link"
-           href="http://edx.readthedocs.io/projects/edx-partner-course-staff/en/latest/exercises_tools/create_exercises_and_tools.html#levels-of-support-for-tools" target="_blank">
+           href="https://edx.readthedocs.io/projects/edx-partner-course-staff/en/latest/exercises_tools/create_exercises_and_tools.html#levels-of-support-for-tools" target="_blank">
             <%- support_legend.documentation_label %>
         </a>
         <span class="support-documentation-level">

--- a/common/djangoapps/third_party_auth/pipeline.py
+++ b/common/djangoapps/third_party_auth/pipeline.py
@@ -54,7 +54,7 @@ This is surprising but important behavior, since it allows a single function in
 the pipeline to consolidate all the operations needed to establish invariants
 rather than spreading them across two functions in the pipeline.
 
-See http://python-social-auth.readthedocs.io/en/latest/pipeline.html for more docs.
+See https://python-social-auth.readthedocs.io/en/latest/pipeline.html for more docs.
 """
 
 import base64

--- a/common/lib/xmodule/setup.py
+++ b/common/lib/xmodule/setup.py
@@ -58,7 +58,7 @@ setup(
         'xmodule': ['js/module/*'],
     },
 
-    # See http://setuptools.readthedocs.io/en/latest/setuptools.html#dynamic-discovery-of-services-and-plugins
+    # See https://setuptools.readthedocs.io/en/latest/setuptools.html#dynamic-discovery-of-services-and-plugins
     # for a description of entry_points
     entry_points={
         'xblock.v1': XMODULES + XBLOCKS,

--- a/common/lib/xmodule/xmodule/lti_module.py
+++ b/common/lib/xmodule/xmodule/lti_module.py
@@ -82,7 +82,7 @@ log = logging.getLogger(__name__)
 
 DOCS_ANCHOR_TAG_OPEN = (
     "<a target='_blank' "
-    "href='http://edx.readthedocs.io/projects/edx-partner-course-staff/en/latest/exercises_tools/lti_component.html'>"
+    "href='https://edx.readthedocs.io/projects/edx-partner-course-staff/en/latest/exercises_tools/lti_component.html'>"
 )
 
 # Make '_' a no-op so we can scrape strings. Using lambda instead of

--- a/common/lib/xmodule/xmodule/templates/about/overview.yaml
+++ b/common/lib/xmodule/xmodule/templates/about/overview.yaml
@@ -42,7 +42,7 @@ data: |
         <article class="response">
           <h3>What web browser should I use?</h3>
           <p>The Open edX platform works best with current versions of Chrome, Edge, Firefox, Internet Explorer, or Safari.</p>
-          <p>See our <a href="http://edx.readthedocs.org/projects/open-edx-learner-guide/en/latest/front_matter/browsers.html">list of supported browsers</a> for the most up-to-date information.</p>
+          <p>See our <a href="https://edx.readthedocs.org/projects/open-edx-learner-guide/en/latest/front_matter/browsers.html">list of supported browsers</a> for the most up-to-date information.</p>
         </article>
 
         <article class="response">

--- a/common/lib/xmodule/xmodule/templates/problem/circuitschematic.yaml
+++ b/common/lib/xmodule/xmodule/templates/problem/circuitschematic.yaml
@@ -12,7 +12,7 @@ data: |
         </p>
         <p>
             For more information, see
-            <a href="http://edx.readthedocs.io/projects/edx-partner-course-staff/en/latest/exercises_tools/circuit_schematic_builder.html" target="_blank">
+            <a href="https://edx.readthedocs.io/projects/edx-partner-course-staff/en/latest/exercises_tools/circuit_schematic_builder.html" target="_blank">
             Circuit Schematic Builder Problem</a> in <i>Building and Running an edX Course</i>.
         </p>
         <p>

--- a/common/lib/xmodule/xmodule/templates/problem/customgrader.yaml
+++ b/common/lib/xmodule/xmodule/templates/problem/customgrader.yaml
@@ -23,7 +23,7 @@ data: |
                 click the "Show Answer" button.
             </p>
             <p>
-                For more information, see <a href="http://edx.readthedocs.io/projects/edx-partner-course-staff/en/latest/exercises_tools/custom_python.html" target="_blank">
+                For more information, see <a href="https://edx.readthedocs.io/projects/edx-partner-course-staff/en/latest/exercises_tools/custom_python.html" target="_blank">
                 Write-Your-Own-Grader Problem</a> in <i>Building and Running an edX Course</i>.
             </p>
             <p>

--- a/common/lib/xmodule/xmodule/templates/problem/drag_and_drop.yaml
+++ b/common/lib/xmodule/xmodule/templates/problem/drag_and_drop.yaml
@@ -8,7 +8,7 @@ data: |
       <p>In drag and drop problems, students respond to a question by dragging text or objects to a specific location on an image.</p>
       <p>
           For more information, see
-          <a href="http://edx.readthedocs.io/projects/edx-partner-course-staff/en/latest/exercises_tools/drag_and_drop_deprecated.html" target="_blank">
+          <a href="https://edx.readthedocs.io/projects/edx-partner-course-staff/en/latest/exercises_tools/drag_and_drop_deprecated.html" target="_blank">
           Drag and Drop Problem (Deprecated)</a> in <i>Building and Running an edX Course</i>.
       </p>
       <p>

--- a/common/lib/xmodule/xmodule/templates/problem/imageresponse.yaml
+++ b/common/lib/xmodule/xmodule/templates/problem/imageresponse.yaml
@@ -7,7 +7,7 @@ data:   |
             <p>
                 In an image mapped input problem, also known as a "pointing on a picture" problem, students click inside a defined region in an image. You define this region by including coordinates in the body of the problem. You can define one rectangular region,
                 multiple rectangular regions, or one non-rectangular region. For more information, see
-                <a href="http://edx.readthedocs.io/projects/edx-partner-course-staff/en/latest/exercises_tools/image_mapped_input.html" target="_blank">Image Mapped Input Problem</a>
+                <a href="https://edx.readthedocs.io/projects/edx-partner-course-staff/en/latest/exercises_tools/image_mapped_input.html" target="_blank">Image Mapped Input Problem</a>
                 in
                 <i>Building and Running an edx Course</i>.
             </p>

--- a/common/lib/xmodule/xmodule/templates/problem/jsinput_response.yaml
+++ b/common/lib/xmodule/xmodule/templates/problem/jsinput_response.yaml
@@ -20,12 +20,12 @@ data: |
           </p>
           <p>
               For more information, see
-              <a href="http://edx.readthedocs.io/projects/edx-partner-course-staff/en/latest/exercises_tools/custom_javascript.html" target="_blank">
+              <a href="https://edx.readthedocs.io/projects/edx-partner-course-staff/en/latest/exercises_tools/custom_javascript.html" target="_blank">
               Custom JavaScript Problem</a> in <i>Building and Running an edX Course</i>.
           </p>
           <p>
               JavaScript developers can also see
-              <a href="http://edx.readthedocs.io/projects/edx-developer-guide/en/latest/extending_platform/javascript.html" target="_blank">
+              <a href="https://edx.readthedocs.io/projects/edx-developer-guide/en/latest/extending_platform/javascript.html" target="_blank">
               Custom JavaScript Applications</a> in the <i>EdX Developer's Guide</i>.
           </p>
           <p>

--- a/common/lib/xmodule/xmodule/templates/problem/latex_problem.yaml
+++ b/common/lib/xmodule/xmodule/templates/problem/latex_problem.yaml
@@ -96,7 +96,7 @@ data: |
       </p>
       <p>
           For more information, see
-          <a href="http://edx.readthedocs.io/projects/edx-partner-course-staff/en/latest/exercises_tools/problem_in_latex.html" target="_blank">
+          <a href="https://edx.readthedocs.io/projects/edx-partner-course-staff/en/latest/exercises_tools/problem_in_latex.html" target="_blank">
           Problem Written in LaTeX</a> in <i>Building and Running an edX Course</i>.
       </p>
       <p>You can use the following example problems as models.</p>

--- a/common/test/acceptance/tests/helpers.py
+++ b/common/test/acceptance/tests/helpers.py
@@ -454,7 +454,7 @@ def url_for_help(book_slug, path_component):
     """
     # Emulate the switch between books that happens in envs/bokchoy.py
     books = EDX_BOOKS if RELEASE_LINE == "master" else OPEN_BOOKS
-    url = 'http://edx.readthedocs.io/projects/{}/en/{}{}'.format(books[book_slug], doc_version(), path_component)
+    url = 'https://edx.readthedocs.io/projects/{}/en/{}{}'.format(books[book_slug], doc_version(), path_component)
     return url
 
 

--- a/common/test/acceptance/tests/lms/test_teams.py
+++ b/common/test/acceptance/tests/lms/test_teams.py
@@ -1030,7 +1030,7 @@ class CreateTeamTest(TeamFormActions):
         # way to write something that waits for that event handler to be bound
         # to the button element. So I used time.sleep as well, even though
         # the bok choy docs explicitly ask us not to:
-        # http://bok-choy.readthedocs.io/en/latest/guidelines.html
+        # https://bok-choy.readthedocs.io/en/latest/guidelines.html
         # Sorry! For the story to address this anti-pattern, see TNL-5820
         time.sleep(0.5)
         self.team_management_page.submit_form()

--- a/common/test/data/scoreable/about/overview.html
+++ b/common/test/data/scoreable/about/overview.html
@@ -37,7 +37,7 @@
     <article class="response">
       <h3>What web browser should I use?</h3>
       <p>The Open edX platform works best with current versions of Chrome, Firefox or Safari, or with Internet Explorer version 9 and above.</p>
-      <p>See our <a href="http://edx.readthedocs.org/projects/open-edx-learner-guide/en/latest/front_matter/browsers.html">list of supported browsers</a> for the most up-to-date information.</p>
+      <p>See our <a href="https://edx.readthedocs.org/projects/open-edx-learner-guide/en/latest/front_matter/browsers.html">list of supported browsers</a> for the most up-to-date information.</p>
     </article>
 
     <article class="response">

--- a/docs/best_practices.rst
+++ b/docs/best_practices.rst
@@ -52,6 +52,6 @@ data`_ in the course outline feature.
 .. _Course Overviews: https://github.com/edx/edx-platform/blob/master/openedx/core/djangoapps/content/course_overviews/__init__.py
 .. _example use of course overviews: https://github.com/edx/edx-platform/blob/f81c21902eb0e8d026612b052557142ce1527153/openedx/features/course_experience/views/course_outline.py#L26
 .. _Course Blocks: https://openedx.atlassian.net/wiki/display/EDUCATOR/Course+Blocks
-.. _modulestore: http://edx.readthedocs.io/projects/edx-developer-guide/en/latest/modulestores/index.html
+.. _modulestore: https://edx.readthedocs.io/projects/edx-developer-guide/en/latest/modulestores/index.html
 .. _example of using course blocks: https://github.com/edx/edx-platform/blob/f81c21902eb0e8d026612b052557142ce1527153/openedx/features/course_experience/utils.py#L65-L72
 .. _example loading the student module data: https://github.com/edx/edx-platform/blob/f81c21902eb0e8d026612b052557142ce1527153/openedx/features/course_experience/utils.py#L49

--- a/docs/testing.rst
+++ b/docs/testing.rst
@@ -72,7 +72,7 @@ UI Acceptance Tests
    in favor of Bok Choy for new tests.  Most of these tests simulate user
    interactions through the browser using `splinter`_.
 
-.. _Bok Choy: http://bok-choy.readthedocs.org/en/latest/tutorial.html
+.. _Bok Choy: https://bok-choy.readthedocs.org/en/latest/tutorial.html
 .. _lettuce: http://lettuce.it/
 .. _splinter: http://splinter.cobrateam.info/
 
@@ -463,12 +463,12 @@ Accessibility Developer Tools`_ or `Deque's aXe Core`_.  For more details about
 how to write accessibility tests, please read the `Bok Choy documentation`_ and
 the `Automated Accessibility Tests`_ Open edX Confluence page.
 
-.. _automated accessibility testing: http://bok-choy.readthedocs.org/en/latest/accessibility.html
+.. _automated accessibility testing: https://bok-choy.readthedocs.org/en/latest/accessibility.html
 .. _Selenium: http://docs.seleniumhq.org/
 .. _Python: https://www.python.org/
 .. _Google Accessibility Developer Tools: https://github.com/GoogleChrome/accessibility-developer-tools/
 .. _Deque's aXe Core: https://github.com/dequelabs/axe-core/
-.. _Bok Choy documentation: http://bok-choy.readthedocs.org/en/latest/accessibility.html
+.. _Bok Choy documentation: https://bok-choy.readthedocs.org/en/latest/accessibility.html
 .. _Automated Accessibility Tests: https://openedx.atlassian.net/wiki/display/TE/Automated+Accessibility+Tests
 
 

--- a/lms/celery.py
+++ b/lms/celery.py
@@ -2,7 +2,7 @@
 Import celery, load its settings from the django settings
 and auto discover tasks in all installed django apps.
 
-Taken from: http://celery.readthedocs.org/en/latest/django/first-steps-with-django.html
+Taken from: https://celery.readthedocs.org/en/latest/django/first-steps-with-django.html
 """
 from __future__ import absolute_import
 

--- a/lms/envs/bok_choy.py
+++ b/lms/envs/bok_choy.py
@@ -236,8 +236,8 @@ LMS_ROOT_URL = "http://localhost:8000"
 if RELEASE_LINE == "master":
     # On master, acceptance tests use edX books, not the default Open edX books.
     HELP_TOKENS_BOOKS = {
-        'learner': 'http://edx.readthedocs.io/projects/edx-guide-for-students',
-        'course_author': 'http://edx.readthedocs.io/projects/edx-partner-course-staff',
+        'learner': 'https://edx.readthedocs.io/projects/edx-guide-for-students',
+        'course_author': 'https://edx.readthedocs.io/projects/edx-partner-course-staff',
     }
 
 WAFFLE_OVERRIDE = True

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -1073,7 +1073,7 @@ derived('LOCALE_PATHS')
 MESSAGE_STORAGE = 'django.contrib.messages.storage.session.SessionStorage'
 
 # Guidelines for translators
-TRANSLATORS_GUIDE = 'http://edx.readthedocs.org/projects/edx-developer-guide/en/latest/conventions/internationalization/i18n_translators_guide.html'  # pylint: disable=line-too-long
+TRANSLATORS_GUIDE = 'https://edx.readthedocs.org/projects/edx-developer-guide/en/latest/conventions/internationalization/i18n_translators_guide.html'  # pylint: disable=line-too-long
 
 #################################### GITHUB #######################################
 # gitreload is used in LMS-workflow to pull content from github
@@ -1856,7 +1856,7 @@ WEBPACK_CONFIG_PATH = 'webpack.prod.config.js'
 
 # We don't enable Django Debug Toolbar universally, but whenever we do, we want
 # to avoid patching settings.  Patched settings can cause circular import
-# problems: http://django-debug-toolbar.readthedocs.org/en/1.0/installation.html#explicit-setup
+# problems: https://django-debug-toolbar.readthedocs.org/en/1.0/installation.html#explicit-setup
 
 DEBUG_TOOLBAR_PATCH_SETTINGS = False
 
@@ -3281,8 +3281,8 @@ ENABLE_COMPREHENSIVE_THEMING = True
 # API access management
 API_ACCESS_MANAGER_EMAIL = 'api-access@example.com'
 API_ACCESS_FROM_EMAIL = 'api-requests@example.com'
-API_DOCUMENTATION_URL = 'http://course-catalog-api-guide.readthedocs.io/en/latest/'
-AUTH_DOCUMENTATION_URL = 'http://course-catalog-api-guide.readthedocs.io/en/latest/authentication/index.html'
+API_DOCUMENTATION_URL = 'https://course-catalog-api-guide.readthedocs.io/en/latest/'
+AUTH_DOCUMENTATION_URL = 'https://course-catalog-api-guide.readthedocs.io/en/latest/authentication/index.html'
 
 # Affiliate cookie tracking
 AFFILIATE_COOKIE_NAME = 'affiliate_id'
@@ -3300,8 +3300,8 @@ HELP_TOKENS_INI_FILE = REPO_ROOT / "lms" / "envs" / "help_tokens.ini"
 HELP_TOKENS_LANGUAGE_CODE = lambda settings: settings.LANGUAGE_CODE
 HELP_TOKENS_VERSION = lambda settings: doc_version()
 HELP_TOKENS_BOOKS = {
-    'learner': 'http://edx.readthedocs.io/projects/open-edx-learner-guide',
-    'course_author': 'http://edx.readthedocs.io/projects/open-edx-building-and-running-a-course',
+    'learner': 'https://edx.readthedocs.io/projects/open-edx-learner-guide',
+    'course_author': 'https://edx.readthedocs.io/projects/open-edx-building-and-running-a-course',
 }
 derived('HELP_TOKENS_LANGUAGE_CODE', 'HELP_TOKENS_VERSION')
 

--- a/lms/static/js/fixtures/calculator.html
+++ b/lms/static/js/fixtures/calculator.html
@@ -13,8 +13,8 @@
                         <li class="hint-item" id="hint-moreinfo" tabindex="-1">
                             <p>
                                 <span class="bold">For detailed information, see
-                                <a id="hint-link-first" href="http://edx.readthedocs.io/projects/edx-guide-for-students/en/latest/completing_assignments/SFD_mathformatting.html#math-formatting">Entering Mathematical and Scientific Expressions</a> in the
-                                <a id="hint-link-second" href="http://edx-guide-for-students.readthedocs.io/en/latest/index.html">EdX Learner's Guide</a>.
+                                <a id="hint-link-first" href="https://edx.readthedocs.io/projects/edx-guide-for-students/en/latest/completing_assignments/SFD_mathformatting.html#math-formatting">Entering Mathematical and Scientific Expressions</a> in the
+                                <a id="hint-link-second" href="https://edx-guide-for-students.readthedocs.io/en/latest/index.html">EdX Learner's Guide</a>.
                                 </span>
                             </p>
                         </li>

--- a/lms/static/js/student_account/components/StudentAccountDeletion.jsx
+++ b/lms/static/js/student_account/components/StudentAccountDeletion.jsx
@@ -41,7 +41,7 @@ export class StudentAccountDeletion extends React.Component {
     const loseAccessText = StringUtils.interpolate(
       gettext('You may also lose access to verified certificates and other program credentials like MicroMasters certificates. If you want to make a copy of these for your records before proceeding with deletion, follow the instructions for {htmlStart}printing or downloading a certificate{htmlEnd}.'),
       {
-        htmlStart: '<a href="http://edx.readthedocs.io/projects/edx-guide-for-students/en/latest/SFD_certificates.html#printing-a-certificate" target="_blank">',
+        htmlStart: '<a href="https://edx.readthedocs.io/projects/edx-guide-for-students/en/latest/SFD_certificates.html#printing-a-certificate" target="_blank">',
         htmlEnd: '</a>',
       },
     );

--- a/lms/static/js/student_account/components/StudentAccountDeletionModal.jsx
+++ b/lms/static/js/student_account/components/StudentAccountDeletionModal.jsx
@@ -96,7 +96,7 @@ class StudentAccountDeletionConfirmationModal extends React.Component {
     const loseAccessText = StringUtils.interpolate(
       gettext('You may also lose access to verified certificates and other program credentials like MicroMasters certificates. If you want to make a copy of these for your records before proceeding with deletion, follow the instructions for {htmlStart}printing or downloading a certificate{htmlEnd}.'),
       {
-        htmlStart: '<a href="http://edx.readthedocs.io/projects/edx-guide-for-students/en/latest/SFD_certificates.html#printing-a-certificate" target="_blank">',
+        htmlStart: '<a href="https://edx.readthedocs.io/projects/edx-guide-for-students/en/latest/SFD_certificates.html#printing-a-certificate" target="_blank">',
         htmlEnd: '</a>',
       },
     );

--- a/lms/templates/calculator/toggle_calculator.html
+++ b/lms/templates/calculator/toggle_calculator.html
@@ -25,9 +25,9 @@ from openedx.core.djangolib.markup import HTML, Text
                             <p>
                                 <span class="bold">
                                     ${Text(_("For detailed information, see {math_link_start}Entering Mathematical and Scientific Expressions{math_link_end} in the {guide_link_start}edX Guide for Students{guide_link_end}.")).format(
-                                        math_link_start=HTML('<a href="http://edx.readthedocs.io/projects/edx-guide-for-students/en/latest/completing_assignments/SFD_mathformatting.html#math-formatting">'),
+                                        math_link_start=HTML('<a href="https://edx.readthedocs.io/projects/edx-guide-for-students/en/latest/completing_assignments/SFD_mathformatting.html#math-formatting">'),
                                         math_link_end=HTML('</a>'),
-                                        guide_link_start=HTML('<a href="http://edx-guide-for-students.readthedocs.io/en/latest/index.html">'),
+                                        guide_link_start=HTML('<a href="https://edx-guide-for-students.readthedocs.io/en/latest/index.html">'),
                                         guide_link_end=HTML('</a>'),
                                     )}
                                 </span>

--- a/lms/templates/certificates/_edx-accomplishment-print-help.html
+++ b/lms/templates/certificates/_edx-accomplishment-print-help.html
@@ -8,7 +8,7 @@ from openedx.core.djangolib.markup import HTML, Text
         <div class="accomplishment-support-print">
             <p class="accomplishment-metadata-copy">
                 ${Text(_("For tips and tricks on printing your certificate, view the {link_start}Web Certificates help documentation{link_end}.")).format(
-                    link_start=HTML('<a href="http://edx.readthedocs.org/projects/edx-guide-for-students/en/latest/SFD_certificates.html#web-certificates">'),
+                    link_start=HTML('<a href="https://edx.readthedocs.org/projects/edx-guide-for-students/en/latest/SFD_certificates.html#web-certificates">'),
                     link_end=HTML('</a>'),
                 )}
             </p>

--- a/openedx.yaml
+++ b/openedx.yaml
@@ -1,5 +1,5 @@
 # This file describes this Open edX repo, as described in OEP-2:
-# http://open-edx-proposals.readthedocs.io/en/latest/oeps/oep-0002.html#specification
+# https://open-edx-proposals.readthedocs.io/en/latest/oeps/oep-0002.html#specification
 
 nick: edx
 oeps: {}

--- a/openedx/core/djangoapps/schedules/docs/README.rst
+++ b/openedx/core/djangoapps/schedules/docs/README.rst
@@ -155,7 +155,7 @@ Configuring A.C.E.
 
 These instructions assume you have already setup an Open edX instance or
 are running devstack. See the `Open edX Developer’s
-Guide <http://edx.readthedocs.io/projects/edx-developer-guide/en/latest/>`__
+Guide <https://edx.readthedocs.io/projects/edx-developer-guide/en/latest/>`__
 for information on setting them up.
 
 The Schedule app relies on ACE. When live, ACE sends emails to users

--- a/openedx/core/djangoapps/theming/finders.py
+++ b/openedx/core/djangoapps/theming/finders.py
@@ -14,7 +14,7 @@ they are pushed to production. To make sure that themed assets are collected
 and served by the system (in addition to core assets), we need to extend this
 interface, as well.
 
-.. _Django-Pipeline: http://django-pipeline.readthedocs.org/
+.. _Django-Pipeline: https://django-pipeline.readthedocs.org/
 .. _Django-Require: https://github.com/etianen/django-require
 """
 import os

--- a/openedx/core/lib/celery/routers.py
+++ b/openedx/core/lib/celery/routers.py
@@ -1,7 +1,7 @@
 """
 Custom routers used by both lms and cms when routing tasks to worker queues.
 
-For more, see http://celery.readthedocs.io/en/latest/userguide/routing.html#routers
+For more, see https://celery.readthedocs.io/en/latest/userguide/routing.html#routers
 """
 import logging
 from abc import ABCMeta, abstractproperty

--- a/openedx/features/learner_profile/views/learner_profile.py
+++ b/openedx/features/learner_profile/views/learner_profile.py
@@ -60,7 +60,7 @@ def learner_profile(request, username):
                 'profile. {learn_more_link_start}Learn more{learn_more_link_end}'
             )).format(
                 learn_more_link_start=HTML(
-                    '<a href="http://edx.readthedocs.io/projects/open-edx-learner-guide/en/'
+                    '<a href="https://edx.readthedocs.io/projects/open-edx-learner-guide/en/'
                     'latest/SFD_dashboard_profile_SectionHead.html#adding-profile-information">'
                 ),
                 learn_more_link_end=HTML('</a>')

--- a/pavelib/bok_choy.py
+++ b/pavelib/bok_choy.py
@@ -1,6 +1,6 @@
 """
 Run acceptance tests that use the bok-choy framework
-http://bok-choy.readthedocs.org/en/latest/
+https://bok-choy.readthedocs.org/en/latest/
 """
 
 import os

--- a/pavelib/quality.py
+++ b/pavelib/quality.py
@@ -317,7 +317,7 @@ def run_pep8(options):  # pylint: disable=unused-argument
 def run_complexity():
     """
     Uses radon to examine cyclomatic complexity.
-    For additional details on radon, see http://radon.readthedocs.org/
+    For additional details on radon, see https://radon.readthedocs.org/
     """
     system_string = '/ '.join(ALL_SYSTEMS.split(',')) + '/'
     complexity_report_dir = (Env.REPORT_DIR / "complexity")

--- a/scripts/xss-commit-linter.sh
+++ b/scripts/xss-commit-linter.sh
@@ -26,7 +26,7 @@ show_help() {
     echo "For more help using the xss linter, including details on how to"
     echo "understand and fix any violations, read the docs here:"
     echo ""
-    echo "  http://edx.readthedocs.org/projects/edx-developer-guide/en/latest/conventions/preventing_xss.html#xss-linter"
+    echo "  https://edx.readthedocs.org/projects/edx-developer-guide/en/latest/conventions/preventing_xss.html#xss-linter"
 
 }
 

--- a/scripts/xsslint/xsslint/main.py
+++ b/scripts/xsslint/xsslint/main.py
@@ -133,7 +133,7 @@ def main():
     epilog += "understand and fix any violations, read the docs here:\n"
     epilog += "\n"
     # pylint: disable=line-too-long
-    epilog += "  http://edx.readthedocs.org/projects/edx-developer-guide/en/latest/conventions/preventing_xss.html#xss-linter\n"
+    epilog += "  https://edx.readthedocs.org/projects/edx-developer-guide/en/latest/conventions/preventing_xss.html#xss-linter\n"
 
     parser = argparse.ArgumentParser(
         formatter_class=argparse.RawDescriptionHelpFormatter,


### PR DESCRIPTION
Read the Docs just started redirecting custom domains to HTTPS: https://blog.readthedocs.com/https-for-custom-domains/ .  Update our URLs to fix bok-choy tests and send users to more secure links.