### PR TITLE
(BB-1051) Move field processing for student report to task.

### DIFF
--- a/lms/djangoapps/instructor/views/api.py
+++ b/lms/djangoapps/instructor/views/api.py
@@ -1253,57 +1253,6 @@ def get_students_features(request, course_id, csv=False):  # pylint: disable=red
     report_type = _('enrolled learner profile')
     available_features = instructor_analytics.basic.AVAILABLE_FEATURES
 
-    # Allow for sites to be able to define additional columns.
-    # Note that adding additional columns has the potential to break
-    # the student profile report due to a character limit on the
-    # asynchronous job input which in this case is a JSON string
-    # containing the list of columns to include in the report.
-    # TODO: Refactor the student profile report code to remove the list of columns
-    # that should be included in the report from the asynchronous job input.
-    # We need to clone the list because we modify it below
-    query_features = list(configuration_helpers.get_value('student_profile_download_fields', []))
-
-    if not query_features:
-        query_features = [
-            'id', 'username', 'name', 'email', 'language', 'location',
-            'year_of_birth', 'gender', 'level_of_education', 'mailing_address',
-            'goals', 'enrollment_mode', 'verification_status',
-        ]
-
-    # Provide human-friendly and translatable names for these features. These names
-    # will be displayed in the table generated in data_download.js. It is not (yet)
-    # used as the header row in the CSV, but could be in the future.
-    query_features_names = {
-        'id': _('User ID'),
-        'username': _('Username'),
-        'name': _('Name'),
-        'email': _('Email'),
-        'language': _('Language'),
-        'location': _('Location'),
-        'year_of_birth': _('Birth Year'),
-        'gender': _('Gender'),
-        'level_of_education': _('Level of Education'),
-        'mailing_address': _('Mailing Address'),
-        'goals': _('Goals'),
-        'enrollment_mode': _('Enrollment Mode'),
-        'verification_status': _('Verification Status'),
-    }
-
-    if is_course_cohorted(course.id):
-        # Translators: 'Cohort' refers to a group of students within a course.
-        query_features.append('cohort')
-        query_features_names['cohort'] = _('Cohort')
-
-    if course.teams_enabled:
-        query_features.append('team')
-        query_features_names['team'] = _('Team')
-
-    # For compatibility reasons, city and country should always appear last.
-    query_features.append('city')
-    query_features_names['city'] = _('City')
-    query_features.append('country')
-    query_features_names['country'] = _('Country')
-
     if not csv:
         student_data = instructor_analytics.basic.enrolled_students_features(course_key, query_features)
         response_payload = {

--- a/lms/djangoapps/instructor/views/api.py
+++ b/lms/djangoapps/instructor/views/api.py
@@ -1254,13 +1254,11 @@ def get_students_features(request, course_id, csv=False):  # pylint: disable=red
     available_features = instructor_analytics.basic.AVAILABLE_FEATURES
 
     if not csv:
-        student_data = instructor_analytics.basic.enrolled_students_features(course_key, query_features)
+        student_data = instructor_analytics.basic.enrolled_students_features(course_key)
         response_payload = {
             'course_id': unicode(course_key),
             'students': student_data,
             'students_count': len(student_data),
-            'queried_features': query_features,
-            'feature_names': query_features_names,
             'available_features': available_features,
         }
         return JsonResponse(response_payload)
@@ -1268,8 +1266,7 @@ def get_students_features(request, course_id, csv=False):  # pylint: disable=red
     else:
         lms.djangoapps.instructor_task.api.submit_calculate_students_features_csv(
             request,
-            course_key,
-            query_features
+            course_key
         )
         success_status = SUCCESS_MESSAGE_TEMPLATE.format(report_type=report_type)
 

--- a/lms/djangoapps/instructor_analytics/basic.py
+++ b/lms/djangoapps/instructor_analytics/basic.py
@@ -217,6 +217,53 @@ def enrolled_students_features(course_key, features):
         {'username': 'username3', 'first_name': 'firstname3'}
     ]
     """
+    default_query_features = [
+        'id', 'username', 'name', 'email', 'language', 'location',
+        'year_of_birth', 'gender', 'level_of_education', 'mailing_address',
+        'goals', 'enrollment_mode', 'verification_status',
+    ]
+    default_query_features_names = {
+        'id': _('User ID'),
+        'username': _('Username'),
+        'name': _('Name'),
+        'email': _('Email'),
+        'language': _('Language'),
+        'location': _('Location'),
+        'year_of_birth': _('Birth Year'),
+        'gender': _('Gender'),
+        'level_of_education': _('Level of Education'),
+        'mailing_address': _('Mailing Address'),
+        'goals': _('Goals'),
+        'enrollment_mode': _('Enrollment Mode'),
+        'verification_status': _('Verification Status'),
+    }
+    query_features = list(
+        configuration_helpers.get_value(
+            'student_profile_download_fields',
+            getattr(settings, 'STUDENT_PROFILE_DOWNLOAD_FIELDS', default_query_features)
+        )
+    )
+    query_features_names = list(
+        configuration_helpers.get_value(
+            'student_profile_download_field_names',
+            getattr(settings, 'STUDENT_PROFILE_DOWNLOAD_FIELD_NAMES', default_query_features_names)
+        )
+    )
+
+    if is_course_cohorted(course.id):
+        # Translators: 'Cohort' refers to a group of students within a course.
+        query_features.append('cohort')
+        query_features_names['cohort'] = _('Cohort')
+
+    if course.teams_enabled:
+        query_features.append('team')
+        query_features_names['team'] = _('Team')
+
+    # For compatibility reasons, city and country should always appear last.
+    query_features.append('city')
+    query_features_names['city'] = _('City')
+    query_features.append('country')
+    query_features_names['country'] = _('Country')
     include_cohort_column = 'cohort' in features
     include_team_column = 'team' in features
     include_enrollment_mode = 'enrollment_mode' in features

--- a/lms/djangoapps/instructor_analytics/basic.py
+++ b/lms/djangoapps/instructor_analytics/basic.py
@@ -206,7 +206,7 @@ def issued_certificates(course_key, features):
     return generated_certificates
 
 
-def enrolled_students_features(course_key, features):
+def enrolled_students_features(course_key):
     """
     Return list of student features as dictionaries.
 


### PR DESCRIPTION
When customizing the columns shown/used when creating a students features report there is a limit of 255 characters. This is because the `task_input` field on the [`IntructorTask` model](https://github.com/edx/edx-platform/blob/master/lms/djangoapps/instructor_task/models.py#L70) is only 255. This field limit means that we cannot use an array which serialized is bigger than 255 characters to specify which fields we want in the student report. We must note that the limit is only there when a [CSV report is created](https://github.com/edx/edx-platform/blob/master/lms/djangoapps/instructor/views/api.py#L1320) since the CSV reports are created using a Celery task. When showing the report in the Instructor's dashboard the previously mentioned limit is not taken into account. Another issue to raise here is that there is not way to specify the (human readable) string of any custom columns since [these are hard-coded](https://github.com/edx/edx-platform/blob/master/lms/djangoapps/instructor/views/api.py#L1276).

This PR suggests a refactoring of the [`get_students_feature` function](https://github.com/edx/edx-platform/blob/master/lms/djangoapps/instructor/views/api.py#L1242) and the [`enrolled_students_feature` function](https://github.com/edx/edx-platform/blob/master/lms/djangoapps/instructor_analytics/basic.py#L209) to:
1. Avoid the 255 char limit when it's called as a task (there is a [TODO](https://github.com/edx/edx-platform/blob/master/lms/djangoapps/instructor/views/api.py#L1261) in the code for this).
2. Add the ability to specify custom names for the report's columns.
3. Add the ability to specify the feature list and names either from a `SiteConfiguration` record or from s `settings` variable.

**JIRA tickets**: 

**Discussions**: 

**Dependencies**: 

**Screenshots**: 

**Sandbox URL**: TBD - sandbox is being provisioned.

**Merge deadline**: 

**Testing instructions**:
*The code is not yet ready for testing. This is just a proof of concept and is neither finished nor fully tested.*

**Author notes and concerns**:

1. The code is not yet ready for testing. This is just a proof of concept and is neither finished nor fully tested.

**Reviewers**
- [ ] @kaizoku 
- [ ] edX reviewer[s] TBD