### PR TITLE
increase npm installation timeouts

### DIFF
--- a/pavelib/prereqs.py
+++ b/pavelib/prereqs.py
@@ -129,7 +129,7 @@ def node_prereqs_installation():
     Configures npm and installs Node prerequisites
     """
 
-    @timeout(limit=300)
+    @timeout(limit=600)
     def _run_npm_command(npm_command, npm_log_file):
         """
         helper function for running the npm installation with a timeout.


### PR DESCRIPTION
The purpose of this timeout is to prevent the case where an NPM installation is hanging indefinitely, not to penalize slow installations. It seems that I was too strict in setting the initial timeout value, and builds are timing out regularly, and we can't really tell if it is because of a hang or just a slow install. Hopefully setting it to 10 minutes will help us understand what is going on