### PR TITLE
avoid video url rewrite for third party videos

### DIFF
--- a/common/lib/xmodule/xmodule/video_module/video_module.py
+++ b/common/lib/xmodule/xmodule/video_module/video_module.py
@@ -225,6 +225,7 @@ class VideoModule(VideoFields, VideoTranscriptsMixin, VideoStudentViewHandlers, 
         branding_info = None
         youtube_streams = ""
         video_duration = None
+        video_status = None
 
         # Determine if there is an alternative source for this video
         # based on user locale.  This exists to support cases where
@@ -271,6 +272,7 @@ class VideoModule(VideoFields, VideoTranscriptsMixin, VideoStudentViewHandlers, 
                 # get video duration
                 video_data = edxval_api.get_video_info(self.edx_video_id.strip())
                 video_duration = video_data.get('duration')
+                video_status = video_data.get('status')
 
             except (edxval_api.ValInternalError, edxval_api.ValVideoNotFoundError):
                 # VAL raises this exception if it can't find data for the edx video ID. This can happen if the
@@ -285,7 +287,7 @@ class VideoModule(VideoFields, VideoTranscriptsMixin, VideoStudentViewHandlers, 
         if getattr(self, 'video_speed_optimizations', True) and cdn_url:
             branding_info = BrandingInfoConfig.get_config().get(self.system.user_location)
 
-            if self.edx_video_id and edxval_api:
+            if self.edx_video_id and edxval_api and video_status != u'external':
                 for index, source_url in enumerate(sources):
                     new_url = rewrite_video_url(cdn_url, source_url)
                     if new_url:


### PR DESCRIPTION
### [PROD-229](https://openedx.atlassian.net/browse/PROD-229)

### Description
edX's studio allows course creators to create the content that has a lot of diversity in the way it is presented to the end-users. Videos are one of such ways. By default, edX allows the course teams to upload their videos on the platform so that they go through the proper pipeline. However, the course team can skip that step and provide a URL to their video hosted on a third party site. This feature, however, didn't work as expected. The video URL re-write feature would not distinguish between the uploaded videos and videos from a third party and re-write the URL for the video from a third party. This, in turn, didn't play the video on the LMS. This bug was fixed in this PR(https://github.com/edx/edx-platform/pull/20173)

That fix worked but failed in the scenarios where the course team uploaded their transcripts for the videos hosted on a third party. Adding the transcripts generated a video ID for them, which created a corresponding VAL entry for such videos. The VAL entries were created with status **external**. Since there was a video ID, the re-write happened and incorrect URL was generated. As there was no video related to the new URL, the LMS showed **No Playable Video Source** error. This PR attempts to fix that problem by adding a check for external videos and avoid the URL re-write for them.


### Testing Instruction
 1. Visit the Studio link of the sandbox
 2. Add a video hosted on the third party vendor (the video must be playable on the studio). Don't add any transcript
 3. Publish the changes. View them on the LMS
 4. The video should play
 5. Now, edit that video on the studio, and add a transcript for it. A video id would generate by doing so.
 6. Publish the changes.
 7. View the changes on the LMS. The video and transcripts will work as expected.

### Sandbox
 - [Studio](https://studio-thirdparty.sandbox.edx.org/course/course-v1:ArbX+pd_229+2019_T1)
 - [LMS](https://thirdparty.sandbox.edx.org/courses/course-v1:ArbX+pd_229+2019_T1/course/)

### Reviewers
 - [x] @azarembok 
 - [ ] @fysheets 
 - [x] @awaisdar001 

### Post-Review
 - [ ] Squash & Rebase Commits