### PR TITLE
Fix flaky TestUserPreferenceMiddleware tests for xdist

### DIFF
--- a/openedx/core/djangoapps/lang_pref/tests/test_middleware.py
+++ b/openedx/core/djangoapps/lang_pref/tests/test_middleware.py
@@ -14,6 +14,7 @@ from django.http import HttpResponse
 from django.contrib.sessions.middleware import SessionMiddleware
 from django.utils.translation import LANGUAGE_SESSION_KEY
 from django.utils.translation.trans_real import parse_accept_lang_header
+from openedx.core.djangolib.testing.utils import CacheIsolationTestCase
 
 from openedx.core.djangoapps.lang_pref import LANGUAGE_KEY, COOKIE_DURATION
 from openedx.core.djangoapps.lang_pref.middleware import LanguagePreferenceMiddleware
@@ -23,7 +24,7 @@ from student.tests.factories import AnonymousUserFactory
 
 
 @ddt.ddt
-class TestUserPreferenceMiddleware(TestCase):
+class TestUserPreferenceMiddleware(CacheIsolationTestCase):
     """
     Tests to make sure user preferences are getting properly set in the middleware.
     """


### PR DESCRIPTION
Occasionally there were flaky tests from "too many login attempts." It looks like subclassing the `CacheIsolationTestCase` fixes this, and is a strategy we've used in other similar situations: https://github.com/edx/edx-platform/blob/a824543e238e43216554d099a6d1608359815acf/openedx/core/djangoapps/user_authn/views/tests/test_login.py#L41