### PR TITLE
[BB-1289] Add support for MongoDB authentication database

### DIFF
--- a/common/djangoapps/track/backends/mongodb.py
+++ b/common/djangoapps/track/backends/mongodb.py
@@ -29,6 +29,7 @@ class MongoBackend(BaseBackend):
           - `password`: collection user password
           - `database`: name of the database
           - `collection`: name of the collection
+          - 'auth_source': name of the authentication database
           - `extra`: parameters to pymongo.MongoClient not listed above
 
         """
@@ -45,6 +46,8 @@ class MongoBackend(BaseBackend):
 
         db_name = kwargs.get('database', 'track')
         collection_name = kwargs.get('collection', 'events')
+
+        auth_source = kwargs.get('auth_source') or None
 
         # Other mongo connection arguments
         extra = kwargs.get('extra', {})
@@ -67,7 +70,7 @@ class MongoBackend(BaseBackend):
         database = self.connection[db_name]
 
         if user or password:
-            database.authenticate(user, password)
+            database.authenticate(user, password, source=auth_source)
 
         self.collection = database[collection_name]
 

--- a/common/lib/xmodule/xmodule/mongo_utils.py
+++ b/common/lib/xmodule/xmodule/mongo_utils.py
@@ -36,6 +36,9 @@ def connect_to_mongodb(
         # No 'replicaSet' in kwargs - so no secondary reads.
         mongo_client_class = pymongo.MongoClient
 
+    # If the MongoDB server uses a separate authentication database that should be specified here
+    auth_source = kwargs.pop('auth_source', '') or None
+
     # If read_preference is given as a name of a valid ReadPreference.<NAME> constant
     # such as "SECONDARY_PREFERRED", convert it. Otherwise pass it through unchanged.
     if 'read_preference' in kwargs:
@@ -59,10 +62,9 @@ def connect_to_mongodb(
             mongo_conn,
             wait_time=retry_wait_time
         )
-
     # If credentials were provided, authenticate the user.
     if user is not None and password is not None:
-        mongo_conn.authenticate(user, password)
+        mongo_conn.authenticate(user, password, source=auth_source)
 
     return mongo_conn
 


### PR DESCRIPTION
This PR and its counterparts https://github.com/edx/cs_comments_service/pull/275, https://github.com/edx/configuration/pull/5195 allow specifying a authentication database for MongoDB. 

**JIRA tickets**: OSPR-3660

**Dependencies**:
- Similar PR for forum service: https://github.com/edx/cs_comments_service/pull/275 
- Configuration PR to configure this parameter: https://github.com/edx/configuration/pull/5195

**Sandbox URL**:
- LMS: https://pr20819.sandbox.opencraft.hosting/
- Studio: https://studio.pr20819.sandbox.opencraft.hosting/

**Merge deadline**: None

**Testing instructions**:

1. Set up MongoDB and add users to the authentication database
2. Set "auth_source" along with other MongoDB params in lms.yaml and cms.yaml
3. The application should be able to authenticate.

**Reviewers**
- [ ] (OpenCraft internal reviewer's GitHub username goes here)
- [ ] edX reviewer[s] TBD

**Settings**
```yaml
EDXAPP_FEATURES:
  ENABLE_COMBINED_LOGIN_REGISTRATION: true

# Main mongo DB
EDXAPP_MONGO_HOSTS: 'cluster2-shard-00-00-gc7jt.mongodb.net,cluster2-shard-00-01-gc7jt.mongodb.net,cluster2-shard-00-02-gc7jt.mongodb.net'
EDXAPP_MONGO_PORT: 27017
EDXAPP_MONGO_DB_NAME: 'edxapp'
EDXAPP_MONGO_USER: 'edxapp'
EDXAPP_MONGO_USE_SSL: yes
EDXAPP_MONGO_REPLICA_SET: 'Cluster2-shard-0'
EDXAPP_MONGO_AUTH_DB: 'admin'

# Forum mongo DB
FORUM_MONGO_USE_SSL: true
FORUM_MONGO_AUTH_DB: admin
FORUM_MONGO_URL: "mongodb://edxforum2:{{ FORUM_MONGO_PASSWORD }}@cluster2-shard-00-00-gc7jt.mongodb.net:27017,cluster2-shard-00-01-gc7jt.mongodb.net:27017,cluster2-shard-00-02-gc7jt.mongodb.net:27017/edxforum2?ssl=true&replicaSet=Cluster2-shard-0&authSource=admin&w=majority"
forum_source_repo: "https://github.com/open-craft/cs_comments_service.git"
forum_version: "kshitij/mongo-auth-source"
configuration_version: "kshitij/allow-specifying-mongo-auth-source"

```