### PR TITLE
ENT-1467 Version bump for edx-enterprise to 1.2.8

### DIFF
--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -117,7 +117,7 @@ edx-django-release-util==0.3.1
 edx-django-sites-extensions==2.3.1
 edx-django-utils==1.0.3
 edx-drf-extensions==2.0.1
-edx-enterprise==1.2.5
+edx-enterprise==1.2.8
 edx-i18n-tools==0.4.6
 edx-milestones==0.1.13
 edx-oauth2-provider==1.2.2

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -135,7 +135,7 @@ edx-django-release-util==0.3.1
 edx-django-sites-extensions==2.3.1
 edx-django-utils==1.0.3
 edx-drf-extensions==2.0.1
-edx-enterprise==1.2.5
+edx-enterprise==1.2.8
 edx-i18n-tools==0.4.6
 edx-lint==1.0.0
 edx-milestones==0.1.13

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -130,7 +130,7 @@ edx-django-release-util==0.3.1
 edx-django-sites-extensions==2.3.1
 edx-django-utils==1.0.3
 edx-drf-extensions==2.0.1
-edx-enterprise==1.2.5
+edx-enterprise==1.2.8
 edx-i18n-tools==0.4.6
 edx-lint==1.0.0
 edx-milestones==0.1.13


### PR DESCRIPTION
Includes https://github.com/edx/edx-enterprise/pull/423, https://github.com/edx/edx-enterprise/pull/422, https://github.com/edx/edx-enterprise/pull/421