### PR TITLE
Add support to rename child course

### DIFF
--- a/lms/djangoapps/ccx/tests/test_views.py
+++ b/lms/djangoapps/ccx/tests/test_views.py
@@ -552,7 +552,7 @@ class TestCoachDashboard(CcxTestCase, LoginEnrollmentTestCase):
         previous_display_name = ccx.display_name
         display_name = 'New CCX Updated'
         response = self.client.post(
-            course_details_url, {'display_name': display_name })
+            course_details_url, {'display_name': display_name})
         self.assertEqual(response.status_code, 302)
         ccx = CustomCourseForEdX.objects.get()
         self.assertEqual(ccx.display_name, display_name)

--- a/lms/djangoapps/ccx/tests/test_views.py
+++ b/lms/djangoapps/ccx/tests/test_views.py
@@ -540,6 +540,25 @@ class TestCoachDashboard(CcxTestCase, LoginEnrollmentTestCase):
         self.assertEqual(policy['GRADER'][3]['min_count'], 0)
 
     @patch('ccx.views.render_to_response', intercept_renderer)
+    def test_update_course_details(self):
+        """
+        Get CCX details, modify it, save it.
+        """
+        self.make_coach()
+        ccx = self.make_ccx()
+        course_id = CCXLocator.from_course_locator(self.course.id, ccx.id)
+        course_details_url = reverse(
+            'ccx_update_course_details', kwargs={'course_id': course_id})
+        previous_display_name = ccx.display_name
+        display_name = 'New CCX Updated'
+        response = self.client.post(
+            course_details_url, {'display_name': display_name })
+        self.assertEqual(response.status_code, 302)
+        ccx = CustomCourseForEdX.objects.get()
+        self.assertEqual(ccx.display_name, display_name)
+        self.assertNotEqual(ccx.display_name, previous_display_name)
+
+    @patch('ccx.views.render_to_response', intercept_renderer)
     def test_save_without_min_count(self):
         """
         POST grading policy without min_count field.

--- a/lms/djangoapps/ccx/urls.py
+++ b/lms/djangoapps/ccx/urls.py
@@ -9,6 +9,7 @@ urlpatterns = [
     url(r'^ccx_coach$', ccx.views.dashboard, name='ccx_coach_dashboard'),
     url(r'^create_ccx$', ccx.views.create_ccx, name='create_ccx'),
     url(r'^save_ccx$', ccx.views.save_ccx, name='save_ccx'),
+    url(r'^ccx_update_course_details$', ccx.views.update_course_details, name='ccx_update_course_details'),
     url(r'^ccx_schedule$', ccx.views.ccx_schedule, name='ccx_schedule'),
     url(r'^ccx-manage-students$', ccx.views.ccx_students_management, name='ccx-manage-students'),
 

--- a/lms/djangoapps/ccx/views.py
+++ b/lms/djangoapps/ccx/views.py
@@ -140,9 +140,6 @@ def dashboard(request, course, ccx=None):
         schedule = get_ccx_schedule(course, ccx)
         grading_policy = get_override_for_ccx(
             ccx, course, 'grading_policy', course.grading_policy)
-        # TODO: this logic will change once child course bug is fixed.
-        # This value will be later retrieved from ccx override.
-        context['course_display_name'] = ccx.display_name
         context['course_details_url'] = reverse(
             'ccx_update_course_details', kwargs={'course_id': ccx_locator})
         context['schedule'] = json.dumps(schedule, indent=4)

--- a/lms/djangoapps/ccx/views.py
+++ b/lms/djangoapps/ccx/views.py
@@ -358,11 +358,11 @@ def update_course_details(request, course, ccx=None):
     if not ccx:
         raise Http404
 
-    # TODO: This should have been saved as a override field. This will
-    # be updated once child course display name bug is fixed.
+    name = request.POST['display_name']
     CustomCourseForEdX.objects.filter(
         course_id=course.id,
-        coach=request.user).update(display_name=request.POST['display_name'])
+        coach=request.user).update(display_name=name)
+    override_field_for_ccx(ccx, course, 'display_name', name)
 
     # using CCX object as sender here.
     responses = SignalHandler.course_published.send(

--- a/lms/templates/ccx/coach_dashboard.html
+++ b/lms/templates/ccx/coach_dashboard.html
@@ -56,6 +56,9 @@ from openedx.core.djangolib.js_utils import (
           %if ccx:
           <ul class="instructor-nav">
             <li class="nav-item">
+              <button type="button" class="btn-link" data-section="course_details">${_("Course Details")}</button>
+            </li>
+            <li class="nav-item">
               <button type="button" class="btn-link" data-section="membership">${_("Enrollment")}</button>
             </li>
             <li class="nav-item">
@@ -68,6 +71,9 @@ from openedx.core.djangolib.js_utils import (
               <button type="button" class="btn-link" data-section="grading_policy">${_("Grading Policy")}</button>
             </li>
           </ul>
+          <section id="course_details" class="idash-section" aria-label="${_('Course Details')}">
+            <%include file="course_details.html" args="" />
+          </section>
           <section id="membership" class="idash-section" aria-label="${_('Batch Enrollment')}">
             <%include file="enrollment.html" args="" />
           </section>

--- a/lms/templates/ccx/course_details.html
+++ b/lms/templates/ccx/course_details.html
@@ -1,0 +1,19 @@
+<%page expression_filter="h"/>
+<%!
+from django.utils.translation import ugettext as _
+from django.utils.translation import pgettext
+from openedx.core.djangolib.markup import HTML, Text
+%>
+
+<h2 class="hd hd-2">${_("Course Details")}</h2>
+
+<form action="${course_details_url}" method="POST">
+  <input type="hidden" name="csrfmiddlewaretoken" value="${csrf_token}"/>
+  <div class="field">
+    <label class="sr" for="ccx_display_name">${_('Course Display Name')}</label>
+    <input name="display_name" id="ccx_display_name" placeholder="${_('Enter course name')}" value="${course_display_name}"/><br/>
+  </div>
+  <div class="field">
+    <button id="update-ccx" type="submit">${_('Update')}</button>
+  </div>
+</form>

--- a/lms/templates/ccx/course_details.html
+++ b/lms/templates/ccx/course_details.html
@@ -11,7 +11,7 @@ from openedx.core.djangolib.markup import HTML, Text
   <input type="hidden" name="csrfmiddlewaretoken" value="${csrf_token}"/>
   <div class="field">
     <label for="ccx_display_name">${_('Course Display Name')}</label>
-    <input name="display_name" id="ccx_display_name" placeholder="${_('Enter course name')}" value="${course_display_name}"/><br/>
+    <input name="display_name" id="ccx_display_name" placeholder="${_('Enter course name')}" value="${ccx.display_name}"/><br/>
   </div>
   <div class="field">
     <button id="update-ccx" type="submit">${_('Update')}</button>

--- a/lms/templates/ccx/course_details.html
+++ b/lms/templates/ccx/course_details.html
@@ -7,10 +7,10 @@ from openedx.core.djangolib.markup import HTML, Text
 
 <h2 class="hd hd-2">${_("Course Details")}</h2>
 
-<form action="${course_details_url}" method="POST">
+<form class="ccx-form" action="${course_details_url}" method="POST">
   <input type="hidden" name="csrfmiddlewaretoken" value="${csrf_token}"/>
   <div class="field">
-    <label class="sr" for="ccx_display_name">${_('Course Display Name')}</label>
+    <label for="ccx_display_name">${_('Course Display Name')}</label>
     <input name="display_name" id="ccx_display_name" placeholder="${_('Enter course name')}" value="${course_display_name}"/><br/>
   </div>
   <div class="field">


### PR DESCRIPTION
This PR adds support to rename child course. A new tab called "Course Details" in CCX Coach Dashboard is created for this.

**JIRA tickets**: [OSPR-2573](https://openedx.atlassian.net/browse/OSPR-2573)

**Dependencies**: None

**Screenshots**:  

**Course Details Tab**

<img width="754" alt="screen shot 2018-08-29 at 2 35 39 pm" src="https://user-images.githubusercontent.com/4302268/44777984-897fcc00-ab99-11e8-8a73-5ff10a6e0aec.png">

*Note*: See the changes in green box

**Sandbox URL**: TBD

**Merge deadline**: None

**Testing instructions**:

1. Go to CCX Coach Dashboard and click on the Course Details Tab.
2. You should see a field with a label of "Course Display Name".
3. Enter a new name and then the name should be changed. 
4. Look for a span with class of `course-name` element (<span class="course-name">) and see the updated value over there.

**Author notes and concerns**:

None

**Reviewers**
- [ ] @itsjeyd 
- [ ] edX reviewer[s] TBD

**Settings**
```yaml
EDXAPP_FEATURES:
  CUSTOM_COURSES_EDX: true