### PR TITLE
WIP: Resolve issue with devstack_docker not loading comprehensive theming DIR paths for mako template files.

### DIFF
--- a/lms/envs/devstack_docker.py
+++ b/lms/envs/devstack_docker.py
@@ -1,5 +1,7 @@
 """ Overrides for Docker-based devstack. """
 
+from openedx.core.lib.derived import derive_settings  # pylint: disable=wrong-import-order
+
 from .devstack import *  # pylint: disable=wildcard-import, unused-wildcard-import
 
 # Docker does not support the syslog socket at /dev/log. Rely on the console.
@@ -79,3 +81,7 @@ COURSE_CATALOG_API_URL = 'http://edx.devstack.discovery:18381/api/v1/'
 # Uncomment the lines below if you'd like to see SQL statements in your devstack LMS log.
 # LOGGING['handlers']['console']['level'] = 'DEBUG'
 # LOGGING['loggers']['django.db.backends'] = {'handlers': ['console'], 'level': 'DEBUG', 'propagate': False}
+
+########################## Derive Any Derived Settings  #######################
+
+derive_settings(__name__)

--- a/lms/envs/production.py
+++ b/lms/envs/production.py
@@ -1105,4 +1105,5 @@ plugin_settings.add_plugins(__name__, plugin_constants.ProjectType.LMS, plugin_c
 
 ########################## Derive Any Derived Settings  #######################
 
-derive_settings(__name__)
+if os.environ['DJANGO_SETTINGS_MODULE'] != 'lms.envs.devstack_docker':
+    derive_settings(__name__)


### PR DESCRIPTION
**NOTE:** This is WIP. I created this to discuss with edX best ways to handle this since I'm new to how `derive_settings` works when setting up DIRS for Mako templates for comprehensive theming. I came across this issue when trying to setup comprehensive theming in new directory for the `open-release/hawthorn.master` release under devstack_docker configuration.

**Background:** It appears that when running docker_devstack Django configuration that the derived settings for Django Mako DIRS when calling `_make_mako_template_dirs` does not setup the `COMPREHENSIVE_THEME_DIRS` path correctly when calling the `_derive_settings(__name__)` call at the end of `lms/envs/production.py` since the Django setting for `ENABLE_COMPREHENSIVE_THEMING` is set to `False`. @doctoryes mentions that this derive settings call should be handled at the end of the environment settings configuration after all settings have been set. Since `lms/envs/devstack.py` includes `lms/envs/production.py` this pull request changes the `derive_settings` call to be handled after all configuration settings have been done for the devstack_docker environment; other Django environment settings keep `derive_settings` inline with how it's done previously.

**Slack (#theming):** Initial discussion located at this thread https://openedx.slack.com/archives/C0G15M90X/p1545148298031200

**Studio Updates:** None. Should we be concerned about this as well? I'm thinking yes.

**LMS Updates:** Verify that comprehensive theming is working by overriding the `edx-platform/lms/static/images/logo.png` file and see if the graphic changes. This logo needs to reside in a separate DIR than the default configuration.

**Testing:** Update the following Django configuration settings by including a separate DIR for viewing theming within either `lms/envs/private.py` or `lms/envs/devstack_docker.py`file.
```
################################ THEMING ################################

DEFAULT_SITE_THEME = 'themename'
ENABLE_COMPREHENSIVE_THEMING = True
# COMPREHENSIVE_THEME_DIR = ''
COMPREHENSIVE_THEME_DIRS = [
    '/edx/app/edx-themes/edx-platform'
]
```