### PR TITLE
Skip named release help tests

### DIFF
--- a/common/test/acceptance/tests/lms/test_lms_help.py
+++ b/common/test/acceptance/tests/lms/test_lms_help.py
@@ -12,8 +12,17 @@ from common.test.acceptance.tests.helpers import (
     url_for_help,
     click_and_wait_for_window
 )
+from openedx.core.release import skip_unless_master
+
+# @skip_unless_master is used throughout this file because on named release
+# branches, most work happens leading up to the first release on the branch, and
+# that is before the docs have been published.  Tests that check readthedocs for
+# the right doc page will fail during this time, and it's just a big
+# distraction.  Also, if we bork the docs, it's not the end of the world, and we
+# can fix it easily, so this is a good tradeoff.
 
 
+@skip_unless_master         # See note at the top of the file.
 class TestCohortHelp(ContainerBase, CohortTestMixin):
     """
     Tests help links in Cohort page
@@ -80,6 +89,7 @@ class TestCohortHelp(ContainerBase, CohortTestMixin):
         self.verify_help_link(href)
 
 
+@skip_unless_master         # See note at the top of the file.
 class InstructorDashboardHelp(BaseInstructorDashboardTest):
     """
     Tests opening help from the general Help button in the instructor dashboard.

--- a/common/test/acceptance/tests/studio/test_studio_help.py
+++ b/common/test/acceptance/tests/studio/test_studio_help.py
@@ -35,6 +35,14 @@ from common.test.acceptance.tests.helpers import (
 )
 from common.test.acceptance.tests.studio.base_studio_test import ContainerBase, StudioCourseTest, StudioLibraryTest
 from openedx.core.lib.tests import attr
+from openedx.core.release import skip_unless_master
+
+# @skip_unless_master is used throughout this file because on named release
+# branches, most work happens leading up to the first release on the branch, and
+# that is before the docs have been published.  Tests that check readthedocs for
+# the right doc page will fail during this time, and it's just a big
+# distraction.  Also, if we bork the docs, it's not the end of the world, and we
+# can fix it easily, so this is a good tradeoff.
 
 
 def _get_expected_documentation_url(path):
@@ -45,6 +53,7 @@ def _get_expected_documentation_url(path):
 
 
 @attr(shard=20)
+@skip_unless_master         # See note at the top of the file.
 class StudioHelpTest(StudioCourseTest):
     """Tests for Studio help."""
 
@@ -85,6 +94,7 @@ class StudioHelpTest(StudioCourseTest):
 
 
 @attr(shard=20)
+@skip_unless_master
 class HomeHelpTest(StudioCourseTest):
     """
     Tests help links on 'Home'(Courses tab) page.
@@ -134,6 +144,7 @@ class HomeHelpTest(StudioCourseTest):
 
 
 @attr(shard=20)
+@skip_unless_master
 class NewCourseHelpTest(AcceptanceTest):
     """
     Test help links while creating a new course.
@@ -187,6 +198,7 @@ class NewCourseHelpTest(AcceptanceTest):
 
 
 @attr(shard=20)
+@skip_unless_master
 class NewLibraryHelpTest(AcceptanceTest):
     """
     Test help links while creating a new library
@@ -240,6 +252,7 @@ class NewLibraryHelpTest(AcceptanceTest):
 
 
 @attr(shard=20)
+@skip_unless_master
 class LibraryTabHelpTest(AcceptanceTest):
     """
     Test help links on the library tab present at dashboard.
@@ -273,6 +286,7 @@ class LibraryTabHelpTest(AcceptanceTest):
 
 
 @attr(shard=20)
+@skip_unless_master
 class LibraryHelpTest(StudioLibraryTest):
     """
     Test help links on a Library page.
@@ -306,6 +320,7 @@ class LibraryHelpTest(StudioLibraryTest):
 
 
 @attr(shard=20)
+@skip_unless_master
 class LibraryImportHelpTest(StudioLibraryTest):
     """
     Test help links on a Library import and export pages.
@@ -354,6 +369,7 @@ class LibraryImportHelpTest(StudioLibraryTest):
 
 
 @attr(shard=20)
+@skip_unless_master
 class LibraryExportHelpTest(StudioLibraryTest):
     """
     Test help links on a Library export pages.
@@ -402,6 +418,7 @@ class LibraryExportHelpTest(StudioLibraryTest):
 
 
 @attr(shard=20)
+@skip_unless_master
 class CourseOutlineHelpTest(StudioCourseTest):
     """
     Tests help links on course outline page.
@@ -457,6 +474,7 @@ class CourseOutlineHelpTest(StudioCourseTest):
 
 
 @attr(shard=20)
+@skip_unless_master
 class CourseUpdateHelpTest(StudioCourseTest):
     """
     Test help links on Course Update page
@@ -491,6 +509,7 @@ class CourseUpdateHelpTest(StudioCourseTest):
 
 
 @attr(shard=20)
+@skip_unless_master
 class AssetIndexHelpTest(StudioCourseTest):
     """
     Test help links on Course 'Files & Uploads' page
@@ -525,6 +544,7 @@ class AssetIndexHelpTest(StudioCourseTest):
 
 
 @attr(shard=20)
+@skip_unless_master
 class CoursePagesHelpTest(StudioCourseTest):
     """
     Test help links on Course 'Pages' page
@@ -559,6 +579,7 @@ class CoursePagesHelpTest(StudioCourseTest):
 
 
 @attr(shard=20)
+@skip_unless_master
 class UploadTextbookHelpTest(StudioCourseTest):
     """
     Test help links on Course 'Textbooks' page
@@ -612,6 +633,7 @@ class UploadTextbookHelpTest(StudioCourseTest):
 
 
 @attr(shard=20)
+@skip_unless_master
 class StudioUnitHelpTest(ContainerBase):
     """
     Tests help links on Unit page.
@@ -661,6 +683,7 @@ class StudioUnitHelpTest(ContainerBase):
 
 
 @attr(shard=20)
+@skip_unless_master
 class SettingsHelpTest(StudioCourseTest):
     """
     Tests help links on Schedule and Details Settings page
@@ -697,6 +720,7 @@ class SettingsHelpTest(StudioCourseTest):
 
 
 @attr(shard=20)
+@skip_unless_master
 class GradingPageHelpTest(StudioCourseTest):
     """
     Tests help links on Grading page
@@ -733,6 +757,7 @@ class GradingPageHelpTest(StudioCourseTest):
 
 
 @attr(shard=20)
+@skip_unless_master
 class CourseTeamSettingsHelpTest(StudioCourseTest):
     """
     Tests help links on Course Team settings page
@@ -769,6 +794,7 @@ class CourseTeamSettingsHelpTest(StudioCourseTest):
 
 
 @attr(shard=20)
+@skip_unless_master
 class CourseGroupConfigurationHelpTest(StudioCourseTest):
     """
     Tests help links on course Group Configurations settings page
@@ -826,6 +852,7 @@ class CourseGroupConfigurationHelpTest(StudioCourseTest):
 
 
 @attr(shard=20)
+@skip_unless_master
 class AdvancedSettingHelpTest(StudioCourseTest):
     """
     Tests help links on course Advanced Settings page.
@@ -862,6 +889,7 @@ class AdvancedSettingHelpTest(StudioCourseTest):
 
 
 @attr(shard=20)
+@skip_unless_master
 class CertificatePageHelpTest(StudioCourseTest):
     """
     Tests help links on course Certificate settings page.
@@ -917,6 +945,7 @@ class CertificatePageHelpTest(StudioCourseTest):
 
 
 @attr(shard=20)
+@skip_unless_master
 class GroupExperimentConfigurationHelpTest(ContainerBase):
     """
     Tests help links on course Group Configurations settings page
@@ -970,6 +999,7 @@ class GroupExperimentConfigurationHelpTest(ContainerBase):
 
 
 @attr(shard=20)
+@skip_unless_master
 class ToolsImportHelpTest(StudioCourseTest):
     """
     Tests help links on tools import pages.
@@ -1025,6 +1055,7 @@ class ToolsImportHelpTest(StudioCourseTest):
 
 
 @attr(shard=20)
+@skip_unless_master
 class ToolsExportHelpTest(StudioCourseTest):
     """
     Tests help links on tools export pages.
@@ -1080,6 +1111,7 @@ class ToolsExportHelpTest(StudioCourseTest):
 
 
 @attr(shard=20)
+@skip_unless_master         # See note at the top of the file.
 class StudioWelcomeHelpTest(AcceptanceTest):
     """
     Tests help link on 'Welcome' page ( User not logged in)

--- a/openedx/core/release.py
+++ b/openedx/core/release.py
@@ -2,6 +2,9 @@
 Information about the release line of this Open edX code.
 """
 
+import unittest
+
+
 # The release line: an Open edX release name ("ficus"), or "master".
 # This should always be "master" on the master branch, and will be changed
 # manually when we start release-line branches, like open-release/ficus.master.
@@ -17,3 +20,13 @@ def doc_version():
         return "latest"
     else:
         return "open-release-{}.master".format(RELEASE_LINE)
+
+
+def skip_unless_master(func_or_class):
+    """
+    Only run the decorated test for code on master or destined for master.
+
+    Use this to skip tests that we expect to fail on a named release branch.
+    Please use carefully!
+    """
+    return unittest.skipUnless(RELEASE_LINE == "master", "Test often fails on named releases")(func_or_class)


### PR DESCRIPTION
We have tests that check that the help URLs really serve pages from readthedocs.org.  On named release branches, these URLs change to the specific release.  But we don't publish the books while we are developing the branch, so the tests fail.  Best thing to do now is to skip those tests on the open-release branches.