### PR TITLE
INCR-483: Make compatible with Python 3.x without breaking Python 2.7 support

### DIFF
--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -28,6 +28,8 @@ Longer TODO:
 # and throws spurious errors. Therefore, we disable invalid-name checking.
 # pylint: disable=invalid-name, wrong-import-position
 
+from __future__ import absolute_import
+
 import imp
 import sys
 import os
@@ -37,10 +39,10 @@ from path import Path as path
 from django.utils.translation import ugettext_lazy as _
 from enterprise.constants import (
     ENTERPRISE_ADMIN_ROLE,
-    ENTERPRISE_OPERATOR_ROLE,
-    ENTERPRISE_DASHBOARD_ADMIN_ROLE,
     ENTERPRISE_CATALOG_ADMIN_ROLE,
-    ENTERPRISE_ENROLLMENT_API_ADMIN_ROLE
+    ENTERPRISE_DASHBOARD_ADMIN_ROLE,
+    ENTERPRISE_ENROLLMENT_API_ADMIN_ROLE,
+    ENTERPRISE_OPERATOR_ROLE
 )
 
 from openedx.core.constants import COURSE_KEY_REGEX, COURSE_KEY_PATTERN, COURSE_ID_PATTERN

--- a/lms/envs/load_test.py
+++ b/lms/envs/load_test.py
@@ -6,6 +6,10 @@ Settings for load testing.
 # want to import all variables from base settings files
 # pylint: disable=wildcard-import, unused-wildcard-import
 
+from __future__ import absolute_import
+
+from six.moves import filter
+
 from .production import *
 
 # Disable CSRF for load testing
@@ -13,7 +17,7 @@ EXCLUDE_CSRF = lambda elem: elem not in [
     'django.template.context_processors.csrf',
     'django.middleware.csrf.CsrfViewMiddleware'
 ]
-DEFAULT_TEMPLATE_ENGINE['OPTIONS']['context_processors'] = filter(
+DEFAULT_TEMPLATE_ENGINE['OPTIONS']['context_processors'] = list(filter(
     EXCLUDE_CSRF, DEFAULT_TEMPLATE_ENGINE['OPTIONS']['context_processors']
-)
-MIDDLEWARE_CLASSES = filter(EXCLUDE_CSRF, MIDDLEWARE_CLASSES)
+))
+MIDDLEWARE_CLASSES = list(filter(EXCLUDE_CSRF, MIDDLEWARE_CLASSES))

--- a/lms/envs/production.py
+++ b/lms/envs/production.py
@@ -30,8 +30,8 @@ from django.core.exceptions import ImproperlyConfigured
 from path import Path as path
 
 from openedx.core.djangoapps.plugins import plugin_settings, constants as plugin_constants
-from openedx.core.lib.derived import derive_settings  # pylint: disable=wrong-import-order
-from openedx.core.lib.logsettings import get_logger_config  # pylint: disable=wrong-import-order
+from openedx.core.lib.derived import derive_settings
+from openedx.core.lib.logsettings import get_logger_config
 from xmodule.modulestore.modulestore_settings import convert_module_store_setting_if_needed
 
 from .common import *

--- a/lms/envs/production.py
+++ b/lms/envs/production.py
@@ -17,22 +17,24 @@ Common traits:
 # and throws spurious errors. Therefore, we disable invalid-name checking.
 # pylint: disable=invalid-name
 
+from __future__ import absolute_import
+
 import codecs
 import datetime
-import yaml
-
 import os
+
 import dateutil
-
+import yaml
 from corsheaders.defaults import default_headers as corsheaders_default_headers
-from path import Path as path
-from xmodule.modulestore.modulestore_settings import convert_module_store_setting_if_needed
-from openedx.core.djangoapps.plugins import plugin_settings, constants as plugin_constants
 from django.core.exceptions import ImproperlyConfigured
+from path import Path as path
 
-from .common import *
+from openedx.core.djangoapps.plugins import plugin_settings, constants as plugin_constants
 from openedx.core.lib.derived import derive_settings  # pylint: disable=wrong-import-order
 from openedx.core.lib.logsettings import get_logger_config  # pylint: disable=wrong-import-order
+from xmodule.modulestore.modulestore_settings import convert_module_store_setting_if_needed
+
+from .common import *
 
 
 def get_env_setting(setting):
@@ -295,7 +297,7 @@ CELERY_QUEUES.update(
     {
         alternate: {}
         for alternate in ALTERNATE_QUEUES
-        if alternate not in CELERY_QUEUES.keys()
+        if alternate not in list(CELERY_QUEUES.keys())
     }
 )
 

--- a/lms/envs/test.py
+++ b/lms/envs/test.py
@@ -12,22 +12,31 @@ sessions. Assumes structure:
 # We intentionally define lots of variables that aren't used, and
 # want to import all variables from base settings files
 # pylint: disable=wildcard-import, unused-wildcard-import
-from collections import OrderedDict
+from __future__ import absolute_import
 
-from django.utils.translation import ugettext_lazy
-
-from .common import *
+import logging
 import os
-from path import Path as path
+from collections import OrderedDict
+from random import choice
+from string import digits, letters, punctuation
 from uuid import uuid4
 
-from util.db import NoOpMigrationModules
+import openid.oidutil
+from django.utils.translation import ugettext_lazy
+from path import Path as path
+from six.moves import range
+
+from openedx.core.djangoapps.plugins import plugin_settings, constants as plugin_constants
 from openedx.core.lib.derived import derive_settings
 from openedx.core.lib.tempdir import mkdtemp_clean
 
+from .common import *
+
+from util.db import NoOpMigrationModules  # pylint: disable=wrong-import-order
+from util.testing import patch_sessions, patch_testcase  # pylint: disable=wrong-import-order
+
 # This patch disables the commit_on_success decorator during tests
 # in TestCase subclasses.
-from util.testing import patch_testcase, patch_sessions
 patch_testcase()
 patch_sessions()
 
@@ -37,7 +46,6 @@ ALLOWED_HOSTS = [
 ]
 
 # Silence noisy logs to make troubleshooting easier when tests fail.
-import logging
 LOG_OVERRIDES = [
     ('factory.generate', logging.ERROR),
     ('factory.containers', logging.ERROR),
@@ -283,8 +291,6 @@ FEATURES['ENABLE_PAYMENT_FAKE'] = True
 # Since both the fake payment page and the shoppingcart app are using
 # the same settings, we can generate this randomly and guarantee
 # that they are using the same secret.
-from random import choice
-from string import letters, digits, punctuation
 RANDOM_SHARED_SECRET = ''.join(
     choice(letters + digits + punctuation)
     for x in range(250)
@@ -398,9 +404,9 @@ FEATURES['CLASS_DASHBOARD'] = True
 ################### Make tests quieter
 
 # OpenID spews messages like this to stderr, we don't need to see them:
-#   Generated checkid_setup request to http://testserver/openid/provider/login/ with assocication {HMAC-SHA1}{51d49995}{s/kRmA==}
+# Generated checkid_setup request to http://testserver/openid/provider/login/
+# With assocication {HMAC-SHA1}{51d49995}{s/kRmA==}
 
-import openid.oidutil
 openid.oidutil.log = lambda message, level=0: None
 
 
@@ -618,7 +624,6 @@ JWT_AUTH.update({
 # pylint: enable=unicode-format-string
 ####################### Plugin Settings ##########################
 
-from openedx.core.djangoapps.plugins import plugin_settings, constants as plugin_constants
 plugin_settings.add_plugins(__name__, plugin_constants.ProjectType.LMS, plugin_constants.SettingsType.TEST)
 
 ########################## Derive Any Derived Settings  #######################

--- a/lms/envs/test_static_optimized.py
+++ b/lms/envs/test_static_optimized.py
@@ -11,8 +11,11 @@ from the same directory.
 """
 
 # Start with the common settings
-from .common import *  # pylint: disable=wildcard-import, unused-wildcard-import
+from __future__ import absolute_import
+
 from openedx.core.lib.derived import derive_settings
+
+from .common import *  # pylint: disable=wildcard-import, unused-wildcard-import
 
 # Use an in-memory database since this settings file is only used for updating assets
 DATABASES = {

--- a/lms/startup.py
+++ b/lms/startup.py
@@ -2,6 +2,8 @@
 Module for code that should run during LMS startup (deprecated)
 """
 
+from __future__ import absolute_import
+
 import django
 from django.conf import settings
 

--- a/lms/tests.py
+++ b/lms/tests.py
@@ -1,5 +1,7 @@
 """Tests for the lms module itself."""
 
+from __future__ import absolute_import
+
 import logging
 import mimetypes
 

--- a/lms/urls.py
+++ b/lms/urls.py
@@ -2,15 +2,19 @@
 URLs for LMS
 """
 
+from __future__ import absolute_import
+
+from config_models.views import ConfigurationModelCurrentAPIView
 from django.conf import settings
 from django.conf.urls import include, url
 from django.conf.urls.static import static
 from django.contrib.admin import autodiscover as django_autodiscover
 from django.utils.translation import ugettext_lazy as _
 from django.views.generic.base import RedirectView
+from ratelimitbackend import admin
+from rest_framework_swagger.views import get_swagger_view
 
 from branding import views as branding_views
-from config_models.views import ConfigurationModelCurrentAPIView
 from courseware.masquerade import handle_ajax as courseware_masquerade_handle_ajax
 from courseware.module_render import handle_xblock_callback, handle_xblock_callback_noauth, xblock_view, xqueue_callback
 from courseware.views import views as courseware_views
@@ -43,7 +47,6 @@ from openedx.core.djangoapps.site_configuration import helpers as configuration_
 from openedx.core.djangoapps.verified_track_content import views as verified_track_content_views
 from openedx.core.openapi import schema_view
 from openedx.features.enterprise_support.api import enterprise_enabled
-from ratelimitbackend import admin
 from static_template_view import views as static_template_view_views
 from staticbook import views as staticbook_views
 from student import views as student_views

--- a/lms/urls.py
+++ b/lms/urls.py
@@ -12,7 +12,6 @@ from django.contrib.admin import autodiscover as django_autodiscover
 from django.utils.translation import ugettext_lazy as _
 from django.views.generic.base import RedirectView
 from ratelimitbackend import admin
-from rest_framework_swagger.views import get_swagger_view
 
 from branding import views as branding_views
 from courseware.masquerade import handle_ajax as courseware_masquerade_handle_ajax


### PR DESCRIPTION
python-modernize -w lms/envs/bok_choy_docker.py lms/envs/devstack_docker.py lms/envs/load_test.py lms/envs/production.py lms/envs/test.py lms/envs/test_static_optimized.py lms/envs/common.py lms/urls.py lms/tests.py lms/startup.py

isort -rc lms/envs/bok_choy_docker.py lms/envs/devstack_docker.py lms/envs/load_test.py lms/envs/production.py lms/envs/test.py lms/envs/test_static_optimized.py lms/envs/common.py lms/urls.py lms/tests.py lms/startup.py

[INCR-483](https://openedx.atlassian.net/browse/INCR-483)

@edx/incr-reviewers