### PR TITLE
Change bulk delete retirements to a POST

### DIFF
--- a/openedx/core/djangoapps/user_api/accounts/tests/test_retirement_views.py
+++ b/openedx/core/djangoapps/user_api/accounts/tests/test_retirement_views.py
@@ -1071,7 +1071,7 @@ class TestAccountRetirementCleanup(RetirementTestCase):
         if data is None:
             data = {'usernames': self.usernames}
 
-        response = self.client.delete(self.url, json.dumps(data), **self.headers)
+        response = self.client.post(self.url, json.dumps(data), **self.headers)
         print(response)
         self.assertEqual(response.status_code, expected_status)
         return response

--- a/openedx/core/djangoapps/user_api/accounts/views.py
+++ b/openedx/core/djangoapps/user_api/accounts/views.py
@@ -806,7 +806,7 @@ class AccountRetirementStatusView(ViewSet):
 
     def cleanup(self, request):
         """
-        DELETE /api/user/v1/accounts/update_retirement_status/
+        POST /api/user/v1/accounts/retirement_cleanup/
 
         {
             'usernames': ['user1', 'user2', ...]

--- a/openedx/core/djangoapps/user_api/urls.py
+++ b/openedx/core/djangoapps/user_api/urls.py
@@ -59,7 +59,7 @@ RETIREMENT_UPDATE = AccountRetirementStatusView.as_view({
 })
 
 RETIREMENT_CLEANUP = AccountRetirementStatusView.as_view({
-    'delete': 'cleanup',
+    'post': 'cleanup',
 })
 
 RETIREMENT_POST = AccountRetirementView.as_view({


### PR DESCRIPTION
This PR is needed for https://github.com/edx/tubular/pull/284 to work as Slumber does not allow JSON bodies in DELETE methods. 