### PR TITLE
[INCR-14] Bump python-memcached for Python 3 support

### DIFF
--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -168,7 +168,7 @@ mongoengine==0.10.0
 mpmath==1.1.0             # via sympy
 mysqlclient==1.4.2.post1
 networkx==1.7
-newrelic==4.14.0.115
+newrelic==4.16.0.116
 nltk==3.4
 nodeenv==1.1.1
 numpy==1.16.2             # via scipy
@@ -200,7 +200,7 @@ pyparsing==2.2.0          # via pycontracts
 pysrt==1.1.1
 python-dateutil==2.4.0
 python-levenshtein==0.12.0
-python-memcached==1.48
+python-memcached==1.59
 python-openid==2.2.5 ; python_version == "2.7"  # via social-auth-core
 python-swiftclient==3.7.0
 python3-saml==1.5.0
@@ -228,7 +228,7 @@ social-auth-app-django==2.1.0
 social-auth-core==1.7.0
 sorl-thumbnail==12.3
 sortedcontainers==2.1.0
-soupsieve==1.8            # via beautifulsoup4
+soupsieve==1.9            # via beautifulsoup4
 sqlparse==0.3.0
 stevedore==1.30.1
 sympy==1.3

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -72,7 +72,7 @@ click-log==0.1.8
 click==7.0
 code-annotations==0.3.1
 colorama==0.4.1
-configparser==3.7.3
+configparser==3.7.4
 constantly==15.1.0
 coreapi==2.3.3
 coreschema==0.0.4
@@ -189,7 +189,7 @@ incremental==17.5.0
 inflect==2.1.0
 ipaddress==1.0.22
 isodate==0.6.0
-isort==4.3.15
+isort==4.3.16
 itsdangerous==1.1.0
 itypes==1.1.0
 jinja2-pluralize==0.3.0
@@ -221,7 +221,7 @@ moto==0.3.1
 mpmath==1.1.0
 mysqlclient==1.4.2.post1
 networkx==1.7
-newrelic==4.14.0.115
+newrelic==4.16.0.116
 nltk==3.4
 nodeenv==1.1.1
 numpy==1.16.2
@@ -281,7 +281,7 @@ pytest-xdist==1.27.0
 pytest==4.3.1
 python-dateutil==2.4.0
 python-levenshtein==0.12.0
-python-memcached==1.48
+python-memcached==1.59
 python-mimeparse==1.6.0
 python-openid==2.2.5 ; python_version == "2.7"
 python-slugify==1.2.6
@@ -320,7 +320,7 @@ social-auth-app-django==2.1.0
 social-auth-core==1.7.0
 sorl-thumbnail==12.3
 sortedcontainers==2.1.0
-soupsieve==1.8
+soupsieve==1.9
 sphinx==1.8.5
 sphinxcontrib-websupport==1.1.0  # via sphinx
 splinter==0.9.0

--- a/requirements/edx/paver.in
+++ b/requirements/edx/paver.in
@@ -19,7 +19,7 @@ path.py==8.2.1                      # Easier manipulation of filesystem paths
 paver                               # Build, distribution and deployment scripting tool
 psutil==1.2.1                       # Library for retrieving information on running processes and system utilization
 pymongo==2.9.1                      # via edx-opaque-keys
-python-memcached==1.48              # Python interface to the memcached memory cache daemon
+python-memcached                    # Python interface to the memcached memory cache daemon
 requests                            # Simple interface for making HTTP requests
 stevedore                           # Support for runtime plugins, used for XBlocks and edx-platform Django app plugins
 watchdog                            # Used in paver watch_assets

--- a/requirements/edx/paver.txt
+++ b/requirements/edx/paver.txt
@@ -19,7 +19,7 @@ paver==1.3.4
 pbr==5.1.3                # via stevedore
 psutil==1.2.1
 pymongo==2.9.1
-python-memcached==1.48
+python-memcached==1.59
 pyyaml==5.1               # via watchdog
 requests==2.21.0
 six==1.11.0

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -70,7 +70,7 @@ click-log==0.1.8          # via edx-lint
 click==7.0
 code-annotations==0.3.1
 colorama==0.4.1           # via radon
-configparser==3.7.3       # via entrypoints, flake8, pylint
+configparser==3.7.4       # via entrypoints, flake8, pylint
 constantly==15.1.0        # via twisted
 coreapi==2.3.3
 coreschema==0.0.4
@@ -183,7 +183,7 @@ incremental==17.5.0       # via twisted
 inflect==2.1.0
 ipaddress==1.0.22
 isodate==0.6.0
-isort==4.3.15
+isort==4.3.16
 itsdangerous==1.1.0       # via flask
 itypes==1.1.0
 jinja2-pluralize==0.3.0
@@ -214,7 +214,7 @@ moto==0.3.1
 mpmath==1.1.0
 mysqlclient==1.4.2.post1
 networkx==1.7
-newrelic==4.14.0.115
+newrelic==4.16.0.116
 nltk==3.4
 nodeenv==1.1.1
 numpy==1.16.2
@@ -272,7 +272,7 @@ pytest-xdist==1.27.0
 pytest==4.3.1
 python-dateutil==2.4.0
 python-levenshtein==0.12.0
-python-memcached==1.48
+python-memcached==1.59
 python-mimeparse==1.6.0   # via testtools
 python-openid==2.2.5 ; python_version == "2.7"
 python-slugify==1.2.6     # via code-annotations, transifex-client
@@ -309,7 +309,7 @@ social-auth-app-django==2.1.0
 social-auth-core==1.7.0
 sorl-thumbnail==12.3
 sortedcontainers==2.1.0
-soupsieve==1.8
+soupsieve==1.9
 splinter==0.9.0
 sqlparse==0.3.0
 stevedore==1.30.1


### PR DESCRIPTION
Hello @jmbowman @edx/incr-reviewers 

This pull requests unpins the `python-memcached` dependecy. This is required to support Python 3.

_I had to leave the session early but here's my pull request. I'm still testing it but wanted to get an INCR PR out of the door. I'll will ping again when this is good for review. Any suggestions on testing this?_

**JIRA tickets**: [INCR-14](https://openedx.atlassian.net/browse/INCR-14)

**Sandbox URL**: TBD - sandbox is being provisioned.

**Merge deadline**: "None"

**Testing instructions**: TBD

**Author notes and concerns**: None so far

**Reviewers**
- [ ] (OpenCraft internal reviewer's GitHub username goes here)
- [ ] edX reviewer[s] TBD