### PR TITLE
TE-2852 Preserve screenshots in bok-choy pipeline jobs

### DIFF
--- a/scripts/Jenkinsfiles/bokchoy
+++ b/scripts/Jenkinsfiles/bokchoy
@@ -21,7 +21,7 @@ def runBokchoyTests() {
 }
 
 def bokchoyTestCleanup() {
-    archiveArtifacts allowEmptyArchive: true, artifacts: 'test_root/log/**/*.log,stdout/*.log'
+    archiveArtifacts allowEmptyArchive: true, artifacts: 'test_root/log/**/*.log,test_root/log/**/*.png,stdout/*.log'
     junit '**/reports/bok_choy/**/xunit.xml'
 }
 


### PR DESCRIPTION
We lost screenshots in the switch from build flow, get them back.