### PR TITLE
[WIP] add first purchase offer banner on course home

### DIFF
--- a/lms/static/sass/features/_course-experience.scss
+++ b/lms/static/sass/features/_course-experience.scss
@@ -20,6 +20,23 @@
   }
 }
 
+// First purchase offer banner
+.first-purchase-offer-banner {
+  background-color: #DEE3F1;
+  font-size: 16px;
+  border-radius: 7px;
+  padding: 20px;
+  margin: 20px auto;
+
+  .first-purchase-offer-banner-bold {
+      font-weight: bold;
+      color: #23419F;
+      margin-right: 3px;
+      margin-left: 5px;
+  }
+
+}
+
 // Course call to action message
 .course-message {
   display: flex;

--- a/openedx/features/course_experience/__init__.py
+++ b/openedx/features/course_experience/__init__.py
@@ -47,6 +47,10 @@ USE_BOOTSTRAP_FLAG = CourseWaffleFlag(WAFFLE_FLAG_NAMESPACE, 'use_bootstrap', fl
 SEO_WAFFLE_FLAG_NAMESPACE = WaffleFlagNamespace(name='seo')
 COURSE_ENABLE_UNENROLLED_ACCESS_FLAG = CourseWaffleFlag(SEO_WAFFLE_FLAG_NAMESPACE, 'enable_anonymous_courseware_access')
 
+# Flag to control display of first purchase offer banner
+FIRST_PURCHASE_OFFER_BANNER = WaffleFlagNamespace(name='first_purchase_offer_banner')
+FIRST_PURCHASE_OFFER_BANNER_DISPLAY = WaffleFlag(FIRST_PURCHASE_OFFER_BANNER, 'display', flag_undefined_default=False)
+
 
 def course_home_page_title(course):  # pylint: disable=unused-argument
     """

--- a/openedx/features/course_experience/templates/course_experience/course-home-fragment.html
+++ b/openedx/features/course_experience/templates/course_experience/course-home-fragment.html
@@ -81,6 +81,9 @@ from openedx.features.portfolio_project import INCLUDE_PORTFOLIO_UPSELL_MODAL
     </header>
     <div class="page-content">
         <div class="page-content-main">
+            % if offer_banner_fragment:
+                ${HTML(offer_banner_fragment.content)}
+            % endif
             % if course_expiration_fragment:
                 ${HTML(course_expiration_fragment.content)}
             % endif

--- a/openedx/features/course_experience/utils.py
+++ b/openedx/features/course_experience/utils.py
@@ -2,11 +2,15 @@
 Common utilities for the course experience, including course outline.
 """
 from completion.models import BlockCompletion
+from django.utils.translation import ugettext as _
 
 from lms.djangoapps.course_api.blocks.api import get_blocks
 from lms.djangoapps.course_blocks.utils import get_student_module_as_dict
 from opaque_keys.edx.keys import CourseKey
+from openedx.core.djangolib.markup import HTML
 from openedx.core.lib.cache_utils import request_cached
+from openedx.features.course_experience import FIRST_PURCHASE_OFFER_BANNER_DISPLAY
+from web_fragments.fragment import Fragment
 from xmodule.modulestore.django import modulestore
 
 
@@ -182,3 +186,17 @@ def get_resume_block(block):
         if resume_block:
             return resume_block
     return block
+
+
+def get_first_purchase_offer_banner_fragment(user, course):
+    if FIRST_PURCHASE_OFFER_BANNER_DISPLAY.is_enabled() and user and course:
+        # Translator: xgettext:no-python-format
+        offer_message = _(u'{banner_open}15% off your first upgrade.{span_close}'
+                          u' Discount automatically applied.{div_close}')
+        return Fragment(HTML(offer_message).format(
+            banner_open=HTML(
+                '<div class="first-purchase-offer-banner"><span class="first-purchase-offer-banner-bold">'
+            ),
+            span_close=HTML('</span>'),
+            div_close=HTML('</div>')
+        ))

--- a/openedx/features/course_experience/views/course_home.py
+++ b/openedx/features/course_experience/views/course_home.py
@@ -31,6 +31,7 @@ from openedx.core.djangoapps.plugin_api.views import EdxFragmentView
 from openedx.core.djangoapps.util.maintenance_banner import add_maintenance_banner
 from openedx.features.course_duration_limits.access import generate_course_expired_fragment
 from openedx.features.course_experience.course_tools import CourseToolsPluginManager
+from openedx.features.course_experience.utils import get_first_purchase_offer_banner_fragment
 from student.models import CourseEnrollment
 from util.views import ensure_valid_course_key
 from xmodule.course_module import COURSE_VISIBILITY_PUBLIC, COURSE_VISIBILITY_PUBLIC_OUTLINE
@@ -139,6 +140,7 @@ class CourseHomeFragmentView(EdxFragmentView):
         outline_fragment = None
         update_message_fragment = None
         course_sock_fragment = None
+        offer_banner_fragment = None
         course_expiration_fragment = None
         has_visited_course = None
         resume_course_url = None
@@ -159,9 +161,14 @@ class CourseHomeFragmentView(EdxFragmentView):
             course_sock_fragment = CourseSockFragmentView().render_to_fragment(request, course=course, **kwargs)
             has_visited_course, resume_course_url = self._get_resume_course_info(request, course_id)
             handouts_html = self._get_course_handouts(request, course)
+            course_overview = CourseOverview.get_from_id(course.id)
+            offer_banner_fragment = get_first_purchase_offer_banner_fragment(
+                request.user,
+                course_overview
+            )
             course_expiration_fragment = generate_course_expired_fragment(
                 request.user,
-                CourseOverview.get_from_id(course.id)
+                course_overview
             )
         elif allow_public_outline or allow_public:
             outline_fragment = CourseOutlineFragmentView().render_to_fragment(
@@ -212,6 +219,7 @@ class CourseHomeFragmentView(EdxFragmentView):
             'outline_fragment': outline_fragment,
             'handouts_html': handouts_html,
             'course_home_message_fragment': course_home_message_fragment,
+            'offer_banner_fragment': offer_banner_fragment,
             'course_expiration_fragment': course_expiration_fragment,
             'has_visited_course': has_visited_course,
             'resume_course_url': resume_course_url,


### PR DESCRIPTION
WIP PR for this ticket https://openedx.atlassian.net/browse/REVMI-170

I haven't yet done a full review of Emma's PR, but I structured/named things here a bit differently to facilitate a conversation around how we want to structure the code in the lms. Although it doesn't really matter for the implementation, understanding how we envision this code should help us ensure there is less confusion down the line about when to use what type of discount due to the code. Since I have more limited context than others, some questions below.

1. Are we intending for the lms portion of the first purchase offer code to be a model for how we do many discounts going forward? Or is it mostly just handling this special case? I got the impression from Gabe that it was the latter.  
If the former, I'd agree with making a discounts app but I'd probably put the actual code in a first_purchase_offer.py file to differentiate it from other types of discounts. 
If the latter, I would probably not make a separate djangoapp.

 
2. Are we intending for the discount banner to primarily be used in course-related pages in the lms?  
If we're not building a new way to do discounts and we're using the banner on course home/courseware etc... I might put the code in course_experience like other upgrade features such as the sock and more complex features like the outline.
If we wanted to use the banner on the dashboard for example, then course_experience would probably be not appropriate