### PR TITLE
Updated third_party_auth.models.py

### DIFF
--- a/common/djangoapps/third_party_auth/models.py
+++ b/common/djangoapps/third_party_auth/models.py
@@ -88,7 +88,7 @@ class ProviderConfig(ConfigurationModel):
     """
     Abstract Base Class for configuring a third_party_auth provider
     """
-    KEY_FIELDS = ('slug',)
+    KEY_FIELDS = ('backend_name',)
 
     icon_class = models.CharField(
         max_length=50,


### PR DESCRIPTION
The `KEY_FIELDS` should be set to `backend_name`. 
Having the `KEY_FIELDS` set to `slug` get Django to generate the below SQL request which is likely to yield 0 result:
```
SELECT 
    'third_party_auth_oauth2providerconfig'.'id',
    'third_party_auth_oauth2providerconfig'.'change_date', 
    'third_party_auth_oauth2providerconfig'.'changed_by_id', 
    'third_party_auth_oauth2providerconfig'.'enabled', 
    'third_party_auth_oauth2providerconfig'.'icon_class', 
    'third_party_auth_oauth2providerconfig'.'icon_image', 
    'third_party_auth_oauth2providerconfig'.'name', 
    'third_party_auth_oauth2providerconfig'.'slug', 
    'third_party_auth_oauth2providerconfig'.'secondary', 
    'third_party_auth_oauth2providerconfig'.'site_id', 
    'third_party_auth_oauth2providerconfig'.'skip_hinted_login_dialog', 
    'third_party_auth_oauth2providerconfig'.'skip_registration_form', 
    'third_party_auth_oauth2providerconfig'.'skip_email_verification', 
    'third_party_auth_oauth2providerconfig'.'send_welcome_email', 
    'third_party_auth_oauth2providerconfig'.'visible', 
    'third_party_auth_oauth2providerconfig'.'max_session_length', 
    'third_party_auth_oauth2providerconfig'.'send_to_registration_first', 
    'third_party_auth_oauth2providerconfig'.'sync_learner_profile_data', 
    'third_party_auth_oauth2providerconfig'.'enable_sso_id_verification', 
    'third_party_auth_oauth2providerconfig'.'backend_name', 
    'third_party_auth_oauth2providerconfig'.'key', 
    'third_party_auth_oauth2providerconfig'.'secret', 
    'third_party_auth_oauth2providerconfig'.'other_settings' 
FROM 'third_party_auth_oauth2providerconfig' 
WHERE 
    'third_party_auth_oauth2providerconfig'.'slug' = 'google-oauth2' 
ORDER BY 'third_party_auth_oauth2providerconfig'.'change_date' DESC 
LIMIT 1;
```
As the slug field on Django admin is a free text field with the description, it can contain (and probably will) contain anything *but* the backend name. 

> A short string uniquely identifying this provider. Cannot contain spaces and should be a usable as a CSS class. Examples: "ubc", "mit-staging"

If the SQL statement does not return any row, the ConfigurationManager defaults to a preset where the provider is marked as disabled.

The slug field is used for totally unrelated purpose (e.g. styling with CSS).
Keeping the `slug` field forces to put the exact same value between the `slug` and `backend_name` if you want to get the provider activated.