### PR TITLE
Update the lms cookie name reference for production

### DIFF
--- a/lms/static/js/writable_gradebook.js
+++ b/lms/static/js/writable_gradebook.js
@@ -48,7 +48,9 @@ function courseXblockUpdater(courseID, dataToSend, visibilityData, callback, err
 }
 
 function getEdxUserInfoAsObject() {
-    return JSON.parse($.cookie('edx-user-info').replace(/\\054/g, ',').replace(/^"(.*)"$/, '$1').replace(/\\"/g, '"'));
+    var edxCookie = $.cookie('prod-edx-user-info') || $.cookie('stage-edx-user-info') || $.cookie('edx-user-info');
+    return JSON.parse(edxCookie.replace(/\\054/g, ',').replace(/^"(.*)"$/, '$1').replace(/\\"/g, '"'));
+ 
 }
 
 $(document).ready(function() {


### PR DESCRIPTION
The datatable gradebook would reference a cookie that does not exist in Production. Add the production cookie value for it to quickly fix for production.

@reillz10 and @iloveagent57 Please review.