### PR TITLE
Upgrade to django-pipeline 1.6.14

### DIFF
--- a/cms/djangoapps/pipeline_js/utils.py
+++ b/cms/djangoapps/pipeline_js/utils.py
@@ -10,7 +10,7 @@ def get_xmodule_urls():
     """
     Returns a list of the URLs to hit to grab all the XModule JS
     """
-    pipeline_js_settings = settings.PIPELINE_JS["module-js"]
+    pipeline_js_settings = settings.PIPELINE['JAVASCRIPT']["module-js"]
     if settings.DEBUG:
         paths = [path.replace(".coffee", ".js") for path in pipeline_js_settings["source_filenames"]]
     else:

--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -702,7 +702,18 @@ EMBARGO_SITE_REDIRECT_URL = None
 
 ############################### PIPELINE #######################################
 
-PIPELINE_ENABLED = True
+PIPELINE = {
+    'PIPELINE_ENABLED': True,
+    # Don't use compression by default
+    'CSS_COMPRESSOR': None,
+    'JS_COMPRESSOR': None,
+    # Don't wrap JavaScript as there is code that depends upon updating the global namespace
+    'DISABLE_WRAPPER': True,
+    # Specify the UglifyJS binary to use
+    'UGLIFYJS_BINARY': 'node_modules/.bin/uglifyjs',
+    'COMPILERS': (),
+    'YUI_BINARY': 'yui-compressor',
+}
 
 STATICFILES_STORAGE = 'openedx.core.storage.ProductionStorage'
 
@@ -716,19 +727,9 @@ STATICFILES_FINDERS = [
     'pipeline.finders.PipelineFinder',
 ]
 
-# Don't use compression by default
-PIPELINE_CSS_COMPRESSOR = None
-PIPELINE_JS_COMPRESSOR = 'pipeline.compressors.uglifyjs.UglifyJSCompressor'
-
-# Don't wrap JavaScript as there is code that depends upon updating the global namespace
-PIPELINE_DISABLE_WRAPPER = True
-
-# Specify the UglifyJS binary to use
-PIPELINE_UGLIFYJS_BINARY = 'node_modules/.bin/uglifyjs'
-
 from openedx.core.lib.rooted_paths import rooted_glob
 
-PIPELINE_CSS = {
+PIPELINE['STYLESHEETS'] = {
     'style-vendor': {
         'source_filenames': [
             'css/vendor/normalize.css',
@@ -826,7 +827,7 @@ base_vendor_js = [
 
 # test_order: Determines the position of this chunk of javascript on
 # the jasmine test page
-PIPELINE_JS = {
+PIPELINE['JAVASCRIPT'] = {
     'base_vendor': {
         'source_filenames': base_vendor_js,
         'output_filename': 'js/cms-base-vendor.js',
@@ -841,10 +842,6 @@ PIPELINE_JS = {
         'test_order': 1
     },
 }
-
-PIPELINE_COMPILERS = ()
-PIPELINE_CSS_COMPRESSOR = None
-PIPELINE_JS_COMPRESSOR = None
 
 STATICFILES_IGNORE_PATTERNS = (
     "*.py",
@@ -867,8 +864,6 @@ STATICFILES_IGNORE_PATTERNS = (
     "xmodule_js",
     "common_static",
 )
-
-PIPELINE_YUI_BINARY = 'yui-compressor'
 
 ################################# DJANGO-REQUIRE ###############################
 

--- a/cms/envs/devstack.py
+++ b/cms/envs/devstack.py
@@ -40,7 +40,7 @@ FEATURES['PREVIEW_LMS_BASE'] = "preview." + LMS_BASE
 ########################### PIPELINE #################################
 
 # Skip packaging and optimization in development
-PIPELINE_ENABLED = False
+PIPELINE['PIPELINE_ENABLED'] = False
 STATICFILES_STORAGE = 'openedx.core.storage.DevelopmentStorage'
 
 # Revert to the default set of finders as we don't want the production pipeline

--- a/common/djangoapps/pipeline_mako/__init__.py
+++ b/common/djangoapps/pipeline_mako/__init__.py
@@ -10,7 +10,7 @@ from django.contrib.staticfiles.storage import staticfiles_storage
 
 
 def compressed_css(package_name, raw=False):
-    package = settings.PIPELINE_CSS.get(package_name, {})
+    package = settings.STYLESHEETS.get(package_name, {})
     if package:
         package = {package_name: package}
     packager = Packager(css_packages=package, js_packages={})
@@ -44,7 +44,7 @@ def render_individual_css(package, paths, raw=False):
 
 
 def compressed_js(package_name):
-    package = settings.PIPELINE_JS.get(package_name, {})
+    package = settings.JAVASCRIPT.get(package_name, {})
     if package:
         package = {package_name: package}
     packager = Packager(css_packages={}, js_packages=package)

--- a/common/djangoapps/pipeline_mako/templates/static_content.html
+++ b/common/djangoapps/pipeline_mako/templates/static_content.html
@@ -50,24 +50,24 @@ except:
   <%
       rtl_group = '{}-rtl'.format(group)
 
-      if get_language_bidi() and rtl_group in settings.PIPELINE_CSS:
+      if get_language_bidi() and rtl_group in settings.PIPELINE['STYLESHEETS']:
         group = rtl_group
   %>
 
-  % if settings.PIPELINE_ENABLED:
+  % if settings.PIPELINE['PIPELINE_ENABLED']:
     ${compressed_css(group, raw=raw) | n, decode.utf8}
   % else:
-    % for filename in settings.PIPELINE_CSS[group]['source_filenames']:
+    % for filename in settings.PIPELINE['STYLESHEETS'][group]['source_filenames']:
       <link rel="stylesheet" href="${staticfiles_storage.url(filename.replace('.scss', '.css'))}${"?raw" if raw else ""}" type="text/css" media="all" / >
     % endfor
   %endif
 </%def>
 
 <%def name='js(group)'>
-  % if settings.PIPELINE_ENABLED:
+  % if settings.PIPELINE['PIPELINE_ENABLED']:
     ${compressed_js(group) | n, decode.utf8}
   % else:
-    % for filename in settings.PIPELINE_JS[group]['source_filenames']:
+    % for filename in settings.PIPELINE['JAVASCRIPT'][group]['source_filenames']:
       <script type="text/javascript" src="${staticfiles_storage.url(filename.replace('.coffee', '.js'))}"></script>
     % endfor
   %endif

--- a/common/djangoapps/pipeline_mako/tests/test_render.py
+++ b/common/djangoapps/pipeline_mako/tests/test_render.py
@@ -58,7 +58,9 @@ class PipelineRenderTest(TestCase):
         Verify the behavior of compressed_css, with the pipeline
         both enabled and disabled.
         """
-        with self.settings(PIPELINE_ENABLED=pipeline_enabled):
+        pipeline = settings.PIPELINE.copy()
+        pipeline['PIPELINE_ENABLED'] = pipeline_enabled
+        with self.settings(PIPELINE=pipeline):
             # Verify the default behavior
             css_include = compressed_css('style-main-v1')
             self.assertIn(u'lms-main-v1.css', css_include)
@@ -74,12 +76,15 @@ class PipelineRenderTest(TestCase):
         Verify the behavior of compressed_css, with the pipeline
         both enabled and disabled.
         """
+        pipeline = settings.PIPELINE.copy()
         # Verify that a single JS file is rendered with the pipeline enabled
-        with self.settings(PIPELINE_ENABLED=True):
+        pipeline['PIPELINE_ENABLED'] = True
+        with self.settings(PIPELINE=pipeline):
             js_include = compressed_js('base_application')
             self.assertIn(u'lms-base-application.js', js_include)
 
         # Verify that multiple JS files are rendered with the pipeline disabled
-        with self.settings(PIPELINE_ENABLED=False):
+        pipeline['PIPELINE_ENABLED'] = False
+        with self.settings(PIPELINE=pipeline):
             js_include = compressed_js('base_application')
             self.assertIn(u'/static/js/src/logger.js', js_include)

--- a/lms/djangoapps/branding/views.py
+++ b/lms/djangoapps/branding/views.py
@@ -105,7 +105,7 @@ def _footer_css_urls(request, package_name):
     # to identify the CSS file name(s) to include in the footer.
     # We then construct an absolute URI so that external sites (such as the marketing site)
     # can locate the assets.
-    package = settings.PIPELINE_CSS.get(package_name, {})
+    package = settings.PIPELINE['STYLESHEETS'].get(package_name, {})
     paths = [package['output_filename']] if not settings.DEBUG else package['source_filenames']
     return [
         _footer_static_url(request, path)

--- a/lms/envs/bok_choy.py
+++ b/lms/envs/bok_choy.py
@@ -80,7 +80,7 @@ MEDIA_ROOT = TEST_ROOT / "uploads"
 WEBPACK_LOADER['DEFAULT']['STATS_FILE'] = TEST_ROOT / "staticfiles" / "lms" / "webpack-stats.json"
 
 # Don't use compression during tests
-PIPELINE_JS_COMPRESSOR = None
+PIPELINE['JS_COMPRESSOR'] = None
 
 ################################# CELERY ######################################
 

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -1336,7 +1336,15 @@ P3P_HEADER = 'CP="Open EdX does not have a P3P policy."'
 
 ############################### PIPELINE #######################################
 
-PIPELINE_ENABLED = True
+PIPELINE = {
+    'PIPELINE_ENABLED': True,
+    'CSS_COMPRESSOR': None,
+    'JS_COMPRESSOR': 'pipeline.compressors.uglifyjs.UglifyJSCompressor',
+    # Don't wrap JavaScript as there is code that depends upon updating the global namespace
+    'DISABLE_WRAPPER': True,
+    # Specify the UglifyJS binary to use
+    'UGLIFYJS_BINARY': 'node_modules/.bin/uglifyjs',
+}
 
 STATICFILES_STORAGE = 'openedx.core.storage.ProductionStorage'
 
@@ -1349,15 +1357,6 @@ STATICFILES_FINDERS = [
     'openedx.core.lib.xblock_pipeline.finder.XBlockPipelineFinder',
     'pipeline.finders.PipelineFinder',
 ]
-
-PIPELINE_CSS_COMPRESSOR = None
-PIPELINE_JS_COMPRESSOR = 'pipeline.compressors.uglifyjs.UglifyJSCompressor'
-
-# Don't wrap JavaScript as there is code that depends upon updating the global namespace
-PIPELINE_DISABLE_WRAPPER = True
-
-# Specify the UglifyJS binary to use
-PIPELINE_UGLIFYJS_BINARY = 'node_modules/.bin/uglifyjs'
 
 from openedx.core.lib.rooted_paths import rooted_glob
 
@@ -1504,7 +1503,7 @@ credit_web_view_js = [
     'js/src/logger.js',
 ]
 
-PIPELINE_CSS = {
+PIPELINE['STYLESHEETS'] = {
     'style-vendor': {
         'source_filenames': [
             'css/vendor/font-awesome.css',
@@ -1678,7 +1677,7 @@ lms_application_js = [
     'js/main.js',
 ]
 
-PIPELINE_JS = {
+PIPELINE['JAVASCRIPT'] = {
     'base_application': {
         'source_filenames': base_application_js,
         'output_filename': 'js/lms-base-application.js',

--- a/lms/envs/devstack.py
+++ b/lms/envs/devstack.py
@@ -99,7 +99,7 @@ FEATURES['ENABLE_API_DOCS'] = True
 
 ########################### PIPELINE #################################
 
-PIPELINE_ENABLED = False
+PIPELINE['PIPELINE_ENABLED'] = False
 STATICFILES_STORAGE = 'openedx.core.storage.DevelopmentStorage'
 
 # Revert to the default set of finders as we don't want the production pipeline
@@ -110,12 +110,12 @@ STATICFILES_FINDERS = [
 ]
 
 # Disable JavaScript compression in development
-PIPELINE_JS_COMPRESSOR = None
+PIPELINE['JS_COMPRESSOR'] = None
 
 # Whether to run django-require in debug mode.
 REQUIRE_DEBUG = DEBUG
 
-PIPELINE_SASS_ARGUMENTS = '--debug-info'
+PIPELINE['SASS_ARGUMENTS'] = '--debug-info'
 
 # Load development webpack donfiguration
 WEBPACK_CONFIG_PATH = 'webpack.dev.config.js'

--- a/lms/envs/test.py
+++ b/lms/envs/test.py
@@ -145,7 +145,7 @@ STATICFILES_DIRS += [
 STATICFILES_STORAGE = 'pipeline.storage.NonPackagingPipelineStorage'
 
 # Don't use compression during tests
-PIPELINE_JS_COMPRESSOR = None
+PIPELINE['JS_COMPRESSOR'] = None
 
 update_module_store_settings(
     MODULESTORE,

--- a/openedx/core/djangoapps/plugin_api/views.py
+++ b/openedx/core/djangoapps/plugin_api/views.py
@@ -23,26 +23,26 @@ class EdxFragmentView(FragmentView):
     @staticmethod
     def get_css_dependencies(group):
         """
-        Returns list of CSS dependencies belonging to `group` in settings.PIPELINE_JS.
+        Returns list of CSS dependencies belonging to `group` in settings.PIPELINE['JAVASCRIPT'].
 
-        Respects `PIPELINE_ENABLED` setting.
+        Respects `PIPELINE['PIPELINE_ENABLED']` setting.
         """
-        if settings.PIPELINE_ENABLED:
-            return [settings.PIPELINE_CSS[group]['output_filename']]
+        if settings.PIPELINE['PIPELINE_ENABLED']:
+            return [settings.PIPELINE['STYLESHEETS'][group]['output_filename']]
         else:
-            return settings.PIPELINE_CSS[group]['source_filenames']
+            return settings.PIPELINE['STYLESHEETS'][group]['source_filenames']
 
     @staticmethod
     def get_js_dependencies(group):
         """
-        Returns list of JS dependencies belonging to `group` in settings.PIPELINE_JS.
+        Returns list of JS dependencies belonging to `group` in settings.PIPELINE['JAVASCRIPT'].
 
-        Respects `PIPELINE_ENABLED` setting.
+        Respects `PIPELINE['PIPELINE_ENABLED']` setting.
         """
-        if settings.PIPELINE_ENABLED:
-            return [settings.PIPELINE_JS[group]['output_filename']]
+        if settings.PIPELINE['PIPELINE_ENABLED']:
+            return [settings.PIPELINE['JAVASCRIPT'][group]['output_filename']]
         else:
-            return settings.PIPELINE_JS[group]['source_filenames']
+            return settings.PIPELINE['JAVASCRIPT'][group]['source_filenames']
 
     def vendor_js_dependencies(self):
         """

--- a/openedx/core/djangoapps/theming/storage.py
+++ b/openedx/core/djangoapps/theming/storage.py
@@ -275,7 +275,7 @@ class ThemePipelineMixin(PipelineMixin):
         themes = get_themes()
 
         for theme in themes:
-            css_packages = self.get_themed_packages(theme.theme_dir_name, settings.PIPELINE_CSS)
+            css_packages = self.get_themed_packages(theme.theme_dir_name, settings.PIPELINE['STYLESHEETS'])
 
             from pipeline.packager import Packager
             packager = Packager(storage=self, css_packages=css_packages)

--- a/openedx/core/djangoapps/theming/templatetags/theme_pipeline.py
+++ b/openedx/core/djangoapps/theming/templatetags/theme_pipeline.py
@@ -57,7 +57,7 @@ def stylesheet(parser, token):  # pylint: disable=unused-argument
         _, name = token.split_contents()
     except ValueError:
         raise template.TemplateSyntaxError(
-            u'%r requires exactly one argument: the name of a group in the PIPELINE_CSS setting' %
+            u'%r requires exactly one argument: the name of a group in the PIPELINE["STYLESHEETS"] setting' %
             token.split_contents()[0]
         )
     return ThemeStylesheetNode(name)
@@ -72,7 +72,7 @@ def javascript(parser, token):  # pylint: disable=unused-argument
         _, name = token.split_contents()
     except ValueError:
         raise template.TemplateSyntaxError(
-            u'%r requires exactly one argument: the name of a group in the PIPELINE_JS setting' %
+            u'%r requires exactly one argument: the name of a group in the PIPELINE["JAVASCRIPT"] setting' %
             token.split_contents()[0]
         )
     return ThemeJavascriptNode(name)

--- a/openedx/core/lib/tests/test_xblock_utils.py
+++ b/openedx/core/lib/tests/test_xblock_utils.py
@@ -6,6 +6,7 @@ from __future__ import absolute_import, unicode_literals
 import uuid
 
 import ddt
+from django.conf import settings
 from django.test.client import RequestFactory
 from mock import patch
 from web_fragments.fragment import Fragment
@@ -194,13 +195,15 @@ class TestXblockUtils(SharedModuleStoreTestCase):
         """
         Verify that `get_css_dependencies` returns correct list of files.
         """
-        pipeline_css = {
+        pipeline = settings.PIPELINE.copy()
+        pipeline['PIPELINE_ENABLED'] = pipeline_enabled
+        pipeline['STYLESHEETS'] = {
             'style-group': {
                 'source_filenames': ["a.css", "b.css", "c.css"],
                 'output_filename': "combined.css"
             }
         }
-        with self.settings(PIPELINE_ENABLED=pipeline_enabled, PIPELINE_CSS=pipeline_css):
+        with self.settings(PIPELINE=pipeline):
             css_dependencies = get_css_dependencies("style-group")
             self.assertEqual(css_dependencies, expected_css_dependencies)
 
@@ -213,13 +216,15 @@ class TestXblockUtils(SharedModuleStoreTestCase):
         """
         Verify that `get_js_dependencies` returns correct list of files.
         """
-        pipeline_js = {
+        pipeline = settings.PIPELINE.copy()
+        pipeline['PIPELINE_ENABLED'] = pipeline_enabled
+        pipeline['JAVASCRIPT'] = {
             'js-group': {
                 'source_filenames': ["a.js", "b.js", "c.js"],
                 'output_filename': "combined.js"
             }
         }
-        with self.settings(PIPELINE_ENABLED=pipeline_enabled, PIPELINE_JS=pipeline_js):
+        with self.settings(PIPELINE=pipeline):
             js_dependencies = get_js_dependencies("js-group")
             self.assertEqual(js_dependencies, expected_js_dependencies)
 

--- a/openedx/core/lib/xblock_builtin/__init__.py
+++ b/openedx/core/lib/xblock_builtin/__init__.py
@@ -10,23 +10,23 @@ from django.conf import settings
 
 def get_css_dependencies(group):
     """
-    Returns list of CSS dependencies belonging to `group` in settings.PIPELINE_JS.
+    Returns list of CSS dependencies belonging to `group` in settings.PIPELINE['STYLESHEETS'].
 
-    Respects `PIPELINE_ENABLED` setting.
+    Respects `PIPELINE['PIPELINE_ENABLED']` setting.
     """
-    if settings.PIPELINE_ENABLED:
-        return [settings.PIPELINE_CSS[group]['output_filename']]
+    if settings.PIPELINE['PIPELINE_ENABLED']:
+        return [settings.PIPELINE['STYLESHEETS'][group]['output_filename']]
     else:
-        return settings.PIPELINE_CSS[group]['source_filenames']
+        return settings.PIPELINE['STYLESHEETS'][group]['source_filenames']
 
 
 def get_js_dependencies(group):
     """
-    Returns list of JS dependencies belonging to `group` in settings.PIPELINE_JS.
+    Returns list of JS dependencies belonging to `group` in settings.PIPELINE['JAVASCRIPT'].
 
-    Respects `PIPELINE_ENABLED` setting.
+    Respects `PIPELINE['PIPELINE_ENABLED']` setting.
     """
-    if settings.PIPELINE_ENABLED:
-        return [settings.PIPELINE_JS[group]['output_filename']]
+    if settings.PIPELINE['PIPELINE_ENABLED']:
+        return [settings.PIPELINE['JAVASCRIPT'][group]['output_filename']]
     else:
-        return settings.PIPELINE_JS[group]['source_filenames']
+        return settings.PIPELINE['JAVASCRIPT'][group]['source_filenames']

--- a/openedx/core/lib/xblock_utils/__init__.py
+++ b/openedx/core/lib/xblock_utils/__init__.py
@@ -485,7 +485,7 @@ def xblock_local_resource_url(block, uri):
     as a static asset which will use a CDN in production.
     """
     xblock_class = getattr(block.__class__, 'unmixed_class', block.__class__)
-    if settings.PIPELINE_ENABLED or not settings.REQUIRE_DEBUG:
+    if settings.PIPELINE['PIPELINE_ENABLED'] or not settings.REQUIRE_DEBUG:
         return staticfiles_storage.url('xblock/resources/{package_name}/{path}'.format(
             package_name=xblock_resource_pkg(xblock_class),
             path=uri

--- a/requirements/edx/base.in
+++ b/requirements/edx/base.in
@@ -49,7 +49,7 @@ django-model-utils==3.0.0
 django-mptt>=0.8.6,<0.9
 django-mysql==2.4.1
 django-oauth-toolkit<1.2            # Provides oAuth2 capabilities for Django. 1.2+ requires Django 2 and Python 3.5
-django-pipeline==1.5.3
+django-pipeline
 django-pyfs
 django-ratelimit
 django-ratelimit-backend==1.1.1
@@ -79,7 +79,7 @@ edx-enterprise
 edx-milestones
 edx-oauth2-provider
 edx-organizations
-edx-proctoring>=1.6.0
+edx-proctoring>=2.0.1
 edx-proctoring-proctortrack==1.0.5  # Intentionally and permanently pinned to ensure code changes are reviewed
 edx-rest-api-client
 edx-search

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -82,7 +82,7 @@ django-multi-email-field==0.5.1  # via edx-enterprise
 django-mysql==2.4.1
 django-oauth-toolkit==1.1.3
 django-object-actions==0.10.0  # via edx-enterprise
-django-pipeline==1.5.3
+django-pipeline==1.6.14
 django-pyfs==2.0
 django-ratelimit-backend==1.1.1
 django-ratelimit==2.0.0
@@ -119,7 +119,7 @@ edx-oauth2-provider==1.2.2
 edx-opaque-keys[django]==0.4.4
 edx-organizations==2.0.2
 edx-proctoring-proctortrack==1.0.5
-edx-proctoring==2.0.0
+edx-proctoring==2.0.1
 edx-rbac==0.2.0           # via edx-enterprise
 edx-rest-api-client==1.9.2
 edx-search==1.2.2

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -61,7 +61,7 @@ bok-choy==1.0.0
 boto3==1.4.8
 boto==2.39.0
 botocore==1.8.17
-caniusepython3==7.0.0
+caniusepython3==7.1.0
 celery==3.1.25
 certifi==2019.3.9
 cffi==1.12.3
@@ -72,6 +72,7 @@ code-annotations==0.3.1
 colorama==0.4.1
 configparser==3.7.4
 constantly==15.1.0
+contextlib2==0.5.5
 coreapi==2.3.3
 coreschema==0.0.4
 coverage==4.4
@@ -103,7 +104,7 @@ django-multi-email-field==0.5.1
 django-mysql==2.4.1
 django-oauth-toolkit==1.1.3
 django-object-actions==0.10.0
-django-pipeline==1.5.3
+django-pipeline==1.6.14
 django-pyfs==2.0
 django-ratelimit-backend==1.1.1
 django-ratelimit==2.0.0
@@ -141,7 +142,7 @@ edx-oauth2-provider==1.2.2
 edx-opaque-keys[django]==0.4.4
 edx-organizations==2.0.2
 edx-proctoring-proctortrack==1.0.5
-edx-proctoring==2.0.0
+edx-proctoring==2.0.1
 edx-rbac==0.2.0
 edx-rest-api-client==1.9.2
 edx-search==1.2.2
@@ -180,6 +181,7 @@ httpretty==0.9.6
 hyperlink==19.0.0
 idna==2.8
 imagesize==1.1.0          # via sphinx
+importlib-metadata==0.9
 incremental==17.5.0
 inflect==2.1.0
 ipaddress==1.0.22
@@ -233,7 +235,7 @@ pdfminer.six==20181108
 piexif==1.0.2
 pillow==6.0.0
 pip-tools==3.6.1
-pluggy==0.9.0
+pluggy==0.10.0
 polib==1.1.0
 psutil==1.2.1
 py2neo==3.1.2
@@ -346,4 +348,5 @@ xblock-utils==1.2.1
 xblock==1.2.2
 xmltodict==0.12.0
 zendesk==1.1.1
+zipp==0.4.0
 zope.interface==4.6.0

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -59,7 +59,7 @@ bok-choy==1.0.0
 boto3==1.4.8
 boto==2.39.0
 botocore==1.8.17
-caniusepython3==7.0.0
+caniusepython3==7.1.0
 celery==3.1.25
 certifi==2019.3.9
 cffi==1.12.3
@@ -68,8 +68,9 @@ click-log==0.3.2          # via edx-lint
 click==7.0
 code-annotations==0.3.1
 colorama==0.4.1           # via radon
-configparser==3.7.4       # via entrypoints, flake8, pylint
+configparser==3.7.4       # via entrypoints, flake8, importlib-metadata, pylint
 constantly==15.1.0        # via twisted
+contextlib2==0.5.5        # via importlib-metadata
 coreapi==2.3.3
 coreschema==0.0.4
 coverage==4.4
@@ -100,7 +101,7 @@ django-multi-email-field==0.5.1
 django-mysql==2.4.1
 django-oauth-toolkit==1.1.3
 django-object-actions==0.10.0
-django-pipeline==1.5.3
+django-pipeline==1.6.14
 django-pyfs==2.0
 django-ratelimit-backend==1.1.1
 django-ratelimit==2.0.0
@@ -137,7 +138,7 @@ edx-oauth2-provider==1.2.2
 edx-opaque-keys[django]==0.4.4
 edx-organizations==2.0.2
 edx-proctoring-proctortrack==1.0.5
-edx-proctoring==2.0.0
+edx-proctoring==2.0.1
 edx-rbac==0.2.0
 edx-rest-api-client==1.9.2
 edx-search==1.2.2
@@ -174,6 +175,7 @@ httplib2==0.12.3
 httpretty==0.9.6
 hyperlink==19.0.0         # via twisted
 idna==2.8
+importlib-metadata==0.9   # via pluggy
 incremental==17.5.0       # via twisted
 inflect==2.1.0
 ipaddress==1.0.22
@@ -218,14 +220,14 @@ pa11ycrawler==1.7.3
 packaging==19.0           # via caniusepython3
 parsel==1.5.1             # via scrapy
 path.py==8.2.1
-pathlib2==2.3.3           # via pytest, pytest-django
+pathlib2==2.3.3           # via importlib-metadata, pytest, pytest-django
 pathtools==0.1.2
 paver==1.3.4
 pbr==5.2.0
 pdfminer.six==20181108
 piexif==1.0.2
 pillow==6.0.0
-pluggy==0.9.0             # via pytest, tox
+pluggy==0.10.0            # via pytest, tox
 polib==1.1.0
 psutil==1.2.1
 py2neo==3.1.2
@@ -332,4 +334,5 @@ xblock-utils==1.2.1
 xblock==1.2.2
 xmltodict==0.12.0         # via moto
 zendesk==1.1.1
+zipp==0.4.0               # via importlib-metadata
 zope.interface==4.6.0     # via twisted


### PR DESCRIPTION
Our recent switch from a django-pipeline fork to a slightly newer release left installation broken under Python 3.  This gets us to the latest release of django-pipeline, which installs correctly but also moved all of its Django settings under a single `PIPELINE` dictionary.  Notes:

* The cms common settings had a couple of the settings duplicated.  I kept the behavior the same as it was before, but I don't think this was what had been originally intended (the older settings overrode the more recently added ones).  That may merit review and a separate cleanup PR later.
* I already made a new edx-proctoring release to support the changes.