### PR TITLE
EDUCATOR-3914 fix enroll now text contrast ratio on LMS

### DIFF
--- a/lms/static/sass/bootstrap/_components.scss
+++ b/lms/static/sass/bootstrap/_components.scss
@@ -17,8 +17,13 @@
 
     li {
       margin: 5px 0;
+
+      .alert.alert-warning .message-content .enroll-btn.btn-link {
+        color: #004368;
+      }
+
     }
-  }
+  } 
 
 }
 


### PR DESCRIPTION
[EDUCATOR-3914](https://openedx.atlassian.net/browse/EDUCATOR-3914)

**Description**
The `Enroll Now` text has a luminance contrast ratio of 4.44:1, where the WCAG 2.0 AA minimum for text this size is 4.5:1. This PR fixes this issue by changing the text color to cope with the required ratio.
 
**Before Fix:** (using Color Contrast Analyzer)
<img width="1232" alt="before-fix" src="https://user-images.githubusercontent.com/13939335/51254578-2fa26600-19c3-11e9-908a-057d3e79fea1.png">

**After Fix:** (using Color Contrast Analyzer)
<img width="1235" alt="after-fix" src="https://user-images.githubusercontent.com/13939335/51254634-4a74da80-19c3-11e9-9d18-338bd2b142b9.png">

