### PR TITLE
BB-547 - Fix certificate api when retrieving certificates from deleted courses

### DIFF
--- a/lms/djangoapps/certificates/tests/test_api.py
+++ b/lms/djangoapps/certificates/tests/test_api.py
@@ -14,6 +14,7 @@ from django.test.utils import override_settings
 from django.utils import timezone
 from freezegun import freeze_time
 from mock import patch
+from opaque_keys.edx.keys import CourseKey
 from opaque_keys.edx.locator import CourseLocator
 import pytz
 
@@ -359,6 +360,7 @@ class CertificateGetTests(SharedModuleStoreTestCase):
         cls.student = UserFactory()
         cls.student_no_cert = UserFactory()
         cls.uuid = uuid.uuid4().hex
+        cls.nonexistent_course_id = CourseKey.from_string('course-v1:some+fake+course')
         cls.web_cert_course = CourseFactory.create(
             org='edx',
             number='verified_1',
@@ -390,6 +392,12 @@ class CertificateGetTests(SharedModuleStoreTestCase):
             download_url='www.gmail.com',
             grade="0.99",
             verify_uuid=cls.uuid,
+        )
+        # certificate for a course that will be deleted
+        GeneratedCertificateFactory.create(
+            user=cls.student,
+            course_id=cls.nonexistent_course_id,
+            status=CertificateStatuses.downloadable
         )
 
     @classmethod
@@ -493,6 +501,17 @@ class CertificateGetTests(SharedModuleStoreTestCase):
             uuid=self.uuid
         )
         self.assertEqual('www.gmail.com', cert_url)
+
+    def test_get_certificate_with_deleted_course(self):
+        """
+        Test the case when there is a certificate but the course was deleted.
+        """
+        self.assertIsNone(
+            certs_api.get_certificate_for_user(
+                self.student.username,
+                self.nonexistent_course_id
+            )
+        )
 
 
 @attr(shard=1)


### PR DESCRIPTION
Fix a problem with the Certificates API that make it fail when trying to retrieve user certificates from courses that don't exist anymore. The problem lies in the Certificate API not checking if the courses being retrieved by some user actually exist.

This issue was found when investigating why a user profile page (*/u/username*) was returning 404's. Turns out that **LearnerAchievementsFragmentView** used the certificates api to retrieve certificate information, which did not check if the course exists before trying to pull information from it, resulting in a cascade of errors that lead to a 404 on the user's profile page.

The issue happens at line **37** of file _/home/giovanni-opencraft/opencraft/edx-platform/openedx/features/learner_profile/views/learner_achievements.py_: 
```
course_certificates = certificate_api.get_certificates_for_user(username)
```

**JIRA tickets**: [OSPR-2841](https://openedx.atlassian.net/browse/OSPR-2841).

**Sandbox URL**: [Click here](https://pr19329.sandbox.opencraft.hosting/).

**Merge deadline**: None.

**Testing instructions:**
1. Creating a test course.
2. Giving a user a certificate in this course.
3. Deleting this test course.
4. Accessing the user's profile before and after the fix.

**Author notes and concerns**:

1. This is a fix for existing views and to make the Certificates API more error tolerant. I think that a fix on methods that delete courses is needed to prevent this kind on inconsistencies.

**Reviewers**
- [ ] @xitij2000 
- [ ] edX reviewer[s] TBD
