### PR TITLE
Make coverage parallel everywhere

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -29,6 +29,7 @@ omit =
     openedx/features/*/migrations/*
 
 concurrency=multiprocessing
+parallel = true
 
 [report]
 ignore_errors = True

--- a/openedx/core/lib/.coveragerc
+++ b/openedx/core/lib/.coveragerc
@@ -2,6 +2,7 @@
 [run]
 data_file = reports/openedx/core/lib/.coverage
 source = openedx/core/lib
+parallel = true
 
 [report]
 ignore_errors = True

--- a/requirements/edx/testing.in
+++ b/requirements/edx/testing.in
@@ -36,7 +36,7 @@ pyquery                   # jQuery-like API for retrieving fragments of HTML and
 pysqlite                  # DB-API 2.0 interface for SQLite 3.x (used as the relational database for most tests)
 pytest==3.6.3             # Testing framework # Pinned due to https://github.com/pytest-dev/pytest/issues/3749
 pytest-attrib             # Select tests based on attributes
-pytest-cov<2.6            # pytest plugin for measuring code coverage
+pytest-cov<2.6            # pytest plugin for measuring code coverage. # Pinned due to https://openedx.atlassian.net/browse/TE-2731
 pytest-django==3.1.2      # Django support for pytest
 pytest-randomly           # pytest plugin to randomly order tests
 pytest-xdist              # Parallel execution of tests on multiple CPU cores or hosts


### PR DESCRIPTION
This isn't needed for our current environment, but I was testing newer versions of coverage (5.0a2) and pytest-cov (2.6.0), and getting each to work required using parallel everywhere (plus other fixes that are not in this pull request)..