### PR TITLE
[BB-873] Support for filters, and multiple roots in problem response reports

### DIFF
--- a/lms/djangoapps/instructor/views/api.py
+++ b/lms/djangoapps/instructor/views/api.py
@@ -1023,22 +1023,23 @@ def get_problem_responses(request, course_id):
     Responds with BadRequest if problem location is faulty.
     """
     course_key = CourseKey.from_string(course_id)
-    problem_location = request.POST.get('problem_location', '')
+    # A comma-separated list of problem locations
+    # The name of the POST parameter is `problem_location` (not pluralised) in
+    # order to preserve backwards compatibility with existing third-party
+    # scripts.
+    problem_locations = request.POST.get('problem_location', '')
+    # A comma-separated list of block types
+    problem_types_filter = request.POST.get('problem_types_filter', '')
     report_type = _('problem responses')
 
     try:
-        problem_key = UsageKey.from_string(problem_location)
-        # Are we dealing with an "old-style" problem location?
-        run = problem_key.run
-        if not run:
+        for problem_location in problem_locations.split(','):
             problem_key = UsageKey.from_string(problem_location).map_into_course(course_key)
-        if problem_key.course_key != course_key:
-            raise InvalidKeyError(type(problem_key), problem_key)
     except InvalidKeyError:
         return JsonResponseBadRequest(_("Could not find problem with this location."))
 
     task = task_api.submit_calculate_problem_responses_csv(
-        request, course_key, problem_location
+        request, course_key, problem_locations, problem_types_filter,
     )
     success_status = SUCCESS_MESSAGE_TEMPLATE.format(report_type=report_type)
 

--- a/lms/djangoapps/instructor_task/api.py
+++ b/lms/djangoapps/instructor_task/api.py
@@ -324,7 +324,9 @@ def submit_bulk_course_email(request, course_key, email_id):
     return submit_task(request, task_type, task_class, course_key, task_input, task_key)
 
 
-def submit_calculate_problem_responses_csv(request, course_key, problem_location):
+def submit_calculate_problem_responses_csv(
+    request, course_key, problem_locations, problem_types_filter=None,
+):
     """
     Submits a task to generate a CSV file containing all student
     answers to a given problem.
@@ -333,7 +335,11 @@ def submit_calculate_problem_responses_csv(request, course_key, problem_location
     """
     task_type = 'problem_responses_csv'
     task_class = calculate_problem_responses_csv
-    task_input = {'problem_location': problem_location, 'user_id': request.user.pk}
+    task_input = {
+        'problem_location': problem_locations,
+        'problem_types_filter': problem_types_filter,
+        'user_id': request.user.pk,
+    }
     task_key = ""
 
     return submit_task(request, task_type, task_class, course_key, task_input, task_key)

--- a/lms/djangoapps/instructor_task/tasks.py
+++ b/lms/djangoapps/instructor_task/tasks.py
@@ -161,7 +161,11 @@ def send_bulk_course_email(entry_id, _xmodule_instance_args):
     return run_main_task(entry_id, visit_fcn, action_name)
 
 
-@task(base=BaseInstructorTask, routing_key=settings.GRADES_DOWNLOAD_ROUTING_KEY)
+@task(
+    name='lms.djangoapps.instructor_task.tasks.calculate_problem_responses_csv.v2',
+    base=BaseInstructorTask,
+    routing_key=settings.GRADES_DOWNLOAD_ROUTING_KEY,
+)
 def calculate_problem_responses_csv(entry_id, xmodule_instance_args):
     """
     Compute student answers to a given problem and upload the CSV to

--- a/lms/djangoapps/instructor_task/tests/test_api.py
+++ b/lms/djangoapps/instructor_task/tests/test_api.py
@@ -262,7 +262,7 @@ class InstructorTaskCourseSubmitTest(TestReportMixin, InstructorTaskCourseTestCa
         api_call = lambda: submit_calculate_problem_responses_csv(
             self.create_task_request(self.instructor),
             self.course.id,
-            problem_location=''
+            problem_locations='',
         )
         self._test_resubmission(api_call)
 


### PR DESCRIPTION
This PR includes the following changes to the problem response report API:

1) Support for specifying multiple root blocks. 
    With this feature, you can now pass a comma-separated list of problem locations, and the generated report will include both of them (and children). 

2) Support for specifying a problem type filter. 
    This feature allows you to request a report for only one or more types of blocks. In this case you can request a report for the entire course, but filter it to only blocks of specific types. 


**JIRA tickets**: OSPR-3070

**Discussions**: https://github.com/edx/edx-platform/pull/19507

**Dependencies**: https://github.com/edx/edx-platform/pull/19507, https://github.com/edx/edx-platform/pull/19635

**Sandbox URL**: TBD - sandbox is being provisioned.

**Merge deadline**: None

**Testing instructions**:
1. Log in as an instructor
2. Post to the get_problem_responses API (this needs to include session information till #19635 lands) and with problem_location set to a comma-separated list of problem locations. (API url: http://localhost:18000/courses/course-v1:edX+DemoX+Demo_Course/instructor/api/get_problem_responses )
3. This should start generating a report with all those problem locations
4. Post to the same api again, this time use the course (or a section) as the problem_location, but also provide a problem_types_filter
5. Check the generated report, it should include only blocks of the type specified in problem_types_filter.

**Concerns:**
1. The locations to be included in the report are stored in [this field](https://github.com/edx/edx-platform/blob/master/lms/djangoapps/instructor_task/models.py#L70) which is limited to 255 characters. This limits us to generate a report for a maximum of around 3/4 blocks (or less if the locations are longer). It would be nice if we could somehow remove this restriction by increasing the size of this field. 

2. The task_input is limited to 255 chars, yet [this line](https://github.com/edx/edx-platform/blob/bc32513b0ea8e62b0831aec85c475ff5a1e258fd/lms/djangoapps/instructor_task/models.py#L103) only throws an error if the task_input is longer than 265 characters, I'm not sure why that is. 

**Reviewers**
- [ ] @giovannicimolin 
- [ ] edX reviewer[s] TBD