### PR TITLE
Fix explicit tuple parameters for Python 3

### DIFF
--- a/cms/djangoapps/contentstore/views/videos.py
+++ b/cms/djangoapps/contentstore/views/videos.py
@@ -580,7 +580,7 @@ def get_all_transcript_languages():
     all_languages_dict = dict(settings.ALL_LANGUAGES, **third_party_transcription_languages)
     # Return combined system settings and 3rd party transcript languages.
     all_languages = []
-    for key, value in sorted(all_languages_dict.iteritems(), key=lambda (k, v): v):
+    for key, value in sorted(all_languages_dict.iteritems(), key=lambda k_v: k_v[1]):
         all_languages.append({
             'language_code': key,
             'language_text': value

--- a/common/djangoapps/util/tests/test_date_utils.py
+++ b/common/djangoapps/util/tests/test_date_utils.py
@@ -128,7 +128,8 @@ class StrftimeLocalizedTest(unittest.TestCase):
         ("%I:%M:%S %p", "04:41:17 PM"),
         ("%A at %-I%P", "Thursday at 4pm"),
     )
-    def test_usual_strftime_behavior(self, (fmt, expected)):
+    def test_usual_strftime_behavior(self, fmt_expected):
+        (fmt, expected) = fmt_expected
         dtime = datetime(2013, 02, 14, 16, 41, 17)
         self.assertEqual(expected, strftime_localized(dtime, fmt))
         # strftime doesn't like Unicode, so do the work in UTF8.
@@ -141,7 +142,8 @@ class StrftimeLocalizedTest(unittest.TestCase):
         ("DAY_AND_TIME", "Thursday at 4pm"),
         ("%x %X!", "Feb 14, 2013 04:41:17 PM!"),
     )
-    def test_shortcuts(self, (fmt, expected)):
+    def test_shortcuts(self, fmt_expected):
+        (fmt, expected) = fmt_expected
         dtime = datetime(2013, 02, 14, 16, 41, 17)
         self.assertEqual(expected, strftime_localized(dtime, fmt))
 
@@ -159,7 +161,8 @@ class StrftimeLocalizedTest(unittest.TestCase):
         ("TIME", "04:41:17 XXpmXX"),
         ("%x %X!", "XXfebXX 14, 2013 04:41:17 XXpmXX!"),
     )
-    def test_translated_words(self, (fmt, expected)):
+    def test_translated_words(self, fmt_expected):
+        (fmt, expected) = fmt_expected
         dtime = datetime(2013, 02, 14, 16, 41, 17)
         self.assertEqual(expected, strftime_localized(dtime, fmt))
 
@@ -178,7 +181,8 @@ class StrftimeLocalizedTest(unittest.TestCase):
         ("The time is: %X", "The time is: 16h.41m.17s"),
         ("%x %X", "date(2013.02.14) 16h.41m.17s"),
     )
-    def test_translated_formats(self, (fmt, expected)):
+    def test_translated_formats(self, fmt_expected):
+        (fmt, expected) = fmt_expected
         dtime = datetime(2013, 02, 14, 16, 41, 17)
         self.assertEqual(expected, strftime_localized(dtime, fmt))
 
@@ -190,7 +194,8 @@ class StrftimeLocalizedTest(unittest.TestCase):
         ("SHORT_DATE", "Feb 14, 2013"),
         ("TIME", "04:41:17 PM"),
     )
-    def test_recursion_protection(self, (fmt, expected)):
+    def test_recursion_protection(self, fmt_expected):
+        (fmt, expected) = fmt_expected
         dtime = datetime(2013, 02, 14, 16, 41, 17)
         self.assertEqual(expected, strftime_localized(dtime, fmt))
 

--- a/common/test/acceptance/pages/studio/container.py
+++ b/common/test/acceptance/pages/studio/container.py
@@ -691,7 +691,7 @@ class XBlockWrapper(PageObject):
         return self.q(css=self._bounded_selector('span.message-text a')).first.text[0]
 
 
-def _click_edit(page_object, button_css, view_css, bounded_selector=lambda(x): x):
+def _click_edit(page_object, button_css, view_css, bounded_selector=lambda x: x):
     """
     Click on the first editing button found and wait for the Studio editor to be present.
     """

--- a/common/test/acceptance/tests/studio/test_studio_container.py
+++ b/common/test/acceptance/tests/studio/test_studio_container.py
@@ -80,7 +80,7 @@ class AddComponentTest(NestedVerticalTest):
 
     def add_and_verify(self, menu_index, expected_ordering):
         self.do_action_and_verify(
-            lambda (container): add_discussion(container, menu_index),
+            lambda container: add_discussion(container, menu_index),
             expected_ordering
         )
 
@@ -120,7 +120,7 @@ class DuplicateComponentTest(NestedVerticalTest):
 
     def duplicate_and_verify(self, source_index, expected_ordering):
         self.do_action_and_verify(
-            lambda (container): container.duplicate(source_index),
+            lambda container: container.duplicate(source_index),
             expected_ordering
         )
 
@@ -166,7 +166,7 @@ class DeleteComponentTest(NestedVerticalTest):
 
     def delete_and_verify(self, source_index, expected_ordering):
         self.do_action_and_verify(
-            lambda (container): container.delete(source_index),
+            lambda container: container.delete(source_index),
             expected_ordering
         )
 

--- a/common/test/acceptance/tests/studio/test_studio_outline.py
+++ b/common/test/acceptance/tests/studio/test_studio_outline.py
@@ -112,7 +112,7 @@ class CourseOutlineDragAndDropTest(CourseOutlineTest):
     def drag_and_verify(self, source, target, expected_ordering, outline_page=None):
         self.do_action_and_verify(
             outline_page,
-            lambda (outline): drag(outline, source, target),
+            lambda outline: drag(outline, source, target),
             expected_ordering
         )
 

--- a/lms/djangoapps/instructor_analytics/csvs.py
+++ b/lms/djangoapps/instructor_analytics/csvs.py
@@ -74,7 +74,7 @@ def format_dictlist(dictlist, features):
     def dict_to_entry(dct):
         """ Convert dictionary to a list for a csv row """
         relevant_items = [(k, v) for (k, v) in dct.items() if k in features]
-        ordered = sorted(relevant_items, key=lambda (k, v): header.index(k))
+        ordered = sorted(relevant_items, key=lambda k_v: header.index(k_v[0]))
         vals = [v for (_, v) in ordered]
         return vals
 

--- a/lms/djangoapps/teams/tests/test_models.py
+++ b/lms/djangoapps/teams/tests/test_models.py
@@ -184,10 +184,11 @@ class TeamSignalsTest(EventTestMixin, SharedModuleStoreTestCase):
         )
     )
     @ddt.unpack
-    def test_signals(self, signal_name, (user, should_update)):
+    def test_signals(self, signal_name, user_should_update):
         """Test that `last_activity_at` is correctly updated when team-related
         signals are sent.
         """
+        (user, should_update) = user_should_update
         with self.assert_last_activity_updated(should_update):
             user = getattr(self, user)
             signal = self.SIGNALS[signal_name]

--- a/openedx/core/djangolib/tests/test_markup.py
+++ b/openedx/core/djangolib/tests/test_markup.py
@@ -25,7 +25,8 @@ class FormatHtmlTest(unittest.TestCase):
         (u"Stop & Shop", u"Stop &amp; Shop"),
         (u"<a>нтмℓ-єѕ¢αρє∂</a>", u"&lt;a&gt;нтмℓ-єѕ¢αρє∂&lt;/a&gt;"),
     )
-    def test_simple(self, (before, after)):
+    def test_simple(self, before_after):
+        (before, after) = before_after
         self.assertEqual(unicode(Text(_(before))), after)
         self.assertEqual(unicode(Text(before)), after)
 


### PR DESCRIPTION
$ __futurize -f lib2to3.fixes.fix_tuple_param -w .__

This PR addresses two new syntax errors introduced in Python 3:
1. Explicit tuples can not be function parameters in Python 3: __def func(a, (b, c)):__
2. Lambda parameters must have no parenthesis in Python 3: __lambda (x): x__

Related to https://openedx.atlassian.net/browse/INCR-1