### PR TITLE
Use correct language code in retirement emails

### DIFF
--- a/common/djangoapps/student/models.py
+++ b/common/djangoapps/student/models.py
@@ -426,9 +426,15 @@ class UserProfile(models.Model):
     meta = models.TextField(blank=True)  # JSON dictionary for future expansion
     courseware = models.CharField(blank=True, max_length=255, default='course.xml')
 
+    # Language is deprecated and no longer used. Old rows exist that have
+    # user-entered free form text values (ex. "English"), some of which have
+    # non-ASCII values. You probably want UserPreference version of this, which
+    # stores the user's preferred language code. See openedx/core/djangoapps/lang_pref
+    # for more information.
+    language = models.CharField(blank=True, max_length=255, db_index=True)
+
     # Location is no longer used, but is held here for backwards compatibility
     # for users imported from our first class.
-    language = models.CharField(blank=True, max_length=255, db_index=True)
     location = models.CharField(blank=True, max_length=255, db_index=True)
 
     # Optional demographic data we started capturing from Fall 2012

--- a/openedx/core/djangoapps/user_api/accounts/views.py
+++ b/openedx/core/djangoapps/user_api/accounts/views.py
@@ -10,6 +10,7 @@ from functools import wraps
 
 import pytz
 from consent.models import DataSharingConsent
+from django.conf import settings
 from django.contrib.auth import authenticate, get_user_model, logout
 from django.contrib.sites.models import Site
 from django.core.cache import cache
@@ -39,6 +40,7 @@ from openedx.core.djangoapps.ace_common.template_context import get_base_templat
 from openedx.core.djangoapps.api_admin.models import ApiAccessRequest
 from openedx.core.djangoapps.credit.models import CreditRequirementStatus, CreditRequest
 from openedx.core.djangoapps.course_groups.models import UnregisteredLearnerCohortAssignments
+from openedx.core.djangoapps.lang_pref import LANGUAGE_KEY
 from openedx.core.djangoapps.profile_images.images import remove_profile_images
 from openedx.core.djangoapps.user_api.accounts.image_helpers import get_profile_image_names, set_has_profile_image
 from openedx.core.djangolib.oauth2_retirement_utils import retire_dot_oauth2_models, retire_dop_oauth2_models
@@ -404,9 +406,14 @@ class DeactivateLogoutView(APIView):
                     site = Site.objects.get_current()
                     notification_context = get_base_template_context(site)
                     notification_context.update({'full_name': request.user.profile.name})
+                    language_code = request.user.preferences.model.get_value(
+                        request.user,
+                        LANGUAGE_KEY,
+                        default=settings.LANGUAGE_CODE
+                    )
                     notification = DeletionNotificationMessage().personalize(
                         recipient=Recipient(username='', email_address=user_email),
-                        language=request.user.profile.language,
+                        language=language_code,
                         user_context=notification_context,
                     )
                     ace.send(notification)


### PR DESCRIPTION
tl;dr: This change is intended to address PLAT-2411, where edx-ace is erroring on certain retirement requests due to an incorrect language code being passed down from platform.

Longer: The field that was being passed down to edx-ace here is deprecated, and was a free-form text field populated by the user describing their preferred language. Most users didn't have a value here, and most values are things like "English". Those values, which are obviously not valid language codes, get passed into Django's translation flow here:
https://github.com/edx/edx-ace/blob/master/edx_ace/presentation.py#L27

Normally they have just been failing to find the language and falling back to English, however in the case where non-ASCII characters are present (ex. Español) an error is thrown (see PLAT-2411 for details), preventing the email from being sent and the learner from being able to request retirement.

This change uses the new UserPreference model, as we do for Sailthru emails. I have confirmed in production that rows with the key `pref-lang` have only correct language codes. Unfortunately this seems to be something that we can not test in edx-ace, but the change is not likely to cause any more problems than the current situation. I will test in Stage if the PR gets merged.