### PR TITLE
patch video player speed adjustments

### DIFF
--- a/common/lib/xmodule/xmodule/js/spec/video/general_spec.js
+++ b/common/lib/xmodule/xmodule/js/spec/video/general_spec.js
@@ -85,7 +85,7 @@
                     });
 
                     it('set current video speed via cookie', function() {
-                        expect(state.speed).toEqual('1.50');
+                        expect(state.speed).toEqual(1.5);
                     });
                 });
 

--- a/common/lib/xmodule/xmodule/js/spec/video/initialize_spec.js
+++ b/common/lib/xmodule/xmodule/js/spec/video/initialize_spec.js
@@ -186,7 +186,7 @@ function(Initialize) {
 
                     $.each(map, function(key, expected) {
                         Initialize.prototype.setSpeed.call(state, key);
-                        expect(state.speed).toBe(expected);
+                        expect(state.speed).toBe(parseFloat(expected));
                     });
                 });
             });
@@ -205,7 +205,7 @@ function(Initialize) {
                     });
 
                     it('set new speed', function() {
-                        expect(state.speed).toEqual('0.75');
+                        expect(state.speed).toEqual(0.75);
                     });
                 });
 
@@ -215,7 +215,7 @@ function(Initialize) {
                     });
 
                     it('set speed to 1.0x', function() {
-                        expect(state.speed).toEqual('1.0');
+                        expect(state.speed).toEqual(1);
                     });
                 });
 
@@ -228,7 +228,7 @@ function(Initialize) {
 
                     $.each(map, function(key, expected) {
                         Initialize.prototype.setSpeed.call(state, key);
-                        expect(state.speed).toBe(expected);
+                        expect(state.speed).toBe(parseFloat(expected));
                     });
                 });
             });

--- a/common/lib/xmodule/xmodule/js/spec/video/video_player_spec.js
+++ b/common/lib/xmodule/xmodule/js/spec/video/video_player_spec.js
@@ -56,7 +56,7 @@ function(VideoPlayer, HLS, _) {
 
                 it('create video caption', function() {
                     expect(state.videoCaption).toBeDefined();
-                    expect(state.speed).toEqual('1.50');
+                    expect(state.speed).toEqual(1.5);
                     expect(state.config.transcriptTranslationUrl)
                         .toEqual('/transcript/translation/__lang__');
                 });
@@ -64,7 +64,7 @@ function(VideoPlayer, HLS, _) {
                 it('create video speed control', function() {
                     expect(state.videoSpeedControl).toBeDefined();
                     expect(state.videoSpeedControl.el).toHaveClass('speeds');
-                    expect(state.speed).toEqual('1.50');
+                    expect(state.speed).toEqual(1.5);
                 });
 
                 it('create video progress slider', function() {

--- a/common/lib/xmodule/xmodule/js/src/video/01_initialize.js
+++ b/common/lib/xmodule/xmodule/js/src/video/01_initialize.js
@@ -715,6 +715,7 @@ function(VideoPlayer, i18n, moment, _) {
             newSpeed = map[newSpeed];
             this.speed = _.contains(this.speeds, newSpeed) ? newSpeed : '1.0';
         }
+        this.speed = parseFloat(this.speed);
     }
 
     function setAutoAdvance(enabled) {

--- a/common/lib/xmodule/xmodule/js/src/video/08_video_speed_control.js
+++ b/common/lib/xmodule/xmodule/js/src/video/08_video_speed_control.js
@@ -231,21 +231,22 @@
          * not differs from current speed.
          */
         setSpeed: function(speed, silent, forceUpdate) {
-            if (speed !== this.currentSpeed || forceUpdate) {
+            var newSpeed = this.state.speedToString(speed);
+            if (newSpeed !== this.currentSpeed || forceUpdate) {
                 this.speedsContainer
                     .find('li')
-                    .siblings("li[data-speed='" + speed + "']");
+                    .siblings("li[data-speed='" + newSpeed + "']");
 
-                this.speedButton.find('.value').text(speed + 'x');
-                this.currentSpeed = speed;
+                this.speedButton.find('.value').text(newSpeed + 'x');
+                this.currentSpeed = newSpeed;
 
                 if (!silent) {
-                    this.el.trigger('speedchange', [speed, this.state.speed]);
+                    this.el.trigger('speedchange', [newSpeed, this.state.speed]);
                 }
             }
 
             this.resetActiveSpeed();
-            this.setActiveSpeed(speed);
+            this.setActiveSpeed(newSpeed);
         },
 
         resetActiveSpeed: function() {
@@ -259,13 +260,13 @@
         },
 
         setActiveSpeed: function(speed) {
-            var speedOption = this.speedsContainer.find('li[data-speed="' + speed + '"]');
+            var speedOption = this.speedsContainer.find('li[data-speed="' + this.state.speedToString(speed) + '"]');
 
             speedOption.addClass('is-active')
                 .find('.speed-option')
                 .attr('aria-pressed', 'true');
 
-            this.speedButton.attr('title', gettext('Video speed: ') + speed + 'x');
+            this.speedButton.attr('title', gettext('Video speed: ') + this.state.speedToString(speed) + 'x');
         },
 
         /**

--- a/common/lib/xmodule/xmodule/js/src/video/095_video_context_menu.js
+++ b/common/lib/xmodule/xmodule/js/src/video/095_video_context_menu.js
@@ -217,7 +217,8 @@ function(Component) {
         },
 
         appendContent: function(content) {
-            this.getElement().append(content);
+            var $content = $(content);
+            this.getElement().append($content);
             return this;
         },
 
@@ -247,8 +248,8 @@ function(Component) {
         },
 
         open: function() {
-            var menu = (this.isRendered) ? this.getElement() : this.populateElement();
-            this.container.append(menu);
+            var $menu = (this.isRendered) ? this.getElement() : this.populateElement();
+            this.container.append($menu);
             AbstractItem.prototype.open.call(this);
             this.overlay.show(this.container);
             return this;
@@ -355,7 +356,8 @@ function(Component) {
         },
 
         show: function(container) {
-            $(container).append(this.getElement());
+            var $elem = $(this.getElement());
+            $(container).append($elem);
             this.delegateEvents();
             return this;
         },
@@ -390,7 +392,9 @@ function(Component) {
         },
 
         createElement: function() {
-            var $element = $('<li />', {
+            var $spanElem,
+                $listElem,
+                $element = $('<li />', {
                 class: ['submenu-item', 'menu-item', this.options.prefix + 'submenu-item'].join(' '),
                 'aria-expanded': 'false',
                 'aria-haspopup': 'true',
@@ -399,21 +403,25 @@ function(Component) {
                 tabindex: -1
             });
 
-            this.label = $('<span />', {
+            $spanElem = $('<span />', {
                 id: 'submenu-item-label-' + this.id,
                 text: this.options.label
-            }).appendTo($element);
+            });
+            this.label = $spanElem.appendTo($element);
 
-            this.list = $('<ol />', {
+            $listElem = $('<ol />', {
                 class: ['submenu', this.options.prefix + 'submenu'].join(' '),
                 role: 'menu'
-            }).appendTo($element);
+            });
+
+            this.list = $listElem.appendTo($element);
 
             return $element;
         },
 
         appendContent: function(content) {
-            this.list.append(content);
+            var $content = $(content);
+            this.list.append($content);
             return this;
         },
 
@@ -628,7 +636,7 @@ function(Component) {
                 }, {
                     label: i18n.Speed,
                     items: _.map(state.speeds, function(speed) {
-                        var isSelected = speed === state.speed;
+                        var isSelected = parseFloat(speed) === state.speed;
                         return {label: speed + 'x', callback: speedCallback, speed: speed, isSelected: isSelected};
                     }),
                     initialize: function(menuitem) {

--- a/common/lib/xmodule/xmodule/js/src/video/09_events_plugin.js
+++ b/common/lib/xmodule/xmodule/js/src/video/09_events_plugin.js
@@ -101,8 +101,8 @@
             onSpeedChange: function(event, newSpeed, oldSpeed) {
                 this.log('speed_change_video', {
                     current_time: this.getCurrentTime(),
-                    old_speed: oldSpeed,
-                    new_speed: newSpeed
+                    old_speed: this.state.speedToString(oldSpeed),
+                    new_speed: this.state.speedToString(newSpeed)
                 });
             },
 


### PR DESCRIPTION
### [EDUCATOR-3982](https://openedx.atlassian.net/browse/EDUCATOR-3982)

### Description
This PR is a follow up to https://github.com/edx/edx-platform/pull/19645, where all of a sudden, the video player speed adjustments stopped working for YouTube videos. The fix in the mentioned PR addressed that concern by changing the speed variable type to Float from String, on which the speed adjustment worked fine. That fix was only applicable when the speed was changed from the player. However, some use cases were missing.

1. When a video's speed was changed, and the page was reloaded, the UI showed the changed speed, but the video worked with the 1.0 speed.
2. When user changed the speed, and navigated to a new video, the new video showed the speed of the previous video, but played with 1.0 speed.

A point worth mentioning that even though the speed change requires Float, the UI for both speed button and contextmenu(in case of Non-Youtube videos) adds the active class with a **String** speed variable expected. For the first case, given the string, it searches for the speed < li > in the HTML and adds the _is-active_ class to that list item. For the second case, it tries to bold the selected speed by comparing speed with the pre-defined list of speeds. This PR addresses the concern so that changing speed will get the float and the UI would update appropriately.

### Change Impact
1. Since the expected data type unexpectandly changed from String to Float, the js tests for the underlying behavior, which were written with String in mind, started to fail. In the places where String was expected, float was being checked. So, the tests had to be modified to do the checks with the same data types.
2. One of the files, _common/lib/xmodule/xmodule/js/src/video/095_video_context_menu.js_, had some xsslinter violations in it, which started happening when the file was edited in the commit. Since the change in the file was necessary, so all the linter violations were fixed. There were total of 6 violations from following 2 categories:
   - javascript-jquery-append
   - javascript-jquery-insert-into-target 

They were fixed following the instructions from [here](https://edx.readthedocs.io/projects/edx-developer-guide/en/latest/preventing_xss/preventing_xss.html#javascript-jquery-append)

### Testing Instruction
1. Go to a course with video contents.
2. Locate a section where there are several videos spread across various units.
3. Go to a Youtube video. Ideally, if no video was visited before going to that video i.e. no video state, the video would be at 1.0x speed. 
4. Change the speed and verify. Now, reload the same page.
5. Verify that speed will be the one that was set earlier. Playing it will launch the video with selected speed.
6. Now, from the same page, move onto another unit where there is a video. That video shouldn't have been visited before. 
7. Verify that video's speed is same as the previous video. Play the video.
8. Verify that it will play with the selected speed.

**Additional Instructions**
  - For the YouTube videos, whenever a speed is selected, hover to the button to confirm that selected speed has also been selected in the dropdown.
  - For the non-YouTube videos, right click on the videos to open the context menu. Confirm from the Speed option that the current speed is **bold** in the list.

### Links
 - [Sandbox](https://speedadjustment.sandbox.edx.org/courses/course-v1:arbx+ed3982+2019_T1/courseware/7175367d7c9249a9992932c14e36101b/a1e4c1c92dae421ca428190eedf9c8db/)
 - [Stage Link](https://courses.stage.edx.org/courses/course-v1:ArbiRaees+DZ101+2018_T2/courseware/56430104be2c40c7bf64629d7304b2cf/127ffa6633b7402ea0fdb728d379e8c5/1?activate_block_id=block-v1%3AArbiRaees%2BDZ101%2B2018_T2%2Btype%40vertical%2Bblock%40614e8316c58347cda384c802277bf15e)

### Reviewers
 - [x] @awaisdar001 
 - [x] @noraiz-anwar 
 - [x] @Rabia23 

### Post Review
 - [x] Squash & Rebase Commits
