### PR TITLE
Fix Unicode support for bulk registration and enrollment

### DIFF
--- a/lms/djangoapps/instructor/views/api.py
+++ b/lms/djangoapps/instructor/views/api.py
@@ -350,7 +350,7 @@ def register_and_enroll_students(request, course_id):  # pylint: disable=too-man
         try:
             upload_file = request.FILES.get('students_list')
             if upload_file.name.endswith('.csv'):
-                students = [row for row in csv.reader(upload_file.read().splitlines())]
+                students = [row for row in unicodecsv.reader(UniversalNewlineIterator(upload_file), encoding='utf-8')]
                 course = get_course_by_id(course_id)
             else:
                 general_errors.append({


### PR DESCRIPTION
### Problem
When doing bulk registration and enrollment by uploading a .csv file of students (in LMS instructor dashboard), if the _name_ and _username_ fields are not ASCII text (e.g., students with Korean name), these fields may not be imported correctly.
### Solution
Read .csv file with Unicode encoding.