### PR TITLE
add staff exemption for content access in library content

### DIFF
--- a/lms/djangoapps/course_blocks/transformers/library_content.py
+++ b/lms/djangoapps/course_blocks/transformers/library_content.py
@@ -22,7 +22,7 @@ class ContentLibraryTransformer(FilteringTransformerMixin, BlockStructureTransfo
     blocks within a library_content module to which a user should not
     have access.
 
-    Staff users are *not* exempted from library content pathways.
+    Staff users are to exempted from library content pathways.
     """
     WRITE_VERSION = 1
     READ_VERSION = 1
@@ -123,8 +123,10 @@ class ContentLibraryTransformer(FilteringTransformerMixin, BlockStructureTransfo
             Return True if selected block should be removed.
 
             Block is removed if it is part of library_content, but has
-            not been selected for current user.
+            not been selected for current user, with staff as an exemption.
             """
+            if usage_info.has_staff_access:
+                return False
             if block_key not in all_library_children:
                 return False
             if block_key in all_selected_children:

--- a/lms/djangoapps/course_blocks/transformers/tests/test_library_content.py
+++ b/lms/djangoapps/course_blocks/transformers/tests/test_library_content.py
@@ -164,3 +164,19 @@ class ContentLibraryTransformerTestCase(CourseStructureTestCase):
                 ),
                 u"Expected 'selected' equality failed in iteration {}.".format(i)
             )
+
+    def test_staff_access_to_library_content(self):
+        """
+        To verify that staff member has access to all the library content blocks.
+
+        Scenario: Given a staff member in a course with library content
+        when data is transformed by LibraryContentTransformer
+        none of the unassigned block is removed from the access list
+        and staff member will have access to all the blocks
+        """
+        transformed_blocks = get_course_blocks(
+            self.staff,
+            self.course.location,
+            transformers=self.transformers
+        )
+        self.assertEqual(len(list(transformed_blocks.get_block_keys())), len(self.blocks))


### PR DESCRIPTION
### [EDUCATOR-3994](https://openedx.atlassian.net/browse/EDUCATOR-3994)

### Description
For a randomized library content, it is expected that problems are to be assigned randomly to the users regardless of the type. The user should not be able to access any problem that is not assigned to them. This held true even for the staff members. This posed a problem when generating a problem response CSV for the problems inside the library content. If the staff member tried to generate CSV for any problem that is not assigned to them, the task failed as the access was restricted to the user. This was contributed due to the [ContentLibraryTransformer](https://github.com/edx/edx-platform/blob/master/lms/djangoapps/course_blocks/transformers/library_content.py#L19-L26), that transformed the course blocks during the task run. It removed such blocks that staff members didn't have access to. The fix in PR addresses that behavior by adding a check for staff access in the removal condition so that content blocks aren't restricted for the staff users. Note that this fix doesn't violate the random assignment behavior as the removal of blocks is done after the random assignment.


### Reviewers
 - [x] @awaisdar001 
 - [x] @Rabia23 
 - [ ] @fysheets 

### Sandbox
 - https://educator3994.sandbox.edx.org/

### Testing Instructions
1. Visit the [course](https://educator3994.sandbox.edx.org/courses/course-v1:NintendoX+LoZ2019+2019_T2/course/) as a staff user
2. Navigate to the only unit in the course
3. See the problems assigned. Logout & login as a learner
4. Submit one of the assigned problems that has not been assigned to the staff user.
5. Go to Instructor tab --> Data Download --> Reports.
6. From **Select a section or problem**, navigate to the problem that was submitted by the learner.
7. Download the report. The report should become available after a few moments.

### Post review
 - [x] Squash & Rebase Commits