### PR TITLE
Hackathon - feature toggles - adds feature_toggle_creation_date to annotations

### DIFF
--- a/feature_annotations.yaml
+++ b/feature_annotations.yaml
@@ -14,6 +14,7 @@ annotations:
     - ".. feature_toggle_category:":
     - ".. feature_toggle_use_cases:":
         choices: [incremental_release, launch_date, monitored_rollout, graceful_degradation, beta_testing, vip, opt_out, open_edx]
+    - ".. feature_toggle_creation_date:":
     - ".. feature_toggle_expiration_date:":
     - ".. feature_toggle_warnings:":
     - ".. feature_toggle_tickets:":

--- a/lms/djangoapps/bulk_email/models.py
+++ b/lms/djangoapps/bulk_email/models.py
@@ -441,6 +441,7 @@ class CourseAuthorization(models.Model):
 # .. feature_toggle_description: If the flag is enabled, course-specific authorization is required, and the course_id is either not provided or not authorixed, the feature is not available.
 # .. feature_toggle_category: bulk email
 # .. feature_toggle_use_cases: open_edx
+# .. feature_toggle_creation_date: 2016-05-05
 # .. feature_toggle_expiration_date: None
 # .. feature_toggle_warnings: None
 # .. feature_toggle_tickets: None

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -103,9 +103,10 @@ FEATURES = {
     # .. feature_toggle_name: ENABLE_SYSADMIN_DASHBOARD
     # .. feature_toggle_type: feature_flag
     # .. feature_toggle_default: False
-    # .. feature_toggle_description: enables dashboard at /syadmin/ for django staff, to import and delete courses, users
+    # .. feature_toggle_description: enables dashboard at /syadmin/ for django staff, for seeing overview of system status, for deleting and loading courses, for seeing log of git imports of courseware.
     # .. feature_toggle_category: admin
     # .. feature_toggle_use_cases: open_edx
+    # .. feature_toggle_creation_date: 2013-12-12
     # .. feature_toggle_expiration_date: None
     # .. feature_toggle_warnings: some views are not performant when there are more than 100 courses
     # .. feature_toggle_tickets: None

--- a/openedx/features/course_duration_limits/config.py
+++ b/openedx/features/course_duration_limits/config.py
@@ -26,6 +26,7 @@ CONTENT_TYPE_GATING_FLAG = WaffleFlag(
 # .. feature_toggle_description: Global kill switch for feature based enrollment.  To turn on the kill switch (and turn off both course duration gating and content type gating) enable a waffle flag named: 'content_type_gating.global_kill_switch'
 # .. feature_toggle_category: feature based enrollment
 # .. feature_toggle_use_cases: open_edx, vip
+# .. feature_toggle_creation_date: 2018-12-13
 # .. feature_toggle_expiration_date: None
 # .. feature_toggle_warnings: None
 # .. feature_toggle_tickets: REVE-154


### PR DESCRIPTION
- adds feature_toggle_creation_date to annotation config file
- adds feature_toggle_creation_date to 3 existing annotations
   I used `git blame -L <line number> <file>` to find the dates
- updates description in `ENABLE_SYSADMIN_DASHBOARD` annotations, because I found a better description in the commit message

FYI, I haven't run the code-annotation tool yet on this yet.  