### PR TITLE
Revert "Pull Turkish translations by default"

### DIFF
--- a/conf/locale/config.yaml
+++ b/conf/locale/config.yaml
@@ -77,7 +77,7 @@ locales:
     # - ta  # Tamil
     # - te  # Telugu
     # - th  # Thai
-    - tr_TR  # Turkish (Turkey)
+    # - tr_TR  # Turkish (Turkey)
     # - uk  # Ukranian
     # - ur  # Urdu
     # - uz  # Uzbek


### PR DESCRIPTION
Reverts edx/edx-platform#19252

Broke master with:

```
AssertionError: Missing file in locale tr_TR: django.mo
```