### PR TITLE
update web fragments

### DIFF
--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -236,7 +236,7 @@ urllib3==1.23
 user-util==0.1.5
 voluptuous==0.11.5
 watchdog==0.9.0
-web-fragments==0.2.2
+web-fragments==0.3.0
 webencodings==0.5.1       # via html5lib
 webob==1.8.5              # via xblock
 wrapt==1.10.5

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -348,7 +348,7 @@ voluptuous==0.11.5
 vulture==1.0
 w3lib==1.20.0
 watchdog==0.9.0
-web-fragments==0.2.2
+web-fragments==0.3.0
 webencodings==0.5.1
 webob==1.8.5
 werkzeug==0.14.1

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -334,7 +334,7 @@ virtualenv==16.4.0        # via tox
 voluptuous==0.11.5
 w3lib==1.20.0             # via parsel, scrapy
 watchdog==0.9.0
-web-fragments==0.2.2
+web-fragments==0.3.0
 webencodings==0.5.1
 webob==1.8.5
 werkzeug==0.14.1          # via flask


### PR DESCRIPTION
Upgrade the version of web-fragments. This was recently upgraded to support python 3.6 (https://openedx.atlassian.net/browse/INCR-73)