### PR TITLE
Send duplicate provider to account MFE.

### DIFF
--- a/openedx/core/djangoapps/user_api/accounts/settings_views.py
+++ b/openedx/core/djangoapps/user_api/accounts/settings_views.py
@@ -59,7 +59,18 @@ def account_settings(request):
 
     """
     if should_redirect_to_account_microfrontend():
-        return redirect(settings.ACCOUNT_MICROFRONTEND_URL)
+        url = settings.ACCOUNT_MICROFRONTEND_URL
+
+        duplicate_provider = pipeline.get_duplicate_provider(messages.get_messages(request))
+        if duplicate_provider:
+            url = '{url}?{params}'.format(
+                url=url,
+                params=six.moves.urllib.parse.urlencode({
+                    'duplicate_provider': duplicate_provider,
+                }),
+            )
+
+        return redirect(url)
 
     context = account_settings_context(request)
     return render_to_response('student_account/account_settings.html', context)


### PR DESCRIPTION
When a user attempts to link a TPA provider to an account which is already linked to another edX account, we need to display an error message on the account settings page when redirecting to it. This change will pass the name of the TPA provider which the user was attempting to link to a second edX account as a query parameter when redirecting to the account MFE. The account MFE will extract the parameter and display the error message.