### PR TITLE
Don't join to auth_user when getting verified user ids; use them in a set, not a list

### DIFF
--- a/lms/djangoapps/instructor_task/tasks_helper/grades.py
+++ b/lms/djangoapps/instructor_task/tasks_helper/grades.py
@@ -174,9 +174,7 @@ class _TeamBulkContext(object):
 class _EnrollmentBulkContext(object):
     def __init__(self, context, users):
         CourseEnrollment.bulk_fetch_enrollment_states(users, context.course_id)
-        self.verified_users = [
-            verified.user.id for verified in IDVerificationService.get_verified_users(users)
-        ]
+        self.verified_users = set(IDVerificationService.get_verified_user_ids(users))
 
 
 class _CourseGradeBulkContext(object):

--- a/lms/djangoapps/verify_student/services.py
+++ b/lms/djangoapps/verify_student/services.py
@@ -85,10 +85,9 @@ class IDVerificationService(object):
         return verifications
 
     @classmethod
-    def get_verified_users(cls, users):
+    def get_verified_user_ids(cls, users):
         """
-        Return the list of users that have non-expired verifications of either type from
-        the given list of users.
+        Given a list of users, returns an iterator of user ids that have non-expired verifications of any type.
         """
         filter_kwargs = {
             'user__in': users,
@@ -96,9 +95,9 @@ class IDVerificationService(object):
             'created_at__gte': (earliest_allowed_verification_date())
         }
         return chain(
-            SoftwareSecurePhotoVerification.objects.filter(**filter_kwargs).select_related('user'),
-            SSOVerification.objects.filter(**filter_kwargs).select_related('user'),
-            ManualVerification.objects.filter(**filter_kwargs).select_related('user')
+            SoftwareSecurePhotoVerification.objects.filter(**filter_kwargs).values_list('user_id', flat=True),
+            SSOVerification.objects.filter(**filter_kwargs).values_list('user_id', flat=True),
+            ManualVerification.objects.filter(**filter_kwargs).values_list('user_id', flat=True)
         )
 
     @classmethod

--- a/lms/djangoapps/verify_student/tests/test_services.py
+++ b/lms/djangoapps/verify_student/tests/test_services.py
@@ -123,3 +123,25 @@ class TestIDVerificationService(MockS3Mixin, ModuleStoreTestCase):
 
             status = IDVerificationService.verification_status_for_user(user, enrollment_mode)
             self.assertEqual(status, output)
+
+    def test_get_verified_user_ids(self):
+        """
+        Tests for getting users that are verified.
+        """
+        user_a = UserFactory.create()
+        user_b = UserFactory.create()
+        user_c = UserFactory.create()
+        user_unverified = UserFactory.create()
+        user_denied = UserFactory.create()
+
+        SoftwareSecurePhotoVerification.objects.create(user=user_a, status='approved')
+        ManualVerification.objects.create(user=user_b, status='approved')
+        SSOVerification.objects.create(user=user_c, status='approved')
+        SSOVerification.objects.create(user=user_denied, status='denied')
+
+        verified_user_ids = set(IDVerificationService.get_verified_user_ids([
+            user_a, user_b, user_c, user_unverified, user_denied
+        ]))
+        expected_user_ids = {user_a.id, user_b.id, user_c.id}
+
+        self.assertEqual(expected_user_ids, verified_user_ids)


### PR DESCRIPTION
https://openedx.atlassian.net/browse/EDUCATOR-3406

For instructor CSV grade reports, we include a column specifying if the user is verified.  We're currently using a queryset that joins to `auth_user`, even though we only need the user_id, which is included in all of the verification tables.  This PR eliminates that join.  It also stores the verified user ids in a set for more performant inclusion checking.