### PR TITLE
[BB-753] Fix issue with multiple responses for a single user returned by generate_report_data

### DIFF
--- a/lms/djangoapps/instructor_task/tests/test_tasks_helper.py
+++ b/lms/djangoapps/instructor_task/tests/test_tasks_helper.py
@@ -558,24 +558,35 @@ class TestProblemResponsesReport(TestReportMixin, InstructorTaskModuleTestCase):
         """
         self.define_option_problem(u'Problem1')
         self.submit_student_answer(self.student.username, u'Problem1', ['Option 1'])
-        state = {'some': 'state', 'more': 'state!'}
+        state1 = {'some': 'state1', 'more': 'state1!'}
+        state2 = {'some': 'state2', 'more': 'state2!'}
         mock_generate_report_data.return_value = iter([
-            ('student', state),
+            ('student', state1),
+            ('student', state2),
         ])
         student_data, _ = ProblemResponses._build_student_data(
             user_id=self.instructor.id,
             course_key=self.course.id,
             usage_key_str=str(self.course.location),
         )
-        self.assertEquals(len(student_data), 1)
+        self.assertEquals(len(student_data), 2)
         self.assertDictContainsSubset({
             'username': 'student',
             'location': 'test_course > Section > Subsection > Problem1',
             'block_key': 'i4x://edx/1.23x/problem/Problem1',
             'title': 'Problem1',
-            'some': 'state',
-            'more': 'state!',
+            'some': 'state1',
+            'more': 'state1!',
         }, student_data[0])
+        self.assertDictContainsSubset({
+            'username': 'student',
+            'location': 'test_course > Section > Subsection > Problem1',
+            'block_key': 'i4x://edx/1.23x/problem/Problem1',
+            'title': 'Problem1',
+            'some': 'state2',
+            'more': 'state2!',
+        }, student_data[1])
+        self.assertEquals(student_data[0]['state'], student_data[1]['state'])
 
     def test_build_student_data_for_block_with_real_generate_report_data(self):
         """


### PR DESCRIPTION
The current problem response code has a bug that causes it to only return a response for each user for each block. 

The following code is generating a dictionary keyed on username for the report generated for each block. If a block contains multiple responses per user, then later responses will overwrite older responses. 

https://github.com/edx/edx-platform/blob/8593d4dc711c67535a0a0a98fa32b84ce6abc0c1/lms/djangoapps/instructor_task/tasks_helper/grades.py#L674-L678

**JIRA tickets**: https://openedx.atlassian.net/browse/OSPR-2927

**Discussions**: TBD

**Sandbox URL**:
* LMS: https://pr19507.sandbox.opencraft.hosting/
* Studio: https://studio-pr19507.sandbox.opencraft.hosting/



**Testing instructions**:

1. Generate a problem response report for a block containing multiple questions and responses. 
2. The generated report should include all responses.

**Author notes and concerns**:
Since there are multiple responses for each user state, I am not entirely sure how this should be handled. Currently, it just duplicates the state for each row, however, there may be a good argument for not doing that if it breaks current flows that use the state. (I remember there were concerns when the original PR for this removed the state entirely). 

**Reviewers**
- [ ] TBD
- [ ] edX reviewer[s] TBD