### PR TITLE
Add optional role parameter to course API endpoint.

### DIFF
--- a/lms/djangoapps/course_api/api.py
+++ b/lms/djangoapps/course_api/api.py
@@ -4,14 +4,19 @@ Course API
 
 from __future__ import absolute_import
 
+from django.conf import settings
 from django.contrib.auth.models import AnonymousUser, User
 from rest_framework.exceptions import PermissionDenied
+import search
+import six
 
+from lms.djangoapps.courseware.access import has_access
 from lms.djangoapps.courseware.courses import (
     get_course_overview_with_access,
     get_courses,
     get_permission_for_course_about
 )
+from openedx.core.lib.api.view_utils import LazySequence
 
 from .permissions import can_view_courses_for_username
 
@@ -57,7 +62,20 @@ def course_detail(request, username, course_key):
     )
 
 
-def list_courses(request, username, org=None, filter_=None):
+def _filter_courses_by_role(course_queryset, user, access_type):
+    """
+    Return a course queryset filtered by the access type for which the user has access.
+    """
+    return LazySequence(
+        (
+            course for course in course_queryset
+            if has_access(user, access_type, course.id)
+        ),
+        est_len=len(course_queryset)
+    )
+
+
+def list_courses(request, username, org=None, roles=None, filter_=None, search_term=None):
     """
     Yield all available courses.
 
@@ -78,12 +96,48 @@ def list_courses(request, username, org=None, filter_=None):
             If specified, visible `CourseOverview` objects are filtered
             such that only those belonging to the organization with the provided
             org code (e.g., "HarvardX") are returned. Case-insensitive.
+        roles (list of strings):
+            If specified, visible `CourseOverview` objects are filtered
+            such that only those for which the user has the specified role(s)
+            are returned. Multiple role parameters can be specified.
         filter_ (dict):
             If specified, visible `CourseOverview` objects are filtered
             by the given key-value pairs.
+        search_term (string):
+            Search term to filter courses (used by ElasticSearch).
 
     Return value:
         Yield `CourseOverview` objects representing the collection of courses.
     """
     user = get_effective_user(request.user, username)
-    return get_courses(user, org=org, filter_=filter_)
+    course_qs = get_courses(user, org=org, filter_=filter_)
+
+    # Global staff have access to all courses. Filter course roles for non-global staff only.
+    if not user.is_staff:
+        if roles:
+            for role in roles:
+                # Filter the courses again to return only the courses for which the user has the specified roles.
+                course_qs = _filter_courses_by_role(course_qs, user, role)
+
+    if not settings.FEATURES['ENABLE_COURSEWARE_SEARCH'] or not search_term:
+        return course_qs
+
+    # Return all the results, 10K is the maximum allowed value for ElasticSearch.
+    # We should use 0 after upgrading to 1.1+:
+    #   - https://github.com/elastic/elasticsearch/commit/8b0a863d427b4ebcbcfb1dcd69c996c52e7ae05e
+    results_size_infinity = 10000
+
+    search_courses = search.api.course_discovery_search(
+        search_term,
+        size=results_size_infinity,
+    )
+
+    search_courses_ids = {course['data']['id'] for course in search_courses['results']}
+
+    return LazySequence(
+        (
+            course for course in course_qs
+            if six.text_type(course.id) in search_courses_ids
+        ),
+        est_len=len(course_qs)
+    )

--- a/lms/djangoapps/course_api/forms.py
+++ b/lms/djangoapps/course_api/forms.py
@@ -12,7 +12,7 @@ from django.forms import CharField, Form
 from opaque_keys import InvalidKeyError
 from opaque_keys.edx.keys import CourseKey
 
-from openedx.core.djangoapps.util.forms import ExtendedNullBooleanField
+from openedx.core.djangoapps.util.forms import ExtendedNullBooleanField, MultiValueField
 
 
 class UsernameValidatorMixin(object):
@@ -54,6 +54,7 @@ class CourseListGetForm(UsernameValidatorMixin, Form):
     search_term = CharField(required=False)
     username = CharField(required=False)
     org = CharField(required=False)
+    role = MultiValueField(required=False)
 
     # white list of all supported filter fields
     filter_type = namedtuple('filter_type', ['param_name', 'field_name'])

--- a/lms/djangoapps/course_api/tests/test_forms.py
+++ b/lms/djangoapps/course_api/tests/test_forms.py
@@ -69,6 +69,7 @@ class TestCourseListGetForm(FormTestMixin, UsernameTestMixin, SharedModuleStoreT
         self.cleaned_data = {
             'username': user.username,
             'org': '',
+            'role': set([]),
             'mobile': None,
             'search_term': '',
             'filter_': None,


### PR DESCRIPTION
Insights currently consumes a list of course IDs delivered by OpenID Connect token upon login. Those course IDs are all course IDs for which the user has course staff access in the LMS. Since all OpenID Connect token usage is being removed, an alternate way of providing those course staff IDs is needed.

This PR modifies the existing Course API endpoint that provides a list of courses via CourseOverview, adding a "role" parameter which is used as an additional filter on the returned courses. Insights will call this endpoint post-login to determine for which courses a user should have access in the Insights dashboard. But the changes are also general-purpose as well.