### PR TITLE
INCR-17: Unpin and upgrade sortedcontainers for python3 support

### DIFF
--- a/common/lib/xmodule/xmodule/modulestore/mongo/base.py
+++ b/common/lib/xmodule/xmodule/modulestore/mongo/base.py
@@ -1856,7 +1856,7 @@ class MongoModuleStore(ModuleStoreDraftAndPublished, ModuleStoreWriteBase, Mongo
         # Build an update set with potentially multiple embedded fields.
         updates_by_type = {}
         for asset_type, assets in assets_by_type.iteritems():
-            updates_by_type[self._make_mongo_asset_key(asset_type)] = assets.as_list()
+            updates_by_type[self._make_mongo_asset_key(asset_type)] = list(assets)
 
         # Update the document.
         self.asset_collection.update(

--- a/common/lib/xmodule/xmodule/modulestore/split_mongo/split.py
+++ b/common/lib/xmodule/xmodule/modulestore/split_mongo/split.py
@@ -2856,14 +2856,11 @@ class SplitMongoModuleStore(SplitBulkWriteMixin, ModuleStoreWriteBase):
             course_assets = new_structure.setdefault('assets', {})
 
             asset_type = asset_key.asset_type
-            all_assets = SortedAssetList(iterable=[])
-            # Assets should be pre-sorted, so add them efficiently without sorting.
-            # extend() will raise a ValueError if the passed-in list is not sorted.
-            all_assets.extend(course_assets.setdefault(asset_type, []))
+            all_assets = SortedAssetList(iterable=course_assets.setdefault(asset_type, []))
             asset_idx = all_assets.find(asset_key)
 
             all_assets_updated = update_function(all_assets, asset_idx)
-            new_structure['assets'][asset_type] = all_assets_updated.as_list()
+            new_structure['assets'][asset_type] = list(all_assets_updated)
 
             # update index if appropriate and structures
             self.update_structure(asset_key.course_key, new_structure)
@@ -2894,7 +2891,7 @@ class SplitMongoModuleStore(SplitBulkWriteMixin, ModuleStoreWriteBase):
             )
 
             for asset_type, assets in assets_by_type.iteritems():
-                new_structure['assets'][asset_type] = assets.as_list()
+                new_structure['assets'][asset_type] = list(assets)
 
             # update index if appropriate and structures
             self.update_structure(course_key, new_structure)
@@ -2935,7 +2932,7 @@ class SplitMongoModuleStore(SplitBulkWriteMixin, ModuleStoreWriteBase):
             mdata.update(attr_dict)
 
             # Generate a Mongo doc from the metadata and update the course asset info.
-            all_assets[asset_idx] = mdata.to_storable()
+            all_assets.insert_or_update(mdata)
             return all_assets
 
         self._update_course_assets(user_id, asset_key, _internal_method)

--- a/requirements/edx/base.in
+++ b/requirements/edx/base.in
@@ -141,7 +141,7 @@ sailthru-client==2.2.3              # For Sailthru integration
 Shapely==1.2.16                     # Geometry library, used for image click regions in capa
 six                                 # Utilities for supporting Python 2 & 3 in the same codebase
 sorl-thumbnail==12.3                # Image thumbnail management
-sortedcontainers==0.9.2             # Provides SortedListWithKey, used for lists of XBlock assets
+sortedcontainers                    # Provides SortedKeyList, used for lists of XBlock assets
 sqlparse                            # Required by Django to run migrations.RunSQL
 stevedore                           # Support for runtime plugins, used for XBlocks and edx-platform Django app plugins
 unicodecsv                          # Easier support for CSV files with unicode text

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -225,7 +225,7 @@ slumber==0.7.1            # via edx-rest-api-client
 social-auth-app-django==2.1.0
 social-auth-core==1.7.0
 sorl-thumbnail==12.3
-sortedcontainers==0.9.2
+sortedcontainers==2.1.0
 soupsieve==1.8            # via beautifulsoup4
 sqlparse==0.2.4
 stevedore==1.30.0

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -317,7 +317,7 @@ snowballstemmer==1.2.1    # via sphinx
 social-auth-app-django==2.1.0
 social-auth-core==1.7.0
 sorl-thumbnail==12.3
-sortedcontainers==0.9.2
+sortedcontainers==2.1.0
 soupsieve==1.8
 sphinx==1.8.4
 sphinxcontrib-websupport==1.1.0  # via sphinx

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -306,7 +306,7 @@ slumber==0.7.1
 social-auth-app-django==2.1.0
 social-auth-core==1.7.0
 sorl-thumbnail==12.3
-sortedcontainers==0.9.2
+sortedcontainers==2.1.0
 soupsieve==1.8
 splinter==0.9.0
 sqlparse==0.2.4


### PR DESCRIPTION
* Unpins the `sortedcontainers` library for python3 support.
* The `SortedListWithKey` class was deprecated and is now just an alias for `SortedKeyList` [changelog v 2.0.0](https://github.com/grantjenks/python-sortedcontainers/blob/e05634b0f0b85deae2e796a8acc1cad5961819eb/HISTORY.rst#id15)
* The `as_list` method was removed in favor of `list()`[changelog v 1.4.2](https://github.com/grantjenks/python-sortedcontainers/blob/e05634b0f0b85deae2e796a8acc1cad5961819eb/HISTORY.rst#id194)
* The `__setitem__` method is no longer valid, and should be replaced by deleting an item and readding it to the new value to the list [changelog v 2.0.0](https://github.com/grantjenks/python-sortedcontainers/blob/e05634b0f0b85deae2e796a8acc1cad5961819eb/HISTORY.rst#id15)
* We previously created an empty `SortedListWithKey` and used `extend` to populate it, however the `extend` method has been removed.
