### PR TITLE
Clear cache after tests that create DarkLangConfig objects

### DIFF
--- a/lms/djangoapps/branding/tests/test_views.py
+++ b/lms/djangoapps/branding/tests/test_views.py
@@ -5,7 +5,6 @@ import urllib
 
 import ddt
 import mock
-from config_models.models import cache
 from django.conf import settings
 from django.contrib.auth.models import User
 from django.urls import reverse
@@ -16,18 +15,14 @@ from openedx.core.djangoapps.dark_lang.models import DarkLangConfig
 from openedx.core.djangoapps.lang_pref.api import released_languages
 from openedx.core.djangoapps.site_configuration.tests.mixins import SiteMixin
 from openedx.core.djangoapps.theming.tests.test_util import with_comprehensive_theme_context
+from openedx.core.djangolib.testing.utils import CacheIsolationTestCase
 from student.tests.factories import UserFactory
 
 
 @ddt.ddt
-class TestFooter(TestCase):
+class TestFooter(CacheIsolationTestCase):
     """Test API end-point for retrieving the footer. """
     shard = 4
-
-    def setUp(self):
-        """Clear the configuration cache. """
-        super(TestFooter, self).setUp()
-        cache.clear()
 
     @ddt.data("*/*", "text/html", "application/json")
     def test_feature_flag(self, accepts):

--- a/lms/djangoapps/certificates/tests/test_webview_views.py
+++ b/lms/djangoapps/certificates/tests/test_webview_views.py
@@ -41,6 +41,7 @@ from openedx.core.djangoapps.certificates.config import waffle
 from openedx.core.djangoapps.dark_lang.models import DarkLangConfig
 from openedx.core.lib.tests.assertions.events import assert_event_matches
 from openedx.core.djangolib.js_utils import js_escaped_string
+from openedx.core.djangolib.testing.utils import CacheIsolationTestCase
 from student.roles import CourseStaffRole
 from student.tests.factories import CourseEnrollmentFactory, UserFactory
 from track.tests import EventTrackingTestCase
@@ -241,7 +242,7 @@ class CommonCertificatesTestCase(ModuleStoreTestCase):
 
 
 @ddt.ddt
-class CertificatesViewsTests(CommonCertificatesTestCase):
+class CertificatesViewsTests(CommonCertificatesTestCase, CacheIsolationTestCase):
     """
     Tests for the certificates web/html views
     """

--- a/lms/djangoapps/courseware/tests/test_i18n.py
+++ b/lms/djangoapps/courseware/tests/test_i18n.py
@@ -14,11 +14,12 @@ from django.utils import translation
 
 from openedx.core.djangoapps.dark_lang.models import DarkLangConfig
 from openedx.core.djangoapps.lang_pref import LANGUAGE_KEY
+from openedx.core.djangolib.testing.utils import CacheIsolationTestCase
 from openedx.core.lib.tests import attr
 from student.tests.factories import UserFactory
 
 
-class BaseI18nTestCase(TestCase):
+class BaseI18nTestCase(CacheIsolationTestCase):
     """
     Base utilities for i18n test classes to derive from
     """

--- a/openedx/core/djangoapps/content/course_overviews/tests/test_course_overviews.py
+++ b/openedx/core/djangoapps/content/course_overviews/tests/test_course_overviews.py
@@ -19,6 +19,7 @@ from lms.djangoapps.certificates.api import get_active_web_certificate
 from openedx.core.djangoapps.catalog.tests.mixins import CatalogIntegrationMixin
 from openedx.core.djangoapps.dark_lang.models import DarkLangConfig
 from openedx.core.djangoapps.models.course_details import CourseDetails
+from openedx.core.djangolib.testing.utils import CacheIsolationTestCase
 from openedx.core.lib.courses import course_image_url
 from static_replace.models import AssetBaseUrlConfig
 from xmodule.assetstore.assetmgr import AssetManager
@@ -41,7 +42,7 @@ from .factories import CourseOverviewFactory
 
 
 @ddt.ddt
-class CourseOverviewTestCase(CatalogIntegrationMixin, ModuleStoreTestCase):
+class CourseOverviewTestCase(CatalogIntegrationMixin, ModuleStoreTestCase, CacheIsolationTestCase):
     """
     Tests for CourseOverview model.
     """

--- a/openedx/core/djangoapps/dark_lang/tests.py
+++ b/openedx/core/djangoapps/dark_lang/tests.py
@@ -12,6 +12,7 @@ from mock import Mock
 
 from openedx.core.djangoapps.dark_lang.middleware import DarkLangMiddleware
 from openedx.core.djangoapps.dark_lang.models import DarkLangConfig
+from openedx.core.djangolib.testing.utils import CacheIsolationTestCase
 from student.tests.factories import UserFactory
 
 UNSET = object()
@@ -27,7 +28,7 @@ def set_if_set(dct, key, value):
 
 
 @ddt.ddt
-class DarkLangMiddlewareTests(TestCase):
+class DarkLangMiddlewareTests(CacheIsolationTestCase):
     """
     Tests of DarkLangMiddleware
     """
@@ -203,6 +204,7 @@ class DarkLangMiddlewareTests(TestCase):
             changed_by=self.user,
             enabled=True
         ).save()
+
         self.assertAcceptEquals(
             expected,
             self.process_middleware_request(accept=accept_header)

--- a/openedx/core/djangoapps/lang_pref/tests/test_api.py
+++ b/openedx/core/djangoapps/lang_pref/tests/test_api.py
@@ -11,13 +11,14 @@ import ddt
 from openedx.core.djangoapps.dark_lang.models import DarkLangConfig
 from openedx.core.djangoapps.lang_pref import api as language_api
 from openedx.core.djangoapps.site_configuration.tests.test_util import with_site_configuration_context
+from openedx.core.djangolib.testing.utils import CacheIsolationTestCase
 
 EN = language_api.Language('en', 'English')
 ES_419 = language_api.Language('es-419', u'Español (Latinoamérica)')
 
 
 @ddt.ddt
-class LanguageApiTest(TestCase):
+class LanguageApiTest(CacheIsolationTestCase):
     """
     Tests of the language APIs.
     """

--- a/openedx/core/djangolib/testing/utils.py
+++ b/openedx/core/djangolib/testing/utils.py
@@ -27,7 +27,7 @@ from openedx.core.djangoapps.request_cache.middleware import RequestCache as Dep
 class CacheIsolationMixin(object):
     """
     This class can be used to enable specific django caches for
-    specific the TestCase that it's mixed into.
+    the specific TestCase that it's mixed into.
 
     Usage:
 


### PR DESCRIPTION
Any time the `TestUserPreferenceMiddleware` test class ran on a pytest process that had previously run the `DarkLangMiddlewareTests` test class, `test_login_captures_lang_pref` failed for the input arguments `('es', 'es-419')` and `('es-419', 'es-419')`. [From debugging,](https://build.testeng.edx.org/view/edx-platform-pipeline-pr-tests/job/edx-platform-python-pipeline-pr/293/testReport/junit/openedx.core.djangoapps.lang_pref.tests.test_middleware/TestUserPreferenceMiddleware/Run_Tests___cms_unit___test_login_captures_lang_pref_2___es____es_419__/) it appears that the failure was caused because of a persistent `DarkLangConfig` that did not have spanish in its released_languages_list, which resulted in the response being in English.

The `DarkLangConfig` model subclasses https://github.com/edx/django-config-models and was being cached. Adding the `CacheIsolationTestCase` to any Test Case that creates a `DarkLangConfig` prevents this from happening.
