### PR TITLE
Make Unit URLs Easier to Share

### DIFF
--- a/common/lib/xmodule/xmodule/js/fixtures/sequence.html
+++ b/common/lib/xmodule/xmodule/js/fixtures/sequence.html
@@ -27,6 +27,14 @@
               <div class="sequence-tooltip sr"><span class="sr">problem</span>Unit 102<span class="sr bookmark-icon-sr"></span></div>
             </button>
           </li>
+          <li role="presentation">
+            <button role="tab" tabindex="-1" aria-selected="true" aria-expanded="true" aria-controls="seq_content" class="seq_problem inactive nav-item tab" data-index="2" data-id="block-v1:edX+DemoX+Demo_Course+type@vertical+block@fb79dcbad35b466a8c6364f8ffee9052" data-element="3" data-page-title="Unit 103" data-path="Example Week 2: Get Interactive > Homework - Part 1 > Unit 103" id="tab_2">
+              <span class="icon fa seq_problem" aria-hidden="true"></span>
+              <span class="fa fa-fw fa-bookmark bookmark-icon is-hidden" aria-hidden="true"></span>
+              <span class="fa fa-check-circle check-circle is-hidden" style="color:green" aria-hidden="true">
+              <div class="sequence-tooltip sr"><span class="sr">problem</span>Unit 102<span class="sr bookmark-icon-sr"></span></div>
+            </button>
+          </li>
         </ol>
       </nav>
     </div>

--- a/common/lib/xmodule/xmodule/js/spec/sequence/display_spec.js
+++ b/common/lib/xmodule/xmodule/js/spec/sequence/display_spec.js
@@ -9,12 +9,27 @@
                 ENTER: 13,
                 LEFT: 37,
                 RIGHT: 39
-            };
+            },
+            origin = 'https://www.example.com/',
+            pathname = 'courses/course-v1:edX+DemoX+Demo_Course/courseware/unit_id/title/',
+            unit,
+            position,
+            updateBrowserUrl;
 
         beforeEach(function() {
             loadFixtures('sequence.html');
             local.XBlock = window.XBlock = jasmine.createSpyObj('XBlock', ['initializeBlocks']);
             this.sequence = new Sequence($('.xblock-student_view-sequential'));
+
+            spyOn(this.sequence, 'getUrlParts').and.callFake(function() {
+                return [origin, pathname];
+            });
+
+            spyOn(this.sequence, 'determineBrowserUrl').and.callThrough();
+
+            spyOn(this.sequence, 'previousNav').and.callThrough();
+
+            spyOn(this.sequence, 'nextNav').and.callThrough();
         });
 
         afterEach(function() {
@@ -28,7 +43,47 @@
             document.dispatchEvent(event);
         };
 
+        updateBrowserUrl = function(sequence, position) {
+            var urlParts = sequence.getUrlParts();
+            var newUrl = sequence.determineBrowserUrl(urlParts[0], urlParts[1], position);
+            return newUrl;
+        };
+        
         describe('Navbar', function() {
+            it('appends the unit number in URL on page load', function() {
+                unit = this.sequence.$('.nav-item[data-index=0]').focus();
+                position = unit.data('element');
+                expect(updateBrowserUrl(this.sequence, position)).toBe(origin + pathname + '1');
+            });
+
+            it('updates the unit number in URL when going to the previous unit', function() {
+                unit = this.sequence.$('.nav-item[data-index=1]').focus();
+                this.sequence.previousNav(unit, unit.data('index'));
+                position = this.sequence.$('.nav-item.focused').data('element');
+                expect(updateBrowserUrl(this.sequence, position)).toBe(origin + pathname + '1');
+            });
+
+            it('updates the unit number in URL when going to the next unit', function() {
+                unit = this.sequence.$('.nav-item[data-index=1]').focus();
+                this.sequence.nextNav(unit, unit.data('index'), this.sequence.$('.nav-item').length-1);
+                position = this.sequence.$('.nav-item.focused').data('element');
+                expect(updateBrowserUrl(this.sequence, position)).toBe(origin + pathname + '3');
+            });
+
+            it('updates the unit number in URL when jumping to the last unit in the previous section', function() {
+                unit = this.sequence.$('.nav-item[data-index=0]').focus();
+                this.sequence.previousNav(unit, unit.data('index'));
+                position = this.sequence.$('.nav-item.focused').data('element');
+                expect(updateBrowserUrl(this.sequence, position)).toBe(origin + pathname + '3');
+            });
+
+            it('updates the unit number in URL when jumping to the first unit in the next section', function() {
+                unit = this.sequence.$('.nav-item[data-index=2]').focus();
+                this.sequence.nextNav(unit, unit.data('index'), this.sequence.$('.nav-item').length-1);
+                position = this.sequence.$('.nav-item.focused').data('element');
+                expect(updateBrowserUrl(this.sequence, position)).toBe(origin + pathname + '1');
+            });
+
             it('works with keyboard navigation LEFT and ENTER', function() {
                 this.sequence.$('.nav-item[data-index=0]').focus();
                 keydownHandler(keys.LEFT);

--- a/common/lib/xmodule/xmodule/js/spec/sequence/display_spec.js
+++ b/common/lib/xmodule/xmodule/js/spec/sequence/display_spec.js
@@ -12,6 +12,7 @@
             },
             origin = 'https://www.example.com/',
             pathname = 'courses/course-v1:edX+DemoX+Demo_Course/courseware/unit_id/title/',
+            search = '?activate_block_id=block-v1%3ATesting',
             unit,
             position,
             updateBrowserUrl;
@@ -22,7 +23,7 @@
             this.sequence = new Sequence($('.xblock-student_view-sequential'));
 
             spyOn(this.sequence, 'getUrlParts').and.callFake(function() {
-                return [origin, pathname];
+                return [origin, pathname, search];
             });
 
             spyOn(this.sequence, 'determineBrowserUrl').and.callThrough();
@@ -45,43 +46,43 @@
 
         updateBrowserUrl = function(sequence, position) {
             var urlParts = sequence.getUrlParts();
-            var newUrl = sequence.determineBrowserUrl(urlParts[0], urlParts[1], position);
+            var newUrl = sequence.determineBrowserUrl(urlParts[0], urlParts[1], urlParts[2], position);
             return newUrl;
         };
-        
+
         describe('Navbar', function() {
             it('appends the unit number in URL on page load', function() {
                 unit = this.sequence.$('.nav-item[data-index=0]').focus();
                 position = unit.data('element');
-                expect(updateBrowserUrl(this.sequence, position)).toBe(origin + pathname + '1');
+                expect(updateBrowserUrl(this.sequence, position)).toBe(origin + pathname + '1' + search);
             });
 
             it('updates the unit number in URL when going to the previous unit', function() {
                 unit = this.sequence.$('.nav-item[data-index=1]').focus();
                 this.sequence.previousNav(unit, unit.data('index'));
                 position = this.sequence.$('.nav-item.focused').data('element');
-                expect(updateBrowserUrl(this.sequence, position)).toBe(origin + pathname + '1');
+                expect(updateBrowserUrl(this.sequence, position)).toBe(origin + pathname + '1' + search);
             });
 
             it('updates the unit number in URL when going to the next unit', function() {
                 unit = this.sequence.$('.nav-item[data-index=1]').focus();
                 this.sequence.nextNav(unit, unit.data('index'), this.sequence.$('.nav-item').length-1);
                 position = this.sequence.$('.nav-item.focused').data('element');
-                expect(updateBrowserUrl(this.sequence, position)).toBe(origin + pathname + '3');
+                expect(updateBrowserUrl(this.sequence, position)).toBe(origin + pathname + '3' + search);
             });
 
             it('updates the unit number in URL when jumping to the last unit in the previous section', function() {
                 unit = this.sequence.$('.nav-item[data-index=0]').focus();
                 this.sequence.previousNav(unit, unit.data('index'));
                 position = this.sequence.$('.nav-item.focused').data('element');
-                expect(updateBrowserUrl(this.sequence, position)).toBe(origin + pathname + '3');
+                expect(updateBrowserUrl(this.sequence, position)).toBe(origin + pathname + '3' + search);
             });
 
             it('updates the unit number in URL when jumping to the first unit in the next section', function() {
                 unit = this.sequence.$('.nav-item[data-index=2]').focus();
                 this.sequence.nextNav(unit, unit.data('index'), this.sequence.$('.nav-item').length-1);
                 position = this.sequence.$('.nav-item.focused').data('element');
-                expect(updateBrowserUrl(this.sequence, position)).toBe(origin + pathname + '1');
+                expect(updateBrowserUrl(this.sequence, position)).toBe(origin + pathname + '1' + search);
             });
 
             it('works with keyboard navigation LEFT and ENTER', function() {

--- a/common/lib/xmodule/xmodule/js/src/sequence/display.js
+++ b/common/lib/xmodule/xmodule/js/src/sequence/display.js
@@ -155,6 +155,54 @@
             }
         };
 
+        Sequence.prototype.getUrlParts = function() {
+            /**
+            * Get and return the current URL in parts
+            */
+            var origin = window.location.origin,
+                pathName = window.location.pathname;
+            return [origin, pathName];
+        };
+
+        Sequence.prototype.determineBrowserUrl = function(origin, pathName, position) {
+            /**
+            * Determine what the new URL should be.
+            */
+            var lastCharacter = pathName[pathName.length - 1],
+                lastUrlElementPosition = pathName.lastIndexOf('/'),
+                urlEnd = pathName.substring(lastUrlElementPosition + 1),
+                urlEndIsNumerical = !isNaN(parseInt(urlEnd));
+
+            if (urlEndIsNumerical) {
+                pathName = pathName.substring(0, lastUrlElementPosition);
+            }
+            if (lastCharacter === '/') {
+                pathName = pathName.substring(0, pathName.length - 1);
+            }
+
+            return origin + pathName + '/' + position;
+        };
+
+        Sequence.prototype.pushBrowserUrl = function(newUrl) {
+            /**
+            * Push the new URL to the browser.
+            */
+            window.history.pushState(null, null, newUrl);
+        };
+
+        Sequence.prototype.updateBrowserUrl = function(position) {
+            /**
+            * Incorporate all the previous subfunctions.
+            * (This is split into subfunctions both for legibility and testing purposes.)
+            */
+            var urlParts = this.getUrlParts();
+            position = position || this.position;
+
+            var newUrl = this.determineBrowserUrl(urlParts[0], urlParts[1], position);
+
+            this.pushBrowserUrl(newUrl);
+        };
+
         Sequence.prototype.hookUpContentStateChangeEvent = function() {
             var self = this;
 
@@ -280,6 +328,7 @@
                 this.toggleArrows();
                 this.hookUpContentStateChangeEvent();
                 this.updatePageTitle();
+                this.updateBrowserUrl();
                 sequenceLinks = this.content_container.find('a.seqnav');
                 sequenceLinks.click(this.goto);
 

--- a/common/lib/xmodule/xmodule/js/src/sequence/display.js
+++ b/common/lib/xmodule/xmodule/js/src/sequence/display.js
@@ -160,11 +160,12 @@
             * Get and return the current URL in parts
             */
             var origin = window.location.origin,
-                pathName = window.location.pathname;
-            return [origin, pathName];
+                pathName = window.location.pathname,
+                search = window.location.search;
+            return [origin, pathName, search];
         };
 
-        Sequence.prototype.determineBrowserUrl = function(origin, pathName, position) {
+        Sequence.prototype.determineBrowserUrl = function(origin, pathName, search, position) {
             /**
             * Determine what the new URL should be.
             */
@@ -180,7 +181,7 @@
                 pathName = pathName.substring(0, pathName.length - 1);
             }
 
-            return origin + pathName + '/' + position;
+            return origin + pathName + '/' + position + search;
         };
 
         Sequence.prototype.pushBrowserUrl = function(newUrl) {
@@ -198,7 +199,7 @@
             var urlParts = this.getUrlParts();
             position = position || this.position;
 
-            var newUrl = this.determineBrowserUrl(urlParts[0], urlParts[1], position);
+            var newUrl = this.determineBrowserUrl(urlParts[0], urlParts[1], urlParts[2], position);
 
             this.pushBrowserUrl(newUrl);
         };


### PR DESCRIPTION
PR of proposed changes from https://github.com/edx/edx-platform/pull/19013.

Code is working. Tests need work.

I've included the tests I've tried writing. The value I thought I could use is `this.location.href` but it doesn't seem to be available in that test as is for some reason.

Ideally the tests that would get written would include:
- check url on initial page load
- +- 1 unit/vertical changes
- skipping unit/vertical changes
- unit/vertical changes that go across subsections/sequentials

@ormsbee this is the PR.