### PR TITLE
Remove pytest shards from lms

### DIFF
--- a/lms/djangoapps/badges/api/tests.py
+++ b/lms/djangoapps/badges/api/tests.py
@@ -151,7 +151,6 @@ class TestUserBadgeAssertionsByClass(UserAssertionTestCase):
     """
     Test the Badge Assertions view with the badge class filter.
     """
-    shard = 3
 
     @unpack
     @data((False, False), (True, False), (True, True))

--- a/lms/djangoapps/badges/backends/tests/test_badgr_backend.py
+++ b/lms/djangoapps/badges/backends/tests/test_badgr_backend.py
@@ -35,7 +35,6 @@ class BadgrBackendTestCase(ModuleStoreTestCase, EventTrackingTestCase):
     """
     Tests the BadgeHandler object
     """
-    shard = 4
 
     def setUp(self):
         """

--- a/lms/djangoapps/badges/events/tests/test_course_complete.py
+++ b/lms/djangoapps/badges/events/tests/test_course_complete.py
@@ -13,7 +13,6 @@ class CourseCompleteTestCase(ModuleStoreTestCase):
     """
     Tests for the course completion helper functions.
     """
-    shard = 4
 
     def setUp(self):
         super(CourseCompleteTestCase, self).setUp()

--- a/lms/djangoapps/badges/events/tests/test_course_meta.py
+++ b/lms/djangoapps/badges/events/tests/test_course_meta.py
@@ -21,7 +21,6 @@ class CourseEnrollmentBadgeTest(ModuleStoreTestCase):
     """
     Tests the event which awards badges based on number of courses a user is enrolled in.
     """
-    shard = 4
 
     def setUp(self):
         super(CourseEnrollmentBadgeTest, self).setUp()
@@ -72,7 +71,6 @@ class CourseCompletionBadgeTest(ModuleStoreTestCase):
     """
     Tests the event which awards badges based on the number of courses completed.
     """
-    shard = 4
 
     def setUp(self):
         super(CourseCompletionBadgeTest, self).setUp()
@@ -127,7 +125,6 @@ class CourseGroupBadgeTest(ModuleStoreTestCase):
     """
     Tests the event which awards badges when a user completes a set of courses.
     """
-    shard = 4
 
     def setUp(self):
         super(CourseGroupBadgeTest, self).setUp()

--- a/lms/djangoapps/badges/tests/test_models.py
+++ b/lms/djangoapps/badges/tests/test_models.py
@@ -36,7 +36,6 @@ class BadgeImageConfigurationTest(TestCase):
     """
     Test the validation features of BadgeImageConfiguration.
     """
-    shard = 1
 
     def tearDown(self):
         tmp_path = Path(TEST_DATA_ROOT / 'course_complete_badges')

--- a/lms/djangoapps/branding/tests/test_api.py
+++ b/lms/djangoapps/branding/tests/test_api.py
@@ -14,7 +14,6 @@ from edxmako.shortcuts import marketing_link
 
 class TestHeader(TestCase):
     """Test API end-point for retrieving the header. """
-    shard = 4
 
     def test_cdn_urls_for_logo(self):
         # Ordinarily, we'd use `override_settings()` to override STATIC_URL,
@@ -42,7 +41,6 @@ class TestHeader(TestCase):
 
 
 class TestFooter(TestCase):
-    shard = 4
     maxDiff = None
     """Test retrieving the footer. """
     @mock.patch.dict('django.conf.settings.FEATURES', {'ENABLE_MKTG_SITE': True})

--- a/lms/djangoapps/branding/tests/test_models.py
+++ b/lms/djangoapps/branding/tests/test_models.py
@@ -11,7 +11,6 @@ class BrandingInfoConfigTest(TestCase):
     """
     Test the BrandingInfoConfig model.
     """
-    shard = 1
 
     def setUp(self):
         super(BrandingInfoConfigTest, self).setUp()

--- a/lms/djangoapps/branding/tests/test_page.py
+++ b/lms/djangoapps/branding/tests/test_page.py
@@ -17,7 +17,6 @@ from branding.views import index
 from courseware.tests.helpers import LoginEnrollmentTestCase
 from edxmako.shortcuts import render_to_response
 from openedx.core.djangoapps.site_configuration.tests.mixins import SiteMixin
-from openedx.core.lib.tests import attr
 from util.milestones_helpers import set_prerequisite_courses
 from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
 from xmodule.modulestore.tests.factories import CourseFactory
@@ -37,7 +36,6 @@ def mock_render_to_response(*args, **kwargs):
 RENDER_MOCK = Mock(side_effect=mock_render_to_response)
 
 
-@attr(shard=1)
 class AnonymousIndexPageTest(ModuleStoreTestCase):
     """
     Tests that anonymous users can access the '/' page,  Need courses with start date
@@ -109,7 +107,6 @@ class AnonymousIndexPageTest(ModuleStoreTestCase):
         self.assertEqual(response._headers.get("location")[1], "/login")  # pylint: disable=protected-access
 
 
-@attr(shard=1)
 class PreRequisiteCourseCatalog(ModuleStoreTestCase, LoginEnrollmentTestCase, MilestonesTestCaseMixin):
     """
     Test to simulate and verify fix for disappearing courses in
@@ -155,7 +152,6 @@ class PreRequisiteCourseCatalog(ModuleStoreTestCase, LoginEnrollmentTestCase, Mi
         self.assertIn('course that has pre requisite', resp.content)
 
 
-@attr(shard=1)
 class IndexPageCourseCardsSortingTests(ModuleStoreTestCase):
     """
     Test for Index page course cards sorting
@@ -290,7 +286,6 @@ class IndexPageCourseCardsSortingTests(ModuleStoreTestCase):
         self.assertEqual(context['courses'][2].id, self.course_with_default_start_date.id)
 
 
-@attr(shard=1)
 class IndexPageProgramsTests(SiteMixin, ModuleStoreTestCase):
     """
     Tests for Programs List in Marketing Pages.

--- a/lms/djangoapps/branding/tests/test_views.py
+++ b/lms/djangoapps/branding/tests/test_views.py
@@ -22,7 +22,6 @@ from student.tests.factories import UserFactory
 @ddt.ddt
 class TestFooter(CacheIsolationTestCase):
     """Test API end-point for retrieving the footer. """
-    shard = 4
 
     @ddt.data("*/*", "text/html", "application/json")
     def test_feature_flag(self, accepts):
@@ -280,7 +279,6 @@ class TestFooter(CacheIsolationTestCase):
 
 class TestIndex(SiteMixin, TestCase):
     """ Test the index view """
-    shard = 4
 
     def setUp(self):
         """ Set up a user """

--- a/lms/djangoapps/bulk_email/tests/test_course_optout.py
+++ b/lms/djangoapps/bulk_email/tests/test_course_optout.py
@@ -27,7 +27,6 @@ class TestOptoutCourseEmails(ModuleStoreTestCase):
     """
     Test that optouts are referenced in sending course email.
     """
-    shard = 1
 
     def setUp(self):
         super(TestOptoutCourseEmails, self).setUp()
@@ -122,7 +121,6 @@ class TestACEOptoutCourseEmails(ModuleStoreTestCase):
     """
     Test that optouts are referenced in sending course email.
     """
-    shard = 1
 
     def setUp(self):
         super(TestACEOptoutCourseEmails, self).setUp()

--- a/lms/djangoapps/bulk_email/tests/test_email.py
+++ b/lms/djangoapps/bulk_email/tests/test_email.py
@@ -25,7 +25,6 @@ from enrollment.api import update_enrollment
 from lms.djangoapps.instructor_task.subtasks import update_subtask_status
 from openedx.core.djangoapps.course_groups.cohorts import add_user_to_cohort
 from openedx.core.djangoapps.course_groups.models import CourseCohort
-from openedx.core.lib.tests import attr
 from student.models import CourseEnrollment
 from student.roles import CourseStaffRole
 from student.tests.factories import CourseEnrollmentFactory, UserFactory
@@ -168,7 +167,6 @@ class SendEmailWithMockedUgettextMixin(object):
         return mail.outbox[0]
 
 
-@attr(shard=1)
 @patch.dict(settings.FEATURES, {'ENABLE_INSTRUCTOR_EMAIL': True, 'REQUIRE_COURSE_EMAIL_AUTH': False})
 @ddt.ddt
 class LocalizedFromAddressPlatformLangTestCase(SendEmailWithMockedUgettextMixin, EmailSendFromDashboardTestCase):
@@ -194,7 +192,6 @@ class LocalizedFromAddressPlatformLangTestCase(SendEmailWithMockedUgettextMixin,
         self.assertRegexpMatches(message.from_email, '@EO .* Course Staff@')
 
 
-@attr(shard=1)
 @patch.dict(settings.FEATURES, {'ENABLE_INSTRUCTOR_EMAIL': True, 'REQUIRE_COURSE_EMAIL_AUTH': False})
 @ddt.ddt
 class LocalizedFromAddressCourseLangTestCase(SendEmailWithMockedUgettextMixin, EmailSendFromDashboardTestCase):
@@ -227,7 +224,6 @@ class LocalizedFromAddressCourseLangTestCase(SendEmailWithMockedUgettextMixin, E
         self.assertRegexpMatches(message.from_email, '@AR .* Course Staff@')
 
 
-@attr(shard=1)
 @patch('bulk_email.models.html_to_text', Mock(return_value='Mocking CourseEmail.text_message', autospec=True))
 class TestEmailSendFromDashboardMockedHtmlToText(EmailSendFromDashboardTestCase):
     """
@@ -598,7 +594,6 @@ class TestEmailSendFromDashboardMockedHtmlToText(EmailSendFromDashboardTestCase)
         self.assertItemsEqual(outbox_contents, should_send_contents)
 
 
-@attr(shard=1)
 @skipIf(os.environ.get("TRAVIS") == 'true', "Skip this test in Travis CI.")
 class TestEmailSendFromDashboard(EmailSendFromDashboardTestCase):
     """

--- a/lms/djangoapps/bulk_email/tests/test_err_handling.py
+++ b/lms/djangoapps/bulk_email/tests/test_err_handling.py
@@ -43,7 +43,6 @@ class TestEmailErrors(ModuleStoreTestCase):
     """
     Test that errors from sending email are handled properly.
     """
-    shard = 1
 
     ENABLED_CACHES = ['default', 'mongo_metadata_inheritance', 'loc_cache']
 

--- a/lms/djangoapps/bulk_email/tests/test_forms.py
+++ b/lms/djangoapps/bulk_email/tests/test_forms.py
@@ -14,7 +14,6 @@ from xmodule.modulestore.tests.factories import CourseFactory
 
 class CourseAuthorizationFormTest(ModuleStoreTestCase):
     """Test the CourseAuthorizationAdminForm form for Mongo-backed courses."""
-    shard = 1
 
     def setUp(self):
         super(CourseAuthorizationFormTest, self).setUp()

--- a/lms/djangoapps/bulk_email/tests/test_models.py
+++ b/lms/djangoapps/bulk_email/tests/test_models.py
@@ -21,14 +21,12 @@ from bulk_email.models import (
 )
 from course_modes.models import CourseMode
 from openedx.core.djangoapps.course_groups.models import CourseCohort
-from openedx.core.lib.tests import attr
 from student.tests.factories import UserFactory
 from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
 from xmodule.modulestore.tests.factories import CourseFactory
 
 
 @ddt.ddt
-@attr(shard=1)
 @patch('bulk_email.models.html_to_text', Mock(return_value='Mocking CourseEmail.text_message', autospec=True))
 class CourseEmailTest(ModuleStoreTestCase):
     """Test the CourseEmail model."""
@@ -146,7 +144,6 @@ class CourseEmailTest(ModuleStoreTestCase):
         self.assertEqual(target.long_display(), 'Cohort: test cohort')
 
 
-@attr(shard=1)
 class NoCourseEmailTemplateTest(TestCase):
     """Test the CourseEmailTemplate model without loading the template data."""
 
@@ -155,7 +152,6 @@ class NoCourseEmailTemplateTest(TestCase):
             CourseEmailTemplate.get_template()
 
 
-@attr(shard=1)
 class CourseEmailTemplateTest(TestCase):
     """Test the CourseEmailTemplate model."""
 
@@ -254,7 +250,6 @@ class CourseEmailTemplateTest(TestCase):
         self.assertIn(context['name'], message)
 
 
-@attr(shard=1)
 class CourseAuthorizationTest(TestCase):
     """Test the CourseAuthorization model."""
 

--- a/lms/djangoapps/bulk_email/tests/test_signals.py
+++ b/lms/djangoapps/bulk_email/tests/test_signals.py
@@ -21,7 +21,6 @@ class TestOptoutCourseEmailsBySignal(ModuleStoreTestCase):
     """
     Tests that the force_optout_all signal receiver opts the user out of course emails
     """
-    shard = 1
 
     def setUp(self):
         super(TestOptoutCourseEmailsBySignal, self).setUp()

--- a/lms/djangoapps/bulk_email/tests/test_tasks.py
+++ b/lms/djangoapps/bulk_email/tests/test_tasks.py
@@ -76,7 +76,6 @@ def my_update_subtask_status(entry_id, current_task_id, new_subtask_status):
 @patch('bulk_email.models.html_to_text', Mock(return_value='Mocking CourseEmail.text_message', autospec=True))
 class TestBulkEmailInstructorTask(InstructorTaskCourseTestCase):
     """Tests instructor task that send bulk email."""
-    shard = 5
 
     def setUp(self):
         super(TestBulkEmailInstructorTask, self).setUp()

--- a/lms/djangoapps/bulk_enroll/tests/test_views.py
+++ b/lms/djangoapps/bulk_enroll/tests/test_views.py
@@ -34,7 +34,6 @@ class BulkEnrollmentTest(ModuleStoreTestCase, LoginEnrollmentTestCase, APITestCa
     """
     Test the bulk enrollment endpoint
     """
-    shard = 4
 
     USERNAME = "Bob"
     EMAIL = "bob@example.com"

--- a/lms/djangoapps/ccx/api/v0/tests/test_views.py
+++ b/lms/djangoapps/ccx/api/v0/tests/test_views.py
@@ -166,7 +166,6 @@ class CcxListTest(CcxRestApiTest):
     Test for the CCX REST APIs
     """
     ENABLED_SIGNALS = ['course_published']
-    shard = 9
 
     @classmethod
     def setUpClass(cls):
@@ -877,7 +876,6 @@ class CcxDetailTest(CcxRestApiTest):
     Test for the CCX REST APIs
     """
     ENABLED_SIGNALS = ['course_published']
-    shard = 9
 
     def setUp(self):
         """

--- a/lms/djangoapps/ccx/tests/test_ccx_modulestore.py
+++ b/lms/djangoapps/ccx/tests/test_ccx_modulestore.py
@@ -17,7 +17,6 @@ from xmodule.modulestore.tests.factories import CourseFactory, ItemFactory
 class TestCCXModulestoreWrapper(SharedModuleStoreTestCase):
     """tests for a modulestore wrapped by CCXModulestoreWrapper
     """
-    shard = 7
     MODULESTORE = TEST_DATA_SPLIT_MODULESTORE
 
     @classmethod

--- a/lms/djangoapps/ccx/tests/test_field_override_performance.py
+++ b/lms/djangoapps/ccx/tests/test_field_override_performance.py
@@ -53,7 +53,6 @@ class FieldOverridePerformanceTestCase(FieldOverrideTestMixin, ProceduralCourseT
     __test__ = False
     # Tell Django to clean out all databases, not just default
     multi_db = True
-    shard = 7
 
     # TEST_DATA must be overridden by subclasses
     TEST_DATA = None

--- a/lms/djangoapps/ccx/tests/test_models.py
+++ b/lms/djangoapps/ccx/tests/test_models.py
@@ -22,7 +22,6 @@ class TestCCX(ModuleStoreTestCase):
     """
 
     MODULESTORE = TEST_DATA_SPLIT_MODULESTORE
-    shard = 7
 
     def setUp(self):
         """common setup for all tests"""

--- a/lms/djangoapps/ccx/tests/test_overrides.py
+++ b/lms/djangoapps/ccx/tests/test_overrides.py
@@ -31,7 +31,6 @@ class TestFieldOverrides(FieldOverrideTestMixin, SharedModuleStoreTestCase):
     Make sure field overrides behave in the expected manner.
     """
     MODULESTORE = TEST_DATA_SPLIT_MODULESTORE
-    shard = 7
 
     @classmethod
     def setUpClass(cls):

--- a/lms/djangoapps/ccx/tests/test_tasks.py
+++ b/lms/djangoapps/ccx/tests/test_tasks.py
@@ -28,7 +28,6 @@ class TestSendCCXCoursePublished(ModuleStoreTestCase):
     """
     Unit tests for the send ccx course published task
     """
-    shard = 7
     MODULESTORE = TEST_DATA_SPLIT_MODULESTORE
 
     ENABLED_SIGNALS = ['course_published']

--- a/lms/djangoapps/ccx/tests/test_utils.py
+++ b/lms/djangoapps/ccx/tests/test_utils.py
@@ -22,7 +22,6 @@ from xmodule.modulestore.tests.factories import CourseFactory
 class TestGetCCXFromCCXLocator(ModuleStoreTestCase):
     """Verify that get_ccx_from_ccx_locator functions properly"""
     MODULESTORE = TEST_DATA_SPLIT_MODULESTORE
-    shard = 7
 
     def setUp(self):
         """Set up a course, coach, ccx and user"""

--- a/lms/djangoapps/ccx/tests/test_views.py
+++ b/lms/djangoapps/ccx/tests/test_views.py
@@ -37,7 +37,6 @@ from lms.djangoapps.ccx.views import get_date
 from lms.djangoapps.grades.tasks import compute_all_grades_for_course
 from lms.djangoapps.instructor.access import allow_access, list_with_level
 from openedx.core.djangoapps.content.course_overviews.models import CourseOverview
-from openedx.core.lib.tests import attr
 from student.models import CourseEnrollment, CourseEnrollmentAllowed
 from student.roles import CourseCcxCoachRole, CourseInstructorRole, CourseStaffRole
 from student.tests.factories import AdminFactory, CourseEnrollmentFactory, UserFactory
@@ -167,7 +166,6 @@ class TestAdminAccessCoachDashboard(CcxTestCase, LoginEnrollmentTestCase):
         self.assertEqual(response.status_code, 403)
 
 
-@attr(shard=7)
 @override_settings(
     XBLOCK_FIELD_DATA_WRAPPERS=['lms.djangoapps.courseware.field_overrides:OverrideModulestoreFieldData.wrap'],
     MODULESTORE_FIELD_OVERRIDE_PROVIDERS=['ccx.overrides.CustomCoursesForEdxOverrideProvider'],
@@ -282,7 +280,6 @@ class TestCCXProgressChanges(CcxTestCase, LoginEnrollmentTestCase):
         self.assert_progress_summary(ccx_course_key, due)
 
 
-@attr(shard=7)
 @override_settings(
     XBLOCK_FIELD_DATA_WRAPPERS=['lms.djangoapps.courseware.field_overrides:OverrideModulestoreFieldData.wrap'],
     MODULESTORE_FIELD_OVERRIDE_PROVIDERS=['ccx.overrides.CustomCoursesForEdxOverrideProvider'],
@@ -839,7 +836,6 @@ class TestCoachDashboard(CcxTestCase, LoginEnrollmentTestCase):
         )
 
 
-@attr(shard=7)
 class TestCoachDashboardSchedule(CcxTestCase, LoginEnrollmentTestCase, ModuleStoreTestCase):
     """
     Tests of the CCX Coach Dashboard which need to modify the course content.
@@ -981,7 +977,6 @@ def patched_get_children(self, usage_key_filter=None):
     return list(iter_children())
 
 
-@attr(shard=7)
 @override_settings(
     XBLOCK_FIELD_DATA_WRAPPERS=['lms.djangoapps.courseware.field_overrides:OverrideModulestoreFieldData.wrap'],
     MODULESTORE_FIELD_OVERRIDE_PROVIDERS=['ccx.overrides.CustomCoursesForEdxOverrideProvider'],

--- a/lms/djangoapps/certificates/apis/v0/tests/test_views.py
+++ b/lms/djangoapps/certificates/apis/v0/tests/test_views.py
@@ -25,7 +25,6 @@ class CertificatesRestApiTest(AuthAndScopesTestMixin, SharedModuleStoreTestCase,
     """
     Test for the Certificates REST APIs
     """
-    shard = 4
     now = timezone.now()
     default_scopes = CertificatesDetailView.required_scopes
 

--- a/lms/djangoapps/certificates/tests/test_api.py
+++ b/lms/djangoapps/certificates/tests/test_api.py
@@ -33,7 +33,6 @@ from course_modes.tests.factories import CourseModeFactory
 from courseware.tests.factories import GlobalStaffFactory
 from lms.djangoapps.grades.tests.utils import mock_passing_grade
 from microsite_configuration import microsite
-from openedx.core.lib.tests import attr
 from student.models import CourseEnrollment
 from student.tests.factories import UserFactory
 from util.testing import EventTestMixin
@@ -83,7 +82,6 @@ class WebCertificateTestMixin(object):
         self.store.update_item(self.course, self.user.id)
 
 
-@attr(shard=1)
 @ddt.ddt
 class CertificateDownloadableStatusTests(WebCertificateTestMixin, ModuleStoreTestCase):
     """Tests for the `certificate_downloadable_status` helper function. """
@@ -234,7 +232,6 @@ class CertificateDownloadableStatusTests(WebCertificateTestMixin, ModuleStoreTes
         )
 
 
-@attr(shard=1)
 @ddt.ddt
 class CertificateisInvalid(WebCertificateTestMixin, ModuleStoreTestCase):
     """Tests for the `is_certificate_invalid` helper function. """
@@ -346,7 +343,6 @@ class CertificateisInvalid(WebCertificateTestMixin, ModuleStoreTestCase):
         )
 
 
-@attr(shard=1)
 class CertificateGetTests(SharedModuleStoreTestCase):
     """Tests for the `test_get_certificate_for_user` helper function. """
     now = timezone.now()
@@ -514,7 +510,6 @@ class CertificateGetTests(SharedModuleStoreTestCase):
         )
 
 
-@attr(shard=1)
 @override_settings(CERT_QUEUE='certificates')
 class GenerateUserCertificatesTest(EventTestMixin, WebCertificateTestMixin, ModuleStoreTestCase):
     """Tests for generating certificates for students. """
@@ -610,7 +605,6 @@ class GenerateUserCertificatesTest(EventTestMixin, WebCertificateTestMixin, Modu
         self.assertEqual(url, "")
 
 
-@attr(shard=1)
 @ddt.ddt
 class CertificateGenerationEnabledTest(EventTestMixin, TestCase):
     """Test enabling/disabling self-generated certificates for a course. """
@@ -678,7 +672,6 @@ class CertificateGenerationEnabledTest(EventTestMixin, TestCase):
         self.assertEqual(expect_enabled, actual_enabled)
 
 
-@attr(shard=1)
 class GenerateExampleCertificatesTest(TestCase):
     """Test generation of example certificates. """
 
@@ -766,7 +759,6 @@ def set_microsite(domain):
 
 
 @override_settings(FEATURES=FEATURES_WITH_CERTS_ENABLED)
-@attr(shard=1)
 class CertificatesBrandingTest(TestCase):
     """Test certificates branding. """
 

--- a/lms/djangoapps/certificates/tests/test_cert_management.py
+++ b/lms/djangoapps/certificates/tests/test_cert_management.py
@@ -13,7 +13,6 @@ from badges.tests.factories import BadgeAssertionFactory, CourseCompleteImageCon
 from lms.djangoapps.certificates.models import CertificateStatuses, GeneratedCertificate
 from course_modes.models import CourseMode
 from lms.djangoapps.grades.tests.utils import mock_passing_grade
-from openedx.core.lib.tests import attr
 from student.tests.factories import CourseEnrollmentFactory, UserFactory
 from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
 from xmodule.modulestore.tests.factories import CourseFactory, ItemFactory, check_mongo_calls
@@ -60,7 +59,6 @@ class CertificateManagementTest(ModuleStoreTestCase):
         self.assertEqual(cert.status, expected_status)
 
 
-@attr(shard=1)
 @ddt.ddt
 class ResubmitErrorCertificatesTest(CertificateManagementTest):
     """Tests for the resubmit_error_certificates management command. """
@@ -149,7 +147,6 @@ class ResubmitErrorCertificatesTest(CertificateManagementTest):
 
 
 @ddt.ddt
-@attr(shard=1)
 class RegenerateCertificatesTest(CertificateManagementTest):
     """
     Tests for regenerating certificates.
@@ -219,7 +216,6 @@ class RegenerateCertificatesTest(CertificateManagementTest):
         self.assertFalse(mock_send_to_queue.called)
 
 
-@attr(shard=1)
 class UngenerateCertificatesTest(CertificateManagementTest):
     """
     Tests for generating certificates.

--- a/lms/djangoapps/certificates/tests/test_create_fake_cert.py
+++ b/lms/djangoapps/certificates/tests/test_create_fake_cert.py
@@ -12,7 +12,6 @@ from student.tests.factories import UserFactory
 
 class CreateFakeCertTest(TestCase):
     """Tests for the create_fake_certs management command. """
-    shard = 1
     USERNAME = "test"
     COURSE_KEY = CourseLocator(org='edX', course='DemoX', run='Demo_Course')
 

--- a/lms/djangoapps/certificates/tests/test_models.py
+++ b/lms/djangoapps/certificates/tests/test_models.py
@@ -22,7 +22,6 @@ from lms.djangoapps.certificates.models import (
 )
 from lms.djangoapps.certificates.tests.factories import CertificateInvalidationFactory, GeneratedCertificateFactory
 from lms.djangoapps.instructor_task.tests.factories import InstructorTaskFactory
-from openedx.core.lib.tests import attr
 from student.tests.factories import AdminFactory, UserFactory
 from xmodule.modulestore.tests.django_utils import SharedModuleStoreTestCase
 from xmodule.modulestore.tests.factories import CourseFactory
@@ -37,7 +36,6 @@ PLATFORM_ROOT = TEST_DIR.parent.parent.parent.parent
 TEST_DATA_ROOT = PLATFORM_ROOT / TEST_DATA_DIR
 
 
-@attr(shard=1)
 class ExampleCertificateTest(TestCase):
     """Tests for the ExampleCertificate model. """
 
@@ -103,7 +101,6 @@ class ExampleCertificateTest(TestCase):
         self.assertIs(result, None)
 
 
-@attr(shard=1)
 class CertificateHtmlViewConfigurationTest(TestCase):
     """
     Test the CertificateHtmlViewConfiguration model.
@@ -170,7 +167,6 @@ class CertificateHtmlViewConfigurationTest(TestCase):
         self.assertEquals(self.config.get_config(), {})
 
 
-@attr(shard=1)
 class CertificateTemplateAssetTest(TestCase):
     """
     Test Assets are uploading/saving successfully for CertificateTemplateAsset.
@@ -198,7 +194,6 @@ class CertificateTemplateAssetTest(TestCase):
         self.assertEqual(certificate_template_asset.asset, 'certificate_template_assets/1/picture2.jpg')
 
 
-@attr(shard=1)
 class EligibleCertificateManagerTest(SharedModuleStoreTestCase):
     """
     Test the GeneratedCertificate model's object manager for filtering
@@ -237,7 +232,6 @@ class EligibleCertificateManagerTest(SharedModuleStoreTestCase):
         )
 
 
-@attr(shard=1)
 @ddt.ddt
 class TestCertificateGenerationHistory(TestCase):
     """
@@ -303,7 +297,6 @@ class TestCertificateGenerationHistory(TestCase):
         )
 
 
-@attr(shard=1)
 class CertificateInvalidationTest(SharedModuleStoreTestCase):
     """
     Test for the Certificate Invalidation model.

--- a/lms/djangoapps/certificates/tests/test_queue.py
+++ b/lms/djangoapps/certificates/tests/test_queue.py
@@ -33,7 +33,6 @@ from xmodule.modulestore.tests.factories import CourseFactory
 @override_settings(CERT_QUEUE='certificates')
 class XQueueCertInterfaceAddCertificateTest(ModuleStoreTestCase):
     """Test the "add to queue" operation of the XQueue interface. """
-    shard = 1
 
     def setUp(self):
         super(XQueueCertInterfaceAddCertificateTest, self).setUp()
@@ -281,7 +280,6 @@ class XQueueCertInterfaceAddCertificateTest(ModuleStoreTestCase):
 @override_settings(CERT_QUEUE='certificates')
 class XQueueCertInterfaceExampleCertificateTest(TestCase):
     """Tests for the XQueue interface for certificate generation. """
-    shard = 1
 
     COURSE_KEY = CourseLocator(org='test', course='test', run='test')
 

--- a/lms/djangoapps/certificates/tests/test_services.py
+++ b/lms/djangoapps/certificates/tests/test_services.py
@@ -13,7 +13,6 @@ class CertificateServiceTests(ModuleStoreTestCase):
     """
     Tests for the Certificate service
     """
-    shard = 4
 
     def setUp(self):
         super(CertificateServiceTests, self).setUp()

--- a/lms/djangoapps/certificates/tests/test_signals.py
+++ b/lms/djangoapps/certificates/tests/test_signals.py
@@ -26,7 +26,6 @@ class SelfGeneratedCertsSignalTest(ModuleStoreTestCase):
     """
     Tests for enabling/disabling self-generated certificates according to course-pacing.
     """
-    shard = 4
     ENABLED_SIGNALS = ['course_published']
 
     def setUp(self):
@@ -54,7 +53,6 @@ class WhitelistGeneratedCertificatesTest(ModuleStoreTestCase):
     """
     Tests for whitelisted student auto-certificate generation
     """
-    shard = 4
 
     def setUp(self):
         super(WhitelistGeneratedCertificatesTest, self).setUp()
@@ -135,7 +133,6 @@ class PassingGradeCertsTest(ModuleStoreTestCase):
     """
     Tests for certificate generation task firing on passing grade receipt
     """
-    shard = 4
 
     def setUp(self):
         super(PassingGradeCertsTest, self).setUp()
@@ -229,7 +226,6 @@ class FailingGradeCertsTest(ModuleStoreTestCase):
     and that the signal has no effect on the cert status if the cert has a non-passing
     status
     """
-    shard = 4
 
     def setUp(self):
         super(FailingGradeCertsTest, self).setUp()
@@ -285,7 +281,6 @@ class LearnerTrackChangeCertsTest(ModuleStoreTestCase):
     """
     Tests for certificate generation task firing on learner verification
     """
-    shard = 4
 
     def setUp(self):
         super(LearnerTrackChangeCertsTest, self).setUp()
@@ -358,7 +353,6 @@ class CertificateGenerationTaskTest(ModuleStoreTestCase):
     """
     Tests for certificate generation task.
     """
-    shard = 4
 
     def setUp(self):
         super(CertificateGenerationTaskTest, self).setUp()

--- a/lms/djangoapps/certificates/tests/test_support_views.py
+++ b/lms/djangoapps/certificates/tests/test_support_views.py
@@ -26,7 +26,6 @@ class CertificateSupportTestCase(ModuleStoreTestCase):
     """
     Base class for tests of the certificate support views.
     """
-    shard = 4
 
     SUPPORT_USERNAME = "support"
     SUPPORT_EMAIL = "support@example.com"
@@ -92,7 +91,6 @@ class CertificateSearchTests(CertificateSupportTestCase):
     """
     Tests for the certificate search end-point used by the support team.
     """
-    shard = 4
 
     def setUp(self):
         """
@@ -229,7 +227,6 @@ class CertificateRegenerateTests(CertificateSupportTestCase):
     """
     Tests for the certificate regeneration end-point used by the support team.
     """
-    shard = 4
 
     def setUp(self):
         """
@@ -412,7 +409,6 @@ class CertificateGenerateTests(CertificateSupportTestCase):
     """
     Tests for the certificate generation end-point used by the support team.
     """
-    shard = 4
 
     def setUp(self):
         """

--- a/lms/djangoapps/certificates/tests/test_tasks.py
+++ b/lms/djangoapps/certificates/tests/test_tasks.py
@@ -10,7 +10,6 @@ from student.tests.factories import UserFactory
 
 @ddt.ddt
 class GenerateUserCertificateTest(TestCase):
-    shard = 4
 
     @patch('lms.djangoapps.certificates.tasks.generate_user_certificates')
     @patch('lms.djangoapps.certificates.tasks.User.objects.get')

--- a/lms/djangoapps/certificates/tests/test_views.py
+++ b/lms/djangoapps/certificates/tests/test_views.py
@@ -39,7 +39,6 @@ FEATURES_WITH_CUSTOM_CERTS_ENABLED.update(FEATURES_WITH_CERTS_ENABLED)
 @ddt.ddt
 class UpdateExampleCertificateViewTest(CacheIsolationTestCase):
     """Tests for the XQueue callback that updates example certificates. """
-    shard = 1
 
     COURSE_KEY = CourseLocator(org='test', course='test', run='test')
 
@@ -184,7 +183,6 @@ class MicrositeCertificatesViewsTests(ModuleStoreTestCase):
     """
     Tests for the microsite certificates web/html views
     """
-    shard = 1
 
     def setUp(self):
         super(MicrositeCertificatesViewsTests, self).setUp()

--- a/lms/djangoapps/certificates/tests/test_webview_views.py
+++ b/lms/djangoapps/certificates/tests/test_webview_views.py
@@ -246,7 +246,6 @@ class CertificatesViewsTests(CommonCertificatesTestCase, CacheIsolationTestCase)
     """
     Tests for the certificates web/html views
     """
-    shard = 1
 
     def setUp(self):
         super(CertificatesViewsTests, self).setUp()
@@ -1715,7 +1714,6 @@ class CertificateEventTests(CommonCertificatesTestCase, EventTrackingTestCase):
     """
     Test events emitted by certificate handling.
     """
-    shard = 1
 
     @override_settings(FEATURES=FEATURES_WITH_CERTS_ENABLED)
     def test_certificate_evidence_event_emitted(self):

--- a/lms/djangoapps/certificates/tests/tests.py
+++ b/lms/djangoapps/certificates/tests/tests.py
@@ -28,7 +28,6 @@ class CertificatesModelTest(ModuleStoreTestCase, MilestonesTestCaseMixin):
     """
     Tests for the GeneratedCertificate model
     """
-    shard = 1
 
     def setUp(self):
         super(CertificatesModelTest, self).setUp()

--- a/lms/djangoapps/class_dashboard/tests/test_dashboard_data.py
+++ b/lms/djangoapps/class_dashboard/tests/test_dashboard_data.py
@@ -35,7 +35,6 @@ class TestGetProblemGradeDistribution(SharedModuleStoreTestCase):
     """
     Tests related to class_dashboard/dashboard_data.py
     """
-    shard = 6
 
     @classmethod
     def setUpClass(cls):

--- a/lms/djangoapps/class_dashboard/tests/test_views.py
+++ b/lms/djangoapps/class_dashboard/tests/test_views.py
@@ -17,7 +17,6 @@ class TestViews(ModuleStoreTestCase):
     """
     Tests related to class_dashboard/views.py
     """
-    shard = 1
 
     def setUp(self):
         super(TestViews, self).setUp()

--- a/lms/djangoapps/commerce/api/v0/tests/test_views.py
+++ b/lms/djangoapps/commerce/api/v0/tests/test_views.py
@@ -39,7 +39,6 @@ class BasketsViewTests(EnrollmentEventTestMixin, UserMixin, ModuleStoreTestCase)
     """
     Tests for the commerce Baskets view.
     """
-    shard = 1
 
     def _post_to_view(self, course_id=None, marketing_email_opt_in=False, include_utm_cookie=False):
         """
@@ -284,7 +283,6 @@ class BasketOrderViewTests(UserMixin, TestCase):
     view_name = 'commerce_api:v0:baskets:retrieve_order'
     MOCK_ORDER = {'number': 1}
     path = reverse_lazy(view_name, kwargs={'basket_id': 1})
-    shard = 1
 
     def setUp(self):
         super(BasketOrderViewTests, self).setUp()

--- a/lms/djangoapps/commerce/api/v1/tests/test_models.py
+++ b/lms/djangoapps/commerce/api/v1/tests/test_models.py
@@ -10,7 +10,6 @@ from ..models import Course
 @ddt.ddt
 class CourseTests(TestCase):
     """ Tests for Course model. """
-    shard = 4
 
     def setUp(self):
         super(CourseTests, self).setUp()

--- a/lms/djangoapps/commerce/api/v1/tests/test_serializers.py
+++ b/lms/djangoapps/commerce/api/v1/tests/test_serializers.py
@@ -6,7 +6,6 @@ from ..serializers import serializers, validate_course_id
 
 class CourseValidatorTests(TestCase):
     """ Tests for Course Validator method. """
-    shard = 4
 
     def test_validate_course_id_with_non_existent_course(self):
         """ Verify a validator checking non-existent courses."""

--- a/lms/djangoapps/commerce/api/v1/tests/test_views.py
+++ b/lms/djangoapps/commerce/api/v1/tests/test_views.py
@@ -109,7 +109,6 @@ class CourseRetrieveUpdateViewTests(CourseApiViewTestMixin, ModuleStoreTestCase)
         NOW: datetime.now(),
         None: None,
     }
-    shard = 3
 
     def setUp(self):
         super(CourseRetrieveUpdateViewTests, self).setUp()
@@ -398,7 +397,6 @@ class OrderViewTests(UserMixin, TestCase):
     ORDER_NUMBER = 'EDX-100001'
     MOCK_ORDER = {'number': ORDER_NUMBER}
     path = reverse_lazy(view_name, kwargs={'number': ORDER_NUMBER})
-    shard = 1
 
     def setUp(self):
         super(OrderViewTests, self).setUp()

--- a/lms/djangoapps/commerce/management/commands/tests/test_configure_commerce.py
+++ b/lms/djangoapps/commerce/management/commands/tests/test_configure_commerce.py
@@ -11,7 +11,6 @@ class TestCommerceConfigurationCommand(TestCase):
     """
     Test django management command for enabling commerce configuration.
     """
-    shard = 4
 
     def test_commerce_configuration(self):
         """

--- a/lms/djangoapps/commerce/tests/test_signals.py
+++ b/lms/djangoapps/commerce/tests/test_signals.py
@@ -37,7 +37,6 @@ class TestRefundSignal(TestCase):
     """
     Exercises logic triggered by the REFUND_ORDER signal.
     """
-    shard = 4
 
     def setUp(self):
         super(TestRefundSignal, self).setUp()

--- a/lms/djangoapps/commerce/tests/test_utils.py
+++ b/lms/djangoapps/commerce/tests/test_utils.py
@@ -38,7 +38,6 @@ def update_commerce_config(enabled=False, checkout_page='/test_basket/add/'):
 
 class AuditLogTests(TestCase):
     """Tests of the commerce audit logging helper."""
-    shard = 4
 
     @patch('openedx.core.lib.log_utils.log')
     def test_log_message(self, mock_log):
@@ -54,7 +53,6 @@ class AuditLogTests(TestCase):
 @ddt.ddt
 class EcommerceServiceTests(TestCase):
     """Tests for the EcommerceService helper class."""
-    shard = 4
 
     def setUp(self):
         self.request_factory = RequestFactory()
@@ -185,7 +183,6 @@ class EcommerceServiceTests(TestCase):
 @skip_unless_lms
 class RefundUtilMethodTests(ModuleStoreTestCase):
     """Tests for Refund Utilities"""
-    shard = 4
 
     def setUp(self):
         super(RefundUtilMethodTests, self).setUp()

--- a/lms/djangoapps/commerce/tests/test_views.py
+++ b/lms/djangoapps/commerce/tests/test_views.py
@@ -29,7 +29,6 @@ class UserMixin(object):
 @ddt.ddt
 class ReceiptViewTests(UserMixin, ModuleStoreTestCase):
     """ Tests for the receipt view. """
-    shard = 1
 
     def setUp(self):
         """

--- a/lms/djangoapps/course_api/blocks/tests/test_api.py
+++ b/lms/djangoapps/course_api/blocks/tests/test_api.py
@@ -27,7 +27,6 @@ class TestGetBlocks(SharedModuleStoreTestCase):
     """
     Tests for the get_blocks function
     """
-    shard = 4
 
     @classmethod
     def setUpClass(cls):
@@ -117,7 +116,6 @@ class TestGetBlocksMobileHack(SharedModuleStoreTestCase):
     """
     Tests that requests from the mobile app don't receive empty containers.
     """
-    shard = 4
 
     @classmethod
     def setUpClass(cls):
@@ -165,7 +163,6 @@ class TestGetBlocksQueryCountsBase(SharedModuleStoreTestCase):
     """
     Base for the get_blocks tests.
     """
-    shard = 4
 
     ENABLED_SIGNALS = ['course_published']
 
@@ -198,7 +195,6 @@ class TestGetBlocksQueryCounts(TestGetBlocksQueryCountsBase):
     """
     Tests query counts for the get_blocks function.
     """
-    shard = 4
 
     @ddt.data(
         *product(
@@ -247,7 +243,6 @@ class TestQueryCountsWithIndividualOverrideProvider(TestGetBlocksQueryCountsBase
     """
     Tests query counts for the get_blocks function when IndividualStudentOverrideProvider is set.
     """
-    shard = 4
 
     @ddt.data(
         *product(

--- a/lms/djangoapps/course_api/blocks/tests/test_forms.py
+++ b/lms/djangoapps/course_api/blocks/tests/test_forms.py
@@ -22,7 +22,6 @@ class TestBlockListGetForm(FormTestMixin, SharedModuleStoreTestCase):
     """
     Tests for BlockListGetForm
     """
-    shard = 4
 
     FORM_CLASS = BlockListGetForm
 

--- a/lms/djangoapps/course_api/blocks/tests/test_serializers.py
+++ b/lms/djangoapps/course_api/blocks/tests/test_serializers.py
@@ -20,7 +20,6 @@ class TestBlockSerializerBase(SharedModuleStoreTestCase):
     """
     Base class for testing BlockSerializer and BlockDictSerializer
     """
-    shard = 4
 
     @classmethod
     def setUpClass(cls):
@@ -153,7 +152,6 @@ class TestBlockSerializer(TestBlockSerializerBase):
     """
     Tests the BlockSerializer class, which returns a list of blocks.
     """
-    shard = 4
 
     def create_serializer(self, context=None):
         """
@@ -195,7 +193,6 @@ class TestBlockDictSerializer(TestBlockSerializerBase):
     """
     Tests the BlockDictSerializer class, which returns a dict of blocks key-ed by its block_key.
     """
-    shard = 4
 
     def create_serializer(self, context=None):
         """

--- a/lms/djangoapps/course_api/blocks/tests/test_views.py
+++ b/lms/djangoapps/course_api/blocks/tests/test_views.py
@@ -21,7 +21,6 @@ class TestBlocksView(SharedModuleStoreTestCase):
     """
     Test class for BlocksView
     """
-    shard = 4
     requested_fields = ['graded', 'format', 'student_view_multi_device', 'children', 'not_a_field', 'due']
     BLOCK_TYPES_WITH_STUDENT_VIEW_DATA = ['video', 'discussion', 'html']
 
@@ -251,7 +250,6 @@ class TestBlocksInCourseView(TestBlocksView):
     """
     Test class for BlocksInCourseView
     """
-    shard = 4
 
     def setUp(self):
         super(TestBlocksInCourseView, self).setUp()

--- a/lms/djangoapps/course_api/blocks/transformers/tests/test_block_completion.py
+++ b/lms/djangoapps/course_api/blocks/transformers/tests/test_block_completion.py
@@ -41,7 +41,6 @@ class BlockCompletionTransformerTestCase(TransformerRegistryTestMixin, Completio
     """
     Tests behaviour of BlockCompletionTransformer
     """
-    shard = 4
     TRANSFORMER_CLASS_TO_TEST = BlockCompletionTransformer
     COMPLETION_TEST_VALUE = 0.4
 

--- a/lms/djangoapps/course_api/blocks/transformers/tests/test_block_counts.py
+++ b/lms/djangoapps/course_api/blocks/transformers/tests/test_block_counts.py
@@ -14,7 +14,6 @@ class TestBlockCountsTransformer(ModuleStoreTestCase):
     """
     Test behavior of BlockCountsTransformer
     """
-    shard = 4
 
     def setUp(self):
         super(TestBlockCountsTransformer, self).setUp()

--- a/lms/djangoapps/course_api/blocks/transformers/tests/test_block_depth.py
+++ b/lms/djangoapps/course_api/blocks/transformers/tests/test_block_depth.py
@@ -19,7 +19,6 @@ class BlockDepthTransformerTestCase(TestCase, ChildrenMapTestMixin):
     """
     Test behavior of BlockDepthTransformer
     """
-    shard = 4
 
     @ddt.data(
         (0, [], [], []),

--- a/lms/djangoapps/course_api/blocks/transformers/tests/test_milestones.py
+++ b/lms/djangoapps/course_api/blocks/transformers/tests/test_milestones.py
@@ -22,7 +22,6 @@ class MilestonesTransformerTestCase(CourseStructureTestCase, MilestonesTestCaseM
     Test behavior of ProctoredExamTransformer
     """
     TRANSFORMER_CLASS_TO_TEST = MilestonesAndSpecialExamsTransformer
-    shard = 3
 
     def setUp(self):
         """

--- a/lms/djangoapps/course_api/blocks/transformers/tests/test_navigation.py
+++ b/lms/djangoapps/course_api/blocks/transformers/tests/test_navigation.py
@@ -21,7 +21,6 @@ class BlockNavigationTransformerTestCase(TestCase, ChildrenMapTestMixin):
     """
     Course-agnostic test class for testing the Navigation transformer.
     """
-    shard = 4
 
     @ddt.data(
         (0, 0, [], []),
@@ -72,7 +71,6 @@ class BlockNavigationTransformerCourseTestCase(ModuleStoreTestCase):
     Uses SampleCourseFactory and Modulestore to test the Navigation transformer,
     specifically to test enforcement of the hide_from_toc field
     """
-    shard = 4
 
     def test_hide_from_toc(self):
         course_key = SampleCourseFactory.create().id

--- a/lms/djangoapps/course_api/blocks/transformers/tests/test_student_view.py
+++ b/lms/djangoapps/course_api/blocks/transformers/tests/test_student_view.py
@@ -16,7 +16,6 @@ class TestStudentViewTransformer(ModuleStoreTestCase):
     """
     Test proper behavior for StudentViewTransformer
     """
-    shard = 4
 
     def setUp(self):
         super(TestStudentViewTransformer, self).setUp()

--- a/lms/djangoapps/course_api/tests/test_api.py
+++ b/lms/djangoapps/course_api/tests/test_api.py
@@ -22,7 +22,6 @@ class CourseApiTestMixin(CourseApiFactoryMixin):
     """
     Establish basic functionality for Course API tests
     """
-    shard = 4
 
     @classmethod
     def setUpClass(cls):
@@ -58,7 +57,6 @@ class TestGetCourseDetail(CourseDetailTestMixin, SharedModuleStoreTestCase):
     """
     Test course_detail api function
     """
-    shard = 4
 
     @classmethod
     def setUpClass(cls):
@@ -94,7 +92,6 @@ class CourseListTestMixin(CourseApiTestMixin):
     """
     Common behavior for list_courses tests
     """
-    shard = 4
 
     def _make_api_call(self, requesting_user, specified_user, org=None, filter_=None):
         """
@@ -118,7 +115,6 @@ class TestGetCourseList(CourseListTestMixin, SharedModuleStoreTestCase):
     """
     Test the behavior of the `list_courses` api function.
     """
-    shard = 4
     ENABLED_SIGNALS = ['course_published']
 
     @classmethod
@@ -161,7 +157,6 @@ class TestGetCourseListMultipleCourses(CourseListTestMixin, ModuleStoreTestCase)
     Test the behavior of the `list_courses` api function (with tests that
     modify the courseware).
     """
-    shard = 4
     ENABLED_SIGNALS = ['course_published']
 
     def setUp(self):
@@ -220,7 +215,6 @@ class TestGetCourseListExtras(CourseListTestMixin, ModuleStoreTestCase):
     Tests of course_list api function that require alternative configurations
     of created courses.
     """
-    shard = 4
     ENABLED_SIGNALS = ['course_published']
 
     @classmethod

--- a/lms/djangoapps/course_api/tests/test_forms.py
+++ b/lms/djangoapps/course_api/tests/test_forms.py
@@ -21,7 +21,6 @@ class UsernameTestMixin(object):
     """
     Tests the username Form field.
     """
-    shard = 4
 
     def test_no_user_param_anonymous_access(self):
         self.set_up_data(AnonymousUser())
@@ -39,7 +38,6 @@ class TestCourseListGetForm(FormTestMixin, UsernameTestMixin, SharedModuleStoreT
     """
     Tests for CourseListGetForm
     """
-    shard = 4
     FORM_CLASS = CourseListGetForm
 
     @classmethod
@@ -105,7 +103,6 @@ class TestCourseDetailGetForm(FormTestMixin, UsernameTestMixin, SharedModuleStor
     """
     Tests for CourseDetailGetForm
     """
-    shard = 4
     FORM_CLASS = CourseDetailGetForm
 
     @classmethod

--- a/lms/djangoapps/course_api/tests/test_permissions.py
+++ b/lms/djangoapps/course_api/tests/test_permissions.py
@@ -16,7 +16,6 @@ class ViewCoursesForUsernameTestCase(CourseApiFactoryMixin, TestCase):
     Any user should be able to view their own courses, and staff users
     should be able to view anyone's courses.
     """
-    shard = 4
 
     @classmethod
     def setUpClass(cls):

--- a/lms/djangoapps/course_api/tests/test_serializers.py
+++ b/lms/djangoapps/course_api/tests/test_serializers.py
@@ -29,7 +29,6 @@ class TestCourseSerializer(CourseApiFactoryMixin, ModuleStoreTestCase):
     expected_mongo_calls = 0
     maxDiff = 5000  # long enough to show mismatched dicts, in case of error
     serializer_class = CourseSerializer
-    shard = 3
 
     ENABLED_SIGNALS = ['course_published']
 

--- a/lms/djangoapps/course_api/tests/test_views.py
+++ b/lms/djangoapps/course_api/tests/test_views.py
@@ -16,7 +16,6 @@ from search.tests.utils import SearcherMixin
 from course_modes.models import CourseMode
 from course_modes.tests.factories import CourseModeFactory
 from edx_django_utils.cache import RequestCache
-from openedx.core.lib.tests import attr
 from openedx.features.content_type_gating.models import ContentTypeGatingConfig
 from openedx.features.course_duration_limits.models import CourseDurationLimitConfig
 from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase, SharedModuleStoreTestCase
@@ -62,7 +61,6 @@ class CourseApiTestViewMixin(CourseApiFactoryMixin):
         return response
 
 
-@attr(shard=9)
 @ddt.ddt
 class CourseListViewTestCase(CourseApiTestViewMixin, SharedModuleStoreTestCase):
     """
@@ -144,7 +142,6 @@ class CourseListViewTestCase(CourseApiTestViewMixin, SharedModuleStoreTestCase):
         self.assert_throttle_configured_correctly(user_scope, throws_exception, expected_rate)
 
 
-@attr(shard=9)
 class CourseListViewTestCaseMultipleCourses(CourseApiTestViewMixin, ModuleStoreTestCase):
     """
     Test responses returned from CourseListView (with tests that modify the
@@ -206,7 +203,6 @@ class CourseListViewTestCaseMultipleCourses(CourseApiTestViewMixin, ModuleStoreT
             )
 
 
-@attr(shard=9)
 class CourseDetailViewTestCase(CourseApiTestViewMixin, SharedModuleStoreTestCase):
     """
     Test responses returned from CourseDetailView.
@@ -274,7 +270,6 @@ class CourseDetailViewTestCase(CourseApiTestViewMixin, SharedModuleStoreTestCase
         self.assertEquals(response.status_code, 400)
 
 
-@attr(shard=9)
 @override_settings(ELASTIC_FIELD_MAPPINGS={
     'start_date': {'type': 'date'},
     'enrollment_start': {'type': 'date'},

--- a/lms/djangoapps/course_blocks/transformers/tests/test_hidden_content.py
+++ b/lms/djangoapps/course_blocks/transformers/tests/test_hidden_content.py
@@ -17,7 +17,6 @@ class HiddenContentTransformerTestCase(BlockParentsMapTestCase):
     """
     TRANSFORMER_CLASS_TO_TEST = HiddenContentTransformer
     ALL_BLOCKS = {0, 1, 2, 3, 4, 5, 6}
-    shard = 3
 
     class DueDateType(object):
         """

--- a/lms/djangoapps/course_blocks/transformers/tests/test_library_content.py
+++ b/lms/djangoapps/course_blocks/transformers/tests/test_library_content.py
@@ -26,7 +26,6 @@ class ContentLibraryTransformerTestCase(CourseStructureTestCase):
     """
     ContentLibraryTransformer Test
     """
-    shard = 4
     TRANSFORMER_CLASS_TO_TEST = ContentLibraryTransformer
 
     def setUp(self):

--- a/lms/djangoapps/course_blocks/transformers/tests/test_load_override_data.py
+++ b/lms/djangoapps/course_blocks/transformers/tests/test_load_override_data.py
@@ -30,7 +30,6 @@ class TestOverrideDataTransformer(ModuleStoreTestCase):
     """
     Test proper behavior for OverrideDataTransformer
     """
-    shard = 4
 
     @classmethod
     def setUpClass(cls):

--- a/lms/djangoapps/course_blocks/transformers/tests/test_split_test.py
+++ b/lms/djangoapps/course_blocks/transformers/tests/test_split_test.py
@@ -22,7 +22,6 @@ class SplitTestTransformerTestCase(CourseStructureTestCase):
     """
     TEST_PARTITION_ID = 0
     TRANSFORMER_CLASS_TO_TEST = UserPartitionTransformer
-    shard = 3
 
     def setUp(self):
         """

--- a/lms/djangoapps/course_blocks/transformers/tests/test_start_date.py
+++ b/lms/djangoapps/course_blocks/transformers/tests/test_start_date.py
@@ -21,7 +21,6 @@ class StartDateTransformerTestCase(BlockParentsMapTestCase):
     STUDENT = 1
     BETA_USER = 2
     TRANSFORMER_CLASS_TO_TEST = StartDateTransformer
-    shard = 3
 
     class StartDateType(object):
         """

--- a/lms/djangoapps/course_blocks/transformers/tests/test_user_partitions.py
+++ b/lms/djangoapps/course_blocks/transformers/tests/test_user_partitions.py
@@ -73,7 +73,6 @@ class UserPartitionTransformerTestCase(UserPartitionTestMixin, CourseStructureTe
     """
     UserPartitionTransformer Test
     """
-    shard = 3
 
     def setup_partitions_and_course(self, active=True):
         """
@@ -247,7 +246,6 @@ class MergedGroupAccessTestData(UserPartitionTestMixin, CourseStructureTestCase)
     """
     _MergedGroupAccess Test
     """
-    shard = 3
 
     def setUp(self):
         """

--- a/lms/djangoapps/course_blocks/transformers/tests/test_visibility.py
+++ b/lms/djangoapps/course_blocks/transformers/tests/test_visibility.py
@@ -13,7 +13,6 @@ class VisibilityTransformerTestCase(BlockParentsMapTestCase):
     VisibilityTransformer Test
     """
     TRANSFORMER_CLASS_TO_TEST = VisibilityTransformer
-    shard = 3
 
     # Following test cases are based on BlockParentsMapTestCase.parents_map
     @ddt.data(

--- a/lms/djangoapps/course_goals/tests/test_api.py
+++ b/lms/djangoapps/course_goals/tests/test_api.py
@@ -22,7 +22,6 @@ class TestCourseGoalsAPI(EventTrackingTestCase, SharedModuleStoreTestCase):
     """
     Testing the Course Goals API.
     """
-    shard = 4
 
     def setUp(self):
         # Create a course with a verified track

--- a/lms/djangoapps/course_wiki/tests/test_access.py
+++ b/lms/djangoapps/course_wiki/tests/test_access.py
@@ -9,7 +9,6 @@ from course_wiki import settings
 from course_wiki.utils import course_wiki_slug, user_is_article_course_staff
 from course_wiki.views import get_or_create_root
 from courseware.tests.factories import InstructorFactory, StaffFactory
-from openedx.core.lib.tests import attr
 from student.tests.factories import UserFactory
 from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
 from xmodule.modulestore.tests.factories import CourseFactory
@@ -51,7 +50,6 @@ class TestWikiAccessBase(ModuleStoreTestCase):
         ]
 
 
-@attr(shard=1)
 class TestWikiAccess(TestWikiAccessBase):
     """Test wiki access for course staff."""
     def setUp(self):
@@ -112,7 +110,6 @@ class TestWikiAccess(TestWikiAccessBase):
             self.assertFalse(user_is_article_course_staff(course_staff, self.wiki_310b.article))
 
 
-@attr(shard=1)
 class TestWikiAccessForStudent(TestWikiAccessBase):
     """Test access for students."""
     def setUp(self):
@@ -128,7 +125,6 @@ class TestWikiAccessForStudent(TestWikiAccessBase):
             self.assertFalse(user_is_article_course_staff(self.student, page.article))
 
 
-@attr(shard=1)
 class TestWikiAccessForNumericalCourseNumber(TestWikiAccessBase):
     """Test staff has access if course number is numerical and wiki slug has an underscore appended."""
     def setUp(self):
@@ -148,7 +144,6 @@ class TestWikiAccessForNumericalCourseNumber(TestWikiAccessBase):
                 self.assertTrue(user_is_article_course_staff(course_staff, page.article))
 
 
-@attr(shard=1)
 class TestWikiAccessForOldFormatCourseStaffGroups(TestWikiAccessBase):
     """Test staff has access if course group has old format."""
     def setUp(self):

--- a/lms/djangoapps/course_wiki/tests/test_comprehensive_theming.py
+++ b/lms/djangoapps/course_wiki/tests/test_comprehensive_theming.py
@@ -15,7 +15,6 @@ from xmodule.modulestore.tests.factories import CourseFactory
 
 class TestComprehensiveTheming(ModuleStoreTestCase):
     """Tests for comprehensive theming of wiki pages."""
-    shard = 1
 
     def setUp(self):
         """Test setup."""

--- a/lms/djangoapps/course_wiki/tests/test_middleware.py
+++ b/lms/djangoapps/course_wiki/tests/test_middleware.py
@@ -13,7 +13,6 @@ from xmodule.modulestore.tests.factories import CourseFactory
 
 class TestWikiAccessMiddleware(ModuleStoreTestCase):
     """Tests for WikiAccessMiddleware."""
-    shard = 1
 
     def setUp(self):
         """Test setup."""

--- a/lms/djangoapps/course_wiki/tests/test_tab.py
+++ b/lms/djangoapps/course_wiki/tests/test_tab.py
@@ -13,7 +13,6 @@ from xmodule.modulestore.tests.factories import CourseFactory
 
 class WikiTabTestCase(ModuleStoreTestCase):
     """Test cases for Wiki Tab."""
-    shard = 4
 
     def setUp(self):
         super(WikiTabTestCase, self).setUp()

--- a/lms/djangoapps/course_wiki/tests/tests.py
+++ b/lms/djangoapps/course_wiki/tests/tests.py
@@ -16,7 +16,6 @@ class WikiRedirectTestCase(EnterpriseTestConsentRequired, LoginEnrollmentTestCas
     """
     Tests for wiki course redirection.
     """
-    shard = 1
 
     def setUp(self):
         super(WikiRedirectTestCase, self).setUp()

--- a/lms/djangoapps/courseware/management/commands/tests/test_dump_course.py
+++ b/lms/djangoapps/courseware/management/commands/tests/test_dump_course.py
@@ -37,7 +37,6 @@ class CommandsTestBase(SharedModuleStoreTestCase):
     __test__ = False
     url_name = '2012_Fall'
     ENABLED_SIGNALS = ['course_published']
-    shard = 1
 
     @classmethod
     def setUpClass(cls):

--- a/lms/djangoapps/courseware/tests/test_about.py
+++ b/lms/djangoapps/courseware/tests/test_about.py
@@ -16,7 +16,6 @@ from waffle.testutils import override_switch
 
 from course_modes.models import CourseMode
 from lms.djangoapps.ccx.tests.factories import CcxFactory
-from openedx.core.lib.tests import attr
 from openedx.core.djangoapps.waffle_utils.testutils import override_waffle_flag
 from openedx.features.course_experience.waffle import WAFFLE_NAMESPACE as COURSE_EXPERIENCE_WAFFLE_NAMESPACE
 from openedx.features.course_experience.waffle import ENABLE_COURSE_ABOUT_SIDEBAR_HTML
@@ -51,7 +50,6 @@ SHIB_ERROR_STR = "The currently logged-in user account does not have permission 
 
 
 @ddt.ddt
-@attr(shard=1)
 class AboutTestCase(LoginEnrollmentTestCase, SharedModuleStoreTestCase, EventTrackingTestCase, MilestonesTestCaseMixin):
     """
     Tests about xblock.
@@ -254,7 +252,6 @@ class AboutTestCase(LoginEnrollmentTestCase, SharedModuleStoreTestCase, EventTra
             self.assertIn("Enroll in", resp.content)
 
 
-@attr(shard=1)
 class AboutTestCaseXML(LoginEnrollmentTestCase, ModuleStoreTestCase):
     """
     Tests for the course about page
@@ -302,7 +299,6 @@ class AboutTestCaseXML(LoginEnrollmentTestCase, ModuleStoreTestCase):
         self.assertIn(self.xml_data, resp.content)
 
 
-@attr(shard=1)
 class AboutWithCappedEnrollmentsTestCase(LoginEnrollmentTestCase, SharedModuleStoreTestCase):
     """
     This test case will check the About page when a course has a capped enrollment
@@ -349,7 +345,6 @@ class AboutWithCappedEnrollmentsTestCase(LoginEnrollmentTestCase, SharedModuleSt
         self.assertNotIn(REG_STR, resp.content)
 
 
-@attr(shard=1)
 class AboutWithInvitationOnly(SharedModuleStoreTestCase):
     """
     This test case will check the About page when a course is invitation only.
@@ -395,7 +390,6 @@ class AboutWithInvitationOnly(SharedModuleStoreTestCase):
         self.assertIn(REG_STR, resp.content)
 
 
-@attr(shard=1)
 @patch.dict(settings.FEATURES, {'RESTRICT_ENROLL_BY_REG_METHOD': True})
 class AboutTestCaseShibCourse(LoginEnrollmentTestCase, SharedModuleStoreTestCase):
     """
@@ -436,7 +430,6 @@ class AboutTestCaseShibCourse(LoginEnrollmentTestCase, SharedModuleStoreTestCase
         self.assertIn(REG_STR, resp.content)
 
 
-@attr(shard=1)
 class AboutWithClosedEnrollment(ModuleStoreTestCase):
     """
     This test case will check the About page for a course that has enrollment start/end
@@ -479,7 +472,6 @@ class AboutWithClosedEnrollment(ModuleStoreTestCase):
         self.assertNotIn('<span class="important-dates-item-text">$10</span>', resp.content)
 
 
-@attr(shard=1)
 @ddt.ddt
 class AboutSidebarHTMLTestCase(SharedModuleStoreTestCase):
     """
@@ -523,7 +515,6 @@ class AboutSidebarHTMLTestCase(SharedModuleStoreTestCase):
                 self.assertNotIn('<section class="about-sidebar-html">', resp.content)
 
 
-@attr(shard=1)
 @patch.dict(settings.FEATURES, {'ENABLE_SHOPPING_CART': True})
 @patch.dict(settings.FEATURES, {'ENABLE_PAID_COURSE_REGISTRATION': True})
 class AboutPurchaseCourseTestCase(LoginEnrollmentTestCase, SharedModuleStoreTestCase):

--- a/lms/djangoapps/courseware/tests/test_access.py
+++ b/lms/djangoapps/courseware/tests/test_access.py
@@ -30,7 +30,6 @@ from courseware.tests.helpers import LoginEnrollmentTestCase, masquerade_as_grou
 from lms.djangoapps.ccx.models import CustomCourseForEdX
 from openedx.core.djangoapps.content.course_overviews.models import CourseOverview
 from openedx.core.djangoapps.waffle_utils.testutils import WAFFLE_TABLES
-from openedx.core.lib.tests import attr
 from openedx.features.content_type_gating.models import ContentTypeGatingConfig
 from student.models import CourseEnrollment
 from student.roles import CourseCcxCoachRole, CourseStaffRole
@@ -157,7 +156,6 @@ class CoachAccessTestCaseCCX(SharedModuleStoreTestCase, LoginEnrollmentTestCase)
         self.assertEqual(resp.status_code, 404)
 
 
-@attr(shard=1)
 @ddt.ddt
 class AccessTestCase(LoginEnrollmentTestCase, ModuleStoreTestCase, MilestonesTestCaseMixin):
     """
@@ -673,7 +671,6 @@ class AccessTestCase(LoginEnrollmentTestCase, ModuleStoreTestCase, MilestonesTes
         self.assertEqual(response.status_code, 200)
 
 
-@attr(shard=1)
 class UserRoleTestCase(TestCase):
     """
     Tests for user roles.
@@ -730,7 +727,6 @@ class UserRoleTestCase(TestCase):
         )
 
 
-@attr(shard=5)
 @ddt.ddt
 class CourseOverviewAccessTestCase(ModuleStoreTestCase):
     """

--- a/lms/djangoapps/courseware/tests/test_comprehensive_theming.py
+++ b/lms/djangoapps/courseware/tests/test_comprehensive_theming.py
@@ -12,7 +12,6 @@ from openedx.core.lib.tempdir import create_symlink, delete_symlink, mkdtemp_cle
 
 class TestComprehensiveTheming(TestCase):
     """Test comprehensive theming."""
-    shard = 4
 
     def setUp(self):
         super(TestComprehensiveTheming, self).setUp()

--- a/lms/djangoapps/courseware/tests/test_context_processor.py
+++ b/lms/djangoapps/courseware/tests/test_context_processor.py
@@ -14,7 +14,6 @@ class UserPrefContextProcessorUnitTest(ModuleStoreTestCase):
     """
     Unit test for courseware context_processor
     """
-    shard = 4
 
     def setUp(self):
         super(UserPrefContextProcessorUnitTest, self).setUp()

--- a/lms/djangoapps/courseware/tests/test_course_info.py
+++ b/lms/djangoapps/courseware/tests/test_course_info.py
@@ -15,7 +15,6 @@ from lms.djangoapps.ccx.tests.factories import CcxFactory
 from openedx.core.djangoapps.self_paced.models import SelfPacedConfiguration
 from openedx.core.djangoapps.site_configuration.tests.test_util import with_site_configuration_context
 from openedx.core.djangoapps.waffle_utils.testutils import WAFFLE_TABLES, override_waffle_flag
-from openedx.core.lib.tests import attr
 from openedx.features.content_type_gating.models import ContentTypeGatingConfig
 from openedx.features.course_experience import UNIFIED_COURSE_TAB_FLAG
 from openedx.features.enterprise_support.tests.mixins.enterprise import EnterpriseTestConsentRequired
@@ -39,7 +38,6 @@ from .helpers import LoginEnrollmentTestCase
 QUERY_COUNT_TABLE_BLACKLIST = WAFFLE_TABLES
 
 
-@attr(shard=1)
 @override_waffle_flag(UNIFIED_COURSE_TAB_FLAG, active=False)
 class CourseInfoTestCase(EnterpriseTestConsentRequired, LoginEnrollmentTestCase, SharedModuleStoreTestCase):
     """
@@ -153,7 +151,6 @@ class CourseInfoTestCase(EnterpriseTestConsentRequired, LoginEnrollmentTestCase,
         self.assertEqual(response.status_code, 404)
 
 
-@attr(shard=1)
 @override_waffle_flag(UNIFIED_COURSE_TAB_FLAG, active=False)
 class CourseInfoLastAccessedTestCase(LoginEnrollmentTestCase, ModuleStoreTestCase):
     """
@@ -222,7 +219,6 @@ class CourseInfoLastAccessedTestCase(LoginEnrollmentTestCase, ModuleStoreTestCas
         self.assertEqual(resume_course_url, section_url)
 
 
-@attr(shard=1)
 @override_waffle_flag(UNIFIED_COURSE_TAB_FLAG, active=False)
 @ddt.ddt
 class CourseInfoTitleTestCase(LoginEnrollmentTestCase, ModuleStoreTestCase):
@@ -352,7 +348,6 @@ class CourseInfoTestCaseCCX(SharedModuleStoreTestCase, LoginEnrollmentTestCase):
         self.assertRedirects(response, expected, status_code=302, target_status_code=200)
 
 
-@attr(shard=1)
 @override_waffle_flag(UNIFIED_COURSE_TAB_FLAG, active=False)
 class CourseInfoTestCaseXML(LoginEnrollmentTestCase, ModuleStoreTestCase):
     """
@@ -401,7 +396,6 @@ class CourseInfoTestCaseXML(LoginEnrollmentTestCase, ModuleStoreTestCase):
         self.assertNotIn(self.xml_data, resp.content)
 
 
-@attr(shard=1)
 @override_settings(FEATURES=dict(settings.FEATURES, EMBARGO=False))
 @override_waffle_flag(UNIFIED_COURSE_TAB_FLAG, active=False)
 class SelfPacedCourseInfoTestCase(LoginEnrollmentTestCase, SharedModuleStoreTestCase):

--- a/lms/djangoapps/courseware/tests/test_course_survey.py
+++ b/lms/djangoapps/courseware/tests/test_course_survey.py
@@ -19,7 +19,6 @@ class SurveyViewsTests(LoginEnrollmentTestCase, SharedModuleStoreTestCase, XssTe
     """
     All tests for the views.py file
     """
-    shard = 1
     STUDENT_INFO = [('view@test.com', 'foo')]
 
     @classmethod

--- a/lms/djangoapps/courseware/tests/test_course_tools.py
+++ b/lms/djangoapps/courseware/tests/test_course_tools.py
@@ -23,7 +23,6 @@ from xmodule.modulestore.tests.factories import CourseFactory
 
 
 class VerifiedUpgradeToolTest(SharedModuleStoreTestCase):
-    shard = 3
 
     @classmethod
     def setUpClass(cls):

--- a/lms/djangoapps/courseware/tests/test_courses.py
+++ b/lms/djangoapps/courseware/tests/test_courses.py
@@ -34,7 +34,6 @@ from courseware.module_render import get_module_for_descriptor
 from lms.djangoapps.courseware.courseware_access_exception import CoursewareAccessException
 from openedx.core.djangolib.testing.utils import get_mock_request
 from openedx.core.lib.courses import course_image_url
-from openedx.core.lib.tests import attr
 from student.tests.factories import UserFactory
 from xmodule.modulestore import ModuleStoreEnum
 from xmodule.modulestore.django import _get_modulestore_branch_setting, modulestore
@@ -48,7 +47,6 @@ CMS_BASE_TEST = 'testcms'
 TEST_DATA_DIR = settings.COMMON_TEST_DATA_ROOT
 
 
-@attr(shard=1)
 @ddt.ddt
 class CoursesTest(ModuleStoreTestCase):
     """Test methods related to fetching courses."""
@@ -192,7 +190,6 @@ class CoursesTest(ModuleStoreTestCase):
         self.assertIsNone(get_current_child(mock_xmodule))
 
 
-@attr(shard=1)
 class ModuleStoreBranchSettingTest(ModuleStoreTestCase):
     """Test methods related to the modulestore branch setting."""
     @mock.patch(
@@ -218,7 +215,6 @@ class ModuleStoreBranchSettingTest(ModuleStoreTestCase):
         self.assertEqual(_get_modulestore_branch_setting(), 'fake_default_branch')
 
 
-@attr(shard=1)
 @override_settings(CMS_BASE=CMS_BASE_TEST)
 class MongoCourseImageTestCase(ModuleStoreTestCase):
     """Tests for course image URLs when using a mongo modulestore."""
@@ -274,7 +270,6 @@ class MongoCourseImageTestCase(ModuleStoreTestCase):
         )
 
 
-@attr(shard=1)
 class XmlCourseImageTestCase(XModuleXmlImportTest):
     """Tests for course image URLs when using an xml modulestore."""
 
@@ -292,7 +287,6 @@ class XmlCourseImageTestCase(XModuleXmlImportTest):
         self.assertEquals(course_image_url(course), u'/static/xml_test_course/before after.jpg')
 
 
-@attr(shard=1)
 class CoursesRenderTest(ModuleStoreTestCase):
     """Test methods related to rendering courses content."""
 
@@ -385,7 +379,6 @@ class CourseEnrollmentOpenTests(ModuleStoreTestCase):
         self.assertFalse(course_open_for_self_enrollment(course.id))
 
 
-@attr(shard=1)
 @ddt.ddt
 class CourseInstantiationTests(ModuleStoreTestCase):
     """
@@ -430,7 +423,6 @@ class CourseInstantiationTests(ModuleStoreTestCase):
                         self.assertTrue(item.graded)
 
 
-@attr(shard=1)
 class TestGetCourseChapters(ModuleStoreTestCase):
     """
     Tests for the `get_course_chapter_ids` function.

--- a/lms/djangoapps/courseware/tests/test_credit_requirements.py
+++ b/lms/djangoapps/courseware/tests/test_credit_requirements.py
@@ -21,7 +21,6 @@ class ProgressPageCreditRequirementsTest(SharedModuleStoreTestCase):
     """
     Tests for credit requirement display on the progress page.
     """
-    shard = 4
 
     USERNAME = "bob"
     PASSWORD = "test"

--- a/lms/djangoapps/courseware/tests/test_date_summary.py
+++ b/lms/djangoapps/courseware/tests/test_date_summary.py
@@ -36,14 +36,12 @@ from openedx.core.djangoapps.self_paced.models import SelfPacedConfiguration
 from openedx.core.djangoapps.site_configuration.tests.factories import SiteFactory
 from openedx.core.djangoapps.user_api.preferences.api import set_user_preference
 from openedx.core.djangoapps.waffle_utils.testutils import override_waffle_flag
-from openedx.core.lib.tests import attr
 from openedx.features.course_experience import UNIFIED_COURSE_TAB_FLAG, UPGRADE_DEADLINE_MESSAGE, CourseHomeMessages
 from student.tests.factories import TEST_PASSWORD, CourseEnrollmentFactory, UserFactory
 from xmodule.modulestore.tests.django_utils import SharedModuleStoreTestCase
 from xmodule.modulestore.tests.factories import CourseFactory
 
 
-@attr(shard=1)
 @ddt.ddt
 class CourseDateSummaryTest(SharedModuleStoreTestCase):
     """Tests for course date summary blocks."""
@@ -450,7 +448,6 @@ class CourseDateSummaryTest(SharedModuleStoreTestCase):
             self.assertEqual(block.relative_datestring, expected_date_string)
 
 
-@attr(shard=1)
 @ddt.ddt
 class TestDateAlerts(SharedModuleStoreTestCase):
     """
@@ -567,7 +564,6 @@ class TestDateAlerts(SharedModuleStoreTestCase):
 
 
 @ddt.ddt
-@attr(shard=1)
 class TestScheduleOverrides(SharedModuleStoreTestCase):
 
     def setUp(self):

--- a/lms/djangoapps/courseware/tests/test_discussion_xblock.py
+++ b/lms/djangoapps/courseware/tests/test_discussion_xblock.py
@@ -31,7 +31,6 @@ class TestDiscussionXBlock(XModuleRenderingTestBase):
     Base class for tests
     """
 
-    shard = 4
     PATCH_DJANGO_USER = True
 
     def setUp(self):
@@ -85,7 +84,6 @@ class TestGetDjangoUser(TestDiscussionXBlock):
     Tests for the django_user property.
     """
 
-    shard = 4
     PATCH_DJANGO_USER = False
 
     def setUp(self):
@@ -123,7 +121,6 @@ class TestViews(TestDiscussionXBlock):
     """
     Tests for student_view and author_view.
     """
-    shard = 4
 
     def setUp(self):
         """
@@ -210,7 +207,6 @@ class TestTemplates(TestDiscussionXBlock):
     """
     Tests rendering of templates.
     """
-    shard = 4
 
     def test_has_permission(self):
         """
@@ -256,7 +252,6 @@ class TestXBlockInCourse(SharedModuleStoreTestCase):
     """
     Test the discussion xblock as rendered in the course and course API.
     """
-    shard = 4
 
     @classmethod
     def setUpClass(cls):
@@ -380,7 +375,6 @@ class TestXBlockQueryLoad(SharedModuleStoreTestCase):
     """
     Test the number of queries executed when rendering the XBlock.
     """
-    shard = 4
 
     def test_permissions_query_load(self):
         """

--- a/lms/djangoapps/courseware/tests/test_draft_modulestore.py
+++ b/lms/djangoapps/courseware/tests/test_draft_modulestore.py
@@ -8,7 +8,6 @@ class TestDraftModuleStore(TestCase):
     """
     Test the draft modulestore
     """
-    shard = 1
 
     def test_get_items_with_course_items(self):
         store = modulestore()

--- a/lms/djangoapps/courseware/tests/test_entrance_exam.py
+++ b/lms/djangoapps/courseware/tests/test_entrance_exam.py
@@ -43,7 +43,6 @@ class EntranceExamTestCases(LoginEnrollmentTestCase, ModuleStoreTestCase, Milest
     Creates a test course from scratch. The tests below are designed to execute
     workflows regardless of the feature flag settings.
     """
-    shard = 2
 
     @patch.dict('django.conf.settings.FEATURES', {'ENTRANCE_EXAMS': True})
     def setUp(self):

--- a/lms/djangoapps/courseware/tests/test_favicon.py
+++ b/lms/djangoapps/courseware/tests/test_favicon.py
@@ -8,7 +8,6 @@ class FaviconTestCase(UrlResetMixin, TestCase):
     """
     Tests of the courseware favicon.
     """
-    shard = 1
 
     def test_favicon_redirect(self):
         resp = self.client.get("/favicon.ico")

--- a/lms/djangoapps/courseware/tests/test_field_overrides.py
+++ b/lms/djangoapps/courseware/tests/test_field_overrides.py
@@ -7,7 +7,6 @@ import unittest
 from django.test.utils import override_settings
 from xblock.field_data import DictFieldData
 
-from openedx.core.lib.tests import attr
 from xmodule.modulestore.tests.django_utils import SharedModuleStoreTestCase
 from xmodule.modulestore.tests.factories import CourseFactory
 
@@ -60,7 +59,6 @@ class OverrideFieldBase(SharedModuleStoreTestCase):
         cls.course = CourseFactory.create(enable_ccx=True)
 
 
-@attr(shard=1)
 @override_settings(FIELD_OVERRIDE_PROVIDERS=(
     'courseware.tests.test_field_overrides.TestOverrideProvider',))
 class OverrideFieldDataTests(OverrideFieldBase):
@@ -132,7 +130,6 @@ class OverrideFieldDataTests(OverrideFieldBase):
         self.assertIsInstance(data, DictFieldData)
 
 
-@attr(shard=1)
 @override_settings(
     MODULESTORE_FIELD_OVERRIDE_PROVIDERS=['courseware.tests.test_field_overrides.TestOverrideProvider']
 )
@@ -149,7 +146,6 @@ class OverrideModulestoreFieldDataTests(FieldOverrideTestMixin, OverrideFieldDat
         self.assertIsInstance(data, DictFieldData)
 
 
-@attr(shard=1)
 class ResolveDottedTests(unittest.TestCase):
     """
     Tests for `resolve_dotted`.

--- a/lms/djangoapps/courseware/tests/test_footer.py
+++ b/lms/djangoapps/courseware/tests/test_footer.py
@@ -17,7 +17,6 @@ class TestFooter(TestCase):
     """
     Tests for edx and OpenEdX footer
     """
-    shard = 1
 
     SOCIAL_MEDIA_NAMES = [
         "facebook",

--- a/lms/djangoapps/courseware/tests/test_group_access.py
+++ b/lms/djangoapps/courseware/tests/test_group_access.py
@@ -55,7 +55,6 @@ class GroupAccessTestCase(ModuleStoreTestCase):
     Tests to ensure that has_access() correctly enforces the visibility
     restrictions specified in the `group_access` field of XBlocks.
     """
-    shard = 7
 
     def set_user_group(self, user, partition, group):
         """

--- a/lms/djangoapps/courseware/tests/test_i18n.py
+++ b/lms/djangoapps/courseware/tests/test_i18n.py
@@ -14,7 +14,6 @@ from django.utils import translation
 from openedx.core.djangoapps.dark_lang.models import DarkLangConfig
 from openedx.core.djangoapps.lang_pref import LANGUAGE_KEY
 from openedx.core.djangolib.testing.utils import CacheIsolationTestCase
-from openedx.core.lib.tests import attr
 from student.tests.factories import UserFactory
 
 
@@ -70,7 +69,6 @@ class BaseI18nTestCase(CacheIsolationTestCase):
         self.client.login(username=self.user.username, password=self.pwd)
 
 
-@attr(shard=1)
 class I18nTestCase(BaseI18nTestCase):
     """
     Tests for i18n
@@ -104,7 +102,6 @@ class I18nTestCase(BaseI18nTestCase):
         self.assert_tag_has_attr(response.content, "body", "class", "rtl")
 
 
-@attr(shard=1)
 class I18nRegressionTests(BaseI18nTestCase):
     """
     Tests for i18n
@@ -159,7 +156,6 @@ class I18nRegressionTests(BaseI18nTestCase):
         self.assert_tag_has_attr(response.content, "html", "lang", site_lang)
 
 
-@attr(shard=1)
 class I18nLangPrefTests(BaseI18nTestCase):
     """
     Regression tests of language presented to the user, when they

--- a/lms/djangoapps/courseware/tests/test_lti_integration.py
+++ b/lms/djangoapps/courseware/tests/test_lti_integration.py
@@ -27,7 +27,6 @@ class TestLTI(BaseTestXmodule):
     of `oauthlib` library.
     """
     CATEGORY = "lti"
-    shard = 1
 
     def setUp(self):
         """
@@ -131,7 +130,6 @@ class TestLTIModuleListing(SharedModuleStoreTestCase):
     # arbitrary constant
     COURSE_SLUG = "100"
     COURSE_NAME = "test_course"
-    shard = 1
 
     @classmethod
     def setUpClass(cls):

--- a/lms/djangoapps/courseware/tests/test_masquerade.py
+++ b/lms/djangoapps/courseware/tests/test_masquerade.py
@@ -22,7 +22,6 @@ from openedx.core.djangoapps.lang_pref import LANGUAGE_KEY
 from openedx.core.djangoapps.self_paced.models import SelfPacedConfiguration
 from openedx.core.djangoapps.user_api.preferences.api import get_user_preference, set_user_preference
 from openedx.core.djangoapps.waffle_utils.testutils import override_waffle_flag
-from openedx.core.lib.tests import attr
 from openedx.features.course_experience import UNIFIED_COURSE_TAB_FLAG
 from student.models import CourseEnrollment
 from student.tests.factories import UserFactory
@@ -166,7 +165,6 @@ class MasqueradeTestCase(SharedModuleStoreTestCase, LoginEnrollmentTestCase):
         self.assertEqual(200, masquerade_as_group_member(self.test_user, self.course, partition_id, group_id))
 
 
-@attr(shard=1)
 class NormalStudentVisibilityTest(MasqueradeTestCase):
     """
     Verify the course displays as expected for a "normal" student (to ensure test setup is correct).
@@ -221,7 +219,6 @@ class StaffMasqueradeTestCase(MasqueradeTestCase):
         return response
 
 
-@attr(shard=1)
 class TestStaffMasqueradeAsStudent(StaffMasqueradeTestCase):
     """
     Check for staff being able to masquerade as student.
@@ -260,7 +257,6 @@ class TestStaffMasqueradeAsStudent(StaffMasqueradeTestCase):
 
 
 @ddt.ddt
-@attr(shard=1)
 class TestStaffMasqueradeAsSpecificStudent(StaffMasqueradeTestCase, ProblemSubmissionTestMixin):
     """
     Check for staff being able to masquerade as a specific student.
@@ -455,7 +451,6 @@ class TestStaffMasqueradeAsSpecificStudent(StaffMasqueradeTestCase, ProblemSubmi
         self.assertIn("2 of 2 possible points", masquerade_progress)
 
 
-@attr(shard=1)
 class TestGetMasqueradingGroupId(StaffMasqueradeTestCase):
     """
     Check for staff being able to masquerade as belonging to a group.

--- a/lms/djangoapps/courseware/tests/test_microsites.py
+++ b/lms/djangoapps/courseware/tests/test_microsites.py
@@ -21,7 +21,6 @@ class TestSites(SharedModuleStoreTestCase, LoginEnrollmentTestCase):
     """
     This is testing of the Site Configuration feature
     """
-    shard = 1
     STUDENT_INFO = [('view@test.com', 'foo'), ('view2@test.com', 'foo')]
     ENABLED_SIGNALS = ['course_published']
 

--- a/lms/djangoapps/courseware/tests/test_middleware.py
+++ b/lms/djangoapps/courseware/tests/test_middleware.py
@@ -13,7 +13,6 @@ from xmodule.modulestore.tests.factories import CourseFactory
 
 class CoursewareMiddlewareTestCase(SharedModuleStoreTestCase):
     """Tests that courseware middleware is correctly redirected"""
-    shard = 1
 
     @classmethod
     def setUpClass(cls):

--- a/lms/djangoapps/courseware/tests/test_model_data.py
+++ b/lms/djangoapps/courseware/tests/test_model_data.py
@@ -26,7 +26,6 @@ from courseware.tests.factories import (
     course_id,
     location
 )
-from openedx.core.lib.tests import attr
 from student.tests.factories import UserFactory
 
 
@@ -60,7 +59,6 @@ class StudentModuleFactory(cmfStudentModuleFactory):
     course_id = course_id
 
 
-@attr(shard=1)
 class TestInvalidScopes(TestCase):
     def setUp(self):
         super(TestInvalidScopes, self).setUp()
@@ -81,7 +79,6 @@ class TestInvalidScopes(TestCase):
             self.assertRaises(InvalidScopeError, self.kvs.set_many, {key: 'value'})
 
 
-@attr(shard=1)
 class OtherUserFailureTestMixin(object):
     """
     Mixin class to add test cases for failures when a user trying to use the kvs is not
@@ -106,7 +103,6 @@ class OtherUserFailureTestMixin(object):
             self.kvs.set(self.other_key_factory(self.existing_field_name), "new_value")
 
 
-@attr(shard=1)
 class TestStudentModuleStorage(OtherUserFailureTestMixin, TestCase):
     """Tests for user_state storage via StudentModule"""
     other_key_factory = partial(DjangoKeyValueStore.Key, Scope.user_state, 2, location('usage_id'))  # user_id=2, not 1
@@ -235,7 +231,6 @@ class TestStudentModuleStorage(OtherUserFailureTestMixin, TestCase):
         self.assertEquals(exception_context.exception.saved_field_names, [])
 
 
-@attr(shard=1)
 class TestMissingStudentModule(TestCase):
     # Tell Django to clean out all databases, not just default
     multi_db = True
@@ -291,11 +286,9 @@ class TestMissingStudentModule(TestCase):
             self.assertFalse(self.kvs.has(user_state_key('a_field')))
 
 
-@attr(shard=1)
 class StorageTestBase(object):
     """
     A base class for that gets subclassed when testing each of the scopes.
-
     """
     # Disable pylint warnings that arise because of the way the child classes call
     # this base class -- pylint's static analysis can't keep up with it.

--- a/lms/djangoapps/courseware/tests/test_module_render.py
+++ b/lms/djangoapps/courseware/tests/test_module_render.py
@@ -61,7 +61,6 @@ from openedx.core.djangoapps.credit.api import set_credit_requirement_status, se
 from openedx.core.djangoapps.credit.models import CreditCourse
 from openedx.core.lib.courses import course_image_url
 from openedx.core.lib.gating import api as gating_api
-from openedx.core.lib.tests import attr
 from openedx.core.lib.url_utils import quote_slashes
 from student.models import anonymous_id_for_user
 from verify_student.tests.factories import SoftwareSecurePhotoVerificationFactory
@@ -170,7 +169,6 @@ class XBlockWithoutCompletionAPI(XBlock):
         return self.runtime.publish(self, 'progress', {})
 
 
-@attr(shard=1)
 @ddt.ddt
 class ModuleRenderTestCase(SharedModuleStoreTestCase, LoginEnrollmentTestCase):
     """
@@ -505,7 +503,6 @@ class ModuleRenderTestCase(SharedModuleStoreTestCase, LoginEnrollmentTestCase):
         self.assertEqual(hash_resource(resources), 'a76e27c8e80ca3efd7ce743093aa59e0')
 
 
-@attr(shard=1)
 @ddt.ddt
 class TestHandleXBlockCallback(SharedModuleStoreTestCase, LoginEnrollmentTestCase):
     """
@@ -905,7 +902,6 @@ class TestHandleXBlockCallback(SharedModuleStoreTestCase, LoginEnrollmentTestCas
             BlockCompletion.objects.get(block_key=block.scope_ids.usage_id)
 
 
-@attr(shard=1)
 @ddt.ddt
 @patch.dict('django.conf.settings.FEATURES', {'ENABLE_XBLOCK_VIEW_ENDPOINT': True})
 class TestXBlockView(SharedModuleStoreTestCase, LoginEnrollmentTestCase):
@@ -964,7 +960,6 @@ class TestXBlockView(SharedModuleStoreTestCase, LoginEnrollmentTestCase):
         self.assertEquals(401, response.status_code)
 
 
-@attr(shard=1)
 @ddt.ddt
 class TestTOC(ModuleStoreTestCase):
     """Check the Table of Contents for a course"""
@@ -1070,7 +1065,6 @@ class TestTOC(ModuleStoreTestCase):
             self.assertEquals(actual['next_of_active_section']['url_name'], 'video_123456789012')
 
 
-@attr(shard=1)
 @ddt.ddt
 @patch.dict('django.conf.settings.FEATURES', {'ENABLE_SPECIAL_EXAMS': True})
 class TestProctoringRendering(SharedModuleStoreTestCase):
@@ -1408,7 +1402,6 @@ class TestProctoringRendering(SharedModuleStoreTestCase):
         return None
 
 
-@attr(shard=1)
 class TestGatedSubsectionRendering(SharedModuleStoreTestCase, MilestonesTestCaseMixin):
     @classmethod
     def setUpClass(cls):
@@ -1491,7 +1484,6 @@ class TestGatedSubsectionRendering(SharedModuleStoreTestCase, MilestonesTestCase
         self.assertIsNone(actual['next_of_active_section'])
 
 
-@attr(shard=1)
 @ddt.ddt
 class TestHtmlModifiers(ModuleStoreTestCase):
     """
@@ -1655,7 +1647,6 @@ class XBlockWithJsonInitData(XBlock):
         return frag
 
 
-@attr(shard=1)
 @ddt.ddt
 class JsonInitDataTest(ModuleStoreTestCase):
     """Tests for JSON data injected into the JS init function."""
@@ -1740,7 +1731,6 @@ class ViewInStudioTest(ModuleStoreTestCase):
         self.child_module = self._get_module(course.id, child_descriptor, child_descriptor.location)
 
 
-@attr(shard=1)
 class MongoViewInStudioTest(ViewInStudioTest):
     """Test the 'View in Studio' link visibility in a mongo backed course."""
 
@@ -1769,7 +1759,6 @@ class MongoViewInStudioTest(ViewInStudioTest):
         self.assertNotIn('View Unit in Studio', result_fragment.content)
 
 
-@attr(shard=1)
 class MixedViewInStudioTest(ViewInStudioTest):
     """Test the 'View in Studio' link visibility in a mixed mongo backed course."""
 
@@ -1801,7 +1790,6 @@ class DetachedXBlock(XBlock):
         return frag
 
 
-@attr(shard=1)
 @patch.dict('django.conf.settings.FEATURES', {'DISPLAY_DEBUG_INFO_TO_STAFF': True, 'DISPLAY_HISTOGRAMS_TO_STAFF': True})
 @patch('courseware.module_render.has_access', Mock(return_value=True, autospec=True))
 class TestStaffDebugInfo(SharedModuleStoreTestCase):
@@ -1948,7 +1936,6 @@ PER_STUDENT_ANONYMIZED_DESCRIPTORS = sorted(set(
 ), key=str)
 
 
-@attr(shard=1)
 @ddt.ddt
 class TestAnonymousStudentId(SharedModuleStoreTestCase, LoginEnrollmentTestCase):
     """
@@ -2031,7 +2018,6 @@ class TestAnonymousStudentId(SharedModuleStoreTestCase, LoginEnrollmentTestCase)
         )
 
 
-@attr(shard=1)
 @patch('track.views.tracker', autospec=True)
 class TestModuleTrackingContext(SharedModuleStoreTestCase):
     """
@@ -2150,7 +2136,6 @@ class TestModuleTrackingContext(SharedModuleStoreTestCase):
             self.assertEqual(module_info['original_usage_version'], unicode(original_usage_version))
 
 
-@attr(shard=1)
 class TestXmoduleRuntimeEvent(TestSubmittingProblems):
     """
     Inherit from TestSubmittingProblems to get functionality that set up a course and problems structure
@@ -2220,7 +2205,6 @@ class TestXmoduleRuntimeEvent(TestSubmittingProblems):
             send_mock.assert_called_with(**expected_signal_kwargs)
 
 
-@attr(shard=1)
 class TestRebindModule(TestSubmittingProblems):
     """
     Tests to verify the functionality of rebinding a module.
@@ -2297,7 +2281,6 @@ class TestRebindModule(TestSubmittingProblems):
         self.assertEqual(module.descriptor.scope_ids.user_id, user2.id)
 
 
-@attr(shard=1)
 @ddt.ddt
 class TestEventPublishing(ModuleStoreTestCase, LoginEnrollmentTestCase):
     """
@@ -2336,7 +2319,6 @@ class TestEventPublishing(ModuleStoreTestCase, LoginEnrollmentTestCase):
         mock_track_function.return_value.assert_called_once_with(event_type, event)
 
 
-@attr(shard=1)
 @ddt.ddt
 class LMSXBlockServiceBindingTest(SharedModuleStoreTestCase):
     """
@@ -2427,7 +2409,6 @@ BLOCK_TYPES = ['xblock', 'xmodule']
 USER_NUMBERS = range(2)
 
 
-@attr(shard=1)
 @ddt.ddt
 class TestFilteredChildren(SharedModuleStoreTestCase):
     """
@@ -2582,7 +2563,6 @@ class TestFilteredChildren(SharedModuleStoreTestCase):
         self.assertEquals(set(child_usage_ids), set(child.scope_ids.usage_id for child in block.get_children()))
 
 
-@attr(shard=1)
 @ddt.ddt
 class TestDisabledXBlockTypes(ModuleStoreTestCase):
     """

--- a/lms/djangoapps/courseware/tests/test_navigation.py
+++ b/lms/djangoapps/courseware/tests/test_navigation.py
@@ -23,7 +23,6 @@ class TestNavigation(SharedModuleStoreTestCase, LoginEnrollmentTestCase):
     """
     Check that navigation state is saved properly.
     """
-    shard = 1
     STUDENT_INFO = [('view@test.com', 'foo'), ('view2@test.com', 'foo')]
 
     @classmethod

--- a/lms/djangoapps/courseware/tests/test_password_reset.py
+++ b/lms/djangoapps/courseware/tests/test_password_reset.py
@@ -18,7 +18,6 @@ class TestPasswordReset(LoginEnrollmentTestCase):
     """
     Go through some of the password reset use cases
     """
-    shard = 1
 
     def _setup_user(self, is_staff=False, password=None):
         """

--- a/lms/djangoapps/courseware/tests/test_self_paced_overrides.py
+++ b/lms/djangoapps/courseware/tests/test_self_paced_overrides.py
@@ -23,7 +23,6 @@ class SelfPacedDateOverrideTest(ModuleStoreTestCase):
     """
     Tests for self-paced due date overrides.
     """
-    shard = 4
 
     def setUp(self):
         self.reset_setting_cache_variables()

--- a/lms/djangoapps/courseware/tests/test_split_module.py
+++ b/lms/djangoapps/courseware/tests/test_split_module.py
@@ -24,7 +24,6 @@ class SplitTestBase(SharedModuleStoreTestCase):
     ICON_CLASSES = None
     TOOLTIPS = None
     VISIBLE_CONTENT = None
-    shard = 1
 
     @classmethod
     def setUpClass(cls):
@@ -289,7 +288,6 @@ class SplitTestPosition(SharedModuleStoreTestCase):
     """
     Check that we can change positions in a course with partitions defined
     """
-    shard = 1
 
     @classmethod
     def setUpClass(cls):

--- a/lms/djangoapps/courseware/tests/test_submitting_problems.py
+++ b/lms/djangoapps/courseware/tests/test_submitting_problems.py
@@ -33,7 +33,6 @@ from lms.djangoapps.grades.tasks import compute_all_grades_for_course
 from openedx.core.djangoapps.credit.api import get_credit_requirement_status, set_credit_requirements
 from openedx.core.djangoapps.credit.models import CreditCourse, CreditProvider
 from openedx.core.djangoapps.user_api.tests.factories import UserCourseTagFactory
-from openedx.core.lib.tests import attr
 from openedx.core.lib.url_utils import quote_slashes
 from student.models import CourseEnrollment, anonymous_id_for_user
 from submissions import api as submissions_api
@@ -335,7 +334,6 @@ class TestCourseGrades(TestSubmittingProblems):
         self._verify_grade(expected_problem_score=(0.0, 1.0), expected_hw_grade=(0.0, 1.0))
 
 
-@attr(shard=9)
 @ddt.ddt
 class TestCourseGrader(TestSubmittingProblems):
     """
@@ -752,7 +750,6 @@ class TestCourseGrader(TestSubmittingProblems):
         self.assertEqual(req_status[0]["status"], 'satisfied')
 
 
-@attr(shard=9)
 class ProblemWithUploadedFilesTest(TestSubmittingProblems):
     """Tests of problems with uploaded files."""
     # Tell Django to clean out all databases, not just default
@@ -807,7 +804,6 @@ class ProblemWithUploadedFilesTest(TestSubmittingProblems):
         self.assertItemsEqual(kwargs['files'].keys(), filenames.split())
 
 
-@attr(shard=9)
 class TestPythonGradedResponse(TestSubmittingProblems):
     """
     Check that we can submit a schematic and custom response, and it answers properly.
@@ -1058,7 +1054,6 @@ class TestPythonGradedResponse(TestSubmittingProblems):
         self._check_ireset(name)
 
 
-@attr(shard=9)
 class TestConditionalContent(TestSubmittingProblems):
     """
     Check that conditional content works correctly with grading.

--- a/lms/djangoapps/courseware/tests/test_tabs.py
+++ b/lms/djangoapps/courseware/tests/test_tabs.py
@@ -23,7 +23,6 @@ from courseware.tests.helpers import LoginEnrollmentTestCase
 from courseware.views.views import StaticCourseTabView, get_static_tab_fragment
 from openedx.core.djangoapps.waffle_utils.testutils import override_waffle_flag
 from openedx.core.djangolib.testing.utils import get_mock_request
-from openedx.core.lib.tests import attr
 from openedx.features.course_experience import UNIFIED_COURSE_TAB_FLAG
 from student.models import CourseEnrollment
 from student.tests.factories import UserFactory
@@ -230,7 +229,6 @@ class TextbooksTestCase(TabTestCase):
         self.assertEquals(num_textbooks_found, self.num_textbooks)
 
 
-@attr(shard=1)
 class StaticTabDateTestCase(LoginEnrollmentTestCase, SharedModuleStoreTestCase):
     """Test cases for Static Tab Dates."""
 
@@ -288,7 +286,6 @@ class StaticTabDateTestCase(LoginEnrollmentTestCase, SharedModuleStoreTestCase):
             self.assertIn("this module is temporarily unavailable", static_tab_content)
 
 
-@attr(shard=1)
 class StaticTabDateTestCaseXML(LoginEnrollmentTestCase, ModuleStoreTestCase):
     """
     Tests for the static tab dates of an XML course
@@ -338,7 +335,6 @@ class StaticTabDateTestCaseXML(LoginEnrollmentTestCase, ModuleStoreTestCase):
         self.assertIn(self.xml_data, resp.content)
 
 
-@attr(shard=1)
 @patch.dict('django.conf.settings.FEATURES', {'ENTRANCE_EXAMS': True})
 class EntranceExamsTabsTestCase(LoginEnrollmentTestCase, ModuleStoreTestCase, MilestonesTestCaseMixin):
     """
@@ -447,7 +443,6 @@ class EntranceExamsTabsTestCase(LoginEnrollmentTestCase, ModuleStoreTestCase, Mi
         self.assertEqual(len(course_tab_list), 4)
 
 
-@attr(shard=1)
 class TextBookCourseViewsTestCase(LoginEnrollmentTestCase, SharedModuleStoreTestCase):
     """
     Validate tab behavior when dealing with textbooks.
@@ -573,7 +568,6 @@ class TabListTestCase(TabTestCase):
         self.all_valid_tab_list = xmodule_tabs.CourseTabList().from_json(self.valid_tabs[1])
 
 
-@attr(shard=1)
 class ValidateTabsTestCase(TabListTestCase):
     """Test cases for validating tabs."""
 
@@ -603,7 +597,6 @@ class ValidateTabsTestCase(TabListTestCase):
         )
 
 
-@attr(shard=1)
 class CourseTabListTestCase(TabListTestCase):
     """Testing the generator method for iterating through displayable tabs"""
 
@@ -731,7 +724,6 @@ class CourseTabListTestCase(TabListTestCase):
         self.assertIn('Static Tab Instructors Only', name_list_staff)
 
 
-@attr(shard=1)
 class ProgressTestCase(TabTestCase):
     """Test cases for Progress Tab."""
 
@@ -761,7 +753,6 @@ class ProgressTestCase(TabTestCase):
         )
 
 
-@attr(shard=1)
 class StaticTabTestCase(TabTestCase):
     """Test cases for Static Tab."""
 
@@ -780,7 +771,6 @@ class StaticTabTestCase(TabTestCase):
         self.check_get_and_set_method_for_key(tab, 'url_slug')
 
 
-@attr(shard=1)
 class CourseInfoTabTestCase(TabTestCase):
     """Test cases for the course info tab."""
     def setUp(self):
@@ -809,7 +799,6 @@ class CourseInfoTabTestCase(TabTestCase):
                 self.assertEqual(tab.type, 'course_info')
 
 
-@attr(shard=1)
 class DiscussionLinkTestCase(TabTestCase):
     """Test cases for discussion link tab."""
 

--- a/lms/djangoapps/courseware/tests/test_user_state_client.py
+++ b/lms/djangoapps/courseware/tests/test_user_state_client.py
@@ -17,7 +17,6 @@ class TestDjangoUserStateClient(UserStateClientTestBase, ModuleStoreTestCase):
     Tests of the DjangoUserStateClient backend.
     It reuses all tests from :class:`~UserStateClientTestBase`.
     """
-    shard = 4
     __test__ = True
     # Tell Django to clean out all databases, not just default
     multi_db = True

--- a/lms/djangoapps/courseware/tests/test_video_handlers.py
+++ b/lms/djangoapps/courseware/tests/test_video_handlers.py
@@ -16,7 +16,6 @@ from webob import Request, Response
 
 from common.test.utils import normalize_repr
 from openedx.core.djangoapps.contentserver.caching import del_cached_content
-from openedx.core.lib.tests import attr
 from xmodule.contentstore.content import StaticContent
 from xmodule.contentstore.django import contentstore
 from xmodule.exceptions import NotFoundError
@@ -131,7 +130,6 @@ def attach_bumper_transcript(item, filename, lang="en"):
     item.video_bumper["transcripts"][lang] = filename
 
 
-@attr(shard=1)
 class TestVideo(BaseTestXmodule):
     """Integration tests: web client + mongo."""
     CATEGORY = "video"
@@ -205,7 +203,6 @@ class TestVideo(BaseTestXmodule):
         super(TestVideo, self).tearDown()
 
 
-@attr(shard=1)
 @ddt.ddt
 class TestTranscriptAvailableTranslationsDispatch(TestVideo):
     """
@@ -364,7 +361,6 @@ class TestTranscriptAvailableTranslationsDispatch(TestVideo):
         self.assertEqual(response.status_code, 404)
 
 
-@attr(shard=1)
 @ddt.ddt
 class TestTranscriptAvailableTranslationsBumperDispatch(TestVideo):
     """
@@ -539,7 +535,6 @@ class TestTranscriptDownloadDispatch(TestVideo):
             self.assertEqual(response.headers[attribute], value)
 
 
-@attr(shard=1)
 @ddt.ddt
 class TestTranscriptTranslationGetDispatch(TestVideo):
     """
@@ -821,7 +816,6 @@ class TestTranscriptTranslationGetDispatch(TestVideo):
         self.assertEqual(response.status_code, 404)
 
 
-@attr(shard=1)
 class TestStudioTranscriptTranslationGetDispatch(TestVideo):
     """
     Test Studio video handler that provide translation transcripts.
@@ -880,7 +874,6 @@ class TestStudioTranscriptTranslationGetDispatch(TestVideo):
         self.assertEqual(response.headers["Content-Language"], "zh")
 
 
-@attr(shard=1)
 @ddt.ddt
 class TestStudioTranscriptTranslationPostDispatch(TestVideo):
     """
@@ -987,7 +980,6 @@ class TestStudioTranscriptTranslationPostDispatch(TestVideo):
         )
 
 
-@attr(shard=1)
 @ddt.ddt
 class TestStudioTranscriptTranslationDeleteDispatch(TestVideo):
     """
@@ -1119,7 +1111,6 @@ class TestStudioTranscriptTranslationDeleteDispatch(TestVideo):
         self.assertFalse(_check_asset(self.item_descriptor.location, sub_file_name))
 
 
-@attr(shard=1)
 class TestGetTranscript(TestVideo):
     """
     Make sure that `get_transcript` method works correctly

--- a/lms/djangoapps/courseware/tests/test_video_mongo.py
+++ b/lms/djangoapps/courseware/tests/test_video_mongo.py
@@ -34,7 +34,6 @@ from mock import MagicMock, Mock, patch
 from path import Path as path
 
 from openedx.core.djangolib.testing.utils import CacheIsolationTestCase
-from openedx.core.lib.tests import attr
 from openedx.core.djangoapps.waffle_utils.models import WaffleFlagCourseOverrideModel
 from openedx.core.djangoapps.video_pipeline.config.waffle import waffle_flags, DEPRECATE_YOUTUBE
 from waffle.testutils import override_flag
@@ -75,7 +74,6 @@ I am overwatch.
 TRANSCRIPT_FILE_SJSON_DATA = """{\n   "start": [10],\n   "end": [100],\n   "text": ["Hi, welcome to edxval."]\n}"""
 
 
-@attr(shard=7)
 class TestVideoYouTube(TestVideo):
     METADATA = {}
 
@@ -141,7 +139,6 @@ class TestVideoYouTube(TestVideo):
         )
 
 
-@attr(shard=7)
 class TestVideoNonYouTube(TestVideo):
     """Integration tests: web client + mongo."""
     DATA = """
@@ -224,7 +221,6 @@ class TestVideoNonYouTube(TestVideo):
         )
 
 
-@attr(shard=7)
 @ddt.ddt
 class TestGetHtmlMethod(BaseTestXmodule):
     '''
@@ -1082,7 +1078,6 @@ class TestGetHtmlMethod(BaseTestXmodule):
                 self.assertIn(u'"prioritizeHls": {}'.format(data['result']), context)
 
 
-@attr(shard=7)
 @ddt.ddt
 class TestVideoDescriptorInitialization(BaseTestXmodule):
     """
@@ -1241,7 +1236,6 @@ class TestVideoDescriptorInitialization(BaseTestXmodule):
         self.assertEqual(context['transcripts_basic_tab_metadata']['video_url']['value'], video_url)
 
 
-@attr(shard=7)
 @ddt.ddt
 class TestEditorSavedMethod(BaseTestXmodule):
     """
@@ -1541,7 +1535,6 @@ class TestVideoDescriptorStudentViewJson(CacheIsolationTestCase):
         self.assertItemsEqual(student_view_response['transcripts'].keys(), expected_transcripts)
 
 
-@attr(shard=7)
 @ddt.ddt
 class VideoDescriptorTest(TestCase, VideoDescriptorTestBase):
     """

--- a/lms/djangoapps/courseware/tests/test_video_xml.py
+++ b/lms/djangoapps/courseware/tests/test_video_xml.py
@@ -41,7 +41,6 @@ class VideoModuleLogicTest(LogicTest):
     raw_field_data = {
         'data': '<video />'
     }
-    shard = 1
 
     def test_parse_youtube(self):
         """Test parsing old-style Youtube ID strings into a dict."""

--- a/lms/djangoapps/courseware/tests/test_view_authentication.py
+++ b/lms/djangoapps/courseware/tests/test_view_authentication.py
@@ -29,7 +29,6 @@ class TestViewAuth(EnterpriseTestConsentRequired, ModuleStoreTestCase, LoginEnro
 
     ACCOUNT_INFO = [('view@test.com', 'foo'), ('view2@test.com', 'foo')]
     ENABLED_SIGNALS = ['course_published']
-    shard = 1
 
     @staticmethod
     def _reverse_urls(names, course):
@@ -413,7 +412,6 @@ class TestBetatesterAccess(ModuleStoreTestCase, CourseAccessTestMixin):
     """
     Tests for the beta tester feature
     """
-    shard = 1
 
     def setUp(self):
         super(TestBetatesterAccess, self).setUp()

--- a/lms/djangoapps/courseware/tests/test_views.py
+++ b/lms/djangoapps/courseware/tests/test_views.py
@@ -63,7 +63,6 @@ from openedx.core.djangoapps.credit.models import CreditCourse, CreditProvider
 from openedx.core.djangoapps.waffle_utils.testutils import WAFFLE_TABLES, override_waffle_flag
 from openedx.core.djangolib.testing.utils import get_mock_request
 from openedx.core.lib.gating import api as gating_api
-from openedx.core.lib.tests import attr
 from openedx.core.lib.url_utils import quote_slashes
 from openedx.features.content_type_gating.models import ContentTypeGatingConfig
 from openedx.features.course_duration_limits.models import CourseDurationLimitConfig
@@ -94,7 +93,6 @@ from xmodule.modulestore.tests.factories import CourseFactory, ItemFactory, chec
 QUERY_COUNT_TABLE_BLACKLIST = WAFFLE_TABLES
 
 
-@attr(shard=5)
 class TestJumpTo(ModuleStoreTestCase):
     """
     Check the jumpto link for a course.
@@ -205,7 +203,6 @@ class TestJumpTo(ModuleStoreTestCase):
         self.assertEqual(response.status_code, 404)
 
 
-@attr(shard=5)
 @ddt.ddt
 class IndexQueryTestCase(ModuleStoreTestCase):
     """
@@ -249,7 +246,6 @@ class IndexQueryTestCase(ModuleStoreTestCase):
                 self.assertEqual(response.status_code, 200)
 
 
-@attr(shard=5)
 @ddt.ddt
 class ViewsTestCase(ModuleStoreTestCase):
     """
@@ -964,7 +960,6 @@ class ViewsTestCase(ModuleStoreTestCase):
             self.assertContains(response, test)
 
 
-@attr(shard=5)
 # Patching 'lms.djangoapps.courseware.views.views.get_programs' would be ideal,
 # but for some unknown reason that patch doesn't seem to be applied.
 @patch('openedx.core.djangoapps.catalog.utils.cache')
@@ -1006,7 +1001,6 @@ class TestProgramMarketingView(SharedModuleStoreTestCase):
         self.assertEqual(response.status_code, 200)
 
 
-@attr(shard=5)
 # setting TIME_ZONE_DISPLAYED_FOR_DEADLINES explicitly
 @override_settings(TIME_ZONE_DISPLAYED_FOR_DEADLINES="UTC")
 class BaseDueDateTests(ModuleStoreTestCase):
@@ -1099,7 +1093,6 @@ class TestProgressDueDate(BaseDueDateTests):
 
 
 # TODO: LEARNER-71: Delete entire TestAccordionDueDate class
-@attr(shard=5)
 class TestAccordionDueDate(BaseDueDateTests):
     """
     Test that the accordion page displays due dates correctly
@@ -1139,7 +1132,6 @@ class TestAccordionDueDate(BaseDueDateTests):
         super(TestAccordionDueDate, self).test_format_none()
 
 
-@attr(shard=5)
 class StartDateTests(ModuleStoreTestCase):
     """
     Test that start dates are properly localized and displayed on the student
@@ -1180,7 +1172,6 @@ class StartDateTests(ModuleStoreTestCase):
         self.assertContains(response, "2013-09-16T07:17:28+0000")
 
 
-@attr(shard=5)
 class ProgressPageBaseTests(ModuleStoreTestCase):
     """
     Base class for progress page tests.
@@ -1238,7 +1229,6 @@ class ProgressPageBaseTests(ModuleStoreTestCase):
 
 
 # pylint: disable=protected-access
-@attr(shard=5)
 @ddt.ddt
 class ProgressPageTests(ProgressPageBaseTests):
     """
@@ -1867,7 +1857,6 @@ class ProgressPageTests(ProgressPageBaseTests):
         }
 
 
-@attr(shard=5)
 @ddt.ddt
 class ProgressPageShowCorrectnessTests(ProgressPageBaseTests):
     """
@@ -2147,7 +2136,6 @@ class ProgressPageShowCorrectnessTests(ProgressPageBaseTests):
         self.assert_progress_page_show_grades(resp, show_correctness, due_date, graded, show_grades, 1, 1, .5)
 
 
-@attr(shard=5)
 class VerifyCourseKeyDecoratorTests(TestCase):
     """
     Tests for the ensure_valid_course_key decorator.
@@ -2173,7 +2161,6 @@ class VerifyCourseKeyDecoratorTests(TestCase):
         self.assertFalse(mocked_view.called)
 
 
-@attr(shard=5)
 class GenerateUserCertTests(ModuleStoreTestCase):
     """
     Tests for the view function Generated User Certs
@@ -2332,7 +2319,6 @@ class ViewCheckerBlock(XBlock):
         return result
 
 
-@attr(shard=5)
 @ddt.ddt
 class TestIndexView(ModuleStoreTestCase):
     """
@@ -2485,7 +2471,6 @@ class TestIndexView(ModuleStoreTestCase):
                     self.assertIn('xblock-student_view-video', response.content)
 
 
-@attr(shard=5)
 @ddt.ddt
 class TestIndexViewCompleteOnView(ModuleStoreTestCase, CompletionWaffleTestMixin):
     """
@@ -2622,7 +2607,6 @@ class TestIndexViewCompleteOnView(ModuleStoreTestCase, CompletionWaffleTestMixin
         self.assertNotIn('data-mark-completed-on-view-after-delay', response.content)
 
 
-@attr(shard=5)
 @ddt.ddt
 class TestIndexViewWithVerticalPositions(ModuleStoreTestCase):
     """
@@ -2689,7 +2673,6 @@ class TestIndexViewWithVerticalPositions(ModuleStoreTestCase):
         self._assert_correct_position(resp, expected_position)
 
 
-@attr(shard=5)
 class TestIndexViewWithGating(ModuleStoreTestCase, MilestonesTestCaseMixin):
     """
     Test the index view for a course with gated content
@@ -2741,7 +2724,6 @@ class TestIndexViewWithGating(ModuleStoreTestCase, MilestonesTestCaseMixin):
         self.assertIn("Content Locked", response.content)
 
 
-@attr(shard=5)
 class TestIndexViewWithCourseDurationLimits(ModuleStoreTestCase):
     """
     Test the index view for a course with course duration limits enabled.
@@ -2810,7 +2792,6 @@ class TestIndexViewWithCourseDurationLimits(ModuleStoreTestCase):
         self.assertNotContains(response, bannerText, html=True)
 
 
-@attr(shard=5)
 class TestRenderXBlock(RenderXBlockTestMixin, ModuleStoreTestCase, CompletionWaffleTestMixin):
     """
     Tests for the courseware.render_xblock endpoint.
@@ -2904,7 +2885,6 @@ class TestRenderXBlockSelfPaced(TestRenderXBlock):
         return options
 
 
-@attr(shard=5)
 class TestIndexViewCrawlerStudentStateWrites(SharedModuleStoreTestCase):
     """
     Ensure that courseware index requests do not trigger student state writes.
@@ -2984,7 +2964,6 @@ class TestIndexViewCrawlerStudentStateWrites(SharedModuleStoreTestCase):
         self.assertEqual(response.status_code, 200)
 
 
-@attr(shard=5)
 class EnterpriseConsentTestCase(EnterpriseTestConsentRequired, ModuleStoreTestCase):
     """
     Ensure that the Enterprise Data Consent redirects are in place only when consent is required.
@@ -3014,7 +2993,6 @@ class EnterpriseConsentTestCase(EnterpriseTestConsentRequired, ModuleStoreTestCa
             self.verify_consent_required(self.client, url)
 
 
-@attr(shard=5)
 @ddt.ddt
 class AccessUtilsTestCase(ModuleStoreTestCase):
     """

--- a/lms/djangoapps/courseware/tests/test_word_cloud.py
+++ b/lms/djangoapps/courseware/tests/test_word_cloud.py
@@ -12,7 +12,6 @@ from .helpers import BaseTestXmodule
 class TestWordCloud(BaseTestXmodule):
     """Integration test for word cloud xmodule."""
     CATEGORY = "word_cloud"
-    shard = 1
 
     def _get_resource_url(self, item):
         """

--- a/lms/djangoapps/courseware/tests/tests.py
+++ b/lms/djangoapps/courseware/tests/tests.py
@@ -11,14 +11,12 @@ from six import text_type
 
 from courseware.tests.helpers import LoginEnrollmentTestCase
 from lms.djangoapps.lms_xblock.field_data import LmsFieldData
-from openedx.core.lib.tests import attr
 from xmodule.error_module import ErrorDescriptor
 from xmodule.modulestore.django import modulestore
 from xmodule.modulestore.tests.django_utils import TEST_DATA_MIXED_MODULESTORE, ModuleStoreTestCase
 from xmodule.modulestore.tests.factories import ToyCourseFactory
 
 
-@attr(shard=1)
 class ActivateLoginTest(LoginEnrollmentTestCase):
     """
     Test logging in and logging out.
@@ -122,7 +120,6 @@ class PageLoaderTestCase(LoginEnrollmentTestCase):
             self.assertNotIsInstance(descriptor, ErrorDescriptor)
 
 
-@attr(shard=1)
 class TestMongoCoursesLoad(ModuleStoreTestCase, PageLoaderTestCase):
     """
     Check that all pages in test courses load properly from Mongo.
@@ -146,7 +143,6 @@ class TestMongoCoursesLoad(ModuleStoreTestCase, PageLoaderTestCase):
         self.assertGreater(len(course.textbooks), 0)
 
 
-@attr(shard=1)
 class TestDraftModuleStore(ModuleStoreTestCase):
     def test_get_items_with_course_items(self):
         store = modulestore()
@@ -159,7 +155,6 @@ class TestDraftModuleStore(ModuleStoreTestCase):
         # not allowed to be passed in (i.e. was throwing exception)
 
 
-@attr(shard=1)
 class TestLmsFieldData(TestCase):
     """
     Tests of the LmsFieldData class

--- a/lms/djangoapps/coursewarehistoryextended/tests.py
+++ b/lms/djangoapps/coursewarehistoryextended/tests.py
@@ -21,7 +21,6 @@ class TestStudentModuleHistoryBackends(TestCase):
     """ Tests of data in CSMH and CSMHE """
     # Tell Django to clean out all databases, not just default
     multi_db = True
-    shard = 1
 
     def setUp(self):
         super(TestStudentModuleHistoryBackends, self).setUp()

--- a/lms/djangoapps/dashboard/management/commands/tests/test_git_add_course.py
+++ b/lms/djangoapps/dashboard/management/commands/tests/test_git_add_course.py
@@ -51,7 +51,6 @@ class TestGitAddCourse(SharedModuleStoreTestCase):
     """
     Tests the git_add_course management command for proper functions.
     """
-    shard = 3
     TEST_REPO = 'https://github.com/mitocw/edx4edx_lite.git'
     TEST_COURSE = 'MITx/edx4edx/edx4edx'
     TEST_BRANCH = 'testing_do_not_delete'

--- a/lms/djangoapps/dashboard/tests/test_sysadmin.py
+++ b/lms/djangoapps/dashboard/tests/test_sysadmin.py
@@ -123,7 +123,6 @@ class TestSysAdminMongoCourseImport(SysadminBaseTestCase):
     """
     Check that importing into the mongo module store works
     """
-    shard = 1
 
     @classmethod
     def tearDownClass(cls):

--- a/lms/djangoapps/discussion/tests/test_signals.py
+++ b/lms/djangoapps/discussion/tests/test_signals.py
@@ -10,7 +10,6 @@ from xmodule.modulestore.tests.factories import CourseFactory, ItemFactory
 
 
 class SendMessageHandlerTestCase(TestCase):
-    shard = 4
 
     def setUp(self):
         self.sender = mock.Mock()

--- a/lms/djangoapps/discussion/tests/test_tasks.py
+++ b/lms/djangoapps/discussion/tests/test_tasks.py
@@ -66,7 +66,6 @@ def make_mock_responder(subscribed_thread_ids=None, thread_data=None, comment_da
 
 @ddt.ddt
 class TaskTestCase(ModuleStoreTestCase):
-    shard = 4
 
     @classmethod
     @mock.patch.dict("django.conf.settings.FEATURES", {"ENABLE_DISCUSSION_SERVICE": True})

--- a/lms/djangoapps/discussion/tests/test_views.py
+++ b/lms/djangoapps/discussion/tests/test_views.py
@@ -68,7 +68,6 @@ QUERY_COUNT_TABLE_BLACKLIST = WAFFLE_TABLES
 
 
 class ViewsExceptionTestCase(UrlResetMixin, ModuleStoreTestCase):
-    shard = 4
 
     @patch.dict("django.conf.settings.FEATURES", {"ENABLE_DISCUSSION_SERVICE": True})
     def setUp(self):
@@ -299,7 +298,6 @@ class PartialDictMatcher(object):
 
 @patch('requests.request', autospec=True)
 class SingleThreadTestCase(ForumsEnableMixin, ModuleStoreTestCase):
-    shard = 4
 
     CREATE_USER = False
 
@@ -418,7 +416,6 @@ class SingleThreadQueryCountTestCase(ForumsEnableMixin, ModuleStoreTestCase):
     Ensures the number of modulestore queries and number of sql queries are
     independent of the number of responses retrieved for a given discussion thread.
     """
-    shard = 4
     MODULESTORE = TEST_DATA_MONGO_MODULESTORE
 
     def setUp(self):
@@ -500,7 +497,6 @@ class SingleThreadQueryCountTestCase(ForumsEnableMixin, ModuleStoreTestCase):
 
 @patch('requests.request', autospec=True)
 class SingleCohortedThreadTestCase(CohortedTestCase):
-    shard = 4
 
     def _create_mock_cohorted_thread(self, mock_request):
         self.mock_text = "dummy content"
@@ -565,7 +561,6 @@ class SingleCohortedThreadTestCase(CohortedTestCase):
 
 @patch('lms.lib.comment_client.utils.requests.request', autospec=True)
 class SingleThreadAccessTestCase(CohortedTestCase):
-    shard = 4
 
     def call_view(self, mock_request, commentable_id, user, group_id, thread_group_id=None, pass_group_id=True):
         thread_id = "test_thread_id"
@@ -654,7 +649,6 @@ class SingleThreadAccessTestCase(CohortedTestCase):
 
 @patch('lms.lib.comment_client.utils.requests.request', autospec=True)
 class SingleThreadGroupIdTestCase(CohortedTestCase, GroupIdAssertionMixin):
-    shard = 4
     cs_endpoint = "/threads/dummy_thread_id"
 
     def call_view(self, mock_request, commentable_id, user, group_id, pass_group_id=True, is_ajax=False):
@@ -708,7 +702,6 @@ class ForumFormDiscussionContentGroupTestCase(ForumsEnableMixin, ContentGroupTes
     alpha_module => alpha_group_discussion => alpha_cohort => alpha_user/community_ta
     beta_module => beta_group_discussion => beta_cohort => beta_user
     """
-    shard = 4
 
     @patch.dict("django.conf.settings.FEATURES", {"ENABLE_DISCUSSION_SERVICE": True})
     def setUp(self):
@@ -787,7 +780,6 @@ class ForumFormDiscussionContentGroupTestCase(ForumsEnableMixin, ContentGroupTes
 
 @patch('requests.request', autospec=True)
 class SingleThreadContentGroupTestCase(ForumsEnableMixin, UrlResetMixin, ContentGroupTestCase):
-    shard = 4
 
     @patch.dict("django.conf.settings.FEATURES", {"ENABLE_DISCUSSION_SERVICE": True})
     def setUp(self):
@@ -898,7 +890,6 @@ class SingleThreadContentGroupTestCase(ForumsEnableMixin, UrlResetMixin, Content
 
 @patch('lms.lib.comment_client.utils.requests.request', autospec=True)
 class InlineDiscussionContextTestCase(ForumsEnableMixin, ModuleStoreTestCase):
-    shard = 4
 
     def setUp(self):
         super(InlineDiscussionContextTestCase, self).setUp()
@@ -940,7 +931,6 @@ class InlineDiscussionGroupIdTestCase(
         CohortedTopicGroupIdTestMixin,
         NonCohortedTopicGroupIdTestMixin
 ):
-    shard = 4
     cs_endpoint = "/threads"
 
     def setUp(self):
@@ -988,7 +978,6 @@ class InlineDiscussionGroupIdTestCase(
 
 @patch('lms.lib.comment_client.utils.requests.request', autospec=True)
 class ForumFormDiscussionGroupIdTestCase(CohortedTestCase, CohortedTopicGroupIdTestMixin):
-    shard = 4
     cs_endpoint = "/threads"
 
     def call_view(self, mock_request, commentable_id, user, group_id, pass_group_id=True, is_ajax=False):
@@ -1035,7 +1024,6 @@ class ForumFormDiscussionGroupIdTestCase(CohortedTestCase, CohortedTopicGroupIdT
 
 @patch('lms.lib.comment_client.utils.requests.request', autospec=True)
 class UserProfileDiscussionGroupIdTestCase(CohortedTestCase, CohortedTopicGroupIdTestMixin):
-    shard = 4
     cs_endpoint = "/active_threads"
 
     def call_view_for_profiled_user(
@@ -1197,7 +1185,6 @@ class UserProfileDiscussionGroupIdTestCase(CohortedTestCase, CohortedTopicGroupI
 
 @patch('lms.lib.comment_client.utils.requests.request', autospec=True)
 class FollowedThreadsDiscussionGroupIdTestCase(CohortedTestCase, CohortedTopicGroupIdTestMixin):
-    shard = 4
     cs_endpoint = "/subscribed_threads"
 
     def call_view(self, mock_request, commentable_id, user, group_id, pass_group_id=True):
@@ -1235,7 +1222,6 @@ class FollowedThreadsDiscussionGroupIdTestCase(CohortedTestCase, CohortedTopicGr
 
 @patch('lms.lib.comment_client.utils.requests.request', autospec=True)
 class InlineDiscussionTestCase(ForumsEnableMixin, ModuleStoreTestCase):
-    shard = 4
 
     def setUp(self):
         super(InlineDiscussionTestCase, self).setUp()
@@ -1282,7 +1268,6 @@ class InlineDiscussionTestCase(ForumsEnableMixin, ModuleStoreTestCase):
 
 @patch('requests.request', autospec=True)
 class UserProfileTestCase(ForumsEnableMixin, UrlResetMixin, ModuleStoreTestCase):
-    shard = 4
 
     TEST_THREAD_TEXT = 'userprofile-test-text'
     TEST_THREAD_ID = 'userprofile-test-thread-id'
@@ -1412,7 +1397,6 @@ class UserProfileTestCase(ForumsEnableMixin, UrlResetMixin, ModuleStoreTestCase)
 
 @patch('requests.request', autospec=True)
 class CommentsServiceRequestHeadersTestCase(ForumsEnableMixin, UrlResetMixin, ModuleStoreTestCase):
-    shard = 4
 
     CREATE_USER = False
 
@@ -1479,7 +1463,6 @@ class CommentsServiceRequestHeadersTestCase(ForumsEnableMixin, UrlResetMixin, Mo
 
 
 class InlineDiscussionUnicodeTestCase(ForumsEnableMixin, SharedModuleStoreTestCase, UnicodeTestMixin):
-    shard = 4
 
     @classmethod
     def setUpClass(cls):
@@ -1513,7 +1496,6 @@ class InlineDiscussionUnicodeTestCase(ForumsEnableMixin, SharedModuleStoreTestCa
 
 
 class ForumFormDiscussionUnicodeTestCase(ForumsEnableMixin, SharedModuleStoreTestCase, UnicodeTestMixin):
-    shard = 4
 
     @classmethod
     def setUpClass(cls):
@@ -1548,7 +1530,6 @@ class ForumFormDiscussionUnicodeTestCase(ForumsEnableMixin, SharedModuleStoreTes
 @ddt.ddt
 @patch('lms.lib.comment_client.utils.requests.request', autospec=True)
 class ForumDiscussionXSSTestCase(ForumsEnableMixin, UrlResetMixin, ModuleStoreTestCase):
-    shard = 4
 
     @patch.dict("django.conf.settings.FEATURES", {"ENABLE_DISCUSSION_SERVICE": True})
     def setUp(self):
@@ -1603,7 +1584,6 @@ class ForumDiscussionXSSTestCase(ForumsEnableMixin, UrlResetMixin, ModuleStoreTe
 
 
 class ForumDiscussionSearchUnicodeTestCase(ForumsEnableMixin, SharedModuleStoreTestCase, UnicodeTestMixin):
-    shard = 4
 
     @classmethod
     def setUpClass(cls):
@@ -1640,7 +1620,6 @@ class ForumDiscussionSearchUnicodeTestCase(ForumsEnableMixin, SharedModuleStoreT
 
 
 class SingleThreadUnicodeTestCase(ForumsEnableMixin, SharedModuleStoreTestCase, UnicodeTestMixin):
-    shard = 4
 
     @classmethod
     def setUpClass(cls):
@@ -1674,7 +1653,6 @@ class SingleThreadUnicodeTestCase(ForumsEnableMixin, SharedModuleStoreTestCase, 
 
 
 class UserProfileUnicodeTestCase(ForumsEnableMixin, SharedModuleStoreTestCase, UnicodeTestMixin):
-    shard = 4
 
     @classmethod
     def setUpClass(cls):
@@ -1707,7 +1685,6 @@ class UserProfileUnicodeTestCase(ForumsEnableMixin, SharedModuleStoreTestCase, U
 
 
 class FollowedThreadsUnicodeTestCase(ForumsEnableMixin, SharedModuleStoreTestCase, UnicodeTestMixin):
-    shard = 4
 
     @classmethod
     def setUpClass(cls):
@@ -1744,7 +1721,6 @@ class EnrollmentTestCase(ForumsEnableMixin, ModuleStoreTestCase):
     Tests for the behavior of views depending on if the student is enrolled
     in the course
     """
-    shard = 4
 
     @patch.dict("django.conf.settings.FEATURES", {"ENABLE_DISCUSSION_SERVICE": True})
     def setUp(self):
@@ -1767,7 +1743,6 @@ class EnterpriseConsentTestCase(EnterpriseTestConsentRequired, ForumsEnableMixin
     """
     Ensure that the Enterprise Data Consent redirects are in place only when consent is required.
     """
-    shard = 4
     CREATE_USER = False
 
     @patch.dict("django.conf.settings.FEATURES", {"ENABLE_DISCUSSION_SERVICE": True})
@@ -1810,7 +1785,6 @@ class EnterpriseConsentTestCase(EnterpriseTestConsentRequired, ForumsEnableMixin
 
 
 class DividedDiscussionsTestCase(CohortViewsTestCase):
-    shard = 4
 
     def create_divided_discussions(self):
         """
@@ -1851,7 +1825,6 @@ class CourseDiscussionTopicsTestCase(DividedDiscussionsTestCase):
     """
     Tests the `divide_discussion_topics` view.
     """
-    shard = 4
 
     def test_non_staff(self):
         """
@@ -1907,7 +1880,6 @@ class CourseDiscussionsHandlerTestCase(DividedDiscussionsTestCase):
     """
     Tests the course_discussion_settings_handler
     """
-    shard = 4
 
     def get_expected_response(self):
         """
@@ -2067,7 +2039,6 @@ class DefaultTopicIdGetterTestCase(ModuleStoreTestCase):
     """
     Tests the `_get_discussion_default_topic_id` helper.
     """
-    shard = 4
 
     def test_no_default_topic(self):
         discussion_topics = {
@@ -2100,7 +2071,6 @@ class ThreadViewedEventTestCase(EventTestMixin, ForumsEnableMixin, UrlResetMixin
     """
     Forum thread views are expected to launch analytics events. Test these here.
     """
-    shard = 4
 
     CATEGORY_ID = 'i4x-edx-discussion-id'
     CATEGORY_NAME = 'Discussion 1'

--- a/lms/djangoapps/discussion_api/tests/test_api.py
+++ b/lms/djangoapps/discussion_api/tests/test_api.py
@@ -49,7 +49,6 @@ from django_comment_common.models import (
 from openedx.core.djangoapps.course_groups.models import CourseUserGroupPartitionGroup
 from openedx.core.djangoapps.course_groups.tests.helpers import CohortFactory
 from openedx.core.lib.exceptions import CourseNotFoundError, PageNotFoundError
-from openedx.core.lib.tests import attr
 from student.tests.factories import CourseEnrollmentFactory, UserFactory
 from util.testing import UrlResetMixin
 from xmodule.modulestore import ModuleStoreEnum
@@ -100,7 +99,6 @@ def _create_course_and_cohort_with_user_role(course_is_cohorted, user, role_name
     return [cohort_course, cohort]
 
 
-@attr(shard=8)
 @mock.patch.dict("django.conf.settings.FEATURES", {"ENABLE_DISCUSSION_SERVICE": True})
 class GetCourseTest(ForumsEnableMixin, UrlResetMixin, SharedModuleStoreTestCase):
     """Test for get_course"""
@@ -147,7 +145,6 @@ class GetCourseTest(ForumsEnableMixin, UrlResetMixin, SharedModuleStoreTestCase)
         )
 
 
-@attr(shard=8)
 @ddt.ddt
 @mock.patch.dict("django.conf.settings.FEATURES", {"ENABLE_DISCUSSION_SERVICE": True})
 class GetCourseTestBlackouts(ForumsEnableMixin, UrlResetMixin, ModuleStoreTestCase):
@@ -191,7 +188,6 @@ class GetCourseTestBlackouts(ForumsEnableMixin, UrlResetMixin, ModuleStoreTestCa
         self.assertEqual(result["blackouts"], [])
 
 
-@attr(shard=8)
 @mock.patch.dict("django.conf.settings.FEATURES", {"DISABLE_START_DATES": False})
 @mock.patch.dict("django.conf.settings.FEATURES", {"ENABLE_DISCUSSION_SERVICE": True})
 class GetCourseTopicsTest(ForumsEnableMixin, UrlResetMixin, ModuleStoreTestCase):
@@ -565,7 +561,6 @@ class GetCourseTopicsTest(ForumsEnableMixin, UrlResetMixin, ModuleStoreTestCase)
         )
 
 
-@attr(shard=8)
 @ddt.ddt
 @mock.patch.dict("django.conf.settings.FEATURES", {"ENABLE_DISCUSSION_SERVICE": True})
 class GetThreadListTest(ForumsEnableMixin, CommentsServiceMockMixin, UrlResetMixin, SharedModuleStoreTestCase):
@@ -983,7 +978,6 @@ class GetThreadListTest(ForumsEnableMixin, CommentsServiceMockMixin, UrlResetMix
         self.assertIn("order_direction", assertion.exception.message_dict)
 
 
-@attr(shard=8)
 @ddt.ddt
 @mock.patch.dict("django.conf.settings.FEATURES", {"ENABLE_DISCUSSION_SERVICE": True})
 class GetCommentListTest(ForumsEnableMixin, CommentsServiceMockMixin, SharedModuleStoreTestCase):
@@ -1417,7 +1411,6 @@ class GetCommentListTest(ForumsEnableMixin, CommentsServiceMockMixin, SharedModu
             self.get_comment_list(thread, endorsed=True, page=2, page_size=10)
 
 
-@attr(shard=8)
 @ddt.ddt
 @disable_signal(api, 'thread_created')
 @disable_signal(api, 'thread_voted')
@@ -1721,7 +1714,6 @@ class CreateThreadTest(
             create_thread(self.request, data)
 
 
-@attr(shard=8)
 @ddt.ddt
 @disable_signal(api, 'comment_created')
 @disable_signal(api, 'comment_voted')
@@ -1987,7 +1979,6 @@ class CreateCommentTest(
             create_comment(self.request, data)
 
 
-@attr(shard=8)
 @ddt.ddt
 @disable_signal(api, 'thread_edited')
 @disable_signal(api, 'thread_voted')
@@ -2368,7 +2359,6 @@ class UpdateThreadTest(
         )
 
 
-@attr(shard=8)
 @ddt.ddt
 @disable_signal(api, 'comment_edited')
 @disable_signal(api, 'comment_voted')
@@ -2771,7 +2761,6 @@ class UpdateCommentTest(
             )
 
 
-@attr(shard=8)
 @ddt.ddt
 @disable_signal(api, 'thread_deleted')
 @mock.patch.dict("django.conf.settings.FEATURES", {"ENABLE_DISCUSSION_SERVICE": True})
@@ -2909,7 +2898,6 @@ class DeleteThreadTest(
             self.assertTrue(expected_error)
 
 
-@attr(shard=8)
 @ddt.ddt
 @disable_signal(api, 'comment_deleted')
 @mock.patch.dict("django.conf.settings.FEATURES", {"ENABLE_DISCUSSION_SERVICE": True})
@@ -3066,7 +3054,6 @@ class DeleteCommentTest(
             self.assertTrue(expected_error)
 
 
-@attr(shard=8)
 @ddt.ddt
 @mock.patch.dict("django.conf.settings.FEATURES", {"ENABLE_DISCUSSION_SERVICE": True})
 class RetrieveThreadTest(

--- a/lms/djangoapps/discussion_api/tests/test_forms.py
+++ b/lms/djangoapps/discussion_api/tests/test_forms.py
@@ -15,7 +15,6 @@ from openedx.core.djangoapps.util.test_forms import FormTestMixin
 
 class PaginationTestMixin(object):
     """A mixin for testing forms with pagination fields"""
-    shard = 8
 
     def test_missing_page(self):
         self.form_data.pop("page")
@@ -41,7 +40,6 @@ class PaginationTestMixin(object):
 @ddt.ddt
 class ThreadListGetFormTest(FormTestMixin, PaginationTestMixin, TestCase):
     """Tests for ThreadListGetForm"""
-    shard = 8
     FORM_CLASS = ThreadListGetForm
 
     def setUp(self):
@@ -168,7 +166,6 @@ class ThreadListGetFormTest(FormTestMixin, PaginationTestMixin, TestCase):
 @ddt.ddt
 class CommentListGetFormTest(FormTestMixin, PaginationTestMixin, TestCase):
     """Tests for CommentListGetForm"""
-    shard = 8
     FORM_CLASS = CommentListGetForm
 
     def setUp(self):

--- a/lms/djangoapps/discussion_api/tests/test_pagination.py
+++ b/lms/djangoapps/discussion_api/tests/test_pagination.py
@@ -11,7 +11,6 @@ from discussion_api.tests.utils import make_paginated_api_response
 
 class PaginationSerializerTest(TestCase):
     """Tests for PaginationSerializer"""
-    shard = 8
 
     def do_case(self, objects, page_num, num_pages, expected):
         """

--- a/lms/djangoapps/discussion_api/tests/test_permissions.py
+++ b/lms/djangoapps/discussion_api/tests/test_permissions.py
@@ -14,7 +14,6 @@ from discussion_api.permissions import (
 from lms.lib.comment_client.comment import Comment
 from lms.lib.comment_client.thread import Thread
 from lms.lib.comment_client.user import User
-from openedx.core.lib.tests import attr
 from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
 from xmodule.modulestore.tests.factories import CourseFactory
 
@@ -30,7 +29,6 @@ def _get_context(requester_id, is_requester_privileged, is_cohorted=False, threa
     }
 
 
-@attr(shard=8)
 @ddt.ddt
 class GetInitializableFieldsTest(ModuleStoreTestCase):
     """Tests for get_*_initializable_fields"""
@@ -67,7 +65,6 @@ class GetInitializableFieldsTest(ModuleStoreTestCase):
         self.assertEqual(actual, expected)
 
 
-@attr(shard=8)
 @ddt.ddt
 class GetEditableFieldsTest(ModuleStoreTestCase):
     """Tests for get_editable_fields"""
@@ -106,7 +103,6 @@ class GetEditableFieldsTest(ModuleStoreTestCase):
         self.assertEqual(actual, expected)
 
 
-@attr(shard=8)
 @ddt.ddt
 class CanDeleteTest(ModuleStoreTestCase):
     """Tests for can_delete"""

--- a/lms/djangoapps/discussion_api/tests/test_render.py
+++ b/lms/djangoapps/discussion_api/tests/test_render.py
@@ -16,7 +16,6 @@ def _add_p_tags(raw_body):
 @ddt.ddt
 class RenderBodyTest(TestCase):
     """Tests for render_body"""
-    shard = 8
 
     def test_empty(self):
         self.assertEqual(render_body(""), "")

--- a/lms/djangoapps/discussion_api/tests/test_serializers.py
+++ b/lms/djangoapps/discussion_api/tests/test_serializers.py
@@ -22,7 +22,6 @@ from django_comment_common.models import (
 from lms.lib.comment_client.comment import Comment
 from lms.lib.comment_client.thread import Thread
 from openedx.core.djangoapps.course_groups.tests.helpers import CohortFactory
-from openedx.core.lib.tests import attr
 from student.tests.factories import UserFactory
 from util.testing import UrlResetMixin
 from xmodule.modulestore import ModuleStoreEnum
@@ -31,7 +30,6 @@ from xmodule.modulestore.tests.django_utils import SharedModuleStoreTestCase
 from xmodule.modulestore.tests.factories import CourseFactory
 
 
-@attr(shard=6)
 @ddt.ddt
 class SerializerTestMixin(ForumsEnableMixin, CommentsServiceMockMixin, UrlResetMixin):
     """
@@ -136,7 +134,6 @@ class SerializerTestMixin(ForumsEnableMixin, CommentsServiceMockMixin, UrlResetM
         self.assertEqual(serialized["voted"], True)
 
 
-@attr(shard=6)
 @ddt.ddt
 class ThreadSerializerSerializationTest(SerializerTestMixin, SharedModuleStoreTestCase):
     """Tests for ThreadSerializer serialization."""
@@ -238,7 +235,6 @@ class ThreadSerializerSerializationTest(SerializerTestMixin, SharedModuleStoreTe
         self.assertNotIn("response_count", serialized)
 
 
-@attr(shard=6)
 @ddt.ddt
 class CommentSerializerTest(SerializerTestMixin, SharedModuleStoreTestCase):
     """Tests for CommentSerializer."""
@@ -398,7 +394,6 @@ class CommentSerializerTest(SerializerTestMixin, SharedModuleStoreTestCase):
         self.assertEqual(serialized["children"][1]["children"][0]["parent_id"], "test_child_2")
 
 
-@attr(shard=6)
 @ddt.ddt
 class ThreadSerializerDeserializationTest(
         ForumsEnableMixin,
@@ -608,7 +603,6 @@ class ThreadSerializerDeserializationTest(
         )
 
 
-@attr(shard=6)
 @ddt.ddt
 class CommentSerializerDeserializationTest(ForumsEnableMixin, CommentsServiceMockMixin, SharedModuleStoreTestCase):
     """Tests for ThreadSerializer deserialization."""

--- a/lms/djangoapps/discussion_api/tests/test_views.py
+++ b/lms/djangoapps/discussion_api/tests/test_views.py
@@ -29,7 +29,6 @@ from django_comment_client.tests.utils import ForumsEnableMixin
 from openedx.core.djangoapps.oauth_dispatch.jwt import create_jwt_for_user
 from openedx.core.djangoapps.user_api.accounts.image_helpers import get_profile_image_storage
 from openedx.core.djangoapps.user_api.models import RetirementState, UserRetirementStatus
-from openedx.core.lib.tests import attr
 from student.models import get_retired_username_by_username
 from student.tests.factories import CourseEnrollmentFactory, UserFactory, SuperuserFactory
 from util.testing import PatchMediaTypeMixin, UrlResetMixin
@@ -124,7 +123,6 @@ class DiscussionAPIViewTestMixin(ForumsEnableMixin, CommentsServiceMockMixin, Ur
         self.test_basic()
 
 
-@attr(shard=8)
 @mock.patch.dict("django.conf.settings.FEATURES", {"ENABLE_DISCUSSION_SERVICE": True})
 class CourseViewTest(DiscussionAPIViewTestMixin, ModuleStoreTestCase):
     """Tests for CourseView"""
@@ -159,7 +157,6 @@ class CourseViewTest(DiscussionAPIViewTestMixin, ModuleStoreTestCase):
         )
 
 
-@attr(shard=8)
 @httpretty.activate
 @mock.patch.dict("django.conf.settings.FEATURES", {"ENABLE_DISCUSSION_SERVICE": True})
 class RetireViewTest(DiscussionAPIViewTestMixin, ModuleStoreTestCase):
@@ -232,7 +229,6 @@ class RetireViewTest(DiscussionAPIViewTestMixin, ModuleStoreTestCase):
         pass
 
 
-@attr(shard=8)
 @ddt.ddt
 @mock.patch.dict("django.conf.settings.FEATURES", {"ENABLE_DISCUSSION_SERVICE": True})
 class CourseTopicsViewTest(DiscussionAPIViewTestMixin, ModuleStoreTestCase):
@@ -387,7 +383,6 @@ class CourseTopicsViewTest(DiscussionAPIViewTestMixin, ModuleStoreTestCase):
         )
 
 
-@attr(shard=8)
 @ddt.ddt
 @httpretty.activate
 @mock.patch.dict("django.conf.settings.FEATURES", {"ENABLE_DISCUSSION_SERVICE": True})
@@ -728,7 +723,6 @@ class ThreadViewSetListTest(DiscussionAPIViewTestMixin, ModuleStoreTestCase, Pro
         self.assertEqual({}, response_thread['users'])
 
 
-@attr(shard=8)
 @httpretty.activate
 @disable_signal(api, 'thread_created')
 @mock.patch.dict("django.conf.settings.FEATURES", {"ENABLE_DISCUSSION_SERVICE": True})
@@ -793,7 +787,6 @@ class ThreadViewSetCreateTest(DiscussionAPIViewTestMixin, ModuleStoreTestCase):
         self.assertEqual(response_data, expected_response_data)
 
 
-@attr(shard=8)
 @ddt.ddt
 @httpretty.activate
 @disable_signal(api, 'thread_edited')
@@ -951,7 +944,6 @@ class ThreadViewSetPartialUpdateTest(DiscussionAPIViewTestMixin, ModuleStoreTest
         )
 
 
-@attr(shard=8)
 @httpretty.activate
 @disable_signal(api, 'thread_deleted')
 @mock.patch.dict("django.conf.settings.FEATURES", {"ENABLE_DISCUSSION_SERVICE": True})
@@ -987,7 +979,6 @@ class ThreadViewSetDeleteTest(DiscussionAPIViewTestMixin, ModuleStoreTestCase):
         self.assertEqual(response.status_code, 404)
 
 
-@attr(shard=8)
 @ddt.ddt
 @httpretty.activate
 @mock.patch.dict("django.conf.settings.FEATURES", {"ENABLE_DISCUSSION_SERVICE": True})
@@ -1362,7 +1353,6 @@ class CommentViewSetListTest(DiscussionAPIViewTestMixin, ModuleStoreTestCase, Pr
             self.assertNotIn(response_comment['endorsed_by'], response_users)
 
 
-@attr(shard=8)
 @httpretty.activate
 @disable_signal(api, 'comment_deleted')
 @mock.patch.dict("django.conf.settings.FEATURES", {"ENABLE_DISCUSSION_SERVICE": True})
@@ -1405,7 +1395,6 @@ class CommentViewSetDeleteTest(DiscussionAPIViewTestMixin, ModuleStoreTestCase):
         self.assertEqual(response.status_code, 404)
 
 
-@attr(shard=8)
 @httpretty.activate
 @disable_signal(api, 'comment_created')
 @mock.patch.dict("django.conf.settings.FEATURES", {"ENABLE_DISCUSSION_SERVICE": True})
@@ -1494,7 +1483,6 @@ class CommentViewSetCreateTest(DiscussionAPIViewTestMixin, ModuleStoreTestCase):
         self.assertEqual(response.status_code, 403)
 
 
-@attr(shard=8)
 @ddt.ddt
 @disable_signal(api, 'comment_edited')
 @mock.patch.dict("django.conf.settings.FEATURES", {"ENABLE_DISCUSSION_SERVICE": True})
@@ -1614,7 +1602,6 @@ class CommentViewSetPartialUpdateTest(DiscussionAPIViewTestMixin, ModuleStoreTes
         self.assertEqual(response.status_code, 400)
 
 
-@attr(shard=8)
 @httpretty.activate
 @mock.patch.dict("django.conf.settings.FEATURES", {"ENABLE_DISCUSSION_SERVICE": True})
 class ThreadViewSetRetrieveTest(DiscussionAPIViewTestMixin, ModuleStoreTestCase, ProfileImageTestMixin):
@@ -1666,7 +1653,6 @@ class ThreadViewSetRetrieveTest(DiscussionAPIViewTestMixin, ModuleStoreTestCase,
         self.assertEqual(expected_profile_data, response_users[self.user.username])
 
 
-@attr(shard=8)
 @httpretty.activate
 @mock.patch.dict("django.conf.settings.FEATURES", {"ENABLE_DISCUSSION_SERVICE": True})
 class CommentViewSetRetrieveTest(DiscussionAPIViewTestMixin, ModuleStoreTestCase, ProfileImageTestMixin):

--- a/lms/djangoapps/django_comment_client/base/tests.py
+++ b/lms/djangoapps/django_comment_client/base/tests.py
@@ -38,7 +38,6 @@ from lms.lib.comment_client import Thread
 from openedx.core.djangoapps.course_groups.cohorts import set_course_cohorted
 from openedx.core.djangoapps.course_groups.tests.helpers import CohortFactory
 from openedx.core.djangoapps.waffle_utils.testutils import WAFFLE_TABLES
-from openedx.core.lib.tests import attr
 from student.roles import CourseStaffRole, UserBasedRole
 from student.tests.factories import CourseAccessRoleFactory, CourseEnrollmentFactory, UserFactory
 from util.testing import UrlResetMixin
@@ -73,7 +72,6 @@ class MockRequestSetupMixin(object):
         mock_request.return_value = self._create_response_mock(data)
 
 
-@attr(shard=2)
 @patch('lms.lib.comment_client.utils.requests.request', autospec=True)
 class CreateThreadGroupIdTestCase(
         MockRequestSetupMixin,
@@ -109,7 +107,6 @@ class CreateThreadGroupIdTestCase(
         self._assert_json_response_contains_group_info(response)
 
 
-@attr(shard=2)
 @patch('lms.lib.comment_client.utils.requests.request', autospec=True)
 @disable_signal(views, 'thread_edited')
 @disable_signal(views, 'thread_voted')
@@ -367,7 +364,6 @@ class ViewsTestCaseMixin(object):
         self.assertEqual(data['commentable_id'], 'some_topic')
 
 
-@attr(shard=2)
 @ddt.ddt
 @patch('lms.lib.comment_client.utils.requests.request', autospec=True)
 @disable_signal(views, 'thread_created')
@@ -421,7 +417,6 @@ class ViewsQueryCountTestCase(
         self.update_thread_helper(mock_request)
 
 
-@attr(shard=2)
 @ddt.ddt
 @patch('lms.lib.comment_client.utils.requests.request', autospec=True)
 class ViewsTestCase(
@@ -1067,7 +1062,6 @@ class ViewsTestCase(
         self.assertEqual(response.status_code, 200)
 
 
-@attr(shard=2)
 @patch("lms.lib.comment_client.utils.requests.request", autospec=True)
 @disable_signal(views, 'comment_endorsed')
 class ViewPermissionsTestCase(ForumsEnableMixin, UrlResetMixin, SharedModuleStoreTestCase, MockRequestSetupMixin):
@@ -1177,7 +1171,6 @@ class ViewPermissionsTestCase(ForumsEnableMixin, UrlResetMixin, SharedModuleStor
         self.assertEqual(response.status_code, 200)
 
 
-@attr(shard=2)
 class CreateThreadUnicodeTestCase(
         ForumsEnableMixin,
         SharedModuleStoreTestCase,
@@ -1218,7 +1211,6 @@ class CreateThreadUnicodeTestCase(
         self.assertEqual(mock_request.call_args[1]["data"]["title"], text)
 
 
-@attr(shard=2)
 @disable_signal(views, 'thread_edited')
 class UpdateThreadUnicodeTestCase(
         ForumsEnableMixin,
@@ -1261,7 +1253,6 @@ class UpdateThreadUnicodeTestCase(
         self.assertEqual(mock_request.call_args[1]["data"]["commentable_id"], "test_commentable")
 
 
-@attr(shard=2)
 @disable_signal(views, 'comment_created')
 class CreateCommentUnicodeTestCase(
         ForumsEnableMixin,
@@ -1309,7 +1300,6 @@ class CreateCommentUnicodeTestCase(
             del Thread.commentable_id
 
 
-@attr(shard=2)
 @disable_signal(views, 'comment_edited')
 class UpdateCommentUnicodeTestCase(
         ForumsEnableMixin,
@@ -1348,7 +1338,6 @@ class UpdateCommentUnicodeTestCase(
         self.assertEqual(mock_request.call_args[1]["data"]["body"], text)
 
 
-@attr(shard=2)
 @disable_signal(views, 'comment_created')
 class CreateSubCommentUnicodeTestCase(
         ForumsEnableMixin,
@@ -1400,7 +1389,6 @@ class CreateSubCommentUnicodeTestCase(
             del Thread.commentable_id
 
 
-@attr(shard=2)
 @ddt.ddt
 @patch("lms.lib.comment_client.utils.requests.request", autospec=True)
 @disable_signal(views, 'thread_voted')
@@ -1745,7 +1733,6 @@ class TeamsPermissionsTestCase(ForumsEnableMixin, UrlResetMixin, SharedModuleSto
 TEAM_COMMENTABLE_ID = 'test-team-discussion'
 
 
-@attr(shard=2)
 @disable_signal(views, 'comment_created')
 @ddt.ddt
 class ForumEventTestCase(ForumsEnableMixin, SharedModuleStoreTestCase, MockRequestSetupMixin):
@@ -1931,7 +1918,6 @@ class ForumEventTestCase(ForumsEnableMixin, SharedModuleStoreTestCase, MockReque
         self.assertEqual(event['vote_value'], 'up')
 
 
-@attr(shard=2)
 class UsersEndpointTestCase(ForumsEnableMixin, SharedModuleStoreTestCase, MockRequestSetupMixin):
 
     @classmethod

--- a/lms/djangoapps/django_comment_client/tests/mock_cs_server/test_mock_cs_server.py
+++ b/lms/djangoapps/django_comment_client/tests/mock_cs_server/test_mock_cs_server.py
@@ -13,7 +13,6 @@ class MockCommentServiceServerTest(unittest.TestCase):
     A mock version of the Comment Service server that listens on a local
     port and responds with pre-defined grade messages.
     '''
-    shard = 4
 
     def setUp(self):
         super(MockCommentServiceServerTest, self).setUp()

--- a/lms/djangoapps/django_comment_client/tests/test_middleware.py
+++ b/lms/djangoapps/django_comment_client/tests/test_middleware.py
@@ -9,7 +9,6 @@ import lms.lib.comment_client
 
 
 class AjaxExceptionTestCase(TestCase):
-    shard = 1
 
     def setUp(self):
         super(AjaxExceptionTestCase, self).setUp()

--- a/lms/djangoapps/django_comment_client/tests/test_models.py
+++ b/lms/djangoapps/django_comment_client/tests/test_models.py
@@ -14,7 +14,6 @@ class RoleClassTestCase(ModuleStoreTestCase):
     Tests for roles of the comment client service integration
     """
     MODULESTORE = TEST_DATA_MIXED_MODULESTORE
-    shard = 1
 
     def setUp(self):
         super(RoleClassTestCase, self).setUp()
@@ -55,7 +54,6 @@ class PermissionClassTestCase(TestCase):
     """
     Tests for permissions of the comment client service integration
     """
-    shard = 1
 
     def setUp(self):
         super(PermissionClassTestCase, self).setUp()

--- a/lms/djangoapps/django_comment_client/tests/test_utils.py
+++ b/lms/djangoapps/django_comment_client/tests/test_utils.py
@@ -38,7 +38,6 @@ from openedx.core.djangoapps.course_groups import cohorts
 from openedx.core.djangoapps.course_groups.cohorts import set_course_cohorted
 from openedx.core.djangoapps.course_groups.tests.helpers import CohortFactory, config_course_cohorts
 from openedx.core.djangoapps.util.testing import ContentGroupTestCase
-from openedx.core.lib.tests import attr
 from student.roles import CourseStaffRole
 from student.tests.factories import AdminFactory, CourseEnrollmentFactory, UserFactory
 from xmodule.modulestore import ModuleStoreEnum
@@ -47,7 +46,6 @@ from xmodule.modulestore.tests.django_utils import TEST_DATA_MIXED_MODULESTORE, 
 from xmodule.modulestore.tests.factories import CourseFactory, ItemFactory, ToyCourseFactory
 
 
-@attr(shard=1)
 class DictionaryTestCase(TestCase):
     def test_extract(self):
         d = {'cats': 'meow', 'dogs': 'woof'}
@@ -66,7 +64,6 @@ class DictionaryTestCase(TestCase):
         self.assertEqual(utils.strip_blank(d), expected)
 
 
-@attr(shard=1)
 class AccessUtilsTestCase(ModuleStoreTestCase):
     """
     Base testcase class for access and roles for the
@@ -122,7 +119,6 @@ class AccessUtilsTestCase(ModuleStoreTestCase):
 
 
 @ddt.ddt
-@attr(shard=1)
 class CoursewareContextTestCase(ModuleStoreTestCase):
     """
     Base testcase class for courseware context for the
@@ -228,7 +224,6 @@ class CoursewareContextTestCase(ModuleStoreTestCase):
         self.assertEqual(len(utils.get_accessible_discussion_xblocks(course, self.user)), expected_discussion_xblocks)
 
 
-@attr(shard=3)
 class CachedDiscussionIdMapTestCase(ModuleStoreTestCase):
     """
     Tests that using the cache of discussion id mappings has the same behavior as searching through the course.
@@ -364,7 +359,6 @@ class CategoryMapTestMixin(object):
         )
 
 
-@attr(shard=1)
 class CategoryMapTestCase(CategoryMapTestMixin, ModuleStoreTestCase):
     """
     Base testcase class for discussion categories for the
@@ -1052,7 +1046,6 @@ class CategoryMapTestCase(CategoryMapTestMixin, ModuleStoreTestCase):
         )
 
 
-@attr(shard=1)
 class ContentGroupCategoryMapTestCase(CategoryMapTestMixin, ContentGroupTestCase):
     """
     Tests `get_discussion_category_map` on discussion xblocks which are
@@ -1428,7 +1421,6 @@ class IsCommentableDividedTestCase(ModuleStoreTestCase):
         self.assertTrue(utils.is_commentable_divided(course.id, "random"))
 
 
-@attr(shard=1)
 class GroupIdForUserTestCase(ModuleStoreTestCase):
     """ Test the get_group_id_for_user method. """
 
@@ -1475,7 +1467,6 @@ class GroupIdForUserTestCase(ModuleStoreTestCase):
         )
 
 
-@attr(shard=1)
 class CourseDiscussionDivisionEnabledTestCase(ModuleStoreTestCase):
     """ Test the course_discussion_division_enabled and available_division_schemes methods. """
 
@@ -1522,7 +1513,6 @@ class CourseDiscussionDivisionEnabledTestCase(ModuleStoreTestCase):
         self.assertEqual([CourseDiscussionSettings.ENROLLMENT_TRACK], utils.available_division_schemes(self.course.id))
 
 
-@attr(shard=1)
 class GroupNameTestCase(ModuleStoreTestCase):
     """ Test the get_group_name and get_group_names_by_id methods. """
 

--- a/lms/djangoapps/edxnotes/tests.py
+++ b/lms/djangoapps/edxnotes/tests.py
@@ -29,7 +29,6 @@ from edxnotes.plugins import EdxNotesTab
 from openedx.core.djangoapps.oauth_dispatch.jwt import create_jwt_for_user
 from openedx.core.djangoapps.oauth_dispatch.tests.factories import ApplicationFactory
 from openedx.core.djangoapps.user_api.models import RetirementState, UserRetirementStatus
-from openedx.core.lib.tests import attr
 from student.tests.factories import CourseEnrollmentFactory, SuperuserFactory, UserFactory
 from xmodule.modulestore import ModuleStoreEnum
 from xmodule.modulestore.django import modulestore
@@ -90,7 +89,6 @@ class TestProblem(object):
         return "original_get_html"
 
 
-@attr(shard=3)
 @skipUnless(settings.FEATURES["ENABLE_EDXNOTES"], "EdxNotes feature needs to be enabled.")
 class EdxNotesDecoratorTest(ModuleStoreTestCase):
     """
@@ -186,7 +184,6 @@ class EdxNotesDecoratorTest(ModuleStoreTestCase):
         assert problem.get_html() == "original_get_html"
 
 
-@attr(shard=3)
 @skipUnless(settings.FEATURES["ENABLE_EDXNOTES"], "EdxNotes feature needs to be enabled.")
 @ddt.ddt
 class EdxNotesHelpersTest(ModuleStoreTestCase):
@@ -954,7 +951,6 @@ class EdxNotesHelpersTest(ModuleStoreTestCase):
         verify_url(previous_url, previous_api_url)
 
 
-@attr(shard=3)
 @skipUnless(settings.FEATURES["ENABLE_EDXNOTES"], "EdxNotes feature needs to be enabled.")
 @ddt.ddt
 class EdxNotesViewsTest(ModuleStoreTestCase):
@@ -1150,7 +1146,6 @@ class EdxNotesViewsTest(ModuleStoreTestCase):
         self.assertEqual(response.status_code, 400)
 
 
-@attr(shard=3)
 class EdxNotesRetireAPITest(ModuleStoreTestCase):
     """
     Tests for EdxNotes retirement API.
@@ -1264,7 +1259,6 @@ class EdxNotesRetireAPITest(ModuleStoreTestCase):
         self.assertEqual(response.status_code, 500)
 
 
-@attr(shard=3)
 @skipUnless(settings.FEATURES["ENABLE_EDXNOTES"], "EdxNotes feature needs to be enabled.")
 @ddt.ddt
 class EdxNotesPluginTest(ModuleStoreTestCase):

--- a/lms/djangoapps/email_marketing/tests/test_signals.py
+++ b/lms/djangoapps/email_marketing/tests/test_signals.py
@@ -68,7 +68,6 @@ class EmailMarketingTests(TestCase):
     """
     Tests for the EmailMarketing signals and tasks classes.
     """
-    shard = 4
 
     def setUp(self):
         update_email_marketing_config(enabled=False)
@@ -604,7 +603,6 @@ class SailthruTests(TestCase):
     """
     Tests for the Sailthru tasks class.
     """
-    shard = 4
 
     def setUp(self):
         super(SailthruTests, self).setUp()

--- a/lms/djangoapps/experiments/tests/test_views.py
+++ b/lms/djangoapps/experiments/tests/test_views.py
@@ -18,7 +18,6 @@ CROSS_DOMAIN_REFERER = 'https://ecommerce.edx.org'
 
 
 class ExperimentDataViewSetTests(APITestCase):
-    shard = 4
 
     def assert_data_created_for_user(self, user, method='post', status=201):
         url = reverse('api_experiments:v0:data-list')
@@ -314,7 +313,6 @@ class ExperimentCrossDomainTests(APITestCase):
 
 
 class ExperimentKeyValueViewSetTests(APITestCase):
-    shard = 4
 
     def test_permissions(self):
         """ Staff access is required for write operations. """

--- a/lms/djangoapps/gating/tests/test_api.py
+++ b/lms/djangoapps/gating/tests/test_api.py
@@ -61,7 +61,6 @@ class TestEvaluatePrerequisite(GatingTestCase, MilestonesTestCaseMixin):
     """
     Tests for the evaluate_prerequisite function
     """
-    shard = 3
 
     def setUp(self):
         super(TestEvaluatePrerequisite, self).setUp()

--- a/lms/djangoapps/gating/tests/test_integration.py
+++ b/lms/djangoapps/gating/tests/test_integration.py
@@ -25,7 +25,6 @@ class TestGatedContent(MilestonesTestCaseMixin, SharedModuleStoreTestCase):
     Base TestCase class for setting up a basic course structure
     and testing the gating feature
     """
-    shard = 3
 
     @classmethod
     def setUpClass(cls):

--- a/lms/djangoapps/gating/tests/test_signals.py
+++ b/lms/djangoapps/gating/tests/test_signals.py
@@ -14,7 +14,6 @@ class TestHandleScoreChanged(ModuleStoreTestCase):
     """
     Test case for handle_score_changed django signal handler
     """
-    shard = 4
 
     def setUp(self):
         super(TestHandleScoreChanged, self).setUp()

--- a/lms/djangoapps/grades/api/v1/tests/test_grading_policy_view.py
+++ b/lms/djangoapps/grades/api/v1/tests/test_grading_policy_view.py
@@ -21,7 +21,6 @@ class GradingPolicyTestMixin(object):
     """
     Mixin class for Grading Policy tests
     """
-    shard = 4
     view_name = None
 
     def setUp(self):
@@ -158,7 +157,6 @@ class CourseGradingPolicyTests(GradingPolicyTestMixin, SharedModuleStoreTestCase
     """
     Tests for CourseGradingPolicy view.
     """
-    shard = 4
     view_name = 'grades_api:v1:course_grading_policy'
 
     raw_grader = [
@@ -210,7 +208,6 @@ class CourseGradingPolicyMissingFieldsTests(GradingPolicyTestMixin, SharedModule
     """
     Tests for CourseGradingPolicy view when fields are missing.
     """
-    shard = 4
     view_name = 'grades_api:v1:course_grading_policy'
 
     # Raw grader with missing keys

--- a/lms/djangoapps/grades/config/tests/test_models.py
+++ b/lms/djangoapps/grades/config/tests/test_models.py
@@ -21,7 +21,6 @@ class PersistentGradesFeatureFlagTests(TestCase):
     Tests the behavior of the feature flags for persistent grading.
     These are set via Django admin settings.
     """
-    shard = 4
 
     def setUp(self):
         super(PersistentGradesFeatureFlagTests, self).setUp()

--- a/lms/djangoapps/grades/management/commands/tests/test_compute_grades.py
+++ b/lms/djangoapps/grades/management/commands/tests/test_compute_grades.py
@@ -24,7 +24,6 @@ class TestComputeGrades(SharedModuleStoreTestCase):
     """
     Tests compute_grades management command.
     """
-    shard = 4
     num_users = 3
     num_courses = 5
 

--- a/lms/djangoapps/grades/management/commands/tests/test_recalculate_subsection_grades.py
+++ b/lms/djangoapps/grades/management/commands/tests/test_recalculate_subsection_grades.py
@@ -25,7 +25,6 @@ class TestRecalculateSubsectionGrades(HasCourseWithProblemsMixin, ModuleStoreTes
     """
     Tests recalculate subsection grades management command.
     """
-    shard = 4
 
     def setUp(self):
         super(TestRecalculateSubsectionGrades, self).setUp()

--- a/lms/djangoapps/grades/tests/integration/test_access.py
+++ b/lms/djangoapps/grades/tests/integration/test_access.py
@@ -21,7 +21,6 @@ class GradesAccessIntegrationTest(ProblemSubmissionTestMixin, SharedModuleStoreT
     """
     Tests integration between grading and block access.
     """
-    shard = 4
     ENABLED_SIGNALS = ['course_published']
 
     @classmethod

--- a/lms/djangoapps/grades/tests/integration/test_events.py
+++ b/lms/djangoapps/grades/tests/integration/test_events.py
@@ -24,7 +24,6 @@ class GradesEventIntegrationTest(ProblemSubmissionTestMixin, SharedModuleStoreTe
     Tests integration between the eventing in various layers
     of the grading infrastructure.
     """
-    shard = 4
     ENABLED_SIGNALS = ['course_published']
 
     @classmethod

--- a/lms/djangoapps/grades/tests/integration/test_problems.py
+++ b/lms/djangoapps/grades/tests/integration/test_problems.py
@@ -26,7 +26,6 @@ class TestMultipleProblemTypesSubsectionScores(SharedModuleStoreTestCase):
     """
     Test grading of different problem types.
     """
-    shard = 4
 
     SCORED_BLOCK_COUNT = 7
     ACTUAL_TOTAL_POSSIBLE = 17.0
@@ -101,7 +100,6 @@ class TestVariedMetadata(ProblemSubmissionTestMixin, ModuleStoreTestCase):
     Test that changing the metadata on a block has the desired effect on the
     persisted score.
     """
-    shard = 4
     default_problem_metadata = {
         u'graded': True,
         u'weight': 2.5,
@@ -210,7 +208,6 @@ class TestWeightedProblems(SharedModuleStoreTestCase):
     """
     Test scores and grades with various problem weight values.
     """
-    shard = 4
 
     @classmethod
     def setUpClass(cls):

--- a/lms/djangoapps/grades/tests/test_course_data.py
+++ b/lms/djangoapps/grades/tests/test_course_data.py
@@ -16,7 +16,6 @@ class CourseDataTest(ModuleStoreTestCase):
     """
     Simple tests to ensure CourseData works as advertised.
     """
-    shard = 4
 
     def setUp(self):
         super(CourseDataTest, self).setUp()

--- a/lms/djangoapps/grades/tests/test_course_grade.py
+++ b/lms/djangoapps/grades/tests/test_course_grade.py
@@ -24,7 +24,6 @@ class ZeroGradeTest(GradeTestBase):
     Tests ZeroCourseGrade (and, implicitly, ZeroSubsectionGrade)
     functionality.
     """
-    shard = 4
 
     @ddt.data(True, False)
     def test_zero(self, assume_zero_enabled):
@@ -71,7 +70,6 @@ class TestScoreForModule(SharedModuleStoreTestCase):
                    (2/5) (3/5) (0/1)   -   (1/3)   -   (3/10)
 
     """
-    shard = 4
 
     @classmethod
     def setUpClass(cls):

--- a/lms/djangoapps/grades/tests/test_course_grade_factory.py
+++ b/lms/djangoapps/grades/tests/test_course_grade_factory.py
@@ -247,7 +247,6 @@ class TestGradeIteration(SharedModuleStoreTestCase):
     """
     COURSE_NUM = "1000"
     COURSE_NAME = "grading_test_course"
-    shard = 1
 
     @classmethod
     def setUpClass(cls):

--- a/lms/djangoapps/grades/tests/test_models.py
+++ b/lms/djangoapps/grades/tests/test_models.py
@@ -34,7 +34,6 @@ class BlockRecordListTestCase(TestCase):
     """
     Verify the behavior of BlockRecordList, particularly around edge cases
     """
-    shard = 4
 
     def setUp(self):
         super(BlockRecordListTestCase, self).setUp()
@@ -92,7 +91,6 @@ class BlockRecordTest(GradesModelTestCase):
     """
     Test the BlockRecord model.
     """
-    shard = 4
 
     def test_creation(self):
         """
@@ -132,7 +130,6 @@ class VisibleBlocksTest(GradesModelTestCase):
     """
     Test the VisibleBlocks model.
     """
-    shard = 4
 
     def setUp(self):
         super(VisibleBlocksTest, self).setUp()
@@ -206,7 +203,6 @@ class PersistentSubsectionGradeTest(GradesModelTestCase):
     """
     Test the PersistentSubsectionGrade model.
     """
-    shard = 4
 
     def setUp(self):
         super(PersistentSubsectionGradeTest, self).setUp()
@@ -359,7 +355,6 @@ class PersistentCourseGradesTest(GradesModelTestCase):
     """
     Tests the PersistentCourseGrade model.
     """
-    shard = 4
 
     def setUp(self):
         super(PersistentCourseGradesTest, self).setUp()

--- a/lms/djangoapps/grades/tests/test_scores.py
+++ b/lms/djangoapps/grades/tests/test_scores.py
@@ -52,7 +52,6 @@ class TestScoredBlockTypes(TestCase):
     """
     Tests for the possibly_scored function.
     """
-    shard = 4
     possibly_scored_block_types = {
         'course', 'chapter', 'sequential', 'vertical',
         'library_content', 'split_test', 'conditional', 'library', 'randomize',
@@ -75,7 +74,6 @@ class TestGetScore(TestCase):
     """
     Tests for get_score
     """
-    shard = 4
     display_name = 'test_name'
     location = 'test_location'
 
@@ -228,7 +226,6 @@ class TestWeightedScore(TestCase):
     """
     Tests the helper method: weighted_score
     """
-    shard = 4
 
     @ddt.data(
         (0, 0, 1),
@@ -270,7 +267,6 @@ class TestInternalGetGraded(TestCase):
     """
     Tests the internal helper method: _get_explicit_graded
     """
-    shard = 4
 
     def _create_block(self, explicit_graded_value):
         """
@@ -311,7 +307,6 @@ class TestInternalGetScoreFromBlock(TestCase):
     """
     Tests the internal helper method: _get_score_from_persisted_or_latest_block
     """
-    shard = 4
 
     def _create_block(self, raw_possible):
         """

--- a/lms/djangoapps/grades/tests/test_services.py
+++ b/lms/djangoapps/grades/tests/test_services.py
@@ -34,7 +34,6 @@ class GradesServiceTests(ModuleStoreTestCase):
     """
     Tests for the Grades service
     """
-    shard = 4
 
     def setUp(self):
         super(GradesServiceTests, self).setUp()

--- a/lms/djangoapps/grades/tests/test_signals.py
+++ b/lms/djangoapps/grades/tests/test_signals.py
@@ -92,7 +92,6 @@ class ScoreChangedSignalRelayTest(TestCase):
     This ensures that listeners in the LMS only have to handle one type
     of signal for all scoring events regardless of their origin.
     """
-    shard = 4
     SIGNALS = {
         'score_set': score_set,
         'score_reset': score_reset,

--- a/lms/djangoapps/grades/tests/test_subsection_grade.py
+++ b/lms/djangoapps/grades/tests/test_subsection_grade.py
@@ -11,7 +11,6 @@ from .base import GradeTestBase
 
 @ddt
 class SubsectionGradeTest(GradeTestBase):
-    shard = 4
 
     @data((50, 100, .50), (59.49, 100, .59), (59.51, 100, .60), (59.50, 100, .60), (60.5, 100, .60))
     @unpack

--- a/lms/djangoapps/grades/tests/test_subsection_grade_factory.py
+++ b/lms/djangoapps/grades/tests/test_subsection_grade_factory.py
@@ -28,7 +28,6 @@ class TestSubsectionGradeFactory(ProblemSubmissionTestMixin, GradeTestBase):
     persistent grades are functioning as expected, and that the flag to
     enable saving subsection grades blocks/enables that feature as expected.
     """
-    shard = 4
 
     def assert_grade(self, grade, expected_earned, expected_possible):
         """

--- a/lms/djangoapps/grades/tests/test_tasks.py
+++ b/lms/djangoapps/grades/tests/test_tasks.py
@@ -123,7 +123,6 @@ class RecalculateSubsectionGradeTest(HasCourseWithProblemsMixin, ModuleStoreTest
     """
     Ensures that the recalculate subsection grade task functions as expected when run.
     """
-    shard = 4
     ENABLED_SIGNALS = ['course_published', 'pre_publish']
 
     def setUp(self):
@@ -420,7 +419,6 @@ class ComputeGradesForCourseTest(HasCourseWithProblemsMixin, ModuleStoreTestCase
     """
     Test compute_grades_for_course_v2 task.
     """
-    shard = 4
 
     ENABLED_SIGNALS = ['course_published', 'pre_publish']
 

--- a/lms/djangoapps/grades/tests/test_transformer.py
+++ b/lms/djangoapps/grades/tests/test_transformer.py
@@ -26,7 +26,6 @@ class GradesTransformerTestCase(CourseStructureTestCase):
     """
     Verify behavior of the GradesTransformer
     """
-    shard = 4
 
     TRANSFORMER_CLASS_TO_TEST = GradesTransformer
 
@@ -398,7 +397,6 @@ class MultiProblemModulestoreAccessTestCase(CourseStructureTestCase, SharedModul
     """
     Test mongo usage in GradesTransformer.
     """
-    shard = 4
 
     TRANSFORMER_CLASS_TO_TEST = GradesTransformer
 

--- a/lms/djangoapps/instructor/tests/test_access.py
+++ b/lms/djangoapps/instructor/tests/test_access.py
@@ -6,7 +6,6 @@ import pytest
 
 from django_comment_common.models import FORUM_ROLE_MODERATOR, Role
 from lms.djangoapps.instructor.access import allow_access, list_with_level, revoke_access, update_forum_role
-from openedx.core.lib.tests import attr
 from openedx.core.djangoapps.ace_common.tests.mixins import EmailTemplateTagMixin
 from student.roles import CourseBetaTesterRole, CourseCcxCoachRole, CourseStaffRole
 from student.tests.factories import UserFactory
@@ -14,7 +13,6 @@ from xmodule.modulestore.tests.django_utils import SharedModuleStoreTestCase
 from xmodule.modulestore.tests.factories import CourseFactory
 
 
-@attr(shard=1)
 class TestInstructorAccessList(SharedModuleStoreTestCase):
     """ Test access listings. """
     @classmethod
@@ -40,7 +38,6 @@ class TestInstructorAccessList(SharedModuleStoreTestCase):
         self.assertEqual(set(beta_testers), set(self.beta_testers))
 
 
-@attr(shard=1)
 class TestInstructorAccessAllow(EmailTemplateTagMixin, SharedModuleStoreTestCase):
     """ Test access allow. """
     @classmethod
@@ -86,7 +83,6 @@ class TestInstructorAccessAllow(EmailTemplateTagMixin, SharedModuleStoreTestCase
             allow_access(self.course, user, 'staff')
 
 
-@attr(shard=1)
 class TestInstructorAccessRevoke(SharedModuleStoreTestCase):
     """ Test access revoke. """
     @classmethod
@@ -124,7 +120,6 @@ class TestInstructorAccessRevoke(SharedModuleStoreTestCase):
             revoke_access(self.course, user, 'robot-not-a-level')
 
 
-@attr(shard=1)
 class TestInstructorAccessForum(SharedModuleStoreTestCase):
     """
     Test forum access control.

--- a/lms/djangoapps/instructor/tests/test_api.py
+++ b/lms/djangoapps/instructor/tests/test_api.py
@@ -62,7 +62,6 @@ from lms.djangoapps.instructor_task.api_helper import (
 from openedx.core.djangoapps.course_groups.cohorts import set_course_cohorted
 from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
 from openedx.core.djangoapps.site_configuration.tests.mixins import SiteMixin
-from openedx.core.lib.tests import attr
 from openedx.core.lib.xblock_utils import grade_histogram
 from shoppingcart.models import (
     Coupon,
@@ -272,7 +271,6 @@ def view_queue_connection_error(request):  # pylint: disable=unused-argument
     raise QueueConnectionError()
 
 
-@attr(shard=5)
 @ddt.ddt
 class TestCommonExceptions400(TestCase):
     """
@@ -325,7 +323,6 @@ class TestCommonExceptions400(TestCase):
         self.assertIn('Error occured. Please try again later', resp.content)
 
 
-@attr(shard=5)
 @ddt.ddt
 class TestEndpointHttpMethods(SharedModuleStoreTestCase, LoginEnrollmentTestCase):
     """
@@ -380,7 +377,6 @@ class TestEndpointHttpMethods(SharedModuleStoreTestCase, LoginEnrollmentTestCase
         )
 
 
-@attr(shard=5)
 @patch('bulk_email.models.html_to_text', Mock(return_value='Mocking CourseEmail.text_message', autospec=True))
 class TestInstructorAPIDenyLevels(SharedModuleStoreTestCase, LoginEnrollmentTestCase):
     """
@@ -619,7 +615,6 @@ class TestInstructorAPIDenyLevels(SharedModuleStoreTestCase, LoginEnrollmentTest
             )
 
 
-@attr(shard=5)
 @patch.dict(settings.FEATURES, {'ALLOW_AUTOMATED_SIGNUPS': True})
 class TestInstructorAPIBulkAccountCreationAndEnrollment(SharedModuleStoreTestCase, LoginEnrollmentTestCase):
     """
@@ -1078,7 +1073,6 @@ class TestInstructorAPIBulkAccountCreationAndEnrollment(SharedModuleStoreTestCas
             self.assertEqual(enrollment.enrollment.mode, CourseMode.DEFAULT_SHOPPINGCART_MODE_SLUG)
 
 
-@attr(shard=5)
 @ddt.ddt
 class TestInstructorAPIEnrollment(SharedModuleStoreTestCase, LoginEnrollmentTestCase):
     """
@@ -1973,7 +1967,6 @@ class TestInstructorAPIEnrollment(SharedModuleStoreTestCase, LoginEnrollmentTest
         )
 
 
-@attr(shard=5)
 @ddt.ddt
 class TestInstructorAPIBulkBetaEnrollment(SharedModuleStoreTestCase, LoginEnrollmentTestCase):
     """
@@ -2329,7 +2322,6 @@ class TestInstructorAPIBulkBetaEnrollment(SharedModuleStoreTestCase, LoginEnroll
             ) in body
 
 
-@attr(shard=5)
 class TestInstructorAPILevelsAccess(SharedModuleStoreTestCase, LoginEnrollmentTestCase):
     """
     Test endpoints whereby instructors can change permissions
@@ -2571,7 +2563,6 @@ class TestInstructorAPILevelsAccess(SharedModuleStoreTestCase, LoginEnrollmentTe
             self.assertNotIn(rolename, user_roles)
 
 
-@attr(shard=5)
 @ddt.ddt
 @patch.dict('django.conf.settings.FEATURES', {'ENABLE_PAID_COURSE_REGISTRATION': True})
 class TestInstructorAPILevelsDataDump(SharedModuleStoreTestCase, LoginEnrollmentTestCase):
@@ -3444,7 +3435,6 @@ class TestInstructorAPILevelsDataDump(SharedModuleStoreTestCase, LoginEnrollment
         self.assertEqual(response.status_code, 400)
 
 
-@attr(shard=5)
 class TestInstructorAPIRegradeTask(SharedModuleStoreTestCase, LoginEnrollmentTestCase):
     """
     Test endpoints whereby instructors can change student grades.
@@ -3608,7 +3598,6 @@ class TestInstructorAPIRegradeTask(SharedModuleStoreTestCase, LoginEnrollmentTes
         self.assertEqual(response.status_code, 400)
 
 
-@attr(shard=5)
 @patch.dict(settings.FEATURES, {'ENTRANCE_EXAMS': True})
 @ddt.ddt
 class TestEntranceExamInstructorAPIRegradeTask(SharedModuleStoreTestCase, LoginEnrollmentTestCase):
@@ -3890,7 +3879,6 @@ class TestEntranceExamInstructorAPIRegradeTask(SharedModuleStoreTestCase, LoginE
         self.assertContains(response, message)
 
 
-@attr(shard=5)
 @patch('bulk_email.models.html_to_text', Mock(return_value='Mocking CourseEmail.text_message', autospec=True))
 class TestInstructorSendEmail(SiteMixin, SharedModuleStoreTestCase, LoginEnrollmentTestCase):
     """
@@ -4029,7 +4017,6 @@ class MockCompletionInfo(object):
         return False, 'Task Errored In Some Way'
 
 
-@attr(shard=5)
 class TestInstructorAPITaskLists(SharedModuleStoreTestCase, LoginEnrollmentTestCase):
     """
     Test instructor task list endpoint.
@@ -4199,7 +4186,6 @@ class TestInstructorAPITaskLists(SharedModuleStoreTestCase, LoginEnrollmentTestC
         self.assertEqual(actual_tasks, expected_tasks)
 
 
-@attr(shard=5)
 @patch.object(lms.djangoapps.instructor_task.api, 'get_instructor_task_history', autospec=True)
 class TestInstructorEmailContentList(SharedModuleStoreTestCase, LoginEnrollmentTestCase):
     """
@@ -4333,7 +4319,6 @@ class TestInstructorEmailContentList(SharedModuleStoreTestCase, LoginEnrollmentT
         self.assertDictEqual(expected_info, returned_info)
 
 
-@attr(shard=5)
 class TestInstructorAPIHelpers(TestCase):
     """ Test helpers for instructor.api """
 
@@ -4387,7 +4372,6 @@ def get_extended_due(course, unit, user):
         return None
 
 
-@attr(shard=5)
 class TestDueDateExtensions(SharedModuleStoreTestCase, LoginEnrollmentTestCase):
     """
     Test data dumps for reporting.
@@ -4556,7 +4540,6 @@ class TestDueDateExtensions(SharedModuleStoreTestCase, LoginEnrollmentTestCase):
                 self.user1.profile.name, self.user1.username)})
 
 
-@attr(shard=5)
 class TestDueDateExtensionsDeletedDate(ModuleStoreTestCase, LoginEnrollmentTestCase):
     """
     Tests for deleting due date extensions
@@ -4668,7 +4651,6 @@ class TestDueDateExtensionsDeletedDate(ModuleStoreTestCase, LoginEnrollmentTestC
         )
 
 
-@attr(shard=5)
 class TestCourseIssuedCertificatesData(SharedModuleStoreTestCase):
     """
     Test data dumps for issued certificates.
@@ -4779,7 +4761,6 @@ class TestCourseIssuedCertificatesData(SharedModuleStoreTestCase):
         )
 
 
-@attr(shard=5)
 @override_settings(REGISTRATION_CODE_LENGTH=8)
 class TestCourseRegistrationCodes(SharedModuleStoreTestCase):
     """
@@ -5242,7 +5223,6 @@ class TestCourseRegistrationCodes(SharedModuleStoreTestCase):
         self.assertTrue(body.startswith(EXPECTED_COUPON_CSV_HEADER))
 
 
-@attr(shard=5)
 class TestBulkCohorting(SharedModuleStoreTestCase):
     """
     Test adding users to cohorts in bulk via CSV upload.

--- a/lms/djangoapps/instructor/tests/test_api_email_localization.py
+++ b/lms/djangoapps/instructor/tests/test_api_email_localization.py
@@ -22,7 +22,6 @@ class TestInstructorAPIEnrollmentEmailLocalization(SharedModuleStoreTestCase):
     Test whether the enroll, unenroll and beta role emails are sent in the
     proper language, i.e: the student's language.
     """
-    shard = 1
 
     @classmethod
     def setUpClass(cls):

--- a/lms/djangoapps/instructor/tests/test_certificates.py
+++ b/lms/djangoapps/instructor/tests/test_certificates.py
@@ -33,13 +33,11 @@ from courseware.tests.factories import GlobalStaffFactory, InstructorFactory, Us
 from lms.djangoapps.grades.tests.utils import mock_passing_grade
 from lms.djangoapps.verify_student.services import IDVerificationService
 from lms.djangoapps.verify_student.tests.factories import SoftwareSecurePhotoVerificationFactory
-from openedx.core.lib.tests import attr
 from student.models import CourseEnrollment
 from xmodule.modulestore.tests.django_utils import SharedModuleStoreTestCase
 from xmodule.modulestore.tests.factories import CourseFactory
 
 
-@attr(shard=1)
 @ddt.ddt
 class CertificatesInstructorDashTest(SharedModuleStoreTestCase):
     """Tests for the certificate panel of the instructor dash. """
@@ -213,7 +211,6 @@ class CertificatesInstructorDashTest(SharedModuleStoreTestCase):
         self.assertContains(response, expected_html)
 
 
-@attr(shard=1)
 @override_settings(CERT_QUEUE='certificates')
 @ddt.ddt
 class CertificatesInstructorApiTest(SharedModuleStoreTestCase):
@@ -481,7 +478,6 @@ class CertificatesInstructorApiTest(SharedModuleStoreTestCase):
         self.assertEqual(res_json['message'], u'Please select certificate statuses from the list only.')
 
 
-@attr(shard=1)
 @override_settings(CERT_QUEUE='certificates')
 @ddt.ddt
 class CertificateExceptionViewInstructorApiTest(SharedModuleStoreTestCase):
@@ -768,7 +764,6 @@ class CertificateExceptionViewInstructorApiTest(SharedModuleStoreTestCase):
         )
 
 
-@attr(shard=1)
 @override_settings(CERT_QUEUE='certificates')
 @ddt.ddt
 class GenerateCertificatesInstructorApiTest(SharedModuleStoreTestCase):
@@ -886,7 +881,6 @@ class GenerateCertificatesInstructorApiTest(SharedModuleStoreTestCase):
         )
 
 
-@attr(shard=1)
 @ddt.ddt
 class TestCertificatesInstructorApiBulkWhiteListExceptions(SharedModuleStoreTestCase):
     """
@@ -1044,7 +1038,6 @@ class TestCertificatesInstructorApiBulkWhiteListExceptions(SharedModuleStoreTest
         return data
 
 
-@attr(shard=1)
 @ddt.ddt
 class CertificateInvalidationViewTests(SharedModuleStoreTestCase):
     """

--- a/lms/djangoapps/instructor/tests/test_ecommerce.py
+++ b/lms/djangoapps/instructor/tests/test_ecommerce.py
@@ -21,7 +21,6 @@ class TestECommerceDashboardViews(SiteMixin, SharedModuleStoreTestCase):
     """
     Check for E-commerce view on the new instructor dashboard
     """
-    shard = 1
 
     @classmethod
     def setUpClass(cls):

--- a/lms/djangoapps/instructor/tests/test_email.py
+++ b/lms/djangoapps/instructor/tests/test_email.py
@@ -20,7 +20,6 @@ class TestNewInstructorDashboardEmailViewMongoBacked(SharedModuleStoreTestCase):
     Check for email view on the new instructor dashboard
     for Mongo-backed courses
     """
-    shard = 1
 
     @classmethod
     def setUpClass(cls):
@@ -115,7 +114,6 @@ class TestNewInstructorDashboardEmailViewXMLBacked(SharedModuleStoreTestCase):
     """
 
     MODULESTORE = TEST_DATA_MIXED_MODULESTORE
-    shard = 1
 
     @classmethod
     def setUpClass(cls):

--- a/lms/djangoapps/instructor/tests/test_enrollment.py
+++ b/lms/djangoapps/instructor/tests/test_enrollment.py
@@ -35,7 +35,6 @@ from lms.djangoapps.instructor.enrollment import (
 )
 from openedx.core.djangoapps.ace_common.tests.mixins import EmailTemplateTagMixin
 from openedx.core.djangolib.testing.utils import CacheIsolationTestCase, get_mock_request
-from openedx.core.lib.tests import attr
 from student.models import CourseEnrollment, CourseEnrollmentAllowed, anonymous_id_for_user
 from student.roles import CourseCcxCoachRole
 from student.tests.factories import AdminFactory, UserFactory
@@ -44,7 +43,6 @@ from xmodule.modulestore.tests.django_utils import TEST_DATA_SPLIT_MODULESTORE, 
 from xmodule.modulestore.tests.factories import CourseFactory, ItemFactory
 
 
-@attr(shard=1)
 class TestSettableEnrollmentState(CacheIsolationTestCase):
     """ Test the basis class for enrollment tests. """
     def setUp(self):
@@ -108,7 +106,6 @@ class TestEnrollmentChangeBase(CacheIsolationTestCase):
         self.assertEqual(after, after_ideal)
 
 
-@attr(shard=1)
 class TestInstructorEnrollDB(TestEnrollmentChangeBase):
     """ Test instructor.enrollment.enroll_email """
     def test_enroll(self):
@@ -226,7 +223,6 @@ class TestInstructorEnrollDB(TestEnrollmentChangeBase):
         return self._run_state_change_test(before_ideal, after_ideal, action)
 
 
-@attr(shard=1)
 class TestInstructorUnenrollDB(TestEnrollmentChangeBase):
     """ Test instructor.enrollment.unenroll_email """
     def test_unenroll(self):
@@ -306,7 +302,6 @@ class TestInstructorUnenrollDB(TestEnrollmentChangeBase):
         return self._run_state_change_test(before_ideal, after_ideal, action)
 
 
-@attr(shard=1)
 class TestInstructorEnrollmentStudentModule(SharedModuleStoreTestCase):
     """ Test student module manipulations. """
     @classmethod
@@ -654,7 +649,6 @@ class SettableEnrollmentState(EmailEnrollmentState):
             return EnrollmentObjects(email, None, None, None)
 
 
-@attr(shard=1)
 class TestSendBetaRoleEmail(CacheIsolationTestCase):
     """
     Test edge cases for `send_beta_role_email`
@@ -672,7 +666,6 @@ class TestSendBetaRoleEmail(CacheIsolationTestCase):
             send_beta_role_email(bad_action, self.user, self.email_params)
 
 
-@attr(shard=1)
 class TestGetEmailParamsCCX(SharedModuleStoreTestCase):
     """
     Test what URLs the function get_email_params for CCX student enrollment.
@@ -721,7 +714,6 @@ class TestGetEmailParamsCCX(SharedModuleStoreTestCase):
         self.assertEqual(result['course_url'], self.course_url)
 
 
-@attr(shard=1)
 class TestGetEmailParams(SharedModuleStoreTestCase):
     """
     Test what URLs the function get_email_params returns under different
@@ -764,7 +756,6 @@ class TestGetEmailParams(SharedModuleStoreTestCase):
         self.assertEqual(result['course_url'], self.course_url)
 
 
-@attr(shard=1)
 @ddt.ddt
 class TestRenderMessageToString(EmailTemplateTagMixin, SharedModuleStoreTestCase):
     """

--- a/lms/djangoapps/instructor/tests/test_enrollment_store_provider.py
+++ b/lms/djangoapps/instructor/tests/test_enrollment_store_provider.py
@@ -37,7 +37,6 @@ class TestBaseNotificationDataProvider(TestCase):
     """
     Cover the EnrollmentReportProvider class
     """
-    shard = 4
 
     def test_cannot_create_instance(self):
         """

--- a/lms/djangoapps/instructor/tests/test_proctoring.py
+++ b/lms/djangoapps/instructor/tests/test_proctoring.py
@@ -25,7 +25,6 @@ class TestProctoringDashboardViews(SharedModuleStoreTestCase):
     """
     Check for Proctoring view on the new instructor dashboard
     """
-    shard = 1
 
     @classmethod
     def setUpClass(cls):

--- a/lms/djangoapps/instructor/tests/test_registration_codes.py
+++ b/lms/djangoapps/instructor/tests/test_registration_codes.py
@@ -31,7 +31,6 @@ class TestCourseRegistrationCodeStatus(SharedModuleStoreTestCase):
     """
     Test registration code status.
     """
-    shard = 1
 
     @classmethod
     def setUpClass(cls):

--- a/lms/djangoapps/instructor/tests/test_services.py
+++ b/lms/djangoapps/instructor/tests/test_services.py
@@ -20,7 +20,6 @@ class InstructorServiceTests(SharedModuleStoreTestCase):
     """
     Tests for the InstructorService
     """
-    shard = 1
 
     @classmethod
     def setUpClass(cls):

--- a/lms/djangoapps/instructor/tests/test_spoc_gradebook.py
+++ b/lms/djangoapps/instructor/tests/test_spoc_gradebook.py
@@ -8,7 +8,6 @@ from six import text_type
 from capa.tests.response_xml_factory import StringResponseXMLFactory
 from courseware.tests.factories import StudentModuleFactory
 from lms.djangoapps.grades.tasks import compute_all_grades_for_course
-from openedx.core.lib.tests import attr
 from student.tests.factories import AdminFactory, CourseEnrollmentFactory, UserFactory
 from xmodule.modulestore.tests.django_utils import SharedModuleStoreTestCase
 from xmodule.modulestore.tests.factories import CourseFactory, ItemFactory
@@ -16,7 +15,6 @@ from xmodule.modulestore.tests.factories import CourseFactory, ItemFactory
 USER_COUNT = 11
 
 
-@attr(shard=1)
 class TestGradebook(SharedModuleStoreTestCase):
     """
     Test functionality of the spoc gradebook. Sets up a course with assignments and
@@ -85,7 +83,6 @@ class TestGradebook(SharedModuleStoreTestCase):
         self.assertEquals(self.response.status_code, 200)
 
 
-@attr(shard=1)
 class TestDefaultGradingPolicy(TestGradebook):
     """
     Tests that the grading policy is properly applied for all users in the course
@@ -111,7 +108,6 @@ class TestDefaultGradingPolicy(TestGradebook):
         self.assertEquals(293, self.response.content.count('grade_None'))
 
 
-@attr(shard=1)
 class TestLetterCutoffPolicy(TestGradebook):
     """
     Tests advanced grading policy (with letter grade cutoffs). Includes tests of

--- a/lms/djangoapps/instructor/tests/test_tools.py
+++ b/lms/djangoapps/instructor/tests/test_tools.py
@@ -18,7 +18,6 @@ from six import text_type
 
 from lms.djangoapps.courseware.field_overrides import OverrideFieldData
 from lms.djangoapps.ccx.tests.test_overrides import inject_field_overrides
-from openedx.core.lib.tests import attr
 from student.tests.factories import UserFactory
 from xmodule.fields import Date
 from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase, SharedModuleStoreTestCase
@@ -29,7 +28,6 @@ from ..views import tools
 DATE_FIELD = Date()
 
 
-@attr(shard=1)
 class TestDashboardError(unittest.TestCase):
     """
     Test DashboardError exceptions.
@@ -40,7 +38,6 @@ class TestDashboardError(unittest.TestCase):
         self.assertEqual(response, {'error': 'Oh noes!'})
 
 
-@attr(shard=1)
 class TestHandleDashboardError(unittest.TestCase):
     """
     Test handle_dashboard_error decorator.
@@ -69,7 +66,6 @@ class TestHandleDashboardError(unittest.TestCase):
         self.assertEqual(view(None, None), "Oh yes!")
 
 
-@attr(shard=1)
 class TestRequireStudentIdentifier(TestCase):
     """
     Test require_student_from_identifier()
@@ -92,7 +88,6 @@ class TestRequireStudentIdentifier(TestCase):
             tools.require_student_from_identifier("invalid")
 
 
-@attr(shard=1)
 class TestParseDatetime(unittest.TestCase):
     """
     Test date parsing.
@@ -107,7 +102,6 @@ class TestParseDatetime(unittest.TestCase):
             tools.parse_datetime('foo')
 
 
-@attr(shard=1)
 class TestFindUnit(SharedModuleStoreTestCase):
     """
     Test the find_unit function.
@@ -137,7 +131,6 @@ class TestFindUnit(SharedModuleStoreTestCase):
             tools.find_unit(self.course, url)
 
 
-@attr(shard=1)
 class TestGetUnitsWithDueDate(ModuleStoreTestCase):
     """
     Test the get_units_with_due_date function.
@@ -175,7 +168,6 @@ class TestGetUnitsWithDueDate(ModuleStoreTestCase):
             urls((self.week1, self.week2)))
 
 
-@attr(shard=1)
 class TestTitleOrUrl(unittest.TestCase):
     """
     Test the title_or_url funciton.
@@ -199,7 +191,6 @@ class TestTitleOrUrl(unittest.TestCase):
         self.assertEquals(tools.title_or_url(unit), u'test:hello')
 
 
-@attr(shard=1)
 @override_settings(
     FIELD_OVERRIDE_PROVIDERS=(
         'lms.djangoapps.courseware.student_field_overrides.IndividualStudentOverrideProvider',),
@@ -279,7 +270,6 @@ class TestSetDueDateExtension(ModuleStoreTestCase):
         self.assertEqual(self.week1.due, self.due)
 
 
-@attr(shard=1)
 class TestDataDumps(ModuleStoreTestCase):
     """
     Test data dumps for reporting.
@@ -361,7 +351,6 @@ def msk_from_problem_urlname(course_id, urlname, block_type='problem'):
     return course_id.make_usage_key(block_type, urlname)
 
 
-@attr(shard=1)
 class TestStudentFromIdentifier(TestCase):
     """
     Test get_student_from_identifier()

--- a/lms/djangoapps/instructor/tests/views/test_instructor_dashboard.py
+++ b/lms/djangoapps/instructor/tests/views/test_instructor_dashboard.py
@@ -52,7 +52,6 @@ class TestInstructorDashboard(ModuleStoreTestCase, LoginEnrollmentTestCase, XssT
     """
     Tests for the instructor dashboard (not legacy).
     """
-    shard = 3
 
     def setUp(self):
         """

--- a/lms/djangoapps/instructor_analytics/tests/test_basic.py
+++ b/lms/djangoapps/instructor_analytics/tests/test_basic.py
@@ -51,7 +51,6 @@ from xmodule.modulestore.tests.factories import CourseFactory
 
 class TestAnalyticsBasic(ModuleStoreTestCase):
     """ Test basic analytics functions. """
-    shard = 3
 
     def setUp(self):
         super(TestAnalyticsBasic, self).setUp()

--- a/lms/djangoapps/instructor_analytics/tests/test_csvs.py
+++ b/lms/djangoapps/instructor_analytics/tests/test_csvs.py
@@ -8,7 +8,6 @@ from instructor_analytics.csvs import create_csv_response, format_dictlist, form
 
 class TestAnalyticsCSVS(TestCase):
     """ Test analytics rendering of csv files."""
-    shard = 4
 
     def test_create_csv_response_nodata(self):
         header = ['Name', 'Email']
@@ -40,7 +39,6 @@ class TestAnalyticsCSVS(TestCase):
 
 class TestAnalyticsFormatDictlist(TestCase):
     """ Test format_dictlist method """
-    shard = 4
 
     def test_format_dictlist(self):
         dictlist = [
@@ -85,7 +83,6 @@ class TestAnalyticsFormatDictlist(TestCase):
 
 class TestAnalyticsFormatInstances(TestCase):
     """ test format_instances method """
-    shard = 4
 
     class TestDataClass(object):
         """ Test class to generate objects for format_instances """

--- a/lms/djangoapps/instructor_analytics/tests/test_distributions.py
+++ b/lms/djangoapps/instructor_analytics/tests/test_distributions.py
@@ -12,7 +12,6 @@ from student.tests.factories import UserFactory
 
 class TestAnalyticsDistributions(TestCase):
     '''Test analytics distribution gathering.'''
-    shard = 4
 
     def setUp(self):
         super(TestAnalyticsDistributions, self).setUp()
@@ -76,7 +75,6 @@ class TestAnalyticsDistributions(TestCase):
 
 class TestAnalyticsDistributionsNoData(TestCase):
     '''Test analytics distribution gathering.'''
-    shard = 4
 
     def setUp(self):
         super(TestAnalyticsDistributionsNoData, self).setUp()

--- a/lms/djangoapps/instructor_task/management/commands/tests/test_fail_old_tasks.py
+++ b/lms/djangoapps/instructor_task/management/commands/tests/test_fail_old_tasks.py
@@ -16,7 +16,6 @@ class TestFailOldQueueingTasksCommand(InstructorTaskTestCase):
     """
     Tests for the `fail_old_tasks` management command
     """
-    shard = 4
 
     def setUp(self):
         super(TestFailOldQueueingTasksCommand, self).setUp()

--- a/lms/djangoapps/instructor_task/tests/test_api.py
+++ b/lms/djangoapps/instructor_task/tests/test_api.py
@@ -91,7 +91,6 @@ class InstructorTaskReportTest(InstructorTaskTestCase):
 @ddt.ddt
 class InstructorTaskModuleSubmitTest(InstructorTaskModuleTestCase):
     """Tests API methods that involve the submission of module-based background tasks."""
-    shard = 3
 
     def setUp(self):
         super(InstructorTaskModuleSubmitTest, self).setUp()
@@ -213,7 +212,6 @@ class InstructorTaskModuleSubmitTest(InstructorTaskModuleTestCase):
 @patch('bulk_email.models.html_to_text', Mock(return_value='Mocking CourseEmail.text_message', autospec=True))
 class InstructorTaskCourseSubmitTest(TestReportMixin, InstructorTaskCourseTestCase):
     """Tests API methods that involve the submission of course-based background tasks."""
-    shard = 3
 
     def setUp(self):
         super(InstructorTaskCourseSubmitTest, self).setUp()

--- a/lms/djangoapps/instructor_task/tests/test_base.py
+++ b/lms/djangoapps/instructor_task/tests/test_base.py
@@ -303,7 +303,6 @@ class TestReportMixin(object):
     """
     Cleans up after tests that place files in the reports directory.
     """
-    shard = 4
 
     def setUp(self):
 

--- a/lms/djangoapps/instructor_task/tests/test_integration.py
+++ b/lms/djangoapps/instructor_task/tests/test_integration.py
@@ -72,7 +72,6 @@ class TestRescoringTask(TestIntegrationTask):
 
     Exercises real problems with a minimum of patching.
     """
-    shard = 3
 
     def setUp(self):
         super(TestRescoringTask, self).setUp()

--- a/lms/djangoapps/instructor_task/tests/test_models.py
+++ b/lms/djangoapps/instructor_task/tests/test_models.py
@@ -20,7 +20,6 @@ class ReportStoreTestMixin(object):
     """
     Mixin for report store tests.
     """
-    shard = 4
 
     def setUp(self):
         super(ReportStoreTestMixin, self).setUp()
@@ -121,7 +120,6 @@ class TestS3ReportStorage(MockS3Mixin, TestCase):
     Test the S3ReportStorage to make sure that configuration overrides from settings.FINANCIAL_REPORTS
     are used instead of default ones.
     """
-    shard = 4
 
     def test_financial_report_overrides(self):
         """

--- a/lms/djangoapps/instructor_task/tests/test_subtasks.py
+++ b/lms/djangoapps/instructor_task/tests/test_subtasks.py
@@ -13,7 +13,6 @@ from student.models import CourseEnrollment
 
 class TestSubtasks(InstructorTaskCourseTestCase):
     """Tests for subtasks."""
-    shard = 4
 
     def setUp(self):
         super(TestSubtasks, self).setUp()

--- a/lms/djangoapps/instructor_task/tests/test_tasks.py
+++ b/lms/djangoapps/instructor_task/tests/test_tasks.py
@@ -31,7 +31,6 @@ from lms.djangoapps.instructor_task.tasks import (
 from lms.djangoapps.instructor_task.tasks_helper.misc import upload_ora2_data
 from lms.djangoapps.instructor_task.tests.factories import InstructorTaskFactory
 from lms.djangoapps.instructor_task.tests.test_base import InstructorTaskModuleTestCase
-from openedx.core.lib.tests import attr
 from xmodule.modulestore.exceptions import ItemNotFoundError
 
 PROBLEM_URL_NAME = "test_urlname"
@@ -374,7 +373,6 @@ class TestOverrideScoreInstructorTask(TestInstructorTasks):
         )
 
 
-@attr(shard=3)
 @ddt.ddt
 class TestRescoreInstructorTask(TestInstructorTasks):
     """Tests problem-rescoring instructor task."""
@@ -490,7 +488,6 @@ class TestRescoreInstructorTask(TestInstructorTasks):
         )
 
 
-@attr(shard=3)
 class TestResetAttemptsInstructorTask(TestInstructorTasks):
     """Tests instructor task that resets problem attempts."""
 
@@ -589,7 +586,6 @@ class TestResetAttemptsInstructorTask(TestInstructorTasks):
         self._test_reset_with_student(True)
 
 
-@attr(shard=3)
 class TestDeleteStateInstructorTask(TestInstructorTasks):
     """Tests instructor task that deletes problem state."""
 

--- a/lms/djangoapps/instructor_task/tests/test_tasks_helper.py
+++ b/lms/djangoapps/instructor_task/tests/test_tasks_helper.py
@@ -1007,7 +1007,6 @@ class TestProblemReportSplitTestContent(TestReportMixin, TestConditionalContent,
     """
     Test the problem report on a course that has split tests.
     """
-    shard = 3
     OPTION_1 = 'Option 1'
     OPTION_2 = 'Option 2'
 
@@ -2131,7 +2130,6 @@ class TestCertificateGeneration(InstructorTaskModuleTestCase):
     """
     Test certificate generation task works.
     """
-    shard = 3
 
     ENABLED_CACHES = ['default', 'mongo_metadata_inheritance', 'loc_cache']
 

--- a/lms/djangoapps/instructor_task/tests/test_views.py
+++ b/lms/djangoapps/instructor_task/tests/test_views.py
@@ -21,7 +21,6 @@ class InstructorTaskReportTest(InstructorTaskTestCase):
     """
     Tests view methods that involve the reporting of status for background tasks.
     """
-    shard = 4
 
     def _get_instructor_task_status(self, task_id):
         """Returns status corresponding to task_id via api method."""

--- a/lms/djangoapps/learner_dashboard/tests/test_programs.py
+++ b/lms/djangoapps/learner_dashboard/tests/test_programs.py
@@ -48,7 +48,6 @@ def load_serialized_data(response, key):
 @mock.patch(PROGRAMS_UTILS_MODULE + '.get_programs')
 class TestProgramListing(ProgramsApiConfigMixin, SharedModuleStoreTestCase):
     """Unit tests for the program listing page."""
-    shard = 4
     maxDiff = None
     password = 'test'
     url = reverse_lazy('program_listing_view')
@@ -185,7 +184,6 @@ class TestProgramListing(ProgramsApiConfigMixin, SharedModuleStoreTestCase):
 @mock.patch(PROGRAMS_UTILS_MODULE + '.get_programs')
 class TestProgramDetails(ProgramsApiConfigMixin, CatalogIntegrationMixin, SharedModuleStoreTestCase):
     """Unit tests for the program details page."""
-    shard = 4
     program_uuid = str(uuid4())
     password = 'test'
     url = reverse_lazy('program_details_view', kwargs={'program_uuid': program_uuid})

--- a/lms/djangoapps/learner_dashboard/tests/test_utils.py
+++ b/lms/djangoapps/learner_dashboard/tests/test_utils.py
@@ -13,7 +13,6 @@ class TestUtils(TestCase):
     """
     The test case class covering the all the utils functions
     """
-    shard = 4
 
     @ddt.data('path1/', '/path1/path2/', '/', '')
     def test_strip_course_id(self, path):

--- a/lms/djangoapps/lms_xblock/test/test_runtime.py
+++ b/lms/djangoapps/lms_xblock/test/test_runtime.py
@@ -52,7 +52,6 @@ class BlockMock(Mock):
 
 class TestHandlerUrl(TestCase):
     """Test the LMS handler_url"""
-    shard = 4
 
     def setUp(self):
         super(TestHandlerUrl, self).setUp()
@@ -118,7 +117,6 @@ class TestHandlerUrl(TestCase):
 
 class TestUserServiceAPI(TestCase):
     """Test the user service interface"""
-    shard = 4
 
     def setUp(self):
         super(TestUserServiceAPI, self).setUp()
@@ -169,7 +167,6 @@ class TestUserServiceAPI(TestCase):
 @ddt
 class TestBadgingService(ModuleStoreTestCase):
     """Test the badging service interface"""
-    shard = 4
 
     def setUp(self):
         super(TestBadgingService, self).setUp()
@@ -235,7 +232,6 @@ class TestBadgingService(ModuleStoreTestCase):
 
 class TestI18nService(ModuleStoreTestCase):
     """ Test ModuleI18nService """
-    shard = 4
 
     def setUp(self):
         """ Setting up tests """

--- a/lms/djangoapps/lti_provider/management/commands/tests/test_resend_lti_scores.py
+++ b/lms/djangoapps/lti_provider/management/commands/tests/test_resend_lti_scores.py
@@ -19,7 +19,6 @@ class CommandArgsTestCase(TestCase):
     """
     Test management command parses arguments properly.
     """
-    shard = 4
 
     def _get_arg_parser(self):
         """
@@ -46,7 +45,6 @@ class CommandExecutionTestCase(SharedModuleStoreTestCase):
     """
     Test `manage.py resend_lti_scores` command.
     """
-    shard = 4
 
     @classmethod
     def setUpClass(cls):

--- a/lms/djangoapps/lti_provider/tests/test_outcomes.py
+++ b/lms/djangoapps/lti_provider/tests/test_outcomes.py
@@ -18,7 +18,6 @@ class StoreOutcomeParametersTest(TestCase):
     """
     Tests for the store_outcome_parameters method in outcomes.py
     """
-    shard = 4
 
     def setUp(self):
         super(StoreOutcomeParametersTest, self).setUp()
@@ -133,7 +132,6 @@ class SignAndSendReplaceResultTest(TestCase):
     """
     Tests for the sign_and_send_replace_result method in outcomes.py
     """
-    shard = 4
 
     def setUp(self):
         super(SignAndSendReplaceResultTest, self).setUp()
@@ -185,7 +183,6 @@ class XmlHandlingTest(TestCase):
     Tests for the generate_replace_result_xml and check_replace_result_response
     methods in outcomes.py
     """
-    shard = 4
 
     response_xml = """
         <imsx_POXEnvelopeResponse xmlns = "http://www.imsglobal.org/services/ltiv1p1/xsd/imsoms_v1p0">
@@ -298,7 +295,6 @@ class TestAssignmentsForProblem(ModuleStoreTestCase):
     """
     Test cases for the assignments_for_problem method in outcomes.py
     """
-    shard = 4
 
     def setUp(self):
         super(TestAssignmentsForProblem, self).setUp()

--- a/lms/djangoapps/lti_provider/tests/test_signature_validator.py
+++ b/lms/djangoapps/lti_provider/tests/test_signature_validator.py
@@ -27,7 +27,6 @@ class ClientKeyValidatorTest(TestCase):
     """
     Tests for the check_client_key method in the SignatureValidator class.
     """
-    shard = 4
 
     def setUp(self):
         super(ClientKeyValidatorTest, self).setUp()
@@ -58,7 +57,6 @@ class NonceValidatorTest(TestCase):
     """
     Tests for the check_nonce method in the SignatureValidator class.
     """
-    shard = 4
 
     def setUp(self):
         super(NonceValidatorTest, self).setUp()
@@ -90,7 +88,6 @@ class SignatureValidatorTest(TestCase):
     to check message signatures. Note that these tests mock out the library
     itself, since we assume it to be correct.
     """
-    shard = 4
 
     def setUp(self):
         super(SignatureValidatorTest, self).setUp()

--- a/lms/djangoapps/lti_provider/tests/test_tasks.py
+++ b/lms/djangoapps/lti_provider/tests/test_tasks.py
@@ -71,7 +71,6 @@ class SendLeafOutcomeTest(BaseOutcomeTest):
     """
     Tests for the send_leaf_outcome method in tasks.py
     """
-    shard = 4
 
     @ddt.data(
         (2.0, 2.0, 1.0),
@@ -93,7 +92,6 @@ class SendCompositeOutcomeTest(BaseOutcomeTest):
     """
     Tests for the send_composite_outcome method in tasks.py
     """
-    shard = 4
 
     def setUp(self):
         super(SendCompositeOutcomeTest, self).setUp()

--- a/lms/djangoapps/lti_provider/tests/test_users.py
+++ b/lms/djangoapps/lti_provider/tests/test_users.py
@@ -19,7 +19,6 @@ class UserManagementHelperTest(TestCase):
     """
     Tests for the helper functions in users.py
     """
-    shard = 4
 
     def setUp(self):
         super(UserManagementHelperTest, self).setUp()
@@ -78,7 +77,6 @@ class AuthenticateLtiUserTest(TestCase):
     """
     Tests for the authenticate_lti_user function in users.py
     """
-    shard = 4
 
     def setUp(self):
         super(AuthenticateLtiUserTest, self).setUp()
@@ -146,7 +144,6 @@ class CreateLtiUserTest(TestCase):
     """
     Tests for the create_lti_user function in users.py
     """
-    shard = 4
 
     def setUp(self):
         super(CreateLtiUserTest, self).setUp()
@@ -184,7 +181,6 @@ class LtiBackendTest(TestCase):
     """
     Tests for the authentication backend that authenticates LTI users.
     """
-    shard = 4
 
     def setUp(self):
         super(LtiBackendTest, self).setUp()

--- a/lms/djangoapps/lti_provider/tests/test_views.py
+++ b/lms/djangoapps/lti_provider/tests/test_views.py
@@ -186,7 +186,6 @@ class LtiLaunchTestRender(LtiTestMixin, RenderXBlockTestMixin, ModuleStoreTestCa
     the tests defined in RenderXBlockTestMixin.
     """
     SUCCESS_ENROLLED_STAFF_MONGO_COUNT = 9
-    shard = 3
 
     def get_response(self, usage_key, url_encoded_params=None):
         """

--- a/lms/djangoapps/mobile_api/course_info/tests.py
+++ b/lms/djangoapps/mobile_api/course_info/tests.py
@@ -21,7 +21,6 @@ class TestUpdates(MobileAPITestCase, MobileAuthTestMixin, MobileCourseAccessTest
     Tests for /api/mobile/{api_version}/course_info/{course_id}/updates
     """
     REVERSE_INFO = {'name': 'course-updates-list', 'params': ['course_id', 'api_version']}
-    shard = 3
 
     def verify_success(self, response):
         super(TestUpdates, self).verify_success(response)
@@ -95,7 +94,6 @@ class TestHandouts(MobileAPITestCase, MobileAuthTestMixin, MobileCourseAccessTes
     Tests for /api/mobile/{api_version}/course_info/{course_id}/handouts
     """
     REVERSE_INFO = {'name': 'course-handouts-list', 'params': ['course_id', 'api_version']}
-    shard = 3
 
     @ddt.data(
         (ModuleStoreEnum.Type.mongo, API_V05),

--- a/lms/djangoapps/mobile_api/tests/test_context_processor.py
+++ b/lms/djangoapps/mobile_api/tests/test_context_processor.py
@@ -12,7 +12,6 @@ class MobileContextProcessorTests(TestCase):
     """
     Tests for the configuration context processor.
     """
-    shard = 4
 
     def test_is_from_mobile_app(self):
         """

--- a/lms/djangoapps/mobile_api/tests/test_decorator.py
+++ b/lms/djangoapps/mobile_api/tests/test_decorator.py
@@ -14,7 +14,6 @@ class TestMobileAPIDecorators(TestCase):
     """
     Basic tests for mobile api decorators to ensure they retain the docstrings.
     """
-    shard = 4
 
     @ddt.data(mobile_view, mobile_course_access)
     def test_function_decorator(self, decorator):

--- a/lms/djangoapps/mobile_api/tests/test_middleware.py
+++ b/lms/djangoapps/mobile_api/tests/test_middleware.py
@@ -19,7 +19,6 @@ class TestAppVersionUpgradeMiddleware(CacheIsolationTestCase):
     """
     Tests for version based app upgrade middleware
     """
-    shard = 4
 
     ENABLED_CACHES = ['default']
 

--- a/lms/djangoapps/mobile_api/tests/test_milestones.py
+++ b/lms/djangoapps/mobile_api/tests/test_milestones.py
@@ -21,7 +21,6 @@ class MobileAPIMilestonesMixin(object):
     the mobile api will appropriately block content until the milestone is
     fulfilled.
     """
-    shard = 4
 
     ALLOW_ACCESS_TO_MILESTONE_COURSE = False
 

--- a/lms/djangoapps/mobile_api/tests/test_mobile_platform.py
+++ b/lms/djangoapps/mobile_api/tests/test_mobile_platform.py
@@ -12,7 +12,6 @@ class TestMobilePlatform(TestCase):
     """
     Tests for platform against mobile app request
     """
-    shard = 4
 
     @ddt.data(
         ("edX/org.edx.mobile (0.1.5; OS Version 9.2 (Build 13C75))", "iOS", "0.1.5"),

--- a/lms/djangoapps/mobile_api/tests/test_model.py
+++ b/lms/djangoapps/mobile_api/tests/test_model.py
@@ -15,7 +15,6 @@ class TestAppVersionConfigModel(TestCase):
     """
     Tests for app version configuration model
     """
-    shard = 4
 
     def set_app_version_config(self):
         """ Creates configuration data for platform versions """
@@ -90,7 +89,6 @@ class TestMobileApiConfig(TestCase):
     """
     Tests MobileAPIConfig
     """
-    shard = 4
 
     def test_video_profile_list(self):
         """Check that video_profiles config is returned in order as a list"""

--- a/lms/djangoapps/mobile_api/users/tests.py
+++ b/lms/djangoapps/mobile_api/users/tests.py
@@ -27,7 +27,6 @@ from mobile_api.testutils import (
 )
 from mobile_api.utils import API_V05, API_V1
 from openedx.core.lib.courses import course_image_url
-from openedx.core.lib.tests import attr
 from openedx.core.djangoapps.schedules.tests.factories import ScheduleFactory
 from openedx.features.course_duration_limits.models import CourseDurationLimitConfig
 from openedx.features.course_experience.tests.views.helpers import add_course_mode
@@ -42,7 +41,6 @@ from .. import errors
 from .serializers import CourseEnrollmentSerializer, CourseEnrollmentSerializerv05
 
 
-@attr(shard=9)
 @ddt.ddt
 class TestUserDetailApi(MobileAPITestCase, MobileAuthUserTestMixin):
     """
@@ -59,7 +57,6 @@ class TestUserDetailApi(MobileAPITestCase, MobileAuthUserTestMixin):
         self.assertEqual(response.data['email'], self.user.email)
 
 
-@attr(shard=9)
 @ddt.ddt
 class TestUserInfoApi(MobileAPITestCase, MobileAuthTestMixin):
     """
@@ -76,7 +73,6 @@ class TestUserInfoApi(MobileAPITestCase, MobileAuthTestMixin):
         self.assertIn(self.username, response['location'])
 
 
-@attr(shard=9)
 @ddt.ddt
 @override_settings(MKTG_URLS={'ROOT': 'dummy-root'})
 class TestUserEnrollmentApi(UrlResetMixin, MobileAPITestCase, MobileAuthUserTestMixin,
@@ -321,7 +317,6 @@ class TestUserEnrollmentApi(UrlResetMixin, MobileAPITestCase, MobileAuthUserTest
         self._assert_enrollment_results(api_version, courses, num_courses_returned, False)
 
 
-@attr(shard=9)
 @override_settings(MKTG_URLS={'ROOT': 'dummy-root'})
 class TestUserEnrollmentCertificates(UrlResetMixin, MobileAPITestCase, MilestonesTestCaseMixin):
     """
@@ -397,7 +392,6 @@ class TestUserEnrollmentCertificates(UrlResetMixin, MobileAPITestCase, Milestone
         )
 
 
-@attr(shard=9)
 class CourseStatusAPITestCase(MobileAPITestCase):
     """
     Base test class for /api/mobile/{api_version}/users/<user_name>/course_status_info/{course_id}
@@ -432,7 +426,6 @@ class CourseStatusAPITestCase(MobileAPITestCase):
         )
 
 
-@attr(shard=9)
 class TestCourseStatusGET(CourseStatusAPITestCase, MobileAuthUserTestMixin,
                           MobileCourseAccessTestMixin, MilestonesTestCaseMixin):
     """
@@ -452,7 +445,6 @@ class TestCourseStatusGET(CourseStatusAPITestCase, MobileAuthUserTestMixin,
         )
 
 
-@attr(shard=9)
 class TestCourseStatusPATCH(CourseStatusAPITestCase, MobileAuthUserTestMixin,
                             MobileCourseAccessTestMixin, MilestonesTestCaseMixin):
     """
@@ -556,7 +548,6 @@ class TestCourseStatusPATCH(CourseStatusAPITestCase, MobileAuthUserTestMixin,
         )
 
 
-@attr(shard=9)
 @ddt.ddt
 @patch.dict(settings.FEATURES, {'ENABLE_MKTG_SITE': True})
 @override_settings(MKTG_URLS={'ROOT': 'dummy-root'})

--- a/lms/djangoapps/mobile_api/video_outlines/tests.py
+++ b/lms/djangoapps/mobile_api/video_outlines/tests.py
@@ -25,7 +25,6 @@ from mobile_api.utils import API_V05, API_V1
 from openedx.core.djangoapps.course_groups.cohorts import add_user_to_cohort, remove_user_from_cohort
 from openedx.core.djangoapps.course_groups.models import CourseUserGroupPartitionGroup
 from openedx.core.djangoapps.course_groups.tests.helpers import CohortFactory
-from openedx.core.lib.tests import attr
 from xmodule.modulestore.django import modulestore
 from xmodule.modulestore.tests.factories import ItemFactory
 from xmodule.partitions.partitions import Group, UserPartition
@@ -208,7 +207,6 @@ class TestVideoAPIMixin(object):
         return sub_block_a, sub_block_b
 
 
-@attr(shard=9)
 @ddt.ddt
 class TestNonStandardCourseStructure(MobileAPITestCase, TestVideoAPIMixin, MilestonesTestCaseMixin):
     """
@@ -425,7 +423,6 @@ class TestNonStandardCourseStructure(MobileAPITestCase, TestVideoAPIMixin, Miles
         )
 
 
-@attr(shard=9)
 @ddt.ddt
 class TestVideoSummaryList(TestVideoAPITestCase, MobileAuthTestMixin, MobileCourseAccessTestMixin,
                            TestVideoAPIMixin, MilestonesTestCaseMixin):
@@ -978,7 +975,6 @@ class TestVideoSummaryList(TestVideoAPITestCase, MobileAuthTestMixin, MobileCour
         self.assertItemsEqual(course_outline[0]['summary']['transcripts'].keys(), expected_transcripts)
 
 
-@attr(shard=9)
 @ddt.ddt
 class TestTranscriptsDetail(TestVideoAPITestCase, MobileAuthTestMixin, MobileCourseAccessTestMixin,
                             TestVideoAPIMixin, MilestonesTestCaseMixin):

--- a/lms/djangoapps/oauth2_handler/tests.py
+++ b/lms/djangoapps/oauth2_handler/tests.py
@@ -15,7 +15,6 @@ from xmodule.modulestore.tests.factories import CourseFactory, check_mongo_calls
 
 
 class BaseTestMixin(ModuleStoreTestCase):
-    shard = 6
     profile = None
     ENABLED_SIGNALS = ['course_published']
 
@@ -32,7 +31,6 @@ class BaseTestMixin(ModuleStoreTestCase):
 
 
 class IDTokenTest(BaseTestMixin, IDTokenTestCase):
-    shard = 6
 
     def setUp(self):
         super(IDTokenTest, self).setUp()
@@ -147,7 +145,6 @@ class IDTokenTest(BaseTestMixin, IDTokenTestCase):
 
 
 class UserInfoTest(BaseTestMixin, UserInfoTestCase):
-    shard = 6
 
     def setUp(self):
         super(UserInfoTest, self).setUp()

--- a/lms/djangoapps/rss_proxy/tests/test_models.py
+++ b/lms/djangoapps/rss_proxy/tests/test_models.py
@@ -8,7 +8,6 @@ from rss_proxy.models import WhitelistedRssUrl
 
 class WhitelistedRssUrlTests(TestCase):
     """ Tests for the rss_proxy.WhitelistedRssUrl model """
-    shard = 4
 
     def setUp(self):
         super(WhitelistedRssUrlTests, self).setUp()

--- a/lms/djangoapps/rss_proxy/tests/test_views.py
+++ b/lms/djangoapps/rss_proxy/tests/test_views.py
@@ -11,7 +11,6 @@ from rss_proxy.models import WhitelistedRssUrl
 
 class RssProxyViewTests(TestCase):
     """ Tests for the rss_proxy views """
-    shard = 4
 
     def setUp(self):
         super(RssProxyViewTests, self).setUp()

--- a/lms/djangoapps/shoppingcart/management/tests/test_retire_order.py
+++ b/lms/djangoapps/shoppingcart/management/tests/test_retire_order.py
@@ -13,7 +13,6 @@ from xmodule.modulestore.tests.factories import CourseFactory
 
 class TestRetireOrder(ModuleStoreTestCase):
     """Test the retire_order command"""
-    shard = 4
 
     def setUp(self):
         super(TestRetireOrder, self).setUp()

--- a/lms/djangoapps/shoppingcart/processors/tests/test_CyberSource2.py
+++ b/lms/djangoapps/shoppingcart/processors/tests/test_CyberSource2.py
@@ -34,7 +34,6 @@ class CyberSource2Test(TestCase):
     to be configured a certain way.
 
     """
-    shard = 4
 
     COST = "10.00"
     CALLBACK_URL = "/test_callback_url"

--- a/lms/djangoapps/shoppingcart/tests/test_configuration_overrides.py
+++ b/lms/djangoapps/shoppingcart/tests/test_configuration_overrides.py
@@ -18,7 +18,6 @@ class TestOrderHistoryOnSiteDashboard(SiteMixin, ModuleStoreTestCase):
     """
     Test for dashboard order history site configuration overrides.
     """
-    shard = 4
 
     def setUp(self):
         super(TestOrderHistoryOnSiteDashboard, self).setUp()

--- a/lms/djangoapps/shoppingcart/tests/test_context_processor.py
+++ b/lms/djangoapps/shoppingcart/tests/test_context_processor.py
@@ -17,7 +17,6 @@ class UserCartContextProcessorUnitTest(ModuleStoreTestCase):
     """
     Unit test for shoppingcart context_processor
     """
-    shard = 4
 
     def setUp(self):
         super(UserCartContextProcessorUnitTest, self).setUp()

--- a/lms/djangoapps/shoppingcart/tests/test_models.py
+++ b/lms/djangoapps/shoppingcart/tests/test_models.py
@@ -61,7 +61,6 @@ class OrderTest(ModuleStoreTestCase):
     Test shopping cart orders (e.g., cart contains various items,
     order is taken through various pieces of cart state, etc.)
     """
-    shard = 3
 
     def setUp(self):
         super(OrderTest, self).setUp()
@@ -493,7 +492,6 @@ class PaidCourseRegistrationTest(ModuleStoreTestCase):
     """
     Paid Course Registration Tests.
     """
-    shard = 3
 
     def setUp(self):
         super(PaidCourseRegistrationTest, self).setUp()

--- a/lms/djangoapps/shoppingcart/tests/test_payment_fake.py
+++ b/lms/djangoapps/shoppingcart/tests/test_payment_fake.py
@@ -16,7 +16,6 @@ class PaymentFakeViewTest(TestCase):
     Test that the fake payment view interacts
     correctly with the shopping cart.
     """
-    shard = 4
 
     def setUp(self):
         super(PaymentFakeViewTest, self).setUp()

--- a/lms/djangoapps/shoppingcart/tests/test_pdf.py
+++ b/lms/djangoapps/shoppingcart/tests/test_pdf.py
@@ -40,7 +40,6 @@ class TestPdfFile(unittest.TestCase):
     """
     Unit test cases for pdf file generation
     """
-    shard = 4
 
     def setUp(self):
         super(TestPdfFile, self).setUp()

--- a/lms/djangoapps/shoppingcart/tests/test_reports.py
+++ b/lms/djangoapps/shoppingcart/tests/test_reports.py
@@ -31,7 +31,6 @@ class ReportTypeTests(ModuleStoreTestCase):
     """
     Tests for the models used to generate certificate status reports
     """
-    shard = 4
     FIVE_MINS = datetime.timedelta(minutes=5)
 
     @patch('student.models.CourseEnrollment.refund_cutoff_date')
@@ -165,7 +164,6 @@ class ItemizedPurchaseReportTest(ModuleStoreTestCase):
     """
     Tests for the models used to generate itemized purchase reports
     """
-    shard = 4
     FIVE_MINS = datetime.timedelta(minutes=5)
     TEST_ANNOTATION = u'Ba\xfc\u5305'
 

--- a/lms/djangoapps/shoppingcart/tests/test_views.py
+++ b/lms/djangoapps/shoppingcart/tests/test_views.py
@@ -75,7 +75,6 @@ class ShoppingCartViewsTests(SharedModuleStoreTestCase, XssTestMixin):
     """
     Test shopping cart view under various states
     """
-    shard = 3
 
     @classmethod
     def setUpClass(cls):

--- a/lms/djangoapps/static_template_view/tests/test_views.py
+++ b/lms/djangoapps/static_template_view/tests/test_views.py
@@ -10,7 +10,6 @@ from openedx.core.djangoapps.site_configuration.tests.test_util import with_site
 
 class MarketingSiteViewTests(TestCase):
     """ Tests for the marketing site views """
-    shard = 4
 
     def _test_view(self, view_name, mimetype):
         """

--- a/lms/djangoapps/support/tests/test_refund.py
+++ b/lms/djangoapps/support/tests/test_refund.py
@@ -26,7 +26,6 @@ class RefundTests(ModuleStoreTestCase):
     """
     Tests for the manual refund page
     """
-    shard = 4
 
     def setUp(self):
         super(RefundTests, self).setUp()

--- a/lms/djangoapps/support/tests/test_views.py
+++ b/lms/djangoapps/support/tests/test_views.py
@@ -93,7 +93,6 @@ class SupportViewAccessTests(SupportViewTestCase):
     """
     Tests for access control of support views.
     """
-    shard = 3
 
     @ddt.data(*(
         (url_name, role, has_access)

--- a/lms/djangoapps/survey/tests/test_models.py
+++ b/lms/djangoapps/survey/tests/test_models.py
@@ -19,7 +19,6 @@ class SurveyModelsTests(TestCase):
     """
     All tests for the Survey models.py file
     """
-    shard = 4
 
     def setUp(self):
         """

--- a/lms/djangoapps/survey/tests/test_signals.py
+++ b/lms/djangoapps/survey/tests/test_signals.py
@@ -15,7 +15,6 @@ class SurveyRetireSignalTests(ModuleStoreTestCase):
     """
     Test the _listen_for_lms_retire signal
     """
-    shard = 4
 
     def test_success_answers_exist(self):
         """

--- a/lms/djangoapps/survey/tests/test_utils.py
+++ b/lms/djangoapps/survey/tests/test_utils.py
@@ -17,7 +17,6 @@ class SurveyModelsTests(ModuleStoreTestCase):
     """
     All tests for the utils.py file
     """
-    shard = 4
 
     def setUp(self):
         """

--- a/lms/djangoapps/survey/tests/test_views.py
+++ b/lms/djangoapps/survey/tests/test_views.py
@@ -18,7 +18,6 @@ class SurveyViewsTests(ModuleStoreTestCase):
     """
     All tests for the views.py file
     """
-    shard = 4
 
     def setUp(self):
         """

--- a/lms/djangoapps/teams/management/commands/tests/test_reindex_course_team.py
+++ b/lms/djangoapps/teams/management/commands/tests/test_reindex_course_team.py
@@ -21,7 +21,6 @@ class ReindexCourseTeamTest(SharedModuleStoreTestCase):
     """
     Tests for the ReindexCourseTeam command
     """
-    shard = 4
 
     def setUp(self):
         """

--- a/lms/djangoapps/teams/tests/test_models.py
+++ b/lms/djangoapps/teams/tests/test_models.py
@@ -34,7 +34,6 @@ COURSE_KEY2 = CourseKey.from_string('edx/history/2')
 @ddt.ddt
 class TeamMembershipTest(SharedModuleStoreTestCase):
     """Tests for the TeamMembership model."""
-    shard = 4
 
     def setUp(self):
         """
@@ -117,7 +116,6 @@ class TeamMembershipTest(SharedModuleStoreTestCase):
 @ddt.ddt
 class TeamSignalsTest(EventTestMixin, SharedModuleStoreTestCase):
     """Tests for handling of team-related signals."""
-    shard = 4
 
     SIGNALS = {
         'thread_created': thread_created,

--- a/lms/djangoapps/teams/tests/test_serializers.py
+++ b/lms/djangoapps/teams/tests/test_serializers.py
@@ -33,7 +33,6 @@ class MembershipSerializerTestCase(SerializerTestCase):
     """
     Tests for the membership serializer.
     """
-    shard = 4
 
     def setUp(self):
         super(MembershipSerializerTestCase, self).setUp()
@@ -72,7 +71,6 @@ class TopicSerializerTestCase(SerializerTestCase):
     Tests for the `TopicSerializer`, which should serialize team count data for
     a single topic.
     """
-    shard = 4
 
     def test_topic_with_no_team_count(self):
         """
@@ -122,7 +120,6 @@ class BaseTopicSerializerTestCase(SerializerTestCase):
     """
     Base class for testing the two paginated topic serializers.
     """
-    shard = 4
 
     __test__ = False
     PAGE_SIZE = 5
@@ -179,7 +176,6 @@ class BulkTeamCountTopicSerializerTestCase(BaseTopicSerializerTestCase):
     Tests for the `BulkTeamCountTopicSerializer`, which should serialize team_count
     data for many topics with constant time SQL queries.
     """
-    shard = 4
     __test__ = True
     serializer = BulkTeamCountTopicSerializer
 

--- a/lms/djangoapps/teams/tests/test_views.py
+++ b/lms/djangoapps/teams/tests/test_views.py
@@ -33,7 +33,6 @@ from .factories import LAST_ACTIVITY_AT, CourseTeamFactory
 
 class TestDashboard(SharedModuleStoreTestCase):
     """Tests for the Teams dashboard."""
-    shard = 6
     test_password = "test"
 
     NUM_TOPICS = 10
@@ -196,7 +195,6 @@ class TestDashboard(SharedModuleStoreTestCase):
 class TeamAPITestCase(APITestCase, SharedModuleStoreTestCase):
     """Base class for Team API test cases."""
 
-    shard = 6
     test_password = 'password'
 
     @classmethod
@@ -544,7 +542,6 @@ class TeamAPITestCase(APITestCase, SharedModuleStoreTestCase):
 @ddt.ddt
 class TestListTeamsAPI(EventTestMixin, TeamAPITestCase):
     """Test cases for the team listing API endpoint."""
-    shard = 6
 
     def setUp(self):  # pylint: disable=arguments-differ
         super(TestListTeamsAPI, self).setUp('lms.djangoapps.teams.utils.tracker')
@@ -723,7 +720,6 @@ class TestListTeamsAPI(EventTestMixin, TeamAPITestCase):
 @ddt.ddt
 class TestCreateTeamAPI(EventTestMixin, TeamAPITestCase):
     """Test cases for the team creation endpoint."""
-    shard = 6
 
     def setUp(self):  # pylint: disable=arguments-differ
         super(TestCreateTeamAPI, self).setUp('lms.djangoapps.teams.utils.tracker')
@@ -896,7 +892,6 @@ class TestCreateTeamAPI(EventTestMixin, TeamAPITestCase):
 @ddt.ddt
 class TestDetailTeamAPI(TeamAPITestCase):
     """Test cases for the team detail endpoint."""
-    shard = 6
 
     @ddt.data(
         (None, 401),
@@ -936,7 +931,6 @@ class TestDetailTeamAPI(TeamAPITestCase):
 @ddt.ddt
 class TestDeleteTeamAPI(EventTestMixin, TeamAPITestCase):
     """Test cases for the team delete endpoint."""
-    shard = 6
 
     def setUp(self):  # pylint: disable=arguments-differ
         super(TestDeleteTeamAPI, self).setUp('lms.djangoapps.teams.utils.tracker')
@@ -987,7 +981,6 @@ class TestDeleteTeamAPI(EventTestMixin, TeamAPITestCase):
 @ddt.ddt
 class TestUpdateTeamAPI(EventTestMixin, TeamAPITestCase):
     """Test cases for the team update endpoint."""
-    shard = 6
 
     def setUp(self):  # pylint: disable=arguments-differ
         super(TestUpdateTeamAPI, self).setUp('lms.djangoapps.teams.utils.tracker')
@@ -1064,7 +1057,6 @@ class TestUpdateTeamAPI(EventTestMixin, TeamAPITestCase):
 @ddt.ddt
 class TestListTopicsAPI(TeamAPITestCase):
     """Test cases for the topic listing endpoint."""
-    shard = 6
 
     @ddt.data(
         (None, 401),
@@ -1184,7 +1176,6 @@ class TestListTopicsAPI(TeamAPITestCase):
 @ddt.ddt
 class TestDetailTopicAPI(TeamAPITestCase):
     """Test cases for the topic detail endpoint."""
-    shard = 6
 
     @ddt.data(
         (None, 401),
@@ -1223,7 +1214,6 @@ class TestDetailTopicAPI(TeamAPITestCase):
 @ddt.ddt
 class TestListMembershipAPI(TeamAPITestCase):
     """Test cases for the membership list endpoint."""
-    shard = 6
 
     @ddt.data(
         (None, 401),
@@ -1323,7 +1313,6 @@ class TestListMembershipAPI(TeamAPITestCase):
 @ddt.ddt
 class TestCreateMembershipAPI(EventTestMixin, TeamAPITestCase):
     """Test cases for the membership creation endpoint."""
-    shard = 6
 
     def setUp(self):  # pylint: disable=arguments-differ
         super(TestCreateMembershipAPI, self).setUp('lms.djangoapps.teams.utils.tracker')
@@ -1422,7 +1411,6 @@ class TestCreateMembershipAPI(EventTestMixin, TeamAPITestCase):
 @ddt.ddt
 class TestDetailMembershipAPI(TeamAPITestCase):
     """Test cases for the membership detail endpoint."""
-    shard = 6
 
     @ddt.data(
         (None, 401),
@@ -1489,7 +1477,6 @@ class TestDetailMembershipAPI(TeamAPITestCase):
 @ddt.ddt
 class TestDeleteMembershipAPI(EventTestMixin, TeamAPITestCase):
     """Test cases for the membership deletion endpoint."""
-    shard = 6
 
     def setUp(self):  # pylint: disable=arguments-differ
         super(TestDeleteMembershipAPI, self).setUp('lms.djangoapps.teams.utils.tracker')
@@ -1550,7 +1537,6 @@ class TestDeleteMembershipAPI(EventTestMixin, TeamAPITestCase):
 
 class TestElasticSearchErrors(TeamAPITestCase):
     """Test that the Team API is robust to Elasticsearch connection errors."""
-    shard = 6
 
     ES_ERROR = ConnectionError('N/A', 'connection error', {})
 

--- a/lms/djangoapps/tests/test_utils.py
+++ b/lms/djangoapps/tests/test_utils.py
@@ -11,7 +11,6 @@ from opaque_keys.edx.keys import CourseKey, UsageKey
 
 @ddt.ddt
 class UtilsTests(TestCase):
-    shard = 4
 
     @ddt.data(
         ['edX/DemoX/Demo_Course', CourseKey.from_string('edX/DemoX/Demo_Course'), CourseKey],

--- a/lms/djangoapps/verify_student/management/commands/tests/test_verify_student.py
+++ b/lms/djangoapps/verify_student/management/commands/tests/test_verify_student.py
@@ -26,7 +26,6 @@ class TestVerifyStudentCommand(MockS3Mixin, TestCase):
     """
     Tests for django admin commands in the verify_student module
     """
-    shard = 4
 
     def setUp(self):
         super(TestVerifyStudentCommand, self).setUp()

--- a/lms/djangoapps/verify_student/tests/test_fake_software_secure.py
+++ b/lms/djangoapps/verify_student/tests/test_fake_software_secure.py
@@ -32,7 +32,6 @@ class SoftwareSecureFakeViewDisabledTest(SoftwareSecureFakeViewTest):
     Test the fake software secure response when feature flag
     'ENABLE_SOFTWARE_SECURE_FAKE' is not enabled.
     """
-    shard = 4
 
     def setUp(self):
         super(SoftwareSecureFakeViewDisabledTest, self).setUp(enable_software_secure_fake=False)
@@ -54,7 +53,6 @@ class SoftwareSecureFakeViewEnabledTest(SoftwareSecureFakeViewTest):
     Test the fake software secure response when feature flag
     'ENABLE_SOFTWARE_SECURE_FAKE' is enabled.
     """
-    shard = 4
 
     def setUp(self):
         super(SoftwareSecureFakeViewEnabledTest, self).setUp(enable_software_secure_fake=True)

--- a/lms/djangoapps/verify_student/tests/test_integration.py
+++ b/lms/djangoapps/verify_student/tests/test_integration.py
@@ -15,7 +15,6 @@ class TestProfEdVerification(ModuleStoreTestCase):
     """
     Integration test for professional ed verification, including course mode selection.
     """
-    shard = 4
 
     # Choose an uncommon number for the price so we can search for it on the page
     MIN_PRICE = 1438

--- a/lms/djangoapps/verify_student/tests/test_models.py
+++ b/lms/djangoapps/verify_student/tests/test_models.py
@@ -122,7 +122,6 @@ class TestVerification(TestCase):
 @patch('lms.djangoapps.verify_student.models.requests.post', new=mock_software_secure_post)
 @ddt.ddt
 class TestPhotoVerification(TestVerification, MockS3Mixin, ModuleStoreTestCase):
-    shard = 4
 
     def setUp(self):
         super(TestPhotoVerification, self).setUp()
@@ -394,7 +393,6 @@ class VerificationDeadlineTest(CacheIsolationTestCase):
     """
     Tests for the VerificationDeadline model.
     """
-    shard = 4
 
     ENABLED_CACHES = ['default']
 

--- a/lms/djangoapps/verify_student/tests/test_services.py
+++ b/lms/djangoapps/verify_student/tests/test_services.py
@@ -25,7 +25,6 @@ class TestIDVerificationService(MockS3Mixin, ModuleStoreTestCase):
     """
     Tests for IDVerificationService.
     """
-    shard = 4
 
     def test_user_is_verified(self):
         """

--- a/lms/djangoapps/verify_student/tests/test_signals.py
+++ b/lms/djangoapps/verify_student/tests/test_signals.py
@@ -19,7 +19,6 @@ class VerificationDeadlineSignalTest(ModuleStoreTestCase):
     """
     Tests for the VerificationDeadline signal
     """
-    shard = 4
 
     def setUp(self):
         super(VerificationDeadlineSignalTest, self).setUp()
@@ -57,7 +56,6 @@ class RetirementSignalTest(ModuleStoreTestCase):
     """
     Tests for the VerificationDeadline signal
     """
-    shard = 4
 
     def _create_entry(self):
         """

--- a/lms/djangoapps/verify_student/tests/test_utils.py
+++ b/lms/djangoapps/verify_student/tests/test_utils.py
@@ -27,7 +27,6 @@ class TestVerifyStudentUtils(unittest.TestCase):
     """
     Tests for utility functions in verify_student.
     """
-    shard = 4
 
     def test_verification_for_datetime(self):
         user = UserFactory.create()

--- a/lms/djangoapps/verify_student/tests/test_views.py
+++ b/lms/djangoapps/verify_student/tests/test_views.py
@@ -43,7 +43,6 @@ from lms.djangoapps.verify_student.views import (
 from openedx.core.djangoapps.embargo.test_utils import restrict_course
 from openedx.core.djangoapps.theming.tests.test_util import with_comprehensive_theme
 from openedx.core.djangoapps.user_api.accounts.api import get_account_settings
-from openedx.core.lib.tests import attr
 from shoppingcart.models import CertificateItem, Order
 from student.models import CourseEnrollment
 from student.tests.factories import CourseEnrollmentFactory, UserFactory
@@ -62,7 +61,6 @@ render_mock = Mock(side_effect=mock_render_to_response)
 PAYMENT_DATA_KEYS = {'payment_processor_name', 'payment_page_url', 'payment_form_data'}
 
 
-@attr(shard=2)
 class StartView(TestCase):
     """
     This view is for the first time student is
@@ -83,7 +81,6 @@ class StartView(TestCase):
         self.assertHttpForbidden(self.client.get(self.start_url()))
 
 
-@attr(shard=2)
 @ddt.ddt
 class TestPayAndVerifyView(UrlResetMixin, ModuleStoreTestCase, XssTestMixin):
     """
@@ -1105,7 +1102,6 @@ class TestPayAndVerifyView(UrlResetMixin, ModuleStoreTestCase, XssTestMixin):
         self.assertNotEqual(httpretty.last_request().headers, {})
 
 
-@attr(shard=2)
 class CheckoutTestMixin(object):
     """
     Mixin implementing test methods that should behave identically regardless
@@ -1231,7 +1227,6 @@ class CheckoutTestMixin(object):
         self.assertEqual(data, {'foo': 'bar'})
 
 
-@attr(shard=2)
 @patch('lms.djangoapps.verify_student.views.checkout_with_shoppingcart', return_value=TEST_PAYMENT_DATA, autospec=True)
 class TestCreateOrderShoppingCart(CheckoutTestMixin, ModuleStoreTestCase):
     """ Test view behavior when the shoppingcart is used. """
@@ -1245,7 +1240,6 @@ class TestCreateOrderShoppingCart(CheckoutTestMixin, ModuleStoreTestCase):
         return dict(zip(('request', 'user', 'course_key', 'course_mode', 'amount'), patched_create_order.call_args[0]))
 
 
-@attr(shard=2)
 @override_settings(ECOMMERCE_API_URL=TEST_API_URL)
 @patch(
     'lms.djangoapps.verify_student.views.checkout_with_ecommerce_service',
@@ -1264,7 +1258,6 @@ class TestCreateOrderEcommerceService(CheckoutTestMixin, ModuleStoreTestCase):
         return dict(zip(('user', 'course_key', 'course_mode', 'processor'), patched_create_order.call_args[0]))
 
 
-@attr(shard=2)
 class TestCheckoutWithEcommerceService(ModuleStoreTestCase):
     """
     Ensures correct behavior in the function `checkout_with_ecommerce_service`.
@@ -1310,7 +1303,6 @@ class TestCheckoutWithEcommerceService(ModuleStoreTestCase):
         self.assertEqual(actual_payment_data, expected_payment_data)
 
 
-@attr(shard=2)
 class TestCreateOrderView(ModuleStoreTestCase):
     """
     Tests for the create_order view of verified course enrollment process.
@@ -1414,7 +1406,6 @@ class TestCreateOrderView(ModuleStoreTestCase):
         return response
 
 
-@attr(shard=2)
 @ddt.ddt
 @patch.dict(settings.FEATURES, {'AUTOMATIC_VERIFY_STUDENT_IDENTITY_FOR_TESTING': True})
 class TestSubmitPhotosForVerification(TestCase):
@@ -1659,7 +1650,6 @@ class TestSubmitPhotosForVerification(TestCase):
         return json.loads(last_request.body)
 
 
-@attr(shard=2)
 class TestPhotoVerificationResultsCallback(ModuleStoreTestCase):
     """
     Tests for the results_callback view.
@@ -1874,7 +1864,6 @@ class TestPhotoVerificationResultsCallback(ModuleStoreTestCase):
         self.assertIn('Result Unknown not understood', response.content)
 
 
-@attr(shard=2)
 class TestReverifyView(TestCase):
     """
     Tests for the reverification view.

--- a/lms/lib/courseware_search/test/test_lms_filter_generator.py
+++ b/lms/lib/courseware_search/test/test_lms_filter_generator.py
@@ -12,7 +12,6 @@ from xmodule.modulestore.tests.factories import CourseFactory, ItemFactory
 
 class LmsSearchFilterGeneratorTestCase(ModuleStoreTestCase):
     """ Tests for search result processor """
-    shard = 5
 
     def build_courses(self):
         """

--- a/lms/lib/courseware_search/test/test_lms_result_processor.py
+++ b/lms/lib/courseware_search/test/test_lms_result_processor.py
@@ -9,7 +9,6 @@ from xmodule.modulestore.tests.factories import CourseFactory, ItemFactory
 
 class LmsSearchResultProcessorTestCase(ModuleStoreTestCase):
     """ Test case class to test search result processor """
-    shard = 5
 
     def build_course(self):
         """

--- a/lms/lib/tests/test_utils.py
+++ b/lms/lib/tests/test_utils.py
@@ -11,7 +11,6 @@ class LmsUtilsTest(ModuleStoreTestCase):
     """
     Tests for the LMS utility functions
     """
-    shard = 4
 
     def setUp(self):
         """

--- a/lms/lib/xblock/test/test_mixin.py
+++ b/lms/lib/xblock/test/test_mixin.py
@@ -10,7 +10,6 @@ from lms_xblock.mixin import (
     INVALID_USER_PARTITION_VALIDATION_UNIT,
     NONSENSICAL_ACCESS_RESTRICTION
 )
-from openedx.core.lib.tests import attr
 from xblock.validation import ValidationMessage
 from xmodule.modulestore import ModuleStoreEnum
 from xmodule.modulestore.tests.factories import CourseFactory, ToyCourseFactory, ItemFactory
@@ -64,7 +63,6 @@ class LmsXBlockMixinTestCase(ModuleStoreTestCase):
         self.store.update_item(block, 1)
 
 
-@attr(shard=5)
 class XBlockValidationTest(LmsXBlockMixinTestCase):
     """
     Unit tests for XBlock validation
@@ -274,7 +272,6 @@ class XBlockValidationTest(LmsXBlockMixinTestCase):
         )
 
 
-@attr(shard=5)
 class OpenAssessmentBlockMixinTestCase(ModuleStoreTestCase):
     """
     Tests for OpenAssessmentBlock mixin.
@@ -297,7 +294,6 @@ class OpenAssessmentBlockMixinTestCase(ModuleStoreTestCase):
         self.assertTrue(self.open_assessment.has_score)
 
 
-@attr(shard=5)
 @ddt.ddt
 class XBlockGetParentTest(LmsXBlockMixinTestCase):
     """
@@ -390,7 +386,6 @@ def ddt_named(parent, child):
     return args
 
 
-@attr(shard=5)
 @ddt.ddt
 class XBlockMergedGroupAccessTest(LmsXBlockMixinTestCase):
     """

--- a/lms/tests.py
+++ b/lms/tests.py
@@ -22,7 +22,6 @@ class LmsModuleTests(TestCase):
     """
     Tests for lms module itself.
     """
-    shard = 5
 
     def test_new_mimetypes(self):
         extensions = ['eot', 'otf', 'ttf', 'woff']
@@ -43,7 +42,6 @@ class TemplateLookupTests(TestCase):
     """
     Tests for TemplateLookup.
     """
-    shard = 5
 
     def test_add_lookup_to_main(self):
         """Test that any template directories added are not cleared when microsites are enabled."""
@@ -61,7 +59,6 @@ class TemplateLookupTests(TestCase):
 @patch.dict('django.conf.settings.FEATURES', {'ENABLE_FEEDBACK_SUBMISSION': True})
 class HelpModalTests(ModuleStoreTestCase):
     """Tests for the help modal"""
-    shard = 5
 
     def setUp(self):
         super(HelpModalTests, self).setUp()


### PR DESCRIPTION
No longer needed, as we're dynamically sharding tests via pytest-xdist.

The following test reports confirm we aren't removing any tests by doing this work:

Python test results from this PR: https://build.testeng.edx.org/job/edx-platform-python-pipeline-pr/2451/testReport/
Python test results from latest merge to master: https://build.testeng.edx.org/view/edx-platform-pipeline-master-tests/job/edx-platform-python-pipeline-master/85/testReport/