### PR TITLE
More fixes for Python 3 via tox

### DIFF
--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -8,6 +8,9 @@
 # pin when possible.  Writing an issue against the offending project and
 # linking to it here is good.
 
+# functools32 is a backport which can only be installed on Python 2.7
+functools32 ; python_version == "2.7"
+
 # six is at 1.12.0, but transifex-client requires ==1.11.0
 # https://github.com/transifex/transifex-client/issues/252
 six==1.11.0

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -170,7 +170,7 @@ freezegun==0.3.11
 fs-s3fs==0.1.8
 fs==2.0.18
 funcsigs==1.0.2
-functools32==3.2.3.post2
+functools32==3.2.3.post2 ; python_version == "2.7"
 future==0.17.1
 futures==3.2.0 ; python_version == "2.7"
 fuzzywuzzy==0.17.0

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -164,7 +164,7 @@ freezegun==0.3.11
 fs-s3fs==0.1.8
 fs==2.0.18
 funcsigs==1.0.2           # via pytest
-functools32==3.2.3.post2  # via flake8, parsel
+functools32==3.2.3.post2 ; python_version == "2.7"  # via flake8, parsel
 future==0.17.1
 futures==3.2.0 ; python_version == "2.7"
 fuzzywuzzy==0.17.0

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{27,35}-django{18,19,110,111}
+envlist = py{27,35,36,37}-django{111,20,21}
 
 # This is needed to prevent the lms, cms, and openedx packages inside the "Open
 # edX" package (defined in setup.py) from getting installed into site-packages
@@ -54,10 +54,9 @@ passenv =
     XDIST_NUM_TASKS
     XDIST_REMOTE_NUM_PROCESSES
 deps =
-    django18: Django>=1.8,<1.9
-    django19: Django>=1.9,<1.10
-    django110: Django>=1.10,<1.11
     django111: Django>=1.11,<2
+    django20: Django>=2.0,<2.1
+    django21: Django>=2.1,<2.2
     -r requirements/edx/testing.txt
 whitelist_externals =
     /bin/bash


### PR DESCRIPTION
Only install the functools32 package on Python 2.7, as it isn't needed (and doesn't install cleanly) under Python 3.  Also:

* Drop support for testing no-longer-supported Django versions
* Add support for testing newer Django and Python versions