### PR TITLE
OLX export: Reverted url_name from a constant to course run

### DIFF
--- a/common/lib/xmodule/xmodule/modulestore/tests/test_cross_modulestore_import_export.py
+++ b/common/lib/xmodule/xmodule/modulestore/tests/test_cross_modulestore_import_export.py
@@ -188,7 +188,7 @@ class CrossStoreXMLRoundtrip(CourseComparisonTest, PartitionTestCase):
                         self.assertEqual(source_course.url_name, 'course')
 
                         export_dir_path = path(self.export_dir)
-                        policy_dir = export_dir_path / 'exported_source_course' / 'policies' / source_course.url_name
+                        policy_dir = export_dir_path / 'exported_source_course' / 'policies' / source_course_key.run
                         policy_path = policy_dir / 'policy.json'
                         self.assertTrue(os.path.exists(policy_path))
 

--- a/common/lib/xmodule/xmodule/modulestore/xml_exporter.py
+++ b/common/lib/xmodule/xmodule/modulestore/xml_exporter.py
@@ -166,6 +166,7 @@ class ExportManager(object):
                 # change all of the references inside the course to use the xml expected key type w/o version & branch
                 xml_centric_courselike_key = self.get_key()
                 adapt_references(courselike, xml_centric_courselike_key, export_fs)
+                root.set('url_name', self.courselike_key.run)
                 courselike.add_xml_to_node(root)
 
             # Make any needed adjustments to the root node.
@@ -267,10 +268,6 @@ class CourseExportManager(ExportManager):
         )
 
         course_policy_dir_name = courselike.location.run
-        if courselike.url_name != courselike.location.run and courselike.url_name == 'course':
-            # Use url_name for split mongo because course_run is not used when loading policies.
-            course_policy_dir_name = courselike.url_name
-
         course_run_policy_dir = policies_dir.makedir(course_policy_dir_name, recreate=True)
 
         # export the grading policy
@@ -280,7 +277,7 @@ class CourseExportManager(ExportManager):
 
         # export all of the course metadata in policy.json
         with course_run_policy_dir.open(u'policy.json', 'wb') as course_policy:
-            policy = {'course/' + courselike.location.block_id: own_metadata(courselike)}
+            policy = {'course/' + courselike.location.run: own_metadata(courselike)}
             course_policy.write(dumps(policy, cls=EdxJSONEncoder, sort_keys=True, indent=4).encode('utf-8'))
 
         _export_drafts(self.modulestore, self.courselike_key, export_fs, xml_centric_courselike_key)

--- a/common/lib/xmodule/xmodule/tests/test_import.py
+++ b/common/lib/xmodule/xmodule/tests/test_import.py
@@ -32,6 +32,7 @@ from xblock.runtime import KvsFieldData, DictKeyValueStore
 
 ORG = 'test_org'
 COURSE = 'test_course'
+RUN = 'test_run'
 
 
 class DummySystem(ImportSystem):
@@ -43,7 +44,7 @@ class DummySystem(ImportSystem):
             xmlstore = LibraryXMLModuleStore("data_dir", source_dirs=[], load_error_modules=load_error_modules)
         else:
             xmlstore = XMLModuleStore("data_dir", source_dirs=[], load_error_modules=load_error_modules)
-        course_id = CourseKey.from_string('/'.join([ORG, COURSE, 'test_run']))
+        course_id = CourseKey.from_string('/'.join([ORG, COURSE, RUN]))
         course_dir = "test_dir"
         error_tracker = Mock()
 
@@ -197,7 +198,7 @@ class ImportTestCase(BaseCourseTestCase):
         # Now make sure the exported xml is a sequential
         self.assertEqual(node.tag, 'sequential')
 
-    def course_descriptor_inheritance_check(self, descriptor, from_date_string, unicorn_color, url_name):
+    def course_descriptor_inheritance_check(self, descriptor, from_date_string, unicorn_color, course_run=RUN):
         """
         Checks to make sure that metadata inheritance on a course descriptor is respected.
         """
@@ -228,7 +229,7 @@ class ImportTestCase(BaseCourseTestCase):
         self.assertEqual(node.attrib['org'], ORG)
 
         # Does the course still have unicorns?
-        with descriptor.runtime.export_fs.open(u'course/{url_name}.xml'.format(url_name=url_name)) as f:
+        with descriptor.runtime.export_fs.open(u'course/{course_run}.xml'.format(course_run=course_run)) as f:
             course_xml = etree.fromstring(f.read())
 
         self.assertEqual(course_xml.attrib['unicorn'], unicorn_color)
@@ -267,7 +268,7 @@ class ImportTestCase(BaseCourseTestCase):
         )
         descriptor = system.process_xml(start_xml)
         compute_inherited_metadata(descriptor)
-        self.course_descriptor_inheritance_check(descriptor, from_date_string, unicorn_color, url_name)
+        self.course_descriptor_inheritance_check(descriptor, from_date_string, unicorn_color)
 
     def test_library_metadata_import_export(self):
         """Two checks:
@@ -300,7 +301,7 @@ class ImportTestCase(BaseCourseTestCase):
         compute_inherited_metadata(descriptor)
         # Check the course module, since it has inheritance
         descriptor = descriptor.get_children()[0]
-        self.course_descriptor_inheritance_check(descriptor, from_date_string, unicorn_color, url_name)
+        self.course_descriptor_inheritance_check(descriptor, from_date_string, unicorn_color)
 
     def test_metadata_no_inheritance(self):
         """

--- a/common/lib/xmodule/xmodule/x_module.py
+++ b/common/lib/xmodule/xmodule/x_module.py
@@ -1116,7 +1116,11 @@ class XModuleDescriptor(HTMLSnippet, ResourceTemplates, XModuleMixin):
         node.tag = exported_node.tag
         node.text = exported_node.text
         node.tail = exported_node.tail
+
         for key, value in exported_node.items():
+            if key == 'url_name' and value == 'course' and key in node.attrib:
+                # if url_name is set in ExportManager then do not override it here.
+                continue
             node.set(key, value)
 
         node.extend(list(exported_node))

--- a/common/lib/xmodule/xmodule/xml_module.py
+++ b/common/lib/xmodule/xmodule/xml_module.py
@@ -487,7 +487,11 @@ class XmlParserMixin(object):
         if self.export_to_file():
             # Write the definition to a file
             url_path = name_to_pathname(self.url_name)
-            filepath = self._format_filepath(self.category, url_path)
+            # if folder is course then create file with name {course_run}.xml
+            filepath = self._format_filepath(
+                self.category,
+                self.location.run if self.category == 'course' else url_path,
+            )
             self.runtime.export_fs.makedirs(os.path.dirname(filepath), recreate=True)
             with self.runtime.export_fs.open(filepath, 'wb') as fileobj:
                 ElementTree(xml_object).write(fileobj, pretty_print=True, encoding='utf-8')


### PR DESCRIPTION
#### What are the relevant tickets?
fixes https://github.com/mitodl/edx-platform/issues/31

#### Background
[Nimisha Asthagiri views](https://openedx.atlassian.net/browse/CRI-102?focusedCommentId=329723&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-329723)

I agree that OLX needs a lot of TLC. I just don't see the "side-car" concept as something that moves us forward in a direction that makes sense for the future - given what we need for OLX and decoupling content and enabling reuse.

What I'm proposing is this:

Update the course export code for Split courses so that the value of course-run is placed in the same place as it is for non-Split courses: in the url_name field in the course.xml file.
On OLX import, make sure the "right" thing happens for Split courses. It may already be given the code that exists in import_xblock in Split. That import code sets the "block_id" to "course" for the course_module.
This would be a low-cost solution, without inventing new OLX concepts that we may not need. As another advantage, the resulting OLX would be consistent with non-Split courses.

#### What's this PR do?
- It add course run as child directory inside policies folder.
- it updates `policy.json` file and add `course/{course_run}` as root element
 
#### How should this be manually tested?

1. Create a course in Studio with a unique course run, e.g. the suggested `2104_T1`
2. Export the course and examine the export:
    1. In the root course.xml the value of `course_xml` should be the run you set in studio, not `course`.
    2. In the policies directory, there should be a sub-directory named after the run. Not `course`. 
    3. In policy.json file, the root key should be named `course/[run]` not `course\course`
3. import the course into lms using the management command, for example
  `python /edx/app/edxapp/edx-platform/manage.py lms import /edx/src/course/ /edx/src/course/`
    1. Confirm that the count of courses are the same -- importing the course didn't create a new one with a course run of `course` 

