### PR TITLE
Fixed non accessible subsection in grade report

### DIFF
--- a/lms/djangoapps/grades/api/v1/gradebook_views.py
+++ b/lms/djangoapps/grades/api/v1/gradebook_views.py
@@ -26,6 +26,7 @@ from lms.djangoapps.grades.api.v1.utils import (
 )
 from lms.djangoapps.grades.config.waffle import WRITABLE_GRADEBOOK, waffle_flags
 from lms.djangoapps.grades.constants import ScoreDatabaseTableEnum
+from lms.djangoapps.grades.context import graded_subsections_for_course
 from lms.djangoapps.grades.course_data import CourseData
 from lms.djangoapps.grades.course_grade_factory import CourseGradeFactory
 from lms.djangoapps.grades.events import SUBSECTION_GRADE_CALCULATED, subsection_grade_calculated
@@ -534,19 +535,6 @@ class GradebookView(GradeViewMixin, PaginatedAPIView):
 
             serializer = StudentGradebookEntrySerializer(entries, many=True)
             return self.get_paginated_response(serializer.data)
-
-
-def graded_subsections_for_course(course_structure):
-    """
-    Given a course block structure, yields the subsections of the course that are graded.
-    Args:
-        course_structure: A course structure object.  Not user-specific.
-    """
-    for chapter_key in course_structure.get_children(course_structure.root_block_usage_key):
-        for subsection_key in course_structure.get_children(chapter_key):
-            subsection = course_structure[subsection_key]
-            if subsection.graded:
-                yield subsection
 
 
 GradebookUpdateResponseItem = namedtuple('GradebookUpdateResponseItem', ['user_id', 'usage_id', 'success', 'reason'])

--- a/lms/djangoapps/grades/context.py
+++ b/lms/djangoapps/grades/context.py
@@ -17,6 +17,30 @@ def grading_context_for_course(course):
     return grading_context(course, course_structure)
 
 
+def visible_to_staff_only(subsection):
+    """
+    Returns True if the given subsection is visible to staff only else False
+    """
+    try:
+        return subsection.transformer_data['visibility'].fields['merged_visible_to_staff_only']
+    except KeyError:
+        return False
+
+
+def graded_subsections_for_course(course_structure):
+    """
+    Given a course block structure, yields the subsections of the course that are graded
+    and visible to non-staff users.
+    Args:
+        course_structure: A course structure object.
+    """
+    for chapter_key in course_structure.get_children(course_structure.root_block_usage_key):
+        for subsection_key in course_structure.get_children(chapter_key):
+            subsection = course_structure[subsection_key]
+            if not visible_to_staff_only(subsection) and subsection.graded:
+                yield subsection
+
+
 def grading_context(course, course_structure):
     """
     This returns a dictionary with keys necessary for quickly grading
@@ -40,32 +64,29 @@ def grading_context(course, course_structure):
     count_all_graded_blocks = 0
     all_graded_subsections_by_type = OrderedDict()
 
-    for chapter_key in course_structure.get_children(course_structure.root_block_usage_key):
-        for subsection_key in course_structure.get_children(chapter_key):
-            subsection = course_structure[subsection_key]
-            scored_descendants_of_subsection = []
-            if subsection.graded:
-                for descendant_key in course_structure.post_order_traversal(
-                        filter_func=possibly_scored,
-                        start_node=subsection_key,
-                ):
-                    scored_descendants_of_subsection.append(
-                        course_structure[descendant_key],
-                    )
+    for subsection in graded_subsections_for_course(course_structure):
+        scored_descendants_of_subsection = []
+        for descendant_key in course_structure.post_order_traversal(
+                filter_func=possibly_scored,
+                start_node=subsection.location,
+        ):
+            scored_descendants_of_subsection.append(
+                course_structure[descendant_key],
+            )
 
-                # include only those blocks that have scores, not if they are just a parent
-                subsection_info = {
-                    'subsection_block': subsection,
-                    'scored_descendants': [
-                        child for child in scored_descendants_of_subsection
-                        if getattr(child, 'has_score', None)
-                    ]
-                }
-                subsection_format = getattr(subsection, 'format', '')
-                if subsection_format not in all_graded_subsections_by_type:
-                    all_graded_subsections_by_type[subsection_format] = []
-                all_graded_subsections_by_type[subsection_format].append(subsection_info)
-                count_all_graded_blocks += len(scored_descendants_of_subsection)
+        # include only those blocks that have scores, not if they are just a parent
+        subsection_info = {
+            'subsection_block': subsection,
+            'scored_descendants': [
+                child for child in scored_descendants_of_subsection
+                if getattr(child, 'has_score', None)
+            ]
+        }
+        subsection_format = getattr(subsection, 'format', '')
+        if subsection_format not in all_graded_subsections_by_type:
+            all_graded_subsections_by_type[subsection_format] = []
+        all_graded_subsections_by_type[subsection_format].append(subsection_info)
+        count_all_graded_blocks += len(scored_descendants_of_subsection)
 
     return {
         'all_graded_subsections_by_type': all_graded_subsections_by_type,

--- a/lms/djangoapps/instructor_task/tests/test_base.py
+++ b/lms/djangoapps/instructor_task/tests/test_base.py
@@ -360,10 +360,33 @@ class TestReportMixin(object):
                     {key: row.get(key) for key in expected_rows[index].keys()} for index, row in enumerate(csv_rows)
                 ]
 
+            numeric_csv_rows = [self._extract_and_round_numeric_items(row) for row in csv_rows]
+            numeric_expected_rows = [self._extract_and_round_numeric_items(row) for row in expected_rows]
+
             if verify_order:
                 self.assertEqual(csv_rows, expected_rows)
+                self.assertEqual(numeric_csv_rows, numeric_expected_rows)
             else:
                 self.assertItemsEqual(csv_rows, expected_rows)
+                self.assertItemsEqual(numeric_csv_rows, numeric_expected_rows)
+
+    @staticmethod
+    def _extract_and_round_numeric_items(dictionary):
+        """
+        csv data may contain numeric values that are converted to strings, and fractional
+        numbers can be imprecise (e.g. 1 / 6 is sometimes '0.16666666666666666' and other times
+        '0.166666666667').  This function mutates the provided input (sorry) and returns
+        a new dictionary that contains only the numerically-valued items from it, rounded
+        to four decimal places.
+        """
+        extracted = {}
+        for key, value in dictionary.items():
+            try:
+                float(value)
+                extracted[key] = round(float(dictionary.pop(key)), 4)
+            except ValueError:
+                pass
+        return extracted
 
     def get_csv_row_with_headers(self):
         """

--- a/lms/djangoapps/instructor_task/tests/test_tasks_helper.py
+++ b/lms/djangoapps/instructor_task/tests/test_tasks_helper.py
@@ -7,6 +7,7 @@ Unit tests for LMS instructor-initiated background tasks helper functions.
 - Tests all of the existing reports.
 
 """
+from __future__ import unicode_literals
 
 import os
 import shutil
@@ -763,7 +764,7 @@ class TestInstructorDetailedEnrollmentReport(TestReportMixin, InstructorTaskCour
         response = self.client.get(redeem_url)
         self.assertEquals(response.status_code, 200)
         # check button text
-        self.assertIn('Activate Course Enrollment', response.content)
+        self.assertIn('Activate Course Enrollment', response.content.decode('utf-8'))
 
         response = self.client.post(redeem_url)
         self.assertEquals(response.status_code, 200)
@@ -797,7 +798,7 @@ class TestInstructorDetailedEnrollmentReport(TestReportMixin, InstructorTaskCour
         response = self.client.get(redeem_url)
         self.assertEquals(response.status_code, 200)
         # check button text
-        self.assertIn('Activate Course Enrollment', response.content)
+        self.assertIn('Activate Course Enrollment', response.content.decode('utf-8'))
 
         response = self.client.post(redeem_url)
         self.assertEquals(response.status_code, 200)
@@ -838,7 +839,7 @@ class TestInstructorDetailedEnrollmentReport(TestReportMixin, InstructorTaskCour
         response = self.client.get(redeem_url)
         self.assertEquals(response.status_code, 200)
         # check button text
-        self.assertIn('Activate Course Enrollment', response.content)
+        self.assertIn('Activate Course Enrollment', response.content.decode('utf-8'))
 
         response = self.client.post(redeem_url)
         self.assertEquals(response.status_code, 200)
@@ -1323,7 +1324,7 @@ class TestExecutiveSummaryReport(TestReportMixin, InstructorTaskCourseTestCase):
         response = self.client.get(redeem_url)
         self.assertEquals(response.status_code, 200)
         # check button text
-        self.assertIn('Activate Course Enrollment', response.content)
+        self.assertIn('Activate Course Enrollment', response.content.decode('utf-8'))
 
         response = self.client.post(redeem_url)
         self.assertEquals(response.status_code, 200)
@@ -1952,7 +1953,6 @@ class TestGradeReport(TestReportMixin, InstructorTaskModuleTestCase):
 
         with patch('lms.djangoapps.instructor_task.tasks_helper.runner._get_current_task'):
             result = CourseGradeReport.generate(None, None, self.course.id, None, 'graded')
-
             self.assertDictContainsSubset(
                 {'action_name': 'graded', 'attempted': 1, 'succeeded': 1, 'failed': 0},
                 result,
@@ -1965,10 +1965,9 @@ class TestGradeReport(TestReportMixin, InstructorTaskModuleTestCase):
                         u'Username': self.student.username,
                         u'Grade': '0.13',
                         u'Homework 1: Subsection': '0.5',
-                        u'Homework 2: Hidden': u'Not Attempted',
-                        u'Homework 3: Unattempted': u'Not Attempted',
-                        u'Homework 4: Empty': u'Not Attempted',
-                        u'Homework (Avg)': '0.125',
+                        u'Homework 2: Unattempted': 'Not Attempted',
+                        u'Homework 3: Empty': 'Not Attempted',
+                        u'Homework (Avg)': text_type(1.0 / 6.0),
                     },
                 ],
                 ignore_other_columns=True,


### PR DESCRIPTION
## [PROD-53](https://openedx.atlassian.net/browse/PROD-53)

### Description
When creating a grade report if a subsection is not visible to learners it should not be included in the grade report.

**Sandbox**
https://grade-report.sandbox.edx.org/

### Reviewers
If you've been tagged for review, please check your corresponding box once you've given the :+1:.
- [ ] @awaisdar001 
- [ ] @noraiz-anwar 

### Post-review
- [ ] Rebase and squash commits
