### PR TITLE
ENT-1751: Downgrade log level from "warning" to "info" for expected consent gating workflow.

### DIFF
--- a/openedx/features/enterprise_support/api.py
+++ b/openedx/features/enterprise_support/api.py
@@ -303,7 +303,7 @@ def data_sharing_consent_required(view_func):
         consent_url = get_enterprise_consent_url(request, course_id, enrollment_exists=True)
         if consent_url:
             real_user = getattr(request.user, 'real_user', request.user)
-            LOGGER.warning(
+            LOGGER.info(
                 u'User %s cannot access the course %s because they have not granted consent',
                 real_user,
                 course_id,


### PR DESCRIPTION
It was not clear during the original implementation of this workflow if the consent gate being encountered upon accessing a course should be considered an exceptional state.  At this point we're confident that it is a normal part of the enterprise learner experience and so we can downgrade the log level from "warning" to "info". 