### PR TITLE
Load COURSE_CATALOG_API_URL setting from env in Studio

### DIFF
--- a/cms/envs/production.py
+++ b/cms/envs/production.py
@@ -164,6 +164,8 @@ ENTERPRISE_API_URL = ENV_TOKENS.get('ENTERPRISE_API_URL', LMS_INTERNAL_ROOT_URL 
 ENTERPRISE_CONSENT_API_URL = ENV_TOKENS.get('ENTERPRISE_CONSENT_API_URL', LMS_INTERNAL_ROOT_URL + '/consent/api/v1/')
 # Note that FEATURES['PREVIEW_LMS_BASE'] gets read in from the environment file.
 
+COURSE_CATALOG_API_URL = ENV_TOKENS.get('COURSE_CATALOG_API_URL', COURSE_CATALOG_API_URL)
+
 # List of logout URIs for each IDA that the learner should be logged out of when they logout of
 # Studio. Only applies to IDA for which the social auth flow uses DOT (Django OAuth Toolkit).
 IDA_LOGOUT_URI_LIST = ENV_TOKENS.get('IDA_LOGOUT_URI_LIST', [])


### PR DESCRIPTION
@edx/masters-neem 
https://openedx.atlassian.net/browse/EDUCATOR-4493

The added line corresponds to this line in LMS production.py: https://github.com/edx/edx-platform/blob/master/lms/envs/production.py#L830