### PR TITLE
Proposal: Feature to close courses and block learner access

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -140,3 +140,4 @@ dist
 
 # Visual Studio Code
 .vscode
+


### PR DESCRIPTION
This feature will make it possible to close a course which will block learner access to the closed course. A per-course 'Close course' setting will be provided to close the course or re-open access to the course. Currently, course authors achieve this by moving the course start date to the far future which can be confusing and is a misleading use of the feature. The error message shown when the learner tries to access that course is also misleading.

The functionality of blocking access to the course will be similar to the behavior when the course start date is in the future. The student dashboard will still display the course in the student dashboard but without any links to the blocked course. Navigating to the course content directly by URL will redirect the student to the dashboard page with an appropriate error message.

Most of the code changes to implement this feature will have to be done in the `courseware` module. There are existing checks in that module which check for the course start date and block access if it is in the future. Additional checks can be added for implementing this feature.

**Dependencies**: None

**Merge deadline**: None

**Reviewers**
- [ ] @symbolist 
- [ ] edX reviewer[s] TBD

CC @mduboseedx, requesting a review for this proposal.