### PR TITLE
Update session cookie expiry.

### DIFF
--- a/common/djangoapps/third_party_auth/tests/specs/base.py
+++ b/common/djangoapps/third_party_auth/tests/specs/base.py
@@ -120,7 +120,7 @@ class HelperMixin(object):
         """Asserts failure on /login for missing social auth looks right."""
         self.assertEqual(403, response.status_code)
         self.assertIn(
-            "successfully logged into your %s account, but this account isn't linked" % self.provider.name,
+            "successfully logged into your %s account, but this account isn&#39;t linked" % self.provider.name,
             response.content
         )
 

--- a/openedx/core/djangoapps/user_api/tests/test_views.py
+++ b/openedx/core/djangoapps/user_api/tests/test_views.py
@@ -658,13 +658,7 @@ class LoginSessionViewTest(UserAPITestCase):
         response = self.client.get(reverse("dashboard"))
         self.assertHttpOK(response)
 
-    @ddt.data(
-        (json.dumps(True), False),
-        (json.dumps(False), True),
-        (None, True),
-    )
-    @ddt.unpack
-    def test_login_remember_me(self, remember_value, expire_at_browser_close):
+    def test_session_cookie_expiry(self):
         # Create a test user
         UserFactory.create(username=self.USERNAME, email=self.EMAIL, password=self.PASSWORD)
 
@@ -674,17 +668,13 @@ class LoginSessionViewTest(UserAPITestCase):
             "password": self.PASSWORD,
         }
 
-        if remember_value is not None:
-            data["remember"] = remember_value
-
         response = self.client.post(self.url, data)
         self.assertHttpOK(response)
 
         # Verify that the session expiration was set correctly
-        self.assertEqual(
-            self.client.session.get_expire_at_browser_close(),
-            expire_at_browser_close
-        )
+        cookie = self.client.cookies[settings.SESSION_COOKIE_NAME]
+        expected_expiry = datetime.datetime.now() + datetime.timedelta(weeks=4)
+        self.assertIn(expected_expiry.strftime('%d-%b-%Y'), cookie.get('expires'))
 
     def test_invalid_credentials(self):
         # Create a test user


### PR DESCRIPTION
Update session cookie expiry to 4 weeks regardless of remember me checkbox is checked or not. We are going to remove remember me checkbox, for more details see https://openedx.atlassian.net/browse/LEARNER-6219?focusedCommentId=347707&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-347707

LEARNER-6219