### PR TITLE
Fix xsscommitlint JUnit XML

### DIFF
--- a/pavelib/quality.py
+++ b/pavelib/quality.py
@@ -612,6 +612,15 @@ def run_xsscommitlint():
     _write_metric(violations_count_str, metrics_report)
     # Output report to console.
     sh("cat {metrics_report}".format(metrics_report=metrics_report), ignore_error=True)
+    if num_violations:
+        fail_quality(
+            'xsscommitlint',
+            "FAILURE: XSSCommitLinter Failed.\n{error_message}\n"
+            "See {xsscommitlint_report} or run the following command to hone in on the problem:\n"
+            "  ./scripts/xss-commit-linter.sh -h".format(
+                error_message=violations_count_str, xsscommitlint_report=xsscommitlint_report
+            )
+        )
     write_junit_xml("xsscommitlint")
 
 


### PR DESCRIPTION
A recent PR failed the XSS commit linter, but this was really hard to figure out because the JUnit XML file had been generated incorrectly and a bunch of failures from a prior job on the main worker showed up instead.  This change should get XSS commit linter failures correctly captured on the job summary page, and consistently clearing data from prior jobs is captured in [TE-2793](https://openedx.atlassian.net/browse/TE-2793).