### PR TITLE
Tweak script that gets test list in xdist builds

### DIFF
--- a/scripts/xdist/get_worker_test_list.py
+++ b/scripts/xdist/get_worker_test_list.py
@@ -21,19 +21,24 @@ import shutil
 )
 @click.option(
     '--test-suite',
-    help="Test suite that the pytest worker ran. Example: lms-unit",
+    help="Test suite that the pytest worker ran.",
+    type=click.Choice(['lms-unit', 'cms-unit', 'commonlib-unit']),
     required=True
 )
 def main(log_file, test_suite):
     worker_test_dict = {}
     with io.open(log_file, 'r') as console_file:
         for line in console_file:
-            regex_search = re.search(r'\[{}] \[gw(\d+)] PASSED|FAILED|SKIPPED|ERROR'.format(test_suite), line)
+            regex_search = re.search(r'\[{}] \[gw(\d+)] (PASSED|FAILED|SKIPPED|ERROR)'.format(test_suite), line)
             if regex_search:
                 worker_num_string = regex_search.group(1)
                 if worker_num_string not in worker_test_dict:
                     worker_test_dict[worker_num_string] = []
-                worker_test_dict[worker_num_string].append(line.split()[3])
+                test = line.split()[3]
+                if test_suite == "commonlib-unit":
+                    if "pavelib" not in test:
+                        test = u"common/lib/{}".format(test)
+                worker_test_dict[worker_num_string].append(test)
 
     output_folder_name = "worker_list_files"
     if os.path.isdir(output_folder_name):


### PR DESCRIPTION
1- The existing regex was causing problems, I believe this stemmed from the OR logic. Long story short, it was matching any line that contained words like `ERROR` (which sometimes is just a test name... example: `'[lms-unit] lms/djangoapps/commerce/tests/test_views.py::ReceiptViewTests::test_cybersource_decision_3_ERROR`).
2- commonlib tests need `common/lib/` at the beginning of the test (unless its a paver unit test) so that we can execute these tests from the root of edx-platform locally in devstack.