### PR TITLE
TE-2802 Make notes visibility toggling tests more reliable

### DIFF
--- a/common/test/acceptance/tests/lms/test_lms_edxnotes.py
+++ b/common/test/acceptance/tests/lms/test_lms_edxnotes.py
@@ -1499,12 +1499,12 @@ class EdxNotesToggleNotesTest(EdxNotesTestMixin):
         """
         # Disable all notes
         self.note_unit_page.toggle_visibility()
-        self.assertEqual(len(self.note_unit_page.notes), 0)
+        self.note_unit_page.wait_for(lambda: len(self.note_unit_page.notes) == 0, u"Notes are hidden")
         self.courseware_page.go_to_sequential_position(2)
-        self.assertEqual(len(self.note_unit_page.notes), 0)
+        self.note_unit_page.wait_for(lambda: len(self.note_unit_page.notes) == 0, u"Notes are hidden")
         self.course_home_page.visit()
         self.course_home_page.outline.go_to_section(u"Test Section 1", u"Test Subsection 2")
-        self.assertEqual(len(self.note_unit_page.notes), 0)
+        self.note_unit_page.wait_for(lambda: len(self.note_unit_page.notes) == 0, u"Notes are hidden")
 
     def test_can_reenable_all_notes(self):
         """
@@ -1526,9 +1526,9 @@ class EdxNotesToggleNotesTest(EdxNotesTestMixin):
         # Enable notes to make sure that I can enable notes without refreshing
         # the page.
         self.note_unit_page.toggle_visibility()
-        self.assertGreater(len(self.note_unit_page.notes), 0)
+        self.note_unit_page.wait_for(lambda: len(self.note_unit_page.notes) > 0, u"Notes are visible")
         self.courseware_page.go_to_sequential_position(2)
-        self.assertGreater(len(self.note_unit_page.notes), 0)
+        self.note_unit_page.wait_for(lambda: len(self.note_unit_page.notes) > 0, u"Notes are visible")
         self.course_home_page.visit()
         self.course_home_page.outline.go_to_section(u"Test Section 1", u"Test Subsection 2")
-        self.assertGreater(len(self.note_unit_page.notes), 0)
+        self.note_unit_page.wait_for(lambda: len(self.note_unit_page.notes) > 0, u"Notes are visible")


### PR DESCRIPTION
`test_can_reenable_all_notes` has been failing in about 2% of test runs, apparently because the assertion about note visibility is sometimes executed before the JS to change the visibility has finished running.  Give these conditions some time to become true.