### PR TITLE
REVE-37: prevent studio edits to feature based enrollments

### DIFF
--- a/cms/djangoapps/contentstore/course_group_config.py
+++ b/cms/djangoapps/contentstore/course_group_config.py
@@ -10,7 +10,7 @@ from contentstore.utils import reverse_usage_url
 from lms.lib.utils import get_parent_unit
 from openedx.core.djangoapps.course_groups.partition_scheme import get_cohorted_user_partition
 from util.db import MYSQL_MAX_INT, generate_int_id
-from xmodule.partitions.partitions import MINIMUM_STATIC_PARTITION_ID, UserPartition
+from xmodule.partitions.partitions import MINIMUM_STATIC_PARTITION_ID, ReadOnlyUserPartitionError, UserPartition
 from xmodule.partitions.partitions_service import get_all_partitions_for_course
 from xmodule.split_test_module import get_split_user_partitions
 
@@ -105,7 +105,10 @@ class GroupConfiguration(object):
         """
         Get user partition for saving in course.
         """
-        return UserPartition.from_json(self.configuration)
+        try:
+            return UserPartition.from_json(self.configuration)
+        except ReadOnlyUserPartitionError:
+            raise GroupConfigurationsValidationError(_("unable to load this type of group configuration"))
 
     @staticmethod
     def _get_usage_info(course, unit, item, usage_info, group_id, scheme_name=None):

--- a/cms/djangoapps/contentstore/views/course.py
+++ b/cms/djangoapps/contentstore/views/course.py
@@ -88,6 +88,7 @@ from xmodule.error_module import ErrorDescriptor
 from xmodule.modulestore import EdxJSONEncoder
 from xmodule.modulestore.django import modulestore
 from xmodule.modulestore.exceptions import DuplicateCourseError, ItemNotFoundError
+from xmodule.partitions.partitions import UserPartition
 from xmodule.tabs import CourseTab, CourseTabList, InvalidTabsException
 
 from .component import ADVANCED_COMPONENT_TYPES
@@ -1602,6 +1603,8 @@ def group_configurations_list_handler(request, course_key_string):
             has_content_groups = False
             displayable_partitions = []
             for partition in all_partitions:
+                partition['read_only'] = getattr(UserPartition.get_scheme(partition['scheme']), 'read_only', False)
+
                 if partition['scheme'] == COHORT_SCHEME:
                     has_content_groups = True
                     displayable_partitions.append(partition)

--- a/cms/static/js/models/group_configuration.js
+++ b/cms/static/js/models/group_configuration.js
@@ -23,7 +23,8 @@ function(Backbone, _, gettext, GroupModel, GroupCollection) {
                 ]),
                 showGroups: false,
                 editing: false,
-                usage: []
+                usage: [],
+                read_only: false
             };
         },
 
@@ -78,7 +79,8 @@ function(Backbone, _, gettext, GroupModel, GroupCollection) {
                 scheme: this.get('scheme'),
                 description: this.get('description'),
                 version: this.get('version'),
-                groups: this.get('groups').toJSON()
+                groups: this.get('groups').toJSON(),
+                read_only: this.get('read_only')
             };
         },
 

--- a/cms/static/js/spec/models/group_configuration_spec.js
+++ b/cms/static/js/spec/models/group_configuration_spec.js
@@ -101,7 +101,8 @@ define([
                                 name: 'Group 2',
                                 usage: []
                             }
-                        ]
+                        ],
+                        read_only: true
                     },
                     clientModelSpec = {
                         id: 10,
@@ -124,7 +125,8 @@ define([
                                 usage: []
                             }
                         ],
-                        usage: []
+                        usage: [],
+                        read_only: true
                     },
                     model = new GroupConfigurationModel(
                         serverModelSpec, {parse: true}

--- a/cms/static/js/views/pages/group_configurations.js
+++ b/cms/static/js/views/pages/group_configurations.js
@@ -7,8 +7,7 @@ function($, _, gettext, BasePage, GroupConfigurationsListView, PartitionGroupLis
     var GroupConfigurationsPage = BasePage.extend({
         initialize: function(options) {
             var currentScheme,
-                i,
-                enrollmentScheme = 'enrollment_track';
+                i;
 
             BasePage.prototype.initialize.call(this);
             this.experimentsEnabled = options.experimentsEnabled;
@@ -26,7 +25,7 @@ function($, _, gettext, BasePage, GroupConfigurationsListView, PartitionGroupLis
                 this.allGroupViewList.push(
                     new PartitionGroupListView({
                         collection: this.allGroupConfigurations[i].get('groups'),
-                        restrictEditing: currentScheme === enrollmentScheme,
+                        restrictEditing: this.allGroupConfigurations[i].get('read_only'),
                         scheme: currentScheme
                     })
                 );

--- a/common/lib/xmodule/xmodule/partitions/partitions.py
+++ b/common/lib/xmodule/xmodule/partitions/partitions.py
@@ -40,6 +40,13 @@ class NoSuchUserPartitionGroupError(UserPartitionError):
     pass
 
 
+class ReadOnlyUserPartitionError(UserPartitionError):
+    """
+    Exception to be raised when attempting to modify a read only partition.
+    """
+    pass
+
+
 class Group(namedtuple("Group", "id name")):
     """
     An id and name for a group of students.  The id should be unique
@@ -198,6 +205,9 @@ class UserPartition(namedtuple("UserPartition", "id name description groups sche
         scheme = UserPartition.get_scheme(scheme_id)
         if not scheme:
             raise TypeError("UserPartition dict {0} has unrecognized scheme {1}".format(value, scheme_id))
+
+        if getattr(scheme, 'read_only', False):
+            raise ReadOnlyUserPartitionError("UserPartition dict {0} uses scheme {1} which is read only".format(value, scheme_id))
 
         if hasattr(scheme, "create_user_partition"):
             return scheme.create_user_partition(

--- a/openedx/core/djangoapps/user_api/tests/test_views.py
+++ b/openedx/core/djangoapps/user_api/tests/test_views.py
@@ -673,7 +673,7 @@ class LoginSessionViewTest(UserAPITestCase):
 
         # Verify that the session expiration was set correctly
         cookie = self.client.cookies[settings.SESSION_COOKIE_NAME]
-        expected_expiry = datetime.datetime.now() + datetime.timedelta(weeks=4)
+        expected_expiry = datetime.datetime.utcnow() + datetime.timedelta(weeks=4)
         self.assertIn(expected_expiry.strftime('%d-%b-%Y'), cookie.get('expires'))
 
     def test_invalid_credentials(self):

--- a/openedx/core/djangoapps/verified_track_content/partition_scheme.py
+++ b/openedx/core/djangoapps/verified_track_content/partition_scheme.py
@@ -49,21 +49,13 @@ class EnrollmentTrackUserPartition(UserPartition):
             for mode in CourseMode.modes_for_course(course_key, include_expired=True)
         ]
 
-    def from_json(self):
-        """
-        Because this partition is dynamic, `from_json` is not supported.
-        `to_json` is supported, but shouldn't be used to persist this partition
-        within the course itself (used by Studio for sending data to front-end code)
-
-        Calling this method will raise a TypeError.
-        """
-        raise TypeError("Because EnrollmentTrackUserPartition is a dynamic partition, 'from_json' is not supported.")
-
 
 class EnrollmentTrackPartitionScheme(object):
     """
     This scheme uses learner enrollment tracks to map learners into partition groups.
     """
+
+    read_only = True
 
     @classmethod
     def get_group_for_user(cls, course_key, user, user_partition, **kwargs):  # pylint: disable=unused-argument

--- a/openedx/core/djangoapps/verified_track_content/tests/test_partition_scheme.py
+++ b/openedx/core/djangoapps/verified_track_content/tests/test_partition_scheme.py
@@ -2,17 +2,18 @@
 Tests for verified_track_content/partition_scheme.py.
 """
 from datetime import datetime, timedelta
+
 import pytz
 
-from ..partition_scheme import EnrollmentTrackPartitionScheme, EnrollmentTrackUserPartition, ENROLLMENT_GROUP_IDS
-from ..models import VerifiedTrackCohortedCourse
 from course_modes.models import CourseMode
-
 from student.models import CourseEnrollment
 from student.tests.factories import UserFactory
 from xmodule.modulestore.tests.django_utils import SharedModuleStoreTestCase
 from xmodule.modulestore.tests.factories import CourseFactory
-from xmodule.partitions.partitions import UserPartition, MINIMUM_STATIC_PARTITION_ID
+from xmodule.partitions.partitions import MINIMUM_STATIC_PARTITION_ID, UserPartition, ReadOnlyUserPartitionError
+
+from ..models import VerifiedTrackCohortedCourse
+from ..partition_scheme import ENROLLMENT_GROUP_IDS, EnrollmentTrackPartitionScheme, EnrollmentTrackUserPartition
 
 
 class EnrollmentTrackUserPartitionTest(SharedModuleStoreTestCase):
@@ -60,8 +61,9 @@ class EnrollmentTrackUserPartitionTest(SharedModuleStoreTestCase):
         self.assertEqual('Test partition for segmenting users by enrollment track', user_partition_json['description'])
 
     def test_from_json_not_supported(self):
-        with self.assertRaises(TypeError):
-            EnrollmentTrackUserPartition.from_json()
+        user_partition_json = create_enrollment_track_partition(self.course).to_json()
+        with self.assertRaises(ReadOnlyUserPartitionError):
+            UserPartition.from_json(user_partition_json)
 
     def test_group_ids(self):
         """

--- a/openedx/features/content_type_gating/partitions.py
+++ b/openedx/features/content_type_gating/partitions.py
@@ -127,6 +127,8 @@ class ContentTypeGatingPartitionScheme(object):
     LIMITED_ACCESS = Group(CONTENT_TYPE_GATE_GROUP_IDS['limited_access'], 'Limited-access Users')
     FULL_ACCESS = Group(CONTENT_TYPE_GATE_GROUP_IDS['full_access'], 'Full-access Users')
 
+    read_only = True
+
     @classmethod
     def get_group_for_user(cls, course_key, user, user_partition, **kwargs):  # pylint: disable=unused-argument
         """


### PR DESCRIPTION
I would prefer modify the group configuration data for both enrollment tracks and feature based enrollments to include a field like "is_editable". This is a quick hack that is more of a POC. Haven't figured out how to do the other thing yet.