### PR TITLE
TE-2803 Clone edx-platform in updated xdist worker images

### DIFF
--- a/scripts/xdist/prepare_xdist_nodes.sh
+++ b/scripts/xdist/prepare_xdist_nodes.sh
@@ -10,8 +10,9 @@ python scripts/xdist/pytest_container_manager.py -a up -n ${XDIST_NUM_TASKS} \
 ip_list=$(<pytest_task_ips.txt)
 for ip in $(echo $ip_list | sed "s/,/ /g")
 do
-    container_reqs_cmd="ssh -o StrictHostKeyChecking=no ubuntu@$ip 'cd /edx/app/edxapp/edx-platform;
-    git pull -q; git checkout -q ${XDIST_GIT_BRANCH};
+    container_reqs_cmd="ssh -o StrictHostKeyChecking=no ubuntu@$ip 'cd /edx/app/edxapp;
+    git clone --branch master --depth 1 --no-tags -q https://github.com/edx/edx-platform.git; cd edx-platform;
+    git fetch --depth=1 --no-tags -q origin ${XDIST_GIT_BRANCH}; git checkout -q ${XDIST_GIT_BRANCH};
     source /edx/app/edxapp/edxapp_env; pip install -qr requirements/edx/testing.txt' & "
 
     cmd=$cmd$container_reqs_cmd


### PR DESCRIPTION
The pytest-xdist worker images are being updated to not include an edx-platform clone, so the repo now needs to be cloned instead of just updated.  Get just what we need to run the tests.