### PR TITLE
Update handling of URL-based dependencies

### DIFF
--- a/requirements/edx-sandbox/base.in
+++ b/requirements/edx-sandbox/base.in
@@ -15,7 +15,7 @@ numpy==1.6.2                        # Numeric array processing utilities; used b
 pyparsing==2.2.0                    # Python Parsing module
 scipy==0.14.0                       # Math, science, and engineering library
 sympy==0.7.1                        # Symbolic math library
--e git+https://github.com/edx/openedx-calc.git@e9b698c85ad1152002bc0868f475f153dce88952#egg=calc==0.4
+git+https://github.com/edx/openedx-calc.git@e9b698c85ad1152002bc0868f475f153dce88952#egg=calc==0.4
 
 # Install these packages from the edx-platform working tree
 # NOTE: if you change code in these packages, you MUST change the version

--- a/requirements/edx-sandbox/base.txt
+++ b/requirements/edx-sandbox/base.txt
@@ -4,11 +4,11 @@
 #
 #    make upgrade
 #
-git+https://github.com/edx/openedx-calc.git@e9b698c85ad1152002bc0868f475f153dce88952#egg=calc==0.4
 common/lib/chem
 common/lib/sandbox-packages
 common/lib/symmath
 asn1crypto==0.24.0
+git+https://github.com/edx/openedx-calc.git@e9b698c85ad1152002bc0868f475f153dce88952#egg=calc==0.4
 cffi==1.12.3
 cryptography==2.6.1
 enum34==1.1.6

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -5,36 +5,21 @@
 #    make upgrade
 #
 -e git+https://github.com/edx/acid-block.git@e46f9cda8a03e121a00c7e347084d142d22ebfb7#egg=acid-xblock
-git+https://github.com/edx/openedx-calc.git@e9b698c85ad1152002bc0868f475f153dce88952#egg=calc==0.4
 -e common/lib/capa
 -e common/lib/chem
 -e git+https://github.com/edx/codejail.git@a320d43ce6b9c93b17636b2491f724d9e433be47#egg=codejail
-git+https://github.com/edx/crowdsourcehinter.git@518605f0a95190949fe77bd39158450639e2e1dc#egg=crowdsourcehinter-xblock==0.1
-git+https://github.com/edx/django-celery.git@756cb57aad765cb2b0d37372c1855b8f5f37e6b0#egg=django-celery==3.2.1+edx.2
-git+https://github.com/edx/django-oauth-plus.git@01ec2a161dfc3465f9d35b9211ae790177418316#egg=django-oauth-plus==2.2.9.edx-1
-git+https://github.com/edx/django-openid-auth.git@0.15.1#egg=django-openid-auth==0.15.1
 -e git+https://github.com/edx/django-wiki.git@v0.0.21#egg=django-wiki
-git+https://github.com/edx/django-rest-framework-oauth.git@0a43e8525f1e3048efe4bc70c03de308a277197c#egg=djangorestframework-oauth==1.1.1
-git+https://github.com/edx/django-rest-framework.git@1ceda7c086fddffd1c440cc86856441bbf0bd9cb#egg=djangorestframework==3.6.3
 -e git+https://github.com/edx/DoneXBlock.git@01a14f3bd80ae47dd08cdbbe2f88f3eb88d00fba#egg=done-xblock
 -e git+https://github.com/jazkarta/edx-jsme.git@690dbf75441fa91c7c4899df0b83d77f7deb5458#egg=edx-jsme
-git+https://github.com/mitodl/edx-sga.git@3828ba9e413080a81b907a3381e5ffa05e063f81#egg=edx-sga==0.8.3
-git+https://github.com/edx/xblock-lti-consumer.git@v1.1.8#egg=lti_consumer-xblock==1.1.8
-git+https://github.com/edx/MongoDBProxy.git@25b99097615bda06bd7cdfe5669ed80dc2a7fed0#egg=MongoDBProxy==0.1.0
 -e .
-git+https://github.com/edx/edx-ora2.git@2.2.3#egg=ora2==2.2.3
 -e git+https://github.com/dgrtwo/ParsePy.git@7949b9f754d1445eff8e8f20d0e967b9a6420639#egg=parse_rest
 -e git+https://github.com/dementrock/pystache_custom.git@776973740bdaad83a3b029f96e415a7d1e8bec2f#egg=pystache_custom-dev
 -e git+https://github.com/edx/RateXBlock.git@367e19c0f6eac8a5f002fd0f1559555f8e74bfff#egg=rate-xblock
-git+https://github.com/edx/RecommenderXBlock.git@1.4.0#egg=recommender-xblock==1.4.0
 -e common/lib/safe_lxml
 -e common/lib/sandbox-packages
-git+https://github.com/davestgermain/super-csv@4963bf5da5489f06369da9cce84c92e3e42fe3d2#egg=super-csv==0.1.0
 -e common/lib/symmath
 -e openedx/core/lib/xblock_builtin/xblock_discussion
-git+https://github.com/edx-solutions/xblock-drag-and-drop-v2@v2.2.1#egg=xblock-drag-and-drop-v2==2.2.1
 -e git+https://github.com/edx-solutions/xblock-google-drive.git@138e6fa0bf3a2013e904a085b9fed77dab7f3f21#egg=xblock-google-drive
-git+https://github.com/open-craft/xblock-poll@add89e14558c30f3c8dc7431e5cd6536fff6d941#egg=xblock-poll==1.5.1
 -e common/lib/xmodule
 amqp==1.4.9               # via kombu
 analytics-python==1.2.9
@@ -52,6 +37,7 @@ bleach==2.1.4
 boto3==1.4.8
 boto==2.39.0
 botocore==1.8.17
+git+https://github.com/edx/openedx-calc.git@e9b698c85ad1152002bc0868f475f153dce88952#egg=calc==0.4
 celery==3.1.25
 certifi==2019.3.9
 cffi==1.12.3
@@ -59,6 +45,7 @@ chardet==3.0.4
 click==7.0                # via user-util
 coreapi==2.3.3            # via django-rest-swagger, openapi-codec
 coreschema==0.0.4         # via coreapi
+git+https://github.com/edx/crowdsourcehinter.git@518605f0a95190949fe77bd39158450639e2e1dc#egg=crowdsourcehinter-xblock==0.1
 cryptography==2.6.1
 cssutils==1.0.2           # via pynliner
 ddt==1.2.1
@@ -67,6 +54,7 @@ defusedxml==0.6.0
 django-appconf==1.0.3     # via django-statici18n
 django-babel-underscore==0.5.2
 django-babel==0.6.2       # via django-babel-underscore
+git+https://github.com/edx/django-celery.git@756cb57aad765cb2b0d37372c1855b8f5f37e6b0#egg=django-celery==3.2.1+edx.2
 django-classy-tags==0.9.0  # via django-sekizai
 django-config-models==1.0.1
 django-cors-headers==2.1.0
@@ -80,8 +68,10 @@ django-model-utils==3.0.0
 django-mptt==0.8.7
 django-multi-email-field==0.5.1  # via edx-enterprise
 django-mysql==2.4.1
+git+https://github.com/edx/django-oauth-plus.git@01ec2a161dfc3465f9d35b9211ae790177418316#egg=django-oauth-plus==2.2.9.edx-1
 django-oauth-toolkit==1.1.3
 django-object-actions==0.10.0  # via edx-enterprise
+git+https://github.com/edx/django-openid-auth.git@0.15.1#egg=django-openid-auth==0.15.1
 django-pipeline==1.6.14
 django-pyfs==2.0
 django-ratelimit-backend==1.1.1
@@ -99,7 +89,9 @@ django-waffle==0.12.0
 django-webpack-loader==0.6.0
 django==1.11.20
 djangorestframework-jwt==1.11.0
+git+https://github.com/edx/django-rest-framework-oauth.git@0a43e8525f1e3048efe4bc70c03de308a277197c#egg=djangorestframework-oauth==1.1.1
 djangorestframework-xml==1.3.0  # via edx-enterprise
+git+https://github.com/edx/django-rest-framework.git@1ceda7c086fddffd1c440cc86856441bbf0bd9cb#egg=djangorestframework==3.6.3
 docopt==0.6.2
 docutils==0.14            # via botocore
 edx-ace==0.1.10
@@ -123,6 +115,7 @@ edx-proctoring==2.0.3
 edx-rbac==0.2.1           # via edx-enterprise
 edx-rest-api-client==1.9.2
 edx-search==1.2.2
+git+https://github.com/mitodl/edx-sga.git@3828ba9e413080a81b907a3381e5ffa05e063f81#egg=edx-sga==0.8.3
 edx-submissions==2.1.1
 edx-user-state-client==1.1.0
 edx-when==0.1.5
@@ -154,6 +147,7 @@ lazy==1.1
 lepl==5.1.3               # via rfc6266-parser
 libsass==0.10.0
 loremipsum==1.0.5
+git+https://github.com/edx/xblock-lti-consumer.git@v1.1.8#egg=lti_consumer-xblock==1.1.8
 lxml==3.8.0
 mailsnake==1.6.4
 mako==1.0.2
@@ -162,6 +156,7 @@ markey==0.8               # via django-babel-underscore
 markupsafe==1.1.1
 maxminddb==1.4.1          # via geoip2
 mock==1.0.1
+git+https://github.com/edx/MongoDBProxy.git@25b99097615bda06bd7cdfe5669ed80dc2a7fed0#egg=MongoDBProxy==0.1.0
 mongoengine==0.10.0
 mpmath==1.1.0             # via sympy
 mysqlclient==1.4.2.post1
@@ -173,6 +168,7 @@ numpy==1.16.3             # via scipy
 oauth2==1.9.0.post1
 oauthlib==2.1.0
 openapi-codec==1.3.2      # via django-rest-swagger
+git+https://github.com/edx/edx-ora2.git@2.2.3#egg=ora2==2.2.3
 path.py==8.2.1
 pathtools==0.1.2
 paver==1.3.4
@@ -205,6 +201,7 @@ python3-saml==1.5.0
 pytz==2019.1
 pyuca==1.1
 pyyaml==5.1
+git+https://github.com/edx/RecommenderXBlock.git@1.4.0#egg=recommender-xblock==1.4.0
 redis==2.10.6
 reportlab==3.5.21
 requests-oauthlib==1.1.0
@@ -229,6 +226,7 @@ sortedcontainers==2.1.0
 soupsieve==1.9.1          # via beautifulsoup4
 sqlparse==0.3.0
 stevedore==1.30.1
+git+https://github.com/davestgermain/super-csv@4963bf5da5489f06369da9cce84c92e3e42fe3d2#egg=super-csv==0.1.0
 sympy==1.4
 tincan==0.0.5             # via edx-enterprise
 unicodecsv==0.14.1
@@ -241,6 +239,8 @@ web-fragments==0.3.0
 webencodings==0.5.1       # via html5lib
 webob==1.8.5              # via xblock
 wrapt==1.10.5
+git+https://github.com/edx-solutions/xblock-drag-and-drop-v2@v2.2.1#egg=xblock-drag-and-drop-v2==2.2.1
+git+https://github.com/open-craft/xblock-poll@add89e14558c30f3c8dc7431e5cd6536fff6d941#egg=xblock-poll==1.5.1
 xblock-utils==1.2.1
 xblock==1.2.2
 zendesk==1.1.1

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -5,37 +5,22 @@
 #    make upgrade
 #
 -e git+https://github.com/edx/acid-block.git@e46f9cda8a03e121a00c7e347084d142d22ebfb7#egg=acid-xblock
-git+https://github.com/edx/openedx-calc.git@e9b698c85ad1152002bc0868f475f153dce88952#egg=calc==0.4
 -e common/lib/capa
 -e common/lib/chem
 -e git+https://github.com/edx/codejail.git@a320d43ce6b9c93b17636b2491f724d9e433be47#egg=codejail
-git+https://github.com/edx/crowdsourcehinter.git@518605f0a95190949fe77bd39158450639e2e1dc#egg=crowdsourcehinter-xblock==0.1
-git+https://github.com/edx/django-celery.git@756cb57aad765cb2b0d37372c1855b8f5f37e6b0#egg=django-celery==3.2.1+edx.2
-git+https://github.com/hmarr/django-debug-toolbar-mongo.git@b0686a76f1ce3532088c4aee6e76b9abe61cc808#egg=django-debug-toolbar-mongo==0.1.10
-git+https://github.com/edx/django-oauth-plus.git@01ec2a161dfc3465f9d35b9211ae790177418316#egg=django-oauth-plus==2.2.9.edx-1
-git+https://github.com/edx/django-openid-auth.git@0.15.1#egg=django-openid-auth==0.15.1
+-e git+https://github.com/hmarr/django-debug-toolbar-mongo.git@b0686a76f1ce3532088c4aee6e76b9abe61cc808#egg=django-debug-toolbar-mongo==0.1.10
 -e git+https://github.com/edx/django-wiki.git@v0.0.21#egg=django-wiki
-git+https://github.com/edx/django-rest-framework-oauth.git@0a43e8525f1e3048efe4bc70c03de308a277197c#egg=djangorestframework-oauth==1.1.1
-git+https://github.com/edx/django-rest-framework.git@1ceda7c086fddffd1c440cc86856441bbf0bd9cb#egg=djangorestframework==3.6.3
 -e git+https://github.com/edx/DoneXBlock.git@01a14f3bd80ae47dd08cdbbe2f88f3eb88d00fba#egg=done-xblock
 -e git+https://github.com/jazkarta/edx-jsme.git@690dbf75441fa91c7c4899df0b83d77f7deb5458#egg=edx-jsme
-git+https://github.com/mitodl/edx-sga.git@3828ba9e413080a81b907a3381e5ffa05e063f81#egg=edx-sga==0.8.3
-git+https://github.com/edx/xblock-lti-consumer.git@v1.1.8#egg=lti_consumer-xblock==1.1.8
-git+https://github.com/edx/MongoDBProxy.git@25b99097615bda06bd7cdfe5669ed80dc2a7fed0#egg=MongoDBProxy==0.1.0
 -e .
-git+https://github.com/edx/edx-ora2.git@2.2.3#egg=ora2==2.2.3
 -e git+https://github.com/dgrtwo/ParsePy.git@7949b9f754d1445eff8e8f20d0e967b9a6420639#egg=parse_rest
 -e git+https://github.com/dementrock/pystache_custom.git@776973740bdaad83a3b029f96e415a7d1e8bec2f#egg=pystache_custom-dev
 -e git+https://github.com/edx/RateXBlock.git@367e19c0f6eac8a5f002fd0f1559555f8e74bfff#egg=rate-xblock
-git+https://github.com/edx/RecommenderXBlock.git@1.4.0#egg=recommender-xblock==1.4.0
 -e common/lib/safe_lxml
 -e common/lib/sandbox-packages
-git+https://github.com/davestgermain/super-csv@4963bf5da5489f06369da9cce84c92e3e42fe3d2#egg=super-csv==0.1.0
 -e common/lib/symmath
 -e openedx/core/lib/xblock_builtin/xblock_discussion
-git+https://github.com/edx-solutions/xblock-drag-and-drop-v2@v2.2.1#egg=xblock-drag-and-drop-v2==2.2.1
 -e git+https://github.com/edx-solutions/xblock-google-drive.git@138e6fa0bf3a2013e904a085b9fed77dab7f3f21#egg=xblock-google-drive
-git+https://github.com/open-craft/xblock-poll@add89e14558c30f3c8dc7431e5cd6536fff6d941#egg=xblock-poll==1.5.1
 -e common/lib/xmodule
 alabaster==0.7.12         # via sphinx
 amqp==1.4.9
@@ -61,6 +46,7 @@ bok-choy==1.0.0
 boto3==1.4.8
 boto==2.39.0
 botocore==1.8.17
+git+https://github.com/edx/openedx-calc.git@e9b698c85ad1152002bc0868f475f153dce88952#egg=calc==0.4
 caniusepython3==7.1.0
 celery==3.1.25
 certifi==2019.3.9
@@ -75,6 +61,7 @@ constantly==15.1.0
 coreapi==2.3.3
 coreschema==0.0.4
 coverage==4.4
+git+https://github.com/edx/crowdsourcehinter.git@518605f0a95190949fe77bd39158450639e2e1dc#egg=crowdsourcehinter-xblock==0.1
 cryptography==2.6.1
 cssselect==1.0.3
 cssutils==1.0.2
@@ -87,6 +74,7 @@ distlib==0.2.9.post0
 django-appconf==1.0.3
 django-babel-underscore==0.5.2
 django-babel==0.6.2
+git+https://github.com/edx/django-celery.git@756cb57aad765cb2b0d37372c1855b8f5f37e6b0#egg=django-celery==3.2.1+edx.2
 django-classy-tags==0.9.0
 django-config-models==1.0.1
 django-cors-headers==2.1.0
@@ -101,8 +89,10 @@ django-model-utils==3.0.0
 django-mptt==0.8.7
 django-multi-email-field==0.5.1
 django-mysql==2.4.1
+git+https://github.com/edx/django-oauth-plus.git@01ec2a161dfc3465f9d35b9211ae790177418316#egg=django-oauth-plus==2.2.9.edx-1
 django-oauth-toolkit==1.1.3
 django-object-actions==0.10.0
+git+https://github.com/edx/django-openid-auth.git@0.15.1#egg=django-openid-auth==0.15.1
 django-pipeline==1.6.14
 django-pyfs==2.0
 django-ratelimit-backend==1.1.1
@@ -120,7 +110,9 @@ django-waffle==0.12.0
 django-webpack-loader==0.6.0
 django==1.11.20
 djangorestframework-jwt==1.11.0
+git+https://github.com/edx/django-rest-framework-oauth.git@0a43e8525f1e3048efe4bc70c03de308a277197c#egg=djangorestframework-oauth==1.1.1
 djangorestframework-xml==1.3.0
+git+https://github.com/edx/django-rest-framework.git@1ceda7c086fddffd1c440cc86856441bbf0bd9cb#egg=djangorestframework==3.6.3
 docopt==0.6.2
 docutils==0.14
 edx-ace==0.1.10
@@ -145,6 +137,7 @@ edx-proctoring==2.0.3
 edx-rbac==0.2.1
 edx-rest-api-client==1.9.2
 edx-search==1.2.2
+git+https://github.com/mitodl/edx-sga.git@3828ba9e413080a81b907a3381e5ffa05e063f81#egg=edx-sga==0.8.3
 edx-sphinx-theme==1.4.0
 edx-submissions==2.1.1
 edx-user-state-client==1.1.0
@@ -197,6 +190,7 @@ lazy==1.1
 lepl==5.1.3
 libsass==0.10.0
 loremipsum==1.0.5
+git+https://github.com/edx/xblock-lti-consumer.git@v1.1.8#egg=lti_consumer-xblock==1.1.8
 lxml==3.8.0
 mailsnake==1.6.4
 mako==1.0.2
@@ -208,6 +202,7 @@ maxminddb==1.4.1
 mccabe==0.6.1
 mock==1.0.1
 modernize==0.7
+git+https://github.com/edx/MongoDBProxy.git@25b99097615bda06bd7cdfe5669ed80dc2a7fed0#egg=MongoDBProxy==0.1.0
 mongoengine==0.10.0
 more-itertools==5.0.0
 moto==0.3.1
@@ -221,6 +216,7 @@ numpy==1.16.3
 oauth2==1.9.0.post1
 oauthlib==2.1.0
 openapi-codec==1.3.2
+git+https://github.com/edx/edx-ora2.git@2.2.3#egg=ora2==2.2.3
 pa11ycrawler==1.7.3
 packaging==19.0
 parsel==1.5.1
@@ -284,6 +280,7 @@ pyuca==1.1
 pyyaml==5.1
 queuelib==1.5.0
 radon==3.0.3
+git+https://github.com/edx/RecommenderXBlock.git@1.4.0#egg=recommender-xblock==1.4.0
 redis==2.10.6
 reportlab==3.5.21
 requests-oauthlib==1.1.0
@@ -316,6 +313,7 @@ sphinx==1.8.5
 sphinxcontrib-websupport==1.1.2  # via sphinx
 sqlparse==0.3.0
 stevedore==1.30.1
+git+https://github.com/davestgermain/super-csv@4963bf5da5489f06369da9cce84c92e3e42fe3d2#egg=super-csv==0.1.0
 sympy==1.4
 testfixtures==6.8.2
 text-unidecode==1.2
@@ -343,6 +341,8 @@ webencodings==0.5.1
 webob==1.8.5
 werkzeug==0.15.4
 wrapt==1.10.5
+git+https://github.com/edx-solutions/xblock-drag-and-drop-v2@v2.2.1#egg=xblock-drag-and-drop-v2==2.2.1
+git+https://github.com/open-craft/xblock-poll@add89e14558c30f3c8dc7431e5cd6536fff6d941#egg=xblock-poll==1.5.1
 xblock-utils==1.2.1
 xblock==1.2.2
 xmltodict==0.12.0

--- a/requirements/edx/github.in
+++ b/requirements/edx/github.in
@@ -13,11 +13,11 @@
 #
 # A correct GitHub reference looks like this:
 #
-#   -e git+https://github.com/OWNER/REPO-NAME.git@TAG-OR-SHA#egg=DIST-NAME==VERSION
+#   git+https://github.com/OWNER/REPO-NAME.git@TAG-OR-SHA#egg=DIST-NAME==VERSION
 #
 # For example:
 #
-#   -e git+https://github.com/edx/edx-lint.git@v0.3.2#egg=edx_lint==0.3.2
+#   git+https://github.com/edx/edx-lint.git@v0.3.2#egg=edx_lint==0.3.2
 #
 # where:
 #
@@ -31,13 +31,6 @@
 # Rules to follow (even though many URLs here don't follow them!):
 #
 #   * Don't leave out any of these pieces.
-#
-#   * The "-e" prefix is primarily for the benefit of pip-compile, which does
-#     not yet support non-editable GitHub URLs.  If a VERSION is correctly
-#     specified as shown above, the "-e" prefix will be stripped from the
-#     output file by the post-pip-compile.sh script.  (Note that we previously
-#     recommended omitting this prefix, and will again if the relevant
-#     pip-tools issue is fixed.)
 #
 #   * TAG-OR-SHA is the specific commit to install.  It must be a git tag,
 #     or a git SHA commit hash.  Don't use branch names here.  If OWNER is
@@ -59,45 +52,45 @@
 
 
 # Python libraries to install directly from github
--e git+https://github.com/edx/openedx-calc.git@e9b698c85ad1152002bc0868f475f153dce88952#egg=calc==0.4
+git+https://github.com/edx/openedx-calc.git@e9b698c85ad1152002bc0868f475f153dce88952#egg=calc==0.4
 
 # Third-party:
 -e git+https://github.com/edx/django-wiki.git@v0.0.21#egg=django-wiki
--e git+https://github.com/edx/django-openid-auth.git@0.15.1#egg=django-openid-auth==0.15.1
--e git+https://github.com/edx/MongoDBProxy.git@25b99097615bda06bd7cdfe5669ed80dc2a7fed0#egg=MongoDBProxy==0.1.0
+git+https://github.com/edx/django-openid-auth.git@0.15.1#egg=django-openid-auth==0.15.1
+git+https://github.com/edx/MongoDBProxy.git@25b99097615bda06bd7cdfe5669ed80dc2a7fed0#egg=MongoDBProxy==0.1.0
 -e git+https://github.com/dementrock/pystache_custom.git@776973740bdaad83a3b029f96e415a7d1e8bec2f#egg=pystache_custom-dev
 -e git+https://github.com/jazkarta/edx-jsme.git@690dbf75441fa91c7c4899df0b83d77f7deb5458#egg=edx-jsme
 -e git+https://github.com/dgrtwo/ParsePy.git@7949b9f754d1445eff8e8f20d0e967b9a6420639#egg=parse_rest
 
 # Forked to get Django 1.10+ compat that is in origin BitBucket repo, without an official build.
 # This can go away when we update auth to not use django-rest-framework-oauth
--e git+https://github.com/edx/django-oauth-plus.git@01ec2a161dfc3465f9d35b9211ae790177418316#egg=django-oauth-plus==2.2.9.edx-1
+git+https://github.com/edx/django-oauth-plus.git@01ec2a161dfc3465f9d35b9211ae790177418316#egg=django-oauth-plus==2.2.9.edx-1
 
 # Why a DRF fork? See: https://openedx.atlassian.net/browse/PLAT-1581
--e git+https://github.com/edx/django-rest-framework.git@1ceda7c086fddffd1c440cc86856441bbf0bd9cb#egg=djangorestframework==3.6.3
+git+https://github.com/edx/django-rest-framework.git@1ceda7c086fddffd1c440cc86856441bbf0bd9cb#egg=djangorestframework==3.6.3
 
 # Why a drf-oauth fork? To add Django 1.11 compatibility to the abandoned repo.
 # This dependency will be removed by this work: https://openedx.atlassian.net/browse/PLAT-1660
--e git+https://github.com/edx/django-rest-framework-oauth.git@0a43e8525f1e3048efe4bc70c03de308a277197c#egg=djangorestframework-oauth==1.1.1
+git+https://github.com/edx/django-rest-framework-oauth.git@0a43e8525f1e3048efe4bc70c03de308a277197c#egg=djangorestframework-oauth==1.1.1
 
 # Why a django-celery fork? To add Django 1.11 compatibility to the abandoned repo.
 # This dependency will be removed by the Celery 4 upgrade: https://openedx.atlassian.net/browse/PLAT-1684
--e git+https://github.com/edx/django-celery.git@756cb57aad765cb2b0d37372c1855b8f5f37e6b0#egg=django-celery==3.2.1+edx.2
+git+https://github.com/edx/django-celery.git@756cb57aad765cb2b0d37372c1855b8f5f37e6b0#egg=django-celery==3.2.1+edx.2
 
 # Our libraries:
 -e git+https://github.com/edx/codejail.git@a320d43ce6b9c93b17636b2491f724d9e433be47#egg=codejail
 -e git+https://github.com/edx/acid-block.git@e46f9cda8a03e121a00c7e347084d142d22ebfb7#egg=acid-xblock
--e git+https://github.com/edx/edx-ora2.git@2.2.3#egg=ora2==2.2.3
--e git+https://github.com/edx/RecommenderXBlock.git@1.4.0#egg=recommender-xblock==1.4.0
--e git+https://github.com/edx/crowdsourcehinter.git@518605f0a95190949fe77bd39158450639e2e1dc#egg=crowdsourcehinter-xblock==0.1
+git+https://github.com/edx/edx-ora2.git@2.2.3#egg=ora2==2.2.3
+git+https://github.com/edx/RecommenderXBlock.git@1.4.0#egg=recommender-xblock==1.4.0
+git+https://github.com/edx/crowdsourcehinter.git@518605f0a95190949fe77bd39158450639e2e1dc#egg=crowdsourcehinter-xblock==0.1
 -e git+https://github.com/edx/RateXBlock.git@367e19c0f6eac8a5f002fd0f1559555f8e74bfff#egg=rate-xblock
 -e git+https://github.com/edx/DoneXBlock.git@01a14f3bd80ae47dd08cdbbe2f88f3eb88d00fba#egg=done-xblock
 -e git+https://github.com/edx-solutions/xblock-google-drive.git@138e6fa0bf3a2013e904a085b9fed77dab7f3f21#egg=xblock-google-drive
--e git+https://github.com/edx/xblock-lti-consumer.git@v1.1.8#egg=lti_consumer-xblock==1.1.8
--e git+https://github.com/davestgermain/super-csv@4963bf5da5489f06369da9cce84c92e3e42fe3d2#egg=super-csv==0.1.0
+git+https://github.com/edx/xblock-lti-consumer.git@v1.1.8#egg=lti_consumer-xblock==1.1.8
+git+https://github.com/davestgermain/super-csv@4963bf5da5489f06369da9cce84c92e3e42fe3d2#egg=super-csv==0.1.0
 
 # Third Party XBlocks
 
--e git+https://github.com/mitodl/edx-sga.git@3828ba9e413080a81b907a3381e5ffa05e063f81#egg=edx-sga==0.8.3
--e git+https://github.com/open-craft/xblock-poll@add89e14558c30f3c8dc7431e5cd6536fff6d941#egg=xblock-poll==1.5.1
--e git+https://github.com/edx-solutions/xblock-drag-and-drop-v2@v2.2.1#egg=xblock-drag-and-drop-v2==2.2.1
+git+https://github.com/mitodl/edx-sga.git@3828ba9e413080a81b907a3381e5ffa05e063f81#egg=edx-sga==0.8.3
+git+https://github.com/open-craft/xblock-poll@add89e14558c30f3c8dc7431e5cd6536fff6d941#egg=xblock-poll==1.5.1
+git+https://github.com/edx-solutions/xblock-drag-and-drop-v2@v2.2.1#egg=xblock-drag-and-drop-v2==2.2.1

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -5,36 +5,21 @@
 #    make upgrade
 #
 -e git+https://github.com/edx/acid-block.git@e46f9cda8a03e121a00c7e347084d142d22ebfb7#egg=acid-xblock
-git+https://github.com/edx/openedx-calc.git@e9b698c85ad1152002bc0868f475f153dce88952#egg=calc==0.4
 -e common/lib/capa
 -e common/lib/chem
 -e git+https://github.com/edx/codejail.git@a320d43ce6b9c93b17636b2491f724d9e433be47#egg=codejail
-git+https://github.com/edx/crowdsourcehinter.git@518605f0a95190949fe77bd39158450639e2e1dc#egg=crowdsourcehinter-xblock==0.1
-git+https://github.com/edx/django-celery.git@756cb57aad765cb2b0d37372c1855b8f5f37e6b0#egg=django-celery==3.2.1+edx.2
-git+https://github.com/edx/django-oauth-plus.git@01ec2a161dfc3465f9d35b9211ae790177418316#egg=django-oauth-plus==2.2.9.edx-1
-git+https://github.com/edx/django-openid-auth.git@0.15.1#egg=django-openid-auth==0.15.1
 -e git+https://github.com/edx/django-wiki.git@v0.0.21#egg=django-wiki
-git+https://github.com/edx/django-rest-framework-oauth.git@0a43e8525f1e3048efe4bc70c03de308a277197c#egg=djangorestframework-oauth==1.1.1
-git+https://github.com/edx/django-rest-framework.git@1ceda7c086fddffd1c440cc86856441bbf0bd9cb#egg=djangorestframework==3.6.3
 -e git+https://github.com/edx/DoneXBlock.git@01a14f3bd80ae47dd08cdbbe2f88f3eb88d00fba#egg=done-xblock
 -e git+https://github.com/jazkarta/edx-jsme.git@690dbf75441fa91c7c4899df0b83d77f7deb5458#egg=edx-jsme
-git+https://github.com/mitodl/edx-sga.git@3828ba9e413080a81b907a3381e5ffa05e063f81#egg=edx-sga==0.8.3
-git+https://github.com/edx/xblock-lti-consumer.git@v1.1.8#egg=lti_consumer-xblock==1.1.8
-git+https://github.com/edx/MongoDBProxy.git@25b99097615bda06bd7cdfe5669ed80dc2a7fed0#egg=MongoDBProxy==0.1.0
 -e .
-git+https://github.com/edx/edx-ora2.git@2.2.3#egg=ora2==2.2.3
 -e git+https://github.com/dgrtwo/ParsePy.git@7949b9f754d1445eff8e8f20d0e967b9a6420639#egg=parse_rest
 -e git+https://github.com/dementrock/pystache_custom.git@776973740bdaad83a3b029f96e415a7d1e8bec2f#egg=pystache_custom-dev
 -e git+https://github.com/edx/RateXBlock.git@367e19c0f6eac8a5f002fd0f1559555f8e74bfff#egg=rate-xblock
-git+https://github.com/edx/RecommenderXBlock.git@1.4.0#egg=recommender-xblock==1.4.0
 -e common/lib/safe_lxml
 -e common/lib/sandbox-packages
-git+https://github.com/davestgermain/super-csv@4963bf5da5489f06369da9cce84c92e3e42fe3d2#egg=super-csv==0.1.0
 -e common/lib/symmath
 -e openedx/core/lib/xblock_builtin/xblock_discussion
-git+https://github.com/edx-solutions/xblock-drag-and-drop-v2@v2.2.1#egg=xblock-drag-and-drop-v2==2.2.1
 -e git+https://github.com/edx-solutions/xblock-google-drive.git@138e6fa0bf3a2013e904a085b9fed77dab7f3f21#egg=xblock-google-drive
-git+https://github.com/open-craft/xblock-poll@add89e14558c30f3c8dc7431e5cd6536fff6d941#egg=xblock-poll==1.5.1
 -e common/lib/xmodule
 amqp==1.4.9
 analytics-python==1.2.9
@@ -59,6 +44,7 @@ bok-choy==1.0.0
 boto3==1.4.8
 boto==2.39.0
 botocore==1.8.17
+git+https://github.com/edx/openedx-calc.git@e9b698c85ad1152002bc0868f475f153dce88952#egg=calc==0.4
 caniusepython3==7.1.0
 celery==3.1.25
 certifi==2019.3.9
@@ -73,6 +59,7 @@ constantly==15.1.0        # via twisted
 coreapi==2.3.3
 coreschema==0.0.4
 coverage==4.4
+git+https://github.com/edx/crowdsourcehinter.git@518605f0a95190949fe77bd39158450639e2e1dc#egg=crowdsourcehinter-xblock==0.1
 cryptography==2.6.1
 cssselect==1.0.3
 cssutils==1.0.2
@@ -85,6 +72,7 @@ distlib==0.2.9.post0      # via caniusepython3
 django-appconf==1.0.3
 django-babel-underscore==0.5.2
 django-babel==0.6.2
+git+https://github.com/edx/django-celery.git@756cb57aad765cb2b0d37372c1855b8f5f37e6b0#egg=django-celery==3.2.1+edx.2
 django-classy-tags==0.9.0
 django-config-models==1.0.1
 django-cors-headers==2.1.0
@@ -98,8 +86,10 @@ django-model-utils==3.0.0
 django-mptt==0.8.7
 django-multi-email-field==0.5.1
 django-mysql==2.4.1
+git+https://github.com/edx/django-oauth-plus.git@01ec2a161dfc3465f9d35b9211ae790177418316#egg=django-oauth-plus==2.2.9.edx-1
 django-oauth-toolkit==1.1.3
 django-object-actions==0.10.0
+git+https://github.com/edx/django-openid-auth.git@0.15.1#egg=django-openid-auth==0.15.1
 django-pipeline==1.6.14
 django-pyfs==2.0
 django-ratelimit-backend==1.1.1
@@ -116,7 +106,9 @@ django-user-tasks==0.1.5
 django-waffle==0.12.0
 django-webpack-loader==0.6.0
 djangorestframework-jwt==1.11.0
+git+https://github.com/edx/django-rest-framework-oauth.git@0a43e8525f1e3048efe4bc70c03de308a277197c#egg=djangorestframework-oauth==1.1.1
 djangorestframework-xml==1.3.0
+git+https://github.com/edx/django-rest-framework.git@1ceda7c086fddffd1c440cc86856441bbf0bd9cb#egg=djangorestframework==3.6.3
 docopt==0.6.2
 docutils==0.14
 edx-ace==0.1.10
@@ -141,6 +133,7 @@ edx-proctoring==2.0.3
 edx-rbac==0.2.1
 edx-rest-api-client==1.9.2
 edx-search==1.2.2
+git+https://github.com/mitodl/edx-sga.git@3828ba9e413080a81b907a3381e5ffa05e063f81#egg=edx-sga==0.8.3
 edx-submissions==2.1.1
 edx-user-state-client==1.1.0
 edx-when==0.1.5
@@ -191,6 +184,7 @@ lazy==1.1
 lepl==5.1.3
 libsass==0.10.0
 loremipsum==1.0.5
+git+https://github.com/edx/xblock-lti-consumer.git@v1.1.8#egg=lti_consumer-xblock==1.1.8
 lxml==3.8.0
 mailsnake==1.6.4
 mako==1.0.2
@@ -201,6 +195,7 @@ markupsafe==1.1.1
 maxminddb==1.4.1
 mccabe==0.6.1             # via flake8, pylint
 mock==1.0.1
+git+https://github.com/edx/MongoDBProxy.git@25b99097615bda06bd7cdfe5669ed80dc2a7fed0#egg=MongoDBProxy==0.1.0
 mongoengine==0.10.0
 more-itertools==5.0.0     # via pytest
 moto==0.3.1
@@ -214,6 +209,7 @@ numpy==1.16.3
 oauth2==1.9.0.post1
 oauthlib==2.1.0
 openapi-codec==1.3.2
+git+https://github.com/edx/edx-ora2.git@2.2.3#egg=ora2==2.2.3
 pa11ycrawler==1.7.3
 packaging==19.0           # via caniusepython3
 parsel==1.5.1             # via scrapy
@@ -275,6 +271,7 @@ pyuca==1.1
 pyyaml==5.1
 queuelib==1.5.0           # via scrapy
 radon==3.0.3
+git+https://github.com/edx/RecommenderXBlock.git@1.4.0#egg=recommender-xblock==1.4.0
 redis==2.10.6
 reportlab==3.5.21
 requests-oauthlib==1.1.0
@@ -303,6 +300,7 @@ sortedcontainers==2.1.0
 soupsieve==1.9.1
 sqlparse==0.3.0
 stevedore==1.30.1
+git+https://github.com/davestgermain/super-csv@4963bf5da5489f06369da9cce84c92e3e42fe3d2#egg=super-csv==0.1.0
 sympy==1.4
 testfixtures==6.8.2
 text-unidecode==1.2       # via faker
@@ -329,6 +327,8 @@ webencodings==0.5.1
 webob==1.8.5
 werkzeug==0.15.4          # via flask
 wrapt==1.10.5
+git+https://github.com/edx-solutions/xblock-drag-and-drop-v2@v2.2.1#egg=xblock-drag-and-drop-v2==2.2.1
+git+https://github.com/open-craft/xblock-poll@add89e14558c30f3c8dc7431e5cd6536fff6d941#egg=xblock-poll==1.5.1
 xblock-utils==1.2.1
 xblock==1.2.2
 xmltodict==0.12.0         # via moto

--- a/scripts/post-pip-compile.sh
+++ b/scripts/post-pip-compile.sh
@@ -14,10 +14,6 @@ function show_help {
 function clean_file {
     FILE_PATH=$1
     TEMP_FILE=${FILE_PATH}.tmp
-    # If an editable VCS URL has a version number suffix, it was only editable for pip-compile's benefit;
-    # this is a workaround for https://github.com/jazzband/pip-tools/issues/355
-    sed 's/-e \(.*==.*\)/\1/' ${FILE_PATH} > ${TEMP_FILE}
-    mv ${TEMP_FILE} ${FILE_PATH}
     # Workaround for https://github.com/jazzband/pip-tools/issues/204 -
     # change absolute paths for local editable packages back to relative ones
     FILE_CONTENT=$(<${FILE_PATH})


### PR DESCRIPTION
A recent pip-tools release fixed a bug in processing dependencies given as git URLs, so we no longer need our workaround for that.  This rearranges the output files such that the URL dependencies are now correctly sorted by package name, which is kind of nice.

Note that some dependencies still use the editable prefix; at least some of these actually need to be installed as editable, and it's hard to tell which ones.  I tried to keep the essential content of the output files unchanged so as to avoid unexpected bugs while removing the workaround.