### PR TITLE
Fix bug: error messages are not shown in Course Team Management

### DIFF
--- a/lms/static/js/instructor_dashboard/membership.js
+++ b/lms/static/js/instructor_dashboard/membership.js
@@ -269,12 +269,12 @@ such that the value can be defined later than this assignment (file load order).
             this.clear_input();
             if (data.userDoesNotExist) {
                 msg = gettext("Could not find a user with username or email address '<%- identifier %>'.");
-                return this.show_errors(_.template(msg, {
+                return this.show_errors(_.template(msg)({
                     identifier: data.unique_student_identifier
                 }));
             } else if (data.inactiveUser) {
                 msg = gettext("Error: User '<%- username %>' has not yet activated their account. Users must create and activate their accounts before they can be assigned a role.");  // eslint-disable-line max-len
-                return this.show_errors(_.template(msg, {
+                return this.show_errors(_.template(msg)({
                     username: data.unique_student_identifier
                 }));
             } else if (data.removingSelfAsInstructor) {

--- a/lms/static/js/spec/instructor_dashboard/membership_auth_spec.js
+++ b/lms/static/js/spec/instructor_dashboard/membership_auth_spec.js
@@ -63,6 +63,31 @@ define(['jquery',
                 expect($('.auth-list-container.active .add-field').attr('disabled')).toBe(undefined);
             });
 
+            it('Error message is shown if user with given identifier does not exist', function() {
+                var url, params;
+                var requests = AjaxHelpers.requests(this);
+                $('.active .add-field').val('smth');
+                $('.active .add').click();
+                expect(requests.length).toEqual(1);
+
+                url = '/courses/course-v1:edx+ed202+2017_T3/instructor/api/modify_access';
+                params = $.param({
+                    unique_student_identifier: 'smth',
+                    rolename: 'staff',
+                    action: 'allow'
+                });
+                AjaxHelpers.expectPostRequest(requests, url, params);
+
+                AjaxHelpers.respondWithJson(requests, {
+                    unique_student_identifier: 'smth',
+                    userDoesNotExist: true
+                });
+
+                expect($('.request-response-error').text()).toEqual(
+                "Could not find a user with username or email address 'smth'."
+                );
+            });
+
             it('When no discussions division scheme is selected error is shown and inputs are disabled', function() {
                 var requests = AjaxHelpers.requests(this),
                     data,


### PR DESCRIPTION
**Backround:** This PR fixes a bug in Instructor Dashboard > Membership > Course Team Management. Error messages were not shown when attempted to assign a role to a non-existing or inactive user. See screenshots 'Before' and 'After'.

**Studio updates:** None

**LMS updates:** proper template message call in `lms/static/js/instructor_dashboard/membership.js`
A unit test has been added to check the fix (`lms/static/js/spec/instructor_dashboard/membership_auth_spec.js`).

**Test plan:**
_Before the fix:_
In lms, sign in as staff. Go to Instructor > Membership > Course Team Management.
Try to add a non-existing user as 'staff' member.
The user is not added, an error message is NOT shown. An error is thrown to the browser’s js console.
The same scenario occurs if you try to assign 'staff' role to an inactive user.
_After the fix:_
Try to add a non-existing user as 'staff' member.
An error message IS shown.
Try to add an inactive user as 'staff'.
An error message is shown as well.

![Before_NonexistingUser](https://user-images.githubusercontent.com/33125830/54290101-0a8d3680-45b3-11e9-9817-592b12519281.png)
![After_NonexistingUser](https://user-images.githubusercontent.com/33125830/54290124-137e0800-45b3-11e9-9fb3-b271ded060c2.png)
