### PR TITLE
Make gradebook GET API more performant.

### DIFF
--- a/lms/djangoapps/grades/api/serializers.py
+++ b/lms/djangoapps/grades/api/serializers.py
@@ -34,35 +34,17 @@ class SectionBreakdownSerializer(serializers.Serializer):
     """
     Serializer for the `section_breakdown` portion of a gradebook entry.
     """
-    are_grades_published = serializers.BooleanField()
-    auto_grade = serializers.BooleanField()
     category = serializers.CharField()
-    chapter_name = serializers.CharField()
-    comment = serializers.CharField()
-    detail = serializers.CharField()
     displayed_value = serializers.CharField()
     is_graded = serializers.BooleanField()
     grade_description = serializers.CharField()
-    is_ag = serializers.BooleanField()
-    is_average = serializers.BooleanField()
-    is_manually_graded = serializers.BooleanField()
     label = serializers.CharField()
     letter_grade = serializers.CharField()
     module_id = serializers.CharField()
     percent = serializers.FloatField()
     score_earned = serializers.FloatField()
     score_possible = serializers.FloatField()
-    section_block_id = serializers.CharField()
     subsection_name = serializers.CharField()
-
-
-class SimpleSerializer(serializers.BaseSerializer):
-    """
-    A Serializer intended to take a dictionary of data and simply spit
-    that same dictionary back out as the "serialization".
-    """
-    def to_representation(self, instance):
-        return instance
 
 
 class StudentGradebookEntrySerializer(serializers.Serializer):
@@ -79,4 +61,3 @@ class StudentGradebookEntrySerializer(serializers.Serializer):
     letter_grade = serializers.CharField()
     progress_page_url = serializers.CharField()
     section_breakdown = SectionBreakdownSerializer(many=True)
-    aggregates = SimpleSerializer()

--- a/lms/djangoapps/grades/course_grade_factory.py
+++ b/lms/djangoapps/grades/course_grade_factory.py
@@ -120,7 +120,7 @@ class CourseGradeFactory(object):
                 'user': user,
                 'course': course_data.course,
                 'collected_block_structure': course_data.collected_structure,
-                'course_key': course_data.course_key
+                'course_key': course_data.course_key,
             }
             if force_update:
                 kwargs['force_update_subsections'] = True

--- a/lms/djangoapps/grades/subsection_grade.py
+++ b/lms/djangoapps/grades/subsection_grade.py
@@ -5,6 +5,7 @@ from abc import ABCMeta
 from collections import OrderedDict
 from logging import getLogger
 
+from django.utils.html import escape
 from lazy import lazy
 
 from lms.djangoapps.grades.models import BlockRecord, PersistentSubsectionGrade
@@ -23,7 +24,7 @@ class SubsectionGradeBase(object):
 
     def __init__(self, subsection):
         self.location = subsection.location
-        self.display_name = block_metadata_utils.display_name_with_default_escaped(subsection)
+        self.display_name = escape(block_metadata_utils.display_name_with_default(subsection))
         self.url_name = block_metadata_utils.url_name_for_block(subsection)
 
         self.format = getattr(subsection, 'format', '')
@@ -89,10 +90,22 @@ class ZeroSubsectionGrade(SubsectionGradeBase):
 
     @property
     def all_total(self):
+        """
+        Returns the total score (earned and possible) amongst all problems (graded and ungraded) in this subsection.
+        NOTE: This will traverse this subsection's subtree to determine
+        problem scores.  If self.course_data.structure is currently null, this means
+        we will first fetch the user-specific course structure from the data store!
+        """
         return self._aggregate_scores[0]
 
     @property
     def graded_total(self):
+        """
+        Returns the total score (earned and possible) amongst all graded problems in this subsection.
+        NOTE: This will traverse this subsection's subtree to determine
+        problem scores.  If self.course_data.structure is currently null, this means
+        we will first fetch the user-specific course structure from the data store!
+        """
         return self._aggregate_scores[1]
 
     @lazy
@@ -105,6 +118,9 @@ class ZeroSubsectionGrade(SubsectionGradeBase):
         Overrides the problem_scores member variable in order
         to return empty scores for all scorable problems in the
         course.
+        NOTE: The use of `course_data.structure` here is very intentional.
+        It means we look through the user-specific subtree of this subsection,
+        taking into account which problems are visible to the user.
         """
         locations = OrderedDict()  # dict of problem locations to ProblemScore
         for block_key in self.course_data.structure.post_order_traversal(
@@ -194,6 +210,12 @@ class ReadSubsectionGrade(NonZeroSubsectionGrade):
 
     @lazy
     def problem_scores(self):
+        """
+        Returns the scores of the problem blocks that compose this subsection.
+        NOTE: The use of `course_data.structure` here is very intentional.
+        It means we look through the user-specific subtree of this subsection,
+        taking into account which problems are visible to the user.
+        """
         problem_scores = OrderedDict()
         for block in self.model.visible_blocks.blocks:
             problem_score = self._compute_block_score(

--- a/openedx/features/course_experience/tests/views/test_course_updates.py
+++ b/openedx/features/course_experience/tests/views/test_course_updates.py
@@ -5,7 +5,7 @@ from datetime import datetime
 
 from courseware.courses import get_course_info_usage_key
 from django.urls import reverse
-from openedx.core.djangoapps.waffle_utils.testutils import WAFFLE_TABLES, override_waffle_flag
+from openedx.core.djangoapps.waffle_utils.testutils import WAFFLE_TABLES
 from openedx.features.content_type_gating.models import ContentTypeGatingConfig
 from openedx.features.course_experience.views.course_updates import STATUS_VISIBLE
 from student.models import CourseEnrollment


### PR DESCRIPTION
**Currently**
The `GradebookView` class uses `CourseGradeFactory.iter()` to iterate over a set of users in a course and fetch their course and subsection grades.  `iter()` attempts to reduce the number of times that the course structure has to be fetched by creating a base `CourseData` instance up front, containing the entire course tree, and then passing that structure along to each CourseData instance created in the iteration over users.  While iterating through subsection grades for a single user, `GradebookView` uses the `graded_total` attribute to get the total score earned and total score possible for a subsection.  Looking at the possible score earned for a subsection requires traversing the subsection's subtree - the `SubsectionGrade` class does this by using the `CourseData.structure` property.  This property uses `get_course_blocks()` from the `course_blocks` API to get course_structure.  `CourseGradeFactory.iter()` does not initialize this property of course data, becuase `get_course_blocks()` requires a user object to get course blocks for.  So, because we need to know the possible score of a subsection, for every user that we iterate through, we are calling `get_course_blocks()`.

**What this PR changes**
* The `iter()` method does initialize `collected_structure` using the `block_structure` API (this does not require a user).  `CourseData` also has an `effective_structure` property which looks for structure in the private fields `_structure` and `_collected_block_structure`.  I've changed the implementation of `problem_scores` in SubsectionGrade classes to use the `effective_structure` property instead of `structure`.  When structure hasn't been initialized but collected_structure has, `effective_structure` will pick `collected_structure` as the course structure to use, which is what we want, because that's what `iter()` initializes and passes down to the course grade factory for each user.
* We now take the approach of explicitly determining all graded subsections up-front, and relying on the `CourseGrade.subsection_grade(key)` method for fetching subsection grades, to be more inline with how course grade reports are generated.
* Eliminates the `SubsectionLabelFinder` class, which used `CourseGrade.summary` (which in turn ran into the same issue of eventually invoking `get_course_blocks()`), and is also not needed anymore thanks to the functionality of `get_default_short_labeler`.  Note that the elimination of this class alone wasn't enough to improve performance on my devstack - it was not until modifying the `problem_scores` implementations that I saw us stop fetching all course data for each user.

**Note**
There is still some code clean-up and organization I'd like to do here, but I want to get feedback on potential pitfalls before I proceed.