### PR TITLE
ENT-1533: Updating recovery email address from an already verified email address auto verifies the new address

### DIFF
--- a/common/djangoapps/student/models.py
+++ b/common/djangoapps/student/models.py
@@ -2750,3 +2750,14 @@ class AccountRecovery(models.Model):
         db_table = "auth_accountrecovery"
 
     objects = AccountRecoveryManager()
+
+    def update_recovery_email(self, email):
+        """
+        Update the secondary email address on the instance to the email in the argument.
+
+        Arguments:
+            email (str): New email address to be set as the secondary email address.
+        """
+        self.secondary_email = email
+        self.is_active = False
+        self.save()

--- a/openedx/core/djangoapps/user_api/accounts/api.py
+++ b/openedx/core/djangoapps/user_api/accounts/api.py
@@ -209,8 +209,7 @@ def update_account_settings(requesting_user, update, username=None):
                 "user_message": text_type(err)
             }
         else:
-            account_recovery.secondary_email = update["secondary_email"]
-            account_recovery.save()
+            account_recovery.update_recovery_email(update["secondary_email"])
 
     # If the user asked to change full name, validate it
     if changing_full_name:


### PR DESCRIPTION
**Description:**
If a learner has already set and verified the account recovery email address and then he wants to updates the recovery email address to a new address. The learner should receive an email to verify this new email address before using this new email address as the recovery address.
