### PR TITLE
EDUCATOR-4413 - Update LMS API to send correct response status code

### DIFF
--- a/lms/djangoapps/program_enrollments/api/v1/tests/test_views.py
+++ b/lms/djangoapps/program_enrollments/api/v1/tests/test_views.py
@@ -474,7 +474,7 @@ class BaseCourseEnrollmentTestsMixin(ProgramCacheTestCaseMixin):
     )
     def test_422_unprocessable_entity_bad_data(self, request_data):
         response = self.request(self.default_url, request_data)
-        self.assertEqual(response.status_code, 422)
+        self.assertEqual(response.status_code, 400)
         self.assertIn('invalid enrollment record', response.data)
 
     @ddt.data(
@@ -487,7 +487,7 @@ class BaseCourseEnrollmentTestsMixin(ProgramCacheTestCaseMixin):
         request_data.extend(bad_records)
         response = self.request(self.default_url, request_data)
 
-        self.assertEqual(response.status_code, status.HTTP_422_UNPROCESSABLE_ENTITY)
+        self.assertEqual(response.status_code, 400)
         self.assertIn('invalid enrollment record', response.data)
 
 
@@ -976,7 +976,8 @@ class ProgramEnrollmentViewPostTests(APITestCase):
                     content_type='application/json'
                 )
 
-        self.assertEqual(response.status_code, status.HTTP_422_UNPROCESSABLE_ENTITY)
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.data, 'invalid enrollment record')
 
     def test_unauthenticated(self):
         self.client.logout()
@@ -1056,7 +1057,7 @@ class ProgramEnrollmentViewPostTests(APITestCase):
             ):
                 response = self.client.post(url, json.dumps(enrollments), content_type='application/json')
 
-        self.assertEqual(422, response.status_code)
+        self.assertEqual(400, response.status_code)
         self.assertEqual('invalid enrollment record', response.data)
 
     @ddt.data(REQUEST_STUDENT_KEY, 'status', 'curriculum_uuid')
@@ -1074,7 +1075,7 @@ class ProgramEnrollmentViewPostTests(APITestCase):
             ):
                 response = self.client.post(url, json.dumps(enrollments), content_type='application/json')
 
-        self.assertEqual(422, response.status_code)
+        self.assertEqual(400, response.status_code)
         self.assertEqual('invalid enrollment record', response.data)
 
     @ddt.data(
@@ -1094,7 +1095,7 @@ class ProgramEnrollmentViewPostTests(APITestCase):
             ):
                 response = self.client.post(url, json.dumps(enrollments), content_type='application/json')
 
-        self.assertEqual(response.status_code, status.HTTP_422_UNPROCESSABLE_ENTITY)
+        self.assertEqual(response.status_code, 400)
         self.assertEqual('invalid enrollment record', response.data)
 
 
@@ -1229,7 +1230,8 @@ class ProgramEnrollmentViewPatchTests(APITestCase):
                 content_type='application/json'
             )
 
-        self.assertEqual(response.status_code, status.HTTP_422_UNPROCESSABLE_ENTITY)
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.data, 'invalid enrollment record')
 
     def test_duplicate_enrollment(self):
         enrollments = {}
@@ -1332,7 +1334,7 @@ class ProgramEnrollmentViewPatchTests(APITestCase):
         with mock.patch('lms.djangoapps.program_enrollments.api.v1.views.get_programs', autospec=True):
             response = self.client.patch(url, json.dumps(enrollments), content_type='application/json')
 
-        self.assertEqual(422, response.status_code)
+        self.assertEqual(400, response.status_code)
         self.assertEqual('invalid enrollment record', response.data)
 
 

--- a/lms/djangoapps/program_enrollments/api/v1/views.py
+++ b/lms/djangoapps/program_enrollments/api/v1/views.py
@@ -356,7 +356,7 @@ class ProgramEnrollmentsView(DeveloperErrorViewMixin, PaginatedAPIView):
         if None in student_data:
             return Response(
                 'invalid enrollment record',
-                status.HTTP_422_UNPROCESSABLE_ENTITY
+                status.HTTP_400_BAD_REQUEST
             )
 
         response_data = {}
@@ -385,7 +385,7 @@ class ProgramEnrollmentsView(DeveloperErrorViewMixin, PaginatedAPIView):
                 else:
                     return Response(
                         'invalid enrollment record',
-                        status.HTTP_422_UNPROCESSABLE_ENTITY
+                        status.HTTP_400_BAD_REQUEST
                     )
 
         # TODO: make this a bulk save - https://openedx.atlassian.net/browse/EDUCATOR-4305
@@ -410,7 +410,7 @@ class ProgramEnrollmentsView(DeveloperErrorViewMixin, PaginatedAPIView):
         if None in student_data:
             return Response(
                 'invalid enrollment record',
-                status.HTTP_422_UNPROCESSABLE_ENTITY
+                status.HTTP_400_BAD_REQUEST
             )
 
         response_data = {}
@@ -725,7 +725,7 @@ class ProgramCourseEnrollmentsView(DeveloperErrorViewMixin, ProgramCourseRunSpec
         enrollments = []
 
         if not isinstance(request.data, list):
-            return Response('invalid enrollment record', status.HTTP_422_UNPROCESSABLE_ENTITY)
+            return Response('invalid enrollment record', status.HTTP_400_BAD_REQUEST)
         if len(request.data) > MAX_ENROLLMENT_RECORDS:
             return Response(
                 'enrollment limit 25', status.HTTP_413_REQUEST_ENTITY_TOO_LARGE
@@ -739,11 +739,11 @@ class ProgramCourseEnrollmentsView(DeveloperErrorViewMixin, ProgramCourseRunSpec
                 else:
                     enrollments.append(enrollment_request)
         except KeyError:  # student_key is not in enrollment_request
-            return Response('invalid enrollment record', status.HTTP_422_UNPROCESSABLE_ENTITY)
+            return Response('invalid enrollment record', status.HTTP_400_BAD_REQUEST)
         except TypeError:  # enrollment_request isn't a dict
-            return Response('invalid enrollment record', status.HTTP_422_UNPROCESSABLE_ENTITY)
+            return Response('invalid enrollment record', status.HTTP_400_BAD_REQUEST)
         except ValidationError:  # there was some other error raised by the serializer
-            return Response('invalid enrollment record', status.HTTP_422_UNPROCESSABLE_ENTITY)
+            return Response('invalid enrollment record', status.HTTP_400_BAD_REQUEST)
 
         program_enrollments = self.get_existing_program_enrollments(program_uuid, enrollments)
         for enrollment in enrollments:


### PR DESCRIPTION
https://openedx.atlassian.net/browse/EDUCATOR-4413

This change would update the status we send in case of enrollment data error as 400 rather than 422.

@edx/masters-neem Please review