### PR TITLE
create access denied fragment when HTTP request is null

### DIFF
--- a/openedx/features/content_type_gating/partitions.py
+++ b/openedx/features/content_type_gating/partitions.py
@@ -88,7 +88,7 @@ class ContentTypeGatingPartition(UserPartition):
 
         request = crum.get_current_request()
         frag = Fragment(render_to_string('content_type_gating/access_denied_message.html', {
-            'mobile_app': is_request_from_mobile_app(request),
+            'mobile_app': request and is_request_from_mobile_app(request),
             'ecommerce_checkout_link': ecommerce_checkout_link,
             'min_price': str(verified_mode.min_price)
         }))


### PR DESCRIPTION
### [EDUCATOR-3901](https://openedx.atlassian.net/browse/EDUCATOR-3901)

### Description
With the newly added FBE feature, the audit enrolled users are shown a banner that specifies they will have to upgrade to access the content. Courses have the capacity to enable the FBE even the course is live. This poses a problem since there can be some audit enrollments' problem submissions(which are not accessible to such users when FBE is enabled). One of the such problems was seen when rescoring some problems. To skip rescoring for audit enrollments, an access denied fragment is returned. That fragment requires the HTTP request to categorize if the request is from mobile or web. That request is retrieved using the CRUM middle-ware. However, rescoring is an async celery task, hence no HTTP request was found and None was returned by the CRUM. That None was passed along in the task and wherever request(and its attributes) were accessed, an **AttributeError** was thrown. This PR addresses that problem by adding a check for the None requests and subsequently, allow the fragment creation.

### Sandbox
 - https://educator3901.sandbox.edx.org/

### How to Test
 1. Visit the sandbox and create a test problem in any unit
 2. Provide submissions for the problem using both Audit & Verified Track.
 3. Enable [FBE](https://openedx.atlassian.net/wiki/spaces/RS/pages/922354184/How+to+turn+on+FBE+on+devstack+or+a+sandbox) for that course.
4. Visit the course again, and rescore that problem(Rescore only if Improves) from the Instructor Tab.
5. The rescoring should complete, with audit submissions skipped.

### Reviewers
 - [x] @awaisdar001 
 - [x] @noraiz-anwar 

### Post Review
 - [x] Squash & Rebase commits