### PR TITLE
LEARNER-5538 : Show dates in dropdown for program dashboard

### DIFF
--- a/lms/static/js/learner_dashboard/models/course_card_model.js
+++ b/lms/static/js/learner_dashboard/models/course_card_model.js
@@ -152,10 +152,18 @@ class CourseCardModel extends Backbone.Model {
   formatDateString(run) {
     const pacingType = run.pacing_type;
     let dateString;
-    const start = CourseCardModel.valueIsDefined(run.start_date) ?
+    let start = CourseCardModel.valueIsDefined(run.start_date) ?
       run.advertised_start || run.start_date :
       this.get('start_date');
-    const end = CourseCardModel.valueIsDefined(run.end_date) ? run.end_date : this.get('end_date');
+    if (start === undefined) {
+      start = CourseCardModel.valueIsDefined(run.start) ?
+        run.advertised_start || CourseCardModel.formatDate(run.start) : undefined;
+    }
+    let end = CourseCardModel.valueIsDefined(run.end_date) ? run.end_date : this.get('end_date');
+    if (end === undefined) {
+      end = CourseCardModel.valueIsDefined(run.end) ?
+        CourseCardModel.formatDate(run.end) : undefined;
+    }
     const now = new Date();
     const startDate = new Date(start);
     const endDate = new Date(end);


### PR DESCRIPTION
#### Description 
On the programs dashboard for programs with bundling available, the dropdown "Select a Session" menus for each course are blank. For [this](https://courses.edx.org/dashboard/programs/f374fbdf-4f5e-483e-90a4-602be7a18bf7/ ) program see how for instructor led courses the session (course run) start date is not showing.

This is preventing learners from selecting and enrolling in a course run of their choice from this page. When they click any on the blank lines one of the course run is selected but user is unable to see for himself what date to choose.

#### Changes
The problem was with variable name. The variable run which represents courseRun here has no key "start_date"  or "end_date", instead it has run.start and run.end receptively.

#### Tests
- Tested on local by creating a instructor led course and self-paced course in a program