### PR TITLE
Add a site configuration option to disable social media links

### DIFF
--- a/lms/static/js/student_account/views/account_settings_factory.js
+++ b/lms/static/js/student_account/views/account_settings_factory.js
@@ -287,34 +287,35 @@
             }
 
 
-            // Add the social link fields
-            socialFields = {
-                title: gettext('Social Media Links'),
-                subtitle: gettext('Optionally, link your personal accounts to the social media icons on your edX profile.'),  // eslint-disable-line max-len
-                fields: []
-            };
+            if (!$.isEmptyObject(socialPlatforms)) {
+                // Add the social link fields
+                socialFields = {
+                    title: gettext('Social Media Links'),
+                    subtitle: gettext('Optionally, link your personal accounts to the social media icons on your edX profile.'),  // eslint-disable-line max-len
+                    fields: []
+                };
 
-            for (var socialPlatform in socialPlatforms) {  // eslint-disable-line guard-for-in, no-restricted-syntax, vars-on-top, max-len
-                platformData = socialPlatforms[socialPlatform];
-                socialFields.fields.push(
-                    {
-                        view: new AccountSettingsFieldViews.SocialLinkTextFieldView({
-                            model: userAccountModel,
-                            title: gettext(platformData.display_name + ' Link'),
-                            valueAttribute: 'social_links',
-                            helpMessage: gettext(
-                                'Enter your ' + platformData.display_name + ' username or the URL to your ' +
-                                platformData.display_name + ' page. Delete the URL to remove the link.'
-                            ),
-                            platform: socialPlatform,
-                            persistChanges: true,
-                            placeholder: platformData.example
-                        })
-                    }
-                );
+                for (var socialPlatform in socialPlatforms) {  // eslint-disable-line guard-for-in, no-restricted-syntax, vars-on-top, max-len
+                    platformData = socialPlatforms[socialPlatform];
+                    socialFields.fields.push(
+                        {
+                            view: new AccountSettingsFieldViews.SocialLinkTextFieldView({
+                                model: userAccountModel,
+                                title: gettext(platformData.display_name + ' Link'),
+                                valueAttribute: 'social_links',
+                                helpMessage: gettext(
+                                    'Enter your ' + platformData.display_name + ' username or the URL to your ' +
+                                        platformData.display_name + ' page. Delete the URL to remove the link.'
+                                ),
+                                platform: socialPlatform,
+                                persistChanges: true,
+                                placeholder: platformData.example
+                            })
+                        }
+                    );
+                }
+                aboutSectionsData.push(socialFields);
             }
-            aboutSectionsData.push(socialFields);
-
             // Add account deletion fields
             if (displayAccountDeletion) {
                 accountDeletionFields = {

--- a/lms/templates/student_account/account_settings.html
+++ b/lms/templates/student_account/account_settings.html
@@ -39,7 +39,7 @@ from openedx.core.djangoapps.user_api.accounts.utils import is_secondary_email_f
         platformName = '${ static.get_platform_name() | n, js_escaped_string }',
         contactEmail = '${ static.get_contact_email_address() | n, js_escaped_string }',
         allowEmailChange = ${ bool(settings.FEATURES['ALLOW_EMAIL_ADDRESS_CHANGE']) | n, dump_js_escaped_json },
-        socialPlatforms = ${ settings.SOCIAL_PLATFORMS | n, dump_js_escaped_json },
+        socialPlatforms = ${ social_platforms | n, dump_js_escaped_json },
 
         syncLearnerProfileData = ${ bool(sync_learner_profile_data) | n, dump_js_escaped_json },
         enterpriseName = '${ enterprise_name | n, js_escaped_string }',

--- a/openedx/core/djangoapps/user_api/accounts/settings_views.py
+++ b/openedx/core/djangoapps/user_api/accounts/settings_views.py
@@ -111,6 +111,9 @@ def account_settings_context(request):
             'ENABLE_ACCOUNT_DELETION', settings.FEATURES.get('ENABLE_ACCOUNT_DELETION', False)
         ),
         'extended_profile_fields': _get_extended_profile_fields(),
+        'social_platforms': settings.SOCIAL_PLATFORMS if configuration_helpers.get_value(
+            'ENABLE_SOCIAL_MEDIA_LINKS', True
+        ) else {}
     }
 
     enterprise_customer = get_enterprise_customer_for_learner(site=request.site, user=request.user)

--- a/openedx/core/djangoapps/user_api/accounts/tests/test_settings_views.py
+++ b/openedx/core/djangoapps/user_api/accounts/tests/test_settings_views.py
@@ -1,8 +1,9 @@
 """ Tests for views related to account settings. """
 # -*- coding: utf-8 -*-
+import unittest
+
 import ddt
 import mock
-import unittest
 from django.conf import settings
 from django.contrib import messages
 from django.contrib.messages.middleware import MessageMiddleware
@@ -140,16 +141,17 @@ class AccountSettingsViewTest(ThirdPartyAuthTestMixin, TestCase, ProgramsApiConf
 
     @unittest.skipUnless(settings.ROOT_URLCONF == 'lms.urls', 'Test only valid in lms')
     @ddt.data(
-        ({'ENABLE_SOCIAL_MEDIA_LINKS': True}, settings.SOCIAL_PLATFORMS),
-        ({'ENABLE_SOCIAL_MEDIA_LINKS': False}, {}),
-        ({}, settings.SOCIAL_PLATFORMS)
+        {'ENABLE_SOCIAL_MEDIA_LINKS': True},
+        {'ENABLE_SOCIAL_MEDIA_LINKS': False},
+        {},
     )
-    @ddt.unpack
-    def test_context_social_platforms_site_configuration(self, configuration, expected_value):
+    def test_context_social_platforms_site_configuration(self, configuration):
         """
         Verify that the social media links are not shown if they are disabled.
         """
         self.request.site = SiteFactory.create()
+
+        expected_value = settings.SOCIAL_PLATFORMS if configuration.get('ENABLE_SOCIAL_MEDIA_LINKS', True) else {}
 
         with with_site_configuration_context(configuration=configuration):
             context = account_settings_context(self.request)

--- a/openedx/core/djangoapps/user_api/accounts/tests/test_settings_views.py
+++ b/openedx/core/djangoapps/user_api/accounts/tests/test_settings_views.py
@@ -2,6 +2,7 @@
 # -*- coding: utf-8 -*-
 import ddt
 import mock
+import unittest
 from django.conf import settings
 from django.contrib import messages
 from django.contrib.messages.middleware import MessageMiddleware
@@ -137,6 +138,7 @@ class AccountSettingsViewTest(ThirdPartyAuthTestMixin, TestCase, ProgramsApiConf
             context['enterprise_readonly_account_fields'], {'fields': settings.ENTERPRISE_READONLY_ACCOUNT_FIELDS}
         )
 
+    @unittest.skipUnless(settings.ROOT_URLCONF == 'lms.urls', 'Test only valid in lms')
     @ddt.data(
         ({'ENABLE_SOCIAL_MEDIA_LINKS': True}, settings.SOCIAL_PLATFORMS),
         ({'ENABLE_SOCIAL_MEDIA_LINKS': False}, {}),

--- a/openedx/features/learner_profile/tests/views/test_learner_profile.py
+++ b/openedx/features/learner_profile/tests/views/test_learner_profile.py
@@ -13,6 +13,7 @@ from django.conf import settings
 from django.urls import reverse
 from django.test.client import RequestFactory
 from opaque_keys.edx.locator import CourseLocator
+from openedx.core.djangoapps.site_configuration.tests.test_util import with_site_configuration_context
 from openedx.features.learner_profile.views.learner_profile import learner_profile_context
 from student.tests.factories import CourseEnrollmentFactory, UserFactory
 from util.testing import UrlResetMixin
@@ -222,3 +223,20 @@ class LearnerProfileViewTest(UrlResetMixin, ModuleStoreTestCase):
         response = self.client.get('/u/{username}'.format(username=self.user.username))
 
         self.assertNotContains(response, 'card certificate-card mode-{cert_mode}'.format(cert_mode=cert.mode))
+
+    @ddt.data(
+        ({'ENABLE_SOCIAL_MEDIA_LINKS': True}, settings.SOCIAL_PLATFORMS),
+        ({'ENABLE_SOCIAL_MEDIA_LINKS': False}, {}),
+        ({}, settings.SOCIAL_PLATFORMS),
+    )
+    @ddt.unpack
+    def test_context_social_platforms_site_configuration(self, configuration, expected_value):
+        """
+        Verify that the social media links are not shown if they are configured to be hidden
+        """
+        with with_site_configuration_context(configuration=configuration):
+            request = RequestFactory().get('/url')
+            request.user = self.user
+
+            context = learner_profile_context(request, self.USERNAME, self.user.is_staff)
+            self.assertEqual(context['data']['social_platforms'], expected_value)

--- a/openedx/features/learner_profile/tests/views/test_learner_profile.py
+++ b/openedx/features/learner_profile/tests/views/test_learner_profile.py
@@ -4,6 +4,7 @@
 import datetime
 import ddt
 import mock
+import unittest
 
 from lms.djangoapps.certificates.tests.factories import GeneratedCertificateFactory
 from lms.djangoapps.certificates.api import is_passing_status
@@ -224,6 +225,7 @@ class LearnerProfileViewTest(UrlResetMixin, ModuleStoreTestCase):
 
         self.assertNotContains(response, 'card certificate-card mode-{cert_mode}'.format(cert_mode=cert.mode))
 
+    @unittest.skipUnless(settings.ROOT_URLCONF == 'lms.urls', 'Test only valid in lms')
     @ddt.data(
         ({'ENABLE_SOCIAL_MEDIA_LINKS': True}, settings.SOCIAL_PLATFORMS),
         ({'ENABLE_SOCIAL_MEDIA_LINKS': False}, {}),

--- a/openedx/features/learner_profile/tests/views/test_learner_profile.py
+++ b/openedx/features/learner_profile/tests/views/test_learner_profile.py
@@ -1,10 +1,11 @@
 # -*- coding: utf-8 -*-
 """ Tests for student profile views. """
 
+import unittest
+
 import datetime
 import ddt
 import mock
-import unittest
 
 from lms.djangoapps.certificates.tests.factories import GeneratedCertificateFactory
 from lms.djangoapps.certificates.api import is_passing_status
@@ -227,15 +228,16 @@ class LearnerProfileViewTest(UrlResetMixin, ModuleStoreTestCase):
 
     @unittest.skipUnless(settings.ROOT_URLCONF == 'lms.urls', 'Test only valid in lms')
     @ddt.data(
-        ({'ENABLE_SOCIAL_MEDIA_LINKS': True}, settings.SOCIAL_PLATFORMS),
-        ({'ENABLE_SOCIAL_MEDIA_LINKS': False}, {}),
-        ({}, settings.SOCIAL_PLATFORMS),
+        {'ENABLE_SOCIAL_MEDIA_LINKS': True},
+        {'ENABLE_SOCIAL_MEDIA_LINKS': False},
+        {},
     )
-    @ddt.unpack
-    def test_context_social_platforms_site_configuration(self, configuration, expected_value):
+    def test_context_social_platforms_site_configuration(self, configuration):
         """
         Verify that the social media links are not shown if they are configured to be hidden
         """
+        expected_value = settings.SOCIAL_PLATFORMS if configuration.get('ENABLE_SOCIAL_MEDIA_LINKS', True) else {}
+
         with with_site_configuration_context(configuration=configuration):
             request = RequestFactory().get('/url')
             request.user = self.user

--- a/openedx/features/learner_profile/views/learner_profile.py
+++ b/openedx/features/learner_profile/views/learner_profile.py
@@ -135,7 +135,9 @@ def learner_profile_context(request, profile_username, user_is_staff):
             'badges_icon': staticfiles_storage.url('certificates/images/ico-mozillaopenbadges.png'),
             'backpack_ui_img': staticfiles_storage.url('certificates/images/backpack-ui.png'),
             'platform_name': configuration_helpers.get_value('platform_name', settings.PLATFORM_NAME),
-            'social_platforms': settings.SOCIAL_PLATFORMS,
+            'social_platforms': settings.SOCIAL_PLATFORMS if configuration_helpers.get_value(
+                'ENABLE_SOCIAL_MEDIA_LINKS', True
+            ) else {},
         },
         'show_program_listing': ProgramsApiConfig.is_enabled(),
         'show_journal_listing': journals_enabled(),


### PR DESCRIPTION
This PR contains the changes to disable social media links in the account settings and profile pages using a site configuration parameter.

**JIRA tickets**: TBD

**Dependencies**: None

**Sandbox URL**: TBD - sandbox is being provisioned.

**Merge deadline**: None

**Testing instructions**:
1. On the devstack running this PR branch, log in to the LMS as one of the demo users.
1. From the dashboard, click the arrow next to the username on the top right of the page to trigger the display of the dropdown.
1. Click on 'Account' in the dropdown menu to navigate to the 'Account Settings' page. Alternatively, navigate directly to the `/account/settings` URL.
1. Near the bottom of the page, there is a section titled 'Social Media Links' which allows users to link their accounts to the social media icons on their profile page. 
1. Configure one or more social media links using the form fields in that section.
1. Navigate to the user profile page (`/u/<username>`) by clicking on the 'Profile' menu item from the user account dropdown in the top-right corner of the page.
1. Verify that the configured social media links are shown with the corresponding social media icons in the profile page.
1. Log in to the LMS admin interface as an admin user.
1. Navigate to the `SiteConfiguration` model admin interface.
1. Click the configured site listed on that page to edit its site configuration.
1. Add a site configuration variable `ENABLE_SOCIAL_MEDIA_LINKS` and set its value to `true`.
1. Restart the LMS server.
1. Navigate to the 'Account Settings' page as the previous non-admin demo user and verify that the social media links section is present.
1. Navigate to the 'Profile' page and verify that the configured social media links are listed on the page.
1. As an admin user, update the site configuration to set `ENABLE_SOCIAL_MEDIA_LINKS` to `false`.
1. Restart the LMS server.
1. Navigate to the 'Account Settings' page as the previous non-admin demo user and verify that the social media links section is not present.
1. Navigate to the 'Profile' page and verify that the social media links are not shown in the profile page.

**Author notes and concerns**:
1. Is there some other way we should be controlling this behavior?
1. Is this a suitable name for the site configuration variable?

**Reviewers**
- [ ] @kaizoku 
- [ ] edX reviewer[s] TBD