### PR TITLE
(BB-1389) Update enrollment serializer and Add problem submission history endpoint

### DIFF
--- a/lms/djangoapps/courseware/access_utils.py
+++ b/lms/djangoapps/courseware/access_utils.py
@@ -9,23 +9,21 @@ from logging import getLogger
 
 from django.conf import settings
 from pytz import UTC
+from xmodule.course_module import COURSE_VISIBILITY_PUBLIC
+from xmodule.util.xmodule_django import get_current_request_hostname
+
+from common.djangoapps.student.models import CourseEnrollment
+from common.djangoapps.student.roles import CourseBetaTesterRole
 from lms.djangoapps.courseware.access_response import (
     AccessResponse,
-    StartDateError,
-    EnrollmentRequiredAccessError,
     AuthenticationRequiredAccessError,
+    EnrollmentRequiredAccessError,
+    StartDateError
 )
 from lms.djangoapps.courseware.masquerade import get_course_masquerade, is_masquerading_as_student
 from openedx.core.djangoapps.util.user_messages import PageLevelMessages  # lint-amnesty, pylint: disable=unused-import
 from openedx.core.djangolib.markup import HTML  # lint-amnesty, pylint: disable=unused-import
-from openedx.features.course_experience import (
-    COURSE_PRE_START_ACCESS_FLAG,
-    COURSE_ENABLE_UNENROLLED_ACCESS_FLAG,
-)
-from common.djangoapps.student.models import CourseEnrollment
-from common.djangoapps.student.roles import CourseBetaTesterRole
-from xmodule.util.xmodule_django import get_current_request_hostname
-from xmodule.course_module import COURSE_VISIBILITY_PUBLIC
+from openedx.features.course_experience import COURSE_ENABLE_UNENROLLED_ACCESS_FLAG, COURSE_PRE_START_ACCESS_FLAG
 
 DEBUG_ACCESS = False
 log = getLogger(__name__)
@@ -75,7 +73,7 @@ def check_start_date(user, days_early_for_beta, start, course_key, display_error
     Returns:
         AccessResponse: Either ACCESS_GRANTED or StartDateError.
     """
-    start_dates_disabled = settings.FEATURES['DISABLE_START_DATES']
+    start_dates_disabled = settings.FEATURES.get('DISABLE_START_DATES', False)
     masquerading_as_student = is_masquerading_as_student(user, course_key)
 
     if start_dates_disabled and not masquerading_as_student:

--- a/lms/djangoapps/support/tests/test_views.py
+++ b/lms/djangoapps/support/tests/test_views.py
@@ -369,7 +369,7 @@ class SupportViewEnrollmentsTests(SharedModuleStoreTestCase, SupportViewTestCase
             'course_id': str(self.course.id),
             'old_mode': CourseMode.AUDIT,
             'new_mode': CourseMode.VERIFIED,
-            'reason': 'Financial Assistance'
+            'reason': u'Financial Assistance'
         })
         entitlement.refresh_from_db()
         assert response.status_code == 200

--- a/lms/envs/test.py
+++ b/lms/envs/test.py
@@ -597,3 +597,17 @@ REGISTRATION_RATELIMIT = '5/minute'
 
 RESET_PASSWORD_TOKEN_VALIDATE_API_RATELIMIT = '2/m'
 RESET_PASSWORD_API_RATELIMIT = '2/m'
+
+COURSE_ENROLLMENT_MODES['test'] = {
+    "id": 8,
+    "slug": u"test",
+    "display_name": u"Test",
+    "min_price": 0
+}
+
+COURSE_ENROLLMENT_MODES['test_mode'] = {
+    "id": 9,
+    "slug": u"test_mode",
+    "display_name": u"Test Mode",
+    "min_price": 0
+}

--- a/openedx/core/djangoapps/content/block_structure/store.py
+++ b/openedx/core/djangoapps/content/block_structure/store.py
@@ -6,6 +6,7 @@ Module for the Storage of BlockStructure objects.
 
 from logging import getLogger
 
+import six
 from django.utils.encoding import python_2_unicode_compatible
 
 from openedx.core.lib.cache_utils import zpickle, zunpickle

--- a/openedx/core/djangoapps/content/block_structure/store.py
+++ b/openedx/core/djangoapps/content/block_structure/store.py
@@ -230,7 +230,7 @@ class BlockStructureStore:
         Returns the cache key to use for the given
         BlockStructureModel or StubModel.
         """
-        if _is_storage_backing_enabled():
+        if config.STORAGE_BACKING_FOR_CACHE.is_enabled():
             return six.text_type(bs_model)
 
         else:

--- a/openedx/core/djangoapps/content/block_structure/store.py
+++ b/openedx/core/djangoapps/content/block_structure/store.py
@@ -230,12 +230,14 @@ class BlockStructureStore:
         Returns the cache key to use for the given
         BlockStructureModel or StubModel.
         """
-        if config.STORAGE_BACKING_FOR_CACHE.is_enabled():
-            return str(bs_model)
-        return "v{version}.root.key.{root_usage_key}".format(
-            version=str(BlockStructureBlockData.VERSION),
-            root_usage_key=str(bs_model.data_usage_key),
-        )
+        if _is_storage_backing_enabled():
+            return six.text_type(bs_model)
+
+        else:
+            return u"v{version}.root.key.{root_usage_key}".format(
+                version=six.text_type(BlockStructureBlockData.VERSION),
+                root_usage_key=six.text_type(bs_model.data_usage_key),
+            )
 
     @staticmethod
     def _version_data_of_block(root_block):

--- a/openedx/core/djangoapps/enrollments/serializers.py
+++ b/openedx/core/djangoapps/enrollments/serializers.py
@@ -5,10 +5,13 @@ Serializers for all Course Enrollment related return objects.
 
 import logging
 
+from django.core.exceptions import PermissionDenied
 from rest_framework import serializers
+from xmodule.modulestore.django import modulestore
 
 from common.djangoapps.course_modes.models import CourseMode
 from common.djangoapps.student.models import CourseEnrollment
+from lms.djangoapps.grades.course_grade_factory import CourseGradeFactory
 
 log = logging.getLogger(__name__)
 
@@ -83,15 +86,49 @@ class CourseEnrollmentSerializer(serializers.ModelSerializer):
 
     """
     course_details = CourseSerializer(source="course_overview")
-    user = serializers.SerializerMethodField('get_username')
+    user = serializers.SerializerMethodField("get_username")
+    finished = serializers.SerializerMethodField()
+    grading = serializers.SerializerMethodField()
 
     def get_username(self, model):
         """Retrieves the username from the associated model."""
         return model.username
 
-    class Meta:
+    def get_finished(self, model):
+        """Retrieve finished course."""
+        course = modulestore().get_course(model.course_id)
+        if course:
+            try:
+                coursegrade = CourseGradeFactory().read(model.user, course).passed
+            except PermissionDenied:
+                return False
+            return coursegrade
+        return False
+
+    def get_grading(self, model):
+        """Retrieve course grade."""
+        course = modulestore().get_course(model.course_id)
+        course_grade = None
+        summary = []
+        current_grade = 0
+        if course:
+            try:
+                course_grade = CourseGradeFactory().read(model.user, course)
+                current_grade = int(course_grade.percent * 100)
+                for section in course_grade.summary.get(u'section_breakdown'):
+                    if section.get(u'prominent'):
+                        summary.append(section)
+            except PermissionDenied:
+                pass
+        return [
+            {u'current_grade': current_grade,
+             u'certificate_eligible': course_grade.passed if course_grade else False,
+             u'summary': summary}
+        ]
+
+    class Meta(object):
         model = CourseEnrollment
-        fields = ('created', 'mode', 'is_active', 'course_details', 'user')
+        fields = ('created', 'mode', 'is_active', 'course_details', 'user', 'finished', 'grading')
         lookup_field = 'username'
 
 

--- a/openedx/core/djangoapps/enrollments/tests/fixtures/course-enrollments-api-list-valid-data.json
+++ b/openedx/core/djangoapps/enrollments/tests/fixtures/course-enrollments-api-list-valid-data.json
@@ -9,14 +9,74 @@
                 "is_active": true,
                 "mode": "honor",
                 "user": "student1",
-                "created": "2018-01-01T00:00:01Z"
+                "created": "2018-01-01T00:00:01Z",
+                "finished": false,
+                "grading": [{
+                    "certificate_eligible": false,
+                    "current_grade": 0,
+                    "summary": [{
+                        "category": "Homework",
+                        "prominent": true,
+                        "percent": 0.0,
+                        "detail": "Homework Average = 0%",
+                        "label": "HW Avg"
+                    },{
+                        "category": "Lab",
+                        "prominent": true,
+                        "percent": 0.0,
+                        "detail": "Lab Average = 0%",
+                        "label": "Lab Avg"
+                    },{
+                        "category": "Midterm Exam",
+                        "prominent": true,
+                        "percent": 0.0,
+                        "detail": "Midterm Exam = 0%",
+                        "label": "Midterm"
+                    },{
+                        "category": "Final Exam",
+                        "prominent": true,
+                        "percent": 0.0,
+                        "detail": "Final Exam = 0%",
+                        "label": "Final"
+                    }]
+                }]
             },
             {
                 "course_id": "e/d/X",
                 "is_active": true,
                 "mode": "honor",
                 "user": "student2",
-                "created": "2018-01-01T00:00:01Z"
+                "created": "2018-01-01T00:00:01Z",
+                "finished": false,
+                "grading": [{
+                    "certificate_eligible": false,
+                    "current_grade": 0,
+                    "summary": [{
+                        "category": "Homework",
+                        "prominent": true,
+                        "percent": 0.0,
+                        "detail": "Homework Average = 0%",
+                        "label": "HW Avg"
+                    },{
+                        "category": "Lab",
+                        "prominent": true,
+                        "percent": 0.0,
+                        "detail": "Lab Average = 0%",
+                        "label": "Lab Avg"
+                    },{
+                        "category": "Midterm Exam",
+                        "prominent": true,
+                        "percent": 0.0,
+                        "detail": "Midterm Exam = 0%",
+                        "label": "Midterm"
+                    },{
+                        "category": "Final Exam",
+                        "prominent": true,
+                        "percent": 0.0,
+                        "detail": "Final Exam = 0%",
+                        "label": "Final"
+                    }]
+                }]
             }
         ]
     ],
@@ -30,21 +90,111 @@
                 "is_active": true,
                 "mode": "verified",
                 "user": "staff",
-                "created": "2018-01-01T00:00:01Z"
+                "created": "2018-01-01T00:00:01Z",
+                "finished": false,
+                "grading": [{
+                    "certificate_eligible": false,
+                    "current_grade": 0,
+                    "summary": [{
+                        "category": "Homework",
+                        "prominent": true,
+                        "percent": 0.0,
+                        "detail": "Homework Average = 0%",
+                        "label": "HW Avg"
+                    },{
+                        "category": "Lab",
+                        "prominent": true,
+                        "percent": 0.0,
+                        "detail": "Lab Average = 0%",
+                        "label": "Lab Avg"
+                    },{
+                        "category": "Midterm Exam",
+                        "prominent": true,
+                        "percent": 0.0,
+                        "detail": "Midterm Exam = 0%",
+                        "label": "Midterm"
+                    },{
+                        "category": "Final Exam",
+                        "prominent": true,
+                        "percent": 0.0,
+                        "detail": "Final Exam = 0%",
+                        "label": "Final"
+                    }]
+                }]
             },
             {
                 "course_id": "x/y/Z",
                 "is_active": true,
                 "mode": "honor",
                 "user": "student2",
-                "created": "2018-01-01T00:00:01Z"
+                "created": "2018-01-01T00:00:01Z",
+                "finished": false,
+                "grading": [{
+                    "certificate_eligible": false,
+                    "current_grade": 0,
+                    "summary": [{
+                        "category": "Homework",
+                        "prominent": true,
+                        "percent": 0.0,
+                        "detail": "Homework Average = 0%",
+                        "label": "HW Avg"
+                    },{
+                        "category": "Lab",
+                        "prominent": true,
+                        "percent": 0.0,
+                        "detail": "Lab Average = 0%",
+                        "label": "Lab Avg"
+                    },{
+                        "category": "Midterm Exam",
+                        "prominent": true,
+                        "percent": 0.0,
+                        "detail": "Midterm Exam = 0%",
+                        "label": "Midterm"
+                    },{
+                        "category": "Final Exam",
+                        "prominent": true,
+                        "percent": 0.0,
+                        "detail": "Final Exam = 0%",
+                        "label": "Final"
+                    }]
+                }]
             },
             {
                 "course_id": "x/y/Z",
                 "is_active": true,
                 "mode": "verified",
                 "user": "student3",
-                "created": "2018-01-01T00:00:01Z"
+                "created": "2018-01-01T00:00:01Z",
+                "finished": false,
+                "grading": [{
+                    "certificate_eligible": false,
+                    "current_grade": 0,
+                    "summary": [{
+                        "category": "Homework",
+                        "prominent": true,
+                        "percent": 0.0,
+                        "detail": "Homework Average = 0%",
+                        "label": "HW Avg"
+                    },{
+                        "category": "Lab",
+                        "prominent": true,
+                        "percent": 0.0,
+                        "detail": "Lab Average = 0%",
+                        "label": "Lab Avg"
+                    },{
+                        "category": "Midterm Exam",
+                        "prominent": true,
+                        "percent": 0.0,
+                        "detail": "Midterm Exam = 0%",
+                        "label": "Midterm"
+                    },{
+                        "category": "Final Exam",
+                        "prominent": true,
+                        "percent": 0.0,
+                        "detail": "Final Exam = 0%",
+                        "label": "Final"
+                    }]
+                }]
             }
         ]
     ],
@@ -59,14 +209,74 @@
                 "is_active": true,
                 "mode": "honor",
                 "user": "student2",
-                "created": "2018-01-01T00:00:01Z"
+                "created": "2018-01-01T00:00:01Z",
+                "finished": false,
+                "grading": [{
+                    "certificate_eligible": false,
+                    "current_grade": 0,
+                    "summary": [{
+                        "category": "Homework",
+                        "prominent": true,
+                        "percent": 0.0,
+                        "detail": "Homework Average = 0%",
+                        "label": "HW Avg"
+                    },{
+                        "category": "Lab",
+                        "prominent": true,
+                        "percent": 0.0,
+                        "detail": "Lab Average = 0%",
+                        "label": "Lab Avg"
+                    },{
+                        "category": "Midterm Exam",
+                        "prominent": true,
+                        "percent": 0.0,
+                        "detail": "Midterm Exam = 0%",
+                        "label": "Midterm"
+                    },{
+                        "category": "Final Exam",
+                        "prominent": true,
+                        "percent": 0.0,
+                        "detail": "Final Exam = 0%",
+                        "label": "Final"
+                    }]
+                }]
             },
             {
                 "course_id": "x/y/Z",
                 "is_active": true,
                 "mode": "verified",
                 "user": "student3",
-                "created": "2018-01-01T00:00:01Z"
+                "created": "2018-01-01T00:00:01Z",
+                "finished": false,
+                "grading": [{
+                    "certificate_eligible": false,
+                    "current_grade": 0,
+                    "summary": [{
+                        "category": "Homework",
+                        "prominent": true,
+                        "percent": 0.0,
+                        "detail": "Homework Average = 0%",
+                        "label": "HW Avg"
+                    },{
+                        "category": "Lab",
+                        "prominent": true,
+                        "percent": 0.0,
+                        "detail": "Lab Average = 0%",
+                        "label": "Lab Avg"
+                    },{
+                        "category": "Midterm Exam",
+                        "prominent": true,
+                        "percent": 0.0,
+                        "detail": "Midterm Exam = 0%",
+                        "label": "Midterm"
+                    },{
+                        "category": "Final Exam",
+                        "prominent": true,
+                        "percent": 0.0,
+                        "detail": "Final Exam = 0%",
+                        "label": "Final"
+                    }]
+                }]
             }
         ]
     ],
@@ -81,7 +291,37 @@
                 "is_active": true,
                 "mode": "honor",
                 "user": "student2",
-                "created": "2018-01-01T00:00:01Z"
+                "created": "2018-01-01T00:00:01Z",
+                "finished": false,
+                "grading": [{
+                    "certificate_eligible": false,
+                    "current_grade": 0,
+                    "summary": [{
+                        "category": "Homework",
+                        "prominent": true,
+                        "percent": 0.0,
+                        "detail": "Homework Average = 0%",
+                        "label": "HW Avg"
+                    },{
+                        "category": "Lab",
+                        "prominent": true,
+                        "percent": 0.0,
+                        "detail": "Lab Average = 0%",
+                        "label": "Lab Avg"
+                    },{
+                        "category": "Midterm Exam",
+                        "prominent": true,
+                        "percent": 0.0,
+                        "detail": "Midterm Exam = 0%",
+                        "label": "Midterm"
+                    },{
+                        "category": "Final Exam",
+                        "prominent": true,
+                        "percent": 0.0,
+                        "detail": "Final Exam = 0%",
+                        "label": "Final"
+                    }]
+                }]
             }
         ]
     ],
@@ -95,21 +335,111 @@
                 "is_active": true,
                 "mode": "verified",
                 "user": "staff",
-                "created": "2018-01-01T00:00:01Z"
+                "created": "2018-01-01T00:00:01Z",
+                "finished": false,
+                "grading": [{
+                    "certificate_eligible": false,
+                    "current_grade": 0,
+                    "summary": [{
+                        "category": "Homework",
+                        "prominent": true,
+                        "percent": 0.0,
+                        "detail": "Homework Average = 0%",
+                        "label": "HW Avg"
+                    },{
+                        "category": "Lab",
+                        "prominent": true,
+                        "percent": 0.0,
+                        "detail": "Lab Average = 0%",
+                        "label": "Lab Avg"
+                    },{
+                        "category": "Midterm Exam",
+                        "prominent": true,
+                        "percent": 0.0,
+                        "detail": "Midterm Exam = 0%",
+                        "label": "Midterm"
+                    },{
+                        "category": "Final Exam",
+                        "prominent": true,
+                        "percent": 0.0,
+                        "detail": "Final Exam = 0%",
+                        "label": "Final"
+                    }]
+                }]
             },
             {
                 "course_id": "e/d/X",
                 "is_active": true,
                 "mode": "honor",
                 "user": "student2",
-                "created": "2018-01-01T00:00:01Z"
+                "created": "2018-01-01T00:00:01Z",
+                "finished": false,
+                "grading": [{
+                    "certificate_eligible": false,
+                    "current_grade": 0,
+                    "summary": [{
+                        "category": "Homework",
+                        "prominent": true,
+                        "percent": 0.0,
+                        "detail": "Homework Average = 0%",
+                        "label": "HW Avg"
+                    },{
+                        "category": "Lab",
+                        "prominent": true,
+                        "percent": 0.0,
+                        "detail": "Lab Average = 0%",
+                        "label": "Lab Avg"
+                    },{
+                        "category": "Midterm Exam",
+                        "prominent": true,
+                        "percent": 0.0,
+                        "detail": "Midterm Exam = 0%",
+                        "label": "Midterm"
+                    },{
+                        "category": "Final Exam",
+                        "prominent": true,
+                        "percent": 0.0,
+                        "detail": "Final Exam = 0%",
+                        "label": "Final"
+                    }]
+                }]
             },
             {
                 "course_id": "x/y/Z",
                 "is_active": true,
                 "mode": "honor",
                 "user": "student2",
-                "created": "2018-01-01T00:00:01Z"
+                "created": "2018-01-01T00:00:01Z",
+                "finished": false,
+                "grading": [{
+                    "certificate_eligible": false,
+                    "current_grade": 0,
+                    "summary": [{
+                        "category": "Homework",
+                        "prominent": true,
+                        "percent": 0.0,
+                        "detail": "Homework Average = 0%",
+                        "label": "HW Avg"
+                    },{
+                        "category": "Lab",
+                        "prominent": true,
+                        "percent": 0.0,
+                        "detail": "Lab Average = 0%",
+                        "label": "Lab Avg"
+                    },{
+                        "category": "Midterm Exam",
+                        "prominent": true,
+                        "percent": 0.0,
+                        "detail": "Midterm Exam = 0%",
+                        "label": "Midterm"
+                    },{
+                        "category": "Final Exam",
+                        "prominent": true,
+                        "percent": 0.0,
+                        "detail": "Final Exam = 0%",
+                        "label": "Final"
+                    }]
+                }]
             }
         ]
 
@@ -122,35 +452,185 @@
                 "is_active": true,
                 "mode": "honor",
                 "user": "student1",
-                "created": "2018-01-01T00:00:01Z"
+                "created": "2018-01-01T00:00:01Z",
+                "finished": false,
+                "grading": [{
+                    "certificate_eligible": false,
+                    "current_grade": 0,
+                    "summary": [{
+                        "category": "Homework",
+                        "prominent": true,
+                        "percent": 0.0,
+                        "detail": "Homework Average = 0%",
+                        "label": "HW Avg"
+                    },{
+                        "category": "Lab",
+                        "prominent": true,
+                        "percent": 0.0,
+                        "detail": "Lab Average = 0%",
+                        "label": "Lab Avg"
+                    },{
+                        "category": "Midterm Exam",
+                        "prominent": true,
+                        "percent": 0.0,
+                        "detail": "Midterm Exam = 0%",
+                        "label": "Midterm"
+                    },{
+                        "category": "Final Exam",
+                        "prominent": true,
+                        "percent": 0.0,
+                        "detail": "Final Exam = 0%",
+                        "label": "Final"
+                    }]
+                }]
             },
             {
                 "course_id": "e/d/X",
                 "is_active": true,
                 "mode": "honor",
                 "user": "student2",
-                "created": "2018-01-01T00:00:01Z"
+                "created": "2018-01-01T00:00:01Z",
+                "finished": false,
+                "grading": [{
+                    "certificate_eligible": false,
+                    "current_grade": 0,
+                    "summary": [{
+                        "category": "Homework",
+                        "prominent": true,
+                        "percent": 0.0,
+                        "detail": "Homework Average = 0%",
+                        "label": "HW Avg"
+                    },{
+                        "category": "Lab",
+                        "prominent": true,
+                        "percent": 0.0,
+                        "detail": "Lab Average = 0%",
+                        "label": "Lab Avg"
+                    },{
+                        "category": "Midterm Exam",
+                        "prominent": true,
+                        "percent": 0.0,
+                        "detail": "Midterm Exam = 0%",
+                        "label": "Midterm"
+                    },{
+                        "category": "Final Exam",
+                        "prominent": true,
+                        "percent": 0.0,
+                        "detail": "Final Exam = 0%",
+                        "label": "Final"
+                    }]
+                }]
             },
             {
                 "course_id": "x/y/Z",
                 "is_active": true,
                 "mode": "verified",
                 "user": "student3",
-                "created": "2018-01-01T00:00:01Z"
+                "created": "2018-01-01T00:00:01Z",
+                "finished": false,
+                "grading": [{
+                    "certificate_eligible": false,
+                    "current_grade": 0,
+                    "summary": [{
+                        "category": "Homework",
+                        "prominent": true,
+                        "percent": 0.0,
+                        "detail": "Homework Average = 0%",
+                        "label": "HW Avg"
+                    },{
+                        "category": "Lab",
+                        "prominent": true,
+                        "percent": 0.0,
+                        "detail": "Lab Average = 0%",
+                        "label": "Lab Avg"
+                    },{
+                        "category": "Midterm Exam",
+                        "prominent": true,
+                        "percent": 0.0,
+                        "detail": "Midterm Exam = 0%",
+                        "label": "Midterm"
+                    },{
+                        "category": "Final Exam",
+                        "prominent": true,
+                        "percent": 0.0,
+                        "detail": "Final Exam = 0%",
+                        "label": "Final"
+                    }]
+                }]
             },
             {
                 "course_id": "x/y/Z",
                 "is_active": true,
                 "mode": "honor",
                 "user": "student2",
-                "created": "2018-01-01T00:00:01Z"
+                "created": "2018-01-01T00:00:01Z",
+                "finished": false,
+                "grading": [{
+                    "certificate_eligible": false,
+                    "current_grade": 0,
+                    "summary": [{
+                        "category": "Homework",
+                        "prominent": true,
+                        "percent": 0.0,
+                        "detail": "Homework Average = 0%",
+                        "label": "HW Avg"
+                    },{
+                        "category": "Lab",
+                        "prominent": true,
+                        "percent": 0.0,
+                        "detail": "Lab Average = 0%",
+                        "label": "Lab Avg"
+                    },{
+                        "category": "Midterm Exam",
+                        "prominent": true,
+                        "percent": 0.0,
+                        "detail": "Midterm Exam = 0%",
+                        "label": "Midterm"
+                    },{
+                        "category": "Final Exam",
+                        "prominent": true,
+                        "percent": 0.0,
+                        "detail": "Final Exam = 0%",
+                        "label": "Final"
+                    }]
+                }]
             },
             {
                 "course_id": "x/y/Z",
                 "is_active": true,
                 "mode": "verified",
                 "user": "staff",
-                "created": "2018-01-01T00:00:01Z"
+                "created": "2018-01-01T00:00:01Z",
+                "finished": false,
+                "grading": [{
+                    "certificate_eligible": false,
+                    "current_grade": 0,
+                    "summary": [{
+                        "category": "Homework",
+                        "prominent": true,
+                        "percent": 0.0,
+                        "detail": "Homework Average = 0%",
+                        "label": "HW Avg"
+                    },{
+                        "category": "Lab",
+                        "prominent": true,
+                        "percent": 0.0,
+                        "detail": "Lab Average = 0%",
+                        "label": "Lab Avg"
+                    },{
+                        "category": "Midterm Exam",
+                        "prominent": true,
+                        "percent": 0.0,
+                        "detail": "Midterm Exam = 0%",
+                        "label": "Midterm"
+                    },{
+                        "category": "Final Exam",
+                        "prominent": true,
+                        "percent": 0.0,
+                        "detail": "Final Exam = 0%",
+                        "label": "Final"
+                    }]
+                }]
             }
         ]
     ]

--- a/openedx/core/djangoapps/enrollments/tests/test_views.py
+++ b/openedx/core/djangoapps/enrollments/tests/test_views.py
@@ -14,6 +14,7 @@ import ddt
 import httpretty
 import pytest
 import pytz
+import six
 from django.conf import settings
 from django.core.cache import cache
 from django.core.exceptions import ImproperlyConfigured
@@ -24,8 +25,6 @@ from django.urls import reverse
 from freezegun import freeze_time
 from rest_framework import status
 from rest_framework.test import APITestCase
-from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
-from xmodule.modulestore.tests.factories import CourseFactory, check_mongo_calls_range
 
 from common.djangoapps.course_modes.models import CourseMode
 from common.djangoapps.course_modes.tests.factories import CourseModeFactory
@@ -46,6 +45,8 @@ from openedx.core.djangoapps.user_api.models import RetirementState, UserOrgTag,
 from openedx.core.lib.django_test_client_utils import get_absolute_url
 from openedx.features.enterprise_support.tests import FAKE_ENTERPRISE_CUSTOMER
 from openedx.features.enterprise_support.tests.mixins.enterprise import EnterpriseServiceMockMixin
+from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
+from xmodule.modulestore.tests.factories import CourseFactory, check_mongo_calls_range
 
 
 class EnrollmentTestMixin:

--- a/openedx/core/djangoapps/enrollments/tests/test_views.py
+++ b/openedx/core/djangoapps/enrollments/tests/test_views.py
@@ -9,9 +9,10 @@ import itertools
 import json
 import unittest
 from unittest.mock import patch
-import pytest
+
 import ddt
 import httpretty
+import pytest
 import pytz
 from django.conf import settings
 from django.core.cache import cache
@@ -23,9 +24,16 @@ from django.urls import reverse
 from freezegun import freeze_time
 from rest_framework import status
 from rest_framework.test import APITestCase
+from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
+from xmodule.modulestore.tests.factories import CourseFactory, check_mongo_calls_range
 
 from common.djangoapps.course_modes.models import CourseMode
 from common.djangoapps.course_modes.tests.factories import CourseModeFactory
+from common.djangoapps.student.models import CourseEnrollment
+from common.djangoapps.student.roles import CourseStaffRole
+from common.djangoapps.student.tests.factories import AdminFactory, SuperuserFactory, UserFactory
+from common.djangoapps.util.models import RateLimitConfiguration
+from common.djangoapps.util.testing import UrlResetMixin
 from openedx.core.djangoapps.content.course_overviews.models import CourseOverview
 from openedx.core.djangoapps.course_groups import cohorts
 from openedx.core.djangoapps.embargo.models import Country, CountryAccessRule, RestrictedCourse
@@ -38,13 +46,6 @@ from openedx.core.djangoapps.user_api.models import RetirementState, UserOrgTag,
 from openedx.core.lib.django_test_client_utils import get_absolute_url
 from openedx.features.enterprise_support.tests import FAKE_ENTERPRISE_CUSTOMER
 from openedx.features.enterprise_support.tests.mixins.enterprise import EnterpriseServiceMockMixin
-from common.djangoapps.student.models import CourseEnrollment
-from common.djangoapps.student.roles import CourseStaffRole
-from common.djangoapps.student.tests.factories import AdminFactory, SuperuserFactory, UserFactory
-from common.djangoapps.util.models import RateLimitConfiguration
-from common.djangoapps.util.testing import UrlResetMixin
-from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
-from xmodule.modulestore.tests.factories import CourseFactory, check_mongo_calls_range
 
 
 class EnrollmentTestMixin:
@@ -62,7 +63,7 @@ class EnrollmentTestMixin:
             is_active=None,
             enrollment_attributes=None,
             min_mongo_calls=0,
-            max_mongo_calls=0,
+            max_mongo_calls=8,
             linked_enterprise_customer=None,
             cohort=None,
     ):
@@ -378,10 +379,7 @@ class EnrollmentTest(EnrollmentTestMixin, ModuleStoreTestCase, APITestCase, Ente
                 mode_slug=CourseMode.DEFAULT_MODE_SLUG,
                 mode_display_name=CourseMode.DEFAULT_MODE_SLUG,
             )
-            self.assert_enrollment_status(
-                course_id=str(course.id),
-                max_mongo_calls=0,
-            )
+            self.assert_enrollment_status(course_id=six.text_type(course.id))
         # Verify the user himself can see both of his enrollments.
         self._assert_enrollments_visible_in_list([self.course, other_course])
         # Verify that self.other_user can't see any of the enrollments.

--- a/openedx/core/djangoapps/enrollments/urls.py
+++ b/openedx/core/djangoapps/enrollments/urls.py
@@ -13,6 +13,7 @@ from .views import (
     EnrollmentListView,
     EnrollmentUserRolesView,
     EnrollmentView,
+    SubmissionHistoryView,
     UnenrollmentView
 )
 
@@ -29,4 +30,5 @@ urlpatterns = [
         EnrollmentCourseDetailView.as_view(), name='courseenrollmentdetails'),
     url(r'^unenroll/$', UnenrollmentView.as_view(), name='unenrollment'),
     url(r'^roles/$', EnrollmentUserRolesView.as_view(), name='roles'),
+    url(r'^submission_history$', SubmissionHistoryView.as_view(), name='submissionhistory'),
 ]

--- a/openedx/core/djangoapps/enrollments/views.py
+++ b/openedx/core/djangoapps/enrollments/views.py
@@ -23,7 +23,6 @@ from rest_framework.generics import ListAPIView
 from rest_framework.response import Response
 from rest_framework.throttling import UserRateThrottle
 from rest_framework.views import APIView
-from six import text_type
 
 from common.djangoapps.course_modes.models import CourseMode
 from common.djangoapps.student.auth import user_has_role

--- a/openedx/core/djangoapps/enrollments/views.py
+++ b/openedx/core/djangoapps/enrollments/views.py
@@ -8,24 +8,21 @@ consist primarily of authentication, request validation, and serialization.
 import json
 import logging
 
-from course_modes.models import CourseMode
 from django.core.exceptions import (  # lint-amnesty, pylint: disable=wrong-import-order
     ObjectDoesNotExist,
     ValidationError
 )
-from django.utils.decorators import method_decorator  # lint-amnesty, pylint: disable=wrong-import-order
-from edx_rest_framework_extensions.auth.jwt.authentication import \
-    JwtAuthentication  # lint-amnesty, pylint: disable=wrong-import-order
-from edx_rest_framework_extensions.auth.session.authentication import \
-    SessionAuthenticationAllowInactiveUser  # lint-amnesty, pylint: disable=wrong-import-order
-from opaque_keys import InvalidKeyError  # lint-amnesty, pylint: disable=wrong-import-order
-from opaque_keys.edx.keys import CourseKey  # lint-amnesty, pylint: disable=wrong-import-order
+from django.utils.decorators import method_decorator
+from edx_rest_framework_extensions.auth.jwt.authentication import JwtAuthentication
+from edx_rest_framework_extensions.auth.session.authentication import SessionAuthenticationAllowInactiveUser
+from opaque_keys import InvalidKeyError
+from opaque_keys.edx.keys import CourseKey
 from opaque_keys.edx.locator import CourseLocator
-from rest_framework import permissions, status  # lint-amnesty, pylint: disable=wrong-import-order
-from rest_framework.generics import ListAPIView  # lint-amnesty, pylint: disable=wrong-import-order
-from rest_framework.response import Response  # lint-amnesty, pylint: disable=wrong-import-order
-from rest_framework.throttling import UserRateThrottle  # lint-amnesty, pylint: disable=wrong-import-order
-from rest_framework.views import APIView  # lint-amnesty, pylint: disable=wrong-import-order
+from rest_framework import permissions, status
+from rest_framework.generics import ListAPIView
+from rest_framework.response import Response
+from rest_framework.throttling import UserRateThrottle
+from rest_framework.views import APIView
 from six import text_type
 
 from common.djangoapps.course_modes.models import CourseMode
@@ -35,7 +32,6 @@ from common.djangoapps.student.roles import CourseStaffRole, GlobalStaff
 from common.djangoapps.util.disable_rate_limit import can_disable_rate_limit
 from lms.djangoapps.courseware.courses import get_course
 from lms.djangoapps.courseware.models import BaseStudentModuleHistory, StudentModule
-from lms.djangofromcourseware.models import BaseStudentModuleHistory, StudentModule
 from openedx.core.djangoapps.cors_csrf.authentication import SessionAuthenticationCrossDomainCsrf
 from openedx.core.djangoapps.cors_csrf.decorators import ensure_csrf_cookie_cross_domain
 from openedx.core.djangoapps.course_groups.cohorts import CourseUserGroup, add_user_to_cohort, get_cohort_by_name

--- a/openedx/core/djangoapps/enrollments/views.py
+++ b/openedx/core/djangoapps/enrollments/views.py
@@ -5,22 +5,46 @@ consist primarily of authentication, request validation, and serialization.
 """
 
 
+import json
 import logging
 
-from common.djangoapps.course_modes.models import CourseMode
-from django.core.exceptions import ObjectDoesNotExist, ValidationError  # lint-amnesty, pylint: disable=wrong-import-order
+from course_modes.models import CourseMode
+from django.core.exceptions import (  # lint-amnesty, pylint: disable=wrong-import-order
+    ObjectDoesNotExist,
+    ValidationError
+)
 from django.utils.decorators import method_decorator  # lint-amnesty, pylint: disable=wrong-import-order
-from edx_rest_framework_extensions.auth.jwt.authentication import JwtAuthentication  # lint-amnesty, pylint: disable=wrong-import-order
-from edx_rest_framework_extensions.auth.session.authentication import SessionAuthenticationAllowInactiveUser  # lint-amnesty, pylint: disable=wrong-import-order
+from edx_rest_framework_extensions.auth.jwt.authentication import \
+    JwtAuthentication  # lint-amnesty, pylint: disable=wrong-import-order
+from edx_rest_framework_extensions.auth.session.authentication import \
+    SessionAuthenticationAllowInactiveUser  # lint-amnesty, pylint: disable=wrong-import-order
 from opaque_keys import InvalidKeyError  # lint-amnesty, pylint: disable=wrong-import-order
 from opaque_keys.edx.keys import CourseKey  # lint-amnesty, pylint: disable=wrong-import-order
+from opaque_keys.edx.locator import CourseLocator
+from rest_framework import permissions, status  # lint-amnesty, pylint: disable=wrong-import-order
+from rest_framework.generics import ListAPIView  # lint-amnesty, pylint: disable=wrong-import-order
+from rest_framework.response import Response  # lint-amnesty, pylint: disable=wrong-import-order
+from rest_framework.throttling import UserRateThrottle  # lint-amnesty, pylint: disable=wrong-import-order
+from rest_framework.views import APIView  # lint-amnesty, pylint: disable=wrong-import-order
+from six import text_type
+
+from common.djangoapps.course_modes.models import CourseMode
+from common.djangoapps.student.auth import user_has_role
+from common.djangoapps.student.models import CourseEnrollment, User
+from common.djangoapps.student.roles import CourseStaffRole, GlobalStaff
+from common.djangoapps.util.disable_rate_limit import can_disable_rate_limit
+from lms.djangoapps.courseware.courses import get_course
+from lms.djangoapps.courseware.models import BaseStudentModuleHistory, StudentModule
+from lms.djangofromcourseware.models import BaseStudentModuleHistory, StudentModule
 from openedx.core.djangoapps.cors_csrf.authentication import SessionAuthenticationCrossDomainCsrf
 from openedx.core.djangoapps.cors_csrf.decorators import ensure_csrf_cookie_cross_domain
 from openedx.core.djangoapps.course_groups.cohorts import CourseUserGroup, add_user_to_cohort, get_cohort_by_name
 from openedx.core.djangoapps.embargo import api as embargo_api
 from openedx.core.djangoapps.enrollments import api
 from openedx.core.djangoapps.enrollments.errors import (
-    CourseEnrollmentError, CourseEnrollmentExistsError, CourseModeNotFoundError,
+    CourseEnrollmentError,
+    CourseEnrollmentExistsError,
+    CourseModeNotFoundError
 )
 from openedx.core.djangoapps.enrollments.forms import CourseEnrollmentsApiListForm
 from openedx.core.djangoapps.enrollments.paginators import CourseEnrollmentsApiListPagination
@@ -28,7 +52,10 @@ from openedx.core.djangoapps.enrollments.serializers import CourseEnrollmentsApi
 from openedx.core.djangoapps.user_api.accounts.permissions import CanRetireUser
 from openedx.core.djangoapps.user_api.models import UserRetirementStatus
 from openedx.core.djangoapps.user_api.preferences.api import update_email_opt_in
-from openedx.core.lib.api.authentication import BearerAuthenticationAllowInactiveUser
+from openedx.core.lib.api.authentication import (
+    BearerAuthenticationAllowInactiveUser,
+    OAuth2AuthenticationAllowInactiveUser
+)
 from openedx.core.lib.api.permissions import ApiKeyHeaderPermission, ApiKeyHeaderPermissionIsAuthenticated
 from openedx.core.lib.api.view_utils import DeveloperErrorViewMixin
 from openedx.core.lib.exceptions import CourseNotFoundError
@@ -39,15 +66,6 @@ from openedx.features.enterprise_support.api import (
     EnterpriseApiServiceClient,
     enterprise_enabled
 )
-from rest_framework import permissions, status  # lint-amnesty, pylint: disable=wrong-import-order
-from rest_framework.generics import ListAPIView  # lint-amnesty, pylint: disable=wrong-import-order
-from rest_framework.response import Response  # lint-amnesty, pylint: disable=wrong-import-order
-from rest_framework.throttling import UserRateThrottle  # lint-amnesty, pylint: disable=wrong-import-order
-from rest_framework.views import APIView  # lint-amnesty, pylint: disable=wrong-import-order
-from common.djangoapps.student.auth import user_has_role
-from common.djangoapps.student.models import CourseEnrollment, User
-from common.djangoapps.student.roles import CourseStaffRole, GlobalStaff
-from common.djangoapps.util.disable_rate_limit import can_disable_rate_limit
 
 log = logging.getLogger(__name__)
 REQUIRED_ATTRIBUTES = {
@@ -964,3 +982,164 @@ class CourseEnrollmentsApiListView(DeveloperErrorViewMixin, ListAPIView):
         if usernames:
             queryset = queryset.filter(user__username__in=usernames)
         return queryset
+
+
+@can_disable_rate_limit
+class SubmissionHistoryView(APIView, ApiKeyPermissionMixIn):
+    """
+    Submission history view.
+    """
+    authentication_classes = (OAuth2AuthenticationAllowInactiveUser, EnrollmentCrossDomainSessionAuth)
+    permission_classes = (ApiKeyHeaderPermissionIsAuthenticated, )
+
+    def get(self, request):
+        """
+        Get submission history details.
+
+        **Usecases**:
+
+            Regular users can only retrieve their own submission history and users with GlobalStaff status
+            can retrieve everyone's submission history.
+
+        **Example Requests**:
+
+            GET /api/enrollment/v1/submission_history?course_id=course_id
+            GET /api/enrollment/v1/submission_history?course_id=course_id&user=username
+            GET /api/enrollment/v1/submission_history?course_id=course_id&all_users=true
+
+        **Query Parameters for GET**
+
+            * course_id: Course id to retrieve submission history.
+            * username: Single username for which this view will retrieve the submission history details.
+                If no username specified the requester's username will be used.
+            * all_users: If true and if the requester has the correct permissions,
+                retrieve history submission from every user in a course id.
+
+        **Response Values**:
+
+            If there's an error while getting the submission history an empty response will
+            be returned.
+            The submission history response has the following attributes:
+
+                * Results: A list of submission history:
+                    * course_id: Course id
+                    * course_name: Course name
+                    * user: Username
+                    * problems: List of problems
+                        * location: problem location
+                        * name: problem's display name
+                        * submission_history: List of submission history
+                            * state: State of submission.
+                            * grade: Grade.
+                            * max_grade: Maximum possible grade.
+                        * data: problem's data.
+        """
+        username = request.GET.get('username', request.user.username)
+        data = []
+        if GlobalStaff().has_user(request.user):
+            all_users = bool(request.GET.get('all', False))
+        else:
+            all_users = False
+        course_id = request.GET.get('course_id')
+
+        if not (all_users or username == request.user.username or GlobalStaff().has_user(request.user) or
+                self.has_api_key_permissions(request)):
+            return Response(data)
+
+        course_enrollments = CourseEnrollment.objects.select_related('user').filter(is_active=True)
+        if course_id:
+            if not course_id.startswith("course-v1:"):
+                course_id = "course-v1:{}".format(course_id)
+            try:
+                course_enrollments = course_enrollments.filter(
+                    course_id=CourseLocator.from_string(course_id.replace(' ', '+'))
+                ).order_by('created')
+            except KeyError:
+                return Response(data)
+
+        if not all_users:
+            course_enrollments = course_enrollments.filter(user__username=username).order_by('created')
+
+        courses = {}
+        for course_enrollment in course_enrollments:
+            try:
+                course_list = courses.get(course_enrollment.course_id)
+                if course_list:
+                    course, course_children = course_list
+                else:
+                    course = get_course(course_enrollment.course_id, depth=4)
+                    course_children = course.get_children()
+                    courses[course_enrollment.course_id] = [course, course_children]
+            except ValueError:
+                continue
+            course_data = self._get_course_data(course_enrollment, course, course_children)
+            data.append(course_data)
+
+        return Response({'results': data})
+
+    def _get_problem_data(self, course_enrollment, component):
+        """
+        Get problem data from a course enrollment.
+
+        Args:
+        -----
+        course_enrollment: Course Enrollment.
+        component: Component to analyze.
+        """
+        problem_data = {
+            'location': str(component.location),
+            'name': component.display_name,
+            'submission_history': [],
+            'data': component.data
+        }
+
+        csm = StudentModule.objects.filter(
+            module_state_key=component.location,
+            student__username=course_enrollment.user.username,
+            course_id=course_enrollment.course_id)
+
+        scores = BaseStudentModuleHistory.get_history(csm)
+        for i, score in enumerate(scores):
+            if i % 2 == 1:
+                continue
+
+            state = score.state
+            if state is not None:
+                state = json.loads(state)
+
+            history_data = {
+                'state': state,
+                'grade': score.grade,
+                'max_grade': score.max_grade
+            }
+            problem_data['submission_history'].append(history_data)
+
+        return problem_data
+
+    def _get_course_data(self, course_enrollment, course, course_children):
+        """
+        Get course data.
+
+        Params:
+        --------
+
+        course_enrollment (CourseEnrollment): course enrollment
+        course: course
+        course_children: course children
+        """
+
+        course_data = {
+            'course_id': str(course_enrollment.course_id),
+            'course_name': course.display_name_with_default,
+            'user': course_enrollment.user.username,
+            'problems': []
+        }
+        for section in course_children:
+            for subsection in section.get_children():
+                for vertical in subsection.get_children():
+                    for component in vertical.get_children():
+                        if component.location.category == 'problem' and getattr(component, 'has_score', False):
+                            problem_data = self._get_problem_data(course_enrollment, component)
+                            course_data['problems'].append(problem_data)
+
+        return course_data


### PR DESCRIPTION
Introduction
------------

Another description as I don't have permission to edit the above.

This PR adds an endpoint displaying the submission history for each course a specific user is enrolled.

**Sandbox URL**: https://pr20948.sandbox.opencraft.hosting/ (provisioning)

Testing instructions
--------------------

These can use the sandbox above or a devstack.

1. Ensure the logged in user has submitted a few problems.
2. Browse http://localhost:18000/api/enrollment/v1/submission_history or http://pr20948.sandbox.opencraft.hosting/api/enrollment/v1/submission_history
3. Make sure a JSON object showing the user submissions is displayed

Screenshots
-------------
![image](https://user-images.githubusercontent.com/5691347/77781993-4b78b180-7035-11ea-9cfe-3e3840f25c14.png)



Author notes and concerns
-------------

1. The update in the enrollment serializer makes extra mongodb calls.
