### PR TITLE
Fix CSRF referrer not matching learner portal origin - ENT-2025

### DIFF
--- a/openedx/core/djangoapps/user_api/views.py
+++ b/openedx/core/djangoapps/user_api/views.py
@@ -264,7 +264,6 @@ class UpdateEmailOptInPreference(APIView):
     permission_classes = (IsAuthenticated,)
 
     @method_decorator(require_post_params(["course_id", "email_opt_in"]))
-    @method_decorator(ensure_csrf_cookie)
     def post(self, request):
         """ Post function for updating the email opt in preference.
 


### PR DESCRIPTION
This PR removes `ensure_csrf_cookie` method decorator on POST method of email opt in view. We are removing this because `ensure_csrf_cookie` should be applied on the views which are responsible for serving the HTML template therefore it is unnecessary applied on POST method.

This will help resolve "CSRF Failed: Referer checking failed - https://testorg.stage.edx.org/ does not match any trusted origins" error when saving email opt in settings in learner portal.

[ENT-2025](https://openedx.atlassian.net/browse/ENT-2025)