### PR TITLE
ENT-1438 Update wording in account recovery flow

### DIFF
--- a/common/djangoapps/student/forms.py
+++ b/common/djangoapps/student/forms.py
@@ -77,6 +77,7 @@ def send_account_recovery_email_for_user(user, request, email=None):
     message_context = get_base_template_context(site)
     message_context.update({
         'request': request,  # Used by google_analytics_tracking_pixel
+        'email': email,
         'platform_name': configuration_helpers.get_value('PLATFORM_NAME', settings.PLATFORM_NAME),
         'reset_link': '{protocol}://{site}{link}?is_account_recovery=true'.format(
             protocol='https' if request.is_secure() else 'http',

--- a/common/templates/student/edx_ace/accountrecovery/email/body.html
+++ b/common/templates/student/edx_ace/accountrecovery/email/body.html
@@ -15,11 +15,21 @@
             </p>
 
             <p style="color: rgba(0,0,0,.75);">
-                {% trans "If you didn't request this change, you can disregard this email - we have not yet created your password." %}
+                {% trans "We've restored access to your edX account using the recovery email you provided at registration." %}
                 <br />
             </p>
 
-            {% trans "Create my Password" as course_cta_text %}
+            <p style="color: rgba(0,0,0,.75);">
+                {% blocktrans %}Once you've created a password [below], you will be able to log in to edX with this email ({{ email }}) and your new password.{% endblocktrans %}
+                <br />
+            </p>
+
+            <p style="color: rgba(0,0,0,.75);">
+                {% trans "If you didn't request this change, you can disregard this email - we have not yet reset your password." %}
+                <br />
+            </p>
+
+            {% trans "Create Password" as course_cta_text %}
 
             {% include "ace_common/edx_ace/common/return_to_course_cta.html" with course_cta_text=course_cta_text course_cta_url=reset_link %}
         </td>

--- a/common/templates/student/edx_ace/accountrecovery/email/body.txt
+++ b/common/templates/student/edx_ace/accountrecovery/email/body.txt
@@ -1,11 +1,13 @@
 {% load i18n %}{% autoescape off %}
 {% blocktrans %}You're receiving this e-mail because you requested to create a password for your user account at {{ platform_name }}.{% endblocktrans %}
 
-{% trans "Please go to the following page and choose a new password:" %}
+{% trans "We've restored access to your edX account using the recovery email you provided at registration." %}
+
+{% blocktrans %}Once you've created a password [below], you will be able to log in to edX with this email ({{ email }}) and your new password.{% endblocktrans %}
+
+{% trans "If you didn't request this change, you can disregard this email - we have not yet reset your password." %}
 
 {{ reset_link }}
-
-{% trans "If you didn't request this change, you can disregard this email - we have not yet created your password." %}
 
 {% trans "Thanks for using our site!" %}
 {% blocktrans %}The {{ platform_name }} Team{% endblocktrans %}

--- a/common/templates/student/edx_ace/accountrecovery/email/subject.txt
+++ b/common/templates/student/edx_ace/accountrecovery/email/subject.txt
@@ -1,4 +1,4 @@
 {% load i18n %}
 {% autoescape off %}
-{% blocktrans trimmed %}Create password on {{ platform_name }}{% endblocktrans %}
+{% blocktrans trimmed %}Password creation on {{ platform_name }}{% endblocktrans %}
 {% endautoescape %}

--- a/lms/static/js/student_account/views/account_settings_factory.js
+++ b/lms/static/js/student_account/views/account_settings_factory.js
@@ -86,7 +86,7 @@
 
             secondaryEmailFieldData = {
                 model: userAccountModel,
-                title: gettext('Secondary Email Address'),
+                title: gettext('Recovery Address'),
                 valueAttribute: 'secondary_email',
                 helpMessage: gettext('You may access your account when single-sign on is not available.'),
                 persistChanges: true


### PR DESCRIPTION
**Rename field in account settings to `Recovery Address` instead of `Secondary Email Address`**
<img width="572" alt="screen shot 2019-01-23 at 5 22 44 pm" src="https://user-images.githubusercontent.com/5072991/51608458-5cadc600-1f39-11e9-8d16-b93bfe36bedf.png">
**Updated password reset email for recovery address (HTML Version)**
<img width="700" alt="screen shot 2019-01-23 at 6 02 20 pm" src="https://user-images.githubusercontent.com/5072991/51608484-6f27ff80-1f39-11e9-89c8-b105d9021ae7.png">
**Updated password reset email for recovery address (TEXT Version)**
<img width="715" alt="screen shot 2019-01-23 at 6 02 33 pm" src="https://user-images.githubusercontent.com/5072991/51608592-c201b700-1f39-11e9-89a6-c0a24d1e6048.png">
