### PR TITLE
Translate connect header to spanish

### DIFF
--- a/themes/edx.org/lms/templates/footer.html
+++ b/themes/edx.org/lms/templates/footer.html
@@ -75,7 +75,7 @@
                  <div class="col-xl-4 col-lg-4 col-md-4 col-sm-12 col-xs-12 column-2-1 third-div-border column-styles">
                       <div class="row full-height">
                         <div class="col-lg-12 col-md-12 col-sm-10 full-height column-2-2 column-styles">
-                              <h2 class="heading">Connect</h2>
+                              <h2 class="heading">${_(u"Connect")}</h2>
                               <ul class="list-unstyled clear-margins  ">
                                 % for link in footer["connect_links"]:
                                 <li>


### PR DESCRIPTION
Support team suggests translation of one of the footer title
to spanish.In this PR, hooks are added around that title so
that it can be translated.