### PR TITLE
Remove the word "Student" from the progress title.

### DIFF
--- a/lms/templates/courseware/progress.html
+++ b/lms/templates/courseware/progress.html
@@ -62,7 +62,7 @@ username = get_enterprise_learner_generic_name(request) or student.username
                 </div>
                 % endif
                 <h2 class="hd hd-2 progress-certificates-title">
-                    ${_("Course Progress for Student '{username}' ({email})").format(username=username, email=student.email)}
+                    ${_("Course Progress for '{username}' ({email})").format(username=username, email=student.email)}
                 </h2>
                 % if course_expiration_fragment:
                     ${HTML(course_expiration_fragment.content)}


### PR DESCRIPTION
At Stanford, we are required to refer to users as participants. Removed the word
Student from the progress certificate title. The word "Student" does not change when the
user context is changed.