### PR TITLE
Add --update option to create_dot_access

### DIFF
--- a/openedx/core/djangoapps/oauth_dispatch/management/commands/create_dot_application.py
+++ b/openedx/core/djangoapps/oauth_dispatch/management/commands/create_dot_application.py
@@ -92,7 +92,7 @@ class Command(BaseCommand):
         """
         Update given application with option values.
         """
-        for key, value in application_kwargs:
+        for key, value in application_kwargs.items():
             setattr(application, key, value)
         application.save()
         logger.info('Updated {} application with id: {}, client_id: {}, and client_secret: {}'.format(

--- a/openedx/core/djangoapps/oauth_dispatch/management/commands/create_dot_application.py
+++ b/openedx/core/djangoapps/oauth_dispatch/management/commands/create_dot_application.py
@@ -68,72 +68,108 @@ class Command(BaseCommand):
                             dest='scopes',
                             default='',
                             help='Comma-separated list of scopes that this application will be allowed to request.')
+        parser.add_argument('--update',
+                            action='store_true',
+                            dest='update',
+                            help='If application and/or access already exist, update values.')
 
-    def _create_application_access(self, application, scopes):
-        """
-        If scopes are supplied, creates an oauth_dispatch ApplicationAccess for the provided
-        scopes and DOT application.
-        """
-        if not scopes:
-            return
 
-        if ApplicationAccess.objects.filter(application_id=application.id).exists():
+    def _create_application(self, user, app_name, application_kwargs):
+        """
+        Create new application with given User, name, and option values.
+        """
+        application = Application.objects.create(
+            user=user, name=app_name, **application_kwargs
+        )
+        logger.info('Created {} application with id: {}, client_id: {}, and client_secret: {}'.format(
+            app_name,
+            application.id,
+            application.client_id,
+            application.client_secret,
+        ))
+        return application
+
+    def _update_application(self, application, application_kwargs):
+        """
+        Update given application with option values.
+        """
+        for key, value in application_kwargs:
+            setattr(application, key, value)
+        application.save()
+        logger.info('Updated {} application with id: {}, client_id: {}, and client_secret: {}'.format(
+            app_name,
+            application.id,
+            application.client_id,
+            application.client_secret,
+        ))
+
+    def _create_or_update_access(self, application, scopes, update):
+        """
+        Create application access with specified scopes.
+
+        If application access already exists, then:
+          * Update with specified scopes if update=True,
+          * Otherwise do nothing.
+        """
+        access = ApplicationAccess.objects.filter(application_id=application.id).first()
+
+        if access and update:
+            access.scopes = scopes
+            access.save()
+            logger.info('Updated application access for {} with scopes: {}'.format(
+                application.name,
+                application_access.scopes,
+            ))
+        elif access:
             logger.info('Application access for application {} already exists.'.format(
                 application.name,
             ))
-            return
+        else:
+            application_access = ApplicationAccess.objects.create(
+                application_id=application.id,
+                scopes=scopes,
+            )
+            logger.info('Created application access for {} with scopes: {}'.format(
+                application.name,
+                application_access.scopes,
+            ))
 
-        application_access = ApplicationAccess.objects.create(
-            application_id=application.id,
-            scopes=scopes,
-        )
-        application_access.save()
-        logger.info('Created application access for {} with scopes: {}'.format(
-            application.name,
-            application_access.scopes,
-        ))
 
     def handle(self, *args, **options):
-        app_name = options['name']
         username = options['username']
-        grant_type = options['grant_type']
+        user = User.objects.get(username=username)
+        app_name = options['name']
+        update = options['update']
+
         redirect_uris = options['redirect_uris']
-        skip_authorization = options['skip_authorization']
         client_type = Application.CLIENT_PUBLIC if options['public'] else Application.CLIENT_CONFIDENTIAL
+        grant_type = options['grant_type']
+        skip_authorization = options['skip_authorization']
         client_id = options['client_id']
         client_secret = options['client_secret']
-        scopes = options['scopes']
 
-        user = User.objects.get(username=username)
-
-        if Application.objects.filter(user=user, name=app_name).exists():
-            logger.info('Application with name {} and user {} already exists.'.format(
-                app_name,
-                username
-            ))
-            application = Application.objects.get(user=user, name=app_name)
-            self._create_application_access(application, scopes)
-            return
-
-        create_kwargs = dict(
-            name=app_name,
-            user=user,
+        application_kwargs = dict(
             redirect_uris=redirect_uris,
             client_type=client_type,
             authorization_grant_type=grant_type,
             skip_authorization=skip_authorization
         )
         if client_id:
-            create_kwargs['client_id'] = client_id
+            application_kwargs['client_id'] = client_id
         if client_secret:
-            create_kwargs['client_secret'] = client_secret
+            application_kwargs['client_secret'] = client_secret
 
-        application = Application.objects.create(**create_kwargs)
-        application.save()
-        logger.info('Created {} application with id: {}, client_id: {}, and client_secret: {}'.format(
-            app_name,
-            application.id,
-            application.client_id,
-            application.client_secret
-        ))
-        self._create_application_access(application, scopes)
+        application = Application.objects.filter(user=user, name=app_name).first()
+        if application and update:
+            self._update_application(application, application_kwargs)
+        elif application:
+            logger.info('Application with name {} and user {} already exists.'.format(
+                app_name,
+                username
+            ))
+        else:
+            application = self._create_new_application(user, app_name, application_kwargs)
+
+        scopes = options['scopes']
+        if scopes:
+            self._create_or_update_access(application, scopes, update)

--- a/openedx/core/djangoapps/oauth_dispatch/management/commands/create_dot_application.py
+++ b/openedx/core/djangoapps/oauth_dispatch/management/commands/create_dot_application.py
@@ -96,7 +96,7 @@ class Command(BaseCommand):
             setattr(application, key, value)
         application.save()
         logger.info('Updated {} application with id: {}, client_id: {}, and client_secret: {}'.format(
-            app_name,
+            application.name,
             application.id,
             application.client_id,
             application.client_secret,
@@ -117,7 +117,7 @@ class Command(BaseCommand):
             access.save()
             logger.info('Updated application access for {} with scopes: {}'.format(
                 application.name,
-                application_access.scopes,
+                scopes,
             ))
         elif access:
             logger.info('Application access for application {} already exists.'.format(

--- a/openedx/core/djangoapps/oauth_dispatch/management/commands/create_dot_application.py
+++ b/openedx/core/djangoapps/oauth_dispatch/management/commands/create_dot_application.py
@@ -73,7 +73,6 @@ class Command(BaseCommand):
                             dest='update',
                             help='If application and/or access already exist, update values.')
 
-
     def _create_application(self, user, app_name, application_kwargs):
         """
         Create new application with given User, name, and option values.
@@ -134,7 +133,6 @@ class Command(BaseCommand):
                 application_access.scopes,
             ))
 
-
     def handle(self, *args, **options):
         username = options['username']
         user = User.objects.get(username=username)
@@ -168,7 +166,7 @@ class Command(BaseCommand):
                 username
             ))
         else:
-            application = self._create_new_application(user, app_name, application_kwargs)
+            application = self._create_application(user, app_name, application_kwargs)
 
         scopes = options['scopes']
         if scopes:

--- a/openedx/core/djangoapps/oauth_dispatch/management/commands/tests/test_create_dot_application.py
+++ b/openedx/core/djangoapps/oauth_dispatch/management/commands/tests/test_create_dot_application.py
@@ -40,7 +40,7 @@ class TestCreateDotApplication(TestCase):
             self.user.username,
             "--update",
             "--grant-type",
-            APPLICATION.GRANT_CLIENT_CREDENTIALS,
+            Application.GRANT_CLIENT_CREDENTIALS,
             "--public",
             "--redirect-uris",
         ]
@@ -50,7 +50,7 @@ class TestCreateDotApplication(TestCase):
         call_command(Command(), *call_args)
         app = Application.objects.get(name=APP_NAME)
         self.assertEqual(app.redirect_uris, URI_OLD)
-        self.assertRaises(ApplicationAccess.DoesNotExist):
+        with self.assertRaises(ApplicationAccess.DoesNotExist):
             ApplicationAccess.objects.get(application_id=app.id)
 
         # Make sure we can call again with no changes
@@ -58,7 +58,7 @@ class TestCreateDotApplication(TestCase):
         call_command(Command(), *call_args)
         app = Application.objects.get(name=APP_NAME)
         self.assertEqual(app.redirect_uris, URI_OLD)
-        self.assertRaises(ApplicationAccess.DoesNotExist):
+        with self.assertRaises(ApplicationAccess.DoesNotExist):
             ApplicationAccess.objects.get(application_id=app.id)
 
         # Make sure calling with new URI changes URI, but does not add access
@@ -66,7 +66,7 @@ class TestCreateDotApplication(TestCase):
         call_command(Command(), *call_args)
         app = Application.objects.get(name=APP_NAME)
         self.assertEqual(app.redirect_uris, URI_NEW)
-        self.assertRaises(ApplicationAccess.DoesNotExist):
+        with self.assertRaises(ApplicationAccess.DoesNotExist):
             ApplicationAccess.objects.get(application_id=app.id)
 
         # Make sure calling with scopes adds access

--- a/openedx/core/djangoapps/oauth_dispatch/management/commands/tests/test_create_dot_application.py
+++ b/openedx/core/djangoapps/oauth_dispatch/management/commands/tests/test_create_dot_application.py
@@ -33,8 +33,8 @@ class TestCreateDotApplication(TestCase):
         APP_NAME = "update_test_application"
         URI_OLD = "https://example.com/old"
         URI_NEW = "https://example.com/new"
-        SCOPES_X = "email,profile,user_id"
-        SCOPES_Y = "email,profile"
+        SCOPES_X = ["email", "profile", "user_id"]
+        SCOPES_Y = ["email", "profile"]
         base_call_args = [
             APP_NAME,
             self.user.username,
@@ -70,7 +70,7 @@ class TestCreateDotApplication(TestCase):
             ApplicationAccess.objects.get(application_id=app.id)
 
         # Make sure calling with scopes adds access
-        call_args = base_call_args + [URI_NEW, "--scopes", SCOPES_X]
+        call_args = base_call_args + [URI_NEW, "--scopes", ",".join(SCOPES_X)]
         call_command(Command(), *call_args)
         app = Application.objects.get(name=APP_NAME)
         self.assertEqual(app.redirect_uris, URI_NEW)
@@ -78,7 +78,7 @@ class TestCreateDotApplication(TestCase):
         self.assertEqual(access.scopes, SCOPES_X)
 
         # Make sure calling with new scopes changes them
-        call_args = base_call_args + [URI_NEW, "--scopes", SCOPES_Y]
+        call_args = base_call_args + [URI_NEW, "--scopes", ",".join(SCOPES_Y)]
         call_command(Command(), *call_args)
         app = Application.objects.get(name=APP_NAME)
         self.assertEqual(app.redirect_uris, URI_NEW)

--- a/openedx/core/djangoapps/oauth_dispatch/management/commands/tests/test_create_dot_application.py
+++ b/openedx/core/djangoapps/oauth_dispatch/management/commands/tests/test_create_dot_application.py
@@ -29,7 +29,7 @@ class TestCreateDotApplication(TestCase):
         super(TestCreateDotApplication, self).tearDown()
         Application.objects.filter(user=self.user).delete()
 
-    def test_update_dot_application(self)
+    def test_update_dot_application(self):
         APP_NAME = "update_test_application"
         URI_OLD = "https://example.com/old"
         URI_NEW = "https://example.com/new"
@@ -84,7 +84,6 @@ class TestCreateDotApplication(TestCase):
         self.assertEqual(app.redirect_uris, URI_NEW)
         access = ApplicationAccess.objects.get(application_id=app.id)
         self.assertEqual(access.scopes, SCOPES_Y)
-
 
     @ddt.data(
         (None, None, None, None, False, None),

--- a/openedx/core/djangoapps/oauth_dispatch/management/commands/tests/test_create_dot_application.py
+++ b/openedx/core/djangoapps/oauth_dispatch/management/commands/tests/test_create_dot_application.py
@@ -29,6 +29,63 @@ class TestCreateDotApplication(TestCase):
         super(TestCreateDotApplication, self).tearDown()
         Application.objects.filter(user=self.user).delete()
 
+    def test_update_dot_application(self)
+        APP_NAME = "update_test_application"
+        URI_OLD = "https://example.com/old"
+        URI_NEW = "https://example.com/new"
+        SCOPES_X = "email,profile,user_id"
+        SCOPES_Y = "email,profile"
+        base_call_args = [
+            APP_NAME,
+            self.user.username,
+            "--update",
+            "--grant-type",
+            APPLICATION.GRANT_CLIENT_CREDENTIALS,
+            "--public",
+            "--redirect-uris",
+        ]
+
+        # Make sure we can create Application with --update
+        call_args = base_call_args + [URI_OLD]
+        call_command(Command(), *call_args)
+        app = Application.objects.get(name=APP_NAME)
+        self.assertEqual(app.redirect_uris, URI_OLD)
+        self.assertRaises(ApplicationAccess.DoesNotExist):
+            ApplicationAccess.objects.get(application_id=app.id)
+
+        # Make sure we can call again with no changes
+        call_args = base_call_args + [URI_OLD]
+        call_command(Command(), *call_args)
+        app = Application.objects.get(name=APP_NAME)
+        self.assertEqual(app.redirect_uris, URI_OLD)
+        self.assertRaises(ApplicationAccess.DoesNotExist):
+            ApplicationAccess.objects.get(application_id=app.id)
+
+        # Make sure calling with new URI changes URI, but does not add access
+        call_args = base_call_args + [URI_NEW]
+        call_command(Command(), *call_args)
+        app = Application.objects.get(name=APP_NAME)
+        self.assertEqual(app.redirect_uris, URI_NEW)
+        self.assertRaises(ApplicationAccess.DoesNotExist):
+            ApplicationAccess.objects.get(application_id=app.id)
+
+        # Make sure calling with scopes adds access
+        call_args = base_call_args + [URI_NEW, "--scopes", SCOPES_X]
+        call_command(Command(), *call_args)
+        app = Application.objects.get(name=APP_NAME)
+        self.assertEqual(app.redirect_uris, URI_NEW)
+        access = ApplicationAccess.objects.get(application_id=app.id)
+        self.assertEqual(access.scopes, SCOPES_X)
+
+        # Make sure calling with new scopes changes them
+        call_args = base_call_args + [URI_NEW, "--scopes", SCOPES_Y]
+        call_command(Command(), *call_args)
+        app = Application.objects.get(name=APP_NAME)
+        self.assertEqual(app.redirect_uris, URI_NEW)
+        access = ApplicationAccess.objects.get(application_id=app.id)
+        self.assertEqual(access.scopes, SCOPES_Y)
+
+
     @ddt.data(
         (None, None, None, None, False, None),
         (None, None, 'client-abc', None, False, None),


### PR DESCRIPTION
@edx/masters-neem 
https://openedx.atlassian.net/browse/EDUCATOR-4489
Blocks https://github.com/edx/configuration/pull/5304

One if the bugs causing the linked issue was that `./manage.py lms create_dot_access` will silently do nothing if the specified DOT Application already exists. Because the Registrar (and eCommerce, and Credentials) Applications existed on int-nightly already, provisioning a new sandbox fails to overwrite the `int-nightly` redirect URLs.

In order to avoid breaking any existing users of the command, I added an `--update` option, which causes the command to update the Application and ApplicationAccess with the values from the command.