### PR TITLE
SE-1168 [FAL-92] implement ORA process summary report csv

### DIFF
--- a/lms/djangoapps/instructor/tests/test_api.py
+++ b/lms/djangoapps/instructor/tests/test_api.py
@@ -154,6 +154,7 @@ INSTRUCTOR_POST_ENDPOINTS = {
     'change_due_date',
     'export_ora2_data',
     'export_ora2_submission_files',
+    'export_ora2_summary',
     'get_grading_config',
     'get_problem_responses',
     'get_proctored_exam_results',
@@ -426,6 +427,7 @@ class TestInstructorAPIDenyLevels(SharedModuleStoreTestCase, LoginEnrollmentTest
             ('get_problem_responses', {}),
             ('export_ora2_data', {}),
             ('export_ora2_submission_files', {}),
+            ('export_ora2_summary', {}),
             ('rescore_problem',
              {'problem_to_reset': self.problem_urlname, 'unique_student_identifier': self.user.email}),
             ('override_problem_score',
@@ -2848,6 +2850,26 @@ class TestInstructorAPILevelsDataDump(SharedModuleStoreTestCase, LoginEnrollment
         with patch(
             'lms.djangoapps.instructor_task.api.submit_export_ora2_submission_files'
         ) as mock_submit_ora2_task:
+            mock_submit_ora2_task.side_effect = AlreadyRunningError(already_running_status)
+            response = self.client.post(url, {})
+
+        self.assertContains(response, already_running_status, status_code=400)
+
+    def test_get_ora2_summary_responses_success(self):
+        url = reverse('export_ora2_summary', kwargs={'course_id': str(self.course.id)})
+
+        with patch('lms.djangoapps.instructor_task.api.submit_export_ora2_summary') as mock_submit_ora2_task:
+            mock_submit_ora2_task.return_value = True
+            response = self.client.post(url, {})
+        success_status = "The ORA summary report is being created."
+        self.assertContains(response, success_status)
+
+    def test_get_ora2_summary_responses_already_running(self):
+        url = reverse('export_ora2_summary', kwargs={'course_id': str(self.course.id)})
+        task_type = 'export_ora2_summary'
+        already_running_status = generate_already_running_error_message(task_type)
+
+        with patch('lms.djangoapps.instructor_task.api.submit_export_ora2_summary') as mock_submit_ora2_task:
             mock_submit_ora2_task.side_effect = AlreadyRunningError(already_running_status)
             response = self.client.post(url, {})
 

--- a/lms/djangoapps/instructor/views/api.py
+++ b/lms/djangoapps/instructor/views/api.py
@@ -2034,6 +2034,24 @@ def export_ora2_data(request, course_id):
 @cache_control(no_cache=True, no_store=True, must_revalidate=True)
 @require_course_permission(permissions.CAN_RESEARCH)
 @common_exceptions_400
+def export_ora2_summary(request, course_id):
+    """
+    Pushes a Celery task which will aggregate a summary students' progress in ora2 tasks for a course into a .csv
+    """
+    course_key = CourseKey.from_string(course_id)
+    report_type = _('ORA summary')
+    task_api.submit_export_ora2_summary(request, course_key)
+    success_status = SUCCESS_MESSAGE_TEMPLATE.format(report_type=report_type)
+
+    return JsonResponse({"status": success_status})
+
+
+@transaction.non_atomic_requests
+@require_POST
+@ensure_csrf_cookie
+@cache_control(no_cache=True, no_store=True, must_revalidate=True)
+@require_course_permission(permissions.CAN_RESEARCH)
+@common_exceptions_400
 def export_ora2_submission_files(request, course_id):
     """
     Pushes a Celery task which will download and compress all submission

--- a/lms/djangoapps/instructor/views/api_urls.py
+++ b/lms/djangoapps/instructor/views/api_urls.py
@@ -53,6 +53,7 @@ urlpatterns = [
     # Reports..
     url(r'^get_course_survey_results$', api.get_course_survey_results, name='get_course_survey_results'),
     url(r'^export_ora2_data', api.export_ora2_data, name='export_ora2_data'),
+    url(r'^export_ora2_summary', api.export_ora2_summary, name='export_ora2_summary'),
 
     url(r'^export_ora2_submission_files', api.export_ora2_submission_files,
         name='export_ora2_submission_files'),

--- a/lms/djangoapps/instructor/views/instructor_dashboard.py
+++ b/lms/djangoapps/instructor/views/instructor_dashboard.py
@@ -633,6 +633,7 @@ def _section_data_download(course, access):
         'export_ora2_submission_files_url': reverse(
             'export_ora2_submission_files', kwargs={'course_id': str(course_key)}
         ),
+        'export_ora2_summary_url': reverse('export_ora2_summary', kwargs={'course_id': str(course_key)}),
     }
     if not access.get('data_researcher'):
         section_data['is_hidden'] = True

--- a/lms/djangoapps/instructor_task/api.py
+++ b/lms/djangoapps/instructor_task/api.py
@@ -36,6 +36,7 @@ from lms.djangoapps.instructor_task.tasks import (
     delete_problem_state,
     export_ora2_data,
     export_ora2_submission_files,
+    export_ora2_summary,
     generate_certificates,
     override_problem_score,
     proctored_exam_results_csv,
@@ -457,6 +458,18 @@ def submit_export_ora2_submission_files(request, course_key):
     """
     task_type = 'export_ora2_submission_files'
     task_class = export_ora2_submission_files
+    task_input = {}
+    task_key = ''
+
+    return submit_task(request, task_type, task_class, course_key, task_input, task_key)
+
+
+def submit_export_ora2_summary(request, course_key):
+    """
+    AlreadyRunningError is raised if an ora2 report is already being generated.
+    """
+    task_type = 'export_ora2_summary'
+    task_class = export_ora2_summary
     task_input = {}
     task_key = ''
 

--- a/lms/djangoapps/instructor_task/tasks.py
+++ b/lms/djangoapps/instructor_task/tasks.py
@@ -38,6 +38,7 @@ from lms.djangoapps.instructor_task.tasks_helper.misc import (
     upload_course_survey_report,
     upload_ora2_data,
     upload_ora2_submission_files,
+    upload_ora2_summary,
     upload_proctored_exam_results_report
 )
 from lms.djangoapps.instructor_task.tasks_helper.module_state import (
@@ -315,4 +316,15 @@ def export_ora2_submission_files(entry_id, xmodule_instance_args):
     """
     action_name = ugettext_noop('compressed')
     task_fn = partial(upload_ora2_submission_files, xmodule_instance_args)
+    return run_main_task(entry_id, task_fn, action_name)
+
+
+@shared_task(base=BaseInstructorTask)
+@set_code_owner_attribute
+def export_ora2_summary(entry_id, xmodule_instance_args):
+    """
+    Generate a CSV of ora2/student summaries and push it to S3.
+    """
+    action_name = ugettext_noop('generated')
+    task_fn = partial(upload_ora2_summary, xmodule_instance_args)
     return run_main_task(entry_id, task_fn, action_name)

--- a/lms/djangoapps/instructor_task/tests/test_tasks_helper.py
+++ b/lms/djangoapps/instructor_task/tests/test_tasks_helper.py
@@ -50,7 +50,8 @@ from lms.djangoapps.instructor_task.tasks_helper.misc import (
     cohort_students_and_upload,
     upload_course_survey_report,
     upload_ora2_data,
-    upload_ora2_submission_files
+    upload_ora2_submission_files,
+    upload_ora2_summary
 )
 from lms.djangoapps.instructor_task.tests.test_base import (
     InstructorTaskCourseTestCase,
@@ -2537,6 +2538,7 @@ class TestCertificateGeneration(InstructorTaskModuleTestCase):
         ]
 
 
+@ddt.ddt
 class TestInstructorOra2Report(SharedModuleStoreTestCase):
     """
     Tests that ORA2 response report generation works.
@@ -2557,17 +2559,20 @@ class TestInstructorOra2Report(SharedModuleStoreTestCase):
         if os.path.exists(settings.GRADES_DOWNLOAD['ROOT_PATH']):
             shutil.rmtree(settings.GRADES_DOWNLOAD['ROOT_PATH'])
 
-    def test_report_fails_if_error(self):
-        with patch(
-            'lms.djangoapps.instructor_task.tasks_helper.misc.OraAggregateData.collect_ora2_data'
-        ) as mock_collect_data:
+    @ddt.data(
+        ('lms.djangoapps.instructor_task.tasks_helper.misc.OraAggregateData.collect_ora2_data', upload_ora2_data),
+        ('lms.djangoapps.instructor_task.tasks_helper.misc.OraAggregateData.collect_ora2_summary', upload_ora2_summary),
+    )
+    @ddt.unpack
+    def test_report_fails_if_error(self, data_collector_module, upload_func):
+        with patch(data_collector_module) as mock_collect_data:
             mock_collect_data.side_effect = KeyError
 
             with patch('lms.djangoapps.instructor_task.tasks_helper.runner._get_current_task') as mock_current_task:
                 mock_current_task.return_value = self.current_task
 
-                response = upload_ora2_data(None, None, self.course.id, None, 'generated')
-                assert response == UPDATE_STATUS_FAILED
+                response = upload_func(None, None, self.course.id, None, 'generated')
+                self.assertEqual(response, UPDATE_STATUS_FAILED)
 
     def test_report_stores_results(self):
         with ExitStack() as stack:
@@ -2627,6 +2632,30 @@ class TestInstructorOra2AttachmentsExport(SharedModuleStoreTestCase):
 
                 response = upload_ora2_submission_files(None, None, self.course.id, None, 'compressed')
                 assert response == UPDATE_STATUS_FAILED
+
+    def test_summary_report_stores_results(self):
+        with freeze_time('2001-01-01 00:00:00'):
+            test_header = ['field1', 'field2']
+            test_rows = [['row1_field1', 'row1_field2'], ['row2_field1', 'row2_field2']]
+
+        with patch('lms.djangoapps.instructor_task.tasks_helper.runner._get_current_task') as mock_current_task:
+            mock_current_task.return_value = self.current_task
+
+            with patch(
+                'lms.djangoapps.instructor_task.tasks_helper.misc.OraAggregateData.collect_ora2_summary'
+            ) as mock_collect_summary:
+                mock_collect_summary.return_value = (test_header, test_rows)
+                with patch(
+                    'lms.djangoapps.instructor_task.models.DjangoStorageReportStore.store_rows'
+                ) as mock_store_rows:
+                    return_val = upload_ora2_summary(None, None, self.course.id, None, 'generated')
+
+                    timestamp_str = datetime.now(UTC).strftime('%Y-%m-%d-%H%M')
+                    course_id_string = quote(str(self.course.id).replace('/', '_'))
+                    filename = '{}_ORA_summary_{}.csv'.format(course_id_string, timestamp_str)
+
+                    self.assertEqual(return_val, UPDATE_STATUS_SUCCEEDED)
+                    mock_store_rows.assert_called_once_with(self.course.id, filename, [test_header] + test_rows)
 
     def test_export_fails_if_error_on_create_zip_step(self):
         with ExitStack() as stack:

--- a/lms/templates/instructor/instructor_dashboard_2/data_download.html
+++ b/lms/templates/instructor/instructor_dashboard_2/data_download.html
@@ -95,6 +95,7 @@ from openedx.core.djangolib.markup import HTML, Text
       <input type="button" name="calculate-grades-csv" class="async-report-btn" value="${_("Generate Grade Report")}" data-endpoint="${ section_data['calculate_grades_csv_url'] }"/>
       <input type="button" name="problem-grade-report" class="async-report-btn" value="${_("Generate Problem Grade Report")}" data-endpoint="${ section_data['problem_grade_report_url'] }"/>
       <input type="button" name="export-ora2-data" class="async-report-btn" value="${_("Generate ORA Data Report")}" data-endpoint="${ section_data['export_ora2_data_url'] }"/>
+      <input type="button" name="export-ora2-summary" class="async-report-btn" value="${_("Generate ORA Summary Report")}" data-endpoint="${ section_data['export_ora2_summary_url'] }"/>
     </p>
 
     <p>${_("Click to generate a ZIP file that contains all submission texts and attachments.")}</p>


### PR DESCRIPTION
This PR implements a summary report designed to be serialized to csv for users' progress in ORAs. The aim is to provide a report that can be used by instructors to perform tasks such as a list of students have submitted a response but not completed the peer assessment step.

The actual logic for generating the data itself is implemented in https://github.com/edx/edx-ora2/pull/1250

**JIRA tickets**: [OSPR-3722](https://openedx.atlassian.net/browse/OSPR-3722)

**Dependencies**: https://github.com/edx/edx-ora2/pull/1250

**Screenshots**:
(data download tab of course instructor page) Added button.
![1562824809](https://user-images.githubusercontent.com/9714796/61025931-3e595b00-a3f1-11e9-8528-2b421accd445.png)


**Sandbox URL**:

-  LMS: https://pr20955.sandbox.opencraft.hosting/
-  Studio: https://studio.pr20955.sandbox.opencraft.hosting/


**Merge deadline**: None

**Testing instructions**:

- generate some progress in a ORA assessment. (eg. [the example in the sandbox](https://pr20955.sandbox.opencraft.hosting/courses/course-v1:edX+DemoX+Demo_Course/courseware/graded_interactions/175e76c4951144a29d46211361266e0e/1?activate_block_id=block-v1%3AedX%2BDemoX%2BDemo_Course%2Btype%40vertical%2Bblock%40fb79dcbad35b466a8c6364f8ffee9050))
- log in with a staff account
- navigate to the [data download](https://pr20955.sandbox.opencraft.hosting/courses/course-v1:edX+DemoX+Demo_Course/instructor#view-data_download) tab of the instructor dashboard for the course
- click the "Generate ORA Summary Report" button
- wait a moment and refresh the page if necessary
- download and view the csv file in the reports download section below. It will be named something like `
edX_DemoX_Demo_Course_ORA_summary_2019-07-10-0336.csv`

**Author notes and concerns**:

- the new button was added to the data download tab so that it could hook into the same task running logic as the 'ORA data report'. (the ORA tab is generated from the edx-ora2 code and so doesn't have direct access to this task running)

**Reviewers**
- [x] @pomegranited 
- [ ] edX reviewer[s] TBD

**Settings**
```yaml
```