### PR TITLE
Change git checkout on xdist workers

### DIFF
--- a/scripts/xdist/prepare_xdist_nodes.sh
+++ b/scripts/xdist/prepare_xdist_nodes.sh
@@ -7,12 +7,19 @@ python scripts/xdist/pytest_container_manager.py -a up -n ${XDIST_NUM_TASKS} \
 -s ${XDIST_CONTAINER_SUBNET} \
 -sg ${XDIST_CONTAINER_SECURITY_GROUP}
 
+# Need to map remote branch to local branch when fetching a branch other than master
+if [ "$XDIST_GIT_BRANCH" == "master" ]; then
+    XDIST_GIT_FETCH_STRING="$XDIST_GIT_BRANCH"
+else
+    XDIST_GIT_FETCH_STRING="$XDIST_GIT_BRANCH:$XDIST_GIT_BRANCH"
+fi
+
 ip_list=$(<pytest_task_ips.txt)
 for ip in $(echo $ip_list | sed "s/,/ /g")
 do
     container_reqs_cmd="ssh -o StrictHostKeyChecking=no ubuntu@$ip 'cd /edx/app/edxapp;
     git clone --branch master --depth 1 --no-tags -q https://github.com/edx/edx-platform.git; cd edx-platform;
-    git fetch --depth=1 --no-tags -q origin ${XDIST_GIT_BRANCH}; git checkout -q ${XDIST_GIT_BRANCH};
+    git fetch --depth=1 --no-tags -q origin ${XDIST_GIT_FETCH_STRING}; git checkout -q ${XDIST_GIT_BRANCH};
     source /edx/app/edxapp/edxapp_env; pip install -qr requirements/edx/testing.txt; mkdir reports' & "
 
     cmd=$cmd$container_reqs_cmd


### PR DESCRIPTION
Previously, our 2 workflows for pipeline builds were either:
- PRs
- Merges to the master branch

In both of these, the current script worked quite well. Either checking out a specific sha for PRs, or the master branch for merges. However, when trying to fetch a branch other than master, the script fails, like when running merge builds on an open-release branch:

`error: pathspec 'open-release/ironwood.master' did not match any file(s) known to git`

This is because we are fetching the remote branch, but not mapping it to a local branch. This small code change fixes this by mapping to a local branch of the same name.

It works when the target branch is either a sha or any branch not named master.