### PR TITLE
Edit worker type in ironwood Jenkinsfiles

### DIFF
--- a/scripts/Jenkinsfiles/bokchoy
+++ b/scripts/Jenkinsfiles/bokchoy
@@ -26,7 +26,7 @@ def bokchoyTestCleanup() {
 }
 
 pipeline {
-    agent { label "jenkins-worker" }
+    agent { label "ironwood-jenkins-worker" }
     options {
         timestamps()
         timeout(60)
@@ -62,7 +62,7 @@ pipeline {
                     for (int i = 1; i <= 22; i++) {
                         int index = i
                         parallel_stages["${index}"] = {
-                            node('jenkins-worker') {
+                            node('ironwood-jenkins-worker') {
                                 withEnv(["SHARD=${index}","TEST_SUITE=bok-choy"]) {
                                     try {
                                         stage("Bokchoy shard: ${index}") {

--- a/scripts/Jenkinsfiles/lettuce
+++ b/scripts/Jenkinsfiles/lettuce
@@ -25,7 +25,7 @@ def lettuceTestCleanup() {
 }
 
 pipeline {
-    agent { label "jenkins-worker" }
+    agent { label "ironwood-jenkins-worker" }
     options {
         timestamps()
         timeout(60)
@@ -57,7 +57,7 @@ pipeline {
         stage('Run Tests') {
             parallel {
                 stage("lms-acceptance") {
-                    agent { label "jenkins-worker" }
+                    agent { label "ironwood-jenkins-worker" }
                     environment {
                         TEST_SUITE = "lms-acceptance"
                     }
@@ -75,7 +75,7 @@ pipeline {
                     }
                 }
                 stage("cms-acceptance") {
-                    agent { label "jenkins-worker" }
+                    agent { label "ironwood-jenkins-worker" }
                     environment {
                         TEST_SUITE = "cms-acceptance"
                     }

--- a/scripts/Jenkinsfiles/python
+++ b/scripts/Jenkinsfiles/python
@@ -36,7 +36,7 @@ def xdist_git_branch() {
 }
 
 pipeline {
-    agent { label "jenkins-worker" }
+    agent { label "ironwood-jenkins-worker" }
     options {
         timestamps()
         timeout(60)
@@ -44,7 +44,7 @@ pipeline {
     environment {
         XDIST_CONTAINER_SUBNET = credentials('XDIST_CONTAINER_SUBNET')
         XDIST_CONTAINER_SECURITY_GROUP = credentials('XDIST_CONTAINER_SECURITY_GROUP')
-        XDIST_CONTAINER_TASK_NAME = "jenkins-worker-task"
+        XDIST_CONTAINER_TASK_NAME = "ironwood-jenkins-worker-task"
         XDIST_GIT_BRANCH = xdist_git_branch()
     }
     stages {
@@ -74,7 +74,7 @@ pipeline {
         stage('Run Tests') {
             parallel {
                 stage("lms-unit") {
-                    agent { label "jenkins-worker" }
+                    agent { label "ironwood-jenkins-worker" }
                     environment {
                         TEST_SUITE = "lms-unit"
                         XDIST_NUM_TASKS = 10
@@ -94,7 +94,7 @@ pipeline {
                     }
                 }
                 stage("cms-unit") {
-                    agent { label "jenkins-worker" }
+                    agent { label "ironwood-jenkins-worker" }
                     environment {
                         TEST_SUITE = "cms-unit"
                         XDIST_NUM_TASKS = 3
@@ -114,7 +114,7 @@ pipeline {
                     }
                 }
                 stage("commonlib-unit") {
-                    agent { label "jenkins-worker" }
+                    agent { label "ironwood-jenkins-worker" }
                     environment {
                         TEST_SUITE = "commonlib-unit"
                         XDIST_NUM_TASKS = 3

--- a/scripts/Jenkinsfiles/quality
+++ b/scripts/Jenkinsfiles/quality
@@ -40,7 +40,7 @@ def qualityTestCleanup() {
 }
 
 pipeline {
-    agent { label "jenkins-worker" }
+    agent { label "ironwood-jenkins-worker" }
     options {
         timestamps()
         timeout(60)
@@ -72,7 +72,7 @@ pipeline {
         stage('Run Tests') {
             parallel {
                 stage("commonlib pylint") {
-                    agent { label "jenkins-worker" }
+                    agent { label "ironwood-jenkins-worker" }
                     environment {
                         TEST_SUITE = "quality"
                         SHARD = 1
@@ -91,7 +91,7 @@ pipeline {
                     }
                 }
                 stage("lms pylint") {
-                    agent { label "jenkins-worker" }
+                    agent { label "ironwood-jenkins-worker" }
                     environment {
                         TEST_SUITE = "quality"
                         SHARD = 2
@@ -110,7 +110,7 @@ pipeline {
                     }
                 }
                 stage("cms/openedx/pavelib pylint") {
-                    agent { label "jenkins-worker" }
+                    agent { label "ironwood-jenkins-worker" }
                     environment {
                         TEST_SUITE = "quality"
                         SHARD = 3
@@ -129,7 +129,7 @@ pipeline {
                     }
                 }
                 stage("Other quality checks") {
-                    agent { label "jenkins-worker" }
+                    agent { label "ironwood-jenkins-worker" }
                     environment {
                         TEST_SUITE = "quality"
                         SHARD = 4


### PR DESCRIPTION
Ironwood CI should run with its own specific workers.

Bokchoy tests that try and hit the RTD links rightfully fail as we haven't officially released yet.