### PR TITLE
Remove user cookie reset on Student Dashboard.

### DIFF
--- a/common/djangoapps/student/tests/test_views.py
+++ b/common/djangoapps/student/tests/test_views.py
@@ -214,19 +214,6 @@ class StudentDashboardTests(SharedModuleStoreTestCase, MilestonesTestCaseMixin, 
 
         course_overview.save()
 
-    def test_user_info_cookie(self):
-        """
-        Verify visiting the learner dashboard sets the user info cookie.
-        """
-        self.assertNotIn(settings.EDXMKTG_USER_INFO_COOKIE_NAME, self.client.cookies)
-
-        request = RequestFactory().get(self.path)
-        request.user = self.user
-        expected = json.dumps(_get_user_info_cookie_data(request, self.user))
-        self.client.get(self.path)
-        actual = self.client.cookies[settings.EDXMKTG_USER_INFO_COOKIE_NAME].value
-        self.assertEqual(actual, expected)
-
     def test_redirect_account_settings(self):
         """
         Verify if user does not have profile he/she is redirected to account_settings.

--- a/common/djangoapps/student/views/dashboard.py
+++ b/common/djangoapps/student/views/dashboard.py
@@ -903,6 +903,4 @@ def student_dashboard(request):
         'resume_button_urls': resume_button_urls
     })
 
-    response = render_to_response('dashboard.html', context)
-    set_logged_in_cookies(request, response, user)
-    return response
+    return render_to_response('dashboard.html', context)

--- a/openedx/core/djangoapps/user_authn/cookies.py
+++ b/openedx/core/djangoapps/user_authn/cookies.py
@@ -238,7 +238,6 @@ def _get_user_info_cookie_data(request, user):
         'version': settings.EDXMKTG_USER_INFO_COOKIE_VERSION,
         'username': user.username,
         'header_urls': header_urls,
-        'enrollmentStatusHash': CourseEnrollment.generate_enrollment_status_hash(user)
     }
 
     return user_info

--- a/openedx/core/djangoapps/user_authn/tests/test_cookies.py
+++ b/openedx/core/djangoapps/user_authn/tests/test_cookies.py
@@ -94,7 +94,6 @@ class CookieTests(TestCase):
             'version': settings.EDXMKTG_USER_INFO_COOKIE_VERSION,
             'username': self.user.username,
             'header_urls': self._get_expected_header_urls(),
-            'enrollmentStatusHash': CourseEnrollment.generate_enrollment_status_hash(self.user)
         }
 
         self.assertDictEqual(actual, expected)


### PR DESCRIPTION
The enrollmentStatusHash cookie value was created in commit f0030334
as an optimization, in order to determine whether the marketing site
needs to refresh the list of a student's enrolled courses with a
call to the LMS. To ensure that this value was kept up to date,
commit d7a7bcc1 reset the user's cookies every time they go to the
learner dashboard page (which used to be the next page loaded after
you enrolled in a course). This didn't just reset the
enrollmentStatusHash though -- it recalculated all the cookie
values, as if you had just logged in.

A number of things have changed since then:

1. Enrolling in a course now goes to that course's info/navigation
   page, rather than going to the student dashboard.
2. It doesn't appear that the value of enrollmentStatusHash is
   actually being examined anywhere -- it's set in a cookie on the
   LMS and read/written by the edX marketing front end code, but
   the value is never looked at to make any decisions.
3. The introduction of add_email_marketing_cookies (which triggers
   off of the CREATE_LOGON_COOKIE signal) has made cookie resets
   far more expensive, as there is a blocking call to Sailthru if
   you have that enabled in EmailMarketingConfiguration (which
   edx.org does). This can add over two seconds to the server
   processing time for the student dashboard at certain times of
   day.

Given this, I'm removing both the call to resetting the cookie on
the student dashboard page, as well as setting the value for
enrollmentStatusHash.