### PR TITLE
Allow calling xblock_view API with OAuth creds

### DIFF
--- a/lms/djangoapps/courseware/tests/test_module_render.py
+++ b/lms/djangoapps/courseware/tests/test_module_render.py
@@ -743,21 +743,33 @@ class TestHandleXBlockCallback(SharedModuleStoreTestCase, LoginEnrollmentTestCas
         with self.assertRaises(BlockCompletion.DoesNotExist):
             BlockCompletion.objects.get(block_key=block.scope_ids.usage_id)
 
-    @patch.dict('django.conf.settings.FEATURES', {'ENABLE_XBLOCK_VIEW_ENDPOINT': True})
-    def test_xblock_view_handler(self):
-        args = [
-            'edX/toy/2012_Fall',
-            quote_slashes('i4x://edX/toy/videosequence/Toy_Videos'),
-            'student_view'
-        ]
-        xblock_view_url = reverse(
-            'xblock_view',
-            args=args
-        )
 
-        request = self.request_factory.get(xblock_view_url)
-        request.user = self.mock_user
-        response = render.xblock_view(request, *args)
+@attr(shard=1)
+@ddt.ddt
+@patch.dict('django.conf.settings.FEATURES', {'ENABLE_XBLOCK_VIEW_ENDPOINT': True})
+class TestXBlockView(SharedModuleStoreTestCase, LoginEnrollmentTestCase):
+    """
+    Test the handle_xblock_callback function
+    """
+    @classmethod
+    def setUpClass(cls):
+        super(TestXBlockView, cls).setUpClass()
+        cls.course_key = ToyCourseFactory.create().id
+        cls.toy_course = modulestore().get_course(cls.course_key)
+
+    def setUp(self):
+        super(TestXBlockView, self).setUp()
+
+        self.location = unicode(self.course_key.make_usage_key('html', 'toyhtml'))
+        self.request_factory = RequestFactory()
+
+        self.view_args = [unicode(self.course_key), quote_slashes(self.location), 'student_view']
+        self.xblock_view_url = reverse('xblock_view', args=self.view_args)
+
+    def test_xblock_view_handler(self):
+        request = self.request_factory.get(self.xblock_view_url)
+        request.user = UserFactory.create()
+        response = render.xblock_view(request, *self.view_args)
         self.assertEquals(200, response.status_code)
 
         expected = ['csrf_token', 'html', 'resources']
@@ -765,7 +777,30 @@ class TestHandleXBlockCallback(SharedModuleStoreTestCase, LoginEnrollmentTestCas
         for section in expected:
             self.assertIn(section, content)
         doc = PyQuery(content['html'])
-        self.assertEquals(len(doc('div.xblock-student_view-videosequence')), 1)
+        self.assertEquals(len(doc('div.xblock-student_view-html')), 1)
+
+    @ddt.data(True, False)
+    def test_hide_staff_markup(self, hide):
+        """
+        When xblock_view gets 'hide_staff_markup' in its context, the staff markup
+        should not be included. See 'add_staff_markup' in xblock_utils/__init__.py
+        """
+        request = self.request_factory.get(self.xblock_view_url)
+        request.user = GlobalStaffFactory.create()
+        request.session = {}
+        if hide:
+            request.GET = {'hide_staff_markup': 'true'}
+        response = render.xblock_view(request, *self.view_args)
+        self.assertEquals(200, response.status_code)
+
+        html = json.loads(response.content)['html']
+        self.assertEqual('Staff Debug Info' in html, not hide)
+
+    def test_xblock_view_handler_not_authenticated(self):
+        request = self.request_factory.get(self.xblock_view_url)
+        request.user = AnonymousUser()
+        response = render.xblock_view(request, *self.view_args)
+        self.assertEquals(401, response.status_code)
 
 
 @attr(shard=1)

--- a/openedx/core/lib/xblock_utils/__init__.py
+++ b/openedx/core/lib/xblock_utils/__init__.py
@@ -309,6 +309,9 @@ def add_staff_markup(user, disable_staff_debug_info, block, view, frag, context)
 
     Does nothing if module is a SequenceModule.
     """
+    if context and context.get('hide_staff_markup', False):
+        # If hide_staff_markup is passed, don't add the markup
+        return frag
     # TODO: make this more general, eg use an XModule attribute instead
     if isinstance(block, VerticalBlock) and (not context or not context.get('child_of_vertical', False)):
         # check that the course is a mongo backed Studio course before doing work


### PR DESCRIPTION
We have a use case where we need to use the `xblock_view` REST API programatically (with OAuth authentication), but it only supported session authentication. This is a simple change to make it support all the usual API authentication methods.

Then, when testing that, I found that the `xblock_view` would also return all the HTML for the staff debug info / staff modal widgets, which doesn't make sense for typical usage of this API. I tweaked the code that adds that HTML so that if the `hide_staff_markup` context var is set, it won't include the markup. That way, the `xblock_view` API can be called with `?hide_staff_markup=true` and it will be excluded.

**Manual Test instructions (Docker Devstack)**:
1. In lms.env.json in your docker devstack's lms-shell, add "ENABLE_XBLOCK_VIEW_ENDPOINT": true, to the FEATURES: dict, then restart the LMS.
1. Create a test OAuth Application at http://localhost:18000/admin/oauth2_provider/application/add/ (type: confidential, grant type: Resource Owner Password Based)
2. Obtain OAuth access token for your a staff user:
    ```
    curl -X POST -d "client_id={client_id}&client_secret={client_secret}&grant_type=password&username=staff&password=edx" http://localhost:18000/oauth2/access_token/
    ```
3. Verify that you can access the api with the resulting OAuth access token:
    ```
    curl http://localhost:18000/courses/course-v1:edX+DemoX+Demo_Course/xblock/block-v1:edX+DemoX+Demo_Course+type@html+block@c2f7008c9ccf4bd09d5d800c98fb0722/view/student_view -H 'Authorization: Bearer {access_token}' -v
    ```
4. Repeat that but with `?hide_staff_markup=true` added to the URL, and note that the resulting HTML is much smaller.

**Notes**:
This is related to #19253, which does the same thing for XBlock handlers, albeit via a different mechanism.