### PR TITLE
Check and update login status with all login-related cookies

### DIFF
--- a/common/djangoapps/student/tests/test_views.py
+++ b/common/djangoapps/student/tests/test_views.py
@@ -175,7 +175,8 @@ class StudentDashboardTests(SharedModuleStoreTestCase, MilestonesTestCaseMixin, 
     MOCK_SETTINGS = {
         'FEATURES': {
             'DISABLE_START_DATES': False,
-            'ENABLE_MKTG_SITE': True
+            'ENABLE_MKTG_SITE': True,
+            'DISABLE_SET_JWT_COOKIES_FOR_TESTS': True,
         },
         'SOCIAL_SHARING_SETTINGS': {
             'CUSTOM_COURSE_URLS': True,
@@ -186,6 +187,7 @@ class StudentDashboardTests(SharedModuleStoreTestCase, MilestonesTestCaseMixin, 
     MOCK_SETTINGS_HIDE_COURSES = {
         'FEATURES': {
             'HIDE_DASHBOARD_COURSES_UNTIL_ACTIVATED': True,
+            'DISABLE_SET_JWT_COOKIES_FOR_TESTS': True,
         }
     }
 

--- a/common/djangoapps/student/views/dashboard.py
+++ b/common/djangoapps/student/views/dashboard.py
@@ -44,7 +44,7 @@ from openedx.features.enterprise_support.api import get_dashboard_consent_notifi
 from openedx.features.journals.api import journals_enabled
 from shoppingcart.api import order_history
 from shoppingcart.models import CourseRegistrationCode, DonationConfiguration
-from openedx.core.djangoapps.user_authn.cookies import set_deprecated_user_info_cookie
+from openedx.core.djangoapps.user_authn.cookies import set_logged_in_cookies
 from student.helpers import cert_info, check_verify_status_by_course
 from student.models import (
     CourseEnrollment,
@@ -851,5 +851,5 @@ def student_dashboard(request):
     })
 
     response = render_to_response('dashboard.html', context)
-    set_deprecated_user_info_cookie(response, request, user)  # pylint: disable=protected-access
+    set_logged_in_cookies(request, response, user)
     return response

--- a/common/djangoapps/third_party_auth/pipeline.py
+++ b/common/djangoapps/third_party_auth/pipeline.py
@@ -632,7 +632,7 @@ def set_logged_in_cookies(backend=None, user=None, strategy=None, auth_entry=Non
             # Check that the cookie isn't already set.
             # This ensures that we allow the user to continue to the next
             # pipeline step once he/she has the cookie set by this step.
-            has_cookie = user_authn_cookies.is_logged_in_cookie_set(request)
+            has_cookie = user_authn_cookies.are_logged_in_cookies_set(request)
             if not has_cookie:
                 try:
                     redirect_url = get_complete_url(current_partial.backend)

--- a/openedx/core/djangoapps/user_authn/tests/test_cookies.py
+++ b/openedx/core/djangoapps/user_authn/tests/test_cookies.py
@@ -117,14 +117,16 @@ class CookieTests(TestCase):
         self._assert_consistent_expires(response)
         self._assert_recreate_jwt_from_cookies(response, can_recreate=True)
 
-    def test_delete_and_is_logged_in_cookie_set(self):
+    @patch.dict("django.conf.settings.FEATURES", {"DISABLE_SET_JWT_COOKIES_FOR_TESTS": False})
+    def test_delete_and_are_logged_in_cookies_set(self):
+        setup_login_oauth_client()
         response = cookies_api.set_logged_in_cookies(self.request, HttpResponse(), self.user)
         self._copy_cookies_to_request(response, self.request)
-        self.assertTrue(cookies_api.is_logged_in_cookie_set(self.request))
+        self.assertTrue(cookies_api.are_logged_in_cookies_set(self.request))
 
         cookies_api.delete_logged_in_cookies(response)
         self._copy_cookies_to_request(response, self.request)
-        self.assertFalse(cookies_api.is_logged_in_cookie_set(self.request))
+        self.assertFalse(cookies_api.are_logged_in_cookies_set(self.request))
 
     @patch.dict("django.conf.settings.FEATURES", {"DISABLE_SET_JWT_COOKIES_FOR_TESTS": False})
     def test_refresh_jwt_cookies(self):

--- a/openedx/core/djangoapps/user_authn/views/tests/test_views.py
+++ b/openedx/core/djangoapps/user_authn/views/tests/test_views.py
@@ -327,9 +327,19 @@ class LoginAndRegistrationTest(ThirdPartyAuthTestMixin, UrlResetMixin, ModuleSto
 
     @ddt.data("signin_user", "register_user")
     def test_login_and_registration_form_already_authenticated(self, url_name):
-        # Create/activate a new account and log in
-        activation_key = create_account(self.USERNAME, self.PASSWORD, self.EMAIL)
-        activate_account(activation_key)
+        # call the account registration api that sets the login cookies
+        url = reverse('user_api_registration')
+        request_data = {
+            'username': self.USERNAME,
+            'password': self.PASSWORD,
+            'email': self.EMAIL,
+            'name': self.USERNAME,
+            'terms_of_service': 'true',
+            'honor_code': 'true',
+        }
+        result = self.client.post(url, data=request_data)
+        self.assertEqual(result.status_code, 200)
+
         result = self.client.login(username=self.USERNAME, password=self.PASSWORD)
         self.assertTrue(result)
 


### PR DESCRIPTION
https://openedx.atlassian.net/browse/ARCH-282

**This PR:**

- updates the dashboard code to refresh _all_ cookies, not just one.
- updates the login form to check for the existence of _all_ cookies, not just the session cookie.

**Rationale:**

Prior to this PR, the code was updating different cookies at different times, which resulted in an infinite loop when a frontend determined a user needed to re-authenticate and the backend determined that the user was already authenticated.

See [ARCH-282](https://openedx.atlassian.net/browse/ARCH-282) for more detail on the discoveries made along the way:

- Django’s SessionMiddleware automatically refreshes the session cookie whenever the session was modified, which doesn't refresh our other login-related cookies.
-  The Learner dashboard automatically refreshes the user's user_info cookie, but didn't refresh other login-related cookies.