### PR TITLE
SE-1199 Campus.il Fix unicode username hints with SSO

### DIFF
--- a/common/djangoapps/third_party_auth/settings.py
+++ b/common/djangoapps/third_party_auth/settings.py
@@ -11,7 +11,7 @@ If true, it:
 """
 
 from __future__ import absolute_import
-
+from django.conf import settings
 from openedx.features.enterprise_support.api import insert_enterprise_pipeline_elements
 
 
@@ -41,6 +41,9 @@ def apply_settings(django_settings):
 
     # Adding extra key value pair in the url query string for microsoft as per request
     django_settings.SOCIAL_AUTH_AZUREAD_OAUTH2_AUTH_EXTRA_ARGUMENTS = {'msafed': 0}
+
+    # Avoid default username check to allow non-ascii characters
+    django_settings.SOCIAL_AUTH_CLEAN_USERNAMES = not settings.FEATURES.get("ENABLE_UNICODE_USERNAME")
 
     # Inject our customized auth pipeline. All auth backends must work with
     # this pipeline.

--- a/common/djangoapps/third_party_auth/tests/test_settings.py
+++ b/common/djangoapps/third_party_auth/tests/test_settings.py
@@ -4,6 +4,7 @@ from __future__ import absolute_import
 
 import unittest
 
+from mock import patch
 from third_party_auth import provider, settings
 from third_party_auth.tests import testutil
 
@@ -58,3 +59,12 @@ class SettingsUnitTest(testutil.TestCase):
     def test_apply_settings_turns_off_redirect_sanitization(self):
         settings.apply_settings(self.settings)
         self.assertFalse(self.settings.SOCIAL_AUTH_SANITIZE_REDIRECTS)
+
+    def test_apply_settings_avoids_default_username_check(self):
+        # Avoid the default username check where non-ascii characters are not
+        # allowed when unicode username is enabled
+        settings.apply_settings(self.settings)
+        self.assertTrue(self.settings.SOCIAL_AUTH_CLEAN_USERNAMES)   # verify default behavior
+        with patch.dict('django.conf.settings.FEATURES', {'ENABLE_UNICODE_USERNAME': True}):
+            settings.apply_settings(self.settings)
+            self.assertFalse(self.settings.SOCIAL_AUTH_CLEAN_USERNAMES)


### PR DESCRIPTION
Usernames containing unicode characters were reportedly not showing up correctly in the registration form when registered with MOE/SAML, FB and Google.

This change fixes the issue by overriding the django setting `SOCIAL_AUTH_CLEAN_USERNAMES` to disable the default username check that wasn't allowing non-ascii values.

**Sandbox URL**:

- LMS: https://pr20900.sandbox.opencraft.hosting/

- Studio: https://studio.pr20900.sandbox.opencraft.hosting/

**Merge deadline**: None

**Testing instructions**:
Automated tests should verify main functionality.

To test manually, you will need to have SSO setup:

1. Create a Google account with the username/full name containing unicode characters.
2. Go to the [dashboard page](https://pr20900.sandbox.opencraft.hosting/login?next=/dashboard) and sign up with the Google account created earlier.
3. Verify that the username/field field being auto-filled in the registration form is correct.

**Reviewers**:

- [ ] @pomegranited 

- [ ] edX reviewer TBD