### PR TITLE
Campus.IL SE-1151 Strings used in models should always use gettext_lazy

### DIFF
--- a/cms/djangoapps/course_creators/models.py
+++ b/cms/djangoapps/course_creators/models.py
@@ -6,7 +6,7 @@ from django.db import models
 from django.db.models.signals import post_init, post_save
 from django.dispatch import Signal, receiver
 from django.utils import timezone
-from django.utils.translation import ugettext as _
+from django.utils.translation import ugettext_lazy as _
 
 # A signal that will be sent when users should be added or removed from the creator group
 update_creator_state = Signal(providing_args=["caller", "user", "state"])

--- a/openedx/core/djangoapps/api_admin/models.py
+++ b/openedx/core/djangoapps/api_admin/models.py
@@ -13,7 +13,8 @@ from django.db import models
 from django.db.models.signals import post_save, pre_save
 from django.dispatch import receiver
 from django.urls import reverse
-from django.utils.translation import ugettext as _
+from django.utils.translation import ugettext as _u
+from django.utils.translation import ugettext_lazy as _
 from model_utils.models import TimeStampedModel
 from six.moves.urllib.parse import urlunsplit  # pylint: disable=import-error
 
@@ -173,7 +174,7 @@ def _send_new_pending_email(instance):
     message = render_to_string('api_admin/api_access_request_email_new_request.txt', context)
     try:
         send_mail(
-            _(u'API access request from {company}').format(company=instance.company_name),
+            _u(u'API access request from {company}').format(company=instance.company_name),
             message,
             settings.API_ACCESS_FROM_EMAIL,
             [settings.API_ACCESS_MANAGER_EMAIL],
@@ -208,7 +209,7 @@ def _send_decision_email(instance):
     )
     try:
         send_mail(
-            _('API access request'),
+            _u('API access request'),
             message,
             settings.API_ACCESS_FROM_EMAIL,
             [instance.user.email],

--- a/openedx/core/djangoapps/credit/models.py
+++ b/openedx/core/djangoapps/credit/models.py
@@ -449,7 +449,7 @@ class CreditRequirementStatus(TimeStampedModel):
 
     class Meta(object):
         unique_together = ('username', 'requirement')
-        verbose_name_plural = _('Credit requirement statuses')
+        verbose_name_plural = ugettext_lazy('Credit requirement statuses')
 
     @classmethod
     def get_statuses(cls, requirements, username):
@@ -786,9 +786,9 @@ class CreditConfig(ConfigurationModel):
     CACHE_KEY = 'credit.providers.api.data'
 
     cache_ttl = models.PositiveIntegerField(
-        verbose_name=_("Cache Time To Live"),
+        verbose_name=ugettext_lazy("Cache Time To Live"),
         default=0,
-        help_text=_(
+        help_text=ugettext_lazy(
             "Specified in seconds. Enable caching by setting this to a value greater than 0."
         )
     )


### PR DESCRIPTION
Otherwise, they generate false migrations when languages other than English are used as the default.

**Discussions**: https://stackoverflow.com/a/4164683/4302112

**JIRA tickets**: [OSPR-3624](https://openedx.atlassian.net/browse/OSPR-3624)

**Sandbox URL**: TBD - sandbox is being provisioned.

**Merge deadline**: None

**Testing instructions**

TBD

1. Set the env `LANGUAGE_CODE` to something besides the default `'en'`.
1. Run `makemigrations`, and note that no migration changes are added.

**Reviewers**
- [ ] OpenCraft TBD
- [ ] edX TBD 

**Settings**
```yaml
EDXAPP_LANGUAGE_CODE: "he"
```