### PR TITLE
Hiding overall grades in progress page for a sequential when problem scores are hidden

### DIFF
--- a/lms/djangoapps/courseware/tests/test_views.py
+++ b/lms/djangoapps/courseware/tests/test_views.py
@@ -1995,34 +1995,48 @@ class ProgressPageShowCorrectnessTests(ProgressPageBaseTests):
         Ensures that grades and scores are shown or not shown on the progress page as required.
         """
 
-        expected_score = "<dd>{score}/{max_score}</dd>".format(score=score, max_score=max_score)
+        expected_score = u"<dd>{score}/{max_score}</dd>".format(score=score, max_score=max_score)
         percent = score / float(max_score)
 
+        # Test individual problem scores
         if show_grades:
             # If grades are shown, we should be able to see the current problem scores.
-            self.assertIn(expected_score, response.content)
+            self.assertIn(expected_score, response.content.decode("utf-8"))
 
             if graded:
-                expected_summary_text = "Problem Scores:"
+                expected_summary_text = u"Problem Scores:"
             else:
-                expected_summary_text = "Practice Scores:"
+                expected_summary_text = u"Practice Scores:"
 
         else:
             # If grades are hidden, we should not be able to see the current problem scores.
-            self.assertNotIn(expected_score, response.content)
+            self.assertNotIn(expected_score, response.content.decode("utf-8"))
 
             if graded:
-                expected_summary_text = "Problem scores are hidden"
+                expected_summary_text = u"Problem scores are hidden"
             else:
-                expected_summary_text = "Practice scores are hidden"
+                expected_summary_text = u"Practice scores are hidden"
 
             if show_correctness == ShowCorrectness.PAST_DUE and due_date:
-                expected_summary_text += ' until the due date.'
+                expected_summary_text += u' until the due date.'
             else:
-                expected_summary_text += '.'
+                expected_summary_text += u'.'
 
         # Ensure that expected text is present
-        self.assertIn(expected_summary_text, response.content)
+        self.assertIn(expected_summary_text, response.content.decode("utf-8"))
+
+        # Test overall sequential score
+        if graded and max_score > 0:
+            percentageString = "{0:.0%}".format(percent) if max_score > 0 else ""
+            template = u'<span> ({0:.3n}/{1:.3n}) {2}</span>'
+            expected_grade_summary = template.format(float(score),
+                                                     float(max_score),
+                                                     percentageString)
+
+            if show_grades:
+                self.assertIn(expected_grade_summary, response.content.decode("utf-8"))
+            else:
+                self.assertNotIn(expected_grade_summary, response.content.decode("utf-8"))
 
     @ddt.data(
         ('', None, False),

--- a/lms/templates/courseware/progress.html
+++ b/lms/templates/courseware/progress.html
@@ -177,13 +177,13 @@ username = get_enterprise_learner_generic_name(request) or student.username
                                         <h4 class="hd hd-4">
                                             <a href="${reverse('courseware_section', kwargs=dict(course_id=text_type(course.id), chapter=chapter['url_name'], section=section.url_name))}">
                                                 ${ section.display_name}
-                                                %if total > 0 or earned > 0:
+                                                %if (total > 0 or earned > 0) and section.show_grades(staff_access):
                                                 <span class="sr">
                                                     ${_("{earned} of {total} possible points").format(earned='{:.3n}'.format(float(earned)), total='{:.3n}'.format(float(total)))}
                                                 </span>
                                                 %endif
                                             </a>
-                                            %if total > 0 or earned > 0:
+                                            %if (total > 0 or earned > 0) and section.show_grades(staff_access):
                                             <span> ${"({0:.3n}/{1:.3n}) {2}".format( float(earned), float(total), percentageString )}</span>
                                             %endif
                                         </h4>


### PR DESCRIPTION
This PR provides a small fix to the progress page. Presently, when problem scores are hidden in a sequential, the overall score for the sequential is displayed:

![Screen Shot 2019-03-28 at 11 09 38 PM](https://user-images.githubusercontent.com/6232546/55212862-a079b180-51ae-11e9-8cd0-171cac6f6083.png)

This PR detects if the individual problem scores are hidden, and likewise hides the overall score for the sequential. Tests are included.

@pdpinch @sstack22 
Note that unlike we discussed in conversations today, I was able to implement this by just changing the mako templates to behave correctly; no course settings required!