### PR TITLE
Add comments for code implementation

### DIFF
--- a/lms/djangoapps/verify_student/views.py
+++ b/lms/djangoapps/verify_student/views.py
@@ -1165,6 +1165,11 @@ def results_callback(request):
             verification = SoftwareSecurePhotoVerification.objects.filter(status='approved', user_id=attempt.user_id)
             if verification:
                 log.info(u'Making expiry date of previous approved verification NULL for {}'.format(attempt.user_id))
+                # The updated_at field in sspv model has auto_now set to True, which means any time save() is called on
+                # the model instance, `updated_at` will change. Some of the existing functionality of verification
+                # (showing your verification has expired on dashboard) relies on updated_at.
+                # In case the attempt.approve() fails for some reason and to not cause any inconsistencies in existing
+                # functionality update() is called instead of save()
                 previous_verification = verification.latest('updated_at')
                 SoftwareSecurePhotoVerification.objects.filter(pk=previous_verification.pk
                                                                ).update(expiry_date=None, expiry_email_date=None)


### PR DESCRIPTION
[discussion for why this is needed can be found here](https://github.com/edx/edx-platform/pull/19889#discussion_r263413888)
Added an explanation as to why I have not used save() like this
```
previous_verfication.expiry_date = None
previous_verfication.expiry_email_date = None
previous_verification.save()
```
and made two database hits [here](https://github.com/edx/edx-platform/blob/master/lms/djangoapps/verify_student/views.py#L1168)
