### PR TITLE
Make upgrade

### DIFF
--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -64,3 +64,6 @@ edx-search==1.2.2
 # This ruamel.ordereddict will not be supported in python3 but is a dependency of ruamel.yaml
 # install it only on python 2.7
 ruamel.ordereddict; python_version == "2.7"
+
+# 1.16.1 requires djangorestframework>=3.8
+drf-yasg==1.16

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -94,7 +94,7 @@ djangorestframework-xml==1.3.0  # via edx-enterprise
 djangorestframework==3.7.7
 docopt==0.6.2
 docutils==0.14            # via botocore
-drf-yasg==1.16.0
+drf-yasg==1.16
 edx-ace==0.1.10
 edx-analytics-data-api-client==0.15.3
 edx-bulk-grades==0.1.5
@@ -106,12 +106,12 @@ edx-django-release-util==0.3.1
 edx-django-sites-extensions==2.3.1
 edx-django-utils==2.0.0
 edx-drf-extensions==2.3.1
-edx-enterprise==1.7.0
+edx-enterprise==1.7.1
 edx-i18n-tools==0.4.8
 edx-milestones==0.2.3
 edx-oauth2-provider==1.2.2
 edx-opaque-keys[django]==1.0.1
-edx-organizations==2.0.3
+edx-organizations==2.1.0
 edx-proctoring-proctortrack==1.0.5
 edx-proctoring==2.0.6
 edx-rbac==0.2.1           # via edx-enterprise
@@ -214,7 +214,7 @@ requests==2.22.0
 rest-condition==1.0.3
 rfc6266-parser==0.0.5.post2
 ruamel.ordereddict==0.4.13 ; python_version == "2.7"  # via ruamel.yaml
-ruamel.yaml==0.15.99      # via drf-yasg
+ruamel.yaml==0.15.100     # via drf-yasg
 rules==2.0.1
 s3transfer==0.1.13        # via boto3
 sailthru-client==2.2.3
@@ -234,7 +234,7 @@ soupsieve==1.9.2          # via beautifulsoup4
 sqlparse==0.3.0
 staff-graded-xblock==0.3
 stevedore==1.30.1
-super-csv==0.6
+super-csv==0.7
 sympy==1.4
 testfixtures==6.10.0      # via edx-enterprise
 tincan==0.0.5             # via edx-enterprise

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -113,7 +113,7 @@ djangorestframework-xml==1.3.0
 djangorestframework==3.7.7
 docopt==0.6.2
 docutils==0.14
-drf-yasg==1.16.0
+drf-yasg==1.16
 edx-ace==0.1.10
 edx-analytics-data-api-client==0.15.3
 edx-bulk-grades==0.1.5
@@ -125,13 +125,13 @@ edx-django-release-util==0.3.1
 edx-django-sites-extensions==2.3.1
 edx-django-utils==2.0.0
 edx-drf-extensions==2.3.1
-edx-enterprise==1.7.0
+edx-enterprise==1.7.1
 edx-i18n-tools==0.4.8
 edx-lint==1.3.0
 edx-milestones==0.2.3
 edx-oauth2-provider==1.2.2
 edx-opaque-keys[django]==1.0.1
-edx-organizations==2.0.3
+edx-organizations==2.1.0
 edx-proctoring-proctortrack==1.0.5
 edx-proctoring==2.0.6
 edx-rbac==0.2.1
@@ -281,7 +281,7 @@ requests==2.22.0
 rest-condition==1.0.3
 rfc6266-parser==0.0.5.post2
 ruamel.ordereddict==0.4.13 ; python_version == "2.7"
-ruamel.yaml==0.15.99
+ruamel.yaml==0.15.100
 rules==2.0.1
 s3transfer==0.1.13
 sailthru-client==2.2.3
@@ -307,7 +307,7 @@ sphinxcontrib-websupport==1.1.2  # via sphinx
 sqlparse==0.3.0
 staff-graded-xblock==0.3
 stevedore==1.30.1
-super-csv==0.6
+super-csv==0.7
 sympy==1.4
 testfixtures==6.10.0
 text-unidecode==1.2
@@ -330,7 +330,7 @@ wcwidth==0.1.7
 web-fragments==0.3.0
 webencodings==0.5.1
 webob==1.8.5
-werkzeug==0.15.4
+werkzeug==0.15.5
 wrapt==1.10.5
 git+https://github.com/edx-solutions/xblock-drag-and-drop-v2@v2.2.1#egg=xblock-drag-and-drop-v2==2.2.1
 git+https://github.com/open-craft/xblock-poll@add89e14558c30f3c8dc7431e5cd6536fff6d941#egg=xblock-poll==1.5.1

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -109,7 +109,7 @@ djangorestframework-xml==1.3.0
 djangorestframework==3.7.7
 docopt==0.6.2
 docutils==0.14
-drf-yasg==1.16.0
+drf-yasg==1.16
 edx-ace==0.1.10
 edx-analytics-data-api-client==0.15.3
 edx-bulk-grades==0.1.5
@@ -121,13 +121,13 @@ edx-django-release-util==0.3.1
 edx-django-sites-extensions==2.3.1
 edx-django-utils==2.0.0
 edx-drf-extensions==2.3.1
-edx-enterprise==1.7.0
+edx-enterprise==1.7.1
 edx-i18n-tools==0.4.8
 edx-lint==1.3.0
 edx-milestones==0.2.3
 edx-oauth2-provider==1.2.2
 edx-opaque-keys[django]==1.0.1
-edx-organizations==2.0.3
+edx-organizations==2.1.0
 edx-proctoring-proctortrack==1.0.5
 edx-proctoring==2.0.6
 edx-rbac==0.2.1
@@ -272,7 +272,7 @@ requests==2.22.0
 rest-condition==1.0.3
 rfc6266-parser==0.0.5.post2
 ruamel.ordereddict==0.4.13 ; python_version == "2.7"
-ruamel.yaml==0.15.99
+ruamel.yaml==0.15.100
 rules==2.0.1
 s3transfer==0.1.13
 sailthru-client==2.2.3
@@ -294,7 +294,7 @@ soupsieve==1.9.2
 sqlparse==0.3.0
 staff-graded-xblock==0.3
 stevedore==1.30.1
-super-csv==0.6
+super-csv==0.7
 sympy==1.4
 testfixtures==6.10.0
 text-unidecode==1.2       # via faker
@@ -316,7 +316,7 @@ wcwidth==0.1.7            # via pytest
 web-fragments==0.3.0
 webencodings==0.5.1
 webob==1.8.5
-werkzeug==0.15.4          # via flask
+werkzeug==0.15.5          # via flask
 wrapt==1.10.5
 git+https://github.com/edx-solutions/xblock-drag-and-drop-v2@v2.2.1#egg=xblock-drag-and-drop-v2==2.2.1
 git+https://github.com/open-craft/xblock-poll@add89e14558c30f3c8dc7431e5cd6536fff6d941#egg=xblock-poll==1.5.1


### PR DESCRIPTION
This pins `drf-yasg` because their latest point release drops support for Django Rest Framework <3.8

