### PR TITLE
TE-2812 Better output when print_setting fails

### DIFF
--- a/pavelib/paver_tests/test_servers.py
+++ b/pavelib/paver_tests/test_servers.py
@@ -42,9 +42,9 @@ EXPECTED_INDEX_COURSE_COMMAND = (
     u"python manage.py {system} --settings={settings} reindex_course --setup"
 )
 EXPECTED_PRINT_SETTINGS_COMMAND = [
-    u"python manage.py lms --settings={settings} print_setting STATIC_ROOT 2>/dev/null",
-    u"python manage.py cms --settings={settings} print_setting STATIC_ROOT 2>/dev/null",
-    u"python manage.py lms --settings={settings} print_setting WEBPACK_CONFIG_PATH 2>/dev/null"
+    u"python manage.py lms --settings={settings} print_setting STATIC_ROOT 2>{log_file}",
+    u"python manage.py cms --settings={settings} print_setting STATIC_ROOT 2>{log_file}",
+    u"python manage.py lms --settings={settings} print_setting WEBPACK_CONFIG_PATH 2>{log_file}"
 ]
 EXPECTED_WEBPACK_COMMAND = (
     u"NODE_ENV={node_env} STATIC_ROOT_LMS={static_root_lms} STATIC_ROOT_CMS={static_root_cms} "
@@ -243,7 +243,8 @@ class TestPaverServerTasks(PaverTestCase):
             expected_messages.append(u"xmodule_assets common/static/xmodule")
             expected_messages.append(u"install npm_assets")
             expected_messages.extend(
-                [c.format(settings=expected_asset_settings) for c in EXPECTED_PRINT_SETTINGS_COMMAND]
+                [c.format(settings=expected_asset_settings,
+                          log_file=Env.PRINT_SETTINGS_LOG_FILE) for c in EXPECTED_PRINT_SETTINGS_COMMAND]
             )
             expected_messages.append(EXPECTED_WEBPACK_COMMAND.format(
                 node_env="production",
@@ -288,7 +289,8 @@ class TestPaverServerTasks(PaverTestCase):
             expected_messages.append(u"xmodule_assets common/static/xmodule")
             expected_messages.append(u"install npm_assets")
             expected_messages.extend(
-                [c.format(settings=expected_asset_settings) for c in EXPECTED_PRINT_SETTINGS_COMMAND]
+                [c.format(settings=expected_asset_settings,
+                          log_file=Env.PRINT_SETTINGS_LOG_FILE) for c in EXPECTED_PRINT_SETTINGS_COMMAND]
             )
             expected_messages.append(EXPECTED_WEBPACK_COMMAND.format(
                 node_env="production",


### PR DESCRIPTION
Redirect stderr from the `print_setting` management command to a log file instead of `/dev/null`, so when it fails we can give useful information about why it failed.  This sometimes happens when a bug triggers an error in loading settings, and this has been tricky to diagnose and fix in the absence of any error message.  Now there should be output like the following:

```
python manage.py lms --settings=devstack print_setting STATIC_URL 2>/edx/app/edxapp/edx-platform/test_root/log/print_setting.log

Unable to print the value of the STATIC_URL setting:
WARNING:py.warnings:/edx/app/edxapp/edx-platform/lms/djangoapps/courseware/__init__.py:5: DeprecationWarning: Importing 'lms.djangoapps.courseware' as 'courseware' is no longer supported
  warnings.warn("Importing 'lms.djangoapps.courseware' as 'courseware' is no longer supported", DeprecationWarning)

Traceback (most recent call last):
  File "manage.py", line 117, in <module>
    startup = importlib.import_module(edx_args.startup)
  File "/usr/lib/python2.7/importlib/__init__.py", line 37, in import_module
    __import__(name)
  File "/edx/app/edxapp/edx-platform/lms/startup.py", line 9, in <module>
    settings.INSTALLED_APPS  # pylint: disable=pointless-statement
  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/django/conf/__init__.py", line 56, in __getattr__
    self._setup(name)
  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/django/conf/__init__.py", line 41, in _setup
    self._wrapped = Settings(settings_module)
  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/django/conf/__init__.py", line 110, in __init__
    mod = importlib.import_module(self.SETTINGS_MODULE)
  File "/usr/lib/python2.7/importlib/__init__.py", line 37, in import_module
    __import__(name)
  File "/edx/app/edxapp/edx-platform/lms/envs/devstack.py", line 276, in <module>
    raise Exception('Boom!')
Exception: Boom!
```