### PR TITLE
Segregate learner account settings strings.

### DIFF
--- a/.tx/config
+++ b/.tx/config
@@ -25,6 +25,12 @@ source_file = conf/locale/en/LC_MESSAGES/djangojs-studio.po
 source_lang = en
 type = PO
 
+[edx-platform.djangojs-account-settings-view]
+file_filter = conf/locale/<lang>/LC_MESSAGES/djangojs-account-settings-view.po
+source_file = conf/locale/en/LC_MESSAGES/djangojs-account-settings-view.po
+source_lang = en
+type = PO
+
 [edx-platform.mako]
 file_filter = conf/locale/<lang>/LC_MESSAGES/mako.po
 source_file = conf/locale/en/LC_MESSAGES/mako.po

--- a/conf/locale/config.yaml
+++ b/conf/locale/config.yaml
@@ -157,6 +157,10 @@ segment:
     djangojs-partial.po:
         djangojs-studio.po:
             - cms/*
+        djangojs-account-settings-view.po:
+            - lms/static/js/student_account/views/account_settings_view.js
+        # Segregating student account settings view strings, so that beta language message
+        # can be translated for wide set of partially supported languages.
     mako.po:
         mako-studio.po:
             - cms/*
@@ -176,5 +180,6 @@ generate_merge:
     djangojs.po:
         - djangojs-partial.po
         - djangojs-studio.po
+        - djangojs-account-settings-view.po
         - underscore.po
         - underscore-studio.po


### PR DESCRIPTION
This would let the team order translations for the beta language message to ensure that it remains translated for a wide set of partially supported languages.

LEARNER-4304