### PR TITLE
Remove extra quotation mark from template

### DIFF
--- a/lms/templates/verify_student/edx_ace/verificationexpiry/email/body.html
+++ b/lms/templates/verify_student/edx_ace/verificationexpiry/email/body.html
@@ -12,7 +12,7 @@
             <p style="color: rgba(0,0,0,.75);">
                 {% blocktrans %}Hello {{full_name}},{% endblocktrans %}
                 <br />
-                {% blocktrans %}Your {{platform_name}} ID verification has expired." {% endblocktrans %}
+                {% blocktrans %}Your {{platform_name}} ID verification has expired. {% endblocktrans %}
                 <br />
             </p>
             <p style="color: rgba(0,0,0,.75);">


### PR DESCRIPTION
There is an extra quotation mark at the end of verification expiry email. 