### PR TITLE
Load proctoring js files for authenticated users only

### DIFF
--- a/lms/templates/courseware/course_navigation.html
+++ b/lms/templates/courseware/course_navigation.html
@@ -16,7 +16,11 @@ if active_page is None and active_page_context is not UNDEFINED:
     active_page = active_page_context
 
 if course is not None:
-    include_special_exams = settings.FEATURES.get('ENABLE_SPECIAL_EXAMS', False) and (course.enable_proctored_exams or course.enable_timed_exams)
+    include_special_exams = (
+    request.user.is_authenticated and
+    settings.FEATURES.get('ENABLE_SPECIAL_EXAMS', False) and
+    (course.enable_proctored_exams or course.enable_timed_exams)
+    )
 %>
 
 % if include_special_exams is not UNDEFINED and include_special_exams:

--- a/lms/templates/courseware/courseware.html
+++ b/lms/templates/courseware/courseware.html
@@ -15,7 +15,11 @@ from openedx.core.djangolib.markup import HTML
 from openedx.features.course_experience import course_home_page_title, COURSE_OUTLINE_PAGE_FLAG
 %>
 <%
-  include_special_exams = settings.FEATURES.get('ENABLE_SPECIAL_EXAMS', False) and (course.enable_proctored_exams or course.enable_timed_exams)
+   include_special_exams = (
+   request.user.is_authenticated and
+   settings.FEATURES.get('ENABLE_SPECIAL_EXAMS', False) and
+   (course.enable_proctored_exams or course.enable_timed_exams)
+   )
 %>
 <%def name="course_name()">
  <% return _("{course_number} Courseware").format(course_number=course.display_number_with_default) %>


### PR DESCRIPTION
## [EDUCATOR-3416](https://openedx.atlassian.net/browse/EDUCATOR-3416)

### Description

Proctoring js resources are loaded and initialized whenever a request is made to any page in LMS. We only check if a course has enabled proctored exams here. 
This PR adds an additional check of user authentication before adding proctoring js resources. So, for pages like course home page '/course' which is accessible to unauthenticated users, we can save an API call destined for a 403.

### Reviewers
- [x] @fysheets 
- [ ] @awaisdar001 
 
### Post-review
- [ ] Rebase and squash commits