### PR TITLE
Hammad/WL-1798 Participants not able to move on to course assignments from pre-assessment	

### DIFF
--- a/openedx/core/lib/gating/api.py
+++ b/openedx/core/lib/gating/api.py
@@ -470,7 +470,8 @@ def get_subsection_completion_percentage(subsection_usage_key, user):
                     block, 'completion_mode'
                 )
 
-                if completion_mode not in (CompletionMode.AGGREGATOR, CompletionMode.EXCLUDED):
+                if completion_mode not in (CompletionMode.AGGREGATOR, CompletionMode.EXCLUDED) \
+                        and not block.block_type == 'html':
                     completable_blocks.append(block)
 
             if not completable_blocks:


### PR DESCRIPTION
Sometimes user doesn't see html blocks for required time(set in **COMPLETION_BY_VIEWING_DELAY_MS**) to consider a block as completed for prerequisite blocks.
as a result user does not get unlocked for next page.  
So now gated blocks are ignoring HTML blocks when considering the completion of prerequisite blocks