### PR TITLE
Add support for version 4 of RPNow for proctoring

### DIFF
--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -119,13 +119,13 @@ edx-oauth2-provider==1.2.2
 edx-opaque-keys[django]==0.4.4
 edx-organizations==1.0.1
 edx-proctoring-proctortrack==1.0.5
-edx-proctoring==1.6.2
+edx-proctoring==1.7.1
 edx-rbac==0.1.11          # via edx-enterprise
 edx-rest-api-client==1.9.2
 edx-search==1.2.2
 edx-submissions==2.1.1
 edx-user-state-client==1.0.4
-edx-when==0.1.2
+edx-when==0.1.4
 edxval==1.1.25
 elasticsearch==1.9.0      # via edx-search
 enum34==1.1.6

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -141,14 +141,14 @@ edx-oauth2-provider==1.2.2
 edx-opaque-keys[django]==0.4.4
 edx-organizations==1.0.1
 edx-proctoring-proctortrack==1.0.5
-edx-proctoring==1.6.2
+edx-proctoring==1.7.1
 edx-rbac==0.1.11
 edx-rest-api-client==1.9.2
 edx-search==1.2.2
 edx-sphinx-theme==1.4.0
 edx-submissions==2.1.1
 edx-user-state-client==1.0.4
-edx-when==0.1.2
+edx-when==0.1.4
 edxval==1.1.25
 elasticsearch==1.9.0
 entrypoints==0.3

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -137,13 +137,13 @@ edx-oauth2-provider==1.2.2
 edx-opaque-keys[django]==0.4.4
 edx-organizations==1.0.1
 edx-proctoring-proctortrack==1.0.5
-edx-proctoring==1.6.2
+edx-proctoring==1.7.1
 edx-rbac==0.1.11
 edx-rest-api-client==1.9.2
 edx-search==1.2.2
 edx-submissions==2.1.1
 edx-user-state-client==1.0.4
-edx-when==0.1.2
+edx-when==0.1.4
 edxval==1.1.25
 elasticsearch==1.9.0
 entrypoints==0.3          # via flake8


### PR DESCRIPTION
Adds a waffle switch edx_proctoring.rpnowv4_flow which gates several
learner workflow changes which will need to be applied at the time we
cut over a platform to using RPNow version 4 rather than version 2.

JIRA:EDUCATOR-3765