### PR TITLE
Add capability to override MANUAL_ENROLLMENT_ROLE_CHOICES

### DIFF
--- a/lms/envs/production.py
+++ b/lms/envs/production.py
@@ -1117,3 +1117,7 @@ plugin_settings.add_plugins(__name__, plugin_constants.ProjectType.LMS, plugin_c
 ########################## Derive Any Derived Settings  #######################
 
 derive_settings(__name__)
+
+######################### Overriding custom enrollment roles ###############
+
+MANUAL_ENROLLMENT_ROLE_CHOICES = ENV_TOKENS.get('MANUAL_ENROLLMENT_ROLE_CHOICES', MANUAL_ENROLLMENT_ROLE_CHOICES)


### PR DESCRIPTION
This PR allows to override `MANUAL_ENROLLMENT_ROLE_CHOICE` from `lms.env.json`.
What happens is that `production.py` [settings file](https://github.com/edx/edx-platform/blob/master/lms/envs/production.py) do not override the variable `MANUAL_ENROLLMENT_ROLE_CHOICE` and anything that's overridden by `lms.env.json` has to be explicitly done in `production.py`.

**JIRA tickets**: 

**Discussions**: 

**Dependencies**: 

**Screenshots**: 

**Sandbox URL**: TBD - sandbox is being provisioned.

**Merge deadline**: "None" 

**Testing instructions**:

1. Add `MANUAL_ENROLLMENT_ROLE_CHOICE` to your `lms.env.json`
2. Run this branch.
3. Run a django shell using the `aws.py` settings file: `/edx/bin/manage.edxapp lms shell --settings="production"`
4. Check the `MANUAL_ENROLLMENT_ROLE_CHOICE` value was overridden:
```
>>> from django.conf import settings
>>> settings.MANUAL_ENROLLMENT_ROLE_CHOICE
```

**Author notes and concerns**:

**Reviewers**
- [ ] @kaizoku 
- [ ] edX reviewer[s] TBD