### PR TITLE
bump code annotations

### DIFF
--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -105,7 +105,7 @@ edx-django-release-util==0.3.1
 edx-django-sites-extensions==2.3.1
 edx-django-utils==1.0.5
 edx-drf-extensions==2.3.1
-edx-enterprise==1.6.15
+edx-enterprise==1.6.17
 edx-i18n-tools==0.4.8
 edx-milestones==0.2.3
 edx-oauth2-provider==1.2.2
@@ -123,7 +123,7 @@ edx-when==0.1.6
 edxval==1.1.25
 elasticsearch==1.9.0      # via edx-search
 enum34==1.1.6
-event-tracking==0.2.8
+event-tracking==0.2.9
 feedparser==5.1.3
 firebase-token-generator==1.3.2
 fs-s3fs==0.1.8

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -53,7 +53,7 @@ cffi==1.12.3
 chardet==3.0.4
 click-log==0.3.2
 click==7.0
-code-annotations==0.3.1
+code-annotations==0.3.2
 colorama==0.4.1
 configparser==3.7.4
 contextlib2==0.5.5
@@ -125,7 +125,7 @@ edx-django-release-util==0.3.1
 edx-django-sites-extensions==2.3.1
 edx-django-utils==1.0.5
 edx-drf-extensions==2.3.1
-edx-enterprise==1.6.15
+edx-enterprise==1.6.17
 edx-i18n-tools==0.4.8
 edx-lint==1.3.0
 edx-milestones==0.2.3
@@ -146,7 +146,7 @@ edxval==1.1.25
 elasticsearch==1.9.0
 entrypoints==0.3
 enum34==1.1.6
-event-tracking==0.2.8
+event-tracking==0.2.9
 execnet==1.6.0
 factory_boy==2.8.1
 faker==1.0.7
@@ -316,7 +316,7 @@ tox==3.12.1
 transifex-client==0.13.6
 typing==3.7.4
 unicodecsv==0.14.1
-unidecode==1.1.0
+unidecode==1.1.1
 uritemplate==3.0.0
 urllib3==1.23
 user-util==0.1.5

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -51,7 +51,7 @@ cffi==1.12.3
 chardet==3.0.4
 click-log==0.3.2          # via edx-lint
 click==7.0
-code-annotations==0.3.1
+code-annotations==0.3.2
 colorama==0.4.1           # via radon
 configparser==3.7.4       # via entrypoints, flake8, importlib-metadata, pylint
 contextlib2==0.5.5        # via importlib-metadata
@@ -121,7 +121,7 @@ edx-django-release-util==0.3.1
 edx-django-sites-extensions==2.3.1
 edx-django-utils==1.0.5
 edx-drf-extensions==2.3.1
-edx-enterprise==1.6.15
+edx-enterprise==1.6.17
 edx-i18n-tools==0.4.8
 edx-lint==1.3.0
 edx-milestones==0.2.3
@@ -141,7 +141,7 @@ edxval==1.1.25
 elasticsearch==1.9.0
 entrypoints==0.3          # via flake8
 enum34==1.1.6
-event-tracking==0.2.8
+event-tracking==0.2.9
 execnet==1.6.0            # via pytest-xdist
 factory_boy==2.8.1
 faker==1.0.7              # via factory-boy
@@ -303,7 +303,7 @@ tox==3.12.1
 transifex-client==0.13.6
 typing==3.7.4             # via flake8
 unicodecsv==0.14.1
-unidecode==1.1.0          # via python-slugify
+unidecode==1.1.1          # via python-slugify
 uritemplate==3.0.0
 urllib3==1.23
 user-util==0.1.5


### PR DESCRIPTION
As part of the feature toggle report generator, we need to have code-annotations installed in each IDA that we want to report on. This will be used to gather data on the in-code definitions of feature toggles.