### PR TITLE
Remove the current_grades column that is not supported by backend

### DIFF
--- a/common/static/common/templates/gradebook/_gradebook_table.underscore
+++ b/common/static/common/templates/gradebook/_gradebook_table.underscore
@@ -34,7 +34,6 @@
           </th>
         <% }) %>
   
-        <th title="Current grade"><div class="assignment-label"><%- strLib.userHeading %></div></th>
         <th title="Total"><div class="assignment-label"><%- strLib.total %></div></th>
       </tr>
     </thead>
@@ -62,11 +61,6 @@
               <%- (section.grade_description || '') %>
             </td>
           <% }) %>
-  
-          <td class="grade_<%- student.current_letter_grade %> data-score-container-class"
-              title="Current grade">
-            <%- (student.current_percent * 100).toFixed(2) %>&percnt;
-          </td>
   
           <td class="grade_<%- student.total_letter_grade %> data-score-container-class"
               title="Total">

--- a/lms/static/js/writable_gradebook.js
+++ b/lms/static/js/writable_gradebook.js
@@ -235,7 +235,6 @@ $(document).ready(function() {
                     studentsData: studentsData,
                     strLib: {
                         userHeading: gettext('Username'),
-                        currentGrade: gettext('Current grade'),
                         total: gettext('Total')
                     }
                 }).toString();


### PR DESCRIPTION
This column is currently not supported by the gradebook backend. Remove it and we may introduce this column in later.