### PR TITLE
Remove Profile Tab on Dashboard pages

### DIFF
--- a/common/test/acceptance/tests/lms/test_learner_profile.py
+++ b/common/test/acceptance/tests/lms/test_learner_profile.py
@@ -9,7 +9,6 @@ from unittest import skip
 from common.test.acceptance.pages.common.auto_auth import AutoAuthPage
 from common.test.acceptance.pages.common.logout import LogoutPage
 from common.test.acceptance.pages.lms.account_settings import AccountSettingsPage
-from common.test.acceptance.pages.lms.dashboard import DashboardPage
 from common.test.acceptance.pages.lms.learner_profile import LearnerProfilePage
 from common.test.acceptance.tests.helpers import AcceptanceTest, EventsTestMixin
 
@@ -267,25 +266,6 @@ class OwnLearnerProfilePageTest(LearnerProfileTestMixin, AcceptanceTest):
         self.browser.refresh()
         profile_page.wait_for_page()
         self.verify_profile_page_is_private(profile_page)
-
-    def test_dashboard_learner_profile_link(self):
-        """
-        Scenario: Verify that my profile link is present on dashboard page and we can navigate to correct page.
-
-        Given that I am a registered user.
-        When I go to Dashboard page.
-        And I click on username dropdown.
-        Then I see Profile link in the dropdown menu.
-        When I click on Profile link.
-        Then I will be navigated to Profile page.
-        """
-        username, __ = self.log_in_as_unique_user()
-        dashboard_page = DashboardPage(self.browser)
-        dashboard_page.visit()
-        self.assertIn('Profile', dashboard_page.tabs_link_text)
-        dashboard_page.click_my_profile_link()
-        my_profile_page = LearnerProfilePage(self.browser, username)
-        my_profile_page.wait_for_page()
 
     def test_fields_on_my_private_profile(self):
         """

--- a/lms/templates/header/navbar-authenticated.html
+++ b/lms/templates/header/navbar-authenticated.html
@@ -51,12 +51,6 @@ from openedx.core.djangoapps.site_configuration import helpers as configuration_
           </a>
         </div>
       % endif
-      <div class="mobile-nav-item hidden-mobile nav-item nav-tab">
-          <a class="${'active ' if '/u/' in request.path  else ''}tab-nav-link" href="${reverse('learner_profile', args=[self.real_user.username])}"
-             aria-current="${'page' if '/u/' in request.path else 'false'}">
-             ${_("Profile")}
-          </a>
-      </div>
     % endif
     % if show_explore_courses:
       <div class="mobile-nav-item hidden-mobile nav-item nav-tab">

--- a/lms/templates/navigation/bootstrap/navbar-authenticated.html
+++ b/lms/templates/navigation/bootstrap/navbar-authenticated.html
@@ -53,15 +53,6 @@ from django.utils.translation import ugettext as _
           </a>
         </li>
       % endif
-      <%
-        self.real_user = getattr(user, 'real_user', user)
-        is_on_profile_page = data and data.get('profile_user_id') is not None
-      %>
-      <li class="nav-item mt-2 nav-item-open-collapsed">
-        <a class="${'active ' if is_on_profile_page else ''}tab-nav-link" href="${reverse('learner_profile', args=[self.real_user.username])}">
-          ${_("Profile")}
-        </a>
-      </li>
     % endif
 
     % if settings.FEATURES.get('ENABLE_SYSADMIN_DASHBOARD','') and user.is_staff:

--- a/lms/templates/navigation/navbar-authenticated.html
+++ b/lms/templates/navigation/navbar-authenticated.html
@@ -36,15 +36,6 @@ from django.utils.translation import ugettext as _
           </a>
         </li>
       % endif
-      <%
-        self.real_user = getattr(user, 'real_user', user)
-        is_on_profile_page = data and data.get('profile_user_id') is not None
-      %>
-      <li class="tab-nav-item">
-        <a class="${'active ' if is_on_profile_page else ''}tab-nav-link" href="${reverse('learner_profile', args=[self.real_user.username])}">
-          ${_("Profile")}
-        </a>
-      </li>
     % endif
     % if settings.FEATURES.get('ENABLE_SYSADMIN_DASHBOARD','') and user.is_staff:
       <li class="item">

--- a/themes/edx.org/lms/templates/header/navbar-authenticated.html
+++ b/themes/edx.org/lms/templates/header/navbar-authenticated.html
@@ -54,12 +54,6 @@ from openedx.core.djangoapps.site_configuration import helpers as configuration_
             </a>
           </div>
         % endif
-        <div class="mobile-nav-item hidden-mobile nav-item nav-tab">
-          <a class="${'active ' if '/u/' in request.path  else ''}tab-nav-link" href="${reverse('learner_profile', args=[self.real_user.username])}"
-             aria-current="${'page' if '/u/' in request.path else 'false'}">
-            ${_("Profile")}
-          </a>
-        </div>
       % endif
     % endif
 


### PR DESCRIPTION
This PR removes the Profile tab from the navigation of dashboard pages - in preparation for migrating the Profile feature to its new home as a microfrontend.