### PR TITLE
Fixes for assorted flaky bok-choy tests

### DIFF
--- a/common/test/acceptance/pages/lms/discussion.py
+++ b/common/test/acceptance/pages/lms/discussion.py
@@ -723,6 +723,7 @@ class DiscussionTabHomePage(CoursePage, DiscussionPageMixin):
         Get the rendered preview of the contents of the Discussions new post editor
         Waits for content to appear, as the preview is triggered on debounced/delayed onchange
         """
+        self.scroll_to_element(selector)
         self.wait_for_element_visibility(selector, "WMD preview pane has contents", timeout=10)
         return self.q(css=".wmd-preview").html[0]
 

--- a/common/test/acceptance/pages/lms/teams.py
+++ b/common/test/acceptance/pages/lms/teams.py
@@ -520,6 +520,7 @@ class TeamPage(CoursePage, PaginatedUIMixin, BreadcrumbsMixin):
     def click_leave_team_link(self, remaining_members=0, cancel=False):
         """ Click on Leave Team link"""
         leave_team_css = '.leave-team-link'
+        self.scroll_to_element(leave_team_css)
         self.wait_for_element_visibility(leave_team_css, 'Leave Team link is visible.')
         click_css(self, leave_team_css, require_notification=False)
         confirm_prompt(self, cancel, require_notification=False)

--- a/common/test/acceptance/tests/lms/test_lms_user_preview.py
+++ b/common/test/acceptance/tests/lms/test_lms_user_preview.py
@@ -435,8 +435,8 @@ def verify_expected_problem_visibility(test, courseware_page, expected_problems)
     """
     Helper method that checks that the expected problems are visible on the current page.
     """
-    test.assertEqual(
-        len(expected_problems), courseware_page.num_xblock_components, "Incorrect number of visible problems"
+    courseware_page.wait_for(
+        lambda: courseware_page.num_xblock_components == len(expected_problems), "Expected number of problems visible"
     )
     for index, expected_problem in enumerate(expected_problems):
         test.assertIn(expected_problem, courseware_page.xblock_components[index].text)

--- a/common/test/acceptance/tests/studio/test_studio_container.py
+++ b/common/test/acceptance/tests/studio/test_studio_container.py
@@ -1066,8 +1066,9 @@ class UnitPublishingTest(ContainerBase):
         """
         Verifies no component is visible when viewing as a student.
         """
-        self._verify_and_return_staff_page().set_staff_view_mode('Learner')
-        self.assertEqual(0, self.courseware.num_xblock_components)
+        page = self._verify_and_return_staff_page()
+        page.set_staff_view_mode('Learner')
+        page.wait_for(lambda: self.courseware.num_xblock_components == 0, 'No XBlocks visible')
 
     def _verify_student_view_visible(self, expected_components):
         """

--- a/common/test/acceptance/tests/studio/test_studio_outline.py
+++ b/common/test/acceptance/tests/studio/test_studio_outline.py
@@ -802,7 +802,8 @@ class StaffLockTest(CourseOutlineTest):
         course_home_page.wait_for_page()
         self.assertEqual(course_home_page.outline.num_sections, 2)
         course_home_page.preview.set_staff_view_mode('Learner')
-        self.assertEqual(course_home_page.outline.num_sections, 1)
+        course_home_page.wait_for(lambda: course_home_page.outline.num_sections == 1,
+                                  'Only 1 section is visible in the outline')
 
     def test_toggling_staff_lock_on_section_does_not_publish_draft_units(self):
         """


### PR DESCRIPTION
Attempt fixes for several bok-choy tests which have each been failing on master occasionally.  It'll take a while to determine if this truly resolves all the targeted issues, but odds are high that it'll fix some of them.

* Some tests didn't always wait long enough for the page content to be updated after a change of viewer role - [9770](https://build.testeng.edx.org/job/edx-platform-bok-choy-master/9770/), [9772](https://build.testeng.edx.org/job/edx-platform-bok-choy-master/9772/), [9782](https://build.testeng.edx.org/job/edx-platform-bok-choy-master/9782/), [9783](https://build.testeng.edx.org/job/edx-platform-bok-choy-master/9783/)
* A link to leave a team was sometimes obscured at the bottom of the viewport by a MathJax loading message - [9781](https://build.testeng.edx.org/job/edx-platform-bok-choy-master/9781/)
* A discussion test sometimes failed because the post preview pane was just outside the viewport - [9784](https://build.testeng.edx.org/job/edx-platform-bok-choy-master/9784/), [9785](https://build.testeng.edx.org/job/edx-platform-bok-choy-master/9785/)