### PR TITLE
Add CSRF_TRUSTED_ORIGINS settings

### DIFF
--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -2314,6 +2314,7 @@ CSRF_COOKIE_AGE = 60 * 60 * 24 * 7 * 52
 # It is highly recommended that you override this in any environment accessed by
 # end users
 CSRF_COOKIE_SECURE = False
+CSRF_TRUSTED_ORIGINS = []
 
 ######################### Django Rest Framework ########################
 

--- a/lms/envs/production.py
+++ b/lms/envs/production.py
@@ -428,6 +428,9 @@ NOTIFICATION_EMAIL_EDX_LOGO = ENV_TOKENS.get('NOTIFICATION_EMAIL_EDX_LOGO', NOTI
 # by end users.
 CSRF_COOKIE_SECURE = ENV_TOKENS.get('CSRF_COOKIE_SECURE', False)
 
+# Determines which origins are trusted for unsafe requests eg. POST requests.
+CSRF_TRUSTED_ORIGINS = ENV_TOKENS.get('CSRF_TRUSTED_ORIGINS', [])
+
 # Whitelist of domains to which the login/logout pages will redirect.
 LOGIN_REDIRECT_WHITELIST = ENV_TOKENS.get('LOGIN_REDIRECT_WHITELIST', LOGIN_REDIRECT_WHITELIST)
 


### PR DESCRIPTION
This PR adds a config variable CSRF_TRUSTED_ORIGINS that will let learner portal origin to be trusted when making a POST call to LMS. 

[ENT-2025](https://openedx.atlassian.net/browse/ENT-2025)