### PR TITLE
Resolve deprecation warning on grades model

### DIFF
--- a/lms/djangoapps/grades/models.py
+++ b/lms/djangoapps/grades/models.py
@@ -41,7 +41,7 @@ class BaseTuple(tuple):
     """
     Wrapper class for tuple to allow overrides for both __new__ and __init__
     
-    Normally overriding both methods will produce a deprication warning.  This will
+    Normally overriding both methods will produce a deprecation warning.  This will
     resolve that error and maintain existing behavior.
         See https://bugs.python.org/issue1683368
     """

--- a/lms/djangoapps/grades/models.py
+++ b/lms/djangoapps/grades/models.py
@@ -37,14 +37,31 @@ BLOCK_RECORD_LIST_VERSION = 1
 BlockRecord = namedtuple('BlockRecord', ['locator', 'weight', 'raw_possible', 'graded'])
 
 
-class BlockRecordList(tuple):
+class BaseTuple(tuple):
+    """
+    Wrapper class for tuple to allow overrides for both __new__ and __init__
+    
+    Normally overriding both methods will produce a deprication warning.  This will
+    resolve that error and maintain existing behavior.
+        See https://bugs.python.org/issue1683368
+    """
+    # pylint: disable=unused-argument,super-init-not-called,no-member
+
+    def __new__(cls, iterable, *args, **kwargs):
+        return super(BaseTuple, cls).__new__(cls, iterable)
+
+    def __init__(self, iterable, *args, **kwargs):
+        super_init = super(BaseTuple, self).__init__
+        if super_init.__objclass__ is object:
+            super_init()
+        else:
+            super_init(iterable)
+
+
+class BlockRecordList(BaseTuple):
     """
     An immutable ordered list of BlockRecord objects.
     """
-
-    def __new__(cls, blocks, course_key, version=None):  # pylint: disable=unused-argument
-        return super(BlockRecordList, cls).__new__(cls, blocks)
-
     def __init__(self, blocks, course_key, version=None):
         super(BlockRecordList, self).__init__(blocks)
         self.course_key = course_key


### PR DESCRIPTION
While attempting to cleanup a warning throw in the grades module and we came across a problem where overriding both \_\_new__ AND \_\_init__ will throw a deprecation message.  While not ideal, this at least isolates the issue and keeps our output clean so we don't need to work around an esoteric error.

This issue is called out in greater detail here:
https://bugs.python.org/issue1683368#msg219300

Source for solution:
https://blog.jaraco.com/how-to-safely-override-init-or-new-in/