### PR TITLE
EDUCATOR-3213 make Global EdX Staff able to view all forum posts

### DIFF
--- a/common/djangoapps/django_comment_common/models.py
+++ b/common/djangoapps/django_comment_common/models.py
@@ -14,6 +14,7 @@ from six import text_type
 
 from openedx.core.djangoapps.xmodule_django.models import NoneToEmptyManager
 from student.models import CourseEnrollment
+from student.roles import GlobalStaff
 from xmodule.modulestore.django import modulestore
 from xmodule.modulestore.exceptions import ItemNotFoundError
 
@@ -156,6 +157,13 @@ def all_permissions_for_user_in_course(user, course_id):  # pylint: disable=inva
         for permission in role.permissions.all():
             if not permission_blacked_out(course, role_names, permission.name):
                 permission_names.add(permission.name)
+
+    # Prevent a circular import
+    from django_comment_common.utils import GLOBAL_STAFF_ROLE_PERMISSIONS
+
+    if GlobalStaff().has_user(user):
+        for permission in GLOBAL_STAFF_ROLE_PERMISSIONS:
+            permission_names.add(permission)
 
     return permission_names
 

--- a/common/djangoapps/django_comment_common/utils.py
+++ b/common/djangoapps/django_comment_common/utils.py
@@ -3,6 +3,7 @@ Common comment client utility functions.
 """
 
 from django_comment_common.models import (
+    CourseDiscussionSettings,
     FORUM_ROLE_ADMINISTRATOR,
     FORUM_ROLE_COMMUNITY_TA,
     FORUM_ROLE_GROUP_MODERATOR,
@@ -12,8 +13,6 @@ from django_comment_common.models import (
 )
 from openedx.core.djangoapps.course_groups.cohorts import get_legacy_discussion_settings
 from openedx.core.lib.cache_utils import request_cached
-
-from .models import CourseDiscussionSettings
 
 
 class ThreadContext(object):
@@ -33,6 +32,8 @@ GROUP_MODERATOR_ROLE_PERMISSIONS = ["group_edit_content", "group_delete_thread",
                                     "group_endorse_comment", "group_delete_comment"]
 
 ADMINISTRATOR_ROLE_PERMISSIONS = ["manage_moderator"]
+
+GLOBAL_STAFF_ROLE_PERMISSIONS = ["see_all_cohorts"]
 
 
 def _save_forum_role(course_key, name):

--- a/lms/djangoapps/discussion/tests/test_views.py
+++ b/lms/djangoapps/discussion/tests/test_views.py
@@ -771,6 +771,17 @@ class ForumFormDiscussionContentGroupTestCase(ForumsEnableMixin, ContentGroupTes
         )
         self.assert_has_access(response, 3)
 
+    def test_global_staff_user(self, mock_request):
+        """
+        Verify that global staff user has access to all threads regardless
+        of cohort.
+        """
+        response = self.call_view(
+            mock_request,
+            self.staff_user
+        )
+        self.assert_has_access(response, 4)
+
 
 @patch('requests.request', autospec=True)
 class SingleThreadContentGroupTestCase(ForumsEnableMixin, UrlResetMixin, ContentGroupTestCase):

--- a/openedx/core/djangoapps/util/testing.py
+++ b/openedx/core/djangoapps/util/testing.py
@@ -72,7 +72,7 @@ class ContentGroupTestCase(ModuleStoreTestCase):
         alpha_cohort = CohortFactory(
             course_id=self.course.id,
             name='Cohort Alpha',
-            users=[self.alpha_user, self.community_ta]
+            users=[self.alpha_user, self.community_ta, self.staff_user]
         )
         beta_cohort = CohortFactory(
             course_id=self.course.id,


### PR DESCRIPTION
# [EDUCATOR-3213](https://openedx.atlassian.net/browse/EDUCATOR-3213)

### Description
In the past, Global Edx Staff users had access to their assigned cohort/ enrollment track group forum posts. Now, they will be able to see all forum posts.

### Reviewers
If you've been tagged for review, please check your corresponding box once you've given the :+1:.
- [ ] Code review: @fysheets 
- [ ] Code review:  @awaisdar001 

### Testing
- [x] Unit test

### Post-review
- [ ] Rebase and squash commits