### PR TITLE
Extension point to customize certificate views

### DIFF
--- a/lms/djangoapps/certificates/views/webview.py
+++ b/lms/djangoapps/certificates/views/webview.py
@@ -19,6 +19,7 @@ from eventtracking import tracker
 from opaque_keys import InvalidKeyError
 from opaque_keys.edx.keys import CourseKey
 from organizations import api as organizations_api
+from edx_django_utils.plugins import pluggable_override
 
 from common.djangoapps.edxmako.shortcuts import render_to_response
 from common.djangoapps.edxmako.template import Template
@@ -474,10 +475,12 @@ def render_cert_by_uuid(request, certificate_uuid):
     template_path="certificates/server-error.html",
     test_func=lambda request: request.GET.get('preview', None)
 )
+@pluggable_override('OVERRIDE_RENDER_CERTIFICATE_VIEW')
 def render_html_view(request, course_id, certificate=None):
     """
     This public view generates an HTML representation of the specified user and course
     If a certificate is not available, we display a "Sorry!" screen instead
+    It can be overridden by setting `OVERRIDE_RENDER_CERTIFICATE_VIEW` to an alternative implementation.
     """
     user = certificate.user if certificate else request.user
     user_id = user.id


### PR DESCRIPTION
We'd like to optionally require logins for viewing and downloading certificates.
This PR adds an extension point using a new feature added in https://github.com/edx/edx-django-utils/pull/64 to allow modifying the webview for certificates.

**JIRA tickets**: Implements BB-1388.

**Dependencies**: None

**Sandbox URL**: https://pr20957.sandbox.opencraft.hosting/

**Testing instructions**:

1. Generate a certificate to test with.
    ```
    /edx/bin/{python,manage}.edxapp lms --settings=devstack_docker generate_fake_cert verified course-v1:edX+DemoX+Demo_Course
    ```
2. Check the certificate renders normally with no login required in an logged-out browser: http://localhost:18000/certificates/user/8/course/course-v1:edX+DemoX+Demo_Course
3. Add the following to `lms/envs/private.py` in the devstack
    ```
    OVERRIDE_RENDER_CERTIFICATE_VIEW = "lms.envs.private.certificate_render_html_view_override"
    from django.contrib.auth.decorators import login_required
    def certificate_render_html_view_override(prev_fn, request, user_id, course_id):
        return login_required(prev_fn)(request, user_id, course_id)
    ```
4. Check the certificate page again and ensure it requires login now.

**Author notes and concerns**: None

**Reviewers**
- [ ] (@giovannicimolin )
- [ ] @bradenmacdonald 