### PR TITLE
Move command arguments to common settings

### DIFF
--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -2480,6 +2480,14 @@ VERIFY_STUDENT = {
     # The variable represents the window within which a verification is considered to be "expiring soon."
     "EXPIRING_SOON_WINDOW": 28,
 }
+
+################# Student Verification Expiry Email #################
+VERIFICATION_EXPIRY_EMAIL = {
+    "RESEND_DAYS": 15,
+    "DAYS_RANGE": 1,
+    "DEFAULT_EMAILS": 2,
+}
+
 DISABLE_ACCOUNT_ACTIVATION_REQUIREMENT_SWITCH = "verify_student_disable_account_activation_requirement"
 
 ### This enables the Metrics tab for the Instructor dashboard ###########


### PR DESCRIPTION
Move command parameter arguments, resend-days and days-range, to common settings. This will help in creating a consistency in code when the default values are changed in the future and are referenced in many places other than the management command

LEARNER-7313