### PR TITLE
fix:TransactionManagementError when create an existing user through sysadmin 

### DIFF
--- a/lms/djangoapps/dashboard/sysadmin.py
+++ b/lms/djangoapps/dashboard/sysadmin.py
@@ -17,7 +17,7 @@ from django.contrib.auth.decorators import login_required
 from django.contrib.auth.models import User
 from django.core.exceptions import PermissionDenied
 from django.core.paginator import EmptyPage, PageNotAnInteger, Paginator
-from django.db import IntegrityError
+from django.db import IntegrityError, transaction
 from django.http import Http404, HttpResponse
 from django.utils import timezone
 from django.utils.decorators import method_decorator
@@ -194,7 +194,8 @@ class Users(SysadminDashboardView):
         user = User(username=uname, email=email, is_active=True)
         user.set_password(new_password)
         try:
-            user.save()
+            with transaction.atomic():
+                user.save()
         except IntegrityError:
             msg += _('Oops, failed to create user {user}, {error}').format(
                 user=user,


### PR DESCRIPTION
when I use sysadmin to create an existing user , lms get a 500 error.
But it supposed to be an 'IntegrityError' tip.
1. url:
```
http://192.168.56.20/sysadmin/
```
2. lms error log as follow:
```
Nov 12 22:23:41 ubuntu [service_variant=lms][openedx.core.djangoapps.user_api.helpers][env:sandbox] ERROR [ubuntu  32643] [helpers.py:83] - An unexpected error occurred when calling 'get_user_preferences' with arguments '(<User: staff>,)' and keyword arguments '{}' from File "/edx/app/edxapp/edx-platform/lms/djangoapps/courseware/context_processor.py", line 36, in user_timezone_locale_prefs
	    user_preferences = get_user_preferences(request.user): TransactionManagementError("An error occurred in the current transaction. You can't execute queries until the end of the 'atomic' block.",)
	Traceback (most recent call last):
	  File "/edx/app/edxapp/edx-platform/openedx/core/djangoapps/user_api/helpers.py", line 51, in _wrapped
	    return func(*args, **kwargs)
	  File "/edx/app/edxapp/edx-platform/openedx/core/djangoapps/user_api/preferences/api.py", line 76, in get_user_preferences
	    return UserPreference.get_all_preferences(existing_user)
	  File "/edx/app/edxapp/edx-platform/openedx/core/djangoapps/user_api/models.py", line 52, in get_all_preferences
	    return dict([(pref.key, pref.value) for pref in user.preferences.all()])
	  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/django/db/models/query.py", line 250, in __iter__
	    self._fetch_all()
	  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/django/db/models/query.py", line 1118, in _fetch_all
	    self._result_cache = list(self._iterable_class(self))
	  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/django/db/models/query.py", line 53, in __iter__
	    results = compiler.execute_sql(chunked_fetch=self.chunked_fetch)
	  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/django/db/models/sql/compiler.py", line 899, in execute_sql
	    raise original_exception
	TransactionManagementError: An error occurred in the current transaction. You can't execute queries until the end of the 'atomic' block.
	Nov 12 22:23:41 ubuntu [service_variant=lms][root][env:sandbox] ERROR [ubuntu  32643] [signals.py:17] - Uncaught exception from None
	Traceback (most recent call last):
	  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/django/core/handlers/exception.py", line 41, in inner
	    response = get_response(request)
	  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/django/core/handlers/base.py", line 249, in _legacy_get_response
	    response = self._get_response(request)
	  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/django/core/handlers/base.py", line 187, in _get_response
	    response = self.process_exception_by_middleware(e, request)
	  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/django/core/handlers/base.py", line 185, in _get_response
	    response = wrapped_callback(request, *callback_args, **callback_kwargs)
	  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/django/utils/decorators.py", line 185, in inner
	    return func(*args, **kwargs)
	  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/django/views/generic/base.py", line 68, in view
	    return self.dispatch(request, *args, **kwargs)
	  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/django/utils/decorators.py", line 67, in _wrapper
	    return bound_func(*args, **kwargs)
	  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/django/utils/decorators.py", line 149, in _wrapped_view
	    response = view_func(request, *args, **kwargs)
	  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/django/utils/decorators.py", line 63, in bound_func
	    return func.__get__(self, type(self))(*args2, **kwargs2)
	  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/django/utils/decorators.py", line 67, in _wrapper
	    return bound_func(*args, **kwargs)
	  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/django/contrib/auth/decorators.py", line 23, in _wrapped_view
	    return view_func(request, *args, **kwargs)
	  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/django/utils/decorators.py", line 63, in bound_func
	    return func.__get__(self, type(self))(*args2, **kwargs2)
	  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/django/utils/decorators.py", line 67, in _wrapper
	    return bound_func(*args, **kwargs)
	  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/django/views/decorators/cache.py", line 43, in _cache_controlled
	    response = viewfunc(request, *args, **kw)
	  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/django/utils/decorators.py", line 63, in bound_func
	    return func.__get__(self, type(self))(*args2, **kwargs2)
	  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/django/utils/decorators.py", line 67, in _wrapper
	    return bound_func(*args, **kwargs)
	  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/django/views/decorators/http.py", line 99, in inner
	    response = func(request, *args, **kwargs)
	  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/django/utils/decorators.py", line 63, in bound_func
	    return func.__get__(self, type(self))(*args2, **kwargs2)
	  File "/edx/app/edxapp/edx-platform/lms/djangoapps/dashboard/sysadmin.py", line 71, in dispatch
	    return super(SysadminDashboardView, self).dispatch(*args, **kwargs)
	  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/django/views/generic/base.py", line 88, in dispatch
	    return handler(request, *args, **kwargs)
	  File "/edx/app/edxapp/edx-platform/lms/djangoapps/dashboard/sysadmin.py", line 330, in post
	    return render_to_response(self.template_name, context)
	  File "/edx/app/edxapp/edx-platform/common/djangoapps/edxmako/shortcuts.py", line 169, in render_to_response
	    return HttpResponse(render_to_string(template_name, dictionary, namespace, request), **kwargs)
	  File "/edx/app/edxapp/edx-platform/common/djangoapps/edxmako/shortcuts.py", line 159, in render_to_string
	    return template.render(dictionary, request)
	  File "/edx/app/edxapp/edx-platform/common/djangoapps/edxmako/template.py", line 59, in render
	    return self.mako_template.render_unicode(**context_dictionary)
	  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/mako/template.py", line 454, in render_unicode
	    as_unicode=True)
	  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/mako/runtime.py", line 829, in _render
	    **_kwargs_for_callable(callable_, data))
	  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/mako/runtime.py", line 864, in _render_context
	    _exec_template(inherit, lclcontext, args=args, kwargs=kwargs)
	  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/mako/runtime.py", line 890, in _exec_template
	    callable_(context, *args, **kwargs)
	  File "/tmp/mako_lms/7fa50c86c772c2affd8b5a04d05a85da/main.html.py", line 330, in render_body
	    runtime._include_file(context, (static.get_template_path('header.html')), _template_uri, online_help_token=online_help_token)
	  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/mako/runtime.py", line 752, in _include_file
	    callable_(ctx, **_kwargs_for_include(callable_, context._data, **kwargs))
	  File "/tmp/mako_lms/7fa50c86c772c2affd8b5a04d05a85da/header.html.py", line 34, in render_body
	    runtime._include_file(context, (static.get_template_path(relative_path='header/header.html')), _template_uri, online_help_token=online_help_token)
	  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/mako/runtime.py", line 752, in _include_file
	    callable_(ctx, **_kwargs_for_include(callable_, context._data, **kwargs))
	  File "/tmp/mako_lms/7fa50c86c772c2affd8b5a04d05a85da/header/header.html.py", line 96, in render_body
	    runtime._include_file(context, u'navbar-authenticated.html', _template_uri, online_help_token=online_help_token)
	  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/mako/runtime.py", line 752, in _include_file
	    callable_(ctx, **_kwargs_for_include(callable_, context._data, **kwargs))
	  File "/tmp/mako_lms/7fa50c86c772c2affd8b5a04d05a85da/header/navbar-authenticated.html.py", line 126, in render_body
	    runtime._include_file(context, u'user_dropdown.html', _template_uri)
	  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/mako/runtime.py", line 752, in _include_file
	    callable_(ctx, **_kwargs_for_include(callable_, context._data, **kwargs))
	  File "/tmp/mako_lms/7fa50c86c772c2affd8b5a04d05a85da/header/user_dropdown.html.py", line 50, in render_body
	    profile_image_url = get_profile_image_urls_for_user(self.real_user)['medium']
	  File "/edx/app/edxapp/edx-platform/openedx/core/djangoapps/user_api/accounts/image_helpers.py", line 91, in get_profile_image_urls_for_user
	    if user.profile.has_profile_image:
	  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/django/db/models/fields/related_descriptors.py", line 393, in __get__
	    rel_obj = self.get_queryset(instance=instance).get(**filter_args)
	  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/django/db/models/query.py", line 374, in get
	    num = len(clone)
	  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/django/db/models/query.py", line 232, in __len__
	    self._fetch_all()
	  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/django/db/models/query.py", line 1118, in _fetch_all
	    self._result_cache = list(self._iterable_class(self))
	  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/django/db/models/query.py", line 53, in __iter__
	    results = compiler.execute_sql(chunked_fetch=self.chunked_fetch)
	  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/django/db/models/sql/compiler.py", line 899, in execute_sql
	    raise original_exception
	TransactionManagementError: An error occurred in the current transaction. You can't execute queries until the end of the 'atomic' block.
```