### PR TITLE
Add proctortrack library

### DIFF
--- a/conf/locale/config.yaml
+++ b/conf/locale/config.yaml
@@ -139,6 +139,7 @@ ignore_dirs:
 # .tx/config file so that it will be pushed to and pulled from transifex.
 third_party:
     - wiki
+    - edx_proctoring_proctortrack
 
 
 # How should .po files be segmented?  See i18n/segment.py for details. Strings

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -126,7 +126,7 @@ edx-milestones==0.1.13
 edx-oauth2-provider==1.2.2
 edx-opaque-keys[django]==0.4.4
 edx-organizations==1.0.0
-edx-proctoring==1.5.0
+edx-proctoring==1.5.1
 edx-rest-api-client==1.9.2
 edx-search==1.2.1
 edx-submissions==2.0.12

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -22,6 +22,7 @@ git+https://github.com/edx/django-rest-framework.git@1ceda7c086fddffd1c440cc8685
 -e git+https://github.com/edx/DoneXBlock.git@01a14f3bd80ae47dd08cdbbe2f88f3eb88d00fba#egg=done-xblock
 -e git+https://github.com/jazkarta/edx-jsme.git@690dbf75441fa91c7c4899df0b83d77f7deb5458#egg=edx-jsme
 git+https://github.com/mitodl/edx-sga.git@3828ba9e413080a81b907a3381e5ffa05e063f81#egg=edx-sga==0.8.3
+git+https://github.com/joshivj/edx-proctoring-proctortrack.git@c4f49973562bf0e54518b74efce20bafa299616a#egg=edx_proctoring_proctortrack==1.0.0
 git+https://github.com/edx/xblock-lti-consumer.git@v1.1.8#egg=lti_consumer-xblock==1.1.8
 git+https://github.com/edx/MongoDBProxy.git@25b99097615bda06bd7cdfe5669ed80dc2a7fed0#egg=MongoDBProxy==0.1.0
 -e .

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -24,6 +24,7 @@ git+https://github.com/edx/django-rest-framework.git@1ceda7c086fddffd1c440cc8685
 -e git+https://github.com/edx/DoneXBlock.git@01a14f3bd80ae47dd08cdbbe2f88f3eb88d00fba#egg=done-xblock
 -e git+https://github.com/jazkarta/edx-jsme.git@690dbf75441fa91c7c4899df0b83d77f7deb5458#egg=edx-jsme
 git+https://github.com/mitodl/edx-sga.git@3828ba9e413080a81b907a3381e5ffa05e063f81#egg=edx-sga==0.8.3
+git+https://github.com/joshivj/edx-proctoring-proctortrack.git@c4f49973562bf0e54518b74efce20bafa299616a#egg=edx_proctoring_proctortrack==1.0.0
 git+https://github.com/edx/lettuce.git@7a04591c78ac56dac3eb3e91ca94b15cce844133#egg=lettuce==0.2.23+edx.1
 git+https://github.com/edx/xblock-lti-consumer.git@v1.1.8#egg=lti_consumer-xblock==1.1.8
 git+https://github.com/edx/MongoDBProxy.git@25b99097615bda06bd7cdfe5669ed80dc2a7fed0#egg=MongoDBProxy==0.1.0

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -145,7 +145,7 @@ edx-milestones==0.1.13
 edx-oauth2-provider==1.2.2
 edx-opaque-keys[django]==0.4.4
 edx-organizations==1.0.0
-edx-proctoring==1.5.0
+edx-proctoring==1.5.1
 edx-rest-api-client==1.9.2
 edx-search==1.2.1
 edx-sphinx-theme==1.4.0

--- a/requirements/edx/github.in
+++ b/requirements/edx/github.in
@@ -71,6 +71,9 @@
 -e git+https://github.com/mitodl/django-cas.git@afac57bc523f145ae826f4ed3d4fa8b2c86c5364#egg=django-cas==2.1.1
 -e git+https://github.com/dgrtwo/ParsePy.git@7949b9f754d1445eff8e8f20d0e967b9a6420639#egg=parse_rest
 
+# pinned to repo until verificient uploads their package to pypi
+-e git+https://github.com/joshivj/edx-proctoring-proctortrack.git@c4f49973562bf0e54518b74efce20bafa299616a#egg=edx_proctoring_proctortrack==1.0.0
+
 # Forked to get Django 1.10+ compat that is in origin BitBucket repo, without an official build.
 # This can go away when we update auth to not use django-rest-framework-oauth
 -e git+https://github.com/edx/django-oauth-plus.git@01ec2a161dfc3465f9d35b9211ae790177418316#egg=django-oauth-plus==2.2.9.edx-1

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -22,6 +22,7 @@ git+https://github.com/edx/django-rest-framework.git@1ceda7c086fddffd1c440cc8685
 -e git+https://github.com/edx/DoneXBlock.git@01a14f3bd80ae47dd08cdbbe2f88f3eb88d00fba#egg=done-xblock
 -e git+https://github.com/jazkarta/edx-jsme.git@690dbf75441fa91c7c4899df0b83d77f7deb5458#egg=edx-jsme
 git+https://github.com/mitodl/edx-sga.git@3828ba9e413080a81b907a3381e5ffa05e063f81#egg=edx-sga==0.8.3
+git+https://github.com/joshivj/edx-proctoring-proctortrack.git@c4f49973562bf0e54518b74efce20bafa299616a#egg=edx_proctoring_proctortrack==1.0.0
 git+https://github.com/edx/lettuce.git@7a04591c78ac56dac3eb3e91ca94b15cce844133#egg=lettuce==0.2.23+edx.1
 git+https://github.com/edx/xblock-lti-consumer.git@v1.1.8#egg=lti_consumer-xblock==1.1.8
 git+https://github.com/edx/MongoDBProxy.git@25b99097615bda06bd7cdfe5669ed80dc2a7fed0#egg=MongoDBProxy==0.1.0

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -140,7 +140,7 @@ edx-milestones==0.1.13
 edx-oauth2-provider==1.2.2
 edx-opaque-keys[django]==0.4.4
 edx-organizations==1.0.0
-edx-proctoring==1.5.0
+edx-proctoring==1.5.1
 edx-rest-api-client==1.9.2
 edx-search==1.2.1
 edx-submissions==2.0.12


### PR DESCRIPTION
This (plus a configuration change to add their API key) will enable choosing proctortrack as a proctoring backend. 