### PR TITLE
LEARNER-5532 Change css for edX edge about page

### DIFF
--- a/lms/static/sass/multicourse/_course_about.scss
+++ b/lms/static/sass/multicourse/_course_about.scss
@@ -19,8 +19,7 @@
     box-shadow: 0 1px 80px 0 rgba(0, 0, 0, 0.5);
     border-bottom: 1px solid $border-color-3;
     box-shadow: inset 0 1px 5px 0 $shadow-l1;
-    height: 280px;
-    padding-top: 150px;
+    height: 100%;
     overflow: hidden;
     position: relative;
     width: 100%;


### PR DESCRIPTION
#### Changes
* Removed padding and increased the height to 100% to make enroll button visible on mobile view for courses with long title
* This solved the other issue that was caused when a video was added to course about page and the enroll button disappeared for the web view

[LEARNER-5532](https://openedx.atlassian.net/browse/LEARNER-5532)