### PR TITLE
Restrict number of ID verification expiry emails

### DIFF
--- a/lms/djangoapps/verify_student/management/commands/tests/test_send_verification_expiry_email.py
+++ b/lms/djangoapps/verify_student/management/commands/tests/test_send_verification_expiry_email.py
@@ -11,22 +11,24 @@ from django.conf import settings
 from django.contrib.sites.models import Site
 from django.core import mail
 from django.core.management import call_command
-from django.test import TestCase
 from django.utils.timezone import now
 from mock import patch
+from student.tests.factories import CourseEnrollmentFactory
+from student.tests.factories import UserFactory
 from testfixtures import LogCapture
+from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
+from xmodule.modulestore.tests.factories import CourseFactory
 
 from common.test.utils import MockS3Mixin
 from lms.djangoapps.verify_student.models import SoftwareSecurePhotoVerification
 from lms.djangoapps.verify_student.tests.test_models import FAKE_SETTINGS, mock_software_secure_post
-from student.tests.factories import UserFactory
 
 LOGGER_NAME = 'lms.djangoapps.verify_student.management.commands.send_verification_expiry_email'
 
 
 @patch.dict(settings.VERIFY_STUDENT, FAKE_SETTINGS)
 @patch('lms.djangoapps.verify_student.models.requests.post', new=mock_software_secure_post)
-class TestSendVerificationExpiryEmail(MockS3Mixin, TestCase):
+class TestSendVerificationExpiryEmail(MockS3Mixin, ModuleStoreTestCase):
     """ Tests for django admin command `send_verification_expiry_email` in the verify_student module """
 
     def setUp(self):
@@ -35,6 +37,9 @@ class TestSendVerificationExpiryEmail(MockS3Mixin, TestCase):
         connection = boto.connect_s3()
         connection.create_bucket(FAKE_SETTINGS['SOFTWARE_SECURE']['S3_BUCKET'])
         Site.objects.create(domain='edx.org', name='edx.org')
+        self.resend_days = settings.VERIFICATION_EXPIRY_EMAIL['RESEND_DAYS']
+        self.days = settings.VERIFICATION_EXPIRY_EMAIL['DAYS_RANGE']
+        self.default_no_of_emails = settings.VERIFICATION_EXPIRY_EMAIL['DEFAULT_EMAILS']
 
     def create_and_submit(self, user):
         """ Helper method that lets us create new SoftwareSecurePhotoVerifications """
@@ -53,16 +58,16 @@ class TestSendVerificationExpiryEmail(MockS3Mixin, TestCase):
         user = UserFactory.create()
         verification_in_range = self.create_and_submit(user)
         verification_in_range.status = 'approved'
-        verification_in_range.expiry_date = now() - timedelta(days=1)
+        verification_in_range.expiry_date = now() - timedelta(days=self.days)
         verification_in_range.save()
 
         user = UserFactory.create()
         verification = self.create_and_submit(user)
         verification.status = 'approved'
-        verification.expiry_date = now() - timedelta(days=5)
+        verification.expiry_date = now() - timedelta(days=self.days+1)
         verification.save()
 
-        call_command('send_verification_expiry_email', '--days-range=2')
+        call_command('send_verification_expiry_email')
 
         # Check that only one email is sent
         self.assertEqual(len(mail.outbox), 1)
@@ -77,14 +82,14 @@ class TestSendVerificationExpiryEmail(MockS3Mixin, TestCase):
         resending email
         """
         user = UserFactory.create()
+        today = now().replace(hour=0, minute=0, second=0, microsecond=0)
         verification_in_range = self.create_and_submit(user)
         verification_in_range.status = 'approved'
-        verification_in_range.expiry_date = now() - timedelta(days=30)
-        verification_in_range.expiry_email_date = now() - timedelta(days=3)
+        verification_in_range.expiry_date = now() - timedelta(days=self.days+1)
+        verification_in_range.expiry_email_date = today - timedelta(days=self.resend_days)
         verification_in_range.save()
 
-        command_args = '--days-range={} --resend-days={}'  # pylint: disable=unicode-format-string
-        call_command('send_verification_expiry_email', *command_args.format(2, 2).split(' '))
+        call_command('send_verification_expiry_email')
 
         # Check that email is sent even if the verification is not in expiry_date range but matches the criteria
         # to resend email
@@ -112,7 +117,7 @@ class TestSendVerificationExpiryEmail(MockS3Mixin, TestCase):
         user = UserFactory.create()
         verification = self.create_and_submit(user)
         verification.status = 'approved'
-        verification.expiry_date = now() - timedelta(days=1)
+        verification.expiry_date = now() - timedelta(days=self.days)
         verification.save()
 
         call_command('send_verification_expiry_email')
@@ -130,7 +135,7 @@ class TestSendVerificationExpiryEmail(MockS3Mixin, TestCase):
         user = UserFactory.create()
         verification = self.create_and_submit(user)
         verification.status = 'approved'
-        verification.expiry_date = now() - timedelta(days=1)
+        verification.expiry_date = now() - timedelta(days=self.days)
         verification.expiry_email_date = now()
         verification.save()
 
@@ -142,7 +147,7 @@ class TestSendVerificationExpiryEmail(MockS3Mixin, TestCase):
         """
         Test that if no approved and expired verifications are found the management command terminates gracefully
         """
-        start_date = now() - timedelta(days=1)  # using default days
+        start_date = now() - timedelta(days=self.days)  # using default days
         with LogCapture(LOGGER_NAME) as logger:
             call_command('send_verification_expiry_email')
             logger.check(
@@ -158,10 +163,10 @@ class TestSendVerificationExpiryEmail(MockS3Mixin, TestCase):
         user = UserFactory.create()
         verification = self.create_and_submit(user)
         verification.status = 'approved'
-        verification.expiry_date = now() - timedelta(days=1)
+        verification.expiry_date = now() - timedelta(days=self.days)
         verification.save()
 
-        start_date = now() - timedelta(days=1)  # using default days
+        start_date = now() - timedelta(days=self.days)  # using default days
         count = 1
 
         with LogCapture(LOGGER_NAME) as logger:
@@ -178,3 +183,46 @@ class TestSendVerificationExpiryEmail(MockS3Mixin, TestCase):
                  u"to {} learner(s)".format(count)
                  ))
         self.assertEqual(len(mail.outbox), 0)
+
+    def test_not_enrolled_in_verified_course(self):
+        """
+        Test that if the user is not enrolled in verified track, then after sending the default no of
+        emails, `expiry_email_date` is updated to None so that it's not filtered in the future for
+        sending emails
+        """
+        user = UserFactory.create()
+        today = now().replace(hour=0, minute=0, second=0, microsecond=0)
+        verification = self.create_and_submit(user)
+        verification.status = 'approved'
+        verification.expiry_date = now() - timedelta(days=self.resend_days*self.default_no_of_emails)
+        verification.expiry_email_date = today - timedelta(days=self.resend_days)
+        verification.save()
+
+        call_command('send_verification_expiry_email')
+
+        # check that after sending the default number of emails, the expiry_email_date is set to none for a
+        # user who is not enrolled in verified track
+        attempt = SoftwareSecurePhotoVerification.objects.get(pk=verification.id)
+        self.assertEqual(len(mail.outbox), 1)
+        self.assertIsNone(attempt.expiry_email_date)
+
+    def test_user_enrolled_in_verified_course(self):
+        """
+        Test that if the user is enrolled in verified track, then after sending the second email,
+        `expiry_email_date` is updated to now() so that it's filtered in the future(today+date_range)
+        to send email again
+        """
+        user = UserFactory.create()
+        course = CourseFactory()
+        CourseEnrollmentFactory.create(user=user, course_id=course.id, mode='verified')
+        today = now().replace(hour=0, minute=0, second=0, microsecond=0)
+        verification = self.create_and_submit(user)
+        verification.status = 'approved'
+        verification.expiry_date = now() - timedelta(days=self.resend_days*(self.default_no_of_emails+1))
+        verification.expiry_email_date = today - timedelta(days=self.resend_days)
+        verification.save()
+
+        call_command('send_verification_expiry_email')
+
+        attempt = SoftwareSecurePhotoVerification.objects.get(pk=verification.id)
+        self.assertEqual(attempt.expiry_email_date, today)

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -2480,6 +2480,15 @@ VERIFY_STUDENT = {
     # The variable represents the window within which a verification is considered to be "expiring soon."
     "EXPIRING_SOON_WINDOW": 28,
 }
+
+################# Student Verification Expiry Email #################
+VERIFICATION_EXPIRY_EMAIL = {
+    "RESEND_DAYS": 15,
+    "DAYS_RANGE": 1,
+    "DEFAULT_EMAILS": 2,
+}
+
+
 DISABLE_ACCOUNT_ACTIVATION_REQUIREMENT_SWITCH = "verify_student_disable_account_activation_requirement"
 
 ### This enables the Metrics tab for the Instructor dashboard ###########


### PR DESCRIPTION
Change the criteria to send ID verification expiry email for users that are enrolled in only audit track of courses.

Updated criteria for sending emails:
* an email is sent 1 day after expiration of a users verified status
* A second email is sent 15 days after the initial expiration date if the user has not re-verified
* Additional emails will be capped in the following manner:
    * If a user's verification status is expired and they are in a verified seat in an active course run, they receive 1 email every 15 days after expiration of their verified status until they are no longer enrolled in an active course run or become re-verified
     * If a user is not enrolled in a verified seat of an active course run no additional emails are sent

Additional Changes:
* Updated tests to include values from settings instead of hardcoding them so that if in the future those values are changed, the tests don't start failing
* Changes in common/djangoapps/student/models.py::CourseEnrollment to check if after a new course enrollment is added, does the user qualify to start sending ID verification expiry emails


[LEARNER-7313](https://openedx.atlassian.net/browse/LEARNER-7313)