### PR TITLE
Python-modernize on edx-platform (336 of 380)

### DIFF
--- a/lms/djangoapps/grades/admin.py
+++ b/lms/djangoapps/grades/admin.py
@@ -1,8 +1,11 @@
 """
 Django admin page for grades models
 """
+from __future__ import absolute_import
+
 from config_models.admin import ConfigurationModelAdmin, KeyedConfigurationModelAdmin
 from django.contrib import admin
+
 from lms.djangoapps.grades.config.forms import CoursePersistentGradesAdminForm
 from lms.djangoapps.grades.config.models import (
     ComputeGradesSetting,

--- a/lms/djangoapps/grades/api.py
+++ b/lms/djangoapps/grades/api.py
@@ -3,36 +3,30 @@
 Python APIs exposed by the grades app to other in-process apps.
 """
 from __future__ import absolute_import, unicode_literals
+
 from datetime import datetime
 
 import pytz
+from django.core.exceptions import ObjectDoesNotExist
+from opaque_keys.edx.keys import CourseKey, UsageKey
 from six import text_type
 
-from django.core.exceptions import ObjectDoesNotExist
-
-# Public Grades Factories
-from lms.djangoapps.grades.course_grade_factory import CourseGradeFactory
-from lms.djangoapps.grades.subsection_grade import CreateSubsectionGrade
-from lms.djangoapps.grades.subsection_grade_factory import SubsectionGradeFactory
-
-# Public Grades Functions
-from lms.djangoapps.grades.models_api import *
-from lms.djangoapps.grades.tasks import compute_all_grades_for_course as task_compute_all_grades_for_course
-
 # Public Grades Modules
-from lms.djangoapps.grades import events, constants, context, course_data
-from lms.djangoapps.grades.signals import signals
-from lms.djangoapps.grades.util_services import GradesUtilService
-
-# TODO exposing functionality from Grades handlers seems fishy.
-from lms.djangoapps.grades.signals.handlers import disconnect_submissions_signal_receiver
-
+from lms.djangoapps.grades import constants, context, course_data, events
 # Grades APIs that should NOT belong within the Grades subsystem
 # TODO move Gradebook to be an external feature outside of core Grades
 from lms.djangoapps.grades.config.waffle import is_writable_gradebook_enabled
+# Public Grades Factories
+from lms.djangoapps.grades.course_grade_factory import CourseGradeFactory
+from lms.djangoapps.grades.models_api import *
+from lms.djangoapps.grades.signals import signals
+# TODO exposing functionality from Grades handlers seems fishy.
+from lms.djangoapps.grades.signals.handlers import disconnect_submissions_signal_receiver
+from lms.djangoapps.grades.subsection_grade import CreateSubsectionGrade
+from lms.djangoapps.grades.subsection_grade_factory import SubsectionGradeFactory
+from lms.djangoapps.grades.tasks import compute_all_grades_for_course as task_compute_all_grades_for_course
+from lms.djangoapps.grades.util_services import GradesUtilService
 from lms.djangoapps.utils import _get_key
-
-from opaque_keys.edx.keys import CourseKey, UsageKey
 from track.event_transaction_utils import create_new_event_transaction_id, set_event_transaction_type
 
 

--- a/lms/djangoapps/grades/apps.py
+++ b/lms/djangoapps/grades/apps.py
@@ -4,10 +4,13 @@ Grades Application Configuration
 Signal handlers are connected here.
 """
 
+from __future__ import absolute_import
+
 from django.apps import AppConfig
 from django.conf import settings
 from edx_proctoring.runtime import set_runtime_service
-from openedx.core.djangoapps.plugins.constants import ProjectType, SettingsType, PluginURLs, PluginSettings
+
+from openedx.core.djangoapps.plugins.constants import PluginSettings, PluginURLs, ProjectType, SettingsType
 
 
 class GradesConfig(AppConfig):

--- a/lms/djangoapps/grades/course_data.py
+++ b/lms/djangoapps/grades/course_data.py
@@ -1,3 +1,9 @@
+"""
+Code used to get and cache the requested course-data
+"""
+
+from __future__ import absolute_import
+
 from lms.djangoapps.course_blocks.api import get_course_blocks
 from openedx.core.djangoapps.content.block_structure.api import get_block_structure_manager
 from xmodule.modulestore.django import modulestore

--- a/lms/djangoapps/grades/course_grade_factory.py
+++ b/lms/djangoapps/grades/course_grade_factory.py
@@ -1,21 +1,25 @@
 """
 Course Grade Factory Class
 """
+from __future__ import absolute_import
+
 from collections import namedtuple
 from logging import getLogger
 
+import six
 from six import text_type
 
-from openedx.core.djangoapps.signals.signals import (COURSE_GRADE_CHANGED,
-                                                     COURSE_GRADE_NOW_PASSED,
-                                                     COURSE_GRADE_NOW_FAILED)
+from openedx.core.djangoapps.signals.signals import (
+    COURSE_GRADE_CHANGED,
+    COURSE_GRADE_NOW_FAILED,
+    COURSE_GRADE_NOW_PASSED
+)
 
 from .config import assume_zero_if_absent, should_persist_grades
 from .course_data import CourseData
 from .course_grade import CourseGrade, ZeroCourseGrade
 from .models import PersistentCourseGrade
 from .models_api import prefetch_grade_overrides_and_visible_blocks
-
 
 log = getLogger(__name__)
 
@@ -138,7 +142,7 @@ class CourseGradeFactory(object):
         """
         Returns a ZeroCourseGrade object for the given user and course.
         """
-        log.debug(u'Grades: CreateZero, %s, User: %s', unicode(course_data), user.id)
+        log.debug(u'Grades: CreateZero, %s, User: %s', six.text_type(course_data), user.id)
         return ZeroCourseGrade(user, course_data)
 
     @staticmethod
@@ -151,7 +155,7 @@ class CourseGradeFactory(object):
             raise PersistentCourseGrade.DoesNotExist
 
         persistent_grade = PersistentCourseGrade.read(user.id, course_data.course_key)
-        log.debug(u'Grades: Read, %s, User: %s, %s', unicode(course_data), user.id, persistent_grade)
+        log.debug(u'Grades: Read, %s, User: %s, %s', six.text_type(course_data), user.id, persistent_grade)
 
         return CourseGrade(
             user,

--- a/lms/djangoapps/grades/services.py
+++ b/lms/djangoapps/grades/services.py
@@ -2,6 +2,7 @@
 Grade service
 """
 from __future__ import absolute_import
+
 from . import api
 
 

--- a/lms/djangoapps/grades/subsection_grade_factory.py
+++ b/lms/djangoapps/grades/subsection_grade_factory.py
@@ -1,7 +1,14 @@
+"""
+SubsectionGrade Factory Class
+"""
+
+from __future__ import absolute_import
+
 from collections import OrderedDict
 from logging import getLogger
 
 from lazy import lazy
+from submissions import api as submissions_api
 
 from courseware.model_data import ScoresClient
 from lms.djangoapps.grades.config import assume_zero_if_absent, should_persist_grades
@@ -9,7 +16,6 @@ from lms.djangoapps.grades.models import PersistentSubsectionGrade
 from lms.djangoapps.grades.scores import possibly_scored
 from openedx.core.lib.grade_utils import is_score_higher_or_equal
 from student.models import anonymous_id_for_user
-from submissions import api as submissions_api
 
 from .course_data import CourseData
 from .subsection_grade import CreateSubsectionGrade, ReadSubsectionGrade, ZeroSubsectionGrade
@@ -59,7 +65,7 @@ class SubsectionGradeFactory(object):
         Bulk creates all the unsaved subsection_grades to this point.
         """
         CreateSubsectionGrade.bulk_create_models(
-            self.student, self._unsaved_subsection_grades.values(), self.course_data.course_key
+            self.student, list(self._unsaved_subsection_grades.values()), self.course_data.course_key
         )
         self._unsaved_subsection_grades.clear()
 

--- a/lms/djangoapps/grades/tasks.py
+++ b/lms/djangoapps/grades/tasks.py
@@ -2,6 +2,8 @@
 This module contains tasks for asynchronous execution of grade updates.
 """
 
+from __future__ import absolute_import
+
 from logging import getLogger
 
 import six
@@ -29,11 +31,10 @@ from .config.waffle import DISABLE_REGRADE_ON_POLICY_CHANGE, waffle
 from .constants import ScoreDatabaseTableEnum
 from .course_grade_factory import CourseGradeFactory
 from .exceptions import DatabaseNotReadyError
+from .grade_utils import are_grades_frozen
 from .signals.signals import SUBSECTION_SCORE_CHANGED
 from .subsection_grade_factory import SubsectionGradeFactory
 from .transformer import GradesTransformer
-from .grade_utils import are_grades_frozen
-
 
 log = getLogger(__name__)
 
@@ -211,7 +212,7 @@ def _recalculate_subsection_grade(self, **kwargs):
         scored_block_usage_key = UsageKey.from_string(kwargs['usage_id']).replace(course_key=course_key)
 
         set_custom_metrics_for_course_key(course_key)
-        set_custom_metric('usage_id', unicode(scored_block_usage_key))
+        set_custom_metric('usage_id', six.text_type(scored_block_usage_key))
 
         # The request cache is not maintained on celery workers,
         # where this code runs. So we take the values from the
@@ -261,8 +262,8 @@ def _has_db_updated_with_new_score(self, scored_block_usage_key, **kwargs):
         score = sub_api.get_score(
             {
                 "student_id": kwargs['anonymous_user_id'],
-                "course_id": unicode(scored_block_usage_key.course_key),
-                "item_id": unicode(scored_block_usage_key),
+                "course_id": six.text_type(scored_block_usage_key.course_key),
+                "item_id": six.text_type(scored_block_usage_key),
                 "item_type": scored_block_usage_key.block_type,
             }
         )


### PR DESCRIPTION
[INCR-439](https://openedx.atlassian.net/browse/INCR-439)

After executing python-modernize and isort, few changes occurred in import sequence as well as unicode func is replaced by six.text_type func.