### PR TITLE
Optimize award_program_certificates task

### DIFF
--- a/lms/djangoapps/certificates/models.py
+++ b/lms/djangoapps/certificates/models.py
@@ -226,8 +226,9 @@ class EligibleAvailableCertificateManager(EligibleCertificateManager):
         Return a queryset for `GeneratedCertificate` models, filtering out
         ineligible certificates and any linked to nonexistent courses.
         """
-        return super(EligibleAvailableCertificateManager, self).get_queryset().filter(
-            course_id__in=list(CourseOverview.objects.values_list('id', flat=True))
+        return super(EligibleAvailableCertificateManager, self).get_queryset().extra(
+            tables=['course_overviews_courseoverview'],
+            where=['course_id = course_overviews_courseoverview.id']
         )
 
 


### PR DESCRIPTION
Description:
The query is [invoked here](https://github.com/edx/edx-platform/blob/bda16a9b6bf5dcd67aa6591fb4f48bf3686e1bdb/openedx/core/djangoapps/programs/utils.py#L288) from task **award_program_certificates**, where it's being used with a filter on user. In that case, the query takes 1.28s in the trace to run 8 times, and there's a lot of CPU burn right before. Doing the equivalent query for my user id(11) with the join executes in 0.26s uncached and less than 0.01s cached.

Implementation notes:
More than 70% of the execution time is spent in CPU. The change of query is to avoid the massive "course_id__in", the GeneratedCertificate was doing on CourseOverview

[PROD-67](https://openedx.atlassian.net/browse/PROD-67)