### PR TITLE
Security: Read the whitelist of allowed hostnames from configuration 

### DIFF
--- a/cms/envs/aws.py
+++ b/cms/envs/aws.py
@@ -146,11 +146,7 @@ ENTERPRISE_CONSENT_API_URL = ENV_TOKENS.get('ENTERPRISE_CONSENT_API_URL', LMS_IN
 
 SITE_NAME = ENV_TOKENS['SITE_NAME']
 
-ALLOWED_HOSTS = [
-    # TODO: bbeggs remove this before prod, temp fix to get load testing running
-    "*",
-    ENV_TOKENS.get('CMS_BASE')
-]
+ALLOWED_HOSTS = ENV_TOKENS.get('CMS_ALLOWED_HOSTS')
 
 LOG_DIR = ENV_TOKENS['LOG_DIR']
 DATA_DIR = path(ENV_TOKENS.get('DATA_DIR', DATA_DIR))

--- a/lms/envs/aws.py
+++ b/lms/envs/aws.py
@@ -180,12 +180,7 @@ for feature, value in ENV_FEATURES.items():
 
 CMS_BASE = ENV_TOKENS.get('CMS_BASE', 'studio.edx.org')
 
-ALLOWED_HOSTS = [
-    # TODO: bbeggs remove this before prod, temp fix to get load testing running
-    "*",
-    ENV_TOKENS.get('LMS_BASE'),
-    FEATURES['PREVIEW_LMS_BASE'],
-]
+ALLOWED_HOSTS = ENV_TOKENS.get('LMS_ALLOWED_HOSTS')
 
 # allow for environments to specify what cookie name our login subsystem should use
 # this is to fix a bug regarding simultaneous logins between edx.org and edge.edx.org which can


### PR DESCRIPTION
Also needed in Hawthorn.

This PR is a minor change which reads the whitelist of allowed hostnames used to mitigate a host header attack from configuration files.  It has a corresponding configuration PR: https://github.com/edx/configuration/pull/4848.