### PR TITLE
Upgrade axe-core (via bok-choy) to 3.2.2

### DIFF
--- a/common/test/acceptance/tests/discussion/test_cohort_management.py
+++ b/common/test/acceptance/tests/discussion/test_cohort_management.py
@@ -693,6 +693,7 @@ class CohortConfigurationTest(EventsTestMixin, UniqueCourseTest, CohortTestMixin
         self.cohort_management_page.a11y_audit.config.set_rules({
             "ignore": [
                 'aria-valid-attr',  # TODO: LEARNER-6611 & LEARNER-6865
+                'region',  # TODO: AC-932
             ]
         })
         self.cohort_management_page.a11y_audit.check_for_accessibility_errors()

--- a/common/test/acceptance/tests/discussion/test_discussion.py
+++ b/common/test/acceptance/tests/discussion/test_discussion.py
@@ -229,6 +229,7 @@ class DiscussionHomePageTest(BaseDiscussionTestCase):
                 'section',  # TODO: AC-491
                 'aria-required-children',  # TODO: AC-534
                 'aria-valid-attr',  # TODO: LEARNER-6611 & LEARNER-6865
+                'region'  # TODO: AC-932
             ]
         })
         self.page.a11y_audit.check_for_accessibility_errors()
@@ -467,6 +468,7 @@ class DiscussionTabMultipleThreadTest(BaseDiscussionTestCase, BaseDiscussionMixi
                 'section',  # TODO: AC-491
                 'aria-required-children',  # TODO: AC-534
                 'aria-valid-attr',  # TODO: LEARNER-6611 & LEARNER-6865
+                'region',  # TODO: AC-932
             ]
         })
 
@@ -476,6 +478,7 @@ class DiscussionTabMultipleThreadTest(BaseDiscussionTestCase, BaseDiscussionMixi
             "ignore": [
                 'section',  # TODO: AC-491
                 'aria-required-children',  # TODO: AC-534
+                'region'  # TODO: AC-932
             ]
         })
 
@@ -540,6 +543,7 @@ class DiscussionOpenClosedThreadTest(BaseDiscussionTestCase):
                 'aria-required-children',  # TODO: AC-534
                 'color-contrast',  # Commented out for now because they reproducibly fail on Jenkins but not locally
                 'aria-valid-attr',  # TODO: LEARNER-6611 & LEARNER-6865
+                'region',  # TODO: AC-932
             ]
         })
         page.a11y_audit.check_for_accessibility_errors()
@@ -551,6 +555,7 @@ class DiscussionOpenClosedThreadTest(BaseDiscussionTestCase):
                 'aria-required-children',  # TODO: AC-534
                 'color-contrast',  # Commented out for now because they reproducibly fail on Jenkins but not locally
                 'aria-valid-attr',  # TODO: LEARNER-6611 & LEARNER-6865
+                'region',  # TODO: AC-932
             ]
         })
         page.a11y_audit.check_for_accessibility_errors()
@@ -845,6 +850,7 @@ class DiscussionResponseEditTest(BaseDiscussionTestCase):
                 'section',  # TODO: AC-491
                 'aria-required-children',  # TODO: AC-534
                 'aria-valid-attr',  # TODO: LEARNER-6611 & LEARNER-6865
+                'region',  # TODO: AC-932
             ]
         })
         page.visit()
@@ -947,6 +953,7 @@ class DiscussionCommentEditTest(BaseDiscussionTestCase):
                 'section',  # TODO: AC-491
                 'aria-required-children',  # TODO: AC-534
                 'aria-valid-attr',  # TODO: LEARNER-6611 & LEARNER-6865
+                'region',  # TODO: AC-932
             ]
         })
         page.a11y_audit.check_for_accessibility_errors()
@@ -1392,6 +1399,7 @@ class DiscussionSearchAlertTest(UniqueCourseTest):
                 'section',  # TODO: AC-491
                 'aria-required-children',  # TODO: AC-534
                 'aria-valid-attr',  # TODO: LEARNER-6611 & LEARNER-6865
+                'region',  # TODO: AC-932
             ]
         })
         self.page.a11y_audit.check_for_accessibility_errors()

--- a/common/test/acceptance/tests/lms/test_account_settings.py
+++ b/common/test/acceptance/tests/lms/test_account_settings.py
@@ -550,6 +550,7 @@ class AccountSettingsA11yTest(AccountSettingsTestMixin, AcceptanceTest):
         self.account_settings_page.a11y_audit.config.set_rules({
             "ignore": [
                 'aria-valid-attr',  # TODO: LEARNER-6611 & LEARNER-6865
+                'region',  # TODO: AC-932
             ]
         })
         self.account_settings_page.a11y_audit.check_for_accessibility_errors()

--- a/common/test/acceptance/tests/lms/test_bookmarks.py
+++ b/common/test/acceptance/tests/lms/test_bookmarks.py
@@ -598,6 +598,10 @@ class BookmarksA11yTests(BookmarksTestMixin):
         self.bookmarks_page.a11y_audit.config.set_rules({
             "ignore": [
                 'aria-valid-attr',  # TODO: LEARNER-6611 & LEARNER-6865
+                'heading-order',  # TODO: AC-933
+                'landmark-no-duplicate-banner',  # TODO: AC-934
+                'landmark-one-main',  # TODO: AC-944
+                'region'  # TODO: AC-932
             ]
         })
         self.setup_test(num_chapters=11)

--- a/common/test/acceptance/tests/lms/test_learner_profile.py
+++ b/common/test/acceptance/tests/lms/test_learner_profile.py
@@ -660,6 +660,7 @@ class LearnerProfileA11yTest(LearnerProfileTestMixin, AcceptanceTest):
         profile_page.a11y_audit.config.set_rules({
             "ignore": [
                 'aria-valid-attr',  # TODO: LEARNER-6611 & LEARNER-6865
+                'region',  # TODO: AC-932
             ]
         })
         profile_page.a11y_audit.check_for_accessibility_errors()
@@ -686,6 +687,7 @@ class LearnerProfileA11yTest(LearnerProfileTestMixin, AcceptanceTest):
         profile_page.a11y_audit.config.set_rules({
             "ignore": [
                 'aria-valid-attr',  # TODO: LEARNER-6611 & LEARNER-6865
+                'region',  # TODO: AC-932
             ]
         })
         profile_page.a11y_audit.check_for_accessibility_errors()
@@ -701,6 +703,8 @@ class LearnerProfileA11yTest(LearnerProfileTestMixin, AcceptanceTest):
         profile_page.a11y_audit.config.set_rules({
             "ignore": [
                 'aria-valid-attr',  # TODO: LEARNER-6611 & LEARNER-6865
+                'region',  # TODO: AC-932
+                'color-contrast'  # AC-938
             ]
         })
         profile_page.display_accomplishments()

--- a/common/test/acceptance/tests/lms/test_lms.py
+++ b/common/test/acceptance/tests/lms/test_lms.py
@@ -533,6 +533,7 @@ class CourseWikiA11yTest(UniqueCourseTest):
         self.course_wiki_page.a11y_audit.config.set_rules({
             "ignore": [
                 'aria-valid-attr',  # TODO: LEARNER-6611 & LEARNER-6865
+                'region',  # TODO: AC-932
             ]
         })
         self.course_wiki_page.a11y_audit.check_for_accessibility_errors()
@@ -545,6 +546,7 @@ class CourseWikiA11yTest(UniqueCourseTest):
         self.course_wiki_edit_page.a11y_audit.config.set_rules({
             "ignore": [
                 'aria-valid-attr',  # TODO: LEARNER-6611 & LEARNER-6865
+                'region',  # TODO: AC-932
             ]
         })
         self.course_wiki_edit_page.a11y_audit.check_for_accessibility_errors()
@@ -558,6 +560,7 @@ class CourseWikiA11yTest(UniqueCourseTest):
         history_page.a11y_audit.config.set_rules({
             "ignore": [
                 'aria-valid-attr',  # TODO: LEARNER-6611 & LEARNER-6865
+                'region',  # TODO: AC-932
             ]
         })
         history_page.wait_for_page()
@@ -572,6 +575,7 @@ class CourseWikiA11yTest(UniqueCourseTest):
         children_page.a11y_audit.config.set_rules({
             "ignore": [
                 'aria-valid-attr',  # TODO: LEARNER-6611 & LEARNER-6865
+                'region',  # TODO: AC-932
             ]
         })
         children_page.wait_for_page()

--- a/common/test/acceptance/tests/lms/test_lms_course_home.py
+++ b/common/test/acceptance/tests/lms/test_lms_course_home.py
@@ -141,6 +141,8 @@ class CourseHomeA11yTest(CourseHomeBaseTest):
         course_home_page.a11y_audit.config.set_rules({
             "ignore": [
                 'aria-valid-attr',  # TODO: LEARNER-6611 & LEARNER-6865
+                'region',  # TODO: AC-932
+                'landmark-no-duplicate-banner',  # TODO: AC-934
             ]
         })
         course_home_page.a11y_audit.check_for_accessibility_errors()
@@ -155,6 +157,8 @@ class CourseHomeA11yTest(CourseHomeBaseTest):
         course_search_results_page.a11y_audit.config.set_rules({
             "ignore": [
                 'aria-valid-attr',  # TODO: LEARNER-6611 & LEARNER-6865
+                'region',  # TODO: AC-932
+                'landmark-no-duplicate-banner',  # TODO: AC-934
             ]
         })
         course_search_results_page.a11y_audit.check_for_accessibility_errors()

--- a/common/test/acceptance/tests/lms/test_lms_dashboard.py
+++ b/common/test/acceptance/tests/lms/test_lms_dashboard.py
@@ -411,6 +411,10 @@ class LmsDashboardA11yTest(BaseLmsDashboardTestMultiple):
         self.dashboard_page.a11y_audit.config.set_rules({
             "ignore": [
                 'aria-valid-attr',  # TODO: LEARNER-6611 & LEARNER-6865
+                'button-name',  # TODO: AC-935
+                'landmark-no-duplicate-banner',  # TODO: AC-934
+                'landmark-complementary-is-top-level',  # TODO: AC-939
+                'region'  # TODO: AC-932
             ]
         })
         course_listings = self.dashboard_page.get_courses()

--- a/common/test/acceptance/tests/lms/test_lms_instructor_dashboard.py
+++ b/common/test/acceptance/tests/lms/test_lms_instructor_dashboard.py
@@ -80,6 +80,7 @@ class LMSInstructorDashboardA11yTest(BaseInstructorDashboardTest):
         self.instructor_dashboard_page.a11y_audit.config.set_rules({
             "ignore": [
                 'aria-valid-attr',  # TODO: LEARNER-6611 & LEARNER-6865
+                'region',  # TODO: AC-932
             ]
         })
         self.instructor_dashboard_page.a11y_audit.check_for_accessibility_errors()
@@ -115,6 +116,9 @@ class BulkEmailTest(BaseInstructorDashboardTest):
         self.send_email_page.a11y_audit.config.set_rules({
             "ignore": [
                 'button-name',  # TODO: TNL-5830
+                'aria-allowed-role',  # TODO: AC-936
+                'color-contrast',  # TODO: AC-938
+                'listitem'  # TODO: AC-937
             ]
         })
         self.send_email_page.a11y_audit.check_for_accessibility_errors()
@@ -232,7 +236,7 @@ class AutoEnrollmentWithCSVTest(BaseInstructorDashboardTest):
         Auto-enrollment with CSV accessibility tests
         """
         self.auto_enroll_section.a11y_audit.config.set_scope([
-            '#member-list-widget-template'
+            '#membership-list-widget-tpl'
         ])
         self.auto_enroll_section.a11y_audit.check_for_accessibility_errors()
 
@@ -1113,6 +1117,11 @@ class CertificatesTest(BaseInstructorDashboardTest):
         """
         Certificates page accessibility tests
         """
+        self.certificates_section.a11y_audit.config.set_rules({
+            "ignore": [
+                'aria-hidden-focus'  # TODO: AC-938
+            ]
+        })
         self.certificates_section.a11y_audit.config.set_scope([
             '.certificates-wrapper'
         ])
@@ -1322,6 +1331,11 @@ class CertificateInvalidationTest(BaseInstructorDashboardTest):
         """
         Certificate invalidation accessibility tests
         """
+        self.certificates_section.a11y_audit.config.set_rules({
+            "ignore": [
+                'aria-hidden-focus'  # TODO: AC-938
+            ]
+        })
         self.certificates_section.a11y_audit.config.set_scope([
             '.certificates-wrapper'
         ])

--- a/common/test/acceptance/tests/lms/test_lms_user_preview.py
+++ b/common/test/acceptance/tests/lms/test_lms_user_preview.py
@@ -426,6 +426,7 @@ class CourseWithContentGroupsTest(StaffViewTest):
                 'color-contrast',  # TODO: AC-559
                 'link-href',  # TODO: AC-559
                 'section',  # TODO: AC-559
+                'region',  # TODO: AC-932
             ]
         })
         course_page.a11y_audit.check_for_accessibility_errors()

--- a/common/test/acceptance/tests/lms/test_problem_types.py
+++ b/common/test/acceptance/tests/lms/test_problem_types.py
@@ -173,7 +173,8 @@ class ProblemTypeA11yTestMixin(object):
 
         # Set the scope to the problem container
         self.problem_page.a11y_audit.config.set_scope(
-            include=['div#seq_content'])
+            include=['div#seq_content']
+        )
 
         # Run the accessibility audit.
         self.problem_page.a11y_audit.check_for_accessibility_errors()
@@ -618,6 +619,7 @@ class AnnotationProblemTypeBase(ProblemTypeTestBase):
         self.problem_page.a11y_audit.config.set_rules({
             "ignore": [
                 'label',  # TODO: AC-491
+                'label-title-only',  # TODO: AC-493
             ]
         })
 

--- a/common/test/acceptance/tests/lms/test_programs.py
+++ b/common/test/acceptance/tests/lms/test_programs.py
@@ -123,6 +123,7 @@ class ProgramListingPageA11yTest(ProgramPageBase):
         self.listing_page.a11y_audit.config.set_rules({
             "ignore": [
                 'aria-valid-attr',  # TODO: LEARNER-6611 & LEARNER-6865
+                'region',  # TODO: AC-932
             ]
         })
         self.auth(enroll=False)
@@ -140,6 +141,8 @@ class ProgramListingPageA11yTest(ProgramPageBase):
         self.listing_page.a11y_audit.config.set_rules({
             "ignore": [
                 'aria-valid-attr',  # TODO: LEARNER-6611 & LEARNER-6865
+                'landmark-complementary-is-top-level',  # TODO: AC-939
+                'region',  # TODO: AC-932
             ]
         })
         self.auth()
@@ -170,6 +173,8 @@ class ProgramDetailsPageA11yTest(ProgramPageBase):
         self.details_page.a11y_audit.config.set_rules({
             "ignore": [
                 'aria-valid-attr',  # TODO: LEARNER-6611 & LEARNER-6865
+                'landmark-complementary-is-top-level',  # TODO: AC-939
+                'region',  # TODO: AC-932
             ]
         })
         self.auth()

--- a/common/test/acceptance/tests/lms/test_progress_page.py
+++ b/common/test/acceptance/tests/lms/test_progress_page.py
@@ -333,6 +333,7 @@ class SubsectionGradingPolicyA11yTest(SubsectionGradingPolicyBase):
             self.progress_page.a11y_audit.config.set_rules({
                 "ignore": [
                     'aria-valid-attr',  # TODO: LEARNER-6611 & LEARNER-6865
+                    'region',  # TODO: AC-932
                 ]
             })
             self.progress_page.visit()
@@ -420,6 +421,7 @@ class ProgressPageA11yTest(ProgressPageBaseTest):
         self.progress_page.a11y_audit.config.set_rules({
             "ignore": [
                 'aria-valid-attr',  # TODO: LEARNER-6611 & LEARNER-6865
+                'region',  # TODO: AC-932
             ]
         })
         self.progress_page.visit()

--- a/common/test/acceptance/tests/studio/test_studio_library.py
+++ b/common/test/acceptance/tests/studio/test_studio_library.py
@@ -654,6 +654,10 @@ class StudioLibraryA11yTest(StudioLibraryTest):
         lib_page.a11y_audit.config.set_rules({
             "ignore": [
                 'link-href',  # TODO: AC-590
+                'duplicate-id-aria',  # TODO: AC-940
+                'heading-order',  # TODO: AC-933
+                'landmark-complementary-is-top-level',  # TODO: AC-939
+                'region'  # TODO: AC-932
             ],
         })
 

--- a/common/test/acceptance/tests/studio/test_studio_settings.py
+++ b/common/test/acceptance/tests/studio/test_studio_settings.py
@@ -760,6 +760,10 @@ class StudioSettingsA11yTest(StudioCourseTest):
         self.settings_page.a11y_audit.config.set_rules({
             "ignore": [
                 'link-href',  # TODO: AC-590
+                'aria-allowed-role',  # TODO: AC-936
+                'landmark-complementary-is-top-level',  # TODO: AC-939
+                'radiogroup',  # TODO:  AC-941
+                'region',  # TODO: AC-932
             ],
         })
 
@@ -819,6 +823,11 @@ class StudioSubsectionSettingsA11yTest(StudioCourseTest):
         self.course_outline.open_subsection_settings_dialog()
         self.course_outline.select_advanced_tab()
 
+        self.course_outline.a11y_audit.config.set_rules({
+            "ignore": [
+                'section',  # TODO: AC-491
+            ],
+        })
         # limit the scope of the audit to the special exams tab on the modal dialog
         self.course_outline.a11y_audit.config.set_scope(
             include=['section.edit-settings-timed-examination']

--- a/common/test/acceptance/tests/studio/test_studio_textbooks.py
+++ b/common/test/acceptance/tests/studio/test_studio_textbooks.py
@@ -83,6 +83,7 @@ class TextbooksTest(StudioCourseTest):
             'ignore': [
                 'section',  # AC-503
                 'aria-valid-attr',  # TODO: LEARNER-6611 & LEARNER-6865
+                'region',  # TODO: AC-932
             ],
         })
         self.textbook_view_page.a11y_audit.check_for_accessibility_errors()
@@ -97,14 +98,21 @@ class TextbooksTest(StudioCourseTest):
         self.textbook_view_page.visit()
 
         self.textbook_view_page.switch_to_pdf_frame(self)
-        self.textbook_view_page.a11y_audit.config.set_scope({
-            'exclude': [
+        self.textbook_view_page.a11y_audit.config.set_scope(
+            exclude=[
                 '#viewer',  # PDF viewer (vendor file)
             ]
-        })
+        )
         self.textbook_view_page.a11y_audit.config.set_rules({
             'ignore': [
-                'color-contrast',  # will always fail because pdf.js converts pdf to divs with transparent text
+                'html-has-lang',  # TODO: AC-942
+                'label-title-only',  # TODO: AC-493
+                'landmark-one-main',  # TODO: AC-944
+                'page-has-heading-one',  # TODO: AC-945
+                'region',  # TODO: AC-932
+                'link-href',  # TODO: AC-559
+                'skip-link',  # TODO: AC-937
+                'bypass'  # Commented out for now because they reproducibly fail on Jenkins but not locally
             ],
         })
         self.textbook_view_page.a11y_audit.check_for_accessibility_errors()

--- a/package-lock.json
+++ b/package-lock.json
@@ -3347,9 +3347,9 @@
       }
     },
     "edx-custom-a11y-rules": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/edx-custom-a11y-rules/-/edx-custom-a11y-rules-1.0.5.tgz",
-      "integrity": "sha512-0yPTw6IEQ5Eu/Nm2CBQzFVTnmXf5qa9NPopVKz2b9CtYHQcJyqxoiKboUH49S9ozTVMMPrvtc7rt5acdCTSGNg==",
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/edx-custom-a11y-rules/-/edx-custom-a11y-rules-1.0.6.tgz",
+      "integrity": "sha512-syMILFpMPFDfTdoSgU1ctcM0OMg2wKFFcF1uyTmLUpvIoUewQbj6zNr3gBs61s51JZZRXN3N5S+FyUMkMsgELw==",
       "dev": true
     },
     "edx-pattern-library": {

--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "@edx/mockprock": "^1.0.1",
     "@edx/stylelint-config-edx": "1.1.0",
     "babel-jest": "23.0.1",
-    "edx-custom-a11y-rules": "1.0.5",
+    "edx-custom-a11y-rules": "1.0.6",
     "enzyme": "3.3.0",
     "enzyme-adapter-react-16": "1.1.1",
     "eslint-config-edx": "3.0.1",

--- a/requirements/edx-sandbox/base.txt
+++ b/requirements/edx-sandbox/base.txt
@@ -17,7 +17,7 @@ lxml==3.8.0
 markupsafe==1.1.1
 matplotlib==1.3.1
 networkx==1.7
-nltk==3.4
+nltk==3.4.1
 nose==1.3.7               # via matplotlib
 numpy==1.6.2
 pycparser==2.19

--- a/requirements/edx-sandbox/shared.txt
+++ b/requirements/edx-sandbox/shared.txt
@@ -11,7 +11,7 @@ enum34==1.1.6             # via cryptography
 ipaddress==1.0.22         # via cryptography
 lxml==3.8.0
 networkx==1.7
-nltk==3.4
+nltk==3.4.1
 pycparser==2.19           # via cffi
 singledispatch==3.4.0.3   # via nltk
 six==1.11.0               # via cryptography, nltk, singledispatch

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -112,7 +112,7 @@ edx-django-release-util==0.3.1
 edx-django-sites-extensions==2.3.1
 edx-django-utils==1.0.3
 edx-drf-extensions==2.2.0
-edx-enterprise==1.4.5
+edx-enterprise==1.4.6
 edx-i18n-tools==0.4.8
 edx-milestones==0.1.13
 edx-oauth2-provider==1.2.2
@@ -134,7 +134,7 @@ firebase-token-generator==1.3.2
 fs-s3fs==0.1.8
 fs==2.0.18
 future==0.17.1            # via pyjwkest
-futures==3.2.0 ; python_version == "2.7"  # via python-swiftclient, s3transfer, xblock-utils
+futures==3.2.0 ; python_version == "2.7"  # via django-pipeline, python-swiftclient, s3transfer, xblock-utils
 geoip2==2.9.0
 glob2==0.6
 gunicorn==19.0
@@ -166,7 +166,7 @@ mpmath==1.1.0             # via sympy
 mysqlclient==1.4.2.post1
 networkx==1.7
 newrelic==4.16.1.117
-nltk==3.4
+nltk==3.4.1
 nodeenv==1.1.1
 numpy==1.16.2             # via scipy
 oauth2==1.9.0.post1

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -58,7 +58,7 @@ beautifulsoup4==4.7.1
 before-after==1.0.1
 billiard==3.3.0.23
 bleach==2.1.4
-bok-choy==0.9.3
+bok-choy==1.0.0
 boto3==1.4.8
 boto==2.39.0
 botocore==1.8.17
@@ -134,7 +134,7 @@ edx-django-release-util==0.3.1
 edx-django-sites-extensions==2.3.1
 edx-django-utils==1.0.3
 edx-drf-extensions==2.2.0
-edx-enterprise==1.4.5
+edx-enterprise==1.4.6
 edx-i18n-tools==0.4.8
 edx-lint==1.1.2
 edx-milestones==0.1.13
@@ -219,7 +219,7 @@ mpmath==1.1.0
 mysqlclient==1.4.2.post1
 networkx==1.7
 newrelic==4.16.1.117
-nltk==3.4
+nltk==3.4.1
 nodeenv==1.1.1
 numpy==1.16.2
 oauth2==1.9.0.post1
@@ -331,7 +331,7 @@ text-unidecode==1.2
 tincan==0.0.5
 toml==0.10.0
 tox-battery==0.5.1
-tox==3.8.6
+tox==3.9.0
 traceback2==1.4.0
 transifex-client==0.13.6
 twisted==19.2.0

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -56,7 +56,7 @@ beautifulsoup4==4.7.1
 before-after==1.0.1
 billiard==3.3.0.23
 bleach==2.1.4
-bok-choy==0.9.3
+bok-choy==1.0.0
 boto3==1.4.8
 boto==2.39.0
 botocore==1.8.17
@@ -130,7 +130,7 @@ edx-django-release-util==0.3.1
 edx-django-sites-extensions==2.3.1
 edx-django-utils==1.0.3
 edx-drf-extensions==2.2.0
-edx-enterprise==1.4.5
+edx-enterprise==1.4.6
 edx-i18n-tools==0.4.8
 edx-lint==1.1.2
 edx-milestones==0.1.13
@@ -212,7 +212,7 @@ mpmath==1.1.0
 mysqlclient==1.4.2.post1
 networkx==1.7
 newrelic==4.16.1.117
-nltk==3.4
+nltk==3.4.1
 nodeenv==1.1.1
 numpy==1.16.2
 oauth2==1.9.0.post1
@@ -318,7 +318,7 @@ text-unidecode==1.2       # via faker
 tincan==0.0.5
 toml==0.10.0              # via tox
 tox-battery==0.5.1
-tox==3.8.6
+tox==3.9.0
 traceback2==1.4.0         # via testtools, unittest2
 transifex-client==0.13.6
 twisted==19.2.0           # via scrapy


### PR DESCRIPTION
Summary
---

Bumping our bok-choy version to 1.0.0, which jumps axe-core from `1.1.0` all the way to the latest `3.2.2`: https://github.com/edx/bok-choy/pull/226

Clearly, this is a massive jump, which comes with a large set of new rules (33 new rules ids). The general approach I've taken here is to just ignore new failures for now, and ticket out the work to chip away at fixing them (probably to the Fedx board).

If it helps to add `# TODO: <TICKET>` to the new ignore rules, I'm happy to do that. Also, any feedback on the best way to ticket out these new ignore rules (by rule, by test, etc) is greatly appreciated.

Once this PR has been reviewed I'll cut a new release of bok-choy and update the requirements, I just don't want to block `make upgrade` in the meantime.

Test Exceptions
---

There were 2 tests that were actually throwing exceptions (not just a11y errors):

1- `studio/test_studio_textbooks.py::TextbooksTest::test_pdf_viewer_a11y`: which was incorrectly passing a dictionary to the `set_scope` method (located here: [link to bok-choy set_scope method](https://github.com/edx/bok-choy/blob/216effbf05447f6306ee5c1ec4a7576f33470279/bok_choy/a11y/axe_core_ruleset.py#L103). Even though this was "passing" in the previous version, I suspect it wasn't actually testing anything. I changed the method call and updated the ignore rules accordingly. Also, I wasn't seeing `color-contrast` errors when running the test, so I removed it from the ignore list.

2- Additionally, `lms/test_lms_instructor_dashboard.py::AutoEnrollmentWithCSVTest::test_auto_enroll_csv_a11y` was throwing an exception that it couldn't find an element with the identifier `#member-list-widget-template`. I ran the tests locally and inspected the page, but couldn't find any selectors by that name. The closest thing I could find was `#membership-list-widget-tpl`. If a reviewer has more context here let me know if it should be changed to something else.

Rules Diff
---

Old version: https://dequeuniversity.com/rules/axe/1.1
New version: https://dequeuniversity.com/rules/axe/3.2

Just append each url with `/<rule-id>` if you want to check out a specific rule in each version (if it exists). Some of the newly ignored rules are just completely new ids, while others have had changes in impact level, requirements, etc.