### PR TITLE
remove ungrouped-imports rule from pylint

### DIFF
--- a/pylintrc
+++ b/pylintrc
@@ -26,17 +26,28 @@
 # 1. Edit the pylintrc file in the edx-lint repo at
 #    https://github.com/edx/edx-lint/blob/master/edx_lint/files/pylintrc
 #
-# 2. Make a new version of edx_lint, which involves the usual steps of
-#    incrementing the version number, submitting and reviewing a pull
-#    request, and updating the edx-lint version reference in this repo.
+# 2. install the updated version of edx-lint (in edx-lint):
 #
-# 3. Install the newer version of edx-lint.
+#       $ pip install .
 #
-# 4. Run:
+# 3. Run (in edx-lint):
 #
+#       # uses pylintrc_tweaks from edx-lint for linting in edx-lint
+#       # NOTE: Use Python 3.x, which no longer includes comments in the output file
 #       $ edx_lint write pylintrc
 #
-# 5. This will modify the local file.  Submit a pull request to get it
+# 4. Make a new version of edx_lint, submit and review a pull request with the
+#    pylintrc update, and after merging, update the edx-lint version by
+#    creating a new tag in the repo (uses pbr).
+#
+# 5. In your local repo, install the newer version of edx-lint.
+#
+# 6. Run:
+#
+#       # uses local pylintrc_tweaks
+#       $ edx_lint write pylintrc
+#
+# 7. This will modify the local file.  Submit a pull request to get it
 #    checked in so that others will benefit.
 #
 #
@@ -252,7 +263,6 @@ enable =
 	too-many-boolean-expressions,
 	# Consistent import order makes finding where code is
 	# imported from easier
-	ungrouped-imports,
 	wrong-import-order,
 	wrong-import-position,
 	wildcard-import,
@@ -446,4 +456,4 @@ int-import-graph =
 [EXCEPTIONS]
 overgeneral-exceptions = Exception
 
-# e841c53729c149a4170b2a8b8315f7f410287777
+# 69925c09262a3e603e0b833ddc773d2d0c267899

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -134,7 +134,7 @@ edx-django-utils==1.0.3
 edx-drf-extensions==2.2.1
 edx-enterprise==1.5.2
 edx-i18n-tools==0.4.8
-edx-lint==1.1.2
+edx-lint==1.2.0
 edx-milestones==0.1.13
 edx-oauth2-provider==1.2.2
 edx-opaque-keys[django]==0.4.4

--- a/requirements/edx/testing.in
+++ b/requirements/edx/testing.in
@@ -25,7 +25,7 @@ code-annotations          # Perform code annotation checking, such as for PII an
 cssselect                 # Used to extract HTML fragments via CSS selectors in 2 test cases and pyquery
 ddt                       # Run a test case multiple times with different input; used in many, many of our tests
 edx-i18n-tools>=0.4.6     # Commands for developers and translators to extract, compile and validate translations
-edx-lint==1.1.2           # pylint extensions for Open edX repositories
+edx-lint==1.2.0           # pylint extensions for Open edX repositories
 factory_boy==2.8.1        # Library for creating test fixtures, used in many tests
 freezegun                 # Allows tests to mock the output of assorted datetime module functions
 httpretty                 # Library for mocking HTTP requests, used in many tests

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -130,7 +130,7 @@ edx-django-utils==1.0.3
 edx-drf-extensions==2.2.1
 edx-enterprise==1.5.2
 edx-i18n-tools==0.4.8
-edx-lint==1.1.2
+edx-lint==1.2.0
 edx-milestones==0.1.13
 edx-oauth2-provider==1.2.2
 edx-opaque-keys[django]==0.4.4


### PR DESCRIPTION
Some INCR PRs with `ungrouped-import` failures can be rebased after this lands to resolve.  Also, this will keep future issues after isort is run.

See edx-lint 1.2.0 release for more details: https://github.com/edx/edx-lint/releases/tag/1.2.0