### PR TITLE
Upgrade to edx-opaque-keys 1.0.1

### DIFF
--- a/common/lib/xmodule/setup.py
+++ b/common/lib/xmodule/setup.py
@@ -44,7 +44,7 @@ XBLOCKS_ASIDES = [
 
 setup(
     name="XModule",
-    version="0.1.1",
+    version="0.1.2",
     packages=find_packages(exclude=["tests"]),
     install_requires=[
         'setuptools',
@@ -52,7 +52,7 @@ setup(
         'capa',
         'path.py',
         'webob',
-        'edx-opaque-keys>=0.4.0,<1.0.0',
+        'edx-opaque-keys>=0.4.0',
     ],
     package_data={
         'xmodule': ['js/module/*'],

--- a/lms/djangoapps/grades/tests/test_models.py
+++ b/lms/djangoapps/grades/tests/test_models.py
@@ -17,6 +17,7 @@ from django.test import TestCase
 from django.utils.timezone import now
 from freezegun import freeze_time
 from mock import patch
+from opaque_keys import InvalidKeyError
 from opaque_keys.edx.locator import BlockUsageLocator, CourseLocator
 
 from lms.djangoapps.grades.constants import GradeOverrideFeatureEnum
@@ -457,7 +458,7 @@ class PersistentCourseGradesTest(GradesModelTestCase):
         ("percent_grade", "Not a float at all", ValueError),
         ("percent_grade", None, IntegrityError),
         ("letter_grade", None, IntegrityError),
-        ("course_id", "Not a course key at all", AssertionError),
+        ("course_id", "Not a course key at all", InvalidKeyError),
         ("user_id", None, IntegrityError),
         ("grading_policy_hash", None, IntegrityError),
     )

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -46,10 +46,6 @@ python3-saml==1.5.0
 # version 1.3.0 breaks make upgrade, as it requires py3.5 or above
 scipy<=1.2.1
 
-# Leaving this unpinned breaks make upgrade, since several packages require <1.0.0, but pip-compile
-# will find and select 1.0.0 for paver.txt and terminate unsuccessfully.
-edx-opaque-keys==0.4.4
-
 # Unless we constrain pytest to <4.6.0, it may break all tests inside of
 # xmodule.tests.test_resource_templates.ResourceTemplatesTests See TE-2391 for details.
 pytest<4.6.0

--- a/requirements/edx/base.in
+++ b/requirements/edx/base.in
@@ -75,7 +75,7 @@ edx-django-release-util             # Release utils for the edx release pipeline
 edx-django-sites-extensions==2.3.1
 edx-django-utils
 edx-drf-extensions
-edx-enterprise
+edx-enterprise==1.6.9
 edx-milestones
 edx-oauth2-provider
 edx-organizations

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -23,7 +23,7 @@
 -e common/lib/xmodule
 amqp==1.4.9               # via kombu
 analytics-python==1.2.9
-aniso8601==6.0.0          # via tincan
+aniso8601==7.0.0          # via tincan
 anyjson==0.3.3            # via kombu
 appdirs==1.4.3            # via fs
 argh==0.26.2
@@ -97,19 +97,19 @@ docutils==0.14            # via botocore
 edx-ace==0.1.10
 edx-analytics-data-api-client==0.15.3
 git+https://github.com/edx/edx-bulk-grades@f58f9fa01d95c01211fc94ebb92f0fb1a04bf32b#egg=edx-bulk-grades==0.1.1
-edx-ccx-keys==0.2.1
+edx-ccx-keys==0.2.2
 edx-celeryutils==0.2.7
 edx-completion==2.0.0
 edx-django-oauth2-provider==1.3.5
 edx-django-release-util==0.3.1
 edx-django-sites-extensions==2.3.1
-edx-django-utils==1.0.3
+edx-django-utils==1.0.5
 edx-drf-extensions==2.3.1
 edx-enterprise==1.6.9
 edx-i18n-tools==0.4.8
-edx-milestones==0.2.2
+edx-milestones==0.2.3
 edx-oauth2-provider==1.2.2
-edx-opaque-keys[django]==0.4.4
+edx-opaque-keys[django]==1.0.1
 edx-organizations==2.0.3
 edx-proctoring-proctortrack==1.0.5
 edx-proctoring==2.0.3
@@ -118,7 +118,7 @@ edx-rest-api-client==1.9.2
 edx-search==1.2.2
 git+https://github.com/mitodl/edx-sga.git@3828ba9e413080a81b907a3381e5ffa05e063f81#egg=edx-sga==0.8.3
 edx-submissions==2.1.1
-edx-user-state-client==1.1.0
+edx-user-state-client==1.1.1
 edx-when==0.1.6
 edxval==1.1.25
 elasticsearch==1.9.0      # via edx-search

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -25,7 +25,7 @@
 alabaster==0.7.12         # via sphinx
 amqp==1.4.9
 analytics-python==1.2.9
-aniso8601==6.0.0
+aniso8601==7.0.0
 anyjson==0.3.3
 apipkg==1.5
 appdirs==1.4.3
@@ -117,20 +117,20 @@ docutils==0.14
 edx-ace==0.1.10
 edx-analytics-data-api-client==0.15.3
 git+https://github.com/edx/edx-bulk-grades@f58f9fa01d95c01211fc94ebb92f0fb1a04bf32b#egg=edx-bulk-grades==0.1.1
-edx-ccx-keys==0.2.1
+edx-ccx-keys==0.2.2
 edx-celeryutils==0.2.7
 edx-completion==2.0.0
 edx-django-oauth2-provider==1.3.5
 edx-django-release-util==0.3.1
 edx-django-sites-extensions==2.3.1
-edx-django-utils==1.0.3
+edx-django-utils==1.0.5
 edx-drf-extensions==2.3.1
 edx-enterprise==1.6.9
 edx-i18n-tools==0.4.8
 edx-lint==1.3.0
-edx-milestones==0.2.2
+edx-milestones==0.2.3
 edx-oauth2-provider==1.2.2
-edx-opaque-keys[django]==0.4.4
+edx-opaque-keys[django]==1.0.1
 edx-organizations==2.0.3
 edx-proctoring-proctortrack==1.0.5
 edx-proctoring==2.0.3
@@ -140,7 +140,7 @@ edx-search==1.2.2
 git+https://github.com/mitodl/edx-sga.git@3828ba9e413080a81b907a3381e5ffa05e063f81#egg=edx-sga==0.8.3
 edx-sphinx-theme==1.4.0
 edx-submissions==2.1.1
-edx-user-state-client==1.1.0
+edx-user-state-client==1.1.1
 edx-when==0.1.6
 edxval==1.1.25
 elasticsearch==1.9.0
@@ -172,7 +172,7 @@ httplib2==0.13.0
 httpretty==0.9.6
 idna==2.8
 imagesize==1.1.0          # via sphinx
-importlib-metadata==0.17
+importlib-metadata==0.18
 inflect==2.1.0
 ipaddress==1.0.22
 isodate==0.6.0

--- a/requirements/edx/paver.txt
+++ b/requirements/edx/paver.txt
@@ -7,7 +7,7 @@
 argh==0.26.2              # via watchdog
 certifi==2019.3.9         # via requests
 chardet==3.0.4            # via requests
-edx-opaque-keys==0.4.4
+edx-opaque-keys==1.0.1
 idna==2.8                 # via requests
 lazy==1.1
 libsass==0.10.0

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -23,7 +23,7 @@
 -e common/lib/xmodule
 amqp==1.4.9
 analytics-python==1.2.9
-aniso8601==6.0.0
+aniso8601==7.0.0
 anyjson==0.3.3
 apipkg==1.5               # via execnet
 appdirs==1.4.3
@@ -113,20 +113,20 @@ docutils==0.14
 edx-ace==0.1.10
 edx-analytics-data-api-client==0.15.3
 git+https://github.com/edx/edx-bulk-grades@f58f9fa01d95c01211fc94ebb92f0fb1a04bf32b#egg=edx-bulk-grades==0.1.1
-edx-ccx-keys==0.2.1
+edx-ccx-keys==0.2.2
 edx-celeryutils==0.2.7
 edx-completion==2.0.0
 edx-django-oauth2-provider==1.3.5
 edx-django-release-util==0.3.1
 edx-django-sites-extensions==2.3.1
-edx-django-utils==1.0.3
+edx-django-utils==1.0.5
 edx-drf-extensions==2.3.1
 edx-enterprise==1.6.9
 edx-i18n-tools==0.4.8
 edx-lint==1.3.0
-edx-milestones==0.2.2
+edx-milestones==0.2.3
 edx-oauth2-provider==1.2.2
-edx-opaque-keys[django]==0.4.4
+edx-opaque-keys[django]==1.0.1
 edx-organizations==2.0.3
 edx-proctoring-proctortrack==1.0.5
 edx-proctoring==2.0.3
@@ -135,7 +135,7 @@ edx-rest-api-client==1.9.2
 edx-search==1.2.2
 git+https://github.com/mitodl/edx-sga.git@3828ba9e413080a81b907a3381e5ffa05e063f81#egg=edx-sga==0.8.3
 edx-submissions==2.1.1
-edx-user-state-client==1.1.0
+edx-user-state-client==1.1.1
 edx-when==0.1.6
 edxval==1.1.25
 elasticsearch==1.9.0
@@ -166,7 +166,7 @@ html5lib==1.0.1
 httplib2==0.13.0
 httpretty==0.9.6
 idna==2.8
-importlib-metadata==0.17  # via pluggy
+importlib-metadata==0.18  # via pluggy
 inflect==2.1.0
 ipaddress==1.0.22
 isodate==0.6.0


### PR DESCRIPTION
Now that all packages which formerly required <1.0.0 have newer releases, upgrade this to unblock future `make upgrade` runs.