### PR TITLE
 Fixed, change in static file URLs in handouts section

### DIFF
--- a/cms/djangoapps/contentstore/tests/test_contentstore.py
+++ b/cms/djangoapps/contentstore/tests/test_contentstore.py
@@ -1118,7 +1118,7 @@ class MiscCourseTests(ContentStoreTestCase):
         self.assertEqual(resp.status_code, 200)
         # check that /static/ has been converted to the full path
         # note, we know the link it should be because that's what in the 'toy' course in the test data
-        asset_key = self.course.id.make_asset_key('asset', 'handouts_sample_handout.txt')
+        asset_key = '/static/handouts/sample_handout.txt'
         self.assertContains(resp, text_type(asset_key))
 
     def test_prefetch_children(self):

--- a/cms/djangoapps/contentstore/tests/test_contentstore.py
+++ b/cms/djangoapps/contentstore/tests/test_contentstore.py
@@ -1101,9 +1101,9 @@ class MiscCourseTests(ContentStoreTestCase):
         self.assertEqual(len(assets), 0)
         self.assertEqual(count, 0)
 
-    def test_course_handouts_rewrites(self):
+    def test_course_handouts_doesnot_rewrites(self):
         """
-        Test that the xblock_handler rewrites static handout links
+        Test that the xblock_handler does not rewrites static handout links
         """
         handouts = self.store.create_item(
             self.user.id, self.course.id, 'course_info', 'handouts', fields={
@@ -1116,8 +1116,7 @@ class MiscCourseTests(ContentStoreTestCase):
 
         # make sure we got a successful response
         self.assertEqual(resp.status_code, 200)
-        # check that /static/ has been converted to the full path
-        # note, we know the link it should be because that's what in the 'toy' course in the test data
+        # check that /static/ has not been converted to the full path
         asset_key = '/static/handouts/sample_handout.txt'
         self.assertContains(resp, text_type(asset_key))
 

--- a/cms/djangoapps/contentstore/views/item.py
+++ b/cms/djangoapps/contentstore/views/item.py
@@ -181,7 +181,7 @@ def xblock_handler(request, usage_key_string):
                     return JsonResponse(ancestor_info)
                 # TODO: pass fields to _get_module_info and only return those
                 with modulestore().bulk_operations(usage_key.course_key):
-                    response = _get_module_info(_get_xblock(usage_key, request.user))
+                    response = _get_module_info(_get_xblock(usage_key, request.user), rewrite_static_links=False)
                 return JsonResponse(response)
             else:
                 return HttpResponse(status=406)


### PR DESCRIPTION
## [PROD-250](https://openedx.atlassian.net/browse/PROD-250)

### Description
This pr fixes change in static files URLs in the handouts section (content update section). Previously, on editing the URL in the editor, it reverts back to the CDN URL. After this fix, it will not revert back.

**Sandbox**
- https://bamberprod250zee.sandbox.edx.org

### Reviewers
If you've been tagged for review, please check your corresponding box once you've given the :+1:.
- [ ] Code review: @awaisdar001
- [ ] Code review: @asadazam93
- [x] Code review: @noraiz-anwar 

### Post-review
- [ ] Rebase and squash commits