### PR TITLE
Upgrade the django-ipware Package to a version Supports Python 3

### DIFF
--- a/requirements/edx/base.in
+++ b/requirements/edx/base.in
@@ -40,7 +40,7 @@ django-countries==4.6.1             # Country data for Django forms and model fi
 django-crum                         # Middleware that stores the current request and user in thread local storage
 django-fernet-fields                # via edx-enterprise (should be added to its setup.py)
 django-filter==1.0.4                # Allows users to filter Django querysets dynamically
-django-ipware==1.1.0                # Get the client's real IP address
+django-ipware                       # Get the client's real IP address
 django-memcached-hashring
 django-method-override==0.1.0
 django-model-utils==3.0.0

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -78,7 +78,7 @@ django-countries==4.6.1
 django-crum==0.7.3
 django-fernet-fields==0.5
 django-filter==1.0.4
-django-ipware==1.1.0
+django-ipware==2.1.0
 django-memcached-hashring==0.1.2
 django-method-override==0.1.0
 django-model-utils==3.0.0
@@ -94,7 +94,7 @@ django-require==1.0.11
 django-rest-swagger==2.2.0
 django-sekizai==0.10.0
 django-ses==0.8.4
-django-simple-history==2.3.0
+django-simple-history==2.4.0
 django-splash==0.2.2
 django-statici18n==1.4.0
 django-storages==1.4.1
@@ -118,7 +118,7 @@ edx-django-release-util==0.3.1
 edx-django-sites-extensions==2.3.1
 edx-django-utils==1.0.1
 edx-drf-extensions==1.7.0
-edx-enterprise==0.73.3
+edx-enterprise==0.73.5
 edx-i18n-tools==0.4.6
 edx-milestones==0.1.13
 edx-oauth2-provider==1.2.2

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -97,7 +97,7 @@ django-crum==0.7.3
 django-debug-toolbar==1.8
 django-fernet-fields==0.5
 django-filter==1.0.4
-django-ipware==1.1.0
+django-ipware==2.1.0
 django-memcached-hashring==0.1.2
 django-method-override==0.1.0
 django-model-utils==3.0.0
@@ -113,7 +113,7 @@ django-require==1.0.11
 django-rest-swagger==2.2.0
 django-sekizai==0.10.0
 django-ses==0.8.4
-django-simple-history==2.3.0
+django-simple-history==2.4.0
 django-splash==0.2.2
 django-statici18n==1.4.0
 django-storages==1.4.1
@@ -137,7 +137,7 @@ edx-django-release-util==0.3.1
 edx-django-sites-extensions==2.3.1
 edx-django-utils==1.0.1
 edx-drf-extensions==1.7.0
-edx-enterprise==0.73.3
+edx-enterprise==0.73.5
 edx-i18n-tools==0.4.6
 edx-lint==0.5.5
 edx-milestones==0.1.13
@@ -297,7 +297,7 @@ s3transfer==0.1.13
 sailthru-client==2.2.3
 scipy==0.14.0
 scrapy==1.1.2
-selenium==3.14.0
+selenium==3.14.1
 semantic-version==2.6.0
 service-identity==17.0.0
 shapely==1.2.16

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -93,7 +93,7 @@ django-countries==4.6.1
 django-crum==0.7.3
 django-fernet-fields==0.5
 django-filter==1.0.4
-django-ipware==1.1.0
+django-ipware==2.1.0
 django-memcached-hashring==0.1.2
 django-method-override==0.1.0
 django-model-utils==3.0.0
@@ -109,7 +109,7 @@ django-require==1.0.11
 django-rest-swagger==2.2.0
 django-sekizai==0.10.0
 django-ses==0.8.4
-django-simple-history==2.3.0
+django-simple-history==2.4.0
 django-splash==0.2.2
 django-statici18n==1.4.0
 django-storages==1.4.1
@@ -132,7 +132,7 @@ edx-django-release-util==0.3.1
 edx-django-sites-extensions==2.3.1
 edx-django-utils==1.0.1
 edx-drf-extensions==1.7.0
-edx-enterprise==0.73.3
+edx-enterprise==0.73.5
 edx-i18n-tools==0.4.6
 edx-lint==0.5.5
 edx-milestones==0.1.13
@@ -285,7 +285,7 @@ s3transfer==0.1.13
 sailthru-client==2.2.3
 scipy==0.14.0
 scrapy==1.1.2             # via pa11ycrawler
-selenium==3.14.0
+selenium==3.14.1
 semantic-version==2.6.0
 service-identity==17.0.0  # via scrapy
 shapely==1.2.16


### PR DESCRIPTION
Upgrade the **django-ipware** package from the **old 1.1.0 version** to the latest version that supports **Python 3**
( **version 2.1.0** as of this commit )

This **PR** is intended to close **INCR-7** issue ( see https://openedx.atlassian.net/browse/INCR-7 )