### PR TITLE
Migrations are run on machines without development requirements

### DIFF
--- a/requirements/edx/base.in
+++ b/requirements/edx/base.in
@@ -141,6 +141,7 @@ Shapely==1.2.16                     # Geometry library, used for image click reg
 six                                 # Utilities for supporting Python 2 & 3 in the same codebase
 sorl-thumbnail==12.3                # Image thumbnail management
 sortedcontainers==0.9.2             # Provides SortedListWithKey, used for lists of XBlock assets
+sqlparse                            # Required by Django to run migrations.RunSQL
 stevedore                           # Support for runtime plugins, used for XBlocks and edx-platform Django app plugins
 unicodecsv                          # Easier support for CSV files with unicode text
 user-util                           # Functionality for retiring users (GDPR compliance)

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -226,6 +226,7 @@ social-auth-app-django==2.1.0
 social-auth-core==1.7.0
 sorl-thumbnail==12.3
 sortedcontainers==0.9.2
+sqlparse==0.2.4
 stevedore==1.10.0
 sympy==0.7.1
 tincan==0.0.5             # via edx-enterprise

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -314,7 +314,7 @@ sortedcontainers==0.9.2
 sphinx==1.7.8
 sphinxcontrib-websupport==1.1.0  # via sphinx
 splinter==0.9.0
-sqlparse==0.2.4           # via django-debug-toolbar
+sqlparse==0.2.4
 stevedore==1.10.0
 sure==1.4.11
 sympy==0.7.1

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -298,6 +298,7 @@ social-auth-core==1.7.0
 sorl-thumbnail==12.3
 sortedcontainers==0.9.2
 splinter==0.9.0
+sqlparse==0.2.4
 stevedore==1.10.0
 sure==1.4.11
 sympy==0.7.1


### PR DESCRIPTION
We added a migration to a ManyToMany key in both directions and that had
to be done with RunSQL which requires sqlparse
https://docs.djangoproject.com/en/1.11/ref/migration-operations/#runsql

#18858