### PR TITLE
Fixes flaky tests in schedules.tests.TestCourseUpdateResolver

### DIFF
--- a/openedx/core/djangoapps/schedules/tests/test_resolvers.py
+++ b/openedx/core/djangoapps/schedules/tests/test_resolvers.py
@@ -99,7 +99,7 @@ class TestBinnedSchedulesBaseResolver(SchedulesResolverTestMixin, CacheIsolation
             "Can't test schedules if the app isn't installed")
 @override_waffle_flag(COURSE_UPDATE_WAFFLE_FLAG, True)
 @freeze_time('2017-08-01 01:00:00', tz_offset=0, tick=False)
-class TestCourseUpdateResolver(SchedulesResolverTestMixin, ModuleStoreTestCase):
+class TestCourseUpdateResolver(SchedulesResolverTestMixin, CacheIsolationTestCase, ModuleStoreTestCase):
     """
     Tests the CourseUpdateResolver.
     """


### PR DESCRIPTION
Uses `CacheIsolationTestCase` to fix flaky tests added by https://github.com/edx/edx-platform/pull/19018

Using `CacheIsolationTestCase` is recommended by [Debugging test failures with pytest-xdist](https://openedx.atlassian.net/wiki/spaces/TE/pages/884998163/Debugging+test+failures+with+pytest-xdist#Debuggingtestfailureswithpytest-xdist-Flakinessfromunwantedcachingorotherpersistentconfig).  It is also used by the [other resolver tests](https://github.com/edx/edx-platform/pull/19773/files#diff-ac9f139f3ea9eb22089618365f6ed5a5L42), so this seems like a probable solution here.

**JIRA tickets**: [OSPR-3060](https://openedx.atlassian.net/browse/OSPR-3060)

**Discussions**: Please see https://github.com/edx/edx-platform/pull/19018#issuecomment-461482855

**Merge deadline**: ASAP

**Testing instructions**:

\<HaltingProblem>
This is a fix to the automated tests only, so the tests passing (all the time) is the way to verify this works.
\</HaltingProblem>

**Reviewers**
- [ ] @SSPJ 
- [ ] @jmbowman 

CC @awaisdar001
