### PR TITLE
remove mathjax autocollapse feature

### DIFF
--- a/cms/static/cms/js/require-config.js
+++ b/cms/static/cms/js/require-config.js
@@ -261,7 +261,6 @@
                             ]
                         }
                     });
-
                     // In order to eliminate all flashing during interactive
                     // preview, it is necessary to set processSectionDelay to 0
                     // (remove delay between input and output phases). This

--- a/cms/static/cms/js/require-config.js
+++ b/cms/static/cms/js/require-config.js
@@ -56,7 +56,10 @@
             // When upgrading to 2.6, check if this variable name changed.
             window.MathJax = {
                 menuSettings: {
-                    CHTMLpreview: false
+                    CHTMLpreview: false,
+                    collapsible: true,
+                    autocollapse: false,
+                    explorer: true
                 }
             };
         };
@@ -258,6 +261,7 @@
                             ]
                         }
                     });
+
                     // In order to eliminate all flashing during interactive
                     // preview, it is necessary to set processSectionDelay to 0
                     // (remove delay between input and output phases). This

--- a/common/static/common/js/discussion/mathjax_include.js
+++ b/common/static/common/js/discussion/mathjax_include.js
@@ -46,7 +46,7 @@ if (typeof MathJax === 'undefined') {
     window.MathJax = {
         menuSettings: {
             collapsible: true,
-            autocollapse: true,
+            autocollapse: false,
             explorer: true
         }
     };

--- a/common/templates/mathjax_include.html
+++ b/common/templates/mathjax_include.html
@@ -80,7 +80,7 @@
     window.MathJax = {
         menuSettings: {
             collapsible: true,
-            autocollapse: true,
+            autocollapse: false,
             explorer: true
         }
     };


### PR DESCRIPTION
### [PROD-167](https://openedx.atlassian.net/browse/PROD-167)

### Description
One of the MathJax accessibility features is the ability to collapse large math expressions to accommodate on the screen. This feature has a variant, called **autocollapse** which collapses expressions automatically based on the available viewport. The collapse is removed by clicking on the expression. For learners, viewing a strange character rather than math is confusing. This PR attempts to take care of that behavior by disabling autocollapse across LMS & Studio. Studio's math config was missing, so it was catered for in the PR as well.

**Important note**: This PR doesn't remove collapse feature as it is required for speech generation. Only autocollapse has been removed.

### Testing Instructions
A test course with some MathJax content has been created. Make sure that by default, **Auto Collapse** is not checked. 
![image](https://user-images.githubusercontent.com/40599381/56570489-7d3afa00-65d4-11e9-90c9-3bfff0433ae9.png)


### Reviewers
 - [ ] @awaisdar001 
 - [ ] @asadazam93
 - [ ] @wittjeff  

### Sandbox
 - [Studio](https://studio-mathjax.sandbox.edx.org/course/course-v1:ArbX+167+2019_T1)
 - [LMS](https://mathjax.sandbox.edx.org/courses/course-v1:ArbX+167+2019_T1/course/) 
 - MathJax [Reference](https://math.meta.stackexchange.com/questions/5020/mathjax-basic-tutorial-and-quick-reference)

### Post Review
 - [ ] Squash & Rebase commits