### PR TITLE
Fix flaky mongo count test with xdist

### DIFF
--- a/openedx/core/djangoapps/credentials/management/commands/tests/test_notify_credentials.py
+++ b/openedx/core/djangoapps/credentials/management/commands/tests/test_notify_credentials.py
@@ -111,6 +111,7 @@ class TestNotifyCredentials(TestCase):
 
     @override_settings(DEBUG=True)
     def test_page_size(self):
+        reset_queries()
         call_command(Command(), '--start-date', '2017-01-01')
         baseline = len(connection.queries)
 


### PR DESCRIPTION
This test case is flaky, and when it fails its because the baseline query number is much to high. Resetting the query count before we calculate a baseline seems to help with this. https://build.testeng.edx.org/view/edx-platform-pipeline-pr-tests/job/edx-platform-python-pipeline-pr/592/testReport/junit/openedx.core.djangoapps.credentials.management.commands.tests.test_notify_credentials/TestNotifyCredentials/Run_Tests___lms_unit___test_page_size/