### PR TITLE
Account API: Support Per-field Visibility

### DIFF
--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -2962,52 +2962,45 @@ ACCOUNT_VISIBILITY_CONFIGURATION = {
     # The value is one of: 'all_users', 'private'
     "default_visibility": "all_users",
 
-    # The list of all fields that can be shared with other users
-    "shareable_fields": [
-        'username',
-        'profile_image',
-        'country',
-        'time_zone',
-        'date_joined',
-        'language_proficiencies',
-        'bio',
-        'social_links',
-        'account_privacy',
-        # Not an actual field, but used to signal whether badges should be public.
-        'accomplishments_shared',
-    ],
-
     # The list of account fields that are always public
     "public_fields": [
-        'username',
-        'profile_image',
         'account_privacy',
+        'profile_image',
+        'username',
     ],
+}
 
-    # The list of account fields that are visible only to staff and users viewing their own profiles
-    "admin_fields": [
-        "username",
+# The list of all fields that can be shared with other users
+ACCOUNT_VISIBILITY_CONFIGURATION["shareable_fields"] = (
+    ACCOUNT_VISIBILITY_CONFIGURATION["public_fields"] + [
+        'bio',
+        'country',
+        'date_joined',
+        'language_proficiencies',
+        "level_of_education",
+        'social_links',
+        'time_zone',
+
+        # Not an actual field, but used to signal whether badges should be public.
+        'accomplishments_shared',
+    ]
+)
+
+# The list of account fields that are visible only to staff and users viewing their own profiles
+ACCOUNT_VISIBILITY_CONFIGURATION["admin_fields"] = (
+    ACCOUNT_VISIBILITY_CONFIGURATION["shareable_fields"] + [
         "email",
-        "is_active",
-        "bio",
-        "country",
-        "date_joined",
-        "profile_image",
-        "language_proficiencies",
-        "social_links",
-        "name",
+        "extended_profile",
         "gender",
         "goals",
-        "year_of_birth",
-        "level_of_education",
+        "is_active",
         "mailing_address",
+        "name",
         "requires_parental_consent",
-        "account_privacy",
-        "accomplishments_shared",
-        "extended_profile",
         "secondary_email",
+        "year_of_birth",
     ]
-}
+)
 
 # The current list of social platforms to be shown to the user.
 #

--- a/openedx/core/djangoapps/user_api/accounts/__init__.py
+++ b/openedx/core/djangoapps/user_api/accounts/__init__.py
@@ -26,6 +26,12 @@ ALL_USERS_VISIBILITY = 'all_users'
 # Indicates the user's preference that all their account information be private.
 PRIVATE_VISIBILITY = 'private'
 
+# Indicates that the user has custom preferences for the visibility of their account information.
+CUSTOM_VISIBILITY = 'custom'
+
+# Prefix prepended to user preferences related to custom account visibility preferences.
+VISIBILITY_PREFIX = 'visibility.'
+
 # Translators: This message is shown when the Unicode usernames are NOT allowed.
 # It is shown to users who attempt to create a new account using invalid characters
 # in the username.

--- a/openedx/core/djangoapps/user_api/accounts/tests/test_api.py
+++ b/openedx/core/djangoapps/user_api/accounts/tests/test_api.py
@@ -425,7 +425,8 @@ class AccountSettingsOnCreationTest(TestCase):
             'account_privacy': PRIVATE_VISIBILITY,
             'accomplishments_shared': False,
             'extended_profile': [],
-            'secondary_email': None
+            'secondary_email': None,
+            'time_zone': None,
         })
 
     def test_normalize_password(self):

--- a/openedx/core/djangoapps/user_api/accounts/views.py
+++ b/openedx/core/djangoapps/user_api/accounts/views.py
@@ -212,8 +212,12 @@ class AccountViewSet(ViewSet):
 
             * username: The username associated with the account.
             * year_of_birth: The year the user was born, as an integer, or null.
+
             * account_privacy: The user's setting for sharing her personal
-              profile. Possible values are "all_users" or "private".
+              profile. Possible values are "all_users", "private", or "custom".
+              If "custom", the user has selectively chosen a subset of shareable
+              fields to make visible to others via the User Preferences API.
+
             * accomplishments_shared: Signals whether badges are enabled on the
               platform and should be fetched.
 
@@ -223,7 +227,7 @@ class AccountViewSet(ViewSet):
 
             If a user who does not have "is_staff" access requests account
             information for a different user, only a subset of these fields is
-            returned. The returns fields depend on the
+            returned. The returned fields depend on the
             ACCOUNT_VISIBILITY_CONFIGURATION configuration setting and the
             visibility preference of the user for whom data is requested.
 


### PR DESCRIPTION
This PR updates the "visibility" capabilities of Account settings as follows:
* Refactors the declaration of `ACCOUNT_VISIBILITY_CONFIGURATION` in `common.py` in order to clarify which fields are always public, allowed to be shared, and always private.
* Adds support for "custom" visibility preferences, allowing the user to selectively choose a subset of the _shareable_ fields to be actually shared.
* Use the User Preferences API to manage the account privacy setting and the specific fields to share/keep-private.
* Here's an example jquery call for setting custom visibility:
```
$.ajax({  
    type: "PATCH",
    url: "http://localhost:18000/api/user/v1/preferences/edx",
    data: JSON.stringify({
        "account_privacy": "custom",
        "visibility.bio": "all_users",
        "visibility.country": "private",
        "visibility.language_proficiencies": "all_users"
    }),
    dataType: 'json',
    contentType: 'application/merge-patch+json'
})
```