### PR TITLE
ignore db cache files for bokchoy testing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -84,7 +84,7 @@ test_root/paver_logs/
 test_root/uploads/
 django-pyfs
 .tox/
-common/test/db_cache/bok_choy_*.yaml
+common/test/db_cache/*
 
 ### Installation artifacts
 *.egg-info


### PR DESCRIPTION
We do not want humans to commit updates to any of the bok choy db cache files. These are updated via an automated process.