### PR TITLE
PROPOSAL: Enable shuffling of checkbox responses.

### DIFF
--- a/common/lib/capa/capa/responsetypes.py
+++ b/common/lib/capa/capa/responsetypes.py
@@ -658,6 +658,7 @@ class ChoiceResponse(LoncapaResponse):
     choices must be given names. This behavior seems like a leaky abstraction,
     and it'd be nice to change this at some point.
 
+    TODO: add shuffling to Choice/Checkboxes response type.
     """
     human_name = _('Checkboxes')
     tags = ['choiceresponse']


### PR DESCRIPTION
**Background:**
> As a course author, I want to be able to randomize the answer options for problems where more than one answer can be selected.

**Current State:**
Only Multiple Choice response types allow instructors to shuffle the answer options.

**Desired State**
The "Choice Response" (AKA Checkboxes) problem type should also allow an instructor to shuffle the responses.

**Proposal:**
Do the work described in https://openedx.atlassian.net/browse/TNL-5985.
