### PR TITLE
Remove course publish from CCX data migration.

### DIFF
--- a/lms/djangoapps/ccx/migrations/0006_set_display_name_as_override.py
+++ b/lms/djangoapps/ccx/migrations/0006_set_display_name_as_override.py
@@ -10,7 +10,6 @@ import logging
 
 from ccx_keys.locator import CCXLocator
 from courseware.courses import get_course_by_id
-from xmodule.modulestore.django import SignalHandler
 
 log = logging.getLogger(__name__)
 
@@ -48,19 +47,6 @@ def save_display_name(apps, schema_editor):
             field='display_name',
             defaults={'value': serialized_display_name},
         )
-
-        # Publish change
-        responses = SignalHandler.course_published.send(
-            sender=ccx,
-            course_key=CCXLocator.from_course_locator(course.id, unicode(ccx.id))
-        )
-        for rec, response in responses:
-            log.info(
-                'Signal fired when course is published. Course %s. Receiver: %s. Response: %s',
-                ccx.course_id,
-                rec,
-                response
-            )
 
 
 class Migration(migrations.Migration):


### PR DESCRIPTION
This removes the portion of the CCX course names data migration
that triggers course publishing. While course publishing is the
desired behavior, doing so within the migration makes it so that
this migration is not practical to run if you have hundreds or
thousands of CCX courses (we run out of memory).

By doing the data migration without the accompanying course
publishes, this means that CCX course names will still show up
incorrectly for courses until there is an edit or publish of
either that CCX course or the underlying course that the CCX
course extends. But we at least set up the data so that it's
gradually self-correcting over time, and do so with little coding
effort or operational risk/weirdness.

A more comprehensive fix for this would involve:

* Fixing the memory leak around CourseOverviews creation and/or;
* Moving CourseOverview generation to happen asynchronously and/or;
* Being more careful about transactionality in the data migration
  and running it repeatedly until it all passes.

Full details of our migration issues are at:

https://github.com/edx/edx-platform/pull/18808#issuecomment-422930820