### PR TITLE
load cached npm cache on jenkins workers

### DIFF
--- a/scripts/jenkins-common.sh
+++ b/scripts/jenkins-common.sh
@@ -26,6 +26,16 @@ if [ -e $HOME/edx-venv_clean.tar.gz ]; then
     tar -C $HOME -xf $HOME/edx-venv_clean.tar.gz
 fi
 
+# Load the npm packages from the time the worker was built
+# into the npm cache. This is an attempt to reduce the number
+# of times that npm gets stuck during an installation, by
+# reducing the number of packages that npm needs to fetch.
+if [ -e $HOME/edx-npm-cache_clean.tar.gz ]; then
+    echo "Loading archived npm packages into the local npm cache"
+    rm -rf $HOME/.npm
+    tar -C $HOME -xf $HOME/edx-npm-cache_clean.tar.gz
+fi
+
 # Activate the Python virtualenv
 source $HOME/edx-venv/bin/activate
 


### PR DESCRIPTION
Just wanted to get this into hawthorn CI jobs so they don't hang while installing.