### PR TITLE
Add in messaging for 403 errors on about pages & update error color for a11y

### DIFF
--- a/lms/static/sass/multicourse/_course_about.scss
+++ b/lms/static/sass/multicourse/_course_about.scss
@@ -188,8 +188,8 @@
 
           #register_error {
             background: $error-color;
-            border: 1px solid rgb(202, 17, 17);
-            color: rgb(143, 14, 14);
+            border: 1px $error-color;
+            color: $white;
             display: none;
             padding: 12px;
             margin-top: ($baseline/4);

--- a/lms/templates/courseware/course_about.html
+++ b/lms/templates/courseware/course_about.html
@@ -50,7 +50,7 @@ from six import string_types
         $.ajax({
           url: "${reverse('add_course_to_cart', args=[text_type(course.id)]) | n, js_escaped_string}",
           type: "POST",
-          /* Rant: HAD TO USE COMPLETE B/C PROMISE.DONE FOR SOME REASON DOES NOT WORK ON THIS PAGE. */
+          /* Using `complete` as promise.done did not work on this page */
           complete: add_course_complete_handler
         })
         event.preventDefault();
@@ -58,13 +58,17 @@ from six import string_types
     % endif
 
     $('#class_enroll_form').on('ajax:complete', function(event, xhr) {
-      if(xhr.status == 200) {
+      if (xhr.status == 200) {
         if (xhr.responseText == "") {
           location.href = "${reverse('dashboard') | n, js_escaped_string}";
         }
         else {
           location.href = xhr.responseText;
         }
+      } else if (xhr.status == 403) {
+        $('#register_error').text(
+            (xhr.responseText ? xhr.responseText : "${_("An error has occurred. Please ensure that you are logged in to enroll.") | n, js_escaped_string}")
+        ).css("display", "block");
       } else {
         $('#register_error').text(
             (xhr.responseText ? xhr.responseText : "${_("An error occurred. Please try again later.") | n, js_escaped_string}")


### PR DESCRIPTION
## [PROD-70](https://openedx.atlassian.net/browse/PROD-70)

The messaging for a 403 when trying to enroll through the built in about page was unclear and provided a poor experience for learners. This change calls out that they need to log in prior to enrolling in a course as well as updating the colors to be more accessible to read.

Before:
<img width="1244" alt="Screen Shot 2019-06-07 at 11 44 51 AM" src="https://user-images.githubusercontent.com/9357438/59116611-f8086c00-8919-11e9-8d35-39c40f4a7798.png">

After:
<img width="1248" alt="Screen Shot 2019-06-07 at 11 24 08 AM" src="https://user-images.githubusercontent.com/9357438/59116624-fdfe4d00-8919-11e9-9778-a353b16dd5b2.png">
