### PR TITLE
Setting template to show currency defined in the course mode DB record

### DIFF
--- a/common/djangoapps/course_modes/views.py
+++ b/common/djangoapps/course_modes/views.py
@@ -13,6 +13,7 @@ import six.moves.urllib.parse
 import six.moves.urllib.request
 import waffle
 from babel.dates import format_datetime
+from babel.numbers import get_currency_symbol
 from django.contrib.auth.decorators import login_required
 from django.db import transaction
 from django.http import HttpResponse, HttpResponseBadRequest
@@ -208,6 +209,7 @@ class ChooseModeView(View):
             price_before_discount = verified_mode.min_price
 
             context["currency"] = verified_mode.currency.upper()
+            context["currency_symbol"] = get_currency_symbol(verified_mode.currency.upper())
             context["min_price"] = price_before_discount
             context["verified_name"] = verified_mode.name
             context["verified_description"] = verified_mode.description

--- a/lms/templates/course_modes/_upgrade_button.html
+++ b/lms/templates/course_modes/_upgrade_button.html
@@ -17,9 +17,9 @@ from openedx.core.djangolib.markup import HTML, Text
             <span>${_('Pursue a Verified Certificate')}</span>
     % endif
         % if price_before_discount:
-        (<span class="upgrade-price-string">$${min_price} USD</span> <del> <span class="upgrade-price-string">${Text('${price} USD').format(price=price_before_discount)}</span></del>)
+        (<span class="upgrade-price-string">${currency_symbol}${min_price} ${currency}</span> <del> <span class="upgrade-price-string">${Text('{currency_symbol}{price} {currency}').format(currency_symbol=currency_symbol, price=price_before_discount, currency=currency)}</span></del>)
         % else:
-        (<span class="upgrade-price-string">$${min_price} USD</span>)
+        (<span class="upgrade-price-string">${currency_symbol}${min_price} ${currency}</span>)
         % endif
         </button>
 </li>

--- a/lms/templates/course_modes/choose.html
+++ b/lms/templates/course_modes/choose.html
@@ -124,7 +124,7 @@ from openedx.core.djangolib.markup import HTML, Text
                                                 </div>
                                                 <div class="copy-inline list-actions">
                                                     <ul class="list-actions">
-                                                        <%include file='_upgrade_button.html' args='content_gating_enabled=content_gating_enabled, course_duration_limit_enabled=course_duration_limit_enabled, min_price=min_price, price_before_discount=price_before_discount' />
+                                                        <%include file='_upgrade_button.html' args='content_gating_enabled=content_gating_enabled, course_duration_limit_enabled=course_duration_limit_enabled, currency=currency, currency_symbol=currency_symbol, min_price=min_price, price_before_discount=price_before_discount' />
                                                     </ul>
                                                 </div>
                                             </div>
@@ -165,7 +165,7 @@ from openedx.core.djangolib.markup import HTML, Text
                                                 </div>
                                                 <div class="copy-inline list-actions">
                                                     <ul class="list-actions">
-                                                        <%include file='_upgrade_button.html' args='content_gating_enabled=content_gating_enabled, course_duration_limit_enabled=course_duration_limit_enabled, min_price=min_price, price_before_discount=price_before_discount' />
+                                                        <%include file='_upgrade_button.html' args='content_gating_enabled=content_gating_enabled, course_duration_limit_enabled=course_duration_limit_enabled, currency=currency, currency_symbol=currency_symbol, min_price=min_price, price_before_discount=price_before_discount' />
                                                     </ul>
                                                 </div>
                                             </div>


### PR DESCRIPTION
No matter which currency is defined in the course mode, the choose mode page is displaying USD and the $ symbol.

![image](https://user-images.githubusercontent.com/22335041/63382228-47323a80-c368-11e9-8522-6d855b17deb0.png)


With this change, the template will show the currency defined in the course mode

![image](https://user-images.githubusercontent.com/22335041/63382384-9d06e280-c368-11e9-8d65-4061575b3bd4.png)

