### PR TITLE
Unpin edx-enterprise and edx-drf-extensions

### DIFF
--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -54,8 +54,5 @@ edx-opaque-keys==0.4.4
 # xmodule.tests.test_resource_templates.ResourceTemplatesTests See TE-2391 for details.
 pytest<4.6.0
 
-# Pinning to older versions of edx-enterprise, edx-rbac, and edx-drf-extensions until
-# a bug is fixed in the edx-drf-extensions package.
-edx-drf-extensions==2.2.1
-edx-enterprise==1.6.0
+# Pinning to older version of edx-rbac until ENT-2002 is resolved.
 edx-rbac==0.2.1

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -103,8 +103,8 @@ edx-django-oauth2-provider==1.3.5
 edx-django-release-util==0.3.1
 edx-django-sites-extensions==2.3.1
 edx-django-utils==1.0.3
-edx-drf-extensions==2.2.1
-edx-enterprise==1.6.0
+edx-drf-extensions==2.3.1
+edx-enterprise==1.6.5
 edx-i18n-tools==0.4.8
 edx-milestones==0.2.2
 edx-oauth2-provider==1.2.2
@@ -246,3 +246,6 @@ xblock-utils==1.2.1
 xblock==1.2.2
 xmlsec==1.3.3             # via python3-saml
 zendesk==1.1.1
+
+# The following packages are considered to be unsafe in a requirements file:
+# setuptools==41.0.1        # via fs, lazy, python-levenshtein

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -123,8 +123,8 @@ edx-django-oauth2-provider==1.3.5
 edx-django-release-util==0.3.1
 edx-django-sites-extensions==2.3.1
 edx-django-utils==1.0.3
-edx-drf-extensions==2.2.1
-edx-enterprise==1.6.0
+edx-drf-extensions==2.3.1
+edx-enterprise==1.6.5
 edx-i18n-tools==0.4.8
 edx-lint==1.3.0
 edx-milestones==0.2.2
@@ -335,3 +335,6 @@ xmlsec==1.3.3
 xmltodict==0.12.0
 zendesk==1.1.1
 zipp==0.5.1
+
+# The following packages are considered to be unsafe in a requirements file:
+# setuptools==41.0.1        # via caniusepython3, fs, lazy, pytest, python-levenshtein, sphinx, tox

--- a/requirements/edx/paver.txt
+++ b/requirements/edx/paver.txt
@@ -27,3 +27,6 @@ stevedore==1.30.1
 urllib3==1.23             # via requests
 watchdog==0.9.0
 wrapt==1.10.5
+
+# The following packages are considered to be unsafe in a requirements file:
+# setuptools==41.0.1        # via lazy

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -119,8 +119,8 @@ edx-django-oauth2-provider==1.3.5
 edx-django-release-util==0.3.1
 edx-django-sites-extensions==2.3.1
 edx-django-utils==1.0.3
-edx-drf-extensions==2.2.1
-edx-enterprise==1.6.0
+edx-drf-extensions==2.3.1
+edx-enterprise==1.6.5
 edx-i18n-tools==0.4.8
 edx-lint==1.3.0
 edx-milestones==0.2.2
@@ -321,3 +321,6 @@ xmlsec==1.3.3
 xmltodict==0.12.0         # via moto
 zendesk==1.1.1
 zipp==0.5.1               # via importlib-metadata
+
+# The following packages are considered to be unsafe in a requirements file:
+# setuptools==41.0.1        # via caniusepython3, fs, lazy, pytest, python-levenshtein, tox


### PR DESCRIPTION
This unblocks future releases of edx-enterprise and edx-drf-extensions due to the changes here: https://github.com/edx/edx-enterprise/pull/494