### PR TITLE
Fix some eslint warnings about global _

### DIFF
--- a/cms/static/js/models/settings/course_grading_policy.js
+++ b/cms/static/js/models/settings/course_grading_policy.js
@@ -1,3 +1,4 @@
+/* globals _ */
 define(['backbone', 'js/models/location', 'js/collections/course_grader'],
     function(Backbone, Location, CourseGraderCollection) {
         var CourseGradingPolicy = Backbone.Model.extend({

--- a/common/lib/xmodule/xmodule/js/spec/video/video_context_menu_spec.js
+++ b/common/lib/xmodule/xmodule/js/spec/video/video_context_menu_spec.js
@@ -1,3 +1,4 @@
+/* globals _ */
 (function() {
     'use strict';
     describe('Video Context Menu', function() {

--- a/common/static/common/js/spec/discussion/view/discussion_thread_view_spec.js
+++ b/common/static/common/js/spec/discussion/view/discussion_thread_view_spec.js
@@ -1,5 +1,5 @@
 /* global
-    Discussion, DiscussionThreadShowView, DiscussionViewSpecHelper, DiscussionSpecHelper, DiscussionThreadView,
+    _, Discussion, DiscussionThreadShowView, DiscussionViewSpecHelper, DiscussionSpecHelper, DiscussionThreadView,
     DiscussionUtil, Thread, DiscussionContentView, ThreadResponseShowView
 */
 (function() {

--- a/lms/djangoapps/teams/static/teams/js/collections/base.js
+++ b/lms/djangoapps/teams/static/teams/js/collections/base.js
@@ -1,3 +1,4 @@
+/* globals _ */
 (function(define) {
     'use strict';
     define(['edx-ui-toolkit/js/pagination/paging-collection'],

--- a/lms/static/js/staff_debug_actions.js
+++ b/lms/static/js/staff_debug_actions.js
@@ -1,3 +1,4 @@
+/* globals _ */
 // Build StaffDebug object
 var StaffDebug = (function() {
     /* global getCurrentUrl:true */

--- a/lms/static/js/verify_student/views/review_photos_step_view.js
+++ b/lms/static/js/verify_student/views/review_photos_step_view.js
@@ -1,3 +1,4 @@
+/* globals _ */
 /**
  * View for the "review photos" step of the payment/verification flow.
  */


### PR DESCRIPTION
The recent merge of an old PR put us over the eslint threshold by one.  This fixes several `'_' is not defined` warnings, which gets us well under the threshold again.  I'll create a followup ticket to fix the remaining instances of this and reduce the threshold appropriately.