### PR TITLE
EDUCATOR-3668 | Fix grade override bug

### DIFF
--- a/lms/djangoapps/grades/tests/test_subsection_grade_factory.py
+++ b/lms/djangoapps/grades/tests/test_subsection_grade_factory.py
@@ -1,10 +1,13 @@
+"""
+Tests for the SubsectionGradeFactory class.
+"""
 import ddt
 from courseware.tests.test_submitting_problems import ProblemSubmissionTestMixin
 from django.conf import settings
 from lms.djangoapps.grades.config.tests.utils import persistent_grades_feature_flags
 from mock import patch
 
-from ..models import PersistentSubsectionGrade
+from ..models import PersistentSubsectionGrade, PersistentSubsectionGradeOverride
 from ..subsection_grade_factory import ZeroSubsectionGrade
 from .base import GradeTestBase
 from .utils import mock_get_score
@@ -27,6 +30,10 @@ class TestSubsectionGradeFactory(ProblemSubmissionTestMixin, GradeTestBase):
         """
         self.assertEqual(
             (grade.all_total.earned, grade.all_total.possible),
+            (expected_earned, expected_possible),
+        )
+        self.assertEqual(
+            (grade.graded_total.earned, grade.graded_total.possible),
             (expected_earned, expected_possible),
         )
 
@@ -100,3 +107,32 @@ class TestSubsectionGradeFactory(ProblemSubmissionTestMixin, GradeTestBase):
             ):
                 self.subsection_grade_factory.create(self.sequence)
         self.assertEqual(mock_read_saved_grade.called, feature_flag and course_setting)
+
+    def test_update_with_override(self):
+        """
+        Tests that when a PersistentSubsectionGradeOverride exists, the update()
+        method returns a CreateSubsectionGrade with scores that account
+        for the override.
+        """
+        # first, do an update to create a persistent grade
+        with mock_get_score(2, 3):
+            grade = self.subsection_grade_factory.update(self.sequence)
+            self.assert_grade(grade, 2, 3)
+
+        # there should only be one persistent grade
+        persistent_grade = PersistentSubsectionGrade.objects.first()
+        self.assertEqual(2, persistent_grade.earned_graded)
+        self.assertEqual(3, persistent_grade.possible_graded)
+
+        # Now create the override
+        PersistentSubsectionGradeOverride.objects.create(
+            grade=persistent_grade,
+            earned_graded_override=0,
+            earned_all_override=0,
+        )
+
+        # Now, even if the problem scores interface gives us a 2/3,
+        # the subsection grade returned should be 0/3 due to the override.
+        with mock_get_score(2, 3):
+            grade = self.subsection_grade_factory.update(self.sequence)
+            self.assert_grade(grade, 0, 3)


### PR DESCRIPTION
https://openedx.atlassian.net/browse/EDUCATOR-3668

Instances of CreateSubsectionGrade should reflect possibly overridden values from the PersistentSubsectionGrade model.  While grade overrides were being respected at the level of the `PersistentSubsectionGrade` model, they weren't reflected in the grade values of the `CreateSubsectionGrade` class.  This means that `PersistentCourseGrades` also weren't respecting these values under some circumstances, because they depend on the calculated values from `CreateSubsectionGrade` when calculating the course grade percentage.

This PR makes it so that, whenever a persistent subsection grade is created/updated from a  `CreateSubsectionGrade` object, we also update the values of that object to reflect what we just wrote into the database.