### PR TITLE
Shore up whitespace on proctoring instructions page for PSI exams

### DIFF
--- a/lms/static/sass/course/courseware/_courseware.scss
+++ b/lms/static/sass/course/courseware/_courseware.scss
@@ -320,6 +320,21 @@ html.video-fullscreen {
         }
       }
 
+      &.instructions {
+        p {
+          margin: 0;
+        }
+        h4 {
+          margin-top: ($baseline * 3/2);
+        }
+        ul {
+          margin: 0;
+        }
+        .exam-action-button {
+          margin-top: $baseline / 2;
+        }
+      }
+
       hr {
         border-bottom: 1px solid $uxpl-gray-background;
       }

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -120,7 +120,7 @@ edx-oauth2-provider==1.2.2
 edx-opaque-keys[django]==0.4.4
 edx-organizations==1.0.1
 edx-proctoring-proctortrack==1.0.2
-edx-proctoring==1.5.17
+edx-proctoring==1.5.18
 edx-rest-api-client==1.9.2
 edx-search==1.2.1
 edx-submissions==2.1.1

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -143,7 +143,7 @@ edx-oauth2-provider==1.2.2
 edx-opaque-keys[django]==0.4.4
 edx-organizations==1.0.1
 edx-proctoring-proctortrack==1.0.2
-edx-proctoring==1.5.17
+edx-proctoring==1.5.18
 edx-rest-api-client==1.9.2
 edx-search==1.2.1
 edx-sphinx-theme==1.4.0

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -139,7 +139,7 @@ edx-oauth2-provider==1.2.2
 edx-opaque-keys[django]==0.4.4
 edx-organizations==1.0.1
 edx-proctoring-proctortrack==1.0.2
-edx-proctoring==1.5.17
+edx-proctoring==1.5.18
 edx-rest-api-client==1.9.2
 edx-search==1.2.1
 edx-submissions==2.1.1


### PR DESCRIPTION
JIRA:EDUCATOR-4105

depends on https://github.com/edx/edx-proctoring/pull/548 (version bump to implemented once the version is cut)