### PR TITLE
edx-enterprise version bump to 1.3.9

### DIFF
--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -112,7 +112,7 @@ edx-django-release-util==0.3.1
 edx-django-sites-extensions==2.3.1
 edx-django-utils==1.0.3
 edx-drf-extensions==2.1.0
-edx-enterprise==1.3.7
+edx-enterprise==1.3.9
 edx-i18n-tools==0.4.8
 edx-milestones==0.1.13
 edx-oauth2-provider==1.2.2

--- a/requirements/edx/development.in
+++ b/requirements/edx/development.in
@@ -18,7 +18,7 @@ django-debug-toolbar==1.8           # A set of panels that display debug informa
 edx-sphinx-theme                    # Documentation theme
 pyinotify                           # More efficient checking for runserver reload trigger events
 snakefood                           # Lists dependencies between Python modules, used in scripts/dependencies/*
-sphinx                              # Developer documentation builder
+sphinx==1.8.5                       # Pinned because 2.0.0 release requires Python '>=3.5' but current Python is 2.7.12
 vulture                             # Detects possible dead/unused code, used in scripts/find-dead-code.sh
 modernize                           # Used to make Python 2 code more modern with the intention of eventually porting it over to Python 3.
 

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -134,7 +134,7 @@ edx-django-release-util==0.3.1
 edx-django-sites-extensions==2.3.1
 edx-django-utils==1.0.3
 edx-drf-extensions==2.1.0
-edx-enterprise==1.3.7
+edx-enterprise==1.3.9
 edx-i18n-tools==0.4.8
 edx-lint==1.1.1
 edx-milestones==0.1.13
@@ -333,7 +333,7 @@ text-unidecode==1.2
 tincan==0.0.5
 toml==0.10.0
 tox-battery==0.5.1
-tox==3.8.1
+tox==3.8.2
 traceback2==1.4.0
 transifex-client==0.13.6
 twisted==18.9.0

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -130,7 +130,7 @@ edx-django-release-util==0.3.1
 edx-django-sites-extensions==2.3.1
 edx-django-utils==1.0.3
 edx-drf-extensions==2.1.0
-edx-enterprise==1.3.7
+edx-enterprise==1.3.9
 edx-i18n-tools==0.4.8
 edx-lint==1.1.1
 edx-milestones==0.1.13
@@ -320,7 +320,7 @@ text-unidecode==1.2       # via faker
 tincan==0.0.5
 toml==0.10.0              # via tox
 tox-battery==0.5.1
-tox==3.8.1
+tox==3.8.2
 traceback2==1.4.0         # via testtools, unittest2
 transifex-client==0.13.6
 twisted==18.9.0           # via scrapy


### PR DESCRIPTION
This PR bumps version of edx-enterprise to `1.3.9`

JIRA ticket: https://openedx.atlassian.net/browse/ENT-1736
