### PR TITLE
Remove Remember me button from login page

### DIFF
--- a/lms/static/js/spec/student_account/login_spec.js
+++ b/lms/static/js/spec/student_account/login_spec.js
@@ -21,7 +21,6 @@
                     USER_DATA = {
                         email: 'xsy@edx.org',
                         password: 'xsyisawesome',
-                        remember: true
                     },
                     THIRD_PARTY_AUTH = {
                         currentProvider: null,
@@ -64,16 +63,6 @@
                                 type: 'password',
                                 required: true,
                                 instructions: 'Enter your password.',
-                                restrictions: {}
-                            },
-                            {
-                                placeholder: '',
-                                name: 'remember',
-                                label: 'Remember me',
-                                defaultValue: '',
-                                type: 'checkbox',
-                                required: true,
-                                instructions: 'Agree to the terms of service.',
                                 restrictions: {}
                             }
                         ]
@@ -119,9 +108,6 @@
                 // Simulate manual entry of login form data
                     $('#login-email').val(USER_DATA.email);
                     $('#login-password').val(USER_DATA.password);
-
-                // Check the 'Remember me' checkbox
-                    $('#login-remember').prop('checked', USER_DATA.remember);
 
                 // If validationSuccess isn't passed, we avoid
                 // spying on `view.validate` twice

--- a/lms/static/js/student_account/models/LoginModel.js
+++ b/lms/static/js/student_account/models/LoginModel.js
@@ -8,8 +8,7 @@
         return Backbone.Model.extend({
             defaults: {
                 email: '',
-                password: '',
-                remember: false
+                password: ''
             },
 
             ajaxType: '',

--- a/lms/templates/login.html
+++ b/lms/templates/login.html
@@ -1,11 +1,17 @@
+<%page expression_filter="h"/>
 <%inherit file="main.html" />
 <%namespace name='static' file='static_content.html'/>
 
 <%!
 from django.urls import reverse
 from django.utils.translation import ugettext as _
+from openedx.core.djangolib.markup import HTML, Text
 import third_party_auth
 from third_party_auth import provider, pipeline
+%>
+
+<%!
+from openedx.core.djangolib.js_utils import js_escaped_string
 %>
 
 <%block name="pagetitle">${_("Log into your {platform_name} Account").format(platform_name=platform_name)}</%block>
@@ -54,24 +60,24 @@ from third_party_auth import provider, pipeline
         if (request.status === 403) {
           $('.message.submission-error').removeClass('is-shown');
           $('.third-party-signin.message').addClass('is-shown').focus();
-          $('.third-party-signin.message .instructions').html(request.responseText);
+          $('.third-party-signin.message .instructions').HtmlUtils.setHtml(request.responseText);
         } else {
           $('.third-party-signin.message').removeClass('is-shown');
           $('.message.submission-error').addClass('is-shown').focus();
-          $('.message.submission-error').html(gettext("Your request could not be completed.  Please try again."));
+          $('.message.submission-error').text(gettext("Your request could not be completed.  Please try again."));
         }
       });
 
       $('#login-form').on('ajax:success', function(event, json, xhr) {
         if(json.success) {
-          var nextUrl = "${login_redirect_url}";
+          var nextUrl = "${login_redirect_url | n}"; // xss-lint: disable=mako-invalid-js-filter
           if (json.redirect_url) {
             nextUrl = json.redirect_url; // Most likely third party auth completion. This trumps 'nextUrl' above.
           }
           if (!isExternal(nextUrl)) {
             location.href=nextUrl;
           } else {
-            location.href="${reverse('dashboard')}";
+            location.href="${reverse('dashboard') | n, js_escaped_string}";
           }
         } else if(json.hasOwnProperty('redirect')) {
           // Shibboleth authentication redirect requested by the server:
@@ -83,7 +89,7 @@ from third_party_auth import provider, pipeline
         } else {
           toggleSubmitButton(true);
           $('.message.submission-error').addClass('is-shown').focus();
-          $('.message.submission-error .message-copy').html(json.value);
+          $('.message.submission-error .message-copy').HtmlUtils.setHtml(json.value);
         }
       });
       $("#forgot-password-link").click(function() {
@@ -95,19 +101,21 @@ from third_party_auth import provider, pipeline
 
     function toggleSubmitButton(enable) {
       var $submitButton = $('form .form-actions #submit');
+      var $var1 = '${_('Log into My {platform_name} Account').format(platform_name=platform_name) | n, js_escaped_string}'
+      var $var2 = '${_('Access My Courses') | n, js_escaped_string}'
 
       if(enable) {
         $submitButton.
           removeClass('is-disabled').
           attr('aria-disabled', false).
           prop('disabled', false).
-          html("${_('Log into My {platform_name} Account').format(platform_name=platform_name)} <span class='orn-plus'>+</span> ${_('Access My Courses')}");
+          HtmlUtils.setHtml("$var1 <span class='orn-plus'>+</span> $var2");
       }
       else {
         $submitButton.
           addClass('is-disabled').
           prop('disabled', true).
-          text("${_(u'Processing your account information')}");
+          text("${_(u'Processing your account information') | n, js_escaped_string}");
       }
     }
 
@@ -125,7 +133,7 @@ from third_party_auth import provider, pipeline
        if (pipeline_running) {
          $('#login-form').submit();
        }
-    })(${pipeline_running})
+    })('${pipeline_running | n, js_escaped_string}')
   </script>
 </%block>
 
@@ -170,7 +178,7 @@ from third_party_auth import provider, pipeline
       % endif
 
       <p class="instructions sr">
-        ${_('Please provide the following information to log into your {platform_name} account. Required fields are noted by <strong class="indicator">bold text and an asterisk (*)</strong>.').format(platform_name=platform_name)}
+        ${HTML(_('Please provide the following information to log into your {platform_name} account. Required fields are noted by <strong class="indicator">bold text and an asterisk (*)</strong>.')).format(platform_name=platform_name)}
       </p>
 
       <div class="group group-form group-form-requiredinformation">
@@ -192,17 +200,6 @@ from third_party_auth import provider, pipeline
         </ol>
       </div>
 
-      <div class="group group-form group-form-secondary group-form-accountpreferences">
-        <h2 class="sr">${_('Account Preferences')}</h2>
-
-        <ol class="list-input">
-          <li class="field required checkbox" id="field-remember">
-            <input id="remember-yes" type="checkbox" name="remember" value="true" />
-            <label for="remember-yes">${_('Remember me')}</label>
-          </li>
-        </ol>
-      </div>
-
       <div class="form-actions">
         <button name="submit" type="submit" id="submit" class="action action-primary action-update login-button"></button>
       </div>
@@ -220,7 +217,8 @@ from third_party_auth import provider, pipeline
 
     % for enabled in provider.Registry.displayed_for_login():
       ## Translators: provider_name is the name of an external, third-party user authentication provider (like Google or LinkedIn).
-      <button type="submit" class="button button-primary button-${enabled.provider_id} login-${enabled.provider_id}" onclick="thirdPartySignin(event, '${pipeline_url[enabled.provider_id]}');">
+        ## xss-lint: disable=mako-invalid-html-filter
+      <button type="submit" class="button button-primary button-${enabled.provider_id} login-${enabled.provider_id}" onclick="thirdPartySignin(event, '${pipeline_url[enabled.provider_id]|n}');">
         % if enabled.icon_class:
         <span class="icon fa ${enabled.icon_class}" aria-hidden="true"></span>
         % else:

--- a/openedx/core/djangoapps/user_api/api.py
+++ b/openedx/core/djangoapps/user_api/api.py
@@ -120,14 +120,6 @@ def get_login_session_form(request):
         restrictions={'max_length': DEFAULT_MAX_PASSWORD_LENGTH}
     )
 
-    form_desc.add_field(
-        "remember",
-        field_type="checkbox",
-        label=_("Remember me"),
-        default=False,
-        required=False,
-    )
-
     return form_desc
 
 

--- a/openedx/core/djangoapps/user_api/tests/test_views.py
+++ b/openedx/core/djangoapps/user_api/tests/test_views.py
@@ -640,19 +640,6 @@ class LoginSessionViewTest(UserAPITestCase):
                 "supplementalText": "",
                 "supplementalLink": "",
             },
-            {
-                "name": "remember",
-                "defaultValue": False,
-                "type": "checkbox",
-                "required": False,
-                "label": "Remember me",
-                "placeholder": "",
-                "instructions": "",
-                "restrictions": {},
-                "errorMessages": {},
-                "supplementalText": "",
-                "supplementalLink": "",
-            },
         ])
 
     def test_login(self):


### PR DESCRIPTION
#### Description 
Remember me button does the same thing regardless of if it is checked or not. Remember me button being unchecked makes a user think they will be logged out at the end of a browsing session when this is in fact not the case

#### Ticket
[LEARNER-6220](https://openedx.atlassian.net/browse/LEARNER-6220)

#### Note
Devops recommends we remove it as it should set an expiry to 2 weeks regardless of if it is checked or not, as session cookies do not act as one would expect in modern browsers under default settings. See:   LEARNER-6219 and SEC‌-293 This effectively makes the button do nothing.