### PR TITLE
Add waffle flag to show about page when marketing site is enabled

### DIFF
--- a/lms/djangoapps/courseware/views/views.py
+++ b/lms/djangoapps/courseware/views/views.py
@@ -92,7 +92,7 @@ from openedx.features.course_experience import UNIFIED_COURSE_TAB_FLAG, course_h
 from openedx.features.course_experience.course_tools import CourseToolsPluginManager
 from openedx.features.course_experience.views.course_dates import CourseDatesFragmentView
 from openedx.features.course_experience.waffle import waffle as course_experience_waffle
-from openedx.features.course_experience.waffle import ENABLE_COURSE_ABOUT_SIDEBAR_HTML
+from openedx.features.course_experience.waffle import ENABLE_COURSE_ABOUT_SIDEBAR_HTML, ENABLE_COURSE_ABOUT_MARKETING
 from openedx.features.enterprise_support.api import data_sharing_consent_required
 from openedx.features.journals.api import get_journals_context
 from shoppingcart.utils import is_shopping_cart_enabled
@@ -771,7 +771,8 @@ def course_about(request, course_id):
         course_details = CourseDetails.populate(course)
         modes = CourseMode.modes_for_course_dict(course_key)
 
-        if configuration_helpers.get_value('ENABLE_MKTG_SITE', settings.FEATURES.get('ENABLE_MKTG_SITE', False)):
+        if configuration_helpers.get_value('ENABLE_MKTG_SITE', settings.FEATURES.get('ENABLE_MKTG_SITE', False)) and \
+                not course_experience_waffle().is_enabled(ENABLE_COURSE_ABOUT_MARKETING):
             return redirect(reverse(course_home_url_name(course.id), args=[text_type(course.id)]))
 
         registered = registered_for_course(course, request.user)

--- a/openedx/features/course_experience/waffle.py
+++ b/openedx/features/course_experience/waffle.py
@@ -8,6 +8,7 @@ WAFFLE_NAMESPACE = u'course_experience'
 
 # Switches
 ENABLE_COURSE_ABOUT_SIDEBAR_HTML = u'enable_about_sidebar_html'
+ENABLE_COURSE_ABOUT_MARKETING = u'enable_about_marketing'
 
 
 def waffle():


### PR DESCRIPTION
We wanted to continue showing the about page even when the marketing site integration was enabled.
This PR adds a waffle flag to prevent the course about page from redirecting to the info page.
This will allow students to continue use the enrollment button via the about page, while we use the marketing site integration elsewhere in the platform.

**JIRA tickets**: Implements BB-648

**Dependencies**: None

**Merge deadline**: None

**Testing instructions**:

1. Enable marketing site in devstack: `settings.FEATURES['ENABLE_MKTG_SITE'] = True`
2. Check that a course about page redirects to the info page for that course
3. Enable the waffle switch
4. Check that the course about page loads again, without redirecting to the info page

**Author notes and concerns**:

1. Is this a suitable name for the waffle flag?
2. Is there some other way we should be controlling this behavior?

**Reviewers**
- [ ] (@lgp171188)
- [ ] edX reviewer[s] TBD

**Settings**
```yaml
EDXAPP_FEATURES:
  ENABLE_MKTG_SITE: true
```