### PR TITLE
Pull Turkish translations by default

### DIFF
--- a/conf/locale/config.yaml
+++ b/conf/locale/config.yaml
@@ -77,7 +77,7 @@ locales:
     # - ta  # Tamil
     # - te  # Telugu
     # - th  # Thai
-    # - tr_TR  # Turkish (Turkey)
+    - tr_TR  # Turkish (Turkey)
     # - uk  # Ukranian
     # - ur  # Urdu
     # - uz  # Uzbek


### PR DESCRIPTION
Turkish has become the fifth most translated language by recent efforts of @AliIsingor. We think it should be enabled by default and updated regularly with edx-transifex-bot.