### PR TITLE
Return credit status error if no provider info found.

### DIFF
--- a/common/djangoapps/student/views/dashboard.py
+++ b/common/djangoapps/student/views/dashboard.py
@@ -510,6 +510,14 @@ def _credit_statuses(user, course_enrollments):
                 status["provider_status_url"] = provider_info.get("status_url")
                 status["provider_id"] = provider_id
 
+                if not status["provider_name"] and not status["provider_status_url"]:
+                    status["error"] = True
+                    log.error(
+                        u"Could not find credit provider info for [%s] in [%s]. The user will not "
+                        u"be able to see his or her credit request status on the student dashboard.",
+                        provider_id, provider_info_by_id
+                    )
+
         statuses[course_key] = status
 
     return statuses

--- a/openedx/core/djangoapps/credit/models.py
+++ b/openedx/core/djangoapps/credit/models.py
@@ -184,8 +184,6 @@ class CreditProvider(TimeStampedModel):
             ]
 
             cache.set(cls.CREDIT_PROVIDERS_CACHE_KEY, credit_providers)
-        else:
-            log.info(u"Found %d credit providers from cache.", len(credit_providers))
 
         if providers_list:
             credit_providers = [provider for provider in credit_providers if provider['id'] in providers_list]


### PR DESCRIPTION
Return credit status error if no provider info found in provider info by id dict. Also adding logs to get an idea what is in this dict and why learner not seeing credit provider info on dashboard while they are eligible for credit.

LEARNER-6643