### PR TITLE
Remove dependency on django-cas

### DIFF
--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -10,7 +10,6 @@ git+https://github.com/edx/openedx-calc.git@e9b698c85ad1152002bc0868f475f153dce8
 -e common/lib/chem
 -e git+https://github.com/edx/codejail.git@a320d43ce6b9c93b17636b2491f724d9e433be47#egg=codejail
 git+https://github.com/edx/crowdsourcehinter.git@518605f0a95190949fe77bd39158450639e2e1dc#egg=crowdsourcehinter-xblock==0.1
-git+https://github.com/mitodl/django-cas.git@afac57bc523f145ae826f4ed3d4fa8b2c86c5364#egg=django-cas==2.1.1
 git+https://github.com/edx/django-celery.git@756cb57aad765cb2b0d37372c1855b8f5f37e6b0#egg=django-celery==3.2.1+edx.2
 git+https://github.com/edx/django-oauth-plus.git@01ec2a161dfc3465f9d35b9211ae790177418316#egg=django-oauth-plus==2.2.9.edx-1
 git+https://github.com/edx/django-openid-auth.git@0.15.1#egg=django-openid-auth==0.15.1
@@ -188,7 +187,7 @@ pycountry==18.12.8
 pycparser==2.19
 pycryptodome==3.8.1       # via pdfminer.six
 pycryptodomex==3.4.7
-pygments==2.3.1
+pygments==2.4.0
 pygraphviz==1.5
 pyjwkest==1.3.2
 pyjwt==1.5.2

--- a/requirements/edx/coverage.txt
+++ b/requirements/edx/coverage.txt
@@ -10,5 +10,5 @@ inflect==2.1.0            # via jinja2-pluralize
 jinja2-pluralize==0.3.0   # via diff-cover
 jinja2==2.10.1            # via diff-cover, jinja2-pluralize
 markupsafe==1.1.1         # via jinja2
-pygments==2.3.1           # via diff-cover
+pygments==2.4.0           # via diff-cover
 six==1.11.0

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -10,7 +10,6 @@ git+https://github.com/edx/openedx-calc.git@e9b698c85ad1152002bc0868f475f153dce8
 -e common/lib/chem
 -e git+https://github.com/edx/codejail.git@a320d43ce6b9c93b17636b2491f724d9e433be47#egg=codejail
 git+https://github.com/edx/crowdsourcehinter.git@518605f0a95190949fe77bd39158450639e2e1dc#egg=crowdsourcehinter-xblock==0.1
-git+https://github.com/mitodl/django-cas.git@afac57bc523f145ae826f4ed3d4fa8b2c86c5364#egg=django-cas==2.1.1
 git+https://github.com/edx/django-celery.git@756cb57aad765cb2b0d37372c1855b8f5f37e6b0#egg=django-celery==3.2.1+edx.2
 git+https://github.com/hmarr/django-debug-toolbar-mongo.git@b0686a76f1ce3532088c4aee6e76b9abe61cc808#egg=django-debug-toolbar-mongo==0.1.10
 git+https://github.com/edx/django-oauth-plus.git@01ec2a161dfc3465f9d35b9211ae790177418316#egg=django-oauth-plus==2.2.9.edx-1
@@ -156,7 +155,7 @@ enum34==1.1.6
 event-tracking==0.2.8
 execnet==1.6.0
 factory_boy==2.8.1
-faker==1.0.5
+faker==1.0.6
 feedparser==5.1.3
 filelock==3.0.10
 firebase-token-generator==1.3.2
@@ -232,7 +231,7 @@ pbr==5.2.0
 pdfminer.six==20181108
 piexif==1.0.2
 pillow==6.0.0
-pip-tools==3.6.1
+pip-tools==3.7.0
 pluggy==0.11.0
 polib==1.1.0
 psutil==1.2.1
@@ -248,7 +247,7 @@ pycryptodome==3.8.1
 pycryptodomex==3.4.7
 pydispatcher==2.0.5
 pyflakes==2.1.1
-pygments==2.3.1
+pygments==2.4.0
 pygraphviz==1.5
 pyhamcrest==1.9.0
 pyinotify==0.9.6
@@ -271,7 +270,7 @@ pytest-django==3.4.8
 pytest-forked==1.0.2
 pytest-randomly==1.2.3
 pytest-xdist==1.28.0
-pytest==4.4.1
+pytest==4.4.2
 python-dateutil==2.4.0
 python-levenshtein==0.12.0
 python-memcached==1.59

--- a/requirements/edx/github.in
+++ b/requirements/edx/github.in
@@ -67,7 +67,6 @@
 -e git+https://github.com/edx/MongoDBProxy.git@25b99097615bda06bd7cdfe5669ed80dc2a7fed0#egg=MongoDBProxy==0.1.0
 -e git+https://github.com/dementrock/pystache_custom.git@776973740bdaad83a3b029f96e415a7d1e8bec2f#egg=pystache_custom-dev
 -e git+https://github.com/jazkarta/edx-jsme.git@690dbf75441fa91c7c4899df0b83d77f7deb5458#egg=edx-jsme
--e git+https://github.com/mitodl/django-cas.git@afac57bc523f145ae826f4ed3d4fa8b2c86c5364#egg=django-cas==2.1.1
 -e git+https://github.com/dgrtwo/ParsePy.git@7949b9f754d1445eff8e8f20d0e967b9a6420639#egg=parse_rest
 
 # Forked to get Django 1.10+ compat that is in origin BitBucket repo, without an official build.

--- a/requirements/edx/pip-tools.txt
+++ b/requirements/edx/pip-tools.txt
@@ -5,5 +5,5 @@
 #    make upgrade
 #
 click==7.0                # via pip-tools
-pip-tools==3.6.1
+pip-tools==3.7.0
 six==1.11.0

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -10,7 +10,6 @@ git+https://github.com/edx/openedx-calc.git@e9b698c85ad1152002bc0868f475f153dce8
 -e common/lib/chem
 -e git+https://github.com/edx/codejail.git@a320d43ce6b9c93b17636b2491f724d9e433be47#egg=codejail
 git+https://github.com/edx/crowdsourcehinter.git@518605f0a95190949fe77bd39158450639e2e1dc#egg=crowdsourcehinter-xblock==0.1
-git+https://github.com/mitodl/django-cas.git@afac57bc523f145ae826f4ed3d4fa8b2c86c5364#egg=django-cas==2.1.1
 git+https://github.com/edx/django-celery.git@756cb57aad765cb2b0d37372c1855b8f5f37e6b0#egg=django-celery==3.2.1+edx.2
 git+https://github.com/edx/django-oauth-plus.git@01ec2a161dfc3465f9d35b9211ae790177418316#egg=django-oauth-plus==2.2.9.edx-1
 git+https://github.com/edx/django-openid-auth.git@0.15.1#egg=django-openid-auth==0.15.1
@@ -151,7 +150,7 @@ enum34==1.1.6
 event-tracking==0.2.8
 execnet==1.6.0            # via pytest-xdist
 factory_boy==2.8.1
-faker==1.0.5              # via factory-boy
+faker==1.0.6              # via factory-boy
 feedparser==5.1.3
 filelock==3.0.10          # via tox
 firebase-token-generator==1.3.2
@@ -240,7 +239,7 @@ pycryptodome==3.8.1
 pycryptodomex==3.4.7
 pydispatcher==2.0.5       # via scrapy
 pyflakes==2.1.1           # via flake8
-pygments==2.3.1
+pygments==2.4.0
 pygraphviz==1.5
 pyhamcrest==1.9.0         # via twisted
 pyjwkest==1.3.2
@@ -262,7 +261,7 @@ pytest-django==3.4.8
 pytest-forked==1.0.2      # via pytest-xdist
 pytest-randomly==1.2.3
 pytest-xdist==1.28.0
-pytest==4.4.1
+pytest==4.4.2
 python-dateutil==2.4.0
 python-levenshtein==0.12.0
 python-memcached==1.59


### PR DESCRIPTION
All usage of the django-cas package was removed in https://github.com/edx/edx-platform/pull/19693 but the dependency on it wasn't removed.  It's just dead weight (which doesn't work under Python 3), so removing it.