### PR TITLE
Check if enterprise matches site before consent

### DIFF
--- a/openedx/features/enterprise_support/api.py
+++ b/openedx/features/enterprise_support/api.py
@@ -8,6 +8,7 @@ from functools import wraps
 
 from django.conf import settings
 from django.contrib.auth.models import User
+from django.contrib.sites.models import Site
 from django.core.cache import cache
 from django.shortcuts import redirect
 from django.template.loader import render_to_string
@@ -462,7 +463,8 @@ def consent_needed_for_course(request, user, course_id, enrollment_exists=False)
     else:
         client = ConsentApiClient(user=request.user)
         consent_needed = any(
-            client.consent_required(
+            Site.objects.get(domain=learner['enterprise_customer']['site']['domain']) == request.site
+            and client.consent_required(
                 username=user.username,
                 course_id=course_id,
                 enterprise_customer_uuid=learner['enterprise_customer']['uuid'],

--- a/openedx/features/enterprise_support/tests/test_api.py
+++ b/openedx/features/enterprise_support/tests/test_api.py
@@ -15,6 +15,7 @@ from django.core.cache import cache
 from django.http import HttpResponseRedirect
 from django.test.utils import override_settings
 from django.urls import reverse
+from openedx.core.djangoapps.site_configuration.tests.factories import SiteFactory
 from openedx.core.djangolib.testing.utils import CacheIsolationTestCase, skip_unless_lms
 from openedx.features.enterprise_support.api import (
     ConsentApiClient,
@@ -169,7 +170,7 @@ class TestEnterpriseApi(EnterpriseServiceMockMixin, CacheIsolationTestCase):
     @httpretty.activate
     def test_consent_needed_for_course(self):
         user = UserFactory(username='janedoe')
-        request = mock.MagicMock(session={}, user=user)
+        request = mock.MagicMock(session={}, user=user, site=SiteFactory(domain="example.com"))
         ec_uuid = 'cf246b88-d5f6-4908-a522-fc307e0b0c59'
         course_id = 'fake-course'
         self.mock_enterprise_learner_api()


### PR DESCRIPTION
We don't support enterprises with catalogs that span sites, so we can
safely ignore checking for consent when the site a learner is viewing a
course in is different than the enterprise that the learner is linked
to.