### PR TITLE
ENT-1334: Fix: SSO users last_login set to NULL

### DIFF
--- a/common/djangoapps/student/models.py
+++ b/common/djangoapps/student/models.py
@@ -765,7 +765,7 @@ class Registration(models.Model):
     def activate(self):
         self.user.is_active = True
         self._track_activation()
-        self.user.save()
+        self.user.save(update_fields=['is_active'])
         log.info(u'User %s (%s) account is successfully activated.', self.user.username, self.user.email)
 
     def _track_activation(self):


### PR DESCRIPTION
- The very first time a user signed in through SSO their ```last_login```
  field on the ```auth_user``` table was set to NULL instead of the
  appropriate time stamp.  This fixes that issue.