### PR TITLE
BB-755 Check if username is already unicode.

### DIFF
--- a/common/djangoapps/student/models.py
+++ b/common/djangoapps/student/models.py
@@ -915,39 +915,13 @@ class LoginFailures(models.Model):
         except ObjectDoesNotExist:
             return
 
-    def __repr__(self):
-        """Repr -> LoginFailures(username, count, date)"""
-        date_str = '-'
-        if self.lockout_until is not None:
-            date_str = self.lockout_until.isoformat()
-
-        try:
-            username = unicode(self.user.username, 'utf-8')
-        except TypeError:
-            username = self.user.username
-
-        return u'LoginFailures({username}, {count}, {date})'.format(
-            username=username,
-            count=self.failure_count,
-            date=date_str
-        )
-
     def __str__(self):
         """Str -> Username: count - date."""
-        date_str = '-'
-        if self.lockout_until is not None:
-            date_str = self.lockout_until.isoformat()
-
-        try:
-            username = unicode(self.user.username, 'utf-8')
-        except TypeError:
-            username = self.user.username
-
-        return u'{username}: {count} - {date}'.format(
-            username=username,
+        return six.text_type('{username}: {count} - {date}'.format(
+            username=self.user.username,
             count=self.failure_count,
-            date=date_str
-        )
+            date=self.lockout_until.isoformat() if self.lockout_until else '-'
+        ))
 
     class Meta:
         verbose_name = 'Login Failure'

--- a/common/djangoapps/student/models.py
+++ b/common/djangoapps/student/models.py
@@ -917,11 +917,11 @@ class LoginFailures(models.Model):
 
     def __str__(self):
         """Str -> Username: count - date."""
-        return six.text_type('{username}: {count} - {date}'.format(
+        return u'{username}: {count} - {date}'.format(
             username=self.user.username,
             count=self.failure_count,
             date=self.lockout_until.isoformat() if self.lockout_until else '-'
-        ))
+        )
 
     class Meta:
         verbose_name = 'Login Failure'

--- a/common/djangoapps/student/models.py
+++ b/common/djangoapps/student/models.py
@@ -921,8 +921,13 @@ class LoginFailures(models.Model):
         if self.lockout_until is not None:
             date_str = self.lockout_until.isoformat()
 
+        try:
+            username = unicode(self.user.username, 'utf-8')
+        except TypeError:
+            username = self.user.username
+
         return u'LoginFailures({username}, {count}, {date})'.format(
-            username=six.text_type(self.user.username, 'utf-8'),
+            username=username,
             count=self.failure_count,
             date=date_str
         )
@@ -933,8 +938,13 @@ class LoginFailures(models.Model):
         if self.lockout_until is not None:
             date_str = self.lockout_until.isoformat()
 
+        try:
+            username = unicode(self.user.username, 'utf-8')
+        except TypeError:
+            username = self.user.username
+
         return u'{username}: {count} - {date}'.format(
-            username=six.text_type(self.user.username, 'utf-8'),
+            username=username,
             count=self.failure_count,
             date=date_str
         )

--- a/common/djangoapps/student/tests/test_admin_views.py
+++ b/common/djangoapps/student/tests/test_admin_views.py
@@ -333,6 +333,16 @@ class LoginFailuresAdminTest(TestCase):
         super(LoginFailuresAdminTest, self).tearDown()
         LoginFailures.objects.all().delete()
 
+    def test_unicode_username(self):
+        """
+        Test if `__str__` method behaves correctly for unicode username.
+        It shouldn't raise `TypeError`.
+        """
+        try:
+            map(str, LoginFailures.objects.all())
+        except TypeError, e:
+            self.fail("Failed executing `__str__` with unicode: {0}".format(e))
+
     @ddt.data(
         reverse('admin:student_loginfailures_changelist'),
         reverse('admin:student_loginfailures_add'),

--- a/common/djangoapps/student/tests/test_admin_views.py
+++ b/common/djangoapps/student/tests/test_admin_views.py
@@ -1,3 +1,4 @@
+# coding=UTF-8
 """
 Tests student admin.py
 """
@@ -324,7 +325,7 @@ class LoginFailuresAdminTest(TestCase):
         """Setup."""
         super(LoginFailuresAdminTest, self).setUp()
         self.client.login(username=self.user.username, password='test')
-        self.user2 = UserFactory.create()
+        self.user2 = UserFactory.create(username=u'Zażółć gęślą jaźń')
         LoginFailures.objects.create(user=self.user, failure_count=10, lockout_until=datetime.datetime.now())
         LoginFailures.objects.create(user=self.user2, failure_count=2)
 
@@ -338,11 +339,8 @@ class LoginFailuresAdminTest(TestCase):
         Test if `__str__` method behaves correctly for unicode username.
         It shouldn't raise `TypeError`.
         """
-        try:
-            str(LoginFailures.objects.get(user=self.user))
-            str(LoginFailures.objects.get(user=self.user2))
-        except TypeError as e:
-            self.fail("Failed executing `__str__` with unicode: {0}".format(e))
+        str(LoginFailures.objects.get(user=self.user))
+        str(LoginFailures.objects.get(user=self.user2))
 
     @ddt.data(
         reverse('admin:student_loginfailures_changelist'),

--- a/common/djangoapps/student/tests/test_admin_views.py
+++ b/common/djangoapps/student/tests/test_admin_views.py
@@ -324,9 +324,9 @@ class LoginFailuresAdminTest(TestCase):
         """Setup."""
         super(LoginFailuresAdminTest, self).setUp()
         self.client.login(username=self.user.username, password='test')
-        user = UserFactory.create()
+        self.user2 = UserFactory.create()
         LoginFailures.objects.create(user=self.user, failure_count=10, lockout_until=datetime.datetime.now())
-        LoginFailures.objects.create(user=user, failure_count=2)
+        LoginFailures.objects.create(user=self.user2, failure_count=2)
 
     def tearDown(self):
         """Tear Down."""
@@ -339,8 +339,9 @@ class LoginFailuresAdminTest(TestCase):
         It shouldn't raise `TypeError`.
         """
         try:
-            map(str, LoginFailures.objects.all())
-        except TypeError, e:
+            str(LoginFailures.objects.get(user=self.user))
+            str(LoginFailures.objects.get(user=self.user2))
+        except TypeError as e:
             self.fail("Failed executing `__str__` with unicode: {0}".format(e))
 
     @ddt.data(

--- a/common/djangoapps/student/tests/test_admin_views.py
+++ b/common/djangoapps/student/tests/test_admin_views.py
@@ -16,6 +16,7 @@ from django.test import TestCase, override_settings
 from django.urls import reverse
 from django.utils.timezone import now
 from mock import Mock
+from pytz import UTC
 
 from student.admin import COURSE_ENROLLMENT_ADMIN_SWITCH, UserAdmin, CourseEnrollmentForm
 from student.models import CourseEnrollment, LoginFailures
@@ -318,7 +319,7 @@ class LoginFailuresAdminTest(TestCase):
     def setUpClass(cls):
         """Setup class"""
         super(LoginFailuresAdminTest, cls).setUpClass()
-        cls.user = UserFactory.create(is_staff=True, is_superuser=True)
+        cls.user = UserFactory.create(username=u'§', is_staff=True, is_superuser=True)
         cls.user.save()
 
     def setUp(self):
@@ -326,7 +327,8 @@ class LoginFailuresAdminTest(TestCase):
         super(LoginFailuresAdminTest, self).setUp()
         self.client.login(username=self.user.username, password='test')
         self.user2 = UserFactory.create(username=u'Zażółć gęślą jaźń')
-        LoginFailures.objects.create(user=self.user, failure_count=10, lockout_until=datetime.datetime.now())
+        self.user_lockout_until = datetime.datetime.now(UTC)
+        LoginFailures.objects.create(user=self.user, failure_count=10, lockout_until=self.user_lockout_until)
         LoginFailures.objects.create(user=self.user2, failure_count=2)
 
     def tearDown(self):
@@ -339,8 +341,10 @@ class LoginFailuresAdminTest(TestCase):
         Test if `__str__` method behaves correctly for unicode username.
         It shouldn't raise `TypeError`.
         """
-        str(LoginFailures.objects.get(user=self.user))
-        str(LoginFailures.objects.get(user=self.user2))
+        self.assertEqual(
+            str(LoginFailures.objects.get(user=self.user)), '§: 10 - {}'.format(self.user_lockout_until.isoformat())
+        )
+        self.assertEqual(str(LoginFailures.objects.get(user=self.user2)), 'Zażółć gęślą jaźń: 2 - -')
 
     @ddt.data(
         reverse('admin:student_loginfailures_changelist'),


### PR DESCRIPTION
We found a bug in a previous PR. If the username is already in unicode there's a `TypeError` raised. This fixes that issue.