### PR TITLE
Consistent expiration for all login-related cookies

### DIFF
--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -3159,7 +3159,7 @@ JWT_AUTH = {
 
     # Number of seconds before JWTs expire
     'JWT_EXPIRATION': 30,
-    'JWT_COOKIE_EXPIRATION': 60 * 60,
+    'JWT_IN_COOKIE_EXPIRATION': 60 * 60,
 
     'JWT_LOGIN_CLIENT_ID': 'login-service-client-id',
     'JWT_LOGIN_SERVICE_USERNAME': 'login_service_user',


### PR DESCRIPTION
https://openedx.atlassian.net/browse/ARCH-246
This PR completes the changes related to setting consistent and expected expiration values on JWTs and their enveloping cookies.  The [1st PR](https://github.com/edx/edx-platform/pull/19074) addressed configuration of the JWT's expiration value.  This PR addresses the expiration of the enveloping cookies and makes their expirations consistent with other login-related cookies.

In summary:
- The expiration of all login-related cookies is consistently set.
- We are not changing the [behavior of the "Remember me" setting](https://github.com/edx/edx-platform/blob/f93c9a929841d3c1f7e83552b273492f5001da3a/openedx/core/djangoapps/user_authn/views/login.py#L257-L261).  So the user's login-related cookies expire either (1) in [1 week](https://github.com/edx/edx-platform/blob/f93c9a929841d3c1f7e83552b273492f5001da3a/openedx/core/djangoapps/user_authn/views/login.py#L258) (if "remember") or (2) when their [browser closes](https://github.com/edx/edx-platform/blob/f93c9a929841d3c1f7e83552b273492f5001da3a/openedx/core/djangoapps/user_authn/views/login.py#L261) (if _not_ "remember").
- The expiration of the JWT embedded inside the cookies depends on the `JWT_IN_COOKIE_EXPIRATION` setting (defaults to [1 hour](https://github.com/edx/edx-platform/blob/f93c9a929841d3c1f7e83552b273492f5001da3a/lms/envs/common.py#L3174)).
- The refresh token expiration remains untouched and depends on the `REFRESH_TOKEN_EXPIRE_SECONDS` setting ([defaults to 3 months](https://github.com/edx/edx-platform/blob/f93c9a929841d3c1f7e83552b273492f5001da3a/lms/envs/common.py#L505-L506)).