### PR TITLE
Don't break exports for uninstalled XBlock content

### DIFF
--- a/common/lib/xmodule/xmodule/xml_module.py
+++ b/common/lib/xmodule/xmodule/xml_module.py
@@ -429,6 +429,12 @@ class XmlParserMixin(object):
         """
         # Get the definition
         xml_object = self.definition_to_xml(self.runtime.export_fs)
+
+        # If xml_object is None, we don't know how to serialize this node, but
+        # we shouldn't crash out the whole export for it.
+        if xml_object is None:
+            return
+
         for aside in self.runtime.get_asides(self):
             if aside.needs_serialization():
                 aside_node = etree.Element("unknown_root", nsmap=XML_NAMESPACES)


### PR DESCRIPTION
When an unknown content type is encountered, it's imported as a RawDescriptor, which will preserve the OLX and export it back out. But if we import a course while an XBlock is installed and then export it
after that XBlock is removed, we export RawDescriptors that never got to save the original OLX and have a blank "data" field. Attempting to export this used to fail and break export altogether. We now test that the export continues to complete, and just skips over anything it can't serialize out.