### PR TITLE
Add aria-label toggling for play/pause and fill browser buttons

### DIFF
--- a/common/lib/xmodule/xmodule/js/src/video/04_video_full_screen.js
+++ b/common/lib/xmodule/xmodule/js/src/video/04_video_full_screen.js
@@ -136,7 +136,7 @@
             fullScreenClassNameEl.removeClass('video-fullscreen');
             $(window).scrollTop(this.scrollPos);
             this.videoFullScreen.fullScreenEl
-            .attr('title', gettext('Fill browser'))
+            .attr({title: gettext('Fill browser'), 'aria-label': gettext('Fill browser')})
             .find('.icon')
                 .removeClass('fa-compress')
                 .addClass('fa-arrows-alt');
@@ -158,7 +158,7 @@
             this.videoFullScreen.fullScreenState = this.isFullScreen = true;
             fullScreenClassNameEl.addClass('video-fullscreen');
             this.videoFullScreen.fullScreenEl
-            .attr('title', gettext('Exit full browser'))
+            .attr({title: gettext('Exit full browser'), 'aria-label': gettext('Exit full browser')})
             .find('.icon')
                 .removeClass('fa-arrows-alt')
                 .addClass('fa-compress');

--- a/common/lib/xmodule/xmodule/js/src/video/09_play_pause_control.js
+++ b/common/lib/xmodule/xmodule/js/src/video/09_play_pause_control.js
@@ -74,7 +74,7 @@
                 this.el
                 .addClass('pause')
                 .removeClass('play')
-                .attr('title', gettext('Pause'))
+                .attr({title: gettext('Pause'), 'aria-label': gettext('Pause')})
                 .find('.icon')
                     .removeClass('fa-play')
                     .addClass('fa-pause');
@@ -84,7 +84,7 @@
                 this.el
                 .removeClass('pause')
                 .addClass('play')
-                .attr('title', gettext('Play'))
+                .attr({title: gettext('Play'), 'aria-label': gettext('Play')})
                 .find('.icon')
                     .removeClass('fa-pause')
                     .addClass('fa-play');


### PR DESCRIPTION
### [PROD-21](https://openedx.atlassian.net/browse/PROD-21)

### Description
The video player being used on the platform provides various accessibility-related choices to cater for different types of learners. However, some use cases were missing for the Play/Pause and Fill Browser/Exit Full Browser buttons. In the typical working, whenever the play/pause button is pressed, the **title** attribute changed to represent the action possible with the button i.e. If the video is currently playing, the button's title would be Pause. Same is the case for the Fill/Exit Fill buttons. The missing case was that toggling didn't alter the **aria-label**, and it remained at the initial values. This is problematic since the screenreaders use aria-label and it needs to be consistent with the current state. This PR addresses that concern and updates both fields simultaneously.   

### Testing Instructions
1. Visit the Sandbox
2. Navigate to any video from the provided options
3. Play the video. Inspect the button from Inspect tab. The title and aria-label should have 'Pause' value.
4. Now, pause the video. Both title and aria-label should have been toggled.
5. Navigate to **Fill Screen** button and press it. Confirm the title and aria-label for the button would say 'Exit full Browser'.
6. Exit the full screen. The values should have been toggled.

### Sandbox
 - https://buttons.sandbox.edx.org/courses/course-v1:prodX+prod21+2019_T1/courseware/d085259ae1694e34aa1674fd2c24cfc4/c888930cb1864ad2b4a12a04a39db86d/

### Reviewers
 - [x] @wittjeff 
 - [x] @Rabia23 

### Post Review
 - [x] Squash & Rebase commits