### PR TITLE
Add email in course enrollment event

### DIFF
--- a/common/djangoapps/student/models.py
+++ b/common/djangoapps/student/models.py
@@ -1237,6 +1237,8 @@ class CourseEnrollment(models.Model):
                 'run': self.course_id.run,
                 'mode': self.mode,
             }
+            if event_name == EVENT_NAME_ENROLLMENT_ACTIVATED:
+                segment_properties['email'] = self.user.email
             with tracker.get_tracker().context(event_name, context):
                 tracker.emit(event_name, data)
                 segment.track(self.user_id, event_name, segment_properties)


### PR DESCRIPTION
For Rockerbox integration, we need to add some fields in events being emitted from platform & ecommerce. This PR adds email field to course enrollment event.