### PR TITLE
Message related to certificate on courseware progress page are translated to platform language only. Part 2 of 2.

### DIFF
--- a/lms/djangoapps/courseware/views/views.py
+++ b/lms/djangoapps/courseware/views/views.py
@@ -21,7 +21,8 @@ from django.urls import reverse
 from django.utils.decorators import method_decorator
 from django.utils.http import urlquote_plus
 from django.utils.text import slugify
-from django.utils.translation import ugettext as _
+from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import ugettext
 from django.views.decorators.cache import cache_control
 from django.views.decorators.clickjacking import xframe_options_exempt
 from django.views.decorators.csrf import ensure_csrf_cookie
@@ -1692,7 +1693,7 @@ def financial_assistance_form(request):
                 'defaultValue': '',
                 'required': True,
                 'options': enrolled_courses,
-                'instructions': _(
+                'instructions': ugettext(
                     'Select the course for which you want to earn a verified certificate. If'
                     ' the course does not appear in the list, make sure that you have enrolled'
                     ' in the audit track for the course.'


### PR DESCRIPTION
I made a mistake on a previous pull request about this: #19107
I didn't test it properly. It should work now with this addition.

> I opened a JIRA ticket about this : https://openedx.atlassian.net/browse/LOC-112
> 
> **Background:**
> The values in the views.py is translated into the platform language before being sent to progress.html.
> This causes the strings to show only in the platform language and not the user selected one. They should only be translated once received by progress.html.
> 
> https://github.com/edx/edx-platform/blob/master/lms/templates/courseware/progress.html
> The value collected on line 74 and 75 come from the following file.
> https://github.com/edx/edx-platform/blob/master/lms/djangoapps/courseware/views/views.py
> The possible values are on line 123 to 175.
> 
> We saw the same problem on edx.org's spanish version.
> https://user-images.githubusercontent.com/17911549/46960488-acdcd880-d06c-11e8-947c-16a818867fca.png
> 
> This affects all user using another language than the platform's default language.
> 
> **LMS Updates:**
> We removed translations marker from the values in views.py and added them to progress.html
> This shows the message in the user selected language.
> https://user-images.githubusercontent.com/17911549/46961120-04c80f00-d06e-11e8-8162-c8c42bbea5a5.png
> https://user-images.githubusercontent.com/17911549/46961119-04c80f00-d06e-11e8-936a-10c08d78aea3.png
> 
> **Test:**
> 1. Use a multilingual edx-platform.
> 2. Register for a course in audit mode.
> 3. Go to the course progress page.
> 4. See message related to audit mode.
> 5. Change language.
> 6. You can do the same with verified course, but you need to be eligible for a certificate but not generated the certificate for the problematic messages to appear. A different problematic message also appear if your identity has not been verified.
> 
> **Comment:**
> The progress.html tests are hard coded to test only for english. I'm not sure how to tackle that problem.