### PR TITLE
Remove un-translated page links from spanish website's footer

### DIFF
--- a/lms/djangoapps/branding/api.py
+++ b/lms/djangoapps/branding/api.py
@@ -34,7 +34,7 @@ def is_enabled():
     return BrandingApiConfig.current().enabled
 
 
-def get_footer(is_secure=True):
+def get_footer(is_secure=True, language=settings.LANGUAGE_CODE):
     """Retrieve information used to render the footer.
 
     This will handle both the Open edX and edX.org versions
@@ -99,13 +99,13 @@ def get_footer(is_secure=True):
         "copyright": _footer_copyright(),
         "logo_image": _footer_logo_img(is_secure),
         "social_links": _footer_social_links(),
-        "business_links": _footer_business_links(),
+        "business_links": _footer_business_links(language),
         "mobile_links": _footer_mobile_links(is_secure),
-        "more_info_links": _footer_more_info_links(),
-        "connect_links": _footer_connect_links(),
+        "more_info_links": _footer_more_info_links(language),
+        "connect_links": _footer_connect_links(language),
         "openedx_link": _footer_openedx_link(),
-        "navigation_links": _footer_navigation_links(),
-        "legal_links": _footer_legal_links(),
+        "navigation_links": _footer_navigation_links(language),
+        "legal_links": _footer_legal_links(language),
         "edx_org_link": {
             "url": "https://www.edx.org/?utm_medium=affiliate_partner&utm_source=opensource-partner&utm_content=open-edx-partner-footer-link&utm_campaign=open-edx-footer",
             "text": _("Take free online courses at edX.org"),
@@ -170,8 +170,17 @@ def _footer_social_links():
     return links
 
 
-def _footer_connect_links():
+def _footer_connect_links(language=settings.LANGUAGE_CODE):
     """Return the connect links to display in the footer. """
+    links = [
+        ("blog", (marketing_link("BLOG"), _("Blog"))),
+        ("contact", (_build_support_form_url(), _("Contact Us"))),
+        ("help-center", (settings.SUPPORT_SITE_LINK, _("Help Center"))),
+    ]
+
+    if language == settings.LANGUAGE_CODE:
+        links.append(("media_kit", (marketing_link("MEDIA_KIT"), _("Media Kit"))))
+        links.append(("donate", (marketing_link("DONATE"), _("Donate"))))
 
     return [
         {
@@ -179,13 +188,7 @@ def _footer_connect_links():
             "title": link_title,
             "url": link_url,
         }
-        for link_name, link_url, link_title in [
-            ("blog", marketing_link("BLOG"), _("Blog")),
-            ("contact", _build_support_form_url(), _("Contact Us")),
-            ("help-center", settings.SUPPORT_SITE_LINK, _("Help Center")),
-            ("media_kit", marketing_link("MEDIA_KIT"), _("Media Kit")),
-            ("donate", marketing_link("DONATE"), _("Donate")),
-        ]
+        for link_name, (link_url, link_title) in links
         if link_url and link_url != "#"
     ]
 
@@ -194,39 +197,50 @@ def _build_support_form_url():
     return '{base_url}/support/contact_us'.format(base_url=settings.LMS_ROOT_URL)
 
 
-def _footer_navigation_links():
+def _find_position_of_link(links, key):
+    "Returns position of the link to be inserted"
+    for link in links:
+        if link[0] == key:
+            return links.index(link) + 1
+
+
+def _footer_navigation_links(language=settings.LANGUAGE_CODE):
     """Return the navigation links to display in the footer. """
     platform_name = configuration_helpers.get_value('platform_name', settings.PLATFORM_NAME)
+    links = [
+        ("about", (marketing_link("ABOUT"), _("About"))),
+        ("enterprise", (marketing_link("ENTERPRISE"),
+                        _("{platform_name} for Business").format(platform_name=platform_name))),
+        ("blog", (marketing_link("BLOG"), _("Blog"))),
+        ("help-center", (settings.SUPPORT_SITE_LINK, _("Help Center"))),
+        ("contact", (reverse("support:contact_us"), _("Contact"))),
+        ("careers", (marketing_link("CAREERS"), _("Careers"))),
+        ("donate", (marketing_link("DONATE"), _("Donate"))),
+    ]
+
+    if language == settings.LANGUAGE_CODE:
+        position = _find_position_of_link(links, 'blog')
+        links.insert(position, ("news", (marketing_link("NEWS"), _("News"))))
+
     return [
         {
             "name": link_name,
             "title": link_title,
             "url": link_url,
         }
-        for link_name, link_url, link_title in [
-            ("about", marketing_link("ABOUT"), _("About")),
-            ("enterprise", marketing_link("ENTERPRISE"),
-             _(u"{platform_name} for Business").format(platform_name=platform_name)),
-            ("blog", marketing_link("BLOG"), _("Blog")),
-            ("news", marketing_link("NEWS"), _("News")),
-            ("help-center", settings.SUPPORT_SITE_LINK, _("Help Center")),
-            ("contact", reverse("support:contact_us"), _("Contact")),
-            ("careers", marketing_link("CAREERS"), _("Careers")),
-            ("donate", marketing_link("DONATE"), _("Donate")),
-        ]
+        for link_name, (link_url, link_title) in links
         if link_url and link_url != "#"
     ]
 
 
-def _footer_legal_links():
+def _footer_legal_links(language=settings.LANGUAGE_CODE):
     """Return the legal footer links (e.g. terms of service). """
 
     links = [
-        ("terms_of_service_and_honor_code", marketing_link("TOS_AND_HONOR"), _("Terms of Service & Honor Code")),
-        ("privacy_policy", marketing_link("PRIVACY"), _("Privacy Policy")),
-        ("accessibility_policy", marketing_link("ACCESSIBILITY"), _("Accessibility Policy")),
-        ("sitemap", marketing_link("SITE_MAP"), _("Sitemap")),
-        ("media_kit", marketing_link("MEDIA_KIT"), _("Media Kit")),
+        ("terms_of_service_and_honor_code", (marketing_link("TOS_AND_HONOR"), _("Terms of Service & Honor Code"))),
+        ("privacy_policy", (marketing_link("PRIVACY"), _("Privacy Policy"))),
+        ("accessibility_policy", (marketing_link("ACCESSIBILITY"), _("Accessibility Policy"))),
+        ("media_kit", (marketing_link("MEDIA_KIT"), _("Media Kit"))),
     ]
 
     # Backwards compatibility: If a combined "terms of service and honor code"
@@ -234,24 +248,42 @@ def _footer_legal_links():
     tos_and_honor_link = marketing_link("TOS_AND_HONOR")
     if not (tos_and_honor_link and tos_and_honor_link != "#"):
         links.extend([
-            ("terms_of_service", marketing_link("TOS"), _("Terms of Service")),
-            ("honor_code", marketing_link("HONOR"), _("Honor Code")),
+            ("terms_of_service", (marketing_link("TOS"), _("Terms of Service"))),
+            ("honor_code", (marketing_link("HONOR"), _("Honor Code"))),
         ])
 
+    if language == settings.LANGUAGE_CODE:
+        position = _find_position_of_link(links, 'accessibility_policy')
+        links.insert(position, ("sitemap", (marketing_link("SITE_MAP"), _("Sitemap"))))
+
     return [
         {
             "name": link_name,
             "title": link_title,
             "url": link_url,
         }
-        for link_name, link_url, link_title in links
+        for link_name, (link_url, link_title) in links
         if link_url and link_url != "#"
     ]
 
 
-def _footer_business_links():
+def _footer_business_links(language=settings.LANGUAGE_CODE):
     """Return the business links to display in the footer. """
     platform_name = configuration_helpers.get_value('platform_name', settings.PLATFORM_NAME)
+    links = [
+        ("about", (marketing_link("ABOUT"), _("About"))),
+        ("enterprise", (marketing_link("ENTERPRISE"),
+         _("{platform_name} for Business").format(platform_name=platform_name))),
+        ("news", (marketing_link("NEWS"), _("News"))),
+    ]
+
+    if language == settings.LANGUAGE_CODE:
+        links.insert(_find_position_of_link(links, 'enterprise'),
+                     ('affiliates', (marketing_link("AFFILIATES"), _("Affiliates"))))
+        links.insert(_find_position_of_link(links, 'affiliates'),
+                     ('openedx', (_footer_openedx_link()["url"], _("Open edX"))))
+        links.insert(_find_position_of_link(links, 'openedx'),
+                     ('careers', (marketing_link("CAREERS"), _("Careers"))))
 
     return [
         {
@@ -259,28 +291,19 @@ def _footer_business_links():
             "title": link_title,
             "url": link_url,
         }
-        for link_name, link_url, link_title in [
-            ("about", marketing_link("ABOUT"), _("About")),
-            ("enterprise", marketing_link("ENTERPRISE"),
-             _(u"{platform_name} for Business").format(platform_name=platform_name)),
-            ("affiliates", marketing_link("AFFILIATES"), _("Affiliates")),
-            ("openedx", _footer_openedx_link()["url"], _("Open edX")),
-            ("careers", marketing_link("CAREERS"), _("Careers")),
-            ("news", marketing_link("NEWS"), _("News")),
-        ]
+        for link_name, (link_url, link_title) in links
         if link_url and link_url != "#"
     ]
 
 
-def _footer_more_info_links():
+def _footer_more_info_links(language=settings.LANGUAGE_CODE):
     """Return the More Information footer links (e.g. terms of service). """
 
     links = [
-        ("terms_of_service_and_honor_code", marketing_link("TOS_AND_HONOR"), _("Terms of Service & Honor Code")),
-        ("privacy_policy", marketing_link("PRIVACY"), _("Privacy Policy")),
-        ("accessibility_policy", marketing_link("ACCESSIBILITY"), _("Accessibility Policy")),
-        ("trademarks", marketing_link("TRADEMARKS"), _("Trademark Policy")),
-        ("sitemap", marketing_link("SITE_MAP"), _("Sitemap")),
+        ("terms_of_service_and_honor_code", (marketing_link("TOS_AND_HONOR"), _("Terms of Service & Honor Code"))),
+        ("privacy_policy", (marketing_link("PRIVACY"), _("Privacy Policy"))),
+        ("accessibility_policy", (marketing_link("ACCESSIBILITY"), _("Accessibility Policy"))),
+        ("sitemap", (marketing_link("SITE_MAP"), _("Sitemap"))),
     ]
 
     # Backwards compatibility: If a combined "terms of service and honor code"
@@ -288,9 +311,13 @@ def _footer_more_info_links():
     tos_and_honor_link = marketing_link("TOS_AND_HONOR")
     if not (tos_and_honor_link and tos_and_honor_link != "#"):
         links.extend([
-            ("terms_of_service", marketing_link("TOS"), _("Terms of Service")),
-            ("honor_code", marketing_link("HONOR"), _("Honor Code")),
+            ("terms_of_service", (marketing_link("TOS"), _("Terms of Service"))),
+            ("honor_code", (marketing_link("HONOR"), _("Honor Code"))),
         ])
+
+    if language == settings.LANGUAGE_CODE:
+        position = _find_position_of_link(links, 'accessibility_policy')
+        links.insert(position, ("trademarks", (marketing_link("TRADEMARKS"), _("Trademark Policy"))))
 
     return [
         {
@@ -298,7 +325,7 @@ def _footer_more_info_links():
             "title": link_title,
             "url": link_url,
         }
-        for link_name, link_url, link_title in links
+        for link_name, (link_url, link_title) in links
         if link_url and link_url != "#"
     ]
 

--- a/lms/djangoapps/branding/views.py
+++ b/lms/djangoapps/branding/views.py
@@ -123,7 +123,7 @@ def _footer_css_urls(request, package_name):
     ]
 
 
-def _render_footer_html(request, show_openedx_logo, include_dependencies, include_language_selector):
+def _render_footer_html(request, show_openedx_logo, include_dependencies, include_language_selector, language):
     """Render the footer as HTML.
 
     Arguments:
@@ -143,7 +143,8 @@ def _render_footer_html(request, show_openedx_logo, include_dependencies, includ
         'footer_css_urls': _footer_css_urls(request, css_name),
         'bidi': bidi,
         'include_dependencies': include_dependencies,
-        'include_language_selector': include_language_selector
+        'include_language_selector': include_language_selector,
+        'language': language
     }
 
     return render_to_response("footer.html", context)
@@ -288,7 +289,7 @@ def footer(request):
         if content is None:
             with translation.override(language):
                 content = _render_footer_html(
-                    request, show_openedx_logo, include_dependencies, include_language_selector
+                    request, show_openedx_logo, include_dependencies, include_language_selector, language
                 )
                 cache.set(cache_key, content, settings.FOOTER_CACHE_TIMEOUT)
         return HttpResponse(content, status=200, content_type="text/html; charset=utf-8")

--- a/themes/edx.org/lms/templates/footer.html
+++ b/themes/edx.org/lms/templates/footer.html
@@ -1,4 +1,5 @@
 ## mako
+<%page expression_filter="h"/>
 <%!
   import datetime
 
@@ -6,7 +7,7 @@
   from branding.api import get_footer
   from openedx.core.djangoapps.lang_pref.api import footer_language_selector_is_enabled
 %>
-<% footer = get_footer(is_secure=is_secure) %>
+<% footer = get_footer(is_secure=is_secure, language=language) %>
 <%namespace name='static' file='static_content.html'/>
 
 
@@ -152,7 +153,6 @@
 
 
 </div>
-
 
 </footer>
 


### PR DESCRIPTION
### Description

[LEARNER-6981](https://openedx.atlassian.net/browse/LEARNER-6981)

Currently, spanish website's main page has links in footer whose pages are still un-translated.In this PR, links of them are removed so that user-experience should be improved.