### PR TITLE
Add email address to retirement cancel success & test.

### DIFF
--- a/openedx/core/djangoapps/user_api/management/commands/cancel_user_retirement_request.py
+++ b/openedx/core/djangoapps/user_api/management/commands/cancel_user_retirement_request.py
@@ -56,4 +56,4 @@ class Command(BaseCommand):
         # No need to delete the accompanying "permanent" retirement request record - it gets done via Django signal.
         retirement_status.delete()
 
-        print("Successfully cancelled retirement request for user with email address '{}'.")
+        print("Successfully cancelled retirement request for user with email address '{}'.".format(email_address))

--- a/openedx/core/djangoapps/user_api/management/tests/test_cancel_retirement.py
+++ b/openedx/core/djangoapps/user_api/management/tests/test_cancel_retirement.py
@@ -15,11 +15,12 @@ from student.tests.factories import UserFactory
 pytestmark = pytest.mark.django_db
 
 
-def test_successful_cancellation(setup_retirement_states, logged_out_retirement_request):  # pylint: disable=redefined-outer-name, unused-argument
+def test_successful_cancellation(setup_retirement_states, logged_out_retirement_request, capsys):  # pylint: disable=redefined-outer-name, unused-argument
     """
     Test a successfully cancelled retirement request.
     """
     call_command('cancel_user_retirement_request', logged_out_retirement_request.original_email)
+    output = capsys.readouterr().out
     # Confirm that no retirement status exists for the user.
     with pytest.raises(UserRetirementStatus.DoesNotExist):
         UserRetirementStatus.objects.get(original_email=logged_out_retirement_request.user.email)
@@ -28,6 +29,8 @@ def test_successful_cancellation(setup_retirement_states, logged_out_retirement_
         UserRetirementRequest.objects.get(user=logged_out_retirement_request.user)
     # Ensure user can be retrieved using the original email address.
     User.objects.get(email=logged_out_retirement_request.original_email)
+    assert "Successfully cancelled retirement request for user with email address" in output
+    assert logged_out_retirement_request.original_email in output
 
 
 def test_cancellation_in_unrecoverable_state(setup_retirement_states, logged_out_retirement_request):  # pylint: disable=redefined-outer-name, unused-argument


### PR DESCRIPTION
Add email address to log message upon successful retirement of user. It was mistakenly left out in the initial implementation.