### PR TITLE
Fix broken link to oep2 in openedx.yml

### DIFF
--- a/openedx.yaml
+++ b/openedx.yaml
@@ -1,5 +1,5 @@
 # This file describes this Open edX repo, as described in OEP-2:
-# https://open-edx-proposals.readthedocs.io/en/latest/oeps/oep-0002.html#specification
+# https://open-edx-proposals.readthedocs.io/en/latest/oep-0002-bp-repo-metadata.html#specification
 
 nick: edx
 oeps: {}


### PR DESCRIPTION
Looks like the current readthedocs link is broken.