### PR TITLE
Add waffle to installed_apps in openedx test settings file

### DIFF
--- a/openedx/tests/settings.py
+++ b/openedx/tests/settings.py
@@ -75,6 +75,7 @@ INSTALLED_APPS = (
     'openedx.core.djangoapps.self_paced',
     'milestones',
     'celery_utils',
+    'waffle',
 
     # Django 1.11 demands to have imported models supported by installed apps.
     'completion',


### PR DESCRIPTION
Was seeing failures on the pipeline job ([link to failure](https://build.testeng.edx.org/view/edx-platform-pipeline-pr-tests/job/edx-platform-python-pipeline-pr/1614/testReport/junit/xmodule.xmodule.tests.test_split_test_module/SplitTestModuleStudioTest/Run_Tests___commonlib_unit___test_render_author_view/)). I was able to reproduce it locally on devstack, which revealed the following stack trace:

```
ERROR:xmodule.x_module:Error creating xmodule
Traceback (most recent call last):
  File "/edx/app/edxapp/edx-platform/common/lib/xmodule/xmodule/x_module.py", line 1194, in _xmodule
    for_parent=self.get_parent() if self.has_cached_parent else None
  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/xblock/runtime.py", line 635, in construct_xblock_from_class
    *args, **kwargs
  File "/edx/app/edxapp/edx-platform/common/lib/xmodule/xmodule/split_test_module.py", line 124, in __init__
    child_descriptors = self.get_child_descriptors()
  File "/edx/app/edxapp/edx-platform/common/lib/xmodule/xmodule/split_test_module.py", line 171, in get_child_descriptors
    group_id = self.get_group_id()
  File "/edx/app/edxapp/edx-platform/common/lib/xmodule/xmodule/split_test_module.py", line 200, in get_group_id
    return partitions_service.get_user_group_id_for_partition(user, self.user_partition_id)
  File "/edx/app/edxapp/edx-platform/common/lib/xmodule/xmodule/partitions/partitions_service.py", line 145, in get_user_group_id_for_partition
    user_partition = self.get_user_partition(user_partition_id)
  File "/edx/app/edxapp/edx-platform/common/lib/xmodule/xmodule/partitions/partitions_service.py", line 168, in get_user_partition
    return _get_partition_from_id(self.course_partitions, user_partition_id)
  File "/edx/app/edxapp/edx-platform/common/lib/xmodule/xmodule/partitions/partitions_service.py", line 118, in course_partitions
    return get_all_partitions_for_course(self.get_course())
  File "/edx/app/edxapp/edx-platform/openedx/core/lib/cache_utils.py", line 74, in _decorator
    result = f(*args, **kwargs)
  File "/edx/app/edxapp/edx-platform/common/lib/xmodule/xmodule/partitions/partitions_service.py", line 39, in get_all_partitions_for_course
    all_partitions = course.user_partitions + _get_dynamic_partitions(course)
  File "/edx/app/edxapp/edx-platform/common/lib/xmodule/xmodule/partitions/partitions_service.py", line 54, in _get_dynamic_partitions
    create_content_gating_partition(course),
  File "/edx/app/edxapp/edx-platform/openedx/features/content_type_gating/partitions.py", line 44, in create_content_gating_partition
    if not (CONTENT_TYPE_GATING_FLAG.is_enabled() or CONTENT_TYPE_GATING_STUDIO_UI_FLAG.is_enabled()):
  File "/edx/app/edxapp/edx-platform/openedx/core/djangoapps/waffle_utils/__init__.py", line 331, in is_enabled
    flag_undefined_default=self.flag_undefined_default
  File "/edx/app/edxapp/edx-platform/openedx/core/djangoapps/waffle_utils/__init__.py", line 260, in is_flag_active
    from waffle.models import Flag
  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/waffle/models.py", line 101, in <module>
    class Flag(BaseModel):
  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/django/db/models/base.py", line 118, in __new__
    "INSTALLED_APPS." % (module, name)
RuntimeError: Model class waffle.models.Flag doesn't declare an explicit app_label and isn't in an application in INSTALLED_APPS.
```

I think this originated in the following PR: https://github.com/edx/edx-platform/pull/19155