### PR TITLE
added fix for broken 'enroll in class' button on about course page

### DIFF
--- a/lms/static/js/course_info.js
+++ b/lms/static/js/course_info.js
@@ -8,4 +8,8 @@ $(document).ready(function() {
         $('.tab').slideUp();
         $(data_class + ':hidden').slideDown();
     });
+    var isSafari = !!navigator.userAgent.match(/Version\/[\d\.]+.*Safari/);
+    if (isSafari) {
+        $('.main-cta').addClass('safari-wrapper');
+    }
 });

--- a/lms/static/sass/multicourse/_course_about.scss
+++ b/lms/static/sass/multicourse/_course_about.scss
@@ -8,6 +8,10 @@
     }
   }
 
+  .safari-wrapper {
+    padding-bottom: 200px;
+  }
+
   header.course-profile {
     background: $course-profile-bg;
     background-image: $homepage-bg-image;


### PR DESCRIPTION
added fix for broken 'enroll in class' button on about course page in safari browser full screen.
Before the fix the "enroll in course" button is not visible in safari full screen mode as shown:
<img width="1680" alt="screen shot 2018-09-30 at 3 12 57 pm" src="https://user-images.githubusercontent.com/6545467/46257705-ccf09180-c4db-11e8-9a80-16d9656579a4.png">
After the fix(by adding padding-bottom), the button is now visible as shown:
<img width="1677" alt="screen shot 2018-09-30 at 3 13 06 pm" src="https://user-images.githubusercontent.com/6545467/46257714-ded23480-c4db-11e8-9f3d-b230a49fa21d.png">
