### PR TITLE
Wrongly assumed all certificates were HTML certificates

### DIFF
--- a/lms/djangoapps/courseware/views/views.py
+++ b/lms/djangoapps/courseware/views/views.py
@@ -1006,8 +1006,7 @@ def _progress(request, course_key, student_id):
         'credit_course_requirements': _credit_course_requirements(course_key, student),
         'course_expiration_fragment': course_expiration_fragment,
     }
-    if certs_api.get_active_web_certificate(course):
-        context['certificate_data'] = _get_cert_data(student, course, enrollment_mode, course_grade)
+    context['certificate_data'] = _get_cert_data(student, course, enrollment_mode, course_grade)
     context.update(
         get_experiment_user_metadata_context(
             course,


### PR DESCRIPTION
A modification in master / Ironwood prevents the lms/templates/courseware/progress.html page to display the 'Download Your Certificate' or 'Request Certificate' buttons because it assumes that certificate_data is available.

In Ironwood, context['certificate_data'] is only available if the course as an active web certificate. This breaks the process for sites that still use PDF certificates like us.

Previously in Hawthorn, the certificate_data was added to the context in all cases (PDF or HTML).
