### PR TITLE
WL-1899 | 500 error when SAML attribute is mapped + present, but has no value

### DIFF
--- a/common/djangoapps/third_party_auth/saml.py
+++ b/common/djangoapps/third_party_auth/saml.py
@@ -219,8 +219,12 @@ class EdXSAMLIdentityProvider(SAMLIdentityProvider):
         another attribute to use.
         """
         key = self.conf.get(conf_key, default_attribute)
-        default = self.conf['attr_defaults'].get(conf_key) or None
-        return attributes[key][0] if key in attributes else default
+        if key in attributes:
+            try:
+                return attributes[key][0]
+            except IndexError:
+                log.warning(u'SAML attribute "%s" value not found.', key)
+        return self.conf['attr_defaults'].get(conf_key) or None
 
     @property
     def saml_sp_configuration(self):

--- a/common/djangoapps/third_party_auth/tests/data/saml_identity_provider_mock_data.py
+++ b/common/djangoapps/third_party_auth/tests/data/saml_identity_provider_mock_data.py
@@ -1,0 +1,23 @@
+"""Mock data for SAMLIdentityProvider"""
+
+from social_core.backends.saml import OID_MAIL, OID_GIVEN_NAME, OID_SURNAME, OID_COMMON_NAME, OID_USERID
+
+expected_user_details = {
+    'username': 'myself',
+    'fullname': 'Me Myself And I',
+    'last_name': None,
+    'first_name': 'Me Myself',
+    'email': 'myself@testshib.org'
+}
+
+mock_attributes = {
+    OID_USERID: ['myself'],
+    OID_COMMON_NAME: ['Me Myself And I'],
+    OID_SURNAME: [],                        # Assume user has not provided Last Name
+    OID_GIVEN_NAME: ['Me Myself'],
+    OID_MAIL: ['myself@testshib.org']
+}
+
+mock_conf = {
+    'attr_defaults': {}
+}

--- a/common/djangoapps/third_party_auth/tests/testutil.py
+++ b/common/djangoapps/third_party_auth/tests/testutil.py
@@ -26,6 +26,8 @@ from third_party_auth.models import (
     SAMLProviderConfig
 )
 from third_party_auth.saml import EdXSAMLIdentityProvider, get_saml_idp_class
+from third_party_auth.tests.data.saml_identity_provider_mock_data import mock_conf, mock_attributes,\
+    expected_user_details
 
 AUTH_FEATURES_KEY = 'ENABLE_THIRD_PARTY_AUTH'
 AUTH_FEATURE_ENABLED = AUTH_FEATURES_KEY in settings.FEATURES
@@ -224,6 +226,11 @@ class SAMLTestCase(TestCase):
             'fake_idp_class_option'
         )
         self.assertIs(idp_class, EdXSAMLIdentityProvider)
+
+    def test_get_user_details(self):
+        """ test get_attr and get_user_details of EdXSAMLIdentityProvider"""
+        edx_smal_identity_provider = EdXSAMLIdentityProvider('demo', **mock_conf)
+        self.assertEqual(edx_smal_identity_provider.get_user_details(mock_attributes), expected_user_details)
 
 
 @contextmanager


### PR DESCRIPTION

Scenario that is Fixed in this PR: 
If a SAML attribute is mapped for a given provider, and the provider includes this attribute in the SAML AttributeStatement, but the attribute value is empty/missing, then the edX system will encounter an 500 error