### PR TITLE
BB-732 Fix Django admin form for Course Enrollment

### DIFF
--- a/common/djangoapps/student/admin.py
+++ b/common/djangoapps/student/admin.py
@@ -159,7 +159,6 @@ class LinkedInAddToProfileConfigurationAdmin(admin.ModelAdmin):
 
 
 class CourseEnrollmentForm(forms.ModelForm):
-
     def __init__(self, *args, **kwargs):
         # If args is a QueryDict, then the ModelForm addition request came in as a POST with a course ID string.
         # Change the course ID string to a CourseLocator object by copying the QueryDict to make it mutable.
@@ -194,6 +193,15 @@ class CourseEnrollmentForm(forms.ModelForm):
 
         return course_key
 
+    def save(self, *args, **kwargs):
+        course_enrollment = super(CourseEnrollmentForm, self).save(commit=False)
+        user = self.cleaned_data['user']
+        course_overview = self.cleaned_data['course']
+        enrollment = CourseEnrollment.get_or_create_enrollment(user, course_overview.id)
+        course_enrollment.id = enrollment.id
+        course_enrollment.created = enrollment.created
+        return course_enrollment
+
     class Meta:
         model = CourseEnrollment
         fields = '__all__'
@@ -204,7 +212,7 @@ class CourseEnrollmentAdmin(admin.ModelAdmin):
     """ Admin interface for the CourseEnrollment model. """
     list_display = ('id', 'course_id', 'mode', 'user', 'is_active',)
     list_filter = ('mode', 'is_active',)
-    raw_id_fields = ('user',)
+    raw_id_fields = ('user', 'course')
     search_fields = ('course__id', 'mode', 'user__username',)
     form = CourseEnrollmentForm
 

--- a/common/djangoapps/student/tests/test_admin_views.py
+++ b/common/djangoapps/student/tests/test_admin_views.py
@@ -13,13 +13,15 @@ from django.contrib.auth.models import User
 from django.forms import ValidationError
 from django.test import TestCase, override_settings
 from django.urls import reverse
+from django.utils.timezone import now
 from mock import Mock
 
-from student.admin import COURSE_ENROLLMENT_ADMIN_SWITCH, UserAdmin
-from student.models import LoginFailures
+from student.admin import COURSE_ENROLLMENT_ADMIN_SWITCH, UserAdmin, CourseEnrollmentForm
+from student.models import CourseEnrollment, LoginFailures
 from student.tests.factories import CourseEnrollmentFactory, UserFactory
 from xmodule.modulestore.tests.django_utils import SharedModuleStoreTestCase
 from xmodule.modulestore.tests.factories import CourseFactory
+from openedx.core.djangoapps.content.course_overviews.tests.factories import CourseOverviewFactory
 
 
 class AdminCourseRolesPageTest(SharedModuleStoreTestCase):
@@ -370,3 +372,53 @@ class LoginFailuresAdminTest(TestCase):
         )
         count = LoginFailures.objects.count()
         self.assertEqual(count, start_count - 1)
+
+
+class CourseEnrollmentAdminFormTest(SharedModuleStoreTestCase):
+    """
+    Unit test for CourseEnrollment admin ModelForm.
+    """
+    @classmethod
+    def setUpClass(cls):
+        super(CourseEnrollmentAdminFormTest, cls).setUpClass()
+        cls.course = CourseOverviewFactory(start=now())
+
+    def setUp(self):
+        super(CourseEnrollmentAdminFormTest, self).setUp()
+        self.user = UserFactory.create()
+
+    def test_admin_model_form_create(self):
+        """
+        Test CourseEnrollmentAdminForm creation.
+        """
+        self.assertEqual(CourseEnrollment.objects.count(), 0)
+
+        form = CourseEnrollmentForm({
+            'user': self.user.id,
+            'course': six.text_type(self.course.id),
+            'is_active': True,
+            'mode': 'audit',
+        })
+        self.assertTrue(form.is_valid())
+        enrollment = form.save()
+        self.assertEqual(CourseEnrollment.objects.count(), 1)
+        self.assertEqual(CourseEnrollment.objects.first(), enrollment)
+
+    def test_admin_model_form_update(self):
+        """
+        Test CourseEnrollmentAdminForm update.
+        """
+        enrollment = CourseEnrollment.get_or_create_enrollment(self.user, self.course.id)
+        count = CourseEnrollment.objects.count()
+        form = CourseEnrollmentForm({
+            'user': self.user.id,
+            'course': six.text_type(self.course.id),
+            'is_active': False,
+            'mode': 'audit'},
+            instance=enrollment
+        )
+        self.assertTrue(form.is_valid())
+        course_enrollment = form.save()
+        self.assertEqual(count, CourseEnrollment.objects.count())
+        self.assertFalse(course_enrollment.is_active)
+        self.assertEqual(enrollment.id, course_enrollment.id)


### PR DESCRIPTION
Course enrollment admin is disabled by default in hawthorn, it can be enabled using a [waffle switich (`student.courseenrollment_admin`)](https://github.com/edx/edx-platform/blob/b034f4e0d42259af2e98758d792f436de9b8e1eb/common/djangoapps/student/admin.py#L39). When course enrollment admin is enabled the form doesn't work as expected because in hawthorn there's a [custom admin form](https://github.com/edx/edx-platform/blob/open-release/hawthorn.master/common/djangoapps/student/admin.py#L147). This custom admin form breaks when trying to save a course enrollment because the correct way to create a course enrollment is using [`CourseEnrollment.get_or_create_enrollment`](https://github.com/edx/edx-platform/blob/open-release/hawthorn.master/common/djangoapps/student/models.py#L1258). The admin form also breaks when updating a Course Enrollment since this is done via a POST and at this point the form's `data` is a POST `QueryDict` which is unmutable unless `_mutale=True`.

- This PR overrides `save()` on the admin form to use the correct method to create a course enrollment using the Django admin UI.
- Set `data._mutable = True` if possible so we can correctly parse the course id string.
- I took the liberty to set `course` as a raw id that way there won't be a dropdown of 100s of course ids in the form and instead there's a nice lookup popup.

**JIRA tickets**:  Ticket where custom admin form was introduced: https://openedx.atlassian.net/browse/LEARNER-3672

**Discussions**: Custom admin form [PR](https://github.com/edx/edx-platform/pull/17254)

**Sandbox URL**: http://147.135.195.136

**Merge deadline**: "None" 

**Testing instructions**:

1. Go to sandbox VM: 147.135.195.136
    1.a For Devstack
        1.a.1 Run local devstack.
        1.a.2 Create a waffle switch with the name `student.courseenrollmen_admin` by running this command" `./manage.py lms waffle_switch student.courseenrollment_admin on --create`.
2. Go to `/admin/student/courseenrollment/`.
3. Create a new course enrollment.

**Author notes and concerns**:

1. CourseEnrollment was hidden from the admin UI, probably, because it was listing every course in the instance to populate the dropdown. This PR fixes that and it's probably safe to hide CourseEnrollment since it's a nice feature to be able to manage course enrollments from the admin UI.
2. Setting `data._mutable = True` and everything done in the admin form `__init__` should be safe to delete once `edx-platform` moves to use `edx:opaque-keys` > 0.4.4 where [this commit](https://github.com/edx/opaque-keys/commit/5b5119979a7d5f186350a92b4b5748c3d4bcc92f) will be released.

**Reviewers**
- [x] @Agrendalath (Piotr)
- [ ] edX reviewer[s] TBD