### PR TITLE
WIP: Update verification expiry email criteria

### DIFF
--- a/common/djangoapps/student/models.py
+++ b/common/djangoapps/student/models.py
@@ -78,8 +78,6 @@ log = logging.getLogger(__name__)
 AUDIT_LOG = logging.getLogger("audit")
 SessionStore = import_module(settings.SESSION_ENGINE).SessionStore  # pylint: disable=invalid-name
 
-resend_days = settings.VERIFICATION_EXPIRY_EMAIL['RESEND_DAYS']
-delta_days = settings.VERIFICATION_EXPIRY_EMAIL['DAYS_RANGE']
 # enroll status changed events - signaled to email_marketing.  See email_marketing.tasks for more info
 
 
@@ -2043,6 +2041,9 @@ def update_expiry_email_date(sender, instance, **kwargs):  # pylint: disable=unu
     verification then send email to get the ID verified by setting the
     expiry_email_date field.
     """
+    resend_days = settings.VERIFICATION_EXPIRY_EMAIL['RESEND_DAYS']
+    delta_days = settings.VERIFICATION_EXPIRY_EMAIL['DAYS_RANGE']
+
     if instance.mode == 'verified':
         today = timezone.now().replace(hour=0, minute=0, second=0, microsecond=0)
         recently_expired_date = today - timedelta(days=delta_days)

--- a/lms/djangoapps/verify_student/management/commands/tests/test_send_verification_expiry_email.py
+++ b/lms/djangoapps/verify_student/management/commands/tests/test_send_verification_expiry_email.py
@@ -193,7 +193,7 @@ class TestSendVerificationExpiryEmail(MockS3Mixin, ModuleStoreTestCase):
         today = now().replace(hour=0, minute=0, second=0, microsecond=0)
         verification = self.create_and_submit(user)
         verification.status = 'approved'
-        verification.expiry_date = now() - timedelta(days=self.resend_days*self.default_no_of_emails)
+        verification.expiry_date = now() - timedelta(days=self.resend_days * self.default_no_of_emails)
         verification.expiry_email_date = today - timedelta(days=self.resend_days)
         verification.save()
 
@@ -217,7 +217,7 @@ class TestSendVerificationExpiryEmail(MockS3Mixin, ModuleStoreTestCase):
         today = now().replace(hour=0, minute=0, second=0, microsecond=0)
         verification = self.create_and_submit(user)
         verification.status = 'approved'
-        verification.expiry_date = now() - timedelta(days=self.resend_days*self.default_no_of_emails)
+        verification.expiry_date = now() - timedelta(days=self.resend_days * self.default_no_of_emails)
         verification.expiry_email_date = today - timedelta(days=self.resend_days)
         verification.save()
 

--- a/lms/djangoapps/verify_student/tests/factories.py
+++ b/lms/djangoapps/verify_student/tests/factories.py
@@ -1,7 +1,10 @@
 """
 Factories related to student verification.
 """
+from datetime import timedelta
 
+from django.conf import settings
+from django.utils.timezone import now
 from factory.django import DjangoModelFactory
 
 from lms.djangoapps.verify_student.models import SoftwareSecurePhotoVerification
@@ -15,3 +18,5 @@ class SoftwareSecurePhotoVerificationFactory(DjangoModelFactory):
         model = SoftwareSecurePhotoVerification
 
     status = 'approved'
+    if settings.VERIFY_STUDENT:
+        expiry_date = now() + timedelta(days=settings.VERIFY_STUDENT["DAYS_GOOD_FOR"])


### PR DESCRIPTION
#### Criteria:
* An email is sent 1 day after expiration of a users verified status
* A second email is sent 15 days after the initial expiration date if the user has not re-verified
* Additional emails will be capped in the following manner:
    * If a user's verification status is expired and they are in a verified seat in an active course run, they 
         receive 1 email every 15 days after expiration of their verified status until they are no longer 
         enrolled in an active course run or become re-verified
    * If a user is not enrolled in a verified seat of an active course run no additional emails are sent until 
       the user gets enrolled in verified track with expired verification(begin prompting the learner again 
       until they re-verify)

#### Changes:
* Call _set_email_expiry_date() after sending email to see if additional emails will be sent to the learner
* **[platform-core]** post_save signal on CourseEnrollment to check if the user qualifies (has expired verification, not currently sending him emails and is now enrolled in verified track) to start sending emails again

[LEARNER-7313](https://openedx.atlassian.net/browse/LEARNER-7313)