### PR TITLE
INCR-31 Remove version for pysrt

### DIFF
--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -21,9 +21,6 @@ Markdown==2.6.11
 # Can be removed when we get to Python 3.
 pylint-plugin-utils==0.3
 
-# Testing framework # Pinned due to https://github.com/pytest-dev/pytest/issues/3749
-pytest==3.6.3
-
 # pytest plugin for measuring code coverage. # Pinned due to https://openedx.atlassian.net/browse/TE-2731
 pytest-cov<2.6
 

--- a/requirements/edx/base.in
+++ b/requirements/edx/base.in
@@ -132,7 +132,7 @@ rest-condition                      # DRF's recommendation for supporting comple
 rfc6266-parser                      # Used to generate Content-Disposition headers.
 social-auth-app-django<3.0.0
 social-auth-core<2.0.0
-pysrt==0.4.7                        # Support for SubRip subtitle files, used in the video XModule
+pysrt                               # Support for SubRip subtitle files, used in the video XModule
 pytz==2016.10                       # Time zone information database
 PyYAML                              # Used to parse XModule resource templates
 redis==2.10.6                       # celery task broker

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -118,7 +118,7 @@ edx-django-release-util==0.3.1
 edx-django-sites-extensions==2.3.1
 edx-django-utils==1.0.3
 edx-drf-extensions==2.0.1
-edx-enterprise==1.2.0
+edx-enterprise==1.2.1
 edx-i18n-tools==0.4.6
 edx-milestones==0.1.13
 edx-oauth2-provider==1.2.2

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -53,7 +53,6 @@ argh==0.26.2
 argparse==1.4.0
 asn1crypto==0.24.0
 astroid==1.5.3
-atomicwrites==1.2.1
 attrs==17.4.0
 babel==1.3
 backports.functools-lru-cache==1.5
@@ -137,7 +136,7 @@ edx-django-release-util==0.3.1
 edx-django-sites-extensions==2.3.1
 edx-django-utils==1.0.3
 edx-drf-extensions==2.0.1
-edx-enterprise==1.2.0
+edx-enterprise==1.2.1
 edx-i18n-tools==0.4.6
 edx-lint==1.0.0
 edx-milestones==0.1.13
@@ -168,7 +167,6 @@ flask==1.0.2
 freezegun==0.3.11
 fs-s3fs==0.1.8
 fs==2.0.18
-funcsigs==1.0.2
 functools32==3.2.3.post2
 future==0.17.1
 futures==3.2.0 ; python_version == "2.7"
@@ -213,7 +211,6 @@ mccabe==0.6.1
 mock==1.0.1
 modernize==0.6.1
 mongoengine==0.10.0
-more-itertools==4.3.0
 moto==0.3.1
 mysql-python==1.2.5
 networkx==1.7
@@ -235,7 +232,7 @@ pdfminer==20140328
 piexif==1.0.2
 pillow==5.3.0
 pip-tools==3.2.0
-pluggy==0.6.0
+pluggy==0.8.0
 polib==1.1.0
 psutil==1.2.1
 py2neo==3.1.2
@@ -312,20 +309,20 @@ social-auth-app-django==2.1.0
 social-auth-core==1.7.0
 sorl-thumbnail==12.3
 sortedcontainers==0.9.2
-sphinx==1.8.2
+sphinx==1.8.3
 sphinxcontrib-websupport==1.1.0  # via sphinx
 splinter==0.9.0
 sqlparse==0.2.4
 stevedore==1.10.0
 sure==1.4.11
 sympy==0.7.1
-testfixtures==6.4.0
+testfixtures==6.4.1
 testtools==2.3.0
 text-unidecode==1.2
 tincan==0.0.5
 toml==0.10.0
 tox-battery==0.5.1
-tox==3.6.0
+tox==3.6.1
 traceback2==1.4.0
 transifex-client==0.13.5
 twisted==16.6.0

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -53,6 +53,7 @@ argh==0.26.2
 argparse==1.4.0
 asn1crypto==0.24.0
 astroid==1.5.3
+atomicwrites==1.2.1
 attrs==17.4.0
 babel==1.3
 backports.functools-lru-cache==1.5
@@ -167,6 +168,7 @@ flask==1.0.2
 freezegun==0.3.11
 fs-s3fs==0.1.8
 fs==2.0.18
+funcsigs==1.0.2
 functools32==3.2.3.post2
 future==0.17.1
 futures==3.2.0 ; python_version == "2.7"
@@ -211,6 +213,7 @@ mccabe==0.6.1
 mock==1.0.1
 modernize==0.6.1
 mongoengine==0.10.0
+more-itertools==4.3.0
 moto==0.3.1
 mysql-python==1.2.5
 networkx==1.7
@@ -225,6 +228,7 @@ pa11ycrawler==1.6.2
 packaging==18.0           # via sphinx
 parsel==1.5.1
 path.py==8.2.1
+pathlib2==2.3.3
 pathtools==0.1.2
 paver==1.3.4
 pbr==5.1.1
@@ -268,7 +272,7 @@ pytest-django==3.1.2
 pytest-forked==0.2
 pytest-randomly==1.2.3
 pytest-xdist==1.25.0
-pytest==3.6.3
+pytest==4.0.2
 python-dateutil==2.4.0
 python-levenshtein==0.12.0
 python-memcached==1.48
@@ -292,6 +296,7 @@ rfc6266-parser==0.0.5.post2
 rules==2.0.1
 s3transfer==0.1.13
 sailthru-client==2.2.3
+scandir==1.9.0
 scipy==0.14.0
 scrapy==1.1.2
 selenium==3.141.0

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -50,6 +50,7 @@ argh==0.26.2
 argparse==1.4.0
 asn1crypto==0.24.0
 astroid==1.5.3            # via edx-lint, pylint, pylint-celery
+atomicwrites==1.2.1       # via pytest
 attrs==17.4.0
 babel==1.3
 backports.functools-lru-cache==1.5  # via astroid, pylint
@@ -161,6 +162,7 @@ flask==1.0.2              # via moto
 freezegun==0.3.11
 fs-s3fs==0.1.8
 fs==2.0.18
+funcsigs==1.0.2           # via pytest
 functools32==3.2.3.post2  # via parsel
 future==0.17.1
 futures==3.2.0 ; python_version == "2.7"
@@ -203,6 +205,7 @@ markupsafe==1.1.0
 mccabe==0.6.1             # via flake8, pylint
 mock==1.0.1
 mongoengine==0.10.0
+more-itertools==4.3.0     # via pytest
 moto==0.3.1
 mysql-python==1.2.5
 networkx==1.7
@@ -216,17 +219,18 @@ openapi-codec==1.3.2
 pa11ycrawler==1.6.2
 parsel==1.5.1             # via scrapy
 path.py==8.2.1
+pathlib2==2.3.3           # via pytest
 pathtools==0.1.2
 paver==1.3.4
 pbr==5.1.1
 pdfminer==20140328
 piexif==1.0.2
 pillow==5.3.0
-pluggy==0.8.0             # via tox
+pluggy==0.8.0             # via pytest, tox
 polib==1.1.0
 psutil==1.2.1
 py2neo==3.1.2
-py==1.7.0                 # via tox
+py==1.7.0                 # via pytest, tox
 pyasn1-modules==0.2.2     # via service-identity
 pyasn1==0.4.4             # via pyasn1-modules, service-identity
 pycodestyle==2.4.0
@@ -257,7 +261,7 @@ pytest-django==3.1.2
 pytest-forked==0.2        # via pytest-xdist
 pytest-randomly==1.2.3
 pytest-xdist==1.25.0
-pytest==3.6.3
+pytest==4.0.2
 python-dateutil==2.4.0
 python-levenshtein==0.12.0
 python-memcached==1.48
@@ -281,6 +285,7 @@ rfc6266-parser==0.0.5.post2
 rules==2.0.1
 s3transfer==0.1.13
 sailthru-client==2.2.3
+scandir==1.9.0            # via pathlib2
 scipy==0.14.0
 scrapy==1.1.2             # via pa11ycrawler
 selenium==3.141.0

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -50,7 +50,6 @@ argh==0.26.2
 argparse==1.4.0
 asn1crypto==0.24.0
 astroid==1.5.3            # via edx-lint, pylint, pylint-celery
-atomicwrites==1.2.1       # via pytest
 attrs==17.4.0
 babel==1.3
 backports.functools-lru-cache==1.5  # via astroid, pylint
@@ -132,7 +131,7 @@ edx-django-release-util==0.3.1
 edx-django-sites-extensions==2.3.1
 edx-django-utils==1.0.3
 edx-drf-extensions==2.0.1
-edx-enterprise==1.2.0
+edx-enterprise==1.2.1
 edx-i18n-tools==0.4.6
 edx-lint==1.0.0
 edx-milestones==0.1.13
@@ -162,7 +161,6 @@ flask==1.0.2              # via moto
 freezegun==0.3.11
 fs-s3fs==0.1.8
 fs==2.0.18
-funcsigs==1.0.2           # via pytest
 functools32==3.2.3.post2  # via parsel
 future==0.17.1
 futures==3.2.0 ; python_version == "2.7"
@@ -205,7 +203,6 @@ markupsafe==1.1.0
 mccabe==0.6.1             # via flake8, pylint
 mock==1.0.1
 mongoengine==0.10.0
-more-itertools==4.3.0     # via pytest
 moto==0.3.1
 mysql-python==1.2.5
 networkx==1.7
@@ -225,11 +222,11 @@ pbr==5.1.1
 pdfminer==20140328
 piexif==1.0.2
 pillow==5.3.0
-pluggy==0.6.0             # via pytest, tox
+pluggy==0.8.0             # via tox
 polib==1.1.0
 psutil==1.2.1
 py2neo==3.1.2
-py==1.7.0                 # via pytest, tox
+py==1.7.0                 # via tox
 pyasn1-modules==0.2.2     # via service-identity
 pyasn1==0.4.4             # via pyasn1-modules, service-identity
 pycodestyle==2.4.0
@@ -246,7 +243,7 @@ pyjwt==1.5.2
 pylint-celery==0.3        # via edx-lint
 pylint-django==0.7.2      # via edx-lint
 pylint-plugin-utils==0.3  # via pylint-celery, pylint-django
-pylint==1.7.6             # via edx-lint, pylint-celery, pylint-django, pylint-plugin-utils
+pylint==1.7.6             # via edx-lint, pylint-celery, pylint-django
 pymongo==2.9.1
 pynliner==0.8.0
 pyopenssl==18.0.0         # via scrapy
@@ -304,13 +301,13 @@ sqlparse==0.2.4
 stevedore==1.10.0
 sure==1.4.11
 sympy==0.7.1
-testfixtures==6.4.0
+testfixtures==6.4.1
 testtools==2.3.0          # via fixtures, python-subunit
 text-unidecode==1.2       # via faker
 tincan==0.0.5
 toml==0.10.0              # via tox
 tox-battery==0.5.1
-tox==3.6.0
+tox==3.6.1
 traceback2==1.4.0         # via testtools, unittest2
 transifex-client==0.13.5
 twisted==16.6.0           # via pa11ycrawler, scrapy


### PR DESCRIPTION
Remove version for _pysrt_ and run `make upgrade`.

Also remove constraint on _pytest_ 3.6.3 to support _pluggy_ 0.8.0 since https://github.com/pytest-dev/pytest/issues/3749 has been fixed