### PR TITLE
Add apple fonts to dashboard and programs_fragments

### DIFF
--- a/lms/static/sass/elements/_program-card.scss
+++ b/lms/static/sass/elements/_program-card.scss
@@ -114,6 +114,7 @@
   }
 
   .hd-3 {
+    font: -apple-system-short-headline !important;
     color: palette(grayscale, dark);
     min-height: ($baseline*3);
     line-height: 1.15;
@@ -124,6 +125,7 @@
     margin-bottom: 5px;
 
     .number-status {
+      font: -apple-system-short-caption1 !important;
       text-align: center;
       width: 100%;
       float: left;

--- a/lms/static/sass/multicourse/_dashboard.scss
+++ b/lms/static/sass/multicourse/_dashboard.scss
@@ -136,6 +136,7 @@
               padding-top: $baseline/2;
 
               a, span {
+                font: -apple-system-short-headline !important;
                 @extend %t-title3;
                 @extend %t-regular;
 
@@ -152,6 +153,7 @@
 
             .course-info {
               [class*="info-"] {
+                font: -apple-system-short-subheadline !important;
                 color: $gray-d1;
 
                 @extend %t-title7;
@@ -163,6 +165,7 @@
                 display: block;
 
                 .info-date-block{
+                  font: -apple-system-short-subheadline !important;
                   @extend %t-title7;
 
                   color: $gray; // WCAG 2.0 AA compliant
@@ -393,6 +396,7 @@
           }
 
           .enter-course {
+            font: -apple-system-short-subheadline !important;
             @extend %btn-pl-white-base;
 
             @include float(right);


### PR DESCRIPTION
[LEARNER-6728](https://openedx.atlassian.net/browse/LEARNER-6728)

The following fonts have been used:
For https://courses.edx.org/dashboard/
- Title : -apple-system-short-headline 
- Date: -apple-system-short-subheadline 
- Course Info: -apple-system-short-subheadline 
- Button "View Course": -apple-system-short-subheadline

For https://courses.edx.org/dashboard/programs_fragment/?mobile_only=true:
- Title: -apple-system-short-headline 
- For "Completed", "In Progress", "Remaining": -apple-system-short-caption1



