### PR TITLE
Change the version of social-auth-core

### DIFF
--- a/common/djangoapps/third_party_auth/tests/utils.py
+++ b/common/djangoapps/third_party_auth/tests/utils.py
@@ -96,7 +96,7 @@ class ThirdPartyOAuthTestMixinFacebook(object):
 class ThirdPartyOAuthTestMixinGoogle(object):
     """Tests oauth with the Google backend"""
     BACKEND = "google-oauth2"
-    USER_URL = "https://www.googleapis.com/plus/v1/people/me"
+    USER_URL = "https://www.googleapis.com/oauth2/v3/userinfo"
     # In google-oauth2 responses, the "email" field is used as the user's identifier
     UID_FIELD = "email"
 

--- a/requirements/edx/base.in
+++ b/requirements/edx/base.in
@@ -130,7 +130,7 @@ reportlab                           # Used for shopping cart's pdf invoice/recei
 rest-condition                      # DRF's recommendation for supporting complex permissions
 rfc6266-parser                      # Used to generate Content-Disposition headers.
 social-auth-app-django<3.0.0
-social-auth-core<2.0.0
+social-auth-core==3.0.0
 pysrt                               # Support for SubRip subtitle files, used in the video XModule
 pytz                                # Time zone information database
 PyYAML                              # Used to parse XModule resource templates

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -223,7 +223,7 @@ singledispatch==3.4.0.3
 six==1.11.0
 slumber==0.7.1            # via edx-rest-api-client
 social-auth-app-django==2.1.0
-social-auth-core==1.7.0
+social-auth-core==3.0.0
 sorl-thumbnail==12.3
 sortedcontainers==2.1.0
 soupsieve==1.8            # via beautifulsoup4

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -315,7 +315,7 @@ slumber==0.7.1
 snakefood==1.4
 snowballstemmer==1.2.1    # via sphinx
 social-auth-app-django==2.1.0
-social-auth-core==1.7.0
+social-auth-core==3.0.0
 sorl-thumbnail==12.3
 sortedcontainers==2.1.0
 soupsieve==1.8

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -304,7 +304,7 @@ singledispatch==3.4.0.3
 six==1.11.0
 slumber==0.7.1
 social-auth-app-django==2.1.0
-social-auth-core==1.7.0
+social-auth-core==3.0.0
 sorl-thumbnail==12.3
 sortedcontainers==2.1.0
 soupsieve==1.8


### PR DESCRIPTION
Currently edx is using 1.7.0 version of social-auth-core which uses google-plus-api to sign in with google. As google plus is being shutting down on 7th of March link, so this version of social-auth-core will cause problems.
Luckily social-auth-core version 3.0.0 Link has handled this issue already so this PR is to incorporate that fix into the edx code by changing the version of socail-auth-core

I have also made two PR's regarding that issue In this [PR](https://github.com/edx/edx-platform/pull/19919)
I just changed the version of `social-auth-core` but I missed to replace a `user_url` in it, which I have fixed in this PR as that PR has already closed.
In the second [PR](https://github.com/edx/edx-platform/pull/19945) I have written some `custom_backend` for that issue but to me, the solution given in this PR is much better.