### PR TITLE
(WIP) Upgrade bleach to 2.1.4

### DIFF
--- a/common/lib/capa/capa/util.py
+++ b/common/lib/capa/capa/util.py
@@ -173,8 +173,8 @@ def sanitize_html(html_code):
     attributes = bleach.ALLOWED_ATTRIBUTES.copy()
     # Yuck! but bleach does not offer the option of passing in allowed_protocols,
     # and matlab uses data urls for images
-    if u'data' not in bleach.BleachSanitizer.allowed_protocols:
-        bleach.BleachSanitizer.allowed_protocols.append(u'data')
+    if u'data' not in bleach.ALLOWED_PROTOCOLS:
+        bleach.ALLOWED_PROTOCOLS.append(u'data')
     attributes.update({
         '*': ['class', 'style', 'id'],
         'audio': ['controls', 'autobuffer', 'autoplay', 'src'],

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -51,7 +51,7 @@ attrs==17.4.0
 babel==1.3
 beautifulsoup4==4.6.3     # via pynliner
 billiard==3.3.0.23        # via celery
-bleach==1.4
+bleach==2.1.4
 boto3==1.4.8
 boto==2.39.0
 botocore==1.8.17
@@ -142,7 +142,7 @@ glob2==0.3
 gunicorn==17.5
 hash-ring==1.3.1          # via django-memcached-hashring
 help-tokens==1.0.3
-html5lib==0.999
+html5lib==1.0.1
 httplib2==0.11.3          # via oauth2, zendesk
 idna==2.7
 ipaddr==2.1.11


### PR DESCRIPTION
This PR allows the platform to use the version `2.1.4` of `bleach` library. This is needed in the platform as we're using it in building the new [HTML XBlock](https://github.com/open-craft/xblock-html). 