### PR TITLE
add cohort to metadata

### DIFF
--- a/lms/djangoapps/ccx/tests/test_field_override_performance.py
+++ b/lms/djangoapps/ccx/tests/test_field_override_performance.py
@@ -218,6 +218,7 @@ class FieldOverridePerformanceTestCase(FieldOverrideTestMixin, ProceduralCourseT
             sql_queries, mongo_reads = self.TEST_DATA[
                 (overrides, course_width, enable_ccx, view_as_ccx)
             ]
+
             self.instrument_course_progress_render(
                 course_width, enable_ccx, view_as_ccx, sql_queries, mongo_reads,
             )
@@ -235,18 +236,18 @@ class TestFieldOverrideMongoPerformance(FieldOverridePerformanceTestCase):
         #     # of sql queries to default,
         #     # of mongo queries,
         # )
-        ('no_overrides', 1, True, False): (18, 1),
-        ('no_overrides', 2, True, False): (18, 1),
-        ('no_overrides', 3, True, False): (18, 1),
-        ('ccx', 1, True, False): (18, 1),
-        ('ccx', 2, True, False): (18, 1),
-        ('ccx', 3, True, False): (18, 1),
-        ('no_overrides', 1, False, False): (18, 1),
-        ('no_overrides', 2, False, False): (18, 1),
-        ('no_overrides', 3, False, False): (18, 1),
-        ('ccx', 1, False, False): (18, 1),
-        ('ccx', 2, False, False): (18, 1),
-        ('ccx', 3, False, False): (18, 1),
+        ('no_overrides', 1, True, False): (24, 2),
+        ('no_overrides', 2, True, False): (24, 2),
+        ('no_overrides', 3, True, False): (24, 2),
+        ('ccx', 1, True, False): (24, 2),
+        ('ccx', 2, True, False): (24, 2),
+        ('ccx', 3, True, False): (24, 2),
+        ('no_overrides', 1, False, False): (24, 2),
+        ('no_overrides', 2, False, False): (24, 2),
+        ('no_overrides', 3, False, False): (24, 2),
+        ('ccx', 1, False, False): (24, 2),
+        ('ccx', 2, False, False): (24, 2),
+        ('ccx', 3, False, False): (24, 2),
     }
 
 
@@ -258,19 +259,19 @@ class TestFieldOverrideSplitPerformance(FieldOverridePerformanceTestCase):
     __test__ = True
 
     TEST_DATA = {
-        ('no_overrides', 1, True, False): (18, 3),
-        ('no_overrides', 2, True, False): (18, 3),
-        ('no_overrides', 3, True, False): (18, 3),
-        ('ccx', 1, True, False): (18, 3),
-        ('ccx', 2, True, False): (18, 3),
-        ('ccx', 3, True, False): (18, 3),
-        ('ccx', 1, True, True): (19, 3),
-        ('ccx', 2, True, True): (19, 3),
-        ('ccx', 3, True, True): (19, 3),
-        ('no_overrides', 1, False, False): (18, 3),
-        ('no_overrides', 2, False, False): (18, 3),
-        ('no_overrides', 3, False, False): (18, 3),
-        ('ccx', 1, False, False): (18, 3),
-        ('ccx', 2, False, False): (18, 3),
-        ('ccx', 3, False, False): (18, 3),
+        ('no_overrides', 1, True, False): (24, 3),
+        ('no_overrides', 2, True, False): (24, 3),
+        ('no_overrides', 3, True, False): (24, 3),
+        ('ccx', 1, True, False): (24, 3),
+        ('ccx', 2, True, False): (24, 3),
+        ('ccx', 3, True, False): (24, 3),
+        ('ccx', 1, True, True): (25, 3),
+        ('ccx', 2, True, True): (25, 3),
+        ('ccx', 3, True, True): (25, 3),
+        ('no_overrides', 1, False, False): (24, 3),
+        ('no_overrides', 2, False, False): (24, 3),
+        ('no_overrides', 3, False, False): (24, 3),
+        ('ccx', 1, False, False): (24, 3),
+        ('ccx', 2, False, False): (24, 3),
+        ('ccx', 3, False, False): (24, 3),
     }

--- a/lms/djangoapps/courseware/tests/test_course_info.py
+++ b/lms/djangoapps/courseware/tests/test_course_info.py
@@ -431,7 +431,7 @@ class SelfPacedCourseInfoTestCase(LoginEnrollmentTestCase, SharedModuleStoreTest
         self.assertEqual(resp.status_code, 200)
 
     def test_num_queries_instructor_paced(self):
-        self.fetch_course_info_with_queries(self.instructor_paced_course, 28, 3)
+        self.fetch_course_info_with_queries(self.instructor_paced_course, 34, 4)
 
     def test_num_queries_self_paced(self):
-        self.fetch_course_info_with_queries(self.self_paced_course, 28, 3)
+        self.fetch_course_info_with_queries(self.self_paced_course, 34, 4)

--- a/lms/djangoapps/courseware/tests/test_views.py
+++ b/lms/djangoapps/courseware/tests/test_views.py
@@ -205,8 +205,8 @@ class IndexQueryTestCase(ModuleStoreTestCase):
     NUM_PROBLEMS = 20
 
     @ddt.data(
-        (ModuleStoreEnum.Type.mongo, 10, 147),
-        (ModuleStoreEnum.Type.split, 4, 147),
+        (ModuleStoreEnum.Type.mongo, 11, 153),
+        (ModuleStoreEnum.Type.split, 4, 153),
     )
     @ddt.unpack
     def test_index_query_counts(self, store_type, expected_mongo_query_count, expected_mysql_query_count):
@@ -1430,20 +1430,20 @@ class ProgressPageTests(ProgressPageBaseTests):
                 self.assertContains(resp, u"Download Your Certificate")
 
     @ddt.data(
-        (True, 38),
-        (False, 37)
+        (True, 44),
+        (False, 43)
     )
     @ddt.unpack
     def test_progress_queries_paced_courses(self, self_paced, query_count):
         """Test that query counts remain the same for self-paced and instructor-paced courses."""
         self.setup_course(self_paced=self_paced)
-        with self.assertNumQueries(query_count, table_blacklist=QUERY_COUNT_TABLE_BLACKLIST), check_mongo_calls(1):
+        with self.assertNumQueries(query_count, table_blacklist=QUERY_COUNT_TABLE_BLACKLIST), check_mongo_calls(2):
             self._get_progress_page()
 
     @patch.dict(settings.FEATURES, {'ASSUME_ZERO_GRADE_IF_ABSENT_FOR_ALL_TESTS': False})
     @ddt.data(
-        (False, 45, 28),
-        (True, 37, 24)
+        (False, 51, 29),
+        (True, 43, 25)
     )
     @ddt.unpack
     def test_progress_queries(self, enable_waffle, initial, subsequent):
@@ -1451,7 +1451,7 @@ class ProgressPageTests(ProgressPageBaseTests):
         with grades_waffle().override(ASSUME_ZERO_GRADE_IF_ABSENT, active=enable_waffle):
             with self.assertNumQueries(
                 initial, table_blacklist=QUERY_COUNT_TABLE_BLACKLIST
-            ), check_mongo_calls(1):
+            ), check_mongo_calls(2):
                 self._get_progress_page()
 
             # subsequent accesses to the progress page require fewer queries.

--- a/lms/djangoapps/courseware/testutils.py
+++ b/lms/djangoapps/courseware/testutils.py
@@ -154,9 +154,9 @@ class RenderXBlockTestMixin(object):
         return response
 
     @ddt.data(
-        ('vertical_block', ModuleStoreEnum.Type.mongo, 11),
+        ('vertical_block', ModuleStoreEnum.Type.mongo, 12),
         ('vertical_block', ModuleStoreEnum.Type.split, 6),
-        ('html_block', ModuleStoreEnum.Type.mongo, 12),
+        ('html_block', ModuleStoreEnum.Type.mongo, 13),
         ('html_block', ModuleStoreEnum.Type.split, 6),
     )
     @ddt.unpack

--- a/lms/djangoapps/experiments/utils.py
+++ b/lms/djangoapps/experiments/utils.py
@@ -7,6 +7,7 @@ from course_modes.models import (
 from courseware.date_summary import (
     verified_upgrade_deadline_link, verified_upgrade_link_is_valid
 )
+from openedx.core.djangoapps.course_groups.cohorts import get_cohort
 
 
 def check_and_get_upgrade_link_and_date(user, enrollment=None, course=None):
@@ -64,6 +65,9 @@ def get_experiment_user_metadata_context(course, user):
     forum_roles = []
     if user.is_authenticated:
         forum_roles = list(Role.objects.filter(users=user, course_id=course.id).values_list('name').distinct())
+    cohort_name = get_cohort(user, course.id, assign=False, use_cached=True)
+    if cohort_name:
+        cohort_name = cohort_name.name
 
     return {
         'upgrade_link': upgrade_link,
@@ -76,5 +80,6 @@ def get_experiment_user_metadata_context(course, user):
         'course_start': course.start,
         'course_end': course.end,
         'has_staff_access': has_staff_access,
-        'forum_roles': forum_roles
+        'forum_roles': forum_roles,
+        'cohort_name': cohort_name
     }

--- a/lms/templates/user_metadata.html
+++ b/lms/templates/user_metadata.html
@@ -16,7 +16,8 @@ user_metadata = {
         'upgrade_price',
         'pacing_type',
         'has_staff_access',
-        'forum_roles'
+        'forum_roles',
+        'cohort_name',
     )
 }
 

--- a/openedx/features/course_experience/tests/views/test_course_home.py
+++ b/openedx/features/course_experience/tests/views/test_course_home.py
@@ -173,7 +173,7 @@ class TestCourseHomePage(CourseHomePageTestCase):
         course_home_url(self.course)
 
         # Fetch the view and verify the query counts
-        with self.assertNumQueries(54, table_blacklist=QUERY_COUNT_TABLE_BLACKLIST):
+        with self.assertNumQueries(60, table_blacklist=QUERY_COUNT_TABLE_BLACKLIST):
             with check_mongo_calls(4):
                 url = course_home_url(self.course)
                 self.client.get(url)

--- a/openedx/features/course_experience/tests/views/test_course_updates.py
+++ b/openedx/features/course_experience/tests/views/test_course_updates.py
@@ -124,7 +124,7 @@ class TestCourseUpdatesPage(SharedModuleStoreTestCase):
         course_updates_url(self.course)
 
         # Fetch the view and verify that the query counts haven't changed
-        with self.assertNumQueries(34, table_blacklist=QUERY_COUNT_TABLE_BLACKLIST):
+        with self.assertNumQueries(40, table_blacklist=QUERY_COUNT_TABLE_BLACKLIST):
             with check_mongo_calls(4):
                 url = course_updates_url(self.course)
                 self.client.get(url)


### PR DESCRIPTION
we could probably have an audience in optimizely that would look up the cohort with
`JSON.parse($('#user-metadata').text()).cohort_name` and then check if the cohort is in a list of excluded cohort names