### PR TITLE
REVE-101: Fix Beta Tester Experience and Test

### DIFF
--- a/openedx/features/content_type_gating/partitions.py
+++ b/openedx/features/content_type_gating/partitions.py
@@ -24,6 +24,7 @@ from lms.djangoapps.courseware.masquerade import (
 from xmodule.partitions.partitions import Group, UserPartition, UserPartitionError
 from openedx.core.lib.mobile_utils import is_request_from_mobile_app
 from openedx.features.content_type_gating.models import ContentTypeGatingConfig
+from student.roles import CourseBetaTesterRole
 
 LOG = logging.getLogger(__name__)
 
@@ -153,6 +154,10 @@ class ContentTypeGatingPartitionScheme(object):
 
         # If there is no verified mode, all users are granted FULL_ACCESS
         if not course_mode.has_verified_mode(modes_dict):
+            return cls.FULL_ACCESS
+
+        # If the user is a beta tester for this course they are granted FULL_ACCESS
+        if CourseBetaTesterRole(course_key).has_user(user):
             return cls.FULL_ACCESS
 
         course_enrollment = apps.get_model('student.CourseEnrollment')

--- a/openedx/features/content_type_gating/tests/test_access.py
+++ b/openedx/features/content_type_gating/tests/test_access.py
@@ -16,7 +16,7 @@ from openedx.core.djangoapps.waffle_utils.testutils import override_waffle_flag
 from openedx.core.lib.url_utils import quote_slashes
 from openedx.features.content_type_gating.partitions import CONTENT_GATING_PARTITION_ID
 from openedx.features.content_type_gating.models import ContentTypeGatingConfig
-from student.roles import CourseInstructorRole, CourseStaffRole
+from student.roles import CourseBetaTesterRole, CourseInstructorRole, CourseStaffRole
 from student.tests.factories import (
     AdminFactory,
     CourseAccessRoleFactory,
@@ -384,13 +384,21 @@ class TestProblemTypeAccess(SharedModuleStoreTestCase):
         # There are two types of course team members: instructor and staff
         # they have different privileges, but for the purpose of this test the important thing is that they should both
         # have access to all graded content
+        course_team = []
         instructor = UserFactory.create()
         CourseInstructorRole(self.course.id).add_users(instructor)
+        course_team.append(instructor)
+
         staff = UserFactory.create()
         CourseStaffRole(self.course.id).add_users(staff)
+        course_team.append(staff)
+
+        beta_tester = UserFactory.create()
+        CourseBetaTesterRole(self.course.id).add_users(beta_tester)
+        course_team.append(beta_tester)
 
         # assert that all course team members have access to graded content
-        for course_team_member in [instructor, staff]:
+        for course_team_member in course_team:
             self._assert_block_is_gated(
                 block=self.blocks_dict['problem'],
                 user_id=course_team_member.id,

--- a/openedx/features/course_duration_limits/access.py
+++ b/openedx/features/course_duration_limits/access.py
@@ -18,6 +18,7 @@ from openedx.core.djangoapps.content.course_overviews.models import CourseOvervi
 from openedx.core.djangoapps.util.user_messages import PageLevelMessages
 from openedx.core.djangolib.markup import HTML
 from openedx.features.course_duration_limits.models import CourseDurationLimitConfig
+from student.roles import CourseBetaTesterRole
 
 MIN_DURATION = timedelta(weeks=4)
 MAX_DURATION = timedelta(weeks=12)
@@ -62,6 +63,10 @@ def get_user_course_expiration_date(user, course):
     CourseEnrollment = apps.get_model('student.CourseEnrollment')
     enrollment = CourseEnrollment.get_enrollment(user, course.id)
     if enrollment is None or enrollment.mode != 'audit':
+        return None
+
+    # if the user is a beta tester their access should not expire
+    if CourseBetaTesterRole(course.id).has_user(user):
         return None
 
     try:


### PR DESCRIPTION
Fix content type gating and duration gating expierence for Beta Testers

- Beta Testers are users who are granted early access to the course to
  test it out, they should not be gated on type or duration
- This change makes sure beta testers will have access to graded content
  and their access will not expire
- Added unit tests for the above change