### PR TITLE
Revert any test db cache changes after test_a11y

### DIFF
--- a/scripts/accessibility-tests.sh
+++ b/scripts/accessibility-tests.sh
@@ -36,5 +36,8 @@ SELENIUM_BROWSER=chrome BOKCHOY_HEADLESS=true $TOX paver test_a11y
 # The settings that we use are installed with the pa11ycrawler module
 export SCRAPY_SETTINGS_MODULE='pa11ycrawler.settings'
 
+echo "Reset db cache files to remove any changes from running a11y tests"
+git checkout -- common/test/db_cache
+
 echo "Running pa11ycrawler against test course..."
 $TOX paver pa11ycrawler --fasttest --skip-clean --fetch-course --with-html


### PR DESCRIPTION
We were seeing a11y failures on: https://github.com/edx/edx-platform/pull/19287#issuecomment-442498549 .

Basically in the test_a11y paver step, a fingerprint was calculated, and the cache files were pulled from s3. When it became time to run pa11ycrawler, the database itself got cleared but the files from s3 were not. This drift resulted in a different fingerprint, and led django to incorrectly think it had no migrations to run on the database.