### PR TITLE
tiny style modification

### DIFF
--- a/lms/static/sass/_header.scss
+++ b/lms/static/sass/_header.scss
@@ -209,7 +209,7 @@
           position: absolute;
           background-color: theme-color("inverse");
           color: theme-color("secondary");
-          right: 30px;
+          @include right(30px);
           top: 55px;
           z-index: 10;
 


### PR DESCRIPTION
without this change dropdown-user-menu renders at the right corner of webpage independent to the site direction.  

![image](https://user-images.githubusercontent.com/21006810/51439506-b790b480-1cd0-11e9-8794-51cb8cea0e24.png)
