### PR TITLE
Upgrade the ddt package to a version supports Python 3

### DIFF
--- a/common/djangoapps/util/tests/test_keyword_sub_utils.py
+++ b/common/djangoapps/util/tests/test_keyword_sub_utils.py
@@ -39,15 +39,15 @@ class KeywordSubTest(ModuleStoreTestCase):
         }
 
     @file_data('fixtures/test_keyword_coursename_sub.json')
-    def test_course_name_sub(self, test_info):
+    def test_course_name_sub(self, test_string, expected):
         """ Tests subbing course name in various scenarios """
         course_name = self.course.display_name
         result = Ks.substitute_keywords_with_data(
-            test_info['test_string'], self.context,
+            test_string, self.context,
         )
 
         self.assertIn(course_name, result)
-        self.assertEqual(result, test_info['expected'])
+        self.assertEqual(result, expected)
 
     def test_anonymous_id_sub(self):
         """
@@ -97,15 +97,15 @@ class KeywordSubTest(ModuleStoreTestCase):
         self.assertEquals(test_string, result)
 
     @file_data('fixtures/test_keywordsub_multiple_tags.json')
-    def test_sub_multiple_tags(self, test_info):
+    def test_sub_multiple_tags(self, test_string, expected):
         """ Test that subbing works with multiple subtags """
         anon_id = '123456789'
 
         with patch('util.keyword_substitution.anonymous_id_from_user_id', lambda user_id: anon_id):
             result = Ks.substitute_keywords_with_data(
-                test_info['test_string'], self.context,
+                test_string, self.context,
             )
-            self.assertEqual(result, test_info['expected'])
+            self.assertEqual(result, expected)
 
     def test_subbing_no_userid_or_courseid(self):
         """

--- a/requirements/edx/base.in
+++ b/requirements/edx/base.in
@@ -31,7 +31,6 @@ boto==2.39.0                        # Deprecated version of the AWS SDK; we shou
 boto3==1.4.8                        # Amazon Web Services SDK for Python
 botocore==1.8.17                    # via boto3, s3transfer
 celery==3.1.25                      # Asynchronous task execution library
-ddt==0.8.0                          # via xblock-drag-and-drop-v2 (which probably shouldn't require it)
 defusedxml==0.4.1                   # XML bomb protection for common XML parsers
 Django==1.11.15                     # Web application framework
 django-babel-underscore             # underscore template extractor for django-babel (internationalization utilities)

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -63,7 +63,7 @@ coreapi==2.3.3            # via django-rest-swagger, openapi-codec
 coreschema==0.0.4         # via coreapi
 cryptography==2.3.1
 cssutils==1.0.2           # via pynliner
-ddt==0.8.0
+ddt==1.2.0
 decorator==4.3.0          # via dogapi, pycontracts
 defusedxml==0.4.1
 django-appconf==1.0.2     # via django-statici18n
@@ -117,7 +117,7 @@ edx-django-release-util==0.3.1
 edx-django-sites-extensions==2.3.1
 edx-django-utils==1.0.1
 edx-drf-extensions==1.6.2
-edx-enterprise==0.73.0
+edx-enterprise==0.73.1
 edx-i18n-tools==0.4.6
 edx-milestones==0.1.13
 edx-oauth2-provider==1.2.2

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -53,7 +53,7 @@ argh==0.26.2
 argparse==1.4.0
 asn1crypto==0.24.0
 astroid==1.5.2
-atomicwrites==1.2.0
+atomicwrites==1.2.1
 attrs==17.4.0
 babel==1.3
 backports.functools-lru-cache==1.5
@@ -79,7 +79,7 @@ coverage==4.2
 cryptography==2.3.1
 cssselect==1.0.3
 cssutils==1.0.2
-ddt==0.8.0
+ddt==1.2.0
 decorator==4.3.0
 defusedxml==0.4.1
 dicttoxml==1.7.4
@@ -136,7 +136,7 @@ edx-django-release-util==0.3.1
 edx-django-sites-extensions==2.3.1
 edx-django-utils==1.0.1
 edx-drf-extensions==1.6.2
-edx-enterprise==0.73.0
+edx-enterprise==0.73.1
 edx-i18n-tools==0.4.6
 edx-lint==0.5.5
 edx-milestones==0.1.13
@@ -180,7 +180,7 @@ html5lib==0.999
 httplib2==0.11.3
 httpretty==0.9.5
 idna==2.7
-imagesize==1.0.0          # via sphinx
+imagesize==1.1.0          # via sphinx
 incremental==17.5.0
 inflect==1.0.0
 ipaddr==2.1.11
@@ -277,7 +277,7 @@ python-memcached==1.48
 python-mimeparse==1.6.0
 python-openid==2.2.5
 python-saml==2.4.0
-python-slugify==1.2.5
+python-slugify==1.2.6
 python-subunit==1.3.0
 python-swiftclient==3.6.0
 pytz==2016.10
@@ -311,14 +311,14 @@ social-auth-app-django==2.1.0
 social-auth-core==1.7.0
 sorl-thumbnail==12.3
 sortedcontainers==0.9.2
-sphinx==1.7.8
+sphinx==1.7.9
 sphinxcontrib-websupport==1.1.0  # via sphinx
 splinter==0.9.0
 sqlparse==0.2.4
 stevedore==1.10.0
 sure==1.4.11
 sympy==0.7.1
-testfixtures==6.2.0
+testfixtures==6.3.0
 testtools==2.3.0
 text-unidecode==1.2
 tincan==0.0.5

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -50,7 +50,7 @@ argh==0.26.2
 argparse==1.4.0
 asn1crypto==0.24.0
 astroid==1.5.2            # via edx-lint, pylint, pylint-celery
-atomicwrites==1.2.0       # via pytest
+atomicwrites==1.2.1       # via pytest
 attrs==17.4.0
 babel==1.3
 backports.functools-lru-cache==1.5  # via astroid, pylint
@@ -76,7 +76,7 @@ coverage==4.2
 cryptography==2.3.1
 cssselect==1.0.3
 cssutils==1.0.2
-ddt==0.8.0
+ddt==1.2.0
 decorator==4.3.0
 defusedxml==0.4.1
 dicttoxml==1.7.4          # via moto
@@ -131,7 +131,7 @@ edx-django-release-util==0.3.1
 edx-django-sites-extensions==2.3.1
 edx-django-utils==1.0.1
 edx-drf-extensions==1.6.2
-edx-enterprise==0.73.0
+edx-enterprise==0.73.1
 edx-i18n-tools==0.4.6
 edx-lint==0.5.5
 edx-milestones==0.1.13
@@ -265,7 +265,7 @@ python-memcached==1.48
 python-mimeparse==1.6.0   # via testtools
 python-openid==2.2.5
 python-saml==2.4.0
-python-slugify==1.2.5     # via transifex-client
+python-slugify==1.2.6     # via transifex-client
 python-subunit==1.3.0
 python-swiftclient==3.6.0
 pytz==2016.10
@@ -302,7 +302,7 @@ sqlparse==0.2.4
 stevedore==1.10.0
 sure==1.4.11
 sympy==0.7.1
-testfixtures==6.2.0
+testfixtures==6.3.0
 testtools==2.3.0          # via fixtures, python-subunit
 text-unidecode==1.2       # via faker
 tincan==0.0.5


### PR DESCRIPTION
Upgrade the **ddt package** from the old **version 0.8.0** to the latest version that supports Python3 (**version 1.2.0** as of this commit).

This commit is intended to close **INCR-6** issue (see https://openedx.atlassian.net/browse/INCR-6 )

This will update requirements file **base.in** to remove the version restriction. It will also update few lines of code affected by the **ddt upgrade**