### PR TITLE
Add email_verified field in JWT token

### DIFF
--- a/openedx/core/djangoapps/oauth_dispatch/jwt.py
+++ b/openedx/core/djangoapps/oauth_dispatch/jwt.py
@@ -115,6 +115,7 @@ def _create_jwt(
         'sub': anonymous_id_for_user(user, None),
         'filters': filters or [],
         'is_restricted': is_restricted,
+        'email_verified': user.is_active,
     }
     payload.update(additional_claims or {})
     _update_from_additional_handlers(payload, user, scopes)

--- a/openedx/core/djangoapps/oauth_dispatch/tests/mixins.py
+++ b/openedx/core/djangoapps/oauth_dispatch/tests/mixins.py
@@ -63,6 +63,7 @@ class AccessTokenMixin(object):
             'scopes': scopes,
             'version': settings.JWT_AUTH['JWT_SUPPORTED_VERSION'],
             'sub': anonymous_id_for_user(user, None),
+            'email_verified': user.is_active,
         }
 
         if 'email' in scopes:

--- a/openedx/core/djangoapps/oauth_dispatch/tests/test_jwt.py
+++ b/openedx/core/djangoapps/oauth_dispatch/tests/test_jwt.py
@@ -82,7 +82,11 @@ class TestCreateJWTs(AccessTokenMixin, TestCase):
             )
             self._assert_jwt_is_valid(jwt_token, should_be_asymmetric_key=scopes_enforced and client_restricted)
 
-    def test_create_jwt_for_user(self):
+    @ddt.data(True, False)
+    def test_create_jwt_for_user(self, user_email_verified):
+        self.user.is_active = user_email_verified
+        self.user.save()
+
         aud = 'test_aud'
         secret = 'test_secret'
         additional_claims = {'claim1_key': 'claim1_val'}
@@ -91,3 +95,4 @@ class TestCreateJWTs(AccessTokenMixin, TestCase):
             jwt_token, self.user, self.default_scopes, aud=aud, secret=secret,
         )
         self.assertDictContainsSubset(additional_claims, token_payload)
+        self.assertEqual(user_email_verified, token_payload['email_verified'])


### PR DESCRIPTION
Allow OAuth Clients to check whether the user associated with the JWT token has a verified email address.

https://openedx.atlassian.net/browse/LEARNER-6776