### PR TITLE
Fix change enrollment command for credit.

### DIFF
--- a/common/djangoapps/student/management/commands/change_enrollment.py
+++ b/common/djangoapps/student/management/commands/change_enrollment.py
@@ -8,9 +8,8 @@ from opaque_keys import InvalidKeyError
 from opaque_keys.edx.keys import CourseKey
 from six import text_type
 
-from student.models import CourseEnrollment, User
-
-from student.models import CourseEnrollmentAttribute
+from openedx.core.djangoapps.credit.email_utils import get_credit_provider_attribute_values
+from student.models import CourseEnrollment, CourseEnrollmentAttribute, User
 
 logger = logging.getLogger(__name__)  # pylint: disable=invalid-name
 
@@ -102,6 +101,17 @@ class Command(BaseCommand):
         """ Update enrollments for a specific user identifier (email or username). """
         users = options[identifier].split(",")
 
+        credit_provider_attr = {}
+        if options['to_mode'] == 'credit':
+            provider_ids = get_credit_provider_attribute_values(
+                enrollment_args.get('course_id'), 'id'
+            )
+            credit_provider_attr = {
+                'namespace': 'credit',
+                'name': 'provider_id',
+                'value': provider_ids[0],
+            }
+
         for identified_user in users:
             logger.info(identified_user)
 
@@ -119,13 +129,10 @@ class Command(BaseCommand):
                         enrollment.update_enrollment(mode=options['to_mode'])
                         enrollment.save()
                         if options['to_mode'] == 'credit':
-                            enrollment_attrs.append({
-                                'namespace': 'credit',
-                                'name': 'provider_id',
-                                'value': enrollment_args['course_id'].org,
-                            })
-                            CourseEnrollmentAttribute.add_enrollment_attr(enrollment=enrollment,
-                                                                          data_list=enrollment_attrs)
+                            enrollment_attrs.append(credit_provider_attr)
+                            CourseEnrollmentAttribute.add_enrollment_attr(
+                                enrollment=enrollment, data_list=enrollment_attrs
+                            )
 
                     if options['noop']:
                         raise RollbackException('Forced rollback.')

--- a/common/djangoapps/student/tests/test_credit.py
+++ b/common/djangoapps/student/tests/test_credit.py
@@ -233,7 +233,7 @@ class CreditCourseDashboardTest(ModuleStoreTestCase):
         self._make_eligible()
 
         # The user should have the option to purchase credit
-        with patch('student.views.dashboard.get_credit_provider_display_names') as mock_method:
+        with patch('student.views.dashboard.get_credit_provider_attribute_values') as mock_method:
             mock_method.return_value = providers_list
             response = self._load_dashboard()
 

--- a/common/djangoapps/student/views/dashboard.py
+++ b/common/djangoapps/student/views/dashboard.py
@@ -33,7 +33,7 @@ from openedx.core.djangoapps.catalog.utils import (
     get_pseudo_session_for_entitlement,
     get_visible_sessions_for_entitlement
 )
-from openedx.core.djangoapps.credit.email_utils import get_credit_provider_display_names, make_providers_strings
+from openedx.core.djangoapps.credit.email_utils import get_credit_provider_attribute_values, make_providers_strings
 from openedx.core.djangoapps.programs.models import ProgramsApiConfig
 from openedx.core.djangoapps.programs.utils import ProgramDataExtender, ProgramProgressMeter
 from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
@@ -483,7 +483,7 @@ def _credit_statuses(user, course_enrollments):
     statuses = {}
     for eligibility in credit_api.get_eligibilities_for_user(user.username):
         course_key = CourseKey.from_string(text_type(eligibility["course_key"]))
-        providers_names = get_credit_provider_display_names(course_key)
+        providers_names = get_credit_provider_attribute_values(course_key, 'display_name')
         status = {
             "course_key": text_type(course_key),
             "eligible": True,


### PR DESCRIPTION
Get provider id from ecommerce upon changing enrollment to credit instead of setting course_key org.

[LEARNER-6643](https://openedx.atlassian.net/browse/LEARNER-6643)