### PR TITLE
REVEM-151 Updating text when asking for learner emails

### DIFF
--- a/lms/templates/dashboard/_entitlement_reason_survey.html
+++ b/lms/templates/dashboard/_entitlement_reason_survey.html
@@ -121,7 +121,7 @@ from django.utils.translation import ugettext as _
     </div>
     <br>
 
-    <h4>${_("Can we contact you for follow up? If so, enter your email address below:")}</h4>
+    <h4>${_("Can we contact you via email for follow up?")}</h4>
     <div>
       <input type="radio" name="emailEntitlementUnenrollment" id="unavailableEntitlementUnenrollment1" value="yes">
       <label for="emailEntitlementUnenrollment1">Yes</label>


### PR DESCRIPTION
Just noticed that the question text was asking them to enter their emails when it's just a yes/no question, so I'm fixing that. No review necessary, but adding reviewers for process's sake.