### PR TITLE
add back off for failing recurrent requests

### DIFF
--- a/lms/static/js/instructor_dashboard/util.js
+++ b/lms/static/js/instructor_dashboard/util.js
@@ -327,6 +327,7 @@
             this.ms = ms;
             this.fn = fn;
             this.intervalID = null;
+            this.failedTries = 0;
         }
 
         intervalManager.prototype.start = function() {
@@ -342,6 +343,15 @@
             clearInterval(this.intervalID);
             this.intervalID = null;
             return this.intervalID;
+        };
+
+        intervalManager.prototype.failed_retry_threshold = 5;
+
+        intervalManager.prototype.backOff = function() {
+            this.failedTries++;
+            if (this.failedTries >= this.failed_retry_threshold) {
+                this.stop();
+            }
         };
 
         return intervalManager;
@@ -388,6 +398,9 @@
                         ths.$no_tasks_message.append($('<p>').text(gettext('No tasks currently running.')));
                         return ths.$no_tasks_message.show();
                     }
+                },
+                error: function() {
+                    ths.task_poller.backOff();
                 }
             });
         };
@@ -464,6 +477,9 @@
                     } else {
                         return false;
                     }
+                },
+                error: function() {
+                    ths.downloads_poller.backOff();
                 }
             });
         };


### PR DESCRIPTION
## [EDUCATOR-4108](https://openedx.atlassian.net/browse/EDUCATOR-4108)

### Description

Added 'back off' method to stop sending requests to the instructor API if requests are continuously failing. Currently, the threshold of failed requests is set to 5.

### Sandbox
The fix can be tested on sandbox as follows.
- Go to https://retries.sandbox.edx.org/courses/course-v1:edX+DemoX+Demo_Course/instructor#view-data_download
- Observe (in network tab) that request to instructor API is being sent continuously.
- Logout from the sandbox in another window.
- Verify that we stop requesting instructor API after 5 failed requests.

### Reviewers
- [ ] @awaisdar001 
- [ ] @asadazam93 

 
### Post-review
- [ ] Rebase and squash commits