### PR TITLE
Fix Numeric input problems are backwards for right-to-left languages

### DIFF
--- a/cms/static/sass/elements/_xblocks.scss
+++ b/cms/static/sass/elements/_xblocks.scss
@@ -438,6 +438,11 @@
       margin: ($baseline/2);
       padding: ($baseline/2);
       overflow: hidden;
+
+      code::before,
+      code::after {
+        @include display-left-to-right();
+      }
     }
 
     // STATE: container/component with children - abbreviated preview

--- a/cms/static/sass/vendor/bi-app/_mixins.scss
+++ b/cms/static/sass/vendor/bi-app/_mixins.scss
@@ -316,3 +316,9 @@
     @content;
   }
 }
+
+@mixin display-left-to-right {
+  @if $bi-app-direction == rtl {
+    content: "\200E‎";
+  }
+}

--- a/lms/static/sass/course/courseware/_courseware.scss
+++ b/lms/static/sass/course/courseware/_courseware.scss
@@ -327,12 +327,15 @@ html.video-fullscreen {
         p {
           margin: 0;
         }
+
         h4 {
           margin-top: ($baseline * 3/2);
         }
+
         ul {
           margin: 0;
         }
+
         .exam-action-button {
           margin-top: $baseline / 2;
         }
@@ -348,7 +351,7 @@ html.video-fullscreen {
         position: relative;
 
         &.start-timed-exam {
-          margin-bottom:($baseline/2);
+          margin-bottom: ($baseline/2);
           display: block;
 
           &.action-primary {
@@ -382,7 +385,7 @@ html.video-fullscreen {
 
     .proctored-exam-skip-confirm-wrapper {
       border-left: ($baseline/4) solid $red;
-      padding: $baseline ($baseline*1.5);;
+      padding: $baseline ($baseline*1.5);
       background-color: rgb(242, 244, 245);
 
       .msg-title {
@@ -433,7 +436,6 @@ html.video-fullscreen {
         float: left;
         width: 80%;
         margin-bottom: 25px;
-
       }
 
       a.contest-review {
@@ -467,7 +469,7 @@ html.video-fullscreen {
     .faq-proctoring-exam {
       @extend .footer-sequence;
 
-      border-bottom : none;
+      border-bottom: none;
 
       a.footer-link {
         display: block;
@@ -513,6 +515,11 @@ html.video-fullscreen {
         margin-bottom: lh();
         padding-bottom: 0;
         border-bottom: none;
+      }
+
+      code::before,
+      code::after {
+        @include display-left-to-right();
       }
     }
 
@@ -664,7 +671,9 @@ html.video-fullscreen {
       }
     }
 
-    .xqa-modal, .staff-modal, .history-modal {
+    .xqa-modal,
+    .staff-modal,
+    .history-modal {
       width: 80%;
       height: 80%;
       left: left(20%);
@@ -749,7 +758,6 @@ html.video-fullscreen {
 
 .xmodule_VideoModule {
   margin-bottom: ($baseline*1.5);
-
 }
 
 textarea.short-form-response {

--- a/lms/static/sass/vendor/bi-app/_mixins.scss
+++ b/lms/static/sass/vendor/bi-app/_mixins.scss
@@ -292,3 +292,9 @@
     @content;
   }
 }
+
+@mixin display-left-to-right {
+  @if $bi-app-direction == rtl {
+    content: "\200E‎";
+  }
+}


### PR DESCRIPTION
## Fix Numeric input problems are backward for right-to-left languages
This PR fixes bidirectional languages issue with numeric inputs. The bidi(bi-directional) algorithm is not intelligent enough at the moment to decide how to display numeric expression. As suggested on the request, we should always display numeric expression (text wrapped inside the `code` elements) in LTR( Left to Right ) no matter if the browser language is RTL (Right to Left).

Directions for Code Review:
1. Switch the language to `arabic` from your account settings > Site preferences. 
2. Verify the content is being displayed same in LTR (English language) and RTL (Arabic Langauge)



[PROD-368](https://openedx.atlassian.net/browse/PROD-368) 
Test & reproduce on on Prod : [Prod](https://courses.edx.org/courses/course-v1:MITx+6.00.1x+2T2019/courseware/fc8f42302c644118adfcfa720f9f403e/221a4c17dba341d6a970a0d80343253c/11)
Verify the fix on [SandBox -- Studio](https://studio-ltr.sandbox.edx.org/container/block-v1:edX+DemoX+Demo_Course+type@vertical+block@1247b38c533845e1b471e8ebbc367121?action=new)