### PR TITLE
Fixup /api-docs

### DIFF
--- a/lms/envs/test.py
+++ b/lms/envs/test.py
@@ -80,6 +80,8 @@ FEATURES['ENABLE_ENROLLMENT_TRACK_USER_PARTITION'] = True
 
 FEATURES['ENABLE_BULK_ENROLLMENT_VIEW'] = True
 
+FEATURES['ENABLE_API_DOCS'] = True
+
 DEFAULT_MOBILE_AVAILABLE = True
 
 # Need wiki for courseware views to work. TODO (vshnayder): shouldn't need it.

--- a/lms/tests.py
+++ b/lms/tests.py
@@ -3,8 +3,9 @@
 import logging
 import mimetypes
 
-from django.urls import reverse
+from django.conf import settings
 from django.test import TestCase
+from django.urls import reverse
 from mock import patch
 from six import text_type
 
@@ -28,6 +29,14 @@ class LmsModuleTests(TestCase):
         for extension in extensions:
             mimetype, _ = mimetypes.guess_type('test.' + extension)
             self.assertIsNotNone(mimetype)
+
+    def test_api_docs(self):
+        """
+        Tests that requests to the `/api-docs/` endpoint do not raise an exception.
+        """
+        assert settings.FEATURES['ENABLE_API_DOCS']
+        response = self.client.get('/api-docs/')
+        self.assertEqual(200, response.status_code)
 
 
 class TemplateLookupTests(TestCase):


### PR DESCRIPTION
* The grades API views previously subclassed `GenericAPIView` to get the `paginate_queryset` and `get_paginated_response` methods out of the box.  These views aren't really suited to be Generic API Views.  They lack a `serializer_class` (they don't fit the pattern that this class requires) attribute, which breaks swagger.  This PR adds a `PaginatedAPIView` class, which simply subclasses `APIView` and adds the pagination methods to it.

* Also, this changes the test settings to enable api docs and adds a very brief test to ensure that the `/api-docs/` endpoint works.