### PR TITLE
Swagger API Docs fix: course groups API

### DIFF
--- a/openedx/core/djangoapps/course_groups/views.py
+++ b/openedx/core/djangoapps/course_groups/views.py
@@ -21,6 +21,7 @@ from opaque_keys.edx.keys import CourseKey
 from rest_framework import status, permissions
 from rest_framework.generics import GenericAPIView
 from rest_framework.response import Response
+from rest_framework.serializers import Serializer
 from six import text_type
 
 from courseware.courses import get_course_with_access
@@ -426,6 +427,7 @@ class APIPermissions(GenericAPIView):
         SessionAuthenticationAllowInactiveUser,
     )
     permission_classes = (permissions.IsAuthenticated, permissions.IsAdminUser)
+    serializer_class = Serializer
 
 
 class CohortSettings(DeveloperErrorViewMixin, APIPermissions):
@@ -494,7 +496,6 @@ class CohortHandler(DeveloperErrorViewMixin, APIPermissions):
             * user_partition_id: The integer identified of the UserPartition.
             * group_id: The integer identified of the specific group in the partition.
     """
-
     def get(self, request, course_key_string, cohort_id=None):
         """
         Endpoint to get either one or all cohorts.


### PR DESCRIPTION
Add the base DRF Serializer as the serializer class for course_groups views that don't specify one.

Without this change, when visiting http://localhost:18000/api-docs/, you get the following error:
```
AssertionError at /api-docs/
'CohortHandler' should either include a `serializer_class` attribute, or override the `get_serializer_class()` method.
```