### PR TITLE
ENT-1392 bump enterprise version to 1.2.2

### DIFF
--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -119,7 +119,7 @@ edx-django-release-util==0.3.1
 edx-django-sites-extensions==2.3.1
 edx-django-utils==1.0.3
 edx-drf-extensions==2.0.1
-edx-enterprise==1.2.1
+edx-enterprise==1.2.2
 edx-i18n-tools==0.4.6
 edx-milestones==0.1.13
 edx-oauth2-provider==1.2.2

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -137,7 +137,7 @@ edx-django-release-util==0.3.1
 edx-django-sites-extensions==2.3.1
 edx-django-utils==1.0.3
 edx-drf-extensions==2.0.1
-edx-enterprise==1.2.1
+edx-enterprise==1.2.2
 edx-i18n-tools==0.4.6
 edx-lint==1.0.0
 edx-milestones==0.1.13

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -132,7 +132,7 @@ edx-django-release-util==0.3.1
 edx-django-sites-extensions==2.3.1
 edx-django-utils==1.0.3
 edx-drf-extensions==2.0.1
-edx-enterprise==1.2.1
+edx-enterprise==1.2.2
 edx-i18n-tools==0.4.6
 edx-lint==1.0.0
 edx-milestones==0.1.13


### PR DESCRIPTION
**Description:** Given that an enrollable course does not start until a future date, when a learner views the B2B landing page for that course, then the system should highlight the future start date so that it is clear to the learner.

**Related Enterprise PR:** https://github.com/edx/edx-enterprise/pull/418

`edx-enterprise` changes: https://github.com/edx/edx-enterprise/compare/1.2.1...1.2.2
