### PR TITLE
Proctoring exam always on top

### DIFF
--- a/lms/static/sass/course/layout/_courseware_preview.scss
+++ b/lms/static/sass/course/layout/_courseware_preview.scss
@@ -63,6 +63,7 @@ $proctoring-banner-text-size: 14px;
 
     box-shadow: 0 3px 3px $shadow-d1;
     position: fixed;
+    z-index: 100;
     top: 0;
     width: 100%;
   }


### PR DESCRIPTION
proctoring banner was interfering
with course goal banner. Z-index
added on proctoring banner to make
sure its always on top

learner-5581