### PR TITLE
Fix sharding for unittests to avoid skipped tests

### DIFF
--- a/openedx/core/lib/gating/tests/test_api.py
+++ b/openedx/core/lib/gating/tests/test_api.py
@@ -236,6 +236,7 @@ class TestGatingApi(ModuleStoreTestCase, MilestonesTestCaseMixin):
         (0, 1, 0),
     )
     @unpack
+    @unittest.skipUnless(settings.ROOT_URLCONF == 'lms.urls', 'Test only valid in lms')
     def test_get_subsection_completion_percentage(self, user_problem_completion, user_html_completion,
                                                   expected_completion_percentage):
         """

--- a/scripts/unit-tests.sh
+++ b/scripts/unit-tests.sh
@@ -61,7 +61,7 @@ case "${TEST_SUITE}" in
                 paver test_system -s lms --disable_capture --eval-attr="shard==$SHARD" ${PAVER_ARGS} ${PARALLEL} 2> lms-tests.${SHARD}.log
                 ;;
             10|"noshard")
-                paver test_system -s lms --disable_capture --eval-attr='not shard' ${PAVER_ARGS} ${PARALLEL} 2> lms-tests.10.log
+                paver test_system -s lms --disable_capture --eval-attr="shard>=$SHARD or not shard" ${PAVER_ARGS} ${PARALLEL} 2> lms-tests.10.log
                 ;;
             *)
                 # If no shard is specified, rather than running all tests, create an empty xunit file. This is a
@@ -83,7 +83,7 @@ case "${TEST_SUITE}" in
                 paver test_system -s cms --disable_capture --eval-attr="shard==$SHARD" ${PAVER_ARGS} 2> cms-tests.${SHARD}.log
                 ;;
             2|"noshard")
-                paver test_system -s cms --disable_capture --eval-attr='not shard' ${PAVER_ARGS} 2> cms-tests.2.log
+                paver test_system -s cms --disable_capture --eval-attr="shard>=$SHARD or not shard" ${PAVER_ARGS} 2> cms-tests.2.log
                 ;;
             *)
                 # If no shard is specified, rather than running all tests, create an empty xunit file. This is a
@@ -105,7 +105,7 @@ case "${TEST_SUITE}" in
                 paver test_lib -l common/lib/xmodule --disable_capture --eval-attr="shard==$SHARD" ${PAVER_ARGS} 2> common-tests.${SHARD}.log
                 ;;
             3|"noshard")
-                paver test_lib --disable_capture --eval-attr='not shard' ${PAVER_ARGS} 2> common-tests.3.log
+                paver test_lib --disable_capture --eval-attr="shard>=$SHARD or not shard" ${PAVER_ARGS} 2> common-tests.3.log
                 ;;
             *)
                 # If no shard is specified, rather than running all tests, create an empty xunit file. This is a


### PR DESCRIPTION
The upper bound shard in each suite wasn't actually being run... since the paver command only looked for `'not shard'`. Also, in case there are more shards than we are accounting for, the upper bound shard will also check for any tests that may have a higher shard value.

I'm also skipping test_get_subsection_completion_percentage on CMS (this PR revealed that it was failing), I spoke with Zia and verified it is only valid on LMS.