### PR TITLE
add babel-polyfill in commons

### DIFF
--- a/common/static/js/src/ReactRenderer.jsx
+++ b/common/static/js/src/ReactRenderer.jsx
@@ -1,10 +1,6 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 
-// babel-polyfill must be imported last because of https://github.com/facebook/react/issues/8379
-// which otherwise causes "Objects are not valid as a react child" errors in IE11.
-import 'babel-polyfill';
-
 class ReactRendererException extends Error {
   constructor(message) {
     super(`ReactRendererException: ${message}`);

--- a/webpack.common.config.js
+++ b/webpack.common.config.js
@@ -79,7 +79,8 @@ module.exports = Merge.smart({
         ReactRenderer: './common/static/js/src/ReactRenderer.jsx',
         XModuleShim: 'xmodule/js/src/xmodule.js',
 
-        VerticalStudentView: './common/lib/xmodule/xmodule/assets/vertical/public/js/vertical_student_view.js'
+        VerticalStudentView: './common/lib/xmodule/xmodule/assets/vertical/public/js/vertical_student_view.js',
+        commons : 'babel-polyfill',
     },
 
     output: {


### PR DESCRIPTION
## [EDUCATOR-3518](https://openedx.atlassian.net/browse/EDUCATOR-3518)

### Description
Moved `babel-polyfill` to 'common' bundle. This bundle contains common dependencies of all other bundles and is always loaded (and cached).
Placing `babel-polyfill` here has other pros too, like we can remove individual polyfills added in other js files and we don't have to worry about adding any polyfill in future (as long as that polyfill is present in `babel-polyfill`).

### Sandbox
- https://common.sandbox.edx.org

Sandbox uses edx.org theme so the original issue described in ticket can not be reproduced there. One can use this sandbox to review js bundles.

### Reviewers
- [ ] @cpennington 
- [ ] @awaisdar001 
- [ ] @Rabia23 
 
### Post-review
- [ ] Rebase and squash commits