### PR TITLE
Prefetch/cache subsection grades for gradebook.

### DIFF
--- a/lms/djangoapps/instructor_task/tasks_helper/grades.py
+++ b/lms/djangoapps/instructor_task/tasks_helper/grades.py
@@ -22,7 +22,7 @@ from instructor_analytics.basic import list_problem_responses
 from instructor_analytics.csvs import format_dictlist
 from lms.djangoapps.certificates.models import CertificateWhitelist, GeneratedCertificate, certificate_info_for_user
 from lms.djangoapps.grades.context import grading_context, grading_context_for_course
-from lms.djangoapps.grades.models import PersistentCourseGrade
+from lms.djangoapps.grades.models import PersistentCourseGrade, PersistentSubsectionGrade
 from lms.djangoapps.grades.course_grade_factory import CourseGradeFactory
 from lms.djangoapps.teams.models import CourseTeamMembership
 from lms.djangoapps.verify_student.services import IDVerificationService
@@ -190,6 +190,7 @@ class _CourseGradeBulkContext(object):
         bulk_cache_cohorts(context.course_id, users)
         BulkRoleCache.prefetch(users)
         PersistentCourseGrade.prefetch(context.course_id, users)
+        PersistentSubsectionGrade.prefetch(context.course_id, users)
         BulkCourseTags.prefetch(context.course_id, users)
 
 

--- a/lms/djangoapps/instructor_task/tests/test_tasks_helper.py
+++ b/lms/djangoapps/instructor_task/tests/test_tasks_helper.py
@@ -413,7 +413,7 @@ class TestInstructorGradeReport(InstructorGradeReportTestCase):
 
         RequestCache.clear_all_namespaces()
 
-        expected_query_count = 48
+        expected_query_count = 49
         with patch('lms.djangoapps.instructor_task.tasks_helper.runner._get_current_task'):
             with check_mongo_calls(mongo_count):
                 with self.assertNumQueries(expected_query_count):

--- a/lms/envs/devstack_docker.py
+++ b/lms/envs/devstack_docker.py
@@ -74,3 +74,7 @@ MKTG_URLS = {
 CREDENTIALS_SERVICE_USERNAME = 'credentials_worker'
 
 COURSE_CATALOG_API_URL = 'http://edx.devstack.discovery:18381/api/v1/'
+
+# Uncomment the lines below if you'd like to see SQL statements in your devstack LMS log.
+# LOGGING['handlers']['console']['level'] = 'DEBUG'
+# LOGGING['loggers']['django.db.backends'] = {'handlers': ['console'], 'level': 'DEBUG', 'propagate': False}


### PR DESCRIPTION
https://openedx.atlassian.net/browse/EDUCATOR-3676

We know this view: https://github.com/edx/edx-platform/blob/master/lms/djangoapps/grades/api/v1/views.py#L414 can be a little bit slow for courses with a large number of enrollments.  This PR attempts to address that by pre-fetching course and subsection grades for all of the users covered by a paginated request.