### PR TITLE
[WIP] SE-760 Public Courses: Show "Enroll" links on public courses only if self-enrollment is allowed

### DIFF
--- a/openedx/features/course_experience/tests/views/test_course_home.py
+++ b/openedx/features/course_experience/tests/views/test_course_home.py
@@ -205,7 +205,7 @@ class TestCourseHomePage(CourseHomePageTestCase):
 
         # Fetch the view and verify the query counts
         # TODO: decrease query count as part of REVO-28
-        with self.assertNumQueries(89, table_blacklist=QUERY_COUNT_TABLE_BLACKLIST):
+        with self.assertNumQueries(91, table_blacklist=QUERY_COUNT_TABLE_BLACKLIST):
             with check_mongo_calls(4):
                 url = course_home_url(self.course)
                 self.client.get(url)

--- a/openedx/features/course_experience/tests/views/test_course_home.py
+++ b/openedx/features/course_experience/tests/views/test_course_home.py
@@ -4,6 +4,10 @@ Tests for the course home page.
 """
 from datetime import datetime, timedelta
 
+import pytz
+from openedx.core.djangoapps.waffle_utils.models import WaffleFlagCourseOverrideModel
+from student.models import CourseEnrollmentAllowed
+
 import ddt
 import mock
 from django.conf import settings
@@ -844,7 +848,6 @@ class TestCourseHomePageAccess(CourseHomePageTestCase):
         self.assertContains(response, TEST_COURSE_GOAL_UPDATE_FIELD)
         self.assertNotContains(response, TEST_COURSE_GOAL_UPDATE_FIELD_HIDDEN)
 
-    #TODO SE-760
     @override_waffle_flag(COURSE_PRE_START_ACCESS_FLAG, active=True)
     def test_course_messaging_for_public_course(self):
         """
@@ -855,11 +858,6 @@ class TestCourseHomePageAccess(CourseHomePageTestCase):
         3) Unenrolled users are shown a course message asking them to enroll for courses that allow
            self-enrollment
         """
-
-        import pytz
-        from openedx.core.djangoapps.waffle_utils.models import WaffleFlagCourseOverrideModel
-        from student.models import CourseEnrollmentAllowed
-
         TEST_COURSE_ANONYMOUS_MESSAGE = 'You must be enrolled in the course to see course content.'
         enable_unenrolled_access = True
 

--- a/openedx/features/course_experience/tests/views/test_course_home.py
+++ b/openedx/features/course_experience/tests/views/test_course_home.py
@@ -342,7 +342,6 @@ class TestCourseHomePageAccess(CourseHomePageTestCase):
         if not is_enrolled and enabled_unenrolled_access:
             self.assertContains(response, 'You must be enrolled in the course to see course content.')
 
-
     @override_waffle_flag(UNIFIED_COURSE_TAB_FLAG, active=False)
     @override_waffle_flag(SHOW_REVIEWS_TOOL_FLAG, active=True)
     @ddt.data(
@@ -865,6 +864,7 @@ class TestCourseHomePageAccess(CourseHomePageTestCase):
         response = self.client.get(course_home_url(verifiable_course))
         self.assertContains(response, TEST_COURSE_GOAL_UPDATE_FIELD)
         self.assertNotContains(response, TEST_COURSE_GOAL_UPDATE_FIELD_HIDDEN)
+
 
 class CourseHomeFragmentViewTests(ModuleStoreTestCase):
     """

--- a/openedx/features/course_experience/tests/views/test_course_home.py
+++ b/openedx/features/course_experience/tests/views/test_course_home.py
@@ -326,21 +326,21 @@ class TestCourseHomePageAccess(CourseHomePageTestCase):
                 self.assertContains(response, 'You must be enrolled in the course to see course content.')
 
         # Verify that anonymous users are not show a message to enroll on a public course
-        if is_anonymous and course_visibility == COURSE_VISIBILITY_PUBLIC:
-            self.assertNotContains(response, 'You must be enrolled in the course to see course content.')
+        #if is_anonymous and course_visibility == COURSE_VISIBILITY_PUBLIC:
+        #    self.assertNotContains(response, 'You must be enrolled in the course to see course content.')
 
-        # Verify that unenrolled users are not shown an enroll message for public courses
-        if not is_enrolled and course_visibility == COURSE_VISIBILITY_PUBLIC:
-            self.assertNotContains(response, 'You must be enrolled in the course to see course content.')
+        ## Verify that unenrolled users are not shown an enroll message for public courses
+        #if not is_enrolled and course_visibility == COURSE_VISIBILITY_PUBLIC:
+        #    self.assertNotContains(response, 'You must be enrolled in the course to see course content.')
 
-        # Verify that unenrolled users are not shown an enroll message for courses
-        # that do not allow self-enrollment
-        if not is_enrolled and not enabled_unenrolled_access:
-            self.assertNotContains(response, 'You must be enrolled in the course to see course content.')
+        ## Verify that unenrolled users are not shown an enroll message for courses
+        ## that do not allow self-enrollment
+        #if not is_enrolled and not enable_unenrolled_access:
+        #    self.assertNotContains(response, 'You must be enrolled in the course to see course content.')
 
-        # Verify that unenrolled users are shown an enroll for courses that allow self-enrollment
-        if not is_enrolled and enabled_unenrolled_access:
-            self.assertContains(response, 'You must be enrolled in the course to see course content.')
+        ## Verify that unenrolled users are shown an enroll for courses that allow self-enrollment
+        #if not is_enrolled and enable_unenrolled_access:
+        #    self.assertContains(response, 'You must be enrolled in the course to see course content.')
 
     @override_waffle_flag(UNIFIED_COURSE_TAB_FLAG, active=False)
     @override_waffle_flag(SHOW_REVIEWS_TOOL_FLAG, active=True)

--- a/openedx/features/course_experience/views/course_home.py
+++ b/openedx/features/course_experience/views/course_home.py
@@ -127,10 +127,11 @@ class CourseHomeFragmentView(EdxFragmentView):
             'is_staff': has_access(request.user, 'staff', course_key),
         }
 
+        allow_anonymous = COURSE_ENABLE_UNENROLLED_ACCESS_FLAG.is_enabled(course_key)
         course_access = {
             'allow_anonymous': COURSE_ENABLE_UNENROLLED_ACCESS_FLAG.is_enabled(course_key),
-            'is_public': allow_anonymous and course.course_visibility == COURSE_VISIBILITY_PUBLIC,
-            'is_public_outline': allow_anonymous and course.course_visibility == COURSE_VISIBILITY_PUBLIC_OUTLINE,
+            'allow_public': allow_anonymous and course.course_visibility == COURSE_VISIBILITY_PUBLIC,
+            'allow_public_outline': allow_anonymous and course.course_visibility == COURSE_VISIBILITY_PUBLIC_OUTLINE,
             'allow_enrollment': course_open_for_self_enrollment(course.id)
         }
 

--- a/openedx/features/course_experience/views/course_home.py
+++ b/openedx/features/course_experience/views/course_home.py
@@ -131,7 +131,7 @@ class CourseHomeFragmentView(EdxFragmentView):
             'allow_anonymous': COURSE_ENABLE_UNENROLLED_ACCESS_FLAG.is_enabled(course_key),
             'is_public': allow_anonymous and course.course_visibility == COURSE_VISIBILITY_PUBLIC,
             'is_public_outline': allow_anonymous and course.course_visibility == COURSE_VISIBILITY_PUBLIC_OUTLINE,
-            'allow_enrollment':course_open_for_self_enrollment(course.id)
+            'allow_enrollment': course_open_for_self_enrollment(course.id)
         }
 
         # Set all the fragments

--- a/openedx/features/course_experience/views/course_home_messages.py
+++ b/openedx/features/course_experience/views/course_home_messages.py
@@ -27,6 +27,9 @@ from openedx.core.djangoapps.plugin_api.views import EdxFragmentView
 from openedx.core.djangolib.markup import HTML, Text
 from openedx.features.course_experience import CourseHomeMessages
 from student.models import CourseEnrollment
+from lms.djangoapps.courseware.courses import allow_public_access
+from courseware.courses import course_open_for_self_enrollment
+from xmodule.course_module import COURSE_VISIBILITY_PUBLIC
 
 
 class CourseHomeMessageFragmentView(EdxFragmentView):
@@ -106,9 +109,6 @@ def _register_course_home_messages(request, course, user_access, course_start_da
     """
     Register messages to be shown in the course home content page.
     """
-    from lms.djangoapps.courseware.courses import allow_public_access
-    from courseware.courses import course_open_for_self_enrollment
-    from xmodule.course_module import COURSE_VISIBILITY_PUBLIC
 
     is_course_public = allow_public_access(course, [COURSE_VISIBILITY_PUBLIC])
     is_self_enrollment_allowed = course_open_for_self_enrollment(course.id)

--- a/openedx/features/course_experience/views/course_home_messages.py
+++ b/openedx/features/course_experience/views/course_home_messages.py
@@ -117,6 +117,12 @@ def _register_course_home_messages(request, course, user_access, course_access, 
     """
     Register messages to be shown in the course home content page.
     """
+    if course_access['is_public'] and not course_access['allow_enrollment']:
+        CourseHomeMessages.register_info_message(
+            request,
+            Text(_('You must be enrolled in the course to see course content.'))
+        )
+
     if course_access['is_public'] and course_access['allow_enrollment']:
         if not user_access['is_anonymous'] and not user_access['is_staff'] and not user_access['is_enrolled']:
             CourseHomeMessages.register_info_message(

--- a/openedx/features/course_experience/views/course_home_messages.py
+++ b/openedx/features/course_experience/views/course_home_messages.py
@@ -50,8 +50,8 @@ class CourseHomeMessageFragmentView(EdxFragmentView):
 
     course_access = {
         'allow_anonymous': True if course allows anonymous user access, False otherwise
-        'is_public': True if course allows public access, False otherwise
-        'is_public_outline': True if course outline is enabled for public access,
+        'allow_public': True if course allows public access, False otherwise
+        'allow_public_outline': True if course outline is enabled for public access,
                                 False otherwise
         'allow_enrollment': True if course allows self-enrollment, False otherwise
     }
@@ -117,13 +117,13 @@ def _register_course_home_messages(request, course, user_access, course_access, 
     """
     Register messages to be shown in the course home content page.
     """
-    if course_access['is_public'] and not course_access['allow_enrollment']:
+    if course_access['allow_public'] and not course_access['allow_enrollment']:
         CourseHomeMessages.register_info_message(
             request,
             Text(_('You must be enrolled in the course to see course content.'))
         )
 
-    if course_access['is_public'] and course_access['allow_enrollment']:
+    if course_access['allow_public'] and course_access['allow_enrollment']:
         if not user_access['is_anonymous'] and not user_access['is_staff'] and not user_access['is_enrolled']:
             CourseHomeMessages.register_info_message(
                 request,
@@ -138,7 +138,7 @@ def _register_course_home_messages(request, course, user_access, course_access, 
                 )
             )
 
-    if not course_access['is_public']:
+    if not course_access['allow_public']:
         if user_access['is_anonymous']:
             CourseHomeMessages.register_info_message(
                 request,

--- a/openedx/features/course_experience/views/course_home_messages.py
+++ b/openedx/features/course_experience/views/course_home_messages.py
@@ -105,6 +105,7 @@ class CourseHomeMessageFragmentView(EdxFragmentView):
         html = render_to_string('course_experience/course-messages-fragment.html', context)
         return Fragment(html)
 
+
 def _register_course_home_messages(request, course, user_access, course_start_data):
     """
     Register messages to be shown in the course home content page.
@@ -159,6 +160,7 @@ def _register_course_home_messages(request, course, user_access, course_start_da
                     course_display_name=course.display_name
                 )
             )
+
 
 def _register_course_goal_message(request, course):
     """

--- a/openedx/features/course_experience/views/course_home_messages.py
+++ b/openedx/features/course_experience/views/course_home_messages.py
@@ -165,7 +165,6 @@ def _register_course_home_messages(request, course, user_access, course_start_da
                 )
             )
 
-
 def _register_course_goal_message(request, course):
     """
     Register a message to let a learner specify a course goal.

--- a/openedx/features/course_experience/views/course_home_messages.py
+++ b/openedx/features/course_experience/views/course_home_messages.py
@@ -113,11 +113,6 @@ def _register_course_home_messages(request, course, user_access, course_start_da
     is_course_public = allow_public_access(course, [COURSE_VISIBILITY_PUBLIC])
     is_self_enrollment_allowed = course_open_for_self_enrollment(course.id)
 
-    if is_course_public and not is_self_enrollment_allowed:
-        if user_access['is_anonymous']:
-            pass
-        if not user_access['is_enrolled']:
-            pass
     if is_course_public and is_self_enrollment_allowed:
         if not user_access['is_anonymous'] and not user_access['is_staff'] and not user_access['is_enrolled']:
             CourseHomeMessages.register_info_message(

--- a/openedx/features/course_experience/views/course_home_messages.py
+++ b/openedx/features/course_experience/views/course_home_messages.py
@@ -108,9 +108,9 @@ def _register_course_home_messages(request, course, user_access, course_start_da
     """
     from lms.djangoapps.courseware.courses import allow_public_access
     from courseware.courses import course_open_for_self_enrollment
-    from xmodule.course_module import COURSE_VISIBILITY_PRIVATE, COURSE_VISIBILITY_PUBLIC_OUTLINE, COURSE_VISIBILITY_PUBLIC
+    from xmodule.course_module import COURSE_VISIBILITY_PUBLIC
 
-    is_course_public = allow_public_access(course, [COURSE_VISIBILITY_PUBLIC, COURSE_VISIBILITY_PUBLIC_OUTLINE])
+    is_course_public = allow_public_access(course, [COURSE_VISIBILITY_PUBLIC])
     is_self_enrollment_allowed = course_open_for_self_enrollment(course.id)
 
     if is_course_public and not is_self_enrollment_allowed:

--- a/openedx/features/course_experience/views/course_home_messages.py
+++ b/openedx/features/course_experience/views/course_home_messages.py
@@ -102,41 +102,68 @@ class CourseHomeMessageFragmentView(EdxFragmentView):
         html = render_to_string('course_experience/course-messages-fragment.html', context)
         return Fragment(html)
 
-
 def _register_course_home_messages(request, course, user_access, course_start_data):
     """
     Register messages to be shown in the course home content page.
     """
-    if user_access['is_anonymous']:
-        CourseHomeMessages.register_info_message(
-            request,
-            Text(_(
-                '{sign_in_link} or {register_link} and then enroll in this course.'
-            )).format(
-                sign_in_link=HTML('<a href="/login?next={current_url}">{sign_in_label}</a>').format(
-                    sign_in_label=_('Sign in'),
-                    current_url=urlquote_plus(request.path),
+    from lms.djangoapps.courseware.courses import allow_public_access
+    from courseware.courses import course_open_for_self_enrollment
+    from xmodule.course_module import COURSE_VISIBILITY_PRIVATE, COURSE_VISIBILITY_PUBLIC_OUTLINE, COURSE_VISIBILITY_PUBLIC
+
+    is_course_public = allow_public_access(course, [COURSE_VISIBILITY_PUBLIC, COURSE_VISIBILITY_PUBLIC_OUTLINE])
+    is_self_enrollment_allowed = course_open_for_self_enrollment(course.id)
+
+    if is_course_public and not is_self_enrollment_allowed:
+        if user_access['is_anonymous']:
+            pass
+        if not user_access['is_enrolled']:
+            pass
+    if is_course_public and is_self_enrollment_allowed:
+        if not user_access['is_anonymous'] and not user_access['is_staff'] and not user_access['is_enrolled']:
+            CourseHomeMessages.register_info_message(
+                request,
+                Text(_(
+                    '{open_enroll_link}Enroll now{close_enroll_link} to access the full course.'
+                )).format(
+                    open_enroll_link=HTML('<button class="enroll-btn btn-link">'),
+                    close_enroll_link=HTML('</button>')
                 ),
-                register_link=HTML('<a href="/register?next={current_url}">{register_label}</a>').format(
-                    register_label=_('register'),
-                    current_url=urlquote_plus(request.path),
+                title=Text(_('Welcome to {course_display_name}')).format(
+                    course_display_name=course.display_name
                 )
-            ),
-            title=Text(_('You must be enrolled in the course to see course content.'))
-        )
-    if not user_access['is_anonymous'] and not user_access['is_staff'] and not user_access['is_enrolled']:
-        CourseHomeMessages.register_info_message(
-            request,
-            Text(_(
-                '{open_enroll_link}Enroll now{close_enroll_link} to access the full course.'
-            )).format(
-                open_enroll_link=HTML('<button class="enroll-btn btn-link">'),
-                close_enroll_link=HTML('</button>')
-            ),
-            title=Text(_('Welcome to {course_display_name}')).format(
-                course_display_name=course.display_name
             )
-        )
+
+    if not is_course_public:
+        if user_access['is_anonymous']:
+            CourseHomeMessages.register_info_message(
+                request,
+                Text(_(
+                    '{sign_in_link} or {register_link} and then enroll in this course.'
+                )).format(
+                    sign_in_link=HTML('<a href="/login?next={current_url}">{sign_in_label}</a>').format(
+                        sign_in_label=_('Sign in'),
+                        current_url=urlquote_plus(request.path),
+                    ),
+                    register_link=HTML('<a href="/register?next={current_url}">{register_label}</a>').format(
+                        register_label=_('register'),
+                        current_url=urlquote_plus(request.path),
+                    )
+                ),
+                title=Text(_('You must be enrolled in the course to see course content.'))
+            )
+        if not user_access['is_anonymous'] and not user_access['is_staff'] and not user_access['is_enrolled']:
+            CourseHomeMessages.register_info_message(
+                request,
+                Text(_(
+                    '{open_enroll_link}Enroll now{close_enroll_link} to access the full course.'
+                )).format(
+                    open_enroll_link=HTML('<button class="enroll-btn btn-link">'),
+                    close_enroll_link=HTML('</button>')
+                ),
+                title=Text(_('Welcome to {course_display_name}')).format(
+                    course_display_name=course.display_name
+                )
+            )
 
 
 def _register_course_goal_message(request, course):


### PR DESCRIPTION
This PR contains bug fixes to the course home page with regards to courses that are marked as "public".

Specifically:
1. Enroll warning is shown only if user is registered and not enrolled
2. Enroll button is shown only if self-enrollment is allowed
3. Enroll message is shown only if self-enrolment is allowed

**Dependencies**: None

**Sandbox URL**: TBD - sandbox is being provisioned.

**Merge deadline**: ASAP

**Testing instructions**:

1. Set up edx-devstack
2. Clone "opencraft/edx-platform/devan/show-enroll-links-on-public-courses-only-if-self-enrollment-allowed" to edx-platform
3. Run "make lms-shell"
4. Run
`pytest openedx/features/course_experience/tests/view/test_course_home.py::TestCourseHomePageAccess`

**Reviewers**
- [ ] Pooja Kulkarni (pkulkark)
- [ ] edX reviewer[s] TBD
