### PR TITLE
Add skip-authorization flag for DOT application creation.

### DIFF
--- a/openedx/core/djangoapps/oauth_dispatch/management/commands/create_dot_application.py
+++ b/openedx/core/djangoapps/oauth_dispatch/management/commands/create_dot_application.py
@@ -45,6 +45,10 @@ class Command(BaseCommand):
                             dest='public',
                             default=False,
                             help='Make the application public?  Confidential by default.')
+        parser.add_argument('--skip-authorization',
+                            action='store_true',
+                            dest='skip_authorization',
+                            help='Skip the in-browser user authorization?  False by default.')
         parser.add_argument('--client-id',
                             action='store',
                             dest='client_id',
@@ -61,6 +65,7 @@ class Command(BaseCommand):
         username = options['username']
         grant_type = options['grant_type']
         redirect_uris = options['redirect_uris']
+        skip_authorization = options['skip_authorization']
         client_type = Application.CLIENT_PUBLIC if options['public'] else Application.CLIENT_CONFIDENTIAL
         client_id = options['client_id']
         client_secret = options['client_secret']
@@ -79,7 +84,8 @@ class Command(BaseCommand):
             user=user,
             redirect_uris=redirect_uris,
             client_type=client_type,
-            authorization_grant_type=grant_type
+            authorization_grant_type=grant_type,
+            skip_authorization=skip_authorization
         )
         if client_id:
             create_kwargs['client_id'] = client_id

--- a/openedx/core/djangoapps/oauth_dispatch/management/commands/tests/test_create_dot_application.py
+++ b/openedx/core/djangoapps/oauth_dispatch/management/commands/tests/test_create_dot_application.py
@@ -31,13 +31,13 @@ class TestCreateDotApplication(TestCase):
         Application.objects.filter(user=self.user).delete()
 
     @ddt.data(
-        (None, None, None, None),
-        (None, None, 'client-abc', None),
-        (None, None, None, 'great-big-secret'),
-        ('password', True, 'client-dce', 'has-a-great-big-secret'),
+        (None, None, None, None, False),
+        (None, None, 'client-abc', None, False),
+        (None, None, None, 'great-big-secret', False),
+        ('password', True, 'client-dce', 'has-a-great-big-secret', True),
     )
     @ddt.unpack
-    def test_create_dot_application(self, grant_type, public, client_id, client_secret):
+    def test_create_dot_application(self, grant_type, public, client_id, client_secret, skip_auth):
         # Add optional arguments if provided
         call_args = ['testing_application', self.user.username]
         if grant_type:
@@ -58,6 +58,8 @@ class TestCreateDotApplication(TestCase):
         if client_secret:
             call_args.append('--client-secret')
             call_args.append(client_secret)
+        if skip_auth:
+            call_args.append('--skip-authorization')
 
         call_command(Command(), *call_args)
 
@@ -69,6 +71,7 @@ class TestCreateDotApplication(TestCase):
         self.assertEqual(grant_type, application.authorization_grant_type)
         self.assertEqual(client_type, application.client_type)
         self.assertEqual('', application.redirect_uris)
+        self.assertEqual(skip_auth, application.skip_authorization)
 
         if client_id:
             self.assertEqual(client_id, application.client_id)


### PR DESCRIPTION
A `skip_authorization` flag was missing from the `create_dot_application` mgmt cmd. This PR adds such a flag.