### PR TITLE
EDUCATOR-3514 increase the length of task_input while creating instance of InstructorTask

### DIFF
--- a/lms/djangoapps/instructor_task/models.py
+++ b/lms/djangoapps/instructor_task/models.py
@@ -98,8 +98,8 @@ class InstructorTask(models.Model):
         json_task_input = json.dumps(task_input)
 
         # check length of task_input, and return an exception if it's too long:
-        if len(json_task_input) > 255:
-            fmt = 'Task input longer than 255: "{input}" for "{task}" of "{course}"'
+        if len(json_task_input) > 265:
+            fmt = 'Task input longer than 265: "{input}" for "{task}" of "{course}"'
             msg = fmt.format(input=json_task_input, task=task_type, course=course_id)
             raise ValueError(msg)
 


### PR DESCRIPTION
# [EDUCATOR-3514](https://openedx.atlassian.net/browse/EDUCATOR-3514)

### Description
For MIT, while downloading the student profile information as a csv `ValueError` is thrown by InstructorTask `create` method  because the length of `task_input` is greater than 255. 
This PR increases the length of task_input from 255 to 265.

### Reviewers
If you've been tagged for review, please check your corresponding box once you've given the :+1:.
- [x] Code review: @fysheets 
- [x] Code review: @noraiz-anwar 

### Post-review
- [x] Rebase and squash commits