### PR TITLE
Use a unique name for test mongo dbs

### DIFF
--- a/cms/envs/test.py
+++ b/cms/envs/test.py
@@ -90,10 +90,10 @@ update_module_store_settings(
         'fs_root': TEST_ROOT / "data",
     },
     doc_store_settings={
-        'db': 'test_xmodule',
+        'db': 'test_xmodule_{}'.format(THIS_UUID),
         'host': MONGO_HOST,
         'port': MONGO_PORT_NUM,
-        'collection': 'test_modulestore{0}'.format(THIS_UUID),
+        'collection': 'test_modulestore',
     },
 )
 

--- a/common/lib/xmodule/xmodule/modulestore/tests/test_split_modulestore.py
+++ b/common/lib/xmodule/xmodule/modulestore/tests/test_split_modulestore.py
@@ -8,6 +8,7 @@ from path import Path as path
 import random
 import re
 import unittest
+import os
 import uuid
 
 import ddt
@@ -53,9 +54,9 @@ class SplitModuleTest(unittest.TestCase):
     # Snippets of what would be in the django settings envs file
     DOC_STORE_CONFIG = {
         'host': MONGO_HOST,
-        'db': 'test_xmodule',
+        'db': 'test_xmodule_{0}'.format(os.getpid()),
         'port': MONGO_PORT_NUM,
-        'collection': 'modulestore{0}'.format(uuid.uuid4().hex[:5]),
+        'collection': 'modulestore',
     }
     modulestore_options = {
         'default_class': 'xmodule.raw_module.RawDescriptor',

--- a/common/lib/xmodule/xmodule/modulestore/tests/test_split_w_old_mongo.py
+++ b/common/lib/xmodule/xmodule/modulestore/tests/test_split_w_old_mongo.py
@@ -2,7 +2,7 @@ import datetime
 import random
 import unittest
 import uuid
-
+import os
 import mock
 import pytest
 
@@ -35,7 +35,8 @@ class SplitWMongoCourseBootstrapper(unittest.TestCase):
     db_config = {
         'host': MONGO_HOST,
         'port': MONGO_PORT_NUM,
-        'db': 'test_xmodule',
+        'db': 'test_xmodule_{}'.format(os.getpid()),
+        'collection': 'modulestore'
     }
 
     modulestore_options = {
@@ -48,8 +49,6 @@ class SplitWMongoCourseBootstrapper(unittest.TestCase):
     split_course_key = CourseLocator('test_org', 'test_course', 'runid', branch=ModuleStoreEnum.BranchName.draft)
 
     def setUp(self):
-        self.db_config['collection'] = 'modulestore{0}'.format(uuid.uuid4().hex[:5])
-
         self.user_id = random.getrandbits(32)
         super(SplitWMongoCourseBootstrapper, self).setUp()
         self.split_mongo = SplitMongoModuleStore(

--- a/common/lib/xmodule/xmodule/modulestore/tests/utils.py
+++ b/common/lib/xmodule/xmodule/modulestore/tests/utils.py
@@ -9,6 +9,7 @@ from path import Path as path
 from shutil import rmtree
 from tempfile import mkdtemp
 from unittest import TestCase
+import os
 
 from xmodule.x_module import XModuleMixin
 from xmodule.contentstore.mongo import MongoContentStore
@@ -87,7 +88,7 @@ class MixedSplitTestCase(TestCase):
     DOC_STORE_CONFIG = {
         'host': MONGO_HOST,
         'port': MONGO_PORT_NUM,
-        'db': 'test_mongo_libs',
+        'db': 'test_mongo_libs_{0}'.format(os.getpid()),
         'collection': 'modulestore',
         'asset_collection': 'assetstore',
     }


### PR DESCRIPTION
Inside of `commonlib-unit` there has been a ton of flakiness when running xdist. It looks like this is mainly from using the same DB across multiple processes (even though they use different collections). It looks like using a unique DB for each process fixes this.

Here are some of the test failures with this flakiness, prior to the change:
* https://build.testeng.edx.org/job/edx-platform-python-pipeline-pr/161/testReport/junit/xmodule.xmodule.modulestore.tests.test_split_modulestore/SplitModuleItemTests/Run_Tests___commonlib_unit___test_has_item/
* https://build.testeng.edx.org/job/edx-platform-python-pipeline-pr/160/testReport/junit/xmodule.xmodule.modulestore.tests.test_split_modulestore/TestItemCrud/Run_Tests___commonlib_unit___test_create_minimal_item/
* https://build.testeng.edx.org/job/edx-platform-python-pipeline-pr/162/testReport/junit/xmodule.xmodule.tests.test_library_content/TestLibraryContentModuleNoSearchIndex/Run_Tests___commonlib_unit___test_validation_of_course_libraries/