### PR TITLE
production.py should fallback to aws.py incase the plugin has not yet…

### DIFF
--- a/cms/envs/production.py
+++ b/cms/envs/production.py
@@ -11,6 +11,7 @@ import os
 
 from path import Path as path
 from xmodule.modulestore.modulestore_settings import convert_module_store_setting_if_needed
+from openedx.core.djangoapps.plugins import plugin_settings, constants as plugin_constants
 
 from .common import *
 
@@ -593,8 +594,14 @@ COURSE_ENROLLMENT_MODES = ENV_TOKENS.get('COURSE_ENROLLMENT_MODES', COURSE_ENROL
 ####################### Plugin Settings ##########################
 
 # This is at the bottom because it is going to load more settings after base settings are loaded
-from openedx.core.djangoapps.plugins import plugin_settings, constants as plugin_constants  # pylint: disable=wrong-import-order, wrong-import-position
-plugin_settings.add_plugins(__name__, plugin_constants.ProjectType.CMS, plugin_constants.SettingsType.AWS)
+
+# Load aws.py in plugins for reverse compatibility.  This can be removed after aws.py
+# is officially removed.
+plugin_settings.add_plugins(__name__, plugin_constants.ProjectType.CMS,
+                            plugin_constants.SettingsType.AWS)
+
+# We continue to load production.py over aws.py
+plugin_settings.add_plugins(__name__, plugin_constants.ProjectType.CMS, plugin_constants.SettingsType.PRODUCTION)
 
 ########################## Derive Any Derived Settings  #######################
 

--- a/lms/envs/production.py
+++ b/lms/envs/production.py
@@ -29,7 +29,6 @@ from xmodule.modulestore.modulestore_settings import convert_module_store_settin
 from openedx.core.djangoapps.plugins import plugin_settings, constants as plugin_constants
 
 from .common import *
-
 from openedx.core.lib.derived import derive_settings  # pylint: disable=wrong-import-order
 from openedx.core.lib.logsettings import get_logger_config  # pylint: disable=wrong-import-order
 

--- a/lms/envs/production.py
+++ b/lms/envs/production.py
@@ -23,11 +23,12 @@ import json
 import os
 import dateutil
 
-from corsheaders.defaults import default_headers as corsheaders_default_headers
 from path import Path as path
 from xmodule.modulestore.modulestore_settings import convert_module_store_setting_if_needed
+from openedx.core.djangoapps.plugins import plugin_settings, constants as plugin_constants
 
 from .common import *
+
 from openedx.core.lib.derived import derive_settings  # pylint: disable=wrong-import-order
 from openedx.core.lib.logsettings import get_logger_config  # pylint: disable=wrong-import-order
 
@@ -1101,8 +1102,14 @@ WRITABLE_GRADEBOOK_URL = ENV_TOKENS.get('WRITABLE_GRADEBOOK_URL', WRITABLE_GRADE
 ############################### Plugin Settings ###############################
 
 # This is at the bottom because it is going to load more settings after base settings are loaded
-from openedx.core.djangoapps.plugins import plugin_settings, constants as plugin_constants  # pylint: disable=wrong-import-order, wrong-import-position
-plugin_settings.add_plugins(__name__, plugin_constants.ProjectType.LMS, plugin_constants.SettingsType.AWS)
+
+# Load aws.py in plugins for reverse compatibility.  This can be removed after aws.py
+# is officially removed.
+plugin_settings.add_plugins(__name__, plugin_constants.ProjectType.LMS,
+                            plugin_constants.SettingsType.AWS)
+
+# Load production.py in plugins
+plugin_settings.add_plugins(__name__, plugin_constants.ProjectType.LMS, plugin_constants.SettingsType.PRODUCTION)
 
 ########################## Derive Any Derived Settings  #######################
 

--- a/lms/envs/production.py
+++ b/lms/envs/production.py
@@ -23,6 +23,7 @@ import json
 import os
 import dateutil
 
+from corsheaders.defaults import default_headers as corsheaders_default_headers
 from path import Path as path
 from xmodule.modulestore.modulestore_settings import convert_module_store_setting_if_needed
 from openedx.core.djangoapps.plugins import plugin_settings, constants as plugin_constants

--- a/openedx/core/djangoapps/plugins/constants.py
+++ b/openedx/core/djangoapps/plugins/constants.py
@@ -29,7 +29,8 @@ class SettingsType(object):
     See https://github.com/edx/edx-platform/master/lms/envs/docs/README.rst for
     further information on each Settings Type.
     """
-    AWS = u'aws'
+    AWS = u'aws'  # aws.py has been deprecated. See https://openedx.atlassian.net/browse/DEPR-14
+    PRODUCTION = u'production'
     COMMON = u'common'
     DEVSTACK = u'devstack'
     TEST = u'test'


### PR DESCRIPTION
… been migrated to use production.py