### PR TITLE
Enable private pipeline jobs

### DIFF
--- a/scripts/Jenkinsfiles/bokchoy
+++ b/scripts/Jenkinsfiles/bokchoy
@@ -5,14 +5,14 @@ def runBokchoyTests() {
         git_branch = "${ghprbActualCommit}"
         git_refspec = "+refs/pull/${ghprbPullId}/*:refs/remotes/origin/pr/${ghprbPullId}/*"
     } else {
-        git_branch = 'master'
-        git_refspec = "+refs/heads/master:refs/remotes/origin/master"
+        git_branch = "${BRANCH_NAME}"
+        git_refspec = "+refs/heads/${BRANCH_NAME}:refs/remotes/origin/${BRANCH_NAME}"
     }
     sshagent(credentials: ['jenkins-worker'], ignoreMissing: true) {
         checkout changelog: false, poll: false, scm: [$class: 'GitSCM', branches: [[name: git_branch]],
             doGenerateSubmoduleConfigurations: false, extensions: [[$class: 'CloneOption', honorRefspec: true,
             noTags: true, shallow: true]], submoduleCfg: [], userRemoteConfigs: [[credentialsId: 'jenkins-worker',
-            refspec: git_refspec, url: 'git@github.com:edx/edx-platform.git']]]
+            refspec: git_refspec, url: "git@github.com:edx/${REPO_NAME}.git"]]]
         console_output = sh(returnStdout: true, script: 'bash scripts/all-tests.sh').trim()
         dir('stdout') {
             writeFile file: "${TEST_SUITE}-${SHARD}-stdout.log", text: console_output
@@ -43,10 +43,13 @@ pipeline {
                     build job: 'github-build-status',
                         parameters: [
                             string(name: 'GIT_SHA', value: commit_sha),
-                            string(name: 'GITHUB_ORG', value: 'edx'), string(name: 'GITHUB_REPO', value: 'edx-platform'),
+                            string(name: 'GITHUB_ORG', value: 'edx'),
+                            string(name: 'GITHUB_REPO', value: "${REPO_NAME}"),
                             string(name: 'TARGET_URL', value: "${BUILD_URL}"),
-                            string(name: 'DESCRIPTION', value: 'Pending'), string(name: 'CONTEXT', value: 'jenkins/bokchoy'),
-                            string(name: 'CREATE_DEPLOYMENT', value: 'false'), string(name: 'BUILD_STATUS', value: 'pending')
+                            string(name: 'DESCRIPTION', value: 'Pending'),
+                            string(name: 'CONTEXT', value: 'jenkins/bokchoy'),
+                            string(name: 'CREATE_DEPLOYMENT', value: 'false'),
+                            string(name: 'BUILD_STATUS', value: 'pending')
                         ],
                         propagate: false, wait: false
                 }
@@ -100,10 +103,13 @@ pipeline {
                     build job: 'github-build-status',
                         parameters: [
                             string(name: 'GIT_SHA', value: commit_sha),
-                            string(name: 'GITHUB_ORG', value: 'edx'), string(name: 'GITHUB_REPO', value: 'edx-platform'),
+                            string(name: 'GITHUB_ORG', value: 'edx'),
+                            string(name: 'GITHUB_REPO', value: "${REPO_NAME}"),
                             string(name: 'TARGET_URL', value: "${BUILD_URL}"),
-                            string(name: 'DESCRIPTION', value: build_description), string(name: 'CONTEXT', value: 'jenkins/bokchoy'),
-                            string(name: 'CREATE_DEPLOYMENT', value: create_deployment), string(name: 'BUILD_STATUS', value: build_status)
+                            string(name: 'DESCRIPTION', value: build_description),
+                            string(name: 'CONTEXT', value: 'jenkins/bokchoy'),
+                            string(name: 'CREATE_DEPLOYMENT', value: create_deployment),
+                            string(name: 'BUILD_STATUS', value: build_status)
                         ],
                         propagate: false, wait: false
 

--- a/scripts/Jenkinsfiles/lettuce
+++ b/scripts/Jenkinsfiles/lettuce
@@ -4,14 +4,14 @@ def runLettuceTests() {
         git_branch = "${ghprbActualCommit}"
         git_refspec = "+refs/pull/${ghprbPullId}/*:refs/remotes/origin/pr/${ghprbPullId}/*"
     } else {
-        git_branch = 'master'
-        git_refspec = "+refs/heads/master:refs/remotes/origin/master"
+        git_branch = "${BRANCH_NAME}"
+        git_refspec = "+refs/heads/${BRANCH_NAME}:refs/remotes/origin/${BRANCH_NAME}"
     }
     sshagent(credentials: ['jenkins-worker', 'jenkins-worker-pem'], ignoreMissing: true) {
         checkout changelog: false, poll: false, scm: [$class: 'GitSCM', branches: [[name: git_branch]],
             doGenerateSubmoduleConfigurations: false, extensions: [[$class: 'CloneOption', honorRefspec: true,
             noTags: true, shallow: true]], submoduleCfg: [], userRemoteConfigs: [[credentialsId: 'jenkins-worker',
-            refspec: git_refspec, url: 'git@github.com:edx/edx-platform.git']]]
+            refspec: git_refspec, url: "git@github.com:edx/${REPO_NAME}.git"]]]
         console_output = sh(returnStdout: true, script: 'bash scripts/all-tests.sh').trim()
         dir('stdout') {
             writeFile file: "${TEST_SUITE}-stdout.log", text: console_output
@@ -42,10 +42,13 @@ pipeline {
                     build job: 'github-build-status',
                         parameters: [
                             string(name: 'GIT_SHA', value: commit_sha),
-                            string(name: 'GITHUB_ORG', value: 'edx'), string(name: 'GITHUB_REPO', value: 'edx-platform'),
+                            string(name: 'GITHUB_ORG', value: 'edx'),
+                            string(name: 'GITHUB_REPO', value: "${REPO_NAME}"),
                             string(name: 'TARGET_URL', value: "${BUILD_URL}"),
-                            string(name: 'DESCRIPTION', value: 'Pending'), string(name: 'CONTEXT', value: 'jenkins/lettuce'),
-                            string(name: 'CREATE_DEPLOYMENT', value: 'false'), string(name: 'BUILD_STATUS', value: 'pending')
+                            string(name: 'DESCRIPTION', value: 'Pending'),
+                            string(name: 'CONTEXT', value: 'jenkins/lettuce'),
+                            string(name: 'CREATE_DEPLOYMENT', value: 'false'),
+                            string(name: 'BUILD_STATUS', value: 'pending')
                         ],
                         propagate: false, wait: false
                 }
@@ -115,10 +118,13 @@ pipeline {
                     build job: 'github-build-status',
                         parameters: [
                             string(name: 'GIT_SHA', value: commit_sha),
-                            string(name: 'GITHUB_ORG', value: 'edx'), string(name: 'GITHUB_REPO', value: 'edx-platform'),
+                            string(name: 'GITHUB_ORG', value: 'edx'),
+                            string(name: 'GITHUB_REPO', value: "${REPO_NAME}"),
                             string(name: 'TARGET_URL', value: "${BUILD_URL}"),
-                            string(name: 'DESCRIPTION', value: build_description), string(name: 'CONTEXT', value: 'jenkins/lettuce'),
-                            string(name: 'CREATE_DEPLOYMENT', value: create_deployment), string(name: 'BUILD_STATUS', value: build_status)
+                            string(name: 'DESCRIPTION', value: build_description),
+                            string(name: 'CONTEXT', value: 'jenkins/lettuce'),
+                            string(name: 'CREATE_DEPLOYMENT', value: create_deployment),
+                            string(name: 'BUILD_STATUS', value: build_status)
                         ],
                         propagate: false, wait: false
 

--- a/scripts/Jenkinsfiles/python
+++ b/scripts/Jenkinsfiles/python
@@ -4,14 +4,14 @@ def runPythonTests() {
         git_branch = "${ghprbActualCommit}"
         git_refspec = "+refs/pull/${ghprbPullId}/*:refs/remotes/origin/pr/${ghprbPullId}/*"
     } else {
-        git_branch = 'master'
-        git_refspec = "+refs/heads/master:refs/remotes/origin/master"
+        git_branch = "${BRANCH_NAME}"
+        git_refspec = "+refs/heads/${BRANCH_NAME}:refs/remotes/origin/${BRANCH_NAME}"
     }
     sshagent(credentials: ['jenkins-worker', 'jenkins-worker-pem'], ignoreMissing: true) {
         checkout changelog: false, poll: false, scm: [$class: 'GitSCM', branches: [[name: git_branch]],
             doGenerateSubmoduleConfigurations: false, extensions: [[$class: 'CloneOption', honorRefspec: true,
             noTags: true, shallow: true]], submoduleCfg: [], userRemoteConfigs: [[credentialsId: 'jenkins-worker',
-            refspec: git_refspec, url: 'git@github.com:edx/edx-platform.git']]]
+            refspec: git_refspec, url: "git@github.com:edx/${REPO_NAME}.git"]]]
         console_output = sh(returnStdout: true, script: 'bash scripts/all-tests.sh').trim()
         dir('stdout') {
             writeFile file: "${TEST_SUITE}-stdout.log", text: console_output
@@ -51,10 +51,13 @@ pipeline {
                     build job: 'github-build-status',
                         parameters: [
                             string(name: 'GIT_SHA', value: commit_sha),
-                            string(name: 'GITHUB_ORG', value: 'edx'), string(name: 'GITHUB_REPO', value: 'edx-platform'),
+                            string(name: 'GITHUB_ORG', value: 'edx'),
+                            string(name: 'GITHUB_REPO', value: "${REPO_NAME}"),
                             string(name: 'TARGET_URL', value: "${BUILD_URL}"),
-                            string(name: 'DESCRIPTION', value: 'Pending'), string(name: 'CONTEXT', value: 'jenkins/python'),
-                            string(name: 'CREATE_DEPLOYMENT', value: 'false'), string(name: 'BUILD_STATUS', value: 'pending')
+                            string(name: 'DESCRIPTION', value: 'Pending'),
+                            tring(name: 'CONTEXT', value: 'jenkins/python'),
+                            string(name: 'CREATE_DEPLOYMENT', value: 'false'),
+                            string(name: 'BUILD_STATUS', value: 'pending')
                         ],
                         propagate: false, wait: false
                 }
@@ -137,17 +140,17 @@ pipeline {
                         ci_branch = "${ghprbSourceBranch}"
                         target_branch = "origin/${ghprbTargetBranch}"
                     } else {
-                        git_branch = 'master'
-                        git_refspec = "+refs/heads/master:refs/remotes/origin/master"
-                        ci_branch = "master"
-                        target_branch =  "origin/master"
+                        git_branch = "${BRANCH_NAME}"
+                        git_refspec = "+refs/heads/${BRANCH_NAME}:refs/remotes/origin/${BRANCH_NAME}"
+                        ci_branch = "${BRANCH_NAME}"
+                        target_branch =  "origin/${BRANCH_NAME}"
                     }
                     sshagent(credentials: ['jenkins-worker'], ignoreMissing: true) {
                         checkout changelog: false, poll: false, scm: [$class: 'GitSCM', branches: [[name: git_branch]],
                             doGenerateSubmoduleConfigurations: false, extensions: [[$class: 'CloneOption',
                             honorRefspec: true, noTags: true, shallow: true]], submoduleCfg: [],
                             userRemoteConfigs: [[credentialsId: 'jenkins-worker',
-                            refspec: git_refspec, url: 'git@github.com:edx/edx-platform.git']]]
+                            refspec: git_refspec, url: "git@github.com:edx/${REPO_NAME}.git"]]]
                         unstash 'lms-unit-reports'
                         unstash 'cms-unit-reports'
                         unstash 'commonlib-unit-reports'
@@ -197,10 +200,13 @@ pipeline {
                     build job: 'github-build-status',
                         parameters: [
                             string(name: 'GIT_SHA', value: commit_sha),
-                            string(name: 'GITHUB_ORG', value: 'edx'), string(name: 'GITHUB_REPO', value: 'edx-platform'),
+                            string(name: 'GITHUB_ORG', value: 'edx'),
+                            string(name: 'GITHUB_REPO', value: "${REPO_NAME}"),
                             string(name: 'TARGET_URL', value: "${BUILD_URL}"),
-                            string(name: 'DESCRIPTION', value: build_description), string(name: 'CONTEXT', value: 'jenkins/python'),
-                            string(name: 'CREATE_DEPLOYMENT', value: create_deployment), string(name: 'BUILD_STATUS', value: build_status)
+                            string(name: 'DESCRIPTION', value: build_description),
+                            string(name: 'CONTEXT', value: 'jenkins/python'),
+                            string(name: 'CREATE_DEPLOYMENT', value: create_deployment),
+                            string(name: 'BUILD_STATUS', value: build_status)
                         ],
                         propagate: false, wait: false
 

--- a/scripts/Jenkinsfiles/quality
+++ b/scripts/Jenkinsfiles/quality
@@ -9,21 +9,28 @@ def runQualityTests() {
             if (SHARD == "4") {
                 git_shallow_clone = false
                 git_extensions.add([$class: 'WipeWorkspace'])
-                refspec = refspec + " +refs/heads/master:refs/remotes/origin/master"
+                refspec = refspec + " +refs/heads/${TARGET_BRANCH}:refs/remotes/origin/${TARGET_BRANCH}"
             }
         } else {
-            git_branch = 'master'
-            refspec = "+refs/heads/master:refs/remotes/origin/master"
+            git_branch = "${BRANCH_NAME}"
+            refspec = "+refs/heads/${BRANCH_NAME}:refs/remotes/origin/${BRANCH_NAME}"
         }
         git_extensions.add([$class: 'CloneOption', honorRefspec: true, noTags: true, shallow: git_shallow_clone ])
 
         checkout changelog: false, poll: false, scm: [$class: 'GitSCM', branches: [[name: git_branch]],
             doGenerateSubmoduleConfigurations: false, extensions: git_extensions, submoduleCfg: [], userRemoteConfigs: [[credentialsId: 'jenkins-worker',
-            refspec: refspec,
-            url: 'git@github.com:edx/edx-platform.git']]]
+            refspec: refspec, url: "git@github.com:edx/${REPO_NAME}.git"]]]
 
         sh "bash scripts/all-tests.sh"
         stash includes: '**/reports/**/*', name: "${TEST_SUITE}-${SHARD}-reports"
+    }
+}
+
+def getTargetBranch(job_name) {
+    if (env.ghprbTargetBranch) {
+        return env.ghprbTargetBranch
+    } else {
+        return "${BRANCH_NAME}"
     }
 }
 
@@ -50,10 +57,13 @@ pipeline {
                     build job: 'github-build-status',
                         parameters: [
                             string(name: 'GIT_SHA', value: commit_sha),
-                            string(name: 'GITHUB_ORG', value: 'edx'), string(name: 'GITHUB_REPO', value: 'edx-platform'),
+                            string(name: 'GITHUB_ORG', value: 'edx'),
+                            string(name: 'GITHUB_REPO', value: "${REPO_NAME}"),
                             string(name: 'TARGET_URL', value: "${BUILD_URL}"),
-                            string(name: 'DESCRIPTION', value: 'Pending'), string(name: 'CONTEXT', value: 'jenkins/quality'),
-                            string(name: 'CREATE_DEPLOYMENT', value: 'false'), string(name: 'BUILD_STATUS', value: 'pending')
+                            string(name: 'DESCRIPTION', value: 'Pending'),
+                            string(name: 'CONTEXT', value: 'jenkins/quality'),
+                            string(name: 'CREATE_DEPLOYMENT', value: 'false'),
+                            string(name: 'BUILD_STATUS', value: 'pending')
                         ],
                         propagate: false, wait: false
                 }
@@ -123,6 +133,7 @@ pipeline {
                     environment {
                         TEST_SUITE = "quality"
                         SHARD = 4
+                        TARGET_BRANCH = getTargetBranch("${JOB_NAME}")
                     }
                     steps {
                         script {
@@ -154,7 +165,7 @@ pipeline {
                         honorRefspec: true, noTags: true, shallow: false], [$class: 'WipeWorkspace']], submoduleCfg: [],
                         userRemoteConfigs: [[credentialsId: 'jenkins-worker',
                         refspec: "+refs/heads/${ghprbTargetBranch}:refs/remotes/origin/${ghprbTargetBranch} +refs/pull/${ghprbPullId}/*:refs/remotes/origin/pr/${ghprbPullId}/*",
-                        url: 'git@github.com:edx/edx-platform.git']]]
+                        url: "git@github.com:edx/${REPO_NAME}.git"]]]
                     unstash 'quality-1-reports'
                     unstash 'quality-2-reports'
                     unstash 'quality-3-reports'
@@ -209,10 +220,13 @@ pipeline {
                         commit_sha = sh(returnStdout: true, script: 'git rev-parse HEAD').trim()
                         build job: 'github-build-status', parameters: [
                                 string(name: 'GIT_SHA', value: commit_sha),
-                                string(name: 'GITHUB_ORG', value: 'edx'), string(name: 'GITHUB_REPO', value: 'edx-platform'),
+                                string(name: 'GITHUB_ORG', value: 'edx'),
+                                string(name: 'GITHUB_REPO', value: "${REPO_NAME}"),
                                 string(name: 'TARGET_URL', value: "${BUILD_URL}"),
-                                string(name: 'DESCRIPTION', value: build_description), string(name: 'CONTEXT', value: 'jenkins/quality'),
-                                string(name: 'CREATE_DEPLOYMENT', value: create_deployment), string(name: 'BUILD_STATUS', value: build_status)
+                                string(name: 'DESCRIPTION', value: build_description),
+                                string(name: 'CONTEXT', value: 'jenkins/quality'),
+                                string(name: 'CREATE_DEPLOYMENT', value: create_deployment),
+                                string(name: 'BUILD_STATUS', value: build_status)
                             ],
                             propagate: false, wait: false
 


### PR DESCRIPTION
Allows private jobs to use the same Jenkinsfile by relying on a few environment variables in the DSL: `REPO_NAME` and `BRANCH_NAME`. Also fixes some parameter formatting when calling `github-build-status`.

Look at the latest commit here to see builds run on private jobs: https://github.com/edx/edx-platform-private/pull/150