### PR TITLE
Add language selection button in footer

### DIFF
--- a/lms/static/sass/shared/_footer.scss
+++ b/lms/static/sass/shared/_footer.scss
@@ -202,6 +202,19 @@
         cursor: initial;
       }
     }
+
+    .select-lang-button {
+        padding: 5px;
+        color: $m-blue-d3 !important;
+        height: 30px;
+
+        &:hover,
+        &:active,
+        &:focus {
+            background: $m-blue-d3 !important;
+            color: white !important;
+        }
+    }
   }
 
   // edx theme overrides

--- a/lms/templates/widgets/footer-language-selector.html
+++ b/lms/templates/widgets/footer-language-selector.html
@@ -18,20 +18,26 @@
 <%namespace name='static' file='../static_content.html'/>
 
 <div class="footer-language-selector">
-    <label for="footer-language-select">
-        <span class="icon fa fa-globe" aria-hidden="true"></span>
-        <span class="sr">${_("Choose Language")}</span>
-    </label>
-    <select id="footer-language-select" name="language" onchange="footerLanguageSelector.handleSelection(this)">
-        % for language in sorted(released_languages(), key=lambda x: x.code):
-            <% language_name = Locale.parse(language.code.replace('_', '-'), sep='-').language_name %>
-            % if language.code == LANGUAGE_CODE:
-                <option value="${language.code}" selected="selected">${language_name}</option>
-            % else:
-                <option value="${language.code}">${language_name}</option>
-            % endif
-        % endfor
-    </select>
+    <div role="group" aria-label="Change page language">
+        <label for="footer-language-select">
+            <span class="icon fa fa-globe" aria-hidden="true"></span>
+            <span class="sr">${_("Choose Language")}</span>
+        </label>
+        <select id="footer-language-select" name="language" onchange="footerLanguageSelector.handleSelection(this)">
+            % for language in sorted(released_languages(), key=lambda x: x.code):
+                <% language_name = Locale.parse(language.code.replace('_', '-'), sep='-').language_name %>
+                % if language.code == LANGUAGE_CODE:
+                    <option value="${language.code}" selected="selected">${language_name}</option>
+                % else:
+                    <option value="${language.code}">${language_name}</option>
+                % endif
+            % endfor
+        </select>
+        <button id="footer-language-button" type="button" class="btn-edged-blue select-lang-button"
+                onclick="footerLanguageSelector.langSelection()">
+            ${_('Submit')}
+        </button>
+    </div>
 </div>
 
 <script type="text/javascript">
@@ -48,8 +54,10 @@
         ## preference to the user's profile. This effect may be delayed on pages that do not use the LMS language
         ## selection middleware.
         ##
-        handleSelection: function($select) {
-            this.setLanguageCookie($select.value, this.refreshPage);
+        langSelection: function() {
+            var footer = document.getElementById('footer-language-select');
+            var lang = footer.options[footer.selectedIndex].value;
+            this.setLanguageCookie(lang, this.refreshPage);
         },
 
         setLanguageCookie: function(value, callback) {


### PR DESCRIPTION
#### Issue
As a keyboard-only user, the act of moving through the list of language options with keyboard fires an event that changes the language and reloads the page, and moves focus back to the top of the page.

#### Description 
To avoid this, in the footer added a button to the right of lang selection dropdown which reloads the page once it's clicked.
For now I have kept the old functionality that is associated with select onChange (handleSelection function) because it is used by marketing site. Once the marketing site is updated to use this button, I will remove the old functionality

[LEARNER-1338](https://openedx.atlassian.net/browse/LEARNER-1338)