### PR TITLE
ENT-876: edx-enterprise version upgrade to 0.72.6

### DIFF
--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -117,7 +117,7 @@ edx-django-release-util==0.3.1
 edx-django-sites-extensions==2.3.1
 edx-django-utils==0.4.1
 edx-drf-extensions==1.6.1
-edx-enterprise==0.72.5
+edx-enterprise==0.72.6
 edx-i18n-tools==0.4.6
 edx-milestones==0.1.13
 edx-oauth2-provider==1.2.2

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -137,7 +137,7 @@ edx-django-release-util==0.3.1
 edx-django-sites-extensions==2.3.1
 edx-django-utils==0.4.1
 edx-drf-extensions==1.6.1
-edx-enterprise==0.72.5
+edx-enterprise==0.72.6
 edx-i18n-tools==0.4.6
 edx-lint==0.5.5
 edx-milestones==0.1.13

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -132,7 +132,7 @@ edx-django-release-util==0.3.1
 edx-django-sites-extensions==2.3.1
 edx-django-utils==0.4.1
 edx-drf-extensions==1.6.1
-edx-enterprise==0.72.5
+edx-enterprise==0.72.6
 edx-i18n-tools==0.4.6
 edx-lint==0.5.5
 edx-milestones==0.1.13


### PR DESCRIPTION
__Description:__

This PR upgrades edx-enterprise version from [0.72.5 to 0.72.6](https://github.com/edx/edx-enterprise/compare/0.72.5...0.72.6)

**JIRA Ticket:** [ENT-876](https://openedx.atlassian.net/browse/ENT-876)