### PR TITLE
add submission deadline methods in InheritanceMixin

### DIFF
--- a/common/lib/xmodule/xmodule/modulestore/inheritance.py
+++ b/common/lib/xmodule/xmodule/modulestore/inheritance.py
@@ -4,6 +4,7 @@ Support for inheritance of fields down an XBlock hierarchy.
 from __future__ import absolute_import
 
 from django.conf import settings
+from django.utils import timezone
 
 from xmodule.partitions.partitions import UserPartition
 from xblock.core import XBlockMixin
@@ -232,6 +233,39 @@ class InheritanceMixin(XBlockMixin):
         default=False,
         scope=Scope.settings
     )
+
+    @property
+    def close_date(self):
+        """
+        Return the date submissions should be closed from.
+
+        If graceperiod is present for the course, all the submissions
+        can be submitted till due date and the graceperiod. If no
+        graceperiod, then the close date is same as the due date.
+        """
+        due_date = self.due
+
+        if self.graceperiod is not None and due_date:
+            return due_date + self.graceperiod
+        return due_date
+
+    def is_past_due(self):
+        """
+        Returns the boolean identifying if the submission due date has passed.
+        """
+        return self.close_date is not None and timezone.now() > self.close_date
+
+    def has_deadline_passed(self):
+        """
+        Returns a boolean indicating if the submission is past its deadline.
+
+        If the course is self-paced or no due date has been
+        specified, then the submission can be made. If none of these
+        cases exists, check if the submission due date has passed or not.
+        """
+        if self.self_paced or self.close_date is None:
+            return False
+        return self.is_past_due()
 
 
 def compute_inherited_metadata(descriptor):

--- a/common/lib/xmodule/xmodule/modulestore/tests/test_inheritance.py
+++ b/common/lib/xmodule/xmodule/modulestore/tests/test_inheritance.py
@@ -1,0 +1,67 @@
+"""
+Unit tests for testing inheritance mixins
+"""
+from __future__ import absolute_import
+
+import ddt
+import unittest
+
+from mock import Mock
+from django.utils.timezone import now, timedelta
+from xblock.core import XBlock
+from xblock.fields import ScopeIds
+from xblock.test.tools import TestRuntime
+
+from xmodule.modulestore.inheritance import InheritanceMixin
+
+
+class TestXBlock:
+    """
+    An empty Xblock, to be used, when creating a block with mixins.
+    """
+    pass
+
+
+@ddt.ddt
+class TestInheritanceMixin(unittest.TestCase):
+    """
+    Test Suite to verify various methods of the InheritanceMixin
+    """
+
+    def setUp(self):
+        """
+        Create a test xblock with mock runtime.
+        """
+        runtime = TestRuntime(
+            Mock(entry_point=XBlock.entry_point), mixins=[InheritanceMixin], services={'field-data': {}}
+        )
+        self.xblock = runtime.construct_xblock_from_class(
+            TestXBlock, ScopeIds('user', 'TestXBlock', 'def_id', 'usage_id')
+        )
+        super(TestInheritanceMixin, self).setUp()
+
+    def add_submission_deadline_information(self, due_date, graceperiod, self_paced):
+        """
+        Helper function to add pacing, due date and graceperiod fields to Xblock.
+        """
+        self.xblock.due = due_date
+        self.xblock.graceperiod = graceperiod
+        self.xblock.self_paced = self_paced
+
+    @ddt.data(
+        (False, now(), None, True),
+        (True, now(), None, False),
+        (False, now(), timedelta(days=1), False),
+        (True, now(), timedelta(days=1), False),
+        (False, now() - timedelta(hours=1), None, True),
+    )
+    @ddt.unpack
+    def test_submission_deadline(self, self_paced, due_date, graceperiod, is_past_deadline):
+        """
+        Verifies the deadline passed boolean value w.r.t pacing and due date.
+
+        Given the pacing information, due date and graceperiod,
+        confirm if the submission deadline has passed or not.
+        """
+        self.add_submission_deadline_information(due_date, graceperiod, self_paced)
+        self.assertEqual(is_past_deadline, self.xblock.has_deadline_passed())


### PR DESCRIPTION
### [EDUCATOR - 4499](https://openedx.atlassian.net/browse/EDUCATOR-4499)

### Description
While doing an enhancement to the DnDXblock in https://github.com/edx-solutions/xblock-drag-and-drop-v2/pull/217, the checks to verify if the submission deadline has passed were implemented. The methods implemented were generic and can be reused by other XBlocks. As per suggested on that PR, this PR is adding those methods in the InheritanceMixin, a mixin which is responsible for adding numerous fields to all the XBlocks in the platform.

### Reviewers
 - [x] @awaisdar001 
 - [x] @noraiz-anwar 

### Post Review
 - [x] Squash & Rebase commits