### PR TITLE
Add feature flag to disable honor mode certificates.

### DIFF
--- a/common/djangoapps/course_modes/models.py
+++ b/common/djangoapps/course_modes/models.py
@@ -759,7 +759,12 @@ class CourseMode(models.Model):
         GeneratedCertificate records with mode='audit' which are
         eligible.
         """
-        return mode_slug != cls.AUDIT
+        ineligible_modes = [cls.AUDIT]
+
+        if settings.FEATURES['DISABLE_HONOR_CERTIFICATES']:
+            ineligible_modes.append(cls.HONOR)
+
+        return mode_slug not in ineligible_modes
 
     def to_tuple(self):
         """

--- a/common/djangoapps/course_modes/tests/test_models.py
+++ b/common/djangoapps/course_modes/tests/test_models.py
@@ -456,17 +456,24 @@ class CourseModeModelTest(TestCase):
         self.assertIsNone(verified_mode.expiration_datetime)
 
     @ddt.data(
-        (CourseMode.AUDIT, False),
-        (CourseMode.HONOR, True),
-        (CourseMode.VERIFIED, True),
-        (CourseMode.CREDIT_MODE, True),
-        (CourseMode.PROFESSIONAL, True),
-        (CourseMode.NO_ID_PROFESSIONAL_MODE, True),
+        (False, CourseMode.AUDIT, False),
+        (False, CourseMode.HONOR, True),
+        (False, CourseMode.VERIFIED, True),
+        (False, CourseMode.CREDIT_MODE, True),
+        (False, CourseMode.PROFESSIONAL, True),
+        (False, CourseMode.NO_ID_PROFESSIONAL_MODE, True),
+        (True, CourseMode.AUDIT, False),
+        (True, CourseMode.HONOR, False),
+        (True, CourseMode.VERIFIED, True),
+        (True, CourseMode.CREDIT_MODE, True),
+        (True, CourseMode.PROFESSIONAL, True),
+        (True, CourseMode.NO_ID_PROFESSIONAL_MODE, True),
     )
     @ddt.unpack
-    def test_eligible_for_cert(self, mode_slug, expected_eligibility):
+    def test_eligible_for_cert(self, disable_honor_cert, mode_slug, expected_eligibility):
         """Verify that non-audit modes are eligible for a cert."""
-        self.assertEqual(CourseMode.is_eligible_for_certificate(mode_slug), expected_eligibility)
+        with override_settings(FEATURES={'DISABLE_HONOR_CERTIFICATES': disable_honor_cert}):
+            self.assertEqual(CourseMode.is_eligible_for_certificate(mode_slug), expected_eligibility)
 
     @ddt.data(
         (CourseMode.AUDIT, False),

--- a/lms/djangoapps/certificates/models.py
+++ b/lms/djangoapps/certificates/models.py
@@ -90,6 +90,7 @@ class CertificateStatuses(object):
     auditing = 'auditing'
     audit_passing = 'audit_passing'
     audit_notpassing = 'audit_notpassing'
+    honor_passing = 'honor_passing'
     unverified = 'unverified'
     invalidated = 'invalidated'
     requesting = 'requesting'

--- a/lms/djangoapps/courseware/views/views.py
+++ b/lms/djangoapps/courseware/views/views.py
@@ -135,6 +135,19 @@ AUDIT_PASSING_CERT_DATA = CertData(
     cert_web_view_url=None
 )
 
+HONOR_PASSING_CERT_DATA = CertData(
+    CertificateStatuses.honor_passing,
+    _('Your enrollment: Honor track'),
+    _('You are enrolled in the honor track for this course. The honor track does not include a certificate.'),
+    download_url=None,
+    cert_web_view_url=None
+)
+
+INELIGIBLE_PASSING_CERT_DATA = {
+    CourseMode.AUDIT: AUDIT_PASSING_CERT_DATA,
+    CourseMode.HONOR: HONOR_PASSING_CERT_DATA
+}
+
 GENERATING_CERT_DATA = CertData(
     CertificateStatuses.generating,
     _("We're working on it..."),
@@ -1089,7 +1102,7 @@ def _get_cert_data(student, course, enrollment_mode, course_grade=None):
         returns dict if course certificate is available else None.
     """
     if not CourseMode.is_eligible_for_certificate(enrollment_mode):
-        return AUDIT_PASSING_CERT_DATA
+        return INELIGIBLE_PASSING_CERT_DATA.get(enrollment_mode)
 
     certificates_enabled_for_course = certs_api.cert_generation_enabled(course.id)
     if course_grade is None:

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -197,6 +197,18 @@ FEATURES = {
     # Toggle to enable certificates of courses on dashboard
     'ENABLE_VERIFIED_CERTIFICATES': False,
 
+    # .. toggle_name: DISABLE_HONOR_CERTIFICATES
+    # .. toggle_type: feature_flag
+    # .. toggle_default: False
+    # .. toggle_description: Set to True to disable honor certificates. Typically used when your installation only allows verified certificates, like courses.edx.org.
+    # .. toggle_category: certificates
+    # .. toggle_use_cases: open_edx
+    # .. toggle_creation_date: 2019-05-14
+    # .. toggle_expiration_date: None
+    # .. toggle_tickets: https://openedx.atlassian.net/browse/PROD-269
+    # .. toggle_status: supported
+    'DISABLE_HONOR_CERTIFICATES': False,  # Toggle to disable honor certificates
+
     # for acceptance and load testing
     'AUTOMATIC_AUTH_FOR_TESTING': False,
 


### PR DESCRIPTION
Added a feature flag to disable honor mode certificates for edx.org, by default set to false to allow honor mode certificates for open community.

PROD-269