### PR TITLE
Defer slow fields on site configuration query

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -290,3 +290,4 @@ Matt Tuchfarber <mtuchfarber@edx.org>
 Stuart Young <syoung@edx.org>
 Michael Youngstrom <myoungstrom@edx.org>
 Sahar Markovich <sahar.markovich@gmail.com>
+Anders Pearson <anders@thraxil.org>

--- a/openedx/core/djangoapps/site_configuration/models.py
+++ b/openedx/core/djangoapps/site_configuration/models.py
@@ -74,7 +74,7 @@ class SiteConfiguration(models.Model):
         Returns:
             Configuration value for the given key.
         """
-        for configuration in cls.objects.filter(values__contains=org, enabled=True).all():
+        for configuration in cls.objects.filter(values__contains=org, enabled=True).defer('page_elements', 'sass_variables').all():
             course_org_filter = configuration.get_value('course_org_filter', [])
             # The value of 'course_org_filter' can be configured as a string representing
             # a single organization or a list of strings representing multiple organizations.
@@ -95,7 +95,7 @@ class SiteConfiguration(models.Model):
         """
         org_filter_set = set()
 
-        for configuration in cls.objects.filter(values__contains='course_org_filter', enabled=True).all():
+        for configuration in cls.objects.filter(values__contains='course_org_filter', enabled=True).defer('page_elements', 'sass_variables').all():
             course_org_filter = configuration.get_value('course_org_filter', [])
             if not isinstance(course_org_filter, list):
                 course_org_filter = [course_org_filter]


### PR DESCRIPTION
The `sass_variables` and `page_elements` fields on `SiteConfiguration` are typically large JSON strings. Including them in the queries in `.get_value_for_org()` and `.get_all_orgs()` adds latency and load to the database and to the app server when Django decodes them. They aren't actually used in the context of those methods, so it is just extra work. On our deployment, this is typically 10-20ms per object/row returned. For most deployments, that is a minor issue. We run a multi-tenant deployment with many hundreds of organizations though and we see upwards of 10 seconds of latency added to certain views (LMS dashboard, CMS settings page).

We applied this patch to our production instance in July and saw the problem immediately disappear and we have not seen any bugs resulting from the patch.

I haven't really been able to figure out a good way to automatically test this change to prevent a regression since it's mainly a performance improvement. I'm open to ideas though.