### PR TITLE
Capture screenshots on progress page test failures

### DIFF
--- a/common/test/acceptance/tests/lms/test_progress_page.py
+++ b/common/test/acceptance/tests/lms/test_progress_page.py
@@ -113,17 +113,16 @@ class ProgressPageBaseTest(UniqueCourseTest):
     def _logged_in_session(self, staff=False):
         """
         Ensure that the user is logged in and out appropriately at the beginning
-        and end of the current test.
+        and end of the current test.  But if there's an error, don't log out
+        before capturing a screenshot.
         """
         self.logout_page.visit()
-        try:
-            if staff:
-                auto_auth(self.browser, "STAFF_TESTER", "staff101@example.com", True, self.course_id)
-            else:
-                auto_auth(self.browser, self.USERNAME, self.EMAIL, False, self.course_id)
-            yield
-        finally:
-            self.logout_page.visit()
+        if staff:
+            auto_auth(self.browser, "STAFF_TESTER", "staff101@example.com", True, self.course_id)
+        else:
+            auto_auth(self.browser, self.USERNAME, self.EMAIL, False, self.course_id)
+        yield
+        self.logout_page.visit()
 
 
 @ddt.ddt


### PR DESCRIPTION
While debugging the one bok-choy test that failed in https://build.testeng.edx.org/job/edx-platform-bokchoy-pipeline-master/243/ , I discovered that most of the tests in that module are configured to log out before teardown has a chance to take a screenshot if there was a failure.  I've tweaked this to ensure that if there's an error, the correct screenshot will be taken; the browser session ends at the end of each test anyway, so there shouldn't be any worry about a session leaking over into another test case.