### PR TITLE
Educator 2234 - Avoid multiple mathjax loading on the discussion user profile page

### DIFF
--- a/common/templates/mathjax_include.html
+++ b/common/templates/mathjax_include.html
@@ -5,8 +5,11 @@
 ## MathJax configuration for Studio lives in
 ## cms/js/require-config.js.
 
+<%page args="disable_fast_preview=True" expression_filter="h"/>
 
-<%page args="disable_fast_preview=True"/>
+## Avoid loading mathjax if already loaded on the page
+
+%if context.get('load_mathjax', True):
 
 %if disable_fast_preview:
 <script type="text/javascript">
@@ -77,3 +80,4 @@
      It can't be run through static.url because MathJax uses crazy url introspection to do lazy loading of
      MathJax extension libraries -->
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.1/MathJax.js?config=TeX-MML-AM_SVG"></script>
+%endif

--- a/lms/djangoapps/courseware/views/views.py
+++ b/lms/djangoapps/courseware/views/views.py
@@ -629,6 +629,10 @@ class CourseTabView(EdxFragmentView):
             'uses_pattern_library': not uses_bootstrap,
             'disable_courseware_js': True,
         }
+        # Avoid Multiple Mathjax loading on the 'user_profile'
+        if 'profile_page_context' in kwargs:
+            context['load_mathjax'] = kwargs['profile_page_context'].get('load_mathjax', True)
+
         context.update(
             get_experiment_user_metadata_context(
                 course,

--- a/lms/djangoapps/discussion/views.py
+++ b/lms/djangoapps/discussion/views.py
@@ -581,6 +581,12 @@ def user_profile(request, course_key, user_id):
             })
         else:
             tab_view = CourseTabView()
+
+            # To avoid mathjax loading from 'mathjax_include.html'
+            # as that file causes multiple loadings of Mathjax on
+            # 'user_profile' page
+            context['load_mathjax'] = False
+
             return tab_view.get(request, unicode(course_key), 'discussion', profile_page_context=context)
     except User.DoesNotExist:
         raise Http404

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -1426,7 +1426,6 @@ dashboard_js = (
     sorted(rooted_glob(PROJECT_ROOT / 'static', 'js/dashboard/**/*.js'))
 )
 discussion_js = (
-    rooted_glob(COMMON_ROOT / 'static', 'common/js/discussion/mathjax_include.js') +
     rooted_glob(PROJECT_ROOT / 'static', 'js/customwmd.js') +
     rooted_glob(PROJECT_ROOT / 'static', 'js/mathjax_accessible.js') +
     rooted_glob(PROJECT_ROOT / 'static', 'js/mathjax_delay_renderer.js') +


### PR DESCRIPTION
## [EDUCATOR-2234](https://openedx.atlassian.net/browse/EDUCATOR-2234)

### Description
This PR addresses the problem of multiple MathJax loading on the discussion user profile page. The 'user_profile' view generates the HTML page for the discussion user profile page. With the fragment approach, mathjax is included into the page from 3 locations:
  1. common.py
  2. tab-view.html
  3. _js_body_dependencies.html

With Mathjax, if it is loaded multiple times, it sends multiple requests for its required resources. Internally, Mathjax generates the URL by the **config()** call. But only one request has correct URL and rest of the requests result in [404 error](https://github.com/mathjax/MathJax/issues/1945). With the fix in PR, it has been ensured that mathjax, wherever it is required, is only loaded once. **lms/envs/common.py** included the **mathjax_include.js** file whenever the discussion module was loaded. But the other two mentioned files included the mathjax through **mathjax_include.html**. To avoid that, a flag has been added that doesn't allow the loading of the 'mathjax_include.html'  on the 'user_profile' view. 

### Stage error link
https://courses.edx.org/courses/course-v1:Microsoft+DAT257x+3T2017/discussion/forum/users/113794

### Sandbox
 - https://educator2234.sandbox.edx.org/
 - https://preview-educator2234.sandbox.edx.org/courses/course-v1:edu2234+ed2234+2018_t2/discussion/forum/users/10

### Reviewers
If you've been tagged for review, please check your corresponding box once you've given the :+1: 
- [x] Code review: @awaisdar001

### Post-review
- [x] Rebase and squash commits