### PR TITLE
Fixed CDN urls to Static urls on edit.

### DIFF
--- a/cms/static/js/views/course_info_helper.js
+++ b/cms/static/js/views/course_info_helper.js
@@ -2,6 +2,7 @@ define(['codemirror', 'js/utils/handle_iframe_binding', 'utility'],
     function(CodeMirror, IframeBinding) {
         var editWithCodeMirror = function(model, contentName, baseAssetUrl, textArea) {
             var content = rewriteStaticLinks(model.get(contentName), baseAssetUrl, '/static/');
+            content = rewriteCdnLinksToStatic(content); // eslint-disable-line no-undef
             model.set(contentName, content);
             var $codeMirror = CodeMirror.fromTextArea(textArea, {
                 mode: 'text/html',

--- a/common/static/js/spec/utility_spec.js
+++ b/common/static/js/spec/utility_spec.js
@@ -16,3 +16,25 @@ describe('utility.rewriteStaticLinks', function() {
         ).toBe('<img src="http://www.mysite.org/static/foo.x"/>');
     });
 });
+describe('utility.rewriteCdnLinksToStatic', function() {
+    'use strict';
+    it('does not replace "url" to "static url" if url is not following "cdn url" pattern', function() {
+        expect(
+            rewriteCdnLinksToStatic( // eslint-disable-line no-undef
+            '<img src="/asset-v1:UCentralLah+Cs201+2019_1+type@asset+block/foo.x"/>')
+        ).toBe('<img src="/asset-v1:UCentralLah+Cs201+2019_1+type@asset+block/foo.x"/>');
+        expect(
+            rewriteCdnLinksToStatic('<img src="/assets/foo.x"/>') // eslint-disable-line no-undef
+        ).toBe('<img src="/assets/foo.x"/>');
+    });
+    it('does a replace of "cdn url" to "static url" if url is part of absolute url', function() {
+        expect(
+            rewriteCdnLinksToStatic( // eslint-disable-line no-undef
+              '<img src="//prod-edxapp.edx-cdn.org/assets/foo.x"/>')
+        ).toBe('<img src="/static/foo.x"/>');
+        expect(
+          rewriteCdnLinksToStatic( // eslint-disable-line no-undef
+            '<img src="https://prod-edxapp.edx-cdn.org/assets/foo.x"/>')
+        ).toBe('<img src="/static/foo.x"/>');
+    });
+});

--- a/common/static/js/src/utility.js
+++ b/common/static/js/src/utility.js
@@ -35,5 +35,13 @@ window.rewriteStaticLinks = function(content, from, to) {
     // escape all regex interpretable chars
     fromRe = from.replace(/[-\/\\^$*+?.()|[\]{}]/g, '\\$&');
     var regex = new RegExp('(https?:\/\/(www\.)?[-a-zA-Z0-9@:%._\+~#=]{2,256}\.[a-z]{2,6}([-a-zA-Z0-9@:%_\+.~#?&//=]*))?' + fromRe, 'g');
+
     return content.replace(regex, replacer);
+};
+
+// Utility method for replacing absolute URLs
+window.rewriteCdnLinksToStatic = function(content) {
+    'use strict';
+    var regex = new RegExp('((https?:)?[/][/](www.)?[-a-zA-Z0-9@:%._+~#=]{2,256}[a-z]{2,6}([-a-zA-Z0-9@:%_+~#?&//=]*)|[a-z-]{14})[/]', 'g');// eslint-disable-line max-len
+    return content.replace(regex, '/static/');
 };


### PR DESCRIPTION
## [PROD-250](https://openedx.atlassian.net/browse/PROD-250)

### Description
This pr fixes rewriting of static URLs to direct links in the handouts section (content update section). Previously, on editing the URL in the editor, it reverts back to the CDN URL. The method is written only for replacing the relative URL. One new method is added for replacing absolute URL i-e CDN URLs to static URLs. After this fix, static URL will not revert to direct links, on page refresh.

**Sandbox**
https://studio-zb-prod-250.sandbox.edx.org/course_info/course-v1:edX+DemoX+Demo_Course#

### Reviewers
If you've been tagged for review, please check your corresponding box once you've given the :+1:.
- [x] Code review: @DawoudSheraz 
- [x] Code review: @asadazam93 

### Post-review
- [x] Rebase and squash commits