### PR TITLE
Fix that discussions are loading in the profile view.

### DIFF
--- a/common/static/common/js/discussion/utils.js
+++ b/common/static/common/js/discussion/utils.js
@@ -31,6 +31,9 @@
             if (_.isUndefined(userId)) {
                 userId = this.user ? this.user.id : void 0;
             }
+            if(_.isUndefined(this.roleIds)) {
+                this.roleIds = {}
+            }
             staff = _.union(this.roleIds.Moderator, this.roleIds.Administrator);
             return _.include(staff, parseInt(userId));
         };


### PR DESCRIPTION
### [EDUCATOR-3581](https://openedx.atlassian.net/browse/EDUCATOR-3581)

I have added a fix for it. 


While debugging on the production env i have debugged through this code and i am able to load all the discussion in thr profile view.

```
if(_.isUndefined(this.roleIds)) {
                this.roleIds = {}
            }
```
<img width="1279" alt="screen shot 2018-10-23 at 2 40 06 pm" src="https://user-images.githubusercontent.com/7627421/47351531-99b3b380-d6d1-11e8-9daf-1bd4af3b90f7.png">


Test is also written https://github.com/edx/edx-platform/blob/6ada0ca76decda7938fdc808ba77cac150453099/lms/djangoapps/discussion/static/discussion/js/spec/discussion_profile_page_factory_spec.js#L43
But it strange some times this issue is reproduce and some times its not.



@Rabia23 @awaisdar001 @fysheets Can you guys please review it.