### PR TITLE
Remove a mistaken trailing comma

### DIFF
--- a/cms/djangoapps/contentstore/views/item.py
+++ b/cms/djangoapps/contentstore/views/item.py
@@ -1221,7 +1221,7 @@ def create_xblock_info(xblock, data=None, metadata=None, include_ancestor_info=F
                     'enable_timed_exams': xblock.enable_timed_exams
                 })
             elif xblock.category == 'sequential':
-                rules_url = settings.PROCTORING_SETTINGS.get('LINK_URLS', {}).get('online_proctoring_rules', ""),
+                rules_url = settings.PROCTORING_SETTINGS.get('LINK_URLS', {}).get('online_proctoring_rules', "")
                 xblock_info.update({
                     'is_proctored_exam': xblock.is_proctored_exam,
                     'online_proctoring_rules': rules_url,


### PR DESCRIPTION
This looks like it used to be a comma for the dict items just below, but was refactored to its own line.  The trailing comma makes rules_url a tuple, which it probably shouldn't be?

This was pointed out by an upgrade to pylint, but since it's all about proctoring, I figured you could look into it? Thanks.
@MichaelRoytman @davestgermain 