### PR TITLE
Add cohorts to BulkEnroll endpoint.

### DIFF
--- a/lms/djangoapps/bulk_enroll/views.py
+++ b/lms/djangoapps/bulk_enroll/views.py
@@ -1,7 +1,9 @@
 """
 API views for Bulk Enrollment
 """
+import itertools
 import json
+
 from edx_rest_framework_extensions.auth.jwt.authentication import JwtAuthentication
 from rest_framework import status
 from rest_framework.response import Response
@@ -10,6 +12,13 @@ from rest_framework.views import APIView
 from bulk_enroll.serializers import BulkEnrollmentSerializer
 from enrollment.views import EnrollmentUserThrottle
 from instructor.views.api import students_update_enrollment
+from opaque_keys import InvalidKeyError
+from opaque_keys.edx.keys import CourseKey
+from openedx.core.djangoapps.course_groups.cohorts import (
+    get_cohort_by_name,
+    add_user_to_cohort,
+)
+from openedx.core.djangoapps.course_groups.models import CourseUserGroup
 from openedx.core.lib.api.authentication import OAuth2Authentication
 from openedx.core.lib.api.permissions import IsStaff
 from util.disable_rate_limit import can_disable_rate_limit
@@ -29,6 +38,7 @@ class BulkEnrollView(APIView):
             "email_students": true,
             "action": "enroll",
             "courses": "course-v1:edX+Demo+123,course-v1:edX+Demo2+456",
+            "cohorts": "cohortA,cohortA",
             "identifiers": "brandon@example.com,yamilah@example.com"
         }
 
@@ -40,7 +50,10 @@ class BulkEnrollView(APIView):
             as they register.
           * email_students: When set to `true`, students will be sent email
             notifications upon enrollment.
-          * action: Can either be set to "enroll" or "unenroll". This determines the behabior
+          * action: Can either be set to "enroll" or "unenroll". This determines the behavior
+          * cohorts: Optional. If provided, the number of items in the list should be equal to
+            the number of courses. first cohort coressponds with the first course and so on.
+            The learners will be added to the corresponding cohort.
 
     **Response Values**
 
@@ -51,6 +64,9 @@ class BulkEnrollView(APIView):
         enrollment. (See the `instructor.views.api.students_update_enrollment`
         docstring for the specifics of the response data available for each
         enrollment)
+
+        If a cohorts list is provided, additional 'cohort' keys will be added
+        to the 'before' and 'after' states.
     """
 
     authentication_classes = JwtAuthentication, OAuth2Authentication
@@ -72,9 +88,37 @@ class BulkEnrollView(APIView):
                 'action': serializer.data.get('action'),
                 'courses': {}
             }
-            for course in serializer.data.get('courses'):
-                response = students_update_enrollment(self.request, course_id=course)
-                response_dict['courses'][course] = json.loads(response.content)
+            for course_id, cohort_name in itertools.izip_longest(serializer.data.get('courses'),
+                                                                 serializer.data.get('cohorts', [])):
+                response = students_update_enrollment(self.request, course_id=course_id)
+                response_content = json.loads(response.content)
+
+                if cohort_name:
+                    try:
+                        course_key = CourseKey.from_string(course_id)
+                        cohort = get_cohort_by_name(course_key=course_key, name=cohort_name)
+                    except (CourseUserGroup.DoesNotExist, InvalidKeyError) as exc:
+                        return Response(exc.message, status=status.HTTP_400_BAD_REQUEST)
+
+                    for user_data in response_content['results']:
+                        if "after" in user_data and (
+                            user_data["after"].get("enrollment", False) is True or
+                            user_data["after"].get("allowed", False) is True
+                        ):
+                            user_id = user_data['identifier']
+                            try:
+                                _user_obj, previous_cohort, _pre_assigned = add_user_to_cohort(cohort, user_id)
+                            except ValueError:
+                                # User already present in cohort
+                                previous_cohort = cohort_name
+
+                            if previous_cohort:
+                                user_data['before']['cohort'] = previous_cohort
+                            else:
+                                user_data['before']['cohort'] = None
+                            user_data['after']['cohort'] = cohort_name
+
+                response_dict['courses'][course_id] = response_content
             return Response(data=response_dict, status=status.HTTP_200_OK)
         else:
             return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)


### PR DESCRIPTION
This PR adds the ability to assign a cohort to the users from the BulkEnroll endpoint.

**JIRA tickets**: SE-15, [OSPR-2642](https://openedx.atlassian.net/browse/OSPR-2642)

**Discussions**: Replacement PR for https://github.com/edx/edx-platform/pull/18282

**Dependencies**: None

**Screenshots**: None -- no GUI changes made.

**Sandbox URL**:  

Running 5896d98 

* LMS: https://pr19032.sandbox.opencraft.hosting/
* Studio: https://studio-pr19032.sandbox.opencraft.hosting/

For testing purposes:
* A course has already been created on the sandbox: https://pr19032.sandbox.opencraft.hosting/courses/course-v1:OpenCraft+cohorts+2018_1
* Two cohorts "Apples" and "Oranges" have been added to the test course.
* An OAuth2 token `fake-token` has been generated 

**Merge deadline**: None

**Testing instructions**:

1. Create a new course and add cohorts to it. cf [cohorts docs](http://edx.readthedocs.io/projects/edx-partner-course-staff/en/latest/course_features/cohorts/cohorts_overview.html#cohorts-overview)
1. Hit the bulk enroll endpoint with the correct data and the learner should be enrolled in the course, as well as added to the required cohort.
  E.g., the following command:
   ```bash
   curl -X POST --header "Authorization: Bearer fake-token" -H "Content-Type: application/json" \
      -d '{"action": "enroll","auto_enroll": true,"email_students": true,"courses": "course-v1:OpenCraft+cohorts+2018_1", "identifiers": "verified", "cohorts": "Apples"}' \
      https://pr19032.sandbox.opencraft.hosting/api/bulk_enroll/v1/bulk_enroll
   ```
   Running this command [enrolls the `verified` user in the `Apples` cohort](https://pr19032.sandbox.opencraft.hosting/courses/course-v1:OpenCraft+cohorts+2018_1/instructor#view-cohort_management), and returns:
   ```javascript
   {
      "action":"enroll",
      "courses":{
         "course-v1:OpenCraft+cohorts+2018_1":{
            "action":"enroll",
            "results":[
               {
                  "identifier":"verified",
                  "after":{
                     "cohort":"Apples",
                     "enrollment":true,
                     "allowed":false,
                     "user":true,
                     "auto_enroll":false
                  },
                  "before":{
                     "cohort":null,
                     "enrollment":false,
                     "allowed":false,
                     "user":true,
                     "auto_enroll":false
                  }
               }
            ],
            "auto_enroll":true
         }
      },
      "email_students":true,
      "auto_enroll":true
   }
   ```
1. An invalid call will return an error.  
  E.g. the number of cohorts and number of courses must match:
   ```bash
   curl -X POST --header "Authorization: Bearer fake-token" -H "Content-Type: application/json" \
      -d '{"action": "enroll","auto_enroll": true,"email_students": true,"courses": "course-v1:OpenCraft+cohorts+2018_1","identifiers": "verified", "cohorts": "Apples,Oranges"}' \
      https://pr19032.sandbox.opencraft.hosting/api/bulk_enroll/v1/bulk_enroll
   ```
   returns:
   ```javascript
   {
      "non_field_errors": ["If provided, the cohorts and courses should have equal number of items."]
   }
   ```

**Reviewers**
- [ ] @symbolist 
- [ ] edX reviewer[s] TBD

**Settings**
```yaml
EDXAPP_FEATURES:
  ENABLE_BULK_ENROLLMENT_VIEW: true
  ENABLE_COMBINED_LOGIN_REGISTRATION: true
```