### PR TITLE
Add path to linter unittests to testing environment

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -10,6 +10,7 @@ source =
     lms
     openedx
     pavelib
+    scripts
 
 omit =
     cms/envs/*

--- a/pavelib/utils/envs.py
+++ b/pavelib/utils/envs.py
@@ -221,6 +221,7 @@ class Env(object):
         if dir_name.isdir() and not dir_name.endswith(IGNORED_TEST_DIRS):
             LIB_TEST_DIRS.append(path("common/lib") / item.basename())
     LIB_TEST_DIRS.append(path("pavelib/paver_tests"))
+    LIB_TEST_DIRS.append(path("scripts/xsslint/tests"))
 
     # Directory for i18n test reports
     I18N_REPORT_DIR = REPORT_DIR / 'i18n'


### PR DESCRIPTION
Our unittests weren't configured to run tests in the script dir