### PR TITLE
Include ConnectTimeout under ecs script retry

### DIFF
--- a/scripts/xdist/pytest_container_manager.py
+++ b/scripts/xdist/pytest_container_manager.py
@@ -74,8 +74,7 @@ class PytestContainerManager():
                 else:
                     break
 
-            if not response['tasks']:
-                assert response == 'dummy_val'
+            print(response)
 
             for task_response in response['tasks']:
                 task_arns.append(task_response['taskArn'])

--- a/scripts/xdist/pytest_container_manager.py
+++ b/scripts/xdist/pytest_container_manager.py
@@ -4,6 +4,7 @@ import time
 
 import boto3
 from botocore.exceptions import ClientError
+from botocore.vendored.requests.exceptions import ConnectTimeout
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
@@ -56,7 +57,7 @@ class PytestContainerManager():
                         },
                         taskDefinition=task_definition
                     )
-                except ClientError as err:
+                except (ClientError, ConnectTimeout) as err:
                     # Handle AWS throttling with an exponential backoff
                     if retry == MAX_RUN_TASK_RETRIES:
                         raise StandardError(

--- a/scripts/xdist/pytest_container_manager.py
+++ b/scripts/xdist/pytest_container_manager.py
@@ -74,7 +74,7 @@ class PytestContainerManager():
                 else:
                     break
 
-            print(response)
+            logger.info(response)
 
             for task_response in response['tasks']:
                 task_arns.append(task_response['taskArn'])

--- a/scripts/xdist/pytest_container_manager.py
+++ b/scripts/xdist/pytest_container_manager.py
@@ -74,7 +74,8 @@ class PytestContainerManager():
                 else:
                     break
 
-            logger.info(response)
+            if not response['tasks']:
+                logger.info(response)
 
             for task_response in response['tasks']:
                 task_arns.append(task_response['taskArn'])

--- a/scripts/xdist/pytest_container_manager.py
+++ b/scripts/xdist/pytest_container_manager.py
@@ -14,7 +14,7 @@ class PytestContainerManager():
     """
     Responsible for spinning up and terminating ECS tasks to be used with pytest-xdist
     """
-    TASK_RUN_TIMEOUT_MINUTES = 10
+    TASK_RUN_TIMEOUT_MINUTES = 20
     MAX_RUN_TASK_RETRIES = 7
 
     def __init__(self, region, cluster):

--- a/scripts/xdist/pytest_container_manager.py
+++ b/scripts/xdist/pytest_container_manager.py
@@ -65,7 +65,7 @@ class PytestContainerManager():
                     # Handle AWS throttling with an exponential backoff
                     if retry == self.MAX_RUN_TASK_RETRIES:
                         raise StandardError(
-                            "self.MAX_RUN_TASK_RETRIES ({}) reached while spinning up tasks due to AWS throttling.".format(self.MAX_RUN_TASK_RETRIES)
+                            "MAX_RUN_TASK_RETRIES ({}) reached while spinning up tasks due to AWS throttling.".format(self.MAX_RUN_TASK_RETRIES)
                         )
                     logger.info("Hit error: {}. Retrying".format(err))
                     countdown = 2 ** retry
@@ -73,6 +73,9 @@ class PytestContainerManager():
                     time.sleep(countdown)
                 else:
                     break
+
+            if not response['tasks']:
+                assert response == 'dummy_val'
 
             for task_response in response['tasks']:
                 task_arns.append(task_response['taskArn'])


### PR DESCRIPTION
Sometimes we were seeing a connection timeout when booting up ecs containers. We should be catching this error (like we are with `ClientError` and retrying.