### PR TITLE
Fix Collapse All/Expand All translation

### DIFF
--- a/openedx/features/course_experience/static/course_experience/js/CourseOutline.js
+++ b/openedx/features/course_experience/static/course_experience/js/CourseOutline.js
@@ -1,4 +1,4 @@
-/* globals Logger */
+/* globals gettext, Logger */
 
 import { keys } from 'edx-ui-toolkit/js/utils/constants';
 
@@ -82,12 +82,12 @@ export class CourseOutline {  // eslint-disable-line import/prefer-default-expor
         toggleAllButton.setAttribute('aria-expanded', 'false');
         sectionAction = collapseSection;
         toggleAllSpan.classList.add(extraPaddingClass);
-        toggleAllSpan.innerText = 'Expand All';
+        toggleAllSpan.innerText = gettext('Expand All');
       } else {
         toggleAllButton.setAttribute('aria-expanded', 'true');
         sectionAction = expandSection;
         toggleAllSpan.classList.remove(extraPaddingClass);
-        toggleAllSpan.innerText = 'Collapse All';
+        toggleAllSpan.innerText = gettext('Collapse All');
       }
       const sections = Array.prototype.slice.call(document.querySelectorAll('.accordion-trigger'));
       sections.forEach((sectionToggleButton) => {


### PR DESCRIPTION
There is a button at course outline that says 'Expand All' and it is correctly translated. But when I click on it, the translation behavior is broken. Both 'Expand All' and 'Collapse All' strings in the js file aren't using the gettext() function. With this change the translation behavior is fixed.

This is how it looks now.

![image](https://user-images.githubusercontent.com/22335041/51769595-e2587f80-20b9-11e9-8ea1-dcfb0d690092.png)

![image](https://user-images.githubusercontent.com/22335041/51769645-f9976d00-20b9-11e9-9193-69d49ada6f00.png)



