### PR TITLE
LEARNER-6398: Change get_country_time_zones logic.

### DIFF
--- a/openedx/core/djangoapps/user_api/preferences/api.py
+++ b/openedx/core/djangoapps/user_api/preferences/api.py
@@ -418,20 +418,22 @@ def _create_preference_update_error(preference_key, preference_value, error):
 
 def get_country_time_zones(country_code=None):
     """
-    Returns a sorted list of time zones commonly used in given
-    country or list of all time zones, if country code is None.
+    Returns a sorted list of time zones commonly used in the specified
+    country.  If country_code is None (or unrecognized), or if the country
+    has no defined time zones, return a list of all time zones.
 
     Arguments:
         country_code (str): ISO 3166-1 Alpha-2 country code
-
-    Raises:
-        CountryCodeError: the given country code is invalid
     """
-    if country_code is None:
+    if country_code is None or country_code.upper() not in set(countries.alt_codes):
         return _get_sorted_time_zone_list(common_timezones)
-    if country_code.upper() in set(countries.alt_codes):
+
+    # We can still get a failure here because there are some countries that are
+    # valid, but have no defined timezones in the pytz package (e.g. BV, HM)
+    try:
         return _get_sorted_time_zone_list(country_timezones(country_code))
-    raise CountryCodeError
+    except KeyError:
+        return _get_sorted_time_zone_list(common_timezones)
 
 
 def _get_sorted_time_zone_list(time_zone_list):

--- a/openedx/core/djangoapps/user_api/preferences/tests/test_api.py
+++ b/openedx/core/djangoapps/user_api/preferences/tests/test_api.py
@@ -442,10 +442,14 @@ class CountryTimeZoneTest(CacheIsolationTestCase):
     """
 
     @ddt.data(('ES', ['Africa/Ceuta', 'Atlantic/Canary', 'Europe/Madrid']),
-              (None, common_timezones[:10]))
+              (None, common_timezones[:10]),
+              ('AA', common_timezones[:10]))
     @ddt.unpack
     def test_get_country_time_zones(self, country_code, expected_time_zones):
-        """Verify that list of common country time zones dictionaries is returned"""
+        """
+        Verify that list of common country time zones dictionaries is returned
+        An unrecognized country code (e.g. AA) will return the list of common timezones
+        """
         expected_dict = [
             {
                 'time_zone': time_zone,
@@ -455,11 +459,6 @@ class CountryTimeZoneTest(CacheIsolationTestCase):
         ]
         country_time_zones_dicts = get_country_time_zones(country_code)[:10]
         self.assertEqual(country_time_zones_dicts, expected_dict)
-
-    def test_country_code_errors(self):
-        """Verify that country code error is raised for invalid country code"""
-        with self.assertRaises(CountryCodeError):
-            get_country_time_zones('AA')
 
 
 def get_expected_validation_developer_message(preference_key, preference_value):


### PR DESCRIPTION
[LEARNER-6398](https://openedx.atlassian.net/browse/LEARNER-6398)
Change get_country_time_zones to not raise exception for unrecognized timezones.  