### PR TITLE
WL-1905 |  Some learners not showing up in report | Missing Data Sharing Consent Redirection

### DIFF
--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -3320,6 +3320,8 @@ ENTERPRISE_READONLY_ACCOUNT_FIELDS = [
 ENTERPRISE_CUSTOMER_COOKIE_NAME = 'enterprise_customer_uuid'
 BASE_COOKIE_DOMAIN = 'localhost'
 
+DATA_CONSENT_SHARE_CACHE_TIMEOUT = None  # Never expire
+
 ############## Settings for Course Enrollment Modes ######################
 # The min_price key refers to the minimum price allowed for an instance
 # of a particular type of course enrollment mode. This is not to be confused

--- a/openedx/features/enterprise_support/signals.py
+++ b/openedx/features/enterprise_support/signals.py
@@ -6,8 +6,10 @@ from django.dispatch import receiver
 from django.db.models.signals import post_save
 from django.contrib.auth.models import User
 
-from enterprise.models import EnterpriseCustomerUser
+from enterprise.models import EnterpriseCustomerUser, EnterpriseCourseEnrollment
 from email_marketing.tasks import update_user
+
+from openedx.features.enterprise_support.utils import clear_data_consent_share_cache
 
 
 @receiver(post_save, sender=EnterpriseCustomerUser)
@@ -24,4 +26,15 @@ def update_email_marketing_user_with_enterprise_vars(sender, instance, **kwargs)
             'enterprise_name': instance.enterprise_customer.name,
         },
         email=user.email
+    )
+
+
+@receiver(post_save, sender=EnterpriseCourseEnrollment)
+def update_data_consent_share_cache(sender, instance, **kwargs):  # pylint: disable=unused-argument
+    """
+        clears data_sharing_consent_needed cache after Enterprise Course Enrollment
+    """
+    clear_data_consent_share_cache(
+        instance.enterprise_customer_user.user_id,
+        instance.course_id
     )

--- a/openedx/features/enterprise_support/utils.py
+++ b/openedx/features/enterprise_support/utils.py
@@ -8,6 +8,7 @@ from django.conf import settings
 from django.utils.translation import ugettext as _
 
 import third_party_auth
+from edx_django_utils.cache import TieredCache
 from third_party_auth import pipeline
 from enterprise.models import EnterpriseCustomerUser
 
@@ -38,6 +39,22 @@ def get_cache_key(**kwargs):
     key = '__'.join(['{}:{}'.format(item, value) for item, value in six.iteritems(kwargs)])
 
     return hashlib.md5(key).hexdigest()
+
+
+def get_data_consent_share_cache_key(user_id, course_id):
+    """
+        Returns cache key for data sharing consent needed against user_id and course_id
+    """
+
+    return get_cache_key(type='data_sharing_consent_needed', user_id=user_id, course_id=course_id)
+
+
+def clear_data_consent_share_cache(user_id, course_id):
+    """
+        clears data_sharing_consent_needed cache
+    """
+    consent_cache_key = get_data_consent_share_cache_key(user_id, course_id)
+    TieredCache.delete_all_tiers(consent_cache_key)
 
 
 def update_logistration_context_for_enterprise(request, context, enterprise_customer):


### PR DESCRIPTION
We have many B2B learners who arrive at edX first and then become connected to the enterprise customer. When they were arriving at edX it was getting stored is their session Not to show **data sharing consent**. Then if they connected to enterprise customer, still they were not getting asked for **data sharing consent** as it was already in their session Not to show them any **data sharing consent**.

In this PR:
session is replaced with cache to hold data_sharing_consent_needed flag value
added signal to destroy data_sharing_consent_needed flag when user is
is enrolled in enterprise course.