### PR TITLE
EDUCATOR-4082 - Proctoring override creates PSG if none exists

### DIFF
--- a/lms/djangoapps/grades/tests/test_services.py
+++ b/lms/djangoapps/grades/tests/test_services.py
@@ -21,6 +21,9 @@ from ..constants import ScoreDatabaseTableEnum
 
 
 class MockWaffleFlag(object):
+    """
+    A Mock WaffleFlag object.
+    """
     def __init__(self, state):
         self.state = state
 
@@ -40,6 +43,11 @@ class GradesServiceTests(ModuleStoreTestCase):
         self.service = GradesService()
         self.course = CourseFactory.create(org='edX', number='DemoX', display_name='Demo_Course', run='Spring2019')
         self.subsection = ItemFactory.create(parent=self.course, category="subsection", display_name="Subsection")
+        self.subsection_without_grade = ItemFactory.create(
+            parent=self.course,
+            category="subsection",
+            display_name="Subsection without grade"
+        )
         self.user = UserFactory()
         self.grade = PersistentSubsectionGrade.update_or_create_grade(
             user_id=self.user.id,
@@ -66,6 +74,7 @@ class GradesServiceTests(ModuleStoreTestCase):
         }
 
     def tearDown(self):
+        super(GradesServiceTests, self).tearDown()
         PersistentSubsectionGradeOverride.objects.all().delete()  # clear out all previous overrides
         self.signal_patcher.stop()
         self.id_patcher.stop()
@@ -140,37 +149,24 @@ class GradesServiceTests(ModuleStoreTestCase):
         self.assertEqual(override_history.action, history_action)
 
     @ddt.data(
-        [{
+        {
             'earned_all': 0.0,
             'earned_graded': 0.0
-        }, {
-            'earned_all': 0.0,
-            'earned_graded': 0.0
-        }],
-        [{
+        },
+        {
             'earned_all': 0.0,
             'earned_graded': None
-        }, {
-            'earned_all': 0.0,
-            'earned_graded': 5.0
-        }],
-        [{
+        },
+        {
             'earned_all': None,
             'earned_graded': None
-        }, {
-            'earned_all': 6.0,
-            'earned_graded': 5.0
-        }],
-        [{
+        },
+        {
             'earned_all': 3.0,
             'earned_graded': 2.0
-        }, {
-            'earned_all': 3.0,
-            'earned_graded': 2.0
-        }],
+        },
     )
-    @ddt.unpack
-    def test_override_subsection_grade(self, override, expected):
+    def test_override_subsection_grade(self, override):
         self.service.override_subsection_grade(
             user_id=self.user.id,
             course_key_or_id=self.course.id,
@@ -195,6 +191,57 @@ class GradesServiceTests(ModuleStoreTestCase):
                 user_id=self.user.id,
                 course_id=unicode(self.course.id),
                 usage_id=unicode(self.subsection.location),
+                only_if_higher=False,
+                modified=override_obj.modified,
+                score_deleted=False,
+                score_db_table=ScoreDatabaseTableEnum.overrides
+            )
+        )
+        override_history = PersistentSubsectionGradeOverrideHistory.objects.filter(override_id=override_obj.id).first()
+        self._verify_override_history(override_history, PersistentSubsectionGradeOverrideHistory.CREATE_OR_UPDATE)
+
+    def test_override_subsection_grade_no_psg(self):
+        """
+        When there is no PersistentSubsectionGrade associated with the learner
+        and subsection to override, one should be created.
+        """
+        earned_all_override = 2
+        earned_graded_override = 0
+        self.service.override_subsection_grade(
+            user_id=self.user.id,
+            course_key_or_id=self.course.id,
+            usage_key_or_id=self.subsection_without_grade.location,
+            earned_all=earned_all_override,
+            earned_graded=earned_graded_override
+        )
+
+        # Assert that a new PersistentSubsectionGrade was created
+        subsection_grade = self.service.get_subsection_grade(
+            self.user.id,
+            self.course.id,
+            self.subsection_without_grade.location
+        )
+        self.assertIsNotNone(subsection_grade)
+        self.assertEqual(0, subsection_grade.earned_all)
+        self.assertEqual(0, subsection_grade.earned_graded)
+
+        # Now assert things about the grade override
+        override_obj = self.service.get_subsection_grade_override(
+            self.user.id,
+            self.course.id,
+            self.subsection_without_grade.location
+        )
+        self.assertIsNotNone(override_obj)
+        self.assertEqual(override_obj.earned_all_override, earned_all_override)
+        self.assertEqual(override_obj.earned_graded_override, earned_graded_override)
+
+        self.assertEqual(
+            self.mock_signal.call_args,
+            call(
+                sender=None,
+                user_id=self.user.id,
+                course_id=unicode(self.course.id),
+                usage_id=unicode(self.subsection_without_grade.location),
                 only_if_higher=False,
                 modified=override_obj.modified,
                 score_deleted=False,


### PR DESCRIPTION
When creating subsection grade override from the grades service, create a PSG if one does not exist.

https://openedx.atlassian.net/browse/EDUCATOR-4082