### PR TITLE
Adds username replacement API

### DIFF
--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -1361,6 +1361,7 @@ ADVANCED_PROBLEM_TYPES = [
     }
 ]
 
+USERNAME_REPLACEMENT_WORKER = "REPLACE WITH VALID USERNAME"
 
 # Files and Uploads type filter values
 

--- a/lms/djangoapps/discussion_api/tests/test_views.py
+++ b/lms/djangoapps/discussion_api/tests/test_views.py
@@ -282,7 +282,7 @@ class ReplaceUsernamesViewTest(DiscussionAPIViewTestMixin, ModuleStoreTestCase):
         data = {
             "username_mappings": mapping_data
         }
-        response = self.call_api(self.url, self.client_user, data)
+        response = self.call_api(self.client_user, data)
         self.assertEqual(response.status_code, 400)
 
     def test_auth(self):
@@ -300,11 +300,11 @@ class ReplaceUsernamesViewTest(DiscussionAPIViewTestMixin, ModuleStoreTestCase):
 
         # Test non-service worker
         random_user = UserFactory()
-        response = self.call_api(self.url, random_user, data)
+        response = self.call_api(random_user, data)
         self.assertEqual(response.status_code, 403)
 
         # Test service worker
-        response = self.call_api(self.url, self.client_user, data)
+        response = self.call_api(self.client_user, data)
         self.assertEqual(response.status_code, 200)
 
     def test_basic(self):
@@ -319,7 +319,7 @@ class ReplaceUsernamesViewTest(DiscussionAPIViewTestMixin, ModuleStoreTestCase):
             'successful_replacements': data["username_mappings"]
         }
         self.register_get_username_replacement_response(self.user)
-        response = self.call_api(self.url, self.client_user, data)
+        response = self.call_api(self.client_user, data)
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.data, expected_response)
 

--- a/lms/djangoapps/discussion_api/tests/test_views.py
+++ b/lms/djangoapps/discussion_api/tests/test_views.py
@@ -236,6 +236,7 @@ class RetireViewTest(DiscussionAPIViewTestMixin, ModuleStoreTestCase):
         """
         pass
 
+
 @httpretty.activate
 @mock.patch('django.conf.settings.USERNAME_REPLACEMENT_WORKER', 'test_replace_username_service_worker')
 @mock.patch.dict("django.conf.settings.FEATURES", {"ENABLE_DISCUSSION_SERVICE": True})
@@ -311,6 +312,7 @@ class ReplaceUsernameViewTest(DiscussionAPIViewTestMixin, ModuleStoreTestCase):
         Override the parent implementation of this, we JWT auth for this API
         """
         pass
+
 
 @ddt.ddt
 @mock.patch.dict("django.conf.settings.FEATURES", {"ENABLE_DISCUSSION_SERVICE": True})

--- a/lms/djangoapps/discussion_api/tests/test_views.py
+++ b/lms/djangoapps/discussion_api/tests/test_views.py
@@ -10,7 +10,6 @@ from urlparse import urlparse
 import ddt
 import httpretty
 import mock
-from django.conf import settings
 from django.urls import reverse
 from edx_oauth2_provider.tests.factories import ClientFactory, AccessTokenFactory
 from opaque_keys.edx.keys import CourseKey

--- a/lms/djangoapps/discussion_api/tests/test_views.py
+++ b/lms/djangoapps/discussion_api/tests/test_views.py
@@ -10,6 +10,7 @@ from urlparse import urlparse
 import ddt
 import httpretty
 import mock
+from django.conf import settings
 from django.urls import reverse
 from edx_oauth2_provider.tests.factories import ClientFactory, AccessTokenFactory
 from opaque_keys.edx.keys import CourseKey
@@ -235,6 +236,81 @@ class RetireViewTest(DiscussionAPIViewTestMixin, ModuleStoreTestCase):
         """
         pass
 
+@httpretty.activate
+@mock.patch('django.conf.settings.USERNAME_REPLACEMENT_WORKER', 'test_replace_username_service_worker')
+@mock.patch.dict("django.conf.settings.FEATURES", {"ENABLE_DISCUSSION_SERVICE": True})
+class ReplaceUsernameViewTest(DiscussionAPIViewTestMixin, ModuleStoreTestCase):
+    """Tests for ReplaceUsernameView"""
+    def setUp(self):
+        super(ReplaceUsernameViewTest, self).setUp()
+        self.client_user = UserFactory()
+        self.client_user.username = "test_replace_username_service_worker"
+        self.new_username = "test_username_replacement"
+        self.url = reverse("replace_discussion_username")
+
+    def assert_response_correct(self, response, expected_status, expected_content):
+        """
+        Assert that the response has the given status code and content
+        """
+        self.assertEqual(response.status_code, expected_status)
+
+        if expected_content:
+            self.assertEqual(text_type(response.content), expected_content)
+
+    def build_jwt_headers(self, user):
+        """
+        Helper function for creating headers for the JWT authentication.
+        """
+        token = create_jwt_for_user(user)
+        headers = {'HTTP_AUTHORIZATION': 'JWT ' + token}
+        return headers
+
+    def test_missing_params(self):
+        headers = self.build_jwt_headers(self.client_user)
+        # Using this instead of ddt so we can access self.user
+        bad_post_contents = (
+            {},
+            {"current_username": self.user.username},
+            {"new_username": "test_username_replacement"},
+        )
+        for data in bad_post_contents:
+            response = self.client.post(self.url, data, **headers)
+            self.assert_response_correct(response, 400, "")
+
+    def test_basic(self):
+        """ Check successful replacement """
+        self.register_get_username_replacement_response(self.user)
+        headers = self.build_jwt_headers(self.client_user)
+        data = {"current_username": self.user.username, "new_username": self.new_username}
+        response = self.client.post(self.url, data, **headers)
+        self.assert_response_correct(response, 204, "")
+
+    def test_nonexistant_user(self):
+        self.register_get_username_replacement_response(self.user)
+        headers = self.build_jwt_headers(self.client_user)
+        data = {"current_username": "non-existant-user", "new_username": self.new_username}
+        response = self.client.post(self.url, data, **headers)
+        self.assert_response_correct(response, 404, "")
+
+    def test_client_404(self):
+        self.register_get_username_replacement_response(self.user, status=404)
+        headers = self.build_jwt_headers(self.client_user)
+        data = {"current_username": self.user.username, "new_username": self.new_username}
+        response = self.client.post(self.url, data, **headers)
+        self.assert_response_correct(response, 404, "")
+
+    def test_client_500(self):
+        self.register_get_username_replacement_response(self.user, status=500)
+        headers = self.build_jwt_headers(self.client_user)
+        data = {"current_username": self.user.username, "new_username": self.new_username}
+        response = self.client.post(self.url, data, **headers)
+        self.assert_response_correct(response, 500, "")
+
+    def test_not_authenticated(self):
+        """
+        Override the parent implementation of this, we JWT auth for this API
+        """
+        pass
 
 @ddt.ddt
 @mock.patch.dict("django.conf.settings.FEATURES", {"ENABLE_DISCUSSION_SERVICE": True})

--- a/lms/djangoapps/discussion_api/tests/utils.py
+++ b/lms/djangoapps/discussion_api/tests/utils.py
@@ -226,6 +226,15 @@ class CommentsServiceMockMixin(object):
             status=status
         )
 
+    def register_get_username_replacement_response(self, user, status=200, body=""):
+        assert httpretty.is_enabled(), 'httpretty must be enabled to mock calls.'
+        httpretty.register_uri(
+            httpretty.POST,
+            "http://localhost:4567/api/v1/users/{id}/replace_username".format(id=user.id),
+            body=body,
+            status=status
+        )
+
     def register_subscribed_threads_response(self, user, threads, page, num_pages):
         """Register a mock response for GET on the CS user instance endpoint"""
         assert httpretty.is_enabled(), 'httpretty must be enabled to mock calls.'

--- a/lms/djangoapps/discussion_api/urls.py
+++ b/lms/djangoapps/discussion_api/urls.py
@@ -13,7 +13,7 @@ from discussion_api.views import (
     CourseView,
     ThreadViewSet,
     RetireUserView,
-    ReplaceUsernameView,
+    ReplaceUsernamesView,
 )
 
 ROUTER = SimpleRouter()
@@ -41,7 +41,7 @@ urlpatterns = [
         name="discussion_course"
     ),
     url(r"^v1/accounts/retire_forum", RetireUserView.as_view(), name="retire_discussion_user"),
-    url(r"^v1/accounts/replace_username", ReplaceUsernameView.as_view(), name="replace_discussion_username"),
+    url(r"^v1/accounts/replace_username", ReplaceUsernamesView.as_view(), name="replace_discussion_username"),
     url(
         r"^v1/course_topics/{}".format(settings.COURSE_ID_PATTERN),
         CourseTopicsView.as_view(),

--- a/lms/djangoapps/discussion_api/urls.py
+++ b/lms/djangoapps/discussion_api/urls.py
@@ -13,6 +13,7 @@ from discussion_api.views import (
     CourseView,
     ThreadViewSet,
     RetireUserView,
+    ReplaceUsernameView,
 )
 
 ROUTER = SimpleRouter()
@@ -40,6 +41,7 @@ urlpatterns = [
         name="discussion_course"
     ),
     url(r"^v1/accounts/retire_forum", RetireUserView.as_view(), name="retire_discussion_user"),
+    url(r"^v1/accounts/replace_username", ReplaceUsernameView.as_view(), name="replace_discussion_username"),
     url(
         r"^v1/course_topics/{}".format(settings.COURSE_ID_PATTERN),
         CourseTopicsView.as_view(),

--- a/lms/djangoapps/discussion_api/views.py
+++ b/lms/djangoapps/discussion_api/views.py
@@ -682,6 +682,7 @@ class ReplaceUsernamesView(APIView):
                 return False
         return True
 
+
 class CourseDiscussionSettingsAPIView(DeveloperErrorViewMixin, APIView):
     """
     **Use Cases**

--- a/lms/djangoapps/discussion_api/views.py
+++ b/lms/djangoapps/discussion_api/views.py
@@ -627,7 +627,7 @@ class ReplaceUsernameView(APIView):
             if exc.status_code == 404:
                 return Response(status=status.HTTP_404_NOT_FOUND)
             raise
-        except Exception as exc:
+        except Exception as exc:  #pylint disable-broad-except
             return Response(text_type(exc), status=status.HTTP_500_INTERNAL_SERVER_ERROR)
         return Response(status=status.HTTP_204_NO_CONTENT)
 

--- a/lms/djangoapps/discussion_api/views.py
+++ b/lms/djangoapps/discussion_api/views.py
@@ -627,7 +627,7 @@ class ReplaceUsernameView(APIView):
             if exc.status_code == 404:
                 return Response(status=status.HTTP_404_NOT_FOUND)
             raise
-        except Exception as exc:  #pylint disable-broad-except
+        except Exception as exc:  # pylint disable-broad-except
             return Response(text_type(exc), status=status.HTTP_500_INTERNAL_SERVER_ERROR)
         return Response(status=status.HTTP_204_NO_CONTENT)
 

--- a/lms/djangoapps/discussion_api/views.py
+++ b/lms/djangoapps/discussion_api/views.py
@@ -658,12 +658,20 @@ class ReplaceUsernamesView(APIView):
             )
             return True
         except comment_client.CommentClientRequestError as exc:
-            log.exception(
-                u"Unable to change username from %s to %s in forums because forums API call failed with: %s.",
-                current_username,
-                new_username,
-                exc,
-            )
+            if exc.status_code == 404:
+                log.info(
+                    u"Unable to change username from %s to %s in forums because user doesn't exist in forums",
+                    current_username,
+                    new_username,
+                )
+                return True
+            else:
+                log.exception(
+                    u"Unable to change username from %s to %s in forums because forums API call failed with: %s.",
+                    current_username,
+                    new_username,
+                    exc,
+                )
             return False
 
         log.info(

--- a/lms/djangoapps/discussion_api/views.py
+++ b/lms/djangoapps/discussion_api/views.py
@@ -627,7 +627,7 @@ class ReplaceUsernameView(APIView):
             if exc.status_code == 404:
                 return Response(status=status.HTTP_404_NOT_FOUND)
             raise
-        except Exception as exc:  # pylint disable-broad-except
+        except Exception as exc:  # pylint: disable=broad-except
             return Response(text_type(exc), status=status.HTTP_500_INTERNAL_SERVER_ERROR)
         return Response(status=status.HTTP_204_NO_CONTENT)
 

--- a/lms/djangoapps/discussion_api/views.py
+++ b/lms/djangoapps/discussion_api/views.py
@@ -588,6 +588,7 @@ class RetireUserView(APIView):
 
         return Response(status=status.HTTP_204_NO_CONTENT)
 
+
 class ReplaceUsernameView(APIView):
     """
     A request from the settings.USERNAME_REPLACEMENT_WORKER user can replace
@@ -629,15 +630,6 @@ class ReplaceUsernameView(APIView):
         except Exception as exc:
             return Response(text_type(exc), status=status.HTTP_500_INTERNAL_SERVER_ERROR)
         return Response(status=status.HTTP_204_NO_CONTENT)
-
-
-
-
-
-
-
-
-
 
 
 class CourseDiscussionSettingsAPIView(DeveloperErrorViewMixin, APIView):

--- a/lms/djangoapps/discussion_api/views.py
+++ b/lms/djangoapps/discussion_api/views.py
@@ -643,6 +643,9 @@ class ReplaceUsernamesView(APIView):
         )
 
     def _replace_username(self, current_username, new_username):
+        """
+        Replaces the current username with the new username in the forums service
+        """
         try:
             # This API will be called after the regular LMS API, so the username in
             # the DB will have already been updated to new_username

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -3450,6 +3450,8 @@ RETIREMENT_STATES = [
     'COMPLETE',
 ]
 
+USERNAME_REPLACEMENT_WORKER = "REPLACE WITH VALID USERNAME"
+
 ############## Settings for Microfrontends  #########################
 # If running a Gradebook container locally,
 # modify lms/envs/private.py to give it a non-null value

--- a/lms/lib/comment_client/user.py
+++ b/lms/lib/comment_client/user.py
@@ -225,6 +225,7 @@ def _url_for_retire(user_id):
     """
     return "{prefix}/users/{user_id}/retire".format(prefix=settings.PREFIX, user_id=user_id)
 
+
 def _url_for_username_replacement(user_id):
     """
     Returns cs_comments_servuce url endpoint to replace the username of a user

--- a/lms/lib/comment_client/user.py
+++ b/lms/lib/comment_client/user.py
@@ -180,6 +180,17 @@ class User(models.Model):
             metric_tags=self._metric_tags
         )
 
+    def replace_username(self, new_username):
+        url = _url_for_username_replacement(self.id)
+        params = {"new_username": new_username}
+
+        utils.perform_request(
+            'post',
+            url,
+            params,
+            raw=True,
+        )
+
 
 def _url_for_vote_comment(comment_id):
     return "{prefix}/comments/{comment_id}/votes".format(prefix=settings.PREFIX, comment_id=comment_id)
@@ -213,3 +224,9 @@ def _url_for_retire(user_id):
     Returns cs_comments_service url endpoint to retire a user (remove all post content, etc.)
     """
     return "{prefix}/users/{user_id}/retire".format(prefix=settings.PREFIX, user_id=user_id)
+
+def _url_for_username_replacement(user_id):
+    """
+    Returns cs_comments_servuce url endpoint to replace the username of a user
+    """
+    return "{prefix}/users/{user_id}/replace_username".format(prefix=settings.PREFIX, user_id=user_id)

--- a/openedx/core/djangoapps/user_api/accounts/permissions.py
+++ b/openedx/core/djangoapps/user_api/accounts/permissions.py
@@ -6,6 +6,7 @@ from __future__ import unicode_literals
 from django.conf import settings
 from rest_framework import permissions
 
+
 class CanDeactivateUser(permissions.BasePermission):
     """
     Grants access to AccountDeactivationView if the requesting user is a superuser
@@ -23,6 +24,7 @@ class CanRetireUser(permissions.BasePermission):
     """
     def has_permission(self, request, view):
         return request.user.has_perm('accounts.can_retire_user')
+
 
 class CanReplaceUsername(permissions.BasePermission):
     """

--- a/openedx/core/djangoapps/user_api/accounts/permissions.py
+++ b/openedx/core/djangoapps/user_api/accounts/permissions.py
@@ -5,6 +5,7 @@ from __future__ import unicode_literals
 
 from rest_framework import permissions
 
+USERNAME_REPLACEMENT_GROUP = "username_replacement_admin"
 
 class CanDeactivateUser(permissions.BasePermission):
     """
@@ -23,3 +24,11 @@ class CanRetireUser(permissions.BasePermission):
     """
     def has_permission(self, request, view):
         return request.user.has_perm('accounts.can_retire_user')
+
+class CanReplaceUsername(permissions.BasePermission):
+    """
+    Grants access to the Username Replacement API for anyone in the group,
+    including the service user.
+    """
+    def has_permission(self, request, view):
+        return request.user.groups.filter(name=USERNAME_REPLACEMENT_GROUP).exists()

--- a/openedx/core/djangoapps/user_api/accounts/permissions.py
+++ b/openedx/core/djangoapps/user_api/accounts/permissions.py
@@ -6,8 +6,6 @@ from __future__ import unicode_literals
 from django.conf import settings
 from rest_framework import permissions
 
-USERNAME_REPLACEMENT_GROUP = "username_replacement_admin"
-
 class CanDeactivateUser(permissions.BasePermission):
     """
     Grants access to AccountDeactivationView if the requesting user is a superuser

--- a/openedx/core/djangoapps/user_api/accounts/permissions.py
+++ b/openedx/core/djangoapps/user_api/accounts/permissions.py
@@ -28,8 +28,7 @@ class CanRetireUser(permissions.BasePermission):
 
 class CanReplaceUsername(permissions.BasePermission):
     """
-    Grants access to the Username Replacement API for anyone in the group,
-    including the service user.
+    Grants access to the Username Replacement API for the service user.
     """
     def has_permission(self, request, view):
         return request.user.username == getattr(settings, "USERNAME_REPLACEMENT_WORKER", False)

--- a/openedx/core/djangoapps/user_api/accounts/permissions.py
+++ b/openedx/core/djangoapps/user_api/accounts/permissions.py
@@ -3,6 +3,7 @@ Permissions classes for User accounts API views.
 """
 from __future__ import unicode_literals
 
+from django.conf import settings
 from rest_framework import permissions
 
 USERNAME_REPLACEMENT_GROUP = "username_replacement_admin"
@@ -31,4 +32,4 @@ class CanReplaceUsername(permissions.BasePermission):
     including the service user.
     """
     def has_permission(self, request, view):
-        return request.user.groups.filter(name=USERNAME_REPLACEMENT_GROUP).exists()
+        return request.user.username == getattr(settings, "USERNAME_REPLACEMENT_WORKER")

--- a/openedx/core/djangoapps/user_api/accounts/permissions.py
+++ b/openedx/core/djangoapps/user_api/accounts/permissions.py
@@ -32,4 +32,4 @@ class CanReplaceUsername(permissions.BasePermission):
     including the service user.
     """
     def has_permission(self, request, view):
-        return request.user.username == getattr(settings, "USERNAME_REPLACEMENT_WORKER")
+        return request.user.username == getattr(settings, "USERNAME_REPLACEMENT_WORKER", False)

--- a/openedx/core/djangoapps/user_api/accounts/tests/test_views.py
+++ b/openedx/core/djangoapps/user_api/accounts/tests/test_views.py
@@ -951,7 +951,7 @@ class UsernameReplacementViewTests(APITestCase):
         Helper function for creating headers for the JWT authentication.
         """
         token = create_jwt_for_user(user)
-        headers = {'HTTP_AUTHORIZATION': token}
+        headers = {'HTTP_AUTHORIZATION': 'JWT {}'.format(token)}
         return headers
 
     def call_api(self, user, data):

--- a/openedx/core/djangoapps/user_api/accounts/tests/test_views.py
+++ b/openedx/core/djangoapps/user_api/accounts/tests/test_views.py
@@ -951,7 +951,7 @@ class UsernameReplacementViewTests(APITestCase):
         Helper function for creating headers for the JWT authentication.
         """
         token = create_jwt_for_user(user)
-        headers = {'HTTP_AUTHORIZATION': 'JWT {}'.format(token)}
+        headers = {'HTTP_AUTHORIZATION': u'JWT {}'.format(token)}
         return headers
 
     def call_api(self, user, data):

--- a/openedx/core/djangoapps/user_api/accounts/tests/test_views.py
+++ b/openedx/core/djangoapps/user_api/accounts/tests/test_views.py
@@ -17,6 +17,7 @@ import mock
 import pytz
 from rest_framework.test import APIClient, APITestCase
 
+from openedx.core.djangoapps.oauth_dispatch.jwt import create_jwt_for_user
 from openedx.core.djangoapps.user_api.accounts import ACCOUNT_VISIBILITY_PREF_KEY
 from openedx.core.djangoapps.user_api.models import UserPreference
 from openedx.core.djangoapps.user_api.preferences.api import set_user_preference
@@ -932,3 +933,81 @@ class TestAccountAPITransactions(TransactionTestCase):
         data = response.data
         self.assertEqual(old_email, data["email"])
         self.assertEqual(u"m", data["gender"])
+
+
+@ddt.ddt
+@mock.patch('django.conf.settings.USERNAME_REPLACEMENT_WORKER', 'test_replace_username_service_worker')
+class UsernameReplacementViewTests(APITestCase):
+    """ Tests UsernameReplacementView """
+    SERVICE_USERNAME = 'test_replace_username_service_worker'
+
+    def setUp(self):
+        super(UsernameReplacementViewTests, self).setUp()
+        self.service_user = UserFactory(username=self.SERVICE_USERNAME)
+        self.url = reverse("username_replacement")
+
+    def build_jwt_headers(self, user):
+        """
+        Helper function for creating headers for the JWT authentication.
+        """
+        token = create_jwt_for_user(user)
+        headers = {'HTTP_AUTHORIZATION': token}
+        return headers
+
+    def call_api(self, user, data):
+        """ Helper function to call API with data """
+        data = json.dumps(data)
+        headers = self.build_jwt_headers(user)
+        return self.client.post(self.url, data, content_type='application/json', **headers)
+
+    def test_auth(self):
+        """ Verify the endpoint only works with the service worker """
+        data = {
+            "username_mappings": [
+                {"test_username_1": "test_new_username_1"},
+                {"test_username_2": "test_new_username_2"}
+            ]
+        }
+
+        # Test unauthenticated
+        response = self.client.post(self.url)
+        self.assertEqual(response.status_code, 401)
+
+        # Test non-service worker
+        random_user = UserFactory()
+        response = self.call_api(random_user, data)
+        self.assertEqual(response.status_code, 403)
+
+        # Test service worker
+        response = self.call_api(self.service_user, data)
+        self.assertEqual(response.status_code, 200)
+
+    @ddt.data(
+        [{}, {}],
+        {},
+        [{"test_key": "test_value", "test_key_2": "test_value_2"}]
+    )
+    def test_bad_schema(self, mapping_data):
+        """ Verify the endpoint rejects bad data schema """
+        data = {
+            "username_mappings": mapping_data
+        }
+        response = self.call_api(self.service_user, data)
+        self.assertEqual(response.status_code, 400)
+
+    def test_existing_and_non_existing_users(self):
+        """ Tests a mix of existing and non existing users """
+        random_users = [UserFactory() for _ in range(5)]
+        fake_usernames = ["myname_" + str(x) for x in range(5)]
+        existing_users = [{user.username: user.username + '_new'} for user in random_users]
+        non_existing_users = [{username: username + '_new'} for username in fake_usernames]
+        data = {
+            "username_mappings": existing_users + non_existing_users
+        }
+        expected_response = {
+            'failed_replacements': [],
+            'successful_replacements': existing_users + non_existing_users
+        }
+        response = self.call_api(self.service_user, data)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.data, expected_response)

--- a/openedx/core/djangoapps/user_api/accounts/views.py
+++ b/openedx/core/djangoapps/user_api/accounts/views.py
@@ -1145,21 +1145,25 @@ class UsernameReplacementView(APIView):
                         **{column: new_username}
                     )
         except Exception as exc:  # pylint: disable-broad-except
-            log.exception("Unable to change username from {current} to {new}. Reason: {error}".format(
-                current=current_username,
-                new=new_username,
-                error=exc
-            ))
+            log.exception(
+                "Unable to change username from %s to %s. Reason: %s",
+                current_username,
+                new_username,
+                exc
+            )
             return False
         if num_rows_changed == 0:
-            log.warning("Unable to change username from {current} to {new} because {current} doesn't exist.".format(
-                current=current_username,
-                new=new_username,
-            ))
+            log.warning(
+                "Unable to change username from %s to %s because %s doesn't exist.",
+                current_username,
+                new_username,
+                current_username,
+            )
             return False
 
-        log.info("Successfully changed username from {current} to {new}.".format(
-            current=current_username,
-            new=new_username,
-        ))
+        log.info(
+            "Successfully changed username from %s to %s.",
+            current_username,
+            new_username,
+        )
         return True

--- a/openedx/core/djangoapps/user_api/accounts/views.py
+++ b/openedx/core/djangoapps/user_api/accounts/views.py
@@ -1006,6 +1006,7 @@ class AccountRetirementView(ViewSet):
         for entitlement in CourseEntitlement.objects.filter(user_id=user.id):
             entitlement.courseentitlementsupportdetail_set.all().update(comments='')
 
+
 class UsernameReplacementView(APIView):
     """
     WARNING: This API is only meant to be used as part of a larger job that
@@ -1163,4 +1164,3 @@ class UsernameReplacementView(APIView):
             new=new_username,
         ))
         return True
-

--- a/openedx/core/djangoapps/user_api/accounts/views.py
+++ b/openedx/core/djangoapps/user_api/accounts/views.py
@@ -1144,9 +1144,9 @@ class UsernameReplacementView(APIView):
                     ).update(
                         **{column: new_username}
                     )
-        except Exception as exc:  # pylint: disable-broad-except
+        except Exception as exc:  # pylint: disable=broad-except
             log.exception(
-                "Unable to change username from %s to %s. Reason: %s",
+                u"Unable to change username from %s to %s. Reason: %s",
                 current_username,
                 new_username,
                 exc
@@ -1154,7 +1154,7 @@ class UsernameReplacementView(APIView):
             return False
         if num_rows_changed == 0:
             log.warning(
-                "Unable to change username from %s to %s because %s doesn't exist.",
+                u"Unable to change username from %s to %s because %s doesn't exist.",
                 current_username,
                 new_username,
                 current_username,
@@ -1162,7 +1162,7 @@ class UsernameReplacementView(APIView):
             return False
 
         log.info(
-            "Successfully changed username from %s to %s.",
+            u"Successfully changed username from %s to %s.",
             current_username,
             new_username,
         )

--- a/openedx/core/djangoapps/user_api/accounts/views.py
+++ b/openedx/core/djangoapps/user_api/accounts/views.py
@@ -1014,6 +1014,9 @@ class UsernameReplacementView(APIView):
 
     API will recieve a list of current usernames and their requested new
     username. If their new username is taken, it will randomly assign a new username.
+
+    This API will be called first, before calling the APIs in other services as this
+    one handles the checks on the usernames provided.
     """
     authentication_classes = (JwtAuthentication, )
     permission_classes = (permissions.IsAuthenticated, CanReplaceUsername)

--- a/openedx/core/djangoapps/user_api/accounts/views.py
+++ b/openedx/core/djangoapps/user_api/accounts/views.py
@@ -1148,9 +1148,10 @@ class UsernameReplacementView(APIView):
                     )
         except Exception as exc:  # pylint: disable=broad-except
             log.exception(
-                u"Unable to change username from %s to %s. Reason: %s",
+                u"Unable to change username from %s to %s. Failed on table %s because %s",
                 current_username,
                 new_username,
+                model.__class__.__name__,  # Retrieves the model name that it failed on
                 exc
             )
             return False

--- a/openedx/core/djangoapps/user_api/accounts/views.py
+++ b/openedx/core/djangoapps/user_api/accounts/views.py
@@ -1052,8 +1052,6 @@ class UsernameReplacementView(APIView):
                 {"old_username_2": "new_username_2"}
             ]
         }
-
-        TODO: Determine if we need an audit trail outside of logging and API response.
         """
 
         # (model_name, column_name)
@@ -1117,7 +1115,11 @@ class UsernameReplacementView(APIView):
         return True
 
     def _generate_unique_username(self, desired_username, suffix_length=4):
-        """ Accepts a username and returns a unique username if the requested is taken """
+        """
+        Generates a unique username.
+        If the desired username is available, that will be returned.
+        Otherwise it will generate unique suffixs to the desired username until it is an available username.
+        """
         new_username = desired_username
         # Keep checking usernames in case desired_username + random suffix is already taken
         while True:

--- a/openedx/core/djangoapps/user_api/accounts/views.py
+++ b/openedx/core/djangoapps/user_api/accounts/views.py
@@ -1144,7 +1144,7 @@ class UsernameReplacementView(APIView):
                     ).update(
                         **{column: new_username}
                     )
-        except Exception as exc:  #pylint: disable-broad-except
+        except Exception as exc:  # pylint: disable-broad-except
             log.exception("Unable to change username from {current} to {new}. Reason: {error}".format(
                 current=current_username,
                 new=new_username,

--- a/openedx/core/djangoapps/user_api/accounts/views.py
+++ b/openedx/core/djangoapps/user_api/accounts/views.py
@@ -1153,17 +1153,16 @@ class UsernameReplacementView(APIView):
             )
             return False
         if num_rows_changed == 0:
-            log.warning(
+            log.info(
                 u"Unable to change username from %s to %s because %s doesn't exist.",
                 current_username,
                 new_username,
                 current_username,
             )
-            return False
-
-        log.info(
-            u"Successfully changed username from %s to %s.",
-            current_username,
-            new_username,
-        )
+        else:
+            log.info(
+                u"Successfully changed username from %s to %s.",
+                current_username,
+                new_username,
+            )
         return True

--- a/openedx/core/djangoapps/user_api/accounts/views.py
+++ b/openedx/core/djangoapps/user_api/accounts/views.py
@@ -1118,7 +1118,6 @@ class UsernameReplacementView(APIView):
 
     def _generate_unique_username(self, desired_username, suffix_length=4):
         """ Accepts a username and returns a unique username if the requested is taken """
-        User = apps.get_model('auth.user')
         new_username = desired_username
         # Keep checking usernames in case desired_username + random suffix is already taken
         while True:
@@ -1145,7 +1144,7 @@ class UsernameReplacementView(APIView):
                     ).update(
                         **{column: new_username}
                     )
-        except Exception as exc:
+        except Exception as exc:  #pylint: disable-broad-except
             log.exception("Unable to change username from {current} to {new}. Reason: {error}".format(
                 current=current_username,
                 new=new_username,

--- a/openedx/core/djangoapps/user_api/urls.py
+++ b/openedx/core/djangoapps/user_api/urls.py
@@ -13,7 +13,8 @@ from .accounts.views import (
     AccountRetirementView,
     AccountViewSet,
     DeactivateLogoutView,
-    LMSAccountRetirementView
+    LMSAccountRetirementView,
+    UsernameReplacementView
 )
 from .preferences.views import PreferencesDetailView, PreferencesView
 from .verification_api.views import IDVerificationStatusView
@@ -149,6 +150,11 @@ urlpatterns = [
         r'^v1/accounts/update_retirement_status/$',
         RETIREMENT_UPDATE,
         name='accounts_retirement_update'
+    ),
+    url(
+        r'^v1/accounts/replace_usernames/$',
+        UsernameReplacementView.as_view(),
+        name='username_replacement'
     ),
     url(
         r'^v1/validation/registration$',


### PR DESCRIPTION
New API replaces all copies of username in LMS a desired username. Requires user be in username_replacement_admin group. Should only be ran as a larger job to update usernames across all services, otherwise the system will be left in a broken state for those users.