### PR TITLE
Configuration changes to translation of third party lib

### DIFF
--- a/.tx/config
+++ b/.tx/config
@@ -54,3 +54,9 @@ file_filter = conf/locale/<lang>/LC_MESSAGES/wiki.po
 source_file = conf/locale/en/LC_MESSAGES/wiki.po
 source_lang = en
 type = PO
+
+[edx-platform.edx_proctoring_proctortrack]
+file_filter = conf/locale/<lang>/LC_MESSAGES/edx_proctoring_proctortrack.po
+source_file = conf/locale/en/LC_MESSAGES/edx_proctoring_proctortrack.po
+source_lang = en
+type = PO

--- a/conf/locale/config.yaml
+++ b/conf/locale/config.yaml
@@ -172,6 +172,7 @@ generate_merge:
         - mako.po
         - mako-studio.po
         - wiki.po
+        - edx_proctoring_proctortrack.po
     djangojs.po:
         - djangojs-partial.po
         - djangojs-studio.po


### PR DESCRIPTION
[EDUCATOR-3913](https://openedx.atlassian.net/browse/EDUCATOR-3913)

These configuration changes ensure that the proctortrack specific i18n messages are merged into the larger po files pushed + pulled to transifex.