### PR TITLE
fix proctoring messages color contrast ratio

### DIFF
--- a/lms/static/sass/course/courseware/_courseware.scss
+++ b/lms/static/sass/course/courseware/_courseware.scss
@@ -182,7 +182,7 @@ html.video-fullscreen {
       }
 
       p {
-        color: #797676;
+        color: #666666;
 
         strong {
           font-weight: 600;


### PR DESCRIPTION
### [EDUCATOR-3898](https://openedx.atlassian.net/browse/EDUCATOR-3898)

### Description
Proctoring related messages with normal text size color contrast ratio is imbalanced, with text being **too light** in comparison to tinted background. This violates the WCAG AA level(4:5:1). This PR addresses that by changing the text color to cope with the required ratio. Various proctoring text outputs have been verified after the fix using **Color Contrast Analyzer**.

### Before Fix
![pr_bef-1](https://user-images.githubusercontent.com/40599381/51178794-86d20900-18e5-11e9-92c0-de409ce19ac6.png)
![pr-bef-2](https://user-images.githubusercontent.com/40599381/51178795-876a9f80-18e5-11e9-8cfe-f92758ecee3c.png)
![pr-bef-3](https://user-images.githubusercontent.com/40599381/51178796-876a9f80-18e5-11e9-8045-5cb5001c5bc1.png)


### After Fix
![pr-after-1](https://user-images.githubusercontent.com/40599381/51178815-92bdcb00-18e5-11e9-94a7-c26c02a09c5e.png)
![pr-after-2](https://user-images.githubusercontent.com/40599381/51178816-92bdcb00-18e5-11e9-8b88-7d36bd4475f8.png)
![pr-after-3](https://user-images.githubusercontent.com/40599381/51178817-93566180-18e5-11e9-842a-8161523b584e.png)


### Reviewers
 - [x] @wittjeff 
 - [ ] @noraiz-anwar 
 - [x] @matthugs 

### Post Review
 - [x] Squash & Rebase Commits