### PR TITLE
BB-674 - Change Django's configuration precedence in manage.py

### DIFF
--- a/manage.py
+++ b/manage.py
@@ -97,11 +97,13 @@ def parse_args():
 if __name__ == "__main__":
     edx_args, django_args = parse_args()
 
+    edx_args_base = edx_args.settings_base.replace('/', '.') + '.'
     if edx_args.settings:
-        os.environ["DJANGO_SETTINGS_MODULE"] = edx_args.settings_base.replace('/', '.') + "." + edx_args.settings
-    else:
-        os.environ.setdefault("DJANGO_SETTINGS_MODULE", edx_args.default_settings)
+        os.environ["DJANGO_SETTINGS_MODULE"] = edx_args_base + edx_args.settings
+    elif os.environ.get("EDX_PLATFORM_SETTINGS") and not os.environ.get("DJANGO_SETTINGS_MODULE"):
+        os.environ["DJANGO_SETTINGS_MODULE"] = edx_args_base + os.environ["EDX_PLATFORM_SETTINGS"]
 
+    os.environ.setdefault("DJANGO_SETTINGS_MODULE", edx_args.default_settings)
     os.environ.setdefault("SERVICE_VARIANT", edx_args.service_variant)
 
     enable_contracts = os.environ.get('ENABLE_CONTRACTS', False)


### PR DESCRIPTION
This PR contains a fix for the precedence of loading Django settings when running management commands. This is useful when running managements commands in any environment, not needing to set the `--settings` flag as long as the correct environment variables are present.

The manage.py script defaults to using `lms.envs.docker_devstack`, and this can only be overridden by either passing the command-line switch or setting the `DJANGO_SETTINGS_MODULE` environment variable. The problem with this approach is that it depends on whether we want to run an `lms` or `cms` command. The scripts `lms.sh` and `cms.sh` take care of this and set the variable correctly for the respective service variant when using the devstack, but that doesn't happen on a production environment.

This fix implements the following precedence for loading `DJANGO_SETTINGS_MODULE`:
1. `--settings` passed on the command line
2. `EDX_PLATFORM_SETTINGS` environment variable
3. `DJANGO_SETTINGS_MODULE`  environment variable

**JIRA tickets**: [OSPR-2875](https://openedx.atlassian.net/browse/OSPR-2875).

**Sandbox URL**: 
LMS: https://pr19367.sandbox.opencraft.hosting/
VM's IP Address: 149.202.163.139

**Merge deadline**: None.

**Testing instructions**:

1. Run devstack instance using this branch
2. `make lms-shell`
3. Check if the environment variable `EDX_PLATFORM_SETTINGS=devstack_docker` (using `env | grep EDX`)
4. Check if correct Django config module is loaded. You can do that running:
```
./manage.py lms shell
>>> from django.conf import settings
>>> settings      # Check configuration here
<LazySettings "lms.envs.devstack_docker">
```
5. Exit the python shell and unset `EDX_PLATFORM_SETTINGS` (by running `unset EDX_PLATFORM_SETTINGS`)
6. Check if the Django Config used the default value for the `DJANGO_SETTINGS_MODULE` (should be `lms|cms.envs.devstack_docker`) for both **lms** and **cms** by running `./manage.py lms|cms shell` and checking settings
7. Run a sandbox with this branch and ssh into it.
8. Do steps 3 and 4 on the Sandbox and check if the correct settings are set for a production environment (should be `EDX_PLATFORM_SETTINGS=production` and `<LazySettings "lms.envs.production">`

**Author notes and concerns**:

1. This is backwards compatible, but might change behavior in cases where `EDX_PLATFORM_SETTINGS` and `DJANGO_SETTINGS_MODULE` are set to different values.

**Reviewers**
- [ ] @lgp171188 
- [ ] edX reviewer[s] TBD