### PR TITLE
WIP: Remove warnings for public courses

### DIFF
--- a/common/lib/xmodule/xmodule/x_module.py
+++ b/common/lib/xmodule/xmodule/x_module.py
@@ -72,7 +72,9 @@ STUDIO_VIEW = 'studio_view'
 # Views that present a "preview" view of an xblock (as opposed to an editing view).
 PREVIEW_VIEWS = [STUDENT_VIEW, PUBLIC_VIEW, AUTHOR_VIEW]
 
-DEFAULT_PUBLIC_VIEW_MESSAGE = u'Please enroll to view this content.'
+DEFAULT_PUBLIC_VIEW_MESSAGE = u'''
+%s is only accessible to enrolled learners. Sign in or register, and enroll in this course to view it.
+'''
 
 # Make '_' a no-op so we can scrape strings. Using lambda instead of
 #  `django.utils.translation.ugettext_noop` because Django cannot be imported in this file
@@ -766,7 +768,13 @@ class XModuleMixin(XModuleFields, XBlock):
             u'<span class="icon icon-alert fa fa fa-warning" aria-hidden="true"></span>'
             u'<div class="message-content">{}</div></div></div>'
         )
-        return Fragment(alert_html.format(DEFAULT_PUBLIC_VIEW_MESSAGE))
+
+        if self.display_name:
+            display_text = DEFAULT_PUBLIC_VIEW_MESSAGE %self.display_name
+        else:
+            display_text = DEFAULT_PUBLIC_VIEW_MESSAGE %"This content"
+
+        return Fragment(alert_html.format(display_text))
 
 
 class ProxyAttribute(object):

--- a/common/lib/xmodule/xmodule/x_module.py
+++ b/common/lib/xmodule/xmodule/x_module.py
@@ -73,7 +73,7 @@ STUDIO_VIEW = 'studio_view'
 PREVIEW_VIEWS = [STUDENT_VIEW, PUBLIC_VIEW, AUTHOR_VIEW]
 
 DEFAULT_PUBLIC_VIEW_MESSAGE = u'''
-%s is only accessible to enrolled learners. Sign in or register, and enroll in this course to view it.
+This content is only accessible to enrolled learners. Sign in or register, and enroll in this course to view it.
 '''
 
 # Make '_' a no-op so we can scrape strings. Using lambda instead of
@@ -770,9 +770,14 @@ class XModuleMixin(XModuleFields, XBlock):
         )
 
         if self.display_name:
-            display_text = DEFAULT_PUBLIC_VIEW_MESSAGE %self.display_name
+            display_text = _(
+                "{display_name} is only accessible to enrolled learners."
+                " Sign in or register, and enroll in this course to view it."
+                ).format(
+                    display_name=self.display_name
+                )
         else:
-            display_text = DEFAULT_PUBLIC_VIEW_MESSAGE %"This content"
+            display_text = _(DEFAULT_PUBLIC_VIEW_MESSAGE)
 
         return Fragment(alert_html.format(display_text))
 

--- a/lms/djangoapps/course_blocks/transformers/library_content.py
+++ b/lms/djangoapps/course_blocks/transformers/library_content.py
@@ -81,7 +81,10 @@ class ContentLibraryTransformer(FilteringTransformerMixin, BlockStructureTransfo
                 max_count = block_structure.get_xblock_field(block_key, 'max_count')
 
                 # Retrieve "selected" json from LMS MySQL database.
-                state_dict = get_student_module_as_dict(usage_info.user, usage_info.course_key, block_key)
+                if not usage_info.user.is_authenticated():
+                    state_dict = {}
+                else:
+                    state_dict = get_student_module_as_dict(usage_info.user, usage_info.course_key, block_key)
                 for selected_block in state_dict.get('selected', []):
                     # Add all selected entries for this user for this
                     # library module to the selected list.
@@ -96,7 +99,8 @@ class ContentLibraryTransformer(FilteringTransformerMixin, BlockStructureTransfo
                 selected = block_keys['selected']
 
                 # Save back any changes
-                if any(block_keys[changed] for changed in ('invalid', 'overlimit', 'added')):
+                if usage_info.user.is_authenticated() and any(block_keys[changed]
+                                                              for changed in ('invalid', 'overlimit', 'added')):
                     state_dict['selected'] = list(selected)
                     StudentModule.objects.update_or_create(
                         student=usage_info.user,

--- a/lms/djangoapps/courseware/courses.py
+++ b/lms/djangoapps/courseware/courses.py
@@ -41,7 +41,7 @@ from survey.utils import is_survey_required_and_unanswered
 from util.date_utils import strftime_localized
 from xmodule.modulestore.django import modulestore
 from xmodule.modulestore.exceptions import ItemNotFoundError
-from xmodule.x_module import STUDENT_VIEW
+from xmodule.x_module import STUDENT_VIEW, PUBLIC_VIEW
 
 log = logging.getLogger(__name__)
 
@@ -365,7 +365,10 @@ def get_course_info_section(request, user, course, section_key):
     html = ''
     if info_module is not None:
         try:
-            html = info_module.render(STUDENT_VIEW).content.strip()
+            if user.is_authenticated():
+                html = info_module.render(STUDENT_VIEW).content.strip()
+            else:
+                html = info_module.render(PUBLIC_VIEW).content.strip()
         except Exception:  # pylint: disable=broad-except
             html = render_to_string('courseware/error-message.html', None)
             log.exception(

--- a/lms/djangoapps/courseware/views/index.py
+++ b/lms/djangoapps/courseware/views/index.py
@@ -44,7 +44,7 @@ from shoppingcart.models import CourseRegistrationCode
 from student.views import is_course_blocked
 from util.views import ensure_valid_course_key
 from xmodule.modulestore.django import modulestore
-from xmodule.course_module import COURSE_VISIBILITY_PUBLIC, COURSE_VISIBILITY_PRIVATE
+from xmodule.course_module import COURSE_VISIBILITY_PUBLIC
 from xmodule.x_module import PUBLIC_VIEW, STUDENT_VIEW
 from .views import CourseTabView
 from ..access import has_access
@@ -190,7 +190,7 @@ class CoursewareIndex(View):
             })
 
             unenrolled_access_flag = COURSE_ENABLE_UNENROLLED_ACCESS_FLAG.is_enabled(self.course.id)
-            allow_anonymous = unenrolled_access_flag and self.course.course_visibility != COURSE_VISIBILITY_PRIVATE
+            allow_anonymous = unenrolled_access_flag and self.course.course_visibility == COURSE_VISIBILITY_PUBLIC
 
             if not allow_anonymous:
                 PageLevelMessages.register_warning_message(

--- a/lms/djangoapps/courseware/views/views.py
+++ b/lms/djangoapps/courseware/views/views.py
@@ -105,7 +105,7 @@ from util.cache import cache, cache_if_anonymous
 from util.db import outer_atomic
 from util.milestones_helpers import get_prerequisite_courses_display
 from util.views import _record_feedback_in_zendesk, ensure_valid_course_key, ensure_valid_usage_key
-from xmodule.course_module import COURSE_VISIBILITY_PRIVATE
+from xmodule.course_module import COURSE_VISIBILITY_PRIVATE, COURSE_VISIBILITY_PUBLIC
 from web_fragments.fragment import Fragment
 from xmodule.modulestore.django import modulestore
 from xmodule.modulestore.exceptions import ItemNotFoundError, NoPathToItem
@@ -533,7 +533,7 @@ class CourseTabView(EdxFragmentView):
         """
         unenrolled_access_flag = COURSE_ENABLE_UNENROLLED_ACCESS_FLAG.is_enabled(course_key)
         course = get_course(course_key)
-        allow_anonymous = unenrolled_access_flag and course.course_visibility != COURSE_VISIBILITY_PRIVATE
+        allow_anonymous = unenrolled_access_flag and course.course_visibility == COURSE_VISIBILITY_PUBLIC
 
         if request.user.is_anonymous and not allow_anonymous:
             PageLevelMessages.register_warning_message(

--- a/lms/templates/courseware/course_about.html
+++ b/lms/templates/courseware/course_about.html
@@ -168,6 +168,12 @@ from six import string_types
               .format(course_name=course.display_number_with_default, price=course_price)}
           </a>
           <div id="register_error"></div>
+        %elif allow_anonymous:
+          %if show_courseware_link:
+            <a href="${course_target}">
+            <strong>${_("View Course")}</strong>
+            </a>
+          %endif
         %else:
           <% 
             if ecommerce_checkout:

--- a/openedx/core/djangoapps/course_groups/tests/test_cohorts.py
+++ b/openedx/core/djangoapps/course_groups/tests/test_cohorts.py
@@ -391,6 +391,10 @@ class TestCohorts(ModuleStoreTestCase):
         Anonymous user is not assigned to any cohort group.
         """
         course = modulestore().get_course(self.toy_course_key)
+
+        # verify cohorts is None when course is not cohorted
+        self.assertIsNone(cohorts.get_cohort(AnonymousUser(), course.id))
+
         config_course_cohorts(
             course,
             is_cohorted=True,

--- a/openedx/features/course_experience/tests/views/test_course_home.py
+++ b/openedx/features/course_experience/tests/views/test_course_home.py
@@ -312,12 +312,13 @@ class TestCourseHomePageAccess(CourseHomePageTestCase):
         self.assertContains(response, TEST_CHAPTER_NAME, count=(1 if expected_course_outline else 0))
 
         # Verify that the expected message is shown to the user
-        self.assertContains(
-            response, 'To see course content', count=(1 if is_anonymous else 0)
-        )
-        self.assertContains(response, '<div class="user-messages"', count=(1 if expected_enroll_message else 0))
-        if expected_enroll_message:
-            self.assertContains(response, 'You must be enrolled in the course to see course content.')
+        if not enable_unenrolled_access or course_visibility == COURSE_VISIBILITY_PRIVATE:
+            self.assertContains(
+                response, 'To see course content', count=(1 if is_anonymous else 0)
+            )
+            self.assertContains(response, '<div class="user-messages"', count=(1 if expected_enroll_message else 0))
+            if expected_enroll_message:
+                self.assertContains(response, 'You must be enrolled in the course to see course content.')
 
     @override_waffle_flag(UNIFIED_COURSE_TAB_FLAG, active=False)
     @override_waffle_flag(SHOW_REVIEWS_TOOL_FLAG, active=True)

--- a/openedx/features/course_experience/tests/views/test_course_home.py
+++ b/openedx/features/course_experience/tests/views/test_course_home.py
@@ -312,7 +312,7 @@ class TestCourseHomePageAccess(CourseHomePageTestCase):
         self.assertContains(response, TEST_CHAPTER_NAME, count=(1 if expected_course_outline else 0))
 
         # Verify that the expected message is shown to the user
-        if not enable_unenrolled_access or course_visibility == COURSE_VISIBILITY_PRIVATE:
+        if not enable_unenrolled_access or course_visibility != COURSE_VISIBILITY_PUBLIC:
             self.assertContains(
                 response, 'To see course content', count=(1 if is_anonymous else 0)
             )

--- a/openedx/features/course_experience/views/course_home.py
+++ b/openedx/features/course_experience/views/course_home.py
@@ -159,6 +159,8 @@ class CourseHomeFragmentView(EdxFragmentView):
                 request, course_id=course_id, user_is_enrolled=False, **kwargs
             )
             course_sock_fragment = CourseSockFragmentView().render_to_fragment(request, course=course, **kwargs)
+            if allow_public:
+                handouts_html = self._get_course_handouts(request, course)
         else:
             # Redirect the user to the dashboard if they are not enrolled and
             # this is a course that does not support direct enrollment.

--- a/openedx/features/course_experience/views/course_home_messages.py
+++ b/openedx/features/course_experience/views/course_home_messages.py
@@ -27,7 +27,7 @@ from openedx.core.djangoapps.plugin_api.views import EdxFragmentView
 from openedx.core.djangolib.markup import HTML, Text
 from openedx.features.course_experience import CourseHomeMessages, COURSE_ENABLE_UNENROLLED_ACCESS_FLAG
 from student.models import CourseEnrollment
-from xmodule.course_module import COURSE_VISIBILITY_PRIVATE
+from xmodule.course_module import COURSE_VISIBILITY_PUBLIC
 
 
 class CourseHomeMessageFragmentView(EdxFragmentView):
@@ -109,7 +109,7 @@ def _register_course_home_messages(request, course, user_access, course_start_da
     Register messages to be shown in the course home content page.
     """
     unenrolled_access_flag = COURSE_ENABLE_UNENROLLED_ACCESS_FLAG.is_enabled(course.id)
-    allow_anonymous = unenrolled_access_flag and course.course_visibility != COURSE_VISIBILITY_PRIVATE
+    allow_anonymous = unenrolled_access_flag and course.course_visibility == COURSE_VISIBILITY_PUBLIC
 
     if user_access['is_anonymous'] and not allow_anonymous:
         CourseHomeMessages.register_info_message(


### PR DESCRIPTION
**Work in progress** : Do not merge. We will ping once our internal review is done.

This PR depends on #19385.

**Description:**

Currently the warnings show up for anonymous and unenrolled users irrespective of whether the course is marked public. This PR hides the different warnings and messages asking the user to sign-in and enroll in the course, when the course is marked public.
This PR also modifies the default public_view text to include the component display_name when unenrolled access is not available.

Sandbox server:

- LMS:  https://pr19624.sandbox.opencraft.hosting/

- Studio: https://studio-pr19624.sandbox.opencraft.hosting/

Contains 2 course:

- [edX Demo Course](https://pr19624.sandbox.opencraft.hosting/courses/course-v1:edX+DemoX+Demo_Course/course/) has `seo.enable_anonymous_courseware_access` course waffle flag, and the "Advanced Settings > Course Visibility For Unenrolled Learners" set to private. Anonymous and unenrolled users can see the warning messages.

- [Test Course](https://pr19624.sandbox.opencraft.hosting/courses/course-v1:test+test01+2018_T1/course/) has `seo.enable_anonymous_courseware_access` course waffle flag, and the "Advanced Settings > Course Visibility For Unenrolled Learners" set to public. Anonymous and unenrolled users should not see any of the warning messages. Unit-2 is a library content which does not have unenrolled access. The warning message should include the display_name (in this case, Randomised content block).

**Testing Instructions:**

- If testing on devstack, create a course and mark the course as public.

- Access the course as an anonymous or unenrolled user. There should not be any warning messages asking the user to sign in or register or enroll in the course.

- Add any content that does not support unenrolled access (library content for example) and access the course as an anonymous or unenrolled user. The warning message should contain the display_name if the component has one.
