### PR TITLE
Account Page refreshes on autosave/combobox Language value change

### DIFF
--- a/lms/static/js/student_account/views/account_settings_factory.js
+++ b/lms/static/js/student_account/views/account_settings_factory.js
@@ -168,7 +168,8 @@
                                     {platform_name: platformName}
                                 ),
                                 options: fieldsData.language.options,
-                                persistChanges: true
+                                persistChanges: true,
+                                focusNextID: '#u-field-select-country',
                             })
                         },
                         countryFieldView,
@@ -388,7 +389,12 @@
             });
 
             accountSettingsView.render();
-
+            if( $.cookie('focus_id')) {
+                $($.cookie('focus_id')).attr({"tabindex": 0});
+                $($.cookie('focus_id')).focus();
+                // Deleting the cookie
+                document.cookie = "focus_id=; expires=Thu, 01 Jan 1970 00:00:00 UTC; path=/account;";
+            }
             showAccountSettingsPage = function() {
                 // Record that the account settings page was viewed.
                 Logger.log('edx.user.settings.viewed', {

--- a/lms/static/js/views/fields.js
+++ b/lms/static/js/views/fields.js
@@ -143,6 +143,9 @@
                 this.showNotificationMessage(successMessage);
 
                 if (this.options.refreshPageOnSave) {
+                    if ("focusNextID" in this.options) {
+                        $.cookie('focus_id', this.options.focusNextID );
+                    }
                     location.reload(true);
                 }
 


### PR DESCRIPTION
Passing the next field id to focus the next field automatically after the page
reload due to the language selection.
Sandbox = https://learner-3832.sandbox.edx.org/account/settings
LEARNER-3832