### PR TITLE
Upgrade post pip compile script

### DIFF
--- a/scripts/post-pip-compile.sh
+++ b/scripts/post-pip-compile.sh
@@ -21,7 +21,7 @@ function clean_file {
     # Workaround for https://github.com/jazzband/pip-tools/issues/204 -
     # change absolute paths for local editable packages back to relative ones
     FILE_CONTENT=$(<${FILE_PATH})
-    FILE_URL_REGEX="-e (file:///[^'$'\n'']*)/common/lib/symmath"
+    FILE_URL_REGEX="-e (file:///[^"$'\n'"]*)/common/lib/symmath"
     if [[ "${FILE_CONTENT}" =~ ${FILE_URL_REGEX} ]]; then
         BASE_FILE_URL=${BASH_REMATCH[1]}
         sed "s|$BASE_FILE_URL/||" ${FILE_PATH} > ${TEMP_FILE}


### PR DESCRIPTION
The regex was not matching strings with a new line as expected, but it also wasn't matching strings with the letter n in it... Switching to double quotes fixes this.

Discovered while trying to automate the `make upgrade` command:
Before: https://github.com/edx/edx-platform/pull/20141/files
After: https://github.com/edx/edx-platform/pull/20149/files