### PR TITLE
Remove unused 'plot' references in sysadmin

### DIFF
--- a/lms/templates/sysadmin_dashboard.html
+++ b/lms/templates/sysadmin_dashboard.html
@@ -7,8 +7,6 @@ from django.utils.translation import ugettext as _
 
 <%block name="headextra">
   <%static:css group='style-course'/>
-  <script type="text/javascript" src="${static.url('js/vendor/flot/jquery.flot.js')}"></script>
-  <script type="text/javascript" src="${static.url('js/vendor/flot/jquery.flot.axislabels.js')}"></script>
 </%block>
 
 <style type="text/css">
@@ -192,28 +190,6 @@ textarea {
       </table>
     </p>
 %endif
-
-%if plots:
-
-    %for plot in plots:
-      <br/>
-      <h3>${plot['title']}</h3>
-      <br/>
-      <p>${plot['info']}</p>
-      <br/>
-      <div id="plot_${plot['id']}" style="width:600px;height:300px;"></div>
-      <script type="text/javascript">
-          $(function () {
-              ${plot['data']}
-              $.plot($("#plot_${plot['id']}"), ${plot['cmd']}  );
-          });
-      </script>
-      <br/>
-      <br/>
-    %endfor
-
-%endif
-
   </section>
   <div style="text-align:right; float: right"><span id="djangopid">'Django PID': ${djangopid}</span>
   ## Translators: A version number appears after this string


### PR DESCRIPTION
This appears to have been included with the original commit that
introduced the sysadmin page [1].
It doesn't appear to have been ever used and, more importantly,
the view isn't passing it in the context to the template,
so it should be good to go.

- [1] ccc87337d63b593cad06cf4bc812c5bcf01b8be3