### PR TITLE
EDUCATOR-4353 - backend - send simple history via api

### DIFF
--- a/lms/djangoapps/grades/rest_api/serializers.py
+++ b/lms/djangoapps/grades/rest_api/serializers.py
@@ -76,15 +76,23 @@ class SubsectionGradeSerializer(serializers.Serializer):
     possible_graded = serializers.FloatField()
 
 
-class SubsectionGradeOverrideHistorySerializer(serializers.Serializer):
+class SubsectionGradeOverrideSimpleHistorySerializer(serializers.Serializer):
     """
     Serializer for subsection grade override history.
     """
-    user = serializers.CharField()
-    comments = serializers.CharField()
     created = serializers.DateTimeField()
-    feature = serializers.CharField()
-    action = serializers.CharField()
+    grade_id = serializers.IntegerField()
+    history_id = serializers.IntegerField()
+    earned_all_override = serializers.FloatField()
+    earned_graded_override = serializers.FloatField()
+    history_change_reason = serializers.CharField()
+    history_date = serializers.DateTimeField()
+    history_type = serializers.CharField()
+    history_user = serializers.CharField()
+    history_user_id = serializers.IntegerField()
+    id = serializers.IntegerField()
+    possible_all_override = serializers.FloatField()
+    possible_graded_override = serializers.FloatField()
 
 
 class SubsectionGradeResponseSerializer(serializers.Serializer):
@@ -96,4 +104,4 @@ class SubsectionGradeResponseSerializer(serializers.Serializer):
     course_id = serializers.CharField()
     original_grade = SubsectionGradeSerializer()
     override = SubsectionGradeOverrideSerializer()
-    history = SubsectionGradeOverrideHistorySerializer(many=True)
+    history = SubsectionGradeOverrideSimpleHistorySerializer(many=True)

--- a/lms/djangoapps/grades/rest_api/v1/gradebook_views.py
+++ b/lms/djangoapps/grades/rest_api/v1/gradebook_views.py
@@ -925,7 +925,7 @@ class SubsectionGradeView(GradeViewMixin, APIView):
 
         try:
             override = original_grade.override
-            history = PersistentSubsectionGradeOverrideHistory.objects.filter(override_id=override.id)
+            history = override.history.all()
         except PersistentSubsectionGradeOverride.DoesNotExist:
             override = None
             history = []
@@ -938,5 +938,4 @@ class SubsectionGradeView(GradeViewMixin, APIView):
             'user_id': original_grade.user_id,
             'course_id': original_grade.course_id,
         })
-
         return Response(results.data)

--- a/lms/djangoapps/grades/rest_api/v1/tests/test_gradebook_views.py
+++ b/lms/djangoapps/grades/rest_api/v1/tests/test_gradebook_views.py
@@ -1447,7 +1447,8 @@ class SubsectionGradeViewTest(GradebookViewTestBase):
         'login_course_admin',
         'login_course_staff',
     )
-    def test_with_override_no_history(self, login_method):
+    @freeze_time('2019-01-01')
+    def test_with_override_no_modification(self, login_method):
         getattr(self, login_method)()
 
         override = PersistentSubsectionGradeOverride.objects.create(
@@ -1478,10 +1479,24 @@ class SubsectionGradeViewTest(GradebookViewTestBase):
             ]),
             'course_id': text_type(self.course_key),
             'subsection_id': text_type(self.usage_key),
-            'history': []
+            'history': [OrderedDict([
+                ('created', '2019-01-01T00:00:00Z'),
+                ('grade_id', 1),
+                ('history_id', 1),
+                ('earned_all_override', 0.0),
+                ('earned_graded_override', 0.0),
+                ('history_change_reason', None),
+                ('history_date', '2019-01-01T00:00:00Z'),
+                ('history_type', u'+'),
+                ('history_user', None),
+                ('history_user_id', None),
+                ('id', 1),
+                ('possible_all_override', 12.0),
+                ('possible_graded_override', 8.0),
+            ])],
         }
 
-        self.assertEqual(expected_data, resp.data)
+        assert expected_data == resp.data
 
     @ddt.data(
         'login_staff',
@@ -1520,16 +1535,24 @@ class SubsectionGradeViewTest(GradebookViewTestBase):
             ]),
             'course_id': text_type(self.course_key),
             'subsection_id': text_type(self.usage_key),
-            'history': [{
-                'user': self.global_staff.username,
-                'comments': None,
-                'created': '2019-01-01T00:00:00Z',
-                'feature': 'GRADEBOOK',
-                'action': 'CREATEORUPDATE'
-            }]
+            'history': [OrderedDict([
+                ('created', '2019-01-01T00:00:00Z'),
+                ('grade_id', 1),
+                ('history_id', 1),
+                ('earned_all_override', 0.0),
+                ('earned_graded_override', 0.0),
+                ('history_change_reason', 'GRADEBOOK'),
+                ('history_date', '2019-01-01T00:00:00Z'),
+                ('history_type', u'+'),
+                ('history_user', None),
+                ('history_user_id', None),
+                ('id', 1),
+                ('possible_all_override', 12.0),
+                ('possible_graded_override', 8.0),
+            ])],
         }
 
-        self.assertEqual(expected_data, resp.data)
+        assert expected_data == resp.data
 
     @ddt.data(
         'login_staff',


### PR DESCRIPTION
Update backend code to send simple history via API instead of manual table