### PR TITLE
Override admin templates to remove links that allow admin users to change passwords

### DIFF
--- a/cms/templates/admin/base_site.html
+++ b/cms/templates/admin/base_site.html
@@ -1,0 +1,19 @@
+{% extends "admin/base.html" %}
+{% load i18n admin_urls %}
+{% block title %}{{ title }} | {{ site_title|default:_('Django site admin') }}{% endblock %}
+{% block branding %}
+<h1 id="site-name"><a href="{% url 'admin:index' %}">{{ site_header|default:_('Django administration') }}</a></h1>
+{% endblock %}
+{% block nav-global %}{% endblock %}
+{% block userlinks %}
+    {% if site_url %}
+        <a href="{{ site_url }}">{% trans 'View site' %}</a> /
+    {% endif %}
+    {% if user.is_active and user.is_staff %}
+        {% url 'django-admindocs-docroot' as docsroot %}
+        {% if docsroot %}
+            <a href="{{ docsroot }}">{% trans 'Documentation' %}</a> /
+        {% endif %}
+    {% endif %}
+    <a href="{% url 'admin:logout' %}">{% trans 'Log out' %}</a>
+{% endblock %}

--- a/common/djangoapps/student/admin.py
+++ b/common/djangoapps/student/admin.py
@@ -5,6 +5,7 @@ from django.contrib import admin
 from django.contrib.admin.sites import NotRegistered
 from django.contrib.auth import get_user_model
 from django.contrib.auth.admin import UserAdmin as BaseUserAdmin
+from django.contrib.auth.forms import ReadOnlyPasswordHashField, UserChangeForm as BaseUserChangeForm
 from django.db import models
 from django.utils.translation import ugettext_lazy as _
 from opaque_keys import InvalidKeyError
@@ -240,9 +241,24 @@ class UserProfileInline(admin.StackedInline):
     verbose_name_plural = _('User profile')
 
 
+class UserChangeForm(BaseUserChangeForm):
+    """
+    Override the default UserChangeForm such that the password field
+    does not contain a link to a 'change password' form.
+    """
+    password = ReadOnlyPasswordHashField(
+        label=_("Password"),
+        help_text=_(
+            "Raw passwords are not stored, so there is no way to see this "
+            "user's password."
+        ),
+    )
+
+
 class UserAdmin(BaseUserAdmin):
     """ Admin interface for the User model. """
     inlines = (UserProfileInline,)
+    form = UserChangeForm
 
     def get_readonly_fields(self, request, obj=None):
         """

--- a/lms/templates/admin/base_site.html
+++ b/lms/templates/admin/base_site.html
@@ -1,0 +1,19 @@
+{% extends "admin/base.html" %}
+{% load i18n admin_urls %}
+{% block title %}{{ title }} | {{ site_title|default:_('Django site admin') }}{% endblock %}
+{% block branding %}
+<h1 id="site-name"><a href="{% url 'admin:index' %}">{{ site_header|default:_('Django administration') }}</a></h1>
+{% endblock %}
+{% block nav-global %}{% endblock %}
+{% block userlinks %}
+    {% if site_url %}
+        <a href="{{ site_url }}">{% trans 'View site' %}</a> /
+    {% endif %}
+    {% if user.is_active and user.is_staff %}
+        {% url 'django-admindocs-docroot' as docsroot %}
+        {% if docsroot %}
+            <a href="{{ docsroot }}">{% trans 'Documentation' %}</a> /
+        {% endif %}
+    {% endif %}
+    <a href="{% url 'admin:logout' %}">{% trans 'Log out' %}</a>
+{% endblock %}


### PR DESCRIPTION
https://openedx.atlassian.net/browse/LEARNER-4928

This overrides fields in two areas so that links to 'change password' forms are not presented to the admin user:
- The header of admin pages
- The modify user page

Sandbox: https://dianakhuang.sandbox.edx.org/admin/