### PR TITLE
wait for ajax on problem reset in test

### DIFF
--- a/common/test/acceptance/pages/lms/problem.py
+++ b/common/test/acceptance/pages/lms/problem.py
@@ -173,6 +173,7 @@ class ProblemPage(PageObject):
         Click the Reset button.
         """
         click_css(self, '.problem .reset', require_notification=False)
+        self.wait_for_ajax()
 
     def click_show(self):
         """


### PR DESCRIPTION
common.test.acceptance.tests.lms.test_lms_problems.FormulaProblemRandomizeTest testMethod=test_reset_problem_after_submission_3___R_1_R_2_R_3____correct__ has become flaky lately and is failing in the following manner: https://build.testeng.edx.org/view/edx-platform-pipeline-master-tests/job/edx-platform-bokchoy-pipeline-master/199/testReport/junit/acceptance.tests.lms.test_lms_problems/FormulaProblemRandomizeTest/Run_tests___23___test_reset_problem_after_submission_3___R_1_R_2_R_3____correct__/
