### PR TITLE
SE-614 Adds optional args to create_dot_application command

### DIFF
--- a/openedx/core/djangoapps/oauth_dispatch/management/commands/tests/test_create_dot_application.py
+++ b/openedx/core/djangoapps/oauth_dispatch/management/commands/tests/test_create_dot_application.py
@@ -3,6 +3,8 @@ Tests the ``create_dot_application`` management command.
 """
 from __future__ import absolute_import, unicode_literals
 
+import ddt
+
 from django.core.management import call_command
 from django.test import TestCase
 from oauth2_provider.models import get_application_model
@@ -15,6 +17,7 @@ from ..create_dot_application import Command
 Application = get_application_model()
 
 
+@ddt.ddt
 class TestCreateDotApplication(TestCase):
     """
     Tests the ``create_dot_application`` management command.
@@ -27,20 +30,53 @@ class TestCreateDotApplication(TestCase):
         super(TestCreateDotApplication, self).tearDown()
         Application.objects.filter(user=self.user).delete()
 
-    def test_create_dot_application(self):
-        call_command(Command(), 'testing_application', self.user.username)
+    @ddt.data(
+        (None, None, None, None),
+        (None, None, 'client-abc', None),
+        (None, None, None, 'great-big-secret'),
+        ('password', True, 'client-dce', 'has-a-great-big-secret'),
+    )
+    @ddt.unpack
+    def test_create_dot_application(self, grant_type, public, client_id, client_secret):
+        # Add optional arguments if provided
+        call_args = ['testing_application', self.user.username]
+        if grant_type:
+            call_args.append('--grant-type')
+            call_args.append(grant_type)
+        else:
+            grant_type = Application.GRANT_CLIENT_CREDENTIALS
+
+        if public:
+            call_args.append('--public')
+            client_type = Application.CLIENT_PUBLIC
+        else:
+            client_type = Application.CLIENT_CONFIDENTIAL
+
+        if client_id:
+            call_args.append('--client-id')
+            call_args.append(client_id)
+        if client_secret:
+            call_args.append('--client-secret')
+            call_args.append(client_secret)
+
+        call_command(Command(), *call_args)
 
         apps = Application.objects.filter(name='testing_application')
         self.assertEqual(1, len(apps))
         application = apps[0]
         self.assertEqual('testing_application', application.name)
         self.assertEqual(self.user, application.user)
-        self.assertEqual(Application.GRANT_CLIENT_CREDENTIALS, application.authorization_grant_type)
-        self.assertEqual(Application.CLIENT_CONFIDENTIAL, application.client_type)
+        self.assertEqual(grant_type, application.authorization_grant_type)
+        self.assertEqual(client_type, application.client_type)
         self.assertEqual('', application.redirect_uris)
+
+        if client_id:
+            self.assertEqual(client_id, application.client_id)
+        if client_secret:
+            self.assertEqual(client_secret, application.client_secret)
 
         # When called a second time with the same arguments, the command should
         # exit gracefully without creating a second application.
-        call_command(Command(), 'testing_application', self.user.username)
+        call_command(Command(), *call_args)
         apps = Application.objects.filter(name='testing_application')
         self.assertEqual(1, len(apps))


### PR DESCRIPTION
Allows creation of `Public` applications, and passing of the `client_id` or `client_secret` to the command, e.g. from configuration playbooks.

**Background**:

Since https://github.com/edx/edx-platform/pull/17633 was merged, the mobile applications must use DOT applications in order to access HTTP and Problem blocks in the LMS.  If the LMS sits behind basic authentication (e.g. with OpenCraft's load balancer setup), then the basic authentication credentials are also passed through to the OAuth2 provider, and so there must be a corresponding DOT entry for that basic auth, as well as an entry for the mobile app client.

This change, along with https://github.com/edx/configuration/pull/4937, allows us to provision basic authenticated LMS servers which can still be used by their mobile applications.

**JIRA tickets**: [OSPR-2964](https://openedx.atlassian.net/browse/OSPR-2964)

**Discussion**: [Slack#mobile-apps thread](https://openedx.slack.com/archives/C0F0NA2F5/p1546911490051200?thread_ts=1542608835.007800&cid=C0F0NA2F5)

**Sandbox URL**: TBD - sandbox is being provisioned.

* LMS: https://pr19571.sandbox.opencraft.hosting/
* Studio: https://studio-pr19571.sandbox.opencraft.hosting/

**Testing instructions**:

The sandbox was created using the configuration settings noted below.

1. Login to the Django Admin as a superuser (the `staff@example.com` user has been elevated to `superuser` on the sandbox).
1. Visit `/admin/oauth2_provider/application/`
   Note that there is a application there named "Basic Auth test" attached to the `login_service_user`, with a `client_id` and `client_secret` corresponding to the basic auth credentials shown in the settings below.
  This application was created by the configuration management command call added by https://github.com/edx/configuration/pull/4937.

To test modified command changes here:
1. Open an LMS shell
1. Run the command below, and check that it creates a new application accordingly:
   ```
   ./manage.py lms create_dot_application --settings=$EDX_PLATFORM_SETTINGS \
       "Another App" "login_service_user" --client-id "abcdefg" --client-secret "ahijklm" \
       --public --grant-type "implicit"
   # Created Basic Auth application with id: ...
   ```
1. Re-running the above command should succeed, but result in this message:
   ```
   Application with name Another App and user login_service_user already exists.
   ```

**Author Notes & Concerns**
1. Bokchoy test failure looks totally unrelated.

**Reviewers**
- [ ] @symbolist 

**Settings**
```yaml
configuration_version: jill/dot-basic-auth
configuration_source_repo_url: https://github.com/open-craft/configuration

COMMON_ENABLE_BASIC_AUTH: true
COMMON_HTPASSWD_PASS: 81993fa40bf91c89
COMMON_HTPASSWD_USER: 6cd15d9a6bc5de1d
EDXAPP_BASIC_AUTH_DOT_APP_NAME: "Basic Auth test"

EDXAPP_FEATURES:
  ENABLE_COMBINED_LOGIN_REGISTRATION: true
```
