### PR TITLE
Fix Incorrect data for cert table

### DIFF
--- a/lms/djangoapps/certificates/signals.py
+++ b/lms/djangoapps/certificates/signals.py
@@ -84,10 +84,11 @@ def _listen_for_failing_grade(sender, user, course_id, grade, **kwargs):  # pyli
     cert = GeneratedCertificate.certificate_for_student(user, course_id)
     if cert is not None:
         if CertificateStatuses.is_passing_status(cert.status):
-            cert.mark_notpassing(grade)
-            log.info(u'Certificate marked not passing for {user} : {course} via failing grade'.format(
+            cert.mark_notpassing(grade.percent)
+            log.info(u'Certificate marked not passing for {user} : {course} via failing grade: {grade}'.format(
                 user=user.id,
-                course=course_id
+                course=course_id,
+                grade=grade
             ))
 
 


### PR DESCRIPTION
Background
The bug was introduced in the PR: https://github.com/edx/edx-platform/pull/19676/files

which has implemented a signal COURSE_GRADE_NOW_FAILED and in the receiver, the whole the course grade object is sent assuming is a grade. So the Unicode representation of the course grade object is sent as a grade. The Unicode representation of the grade is Course Grade: percent: '1.0', letter_grade: A, passed: True and we have a limit of length 5 on grade field which is why Cours is added as a grade.

Course Grade Unicode method: https://github.com/edx/edx-platform/blob/fde830b73aae88227869588e83752bf5b38c0842/lms/djangoapps/grades/course_grade.py#L35

### Fix
Use course grade percent for storing in cert table. 
### Sandbox
https://awaisdar001.sandbox.edx.org/courses/course-v1:edX+DemoX+Demo_Course/
User:Staff

### Log after fix
```
Mar  6 11:35:03 ip-192-168-0-89 [service_variant=lms][lms.djangoapps.certificates.signals][env:sandbox] INFO [awaisdar001  20888] [signals.py:91] - Certificate marked not passing for 10 : course-v1:edX+DemoX+Demo_Course via failing grade: Course Grade: percent: 0.17, letter_grade: None, passed: False
```
[EDUCATOR-4128](https://openedx.atlassian.net/browse/EDUCATOR-4128)

FYI -- @jansenk @schenedx 