### PR TITLE
Fix the program_enrollments admin classes.

### DIFF
--- a/lms/djangoapps/program_enrollments/admin.py
+++ b/lms/djangoapps/program_enrollments/admin.py
@@ -13,12 +13,20 @@ class ProgramEnrollmentAdmin(admin.ModelAdmin):
     """
     Admin tool for the ProgramEnrollment model
     """
+    list_display = ('id', 'user', 'external_user_key', 'program_uuid', 'curriculum_uuid', 'status')
+    list_filter = ('status',)
+    raw_id_fields = ('user',)
+    search_fields = ('user__username',)
 
 
 class ProgramCourseEnrollmentAdmin(admin.ModelAdmin):
     """
     Admin tool for the ProgramCourseEnrollment model
     """
+    list_display = ('id', 'program_enrollment', 'course_enrollment', 'course_key', 'status')
+    list_filter = ('course_key',)
+    raw_id_fields = ('program_enrollment', 'course_enrollment')
+
 
 admin.site.register(ProgramEnrollment, ProgramEnrollmentAdmin)
 admin.site.register(ProgramCourseEnrollment, ProgramCourseEnrollmentAdmin)

--- a/lms/djangoapps/program_enrollments/models.py
+++ b/lms/djangoapps/program_enrollments/models.py
@@ -70,6 +70,9 @@ class ProgramEnrollment(TimeStampedModel):  # pylint: disable=model-missing-unic
         enrollments.update(external_user_key=None)
         return True
 
+    def __str__(self):
+        return '[ProgramEnrollment id={}]'.format(self.id)
+
 
 class ProgramCourseEnrollment(TimeStampedModel):  # pylint: disable=model-missing-unicode
     """
@@ -95,3 +98,6 @@ class ProgramCourseEnrollment(TimeStampedModel):  # pylint: disable=model-missin
     course_key = CourseKeyField(max_length=255)
     status = models.CharField(max_length=9, choices=STATUSES)
     historical_records = HistoricalRecords()
+
+    def __str__(self):
+        return '[ProgramCourseEnrollment id={}]'.format(self.id)

--- a/lms/djangoapps/program_enrollments/tests/test_admin.py
+++ b/lms/djangoapps/program_enrollments/tests/test_admin.py
@@ -1,0 +1,39 @@
+"""
+Unit tests for the ProgramEnrollment admin classes.
+"""
+from __future__ import unicode_literals
+
+from django.contrib.admin.sites import AdminSite
+from django.test import TestCase
+import mock
+
+from lms.djangoapps.program_enrollments.admin import ProgramEnrollmentAdmin, ProgramCourseEnrollmentAdmin
+from lms.djangoapps.program_enrollments.models import ProgramEnrollment, ProgramCourseEnrollment
+
+
+class ProgramEnrollmentAdminTests(TestCase):
+    """
+    Unit tests for the ProgramEnrollments app.  This just gives us a little
+    protection against exposing high-cardinality fields as drop-downs, exposing
+    new fields, etc.
+    """
+    def setUp(self):
+        super(ProgramEnrollmentAdminTests, self).setUp()
+        self.program_admin = ProgramEnrollmentAdmin(ProgramEnrollment, AdminSite())
+        self.program_course_admin = ProgramCourseEnrollmentAdmin(ProgramCourseEnrollment, AdminSite())
+
+    def test_program_enrollment_admin(self):
+        request = mock.Mock()
+
+        expected_list_display = ('id', 'user', 'external_user_key', 'program_uuid', 'curriculum_uuid', 'status')
+        assert expected_list_display == self.program_admin.get_list_display(request)
+        expected_raw_id_fields = ('user',)
+        assert expected_raw_id_fields == self.program_admin.raw_id_fields
+
+    def test_program_course_enrollment_admin(self):
+        request = mock.Mock()
+
+        expected_list_display = ('id', 'program_enrollment', 'course_enrollment', 'course_key', 'status')
+        assert expected_list_display == self.program_course_admin.get_list_display(request)
+        expected_raw_id_fields = ('program_enrollment', 'course_enrollment')
+        assert expected_raw_id_fields == self.program_course_admin.raw_id_fields


### PR DESCRIPTION
https://openedx.atlassian.net/browse/EDUCATOR-4211

This restricts highly-populated fields in `ProgramEnrollment` and `ProgramCourseEnrollment` admins to only expose ids and not try to generate a selector across all values of the field.