### PR TITLE
ENT-1286 bump enterprise version to 1.2.3

### DIFF
--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -117,7 +117,7 @@ edx-django-release-util==0.3.1
 edx-django-sites-extensions==2.3.1
 edx-django-utils==1.0.3
 edx-drf-extensions==2.0.1
-edx-enterprise==1.2.2
+edx-enterprise==1.2.3
 edx-i18n-tools==0.4.6
 edx-milestones==0.1.13
 edx-oauth2-provider==1.2.2

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -135,7 +135,7 @@ edx-django-release-util==0.3.1
 edx-django-sites-extensions==2.3.1
 edx-django-utils==1.0.3
 edx-drf-extensions==2.0.1
-edx-enterprise==1.2.2
+edx-enterprise==1.2.3
 edx-i18n-tools==0.4.6
 edx-lint==1.0.0
 edx-milestones==0.1.13

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -130,7 +130,7 @@ edx-django-release-util==0.3.1
 edx-django-sites-extensions==2.3.1
 edx-django-utils==1.0.3
 edx-drf-extensions==2.0.1
-edx-enterprise==1.2.2
+edx-enterprise==1.2.3
 edx-i18n-tools==0.4.6
 edx-lint==1.0.0
 edx-milestones==0.1.13


### PR DESCRIPTION
**Description:** Add managemenet command `"unlink_inactive_sap_learners"` to unlink inactive SAP learners from the related enterprises.

**Related Enterprise PR:** https://github.com/edx/edx-enterprise/pull/380/

**edx-enterprise changes:** https://github.com/edx/edx-enterprise/compare/1.2.2...1.2.3