### PR TITLE
Remove pytest shards from cms

### DIFF
--- a/cms/djangoapps/contentstore/tests/test_contentstore.py
+++ b/cms/djangoapps/contentstore/tests/test_contentstore.py
@@ -92,7 +92,6 @@ class ImportRequiredTestCases(ContentStoreTestCase):
     """
     Tests which legitimately need to import a course
     """
-    shard = 1
 
     def test_no_static_link_rewrites_on_import(self):
         course_items = import_course_from_xml(
@@ -611,7 +610,6 @@ class MiscCourseTests(ContentStoreTestCase):
     """
     Tests that rely on the toy courses.
     """
-    shard = 1
 
     def setUp(self):
         super(MiscCourseTests, self).setUp()
@@ -1160,7 +1158,6 @@ class ContentStoreTest(ContentStoreTestCase):
     """
     Tests for the CMS ContentStore application.
     """
-    shard = 1
     duplicate_course_error = ("There is already a course defined with the same organization and course number. "
                               "Please change either organization or course number to be unique.")
 
@@ -1809,7 +1806,6 @@ class ContentStoreTest(ContentStoreTestCase):
 
 class MetadataSaveTestCase(ContentStoreTestCase):
     """Test that metadata is correctly cached and decached."""
-    shard = 1
 
     def setUp(self):
         super(MetadataSaveTestCase, self).setUp()
@@ -1871,7 +1867,6 @@ class RerunCourseTest(ContentStoreTestCase):
     """
     Tests for Rerunning a course via the view handler
     """
-    shard = 1
 
     def setUp(self):
         super(RerunCourseTest, self).setUp()
@@ -2139,7 +2134,6 @@ class ContentLicenseTest(ContentStoreTestCase):
     """
     Tests around content licenses
     """
-    shard = 1
 
     def test_course_license_export(self):
         content_store = contentstore()
@@ -2179,7 +2173,6 @@ class EntryPageTestCase(TestCase):
     """
     Tests entry pages that aren't specific to a course.
     """
-    shard = 1
 
     def setUp(self):
         super(EntryPageTestCase, self).setUp()
@@ -2215,7 +2208,6 @@ class SigninPageTestCase(TestCase):
     important to make sure that the script is functional independently of any
     other script.
     """
-    shard = 1
 
     def test_csrf_token_is_present_in_form(self):
         # Expected html:

--- a/cms/djangoapps/contentstore/tests/test_course_settings.py
+++ b/cms/djangoapps/contentstore/tests/test_course_settings.py
@@ -46,7 +46,6 @@ class CourseSettingsEncoderTest(CourseTestCase):
     """
     Tests for CourseSettingsEncoder.
     """
-    shard = 1
 
     def test_encoder(self):
         details = CourseDetails.fetch(self.course.id)
@@ -94,7 +93,6 @@ class CourseDetailsViewTest(CourseTestCase, MilestonesTestCaseMixin):
     """
     Tests for modifying content on the first course settings page (course dates, overview, etc.).
     """
-    shard = 1
 
     def alter_field(self, url, details, field, val):
         """
@@ -448,7 +446,6 @@ class CourseGradingTest(CourseTestCase):
     """
     Tests for the course settings grading page.
     """
-    shard = 1
 
     def test_initial_grader(self):
         test_grader = CourseGradingModel(self.course)
@@ -792,7 +789,6 @@ class CourseMetadataEditingTest(CourseTestCase):
     """
     Tests for CourseMetadata.
     """
-    shard = 1
 
     def setUp(self):
         super(CourseMetadataEditingTest, self).setUp()
@@ -1392,7 +1388,6 @@ class CourseGraderUpdatesTest(CourseTestCase):
     """
     Test getting, deleting, adding, & updating graders
     """
-    shard = 1
 
     def setUp(self):
         """Compute the url to use in tests"""
@@ -1459,7 +1454,6 @@ class CourseEnrollmentEndFieldTest(CourseTestCase):
     Base class to test the enrollment end fields in the course settings details view in Studio
     when using marketing site flag and global vs non-global staff to access the page.
     """
-    shard = 1
 
     NOT_EDITABLE_HELPER_MESSAGE = "Contact your edX partner manager to update these settings."
     NOT_EDITABLE_DATE_WRAPPER = "<div class=\"field date is-not-editable\" id=\"field-enrollment-end-date\">"

--- a/cms/djangoapps/contentstore/tests/test_courseware_index.py
+++ b/cms/djangoapps/contentstore/tests/test_courseware_index.py
@@ -186,7 +186,6 @@ class MixedWithOptionsTestCase(MixedSplitTestCase):
 @ddt.ddt
 class TestCoursewareSearchIndexer(MixedWithOptionsTestCase):
     """ Tests the operation of the CoursewareSearchIndexer """
-    shard = 1
 
     WORKS_WITH_STORES = (ModuleStoreEnum.Type.mongo, ModuleStoreEnum.Type.split)
 
@@ -607,7 +606,6 @@ class TestCoursewareSearchIndexer(MixedWithOptionsTestCase):
 @ddt.ddt
 class TestLargeCourseDeletions(MixedWithOptionsTestCase):
     """ Tests to excerise deleting items from a course """
-    shard = 1
 
     WORKS_WITH_STORES = (ModuleStoreEnum.Type.mongo, ModuleStoreEnum.Type.split)
 
@@ -691,7 +689,6 @@ class TestTaskExecution(SharedModuleStoreTestCase):
     being present, which allows us to ensure that when the listener is
     executed, it is done as expected.
     """
-    shard = 1
 
     @classmethod
     def setUpClass(cls):
@@ -786,7 +783,6 @@ class TestTaskExecution(SharedModuleStoreTestCase):
 @ddt.ddt
 class TestLibrarySearchIndexer(MixedWithOptionsTestCase):
     """ Tests the operation of the CoursewareSearchIndexer """
-    shard = 1
 
     # libraries work only with split, so do library indexer
     WORKS_WITH_STORES = (ModuleStoreEnum.Type.split, )
@@ -960,7 +956,6 @@ class GroupConfigurationSearchMongo(CourseTestCase, MixedWithOptionsTestCase):
     """
     Tests indexing of content groups on course modules using mongo modulestore.
     """
-    shard = 1
 
     MODULESTORE = TEST_DATA_MONGO_MODULESTORE
     INDEX_NAME = CoursewareSearchIndexer.INDEX_NAME

--- a/cms/djangoapps/contentstore/tests/test_libraries.py
+++ b/cms/djangoapps/contentstore/tests/test_libraries.py
@@ -35,7 +35,6 @@ class LibraryTestCase(ModuleStoreTestCase):
     """
     Common functionality for content libraries tests
     """
-    shard = 1
 
     def setUp(self):
         super(LibraryTestCase, self).setUp()
@@ -149,7 +148,6 @@ class TestLibraries(LibraryTestCase):
     """
     High-level tests for libraries
     """
-    shard = 1
 
     @ddt.data(
         (2, 1, 1),
@@ -483,7 +481,6 @@ class TestLibraryAccess(LibraryTestCase):
     """
     Test Roles and Permissions related to Content Libraries
     """
-    shard = 1
 
     def setUp(self):
         """ Create a library, staff user, and non-staff user """
@@ -818,7 +815,6 @@ class TestOverrides(LibraryTestCase):
     """
     Test that overriding block Scope.settings fields from a library in a specific course works
     """
-    shard = 1
 
     def setUp(self):
         super(TestOverrides, self).setUp()
@@ -1004,7 +1000,6 @@ class TestIncompatibleModuleStore(LibraryTestCase):
     """
     Tests for proper validation errors with an incompatible course modulestore.
     """
-    shard = 1
 
     def setUp(self):
         super(TestIncompatibleModuleStore, self).setUp()

--- a/cms/djangoapps/contentstore/views/tests/test_certificates.py
+++ b/cms/djangoapps/contentstore/views/tests/test_certificates.py
@@ -106,7 +106,6 @@ class CertificatesBaseTestCase(object):
     """
     Mixin with base test cases for the certificates.
     """
-    shard = 1
 
     def _remove_ids(self, content):
         """
@@ -200,7 +199,6 @@ class CertificatesListHandlerTestCase(
     """
     Test cases for certificates_list_handler.
     """
-    shard = 1
 
     def setUp(self):
         """
@@ -428,8 +426,6 @@ class CertificatesDetailHandlerTestCase(
     """
     Test cases for CertificatesDetailHandlerTestCase.
     """
-    shard = 1
-
     _id = 0
 
     def setUp(self):  # pylint: disable=arguments-differ

--- a/cms/djangoapps/contentstore/views/tests/test_course_index.py
+++ b/cms/djangoapps/contentstore/views/tests/test_course_index.py
@@ -42,7 +42,6 @@ class TestCourseIndex(CourseTestCase):
     """
     Unit tests for getting the list of courses and the course outline.
     """
-    shard = 1
 
     def setUp(self):
         """
@@ -317,8 +316,6 @@ class TestCourseIndexArchived(CourseTestCase):
     """
     Unit tests for testing the course index list when there are archived courses.
     """
-    shard = 1
-
     NOW = datetime.datetime.now(pytz.utc)
     DAY = datetime.timedelta(days=1)
     YESTERDAY = NOW - DAY
@@ -432,7 +429,6 @@ class TestCourseOutline(CourseTestCase):
     """
     Unit tests for the course outline.
     """
-    shard = 1
     ENABLED_SIGNALS = ['course_published']
 
     def setUp(self):
@@ -608,7 +604,6 @@ class TestCourseReIndex(CourseTestCase):
     """
     Unit tests for the course outline.
     """
-    shard = 1
     SUCCESSFUL_RESPONSE = _("Course has been successfully reindexed.")
 
     ENABLED_SIGNALS = ['course_published']

--- a/cms/djangoapps/contentstore/views/tests/test_group_configurations.py
+++ b/cms/djangoapps/contentstore/views/tests/test_group_configurations.py
@@ -171,7 +171,6 @@ class GroupConfigurationsBaseTestCase(object):
     """
     Mixin with base test cases for the group configurations.
     """
-    shard = 1
 
     def _remove_ids(self, content):
         """
@@ -246,7 +245,6 @@ class GroupConfigurationsListHandlerTestCase(CourseTestCase, GroupConfigurations
     """
     Test cases for group_configurations_list_handler.
     """
-    shard = 1
 
     def _url(self):
         """
@@ -353,8 +351,6 @@ class GroupConfigurationsDetailHandlerTestCase(CourseTestCase, GroupConfiguratio
     """
     Test cases for group_configurations_detail_handler.
     """
-
-    shard = 1
     ID = 0
 
     def _url(self, cid=-1):
@@ -693,7 +689,6 @@ class GroupConfigurationsUsageInfoTestCase(CourseTestCase, HelperMethods):
     """
     Tests for usage information of configurations and content groups.
     """
-    shard = 1
 
     def _get_user_partition(self, scheme):
         """
@@ -1169,7 +1164,6 @@ class GroupConfigurationsValidationTestCase(CourseTestCase, HelperMethods):
     """
     Tests for validation in Group Configurations.
     """
-    shard = 1
 
     @patch('xmodule.split_test_module.SplitTestDescriptor.validate_split_test')
     def verify_validation_add_usage_info(self, expected_result, mocked_message, mocked_validation_messages):

--- a/cms/djangoapps/contentstore/views/tests/test_item.py
+++ b/cms/djangoapps/contentstore/views/tests/test_item.py
@@ -127,7 +127,6 @@ class ItemTest(CourseTestCase):
 @ddt.ddt
 class GetItemTest(ItemTest):
     """Tests for '/xblock' GET url."""
-    shard = 1
 
     def _get_preview(self, usage_key, data=None):
         """ Makes a request to xblock preview handler """
@@ -472,7 +471,6 @@ class GetItemTest(ItemTest):
 @ddt.ddt
 class DeleteItem(ItemTest):
     """Tests for '/xblock' DELETE url."""
-    shard = 1
 
     @ddt.data(ModuleStoreEnum.Type.mongo, ModuleStoreEnum.Type.split)
     def test_delete_static_page(self, store):
@@ -490,7 +488,6 @@ class TestCreateItem(ItemTest):
     """
     Test the create_item handler thoroughly
     """
-    shard = 1
 
     def test_create_nicely(self):
         """
@@ -667,7 +664,6 @@ class TestDuplicateItem(ItemTest, DuplicateHelper):
     """
     Test the duplicate method.
     """
-    shard = 1
 
     def setUp(self):
         """ Creates the test course structure and a few components to 'duplicate'. """
@@ -775,7 +771,6 @@ class TestMoveItem(ItemTest):
     """
     Tests for move item.
     """
-    shard = 1
 
     def setUp(self):
         """
@@ -1328,7 +1323,6 @@ class TestDuplicateItemWithAsides(ItemTest, DuplicateHelper):
     """
     Test the duplicate method for blocks with asides.
     """
-    shard = 1
 
     MODULESTORE = TEST_DATA_SPLIT_MODULESTORE
 
@@ -1392,7 +1386,6 @@ class TestEditItemSetup(ItemTest):
     """
     Setup for xblock update tests.
     """
-    shard = 1
 
     def setUp(self):
         """ Creates the test course structure and a couple problems to 'edit'. """
@@ -1425,7 +1418,6 @@ class TestEditItem(TestEditItemSetup):
     """
     Test xblock update.
     """
-    shard = 1
 
     def test_delete_field(self):
         """
@@ -1892,7 +1884,6 @@ class TestEditItemSplitMongo(TestEditItemSetup):
     """
     Tests for EditItem running on top of the SplitMongoModuleStore.
     """
-    shard = 1
     MODULESTORE = TEST_DATA_SPLIT_MODULESTORE
 
     def test_editing_view_wrappers(self):
@@ -1914,7 +1905,6 @@ class TestEditSplitModule(ItemTest):
     """
     Tests around editing instances of the split_test module.
     """
-    shard = 1
 
     def setUp(self):
         super(TestEditSplitModule, self).setUp()
@@ -2138,7 +2128,6 @@ class TestEditSplitModule(ItemTest):
 @ddt.ddt
 class TestComponentHandler(TestCase):
     """Tests for component handler api"""
-    shard = 1
 
     def setUp(self):
         super(TestComponentHandler, self).setUp()
@@ -2238,7 +2227,6 @@ class TestComponentTemplates(CourseTestCase):
     """
     Unit tests for the generation of the component templates for a course.
     """
-    shard = 1
 
     def setUp(self):
         super(TestComponentTemplates, self).setUp()
@@ -2474,7 +2462,6 @@ class TestXBlockInfo(ItemTest):
     """
     Unit tests for XBlock's outline handling.
     """
-    shard = 1
 
     def setUp(self):
         super(TestXBlockInfo, self).setUp()
@@ -2832,7 +2819,6 @@ class TestLibraryXBlockInfo(ModuleStoreTestCase):
     """
     Unit tests for XBlock Info for XBlocks in a content library
     """
-    shard = 1
 
     def setUp(self):
         super(TestLibraryXBlockInfo, self).setUp()
@@ -2883,7 +2869,6 @@ class TestLibraryXBlockCreation(ItemTest):
     """
     Tests the adding of XBlocks to Library
     """
-    shard = 1
 
     def test_add_xblock(self):
         """
@@ -2921,7 +2906,6 @@ class TestXBlockPublishingInfo(ItemTest):
     """
     Unit tests for XBlock's outline handling.
     """
-    shard = 1
     FIRST_SUBSECTION_PATH = [0]
     FIRST_UNIT_PATH = [0, 0]
     SECOND_UNIT_PATH = [0, 1]

--- a/cms/djangoapps/contentstore/views/tests/test_videos.py
+++ b/cms/djangoapps/contentstore/views/tests/test_videos.py
@@ -68,7 +68,6 @@ class VideoUploadTestBase(object):
     """
     Test cases for the video upload feature
     """
-    shard = 1
 
     def get_url_for_course_key(self, course_key, kwargs=None):
         """Return video handler URL for the given course"""
@@ -179,7 +178,6 @@ class VideoUploadTestMixin(VideoUploadTestBase):
     """
     Test cases for the video upload feature
     """
-    shard = 1
 
     def test_anon_user(self):
         self.client.logout()
@@ -220,7 +218,6 @@ class VideoUploadTestMixin(VideoUploadTestBase):
 @override_settings(VIDEO_UPLOAD_PIPELINE={"BUCKET": "test_bucket", "ROOT_PATH": "test_root"})
 class VideosHandlerTestCase(VideoUploadTestMixin, CourseTestCase):
     """Test cases for the main video upload endpoint"""
-    shard = 1
 
     VIEW_NAME = 'videos_handler'
 
@@ -793,7 +790,6 @@ class VideoImageTestCase(VideoUploadTestBase, CourseTestCase):
     """
     Tests for video image.
     """
-    shard = 1
 
     VIEW_NAME = "video_images_handler"
 
@@ -1082,7 +1078,6 @@ class TranscriptPreferencesTestCase(VideoUploadTestBase, CourseTestCase):
     """
     Tests for video transcripts preferences.
     """
-    shard = 1
 
     VIEW_NAME = 'transcript_preferences_handler'
 
@@ -1394,7 +1389,6 @@ class TranscriptPreferencesTestCase(VideoUploadTestBase, CourseTestCase):
 @override_settings(VIDEO_UPLOAD_PIPELINE={"BUCKET": "test_bucket", "ROOT_PATH": "test_root"})
 class VideoUrlsCsvTestCase(VideoUploadTestMixin, CourseTestCase):
     """Test cases for the CSV download endpoint for video uploads"""
-    shard = 1
 
     VIEW_NAME = "video_encodings_download"
 


### PR DESCRIPTION
No longer needed, as we're dynamically sharding tests via pytest-xdist.

The following test reports confirm we aren't removing any tests by doing this work:

Python test results from this PR: https://build.testeng.edx.org/job/edx-platform-python-pipeline-pr/2454/testReport/
Python test results from latest merge to master: https://build.testeng.edx.org/view/edx-platform-pipeline-master-tests/job/edx-platform-python-pipeline-master/85/testReport/