### PR TITLE
Fix slack messaging in pipelines

### DIFF
--- a/scripts/Jenkinsfiles/bokchoy
+++ b/scripts/Jenkinsfiles/bokchoy
@@ -111,7 +111,8 @@ pipeline {
                         propagate: false, wait: false
 
                     if (currentBuild.currentResult != "SUCCESS"){
-                        slackSend "`${JOB_NAME}` #${BUILD_NUMBER}: ${currentBuild.currentResult} after ${currentBuild.durationString.replace(' and counting', '')}\n${BUILD_URL}"
+                        slackSend botUser: true,
+                            message: "`${JOB_NAME}` #${BUILD_NUMBER}: ${currentBuild.currentResult} after ${currentBuild.durationString.replace(' and counting', '')}\n${BUILD_URL}"
 
                         email_body = "See: <${BUILD_URL}>\n\nChanges:\n"
                         change_sets = currentBuild.changeSets
@@ -125,7 +126,8 @@ pipeline {
                         emailext body: email_body,
                             subject: "Build failed in Jenkins: ${JOB_NAME} #${BUILD_NUMBER}", to: 'testeng@edx.org'
                     } else if (currentBuild.currentResult == "SUCCESS" && currentBuild.previousBuild.currentResult != "SUCCESS") {
-                        slackSend "`${JOB_NAME}` #${BUILD_NUMBER}: Back to normal after ${currentBuild.durationString.replace(' and counting', '')}\n${BUILD_URL}"
+                        slackSend botUser: true,
+                            message: "`${JOB_NAME}` #${BUILD_NUMBER}: Back to normal after ${currentBuild.durationString.replace(' and counting', '')}\\n${BUILD_URL}"
                         emailext body: "See <${BUILD_URL}>",
                             subject: "Jenkins Build is back to normal: ${JOB_NAME} #${BUILD_NUMBER}", to: 'testeng@edx.org'
                     }

--- a/scripts/Jenkinsfiles/python
+++ b/scripts/Jenkinsfiles/python
@@ -216,7 +216,8 @@ pipeline {
                         propagate: false, wait: false
 
                     if (currentBuild.currentResult != "SUCCESS"){
-                        slackSend "`${JOB_NAME}` #${BUILD_NUMBER}: ${currentBuild.currentResult} after ${currentBuild.durationString.replace(' and counting', '')}\n${BUILD_URL}"
+                        slackSend botUser: true,
+                            message: "`${JOB_NAME}` #${BUILD_NUMBER}: ${currentBuild.currentResult} after ${currentBuild.durationString.replace(' and counting', '')}\n${BUILD_URL}"
 
                         email_body = "See: <${BUILD_URL}>\n\nChanges:\n"
                         change_sets = currentBuild.changeSets
@@ -230,7 +231,8 @@ pipeline {
                         emailext body: email_body,
                             subject: "Build failed in Jenkins: ${JOB_NAME} #${BUILD_NUMBER}", to: 'testeng@edx.org'
                     } else if (currentBuild.currentResult == "SUCCESS" && currentBuild.previousBuild.currentResult != "SUCCESS") {
-                        slackSend "`${JOB_NAME}` #${BUILD_NUMBER}: Back to normal after ${currentBuild.durationString.replace(' and counting', '')}\n${BUILD_URL}"
+                        slackSend botUser: true,
+                            message: "`${JOB_NAME}` #${BUILD_NUMBER}: Back to normal after ${currentBuild.durationString.replace(' and counting', '')}\n${BUILD_URL}"
                         emailext body: "See <${BUILD_URL}>",
                             subject: "Jenkins Build is back to normal: ${JOB_NAME} #${BUILD_NUMBER}", to: 'testeng@edx.org'
                     }

--- a/scripts/Jenkinsfiles/quality
+++ b/scripts/Jenkinsfiles/quality
@@ -231,7 +231,8 @@ pipeline {
                             propagate: false, wait: false
 
                         if (currentBuild.currentResult != "SUCCESS"){
-                            slackSend "`${JOB_NAME}` #${BUILD_NUMBER}: ${currentBuild.currentResult} after ${currentBuild.durationString.replace(' and counting', '')}\n${BUILD_URL}"
+                            slackSend botUser: true,
+                                message: "`${JOB_NAME}` #${BUILD_NUMBER}: ${currentBuild.currentResult} after ${currentBuild.durationString.replace(' and counting', '')}\n${BUILD_URL}"
 
                             email_body = "See: <${BUILD_URL}>\n\nChanges:\n"
                             change_sets = currentBuild.changeSets
@@ -245,7 +246,8 @@ pipeline {
                             emailext body: email_body,
                                 subject: "Build failed in Jenkins: ${JOB_NAME} #${BUILD_NUMBER}", to: 'testeng@edx.org'
                         } else if (currentBuild.currentResult == "SUCCESS" && currentBuild.previousBuild.currentResult != "SUCCESS") {
-                            slackSend "`${JOB_NAME}` #${BUILD_NUMBER}: Back to normal after ${currentBuild.durationString.replace(' and counting', '')}\n${BUILD_URL}"
+                            slackSend botUser: true,
+                                message: "`${JOB_NAME}` #${BUILD_NUMBER}: Back to normal after ${currentBuild.durationString.replace(' and counting', '')}\n${BUILD_URL}"
                             emailext body: "See <${BUILD_URL}>",
                                 subject: "Jenkins Build is back to normal: ${JOB_NAME} #${BUILD_NUMBER}", to: 'testeng@edx.org'
                         }


### PR DESCRIPTION
Slack integration has been broken since we upgraded. It now expects keyword arguments, so we need to explicitly add `message:`.

Also it looks like we need to add `botUser` to be `True`.  The UI has an explanation for the optional setting: `If the notification will be sent to a user via direct message, the default integration sends it via @slackbot, use this option if you want to send messages via a bot user.` And I tested via a different job, and it appears we want this to be True in order to get it working as we previously had it.