### PR TITLE
Backend-specific dashboard launches depend on the name field

### DIFF
--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -112,7 +112,7 @@ edx-oauth2-provider==1.2.2
 edx-opaque-keys[django]==1.0.1
 edx-organizations==2.0.3
 edx-proctoring-proctortrack==1.0.5
-edx-proctoring==2.0.3
+edx-proctoring==2.0.4
 edx-rbac==0.2.1           # via edx-enterprise
 edx-rest-api-client==1.9.2
 edx-search==1.2.2

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -133,7 +133,7 @@ edx-oauth2-provider==1.2.2
 edx-opaque-keys[django]==1.0.1
 edx-organizations==2.0.3
 edx-proctoring-proctortrack==1.0.5
-edx-proctoring==2.0.3
+edx-proctoring==2.0.4
 edx-rbac==0.2.1
 edx-rest-api-client==1.9.2
 edx-search==1.2.2

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -129,7 +129,7 @@ edx-oauth2-provider==1.2.2
 edx-opaque-keys[django]==1.0.1
 edx-organizations==2.0.3
 edx-proctoring-proctortrack==1.0.5
-edx-proctoring==2.0.3
+edx-proctoring==2.0.4
 edx-rbac==0.2.1
 edx-rest-api-client==1.9.2
 edx-search==1.2.2


### PR DESCRIPTION
... being set and fail if there is none. We were drawing in this
information from the auth_user.first_name and .last_name fields, which
are deprecated on the edX platform.