### PR TITLE
remove bot user from slack notification

### DIFF
--- a/scripts/Jenkinsfiles/bokchoy
+++ b/scripts/Jenkinsfiles/bokchoy
@@ -111,8 +111,7 @@ pipeline {
                         propagate: false, wait: false
 
                     if (currentBuild.currentResult != "SUCCESS"){
-                        slackSend botUser: true,
-                            message: "`${JOB_NAME}` #${BUILD_NUMBER}: ${currentBuild.currentResult} after ${currentBuild.durationString.replace(' and counting', '')}\n${BUILD_URL}"
+                        slackSend message: "`${JOB_NAME}` #${BUILD_NUMBER}: ${currentBuild.currentResult} after ${currentBuild.durationString.replace(' and counting', '')}\n${BUILD_URL}"
 
                         email_body = "See: <${BUILD_URL}>\n\nChanges:\n"
                         change_sets = currentBuild.changeSets
@@ -126,8 +125,7 @@ pipeline {
                         emailext body: email_body,
                             subject: "Build failed in Jenkins: ${JOB_NAME} #${BUILD_NUMBER}", to: 'testeng@edx.org'
                     } else if (currentBuild.currentResult == "SUCCESS" && currentBuild.previousBuild.currentResult != "SUCCESS") {
-                        slackSend botUser: true,
-                            message: "`${JOB_NAME}` #${BUILD_NUMBER}: Back to normal after ${currentBuild.durationString.replace(' and counting', '')}\\n${BUILD_URL}"
+                        slackSend message: "`${JOB_NAME}` #${BUILD_NUMBER}: Back to normal after ${currentBuild.durationString.replace(' and counting', '')}\\n${BUILD_URL}"
                         emailext body: "See <${BUILD_URL}>",
                             subject: "Jenkins Build is back to normal: ${JOB_NAME} #${BUILD_NUMBER}", to: 'testeng@edx.org'
                     }

--- a/scripts/Jenkinsfiles/python
+++ b/scripts/Jenkinsfiles/python
@@ -216,8 +216,7 @@ pipeline {
                         propagate: false, wait: false
 
                     if (currentBuild.currentResult != "SUCCESS"){
-                        slackSend botUser: true,
-                            message: "`${JOB_NAME}` #${BUILD_NUMBER}: ${currentBuild.currentResult} after ${currentBuild.durationString.replace(' and counting', '')}\n${BUILD_URL}"
+                        slackSend message: "`${JOB_NAME}` #${BUILD_NUMBER}: ${currentBuild.currentResult} after ${currentBuild.durationString.replace(' and counting', '')}\n${BUILD_URL}"
 
                         email_body = "See: <${BUILD_URL}>\n\nChanges:\n"
                         change_sets = currentBuild.changeSets
@@ -231,8 +230,7 @@ pipeline {
                         emailext body: email_body,
                             subject: "Build failed in Jenkins: ${JOB_NAME} #${BUILD_NUMBER}", to: 'testeng@edx.org'
                     } else if (currentBuild.currentResult == "SUCCESS" && currentBuild.previousBuild.currentResult != "SUCCESS") {
-                        slackSend botUser: true,
-                            message: "`${JOB_NAME}` #${BUILD_NUMBER}: Back to normal after ${currentBuild.durationString.replace(' and counting', '')}\n${BUILD_URL}"
+                        slackSend message: "`${JOB_NAME}` #${BUILD_NUMBER}: Back to normal after ${currentBuild.durationString.replace(' and counting', '')}\n${BUILD_URL}"
                         emailext body: "See <${BUILD_URL}>",
                             subject: "Jenkins Build is back to normal: ${JOB_NAME} #${BUILD_NUMBER}", to: 'testeng@edx.org'
                     }

--- a/scripts/Jenkinsfiles/python
+++ b/scripts/Jenkinsfiles/python
@@ -188,6 +188,7 @@ pipeline {
                 if (env.ghprbPullId != null) {
                     // For PR jobs, run the edx-platform-test-notifier for PR reporting
                     build job: 'edx-platform-test-notifier', parameters: [string(name: 'PR_NUMBER', value: "${ghprbPullId}")], wait: false
+                    slackSend message: "`${JOB_NAME}` #${BUILD_NUMBER}: ${currentBuild.currentResult} after ${currentBuild.durationString.replace(' and counting', '')}\n${BUILD_URL}"
                 } else {
                     // For master jobs run github-build-status and report to slack when necessary
                     if (currentBuild.currentResult == "SUCCESS") {

--- a/scripts/Jenkinsfiles/quality
+++ b/scripts/Jenkinsfiles/quality
@@ -231,8 +231,7 @@ pipeline {
                             propagate: false, wait: false
 
                         if (currentBuild.currentResult != "SUCCESS"){
-                            slackSend botUser: true,
-                                message: "`${JOB_NAME}` #${BUILD_NUMBER}: ${currentBuild.currentResult} after ${currentBuild.durationString.replace(' and counting', '')}\n${BUILD_URL}"
+                            slackSend message: "`${JOB_NAME}` #${BUILD_NUMBER}: ${currentBuild.currentResult} after ${currentBuild.durationString.replace(' and counting', '')}\n${BUILD_URL}"
 
                             email_body = "See: <${BUILD_URL}>\n\nChanges:\n"
                             change_sets = currentBuild.changeSets
@@ -246,8 +245,7 @@ pipeline {
                             emailext body: email_body,
                                 subject: "Build failed in Jenkins: ${JOB_NAME} #${BUILD_NUMBER}", to: 'testeng@edx.org'
                         } else if (currentBuild.currentResult == "SUCCESS" && currentBuild.previousBuild.currentResult != "SUCCESS") {
-                            slackSend botUser: true,
-                                message: "`${JOB_NAME}` #${BUILD_NUMBER}: Back to normal after ${currentBuild.durationString.replace(' and counting', '')}\n${BUILD_URL}"
+                            slackSend message: "`${JOB_NAME}` #${BUILD_NUMBER}: Back to normal after ${currentBuild.durationString.replace(' and counting', '')}\n${BUILD_URL}"
                             emailext body: "See <${BUILD_URL}>",
                                 subject: "Jenkins Build is back to normal: ${JOB_NAME} #${BUILD_NUMBER}", to: 'testeng@edx.org'
                         }


### PR DESCRIPTION
I changed the `slackSend` configuration when we upgraded the plugin because it was throwing errors from a lack of named arguments. 

However, ever since then, even though the slack posts work, we see this error in the job log `ERROR: Could not parse response from slack, potentially because of invalid configuration (botUser: true and baseUrl set), response: ok`.

It's tough to know for sure if this will fix the error, since it only runs on master, but regardless I don't think we need to explicitly add this bot user setting anymore. I had falsely targeted that setting as the blame for the spigot notifier not working, but have debunked that.