### PR TITLE
Fix time zone bug in send_verification_expiry_email

### DIFF
--- a/lms/djangoapps/verify_student/models.py
+++ b/lms/djangoapps/verify_student/models.py
@@ -13,10 +13,9 @@ import json
 import logging
 import os.path
 import uuid
-from datetime import datetime, timedelta
+from datetime import timedelta
 from email.utils import formatdate
 
-import pytz
 import requests
 import six
 from django.conf import settings
@@ -27,6 +26,7 @@ from django.urls import reverse
 from django.db import models
 from django.dispatch import receiver
 from django.utils.functional import cached_property
+from django.utils.timezone import now
 from django.utils.translation import ugettext_lazy
 from model_utils import Choices
 from model_utils.models import StatusModel, TimeStampedModel
@@ -138,7 +138,7 @@ class IDVerificationAttempt(StatusModel):
         """
         return (
             self.created_at < deadline and
-            self.expiration_datetime > datetime.now(pytz.UTC)
+            self.expiration_datetime > now()
         )
 
 
@@ -573,7 +573,7 @@ class SoftwareSecurePhotoVerification(PhotoVerification):
             status is set to `approved`
             expiry_date is set to one year from now
         """
-        self.expiry_date = datetime.now(pytz.UTC) + timedelta(
+        self.expiry_date = now() + timedelta(
             days=settings.VERIFY_STUDENT["DAYS_GOOD_FOR"]
         )
         super(SoftwareSecurePhotoVerification, self).approve(user_id, service)
@@ -675,7 +675,7 @@ class SoftwareSecurePhotoVerification(PhotoVerification):
         try:
             response = self.send_request(copy_id_photo_from=copy_id_photo_from)
             if response.ok:
-                self.submitted_at = datetime.now(pytz.UTC)
+                self.submitted_at = now()
                 self.status = "submitted"
                 self.save()
             else:

--- a/lms/djangoapps/verify_student/tests/test_signals.py
+++ b/lms/djangoapps/verify_student/tests/test_signals.py
@@ -2,9 +2,9 @@
 Unit tests for the VerificationDeadline signals
 """
 
-from datetime import datetime, timedelta
+from datetime import timedelta
 
-from pytz import UTC
+from django.utils.timezone import now
 
 from lms.djangoapps.verify_student.models import SoftwareSecurePhotoVerification, VerificationDeadline
 from lms.djangoapps.verify_student.signals import _listen_for_course_publish, _listen_for_lms_retire
@@ -22,7 +22,7 @@ class VerificationDeadlineSignalTest(ModuleStoreTestCase):
 
     def setUp(self):
         super(VerificationDeadlineSignalTest, self).setUp()
-        self.end = datetime.now(tz=UTC).replace(microsecond=0) + timedelta(days=7)
+        self.end = now().replace(microsecond=0) + timedelta(days=7)
         self.course = CourseFactory.create(end=self.end)
         VerificationDeadline.objects.all().delete()
 
@@ -34,7 +34,7 @@ class VerificationDeadlineSignalTest(ModuleStoreTestCase):
 
     def test_deadline(self):
         """ Verify deadline is set to course end date by signal when changed. """
-        deadline = datetime.now(tz=UTC) - timedelta(days=7)
+        deadline = now() - timedelta(days=7)
         VerificationDeadline.set_deadline(self.course.id, deadline)
 
         _listen_for_course_publish('store', self.course.id)
@@ -42,7 +42,7 @@ class VerificationDeadlineSignalTest(ModuleStoreTestCase):
 
     def test_deadline_explicit(self):
         """ Verify deadline is unchanged by signal when explicitly set. """
-        deadline = datetime.now(tz=UTC) - timedelta(days=7)
+        deadline = now() - timedelta(days=7)
         VerificationDeadline.set_deadline(self.course.id, deadline, is_explicit=True)
 
         _listen_for_course_publish('store', self.course.id)

--- a/lms/djangoapps/verify_student/tests/test_utils.py
+++ b/lms/djangoapps/verify_student/tests/test_utils.py
@@ -3,14 +3,14 @@
 Tests for verify_student utility functions.
 """
 
-from datetime import datetime, timedelta
+from datetime import timedelta
 
 import ddt
 import unittest
-import pytz
 from mock import patch
 from pytest import mark
 from django.conf import settings
+from django.utils import timezone
 from lms.djangoapps.verify_student.models import SoftwareSecurePhotoVerification, SSOVerification, ManualVerification
 from lms.djangoapps.verify_student.utils import verification_for_datetime, most_recent_verification
 from student.tests.factories import UserFactory
@@ -30,7 +30,7 @@ class TestVerifyStudentUtils(unittest.TestCase):
 
     def test_verification_for_datetime(self):
         user = UserFactory.create()
-        now = datetime.now(pytz.UTC)
+        now = timezone.now()
 
         # No attempts in the query set, so should return None
         query = SoftwareSecurePhotoVerification.objects.filter(user=user)
@@ -72,7 +72,7 @@ class TestVerifyStudentUtils(unittest.TestCase):
         # Immediately after the expiration date, should not get the attempt
         attempt.created_at = attempt.created_at - timedelta(days=settings.VERIFY_STUDENT["DAYS_GOOD_FOR"])
         attempt.save()
-        after = datetime.now(pytz.UTC) + timedelta(days=1)
+        after = now + timedelta(days=1)
         query = SoftwareSecurePhotoVerification.objects.filter(user=user)
         result = verification_for_datetime(after, query)
         self.assertIs(result, None)

--- a/lms/djangoapps/verify_student/utils.py
+++ b/lms/djangoapps/verify_student/utils.py
@@ -5,9 +5,9 @@ Common Utilities for the verify_student application.
 
 import datetime
 import logging
-import pytz
 
 from django.conf import settings
+from django.utils.timezone import now
 from sailthru import SailthruClient
 
 log = logging.getLogger(__name__)
@@ -18,7 +18,7 @@ def is_verification_expiring_soon(expiration_datetime):
     Returns True if verification is expiring within EXPIRING_SOON_WINDOW.
     """
     if expiration_datetime:
-        if (expiration_datetime - datetime.datetime.now(pytz.UTC)).days <= settings.VERIFY_STUDENT.get(
+        if (expiration_datetime - now()).days <= settings.VERIFY_STUDENT.get(
                 "EXPIRING_SOON_WINDOW"):
             return True
 
@@ -30,7 +30,7 @@ def earliest_allowed_verification_date():
     Returns the earliest allowed date given the settings
     """
     days_good_for = settings.VERIFY_STUDENT["DAYS_GOOD_FOR"]
-    return datetime.datetime.now(pytz.UTC) - datetime.timedelta(days=days_good_for)
+    return now() - datetime.timedelta(days=days_good_for)
 
 
 def verification_for_datetime(deadline, candidates):

--- a/lms/djangoapps/verify_student/views.py
+++ b/lms/djangoapps/verify_student/views.py
@@ -17,6 +17,7 @@ from django.http import Http404, HttpResponse, HttpResponseBadRequest
 from django.shortcuts import redirect
 from django.urls import reverse
 from django.utils.decorators import method_decorator
+from django.utils.timezone import now
 from django.utils.translation import ugettext as _
 from django.utils.translation import ugettext_lazy
 from django.views.decorators.csrf import csrf_exempt
@@ -27,7 +28,6 @@ from eventtracking import tracker
 from ipware.ip import get_ip
 from opaque_keys import InvalidKeyError
 from opaque_keys.edx.keys import CourseKey
-from pytz import UTC
 
 from course_modes.models import CourseMode
 from edxmako.shortcuts import render_to_response, render_to_string
@@ -376,7 +376,7 @@ class PayAndVerifyView(View):
                 current_step = display_steps[current_step_idx + 1]['name']
 
         courseware_url = ""
-        if not course.start or course.start < datetime.datetime.today().replace(tzinfo=UTC):
+        if not course.start or course.start < now():
             courseware_url = reverse(
                 'course_root',
                 kwargs={'course_id': unicode(course_key)}
@@ -716,7 +716,7 @@ class PayAndVerifyView(View):
 
         deadline_passed = (
             deadline_datetime is not None and
-            deadline_datetime < datetime.datetime.now(UTC)
+            deadline_datetime < now()
         )
         if deadline_passed:
             context = {


### PR DESCRIPTION
So those tests failed again ([here](https://build.testeng.edx.org/job/edx-platform-python-pipeline-pr/4502/) and [here](https://build.testeng.edx.org/job/edx-platform-python-pipeline-master/508/), for example).  I figured out how to fake the time of failure in devstack (instructions [here](https://openedx.atlassian.net/wiki/spaces/TE/pages/884998163/Debugging+test+failures+with+pytest-xdist)).  The key change is in `send_verification_expiry_email.py`, the rest is just cleanup for simplicity and consistency.  I switched the logic from "use midnight UTC of the day specified" to "use midnight in local time of the day specified" as the query endpoints (Django uses UTC in the database, but local time for most date calculations at the Python level).  I'm pretty sure this fixes the tests, and seems like it should better match the user's expectations, but want some validation from someone who worked on it that this doesn't cause any problems.