### PR TITLE
Hide the re-index button for non-global staff

### DIFF
--- a/cms/djangoapps/contentstore/views/course.py
+++ b/cms/djangoapps/contentstore/views/course.py
@@ -627,7 +627,8 @@ def course_index(request, course_key):
         lms_link = get_lms_link_for_item(course_module.location)
         reindex_link = None
         if settings.FEATURES.get('ENABLE_COURSEWARE_INDEX', False):
-            reindex_link = "/course/{course_id}/search_reindex".format(course_id=six.text_type(course_key))
+            if GlobalStaff().has_user(request.user):
+                reindex_link = "/course/{course_id}/search_reindex".format(course_id=six.text_type(course_key))
         sections = course_module.get_children()
         course_structure = _course_outline_json(request, course_module)
         locator_to_show = request.GET.get('show', None)


### PR DESCRIPTION
# Overview
A customer reported that the "Reindex" course shows up but when clicking it, a 403 Forbidden error shows up.

## How to Reproduce

 - Create register a new normal user.
 - Add that user as a course staff while setting `user.is_staff` to `False`
 - Click on the "Reindex" button
 
**Expected:** To index the course, or at least the button wouldn't show up.
**Actual:** The button shows up but clicking on it gives a 403 forbidden error.

# Solution
Hide the button for non-global staff. Course Reindex is being done anyway on save or publish.

~This pull request allows course staff to reindex the course.~

## ~Why not Hiding the Button?~
~Because re-indexing the course looks safe enough to trust course staff to do it, it accepts a course key and can't do anything other than re-indexing. Besides, there's not much of global staff in multi-tenant environments.~