### PR TITLE
edx-enterprise version bump to 1.3.7 - ENT-1734

### DIFF
--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -113,7 +113,7 @@ edx-django-release-util==0.3.1
 edx-django-sites-extensions==2.3.1
 edx-django-utils==1.0.3
 edx-drf-extensions==2.1.0
-edx-enterprise==1.3.5
+edx-enterprise==1.3.7
 edx-i18n-tools==0.4.8
 edx-milestones==0.1.13
 edx-oauth2-provider==1.2.2
@@ -168,7 +168,7 @@ mongoengine==0.10.0
 mpmath==1.1.0             # via sympy
 mysqlclient==1.4.2.post1
 networkx==1.7
-newrelic==4.14.0.115
+newrelic==4.16.0.116
 nltk==3.4
 nodeenv==1.1.1
 numpy==1.16.2             # via scipy
@@ -208,7 +208,7 @@ pytz==2018.9
 pyuca==1.1
 pyyaml==5.1
 redis==2.10.6
-reportlab==3.5.13
+reportlab==3.5.16
 requests-oauthlib==1.1.0
 requests==2.21.0
 rest-condition==1.0.3
@@ -228,7 +228,7 @@ social-auth-app-django==2.1.0
 social-auth-core==1.7.0
 sorl-thumbnail==12.3
 sortedcontainers==2.1.0
-soupsieve==1.8            # via beautifulsoup4
+soupsieve==1.9            # via beautifulsoup4
 sqlparse==0.3.0
 stevedore==1.30.1
 sympy==1.3

--- a/requirements/edx/development.in
+++ b/requirements/edx/development.in
@@ -18,7 +18,7 @@ django-debug-toolbar==1.8           # A set of panels that display debug informa
 edx-sphinx-theme                    # Documentation theme
 pyinotify                           # More efficient checking for runserver reload trigger events
 snakefood                           # Lists dependencies between Python modules, used in scripts/dependencies/*
-sphinx                              # Developer documentation builder
+sphinx==1.8.5                       # Pinned because 2.0.0 release requires Python '>=3.5' but current Python is 2.7.12
 vulture                             # Detects possible dead/unused code, used in scripts/find-dead-code.sh
 modernize                           # Used to make Python 2 code more modern with the intention of eventually porting it over to Python 3.
 

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -72,7 +72,7 @@ click-log==0.1.8
 click==7.0
 code-annotations==0.3.1
 colorama==0.4.1
-configparser==3.7.3
+configparser==3.7.4
 constantly==15.1.0
 coreapi==2.3.3
 coreschema==0.0.4
@@ -135,7 +135,7 @@ edx-django-release-util==0.3.1
 edx-django-sites-extensions==2.3.1
 edx-django-utils==1.0.3
 edx-drf-extensions==2.1.0
-edx-enterprise==1.3.5
+edx-enterprise==1.3.7
 edx-i18n-tools==0.4.8
 edx-lint==1.1.1
 edx-milestones==0.1.13
@@ -189,7 +189,7 @@ incremental==17.5.0
 inflect==2.1.0
 ipaddress==1.0.22
 isodate==0.6.0
-isort==4.3.15
+isort==4.3.16
 itsdangerous==1.1.0
 itypes==1.1.0
 jinja2-pluralize==0.3.0
@@ -221,7 +221,7 @@ moto==0.3.1
 mpmath==1.1.0
 mysqlclient==1.4.2.post1
 networkx==1.7
-newrelic==4.14.0.115
+newrelic==4.16.0.116
 nltk==3.4
 nodeenv==1.1.1
 numpy==1.16.2
@@ -294,7 +294,7 @@ pyyaml==5.1
 queuelib==1.5.0
 radon==3.0.1
 redis==2.10.6
-reportlab==3.5.13
+reportlab==3.5.16
 requests-oauthlib==1.1.0
 requests==2.21.0
 rest-condition==1.0.3
@@ -320,7 +320,7 @@ social-auth-app-django==2.1.0
 social-auth-core==1.7.0
 sorl-thumbnail==12.3
 sortedcontainers==2.1.0
-soupsieve==1.8
+soupsieve==1.9
 sphinx==1.8.5
 sphinxcontrib-websupport==1.1.0  # via sphinx
 splinter==0.9.0
@@ -334,7 +334,7 @@ text-unidecode==1.2
 tincan==0.0.5
 toml==0.10.0
 tox-battery==0.5.1
-tox==3.7.0
+tox==3.8.1
 traceback2==1.4.0
 transifex-client==0.13.6
 twisted==18.9.0

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -70,7 +70,7 @@ click-log==0.1.8          # via edx-lint
 click==7.0
 code-annotations==0.3.1
 colorama==0.4.1           # via radon
-configparser==3.7.3       # via entrypoints, flake8, pylint
+configparser==3.7.4       # via entrypoints, flake8, pylint
 constantly==15.1.0        # via twisted
 coreapi==2.3.3
 coreschema==0.0.4
@@ -131,7 +131,7 @@ edx-django-release-util==0.3.1
 edx-django-sites-extensions==2.3.1
 edx-django-utils==1.0.3
 edx-drf-extensions==2.1.0
-edx-enterprise==1.3.5
+edx-enterprise==1.3.7
 edx-i18n-tools==0.4.8
 edx-lint==1.1.1
 edx-milestones==0.1.13
@@ -183,7 +183,7 @@ incremental==17.5.0       # via twisted
 inflect==2.1.0
 ipaddress==1.0.22
 isodate==0.6.0
-isort==4.3.15
+isort==4.3.16
 itsdangerous==1.1.0       # via flask
 itypes==1.1.0
 jinja2-pluralize==0.3.0
@@ -214,7 +214,7 @@ moto==0.3.1
 mpmath==1.1.0
 mysqlclient==1.4.2.post1
 networkx==1.7
-newrelic==4.14.0.115
+newrelic==4.16.0.116
 nltk==3.4
 nodeenv==1.1.1
 numpy==1.16.2
@@ -285,7 +285,7 @@ pyyaml==5.1
 queuelib==1.5.0           # via scrapy
 radon==3.0.1
 redis==2.10.6
-reportlab==3.5.13
+reportlab==3.5.16
 requests-oauthlib==1.1.0
 requests==2.21.0
 rest-condition==1.0.3
@@ -309,7 +309,7 @@ social-auth-app-django==2.1.0
 social-auth-core==1.7.0
 sorl-thumbnail==12.3
 sortedcontainers==2.1.0
-soupsieve==1.8
+soupsieve==1.9
 splinter==0.9.0
 sqlparse==0.3.0
 stevedore==1.30.1
@@ -321,7 +321,7 @@ text-unidecode==1.2       # via faker
 tincan==0.0.5
 toml==0.10.0              # via tox
 tox-battery==0.5.1
-tox==3.7.0
+tox==3.8.1
 traceback2==1.4.0         # via testtools, unittest2
 transifex-client==0.13.6
 twisted==18.9.0           # via scrapy


### PR DESCRIPTION
This PR bumps version of edx-enterprise to `1.3.7`

JIRA ticket: https://openedx.atlassian.net/browse/ENT-1734