### PR TITLE
 Logs in Certificate Generation after Id Verification

### DIFF
--- a/lms/djangoapps/certificates/api.py
+++ b/lms/djangoapps/certificates/api.py
@@ -188,6 +188,10 @@ def generate_user_certificates(student, course_key, course=None, insecure=False,
         generate_pdf=generate_pdf,
         forced_grade=forced_grade
     )
+
+    message = u'Queued Certificate Generation task for {user} : {course}'
+    log.info(message.format(user=student.id, course=course_key))
+
     # If cert_status is not present in certificate valid_statuses (for example unverified) then
     # add_cert returns None and raises AttributeError while accesing cert attributes.
     if cert is None:

--- a/lms/djangoapps/certificates/signals.py
+++ b/lms/djangoapps/certificates/signals.py
@@ -146,6 +146,9 @@ def fire_ungenerated_certificate_task(user, course_key, expected_verification_st
     traffic to workers.
     """
 
+    message = u'Entered into Ungenerated Certificate task for {user} : {course}'
+    log.info(message.format(user=user.id, course=course_key))
+
     allowed_enrollment_modes_list = [
         CourseMode.VERIFIED,
         CourseMode.CREDIT_MODE,
@@ -169,3 +172,6 @@ def fire_ungenerated_certificate_task(user, course_key, expected_verification_st
             kwargs['expected_verification_status'] = six.text_type(expected_verification_status)
         generate_certificate.apply_async(countdown=CERTIFICATE_DELAY_SECONDS, kwargs=kwargs)
         return True
+
+    message = u'Certificate Generation task failed for {user} : {course}'
+    log.info(message.format(user=user.id, course=course_key))

--- a/lms/djangoapps/certificates/tasks.py
+++ b/lms/djangoapps/certificates/tasks.py
@@ -38,13 +38,14 @@ def generate_certificate(self, **kwargs):
         actual_verification_status = IDVerificationService.user_status(student)
         actual_verification_status = actual_verification_status['status']
         if expected_verification_status != actual_verification_status:
-            logger.warn(u'Expected verification status {expected} '
-                        u'differs from actual verification status {actual} '
-                        u'for user {user} in course {course}'.format(
-                            expected=expected_verification_status,
-                            actual=actual_verification_status,
-                            user=student.id,
-                            course=course_key
-                        ))
+            logger.warning(
+                u'Expected verification status {expected} '
+                u'differs from actual verification status {actual} '
+                u'for user {user} in course {course}'.format(
+                    expected=expected_verification_status,
+                    actual=actual_verification_status,
+                    user=student.id,
+                    course=course_key
+                ))
             raise self.retry(kwargs=original_kwargs)
     generate_user_certificates(student=student, course_key=course_key, **kwargs)

--- a/lms/djangoapps/verify_student/models.py
+++ b/lms/djangoapps/verify_student/models.py
@@ -420,6 +420,9 @@ class PhotoVerification(IDVerificationAttempt):
             user=self.user
         )
 
+        message = u'LEARNER_NOW_VERIFIED signal fired for {user}'
+        log.info(message.format(user=self.user.username))
+
     @status_before_must_be("must_retry", "submitted", "approved", "denied")
     def deny(self,
              error_msg,


### PR DESCRIPTION
Ticket: [learner-6648](https://openedx.atlassian.net/browse/LEARNER-6648)

**DESCRIPTION:**
Added additional logs in the certificate generation
task being executed after id verification of a learner.

**Expected Behavior:**
For learners who have earned the certificates in some courses before their photo-id-verification, their certificates should be automatically generated. 

**Current Behavior:**
As of now, the certificates are not being generated automatically and many learners have to ask the support to re-generate the certificate manually. 

**Implementation:**
There are not enough logs in the code to pinpoint the main issue which is causing the failure of the implemented method, hence more logs are being added to get further details on the issues. 

