### PR TITLE
fix a11y on discussion page

### DIFF
--- a/lms/static/sass/discussion/elements/_actions.scss
+++ b/lms/static/sass/discussion/elements/_actions.scss
@@ -338,4 +338,10 @@
       }
     }
   }
+
+  .btn-primary, .btn-outline-primary{
+    &:focus{
+      box-shadow: 0 0 0 2px rgb(0,120,180);
+    }
+  }
 }


### PR DESCRIPTION
## [EDUCATOR-3602](https://openedx.atlassian.net/browse/EDUCATOR-3602)

### Description

Buttons on discussion page are set with custom box-shadow on focus.


### Reviewers
- [x] @wittjeff 
- [x] @Rabia23 

 
### Post-review
- [ ] Rebase and squash commits