### PR TITLE
Delete flaky test due for removal anyway

### DIFF
--- a/common/test/acceptance/tests/lms/test_lms_courseware.py
+++ b/common/test/acceptance/tests/lms/test_lms_courseware.py
@@ -509,42 +509,6 @@ class CoursewareMultipleVerticalsTest(CoursewareMultipleVerticalsTestBase):
             sequence_ui_events
         )
 
-    # TODO: TNL-6546: Delete this whole test if these events are going away(?)
-    def test_outline_selected_events(self):
-        self.courseware_page.visit()
-
-        self.courseware_page.nav.go_to_section('Test Section 1', 'Test Subsection 1,2')
-
-        self.courseware_page.nav.go_to_section('Test Section 2', 'Test Subsection 2,1')
-
-        # test UI events emitted by navigating via the course outline
-        filter_selected_events = lambda event: event.get('name', '') == 'edx.ui.lms.outline.selected'
-        selected_events = self.wait_for_events(event_filter=filter_selected_events, timeout=2)
-
-        # note: target_url is tested in unit tests, as the url changes here with every test (it includes GUIDs).
-        self.assert_events_match(
-            [
-                {
-                    'event_type': 'edx.ui.lms.outline.selected',
-                    'name': 'edx.ui.lms.outline.selected',
-                    'event': {
-                        'target_name': 'Test Subsection 1,2 ',
-                        'widget_placement': 'accordion',
-                    }
-                },
-                {
-                    'event_type': 'edx.ui.lms.outline.selected',
-                    'name': 'edx.ui.lms.outline.selected',
-                    'event': {
-                        'target_name': 'Test Subsection 2,1 ',
-                        'widget_placement': 'accordion',
-
-                    }
-                },
-            ],
-            selected_events
-        )
-
     # TODO: Delete as part of TNL-6546 / LEARNER-71
     def test_link_clicked_events(self):
         """


### PR DESCRIPTION
This test has been flaking pretty often recently ([pass](https://build.testeng.edx.org/job/edx-platform-bok-choy-pr/57530/) and [fail](https://build.testeng.edx.org/job/edx-platform-bok-choy-pr/57529/) on same commit), and is due for removal anyway as part of [TNL-6546/LEARNER-71](https://openedx.atlassian.net/browse/LEARNER-71).