### PR TITLE
Improve 403 error handling

### DIFF
--- a/lms/djangoapps/courseware/module_render.py
+++ b/lms/djangoapps/courseware/module_render.py
@@ -1043,7 +1043,7 @@ def handle_xblock_callback(request, course_id, usage_id, handler, suffix=None):
     # NOTE (CCB): Allow anonymous GET calls (e.g. for transcripts). Modifying this view is simpler than updating
     # the XBlocks to use `handle_xblock_callback_noauth`, which is practically identical to this view.
     if request.method != 'GET' and not (request.user and request.user.is_authenticated):
-        return HttpResponseForbidden()
+        return HttpResponseForbidden('Unauthenticated')
 
     request.user.known = request.user.is_authenticated
 

--- a/lms/djangoapps/courseware/tests/test_module_render.py
+++ b/lms/djangoapps/courseware/tests/test_module_render.py
@@ -327,6 +327,9 @@ class ModuleRenderTestCase(SharedModuleStoreTestCase, LoginEnrollmentTestCase):
         """Test that anonymous POST is not allowed."""
         dispatch_url = self._get_dispatch_url()
         response = self.client.post(dispatch_url, {'position': 2})
+
+        # https://openedx.atlassian.net/browse/LEARNER-7131
+        self.assertEquals('Unauthenticated', response.content)
         self.assertEquals(403, response.status_code)
 
     def test_session_authentication(self):

--- a/lms/static/js/ajax-error.js
+++ b/lms/static/js/ajax-error.js
@@ -1,5 +1,5 @@
 $(document).ajaxError(function(event, jXHR) {
-    if (jXHR.status === 403) {
+    if (jXHR.status === 403 && jXHR.responseText === 'Unauthenticated') {
         var message = gettext(
             'You have been logged out of your edX account. ' +
             'Click Okay to log in again now. ' +


### PR DESCRIPTION
Currently, ajax calls in courseware is handling 403 like 401.In this PR, proper modifications have been done to make it coherent with its intended behaviour.

LEARNER-7131