### PR TITLE
Proposal: New course field to support specifying base language course ID

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -140,3 +140,5 @@ dist
 
 # Visual Studio Code
 .vscode
+
+an empty line


### PR DESCRIPTION
We are currently exploring a way to discover multi-lingual courses by linking them together in some way. For instance, given a course in one language we want to be able to get a list of the same course in multiple different languages. 

To this end we are currently exploring the following approach and would love to get feedback on it before beginning implementation:

* Add a new [course field](https://github.com/edx/edx-platform/blob/d9e841298d60a7c8061fa6438c0cdd37da842817/common/lib/xmodule/xmodule/course_module.py#L182) that stores the course ID for a course's base language version. i.e. for a course available in EFIGS this field would be set to the course ID for the course in whichever language it was originally created in, which could be English or French. Let's call this field `base_language_course_id` for now. 
* For any course, the base language course can be fetched using the value of `base_language_course_id`. 
* For any course, other translations of the course can be fetched by looking up courses that have the same value of `base_language_course_id`. 

We also want to make it possible to filter by this field in the course API, making it possible to list sibling course for any course. 

CC: @mduboseedx 