### PR TITLE
Change button text for creating account

### DIFF
--- a/lms/templates/student_account/institution_register.underscore
+++ b/lms/templates/student_account/institution_register.underscore
@@ -26,6 +26,6 @@
     </div>
 
     <div class="toggle-form">
-        <button class="nav-btn form-toggle" data-type="register"><%- gettext("Register through edX") %></button>
+        <button class="nav-btn form-toggle" data-type="register"><%- gettext("Create an Account") %></button>
     </div>
 </div>


### PR DESCRIPTION
Changed button text from "Register through edX" to "Create an Account" on Register with Institution/Campus Credentials page, so we don't have the hardcoded name edX for different organizations.

@stvstnfrd 