### PR TITLE
Fix error when saving CourseEnrollment in admin

### DIFF
--- a/common/djangoapps/course_modes/admin.py
+++ b/common/djangoapps/course_modes/admin.py
@@ -56,7 +56,7 @@ class CourseModeForm(forms.ModelForm):
     def __init__(self, *args, **kwargs):
         # If args is a QueryDict, then the ModelForm addition request came in as a POST with a course ID string.
         # Change the course ID string to a CourseLocator object by copying the QueryDict to make it mutable.
-        if len(args) > 0 and 'course' in args[0] and isinstance(args[0], QueryDict):
+        if args and 'course' in args[0] and isinstance(args[0], QueryDict):
             args_copy = args[0].copy()
             args_copy['course'] = CourseKey.from_string(args_copy['course'])
             args = [args_copy]

--- a/common/djangoapps/student/admin.py
+++ b/common/djangoapps/student/admin.py
@@ -7,6 +7,7 @@ from django.contrib.auth import get_user_model
 from django.contrib.auth.admin import UserAdmin as BaseUserAdmin
 from django.contrib.auth.forms import ReadOnlyPasswordHashField, UserChangeForm as BaseUserChangeForm
 from django.db import models
+from django.http.request import QueryDict
 from django.utils.translation import ugettext_lazy as _
 from opaque_keys import InvalidKeyError
 from opaque_keys.edx.keys import CourseKey
@@ -149,13 +150,26 @@ class LinkedInAddToProfileConfigurationAdmin(admin.ModelAdmin):
 class CourseEnrollmentForm(forms.ModelForm):
 
     def __init__(self, *args, **kwargs):
+        # If args is a QueryDict, then the ModelForm addition request came in as a POST with a course ID string.
+        # Change the course ID string to a CourseLocator object by copying the QueryDict to make it mutable.
+        if args and 'course' in args[0] and isinstance(args[0], QueryDict):
+            args_copy = args[0].copy()
+            try:
+                args_copy['course'] = CourseKey.from_string(args_copy['course'])
+            except InvalidKeyError:
+                raise forms.ValidationError("Cannot make a valid CourseKey from id {}!".format(args_copy['course']))
+            args = [args_copy]
+
         super(CourseEnrollmentForm, self).__init__(*args, **kwargs)
 
         if self.data.get('course'):
             try:
                 self.data['course'] = CourseKey.from_string(self.data['course'])
-            except InvalidKeyError:
-                raise forms.ValidationError("Cannot make a valid CourseKey from id {}!".format(self.data['course']))
+            except AttributeError:
+                # Change the course ID string to a CourseLocator.
+                # On a POST request, self.data is a QueryDict and is immutable - so this code will fail.
+                # However, the args copy above before the super() call handles this case.
+                pass
 
     def clean_course_id(self):
         course_id = self.cleaned_data['course']


### PR DESCRIPTION
Right now, we can't save a `StudentEnrollment` from admin (when that admin view is enabled), it crashes:
```
Internal Server Error: /admin/student/courseenrollment/64747/change/
Traceback (most recent call last):
[…]
  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/django/contrib/admin/options.py", line 1440, in _changeform_view
    form = ModelForm(request.POST, request.FILES, instance=obj)
  File "/edx/app/edxapp/edx-platform/common/djangoapps/student/admin.py", line 155, in __init__
    self.data['course'] = CourseKey.from_string(self.data['course'])
  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/django/http/request.py", line 434, in __setitem__
    self._assert_mutable()
  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/django/http/request.py", line 431, in _assert_mutable
    raise AttributeError("This QueryDict instance is immutable")
AttributeError: This QueryDict instance is immutable
```

We're applying the solution found [in this existing code](https://github.com/edx/edx-platform/blob/4d37779f58f1132176fa5aa095692f01a479f769/common/djangoapps/course_modes/admin.py#L68), also [described here](https://stackoverflow.com/questions/18930234/django-modifying-the-request-object/18931697), to copy the dict so that it is mutable.

**JIRA tickets**: None
**Discussions**: None
**Dependencies**: None
**Screenshots**: None
**Sandbox URL**: creating one
**Merge deadline**: None

**Testing instructions**:

1. Go to http://localhost:18000/admin/waffle/switch/ and add a switch called `student.courseenrollment_admin`
2. Now http://localhost:18000/admin/student/courseenrollment/ will work
3. Go to some existing CE like http://localhost:18000/admin/student/courseenrollment/2/change/
4. Toggle its `Is active` and save
5. With this patch, it should work (CourseEnrollment toggled between active/inactive). Without, it showed `AttributeError: This QueryDict instance is immutable`
6. Play with the forms in more ways

To test the `InvalidKeyError` case: temporarily change the code to use an invalid ID:
`args_copy['course'] = CourseKey.from_string("---xxxxxxxxxxxxxxxxx---")`
and save the form again after toggling `is_active`. You should see a `forms.ValidationError` (as a Django error page if you run in DEBUG).

**Reviewers**
- [ ] @pomegranited
- [ ] edX

**Author concerns**:

Why the `InvalidKeyError` validation was moved to the top (and why it isn't needed below):
- when we go through POST, the above code is run and the validation runs once, and the fragment below will find a valid `CourseLocatior`
- when we go through GET/others (and it seems other aren't used in admin), the `if self.data.get('course')` doesn't run (I guess `.data` isn't used), so the validation isn't needed there. In addition: any use of GET would be extracting CourseKey from DB, which are already valid. Only the admin's POST requires validation
- [this existing code](https://github.com/edx/edx-platform/blob/4d37779f58f1132176fa5aa095692f01a479f769/common/djangoapps/course_modes/admin.py#L68) works and doesn't include the validation
