### PR TITLE
[BB-527] expand subsections when the url anchor points to them.

### DIFF
--- a/openedx/features/course_experience/static/course_experience/js/CourseOutline.js
+++ b/openedx/features/course_experience/static/course_experience/js/CourseOutline.js
@@ -96,5 +96,17 @@ export class CourseOutline {  // eslint-disable-line import/prefer-default-expor
       });
       event.stopImmediatePropagation();
     });
+
+    const urlHash = window.location.hash;
+
+    if (urlHash !== '') {
+      const button = document.getElementById(urlHash.substr(1, urlHash.length));
+      if (button.classList.contains('subsection-text')) {
+        const parentLi = button.closest('.section');
+        const parentButton = parentLi.querySelector('.section-name');
+        expandSection(parentButton);
+      }
+      expandSection(button);
+    }
   }
 }


### PR DESCRIPTION
When visiting a specific page on a course there are breadcrumbs on top linking to section and subsections this page is a part of. The breadcrumbs are links to the main course overview page with an achor in the URL pointing to the id of the relevant section. However if the anchor links to a subsection that is currently collapsed this does not work.

**Dependencies**: None

**Sandbox URL**: https://pr19283.sandbox.opencraft.hosting/, https://studio-pr19283.sandbox.opencraft.hosting/

**Merge deadline**: None 

**Testing instructions**:

1. Go to a course
2. Open a course page that is not expanded by default.
3. Click on a link in the breadcrumbs.
4. Verify the right sections were expanded.

**Author notes and concerns**:
The following commit adds a small amount of javascript to the page to automatically open the relevant (sub)sections, so the anchor in the URL works as expected. There was talk about adding specific ID's, but I think this approach using closest to find the section works too. 

**Reviewers**
- [ ] @xitij2000 
- [ ] edX reviewer[s] TBD