### PR TITLE
EDUCATOR-3764 Mathjax accessibility files

### DIFF
--- a/cms/djangoapps/pipeline_js/js/xmodule.js
+++ b/cms/djangoapps/pipeline_js/js/xmodule.js
@@ -18,7 +18,7 @@ define(
         window._ = _;
 
         $script(
-            '//cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.1/MathJax.js' +
+            'https://cdn.jsdelivr.net/npm/mathjax@2.7.5/MathJax.js' +
             '?config=TeX-MML-AM_SVG&delayStartupUntil=configured',
             'mathjax',
             function() {

--- a/cms/static/cms/js/require-config.js
+++ b/cms/static/cms/js/require-config.js
@@ -55,8 +55,11 @@
             // the option as displayed in the context menu to false.
             // When upgrading to 2.6, check if this variable name changed.
             window.MathJax = {
-                menuSettings: {CHTMLpreview: false}
+                menuSettings: {
+                    CHTMLpreview: false
+                }
             };
+
         };
 
         defineDependency('jQuery', 'jquery');
@@ -131,7 +134,7 @@
             'lang_edx': 'js/src/lang_edx',
 
             // externally hosted files
-            mathjax: '//cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.1/MathJax.js?config=TeX-MML-AM_SVG&delayStartupUntil=configured',  // eslint-disable-line max-len
+            mathjax: 'https://cdn.jsdelivr.net/npm/mathjax@2.7.5/MathJax.js?config=TeX-MML-AM_SVG&delayStartupUntil=configured',  // eslint-disable-line max-len
             'youtube': [
                 // youtube URL does not end in '.js'. We add '?noext' to the path so
                 // that require.js adds the '.js' to the query component of the URL,

--- a/cms/static/cms/js/spec/main.js
+++ b/cms/static/cms/js/spec/main.js
@@ -69,7 +69,7 @@
             'domReady': 'xmodule_js/common_static/js/vendor/domReady',
             'URI': 'xmodule_js/common_static/js/vendor/URI.min',
             'mock-ajax': 'xmodule_js/common_static/js/vendor/mock-ajax',
-            mathjax: '//cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.1/MathJax.js?config=TeX-MML-AM_SVG&delayStartupUntil=configured',   // eslint-disable-line max-len
+            mathjax: 'https://cdn.jsdelivr.net/npm/mathjax@2.7.5/MathJax.js?config=TeX-MML-AM_SVG&delayStartupUntil=configured',   // eslint-disable-line max-len
             'youtube': '//www.youtube.com/player_api?noext',
             'js/src/ajax_prefix': 'xmodule_js/common_static/js/src/ajax_prefix',
             'js/spec/test_utils': 'js/spec/test_utils'

--- a/cms/static/cms/js/spec/main_squire.js
+++ b/cms/static/cms/js/spec/main_squire.js
@@ -48,7 +48,7 @@
             'draggabilly': 'xmodule_js/common_static/js/vendor/draggabilly',
             'domReady': 'xmodule_js/common_static/js/vendor/domReady',
             'URI': 'xmodule_js/common_static/js/vendor/URI.min',
-            mathjax: '//cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.1/MathJax.js?config=TeX-MML-AM_SVG&delayStartupUntil=configured',   // eslint-disable-line max-len
+            mathjax: 'https://cdn.jsdelivr.net/npm/mathjax@2.7.5/MathJax.js?config=TeX-MML-AM_SVG&delayStartupUntil=configured',   // eslint-disable-line max-len
             'youtube': '//www.youtube.com/player_api?noext',
             'js/src/ajax_prefix': 'xmodule_js/common_static/js/src/ajax_prefix'
         },

--- a/common/static/common/js/discussion/mathjax_include.js
+++ b/common/static/common/js/discussion/mathjax_include.js
@@ -42,6 +42,15 @@ if (typeof MathJax === 'undefined') {
             });
         };
     };
-    vendorScript.src = 'https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.1/MathJax.js?config=TeX-MML-AM_SVG';
+
+    // Automatic loading of Mathjax accessibility files
+    window.MathJax = {
+        menuSettings: {
+            collapsible: true,
+            autocollapse: true,
+            explorer: true
+        }
+    };
+    vendorScript.src = 'https://cdn.jsdelivr.net/npm/mathjax@2.7.5/MathJax.js?config=TeX-MML-AM_SVG';
     document.body.appendChild(vendorScript);
 }

--- a/common/static/common/js/discussion/utils.js
+++ b/common/static/common/js/discussion/utils.js
@@ -482,10 +482,10 @@
                 this.postMathJaxProcessor(this.markdownWithHighlight(element.text()))
             );
 
-            this.typesetMathJax(element);
         };
 
         DiscussionUtil.typesetMathJax = function(element) {
+
             if (typeof MathJax !== 'undefined' && MathJax !== null) {
                 MathJax.Hub.Queue(['Typeset', MathJax.Hub, element[0]]);
             }

--- a/common/static/common/js/discussion/views/discussion_thread_show_view.js
+++ b/common/static/common/js/discussion/views/discussion_thread_show_view.js
@@ -59,13 +59,12 @@
                 this.renderAttrs();
                 this.$('span.timeago').timeago();
                 this.convertMath();
-                this.$('.post-body');
-                this.$('h1,h3');
                 return this;
             };
 
             DiscussionThreadShowView.prototype.convertMath = function() {
                 DiscussionUtil.convertMath(this.$('.post-body'));
+                DiscussionUtil.typesetMathJax(this.$('.post-body'));
             };
 
             DiscussionThreadShowView.prototype.edit = function(event) {

--- a/common/static/common/js/discussion/views/discussion_thread_view.js
+++ b/common/static/common/js/discussion/views/discussion_thread_view.js
@@ -317,7 +317,10 @@
                 if (options.focusAddedResponse) {
                     this.focusToTheAddedResponse(view.el);
                 }
-                DiscussionUtil.typesetMathJax(view.$el.find('.js-response-list'));
+
+                // Typeset the response when initially loaded for any forum
+                DiscussionUtil.typesetMathJax(view.$el);
+                return view;
             };
 
             DiscussionThreadView.prototype.renderAddResponseButton = function() {
@@ -345,7 +348,7 @@
             };
 
             DiscussionThreadView.prototype.submitComment = function(event) {
-                var body, comment, url;
+                var body, comment, url, view;
                 event.preventDefault();
                 url = this.model.urlFor('reply');
                 body = this.getWmdContent('reply-body');
@@ -365,7 +368,7 @@
                     user_id: window.user.get('id')
                 });
                 comment.set('thread', this.model.get('thread'));
-                this.renderResponseToList(comment, '.js-response-list', {
+                view = this.renderResponseToList(comment, '.js-response-list', {
                     focusAddedResponse: true
                 });
                 this.model.addComment();
@@ -379,8 +382,9 @@
                         body: body
                     },
                     success: function(data) {
-                        comment.updateInfo(data.annotated_content_info);
-                        return comment.set(data.content);
+                         comment.updateInfo(data.annotated_content_info);
+                         comment.set(data.content);
+                         DiscussionUtil.typesetMathJax(view.$el.find('.response-body'));
                     }
                 });
             };

--- a/common/static/common/js/discussion/views/response_comment_show_view.js
+++ b/common/static/common/js/discussion/views/response_comment_show_view.js
@@ -72,6 +72,8 @@
 
             ResponseCommentShowView.prototype.convertMath = function() {
                 DiscussionUtil.convertMath(this.$el.find('.response-body'));
+                DiscussionUtil.typesetMathJax(this.$el.find('.response-body'));
+
             };
 
             ResponseCommentShowView.prototype._delete = function(event) {

--- a/common/static/common/js/discussion/views/thread_response_view.js
+++ b/common/static/common/js/discussion/views/thread_response_view.js
@@ -82,7 +82,9 @@
 
             ThreadResponseView.prototype.render = function() {
                 this.$el.addClass('response_' + this.model.get('id'));
-                this.$el.html(this.renderTemplate());
+
+                // Setting the HTML through utils to cope for tag-less text
+                edx.HtmlUtils.setHtml(this.$el, edx.HtmlUtils.HTML(this.renderTemplate()));
                 this.delegateEvents();
                 this.renderShowView();
                 this.renderAttrs();
@@ -309,6 +311,7 @@
                 event.preventDefault();
                 this.createShowView();
                 this.renderShowView();
+                DiscussionUtil.typesetMathJax(this.$el.find('.response-body'));
                 return this.showCommentForm();
             };
 
@@ -342,6 +345,7 @@
                         });
                         self.createShowView();
                         self.renderShowView();
+                        DiscussionUtil.typesetMathJax(self.$el.find('.response-body'));
                         return self.showCommentForm();
                     }
                 });

--- a/common/templates/mathjax_include.html
+++ b/common/templates/mathjax_include.html
@@ -75,9 +75,20 @@
   }
 </script>
 
+<script type="text/javascript">
+    // Activating Mathjax accessibility files
+    window.MathJax = {
+        menuSettings: {
+            collapsible: true,
+            autocollapse: true,
+            explorer: true
+        }
+    };
+</script>
+
 
 <!-- This must appear after all mathjax-config blocks, so it is after the imports from the other templates.
      It can't be run through static.url because MathJax uses crazy url introspection to do lazy loading of
      MathJax extension libraries -->
-<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.1/MathJax.js?config=TeX-MML-AM_SVG"></script>
+<script type="text/javascript" src="https://cdn.jsdelivr.net/npm/mathjax@2.7.5/MathJax.js?config=TeX-MML-AM_SVG"></script>
 %endif

--- a/lms/static/lms/js/spec/main.js
+++ b/lms/static/lms/js/spec/main.js
@@ -56,7 +56,7 @@
             'squire': 'common/js/vendor/Squire',
             'jasmine-imagediff': 'xmodule_js/common_static/js/vendor/jasmine-imagediff',
             'domReady': 'xmodule_js/common_static/js/vendor/domReady',
-            mathjax: '//cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.1/MathJax.js?config=TeX-MML-AM_SVG&delayStartupUntil=configured',  // eslint-disable-line max-len
+            mathjax: 'https://cdn.jsdelivr.net/npm/mathjax@2.7.5/MathJax.js?config=TeX-MML-AM_SVG&delayStartupUntil=configured',  // eslint-disable-line max-len
             'youtube': '//www.youtube.com/player_api?noext',
             'js/src/ajax_prefix': 'xmodule_js/common_static/js/src/ajax_prefix',
             'js/instructor_dashboard/student_admin': 'js/instructor_dashboard/student_admin',


### PR DESCRIPTION
### [EDUCATOR-3764](https://openedx.atlassian.net/browse/EDUCATOR-3764)

### Description
Mathjax provides with the [accessibility](https://mathjax.github.io/MathJax-a11y/docs/) features to allow access to the rendered content in every possible ways. In current scenario, the files required for the a11y are loaded manually. There is need to enable those files automatically whenever the Mathjax is loaded. This PR addresses the configuration to load the a11y files for the Mathjax by upgrading it to **2.7.5** and adding the required configuration.

### Change Impact
Adding the MathJax a11y files led to the discovery of a problem in the Discussion component. Surprisingly, the problem has been there in first place for quite a long time, but only came under the observation after the inclusion of MathJax a11y. The problem was that whenever a **response** (to a discussion forum) was added/edited, **Math Processing Error** occurred, which halted the further MathJax Processing on the page, unless page was reloaded.

### Problem Identification
Identifying the problem was straightforward, but locating the exact point of the origin was cumbersome. When a response is added, the contents from the input area are taken, and appended to the already present response list. During that process, whenever the **render** of the response model was called, a [Typeset](http://docs.mathjax.org/en/latest/advanced/typeset.html) call was queued inside the MathJax queue (Discussion util **convertMath** function was called inside render). Queue & TypeSet being async performed on their own, while the page DOM modified to append the new response. When a response is successfully appended, the backbone model was updated via **set** call, which in turn generated relevant events. One of the triggered events called the render method again, which led to the additional typeset calls. The problem here is that previous typesetting didn't complete, and DOM changed. The amalgam of async and sync operations is problematic for MathJax operations, as mentioned in [one](https://github.com/mathjax/MathJax/issues/2071) of the MathJax reported issues (For further study, take a look at the [question](https://stackoverflow.com/questions/29357809/mathjax-is-duplicating-my-equations-why-and-how-can-i-fix-this) as well).

### Problem Resolution
Given the coupling of the various discussion component models, it was rather difficult to convert all the operations either sync or async. One of the possible fixes was to TypeSet the response when the underlying operation finished properly. This meant moving the TypeSet call out from convertMath function, and calling the TypeSet explicitly whenever required. This somehow violated the DRY principle as the same thing was mentioned in the multiple places, but in this case, explicit calls were better than the implicit problematic calls. Hence, for the responses, whenever any operation (adding, editing, etc.) finished, only then Typeset was called. This solved the underlying problem.

### Testing

Following Mathjax expressions' speech output has been verified:
- Mathematical symbols (<, >, =)
- Greek Symbols (alpha, beta, gamma etc.)
- Summation
- Fraction
- Matrices

The resultant output expressions were checked using **ChromeVox**   

### Sandbox
- https://educator3764.sandbox.edx.org/
- https://educator3764.sandbox.edx.org/courses/course-v1:TestX+ed3764+2018/course/

### Reviewers
 - [x] @wittjeff 
 - [ ] @awaisdar001 
 - [ ] @fysheets 

### Post Review
 - [x] Squash & Rebase commits