### PR TITLE
Refactored XBlockAside rendering and added support for student view

### DIFF
--- a/cms/djangoapps/contentstore/views/component.py
+++ b/cms/djangoapps/contentstore/views/component.py
@@ -9,7 +9,6 @@ from django.http import Http404, HttpResponseBadRequest
 from django.utils.translation import ugettext as _
 from django.views.decorators.http import require_GET
 from opaque_keys import InvalidKeyError
-from opaque_keys.edx.asides import AsideUsageKeyV1, AsideUsageKeyV2
 from opaque_keys.edx.keys import UsageKey
 from xblock.core import XBlock
 from xblock.django.request import django_to_webob_request, webob_to_django_response
@@ -17,10 +16,11 @@ from xblock.exceptions import NoSuchHandlerError
 from xblock.plugin import PluginMissingError
 from xblock.runtime import Mixologist
 
-from contentstore.utils import get_lms_link_for_item, get_xblock_aside_instance, reverse_course_url
+from contentstore.utils import get_lms_link_for_item, reverse_course_url
 from contentstore.views.helpers import get_parent_xblock, is_unit, xblock_type_display_name
 from contentstore.views.item import StudioEditModuleRuntime, add_container_page_publishing_info, create_xblock_info
 from edxmako.shortcuts import render_to_response
+from openedx.core.lib.xblock_utils import is_xblock_aside, get_aside_from_xblock
 from student.auth import has_course_author_access
 from xblock_django.api import authorable_xblocks, disabled_xblocks
 from xblock_django.models import XBlockStudioConfigurationFlag
@@ -441,25 +441,25 @@ def component_handler(request, usage_key_string, handler, suffix=''):
         :class:`django.http.HttpResponse`: The response from the handler, converted to a
             django response
     """
-
     usage_key = UsageKey.from_string(usage_key_string)
+
     # Let the module handle the AJAX
     req = django_to_webob_request(request)
 
-    asides = []
-
     try:
-        if isinstance(usage_key, (AsideUsageKeyV1, AsideUsageKeyV2)):
+        if is_xblock_aside(usage_key):
+            # Get the descriptor for the block being wrapped by the aside (not the aside itself)
             descriptor = modulestore().get_item(usage_key.usage_key)
-            aside_instance = get_xblock_aside_instance(usage_key)
-            asides = [aside_instance] if aside_instance else []
-            resp = aside_instance.handle(handler, req, suffix)
+            handler_descriptor = get_aside_from_xblock(descriptor, usage_key.aside_type)
+            asides = [handler_descriptor]
         else:
             descriptor = modulestore().get_item(usage_key)
-            descriptor.xmodule_runtime = StudioEditModuleRuntime(request.user)
-            resp = descriptor.handle(handler, req, suffix)
+            handler_descriptor = descriptor
+            asides = []
+        handler_descriptor.xmodule_runtime = StudioEditModuleRuntime(request.user)
+        resp = handler_descriptor.handle(handler, req, suffix)
     except NoSuchHandlerError:
-        log.info("XBlock %s attempted to access missing handler %r", descriptor, handler, exc_info=True)
+        log.info("XBlock %s attempted to access missing handler %r", handler_descriptor, handler, exc_info=True)
         raise Http404
 
     # unintentional update to handle any side effects of handle call

--- a/cms/djangoapps/contentstore/views/item.py
+++ b/cms/djangoapps/contentstore/views/item.py
@@ -52,7 +52,7 @@ from models.settings.course_grading import CourseGradingModel
 from openedx.core.djangoapps.schedules.config import COURSE_UPDATE_WAFFLE_FLAG
 from openedx.core.djangoapps.waffle_utils import WaffleSwitch
 from openedx.core.lib.gating import api as gating_api
-from openedx.core.lib.xblock_utils import request_token, wrap_xblock
+from openedx.core.lib.xblock_utils import request_token, wrap_xblock, wrap_xblock_aside
 from static_replace import replace_static_urls
 from student.auth import has_studio_read_access, has_studio_write_access
 from util.date_utils import get_default_time_display
@@ -324,6 +324,14 @@ def xblock_view_handler(request, usage_key_string, view_name):
             'StudioRuntime',
             usage_id_serializer=unicode,
             request_token=request_token(request),
+        ))
+
+        xblock.runtime.wrappers_asides.append(partial(
+            wrap_xblock_aside,
+            'StudioRuntime',
+            usage_id_serializer=unicode,
+            request_token=request_token(request),
+            extra_classes=['wrapper-comp-plugins']
         ))
 
         if view_name in (STUDIO_VIEW, VISIBILITY_VIEW):

--- a/cms/static/js/views/modals/edit_xblock.js
+++ b/cms/static/js/views/modals/edit_xblock.js
@@ -19,7 +19,7 @@ define(['jquery', 'underscore', 'backbone', 'gettext', 'js/views/modals/base_mod
                 view: 'studio_view',
                 viewSpecificClasses: 'modal-editor confirm',
                 // Translators: "title" is the name of the current component being edited.
-                titleFormat: gettext('Editing: %(title)s'),
+                titleFormat: gettext('Editing: {title}'),
                 addPrimaryActionButton: true
             }),
 
@@ -87,6 +87,10 @@ define(['jquery', 'underscore', 'backbone', 'gettext', 'js/views/modals/base_mod
                     this.$('.modal-window-title').text(title);
                     if (editorView.getDataEditor() && editorView.getMetadataEditor()) {
                         this.addDefaultModes();
+                        // If the plugins content element exists, add a button to reveal it.
+                        if (this.$('.wrapper-comp-plugins').length > 0) {
+                            this.addModeButton('plugins', gettext('Plugins'));
+                        }
                         this.selectMode(editorView.mode);
                     }
                 }
@@ -125,7 +129,11 @@ define(['jquery', 'underscore', 'backbone', 'gettext', 'js/views/modals/base_mod
                         displayName = gettext('Component');
                     }
                 }
-                return interpolate(this.options.titleFormat, {title: displayName}, true);
+                return edx.StringUtils.interpolate(
+                    this.options.titleFormat, {
+                        title: displayName
+                    }
+                );
             },
 
             addDefaultModes: function() {
@@ -192,6 +200,7 @@ define(['jquery', 'underscore', 'backbone', 'gettext', 'js/views/modals/base_mod
 
             addModeButton: function(mode, displayName) {
                 var buttonPanel = this.$('.editor-modes');
+                // xss-lint: disable=javascript-jquery-append
                 buttonPanel.append(this.editorModeButtonTemplate({
                     mode: mode,
                     displayName: displayName

--- a/cms/static/js/views/xblock_editor.js
+++ b/cms/static/js/views/xblock_editor.js
@@ -2,9 +2,9 @@
  * XBlockEditorView displays the authoring view of an xblock, and allows the user to switch between
  * the available modes.
  */
-define(['jquery', 'underscore', 'gettext', 'js/views/xblock', 'js/views/metadata', 'js/collections/metadata',
+define(['jquery', 'underscore', 'gettext', 'js/views/baseview', 'js/views/xblock', 'js/views/metadata', 'js/collections/metadata',
     'jquery.inputnumber'],
-    function($, _, gettext, XBlockView, MetadataView, MetadataCollection) {
+    function($, _, gettext, BaseView, XBlockView, MetadataView, MetadataCollection) {
         var XBlockEditorView = XBlockView.extend({
             // takes XBlockInfo as a model
 
@@ -24,6 +24,7 @@ define(['jquery', 'underscore', 'gettext', 'js/views/xblock', 'js/views/metadata
 
             initializeEditors: function() {
                 var metadataEditor,
+                    pluginEl,
                     defaultMode = 'editor';
                 metadataEditor = this.createMetadataEditor();
                 this.metadataEditor = metadataEditor;
@@ -34,6 +35,12 @@ define(['jquery', 'underscore', 'gettext', 'js/views/xblock', 'js/views/metadata
                         defaultMode = 'settings';
                     }
                     this.selectMode(defaultMode);
+                }
+                pluginEl = this.$('.wrapper-comp-plugins');
+                if (pluginEl.length > 0) {
+                    this.pluginEditor = new BaseView({
+                        el: pluginEl
+                    });
                 }
             },
 
@@ -85,6 +92,10 @@ define(['jquery', 'underscore', 'gettext', 'js/views/xblock', 'js/views/metadata
 
             getMetadataEditor: function() {
                 return this.metadataEditor;
+            },
+
+            getPluginEditor: function() {
+                return this.pluginEditor;
             },
 
             /**
@@ -144,14 +155,17 @@ define(['jquery', 'underscore', 'gettext', 'js/views/xblock', 'js/views/metadata
             },
 
             selectMode: function(mode) {
-                var showEditor = mode === 'editor',
-                    dataEditor = this.getDataEditor(),
-                    metadataEditor = this.getMetadataEditor();
+                var dataEditor = this.getDataEditor(),
+                    metadataEditor = this.getMetadataEditor(),
+                    pluginEditor = this.getPluginEditor();
                 if (dataEditor) {
-                    this.setEditorActivation(dataEditor, showEditor);
+                    this.setEditorActivation(dataEditor, mode === 'editor');
                 }
                 if (metadataEditor) {
-                    this.setEditorActivation(metadataEditor.$el, !showEditor);
+                    this.setEditorActivation(metadataEditor.$el, mode === 'settings');
+                }
+                if (pluginEditor) {
+                    this.setEditorActivation(pluginEditor.$el, mode === 'plugins');
                 }
                 this.mode = mode;
             },

--- a/cms/static/sass/elements/_modal-window.scss
+++ b/cms/static/sass/elements/_modal-window.scss
@@ -276,7 +276,8 @@
             margin-left: ($baseline/2);
 
             .editor-button,
-            .settings-button {
+            .settings-button,
+            .plugins-button {
               @extend %btn-secondary-gray;
               @extend %t-copy-sub1;
 

--- a/cms/static/sass/elements/_xblocks.scss
+++ b/cms/static/sass/elements/_xblocks.scss
@@ -887,6 +887,14 @@
   }
 }
 
+.wrapper-comp-plugins {
+  display: none;
+
+  &.is-active {
+    display: block;
+  }
+}
+
 
 // +Case - Special Xblock Type Overrides
 // ====================

--- a/common/static/common/js/xblock/core.js
+++ b/common/static/common/js/xblock/core.js
@@ -11,6 +11,9 @@
         } else {
             selector = '.' + blockClass;
         }
+        // After an element is initialized, a class is added to it. To avoid repeat initialization, no
+        // elements with that class should be selected.
+        selector += ':not(.xblock-initialized)';
         return $(element).immediateDescendents(selector).map(function(idx, elem) {
             return initializer(elem, requestToken);
         }).toArray();
@@ -112,6 +115,7 @@
         initializeAside: function(element) {
             var blockUsageId = $(element).data('block-id');
             var blockElement = $(element).siblings('[data-usage-id="' + blockUsageId + '"]')[0];
+
             return constructBlock(element, [blockElement, initArgs(element)]);
         },
 

--- a/lms/djangoapps/courseware/student_field_overrides.py
+++ b/lms/djangoapps/courseware/student_field_overrides.py
@@ -5,6 +5,7 @@ by the individual due dates feature.
 import json
 
 from courseware.models import StudentFieldOverride
+from openedx.core.lib.xblock_utils import is_xblock_aside
 
 from .field_overrides import FieldOverrideProvider
 
@@ -44,9 +45,18 @@ def _get_overrides_for_user(user, block):
     Gets all of the individual student overrides for given user and block.
     Returns a dictionary of field override values keyed by field name.
     """
+    if (
+        hasattr(block, "scope_ids") and
+        hasattr(block.scope_ids, "usage_id") and
+        is_xblock_aside(block.scope_ids.usage_id)
+    ):
+        location = block.scope_ids.usage_id.usage_key
+    else:
+        location = block.location
+
     query = StudentFieldOverride.objects.filter(
         course_id=block.runtime.course_id,
-        location=block.location,
+        location=location,
         student_id=user.id,
     )
     overrides = {}

--- a/lms/djangoapps/lms_xblock/runtime.py
+++ b/lms/djangoapps/lms_xblock/runtime.py
@@ -12,7 +12,7 @@ from badges.utils import badges_enabled
 from lms.djangoapps.lms_xblock.models import XBlockAsidesConfig
 from openedx.core.djangoapps.user_api.course_tag import api as user_course_tag_api
 from openedx.core.lib.url_utils import quote_slashes
-from openedx.core.lib.xblock_utils import xblock_local_resource_url
+from openedx.core.lib.xblock_utils import xblock_local_resource_url, wrap_xblock_aside
 from xmodule.library_tools import LibraryToolsService
 from xmodule.modulestore.django import ModuleI18nService, modulestore
 from xmodule.partitions.partitions_service import PartitionService
@@ -184,19 +184,28 @@ class LmsModuleSystem(ModuleSystem):  # pylint: disable=abstract-method
         The default implementation creates a frag to wraps frag w/ a div identifying the xblock. If you have
         javascript, you'll need to override this impl
         """
+        if not frag.content:
+            return frag
+
+        runtime_class = 'LmsRuntime'
         extra_data = {
             'block-id': quote_slashes(unicode(block.scope_ids.usage_id)),
+            'course-id': quote_slashes(unicode(block.course_id)),
             'url-selector': 'asideBaseUrl',
-            'runtime-class': 'LmsRuntime',
+            'runtime-class': runtime_class,
         }
         if self.request_token:
             extra_data['request-token'] = self.request_token
 
-        return self._wrap_ele(
+        return wrap_xblock_aside(
+            runtime_class,
             aside,
             view,
             frag,
-            extra_data,
+            context,
+            usage_id_serializer=unicode,
+            request_token=self.request_token,
+            extra_data=extra_data,
         )
 
     def applicable_aside_types(self, block):

--- a/openedx/core/lib/tests/test_xblock_utils.py
+++ b/openedx/core/lib/tests/test_xblock_utils.py
@@ -7,11 +7,16 @@ import uuid
 
 import ddt
 from django.test.client import RequestFactory
+from mock import patch
 from web_fragments.fragment import Fragment
+from six import text_type
 
+from opaque_keys.edx.asides import AsideUsageKeyV1, AsideUsageKeyV2
 from openedx.core.lib.url_utils import quote_slashes
 from openedx.core.lib.xblock_builtin import get_css_dependencies, get_js_dependencies
 from openedx.core.lib.xblock_utils import (
+    is_xblock_aside,
+    get_aside_from_xblock,
     replace_course_urls,
     replace_jump_to_id_urls,
     replace_static_urls,
@@ -20,9 +25,11 @@ from openedx.core.lib.xblock_utils import (
     wrap_fragment,
     wrap_xblock
 )
+from xblock.core import XBlockAside
 from xmodule.modulestore import ModuleStoreEnum
 from xmodule.modulestore.tests.django_utils import SharedModuleStoreTestCase
-from xmodule.modulestore.tests.factories import CourseFactory
+from xmodule.modulestore.tests.factories import CourseFactory, ItemFactory
+from xmodule.modulestore.tests.test_asides import AsideTestType
 
 
 @ddt.ddt
@@ -216,3 +223,30 @@ class TestXblockUtils(SharedModuleStoreTestCase):
         with self.settings(PIPELINE_ENABLED=pipeline_enabled, PIPELINE_JS=pipeline_js):
             js_dependencies = get_js_dependencies("js-group")
             self.assertEqual(js_dependencies, expected_js_dependencies)
+
+
+class TestXBlockAside(SharedModuleStoreTestCase):
+    """Test the xblock aside function."""
+
+    @classmethod
+    def setUpClass(cls):
+        super(TestXBlockAside, cls).setUpClass()
+        cls.course = CourseFactory.create()
+        cls.block = ItemFactory.create(category='aside', parent=cls.course)
+        cls.aside_v2 = AsideUsageKeyV2(cls.block.scope_ids.usage_id, "aside")
+        cls.aside_v1 = AsideUsageKeyV1(cls.block.scope_ids.usage_id, "aside")
+
+    def test_is_xblock_aside(self):
+        """test if xblock is aside"""
+        assert is_xblock_aside(self.aside_v2) is True
+        assert is_xblock_aside(self.aside_v1) is True
+
+    def test_is_not_xblock_aside(self):
+        """test if xblock is not aside"""
+        assert is_xblock_aside(self.block.scope_ids.usage_id) is False
+
+    @patch('xmodule.modulestore.xml.ImportSystem.applicable_aside_types', lambda self, block: ['test_aside'])
+    @XBlockAside.register_temp_plugin(AsideTestType, 'test_aside')
+    def test_get_aside(self):
+        """test get aside success"""
+        assert get_aside_from_xblock(self.block, text_type("test_aside")) is not None


### PR DESCRIPTION
#### What are the relevant tickets?
fixes https://github.com/mitodl/edx-platform/issues/100

#### What's this PR do?
- Adds aside rendering in the LMS student view, and refactors the aside code to use the same code path in LMS/Studio for dispatching requests to the handlers defined in the aside.
- Changes the invocation of XBlockAside AJAX handler functions. It makes sure the runtime is correctly set up for the aside in both LMS and Studio
- Introduces a set of changes that make the aside studio view work correctly. If an aside defines a studio view, its contents are now rendered in a new tab in the block editor modal. This can be tested with the rapid-response aside

#### How should this be manually tested?
- You can install https://github.com/mitodl/rapid-response-xblock. See readme on edX platform with this branch
- no test should break

@pdpinch 


