### PR TITLE
ARCH-256: Move and rename redirect helper.

### DIFF
--- a/common/djangoapps/student/tests/test_helpers.py
+++ b/common/djangoapps/student/tests/test_helpers.py
@@ -12,7 +12,7 @@ from django.test.utils import override_settings
 from mock import patch
 from testfixtures import LogCapture
 
-from student.helpers import get_next_url_for_login_page, is_safe_redirect
+from student.helpers import get_next_url_for_login_page
 from openedx.core.djangoapps.site_configuration.tests.test_util import with_site_configuration_context
 
 LOGGER_NAME = "student.helpers"
@@ -77,22 +77,6 @@ class TestLoginHelper(TestCase):
         req.META["HTTP_ACCEPT"] = "text/html"  # pylint: disable=no-member
         next_page = get_next_url_for_login_page(req)
         self.assertEqual(next_page, next_url)
-
-    @ddt.data(
-        ('/dashboard', 'testserver', True),
-        ('https://edx.org/courses', 'edx.org', True),
-        ('https://test.edx.org/courses', 'edx.org', True),
-        ('https://www.amazon.org', 'edx.org', False),
-        ('http://edx.org/courses', 'edx.org', False),
-        ('http:///edx.org/courses', 'edx.org', False),  # Django's is_safe_url protects against "///"
-    )
-    @ddt.unpack
-    @override_settings(LOGIN_REDIRECT_WHITELIST=['test.edx.org'])
-    def test_safe_redirect(self, url, host, expected_is_safe):
-        """ Test safe next parameter """
-        req = self.request.get(reverse("login"), HTTP_HOST=host)
-        actual_is_safe = is_safe_redirect(req, url)
-        self.assertEqual(actual_is_safe, expected_is_safe)
 
     @patch('student.helpers.third_party_auth.pipeline.get')
     @ddt.data(

--- a/openedx/core/djangoapps/user_authn/tests/test_utils.py
+++ b/openedx/core/djangoapps/user_authn/tests/test_utils.py
@@ -1,0 +1,33 @@
+""" Test User Authentication utilities """
+
+import ddt
+from django.test import TestCase
+from django.test.client import RequestFactory
+from django.test.utils import override_settings
+
+from openedx.core.djangoapps.user_authn.utils import is_safe_login_or_logout_redirect
+
+
+@ddt.ddt
+class TestRedirectUtils(TestCase):
+    """Test redirect utility methods."""
+
+    def setUp(self):
+        super(TestRedirectUtils, self).setUp()
+        self.request = RequestFactory()
+
+    @ddt.data(
+        ('/dashboard', 'testserver', True),
+        ('https://edx.org/courses', 'edx.org', True),
+        ('https://test.edx.org/courses', 'edx.org', True),
+        ('https://www.amazon.org', 'edx.org', False),
+        ('http://edx.org/courses', 'edx.org', False),
+        ('http:///edx.org/courses', 'edx.org', False),  # Django's is_safe_url protects against "///"
+    )
+    @ddt.unpack
+    @override_settings(LOGIN_REDIRECT_WHITELIST=['test.edx.org'])
+    def test_safe_redirect(self, url, host, expected_is_safe):
+        """ Test safe next parameter """
+        req = self.request.get('/login', HTTP_HOST=host)
+        actual_is_safe = is_safe_login_or_logout_redirect(req, url)
+        self.assertEqual(actual_is_safe, expected_is_safe)

--- a/openedx/core/djangoapps/user_authn/utils.py
+++ b/openedx/core/djangoapps/user_authn/utils.py
@@ -1,0 +1,18 @@
+"""
+Utility functions used during user authentication.
+"""
+from django.conf import settings
+from django.utils import http
+
+
+def is_safe_login_or_logout_redirect(request, redirect_to):
+    """
+    Determine if the given redirect URL/path is safe for redirection.
+    """
+    request_host = request.get_host()  # e.g. 'courses.edx.org'
+
+    login_redirect_whitelist = set(getattr(settings, 'LOGIN_REDIRECT_WHITELIST', []))
+    login_redirect_whitelist.add(request_host)
+
+    is_safe_url = http.is_safe_url(redirect_to, allowed_hosts=login_redirect_whitelist, require_https=True)
+    return is_safe_url

--- a/openedx/core/djangoapps/user_authn/views/logout.py
+++ b/openedx/core/djangoapps/user_authn/views/logout.py
@@ -10,7 +10,7 @@ from django.utils.http import urlencode
 from django.views.generic import TemplateView
 from provider.oauth2.models import Client
 from openedx.core.djangoapps.user_authn.cookies import delete_logged_in_cookies
-from student.helpers import is_safe_redirect
+from openedx.core.djangoapps.user_authn.utils import is_safe_login_or_logout_redirect
 
 
 class LogoutView(TemplateView):
@@ -35,7 +35,7 @@ class LogoutView(TemplateView):
         """
         target_url = self.request.GET.get('redirect_url')
 
-        if target_url and is_safe_redirect(self.request, target_url):
+        if target_url and is_safe_login_or_logout_redirect(self.request, target_url):
             return target_url
         else:
             return self.default_target


### PR DESCRIPTION
- Rename is_safe_redirect to is_safe_login_or_logout_redirect.
- Moved is_safe_login_or_logout_redirect to user_authn.

ARCH-256

@nasthagiri: I started with what was simplest.  I have questions around moving `get_next_url_for_login_page`, so I didn't yet and we can discuss or skip for now.