### PR TITLE
WL-1830: change min-height of video player to support mobile devices

### DIFF
--- a/common/lib/xmodule/xmodule/css/video/display.scss
+++ b/common/lib/xmodule/xmodule/css/video/display.scss
@@ -261,7 +261,7 @@ $cool-dark: rgb(79, 89, 93); // UXPL cool dark
 
     .video-player {
       overflow: hidden;
-      min-height: 300px;
+      min-height: 158px;
 
       > div {
         height: 100%;


### PR DESCRIPTION
This PR is setting min-height of video player div to 158 px to remove empty space at the bottom on mobile devices 320px wide.
@bill-filler could you please review?