### PR TITLE
EDUCATOR-3934 Remove #-of-learners message for writable gradebook

### DIFF
--- a/lms/djangoapps/instructor/tests/views/test_instructor_dashboard.py
+++ b/lms/djangoapps/instructor/tests/views/test_instructor_dashboard.py
@@ -231,6 +231,43 @@ class TestInstructorDashboard(ModuleStoreTestCase, LoginEnrollmentTestCase, XssT
         self.assertIn(expected_gradebook_url, response.content)
         self.assertIn('View Gradebook', response.content)
 
+    GRADEBOOK_LEARNER_COUNT_MESSAGE = (
+        'Note: This feature is available only to courses with a small number ' +
+        'of enrolled learners.'
+    )
+
+    def test_gradebook_learner_count_message(self):
+        """
+        Test that, when the writable gradebook featue is NOT enabled, there IS
+        a message that the feature is only available for courses with small
+        numbers of learners.
+        """
+        response = self.client.get(self.url)
+        self.assertIn(
+            self.GRADEBOOK_LEARNER_COUNT_MESSAGE,
+            response.content
+        )
+        self.assertIn('View Gradebook', response.content)
+
+    @patch(
+        'lms.djangoapps.instructor.views.instructor_dashboard.settings.WRITABLE_GRADEBOOK_URL',
+        'http://gradebook.local.edx.org'
+    )
+    def test_no_gradebook_learner_count_message(self):
+        """
+        Test that, when the writable gradebook featue IS enabled, there is NOT
+        a message that the feature is only available for courses with small
+        numbers of learners.
+        """
+        waffle_flag = waffle_flags()[WRITABLE_GRADEBOOK]
+        with override_waffle_flag(waffle_flag, active=True):
+            response = self.client.get(self.url)
+        self.assertNotIn(
+            TestInstructorDashboard.GRADEBOOK_LEARNER_COUNT_MESSAGE,
+            response.content
+        )
+        self.assertIn('View Gradebook', response.content)
+
     def test_default_currency_in_the_html_response(self):
         """
         Test that checks the default currency_symbol ($) in the response

--- a/lms/templates/instructor/instructor_dashboard_2/student_admin.html
+++ b/lms/templates/instructor/instructor_dashboard_2/student_admin.html
@@ -6,11 +6,11 @@
         <br><br>
         <h4 class="hd hd-4">${_("View gradebook for enrolled learners")}</h4>
         <br>
-        <label for="gradebook-link">${_("Note: This feature is available only to courses with a small number of enrolled learners.")}</label>
-        <br><br>
     %if section_data.get('writable_gradebook_url'):
         <span name="gradebook-link"><a href="${ section_data['writable_gradebook_url'] }" class="gradebook-link"> ${_("View Gradebook")} </a></span>
     %elif section_data.get('is_small_course'):
+        <label for="gradebook-link">${_("Note: This feature is available only to courses with a small number of enrolled learners.")}</label>
+        <br><br>
         <span name="gradebook-link"><a href="${ section_data['spoc_gradebook_url'] }" class="gradebook-link"> ${_("View Gradebook")} </a></span>
     %endif
         <br><br>


### PR DESCRIPTION
**Ticket:** https://openedx.atlassian.net/browse/EDUCATOR-3934
**Team:** @edx/educator-dahlia 

Currently, there's a message that says the gradebook is limited to courses with a small number of learners.

This PR removes that message for courses that use the new writable gradebook.