### PR TITLE
Add user partitions data to course metadata.

### DIFF
--- a/common/lib/xmodule/xmodule/partitions/partitions_service.py
+++ b/common/lib/xmodule/xmodule/partitions/partitions_service.py
@@ -41,32 +41,33 @@ def get_all_partitions_for_course(course, active_only=False):
         all_partitions = [partition for partition in all_partitions if partition.active]
     return all_partitions
 
-def get_user_partition_groups(course_key, user):
-        """
-        Collect group ID for each partition in this course for this user.
 
-        Arguments:
-            course_key (CourseKey)
-            user_partitions (list[UserPartition])
-            user (User)
+def get_user_partition_groups(course_key, user_partitions, user, partition_dict_key='name'):
+    """
+    Collect group ID for each partition in this course for this user.
+     Arguments:
+        course_key (CourseKey)
+        user_partitions (list[UserPartition])
+        user (User)
+        partition_dict_key - i.e. 'id', 'name' depending on which partition attribute you want as a key.
+     Returns:
+        dict[partition_dict_key: Group]: Mapping from user partitions to the group to
+            which the user belongs in each partition. If the user isn't
+            in a group for a particular partition, then that partition's
+            ID will not be in the dict.
+    """
 
-        Returns:
-            dict[int: Group]: Mapping from user partitions to the group to
-                which the user belongs in each partition. If the user isn't
-                in a group for a particular partition, then that partition's
-                ID will not be in the dict.
-        """
-        user_partitions = get_all_partitions_for_course(course)
-        partition_groups = {}
-        for partition in user_partitions:
-            group = partition.scheme.get_group_for_user(
-                course_key,
-                user,
-                partition,
-            )
-            if group is not None:
-                partition_groups[partition.id] = group
-        return partition_groups
+    partition_groups = {}
+    for partition in user_partitions:
+        group = partition.scheme.get_group_for_user(
+            course_key,
+            user,
+            partition,
+        )
+
+        if group is not None:
+            partition_groups[getattr(partition, partition_dict_key)] = group
+    return partition_groups
 
 
 def _get_dynamic_partitions(course):

--- a/common/lib/xmodule/xmodule/partitions/partitions_service.py
+++ b/common/lib/xmodule/xmodule/partitions/partitions_service.py
@@ -41,6 +41,33 @@ def get_all_partitions_for_course(course, active_only=False):
         all_partitions = [partition for partition in all_partitions if partition.active]
     return all_partitions
 
+def get_user_partition_groups(course_key, user):
+        """
+        Collect group ID for each partition in this course for this user.
+
+        Arguments:
+            course_key (CourseKey)
+            user_partitions (list[UserPartition])
+            user (User)
+
+        Returns:
+            dict[int: Group]: Mapping from user partitions to the group to
+                which the user belongs in each partition. If the user isn't
+                in a group for a particular partition, then that partition's
+                ID will not be in the dict.
+        """
+        user_partitions = get_all_partitions_for_course(course)
+        partition_groups = {}
+        for partition in user_partitions:
+            group = partition.scheme.get_group_for_user(
+                course_key,
+                user,
+                partition,
+            )
+            if group is not None:
+                partition_groups[partition.id] = group
+        return partition_groups
+
 
 def _get_dynamic_partitions(course):
     """

--- a/lms/djangoapps/course_blocks/transformers/tests/test_split_test.py
+++ b/lms/djangoapps/course_blocks/transformers/tests/test_split_test.py
@@ -8,9 +8,10 @@ from openedx.core.djangoapps.user_api.partition_schemes import RandomUserPartiti
 from student.tests.factories import CourseEnrollmentFactory
 from xmodule.modulestore.tests.factories import check_mongo_calls
 from xmodule.partitions.partitions import Group, UserPartition
+from xmodule.partitions.partitions_service import get_user_partition_groups
 
 from ...api import get_course_blocks
-from ..user_partitions import UserPartitionTransformer, _get_user_partition_groups
+from ..user_partitions import UserPartitionTransformer
 from .helpers import CourseStructureTestCase, create_location
 
 
@@ -202,8 +203,8 @@ class SplitTestTransformerTestCase(CourseStructureTestCase):
 
     def test_user_randomly_assigned(self):
         # user was randomly assigned to one of the groups
-        user_groups = _get_user_partition_groups(
-            self.course.id, [self.split_test_user_partition], self.user
+        user_groups = get_user_partition_groups(
+            self.course.id, [self.split_test_user_partition], self.user, 'id'
         )
         self.assertEquals(len(user_groups), 1)
 

--- a/lms/djangoapps/course_blocks/transformers/user_partitions.py
+++ b/lms/djangoapps/course_blocks/transformers/user_partitions.py
@@ -6,7 +6,7 @@ from openedx.core.djangoapps.content.block_structure.transformer import (
     BlockStructureTransformer,
     FilteringTransformerMixin
 )
-from xmodule.partitions.partitions_service import get_all_partitions_for_course
+from xmodule.partitions.partitions_service import get_user_partition_groups
 
 from .split_test import SplitTestTransformer
 from .utils import get_field_on_block
@@ -78,7 +78,7 @@ class UserPartitionTransformer(FilteringTransformerMixin, BlockStructureTransfor
         if not user_partitions:
             return [block_structure.create_universal_filter()]
 
-        user_groups = _get_user_partition_groups(usage_info.course_key, user_partitions, user)
+        user_groups = get_user_partition_groups(usage_info.course_key, user_partitions, user)
 
         group_access_filter = block_structure.create_removal_filter(
             lambda block_key: not (
@@ -239,30 +239,3 @@ class _MergedGroupAccess(object):
 
         # The user has access for every partition, grant access.
         return True
-
-
-def _get_user_partition_groups(course_key, user_partitions, user):
-    """
-    Collect group ID for each partition in this course for this user.
-
-    Arguments:
-        course_key (CourseKey)
-        user_partitions (list[UserPartition])
-        user (User)
-
-    Returns:
-        dict[int: Group]: Mapping from user partitions to the group to
-            which the user belongs in each partition. If the user isn't
-            in a group for a particular partition, then that partition's
-            ID will not be in the dict.
-    """
-    partition_groups = {}
-    for partition in user_partitions:
-        group = partition.scheme.get_group_for_user(
-            course_key,
-            user,
-            partition,
-        )
-        if group is not None:
-            partition_groups[partition.id] = group
-    return partition_groups

--- a/lms/djangoapps/course_blocks/transformers/user_partitions.py
+++ b/lms/djangoapps/course_blocks/transformers/user_partitions.py
@@ -6,7 +6,7 @@ from openedx.core.djangoapps.content.block_structure.transformer import (
     BlockStructureTransformer,
     FilteringTransformerMixin
 )
-from xmodule.partitions.partitions_service import get_user_partition_groups
+from xmodule.partitions.partitions_service import get_user_partition_groups, get_all_partitions_for_course
 
 from .split_test import SplitTestTransformer
 from .utils import get_field_on_block
@@ -78,8 +78,7 @@ class UserPartitionTransformer(FilteringTransformerMixin, BlockStructureTransfor
         if not user_partitions:
             return [block_structure.create_universal_filter()]
 
-        user_groups = get_user_partition_groups(usage_info.course_key, user_partitions, user)
-
+        user_groups = get_user_partition_groups(usage_info.course_key, user_partitions, user, 'id')
         group_access_filter = block_structure.create_removal_filter(
             lambda block_key: not (
                 has_access(user, 'staff', block_key) or

--- a/lms/djangoapps/courseware/tests/test_course_info.py
+++ b/lms/djangoapps/courseware/tests/test_course_info.py
@@ -432,9 +432,9 @@ class SelfPacedCourseInfoTestCase(LoginEnrollmentTestCase, SharedModuleStoreTest
         self.assertEqual(resp.status_code, 200)
 
     @override_waffle_flag(CONTENT_TYPE_GATING_FLAG, True)
-    def test_num_queries_instructor_paced(self):
-        self.fetch_course_info_with_queries(self.instructor_paced_course, 29, 3)
+    def gitest_num_queries_instructor_paced(self):
+        self.fetch_course_info_with_queries(self.instructor_paced_course, 31, 3)
 
     @override_waffle_flag(CONTENT_TYPE_GATING_FLAG, True)
     def test_num_queries_self_paced(self):
-        self.fetch_course_info_with_queries(self.self_paced_course, 29, 3)
+        self.fetch_course_info_with_queries(self.self_paced_course, 31, 3)

--- a/lms/djangoapps/courseware/tests/test_views.py
+++ b/lms/djangoapps/courseware/tests/test_views.py
@@ -208,8 +208,8 @@ class IndexQueryTestCase(ModuleStoreTestCase):
 
     @override_waffle_flag(CONTENT_TYPE_GATING_FLAG, True)
     @ddt.data(
-        (ModuleStoreEnum.Type.mongo, 10, 160),
-        (ModuleStoreEnum.Type.split, 4, 156),
+        (ModuleStoreEnum.Type.mongo, 10, 162),
+        (ModuleStoreEnum.Type.split, 4, 158),
     )
     @ddt.unpack
     def test_index_query_counts(self, store_type, expected_mongo_query_count, expected_mysql_query_count):

--- a/lms/djangoapps/experiments/utils.py
+++ b/lms/djangoapps/experiments/utils.py
@@ -7,6 +7,7 @@ from course_modes.models import (
 from courseware.date_summary import (
     verified_upgrade_deadline_link, verified_upgrade_link_is_valid
 )
+from xmodule.partitions.partitions_service import get_user_partition_groups, get_all_partitions_for_course
 
 
 def check_and_get_upgrade_link_and_date(user, enrollment=None, course=None):
@@ -65,6 +66,10 @@ def get_experiment_user_metadata_context(course, user):
     if user.is_authenticated:
         forum_roles = list(Role.objects.filter(users=user, course_id=course.id).values_list('name').distinct())
 
+    # get user partition data
+    partition_groups = get_all_partitions_for_course(course)
+    user_partitions = get_user_partition_groups(course.id, partition_groups, user, 'name')
+
     return {
         'upgrade_link': upgrade_link,
         'upgrade_price': unicode(get_cosmetic_verified_display_price(course)),
@@ -76,5 +81,6 @@ def get_experiment_user_metadata_context(course, user):
         'course_start': course.start,
         'course_end': course.end,
         'has_staff_access': has_staff_access,
-        'forum_roles': forum_roles
+        'forum_roles': forum_roles,
+        'partition_groups': user_partitions,
     }

--- a/lms/templates/user_metadata.html
+++ b/lms/templates/user_metadata.html
@@ -16,7 +16,8 @@ user_metadata = {
         'upgrade_price',
         'pacing_type',
         'has_staff_access',
-        'forum_roles'
+        'forum_roles',
+        'partition_groups',
     )
 }
 

--- a/openedx/features/course_experience/tests/views/test_course_updates.py
+++ b/openedx/features/course_experience/tests/views/test_course_updates.py
@@ -127,7 +127,7 @@ class TestCourseUpdatesPage(SharedModuleStoreTestCase):
         course_updates_url(self.course)
 
         # Fetch the view and verify that the query counts haven't changed
-        with self.assertNumQueries(42, table_blacklist=QUERY_COUNT_TABLE_BLACKLIST):
+        with self.assertNumQueries(44, table_blacklist=QUERY_COUNT_TABLE_BLACKLIST):
             with check_mongo_calls(4):
                 url = course_updates_url(self.course)
                 self.client.get(url)


### PR DESCRIPTION
This partition information will be used for A/B testing on our new revenue model and can be leveraged in other experiments/analytics.

https://openedx.atlassian.net/browse/REV-612