### PR TITLE
clean up where access checks happen

### DIFF
--- a/openedx/features/content_type_gating/helpers.py
+++ b/openedx/features/content_type_gating/helpers.py
@@ -17,6 +17,14 @@ from student.roles import (
     OrgInstructorRole,
     GlobalStaff
 )
+from xmodule.partitions.partitions import Group
+
+CONTENT_TYPE_GATE_GROUP_IDS = {
+    'limited_access': 1,
+    'full_access': 2,
+}
+LIMITED_ACCESS = Group(CONTENT_TYPE_GATE_GROUP_IDS['limited_access'], 'Limited-access Users')
+FULL_ACCESS = Group(CONTENT_TYPE_GATE_GROUP_IDS['full_access'], 'Full-access Users')
 
 
 def has_staff_roles(user, course_key):

--- a/openedx/features/content_type_gating/tests/test_access.py
+++ b/openedx/features/content_type_gating/tests/test_access.py
@@ -35,9 +35,9 @@ from lms.djangoapps.courseware.tests.factories import (
 from openedx.core.djangoapps.user_api.tests.factories import UserCourseTagFactory
 from openedx.core.djangoapps.util.testing import TestConditionalContent
 from openedx.core.lib.url_utils import quote_slashes
+from openedx.features.content_type_gating.helpers import CONTENT_TYPE_GATE_GROUP_IDS
 from openedx.features.content_type_gating.partitions import (
     CONTENT_GATING_PARTITION_ID,
-    CONTENT_TYPE_GATE_GROUP_IDS,
     ContentTypeGatingPartition
 )
 from openedx.features.content_type_gating.models import ContentTypeGatingConfig
@@ -224,8 +224,8 @@ class TestProblemTypeAccess(SharedModuleStoreTestCase):
             graded=True,
             group_access={
                 CONTENT_GATING_PARTITION_ID: [
-                    settings.CONTENT_TYPE_GATE_GROUP_IDS['limited_access'],
-                    settings.CONTENT_TYPE_GATE_GROUP_IDS['full_access']
+                    CONTENT_TYPE_GATE_GROUP_IDS['limited_access'],
+                    CONTENT_TYPE_GATE_GROUP_IDS['full_access']
                 ]
             },
         )

--- a/openedx/features/course_duration_limits/models.py
+++ b/openedx/features/course_duration_limits/models.py
@@ -20,8 +20,8 @@ from lms.djangoapps.courseware.masquerade import (
 )
 from openedx.core.djangoapps.config_model_utils.models import StackedConfigurationModel
 from openedx.core.djangoapps.config_model_utils.utils import is_in_holdback
-from openedx.features.content_type_gating.helpers import has_staff_roles
-from openedx.features.content_type_gating.partitions import CONTENT_GATING_PARTITION_ID, CONTENT_TYPE_GATE_GROUP_IDS
+from openedx.features.content_type_gating.helpers import CONTENT_TYPE_GATE_GROUP_IDS, has_staff_roles
+from openedx.features.content_type_gating.partitions import CONTENT_GATING_PARTITION_ID
 from openedx.features.course_duration_limits.config import (
     CONTENT_TYPE_GATING_FLAG,
     FEATURE_BASED_ENROLLMENT_GLOBAL_KILL_FLAG,

--- a/openedx/features/course_duration_limits/tests/test_course_expiration.py
+++ b/openedx/features/course_duration_limits/tests/test_course_expiration.py
@@ -29,7 +29,8 @@ from lms.djangoapps.courseware.tests.factories import (
 )
 from openedx.core.djangoapps.content.course_overviews.models import CourseOverview
 from openedx.core.djangoapps.schedules.tests.factories import ScheduleFactory
-from openedx.features.content_type_gating.partitions import CONTENT_GATING_PARTITION_ID, CONTENT_TYPE_GATE_GROUP_IDS
+from openedx.features.content_type_gating.helpers import CONTENT_TYPE_GATE_GROUP_IDS
+from openedx.features.content_type_gating.partitions import CONTENT_GATING_PARTITION_ID
 from openedx.features.course_duration_limits.access import get_user_course_expiration_date, MIN_DURATION, MAX_DURATION
 from openedx.features.course_duration_limits.config import EXPERIMENT_ID, EXPERIMENT_DATA_HOLDBACK_KEY
 from openedx.features.course_experience.tests.views.helpers import add_course_mode


### PR DESCRIPTION
Still trying to figure out which settings files need the CONTENT_TYPE_GATE_GROUP_IDS dict to make python tests pass