### PR TITLE
Add revenue field to completed order event

### DIFF
--- a/lms/djangoapps/shoppingcart/models.py
+++ b/lms/djangoapps/shoppingcart/models.py
@@ -524,6 +524,9 @@ class Order(models.Model):
             segment.track(self.user.id, event_name, {
                 'orderId': self.id,
                 'total': str(self.total_cost),
+                # For Rockerbox integration, we need a field named revenue since they cannot parse a field named total.
+                # TODO: DE-1188: Remove / move Rockerbox integration code.
+                'revenue': str(self.total_cost),
                 'currency': self.currency,
                 'products': [item.analytics_data() for item in orderitems]
             })

--- a/lms/djangoapps/shoppingcart/tests/test_models.py
+++ b/lms/djangoapps/shoppingcart/tests/test_models.py
@@ -277,6 +277,7 @@ class OrderTest(ModuleStoreTestCase):
                 'orderId': 1,
                 'currency': 'usd',
                 'total': '40.00',
+                'revenue': '40.00',        # value for revenue field is same as total.
                 'products': [
                     {
                         'sku': u'CertificateItem.honor',
@@ -876,6 +877,7 @@ class CertificateItemTest(ModuleStoreTestCase):
                 'orderId': 1,
                 'currency': 'usd',
                 'total': '40.00',
+                'revenue': '40.00',        # value for revenue field is same as total.
                 'products': [
                     {
                         'sku': u'CertificateItem.verified',


### PR DESCRIPTION
For Rockerbox integration, we need to add some fields in events being emitted from platform & ecommerce. This PR adds revenue field to completed order event. 