### PR TITLE
Round off course card grade

### DIFF
--- a/lms/static/js/learner_dashboard/views/course_card_view.js
+++ b/lms/static/js/learner_dashboard/views/course_card_view.js
@@ -31,7 +31,7 @@ class CourseCardView extends Backbone.View {
       this.model.updateCourseRunWithHighestGrade(this.context.courseData.grades);
     }
     this.grade = this.context.courseData.grades[this.model.get('course_run_key')];
-    this.grade = this.grade * 100;
+    this.grade = Math.round(this.grade * 100);
     this.collectionCourseStatus = this.context.collectionCourseStatus || '';
     this.entitlement = this.model.get('user_entitlement');
 


### PR DESCRIPTION
Grades appeared with many decimals on their Programs page.
To avoid it, course grade is rounded off so that decimals can be
ignored.

LEARNER-5984