### PR TITLE
a11y fix on account page

### DIFF
--- a/lms/templates/fields/field_dropdown.underscore
+++ b/lms/templates/fields/field_dropdown.underscore
@@ -32,7 +32,7 @@
                 <% }); %>
             <% }); %>
         </select>
-        <button class="u-field-value-display">
+        <button class="u-field-value-display" aria-haspopup="true">
             <span class="sr"><%- screenReaderTitle %> &nbsp;</span>
             <span class="u-field-value-readonly"></span>
             <span class="sr">&nbsp; <%- gettext('Click to edit') %></span>

--- a/lms/templates/fields/field_dropdown_account.underscore
+++ b/lms/templates/fields/field_dropdown_account.underscore
@@ -35,7 +35,7 @@
             <% }); %>
         </select>
         <span class="icon-caret-down" aria-hidden="true"></span>
-        <button class="u-field-value-display">
+        <button class="u-field-value-display" aria-haspopup="true">
             <span class="sr"><%- screenReaderTitle %> &nbsp;</span>
             <span class="u-field-value-readonly"></span>
             <span class="sr"><%- gettext('Click to edit') %></span>


### PR DESCRIPTION
## [EDUCATOR-3612](https://openedx.atlassian.net/browse/EDUCATOR-3612)

### Description

On profile page there are 'Location' and 'Language' buttons which pop menus. Adding `aria-haspopup="true"` in these buttons to indicate the pop up of menu.

### Reviewers
- [x] @wittjeff 
- [ ] @awaisdar001 
 
### Post-review
- [ ] Rebase and squash commits