### PR TITLE
Update edx-when to 0.1.5

### DIFF
--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -125,7 +125,7 @@ edx-rest-api-client==1.9.2
 edx-search==1.2.2
 edx-submissions==2.1.1
 edx-user-state-client==1.1.0
-edx-when==0.1.4
+edx-when==0.1.5
 edxval==1.1.25
 elasticsearch==1.9.0      # via edx-search
 enum34==1.1.6

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -148,7 +148,7 @@ edx-search==1.2.2
 edx-sphinx-theme==1.4.0
 edx-submissions==2.1.1
 edx-user-state-client==1.1.0
-edx-when==0.1.4
+edx-when==0.1.5
 edxval==1.1.25
 elasticsearch==1.9.0
 entrypoints==0.3

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -143,7 +143,7 @@ edx-rest-api-client==1.9.2
 edx-search==1.2.2
 edx-submissions==2.1.1
 edx-user-state-client==1.1.0
-edx-when==0.1.4
+edx-when==0.1.5
 edxval==1.1.25
 elasticsearch==1.9.0
 entrypoints==0.3          # via flake8


### PR DESCRIPTION
For [PROD-291](https://openedx.atlassian.net/browse/PROD-291) -- don't copy dates into edx-when for self-paced courses.