### PR TITLE
Static storage fix test

### DIFF
--- a/openedx/core/storage.py
+++ b/openedx/core/storage.py
@@ -25,6 +25,16 @@ class PipelineForgivingStorage(PipelineCachedStorage):
             out = name
         return out
 
+    def stored_name(self, name):
+        try:
+            out = super(PipelineForgivingStorage, self).stored_name(name)
+        except ValueError:
+            # This means that a file could not be found, and normally this would
+            # cause a fatal error, which seems rather excessive given that
+            # some packages have missing files in their css all the time.
+            out = name
+        return out
+
 
 class ProductionStorage(
         PipelineForgivingStorage,


### PR DESCRIPTION
[EDUCATOR-3780](https://openedx.atlassian.net/browse/EDUCATOR-3780)
[EDUCATOR-3723](https://openedx.atlassian.net/browse/EDUCATOR-3723)
@cpennington based on your comments, I have opened this PR. Please take a look if I have understood the comment correctly or there can be anyother way we can improve this?

> the `static_replace` code (which is supposed to be replacing assets in xblocks that look like `/static/...` with the correct URL for the LMS. If it can't find particular assets in the Django storage, though, it's just supposed to leave them alone.



Sandbox: https://studio-educator3723.sandbox.edx.org/container/block-v1:edX+DemoX+Demo_Course+type@vertical+block@45c7cedb4bfe46f4a68c78787151cfb5