### PR TITLE
cherry pick fix for duplicate retired username hashes

### DIFF
--- a/common/djangoapps/student/models.py
+++ b/common/djangoapps/student/models.py
@@ -212,7 +212,14 @@ def is_username_retired(username):
         settings.RETIRED_USERNAME_FMT
     )
 
-    return User.objects.filter(username__in=list(locally_hashed_usernames)).exists()
+    # TODO: Revert to this after username capitalization issues detailed in
+    # PLAT-2276, PLAT-2277, PLAT-2278 are sorted out:
+    # return User.objects.filter(username__in=list(locally_hashed_usernames)).exists()
+
+    # Avoid circular import issues
+    from openedx.core.djangoapps.user_api.models import UserRetirementStatus
+    return User.objects.filter(username__in=list(locally_hashed_usernames)).exists() or \
+        UserRetirementStatus.objects.filter(original_username=username).exists()
 
 
 def is_email_retired(email):
@@ -293,7 +300,27 @@ def get_potentially_retired_user_by_username(username):
     """
     locally_hashed_usernames = list(get_all_retired_usernames_by_username(username))
     locally_hashed_usernames.append(username)
-    return User.objects.get(username__in=locally_hashed_usernames)
+    potential_users = User.objects.filter(username__in=locally_hashed_usernames)
+
+    # Have to disambiguate between several Users here as we could have retirees with
+    # the same username, but for case.
+    # If there's only 1 we're done, this should be the common case
+    if len(potential_users) == 1:
+        return potential_users[0]
+
+    # No user found, throw the usual error
+    if not potential_users:
+        raise User.DoesNotExist()
+
+    # If there are 2, one of two things should be true:
+    # - The user we want is un-retired and has the same case-match username
+    # - Or retired one was the case-match
+    if len(potential_users) == 2:
+        return potential_users[0] if potential_users[0].username == username else potential_users[1]
+
+    # We should have, at most, a retired username and an active one with a username
+    # differing only by case. If there are more we need to disambiguate them by hand.
+    raise Exception('Expected 1 or 2 Users, received {}'.format(text_type(potential_users)))
 
 
 def get_potentially_retired_user_by_username_and_hash(username, hashed_username):

--- a/openedx/core/djangoapps/user_api/accounts/views.py
+++ b/openedx/core/djangoapps/user_api/accounts/views.py
@@ -742,7 +742,7 @@ class AccountRetirementStatusView(ViewSet):
             retirement = None
             if len(retirements) < 1:
                 raise UserRetirementStatus.DoesNotExist()
-            elif len(retirements) > 1:
+            elif len(retirements) >= 1:
                 for r in retirements:
                     if r.original_username == username:
                         retirement = r
@@ -750,10 +750,6 @@ class AccountRetirementStatusView(ViewSet):
                 # UserRetirementStatus was found, but it was the wrong case.
                 if retirement is None:
                     raise UserRetirementStatus.DoesNotExist()
-            else:
-                if username != retirements[0].original_username:
-                    raise UserRetirementStatus.DoesNotExist()
-                retirement = retirements[0]
 
             retirement.update_state(request.data)
             return Response(status=status.HTTP_204_NO_CONTENT)

--- a/openedx/core/djangoapps/user_api/management/commands/bulk_rehash_retired_usernames.py
+++ b/openedx/core/djangoapps/user_api/management/commands/bulk_rehash_retired_usernames.py
@@ -1,0 +1,84 @@
+"""
+One-off script to rehash all retired usernames in UserRetirementStatus and auth_user.
+Background: We discovered that all prior retired usernames were generated based on
+the exact capitalization of the original username, despite the fact that
+usernames are considered case insensitive in practice.  This led to the
+possibility of users registering accounts with effectively retired usernames just
+by changing the capitalization of the username, because the different
+capitalization would hash to a different digest.
+Solution: Rehash all usernames using the normalized-case (lowercase)
+original usernames rather than the possibly mixed-case ones.  This management
+command likely cannot be re-used in the future because eventually we will need
+to clean out the UserRetirementStatus table.
+"""
+from __future__ import print_function
+from django.conf import settings
+from django.db import transaction
+from django.core.management.base import BaseCommand
+from openedx.core.djangoapps.user_api.models import UserRetirementStatus
+from user_util import user_util
+
+
+class Command(BaseCommand):
+    """
+    Implementation of the bulk_rehash_retired_usernames command.
+    """
+    def add_arguments(self, parser):
+        parser.add_argument(
+            '--dry_run',
+            action='store_true',
+            help='Print proposed changes, but take no action.'
+        )
+
+    def handle(self, *args, **options):
+        """
+        Execute the command.
+        """
+        dry_run = options['dry_run']
+        retirements = UserRetirementStatus.objects.all().select_related('user')
+        for retirement in retirements:
+            original_username = retirement.original_username
+            old_retired_username = retirement.retired_username
+            new_retired_username = user_util.get_retired_username(
+                original_username,
+                settings.RETIRED_USER_SALTS,
+                settings.RETIRED_USERNAME_FMT
+            )
+            # Sanity check:
+            if retirement.user.username != old_retired_username:
+                print(
+                    'WARNING: Skipping UserRetirementStatus ID {} / User ID {} because the user does not appear to '
+                    'have a retired username: {} != {}.'.format(
+                        retirement.id,
+                        retirement.user.id,
+                        retirement.user.username,
+                        old_retired_username
+                    )
+                )
+            # If the original username was already normalized (or all lowercase), the old and new hashes would
+            # match:
+            elif old_retired_username == new_retired_username:
+                print(
+                    'Skipping UserRetirementStatus ID {} / User ID {} because the hash would not change.'.format(
+                        retirement.id,
+                        retirement.user.id,
+                    )
+                )
+            # Found an username to update:
+            else:
+                print(
+                    'Updating UserRetirementStatus ID {} / User ID {} '
+                    'to rehash their retired username: {} -> {}'.format(
+                        retirement.id,
+                        retirement.user.id,
+                        old_retired_username,
+                        new_retired_username
+                    )
+                )
+                if not dry_run:
+                    # Update and save both the user table and retirement queue table:
+                    with transaction.atomic():
+                        retirement.user.username = new_retired_username
+                        retirement.user.save()
+                        retirement.retired_username = new_retired_username
+                        retirement.save()

--- a/openedx/core/djangoapps/user_api/management/tests/test_bulk_rehash_retired_usernames.py
+++ b/openedx/core/djangoapps/user_api/management/tests/test_bulk_rehash_retired_usernames.py
@@ -1,0 +1,82 @@
+"""
+Test the bulk_rehash_retired_usernames management command
+"""
+import pytest
+
+from django.core.management import call_command
+
+from openedx.core.djangoapps.user_api.accounts.tests.retirement_helpers import RetirementTestCase, fake_retirement
+from openedx.core.djangoapps.user_api.models import UserRetirementStatus
+from openedx.core.djangolib.testing.utils import skip_unless_lms
+from student.models import get_retired_username_by_username
+from student.tests.factories import UserFactory
+
+pytestmark = pytest.mark.django_db
+
+
+def _setup_users():
+    """
+    Creates and returns test users in the different states of needing rehash:
+    - Skipped: has not yet been retired
+    - Faked: has been fake-retired, but the retired username does not require updating
+    - Needing rehash: has been fake-retired and name changed so it triggers a hash update
+    """
+    # When we loop through creating users, take additional action on these
+    user_indexes_to_be_fake_retired = (2, 4, 6, 8, 10)
+    user_indexes_to_be_rehashed = (4, 6)
+
+    users_skipped = []
+    users_faked = []
+    users_needing_rehash = []
+    retirements = {}
+
+    # Create some test users with retirements
+    for i in range(1, 11):
+        user = UserFactory()
+        retirement = UserRetirementStatus.create_retirement(user)
+        retirements[user.id] = retirement
+
+        if i in user_indexes_to_be_fake_retired:
+            fake_retirement(user)
+
+            if i in user_indexes_to_be_rehashed:
+                # In order to need a rehash user.username must be the same as
+                # retirement.retired_username and NOT the same as the hash
+                # generated when the script is run. So we force that here.
+                retirement.retired_username = retirement.retired_username.upper()
+                user.username = retirement.retired_username
+                retirement.save()
+                user.save()
+                users_needing_rehash.append(user)
+            else:
+                users_faked.append(user)
+        else:
+            users_skipped.append(user)
+    return users_skipped, users_faked, users_needing_rehash, retirements
+
+
+@skip_unless_lms
+def test_successful_rehash(capsys):
+    """
+    Run the command with users of all different hash statuses, expect success
+    """
+    RetirementTestCase.setup_states()
+    users_skipped, users_faked, users_needing_rehash, retirements = _setup_users()
+    call_command('bulk_rehash_retired_usernames')
+    output = capsys.readouterr().out
+
+    for user in users_skipped:
+        assert "User ID {} because the user does not appear to have a retired username:".format(user.id) in output
+
+    for user in users_faked:
+        assert "User ID {} because the hash would not change.".format(user.id) in output
+
+    for user in users_needing_rehash:
+        retirement = retirements[user.id]
+        user.refresh_from_db()
+        retirement.refresh_from_db()
+        new_retired_username = get_retired_username_by_username(retirement.original_username)
+
+        assert "User ID {} to rehash their retired username".format(user.id) in output
+        assert new_retired_username == user.username
+        assert new_retired_username == retirement.retired_username

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -230,7 +230,7 @@ sympy==0.7.1
 unicodecsv==0.14.1
 uritemplate==3.0.0        # via coreapi
 urllib3==1.23             # via elasticsearch
-user-util==0.1.4
+user-util==0.1.5
 voluptuous==0.11.1
 watchdog==0.8.3
 web-fragments==0.2.2

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -334,7 +334,7 @@ unittest2==1.1.0
 uritemplate==3.0.0
 urllib3==1.23
 urlobject==2.4.3
-user-util==0.1.4
+user-util==0.1.5
 virtualenv==16.0.0
 voluptuous==0.11.1
 vulture==0.27

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -316,7 +316,7 @@ unittest2==1.1.0          # via testtools
 uritemplate==3.0.0
 urllib3==1.23
 urlobject==2.4.3          # via pa11ycrawler
-user-util==0.1.4
+user-util==0.1.5
 virtualenv==16.0.0        # via tox
 voluptuous==0.11.1
 w3lib==1.19.0             # via parsel, scrapy


### PR DESCRIPTION
PLAT-2298

This cherry-picks the following commits, from oldest to newest:

- acadd057d9a81e41cb4120802227c6b4a17b8031 (from #18764)
- 8c93e424c0cdf0e97ec6e966a0ab9d734e784a72 (from #18764)
- c4ee7dacbce38ab607305c8579f7d5d0e567d5be (from #18747)
- 2d71697823982b582bfe3c190596a6aca61ac794 (from #18747)
- f207fabfc4be811bd3a713dfc3a0bead8a98f316 (from #18749)
- c17a5d5eaeebc838ff87f63b618f7ad8d677c2fb (from #18783)
- 745aadbcd52073256710e95aa9d65569334bde9f (from #18813) This last commit needed to be hand-modified because it otherwise depends on some other substantial but mostly unrelated commits. See modified commit message for technical detail.

These commits collectively provide a fix for the duplicate username hash problem we encountered on edx.org.  It prevents new account registrations when the retirement hash of the new username collides with the username hash of a preexisting retired user, a breach of integrity.