### PR TITLE
asadiqbal08/ENT-1115 Dashboard alert to set recovery email

### DIFF
--- a/common/djangoapps/student/views/dashboard.py
+++ b/common/djangoapps/student/views/dashboard.py
@@ -39,14 +39,17 @@ from openedx.core.djangoapps.programs.utils import ProgramDataExtender, ProgramP
 from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
 from openedx.core.djangoapps.util.maintenance_banner import add_maintenance_banner
 from openedx.core.djangoapps.waffle_utils import WaffleFlag, WaffleFlagNamespace
+from openedx.core.djangoapps.user_api.accounts.utils import is_secondary_email_feature_enabled_for_user
 from openedx.core.djangolib.markup import HTML, Text
 from openedx.features.enterprise_support.api import get_dashboard_consent_notification
+from openedx.features.enterprise_support.utils import is_enterprise_learner
 from openedx.features.journals.api import journals_enabled
 from shoppingcart.api import order_history
 from shoppingcart.models import CourseRegistrationCode, DonationConfiguration
 from openedx.core.djangoapps.user_authn.cookies import set_deprecated_user_info_cookie
 from student.helpers import cert_info, check_verify_status_by_course
 from student.models import (
+    AccountRecovery,
     CourseEnrollment,
     CourseEnrollmentAttribute,
     DashboardConfiguration,
@@ -629,6 +632,21 @@ def student_dashboard(request):
 
     enterprise_message = get_dashboard_consent_notification(request, user, course_enrollments)
 
+    recovery_email_message = None
+
+    secondary_email_exist = AccountRecovery.objects.filter(user=user).exists()
+    if is_secondary_email_feature_enabled_for_user(user=user) and not secondary_email_exist:
+        recovery_email_message = Text(
+            _(
+                "Add a recovery email to retain access when single-sign on is not available. "
+                "Go to {link_start}your Account Settings{link_end}.")
+        ).format(
+            link_start=HTML("<a target='_blank' href='{account_setting_page}'>").format(
+                account_setting_page=reverse('account_settings'),
+            ),
+            link_end=HTML("</a>")
+        )
+
     # Disable lookup of Enterprise consent_required_course due to ENT-727
     # Will re-enable after fixing WL-1315
     consent_required_courses = set()
@@ -832,6 +850,7 @@ def student_dashboard(request):
         'display_sidebar_account_activation_message': not(user.is_active or hide_dashboard_courses_until_activated),
         'display_dashboard_courses': (user.is_active or not hide_dashboard_courses_until_activated),
         'empty_dashboard_message': empty_dashboard_message,
+        'recovery_email_message': recovery_email_message
     }
 
     if ecommerce_service.is_enabled(request.user):

--- a/lms/static/js/views/message_banner.js
+++ b/lms/static/js/views/message_banner.js
@@ -1,23 +1,43 @@
 (function(define) {
     'use strict';
     define([
-        'gettext', 'jquery', 'underscore', 'backbone', 'text!templates/fields/message_banner.underscore'
-    ], function(gettext, $, _, Backbone, messageBannerTemplate) {
+        'gettext',
+        'jquery',
+        'underscore',
+        'backbone',
+        'text!templates/fields/message_banner.underscore',
+        'edx-ui-toolkit/js/utils/html-utils'
+    ], function(gettext, $, _, Backbone, messageBannerTemplate, HtmlUtils) {
         var MessageBannerView = Backbone.View.extend({
+
+            events: {
+                'click #close': 'closeBanner'
+            },
+
+            closeBanner: function(event) {
+                sessionStorage.setItem("isBannerClosed", true);
+                this.hideMessage();
+            },
 
             initialize: function(options) {
                 if (_.isUndefined(options)) {
                     options = {};
                 }
-                this.options = _.defaults(options, {urgency: 'high', type: ''});
+                this.options = _.defaults(options, {
+                    urgency: 'high',
+                    type: '',
+                    hideCloseBtn: true,
+                    isRecoveryEmailMsg: false
+                });
             },
 
             render: function() {
                 if (_.isUndefined(this.message) || _.isNull(this.message)) {
                     this.$el.html('');
                 } else {
-                    this.$el.html(_.template(messageBannerTemplate)(_.extend(this.options, {
-                        message: this.message
+                    this.$el.html(_.template(messageBannerTemplate)(_.extend(this.options, {  // xss-lint: disable=javascript-jquery-html
+                        message: this.message,
+                        HtmlUtils: HtmlUtils
                     })));
                 }
                 return this;
@@ -25,7 +45,9 @@
 
             showMessage: function(message) {
                 this.message = message;
-                this.render();
+                if (sessionStorage.getItem("isBannerClosed") == null) {
+                    this.render();
+                }
             },
 
             hideMessage: function() {

--- a/lms/static/sass/elements/_system-feedback.scss
+++ b/lms/static/sass/elements/_system-feedback.scss
@@ -111,10 +111,26 @@
     }
   }
 
+  &.recovery-email-alert {
+    &#banner-msg {
+      background: $state-info-bg ;
+      box-shadow: none;
+      border-top: 1px solid #579cc5;
+      padding: 20px 20px 20px 40px;
+      margin-top: -16px;
+    }
+    .fa-close {
+      position: relative;
+      float: right;
+    }
+    .fa-close:hover {
+      cursor: pointer;
+    }
+  }
+
   &.urgency-low {
     background: $notify-banner-bg-3;
     box-shadow: 0 1px 2px $shadow;
-
     .msg {
       color: $black;
     }

--- a/lms/templates/dashboard.html
+++ b/lms/templates/dashboard.html
@@ -84,6 +84,13 @@ from student.models import CourseEnrollment
         banner.showMessage(${redirect_message | n, dump_js_escaped_json})
     </%static:require_module>
   % endif
+  % if recovery_email_message:
+      <%static:require_module module_name="js/views/message_banner" class_name="MessageBannerView">
+        var banner = new MessageBannerView({urgency: 'low', type: 'warning', hideCloseBtn: false, isRecoveryEmailMsg: true});
+        $('#content').prepend(banner.$el);
+        banner.showMessage(${recovery_email_message | n, dump_js_escaped_json})
+      </%static:require_module>
+  % endif
 </%block>
 
 <div class="dashboard-notifications" tabindex="-1">

--- a/lms/templates/fields/message_banner.underscore
+++ b/lms/templates/fields/message_banner.underscore
@@ -1,8 +1,9 @@
-<div class="wrapper-msg urgency-<%- urgency %> <%- type %>" role="alert">
+<div id="banner-msg" class="wrapper-msg urgency-<%- urgency %> <%- type %> <% if (isRecoveryEmailMsg == true) { %> recovery-email-alert <% } %>" role="alert">
+  <i <% if (hideCloseBtn == true) { %> hidden <% } %> id="close" class="fa fa-close close-icon"></i>
     <div class="msg">
         <div class="msg-content">
             <div class="copy">
-                <p><%-message%></p>
+                <p><%= HtmlUtils.HTML(message) %></p>
             </div>
         </div>
     </div>


### PR DESCRIPTION
#### Task: [ENT-1115 Dashboard alert to set recovery email](https://openedx.atlassian.net/browse/ENT-1115)
#### What is implemented in PR?:
1. Existing enterprise learners (without associated recovery email addresses) will see the alert/notification on the LMS dashboard upon the first time logging in after this story is released
2. New (accounts created after this story is released) enterprise learners will see this alert if they chose not to enter a recovery email during account setup (Product to confirm that they are able to do this during setup)
3. When user dismisses the alert, it does not reappear until the user has close/terminate the browser session.

#### Steps for verification:

1. Login in system as an enterprise learner. 
2. You will see an alert if you chose not to enter a recovery email during account setup.
3. On clicking on the [your Account Settings](#) link, User will be redirected to account setting page. 
4. On clicking on the "**x**" icon (top right of the message), alert box will be dismissed and System will show it again when user visit the website in a new browser session. 

<img width="1277" alt="screen shot 2018-12-17 at 5 14 51 pm" src="https://user-images.githubusercontent.com/7334669/50086577-52ecc080-021f-11e9-84a6-c048f314c380.png">
