### PR TITLE
Opencraft/edx platform/devan/show enroll links on public courses only if self enrollment allowed

### DIFF
--- a/lms/djangoapps/courseware/views/views.py
+++ b/lms/djangoapps/courseware/views/views.py
@@ -551,7 +551,7 @@ class CourseTabView(EdxFragmentView):
         else:
             if not CourseEnrollment.is_enrolled(request.user, course.id) and not allow_anonymous:
                 # Only show enroll button if course is open for enrollment.
-                if course_open_for_self_enrollment(course.id):
+                if course_open_for_self_enrollment(course.id) and not course.invitation_only:
                     enroll_message = _(u'You must be enrolled in the course to see course content. \
                             {enroll_link_start}Enroll now{enroll_link_end}.')
                     PageLevelMessages.register_warning_message(

--- a/openedx/features/course_experience/tests/views/test_course_home.py
+++ b/openedx/features/course_experience/tests/views/test_course_home.py
@@ -125,6 +125,14 @@ class CourseHomePageTestCase(SharedModuleStoreTestCase):
                     number='test',
                     display_name='Test Course',
                     start=now() - timedelta(days=30),
+                    metadata={"invitation_only": False}
+                )
+                cls.private_course = CourseFactory.create(
+                    org='edX',
+                    number='test',
+                    display_name='Test Private Course',
+                    start=now() - timedelta(days=30),
+                    metadata={"invitation_only": True}
                 )
                 with cls.store.bulk_operations(cls.course.id):
                     chapter = ItemFactory.create(
@@ -292,6 +300,9 @@ class TestCourseHomePageAccess(CourseHomePageTestCase):
                 url = course_home_url(self.course)
                 response = self.client.get(url)
 
+                private_url = course_home_url(self.private_course)
+                private_response = self.client.get(private_url)
+
         # Verify that the course tools and dates are always shown
         self.assertContains(response, TEST_COURSE_TOOLS)
         self.assertContains(response, TEST_COURSE_TODAY)
@@ -312,7 +323,7 @@ class TestCourseHomePageAccess(CourseHomePageTestCase):
         # Verify the outline is shown to enrolled users, unenrolled_staff and anonymous users if allowed
         self.assertContains(response, TEST_CHAPTER_NAME, count=(1 if expected_course_outline else 0))
 
-        # Verify that the expected message is shown to the user
+        # Verify the message shown to the user
         if not enable_unenrolled_access or course_visibility != COURSE_VISIBILITY_PUBLIC:
             self.assertContains(
                 response, 'To see course content', count=(1 if is_anonymous else 0)
@@ -320,6 +331,12 @@ class TestCourseHomePageAccess(CourseHomePageTestCase):
             self.assertContains(response, '<div class="user-messages"', count=(1 if expected_enroll_message else 0))
             if expected_enroll_message:
                 self.assertContains(response, 'You must be enrolled in the course to see course content.')
+
+        if enable_unenrolled_access and course_visibility == COURSE_VISIBILITY_PUBLIC:
+            if user_type == CourseUserType.UNENROLLED and self.private_course.invitation_only:
+                if expected_enroll_message:
+                    self.assertContains(private_response,
+                                        'You should be enrolled in the course to fully access the contents.')
 
     @override_waffle_flag(UNIFIED_COURSE_TAB_FLAG, active=False)
     @override_waffle_flag(SHOW_REVIEWS_TOOL_FLAG, active=True)


### PR DESCRIPTION
This PR changes the logic for displaying enroll messages on the course home page. 
With this change, public courses will show "Enroll" links  only if self-enrollment is allowed

**Discussions**: Link to any public dicussions about this PR or the design/architecture. Otherwise omit this.

**Screenshots**: 
View when User is unenrolled for Public Outline course (invite-only), before change.
<img width="1645" alt="public_outline_invite_unenrolled_before" src="https://user-images.githubusercontent.com/666068/53112751-e3a18e80-3537-11e9-85aa-e07102bda763.png">
View when User is unenrolled for Public Outline course (invite-only), after change.
<img width="1652" alt="public_outline_invite_unenrolled_after" src="https://user-images.githubusercontent.com/666068/53407772-d57ac480-39b4-11e9-9108-986d83be43d0.png">


View when User is unenrolled for Public course (self-enrollment allowed), before change.
<img width="1621" alt="public_default_unenrolled_before" src="https://user-images.githubusercontent.com/666068/53112749-e308f800-3537-11e9-9ff2-24ff2f9fdd0d.png">
View when User is unenrolled for Public course (self-enrollment allowed), after change.
<img width="1663" alt="public_default_unenrolled_after" src="https://user-images.githubusercontent.com/666068/53407762-cb58c600-39b4-11e9-81ef-de51d8c4a6d5.png">


View when User is anonymous for Public course (self-enrollment allowed), before change.
<img width="1615" alt="public_default_anon_before" src="https://user-images.githubusercontent.com/666068/53112750-e308f800-3537-11e9-843d-6348da226fbb.png">
View when User is anonymous for Public course (self-enrollment allowed), after change.
<img width="1661" alt="public_default_anon_after" src="https://user-images.githubusercontent.com/666068/53407728-bed46d80-39b4-11e9-9dc9-37b5b5b6960d.png">


**Sandbox URL**:
Studio:https://studio-pr19837.sandbox.opencraft.hosting/
LMS:https://pr19837.sandbox.opencraft.hosting/

**Merge deadline**:"None" 

**Testing instructions**:
Contains 2 courses:

[edX Demo Course] has `seo.enable_anonymous_courseware_access` course waffle flag, and the "Advanced Settings > Course Visibility For Unenrolled Learners" set to public_outline and the  "Advanced Settings > Invitation Only " set to true.
https://pr19837.sandbox.opencraft.hosting/courses/course-v1:edX+DemoX+Demo_Course/

[Test Course] has `seo.enable_anonymous_courseware_access` course waffle flag, and the "Advanced Settings > Course Visibility For Unenrolled Learners" set to public and the  "Advanced Settings > Invitation Only " set to false.
https://pr19837.sandbox.opencraft.hosting/courses/course-v1:opencraft+test01+2019_T1/

1.
 Go to LMS
 Sign in
 View the edX Demo Course course page
 You should not see an Enroll message

2.
Go to LMS
 Sign in
 View the Test Course course page of the public course you've created
 You should see an Enroll message

3.
 Open the same link in an anonymous browser
 You should not see an Enroll message

**Reviewers**
- [ ] (OpenCraft internal reviewer's GitHub username goes here)
- [ ] Pooja Kulkarni (pkulkark)
