### PR TITLE
ENT-1481: Update final copy recovery feature copy

### DIFF
--- a/common/djangoapps/student/message_types.py
+++ b/common/djangoapps/student/message_types.py
@@ -24,3 +24,10 @@ class EmailChange(BaseMessageType):
         super(EmailChange, self).__init__(*args, **kwargs)
 
         self.options['transactional'] = True
+
+
+class RecoveryEmailCreate(BaseMessageType):
+    def __init__(self, *args, **kwargs):
+        super(RecoveryEmailCreate, self).__init__(*args, **kwargs)
+
+        self.options['transactional'] = True

--- a/common/djangoapps/student/tests/test_email.py
+++ b/common/djangoapps/student/tests/test_email.py
@@ -653,18 +653,15 @@ class SecondaryEmailChangeRequestTests(EventTestMixin, EmailTemplateTagMixin, Ca
         self.do_secondary_email_change(self.user, new_email, registration_key)
 
         self._assert_email(
-            subject=u'Request to change édX account secondary e-mail',
+            subject=u'Confirm your recovery email for édX',
             body_fragments=[
-                u'We received a request to change the secondary e-mail associated with',
-                u'your édX account to {new_email}.'.format(
+                u'You\'ve registered this recovery email address for édX.'.format(
                     new_email=new_email,
                 ),
-                u'If this is correct, please confirm your new secondary e-mail address by visiting:',
+                u'If you set this email address, click "confirm email."',
+                u'If you didn\'t request this change, you can disregard this email.',
                 u'http://edx.org/activate_secondary_email/{key}'.format(key=registration_key),
-                u'If you didn\'t request this, you don\'t need to do anything;',
-                u'you won\'t receive any more email from us.',
-                u'Please do not reply to this e-mail; if you require assistance,',
-                u'check the help section of the édX web site.',
+
             ],
         )
 

--- a/common/templates/student/edx_ace/accountrecovery/email/body.html
+++ b/common/templates/student/edx_ace/accountrecovery/email/body.html
@@ -15,12 +15,12 @@
             </p>
 
             <p style="color: rgba(0,0,0,.75);">
-                {% trans "We've restored access to your edX account using the recovery email you provided at registration." %}
+                {% blocktrans %}We've restored access to your {{ platform_name }} account using the recovery email you provided at registration.{% endblocktrans %}
                 <br />
             </p>
 
             <p style="color: rgba(0,0,0,.75);">
-                {% blocktrans %}Once you've created a password [below], you will be able to log in to edX with this email ({{ email }}) and your new password.{% endblocktrans %}
+                {% blocktrans %}Once you've created a password [below], you will be able to log in to {{ platform_name }} with this email ({{ email }}) and your new password.{% endblocktrans %}
                 <br />
             </p>
 

--- a/common/templates/student/edx_ace/accountrecovery/email/body.txt
+++ b/common/templates/student/edx_ace/accountrecovery/email/body.txt
@@ -1,9 +1,9 @@
 {% load i18n %}{% autoescape off %}
 {% blocktrans %}You're receiving this e-mail because you requested to create a password for your user account at {{ platform_name }}.{% endblocktrans %}
 
-{% trans "We've restored access to your edX account using the recovery email you provided at registration." %}
+{% blocktrans %}We've restored access to your {{ platform_name }} account using the recovery email you provided at registration.{% endblocktrans %}
 
-{% blocktrans %}Once you've created a password [below], you will be able to log in to edX with this email ({{ email }}) and your new password.{% endblocktrans %}
+{% blocktrans %}Once you've created a password [below], you will be able to log in to {{ platform_name }} with this email ({{ email }}) and your new password.{% endblocktrans %}
 
 {% trans "If you didn't request this change, you can disregard this email - we have not yet reset your password." %}
 

--- a/common/templates/student/edx_ace/emailchange/email/body.html
+++ b/common/templates/student/edx_ace/emailchange/email/body.html
@@ -10,11 +10,7 @@
                 {% trans "Email Change" %}
             </h1>
             <p style="color: rgba(0,0,0,.75);">
-                {% if is_secondary_email_change_request %}
-                    {% blocktrans %}We received a request to change the secondary e-mail associated with your {{ platform_name }} account to {{ new_email }}. If this is correct, please confirm your new secondary e-mail address by visiting:{% endblocktrans %}
-                {% else %}
-                    {% blocktrans %}We received a request to change the e-mail associated with your {{ platform_name }} account from {{ old_email }} to {{ new_email }}. If this is correct, please confirm your new e-mail address by visiting:{% endblocktrans %}
-                {% endif %}
+                {% blocktrans %}We received a request to change the e-mail associated with your {{ platform_name }} account from {{ old_email }} to {{ new_email }}. If this is correct, please confirm your new e-mail address by visiting:{% endblocktrans %}
                 <br />
             </p>
 

--- a/common/templates/student/edx_ace/emailchange/email/body.txt
+++ b/common/templates/student/edx_ace/emailchange/email/body.txt
@@ -1,9 +1,5 @@
 {% load i18n %}{% autoescape off %}
-{% if is_secondary_email_change_request %}
-    {% blocktrans %}We received a request to change the secondary e-mail associated with your {{ platform_name }} account to {{ new_email }}. If this is correct, please confirm your new secondary e-mail address by visiting:{% endblocktrans %}
-{% else %}
-    {% blocktrans %}We received a request to change the e-mail associated with your {{ platform_name }} account from {{ old_email }} to {{ new_email }}. If this is correct, please confirm your new e-mail address by visiting:{% endblocktrans %}
-{% endif %}
+{% blocktrans %}We received a request to change the e-mail associated with your {{ platform_name }} account from {{ old_email }} to {{ new_email }}. If this is correct, please confirm your new e-mail address by visiting:{% endblocktrans %}
 
 {{ confirm_link }}
 

--- a/common/templates/student/edx_ace/emailchange/email/subject.txt
+++ b/common/templates/student/edx_ace/emailchange/email/subject.txt
@@ -1,8 +1,4 @@
 {% load i18n %}
 {% autoescape off %}
-{% if is_secondary_email_change_request %}
-    {% blocktrans trimmed %}Request to change {{ platform_name }} account secondary e-mail{% endblocktrans %}
-{% else %}
-    {% blocktrans trimmed %}Request to change {{ platform_name }} account e-mail{% endblocktrans %}
-{% endif %}
+{% blocktrans trimmed %}Request to change {{ platform_name }} account e-mail{% endblocktrans %}
 {% endautoescape %}

--- a/common/templates/student/edx_ace/recoveryemailcreate/email/body.html
+++ b/common/templates/student/edx_ace/recoveryemailcreate/email/body.html
@@ -1,0 +1,25 @@
+{% extends 'ace_common/edx_ace/common/base_body.html' %}
+
+{% load i18n %}
+{% load static %}
+{% block content %}
+<table width="100%" align="left" border="0" cellpadding="0" cellspacing="0" role="presentation">
+    <tr>
+        <td>
+            <h1>
+                {% trans "Create Recovery Email" %}
+            </h1>
+            <p style="color: rgba(0,0,0,.75);">
+                {% blocktrans %}You've registered this recovery email address for {{ platform_name }}.{% endblocktrans %}
+                <br/>
+                {% blocktrans %}If you set this email address, click "confirm email."  If you didn't request this change, you can disregard this email.{% endblocktrans %}
+                <br />
+            </p>
+
+            {% trans "Confirm Email" as course_cta_text %}
+            {% include "ace_common/edx_ace/common/return_to_course_cta.html" with course_cta_text=course_cta_text course_cta_url=confirm_link %}
+
+        </td>
+    </tr>
+</table>
+{% endblock %}

--- a/common/templates/student/edx_ace/recoveryemailcreate/email/body.txt
+++ b/common/templates/student/edx_ace/recoveryemailcreate/email/body.txt
@@ -1,0 +1,8 @@
+{% load i18n %}{% autoescape off %}
+{% blocktrans %}You've registered this recovery email address for {{ platform_name }}.{% endblocktrans %}
+
+{% blocktrans %}If you set this email address, click "confirm email."  If you didn't request this change, you can disregard this email.{% endblocktrans %}
+
+{{ confirm_link }}
+
+{% endautoescape %}

--- a/common/templates/student/edx_ace/recoveryemailcreate/email/from_name.txt
+++ b/common/templates/student/edx_ace/recoveryemailcreate/email/from_name.txt
@@ -1,0 +1,1 @@
+{{ platform_name }}

--- a/common/templates/student/edx_ace/recoveryemailcreate/email/head.html
+++ b/common/templates/student/edx_ace/recoveryemailcreate/email/head.html
@@ -1,0 +1,1 @@
+{% extends 'ace_common/edx_ace/common/base_head.html' %}

--- a/common/templates/student/edx_ace/recoveryemailcreate/email/subject.txt
+++ b/common/templates/student/edx_ace/recoveryemailcreate/email/subject.txt
@@ -1,0 +1,4 @@
+{% load i18n %}
+{% autoescape off %}
+{% blocktrans trimmed %}Confirm your recovery email for {{ platform_name }} {% endblocktrans %}
+{% endautoescape %}

--- a/lms/static/js/student_account/views/account_settings_factory.js
+++ b/lms/static/js/student_account/views/account_settings_factory.js
@@ -90,7 +90,7 @@
                 model: userAccountModel,
                 title: gettext('Recovery Email Address'),
                 valueAttribute: 'secondary_email',
-                helpMessage: gettext('You may access your account when single-sign on is not available.'),
+                helpMessage: gettext('You may access your account with this address if single-sign on or access to your primary email is not available.'),  // eslint-disable-line max-len
                 persistChanges: true
             };
 

--- a/lms/templates/student_account/password_reset.underscore
+++ b/lms/templates/student_account/password_reset.underscore
@@ -5,7 +5,7 @@
 
 <form id="password-reset" class="password-reset-form" tabindex="-1" method="POST">
 
-    <p class="action-label"><%- gettext("Please enter your registration or recovery email address below and we will send you an email with instructions.") %></p>
+    <p class="action-label"><%- gettext("Please enter your log-in or recovery email address below and we will send you an email with instructions.") %></p>
 
     <%= HtmlUtils.HTML(fields) %>
 


### PR DESCRIPTION
**JIRA:** [ENT-1481](https://openedx.atlassian.net/browse/ENT-1481)

**Description:**
Update final wording copy, specifically the following:

1. Change subtext on the Account settings page to "You may access your account with this address if single-sign or access to your primary email is not available."
2. Confirmation email for recovery address 
3. Password assistance screen - update subtext to "Please enter your log-in or recovery email address below and we will send you an email with instructions." (change is replacing 'registration' with 'log-in')
4. Create password email template - update 2nd paragraph of subtext to "We’ve restored access to your edX account using the recovery email you provided on your account settings page."

**Testing Instructions:**
**Note:** use `staff` user to log in as it has the appropriate permissions to go through the entire flow for account recovery.

1. Go to the [Account Setting Page](https://business.sandbox.edx.org/account/settings), make sure the text next to the `Recover Address` field is in accordance with the description above.
2. Update the Recovery email address and make sure updated email content is present in the email sent to the new address.
3. Logout and visit login page and click on `Need help logging in?`, make sure help text is updated according to the description above.
4. Add the recovery email address in the field (The one you set in step 2) and make sure the email sent to the recovery email address has content updated according to the description above.