### PR TITLE
Discussion forum title input programmatic association

### DIFF
--- a/common/static/common/templates/discussion/new-post.underscore
+++ b/common/static/common/templates/discussion/new-post.underscore
@@ -32,13 +32,14 @@
     <% } %>
     <div class="post-field group-visibility" id="wrapper-visibility-message"></div>
     <div class="post-field">
-        <label class="field-label">
+        <label class="field-label" for='discussion-forum-title'>
             <span class="field-label-text"><%- gettext("Title") %></span>
+
             <div class="field-help" id="field_help_title">
                 <%- gettext("Add a clear and descriptive title to encourage participation. (Required)") %>
             </div>
             <div>
-                <input aria-describedby="field_help_title" type="text" class="js-post-title field-input" name="title">
+                <input id='discussion-forum-title' aria-describedby="field_help_title" type="text" class="js-post-title field-input" name="title">
             </div>
         </label>
     </div>

--- a/common/static/common/templates/discussion/thread-edit.underscore
+++ b/common/static/common/templates/discussion/thread-edit.underscore
@@ -2,12 +2,13 @@
 <ul class="post-errors"></ul>
 <div class="forum-edit-post-form-wrapper"></div>
 <div class="post-field">
-    <label class="field-label">
+    <label class="field-label" for='edit-discussion-forum-title'>
         <span class="field-label-text"><%- gettext("Title") %></span>
+
         <div class="field-help" id="field_help_title">
             <%- gettext("Add a clear and descriptive title to encourage participation. (Required)") %>
         </div>
-        <input aria-describedby="field_help_title" type="text" class="edit-post-title field-input" name="title" value="<%- title %>">
+        <input id='edit-discussion-forum-title' aria-describedby="field_help_title" type="text" class="edit-post-title field-input" name="title" value="<%- title %>">
     </label>
 </div>
 <div class="form-row post-field">


### PR DESCRIPTION
### [EDUCATOR-3604](https://openedx.atlassian.net/browse/EDUCATOR-3604)

### Description
For adding/editing a discussion post, the resultant HTML of the structure had an accessibility inconsistency. To input the title of the post, the code was wrapped with label. Even though _input_ was within label, it didn't comply with WCAG 2.1 and required modification to associate label and input via **for** attribute.

### Sandbox
[Link](https://educator3604.sandbox.edx.org)

### Accessibility Verification
After adjusting the label tag for title input, the resultant structure of both 'Add a Post' and 'Edit Post' has been verified with **WAVE Accessibility Toolbar**. 

#### _Add a Post_
![suggestion_new_post](https://user-images.githubusercontent.com/40599381/49295574-ee6bfa80-f4d7-11e8-8a9c-7c464da316f3.png)

#### _Editing a Post_
![suggestion_edit_post](https://user-images.githubusercontent.com/40599381/49295580-f2981800-f4d7-11e8-925f-60b768fa3270.png)

### Reviewers
- [ ] @awaisdar001 
- [ ] @noraiz-anwar 
- [ ] @wittjeff 

### Post Review
 - [ ] Squash & Rebase Commits