### PR TITLE
Estute/npm cache experiment

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "dependencies": {
     "@edx/cookie-policy-banner": "1.1.10",
     "@edx/edx-bootstrap": "0.4.3",
-    "@edx/paragon": "2.6.4",
+    "@edx/paragon": "3.4.8",
     "@edx/studio-frontend": "1.16.9",
     "babel-core": "6.26.0",
     "babel-loader": "6.4.1",

--- a/scripts/jenkins-common.sh
+++ b/scripts/jenkins-common.sh
@@ -26,6 +26,16 @@ if [ -e $HOME/edx-venv_clean.tar.gz ]; then
     tar -C $HOME -xf $HOME/edx-venv_clean.tar.gz
 fi
 
+# Load the npm packages from the time the worker was built
+# into the npm cache. This is an attempt to reduce the number
+# of times that npm gets stuck during an installation, by
+# reducing the number of packages that npm needs to fetch.
+if [ -e $HOME/edx-npm-cache_clean.tar.gz ]; then
+    echo "Loading archived npm packages into the local npm cache"
+    rm -rf $HOME/.npm
+    tar -C $HOME -xf $HOME/edx-npm-cache_clean.tar.gz
+fi
+
 # Activate the Python virtualenv
 source $HOME/edx-venv/bin/activate
 


### PR DESCRIPTION
DO NOT MERGE!

This PR is just used as an experiment to prove my expectations about using a local npm cache. It contains two components:
1) cherry-picked command from https://github.com/edx/edx-platform/pull/18959, to load an archived npm cache from master at the time the jenkins worker was built when this PR runs tests.
2) an upgrade to the version of paragon installed in this PR. This will be used to prove that even though the worker has an old version of paragon installed, the desired version is installed and used.