### PR TITLE
Fix bug: deleted unit remains in bookmarks.

### DIFF
--- a/cms/djangoapps/contentstore/views/item.py
+++ b/cms/djangoapps/contentstore/views/item.py
@@ -50,6 +50,7 @@ from help_tokens.core import HelpUrlExpert
 from models.settings.course_grading import CourseGradingModel
 from openedx.core.djangoapps.schedules.config import COURSE_UPDATE_WAFFLE_FLAG
 from openedx.core.djangoapps.waffle_utils import WaffleSwitch
+from openedx.core.djangoapps.bookmarks import api as bookmarks_api
 from openedx.core.lib.gating import api as gating_api
 from openedx.core.lib.xblock_utils import request_token, wrap_xblock, wrap_xblock_aside
 from static_replace import replace_static_urls
@@ -938,6 +939,9 @@ def _delete_item(usage_key, user):
             existing_tabs = course.tabs or []
             course.tabs = [tab for tab in existing_tabs if tab.get('url_slug') != usage_key.block_id]
             store.update_item(course, user.id)
+
+        # delete user bookmarks
+        bookmarks_api.delete_bookmarks(usage_key=usage_key)
 
         store.delete_item(usage_key, user.id)
 

--- a/openedx/core/djangoapps/bookmarks/api.py
+++ b/openedx/core/djangoapps/bookmarks/api.py
@@ -156,6 +156,34 @@ def delete_bookmark(user, usage_key):
     _track_event('edx.bookmark.removed', bookmark)
 
 
+def delete_bookmarks(usage_key):
+    """
+    Delete all bookmarks for usage_key (e.g. if unit is deleted).
+
+    Arguments:
+        usage_key (UsageKey): The usage_key of the bookmarks.
+    """
+    units_keys = []
+
+    if usage_key.block_type == u'vertical':
+        units_keys.append(usage_key)
+    else:
+        # Get all children of the deleted block
+        descriptor = modulestore().get_item(usage_key)
+        for child in descriptor.get_children():
+            if usage_key.block_type == u'chapter':
+                units_keys += [unit.location for unit in child.get_children()]
+            else:
+                units_keys.append(child.location)
+
+    bookmarks = Bookmark.objects.filter(usage_key__in=units_keys)
+
+    for bookmark in bookmarks:
+        _track_event('edx.bookmark.removed', bookmark)
+
+    bookmarks.delete()
+
+
 def _track_event(event_name, bookmark):
     """
     Emit events for a bookmark.

--- a/openedx/core/djangoapps/bookmarks/tests/test_api.py
+++ b/openedx/core/djangoapps/bookmarks/tests/test_api.py
@@ -234,3 +234,47 @@ class BookmarksAPITests(BookmarkApiEventTestMixin, BookmarksTestsBase):
                 api.delete_bookmark(user=self.other_user, usage_key=self.vertical_1.location)
 
         self.assert_no_events_were_emitted(mock_tracker)
+
+    def test_delete_bookmarks_unit(self):
+        """
+        Verifies that delete_bookmarks removes given bookmark for all users
+        (usage_key is a key for a unit).
+        """
+        # create 2 bookmarks for the unit
+        api.create_bookmark(user=self.user, usage_key=self.vertical_1.location)
+        api.create_bookmark(user=self.other_user, usage_key=self.vertical_1.location)
+        self.assertEqual(Bookmark.objects.filter(usage_key=self.vertical_1.location).count(), 2)
+
+        # delete bookmarks for this unit
+        api.delete_bookmarks(usage_key=self.vertical_1.location)
+        self.assertEqual(Bookmark.objects.filter(usage_key=self.vertical_1.location).count(), 0)
+
+    def test_delete_bookmarks_subsection(self):
+        """
+        Verifies that delete_bookmarks removes given bookmark for all users
+        (usage_key is a key for a subsection).
+        """
+        # create 2 bookmarks for the unit
+        api.create_bookmark(user=self.user, usage_key=self.vertical_1.location)
+        api.create_bookmark(user=self.other_user, usage_key=self.vertical_1.location)
+        self.assertEqual(Bookmark.objects.filter(usage_key=self.vertical_1.location).count(), 2)
+
+        # delete bookmarks for the parent of the unit (subsection)
+        # this is triggered when the subsection is being deleted
+        api.delete_bookmarks(usage_key=self.sequential_1.location)
+        self.assertEqual(Bookmark.objects.filter(usage_key=self.vertical_1.location).count(), 0)
+
+    def test_delete_bookmarks_section(self):
+        """
+        Verifies that delete_bookmarks removes given bookmark for all users
+        (usage_key is a key for a section).
+        """
+        # create 2 bookmarks for the unit
+        api.create_bookmark(user=self.user, usage_key=self.vertical_1.location)
+        api.create_bookmark(user=self.other_user, usage_key=self.vertical_1.location)
+        self.assertEqual(Bookmark.objects.filter(usage_key=self.vertical_1.location).count(), 2)
+
+        # delete bookmarks for the section that contains the given unit
+        # this is triggered when the section is being deleted
+        api.delete_bookmarks(usage_key=self.chapter_1.location)
+        self.assertEqual(Bookmark.objects.filter(usage_key=self.vertical_1.location).count(), 0)


### PR DESCRIPTION
**Background**: This PR fixes a bug related to bookmarks. If a unit is added to bookmarks and then deleted, it remains on the bookmarks page anyway. Clicking the bookmark causes a 404 error. 


**openedx/core/ updates:** Bookmarks api has been extended by the `delete_bookmarks` method, which picks all bookmarks with specific `usage_key` (i.e. bookmarks made by different users but targeting the same unit), and deletes them.

**Studio updates:** The `delete_bookmarks` api method is invoked on xblock deletion (by `cms.djangoapps.contentstore.views.item._delete_item`).

The above changes have been covered by tests (4 tests added):
`openedx.core.djangoapps.bookmarks.tests.test_api.test_delete_bookmarks_unit`
`openedx.core.djangoapps.bookmarks.tests.test_api.test_delete_bookmarks_subsection`
`cms.djangoapps.contentstore.views.tests.test_item.test_delete_item`
`cms.djangoapps.contentstore.views.tests.test_item.test_delete_bookmarked_item`

**Test plan:** 
Before fix: 
In cms, create a course with several units. Set up the course start date (in the past).
In lms, enroll in course, add one of the units to bookmarks. 
In cms, delete the same unit that you bookmarked. 
In lms, the bookmark of this unit still exists on the bookmarks page . 
After fix:
The same flow, but the bookmark gets deleted together with a unit it points to.
