### PR TITLE
Always include origin for target_branch in diff quality

### DIFF
--- a/scripts/jenkins-quality-diff.sh
+++ b/scripts/jenkins-quality-diff.sh
@@ -10,4 +10,7 @@ echo "Running diff quality."
 mkdir -p test_root/log/
 LOG_PREFIX=test_root/log/run_quality
 
+if [[ $TARGET_BRANCH != origin/* ]]; then
+    TARGET_BRANCH=origin/$TARGET_BRANCH
+fi
 paver run_quality -b $TARGET_BRANCH -p 100 -l $LOWER_PYLINT_THRESHOLD:$UPPER_PYLINT_THRESHOLD 2> $LOG_PREFIX.err.log > $LOG_PREFIX.out.log


### PR DESCRIPTION
Another spot where we need to ensure the target branch has origin in its value: https://build.testeng.edx.org/job/edx-platform-quality-flow-pr_private/57/