### PR TITLE
TE-2886 Upgrade math/science packages in LMS and Studio

### DIFF
--- a/common/lib/calc/calc/tests/test_calc.py
+++ b/common/lib/calc/calc/tests/test_calc.py
@@ -190,12 +190,12 @@ class EvaluatorTest(unittest.TestCase):
 
         # Include those where the real part is between -pi/2 and pi/2
         arcsin_inputs = ['-0.707', '0', '0.5', '0.588', '1.298 + 0.635*j', '-1.1', '1.1']
-        arcsin_angles = [-0.785, 0, 0.524, 0.629, 1 + 1j, -1.570 + 0.443j, 1.570 - 0.443j]
+        arcsin_angles = [-0.785, 0, 0.524, 0.629, 1 + 1j, -1.570 + 0.443j, 1.570 + 0.443j]
         self.assert_function_values('arcsin', arcsin_inputs, arcsin_angles)
 
         # Include those where the real part is between 0 and pi
         arccos_inputs = ['1', '0.866', '0.809', '0.834-0.989*j', '-1.1', '1.1']
-        arccos_angles = [0, 0.524, 0.628, 1 + 1j, 3.141 - 0.443j, 0.443j]
+        arccos_angles = [0, 0.524, 0.628, 1 + 1j, 3.141 - 0.443j, -0.443j]
         self.assert_function_values('arccos', arccos_inputs, arccos_angles)
 
         # Has the same range as arcsin

--- a/common/lib/calc/setup.py
+++ b/common/lib/calc/setup.py
@@ -3,11 +3,11 @@ from setuptools import setup
 
 setup(
     name="calc",
-    version="0.2",
+    version="0.3",
     packages=["calc"],
     install_requires=[
         "pyparsing==2.2.0",
-        "numpy==1.6.2",
-        "scipy==0.14.0",
+        "numpy",
+        "scipy",
     ],
 )

--- a/common/lib/chem/setup.py
+++ b/common/lib/chem/setup.py
@@ -3,12 +3,12 @@ from setuptools import setup
 
 setup(
     name="chem",
-    version="0.2.0",
+    version="0.3.0",
     packages=["chem"],
     install_requires=[
         "pyparsing==2.2.0",
-        "numpy==1.6.2",
-        "scipy==0.14.0",
+        "numpy",
+        "scipy",
         "nltk",
         "markupsafe",  # Should be replaced by other utilities. See LEARNER-5853 for more details.
     ],

--- a/common/lib/symmath/setup.py
+++ b/common/lib/symmath/setup.py
@@ -2,9 +2,9 @@ from setuptools import setup
 
 setup(
     name="symmath",
-    version="0.2",
+    version="0.3",
     packages=["symmath"],
     install_requires=[
-        "sympy==0.7.1",
+        "sympy",
     ],
 )

--- a/requirements/edx-sandbox/base.in
+++ b/requirements/edx-sandbox/base.in
@@ -11,3 +11,15 @@
 
 -r shared.txt                       # Dependencies in common with LMS and Studio
 matplotlib==1.3.1                   # 2D plotting library
+numpy==1.6.2                        # Numeric array processing utilities; used by scipy
+pyparsing==2.2.0                    # Python Parsing module
+scipy==0.14.0                       # Math, science, and engineering library
+sympy==0.7.1                        # Symbolic math library
+
+# Install these packages from the edx-platform working tree
+# NOTE: if you change code in these packages, you MUST change the version
+# number in its setup.py or the code WILL NOT be installed during deploy.
+-e common/lib/calc
+-e common/lib/chem
+-e common/lib/sandbox-packages
+-e common/lib/symmath

--- a/requirements/edx-sandbox/shared.in
+++ b/requirements/edx-sandbox/shared.in
@@ -13,15 +13,3 @@ cryptography                        # Implementations of assorted cryptography a
 lxml==3.8.0                         # XML parser
 networkx==1.7                       # Utilities for creating, manipulating, and studying network graphs
 nltk                                # Natural language processing; used by the chem package
-numpy==1.6.2                        # Numeric array processing utilities; used by calc, chem, and scipy
-pyparsing                           # Python parsing library; used by the calc package
-sympy==0.7.1                        # Symbolic math library; used by the calc package
-scipy==0.14.0                       # Math, science, and engineering library; used by the calc package
-
-# Install these packages from the edx-platform working tree
-# NOTE: if you change code in these packages, you MUST change the version
-# number in its setup.py or the code WILL NOT be installed during deploy.
--e common/lib/calc
--e common/lib/chem
--e common/lib/sandbox-packages
--e common/lib/symmath

--- a/requirements/edx-sandbox/shared.txt
+++ b/requirements/edx-sandbox/shared.txt
@@ -4,23 +4,14 @@
 #
 #    make upgrade
 #
--e common/lib/calc
--e common/lib/chem
--e common/lib/sandbox-packages
--e common/lib/symmath
 asn1crypto==0.24.0        # via cryptography
 cffi==1.12.2              # via cryptography
 cryptography==2.6.1
 enum34==1.1.6             # via cryptography
 ipaddress==1.0.22         # via cryptography
 lxml==3.8.0
-markupsafe==1.1.1
 networkx==1.7
 nltk==3.4
-numpy==1.6.2
 pycparser==2.19           # via cffi
-pyparsing==2.2.0
-scipy==0.14.0
 singledispatch==3.4.0.3   # via nltk
 six==1.11.0               # via cryptography, nltk, singledispatch
-sympy==0.7.1

--- a/requirements/edx/base.in
+++ b/requirements/edx/base.in
@@ -106,12 +106,11 @@ mongoengine==0.10.0                 # Object-document mapper for MongoDB, used i
 mysqlclient                         # Driver for the default production relational database
 newrelic                            # New Relic agent for performance monitoring
 nodeenv==1.1.1                      # Utility for managing Node.js environments; we use this for deployments and testing
-numpy==1.6.2                        # Fast numeric array computation, used in some problem types
 oauthlib                            # OAuth specification support for authenticating via LTI or other Open edX services
 pdfminer                            # Used in shoppingcart for extracting/parsing pdf text
 piexif==1.0.2                       # Exif image metadata manipulation, used in the profile_images app
 Pillow                              # Image manipulation library; used for course assets, profile images, invoice PDFs, etc.
-py2neo<4.0.0                       # Used to communicate with Neo4j, which is used internally for modulestore inspection
+py2neo<4.0.0                        # Used to communicate with Neo4j, which is used internally for modulestore inspection
 PyContracts==1.7.1
 pycountry
 pycryptodomex==3.4.7

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -108,12 +108,12 @@ edx-ace==0.1.10
 edx-analytics-data-api-client==0.15.2
 edx-ccx-keys==0.2.1
 edx-celeryutils==0.2.7
-edx-completion==1.0.2
+edx-completion==1.0.3
 edx-django-oauth2-provider==1.3.5
 edx-django-release-util==0.3.1
 edx-django-sites-extensions==2.3.1
 edx-django-utils==1.0.3
-edx-drf-extensions==2.0.1
+edx-drf-extensions==2.1.0
 edx-enterprise==1.3.1
 edx-i18n-tools==0.4.8
 edx-milestones==0.1.13
@@ -166,12 +166,13 @@ markupsafe==1.1.1
 maxminddb==1.4.1          # via geoip2
 mock==1.0.1
 mongoengine==0.10.0
+mpmath==1.1.0             # via sympy
 mysqlclient==1.4.2.post1
 networkx==1.7
 newrelic==4.14.0.115
 nltk==3.4
 nodeenv==1.1.1
-numpy==1.6.2
+numpy==1.16.2             # via scipy
 oauth2==1.9.0.post1
 oauthlib==2.1.0
 openapi-codec==1.3.2      # via django-rest-swagger
@@ -196,7 +197,7 @@ pyjwkest==1.3.2
 pyjwt==1.5.2
 pymongo==2.9.1
 pynliner==0.8.0
-pyparsing==2.2.0
+pyparsing==2.2.0          # via pycontracts
 pysrt==1.1.1
 python-dateutil==2.4.0
 python-levenshtein==0.12.0
@@ -216,7 +217,7 @@ rfc6266-parser==0.0.5.post2
 rules==2.0.1
 s3transfer==0.1.13        # via boto3
 sailthru-client==2.2.3
-scipy==0.14.0
+scipy==1.2.1
 semantic-version==2.6.0   # via edx-drf-extensions
 shapely==1.6.4.post2
 shortuuid==0.5.0          # via edx-django-oauth2-provider
@@ -231,7 +232,7 @@ sortedcontainers==2.1.0
 soupsieve==1.8            # via beautifulsoup4
 sqlparse==0.3.0
 stevedore==1.30.1
-sympy==0.7.1
+sympy==1.3
 tincan==0.0.5             # via edx-enterprise
 unicodecsv==0.14.1
 uritemplate==3.0.0        # via coreapi

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -70,7 +70,7 @@ cffi==1.12.2
 chardet==3.0.4
 click-log==0.1.8
 click==7.0
-code-annotations==0.3
+code-annotations==0.3.1
 colorama==0.4.1
 configparser==3.7.3
 constantly==15.1.0
@@ -130,12 +130,12 @@ edx-ace==0.1.10
 edx-analytics-data-api-client==0.15.2
 edx-ccx-keys==0.2.1
 edx-celeryutils==0.2.7
-edx-completion==1.0.2
+edx-completion==1.0.3
 edx-django-oauth2-provider==1.3.5
 edx-django-release-util==0.3.1
 edx-django-sites-extensions==2.3.1
 edx-django-utils==1.0.3
-edx-drf-extensions==2.0.1
+edx-drf-extensions==2.1.0
 edx-enterprise==1.3.1
 edx-i18n-tools==0.4.8
 edx-lint==1.1.1
@@ -219,12 +219,13 @@ modernize==0.7
 mongoengine==0.10.0
 more-itertools==5.0.0
 moto==0.3.1
+mpmath==1.1.0
 mysqlclient==1.4.2.post1
 networkx==1.7
 newrelic==4.14.0.115
 nltk==3.4
 nodeenv==1.1.1
-numpy==1.6.2
+numpy==1.16.2
 oauth2==1.9.0.post1
 oauthlib==2.1.0
 openapi-codec==1.3.2
@@ -277,7 +278,7 @@ pytest-cov==2.6.1
 pytest-django==3.4.8
 pytest-forked==1.0.2
 pytest-randomly==1.2.3
-pytest-xdist==1.26.1
+pytest-xdist==1.27.0
 pytest==4.3.1
 python-dateutil==2.4.0
 python-levenshtein==0.12.0
@@ -303,7 +304,7 @@ rules==2.0.1
 s3transfer==0.1.13
 sailthru-client==2.2.3
 scandir==1.10.0
-scipy==0.14.0
+scipy==1.2.1
 scrapy==1.6.0
 selenium==3.141.0
 semantic-version==2.6.0
@@ -327,8 +328,8 @@ splinter==0.9.0
 sqlparse==0.3.0
 stevedore==1.30.1
 sure==1.4.11
-sympy==0.7.1
-testfixtures==6.6.1
+sympy==1.3
+testfixtures==6.6.2
 testtools==2.3.0
 text-unidecode==1.2
 tincan==0.0.5
@@ -354,7 +355,7 @@ watchdog==0.9.0
 web-fragments==0.3.0
 webencodings==0.5.1
 webob==1.8.5
-werkzeug==0.14.1
+werkzeug==0.15.1
 wrapt==1.10.5
 xblock-utils==1.2.0
 xblock==1.2.2

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -68,7 +68,7 @@ cffi==1.12.2
 chardet==3.0.4
 click-log==0.1.8          # via edx-lint
 click==7.0
-code-annotations==0.3
+code-annotations==0.3.1
 colorama==0.4.1           # via radon
 configparser==3.7.3       # via entrypoints, flake8, pylint
 constantly==15.1.0        # via twisted
@@ -126,12 +126,12 @@ edx-ace==0.1.10
 edx-analytics-data-api-client==0.15.2
 edx-ccx-keys==0.2.1
 edx-celeryutils==0.2.7
-edx-completion==1.0.2
+edx-completion==1.0.3
 edx-django-oauth2-provider==1.3.5
 edx-django-release-util==0.3.1
 edx-django-sites-extensions==2.3.1
 edx-django-utils==1.0.3
-edx-drf-extensions==2.0.1
+edx-drf-extensions==2.1.0
 edx-enterprise==1.3.1
 edx-i18n-tools==0.4.8
 edx-lint==1.1.1
@@ -212,12 +212,13 @@ mock==1.0.1
 mongoengine==0.10.0
 more-itertools==5.0.0     # via pytest
 moto==0.3.1
+mpmath==1.1.0
 mysqlclient==1.4.2.post1
 networkx==1.7
 newrelic==4.14.0.115
 nltk==3.4
 nodeenv==1.1.1
-numpy==1.6.2
+numpy==1.16.2
 oauth2==1.9.0.post1
 oauthlib==2.1.0
 openapi-codec==1.3.2
@@ -268,7 +269,7 @@ pytest-cov==2.6.1
 pytest-django==3.4.8
 pytest-forked==1.0.2      # via pytest-xdist
 pytest-randomly==1.2.3
-pytest-xdist==1.26.1
+pytest-xdist==1.27.0
 pytest==4.3.1
 python-dateutil==2.4.0
 python-levenshtein==0.12.0
@@ -294,7 +295,7 @@ rules==2.0.1
 s3transfer==0.1.13
 sailthru-client==2.2.3
 scandir==1.10.0           # via pathlib2
-scipy==0.14.0
+scipy==1.2.1
 scrapy==1.6.0             # via pa11ycrawler
 selenium==3.141.0
 semantic-version==2.6.0
@@ -314,8 +315,8 @@ splinter==0.9.0
 sqlparse==0.3.0
 stevedore==1.30.1
 sure==1.4.11
-sympy==0.7.1
-testfixtures==6.6.1
+sympy==1.3
+testfixtures==6.6.2
 testtools==2.3.0          # via fixtures, python-subunit
 text-unidecode==1.2       # via faker
 tincan==0.0.5
@@ -340,7 +341,7 @@ watchdog==0.9.0
 web-fragments==0.3.0
 webencodings==0.5.1
 webob==1.8.5
-werkzeug==0.14.1          # via flask
+werkzeug==0.15.1          # via flask
 wrapt==1.10.5
 xblock-utils==1.2.0
 xblock==1.2.2

--- a/tox.ini
+++ b/tox.ini
@@ -64,6 +64,6 @@ whitelist_externals =
     /bin/tar
 commands =
     # Upgrade sqlite to fix crashes during testing.
-    bash scripts/upgrade_pysqlite.sh
+    py27: bash scripts/upgrade_pysqlite.sh
     # Now perform testing.
     {posargs}


### PR DESCRIPTION
We've held off on upgrading NumPy, SciPy, and sympy because they're used in code sandboxes by instructor-contributed code, but these versions don't work with Python 3.6.  Upgrade them for LMS and Studio so we can upgrade Python in those, while keeping the versions in sandboxes the same to avoid breaking contributed code.  We plan to introduce a newer sandbox environment shortly with updated Python and package versions to run in parallel and facilitate code updates.