### PR TITLE
Change Account Settings form controls border color

### DIFF
--- a/lms/static/sass/partials/lms/theme/_variables-v1.scss
+++ b/lms/static/sass/partials/lms/theme/_variables-v1.scss
@@ -238,6 +238,9 @@ $zebra-stripe-color: rgb(249, 250, 252) !default;
 $divider-color: rgb(226, 231, 236) !default;
 $lms-preview-menu-color: #c8c8c8 !default;
 
+//Form control border color for account settings
+$gray58-border: tint($gray, 22%) !default;
+
 // old color variables
 // DEPRECATED: Do not continue to use these colors, instead use pattern libary and base colors above.
 $dark-gray1: rgb(74, 74, 74) !default;

--- a/lms/static/sass/views/_account-settings.scss
+++ b/lms/static/sass/views/_account-settings.scss
@@ -203,7 +203,7 @@
             @include appearance(none);
 
             padding: 14px 30px 14px 15px;
-            border: 1px solid $light-gray;
+            border: 1px solid $gray58-border;
             background-color: transparent;
             border-radius: 2px;
             position: relative;
@@ -242,7 +242,7 @@
 
             display: inline-block;
             padding: 0.625rem;
-            border: 1px solid $light-gray;
+            border: 1px solid $gray58-border;
             border-radius: 2px;
             background: $white;
             font-size: $body-font-size;


### PR DESCRIPTION
[LEARNER-6610](https://openedx.atlassian.net/browse/LEARNER-6610)

#### Description 
WCAG 2.1 requires actionable elements to have clearly discernible borders. For the "Account Settings" page all the <input> and <select> tags now have border color set to #949494 (Gray58), previously it had a border color of #dddddd (light-gray)