### PR TITLE
EDUCATOR-3786 Anonymous user is not associated to any cohort

### DIFF
--- a/openedx/core/djangoapps/course_groups/cohorts.py
+++ b/openedx/core/djangoapps/course_groups/cohorts.py
@@ -215,6 +215,8 @@ def get_cohort(user, course_key, assign=True, use_cached=False):
     Raises:
        ValueError if the CourseKey doesn't exist.
     """
+    if user.is_anonymous:
+        return None
     cache = RequestCache(COHORT_CACHE_NAMESPACE).data
     cache_key = _cohort_cache_key(user.id, course_key)
 

--- a/openedx/core/djangoapps/course_groups/tests/test_cohorts.py
+++ b/openedx/core/djangoapps/course_groups/tests/test_cohorts.py
@@ -6,7 +6,7 @@ import ddt
 from mock import call, patch
 
 import before_after
-from django.contrib.auth.models import User
+from django.contrib.auth.models import User, AnonymousUser
 from django.db import IntegrityError
 from django.http import Http404
 from django.test import TestCase
@@ -385,6 +385,18 @@ class TestCohorts(ModuleStoreTestCase):
         self.assertEquals(cohorts.get_cohort(user1, course.id).id, cohort.id, "user1 should stay put")
 
         self.assertEquals(cohorts.get_cohort(user2, course.id).name, "AutoGroup", "user2 should be auto-cohorted")
+
+    def test_anonymous_user_cohort(self):
+        """
+        Anonymous user is not assigned to any cohort group.
+        """
+        course = modulestore().get_course(self.toy_course_key)
+        config_course_cohorts(
+            course,
+            is_cohorted=True,
+            auto_cohorts=["AutoGroup"]
+        )
+        self.assertIsNone(cohorts.get_cohort(AnonymousUser(), course.id))
 
     def test_cohorting_with_migrations_done(self):
         """


### PR DESCRIPTION
### [EDUCATOR-3786](https://openedx.atlassian.net/browse/EDUCATOR-3786)

### Description
Discussion cohorts are one of the way to restrict access to certain discussion modules. Ideally, each learner is associated to some cohort [(docs)](https://edx.readthedocs.io/projects/edx-partner-course-staff/en/latest/course_features/cohorts/cohorts_overview.html). When getting the cohort information of a particular user in a course, if he/she is not assigned to a cohort, a random cohort is assigned(get_cohort function inside **cohorts.py.** But there is no check if an AnonymousUser is passed. This PR addresses that problem and adds appropriate check for an AnonymousUser when getting the cohort.

### Problem Identification
The problem under consideration doesn't always happen. There is a specific case when error takes place. It occurs when trying to get the discussion settings for a course, but only when discussion access is restricted via Content Group and enabled cohorts. To simplify, whenever a discussion module is restricted access through some custom **Content Group** (other than Enrollment Track based access) with enabled cohorts, the discussion settings are not retrieved. This happens because when trying to get the information about the divided discussions(get_divided_discussion() inside [discussion/views.py](https://github.com/edx/edx-platform/blob/master/lms/djangoapps/discussion/views.py)), the call to **get_discussion_categories_ids** passes user as None. This None is converted into an AnonymousUser inside the **has_access()** function present inside [courseware/access.py](https://github.com/edx/edx-platform/blob/master/lms/djangoapps/courseware/access.py), which ultimately causes the AttributeError in the get_cohort function.

### Problem Resolution
The resolution was rather simple, and involved adding a check for AnonymousUser when getting the cohort information.

### Sandbox
 - [Sandbox](/https://cohorts.sandbox.edx.org/)

### Reviewers
- [x] @asadazam93 
- [x] @Rabia23 

### Post Review
 - [x] Squash & Rebase Commits