### PR TITLE
Upgrade the edx-django-oauth2-provider package to a version Supports Python 3

### DIFF
--- a/requirements/edx-sandbox/base.txt
+++ b/requirements/edx-sandbox/base.txt
@@ -23,7 +23,7 @@ networkx==1.7
 nltk==3.3.0
 nose==1.3.7               # via matplotlib
 numpy==1.6.2
-pycparser==2.18
+pycparser==2.19
 pyparsing==2.2.0
 python-dateutil==2.7.3    # via matplotlib
 scipy==0.14.0

--- a/requirements/edx-sandbox/shared.txt
+++ b/requirements/edx-sandbox/shared.txt
@@ -19,7 +19,7 @@ markupsafe==1.0
 networkx==1.7
 nltk==3.3.0
 numpy==1.6.2
-pycparser==2.18           # via cffi
+pycparser==2.19           # via cffi
 pyparsing==2.2.0
 scipy==0.14.0
 six==1.11.0               # via cryptography, nltk

--- a/requirements/edx/base.in
+++ b/requirements/edx/base.in
@@ -68,7 +68,7 @@ edx-analytics-data-api-client
 edx-ccx-keys
 edx-celeryutils
 edx-completion
-edx-django-oauth2-provider==1.3.4
+edx-django-oauth2-provider
 edx-django-release-util             # Release utils for the edx release pipeline
 edx-django-sites-extensions==2.3.1
 edx-django-utils

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -56,7 +56,7 @@ boto3==1.4.8
 boto==2.39.0
 botocore==1.8.17
 celery==3.1.25
-certifi==2018.8.13
+certifi==2018.8.24
 cffi==1.11.5
 charade==1.0.3            # via pysrt
 chardet==3.0.4
@@ -113,11 +113,11 @@ edx-analytics-data-api-client==0.14.4
 edx-ccx-keys==0.2.1
 edx-celeryutils==0.2.7
 edx-completion==0.1.10
-edx-django-oauth2-provider==1.3.4
+edx-django-oauth2-provider==1.3.5
 edx-django-release-util==0.3.1
 edx-django-sites-extensions==2.3.1
 edx-django-utils==1.0.1
-edx-drf-extensions==1.6.2
+edx-drf-extensions==1.7.0
 edx-enterprise==0.73.3
 edx-i18n-tools==0.4.6
 edx-milestones==0.1.13
@@ -188,7 +188,7 @@ psutil==1.2.1
 py2neo==3.1.2
 pycontracts==1.7.1
 pycountry==1.20
-pycparser==2.18
+pycparser==2.19
 pycryptodomex==3.4.7
 pygments==2.2.0
 pygraphviz==1.1

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -66,7 +66,7 @@ boto3==1.4.8
 boto==2.39.0
 botocore==1.8.17
 celery==3.1.25
-certifi==2018.8.13
+certifi==2018.8.24
 cffi==1.11.5
 charade==1.0.3
 chardet==3.0.4
@@ -132,11 +132,11 @@ edx-analytics-data-api-client==0.14.4
 edx-ccx-keys==0.2.1
 edx-celeryutils==0.2.7
 edx-completion==0.1.10
-edx-django-oauth2-provider==1.3.4
+edx-django-oauth2-provider==1.3.5
 edx-django-release-util==0.3.1
 edx-django-sites-extensions==2.3.1
 edx-django-utils==1.0.1
-edx-drf-extensions==1.6.2
+edx-drf-extensions==1.7.0
 edx-enterprise==0.73.3
 edx-i18n-tools==0.4.6
 edx-lint==0.5.5
@@ -245,7 +245,7 @@ pyasn1==0.4.4
 pycodestyle==2.3.1
 pycontracts==1.7.1
 pycountry==1.20
-pycparser==2.18
+pycparser==2.19
 pycryptodomex==3.4.7
 pydispatcher==2.0.5
 pyflakes==1.6.0
@@ -325,7 +325,7 @@ text-unidecode==1.2
 tincan==0.0.5
 toml==0.9.6
 tox-battery==0.5.1
-tox==3.3.0
+tox==3.4.0
 traceback2==1.4.0
 transifex-client==0.13.4
 twisted==16.6.0

--- a/requirements/edx/paver.txt
+++ b/requirements/edx/paver.txt
@@ -6,7 +6,7 @@
 #
 argh==0.26.2              # via watchdog
 argparse==1.4.0           # via stevedore
-certifi==2018.8.13        # via requests
+certifi==2018.8.24        # via requests
 chardet==3.0.4            # via requests
 edx-opaque-keys==0.4.4
 idna==2.7                 # via requests
@@ -25,5 +25,6 @@ pyyaml==3.13              # via watchdog
 requests==2.19.1
 six==1.11.0               # via edx-opaque-keys, libsass, paver, stevedore
 stevedore==1.10.0
+urllib3==1.23             # via requests
 watchdog==0.9.0
 wrapt==1.10.5

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -63,7 +63,7 @@ boto3==1.4.8
 boto==2.39.0
 botocore==1.8.17
 celery==3.1.25
-certifi==2018.8.13
+certifi==2018.8.24
 cffi==1.11.5
 charade==1.0.3
 chardet==3.0.4
@@ -127,11 +127,11 @@ edx-analytics-data-api-client==0.14.4
 edx-ccx-keys==0.2.1
 edx-celeryutils==0.2.7
 edx-completion==0.1.10
-edx-django-oauth2-provider==1.3.4
+edx-django-oauth2-provider==1.3.5
 edx-django-release-util==0.3.1
 edx-django-sites-extensions==2.3.1
 edx-django-utils==1.0.1
-edx-drf-extensions==1.6.2
+edx-drf-extensions==1.7.0
 edx-enterprise==0.73.3
 edx-i18n-tools==0.4.6
 edx-lint==0.5.5
@@ -234,7 +234,7 @@ pyasn1==0.4.4             # via pyasn1-modules, service-identity
 pycodestyle==2.3.1
 pycontracts==1.7.1
 pycountry==1.20
-pycparser==2.18
+pycparser==2.19
 pycryptodomex==3.4.7
 pydispatcher==2.0.5       # via scrapy
 pyflakes==1.6.0           # via flake8
@@ -309,7 +309,7 @@ text-unidecode==1.2       # via faker
 tincan==0.0.5
 toml==0.9.6               # via tox
 tox-battery==0.5.1
-tox==3.3.0
+tox==3.4.0
 traceback2==1.4.0         # via testtools, unittest2
 transifex-client==0.13.4
 twisted==16.6.0           # via pa11ycrawler, scrapy


### PR DESCRIPTION
Upgrade the **edx-django-oauth2-provider** package to a version that supports **Python3**

( **version 1.3.4** as of this commit )

This commit is intended to close **INCR-8** issue ( see https://openedx.atlassian.net/browse/INCR-8 )

**Important Note:** The original **_requirements/edx/base.in_** file is already using the latest **version 1.3.4** which has been set as a constraint (_constraint is removed by this PR_). As per the package documentation, the package already supports **Python 3** since **version 1.3.0** ( see https://pypi.org/project/edx-django-oauth2-provider ). Tests in **devstack** are passing; no need for any extra coding