### PR TITLE
EDUCATOR-4307 | Don't bother with celery to run expire waiting enrollment commands

### DIFF
--- a/lms/djangoapps/program_enrollments/management/commands/expire_waiting_enrollments.py
+++ b/lms/djangoapps/program_enrollments/management/commands/expire_waiting_enrollments.py
@@ -29,5 +29,4 @@ class Command(BaseCommand):
     def handle(self, *args, **options):
         expiration_days = options.get('expiration_days')
         logger.info(u'Deleting waiting enrollments unmodified for %s days', expiration_days)
-        task = tasks.expire_waiting_enrollments.apply_async(args=[expiration_days])
-        task.get()  # wait for task to complete before exiting
+        tasks.expire_waiting_enrollments(expiration_days)

--- a/lms/djangoapps/program_enrollments/management/commands/tests/test_expire_waiting_enrollments.py
+++ b/lms/djangoapps/program_enrollments/management/commands/tests/test_expire_waiting_enrollments.py
@@ -19,7 +19,7 @@ class TestExpireWaitingEnrollments(TestCase):
         cls.command = expire_waiting_enrollments.Command()
 
     @ddt.data(90, None)
-    @patch('lms.djangoapps.program_enrollments.tasks.expire_waiting_enrollments')
+    @patch('lms.djangoapps.program_enrollments.tasks.expire_waiting_enrollments', autospec=True)
     def test_task_fired_with_args(self, expire_days_argument, mock_task):
         mock_task.return_value = {}
         expected_expiration = 60
@@ -30,10 +30,10 @@ class TestExpireWaitingEnrollments(TestCase):
         else:
             call_command(command)
 
-        mock_task.apply_async.assert_called_with(args=[expected_expiration])
+        mock_task.assert_called_with(expected_expiration)
 
-    @patch('lms.djangoapps.program_enrollments.tasks.expire_waiting_enrollments')
+    @patch('lms.djangoapps.program_enrollments.tasks.expire_waiting_enrollments', autospec=True)
     def test_task_failure_fails_command(self, mock_task):
-        mock_task.apply_async.side_effect = Exception('BOOM!')
+        mock_task.side_effect = Exception('BOOM!')
         with self.assertRaises(Exception):
             call_command('expire_waiting_enrollments')


### PR DESCRIPTION
Devops successfully ran the seed job and created the waiting program enrollments job for us inside the "programs" folder.

BUT: we ran it the first time and it just hung for about 25 minutes before Joe killed it. He disabled this job in stage and prod for now until we try something new. This PR just runs the task as a regular function, outside of celery.