### PR TITLE
Registration deprecation: switch existing tests to use the newer endpoint.

### DIFF
--- a/cms/djangoapps/contentstore/tests/tests.py
+++ b/cms/djangoapps/contentstore/tests/tests.py
@@ -32,22 +32,21 @@ class ContentStoreTestCase(ModuleStoreTestCase):
         returned json
         """
         resp = self.client.post(
-            reverse('login_post'),
+            reverse('user_api_login_session'),
             {'email': email, 'password': password}
         )
-        self.assertEqual(resp.status_code, 200)
         return resp
 
     def login(self, email, password):
         """Login, check that it worked."""
         resp = self._login(email, password)
-        data = parse_json(resp)
-        self.assertTrue(data['success'])
+        self.assertEqual(resp.status_code, 200)
         return resp
 
     def _create_account(self, username, email, password):
         """Try to create an account.  No error checking"""
-        resp = self.client.post('/create_account', {
+        registration_url = reverse('user_api_registration')
+        resp = self.client.post(registration_url, {
             'username': username,
             'email': email,
             'password': password,
@@ -150,10 +149,9 @@ class AuthTestCase(ContentStoreTestCase):
 
     def test_create_account_errors(self):
         # No post data -- should fail
-        resp = self.client.post('/create_account', {})
+        registration_url = reverse('user_api_registration')
+        resp = self.client.post(registration_url, {})
         self.assertEqual(resp.status_code, 400)
-        data = parse_json(resp)
-        self.assertEqual(data['success'], False)
 
     def test_create_account(self):
         self.create_account(self.username, self.email, self.pw)
@@ -163,7 +161,7 @@ class AuthTestCase(ContentStoreTestCase):
         User.objects.create_user(self.username, self.email, self.pw)
         resp = self._create_account(self.username, "abc@def.com", "password")
         # we have a constraint on unique usernames, so this should fail
-        self.assertEqual(resp.status_code, 400)
+        self.assertEqual(resp.status_code, 409)
 
     def test_create_account_pw_already_exists(self):
         User.objects.create_user(self.username, self.email, self.pw)
@@ -176,8 +174,6 @@ class AuthTestCase(ContentStoreTestCase):
 
         # Not activated yet.  Login should fail.
         resp = self._login(self.email, self.pw)
-        data = parse_json(resp)
-        self.assertFalse(data['success'])
 
         self.activate_user(self.email)
 
@@ -189,12 +185,10 @@ class AuthTestCase(ContentStoreTestCase):
         # login attempts in one 5 minute period before the rate gets limited
         for i in xrange(30):
             resp = self._login(self.email, 'wrong_password{0}'.format(i))
-            self.assertEqual(resp.status_code, 200)
+            self.assertEqual(resp.status_code, 403)
         resp = self._login(self.email, 'wrong_password')
-        self.assertEqual(resp.status_code, 200)
-        data = parse_json(resp)
-        self.assertFalse(data['success'])
-        self.assertIn('Too many failed login attempts.', data['value'])
+        self.assertEqual(resp.status_code, 403)
+        self.assertIn('Too many failed login attempts.', resp.content)
 
     @override_settings(MAX_FAILED_LOGIN_ATTEMPTS_ALLOWED=3)
     @override_settings(MAX_FAILED_LOGIN_ATTEMPTS_LOCKOUT_PERIOD_SECS=2)
@@ -208,23 +202,19 @@ class AuthTestCase(ContentStoreTestCase):
 
             for i in xrange(3):
                 resp = self._login(self.email, 'wrong_password{0}'.format(i))
-                self.assertEqual(resp.status_code, 200)
-                data = parse_json(resp)
-                self.assertFalse(data['success'])
+                self.assertEqual(resp.status_code, 403)
                 self.assertIn(
                     'Email or password is incorrect.',
-                    data['value']
+                    resp.content
                 )
 
             # now the account should be locked
 
             resp = self._login(self.email, 'wrong_password')
-            self.assertEqual(resp.status_code, 200)
-            data = parse_json(resp)
-            self.assertFalse(data['success'])
+            self.assertEqual(resp.status_code, 403)
             self.assertIn(
                 'This account has been temporarily locked due to excessive login failures.',
-                data['value']
+                resp.content
             )
 
             with freeze_time('2100-01-01'):
@@ -232,9 +222,11 @@ class AuthTestCase(ContentStoreTestCase):
 
             # make sure the failed attempt counter gets reset on successful login
             resp = self._login(self.email, 'wrong_password')
-            self.assertEqual(resp.status_code, 200)
-            data = parse_json(resp)
-            self.assertFalse(data['success'])
+            self.assertEqual(resp.status_code, 403)
+            self.assertIn(
+                'Email or password is incorrect.',
+                resp.content
+            )
 
             # account should not be locked out after just one attempt
             self.login(self.email, self.pw)

--- a/cms/envs/test.py
+++ b/cms/envs/test.py
@@ -197,6 +197,8 @@ FEATURES['ENABLE_SERVICE_STATUS'] = True
 # Toggles embargo on for testing
 FEATURES['EMBARGO'] = True
 
+FEATURES['ENABLE_COMBINED_LOGIN_REGISTRATION'] = True
+
 # set up some testing for microsites
 FEATURES['USE_MICROSITES'] = True
 MICROSITE_ROOT_DIR = COMMON_ROOT / 'test' / 'test_sites'

--- a/common/djangoapps/student/tests/test_retirement.py
+++ b/common/djangoapps/student/tests/test_retirement.py
@@ -250,7 +250,7 @@ class TestRegisterRetiredUsername(TestCase):
     """
     def setUp(self):
         super(TestRegisterRetiredUsername, self).setUp()
-        self.url = reverse('create_account')
+        self.url = reverse('user_api_registration')
         self.url_params = {
             'username': 'username',
             'email': 'foo_bar' + '@bar.com',
@@ -264,13 +264,13 @@ class TestRegisterRetiredUsername(TestCase):
         """
         Validates a response stating that a username already exists.
         """
-        assert response.status_code == 400
+        assert response.status_code == 409
         obj = json.loads(response.content)
-        assert obj['value'].startswith('An account with the Public Username')
-        assert obj['value'].endswith('already exists.')
-        assert orig_username in obj['value']
-        assert obj['field'] == 'username'
-        assert not obj['success']
+
+        username_msg = obj['username'][0]['user_message']
+        assert username_msg.startswith('An account with the Public Username')
+        assert username_msg.endswith('already exists.')
+        assert orig_username in username_msg
 
     def test_retired_username(self):
         """

--- a/lms/djangoapps/courseware/tests/helpers.py
+++ b/lms/djangoapps/courseware/tests/helpers.py
@@ -194,11 +194,9 @@ class LoginEnrollmentTestCase(TestCase):
         """
         Login, check that the corresponding view's response has a 200 status code.
         """
-        resp = self.client.post(reverse('login'),
+        resp = self.client.post(reverse('user_api_login_session'),
                                 {'email': email, 'password': password})
         self.assertEqual(resp.status_code, 200)
-        data = json.loads(resp.content)
-        self.assertTrue(data['success'])
 
     def logout(self):
         """
@@ -212,7 +210,7 @@ class LoginEnrollmentTestCase(TestCase):
         """
         Create the account and check that it worked.
         """
-        url = reverse('create_account')
+        url = reverse('user_api_registration')
         request_data = {
             'username': username,
             'email': email,
@@ -222,8 +220,6 @@ class LoginEnrollmentTestCase(TestCase):
             'honor_code': 'true',
         }
         resp = self.assert_request_status_code(200, url, method="POST", data=request_data)
-        data = json.loads(resp.content)
-        self.assertEqual(data['success'], True)
         # Check both that the user is created, and inactive
         user = User.objects.get(email=email)
         self.assertFalse(user.is_active)


### PR DESCRIPTION
Switch some tests away from using the older `create_account` endpoint and moving them to use the newer user_api.