### PR TITLE
add pytest decorator for skipping py3 test

### DIFF
--- a/common/test/utils.py
+++ b/common/test/utils.py
@@ -155,6 +155,7 @@ def normalize_repr(func):
     """
     return reprwrapper(func)
 
+
 # Decorator for skipping tests that are not ready to be run with Python 3.x.
 # While we expect many tests to fail with Python 3.x as we transition, this
 # is specifically for tests that rely on external or large scale fixes. It can

--- a/common/test/utils.py
+++ b/common/test/utils.py
@@ -6,6 +6,7 @@ import sys
 from contextlib import contextmanager
 
 import moto
+import pytest
 from django.dispatch import Signal
 from markupsafe import escape
 from mock import Mock, patch
@@ -153,3 +154,12 @@ def normalize_repr(func):
     between worker processes.
     """
     return reprwrapper(func)
+
+# Decorator for skipping tests that are not ready to be run with Python 3.x.
+# While we expect many tests to fail with Python 3.x as we transition, this
+# is specifically for tests that rely on external or large scale fixes. It can
+# be added to individual tests or test classes.
+py2_only = pytest.mark.skipif(
+    sys.version_info > (3, 0),
+    reason="This test can only be run with Python 2.7, currently"
+)


### PR DESCRIPTION
Add a common `py2_only` decorator for skipping python 3 tests/test classes. This should not be used liberally; rather, it should be used to prevent useless tests from running if there are specific cases in which we are waiting on a long, external fix that is causing failures with Python 3.