### PR TITLE
Allow setting custom unit icons

### DIFF
--- a/cms/djangoapps/contentstore/views/item.py
+++ b/cms/djangoapps/contentstore/views/item.py
@@ -1191,6 +1191,7 @@ def create_xblock_info(xblock, data=None, metadata=None, include_ancestor_info=F
             'group_access': xblock.group_access,
             'user_partitions': user_partitions,
             'show_correctness': xblock.show_correctness,
+            'icon': xblock.icon,
         })
 
         if xblock.category == 'sequential':

--- a/cms/static/js/models/xblock_info.js
+++ b/cms/static/js/models/xblock_info.js
@@ -54,6 +54,10 @@ function(Backbone, _, str, ModuleUtils) {
              */
             has_children: null,
             /**
+             * Meta icon of the unit.
+             */
+            icons: null,
+            /**
              * True if the xblock has changes.
              * Note: this is not always provided as a performance optimization. It is only provided for
              * verticals functioning as units.

--- a/cms/static/js/spec/views/pages/course_outline_spec.js
+++ b/cms/static/js/spec/views/pages/course_outline_spec.js
@@ -270,7 +270,7 @@ describe('CourseOutlinePage', function() {
             'staff-lock-editor', 'unit-access-editor', 'content-visibility-editor',
             'settings-modal-tabs', 'timed-examination-preference-editor', 'access-editor',
             'show-correctness-editor', 'highlights-editor', 'highlights-enable-editor',
-            'course-highlights-enable'
+            'course-highlights-enable', 'icon-editor'
         ]);
         appendSetFixtures(mockOutlinePage);
         mockCourseJSON = createMockCourseJSON({}, [

--- a/cms/static/js/views/modals/course_outline_modals.js
+++ b/cms/static/js/views/modals/course_outline_modals.js
@@ -17,7 +17,8 @@ define(['jquery', 'backbone', 'underscore', 'gettext', 'js/views/baseview',
         AbstractEditor, BaseDateEditor,
         ReleaseDateEditor, DueDateEditor, GradingEditor, PublishEditor, AbstractVisibilityEditor,
         StaffLockEditor, UnitAccessEditor, ContentVisibilityEditor, TimedExaminationPreferenceEditor,
-        AccessEditor, ShowCorrectnessEditor, HighlightsEditor, HighlightsEnableXBlockModal, HighlightsEnableEditor;
+        AccessEditor, ShowCorrectnessEditor, HighlightsEditor, HighlightsEnableXBlockModal, HighlightsEnableEditor,
+        IconEditor;
 
     CourseOutlineXBlockModal = BaseModal.extend({
         events: _.extend({}, BaseModal.prototype.events, {
@@ -1026,6 +1027,28 @@ define(['jquery', 'backbone', 'underscore', 'gettext', 'js/views/baseview',
         }
     });
 
+    IconEditor = BaseDateEditor.extend({
+        fieldName: 'icon',
+        templateName: 'icon-editor',
+
+        hasChanges: function() {
+            return this.model.get("icon") !== parseInt(this.$('#icon').val());
+        },
+
+        getValue: function () {
+            return (parseInt(this.$('#icon').val()));
+        },
+
+        getRequestData: function () {
+            return this.hasChanges() ? {
+                publish: 'republish',
+                metadata: {
+                    'icon': this.getValue()
+                }
+            } : {};
+        }
+    });
+
     return {
         getModal: function(type, xblockInfo, options) {
             if (type === 'edit') {
@@ -1050,7 +1073,7 @@ define(['jquery', 'backbone', 'underscore', 'gettext', 'js/views/baseview',
                 editors: []
             };
             if (xblockInfo.isVertical()) {
-                editors = [StaffLockEditor, UnitAccessEditor];
+                editors = [StaffLockEditor, UnitAccessEditor, IconEditor];
             } else {
                 tabs = [
                     {

--- a/cms/templates/course_outline.html
+++ b/cms/templates/course_outline.html
@@ -26,7 +26,7 @@ from django.core.urlresolvers import reverse
 
 <%block name="header_extras">
 <link rel="stylesheet" type="text/css" href="${static.url('js/vendor/timepicker/jquery.timepicker.css')}" />
-% for template_name in ['course-outline', 'xblock-string-field-editor', 'basic-modal', 'modal-button', 'course-outline-modal', 'due-date-editor', 'release-date-editor', 'grading-editor', 'publish-editor', 'staff-lock-editor', 'unit-access-editor', 'content-visibility-editor', 'verification-access-editor', 'timed-examination-preference-editor', 'access-editor', 'settings-modal-tabs', 'show-correctness-editor', 'highlights-editor', 'highlights-enable-editor', 'course-highlights-enable']:
+% for template_name in ['course-outline', 'xblock-string-field-editor', 'basic-modal', 'modal-button', 'course-outline-modal', 'due-date-editor', 'release-date-editor', 'grading-editor', 'publish-editor', 'staff-lock-editor', 'unit-access-editor', 'content-visibility-editor', 'verification-access-editor', 'timed-examination-preference-editor', 'access-editor', 'settings-modal-tabs', 'show-correctness-editor', 'highlights-editor', 'highlights-enable-editor', 'course-highlights-enable', 'icon-editor']:
 <script type="text/template" id="${template_name}-tpl">
     <%static:include path="js/${template_name}.underscore" />
 </script>
@@ -164,7 +164,7 @@ from django.core.urlresolvers import reverse
                     <div style="width: 50%" class="status-studio-frontend">
                 % endif
                     <%static:studiofrontend entry="courseOutlineHealthCheck">
-                        <% 
+                        <%
                             course_key = context_course.id
                         %>
                         {
@@ -188,7 +188,7 @@ from django.core.urlresolvers import reverse
                                 "settings": ${reverse('settings_handler', kwargs={'course_key_string': unicode(course_key)})| n, dump_js_escaped_json}
                             }
                         }
-                    </%static:studiofrontend> 
+                    </%static:studiofrontend>
                 </div>
                 <div class="status-highlights-enabled"></div>
             </div>

--- a/cms/templates/js/icon-editor.underscore
+++ b/cms/templates/js/icon-editor.underscore
@@ -1,0 +1,8 @@
+<h3 class="modal-section-title">Select icon</h3>
+<select id="icon">
+  <option value="0" <% if (xblockInfo.get("icon") === 0) { %> selected <% } %> ><%- gettext('Default') %></option>
+  <option value="1" <% if (xblockInfo.get("icon") === 1) { %> selected <% } %> ><%- gettext('Other') %></option>
+  <option value="2" <% if (xblockInfo.get("icon") === 2) { %> selected <% } %> ><%- gettext('Problem') %></option>
+  <option value="3" <% if (xblockInfo.get("icon") === 3) { %> selected <% } %> ><%- gettext('Vertical') %></option>
+  <option value="4" <% if (xblockInfo.get("icon") === 4) { %> selected <% } %> ><%- gettext('Video') %></option>
+</select>

--- a/common/lib/xmodule/xmodule/modulestore/inheritance.py
+++ b/common/lib/xmodule/xmodule/modulestore/inheritance.py
@@ -51,6 +51,12 @@ class InheritanceMixin(XBlockMixin):
         default=False,
         scope=Scope.settings,
     )
+    icon = Integer(
+        display_name=_("Icon"),
+        default=0,
+        help=_("XBlock Icon ID"),
+        scope=Scope.settings,
+    )
     course_edit_method = String(
         display_name=_("Course Editor"),
         help=_("Enter the method by which this course is edited (\"XML\" or \"Studio\")."),

--- a/common/lib/xmodule/xmodule/seq_module.py
+++ b/common/lib/xmodule/xmodule/seq_module.py
@@ -492,7 +492,8 @@ class SequenceModule(SequenceFields, ProctoringFields, XModule):
                 'id': text_type(usage_id),
                 'bookmarked': is_bookmarked,
                 'path': " > ".join(display_names + [item.display_name_with_default]),
-                'graded': item.graded
+                'graded': item.graded,
+                'icon': item.icon,
             }
 
             if is_user_authenticated:

--- a/lms/templates/seq_module.html
+++ b/lms/templates/seq_module.html
@@ -38,8 +38,30 @@
         </li>
         % else:
         % for idx, item in enumerate(items):
+
+        <%
+            icon = item.get('icon', 0)
+            iconClass = 'null'
+        %>
+
+        % if icon == 0:
+          <% iconClass = item['type'] %>
+        % endif
+        % if icon == 1:
+          <% iconClass = 'other' %>
+        % endif
+        % if icon == 2:
+          <% iconClass = 'problem' %>
+        % endif
+        % if icon == 3:
+          <% iconClass = 'vertical' %>
+        % endif
+        % if icon == 4:
+          <% iconClass = 'video' %>
+        % endif
+
         <li role="presentation">
-          <button class="seq_${item['type']} inactive nav-item tab"
+          <button class="seq_${iconClass} inactive nav-item tab"
             role="tab"
             tabindex="-1"
             aria-selected="false"
@@ -52,10 +74,10 @@
             data-path="${item['path']}"
             data-graded="${item['graded']}"
             id="tab_${idx}">
-            <span class="icon fa seq_${item['type']}" aria-hidden="true"></span>
+            <span class="icon fa seq_${iconClass}" aria-hidden="true"></span>
             % if 'complete' in item:
-              <span 
-                class="fa fa-check-circle check-circle ${"is-hidden" if not item['complete'] else ""}" 
+              <span
+                class="fa fa-check-circle check-circle ${"is-hidden" if not item['complete'] else ""}"
                 style="color:green"
                 aria-hidden="true"
               ></span>


### PR DESCRIPTION
This allows setting custom icons for each unit in Studio. By default the icon will be derived from unit's type. The custom icon can be specified in studio - please see the screenshot.

**JIRA tickets**: [OSPR-3059](https://openedx.atlassian.net/browse/OSPR-3059)

**Dependencies**: None

**Screenshots**:
![options](https://user-images.githubusercontent.com/3189670/52456335-79aae180-2b54-11e9-9710-7d4e447dec2f.png)


**Testing instructions**:

1. Check out this branch.
1. Log into the studio.
1. Create new course (or enter an existing one).
1. Create new subsection and couple of units inside it.
1. Click `Configure` (`fa-gear`) button next to the unit, choose custom icon from the dropdown (like on attached screenshot) and click `Save`.
1. Log into the LMS and enter modified course.
1. Enter the modified unit and check if its icon matches the chosen one.


**Reviewers**
- [ ] @kaizoku 
- [ ] edX reviewer[s] TBD