### PR TITLE
Fix the dummy switch-to-revision button in lms wiki page

### DIFF
--- a/lms/templates/wiki/history.html
+++ b/lms/templates/wiki/history.html
@@ -215,7 +215,7 @@
         {% trans "Back to history view" as tmsg %}{{tmsg|force_escape}}
       </a>
       {% if article|can_write:user %}
-        <a type="button" class="btn btn-large btn-primary switch-to-revision">
+        <a class="btn btn-large btn-primary switch-to-revision">
           <span class="icon fa fa-flag" aria-hidden="true"></span>
           {% trans "Switch to this version" as tmsg %}{{tmsg|force_escape}}
         </a>

--- a/lms/templates/wiki/history.html
+++ b/lms/templates/wiki/history.html
@@ -215,10 +215,10 @@
         {% trans "Back to history view" as tmsg %}{{tmsg|force_escape}}
       </a>
       {% if article|can_write:user %}
-        <button type="button" class="btn btn-large btn-primary switch-to-revision">
+        <a type="button" class="btn btn-large btn-primary switch-to-revision">
           <span class="icon fa fa-flag" aria-hidden="true"></span>
           {% trans "Switch to this version" as tmsg %}{{tmsg|force_escape}}
-        </button>
+        </a>
       {% else %}
         <button type="button" class="btn btn-large btn-primary disabled">
           <span class="icon fa fa-lock" aria-hidden="true"></span>


### PR DESCRIPTION
- **Problem** : The switch-to-revision button in lms wiki page is dummy

- **Cause**: In the processed web page, a "href" attribute will be added to the switch-to-revision button, so that the function is useless. 

- **Solution**: To make the button able to work, it should be changed to an "a" element. The style of the button is not affected after the change.