### PR TITLE
Revert "Bump ORA2 dependency to 2.2.2"

### DIFF
--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -24,7 +24,7 @@ git+https://github.com/mitodl/edx-sga.git@3828ba9e413080a81b907a3381e5ffa05e063f
 git+https://github.com/edx/xblock-lti-consumer.git@v1.1.8#egg=lti_consumer-xblock==1.1.8
 git+https://github.com/edx/MongoDBProxy.git@25b99097615bda06bd7cdfe5669ed80dc2a7fed0#egg=MongoDBProxy==0.1.0
 -e .
-git+https://github.com/edx/edx-ora2.git@2.2.2#egg=ora2==2.2.2
+git+https://github.com/edx/edx-ora2.git@2.2.1#egg=ora2==2.2.1
 -e git+https://github.com/dgrtwo/ParsePy.git@7949b9f754d1445eff8e8f20d0e967b9a6420639#egg=parse_rest
 -e git+https://github.com/dementrock/pystache_custom.git@776973740bdaad83a3b029f96e415a7d1e8bec2f#egg=pystache_custom-dev
 -e git+https://github.com/edx/RateXBlock.git@367e19c0f6eac8a5f002fd0f1559555f8e74bfff#egg=rate-xblock

--- a/requirements/edx/github.in
+++ b/requirements/edx/github.in
@@ -88,7 +88,7 @@
 # Our libraries:
 -e git+https://github.com/edx/codejail.git@a320d43ce6b9c93b17636b2491f724d9e433be47#egg=codejail
 -e git+https://github.com/edx/acid-block.git@e46f9cda8a03e121a00c7e347084d142d22ebfb7#egg=acid-xblock
--e git+https://github.com/edx/edx-ora2.git@2.2.2#egg=ora2==2.2.2
+-e git+https://github.com/edx/edx-ora2.git@2.2.1#egg=ora2==2.2.1
 -e git+https://github.com/edx/RecommenderXBlock.git@1.4.0#egg=recommender-xblock==1.4.0
 -e git+https://github.com/solashirai/crowdsourcehinter.git@518605f0a95190949fe77bd39158450639e2e1dc#egg=crowdsourcehinter-xblock==0.1
 -e git+https://github.com/edx/RateXBlock.git@367e19c0f6eac8a5f002fd0f1559555f8e74bfff#egg=rate-xblock


### PR DESCRIPTION
Reverts edx/edx-platform#19917

@feanil: This reverts the ORA2 version bump, until I can figure out the right thing to do there.

@nedbat: FYI. It wasn't the latest change that causes issues, but the other one that added sig v4 support. Will write more on it later after I figure out how to fix it.