### PR TITLE
Management to sync course schedules to course start dates

### DIFF
--- a/openedx/core/djangoapps/schedules/management/commands/sync_schedules_to_course_start.py
+++ b/openedx/core/djangoapps/schedules/management/commands/sync_schedules_to_course_start.py
@@ -1,7 +1,8 @@
 """
 Support "fixing" schedules that currently have start dates prior to the course start date.
 
-This can happen if a course start date is moved into the future and the corresponding schedules are not updated for any reason.
+This can happen if a course start date is moved into the future and the corresponding
+schedules are not updated for any reason.
 """
 from __future__ import print_function
 
@@ -19,7 +20,8 @@ class Command(BaseCommand):
     """
     Support "fixing" schedules that currently have start dates prior to the course start date.
 
-    This can happen if a course start date is moved into the future and the corresponding schedules are not updated for any reason.
+    This can happen if a course start date is moved into the future and the corresponding
+    schedules are not updated for any reason.
     """
 
     def add_arguments(self, parser):

--- a/openedx/core/djangoapps/schedules/management/commands/sync_schedules_to_course_start.py
+++ b/openedx/core/djangoapps/schedules/management/commands/sync_schedules_to_course_start.py
@@ -16,11 +16,11 @@ LOG = logging.getLogger(__name__)
 
 
 class Command(BaseCommand):
-"""
-Support "fixing" schedules that currently have start dates prior to the course start date.
-
-This can happen if a course start date is moved into the future and the corresponding schedules are not updated for any reason.
-"""
+    """
+    Support "fixing" schedules that currently have start dates prior to the course start date.
+    
+    This can happen if a course start date is moved into the future and the corresponding schedules are not updated for any reason.
+    """
 
     def add_arguments(self, parser):
         parser.add_argument('--dry-run', default=False, action='store_true')

--- a/openedx/core/djangoapps/schedules/management/commands/sync_schedules_to_course_start.py
+++ b/openedx/core/djangoapps/schedules/management/commands/sync_schedules_to_course_start.py
@@ -1,0 +1,42 @@
+from __future__ import print_function
+
+import logging
+import textwrap
+
+from django.core.management.base import BaseCommand
+from django.db import connection
+
+
+LOG = logging.getLogger(__name__)
+
+
+class Command(BaseCommand):
+
+    def add_arguments(self, parser):
+        parser.add_argument('--dry-run', default=False, action='store_true')
+        parser.add_argument('from_date')
+        parser.add_argument('course_id')
+
+    def handle(self, *args, **options):
+        query = textwrap.dedent(
+            """
+            UPDATE
+                schedules_schedule s
+            JOIN student_courseenrollment e ON e.id = s.enrollment_id
+            JOIN course_overviews_courseoverview c ON c.id = e.course_id
+            SET s.start = c.start
+            WHERE
+                s.start < c.start
+                AND s.start > %s
+                AND c.start < CURRENT_DATE()
+                AND c.id = %s;
+            """
+        )
+        parameters = [options['from_date'], options['course_id']]
+        if options['dry_run']:
+            print(query)
+            print(parameters)
+        else:
+            with connection.cursor() as cursor:
+                cursor.execute(query, parameters)
+                print('Rows updated: {}'.format(cursor.rowcount))

--- a/openedx/core/djangoapps/schedules/management/commands/sync_schedules_to_course_start.py
+++ b/openedx/core/djangoapps/schedules/management/commands/sync_schedules_to_course_start.py
@@ -18,7 +18,7 @@ LOG = logging.getLogger(__name__)
 class Command(BaseCommand):
     """
     Support "fixing" schedules that currently have start dates prior to the course start date.
-    
+
     This can happen if a course start date is moved into the future and the corresponding schedules are not updated for any reason.
     """
 

--- a/openedx/core/djangoapps/schedules/management/commands/sync_schedules_to_course_start.py
+++ b/openedx/core/djangoapps/schedules/management/commands/sync_schedules_to_course_start.py
@@ -1,3 +1,8 @@
+"""
+Support "fixing" schedules that currently have start dates prior to the course start date.
+
+This can happen if a course start date is moved into the future and the corresponding schedules are not updated for any reason.
+"""
 from __future__ import print_function
 
 import logging
@@ -11,6 +16,11 @@ LOG = logging.getLogger(__name__)
 
 
 class Command(BaseCommand):
+"""
+Support "fixing" schedules that currently have start dates prior to the course start date.
+
+This can happen if a course start date is moved into the future and the corresponding schedules are not updated for any reason.
+"""
 
     def add_arguments(self, parser):
         parser.add_argument('--dry-run', default=False, action='store_true')

--- a/openedx/core/djangoapps/schedules/management/commands/sync_schedules_to_course_start.py
+++ b/openedx/core/djangoapps/schedules/management/commands/sync_schedules_to_course_start.py
@@ -40,7 +40,6 @@ class Command(BaseCommand):
             WHERE
                 s.start < c.start
                 AND s.start > %s
-                AND c.start < CURRENT_DATE()
                 AND c.id = %s;
             """
         )


### PR DESCRIPTION
Fix data left behind by the celery tasks that weren't updating schedules when course start dates were changing.

This command allows you to update the data for a single course.

Relevant tickets:
- https://openedx.atlassian.net/browse/EDUCATOR-3965
- https://openedx.atlassian.net/browse/REVMI-105
- https://openedx.atlassian.net/projects/DEVOPS/queues/custom/16/DEVOPS-8288