### PR TITLE
OC-5192 Fix: Convert DATA_DIR to a Path object when fetching its value from ENV_TOKENS

### DIFF
--- a/cms/envs/aws.py
+++ b/cms/envs/aws.py
@@ -154,7 +154,7 @@ ALLOWED_HOSTS = [
 ]
 
 LOG_DIR = ENV_TOKENS['LOG_DIR']
-DATA_DIR = ENV_TOKENS.get('DATA_DIR', DATA_DIR)
+DATA_DIR = path(ENV_TOKENS.get('DATA_DIR', DATA_DIR))
 
 CACHES = ENV_TOKENS['CACHES']
 # Cache used for location mapping -- called many times with the same key/value

--- a/lms/envs/aws.py
+++ b/lms/envs/aws.py
@@ -324,7 +324,7 @@ WIKI_ENABLED = ENV_TOKENS.get('WIKI_ENABLED', WIKI_ENABLED)
 
 local_loglevel = ENV_TOKENS.get('LOCAL_LOGLEVEL', 'INFO')
 LOG_DIR = ENV_TOKENS['LOG_DIR']
-DATA_DIR = ENV_TOKENS.get('DATA_DIR', DATA_DIR)
+DATA_DIR = path(ENV_TOKENS.get('DATA_DIR', DATA_DIR))
 
 LOGGING = get_logger_config(LOG_DIR,
                             logging_env=ENV_TOKENS['LOGGING_ENV'],


### PR DESCRIPTION
This PR fixes the exceptions raised by code that expects `settings.DATA_DIR` to be a Path
object. When the value of `settings.DATA_DIR` is read from `ENV_TOKENS`, it is a string but the default value is a `Path` object. For instance, the LMS sysadmin dashboard courses page expects
`settings.DATA_DIR` to be a `Path` object and throws a `500 Internal Server error` if
it isn't.

**Dependencies**: None

**Sandbox URL**: 
- LMS - https://pr18856.sandbox.opencraft.hosting/
- Studio - https://studio-pr18856.sandbox.opencraft.hosting/

**Merge deadline**: None

**Testing instructions**:
1. Ensure that the `ENV_TOKENS` dictionary is loaded from the YAML files and that `DATA_DIR` is defined in the file for LMS. 
1.  Enable the sysadmin dashboard feature in LMS. Using the `ENABLE_SYSADMIN_DASHBOARD` configuration flag.
1. Login to the LMS as an admin user.
1. Navigate to the Sysadmin dashboard courses page.
1. The page should load without any error.
1. Without the fix, the page throws a `500 Internal Server Error` due to the exception `TypeError: unsupported operand type(s) for /: 'unicode' and 'unicode'` thrown by [this line](https://github.com/edx/edx-platform/blob/master/lms/djangoapps/dashboard/sysadmin.py#L343).

**Reviewers**
- [ ] @viadanna
- [ ] edX reviewer[s] TBD

