### PR TITLE
fix bug: AttributeError: 'str' object has no attribute 'json_value'

### DIFF
--- a/lms/djangoapps/grades/models.py
+++ b/lms/djangoapps/grades/models.py
@@ -225,7 +225,7 @@ class VisibleBlocks(models.Model):
         only for those that aren't already created.
         """
         cached_records = cls.bulk_read(user_id, course_key)
-        non_existent_brls = {brl.hash_value for brl in block_record_lists if brl.hash_value not in cached_records}
+        non_existent_brls = {brl for brl in block_record_lists if brl.hash_value not in cached_records}
         cls.bulk_create(user_id, course_key, non_existent_brls)
 
     @classmethod


### PR DESCRIPTION
This error happens when we try to generate learner's grade after PersitGrade feature is enabled.
brl.hash_value is 'str' type. It is supposed to be BlockRecordList object. 