### PR TITLE
pass grade feeze info to xblocks

### DIFF
--- a/lms/djangoapps/courseware/module_render.py
+++ b/lms/djangoapps/courseware/module_render.py
@@ -56,6 +56,7 @@ from lms.djangoapps.grades.signals.signals import SCORE_PUBLISHED
 from lms.djangoapps.lms_xblock.field_data import LmsFieldData
 from lms.djangoapps.lms_xblock.models import XBlockAsidesConfig
 from lms.djangoapps.lms_xblock.runtime import LmsModuleSystem
+from lms.djangoapps.grades.util_services import GradesUtilService
 from lms.djangoapps.verify_student.services import XBlockVerificationService
 from openedx.core.djangoapps.bookmarks.services import BookmarksService
 from openedx.core.djangoapps.crawlers.models import CrawlersConfig
@@ -821,6 +822,7 @@ def get_module_system_for_user(
             'credit': CreditService(),
             'bookmarks': BookmarksService(user=user),
             'gating': GatingService(),
+            'grade_utils': GradesUtilService(course_id=course_id),
         },
         get_user_role=lambda: get_user_role(user, course_id),
         descriptor_runtime=descriptor._runtime,  # pylint: disable=protected-access

--- a/lms/djangoapps/grades/api/v1/gradebook_views.py
+++ b/lms/djangoapps/grades/api/v1/gradebook_views.py
@@ -36,7 +36,8 @@ from lms.djangoapps.grades.models import (
     PersistentSubsectionGradeOverrideHistory,
 )
 from lms.djangoapps.grades.subsection_grade import CreateSubsectionGrade
-from lms.djangoapps.grades.tasks import are_grades_frozen, recalculate_subsection_grade_v3
+from lms.djangoapps.grades.tasks import recalculate_subsection_grade_v3
+from lms.djangoapps.grades.grade_utils import are_grades_frozen
 from opaque_keys import InvalidKeyError
 from opaque_keys.edx.keys import CourseKey, UsageKey
 from openedx.core.djangoapps.course_groups import cohorts

--- a/lms/djangoapps/grades/grade_utils.py
+++ b/lms/djangoapps/grades/grade_utils.py
@@ -1,0 +1,18 @@
+"""
+This module contains utility functions for grading.
+"""
+from datetime import timedelta
+from django.utils import timezone
+from openedx.core.djangoapps.content.course_overviews.models import CourseOverview
+from .config.waffle import ENFORCE_FREEZE_GRADE_AFTER_COURSE_END, waffle_flags
+
+
+def are_grades_frozen(course_key):
+    """ Returns whether grades are frozen for the given course. """
+    if waffle_flags()[ENFORCE_FREEZE_GRADE_AFTER_COURSE_END].is_enabled(course_key):
+        course = CourseOverview.get_from_id(course_key)
+        if course.end:
+            freeze_grade_date = course.end + timedelta(30)
+            now = timezone.now()
+            return now > freeze_grade_date
+    return False

--- a/lms/djangoapps/grades/util_services.py
+++ b/lms/djangoapps/grades/util_services.py
@@ -1,0 +1,17 @@
+"A light weight interface to grading helper functions"
+
+
+from .grade_utils import are_grades_frozen
+
+
+class GradesUtilService(object):
+    """
+    An interface to be used by xblocks.
+    """
+    def __init__(self, **kwargs):
+        super(GradesUtilService, self).__init__()
+        self.course_id = kwargs.get('course_id', None)
+
+    def are_grades_frozen(self):
+        "Check if grades are frozen for given course key"
+        return are_grades_frozen(self.course_id)

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -202,7 +202,7 @@ python-levenshtein==0.12.0
 python-memcached==1.59
 python-openid==2.2.5 ; python_version == "2.7"  # via social-auth-core
 python-swiftclient==3.7.0
-python3-saml==1.6.0
+python3-saml==1.5.0
 pytz==2019.1
 pyuca==1.1
 pyyaml==5.1

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -24,7 +24,7 @@ git+https://github.com/mitodl/edx-sga.git@3828ba9e413080a81b907a3381e5ffa05e063f
 git+https://github.com/edx/xblock-lti-consumer.git@v1.1.8#egg=lti_consumer-xblock==1.1.8
 git+https://github.com/edx/MongoDBProxy.git@25b99097615bda06bd7cdfe5669ed80dc2a7fed0#egg=MongoDBProxy==0.1.0
 -e .
-git+https://github.com/edx/edx-ora2.git@2.2.1#egg=ora2==2.2.1
+git+https://github.com/edx/edx-ora2.git@2.2.3#egg=ora2==2.2.3
 -e git+https://github.com/dgrtwo/ParsePy.git@7949b9f754d1445eff8e8f20d0e967b9a6420639#egg=parse_rest
 -e git+https://github.com/dementrock/pystache_custom.git@776973740bdaad83a3b029f96e415a7d1e8bec2f#egg=pystache_custom-dev
 -e git+https://github.com/edx/RateXBlock.git@367e19c0f6eac8a5f002fd0f1559555f8e74bfff#egg=rate-xblock
@@ -112,7 +112,7 @@ edx-django-release-util==0.3.1
 edx-django-sites-extensions==2.3.1
 edx-django-utils==1.0.3
 edx-drf-extensions==2.2.0
-edx-enterprise==1.4.0
+edx-enterprise==1.4.1
 edx-i18n-tools==0.4.8
 edx-milestones==0.1.13
 edx-oauth2-provider==1.2.2
@@ -120,7 +120,7 @@ edx-opaque-keys[django]==0.4.4
 edx-organizations==1.0.1
 edx-proctoring-proctortrack==1.0.4
 edx-proctoring==1.6.1
-edx-rbac==0.1.9           # via edx-enterprise
+edx-rbac==0.1.11          # via edx-enterprise
 edx-rest-api-client==1.9.2
 edx-search==1.2.2
 edx-submissions==2.1.1
@@ -202,8 +202,8 @@ python-levenshtein==0.12.0
 python-memcached==1.59
 python-openid==2.2.5 ; python_version == "2.7"  # via social-auth-core
 python-swiftclient==3.7.0
-python3-saml==1.5.0
-pytz==2018.9
+python3-saml==1.6.0
+pytz==2019.1
 pyuca==1.1
 pyyaml==5.1
 redis==2.10.6
@@ -230,7 +230,7 @@ sortedcontainers==2.1.0
 soupsieve==1.9            # via beautifulsoup4
 sqlparse==0.3.0
 stevedore==1.30.1
-sympy==1.3
+sympy==1.4
 tincan==0.0.5             # via edx-enterprise
 unicodecsv==0.14.1
 uritemplate==3.0.0        # via coreapi

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -26,7 +26,7 @@ git+https://github.com/edx/lettuce.git@7a04591c78ac56dac3eb3e91ca94b15cce844133#
 git+https://github.com/edx/xblock-lti-consumer.git@v1.1.8#egg=lti_consumer-xblock==1.1.8
 git+https://github.com/edx/MongoDBProxy.git@25b99097615bda06bd7cdfe5669ed80dc2a7fed0#egg=MongoDBProxy==0.1.0
 -e .
-git+https://github.com/edx/edx-ora2.git@2.2.1#egg=ora2==2.2.1
+git+https://github.com/edx/edx-ora2.git@2.2.3#egg=ora2==2.2.3
 -e git+https://github.com/dgrtwo/ParsePy.git@7949b9f754d1445eff8e8f20d0e967b9a6420639#egg=parse_rest
 -e git+https://github.com/dementrock/pystache_custom.git@776973740bdaad83a3b029f96e415a7d1e8bec2f#egg=pystache_custom-dev
 -e git+https://github.com/edx/RateXBlock.git@367e19c0f6eac8a5f002fd0f1559555f8e74bfff#egg=rate-xblock
@@ -134,7 +134,7 @@ edx-django-release-util==0.3.1
 edx-django-sites-extensions==2.3.1
 edx-django-utils==1.0.3
 edx-drf-extensions==2.2.0
-edx-enterprise==1.4.0
+edx-enterprise==1.4.1
 edx-i18n-tools==0.4.8
 edx-lint==1.1.1
 edx-milestones==0.1.13
@@ -143,7 +143,7 @@ edx-opaque-keys[django]==0.4.4
 edx-organizations==1.0.1
 edx-proctoring-proctortrack==1.0.4
 edx-proctoring==1.6.1
-edx-rbac==0.1.9
+edx-rbac==0.1.11
 edx-rest-api-client==1.9.2
 edx-search==1.2.2
 edx-sphinx-theme==1.4.0
@@ -286,8 +286,8 @@ python-openid==2.2.5 ; python_version == "2.7"
 python-slugify==1.2.6
 python-subunit==1.3.0
 python-swiftclient==3.7.0
-python3-saml==1.5.0
-pytz==2018.9
+python3-saml==1.6.0
+pytz==2019.1
 pyuca==1.1
 pyyaml==5.1
 queuelib==1.5.0
@@ -326,7 +326,7 @@ splinter==0.9.0
 sqlparse==0.3.0
 stevedore==1.30.1
 sure==1.4.11
-sympy==1.3
+sympy==1.4
 testfixtures==6.6.2
 testtools==2.3.0
 text-unidecode==1.2

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -286,7 +286,7 @@ python-openid==2.2.5 ; python_version == "2.7"
 python-slugify==1.2.6
 python-subunit==1.3.0
 python-swiftclient==3.7.0
-python3-saml==1.6.0
+python3-saml==1.5.0
 pytz==2019.1
 pyuca==1.1
 pyyaml==5.1

--- a/requirements/edx/github.in
+++ b/requirements/edx/github.in
@@ -88,7 +88,7 @@
 # Our libraries:
 -e git+https://github.com/edx/codejail.git@a320d43ce6b9c93b17636b2491f724d9e433be47#egg=codejail
 -e git+https://github.com/edx/acid-block.git@e46f9cda8a03e121a00c7e347084d142d22ebfb7#egg=acid-xblock
--e git+https://github.com/edx/edx-ora2.git@2.2.1#egg=ora2==2.2.1
+-e git+https://github.com/edx/edx-ora2.git@2.2.3#egg=ora2==2.2.3
 -e git+https://github.com/edx/RecommenderXBlock.git@1.4.0#egg=recommender-xblock==1.4.0
 -e git+https://github.com/edx/crowdsourcehinter.git@518605f0a95190949fe77bd39158450639e2e1dc#egg=crowdsourcehinter-xblock==0.1
 -e git+https://github.com/edx/RateXBlock.git@367e19c0f6eac8a5f002fd0f1559555f8e74bfff#egg=rate-xblock

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -25,7 +25,7 @@ git+https://github.com/edx/lettuce.git@7a04591c78ac56dac3eb3e91ca94b15cce844133#
 git+https://github.com/edx/xblock-lti-consumer.git@v1.1.8#egg=lti_consumer-xblock==1.1.8
 git+https://github.com/edx/MongoDBProxy.git@25b99097615bda06bd7cdfe5669ed80dc2a7fed0#egg=MongoDBProxy==0.1.0
 -e .
-git+https://github.com/edx/edx-ora2.git@2.2.1#egg=ora2==2.2.1
+git+https://github.com/edx/edx-ora2.git@2.2.3#egg=ora2==2.2.3
 -e git+https://github.com/dgrtwo/ParsePy.git@7949b9f754d1445eff8e8f20d0e967b9a6420639#egg=parse_rest
 -e git+https://github.com/dementrock/pystache_custom.git@776973740bdaad83a3b029f96e415a7d1e8bec2f#egg=pystache_custom-dev
 -e git+https://github.com/edx/RateXBlock.git@367e19c0f6eac8a5f002fd0f1559555f8e74bfff#egg=rate-xblock
@@ -130,7 +130,7 @@ edx-django-release-util==0.3.1
 edx-django-sites-extensions==2.3.1
 edx-django-utils==1.0.3
 edx-drf-extensions==2.2.0
-edx-enterprise==1.4.0
+edx-enterprise==1.4.1
 edx-i18n-tools==0.4.8
 edx-lint==1.1.1
 edx-milestones==0.1.13
@@ -139,7 +139,7 @@ edx-opaque-keys[django]==0.4.4
 edx-organizations==1.0.1
 edx-proctoring-proctortrack==1.0.4
 edx-proctoring==1.6.1
-edx-rbac==0.1.9
+edx-rbac==0.1.11
 edx-rest-api-client==1.9.2
 edx-search==1.2.2
 edx-submissions==2.1.1
@@ -277,8 +277,8 @@ python-openid==2.2.5 ; python_version == "2.7"
 python-slugify==1.2.6     # via code-annotations, transifex-client
 python-subunit==1.3.0
 python-swiftclient==3.7.0
-python3-saml==1.5.0
-pytz==2018.9
+python3-saml==1.6.0
+pytz==2019.1
 pyuca==1.1
 pyyaml==5.1
 queuelib==1.5.0           # via scrapy
@@ -313,7 +313,7 @@ splinter==0.9.0
 sqlparse==0.3.0
 stevedore==1.30.1
 sure==1.4.11
-sympy==1.3
+sympy==1.4
 testfixtures==6.6.2
 testtools==2.3.0          # via fixtures, python-subunit
 text-unidecode==1.2       # via faker

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -277,7 +277,7 @@ python-openid==2.2.5 ; python_version == "2.7"
 python-slugify==1.2.6     # via code-annotations, transifex-client
 python-subunit==1.3.0
 python-swiftclient==3.7.0
-python3-saml==1.6.0
+python3-saml==1.5.0
 pytz==2019.1
 pyuca==1.1
 pyyaml==5.1


### PR DESCRIPTION
## [PROD-104](https://openedx.atlassian.net/browse/PROD-104)

### Description

We freeze grades once the course end date has passed 30 days. This PR would make xblocks able to know that grades are frozen and let xblocks decide what they want to do in such situation.

### Sandbox
- [ ] https://accept.sandbox.edx.org

### Steps to verify the fix:
1.  Login as staff, and visit [an ORA problem created for testing purposes](https://accept.sandbox.edx.org/courses/course-v1:edx+ORA203+course/courseware/a4dfec19cf9b4a6fb5b18be6ccd9cecc/338a4affb58a45459629e0566291381e/1?activate_block_id=block-v1%3Aedx%2BORA203%2Bcourse%2Btype%40vertical%2Bblock%40e244a29a969b4987b63a90a7be6dddf5)
2. Go to 'Manage Individual Learner' of problem and give a username. (A submission on problem is needed, reviewer may do a test submission on given problem and can provide his own username).
3. See option 'Submit Assessment Grade Override'
4. Change course date to past (make sure end date has passed 30 days)
5. Repeat step 2 and verify 'Submit Assessment Grade Override' is NOT visible.


### Testing
- [ ] Acceptance

### Reviewers
- [ ] @awaisdar001 
- [ ] @asadazam93 

### PR in ORA:
https://github.com/edx/edx-ora2/pull/1231
 
### Post-review
- [ ] Rebase and squash commits