### PR TITLE
Make copyright year dynamic

### DIFF
--- a/lms/djangoapps/bulk_email/tasks.py
+++ b/lms/djangoapps/bulk_email/tasks.py
@@ -29,10 +29,10 @@ from celery import current_task, task
 from celery.exceptions import RetryTaskError
 from celery.states import FAILURE, RETRY, SUCCESS
 from django.conf import settings
-from django.contrib.auth.models import User
 from django.core.mail import EmailMultiAlternatives, get_connection
 from django.core.mail.message import forbid_multi_line_headers
 from django.urls import reverse
+from django.utils import timezone
 from django.utils.translation import override as override_language
 from django.utils.translation import ugettext as _
 from markupsafe import escape
@@ -118,6 +118,7 @@ def _get_course_email_context(course):
         'account_settings_url': '{}{}'.format(settings.LMS_ROOT_URL, reverse('account_settings')),
         'email_settings_url': '{}{}'.format(settings.LMS_ROOT_URL, reverse('dashboard')),
         'platform_name': configuration_helpers.get_value('PLATFORM_NAME', settings.PLATFORM_NAME),
+        'year': timezone.now().year,
     }
     return email_context
 


### PR DESCRIPTION
### Description

[PROD-106](https://openedx.atlassian.net/browse/PROD-106)

Currently, course email templates have hard-coded copyright year.Marketing team needs to ping engineering to update it every year.In this PR, steps are taken to make it dynamic.