### PR TITLE
enable searching for course in FBE admin

### DIFF
--- a/openedx/features/content_type_gating/admin.py
+++ b/openedx/features/content_type_gating/admin.py
@@ -36,5 +36,6 @@ class ContentTypeGatingConfigAdmin(StackedConfigModelAdmin):
             ),
         })
     )
+    raw_id_fields = ('course',)
 
 admin.site.register(ContentTypeGatingConfig, ContentTypeGatingConfigAdmin)

--- a/openedx/features/course_duration_limits/admin.py
+++ b/openedx/features/course_duration_limits/admin.py
@@ -36,5 +36,6 @@ class CourseDurationLimitConfigAdmin(StackedConfigModelAdmin):
             ),
         })
     )
+    raw_id_fields = ('course',)
 
 admin.site.register(CourseDurationLimitConfig, CourseDurationLimitConfigAdmin)


### PR DESCRIPTION
I was initially looking at adding a django-autocomplete-light autocomplete field like we use in course discovery.  
I then found I could add this admin option, which appears to be sufficient.  
I'm not sure if there are any reasons this wouldn't work in prod, but it appears to work fine locally