### PR TITLE
Don't pin Django to a patch version.

### DIFF
--- a/requirements/edx/base.in
+++ b/requirements/edx/base.in
@@ -35,7 +35,7 @@ boto3==1.4.8                        # Amazon Web Services SDK for Python
 botocore==1.8.17                    # via boto3, s3transfer
 celery==3.1.25                      # Asynchronous task execution library
 defusedxml
-Django==1.11.22                     # Web application framework
+Django<1.12                     # Web application framework
 django-babel-underscore             # underscore template extractor for django-babel (internationalization utilities)
 django-config-models>=1.0.0         # Configuration models for Django allowing config management with auditing
 django-cors-headers==2.1.0          # Used to allow to configure CORS headers for cross-domain requests


### PR DESCRIPTION
Pin to the minor version so that we can get patches via the update
automation.  Since Django is pretty good at SemVer we can rely on these
to be pretty safe and it will speed up our security update process when
Django releases new security patches.