### PR TITLE
EDUCATOR-1714 due dates are not shown for Timed exams subsections on self-paced course on studio

### DIFF
--- a/cms/templates/js/course-outline.underscore
+++ b/cms/templates/js/course-outline.underscore
@@ -218,7 +218,7 @@ if (is_proctored_exam) {
                          -
                         <span class="sr status-proctored-exam-label"> <%- exam_value %> </span>
                         <span class="status-proctored-exam-value"> <%- exam_value %> </span>
-                        <% if (xblockInfo.get('due_date')) { %>
+                        <% if (xblockInfo.get('due_date') && !course.get('self_paced')) { %>
                             <span class="status-grading-date"> <%- gettext('Due:') %> <%- xblockInfo.get('due_date') %> </span>
                         <% } %>
                     </p>

--- a/common/test/acceptance/tests/studio/test_studio_outline.py
+++ b/common/test/acceptance/tests/studio/test_studio_outline.py
@@ -1911,3 +1911,65 @@ class CourseStatusOutlineTest(CourseOutlineTest):
         self.course_outline_page.visit()
         self.course_outline_page.click_course_status_section_checklists_link()
         self.checklists.wait_for_page()
+
+
+class InstructorPacedToSelfPacedOutlineTest(CourseOutlineTest):
+    """
+    Test the course outline when pacing is changed from
+    instructor to self paced.
+    """
+    def populate_course_fixture(self, course_fixture):
+        course_fixture.add_children(
+            XBlockFixtureDesc('chapter', SECTION_NAME).add_children(
+                XBlockFixtureDesc('sequential', SUBSECTION_NAME).add_children(
+                    XBlockFixtureDesc('vertical', UNIT_NAME)
+                )
+            ),
+        )
+        self.course_fixture.add_course_details({
+            'start_date': datetime.now() + timedelta(days=1),
+        })
+        self.course_fixture.add_advanced_settings({
+            'enable_timed_exams': {
+                'value': True
+            }
+        })
+
+    def test_due_dates_not_shown(self):
+        """
+        Scenario: Ensure that due dates for timed exams
+            are not displayed on the course outline page when switched to
+            self-paced mode from instructor-paced.
+
+        Given an instructor paced course, add a due date for a subsection.
+        Change the course's pacing to self-paced.
+        Make the subsection a timed exam.
+        Make sure adding the timed exam doesn't display the due date.
+        """
+        self.course_outline_page.visit()
+        section = self.course_outline_page.section(SECTION_NAME)
+        subsection = section.subsection(SUBSECTION_NAME)
+
+        modal = subsection.edit()
+        modal.due_date = '5/14/2016'
+        modal.policy = 'Homework'
+        modal.save()
+        # Checking if the added due date saved
+        self.assertIn('May 14', subsection.due_date)
+        # Checking if grading policy added
+        self.assertEqual('Homework', subsection.policy)
+
+        # Updating the course mode to self-paced
+        self.course_fixture.add_course_details({
+            'self_paced': True
+        })
+        # Making the subsection a timed exam
+        self.course_outline_page.open_subsection_settings_dialog()
+        self.course_outline_page.select_advanced_tab()
+        self.course_outline_page.make_exam_timed()
+
+        # configure call to actually update course with new settings
+        self.course_fixture.configure_course()
+        # Reloading page after the changes
+        self.course_outline_page.visit()
+        self.assertIsNone(subsection.due_date)


### PR DESCRIPTION
### [EDUCATOR-1714](https://openedx.atlassian.net/browse/EDUCATOR-1714)
### Description
On the studio course layout, the due dates are displayed for the Instructor paced course. Even if due dates are specified and later, the pacing is changed to **self-paced**, the due dates are not shown. But there is a bug that if the sub-section is a special exam, such as a timed exam, the due dates are shown. The problem is only UI based and doesn't affect the working/pacing of course. This PR addresses the issue by adding a check to display due date for a special exam subsection only when the course is instructor-paced.
#### Before Fix
![image](https://user-images.githubusercontent.com/40599381/48980206-f991e580-f0e7-11e8-9bd3-5697d6f79248.png)

#### After Fix
![image](https://user-images.githubusercontent.com/40599381/48980214-0dd5e280-f0e8-11e8-950c-e9fa54e16e74.png)

### Sandbox
 - [Sandbox](http://educator1714.sandbox.edx.org/)
 - [Test Course](https://studio-educator1714.sandbox.edx.org/course/course-v1:edArb+Ed1714+2018_t2)

### Reviewers

 - [x] @Rabia23 
 - [x] @awaisdar001 

### Post Review
- [x] Squash & Rebase Commits
