### PR TITLE
Add link to course url in the account creation and enrollment email

### DIFF
--- a/lms/templates/instructor/edx_ace/accountcreationandenrollment/email/body.html
+++ b/lms/templates/instructor/edx_ace/accountcreationandenrollment/email/body.html
@@ -42,6 +42,15 @@
             </p>
 
             <p style="color: rgba(0,0,0,.75);">
+              <a href="{{ course_url }}">
+                {% filter force_escape %}
+                {% blocktrans %}You may access your course.{% endblocktrans %}
+                {% endfilter %}
+              </a>
+                <br />
+            </p>
+
+            <p style="color: rgba(0,0,0,.75);">
                 {% filter force_escape %}
                 {% blocktrans %}Sincerely yours, The {{ course_name }} Team{% endblocktrans %}
                 {% endfilter %}

--- a/lms/templates/instructor/edx_ace/accountcreationandenrollment/email/body.txt
+++ b/lms/templates/instructor/edx_ace/accountcreationandenrollment/email/body.txt
@@ -8,4 +8,6 @@
 
 {% blocktrans %}It is recommended that you change your password.{% endblocktrans %}
 
+{% blocktrans %}You may access your course at: {{ course_url }}.{% endblocktrans %}
+
 {% blocktrans %}Sincerely yours, The {{ course_name }} Team{% endblocktrans %}{% endautoescape %}


### PR DESCRIPTION
This PR adds a link to the course URL in the email sent when users are created and enrolled in a course at the same time with `create_and_enroll_user`. (Which should be the case when using the `ALLOW_AUTOMATED_SIGNUPS` feature.)

**JIRA tickets**: [OSPR-3652](https://openedx.atlassian.net/browse/OSPR-3652)

**Dependencies**: None

**Sandbox URL**: [Sandbox](https://pr20806.sandbox.opencraft.hosting/)

**Merge deadline**: "None"

**Testing instructions**:

Ensure `ALLOW_AUTOMATED_SIGNUPS` feature flag is enabled.

Create a CSV file that contains the following columns in this exact order: email, username, name, and country. 

On the Instructor Dashboard of LMS, register a user and enroll them into course with the CSV upload functionality on the Instructor dashboard of LMS. Please include one test user per row and do not include any headers, footers, or blank lines

Note that account creation and enrollment email sent will now include a link to the course that the user was just enrolled in.  

You can verify this by attaching to a docker container and checking the logs if using devstack, or with a sandbox environment with an actual SMTP server provisioned. Check the HTML as well as the text version of the e-mail.

**Author notes and concerns**: 

The exact text of the link needs to be decided.

**Reviewers**
- @clemente 
- [ ] edX reviewer[s] TBD