### PR TITLE
DEPR-12 Remove microsites references from edxmako

### DIFF
--- a/common/djangoapps/edxmako/paths.py
+++ b/common/djangoapps/edxmako/paths.py
@@ -14,7 +14,6 @@ from django.conf import settings
 from mako.exceptions import TopLevelLookupException
 from mako.lookup import TemplateLookup
 
-from openedx.core.djangoapps.theming.helpers import get_template as themed_template
 from openedx.core.djangoapps.theming.helpers import get_template_path_with_theme, strip_site_theme_templates_path
 from openedx.core.lib.cache_utils import request_cached
 
@@ -63,7 +62,7 @@ class DynamicTemplateLookup(TemplateLookup):
         self._collection.clear()
         self._uri_cache.clear()
 
-    def adjust_uri(self, uri, calling_uri):
+    def adjust_uri(self, uri, relativeto):
         """
         This method is called by mako when including a template in another template or when inheriting an existing mako
         template. The method adjusts the `uri` to make it relative to the calling template's location.
@@ -76,12 +75,12 @@ class DynamicTemplateLookup(TemplateLookup):
         that template lookup skips the current theme and looks up the built-in template in standard locations.
         """
         # Make requested uri relative to the calling uri.
-        relative_uri = super(DynamicTemplateLookup, self).adjust_uri(uri, calling_uri)
-        # Is the calling template (calling_uri) which is including or inheriting current template (uri)
+        relative_uri = super(DynamicTemplateLookup, self).adjust_uri(uri, relativeto)
+        # Is the calling template (relativeto) which is including or inheriting current template (uri)
         # located inside a theme?
-        if calling_uri != strip_site_theme_templates_path(calling_uri):
+        if relativeto != strip_site_theme_templates_path(relativeto):
             # Is the calling template trying to include/inherit itself?
-            if calling_uri == get_template_path_with_theme(relative_uri):
+            if relativeto == get_template_path_with_theme(relative_uri):
                 return TopLevelTemplateURI(relative_uri)
         return relative_uri
 
@@ -96,20 +95,14 @@ class DynamicTemplateLookup(TemplateLookup):
         If still unable to find a template, it will fallback to the default template directories after stripping off
         the prefix path to theme.
         """
-        # try to get template for the given file from microsite
-        template = themed_template(uri)
-
-        # if microsite template is not present or request is not in microsite then
-        # let mako find and serve a template
-        if not template:
-            if isinstance(uri, TopLevelTemplateURI):
+        if isinstance(uri, TopLevelTemplateURI):
+            template = self._get_toplevel_template(uri)
+        else:
+            try:
+                # Try to find themed template, i.e. see if current theme overrides the template
+                template = super(DynamicTemplateLookup, self).get_template(get_template_path_with_theme(uri))
+            except TopLevelLookupException:
                 template = self._get_toplevel_template(uri)
-            else:
-                try:
-                    # Try to find themed template, i.e. see if current theme overrides the template
-                    template = super(DynamicTemplateLookup, self).get_template(get_template_path_with_theme(uri))
-                except TopLevelLookupException:
-                    template = self._get_toplevel_template(uri)
 
         return template
 


### PR DESCRIPTION
Removed support for microsites from `get_template()`.  Also fixed a pylint warning due to renaming a parameter in another method overridden from the superclass.