### PR TITLE
REVMI-341 Stop sending lms_client_id in jwt sent to ecommerce

### DIFF
--- a/lms/djangoapps/commerce/tests/__init__.py
+++ b/lms/djangoapps/commerce/tests/__init__.py
@@ -28,7 +28,6 @@ TEST_PAYMENT_DATA = {
 class EdxRestApiClientTest(TestCase):
     """ Tests to ensure the client is initialized properly. """
 
-    TEST_CLIENT_ID = 'test-client-id'
     SCOPES = [
         'user_id',
         'email',
@@ -55,7 +54,7 @@ class EdxRestApiClientTest(TestCase):
             )
 
             mock_tracker = mock.Mock()
-            mock_tracker.resolve_context = mock.Mock(return_value={'client_id': self.TEST_CLIENT_ID, 'ip': '127.0.0.1'})
+            mock_tracker.resolve_context = mock.Mock(return_value={'ip': '127.0.0.1'})
             with mock.patch('openedx.core.djangoapps.commerce.utils.tracker.get_tracker', return_value=mock_tracker):
                 ecommerce_api_client(self.user).baskets(1).post()
 
@@ -65,7 +64,6 @@ class EdxRestApiClientTest(TestCase):
             claims = {
                 'tracking_context': {
                     'lms_user_id': self.user.id,
-                    'lms_client_id': self.TEST_CLIENT_ID,
                     'lms_ip': '127.0.0.1',
                 }
             }

--- a/openedx/core/djangoapps/commerce/utils.py
+++ b/openedx/core/djangoapps/commerce/utils.py
@@ -18,7 +18,6 @@ def create_tracking_context(user):
 
     return {
         'lms_user_id': user.id,
-        'lms_client_id': context_tracker.get('client_id'),
         'lms_ip': context_tracker.get('ip'),
     }
 


### PR DESCRIPTION
E-commerce does not seem to use this. See https://github.com/edx/ecommerce/blob/1b679dc2184663b4868bf459abd3f1604dc72e6a/ecommerce/extensions/analytics/middleware.py#L32