### PR TITLE
Bugfix: Text Input problem type expects numeric answer when correct answer starts with a number

### DIFF
--- a/common/lib/xmodule/xmodule/js/spec/problem/edit_spec.js
+++ b/common/lib/xmodule/xmodule/js/spec/problem/edit_spec.js
@@ -156,6 +156,9 @@ If first and last symbols are not brackets, or they are not closed, stringrespon
 = (7), 7
 = (1+2
 
+Just input 100 test. Stringresponse will appear:
+= 100 test
+
 [Explanation]
 Pi, or the the ratio between a circle's circumference to its diameter, is an irrational number known to extreme precision. It is value is approximately equal to 3.14.
 
@@ -193,6 +196,10 @@ If you look at your hand, you can count that you have five fingers.
     <textline size="20"/>
   </stringresponse>
   <stringresponse answer="(1+2" type="ci" >
+    <textline size="20"/>
+  </stringresponse>
+  <p>Just input 100 test. Stringresponse will appear:</p>
+  <stringresponse answer="100 test" type="ci" >
     <textline size="20"/>
   </stringresponse>
   <solution>

--- a/common/lib/xmodule/xmodule/js/src/problem/edit.js
+++ b/common/lib/xmodule/xmodule/js/src/problem/edit.js
@@ -573,6 +573,17 @@
                             );
                         },
 
+                        checkIsNumeric = function(stringValue) {
+                            // remove OLX feedback
+                            if ((stringValue.indexOf('{{') !== -1) && (stringValue.indexOf('}}') !== -1)) {
+                                stringValue = stringValue.replace(/{{[\s\S]*?}}/g, '').trim();
+                            }
+                            if (stringValue.match(/[a-z]/i)) {
+                                return false;
+                            }
+                            return !isNaN(parseFloat(stringValue));
+                        },
+
                         getAnswerData = function(answerValue) {
                             var answerData = {},
                                 answerParams = /(.*?)\+\-\s*(.*?$)/.exec(answerValue);
@@ -593,7 +604,7 @@
                             firstAnswer = answerValues[0].replace(/^\=\s*/, '');
 
                             // If answer is not numerical
-                            if (isNaN(parseFloat(firstAnswer)) && !isRangeToleranceCase(firstAnswer)) {
+                            if (!checkIsNumeric(firstAnswer) && !isRangeToleranceCase(firstAnswer)) {
                                 return false;
                             }
 


### PR DESCRIPTION
Example:

```
>>Question.<<

= 100 test
or=test 100

```

Because the correct answer option (= 100 test) is a string that begins with the number, edX is treating the problem as though it requires a number answer, rather than a text string that can include letters and numbers. If the user enters an answer with text instead of just numbers, an error message that says "Error, couldn't parse formula" appears.

<img width="1177" alt="screenshot 2018-12-26 18 41 51" src="https://user-images.githubusercontent.com/1876893/50450321-37c83200-093e-11e9-8b3a-d6641a865963.png">

<img width="948" alt="screenshot 2018-12-26 18 42 01" src="https://user-images.githubusercontent.com/1876893/50450322-37c83200-093e-11e9-9df5-1d1036af7267.png">


