### PR TITLE
Update the version of matplotlib running in sandboxes.

### DIFF
--- a/requirements/edx-sandbox/base.in
+++ b/requirements/edx-sandbox/base.in
@@ -10,7 +10,7 @@
 -c ../constraints.txt
 
 -r shared.txt                       # Dependencies in common with LMS and Studio
-matplotlib==1.3.1                   # 2D plotting library
+matplotlib==1.5.3                   # 2D plotting library
 numpy==1.6.2                        # Numeric array processing utilities; used by scipy
 pyparsing==2.2.0                    # Python Parsing module
 scipy==0.14.0                       # Math, science, and engineering library

--- a/requirements/edx-sandbox/base.txt
+++ b/requirements/edx-sandbox/base.txt
@@ -12,19 +12,20 @@ git+https://github.com/edx/openedx-calc.git@e9b698c85ad1152002bc0868f475f153dce8
 cffi==1.12.3
 git+https://github.com/edx/openedx-chem.git@ff4e3a03d3c7610e47a9af08eb648d8aabe2eb18#egg=chem==1.0.0
 cryptography==2.7
+cycler==0.10.0            # via matplotlib
 enum34==1.1.6
 futures==3.2.0 ; python_version == "2.7"  # via tornado
 ipaddress==1.0.22
 lxml==3.8.0
 markupsafe==1.1.1
-matplotlib==1.3.1
+matplotlib==1.5.3
 networkx==1.7
 nltk==3.4.3
-nose==1.3.7               # via matplotlib
 numpy==1.6.2
 pycparser==2.19
 pyparsing==2.2.0
 python-dateutil==2.8.0    # via matplotlib
+pytz==2019.1              # via matplotlib
 scipy==0.14.0
 singledispatch==3.4.0.3
 six==1.11.0


### PR DESCRIPTION
Changelog can be found here: https://matplotlib.org/1.5.3/users/whats_new.html

This version fixes the odd setup.py in matplotlib that tries to install
numpy as a part of matplotlib setup.py execution.

Looking at the changelog I don't see any incompatibility issues just bug
fixes and feature additions.