### PR TITLE
Fix intermittent unit test failures

### DIFF
--- a/openedx/core/djangoapps/schedules/management/commands/tests/send_email_base.py
+++ b/openedx/core/djangoapps/schedules/management/commands/tests/send_email_base.py
@@ -12,6 +12,8 @@ import attr
 import ddt
 import pytz
 from django.conf import settings
+from django.contrib.auth.models import User
+from django.db.models import Max
 from edx_ace.channel import ChannelMap, ChannelType
 from edx_ace.test_utils import StubPolicy, patch_policies
 from edx_ace.utils.date import serialize
@@ -104,6 +106,18 @@ class ScheduleSendEmailTestMixin(FilteredQueryCountMixin):
 
     def _calculate_bin_for_user(self, user):
         return user.id % self.task.num_bins
+
+    def _next_user_id(self):
+        """
+        Get the next user ID which is a multiple of the bin count and greater
+        than the current largest user ID.  Avoids intermittent ID collisions
+        with the user created in ModuleStoreTestCase.setUp().
+        """
+        max_user_id = User.objects.aggregate(Max('id'))['id__max']
+        if max_user_id is None:
+            max_user_id = 0
+        num_bins = self.task.num_bins
+        return max_user_id + num_bins - (max_user_id % num_bins)
 
     def _get_dates(self, offset=None):
         current_day = _get_datetime_beginning_of_day(datetime.datetime.now(pytz.UTC))
@@ -296,8 +310,8 @@ class ScheduleSendEmailTestMixin(FilteredQueryCountMixin):
         for config in (this_config, other_config):
             ScheduleConfigFactory.create(site=config.site)
 
-        user1 = UserFactory.create(id=self.task.num_bins)
-        user2 = UserFactory.create(id=self.task.num_bins * 2)
+        user1 = UserFactory.create(id=self._next_user_id())
+        user2 = UserFactory.create(id=user1.id + self.task.num_bins)
         current_day, offset, target_day, upgrade_deadline = self._get_dates()
 
         self._schedule_factory(
@@ -323,7 +337,7 @@ class ScheduleSendEmailTestMixin(FilteredQueryCountMixin):
 
     @ddt.data(True, False)
     def test_course_end(self, has_course_ended):
-        user1 = UserFactory.create(id=self.task.num_bins)
+        user1 = UserFactory.create(id=self._next_user_id())
         current_day, offset, target_day, upgrade_deadline = self._get_dates()
 
         end_date_offset = -2 if has_course_ended else 2


### PR DESCRIPTION
4 tests in this file would fail if the user created during `ModuleStoreTestCase.setUp()` happened to have an ID of 24 or 48 (due to randomness in the sequence of tests run prior to these).  The tests depend on the ID being an even multiple of the bin size, so just increase to the next available multiple.