### PR TITLE
ENT-1500 Update third_party_auth pipeline to override get_username

### DIFF
--- a/common/djangoapps/third_party_auth/saml.py
+++ b/common/djangoapps/third_party_auth/saml.py
@@ -512,7 +512,14 @@ class SapSuccessFactorsIdentityProvider(EdXSAMLIdentityProvider):
             }
             self.log_bizx_api_exception(transaction_data, err)
             return basic_details
-        return self.get_registration_fields(response)
+        registration_fields = self.get_registration_fields(response)
+        # This statement is here for debugging purposes and should be removed when ENT-1500 is resolved.
+        if user_id != registration_fields.get('username'):
+            log.info(u'loggedinuser_id %s is different from BizX username %s',
+                     user_id,
+                     registration_fields.get('username'))
+
+        return registration_fields
 
 
 def get_saml_idp_choices():

--- a/common/djangoapps/third_party_auth/settings.py
+++ b/common/djangoapps/third_party_auth/settings.py
@@ -49,7 +49,7 @@ def apply_settings(django_settings):
         'social_core.pipeline.social_auth.auth_allowed',
         'social_core.pipeline.social_auth.social_user',
         'third_party_auth.pipeline.associate_by_email_if_login_api',
-        'social_core.pipeline.user.get_username',
+        'third_party_auth.pipeline.get_username',
         'third_party_auth.pipeline.set_pipeline_timeout',
         'third_party_auth.pipeline.ensure_user_information',
         'social_core.pipeline.user.create_user',

--- a/common/djangoapps/third_party_auth/tests/test_utils.py
+++ b/common/djangoapps/third_party_auth/tests/test_utils.py
@@ -32,3 +32,6 @@ class TestUtils(TestCase):
         self.assertFalse(
             user_exists({'username': 'invalid_user'}),
         )
+        self.assertTrue(
+            user_exists({'username': 'TesT_User'})
+        )

--- a/common/djangoapps/third_party_auth/utils.py
+++ b/common/djangoapps/third_party_auth/utils.py
@@ -21,7 +21,7 @@ def user_exists(details):
     if email:
         user_queryset_filter['email'] = email
     elif username:
-        user_queryset_filter['username'] = username
+        user_queryset_filter['username__iexact'] = username
 
     if user_queryset_filter:
         return User.objects.filter(**user_queryset_filter).exists()


### PR DESCRIPTION
We are doing this for two reasons:
1. We suspect that the get_username function in social_core is performing a case-sensitive
username check which is breaking when we try to create the user with a duplicate username.
This version ensures we perform a case insensitive check.

2. If it's not that, we want more logging information in order to debug the issue.