### PR TITLE
Rename python processes for monitoring

### DIFF
--- a/cms/conftest.py
+++ b/cms/conftest.py
@@ -10,8 +10,10 @@ from __future__ import absolute_import, unicode_literals
 
 import importlib
 import os
+
 import contracts
 import pytest
+from setproctitle import getproctitle, setproctitle
 
 
 # Patch the xml libs before anything else.
@@ -25,6 +27,13 @@ def pytest_configure(config):
     """
     if config.getoption('help'):
         return
+    if hasattr(config, 'workerinput'):
+        # Set the process name for pytest-xdist workers to something
+        # recognizable, like "py_xdist_gw0", for the benefit of tools like
+        # New Relic Infrastructure and top
+        old_name = getproctitle()
+        new_name = 'py_xdist_{}'.format(config.workerinput['workerid'])
+        setproctitle(old_name.replace('python', new_name, 1))
     enable_contracts = os.environ.get('ENABLE_CONTRACTS', False)
     if not enable_contracts:
         contracts.disable_all()

--- a/common/lib/conftest.py
+++ b/common/lib/conftest.py
@@ -1,4 +1,9 @@
-"""Code run by pylint before running any tests."""
+"""
+Code run by pylint before running any tests.
+"""
+from __future__ import absolute_import
+
+from setproctitle import getproctitle, setproctitle
 
 # Patch the xml libs before anything else.
 from safe_lxml import defuse_xml_libs
@@ -21,3 +26,16 @@ def no_webpack_loader(monkeypatch):
         "webpack_loader.utils.get_files",
         lambda entry, extension=None, config='DEFAULT', attrs='': []
     )
+
+
+def pytest_configure(config):
+    """
+    Rename the process for pytest-xdist workers for easier identification.
+    """
+    if hasattr(config, 'workerinput'):
+        # Set the process name for pytest-xdist workers to something
+        # recognizable, like "py_xdist_gw0", for the benefit of tools like
+        # New Relic Infrastructure and top
+        old_name = getproctitle()
+        new_name = 'py_xdist_{}'.format(config.workerinput['workerid'])
+        setproctitle(old_name.replace('python', new_name, 1))

--- a/common/test/conftest.py
+++ b/common/test/conftest.py
@@ -1,5 +1,23 @@
-"""Code run by pylint before running any tests."""
+"""
+Code run by pylint before running any tests.
+"""
+from __future__ import absolute_import
+
+from setproctitle import getproctitle, setproctitle
 
 # Patch the xml libs before anything else.
 from safe_lxml import defuse_xml_libs
 defuse_xml_libs()
+
+
+def pytest_configure(config):
+    """
+    Rename the process for pytest-xdist workers for easier identification.
+    """
+    if hasattr(config, 'workerinput'):
+        # Set the process name for pytest-xdist workers to something
+        # recognizable, like "py_xdist_gw0", for the benefit of tools like
+        # New Relic Infrastructure and top
+        old_name = getproctitle()
+        new_name = 'py_xdist_{}'.format(config.workerinput['workerid'])
+        setproctitle(old_name.replace('python', new_name, 1))

--- a/pavelib/paver_tests/conftest.py
+++ b/pavelib/paver_tests/conftest.py
@@ -8,6 +8,7 @@ import os
 from shutil import rmtree
 
 import pytest
+from setproctitle import getproctitle, setproctitle
 
 from pavelib.utils.envs import Env
 
@@ -21,3 +22,16 @@ def delete_quality_junit_xml():
     yield
     if os.path.exists(Env.QUALITY_DIR):
         rmtree(Env.QUALITY_DIR, ignore_errors=True)
+
+
+def pytest_configure(config):
+    """
+    Rename the process for pytest-xdist workers for easier identification.
+    """
+    if hasattr(config, 'workerinput'):
+        # Set the process name for pytest-xdist workers to something
+        # recognizable, like "py_xdist_gw0", for the benefit of tools like
+        # New Relic Infrastructure and top
+        old_name = getproctitle()
+        new_name = 'py_xdist_{}'.format(config.workerinput['workerid'])
+        setproctitle(old_name.replace('python', new_name, 1))

--- a/pavement.py
+++ b/pavement.py
@@ -1,5 +1,7 @@
-import sys
 import os
+import sys
+
+from setproctitle import getproctitle, setproctitle
 
 # Ensure that we can import pavelib, and that our copy of pavelib
 # takes precedence over anything else installed in the virtualenv.
@@ -12,3 +14,19 @@ import os
 sys.path.insert(0, os.path.dirname(__file__))
 
 from pavelib import *
+
+
+def rename_process():
+    """
+    Replace "python" in the process name with "py_pav_<command>"
+    to make it clear in tools like New Relic Infrastructure and top
+    which particular paver command was called.
+    """
+    old_name = getproctitle()
+    if 'paver' in sys.argv[0] and 'py_pav_' not in old_name:
+        command_name = sys.argv[1]
+        new_name = 'py_pav_{}'.format(command_name)
+        setproctitle(old_name.replace('python', new_name, 1))
+
+
+rename_process()

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -218,6 +218,7 @@ s3transfer==0.1.13        # via boto3
 sailthru-client==2.2.3
 scipy==1.2.1
 semantic-version==2.6.0   # via edx-drf-extensions
+setproctitle==1.1.10
 shapely==1.6.4.post2
 shortuuid==0.5.0          # via edx-django-oauth2-provider
 simplejson==3.16.0        # via mailsnake, sailthru-client, zendesk

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -289,6 +289,7 @@ scandir==1.10.0
 scipy==1.2.1
 selenium==3.141.0
 semantic-version==2.6.0
+setproctitle==1.1.10
 shapely==1.6.4.post2
 shortuuid==0.5.0
 simplejson==3.16.0

--- a/requirements/edx/paver.in
+++ b/requirements/edx/paver.in
@@ -21,6 +21,7 @@ psutil==1.2.1                       # Library for retrieving information on runn
 pymongo==2.9.1                      # via edx-opaque-keys
 python-memcached                    # Python interface to the memcached memory cache daemon
 requests                            # Simple interface for making HTTP requests
+setproctitle                        # Support for changing the process name to allow easier monitoring
 stevedore                           # Support for runtime plugins, used for XBlocks and edx-platform Django app plugins
 watchdog                            # Used in paver watch_assets
 wrapt==1.10.5                       # Decorator utilities used in the @timed paver task decorator

--- a/requirements/edx/paver.txt
+++ b/requirements/edx/paver.txt
@@ -22,6 +22,7 @@ pymongo==2.9.1
 python-memcached==1.59
 pyyaml==5.1.1             # via watchdog
 requests==2.22.0
+setproctitle==1.1.10
 six==1.11.0
 stevedore==1.30.1
 urllib3==1.23             # via requests

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -280,6 +280,7 @@ scandir==1.10.0           # via pathlib2
 scipy==1.2.1
 selenium==3.141.0
 semantic-version==2.6.0
+setproctitle==1.1.10
 shapely==1.6.4.post2
 shortuuid==0.5.0
 simplejson==3.16.0

--- a/scripts/accessibility-tests.sh
+++ b/scripts/accessibility-tests.sh
@@ -22,6 +22,8 @@ source scripts/jenkins-common.sh
 # with tox env invocation
 if [ -z ${TOX_ENV+x} ] || [[ ${TOX_ENV} == 'null' ]]; then
     TOX=""
+    echo "Installing paver requirements..."
+    pip install -qr requirements/edx/paver.txt
 elif tox -l |grep -q "${TOX_ENV}"; then
     TOX="tox -r -e ${TOX_ENV} --"
 else

--- a/scripts/generic-ci-tests.sh
+++ b/scripts/generic-ci-tests.sh
@@ -69,6 +69,8 @@ END
 # with tox env invocation
 if [ -z ${TOX_ENV+x} ] || [[ ${TOX_ENV} == 'null' ]]; then
     TOX=""
+    echo "Installing paver requirements..."
+    pip install -qr requirements/edx/paver.txt
 elif tox -l |grep -q "${TOX_ENV}"; then
     TOX="tox -r -e ${TOX_ENV} --"
 else

--- a/scripts/jenkins-quality-diff.sh
+++ b/scripts/jenkins-quality-diff.sh
@@ -5,6 +5,9 @@ set -e
 source scripts/jenkins-common.sh
 source scripts/thresholds.sh
 
+echo "Installing paver requirements..."
+pip install -qr requirements/edx/paver.txt
+
 # Run quality task. Pass in the 'fail-under' percentage to diff-quality
 echo "Running diff quality."
 mkdir -p test_root/log/

--- a/scripts/jenkins-report.sh
+++ b/scripts/jenkins-report.sh
@@ -11,6 +11,9 @@ set -e
 
 source scripts/jenkins-common.sh
 
+echo "Installing paver requirements..."
+pip install -qr requirements/edx/paver.txt
+
 # Get the diff coverage and html reports for unit tests
 paver coverage -b $TARGET_BRANCH
 


### PR DESCRIPTION
Use the `setproctitle` package to rename processes for paver commands, Django management commands, and pytest-xdist workers so they can be distinguished in tools like New Relic Infrastructure that don't display any of the arguments it was started with (can also be useful in `top`, etc.).  Only renames the "python" string in the process name, all paths and arguments are preserved.

Also started installing paver requirements in each main script called by Jenkins, primarily so `setproctitle` gets installed before we try using it, but we may want to leave this in place to simplify future dependency upgrades.  It only takes about 5 seconds to run.