### PR TITLE
Update version of edx-proctoring-proctortrack

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3376,7 +3376,7 @@
       }
     },
     "edx-proctoring-proctortrack": {
-      "version": "git+https://git@github.com/joshivj/edx-proctoring-proctortrack.git#66650ed6cd39bf489a86723d5ad3593c2ec8992f",
+      "version": "git+https://git@github.com/joshivj/edx-proctoring-proctortrack.git#c4f49973562bf0e54518b74efce20bafa299616a",
       "requires": {
         "@edx/edx-proctoring": "1.5.0"
       }

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "datatables": "1.10.18",
     "datatables.net-fixedcolumns": "3.2.6",
     "edx-pattern-library": "0.18.1",
-    "edx-proctoring-proctortrack": "git+https://git@github.com/joshivj/edx-proctoring-proctortrack.git",
+    "edx-proctoring-proctortrack": "git+https://git@github.com/joshivj/edx-proctoring-proctortrack.git#c4f49973562bf0e54518b74efce20bafa299616a",
     "edx-ui-toolkit": "1.5.2",
     "exports-loader": "0.6.4",
     "extract-text-webpack-plugin": "2.1.2",


### PR DESCRIPTION
Quality builds were failing due to a dirty package-lock.json file.

Turns out there was action this morning inside https://github.com/joshivj/edx-proctoring-proctortrack, which was causing this because we don't explicitly pin the repo to a sha or version (they haven't released any versions). I chose to not just update the lock but also pin the repo to this sha to prevent this from breaking every time a change is made to the repo.