### PR TITLE
Use uuid instead of randint for db names in Mongo builders

### DIFF
--- a/common/lib/xmodule/xmodule/modulestore/tests/utils.py
+++ b/common/lib/xmodule/xmodule/modulestore/tests/utils.py
@@ -1,6 +1,7 @@
 """
 Helper classes and methods for running modulestore tests without Django.
 """
+from uuid import uuid4
 import io
 import os
 import random
@@ -228,7 +229,7 @@ class MongoContentstoreBuilder(object):
         when the context closes.
         """
         contentstore = MongoContentStore(
-            db='contentstore{}'.format(random.randint(0, 10000)),
+            db='contentstore{}'.format(THIS_UUID),
             collection='content',
             **COMMON_DOCSTORE_CONFIG
         )
@@ -286,7 +287,7 @@ class MongoModulestoreBuilder(StoreBuilderBase):
                 all of its assets.
         """
         doc_store_config = dict(
-            db='modulestore{}'.format(random.randint(0, 10000)),
+            db='modulestore{}'.format(THIS_UUID),
             collection='xmodule',
             asset_collection='asset_metadata',
             **COMMON_DOCSTORE_CONFIG
@@ -334,7 +335,7 @@ class VersioningModulestoreBuilder(StoreBuilderBase):
                 all of its assets.
         """
         doc_store_config = dict(
-            db='modulestore{}'.format(random.randint(0, 10000)),
+            db='modulestore{}'.format(THIS_UUID),
             collection='split_module',
             **COMMON_DOCSTORE_CONFIG
         )
@@ -454,6 +455,8 @@ class MixedModulestoreBuilder(StoreBuilderBase):
             # Split stores all asset metadata in the structure collection.
             return store.db_connection.structures
 
+
+THIS_UUID = uuid4().hex
 
 COMMON_DOCSTORE_CONFIG = {
     'host': MONGO_HOST,


### PR DESCRIPTION
I was seeing a flaky failure once in a while inside `CrossStoreXmlRoundtrip`, specifically from the `test_round_trip` test. Here's an example:  https://build.testeng.edx.org/view/edx-platform-pipeline-pr-tests/job/edx-platform-python-pipeline-pr/1288/

I know the odds of 2 processes interfering because of a randomly generated number in such a large range is small, but keep in mind thanks to ddt, this test is run 36 times per build, and runs for a total of about 15 minutes. Mix in the fact that this was only failing maybe 10% of the time, and it seems like it actually could be related. Regardless, sticking with the theme of tying the process id to the db name seems consistent and better than a random number.
