### PR TITLE
Gradebook: check if subsection grade has an override when including scores

### DIFF
--- a/lms/djangoapps/grades/api/v1/gradebook_views.py
+++ b/lms/djangoapps/grades/api/v1/gradebook_views.py
@@ -431,12 +431,14 @@ class GradebookView(GradeViewMixin, PaginatedAPIView):
             # For ZeroSubsectionGrades, we don't want to crawl the subsection's
             # subtree to find the problem scores specific to this user
             # (ZeroSubsectionGrade.attempted_graded is always False).
-            # We've already fetched the whole course structure in a non-specific way
+            # We've already fetched the whole course structure in a non-user-specific way
             # when creating `graded_subsections`.  Looking at the problem scores
             # specific to this user (the user in `course_grade.user`) would require
             # us to re-fetch the user-specific course structure from the modulestore,
-            # which is a costly operation.
-            if subsection_grade.attempted_graded:
+            # which is a costly operation.  So we only drill into the `graded_total`
+            # attribute if the user has attempted this graded subsection, or if there
+            # has been a grade override applied.
+            if subsection_grade.attempted_graded or subsection_grade.override:
                 graded_description = '({earned:.2f}/{possible:.2f})'.format(
                     earned=subsection_grade.graded_total.earned,
                     possible=subsection_grade.graded_total.possible,


### PR DESCRIPTION
https://openedx.atlassian.net/browse/EDUCATOR-3812

The issue here isn't that there isn't a `PersistentSubsectionGrade` (we actually do, because we have to create a persistent grade for the override to reference), but that the persistent grade model's `first_attempted` attribute is null.  That attribute is only null when there's an override, so checking for an override is sufficient to get the earned/possible scores.