### PR TITLE
Update completion api version

### DIFF
--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -107,7 +107,7 @@ edx-ace==0.1.10
 edx-analytics-data-api-client==0.15.2
 edx-ccx-keys==0.2.1
 edx-celeryutils==0.2.7
-edx-completion==1.0.1
+edx-completion==1.0.2
 edx-django-oauth2-provider==1.3.5
 edx-django-release-util==0.3.1
 edx-django-sites-extensions==2.3.1

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -129,7 +129,7 @@ edx-ace==0.1.10
 edx-analytics-data-api-client==0.15.2
 edx-ccx-keys==0.2.1
 edx-celeryutils==0.2.7
-edx-completion==1.0.1
+edx-completion==1.0.2
 edx-django-oauth2-provider==1.3.5
 edx-django-release-util==0.3.1
 edx-django-sites-extensions==2.3.1

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -125,7 +125,7 @@ edx-ace==0.1.10
 edx-analytics-data-api-client==0.15.2
 edx-ccx-keys==0.2.1
 edx-celeryutils==0.2.7
-edx-completion==1.0.1
+edx-completion==1.0.2
 edx-django-oauth2-provider==1.3.5
 edx-django-release-util==0.3.1
 edx-django-sites-extensions==2.3.1


### PR DESCRIPTION
### [EDUCATOR-3926](https://openedx.atlassian.net/browse/EDUCATOR-3926)

### Description

The completion-batch API is used by the mobile team to mark a block containing video as complete when the video finishes. The API uses some different authentication mechanisms to verify the learner and underlying content. The current scheme, where SessionAuthentication is before OAuth2, caused issues on the iOS app. The problem was happening that both token and session ids were being sent in the request. Since SessionAuth was first, it tried to authenticate using that class. In the request, the **Referer** field was missing, which is necessary in the case of SessionAuth, which led to 403 error. The interesting part was that the iOS app uses the same request generation methodology for other APIs and they were working fine. All those APIs had the OAuth2 before SessionAuth([example](https://github.com/edx/edx-platform/blob/master/lms/djangoapps/discussion_api/views.py#L642)). This PR just updates the version of the completion app so that the fix can be made public.

### Related PR
 - Completion repo PR: https://github.com/edx/completion/pull/41

### Sandbox  
 - https://completion.sandbox.edx.org/

### Reviewers
 - [x] @awaisdar001 

### Post Review
 - [x] Squash & Rebase Commits
