### PR TITLE
WL-1810: Do not send user info to sailthru when registered from white label site

### DIFF
--- a/lms/djangoapps/email_marketing/signals.py
+++ b/lms/djangoapps/email_marketing/signals.py
@@ -53,7 +53,7 @@ def update_sailthru(sender, user, mode, course_id, **kwargs):  # pylint: disable
     """
     if WAFFLE_SWITCHES.is_enabled(SAILTHRU_AUDIT_PURCHASE_ENABLED) and mode in CourseMode.AUDIT_MODES:
         email = str(user.email)
-        update_course_enrollment.delay(email, course_id, mode)
+        update_course_enrollment.delay(email, course_id, mode, site=_get_current_site())
 
 
 @receiver(CREATE_LOGON_COOKIE)


### PR DESCRIPTION
This PR has changes to 

1. Stop sending user record to sailthru when registered from white label site.
2. Stop sending purchase info if user enrolled in a course on white label site.

@bill-filler could you please review?