### PR TITLE
fix inconsistent line breaks while creating course updates

### DIFF
--- a/common/static/js/vendor/CodeMirror/codemirror.css
+++ b/common/static/js/vendor/CodeMirror/codemirror.css
@@ -195,7 +195,7 @@ div.CodeMirror span.CodeMirror-nonmatchingbracket {color: #f22;}
 .CodeMirror-wrap pre {
   word-wrap: break-word;
   white-space: pre-wrap;
-  word-break: normal;
+  word-break: break-word;
 }
 .CodeMirror-code pre {
   border-right: 30px solid transparent;


### PR DESCRIPTION
### [EDUCATOR-3851](https://openedx.atlassian.net/browse/EDUCATOR-3851)

### Description
When creating/editing an update for the course on the studio, for some longer lines, involving links, the inconsistent lines and words break were happening. Combined with CodeMirror editor, the inconsistency led to incorrect places of content change with respect to cursor. This error was only observed with Chrome(working fine on Firefox). The rationale behind that is that line breaks were left onto browser. Given each browser behaved differently, the line breaks were not consistent across browsers. Firefox handled them correctly, while Chrome didn't. A similar issue had previously been reported on the CodeMirror GitHub [repo](https://github.com/codemirror/CodeMirror/issues/1642) , where some Chrome issues caused the problem in question. Even after the fix rolled out, some users still faced the issue. To counter this issue, the word breaks were taken care of explicitly so that behavior gets a near consistent state on different browsers.

### Note
Another noticed behavior is that when the word breaks occur, if there is no immediate white-space after the last character, the cursor moves to next line instead of moving after the last character. It might look like a bug, but that is how the CodeMirror works, as mentioned in this [issue](https://github.com/codemirror/CodeMirror/issues/4841#issuecomment-314045480)

### Sandbox
 - https://codemirror.sandbox.edx.org/dashboard

#### Before Fix
![before_fix](https://user-images.githubusercontent.com/40599381/50878869-8b388680-13fa-11e9-9d4f-078a7c6401dc.gif)


#### After Fix
![after_fix](https://user-images.githubusercontent.com/40599381/50878873-925f9480-13fa-11e9-9293-d4fce4d3db8f.gif)

### Reviewers
 - [x] @noraiz-anwar 
 - [x] @Rabia23 

### Post Review
 - [x] Squash & Rebase commits
