### PR TITLE
DEPR-16 Stop using deprecated OpaqueKey methods

### DIFF
--- a/cms/djangoapps/contentstore/tests/test_contentstore.py
+++ b/cms/djangoapps/contentstore/tests/test_contentstore.py
@@ -23,8 +23,8 @@ from edxval.api import create_video, get_videos_for_course
 from fs.osfs import OSFS
 from lxml import etree
 from opaque_keys import InvalidKeyError
-from opaque_keys.edx.keys import CourseKey, UsageKey
-from opaque_keys.edx.locations import AssetLocation, CourseLocator
+from opaque_keys.edx.keys import AssetKey, CourseKey, UsageKey
+from opaque_keys.edx.locations import CourseLocator
 from path import Path as path
 from six import text_type
 from waffle.testutils import override_switch
@@ -215,7 +215,7 @@ class ImportRequiredTestCases(ContentStoreTestCase):
         all_thumbnails = content_store.get_all_content_thumbnails_for_course(course.id)
         self.assertGreater(len(all_thumbnails), 0)
 
-        location = AssetLocation.from_deprecated_string('/c4x/edX/toy/asset/just_a_test.jpg')
+        location = AssetKey.from_string('/c4x/edX/toy/asset/just_a_test.jpg')
         content = content_store.find(location)
         self.assertIsNotNone(content)
 

--- a/cms/djangoapps/contentstore/tests/utils.py
+++ b/cms/djangoapps/contentstore/tests/utils.py
@@ -8,8 +8,7 @@ from django.conf import settings
 from django.contrib.auth.models import User
 from django.test.client import Client
 from mock import Mock
-from opaque_keys.edx.keys import CourseKey
-from opaque_keys.edx.locations import AssetLocation
+from opaque_keys.edx.keys import AssetKey, CourseKey
 
 from contentstore.utils import reverse_url
 from student.models import Registration
@@ -121,7 +120,7 @@ class CourseTestCase(ProceduralCourseTestMixin, ModuleStoreTestCase):
     SEQUENTIAL = 'vertical_sequential'
     DRAFT_HTML = 'draft_html'
     DRAFT_VIDEO = 'draft_video'
-    LOCKED_ASSET_KEY = AssetLocation.from_deprecated_string('/c4x/edX/toy/asset/sample_static.html')
+    LOCKED_ASSET_KEY = AssetKey.from_string('/c4x/edX/toy/asset/sample_static.html')
 
     def import_and_populate_course(self):
         """

--- a/cms/djangoapps/contentstore/views/tests/test_assets.py
+++ b/cms/djangoapps/contentstore/views/tests/test_assets.py
@@ -10,7 +10,7 @@ from ddt import data, ddt
 from django.conf import settings
 from django.test.utils import override_settings
 from mock import patch
-from opaque_keys.edx.locations import AssetLocation
+from opaque_keys.edx.keys import AssetKey
 from opaque_keys.edx.locator import CourseLocator
 from PIL import Image
 from pytz import UTC
@@ -102,7 +102,7 @@ class BasicAssetsTestCase(AssetsTestCase):
         # Test valid contentType for pdf asset (textbook.pdf)
         resp = self.client.get(url, HTTP_ACCEPT='application/json')
         self.assertContains(resp, "/c4x/edX/toy/asset/textbook.pdf")
-        asset_location = AssetLocation.from_deprecated_string('/c4x/edX/toy/asset/textbook.pdf')
+        asset_location = AssetKey.from_string('/c4x/edX/toy/asset/textbook.pdf')
         content = contentstore().find(asset_location)
         # Check after import textbook.pdf has valid contentType ('application/pdf')
 
@@ -507,7 +507,7 @@ class DeleteAssetTestCase(AssetsTestCase):
         self.assertEquals(response.status_code, 200)
         self.uploaded_url = json.loads(response.content)['asset']['url']
 
-        self.asset_location = AssetLocation.from_deprecated_string(self.uploaded_url)
+        self.asset_location = AssetKey.from_string(self.uploaded_url)
         self.content = contentstore().find(self.asset_location)
 
     def test_delete_asset(self):
@@ -533,7 +533,7 @@ class DeleteAssetTestCase(AssetsTestCase):
         thumbnail_url = json.loads(response.content)['asset']['url']
         thumbnail_location = StaticContent.get_location_from_path(thumbnail_url)
 
-        image_asset_location = AssetLocation.from_deprecated_string(uploaded_image_url)
+        image_asset_location = AssetKey.from_string(uploaded_image_url)
         content = contentstore().find(image_asset_location)
         content.thumbnail_location = thumbnail_location
         contentstore().save(content)

--- a/lms/djangoapps/instructor/tests/test_api.py
+++ b/lms/djangoapps/instructor/tests/test_api.py
@@ -1913,7 +1913,7 @@ class TestInstructorAPIEnrollment(SharedModuleStoreTestCase, LoginEnrollmentTest
         # enrolled, active
         url = reverse(
             'get_student_enrollment_status',
-            kwargs={'course_id': self.course.id.to_deprecated_string()},
+            kwargs={'course_id': text_type(self.course.id)},
         )
         params = {
             'unique_student_identifier': 'EnrolledStudent'

--- a/lms/djangoapps/instructor/views/api.py
+++ b/lms/djangoapps/instructor/views/api.py
@@ -1968,7 +1968,7 @@ def get_student_enrollment_status(request, course_id):
             enrollment_status = _(u'Enrollment status for {student}: never enrolled').format(student=email)
 
     response_payload = {
-        'course_id': course_id.to_deprecated_string(),
+        'course_id': text_type(course_id),
         'error': error,
         'enrollment_status': enrollment_status
     }


### PR DESCRIPTION
Remove the last remaining uses of `from_deprecated_string()` and `to_deprecated_string()`.