### PR TITLE
make default value of invite_only configurable

### DIFF
--- a/lms/djangoapps/courseware/access.py
+++ b/lms/djangoapps/courseware/access.py
@@ -270,7 +270,8 @@ def _can_enroll_courselike(user, courselike):
     if _has_staff_access_to_descriptor(user, courselike, course_key):
         return ACCESS_GRANTED
 
-    if courselike.invitation_only:
+    # Access denied when default value of COURSE_DEFAULT_INVITE_ONLY set to True
+    if settings.FEATURES.get('COURSE_DEFAULT_INVITE_ONLY') or courselike.invitation_only:
         debug("Deny: invitation only")
         return ACCESS_DENIED
 

--- a/lms/djangoapps/courseware/tests/test_access.py
+++ b/lms/djangoapps/courseware/tests/test_access.py
@@ -545,6 +545,39 @@ class AccessTestCase(LoginEnrollmentTestCase, ModuleStoreTestCase, MilestonesTes
         )
         self.assertFalse(access._has_access_course(user, 'enroll', course))
 
+    @patch.dict('django.conf.settings.FEATURES', {'COURSE_DEFAULT_INVITE_ONLY': False})
+    def test__course_default_invite_only_flag_false(self):
+        """Tests that default value of COURSE_DEFAULT_INVITE_ONLY as False."""
+
+        user = UserFactory.create()
+
+        course = self._mock_course(invitation=True)
+        self.assertFalse(access._has_access_course(user, 'enroll', course))
+
+        course = self._mock_course(invitation=False)
+        self.assertTrue(access._has_access_course(user, 'enroll', course))
+
+    @patch.dict('django.conf.settings.FEATURES', {'COURSE_DEFAULT_INVITE_ONLY': True})
+    def test__course_default_invite_only_flag_true(self):
+        """Tests that default value of COURSE_DEFAULT_INVITE_ONLY as True."""
+
+        user = UserFactory.create()
+
+        course = self._mock_course(invitation=True)
+        self.assertFalse(access._has_access_course(user, 'enroll', course))
+
+        course = self._mock_course(invitation=False)
+        self.assertFalse(access._has_access_course(user, 'enroll', course))
+
+    def _mock_course(self, invitation):
+        yesterday = datetime.datetime.now(pytz.utc) - datetime.timedelta(days=1)
+        tomorrow = datetime.datetime.now(pytz.utc) + datetime.timedelta(days=1)
+        return Mock(
+            enrollment_start=yesterday, enrollment_end=tomorrow,
+            id=CourseLocator('edX', 'test', '2012_Fall'), enrollment_domain='',
+            invitation_only=invitation
+        )
+
     def test__user_passed_as_none(self):
         """Ensure has_access handles a user being passed as null"""
         access.has_access(None, 'staff', 'global', None)

--- a/lms/djangoapps/courseware/views/views.py
+++ b/lms/djangoapps/courseware/views/views.py
@@ -922,7 +922,7 @@ def course_about(request, course_id):
 
         # Used to provide context to message to student if enrollment not allowed
         can_enroll = bool(request.user.has_perm(ENROLL_IN_COURSE, course))
-        invitation_only = course.invitation_only
+        invitation_only = settings.FEATURES.get('COURSE_DEFAULT_INVITE_ONLY') or course.invitation_only
         is_course_full = CourseEnrollment.objects.is_course_full(course)
 
         # Register button should be disabled if one of the following is true:

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -401,6 +401,18 @@ FEATURES = {
 
     # Enable feature to remove enrollments and users. Used to reset state of master's integration environments
     'ENABLE_ENROLLMENT_RESET': False,
+
+    # .. toggle_name: COURSE_DEFAULT_INVITE_ONLY
+    # .. toggle_type: feature_flag
+    # .. toggle_default: False
+    # .. toggle_description: Set this to manage the default value for INVITE_ONLY across all courses in a given deployment
+    # .. toggle_category: admin
+    # .. toggle_use_cases: open_edx
+    # .. toggle_creation_date: 2019-05-16
+    # .. toggle_expiration_date: None
+    # .. toggle_tickets: https://github.com/mitodl/edx-platform/issues/123
+    # .. toggle_status: unsupported
+    'COURSE_DEFAULT_INVITE_ONLY': False,
 }
 
 # Settings for the course reviews tool template and identification key, set either to None to disable course reviews

--- a/lms/templates/courseware/course_about.html
+++ b/lms/templates/courseware/course_about.html
@@ -123,7 +123,7 @@ from six import string_types
           <span class="register disabled">
             ${_("Course is full")}
           </span>
-        % elif invitation_only and not can_enroll:
+        % elif settings.FEATURES.get('COURSE_DEFAULT_INVITE_ONLY') or invitation_only and not can_enroll:
           <span class="register disabled">${_("Enrollment in this course is by invitation only")}</span>
         ## Shib courses need the enrollment button to be displayed even when can_enroll is False,
         ## because AnonymousUsers cause can_enroll for shib courses to be False, but we need them to be able to click


### PR DESCRIPTION
Fixes https://github.com/mitodl/edx-platform/issues/135

**Background:**

We would like to make the default value of the invitation_required attribute of the courseware object configurable via a feature flag, to be named `COURSE_DEFAULT_INVITE_ONLY`

As it is currently, this is a manually updated flag in the course advanced settings and we would like to be able to manage the default value across all courses in a given deployment. The default value of the added setting should remain the same as the current setting of `False`, but allow us to set it to True through the existing settings mechanism.

We have merged this solution in our forked repository https://github.com/mitodl/edx-platform/pull/126.