### PR TITLE
Fix flaky test_list_student_profile_information

### DIFF
--- a/common/test/acceptance/tests/lms/test_lms_instructor_dashboard.py
+++ b/common/test/acceptance/tests/lms/test_lms_instructor_dashboard.py
@@ -726,6 +726,7 @@ class DataDownloadsWithMultipleRoleTests(BaseInstructorDashboardTest):
         data_download_section = instructor_dashboard_page.select_data_download()
 
         data_download_section.enrolled_student_profile_button.click()
+        instructor_dashboard_page.wait_for_ajax()
         student_profile_info = data_download_section.student_profile_information
 
         self.assertNotIn(student_profile_info, [u'', u'Loading'])


### PR DESCRIPTION
I verified that there's an ajax call to `/courses/{course_id}/instructor/api/get_students_features` which needs to complete, otherwise we may see errors like in https://build.testeng.edx.org/job/edx-platform-bokchoy-pipeline-pr/1625/execution/node/318/log/?consoleFull, pasted below:

```
16:00:43 =================================== FAILURES ===================================
16:00:43  DataDownloadsWithMultipleRoleTests.test_list_student_profile_information_1___staff__ 
16:00:43 
16:00:43 self = <common.test.acceptance.tests.lms.test_lms_instructor_dashboard.DataDownloadsWithMultipleRoleTests testMethod=test_list_student_profile_information_1___staff__>
16:00:43 role = ['staff']
16:00:43 
16:00:43     @ddt.data(['staff'], ['instructor'])
16:00:43     def test_list_student_profile_information(self, role):
16:00:43         """
16:00:43         Scenario: List enrolled students' profile information
16:00:43         Given I am "<Role>" for a course
16:00:43         When I click "List enrolled students' profile information"
16:00:43             Then I see a table of student profiles
16:00:43             Examples:
16:00:43             | Role          |
16:00:43             | instructor    |
16:00:43             | staff         |
16:00:43         """
16:00:43         username, user_id, email, __ = self.log_in_as_instructor(
16:00:43             global_staff=False,
16:00:43             course_access_roles=role
16:00:43         )
16:00:43         instructor_dashboard_page = self.visit_instructor_dashboard()
16:00:43         data_download_section = instructor_dashboard_page.select_data_download()
16:00:43     
16:00:43         data_download_section.enrolled_student_profile_button.click()
16:00:43         student_profile_info = data_download_section.student_profile_information
16:00:43     
16:00:43         self.assertNotIn(student_profile_info, [u'', u'Loading'])
16:00:43         expected_data = [user_id, username, email]
16:00:43         for datum in expected_data:
16:00:43 >           self.assertIn(str(datum), student_profile_info[0].split('\n'))
16:00:43 E           AssertionError: '1039' not found in [u'Loading']
16:00:43 
16:00:43 common/test/acceptance/tests/lms/test_lms_instructor_dashboard.py:734: AssertionError
```