### PR TITLE
Restrict grading endpoints in LMS

### DIFF
--- a/lms/djangoapps/courseware/module_render.py
+++ b/lms/djangoapps/courseware/module_render.py
@@ -577,16 +577,17 @@ def get_module_system_for_user(
         """
         Submit a grade for the block.
         """
-        grades_signals.SCORE_PUBLISHED.send(
-            sender=None,
-            block=block,
-            user=user,
-            raw_earned=event['value'],
-            raw_possible=event['max_value'],
-            only_if_higher=event.get('only_if_higher'),
-            score_deleted=event.get('score_deleted'),
-            grader_response=event.get('grader_response')
-        )
+        if not user.is_anonymous():
+            grades_signals.SCORE_PUBLISHED.send(
+                sender=None,
+                block=block,
+                user=user,
+                raw_earned=event['value'],
+                raw_possible=event['max_value'],
+                only_if_higher=event.get('only_if_higher'),
+                score_deleted=event.get('score_deleted'),
+                grader_response=event.get('grader_response')
+            )
 
     def handle_deprecated_progress_event(block, event):
         """


### PR DESCRIPTION
## [LEARNER-3761](https://openedx.atlassian.net/browse/LEARNER-3761)

### Description

Currently, grading endpoints in capa-module are vulnerable as they are not restricted.To avoid it, changes have been made so that they are available only for logged-in users.