### PR TITLE
Allow a configurable number of weekly course highlight emails

### DIFF
--- a/openedx/core/djangoapps/schedules/management/commands/__init__.py
+++ b/openedx/core/djangoapps/schedules/management/commands/__init__.py
@@ -6,6 +6,7 @@ Base management command for sending emails
 import datetime
 
 import pytz
+from six.moves import range
 from django.contrib.sites.models import Site
 from django.core.management.base import BaseCommand
 
@@ -14,7 +15,10 @@ from openedx.core.djangoapps.schedules.utils import PrefixedDebugLoggerMixin
 
 class SendEmailBaseCommand(PrefixedDebugLoggerMixin, BaseCommand):
     async_send_task = None  # define in subclass
-    offsets = ()  # define in subclass
+
+    # An iterable of day offsets (e.g. -7, -14, -21, -28, ...) that defines the days for
+    # which emails are sent out, relative to the 'date' parameter
+    offsets = range(-7, -77, -7)
 
     def add_arguments(self, parser):
         parser.add_argument(
@@ -27,9 +31,19 @@ class SendEmailBaseCommand(PrefixedDebugLoggerMixin, BaseCommand):
             help='Send all emails to this address instead of the actual recipient'
         )
         parser.add_argument('site_domain_name')
+        parser.add_argument(
+            '--weeks',
+            type=int,
+            help='Number of weekly emails to be sent',
+        )
 
     def handle(self, *args, **options):
         self.log_debug('Args = %r', options)
+
+        if 'weeks' in options:
+            num_weeks = options['weeks']
+            num_days = (7 * num_weeks) + 1
+            self.offsets = range(-7, -num_days, -7)
 
         current_date = datetime.datetime(
             *[int(x) for x in options['date'].split('-')],

--- a/openedx/core/djangoapps/schedules/management/commands/send_course_update.py
+++ b/openedx/core/djangoapps/schedules/management/commands/send_course_update.py
@@ -5,7 +5,6 @@ Management command to send Schedule course updates
 
 from textwrap import dedent
 
-from six.moves import range
 
 from openedx.core.djangoapps.schedules.management.commands import SendEmailBaseCommand
 from openedx.core.djangoapps.schedules.tasks import ScheduleCourseUpdate
@@ -18,4 +17,3 @@ class Command(SendEmailBaseCommand):
     help = dedent(__doc__).strip()
     async_send_task = ScheduleCourseUpdate
     log_prefix = 'Course Update'
-    offsets = range(-7, -77, -7)

--- a/openedx/core/djangoapps/schedules/management/commands/tests/test_send_email_base_command.py
+++ b/openedx/core/djangoapps/schedules/management/commands/tests/test_send_email_base_command.py
@@ -36,6 +36,11 @@ class TestSendEmailBaseCommand(CacheIsolationTestCase):
                 None
             )
 
+    def test_weeks_option(self):
+        with patch.object(self.command, 'enqueue') as enqueue:
+            self.command.handle(site_domain_name=self.site.domain, date='2017-09-29', weeks=12)
+            self.assertEqual(enqueue.call_count, 12)
+
     def test_send_emails(self):
         with patch.multiple(
             self.command,


### PR DESCRIPTION
This PR contains changes to the "send_course_update" management command to allow an input value to replace the default duration of 77 days.

**Sandbox URL**: 
LMS: https://pr19906.sandbox.opencraft.hosting/
Studio: https://studio.pr19906.sandbox.opencraft.hosting/

**Merge deadline**: "None"

**Testing instructions**:
None at this point in time.

**Reviewers**
- [ ] Pooja Kulkarni (pkulkark)