### PR TITLE
Remove linking enterprise SSO accounts to existing users via username lookup

### DIFF
--- a/common/djangoapps/third_party_auth/pipeline.py
+++ b/common/djangoapps/third_party_auth/pipeline.py
@@ -836,8 +836,6 @@ def get_username(strategy, details, backend, user=None, *args, **kwargs):
 
         if email_as_username and details.get('email'):
             username = details['email']
-        elif details.get('username'):
-            username = details['username']
         else:
             username = uuid4().hex
 


### PR DESCRIPTION
**Description:**

Coming out of ENT-1629 there is an issue if the enterprise IDP configuration does not pass along email address, but we try to assign a default value to the username.
This is because the username is also used to check if the user already has an edx account (in addition to email). Because of this, the system will prompt to link accounts prior to the registration page, where the default username would match an existing user and the social-auth code that appends a unique string would kick in.

**The code first checks:**

1. Is there an email match? (no, theres no email being passed)
2. Is there a username match? (yes, using the default username)
3. If either above, prompt to link accounts, otherwise prompt to register

**Further within registration:**
if there's a username match, append the string to make it unique (part of social-auth - we never get here because we hit the linkage above)

**Acceptance Criteria:**
We do not try to link accounts on usernames. remove that check entirely
