### PR TITLE
BB-1132 Decrease NAME_MIN_LENGTH to 1.

### DIFF
--- a/common/djangoapps/student/forms.py
+++ b/common/djangoapps/student/forms.py
@@ -248,7 +248,7 @@ class AccountCreationForm(forms.Form):
     """
 
     _EMAIL_INVALID_MSG = _("A properly formatted e-mail is required")
-    _NAME_TOO_SHORT_MSG = _("Your legal name must be a minimum of two characters long")
+    _NAME_TOO_SHORT_MSG = _("Your legal name must be a minimum of one character long")
 
     # TODO: Resolve repetition
 

--- a/common/test/acceptance/tests/lms/test_account_settings.py
+++ b/common/test/acceptance/tests/lms/test_account_settings.py
@@ -291,7 +291,7 @@ class AccountSettingsPageTest(AccountSettingsTestMixin, AcceptanceTest):
             u'name',
             u'Full Name',
             self.full_name,
-            u'@',
+            u' ',
             [u'<h1>another name<h1>', u'<script>'],
             'Full Name cannot contain the following characters: < >',
             False

--- a/lms/djangoapps/verify_student/tests/test_views.py
+++ b/lms/djangoapps/verify_student/tests/test_views.py
@@ -1549,10 +1549,10 @@ class TestSubmitPhotosForVerification(TestCase):
         response = self._submit_photos(
             face_image=self.IMAGE_DATA,
             photo_id_image=self.IMAGE_DATA,
-            full_name="a",
+            full_name="",
             expected_status_code=400
         )
-        self.assertEqual(response.content, "Name must be at least 2 characters long.")
+        self.assertEqual(response.content, "Name must be at least 1 character long.")
 
     def test_missing_required_param(self):
         # Missing face image parameter

--- a/lms/djangoapps/verify_student/views.py
+++ b/lms/djangoapps/verify_student/views.py
@@ -993,7 +993,7 @@ class SubmitPhotosView(View):
             return HttpResponseBadRequest(_("No profile found for user"))
         except AccountValidationError:
             msg = _(
-                u"Name must be at least {min_length} characters long."
+                u"Name must be at least {min_length} character long."
             ).format(min_length=NAME_MIN_LENGTH)
             return HttpResponseBadRequest(msg)
 

--- a/openedx/core/djangoapps/user_api/accounts/__init__.py
+++ b/openedx/core/djangoapps/user_api/accounts/__init__.py
@@ -11,7 +11,7 @@ from django.utils.translation import ugettext_lazy as _
 BIO_MAX_LENGTH = 300
 
 # The minimum and maximum length for the name ("full name") account field
-NAME_MIN_LENGTH = 2
+NAME_MIN_LENGTH = 1
 NAME_MAX_LENGTH = 255
 
 # The minimum and maximum length for the username account field

--- a/openedx/core/djangoapps/user_api/accounts/serializers.py
+++ b/openedx/core/djangoapps/user_api/accounts/serializers.py
@@ -233,7 +233,7 @@ class AccountLegacyProfileSerializer(serializers.HyperlinkedModelSerializer, Rea
         """ Enforce minimum length for name. """
         if len(new_name) < NAME_MIN_LENGTH:
             raise serializers.ValidationError(
-                u"The name field must be at least {} characters long.".format(NAME_MIN_LENGTH)
+                u"The name field must be at least {} character long.".format(NAME_MIN_LENGTH)
             )
         return new_name
 

--- a/openedx/core/djangoapps/user_api/accounts/tests/test_views.py
+++ b/openedx/core/djangoapps/user_api/accounts/tests/test_views.py
@@ -552,7 +552,7 @@ class TestAccountsAPI(CacheIsolationTestCase, UserAPITestCase):
         ("country", "GB", "XY", u'"XY" is not a valid choice.'),
         ("year_of_birth", 2009, "not_an_int", u"A valid integer is required."),
         ("name", "bob", "z" * 256, u"Ensure this value has at most 255 characters (it has 256)."),
-        ("name", u"ȻħȺɍłɇs", "z   ", u"The name field must be at least 2 characters long."),
+        ("name", u"ȻħȺɍłɇs", "   ", u"The name field must be at least 1 character long."),
         ("goals", "Smell the roses"),
         ("mailing_address", "Sesame Street"),
         # Note that we store the raw data, so it is up to client to escape the HTML.

--- a/openedx/core/djangoapps/user_authn/views/tests/test_register.py
+++ b/openedx/core/djangoapps/user_authn/views/tests/test_register.py
@@ -658,12 +658,11 @@ class TestCreateAccountValidation(TestCase):
 
         # Missing
         del params["name"]
-        assert_name_error("Your legal name must be a minimum of two characters long")
+        assert_name_error("Your legal name must be a minimum of one character long")
 
         # Empty, too short
-        for name in ["", "a"]:
-            params["name"] = name
-            assert_name_error("Your legal name must be a minimum of two characters long")
+        params["name"] = ""
+        assert_name_error("Your legal name must be a minimum of one character long")
 
     def test_honor_code(self):
         params = dict(self.minimal_params)


### PR DESCRIPTION
This PR decreases the minimum name length for registration to 1.

**JIRA tickets**: 

**Discussions**: 

**Dependencies**: None

**Screenshots**: 

**Sandbox URL**: TBD - sandbox is being provisioned.

**Merge deadline**: 

**Testing instructions**:

Register a user with a full name of only one letter.

**Author notes and concerns**:

**Reviewers**
- [ ] @kaizoku 
- [ ] edX reviewer[s] TBD

**Settings**