### PR TITLE
Bump timeout for bokchoy

### DIFF
--- a/scripts/Jenkinsfiles/bokchoy
+++ b/scripts/Jenkinsfiles/bokchoy
@@ -29,7 +29,7 @@ pipeline {
     agent { label "jenkins-worker" }
     options {
         timestamps()
-        timeout(60)
+        timeout(75)
     }
     stages {
         stage('Mark build as pending on Github') {


### PR DESCRIPTION
timing out, likely to unbalanced shards. will investigate but want to get builds passing in the meantime.