### PR TITLE
Reverting ENT-1054

### DIFF
--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -104,7 +104,7 @@ edx-django-release-util==0.3.1
 edx-django-sites-extensions==2.3.1
 edx-django-utils==1.0.3
 edx-drf-extensions==2.2.1
-edx-enterprise==1.5.6
+edx-enterprise==1.5.9
 edx-i18n-tools==0.4.8
 edx-milestones==0.1.13
 edx-oauth2-provider==1.2.2
@@ -164,7 +164,7 @@ networkx==1.7
 newrelic==4.20.0.120
 nltk==3.4.1
 nodeenv==1.1.1
-numpy==1.16.3             # via scipy
+numpy==1.16.3
 oauth2==1.9.0.post1
 oauthlib==2.1.0
 openapi-codec==1.3.2      # via django-rest-swagger
@@ -184,7 +184,7 @@ pycountry==18.12.8
 pycparser==2.19
 pycryptodome==3.8.1       # via pdfminer.six
 pycryptodomex==3.4.7
-pygments==2.4.0
+pygments==2.4.1
 pygraphviz==1.5
 pyjwkest==1.3.2
 pyjwt==1.5.2

--- a/requirements/edx/coverage.txt
+++ b/requirements/edx/coverage.txt
@@ -10,5 +10,5 @@ inflect==2.1.0            # via jinja2-pluralize
 jinja2-pluralize==0.3.0   # via diff-cover
 jinja2==2.10.1            # via diff-cover, jinja2-pluralize
 markupsafe==1.1.1         # via jinja2
-pygments==2.4.0           # via diff-cover
+pygments==2.4.1           # via diff-cover
 six==1.11.0

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -123,7 +123,7 @@ edx-django-release-util==0.3.1
 edx-django-sites-extensions==2.3.1
 edx-django-utils==1.0.3
 edx-drf-extensions==2.2.1
-edx-enterprise==1.5.6
+edx-enterprise==1.5.9
 edx-i18n-tools==0.4.8
 edx-lint==1.2.1
 edx-milestones==0.1.13
@@ -235,7 +235,7 @@ pycparser==2.19
 pycryptodome==3.8.1
 pycryptodomex==3.4.7
 pyflakes==2.1.1
-pygments==2.4.0
+pygments==2.4.1
 pygraphviz==1.5
 pyinotify==0.9.6
 pyjwkest==1.3.2

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -119,7 +119,7 @@ edx-django-release-util==0.3.1
 edx-django-sites-extensions==2.3.1
 edx-django-utils==1.0.3
 edx-drf-extensions==2.2.1
-edx-enterprise==1.5.6
+edx-enterprise==1.5.9
 edx-i18n-tools==0.4.8
 edx-lint==1.2.1
 edx-milestones==0.1.13
@@ -227,7 +227,7 @@ pycparser==2.19
 pycryptodome==3.8.1
 pycryptodomex==3.4.7
 pyflakes==2.1.1           # via flake8
-pygments==2.4.0
+pygments==2.4.1
 pygraphviz==1.5
 pyjwkest==1.3.2
 pyjwt==1.5.2


### PR DESCRIPTION
Upgrading edx-enterprise to 1.5.9 to revert code related to ENT-1054. See https://github.com/edx/edx-enterprise/pull/483/files.