### PR TITLE
TE-2731 Upgrade to pytest-cov 2.6.0

### DIFF
--- a/openedx/core/djangoapps/user_api/tests/test_views.py
+++ b/openedx/core/djangoapps/user_api/tests/test_views.py
@@ -2718,7 +2718,7 @@ class CountryTimeZoneListViewTest(UserApiTestCase):
         self.assertEqual(time_zone_info['description'], get_display_time_zone(time_zone_name))
 
     # The time zones count may need to change each time we upgrade pytz
-    @ddt.data((ALL_TIME_ZONES_URI, 439),
+    @ddt.data((ALL_TIME_ZONES_URI, 440),
               (COUNTRY_TIME_ZONES_URI, 28))
     @ddt.unpack
     def test_get_basic(self, country_uri, expected_count):

--- a/pavelib/paver_tests/test_paver_pytest_cmds.py
+++ b/pavelib/paver_tests/test_paver_pytest_cmds.py
@@ -75,12 +75,7 @@ class TestPaverPytestCmd(unittest.TestCase):
         ])
 
         if run_under_coverage:
-            if xdist_ip_addresses:
-                for module in Env.covered_modules():
-                    expected_statement.append('--cov')
-                    expected_statement.append(module)
-            else:
-                expected_statement.append('--cov')
+            expected_statement.append('--cov')
             expected_statement.append('--cov-report=')
         return expected_statement
 

--- a/pavelib/utils/test/suites/pytest_suite.py
+++ b/pavelib/utils/test/suites/pytest_suite.py
@@ -126,12 +126,7 @@ class SystemTestSuite(PytestSuite):
         unaltered otherwise.
         """
         if self.run_under_coverage:
-            if self.xdist_ip_addresses:
-                for module in Env.covered_modules():
-                    cmd.append('--cov')
-                    cmd.append(module)
-            else:
-                cmd.append('--cov')
+            cmd.append('--cov')
             cmd.append('--cov-report=')
 
         return cmd
@@ -320,12 +315,7 @@ class LibTestSuite(PytestSuite):
         unaltered otherwise.
         """
         if self.run_under_coverage:
-            if self.xdist_ip_addresses:
-                for module in Env.covered_modules():
-                    cmd.append('--cov')
-                    cmd.append(module)
-            else:
-                cmd.append('--cov')
+            cmd.append('--cov')
             if self.append_coverage:
                 cmd.append('--cov-append')
             cmd.append('--cov-report=')

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -15,15 +15,9 @@ six==1.11.0
 # Convert text markup to HTML; used in capa problems, forums, and course wikis; pin Markdown version as tests failed for its upgrade to latest release
 Markdown==2.6.11
 
-# 5.4.0 causes cms/djangoapps/api/v1/tests/test_views/test_course_runs.py::CourseRunViewSetTests::test_images_upload to fail
-pillow==5.3.0
-
 # required by edx-lint and pinned explicitly here because newer versions don't guarantee python 2 support.
 # Can be removed when we get to Python 3.
 pylint-plugin-utils==0.3
-
-# pytest plugin for measuring code coverage. # Pinned due to https://openedx.atlassian.net/browse/TE-2731
-pytest-cov<2.6
 
 # Browser driver used by lettuce - pinned because splinter==0.10.0 breaks lettuce tests.  EDUCATOR-3795
 splinter==0.9.0

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -51,7 +51,7 @@ asn1crypto==0.24.0
 attrs==17.4.0
 babel==1.3
 backports.functools-lru-cache==1.5  # via soupsieve
-beautifulsoup4==4.7.0     # via pynliner
+beautifulsoup4==4.7.1     # via pynliner
 billiard==3.3.0.23        # via celery
 bleach==2.1.4
 boto3==1.4.8
@@ -183,7 +183,7 @@ paver==1.3.4
 pbr==5.1.1
 pdfminer==20140328
 piexif==1.0.2
-pillow==5.3.0
+pillow==5.4.1
 polib==1.1.0              # via edx-i18n-tools
 psutil==1.2.1
 py2neo==3.1.2
@@ -205,7 +205,7 @@ python-memcached==1.48
 python-openid==2.2.5
 python-saml==2.4.0
 python-swiftclient==3.6.0
-pytz==2018.7
+pytz==2018.9
 pyuca==1.1
 pyyaml==3.13
 redis==2.10.6

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -58,7 +58,7 @@ atomicwrites==1.2.1
 attrs==17.4.0
 babel==1.3
 backports.functools-lru-cache==1.5
-beautifulsoup4==4.7.0
+beautifulsoup4==4.7.1
 before-after==1.0.1
 billiard==3.3.0.23
 bleach==2.1.4
@@ -234,7 +234,7 @@ paver==1.3.4
 pbr==5.1.1
 pdfminer==20140328
 piexif==1.0.2
-pillow==5.3.0
+pillow==5.4.1
 pip-tools==3.2.0
 pluggy==0.8.0
 polib==1.1.0
@@ -267,12 +267,12 @@ pyquery==1.4.0
 pysqlite==2.8.3
 pysrt==1.1.1
 pytest-attrib==0.1.3
-pytest-cov==2.5.1
-pytest-django==3.1.2
+pytest-cov==2.6.1
+pytest-django==3.4.5
 pytest-forked==0.2
 pytest-randomly==1.2.3
 pytest-xdist==1.25.0
-pytest==4.0.2
+pytest==4.1.0
 python-dateutil==2.4.0
 python-levenshtein==0.12.0
 python-memcached==1.48
@@ -282,7 +282,7 @@ python-saml==2.4.0
 python-slugify==1.2.6
 python-subunit==1.3.0
 python-swiftclient==3.6.0
-pytz==2018.7
+pytz==2018.9
 pyuca==1.1
 pyyaml==3.13
 queuelib==1.5.0

--- a/requirements/edx/testing.in
+++ b/requirements/edx/testing.in
@@ -37,7 +37,7 @@ pysqlite                  # DB-API 2.0 interface for SQLite 3.x (used as the rel
 pytest                    # Testing framework
 pytest-attrib             # Select tests based on attributes
 pytest-cov                # pytest plugin for measuring code coverage.
-pytest-django==3.1.2      # Django support for pytest
+pytest-django             # Django support for pytest
 pytest-randomly           # pytest plugin to randomly order tests
 pytest-xdist              # Parallel execution of tests on multiple CPU cores or hosts
 radon                     # Calculates cyclomatic complexity of Python code (code quality utility)

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -55,7 +55,7 @@ atomicwrites==1.2.1       # via pytest
 attrs==17.4.0
 babel==1.3
 backports.functools-lru-cache==1.5
-beautifulsoup4==4.7.0
+beautifulsoup4==4.7.1
 before-after==1.0.1
 billiard==3.3.0.23
 bleach==2.1.4
@@ -219,13 +219,13 @@ openapi-codec==1.3.2
 pa11ycrawler==1.6.2
 parsel==1.5.1             # via scrapy
 path.py==8.2.1
-pathlib2==2.3.3           # via pytest
+pathlib2==2.3.3           # via pytest, pytest-django
 pathtools==0.1.2
 paver==1.3.4
 pbr==5.1.1
 pdfminer==20140328
 piexif==1.0.2
-pillow==5.3.0
+pillow==5.4.1
 pluggy==0.8.0             # via pytest, tox
 polib==1.1.0
 psutil==1.2.1
@@ -256,12 +256,12 @@ pyquery==1.4.0
 pysqlite==2.8.3
 pysrt==1.1.1
 pytest-attrib==0.1.3
-pytest-cov==2.5.1
-pytest-django==3.1.2
+pytest-cov==2.6.1
+pytest-django==3.4.5
 pytest-forked==0.2        # via pytest-xdist
 pytest-randomly==1.2.3
 pytest-xdist==1.25.0
-pytest==4.0.2
+pytest==4.1.0
 python-dateutil==2.4.0
 python-levenshtein==0.12.0
 python-memcached==1.48
@@ -271,7 +271,7 @@ python-saml==2.4.0
 python-slugify==1.2.6     # via transifex-client
 python-subunit==1.3.0
 python-swiftclient==3.6.0
-pytz==2018.7
+pytz==2018.9
 pyuca==1.1
 pyyaml==3.13
 queuelib==1.5.0           # via scrapy

--- a/scripts/unit-tests.sh
+++ b/scripts/unit-tests.sh
@@ -56,12 +56,15 @@ case "${TEST_SUITE}" in
         case "$SHARD" in
             "all")
                 paver test_system -s lms --disable_capture ${PAVER_ARGS} ${PARALLEL} 2> lms-tests.log
+                mv reports/.coverage reports/.coverage.lms
                 ;;
             [1-9])
                 paver test_system -s lms --disable_capture --eval-attr="shard==$SHARD" ${PAVER_ARGS} ${PARALLEL} 2> lms-tests.${SHARD}.log
+                mv reports/.coverage reports/.coverage.lms.${SHARD}
                 ;;
             10|"noshard")
                 paver test_system -s lms --disable_capture --eval-attr="shard>=$SHARD or not shard" ${PAVER_ARGS} ${PARALLEL} 2> lms-tests.10.log
+                mv reports/.coverage reports/.coverage.lms.10
                 ;;
             *)
                 # If no shard is specified, rather than running all tests, create an empty xunit file. This is a
@@ -78,12 +81,15 @@ case "${TEST_SUITE}" in
         case "$SHARD" in
             "all")
                 paver test_system -s cms --disable_capture ${PAVER_ARGS} ${PARALLEL} 2> cms-tests.log
+                mv reports/.coverage reports/.coverage.cms
                 ;;
             1)
                 paver test_system -s cms --disable_capture --eval-attr="shard==$SHARD" ${PAVER_ARGS} 2> cms-tests.${SHARD}.log
+                mv reports/.coverage reports/.coverage.cms.${SHARD}
                 ;;
             2|"noshard")
                 paver test_system -s cms --disable_capture --eval-attr="shard>=$SHARD or not shard" ${PAVER_ARGS} 2> cms-tests.2.log
+                mv reports/.coverage reports/.coverage.cms.2
                 ;;
             *)
                 # If no shard is specified, rather than running all tests, create an empty xunit file. This is a
@@ -100,12 +106,15 @@ case "${TEST_SUITE}" in
         case "$SHARD" in
             "all")
                 paver test_lib --disable_capture ${PAVER_ARGS} ${PARALLEL} 2> common-tests.log
+                mv reports/.coverage reports/.coverage.commonlib
                 ;;
             [1-2])
                 paver test_lib -l common/lib/xmodule --disable_capture --eval-attr="shard==$SHARD" ${PAVER_ARGS} 2> common-tests.${SHARD}.log
+                mv reports/.coverage reports/.coverage.commonlib.${SHARD}
                 ;;
             3|"noshard")
                 paver test_lib --disable_capture --eval-attr="shard>=$SHARD or not shard" ${PAVER_ARGS} 2> common-tests.3.log
+                mv reports/.coverage reports/.coverage.commonlib.3
                 ;;
             *)
                 # If no shard is specified, rather than running all tests, create an empty xunit file. This is a


### PR DESCRIPTION
pytest-cov 2.5.1 isn't gathering coverage data correctly from remote pytest-xdist workers.  Some fixes were made around this in 2.6.0, so try upgrading.  This required making some tweaks to accommodate changes made in the new version:

* Remove the workaround for https://github.com/pytest-dev/pytest-cov/pull/213 now that my fix has been released
* Rename the `.coverage` files generated when pytest-cov auto-combines the coverage data from each worker, so they don't overwrite each other when collected to combine after all pytest runs finish

Also pinned `pillow` since the new version is causing one test to fail for a reason I haven't had time to diagnose yet.