### PR TITLE
INCR-19: Move to python3-saml

### DIFF
--- a/cms/djangoapps/contentstore/views/course.py
+++ b/cms/djangoapps/contentstore/views/course.py
@@ -1505,8 +1505,7 @@ def textbooks_detail_handler(request, course_key_string, textbook_id):
             if not textbook:
                 return JsonResponse(status=404)
             return JsonResponse(textbook)
-        elif request.method in ('POST', 'PUT'):  # can be either and sometimes
-                                            # django is rewriting one to the other
+        elif request.method in ('POST', 'PUT'):  # can be either and sometimes django is rewriting one to the other
             try:
                 new_textbook = validate_textbook_json(request.body)
             except TextbookValidationError as err:
@@ -1690,8 +1689,7 @@ def group_configurations_detail_handler(request, course_key_string, group_config
         else:
             configuration = None
 
-        if request.method in ('POST', 'PUT'):  # can be either and sometimes
-                                            # django is rewriting one to the other
+        if request.method in ('POST', 'PUT'):  # can be either and sometimes django is rewriting one to the other
             try:
                 new_configuration = GroupConfiguration(request.body, course, group_configuration_id).get_user_partition()
             except GroupConfigurationsValidationError as err:

--- a/common/djangoapps/third_party_auth/tests/utils.py
+++ b/common/djangoapps/third_party_auth/tests/utils.py
@@ -135,6 +135,6 @@ def prepare_saml_response_from_xml(xml, relay_state='testshib'):
     """
     b64encoded_xml = b64encode(xml)
     return 'RelayState={relay_state}&SAMLResponse={saml_response}'.format(
-        relay_state=OneLogin_Saml2_Utils.case_sensitive_urlencode(relay_state),
-        saml_response=OneLogin_Saml2_Utils.case_sensitive_urlencode(b64encoded_xml)
+        relay_state=OneLogin_Saml2_Utils.escape_url(relay_state),
+        saml_response=OneLogin_Saml2_Utils.escape_url(b64encoded_xml)
     )

--- a/common/lib/xmodule/xmodule/contentstore/mongo.py
+++ b/common/lib/xmodule/xmodule/contentstore/mongo.py
@@ -477,15 +477,15 @@ class MongoContentStore(ContentStore):
         # which can be `uploadDate`, `displayname`,
         # TODO: uncomment this line once this index in prod is cleaned up. See OPS-2863 for tracking clean up.
         #  create_collection_index(
-            #  self.fs_files,
-            #  [
-                #  ('_id.tag', pymongo.ASCENDING),
-                #  ('_id.org', pymongo.ASCENDING),
-                #  ('_id.course', pymongo.ASCENDING),
-                #  ('_id.category', pymongo.ASCENDING)
-            #  ],
-            #  sparse=True,
-            #  background=True
+        #      self.fs_files,
+        #      [
+        #          ('_id.tag', pymongo.ASCENDING),
+        #          ('_id.org', pymongo.ASCENDING),
+        #          ('_id.course', pymongo.ASCENDING),
+        #          ('_id.category', pymongo.ASCENDING)
+        #      ],
+        #      sparse=True,
+        #      background=True
         #  )
         create_collection_index(
             self.fs_files,

--- a/common/lib/xmodule/xmodule/modulestore/mongo/base.py
+++ b/common/lib/xmodule/xmodule/modulestore/mongo/base.py
@@ -1025,7 +1025,7 @@ class MongoModuleStore(ModuleStoreDraftAndPublished, ModuleStoreWriteBase, Mongo
                 course_queries.append(course_query)
             query = {'$or': course_queries}
         elif course_org_filter:
-                query['_id.org'] = course_org_filter
+            query['_id.org'] = course_org_filter
 
         course_records = self.collection.find(query, {'metadata': True})
 

--- a/lms/djangoapps/courseware/tabs.py
+++ b/lms/djangoapps/courseware/tabs.py
@@ -324,7 +324,7 @@ def get_course_tab_list(request, course):
             tab.name = _("Entrance Exam")
         # TODO: LEARNER-611 - once the course_info tab is removed, remove this code
         if UNIFIED_COURSE_TAB_FLAG.is_enabled(course.id) and tab.type == 'course_info':
-                continue
+            continue
         if tab.type == 'static_tab' and tab.course_staff_only and \
                 not bool(user and has_access(user, 'staff', course, course.id)):
             continue

--- a/lms/djangoapps/django_comment_client/permissions.py
+++ b/lms/djangoapps/django_comment_client/permissions.py
@@ -147,7 +147,7 @@ def _check_conditions_permissions(user, permissions, course_id, content, user_gr
                         or user_group_id is None
                         or content_user_group is None
                         or user_group_id != content_user_group):
-                        return False
+                    return False
             return has_permission(user, per, course_id=course_id)
         elif isinstance(per, list) and operator in ["and", "or"]:
             results = [test(user, x, operator="and") for x in per]

--- a/lms/djangoapps/django_comment_client/tests/utils.py
+++ b/lms/djangoapps/django_comment_client/tests/utils.py
@@ -74,40 +74,40 @@ def config_course_discussions(
         divided_discussions=[],
         always_divide_inline_discussions=False
 ):
-        """
-        Set discussions and configure divided discussions for a course.
+    """
+    Set discussions and configure divided discussions for a course.
 
-        Arguments:
-            course: CourseDescriptor
-            discussion_topics (Dict): Discussion topic names. Picks ids and
-                sort_keys automatically.
-            divided_discussions: Discussion topics to divide. Converts the
-                list to use the same ids as discussion topic names.
-            always_divide_inline_discussions (bool): Whether inline discussions
-                should be divided by default.
+    Arguments:
+        course: CourseDescriptor
+        discussion_topics (Dict): Discussion topic names. Picks ids and
+            sort_keys automatically.
+        divided_discussions: Discussion topics to divide. Converts the
+            list to use the same ids as discussion topic names.
+        always_divide_inline_discussions (bool): Whether inline discussions
+            should be divided by default.
 
-        Returns:
-            Nothing -- modifies course in place.
-        """
+    Returns:
+        Nothing -- modifies course in place.
+    """
 
-        def to_id(name):
-            """Convert name to id."""
-            return topic_name_to_id(course, name)
+    def to_id(name):
+        """Convert name to id."""
+        return topic_name_to_id(course, name)
 
-        set_course_discussion_settings(
-            course.id,
-            divided_discussions=[to_id(name) for name in divided_discussions],
-            always_divide_inline_discussions=always_divide_inline_discussions,
-            division_scheme=CourseDiscussionSettings.COHORT,
-        )
+    set_course_discussion_settings(
+        course.id,
+        divided_discussions=[to_id(name) for name in divided_discussions],
+        always_divide_inline_discussions=always_divide_inline_discussions,
+        division_scheme=CourseDiscussionSettings.COHORT,
+    )
 
-        course.discussion_topics = dict((name, {"sort_key": "A", "id": to_id(name)})
-                                        for name in discussion_topics)
-        try:
-            # Not implemented for XMLModulestore, which is used by test_cohorts.
-            modulestore().update_item(course, ModuleStoreEnum.UserID.test)
-        except NotImplementedError:
-            pass
+    course.discussion_topics = dict((name, {"sort_key": "A", "id": to_id(name)})
+                                    for name in discussion_topics)
+    try:
+        # Not implemented for XMLModulestore, which is used by test_cohorts.
+        modulestore().update_item(course, ModuleStoreEnum.UserID.test)
+    except NotImplementedError:
+        pass
 
 
 def topic_name_to_id(course, name):

--- a/openedx/core/djangoapps/catalog/utils.py
+++ b/openedx/core/djangoapps/catalog/utils.py
@@ -486,9 +486,9 @@ def get_fulfillable_course_runs_for_entitlement(entitlement, course_runs):
             # this will ensure it is available for the UI
             enrollable_sessions.append(course_run)
         elif (course_run.get('status') == COURSE_PUBLISHED and not
-              is_enrolled_in_mode and
-              is_course_run_entitlement_fulfillable(course_id, entitlement, search_time)):
-                enrollable_sessions.append(course_run)
+                is_enrolled_in_mode and
+                is_course_run_entitlement_fulfillable(course_id, entitlement, search_time)):
+            enrollable_sessions.append(course_run)
 
     enrollable_sessions.sort(key=lambda session: session.get('start'))
     return enrollable_sessions

--- a/pavelib/prereqs.py
+++ b/pavelib/prereqs.py
@@ -198,6 +198,7 @@ PACKAGES_TO_UNINSTALL = [
     "django-oauth2-provider",       # Because now it's called edx-django-oauth2-provider.
     "edx-oauth2-provider",          # Because it moved from github to pypi
     "i18n-tools",                   # Because now it's called edx-i18n-tools
+    "python-saml",                  # Because python3-saml shares the same directory name
 ]
 
 

--- a/requirements/edx/base.in
+++ b/requirements/edx/base.in
@@ -34,7 +34,7 @@ boto==2.39.0                        # Deprecated version of the AWS SDK; we shou
 boto3==1.4.8                        # Amazon Web Services SDK for Python
 botocore==1.8.17                    # via boto3, s3transfer
 celery==3.1.25                      # Asynchronous task execution library
-defusedxml==0.4.1                   # XML bomb protection for common XML parsers
+defusedxml
 Django==1.11.18                     # Web application framework
 django-babel-underscore             # underscore template extractor for django-babel (internationalization utilities)
 django-config-models>=0.2.2         # Configuration models for Django allowing config management with auditing
@@ -126,7 +126,7 @@ pynliner                            # Inlines CSS styles into HTML for email not
 python-dateutil==2.4
 python-Levenshtein
 python-openid
-python-saml==2.4.0
+python3-saml
 pyuca==1.1                          # For more accurate sorting of translated country names in django-countries
 reportlab                           # Used for shopping cart's pdf invoice/receipt generation
 rest-condition                      # DRF's recommendation for supporting complex permissions

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -66,7 +66,7 @@ cryptography==2.5
 cssutils==1.0.2           # via pynliner
 ddt==1.2.0
 decorator==4.3.2          # via dogapi, pycontracts
-defusedxml==0.4.1
+defusedxml==0.5.0
 django-appconf==1.0.2     # via django-statici18n
 django-babel-underscore==0.5.2
 django-babel==0.6.2       # via django-babel-underscore
@@ -103,7 +103,6 @@ django-webpack-loader==0.6.0
 django==1.11.18
 djangorestframework-jwt==1.11.0
 djangorestframework-xml==1.3.0  # via edx-enterprise
-dm.xmlsec.binding==1.3.3  # via python-saml
 docopt==0.6.2
 docutils==0.14            # via botocore
 dogapi==1.2.1
@@ -148,7 +147,7 @@ httplib2==0.12.0          # via oauth2, zendesk
 idna==2.8
 ipaddr==2.1.11
 ipaddress==1.0.22
-isodate==0.6.0            # via python-saml
+isodate==0.6.0            # via python3-saml
 itypes==1.1.0             # via coreapi
 jinja2==2.10              # via coreschema
 jmespath==0.9.3           # via boto3, botocore
@@ -179,10 +178,11 @@ openapi-codec==1.3.2      # via django-rest-swagger
 path.py==8.2.1
 pathtools==0.1.2
 paver==1.3.4
-pbr==5.1.1
+pbr==5.1.2
 pdfminer==20140328
 piexif==1.0.2
 pillow==5.4.1
+pkgconfig==1.4.0          # via xmlsec
 polib==1.1.0              # via edx-i18n-tools
 psutil==1.2.1
 py2neo==3.1.2
@@ -202,8 +202,8 @@ python-dateutil==2.4.0
 python-levenshtein==0.12.0
 python-memcached==1.48
 python-openid==2.2.5
-python-saml==2.4.0
 python-swiftclient==3.6.0
+python3-saml==1.5.0
 pytz==2018.9
 pyuca==1.1
 pyyaml==3.13
@@ -246,4 +246,5 @@ wrapt==1.10.5
 xblock-review==1.1.5
 xblock-utils==1.2.0
 xblock==1.2.2
+xmlsec==1.3.3             # via python3-saml
 zendesk==1.1.1

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -81,7 +81,7 @@ cssselect==1.0.3
 cssutils==1.0.2
 ddt==1.2.0
 decorator==4.3.2
-defusedxml==0.4.1
+defusedxml==0.5.0
 dicttoxml==1.7.4
 diff-cover==0.9.8
 django-appconf==1.0.2
@@ -121,7 +121,6 @@ django-webpack-loader==0.6.0
 django==1.11.18
 djangorestframework-jwt==1.11.0
 djangorestframework-xml==1.3.0
-dm.xmlsec.binding==1.3.3
 docopt==0.6.2
 docutils==0.14
 dogapi==1.2.1
@@ -151,6 +150,7 @@ edx-submissions==2.1.1
 edx-user-state-client==1.0.4
 edxval==1.1.25
 elasticsearch==1.9.0
+entrypoints==0.3
 enum34==1.1.6
 event-tracking==0.2.7
 execnet==1.5.0
@@ -162,7 +162,7 @@ filelock==3.0.10
 firebase-token-generator==1.3.2
 fixtures==3.0.0
 flake8-polyfill==1.0.2
-flake8==3.6.0
+flake8==3.7.1
 flask==1.0.2
 freezegun==0.3.11
 fs-s3fs==0.1.8
@@ -230,11 +230,12 @@ path.py==8.2.1
 pathlib2==2.3.3
 pathtools==0.1.2
 paver==1.3.4
-pbr==5.1.1
+pbr==5.1.2
 pdfminer==20140328
 piexif==1.0.2
 pillow==5.4.1
 pip-tools==3.3.2
+pkgconfig==1.4.0
 pluggy==0.8.1
 polib==1.1.0
 psutil==1.2.1
@@ -242,13 +243,13 @@ py2neo==3.1.2
 py==1.7.0
 pyasn1-modules==0.2.4
 pyasn1==0.4.5
-pycodestyle==2.4.0
+pycodestyle==2.5.0
 pycontracts==1.7.1
 pycountry==1.20
 pycparser==2.19
 pycryptodomex==3.4.7
 pydispatcher==2.0.5
-pyflakes==2.0.0
+pyflakes==2.1.0
 pygments==2.3.1
 pygraphviz==1.1
 pyinotify==0.9.6
@@ -277,10 +278,10 @@ python-levenshtein==0.12.0
 python-memcached==1.48
 python-mimeparse==1.6.0
 python-openid==2.2.5
-python-saml==2.4.0
 python-slugify==1.2.6
 python-subunit==1.3.0
 python-swiftclient==3.6.0
+python3-saml==1.5.0
 pytz==2018.9
 pyuca==1.1
 pyyaml==3.13
@@ -331,7 +332,7 @@ tox==3.7.0
 traceback2==1.4.0
 transifex-client==0.13.5
 twisted==16.6.0
-typing==3.6.6             # via sphinx
+typing==3.6.6
 unicodecsv==0.14.1
 unidecode==1.0.23
 unittest2==1.1.0
@@ -352,6 +353,7 @@ wrapt==1.10.5
 xblock-review==1.1.5
 xblock-utils==1.2.0
 xblock==1.2.2
+xmlsec==1.3.3
 xmltodict==0.11.0
 zendesk==1.1.1
 zope.interface==4.6.0

--- a/requirements/edx/paver.txt
+++ b/requirements/edx/paver.txt
@@ -17,7 +17,7 @@ mock==1.0.1
 path.py==8.2.1
 pathtools==0.1.2          # via watchdog
 paver==1.3.4
-pbr==5.1.1                # via stevedore
+pbr==5.1.2                # via stevedore
 psutil==1.2.1
 pymongo==2.9.1
 python-memcached==1.48

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -68,7 +68,7 @@ chardet==3.0.4
 click-log==0.1.8          # via edx-lint
 click==7.0
 colorama==0.4.1           # via radon
-configparser==3.7.1       # via flake8, pylint
+configparser==3.7.1       # via entrypoints, flake8, pylint
 constantly==15.1.0        # via twisted
 coreapi==2.3.3
 coreschema==0.0.4
@@ -78,7 +78,7 @@ cssselect==1.0.3
 cssutils==1.0.2
 ddt==1.2.0
 decorator==4.3.2
-defusedxml==0.4.1
+defusedxml==0.5.0
 dicttoxml==1.7.4          # via moto
 diff-cover==0.9.8
 django-appconf==1.0.2
@@ -116,7 +116,6 @@ django-waffle==0.12.0
 django-webpack-loader==0.6.0
 djangorestframework-jwt==1.11.0
 djangorestframework-xml==1.3.0
-dm.xmlsec.binding==1.3.3
 docopt==0.6.2
 docutils==0.14
 dogapi==1.2.1
@@ -145,6 +144,7 @@ edx-submissions==2.1.1
 edx-user-state-client==1.0.4
 edxval==1.1.25
 elasticsearch==1.9.0
+entrypoints==0.3          # via flake8
 enum34==1.1.6
 event-tracking==0.2.7
 execnet==1.5.0            # via pytest-xdist
@@ -156,7 +156,7 @@ filelock==3.0.10          # via tox
 firebase-token-generator==1.3.2
 fixtures==3.0.0           # via testtools
 flake8-polyfill==1.0.2    # via radon
-flake8==3.6.0             # via flake8-polyfill
+flake8==3.7.1             # via flake8-polyfill
 flask==1.0.2              # via moto
 freezegun==0.3.11
 fs-s3fs==0.1.8
@@ -221,10 +221,11 @@ path.py==8.2.1
 pathlib2==2.3.3           # via pytest, pytest-django
 pathtools==0.1.2
 paver==1.3.4
-pbr==5.1.1
+pbr==5.1.2
 pdfminer==20140328
 piexif==1.0.2
 pillow==5.4.1
+pkgconfig==1.4.0
 pluggy==0.8.1             # via pytest, tox
 polib==1.1.0
 psutil==1.2.1
@@ -232,13 +233,13 @@ py2neo==3.1.2
 py==1.7.0                 # via pytest, tox
 pyasn1-modules==0.2.4     # via service-identity
 pyasn1==0.4.5             # via pyasn1-modules, service-identity
-pycodestyle==2.4.0
+pycodestyle==2.5.0
 pycontracts==1.7.1
 pycountry==1.20
 pycparser==2.19
 pycryptodomex==3.4.7
 pydispatcher==2.0.5       # via scrapy
-pyflakes==2.0.0           # via flake8
+pyflakes==2.1.0           # via flake8
 pygments==2.3.1
 pygraphviz==1.1
 pyjwkest==1.3.2
@@ -266,10 +267,10 @@ python-levenshtein==0.12.0
 python-memcached==1.48
 python-mimeparse==1.6.0   # via testtools
 python-openid==2.2.5
-python-saml==2.4.0
 python-slugify==1.2.6     # via transifex-client
 python-subunit==1.3.0
 python-swiftclient==3.6.0
+python3-saml==1.5.0
 pytz==2018.9
 pyuca==1.1
 pyyaml==3.13
@@ -316,6 +317,7 @@ tox==3.7.0
 traceback2==1.4.0         # via testtools, unittest2
 transifex-client==0.13.5
 twisted==16.6.0           # via pa11ycrawler, scrapy
+typing==3.6.6             # via flake8
 unicodecsv==0.14.1
 unidecode==1.0.23         # via python-slugify
 unittest2==1.1.0          # via testtools
@@ -335,6 +337,7 @@ wrapt==1.10.5
 xblock-review==1.1.5
 xblock-utils==1.2.0
 xblock==1.2.2
+xmlsec==1.3.3
 xmltodict==0.11.0         # via moto
 zendesk==1.1.1
 zope.interface==4.6.0     # via twisted


### PR DESCRIPTION
* Per https://openedx.atlassian.net/browse/INCR-19 , this PR moves us from python-saml to python3-saml
* The pinned version of `defusedxml` was causing problems when running `make upgrade`. Looking into why it was pinned, I noticed the library was added to edx-platform in this PR: https://github.com/edx/edx-platform/pull/5177 and was simply pinned to the latest version at the time. I don't see any reason why we can't upgrade it now.
* Accounted for a method name change in python3-saml inside of `common/djangoapps/third_party_auth/tests/utils.py`. Here's the former method in the python-saml repo: [case_sensitive_urlencode](https://github.com/onelogin/python-saml/blob/4f7add5b2c1491038048eed529b949159d1db7f4/src/onelogin/saml2/utils.py#L1269) and the new one in python3-saml: [python3-saml escape_url](https://github.com/onelogin/python3-saml/blob/c5286ae73e9c3f752465699e5b96c791852da3d5/src/onelogin/saml2/utils.py#L69)
* `make upgrade` also yielded a new version of `pycodestyle`, which forced me to add some pep8 fixes to this PR as well.