### PR TITLE
Use CursorPagination to paginate responses from grades views.

### DIFF
--- a/lms/djangoapps/grades/api/v1/tests/test_views.py
+++ b/lms/djangoapps/grades/api/v1/tests/test_views.py
@@ -687,7 +687,6 @@ class GradebookViewTest(GradeViewTestMixin, APITestCase):
                 self.get_url(course_key=self.empty_course.id)
             )
             expected_data = {
-                'count': 0,
                 'next': None,
                 'previous': None,
                 'results': [],
@@ -762,7 +761,6 @@ class GradebookViewTest(GradeViewTestMixin, APITestCase):
 
                 self.assertEqual(status.HTTP_200_OK, resp.status_code)
                 actual_data = dict(resp.data)
-                self.assertEqual(2, actual_data['count'])
                 self.assertIsNone(actual_data['next'])
                 self.assertIsNone(actual_data['previous'])
                 self.assertEqual(expected_results, actual_data['results'])

--- a/lms/djangoapps/grades/api/v1/views.py
+++ b/lms/djangoapps/grades/api/v1/views.py
@@ -9,7 +9,7 @@ from django.urls import reverse
 from rest_framework import status
 from rest_framework.exceptions import AuthenticationFailed
 from rest_framework.generics import GenericAPIView
-from rest_framework.pagination import PageNumberPagination
+from rest_framework.pagination import CursorPagination
 from rest_framework.response import Response
 from six import text_type
 
@@ -91,6 +91,14 @@ def verify_writable_gradebook_enabled(view_func):
             )
         return view_func(self, request, **kwargs)
     return wrapped_function
+
+
+class CourseEnrollmentPagination(CursorPagination):
+    """
+    Paginates over CourseEnrollment objects.
+    """
+    page_size = 25
+    ordering = 'id'
 
 
 class GradeViewMixin(DeveloperErrorViewMixin):
@@ -316,6 +324,8 @@ class CourseGradesView(GradeViewMixin, GenericAPIView):
 
     permission_classes = (permissions.JWT_RESTRICTED_APPLICATION_OR_USER_ACCESS,)
 
+    pagination_class = CourseEnrollmentPagination
+
     required_scopes = ['grades:read']
 
     @verify_course_exists
@@ -340,11 +350,6 @@ class CourseGradesView(GradeViewMixin, GenericAPIView):
         else:
             # If no username passed, get paginated list of grades for all users in course
             return self._get_user_grades(course_key)
-
-
-class GradebookPagination(PageNumberPagination):
-    page_size = 25
-    page_size_query_param = 'page_size'
 
 
 class GradebookView(GradeViewMixin, GenericAPIView):
@@ -452,9 +457,9 @@ class GradebookView(GradeViewMixin, GenericAPIView):
 
     permission_classes = (permissions.JWT_RESTRICTED_APPLICATION_OR_USER_ACCESS,)
 
-    required_scopes = ['grades:read']
+    pagination_class = CourseEnrollmentPagination
 
-    pagination_class = GradebookPagination
+    required_scopes = ['grades:read']
 
     def _section_breakdown(self, course_grade):
         """


### PR DESCRIPTION
This PR modifies the `CourseGradesView` and `GradebookView` classes to use `CursorPagination` instead of page number pagination.  The pagination occurs over `CourseEnrollment` objects and the ordering is determined by the `id` field of that model.