### PR TITLE
ARCH-233: Add JWT Auth Middleware.

### DIFF
--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -532,7 +532,8 @@ MIDDLEWARE_CLASSES = [
     # Outputs monitoring metrics for a request.
     'edx_rest_framework_extensions.middleware.RequestMetricsMiddleware',
 
-    'edx_rest_framework_extensions.middleware.EnsureJWTAuthSettingsMiddleware',
+    'edx_rest_framework_extensions.auth.jwt.middleware.EnsureJWTAuthSettingsMiddleware',
+    'edx_rest_framework_extensions.auth.jwt.middleware.JwtAuthCookieMiddleware',
 
     # This must be last so that it runs first in the process_response chain
     'openedx.core.djangoapps.site_configuration.middleware.SessionCookieDomainOverrideMiddleware',

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -1296,7 +1296,8 @@ MIDDLEWARE_CLASSES = [
     # Outputs monitoring metrics for a request.
     'edx_rest_framework_extensions.middleware.RequestMetricsMiddleware',
 
-    'edx_rest_framework_extensions.middleware.EnsureJWTAuthSettingsMiddleware',
+    'edx_rest_framework_extensions.auth.jwt.middleware.EnsureJWTAuthSettingsMiddleware',
+    'edx_rest_framework_extensions.auth.jwt.middleware.JwtAuthCookieMiddleware',
 
     # This must be last
     'openedx.core.djangoapps.site_configuration.middleware.SessionCookieDomainOverrideMiddleware',


### PR DESCRIPTION
From edx-drf-extensions:
1. EnsureJWTAuthSettingsMiddleware: Ensures proper JWT auth settings
   for endpoints.
2. JwtAuthCookieMiddleware: Combines the JWT auth cookie parts into a
   JWT auth cookie.

ARCH-233