### PR TITLE
Adding changes from CT to fix circuit simulator on moder chrome.

### DIFF
--- a/common/lib/xmodule/xmodule/js/src/capa/schematic.js
+++ b/common/lib/xmodule/xmodule/js/src/capa/schematic.js
@@ -5103,7 +5103,7 @@ schematic = (function() {
 	    {
 		offset_x: this.offset_x,
 		offset_y: this.offset_y,
-		parent: edx.HtmlUtils.HTML(this.parent.toString())
+		parent: edx.HtmlUtils.ensureHTML(this.parent.toString())
 	    });
 	}
 

--- a/common/lib/xmodule/xmodule/js/src/capa/schematic.js
+++ b/common/lib/xmodule/xmodule/js/src/capa/schematic.js
@@ -2810,7 +2810,7 @@ schematic = (function() {
 			    // for each requested freq, interpolate response value
 			    for (var k = 1; k < flist.length; k++) {
 				var f = flist[k];
-				var v = interpolate(f,x_values,values);
+				var v = interpolate(f,x_values,values);  //xss-lint: disable=javascript-interpolate
 				// convert to dB
 				fvlist.push([f,v == undefined ? 'undefined' : 20.0 * Math.log(v)/Math.LN10]);
 			    }
@@ -2932,7 +2932,7 @@ schematic = (function() {
 				    // for each requested time, interpolate waveform value
 				    for (var k = 1; k < tlist.length; k++) {
 					var t = tlist[k];
-					var v = interpolate(t,times,values);
+					var v = interpolate(t,times,values); // xss-lint: disable=javascript-interpolate
 					tvlist.push([t,v == undefined ? 'undefined' : v]);
 				    }
 				    // save results as list of [t,value] pairs
@@ -2978,7 +2978,7 @@ schematic = (function() {
 
 	// t is the time at which we want a value
 	// times is a list of timepoints from the simulation
-	function interpolate(t,times,values) {
+	function interpolate(t,times,values) { // xss-lint: disable=javascript-interpolate
 	    if (values == undefined) return undefined;
 
 	    for (var i = 0; i < times.length; i++)
@@ -4588,7 +4588,7 @@ schematic = (function() {
 	    this.canvas.style.cursor = 'default';
 	    this.canvas.height = part_w;
 	    this.canvas.width = part_h;
-	    this.canvas.part = this;
+	    this.canvas.xpart = this;
 
 	    this.canvas.addEventListener('mouseover',part_enter,false);
 	    this.canvas.addEventListener('mouseout',part_leave,false);
@@ -4680,7 +4680,7 @@ schematic = (function() {
 	function part_enter(event) {
 	    if (!event) event = window.event;
 	    var canvas = (window.event) ? event.srcElement : event.target;
-	    var part = canvas.part;
+	    var part = canvas.xpart;
 
 	    // avoid Chrome bug that changes to text cursor whenever
 	    // drag starts.  We'll restore the default handler at
@@ -4697,7 +4697,7 @@ schematic = (function() {
 	function part_leave(event) {
 	    if (!event) event = window.event;
 	    var canvas = (window.event) ? event.srcElement : event.target;
-	    var part = canvas.part;
+	    var part = canvas.xpart;
 
 	    if (typeof part.sch.new_part == 'undefined') {
 		// leaving with no part selected?  revert handler
@@ -4711,7 +4711,7 @@ schematic = (function() {
 
 	function part_mouse_down(event) {
 	    if (!event) event = window.event;
-	    var part = (window.event) ? event.srcElement.part : event.target.part;
+	    var part = (window.event) ? event.srcElement.xpart : event.target.xpart;
 
 	    part.select(true);
 	    part.sch.new_part = part;
@@ -4720,7 +4720,7 @@ schematic = (function() {
 
 	function part_mouse_up(event) {
 	    if (!event) event = window.event;
-	    var part = (window.event) ? event.srcElement.part : event.target.part;
+	    var part = (window.event) ? event.srcElement.xpart : event.target.xpart;
 
 	    part.select(false);
 	    part.sch.new_part = undefined;
@@ -5099,8 +5099,14 @@ schematic = (function() {
 	}
 
 	ConnectionPoint.prototype.toString = function() {
-	    return '<ConnectionPoint ('+this.offset_x+','+this.offset_y+') '+this.parent.toString()+'>';
+	    return edx.StringUtils.interpolate('<ConnectionPoint ({offset_x},{offset_y}) {parent}>',
+	    {
+		offset_x: this.offset_x,
+		offset_y: this.offset_y,
+		parent: edx.HtmlUtils.HTML(this.parent.toString())
+	    });
 	}
+
 
 	ConnectionPoint.prototype.json = function() {
 	    return this.label;
@@ -5213,9 +5219,16 @@ schematic = (function() {
 	}
 	Wire.prototype = new Component();
 	Wire.prototype.constructor = Wire;
-
-	Wire.prototype.toString = function() {
-	    return '<Wire ('+this.x+','+this.y+') ('+(this.x+this.dx)+','+(this.y+this.dy)+')>';
+    
+        Wire.prototype.toString = function() {
+	    return edx.StringUtils.interpolate(
+		'<Wire ({x},{y}) ({x_plus_dx},{y_plus_dy})>',
+		{
+		    x: this.x,
+		    y: this.y,
+		    x_plus_dx: this.x + this.dx,
+		    y_plus_dy: this.y + this.dy
+		});
 	}
 
 	// return connection point at other end of wire from specified cp
@@ -5328,9 +5341,14 @@ schematic = (function() {
 	Ground.prototype.constructor = Ground;
 
 	Ground.prototype.toString = function() {
-	    return '<Ground ('+this.x+','+this.y+')>';
+	    return edx.StringUtils.interpolate(
+		'<Ground ({x},{y})>',
+		{
+		    x: this.x,
+		    y: this.y
+		});
 	}
-
+    
 	Ground.prototype.draw = function(c) {
 	    Component.prototype.draw.call(this,c);   // give superclass a shot
 	    this.draw_line(c,0,0,0,8);
@@ -5369,7 +5387,12 @@ schematic = (function() {
 	Label.prototype.constructor = Label;
 
 	Label.prototype.toString = function() {
-	    return '<Label'+' ('+this.x+','+this.y+')>';
+	    return edx.StringUtils.interpolate(
+		'<Label ({x},{y})>',
+		{
+		    x: this.x,
+		    y: this.y
+		});
 	}
 
 	Label.prototype.draw = function(c) {
@@ -5418,7 +5441,12 @@ schematic = (function() {
 	Probe.prototype.constructor = Probe;
 
 	Probe.prototype.toString = function() {
-	    return '<Probe ('+this.x+','+this.y+')>';
+	    return edx.StringUtils.interpolate(
+		'<Probe ({x},{y})>',
+		{
+		    x: this.x,
+		    y: this.y
+		});
 	}
 
 	Probe.prototype.draw = function(c) {
@@ -5497,7 +5525,12 @@ schematic = (function() {
 	Ammeter.prototype.constructor = Ammeter;
 
 	Ammeter.prototype.toString = function() {
-	    return '<Ammeter ('+this.x+','+this.y+')>';
+	    return edx.StringUtils.interpolate(
+		'<Ammeter ({x},{y})>',
+		{
+		    x: this.x,
+		    y: this.y
+		});
 	}
 
 	Ammeter.prototype.move_end = function() {
@@ -5591,7 +5624,13 @@ schematic = (function() {
 	Resistor.prototype.constructor = Resistor;
 
 	Resistor.prototype.toString = function() {
-	    return '<Resistor '+this.properties['r']+' ('+this.x+','+this.y+')>';
+	    return edx.StringUtils.interpolate(
+		'<Resistor {r} ({x},{y})>',
+		{
+		    r: this.properties['r'],
+		    x: this.x,
+		    y: this.y
+		});
 	}
 
 	Resistor.prototype.draw = function(c) {
@@ -5634,7 +5673,13 @@ schematic = (function() {
 	Capacitor.prototype.constructor = Capacitor;
 
 	Capacitor.prototype.toString = function() {
-	    return '<Capacitor '+this.properties['r']+' ('+this.x+','+this.y+')>';
+	    return edx.StringUtils.interpolate(
+		'<Capacitor {r} ({x},{y})>',
+		{
+		    r: this.properties['r'],
+		    x: this.x,
+		    y: this.y
+		});
 	}
 
 	Capacitor.prototype.draw = function(c) {
@@ -5672,7 +5717,13 @@ schematic = (function() {
 	Inductor.prototype.constructor = Inductor;
 
 	Inductor.prototype.toString = function() {
-	    return '<Inductor '+this.properties['l']+' ('+this.x+','+this.y+')>';
+	    return edx.StringUtils.interpolate(
+		'<Inductor {l}, ({x},{y})>',
+		{
+		    l: this.properties['l'],
+		    x: this.x,
+		    y: this.y
+		});
 	}
 
 	Inductor.prototype.draw = function(c) {
@@ -5715,7 +5766,13 @@ schematic = (function() {
 	Diode.prototype.constructor = Diode;
 
 	Diode.prototype.toString = function() {
-	    return '<Diode '+this.properties['area']+' ('+this.x+','+this.y+')>';
+	    return edx.StringUtils.interpolate(
+		'<Diode {area} ({x},{y})>',
+		{
+		    area: this.properties['area'],
+		    x: this.x,
+		    y: this.y
+		});
 	}
 
 	Diode.prototype.draw = function(c) {
@@ -5786,7 +5843,13 @@ schematic = (function() {
 	NFet.prototype.constructor = NFet;
 
 	NFet.prototype.toString = function() {
-	    return '<NFet '+this.properties['W/L']+' ('+this.x+','+this.y+')>';
+	    return edx.StringUtils.interpolate(
+		'<NFet {W_L} ({x},{y})>',
+		{
+		    W_L: this.properties['W/L'],
+		    x: this.x,
+		    y: this.y
+		});
 	}
 
 	NFet.prototype.draw = function(c) {
@@ -5831,7 +5894,12 @@ schematic = (function() {
 	PFet.prototype.constructor = PFet;
 
 	PFet.prototype.toString = function() {
-	    return '<PFet '+this.properties['W/L']+' ('+this.x+','+this.y+')>';
+	    return edx.StringUtils.interpolate('<PFet {W_L} ({x},{y})>',
+	    {
+		W_L: this.properties['W/L'],
+		x: this.x,
+		y: this.y
+	    });
 	}
 
 	PFet.prototype.draw = function(c) {
@@ -5878,7 +5946,13 @@ schematic = (function() {
 	OpAmp.prototype.constructor = OpAmp;
 
 	OpAmp.prototype.toString = function() {
-	    return '<OpAmp'+this.properties['A']+' ('+this.x+','+this.y+')>';
+	    return edx.StringUtils.interpolate(
+		'<OpAmp{A} ({x},{y})>',
+		{
+		    A: this.properties['A'],
+		    x: this.x,
+		    y: this.y
+		});
 	}
 
 	OpAmp.prototype.draw = function(c) {
@@ -5927,7 +6001,14 @@ schematic = (function() {
 	Source.prototype.constructor = Source;
 
 	Source.prototype.toString = function() {
-	    return '<'+this.type+'source '+this.properties['params']+' ('+this.x+','+this.y+')>';
+	    return edx.StringUtils.interpolate(
+		'<{type}source {params} ({x},{y})>',
+		{
+		    type: this.type,
+		    params: this.properties['params'],
+		    x: this.x,
+		    y: this.y
+		});
 	}
 
 	Source.prototype.draw = function(c) {


### PR DESCRIPTION
This PR fixes an issue that causes the circuit simulator to not function in modern versions of Chrome.  It is based on a patch provided by Chris Terman of MIT.

> BUG/FIX: selection of parts from the parts bin in schematic problem type no longer works in latest Chrome browser.  Google’s latest update added an attribute to the canvas object that conflicted with an attribute added by schematic.js.  The fix is simple: just rename the attribute added by schematic.js.  

@terman PR based on your patch.

I'll find an internal reviewer to move it along.