### PR TITLE
Move pin for vendor proctoring module

### DIFF
--- a/requirements/edx/base.in
+++ b/requirements/edx/base.in
@@ -79,7 +79,7 @@ edx-milestones
 edx-oauth2-provider
 edx-organizations
 edx-proctoring>=1.6.0
-edx-proctoring-proctortrack==1.0.4  # Intentionally and permanently pinned to ensure code changes are reviewed
+edx-proctoring-proctortrack==1.0.5  # Intentionally and permanently pinned to ensure code changes are reviewed
 edx-rest-api-client
 edx-search
 edx-submissions

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -118,7 +118,7 @@ edx-milestones==0.1.13
 edx-oauth2-provider==1.2.2
 edx-opaque-keys[django]==0.4.4
 edx-organizations==1.0.1
-edx-proctoring-proctortrack==1.0.4
+edx-proctoring-proctortrack==1.0.5
 edx-proctoring==1.6.1
 edx-rbac==0.1.11          # via edx-enterprise
 edx-rest-api-client==1.9.2

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -141,7 +141,7 @@ edx-milestones==0.1.13
 edx-oauth2-provider==1.2.2
 edx-opaque-keys[django]==0.4.4
 edx-organizations==1.0.1
-edx-proctoring-proctortrack==1.0.4
+edx-proctoring-proctortrack==1.0.5
 edx-proctoring==1.6.1
 edx-rbac==0.1.11
 edx-rest-api-client==1.9.2

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -137,7 +137,7 @@ edx-milestones==0.1.13
 edx-oauth2-provider==1.2.2
 edx-opaque-keys[django]==0.4.4
 edx-organizations==1.0.1
-edx-proctoring-proctortrack==1.0.4
+edx-proctoring-proctortrack==1.0.5
 edx-proctoring==1.6.1
 edx-rbac==0.1.11
 edx-rest-api-client==1.9.2


### PR DESCRIPTION
This has the effect of preventing Open edX installations from having
details which should be in configuration (because they're
edx.org-specific) end up in their applications.