### PR TITLE
Making templates rendering pluggable

### DIFF
--- a/common/djangoapps/edxmako/shortcuts.py
+++ b/common/djangoapps/edxmako/shortcuts.py
@@ -24,6 +24,7 @@ from openedx.core.djangoapps.site_configuration import helpers as configuration_
 from openedx.core.djangoapps.theming.helpers import is_request_in_themed_site
 
 from . import Engines
+from . import signals
 
 log = logging.getLogger(__name__)
 
@@ -151,6 +152,8 @@ def render_to_string(template_name, dictionary, namespace='main', request=None):
         request: The request to use to construct the RequestContext for rendering
             this template. If not supplied, the current request will be used.
     """
+    signals.BEFORE_RENDER_TO_RESPONSE.send(sender=template_name, template_name=template_name, dictionary=dictionary, request=request)
+
     if namespace == 'lms.main':
         engine = engines[Engines.PREVIEW]
     else:
@@ -164,6 +167,5 @@ def render_to_response(template_name, dictionary=None, namespace='main', request
     Returns a HttpResponse whose content is filled with the result of calling
     lookup.get_template(args[0]).render with the passed arguments.
     """
-
     dictionary = dictionary or {}
     return HttpResponse(render_to_string(template_name, dictionary, namespace, request), **kwargs)

--- a/common/djangoapps/edxmako/shortcuts.py
+++ b/common/djangoapps/edxmako/shortcuts.py
@@ -152,7 +152,12 @@ def render_to_string(template_name, dictionary, namespace='main', request=None):
         request: The request to use to construct the RequestContext for rendering
             this template. If not supplied, the current request will be used.
     """
-    signals.BEFORE_RENDER_TO_RESPONSE.send(sender=template_name, template_name=template_name, dictionary=dictionary, request=request)
+    responses = signals.BEFORE_RENDER_TO_RESPONSE.send(sender=template_name, template_name=template_name, dictionary=dictionary, request=request)
+    for receiver, response in responses:
+        if isinstance(list, response):
+            dictionary = response.get('dictionary', dictionary)
+            template_name = response.get('template_name', template_name)
+            request = response.get('request', request)
 
     if namespace == 'lms.main':
         engine = engines[Engines.PREVIEW]

--- a/common/djangoapps/edxmako/shortcuts.py
+++ b/common/djangoapps/edxmako/shortcuts.py
@@ -154,7 +154,7 @@ def render_to_string(template_name, dictionary, namespace='main', request=None):
     """
     responses = signals.BEFORE_RENDER_TO_RESPONSE.send(sender=template_name, template_name=template_name, dictionary=dictionary, request=request)
     for receiver, response in responses:
-        if isinstance(list, response):
+        if isinstance(dict, response):
             dictionary = response.get('dictionary', dictionary)
             template_name = response.get('template_name', template_name)
             request = response.get('request', request)

--- a/common/djangoapps/edxmako/shortcuts.py
+++ b/common/djangoapps/edxmako/shortcuts.py
@@ -154,7 +154,7 @@ def render_to_string(template_name, dictionary, namespace='main', request=None):
     """
     responses = signals.BEFORE_RENDER_TO_RESPONSE.send(sender=template_name, template_name=template_name, dictionary=dictionary, request=request)
     for receiver, response in responses:
-        if isinstance(dict, response):
+        if isinstance(response, dict):
             dictionary = response.get('dictionary', dictionary)
             template_name = response.get('template_name', template_name)
             request = response.get('request', request)

--- a/common/djangoapps/edxmako/signals.py
+++ b/common/djangoapps/edxmako/signals.py
@@ -1,0 +1,5 @@
+"""Signals related to the edxmako rendering methods."""
+from django.dispatch import Signal
+
+
+BEFORE_RENDER_TO_RESPONSE = Signal(providing_args=["template_name", "dictionary", "namespace", "request"])


### PR DESCRIPTION
This feature will make it possible for third-party [plugins](https://github.com/edx/edx-platform/tree/master/openedx/core/djangoapps/plugins) and apps installed along with Open edX to modify template context arguments (A.K.A. `dictionary` function argument) without needing to modify the theme files (which requires a lot more work than installing a plugin and if the theme is created by a third-party will break if updated) 

Usage example:
```python
@receiver(pre_save, sender='dashboard.html')
def my_handler(sender, **kwargs):
    pass
```