### PR TITLE
Update error messages on account creation

### DIFF
--- a/common/djangoapps/student/forms.py
+++ b/common/djangoapps/student/forms.py
@@ -306,7 +306,7 @@ class AccountCreationForm(forms.Form):
         if email_exists_or_retired(email):
             raise ValidationError(
                 _(
-                    "It looks like {email} belongs to an existing account. Try again with a different email address."
+                    "It looks like {email} was already registered. Try again with a different email address."
                 ).format(email=email)
             )
         return email

--- a/common/djangoapps/student/helpers.py
+++ b/common/djangoapps/student/helpers.py
@@ -64,8 +64,8 @@ DISABLE_UNENROLL_CERT_STATES = [
     'generating',
     'downloadable',
 ]
-USERNAME_EXISTS_MSG_FMT = _("An account with the Public Username '{username}' already exists.")
-
+USERNAME_EXISTS_MSG_FMT = _("It looks like '{username}' was already registered. Try again with a different username.")
+EMAIL_EXISTS_MSG_FMT = _("It looks like {email} was already registered. Try again with a different email address.")
 
 log = logging.getLogger(__name__)
 
@@ -634,7 +634,7 @@ def do_create_account(form, custom_form=None):
         # TODO duplicate email is already handled by form.errors above as a ValidationError.
         # The checks for duplicate email/username should occur in the same place with an
         # AccountValidationError and a consistent user message returned (i.e. both should
-        # return "It looks like {username} belongs to an existing account. Try again with a
+        # return "It looks like {username} was already registered. Try again with a
         # different username.")
         if username_exists_or_retired(user.username):
             raise AccountValidationError(
@@ -643,7 +643,7 @@ def do_create_account(form, custom_form=None):
             )
         elif email_exists_or_retired(user.email):
             raise AccountValidationError(
-                _("An account with the Email '{email}' already exists.").format(email=user.email),
+                EMAIL_EXISTS_MSG_FMT.format(email=user.email),
                 field="email"
             )
         else:

--- a/common/djangoapps/student/tests/test_retirement.py
+++ b/common/djangoapps/student/tests/test_retirement.py
@@ -238,10 +238,7 @@ class TestRegisterRetiredUsername(TestCase):
     """
     Tests to ensure that retired usernames can no longer be used in registering new accounts.
     """
-    # The returned message here varies depending on whether a ValidationError -or-
-    # an AccountValidationError occurs.
-    INVALID_ACCT_ERR_MSG = ('An account with the Public Username', 'already exists.')
-    INVALID_ERR_MSG = ('It looks like', 'belongs to an existing account. Try again with a different username.')
+    INVALID_ACCT_ERR_MSG = ('It looks like', 'was already registered. Try again with a different username.')
 
     def setUp(self):
         super(TestRegisterRetiredUsername, self).setUp()
@@ -255,7 +252,13 @@ class TestRegisterRetiredUsername(TestCase):
             'honor_code': 'true',
         }
 
-    def _validate_exiting_username_response(self, orig_username, response, start_msg=INVALID_ACCT_ERR_MSG[0], end_msg=INVALID_ACCT_ERR_MSG[1]):
+    def _validate_exiting_username_response(
+            self,
+            orig_username,
+            response,
+            start_msg=INVALID_ACCT_ERR_MSG[0],
+            end_msg=INVALID_ACCT_ERR_MSG[1]
+    ):
         """
         Validates a response stating that a username already exists -or- is invalid.
         """
@@ -263,6 +266,7 @@ class TestRegisterRetiredUsername(TestCase):
         obj = json.loads(response.content)
 
         username_msg = obj['username'][0]['user_message']
+
         assert username_msg.startswith(start_msg)
         assert username_msg.endswith(end_msg)
         assert orig_username in username_msg
@@ -281,7 +285,7 @@ class TestRegisterRetiredUsername(TestCase):
         # Attempt to create another account with the same username that's been retired.
         self.url_params['username'] = orig_username
         response = self.client.post(self.url, self.url_params)
-        self._validate_exiting_username_response(orig_username, response, self.INVALID_ERR_MSG[0], self.INVALID_ERR_MSG[1])
+        self._validate_exiting_username_response(orig_username, response)
 
     def test_username_close_to_retired_format_active(self):
         """

--- a/common/djangoapps/third_party_auth/tests/specs/base.py
+++ b/common/djangoapps/third_party_auth/tests/specs/base.py
@@ -129,7 +129,7 @@ class HelperMixin(object):
         self.assertEqual(400, response.status_code)
         payload = json.loads(response.content)
         self.assertFalse(payload.get('success'))
-        self.assertIn('belongs to an existing account', payload.get('value'))
+        self.assertIn('was already registered', payload.get('value'))
 
     def assert_json_success_response_looks_correct(self, response):
         """Asserts the json response indicates success and redirection."""

--- a/lms/templates/email_exists.html
+++ b/lms/templates/email_exists.html
@@ -8,7 +8,7 @@
     <h1 class="invalid">${_("E-mail change failed")}</h1>
     <hr class="horizontal-divider">
 
-    <p>${_("An account with the new e-mail address already exists.")}</p>
+    <p>${_("It looks like this email was already registered. Try again with a different email address.")}</p>
 
     <p>${_("Go back to the {link_start}home page{link_end}.").format(link_start='<a href="/">', link_end='</a>')}</p>
   </section>

--- a/openedx/core/djangoapps/user_api/accounts/__init__.py
+++ b/openedx/core/djangoapps/user_api/accounts/__init__.py
@@ -47,11 +47,11 @@ EMAIL_INVALID_MSG = _(u'"{email}" is not a valid email address.')
 # Translators: This message is shown to users who attempt to create a new
 # account using an username/email associated with an existing account.
 EMAIL_CONFLICT_MSG = _(
-    u"It looks like {email_address} belongs to an existing account. "
+    u"It looks like {email_address} was already registered. "
     u"Try again with a different email address."
 )
 USERNAME_CONFLICT_MSG = _(
-    u"It looks like {username} belongs to an existing account. "
+    u"It looks like {username} was already registered. "
     u"Try again with a different username."
 )
 

--- a/openedx/core/djangoapps/user_api/tests/test_views.py
+++ b/openedx/core/djangoapps/user_api/tests/test_views.py
@@ -840,8 +840,7 @@ class RegistrationViewValidationErrorTest(ThirdPartyAuthTestMixin, UserAPITestCa
             {
                 "email": [{
                     "user_message": (
-                        "It looks like {} belongs to an existing account. "
-                        "Try again with a different email address."
+                        "It looks like {} was already registered. Try again with a different email address."
                     ).format(
                         self.EMAIL
                     )
@@ -882,7 +881,7 @@ class RegistrationViewValidationErrorTest(ThirdPartyAuthTestMixin, UserAPITestCa
             {
                 "email": [{
                     "user_message": (
-                        "It looks like {} belongs to an existing account. "
+                        "It looks like {} was already registered. "
                         "Try again with a different email address."
                     ).format(
                         self.EMAIL
@@ -924,7 +923,7 @@ class RegistrationViewValidationErrorTest(ThirdPartyAuthTestMixin, UserAPITestCa
             {
                 "username": [{
                     "user_message": (
-                        "It looks like {} belongs to an existing account. "
+                        "It looks like {} was already registered. "
                         "Try again with a different username."
                     ).format(
                         self.USERNAME
@@ -961,8 +960,7 @@ class RegistrationViewValidationErrorTest(ThirdPartyAuthTestMixin, UserAPITestCa
             {
                 "email": [{
                     "user_message": (
-                        "It looks like {} belongs to an existing account. "
-                        "Try again with a different email address."
+                        "It looks like {} was already registered. Try again with a different email address."
                     ).format(
                         self.EMAIL
                     )
@@ -998,7 +996,7 @@ class RegistrationViewValidationErrorTest(ThirdPartyAuthTestMixin, UserAPITestCa
             {
                 u"username": [{
                     u"user_message": (
-                        u"An account with the Public Username '{}' already exists."
+                        u"It looks like '{}' was already registered. Try again with a different username."
                     ).format(
                         self.USERNAME
                     )
@@ -1034,8 +1032,7 @@ class RegistrationViewValidationErrorTest(ThirdPartyAuthTestMixin, UserAPITestCa
             {
                 "email": [{
                     "user_message": (
-                        "It looks like {} belongs to an existing account. "
-                        "Try again with a different email address."
+                        "It looks like {} was already registered. Try again with a different email address."
                     ).format(
                         self.EMAIL
                     )
@@ -2195,7 +2192,7 @@ class RegistrationViewTest(ThirdPartyAuthTestMixin, UserAPITestCase):
             {
                 "email": [{
                     "user_message": (
-                        "It looks like {} belongs to an existing account. "
+                        "It looks like {} was already registered. "
                         "Try again with a different email address."
                     ).format(
                         self.EMAIL
@@ -2230,7 +2227,7 @@ class RegistrationViewTest(ThirdPartyAuthTestMixin, UserAPITestCase):
             {
                 "username": [{
                     "user_message": (
-                        "It looks like {} belongs to an existing account. "
+                        "It looks like {} was already registered. "
                         "Try again with a different username."
                     ).format(
                         self.USERNAME
@@ -2265,7 +2262,7 @@ class RegistrationViewTest(ThirdPartyAuthTestMixin, UserAPITestCase):
             {
                 "username": [{
                     "user_message": (
-                        "It looks like {} belongs to an existing account. "
+                        "It looks like {} was already registered. "
                         "Try again with a different username."
                     ).format(
                         self.USERNAME
@@ -2273,8 +2270,7 @@ class RegistrationViewTest(ThirdPartyAuthTestMixin, UserAPITestCase):
                 }],
                 "email": [{
                     "user_message": (
-                        "It looks like {} belongs to an existing account. "
-                        "Try again with a different email address."
+                        "It looks like {} was already registered. Try again with a different email address."
                     ).format(
                         self.EMAIL
                     )
@@ -2456,7 +2452,7 @@ class ThirdPartyRegistrationTestMixin(ThirdPartyOAuthTestMixin, CacheIsolationTe
         errors = json.loads(response.content)
         for conflict_attribute in ["username", "email"]:
             self.assertIn(conflict_attribute, errors)
-            self.assertIn("belongs to an existing account", errors[conflict_attribute][0]["user_message"])
+            self.assertIn("was already registered", errors[conflict_attribute][0]["user_message"])
 
     def _assert_access_token_error(self, response, expected_error_message):
         """Assert that the given response was an error for the access_token field with the given error message."""

--- a/openedx/core/djangoapps/user_api/validation/views.py
+++ b/openedx/core/djangoapps/user_api/validation/views.py
@@ -90,7 +90,7 @@ class RegistrationValidationView(APIView):
             >>> {
             >>>     "validation_decisions": {
             >>>         "username": "",
-            >>>         "email": "It looks like cto@edx.org belongs to an existing account. Try again with a different email address.",
+            >>>         "email": "It looks like cto@edx.org was already registered.",
             >>>         "password": "Password must be at least 2 characters long",
             >>>     }
             >>> }

--- a/openedx/core/djangoapps/user_authn/views/register.py
+++ b/openedx/core/djangoapps/user_authn/views/register.py
@@ -95,13 +95,10 @@ def create_account_with_params(request, params):
       minimum of two characters long" rather than "Please use a username of
       at least two characters").
     * Duplicate email raises a ValidationError (rather than the expected
-      AccountValidationError). Duplicate username returns an inconsistent
-      user message (i.e. "An account with the Public Username '{username}'
-      already exists." rather than "It looks like {username} belongs to an
-      existing account. Try again with a different username.") The two checks
-      occur at different places in the code; as a result, registering with
-      both a duplicate username and email raises only a ValidationError for
-      email only.
+      AccountValidationError).
+    * The two checks occur at different places in the code; as a result,
+      registering with both a duplicate username and email raises only a
+      ValidationError for the email.
     """
     # Copy params so we can modify it; we can't just do dict(params) because if
     # params is request.POST, that results in a dict containing lists of values


### PR DESCRIPTION
Per PLAT-2179, update the error messages to be more clear that the username or email may not still be in use.