### PR TITLE
Refactored the retirement permission to use Django rules

### DIFF
--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -651,8 +651,10 @@ derived_collection_entry('DEFAULT_TEMPLATE_ENGINE', 'DIRS')
 ###############################################################################################
 
 AUTHENTICATION_BACKENDS = [
+    'rules.permissions.ObjectPermissionBackend',
     'openedx.core.djangoapps.oauth_dispatch.dot_overrides.backends.EdxRateLimitedAllowAllUsersModelBackend'
 ]
+
 STUDENT_FILEUPLOAD_MAX_SIZE = 4 * 1000 * 1000  # 4 MB
 MAX_FILEUPLOADS_PER_INPUT = 20
 
@@ -2238,6 +2240,9 @@ INSTALLED_APPS = [
 
     # additional release utilities to ease automation
     'release_util',
+
+    # rule-based authorization
+    'rules.apps.AutodiscoverRulesConfig',
 
     # Customized celery tasks, including persisting failed tasks so they can
     # be retried

--- a/openedx/core/djangoapps/user_api/accounts/permissions.py
+++ b/openedx/core/djangoapps/user_api/accounts/permissions.py
@@ -3,7 +3,6 @@ Permissions classes for User accounts API views.
 """
 from __future__ import unicode_literals
 
-from django.conf import settings
 from rest_framework import permissions
 
 
@@ -23,7 +22,4 @@ class CanRetireUser(permissions.BasePermission):
     retire a User account.
     """
     def has_permission(self, request, view):
-        return (
-            request.user.username == settings.RETIREMENT_SERVICE_WORKER_USERNAME or
-            request.user.is_superuser
-        )
+        return request.user.has_perm('accounts.can_retire_user')

--- a/openedx/core/djangoapps/user_api/rules.py
+++ b/openedx/core/djangoapps/user_api/rules.py
@@ -1,0 +1,20 @@
+"""
+Django rules for accounts
+"""
+from __future__ import absolute_import
+
+from django.conf import settings
+import rules
+
+
+@rules.predicate
+def can_retire_user(user):
+    """
+    Returns whether the user can retire accounts
+    """
+    return (
+        user.username == settings.RETIREMENT_SERVICE_WORKER_USERNAME or
+        user.is_superuser
+    )
+
+rules.add_perm('accounts.can_retire_user', can_retire_user)


### PR DESCRIPTION
This will allow pluggable Django apps to access the retirement permission without having to import anything from edx-platform.

