### PR TITLE
REVEM-262 Add more logging of ids

### DIFF
--- a/lms/djangoapps/experiments/utils.py
+++ b/lms/djangoapps/experiments/utils.py
@@ -95,15 +95,30 @@ def check_and_get_upgrade_link_and_date(user, enrollment=None, course=None):
         if course is None:
             course = enrollment.course
         elif enrollment.course_id != course.id:
-            logger.warn(u'{} refers to a different course than {} which was supplied'.format(
-                enrollment, course
-            ))
+            logger.warn(u'{} refers to a different course than {} which was supplied. Enrollment course id={}, '
+                        u'repr={!r}, deprecated={}. Course id={}, repr={!r}, deprecated={}.'
+                        .format(enrollment,
+                                course,
+                                enrollment.course_id,
+                                enrollment.course_id,
+                                enrollment.course_id.deprecated,
+                                course.id,
+                                course.id,
+                                course.id.deprecated
+                                )
+                        )
             return (None, None)
 
         if enrollment.user_id != user.id:
-            logger.warn(u'{} refers to a different user than {} which was supplied'.format(
-                enrollment, user
-            ))
+            logger.warn(u'{} refers to a different user than {} which was supplied. Enrollment user id={}, repr={!r}. '
+                        u'User id={}, repr={!r}.'.format(enrollment,
+                                                         user,
+                                                         enrollment.user_id,
+                                                         enrollment.user_id,
+                                                         user.id,
+                                                         user.id,
+                                                         )
+                        )
             return (None, None)
 
     if enrollment is None:


### PR DESCRIPTION
Sample logging:

```
edx.devstack.lms     | 2019-03-29 19:55:00,237 WARNING 6059 [lms.djangoapps.experiments.utils] [user 7] utils.py:86 - [CourseEnrollment] audit: course-v1:edX+DemoX+Demo_Course (2017-06-07 00:44:32.887985+00:00); active: (True) refers to a different course than CourseDescriptorWithMixins(CombinedSystem(None, <xmodule.modulestore.split_mongo.caching_descriptor_system.CachingDescriptorSystem object at 0x7fb889b40a90>), InheritingFieldData(<xmodule.modulestore.split_mongo.split_mongo_kvs.SplitMongoKVS object at 0x7fb89bb9bd90>), ScopeIds(user_id=None, block_type=u'course', def_id=BlockUsageLocator(CourseLocator(u'edX', u'DemoX', u'Demo_Course', None, None), u'course', u'course'), usage_id=BlockUsageLocator(CourseLocator(u'edX', u'DemoX', u'Demo_Course', None, None), u'course', u'course'))) which was supplied. Enrollment course id=course-v1:edX+DemoX+Demo_Course, repr=CourseLocator(u'edX', u'DemoX', u'Demo_Course', None, None), deprecated=False. Course id=course-v1:edX+DemoX+Demo_Course, repr=CourseLocator(u'edX', u'DemoX', u'Demo_Course', None, None), deprecated=False.


edx.devstack.lms     | 2019-03-29 19:55:00,238 WARNING 6059 [lms.djangoapps.experiments.utils] [user 7] utils.py:96 - [CourseEnrollment] audit: course-v1:edX+DemoX+Demo_Course (2017-06-07 00:44:32.887985+00:00); active: (True) refers to a different user than audit which was supplied. Enrollment user id=7, repr=7. User id=7, repr=7.
```