### PR TITLE
Security: Set httponly to true

### DIFF
--- a/common/djangoapps/student/cookies.py
+++ b/common/djangoapps/student/cookies.py
@@ -35,7 +35,7 @@ def standard_cookie_settings(request):
         'expires': expires,
         'domain': settings.SESSION_COOKIE_DOMAIN,
         'path': '/',
-        'httponly': None,
+        'httponly': True,
     }
 
     return cookie_settings


### PR DESCRIPTION
Mitigates malicious client-side scripts from accessing cookies and accessing the session id.