### PR TITLE
Revert "Version bump for edx-enterprise"

### DIFF
--- a/openedx/features/enterprise_support/api.py
+++ b/openedx/features/enterprise_support/api.py
@@ -187,6 +187,7 @@ class EnterpriseApiClient(object):
                         "enterprise_customer": {
                             "uuid": "cf246b88-d5f6-4908-a522-fc307e0b0c59",
                             "name": "TestShib",
+                            "catalog": 2,
                             "active": true,
                             "site": {
                                 "domain": "example.com",

--- a/openedx/features/enterprise_support/tests/__init__.py
+++ b/openedx/features/enterprise_support/tests/__init__.py
@@ -12,6 +12,7 @@ FEATURES_WITH_ENTERPRISE_ENABLED['ENABLE_ENTERPRISE_INTEGRATION'] = True
 FAKE_ENTERPRISE_CUSTOMER = {
     'active': True,
     'branding_configuration': None,
+    'catalog': None,
     'enable_audit_enrollment': False,
     'enable_data_sharing_consent': False,
     'enforce_data_sharing_consent': 'at_enrollment',

--- a/openedx/features/enterprise_support/tests/factories.py
+++ b/openedx/features/enterprise_support/tests/factories.py
@@ -33,6 +33,7 @@ class EnterpriseCustomerFactory(factory.django.DjangoModelFactory):
     name = factory.LazyAttribute(lambda x: FAKER.company())  # pylint: disable=no-member
     active = True
     site = factory.SubFactory(SiteFactory)
+    catalog = factory.LazyAttribute(lambda x: FAKER.random_int(min=0, max=1000000))  # pylint: disable=no-member
     enable_data_sharing_consent = True
     enforce_data_sharing_consent = EnterpriseCustomer.AT_ENROLLMENT
 

--- a/openedx/features/enterprise_support/tests/mixins/enterprise.py
+++ b/openedx/features/enterprise_support/tests/mixins/enterprise.py
@@ -144,6 +144,7 @@ class EnterpriseServiceMockMixin(object):
 
     def mock_enterprise_learner_api(
             self,
+            catalog_id=1,
             entitlement_id=1,
             learner_id=1,
             enterprise_customer_uuid='cf246b88-d5f6-4908-a522-fc307e0b0c59',
@@ -162,6 +163,7 @@ class EnterpriseServiceMockMixin(object):
                     'enterprise_customer': {
                         'uuid': enterprise_customer_uuid,
                         'name': 'TestShib',
+                        'catalog': catalog_id,
                         'active': True,
                         'site': {
                             'domain': 'example.com',

--- a/requirements/edx/base.in
+++ b/requirements/edx/base.in
@@ -75,7 +75,7 @@ edx-django-release-util             # Release utils for the edx release pipeline
 edx-django-sites-extensions==2.3.1
 edx-django-utils
 edx-drf-extensions
-edx-enterprise==1.6.9
+edx-enterprise==1.6.7
 edx-milestones
 edx-oauth2-provider
 edx-organizations

--- a/requirements/edx/base.in
+++ b/requirements/edx/base.in
@@ -75,7 +75,7 @@ edx-django-release-util             # Release utils for the edx release pipeline
 edx-django-sites-extensions==2.3.1
 edx-django-utils
 edx-drf-extensions
-edx-enterprise
+edx-enterprise==1.6.9
 edx-milestones
 edx-oauth2-provider
 edx-organizations

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -105,14 +105,14 @@ edx-django-release-util==0.3.1
 edx-django-sites-extensions==2.3.1
 edx-django-utils==1.0.5
 edx-drf-extensions==2.3.1
-edx-enterprise==1.6.12
+edx-enterprise==1.6.9
 edx-i18n-tools==0.4.8
 edx-milestones==0.2.3
 edx-oauth2-provider==1.2.2
 edx-opaque-keys[django]==1.0.1
 edx-organizations==2.0.3
 edx-proctoring-proctortrack==1.0.5
-edx-proctoring==2.0.4
+edx-proctoring==2.0.3
 edx-rbac==0.2.1           # via edx-enterprise
 edx-rest-api-client==1.9.2
 edx-search==1.2.2
@@ -174,7 +174,7 @@ git+https://github.com/edx/edx-ora2.git@2.2.3#egg=ora2==2.2.3
 path.py==8.2.1
 pathtools==0.1.2
 paver==1.3.4
-pbr==5.3.0
+pbr==5.2.1
 pdfminer.six==20181108
 piexif==1.0.2
 pillow==6.0.0

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -105,7 +105,7 @@ edx-django-release-util==0.3.1
 edx-django-sites-extensions==2.3.1
 edx-django-utils==1.0.5
 edx-drf-extensions==2.3.1
-edx-enterprise==1.6.9
+edx-enterprise==1.6.7
 edx-i18n-tools==0.4.8
 edx-milestones==0.2.3
 edx-oauth2-provider==1.2.2

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -125,7 +125,7 @@ edx-django-release-util==0.3.1
 edx-django-sites-extensions==2.3.1
 edx-django-utils==1.0.5
 edx-drf-extensions==2.3.1
-edx-enterprise==1.6.9
+edx-enterprise==1.6.7
 edx-i18n-tools==0.4.8
 edx-lint==1.3.0
 edx-milestones==0.2.3

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -125,7 +125,7 @@ edx-django-release-util==0.3.1
 edx-django-sites-extensions==2.3.1
 edx-django-utils==1.0.5
 edx-drf-extensions==2.3.1
-edx-enterprise==1.6.12
+edx-enterprise==1.6.9
 edx-i18n-tools==0.4.8
 edx-lint==1.3.0
 edx-milestones==0.2.3
@@ -133,7 +133,7 @@ edx-oauth2-provider==1.2.2
 edx-opaque-keys[django]==1.0.1
 edx-organizations==2.0.3
 edx-proctoring-proctortrack==1.0.5
-edx-proctoring==2.0.4
+edx-proctoring==2.0.3
 edx-rbac==0.2.1
 edx-rest-api-client==1.9.2
 edx-search==1.2.2
@@ -222,7 +222,7 @@ path.py==8.2.1
 pathlib2==2.3.3
 pathtools==0.1.2
 paver==1.3.4
-pbr==5.3.0
+pbr==5.2.1
 pdfminer.six==20181108
 piexif==1.0.2
 pillow==6.0.0
@@ -316,7 +316,7 @@ tox==3.12.1
 transifex-client==0.13.6
 typing==3.6.6
 unicodecsv==0.14.1
-unidecode==1.1.0
+unidecode==1.0.23
 uritemplate==3.0.0
 urllib3==1.23
 user-util==0.1.5

--- a/requirements/edx/paver.txt
+++ b/requirements/edx/paver.txt
@@ -16,7 +16,7 @@ mock==1.0.1
 path.py==8.2.1
 pathtools==0.1.2          # via watchdog
 paver==1.3.4
-pbr==5.3.0                # via stevedore
+pbr==5.2.1                # via stevedore
 psutil==1.2.1
 pymongo==2.9.1
 python-memcached==1.59

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -121,7 +121,7 @@ edx-django-release-util==0.3.1
 edx-django-sites-extensions==2.3.1
 edx-django-utils==1.0.5
 edx-drf-extensions==2.3.1
-edx-enterprise==1.6.12
+edx-enterprise==1.6.9
 edx-i18n-tools==0.4.8
 edx-lint==1.3.0
 edx-milestones==0.2.3
@@ -129,7 +129,7 @@ edx-oauth2-provider==1.2.2
 edx-opaque-keys[django]==1.0.1
 edx-organizations==2.0.3
 edx-proctoring-proctortrack==1.0.5
-edx-proctoring==2.0.4
+edx-proctoring==2.0.3
 edx-rbac==0.2.1
 edx-rest-api-client==1.9.2
 edx-search==1.2.2
@@ -215,7 +215,7 @@ path.py==8.2.1
 pathlib2==2.3.3           # via importlib-metadata, pytest, pytest-django
 pathtools==0.1.2
 paver==1.3.4
-pbr==5.3.0
+pbr==5.2.1
 pdfminer.six==20181108
 piexif==1.0.2
 pillow==6.0.0
@@ -303,7 +303,7 @@ tox==3.12.1
 transifex-client==0.13.6
 typing==3.6.6             # via flake8
 unicodecsv==0.14.1
-unidecode==1.1.0          # via python-slugify
+unidecode==1.0.23         # via python-slugify
 uritemplate==3.0.0
 urllib3==1.23
 user-util==0.1.5

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -121,7 +121,7 @@ edx-django-release-util==0.3.1
 edx-django-sites-extensions==2.3.1
 edx-django-utils==1.0.5
 edx-drf-extensions==2.3.1
-edx-enterprise==1.6.9
+edx-enterprise==1.6.7
 edx-i18n-tools==0.4.8
 edx-lint==1.3.0
 edx-milestones==0.2.3


### PR DESCRIPTION
This reverts commit bf88bca776fe2291fb09b979856fccbf54dfb8a7.
This reverts commit 375ccb7.

This reverts edx-enterprise back to 1.6.7 - prior to the changes for ENT-1054 and CR-908. While ENT-1054 did fix the issues related to course_run_id and course_keys, it introduced an issue for white-label sites. A fix forward was attempted, but this introduced new issues:

> "Unknown column 'enterprise_enterprisecustomer.catalog' in 'field list'"

This seems likely to the changes in bf88bca.

Reverting this so that platform releases can become unblocked, but we must resolve this issue before we attempt to bump the edx-enterprise version again.