### PR TITLE
Fix sudden breakage of expectedFail

### DIFF
--- a/common/test/acceptance/tests/lms/test_lms_acid_xblock.py
+++ b/common/test/acceptance/tests/lms/test_lms_acid_xblock.py
@@ -3,7 +3,7 @@
 End-to-end tests for the LMS.
 """
 
-from unittest import expectedFailure
+import pytest
 
 from common.test.acceptance.fixtures.course import CourseFixture, XBlockFixtureDesc
 from common.test.acceptance.pages.common.auto_auth import AutoAuthPage
@@ -120,6 +120,7 @@ class XBlockAcidChildTest(XBlockAcidBase):
         self.validate_acid_block_view(acid_block)
 
 
+@pytest.mark.xfail
 class XBlockAcidAsideTest(XBlockAcidBase):
     """
     Tests of an AcidBlock with children
@@ -144,7 +145,6 @@ class XBlockAcidAsideTest(XBlockAcidBase):
             )
         ).install()
 
-    @expectedFailure
     def test_acid_block(self):
         """
         Verify that all expected acid block tests pass in the lms.


### PR DESCRIPTION
This test suddenly started [consistently breaking](https://build.testeng.edx.org/job/edx-platform-bok-choy-master/9275/) today in both Jenkins and devstack.  It was marked as `expectedFailure`, and in fact still raises `_ExpectedFailure`.  But now for some reason the test runner counts that as a test failure.  I found [one corroborated account](https://stackoverflow.com/questions/5809333/python-raising-expectedfailure-for-unittests-with-unittest-expectedfailure) of a similar incident, which seemed to have something to do with a particular Python installation.

Anyway, switching to the `pytest` xfail marker returns the test to functioning as before.  This is the only bok-choy test in which we use the `expectedFailure` decorator; it's also used in one unit test, which still seems to be working as expected.  It may be worth further investigation to figure out what happened here, but at least this should fix the bok-choy test runs in the meantime.