### PR TITLE
Dont assume user id in test_shib

### DIFF
--- a/openedx/core/djangoapps/external_auth/tests/test_shib.py
+++ b/openedx/core/djangoapps/external_auth/tests/test_shib.py
@@ -222,6 +222,8 @@ class ShibSPTest(CacheIsolationTestCase):
         linked users, activates them, and logs them in
         """
         inactive_user = UserFactory.create(email='inactive@stanford.edu')
+        if not log_user_string:
+            log_user_string = "user.id: {}".format(inactive_user.id)
         inactive_user.is_active = False
         inactive_user.save()
         request = self.request_factory.get('/shib-login')
@@ -266,7 +268,7 @@ class ShibSPTest(CacheIsolationTestCase):
         """
         Wrapper to run base_test_extauth_auto_activate_user_with_flag with {'SQUELCH_PII_IN_LOGS': True}
         """
-        self._test_auto_activate_user_with_flag(log_user_string="user.id: 1")
+        self._test_auto_activate_user_with_flag(log_user_string=None)
 
     @unittest.skipUnless(settings.FEATURES.get('AUTH_USE_SHIB'), "AUTH_USE_SHIB not set")
     @data(*gen_all_identities())


### PR DESCRIPTION
Occasionally this test flaked: [link to failing build](https://build.testeng.edx.org/view/edx-platform-pipeline-pr-tests/job/edx-platform-python-pipeline-pr/789/testReport/junit/openedx.core.djangoapps.external_auth.tests.test_shib/ShibSPTest/Run_Tests___lms_unit___test_extauth_auto_activate_user_with_flag_squelch/). It looks like it was failing when a different process created a user, causing the user created in this test to have an id greater than `1`. We shouldn't really be assuming an id anyways, since that isn't written in stone.