### PR TITLE
Fix overriding of token expiration in DOT (ARCH-246)

### DIFF
--- a/openedx/core/djangoapps/oauth_dispatch/dot_overrides/validators.py
+++ b/openedx/core/djangoapps/oauth_dispatch/dot_overrides/validators.py
@@ -3,7 +3,7 @@ Classes that override default django-oauth-toolkit behavior
 """
 from __future__ import unicode_literals
 
-from datetime import datetime
+from datetime import datetime, timedelta
 
 from django.contrib.auth import authenticate, get_user_model
 from django.db.models.signals import pre_save
@@ -82,21 +82,9 @@ class EdxOAuth2Validator(OAuth2Validator):
 
         super(EdxOAuth2Validator, self).save_bearer_token(token, request, *args, **kwargs)
 
-        if RestrictedApplication.should_expire_access_token(request.client):
-            # Since RestrictedApplications will override the DOT defined expiry, so that access_tokens
-            # are always expired, we need to re-read the token from the database and then calculate the
-            # expires_in (in seconds) from what we stored in the database. This value should be a negative
-            #value, meaning that it is already expired
-
-            access_token = AccessToken.objects.get(token=token['access_token'])
-            utc_now = datetime.utcnow().replace(tzinfo=utc)
-            expires_in = (access_token.expires - utc_now).total_seconds()
-
-            # assert that RestrictedApplications only issue expired tokens
-            # blow up processing if we see otherwise
-            assert expires_in < 0
-
-            token['expires_in'] = expires_in
+        is_restricted_client = self._update_token_expiry_if_restricted_client(token, request.client)
+        if not is_restricted_client:
+            self._update_token_expiry_if_overridden_in_request(token, request)
 
         # Restore the original request attributes
         request.grant_type = grant_type
@@ -108,3 +96,43 @@ class EdxOAuth2Validator(OAuth2Validator):
         """
         available_scopes = get_scopes_backend().get_available_scopes(application=client, request=request)
         return set(scopes).issubset(set(available_scopes))
+
+    def _update_token_expiry_if_restricted_client(self, token, client):
+        """
+        Update the token's expires_in value if the given client is a
+        RestrictedApplication and return whether the given client is restricted.
+        """
+        # Since RestrictedApplications override the DOT defined expiry such that
+        # access_tokens are always expired, re-read the token from the database
+        # and calculate expires_in (in seconds) from the database value. This
+        # value should be a negative value, meaning that it is already expired.
+        if RestrictedApplication.should_expire_access_token(client):
+            access_token = AccessToken.objects.get(token=token['access_token'])
+            expires_in = (access_token.expires - _get_utc_now()).total_seconds()
+            assert expires_in < 0
+            token['expires_in'] = expires_in
+            return True
+
+    def _update_token_expiry_if_overridden_in_request(self, token, request):
+        """
+        Update the token's expires_in value if the request specifies an
+        expiration value and update the expires value on the stored AccessToken
+        object.
+
+        This is needed since DOT's save_bearer_token method always uses
+        the dot_settings.ACCESS_TOKEN_EXPIRE_SECONDS value instead of applying
+        the requesting expiration value.
+        """
+        expires_in = getattr(request, 'expires_in', None)
+        if expires_in:
+            access_token = AccessToken.objects.get(token=token['access_token'])
+            access_token.expires = _get_utc_now() + timedelta(seconds=expires_in)
+            access_token.save()
+            token['expires_in'] = expires_in
+
+
+def _get_utc_now():
+    """
+    Return current time in UTC.
+    """
+    return datetime.utcnow().replace(tzinfo=utc)


### PR DESCRIPTION
Currently, django-oauth-toolkit (DOT) does _not_ allow us to customize the expiration value on individual access tokens.  Rather, it has a system-wide Django setting for configuring access tokens ([ACCESS_TOKEN_EXPIRE_SECONDS](https://github.com/jazzband/django-oauth-toolkit/blob/ee8cb080ff13b3fad8fd68a47ae7d5a671222a2c/oauth2_provider/settings.py#L44)) that is not intended to be changed dynamically (neither per request nor per OAuth client).

For us, we would like to have different expiration values for the different usages of access tokens in our system.  For instance, we'd like our stateless JWT tokens to expire in just **1 hour** (since they don't check the database on each call) and yet allow vanilla OAuth tokens to expire after **10 hours**.  Since our platform has multiple forms of authentication in this transitory period, we need these different expiration values.

### Creating Access tokens
When we [create an access token](https://github.com/edx/edx-platform/blob/40918f36d8453959e9655ecc0b72239389ca97e2/openedx/core/djangoapps/oauth_dispatch/api.py#L46), we do so via a [BearerToken Generator](https://github.com/oauthlib/oauthlib/blob/f853295b674cb2be0b83f72f71739a7a23f5936e/oauthlib/oauth2/rfc6749/tokens.py#L252) and eventually call into DOT's [save_bearer_token](https://github.com/jazzband/django-oauth-toolkit/blob/ee8cb080ff13b3fad8fd68a47ae7d5a671222a2c/oauth2_provider/oauth2_validators.py#L445) method, which [just uses the system-wide expires value rather than the requested expires value](https://github.com/jazzband/django-oauth-toolkit/blob/ee8cb080ff13b3fad8fd68a47ae7d5a671222a2c/oauth2_provider/oauth2_validators.py#L456).  This is the expiration value that is set in the `AccessToken` table in the database.  Below is the stack trace.
```
oauthlib/oauth2/rfc6749/tokens.py(252)create_token(save_token=True) (on BearerToken)
    oauthlib/oauth2/rfc6749/tokens.py(213)random_token_generator()
        oauth_dispatch/dot_overrides/validators.py(64)save_bearer_token()
            # following doesn't use the token['expires_in'] value that's passed in
            oauth2_provider/oauth2_validators.py(552)save_bearer_token() 
                oauth2_provider/oauth2_validators.py(557)_create_access_token()
```

### Refreshing Access tokens
When we [refresh an access token](https://github.com/edx/edx-platform/blob/40918f36d8453959e9655ecc0b72239389ca97e2/openedx/core/djangoapps/oauth_dispatch/api.py#L49), we do so by [plumbing through a refresh_token request through the oauth library in order to make sure it goes through the normal validation channels](https://github.com/edx/edx-platform/blob/40918f36d8453959e9655ecc0b72239389ca97e2/openedx/core/djangoapps/oauth_dispatch/api.py#L58-L62).  Here too, it eventually calls into DOT's [save_bearer_token](https://github.com/jazzband/django-oauth-toolkit/blob/ee8cb080ff13b3fad8fd68a47ae7d5a671222a2c/oauth2_provider/oauth2_validators.py#L445) method that doesn't use the requested expires value.  Below is the stack trace.
```
openedx/core/djangoapps/oauth_dispatch/api.py(62)refresh_dot_access_token()
  oauth2_provider/oauth2_backends.py(140)create_token_response()
    oauthlib/oauth2/rfc6749/endpoints/base.py(64)wrapper()
      oauthlib/oauth2/rfc6749/endpoints/token.py(117)create_token_response()
        oauthlib/oauth2/rfc6749/grant_types/refresh_token.py(68)create_token_response()
          oauthlib/oauth2/rfc6749/request_validator.py(246)save_token()                       
            openedx/core/djangoapps/oauth_dispatch/dot_overrides/validators.py(86)save_bearer_token()
```

Additionally during refresh, since we do not create the BearerToken directly but do so via the oauth library, we need to pass the expiration value through the `token_expires_in` parameter when creating the [oauth "server"](https://github.com/oauthlib/oauthlib/blob/d5a4d5ea0eab04ddddefac7d1e7a4902fc469286/oauthlib/oauth2/rfc6749/endpoints/pre_configured.py#L24-L31).  This is the expiration value that is provided in the resulting token `dict` object.