### PR TITLE
Put certificate data message into it's own block for overriding

### DIFF
--- a/lms/templates/courseware/progress.html
+++ b/lms/templates/courseware/progress.html
@@ -66,26 +66,28 @@ username = get_enterprise_learner_generic_name(request) or student.username
 
                 <div class="wrapper-msg wrapper-auto-cert">
                     <div id="errors-info" class="errors-info"></div>
-                    %if certificate_data:
-                    <div class="auto-cert-message" id="course-success">
-                        <div class="has-actions">
-                            <% post_url = reverse('generate_user_cert', args=[unicode(course.id)]) %>
-                            <div class="msg-content">
-                                <h4 class="hd hd-4 title">${certificate_data.title}</h4>
-                                <p class="copy">${certificate_data.msg}</p>
-                            </div>
-                            <div class="msg-actions">
-                                %if certificate_data.cert_web_view_url:
-                                <a class="btn" href="${certificate_data.cert_web_view_url}" target="_blank">${_("View Certificate")} <span class="sr">${_("Opens in a new browser window")}</span></a>
-                                %elif certificate_data.cert_status == CertificateStatuses.downloadable and certificate_data.download_url:
-                                <a class="btn" href="${certificate_data.download_url}" target="_blank">${_("Download Your Certificate")} <span class="sr">${_("Opens in a new browser window")}</span></a>
-                                %elif certificate_data.cert_status == CertificateStatuses.requesting:
-                                <button class="btn generate_certs" data-endpoint="${post_url}" id="btn_generate_cert">${_('Request Certificate')}</button>
-                                %endif
+                    <%block name="certificate_block">
+                        %if certificate_data:
+                        <div class="auto-cert-message" id="course-success">
+                            <div class="has-actions">
+                                <% post_url = reverse('generate_user_cert', args=[unicode(course.id)]) %>
+                                <div class="msg-content">
+                                    <h4 class="hd hd-4 title">${certificate_data.title}</h4>
+                                    <p class="copy">${certificate_data.msg}</p>
+                                </div>
+                                <div class="msg-actions">
+                                    %if certificate_data.cert_web_view_url:
+                                    <a class="btn" href="${certificate_data.cert_web_view_url}" target="_blank">${_("View Certificate")} <span class="sr">${_("Opens in a new browser window")}</span></a>
+                                    %elif certificate_data.cert_status == CertificateStatuses.downloadable and certificate_data.download_url:
+                                    <a class="btn" href="${certificate_data.download_url}" target="_blank">${_("Download Your Certificate")} <span class="sr">${_("Opens in a new browser window")}</span></a>
+                                    %elif certificate_data.cert_status == CertificateStatuses.requesting:
+                                    <button class="btn generate_certs" data-endpoint="${post_url}" id="btn_generate_cert">${_('Request Certificate')}</button>
+                                    %endif
+                                </div>
                             </div>
                         </div>
-                    </div>
-                    %endif
+                        %endif
+                    </%block>
                 </div>
 
                 %if not course.disable_progress_graph:


### PR DESCRIPTION
This PR simply puts the certificate information into a block in order to facilitate overriding it without overriding the entire progress template.

**Dependencies**: None

**Testing instructions**:

1. Create and activate a theme with content in `lms/templates/courseware/progress.html` similar to the following:
```
<%inherit file="progress.html" />
<%block name="certificate_block">Test Override Block</%block>
${parent.body()}
```
2. Check the progress page and see that the block is overrode and "Test Override Block" shows above the course progress display.

**Reviewers**
- [ ] edX reviewer[s] TBD