### PR TITLE
add program course enrollment PATCH

### DIFF
--- a/lms/djangoapps/program_enrollments/api/v1/constants.py
+++ b/lms/djangoapps/program_enrollments/api/v1/constants.py
@@ -18,6 +18,7 @@ class CourseEnrollmentResponseStatuses(object):
     CONFLICT = "conflict"
     ILLEGAL_OPERATION = "illegal-operation"
     NOT_IN_PROGRAM = "not-in-program"
+    NOT_FOUND = "not-found"
     INTERNAL_ERROR = "internal-error"
 
     ERROR_STATUSES = (
@@ -26,5 +27,6 @@ class CourseEnrollmentResponseStatuses(object):
         CONFLICT,
         ILLEGAL_OPERATION,
         NOT_IN_PROGRAM,
+        NOT_FOUND,
         INTERNAL_ERROR,
     )

--- a/lms/djangoapps/program_enrollments/tests/test_models.py
+++ b/lms/djangoapps/program_enrollments/tests/test_models.py
@@ -4,11 +4,14 @@ Unit tests for ProgramEnrollment models.
 from __future__ import unicode_literals
 
 from uuid import uuid4
+from testfixtures import LogCapture
 
 from django.test import TestCase
+from opaque_keys.edx.keys import CourseKey
 
-from lms.djangoapps.program_enrollments.models import ProgramEnrollment
-from student.tests.factories import UserFactory
+from lms.djangoapps.program_enrollments.models import ProgramEnrollment, ProgramCourseEnrollment
+from student.tests.factories import UserFactory, CourseEnrollmentFactory
+from openedx.core.djangoapps.catalog.tests.factories import generate_course_run_key
 
 
 class ProgramEnrollmentModelTests(TestCase):
@@ -97,3 +100,58 @@ class ProgramEnrollmentModelTests(TestCase):
         self.assertTrue(self.enrollment.historical_records.all())
         for record in self.enrollment.historical_records.all():
             self.assertEquals(record.external_user_key, None)
+
+
+class ProgramCourseEnrollmentModelTests(TestCase):
+    """
+    Tests for the ProgramCourseEnrollment model.
+    """
+    def setUp(self):
+        """
+        Set up test data
+        """
+        super(ProgramCourseEnrollmentModelTests, self).setUp()
+        self.user = UserFactory.create()
+        self.program_uuid = uuid4()
+        self.program_enrollment = ProgramEnrollment.objects.create(
+            user=self.user,
+            external_user_key='abc',
+            program_uuid=self.program_uuid,
+            curriculum_uuid=uuid4(),
+            status='enrolled'
+        )
+        self.course_key = CourseKey.from_string(generate_course_run_key())
+        self.course_enrollment = CourseEnrollmentFactory.create(
+            course_id=self.course_key,
+            user=self.user,
+        )
+        self.program_course_enrollment = ProgramCourseEnrollment.objects.create(
+            program_enrollment=self.program_enrollment,
+            course_key=self.course_key,
+            course_enrollment=self.course_enrollment,
+            status="active"
+        )
+
+    def test_change_status_no_enrollment(self):
+        with LogCapture() as capture:
+            self.program_course_enrollment.course_enrollment = None
+            self.program_course_enrollment.change_status("inactive")
+            expected_message = "User {} {} {} has no course_enrollment".format(
+                self.user,
+                self.program_enrollment,
+                self.course_key
+            )
+            capture.check(
+                ('lms.djangoapps.program_enrollments.models', 'WARNING', expected_message)
+            )
+
+    def test_change_status_not_active_or_inactive(self):
+        with LogCapture() as capture:
+            status = "potential-future-status-0123"
+            self.program_course_enrollment.change_status(status)
+            message = ("Changed {} status to {}, not changing course_enrollment"
+                       " status because status is not 'active' or 'inactive'")
+            expected_message = message.format(self.program_course_enrollment, status)
+            capture.check(
+                ('lms.djangoapps.program_enrollments.models', 'WARNING', expected_message)
+            )


### PR DESCRIPTION
refactor `post` into a shared `process_enrollment_list_request` method, allowing post and patch to share behavior up to the point where we actually perform an operation.

I did a similar thing to the tests as well, creating a new `BaseCourseEnrollmentTestsMixin` for shared tests between the two methods