### PR TITLE
Change attribute in ProgramDataExtender log warning

### DIFF
--- a/openedx/core/djangoapps/programs/utils.py
+++ b/openedx/core/djangoapps/programs/utils.py
@@ -500,9 +500,7 @@ class ProgramDataExtender(object):
                 try:
                     self.course_overview = CourseOverview.get_from_id(self.course_run_key)
                 except CourseOverview.DoesNotExist:
-                    log.warning(u'Failed to get course overview for course run key: %s',
-                                self.course_run.get('key'),
-                                exec_info=True)
+                    log.warning(u'Failed to get course overview for course run key: %s', course_run.get('key'))
                 else:
                     self.enrollment_start = self.course_overview.enrollment_start or DEFAULT_ENROLLMENT_START_DATE
 


### PR DESCRIPTION
#### Description: 
User is getting **error 500**  on trying to access the program details page from the dashboard. The course overview for one of the course(**MITx/16.101x/2013_SOND**) in program does not exists because it is an old course run. In such cases we should skip getting course overview and log it as a warning. 
#### Notes
The view crashes because the variable course_run is not an attribute of object ProgramDataExtender and should not be accessed using self.

[LEARNER-6734](https://openedx.atlassian.net/browse/LEARNER-6734)