### PR TITLE
Remove shards from commonlib-unit tests

### DIFF
--- a/common/djangoapps/course_modes/tests/test_views.py
+++ b/common/djangoapps/course_modes/tests/test_views.py
@@ -35,7 +35,6 @@ class CourseModeViewTest(CatalogIntegrationMixin, UrlResetMixin, ModuleStoreTest
     """
     Course Mode View tests
     """
-    shard = 5
     URLCONF_MODULES = ['course_modes.urls']
 
     @patch.dict(settings.FEATURES, {'MODE_CREATION_FOR_TESTING': True})

--- a/common/djangoapps/django_comment_common/tests.py
+++ b/common/djangoapps/django_comment_common/tests.py
@@ -5,7 +5,6 @@ from six import text_type
 from django_comment_common.models import Role
 from models import CourseDiscussionSettings
 from openedx.core.djangoapps.course_groups.cohorts import CourseCohortsSettings
-from openedx.core.lib.tests import attr
 from student.models import CourseEnrollment, User
 from utils import get_course_discussion_settings, set_course_discussion_settings
 from xmodule.modulestore import ModuleStoreEnum
@@ -14,7 +13,6 @@ from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
 from xmodule.modulestore.tests.factories import CourseFactory
 
 
-@attr(shard=1)
 class RoleAssignmentTest(TestCase):
     """
     Basic checks to make sure our Roles get assigned and unassigned as students
@@ -67,7 +65,6 @@ class RoleAssignmentTest(TestCase):
     #     self.assertIn(student_role, another_student.roles.all())
 
 
-@attr(shard=1)
 class CourseDiscussionSettingsTest(ModuleStoreTestCase):
 
     def setUp(self):

--- a/common/djangoapps/enrollment/tests/test_views.py
+++ b/common/djangoapps/enrollment/tests/test_views.py
@@ -158,7 +158,6 @@ class EnrollmentTest(EnrollmentTestMixin, ModuleStoreTestCase, APITestCase, Ente
     """
     Test user enrollment, especially with different course modes.
     """
-    shard = 3
     USERNAME = "Bob"
     EMAIL = "bob@example.com"
     PASSWORD = "edx"
@@ -1531,7 +1530,6 @@ class CourseEnrollmentsApiListTest(APITestCase, ModuleStoreTestCase):
     """
     Test the course enrollments list API.
     """
-    shard = 3
     CREATED_DATA = datetime.datetime(2018, 1, 1, 0, 0, 1, tzinfo=pytz.UTC)
 
     def setUp(self):

--- a/common/djangoapps/pipeline_mako/tests/test_render.py
+++ b/common/djangoapps/pipeline_mako/tests/test_render.py
@@ -12,7 +12,6 @@ from pipeline_mako import compressed_css, compressed_js, render_require_js_path_
 
 class RequireJSPathOverridesTest(TestCase):
     """Test RequireJS path overrides. """
-    shard = 7
 
     OVERRIDES = {
         'jquery': 'common/js/vendor/jquery.js',
@@ -44,7 +43,6 @@ class RequireJSPathOverridesTest(TestCase):
 @ddt.ddt
 class PipelineRenderTest(TestCase):
     """Test individual pipeline rendering functions. """
-    shard = 7
 
     @staticmethod
     def mock_staticfiles_lookup(path):

--- a/common/djangoapps/pipeline_mako/tests/test_static_content.py
+++ b/common/djangoapps/pipeline_mako/tests/test_static_content.py
@@ -9,7 +9,6 @@ from edxmako.shortcuts import render_to_string
 
 class TestStaticContent(unittest.TestCase):
     """Tests for static_content.html"""
-    shard = 7
 
     def test_optional_include_mako(self):
         out = render_to_string("test_optional_include_mako.html", {})

--- a/common/djangoapps/student/tests/test_enrollment.py
+++ b/common/djangoapps/student/tests/test_enrollment.py
@@ -31,7 +31,6 @@ class EnrollmentTest(UrlResetMixin, SharedModuleStoreTestCase):
     Test student enrollment, especially with different course modes.
     """
 
-    shard = 3
     USERNAME = "Bob"
     EMAIL = "bob@example.com"
     PASSWORD = "edx"

--- a/common/djangoapps/student/tests/test_recent_enrollments.py
+++ b/common/djangoapps/student/tests/test_recent_enrollments.py
@@ -29,7 +29,6 @@ class TestRecentEnrollments(ModuleStoreTestCase, XssTestMixin):
     """
     Unit tests for getting the list of courses for a logged in user
     """
-    shard = 3
     PASSWORD = 'test'
 
     def setUp(self):

--- a/common/djangoapps/student/tests/test_verification_status.py
+++ b/common/djangoapps/student/tests/test_verification_status.py
@@ -31,7 +31,6 @@ from xmodule.modulestore.tests.factories import CourseFactory
 class TestCourseVerificationStatus(UrlResetMixin, ModuleStoreTestCase):
     """Tests for per-course verification status on the dashboard. """
 
-    shard = 3
     PAST = 'past'
     FUTURE = 'future'
     DATES = {

--- a/common/djangoapps/student/tests/tests.py
+++ b/common/djangoapps/student/tests/tests.py
@@ -1066,7 +1066,6 @@ class AnonymousLookupTable(ModuleStoreTestCase):
 @patch('openedx.core.djangoapps.programs.utils.get_programs')
 class RelatedProgramsTests(ProgramsApiConfigMixin, SharedModuleStoreTestCase):
     """Tests verifying that related programs appear on the course dashboard."""
-    shard = 3
     maxDiff = None
     password = 'test'
     related_programs_preface = 'Related Programs'

--- a/common/djangoapps/track/views/tests/test_segmentio.py
+++ b/common/djangoapps/track/views/tests/test_segmentio.py
@@ -33,7 +33,6 @@ class SegmentIOTrackingTestCase(SegmentIOTrackingTestCaseBase):
     """
     Test processing of Segment events.
     """
-    shard = 3
 
     def setUp(self):
         super(SegmentIOTrackingTestCase, self).setUp()

--- a/common/lib/xmodule/xmodule/assetstore/tests/test_asset_xml.py
+++ b/common/lib/xmodule/xmodule/assetstore/tests/test_asset_xml.py
@@ -16,7 +16,6 @@ class TestAssetXml(unittest.TestCase):
     """
     Tests for storing/querying course asset metadata.
     """
-    shard = 1
 
     def setUp(self):
         super(TestAssetXml, self).setUp()

--- a/common/lib/xmodule/xmodule/modulestore/tests/test_abstraction.py
+++ b/common/lib/xmodule/xmodule/modulestore/tests/test_abstraction.py
@@ -10,7 +10,6 @@ class AbstractionTest(TestCase):
     """
     Tests that the ModuleStore objects are properly abstracted
     """
-    shard = 1
 
     def test_cant_instantiate_abstract_class(self):
         self.assertRaises(TypeError, ModuleStoreRead)  # Cannot be instantiated due to explicit abstraction

--- a/common/lib/xmodule/xmodule/modulestore/tests/test_asides.py
+++ b/common/lib/xmodule/xmodule/modulestore/tests/test_asides.py
@@ -28,7 +28,6 @@ class TestAsidesXmlStore(TestCase):
     """
     Test Asides sourced from xml store
     """
-    shard = 1
 
     @patch('xmodule.modulestore.xml.ImportSystem.applicable_aside_types', lambda self, block: ['test_aside'])
     @XBlockAside.register_temp_plugin(AsideTestType, 'test_aside')

--- a/common/lib/xmodule/xmodule/modulestore/tests/test_assetstore.py
+++ b/common/lib/xmodule/xmodule/modulestore/tests/test_assetstore.py
@@ -63,7 +63,6 @@ class TestSortedAssetList(unittest.TestCase):
     """
     Tests the SortedAssetList class.
     """
-    shard = 1
 
     def setUp(self):
         super(TestSortedAssetList, self).setUp()
@@ -92,7 +91,6 @@ class TestMongoAssetMetadataStorage(TestCase):
     """
     Tests for storing/querying course asset metadata.
     """
-    shard = 1
     XML_MODULESTORE_MAP = {
         'XML_MODULESTORE_BUILDER': XmlModulestoreBuilder(),
         'MIXED_MODULESTORE_BUILDER': MixedModulestoreBuilder([('xml', XmlModulestoreBuilder())])

--- a/common/lib/xmodule/xmodule/modulestore/tests/test_contentstore.py
+++ b/common/lib/xmodule/xmodule/modulestore/tests/test_contentstore.py
@@ -30,7 +30,6 @@ class TestContentstore(unittest.TestCase):
     """
     Test the methods in contentstore.mongo using deprecated and non-deprecated keys
     """
-    shard = 2
 
     # don't use these 2 class vars as they restore behavior once the tests are done
     asset_deprecated = None

--- a/common/lib/xmodule/xmodule/modulestore/tests/test_cross_modulestore_import_export.py
+++ b/common/lib/xmodule/xmodule/modulestore/tests/test_cross_modulestore_import_export.py
@@ -42,7 +42,6 @@ COURSE_DATA_NAMES = (
 EXPORTED_COURSE_DIR_NAME = u'exported_source_course'
 
 
-@attr(shard=2)
 @ddt.ddt
 @attr('mongo')
 class CrossStoreXMLRoundtrip(CourseComparisonTest, PartitionTestCase):

--- a/common/lib/xmodule/xmodule/modulestore/tests/test_libraries.py
+++ b/common/lib/xmodule/xmodule/modulestore/tests/test_libraries.py
@@ -21,7 +21,6 @@ class TestLibraries(MixedSplitTestCase):
     Test for libraries.
     Mostly tests code found throughout split mongo, but also tests library_root_xblock.py
     """
-    shard = 2
 
     def test_create_library(self):
         """

--- a/common/lib/xmodule/xmodule/modulestore/tests/test_modulestore_settings.py
+++ b/common/lib/xmodule/xmodule/modulestore/tests/test_modulestore_settings.py
@@ -19,7 +19,6 @@ class ModuleStoreSettingsMigration(TestCase):
     """
     Tests for the migration code for the module store settings
     """
-    shard = 2
 
     OLD_CONFIG = {
         "default": {

--- a/common/lib/xmodule/xmodule/modulestore/tests/test_mongo.py
+++ b/common/lib/xmodule/xmodule/modulestore/tests/test_mongo.py
@@ -76,7 +76,6 @@ class TestMongoModuleStoreBase(TestCase):
     '''
     Basic setup for all tests
     '''
-    shard = 2
     # Explicitly list the courses to load (don't want the big one)
     courses = ['toy', 'simple', 'simple_with_draft', 'test_unicode']
 
@@ -180,7 +179,6 @@ class TestMongoModuleStoreBase(TestCase):
 
 class TestMongoModuleStore(TestMongoModuleStoreBase):
     '''Module store tests'''
-    shard = 2
 
     @classmethod
     def add_asset_collection(cls, doc_store_config):
@@ -724,7 +722,6 @@ class TestMongoModuleStoreWithNoAssetCollection(TestMongoModuleStore):
     '''
     Tests a situation where no asset_collection is specified.
     '''
-    shard = 2
 
     @classmethod
     def add_asset_collection(cls, doc_store_config):
@@ -757,7 +754,6 @@ class TestMongoKeyValueStore(TestCase):
     """
     Tests for MongoKeyValueStore.
     """
-    shard = 2
 
     def setUp(self):
         super(TestMongoKeyValueStore, self).setUp()

--- a/common/lib/xmodule/xmodule/modulestore/tests/test_mongo_call_count.py
+++ b/common/lib/xmodule/xmodule/modulestore/tests/test_mongo_call_count.py
@@ -28,7 +28,6 @@ class CountMongoCallsXMLRoundtrip(TestCase):
     """
     This class exists to test XML import and export to/from Split.
     """
-    shard = 2
 
     def setUp(self):
         super(CountMongoCallsXMLRoundtrip, self).setUp()
@@ -89,7 +88,6 @@ class CountMongoCallsCourseTraversal(TestCase):
     Tests the number of Mongo calls made when traversing a course tree from the top course root
     to the leaf nodes.
     """
-    shard = 2
 
     def _traverse_blocks_in_course(self, course, access_all_block_fields):
         """

--- a/common/lib/xmodule/xmodule/modulestore/tests/test_publish.py
+++ b/common/lib/xmodule/xmodule/modulestore/tests/test_publish.py
@@ -25,7 +25,6 @@ from xmodule.modulestore.tests.utils import (
 )
 
 
-@attr(shard=1)
 @attr('mongo')
 class TestPublish(SplitWMongoCourseBootstrapper):
     """
@@ -157,7 +156,6 @@ class TestPublish(SplitWMongoCourseBootstrapper):
         self.assertTrue(self.draft_mongo.has_item(other_child_loc), "Oops, lost moved item")
 
 
-@attr(shard=1)
 class DraftPublishedOpTestCourseSetup(unittest.TestCase):
     """
     This class exists to test XML import and export between different modulestore
@@ -272,7 +270,6 @@ class DraftPublishedOpTestCourseSetup(unittest.TestCase):
         super(DraftPublishedOpTestCourseSetup, self).setUp()
 
 
-@attr(shard=1)
 class OLXFormatChecker(unittest.TestCase):
     """
     Examines the on-disk course export to verify that specific items are present/missing
@@ -645,7 +642,6 @@ class DraftPublishedOpBaseTestSetup(OLXFormatChecker, DraftPublishedOpTestCourse
         self.export_dir = self._make_new_export_dir_name()
 
 
-@attr(shard=1)
 @ddt.ddt
 class ElementalPublishingTests(DraftPublishedOpBaseTestSetup):
     """
@@ -820,7 +816,6 @@ class ElementalPublishingTests(DraftPublishedOpBaseTestSetup):
             self.assertOLXIsDraftOnly(block_list_untouched)
 
 
-@attr(shard=1)
 @ddt.ddt
 class ElementalUnpublishingTests(DraftPublishedOpBaseTestSetup):
     """
@@ -940,7 +935,6 @@ class ElementalUnpublishingTests(DraftPublishedOpBaseTestSetup):
                 self.unpublish(block_list_to_unpublish)
 
 
-@attr(shard=1)
 @ddt.ddt
 class ElementalDeleteItemTests(DraftPublishedOpBaseTestSetup):
     """
@@ -1138,7 +1132,6 @@ class ElementalDeleteItemTests(DraftPublishedOpBaseTestSetup):
             self.assertOLXIsDeleted(block_list_draft_children)
 
 
-@attr(shard=1)
 @ddt.ddt
 class ElementalConvertToDraftTests(DraftPublishedOpBaseTestSetup):
     """
@@ -1196,7 +1189,6 @@ class ElementalConvertToDraftTests(DraftPublishedOpBaseTestSetup):
                 raise Exception("Must test either Old Mongo or Split modulestore!")
 
 
-@attr(shard=1)
 @ddt.ddt
 class ElementalRevertToPublishedTests(DraftPublishedOpBaseTestSetup):
     """

--- a/common/lib/xmodule/xmodule/modulestore/tests/test_semantics.py
+++ b/common/lib/xmodule/xmodule/modulestore/tests/test_semantics.py
@@ -43,7 +43,6 @@ class DirectOnlyCategorySemantics(PureModulestoreTestCase):
     Verify the behavior of Direct Only items
     blocks intended to store snippets of course content.
     """
-    shard = 1
 
     __test__ = False
 
@@ -416,7 +415,6 @@ class TestSplitDirectOnlyCategorySemantics(DirectOnlyCategorySemantics):
     """
     Verify DIRECT_ONLY_CATEGORY semantics against the SplitMongoModulestore.
     """
-    shard = 1
     MODULESTORE = SPLIT_MODULESTORE_SETUP
     __test__ = True
 
@@ -451,6 +449,5 @@ class TestMongoDirectOnlyCategorySemantics(DirectOnlyCategorySemantics):
     """
     Verify DIRECT_ONLY_CATEGORY semantics against the MongoModulestore
     """
-    shard = 1
     MODULESTORE = MongoModulestoreBuilder()
     __test__ = True

--- a/common/lib/xmodule/xmodule/modulestore/tests/test_split_copy_from_template.py
+++ b/common/lib/xmodule/xmodule/modulestore/tests/test_split_copy_from_template.py
@@ -15,7 +15,6 @@ class TestSplitCopyTemplate(MixedSplitTestCase):
     """
     Test for split's copy_from_template method.
     """
-    shard = 2
 
     @ddt.data(
         LibraryFactory,

--- a/common/lib/xmodule/xmodule/modulestore/tests/test_split_migrator.py
+++ b/common/lib/xmodule/xmodule/modulestore/tests/test_split_migrator.py
@@ -13,7 +13,6 @@ from xmodule.modulestore.split_migrator import SplitMigrator
 from xmodule.modulestore.tests.test_split_w_old_mongo import SplitWMongoCourseBootstrapper
 
 
-@attr(shard=2)
 @attr('mongo')
 class TestMigration(SplitWMongoCourseBootstrapper):
     """

--- a/common/lib/xmodule/xmodule/modulestore/tests/test_split_modulestore.py
+++ b/common/lib/xmodule/xmodule/modulestore/tests/test_split_modulestore.py
@@ -42,7 +42,6 @@ BRANCH_NAME_DRAFT = ModuleStoreEnum.BranchName.draft
 BRANCH_NAME_PUBLISHED = ModuleStoreEnum.BranchName.published
 
 
-@attr(shard=2)
 @attr('mongo')
 class SplitModuleTest(unittest.TestCase):
     '''
@@ -569,7 +568,6 @@ class SplitModuleTest(unittest.TestCase):
                 return element
 
 
-@attr(shard=2)
 class TestHasChildrenAtDepth(SplitModuleTest):
     """Test the has_children_at_depth method of XModuleMixin. """
 
@@ -607,7 +605,6 @@ class TestHasChildrenAtDepth(SplitModuleTest):
         self.assertFalse(ch3.has_children_at_depth(1))
 
 
-@attr(shard=2)
 @ddt.ddt
 class SplitModuleCourseTests(SplitModuleTest):
     '''
@@ -938,7 +935,6 @@ class SplitModuleCourseTests(SplitModuleTest):
         self.assertEqual(root_block_key.block_id, "course")
 
 
-@attr(shard=2)
 class TestCourseStructureCache(SplitModuleTest):
     """Tests for the CourseStructureCache"""
 
@@ -1012,7 +1008,6 @@ class TestCourseStructureCache(SplitModuleTest):
         )
 
 
-@attr(shard=2)
 class SplitModuleItemTests(SplitModuleTest):
     '''
     Item read tests including inheritance
@@ -1275,7 +1270,6 @@ def version_agnostic(children):
     return [child.version_agnostic() for child in children]
 
 
-@attr(shard=2)
 class TestItemCrud(SplitModuleTest):
     """
     Test create update and delete of items
@@ -1768,7 +1762,6 @@ class TestItemCrud(SplitModuleTest):
             store.delete_course(refetch_course.id, user)
 
 
-@attr(shard=2)
 class TestCourseCreation(SplitModuleTest):
     """
     Test create_course
@@ -1967,7 +1960,6 @@ class TestCourseCreation(SplitModuleTest):
                     self.assertEqual(fetched_modified.advertised_start, modified_course.advertised_start)
 
 
-@attr(shard=2)
 class TestInheritance(SplitModuleTest):
     """
     Test the metadata inheritance mechanism.
@@ -2043,7 +2035,6 @@ class TestInheritance(SplitModuleTest):
 #         self.assertTrue(parented_problem.visible_to_staff_only)
 
 
-@attr(shard=2)
 class TestPublish(SplitModuleTest):
     """
     Test the publishing api
@@ -2219,7 +2210,6 @@ class TestPublish(SplitModuleTest):
         self.assertEqual(source_block_keys, dest_block_keys)
 
 
-@attr(shard=2)
 class TestSchema(SplitModuleTest):
     """
     Test the db schema (and possibly eventually migrations?)

--- a/common/lib/xmodule/xmodule/modulestore/tests/test_split_modulestore_bulk_operations.py
+++ b/common/lib/xmodule/xmodule/modulestore/tests/test_split_modulestore_bulk_operations.py
@@ -22,7 +22,6 @@ SAMPLE_GUIDS_LIST = ['SAMPLE_VERSION_GUID', 'SAMPLE_UNICODE_VERSION_GUID', 'BSON
 
 
 class TestBulkWriteMixin(unittest.TestCase):
-    shard = 2
 
     def setUp(self):
         super(TestBulkWriteMixin, self).setUp()
@@ -64,7 +63,6 @@ class TestBulkWriteMixinClosed(TestBulkWriteMixin):
     """
     Tests of the bulk write mixin when bulk operations aren't active.
     """
-    shard = 2
 
     @ddt.data(*SAMPLE_GUIDS_LIST)
     def test_no_bulk_read_structure(self, version_guid_name):
@@ -310,7 +308,6 @@ class TestBulkWriteMixinFindMethods(TestBulkWriteMixin):
     """
     Tests of BulkWriteMixin methods for finding many structures or indexes
     """
-    shard = 2
 
     def test_no_bulk_find_matching_course_indexes(self):
         branch = Mock(name='branch')
@@ -588,7 +585,6 @@ class TestBulkWriteMixinOpen(TestBulkWriteMixin):
     """
     Tests of the bulk write mixin when bulk write operations are open
     """
-    shard = 2
 
     def setUp(self):
         super(TestBulkWriteMixinOpen, self).setUp()

--- a/common/lib/xmodule/xmodule/modulestore/tests/test_split_mongo_mongo_connection.py
+++ b/common/lib/xmodule/xmodule/modulestore/tests/test_split_mongo_mongo_connection.py
@@ -7,7 +7,6 @@ from xmodule.exceptions import HeartbeatFailure
 
 class TestHeartbeatFailureException(unittest.TestCase):
     """ Test that a heartbeat failure is thrown at the appropriate times """
-    shard = 2
 
     @patch('pymongo.MongoClient')
     @patch('pymongo.database.Database')

--- a/common/lib/xmodule/xmodule/modulestore/tests/test_store_utilities.py
+++ b/common/lib/xmodule/xmodule/modulestore/tests/test_store_utilities.py
@@ -49,7 +49,6 @@ class TestUtils(unittest.TestCase):
                 /        \
             child_3    child_4
     """
-    shard = 2
 
     ONLY_ROOTS = [
         ('url1', 'vertical'),

--- a/common/lib/xmodule/xmodule/modulestore/tests/test_xml.py
+++ b/common/lib/xmodule/xmodule/modulestore/tests/test_xml.py
@@ -35,7 +35,6 @@ class TestXMLModuleStore(TestCase):
     """
     Test around the XML modulestore
     """
-    shard = 2
 
     @patch('xmodule.tabs.CourseTabList.initialize_default', Mock())
     def test_unicode_chars_in_xml_content(self):
@@ -143,7 +142,6 @@ class TestXMLModuleStore(TestCase):
 
 
 class TestModuleStoreIgnore(TestXMLModuleStore):
-    shard = 2
     course_dir = DATA_DIR / "course_ignore"
 
     def setUp(self):

--- a/common/lib/xmodule/xmodule/modulestore/tests/test_xml_importer.py
+++ b/common/lib/xmodule/xmodule/modulestore/tests/test_xml_importer.py
@@ -126,7 +126,6 @@ class RemapNamespaceTest(ModuleStoreNoSettings):
     """
     Test that remapping the namespace from import to the actual course location.
     """
-    shard = 2
 
     def setUp(self):
         """
@@ -275,7 +274,6 @@ class UpdateLocationTest(ModuleStoreNoSettings):
     """
     Test that updating location preserves "is_set_on" status on fields
     """
-    shard = 2
     CONTENT_FIELDS = ['test_content_field', 'test_mutable_content_field']
     SETTINGS_FIELDS = ['test_settings_field', 'test_mutable_settings_field']
     CHILDREN_FIELDS = ['children']
@@ -343,7 +341,6 @@ class UpdateLocationTest(ModuleStoreNoSettings):
 
 
 class StaticContentImporterTest(unittest.TestCase):
-    shard = 2
 
     def setUp(self):
         self.course_data_path = path('/path')

--- a/common/lib/xmodule/xmodule/partitions/tests/test_partitions.py
+++ b/common/lib/xmodule/xmodule/partitions/tests/test_partitions.py
@@ -21,7 +21,6 @@ from openedx.features.content_type_gating.models import ContentTypeGatingConfig
 
 class TestGroup(TestCase):
     """Test constructing groups"""
-    shard = 2
 
     def test_construct(self):
         test_id = 10
@@ -123,7 +122,6 @@ class MockEnrollmentTrackUserPartitionScheme(MockUserPartitionScheme):
 
 class PartitionTestCase(TestCase):
     """Base class for test cases that require partitions"""
-    shard = 2
     TEST_ID = 0
     TEST_NAME = "Mock Partition"
     TEST_DESCRIPTION = "for testing purposes"
@@ -179,7 +177,6 @@ class PartitionTestCase(TestCase):
 
 class TestUserPartition(PartitionTestCase):
     """Test constructing UserPartitions"""
-    shard = 2
 
     def test_construct(self):
         user_partition = UserPartition(
@@ -466,7 +463,6 @@ class TestPartitionService(PartitionServiceBaseClass):
     """
     Test getting a user's group out of a partition
     """
-    shard = 2
 
     def test_get_user_group_id_for_partition(self):
         # assign the first group to be returned
@@ -557,7 +553,6 @@ class TestGetCourseUserPartitions(PartitionServiceBaseClass):
     """
     Test the helper method get_all_partitions_for_course.
     """
-    shard = 2
 
     def setUp(self):
         super(TestGetCourseUserPartitions, self).setUp()

--- a/common/lib/xmodule/xmodule/tests/__init__.py
+++ b/common/lib/xmodule/xmodule/tests/__init__.py
@@ -177,7 +177,6 @@ def mock_render_template(*args, **kwargs):
 
 
 class ModelsTest(unittest.TestCase):
-    shard = 1
 
     def test_load_class(self):
         vc = XModuleDescriptor.load_class('video')
@@ -187,7 +186,6 @@ class ModelsTest(unittest.TestCase):
 
 class LogicTest(unittest.TestCase):
     """Base class for testing xmodule logic."""
-    shard = 1
     descriptor_class = None
     raw_field_data = {}
 
@@ -403,7 +401,6 @@ class CourseComparisonTest(BulkAssertionTest):
     """
     Mixin that has methods for comparing courses for equality.
     """
-    shard = 1
 
     def setUp(self):
         super(CourseComparisonTest, self).setUp()

--- a/common/lib/xmodule/xmodule/tests/test_annotatable_module.py
+++ b/common/lib/xmodule/xmodule/tests/test_annotatable_module.py
@@ -14,7 +14,6 @@ from . import get_test_system
 
 
 class AnnotatableModuleTestCase(unittest.TestCase):
-    shard = 1
     sample_xml = '''
         <annotatable display_name="Iliad">
             <instructions>Read the text.</instructions>

--- a/common/lib/xmodule/xmodule/tests/test_annotator_mixin.py
+++ b/common/lib/xmodule/xmodule/tests/test_annotator_mixin.py
@@ -12,7 +12,6 @@ class HelperFunctionTest(unittest.TestCase):
     """
     Tests to ensure that the following helper functions work for the annotation tool
     """
-    shard = 1
     sample_xml = '''
         <annotatable>
             <instructions><p>Helper Test Instructions.</p></instructions>

--- a/common/lib/xmodule/xmodule/tests/test_annotator_token.py
+++ b/common/lib/xmodule/xmodule/tests/test_annotator_token.py
@@ -10,7 +10,6 @@ class TokenRetriever(unittest.TestCase):
     """
     Tests to make sure that when passed in a username and secret token, that it will be encoded correctly
     """
-    shard = 1
 
     def test_token(self):
         """

--- a/common/lib/xmodule/xmodule/tests/test_bulk_assertions.py
+++ b/common/lib/xmodule/xmodule/tests/test_bulk_assertions.py
@@ -52,7 +52,6 @@ CONTEXT_FAILING_ASSERTIONS = (
 
 @ddt.ddt
 class TestBulkAssertionTestCase(BulkAssertionTest):
-    shard = 1
 
     # We have to use assertion methods from the base UnitTest class,
     # so we make a number of super calls that skip BulkAssertionTest.

--- a/common/lib/xmodule/xmodule/tests/test_capa_module.py
+++ b/common/lib/xmodule/xmodule/tests/test_capa_module.py
@@ -183,7 +183,6 @@ if submission[0] == '':
 
 @ddt.ddt
 class CapaModuleTest(unittest.TestCase):
-    shard = 1
 
     def setUp(self):
         super(CapaModuleTest, self).setUp()
@@ -2137,7 +2136,6 @@ class CapaModuleTest(unittest.TestCase):
 
 @ddt.ddt
 class CapaDescriptorTest(unittest.TestCase):
-    shard = 1
 
     sample_checkbox_problem_xml = textwrap.dedent("""
         <problem>
@@ -2933,7 +2931,6 @@ class CapaDescriptorTest(unittest.TestCase):
 
 
 class ComplexEncoderTest(unittest.TestCase):
-    shard = 1
 
     def test_default(self):
         """
@@ -2949,7 +2946,6 @@ class TestProblemCheckTracking(unittest.TestCase):
     """
     Ensure correct tracking information is included in events emitted during problem checks.
     """
-    shard = 1
 
     def setUp(self):
         super(TestProblemCheckTracking, self).setUp()

--- a/common/lib/xmodule/xmodule/tests/test_conditional.py
+++ b/common/lib/xmodule/xmodule/tests/test_conditional.py
@@ -147,7 +147,6 @@ class ConditionalModuleBasicTest(unittest.TestCase):
     Make sure that conditional module works, using mocks for
     other modules.
     """
-    shard = 1
 
     def setUp(self):
         super(ConditionalModuleBasicTest, self).setUp()
@@ -220,7 +219,6 @@ class ConditionalModuleXmlTest(unittest.TestCase):
     """
     Make sure ConditionalModule works, by loading data in from an XML-defined course.
     """
-    shard = 1
 
     @staticmethod
     def get_system(load_error_modules=True):
@@ -384,7 +382,6 @@ class ConditionalModuleStudioTest(XModuleXmlImportTest):
     """
     Unit tests for how conditional test interacts with Studio.
     """
-    shard = 1
 
     def setUp(self):
         super(ConditionalModuleStudioTest, self).setUp()

--- a/common/lib/xmodule/xmodule/tests/test_conditional_logic.py
+++ b/common/lib/xmodule/xmodule/tests/test_conditional_logic.py
@@ -7,7 +7,6 @@ from . import LogicTest
 
 class ConditionalModuleTest(LogicTest):
     """Logic tests for Conditional Xmodule."""
-    shard = 1
     descriptor_class = ConditionalDescriptor
 
     def test_ajax_request(self):

--- a/common/lib/xmodule/xmodule/tests/test_content.py
+++ b/common/lib/xmodule/xmodule/tests/test_content.py
@@ -100,7 +100,6 @@ class MockImage(Mock):
 
 @ddt.ddt
 class ContentTest(unittest.TestCase):
-    shard = 1
 
     def test_thumbnail_none(self):
         # We had a bug where a thumbnail location of None was getting transformed into a Location tuple, with

--- a/common/lib/xmodule/xmodule/tests/test_course_metadata_utils.py
+++ b/common/lib/xmodule/xmodule/tests/test_course_metadata_utils.py
@@ -37,7 +37,6 @@ class CourseMetadataUtilsTestCase(TestCase):
     """
     Tests for course_metadata_utils.
     """
-    shard = 1
 
     def setUp(self):
         """

--- a/common/lib/xmodule/xmodule/tests/test_course_module.py
+++ b/common/lib/xmodule/xmodule/tests/test_course_module.py
@@ -29,7 +29,6 @@ _NEXT_WEEK = _TODAY + timedelta(days=7)
 
 
 class CourseFieldsTestCase(unittest.TestCase):
-    shard = 1
 
     def test_default_start_date(self):
         self.assertEqual(
@@ -100,7 +99,6 @@ def get_dummy_course(start, announcement=None, is_new=None, advertised_start=Non
 
 class HasEndedMayCertifyTestCase(unittest.TestCase):
     """Double check the semantics around when to finalize courses."""
-    shard = 1
 
     def setUp(self):
         super(HasEndedMayCertifyTestCase, self).setUp()
@@ -151,7 +149,6 @@ class HasEndedMayCertifyTestCase(unittest.TestCase):
 
 class CourseSummaryHasEnded(unittest.TestCase):
     """ Test for has_ended method when end date is missing timezone information. """
-    shard = 1
 
     def test_course_end(self):
         test_course = get_dummy_course("2012-01-01T12:00")
@@ -163,7 +160,6 @@ class CourseSummaryHasEnded(unittest.TestCase):
 @ddt.ddt
 class IsNewCourseTestCase(unittest.TestCase):
     """Make sure the property is_new works on courses"""
-    shard = 1
 
     def setUp(self):
         super(IsNewCourseTestCase, self).setUp()
@@ -267,7 +263,6 @@ class IsNewCourseTestCase(unittest.TestCase):
 
 
 class DiscussionTopicsTestCase(unittest.TestCase):
-    shard = 1
 
     def test_default_discussion_topics(self):
         d = get_dummy_course('2012-12-02T12:00')
@@ -278,7 +273,6 @@ class TeamsConfigurationTestCase(unittest.TestCase):
     """
     Tests for the configuration of teams and the helper methods for accessing them.
     """
-    shard = 1
 
     def setUp(self):
         super(TeamsConfigurationTestCase, self).setUp()
@@ -347,7 +341,6 @@ class TeamsConfigurationTestCase(unittest.TestCase):
 
 class SelfPacedTestCase(unittest.TestCase):
     """Tests for self-paced courses."""
-    shard = 1
 
     def setUp(self):
         super(SelfPacedTestCase, self).setUp()
@@ -359,7 +352,6 @@ class SelfPacedTestCase(unittest.TestCase):
 
 class BypassHomeTestCase(unittest.TestCase):
     """Tests for setting which allows course home to be bypassed."""
-    shard = 1
 
     def setUp(self):
         super(BypassHomeTestCase, self).setUp()
@@ -378,7 +370,6 @@ class CourseDescriptorTestCase(unittest.TestCase):
     class definitely isn't a comprehensive test case for CourseDescriptor, as
     writing a such a test case was out of the scope of the PR.
     """
-    shard = 1
 
     def setUp(self):
         """
@@ -428,7 +419,6 @@ class ProctoringProviderTestCase(unittest.TestCase):
     """
     Tests for ProctoringProvider, including the default value, validation, and inheritance behavior.
     """
-    shard = 1
 
     def setUp(self):
         """

--- a/common/lib/xmodule/xmodule/tests/test_delay_between_attempts.py
+++ b/common/lib/xmodule/xmodule/tests/test_delay_between_attempts.py
@@ -124,7 +124,6 @@ class XModuleQuizAttemptsDelayTest(unittest.TestCase):
     """
     Class to test delay between quiz attempts.
     """
-    shard = 1
 
     def create_and_check(self,
                          num_attempts=None,

--- a/common/lib/xmodule/xmodule/tests/test_editing_module.py
+++ b/common/lib/xmodule/xmodule/tests/test_editing_module.py
@@ -17,7 +17,6 @@ log = logging.getLogger(__name__)
 
 class TabsEditingDescriptorTestCase(unittest.TestCase):
     """ Testing TabsEditingDescriptor"""
-    shard = 1
 
     def setUp(self):
         super(TabsEditingDescriptorTestCase, self).setUp()

--- a/common/lib/xmodule/xmodule/tests/test_error_module.py
+++ b/common/lib/xmodule/xmodule/tests/test_error_module.py
@@ -16,7 +16,6 @@ from xblock.test.tools import unabc
 
 class SetupTestErrorModules(unittest.TestCase):
     """Common setUp for use in ErrorModule tests."""
-    shard = 1
 
     def setUp(self):
         super(SetupTestErrorModules, self).setUp()
@@ -31,7 +30,6 @@ class TestErrorModule(SetupTestErrorModules):
     """
     Tests for ErrorModule and ErrorDescriptor
     """
-    shard = 1
 
     def test_error_module_xml_rendering(self):
         descriptor = ErrorDescriptor.from_xml(
@@ -66,7 +64,6 @@ class TestNonStaffErrorModule(SetupTestErrorModules):
     """
     Tests for NonStaffErrorModule and NonStaffErrorDescriptor
     """
-    shard = 1
 
     def test_non_staff_error_module_create(self):
         descriptor = NonStaffErrorDescriptor.from_xml(
@@ -127,7 +124,6 @@ class TestErrorModuleConstruction(unittest.TestCase):
     """
     Test that error module construction happens correctly
     """
-    shard = 1
 
     def setUp(self):
         # pylint: disable=abstract-class-instantiated

--- a/common/lib/xmodule/xmodule/tests/test_export.py
+++ b/common/lib/xmodule/xmodule/tests/test_export.py
@@ -65,7 +65,6 @@ class RoundTripTestCase(unittest.TestCase):
     And we compare original import with second import (after export).
     Thus we make sure that export and import work properly.
     """
-    shard = 1
 
     def setUp(self):
         super(RoundTripTestCase, self).setUp()
@@ -156,7 +155,6 @@ class TestEdxJsonEncoder(unittest.TestCase):
     """
     Tests for xml_exporter.EdxJSONEncoder
     """
-    shard = 1
 
     def setUp(self):
         super(TestEdxJsonEncoder, self).setUp()

--- a/common/lib/xmodule/xmodule/tests/test_fields.py
+++ b/common/lib/xmodule/xmodule/tests/test_fields.py
@@ -10,7 +10,6 @@ from xmodule.timeinfo import TimeInfo
 
 
 class DateTest(unittest.TestCase):
-    shard = 1
     date = Date()
 
     def compare_dates(self, dt1, dt2, expected_delta):
@@ -123,7 +122,6 @@ class DateTest(unittest.TestCase):
 
 
 class TimedeltaTest(unittest.TestCase):
-    shard = 1
     delta = Timedelta()
 
     def test_from_json(self):
@@ -158,7 +156,6 @@ class TimedeltaTest(unittest.TestCase):
 
 
 class TimeInfoTest(unittest.TestCase):
-    shard = 1
 
     def test_time_info(self):
         due_date = datetime.datetime(2000, 4, 14, 10, tzinfo=UTC)
@@ -171,7 +168,6 @@ class TimeInfoTest(unittest.TestCase):
 
 
 class RelativeTimeTest(unittest.TestCase):
-    shard = 1
 
     delta = RelativeTime()
 

--- a/common/lib/xmodule/xmodule/tests/test_graders.py
+++ b/common/lib/xmodule/xmodule/tests/test_graders.py
@@ -19,7 +19,6 @@ class GradesheetTest(unittest.TestCase):
     """
     Tests the aggregate_scores method
     """
-    shard = 1
 
     def test_weighted_grading(self):
         scores = []
@@ -82,7 +81,6 @@ class GraderTest(unittest.TestCase):
     """
     Tests grader implementations
     """
-    shard = 1
 
     empty_gradesheet = {
     }
@@ -332,7 +330,6 @@ class ShowCorrectnessTest(unittest.TestCase):
     """
     Tests the correctness_available method
     """
-    shard = 1
 
     def setUp(self):
         super(ShowCorrectnessTest, self).setUp()

--- a/common/lib/xmodule/xmodule/tests/test_html_module.py
+++ b/common/lib/xmodule/xmodule/tests/test_html_module.py
@@ -33,7 +33,6 @@ class HtmlModuleCourseApiTestCase(unittest.TestCase):
     """
     Test the HTML XModule's student_view_data method.
     """
-    shard = 1
 
     @ddt.data(
         dict(),
@@ -101,7 +100,6 @@ class HtmlModuleCourseApiTestCase(unittest.TestCase):
 
 class HtmlModuleSubstitutionTestCase(unittest.TestCase):
     descriptor = Mock()
-    shard = 1
 
     def test_substitution_works(self):
         sample_xml = '''%%USER_ID%%'''
@@ -134,7 +132,6 @@ class HtmlDescriptorIndexingTestCase(unittest.TestCase):
     """
     Make sure that HtmlDescriptor can format data for indexing as expected.
     """
-    shard = 1
 
     def test_index_dictionary_simple_html_module(self):
         sample_xml = '''
@@ -227,7 +224,6 @@ class CourseInfoModuleTestCase(unittest.TestCase):
     """
     Make sure that CourseInfoModule renders updates properly.
     """
-    shard = 1
 
     def test_updates_render(self):
         """

--- a/common/lib/xmodule/xmodule/tests/test_import.py
+++ b/common/lib/xmodule/xmodule/tests/test_import.py
@@ -65,7 +65,6 @@ class DummySystem(ImportSystem):
 
 class BaseCourseTestCase(TestCase):
     '''Make sure module imports work properly, including for malformed inputs'''
-    shard = 1
 
     @staticmethod
     def get_system(load_error_modules=True, library=False):
@@ -99,7 +98,6 @@ class PureXBlockImportTest(BaseCourseTestCase):
     """
     Tests of import pure XBlocks (not XModules) from xml
     """
-    shard = 1
 
     def assert_xblocks_are_good(self, block):
         """Assert a number of conditions that must be true for `block` to be good."""
@@ -127,7 +125,6 @@ class PureXBlockImportTest(BaseCourseTestCase):
 
 
 class ImportTestCase(BaseCourseTestCase):
-    shard = 1
     date = Date()
 
     def test_fallback(self):

--- a/common/lib/xmodule/xmodule/tests/test_import_static.py
+++ b/common/lib/xmodule/xmodule/tests/test_import_static.py
@@ -14,7 +14,6 @@ from xmodule.modulestore.tests.utils import (
 
 class IgnoredFilesTestCase(unittest.TestCase):
     "Tests for ignored files"
-    shard = 1
     course_dir = DATA_DIR / "course_ignore"
     dict_list = [DOT_FILES_DICT, TILDA_FILES_DICT]
 

--- a/common/lib/xmodule/xmodule/tests/test_library_content.py
+++ b/common/lib/xmodule/xmodule/tests/test_library_content.py
@@ -71,7 +71,6 @@ class LibraryContentModuleTestMixin(object):
     """
     Basic unit tests for LibraryContentModule
     """
-    shard = 1
     problem_types = [
         ["multiplechoiceresponse"], ["optionresponse"], ["optionresponse", "coderesponse"],
         ["coderesponse", "optionresponse"]
@@ -324,7 +323,6 @@ class TestLibraryContentRender(LibraryContentTest):
     """
     Rendering unit tests for LibraryContentModule
     """
-    shard = 1
 
     def test_preview_view(self):
         """ Test preview view rendering """
@@ -350,7 +348,6 @@ class TestLibraryContentAnalytics(LibraryContentTest):
     """
     Test analytics features of LibraryContentModule
     """
-    shard = 1
 
     def setUp(self):
         super(TestLibraryContentAnalytics, self).setUp()

--- a/common/lib/xmodule/xmodule/tests/test_library_root.py
+++ b/common/lib/xmodule/xmodule/tests/test_library_root.py
@@ -24,7 +24,6 @@ class TestLibraryRoot(MixedSplitTestCase):
     """
     Basic unit tests for LibraryRoot (library_root_xblock.py)
     """
-    shard = 1
 
     def test_library_author_view(self):
         """

--- a/common/lib/xmodule/xmodule/tests/test_library_tools.py
+++ b/common/lib/xmodule/xmodule/tests/test_library_tools.py
@@ -11,7 +11,6 @@ class LibraryToolsServiceTest(MixedSplitTestCase):
     """
     Tests for library service.
     """
-    shard = 1
 
     def setUp(self):
         super(LibraryToolsServiceTest, self).setUp()

--- a/common/lib/xmodule/xmodule/tests/test_lti20_unit.py
+++ b/common/lib/xmodule/xmodule/tests/test_lti20_unit.py
@@ -13,7 +13,6 @@ from . import LogicTest
 
 class LTI20RESTResultServiceTest(LogicTest):
     """Logic tests for LTI module. LTI2.0 REST ResultService"""
-    shard = 1
     descriptor_class = LTIDescriptor
 
     def setUp(self):

--- a/common/lib/xmodule/xmodule/tests/test_lti_unit.py
+++ b/common/lib/xmodule/xmodule/tests/test_lti_unit.py
@@ -20,7 +20,6 @@ from . import LogicTest
 
 class LTIModuleTest(LogicTest):
     """Logic tests for LTI module."""
-    shard = 1
     descriptor_class = LTIDescriptor
 
     def setUp(self):

--- a/common/lib/xmodule/xmodule/tests/test_mako_module.py
+++ b/common/lib/xmodule/xmodule/tests/test_mako_module.py
@@ -8,7 +8,6 @@ from xmodule.mako_module import MakoModuleDescriptor
 
 class MakoModuleTest(TestCase):
     """ Test MakoModuleDescriptor """
-    shard = 1
 
     def test_render_template_check(self):
         mock_system = Mock()

--- a/common/lib/xmodule/xmodule/tests/test_mongo_utils.py
+++ b/common/lib/xmodule/xmodule/tests/test_mongo_utils.py
@@ -16,7 +16,6 @@ class MongoUtilsTests(TestCase):
     """
     Tests for methods exposed in mongo_utils
     """
-    shard = 1
 
     @ddt.data(
         ('PRIMARY', 'primary', ReadPreference.PRIMARY),

--- a/common/lib/xmodule/xmodule/tests/test_poll.py
+++ b/common/lib/xmodule/xmodule/tests/test_poll.py
@@ -9,7 +9,6 @@ from .test_import import DummySystem
 
 class PollModuleTest(LogicTest):
     """Logic tests for Poll Xmodule."""
-    shard = 1
     descriptor_class = PollDescriptor
     raw_field_data = {
         'poll_answers': {'Yes': 1, 'Dont_know': 0, 'No': 0},

--- a/common/lib/xmodule/xmodule/tests/test_progress.py
+++ b/common/lib/xmodule/xmodule/tests/test_progress.py
@@ -15,7 +15,6 @@ class ProgressTest(unittest.TestCase):
     ''' Test that basic Progress objects work.  A Progress represents a
     fraction between 0 and 1.
     '''
-    shard = 1
     not_started = Progress(0, 17)
     part_done = Progress(2, 6)
     half_done = Progress(3, 6)
@@ -118,7 +117,6 @@ class ProgressTest(unittest.TestCase):
 class ModuleProgressTest(unittest.TestCase):
     ''' Test that get_progress() does the right thing for the different modules
     '''
-    shard = 1
 
     def test_xmodule_default(self):
         '''Make sure default get_progress exists, returns None'''

--- a/common/lib/xmodule/xmodule/tests/test_randomize_module.py
+++ b/common/lib/xmodule/xmodule/tests/test_randomize_module.py
@@ -23,7 +23,6 @@ _NEXT_WEEK = _TODAY + timedelta(days=7)
 
 class RandomizeModuleTestCase(unittest.TestCase):
     """Make sure the randomize module works"""
-    shard = 1
 
     def setUp(self):
         """

--- a/common/lib/xmodule/xmodule/tests/test_resource_templates.py
+++ b/common/lib/xmodule/xmodule/tests/test_resource_templates.py
@@ -10,7 +10,6 @@ class ResourceTemplatesTests(unittest.TestCase):
     """
     Tests for xmodule.x_module.ResourceTemplates
     """
-    shard = 1
 
     def test_templates(self):
         expected = set([

--- a/common/lib/xmodule/xmodule/tests/test_sequence.py
+++ b/common/lib/xmodule/xmodule/tests/test_sequence.py
@@ -26,7 +26,6 @@ class SequenceBlockTestCase(XModuleXmlImportTest):
     """
     Base class for tests of Sequence Module.
     """
-    shard = 1
 
     def setUp(self):
         super(SequenceBlockTestCase, self).setUp()

--- a/common/lib/xmodule/xmodule/tests/test_services.py
+++ b/common/lib/xmodule/xmodule/tests/test_services.py
@@ -37,7 +37,6 @@ class DummyUnexpected(object):
 @ddt.ddt
 class TestSettingsService(TestCase):
     """ Test SettingsService """
-    shard = 1
 
     xblock_setting_key1 = 'dummy_block'
     xblock_setting_key2 = 'other_dummy_block'
@@ -99,7 +98,6 @@ class TestConfigurationService(TestCase):
     """
     Tests for ConfigurationService
     """
-    shard = 1
 
     def test_given_unexpected_class_throws_value_error(self):
         """

--- a/common/lib/xmodule/xmodule/tests/test_split_test_module.py
+++ b/common/lib/xmodule/xmodule/tests/test_split_test_module.py
@@ -27,7 +27,6 @@ class SplitTestUtilitiesTest(PartitionTestCase):
     """
     Tests for utility methods related to split_test module.
     """
-    shard = 1
 
     def test_split_user_partitions(self):
         """
@@ -125,7 +124,6 @@ class SplitTestModuleLMSTest(SplitTestModuleTest):
     """
     Test the split test module
     """
-    shard = 1
 
     def setUp(self):
         super(SplitTestModuleLMSTest, self).setUp()
@@ -194,7 +192,6 @@ class SplitTestModuleStudioTest(SplitTestModuleTest):
     """
     Unit tests for how split test interacts with Studio.
     """
-    shard = 1
 
     @patch('xmodule.split_test_module.SplitTestDescriptor.group_configuration_url', return_value='http://example.com')
     def test_render_author_view(self, group_configuration_url):

--- a/common/lib/xmodule/xmodule/tests/test_stringify.py
+++ b/common/lib/xmodule/xmodule/tests/test_stringify.py
@@ -3,11 +3,9 @@ Tests stringify functions used in xmodule html
 """
 from __future__ import print_function
 from lxml import etree
-from openedx.core.lib.tests import attr
 from xmodule.stringify import stringify_children
 
 
-@attr(shard=1)
 def test_stringify():
     text = 'Hi <div x="foo">there <span>Bruce</span><b>!</b></div>'
     html = '''<html a="b" foo="bar">{0}</html>'''.format(text)
@@ -16,7 +14,6 @@ def test_stringify():
     assert out == text
 
 
-@attr(shard=1)
 def test_stringify_again():
     html = r"""<html name="Voltage Source Answer" >A voltage source is non-linear!
 <div align="center">

--- a/common/lib/xmodule/xmodule/tests/test_studio_editable.py
+++ b/common/lib/xmodule/xmodule/tests/test_studio_editable.py
@@ -10,7 +10,6 @@ class StudioEditableModuleTestCase(BaseVerticalBlockTest):
     """
     Class containing StudioEditableModule tests.
     """
-    shard = 1
 
     def test_render_reorderable_children(self):
         """

--- a/common/lib/xmodule/xmodule/tests/test_util_duedate.py
+++ b/common/lib/xmodule/xmodule/tests/test_util_duedate.py
@@ -11,7 +11,6 @@ class TestGetExtendedDueDate(unittest.TestCase):
     """
     Test `get_extended_due_date` function.
     """
-    shard = 1
 
     def call_fut(self, node):
         """

--- a/common/lib/xmodule/xmodule/tests/test_utils_django.py
+++ b/common/lib/xmodule/xmodule/tests/test_utils_django.py
@@ -7,7 +7,6 @@ class UtilDjangoTests(TestCase):
     """
     Tests for methods exposed in util/django
     """
-    shard = 1
 
     def test_get_current_request(self):
         """

--- a/common/lib/xmodule/xmodule/tests/test_utils_escape_html_characters.py
+++ b/common/lib/xmodule/xmodule/tests/test_utils_escape_html_characters.py
@@ -7,7 +7,6 @@ class UtilHtmlEscapeTests(TestCase):
     """
     Tests for methods exposed in util/misc
     """
-    shard = 1
 
     final_content = " This is a paragraph. "
 

--- a/common/lib/xmodule/xmodule/tests/test_validation.py
+++ b/common/lib/xmodule/xmodule/tests/test_validation.py
@@ -14,7 +14,6 @@ class StudioValidationMessageTest(unittest.TestCase):
     """
     Tests for `ValidationMessage`
     """
-    shard = 1
 
     def test_bad_parameters(self):
         """
@@ -74,7 +73,6 @@ class StudioValidationTest(unittest.TestCase):
     """
     Tests for `StudioValidation` class.
     """
-    shard = 1
 
     def test_copy(self):
         validation = Validation("id")

--- a/common/lib/xmodule/xmodule/tests/test_vertical.py
+++ b/common/lib/xmodule/xmodule/tests/test_vertical.py
@@ -107,7 +107,6 @@ class VerticalBlockTestCase(BaseVerticalBlockTest):
     """
     Tests for the VerticalBlock.
     """
-    shard = 1
 
     def assert_bookmark_info(self, assertion, content):
         """

--- a/common/lib/xmodule/xmodule/tests/test_video.py
+++ b/common/lib/xmodule/xmodule/tests/test_video.py
@@ -121,7 +121,6 @@ class _MockValCannotCreateError(Exception):
 
 class VideoModuleTest(LogicTest):
     """Logic tests for Video Xmodule."""
-    shard = 1
     descriptor_class = VideoDescriptor
 
     raw_field_data = {
@@ -203,7 +202,6 @@ class VideoDescriptorTestBase(unittest.TestCase):
     """
     Base class for tests for VideoDescriptor
     """
-    shard = 1
 
     def setUp(self):
         super(VideoDescriptorTestBase, self).setUp()
@@ -229,7 +227,6 @@ class TestCreateYoutubeString(VideoDescriptorTestBase):
     """
     Checks that create_youtube_string correcty extracts information from Video descriptor.
     """
-    shard = 1
 
     def test_create_youtube_string(self):
         """
@@ -257,7 +254,6 @@ class TestCreateYouTubeUrl(VideoDescriptorTestBase):
     """
     Tests for helper method `create_youtube_url`.
     """
-    shard = 1
 
     def test_create_youtube_url_unicode(self):
         """
@@ -272,7 +268,6 @@ class VideoDescriptorImportTestCase(TestCase):
     """
     Make sure that VideoDescriptor can import an old XML-based video correctly.
     """
-    shard = 1
 
     def assert_attributes_equal(self, video, attrs):
         """
@@ -702,7 +697,6 @@ class VideoExportTestCase(VideoDescriptorTestBase):
     """
     Make sure that VideoDescriptor can export itself to XML correctly.
     """
-    shard = 1
 
     def setUp(self):
         super(VideoExportTestCase, self).setUp()
@@ -860,7 +854,6 @@ class VideoDescriptorStudentViewDataTestCase(unittest.TestCase):
     """
     Make sure that VideoDescriptor returns the expected student_view_data.
     """
-    shard = 1
 
     VIDEO_URL_1 = 'http://www.example.com/source_low.mp4'
     VIDEO_URL_2 = 'http://www.example.com/source_med.mp4'
@@ -1013,7 +1006,6 @@ class VideoDescriptorIndexingTestCase(unittest.TestCase):
     """
     Make sure that VideoDescriptor can format data for indexing as expected.
     """
-    shard = 1
 
     def test_video_with_no_subs_index_dictionary(self):
         """

--- a/common/lib/xmodule/xmodule/tests/test_word_cloud.py
+++ b/common/lib/xmodule/xmodule/tests/test_word_cloud.py
@@ -8,7 +8,6 @@ from . import LogicTest
 
 class WordCloudModuleTest(LogicTest):
     """Logic tests for Word Cloud Xmodule."""
-    shard = 1
     descriptor_class = WordCloudDescriptor
     raw_field_data = {
         'all_words': {'cat': 10, 'dog': 5, 'mom': 1, 'dad': 2},

--- a/common/lib/xmodule/xmodule/tests/test_xblock_wrappers.py
+++ b/common/lib/xmodule/xmodule/tests/test_xblock_wrappers.py
@@ -265,7 +265,6 @@ class XBlockWrapperTestMixin(object):
     You can create an actual test case by inheriting from this class and UnitTest,
     and implement skip_if_invalid and check_property.
     """
-    shard = 1
 
     def skip_if_invalid(self, descriptor_cls):
         """
@@ -324,7 +323,6 @@ class TestStudentView(XBlockWrapperTestMixin, TestCase):
     """
     This tests that student_view and XModule.get_html produce the same results.
     """
-    shard = 1
 
     def skip_if_invalid(self, descriptor_cls):
         pure_xblock_class = issubclass(descriptor_cls, XBlock) and not issubclass(descriptor_cls, XModuleDescriptor)
@@ -349,7 +347,6 @@ class TestStudioView(XBlockWrapperTestMixin, TestCase):
     """
     This tests that studio_view and XModuleDescriptor.get_html produce the same results
     """
-    shard = 1
 
     def skip_if_invalid(self, descriptor_cls):
         if descriptor_cls in NOT_STUDIO_EDITABLE:
@@ -375,7 +372,6 @@ class TestXModuleHandler(TestCase):
     """
     Tests that the xmodule_handler function correctly wraps handle_ajax
     """
-    shard = 1
 
     def setUp(self):
         super(TestXModuleHandler, self).setUp()
@@ -416,7 +412,6 @@ class TestXmlExport(XBlockWrapperTestMixin, TestCase):
     """
     This tests that XModuleDescriptor.export_course_to_xml and add_xml_to_node produce the same results.
     """
-    shard = 1
 
     def skip_if_invalid(self, descriptor_cls):
         if descriptor_cls.add_xml_to_node != XModuleDescriptor.add_xml_to_node:
@@ -440,7 +435,6 @@ class TestPublicView(XBlockWrapperTestMixin, TestCase):
     """
     This tests that default public_view shows the correct message.
     """
-    shard = 1
 
     def skip_if_invalid(self, descriptor_cls):
         pure_xblock_class = issubclass(descriptor_cls, XBlock) and not issubclass(descriptor_cls, XModuleDescriptor)

--- a/common/lib/xmodule/xmodule/tests/test_xml_module.py
+++ b/common/lib/xmodule/xmodule/tests/test_xml_module.py
@@ -64,7 +64,6 @@ class InheritingFieldDataTest(unittest.TestCase):
     """
     Tests of InheritingFieldData.
     """
-    shard = 1
 
     class TestableInheritingXBlock(XmlDescriptor):
         """
@@ -228,7 +227,6 @@ class InheritingFieldDataTest(unittest.TestCase):
 
 
 class EditableMetadataFieldsTest(unittest.TestCase):
-    shard = 1
 
     def test_display_name_field(self):
         editable_fields = self.get_xml_editable_fields(DictFieldData({}))
@@ -372,7 +370,6 @@ class EditableMetadataFieldsTest(unittest.TestCase):
 
 class TestSerialize(unittest.TestCase):
     """ Tests the serialize, method, which is not dependent on type. """
-    shard = 1
 
     def test_serialize(self):
         assert serialize_field(None) == 'null'
@@ -392,7 +389,6 @@ class TestSerialize(unittest.TestCase):
 
 
 class TestDeserialize(unittest.TestCase):
-    shard = 1
 
     def assertDeserializeEqual(self, expected, arg):
         """
@@ -417,7 +413,6 @@ class TestDeserialize(unittest.TestCase):
 class TestDeserializeInteger(TestDeserialize):
     """ Tests deserialize as related to Integer type. """
 
-    shard = 1
     field_type = Integer
 
     def test_deserialize(self):
@@ -442,7 +437,6 @@ class TestDeserializeInteger(TestDeserialize):
 
 class TestDeserializeFloat(TestDeserialize):
     """ Tests deserialize as related to Float type. """
-    shard = 1
 
     field_type = Float
 
@@ -466,7 +460,6 @@ class TestDeserializeFloat(TestDeserialize):
 
 class TestDeserializeBoolean(TestDeserialize):
     """ Tests deserialize as related to Boolean type. """
-    shard = 1
 
     field_type = Boolean
 
@@ -492,7 +485,6 @@ class TestDeserializeBoolean(TestDeserialize):
 
 class TestDeserializeString(TestDeserialize):
     """ Tests deserialize as related to String type. """
-    shard = 1
 
     field_type = String
 
@@ -511,7 +503,6 @@ class TestDeserializeString(TestDeserialize):
 
 class TestDeserializeAny(TestDeserialize):
     """ Tests deserialize as related to Any type. """
-    shard = 1
 
     field_type = Any
 
@@ -528,7 +519,6 @@ class TestDeserializeAny(TestDeserialize):
 
 class TestDeserializeList(TestDeserialize):
     """ Tests deserialize as related to List type. """
-    shard = 1
 
     field_type = List
 
@@ -546,7 +536,6 @@ class TestDeserializeList(TestDeserialize):
 
 class TestDeserializeDate(TestDeserialize):
     """ Tests deserialize as related to Date type. """
-    shard = 1
 
     field_type = Date
 
@@ -558,7 +547,6 @@ class TestDeserializeDate(TestDeserialize):
 
 class TestDeserializeTimedelta(TestDeserialize):
     """ Tests deserialize as related to Timedelta type. """
-    shard = 1
 
     field_type = Timedelta
 
@@ -576,7 +564,6 @@ class TestDeserializeTimedelta(TestDeserialize):
 
 class TestDeserializeRelativeTime(TestDeserialize):
     """ Tests deserialize as related to Timedelta type. """
-    shard = 1
 
     field_type = RelativeTime
 
@@ -598,7 +585,6 @@ class TestDeserializeRelativeTime(TestDeserialize):
 
 
 class TestXmlAttributes(XModuleXmlImportTest):
-    shard = 1
 
     def test_unknown_attribute(self):
         assert not hasattr(CourseDescriptor, 'unknown_attr')

--- a/common/lib/xmodule/xmodule/tests/xml/test_inheritance.py
+++ b/common/lib/xmodule/xmodule/tests/xml/test_inheritance.py
@@ -8,9 +8,7 @@ from xmodule.tests.xml.factories import CourseFactory, SequenceFactory, ProblemF
 class TestInheritedFieldParsing(XModuleXmlImportTest):
     """
     Test that inherited fields work correctly when parsing XML
-
     """
-    shard = 2
 
     def test_null_string(self):
         # Test that the string inherited fields are passed through 'deserialize_field',

--- a/common/lib/xmodule/xmodule/tests/xml/test_policy.py
+++ b/common/lib/xmodule/xmodule/tests/xml/test_policy.py
@@ -12,7 +12,6 @@ class TestPolicy(XModuleXmlImportTest):
     """
     Tests that policy json files import correctly when loading xml
     """
-    shard = 2
 
     def test_no_attribute_mapping(self):
         # Policy files are json, and thus the values aren't passed through 'deserialize_field'

--- a/openedx/core/djangoapps/bookmarks/tests/test_api.py
+++ b/openedx/core/djangoapps/bookmarks/tests/test_api.py
@@ -41,7 +41,6 @@ class BookmarksAPITests(BookmarkApiEventTestMixin, BookmarksTestsBase):
     """
     These tests cover the parts of the API methods.
     """
-    shard = 9
 
     def test_get_bookmark(self):
         """

--- a/openedx/core/djangoapps/bookmarks/tests/test_models.py
+++ b/openedx/core/djangoapps/bookmarks/tests/test_models.py
@@ -229,7 +229,6 @@ class BookmarkModelTests(BookmarksTestsBase):
     """
     Test the Bookmark model.
     """
-    shard = 9
 
     def setUp(self):
         super(BookmarkModelTests, self).setUp()
@@ -415,7 +414,6 @@ class XBlockCacheModelTest(ModuleStoreTestCase):
     """
     Test the XBlockCache model.
     """
-    shard = 9
     COURSE_KEY = CourseLocator(org='test', course='test', run='test')
     CHAPTER1_USAGE_KEY = BlockUsageLocator(COURSE_KEY, block_type='chapter', block_id='chapter1')
     SECTION1_USAGE_KEY = BlockUsageLocator(COURSE_KEY, block_type='section', block_id='section1')

--- a/openedx/core/djangoapps/bookmarks/tests/test_services.py
+++ b/openedx/core/djangoapps/bookmarks/tests/test_services.py
@@ -14,7 +14,6 @@ class BookmarksServiceTests(BookmarksTestsBase):
     """
     Tests the Bookmarks service.
     """
-    shard = 9
 
     def setUp(self):
         super(BookmarksServiceTests, self).setUp()

--- a/openedx/core/djangoapps/bookmarks/tests/test_tasks.py
+++ b/openedx/core/djangoapps/bookmarks/tests/test_tasks.py
@@ -15,7 +15,6 @@ class XBlockCacheTaskTests(BookmarksTestsBase):
     """
     Test the XBlockCache model.
     """
-    shard = 9
 
     def setUp(self):
         super(XBlockCacheTaskTests, self).setUp()

--- a/openedx/core/djangoapps/bookmarks/tests/test_views.py
+++ b/openedx/core/djangoapps/bookmarks/tests/test_views.py
@@ -68,7 +68,6 @@ class BookmarksListViewTests(BookmarksViewsTestsBase):
     GET /api/bookmarks/v1/bookmarks/?course_id={course_id1}
     POST /api/bookmarks/v1/bookmarks
     """
-    shard = 9
 
     @ddt.data(
         (1, False),
@@ -372,7 +371,6 @@ class BookmarksDetailViewTests(BookmarksViewsTestsBase):
     """
     This contains the tests for GET & DELETE methods of bookmark.views.BookmarksDetailView class
     """
-    shard = 9
 
     @ddt.data(
         ('', False),

--- a/openedx/core/djangoapps/ccxcon/tests/test_api.py
+++ b/openedx/core/djangoapps/ccxcon/tests/test_api.py
@@ -42,7 +42,6 @@ class APIsTestCase(SharedModuleStoreTestCase):
     Unit tests for the API module functions
     """
     MODULESTORE = TEST_DATA_SPLIT_MODULESTORE
-    shard = 1
 
     @classmethod
     def setUpClass(cls):

--- a/openedx/core/djangoapps/ccxcon/tests/test_signals.py
+++ b/openedx/core/djangoapps/ccxcon/tests/test_signals.py
@@ -15,7 +15,6 @@ class CCXConSignalTestCase(TestCase):
     the call for the ccxcon update are performed correctly by the
     course_published signal handler
     """
-    shard = 2
 
     @mock.patch('openedx.core.djangoapps.ccxcon.tasks.update_ccxcon.delay')
     def test_course_published_ccxcon_call(self, mock_upc):

--- a/openedx/core/djangoapps/ccxcon/tests/test_tasks.py
+++ b/openedx/core/djangoapps/ccxcon/tests/test_tasks.py
@@ -14,7 +14,6 @@ class CCXConTaskTestCase(TestCase):
     """
     Tests for CCXCon tasks.
     """
-    shard = 2
 
     @mock.patch('openedx.core.djangoapps.ccxcon.api.course_info_to_ccxcon')
     def test_update_ccxcon_task_ok(self, mock_citc):

--- a/openedx/core/djangoapps/content/block_structure/tests/test_block_structure.py
+++ b/openedx/core/djangoapps/content/block_structure/tests/test_block_structure.py
@@ -22,7 +22,6 @@ class TestBlockStructure(TestCase, ChildrenMapTestMixin):
     """
     Tests for BlockStructure
     """
-    shard = 2
 
     @ddt.data(
         [],
@@ -52,7 +51,6 @@ class TestBlockStructureData(TestCase, ChildrenMapTestMixin):
     """
     Tests for BlockStructureBlockData and BlockStructureModulestoreData
     """
-    shard = 2
 
     def test_non_versioned_transformer(self):
         class TestNonVersionedTransformer(MockTransformer):

--- a/openedx/core/djangoapps/content/block_structure/tests/test_factory.py
+++ b/openedx/core/djangoapps/content/block_structure/tests/test_factory.py
@@ -16,7 +16,6 @@ class TestBlockStructureFactory(TestCase, ChildrenMapTestMixin):
     """
     Tests for BlockStructureFactory
     """
-    shard = 2
 
     def setUp(self):
         super(TestBlockStructureFactory, self).setUp()

--- a/openedx/core/djangoapps/content/block_structure/tests/test_manager.py
+++ b/openedx/core/djangoapps/content/block_structure/tests/test_manager.py
@@ -93,7 +93,6 @@ class TestBlockStructureManager(UsageKeyFactoryMixin, ChildrenMapTestMixin, Test
     """
     Test class for BlockStructureManager.
     """
-    shard = 2
 
     def setUp(self):
         super(TestBlockStructureManager, self).setUp()

--- a/openedx/core/djangoapps/content/block_structure/tests/test_store.py
+++ b/openedx/core/djangoapps/content/block_structure/tests/test_store.py
@@ -18,7 +18,6 @@ class TestBlockStructureStore(UsageKeyFactoryMixin, ChildrenMapTestMixin, CacheI
     Tests for BlockStructureStore
     """
     ENABLED_CACHES = ['default']
-    shard = 2
 
     def setUp(self):
         super(TestBlockStructureStore, self).setUp()

--- a/openedx/core/djangoapps/content/block_structure/tests/test_transformer_registry.py
+++ b/openedx/core/djangoapps/content/block_structure/tests/test_transformer_registry.py
@@ -35,7 +35,6 @@ class TransformerRegistryTestCase(TestCase):
     """
     Test cases for TransformerRegistry.
     """
-    shard = 2
 
     def tearDown(self):
         super(TransformerRegistryTestCase, self).tearDown()

--- a/openedx/core/djangoapps/content/block_structure/tests/test_transformers.py
+++ b/openedx/core/djangoapps/content/block_structure/tests/test_transformers.py
@@ -16,7 +16,6 @@ class TestBlockStructureTransformers(ChildrenMapTestMixin, TestCase):
     """
     Test class for testing BlockStructureTransformers
     """
-    shard = 2
 
     class UnregisteredTransformer(MockTransformer):
         """

--- a/openedx/core/djangoapps/content/course_overviews/management/commands/tests/test_generate_course_overview.py
+++ b/openedx/core/djangoapps/content/course_overviews/management/commands/tests/test_generate_course_overview.py
@@ -15,7 +15,6 @@ class TestGenerateCourseOverview(ModuleStoreTestCase):
     """
     Tests course overview management command.
     """
-    shard = 2
 
     def setUp(self):
         """

--- a/openedx/core/djangoapps/content/course_overviews/tests/test_course_overviews.py
+++ b/openedx/core/djangoapps/content/course_overviews/tests/test_course_overviews.py
@@ -46,7 +46,6 @@ class CourseOverviewTestCase(CatalogIntegrationMixin, ModuleStoreTestCase, Cache
     """
     Tests for CourseOverview model.
     """
-    shard = 3
     TODAY = timezone.now()
     LAST_MONTH = 'last_month'
     LAST_WEEK = 'last_week'
@@ -564,7 +563,6 @@ class CourseOverviewImageSetTestCase(ModuleStoreTestCase):
     Course thumbnail generation tests.
     """
     ENABLED_SIGNALS = ['course_published']
-    shard = 3
 
     def setUp(self):
         """Create an active CourseOverviewImageConfig with non-default values."""
@@ -1042,7 +1040,6 @@ class CourseOverviewTabTestCase(ModuleStoreTestCase):
     """
     Tests for CourseOverviewTab model.
     """
-    shard = 3
 
     ENABLED_SIGNALS = ['course_published']
 

--- a/openedx/core/djangoapps/content/course_overviews/tests/test_signals.py
+++ b/openedx/core/djangoapps/content/course_overviews/tests/test_signals.py
@@ -17,7 +17,6 @@ class CourseOverviewSignalsTestCase(ModuleStoreTestCase):
     ENABLED_SIGNALS = ['course_deleted', 'course_published']
     TODAY = datetime.datetime.utcnow()
     NEXT_WEEK = TODAY + datetime.timedelta(days=7)
-    shard = 3
 
     @ddt.data(ModuleStoreEnum.Type.mongo, ModuleStoreEnum.Type.split)
     def test_caching(self, modulestore_type):

--- a/openedx/core/djangoapps/course_groups/tests/test_cohorts.py
+++ b/openedx/core/djangoapps/course_groups/tests/test_cohorts.py
@@ -33,7 +33,6 @@ class TestCohortSignals(TestCase):
     """
     Test cases to validate event emissions for various cohort-related workflows
     """
-    shard = 2
 
     def setUp(self):
         super(TestCohortSignals, self).setUp()
@@ -140,7 +139,6 @@ class TestCohorts(ModuleStoreTestCase):
     Test the cohorts feature
     """
     MODULESTORE = TEST_DATA_MIXED_MODULESTORE
-    shard = 2
 
     def setUp(self):
         """
@@ -750,7 +748,6 @@ class TestCohortsAndPartitionGroups(ModuleStoreTestCase):
     Test Cohorts and Partitions Groups.
     """
     MODULESTORE = TEST_DATA_MIXED_MODULESTORE
-    shard = 2
 
     def setUp(self):
         """

--- a/openedx/core/djangoapps/course_groups/tests/test_partition_scheme.py
+++ b/openedx/core/djangoapps/course_groups/tests/test_partition_scheme.py
@@ -14,7 +14,6 @@ from xmodule.modulestore.tests.factories import ToyCourseFactory
 
 from openedx.core.djangoapps.user_api.partition_schemes import RandomUserPartitionScheme
 from openedx.core.djangolib.testing.utils import skip_unless_lms
-from openedx.core.lib.tests import attr
 from ..partition_scheme import CohortPartitionScheme, get_cohorted_user_partition
 from ..models import CourseUserGroupPartitionGroup
 from ..views import link_cohort_to_partition_group, unlink_cohort_partition_group
@@ -22,7 +21,6 @@ from ..cohorts import add_user_to_cohort, remove_user_from_cohort, get_course_co
 from .helpers import CohortFactory, config_course_cohorts
 
 
-@attr(shard=2)
 class TestCohortPartitionScheme(ModuleStoreTestCase):
     """
     Test the logic for linking a user to a partition group based on their cohort.
@@ -256,7 +254,6 @@ class TestCohortPartitionScheme(ModuleStoreTestCase):
             self.assertRegexpMatches(mock_log.warn.call_args[0][0], 'partition mismatch')
 
 
-@attr(shard=2)
 class TestExtension(django.test.TestCase):
     """
     Ensure that the scheme extension is correctly plugged in (via entry point
@@ -269,7 +266,6 @@ class TestExtension(django.test.TestCase):
             UserPartition.get_scheme('other')
 
 
-@attr(shard=2)
 class TestGetCohortedUserPartition(ModuleStoreTestCase):
     """
     Test that `get_cohorted_user_partition` returns the first user_partition with scheme `CohortPartitionScheme`.
@@ -327,7 +323,6 @@ class TestGetCohortedUserPartition(ModuleStoreTestCase):
         self.assertIsNone(get_cohorted_user_partition(self.course))
 
 
-@attr(shard=2)
 class TestMasqueradedGroup(StaffMasqueradeTestCase):
     """
     Check for staff being able to masquerade as belonging to a group.

--- a/openedx/core/djangoapps/course_groups/tests/test_views.py
+++ b/openedx/core/djangoapps/course_groups/tests/test_views.py
@@ -13,7 +13,6 @@ from django_comment_common.models import CourseDiscussionSettings
 from django_comment_common.utils import get_course_discussion_settings
 from lms.djangoapps.courseware.tests.factories import StaffFactory, InstructorFactory
 from opaque_keys.edx.locator import CourseLocator
-from openedx.core.lib.tests import attr
 from student.models import CourseEnrollment
 from student.tests.factories import UserFactory
 from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
@@ -32,7 +31,6 @@ from ..views import (
 from .helpers import CohortFactory, CourseCohortFactory, config_course_cohorts, config_course_cohorts_legacy
 
 
-@attr(shard=2)
 class CohortViewsTestCase(ModuleStoreTestCase):
     """
     Base class which sets up a course and staff/non-staff users.
@@ -144,7 +142,6 @@ class CohortViewsTestCase(ModuleStoreTestCase):
         return json.loads(response.content)
 
 
-@attr(shard=2)
 class CourseCohortSettingsHandlerTestCase(CohortViewsTestCase):
     """
     Tests the `course_cohort_settings_handler` view.
@@ -234,7 +231,6 @@ class CourseCohortSettingsHandlerTestCase(CohortViewsTestCase):
         )
 
 
-@attr(shard=2)
 class CohortHandlerTestCase(CohortViewsTestCase):
     """
     Tests the `cohort_handler` view.
@@ -604,7 +600,6 @@ class CohortHandlerTestCase(CohortViewsTestCase):
         )
 
 
-@attr(shard=2)
 class UsersInCohortTestCase(CohortViewsTestCase):
     """
     Tests the `users_in_cohort` view.
@@ -737,7 +732,6 @@ class UsersInCohortTestCase(CohortViewsTestCase):
         self.request_users_in_cohort(cohort, self.course, -1, should_return_bad_request=True)
 
 
-@attr(shard=2)
 class AddUsersToCohortTestCase(CohortViewsTestCase):
     """
     Tests the `add_users_to_cohort` view.
@@ -1130,7 +1124,6 @@ class AddUsersToCohortTestCase(CohortViewsTestCase):
         )
 
 
-@attr(shard=2)
 class RemoveUserFromCohortTestCase(CohortViewsTestCase):
     """
     Tests the `remove_user_from_cohort` view.

--- a/openedx/core/djangoapps/credentials/tests/test_models.py
+++ b/openedx/core/djangoapps/credentials/tests/test_models.py
@@ -13,7 +13,6 @@ CREDENTIALS_PUBLIC_SERVICE_URL = 'https://credentials.example.com'
 @skip_unless_lms
 class TestCredentialsApiConfig(CredentialsApiConfigMixin, TestCase):
     """Tests covering the CredentialsApiConfig model."""
-    shard = 2
 
     @override_settings(
         CREDENTIALS_INTERNAL_SERVICE_URL=CREDENTIALS_INTERNAL_SERVICE_URL,

--- a/openedx/core/djangoapps/credentials/tests/test_utils.py
+++ b/openedx/core/djangoapps/credentials/tests/test_utils.py
@@ -20,7 +20,6 @@ UTILS_MODULE = 'openedx.core.djangoapps.credentials.utils'
 @mock.patch(UTILS_MODULE + '.get_edx_api_data')
 class TestGetCredentials(CredentialsApiConfigMixin, CacheIsolationTestCase):
     """ Tests for credentials utility functions. """
-    shard = 2
 
     ENABLED_CACHES = ['default']
 

--- a/openedx/core/djangoapps/credit/tests/test_api.py
+++ b/openedx/core/djangoapps/credit/tests/test_api.py
@@ -207,7 +207,6 @@ class CreditRequirementApiTests(CreditApiTestBase):
     """
     Test Python API for credit requirements and eligibility.
     """
-    shard = 2
 
     @ddt.data(
         [
@@ -878,7 +877,6 @@ class CreditProviderIntegrationApiTests(CreditApiTestBase):
     """
     Test Python API for credit provider integration.
     """
-    shard = 2
 
     USER_INFO = {
         "username": "bob",
@@ -1208,7 +1206,6 @@ class CreditProviderIntegrationApiTests(CreditApiTestBase):
 @ddt.ddt
 class CourseApiTests(CreditApiTestBase):
     """Test Python API for course product information."""
-    shard = 2
 
     def setUp(self):
         super(CourseApiTests, self).setUp()

--- a/openedx/core/djangoapps/credit/tests/test_models.py
+++ b/openedx/core/djangoapps/credit/tests/test_models.py
@@ -38,7 +38,6 @@ class CreditEligibilityModelTests(TestCase):
     """
     Tests for credit models used to track credit eligibility.
     """
-    shard = 2
 
     def setUp(self):
         super(CreditEligibilityModelTests, self).setUp()

--- a/openedx/core/djangoapps/credit/tests/test_serializers.py
+++ b/openedx/core/djangoapps/credit/tests/test_serializers.py
@@ -11,7 +11,6 @@ from student.tests.factories import UserFactory
 
 class CreditProviderSerializerTests(TestCase):
     """ CreditProviderSerializer tests. """
-    shard = 2
 
     def test_data(self):
         """ Verify the correct fields are serialized. """
@@ -32,7 +31,6 @@ class CreditProviderSerializerTests(TestCase):
 
 class CreditEligibilitySerializerTests(TestCase):
     """ CreditEligibilitySerializer tests. """
-    shard = 2
 
     def test_data(self):
         """ Verify the correct fields are serialized. """

--- a/openedx/core/djangoapps/credit/tests/test_services.py
+++ b/openedx/core/djangoapps/credit/tests/test_services.py
@@ -20,7 +20,6 @@ class CreditServiceTests(ModuleStoreTestCase):
     """
     Tests for the Credit xBlock service
     """
-    shard = 2
 
     def setUp(self):
         super(CreditServiceTests, self).setUp()

--- a/openedx/core/djangoapps/credit/tests/test_signals.py
+++ b/openedx/core/djangoapps/credit/tests/test_signals.py
@@ -32,7 +32,6 @@ class TestMinGradedRequirementStatus(ModuleStoreTestCase):
     """
     VALID_DUE_DATE = datetime.now(pytz.UTC) + timedelta(days=20)
     EXPIRED_DUE_DATE = datetime.now(pytz.UTC) - timedelta(days=20)
-    shard = 2
 
     DATES = {
         'valid': VALID_DUE_DATE,

--- a/openedx/core/djangoapps/credit/tests/test_signature.py
+++ b/openedx/core/djangoapps/credit/tests/test_signature.py
@@ -16,7 +16,6 @@ class SignatureTest(TestCase):
     """
     Tests for digital signatures.
     """
-    shard = 2
 
     def test_unicode_secret_key(self):
         # Test a key that has type `unicode` but consists of ASCII characters

--- a/openedx/core/djangoapps/credit/tests/test_tasks.py
+++ b/openedx/core/djangoapps/credit/tests/test_tasks.py
@@ -23,7 +23,6 @@ class TestTaskExecution(ModuleStoreTestCase):
     allows us to ensure that when the listener is executed, it is done as
     expected.
     """
-    shard = 2
 
     def mocked_set_credit_requirements(course_key, requirements):  # pylint: disable=no-self-argument, unused-argument
         """Used as a side effect when mocking method credit api method

--- a/openedx/core/djangoapps/credit/tests/test_views.py
+++ b/openedx/core/djangoapps/credit/tests/test_views.py
@@ -26,7 +26,6 @@ from openedx.core.djangoapps.credit.tests.factories import (
 )
 from openedx.core.djangoapps.oauth_dispatch.jwt import create_jwt_for_user
 from openedx.core.djangolib.testing.utils import skip_unless_lms
-from openedx.core.lib.tests import attr
 from student.tests.factories import UserFactory, AdminFactory
 from util.date_utils import to_timestamp
 
@@ -108,7 +107,6 @@ class ReadOnlyMixin(object):
         self.assertEqual(response.status_code, 405)
 
 
-@attr(shard=2)
 @skip_unless_lms
 class CreditCourseViewSetTests(AuthMixin, UserMixin, TestCase):
     """ Tests for the CreditCourse endpoints.
@@ -270,7 +268,6 @@ class CreditCourseViewSetTests(AuthMixin, UserMixin, TestCase):
         self.assertTrue(credit_course.enabled)
 
 
-@attr(shard=2)
 @ddt.ddt
 @skip_unless_lms
 class CreditProviderViewSetTests(ApiTestCaseMixin, ReadOnlyMixin, AuthMixin, UserMixin, TestCase):
@@ -315,7 +312,6 @@ class CreditProviderViewSetTests(ApiTestCaseMixin, ReadOnlyMixin, AuthMixin, Use
         self.assertEqual(response.data, CreditProviderSerializer(self.bayside).data)
 
 
-@attr(shard=2)
 @skip_unless_lms
 class CreditProviderRequestCreateViewTests(ApiTestCaseMixin, UserMixin, TestCase):
     """ Tests for CreditProviderRequestCreateView. """
@@ -464,7 +460,6 @@ class CreditProviderRequestCreateViewTests(ApiTestCaseMixin, UserMixin, TestCase
         self.assertEqual(response.status_code, 400)
 
 
-@attr(shard=2)
 @ddt.ddt
 @skip_unless_lms
 class CreditProviderCallbackViewTests(UserMixin, TestCase):
@@ -622,7 +617,6 @@ class CreditProviderCallbackViewTests(UserMixin, TestCase):
             self.assertEqual(response.status_code, 403)
 
 
-@attr(shard=2)
 @ddt.ddt
 @skip_unless_lms
 class CreditEligibilityViewTests(AuthMixin, UserMixin, ReadOnlyMixin, TestCase):

--- a/openedx/core/djangoapps/embargo/tests/test_api.py
+++ b/openedx/core/djangoapps/embargo/tests/test_api.py
@@ -43,7 +43,6 @@ MODULESTORE_CONFIG = mixed_store_config(settings.COMMON_TEST_DATA_ROOT, {})
 @mock.patch.dict(settings.FEATURES, {'EMBARGO': True})
 class EmbargoCheckAccessApiTests(ModuleStoreTestCase):
     """Test the embargo API calls to determine whether a user has access. """
-    shard = 3
     ENABLED_CACHES = ['default', 'mongo_metadata_inheritance', 'loc_cache']
 
     def setUp(self):

--- a/openedx/core/djangoapps/embargo/tests/test_middleware.py
+++ b/openedx/core/djangoapps/embargo/tests/test_middleware.py
@@ -34,7 +34,6 @@ class EmbargoMiddlewareAccessTests(UrlResetMixin, ModuleStoreTestCase):
     PASSWORD = 'secret'
 
     URLCONF_MODULES = ['openedx.core.djangoapps.embargo']
-    shard = 3
 
     @patch.dict(settings.FEATURES, {'EMBARGO': True})
     def setUp(self):

--- a/openedx/core/djangoapps/external_auth/tests/test_shib.py
+++ b/openedx/core/djangoapps/external_auth/tests/test_shib.py
@@ -81,7 +81,6 @@ class ShibSPTest(CacheIsolationTestCase):
     Tests for the Shibboleth SP, which communicates via request.META
     (Apache environment variables set by mod_shib)
     """
-    shard = 3
 
     ENABLED_CACHES = ['default']
 

--- a/openedx/core/djangoapps/models/tests/test_course_details.py
+++ b/openedx/core/djangoapps/models/tests/test_course_details.py
@@ -18,7 +18,6 @@ class CourseDetailsTestCase(ModuleStoreTestCase):
     """
     Tests the first course settings page (course dates, overview, etc.).
     """
-    shard = 2
 
     def setUp(self):
         super(CourseDetailsTestCase, self).setUp()

--- a/openedx/core/djangoapps/profile_images/tests/test_images.py
+++ b/openedx/core/djangoapps/profile_images/tests/test_images.py
@@ -39,7 +39,6 @@ class TestValidateUploadedImage(TestCase):
             valid_file_types=_get_valid_file_types()
         )
     )
-    shard = 2
 
     def check_validation_result(self, uploaded_file, expected_failure_message):
         """
@@ -130,7 +129,6 @@ class TestGenerateProfileImages(TestCase):
     """
     Test create_profile_images
     """
-    shard = 2
 
     def check_exif_orientation(self, image, expected_orientation):
         """
@@ -227,7 +225,6 @@ class TestRemoveProfileImages(TestCase):
     """
     Test remove_profile_images
     """
-    shard = 2
 
     def test_remove(self):
         """

--- a/openedx/core/djangoapps/profile_images/tests/test_views.py
+++ b/openedx/core/djangoapps/profile_images/tests/test_views.py
@@ -22,7 +22,6 @@ from openedx.core.djangoapps.user_api.accounts.image_helpers import (
     get_profile_image_storage,
 )
 from openedx.core.djangolib.testing.utils import skip_unless_lms
-from openedx.core.lib.tests import attr
 
 from ..images import create_profile_images, ImageValidationError
 from ..views import LOG_MESSAGE_CREATE, LOG_MESSAGE_DELETE
@@ -116,7 +115,6 @@ class ProfileImageEndpointMixin(UserSettingsEventTestMixin):
         self.assert_no_events_were_emitted()
 
 
-@attr(shard=2)
 @skip_unless_lms
 @mock.patch('openedx.core.djangoapps.profile_images.views.log')
 class ProfileImageViewGeneralTestCase(ProfileImageEndpointMixin, APITestCase):
@@ -136,7 +134,6 @@ class ProfileImageViewGeneralTestCase(ProfileImageEndpointMixin, APITestCase):
         self.assert_no_events_were_emitted()
 
 
-@attr(shard=2)
 @ddt.ddt
 @skip_unless_lms
 @mock.patch('openedx.core.djangoapps.profile_images.views.log')
@@ -359,7 +356,6 @@ class ProfileImageViewPostTestCase(ProfileImageEndpointMixin, APITestCase):
         self.assert_no_events_were_emitted()
 
 
-@attr(shard=2)
 @skip_unless_lms
 @mock.patch('openedx.core.djangoapps.profile_images.views.log')
 class ProfileImageViewDeleteTestCase(ProfileImageEndpointMixin, APITestCase):
@@ -490,7 +486,6 @@ class DeprecatedProfileImageTestMixin(ProfileImageEndpointMixin):
         self.assert_no_events_were_emitted()
 
 
-@attr(shard=2)
 @skip_unless_lms
 @mock.patch('openedx.core.djangoapps.profile_images.views.log')
 class DeprecatedProfileImageUploadTestCase(DeprecatedProfileImageTestMixin, APITestCase):
@@ -503,7 +498,6 @@ class DeprecatedProfileImageUploadTestCase(DeprecatedProfileImageTestMixin, APIT
     _replacement_method = 'openedx.core.djangoapps.profile_images.views.ProfileImageView.post'
 
 
-@attr(shard=2)
 @skip_unless_lms
 @mock.patch('openedx.core.djangoapps.profile_images.views.log')
 class DeprecatedProfileImageRemoveTestCase(DeprecatedProfileImageTestMixin, APITestCase):

--- a/openedx/core/djangoapps/programs/tests/test_signals.py
+++ b/openedx/core/djangoapps/programs/tests/test_signals.py
@@ -29,7 +29,6 @@ class CertAwardedReceiverTest(TestCase):
     """
     Tests for the `handle_course_cert_awarded` signal handler function.
     """
-    shard = 2
 
     @property
     def signal_kwargs(self):
@@ -91,7 +90,6 @@ class CertChangedReceiverTest(TestCase):
     """
     Tests for the `handle_course_cert_changed` signal handler function.
     """
-    shard = 2
 
     def setUp(self):
         super(CertChangedReceiverTest, self).setUp()

--- a/openedx/core/djangoapps/programs/tests/test_utils.py
+++ b/openedx/core/djangoapps/programs/tests/test_utils.py
@@ -57,7 +57,6 @@ UTILS_MODULE = 'openedx.core.djangoapps.programs.utils'
 @mock.patch(UTILS_MODULE + '.get_programs')
 class TestProgramProgressMeter(TestCase):
     """Tests of the program progress utility class."""
-    shard = 2
 
     def setUp(self):
         super(TestProgramProgressMeter, self).setUp()

--- a/openedx/core/djangoapps/safe_sessions/tests/test_middleware.py
+++ b/openedx/core/djangoapps/safe_sessions/tests/test_middleware.py
@@ -23,7 +23,6 @@ class TestSafeSessionProcessRequest(TestSafeSessionsLogMixin, TestCase):
     """
     Test class for SafeSessionMiddleware.process_request
     """
-    shard = 2
 
     def setUp(self):
         super(TestSafeSessionProcessRequest, self).setUp()
@@ -127,7 +126,6 @@ class TestSafeSessionProcessResponse(TestSafeSessionsLogMixin, TestCase):
     """
     Test class for SafeSessionMiddleware.process_response
     """
-    shard = 2
 
     def setUp(self):
         super(TestSafeSessionProcessResponse, self).setUp()
@@ -233,7 +231,6 @@ class TestSafeSessionMiddleware(TestSafeSessionsLogMixin, TestCase):
     Test class for SafeSessionMiddleware, testing both
     process_request and process_response.
     """
-    shard = 2
 
     def setUp(self):
         super(TestSafeSessionMiddleware, self).setUp()

--- a/openedx/core/djangoapps/safe_sessions/tests/test_safe_cookie_data.py
+++ b/openedx/core/djangoapps/safe_sessions/tests/test_safe_cookie_data.py
@@ -18,7 +18,6 @@ class TestSafeCookieData(TestSafeSessionsLogMixin, TestCase):
     """
     Test class for SafeCookieData
     """
-    shard = 2
 
     def setUp(self):
         super(TestSafeCookieData, self).setUp()

--- a/openedx/core/djangoapps/schedules/management/commands/tests/test_send_course_update.py
+++ b/openedx/core/djangoapps/schedules/management/commands/tests/test_send_course_update.py
@@ -31,7 +31,6 @@ from xmodule.modulestore.tests.factories import CourseFactory, ItemFactory
     "Can't test schedules if the app isn't installed",
 )
 class TestSendCourseUpdate(ScheduleUpsellTestMixin, ScheduleSendEmailTestMixin, ModuleStoreTestCase):
-    shard = 6
     __test__ = True
 
     # pylint: disable=protected-access

--- a/openedx/core/djangoapps/schedules/management/commands/tests/test_send_email_base_command.py
+++ b/openedx/core/djangoapps/schedules/management/commands/tests/test_send_email_base_command.py
@@ -16,7 +16,6 @@ from openedx.core.djangolib.testing.utils import CacheIsolationTestCase, skip_un
 @skipUnless('openedx.core.djangoapps.schedules.apps.SchedulesConfig' in settings.INSTALLED_APPS,
             "Can't test schedules if the app isn't installed")
 class TestSendEmailBaseCommand(CacheIsolationTestCase):
-    shard = 6
 
     def setUp(self):
         self.command = SendEmailBaseCommand()

--- a/openedx/core/djangoapps/schedules/management/commands/tests/test_send_recurring_nudge.py
+++ b/openedx/core/djangoapps/schedules/management/commands/tests/test_send_recurring_nudge.py
@@ -24,7 +24,6 @@ from openedx.core.djangolib.testing.utils import skip_unless_lms, CacheIsolation
     "Can't test schedules if the app isn't installed",
 )
 class TestSendRecurringNudge(ScheduleUpsellTestMixin, ScheduleSendEmailTestMixin, CacheIsolationTestCase):
-    shard = 6
     __test__ = True
 
     # pylint: disable=protected-access

--- a/openedx/core/djangoapps/schedules/management/commands/tests/test_send_upgrade_reminder.py
+++ b/openedx/core/djangoapps/schedules/management/commands/tests/test_send_upgrade_reminder.py
@@ -31,7 +31,6 @@ LOG = logging.getLogger(__name__)
 @skipUnless('openedx.core.djangoapps.schedules.apps.SchedulesConfig' in settings.INSTALLED_APPS,
             "Can't test schedules if the app isn't installed")
 class TestUpgradeReminder(ScheduleSendEmailTestMixin, CacheIsolationTestCase):
-    shard = 6
     __test__ = True
 
     resolver = resolvers.UpgradeReminderResolver

--- a/openedx/core/djangoapps/user_api/accounts/tests/test_api.py
+++ b/openedx/core/djangoapps/user_api/accounts/tests/test_api.py
@@ -58,7 +58,6 @@ from openedx.core.djangoapps.user_api.errors import (
     UserNotFound
 )
 from openedx.core.djangolib.testing.utils import skip_unless_lms
-from openedx.core.lib.tests import attr
 from student.models import PendingEmailChange
 from student.tests.factories import UserFactory
 from student.tests.tests import UserSettingsEventTestMixin
@@ -69,7 +68,6 @@ def mock_render_to_string(template_name, context):
     return str((template_name, sorted(iteritems(context))))
 
 
-@attr(shard=2)
 @skip_unless_lms
 class TestAccountApi(UserSettingsEventTestMixin, EmailTemplateTagMixin, RetirementTestCase):
     """
@@ -373,7 +371,6 @@ class TestAccountApi(UserSettingsEventTestMixin, EmailTemplateTagMixin, Retireme
         verify_event_emitted([], [{"code": "en"}, {"code": "fr"}])
 
 
-@attr(shard=2)
 @patch('openedx.core.djangoapps.user_api.accounts.image_helpers._PROFILE_IMAGE_SIZES', [50, 10])
 @patch.dict(
     'django.conf.settings.PROFILE_IMAGE_SIZES_MAP',
@@ -444,7 +441,6 @@ class AccountSettingsOnCreationTest(TestCase):
         self.assertEqual(expected_user_password, user.password)
 
 
-@attr(shard=2)
 @pytest.mark.django_db
 def test_create_account_duplicate_email(django_db_use_migrations):
     """
@@ -470,7 +466,6 @@ def test_create_account_duplicate_email(django_db_use_migrations):
             create_account('different_user', password, email)
 
 
-@attr(shard=2)
 @ddt.ddt
 class AccountCreationActivationAndPasswordChangeTest(TestCase):
     """
@@ -613,7 +608,6 @@ class AccountCreationActivationAndPasswordChangeTest(TestCase):
         self.assertEqual(response.status_code, 403)
 
 
-@attr(shard=2)
 @ddt.ddt
 class AccountCreationUnicodeUsernameTest(TestCase):
     """

--- a/openedx/core/djangoapps/user_api/accounts/tests/test_image_helpers.py
+++ b/openedx/core/djangoapps/user_api/accounts/tests/test_image_helpers.py
@@ -22,7 +22,6 @@ class ProfileImageUrlTestCase(TestCase):
     """
     Tests for profile image URL generation helpers.
     """
-    shard = 2
 
     def setUp(self):
         super(ProfileImageUrlTestCase, self).setUp()

--- a/openedx/core/djangoapps/user_api/accounts/tests/test_views.py
+++ b/openedx/core/djangoapps/user_api/accounts/tests/test_views.py
@@ -145,7 +145,6 @@ class TestOwnUsernameAPI(CacheIsolationTestCase, UserAPITestCase):
     """
     Unit tests for the Accounts API.
     """
-    shard = 2
 
     ENABLED_CACHES = ['default']
 
@@ -204,7 +203,6 @@ class TestAccountsAPI(CacheIsolationTestCase, UserAPITestCase):
     """
     Unit tests for the Accounts API.
     """
-    shard = 2
 
     ENABLED_CACHES = ['default']
 
@@ -813,7 +811,6 @@ class TestAccountAPITransactions(TransactionTestCase):
     """
     Tests the transactional behavior of the account API
     """
-    shard = 2
 
     def setUp(self):
         super(TestAccountAPITransactions, self).setUp()

--- a/openedx/core/djangoapps/user_api/course_tag/tests/test_api.py
+++ b/openedx/core/djangoapps/user_api/course_tag/tests/test_api.py
@@ -12,7 +12,6 @@ class TestCourseTagAPI(TestCase):
     """
     Test the user service
     """
-    shard = 2
 
     def setUp(self):
         super(TestCourseTagAPI, self).setUp()

--- a/openedx/core/djangoapps/user_api/management/tests/test_email_opt_in_list.py
+++ b/openedx/core/djangoapps/user_api/management/tests/test_email_opt_in_list.py
@@ -27,7 +27,6 @@ from openedx.core.djangolib.testing.utils import skip_unless_lms
 @skip_unless_lms
 class EmailOptInListTest(ModuleStoreTestCase):
     """Tests for the email opt-in list management command. """
-    shard = 2
     USER_USERNAME = "test_user"
     USER_FIRST_NAME = u"Ṫëṡẗ"
     USER_LAST_NAME = u"Űśéŕ"

--- a/openedx/core/djangoapps/user_api/preferences/tests/test_api.py
+++ b/openedx/core/djangoapps/user_api/preferences/tests/test_api.py
@@ -47,7 +47,6 @@ class TestPreferenceAPI(CacheIsolationTestCase):
     are not specified.
     """
     password = "test"
-    shard = 2
 
     def setUp(self):
         super(TestPreferenceAPI, self).setUp()
@@ -335,7 +334,6 @@ class UpdateEmailOptInTests(ModuleStoreTestCase):
     USERNAME = u'claire-underwood'
     PASSWORD = u'ṕáśśẃőŕd'
     EMAIL = u'claire+underwood@example.com'
-    shard = 2
 
     @ddt.data(
         # Check that a 27 year old can opt-in

--- a/openedx/core/djangoapps/user_authn/views/tests/test_views.py
+++ b/openedx/core/djangoapps/user_authn/views/tests/test_views.py
@@ -298,7 +298,6 @@ class UserAccountUpdateTest(CacheIsolationTestCase, UrlResetMixin):
 @ddt.ddt
 class LoginAndRegistrationTest(ThirdPartyAuthTestMixin, UrlResetMixin, ModuleStoreTestCase):
     """ Tests for the student account views that update the user's account information. """
-    shard = 7
     USERNAME = "bob"
     EMAIL = "bob@example.com"
     PASSWORD = u"password"

--- a/openedx/core/djangoapps/verified_track_content/tests/test_views.py
+++ b/openedx/core/djangoapps/verified_track_content/tests/test_views.py
@@ -21,7 +21,6 @@ class CohortingSettingsTestCase(SharedModuleStoreTestCase):
     """
     Tests the `cohort_discussion_topics` view.
     """
-    shard = 2
 
     @classmethod
     def setUpClass(cls):

--- a/openedx/core/djangolib/tests/test_js_utils.py
+++ b/openedx/core/djangolib/tests/test_js_utils.py
@@ -15,7 +15,6 @@ class TestJSUtils(TestCase):
     """
     Test JS utils
     """
-    shard = 2
 
     class NoDefaultEncoding(object):
         """

--- a/openedx/core/djangolib/tests/test_markup.py
+++ b/openedx/core/djangolib/tests/test_markup.py
@@ -16,7 +16,6 @@ from openedx.core.djangolib.markup import HTML, Text, strip_all_tags_but_br
 @ddt.ddt
 class FormatHtmlTest(unittest.TestCase):
     """Test that we can format plain strings and HTML into them properly."""
-    shard = 2
 
     @ddt.data(
         (u"hello", u"hello"),

--- a/openedx/core/lib/api/tests/test_authentication.py
+++ b/openedx/core/lib/api/tests/test_authentication.py
@@ -77,7 +77,6 @@ urlpatterns = [
 @override_settings(ROOT_URLCONF=__name__)
 class OAuth2Tests(TestCase):
     """OAuth 2.0 authentication"""
-    shard = 2
 
     def setUp(self):
         super(OAuth2Tests, self).setUp()

--- a/openedx/core/lib/api/tests/test_exceptions.py
+++ b/openedx/core/lib/api/tests/test_exceptions.py
@@ -11,7 +11,6 @@ class TestDictExceptionsAllowDictDetails(TestCase):
     """
     Test that standard DRF exceptions can return dictionaries in error details.
     """
-    shard = 2
 
     def test_drf_errors_are_not_coerced_to_strings(self):
         # Demonstrate that dictionaries in exceptions are not coerced to strings.

--- a/openedx/core/lib/api/tests/test_parsers.py
+++ b/openedx/core/lib/api/tests/test_parsers.py
@@ -15,7 +15,6 @@ class TestTypedFileUploadParser(APITestCase):
     """
     Tests that verify the behavior of TypedFileUploadParser
     """
-    shard = 2
 
     def setUp(self):
         super(TestTypedFileUploadParser, self).setUp()

--- a/openedx/core/lib/api/tests/test_permissions.py
+++ b/openedx/core/lib/api/tests/test_permissions.py
@@ -32,7 +32,6 @@ class TestCcxObject(TestObject):
 
 class IsCourseStaffInstructorTests(TestCase):
     """ Test for IsCourseStaffInstructor permission class. """
-    shard = 2
 
     def setUp(self):
         super(IsCourseStaffInstructorTests, self).setUp()
@@ -66,7 +65,6 @@ class IsCourseStaffInstructorTests(TestCase):
 
 class IsMasterCourseStaffInstructorTests(TestCase):
     """ Test for IsMasterCourseStaffInstructorTests permission class. """
-    shard = 2
 
     def setUp(self):
         super(IsMasterCourseStaffInstructorTests, self).setUp()
@@ -112,7 +110,6 @@ class IsMasterCourseStaffInstructorTests(TestCase):
 @ddt.ddt
 class IsStaffOrOwnerTests(TestCase):
     """ Tests for IsStaffOrOwner permission class. """
-    shard = 2
 
     def setUp(self):
         super(IsStaffOrOwnerTests, self).setUp()

--- a/openedx/core/lib/gating/tests/test_api.py
+++ b/openedx/core/lib/gating/tests/test_api.py
@@ -22,7 +22,6 @@ class TestGatingApi(ModuleStoreTestCase, MilestonesTestCaseMixin):
     """
     Tests for the gating API
     """
-    shard = 2
 
     MODULESTORE = TEST_DATA_SPLIT_MODULESTORE
 

--- a/openedx/core/lib/tests/test_course_tab_api.py
+++ b/openedx/core/lib/tests/test_course_tab_api.py
@@ -12,7 +12,6 @@ class TestCourseTabApi(TestCase):
     """
     Unit tests for the course tab plugin API
     """
-    shard = 2
 
     def test_get_plugin(self):
         """

--- a/openedx/core/lib/tests/test_course_tabs.py
+++ b/openedx/core/lib/tests/test_course_tabs.py
@@ -10,7 +10,6 @@ from openedx.core.lib.course_tabs import CourseTabPluginManager
 
 class CourseTabPluginManagerTestCase(TestCase):
     """Test cases for CourseTabPluginManager class"""
-    shard = 2
 
     @patch('openedx.core.lib.course_tabs.CourseTabPluginManager.get_available_plugins')
     def test_get_tab_types(self, get_available_plugins):
@@ -40,7 +39,6 @@ class CourseTabPluginManagerTestCase(TestCase):
 
 class KeyCheckerTestCase(TestCase):
     """Test cases for KeyChecker class"""
-    shard = 2
 
     def setUp(self):
         super(KeyCheckerTestCase, self).setUp()
@@ -59,7 +57,6 @@ class KeyCheckerTestCase(TestCase):
 
 class NeedNameTestCase(TestCase):
     """Test cases for NeedName validator"""
-    shard = 2
 
     def setUp(self):
         super(NeedNameTestCase, self).setUp()

--- a/openedx/core/lib/tests/test_courses.py
+++ b/openedx/core/lib/tests/test_courses.py
@@ -15,7 +15,6 @@ from ..courses import course_image_url
 @ddt.ddt
 class CourseImageTestCase(ModuleStoreTestCase):
     """Tests for course image URLs."""
-    shard = 2
 
     def verify_url(self, expected_url, actual_url):
         """

--- a/openedx/core/lib/tests/test_edx_api_utils.py
+++ b/openedx/core/lib/tests/test_edx_api_utils.py
@@ -23,7 +23,6 @@ TEST_API_URL = 'http://www-internal.example.com/api'
 class TestGetEdxApiData(CatalogIntegrationMixin, CredentialsApiConfigMixin, CacheIsolationTestCase):
     """Tests for edX API data retrieval utility."""
     ENABLED_CACHES = ['default']
-    shard = 2
 
     def setUp(self):
         super(TestGetEdxApiData, self).setUp()

--- a/openedx/core/lib/tests/test_graph_traversals.py
+++ b/openedx/core/lib/tests/test_graph_traversals.py
@@ -12,7 +12,6 @@ class TestGraphTraversals(TestCase):
     """
     Test Class for graph traversal generator functions.
     """
-    shard = 2
 
     def setUp(self):
         # Creates a test graph with the following disconnected

--- a/openedx/core/lib/tests/test_xblock_utils.py
+++ b/openedx/core/lib/tests/test_xblock_utils.py
@@ -37,7 +37,6 @@ class TestXblockUtils(SharedModuleStoreTestCase):
     """
     Tests for xblock utility functions.
     """
-    shard = 2
 
     @classmethod
     def setUpClass(cls):

--- a/openedx/core/lib/xblock_builtin/xblock_discussion/tests.py
+++ b/openedx/core/lib/xblock_builtin/xblock_discussion/tests.py
@@ -59,7 +59,6 @@ class DiscussionXBlockImportExportTests(TestCase):
     Import and export tests
     """
     DISCUSSION_XBLOCK_LOCATION = "openedx.core.lib.xblock_builtin.xblock_discussion.xblock_discussion.DiscussionXBlock"
-    shard = 2
 
     def setUp(self):
         """

--- a/openedx/features/journals/tests/test_marketing_views.py
+++ b/openedx/features/journals/tests/test_marketing_views.py
@@ -64,7 +64,6 @@ class JournalIndexViewTest(SiteMixin, ModuleStoreTestCase):
     """
     Tests for Journals Listing in Marketing Pages.
     """
-    shard = 1
 
     def setUp(self):
         super(JournalIndexViewTest, self).setUp()

--- a/openedx/tests/xblock_integration/test_crowdsource_hinter.py
+++ b/openedx/tests/xblock_integration/test_crowdsource_hinter.py
@@ -139,7 +139,6 @@ class TestHinterFunctions(TestCrowdsourceHinter):
     Tests cover the basic process of receiving a hint, adding a new hint,
     and rating/reporting hints.
     """
-    shard = 6
 
     def test_get_hint_with_no_hints(self):
         """

--- a/openedx/tests/xblock_integration/test_recommender.py
+++ b/openedx/tests/xblock_integration/test_recommender.py
@@ -16,7 +16,6 @@ from ddt import data, ddt
 from lms.djangoapps.courseware.tests.factories import GlobalStaffFactory
 from lms.djangoapps.courseware.tests.helpers import LoginEnrollmentTestCase
 from six import text_type
-from openedx.core.lib.tests import attr
 from openedx.core.lib.url_utils import quote_slashes
 from xmodule.modulestore.tests.django_utils import SharedModuleStoreTestCase
 from xmodule.modulestore.tests.factories import CourseFactory, ItemFactory
@@ -196,7 +195,6 @@ class TestRecommender(SharedModuleStoreTestCase, LoginEnrollmentTestCase):
         self.assert_request_status_code(200, self.course_url)
 
 
-@attr(shard=6)
 class TestRecommenderCreateFromEmpty(TestRecommender):
     """
     Check whether we can add resources to an empty database correctly
@@ -223,7 +221,6 @@ class TestRecommenderCreateFromEmpty(TestRecommender):
                 self.assert_request_status_code(200, self.course_url)
 
 
-@attr(shard=6)
 class TestRecommenderResourceBase(TestRecommender):
     """Base helper class for tests with resources."""
     def setUp(self):
@@ -256,7 +253,6 @@ class TestRecommenderResourceBase(TestRecommender):
         return resource
 
 
-@attr(shard=6)
 class TestRecommenderWithResources(TestRecommenderResourceBase):
     """
     Check whether we can add/edit/flag/export resources correctly
@@ -421,7 +417,6 @@ class TestRecommenderWithResources(TestRecommenderResourceBase):
         self.assert_request_status_code(200, self.course_url)
 
 
-@attr(shard=6)
 @ddt
 class TestRecommenderVoteWithResources(TestRecommenderResourceBase):
     """
@@ -535,7 +530,6 @@ class TestRecommenderVoteWithResources(TestRecommenderResourceBase):
         self.check_event_response_by_key('handle_vote', resource, 'newVotes', test_case['new_votes'])
 
 
-@attr(shard=6)
 @ddt
 class TestRecommenderStaffFeedbackWithResources(TestRecommenderResourceBase):
     """
@@ -630,7 +624,6 @@ class TestRecommenderStaffFeedbackWithResources(TestRecommenderResourceBase):
         self.check_event_response_by_http_status(test_case['handler'], resource, test_case['status'])
 
 
-@attr(shard=6)
 @ddt
 class TestRecommenderFileUploading(TestRecommender):
     """


### PR DESCRIPTION
No longer needed, as we're dynamically sharding tests via pytest-xdist.

The following test reports confirm we aren't removing any tests by doing this work:

Python test results from this PR: https://build.testeng.edx.org/job/edx-platform-python-pipeline-pr/2471/testReport/
Python test results from a recent merge to master: https://build.testeng.edx.org/view/edx-platform-pipeline-master-tests/job/edx-platform-python-pipeline-master/85/testReport/