### PR TITLE
Fixed download txt transcript 500

### DIFF
--- a/common/lib/xmodule/xmodule/video_module/transcripts_utils.py
+++ b/common/lib/xmodule/xmodule/video_module/transcripts_utils.py
@@ -669,7 +669,8 @@ class Transcript(object):
 
             if output_format == 'txt':
                 text = json.loads(content)['text']
-                return HTMLParser().unescape("\n".join(text))
+                text_without_none = [line if line else '' for line in text]
+                return HTMLParser().unescape("\n".join(text_without_none))
 
             elif output_format == 'srt':
                 return generate_srt_from_sjson(json.loads(content), speed=1.0)
@@ -890,9 +891,6 @@ def get_transcript_from_val(edx_video_id, lang=None, output_format=Transcript.SR
         raise NotFoundError(u'Transcript not found for {}, lang: {}'.format(edx_video_id, lang))
 
     transcript_conversion_props = dict(transcript, output_format=output_format)
-    # Log for EDUCATOR-3928
-    if edx_video_id == 'MIT6002XT214-V002700':
-        log.info("Transcript content: %s", transcript_conversion_props.get('content', ''))
     transcript = convert_video_transcript(**transcript_conversion_props)
     filename = transcript['filename']
     content = transcript['content']


### PR DESCRIPTION
## [EDUCATOR-3928](https://openedx.atlassian.net/browse/EDUCATOR-3928)

### Description
The sjon transcript text can contain None lines. However the join method does not work if an element of the array is None. I have replaced the None with an empty string "". I have also removed the log I added to gather more information about the issue.
t.

### Reviewers
If you've been tagged for review, please check your corresponding box once you've given the :+1:.
- [ ] @noraiz-anwar
- [ ] @awaisdar001 

### Post-review
- [ ] Rebase and squash commits
