### PR TITLE
Add credit mode in support enrollment tool.

### DIFF
--- a/common/djangoapps/course_modes/models.py
+++ b/common/djangoapps/course_modes/models.py
@@ -333,7 +333,9 @@ class CourseMode(models.Model):
 
     @classmethod
     @request_cached(CACHE_NAMESPACE)
-    def modes_for_course(cls, course_id=None, include_expired=False, only_selectable=True, course=None):
+    def modes_for_course(
+        cls, course_id=None, include_expired=False, only_selectable=True, course=None, exclude_credit=True
+    ):
         """
         Returns a list of the non-expired modes for a given course id
 
@@ -384,7 +386,7 @@ class CourseMode(models.Model):
         if only_selectable:
             if course is not None and hasattr(course, 'selectable_modes'):
                 found_course_modes = course.selectable_modes
-            else:
+            elif exclude_credit:
                 found_course_modes = found_course_modes.exclude(mode_slug__in=cls.CREDIT_MODES)
 
         modes = ([mode.to_tuple() for mode in found_course_modes])


### PR DESCRIPTION
## [PROD-305](https://openedx.atlassian.net/browse/PROD-305)

### Description

Currently, enrollment support tool is only allowing support members to change course enrollment only one of the two modes i.e. audit and verified.To move a learner other than these modes,they need to ping devops.To broaden the scope of enrollment support tool,changes have been done so that enrollment would be changed to other modes as well.