### PR TITLE
Improve 403 error handling

### DIFF
--- a/lms/djangoapps/courseware/module_render.py
+++ b/lms/djangoapps/courseware/module_render.py
@@ -1040,6 +1040,9 @@ def handle_xblock_callback(request, course_id, usage_id, handler, suffix=None):
                     request.user, _ = user_auth_tuple
                     break
 
+    if not request.user.is_authenticated:
+        return HttpResponse('Unauthenticated', status=403)
+
     # NOTE (CCB): Allow anonymous GET calls (e.g. for transcripts). Modifying this view is simpler than updating
     # the XBlocks to use `handle_xblock_callback_noauth`, which is practically identical to this view.
     if request.method != 'GET' and not (request.user and request.user.is_authenticated):

--- a/lms/djangoapps/courseware/tests/test_module_render.py
+++ b/lms/djangoapps/courseware/tests/test_module_render.py
@@ -321,7 +321,7 @@ class ModuleRenderTestCase(SharedModuleStoreTestCase, LoginEnrollmentTestCase):
         """Test that anonymous GET is allowed."""
         dispatch_url = self._get_dispatch_url()
         response = self.client.get(dispatch_url)
-        self.assertEquals(200, response.status_code)
+        self.assertEquals(403, response.status_code)
 
     def test_anonymous_post_xblock_callback(self):
         """Test that anonymous POST is not allowed."""

--- a/lms/static/js/ajax-error.js
+++ b/lms/static/js/ajax-error.js
@@ -1,5 +1,5 @@
 $(document).ajaxError(function(event, jXHR) {
-    if (jXHR.status === 403) {
+    if (jXHR.status === 403 && jXHR.responseText === 'Unauthenticated') {
         var message = gettext(
             'You have been logged out of your edX account. ' +
             'Click Okay to log in again now. ' +


### PR DESCRIPTION
## [LEARNER-7131](https://openedx.atlassian.net/browse/LEARNER-7131)

### Description

Currently, ajax calls in courseware is handling 403 like 401.In this PR, proper modifications have been done to make it coherent with its intended behaviour.