### PR TITLE
TE-2871 Switch to mysqlclient

### DIFF
--- a/pavelib/prereqs.py
+++ b/pavelib/prereqs.py
@@ -192,6 +192,7 @@ def install_node_prereqs():
 # To add a package to the uninstall list, just add it to this list! No need
 # to touch any other part of this file.
 PACKAGES_TO_UNINSTALL = [
+    "MySQL-python",                 # Because mysqlclient shares the same directory name
     "South",                        # Because it interferes with Django 1.8 migrations.
     "edxval",                       # Because it was bork-installed somehow.
     "django-storages",

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -20,6 +20,9 @@ six==1.11.0
 # Convert text markup to HTML; used in capa problems, forums, and course wikis; pin Markdown version as tests failed for its upgrade to latest release
 Markdown==2.6.11
 
+# mysqlclient 1.5 is scheduled to change internal APIs used by Django 1.11
+mysqlclient<1.5
+
 # required by edx-lint and pinned explicitly here because newer versions don't guarantee python 2 support.
 # Can be removed when we get to Python 3.
 pylint-plugin-utils==0.3

--- a/requirements/edx/base.in
+++ b/requirements/edx/base.in
@@ -102,7 +102,7 @@ mailsnake                           # Needed for mailchimp (mailing djangoapp)
 mako==1.0.2                         # Primary template language used for server-side page rendering
 Markdown                            # Convert text markup to HTML; used in capa problems, forums, and course wikis
 mongoengine==0.10.0                 # Object-document mapper for MongoDB, used in the LMS dashboard
-MySQL-python                        # Driver for the default production relational database
+mysqlclient                         # Driver for the default production relational database
 newrelic                            # New Relic agent for performance monitoring
 nodeenv==1.1.1                      # Utility for managing Node.js environments; we use this for deployments and testing
 numpy==1.6.2                        # Fast numeric array computation, used in some problem types

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -164,7 +164,7 @@ markupsafe==1.1.0
 maxminddb==1.4.1          # via geoip2
 mock==1.0.1
 mongoengine==0.10.0
-mysql-python==1.2.5
+mysqlclient==1.4.2.post1
 networkx==1.7
 newrelic==4.14.0.115
 nltk==3.4

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -217,7 +217,7 @@ modernize==0.6.1
 mongoengine==0.10.0
 more-itertools==5.0.0
 moto==0.3.1
-mysql-python==1.2.5
+mysqlclient==1.4.2.post1
 networkx==1.7
 newrelic==4.14.0.115
 nltk==3.4

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -210,7 +210,7 @@ mock==1.0.1
 mongoengine==0.10.0
 more-itertools==5.0.0     # via pytest
 moto==0.3.1
-mysql-python==1.2.5
+mysqlclient==1.4.2.post1
 networkx==1.7
 newrelic==4.14.0.115
 nltk==3.4


### PR DESCRIPTION
This is required for Python 3 support, and gains us a number of bug fixes and performance improvements in the process.  This should be a straightforward drop-in replacement, but none of our automated tests use MySQL until the e2e tests against stage.  Provisioning in devstack with this installed finished without problems.  We just need to decide how much (if any) manual testing we want to do as risk mitigation on this before attempting to deploy it.  Note that mysqlclient is the package recommended since at least Django 1.11 to use as the MySQL driver for Python, and we already use it in 5 other services.