### PR TITLE
fix disable of pylint ungrouped-imports

### DIFF
--- a/pylintrc
+++ b/pylintrc
@@ -350,6 +350,7 @@ disable =
 	too-many-locals,
 	too-many-public-methods,
 	too-many-return-statements,
+	ungrouped-imports,
 	unichr-builtin,
 	unicode-builtin,
 	unpacking-in-except,
@@ -456,4 +457,4 @@ int-import-graph =
 [EXCEPTIONS]
 overgeneral-exceptions = Exception
 
-# 69925c09262a3e603e0b833ddc773d2d0c267899
+# f53942526b8e9020150e5025e6a8aa60c76971d9

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -127,7 +127,7 @@ edx-django-utils==1.0.3
 edx-drf-extensions==2.2.1
 edx-enterprise==1.5.5
 edx-i18n-tools==0.4.8
-edx-lint==1.2.0
+edx-lint==1.2.1
 edx-milestones==0.1.13
 edx-oauth2-provider==1.2.2
 edx-opaque-keys[django]==0.4.4

--- a/requirements/edx/testing.in
+++ b/requirements/edx/testing.in
@@ -25,7 +25,7 @@ code-annotations          # Perform code annotation checking, such as for PII an
 cssselect                 # Used to extract HTML fragments via CSS selectors in 2 test cases and pyquery
 ddt                       # Run a test case multiple times with different input; used in many, many of our tests
 edx-i18n-tools>=0.4.6     # Commands for developers and translators to extract, compile and validate translations
-edx-lint==1.2.0           # pylint extensions for Open edX repositories
+edx-lint==1.2.1           # pylint extensions for Open edX repositories
 factory_boy==2.8.1        # Library for creating test fixtures, used in many tests
 freezegun                 # Allows tests to mock the output of assorted datetime module functions
 httpretty                 # Library for mocking HTTP requests, used in many tests

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -123,7 +123,7 @@ edx-django-utils==1.0.3
 edx-drf-extensions==2.2.1
 edx-enterprise==1.5.5
 edx-i18n-tools==0.4.8
-edx-lint==1.2.0
+edx-lint==1.2.1
 edx-milestones==0.1.13
 edx-oauth2-provider==1.2.2
 edx-opaque-keys[django]==0.4.4


### PR DESCRIPTION
This fixes an issue from https://github.com/edx/edx-platform/pull/20644 where ungrouped-imports rule needed to be added to the disabled list in addition to removing from the enabled list.