### PR TITLE
Ignore errors in paver test cleanup

### DIFF
--- a/pavelib/paver_tests/conftest.py
+++ b/pavelib/paver_tests/conftest.py
@@ -20,4 +20,4 @@ def delete_quality_junit_xml():
     """
     yield
     if os.path.exists(Env.QUALITY_DIR):
-        rmtree(Env.QUALITY_DIR)
+        rmtree(Env.QUALITY_DIR, ignore_errors=True)


### PR DESCRIPTION
Even though we check to see if the file exists, it seems like we occasionally hit errors where another test's teardown deletes this directory first.

https://build.testeng.edx.org/view/edx-platform-pipeline-pr-tests/job/edx-platform-python-pipeline-pr/544/
https://build.testeng.edx.org/view/edx-platform-pipeline-pr-tests/job/edx-platform-python-pipeline-pr/546/