### PR TITLE
Bug fix: broken course links in solution blocks

### DIFF
--- a/common/lib/xmodule/xmodule/capa_base.py
+++ b/common/lib/xmodule/xmodule/capa_base.py
@@ -1026,6 +1026,8 @@ class CapaMixin(ScorableXBlockMixin, CapaFields):
         for answer_id in answers:
             try:
                 answer_content = self.runtime.replace_urls(answers[answer_id])
+                if self.runtime.replace_course_urls:
+                    answer_content = self.runtime.replace_course_urls(answer_content)
                 if self.runtime.replace_jump_to_id_urls:
                     answer_content = self.runtime.replace_jump_to_id_urls(answer_content)
                 new_answer = {answer_id: answer_content}


### PR DESCRIPTION
I'm using a link to a textbook inside a solution block in a course currently running on edX. That link goes to `/course/pdfbook/0/chapter/2/21`, as expected for a link to the textbook. However, it's presently not working, because it's in a solution block.

There are three special types of links (that I'm aware of) that get replaced to point to the current course:
* `/course/`
* `/static/`
* `/jump_to_id/`
For some reason, only `/static/` and `/jump_to_id/` are replaced inside a solution block, and not `/course/`. This seems like an oversight, and is addressed by this PR.

Note that this PR copies the code used in `get_problem_html`, a few lines up in `capa_base.py`.

Here is a sample XML problem to demonstrate the issue:

```xml
<problem>
  <p>There are three types of special links that a course can have: <code>/course/</code>, <code>/static/</code> and <code>jumpto</code> links. Below are examples of each. Note that they are all internally modified to point to THIS course by the LMS.</p>
  <ul>
    <li><a href="/course/pdfbook/something">/course/</a></li>
    <li><a href="/static/file.ext">/static/</a></li>
    <li><a href="/jump_to_id/abcd">jumpto</a></li>
  </ul>
  <p>Inside a solution block, for some reason <code>/course/</code> doesn't get modified:</p>
  <solution>
    <ul>
      <li><a href="/course/pdfbook/something">/course/</a></li>
      <li><a href="/static/file.ext">/static/</a></li>
      <li><a href="/jump_to_id/abcd">jumpto</a></li>
    </ul>
  </solution>
</problem>
```
