### PR TITLE
ENT-1492: Update dashboard alert link and account settings page styling

### DIFF
--- a/common/djangoapps/student/views/dashboard.py
+++ b/common/djangoapps/student/views/dashboard.py
@@ -642,7 +642,7 @@ def student_dashboard(request):
                     "Add a recovery email to retain access when single-sign on is not available. "
                     "Go to {link_start}your Account Settings{link_end}.")
             ).format(
-                link_start=HTML("<a target='_blank' href='{account_setting_page}'>").format(
+                link_start=HTML("<a href='{account_setting_page}'>").format(
                     account_setting_page=reverse('account_settings'),
                 ),
                 link_end=HTML("</a>")

--- a/lms/static/js/student_account/views/account_settings_factory.js
+++ b/lms/static/js/student_account/views/account_settings_factory.js
@@ -88,7 +88,7 @@
 
             secondaryEmailFieldData = {
                 model: userAccountModel,
-                title: gettext('Recovery Address'),
+                title: gettext('Recovery Email Address'),
                 valueAttribute: 'secondary_email',
                 helpMessage: gettext('You may access your account when single-sign on is not available.'),
                 persistChanges: true


### PR DESCRIPTION
**JIRA:** [ENT-1492](https://openedx.atlassian.net/browse/ENT-1492)

__Requirements__
**Dashboard alert**

1. On the new dashboard, alert prompting learners to enter a recovery email address, clicking the link should redirect the user to their account settings page in the same browser tab/window (current behavior is opening a new tab).

**Account settings page**

1. The padding and indent for the Recovery address section on the account settings page should be checked and updated to be consistent with the other sections.
2. The Header text for the recovery address section should be changed to "Recovery Email Address"