### PR TITLE
Add last_login and date_joined to the student profile export

### DIFF
--- a/lms/djangoapps/instructor/views/api.py
+++ b/lms/djangoapps/instructor/views/api.py
@@ -1317,6 +1317,7 @@ def get_students_features(request, course_id, csv=False):  # pylint: disable=red
             'id', 'username', 'name', 'email', 'language', 'location',
             'year_of_birth', 'gender', 'level_of_education', 'mailing_address',
             'goals', 'enrollment_mode', 'verification_status',
+            'last_login', 'date_joined',
         ]
 
     # Provide human-friendly and translatable names for these features. These names
@@ -1336,6 +1337,8 @@ def get_students_features(request, course_id, csv=False):  # pylint: disable=red
         'goals': _('Goals'),
         'enrollment_mode': _('Enrollment Mode'),
         'verification_status': _('Verification Status'),
+        'last_login': _('Last Login'),
+        'date_joined': _('Date Joined'),
     }
 
     if is_course_cohorted(course.id):

--- a/lms/djangoapps/instructor_analytics/basic.py
+++ b/lms/djangoapps/instructor_analytics/basic.py
@@ -39,7 +39,8 @@ from student.models import CourseEnrollment, CourseEnrollmentAllowed
 log = logging.getLogger(__name__)
 
 
-STUDENT_FEATURES = ('id', 'username', 'first_name', 'last_name', 'is_staff', 'email')
+STUDENT_FEATURES = ('id', 'username', 'first_name', 'last_name', 'is_staff', 'email',
+                    'date_joined', 'last_login')
 PROFILE_FEATURES = ('name', 'language', 'location', 'year_of_birth', 'gender',
                     'level_of_education', 'mailing_address', 'goals', 'meta',
                     'city', 'country')


### PR DESCRIPTION
This adds two columns to the student profile CSV export in the *Instructor dashboard*:
- **last login date**: this is mainly useful to tell apart the users who logged in at least once from those who never logged in, after having added them through a CSV file ([bulk enroll](https://github.com/edx/edx-platform/blob/920ce74877177a12029fc547da42ea932efeac28/lms/djangoapps/instructor/settings/common.py#L33)). The exact concept of *last login date* isn't very intuitive: it isn't when a user opened the site for the last time, but when it went through the login form, which happens less often. But still, the ability to find users who never logged in is more useful
- **creation date**: it seems an interesting information to have together with last login date

Note that one particular case of differentiating between users who logged in and users who didn't is: after doing a bulk enroll from a CSV file, Open edX sends an e-mail to the user. But if the e-mail address was wrong (e.g. typos), the user won't get the e-mail and Open edX won't notice. By looking at `last_login`, staff can find those users.    



**JIRA tickets**: None. This is SE-1078 internally

**Discussions**:

I decided to enable both by default. But if you consider they are not useful to everyone, another option would be not to show them by default, and whoever wants them could enable them through a `SiteConfiguration` variable like:
```
{
"student_profile_download_fields":
[
            "id", "username", "name", "email", "language", "location",
            "year_of_birth", "gender", "level_of_education", "mailing_address",
            "goals", "enrollment_mode", "verification_status",
            "last_login", "date_joined"
]
}
```

We'd still need the rest of the code in this PR, since otherwise the fields would show blank.

**Dependencies**: None

**Screenshots**:

The new columns appear like this
![new-columns](https://user-images.githubusercontent.com/132703/58277330-23c81580-7da2-11e9-9948-55eab68825cf.png)

whereas the CSV will look like:
```
id,username,name,email,language,location,year_of_birth,gender,level_of_education,mailing_address,goals,enrollment_mode,verification_status,last_login,date_joined,city,country
14,danieltest11,Daniel Eleven,daniel+test11@xxxxxx.com,,,None,None,None,None,None,audit,N/A,None,2019-02-20 02:12:48.957127+00:00,None,es
2,edx,,edx@example.com,,,None,None,None,None,None,audit,N/A,2019-05-21 21:51:21.144979+00:00,2016-12-17 01:53:34.104225+00:00,None,
…
```

**Sandbox URL**: provisioning a sandbox, but there was an unrelated error… I'll try to have that fixed; let me know if you need a sandbox.

**Merge deadline**: None

**Testing instructions**:

1. Go to http://localhost:18000/courses/course-v1:edX+DemoX+Demo_Course/instructor#view-data_download
2. click the button at the top, *Download profile information as a CSV*, and get it at the bottom. In the docker devstack, the file ends up somewhere like `/tmp/edx-s3/grades/bb6d638a296059742509a0d319ddf8456b6dbf9a/edX_DemoX_Demo_Course_student_profile_info_2019-05-22-2318.csv` (the MEDIA folder seems to be wrong); get it from there
3. also try the *List enrolled students' profile information* button below, which shows it in a table
4. the information should match data seen in the Django admin

**Reviewers**
- [x] @sspj 
- edX

**Author concerns**: This includes new translatable strings. The timestamps are in raw format.
**Settings**: None
