### PR TITLE
when masquerading as limited access content gates should not dissapear

### DIFF
--- a/openedx/features/content_type_gating/partitions.py
+++ b/openedx/features/content_type_gating/partitions.py
@@ -130,6 +130,9 @@ class ContentTypeGatingPartition(UserPartition):
         if course_masquerade.user_partition_id == ENROLLMENT_TRACK_PARTITION_ID:
             audit_mode_id = settings.COURSE_ENROLLMENT_MODES.get(CourseMode.AUDIT, {}).get('id')
             return course_masquerade.group_id == audit_mode_id
+        if course_masquerade.user_partition_id == CONTENT_GATING_PARTITION_ID:
+            limited_access_group_id = LIMITED_ACCESS.id
+            return course_masquerade.group_id == limited_access_group_id
         return False
 
     def _has_active_enrollment_in_audit_mode(self, user, course_key):


### PR DESCRIPTION
The content gate only shows up if the user has an audit enrollment.  
https://github.com/edx/edx-platform/pull/20041/files#diff-fde3ceaf99346131cca06f5231f8dd79R85
When determining if the user has an audit enrollment in masquerade, we should consider limited access as audit as well