### PR TITLE
escape json for use in js

### DIFF
--- a/common/templates/xblock_wrapper.html
+++ b/common/templates/xblock_wrapper.html
@@ -1,7 +1,11 @@
-<div class="${' '.join(classes) | n}" ${data_attributes}>
+## xss-lint: disable=mako-missing-default
+<%!
+from openedx.core.djangolib.js_utils import dump_js_escaped_json
+%>
+<div class="${' '.join(classes) | n, decode.utf8}" ${data_attributes}>
 % if js_init_parameters:
   <script type="json/xblock-args" class="xblock-json-init-args">
-    ${js_init_parameters}
+    ${js_init_parameters | n, dump_js_escaped_json}
   </script>
 % endif
   ${content}

--- a/lms/djangoapps/courseware/tests/test_module_render.py
+++ b/lms/djangoapps/courseware/tests/test_module_render.py
@@ -1466,7 +1466,7 @@ class JsonInitDataTest(ModuleStoreTestCase):
 
     @ddt.data(
         ({'a': 17}, '''{"a": 17}'''),
-        ({'xss': '</script>alert("XSS")'}, r'''{"xss": "<\/script>alert(\"XSS\")"}'''),
+        ({'xss': '</script>alert("XSS")'}, r'''{"xss": "\u003c/script\u003ealert(\"XSS\")"}'''),
     )
     @ddt.unpack
     @XBlock.register_temp_plugin(XBlockWithJsonInitData, identifier='withjson')

--- a/openedx/core/lib/xblock_utils/__init__.py
+++ b/openedx/core/lib/xblock_utils/__init__.py
@@ -139,14 +139,13 @@ def wrap_xblock(
     template_context = {
         'content': block.display_name if display_name_only else frag.content,
         'classes': css_classes,
-        'display_name': block.display_name_with_default_escaped,
+        'display_name': block.display_name_with_default_escaped,  # xss-lint: disable=python-deprecated-display-name
         'data_attributes': u' '.join(u'data-{}="{}"'.format(markupsafe.escape(key), markupsafe.escape(value))
                                      for key, value in data.iteritems()),
     }
 
     if hasattr(frag, 'json_init_args') and frag.json_init_args is not None:
-        # Replace / with \/ so that "</script>" in the data won't break things.
-        template_context['js_init_parameters'] = json.dumps(frag.json_init_args).replace("/", r"\/")
+        template_context['js_init_parameters'] = frag.json_init_args
     else:
         template_context['js_init_parameters'] = ""
 
@@ -215,8 +214,7 @@ def wrap_xblock_aside(
     }
 
     if hasattr(frag, 'json_init_args') and frag.json_init_args is not None:
-        # Replace / with \/ so that "</script>" in the data won't break things.
-        template_context['js_init_parameters'] = json.dumps(frag.json_init_args).replace("/", r"\/")
+        template_context['js_init_parameters'] = frag.json_init_args
     else:
         template_context['js_init_parameters'] = ""
 
@@ -443,6 +441,7 @@ def get_course_update_items(course_updates, provided_index=0):
         except (etree.XMLSyntaxError, etree.ParserError):
             log.error("Cannot parse: " + course_updates.data)
             escaped = escape(course_updates.data)
+            # xss-lint: disable=python-concat-html
             course_html_parsed = html.fromstring("<ol><li>" + escaped + "</li></ol>")
 
         # confirm that root is <ol>, iterate over <li>, pull out <h2> subs and then rest of val


### PR DESCRIPTION
## [EDUCATOR-3655](https://openedx.atlassian.net/browse/EDUCATOR-3655)

### Description
We are passing json as arguments to js file. That json needs to be escaped properly so it is not mistaken for html.

### Sandbox
To test the fix on sandbox, one can try to reproduce behavior mentioned in ticket. 
- [ ] http://escaping.sandbox.edx.org/

### Reviewers
- [ ] @asadazam93 
- [ ] @Rabia23 

 
### Post-review
- [ ] Rebase and squash commits