### PR TITLE
Update edx-lint to 1.3.0

### DIFF
--- a/pylintrc
+++ b/pylintrc
@@ -304,11 +304,13 @@ disable =
 	dict-view-method,
 	duplicate-code,
 	execfile-builtin,
+	feature-toggle-needs-doc,
 	file-builtin,
 	filter-builtin-not-iterating,
 	fixme,
 	getslice-method,
 	hex-method,
+	illegal-waffle-usage,
 	import-star-module-level,
 	indexing-exception,
 	input-builtin,
@@ -457,4 +459,4 @@ int-import-graph =
 [EXCEPTIONS]
 overgeneral-exceptions = Exception
 
-# f53942526b8e9020150e5025e6a8aa60c76971d9
+# c9c6a6da98d5eb4ede060038e6b0f1892f32f83b

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -126,7 +126,7 @@ edx-django-utils==1.0.3
 edx-drf-extensions==2.3.0
 edx-enterprise==1.6.3
 edx-i18n-tools==0.4.8
-edx-lint==1.2.1
+edx-lint==1.3.0
 edx-milestones==0.1.13
 edx-oauth2-provider==1.2.2
 edx-opaque-keys[django]==0.4.4

--- a/requirements/edx/testing.in
+++ b/requirements/edx/testing.in
@@ -25,7 +25,7 @@ code-annotations          # Perform code annotation checking, such as for PII an
 cssselect                 # Used to extract HTML fragments via CSS selectors in 2 test cases and pyquery
 ddt                       # Run a test case multiple times with different input; used in many, many of our tests
 edx-i18n-tools>=0.4.6     # Commands for developers and translators to extract, compile and validate translations
-edx-lint==1.2.1           # pylint extensions for Open edX repositories
+edx-lint==1.3.0           # pylint extensions for Open edX repositories
 factory_boy==2.8.1        # Library for creating test fixtures, used in many tests
 freezegun                 # Allows tests to mock the output of assorted datetime module functions
 httpretty                 # Library for mocking HTTP requests, used in many tests

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -122,7 +122,7 @@ edx-django-utils==1.0.3
 edx-drf-extensions==2.3.0
 edx-enterprise==1.6.3
 edx-i18n-tools==0.4.8
-edx-lint==1.2.1
+edx-lint==1.3.0
 edx-milestones==0.1.13
 edx-oauth2-provider==1.2.2
 edx-opaque-keys[django]==0.4.4


### PR DESCRIPTION
Adds in the new feature toggle linter, but disables the new warnings for now, as it would introduce 200+ new pylint warnings.