### PR TITLE
TE-2790 Fix microsite config leak in tests

### DIFF
--- a/lms/djangoapps/certificates/tests/test_api.py
+++ b/lms/djangoapps/certificates/tests/test_api.py
@@ -737,8 +737,11 @@ def set_microsite(domain):
             """
             Execute the function after setting up the microsite.
             """
-            microsite.set_by_domain(domain)
-            return func(request, *args, **kwargs)
+            try:
+                microsite.set_by_domain(domain)
+                return func(request, *args, **kwargs)
+            finally:
+                microsite.clear()
         return inner
     return decorator
 


### PR DESCRIPTION
This helper function (used in 2 test cases) set a microsite configuration but never undid it.  Most tests don't care one way or the other, but this caused all the tests in `lms/djangoapps/course_api/tests/test_api.py::TestGetCourseListMultipleCourses` to fail if they ran after this.  Fixed to undo the changes before exiting the test case (whether it passes or not).