### PR TITLE
Fix coverage on remote xdist nodes

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -49,6 +49,4 @@ output = reports/coverage.xml
 jenkins_source =
     /home/jenkins/workspace/$JOB_NAME
     /home/jenkins/workspace/$SUBSET_JOB
-
-devstack_source =
     /edx/app/edxapp/edx-platform

--- a/common/lib/xmodule/xmodule/partitions/tests/test_partitions.py
+++ b/common/lib/xmodule/xmodule/partitions/tests/test_partitions.py
@@ -476,12 +476,12 @@ class TestPartitionService(PartitionServiceBaseClass):
 
         # get a group assigned to the user
         group1_id = self.partition_service.get_user_group_id_for_partition(self.user, user_partition_id)
-        self.assertEqual(group1_id, groups[0].id)
+        assert group1_id == groups[0].id
 
         # switch to the second group and verify that it is returned for the user
         self.user_partition.scheme.current_group = groups[1]
         group2_id = self.partition_service.get_user_group_id_for_partition(self.user, user_partition_id)
-        self.assertEqual(group2_id, groups[1].id)
+        assert group2_id == groups[1].id
 
     def test_caching(self):
         username = "psvc_cache_user"

--- a/scripts/Jenkinsfiles/python
+++ b/scripts/Jenkinsfiles/python
@@ -27,6 +27,14 @@ def pythonTestCleanup() {
     bash scripts/xdist/terminate_xdist_nodes.sh'''
 }
 
+def xdist_git_branch() {
+    if (env.ghprbActualCommit) {
+        return "${ghprbActualCommit}"
+    } else {
+        return "${BRANCH_NAME}"
+    }
+}
+
 pipeline {
     agent { label "jenkins-worker" }
     options {
@@ -37,7 +45,7 @@ pipeline {
         XDIST_CONTAINER_SUBNET = credentials('XDIST_CONTAINER_SUBNET')
         XDIST_CONTAINER_SECURITY_GROUP = credentials('XDIST_CONTAINER_SECURITY_GROUP')
         XDIST_CONTAINER_TASK_NAME = "jenkins-worker-task"
-        XDIST_GIT_BRANCH = "${ghprbActualCommit}"
+        XDIST_GIT_BRANCH = xdist_git_branch()
     }
     stages {
         stage('Mark build as pending on Github') {

--- a/scripts/xdist/prepare_xdist_nodes.sh
+++ b/scripts/xdist/prepare_xdist_nodes.sh
@@ -13,7 +13,7 @@ do
     container_reqs_cmd="ssh -o StrictHostKeyChecking=no ubuntu@$ip 'cd /edx/app/edxapp;
     git clone --branch master --depth 1 --no-tags -q https://github.com/edx/edx-platform.git; cd edx-platform;
     git fetch --depth=1 --no-tags -q origin ${XDIST_GIT_BRANCH}; git checkout -q ${XDIST_GIT_BRANCH};
-    source /edx/app/edxapp/edxapp_env; pip install -qr requirements/edx/testing.txt' & "
+    source /edx/app/edxapp/edxapp_env; pip install -qr requirements/edx/testing.txt; mkdir reports' & "
 
     cmd=$cmd$container_reqs_cmd
 done


### PR DESCRIPTION
Fixed coverage reporting with remote xdist workers by using the correct `[paths]` configuration in `.coveragerc`; pytest-cov tries to set it automatically, but has a bug in doing so that I [just reported](https://github.com/pytest-dev/pytest-cov/issues/232#issuecomment-456539605).  Also fixed a few other things I noticed while debugging:

* Check out the correct branch on workers for non-PR builds; this should reduce the rsync duration.
* Automatically create the `reports` directory on xdist workers; the paver commands already do this, but direct pytest runs from devstack benefit from having this here.
* Updated some assertions in a test I saw flake once, to get more useful data if it happens again.