### PR TITLE
Switch static assets to courseware friendly version

### DIFF
--- a/openedx/features/content_type_gating/templates/content_type_gating/access_denied_message.html
+++ b/openedx/features/content_type_gating/templates/content_type_gating/access_denied_message.html
@@ -17,5 +17,5 @@
         </span>
         {% endif %}
     </div>
-    <img src="{% static 'images/edx-verified-mini-cert.png' %}" alt="">
+    <img src="/static/images/edx-verified-mini-cert.png">
 </div>


### PR DESCRIPTION
The crux of this is: we're rendering the access-denied message as an xblock, so it should use a path of just `/static/...`, which the xblock runtime does the correct interpretation/hashing for.