### PR TITLE
Message related to certificate on courseware progress page are translated to platform language only

### DIFF
--- a/lms/templates/courseware/progress.html
+++ b/lms/templates/courseware/progress.html
@@ -71,8 +71,8 @@ username = get_enterprise_learner_generic_name(request) or student.username
                         <div class="has-actions">
                             <% post_url = reverse('generate_user_cert', args=[unicode(course.id)]) %>
                             <div class="msg-content">
-                                <h4 class="hd hd-4 title">${certificate_data.title}</h4>
-                                <p class="copy">${certificate_data.msg}</p>
+                                <h4 class="hd hd-4 title">${_(certificate_data.title)}</h4>
+                                <p class="copy">${_(certificate_data.msg)}</p>
                             </div>
                             <div class="msg-actions">
                                 %if certificate_data.cert_web_view_url:


### PR DESCRIPTION
I opened a JIRA ticket about this : https://openedx.atlassian.net/browse/LOC-112

**Background:** 
The values in the views.py is translated into the platform language before being sent to progress.html.
This causes the strings to show only in the platform language and not the user selected one. They should only be translated once received by progress.html.

https://github.com/edx/edx-platform/blob/master/lms/templates/courseware/progress.html
The value collected on line 74 and 75 come from the following file.
https://github.com/edx/edx-platform/blob/master/lms/djangoapps/courseware/views/views.py
The possible values are on line 123 to 175.

We saw the same problem on edx.org's spanish version.
<img width="1806" alt="spanish" src="https://user-images.githubusercontent.com/17911549/46960488-acdcd880-d06c-11e8-947c-16a818867fca.png">

This affects all user using another language than the platform's default language.

**LMS Updates:** 
We removed translations marker from the values in views.py and added them to progress.html
This shows the message in the user selected language.
![screenshot_2018-10-15 mus-001 1 progress edulib](https://user-images.githubusercontent.com/17911549/46961120-04c80f00-d06e-11e8-8162-c8c42bbea5a5.png)
![screenshot_2018-10-15 progression mus-001 1 edulib](https://user-images.githubusercontent.com/17911549/46961119-04c80f00-d06e-11e8-936a-10c08d78aea3.png)

**Test:**
1. Use a multilingual edx-platform.
2. Register for a course in audit mode.
3. Go to the course progress page.
4. See message related to audit mode.
5. Change language.
You can do the same with verified course, but you need to be eligible for a certificate but not generated the certificate for the problematic messages to appear. A different problematic message also appear if your identity has not been verified.

**Comment:**
The progress.html tests are hard coded to test only for english. I'm not sure how to tackle that problem.