### PR TITLE
Handle out-of-memory exception on Sysadmin Courses

### DIFF
--- a/lms/djangoapps/dashboard/sysadmin.py
+++ b/lms/djangoapps/dashboard/sysadmin.py
@@ -358,6 +358,8 @@ class Courses(SysadminDashboardView):
             info = [output_json['commit'],
                     output_json['date'],
                     output_json['author'], ]
+        except OSError as error:
+            log.warning(text_type(u"Error fetching git data: %s - %s"), text_type(cdir), text_type(error))
         except (ValueError, subprocess.CalledProcessError):
             pass
 


### PR DESCRIPTION
We've been running into OoM issues with this functionality while
executing on one of our smaller application servers.
- Sometimes this manifests by preventing the entire page from loading
  (exception during the GET).
- At others, it occurs using the `Delete course from site` functionality
  by breaking during the POST handler. This case is particularly
  frustrating because the course actually is deleted, but looks like it
  may not have been. Internally, this is because the 500 error occurs
  _after_ the course has been successfully deleted, though this is
  opaque to the end-user.

While this doesn't address the underlying memory issue,
it does at least allow the app to recover gracefully.