### PR TITLE
asadiqbal08/ENT-1419 Show an alert for secondary email activation on dashboard.

### DIFF
--- a/lms/templates/dashboard.html
+++ b/lms/templates/dashboard.html
@@ -91,6 +91,13 @@ from student.models import CourseEnrollment
         banner.showMessage(${recovery_email_message | n, dump_js_escaped_json})
       </%static:require_module>
   % endif
+  % if recovery_email_activation_message:
+      <%static:require_module module_name="js/views/message_banner" class_name="MessageBannerView">
+        var banner = new MessageBannerView({urgency: 'low', type: 'warning', isRecoveryEmailMsg: true});
+        $('#content').prepend(banner.$el);
+        banner.showMessage(${recovery_email_activation_message | n, dump_js_escaped_json})
+      </%static:require_module>
+  % endif
 </%block>
 
 <div class="dashboard-notifications" tabindex="-1">

--- a/themes/edx.org/lms/templates/dashboard.html
+++ b/themes/edx.org/lms/templates/dashboard.html
@@ -98,6 +98,13 @@ from student.models import CourseEnrollment
         banner.showMessage(${recovery_email_message | n, dump_js_escaped_json})
       </%static:require_module>
   % endif
+  % if recovery_email_activation_message:
+      <%static:require_module module_name="js/views/message_banner" class_name="MessageBannerView">
+        var banner = new MessageBannerView({urgency: 'low', type: 'warning', isRecoveryEmailMsg: true});
+        $('#content').prepend(banner.$el);
+        banner.showMessage(${recovery_email_activation_message | n, dump_js_escaped_json})
+      </%static:require_module>
+  % endif
 </%block>
 
 <div class="dashboard-notifications" tabindex="-1">


### PR DESCRIPTION
[ENT-1419](https://openedx.atlassian.net/browse/ENT-1419)

#### Description:
We need to show an alert on LMS dashboard if user did not click on the secondary email activation link in his/her email. The purpose of this story to remind the user to check his/her email and activate his secondary email address for future use.

#### ScreenShot

![screen shot 2019-01-10 at 3 59 15 pm](https://user-images.githubusercontent.com/7334669/50964321-cb7a3080-14f0-11e9-8d5c-338a90588d0f.png)

