### PR TITLE
Change the version of social_auth_core to handle the Google plus shutdown issue

### DIFF
--- a/requirements/edx/base.in
+++ b/requirements/edx/base.in
@@ -130,7 +130,7 @@ reportlab                           # Used for shopping cart's pdf invoice/recei
 rest-condition                      # DRF's recommendation for supporting complex permissions
 rfc6266-parser                      # Used to generate Content-Disposition headers.
 social-auth-app-django<3.0.0
-social-auth-core<2.0.0
+social-auth-core==3.0.0
 pysrt                               # Support for SubRip subtitle files, used in the video XModule
 pytz                                # Time zone information database
 PyYAML                              # Used to parse XModule resource templates

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -223,7 +223,7 @@ singledispatch==3.4.0.3
 six==1.11.0
 slumber==0.7.1            # via edx-rest-api-client
 social-auth-app-django==2.1.0
-social-auth-core==1.7.0
+social-auth-core==3.0.0
 sorl-thumbnail==12.3
 sortedcontainers==2.1.0
 soupsieve==1.8            # via beautifulsoup4

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -315,7 +315,7 @@ slumber==0.7.1
 snakefood==1.4
 snowballstemmer==1.2.1    # via sphinx
 social-auth-app-django==2.1.0
-social-auth-core==1.7.0
+social-auth-core==3.0.0
 sorl-thumbnail==12.3
 sortedcontainers==2.1.0
 soupsieve==1.8

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -304,7 +304,7 @@ singledispatch==3.4.0.3
 six==1.11.0
 slumber==0.7.1
 social-auth-app-django==2.1.0
-social-auth-core==1.7.0
+social-auth-core==3.0.0
 sorl-thumbnail==12.3
 sortedcontainers==2.1.0
 soupsieve==1.8


### PR DESCRIPTION
Currently edx is using 1.7.0 version of `social-auth-core` which uses `google-plus-api` to sign in with google. As `google plus` is being shutting down on 7th of March [link](https://developers.google.com/+/api-shutdown), so this version of `social-auth-core` will cause problems. 
Luckily `social-auth-core` version 3.0.0  [Link](https://github.com/python-social-auth/social-core/commit/d77d75547b9ada3460a1b6809c8c9ad854f76871) has handled this issue already so this PR is to incorporate that fix into the edx code by changing the version of `socail-auth-core`