### PR TITLE
Disable JWT auth cookie.

### DIFF
--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -3180,8 +3180,6 @@ JWT_AUTH = {
     'JWT_EXPIRATION': 30,
     'JWT_IN_COOKIE_EXPIRATION': 60 * 60,
 
-    'JWT_AUTH_COOKIE': 'edx-jwt-cookie',
-
     'JWT_LOGIN_CLIENT_ID': 'login-service-client-id',
     'JWT_LOGIN_SERVICE_USERNAME': 'login_service_user',
 


### PR DESCRIPTION
This will prevent the JWT cookie from coming into play during authentication.