### PR TITLE
Subclass PaverTestCase in flaky paver db tests

### DIFF
--- a/pavelib/paver_tests/test_database.py
+++ b/pavelib/paver_tests/test_database.py
@@ -17,6 +17,7 @@ from pavelib.utils.db_utils import (
 )
 from pavelib.utils import db_utils
 from pavelib import database
+from .utils import PaverTestCase
 
 
 class TestPaverDbS3Utils(MockS3Mixin, TestCase):
@@ -77,7 +78,7 @@ def _write_temporary_db_cache_files(path, files):
             cache_file.write(str(index))
 
 
-class TestPaverDatabaseTasks(MockS3Mixin, TestCase):
+class TestPaverDatabaseTasks(MockS3Mixin, PaverTestCase):
     """
     Tests for the high level database tasks
     """


### PR DESCRIPTION
This test class was flaky when switching over to xdist. It looks like subclassing `PaverTestClass` helps reduce this flakiness.