### PR TITLE
EDUCATOR-3930 fix video player speed adjustments

### DIFF
--- a/common/lib/xmodule/xmodule/js/spec/video/video_player_spec.js
+++ b/common/lib/xmodule/xmodule/js/spec/video/video_player_spec.js
@@ -911,9 +911,9 @@ function(VideoPlayer, HLS) {
 
                 it('set video speed to the new speed', function() {
                     VideoPlayer.prototype.onSpeedChange.call(state, '0.75', false);
-                    expect(state.setSpeed).toHaveBeenCalledWith('0.75');
+                    expect(state.setSpeed).toHaveBeenCalledWith(0.75);
                     expect(state.videoPlayer.setPlaybackRate)
-                        .toHaveBeenCalledWith('0.75');
+                        .toHaveBeenCalledWith(0.75);
                 });
             });
         });

--- a/common/lib/xmodule/xmodule/js/src/video/03_video_player.js
+++ b/common/lib/xmodule/xmodule/js/src/video/03_video_player.js
@@ -421,7 +421,7 @@ function(HTML5Video, HTML5HLSVideo, Resizer, HLS, _) {
             );
         }
 
-        newSpeed = parseFloat(newSpeed).toFixed(2).replace(/\.00$/, '.0');
+        newSpeed = parseFloat(newSpeed);
         this.setSpeed(newSpeed);
         this.videoPlayer.setPlaybackRate(newSpeed);
     }


### PR DESCRIPTION
**Description**
This PR is to merge #19645 into the olive branch. It fixes the video player speed adjustments which are not working for YouTube videos. The fix has been running on edx.org production since Jan 25th.


**Reviewers**

- [ ] @coryleeio 