### PR TITLE
EDUCATOR-3030 don't submit completion for grader's response while updating problem score.

### DIFF
--- a/common/lib/xmodule/xmodule/capa_base.py
+++ b/common/lib/xmodule/xmodule/capa_base.py
@@ -952,7 +952,7 @@ class CapaMixin(ScorableXBlockMixin, CapaFields):
         self.lcp.update_score(score_msg, queuekey)
         self.set_state_from_lcp()
         self.set_score(self.score_from_lcp())
-        self.publish_grade()
+        self.publish_grade(grader_response=True)
 
         return dict()  # No AJAX return is needed
 
@@ -1131,21 +1131,21 @@ class CapaMixin(ScorableXBlockMixin, CapaFields):
 
         return answers
 
-    def publish_grade(self, score=None, only_if_higher=None):
+    def publish_grade(self, score=None, only_if_higher=None, **kwargs):
         """
         Publishes the student's current grade to the system as an event
         """
         if not score:
             score = self.score
-        self.runtime.publish(
-            self,
-            'grade',
-            {
-                'value': score.raw_earned,
-                'max_value': score.raw_possible,
-                'only_if_higher': only_if_higher,
-            }
-        )
+        event = {
+            'value': score.raw_earned,
+            'max_value': score.raw_possible,
+            'only_if_higher': only_if_higher,
+        }
+        if kwargs.get('grader_response'):
+            event['grader_response'] = kwargs['grader_response']
+
+        self.runtime.publish(self, 'grade', event)
 
         return {'grade': self.score.raw_earned, 'max_grade': self.score.raw_possible}
 

--- a/lms/djangoapps/courseware/module_render.py
+++ b/lms/djangoapps/courseware/module_render.py
@@ -539,6 +539,7 @@ def get_module_system_for_user(
             raw_possible=event['max_value'],
             only_if_higher=event.get('only_if_higher'),
             score_deleted=event.get('score_deleted'),
+            grader_response=event.get('grader_response')
         )
 
     def handle_deprecated_progress_event(block, event):

--- a/lms/djangoapps/courseware/tests/test_module_render.py
+++ b/lms/djangoapps/courseware/tests/test_module_render.py
@@ -2018,6 +2018,7 @@ class TestXmoduleRuntimeEvent(TestSubmittingProblems):
                 'modified': datetime.now().replace(tzinfo=pytz.UTC),
                 'score_db_table': 'csm',
                 'score_deleted': None,
+                'grader_response': None
             }
             send_mock.assert_called_with(**expected_signal_kwargs)
 

--- a/lms/djangoapps/grades/signals/handlers.py
+++ b/lms/djangoapps/grades/signals/handlers.py
@@ -172,6 +172,7 @@ def score_published_handler(sender, block, user, raw_earned, raw_possible, only_
             modified=score_modified_time,
             score_db_table=ScoreDatabaseTableEnum.courseware_student_module,
             score_deleted=kwargs.get('score_deleted', False),
+            grader_response=kwargs.get('grader_response', False)
         )
     return update_score
 
@@ -202,6 +203,7 @@ def problem_raw_score_changed_handler(sender, **kwargs):  # pylint: disable=unus
         score_deleted=kwargs.get('score_deleted', False),
         modified=kwargs['modified'],
         score_db_table=kwargs['score_db_table'],
+        grader_response=kwargs.get('grader_response', False)
     )
 
 

--- a/lms/djangoapps/grades/tests/test_signals.py
+++ b/lms/djangoapps/grades/tests/test_signals.py
@@ -63,6 +63,7 @@ PROBLEM_RAW_SCORE_CHANGED_KWARGS = {
     'score_deleted': True,
     'modified': FROZEN_NOW_TIMESTAMP,
     'score_db_table': ScoreDatabaseTableEnum.courseware_student_module,
+    'grader_response': None
 }
 
 PROBLEM_WEIGHTED_SCORE_CHANGED_KWARGS = {
@@ -76,6 +77,7 @@ PROBLEM_WEIGHTED_SCORE_CHANGED_KWARGS = {
     'score_deleted': True,
     'modified': FROZEN_NOW_TIMESTAMP,
     'score_db_table': ScoreDatabaseTableEnum.courseware_student_module,
+    'grader_response': None
 }
 
 

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -111,11 +111,11 @@ edx-ace==0.1.9
 edx-analytics-data-api-client==0.14.4
 edx-ccx-keys==0.2.1
 edx-celeryutils==0.2.7
-edx-completion==0.1.8
+edx-completion==0.1.9
 edx-django-oauth2-provider==1.3.4
 edx-django-release-util==0.3.1
 edx-django-sites-extensions==2.3.1
-edx-django-utils==0.5.1
+edx-django-utils==1.0.0
 edx-drf-extensions==1.6.2
 edx-enterprise==0.73.0
 edx-i18n-tools==0.4.6
@@ -234,7 +234,7 @@ uritemplate==3.0.0        # via coreapi
 urllib3==1.23             # via elasticsearch
 user-util==0.1.5
 voluptuous==0.11.5
-watchdog==0.8.3
+watchdog==0.9.0
 web-fragments==0.2.2
 webob==1.8.2              # via xblock
 wrapt==1.10.5

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -53,7 +53,7 @@ argh==0.26.2
 argparse==1.4.0
 asn1crypto==0.24.0
 astroid==1.5.2
-atomicwrites==1.1.5
+atomicwrites==1.2.0
 attrs==17.4.0
 babel==1.3
 backports.functools-lru-cache==1.5
@@ -130,11 +130,11 @@ edx-ace==0.1.9
 edx-analytics-data-api-client==0.14.4
 edx-ccx-keys==0.2.1
 edx-celeryutils==0.2.7
-edx-completion==0.1.8
+edx-completion==0.1.9
 edx-django-oauth2-provider==1.3.4
 edx-django-release-util==0.3.1
 edx-django-sites-extensions==2.3.1
-edx-django-utils==0.5.1
+edx-django-utils==1.0.0
 edx-drf-extensions==1.6.2
 edx-enterprise==0.73.0
 edx-i18n-tools==0.4.6
@@ -238,7 +238,7 @@ pluggy==0.6.0
 polib==1.1.0
 psutil==1.2.1
 py2neo==3.1.2
-py==1.5.4
+py==1.6.0
 pyasn1-modules==0.2.2
 pyasn1==0.4.4
 pycodestyle==2.3.1
@@ -269,7 +269,7 @@ pytest-cov==2.5.1
 pytest-django==3.1.2
 pytest-forked==0.2
 pytest-randomly==1.2.3
-pytest-xdist==1.22.5
+pytest-xdist==1.23.0
 pytest==3.6.3
 python-dateutil==2.4.0
 python-levenshtein==0.12.0
@@ -311,9 +311,9 @@ social-auth-app-django==2.1.0
 social-auth-core==1.7.0
 sorl-thumbnail==12.3
 sortedcontainers==0.9.2
-sphinx==1.7.7
+sphinx==1.7.8
 sphinxcontrib-websupport==1.1.0  # via sphinx
-splinter==0.8.0
+splinter==0.9.0
 sqlparse==0.2.4           # via django-debug-toolbar
 stevedore==1.10.0
 sure==1.4.11
@@ -327,7 +327,7 @@ tox==3.2.1
 traceback2==1.4.0
 transifex-client==0.13.4
 twisted==16.6.0
-typing==3.6.4             # via sphinx
+typing==3.6.6             # via sphinx
 unicodecsv==0.14.1
 unidecode==1.0.22
 unittest2==1.1.0
@@ -339,7 +339,7 @@ virtualenv==16.0.0
 voluptuous==0.11.5
 vulture==0.29
 w3lib==1.19.0
-watchdog==0.8.3
+watchdog==0.9.0
 web-fragments==0.2.2
 webob==1.8.2
 werkzeug==0.14.1

--- a/requirements/edx/paver.txt
+++ b/requirements/edx/paver.txt
@@ -22,5 +22,5 @@ pyyaml==3.13              # via watchdog
 requests==2.9.1
 six==1.11.0               # via edx-opaque-keys, libsass, paver, stevedore
 stevedore==1.10.0
-watchdog==0.8.3
+watchdog==0.9.0
 wrapt==1.10.5

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -50,7 +50,7 @@ argh==0.26.2
 argparse==1.4.0
 asn1crypto==0.24.0
 astroid==1.5.2            # via edx-lint, pylint, pylint-celery
-atomicwrites==1.1.5       # via pytest
+atomicwrites==1.2.0       # via pytest
 attrs==17.4.0
 babel==1.3
 backports.functools-lru-cache==1.5  # via astroid, pylint
@@ -125,11 +125,11 @@ edx-ace==0.1.9
 edx-analytics-data-api-client==0.14.4
 edx-ccx-keys==0.2.1
 edx-celeryutils==0.2.7
-edx-completion==0.1.8
+edx-completion==0.1.9
 edx-django-oauth2-provider==1.3.4
 edx-django-release-util==0.3.1
 edx-django-sites-extensions==2.3.1
-edx-django-utils==0.5.1
+edx-django-utils==1.0.0
 edx-drf-extensions==1.6.2
 edx-enterprise==0.73.0
 edx-i18n-tools==0.4.6
@@ -227,7 +227,7 @@ pluggy==0.6.0             # via pytest, tox
 polib==1.1.0
 psutil==1.2.1
 py2neo==3.1.2
-py==1.5.4                 # via pytest, tox
+py==1.6.0                 # via pytest, tox
 pyasn1-modules==0.2.2     # via service-identity
 pyasn1==0.4.4             # via pyasn1-modules, service-identity
 pycodestyle==2.3.1
@@ -257,7 +257,7 @@ pytest-cov==2.5.1
 pytest-django==3.1.2
 pytest-forked==0.2        # via pytest-xdist
 pytest-randomly==1.2.3
-pytest-xdist==1.22.5
+pytest-xdist==1.23.0
 pytest==3.6.3
 python-dateutil==2.4.0
 python-levenshtein==0.12.0
@@ -297,7 +297,7 @@ social-auth-app-django==2.1.0
 social-auth-core==1.7.0
 sorl-thumbnail==12.3
 sortedcontainers==0.9.2
-splinter==0.8.0
+splinter==0.9.0
 stevedore==1.10.0
 sure==1.4.11
 sympy==0.7.1
@@ -320,7 +320,7 @@ user-util==0.1.5
 virtualenv==16.0.0        # via tox
 voluptuous==0.11.5
 w3lib==1.19.0             # via parsel, scrapy
-watchdog==0.8.3
+watchdog==0.9.0
 web-fragments==0.2.2
 webob==1.8.2
 werkzeug==0.14.1          # via flask


### PR DESCRIPTION
# [EDUCATOR-3030](https://openedx.atlassian.net/browse/EDUCATOR-3030)

### Description
We have seen _IntegrityErrors_ for different types of block_types. One of them is a **problem** block type. The basic problem is that we are tracking completion twice which results in a race condition in [get_or_create](https://github.com/edx/completion/blob/master/completion/models.py#L92-L98) method of **BlockCompletion** table inside [submit_completion](https://github.com/edx/completion/blob/master/completion/models.py#L42) function. This PR eliminates race condition by submitting completion once.

### Reviewers
If you've been tagged for review, please check your corresponding box once you've given the :+1:.
- [ ] Code review: @iloveagent57 
- [x] Code review: @awaisdar001 

### Post-review
- [ ] Rebase and squash commits