### PR TITLE
Check for username retirement in validation endpoint.

### DIFF
--- a/common/djangoapps/student/helpers.py
+++ b/common/djangoapps/student/helpers.py
@@ -44,7 +44,8 @@ from student.models import (
     UserAttribute,
     UserProfile,
     unique_id_for_user,
-    email_exists_or_retired
+    email_exists_or_retired,
+    username_exists_or_retired
 )
 
 
@@ -628,7 +629,7 @@ def do_create_account(form, custom_form=None):
         # AccountValidationError and a consistent user message returned (i.e. both should
         # return "It looks like {username} belongs to an existing account. Try again with a
         # different username.")
-        if User.objects.filter(username=user.username):
+        if username_exists_or_retired(user.username):
             raise AccountValidationError(
                 USERNAME_EXISTS_MSG_FMT.format(username=proposed_username),
                 field="username"

--- a/common/djangoapps/student/models.py
+++ b/common/djangoapps/student/models.py
@@ -233,6 +233,13 @@ def is_username_retired(username):
         raise
 
 
+def username_exists_or_retired(username):
+    """
+    Check a username for existence -or- retirement against the User model.
+    """
+    return User.objects.filter(username=username).exists() or is_username_retired(username)
+
+
 def is_email_retired(email):
     """
     Checks to see if the given email has been previously retired

--- a/openedx/core/djangoapps/user_api/accounts/api.py
+++ b/openedx/core/djangoapps/user_api/accounts/api.py
@@ -14,7 +14,7 @@ from django.http import HttpResponseForbidden
 from openedx.core.djangoapps.theming.helpers import get_current_request
 from six import text_type
 
-from student.models import User, UserProfile, Registration, email_exists_or_retired
+from student.models import User, UserProfile, Registration, email_exists_or_retired, username_exists_or_retired
 from student import forms as student_forms
 from student import views as student_views
 from util.model_utils import emit_setting_changed_event
@@ -695,7 +695,7 @@ def _validate_username_doesnt_exist(username):
     :return: None
     :raises: errors.AccountUsernameAlreadyExists
     """
-    if username is not None and User.objects.filter(username=username).exists():
+    if username is not None and username_exists_or_retired(username):
         raise errors.AccountUsernameAlreadyExists(_(accounts.USERNAME_CONFLICT_MSG).format(username=username))
 
 


### PR DESCRIPTION
https://openedx.atlassian.net/browse/PLAT-2146

Check for retired usernames as well as existing usernames in the username/email validation code. This change fixes the registration page by reporting immediately with a red X when an existing username is entered. The endpoint is hit by JS and is a POST to this URL:

https://courses.edx.org/api/user/v1/validation/registration

I have not added an integration test which tests the endpoint from the registration page itself - feel free to comment on that in your review. But the endpoint's underlying code *does* get exercised in the added unit test.

This validation hole has never allowed usage of a retired username because and retired usernames get caught before the user.save() actually happens due to this pre-save signal handler:

https://github.com/edx/edx-platform/blob/master/common/djangoapps/student/signals/receivers.py#L31-L59
