### PR TITLE
WIP SE-126 Allow subclasses of ScheduleMessageBaseTask to be run via celerybeat

### DIFF
--- a/lms/envs/production.py
+++ b/lms/envs/production.py
@@ -278,6 +278,11 @@ CELERY_QUEUES.update(
     }
 )
 
+# Allow additional celerybeat schedules to be configured from the environment
+ADDITIONAL_CELERYBEAT_SCHEDULES = ENV_TOKENS.get('ADDITIONAL_CELERYBEAT_SCHEDULES', {})
+for schedule in ADDITIONAL_CELERYBEAT_SCHEDULES:
+    CELERYBEAT_SCHEDULE[schedule] = ADDITIONAL_CELERYBEAT_SCHEDULES[schedule]
+
 # following setting is for backward compatibility
 if ENV_TOKENS.get('COMPREHENSIVE_THEME_DIR', None):
     COMPREHENSIVE_THEME_DIR = ENV_TOKENS.get('COMPREHENSIVE_THEME_DIR')

--- a/openedx/core/djangoapps/schedules/tasks.py
+++ b/openedx/core/djangoapps/schedules/tasks.py
@@ -1,7 +1,6 @@
 import datetime
 import logging
 
-import json
 from celery import task
 from django.conf import settings
 from django.contrib.auth.models import User
@@ -123,8 +122,8 @@ class ScheduleMessageBaseTask(LoggedTask):
 
         # If no target date was provided, then enqueue tasks from the current date
         if target_day_str is None:
-            if isinstance(day_offset, basestring):
-                day_offset_list = json.loads(day_offset)
+            if isinstance(day_offset, list):
+                day_offset_list = day_offset
             else:
                 day_offset_list = [day_offset]
 

--- a/openedx/core/djangoapps/schedules/tasks.py
+++ b/openedx/core/djangoapps/schedules/tasks.py
@@ -1,6 +1,7 @@
 import datetime
 import logging
 
+import json
 from celery import task
 from django.conf import settings
 from django.contrib.auth.models import User
@@ -122,12 +123,18 @@ class ScheduleMessageBaseTask(LoggedTask):
 
         # If no target date was provided, then enqueue tasks from the current date
         if target_day_str is None:
-            return self.enqueue(
-                site,
-                now(),
-                day_offset,
-                override_recipient_email,
-            )
+            if isinstance(day_offset, basestring):
+                day_offset_list = json.loads(day_offset)
+            else:
+                day_offset_list = [day_offset]
+
+            for offset in day_offset_list:
+                return self.enqueue(
+                    site,
+                    now(),
+                    offset,
+                    override_recipient_email,
+                )
 
         # Otherwise, process the batched tasks
         with emulate_http_request(site=site):

--- a/openedx/core/djangoapps/schedules/tasks.py
+++ b/openedx/core/djangoapps/schedules/tasks.py
@@ -122,13 +122,12 @@ class ScheduleMessageBaseTask(LoggedTask):
 
         # If no target date was provided, then enqueue tasks from the current date
         if target_day_str is None:
-            cls.enqueue(
+            return self.enqueue(
                 site,
                 now(),
                 day_offset,
                 override_recipient_email,
             )
-            return
 
         # Otherwise, process the batched tasks
         with emulate_http_request(site=site):
@@ -178,6 +177,9 @@ def _course_update_schedule_send(site_id, msg_str):
 
 
 class ScheduleRecurringNudge(ScheduleMessageBaseTask):
+    """
+    Task to send the course nudge emails
+    """
     num_bins = resolvers.RECURRING_NUDGE_NUM_BINS
     enqueue_config_var = 'enqueue_recurring_nudge'
     log_prefix = RECURRING_NUDGE_LOG_PREFIX
@@ -189,6 +191,9 @@ class ScheduleRecurringNudge(ScheduleMessageBaseTask):
 
 
 class ScheduleUpgradeReminder(ScheduleMessageBaseTask):
+    """
+    Task to send the course upgrade reminder emails
+    """
     num_bins = resolvers.UPGRADE_REMINDER_NUM_BINS
     enqueue_config_var = 'enqueue_upgrade_reminder'
     log_prefix = UPGRADE_REMINDER_LOG_PREFIX
@@ -200,6 +205,9 @@ class ScheduleUpgradeReminder(ScheduleMessageBaseTask):
 
 
 class ScheduleCourseUpdate(ScheduleMessageBaseTask):
+    """
+    Task to send the weekly course highlights emails
+    """
     num_bins = resolvers.COURSE_UPDATE_NUM_BINS
     enqueue_config_var = 'enqueue_course_update'
     log_prefix = COURSE_UPDATE_LOG_PREFIX

--- a/requirements/edx/github.in
+++ b/requirements/edx/github.in
@@ -84,6 +84,7 @@
 
 # Why a django-celery fork? To add Django 1.11 compatibility to the abandoned repo.
 # This dependency will be removed by the Celery 4 upgrade: https://openedx.atlassian.net/browse/PLAT-1684
+# When upgrading, check compatibility with community-configured settings.CELERYBEAT_SCHEDULES, cf https://github.com/edx/edx-platform/pull/19047
 -e git+https://github.com/edx/django-celery.git@756cb57aad765cb2b0d37372c1855b8f5f37e6b0#egg=django-celery==3.2.1+edx.2
 
 # Our libraries:


### PR DESCRIPTION
Since not everyone has Jenkins available to [run the daily management command](https://github.com/edx/edx-platform/tree/master/openedx/core/djangoapps/schedules/#running-the-management-commands) for sending scheduled emails, this change allows the tasks to be configured and scheduled using the existing `djcelery` library.

This change has two parts:
1. Addition of the `ADDITIONAL_CELERYBEAT_SCHEDULES` env token, which can contain any celery task configuration details. 
   See `Settings` below for the one used here.
1. Modification to `schedules.tasks.ScheduleMessageBaseTask` to make it possible to enqueue a set of scheduled email tasks from the current date.
   By providing a task configuration as shown in `Settings` below, we achieve the behaviour of running the [send_course_update management command via cron/jenkins](https://github.com/edx/edx-platform/blob/b9bc10e7f232c7d22130123a755573901ee3ba49/openedx/core/djangoapps/schedules/management/commands/send_course_update.py#L8).  Though unlike that management command, the actual day offsets used are configurable, and must be specified explicitly.

**JIRA tickets**: SE-126, [OSPR-2646](https://openedx.atlassian.net/browse/OSPR-2646)

**Dependencies**: https://github.com/edx/configuration/pull/4946

This change can be merged independently of https://github.com/edx/configuration/pull/4946, but requires that configuration in order to have the `celery beat` task run and process the configured tasks.

**Screenshots**:

![django admin periodic tasks](https://user-images.githubusercontent.com/7556571/51226285-ac6f1900-199e-11e9-8c8f-d3160608b3ef.png)


**Sandbox URL**:  

* LMS: https://pr19047.sandbox.opencraft.hosting/
* Studio: https://studio-pr19047.sandbox.opencraft.hosting/

(267f56f)

**Merge deadline**: Would like to get this merged before Ironwood if possible.

**Testing instructions**:

1. On the sandbox, register and activate an account.
1. Enrol in the [Weekly Course Updates test course](https://pr19047.sandbox.opencraft.hosting/courses/course-v1:OpenCraft+Highlights+2018_1/about)
1. With the current configuration, you'll get a scheduled course update in your inbox tomorrow, after the celery beat-triggered task runs.  (See below for how to trigger this immediately.)

To check the Django Admin:
1. Login to the sandbox as the `staff` user (it's been elevated to superuser).
1. Visit the [Django Admin › Djcelery › Periodic tasks](https://pr19047.sandbox.opencraft.hosting/admin/djcelery/periodictask/) and note that there are 3 tasks created there.
   1. `celery.backend_cleanup`: installed by default [by djcelery](https://github.com/edx/django-celery/blob/master/djcelery/schedulers.py#L242-L246)
   1. `refresh-saml-metadata`: added by default [by edx-platform](https://github.com/edx/edx-platform/blob/674677daf5e19272fce5cb06b5cdaffbf0292da3/lms/envs/production.py#L707-L711)
   1. `send-course-highlights`: added by the `ADDITIONAL_CELERYBEAT_SCHEDULES` configured below.
1. To make the `send-course-highlights` task send its messages immediately, edit the task to change the Interval from the configured "Every 86400 seconds" to e.g., "Every 5 minutes".
1. Visit the [Django Admin Schedules › Schedules ](https://pr19047.sandbox.opencraft.hosting/admin/schedules/schedule) and locate the schedule created for your newly-registered user above.
   Adjust the Start date to backdate it by 1 week.  You should get an email for Week 1 in your inbox.
1. Run `/edx/bin/supervisorctl restart edxapp_celery_beat:` to revert any manual changes made to the configured task (takes a few seconds to take effect).

**Reviewers**
- [ ] @clemente 
- [ ] edX reviewer[s] TBD

**Author Notes & Concerns**

1. As [edX recommended](https://github.com/edx/edx-platform/pull/19047#issuecomment-435928813), I've [noted the dependency of this feature on the current `edx:django-celery` fork](https://github.com/edx/edx-platform/pull/19047/commits/267f56f2b4c8c06776b3f87353597e83c16f2a48).
  When the upgrade to celery>=4 happens, [database periodic tasks should still be supported](http://docs.celeryproject.org/en/latest/userguide/periodic-tasks.html), however there may be some work required to ensure these are created for the `setting.CELERYBEAT_SCHEDULES` entries.
1. If the `ADDITIONAL_CELERYBEAT_SCHEDULES` setting is unacceptable to upstream, we can remove this change and manually add Periodic Task entries for our clients instead of adding them with configuration variables.

**Settings**
```yaml
## Celerybeat schedule
# Run the ScheduleCourseUpdate task daily, enqueuing tasks with day offsets for yesterday, 1 week ago, 2 weeks ago, etc.
EDXAPP_LMS_ENV_EXTRA:
    ADDITIONAL_CELERYBEAT_SCHEDULES:
     send-course-highlights:
        task: openedx.core.djangoapps.schedules.tasks.ScheduleCourseUpdate
        schedule: 86400
        kwargs:
          site_id: 1
          target_day_str: null
          day_offset: [-1, -7, -14, -21, -28]

# Enables the celery beat processor task
EDXAPP_ENABLE_CELERY_BEAT: true

configuration_repo_url: https://github.com/open-craft/configuration
configuration_version: jill/celery-beat

## Use default django mailer for scheduled course highlight messages
EDXAPP_ACE_CHANNEL_DEFAULT_EMAIL: "django_email"
EDXAPP_ACE_CHANNEL_SAILTHRU_DEBUG: false
EDXAPP_ACE_CHANNEL_SAILTHRU_TEMPLATE_NAME: "template"
EDXAPP_ACE_CHANNEL_TRANSACTIONAL_EMAIL: "django_email"
EDXAPP_ACE_ENABLED_CHANNELS: ["django_email"]
EDXAPP_ACE_ENABLED_POLICIES: ["bulk_email_optout"]
EDXAPP_DEFAULT_FROM_EMAIL: “jill+highlights@opencraft.com” 
 
# Workaround bug in current master
JOURNALS_API_URL: "{{ EDXAPP_LMS_BASE_SCHEME }}://journals-{{ EDXAPP_LMS_BASE }}"
```