### PR TITLE
More reliable container publish in bok-choy tests

### DIFF
--- a/common/test/acceptance/pages/studio/container.py
+++ b/common/test/acceptance/pages/studio/container.py
@@ -185,8 +185,8 @@ class ContainerPage(PageObject, HelpMixin):
         """
         Publishes the container.
         """
-        self.publish_action.click()
-        self.wait_for_ajax()
+        self.scroll_to_element('.action-publish')
+        click_css(self, '.action-publish', 0, require_notification=False)
 
     def discard_changes(self):
         """

--- a/common/test/acceptance/tests/lms/test_bookmarks.py
+++ b/common/test/acceptance/tests/lms/test_bookmarks.py
@@ -238,7 +238,7 @@ class BookmarksTest(BookmarksTestMixin):
         container_page.wait_for_page()
 
         self.assertEqual(container_page.name, modified_name)
-        container_page.publish_action.click()
+        container_page.publish()
 
     def test_bookmark_button(self):
         """

--- a/common/test/acceptance/tests/lms/test_library.py
+++ b/common/test/acceptance/tests/lms/test_library.py
@@ -99,8 +99,7 @@ class LibraryContentTestBase(UniqueCourseTest):
         editor.save()
         self._go_to_unit_page(change_login=False)
         unit_page.wait_for_page()
-        unit_page.publish_action.click()
-        unit_page.wait_for_ajax()
+        unit_page.publish()
         self.assertIn("Published and Live", unit_page.publish_title)
 
     @property

--- a/common/test/acceptance/tests/lms/test_lms_cohorted_courseware_search.py
+++ b/common/test/acceptance/tests/lms/test_lms_cohorted_courseware_search.py
@@ -181,7 +181,7 @@ class CoursewareSearchCohortTest(ContainerBase, CohortTestMixin):
         set_visibility(2, [self.content_group_b])
         set_visibility(3, [self.content_group_a, self.content_group_b])
 
-        container_page.publish_action.click()
+        container_page.publish()
 
     def create_cohorts_and_assign_students(self):
         """

--- a/common/test/acceptance/tests/studio/test_studio_container.py
+++ b/common/test/acceptance/tests/studio/test_studio_container.py
@@ -788,8 +788,7 @@ class UnitPublishingTest(ContainerBase):
         add_discussion(unit)
         unit.verify_publish_title(self.DRAFT_STATUS)
         self._verify_last_published_and_saved(unit, self.LAST_PUBLISHED, self.LAST_SAVED)
-        unit.publish_action.click()
-        unit.wait_for_ajax()
+        unit.publish()
         unit.verify_publish_title(self.PUBLISHED_LIVE_STATUS)
         self._verify_last_published_and_saved(unit, self.LAST_PUBLISHED, self.LAST_PUBLISHED)
 
@@ -852,7 +851,7 @@ class UnitPublishingTest(ContainerBase):
         """
         unit = self.go_to_unit_page()
         add_discussion(unit)
-        unit.publish_action.click()
+        unit.publish()
         self._view_published_version(unit)
         self._verify_components_visible(['html', 'discussion'])
 
@@ -1021,8 +1020,7 @@ class UnitPublishingTest(ContainerBase):
         unit = self.go_to_unit_page()
         unit.delete(0)
         unit.verify_publish_title(self.DRAFT_STATUS)
-        unit.publish_action.click()
-        unit.wait_for_ajax()
+        unit.publish()
         unit.verify_publish_title(self.PUBLISHED_LIVE_STATUS)
         self._view_published_version(unit)
         self.assertEqual(0, self.courseware.num_xblock_components)
@@ -1042,8 +1040,7 @@ class UnitPublishingTest(ContainerBase):
         unit.verify_publish_title(self.PUBLISHED_STATUS)
         add_discussion(unit)
         unit.verify_publish_title(self.DRAFT_STATUS)
-        unit.publish_action.click()
-        unit.wait_for_ajax()
+        unit.publish()
         unit.verify_publish_title(self.PUBLISHED_STATUS)
 
     def _view_published_version(self, unit):
@@ -1319,7 +1316,7 @@ class MoveComponentTest(ContainerBase):
 
         # Now click publish/discard button
         if operation == 'publish':
-            unit_page.publish_action.click()
+            unit_page.publish()
         else:
             unit_page.discard_changes()
 

--- a/common/test/acceptance/tests/studio/test_studio_split_test.py
+++ b/common/test/acceptance/tests/studio/test_studio_split_test.py
@@ -322,7 +322,7 @@ class GroupConfigurationsTest(ContainerBase, SplitTestMixin):
 
         # I publish and view in LMS and it is rendered correctly
         if publish:
-            unit.publish_action.click()
+            unit.publish()
         unit.view_published_version()
         self.assertEqual(len(self.browser.window_handles), 2)
         courseware_page.wait_for_page()

--- a/common/test/acceptance/tests/test_cohorted_courseware.py
+++ b/common/test/acceptance/tests/test_cohorted_courseware.py
@@ -155,7 +155,7 @@ class EndToEndCohortedCoursewareTest(ContainerBase, CohortTestMixin):
         set_visibility(4, [AUDIT_TRACK], enrollment_group)
         set_visibility(5, [self.content_group_a, self.content_group_b])
 
-        container_page.publish_action.click()
+        container_page.publish()
 
     def create_cohorts_and_assign_students(self):
         """

--- a/common/test/acceptance/tests/video/test_video_license.py
+++ b/common/test/acceptance/tests/video/test_video_license.py
@@ -78,7 +78,7 @@ class VideoLicenseTest(StudioCourseTest):
         video.open_advanced_tab()
         video.set_license('all-rights-reserved')
         video.save_settings()
-        container_page.publish_action.click()
+        container_page.publish()
 
         self.lms_courseware.visit()
         video = self.lms_courseware.q(css=".vert .xblock .video")
@@ -108,7 +108,7 @@ class VideoLicenseTest(StudioCourseTest):
         video.open_advanced_tab()
         video.set_license('creative-commons')
         video.save_settings()
-        container_page.publish_action.click()
+        container_page.publish()
 
         self.lms_courseware.visit()
         video = self.lms_courseware.q(css=".vert .xblock .video")


### PR DESCRIPTION
Many bok-choy tests were looking up the "Publish" button element and then separately click it, but this occasionally fails with a `stale element reference` error because the page has been updated in the meantime.  Made the container page's `publish()` method use the more reliable `click_css()` method instead, and updated a bunch of tests which did `page.publish_action.click()` to call `page.publish()` instead.

Note that `click_css()` calls `wait_for_ajax()` internally, so some separate calls to that became redundant.