### PR TITLE
Change enabled_for_enrollment to return false if a course has no verified mode or a user is not enrolled in the audit mode

### DIFF
--- a/common/djangoapps/student/tests/test_views.py
+++ b/common/djangoapps/student/tests/test_views.py
@@ -19,6 +19,7 @@ from opaque_keys import InvalidKeyError
 
 from bulk_email.models import BulkEmailFlag
 from course_modes.models import CourseMode
+from course_modes.tests.factories import CourseModeFactory
 from entitlements.tests.factories import CourseEntitlementFactory
 from milestones.tests.utils import MilestonesTestCaseMixin
 from opaque_keys.edx.keys import CourseKey
@@ -736,6 +737,7 @@ class StudentDashboardTests(SharedModuleStoreTestCase, MilestonesTestCaseMixin, 
         self.override_waffle_switch(True)
 
         course = CourseFactory.create(start=self.THREE_YEARS_AGO)
+        CourseModeFactory.create(course_id=course.id, mode_slug='audit')
         add_course_mode(course, upgrade_deadline_expired=False)
         enrollment = CourseEnrollmentFactory.create(
             user=self.user,

--- a/lms/djangoapps/ccx/tests/test_field_override_performance.py
+++ b/lms/djangoapps/ccx/tests/test_field_override_performance.py
@@ -239,7 +239,7 @@ class TestFieldOverrideMongoPerformance(FieldOverridePerformanceTestCase):
     __test__ = True
 
     # TODO: decrease query count as part of REVO-28
-    QUERY_COUNT = 36
+    QUERY_COUNT = 27
     TEST_DATA = {
         # (providers, course_width, enable_ccx, view_as_ccx): (
         #     # of sql queries to default,
@@ -268,7 +268,7 @@ class TestFieldOverrideSplitPerformance(FieldOverridePerformanceTestCase):
     __test__ = True
 
     # TODO: decrease query count as part of REVO-28
-    QUERY_COUNT = 36
+    QUERY_COUNT = 27
     TEST_DATA = {
         ('no_overrides', 1, True, False): (QUERY_COUNT, 3),
         ('no_overrides', 2, True, False): (QUERY_COUNT, 3),

--- a/lms/djangoapps/courseware/tests/test_access.py
+++ b/lms/djangoapps/courseware/tests/test_access.py
@@ -843,13 +843,13 @@ class CourseOverviewAccessTestCase(ModuleStoreTestCase):
                 num_queries = 1
         elif user_attr_name == 'user_normal' and action == 'see_exists':
             if course_attr_name == 'course_started':
-                num_queries = 7
+                num_queries = 5
             else:
                 # checks staff role and enrollment data
                 num_queries = 2
         elif user_attr_name == 'user_anonymous' and action == 'see_exists':
             if course_attr_name == 'course_started':
-                num_queries = 3
+                num_queries = 1
             else:
                 num_queries = 0
         else:

--- a/lms/djangoapps/courseware/tests/test_course_info.py
+++ b/lms/djangoapps/courseware/tests/test_course_info.py
@@ -430,8 +430,8 @@ class SelfPacedCourseInfoTestCase(LoginEnrollmentTestCase, SharedModuleStoreTest
 
     def test_num_queries_instructor_paced(self):
         # TODO: decrease query count as part of REVO-28
-        self.fetch_course_info_with_queries(self.instructor_paced_course, 44, 3)
+        self.fetch_course_info_with_queries(self.instructor_paced_course, 38, 3)
 
     def test_num_queries_self_paced(self):
         # TODO: decrease query count as part of REVO-28
-        self.fetch_course_info_with_queries(self.self_paced_course, 44, 3)
+        self.fetch_course_info_with_queries(self.self_paced_course, 38, 3)

--- a/lms/djangoapps/courseware/tests/test_views.py
+++ b/lms/djangoapps/courseware/tests/test_views.py
@@ -213,8 +213,8 @@ class IndexQueryTestCase(ModuleStoreTestCase):
     NUM_PROBLEMS = 20
 
     @ddt.data(
-        (ModuleStoreEnum.Type.mongo, 10, 179),
-        (ModuleStoreEnum.Type.split, 4, 173),
+        (ModuleStoreEnum.Type.mongo, 10, 173),
+        (ModuleStoreEnum.Type.split, 4, 167),
     )
     @ddt.unpack
     def test_index_query_counts(self, store_type, expected_mongo_query_count, expected_mysql_query_count):
@@ -1465,8 +1465,8 @@ class ProgressPageTests(ProgressPageBaseTests):
                 self.assertContains(resp, u"Download Your Certificate")
 
     @ddt.data(
-        (True, 56),
-        (False, 55)
+        (True, 47),
+        (False, 46)
     )
     @ddt.unpack
     def test_progress_queries_paced_courses(self, self_paced, query_count):
@@ -1479,8 +1479,8 @@ class ProgressPageTests(ProgressPageBaseTests):
 
     @patch.dict(settings.FEATURES, {'ASSUME_ZERO_GRADE_IF_ABSENT_FOR_ALL_TESTS': False})
     @ddt.data(
-        (False, 64, 44),
-        (True, 55, 39)
+        (False, 55, 38),
+        (True, 46, 33)
     )
     @ddt.unpack
     def test_progress_queries(self, enable_waffle, initial, subsequent):
@@ -1698,6 +1698,7 @@ class ProgressPageTests(ProgressPageBaseTests):
         CourseDurationLimitConfig.objects.create(enabled=True, enabled_as_of=datetime(2018, 1, 1))
         user = UserFactory.create()
         self.assertTrue(self.client.login(username=user.username, password='test'))
+        CourseModeFactory.create(mode_slug=CourseMode.AUDIT, course_id=self.course.id)
         add_course_mode(self.course, upgrade_deadline_expired=False)
         CourseEnrollmentFactory(user=user, course_id=self.course.id, mode=course_mode)
 
@@ -2784,7 +2785,8 @@ class TestIndexViewWithCourseDurationLimits(ModuleStoreTestCase):
         """
         CourseDurationLimitConfig.objects.create(enabled=True, enabled_as_of=datetime(2018, 1, 1))
         self.assertTrue(self.client.login(username=self.user.username, password='test'))
-        add_course_mode(self.course, upgrade_deadline_expired=False)
+        CourseModeFactory.create(mode_slug=CourseMode.AUDIT, course_id=self.course.id)
+        CourseModeFactory.create(mode_slug=CourseMode.VERIFIED, course_id=self.course.id)
         response = self.client.get(
             reverse(
                 'courseware_section',

--- a/lms/djangoapps/discussion/tests/test_views.py
+++ b/lms/djangoapps/discussion/tests/test_views.py
@@ -428,18 +428,18 @@ class SingleThreadQueryCountTestCase(ForumsEnableMixin, ModuleStoreTestCase):
         # course is outside the context manager that is verifying the number of queries,
         # and with split mongo, that method ends up querying disabled_xblocks (which is then
         # cached and hence not queried as part of call_single_thread).
-        (ModuleStoreEnum.Type.mongo, False, 1, 5, 2, 23, 8),
-        (ModuleStoreEnum.Type.mongo, False, 50, 5, 2, 23, 8),
+        (ModuleStoreEnum.Type.mongo, False, 1, 5, 2, 21, 8),
+        (ModuleStoreEnum.Type.mongo, False, 50, 5, 2, 21, 8),
         # split mongo: 3 queries, regardless of thread response size.
-        (ModuleStoreEnum.Type.split, False, 1, 3, 3, 23, 8),
-        (ModuleStoreEnum.Type.split, False, 50, 3, 3, 23, 8),
+        (ModuleStoreEnum.Type.split, False, 1, 3, 3, 21, 8),
+        (ModuleStoreEnum.Type.split, False, 50, 3, 3, 21, 8),
 
         # Enabling Enterprise integration should have no effect on the number of mongo queries made.
-        (ModuleStoreEnum.Type.mongo, True, 1, 5, 2, 23, 8),
-        (ModuleStoreEnum.Type.mongo, True, 50, 5, 2, 23, 8),
+        (ModuleStoreEnum.Type.mongo, True, 1, 5, 2, 21, 8),
+        (ModuleStoreEnum.Type.mongo, True, 50, 5, 2, 21, 8),
         # split mongo: 3 queries, regardless of thread response size.
-        (ModuleStoreEnum.Type.split, True, 1, 3, 3, 23, 8),
-        (ModuleStoreEnum.Type.split, True, 50, 3, 3, 23, 8),
+        (ModuleStoreEnum.Type.split, True, 1, 3, 3, 21, 8),
+        (ModuleStoreEnum.Type.split, True, 50, 3, 3, 21, 8),
     )
     @ddt.unpack
     def test_number_of_mongo_queries(

--- a/lms/djangoapps/django_comment_client/base/tests.py
+++ b/lms/djangoapps/django_comment_client/base/tests.py
@@ -399,8 +399,8 @@ class ViewsQueryCountTestCase(
         return inner
 
     @ddt.data(
-        (ModuleStoreEnum.Type.mongo, 3, 4, 41),
-        (ModuleStoreEnum.Type.split, 3, 13, 41),
+        (ModuleStoreEnum.Type.mongo, 3, 4, 39),
+        (ModuleStoreEnum.Type.split, 3, 13, 39),
     )
     @ddt.unpack
     @count_queries
@@ -408,8 +408,8 @@ class ViewsQueryCountTestCase(
         self.create_thread_helper(mock_request)
 
     @ddt.data(
-        (ModuleStoreEnum.Type.mongo, 3, 3, 37),
-        (ModuleStoreEnum.Type.split, 3, 10, 37),
+        (ModuleStoreEnum.Type.mongo, 3, 3, 35),
+        (ModuleStoreEnum.Type.split, 3, 10, 35),
     )
     @ddt.unpack
     @count_queries

--- a/lms/djangoapps/grades/tests/test_course_grade_factory.py
+++ b/lms/djangoapps/grades/tests/test_course_grade_factory.py
@@ -95,7 +95,7 @@ class TestCourseGradeFactory(GradeTestBase):
                 [self.sequence.display_name, self.sequence2.display_name]
             )
 
-        with self.assertNumQueries(5), mock_get_score(1, 2):
+        with self.assertNumQueries(4), mock_get_score(1, 2):
             _assert_read(expected_pass=False, expected_percent=0)  # start off with grade of 0
 
         num_queries = 47
@@ -313,7 +313,7 @@ class TestGradeIteration(SharedModuleStoreTestCase):
             else mock_course_grade.return_value
             for student in self.students
         ]
-        with self.assertNumQueries(7):
+        with self.assertNumQueries(8):
             all_course_grades, all_errors = self._course_grades_and_errors_for(self.course, self.students)
         self.assertEqual(
             {student: text_type(all_errors[student]) for student in all_errors},

--- a/lms/djangoapps/instructor_task/tests/test_tasks_helper.py
+++ b/lms/djangoapps/instructor_task/tests/test_tasks_helper.py
@@ -413,7 +413,7 @@ class TestInstructorGradeReport(InstructorGradeReportTestCase):
 
         RequestCache.clear_all_namespaces()
 
-        expected_query_count = 48
+        expected_query_count = 49
         with patch('lms.djangoapps.instructor_task.tasks_helper.runner._get_current_task'):
             with check_mongo_calls(mongo_count):
                 with self.assertNumQueries(expected_query_count):

--- a/lms/djangoapps/mobile_api/users/tests.py
+++ b/lms/djangoapps/mobile_api/users/tests.py
@@ -13,6 +13,7 @@ from django.utils.timezone import now
 from milestones.tests.utils import MilestonesTestCaseMixin
 from mock import patch
 
+from course_modes.tests.factories import CourseModeFactory
 from lms.djangoapps.certificates.api import generate_user_certificates
 from lms.djangoapps.certificates.models import CertificateStatuses
 from lms.djangoapps.certificates.tests.factories import GeneratedCertificateFactory
@@ -266,6 +267,7 @@ class TestUserEnrollmentApi(UrlResetMixin, MobileAPITestCase, MobileAuthUserTest
             course = CourseFactory.create(start=self.LAST_WEEK, mobile_available=True)
             self.enroll(course.id)
 
+        CourseModeFactory.create(course_id=course.id, mode_slug='audit')
         add_course_mode(course, upgrade_deadline_expired=False)
 
     def _get_enrollment_data(self, api_version, expired):

--- a/openedx/features/content_type_gating/helpers.py
+++ b/openedx/features/content_type_gating/helpers.py
@@ -1,8 +1,12 @@
 """
 Helper functions used by both content_type_gating and course_duration_limits.
 """
+import logging
+
+from django.apps import apps
 
 from xmodule.partitions.partitions import Group
+from course_modes.models import CourseMode
 
 # Studio generates partition IDs starting at 100. There is already a manually generated
 # partition for Enrollment Track that uses ID 50, so we'll use 51.
@@ -14,3 +18,41 @@ CONTENT_TYPE_GATE_GROUP_IDS = {
 }
 LIMITED_ACCESS = Group(CONTENT_TYPE_GATE_GROUP_IDS['limited_access'], 'Limited-access Users')
 FULL_ACCESS = Group(CONTENT_TYPE_GATE_GROUP_IDS['full_access'], 'Full-access Users')
+LOG = logging.getLogger(__name__)
+
+
+def correct_modes_for_fbe(course_key, enrollment=None, user=None):
+    # If CONTENT_TYPE_GATING is enabled use the following logic to determine whether
+    # enabled_for_enrollment should be false
+    if course_key is None:
+        return True
+
+    course_mode = apps.get_model('course_modes.CourseMode')
+    modes = course_mode.modes_for_course(course_key, include_expired=True, only_selectable=False)
+    modes_dict = {mode.slug: mode for mode in modes}
+
+    # If there is no verified mode, FBE will not be enabled
+    if not course_mode.has_verified_mode(modes_dict):
+        return False
+
+    if enrollment and user:
+        mode_slug = enrollment.mode
+        if enrollment.is_active:
+            course_mode = course_mode.mode_for_course(
+                course_key,
+                mode_slug,
+                modes=modes,
+            )
+            if course_mode is None:
+                LOG.error(
+                    u"User %s is in an unknown CourseMode '%s'"
+                    u" for course %s. Granting full access to content for this user",
+                    user.username,
+                    mode_slug,
+                    course_key,
+                )
+                return False
+
+            if mode_slug != CourseMode.AUDIT:
+                return False
+    return True

--- a/openedx/features/content_type_gating/helpers.py
+++ b/openedx/features/content_type_gating/helpers.py
@@ -22,8 +22,10 @@ LOG = logging.getLogger(__name__)
 
 
 def correct_modes_for_fbe(course_key, enrollment=None, user=None):
-    # If CONTENT_TYPE_GATING is enabled use the following logic to determine whether
-    # enabled_for_enrollment should be false
+    """
+    If CONTENT_TYPE_GATING is enabled use the following logic to determine whether
+    enabled_for_enrollment should be false
+    """
     if course_key is None:
         return True
 

--- a/openedx/features/content_type_gating/models.py
+++ b/openedx/features/content_type_gating/models.py
@@ -137,16 +137,18 @@ class ContentTypeGatingConfig(StackedConfigurationModel):
         if user_variable_represents_correct_user and is_in_holdback(user):
             return False
 
+        if not correct_modes_for_fbe(course_key, enrollment, user):
+            return False
+
         # enrollment might be None if the user isn't enrolled. In that case,
         # return enablement as if the user enrolled today
         # Also, ignore enrollment creation date if the user is masquerading.
         if enrollment is None or course_masquerade:
-            return cls.enabled_for_course(course_key=course_key, target_datetime=timezone.now())
+            target_datetime = timezone.now()
         else:
-            if not correct_modes_for_fbe(course_key, enrollment, user):
-                return False
-            current_config = cls.current(course_key=enrollment.course_id)
-            return current_config.enabled_as_of_datetime(target_datetime=enrollment.created)
+            target_datetime = enrollment.created
+        current_config = cls.current(course_key=course_key)
+        return current_config.enabled_as_of_datetime(target_datetime=target_datetime)
 
     @classmethod
     def enabled_for_course(cls, course_key, target_datetime=None):

--- a/openedx/features/content_type_gating/partitions.py
+++ b/openedx/features/content_type_gating/partitions.py
@@ -184,42 +184,6 @@ class ContentTypeGatingPartitionScheme(object):
         if not ContentTypeGatingConfig.enabled_for_enrollment(user=user, course_key=course_key,
                                                               user_partition=user_partition):
             return FULL_ACCESS
-
-        # If CONTENT_TYPE_GATING is enabled use the following logic to determine whether a user should have FULL_ACCESS
-        # or LIMITED_ACCESS
-
-        course_mode = apps.get_model('course_modes.CourseMode')
-        modes = course_mode.modes_for_course(course_key, include_expired=True, only_selectable=False)
-        modes_dict = {mode.slug: mode for mode in modes}
-
-        # If there is no verified mode, all users are granted FULL_ACCESS
-        if not course_mode.has_verified_mode(modes_dict):
-            return FULL_ACCESS
-
-        course_enrollment = apps.get_model('student.CourseEnrollment')
-
-        mode_slug, is_active = course_enrollment.enrollment_mode_for_user(user, course_key)
-
-        if mode_slug and is_active:
-            course_mode = course_mode.mode_for_course(
-                course_key,
-                mode_slug,
-                modes=modes,
-            )
-            if course_mode is None:
-                LOG.error(
-                    u"User %s is in an unknown CourseMode '%s'"
-                    u" for course %s. Granting full access to content for this user",
-                    user.username,
-                    mode_slug,
-                    course_key,
-                )
-                return FULL_ACCESS
-
-            if mode_slug == CourseMode.AUDIT:
-                return LIMITED_ACCESS
-            else:
-                return FULL_ACCESS
         else:
             # Unenrolled users don't get gated content
             return LIMITED_ACCESS

--- a/openedx/features/content_type_gating/partitions.py
+++ b/openedx/features/content_type_gating/partitions.py
@@ -177,15 +177,10 @@ class ContentTypeGatingPartitionScheme(object):
         """
         Returns the Group for the specified user.
         """
-
-        # For now, treat everyone as a Full-access user, until we have the rest of the
-        # feature gating logic in place.
-
         if not ContentTypeGatingConfig.enabled_for_enrollment(user=user, course_key=course_key,
                                                               user_partition=user_partition):
             return FULL_ACCESS
         else:
-            # Unenrolled users don't get gated content
             return LIMITED_ACCESS
 
     @classmethod

--- a/openedx/features/content_type_gating/tests/test_models.py
+++ b/openedx/features/content_type_gating/tests/test_models.py
@@ -8,6 +8,8 @@ import pytz
 
 from edx_django_utils.cache import RequestCache
 from opaque_keys.edx.locator import CourseLocator
+
+from course_modes.tests.factories import CourseModeFactory
 from openedx.core.djangoapps.config_model_utils.models import Provenance
 from openedx.core.djangoapps.content.course_overviews.tests.factories import CourseOverviewFactory
 from openedx.core.djangoapps.site_configuration.tests.factories import SiteConfigurationFactory
@@ -24,6 +26,8 @@ class TestContentTypeGatingConfig(CacheIsolationTestCase):
 
     def setUp(self):
         self.course_overview = CourseOverviewFactory.create()
+        CourseModeFactory.create(course_id=self.course_overview.id, mode_slug='audit')
+        CourseModeFactory.create(course_id=self.course_overview.id, mode_slug='verified')
         self.user = UserFactory.create()
         super(TestContentTypeGatingConfig, self).setUp()
 
@@ -73,9 +77,9 @@ class TestContentTypeGatingConfig(CacheIsolationTestCase):
             user = self.user
             course_key = self.course_overview.id
 
-        query_count = 6
+        query_count = 7
         if not already_enrolled or not pass_enrollment and already_enrolled:
-            query_count = 7
+            query_count = 8
 
         with self.assertNumQueries(query_count):
             enabled = ContentTypeGatingConfig.enabled_for_enrollment(

--- a/openedx/features/course_duration_limits/access.py
+++ b/openedx/features/course_duration_limits/access.py
@@ -101,6 +101,10 @@ def check_course_expired(user, course):
     """
     Check if the course expired for the user.
     """
+    # masquerading course staff should always have access
+    if get_course_masquerade(user, course.id):
+        return ACCESS_GRANTED
+
     expiration_date = get_user_course_expiration_date(user, course)
     if expiration_date and timezone.now() > expiration_date:
         return AuditExpiredError(user, course, expiration_date)

--- a/openedx/features/course_duration_limits/models.py
+++ b/openedx/features/course_duration_limits/models.py
@@ -139,13 +139,16 @@ class CourseDurationLimitConfig(StackedConfigurationModel):
         # course duration limits will be on if they are on for the course.
         # When masquerading as a specific learner, course duration limits
         # will be on if they are currently on for the learner.
+
+        if not correct_modes_for_fbe(course_key, enrollment, user):
+            return False
+
         if enrollment is None or not_student_masquerade:
-            return cls.enabled_for_course(course_key=course_key, target_datetime=timezone.now())
+            target_datetime = timezone.now()
         else:
-            if not correct_modes_for_fbe(course_key, enrollment, user):
-                return False
-            current_config = cls.current(course_key=enrollment.course_id)
-            return current_config.enabled_as_of_datetime(target_datetime=enrollment.created)
+            target_datetime = enrollment.created
+        current_config = cls.current(course_key=course_key)
+        return current_config.enabled_as_of_datetime(target_datetime=target_datetime)
 
     @classmethod
     def enabled_for_course(cls, course_key, target_datetime=None):

--- a/openedx/features/course_duration_limits/tests/test_models.py
+++ b/openedx/features/course_duration_limits/tests/test_models.py
@@ -12,6 +12,8 @@ import pytz
 
 from edx_django_utils.cache import RequestCache
 from opaque_keys.edx.locator import CourseLocator
+
+from course_modes.tests.factories import CourseModeFactory
 from openedx.core.djangoapps.config_model_utils.models import Provenance
 from openedx.core.djangoapps.site_configuration.tests.factories import SiteConfigurationFactory
 from openedx.core.djangoapps.content.course_overviews.tests.factories import CourseOverviewFactory
@@ -31,6 +33,8 @@ class TestCourseDurationLimitConfig(CacheIsolationTestCase):
 
     def setUp(self):
         self.course_overview = CourseOverviewFactory.create()
+        CourseModeFactory.create(course_id=self.course_overview.id, mode_slug='audit')
+        CourseModeFactory.create(course_id=self.course_overview.id, mode_slug='verified')
         self.user = UserFactory.create()
         super(TestCourseDurationLimitConfig, self).setUp()
 
@@ -81,8 +85,8 @@ class TestCourseDurationLimitConfig(CacheIsolationTestCase):
             course_key = self.course_overview.id
 
         query_count = 7
-        if pass_enrollment and already_enrolled:
-            query_count = 6
+        if not pass_enrollment:
+            query_count = 8
 
         with self.assertNumQueries(query_count):
             enabled = CourseDurationLimitConfig.enabled_for_enrollment(

--- a/openedx/features/course_experience/tests/views/test_course_home.py
+++ b/openedx/features/course_experience/tests/views/test_course_home.py
@@ -213,7 +213,7 @@ class TestCourseHomePage(CourseHomePageTestCase):
 
         # Fetch the view and verify the query counts
         # TODO: decrease query count as part of REVO-28
-        with self.assertNumQueries(89, table_blacklist=QUERY_COUNT_TABLE_BLACKLIST):
+        with self.assertNumQueries(84, table_blacklist=QUERY_COUNT_TABLE_BLACKLIST):
             with check_mongo_calls(4):
                 url = course_home_url(self.course)
                 self.client.get(url)
@@ -686,6 +686,7 @@ class TestCourseHomePageAccess(CourseHomePageTestCase):
 
         # Verify that enrolled users are not shown any state warning message when enrolled and course has begun.
         CourseEnrollment.enroll(user, self.course.id)
+        self.client.login(username=user.username, password=self.TEST_PASSWORD)
         url = course_home_url(self.course)
         response = self.client.get(url)
         self.assertNotContains(response, TEST_COURSE_HOME_MESSAGE_ANONYMOUS)
@@ -702,6 +703,7 @@ class TestCourseHomePageAccess(CourseHomePageTestCase):
             enabled_as_of=datetime(2018, 1, 1)
         )
         config.save()
+        CourseMode.objects.create(course_id=self.course.id, mode_slug=CourseMode.AUDIT)
 
         url = course_home_url(self.course)
         response = self.client.get(url)
@@ -737,6 +739,7 @@ class TestCourseHomePageAccess(CourseHomePageTestCase):
         config.save()
         url = course_home_url(self.course)
         CourseEnrollment.enroll(self.staff_user, self.course.id)
+        self.client.login(username=self.staff_user.username, password=self.TEST_PASSWORD)
         response = self.client.get(url)
         bannerText = get_expiration_banner_text(self.staff_user, self.course)
         self.assertNotContains(response, bannerText, html=True)
@@ -760,9 +763,12 @@ class TestCourseHomePageAccess(CourseHomePageTestCase):
             enabled_as_of=datetime(2018, 1, 1)
         )
         config.save()
+        CourseMode.objects.create(course_id=self.course.id, mode_slug=CourseMode.AUDIT)
+
         url = course_home_url(self.course)
         user = self.create_user_for_course(self.course, CourseUserType.UNENROLLED)
         CourseEnrollment.enroll(user, self.course.id)
+        self.client.login(username=user.username, password=TEST_PASSWORD)
 
         language = 'eo'
         DarkLangConfig(

--- a/openedx/features/course_experience/tests/views/test_course_updates.py
+++ b/openedx/features/course_experience/tests/views/test_course_updates.py
@@ -130,7 +130,7 @@ class TestCourseUpdatesPage(SharedModuleStoreTestCase):
 
         # Fetch the view and verify that the query counts haven't changed
         # TODO: decrease query count as part of REVO-28
-        with self.assertNumQueries(53, table_blacklist=QUERY_COUNT_TABLE_BLACKLIST):
+        with self.assertNumQueries(47, table_blacklist=QUERY_COUNT_TABLE_BLACKLIST):
             with check_mongo_calls(4):
                 url = course_updates_url(self.course)
                 self.client.get(url)


### PR DESCRIPTION
https://openedx.atlassian.net/browse/REVMI-103

This will change existing behavior so enabled_for_enrollment for both content_type_gating and course_duration_limits will return false for audit only/professional only courses  
this also moves the check for whether a user is audit into enabled_for_enrollment and out of get_group_for_user