### PR TITLE
Make sure we return the right possible_grade value on grade APIs

### DIFF
--- a/lms/djangoapps/grades/subsection_grade.py
+++ b/lms/djangoapps/grades/subsection_grade.py
@@ -191,13 +191,15 @@ class NonZeroSubsectionGrade(SubsectionGradeBase):
         used instead.
         """
         score_type = 'graded' if is_graded else 'all'
-        grade_object = grade_model
+        earned_value = getattr(grade_model, 'earned_{}'.format(score_type))
+        possible_value = getattr(grade_model, 'possible_{}'.format(score_type))
         if hasattr(grade_model, 'override'):
             score_type = 'graded_override' if is_graded else 'all_override'
-            grade_object = grade_model.override
+            earned_value = getattr(grade_model.override, 'earned_{}'.format(score_type)) or earned_value
+            possible_value = getattr(grade_model.override, 'possible_{}'.format(score_type)) or possible_value
         return AggregatedScore(
-            tw_earned=getattr(grade_object, 'earned_{}'.format(score_type)),
-            tw_possible=getattr(grade_object, 'possible_{}'.format(score_type)),
+            tw_earned=earned_value,
+            tw_possible=possible_value,
             graded=is_graded,
             first_attempted=grade_model.first_attempted,
         )


### PR DESCRIPTION
@edx/educator-neem FYI
This PR is to fix the problem identified in EDUCATOR-3925.
Basically, if we have null Possible_graded_override value in our PersistentSubsectionGradeOverride table, we should make sure the API return the correct Possible_graded data instead of Null.
Before the fix here, we had a bug on Gradebook where this behavior was not expected.