### PR TITLE
Version 2.1.1 on NPM is not exactly the thing we use.

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "eslint-config-edx-es5": "2.0.0",
     "eslint-import-resolver-webpack": "0.8.4",
     "jasmine-core": "2.6.4",
-    "jasmine-jquery": "2.1.1",
+    "jasmine-jquery": "git+https://github.com/velesin/jasmine-jquery.git#ebad463d592d3fea00c69f26ea18a930e09c7b58",
     "jest": "23.1.0",
     "jest-enzyme": "6.0.2",
     "karma": "0.13.22",


### PR DESCRIPTION
It looks like the package maintainers had a v2.1.1 that was on github
but then released a different 2.1.1 to NPM.  When renovate(upgrade
automation) tries to make any changes, it updates the lockfile to point
to the NPM one which currently breaks tests.

Pinning to the correct version in the package.json so that we can get
other things upgraded.

Tests that break if we pull from NPM: https://build.testeng.edx.org/job/edx-platform-js-pr/63215/#showFailuresLink