### PR TITLE
Send along our client name to NR Insights

### DIFF
--- a/openedx/core/djangoapps/oauth_dispatch/adapters/dop.py
+++ b/openedx/core/djangoapps/oauth_dispatch/adapters/dop.py
@@ -2,6 +2,7 @@
 Adapter to isolate django-oauth2-provider dependencies
 """
 
+from edx_django_utils import monitoring as monitoring_utils
 from provider.oauth2 import models
 from provider import constants, scope
 
@@ -43,7 +44,9 @@ class DOPAdapter(object):
 
         Wraps django's queryset.get() method.
         """
-        return models.Client.objects.get(**filters)
+        client = models.Client.objects.get(**filters)
+        monitoring_utils.set_custom_metric('oauth_client_name', client.name)
+        return client
 
     def get_client_for_token(self, token):
         """

--- a/openedx/core/djangoapps/oauth_dispatch/adapters/dot.py
+++ b/openedx/core/djangoapps/oauth_dispatch/adapters/dot.py
@@ -2,6 +2,7 @@
 Adapter to isolate django-oauth-toolkit dependencies
 """
 
+from edx_django_utils import monitoring as monitoring_utils
 from oauth2_provider import models
 
 from openedx.core.djangoapps.oauth_dispatch.models import RestrictedApplication
@@ -53,7 +54,9 @@ class DOTAdapter(object):
 
         Wraps django's queryset.get() method.
         """
-        return models.Application.objects.get(**filters)
+        client = models.Application.objects.get(**filters)
+        monitoring_utils.set_custom_metric('oauth_client_name', client.name)
+        return client
 
     def get_client_for_token(self, token):
         """

--- a/openedx/core/djangoapps/oauth_dispatch/tests/test_dot_adapter.py
+++ b/openedx/core/djangoapps/oauth_dispatch/tests/test_dot_adapter.py
@@ -8,6 +8,7 @@ from datetime import timedelta
 from django.conf import settings
 from django.test import TestCase
 from django.utils.timezone import now
+from mock import call, patch
 
 import ddt
 from oauth2_provider import models
@@ -84,6 +85,17 @@ class DOTAdapterTestCase(TestCase):
     def test_get_client_not_found(self):
         with self.assertRaises(models.Application.DoesNotExist):
             self.adapter.get_client(client_id='not-found')
+
+    @patch('edx_django_utils.monitoring.set_custom_metric')
+    def test_get_client_metrics(self, mock_set_custom_metric):
+        client = self.adapter.get_client(
+            redirect_uris=DUMMY_REDIRECT_URL,
+            client_type=models.Application.CLIENT_CONFIDENTIAL
+        )
+        expected_calls = [
+            call('oauth_client_name', client.name),
+        ]
+        mock_set_custom_metric.assert_has_calls(expected_calls, any_order=True)
 
     def test_get_client_for_token(self):
         token = models.AccessToken(


### PR DESCRIPTION
Right now we sent the oauth_client_id which is helpful, but means for debugging
you need to go pull the client id out of the database and figure out who the end user is.

I put the metric here to avoid loading the client until some code needs it
(other metrics are done in views.py and I can move there if needed)

OPS-3414