### PR TITLE
EDUCATOR-3374 | Hacky query to fix inline discussions performance.

### DIFF
--- a/common/djangoapps/django_comment_common/models.py
+++ b/common/djangoapps/django_comment_common/models.py
@@ -145,13 +145,25 @@ def all_permissions_for_user_in_course(user, course_id):  # pylint: disable=inva
     if course is None:
         raise ItemNotFoundError(course_id)
 
-    all_roles = {role.name for role in Role.objects.filter(users=user, course_id=course_id)}
+    all_roles = {role for role in Role.objects.filter(users=user, course_id=course_id)}
+    role_names = {role.name for role in all_roles}
+
+    # TODO: EDUCATOR-3374
+    # The `roles__users__roles__in=all_roles` part of this filter is a hack to get the new
+    # Aurora MySql query planner to properly use the unique index on the roles/users join table.
+    # Without this hack, the planner uses a unique index on (role_id, user_id) to do lookup
+    # by user_id only, which is a completely inefficient way to use that index.
+    permission_queryset = Permission.objects.filter(
+        roles__users=user,
+        roles__course_id=course_id,
+        roles__users__roles__in=all_roles
+    ).distinct()
 
     permissions = {
         permission.name
         for permission
-        in Permission.objects.filter(roles__users=user, roles__course_id=course_id)
-        if not permission_blacked_out(course, all_roles, permission.name)
+        in permission_queryset
+        if not permission_blacked_out(course, role_names, permission.name)
     }
     return permissions
 

--- a/lms/djangoapps/courseware/tests/test_discussion_xblock.py
+++ b/lms/djangoapps/courseware/tests/test_discussion_xblock.py
@@ -402,11 +402,13 @@ class TestXBlockQueryLoad(SharedModuleStoreTestCase):
                 discussion_target='Target Discussion',
             ))
 
-        # 3 queries are required to do first discussion xblock render:
+        # 2 queries are required to do first discussion xblock render:
         # * django_comment_client_role
-        # * django_comment_client_permission
         # * lms_xblock_xblockasidesconfig
-        num_queries = 3
+        # If the query for roles returned a non-empty result set, there would be
+        # an additional query against django_comment_client_permission, but there
+        # are no roles associated with this test.
+        num_queries = 2
         for discussion in discussions:
             discussion_xblock = get_module_for_descriptor_internal(
                 user=user,


### PR DESCRIPTION
https://openedx.atlassian.net/browse/EDUCATOR-3374

From playing around in the read-replica, I noticed that adding a condition specifying the roles we're looking for in the role/users join table (in django_comment_client) forces the query planner to use the unique constraint index "the right way".