### PR TITLE
Anomaly in certs visibility on user profile.

### DIFF
--- a/openedx/features/learner_profile/tests/views/test_learner_profile.py
+++ b/openedx/features/learner_profile/tests/views/test_learner_profile.py
@@ -248,3 +248,24 @@ class LearnerProfileViewTest(SiteMixin, UrlResetMixin, ModuleStoreTestCase):
         response = self.client.get('/u/{username}'.format(username=self.user.username))
 
         self.assertNotContains(response, u'card certificate-card mode-{cert_mode}'.format(cert_mode=cert.mode))
+
+    def test_certificates_visible_only_for_staff_and_profile_user(self):
+        """
+        Verify that certificates data are passed to template only in case of staff user
+        and profile user.
+        """
+        request = RequestFactory().get('/url')
+        request.user = self.user
+        profile_username = self.other_user.username
+        user_is_staff = True
+        context = learner_profile_context(request, profile_username, user_is_staff)
+
+        self.assertIn('achievements_fragment', context)
+
+        user_is_staff = False
+        context = learner_profile_context(request, profile_username, user_is_staff)
+        self.assertNotIn('achievements_fragment', context)
+
+        profile_username = self.user.username
+        context = learner_profile_context(request, profile_username, user_is_staff)
+        self.assertIn('achievements_fragment', context)

--- a/openedx/features/learner_profile/views/learner_profile.py
+++ b/openedx/features/learner_profile/views/learner_profile.py
@@ -83,15 +83,8 @@ def learner_profile_context(request, profile_username, user_is_staff):
 
     preferences_data = get_user_preferences(profile_user, profile_username)
 
-    achievements_fragment = LearnerAchievementsFragmentView().render_to_fragment(
-        request,
-        username=profile_user.username,
-        own_profile=own_profile,
-    )
-
     context = {
         'own_profile': own_profile,
-        'achievements_fragment': achievements_fragment,
         'platform_name': configuration_helpers.get_value('platform_name', settings.PLATFORM_NAME),
         'data': {
             'profile_user_id': profile_user.id,
@@ -124,6 +117,14 @@ def learner_profile_context(request, profile_username, user_is_staff):
         'nav_hidden': True,
         'records_url': get_credentials_records_url(),
     }
+
+    if own_profile or user_is_staff:
+        achievements_fragment = LearnerAchievementsFragmentView().render_to_fragment(
+            request,
+            username=profile_user.username,
+            own_profile=own_profile,
+        )
+        context['achievements_fragment'] = achievements_fragment
 
     if badges_enabled():
         context['data']['badges_api_url'] = reverse("badges_api:user_assertions", kwargs={'username': profile_username})


### PR DESCRIPTION
### Description

[LEARNER-7057](https://openedx.atlassian.net/browse/LEARNER-7057)

While visiting a profile of another user from a non-staff account, backend is returning html of its certs in page source.To avoid it, a check is added in backend so that certs are only added when the visiting user is itself visiting its profile or it would be a staff.