### PR TITLE
Fix csv of problem responses silent failure

### DIFF
--- a/common/lib/capa/capa/capa_problem.py
+++ b/common/lib/capa/capa/capa_problem.py
@@ -31,7 +31,7 @@ import capa.xqueue_interface as xqueue_interface
 from capa.correctmap import CorrectMap
 from capa.safe_exec import safe_exec
 from capa.util import contextualize_text, convert_files_to_filenames
-from openedx.core.djangolib.markup import HTML
+from openedx.core.djangolib.markup import HTML, Text
 from xmodule.stringify import stringify_children
 
 # extra things displayed after "show answers" is pressed
@@ -884,7 +884,7 @@ class LoncapaProblem(object):
                 )
             except Exception as err:
                 log.exception("Error while execing script code: " + all_code)
-                msg = "Error while executing script code: %s" % str(err).replace('<', '&lt;')
+                msg = Text("Error while executing script code: %s" % str(err))
                 raise responsetypes.LoncapaProblemError(msg)
 
         # Store code source in context, along with the Python path needed to run it correctly.
@@ -1119,7 +1119,7 @@ class LoncapaProblem(object):
             for inputfield in inputfields:
                 problem_data[inputfield.get('id')] = {
                     'group_label': group_label_tag_text,
-                    'label': inputfield.attrib.get('label', ''),
+                    'label': HTML(inputfield.attrib.get('label', '')),
                     'descriptions': {}
                 }
         else:

--- a/common/lib/capa/capa/tests/test_capa_problem.py
+++ b/common/lib/capa/capa/tests/test_capa_problem.py
@@ -3,7 +3,10 @@ Test capa problem.
 """
 import ddt
 import textwrap
+
+import six
 from lxml import etree
+from markupsafe import Markup
 from mock import patch
 import unittest
 
@@ -145,7 +148,6 @@ class CAPAProblemTest(unittest.TestCase):
                     'descriptions': {}
                 }
             }
-
         )
         for question in (question1, question2):
             self.assertEqual(
@@ -467,16 +469,21 @@ class CAPAMultiInputProblemTest(unittest.TestCase):
         """
         return new_loncapa_problem(xml, use_capa_render_template=True)
 
-    def assert_problem_html(self, problme_html, group_label, *input_labels):
+    def assert_problem_data(self, problem_data):
+        """Verify problem data is in expected state"""
+        for problem_value in six.viewvalues(problem_data):
+            self.assertIsInstance(problem_value['label'], Markup)
+
+    def assert_problem_html(self, problem_html, group_label, *input_labels):
         """
         Verify that correct html is rendered for multiple inputtypes.
 
         Arguments:
-            problme_html (str): problem HTML
+            problem_html (str): problem HTML
             group_label (str or None): multi input group label or None if label is not present
             input_labels (tuple): individual input labels
         """
-        html = etree.XML(problme_html)
+        html = etree.XML(problem_html)
 
         # verify that only one multi input group div is present at correct path
         multi_inputs_group = html.xpath(
@@ -523,6 +530,7 @@ class CAPAMultiInputProblemTest(unittest.TestCase):
         """.format(label_html=label_html, input1_label=input1_label, input2_label=input2_label)
         problem = self.capa_problem(xml)
         self.assert_problem_html(problem.get_html(), group_label, input1_label, input2_label)
+        self.assert_problem_data(problem.problem_data)
 
     @ddt.unpack
     @ddt.data(
@@ -552,6 +560,7 @@ class CAPAMultiInputProblemTest(unittest.TestCase):
         """.format(group_label, input1_label, input2_label, inputtype=inputtype))
         problem = self.capa_problem(xml)
         self.assert_problem_html(problem.get_html(), group_label, input1_label, input2_label)
+        self.assert_problem_data(problem.problem_data)
 
     @ddt.unpack
     @ddt.data(


### PR DESCRIPTION
## [EDUCATOR-4003](https://openedx.atlassian.net/browse/EDUCATOR-4003)

This fixes an issue that when a CAPA problem contained multiple inputs, the system does not format the input `label` with `markup` object instead of a string object. due to this, generating a CSV for problem responses for learners in instructor dashboard fails. 

In this PR, I made the behavior consistent with single input CAPA problem. For multiple input problems, create a markup object as well. 

### How to test it?
## Stage
* Answer the following Problem in LMS:
https://courses.stage.edx.org/courses/course-v1:ArbiRaees+CS101+2017_T2/courseware/98bc47d112114c7989c4f6f7759883cf/e1954f8e68914299b992b439dd0e994c/1
* Go to Instructor Dashboard > Data Download
https://courses.stage.edx.org/courses/course-v1:ArbiRaees+CS101+2017_T2/instructor#view-data_download
* Select a section or problem > Select Blank Advanced Problem (block-v1:ArbiRaees+CS101+2017_T2+type@problem+block@8cf9219027af41228180d911b192ced2)
* Click `Download a CSV of problem responses`
* Observe error in [Splunk](https://splunk.edx.org/en-US/app/search/search?q=search%20index%3D%22stage-edx%22%20%22striptags%22%20%22raised%20unexpected%3A%20AttributeError%22%20%22service_variant%3Dlms%22&earliest=-15m&latest=now&display.page.search.mode=smart&dispatch.sample_ratio=1&sid=1550125632.2982431)


## Standbox
Repeat the same steps for Stage
* Answer this problem (https://awaisdar001.sandbox.edx.org/courses/course-v1:edX+Test101+course/courseware/d7b00afc151e46c5ba1e370c310db679/789f0a355a09465b8d7210a61e1c229f/1?activate_block_id=block-v1%3AedX%2BTest101%2Bcourse%2Btype%40vertical%2Bblock%405b2f889da9a5421d970331a0ffe0d690)
* Go to Instructor Dashboard (https://awaisdar001.sandbox.edx.org/courses/course-v1:ArbiX+CS101+2015_T2/instructor#view-data_download)
* Select Problem (block-v1:ArbiX+CS101+2015_T2+type@problem+block@1d143ff22cdf4e68bb50bf749e9484a2)
* Click `Download a CSV of problem responses`
* Verify CSV generated successfully. 


