### PR TITLE
Faster "npm install" without progress bar

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -2,3 +2,4 @@ fetch-retries = 5
 fetch-retry-factor = 2
 fetch-retry-mintimeout = 10000
 fetch-retry-maxtimeout = 60000
+progress = false


### PR DESCRIPTION
In older versions of npm, displaying a progress bar considerably slows
down "npm install" commands: https://github.com/npm/npm/issues/11283

In Ubuntu 16.04 (supported by open edx) the default version of npm is
3.5.2, so it is affected this issue. The progress bar can be deactivated
globally by running "npm set progress=false", but this is a little-known
command.

With this change, all edx-platform developers benefit from the speed
increase. On a production server with excellent bandwidth, we made the
following benchmark:

rm -rf ./node_modules ~/.npm && npm set progress=false && time npm
install
real    3m29.980s
user    2m36.152s
sys     0m20.868s

rm -rf ./node_modules ~/.npm && npm set progress=true && time npm
install
real    7m5.580s
user    6m2.824s
sys     0m20.304s

There is thus a ~57% improvement on a task that is typically quite
time-consuming, with minimal inconvenience for developers.