### PR TITLE
EDUCATOR-4189 | Account for undefined values in commerce API Course objects

### DIFF
--- a/lms/djangoapps/commerce/api/v1/models.py
+++ b/lms/djangoapps/commerce/api/v1/models.py
@@ -12,6 +12,8 @@ from openedx.core.djangoapps.content.course_overviews.models import CourseOvervi
 
 log = logging.getLogger(__name__)
 
+UNDEFINED = object()
+
 
 class Course(object):
     """ Pseudo-course model used to group CourseMode objects. """
@@ -19,10 +21,12 @@ class Course(object):
     modes = None
     _deleted_modes = None
 
-    def __init__(self, id, modes, verification_deadline=None):  # pylint: disable=redefined-builtin
+    def __init__(self, id, modes, **kwargs):  # pylint: disable=redefined-builtin
         self.id = CourseKey.from_string(unicode(id))  # pylint: disable=invalid-name
         self.modes = list(modes)
-        self.verification_deadline = verification_deadline
+        self.verification_deadline = UNDEFINED
+        if 'verification_deadline' in kwargs:
+            self.verification_deadline = kwargs['verification_deadline']
         self._deleted_modes = []
 
     @property
@@ -59,8 +63,10 @@ class Course(object):
     def save(self, *args, **kwargs):  # pylint: disable=unused-argument
         """ Save the CourseMode objects to the database. """
 
-        # Override the verification deadline for the course (not the individual modes)
-        VerificationDeadline.set_deadline(self.id, self.verification_deadline, is_explicit=True)
+        if self.verification_deadline is not UNDEFINED:
+            # Override the verification deadline for the course (not the individual modes)
+            # This will delete verification deadlines for the course if self.verification_deadline is null
+            VerificationDeadline.set_deadline(self.id, self.verification_deadline, is_explicit=True)
 
         for mode in self.modes:
             mode.course_id = self.id
@@ -73,7 +79,10 @@ class Course(object):
 
     def update(self, attrs):
         """ Update the model with external data (usually passed via API call). """
-        self.verification_deadline = attrs.get('verification_deadline')
+        # There are possible downstream effects of settings self.verification_deadline to null,
+        # so don't assign it a value here unless it is specifically included in attrs.
+        if 'verification_deadline' in attrs:
+            self.verification_deadline = attrs.get('verification_deadline')
 
         existing_modes = {mode.mode_slug: mode for mode in self.modes}
         merged_modes = set()


### PR DESCRIPTION
https://openedx.atlassian.net/browse/EDUCATOR-4189

Manual Testing Steps:
1. Ensure that the DemoX course has a verification deadline in my local LMS.
2. Check that the "masters" course mode has not yet been added for DemoX.
3. In course-discovery, add DemoX to a Masters curriculum via a curriculum course membership (using Rick's branch to automagically create new "masters" course modes: https://github.com/edx/course-discovery/pull/1808)
4. See that the PUT request from discovery to LMS returns a 200.
5. In LMS database, ensure that the verification deadline has not been changed or deleted.
6. In LMS admin, see that a "masters" course mode has been added for DemoX, and all existing course modes for the course were not changed or removed.