### PR TITLE
PROPOSAL: Make Unit URLs easier to share

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -140,3 +140,4 @@ dist
 
 # Visual Studio Code
 .vscode
+


### PR DESCRIPTION
**Background:**
As you navigate through units in a subsection, the URL is not updated to reflect which unit you're viewing. When you share that URL with someone else, it will take them to the 1st unit, or whichever unit they were last in, and not specifically the one that was intended to be shared.

**Current State:**
To point someone to a specific unit you are on, you need to know that you can add a `/<number>` to the URL in order to direct them to that unit. For example, the second unit in a subsection would be at `<instance>/courses/<course-id>/courseware/<location>/2`. As such, this is seldom used by most users, as its difficult/impossible to discover.

**Desired State**
Learners and Instructors should be able to copy the URL from the Browser location field, share it with another user, and have this user see the exact unit that was shared.

**Proposal:**
We are proposing that while navigating courseware, the browser URL be automatically updated to reflect which unit is being displayed. 
We are also proposing that the `<foo>?child=first` and `<foo>?child=last` query strings that get appended to URLs while using the "arrow navigation across subsections" feature be converted to `<foo>/1` and `<foo>/n` (where n is the unit position of the last unit) respectively on page load.

Additionally, this will help with the discoverability of direct linking to units as described in this proposal: https://github.com/edx/edx-platform/pull/18134

@ormsbee & @stvstnfrd 