### PR TITLE
Bump xblock-drag-and-drop-v2 to v2.2.1 which includes i18n support in JS files

### DIFF
--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -35,7 +35,7 @@ git+https://github.com/edx/RecommenderXBlock.git@1.4.0#egg=recommender-xblock==1
 -e common/lib/sandbox-packages
 -e common/lib/symmath
 -e openedx/core/lib/xblock_builtin/xblock_discussion
-git+https://github.com/edx-solutions/xblock-drag-and-drop-v2@v2.1.6#egg=xblock-drag-and-drop-v2==2.1.6
+git+https://github.com/edx-solutions/xblock-drag-and-drop-v2@v2.2.1#egg=xblock-drag-and-drop-v2==2.2.1
 -e git+https://github.com/edx-solutions/xblock-google-drive.git@138e6fa0bf3a2013e904a085b9fed77dab7f3f21#egg=xblock-google-drive
 git+https://github.com/open-craft/xblock-poll@add89e14558c30f3c8dc7431e5cd6536fff6d941#egg=xblock-poll==1.5.1
 -e common/lib/xmodule

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -38,7 +38,7 @@ git+https://github.com/edx/RecommenderXBlock.git@1.4.0#egg=recommender-xblock==1
 -e common/lib/sandbox-packages
 -e common/lib/symmath
 -e openedx/core/lib/xblock_builtin/xblock_discussion
-git+https://github.com/edx-solutions/xblock-drag-and-drop-v2@v2.1.6#egg=xblock-drag-and-drop-v2==2.1.6
+git+https://github.com/edx-solutions/xblock-drag-and-drop-v2@v2.2.1#egg=xblock-drag-and-drop-v2==2.2.1
 -e git+https://github.com/edx-solutions/xblock-google-drive.git@138e6fa0bf3a2013e904a085b9fed77dab7f3f21#egg=xblock-google-drive
 git+https://github.com/open-craft/xblock-poll@add89e14558c30f3c8dc7431e5cd6536fff6d941#egg=xblock-poll==1.5.1
 -e common/lib/xmodule

--- a/requirements/edx/github.in
+++ b/requirements/edx/github.in
@@ -101,4 +101,4 @@
 
 -e git+https://github.com/mitodl/edx-sga.git@3828ba9e413080a81b907a3381e5ffa05e063f81#egg=edx-sga==0.8.3
 -e git+https://github.com/open-craft/xblock-poll@add89e14558c30f3c8dc7431e5cd6536fff6d941#egg=xblock-poll==1.5.1
--e git+https://github.com/edx-solutions/xblock-drag-and-drop-v2@v2.1.6#egg=xblock-drag-and-drop-v2==2.1.6
+-e git+https://github.com/edx-solutions/xblock-drag-and-drop-v2@v2.2.1#egg=xblock-drag-and-drop-v2==2.2.1

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -36,7 +36,7 @@ git+https://github.com/edx/RecommenderXBlock.git@1.4.0#egg=recommender-xblock==1
 -e common/lib/sandbox-packages
 -e common/lib/symmath
 -e openedx/core/lib/xblock_builtin/xblock_discussion
-git+https://github.com/edx-solutions/xblock-drag-and-drop-v2@v2.1.6#egg=xblock-drag-and-drop-v2==2.1.6
+git+https://github.com/edx-solutions/xblock-drag-and-drop-v2@v2.2.1#egg=xblock-drag-and-drop-v2==2.2.1
 -e git+https://github.com/edx-solutions/xblock-google-drive.git@138e6fa0bf3a2013e904a085b9fed77dab7f3f21#egg=xblock-google-drive
 git+https://github.com/open-craft/xblock-poll@add89e14558c30f3c8dc7431e5cd6536fff6d941#egg=xblock-poll==1.5.1
 -e common/lib/xmodule


### PR DESCRIPTION
This bumps the version of Drag and Drop v2 XBlock that includes static translations based on django-statici18n, a bugfix and an API update.

Includes:
https://github.com/edx-solutions/xblock-drag-and-drop-v2/pull/156 Adding i18n support in JS files
https://github.com/edx-solutions/xblock-drag-and-drop-v2/pull/192 Fix JavaScript error when the XBlock is in an IFrame
https://github.com/edx-solutions/xblock-drag-and-drop-v2/pull/158 Rename APIs for Native UI

Supersedes https://github.com/edx/edx-platform/pull/18302 that can be closed.

**Screenshots**:
See edx-solutions/xblock-drag-and-drop-v2#156

**Sandbox URL**:
LMS: https://pr19266.sandbox.opencraft.hosting/
Studio: https://studio-pr19266.sandbox.opencraft.hosting/

**Merge deadline**: None

**Testing instructions**:
See edx-solutions/xblock-drag-and-drop-v2#156

**Reviewers**
- [ ] @xitij2000 
- [ ] edX reviewer[s]