### PR TITLE
Fix static urls in pdf_viewer.html to correctly display PDF viewer for textbooks

### DIFF
--- a/common/djangoapps/pipeline_mako/templates/static_content.html
+++ b/common/djangoapps/pipeline_mako/templates/static_content.html
@@ -31,10 +31,7 @@ logger = logging.getLogger(__name__)
 %></%def>
 
 <%def name='url(file, raw=False)'><%
-try:
-    url = staticfiles_storage.url(file)
-except:
-    url = file
+url = staticfiles_storage.url(file)
 ## HTML-escaping must be handled by caller
 %>${url | n, decode.utf8}${"?raw" if raw else ""}</%def>
 

--- a/lms/templates/pdf_viewer.html
+++ b/lms/templates/pdf_viewer.html
@@ -32,23 +32,23 @@ http://sourceforge.net/adobe/cmap/wiki/License/
     <meta name="path_prefix" content="${EDX_ROOT_URL}">
     <title>${current_chapter['title'] if current_chapter else ''}</title>
 
-    <link rel="stylesheet" href="${static.url('/static/css/vendor/pdfjs/viewer.css')}"/>
+    <link rel="stylesheet" href="${static.url('css/vendor/pdfjs/viewer.css')}"/>
 
-    <script type="text/javascript" src="${static.url('/static/js/vendor/pdfjs/compatibility.js')}"></script>
+    <script type="text/javascript" src="${static.url('js/vendor/pdfjs/compatibility.js')}"></script>
 
     <!-- This snippet is used in production (included from viewer.html) -->
-    <link rel="resource" type="application/l10n" href="${static.url('/static/js/vendor/pdfjs/locale/locale.properties')}"/>
-    <script type="text/javascript" src="${static.url('/static/js/vendor/pdfjs/l10n.js')}"></script>
-    <script type="text/javascript" src="${static.url('/static/js/vendor/pdfjs/pdf.js')}"></script>
+    <link rel="resource" type="application/l10n" href="${static.url('js/vendor/pdfjs/locale/locale.properties')}"/>
+    <script type="text/javascript" src="${static.url('js/vendor/pdfjs/l10n.js')}"></script>
+    <script type="text/javascript" src="${static.url('js/vendor/pdfjs/pdf.js')}"></script>
 
     <script type="text/javascript">
-        PDFJS.imageResourcesPath = "${static.url('/static/css/vendor/pdfjs/images/') | n, js_escaped_string}";
-        PDFJS.workerSrc = "${static.url('/static/js/vendor/pdfjs/pdf.worker.js') | n, js_escaped_string}";
-        PDFJS.cMapUrl = "${static.url('/static/css/vendor/pdfjs/cmaps/') | n, js_escaped_string}";
+        PDFJS.imageResourcesPath = "${static.url('css/vendor/pdfjs/images/') | n, js_escaped_string}";
+        PDFJS.workerSrc = "${static.url('js/vendor/pdfjs/pdf.worker.js') | n, js_escaped_string}";
+        PDFJS.cMapUrl = "${static.url('css/vendor/pdfjs/cmaps/') | n, js_escaped_string}";
         PDF_URL = '${current_url | n, js_escaped_string}';
     </script>
 
-    <script ${static.url('/static/js/vendor/pdfjs/debugger.js')}></script>
+    <script ${static.url('js/vendor/pdfjs/debugger.js')}></script>
     
     <%static:js group='main_vendor'/>
     <%static:js group='application'/>
@@ -417,7 +417,7 @@ http://sourceforge.net/adobe/cmap/wiki/License/
     </div>
   </div>
 </div>
-    <script type="text/javascript" src="${static.url('/static/js/vendor/pdfjs/viewer.js')}"></script>
-    <script type="text/javascript" src="${static.url('/static/js/pdf-analytics.js')}"></script>
+    <script type="text/javascript" src="${static.url('js/vendor/pdfjs/viewer.js')}"></script>
+    <script type="text/javascript" src="${static.url('js/pdf-analytics.js')}"></script>
   </body>
 </html>


### PR DESCRIPTION
Currently textbooks for a course are not loaded in i-frame. Reason is that browser cannot find the resources required to load the viewer. In file `/lms/templates/pdf_viewer.html`,  all static urls e.g. 

```
${static.url('/static/js/vendor/pdfjs/locale/locale.properties')}
```
 have unnecessary `/static` in the beginning of paths, due to which, the viewer is not loaded correctly and textbooks are not displayed correctly.

So I have removed those unnecessary `/static`(s) from the source paths.