### PR TITLE
DEPR-9 Remove dependency on dogapi

### DIFF
--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -8,8 +8,9 @@
 # pin when possible.  Writing an issue against the offending project and
 # linking to it here is good.
 
-# functools32 is a backport which can only be installed on Python 2.7
+# These packages are backports which can only be installed on Python 2.7
 functools32 ; python_version == "2.7"
+futures ; python_version == "2.7"
 
 # six is at 1.12.0, but transifex-client requires ==1.11.0
 # https://github.com/transifex/transifex-client/issues/252
@@ -25,7 +26,7 @@ pylint-plugin-utils==0.3
 # Browser driver used by lettuce - pinned because splinter==0.10.0 breaks lettuce tests.  EDUCATOR-3795
 splinter==0.9.0
 
-# transifex-client 0.13.5 requires urllib3<1.24, but requests will pull in urllib3==1.24 (https://github.com/transifex/transifex-client/pull/241/files)
+# transifex-client 0.13.6 requires urllib3<1.24, but requests will pull in urllib3==1.24 (https://github.com/transifex/transifex-client/pull/241/files)
 urllib3<1.24
 
 # Bumping requests-oauthlib to 1.2 updates oauthlib to 3.0.0, which changes a response code in certain cases

--- a/requirements/edx-sandbox/base.txt
+++ b/requirements/edx-sandbox/base.txt
@@ -13,7 +13,7 @@ backports-abc==0.5        # via tornado
 cffi==1.11.5
 cryptography==2.5
 enum34==1.1.6
-futures==3.2.0            # via tornado
+futures==3.2.0 ; python_version == "2.7"  # via tornado
 ipaddress==1.0.22
 lxml==3.8.0
 markupsafe==1.1.0

--- a/requirements/edx/base.in
+++ b/requirements/edx/base.in
@@ -65,7 +65,6 @@ django-user-tasks
 django-waffle==0.12.0
 django-webpack-loader               # Used to wire webpack bundles into the django asset pipeline
 djangorestframework-jwt
-dogapi==1.2.1                       # Python bindings to Datadog's API, for metrics gathering
 edx-ace==0.1.10
 edx-analytics-data-api-client
 edx-ccx-keys
@@ -93,7 +92,6 @@ feedparser==5.1.3
 firebase-token-generator==1.3.2
 fs==2.0.18
 fs-s3fs==0.1.8
-futures ; python_version == "2.7"   # via django-pipeline, python-swift-client, s3transfer
 glob2                               # Enhanced glob module, used in openedx.core.lib.rooted_paths
 gunicorn==19.0
 help-tokens

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -65,7 +65,7 @@ coreschema==0.0.4         # via coreapi
 cryptography==2.5
 cssutils==1.0.2           # via pynliner
 ddt==1.2.0
-decorator==4.3.2          # via dogapi, pycontracts
+decorator==4.3.2          # via pycontracts
 defusedxml==0.5.0
 django-appconf==1.0.2     # via django-statici18n
 django-babel-underscore==0.5.2
@@ -105,7 +105,6 @@ djangorestframework-jwt==1.11.0
 djangorestframework-xml==1.3.0  # via edx-enterprise
 docopt==0.6.2
 docutils==0.14            # via botocore
-dogapi==1.2.1
 edx-ace==0.1.10
 edx-analytics-data-api-client==0.15.2
 edx-ccx-keys==0.2.1
@@ -137,7 +136,7 @@ firebase-token-generator==1.3.2
 fs-s3fs==0.1.8
 fs==2.0.18
 future==0.17.1            # via pyjwkest
-futures==3.2.0 ; python_version == "2.7"
+futures==3.2.0 ; python_version == "2.7"  # via python-swiftclient, s3transfer, xblock-utils
 glob2==0.6
 gunicorn==19.0
 hash-ring==1.3.1          # via django-memcached-hashring
@@ -220,7 +219,7 @@ scipy==0.14.0
 semantic-version==2.6.0   # via edx-drf-extensions
 shapely==1.2.16
 shortuuid==0.5.0          # via edx-django-oauth2-provider
-simplejson==3.16.0        # via django-rest-swagger, dogapi, mailsnake, sailthru-client, zendesk
+simplejson==3.16.0        # via django-rest-swagger, mailsnake, sailthru-client, zendesk
 singledispatch==3.4.0.3
 six==1.11.0
 slumber==0.7.1            # via edx-rest-api-client

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -125,7 +125,6 @@ djangorestframework-jwt==1.11.0
 djangorestframework-xml==1.3.0
 docopt==0.6.2
 docutils==0.14
-dogapi==1.2.1
 edx-ace==0.1.10
 edx-analytics-data-api-client==0.15.2
 edx-ccx-keys==0.2.1

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -120,7 +120,6 @@ djangorestframework-jwt==1.11.0
 djangorestframework-xml==1.3.0
 docopt==0.6.2
 docutils==0.14
-dogapi==1.2.1
 edx-ace==0.1.10
 edx-analytics-data-api-client==0.15.2
 edx-ccx-keys==0.2.1


### PR DESCRIPTION
Now that we no longer use dogapi to send information to DataDog, remove the dependency on the package.  Also made a fix to ensure that the `futures` backport package isn't installed under Python 3.