### PR TITLE
Move from a github dep to a PyPI dependency.

### DIFF
--- a/requirements/edx/base.in
+++ b/requirements/edx/base.in
@@ -49,6 +49,7 @@ django-model-utils==3.0.0
 django-mptt>=0.8.6,<0.9
 django-mysql==2.4.1
 django-oauth-toolkit<1.2            # Provides oAuth2 capabilities for Django. 1.2+ requires Django 2 and Python 3.5
+django-pipeline==1.5.3
 django-pyfs
 django-ratelimit
 django-ratelimit-backend==1.1.1

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -14,7 +14,6 @@ git+https://github.com/mitodl/django-cas.git@afac57bc523f145ae826f4ed3d4fa8b2c86
 git+https://github.com/edx/django-celery.git@756cb57aad765cb2b0d37372c1855b8f5f37e6b0#egg=django-celery==3.2.1+edx.2
 git+https://github.com/edx/django-oauth-plus.git@01ec2a161dfc3465f9d35b9211ae790177418316#egg=django-oauth-plus==2.2.9.edx-1
 git+https://github.com/edx/django-openid-auth.git@0.15.1#egg=django-openid-auth==0.15.1
-git+https://github.com/jazzband/django-pipeline.git@d068a019169c9de5ee20ece041a6dea236422852#egg=django-pipeline==1.5.3
 -e git+https://github.com/edx/django-wiki.git@v0.0.21#egg=django-wiki
 git+https://github.com/edx/django-rest-framework-oauth.git@0a43e8525f1e3048efe4bc70c03de308a277197c#egg=djangorestframework-oauth==1.1.1
 git+https://github.com/edx/django-rest-framework.git@1ceda7c086fddffd1c440cc86856441bbf0bd9cb#egg=djangorestframework==3.6.3
@@ -83,6 +82,7 @@ django-multi-email-field==0.5.1  # via edx-enterprise
 django-mysql==2.4.1
 django-oauth-toolkit==1.1.3
 django-object-actions==0.10.0  # via edx-enterprise
+django-pipeline==1.5.3
 django-pyfs==2.0
 django-ratelimit-backend==1.1.1
 django-ratelimit==2.0.0

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -15,7 +15,6 @@ git+https://github.com/edx/django-celery.git@756cb57aad765cb2b0d37372c1855b8f5f3
 git+https://github.com/hmarr/django-debug-toolbar-mongo.git@b0686a76f1ce3532088c4aee6e76b9abe61cc808#egg=django-debug-toolbar-mongo==0.1.10
 git+https://github.com/edx/django-oauth-plus.git@01ec2a161dfc3465f9d35b9211ae790177418316#egg=django-oauth-plus==2.2.9.edx-1
 git+https://github.com/edx/django-openid-auth.git@0.15.1#egg=django-openid-auth==0.15.1
-git+https://github.com/jazzband/django-pipeline.git@d068a019169c9de5ee20ece041a6dea236422852#egg=django-pipeline==1.5.3
 -e git+https://github.com/edx/django-wiki.git@v0.0.21#egg=django-wiki
 git+https://github.com/edx/django-rest-framework-oauth.git@0a43e8525f1e3048efe4bc70c03de308a277197c#egg=djangorestframework-oauth==1.1.1
 git+https://github.com/edx/django-rest-framework.git@1ceda7c086fddffd1c440cc86856441bbf0bd9cb#egg=djangorestframework==3.6.3
@@ -105,6 +104,7 @@ django-multi-email-field==0.5.1
 django-mysql==2.4.1
 django-oauth-toolkit==1.1.3
 django-object-actions==0.10.0
+django-pipeline==1.5.3
 django-pyfs==2.0
 django-ratelimit-backend==1.1.1
 django-ratelimit==2.0.0

--- a/requirements/edx/github.in
+++ b/requirements/edx/github.in
@@ -61,7 +61,6 @@
 # Python libraries to install directly from github
 
 # Third-party:
--e git+https://github.com/jazzband/django-pipeline.git@d068a019169c9de5ee20ece041a6dea236422852#egg=django-pipeline==1.5.3
 -e git+https://github.com/edx/django-wiki.git@v0.0.21#egg=django-wiki
 -e git+https://github.com/edx/django-openid-auth.git@0.15.1#egg=django-openid-auth==0.15.1
 -e git+https://github.com/edx/MongoDBProxy.git@25b99097615bda06bd7cdfe5669ed80dc2a7fed0#egg=MongoDBProxy==0.1.0

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -14,7 +14,6 @@ git+https://github.com/mitodl/django-cas.git@afac57bc523f145ae826f4ed3d4fa8b2c86
 git+https://github.com/edx/django-celery.git@756cb57aad765cb2b0d37372c1855b8f5f37e6b0#egg=django-celery==3.2.1+edx.2
 git+https://github.com/edx/django-oauth-plus.git@01ec2a161dfc3465f9d35b9211ae790177418316#egg=django-oauth-plus==2.2.9.edx-1
 git+https://github.com/edx/django-openid-auth.git@0.15.1#egg=django-openid-auth==0.15.1
-git+https://github.com/jazzband/django-pipeline.git@d068a019169c9de5ee20ece041a6dea236422852#egg=django-pipeline==1.5.3
 -e git+https://github.com/edx/django-wiki.git@v0.0.21#egg=django-wiki
 git+https://github.com/edx/django-rest-framework-oauth.git@0a43e8525f1e3048efe4bc70c03de308a277197c#egg=djangorestframework-oauth==1.1.1
 git+https://github.com/edx/django-rest-framework.git@1ceda7c086fddffd1c440cc86856441bbf0bd9cb#egg=djangorestframework==3.6.3
@@ -102,6 +101,7 @@ django-multi-email-field==0.5.1
 django-mysql==2.4.1
 django-oauth-toolkit==1.1.3
 django-object-actions==0.10.0
+django-pipeline==1.5.3
 django-pyfs==2.0
 django-ratelimit-backend==1.1.1
 django-ratelimit==2.0.0


### PR DESCRIPTION
The pinned version is the one tagged with a release that is also on
PyPI.

https://github.com/jazzband/django-pipeline/tree/1.5.3

Use PyPI instead since that will be faster.