### PR TITLE
type uuid for proper encoding.

### DIFF
--- a/openedx/features/enterprise_support/signals.py
+++ b/openedx/features/enterprise_support/signals.py
@@ -5,6 +5,7 @@ This module contains signals related to enterprise.
 from __future__ import absolute_import
 
 import logging
+import six
 
 from django.contrib.auth.models import User
 from django.db.models.signals import post_save, pre_save
@@ -56,7 +57,7 @@ def update_dsc_cache_on_enterprise_customer_update(sender, instance, **kwargs):
         new_value = instance.enable_data_sharing_consent
         old_value = old_instance.enable_data_sharing_consent
         if new_value != old_value:
-            kwargs = {'enterprise_customer_uuid': instance.uuid}
+            kwargs = {'enterprise_customer_uuid': six.text_type(instance.uuid)}
             result = clear_enterprise_customer_data_consent_share_cache.apply_async(kwargs=kwargs)
             log.info(u"DSC: Created {task_name}[{task_id}] with arguments {kwargs}".format(
                 task_name=clear_enterprise_customer_data_consent_share_cache.name,


### PR DESCRIPTION
## Fix for DSC flag issue (ENT-1994)

The error seemingly was caused by the UUID not in a format that was able to be serialized and saved: 
`EncodeError: Object of type UUID is not JSON serializable`

This fix should allow the UUID to be properly saved in the database by typing it to a unicode string ahead of time.