### PR TITLE
remove staff exemption from the library_content transformer

### DIFF
--- a/lms/djangoapps/course_blocks/transformers/library_content.py
+++ b/lms/djangoapps/course_blocks/transformers/library_content.py
@@ -26,7 +26,7 @@ class ContentLibraryTransformer(FilteringTransformerMixin, BlockStructureTransfo
     blocks within a library_content module to which a user should not
     have access.
 
-    Staff users are to exempted from library content pathways.
+    Staff users are not to be exempted from library content pathways.
     """
     WRITE_VERSION = 1
     READ_VERSION = 1
@@ -127,10 +127,8 @@ class ContentLibraryTransformer(FilteringTransformerMixin, BlockStructureTransfo
             Return True if selected block should be removed.
 
             Block is removed if it is part of library_content, but has
-            not been selected for current user, with staff as an exemption.
+            not been selected for current user.
             """
-            if usage_info.has_staff_access:
-                return False
             if block_key not in all_library_children:
                 return False
             if block_key in all_selected_children:

--- a/lms/djangoapps/course_blocks/transformers/tests/test_library_content.py
+++ b/lms/djangoapps/course_blocks/transformers/tests/test_library_content.py
@@ -168,19 +168,3 @@ class ContentLibraryTransformerTestCase(CourseStructureTestCase):
                 ),
                 u"Expected 'selected' equality failed in iteration {}.".format(i)
             )
-
-    def test_staff_access_to_library_content(self):
-        """
-        To verify that staff member has access to all the library content blocks.
-
-        Scenario: Given a staff member in a course with library content
-        when data is transformed by LibraryContentTransformer
-        none of the unassigned block is removed from the access list
-        and staff member will have access to all the blocks
-        """
-        transformed_blocks = get_course_blocks(
-            self.staff,
-            self.course.location,
-            transformers=self.transformers
-        )
-        self.assertEqual(len(list(transformed_blocks.get_block_keys())), len(self.blocks))


### PR DESCRIPTION
### [PROD-136](https://openedx.atlassian.net/browse/PROD-136)

### Description
For a randomized library content, it is expected that problems are to be assigned randomly to the users regardless of the type. The user should not be able to access any problem that is not assigned to them. This held true even for the staff members. Initially, this caused problems for the staff members when they tried to generate the problem response CSV for a problem within library content that was not assigned to them. The task would fail with an exception. To cater to that, a fix was done in https://github.com/edx/edx-platform/pull/19798 that added staff as an exemption when transforming the blocks. This fix caused another problem where the progress page of the staff users would show all the problems of the library content regardless if they are assigned to them or not. 

After removing the fix that was done, the initial problem didn't happen i.e. if the staff member tried to generate the report for a problem that wasn't assigned to them, the report generated. After further analysis, I came across this PR https://github.com/edx/edx-platform/pull/19507 which was merged shortly after I did the fix. That PR made some enhancements to the problem response csv task and added some checks. This [check](https://github.com/edx/edx-platform/pull/19507/files#diff-7683b9bc4a5398602e597d135a5af15bR618) is the reason that error was no longer happening. In short, we no longer need to keep the staff exemption in the library content.

### Reviewers
- [x] @fysheets 

### Post Review
 - [x] Squash & Rebase commit