### PR TITLE
fixup require_course_email_auth annotation

### DIFF
--- a/lms/djangoapps/bulk_email/models.py
+++ b/lms/djangoapps/bulk_email/models.py
@@ -440,7 +440,7 @@ class CourseAuthorization(models.Model):
 # .. feature_toggle_default: True (enabled)
 # .. feature_toggle_description: If the flag is enabled, course-specific authorization is required, and the course_id is either not provided or not authorixed, the feature is not available.
 # .. feature_toggle_category: bulk email
-# .. feature_toggle_use_cases: Open edX option,
+# .. feature_toggle_use_cases: open_edx
 # .. feature_toggle_expiration_date: None
 # .. feature_toggle_warnings: None
 # .. feature_toggle_tickets: None


### PR DESCRIPTION
I changed the code annotation config after I wrote this annotation, and it no longer parses. This should fix it. 