### PR TITLE
Add username to account creation and enrollment email

### DIFF
--- a/conf/locale/en/LC_MESSAGES/django.po
+++ b/conf/locale/en/LC_MESSAGES/django.po
@@ -8542,6 +8542,12 @@ msgstr ""
 #: lms/templates/instructor/edx_ace/accountcreationandenrollment/email/body.html
 #: lms/templates/instructor/edx_ace/accountcreationandenrollment/email/body.txt
 #, python-format
+msgid "username: %(username)s"
+msgstr ""
+
+#: lms/templates/instructor/edx_ace/accountcreationandenrollment/email/body.html
+#: lms/templates/instructor/edx_ace/accountcreationandenrollment/email/body.txt
+#, python-format
 msgid "password: %(password)s"
 msgstr ""
 

--- a/lms/djangoapps/instructor/views/api.py
+++ b/lms/djangoapps/instructor/views/api.py
@@ -601,6 +601,7 @@ def create_and_enroll_user(email, username, name, country, password, course_id, 
                 'message_type': 'account_creation_and_enrollment',
                 'email_address': email,
                 'password': password,
+                'username': username,
                 'platform_name': configuration_helpers.get_value('platform_name', settings.PLATFORM_NAME),
             })
             send_mail_to_student(email, email_params)

--- a/lms/templates/instructor/edx_ace/accountcreationandenrollment/email/body.txt
+++ b/lms/templates/instructor/edx_ace/accountcreationandenrollment/email/body.txt
@@ -3,6 +3,7 @@
 {% blocktrans %}To get started, please visit https://{{ site_name }}. The login information for your account follows.{% endblocktrans %}
 
 {% blocktrans %}email: {{ email_address }}{% endblocktrans %}
+{% blocktrans %}username: {{ username }}{% endblocktrans %}
 {% blocktrans %}password: {{ password }}{% endblocktrans %}
 
 


### PR DESCRIPTION
This PR adds username in the email sent when users are created and enrolled in a course at the same time with `create_and_enroll_user`. (Which should be the case when using the `ALLOW_AUTOMATED_SIGNUPS` feature.)

**JIRA tickets**: [OSPR-3655](https://openedx.atlassian.net/browse/OSPR-3655)

**Dependencies**: None

**Sandbox URL**: TBD - sandbox is being provisioned.

**Merge deadline**: "None"

**Testing instructions**:

Ensure `ALLOW_AUTOMATED_SIGNUPS` feature flag is enabled.

Create a CSV file that contains the following columns in this exact order: email, username, name, and country. 

On the Instructor Dashboard of LMS, register a user and enroll them into course with the CSV upload functionality on the Instructor dashboard of LMS. Please include one test user per row and do not include any headers, footers, or blank lines

Note that account creation and enrollment email sent will now include the username.  

You can verify this by attaching to a docker container and checking the logs if using devstack, or with a sandbox environment with an actual SMTP server provisioned.

**Author notes and concerns**: None so far.

**Reviewers**
- @clemente 
- [ ] edX reviewer[s] TBD
