### PR TITLE
Add access check to change enrollment handler

### DIFF
--- a/common/djangoapps/student/views/management.py
+++ b/common/djangoapps/student/views/management.py
@@ -13,6 +13,7 @@ import analytics
 import dogstats_wrapper as dog_stats_api
 from bulk_email.models import Optout
 from courseware.courses import get_courses, sort_by_announcement, sort_by_start_date
+from courseware.access import has_access
 from django.conf import settings
 from django.contrib import messages
 from django.contrib.auth import login as django_login
@@ -408,6 +409,10 @@ def change_enrollment(request, check_access=True):
         )
         if redirect_url:
             return HttpResponse(redirect_url)
+
+        # Check if user has access to enroll in course
+        if not has_access(request.user, 'enroll', modulestore().get_course(course_id)):
+            return HttpResponseBadRequest(_("Could not enroll"))
 
         if CourseEntitlement.check_for_existing_entitlement_and_enroll(user=user, course_run_key=course_id):
             return HttpResponse(reverse('courseware', args=[unicode(course_id)]))


### PR DESCRIPTION
Currently the change enrollment handler doesn't check the usual access checks for enrollment such as for `CourseEnrollmentAllowed` objects, checks for the enrollment start and end dates, or if the course is marked as invitation only. This PR adds the standard check from `courseware.access.has_access()` to ensure these checks are made when processing a request for updating an enrollment.

**JIRA tickets**: OC-5224

**Dependencies**: None

**Sandbox URL**: TBD - sandbox is being provisioned.

**Testing instructions**:

1. Load a test course about page with the enabled "Enrollment button", leave the page open without clicking the "Enroll in course"
2. Mark the course as invite only
3. Click the enrollment button and ensure that the enrollment does not go through

**Author notes and concerns**:

1. Is this the correct method of making this check?
2. What is the proper response if the access check fails?
3. This could be seen as a security hole, as any registered user could utilize it to enroll in any course. Should this also be backported to ginkgo?

**Reviewers**
- [ ] (@rocioar)
- [ ] edX reviewer[s] TBD