### PR TITLE
fix discussion comment styling

### DIFF
--- a/lms/static/sass/discussion/views/_thread.scss
+++ b/lms/static/sass/discussion/views/_thread.scss
@@ -80,10 +80,11 @@
 .discussion-comment {
   .response-body {
     @extend %t-copy-sub2;
+    @include padding(($baseline / 2), ($baseline * 1.5), 0, 0);
 
     display: inline-block;
-    margin-bottom: ($baseline/2);
-    width: flex-grid(10,12);
+    margin-top: ($baseline/2);
+    width: flex-grid(10, 12);
 
     p + p {
       margin-top: ($baseline/2);
@@ -95,7 +96,7 @@
     @include right($baseline / 2);
 
     position: absolute;
-    top: $baseline / 2;
+    top: 0;
   }
 }
 


### PR DESCRIPTION
### [EDUCATOR-1777](https://openedx.atlassian.net/browse/EDUCATOR-1777)

### Description
This PR fixes a styling bug present in the thread comment view. For every comment, if the comment body had a lot of content, the content would overlap with the action button and hovering over the button will reveal its content on top of the comment body. The styling fix was present for thread response and was replicated for the comments.

###  Before Fix
![image](https://user-images.githubusercontent.com/40599381/58023597-9b3f4000-7b29-11e9-9b6d-d0a19cd0dc67.png)
![image](https://user-images.githubusercontent.com/40599381/58023629-af833d00-7b29-11e9-9c57-79b51083df64.png)


### After Fix
![image](https://user-images.githubusercontent.com/40599381/58023565-85ca1600-7b29-11e9-9293-6dcef8c88700.png)
![image](https://user-images.githubusercontent.com/40599381/58023550-7a76ea80-7b29-11e9-983e-96066fa0a133.png)


### Sandbox
 - https://discussion.sandbox.edx.org/courses/course-v1:edX+DemoX+Demo_Course/course/

### Reviewers
 - [x] @noraiz-anwar 
 - [ ] @wittjeff 

### Post Review
 - [x] Squash & Rebase commits

