### PR TITLE
Add location ID to Studio component footers

### DIFF
--- a/cms/static/sass/elements/_xblocks.scss
+++ b/cms/static/sass/elements/_xblocks.scss
@@ -506,6 +506,29 @@
       }
     }
   }
+  .location-footer {
+    .location-container {
+      position: relative;
+      background: #f9f9f9;
+      border-top: 1px solid #ddd;
+      border-bottom-left-radius: 3px;
+      border-bottom-right-radius: 3px;
+      .location-label {
+        position: absolute;
+        left: 0;
+        padding: 8px 10px;
+        border-right: 1px solid #ddd;
+        z-index: 11;
+      }
+      .location-value {
+        box-sizing: border-box;
+        width: 100%;
+        padding: 5px 10px 5px 90px;
+        z-index: 10;
+        font-size: .75em;
+      }
+    }
+  }
 }
 
 // +Editing - Xblocks

--- a/cms/templates/studio_xblock_wrapper.html
+++ b/cms/templates/studio_xblock_wrapper.html
@@ -166,6 +166,12 @@ block_is_unit = is_unit(xblock)
         % endif
         ${content | n, decode.utf8}
         </article>
+        <footer class="location-footer">
+            <div class="location-container">
+                <label class="location-label">${_('Location:')}</label>
+                <p class="location-value">${ xblock.location }</p>
+            </div>
+        </footer>
     % else:
         <div class="xblock-message-area">
         ${content | n, decode.utf8}


### PR DESCRIPTION
This is helpful for a number of use cases for us at Stanford,
where instructors/staff/admin need access to an item's location id.

Previously, we'd have to dig this value out by other means.
This makes it easy to discover and use as needed, eg: copy/paste, etc.

One major example of our use of it is with the `in-video-quiz` XBlock [1][2],
which maps video components to capa problems.

- [1] https://github.com/Stanford-Online/xblock-in-video-quiz
- [2] https://github.com/Stanford-Online/xblock-in-video-quiz/blob/master/invideoquiz/invideoquiz.py#L41-L61