### PR TITLE
Fix same username w/different case special-case.

### DIFF
--- a/common/djangoapps/student/models.py
+++ b/common/djangoapps/student/models.py
@@ -291,7 +291,7 @@ def get_retired_email_by_email(email):
     return user_util.get_retired_email(email, settings.RETIRED_USER_SALTS, settings.RETIRED_EMAIL_FMT)
 
 
-def get_all_retired_usernames_by_username(username):
+def _get_all_retired_usernames_by_username(username):
     """
     Returns a generator of "retired usernames", one hashed with each
     configured salt. Used for finding out if the given username has
@@ -300,7 +300,7 @@ def get_all_retired_usernames_by_username(username):
     return user_util.get_all_retired_usernames(username, settings.RETIRED_USER_SALTS, settings.RETIRED_USERNAME_FMT)
 
 
-def get_all_retired_emails_by_email(email):
+def _get_all_retired_emails_by_email(email):
     """
     Returns a generator of "retired emails", one hashed with each
     configured salt. Used for finding out if the given email has
@@ -315,7 +315,7 @@ def get_potentially_retired_user_by_username(username):
     does not exist, then any hashed username salted with the historical
     salts.
     """
-    locally_hashed_usernames = list(get_all_retired_usernames_by_username(username))
+    locally_hashed_usernames = list(_get_all_retired_usernames_by_username(username))
     locally_hashed_usernames.append(username)
     potential_users = User.objects.filter(username__in=locally_hashed_usernames)
 
@@ -360,7 +360,7 @@ def get_potentially_retired_user_by_username_and_hash(username, hashed_username)
       does not exist, the any hashed username salted with the historical
       salts.
     """
-    locally_hashed_usernames = list(get_all_retired_usernames_by_username(username))
+    locally_hashed_usernames = list(_get_all_retired_usernames_by_username(username))
 
     if hashed_username not in locally_hashed_usernames:
         raise Exception('Mismatched hashed_username, bad salt?')

--- a/common/djangoapps/student/tests/test_retirement.py
+++ b/common/djangoapps/student/tests/test_retirement.py
@@ -12,8 +12,8 @@ from django.test import TestCase
 import pytest
 
 from student.models import (
-    get_all_retired_emails_by_email,
-    get_all_retired_usernames_by_username,
+    _get_all_retired_emails_by_email,
+    _get_all_retired_usernames_by_username,
     get_potentially_retired_user_by_username,
     get_potentially_retired_user_by_username_and_hash,
     get_retired_email_by_email,
@@ -110,7 +110,7 @@ def test_get_all_retired_usernames_by_username(retirement_user):
     Check that all salts are used for this method and return expected
     formats.
     """
-    hashed_usernames = list(get_all_retired_usernames_by_username(retirement_user.username))
+    hashed_usernames = list(_get_all_retired_usernames_by_username(retirement_user.username))
     assert len(hashed_usernames) == len(settings.RETIRED_USER_SALTS)
 
     for hashed_username in hashed_usernames:
@@ -185,7 +185,7 @@ def test_get_all_retired_email_by_email(retirement_user):
     Check that all salts are used for this method and return expected
     formats.
     """
-    hashed_emails = list(get_all_retired_emails_by_email(retirement_user.email))
+    hashed_emails = list(_get_all_retired_emails_by_email(retirement_user.email))
     assert len(hashed_emails) == len(settings.RETIRED_USER_SALTS)
 
     for hashed_email in hashed_emails:


### PR DESCRIPTION
https://openedx.atlassian.net/browse/PLAT-2404

For a brief period, users were able to retire accounts and make another account with the same differently-cased username, like "testuser" and "TestUser". The logic for the retired user retrieval was incorrect for this case. This PR fixes the logic and adds a test for it.

Also, methods which return hashed usernames/email addresses are marked as private to stress that they shouldn't be used outside this module. Instead, the provided convenience query methods should be used.
