### PR TITLE
load cached npm cache on jenkins workers

### DIFF
--- a/scripts/jenkins-common.sh
+++ b/scripts/jenkins-common.sh
@@ -26,6 +26,16 @@ if [ -e $HOME/edx-venv_clean.tar.gz ]; then
     tar -C $HOME -xf $HOME/edx-venv_clean.tar.gz
 fi
 
+# Load the npm packages from the time the worker was built
+# into the npm cache. This is an attempt to reduce the number
+# of times that npm gets stuck during an installation, by
+# reducing the number of packages that npm needs to fetch.
+if [ -e $HOME/edx-npm-cache_clean.tar.gz ]; then
+    echo "Loading archived npm packages into the local npm cache"
+    rm -rf $HOME/.npm
+    tar -C $HOME -xf $HOME/edx-npm-cache_clean.tar.gz
+fi
+
 # Activate the Python virtualenv
 source $HOME/edx-venv/bin/activate
 


### PR DESCRIPTION
In an effort to deal with npm installations hanging indefinitely, I put a timeout on the installation commands when called as part of the paver setup in CI tests. Since that has gone into place, I have noticed an increase  in the number of jobs that timeout and ultimately fail (\~2% of all builds, but given that a single PR can fan out to \~30 npm installations, this can lead to a non-trivial amount of PRs failing. This means a lot of wasted time). However, I think that we might have misunderestimated the average NPM installation time and/or frequency of hanging installs altogether. If you run a pull request on a Jenkins worker that has previously run tests, it will pull packages from the local npm cache (~/.npm) and only fetch packages explicitly called out in the pull request. The majority of pull requests run on recycled workers, which means that we are somewhat protected from NPM brittleness by the cache. 

This PR will load the archived NPM cache (created in this PR: https://github.com/edx/configuration/pull/4779) prior to doing any installs.