### PR TITLE
edx-enterprise version bump to 1.3.5

### DIFF
--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -108,21 +108,21 @@ edx-ace==0.1.10
 edx-analytics-data-api-client==0.15.2
 edx-ccx-keys==0.2.1
 edx-celeryutils==0.2.7
-edx-completion==1.0.2
+edx-completion==1.0.3
 edx-django-oauth2-provider==1.3.5
 edx-django-release-util==0.3.1
 edx-django-sites-extensions==2.3.1
 edx-django-utils==1.0.3
-edx-drf-extensions==2.0.1
-edx-enterprise==1.3.1
+edx-drf-extensions==2.1.0
+edx-enterprise==1.3.5
 edx-i18n-tools==0.4.8
 edx-milestones==0.1.13
 edx-oauth2-provider==1.2.2
 edx-opaque-keys[django]==0.4.4
 edx-organizations==1.0.1
 edx-proctoring-proctortrack==1.0.4
-edx-proctoring==1.5.21
-edx-rbac==0.1.3           # via edx-enterprise
+edx-proctoring==1.6.0
+edx-rbac==0.1.5           # via edx-enterprise
 edx-rest-api-client==1.9.2
 edx-search==1.2.1
 edx-submissions==2.1.1

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -70,7 +70,7 @@ cffi==1.12.2
 chardet==3.0.4
 click-log==0.1.8
 click==7.0
-code-annotations==0.3
+code-annotations==0.3.1
 colorama==0.4.1
 configparser==3.7.3
 constantly==15.1.0
@@ -130,13 +130,13 @@ edx-ace==0.1.10
 edx-analytics-data-api-client==0.15.2
 edx-ccx-keys==0.2.1
 edx-celeryutils==0.2.7
-edx-completion==1.0.2
+edx-completion==1.0.3
 edx-django-oauth2-provider==1.3.5
 edx-django-release-util==0.3.1
 edx-django-sites-extensions==2.3.1
 edx-django-utils==1.0.3
-edx-drf-extensions==2.0.1
-edx-enterprise==1.3.1
+edx-drf-extensions==2.1.0
+edx-enterprise==1.3.5
 edx-i18n-tools==0.4.8
 edx-lint==1.1.1
 edx-milestones==0.1.13
@@ -144,8 +144,8 @@ edx-oauth2-provider==1.2.2
 edx-opaque-keys[django]==0.4.4
 edx-organizations==1.0.1
 edx-proctoring-proctortrack==1.0.4
-edx-proctoring==1.5.21
-edx-rbac==0.1.3
+edx-proctoring==1.6.0
+edx-rbac==0.1.5
 edx-rest-api-client==1.9.2
 edx-search==1.2.1
 edx-sphinx-theme==1.4.0
@@ -277,7 +277,7 @@ pytest-cov==2.6.1
 pytest-django==3.4.8
 pytest-forked==1.0.2
 pytest-randomly==1.2.3
-pytest-xdist==1.26.1
+pytest-xdist==1.27.0
 pytest==4.3.1
 python-dateutil==2.4.0
 python-levenshtein==0.12.0
@@ -328,7 +328,7 @@ sqlparse==0.3.0
 stevedore==1.30.1
 sure==1.4.11
 sympy==0.7.1
-testfixtures==6.6.1
+testfixtures==6.6.2
 testtools==2.3.0
 text-unidecode==1.2
 tincan==0.0.5
@@ -354,7 +354,7 @@ watchdog==0.9.0
 web-fragments==0.3.0
 webencodings==0.5.1
 webob==1.8.5
-werkzeug==0.14.1
+werkzeug==0.15.1
 wrapt==1.10.5
 xblock-utils==1.2.0
 xblock==1.2.2

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -68,7 +68,7 @@ cffi==1.12.2
 chardet==3.0.4
 click-log==0.1.8          # via edx-lint
 click==7.0
-code-annotations==0.3
+code-annotations==0.3.1
 colorama==0.4.1           # via radon
 configparser==3.7.3       # via entrypoints, flake8, pylint
 constantly==15.1.0        # via twisted
@@ -126,13 +126,13 @@ edx-ace==0.1.10
 edx-analytics-data-api-client==0.15.2
 edx-ccx-keys==0.2.1
 edx-celeryutils==0.2.7
-edx-completion==1.0.2
+edx-completion==1.0.3
 edx-django-oauth2-provider==1.3.5
 edx-django-release-util==0.3.1
 edx-django-sites-extensions==2.3.1
 edx-django-utils==1.0.3
-edx-drf-extensions==2.0.1
-edx-enterprise==1.3.1
+edx-drf-extensions==2.1.0
+edx-enterprise==1.3.5
 edx-i18n-tools==0.4.8
 edx-lint==1.1.1
 edx-milestones==0.1.13
@@ -140,8 +140,8 @@ edx-oauth2-provider==1.2.2
 edx-opaque-keys[django]==0.4.4
 edx-organizations==1.0.1
 edx-proctoring-proctortrack==1.0.4
-edx-proctoring==1.5.21
-edx-rbac==0.1.3
+edx-proctoring==1.6.0
+edx-rbac==0.1.5
 edx-rest-api-client==1.9.2
 edx-search==1.2.1
 edx-submissions==2.1.1
@@ -268,7 +268,7 @@ pytest-cov==2.6.1
 pytest-django==3.4.8
 pytest-forked==1.0.2      # via pytest-xdist
 pytest-randomly==1.2.3
-pytest-xdist==1.26.1
+pytest-xdist==1.27.0
 pytest==4.3.1
 python-dateutil==2.4.0
 python-levenshtein==0.12.0
@@ -315,7 +315,7 @@ sqlparse==0.3.0
 stevedore==1.30.1
 sure==1.4.11
 sympy==0.7.1
-testfixtures==6.6.1
+testfixtures==6.6.2
 testtools==2.3.0          # via fixtures, python-subunit
 text-unidecode==1.2       # via faker
 tincan==0.0.5
@@ -340,7 +340,7 @@ watchdog==0.9.0
 web-fragments==0.3.0
 webencodings==0.5.1
 webob==1.8.5
-werkzeug==0.14.1          # via flask
+werkzeug==0.15.1          # via flask
 wrapt==1.10.5
 xblock-utils==1.2.0
 xblock==1.2.2


### PR DESCRIPTION
This PR bumps version of edx-enterprise to `1.3.5`

JIRA ticket: https://openedx.atlassian.net/browse/ENT-1554