### PR TITLE
Revert "upgrade gunicorn 19.0 and make upgrade"

### DIFF
--- a/common/djangoapps/track/views/__init__.py
+++ b/common/djangoapps/track/views/__init__.py
@@ -96,8 +96,6 @@ def server_track(request, event_type, event, page=None):
     except:
         username = "anonymous"
 
-    host_header = 'HTTP_HOST' if request is not None and 'HTTP_HOST' in request.META else 'SERVER_NAME'
-
     # define output:
     event = {
         "username": username,
@@ -110,7 +108,7 @@ def server_track(request, event_type, event, page=None):
         "agent": _get_request_header(request, 'HTTP_USER_AGENT').decode('latin1'),
         "page": page,
         "time": datetime.datetime.utcnow().replace(tzinfo=pytz.utc),
-        "host": _get_request_header(request, host_header),
+        "host": _get_request_header(request, 'SERVER_NAME'),
         "context": eventtracker.get_tracker().resolve_context(),
     }
 

--- a/common/djangoapps/util/views.py
+++ b/common/djangoapps/util/views.py
@@ -388,8 +388,6 @@ def get_feedback_form_context(request):
 
     context["additional_info"] = {}
 
-    host_header = 'HTTP_HOST' if request is not None and 'HTTP_HOST' in request.META else 'SERVER_NAME'
-
     if request.user.is_authenticated:
         context["realname"] = request.user.profile.name
         context["email"] = request.user.email
@@ -399,7 +397,7 @@ def get_feedback_form_context(request):
         context["email"] = request.POST["email"]
 
     for header, pretty in [("HTTP_REFERER", "Page"), ("HTTP_USER_AGENT", "Browser"), ("REMOTE_ADDR", "Client IP"),
-                           (host_header, "Host")]:
+                           ("SERVER_NAME", "Host")]:
         context["additional_info"][pretty] = request.META.get(header)
 
     context["support_email"] = configuration_helpers.get_value('email_from_address', settings.DEFAULT_FROM_EMAIL)

--- a/lms/djangoapps/dashboard/sysadmin.py
+++ b/lms/djangoapps/dashboard/sysadmin.py
@@ -296,14 +296,12 @@ class Users(SysadminDashboardView):
         action = request.POST.get('action', '')
         track.views.server_track(request, action, {}, page='user_sysdashboard')
 
-        host_header = 'HTTP_HOST' if request is not None and 'HTTP_HOST' in request.META else 'SERVER_NAME'
-
         if action == 'download_users':
             header = [_('username'), _('email'), ]
             data = ([u.username, u.email] for u in
                     (User.objects.all().iterator()))
             return self.return_csv('users_{0}.csv'.format(
-                request.META[host_header]), header, data)
+                request.META['SERVER_NAME']), header, data)
         elif action == 'repair_eamap':
             self.msg = u'<h4>{0}</h4><pre>{1}</pre>{2}'.format(
                 _('Repair Results'),
@@ -554,8 +552,6 @@ class Staffing(SysadminDashboardView):
         track.views.server_track(request, action, {},
                                  page='staffing_sysdashboard')
 
-        host_header = 'HTTP_HOST' if request is not None and 'HTTP_HOST' in request.META else 'SERVER_NAME'
-
         if action == 'get_staff_csv':
             data = []
             roles = [CourseInstructorRole, CourseStaffRole, ]
@@ -570,7 +566,7 @@ class Staffing(SysadminDashboardView):
                       _('role'), _('username'),
                       _('email'), _('full_name'), ]
             return self.return_csv('staff_{0}.csv'.format(
-                request.META[host_header]), header, data)
+                request.META['SERVER_NAME']), header, data)
 
         return self.get(request)
 

--- a/lms/djangoapps/instructor_task/api_helper.py
+++ b/lms/djangoapps/instructor_task/api_helper.py
@@ -135,13 +135,11 @@ def _get_xmodule_instance_args(request, task_id):
     permit old-style xqueue callbacks directly to the appropriate module in the LMS.
     The `task_id` is also passed to the tracking log function.
     """
-    host_header = 'HTTP_HOST' if request is not None and 'HTTP_HOST' in request.META else 'SERVER_NAME'
-
     request_info = {'username': request.user.username,
                     'user_id': request.user.id,
                     'ip': request.META['REMOTE_ADDR'],
                     'agent': request.META.get('HTTP_USER_AGENT', '').decode('latin1'),
-                    'host': request.META[host_header],
+                    'host': request.META['SERVER_NAME'],
                     }
 
     xmodule_instance_args = {'xqueue_callback_url_prefix': get_xqueue_callback_url_prefix(request),

--- a/requirements/edx-sandbox/base.txt
+++ b/requirements/edx-sandbox/base.txt
@@ -25,7 +25,7 @@ nose==1.3.7               # via matplotlib
 numpy==1.6.2
 pycparser==2.19
 pyparsing==2.2.0
-python-dateutil==2.7.5    # via matplotlib
+python-dateutil==2.7.3    # via matplotlib
 scipy==0.14.0
 singledispatch==3.4.0.3   # via tornado
 six==1.11.0

--- a/requirements/edx/base.in
+++ b/requirements/edx/base.in
@@ -24,7 +24,6 @@
 #    as development.in or testing.in instead.
 
 analytics-python==1.1.0             # Used for Segment analytics
-aniso8601==3.0.2                    # via tincan
 attrs                               # Reduces boilerplate code involving class attributes
 Babel==1.3                          # Internationalization utilities, used for date formatting in a few places
 bleach==1.4                         # Allowed-list-based HTML sanitizing library that escapes or strips markup and attributes; used for capa and LTI
@@ -93,7 +92,7 @@ fs==2.0.18
 fs-s3fs==0.1.8
 futures ; python_version == "2.7"   # via django-pipeline, python-swift-client, s3transfer
 glob2==0.3                          # Enhanced glob module, used in openedx.core.lib.rooted_paths
-gunicorn==19.0
+gunicorn==17.5
 help-tokens
 html5lib==0.999                     # HTML parser, used for capa problems
 ipaddr==2.1.11                      # Ip network support for Embargo feature

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -41,7 +41,7 @@ git+https://github.com/open-craft/xblock-poll@add89e14558c30f3c8dc7431e5cd6536ff
 -e common/lib/xmodule
 amqp==1.4.9               # via kombu
 analytics-python==1.1.0
-aniso8601==3.0.2
+aniso8601==3.0.2          # via tincan
 anyjson==0.3.3            # via kombu
 appdirs==1.4.3            # via fs
 argh==0.26.2
@@ -94,7 +94,7 @@ django-require==1.0.11
 django-rest-swagger==2.2.0
 django-sekizai==0.10.0
 django-ses==0.8.4
-django-simple-history==2.5.1
+django-simple-history==2.4.0
 django-splash==0.2.2
 django-statici18n==1.4.0
 django-storages==1.4.1
@@ -126,7 +126,7 @@ edx-oauth2-provider==1.2.2
 edx-opaque-keys[django]==0.4.4
 edx-organizations==1.0.0
 edx-proctoring==1.4.0
-edx-rest-api-client==1.9
+edx-rest-api-client==1.8.2
 edx-search==1.2.1
 edx-submissions==2.0.12
 edx-user-state-client==1.0.4
@@ -141,7 +141,7 @@ fs==2.0.18
 future==0.17.1            # via pyjwkest
 futures==3.2.0 ; python_version == "2.7"
 glob2==0.3
-gunicorn==19.0
+gunicorn==17.5
 hash-ring==1.3.1          # via django-memcached-hashring
 help-tokens==1.0.3
 html5lib==0.999
@@ -180,7 +180,7 @@ openapi-codec==1.3.2      # via django-rest-swagger
 path.py==8.2.1
 pathtools==0.1.2
 paver==1.3.4
-pbr==5.1.0
+pbr==5.0.0
 pdfminer==20140328
 piexif==1.0.2
 pillow==5.3.0
@@ -211,7 +211,7 @@ pyyaml==3.13
 redis==2.10.6
 reportlab==3.5.9
 requests-oauthlib==1.0.0
-requests==2.20.0
+requests==2.19.1
 rest-condition==1.0.3
 rfc6266-parser==0.0.5.post2
 rules==2.0

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -113,7 +113,7 @@ django-require==1.0.11
 django-rest-swagger==2.2.0
 django-sekizai==0.10.0
 django-ses==0.8.4
-django-simple-history==2.5.1
+django-simple-history==2.4.0
 django-splash==0.2.2
 django-statici18n==1.4.0
 django-storages==1.4.1
@@ -146,7 +146,7 @@ edx-oauth2-provider==1.2.2
 edx-opaque-keys[django]==0.4.4
 edx-organizations==1.0.0
 edx-proctoring==1.4.0
-edx-rest-api-client==1.9
+edx-rest-api-client==1.8.2
 edx-search==1.2.1
 edx-sphinx-theme==1.3.0
 edx-submissions==2.0.12
@@ -175,7 +175,7 @@ future==0.17.1
 futures==3.2.0 ; python_version == "2.7"
 fuzzywuzzy==0.17.0
 glob2==0.3
-gunicorn==19.0
+gunicorn==17.5
 hash-ring==1.3.1
 help-tokens==1.0.3
 html5lib==0.999
@@ -189,7 +189,7 @@ ipaddr==2.1.11
 ipaddress==1.0.22
 isodate==0.6.0
 isort==4.3.4
-itsdangerous==1.1.0
+itsdangerous==0.24
 itypes==1.1.0
 jinja2-pluralize==0.3.0
 jinja2==2.10
@@ -227,11 +227,11 @@ oauthlib==2.1.0
 openapi-codec==1.3.2
 pa11ycrawler==1.6.2
 packaging==18.0           # via sphinx
-parsel==1.5.1
+parsel==1.5.0
 path.py==8.2.1
 pathtools==0.1.2
 paver==1.3.4
-pbr==5.1.0
+pbr==5.0.0
 pdfminer==20140328
 piexif==1.0.2
 pillow==5.3.0
@@ -271,7 +271,7 @@ pytest-cov==2.5.1
 pytest-django==3.1.2
 pytest-forked==0.2
 pytest-randomly==1.2.3
-pytest-xdist==1.24.0
+pytest-xdist==1.23.2
 pytest==3.6.3
 python-dateutil==2.4.0
 python-levenshtein==0.12.0
@@ -290,7 +290,7 @@ radon==2.4.0
 redis==2.10.6
 reportlab==3.5.9
 requests-oauthlib==1.0.0
-requests==2.20.0
+requests==2.19.1
 rest-condition==1.0.3
 rfc6266-parser==0.0.5.post2
 rules==2.0
@@ -326,7 +326,7 @@ text-unidecode==1.2
 tincan==0.0.5
 toml==0.10.0
 tox-battery==0.5.1
-tox==3.5.3
+tox==3.5.2
 traceback2==1.4.0
 transifex-client==0.13.5
 twisted==16.6.0
@@ -340,7 +340,7 @@ urlobject==2.4.3
 user-util==0.1.5
 virtualenv==16.0.0
 voluptuous==0.11.5
-vulture==1.0
+vulture==0.29
 w3lib==1.19.0
 watchdog==0.9.0
 web-fragments==0.2.2
@@ -352,4 +352,4 @@ xblock-utils==1.2.0
 xblock==1.2.2
 xmltodict==0.11.0
 zendesk==1.1.1
-zope.interface==4.6.0
+zope.interface==4.5.0

--- a/requirements/edx/paver.in
+++ b/requirements/edx/paver.in
@@ -20,6 +20,5 @@ python-memcached==1.48              # Python interface to the memcached memory c
 requests                            # Simple interface for making HTTP requests
 urllib3<1.24                        # transifex-client 0.13.5 requires urllib3<1.24, but requests will pull in urllib3==1.24 (https://github.com/transifex/transifex-client/pull/241/files)
 stevedore==1.10.0                   # via edx-opaque-keys
-urllib3==1.23                       # via requests
 watchdog                            # Used in paver watch_assets
 wrapt==1.10.5                       # Decorator utilities used in the @timed paver task decorator

--- a/requirements/edx/paver.txt
+++ b/requirements/edx/paver.txt
@@ -17,14 +17,14 @@ mock==1.0.1
 path.py==8.2.1
 pathtools==0.1.2          # via watchdog
 paver==1.3.4
-pbr==5.1.0                # via stevedore
+pbr==5.0.0                # via stevedore
 psutil==1.2.1
 pymongo==2.9.1
 python-memcached==1.48
 pyyaml==3.13              # via watchdog
-requests==2.20.0
+requests==2.19.1
 six==1.11.0               # via edx-opaque-keys, libsass, paver, stevedore
 stevedore==1.10.0
-urllib3==1.23
+urllib3==1.23             # via requests
 watchdog==0.9.0
 wrapt==1.10.5

--- a/requirements/edx/testing.in
+++ b/requirements/edx/testing.in
@@ -25,7 +25,6 @@ edx-lint                  # pylint extensions for Open edX repositories
 pylint-plugin-utils==0.3  # required by edx-lint and pinned explicitly here because newer versions don't guarantee python 2 support.
                           # can be removed when we get to python 3
 factory_boy==2.8.1        # Library for creating test fixtures, used in many tests
-flake8==3.5.0             # via flake8-polyfill
 freezegun                 # Allows tests to mock the output of assorted datetime module functions
 httpretty                 # Library for mocking HTTP requests, used in many tests
 isort                     # For checking and fixing the order of imports

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -109,7 +109,7 @@ django-require==1.0.11
 django-rest-swagger==2.2.0
 django-sekizai==0.10.0
 django-ses==0.8.4
-django-simple-history==2.5.1
+django-simple-history==2.4.0
 django-splash==0.2.2
 django-statici18n==1.4.0
 django-storages==1.4.1
@@ -141,7 +141,7 @@ edx-oauth2-provider==1.2.2
 edx-opaque-keys[django]==0.4.4
 edx-organizations==1.0.0
 edx-proctoring==1.4.0
-edx-rest-api-client==1.9
+edx-rest-api-client==1.8.2
 edx-search==1.2.1
 edx-submissions==2.0.12
 edx-user-state-client==1.0.4
@@ -158,7 +158,7 @@ filelock==3.0.9           # via tox
 firebase-token-generator==1.3.2
 fixtures==3.0.0           # via testtools
 flake8-polyfill==1.0.2    # via radon
-flake8==3.5.0
+flake8==3.5.0             # via flake8-polyfill
 flask==1.0.2              # via moto
 freezegun==0.3.11
 fs-s3fs==0.1.8
@@ -169,7 +169,7 @@ future==0.17.1
 futures==3.2.0 ; python_version == "2.7"
 fuzzywuzzy==0.17.0
 glob2==0.3
-gunicorn==19.0
+gunicorn==17.5
 hash-ring==1.3.1
 help-tokens==1.0.3
 html5lib==0.999
@@ -182,7 +182,7 @@ ipaddr==2.1.11
 ipaddress==1.0.22
 isodate==0.6.0
 isort==4.3.4
-itsdangerous==1.1.0       # via flask
+itsdangerous==0.24        # via flask
 itypes==1.1.0
 jinja2-pluralize==0.3.0
 jinja2==2.10
@@ -218,11 +218,11 @@ oauth2==1.9.0.post1
 oauthlib==2.1.0
 openapi-codec==1.3.2
 pa11ycrawler==1.6.2
-parsel==1.5.1             # via scrapy
+parsel==1.5.0             # via scrapy
 path.py==8.2.1
 pathtools==0.1.2
 paver==1.3.4
-pbr==5.1.0
+pbr==5.0.0
 pdfminer==20140328
 piexif==1.0.2
 pillow==5.3.0
@@ -260,7 +260,7 @@ pytest-cov==2.5.1
 pytest-django==3.1.2
 pytest-forked==0.2        # via pytest-xdist
 pytest-randomly==1.2.3
-pytest-xdist==1.24.0
+pytest-xdist==1.23.2
 pytest==3.6.3
 python-dateutil==2.4.0
 python-levenshtein==0.12.0
@@ -279,7 +279,7 @@ radon==2.4.0
 redis==2.10.6
 reportlab==3.5.9
 requests-oauthlib==1.0.0
-requests==2.20.0
+requests==2.19.1
 rest-condition==1.0.3
 rfc6266-parser==0.0.5.post2
 rules==2.0
@@ -311,7 +311,7 @@ text-unidecode==1.2       # via faker
 tincan==0.0.5
 toml==0.10.0              # via tox
 tox-battery==0.5.1
-tox==3.5.3
+tox==3.5.2
 traceback2==1.4.0         # via testtools, unittest2
 transifex-client==0.13.5
 twisted==16.6.0           # via pa11ycrawler, scrapy
@@ -335,4 +335,4 @@ xblock-utils==1.2.0
 xblock==1.2.2
 xmltodict==0.11.0         # via moto
 zendesk==1.1.1
-zope.interface==4.6.0     # via twisted
+zope.interface==4.5.0     # via twisted


### PR DESCRIPTION
This reverts commit f6c215ae5baa082489aa0a38350ec923086c605b.

We had to roll this back from production because the SAML config was receiving values like https://courses.edx.org:8000/auth/complete/tpa-saml/ instead of https://courses.edx.org/auth/complete/tpa-saml/