### PR TITLE
BB-1156: Enable changing the build profile used by RequireJS

### DIFF
--- a/lms/envs/production.py
+++ b/lms/envs/production.py
@@ -173,6 +173,9 @@ if STATIC_URL_BASE:
     if not STATIC_URL.endswith("/"):
         STATIC_URL += "/"
 
+# Allow overriding build profile used by RequireJS with one
+# contained on a custom theme
+REQUIRE_BUILD_PROFILE = ENV_TOKENS.get('REQUIRE_BUILD_PROFILE', REQUIRE_BUILD_PROFILE)
 
 # The following variables use (or) instead of the default value inside (get). This is to enforce using the Lazy Text
 # values when the varibale is an empty string. Therefore, setting these variable as empty text in related


### PR DESCRIPTION
This PR adds a way of changing the default build profile used by RequireJS via `lms.env.json`. 
This is useful when using custom themes that need extra functionality added to pages and elements that use require.js.

**JIRA tickets**: [OSPR-3306](https://openedx.atlassian.net/browse/OSPR-3306).

**Sandbox URL**: https://pr20225.sandbox.opencraft.hosting/

**Testing instructions:**
1. Pull this branch into your devstack.
2. Copy and paste `build.js` to a folder inside a theme custom theme (doesn't matter which)
3. Modify your `lms.env.json` and add:
```
    "REQUIRE_BUILD_PROFILE": "path-to-theme/lms/build.js",
```
4. Restart LMS
5. Rebuild your LMS assets:
```
make lms-shell
paver update_assets
```
6. Check that the variable was correctly loaded on django settings:
```
make lms-shell
./manage.py lms shell
>>> from django.conf import settings
>>> settings.REQUIRE_BUILD_PROFILE
u'path-to-theme/lms/build.js'  # Should output this
``` 
7. Check that the [user profile page](http://edx.devstack.lms:18000/u/edx) is working correctly (this page uses require.js.

**Reviewers**
- [ ] @jamestait
- [ ] edX reviewer[s] TBD

**Settings**
```yaml
EDXAPP_LMS_ENV_EXTRA: 
  REQUIRE_BUILD_PROFILE: "lms/js/build.js"
```