### PR TITLE
TE-2861 Use correct version of Django in tests

### DIFF
--- a/scripts/xdist/prepare_xdist_nodes.sh
+++ b/scripts/xdist/prepare_xdist_nodes.sh
@@ -14,13 +14,21 @@ else
     XDIST_GIT_FETCH_STRING="$XDIST_GIT_BRANCH:$XDIST_GIT_BRANCH"
 fi
 
+# Install the correct version of Django depending on which tox environment (if any) is in use
+if [[ -z ${TOX_ENV+x} ]] || [[ ${TOX_ENV} == 'null' ]]; then
+    DJANGO_REQUIREMENT="-r requirements/edx/django.txt"
+else
+    DJANGO_REQUIREMENT=$(pip freeze | grep "^[Dd]jango==")
+fi
+
 ip_list=$(<pytest_task_ips.txt)
 for ip in $(echo $ip_list | sed "s/,/ /g")
 do
     container_reqs_cmd="ssh -o StrictHostKeyChecking=no ubuntu@$ip 'cd /edx/app/edxapp;
     git clone --branch master --depth 1 --no-tags -q https://github.com/edx/edx-platform.git; cd edx-platform;
     git fetch --depth=1 --no-tags -q origin ${XDIST_GIT_FETCH_STRING}; git checkout -q ${XDIST_GIT_BRANCH};
-    source /edx/app/edxapp/edxapp_env; pip install -qr requirements/edx/testing.txt; mkdir reports' & "
+    source /edx/app/edxapp/edxapp_env;
+    pip install -q ${DJANGO_REQUIREMENT} -r requirements/edx/testing.txt; mkdir reports' & "
 
     cmd=$cmd$container_reqs_cmd
 done

--- a/tox.ini
+++ b/tox.ini
@@ -54,7 +54,7 @@ passenv =
     XDIST_NUM_TASKS
     XDIST_REMOTE_NUM_PROCESSES
 deps =
-    django111: Django>=1.11,<2
+    django111: -r requirements/edx/django.txt
     django20: Django>=2.0,<2.1
     django21: Django>=2.1,<2.2
     -r requirements/edx/testing.txt


### PR DESCRIPTION
When running tests in Jenkins, we weren't always getting the exact version of Django 1.11.x that was in our requirements files.  Fix this so we can accurately test Django upgrades (without breaking the ability of tox to specify which version of Django to use).