### PR TITLE
Cherry-pick un-deletion management command 

### DIFF
--- a/lms/djangoapps/survey/tests/test_signals.py
+++ b/lms/djangoapps/survey/tests/test_signals.py
@@ -2,7 +2,7 @@
 Test signal handlers for the survey app
 """
 
-from openedx.core.djangoapps.user_api.accounts.tests.retirement_helpers import fake_retirement
+from openedx.core.djangoapps.user_api.accounts.tests.retirement_helpers import fake_completed_retirement
 from student.tests.factories import UserFactory
 from survey.models import SurveyAnswer
 from survey.tests.factories import SurveyAnswerFactory
@@ -43,7 +43,7 @@ class SurveyRetireSignalTests(ModuleStoreTestCase):
 
         # Run twice to make sure no errors are raised
         _listen_for_lms_retire(sender=self.__class__, user=answer.user)
-        fake_retirement(answer.user)
+        fake_completed_retirement(answer.user)
         _listen_for_lms_retire(sender=self.__class__, user=answer.user)
 
         # All values for this user should still be here and just be an empty string

--- a/lms/djangoapps/verify_student/tests/test_signals.py
+++ b/lms/djangoapps/verify_student/tests/test_signals.py
@@ -9,7 +9,7 @@ from pytz import UTC
 from lms.djangoapps.verify_student.models import SoftwareSecurePhotoVerification, VerificationDeadline
 from lms.djangoapps.verify_student.signals import _listen_for_course_publish, _listen_for_lms_retire
 from lms.djangoapps.verify_student.tests.factories import SoftwareSecurePhotoVerificationFactory
-from openedx.core.djangoapps.user_api.accounts.tests.retirement_helpers import fake_retirement
+from openedx.core.djangoapps.user_api.accounts.tests.retirement_helpers import fake_completed_retirement
 from student.tests.factories import UserFactory
 from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
 from xmodule.modulestore.tests.factories import CourseFactory
@@ -95,7 +95,7 @@ class RetirementSignalTest(ModuleStoreTestCase):
 
         # Run this twice to make sure there are no errors raised 2nd time through
         _listen_for_lms_retire(sender=self.__class__, user=verification.user)
-        fake_retirement(verification.user)
+        fake_completed_retirement(verification.user)
         _listen_for_lms_retire(sender=self.__class__, user=verification.user)
 
         ver_obj = SoftwareSecurePhotoVerification.objects.get(user=verification.user)

--- a/openedx/core/djangoapps/credit/tests/test_models.py
+++ b/openedx/core/djangoapps/credit/tests/test_models.py
@@ -15,7 +15,10 @@ from openedx.core.djangoapps.credit.models import (
     CreditRequirement,
     CreditRequirementStatus
 )
-from openedx.core.djangoapps.user_api.accounts.tests.retirement_helpers import RetirementTestCase
+from openedx.core.djangoapps.user_api.accounts.tests.retirement_helpers import (  # pylint: disable=unused-import
+    RetirementTestCase,
+    setup_retirement_states
+)
 from openedx.core.djangoapps.user_api.models import UserRetirementStatus
 from student.tests.factories import UserFactory
 
@@ -97,7 +100,7 @@ class CreditEligibilityModelTests(TestCase):
         self.assertEqual(len(requirements), 1)
 
 
-class CreditRequirementStatusTests(TestCase):
+class CreditRequirementStatusTests(RetirementTestCase):
     """
     Tests for credit requirement status models.
     """
@@ -105,7 +108,6 @@ class CreditRequirementStatusTests(TestCase):
     def setUp(self):
         super(CreditRequirementStatusTests, self).setUp()
         self.course_key = CourseKey.from_string("edX/DemoX/Demo_Course")
-        RetirementTestCase.setup_states()
         self.old_username = "username"
         self.user = UserFactory(username=self.old_username)
         self.retirement = UserRetirementStatus.create_retirement(self.user)
@@ -170,14 +172,13 @@ class CreditRequirementStatusTests(TestCase):
         self.assertFalse(retirement_succeeded)
 
 
-class CreditRequestTest(TestCase):
+class CreditRequestTest(RetirementTestCase):
     """
     The CreditRequest model's test suite.
     """
 
     def setUp(self):
         super(CreditRequestTest, self).setUp()
-        RetirementTestCase.setup_states()
         self.user = UserFactory.create()
         self.retirement = UserRetirementStatus.create_retirement(self.user)
         self.credit_course = CreditCourse.objects.create()

--- a/openedx/core/djangoapps/user_api/accounts/tests/test_models.py
+++ b/openedx/core/djangoapps/user_api/accounts/tests/test_models.py
@@ -11,36 +11,11 @@ from openedx.core.djangoapps.user_api.models import (
 )
 from student.models import get_retired_email_by_email, get_retired_username_by_username
 from student.tests.factories import UserFactory
+from .retirement_helpers import setup_retirement_states  # pylint: disable=unused-import
 
 
 # Tell pytest it's ok to use the database
 pytestmark = pytest.mark.django_db
-
-
-@pytest.fixture
-def setup_retirement_states():
-    """
-    Pytest fixture to create some basic states for testing. Duplicates functionality of the
-    Django test runner in test_views.py unfortunately, but they're not compatible.
-    """
-    default_states = [
-        ('PENDING', 1, False, True),
-        ('LOCKING_ACCOUNT', 20, False, False),
-        ('LOCKING_COMPLETE', 30, False, False),
-        ('RETIRING_LMS', 40, False, False),
-        ('LMS_COMPLETE', 50, False, False),
-        ('ERRORED', 60, True, True),
-        ('ABORTED', 70, True, True),
-        ('COMPLETE', 80, True, True),
-    ]
-
-    for name, ex, dead, req in default_states:
-        RetirementState.objects.create(
-            state_name=name,
-            state_execution_order=ex,
-            is_dead_end_state=dead,
-            required=req
-        )
 
 
 def _assert_retirementstatus_is_user(retirement, user):

--- a/openedx/core/djangoapps/user_api/accounts/tests/test_retirement_views.py
+++ b/openedx/core/djangoapps/user_api/accounts/tests/test_retirement_views.py
@@ -78,7 +78,12 @@ from student.tests.factories import (
 
 from ..views import AccountRetirementView, USER_PROFILE_PII
 from ...tests.factories import UserOrgTagFactory
-from .retirement_helpers import RetirementTestCase, fake_retirement
+from .retirement_helpers import (  # pylint: disable=unused-import
+    RetirementTestCase,
+    fake_completed_retirement,
+    create_retirement_status,
+    setup_retirement_states
+)
 
 
 def build_jwt_headers(user):
@@ -255,8 +260,7 @@ class TestAccountRetireMailings(RetirementTestCase):
 
         # Should be created in parent setUpClass
         retiring_email_lists = RetirementState.objects.get(state_name='RETIRING_EMAIL_LISTS')
-
-        self.retirement = self._create_retirement(retiring_email_lists)
+        self.retirement = create_retirement_status(retiring_email_lists)
         self.test_user = self.retirement.user
 
         self.url = reverse('accounts_retire_mailings')
@@ -456,7 +460,7 @@ class TestPartnerReportingPut(RetirementTestCase, ModuleStoreTestCase):
         Checks the simple success case of creating a user, enrolling in a course, and doing the partner
         report PUT. User should then have the appropriate row in UserRetirementPartnerReportingStatus
         """
-        retirement = self._create_retirement(self.partner_queue_state)
+        retirement = create_retirement_status(self.partner_queue_state)
         for course in self.courses:
             CourseEnrollment.enroll(user=retirement.user, course_key=course.id)
 
@@ -467,7 +471,7 @@ class TestPartnerReportingPut(RetirementTestCase, ModuleStoreTestCase):
         """
         Runs the success test twice to make sure that re-running the step still succeeds.
         """
-        retirement = self._create_retirement(self.partner_queue_state)
+        retirement = create_retirement_status(self.partner_queue_state)
         for course in self.courses:
             CourseEnrollment.enroll(user=retirement.user, course_key=course.id)
 
@@ -475,7 +479,7 @@ class TestPartnerReportingPut(RetirementTestCase, ModuleStoreTestCase):
         self.put_and_assert_status({'username': retirement.original_username})
 
         # Do our basic other retirement step fakery
-        fake_retirement(retirement.user)
+        fake_completed_retirement(retirement.user)
 
         # Try running our step again
         self.put_and_assert_status({'username': retirement.original_username})
@@ -500,7 +504,7 @@ class TestPartnerReportingPut(RetirementTestCase, ModuleStoreTestCase):
         the enrollment.course.org. We now just use the enrollment.course_id.org
         since for this purpose we don't care if the course exists.
         """
-        retirement = self._create_retirement(self.partner_queue_state)
+        retirement = create_retirement_status(self.partner_queue_state)
         user = retirement.user
         enrollment = CourseEnrollment.enroll(user=user, course_key=CourseKey.from_string('edX/Test201/2018_Fall'))
 
@@ -714,7 +718,7 @@ class TestAccountRetirementList(RetirementTestCase):
         Verify that users in dead end states are not returned
         """
         for state in self._get_dead_end_states():
-            self._create_retirement(state)
+            create_retirement_status(state)
         self.assert_status_and_user_list([], states_to_request=self._get_non_dead_end_states())
 
     def test_users_retrieved_in_multiple_states(self):
@@ -723,7 +727,7 @@ class TestAccountRetirementList(RetirementTestCase):
         """
         multiple_states = ['PENDING', 'FORUMS_COMPLETE']
         for state in multiple_states:
-            self._create_retirement(RetirementState.objects.get(state_name=state))
+            create_retirement_status(RetirementState.objects.get(state_name=state))
         data = {'cool_off_days': 0, 'states': multiple_states}
         response = self.client.get(self.url, data, **self.headers)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
@@ -760,7 +764,7 @@ class TestAccountRetirementList(RetirementTestCase):
         pending_state = RetirementState.objects.get(state_name='PENDING')
         for days_back in range(1, days_back_to_test, -1):
             create_datetime = datetime.datetime.now(pytz.UTC) - datetime.timedelta(days=days_back)
-            retirements.append(self._create_retirement(state=pending_state, create_datetime=create_datetime))
+            retirements.append(create_retirement_status(state=pending_state, create_datetime=create_datetime))
 
         # Confirm we get the correct number and data back for each day we add to cool off days
         # For each day we add to `cool_off_days` we expect to get one fewer retirement.
@@ -883,7 +887,7 @@ class TestAccountRetirementsByStatusAndDate(RetirementTestCase):
         Verify that users in non-requested states are not returned
         """
         state = RetirementState.objects.get(state_name='PENDING')
-        self._create_retirement(state=state)
+        create_retirement_status(state=state)
         self.assert_status_and_user_list([])
 
     def test_users_exist(self):
@@ -914,7 +918,7 @@ class TestAccountRetirementsByStatusAndDate(RetirementTestCase):
         # Create retirements for the last 10 days
         for days_back in range(0, 10):
             create_datetime = datetime.datetime.now(pytz.UTC) - datetime.timedelta(days=days_back)
-            ret = self._create_retirement(state=complete_state, create_datetime=create_datetime)
+            ret = create_retirement_status(state=complete_state, create_datetime=create_datetime)
             retirements.append(self._retirement_to_dict(ret))
 
         # Go back in time adding days to the query, assert the correct retirements are present
@@ -1007,7 +1011,7 @@ class TestAccountRetirementRetrieve(RetirementTestCase):
         retirements = []
 
         for state in RetirementState.objects.all():
-            retirements.append(self._create_retirement(state))
+            retirements.append(create_retirement_status(state))
 
         for retirement in retirements:
             values = self._retirement_to_dict(retirement)
@@ -1018,7 +1022,7 @@ class TestAccountRetirementRetrieve(RetirementTestCase):
         Simulate retrieving a retirement by the old username, after the name has been changed to the hashed one
         """
         pending_state = RetirementState.objects.get(state_name='PENDING')
-        retirement = self._create_retirement(pending_state)
+        retirement = create_retirement_status(pending_state)
         original_username = retirement.user.username
 
         hashed_username = get_retired_username_by_username(original_username)
@@ -1041,7 +1045,7 @@ class TestAccountRetirementUpdate(RetirementTestCase):
         self.pending_state = RetirementState.objects.get(state_name='PENDING')
         self.locking_state = RetirementState.objects.get(state_name='LOCKING_ACCOUNT')
 
-        self.retirement = self._create_retirement(self.pending_state)
+        self.retirement = create_retirement_status(self.pending_state)
         self.test_user = self.retirement.user
         self.test_superuser = SuperuserFactory()
         self.headers = build_jwt_headers(self.test_superuser)
@@ -1351,7 +1355,7 @@ class TestAccountRetirementPost(RetirementTestCase):
     def test_retire_user_twice_idempotent(self):
         data = {'username': self.original_username}
         self.post_and_assert_status(data)
-        fake_retirement(self.test_user)
+        fake_completed_retirement(self.test_user)
         self.post_and_assert_status(data)
 
     def test_deletes_pii_from_user_profile(self):
@@ -1571,5 +1575,5 @@ class TestLMSAccountRetirementPost(RetirementTestCase, ModuleStoreTestCase):
         # check that a second call to the retire_misc endpoint will work
         data = {'username': self.original_username}
         self.post_and_assert_status(data)
-        fake_retirement(self.test_user)
+        fake_completed_retirement(self.test_user)
         self.post_and_assert_status(data)

--- a/openedx/core/djangoapps/user_api/accounts/tests/test_retirement_views.py
+++ b/openedx/core/djangoapps/user_api/accounts/tests/test_retirement_views.py
@@ -810,6 +810,155 @@ class TestAccountRetirementList(RetirementTestCase):
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
 
+@ddt.ddt
+@unittest.skipUnless(settings.ROOT_URLCONF == 'lms.urls', 'Account APIs are only supported in LMS')
+class TestAccountRetirementsByStatusAndDate(RetirementTestCase):
+    """
+    Tests the retirements_by_status_and_date endpoint
+    """
+
+    def setUp(self):
+        super(TestAccountRetirementsByStatusAndDate, self).setUp()
+        self.test_superuser = SuperuserFactory()
+        self.headers = build_jwt_headers(self.test_superuser)
+        self.url = reverse('accounts_retirements_by_status_and_date')
+        self.maxDiff = None
+
+    def assert_status_and_user_list(
+            self,
+            expected_data,
+            expected_status=status.HTTP_200_OK,
+            state_to_request=None,
+            start_date=None,
+            end_date=None
+    ):
+        """
+        Helper function for making a request to the endpoint, asserting the status, and
+        optionally asserting data returned. Will try to convert datetime start and end dates
+        to the correct string formatting.
+        """
+        if state_to_request is None:
+            state_to_request = 'COMPLETE'
+
+        if start_date is None:
+            start_date = datetime.datetime.now().date().strftime('%Y-%m-%d')
+        else:
+            start_date = start_date.date().strftime('%Y-%m-%d')
+
+        if end_date is None:
+            end_date = datetime.datetime.now().date().strftime('%Y-%m-%d')
+        else:
+            end_date = end_date.date().strftime('%Y-%m-%d')
+
+        data = {'start_date': start_date, 'end_date': end_date, 'state': state_to_request}
+        response = self.client.get(self.url, data, **self.headers)
+
+        print(response.status_code)
+        print(response)
+
+        self.assertEqual(response.status_code, expected_status)
+        response_data = response.json()
+
+        if expected_data:
+            # These datetimes won't match up due to serialization, but they're inherited fields tested elsewhere
+            for data in (response_data, expected_data):
+                for retirement in data:
+                    # These may have been deleted in a previous pass
+                    try:
+                        del retirement['created']
+                        del retirement['modified']
+                    except KeyError:
+                        pass
+
+            self.assertItemsEqual(response_data, expected_data)
+
+    def test_empty(self):
+        """
+        Verify that an empty array is returned if no users are awaiting retirement
+        """
+        self.assert_status_and_user_list([])
+
+    def test_users_exist_none_in_correct_state(self):
+        """
+        Verify that users in non-requested states are not returned
+        """
+        state = RetirementState.objects.get(state_name='PENDING')
+        self._create_retirement(state=state)
+        self.assert_status_and_user_list([])
+
+    def test_users_exist(self):
+        """
+        Verify correct user is returned when users in different states exist
+        """
+        # Stores the user we expect to get back
+        retirement_values = None
+        for retirement in self._create_users_all_states():
+            if retirement.current_state == 'COMPLETE':
+                retirement_values.append(self._retirement_to_dict(retirement))
+
+        self.assert_status_and_user_list(retirement_values)
+
+    def test_bad_states(self):
+        """
+        Check some bad inputs to make sure we get back the expected status
+        """
+        self.assert_status_and_user_list(None, expected_status=status.HTTP_400_BAD_REQUEST, state_to_request='TACO')
+
+    def test_date_filter(self):
+        """
+        Verifies the functionality of the start and end date filters
+        """
+        retirements = []
+        complete_state = RetirementState.objects.get(state_name='COMPLETE')
+
+        # Create retirements for the last 10 days
+        for days_back in range(0, 10):
+            create_datetime = datetime.datetime.now(pytz.UTC) - datetime.timedelta(days=days_back)
+            ret = self._create_retirement(state=complete_state, create_datetime=create_datetime)
+            retirements.append(self._retirement_to_dict(ret))
+
+        # Go back in time adding days to the query, assert the correct retirements are present
+        end_date = datetime.datetime.now(pytz.UTC)
+        for days_back in range(1, 11):
+            retirement_dicts = retirements[:days_back]
+            start_date = end_date - datetime.timedelta(days=days_back - 1)
+            self.assert_status_and_user_list(
+                retirement_dicts,
+                start_date=start_date,
+                end_date=end_date
+            )
+
+    def test_bad_dates(self):
+        """
+        Check some bad inputs to make sure we get back the expected status
+        """
+        good_date = '2018-01-01'
+        for bad_param, good_param in (('start_date', 'end_date'), ('end_date', 'start_date')):
+            for bad_date in ('10/21/2001', '2118-01-01', '2018-14-25', 'toast', 5):
+                data = {
+                    bad_param: bad_date,
+                    good_param: good_date,
+                    'state': 'COMPLETE'
+                }
+                response = self.client.get(self.url, data, **self.headers)
+                self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+    @ddt.data(
+        {},
+        {'start_date': '2018-01-01'},
+        {'end_date': '2018-01-01'},
+        {'state': 'PENDING'},
+        {'start_date': '2018-01-01', 'state': 'PENDING'},
+        {'end_date': '2018-01-01', 'state': 'PENDING'},
+    )
+    def test_missing_params(self, request_data):
+        """
+        All params are required, make sure that is enforced
+        """
+        response = self.client.get(self.url, request_data, **self.headers)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+
 @unittest.skipUnless(settings.ROOT_URLCONF == 'lms.urls', 'Account APIs are only supported in LMS')
 class TestAccountRetirementRetrieve(RetirementTestCase):
     """

--- a/openedx/core/djangoapps/user_api/accounts/views.py
+++ b/openedx/core/djangoapps/user_api/accounts/views.py
@@ -529,17 +529,18 @@ class AccountRetirementPartnerReportView(ViewSet):
     parser_classes = (JSONParser,)
     serializer_class = UserRetirementStatusSerializer
 
-    def _get_orgs_for_user(self, user):
+    @staticmethod
+    def _get_orgs_for_user(user):
         """
         Returns a set of orgs that the user has enrollments with
         """
         orgs = set()
         for enrollment in user.courseenrollment_set.all():
-            org = enrollment.course.org
+            org = enrollment.course_id.org
 
             # Org can concievably be blank or this bogus default value
             if org and org != 'outdated_entry':
-                orgs.add(enrollment.course.org)
+                orgs.add(org)
         return orgs
 
     def retirement_partner_report(self, request):  # pylint: disable=unused-argument
@@ -792,9 +793,9 @@ class LMSAccountRetirementView(ViewSet):
             course_enrollments = CourseEnrollment.objects.filter(user=retirement.user)
             ManualEnrollmentAudit.retire_manual_enrollments(course_enrollments, retirement.retired_email)
 
-            CreditRequest.retire_user(retirement.original_username, retirement.retired_username)
+            CreditRequest.retire_user(retirement)
             ApiAccessRequest.retire_user(retirement.user)
-            CreditRequirementStatus.retire_user(retirement.user.username)
+            CreditRequirementStatus.retire_user(retirement)
 
             # This signal allows code in higher points of LMS to retire the user as necessary
             USER_RETIRE_LMS_MISC.send(sender=self.__class__, user=retirement.user)

--- a/openedx/core/djangoapps/user_api/management/commands/cancel_user_retirement_request.py
+++ b/openedx/core/djangoapps/user_api/management/commands/cancel_user_retirement_request.py
@@ -1,0 +1,59 @@
+"""
+Use this mgmt command when a user requests retirement mistakenly, then requests
+for the retirement request to be cancelled. The command can't cancel a retirement
+that has already commenced - only pending retirements.
+"""
+from __future__ import print_function
+
+import logging
+
+from django.core.management.base import BaseCommand, CommandError
+from openedx.core.djangoapps.user_api.models import UserRetirementStatus
+
+
+LOGGER = logging.getLogger(__name__)
+
+
+class Command(BaseCommand):
+    """
+    Implementation of the cancel_user_retirement_request command.
+    """
+    help = 'Cancels the retirement of a user who has requested retirement - but has not yet been retired.'
+
+    def add_arguments(self, parser):
+        parser.add_argument('email_address',
+                            help='Email address of user whose retirement request will be cancelled.')
+
+    def handle(self, *args, **options):
+        """
+        Execute the command.
+        """
+        email_address = options['email_address'].lower()
+
+        try:
+            # Load the user retirement status.
+            retirement_status = UserRetirementStatus.objects.select_related('current_state').select_related('user').get(
+                original_email=email_address
+            )
+        except UserRetirementStatus.DoesNotExist:
+            raise CommandError("No retirement request with email address '{}' exists.".format(email_address))
+
+        # Check if the user has started the retirement process -or- not.
+        if retirement_status.current_state.state_name != 'PENDING':
+            raise CommandError(
+                "Retirement requests can only be cancelled for users in the PENDING state."
+                " Current request state for '{}': {}".format(
+                    email_address,
+                    retirement_status.current_state.state_name
+                )
+            )
+
+        # Load the user record using the retired email address -and- change the email address back.
+        retirement_status.user.email = email_address
+        retirement_status.user.save()
+
+        # Delete the user retirement status record.
+        # No need to delete the accompanying "permanent" retirement request record - it gets done via Django signal.
+        retirement_status.delete()
+
+        print("Successfully cancelled retirement request for user with email address '{}'.")

--- a/openedx/core/djangoapps/user_api/management/tests/test_cancel_retirement.py
+++ b/openedx/core/djangoapps/user_api/management/tests/test_cancel_retirement.py
@@ -1,0 +1,50 @@
+"""
+Test the cancel_user_retirement_request management command
+"""
+import pytest
+from django.contrib.auth.models import User
+from django.core.management import CommandError, call_command
+
+from openedx.core.djangoapps.user_api.accounts.tests.retirement_helpers import (  # pylint: disable=unused-import
+    logged_out_retirement_request,
+    setup_retirement_states
+)
+from openedx.core.djangoapps.user_api.models import RetirementState, UserRetirementRequest, UserRetirementStatus
+from student.tests.factories import UserFactory
+
+pytestmark = pytest.mark.django_db
+
+
+def test_successful_cancellation(setup_retirement_states, logged_out_retirement_request):  # pylint: disable=redefined-outer-name, unused-argument
+    """
+    Test a successfully cancelled retirement request.
+    """
+    call_command('cancel_user_retirement_request', logged_out_retirement_request.original_email)
+    # Confirm that no retirement status exists for the user.
+    with pytest.raises(UserRetirementStatus.DoesNotExist):
+        UserRetirementStatus.objects.get(original_email=logged_out_retirement_request.user.email)
+    # Confirm that no retirement request exists for the user.
+    with pytest.raises(UserRetirementRequest.DoesNotExist):
+        UserRetirementRequest.objects.get(user=logged_out_retirement_request.user)
+    # Ensure user can be retrieved using the original email address.
+    User.objects.get(email=logged_out_retirement_request.original_email)
+
+
+def test_cancellation_in_unrecoverable_state(setup_retirement_states, logged_out_retirement_request):  # pylint: disable=redefined-outer-name, unused-argument
+    """
+    Test a failed cancellation of a retirement request due to the retirement already beginning.
+    """
+    retiring_lms_state = RetirementState.objects.get(state_name='RETIRING_LMS')
+    logged_out_retirement_request.current_state = retiring_lms_state
+    logged_out_retirement_request.save()
+    with pytest.raises(CommandError, match=r'Retirement requests can only be cancelled for users in the PENDING state'):
+        call_command('cancel_user_retirement_request', logged_out_retirement_request.original_email)
+
+
+def test_cancellation_unknown_email_address(setup_retirement_states, logged_out_retirement_request):  # pylint: disable=redefined-outer-name, unused-argument
+    """
+    Test attempting to cancel a non-existent request of a user.
+    """
+    user = UserFactory()
+    with pytest.raises(CommandError, match=r'No retirement request with email address'):
+        call_command('cancel_user_retirement_request', user.email)

--- a/openedx/core/djangoapps/user_api/models.py
+++ b/openedx/core/djangoapps/user_api/models.py
@@ -264,13 +264,15 @@ class UserRetirementStatus(TimeStampedModel):
         Confirm that the data passed in is properly formatted
         """
         required_keys = ('username', 'new_state', 'response')
+        optional_keys = ('force', )
+        known_keys = required_keys + optional_keys
 
         for required_key in required_keys:
             if required_key not in data:
                 raise RetirementStateError('RetirementStatus: Required key {} missing from update'.format(required_key))
 
         for key in data:
-            if key not in required_keys:
+            if key not in known_keys:
                 raise RetirementStateError('RetirementStatus: Unknown key {} in update'.format(key))
 
     @classmethod
@@ -310,7 +312,10 @@ class UserRetirementStatus(TimeStampedModel):
         or throw a RetirementStateError with a useful error message
         """
         self._validate_update_data(update)
-        self._validate_state_update(update['new_state'])
+
+        force = update.get('force', False)
+        if not force:
+            self._validate_state_update(update['new_state'])
 
         old_state = self.current_state
         self.current_state = RetirementState.objects.get(state_name=update['new_state'])

--- a/openedx/core/djangoapps/user_api/tests/test_views.py
+++ b/openedx/core/djangoapps/user_api/tests/test_views.py
@@ -41,6 +41,7 @@ from ..accounts import (
     NAME_MAX_LENGTH, EMAIL_MIN_LENGTH, EMAIL_MAX_LENGTH,
     USERNAME_MIN_LENGTH, USERNAME_MAX_LENGTH, USERNAME_BAD_LENGTH_MSG
 )
+from ..accounts.tests.retirement_helpers import setup_retirement_states  # pylint: disable=unused-import
 from ..accounts.api import get_account_settings
 from ..models import UserOrgTag
 from ..tests.factories import UserPreferenceFactory

--- a/openedx/core/djangoapps/user_api/urls.py
+++ b/openedx/core/djangoapps/user_api/urls.py
@@ -43,6 +43,10 @@ RETIREMENT_QUEUE = AccountRetirementStatusView.as_view({
     'get': 'retirement_queue'
 })
 
+RETIREMENT_LIST_BY_STATUS_AND_DATE = AccountRetirementStatusView.as_view({
+    'get': 'retirements_by_status_and_date'
+})
+
 RETIREMENT_RETRIEVE = AccountRetirementStatusView.as_view({
     'get': 'retrieve'
 })
@@ -114,6 +118,11 @@ urlpatterns = [
         r'^v1/accounts/retirement_queue/$',
         RETIREMENT_QUEUE,
         name='accounts_retirement_queue'
+    ),
+    url(
+        r'^v1/accounts/retirements_by_status_and_date/$',
+        RETIREMENT_LIST_BY_STATUS_AND_DATE,
+        name='accounts_retirements_by_status_and_date'
     ),
     url(
         r'^v1/accounts/retire/$',


### PR DESCRIPTION
PLAT-2308

The primary goal is to cherry-pick this commit:

f92a8f6e2471c53e655caa671b7f5207bcce8afc - Mgmt command to cancel user retirement request.

It depends on the following commits which we also cherry-pick:

* caedc68061c0a12b74cbe9c5359cc9da5b665349
  * renames post_and_assert_status to put_and_assert_status
* 04fe4af9c0e18e503c7a8d20d0aa5680d0bc15a8 and 74b07c3ff84d24eb0bd4f59bef8f410b10df6774
  * these introduce a test case which f92a8f6e2471c53e655caa671b7f5207bcce8afc attempts to modify.

Additionally, we now rely on new unit test functionality which has been manually reverted in a previous cherry-pick e5247835859de9afd965e9d5edf4d6720bd8c5e0 as part of https://github.com/edx/edx-platform/pull/18892.

In summary, this PR cherry-picks the following in this order:

1. 32965363db - PLAT-2217 - fix partner reporting queue 500 errors, reduce log spam
1. 99a0c368e5 - PLAT-2186 - allow retirement states to be forced by driver script
1. 715b8d31ac - Adding user_api call to get retirements by date range and current state
1. 313be9b2ab - Mgmt command to cancel user retirement request.

...and then adds a new commit to un-revert some test case changes introduced in e5247835859de9afd965e9d5edf4d6720bd8c5e0.
