### PR TITLE
Fix inconsistency in assumed data dir for course import

### DIFF
--- a/openedx/core/lib/extract_tar.py
+++ b/openedx/core/lib/extract_tar.py
@@ -45,8 +45,8 @@ def safemembers(members, base):
 
     base = resolved(base)
 
-    # check that we're not trying to import outside of the data_dir
-    if not base.startswith(resolved(settings.DATA_DIR)):
+    # check that we're not trying to import outside of the github_repo_root
+    if not base.startswith(resolved(settings.GITHUB_REPO_ROOT)):
         raise SuspiciousOperation("Attempted to import course outside of data dir")
 
     for finfo in members:


### PR DESCRIPTION
With the expanded idea of what `settings.DATA_DIR` pertains to, there is an inconsistency in the assumed location of course repositories that can lead to failed impots. In `import_olx` the root is set to be `settings.GITHUB_REPO_ROOT`, whereas in the `extract_tar.py` file it is validating against `settings.DATA_DIR` which can no longer be assumed to be the same location. This PR brings those two assumptions in line to rely on the `settings.GITHUB_REPO_ROOT` in both locations.