### PR TITLE
Security: Move the hard-coded whitelists of allowed hosts into Ansible configuration 

### DIFF
--- a/cms/envs/aws.py
+++ b/cms/envs/aws.py
@@ -152,11 +152,7 @@ ENTERPRISE_CONSENT_API_URL = ENV_TOKENS.get('ENTERPRISE_CONSENT_API_URL', LMS_IN
 
 SITE_NAME = ENV_TOKENS['SITE_NAME']
 
-ALLOWED_HOSTS = [
-    # TODO: bbeggs remove this before prod, temp fix to get load testing running
-    "*",
-    ENV_TOKENS.get('CMS_BASE')
-]
+ALLOWED_HOSTS = ENV_TOKENS.get('CMS_ALLOWED_HOSTS')
 
 LOG_DIR = ENV_TOKENS['LOG_DIR']
 DATA_DIR = ENV_TOKENS.get('DATA_DIR', DATA_DIR)

--- a/lms/envs/aws.py
+++ b/lms/envs/aws.py
@@ -181,12 +181,7 @@ for feature, value in ENV_FEATURES.items():
 
 CMS_BASE = ENV_TOKENS.get('CMS_BASE', 'studio.edx.org')
 
-ALLOWED_HOSTS = [
-    # TODO: bbeggs remove this before prod, temp fix to get load testing running
-    "*",
-    ENV_TOKENS.get('LMS_BASE'),
-    FEATURES['PREVIEW_LMS_BASE'],
-]
+ALLOWED_HOSTS = ENV_TOKENS.get('LMS_ALLOWED_HOSTS')
 
 # allow for environments to specify what cookie name our login subsystem should use
 # this is to fix a bug regarding simultaneous logins between edx.org and edge.edx.org which can


### PR DESCRIPTION
This is a minor change to the code to mitigate a host header attack.  It fetches the lists of allowed hosts from environment configuration which were previously hard-coded in edx-platform/lms/envs/aws.py and edx-platform/cms/envs/aws.py.