### PR TITLE
ENT-1437 : Make sure only active AccountRecovery records are used

### DIFF
--- a/common/djangoapps/student/forms.py
+++ b/common/djangoapps/student/forms.py
@@ -160,7 +160,7 @@ class AccountRecoveryForm(PasswordResetFormNoActive):
         email = self.cleaned_data["email"]
         # The line below contains the only change, getting users via AccountRecovery
         self.users_cache = User.objects.filter(
-            id__in=AccountRecovery.objects.filter(secondary_email__iexact=email).values_list('user')
+            id__in=AccountRecovery.objects.filter(secondary_email__iexact=email, is_active=True).values_list('user')
         )
 
         if not len(self.users_cache):

--- a/common/djangoapps/student/models.py
+++ b/common/djangoapps/student/models.py
@@ -2700,6 +2700,31 @@ class LogoutViewConfiguration(ConfigurationModel):
         return u'Logout view configuration: {enabled}'.format(enabled=self.enabled)
 
 
+class AccountRecoveryManager(models.Manager):
+    """
+    Custom Manager for AccountRecovery model
+    """
+
+    def get_active(self, **filters):
+        """
+        Return only active AccountRecovery record after applying the given filters.
+
+        Arguments:
+            filters (**kwargs): Filter parameters for AccountRecovery records.
+
+        Returns:
+            AccountRecovery: AccountRecovery object with is_active=true
+        """
+        filters['is_active'] = True
+        return super(AccountRecoveryManager, self).get_queryset().get(**filters)
+
+    def activate(self):
+        """
+        Set is_active flag to True.
+        """
+        super(AccountRecoveryManager, self).get_queryset().update(is_active=True)
+
+
 class AccountRecovery(models.Model):
     """
     Model for storing information for user's account recovery in case of access loss.
@@ -2716,3 +2741,5 @@ class AccountRecovery(models.Model):
 
     class Meta(object):
         db_table = "auth_accountrecovery"
+
+    objects = AccountRecoveryManager()

--- a/common/djangoapps/student/tests/factories.py
+++ b/common/djangoapps/student/tests/factories.py
@@ -210,3 +210,4 @@ class AccountRecoveryFactory(DjangoModelFactory):
 
     user = None
     secondary_email = factory.Sequence(u'robot+test+recovery+{0}@edx.org'.format)
+    is_active = True

--- a/common/djangoapps/student/views/management.py
+++ b/common/djangoapps/student/views/management.py
@@ -759,7 +759,7 @@ def account_recovery_request_handler(request):
 
             # Check if a user exists with the given secondary email, if so then invalidate the existing oauth tokens.
             user = user if user.is_authenticated else User.objects.get(
-                id=AccountRecovery.objects.get(secondary_email__iexact=email).user.id
+                id=AccountRecovery.objects.get_active(secondary_email__iexact=email).user.id
             )
             destroy_oauth_tokens(user)
         except UserNotFound:


### PR DESCRIPTION
**JIRA Ticket:** [ENT-1437](https://openedx.atlassian.net/browse/ENT-1437)

__Description:__
There are places in the system where we are using AccountRecovery records without checking the newly introduced (is_active) flag. We need to update all the usages of AccountRecovery to make sure that correct records are used for account recovery flow.