### PR TITLE
PROD-101: Do not rewrite URL for videos that do not have a video id.

### DIFF
--- a/common/lib/xmodule/xmodule/video_module/video_module.py
+++ b/common/lib/xmodule/xmodule/video_module/video_module.py
@@ -285,10 +285,11 @@ class VideoModule(VideoFields, VideoTranscriptsMixin, VideoStudentViewHandlers, 
         if getattr(self, 'video_speed_optimizations', True) and cdn_url:
             branding_info = BrandingInfoConfig.get_config().get(self.system.user_location)
 
-            for index, source_url in enumerate(sources):
-                new_url = rewrite_video_url(cdn_url, source_url)
-                if new_url:
-                    sources[index] = new_url
+            if self.edx_video_id and edxval_api:
+                for index, source_url in enumerate(sources):
+                    new_url = rewrite_video_url(cdn_url, source_url)
+                    if new_url:
+                        sources[index] = new_url
 
         # If there was no edx_video_id, or if there was no download specified
         # for it, we fall back on whatever we find in the VideoDescriptor

--- a/lms/djangoapps/courseware/tests/test_video_mongo.py
+++ b/lms/djangoapps/courseware/tests/test_video_mongo.py
@@ -842,9 +842,9 @@ class TestGetHtmlMethod(BaseTestXmodule):
             },
         }
 
-        # test with and without edx_video_id specified.
+        # Only videos with a video id should have their URLs rewritten
+        # based on CDN settings
         cases = [
-            dict(case_data, edx_video_id=""),
             dict(case_data, edx_video_id="vid-v1:12345"),
         ]
 


### PR DESCRIPTION
Fixes an issue where videos hosted on 3rd party sites were visible in studio, but not in LMS, because LMS was rewriting the URL of the video based on the VIDEO_CDN_URL environment variable. We will now only rewrite the URLs if there is a video id present (meaning that the video was uploaded through our pipeline).

Also removes a unit test that checked for the behavior being changed here.

https://openedx.atlassian.net/browse/PROD-101