### PR TITLE
TE-2786 Fix grade computation test assertions

### DIFF
--- a/lms/djangoapps/grades/management/commands/tests/test_compute_grades.py
+++ b/lms/djangoapps/grades/management/commands/tests/test_compute_grades.py
@@ -19,13 +19,6 @@ from xmodule.modulestore.tests.django_utils import SharedModuleStoreTestCase
 from xmodule.modulestore.tests.factories import CourseFactory
 
 
-def _sorted_by_batch(calls):
-    """
-    Return the list of calls sorted by course_key and batch.
-    """
-    return sorted(calls, key=lambda x: (x[1]['kwargs']['course_key'], x[1]['kwargs']['offset']))
-
-
 @ddt.ddt
 class TestComputeGrades(SharedModuleStoreTestCase):
     """
@@ -38,12 +31,11 @@ class TestComputeGrades(SharedModuleStoreTestCase):
     @classmethod
     def setUpClass(cls):
         super(TestComputeGrades, cls).setUpClass()
-        User = get_user_model()  # pylint: disable=invalid-name
         cls.command = compute_grades.Command()
 
         cls.courses = [CourseFactory.create() for _ in range(cls.num_courses)]
         cls.course_keys = [six.text_type(course.id) for course in cls.courses]
-        cls.users = [User.objects.create(username='user{}'.format(idx)) for idx in range(cls.num_users)]
+        cls.users = [get_user_model().objects.create(username='user{}'.format(idx)) for idx in range(cls.num_users)]
 
         for user in cls.users:
             for course in cls.courses:
@@ -51,10 +43,7 @@ class TestComputeGrades(SharedModuleStoreTestCase):
 
     def test_select_all_courses(self):
         courses = self.command._get_course_keys({'all_courses': True})
-        self.assertEqual(
-            sorted(six.text_type(course) for course in courses),
-            self.course_keys,
-        )
+        assert set(six.text_type(course) for course in courses) == set(self.course_keys)
 
     def test_specify_courses(self):
         courses = self.command._get_course_keys({'courses': [self.course_keys[0], self.course_keys[1], 'd/n/e']})
@@ -70,10 +59,7 @@ class TestComputeGrades(SharedModuleStoreTestCase):
     def test_from_settings(self):
         ComputeGradesSetting.objects.create(course_ids=" ".join(self.course_keys))
         courses = self.command._get_course_keys({'from_settings': True})
-        self.assertEqual(
-            sorted(six.text_type(course) for course in courses),
-            self.course_keys,
-        )
+        assert set(six.text_type(course) for course in courses) == set(self.course_keys)
         # test that --from_settings always uses the latest setting
         ComputeGradesSetting.objects.create(course_ids='badcoursekey')
         with self.assertRaises(CommandError):
@@ -103,52 +89,56 @@ class TestComputeGrades(SharedModuleStoreTestCase):
             'estimate_first_attempted': estimate_first_attempted,
             'seq_id': ANY,
         }
-        self.assertEqual(
-            _sorted_by_batch(mock_task.apply_async.call_args_list),
-            [
-                ({
-                    'routing_key': 'key',
-                    'kwargs': _kwargs(self.course_keys[0], 0)
-                },),
-                ({
-                    'routing_key': 'key',
-                    'kwargs': _kwargs(self.course_keys[0], 2)
-                },),
-                ({
-                    'routing_key': 'key',
-                    'kwargs': _kwargs(self.course_keys[3], 0)
-                },),
-                ({
-                    'routing_key': 'key',
-                    'kwargs': _kwargs(self.course_keys[3], 2)
-                },),
-            ],
-        )
+        actual = mock_task.apply_async.call_args_list
+        # Order doesn't matter, but can't use a set because dicts aren't hashable
+        expected = [
+            ({
+                'routing_key': 'key',
+                'kwargs': _kwargs(self.course_keys[0], 0)
+            },),
+            ({
+                'routing_key': 'key',
+                'kwargs': _kwargs(self.course_keys[0], 2)
+            },),
+            ({
+                'routing_key': 'key',
+                'kwargs': _kwargs(self.course_keys[3], 0)
+            },),
+            ({
+                'routing_key': 'key',
+                'kwargs': _kwargs(self.course_keys[3], 2)
+            },),
+        ]
+        assert len(expected) == len(actual)
+        for call in expected:
+            assert call in actual
 
     @patch('lms.djangoapps.grades.tasks.compute_grades_for_course_v2')
     def test_tasks_fired_from_settings(self, mock_task):
         ComputeGradesSetting.objects.create(course_ids=self.course_keys[1], batch_size=2)
         call_command('compute_grades', '--from_settings')
-        self.assertEqual(
-            _sorted_by_batch(mock_task.apply_async.call_args_list),
-            [
-                ({
-                    'kwargs': {
-                        'course_key': self.course_keys[1],
-                        'batch_size': 2,
-                        'offset': 0,
-                        'estimate_first_attempted': True,
-                        'seq_id': ANY,
-                    },
-                },),
-                ({
-                    'kwargs': {
-                        'course_key': self.course_keys[1],
-                        'batch_size': 2,
-                        'offset': 2,
-                        'estimate_first_attempted': True,
-                        'seq_id': ANY,
-                    },
-                },),
-            ],
-        )
+        actual = mock_task.apply_async.call_args_list
+        # Order doesn't matter, but can't use a set because dicts aren't hashable
+        expected = [
+            ({
+                'kwargs': {
+                    'course_key': self.course_keys[1],
+                    'batch_size': 2,
+                    'offset': 0,
+                    'estimate_first_attempted': True,
+                    'seq_id': ANY,
+                },
+            },),
+            ({
+                'kwargs': {
+                    'course_key': self.course_keys[1],
+                    'batch_size': 2,
+                    'offset': 2,
+                    'estimate_first_attempted': True,
+                    'seq_id': ANY,
+                },
+            },),
+        ]
+        assert len(expected) == len(actual)
+        for call in expected:
+            assert call in actual


### PR DESCRIPTION
This test was depending on alphabetical sorting of course keys being equivalent to numerical sorting of the sequence numbers used when creating them, but that broke down when the sequence numbers were something like `[97, 98, 99, 100, 101]`.  Fixed the assertions to be order-insensitive without depending on alphabetical sorting.