### PR TITLE
Fix text alignment for word-break

### DIFF
--- a/lms/static/sass/course/base/_base.scss
+++ b/lms/static/sass/course/base/_base.scss
@@ -58,6 +58,7 @@ table {
 
 .xblock table {
   table-layout: auto;
+  word-break: normal;
 }
 
 a {

--- a/lms/static/sass/course/courseware/_courseware.scss
+++ b/lms/static/sass/course/courseware/_courseware.scss
@@ -136,7 +136,6 @@ html.video-fullscreen {
     .xblock {
       overflow-wrap: break-word;
       word-wrap: break-word;
-      word-break: break-word;
       margin: 0 auto;
       font: -apple-system-body;
 


### PR DESCRIPTION
Recent google chrome updates showing awkard alignments on table.To
avoid them modifications in word-break css property are carried out
so that usability of content remains coherent on all browsers.

PROD-185