### PR TITLE
[WIP] Xdist fix flaky test_get_request_or_stub

### DIFF
--- a/openedx/core/djangoapps/external_auth/tests/test_helper.py
+++ b/openedx/core/djangoapps/external_auth/tests/test_helper.py
@@ -4,7 +4,6 @@ Tests for utility functions in external_auth module
 from django.test import TestCase
 from openedx.core.djangoapps.external_auth.views import _safe_postlogin_redirect
 
-
 class ExternalAuthHelperFnTest(TestCase):
     """
     Unit tests for the external_auth.views helper function

--- a/openedx/core/djangoapps/request_cache/tests.py
+++ b/openedx/core/djangoapps/request_cache/tests.py
@@ -18,8 +18,7 @@ class TestRequestCache(TestCase):
     Tests for the request cache.
     """
 
-    @patch('crum.get_current_request', side_effect=lambda: None)
-    def test_get_request_or_stub(self, empty_request):  # pylint: disable=unused-argument
+    def test_get_request_or_stub(self):
         """
         Outside the context of the request, we should still get a request
         that allows us to build an absolute URI.

--- a/openedx/core/djangoapps/request_cache/tests.py
+++ b/openedx/core/djangoapps/request_cache/tests.py
@@ -6,7 +6,7 @@ from celery.task import task
 from django.conf import settings
 from django.test import TestCase
 from django.test.utils import override_settings
-from mock import Mock
+from mock import patch, Mock
 
 from openedx.core.djangoapps.request_cache import get_request_or_stub
 from openedx.core.djangoapps.request_cache.middleware import RequestCache, request_cached
@@ -18,7 +18,8 @@ class TestRequestCache(TestCase):
     Tests for the request cache.
     """
 
-    def test_get_request_or_stub(self):
+    @patch('crum.get_current_request', side_effect=lambda: None)
+    def test_get_request_or_stub(self, empty_request):  # pylint: disable=unused-argument
         """
         Outside the context of the request, we should still get a request
         that allows us to build an absolute URI.


### PR DESCRIPTION
With xdist, it looks like `test_get_request_or_stub` is flaky. The test calls the external function `crum.get_current_request()`, expecting it to return None, but sometimes it returns an actual request. A mock seems like an appropriate fix here.