### PR TITLE
Allow users to update their profile when parental consent is disabled and there's no year of birth

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -290,3 +290,4 @@ Matt Tuchfarber <mtuchfarber@edx.org>
 Stuart Young <syoung@edx.org>
 Michael Youngstrom <myoungstrom@edx.org>
 Sahar Markovich <sahar.markovich@gmail.com>
+Gustavo Sampaio <gbritosampaio@gmail.com>

--- a/common/djangoapps/student/models.py
+++ b/common/djangoapps/student/models.py
@@ -530,7 +530,7 @@ class UserProfile(models.Model):
              True if the user requires parental consent.
         """
         if age_limit is None:
-            age_limit = getattr(settings, 'PARENTAL_CONSENT_AGE_LIMIT', None)
+            age_limit = configuration_helpers.get_value('PARENTAL_CONSENT_AGE_LIMIT', settings.PARENTAL_CONSENT_AGE_LIMIT)
             if age_limit is None:
                 return False
 

--- a/common/djangoapps/student/tests/test_parental_controls.py
+++ b/common/djangoapps/student/tests/test_parental_controls.py
@@ -5,7 +5,7 @@ import datetime
 from django.test import TestCase
 from django.test.utils import override_settings
 from django.utils.timezone import now
-
+from openedx.core.djangoapps.site_configuration.tests.test_util import with_site_configuration
 from student.models import UserProfile
 from student.tests.factories import UserFactory
 
@@ -35,6 +35,18 @@ class ProfileParentalControlsTest(TestCase):
 
     @override_settings(PARENTAL_CONSENT_AGE_LIMIT=None)
     def test_no_parental_controls(self):
+        """Verify the behavior for all users when parental controls are not enabled."""
+        self.assertFalse(self.profile.requires_parental_consent())
+        self.assertFalse(self.profile.requires_parental_consent(default_requires_consent=True))
+        self.assertFalse(self.profile.requires_parental_consent(default_requires_consent=False))
+
+        # Verify that even a child does not require parental consent
+        current_year = now().year
+        self.set_year_of_birth(current_year - 10)
+        self.assertFalse(self.profile.requires_parental_consent())
+
+    @with_site_configuration(configuration={'PARENTAL_CONSENT_AGE_LIMIT': None})
+    def test_no_parental_controls_site_configuration(self):
         """Verify the behavior for all users when parental controls are not enabled."""
         self.assertFalse(self.profile.requires_parental_consent())
         self.assertFalse(self.profile.requires_parental_consent(default_requires_consent=True))

--- a/lms/static/js/student_account/models/user_account_model.js
+++ b/lms/static/js/student_account/models/user_account_model.js
@@ -52,6 +52,11 @@
 
             profileImageUrl: function() {
                 return this.get('profile_image').image_url_large;
+            },
+
+            isBirthYearDefined: function() {
+                var yearOfBirth = this.get('year_of_birth');
+                return !(_.isUndefined(yearOfBirth) || _.isNull(yearOfBirth));
             }
         });
         return UserAccountModel;

--- a/lms/static/js/student_account/models/user_account_model.js
+++ b/lms/static/js/student_account/models/user_account_model.js
@@ -52,12 +52,6 @@
 
             profileImageUrl: function() {
                 return this.get('profile_image').image_url_large;
-            },
-
-            isAboveMinimumAge: function() {
-                var yearOfBirth = this.get('year_of_birth');
-                var isBirthDefined = !(_.isUndefined(yearOfBirth) || _.isNull(yearOfBirth));
-                return isBirthDefined && !(this.get('requires_parental_consent'));
             }
         });
         return UserAccountModel;

--- a/openedx/features/learner_profile/static/learner_profile/js/learner_profile_factory.js
+++ b/openedx/features/learner_profile/static/learner_profile/js/learner_profile_factory.js
@@ -79,6 +79,7 @@
                 ],
                 helpMessage: '',
                 accountSettingsPageUrl: options.account_settings_page_url,
+                parentalConsentAgeLimit: options.parental_consent_age_limit,
                 persistChanges: true
             });
 

--- a/openedx/features/learner_profile/static/learner_profile/js/spec/learner_profile_factory_spec.js
+++ b/openedx/features/learner_profile/static/learner_profile/js/spec/learner_profile_factory_spec.js
@@ -34,6 +34,7 @@ define(
                     badges_api_url: Helpers.BADGES_API_URL,
                     own_profile: ownProfile,
                     account_settings_page_url: Helpers.USER_ACCOUNTS_API_URL,
+                    parental_consent_age_limit: 13,
                     country_options: Helpers.FIELD_OPTIONS,
                     language_options: Helpers.FIELD_OPTIONS,
                     has_preferences_access: true,
@@ -66,6 +67,13 @@ define(
                     learnerProfileView = context.learnerProfileView;
 
                 LearnerProfileHelpers.expectLimitedProfileSectionsAndFieldsToBeRendered(learnerProfileView);
+            });
+
+            it("renders the full profile for undefined 'year_of_birth' with disabled parental consent", function() {
+                var context = createProfilePage(true, {year_of_birth: '', requires_parental_consent: false}),
+                    learnerProfileView = context.learnerProfileView;
+
+                LearnerProfileHelpers.expectProfileSectionsAndFieldsToBeRendered(learnerProfileView, false);
             });
 
             it("doesn't show the mode toggle if badges are disabled", function() {

--- a/openedx/features/learner_profile/static/learner_profile/js/spec/views/learner_profile_fields_spec.js
+++ b/openedx/features/learner_profile/static/learner_profile/js/spec/views/learner_profile_fields_spec.js
@@ -18,11 +18,15 @@ define(
             var MOCK_YEAR_OF_BIRTH = 1989;
             var MOCK_IMAGE_MAX_BYTES = 64;
             var MOCK_IMAGE_MIN_BYTES = 16;
+            var MOCK_REQUIRES_PARENTAL_CONSENT = false;
 
             var createImageView = function(options) {
                 var yearOfBirth = _.isUndefined(options.yearOfBirth) ? MOCK_YEAR_OF_BIRTH : options.yearOfBirth;
                 var imageMaxBytes = _.isUndefined(options.imageMaxBytes) ? MOCK_IMAGE_MAX_BYTES : options.imageMaxBytes;
                 var imageMinBytes = _.isUndefined(options.imageMinBytes) ? MOCK_IMAGE_MIN_BYTES : options.imageMinBytes;
+                var requiresParentalConsent = _.isUndefined(options.requiresParentalConsent) ?
+                                                MOCK_REQUIRES_PARENTAL_CONSENT :
+                                                options.requiresParentalConsent;
                 var messageView;
 
                 var imageData = {
@@ -33,7 +37,7 @@ define(
                 var accountSettingsModel = new UserAccountModel();
                 accountSettingsModel.set({profile_image: imageData});
                 accountSettingsModel.set({year_of_birth: yearOfBirth});
-                accountSettingsModel.set({requires_parental_consent: !!_.isEmpty(yearOfBirth)});
+                accountSettingsModel.set({requires_parental_consent: requiresParentalConsent});
 
                 accountSettingsModel.url = Helpers.USER_ACCOUNTS_API_URL;
 
@@ -230,7 +234,12 @@ define(
                 });
 
                 it("can't upload and remove image if parental consent required", function() {
-                    var imageView = createImageView({ownProfile: true, hasImage: false, yearOfBirth: ''});
+                    var imageView = createImageView({
+                        ownProfile: true,
+                        hasImage: false,
+                        yearOfBirth: '',
+                        requiresParentalConsent: true
+                    });
                     imageView.render();
 
                     spyOn(imageView, 'clickedUploadButton');
@@ -244,6 +253,28 @@ define(
 
                     expect(imageView.clickedUploadButton).not.toHaveBeenCalled();
                     expect(imageView.clickedRemoveButton).not.toHaveBeenCalled();
+                });
+
+                it('can upload and remove image if parental consent not required and not yearOfBirth', function() {
+                    var imageView = createImageView({
+                        ownProfile: true,
+                        hasImage: false,
+                        yearOfBirth: '',
+                        requiresParentalConsent: false
+                    });
+                    imageView.render();
+
+                    spyOn(imageView, 'clickedUploadButton');
+                    spyOn(imageView, 'clickedRemoveButton');
+
+                    expect(imageView.$('.u-field-upload-button').css('display') === 'none').toBeFalsy();
+                    expect(imageView.$('.u-field-remove-button').css('display') === 'none').toBeFalsy();
+
+                    imageView.$('.u-field-upload-button').click();
+                    imageView.$('.u-field-remove-button').click();
+
+                    expect(imageView.clickedUploadButton).toHaveBeenCalled();
+                    expect(imageView.clickedRemoveButton).toHaveBeenCalled();
                 });
 
                 it("can't upload and remove image on others profile", function() {

--- a/openedx/features/learner_profile/static/learner_profile/js/spec/views/learner_profile_fields_spec.js
+++ b/openedx/features/learner_profile/static/learner_profile/js/spec/views/learner_profile_fields_spec.js
@@ -113,14 +113,16 @@ define(
                     expect(view.$('.remove-button-title').text().trim()).toBe(message);
                 };
 
-                it('can upload profile image', function() {
+                var verifyProfileImageUpload = function(imageView) {
                     var requests = AjaxHelpers.requests(this);
                     var imageName = 'profile_image.jpg';
-                    var imageView = createImageView({ownProfile: true, hasImage: false});
                     var data;
                     imageView.render();
 
                     initializeUploader(imageView);
+
+                    // Upload button should be present for default image
+                    expect(imageView.$('.u-field-upload-button').css('display') === 'none').toBeFalsy();
 
                     // Remove button should not be present for default image
                     expect(imageView.$('.u-field-remove-button').css('display') === 'none').toBeTruthy();
@@ -129,7 +131,7 @@ define(
                     verifyImageUploadButtonMessage(imageView, false);
 
                     // Add image to upload queue. Validate the image size and send POST request to upload image
-                    imageView.$('.upload-button-input').fileupload('add', {files: [createFakeImageFile(60)]});
+                    imageView.$('.upload-button-input').fileupload('add', { files: [createFakeImageFile(60)] });
 
                     // Verify image upload progress message
                     verifyImageUploadButtonMessage(imageView, true);
@@ -142,10 +144,12 @@ define(
 
                     // Upon successful image upload, account settings model will be fetched to
                     // get the url for newly uploaded image, So we need to send the response for that GET
-                    data = {profile_image: {
-                        image_url_large: '/media/profile-images/' + imageName,
-                        has_image: true
-                    }};
+                    data = {
+                        profile_image: {
+                            image_url_large: '/media/profile-images/' + imageName,
+                            has_image: true
+                        }
+                    };
                     AjaxHelpers.respondWithJson(requests, data);
 
                     // Verify uploaded image name
@@ -156,6 +160,21 @@ define(
 
                     // After image upload, image title should be `Change image`
                     verifyImageUploadButtonMessage(imageView, false);
+                }
+
+                it('can upload profile image', function() {
+                    var imageView = createImageView({ownProfile: true, hasImage: false});
+                    verifyProfileImageUpload(imageView);
+                });
+
+                it('can upload and remove image if parental consent not required and not yearOfBirth', function () {
+                    var imageView = createImageView({
+                        ownProfile: true,
+                        hasImage: false,
+                        yearOfBirth: '',
+                        requiresParentalConsent: false
+                    });
+                    verifyProfileImageUpload(imageView);
                 });
 
                 it('can remove profile image', function() {
@@ -253,28 +272,6 @@ define(
 
                     expect(imageView.clickedUploadButton).not.toHaveBeenCalled();
                     expect(imageView.clickedRemoveButton).not.toHaveBeenCalled();
-                });
-
-                it('can upload and remove image if parental consent not required and not yearOfBirth', function() {
-                    var imageView = createImageView({
-                        ownProfile: true,
-                        hasImage: false,
-                        yearOfBirth: '',
-                        requiresParentalConsent: false
-                    });
-                    imageView.render();
-
-                    spyOn(imageView, 'clickedUploadButton');
-                    spyOn(imageView, 'clickedRemoveButton');
-
-                    expect(imageView.$('.u-field-upload-button').css('display') === 'none').toBeFalsy();
-                    expect(imageView.$('.u-field-remove-button').css('display') === 'none').toBeFalsy();
-
-                    imageView.$('.u-field-upload-button').click();
-                    imageView.$('.u-field-remove-button').click();
-
-                    expect(imageView.clickedUploadButton).toHaveBeenCalled();
-                    expect(imageView.clickedRemoveButton).toHaveBeenCalled();
                 });
 
                 it("can't upload and remove image on others profile", function() {

--- a/openedx/features/learner_profile/static/learner_profile/js/spec/views/learner_profile_view_spec.js
+++ b/openedx/features/learner_profile/static/learner_profile/js/spec/views/learner_profile_view_spec.js
@@ -50,7 +50,8 @@ define(
                         ['private', 'Limited Profile']
                     ],
                     helpMessage: '',
-                    accountSettingsPageUrl: '/account/settings/'
+                    accountSettingsPageUrl: '/account/settings/',
+                    parentalConsentAgeLimit: 13
                 });
 
                 var messageView = new MessageBannerView({

--- a/openedx/features/learner_profile/static/learner_profile/js/views/learner_profile_fields.js
+++ b/openedx/features/learner_profile/static/learner_profile/js/views/learner_profile_fields.js
@@ -58,7 +58,7 @@
             },
 
             updateFieldValue: function() {
-                if (!this.isAboveMinimumAge) {
+                if (this.requiresParentalConsent) {
                     this.$('.u-field-value select').val('private');
                     this.disableField(true);
                 }
@@ -121,7 +121,7 @@
             },
 
             isEditingAllowed: function() {
-                return this.model.isAboveMinimumAge();
+                return !this.model.get('requires_parental_consent');
             },
 
             isShowingPlaceholder: function() {

--- a/openedx/features/learner_profile/static/learner_profile/js/views/learner_profile_fields.js
+++ b/openedx/features/learner_profile/static/learner_profile/js/views/learner_profile_fields.js
@@ -39,19 +39,24 @@
                     HtmlUtils.HTML('</a>')
                 );
                 if (this.profileIsPrivate) {
-                    this._super(
-                        HtmlUtils.interpolateHtml(
-                            gettext('You must specify your birth year before you can share your full profile. To specify your birth year, go to the {account_settings_page_link}'),  // eslint-disable-line max-len
-                            {account_settings_page_link: accountSettingsLink}
-                        )
-                    );
-                } else if (this.requiresParentalConsent) {
-                    this._super(
-                        HtmlUtils.interpolateHtml(
-                            gettext('You must be over 13 to share a full profile. If you are over 13, make sure that you have specified a birth year on the {account_settings_page_link}'),  // eslint-disable-line max-len
-                            {account_settings_page_link: accountSettingsLink}
-                        )
-                    );
+                    if (this.isBirthYearDefined) {
+                        this._super(
+                            HtmlUtils.interpolateHtml(
+                                gettext('You must be over {parental_consent_age_limit} to share a full profile. If you are over {parental_consent_age_limit}, make sure that you have specified a birth year on the {account_settings_page_link}'),  // eslint-disable-line max-len
+                                {
+                                    parental_consent_age_limit: this.options.parentalConsentAgeLimit,
+                                    account_settings_page_link: accountSettingsLink
+                                }
+                            )
+                        );
+                    } else {
+                        this._super(
+                            HtmlUtils.interpolateHtml(
+                                gettext('You must specify your birth year before you can share your full profile. To specify your birth year, go to the {account_settings_page_link}'),  // eslint-disable-line max-len
+                                {account_settings_page_link: accountSettingsLink}
+                            )
+                        );
+                    }
                 } else {
                     this._super('');
                 }

--- a/openedx/features/learner_profile/static/learner_profile/js/views/learner_profile_view.js
+++ b/openedx/features/learner_profile/static/learner_profile/js/views/learner_profile_view.js
@@ -122,8 +122,9 @@
                     if (this.options.ownProfile) {
                         fieldView = this.options.accountPrivacyFieldView;
                         settings = this.options.accountSettingsModel;
-                        fieldView.profileIsPrivate = !settings.get('year_of_birth');
+                        fieldView.profileIsPrivate = settings.get('requires_parental_consent');
                         fieldView.requiresParentalConsent = settings.get('requires_parental_consent');
+                        fieldView.isBirthYearDefined = settings.isBirthYearDefined();
                         fieldView.undelegateEvents();
                         this.$('.wrapper-profile-field-account-privacy').prepend(fieldView.render().el);
                         fieldView.delegateEvents();

--- a/openedx/features/learner_profile/static/learner_profile/js/views/learner_profile_view.js
+++ b/openedx/features/learner_profile/static/learner_profile/js/views/learner_profile_view.js
@@ -24,9 +24,9 @@
                 },
 
                 showFullProfile: function() {
-                    var isAboveMinimumAge = this.options.accountSettingsModel.isAboveMinimumAge();
+                    var requiresParentalConsent = this.options.accountSettingsModel.get('requires_parental_consent');
                     if (this.options.ownProfile) {
-                        return isAboveMinimumAge
+                        return !requiresParentalConsent
                             && this.options.preferencesModel.get('account_privacy') === 'all_users';
                     } else {
                         return this.options.accountSettingsModel.get('profile_is_public');
@@ -124,7 +124,6 @@
                         settings = this.options.accountSettingsModel;
                         fieldView.profileIsPrivate = !settings.get('year_of_birth');
                         fieldView.requiresParentalConsent = settings.get('requires_parental_consent');
-                        fieldView.isAboveMinimumAge = settings.isAboveMinimumAge();
                         fieldView.undelegateEvents();
                         this.$('.wrapper-profile-field-account-privacy').prepend(fieldView.render().el);
                         fieldView.delegateEvents();

--- a/openedx/features/learner_profile/tests/views/test_learner_profile.py
+++ b/openedx/features/learner_profile/tests/views/test_learner_profile.py
@@ -39,6 +39,7 @@ class LearnerProfileViewTest(UrlResetMixin, ModuleStoreTestCase):
         'language_options',
         'account_settings_data',
         'preferences_data',
+        'parental_consent_age_limit',
     ]
 
     def setUp(self):
@@ -97,6 +98,8 @@ class LearnerProfileViewTest(UrlResetMixin, ModuleStoreTestCase):
         )
 
         self.assertEqual(context['data']['account_settings_page_url'], reverse('account_settings'))
+
+        self.assertEqual(context['data']['parental_consent_age_limit'], settings.PARENTAL_CONSENT_AGE_LIMIT)
 
         for attribute in self.CONTEXT_DATA:
             self.assertIn(attribute, context['data'])

--- a/openedx/features/learner_profile/views/learner_profile.py
+++ b/openedx/features/learner_profile/views/learner_profile.py
@@ -136,6 +136,7 @@ def learner_profile_context(request, profile_username, user_is_staff):
             'backpack_ui_img': staticfiles_storage.url('certificates/images/backpack-ui.png'),
             'platform_name': configuration_helpers.get_value('platform_name', settings.PLATFORM_NAME),
             'social_platforms': settings.SOCIAL_PLATFORMS,
+            'parental_consent_age_limit': configuration_helpers.get_value('PARENTAL_CONSENT_AGE_LIMIT', settings.PARENTAL_CONSENT_AGE_LIMIT)
         },
         'show_program_listing': ProgramsApiConfig.is_enabled(),
         'show_journal_listing': journals_enabled(),

--- a/openedx/features/learner_profile/views/learner_profile.py
+++ b/openedx/features/learner_profile/views/learner_profile.py
@@ -136,7 +136,10 @@ def learner_profile_context(request, profile_username, user_is_staff):
             'backpack_ui_img': staticfiles_storage.url('certificates/images/backpack-ui.png'),
             'platform_name': configuration_helpers.get_value('platform_name', settings.PLATFORM_NAME),
             'social_platforms': settings.SOCIAL_PLATFORMS,
-            'parental_consent_age_limit': configuration_helpers.get_value('PARENTAL_CONSENT_AGE_LIMIT', settings.PARENTAL_CONSENT_AGE_LIMIT)
+            'parental_consent_age_limit': configuration_helpers.get_value(
+                'PARENTAL_CONSENT_AGE_LIMIT',
+                settings.PARENTAL_CONSENT_AGE_LIMIT
+            )
         },
         'show_program_listing': ProgramsApiConfig.is_enabled(),
         'show_journal_listing': journals_enabled(),


### PR DESCRIPTION
This change allows users to update their profile when parental consent is disabled and they do not define a year of birth. Currently, users cannot update their profile when parental consent is disabled (i.e.: `PARENTAL_CONSENT_AGE_LIMIT` is `None`) and they do not define a year of birth, therefore if the parental consent is disabled, they must define a year of birth.

This also updates age limited message that contained a hardcoded age limit value. The message now reflects the current settings. See screenshot.

**Screenshots**:
![image](https://user-images.githubusercontent.com/1891977/49307188-2876d580-f4b3-11e8-95cd-ba795f36e5c4.png)

**Sandbox URL**: [LMS](https://pr19346.sandbox.opencraft.hosting/)

**Testing instructions**:

User https://pr19346.sandbox.opencraft.hosting/u/staff does not have Year of Birth defined and `PARENTAL_CONSENT_AGE_LIMIT` is disabled (i.e.: None) in `site_configuration`. Profile visibility should be Full profile.

**Author notes and concerns**:

1. Changed model to use `site_configuration` helpers, so it can be changed per site.

**Reviewers**
- [ ] @smarnach 
- [ ] edX reviewer[s] TBD
