### PR TITLE
Fix the unpredictable order randomization issue with randomized content blocks

### DIFF
--- a/common/lib/xmodule/xmodule/tests/test_library_content.py
+++ b/common/lib/xmodule/xmodule/tests/test_library_content.py
@@ -272,9 +272,8 @@ class LibraryContentModuleTestMixin(object):
         Helper method that changes the max_count of self.lc_block, refreshes
         children, and asserts that the number of selected children equals the count provided.
         """
-        # Clear the cache (only needed because we skip saving/re-loading the block) pylint: disable=protected-access
-        if hasattr(self.lc_block._xmodule, '_selected_set'):
-            del self.lc_block._xmodule._selected_set
+        # Construct the XModule for the descriptor, if not present already present pylint: disable=protected-access
+        self.lc_block._xmodule
         self.lc_block.max_count = count
         selected = self.lc_block.get_child_descriptors()
         self.assertEqual(len(selected), count)
@@ -397,8 +396,6 @@ class TestLibraryContentAnalytics(LibraryContentTest):
 
         # Now increase max_count so that one more child will be added:
         self.lc_block.max_count = 2
-        # Clear the cache (only needed because we skip saving/re-loading the block) pylint: disable=protected-access
-        del self.lc_block._xmodule._selected_set
         children = self.lc_block.get_child_descriptors()
         self.assertEqual(len(children), 2)
         child, new_child = children if children[0].location == child.location else reversed(children)
@@ -478,8 +475,6 @@ class TestLibraryContentAnalytics(LibraryContentTest):
         self.lc_block.get_child_descriptors()  # This line is needed in the test environment or the change has no effect
         self.publisher.reset_mock()  # Clear the "assigned" event that was just published.
         self.lc_block.max_count = 0
-        # Clear the cache (only needed because we skip saving/re-loading the block) pylint: disable=protected-access
-        del self.lc_block._xmodule._selected_set
 
         # Check that the event says that one block was removed, leaving no blocks left:
         children = self.lc_block.get_child_descriptors()
@@ -497,8 +492,6 @@ class TestLibraryContentAnalytics(LibraryContentTest):
         # Start by assigning two blocks to the student:
         self.lc_block.get_child_descriptors()  # This line is needed in the test environment or the change has no effect
         self.lc_block.max_count = 2
-        # Clear the cache (only needed because we skip saving/re-loading the block) pylint: disable=protected-access
-        del self.lc_block._xmodule._selected_set
         initial_blocks_assigned = self.lc_block.get_child_descriptors()
         self.assertEqual(len(initial_blocks_assigned), 2)
         self.publisher.reset_mock()  # Clear the "assigned" event that was just published.
@@ -512,8 +505,6 @@ class TestLibraryContentAnalytics(LibraryContentTest):
         self.library.children = [keep_block_lib_usage_key]
         self.store.update_item(self.library, self.user_id)
         self.lc_block.refresh_children()
-        # Clear the cache (only needed because we skip saving/re-loading the block) pylint: disable=protected-access
-        del self.lc_block._xmodule._selected_set
 
         # Check that the event says that one block was removed, leaving one block left:
         children = self.lc_block.get_child_descriptors()

--- a/lms/djangoapps/course_blocks/api.py
+++ b/lms/djangoapps/course_blocks/api.py
@@ -39,6 +39,7 @@ def get_course_block_access_transformers(user):
     """
     course_block_access_transformers = [
         library_content.ContentLibraryTransformer(),
+        library_content.ContentLibraryOrderTransformer(),
         start_date.StartDateTransformer(),
         ContentTypeGateTransformer(),
         user_partitions.UserPartitionTransformer(),

--- a/lms/djangoapps/course_blocks/transformers/library_content.py
+++ b/lms/djangoapps/course_blocks/transformers/library_content.py
@@ -4,6 +4,7 @@ Content Library Transformer.
 from __future__ import absolute_import
 
 import json
+import logging
 import random
 
 import six
@@ -19,6 +20,8 @@ from xmodule.library_content_module import LibraryContentModule
 from xmodule.modulestore.django import modulestore
 
 from ..utils import get_student_module_as_dict
+
+logger = logging.getLogger(__name__)
 
 
 class ContentLibraryTransformer(FilteringTransformerMixin, BlockStructureTransformer):
@@ -41,24 +44,15 @@ class ContentLibraryTransformer(FilteringTransformerMixin, BlockStructureTransfo
         return "library_content"
 
     @classmethod
-    def collect(cls, block_structure):
-        """
-        Collects any information that's necessary to execute this
-        transformer's transform method.
-        """
-        block_structure.request_xblock_fields('mode')
-        block_structure.request_xblock_fields('max_count')
-        block_structure.request_xblock_fields('category')
-        store = modulestore()
-
-        # needed for analytics purposes
+    def set_block_analytics_summary(cls, block_structure, store):
+        """Set the block analytics summary information in the children fields."""
         def summarize_block(usage_key):
             """ Basic information about the given block """
             orig_key, orig_version = store.get_block_original_usage(usage_key)
             return {
-                "usage_key": six.text_type(usage_key),
-                "original_usage_key": six.text_type(orig_key) if orig_key else None,
-                "original_usage_version": six.text_type(orig_version) if orig_version else None,
+                "usage_key": unicode(usage_key),
+                "original_usage_key": unicode(orig_key) if orig_key else None,
+                "original_usage_version": unicode(orig_version) if orig_version else None,
             }
 
         # For each block check if block is library_content.
@@ -71,6 +65,20 @@ class ContentLibraryTransformer(FilteringTransformerMixin, BlockStructureTransfo
             for child_key in xblock.children:
                 summary = summarize_block(child_key)
                 block_structure.set_transformer_block_field(child_key, cls, 'block_analytics_summary', summary)
+
+    @classmethod
+    def collect(cls, block_structure):
+        """
+        Collects any information that's necessary to execute this
+        transformer's transform method.
+        """
+        block_structure.request_xblock_fields('mode')
+        block_structure.request_xblock_fields('max_count')
+        block_structure.request_xblock_fields('category')
+        store = modulestore()
+
+        # needed for analytics purposes
+        cls.set_block_analytics_summary(block_structure, store)
 
     def transform_block_filters(self, usage_info, block_structure):
         all_library_children = set()
@@ -104,7 +112,7 @@ class ContentLibraryTransformer(FilteringTransformerMixin, BlockStructureTransfo
                 if any(block_keys[changed] for changed in ('invalid', 'overlimit', 'added')):
                     state_dict['selected'] = list(selected)
                     random.shuffle(state_dict['selected'])
-                    StudentModule.save_state(  # pylint: disable=no-value-for-parameter
+                    StudentModule.save_state(
                         student=usage_info.user,
                         course_id=usage_info.course_key,
                         module_state_key=block_key,
@@ -114,7 +122,7 @@ class ContentLibraryTransformer(FilteringTransformerMixin, BlockStructureTransfo
                     )
 
                 # publish events for analytics
-                self._publish_events(
+                self.publish_events(
                     block_structure,
                     block_key,
                     previous_count,
@@ -139,7 +147,8 @@ class ContentLibraryTransformer(FilteringTransformerMixin, BlockStructureTransfo
 
         return [block_structure.create_removal_filter(check_child_removal)]
 
-    def _publish_events(self, block_structure, location, previous_count, max_count, block_keys, user_id):
+    @staticmethod
+    def publish_events(block_structure, location, previous_count, max_count, block_keys, user_id):
         """
         Helper method to publish events for analytics purposes
         """
@@ -179,3 +188,82 @@ class ContentLibraryTransformer(FilteringTransformerMixin, BlockStructureTransfo
             format_block_keys,
             publish_event,
         )
+
+
+class ContentLibraryOrderTransformer(BlockStructureTransformer):
+    """
+    A transformer that manipulates the block structure by modifying the order of the
+    selected blocks within a library_content module to match the order of the selections
+    made by the ContentLibraryTransformer or the corresponding XBlock. So this transformer
+    requires the selections for the randomized content block to be already
+    made either by the ContentLibraryTransformer or the XBlock.
+
+    Staff users are *not* exempted from library content pathways/
+    """
+    WRITE_VERSION = 1
+    READ_VERSION = 1
+
+    @classmethod
+    def name(cls):
+        """
+        Unique identifier for the transformer's class;
+        same identifier used in setup.py
+        """
+        return "library_content_randomize"
+
+    @classmethod
+    def collect(cls, block_structure):
+        """
+        Collects any information that's necessary to execute this
+        transformer's transform method.
+        """
+        block_structure.request_xblock_fields('mode')
+        block_structure.request_xblock_fields('max_count')
+
+        ContentLibraryTransformer.set_block_analytics_summary(block_structure, modulestore())
+
+    def transform(self, usage_info, block_structure):
+        """
+        Transforms the order of the children of the randomized content block
+        to match the order of the selections made and stored in the XBlock 'selected' field.
+        """
+        for block_key in block_structure:
+            if block_key.block_type != 'library_content':
+                continue
+
+            library_children = block_structure.get_children(block_key)
+
+            if library_children:
+                state_dict = get_student_module_as_dict(usage_info.user, usage_info.course_key, block_key)
+                current_children_blocks = set(block.block_id for block in library_children)
+                current_selected_blocks = set(item[1] for item in state_dict['selected'])
+
+                # Ensure that the current children blocks are the same as the stored selections
+                # before ordering the blocks.
+                if current_children_blocks != current_selected_blocks:
+                    logger.info(
+                        u'Mismatch between the children of %s in the stored state and the actual children',
+                        str(block_key)
+                    )
+                    previous_count = len(current_selected_blocks.intersection(current_children_blocks))
+                    mode = block_structure.get_xblock_field(block_key, 'mode')
+                    max_count = block_structure.get_xblock_field(block_key, 'max_count')
+                    block_keys = LibraryContentModule.make_selection(
+                        state_dict['selected'], library_children, max_count, mode
+                    )
+                    state_dict['selected'] = block_keys['selected']
+                    random.shuffle(state_dict['selected'])
+                    StudentModule.save_state(
+                        student=usage_info.user,
+                        course_id=usage_info.course_key,
+                        module_state_key=block_key,
+                        defaults={
+                            'state': json.dumps(state_dict)
+                        },
+                    )
+                    ContentLibraryTransformer.publish_events(
+                        block_structure, block_key, previous_count, max_count, block_keys, usage_info.user.id
+                    )
+
+                ordering_data = {block[1]: position for position, block in enumerate(state_dict['selected'])}
+                library_children.sort(key=lambda block, data=ordering_data: data[block.block_id])

--- a/lms/djangoapps/course_blocks/transformers/library_content.py
+++ b/lms/djangoapps/course_blocks/transformers/library_content.py
@@ -4,6 +4,7 @@ Content Library Transformer.
 from __future__ import absolute_import
 
 import json
+import random
 
 import six
 from eventtracking import tracker
@@ -102,7 +103,8 @@ class ContentLibraryTransformer(FilteringTransformerMixin, BlockStructureTransfo
                 # Save back any changes
                 if any(block_keys[changed] for changed in ('invalid', 'overlimit', 'added')):
                     state_dict['selected'] = list(selected)
-                    StudentModule.save_state(
+                    random.shuffle(state_dict['selected'])
+                    StudentModule.save_state(  # pylint: disable=no-value-for-parameter
                         student=usage_info.user,
                         course_id=usage_info.course_key,
                         module_state_key=block_key,

--- a/lms/djangoapps/course_blocks/transformers/tests/test_library_content.py
+++ b/lms/djangoapps/course_blocks/transformers/tests/test_library_content.py
@@ -1,6 +1,7 @@
 """
 Tests for ContentLibraryTransformer.
 """
+import mock
 
 from __future__ import absolute_import
 
@@ -11,7 +12,7 @@ from openedx.core.djangoapps.content.block_structure.transformers import BlockSt
 from student.tests.factories import CourseEnrollmentFactory
 
 from ...api import get_course_blocks
-from ..library_content import ContentLibraryTransformer
+from ..library_content import ContentLibraryTransformer, ContentLibraryOrderTransformer
 from .helpers import CourseStructureTestCase
 
 
@@ -166,5 +167,132 @@ class ContentLibraryTransformerTestCase(CourseStructureTestCase):
                     selected_vertical,
                     selected_child,
                 ),
+                u"Expected 'selected' equality failed in iteration {}.".format(i)
+            )
+
+
+class ContentLibraryOrderTransformerTestCase(CourseStructureTestCase):
+    """
+    ContentLibraryOrderTransformer Test
+    """
+    TRANSFORMER_CLASS_TO_TEST = ContentLibraryOrderTransformer
+
+    def setUp(self):
+        """
+        Setup course structure and create user for content library order transformer test.
+        """
+        super(ContentLibraryOrderTransformerTestCase, self).setUp()
+        self.course_hierarchy = self.get_course_hierarchy()
+        self.blocks = self.build_course(self.course_hierarchy)
+        self.course = self.blocks['course']
+        clear_course_from_cache(self.course.id)
+
+        # Enroll user in course.
+        CourseEnrollmentFactory.create(user=self.user, course_id=self.course.id, is_active=True)
+
+    def get_course_hierarchy(self):
+        """
+        Get a course hierarchy to test with.
+        """
+        return [{
+            'org': 'ContentLibraryTransformer',
+            'course': 'CL101F',
+            'run': 'test_run',
+            '#type': 'course',
+            '#ref': 'course',
+            '#children': [
+                {
+                    '#type': 'chapter',
+                    '#ref': 'chapter1',
+                    '#children': [
+                        {
+                            '#type': 'sequential',
+                            '#ref': 'lesson1',
+                            '#children': [
+                                {
+                                    '#type': 'vertical',
+                                    '#ref': 'vertical1',
+                                    '#children': [
+                                        {
+                                            'metadata': {'category': 'library_content'},
+                                            '#type': 'library_content',
+                                            '#ref': 'library_content1',
+                                            '#children': [
+                                                {
+                                                    'metadata': {'display_name': "CL Vertical 2"},
+                                                    '#type': 'vertical',
+                                                    '#ref': 'vertical2',
+                                                    '#children': [
+                                                        {
+                                                            'metadata': {'display_name': "HTML1"},
+                                                            '#type': 'html',
+                                                            '#ref': 'html1',
+                                                        }
+                                                    ]
+                                                },
+                                                {
+                                                    'metadata': {'display_name': "CL Vertical 3"},
+                                                    '#type': 'vertical',
+                                                    '#ref': 'vertical3',
+                                                    '#children': [
+                                                        {
+                                                            'metadata': {'display_name': "HTML2"},
+                                                            '#type': 'html',
+                                                            '#ref': 'html2',
+                                                        }
+                                                    ]
+                                                },
+                                                {
+                                                    'metadata': {'display_name': "CL Vertical 4"},
+                                                    '#type': 'vertical',
+                                                    '#ref': 'vertical4',
+                                                    '#children': [
+                                                        {
+                                                            'metadata': {'display_name': "HTML3"},
+                                                            '#type': 'html',
+                                                            '#ref': 'html3',
+                                                        }
+                                                    ]
+                                                }
+                                            ]
+                                        }
+                                    ],
+                                }
+                            ],
+                        }
+                    ],
+                }
+            ]
+        }]
+
+    @mock.patch('lms.djangoapps.course_blocks.transformers.library_content.get_student_module_as_dict')
+    def test_content_library_randomize(self, mocked):
+        """
+        Test whether the order of the children blocks matches the order of the selected blocks when
+        course has content library section
+        """
+        mocked.return_value = {
+            'selected': [
+                ['vertical', 'vertical_vertical3'],
+                ['vertical', 'vertical_vertical2'],
+                ['vertical', 'vertical_vertical4'],
+            ]
+        }
+        for i in range(5):
+            trans_block_structure = get_course_blocks(
+                self.user,
+                self.course.location,
+                self.transformers,
+            )
+            children = []
+            for block_key in trans_block_structure.topological_traversal():
+                if block_key.block_type == 'library_content':
+                    children = trans_block_structure.get_children(block_key)
+                    break
+
+            expected_children = ['vertical_vertical3', 'vertical_vertical2', 'vertical_vertical4']
+            self.assertEqual(
+                expected_children,
+                [child.block_id for child in children],
                 u"Expected 'selected' equality failed in iteration {}.".format(i)
             )

--- a/lms/djangoapps/course_blocks/transformers/tests/test_library_content.py
+++ b/lms/djangoapps/course_blocks/transformers/tests/test_library_content.py
@@ -1,11 +1,11 @@
 """
 Tests for ContentLibraryTransformer.
 """
-import mock
 
 from __future__ import absolute_import
 
 from six.moves import range
+import mock
 
 from openedx.core.djangoapps.content.block_structure.api import clear_course_from_cache
 from openedx.core.djangoapps.content.block_structure.transformers import BlockStructureTransformers

--- a/setup.py
+++ b/setup.py
@@ -51,6 +51,7 @@ setup(
         ],
         "openedx.block_structure_transformer": [
             "library_content = lms.djangoapps.course_blocks.transformers.library_content:ContentLibraryTransformer",
+            "library_content_randomize = lms.djangoapps.course_blocks.transformers.library_content:ContentLibraryOrderTransformer",
             "split_test = lms.djangoapps.course_blocks.transformers.split_test:SplitTestTransformer",
             "start_date = lms.djangoapps.course_blocks.transformers.start_date:StartDateTransformer",
             "user_partitions = lms.djangoapps.course_blocks.transformers.user_partitions:UserPartitionTransformer",


### PR DESCRIPTION
This PR (supersedes PR #18675 which was merged and then reverted due to [issues](https://github.com/edx/edx-platform/pull/18675#discussion_r282153049)) contains changes to the Randomized Content Block XBlock. The XBlock has unpredictable randomization of the order of the selected child blocks due to the usage of sets, which are unordered, for storing the selected blocks. This becomes apparent when all the available child blocks in a library are chosen for a Randomized Content Block to randomize just the order of the child blocks. 

This PR modifies the XBlock to store the selected child blocks in a list after randomly shuffling them.

To guard against the exceptions seen after PR #18675 was merged, this PR also adds defensive checks for such error conditions and redoes the selection if the selected children blocks stored in the `StudentModule` no longer match the current children of the current library_content block. It also logs a message when this happens.

**JIRA tickets**:  TBD - ticket will be created on creating this PR.

**Dependencies**: None

**Sandbox URL**:  TBD
**Merge deadline**: None

**Testing instructions**:

1. Login to the CMS as a user who can create and edit courses.
1. Create a library with a few child components.
1. Add a unit to a course.
1. Add a Randomized Content Block to the unit.
1. Select the library created above as the source for this XBlock.
1. Select all types of children to be shown.
1. Specify the total number of components present in the library as the number of components to display.
1. Save the unit and publish it.
1. Register a few students to this course.
1. Navigate to the unit containing this Randomized Content Block.
1. Verify that the order of the content blocks are randomized for every student.
1. Also verify that the same order of children blocks is returned by the `course_blocks` API for that randomized content block.

**Reviewers**
- [ ] @kaizoku 
- [ ] edX reviewer[s] TBD (@ormsbee maybe?)
