### PR TITLE
Remove learner from cohort upon unenrollment

### DIFF
--- a/openedx/core/djangoapps/course_groups/models.py
+++ b/openedx/core/djangoapps/course_groups/models.py
@@ -90,8 +90,8 @@ class CohortMembership(models.Model):
     @classmethod
     def assign(cls, cohort, user):
         """
-        Assign user to cohort, switching them to this cohort if they had previously been assigned to another
-        cohort
+        Assigns user to cohort, switching them to this cohort if they had previously been assigned to another
+        cohort.
         Returns CohortMembership, previous_cohort (if any)
         """
         with transaction.atomic():

--- a/openedx/core/djangoapps/course_groups/tests/test_views.py
+++ b/openedx/core/djangoapps/course_groups/tests/test_views.py
@@ -376,7 +376,7 @@ class CohortHandlerTestCase(CohortViewsTestCase):
             }
         )
 
-    ############### Tests of adding a new cohort ###############
+    # Tests of adding a new cohort ###############
 
     def verify_contains_added_cohort(
             self, response_dict, cohort_name, assignment_type=CourseCohort.MANUAL,
@@ -459,7 +459,7 @@ class CohortHandlerTestCase(CohortViewsTestCase):
             "If group_id is specified, user_partition_id must also be specified.", response_dict.get("error")
         )
 
-    ############### Tests of updating an existing cohort ###############
+    # Tests of updating an existing cohort ###############
 
     def test_update_manual_cohort_name(self):
         """

--- a/openedx/core/djangoapps/verified_track_content/tests/test_models.py
+++ b/openedx/core/djangoapps/verified_track_content/tests/test_models.py
@@ -228,27 +228,6 @@ class TestMoveToVerified(SharedModuleStoreTestCase):
         self._reenroll()
         self.assertIn(get_cohort(self.user, self.course.id, assign=False).name, ["Random 1", "Random 2"])
 
-    def test_unenrolled(self):
-        """
-        Test that un-enrolling and re-enrolling works correctly. This is important because usually
-        learners maintain their previously assigned cohort on re-enrollment.
-        """
-        # Enable verified track cohorting feature and enroll in the verified track
-        self._enable_cohorting()
-        self._create_verified_cohort()
-        self._enable_verified_track_cohorting()
-        self._enroll_in_course()
-        self._upgrade_enrollment()
-        self.assertEqual(DEFAULT_VERIFIED_COHORT_NAME, get_cohort(self.user, self.course.id, assign=False).name)
-
-        # Un-enroll from the course and then re-enroll
-        self._unenroll()
-        self.assertEqual(DEFAULT_VERIFIED_COHORT_NAME, get_cohort(self.user, self.course.id, assign=False).name)
-        self._reenroll()
-        self.assertEqual(DEFAULT_COHORT_NAME, get_cohort(self.user, self.course.id, assign=False).name)
-        self._upgrade_enrollment()
-        self.assertEqual(DEFAULT_VERIFIED_COHORT_NAME, get_cohort(self.user, self.course.id, assign=False).name)
-
     def test_custom_verified_cohort_name(self):
         """
         Test that enrolling in verified works correctly when the "verified cohort" has a custom name.
@@ -260,33 +239,3 @@ class TestMoveToVerified(SharedModuleStoreTestCase):
         self._enroll_in_course()
         self._upgrade_enrollment()
         self.assertEqual(custom_cohort_name, get_cohort(self.user, self.course.id, assign=False).name)
-
-    def test_custom_default_cohort_name(self):
-        """
-        Test that enrolling and un-enrolling works correctly when the single cohort
-        of type random has a different name from "Default Group".
-        """
-        random_cohort_name = "custom random cohort"
-        self._enable_cohorting()
-        self._create_verified_cohort()
-        default_cohort = self._create_named_random_cohort(random_cohort_name)
-        self._enable_verified_track_cohorting()
-        self._enroll_in_course()
-        self.assertEqual(random_cohort_name, get_cohort(self.user, self.course.id, assign=False).name)
-        self._upgrade_enrollment()
-        self.assertEqual(DEFAULT_VERIFIED_COHORT_NAME, get_cohort(self.user, self.course.id, assign=False).name)
-
-        # Un-enroll from the course. The learner stays in the verified cohort, but is no longer active.
-        self._unenroll()
-        self.assertEqual(DEFAULT_VERIFIED_COHORT_NAME, get_cohort(self.user, self.course.id, assign=False).name)
-
-        # Change the name of the "default" cohort.
-        modified_cohort_name = "renamed random cohort"
-        default_cohort.name = modified_cohort_name
-        default_cohort.save()
-
-        # Re-enroll in the course, which will downgrade the learner to audit.
-        self._reenroll()
-        self.assertEqual(modified_cohort_name, get_cohort(self.user, self.course.id, assign=False).name)
-        self._upgrade_enrollment()
-        self.assertEqual(DEFAULT_VERIFIED_COHORT_NAME, get_cohort(self.user, self.course.id, assign=False).name)


### PR DESCRIPTION
We want to ensure that if a student in a Masters-related cohort unenrolls and then finds a way to re-enroll (through a link, for instance), they won't be able to rejoin their previous cohort.
