### PR TITLE
Handle exception while saving course display name.

### DIFF
--- a/lms/djangoapps/ccx/migrations/0006_set_display_name_as_override.py
+++ b/lms/djangoapps/ccx/migrations/0006_set_display_name_as_override.py
@@ -3,6 +3,7 @@
 from __future__ import unicode_literals
 
 from django.db import migrations
+from django.http import Http404
 
 import json
 import logging
@@ -28,7 +29,11 @@ def save_display_name(apps, schema_editor):
 
     # Create `display_name` overrides for these CCX courses
     for ccx in ccx_list:
-        course = get_course_by_id(ccx.course_id, depth=None)
+        try:
+            course = get_course_by_id(ccx.course_id, depth=None)
+        except Http404:
+            log.error('Root course %s not found. Skipping saving course display name', ccx.course_id)
+            continue
         display_name = course.fields['display_name']
         display_name_json = display_name.to_json(ccx.display_name)
         serialized_display_name = json.dumps(display_name_json)

--- a/lms/djangoapps/ccx/migrations/0006_set_display_name_as_override.py
+++ b/lms/djangoapps/ccx/migrations/0006_set_display_name_as_override.py
@@ -32,7 +32,11 @@ def save_display_name(apps, schema_editor):
         try:
             course = get_course_by_id(ccx.course_id, depth=None)
         except Http404:
-            log.error('Root course %s not found. Skipping saving course display name', ccx.course_id)
+            log.error(
+                "Root course %s not found. Can't create display_name override for %s.",
+                ccx.course_id,
+                ccx.display_name
+            )
             continue
         display_name = course.fields['display_name']
         display_name_json = display_name.to_json(ccx.display_name)


### PR DESCRIPTION
This commit introduces error check for a special case where the root course does not exists and a data migration is attempting to save it.

**JIRA tickets**: [OSPR-2617](https://openedx.atlassian.net/browse/OSPR-2617)

**Sandbox URL**: TBD

**Merge deadline**: None

**Reviewers**
- [ ] @itsjeyd 
- [ ] @ormsbee 

**Settings**
```yaml
EDXAPP_FEATURES:
  CUSTOM_COURSES_EDX: true
```