### PR TITLE
ENT-1117: Request password reset with recovery email address

### DIFF
--- a/common/djangoapps/student/urls.py
+++ b/common/djangoapps/student/urls.py
@@ -22,6 +22,7 @@ urlpatterns = [
 
     # password reset in views (see below for password reset django views)
     url(r'^account/password$', views.password_change_request_handler, name='password_change_request'),
+    url(r'^account/account_recovery', views.account_recovery_request_handler, name='account_recovery'),
     url(r'^password_reset/$', views.password_reset, name='password_reset'),
     url(
         r'^password_reset_confirm/(?P<uidb36>[0-9A-Za-z]+)-(?P<token>.+)/$',

--- a/lms/static/js/spec/student_account/account_recovery_spec.js
+++ b/lms/static/js/spec/student_account/account_recovery_spec.js
@@ -1,0 +1,152 @@
+(function(define) {
+    'use strict';
+    define([
+        'jquery',
+        'underscore',
+        'common/js/spec_helpers/template_helpers',
+        'edx-ui-toolkit/js/utils/spec-helpers/ajax-helpers',
+        'js/student_account/models/AccountRecoveryModel',
+        'js/student_account/views/AccountRecoveryView'
+    ],
+        function($, _, TemplateHelpers, AjaxHelpers, AccountRecoveryModel, AccountRecoveryView) {
+            describe('edx.student.account.AccountRecoveryView', function() {
+                var model = null,
+                    view = null,
+                    requests = null,
+                    EMAIL = 'xsy@edx.org',
+                    FORM_DESCRIPTION = {
+                        method: 'post',
+                        submit_url: '/account/password',
+                        fields: [{
+                            name: 'email',
+                            label: 'Secondary email',
+                            defaultValue: '',
+                            type: 'text',
+                            required: true,
+                            placeholder: 'place@holder.org',
+                            instructions: 'Enter your secondary email.',
+                            restrictions: {}
+                        }]
+                    };
+
+                var createAccountRecoveryView = function(that) {
+                    // Initialize the account recovery model
+                    model = new AccountRecoveryModel({}, {
+                        url: FORM_DESCRIPTION.submit_url,
+                        method: FORM_DESCRIPTION.method
+                    });
+
+                    // Initialize the account recovery view
+                    view = new AccountRecoveryView({
+                        fields: FORM_DESCRIPTION.fields,
+                        model: model
+                    });
+
+                    // Spy on AJAX requests
+                    requests = AjaxHelpers.requests(that);
+                };
+
+                var submitEmail = function(validationSuccess) {
+                    // Create a fake click event
+                    var clickEvent = $.Event('click');
+
+                    // Simulate manual entry of an email address
+                    $('#password-reset-email').val(EMAIL);
+
+                    // If validationSuccess isn't passed, we avoid
+                    // spying on `view.validate` twice
+                    if (!_.isUndefined(validationSuccess)) {
+                    // Force validation to return as expected
+                        spyOn(view, 'validate').and.returnValue({
+                            isValid: validationSuccess,
+                            message: 'Submission was validated.'
+                        });
+                    }
+
+                // Submit the email address
+                    view.submitForm(clickEvent);
+                };
+
+                beforeEach(function() {
+                    setFixtures('<div id="password-reset-form" class="form-wrapper hidden"></div>');
+                    TemplateHelpers.installTemplate('templates/student_account/account_recovery');
+                    TemplateHelpers.installTemplate('templates/student_account/form_field');
+                });
+
+                it('allows the user to request account recovery', function() {
+                    var syncSpy, passwordEmailSentSpy;
+
+                    createAccountRecoveryView(this);
+
+                    // We expect these events to be triggered upon a successful account recovery
+                    syncSpy = jasmine.createSpy('syncEvent');
+                    passwordEmailSentSpy = jasmine.createSpy('passwordEmailSentEvent');
+                    view.listenTo(view.model, 'sync', syncSpy);
+                    view.listenTo(view, 'account-recovery-email-sent', passwordEmailSentSpy);
+
+                    // Submit the form, with successful validation
+                    submitEmail(true);
+
+                    // Verify that the client contacts the server with the expected data
+                    AjaxHelpers.expectRequest(
+                        requests, 'POST',
+                        FORM_DESCRIPTION.submit_url,
+                        $.param({email: EMAIL})
+                    );
+
+                    // Respond with status code 200
+                    AjaxHelpers.respondWithJson(requests, {});
+
+                    // Verify that the events were triggered
+                    expect(syncSpy).toHaveBeenCalled();
+                    expect(passwordEmailSentSpy).toHaveBeenCalled();
+
+                    // Verify that account recovery view has been removed
+                    expect($(view.el).html().length).toEqual(0);
+                });
+
+                it('validates the email field', function() {
+                    createAccountRecoveryView(this);
+
+                    // Submit the form, with successful validation
+                    submitEmail(true);
+
+                    // Verify that validation of the email field occurred
+                    expect(view.validate).toHaveBeenCalledWith($('#password-reset-email')[0]);
+
+                    // Verify that no submission errors are visible
+                    expect(view.$formFeedback.find('.' + view.formErrorsJsHook).length).toEqual(0);
+                });
+
+                it('displays account recovery validation errors', function() {
+                    createAccountRecoveryView(this);
+
+                    // Submit the form, with failed validation
+                    submitEmail(false);
+
+                    // Verify that submission errors are visible
+                    expect(view.$formFeedback.find('.' + view.formErrorsJsHook).length).toEqual(1);
+                });
+
+                it('displays error if the server returns an error while sending account recovery email', function() {
+                    createAccountRecoveryView(this);
+                    submitEmail(true);
+
+                    // Simulate an error from the LMS servers
+                    AjaxHelpers.respondWithError(requests);
+
+                    // Expect that an error is displayed
+                    expect(view.$formFeedback.find('.' + view.formErrorsJsHook).length).toEqual(1);
+
+                    // If we try again and succeed, the error should go away
+                    submitEmail();
+
+                    // This time, respond with status code 200
+                    AjaxHelpers.respondWithJson(requests, {});
+
+                    // Expect that the error is hidden
+                    expect(view.$formFeedback.find('.' + view.formErrorsJsHook).length).toEqual(0);
+                });
+            });
+        });
+}).call(this, define || RequireJS.define);

--- a/lms/static/js/student_account/models/AccountRecoveryModel.js
+++ b/lms/static/js/student_account/models/AccountRecoveryModel.js
@@ -1,0 +1,38 @@
+(function(define) {
+    'use strict';
+    define(['jquery', 'backbone'],
+        function($, Backbone) {
+            return Backbone.Model.extend({
+                defaults: {
+                    email: ''
+                },
+                ajaxType: '',
+                urlRoot: '',
+
+                initialize: function(attributes, options) {
+                    this.ajaxType = options.method;
+                    this.urlRoot = options.url;
+                },
+
+                sync: function(method, model) {
+                    var headers = {
+                        'X-CSRFToken': $.cookie('csrftoken')
+                    };
+
+                // Only expects an email address.
+                    $.ajax({
+                        url: model.urlRoot,
+                        type: model.ajaxType,
+                        data: model.attributes,
+                        headers: headers,
+                        success: function() {
+                            model.trigger('sync');
+                        },
+                        error: function(error) {
+                            model.trigger('error', error);
+                        }
+                    });
+                }
+            });
+        });
+}).call(this, define || RequireJS.define);

--- a/lms/static/js/student_account/views/AccessView.js
+++ b/lms/static/js/student_account/views/AccessView.js
@@ -9,15 +9,19 @@
         'js/student_account/models/LoginModel',
         'js/student_account/models/PasswordResetModel',
         'js/student_account/models/RegisterModel',
+        'js/student_account/models/AccountRecoveryModel',
         'js/student_account/views/LoginView',
         'js/student_account/views/PasswordResetView',
         'js/student_account/views/RegisterView',
         'js/student_account/views/InstitutionLoginView',
         'js/student_account/views/HintedLoginView',
+        'js/student_account/views/AccountRecoveryView',
+        'edx-ui-toolkit/js/utils/html-utils',
         'js/vendor/history'
     ],
-        function($, utility, _, _s, Backbone, LoginModel, PasswordResetModel, RegisterModel, LoginView,
-                 PasswordResetView, RegisterView, InstitutionLoginView, HintedLoginView) {
+        function($, utility, _, _s, Backbone, LoginModel, PasswordResetModel, RegisterModel, AccountRecoveryModel,
+                 LoginView, PasswordResetView, RegisterView, InstitutionLoginView, HintedLoginView, AccountRecoveryView,
+                 HtmlUtils) {
             return Backbone.View.extend({
                 tpl: '#access-tpl',
                 events: {
@@ -27,6 +31,7 @@
                     login: {},
                     register: {},
                     passwordHelp: {},
+                    accountRecoveryHelp: {},
                     institutionLogin: {},
                     hintedLogin: {}
                 },
@@ -63,6 +68,7 @@
                         login: options.login_form_desc,
                         register: options.registration_form_desc,
                         reset: options.password_reset_form_desc,
+                        account_recovery: options.account_recovery_form_desc,
                         institution_login: null,
                         hinted_login: null
                     };
@@ -74,9 +80,15 @@
                     this.hideAuthWarnings = options.hide_auth_warnings || false;
                     this.pipelineUserDetails = options.third_party_auth.pipeline_user_details;
                     this.enterpriseName = options.enterprise_name || '';
+                    this.isAccountRecoveryFeatureEnabled = options.is_account_recovery_feature_enabled || false;
 
                 // The login view listens for 'sync' events from the reset model
                     this.resetModel = new PasswordResetModel({}, {
+                        method: 'GET',
+                        url: '#'
+                    });
+
+                    this.accountRecoveryModel = new AccountRecoveryModel({}, {
                         method: 'GET',
                         url: '#'
                     });
@@ -93,10 +105,14 @@
                 },
 
                 render: function() {
-                    $(this.el).html(_.template(this.tpl)({
-                        mode: this.activeForm
-                    }));
-
+                    HtmlUtils.setHtml(
+                        $(this.el),
+                        HtmlUtils.HTML(
+                            _.template(this.tpl)({
+                                mode: this.activeForm
+                            })
+                        )
+                    )
                     this.postRender();
 
                     return this;
@@ -106,6 +122,9 @@
                 // get & check current url hash part & load form accordingly
                     if (Backbone.history.getHash() === 'forgot-password-modal') {
                         this.resetPassword();
+                    }
+                    else if (Backbone.history.getHash() === 'account-recovery-modal') {
+                        this.accountRecovery();
                     }
                     this.loadForm(this.activeForm);
                 },
@@ -126,6 +145,7 @@
                             fields: data.fields,
                             model: model,
                             resetModel: this.resetModel,
+                            accountRecoveryModel: this.accountRecoveryModel,
                             thirdPartyAuth: this.thirdPartyAuth,
                             accountActivationMessages: this.accountActivationMessages,
                             platformName: this.platformName,
@@ -139,6 +159,9 @@
 
                     // Listen for 'password-help' event to toggle sub-views
                         this.listenTo(this.subview.login, 'password-help', this.resetPassword);
+
+                    // Listen for 'account-recovery-help' event to toggle sub-views
+                        this.listenTo(this.subview.login, 'account-recovery-help', this.accountRecovery);
 
                     // Listen for 'auth-complete' event so we can enroll/redirect the user appropriately.
                         this.listenTo(this.subview.login, 'auth-complete', this.authComplete);
@@ -155,6 +178,24 @@
 
                     // Listen for 'password-email-sent' event to toggle sub-views
                         this.listenTo(this.subview.passwordHelp, 'password-email-sent', this.passwordEmailSent);
+
+                    // Focus on the form
+                        $('.password-reset-form').focus();
+                    },
+
+                    account_recovery: function(data) {
+                        this.accountRecoveryModel.ajaxType = data.method;
+                        this.accountRecoveryModel.urlRoot = data.submit_url;
+
+                        this.subview.accountRecoveryHelp = new AccountRecoveryView({
+                            fields: data.fields,
+                            model: this.accountRecoveryModel
+                        });
+
+                    // Listen for 'account-recovery-email-sent' event to toggle sub-views
+                        this.listenTo(
+                            this.subview.accountRecoveryHelp, 'account-recovery-email-sent', this.passwordEmailSent
+                        );
 
                     // Focus on the form
                         $('.password-reset-form').focus();
@@ -214,6 +255,19 @@
                     this.element.hide($(this.el).find('#login-anchor'));
                     this.loadForm('reset');
                     this.element.scrollTop($('#password-reset-anchor'));
+                },
+
+                accountRecovery: function() {
+                    if (this.isAccountRecoveryFeatureEnabled) {
+                        window.analytics.track('edx.bi.account_recovery.viewed', {
+                            category: 'user-engagement'
+                        });
+
+                        this.element.hide($(this.el).find('#login-anchor'));
+                        this.loadForm('account_recovery');
+                        this.element.scrollTop($('#password-reset-anchor'));
+                    }
+
                 },
 
                 toggleForm: function(e) {

--- a/lms/static/js/student_account/views/AccountRecoveryView.js
+++ b/lms/static/js/student_account/views/AccountRecoveryView.js
@@ -1,0 +1,39 @@
+(function(define) {
+    'use strict';
+    define([
+        'jquery',
+        'js/student_account/views/FormView'
+    ],
+        function($, FormView) {
+            return FormView.extend({
+                el: '#password-reset-form',
+
+                tpl: '#account_recovery-tpl',
+
+                events: {
+                    'click .js-reset': 'submitForm'
+                },
+
+                formType: 'password-reset',
+
+                requiredStr: '',
+                optionalStr: '',
+
+                submitButton: '.js-reset',
+
+                preRender: function() {
+                    this.element.show($(this.el));
+                    this.element.show($(this.el).parent());
+                    this.listenTo(this.model, 'sync', this.saveSuccess);
+                },
+
+                saveSuccess: function() {
+                    this.trigger('account-recovery-email-sent');
+
+                    // Destroy the view (but not el) and unbind events
+                    this.$el.empty().off();
+                    this.stopListening();
+                }
+            });
+        });
+}).call(this, define || RequireJS.define);

--- a/lms/static/js/student_account/views/FormView.js
+++ b/lms/static/js/student_account/views/FormView.js
@@ -55,10 +55,15 @@
             render: function(html) {
                 var fields = html || '';
 
-                $(this.el).html(_.template(this.tpl)({
-                    fields: fields
-                }));
-
+                HtmlUtils.setHtml(
+                    $(this.el),
+                    HtmlUtils.HTML(
+                        _.template(this.tpl)({
+                            fields: fields,
+                            HtmlUtils: HtmlUtils
+                        })
+                    )
+                )
                 this.postRender();
 
                 return this;
@@ -132,6 +137,12 @@
                 event.preventDefault();
 
                 this.trigger('password-help');
+            },
+
+            accountRecovery: function(event) {
+                event.preventDefault();
+
+                this.trigger('account-recovery-help');
             },
 
             getFormData: function() {

--- a/lms/static/js/student_account/views/LoginView.js
+++ b/lms/static/js/student_account/views/LoginView.js
@@ -23,6 +23,7 @@
             events: {
                 'click .js-login': 'submitForm',
                 'click .forgot-password': 'forgotPassword',
+                'click .account-recovery': 'accountRecovery',
                 'click .login-provider': 'thirdPartyAuth'
             },
             formType: 'login',
@@ -45,6 +46,7 @@
                 this.errorMessage = data.thirdPartyAuth.errorMessage || '';
                 this.platformName = data.platformName;
                 this.resetModel = data.resetModel;
+                this.accountRecoveryModel = data.accountRecoveryModel;
                 this.supportURL = data.supportURL;
                 this.passwordResetSupportUrl = data.passwordResetSupportUrl;
                 this.createAccountOption = data.createAccountOption;
@@ -55,27 +57,32 @@
 
                 this.listenTo(this.model, 'sync', this.saveSuccess);
                 this.listenTo(this.resetModel, 'sync', this.resetEmail);
+                this.listenTo(this.accountRecoveryModel, 'sync', this.resetEmail);
             },
 
             render: function(html) {
                 var fields = html || '';
 
-                $(this.el).html(_.template(this.tpl)({
-                // We pass the context object to the template so that
-                // we can perform variable interpolation using sprintf
-                    context: {
-                        fields: fields,
-                        currentProvider: this.currentProvider,
-                        syncLearnerProfileData: this.syncLearnerProfileData,
-                        providers: this.providers,
-                        hasSecondaryProviders: this.hasSecondaryProviders,
-                        platformName: this.platformName,
-                        createAccountOption: this.createAccountOption,
-                        pipelineUserDetails: this.pipelineUserDetails,
-                        enterpriseName: this.enterpriseName
-                    }
-                }));
-
+                HtmlUtils.setHtml(
+                    $(this.el),
+                    HtmlUtils.HTML(
+                        _.template(this.tpl)({
+                            // We pass the context object to the template so that
+                            // we can perform variable interpolation using sprintf
+                            context: {
+                                fields: fields,
+                                currentProvider: this.currentProvider,
+                                syncLearnerProfileData: this.syncLearnerProfileData,
+                                providers: this.providers,
+                                hasSecondaryProviders: this.hasSecondaryProviders,
+                                platformName: this.platformName,
+                                createAccountOption: this.createAccountOption,
+                                pipelineUserDetails: this.pipelineUserDetails,
+                                enterpriseName: this.enterpriseName
+                            }
+                        })
+                    )
+                )
                 this.postRender();
 
                 return this;
@@ -121,6 +128,13 @@
                 event.preventDefault();
 
                 this.trigger('password-help');
+                this.clearPasswordResetSuccess();
+            },
+
+            accountRecovery: function(event) {
+                event.preventDefault();
+
+                this.trigger('account-recovery-help');
                 this.clearPasswordResetSuccess();
             },
 

--- a/lms/static/lms/js/spec/main.js
+++ b/lms/static/lms/js/spec/main.js
@@ -787,6 +787,7 @@
         'js/spec/student_account/login_spec.js',
         'js/spec/student_account/logistration_factory_spec.js',
         'js/spec/student_account/password_reset_spec.js',
+        'js/spec/student_account/account_recovery_spec.js',
         'js/spec/student_account/register_spec.js',
         'js/spec/student_account/shoppingcart_spec.js',
         'js/spec/verify_student/image_input_spec.js',

--- a/lms/templates/student_account/account_recovery.underscore
+++ b/lms/templates/student_account/account_recovery.underscore
@@ -1,0 +1,13 @@
+<div class="js-form-feedback" aria-live="assertive" tabindex="-1">
+</div>
+
+<h2><%- gettext("Account Recovery") %></h2>
+
+<form id="account-recovery" class="account-recovery-form password-reset-form" tabindex="-1" method="POST">
+
+    <p class="action-label"><%- gettext("Please enter your secondary email address below and we will send you instructions for recovering your account and setting a new password.") %></p>
+
+    <%= HtmlUtils.HTML(fields) %>
+
+    <button type="submit" class="action action-primary action-update js-reset"><%- gettext("Recover my account") %></button>
+</form>

--- a/lms/templates/student_account/login_and_register.html
+++ b/lms/templates/student_account/login_and_register.html
@@ -30,7 +30,7 @@
 </%block>
 
 <%block name="header_extras">
-    % for template_name in ["account", "access", "form_field", "login", "register", "institution_login", "institution_register", "password_reset", "hinted_login"]:
+    % for template_name in ["account", "access", "form_field", "login", "register", "institution_login", "institution_register", "password_reset", "account_recovery", "hinted_login"]:
         <script type="text/template" id="${template_name}-tpl">
             <%static:include path="student_account/${template_name}.underscore" />
         </script>

--- a/openedx/core/djangoapps/user_api/api.py
+++ b/openedx/core/djangoapps/user_api/api.py
@@ -66,6 +66,54 @@ def get_password_reset_form():
     return form_desc
 
 
+def get_account_recovery_form():
+    """
+    Return a description of the password reset, using secondary email, form.
+
+    This decouples clients from the API definition:
+    if the API decides to modify the form, clients won't need
+    to be updated.
+
+    See `user_api.helpers.FormDescription` for examples
+    of the JSON-encoded form description.
+
+    Returns:
+        HttpResponse
+
+    """
+    form_desc = FormDescription("post", reverse("account_recovery"))
+
+    # Translators: This label appears above a field on the password reset
+    # form meant to hold the user's email address.
+    email_label = _(u"Secondary email")
+
+    # Translators: This example email address is used as a placeholder in
+    # a field on the password reset form meant to hold the user's email address.
+    email_placeholder = _(u"username@domain.com")
+
+    # Translators: These instructions appear on the password reset form,
+    # immediately below a field meant to hold the user's email address.
+    email_instructions = _(
+        u"Secondary email address you registered with {platform_name} using account settings page"
+    ).format(
+        platform_name=configuration_helpers.get_value('PLATFORM_NAME', settings.PLATFORM_NAME)
+    )
+
+    form_desc.add_field(
+        "email",
+        field_type="email",
+        label=email_label,
+        placeholder=email_placeholder,
+        instructions=email_instructions,
+        restrictions={
+            "min_length": accounts.EMAIL_MIN_LENGTH,
+            "max_length": accounts.EMAIL_MAX_LENGTH,
+        }
+    )
+
+    return form_desc
+
+
 def get_login_session_form(request):
     """Return a description of the login form.
 

--- a/openedx/core/djangoapps/user_authn/views/login_form.py
+++ b/openedx/core/djangoapps/user_authn/views/login_form.py
@@ -19,10 +19,12 @@ from openedx.core.djangoapps.external_auth.login_and_register import login as ex
 from openedx.core.djangoapps.external_auth.login_and_register import register as external_auth_register
 from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
 from openedx.core.djangoapps.theming.helpers import is_request_in_themed_site
+from openedx.core.djangoapps.user_api.accounts.utils import is_secondary_email_feature_enabled
 from openedx.core.djangoapps.user_api.api import (
     RegistrationFormFactory,
+    get_account_recovery_form,
     get_login_session_form,
-    get_password_reset_form
+    get_password_reset_form,
 )
 from openedx.core.djangoapps.user_authn.cookies import are_logged_in_cookies_set
 from openedx.features.enterprise_support.api import enterprise_customer_for_request
@@ -129,8 +131,10 @@ def login_and_registration_form(request, initial_mode="login"):
             'login_form_desc': json.loads(form_descriptions['login']),
             'registration_form_desc': json.loads(form_descriptions['registration']),
             'password_reset_form_desc': json.loads(form_descriptions['password_reset']),
+            'account_recovery_form_desc': json.loads(form_descriptions['account_recovery']),
             'account_creation_allowed': configuration_helpers.get_value(
-                'ALLOW_PUBLIC_ACCOUNT_CREATION', settings.FEATURES.get('ALLOW_PUBLIC_ACCOUNT_CREATION', True))
+                'ALLOW_PUBLIC_ACCOUNT_CREATION', settings.FEATURES.get('ALLOW_PUBLIC_ACCOUNT_CREATION', True)),
+            'is_account_recovery_feature_enabled': is_secondary_email_feature_enabled()
         },
         'login_redirect_url': redirect_to,  # This gets added to the query string of the "Sign In" button in header
         'responsive': True,
@@ -166,6 +170,7 @@ def _get_form_descriptions(request):
 
     return {
         'password_reset': get_password_reset_form().to_json(),
+        'account_recovery': get_account_recovery_form().to_json(),
         'login': get_login_session_form(request).to_json(),
         'registration': RegistrationFormFactory().get_registration_form(request).to_json()
     }


### PR DESCRIPTION
**JIRA Ticket:** [ENT-1117](https://openedx.atlassian.net/browse/ENT-1117)

**Description:**
As a learner who previously had an enterprise account but can no longer access it (i.e. unlinked and no access to company email), I want to be able to log-in again to access my account. I want to click a link on the log-in page specifically for this scenario, separate from the current “Forgot Password” link, and then be sent an email at my previously entered recovery address with a link directing me to set a new password. I can then set a new password.

**Other considerations:**
If I have not entered a recovery email address, then I'll be unable to set a new password and will instead be directed to a help screen

**Acceptance criteria:**

1.  Toggle secondary email recovery behind Waffle switch
2.  Create "Assistance Page" for getting the secondary email
3.  Show help text for the learner to contact to support in case no learner with secondary email exists
4.  Show "Check You Email" message (a screenshot provided for primary email) asking the learner to check the secondary email for password reset link to set a new password (similar to existing password recovery workflow) and also send an email with the account recovery link.

**Screenshots:**
<img width="1278" alt="screen shot 2018-12-17 at 3 17 16 pm" src="https://user-images.githubusercontent.com/7114956/50080897-f7b2d200-020e-11e9-9804-794863591a7b.png">
<img width="1278" alt="screen shot 2018-12-17 at 3 16 59 pm" src="https://user-images.githubusercontent.com/7114956/50080918-ff727680-020e-11e9-86c9-cd0080199d39.png">
