### PR TITLE
Clean up requests in unittests

### DIFF
--- a/lms/djangoapps/courseware/tests/test_course_tools.py
+++ b/lms/djangoapps/courseware/tests/test_course_tools.py
@@ -56,14 +56,15 @@ class VerifiedUpgradeToolTest(SharedModuleStoreTestCase):
 
         DynamicUpgradeDeadlineConfiguration.objects.create(enabled=True)
 
+        self.request = RequestFactory().request()
+        crum.set_current_request(self.request)
+        self.addCleanup(crum.set_current_request, None)
         self.enrollment = CourseEnrollmentFactory(
             course_id=self.course.id,
             mode=CourseMode.AUDIT,
             course=self.course_overview,
         )
-        self.request = RequestFactory().request()
         self.request.user = self.enrollment.user
-        crum.set_current_request(self.request)
 
     def test_tool_visible(self):
         self.assertTrue(VerifiedUpgradeTool().is_enabled(self.request, self.course.id))

--- a/lms/djangoapps/courseware/tests/test_courses.py
+++ b/lms/djangoapps/courseware/tests/test_courses.py
@@ -14,6 +14,7 @@ from django.test.client import RequestFactory
 from django.test.utils import override_settings
 from opaque_keys.edx.keys import CourseKey
 from six import text_type
+from crum import set_current_request
 
 from courseware.courses import (
     course_open_for_self_enrollment,
@@ -307,6 +308,7 @@ class CoursesRenderTest(ModuleStoreTestCase):
         course_items = import_course_from_xml(store, self.user.id, TEST_DATA_DIR, ['toy'])
         course_key = course_items[0].id
         self.course = get_course_by_id(course_key)
+        self.addCleanup(set_current_request, None)
         self.request = get_mock_request(UserFactory.create())
 
     def test_get_course_info_section_render(self):

--- a/lms/djangoapps/courseware/tests/test_entrance_exam.py
+++ b/lms/djangoapps/courseware/tests/test_entrance_exam.py
@@ -4,6 +4,7 @@ Tests use cases related to LMS Entrance Exam behavior, such as gated content acc
 from django.urls import reverse
 from django.test.client import RequestFactory
 from mock import Mock, patch
+from crum import set_current_request
 
 from capa.tests.response_xml_factory import MultipleChoiceResponseXMLFactory
 from courseware.entrance_exams import (
@@ -140,6 +141,7 @@ class EntranceExamTestCases(LoginEnrollmentTestCase, ModuleStoreTestCase, Milest
         self.course.entrance_exam_id = unicode(self.entrance_exam.scope_ids.usage_id)
 
         self.anonymous_user = AnonymousUserFactory()
+        self.addCleanup(set_current_request, None)
         self.request = get_mock_request(UserFactory())
         modulestore().update_item(self.course, self.request.user.id)
 

--- a/lms/djangoapps/courseware/tests/test_tabs.py
+++ b/lms/djangoapps/courseware/tests/test_tabs.py
@@ -1,13 +1,13 @@
 """
 Test cases for tabs.
 """
-
 from django.contrib.auth.models import AnonymousUser
 from django.urls import reverse
 from django.http import Http404
 from milestones.tests.utils import MilestonesTestCaseMixin
 from mock import MagicMock, Mock, patch
 from six import text_type
+from crum import set_current_request
 
 from courseware.courses import get_course_by_id
 from courseware.tabs import (
@@ -262,6 +262,7 @@ class StaticTabDateTestCase(LoginEnrollmentTestCase, SharedModuleStoreTestCase):
 
     def test_invalid_course_key(self):
         self.setup_user()
+        self.addCleanup(set_current_request, None)
         request = get_mock_request(self.user)
         with self.assertRaises(Http404):
             StaticCourseTabView().get(request, course_id='edX/toy', tab_slug='new_tab')
@@ -269,6 +270,7 @@ class StaticTabDateTestCase(LoginEnrollmentTestCase, SharedModuleStoreTestCase):
     def test_get_static_tab_fragment(self):
         self.setup_user()
         course = get_course_by_id(self.course.id)
+        self.addCleanup(set_current_request, None)
         request = get_mock_request(self.user)
         tab = xmodule_tabs.CourseTabList.get_tab_by_slug(course.tabs, 'new_tab')
 
@@ -368,6 +370,7 @@ class EntranceExamsTabsTestCase(LoginEnrollmentTestCase, ModuleStoreTestCase, Mi
         self.enroll(self.course)
         self.user.is_staff = True
         self.relationship_types = get_milestone_relationship_types()
+        self.addCleanup(set_current_request, None)
 
     def test_get_course_tabs_list_entrance_exam_enabled(self):
         """
@@ -481,6 +484,7 @@ class TextBookCourseViewsTestCase(LoginEnrollmentTestCase, SharedModuleStoreTest
         Test that all textbooks tab links generating correctly.
         """
         type_to_reverse_name = {'textbook': 'book', 'pdftextbook': 'pdf_book', 'htmltextbook': 'html_book'}
+        self.addCleanup(set_current_request, None)
         request = get_mock_request(self.user)
         course_tab_list = get_course_tab_list(request, self.course)
         num_of_textbooks_found = 0
@@ -603,6 +607,10 @@ class ValidateTabsTestCase(TabListTestCase):
 class CourseTabListTestCase(TabListTestCase):
     """Testing the generator method for iterating through displayable tabs"""
 
+    def setUp(self):
+        super(CourseTabListTestCase, self).setUp()
+        self.addCleanup(set_current_request, None)
+
     def has_tab(self, tab_list, tab_type):
         """ Searches the given lab_list for a given tab_type. """
         for tab in tab_list:
@@ -705,6 +713,7 @@ class CourseTabListTestCase(TabListTestCase):
         self.course.save()
 
         user = self.create_mock_user(is_staff=False, is_enrolled=True)
+        self.addCleanup(set_current_request, None)
         request = get_mock_request(user)
         course_tab_list = get_course_tab_list(request, self.course)
         name_list = [x.name for x in course_tab_list]
@@ -776,6 +785,7 @@ class CourseInfoTabTestCase(TabTestCase):
     """Test cases for the course info tab."""
     def setUp(self):
         self.user = self.create_mock_user()
+        self.addCleanup(set_current_request, None)
         self.request = get_mock_request(self.user)
 
     @override_waffle_flag(UNIFIED_COURSE_TAB_FLAG, active=False)

--- a/lms/djangoapps/courseware/tests/test_views.py
+++ b/lms/djangoapps/courseware/tests/test_views.py
@@ -9,6 +9,7 @@ from datetime import datetime, timedelta
 from HTMLParser import HTMLParser
 from urllib import quote, urlencode
 from uuid import uuid4
+from crum import set_current_request
 
 from completion.test_utils import CompletionWaffleTestMixin
 import ddt
@@ -1875,6 +1876,7 @@ class ProgressPageShowCorrectnessTests(ProgressPageBaseTests):
             self.course,
             depth=2
         )
+        self.addCleanup(set_current_request, None)
         # pylint: disable=protected-access
         module = get_module(
             self.user,

--- a/lms/djangoapps/gating/tests/test_integration.py
+++ b/lms/djangoapps/gating/tests/test_integration.py
@@ -2,6 +2,7 @@
 Integration tests for gated content.
 """
 import ddt
+from crum import set_current_request
 from completion import waffle as completion_waffle
 from milestones import api as milestones_api
 from milestones.tests.utils import MilestonesTestCaseMixin
@@ -36,6 +37,7 @@ class TestGatedContent(MilestonesTestCaseMixin, SharedModuleStoreTestCase):
         self.setup_gating_milestone(50, 100)
         self.non_staff_user = UserFactory()
         self.staff_user = UserFactory(is_staff=True, is_superuser=True)
+        self.addCleanup(set_current_request, None)
         self.request = get_mock_request(self.non_staff_user)
 
     @classmethod

--- a/lms/djangoapps/grades/tests/base.py
+++ b/lms/djangoapps/grades/tests/base.py
@@ -1,3 +1,8 @@
+"""
+Base file for Grades tests
+"""
+from crum import set_current_request
+
 from capa.tests.response_xml_factory import MultipleChoiceResponseXMLFactory
 from lms.djangoapps.course_blocks.api import get_course_blocks
 from openedx.core.djangolib.testing.utils import get_mock_request
@@ -72,6 +77,7 @@ class GradeTestBase(SharedModuleStoreTestCase):
 
     def setUp(self):
         super(GradeTestBase, self).setUp()
+        self.addCleanup(set_current_request, None)
         self.request = get_mock_request(UserFactory())
         self.client.login(username=self.request.user.username, password="test")
         self._set_grading_policy()

--- a/lms/djangoapps/grades/tests/integration/test_access.py
+++ b/lms/djangoapps/grades/tests/integration/test_access.py
@@ -1,6 +1,7 @@
 """
 Test grading with access changes.
 """
+from crum import set_current_request
 
 from capa.tests.response_xml_factory import MultipleChoiceResponseXMLFactory
 from courseware.tests.test_submitting_problems import ProblemSubmissionTestMixin
@@ -68,6 +69,7 @@ class GradesAccessIntegrationTest(ProblemSubmissionTestMixin, SharedModuleStoreT
 
     def setUp(self):
         super(GradesAccessIntegrationTest, self).setUp()
+        self.addCleanup(set_current_request, None)
         self.request = get_mock_request(UserFactory())
         self.student = self.request.user
         self.client.login(username=self.student.username, password="test")

--- a/lms/djangoapps/grades/tests/integration/test_events.py
+++ b/lms/djangoapps/grades/tests/integration/test_events.py
@@ -3,6 +3,7 @@ Test grading events across apps.
 """
 
 from mock import call as mock_call, patch
+from crum import set_current_request
 
 from capa.tests.response_xml_factory import MultipleChoiceResponseXMLFactory
 from courseware.tests.test_submitting_problems import ProblemSubmissionTestMixin
@@ -66,6 +67,7 @@ class GradesEventIntegrationTest(ProblemSubmissionTestMixin, SharedModuleStoreTe
     def setUp(self):
         self.reset_course()
         super(GradesEventIntegrationTest, self).setUp()
+        self.addCleanup(set_current_request, None)
         self.request = get_mock_request(UserFactory())
         self.student = self.request.user
         self.client.login(username=self.student.username, password="test")

--- a/lms/djangoapps/grades/tests/integration/test_problems.py
+++ b/lms/djangoapps/grades/tests/integration/test_problems.py
@@ -3,6 +3,7 @@ import itertools
 
 import ddt
 import pytz
+from crum import set_current_request
 from capa.tests.response_xml_factory import MultipleChoiceResponseXMLFactory
 from courseware.tests.test_submitting_problems import ProblemSubmissionTestMixin
 from lms.djangoapps.course_blocks.api import get_course_blocks
@@ -42,6 +43,7 @@ class TestMultipleProblemTypesSubsectionScores(SharedModuleStoreTestCase):
         password = u'test'
         self.student = UserFactory.create(is_staff=False, username=u'test_student', password=password)
         self.client.login(username=self.student.username, password=password)
+        self.addCleanup(set_current_request, None)
         self.request = get_mock_request(self.student)
         self.course_structure = get_course_blocks(self.student, self.course.location)
 
@@ -134,6 +136,7 @@ class TestVariedMetadata(ProblemSubmissionTestMixin, ModuleStoreTestCase):
               </optionresponse>
             </problem>
         '''
+        self.addCleanup(set_current_request, None)
         self.request = get_mock_request(UserFactory())
         self.client.login(username=self.request.user.username, password="test")
         CourseEnrollment.enroll(self.request.user, self.course.id)
@@ -232,6 +235,7 @@ class TestWeightedProblems(SharedModuleStoreTestCase):
     def setUp(self):
         super(TestWeightedProblems, self).setUp()
         self.user = UserFactory()
+        self.addCleanup(set_current_request, None)
         self.request = get_mock_request(self.user)
 
     @classmethod

--- a/lms/djangoapps/grades/tests/test_course_grade.py
+++ b/lms/djangoapps/grades/tests/test_course_grade.py
@@ -1,6 +1,7 @@
 import ddt
 from django.conf import settings
 from mock import patch
+from crum import set_current_request
 
 from openedx.core.djangolib.testing.utils import get_mock_request
 from student.models import CourseEnrollment
@@ -102,6 +103,11 @@ class TestScoreForModule(SharedModuleStoreTestCase):
         answer_problem(cls.course, cls.request, cls.n, score=3, max_value=10)
 
         cls.course_grade = CourseGradeFactory().read(cls.request.user, cls.course)
+
+    @classmethod
+    def tearDownClass(cls):
+        super(TestScoreForModule, cls).tearDownClass()
+        set_current_request(None)
 
     def test_score_chapter(self):
         earned, possible = self.course_grade.score_for_module(self.a.location)

--- a/lms/djangoapps/instructor/tests/test_enrollment.py
+++ b/lms/djangoapps/instructor/tests/test_enrollment.py
@@ -14,6 +14,7 @@ from django.utils.translation import get_language
 from mock import patch
 from opaque_keys.edx.locator import CourseLocator
 from six import text_type
+from crum import set_current_request
 
 from capa.tests.response_xml_factory import MultipleChoiceResponseXMLFactory
 from courseware.models import StudentModule
@@ -540,6 +541,11 @@ class TestStudentModuleGrading(SharedModuleStoreTestCase):
         cls.request = get_mock_request(UserFactory())
         cls.user = cls.request.user
         cls.instructor = UserFactory(username='staff', is_staff=True)
+
+    @classmethod
+    def tearDownClass(cls):
+        super(TestStudentModuleGrading, cls).tearDownClass()
+        set_current_request(None)
 
     def _get_subsection_grade_and_verify(self, all_earned, all_possible, graded_earned, graded_possible):
         """

--- a/lms/djangoapps/mobile_api/tests/test_milestones.py
+++ b/lms/djangoapps/mobile_api/tests/test_milestones.py
@@ -3,6 +3,7 @@ Milestone related tests for the mobile_api
 """
 from django.conf import settings
 from mock import patch
+from crum import set_current_request
 
 from courseware.access_response import MilestoneAccessError
 from courseware.tests.test_entrance_exam import add_entrance_exam_milestone, answer_entrance_exam_problem
@@ -75,6 +76,7 @@ class MobileAPIMilestonesMixin(object):
         """
         Tests access when user has passed the entrance exam
         """
+        self.addCleanup(set_current_request, None)
         self._add_entrance_exam()
         self._pass_entrance_exam()
         self.init_course_access()

--- a/openedx/core/djangoapps/safe_sessions/tests/test_middleware.py
+++ b/openedx/core/djangoapps/safe_sessions/tests/test_middleware.py
@@ -9,6 +9,7 @@ from django.http import HttpResponse, HttpResponseRedirect, SimpleCookie
 from django.test import TestCase
 from django.test.utils import override_settings
 from mock import patch
+from crum import set_current_request
 
 from openedx.core.djangolib.testing.utils import get_mock_request
 
@@ -27,6 +28,7 @@ class TestSafeSessionProcessRequest(TestSafeSessionsLogMixin, TestCase):
     def setUp(self):
         super(TestSafeSessionProcessRequest, self).setUp()
         self.user = UserFactory.create()
+        self.addCleanup(set_current_request, None)
         self.request = get_mock_request()
 
     def assert_response(self, safe_cookie_data=None, success=True):
@@ -130,6 +132,7 @@ class TestSafeSessionProcessResponse(TestSafeSessionsLogMixin, TestCase):
     def setUp(self):
         super(TestSafeSessionProcessResponse, self).setUp()
         self.user = UserFactory.create()
+        self.addCleanup(set_current_request, None)
         self.request = get_mock_request()
         self.request.session = {}
         self.client.response = HttpResponse()
@@ -235,6 +238,7 @@ class TestSafeSessionMiddleware(TestSafeSessionsLogMixin, TestCase):
     def setUp(self):
         super(TestSafeSessionMiddleware, self).setUp()
         self.user = UserFactory.create()
+        self.addCleanup(set_current_request, None)
         self.request = get_mock_request()
         self.client.response = HttpResponse()
         self.client.response.cookies = SimpleCookie()

--- a/openedx/core/djangoapps/waffle_utils/tests/test_init.py
+++ b/openedx/core/djangoapps/waffle_utils/tests/test_init.py
@@ -32,6 +32,7 @@ class TestCourseWaffleFlag(TestCase):
     def setUp(self):
         super(TestCourseWaffleFlag, self).setUp()
         request = RequestFactory().request()
+        self.addCleanup(crum.set_current_request, None)
         crum.set_current_request(request)
         RequestCache.clear_request_cache()
 

--- a/openedx/core/djangoapps/waffle_utils/tests/test_testutils.py
+++ b/openedx/core/djangoapps/waffle_utils/tests/test_testutils.py
@@ -28,6 +28,7 @@ class OverrideWaffleFlagTests(TestCase):
     def setUp(self):
         super(OverrideWaffleFlagTests, self).setUp()
         request = RequestFactory().request()
+        self.addCleanup(crum.set_current_request, None)
         crum.set_current_request(request)
         RequestCache.clear_request_cache()
 

--- a/openedx/core/djangolib/testing/tests/test_utils.py
+++ b/openedx/core/djangolib/testing/tests/test_utils.py
@@ -1,6 +1,8 @@
 """
 Test that testing utils do what they say.
 """
+from crum import set_current_request
+
 from django.contrib.auth import get_user_model
 from django.contrib.auth.models import AnonymousUser
 from django.http.request import HttpRequest
@@ -16,6 +18,9 @@ class TestGetMockRequest(TestCase):
     """
     Validate the behavior of get_mock_request
     """
+    def setUp(self):
+        self.addCleanup(set_current_request, None)
+
     def test_mock_request_is_request(self):
         request = get_mock_request(USER_MODEL())
         self.assertIsInstance(request, HttpRequest)


### PR DESCRIPTION
I noticed that `test_get_request_or_stub` was flaky with xdist [(Link to failing test)](https://build.testeng.edx.org/job/edx-platform-python-pipeline-pr/200/testReport/junit/pavelib.paver_tests.test_xsslint/PaverXSSLintTest/Run_Tests___commonlib_unit___test_xsslint_violation_number_not_found/).

The test essentially expects to get `None` when calling `crum.get_current_request()`, however occasionally it would actually pick up a request (which was created from previous tests). This PR is basically just several cleanups to reset the request to None after tests that call `set_current_request` ... either directly, or through `get_mock_request`.

You'll also notice some slight reordering inside `test_course_tools.py`. For that test class, I noticed adding a request cleanup inside of `setUp` caused `test_tool_visible()` to fail, and after some digging realized that even on master the test will fail (if you run it independently), but by luck/ coincidence of test ordering it passed on Jenkins. It looks like creating the request before creating an enrollment solves this, as a request needs to be present for the waffle flag to be active, and a schedule to be created for the enrollment.