### PR TITLE
Add custom google oauth2 backend

### DIFF
--- a/common/djangoapps/third_party_auth/custom_backends.py
+++ b/common/djangoapps/third_party_auth/custom_backends.py
@@ -1,3 +1,12 @@
+"""
+Currently edx is using 1.7.0 version of social-auth-core
+which uses google-plus-api to sign in with google.
+As google plus is being shutting down on 7th of March,
+so this version of social-auth-core will cause problems.
+Luckily social-auth-core version 3.0.0 Link has handled
+this issue already so this module is to incorporate that fix
+into the edx code by adding custom google oauth2 backend for google+.
+"""
 from social_core.backends.google import GoogleOAuth2
 
 

--- a/common/djangoapps/third_party_auth/custom_backends.py
+++ b/common/djangoapps/third_party_auth/custom_backends.py
@@ -1,0 +1,46 @@
+from social_core.backends.google import GoogleOAuth2
+
+
+class CustomGoogleOAuth(GoogleOAuth2):
+
+    def get_user_id(self, details, response):
+        """Use google email as unique id"""
+        if self.setting('USE_UNIQUE_USER_ID', False):
+            if 'sub' in response:
+                return response['sub']
+            else:
+                return response['id']
+        else:
+            return details['email']
+
+    def get_user_details(self, response):
+        """Return user details from Google API account"""
+        if 'email' in response:
+            email = response['email']
+        else:
+            email = ''
+
+        name, given_name, family_name = (
+            response.get('name', ''),
+            response.get('given_name', ''),
+            response.get('family_name', ''),
+        )
+
+        fullname, first_name, last_name = self.get_user_names(
+            name, given_name, family_name
+        )
+        return {'username': email.split('@', 1)[0],
+                'email': email,
+                'fullname': fullname,
+                'first_name': first_name,
+                'last_name': last_name}
+
+    def user_data(self, access_token, *args, **kwargs):
+        """Return user data from Google API"""
+        return self.get_json(
+            'https://www.googleapis.com/oauth2/v3/userinfo',
+            params={
+                'access_token': access_token,
+                'alt': 'json'
+            }
+        )

--- a/common/djangoapps/third_party_auth/custom_backends.py
+++ b/common/djangoapps/third_party_auth/custom_backends.py
@@ -11,9 +11,14 @@ from social_core.backends.google import GoogleOAuth2
 
 
 class CustomGoogleOAuth(GoogleOAuth2):
+    """
+    Google OAuth2 custom authentication backend
+    """
 
     def get_user_id(self, details, response):
-        """Use google email as unique id"""
+        """
+        Use google email as unique id
+        """
         if self.setting('USE_UNIQUE_USER_ID', False):
             if 'sub' in response:
                 return response['sub']
@@ -23,7 +28,9 @@ class CustomGoogleOAuth(GoogleOAuth2):
             return details['email']
 
     def get_user_details(self, response):
-        """Return user details from Google API account"""
+        """
+        Return user details from Google API account
+        """
         if 'email' in response:
             email = response['email']
         else:
@@ -45,7 +52,9 @@ class CustomGoogleOAuth(GoogleOAuth2):
                 'last_name': last_name}
 
     def user_data(self, access_token, *args, **kwargs):
-        """Return user data from Google API"""
+        """
+        Return user data from Google API
+        """
         return self.get_json(
             'https://www.googleapis.com/oauth2/v3/userinfo',
             params={
@@ -53,3 +62,9 @@ class CustomGoogleOAuth(GoogleOAuth2):
                 'alt': 'json'
             }
         )
+
+    def auth_html(self):
+        """
+        Abstract Method Inclusion
+        """
+        pass

--- a/common/djangoapps/third_party_auth/tests/utils.py
+++ b/common/djangoapps/third_party_auth/tests/utils.py
@@ -96,7 +96,7 @@ class ThirdPartyOAuthTestMixinFacebook(object):
 class ThirdPartyOAuthTestMixinGoogle(object):
     """Tests oauth with the Google backend"""
     BACKEND = "google-oauth2"
-    USER_URL = "https://www.googleapis.com/plus/v1/people/me"
+    USER_URL = "https://www.googleapis.com/oauth2/v3/userinfo"
     # In google-oauth2 responses, the "email" field is used as the user's identifier
     UID_FIELD = "email"
 

--- a/lms/envs/aws.py
+++ b/lms/envs/aws.py
@@ -655,7 +655,7 @@ X_FRAME_OPTIONS = ENV_TOKENS.get('X_FRAME_OPTIONS', X_FRAME_OPTIONS)
 ##### Third-party auth options ################################################
 if FEATURES.get('ENABLE_THIRD_PARTY_AUTH'):
     tmp_backends = ENV_TOKENS.get('THIRD_PARTY_AUTH_BACKENDS', [
-        'social_core.backends.google.GoogleOAuth2',
+        'third_party_auth.custom_backends.CustomGoogleOAuth',
         'social_core.backends.linkedin.LinkedinOAuth2',
         'social_core.backends.facebook.FacebookOAuth2',
         'social_core.backends.azuread.AzureADOAuth2',

--- a/lms/envs/bok_choy.yml
+++ b/lms/envs/bok_choy.yml
@@ -143,7 +143,7 @@ STATIC_URL_BASE: /static/
 SUPPORT_SITE_LINK: https://support.example.com
 SYSLOG_SERVER: ''
 TECH_SUPPORT_EMAIL: technical@example.com
-THIRD_PARTY_AUTH_BACKENDS: [social_core.backends.google.GoogleOAuth2, social_core.backends.linkedin.LinkedinOAuth2,
+THIRD_PARTY_AUTH_BACKENDS: [third_party_auth.custom_backends.CustomGoogleOAuth, social_core.backends.linkedin.LinkedinOAuth2,
   social_core.backends.facebook.FacebookOAuth2, third_party_auth.dummy.DummyBackend,
   third_party_auth.saml.SAMLAuthBackend]
 TIME_ZONE: America/New_York

--- a/lms/envs/bok_choy_docker.yml
+++ b/lms/envs/bok_choy_docker.yml
@@ -147,7 +147,7 @@ STATIC_URL_BASE: /static/
 SUPPORT_SITE_LINK: https://support.example.com
 SYSLOG_SERVER: ''
 TECH_SUPPORT_EMAIL: technical@example.com
-THIRD_PARTY_AUTH_BACKENDS: [social_core.backends.google.GoogleOAuth2, social_core.backends.linkedin.LinkedinOAuth2,
+THIRD_PARTY_AUTH_BACKENDS: [third_party_auth.custom_backends.CustomGoogleOAuth, social_core.backends.linkedin.LinkedinOAuth2,
   social_core.backends.facebook.FacebookOAuth2, third_party_auth.dummy.DummyBackend,
   third_party_auth.saml.SAMLAuthBackend]
 TIME_ZONE: America/New_York

--- a/lms/envs/production.py
+++ b/lms/envs/production.py
@@ -670,7 +670,7 @@ X_FRAME_OPTIONS = ENV_TOKENS.get('X_FRAME_OPTIONS', X_FRAME_OPTIONS)
 ##### Third-party auth options ################################################
 if FEATURES.get('ENABLE_THIRD_PARTY_AUTH'):
     tmp_backends = ENV_TOKENS.get('THIRD_PARTY_AUTH_BACKENDS', [
-        'social_core.backends.google.GoogleOAuth2',
+        'third_party_auth.custom_backends.CustomGoogleOAuth',
         'social_core.backends.linkedin.LinkedinOAuth2',
         'social_core.backends.facebook.FacebookOAuth2',
         'social_core.backends.azuread.AzureADOAuth2',

--- a/lms/envs/test.py
+++ b/lms/envs/test.py
@@ -233,7 +233,7 @@ FEATURES['PREVENT_CONCURRENT_LOGINS'] = False
 FEATURES['ENABLE_THIRD_PARTY_AUTH'] = True
 
 AUTHENTICATION_BACKENDS = [
-    'social_core.backends.google.GoogleOAuth2',
+    'third_party_auth.custom_backends.CustomGoogleOAuth',
     'social_core.backends.linkedin.LinkedinOAuth2',
     'social_core.backends.facebook.FacebookOAuth2',
     'social_core.backends.azuread.AzureADOAuth2',


### PR DESCRIPTION
Currently edx is using 1.7.0 version of `social-auth-core` which uses `google-plus-api` to sign in with google. As `google plus` is being shutting down on 7th of March, so this version of `social-auth-core` will cause problems. Luckily `social-auth-core` version 3.0.0  [Link](https://github.com/python-social-auth/social-core/commit/d77d75547b9ada3460a1b6809c8c9ad854f76871) has handled this issue already so this PR is to incorporate that fix into the edx code by adding `customgoogleoauth2` backend for `google+` sign in.