### PR TITLE
log npm installation on jenkins

### DIFF
--- a/lms/djangoapps/courseware/tests/test_i18n.py
+++ b/lms/djangoapps/courseware/tests/test_i18n.py
@@ -8,7 +8,6 @@ import re
 from django.conf import settings
 from django.contrib.auth.models import User
 from django.urls import reverse, reverse_lazy
-from django.test import TestCase
 from django.test.client import Client
 from django.utils import translation
 

--- a/openedx/core/djangoapps/dark_lang/tests.py
+++ b/openedx/core/djangoapps/dark_lang/tests.py
@@ -5,7 +5,6 @@ import unittest
 
 import ddt
 from django.http import HttpRequest
-from django.test import TestCase
 from django.test.client import Client
 from django.utils.translation import LANGUAGE_SESSION_KEY
 from mock import Mock

--- a/openedx/core/djangoapps/lang_pref/tests/test_api.py
+++ b/openedx/core/djangoapps/lang_pref/tests/test_api.py
@@ -2,7 +2,6 @@
 """ Tests for the language API. """
 
 from mock import patch
-from django.test import TestCase
 from django.test.utils import override_settings
 from django.utils import translation
 from django.contrib.auth.models import User

--- a/pavelib/paver_tests/test_decorators.py
+++ b/pavelib/paver_tests/test_decorators.py
@@ -1,0 +1,30 @@
+""" Tests for the utility decorators for Paver """
+import time
+
+import pytest
+
+from pavelib.utils.decorators import (
+    timeout, TimeoutException
+)
+
+
+def test_function_under_timeout():
+
+    @timeout(1)
+    def sample_function_1():
+        time.sleep(0.1)
+        return "sample text"
+
+    value = sample_function_1()
+    assert value == "sample text"
+
+
+def test_function_over_timeout():
+
+    @timeout(0.1)
+    def sample_function_2():
+        time.sleep(1)
+        return "sample text"
+
+    with pytest.raises(TimeoutException):
+        sample_function_2()

--- a/pavelib/paver_tests/utils.py
+++ b/pavelib/paver_tests/utils.py
@@ -89,23 +89,23 @@ def fail_on_pylint(*args):
         return
 
 
-def fail_on_npm_install(*args):
+def fail_on_npm_install(*args, **kwargs):  # pylint: disable=unused-argument
     """
     For our tests, we need the call for diff-quality running pycodestyle reports to fail, since that is what
     is going to fail when we pass in a percentage ("p") requirement.
     """
-    if "npm install" in args[0]:
+    if ["npm", "install", "--verbose"] == args[0]:
         raise BuildFailure('Subprocess return code: 1')
     else:
         return
 
 
-def unexpected_fail_on_npm_install(*args):
+def unexpected_fail_on_npm_install(*args, **kwargs):  # pylint: disable=unused-argument
     """
     For our tests, we need the call for diff-quality running pycodestyle reports to fail, since that is what
     is going to fail when we pass in a percentage ("p") requirement.
     """
-    if "npm install" in args[0]:
+    if ["npm", "install", "--verbose"] == args[0]:
         raise BuildFailure('Subprocess return code: 50')
     else:
         return

--- a/pavelib/prereqs.py
+++ b/pavelib/prereqs.py
@@ -6,12 +6,15 @@ import hashlib
 import os
 import re
 import sys
+import subprocess
+import io
 from distutils import sysconfig
 
 from paver.easy import BuildFailure, sh, task
 
 from .utils.envs import Env
 from .utils.timer import timed
+from .utils.decorators import timeout, TimeoutException
 
 PREREQS_STATE_DIR = os.getenv('PREREQ_CACHE_DIR', Env.REPO_ROOT / '.prereqs_cache')
 NO_PREREQ_MESSAGE = "NO_PREREQ_INSTALL is set, not installing prereqs"
@@ -79,7 +82,7 @@ def compute_fingerprint(path_list):
 
         # For files, hash the contents of the file
         if os.path.isfile(path_item):
-            with open(path_item, "rb") as file_handle:
+            with io.open(path_item, "rb") as file_handle:
                 hasher.update(file_handle.read())
 
     return hasher.hexdigest()
@@ -98,7 +101,7 @@ def prereq_cache(cache_name, paths, install_func):
     cache_file_path = os.path.join(PREREQS_STATE_DIR, "{}.sha1".format(cache_filename))
     old_hash = None
     if os.path.isfile(cache_file_path):
-        with open(cache_file_path) as cache_file:
+        with io.open(cache_file_path, "rb") as cache_file:
             old_hash = cache_file.read()
 
     # Compare the old hash to the new hash
@@ -112,7 +115,7 @@ def prereq_cache(cache_name, paths, install_func):
         # If the code executed within the context fails (throws an exception),
         # then this step won't get executed.
         create_prereqs_cache_dir()
-        with open(cache_file_path, "w") as cache_file:
+        with io.open(cache_file_path, "wb") as cache_file:
             # Since the pip requirement files are modified during the install
             # process, we need to store the hash generated AFTER the installation
             post_install_hash = compute_fingerprint(paths)
@@ -125,19 +128,48 @@ def node_prereqs_installation():
     """
     Configures npm and installs Node prerequisites
     """
+
+    @timeout(limit=300)
+    def _run_npm_command(npm_command, npm_log_file):
+        """
+        helper function for running the npm installation with a timeout.
+        The implementation of Paver's `sh` function returns before the forked
+        actually returns. Using a Popen object so that we can ensure that
+        the forked process has returned
+        """
+        proc = subprocess.Popen(npm_command, stderr=npm_log_file)
+        proc.wait()
+
+    # NPM installs hang sporadically. Log the installation process so that we
+    # determine if any packages are chronic offenders.
+    shard_str = os.getenv('SHARD', None)
+    if shard_str:
+        npm_log_file_path = '{}/npm-install.{}.log'.format(Env.GEN_LOG_DIR, shard_str)
+    else:
+        npm_log_file_path = '{}/npm-install.log'.format(Env.GEN_LOG_DIR)
+    npm_log_file = io.open(npm_log_file_path, 'wb')
+    npm_command = 'npm install --verbose'.split()
+
     cb_error_text = "Subprocess return code: 1"
 
     # Error handling around a race condition that produces "cb() never called" error. This
     # evinces itself as `cb_error_text` and it ought to disappear when we upgrade
     # npm to 3 or higher. TODO: clean this up when we do that.
     try:
-        sh('npm install')
+        _run_npm_command(npm_command, npm_log_file)
+    except TimeoutException:
+        print "NPM installation took too long. Exiting..."
+        print "Check {} for more information".format(npm_log_file_path)
+        sys.exit(1)
     except BuildFailure, error_text:
         if cb_error_text in error_text:
             print "npm install error detected. Retrying..."
-            sh('npm install')
+            _run_npm_command(npm_command, npm_log_file)
         else:
             raise BuildFailure(error_text)
+    print "Successfully installed NPM packages. Log found at {}".format(
+        npm_log_file_path
+    )
 
 
 def python_prereqs_installation():
@@ -192,7 +224,7 @@ def uninstall_python_packages():
     """
 
     if no_python_uninstall():
-        print(NO_PYTHON_UNINSTALL_MESSAGE)
+        print NO_PYTHON_UNINSTALL_MESSAGE
         return
 
     # So that we don't constantly uninstall things, use a hash of the packages
@@ -204,7 +236,7 @@ def uninstall_python_packages():
     create_prereqs_cache_dir()
 
     if os.path.isfile(state_file_path):
-        with open(state_file_path) as state_file:
+        with io.open(state_file_path) as state_file:
             version = state_file.read()
         if version == expected_version:
             print 'Python uninstalls unchanged, skipping...'
@@ -230,7 +262,7 @@ def uninstall_python_packages():
         return
 
     # Write our version.
-    with open(state_file_path, "w") as state_file:
+    with io.open(state_file_path, "wb") as state_file:
         state_file.write(expected_version)
 
 

--- a/pavelib/utils/decorators.py
+++ b/pavelib/utils/decorators.py
@@ -1,0 +1,58 @@
+""" a collection of utililty decorators for paver tasks """
+
+import multiprocessing
+from functools import wraps
+
+import psutil
+
+
+def timeout(limit=60):
+    """
+    kill a function if it has not completed within a specified timeframe
+    """
+
+    def _handle_function_process(*args, **kwargs):
+        """ helper function for running a function and getting its output """
+        queue = kwargs['queue']
+        function = kwargs['function_to_call']
+        function_args = args
+        function_kwargs = kwargs['function_kwargs']
+        function_output = function(*function_args, **function_kwargs)
+        queue.put(function_output)
+
+    def decorated_function(function):
+        """ the time-limited function returned by the timeout decorator """
+
+        def function_wrapper(*args, **kwargs):
+            """
+            take a function and run it on a separate process, forcing it to
+            either give up its return value or throw a TimeoutException with
+            a specified timeframe (in seconds)
+            """
+            queue = multiprocessing.Queue()
+            args_tuple = tuple(a for a in args)
+            meta_kwargs = {
+                'function_to_call': function, 'queue': queue,
+                'function_kwargs': kwargs
+            }
+            function_proc = multiprocessing.Process(
+                target=_handle_function_process, args=args_tuple, kwargs=meta_kwargs
+            )
+            function_proc.start()
+            function_proc.join(float(limit))
+            if function_proc.is_alive():
+                pid = psutil.Process(function_proc.pid)
+                for child in pid.get_children(recursive=True):
+                    child.terminate()
+                function_proc.terminate()
+                raise TimeoutException
+            function_output = queue.get()
+            return function_output
+
+        return wraps(function)(function_wrapper)
+
+    return decorated_function
+
+
+class TimeoutException(Exception):
+    pass


### PR DESCRIPTION
The NPM installation process hangs occasionally when running CI tests on Jenkins and our only recourse is to kill the job running it. Unfortunately, this prevents any logging from being saved and does not provide us with any information to debug the issue(s) with. 

This pull request does two things:
1) It will run the installation in verbose mode and dump output to a log file(s, if running on a sharded build-flow job). Hopefully, the next time this happens, this logging can help us debug what is going on. Additionally, as we try to speed up the setup time for CI jobs, we can analyze this output to see if there are any packages that are particularly slow to install and perhaps look for alternatives. Logs can be found in **test_root/log/npm.install.log**
2) In order to be able to abort a test run and still get the NPM logs, I added a decorator for timing out functions in paver. For normal pythonic functions, it should fucntion without any extra work, throwing a TimeoutException once the timeout has been reached. In the case of trying to timeout a function that forks another process (like an NPM call), you need to make sure that the child process has been killed. 

The purpose of the work is not to get NPM installs to speed up (although that would be nice), but rather to prevent the case where the installation hangs indefinitely. Therefore, I am using a timeout of 300 seconds. As we move towards quicker CI times, we can reduce this timeout value.