### PR TITLE
allow proctoring exams to be marked error after submission

### DIFF
--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -120,7 +120,7 @@ edx-oauth2-provider==1.2.2
 edx-opaque-keys[django]==0.4.4
 edx-organizations==1.0.1
 edx-proctoring-proctortrack==1.0.4
-edx-proctoring==1.5.20
+edx-proctoring==1.5.21
 edx-rbac==0.1.3           # via edx-enterprise
 edx-rest-api-client==1.9.2
 edx-search==1.2.1

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -143,7 +143,7 @@ edx-oauth2-provider==1.2.2
 edx-opaque-keys[django]==0.4.4
 edx-organizations==1.0.1
 edx-proctoring-proctortrack==1.0.4
-edx-proctoring==1.5.20
+edx-proctoring==1.5.21
 edx-rbac==0.1.3
 edx-rest-api-client==1.9.2
 edx-search==1.2.1

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -139,7 +139,7 @@ edx-oauth2-provider==1.2.2
 edx-opaque-keys[django]==0.4.4
 edx-organizations==1.0.1
 edx-proctoring-proctortrack==1.0.4
-edx-proctoring==1.5.20
+edx-proctoring==1.5.21
 edx-rbac==0.1.3
 edx-rest-api-client==1.9.2
 edx-search==1.2.1


### PR DESCRIPTION
This is necessary to allow new proctoring backends to mark proctored
attempts in error, often due to unuploaded files from the application
or issues with multiple sets of files attached to the same testing
session.