### PR TITLE
Cleanup after tests.

### DIFF
--- a/common/djangoapps/course_modes/api/v1/tests/test_views.py
+++ b/common/djangoapps/course_modes/api/v1/tests/test_views.py
@@ -51,6 +51,12 @@ class CourseModesViewTestBase(AuthAndScopesTestMixin):
 
     @classmethod
     def tearDownClass(cls):
+        cls.course.delete()
+        cls.audit_mode.delete()
+        cls.verified_mode.delete()
+
+    @classmethod
+    def tearDownClass(cls):
         cls.audit_mode.delete()
         cls.verified_mode.delete()
 
@@ -285,7 +291,7 @@ class TestCourseModesDetailViews(CourseModesViewTestBase, APITestCase):
         assert status.HTTP_404_NOT_FOUND == response.status_code
 
     def test_update_course_mode_happy_path(self):
-        _ = CourseModeFactory.create(
+        new_mode = CourseModeFactory.create(
             course_id=self.course_key,
             mode_slug='prof-ed',
             mode_display_name='Professional Education',
@@ -309,6 +315,7 @@ class TestCourseModesDetailViews(CourseModesViewTestBase, APITestCase):
         assert 222 == updated_mode.min_price
         assert 'Something Else' == updated_mode.mode_display_name
         assert 'jpy' == updated_mode.currency
+        self.addCleanup(lambda mode: mode.delete(), new_mode)
 
     def test_update_course_mode_fails_when_updating_static_fields(self):
         self.client.login(username=self.global_staff.username, password=self.user_password)
@@ -353,7 +360,7 @@ class TestCourseModesDetailViews(CourseModesViewTestBase, APITestCase):
         assert status.HTTP_404_NOT_FOUND == response.status_code
 
     def test_delete_course_mode_happy_path(self):
-        _ = CourseModeFactory.create(
+        new_mode = CourseModeFactory.create(
             course_id=self.course_key,
             mode_slug='bachelors',
             mode_display_name='Bachelors',
@@ -366,3 +373,4 @@ class TestCourseModesDetailViews(CourseModesViewTestBase, APITestCase):
 
         assert status.HTTP_204_NO_CONTENT == response.status_code
         assert 0 == CourseMode.objects.filter(course_id=self.course_key, mode_slug='bachelors').count()
+        self.addCleanup(lambda mode: mode.delete(), new_mode)


### PR DESCRIPTION
From Jeremy:
>it looks like a few Python unit tests have been intermittently failing since https://github.com/edx/edx-platform/pull/20134 was merged.  For example, its own merge to master: https://build.testeng.edx.org/job/edx-platform-python-pipeline-master/416/ I think the CourseOverview created in setUpClass is lingering around after teardown, throwing off counts in various other tests: https://github.com/edx/edx-platform/blob/master/common/djangoapps/course_modes/api/v1/tests/test_views.py#L38

This PR cleans up after the `CourseOverview` it created, and also cleans up after `CourseModes` that get created, just in case.