### PR TITLE
Avoid removing TrustedClient tokens after a password reset

### DIFF
--- a/common/djangoapps/student/helpers.py
+++ b/common/djangoapps/student/helpers.py
@@ -376,18 +376,8 @@ def destroy_oauth_tokens(user):
     """
     Destroys ALL OAuth access and refresh tokens for the given user.
     """
-    # Appsembler: Avoid deleting the trusted clients such as the Appsembler Management Console
-    from edx_oauth2_provider.models import TrustedClient
-    from provider.oauth2.models import Client
-    from django.db.models import Subquery
-
-    trusted_clients = Client.objects.filter(pk__in=Subquery(
-        TrustedClient.objects.all().values('id')
-    ))
-
-    dop_access_token.objects.filter(user=user.id).exclude(client__in=trusted_clients).delete()
-    dop_refresh_token.objects.filter(user=user.id).exclude(client__in=trusted_clients).delete()
-
+    dop_access_token.objects.filter(user=user.id).delete()
+    dop_refresh_token.objects.filter(user=user.id).delete()
     dot_access_token.objects.filter(user=user.id).delete()
     dot_refresh_token.objects.filter(user=user.id).delete()
 

--- a/common/djangoapps/student/helpers.py
+++ b/common/djangoapps/student/helpers.py
@@ -15,15 +15,19 @@ from django.core.validators import ValidationError
 from django.contrib.auth import load_backend
 from django.contrib.auth.models import User
 from django.db import IntegrityError, transaction
+from django.db.models import Subquery
 from django.utils import http
 from django.utils.translation import ugettext as _
 from oauth2_provider.models import AccessToken as dot_access_token
 from oauth2_provider.models import RefreshToken as dot_refresh_token
+from provider.constants import CONFIDENTIAL
 from provider.oauth2.models import AccessToken as dop_access_token
+from provider.oauth2.models import Client
 from provider.oauth2.models import RefreshToken as dop_refresh_token
 from pytz import UTC
 from six import iteritems, text_type
 import third_party_auth
+from edx_oauth2_provider.models import TrustedClient
 from course_modes.models import CourseMode
 from lms.djangoapps.certificates.api import (
     get_certificate_url,
@@ -376,8 +380,22 @@ def destroy_oauth_tokens(user):
     """
     Destroys ALL OAuth access and refresh tokens for the given user.
     """
-    dop_access_token.objects.filter(user=user.id).delete()
-    dop_refresh_token.objects.filter(user=user.id).delete()
+    dop_access_query = dop_access_token.objects.filter(user=user.id)
+    dop_refresh_query = dop_refresh_token.objects.filter(user=user.id)
+
+    if settings.FEATURES.get('KEEP_TRUSTED_CONFIDENTIAL_CLIENT_TOKENS', False):
+        # Appsembler: Avoid deleting the trusted confidential clients such as the Appsembler Management Console
+        trusted_clients = Client.objects.filter(
+            client_type=CONFIDENTIAL,
+            pk__in=Subquery(TrustedClient.objects.all().values('id')),
+        )
+
+        dop_access_query = dop_access_query.exclude(client__in=trusted_clients)
+        dop_refresh_query = dop_refresh_query.exclude(client__in=trusted_clients)
+
+    dop_access_query.delete()
+    dop_refresh_query.delete()
+
     dot_access_token.objects.filter(user=user.id).delete()
     dot_refresh_token.objects.filter(user=user.id).delete()
 

--- a/common/djangoapps/student/helpers.py
+++ b/common/djangoapps/student/helpers.py
@@ -376,8 +376,18 @@ def destroy_oauth_tokens(user):
     """
     Destroys ALL OAuth access and refresh tokens for the given user.
     """
-    dop_access_token.objects.filter(user=user.id).delete()
-    dop_refresh_token.objects.filter(user=user.id).delete()
+    # Appsembler: Avoid deleting the trusted clients such as the Appsembler Management Console
+    from edx_oauth2_provider.models import TrustedClient
+    from provider.oauth2.models import Client
+    from django.db.models import Subquery
+
+    trusted_clients = Client.objects.filter(pk__in=Subquery(
+        TrustedClient.objects.all().values('id')
+    ))
+
+    dop_access_token.objects.filter(user=user.id).exclude(client__in=trusted_clients).delete()
+    dop_refresh_token.objects.filter(user=user.id).exclude(client__in=trusted_clients).delete()
+
     dot_access_token.objects.filter(user=user.id).delete()
     dot_refresh_token.objects.filter(user=user.id).delete()
 

--- a/common/djangoapps/student/tests/test_helpers.py
+++ b/common/djangoapps/student/tests/test_helpers.py
@@ -13,7 +13,17 @@ from django.utils import http
 from mock import patch
 from testfixtures import LogCapture
 
-from student.helpers import get_next_url_for_login_page
+from student.helpers import destroy_oauth_tokens, get_next_url_for_login_page
+from student.tests.factories import UserFactory
+from edx_oauth2_provider.models import TrustedClient
+from edx_oauth2_provider.tests.factories import (
+    TrustedClientFactory,
+    AccessTokenFactory,
+    ClientFactory,
+    RefreshTokenFactory,
+)
+from provider.oauth2.models import AccessToken, RefreshToken
+
 from openedx.core.djangoapps.site_configuration.tests.test_util import with_site_configuration_context
 
 LOGGER_NAME = "student.helpers"
@@ -110,3 +120,35 @@ class TestLoginHelper(TestCase):
 
         with with_site_configuration_context(configuration=dict(THIRD_PARTY_AUTH_HINT=tpa_hint)):
             validate_login()
+
+
+class TestDestroyOAuthTokensHelper(TestCase):
+    def setUp(self):
+        super(TestDestroyOAuthTokensHelper, self).setUp()
+        self.user = UserFactory.create()
+        self.client = ClientFactory(logout_uri='https://amc.example.com/logout/')
+        access_token = AccessTokenFactory.create(user=self.user, client=self.client)
+        RefreshTokenFactory.create(user=self.user, client=self.client, access_token=access_token)
+
+    def test_trusted_client(self):
+        """
+        Tokens that have a TurstedClient shouldn't be removed.
+        """
+        TrustedClientFactory.create(client=self.client)
+
+        assert AccessToken.objects.count()  # Sanity check
+        assert RefreshToken.objects.count()  # Sanity check
+        destroy_oauth_tokens(self.user)
+        assert AccessToken.objects.count(), 'Trusted access tokens should be kept'
+        assert RefreshToken.objects.count(), 'Trusted refresh tokens should be kept'
+
+    def test_no_trusted_client(self):
+        """
+        Only tokens that don't have a TurstedClient should be removed.
+        """
+        assert not TrustedClient.objects.count()  # 'Sanity check, there should not be a client'
+        assert AccessToken.objects.count()  # Sanity check
+        assert RefreshToken.objects.count()  # Sanity check
+        destroy_oauth_tokens(self.user)
+        assert not AccessToken.objects.count(), 'All access tokens should be deleted'
+        assert not RefreshToken.objects.count(), 'All refresh tokens should be deleted'


### PR DESCRIPTION
This is a chery-pick from Hawthorn (https://github.com/appsembler/edx-platform/pull/398). It needs rebasing, but I'll do that after product review.

### What's the Issue?
We found out that both of the Access and Refresh tokens of a TrustedClient are removed after a password reset by the `destroy_oauth_tokens` method.

These tokens should only be removed for untrusted clients such as mobile apps or third party apps. A trusted client such as the edX Marketing site (for example) should retain those tokens and only be removed in the case of a marketing site security compromise.

This pull request fixes the issue by avoid removing the tokens for `TrustedClient`s.

See: https://courses.edx.org/admin/edx_oauth2_provider/trustedclient/