### PR TITLE
ARCH-379: add user_id scope and claim for JWT cookies

### DIFF
--- a/openedx/core/djangoapps/oauth_dispatch/jwt.py
+++ b/openedx/core/djangoapps/oauth_dispatch/jwt.py
@@ -156,13 +156,19 @@ def _update_from_additional_handlers(payload, user, scopes):
     requested by the given scopes.
     """
     _claim_handlers = {
+        'user_id': _attach_user_id_claim,
         'email': _attach_email_claim,
-        'profile': _attach_profile_claim
+        'profile': _attach_profile_claim,
     }
     for scope in scopes:
         handler = _claim_handlers.get(scope)
         if handler:
             handler(payload, user)
+
+
+def _attach_user_id_claim(payload, user):
+    """Add the user_id claim details to the JWT payload."""
+    payload['user_id'] = user.id
 
 
 def _attach_email_claim(payload, user):

--- a/openedx/core/djangoapps/oauth_dispatch/tests/mixins.py
+++ b/openedx/core/djangoapps/oauth_dispatch/tests/mixins.py
@@ -66,6 +66,9 @@ class AccessTokenMixin(object):
             'email_verified': user.is_active,
         }
 
+        if 'user_id' in scopes:
+            expected['user_id'] = user.id
+
         if 'email' in scopes:
             expected['email'] = user.email
 

--- a/openedx/core/djangoapps/user_authn/cookies.py
+++ b/openedx/core/djangoapps/user_authn/cookies.py
@@ -270,7 +270,8 @@ def _create_and_set_jwt_cookies(response, request, cookie_settings, user=None, r
         )
     else:
         access_token = create_dot_access_token(
-            request, user, oauth_application, expires_in=expires_in, scopes=['email', 'profile'],
+            # Note: Scopes for JWT cookies do not require additional permissions
+            request, user, oauth_application, expires_in=expires_in, scopes=['user_id', 'email', 'profile'],
         )
     jwt = create_jwt_from_token(access_token, DOTAdapter(), use_asymmetric_key=True)
     jwt_header_and_payload, jwt_signature = _parse_jwt(jwt)

--- a/openedx/core/djangoapps/user_authn/tests/test_cookies.py
+++ b/openedx/core/djangoapps/user_authn/tests/test_cookies.py
@@ -75,7 +75,7 @@ class CookieTests(TestCase):
         if can_recreate:
             jwt_string = self.request.COOKIES[cookies_api.jwt_cookies.jwt_cookie_name()]
             jwt = jwt_decode_handler(jwt_string)
-            self.assertEqual(jwt['scopes'], ['email', 'profile'])
+            self.assertEqual(jwt['scopes'], ['user_id', 'email', 'profile'])
 
     def _assert_cookies_present(self, response, expected_cookies):
         """ Verify all expected_cookies are present in the response. """


### PR DESCRIPTION
The following changes are made to add LMS user_id:
* Adds user_id scope to the JWT to provide the LMS user_id.
* JWT cookies always use the user_id claim.

ARCH-379: Add call in User Account app to Segment's identify user