### PR TITLE
Update search filter to return empty dict if no user

### DIFF
--- a/lms/lib/courseware_search/lms_filter_generator.py
+++ b/lms/lib/courseware_search/lms_filter_generator.py
@@ -28,11 +28,10 @@ class LmsSearchFilterGenerator(SearchFilterGenerator):
     def field_dictionary(self, **kwargs):
         """ add course if provided otherwise add courses in which the user is enrolled in """
         field_dictionary = super(LmsSearchFilterGenerator, self).field_dictionary(**kwargs)
-        if not kwargs.get('user'):
-            field_dictionary['course'] = []
-        elif not kwargs.get('course_id'):
-            user_enrollments = self._enrollments_for_user(kwargs['user'])
-            field_dictionary['course'] = [unicode(enrollment.course_id) for enrollment in user_enrollments]
+        if kwargs.get('user'):
+            if not kwargs.get('course_id'):
+                user_enrollments = self._enrollments_for_user(kwargs['user'])
+                field_dictionary['course'] = [unicode(enrollment.course_id) for enrollment in user_enrollments]
 
         # if we have an org filter, only include results for this org filter
         course_org_filter = configuration_helpers.get_current_site_orgs()

--- a/lms/lib/courseware_search/test/test_lms_filter_generator.py
+++ b/lms/lib/courseware_search/test/test_lms_filter_generator.py
@@ -1,6 +1,7 @@
 """
 Tests for the lms_filter_generator
 """
+from django.test.utils import override_settings
 from mock import Mock, patch
 
 from lms.lib.courseware_search.lms_filter_generator import LmsSearchFilterGenerator
@@ -10,8 +11,9 @@ from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
 from xmodule.modulestore.tests.factories import CourseFactory, ItemFactory
 
 
+@override_settings(SEARCH_FILTER_GENERATOR="lms.lib.courseware_search.lms_filter_generator.LmsSearchFilterGenerator")
 class LmsSearchFilterGeneratorTestCase(ModuleStoreTestCase):
-    """ Tests for search result processor """
+    """ Tests for search filter generator """
 
     def build_courses(self):
         """
@@ -80,12 +82,12 @@ class LmsSearchFilterGeneratorTestCase(ModuleStoreTestCase):
 
     def test_user_not_provided(self):
         """
-        Tests that we get empty list of courses in case the user is not provided
+        Tests that we get empty dict in case the user is not provided
         """
         field_dictionary, filter_dictionary, _ = LmsSearchFilterGenerator.generate_field_filters()
 
         self.assertIn('start_date', filter_dictionary)
-        self.assertEqual(0, len(field_dictionary['course']))
+        self.assertEqual({}, field_dictionary)
 
     def test_excludes_site_org(self):
         """


### PR DESCRIPTION
@nedbat 
This commit is for backwards compatibility in relation with the change to allow custom field filters for course discovery search: https://github.com/edx/edx-search/pull/71