### PR TITLE
OSPR-2818 - Add Contact Us form customization options (BB-548)

### DIFF
--- a/lms/djangoapps/branding/api.py
+++ b/lms/djangoapps/branding/api.py
@@ -170,11 +170,57 @@ def _footer_social_links():
     return links
 
 
+def _build_support_form_url(full_path=False):
+    """
+    Return the support form path
+
+    Returns url of support form, which can have 3 possible values:
+    - '' if the contact form is disabled (by setting SiteConfiguration
+      `CONTACT_US_ENABLE = False`)
+
+    - The normal edx support form path using reverse("support:contact_us") if
+      `CONTACT_US_ENABLE = True` and a custom link isn't set on
+      CONTACT_US_CUSTOM_LINK. There's the optional parameter `full_path`, that
+      if set to True will append the LMS base url to the relative path before
+      returning.
+
+    - CONTACT_US_CUSTOM_LINK if the the user has set a custom URL redirect
+      for support forms (by setting `CONTACT_US_ENABLE = True` and
+      `CONTACT_US_CUSTOM_LINK = http://some.url/for/contact`).
+      If this is set, the returned link is the content of
+      CONTACT_US_CUSTOM_LINK and the `full_path` variable is ignored since this
+      is a path outside the LMS
+
+    Parameters:
+        - full_path: bool. Appends base_url to returned value if
+                     `CONTACT_US_ENABLE = True`and no link is set on
+                     `CONTACT_US_CUSTOM_LINK`
+
+    Returns: string
+
+    """
+    contact_us_page = ''
+
+    if configuration_helpers.get_value('CONTACT_US_ENABLE', True):
+        # Gets custom url ad check if it's enabled
+        contact_us_page = configuration_helpers.get_value('CONTACT_US_CUSTOM_LINK', '')
+
+        # If no custom link is set, get default support form using reverse
+        if not contact_us_page:
+            contact_us_page = reverse("support:contact_us")
+
+            # Prepend with lms base_url if specified by `full_path`
+            if full_path:
+                contact_us_page = '{}{}'.format(settings.LMS_ROOT_URL, contact_us_page)
+
+    return contact_us_page
+
+
 def _footer_connect_links(language=settings.LANGUAGE_CODE):
     """Return the connect links to display in the footer. """
     links = [
         ("blog", (marketing_link("BLOG"), _("Blog"))),
-        ("contact", (_build_support_form_url(), _("Contact Us"))),
+        ("contact", (_build_support_form_url(full_path=True), _("Contact Us"))),
         ("help-center", (settings.SUPPORT_SITE_LINK, _("Help Center"))),
     ]
 
@@ -193,10 +239,6 @@ def _footer_connect_links(language=settings.LANGUAGE_CODE):
     ]
 
 
-def _build_support_form_url():
-    return '{base_url}/support/contact_us'.format(base_url=settings.LMS_ROOT_URL)
-
-
 def _find_position_of_link(links, key):
     "Returns position of the link to be inserted"
     for link in links:
@@ -213,7 +255,7 @@ def _footer_navigation_links(language=settings.LANGUAGE_CODE):
                         _("{platform_name} for Business").format(platform_name=platform_name))),
         ("blog", (marketing_link("BLOG"), _("Blog"))),
         ("help-center", (settings.SUPPORT_SITE_LINK, _("Help Center"))),
-        ("contact", (reverse("support:contact_us"), _("Contact"))),
+        ("contact", (_build_support_form_url(), _("Contact"))),
         ("careers", (marketing_link("CAREERS"), _("Careers"))),
         ("donate", (marketing_link("DONATE"), _("Donate"))),
     ]

--- a/lms/djangoapps/support/views/contact_us.py
+++ b/lms/djangoapps/support/views/contact_us.py
@@ -2,6 +2,7 @@
 Signle support contact view
 """
 from django.conf import settings
+from django.http import Http404
 from django.views.generic import View
 from edxmako.shortcuts import render_to_response
 from student.models import CourseEnrollment
@@ -16,6 +17,9 @@ class ContactUsView(View):
     """
 
     def get(self, request):
+        if not configuration_helpers.get_value('CONTACT_US_PAGE', True):
+            raise Http404
+
         context = {
             'platform_name': configuration_helpers.get_value('platform_name', settings.PLATFORM_NAME),
             'support_email': configuration_helpers.get_value('CONTACT_EMAIL', settings.CONTACT_EMAIL),


### PR DESCRIPTION
This adds functionality on LMS to disable the "Contact Us" and to customize the "Contact Us" link with a custom URL. 
To allow for this customization, two SiteConfiguration variables were added:
* CONTACT_US_ENABLE: Switch to enable/disable the Contact Us page. Setting this to
False will disable the contact page and the links on the footer will disappear.
* CONTACT_US_CUSTOM_LINK: If the contact page is enabled, this setting allows to set
a custom URL for the Contact Us links on edx-platform. If this setting is not set,
the platform will use the default contact form.

**JIRA tickets**: [OSPR-2818](https://openedx.atlassian.net/browse/OSPR-2818).

**Dependencies**: None.

**Sandbox URL**: [Sandbox here.](https://pr19315.sandbox.opencraft.hosting/)

**Merge deadline**: None.

**Testing instructions**:

1. Check if the "Contact Us" footer link is working properly
2. Go to django admin -> site configuration and add `"CONTACT_US_ENABLE" = false`
3. Reload django configs and check that the "Contact Us" button disappeared from the LMS as shown on screenshot
4. Go to django admin -> site configuration and change `"CONTACT_US_ENABLE" = true` and `"CONTACT_US_CUSTOM_LINK": "https://open.edx.org/"`
5. Reload django configs and check that the "Contact Us" button leads to https://open.edx.org/

**Reviewers**
- [ ] @xitij2000 
- [ ] edX reviewer[s] TBD
