### PR TITLE
EDUCATOR-3385 fix attribute error in discussion email notification

### DIFF
--- a/lms/djangoapps/discussion/tasks.py
+++ b/lms/djangoapps/discussion/tasks.py
@@ -113,8 +113,17 @@ def _is_not_subcomment(comment_id):
 
 def _is_first_comment(comment_id, thread_id):
     thread = cc.Thread.find(id=thread_id).retrieve(with_responses=True)
-    first_comment = thread.children[0]
-    return first_comment.get('id') == comment_id
+    if getattr(thread, 'children', None):
+        first_comment = thread.children[0]
+        return first_comment.get('id') == comment_id
+    else:
+        log.info(
+            "EDUCATOR-3385: No child exists for thread_id %s | course_id %s | username %s ",
+            thread.get('id'),
+            thread['course_id'],
+            thread['username']
+        )
+        return False
 
 
 def _is_user_subscribed_to_thread(cc_user, thread_id):


### PR DESCRIPTION
# [EDUCATOR-3385](https://openedx.atlassian.net/browse/EDUCATOR-3385)

### Description
This PR fixes `AttributeError` thrown by discussion task `send_ace_message` if `children` attribute is missing in `Thread` object.

### Reviewers
If you've been tagged for review, please check your corresponding box once you've given the :+1:.
- [x] Code review: @iloveagent57 
- [x] Code review: @schenedx 

### Testing
- [x] Unit Test

### Post-review
- [x] Rebase and squash commits