### PR TITLE
Import lms.djangoapps.courseware, not courseware.

### DIFF
--- a/cms/djangoapps/contentstore/management/commands/edit_course_tabs.py
+++ b/cms/djangoapps/contentstore/management/commands/edit_course_tabs.py
@@ -12,7 +12,7 @@ from django.core.management.base import BaseCommand, CommandError
 from opaque_keys.edx.keys import CourseKey
 
 from contentstore.views import tabs
-from courseware.courses import get_course_by_id
+from lms.djangoapps.courseware.courses import get_course_by_id
 
 from .prompt import query_yes_no
 

--- a/cms/djangoapps/contentstore/tests/test_users_default_role.py
+++ b/cms/djangoapps/contentstore/tests/test_users_default_role.py
@@ -4,7 +4,7 @@ after deleting it creates same course again
 """
 from contentstore.tests.utils import AjaxEnabledTestClient
 from contentstore.utils import delete_course, reverse_url
-from courseware.tests.factories import UserFactory
+from lms.djangoapps.courseware.tests.factories import UserFactory
 from student.models import CourseEnrollment
 from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
 

--- a/common/djangoapps/course_modes/views.py
+++ b/common/djangoapps/course_modes/views.py
@@ -26,7 +26,7 @@ from opaque_keys.edx.keys import CourseKey
 from six import text_type
 
 from course_modes.models import CourseMode
-from courseware.access import has_access
+from lms.djangoapps.courseware.access import has_access
 from edxmako.shortcuts import render_to_response
 from lms.djangoapps.commerce.utils import EcommerceService
 from lms.djangoapps.experiments.utils import get_experiment_user_metadata_context

--- a/common/djangoapps/entitlements/api/v1/permissions.py
+++ b/common/djangoapps/entitlements/api/v1/permissions.py
@@ -7,7 +7,7 @@ from __future__ import absolute_import
 
 from rest_framework.permissions import SAFE_METHODS, BasePermission
 
-from courseware.access import has_access
+from lms.djangoapps.courseware.access import has_access
 
 
 class IsAdminOrSupportOrAuthenticatedReadOnly(BasePermission):

--- a/common/djangoapps/entitlements/api/v1/tests/test_views.py
+++ b/common/djangoapps/entitlements/api/v1/tests/test_views.py
@@ -14,7 +14,7 @@ from opaque_keys.edx.locator import CourseKey
 
 from course_modes.models import CourseMode
 from course_modes.tests.factories import CourseModeFactory
-from courseware.models import DynamicUpgradeDeadlineConfiguration
+from lms.djangoapps.courseware.models import DynamicUpgradeDeadlineConfiguration
 from openedx.core.djangoapps.content.course_overviews.tests.factories import CourseOverviewFactory
 from openedx.core.djangoapps.schedules.tests.factories import ScheduleFactory
 from openedx.core.djangoapps.site_configuration.tests.factories import SiteFactory

--- a/common/djangoapps/student/models.py
+++ b/common/djangoapps/student/models.py
@@ -55,7 +55,7 @@ from slumber.exceptions import HttpClientError, HttpServerError
 from user_util import user_util
 
 from course_modes.models import CourseMode, get_cosmetic_verified_display_price
-from courseware.models import (
+from lms.djangoapps.courseware.models import (
     CourseDynamicUpgradeDeadlineConfiguration,
     DynamicUpgradeDeadlineConfiguration,
     OrgDynamicUpgradeDeadlineConfiguration
@@ -1252,7 +1252,7 @@ class CourseEnrollment(models.Model):
         """
         # Disable the pylint error here, as per ormsbee. This local import was previously
         # in CourseEnrollment.enroll
-        from courseware.access import has_access  # pylint: disable=import-error
+        from lms.djangoapps.courseware.access import has_access  # pylint: disable=import-error
         return not has_access(user, 'enroll', course)
 
     def update_enrollment(self, mode=None, is_active=None, skip_refund=False):

--- a/common/djangoapps/student/tests/test_models.py
+++ b/common/djangoapps/student/tests/test_models.py
@@ -17,7 +17,7 @@ from opaque_keys.edx.keys import CourseKey
 
 from course_modes.models import CourseMode
 from course_modes.tests.factories import CourseModeFactory
-from courseware.models import DynamicUpgradeDeadlineConfiguration
+from lms.djangoapps.courseware.models import DynamicUpgradeDeadlineConfiguration
 from openedx.core.djangoapps.content.course_overviews.models import CourseOverview
 from openedx.core.djangoapps.schedules.models import Schedule
 from openedx.core.djangoapps.schedules.tests.factories import ScheduleFactory

--- a/common/djangoapps/student/tests/test_roles.py
+++ b/common/djangoapps/student/tests/test_roles.py
@@ -8,7 +8,7 @@ import six
 from django.test import TestCase
 from opaque_keys.edx.keys import CourseKey
 
-from courseware.tests.factories import InstructorFactory, StaffFactory, UserFactory
+from lms.djangoapps.courseware.tests.factories import InstructorFactory, StaffFactory, UserFactory
 from student.roles import (
     CourseBetaTesterRole,
     CourseInstructorRole,

--- a/common/djangoapps/student/views/dashboard.py
+++ b/common/djangoapps/student/views/dashboard.py
@@ -24,7 +24,7 @@ import track.views
 from bulk_email.api import is_bulk_email_feature_enabled
 from bulk_email.models import Optout  # pylint: disable=import-error
 from course_modes.models import CourseMode
-from courseware.access import has_access
+from lms.djangoapps.courseware.access import has_access
 from edxmako.shortcuts import render_to_response, render_to_string
 from entitlements.models import CourseEntitlement
 from lms.djangoapps.commerce.utils import EcommerceService  # pylint: disable=import-error

--- a/common/djangoapps/student/views/management.py
+++ b/common/djangoapps/student/views/management.py
@@ -46,7 +46,7 @@ from six import text_type
 import track.views
 from bulk_email.models import Optout
 from course_modes.models import CourseMode
-from courseware.courses import get_courses, sort_by_announcement, sort_by_start_date
+from lms.djangoapps.courseware.courses import get_courses, sort_by_announcement, sort_by_start_date
 from edxmako.shortcuts import marketing_link, render_to_response, render_to_string
 from entitlements.models import CourseEntitlement
 from openedx.core.djangoapps.ace_common.template_context import get_base_template_context

--- a/common/lib/xmodule/xmodule/modulestore/tests/django_utils.py
+++ b/common/lib/xmodule/xmodule/modulestore/tests/django_utils.py
@@ -17,7 +17,7 @@ from django.test.utils import override_settings
 from mock import patch
 from six.moves import range
 
-from courseware.tests.factories import StaffFactory
+from lms.djangoapps.courseware.tests.factories import StaffFactory
 from lms.djangoapps.courseware.field_overrides import OverrideFieldData  # pylint: disable=import-error
 from openedx.core.djangolib.testing.utils import CacheIsolationMixin, CacheIsolationTestCase, FilteredQueryCountMixin
 from openedx.core.lib.tempdir import mkdtemp_clean

--- a/lms/djangoapps/branding/tests/test_page.py
+++ b/lms/djangoapps/branding/tests/test_page.py
@@ -17,7 +17,7 @@ from mock import Mock, patch
 from pytz import UTC
 
 from branding.views import index
-from courseware.tests.helpers import LoginEnrollmentTestCase
+from lms.djangoapps.courseware.tests.helpers import LoginEnrollmentTestCase
 from edxmako.shortcuts import render_to_response
 from openedx.core.djangoapps.site_configuration.tests.mixins import SiteMixin
 from util.milestones_helpers import set_prerequisite_courses

--- a/lms/djangoapps/branding/views.py
+++ b/lms/djangoapps/branding/views.py
@@ -17,7 +17,7 @@ from django.views.decorators.cache import cache_control
 from django.views.decorators.csrf import ensure_csrf_cookie
 
 import branding.api as branding_api
-import courseware.views.views
+import lms.djangoapps.courseware.views.views
 import student.views
 from edxmako.shortcuts import marketing_link, render_to_response
 from openedx.core.djangoapps.lang_pref.api import released_languages

--- a/lms/djangoapps/bulk_email/tasks.py
+++ b/lms/djangoapps/bulk_email/tasks.py
@@ -41,7 +41,7 @@ from markupsafe import escape
 from six import text_type
 
 from bulk_email.models import CourseEmail, Optout
-from courseware.courses import get_course
+from lms.djangoapps.courseware.courses import get_course
 from lms.djangoapps.instructor_task.models import InstructorTask
 from lms.djangoapps.instructor_task.subtasks import (
     SubtaskStatus,

--- a/lms/djangoapps/bulk_email/tests/test_email.py
+++ b/lms/djangoapps/bulk_email/tests/test_email.py
@@ -24,7 +24,7 @@ from mock import Mock, patch
 from bulk_email.models import BulkEmailFlag, Optout
 from bulk_email.tasks import _get_course_email_context, _get_source_address
 from course_modes.models import CourseMode
-from courseware.tests.factories import InstructorFactory, StaffFactory
+from lms.djangoapps.courseware.tests.factories import InstructorFactory, StaffFactory
 from lms.djangoapps.instructor_task.subtasks import update_subtask_status
 from openedx.core.djangoapps.course_groups.cohorts import add_user_to_cohort
 from openedx.core.djangoapps.course_groups.models import CourseCohort

--- a/lms/djangoapps/bulk_enroll/tests/test_views.py
+++ b/lms/djangoapps/bulk_enroll/tests/test_views.py
@@ -17,7 +17,7 @@ from rest_framework.test import APIRequestFactory, APITestCase, force_authentica
 
 from bulk_enroll.serializers import BulkEnrollmentSerializer
 from bulk_enroll.views import BulkEnrollView
-from courseware.tests.helpers import LoginEnrollmentTestCase
+from lms.djangoapps.courseware.tests.helpers import LoginEnrollmentTestCase
 from openedx.core.djangoapps.course_groups.cohorts import get_cohort_id
 from openedx.core.djangoapps.course_groups.tests.helpers import config_course_cohorts
 from openedx.core.djangoapps.site_configuration.helpers import get_value as get_site_value

--- a/lms/djangoapps/ccx/api/v0/tests/test_views.py
+++ b/lms/djangoapps/ccx/api/v0/tests/test_views.py
@@ -23,7 +23,7 @@ from provider.oauth2.models import Client, Grant
 from rest_framework import status
 from rest_framework.test import APITestCase
 
-from courseware import courses
+from lms.djangoapps.courseware import courses
 from lms.djangoapps.ccx.api.v0 import views
 from lms.djangoapps.ccx.models import CcxFieldOverride, CustomCourseForEdX
 from lms.djangoapps.ccx.overrides import override_field_for_ccx

--- a/lms/djangoapps/ccx/api/v0/views.py
+++ b/lms/djangoapps/ccx/api/v0/views.py
@@ -18,7 +18,7 @@ from rest_framework.generics import GenericAPIView
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
 
-from courseware import courses
+from lms.djangoapps.courseware import courses
 from lms.djangoapps.ccx.models import CcxFieldOverride, CustomCourseForEdX
 from lms.djangoapps.ccx.overrides import override_field_for_ccx
 from lms.djangoapps.ccx.utils import (

--- a/lms/djangoapps/ccx/migrations/0003_add_master_course_staff_in_ccx.py
+++ b/lms/djangoapps/ccx/migrations/0003_add_master_course_staff_in_ccx.py
@@ -8,7 +8,7 @@ from ccx_keys.locator import CCXLocator
 from django.db import migrations
 from django.http import Http404
 
-from courseware.courses import get_course_by_id
+from lms.djangoapps.courseware.courses import get_course_by_id
 from lms.djangoapps.ccx.utils import add_master_course_staff_to_ccx, remove_master_course_staff_from_ccx
 
 log = logging.getLogger("edx.ccx")
@@ -83,7 +83,7 @@ class Migration(migrations.Migration):
         ('ccx', '0001_initial'),
         ('ccx', '0002_customcourseforedx_structure_json'),
         ('course_overviews','0010_auto_20160329_2317'), # because we use course overview and are in the same release as that table is modified
-        ('verified_track_content','0001_initial'), # because we use enrollement code and are in the same release as an enrollement related table is created 
+        ('verified_track_content','0001_initial'), # because we use enrollement code and are in the same release as an enrollement related table is created
     ]
 
     operations = [

--- a/lms/djangoapps/ccx/migrations/0004_seed_forum_roles_in_ccx_courses.py
+++ b/lms/djangoapps/ccx/migrations/0004_seed_forum_roles_in_ccx_courses.py
@@ -8,7 +8,7 @@ from ccx_keys.locator import CCXLocator
 from django.db import migrations
 from django.http import Http404
 
-from courseware.courses import get_course_by_id
+from lms.djangoapps.courseware.courses import get_course_by_id
 from openedx.core.djangoapps.django_comment_common.models import (
     FORUM_ROLE_ADMINISTRATOR,
     FORUM_ROLE_COMMUNITY_TA,

--- a/lms/djangoapps/ccx/migrations/0005_change_ccx_coach_to_staff.py
+++ b/lms/djangoapps/ccx/migrations/0005_change_ccx_coach_to_staff.py
@@ -9,7 +9,7 @@ from django.contrib.auth.models import User
 from django.db import migrations
 from django.http import Http404
 
-from courseware.courses import get_course_by_id
+from lms.djangoapps.courseware.courses import get_course_by_id
 from instructor.access import allow_access, revoke_access
 
 log = logging.getLogger("edx.ccx")

--- a/lms/djangoapps/ccx/migrations/0006_set_display_name_as_override.py
+++ b/lms/djangoapps/ccx/migrations/0006_set_display_name_as_override.py
@@ -9,7 +9,7 @@ from ccx_keys.locator import CCXLocator
 from django.db import migrations
 from django.http import Http404
 
-from courseware.courses import get_course_by_id
+from lms.djangoapps.courseware.courses import get_course_by_id
 
 log = logging.getLogger(__name__)
 

--- a/lms/djangoapps/ccx/plugins.py
+++ b/lms/djangoapps/ccx/plugins.py
@@ -5,7 +5,7 @@ Registers the CCX feature for the edX platform.
 from django.conf import settings
 from django.utils.translation import ugettext_noop
 
-from courseware.access import has_access
+from lms.djangoapps.courseware.access import has_access
 from student.roles import CourseCcxCoachRole
 from xmodule.tabs import CourseTab
 

--- a/lms/djangoapps/ccx/tests/test_field_override_performance.py
+++ b/lms/djangoapps/ccx/tests/test_field_override_performance.py
@@ -23,8 +23,8 @@ from opaque_keys.edx.keys import CourseKey
 from pytz import UTC
 from xblock.core import XBlock
 
-from courseware.testutils import FieldOverrideTestMixin
-from courseware.views.views import progress
+from lms.djangoapps.courseware.testutils import FieldOverrideTestMixin
+from lms.djangoapps.courseware.views.views import progress
 from lms.djangoapps.ccx.tests.factories import CcxFactory
 from lms.djangoapps.courseware.field_overrides import OverrideFieldData
 from openedx.core.djangoapps.content.block_structure.api import get_course_in_cache

--- a/lms/djangoapps/ccx/tests/test_overrides.py
+++ b/lms/djangoapps/ccx/tests/test_overrides.py
@@ -13,8 +13,8 @@ from django.test.utils import override_settings
 from edx_django_utils.cache import RequestCache
 from six.moves import range
 
-from courseware.courses import get_course_by_id
-from courseware.testutils import FieldOverrideTestMixin
+from lms.djangoapps.courseware.courses import get_course_by_id
+from lms.djangoapps.courseware.testutils import FieldOverrideTestMixin
 from lms.djangoapps.ccx.models import CustomCourseForEdX
 from lms.djangoapps.ccx.overrides import override_field_for_ccx
 from lms.djangoapps.ccx.tests.utils import flatten, iter_blocks

--- a/lms/djangoapps/ccx/tests/test_views.py
+++ b/lms/djangoapps/ccx/tests/test_views.py
@@ -23,11 +23,11 @@ from opaque_keys.edx.keys import CourseKey
 from pytz import UTC
 
 from capa.tests.response_xml_factory import StringResponseXMLFactory
-from courseware.courses import get_course_by_id
-from courseware.tabs import get_course_tab_list
-from courseware.tests.factories import StudentModuleFactory
-from courseware.tests.helpers import LoginEnrollmentTestCase
-from courseware.testutils import FieldOverrideTestMixin
+from lms.djangoapps.courseware.courses import get_course_by_id
+from lms.djangoapps.courseware.tabs import get_course_tab_list
+from lms.djangoapps.courseware.tests.factories import StudentModuleFactory
+from lms.djangoapps.courseware.tests.helpers import LoginEnrollmentTestCase
+from lms.djangoapps.courseware.testutils import FieldOverrideTestMixin
 from edxmako.shortcuts import render_to_response
 from lms.djangoapps.ccx.models import CustomCourseForEdX
 from lms.djangoapps.ccx.overrides import get_override_for_ccx, override_field_for_ccx

--- a/lms/djangoapps/ccx/utils.py
+++ b/lms/djangoapps/ccx/utils.py
@@ -15,7 +15,7 @@ from django.urls import reverse
 from django.core.validators import validate_email
 from django.utils.translation import ugettext as _
 
-from courseware.courses import get_course_by_id
+from lms.djangoapps.courseware.courses import get_course_by_id
 from lms.djangoapps.ccx.custom_exception import CCXUserValidationException
 from lms.djangoapps.ccx.models import CustomCourseForEdX
 from lms.djangoapps.ccx.overrides import get_override_for_ccx

--- a/lms/djangoapps/ccx/views.py
+++ b/lms/djangoapps/ccx/views.py
@@ -23,8 +23,8 @@ from django.views.decorators.cache import cache_control
 from django.views.decorators.csrf import ensure_csrf_cookie
 from opaque_keys.edx.keys import CourseKey
 
-from courseware.access import has_access
-from courseware.courses import get_course_by_id
+from lms.djangoapps.courseware.access import has_access
+from lms.djangoapps.courseware.courses import get_course_by_id
 from edxmako.shortcuts import render_to_response
 from lms.djangoapps.ccx.models import CustomCourseForEdX
 from lms.djangoapps.ccx.overrides import (

--- a/lms/djangoapps/certificates/tests/test_api.py
+++ b/lms/djangoapps/certificates/tests/test_api.py
@@ -20,7 +20,7 @@ import pytz
 
 from course_modes.models import CourseMode
 from course_modes.tests.factories import CourseModeFactory
-from courseware.tests.factories import GlobalStaffFactory
+from lms.djangoapps.courseware.tests.factories import GlobalStaffFactory
 from lms.djangoapps.certificates import api as certs_api
 from lms.djangoapps.certificates.models import (
     CertificateGenerationConfiguration,

--- a/lms/djangoapps/certificates/views/support.py
+++ b/lms/djangoapps/certificates/views/support.py
@@ -22,7 +22,7 @@ from django.views.decorators.http import require_GET, require_POST
 from opaque_keys import InvalidKeyError
 from opaque_keys.edx.keys import CourseKey
 
-from courseware.access import has_access
+from lms.djangoapps.courseware.access import has_access
 from lms.djangoapps.certificates import api
 from lms.djangoapps.certificates.models import CertificateInvalidation
 from lms.djangoapps.instructor_task.api import generate_certificates_for_students

--- a/lms/djangoapps/certificates/views/webview.py
+++ b/lms/djangoapps/certificates/views/webview.py
@@ -25,8 +25,8 @@ from opaque_keys.edx.keys import CourseKey
 
 from badges.events.course_complete import get_completion_badge
 from badges.utils import badges_enabled
-from courseware.access import has_access
-from courseware.courses import get_course_by_id
+from lms.djangoapps.courseware.access import has_access
+from lms.djangoapps.courseware.courses import get_course_by_id
 from edxmako.shortcuts import render_to_response
 from edxmako.template import Template
 from lms.djangoapps.certificates.api import (

--- a/lms/djangoapps/class_dashboard/dashboard_data.py
+++ b/lms/djangoapps/class_dashboard/dashboard_data.py
@@ -10,7 +10,7 @@ from django.utils.translation import ugettext as _
 from opaque_keys.edx.locator import BlockUsageLocator
 from six import text_type
 
-from courseware import models
+from lms.djangoapps.courseware import models
 from instructor_analytics.csvs import create_csv_response
 from util.json_request import JsonResponse
 from xmodule.modulestore.django import modulestore

--- a/lms/djangoapps/class_dashboard/tests/test_dashboard_data.py
+++ b/lms/djangoapps/class_dashboard/tests/test_dashboard_data.py
@@ -26,7 +26,7 @@ from class_dashboard.dashboard_data import (
     get_students_problem_grades
 )
 from class_dashboard.views import has_instructor_access_for_class
-from courseware.tests.factories import StudentModuleFactory
+from lms.djangoapps.courseware.tests.factories import StudentModuleFactory
 from student.tests.factories import AdminFactory, CourseEnrollmentFactory, UserFactory
 from xmodule.modulestore.tests.django_utils import SharedModuleStoreTestCase
 from xmodule.modulestore.tests.factories import CourseFactory, ItemFactory

--- a/lms/djangoapps/class_dashboard/views.py
+++ b/lms/djangoapps/class_dashboard/views.py
@@ -11,8 +11,8 @@ from django.http import HttpResponse
 from opaque_keys.edx.keys import CourseKey
 
 from class_dashboard import dashboard_data
-from courseware.access import has_access
-from courseware.courses import get_course_overview_with_access
+from lms.djangoapps.courseware.access import has_access
+from lms.djangoapps.courseware.courses import get_course_overview_with_access
 
 log = logging.getLogger(__name__)
 

--- a/lms/djangoapps/commerce/api/v0/views.py
+++ b/lms/djangoapps/commerce/api/v0/views.py
@@ -13,7 +13,7 @@ from rest_framework.views import APIView
 from six import text_type
 
 from course_modes.models import CourseMode
-from courseware import courses
+from lms.djangoapps.courseware import courses
 from entitlements.models import CourseEntitlement
 from openedx.core.djangoapps.commerce.utils import ecommerce_api_client
 from openedx.core.djangoapps.embargo import api as embargo_api

--- a/lms/djangoapps/course_api/blocks/permissions.py
+++ b/lms/djangoapps/course_api/blocks/permissions.py
@@ -2,7 +2,7 @@
 Encapsulates permissions checks for Course Blocks API
 """
 
-from courseware.access import has_access
+from lms.djangoapps.courseware.access import has_access
 from student.models import CourseEnrollment
 from student.roles import CourseStaffRole
 

--- a/lms/djangoapps/course_blocks/transformers/library_content.py
+++ b/lms/djangoapps/course_blocks/transformers/library_content.py
@@ -8,7 +8,7 @@ import json
 import six
 from eventtracking import tracker
 
-from courseware.models import StudentModule
+from lms.djangoapps.courseware.models import StudentModule
 from openedx.core.djangoapps.content.block_structure.transformer import (
     BlockStructureTransformer,
     FilteringTransformerMixin

--- a/lms/djangoapps/course_blocks/transformers/load_override_data.py
+++ b/lms/djangoapps/course_blocks/transformers/load_override_data.py
@@ -5,7 +5,7 @@ from __future__ import absolute_import
 
 import json
 
-from courseware.models import StudentFieldOverride
+from lms.djangoapps.courseware.models import StudentFieldOverride
 from openedx.core.djangoapps.content.block_structure.transformer import BlockStructureTransformer
 
 # The list of fields are in support of Individual due dates and could be expanded for other use cases.

--- a/lms/djangoapps/course_blocks/transformers/tests/test_start_date.py
+++ b/lms/djangoapps/course_blocks/transformers/tests/test_start_date.py
@@ -10,7 +10,7 @@ import six
 from django.utils.timezone import now
 from mock import patch
 
-from courseware.tests.factories import BetaTesterFactory
+from lms.djangoapps.courseware.tests.factories import BetaTesterFactory
 
 from ..start_date import DEFAULT_START_DATE, StartDateTransformer
 from .helpers import BlockParentsMapTestCase, update_block

--- a/lms/djangoapps/course_blocks/utils.py
+++ b/lms/djangoapps/course_blocks/utils.py
@@ -3,7 +3,7 @@ Common utilities for use along with the course blocks.
 """
 import json
 
-from courseware.models import StudentModule
+from lms.djangoapps.courseware.models import StudentModule
 
 
 def get_student_module_as_dict(user, course_key, block_key):

--- a/lms/djangoapps/course_wiki/middleware.py
+++ b/lms/djangoapps/course_wiki/middleware.py
@@ -8,8 +8,8 @@ from django.shortcuts import redirect
 from six import text_type
 from wiki.models import reverse
 
-from courseware.access import has_access
-from courseware.courses import get_course_overview_with_access, get_course_with_access
+from lms.djangoapps.courseware.access import has_access
+from lms.djangoapps.courseware.courses import get_course_overview_with_access, get_course_with_access
 from openedx.core.lib.request_utils import course_id_from_url
 from openedx.features.enterprise_support.api import get_enterprise_consent_url
 from student.models import CourseEnrollment

--- a/lms/djangoapps/course_wiki/tab.py
+++ b/lms/djangoapps/course_wiki/tab.py
@@ -6,7 +6,7 @@ a user has on an article.
 from django.conf import settings
 from django.utils.translation import ugettext_noop
 
-from courseware.tabs import EnrolledTab
+from lms.djangoapps.courseware.tabs import EnrolledTab
 
 
 class WikiTab(EnrolledTab):

--- a/lms/djangoapps/course_wiki/tests/test_access.py
+++ b/lms/djangoapps/course_wiki/tests/test_access.py
@@ -9,7 +9,7 @@ from django.contrib.auth.models import Group
 from course_wiki import settings
 from course_wiki.utils import course_wiki_slug, user_is_article_course_staff
 from course_wiki.views import get_or_create_root
-from courseware.tests.factories import InstructorFactory, StaffFactory
+from lms.djangoapps.courseware.tests.factories import InstructorFactory, StaffFactory
 from student.tests.factories import UserFactory
 from wiki.models import URLPath
 from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase

--- a/lms/djangoapps/course_wiki/tests/test_comprehensive_theming.py
+++ b/lms/djangoapps/course_wiki/tests/test_comprehensive_theming.py
@@ -8,7 +8,7 @@ from unittest import skip
 from django.test.client import Client
 
 from course_wiki.views import get_or_create_root
-from courseware.tests.factories import InstructorFactory
+from lms.djangoapps.courseware.tests.factories import InstructorFactory
 from openedx.core.djangoapps.theming.tests.test_util import with_comprehensive_theme
 from wiki.models import URLPath
 from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase

--- a/lms/djangoapps/course_wiki/tests/test_middleware.py
+++ b/lms/djangoapps/course_wiki/tests/test_middleware.py
@@ -7,7 +7,7 @@ from __future__ import absolute_import
 from django.test.client import Client
 
 from course_wiki.views import get_or_create_root
-from courseware.tests.factories import InstructorFactory
+from lms.djangoapps.courseware.tests.factories import InstructorFactory
 from wiki.models import URLPath
 from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
 from xmodule.modulestore.tests.factories import CourseFactory

--- a/lms/djangoapps/course_wiki/tests/test_tab.py
+++ b/lms/djangoapps/course_wiki/tests/test_tab.py
@@ -7,7 +7,7 @@ from __future__ import absolute_import
 from django.conf import settings
 from django.test.client import RequestFactory
 
-from courseware.tabs import get_course_tab_list
+from lms.djangoapps.courseware.tabs import get_course_tab_list
 from student.tests.factories import AdminFactory, UserFactory
 from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
 from xmodule.modulestore.tests.factories import CourseFactory

--- a/lms/djangoapps/course_wiki/tests/tests.py
+++ b/lms/djangoapps/course_wiki/tests/tests.py
@@ -9,7 +9,7 @@ from django.urls import reverse
 from mock import patch
 from six import text_type
 
-from courseware.tests.tests import LoginEnrollmentTestCase
+from lms.djangoapps.courseware.tests.tests import LoginEnrollmentTestCase
 from openedx.features.enterprise_support.tests.mixins.enterprise import EnterpriseTestConsentRequired
 from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
 from xmodule.modulestore.tests.factories import CourseFactory

--- a/lms/djangoapps/course_wiki/utils.py
+++ b/lms/djangoapps/course_wiki/utils.py
@@ -4,7 +4,7 @@ Utility functions for course_wiki.
 
 from django.core.exceptions import ObjectDoesNotExist
 
-import courseware
+import lms.djangoapps.courseware
 from xmodule import modulestore
 
 

--- a/lms/djangoapps/course_wiki/views.py
+++ b/lms/djangoapps/course_wiki/views.py
@@ -12,7 +12,7 @@ from wiki.core.exceptions import NoRootURL
 from wiki.models import Article, URLPath
 
 from course_wiki.utils import course_wiki_slug
-from courseware.courses import get_course_by_id
+from lms.djangoapps.courseware.courses import get_course_by_id
 from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
 from openedx.core.djangolib.markup import Text
 from openedx.features.enterprise_support.api import data_sharing_consent_required

--- a/lms/djangoapps/courseware/access.py
+++ b/lms/djangoapps/courseware/access.py
@@ -20,12 +20,12 @@ from opaque_keys.edx.keys import CourseKey, UsageKey
 from six import text_type
 from xblock.core import XBlock
 
-from courseware.access_response import (
+from lms.djangoapps.courseware.access_response import (
     MilestoneAccessError,
     MobileAvailabilityError,
     VisibilityError,
 )
-from courseware.access_utils import (
+from lms.djangoapps.courseware.access_utils import (
     ACCESS_DENIED,
     ACCESS_GRANTED,
     adjust_start_date,
@@ -34,11 +34,11 @@ from courseware.access_utils import (
     in_preview_mode,
     check_course_open_for_learner,
 )
-from courseware.access_response import (
+from lms.djangoapps.courseware.access_response import (
     NoAllowedPartitionGroupsError,
     IncorrectPartitionGroupError,
 )
-from courseware.masquerade import get_masquerade_role, is_masquerading_as_student
+from lms.djangoapps.courseware.masquerade import get_masquerade_role, is_masquerading_as_student
 from lms.djangoapps.ccx.custom_exception import CCXLocatorValidationException
 from lms.djangoapps.ccx.models import CustomCourseForEdX
 from mobile_api.models import IgnoreMobileAvailableFlagConfig

--- a/lms/djangoapps/courseware/access_utils.py
+++ b/lms/djangoapps/courseware/access_utils.py
@@ -10,8 +10,8 @@ from django.conf import settings
 from django.utils.translation import ugettext as _
 from pytz import UTC
 
-from courseware.access_response import AccessResponse, StartDateError
-from courseware.masquerade import (
+from lms.djangoapps.courseware.access_response import AccessResponse, StartDateError
+from lms.djangoapps.courseware.masquerade import (
     get_course_masquerade,
     is_masquerading_as_student
 )

--- a/lms/djangoapps/courseware/admin.py
+++ b/lms/djangoapps/courseware/admin.py
@@ -2,7 +2,7 @@ from django.contrib import admin
 
 from config_models.admin import ConfigurationModelAdmin, KeyedConfigurationModelAdmin
 
-from courseware import models
+from lms.djangoapps.courseware import models
 
 admin.site.register(models.DynamicUpgradeDeadlineConfiguration, ConfigurationModelAdmin)
 admin.site.register(models.OfflineComputedGrade)

--- a/lms/djangoapps/courseware/course_tools.py
+++ b/lms/djangoapps/courseware/course_tools.py
@@ -10,7 +10,7 @@ from django.utils.translation import ugettext as _
 from course_modes.models import CourseMode
 from openedx.features.course_experience.course_tools import CourseTool
 from student.models import CourseEnrollment
-from courseware.date_summary import verified_upgrade_deadline_link
+from lms.djangoapps.courseware.date_summary import verified_upgrade_deadline_link
 
 
 class VerifiedUpgradeTool(CourseTool):

--- a/lms/djangoapps/courseware/courses.py
+++ b/lms/djangoapps/courseware/courses.py
@@ -10,9 +10,9 @@ import branding
 import pytz
 from crum import get_current_request
 from openedx.features.course_duration_limits.access import AuditExpiredError
-from courseware.access import has_access
-from courseware.access_response import StartDateError, MilestoneAccessError
-from courseware.date_summary import (
+from lms.djangoapps.courseware.access import has_access
+from lms.djangoapps.courseware.access_response import StartDateError, MilestoneAccessError
+from lms.djangoapps.courseware.date_summary import (
     CourseEndDate,
     CourseStartDate,
     TodaysDate,
@@ -20,9 +20,9 @@ from courseware.date_summary import (
     VerifiedUpgradeDeadlineDate,
     CertificateAvailableDate
 )
-from courseware.masquerade import check_content_start_date_for_masquerade_user
-from courseware.model_data import FieldDataCache
-from courseware.module_render import get_module
+from lms.djangoapps.courseware.masquerade import check_content_start_date_for_masquerade_user
+from lms.djangoapps.courseware.model_data import FieldDataCache
+from lms.djangoapps.courseware.module_render import get_module
 from course_modes.models import CourseMode
 from django.conf import settings
 from django.db.models import Prefetch

--- a/lms/djangoapps/courseware/entrance_exams.py
+++ b/lms/djangoapps/courseware/entrance_exams.py
@@ -2,7 +2,7 @@
 This file contains all entrance exam related utils/logic.
 """
 
-from courseware.access import has_access
+from lms.djangoapps.courseware.access import has_access
 from opaque_keys.edx.keys import UsageKey
 from student.models import EntranceExamConfiguration
 from util.milestones_helpers import get_required_content, is_entrance_exams_enabled

--- a/lms/djangoapps/courseware/migrations/0005_orgdynamicupgradedeadlineconfiguration.py
+++ b/lms/djangoapps/courseware/migrations/0005_orgdynamicupgradedeadlineconfiguration.py
@@ -4,7 +4,7 @@ from __future__ import unicode_literals
 from django.db import migrations, models
 import django.db.models.deletion
 from django.conf import settings
-import courseware.models
+import lms.djangoapps.courseware.models
 
 
 class Migration(migrations.Migration):

--- a/lms/djangoapps/courseware/model_data.py
+++ b/lms/djangoapps/courseware/model_data.py
@@ -36,7 +36,7 @@ from xblock.exceptions import InvalidScopeError, KeyValueMultiSaveError
 from xblock.fields import Scope, UserScope
 from xblock.runtime import KeyValueStore
 
-from courseware.user_state_client import DjangoXBlockUserStateClient
+from lms.djangoapps.courseware.user_state_client import DjangoXBlockUserStateClient
 from xmodule.modulestore.django import modulestore
 
 from .models import StudentModule, XModuleStudentInfoField, XModuleStudentPrefsField, XModuleUserStateSummaryField

--- a/lms/djangoapps/courseware/models.py
+++ b/lms/djangoapps/courseware/models.py
@@ -24,7 +24,7 @@ from django.utils.translation import ugettext_lazy as _
 from model_utils.models import TimeStampedModel
 from six import text_type
 
-import coursewarehistoryextended
+import lms.djangoapps.coursewarehistoryextended
 from opaque_keys.edx.django.models import BlockTypeKeyField, CourseKeyField, UsageKeyField
 
 from openedx.core.djangolib.markup import HTML

--- a/lms/djangoapps/courseware/module_render.py
+++ b/lms/djangoapps/courseware/module_render.py
@@ -40,16 +40,16 @@ from xblock.runtime import KvsFieldData
 
 import static_replace
 from capa.xqueue_interface import XQueueInterface
-from courseware.access import get_user_role, has_access
-from courseware.access_response import IncorrectPartitionGroupError
-from courseware.entrance_exams import user_can_skip_entrance_exam, user_has_passed_entrance_exam
-from courseware.masquerade import (
+from lms.djangoapps.courseware.access import get_user_role, has_access
+from lms.djangoapps.courseware.access_response import IncorrectPartitionGroupError
+from lms.djangoapps.courseware.entrance_exams import user_can_skip_entrance_exam, user_has_passed_entrance_exam
+from lms.djangoapps.courseware.masquerade import (
     MasqueradingKeyValueStore,
     filter_displayed_blocks,
     is_masquerading_as_specific_student,
     setup_masquerade
 )
-from courseware.model_data import DjangoKeyValueStore, FieldDataCache
+from lms.djangoapps.courseware.model_data import DjangoKeyValueStore, FieldDataCache
 from edxmako.shortcuts import render_to_string
 from eventtracking import tracker
 from lms.djangoapps.courseware.field_overrides import OverrideFieldData

--- a/lms/djangoapps/courseware/student_field_overrides.py
+++ b/lms/djangoapps/courseware/student_field_overrides.py
@@ -4,7 +4,7 @@ by the individual due dates feature.
 """
 import json
 
-from courseware.models import StudentFieldOverride
+from lms.djangoapps.courseware.models import StudentFieldOverride
 from openedx.core.lib.xblock_utils import is_xblock_aside
 
 from .field_overrides import FieldOverrideProvider

--- a/lms/djangoapps/courseware/tabs.py
+++ b/lms/djangoapps/courseware/tabs.py
@@ -2,8 +2,8 @@
 This module is essentially a broker to xmodule/tabs.py -- it was originally introduced to
 perform some LMS-specific tab display gymnastics for the Entrance Exams feature
 """
-from courseware.access import has_access
-from courseware.entrance_exams import user_can_skip_entrance_exam
+from lms.djangoapps.courseware.access import has_access
+from lms.djangoapps.courseware.entrance_exams import user_can_skip_entrance_exam
 from django.conf import settings
 from django.utils.translation import ugettext as _
 from django.utils.translation import ugettext_noop

--- a/lms/djangoapps/courseware/tests/factories.py
+++ b/lms/djangoapps/courseware/tests/factories.py
@@ -11,7 +11,7 @@ from factory.django import DjangoModelFactory
 from opaque_keys.edx.keys import CourseKey
 from opaque_keys.edx.locator import CourseLocator
 
-from courseware.models import (
+from lms.djangoapps.courseware.models import (
     StudentModule,
     XModuleStudentInfoField,
     XModuleStudentPrefsField,

--- a/lms/djangoapps/courseware/tests/helpers.py
+++ b/lms/djangoapps/courseware/tests/helpers.py
@@ -17,8 +17,8 @@ from six import text_type
 from six.moves import range
 from xblock.field_data import DictFieldData
 
-from courseware.access import has_access
-from courseware.masquerade import handle_ajax, setup_masquerade
+from lms.djangoapps.courseware.access import has_access
+from lms.djangoapps.courseware.masquerade import handle_ajax, setup_masquerade
 from edxmako.shortcuts import render_to_string
 from lms.djangoapps.courseware.date_summary import verified_upgrade_deadline_link
 from lms.djangoapps.lms_xblock.field_data import LmsFieldData

--- a/lms/djangoapps/courseware/tests/test_access.py
+++ b/lms/djangoapps/courseware/tests/test_access.py
@@ -19,17 +19,17 @@ from milestones.tests.utils import MilestonesTestCaseMixin
 from mock import Mock, patch
 from opaque_keys.edx.locator import CourseLocator
 
-import courseware.access as access
-import courseware.access_response as access_response
-from courseware.masquerade import CourseMasquerade
-from courseware.tests.factories import (
+import lms.djangoapps.courseware.access as access
+import lms.djangoapps.courseware.access_response as access_response
+from lms.djangoapps.courseware.masquerade import CourseMasquerade
+from lms.djangoapps.courseware.tests.factories import (
     BetaTesterFactory,
     GlobalStaffFactory,
     InstructorFactory,
     StaffFactory,
     UserFactory
 )
-from courseware.tests.helpers import LoginEnrollmentTestCase, masquerade_as_group_member
+from lms.djangoapps.courseware.tests.helpers import LoginEnrollmentTestCase, masquerade_as_group_member
 from lms.djangoapps.ccx.models import CustomCourseForEdX
 from openedx.core.djangoapps.content.course_overviews.models import CourseOverview
 from openedx.core.djangoapps.waffle_utils.testutils import WAFFLE_TABLES

--- a/lms/djangoapps/courseware/tests/test_context_processor.py
+++ b/lms/djangoapps/courseware/tests/test_context_processor.py
@@ -6,7 +6,7 @@ from __future__ import absolute_import
 from django.contrib.auth.models import AnonymousUser
 from mock import Mock
 
-from courseware.context_processor import user_timezone_locale_prefs
+from lms.djangoapps.courseware.context_processor import user_timezone_locale_prefs
 from openedx.core.djangoapps.user_api.preferences.api import set_user_preference
 from student.tests.factories import UserFactory
 from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase

--- a/lms/djangoapps/courseware/tests/test_course_survey.py
+++ b/lms/djangoapps/courseware/tests/test_course_survey.py
@@ -13,7 +13,7 @@ from django.urls import reverse
 from six.moves import range
 
 from common.test.utils import XssTestMixin
-from courseware.tests.helpers import LoginEnrollmentTestCase
+from lms.djangoapps.courseware.tests.helpers import LoginEnrollmentTestCase
 from survey.models import SurveyAnswer, SurveyForm
 from xmodule.modulestore.tests.django_utils import SharedModuleStoreTestCase
 from xmodule.modulestore.tests.factories import CourseFactory

--- a/lms/djangoapps/courseware/tests/test_course_tools.py
+++ b/lms/djangoapps/courseware/tests/test_course_tools.py
@@ -13,8 +13,8 @@ from mock import patch
 
 from course_modes.models import CourseMode
 from course_modes.tests.factories import CourseModeFactory
-from courseware.course_tools import VerifiedUpgradeTool
-from courseware.models import DynamicUpgradeDeadlineConfiguration
+from lms.djangoapps.courseware.course_tools import VerifiedUpgradeTool
+from lms.djangoapps.courseware.models import DynamicUpgradeDeadlineConfiguration
 from openedx.core.djangoapps.content.course_overviews.models import CourseOverview
 from openedx.core.djangoapps.schedules.config import CREATE_SCHEDULE_WAFFLE_FLAG
 from openedx.core.djangoapps.site_configuration.tests.factories import SiteFactory

--- a/lms/djangoapps/courseware/tests/test_courses.py
+++ b/lms/djangoapps/courseware/tests/test_courses.py
@@ -20,7 +20,7 @@ from opaque_keys.edx.keys import CourseKey
 from six import text_type
 from six.moves import range
 
-from courseware.courses import (
+from lms.djangoapps.courseware.courses import (
     course_open_for_self_enrollment,
     get_cms_block_link,
     get_cms_course_link,
@@ -33,8 +33,8 @@ from courseware.courses import (
     get_courses,
     get_current_child
 )
-from courseware.model_data import FieldDataCache
-from courseware.module_render import get_module_for_descriptor
+from lms.djangoapps.courseware.model_data import FieldDataCache
+from lms.djangoapps.courseware.module_render import get_module_for_descriptor
 from lms.djangoapps.courseware.courseware_access_exception import CoursewareAccessException
 from openedx.core.djangolib.testing.utils import get_mock_request
 from openedx.core.lib.courses import course_image_url

--- a/lms/djangoapps/courseware/tests/test_date_summary.py
+++ b/lms/djangoapps/courseware/tests/test_date_summary.py
@@ -15,8 +15,8 @@ from pytz import utc
 
 from course_modes.models import CourseMode
 from course_modes.tests.factories import CourseModeFactory
-from courseware.courses import get_course_date_blocks
-from courseware.date_summary import (
+from lms.djangoapps.courseware.courses import get_course_date_blocks
+from lms.djangoapps.courseware.date_summary import (
     CertificateAvailableDate,
     CourseEndDate,
     CourseStartDate,
@@ -24,7 +24,7 @@ from courseware.date_summary import (
     VerificationDeadlineDate,
     VerifiedUpgradeDeadlineDate
 )
-from courseware.models import (
+from lms.djangoapps.courseware.models import (
     CourseDynamicUpgradeDeadlineConfiguration,
     DynamicUpgradeDeadlineConfiguration,
     OrgDynamicUpgradeDeadlineConfiguration

--- a/lms/djangoapps/courseware/tests/test_discussion_xblock.py
+++ b/lms/djangoapps/courseware/tests/test_discussion_xblock.py
@@ -20,7 +20,7 @@ from web_fragments.fragment import Fragment
 from xblock.field_data import DictFieldData
 
 from course_api.blocks.tests.helpers import deserialize_usage_key
-from courseware.module_render import get_module_for_descriptor_internal
+from lms.djangoapps.courseware.module_render import get_module_for_descriptor_internal
 from lms.djangoapps.courseware.tests.helpers import XModuleRenderingTestBase
 from student.tests.factories import CourseEnrollmentFactory, UserFactory
 from xblock_discussion import DiscussionXBlock, loader

--- a/lms/djangoapps/courseware/tests/test_entrance_exam.py
+++ b/lms/djangoapps/courseware/tests/test_entrance_exam.py
@@ -10,16 +10,16 @@ from milestones.tests.utils import MilestonesTestCaseMixin
 from mock import Mock, patch
 
 from capa.tests.response_xml_factory import MultipleChoiceResponseXMLFactory
-from courseware.entrance_exams import (
+from lms.djangoapps.courseware.entrance_exams import (
     course_has_entrance_exam,
     get_entrance_exam_content,
     user_can_skip_entrance_exam,
     user_has_passed_entrance_exam
 )
-from courseware.model_data import FieldDataCache
-from courseware.module_render import get_module, handle_xblock_callback, toc_for_course
-from courseware.tests.factories import InstructorFactory, RequestFactoryNoCsrf, StaffFactory, UserFactory
-from courseware.tests.helpers import LoginEnrollmentTestCase
+from lms.djangoapps.courseware.model_data import FieldDataCache
+from lms.djangoapps.courseware.module_render import get_module, handle_xblock_callback, toc_for_course
+from lms.djangoapps.courseware.tests.factories import InstructorFactory, RequestFactoryNoCsrf, StaffFactory, UserFactory
+from lms.djangoapps.courseware.tests.helpers import LoginEnrollmentTestCase
 from openedx.core.djangoapps.waffle_utils.testutils import override_waffle_flag
 from openedx.core.djangolib.testing.utils import get_mock_request
 from openedx.features.course_experience import COURSE_OUTLINE_PAGE_FLAG, UNIFIED_COURSE_TAB_FLAG

--- a/lms/djangoapps/courseware/tests/test_group_access.py
+++ b/lms/djangoapps/courseware/tests/test_group_access.py
@@ -8,8 +8,8 @@ from __future__ import absolute_import
 import ddt
 from stevedore.extension import Extension, ExtensionManager
 
-import courseware.access as access
-from courseware.tests.factories import StaffFactory, UserFactory
+import lms.djangoapps.courseware.access as access
+from lms.djangoapps.courseware.tests.factories import StaffFactory, UserFactory
 from xmodule.modulestore.django import modulestore
 from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
 from xmodule.modulestore.tests.factories import CourseFactory, ItemFactory

--- a/lms/djangoapps/courseware/tests/test_lti_integration.py
+++ b/lms/djangoapps/courseware/tests/test_lti_integration.py
@@ -14,8 +14,8 @@ from django.conf import settings
 from django.urls import reverse
 from six import text_type
 
-from courseware.tests.helpers import BaseTestXmodule
-from courseware.views.views import get_course_lti_endpoints
+from lms.djangoapps.courseware.tests.helpers import BaseTestXmodule
+from lms.djangoapps.courseware.views.views import get_course_lti_endpoints
 from openedx.core.lib.url_utils import quote_slashes
 from xmodule.modulestore.tests.django_utils import SharedModuleStoreTestCase
 from xmodule.modulestore.tests.factories import CourseFactory, ItemFactory

--- a/lms/djangoapps/courseware/tests/test_masquerade.py
+++ b/lms/djangoapps/courseware/tests/test_masquerade.py
@@ -18,10 +18,10 @@ from pytz import UTC
 from xblock.runtime import DictKeyValueStore
 
 from capa.tests.response_xml_factory import OptionResponseXMLFactory
-from courseware.masquerade import CourseMasquerade, MasqueradingKeyValueStore, get_masquerading_user_group
-from courseware.tests.factories import StaffFactory
-from courseware.tests.helpers import LoginEnrollmentTestCase, masquerade_as_group_member
-from courseware.tests.test_submitting_problems import ProblemSubmissionTestMixin
+from lms.djangoapps.courseware.masquerade import CourseMasquerade, MasqueradingKeyValueStore, get_masquerading_user_group
+from lms.djangoapps.courseware.tests.factories import StaffFactory
+from lms.djangoapps.courseware.tests.helpers import LoginEnrollmentTestCase, masquerade_as_group_member
+from lms.djangoapps.courseware.tests.test_submitting_problems import ProblemSubmissionTestMixin
 from openedx.core.djangoapps.lang_pref import LANGUAGE_KEY
 from openedx.core.djangoapps.self_paced.models import SelfPacedConfiguration
 from openedx.core.djangoapps.user_api.preferences.api import get_user_preference, set_user_preference

--- a/lms/djangoapps/courseware/tests/test_microsites.py
+++ b/lms/djangoapps/courseware/tests/test_microsites.py
@@ -15,7 +15,7 @@ from six import text_type
 from six.moves import range
 
 from course_modes.models import CourseMode
-from courseware.tests.helpers import LoginEnrollmentTestCase
+from lms.djangoapps.courseware.tests.helpers import LoginEnrollmentTestCase
 from xmodule.course_module import CATALOG_VISIBILITY_CATALOG_AND_ABOUT, CATALOG_VISIBILITY_NONE
 from xmodule.modulestore.tests.django_utils import SharedModuleStoreTestCase
 from xmodule.modulestore.tests.factories import CourseFactory, ItemFactory

--- a/lms/djangoapps/courseware/tests/test_model_data.py
+++ b/lms/djangoapps/courseware/tests/test_model_data.py
@@ -13,16 +13,16 @@ from xblock.core import XBlock
 from xblock.exceptions import KeyValueMultiSaveError
 from xblock.fields import BlockScope, Scope, ScopeIds
 
-from courseware.model_data import DjangoKeyValueStore, FieldDataCache, InvalidScopeError
-from courseware.models import (
+from lms.djangoapps.courseware.model_data import DjangoKeyValueStore, FieldDataCache, InvalidScopeError
+from lms.djangoapps.courseware.models import (
     StudentModule,
     XModuleStudentInfoField,
     XModuleStudentPrefsField,
     XModuleUserStateSummaryField
 )
-from courseware.tests.factories import StudentInfoFactory
-from courseware.tests.factories import StudentModuleFactory as cmfStudentModuleFactory
-from courseware.tests.factories import StudentPrefsFactory, UserStateSummaryFactory, course_id, location
+from lms.djangoapps.courseware.tests.factories import StudentInfoFactory
+from lms.djangoapps.courseware.tests.factories import StudentModuleFactory as cmfStudentModuleFactory
+from lms.djangoapps.courseware.tests.factories import StudentPrefsFactory, UserStateSummaryFactory, course_id, location
 from student.tests.factories import UserFactory
 
 

--- a/lms/djangoapps/courseware/tests/test_module_render.py
+++ b/lms/djangoapps/courseware/tests/test_module_render.py
@@ -44,16 +44,16 @@ from xblock.test.tools import TestRuntime
 
 from capa.tests.response_xml_factory import OptionResponseXMLFactory
 from course_modes.models import CourseMode
-from courseware import module_render as render
-from courseware.access_response import AccessResponse
-from courseware.courses import get_course_info_section, get_course_with_access
-from courseware.masquerade import CourseMasquerade
-from courseware.model_data import FieldDataCache
-from courseware.models import StudentModule
-from courseware.module_render import get_module_for_descriptor, hash_resource
-from courseware.tests.factories import GlobalStaffFactory, RequestFactoryNoCsrf, StudentModuleFactory, UserFactory
-from courseware.tests.test_submitting_problems import TestSubmittingProblems
-from courseware.tests.tests import LoginEnrollmentTestCase
+from lms.djangoapps.courseware import module_render as render
+from lms.djangoapps.courseware.access_response import AccessResponse
+from lms.djangoapps.courseware.courses import get_course_info_section, get_course_with_access
+from lms.djangoapps.courseware.masquerade import CourseMasquerade
+from lms.djangoapps.courseware.model_data import FieldDataCache
+from lms.djangoapps.courseware.models import StudentModule
+from lms.djangoapps.courseware.module_render import get_module_for_descriptor, hash_resource
+from lms.djangoapps.courseware.tests.factories import GlobalStaffFactory, RequestFactoryNoCsrf, StudentModuleFactory, UserFactory
+from lms.djangoapps.courseware.tests.test_submitting_problems import TestSubmittingProblems
+from lms.djangoapps.courseware.tests.tests import LoginEnrollmentTestCase
 from lms.djangoapps.courseware.field_overrides import OverrideFieldData
 from lms.djangoapps.lms_xblock.field_data import LmsFieldData
 from openedx.core.djangoapps.credit.api import set_credit_requirement_status, set_credit_requirements

--- a/lms/djangoapps/courseware/tests/test_navigation.py
+++ b/lms/djangoapps/courseware/tests/test_navigation.py
@@ -12,8 +12,8 @@ from mock import patch
 from six import text_type
 from six.moves import range
 
-from courseware.tests.factories import GlobalStaffFactory
-from courseware.tests.helpers import LoginEnrollmentTestCase
+from lms.djangoapps.courseware.tests.factories import GlobalStaffFactory
+from lms.djangoapps.courseware.tests.helpers import LoginEnrollmentTestCase
 from openedx.core.djangoapps.waffle_utils.testutils import override_waffle_flag
 from openedx.features.course_experience import COURSE_OUTLINE_PAGE_FLAG
 from student.tests.factories import UserFactory

--- a/lms/djangoapps/courseware/tests/test_password_reset.py
+++ b/lms/djangoapps/courseware/tests/test_password_reset.py
@@ -11,7 +11,7 @@ from django.contrib.auth.tokens import default_token_generator
 from django.test.utils import override_settings
 from django.utils.http import int_to_base36
 
-from courseware.tests.helpers import LoginEnrollmentTestCase
+from lms.djangoapps.courseware.tests.helpers import LoginEnrollmentTestCase
 from util.password_policy_validators import create_validator_config
 
 

--- a/lms/djangoapps/courseware/tests/test_self_paced_overrides.py
+++ b/lms/djangoapps/courseware/tests/test_self_paced_overrides.py
@@ -8,8 +8,8 @@ import pytz
 from django.test.utils import override_settings
 from mock import patch
 
-from courseware.access import has_access
-from courseware.tests.factories import BetaTesterFactory
+from lms.djangoapps.courseware.access import has_access
+from lms.djangoapps.courseware.tests.factories import BetaTesterFactory
 from lms.djangoapps.ccx.tests.test_overrides import inject_field_overrides
 from lms.djangoapps.courseware.field_overrides import OverrideFieldData, OverrideModulestoreFieldData
 from lms.djangoapps.discussion.django_comment_client.utils import get_accessible_discussion_xblocks

--- a/lms/djangoapps/courseware/tests/test_split_module.py
+++ b/lms/djangoapps/courseware/tests/test_split_module.py
@@ -8,8 +8,8 @@ from django.urls import reverse
 from mock import MagicMock
 from six import text_type
 
-from courseware.model_data import FieldDataCache
-from courseware.module_render import get_module_for_descriptor
+from lms.djangoapps.courseware.model_data import FieldDataCache
+from lms.djangoapps.courseware.module_render import get_module_for_descriptor
 from openedx.core.djangoapps.user_api.tests.factories import UserCourseTagFactory
 from student.tests.factories import CourseEnrollmentFactory, UserFactory
 from xmodule.modulestore.tests.django_utils import SharedModuleStoreTestCase

--- a/lms/djangoapps/courseware/tests/test_submitting_problems.py
+++ b/lms/djangoapps/courseware/tests/test_submitting_problems.py
@@ -30,8 +30,8 @@ from capa.tests.response_xml_factory import (
     SchematicResponseXMLFactory
 )
 from course_modes.models import CourseMode
-from courseware.models import BaseStudentModuleHistory, StudentModule
-from courseware.tests.helpers import LoginEnrollmentTestCase
+from lms.djangoapps.courseware.models import BaseStudentModuleHistory, StudentModule
+from lms.djangoapps.courseware.tests.helpers import LoginEnrollmentTestCase
 from lms.djangoapps.grades.api import CourseGradeFactory, task_compute_all_grades_for_course
 from openedx.core.djangoapps.credit.api import get_credit_requirement_status, set_credit_requirements
 from openedx.core.djangoapps.credit.models import CreditCourse, CreditProvider

--- a/lms/djangoapps/courseware/tests/test_tabs.py
+++ b/lms/djangoapps/courseware/tests/test_tabs.py
@@ -13,8 +13,8 @@ from mock import MagicMock, Mock, patch
 from six import text_type
 from six.moves import range
 
-from courseware.courses import get_course_by_id
-from courseware.tabs import (
+from lms.djangoapps.courseware.courses import get_course_by_id
+from lms.djangoapps.courseware.tabs import (
     CourseInfoTab,
     CoursewareTab,
     ExternalDiscussionCourseTab,
@@ -22,9 +22,9 @@ from courseware.tabs import (
     ProgressTab,
     get_course_tab_list
 )
-from courseware.tests.factories import InstructorFactory, StaffFactory
-from courseware.tests.helpers import LoginEnrollmentTestCase
-from courseware.views.views import StaticCourseTabView, get_static_tab_fragment
+from lms.djangoapps.courseware.tests.factories import InstructorFactory, StaffFactory
+from lms.djangoapps.courseware.tests.helpers import LoginEnrollmentTestCase
+from lms.djangoapps.courseware.views.views import StaticCourseTabView, get_static_tab_fragment
 from openedx.core.djangoapps.waffle_utils.testutils import override_waffle_flag
 from openedx.core.djangolib.testing.utils import get_mock_request
 from openedx.features.course_experience import UNIFIED_COURSE_TAB_FLAG

--- a/lms/djangoapps/courseware/tests/test_user_state_client.py
+++ b/lms/djangoapps/courseware/tests/test_user_state_client.py
@@ -9,8 +9,8 @@ from collections import defaultdict
 
 from edx_user_state_client.tests import UserStateClientTestBase
 
-from courseware.tests.factories import UserFactory
-from courseware.user_state_client import DjangoXBlockUserStateClient
+from lms.djangoapps.courseware.tests.factories import UserFactory
+from lms.djangoapps.courseware.user_state_client import DjangoXBlockUserStateClient
 from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
 
 

--- a/lms/djangoapps/courseware/tests/test_view_authentication.py
+++ b/lms/djangoapps/courseware/tests/test_view_authentication.py
@@ -12,8 +12,8 @@ from mock import patch
 from six import text_type
 from six.moves import range
 
-from courseware.access import has_access
-from courseware.tests.factories import (
+from lms.djangoapps.courseware.access import has_access
+from lms.djangoapps.courseware.tests.factories import (
     BetaTesterFactory,
     GlobalStaffFactory,
     InstructorFactory,
@@ -21,7 +21,7 @@ from courseware.tests.factories import (
     OrgStaffFactory,
     StaffFactory
 )
-from courseware.tests.helpers import CourseAccessTestMixin, LoginEnrollmentTestCase
+from lms.djangoapps.courseware.tests.helpers import CourseAccessTestMixin, LoginEnrollmentTestCase
 from openedx.features.enterprise_support.tests.mixins.enterprise import EnterpriseTestConsentRequired
 from student.tests.factories import CourseEnrollmentFactory, UserFactory
 from xmodule.modulestore.django import modulestore

--- a/lms/djangoapps/courseware/tests/test_views.py
+++ b/lms/djangoapps/courseware/tests/test_views.py
@@ -36,19 +36,19 @@ from web_fragments.fragment import Fragment
 from xblock.core import XBlock
 from xblock.fields import Scope, String
 
-import courseware.views.views as views
+import lms.djangoapps.courseware.views.views as views
 import shoppingcart
 from capa.tests.response_xml_factory import MultipleChoiceResponseXMLFactory
 from course_modes.models import CourseMode
 from course_modes.tests.factories import CourseModeFactory
-from courseware.access_utils import check_course_open_for_learner
-from courseware.model_data import FieldDataCache, set_score
-from courseware.module_render import get_module, handle_xblock_callback
-from courseware.tests.factories import GlobalStaffFactory, RequestFactoryNoCsrf, StudentModuleFactory
-from courseware.tests.helpers import get_expiration_banner_text
-from courseware.testutils import RenderXBlockTestMixin
-from courseware.url_helpers import get_redirect_url
-from courseware.user_state_client import DjangoXBlockUserStateClient
+from lms.djangoapps.courseware.access_utils import check_course_open_for_learner
+from lms.djangoapps.courseware.model_data import FieldDataCache, set_score
+from lms.djangoapps.courseware.module_render import get_module, handle_xblock_callback
+from lms.djangoapps.courseware.tests.factories import GlobalStaffFactory, RequestFactoryNoCsrf, StudentModuleFactory
+from lms.djangoapps.courseware.tests.helpers import get_expiration_banner_text
+from lms.djangoapps.courseware.testutils import RenderXBlockTestMixin
+from lms.djangoapps.courseware.url_helpers import get_redirect_url
+from lms.djangoapps.courseware.user_state_client import DjangoXBlockUserStateClient
 from lms.djangoapps.certificates import api as certs_api
 from lms.djangoapps.certificates.models import (
     CertificateGenerationConfiguration,

--- a/lms/djangoapps/courseware/tests/tests.py
+++ b/lms/djangoapps/courseware/tests/tests.py
@@ -11,7 +11,7 @@ from django.urls import reverse
 from opaque_keys.edx.keys import CourseKey
 from six import text_type
 
-from courseware.tests.helpers import LoginEnrollmentTestCase
+from lms.djangoapps.courseware.tests.helpers import LoginEnrollmentTestCase
 from lms.djangoapps.lms_xblock.field_data import LmsFieldData
 from xmodule.error_module import ErrorDescriptor
 from xmodule.modulestore.django import modulestore

--- a/lms/djangoapps/courseware/user_state_client.py
+++ b/lms/djangoapps/courseware/user_state_client.py
@@ -17,7 +17,7 @@ from edx_django_utils import monitoring as monitoring_utils
 from edx_user_state_client.interface import XBlockUserState, XBlockUserStateClient
 from xblock.fields import Scope
 
-from courseware.models import BaseStudentModuleHistory, StudentModule
+from lms.djangoapps.courseware.models import BaseStudentModuleHistory, StudentModule
 
 try:
     import simplejson as json

--- a/lms/djangoapps/courseware/views/views.py
+++ b/lms/djangoapps/courseware/views/views.py
@@ -38,9 +38,9 @@ from six import text_type
 import shoppingcart
 import survey.views
 from course_modes.models import CourseMode, get_course_prices
-from courseware.access import has_access, has_ccx_coach_role
-from courseware.access_utils import check_course_open_for_learner
-from courseware.courses import (
+from lms.djangoapps.courseware.access import has_access, has_ccx_coach_role
+from lms.djangoapps.courseware.access_utils import check_course_open_for_learner
+from lms.djangoapps.courseware.courses import (
     can_self_enroll_in_course,
     course_open_for_self_enrollment,
     get_course,
@@ -53,11 +53,11 @@ from courseware.courses import (
     sort_by_announcement,
     sort_by_start_date
 )
-from courseware.masquerade import setup_masquerade
-from courseware.model_data import FieldDataCache
-from courseware.models import BaseStudentModuleHistory, StudentModule
-from courseware.url_helpers import get_redirect_url
-from courseware.user_state_client import DjangoXBlockUserStateClient
+from lms.djangoapps.courseware.masquerade import setup_masquerade
+from lms.djangoapps.courseware.model_data import FieldDataCache
+from lms.djangoapps.courseware.models import BaseStudentModuleHistory, StudentModule
+from lms.djangoapps.courseware.url_helpers import get_redirect_url
+from lms.djangoapps.courseware.user_state_client import DjangoXBlockUserStateClient
 from edxmako.shortcuts import marketing_link, render_to_response, render_to_string
 from ipware.ip import get_ip
 from lms.djangoapps.ccx.custom_exception import CCXLocatorValidationException

--- a/lms/djangoapps/coursewarehistoryextended/migrations/0001_initial.py
+++ b/lms/djangoapps/coursewarehistoryextended/migrations/0001_initial.py
@@ -4,7 +4,7 @@ from __future__ import unicode_literals
 from __future__ import absolute_import
 from django.db import migrations, models
 import django.db.models.deletion
-import coursewarehistoryextended.fields
+import lms.djangoapps.coursewarehistoryextended.fields
 from django.conf import settings
 
 def bump_pk_start(apps, schema_editor):

--- a/lms/djangoapps/coursewarehistoryextended/models.py
+++ b/lms/djangoapps/coursewarehistoryextended/models.py
@@ -19,8 +19,8 @@ from django.db import models
 from django.db.models.signals import post_delete, post_save
 from django.dispatch import receiver
 
-from courseware.models import BaseStudentModuleHistory, StudentModule
-from coursewarehistoryextended.fields import UnsignedBigIntAutoField
+from lms.djangoapps.courseware.models import BaseStudentModuleHistory, StudentModule
+from lms.djangoapps.coursewarehistoryextended.fields import UnsignedBigIntAutoField
 
 
 class StudentModuleHistoryExtended(BaseStudentModuleHistory):

--- a/lms/djangoapps/coursewarehistoryextended/tests.py
+++ b/lms/djangoapps/coursewarehistoryextended/tests.py
@@ -14,8 +14,8 @@ from django.conf import settings
 from django.test import TestCase
 from mock import patch
 
-from courseware.models import BaseStudentModuleHistory, StudentModule, StudentModuleHistory
-from courseware.tests.factories import StudentModuleFactory, course_id, location
+from lms.djangoapps.courseware.models import BaseStudentModuleHistory, StudentModule, StudentModuleHistory
+from lms.djangoapps.courseware.tests.factories import StudentModuleFactory, course_id, location
 
 
 @skipUnless(settings.FEATURES["ENABLE_CSMH_EXTENDED"], "CSMH Extended needs to be enabled")

--- a/lms/djangoapps/dashboard/sysadmin.py
+++ b/lms/djangoapps/dashboard/sysadmin.py
@@ -31,7 +31,7 @@ from six import text_type
 
 import dashboard.git_import as git_import
 import track.views
-from courseware.courses import get_course_by_id
+from lms.djangoapps.courseware.courses import get_course_by_id
 from dashboard.git_import import GitImportError
 from dashboard.models import CourseImportLog
 from edxmako.shortcuts import render_to_response

--- a/lms/djangoapps/discussion/django_comment_client/base/views.py
+++ b/lms/djangoapps/discussion/django_comment_client/base/views.py
@@ -25,8 +25,8 @@ from six import text_type
 
 import lms.djangoapps.discussion.django_comment_client.settings as cc_settings
 import openedx.core.djangoapps.django_comment_common.comment_client as cc
-from courseware.access import has_access
-from courseware.courses import get_course_by_id, get_course_overview_with_access, get_course_with_access
+from lms.djangoapps.courseware.access import has_access
+from lms.djangoapps.courseware.courses import get_course_by_id, get_course_overview_with_access, get_course_with_access
 from lms.djangoapps.courseware.exceptions import CourseAccessRedirect
 from lms.djangoapps.discussion.django_comment_client.permissions import (
     check_permissions_by_view,

--- a/lms/djangoapps/discussion/django_comment_client/tests/test_utils.py
+++ b/lms/djangoapps/discussion/django_comment_client/tests/test_utils.py
@@ -17,8 +17,8 @@ from six import text_type
 import lms.djangoapps.discussion.django_comment_client.utils as utils
 from course_modes.models import CourseMode
 from course_modes.tests.factories import CourseModeFactory
-from courseware.tabs import get_course_tab_list
-from courseware.tests.factories import InstructorFactory
+from lms.djangoapps.courseware.tabs import get_course_tab_list
+from lms.djangoapps.courseware.tests.factories import InstructorFactory
 from lms.djangoapps.discussion.django_comment_client.constants import TYPE_ENTRY, TYPE_SUBCATEGORY
 from lms.djangoapps.discussion.django_comment_client.tests.factories import RoleFactory
 from lms.djangoapps.discussion.django_comment_client.tests.unicode import UnicodeTestMixin

--- a/lms/djangoapps/discussion/django_comment_client/utils.py
+++ b/lms/djangoapps/discussion/django_comment_client/utils.py
@@ -14,8 +14,8 @@ from opaque_keys.edx.keys import CourseKey, UsageKey
 from opaque_keys.edx.locations import i4xEncoder
 from six import text_type
 
-from courseware import courses
-from courseware.access import has_access
+from lms.djangoapps.courseware import courses
+from lms.djangoapps.courseware.access import has_access
 from lms.djangoapps.discussion.django_comment_client.constants import TYPE_ENTRY, TYPE_SUBCATEGORY
 from lms.djangoapps.discussion.django_comment_client.permissions import (
     check_permissions_by_view, get_team, has_permission,

--- a/lms/djangoapps/discussion/management/commands/get_discussion_link.py
+++ b/lms/djangoapps/discussion/management/commands/get_discussion_link.py
@@ -4,7 +4,7 @@ from __future__ import absolute_import
 from django.core.management.base import BaseCommand, CommandError
 from opaque_keys.edx.keys import CourseKey
 
-from courseware.courses import get_course
+from lms.djangoapps.courseware.courses import get_course
 
 
 class Command(BaseCommand):

--- a/lms/djangoapps/discussion/plugins.py
+++ b/lms/djangoapps/discussion/plugins.py
@@ -6,7 +6,7 @@ from django.conf import settings
 from django.utils.translation import ugettext_noop
 
 import lms.djangoapps.discussion.django_comment_client.utils as utils
-from courseware.tabs import EnrolledTab
+from lms.djangoapps.courseware.tabs import EnrolledTab
 from xmodule.tabs import TabFragmentViewMixin
 
 from .config import USE_BOOTSTRAP_FLAG

--- a/lms/djangoapps/discussion/rest_api/forms.py
+++ b/lms/djangoapps/discussion/rest_api/forms.py
@@ -13,7 +13,7 @@ from opaque_keys.edx.keys import CourseKey
 from opaque_keys.edx.locator import CourseLocator
 from six import text_type
 
-from courseware.courses import get_course_with_access
+from lms.djangoapps.courseware.courses import get_course_with_access
 from openedx.core.djangoapps.django_comment_common.models import (
     FORUM_ROLE_COMMUNITY_TA,
     FORUM_ROLE_GROUP_MODERATOR,

--- a/lms/djangoapps/discussion/rest_api/tests/test_api.py
+++ b/lms/djangoapps/discussion/rest_api/tests/test_api.py
@@ -19,7 +19,7 @@ from six.moves import range
 from six.moves.urllib.parse import parse_qs, urlencode, urlparse, urlunparse  # pylint: disable=import-error
 
 from common.test.utils import MockSignalHandlerMixin, disable_signal
-from courseware.tests.factories import BetaTesterFactory, StaffFactory
+from lms.djangoapps.courseware.tests.factories import BetaTesterFactory, StaffFactory
 from lms.djangoapps.discussion.django_comment_client.tests.utils import ForumsEnableMixin
 from lms.djangoapps.discussion.rest_api import api
 from lms.djangoapps.discussion.rest_api.api import (

--- a/lms/djangoapps/discussion/views.py
+++ b/lms/djangoapps/discussion/views.py
@@ -23,9 +23,9 @@ from opaque_keys.edx.keys import CourseKey
 from rest_framework import status
 from web_fragments.fragment import Fragment
 
-from courseware.access import has_access
-from courseware.courses import get_course_with_access
-from courseware.views.views import CourseTabView
+from lms.djangoapps.courseware.access import has_access
+from lms.djangoapps.courseware.courses import get_course_with_access
+from lms.djangoapps.courseware.views.views import CourseTabView
 import lms.djangoapps.discussion.django_comment_client.utils as utils
 from lms.djangoapps.discussion.django_comment_client.base.views import track_thread_viewed_event
 from lms.djangoapps.discussion.django_comment_client.constants import TYPE_ENTRY

--- a/lms/djangoapps/edxnotes/helpers.py
+++ b/lms/djangoapps/edxnotes/helpers.py
@@ -21,8 +21,8 @@ from oauth2_provider.models import Application
 from opaque_keys.edx.keys import UsageKey
 from requests.exceptions import RequestException
 
-from courseware.access import has_access
-from courseware.courses import get_current_child
+from lms.djangoapps.courseware.access import has_access
+from lms.djangoapps.courseware.courses import get_current_child
 from edxnotes.exceptions import EdxNotesParseError, EdxNotesServiceUnavailable
 from edxnotes.plugins import EdxNotesTab
 from lms.lib.utils import get_parent_unit

--- a/lms/djangoapps/edxnotes/plugins.py
+++ b/lms/djangoapps/edxnotes/plugins.py
@@ -6,7 +6,7 @@ from __future__ import absolute_import
 from django.conf import settings
 from django.utils.translation import ugettext_noop
 
-from courseware.tabs import EnrolledTab
+from lms.djangoapps.courseware.tabs import EnrolledTab
 
 
 class EdxNotesTab(EnrolledTab):

--- a/lms/djangoapps/edxnotes/tests.py
+++ b/lms/djangoapps/edxnotes/tests.py
@@ -21,9 +21,9 @@ from django.urls import reverse
 from mock import MagicMock, patch
 from oauth2_provider.models import Application
 
-from courseware.model_data import FieldDataCache
-from courseware.module_render import get_module_for_descriptor
-from courseware.tabs import get_course_tab_list
+from lms.djangoapps.courseware.model_data import FieldDataCache
+from lms.djangoapps.courseware.module_render import get_module_for_descriptor
+from lms.djangoapps.courseware.tabs import get_course_tab_list
 from edxmako.shortcuts import render_to_string
 from edxnotes import helpers
 from edxnotes.decorators import edxnotes

--- a/lms/djangoapps/edxnotes/views.py
+++ b/lms/djangoapps/edxnotes/views.py
@@ -18,9 +18,9 @@ from rest_framework.response import Response
 from rest_framework.views import APIView
 from six import text_type
 
-from courseware.courses import get_course_with_access
-from courseware.model_data import FieldDataCache
-from courseware.module_render import get_module_for_descriptor
+from lms.djangoapps.courseware.courses import get_course_with_access
+from lms.djangoapps.courseware.model_data import FieldDataCache
+from lms.djangoapps.courseware.module_render import get_module_for_descriptor
 from edxmako.shortcuts import render_to_response
 from edxnotes.exceptions import EdxNotesParseError, EdxNotesServiceUnavailable
 from edxnotes.helpers import (

--- a/lms/djangoapps/experiments/utils.py
+++ b/lms/djangoapps/experiments/utils.py
@@ -15,8 +15,8 @@ from opaque_keys import InvalidKeyError
 from opaque_keys.edx.keys import CourseKey
 
 from course_modes.models import format_course_price, get_cosmetic_verified_display_price
-from courseware.access import has_staff_access_to_preview_mode
-from courseware.date_summary import verified_upgrade_deadline_link, verified_upgrade_link_is_valid
+from lms.djangoapps.courseware.access import has_staff_access_to_preview_mode
+from lms.djangoapps.courseware.date_summary import verified_upgrade_deadline_link, verified_upgrade_link_is_valid
 from lms.djangoapps.commerce.utils import EcommerceService
 from openedx.core.djangoapps.catalog.utils import get_programs
 from openedx.core.djangoapps.django_comment_common.models import Role

--- a/lms/djangoapps/gating/tests/test_api.py
+++ b/lms/djangoapps/gating/tests/test_api.py
@@ -8,7 +8,7 @@ from milestones import api as milestones_api
 from milestones.tests.utils import MilestonesTestCaseMixin
 from mock import Mock, patch
 
-from courseware.tests.helpers import LoginEnrollmentTestCase
+from lms.djangoapps.courseware.tests.helpers import LoginEnrollmentTestCase
 from gating.api import evaluate_prerequisite
 from openedx.core.lib.gating import api as gating_api
 from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase

--- a/lms/djangoapps/grades/management/commands/recalculate_subsection_grades.py
+++ b/lms/djangoapps/grades/management/commands/recalculate_subsection_grades.py
@@ -13,7 +13,7 @@ from django.core.management.base import BaseCommand, CommandError
 from pytz import utc
 from submissions.models import Submission
 
-from courseware.models import StudentModule
+from lms.djangoapps.courseware.models import StudentModule
 from lms.djangoapps.grades.constants import ScoreDatabaseTableEnum
 from lms.djangoapps.grades.events import PROBLEM_SUBMITTED_EVENT_TYPE
 from lms.djangoapps.grades.tasks import recalculate_subsection_grade_v3

--- a/lms/djangoapps/grades/migrations/0001_initial.py
+++ b/lms/djangoapps/grades/migrations/0001_initial.py
@@ -2,7 +2,7 @@
 from __future__ import unicode_literals
 
 from django.db import migrations, models
-import coursewarehistoryextended.fields
+import lms.djangoapps.coursewarehistoryextended.fields
 import django.utils.timezone
 import model_utils.fields
 from opaque_keys.edx.django.models import CourseKeyField, UsageKeyField

--- a/lms/djangoapps/grades/migrations/0006_persistent_course_grades.py
+++ b/lms/djangoapps/grades/migrations/0006_persistent_course_grades.py
@@ -5,7 +5,7 @@ from django.db import migrations, models
 import django.utils.timezone
 import model_utils.fields
 from opaque_keys.edx.django.models import CourseKeyField
-import coursewarehistoryextended.fields
+import lms.djangoapps.coursewarehistoryextended.fields
 
 
 class Migration(migrations.Migration):

--- a/lms/djangoapps/grades/migrations/0013_persistentsubsectiongradeoverride.py
+++ b/lms/djangoapps/grades/migrations/0013_persistentsubsectiongradeoverride.py
@@ -3,7 +3,7 @@ from __future__ import unicode_literals
 
 from django.db import migrations, models
 
-from coursewarehistoryextended.fields import UnsignedBigIntOneToOneField
+from lms.djangoapps.coursewarehistoryextended.fields import UnsignedBigIntOneToOneField
 
 
 class Migration(migrations.Migration):

--- a/lms/djangoapps/grades/models.py
+++ b/lms/djangoapps/grades/models.py
@@ -22,7 +22,7 @@ from model_utils.models import TimeStampedModel
 from opaque_keys.edx.django.models import CourseKeyField, UsageKeyField
 from opaque_keys.edx.keys import CourseKey, UsageKey
 
-from coursewarehistoryextended.fields import UnsignedBigIntAutoField, UnsignedBigIntOneToOneField
+from lms.djangoapps.coursewarehistoryextended.fields import UnsignedBigIntAutoField, UnsignedBigIntOneToOneField
 from lms.djangoapps.grades import events, constants
 from openedx.core.lib.cache_utils import get_cache
 

--- a/lms/djangoapps/grades/rest_api/v1/gradebook_views.py
+++ b/lms/djangoapps/grades/rest_api/v1/gradebook_views.py
@@ -18,7 +18,7 @@ from rest_framework.response import Response
 from rest_framework.views import APIView
 from six import text_type
 
-from courseware.courses import get_course_by_id
+from lms.djangoapps.courseware.courses import get_course_by_id
 from lms.djangoapps.grades.api import CourseGradeFactory, clear_prefetched_course_and_subsection_grades
 from lms.djangoapps.grades.api import constants as grades_constants
 from lms.djangoapps.grades.api import context as grades_context

--- a/lms/djangoapps/grades/signals/handlers.py
+++ b/lms/djangoapps/grades/signals/handlers.py
@@ -11,7 +11,7 @@ from django.dispatch import receiver
 from submissions.models import score_reset, score_set
 from xblock.scorable import ScorableXBlockMixin, Score
 
-from courseware.model_data import get_score, set_score
+from lms.djangoapps.courseware.model_data import get_score, set_score
 from openedx.core.djangoapps.course_groups.signals.signals import COHORT_MEMBERSHIP_UPDATED
 from openedx.core.lib.grade_utils import is_score_higher_or_equal
 from student.models import user_by_anonymous_id

--- a/lms/djangoapps/grades/subsection_grade_factory.py
+++ b/lms/djangoapps/grades/subsection_grade_factory.py
@@ -3,7 +3,7 @@ from logging import getLogger
 
 from lazy import lazy
 
-from courseware.model_data import ScoresClient
+from lms.djangoapps.courseware.model_data import ScoresClient
 from lms.djangoapps.grades.config import assume_zero_if_absent, should_persist_grades
 from lms.djangoapps.grades.models import PersistentSubsectionGrade
 from lms.djangoapps.grades.scores import possibly_scored

--- a/lms/djangoapps/grades/tasks.py
+++ b/lms/djangoapps/grades/tasks.py
@@ -16,7 +16,7 @@ from opaque_keys.edx.keys import CourseKey, UsageKey
 from opaque_keys.edx.locator import CourseLocator
 from submissions import api as sub_api
 
-from courseware.model_data import get_score
+from lms.djangoapps.courseware.model_data import get_score
 from lms.djangoapps.course_blocks.api import get_course_blocks
 from lms.djangoapps.grades.config.models import ComputeGradesSetting
 from openedx.core.djangoapps.content.course_overviews.models import CourseOverview

--- a/lms/djangoapps/grades/tests/integration/test_access.py
+++ b/lms/djangoapps/grades/tests/integration/test_access.py
@@ -6,7 +6,7 @@ from __future__ import absolute_import
 from crum import set_current_request
 
 from capa.tests.response_xml_factory import MultipleChoiceResponseXMLFactory
-from courseware.tests.test_submitting_problems import ProblemSubmissionTestMixin
+from lms.djangoapps.courseware.tests.test_submitting_problems import ProblemSubmissionTestMixin
 from lms.djangoapps.course_blocks.api import get_course_blocks
 from openedx.core.djangolib.testing.utils import get_mock_request
 from student.models import CourseEnrollment

--- a/lms/djangoapps/grades/tests/integration/test_events.py
+++ b/lms/djangoapps/grades/tests/integration/test_events.py
@@ -10,7 +10,7 @@ from mock import call as mock_call
 from mock import patch
 
 from capa.tests.response_xml_factory import MultipleChoiceResponseXMLFactory
-from courseware.tests.test_submitting_problems import ProblemSubmissionTestMixin
+from lms.djangoapps.courseware.tests.test_submitting_problems import ProblemSubmissionTestMixin
 from lms.djangoapps.instructor.enrollment import reset_student_attempts
 from lms.djangoapps.instructor_task.api import submit_rescore_problem_for_student
 from openedx.core.djangolib.testing.utils import get_mock_request

--- a/lms/djangoapps/grades/tests/integration/test_problems.py
+++ b/lms/djangoapps/grades/tests/integration/test_problems.py
@@ -10,7 +10,7 @@ from crum import set_current_request
 from six.moves import range
 
 from capa.tests.response_xml_factory import MultipleChoiceResponseXMLFactory
-from courseware.tests.test_submitting_problems import ProblemSubmissionTestMixin
+from lms.djangoapps.courseware.tests.test_submitting_problems import ProblemSubmissionTestMixin
 from lms.djangoapps.course_blocks.api import get_course_blocks
 from openedx.core.djangolib.testing.utils import get_mock_request
 from student.models import CourseEnrollment

--- a/lms/djangoapps/grades/tests/test_course_grade_factory.py
+++ b/lms/djangoapps/grades/tests/test_course_grade_factory.py
@@ -10,7 +10,7 @@ from django.conf import settings
 from mock import patch
 from six import text_type
 
-from courseware.access import has_access
+from lms.djangoapps.courseware.access import has_access
 from lms.djangoapps.grades.config.tests.utils import persistent_grades_feature_flags
 from openedx.core.djangoapps.content.block_structure.factory import BlockStructureFactory
 from student.tests.factories import UserFactory

--- a/lms/djangoapps/grades/tests/test_scores.py
+++ b/lms/djangoapps/grades/tests/test_scores.py
@@ -102,7 +102,7 @@ class TestGetScore(TestCase):
 
     def _create_csm_scores(self, csm_value):
         """
-        Creates a stub result from courseware student module for the given values.
+        Creates a stub result from lms.djangoapps.courseware student module for the given values.
         """
         if csm_value.exists:
             stub_csm_record = namedtuple('stub_csm_record', 'correct, total, created')

--- a/lms/djangoapps/grades/tests/test_subsection_grade_factory.py
+++ b/lms/djangoapps/grades/tests/test_subsection_grade_factory.py
@@ -7,7 +7,7 @@ import ddt
 from django.conf import settings
 from mock import patch
 
-from courseware.tests.test_submitting_problems import ProblemSubmissionTestMixin
+from lms.djangoapps.courseware.tests.test_submitting_problems import ProblemSubmissionTestMixin
 from lms.djangoapps.grades.config.tests.utils import persistent_grades_feature_flags
 from student.tests.factories import UserFactory
 

--- a/lms/djangoapps/grades/tests/utils.py
+++ b/lms/djangoapps/grades/tests/utils.py
@@ -9,8 +9,8 @@ from datetime import datetime
 import pytz
 from mock import MagicMock, patch
 
-from courseware.model_data import FieldDataCache
-from courseware.module_render import get_module
+from lms.djangoapps.courseware.model_data import FieldDataCache
+from lms.djangoapps.courseware.module_render import get_module
 from xmodule.graders import ProblemScore
 
 

--- a/lms/djangoapps/instructor/enrollment.py
+++ b/lms/djangoapps/instructor/enrollment.py
@@ -20,7 +20,7 @@ from edx_ace.recipient import Recipient
 from six import text_type
 
 from course_modes.models import CourseMode
-from courseware.models import StudentModule
+from lms.djangoapps.courseware.models import StudentModule
 from eventtracking import tracker
 from lms.djangoapps.grades.api import (
     constants as grades_constants,

--- a/lms/djangoapps/instructor/paidcourse_enrollment_report.py
+++ b/lms/djangoapps/instructor/paidcourse_enrollment_report.py
@@ -7,8 +7,8 @@ import collections
 from django.conf import settings
 from django.utils.translation import ugettext as _
 
-from courseware.access import has_access
-from courseware.courses import get_course_by_id
+from lms.djangoapps.courseware.access import has_access
+from lms.djangoapps.courseware.courses import get_course_by_id
 from lms.djangoapps.instructor.enrollment_report import BaseAbstractEnrollmentReportProvider
 from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
 from shoppingcart.models import (

--- a/lms/djangoapps/instructor/services.py
+++ b/lms/djangoapps/instructor/services.py
@@ -10,7 +10,7 @@ from opaque_keys import InvalidKeyError
 from opaque_keys.edx.keys import CourseKey, UsageKey
 
 import lms.djangoapps.instructor.enrollment as enrollment
-from courseware.models import StudentModule
+from lms.djangoapps.courseware.models import StudentModule
 from lms.djangoapps.commerce.utils import create_zendesk_ticket
 from lms.djangoapps.instructor.views.tools import get_student_from_identifier
 from student import auth

--- a/lms/djangoapps/instructor/tests/test_api.py
+++ b/lms/djangoapps/instructor/tests/test_api.py
@@ -34,15 +34,15 @@ from six.moves import range, zip
 from bulk_email.models import BulkEmailFlag, CourseEmail, CourseEmailTemplate
 from course_modes.models import CourseMode
 from course_modes.tests.factories import CourseModeFactory
-from courseware.models import StudentModule
-from courseware.tests.factories import (
+from lms.djangoapps.courseware.models import StudentModule
+from lms.djangoapps.courseware.tests.factories import (
     BetaTesterFactory,
     GlobalStaffFactory,
     InstructorFactory,
     StaffFactory,
     UserProfileFactory
 )
-from courseware.tests.helpers import LoginEnrollmentTestCase
+from lms.djangoapps.courseware.tests.helpers import LoginEnrollmentTestCase
 from edx_when.api import get_overrides_for_user
 from edx_when.signals import extract_dates
 from lms.djangoapps.certificates.models import CertificateStatuses

--- a/lms/djangoapps/instructor/tests/test_api_email_localization.py
+++ b/lms/djangoapps/instructor/tests/test_api_email_localization.py
@@ -10,7 +10,7 @@ from django.test.utils import override_settings
 from django.urls import reverse
 from six import text_type
 
-from courseware.tests.factories import InstructorFactory
+from lms.djangoapps.courseware.tests.factories import InstructorFactory
 from openedx.core.djangoapps.lang_pref import LANGUAGE_KEY
 from openedx.core.djangoapps.user_api.preferences.api import delete_user_preference, set_user_preference
 from student.models import CourseEnrollment

--- a/lms/djangoapps/instructor/tests/test_certificates.py
+++ b/lms/djangoapps/instructor/tests/test_certificates.py
@@ -19,7 +19,7 @@ from django.urls import reverse
 
 from capa.xqueue_interface import XQueueInterface
 from course_modes.models import CourseMode
-from courseware.tests.factories import GlobalStaffFactory, InstructorFactory, UserFactory
+from lms.djangoapps.courseware.tests.factories import GlobalStaffFactory, InstructorFactory, UserFactory
 from lms.djangoapps.certificates import api as certs_api
 from lms.djangoapps.certificates.models import (
     CertificateGenerationConfiguration,

--- a/lms/djangoapps/instructor/tests/test_enrollment.py
+++ b/lms/djangoapps/instructor/tests/test_enrollment.py
@@ -20,7 +20,7 @@ from six import text_type
 from submissions import api as sub_api
 
 from capa.tests.response_xml_factory import MultipleChoiceResponseXMLFactory
-from courseware.models import StudentModule
+from lms.djangoapps.courseware.models import StudentModule
 from grades.subsection_grade_factory import SubsectionGradeFactory
 from grades.tests.utils import answer_problem
 from lms.djangoapps.ccx.tests.factories import CcxFactory

--- a/lms/djangoapps/instructor/tests/test_registration_codes.py
+++ b/lms/djangoapps/instructor/tests/test_registration_codes.py
@@ -14,7 +14,7 @@ from six.moves import range
 
 from course_modes.models import CourseMode
 from course_modes.tests.factories import CourseModeFactory
-from courseware.tests.factories import InstructorFactory
+from lms.djangoapps.courseware.tests.factories import InstructorFactory
 from shoppingcart.models import (
     CourseRegCodeItem,
     CourseRegistrationCode,

--- a/lms/djangoapps/instructor/tests/test_services.py
+++ b/lms/djangoapps/instructor/tests/test_services.py
@@ -9,7 +9,7 @@ import json
 import mock
 import six
 
-from courseware.models import StudentModule
+from lms.djangoapps.courseware.models import StudentModule
 from lms.djangoapps.instructor.access import allow_access
 from lms.djangoapps.instructor.services import InstructorService
 from lms.djangoapps.instructor.tests.test_tools import msk_from_problem_urlname

--- a/lms/djangoapps/instructor/tests/test_spoc_gradebook.py
+++ b/lms/djangoapps/instructor/tests/test_spoc_gradebook.py
@@ -9,7 +9,7 @@ from six import text_type
 from six.moves import range
 
 from capa.tests.response_xml_factory import StringResponseXMLFactory
-from courseware.tests.factories import StudentModuleFactory
+from lms.djangoapps.courseware.tests.factories import StudentModuleFactory
 from lms.djangoapps.grades.api import task_compute_all_grades_for_course
 from student.tests.factories import AdminFactory, CourseEnrollmentFactory, UserFactory
 from xmodule.modulestore.tests.django_utils import SharedModuleStoreTestCase

--- a/lms/djangoapps/instructor/tests/views/test_instructor_dashboard.py
+++ b/lms/djangoapps/instructor/tests/views/test_instructor_dashboard.py
@@ -20,9 +20,9 @@ from six.moves import range
 
 from common.test.utils import XssTestMixin
 from course_modes.models import CourseMode
-from courseware.tabs import get_course_tab_list
-from courseware.tests.factories import StaffFactory, StudentModuleFactory, UserFactory
-from courseware.tests.helpers import LoginEnrollmentTestCase
+from lms.djangoapps.courseware.tabs import get_course_tab_list
+from lms.djangoapps.courseware.tests.factories import StaffFactory, StudentModuleFactory, UserFactory
+from lms.djangoapps.courseware.tests.helpers import LoginEnrollmentTestCase
 from edxmako.shortcuts import render_to_response
 from lms.djangoapps.grades.config.waffle import WRITABLE_GRADEBOOK, waffle_flags
 from lms.djangoapps.instructor.views.gradebook_api import calculate_page_info

--- a/lms/djangoapps/instructor/utils.py
+++ b/lms/djangoapps/instructor/utils.py
@@ -2,8 +2,8 @@
 Helpers for instructor app.
 """
 
-from courseware.model_data import FieldDataCache
-from courseware.module_render import get_module
+from lms.djangoapps.courseware.model_data import FieldDataCache
+from lms.djangoapps.courseware.module_render import get_module
 from xmodule.modulestore.django import modulestore
 
 

--- a/lms/djangoapps/instructor/views/api.py
+++ b/lms/djangoapps/instructor/views/api.py
@@ -46,9 +46,9 @@ import instructor_analytics.csvs
 import instructor_analytics.distributions
 from bulk_email.api import is_bulk_email_feature_enabled
 from bulk_email.models import CourseEmail
-from courseware.access import has_access
-from courseware.courses import get_course_by_id, get_course_with_access
-from courseware.models import StudentModule
+from lms.djangoapps.courseware.access import has_access
+from lms.djangoapps.courseware.courses import get_course_by_id, get_course_with_access
+from lms.djangoapps.courseware.models import StudentModule
 from lms.djangoapps.discussion.django_comment_client.utils import (
     get_course_discussion_settings,
     get_group_id_for_user,

--- a/lms/djangoapps/instructor/views/gradebook_api.py
+++ b/lms/djangoapps/instructor/views/gradebook_api.py
@@ -10,7 +10,7 @@ from django.urls import reverse
 from django.views.decorators.cache import cache_control
 from opaque_keys.edx.keys import CourseKey
 
-from courseware.courses import get_course_with_access
+from lms.djangoapps.courseware.courses import get_course_with_access
 from edxmako.shortcuts import render_to_response
 from lms.djangoapps.grades.api import CourseGradeFactory
 from lms.djangoapps.instructor.views.api import require_level

--- a/lms/djangoapps/instructor/views/instructor_dashboard.py
+++ b/lms/djangoapps/instructor/views/instructor_dashboard.py
@@ -28,8 +28,8 @@ from xblock.fields import ScopeIds
 from bulk_email.api import is_bulk_email_feature_enabled
 from class_dashboard.dashboard_data import get_array_section_has_problem, get_section_display_name
 from course_modes.models import CourseMode, CourseModesArchive
-from courseware.access import has_access
-from courseware.courses import get_course_by_id, get_studio_url
+from lms.djangoapps.courseware.access import has_access
+from lms.djangoapps.courseware.courses import get_course_by_id, get_studio_url
 from lms.djangoapps.discussion.django_comment_client.utils import available_division_schemes, has_forum_access
 from edxmako.shortcuts import render_to_response
 from edx_when.api import is_enabled_for_course

--- a/lms/djangoapps/instructor/views/registration_codes.py
+++ b/lms/djangoapps/instructor/views/registration_codes.py
@@ -9,7 +9,7 @@ from django.views.decorators.cache import cache_control
 from django.views.decorators.http import require_GET, require_POST
 from opaque_keys.edx.locator import CourseKey
 
-from courseware.courses import get_course_by_id
+from lms.djangoapps.courseware.courses import get_course_by_id
 from lms.djangoapps.instructor.enrollment import get_email_params, send_mail_to_student
 from lms.djangoapps.instructor.views.api import require_level
 from shoppingcart.models import CourseRegistrationCode, RegistrationCodeRedemption

--- a/lms/djangoapps/instructor_analytics/basic.py
+++ b/lms/djangoapps/instructor_analytics/basic.py
@@ -20,7 +20,7 @@ from opaque_keys.edx.keys import UsageKey, CourseKey
 from six import text_type
 
 import xmodule.graders as xmgraders
-from courseware.models import StudentModule
+from lms.djangoapps.courseware.models import StudentModule
 from lms.djangoapps.certificates.models import CertificateStatuses, GeneratedCertificate
 from lms.djangoapps.grades.api import context as grades_context
 from lms.djangoapps.verify_student.services import IDVerificationService

--- a/lms/djangoapps/instructor_analytics/tests/test_basic.py
+++ b/lms/djangoapps/instructor_analytics/tests/test_basic.py
@@ -19,7 +19,7 @@ from six.moves import range, zip
 
 from course_modes.models import CourseMode
 from course_modes.tests.factories import CourseModeFactory
-from courseware.tests.factories import InstructorFactory
+from lms.djangoapps.courseware.tests.factories import InstructorFactory
 from instructor_analytics.basic import (
     AVAILABLE_FEATURES,
     PROFILE_FEATURES,

--- a/lms/djangoapps/instructor_task/api_helper.py
+++ b/lms/djangoapps/instructor_task/api_helper.py
@@ -14,8 +14,8 @@ from django.utils.translation import ugettext as _
 from opaque_keys.edx.keys import UsageKey
 from six import text_type
 
-from courseware.courses import get_problems_in_section
-from courseware.module_render import get_xqueue_callback_url_prefix
+from lms.djangoapps.courseware.courses import get_problems_in_section
+from lms.djangoapps.courseware.module_render import get_xqueue_callback_url_prefix
 from lms.djangoapps.instructor_task.models import PROGRESS, InstructorTask
 from util.db import outer_atomic
 from xmodule.modulestore.django import modulestore

--- a/lms/djangoapps/instructor_task/tasks_helper/enrollments.py
+++ b/lms/djangoapps/instructor_task/tasks_helper/enrollments.py
@@ -12,7 +12,7 @@ from django.conf import settings
 from django.utils.translation import ugettext as _
 from pytz import UTC
 
-from courseware.courses import get_course_by_id
+from lms.djangoapps.courseware.courses import get_course_by_id
 from edxmako.shortcuts import render_to_string
 from instructor_analytics.basic import enrolled_students_features, list_may_enroll
 from instructor_analytics.csvs import format_dictlist

--- a/lms/djangoapps/instructor_task/tasks_helper/grades.py
+++ b/lms/djangoapps/instructor_task/tasks_helper/grades.py
@@ -20,8 +20,8 @@ from six import text_type
 from six.moves import zip, zip_longest
 
 from course_blocks.api import get_course_blocks
-from courseware.courses import get_course_by_id
-from courseware.user_state_client import DjangoXBlockUserStateClient
+from lms.djangoapps.courseware.courses import get_course_by_id
+from lms.djangoapps.courseware.user_state_client import DjangoXBlockUserStateClient
 from instructor_analytics.basic import list_problem_responses
 from instructor_analytics.csvs import format_dictlist
 from lms.djangoapps.certificates.models import CertificateWhitelist, GeneratedCertificate, certificate_info_for_user

--- a/lms/djangoapps/instructor_task/tasks_helper/module_state.py
+++ b/lms/djangoapps/instructor_task/tasks_helper/module_state.py
@@ -14,10 +14,10 @@ from xblock.runtime import KvsFieldData
 from xblock.scorable import Score
 
 from capa.responsetypes import LoncapaProblemError, ResponseError, StudentInputError
-from courseware.courses import get_course_by_id, get_problems_in_section
-from courseware.model_data import DjangoKeyValueStore, FieldDataCache
-from courseware.models import StudentModule
-from courseware.module_render import get_module_for_descriptor_internal
+from lms.djangoapps.courseware.courses import get_course_by_id, get_problems_in_section
+from lms.djangoapps.courseware.model_data import DjangoKeyValueStore, FieldDataCache
+from lms.djangoapps.courseware.models import StudentModule
+from lms.djangoapps.courseware.module_render import get_module_for_descriptor_internal
 from lms.djangoapps.grades.api import events as grades_events
 from student.models import get_user_by_username_or_email
 from track.event_transaction_utils import create_new_event_transaction_id, set_event_transaction_type

--- a/lms/djangoapps/instructor_task/tests/test_api.py
+++ b/lms/djangoapps/instructor_task/tests/test_api.py
@@ -10,7 +10,7 @@ from six.moves import range
 
 from bulk_email.models import SEND_TO_LEARNERS, SEND_TO_MYSELF, SEND_TO_STAFF, CourseEmail
 from common.test.utils import normalize_repr
-from courseware.tests.factories import UserFactory
+from lms.djangoapps.courseware.tests.factories import UserFactory
 from lms.djangoapps.certificates.models import CertificateGenerationHistory, CertificateStatuses
 from lms.djangoapps.instructor_task.api import (
     SpecificStudentIdMissingError,

--- a/lms/djangoapps/instructor_task/tests/test_base.py
+++ b/lms/djangoapps/instructor_task/tests/test_base.py
@@ -21,8 +21,8 @@ from opaque_keys.edx.locations import Location
 from six import text_type
 
 from capa.tests.response_xml_factory import OptionResponseXMLFactory
-from courseware.model_data import StudentModule
-from courseware.tests.tests import LoginEnrollmentTestCase
+from lms.djangoapps.courseware.model_data import StudentModule
+from lms.djangoapps.courseware.tests.tests import LoginEnrollmentTestCase
 from lms.djangoapps.instructor_task.api_helper import encode_problem_and_student_input
 from lms.djangoapps.instructor_task.models import PROGRESS, QUEUING, ReportStore
 from lms.djangoapps.instructor_task.tests.factories import InstructorTaskFactory

--- a/lms/djangoapps/instructor_task/tests/test_integration.py
+++ b/lms/djangoapps/instructor_task/tests/test_integration.py
@@ -23,7 +23,7 @@ from six.moves import range
 
 from capa.responsetypes import StudentInputError
 from capa.tests.response_xml_factory import CodeResponseXMLFactory, CustomResponseXMLFactory
-from courseware.model_data import StudentModule
+from lms.djangoapps.courseware.model_data import StudentModule
 from lms.djangoapps.grades.api import CourseGradeFactory
 from lms.djangoapps.instructor_task.api import (
     submit_delete_problem_state_for_all_students,

--- a/lms/djangoapps/instructor_task/tests/test_tasks.py
+++ b/lms/djangoapps/instructor_task/tests/test_tasks.py
@@ -19,8 +19,8 @@ from opaque_keys.edx.locations import i4xEncoder
 from six.moves import range
 
 from course_modes.models import CourseMode
-from courseware.models import StudentModule
-from courseware.tests.factories import StudentModuleFactory
+from lms.djangoapps.courseware.models import StudentModule
+from lms.djangoapps.courseware.tests.factories import StudentModuleFactory
 from lms.djangoapps.instructor_task.exceptions import UpdateProblemModuleStateError
 from lms.djangoapps.instructor_task.models import InstructorTask
 from lms.djangoapps.instructor_task.tasks import (

--- a/lms/djangoapps/instructor_task/tests/test_tasks_helper.py
+++ b/lms/djangoapps/instructor_task/tests/test_tasks_helper.py
@@ -32,7 +32,7 @@ import openedx.core.djangoapps.user_api.course_tag.api as course_tag_api
 from capa.tests.response_xml_factory import MultipleChoiceResponseXMLFactory
 from course_modes.models import CourseMode
 from course_modes.tests.factories import CourseModeFactory
-from courseware.tests.factories import InstructorFactory
+from lms.djangoapps.courseware.tests.factories import InstructorFactory
 from instructor_analytics.basic import UNAVAILABLE, list_problem_responses
 from lms.djangoapps.certificates.models import CertificateStatuses, GeneratedCertificate
 from lms.djangoapps.certificates.tests.factories import CertificateWhitelistFactory, GeneratedCertificateFactory

--- a/lms/djangoapps/lti_provider/tests/test_views.py
+++ b/lms/djangoapps/lti_provider/tests/test_views.py
@@ -11,7 +11,7 @@ from django.urls import reverse
 from mock import MagicMock, patch
 from opaque_keys.edx.locator import BlockUsageLocator, CourseLocator
 
-from courseware.testutils import RenderXBlockTestMixin
+from lms.djangoapps.courseware.testutils import RenderXBlockTestMixin
 from lti_provider import models, views
 from student.tests.factories import UserFactory
 from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase

--- a/lms/djangoapps/lti_provider/views.py
+++ b/lms/djangoapps/lti_provider/views.py
@@ -143,7 +143,7 @@ def render_courseware(request, usage_key):
     context to render the courseware.
     """
     # return an HttpResponse object that contains the template and necessary context to render the courseware.
-    from courseware.views.views import render_xblock
+    from lms.djangoapps.courseware.views.views import render_xblock
     return render_xblock(request, unicode(usage_key), check_if_enrolled=False)
 
 

--- a/lms/djangoapps/mobile_api/course_info/views.py
+++ b/lms/djangoapps/mobile_api/course_info/views.py
@@ -5,7 +5,7 @@ Views for course info API
 from rest_framework import generics
 from rest_framework.response import Response
 
-from courseware.courses import get_course_info_section_module
+from lms.djangoapps.courseware.courses import get_course_info_section_module
 from openedx.core.lib.xblock_utils import get_course_update_items
 from static_replace import make_static_urls_absolute
 

--- a/lms/djangoapps/mobile_api/tests/test_milestones.py
+++ b/lms/djangoapps/mobile_api/tests/test_milestones.py
@@ -8,8 +8,8 @@ from crum import set_current_request
 from django.conf import settings
 from mock import patch
 
-from courseware.access_response import MilestoneAccessError
-from courseware.tests.test_entrance_exam import add_entrance_exam_milestone, answer_entrance_exam_problem
+from lms.djangoapps.courseware.access_response import MilestoneAccessError
+from lms.djangoapps.courseware.tests.test_entrance_exam import add_entrance_exam_milestone, answer_entrance_exam_problem
 from openedx.core.djangolib.testing.utils import get_mock_request
 from util.milestones_helpers import add_prerequisite_course, fulfill_course_milestone
 from xmodule.modulestore.tests.factories import CourseFactory, ItemFactory

--- a/lms/djangoapps/mobile_api/testutils.py
+++ b/lms/djangoapps/mobile_api/testutils.py
@@ -21,8 +21,8 @@ from opaque_keys.edx.keys import CourseKey
 import pytz
 from rest_framework.test import APITestCase
 
-from courseware.access_response import MobileAvailabilityError, StartDateError, VisibilityError
-from courseware.tests.factories import UserFactory
+from lms.djangoapps.courseware.access_response import MobileAvailabilityError, StartDateError, VisibilityError
+from lms.djangoapps.courseware.tests.factories import UserFactory
 from mobile_api.models import IgnoreMobileAvailableFlagConfig
 from mobile_api.tests.test_milestones import MobileAPIMilestonesMixin
 from mobile_api.utils import API_V1

--- a/lms/djangoapps/mobile_api/users/serializers.py
+++ b/lms/djangoapps/mobile_api/users/serializers.py
@@ -6,7 +6,7 @@ from rest_framework import serializers
 from rest_framework.reverse import reverse
 
 from lms.djangoapps.certificates.api import certificate_downloadable_status
-from courseware.access import has_access
+from lms.djangoapps.courseware.access import has_access
 from openedx.features.course_duration_limits.access import get_user_course_expiration_date
 from openedx.features.course_duration_limits.models import CourseDurationLimitConfig
 from student.models import CourseEnrollment, User

--- a/lms/djangoapps/mobile_api/users/tests.py
+++ b/lms/djangoapps/mobile_api/users/tests.py
@@ -18,7 +18,7 @@ from lms.djangoapps.certificates.models import CertificateStatuses
 from lms.djangoapps.certificates.tests.factories import GeneratedCertificateFactory
 from lms.djangoapps.grades.tests.utils import mock_passing_grade
 from course_modes.models import CourseMode
-from courseware.access_response import MilestoneAccessError, StartDateError, VisibilityError
+from lms.djangoapps.courseware.access_response import MilestoneAccessError, StartDateError, VisibilityError
 from mobile_api.testutils import (
     MobileAPITestCase,
     MobileAuthTestMixin,

--- a/lms/djangoapps/mobile_api/users/views.py
+++ b/lms/djangoapps/mobile_api/users/views.py
@@ -13,11 +13,11 @@ from rest_framework.response import Response
 from xblock.fields import Scope
 from xblock.runtime import KeyValueStore
 
-from courseware.access import is_mobile_available_for_user
-from courseware.courses import get_current_child
-from courseware.model_data import FieldDataCache
-from courseware.module_render import get_module_for_descriptor
-from courseware.views.index import save_positions_recursively_up
+from lms.djangoapps.courseware.access import is_mobile_available_for_user
+from lms.djangoapps.courseware.courses import get_current_child
+from lms.djangoapps.courseware.model_data import FieldDataCache
+from lms.djangoapps.courseware.module_render import get_module_for_descriptor
+from lms.djangoapps.courseware.views.index import save_positions_recursively_up
 from lms.djangoapps.courseware.access_utils import ACCESS_GRANTED
 from mobile_api.utils import API_V05
 from openedx.features.course_duration_limits.access import check_course_expired

--- a/lms/djangoapps/notes/api.py
+++ b/lms/djangoapps/notes/api.py
@@ -10,7 +10,7 @@ from django.core.exceptions import ValidationError
 from django.http import Http404, HttpResponse
 from opaque_keys.edx.keys import CourseKey
 
-from courseware.courses import get_course_with_access
+from lms.djangoapps.courseware.courses import get_course_with_access
 from notes.models import Note
 from notes.utils import notes_enabled_for_course
 

--- a/lms/djangoapps/notes/tests.py
+++ b/lms/djangoapps/notes/tests.py
@@ -17,7 +17,7 @@ from opaque_keys.edx.locator import CourseLocator
 from six import text_type
 from six.moves import range
 
-from courseware.tabs import CourseTab, get_course_tab_list
+from lms.djangoapps.courseware.tabs import CourseTab, get_course_tab_list
 from notes import api, models, utils
 from student.tests.factories import CourseEnrollmentFactory, UserFactory
 from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase

--- a/lms/djangoapps/notes/views.py
+++ b/lms/djangoapps/notes/views.py
@@ -10,8 +10,8 @@ from django.http import Http404
 from django.utils.translation import ugettext_noop
 from opaque_keys.edx.keys import CourseKey
 
-from courseware.courses import get_course_with_access
-from courseware.tabs import EnrolledTab
+from lms.djangoapps.courseware.courses import get_course_with_access
+from lms.djangoapps.courseware.tabs import EnrolledTab
 from edxmako.shortcuts import render_to_response
 from notes.models import Note
 from notes.utils import notes_enabled_for_course

--- a/lms/djangoapps/oauth2_handler/handlers.py
+++ b/lms/djangoapps/oauth2_handler/handlers.py
@@ -6,7 +6,7 @@ import six
 from django.conf import settings
 from django.core.cache import cache
 
-from courseware.access import has_access
+from lms.djangoapps.courseware.access import has_access
 from openedx.core.djangoapps.content.course_overviews.models import CourseOverview
 from openedx.core.djangoapps.lang_pref import LANGUAGE_KEY
 from openedx.core.djangoapps.user_api.models import UserPreference

--- a/lms/djangoapps/shoppingcart/models.py
+++ b/lms/djangoapps/shoppingcart/models.py
@@ -32,7 +32,7 @@ from opaque_keys.edx.django.models import CourseKeyField
 from six import text_type
 
 from course_modes.models import CourseMode
-from courseware.courses import get_course_by_id
+from lms.djangoapps.courseware.courses import get_course_by_id
 from edxmako.shortcuts import render_to_string
 from eventtracking import tracker
 from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers

--- a/lms/djangoapps/shoppingcart/reports.py
+++ b/lms/djangoapps/shoppingcart/reports.py
@@ -7,7 +7,7 @@ from django.utils.translation import ugettext as _
 from six import text_type
 
 from course_modes.models import CourseMode
-from courseware.courses import get_course_by_id
+from lms.djangoapps.courseware.courses import get_course_by_id
 from shoppingcart.models import CertificateItem, OrderItem
 from student.models import CourseEnrollment
 from util.query import use_read_replica_if_available

--- a/lms/djangoapps/shoppingcart/tests/test_views.py
+++ b/lms/djangoapps/shoppingcart/tests/test_views.py
@@ -31,7 +31,7 @@ from six.moves.urllib.parse import urlparse  # pylint: disable=import-error
 from common.test.utils import XssTestMixin
 from course_modes.models import CourseMode
 from course_modes.tests.factories import CourseModeFactory
-from courseware.tests.factories import InstructorFactory
+from lms.djangoapps.courseware.tests.factories import InstructorFactory
 from edxmako.shortcuts import render_to_response
 from openedx.core.djangoapps.embargo.test_utils import restrict_course
 from shoppingcart.admin import SoftDeleteCouponAdmin

--- a/lms/djangoapps/shoppingcart/views.py
+++ b/lms/djangoapps/shoppingcart/views.py
@@ -28,7 +28,7 @@ from opaque_keys.edx.keys import CourseKey
 from opaque_keys.edx.locator import CourseLocator
 
 from course_modes.models import CourseMode
-from courseware.courses import get_course_by_id
+from lms.djangoapps.courseware.courses import get_course_by_id
 from edxmako.shortcuts import render_to_response
 from openedx.core.djangoapps.embargo import api as embargo_api
 from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers

--- a/lms/djangoapps/staticbook/views.py
+++ b/lms/djangoapps/staticbook/views.py
@@ -9,8 +9,8 @@ from django.http import Http404
 from django.views.decorators.clickjacking import xframe_options_exempt
 from opaque_keys.edx.keys import CourseKey
 
-from courseware.access import has_access
-from courseware.courses import get_course_with_access
+from lms.djangoapps.courseware.access import has_access
+from lms.djangoapps.courseware.courses import get_course_with_access
 from edxmako.shortcuts import render_to_response
 from static_replace import replace_static_urls
 

--- a/lms/djangoapps/support/decorators.py
+++ b/lms/djangoapps/support/decorators.py
@@ -6,7 +6,7 @@ from functools import wraps
 from django.contrib.auth.decorators import login_required
 from django.http import HttpResponseForbidden
 
-from courseware.access import has_access
+from lms.djangoapps.courseware.access import has_access
 
 
 def require_support_permission(func):

--- a/lms/djangoapps/survey/utils.py
+++ b/lms/djangoapps/survey/utils.py
@@ -3,7 +3,7 @@ Utilities for determining whether or not a survey needs to be completed.
 """
 from __future__ import absolute_import
 
-from courseware.access import has_access
+from lms.djangoapps.courseware.access import has_access
 from survey.models import SurveyAnswer, SurveyForm
 
 

--- a/lms/djangoapps/teams/plugins.py
+++ b/lms/djangoapps/teams/plugins.py
@@ -3,7 +3,7 @@ Definition of the course team feature.
 """
 from django.utils.translation import ugettext_noop
 
-from courseware.tabs import EnrolledTab
+from lms.djangoapps.courseware.tabs import EnrolledTab
 
 from . import is_feature_enabled
 

--- a/lms/djangoapps/teams/tests/test_views.py
+++ b/lms/djangoapps/teams/tests/test_views.py
@@ -20,7 +20,7 @@ from search.search_engine_base import SearchEngine
 from six.moves import range
 
 from common.test.utils import skip_signal
-from courseware.tests.factories import StaffFactory
+from lms.djangoapps.courseware.tests.factories import StaffFactory
 from openedx.core.djangoapps.django_comment_common.models import FORUM_ROLE_COMMUNITY_TA, Role
 from openedx.core.djangoapps.django_comment_common.utils import seed_permissions_roles
 from student.models import CourseEnrollment

--- a/lms/djangoapps/teams/views.py
+++ b/lms/djangoapps/teams/views.py
@@ -21,7 +21,7 @@ from rest_framework.reverse import reverse
 from rest_framework.views import APIView
 from rest_framework_oauth.authentication import OAuth2Authentication
 
-from courseware.courses import get_course_with_access, has_access
+from lms.djangoapps.courseware.courses import get_course_with_access, has_access
 from lms.djangoapps.discussion.django_comment_client.utils import has_discussion_privileges
 from lms.djangoapps.teams.models import CourseTeam, CourseTeamMembership
 from edx_rest_framework_extensions.paginators import DefaultPagination, paginate_search_results

--- a/lms/lib/courseware_search/lms_search_initializer.py
+++ b/lms/lib/courseware_search/lms_search_initializer.py
@@ -6,8 +6,8 @@ This file contains implementation override of SearchInitializer which will allow
 from opaque_keys.edx.keys import CourseKey
 from search.initializer import SearchInitializer
 
-from courseware.access import has_access
-from courseware.masquerade import setup_masquerade
+from lms.djangoapps.courseware.access import has_access
+from lms.djangoapps.courseware.masquerade import setup_masquerade
 
 
 class LmsSearchInitializer(SearchInitializer):

--- a/lms/lib/courseware_search/test/test_lms_result_processor.py
+++ b/lms/lib/courseware_search/test/test_lms_result_processor.py
@@ -1,7 +1,7 @@
 """
 Tests for the lms_result_processor
 """
-from courseware.tests.factories import UserFactory
+from lms.djangoapps.courseware.tests.factories import UserFactory
 from lms.lib.courseware_search.lms_result_processor import LmsSearchResultProcessor
 from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
 from xmodule.modulestore.tests.factories import CourseFactory, ItemFactory

--- a/lms/urls.py
+++ b/lms/urls.py
@@ -12,11 +12,11 @@ from rest_framework_swagger.views import get_swagger_view
 
 from branding import views as branding_views
 from config_models.views import ConfigurationModelCurrentAPIView
-from courseware.masquerade import handle_ajax as courseware_masquerade_handle_ajax
-from courseware.module_render import handle_xblock_callback, handle_xblock_callback_noauth, xblock_view, xqueue_callback
-from courseware.views import views as courseware_views
-from courseware.views.index import CoursewareIndex
-from courseware.views.views import CourseTabView, EnrollStaffView, StaticCourseTabView
+from lms.djangoapps.courseware.masquerade import handle_ajax as courseware_masquerade_handle_ajax
+from lms.djangoapps.courseware.module_render import handle_xblock_callback, handle_xblock_callback_noauth, xblock_view, xqueue_callback
+from lms.djangoapps.courseware.views import views as courseware_views
+from lms.djangoapps.courseware.views.index import CoursewareIndex
+from lms.djangoapps.courseware.views.views import CourseTabView, EnrollStaffView, StaticCourseTabView
 from debug import views as debug_views
 from lms.djangoapps.certificates import views as certificates_views
 from lms.djangoapps.discussion import views as discussion_views

--- a/openedx/core/djangoapps/course_groups/cohorts.py
+++ b/openedx/core/djangoapps/course_groups/cohorts.py
@@ -20,7 +20,7 @@ from django.utils.translation import ugettext as _
 from edx_django_utils.cache import RequestCache
 from eventtracking import tracker
 
-from courseware import courses
+from lms.djangoapps.courseware import courses
 from openedx.core.lib.cache_utils import request_cached
 from student.models import get_user_by_username_or_email
 

--- a/openedx/core/djangoapps/course_groups/partition_scheme.py
+++ b/openedx/core/djangoapps/course_groups/partition_scheme.py
@@ -5,7 +5,7 @@ from __future__ import absolute_import
 
 import logging
 
-from courseware.masquerade import (
+from lms.djangoapps.courseware.masquerade import (
     get_course_masquerade,
     get_masquerading_user_group,
     is_masquerading_as_specific_student

--- a/openedx/core/djangoapps/course_groups/tests/test_partition_scheme.py
+++ b/openedx/core/djangoapps/course_groups/tests/test_partition_scheme.py
@@ -8,7 +8,7 @@ import django.test
 from mock import patch
 from six.moves import range
 
-from courseware.tests.test_masquerade import StaffMasqueradeTestCase
+from lms.djangoapps.courseware.tests.test_masquerade import StaffMasqueradeTestCase
 from openedx.core.djangoapps.user_api.partition_schemes import RandomUserPartitionScheme
 from openedx.core.djangolib.testing.utils import skip_unless_lms
 from student.tests.factories import UserFactory

--- a/openedx/core/djangoapps/course_groups/views.py
+++ b/openedx/core/djangoapps/course_groups/views.py
@@ -26,7 +26,7 @@ from rest_framework.generics import GenericAPIView
 from rest_framework.response import Response
 from rest_framework.serializers import Serializer
 
-from courseware.courses import get_course, get_course_with_access
+from lms.djangoapps.courseware.courses import get_course, get_course_with_access
 from edxmako.shortcuts import render_to_response
 from openedx.core.djangoapps.course_groups.models import CohortMembership
 from openedx.core.lib.api.authentication import OAuth2AuthenticationAllowInactiveUser

--- a/openedx/core/djangoapps/schedules/content_highlights.py
+++ b/openedx/core/djangoapps/schedules/content_highlights.py
@@ -6,8 +6,8 @@ from __future__ import absolute_import
 
 import logging
 
-from courseware.model_data import FieldDataCache
-from courseware.module_render import get_module_for_descriptor
+from lms.djangoapps.courseware.model_data import FieldDataCache
+from lms.djangoapps.courseware.module_render import get_module_for_descriptor
 from openedx.core.djangoapps.schedules.config import COURSE_UPDATE_WAFFLE_FLAG
 from openedx.core.djangoapps.schedules.exceptions import CourseUpdateDoesNotExist
 from openedx.core.lib.request_utils import get_request_or_stub

--- a/openedx/core/djangoapps/schedules/management/commands/tests/send_email_base.py
+++ b/openedx/core/djangoapps/schedules/management/commands/tests/send_email_base.py
@@ -22,7 +22,7 @@ from six.moves import range
 
 from course_modes.models import CourseMode
 from course_modes.tests.factories import CourseModeFactory
-from courseware.models import DynamicUpgradeDeadlineConfiguration
+from lms.djangoapps.courseware.models import DynamicUpgradeDeadlineConfiguration
 from lms.djangoapps.commerce.models import CommerceConfiguration
 from openedx.core.djangoapps.schedules import resolvers, tasks
 from openedx.core.djangoapps.schedules.resolvers import _get_datetime_beginning_of_day

--- a/openedx/core/djangoapps/schedules/management/commands/tests/upsell_base.py
+++ b/openedx/core/djangoapps/schedules/management/commands/tests/upsell_base.py
@@ -13,7 +13,7 @@ from edx_ace.utils.date import serialize
 from freezegun import freeze_time
 from mock import PropertyMock, patch
 
-from courseware.models import DynamicUpgradeDeadlineConfiguration
+from lms.djangoapps.courseware.models import DynamicUpgradeDeadlineConfiguration
 
 
 @ddt.ddt

--- a/openedx/core/djangoapps/schedules/resolvers.py
+++ b/openedx/core/djangoapps/schedules/resolvers.py
@@ -14,7 +14,7 @@ from edx_ace.recipient import Recipient
 from edx_ace.recipient_resolver import RecipientResolver
 from edx_django_utils.monitoring import function_trace, set_custom_metric
 
-from courseware.date_summary import verified_upgrade_deadline_link, verified_upgrade_link_is_valid
+from lms.djangoapps.courseware.date_summary import verified_upgrade_deadline_link, verified_upgrade_link_is_valid
 from openedx.core.djangoapps.ace_common.template_context import get_base_template_context
 from openedx.core.djangoapps.schedules.content_highlights import get_week_highlights
 from openedx.core.djangoapps.schedules.exceptions import CourseUpdateDoesNotExist

--- a/openedx/core/djangoapps/schedules/signals.py
+++ b/openedx/core/djangoapps/schedules/signals.py
@@ -10,7 +10,7 @@ from django.dispatch import receiver
 from edx_ace.utils import date
 
 from course_modes.models import CourseMode
-from courseware.models import (
+from lms.djangoapps.courseware.models import (
     CourseDynamicUpgradeDeadlineConfiguration,
     DynamicUpgradeDeadlineConfiguration,
     OrgDynamicUpgradeDeadlineConfiguration

--- a/openedx/core/djangoapps/schedules/tests/test_signals.py
+++ b/openedx/core/djangoapps/schedules/tests/test_signals.py
@@ -12,7 +12,7 @@ from pytz import utc
 
 from course_modes.models import CourseMode
 from course_modes.tests.factories import CourseModeFactory
-from courseware.models import DynamicUpgradeDeadlineConfiguration
+from lms.djangoapps.courseware.models import DynamicUpgradeDeadlineConfiguration
 from openedx.core.djangoapps.schedules.models import ScheduleExperience
 from openedx.core.djangoapps.schedules.signals import CREATE_SCHEDULE_WAFFLE_FLAG
 from openedx.core.djangoapps.site_configuration.tests.factories import SiteFactory

--- a/openedx/core/djangoapps/theming/tests/test_views.py
+++ b/openedx/core/djangoapps/theming/tests/test_views.py
@@ -9,7 +9,7 @@ from django.contrib.messages.middleware import MessageMiddleware
 from django.contrib.sites.models import Site
 from django.test import TestCase
 
-from courseware.tests.factories import GlobalStaffFactory
+from lms.djangoapps.courseware.tests.factories import GlobalStaffFactory
 from openedx.core.djangoapps.theming.middleware import CurrentSiteThemeMiddleware
 from student.tests.factories import UserFactory
 

--- a/openedx/core/djangoapps/verified_track_content/partition_scheme.py
+++ b/openedx/core/djangoapps/verified_track_content/partition_scheme.py
@@ -7,7 +7,7 @@ import logging
 import six
 
 from course_modes.models import CourseMode
-from courseware.masquerade import (
+from lms.djangoapps.courseware.masquerade import (
     get_course_masquerade,
     get_masquerading_user_group,
     is_masquerading_as_specific_student

--- a/openedx/features/course_bookmarks/plugins.py
+++ b/openedx/features/course_bookmarks/plugins.py
@@ -2,7 +2,7 @@
 Platform plugins to support course bookmarks.
 """
 
-from courseware.access import has_access
+from lms.djangoapps.courseware.access import has_access
 from django.urls import reverse
 from django.utils.translation import ugettext as _
 from openedx.features.course_experience.course_tools import CourseTool

--- a/openedx/features/course_bookmarks/views/course_bookmarks.py
+++ b/openedx/features/course_bookmarks/views/course_bookmarks.py
@@ -15,7 +15,7 @@ from django.views.generic import View
 from opaque_keys.edx.keys import CourseKey
 from web_fragments.fragment import Fragment
 
-from courseware.courses import get_course_with_access
+from lms.djangoapps.courseware.courses import get_course_with_access
 from openedx.core.djangoapps.plugin_api.views import EdxFragmentView
 from openedx.core.djangoapps.user_api.models import UserPreference
 from openedx.features.course_experience import default_course_url_name

--- a/openedx/features/course_duration_limits/resolvers.py
+++ b/openedx/features/course_duration_limits/resolvers.py
@@ -14,7 +14,7 @@ from django.utils.translation import ugettext as _
 from eventtracking import tracker
 
 from course_modes.models import CourseMode
-from courseware.date_summary import verified_upgrade_deadline_link
+from lms.djangoapps.courseware.date_summary import verified_upgrade_deadline_link
 from lms.djangoapps.experiments.utils import stable_bucketing_hash_group
 from openedx.core.djangoapps.catalog.utils import get_course_run_details
 from openedx.core.djangoapps.schedules.resolvers import (

--- a/openedx/features/course_duration_limits/tests/test_access.py
+++ b/openedx/features/course_duration_limits/tests/test_access.py
@@ -11,7 +11,7 @@ from pytz import UTC
 
 from course_modes.models import CourseMode
 from course_modes.tests.factories import CourseModeFactory
-from courseware.models import DynamicUpgradeDeadlineConfiguration
+from lms.djangoapps.courseware.models import DynamicUpgradeDeadlineConfiguration
 from openedx.core.djangoapps.schedules.tests.factories import ScheduleFactory
 from openedx.core.djangolib.testing.utils import CacheIsolationTestCase
 from openedx.features.course_duration_limits.access import (

--- a/openedx/features/course_experience/plugins.py
+++ b/openedx/features/course_experience/plugins.py
@@ -8,7 +8,7 @@ from __future__ import absolute_import
 from django.urls import reverse
 from django.utils.translation import ugettext as _
 
-from courseware.courses import get_course_by_id
+from lms.djangoapps.courseware.courses import get_course_by_id
 from student.models import CourseEnrollment
 
 from . import SHOW_REVIEWS_TOOL_FLAG, UNIFIED_COURSE_TAB_FLAG

--- a/openedx/features/course_experience/tests/views/test_course_home.py
+++ b/openedx/features/course_experience/tests/views/test_course_home.py
@@ -20,7 +20,7 @@ from waffle.testutils import override_flag
 
 from course_modes.models import CourseMode
 from course_modes.tests.factories import CourseModeFactory
-from courseware.tests.helpers import get_expiration_banner_text
+from lms.djangoapps.courseware.tests.helpers import get_expiration_banner_text
 from experiments.models import ExperimentData
 from lms.djangoapps.commerce.models import CommerceConfiguration
 from lms.djangoapps.commerce.utils import EcommerceService

--- a/openedx/features/course_experience/tests/views/test_course_outline.py
+++ b/openedx/features/course_experience/tests/views/test_course_outline.py
@@ -22,7 +22,7 @@ from six import text_type
 from waffle.models import Switch
 from waffle.testutils import override_switch
 
-from courseware.tests.factories import StaffFactory
+from lms.djangoapps.courseware.tests.factories import StaffFactory
 from gating import api as lms_gating_api
 from lms.djangoapps.course_api.blocks.transformers.milestones import MilestonesAndSpecialExamsTransformer
 from openedx.core.lib.gating import api as gating_api

--- a/openedx/features/course_experience/tests/views/test_course_updates.py
+++ b/openedx/features/course_experience/tests/views/test_course_updates.py
@@ -8,7 +8,7 @@ from datetime import datetime
 import six
 from django.urls import reverse
 
-from courseware.courses import get_course_info_usage_key
+from lms.djangoapps.courseware.courses import get_course_info_usage_key
 from openedx.core.djangoapps.waffle_utils.testutils import WAFFLE_TABLES
 from openedx.features.content_type_gating.models import ContentTypeGatingConfig
 from openedx.features.course_experience.views.course_updates import STATUS_VISIBLE

--- a/openedx/features/course_experience/views/course_dates.py
+++ b/openedx/features/course_experience/views/course_dates.py
@@ -9,7 +9,7 @@ from django.utils.translation import get_language_bidi
 from opaque_keys.edx.keys import CourseKey
 from web_fragments.fragment import Fragment
 
-from courseware.courses import get_course_date_blocks, get_course_with_access
+from lms.djangoapps.courseware.courses import get_course_date_blocks, get_course_with_access
 from openedx.core.djangoapps.plugin_api.views import EdxFragmentView
 
 

--- a/openedx/features/course_experience/views/course_home.py
+++ b/openedx/features/course_experience/views/course_home.py
@@ -15,8 +15,8 @@ from opaque_keys.edx.keys import CourseKey
 from web_fragments.fragment import Fragment
 
 from course_modes.models import get_cosmetic_verified_display_price
-from courseware.access import has_access
-from courseware.courses import can_self_enroll_in_course, get_course_info_section, get_course_with_access
+from lms.djangoapps.courseware.access import has_access
+from lms.djangoapps.courseware.courses import can_self_enroll_in_course, get_course_info_section, get_course_with_access
 from lms.djangoapps.commerce.utils import EcommerceService
 from lms.djangoapps.course_goals.api import (
     get_course_goal,

--- a/openedx/features/course_experience/views/course_home_messages.py
+++ b/openedx/features/course_experience/views/course_home_messages.py
@@ -17,7 +17,7 @@ from pytz import UTC
 from web_fragments.fragment import Fragment
 
 from course_modes.models import CourseMode
-from courseware.courses import get_course_date_blocks, get_course_with_access
+from lms.djangoapps.courseware.courses import get_course_date_blocks, get_course_with_access
 from lms.djangoapps.course_goals.api import (
     get_course_goal,
     get_course_goal_options,

--- a/openedx/features/course_experience/views/course_outline.py
+++ b/openedx/features/course_experience/views/course_outline.py
@@ -15,7 +15,7 @@ from pytz import UTC
 from waffle.models import Switch
 from web_fragments.fragment import Fragment
 
-from courseware.courses import get_course_overview_with_access
+from lms.djangoapps.courseware.courses import get_course_overview_with_access
 from openedx.core.djangoapps.plugin_api.views import EdxFragmentView
 from student.models import CourseEnrollment
 from util.milestones_helpers import get_course_content_milestones

--- a/openedx/features/course_experience/views/course_reviews.py
+++ b/openedx/features/course_experience/views/course_reviews.py
@@ -13,7 +13,7 @@ from django.views.decorators.cache import cache_control
 from opaque_keys.edx.keys import CourseKey
 from web_fragments.fragment import Fragment
 
-from courseware.courses import get_course_with_access
+from lms.djangoapps.courseware.courses import get_course_with_access
 from lms.djangoapps.courseware.views.views import CourseTabView
 from openedx.core.djangoapps.plugin_api.views import EdxFragmentView
 from openedx.features.course_experience import default_course_url_name

--- a/openedx/features/course_experience/views/course_sock.py
+++ b/openedx/features/course_experience/views/course_sock.py
@@ -7,7 +7,7 @@ from django.template.loader import render_to_string
 from web_fragments.fragment import Fragment
 
 from course_modes.models import get_cosmetic_verified_display_price
-from courseware.date_summary import verified_upgrade_deadline_link, verified_upgrade_link_is_valid
+from lms.djangoapps.courseware.date_summary import verified_upgrade_deadline_link, verified_upgrade_link_is_valid
 from openedx.core.djangoapps.plugin_api.views import EdxFragmentView
 from student.models import CourseEnrollment
 

--- a/openedx/features/course_experience/views/course_updates.py
+++ b/openedx/features/course_experience/views/course_updates.py
@@ -15,7 +15,7 @@ from django.views.decorators.cache import cache_control
 from opaque_keys.edx.keys import CourseKey
 from web_fragments.fragment import Fragment
 
-from courseware.courses import get_course_info_section_module, get_course_with_access
+from lms.djangoapps.courseware.courses import get_course_info_section_module, get_course_with_access
 from lms.djangoapps.courseware.views.views import CourseTabView
 from openedx.core.djangoapps.plugin_api.views import EdxFragmentView
 from openedx.features.course_experience import default_course_url_name

--- a/openedx/features/course_experience/views/latest_update.py
+++ b/openedx/features/course_experience/views/latest_update.py
@@ -12,7 +12,7 @@ from django.template.loader import render_to_string
 from opaque_keys.edx.keys import CourseKey
 from web_fragments.fragment import Fragment
 
-from courseware.courses import get_course_with_access
+from lms.djangoapps.courseware.courses import get_course_with_access
 from openedx.core.djangoapps.plugin_api.views import EdxFragmentView
 from openedx.features.course_experience.views.course_updates import get_ordered_updates
 

--- a/openedx/features/course_experience/views/welcome_message.py
+++ b/openedx/features/course_experience/views/welcome_message.py
@@ -12,7 +12,7 @@ from django.views.decorators.csrf import ensure_csrf_cookie
 from opaque_keys.edx.keys import CourseKey
 from web_fragments.fragment import Fragment
 
-from courseware.courses import get_course_with_access
+from lms.djangoapps.courseware.courses import get_course_with_access
 from openedx.core.djangoapps.plugin_api.views import EdxFragmentView
 from openedx.core.djangoapps.user_api.course_tag.api import get_course_tag, set_course_tag
 

--- a/openedx/features/course_search/views/course_search.py
+++ b/openedx/features/course_search/views/course_search.py
@@ -15,7 +15,7 @@ from django.views.decorators.csrf import ensure_csrf_cookie
 from opaque_keys.edx.keys import CourseKey
 from web_fragments.fragment import Fragment
 
-from courseware.courses import get_course_overview_with_access
+from lms.djangoapps.courseware.courses import get_course_overview_with_access
 from lms.djangoapps.courseware.views.views import CourseTabView
 from openedx.core.djangoapps.plugin_api.views import EdxFragmentView
 from openedx.features.course_experience import default_course_url_name


### PR DESCRIPTION
In the early days, we did some hacky path munging to make separate
import trees for LMS vs. CMS (a.k.a. Studio). Some of this lingers
to today. We want to get rid of that hacky path munging, so all
imports of the courseware app should use the real full path of
"lms.djangoapps.courseware", not just "courseware".

This commit does that conversion for edx-platform. I didn't remove
the deprecation warning because it's likely that there are other
repos that are bundled in edx-platform that do use the old form.