### PR TITLE
Test: Change version of social-auth-app-django

### DIFF
--- a/common/djangoapps/third_party_auth/pipeline.py
+++ b/common/djangoapps/third_party_auth/pipeline.py
@@ -209,6 +209,11 @@ def get(request):
     """Gets the running pipeline's data from the passed request."""
     strategy = social_django.utils.load_strategy(request)
     token = strategy.session_get('partial_pipeline_token')
+
+    if not token:
+        strategy.session_set('partial_pipeline_token', strategy.session_get('partial_pipeline_token_'))
+        token = strategy.session_get('partial_pipeline_token')
+
     partial_object = strategy.partial_load(token)
     pipeline_data = None
     if partial_object:
@@ -559,6 +564,9 @@ def ensure_user_information(strategy, auth_entry, backend=None, user=None, socia
         saml_providers_list = list(provider.Registry.get_enabled_by_backend_name('tpa-saml'))
         return (current_provider and
                 current_provider.slug in [saml_provider.slug for saml_provider in saml_providers_list])
+
+    if current_partial:
+        strategy.session_set('partial_pipeline_token_', current_partial.token)
 
     if not user:
         # Use only email for user existence check in case of saml provider

--- a/common/djangoapps/third_party_auth/tests/specs/test_linkedin.py
+++ b/common/djangoapps/third_party_auth/tests/specs/test_linkedin.py
@@ -4,6 +4,15 @@ from __future__ import absolute_import
 from third_party_auth.tests.specs import base
 
 
+def get_localized_name(name):
+    """Returns the localizedName from the name object"""
+    locale = "{}_{}".format(
+        name["preferredLocale"]["language"],
+        name["preferredLocale"]["country"]
+    )
+    return name['localized'].get(locale, '')
+
+
 class LinkedInOauth2IntegrationTest(base.Oauth2IntegrationTest):
     """Integration tests for provider.LinkedInOauth2."""
 
@@ -21,11 +30,29 @@ class LinkedInOauth2IntegrationTest(base.Oauth2IntegrationTest):
         'expires_in': 'expires_in_value',
     }
     USER_RESPONSE_DATA = {
-        'lastName': 'lastName_value',
+        'lastName': {
+            "localized": {
+                "en_US": "Doe"
+            },
+            "preferredLocale": {
+                "country": "US",
+                "language": "en"
+            }
+        },
         'id': 'id_value',
-        'firstName': 'firstName_value',
+        'firstName': {
+            "localized": {
+                "en_US": "Doe"
+            },
+            "preferredLocale": {
+                "country": "US",
+                "language": "en"
+            }
+        },
     }
 
     def get_username(self):
         response_data = self.get_response_data()
-        return response_data.get('firstName') + response_data.get('lastName')
+        first_name = get_localized_name(response_data.get('firstName'))
+        last_name = get_localized_name(response_data.get('lastName'))
+        return first_name + last_name

--- a/common/djangoapps/third_party_auth/tests/utils.py
+++ b/common/djangoapps/third_party_auth/tests/utils.py
@@ -98,7 +98,7 @@ class ThirdPartyOAuthTestMixinFacebook(object):
 class ThirdPartyOAuthTestMixinGoogle(object):
     """Tests oauth with the Google backend"""
     BACKEND = "google-oauth2"
-    USER_URL = "https://www.googleapis.com/plus/v1/people/me"
+    USER_URL = "https://www.googleapis.com/oauth2/v3/userinfo"
     # In google-oauth2 responses, the "email" field is used as the user's identifier
     UID_FIELD = "email"
 

--- a/requirements/edx/base.in
+++ b/requirements/edx/base.in
@@ -131,8 +131,8 @@ pyuca==1.1                          # For more accurate sorting of translated co
 reportlab                           # Used for shopping cart's pdf invoice/receipt generation
 rest-condition                      # DRF's recommendation for supporting complex permissions
 rfc6266-parser                      # Used to generate Content-Disposition headers.
-social-auth-app-django<3.0.0
-social-auth-core<2.0.0
+social-auth-app-django
+social-auth-core
 pysrt                               # Support for SubRip subtitle files, used in the video XModule
 pytz                                # Time zone information database
 PyYAML                              # Used to parse XModule resource templates

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -227,8 +227,8 @@ simplejson==3.16.0        # via mailsnake, sailthru-client
 singledispatch==3.4.0.3
 six==1.12.0
 slumber==0.7.1            # via edx-bulk-grades, edx-enterprise, edx-rest-api-client
-social-auth-app-django==2.1.0
-social-auth-core==1.7.0
+social-auth-app-django==3.1.0
+social-auth-core==3.2.0
 sorl-thumbnail==12.3
 sortedcontainers==2.1.0
 soupsieve==1.9.3          # via beautifulsoup4

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -305,8 +305,8 @@ singledispatch==3.4.0.3
 six==1.12.0
 slumber==0.7.1
 snowballstemmer==1.9.1    # via sphinx
-social-auth-app-django==2.1.0
-social-auth-core==1.7.0
+social-auth-app-django==3.1.0
+social-auth-core==3.2.0
 sorl-thumbnail==12.3
 sortedcontainers==2.1.0
 soupsieve==1.9.3

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -294,8 +294,8 @@ simplejson==3.16.0
 singledispatch==3.4.0.3
 six==1.12.0
 slumber==0.7.1
-social-auth-app-django==2.1.0
-social-auth-core==1.7.0
+social-auth-app-django==3.1.0
+social-auth-core==3.2.0
 sorl-thumbnail==12.3
 sortedcontainers==2.1.0
 soupsieve==1.9.3


### PR DESCRIPTION
Microsoft social login is not working on edx mobile app. The issue is fixed in newer version of social-auth-app-django.

We are not passing response object as keyword argument in [do_auth](https://github.com/edx/edx-platform/blob/32c29b0d8f1d81233601c595857535a9ce88b24e/common/djangoapps/student/views/management.py#L705)
```python
File "/edx/app/edxapp/edx-platform/common/djangoapps/student/views/management.py", line 705, in create_account_with_params
    pipeline_user = request.backend.do_auth(social_access_token, user=user)
  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/social_core/utils.py", line 252, in wrapper
    return func(*args, **kwargs)
  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/social_core/backends/oauth.py", line 410, in do_auth
    data = self.user_data(access_token, *args, **kwargs)
  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/social_core/backends/azuread.py", line 80, in user_data
    id_token = response.get('id_token')
AttributeError: 'NoneType' object has no attribute 'get'
```
[In the version we are using](https://github.com/python-social-auth/social-core/blob/1.7.0/social_core/backends/azuread.py#L78-L80) response object is required
```python
    def user_data(self, access_token, *args, **kwargs):
        response = kwargs.get('response')
        id_token = response.get('id_token')
```
[In newer version this problem is fixed](https://github.com/python-social-auth/social-core/blob/3.2.0/social_core/backends/azuread.py#L78-L83) by making response optional
```python
def user_data(self, access_token, *args, **kwargs):
        response = kwargs.get('response')
        if response and response.get('id_token'):
            id_token = response.get('id_token')
        else:
            id_token = access_token
```

[LEARNER-6357](https://openedx.atlassian.net/browse/LEARNER-6357)