### PR TITLE
Making student account deletion components a bit site aware

### DIFF
--- a/lms/static/js/student_account/StudentAccountDeletionInitializer.js
+++ b/lms/static/js/student_account/StudentAccountDeletionInitializer.js
@@ -16,7 +16,13 @@ const wrapperRendered = setInterval(() => {
       component: StudentAccountDeletion,
       selector: `#${accountDeletionWrapperId}`,
       componentName: 'StudentAccountDeletion',
-      props: { socialAccountLinks: window.auth, isActive: window.isActive },
+      props: {
+        socialAccountLinks: window.auth,
+        isActive: window.isActive,
+        platformName: window.platformName,
+        siteName: window.siteName,
+        lmsUrlRoot: window.lmsUrlRoot
+      },
     });
   }
 

--- a/lms/static/js/student_account/StudentAccountDeletionInitializer.js
+++ b/lms/static/js/student_account/StudentAccountDeletionInitializer.js
@@ -21,7 +21,7 @@ const wrapperRendered = setInterval(() => {
         isActive: window.isActive,
         platformName: window.platformName,
         siteName: window.siteName,
-        lmsUrlRoot: window.lmsUrlRoot
+        mktgRootLink: window.mktgRootLink
       },
     });
   }

--- a/lms/static/js/student_account/StudentAccountDeletionInitializer.js
+++ b/lms/static/js/student_account/StudentAccountDeletionInitializer.js
@@ -19,9 +19,10 @@ const wrapperRendered = setInterval(() => {
       props: {
         socialAccountLinks: window.auth,
         isActive: window.isActive,
+        additionalSiteSpecificDeletionText: window.additionalSiteSpecificDeletionText,
+        mktgRootLink: window.mktgRootLink,
         platformName: window.platformName,
-        siteName: window.siteName,
-        mktgRootLink: window.mktgRootLink
+        siteName: window.siteName
       },
     });
   }

--- a/lms/static/js/student_account/components/StudentAccountDeletion.jsx
+++ b/lms/static/js/student_account/components/StudentAccountDeletion.jsx
@@ -73,18 +73,34 @@ export class StudentAccountDeletion extends React.Component {
     );
 
     const acctDeletionWarningText = StringUtils.interpolate(
-      gettext('{strongStart}Warning: Account deletion is permanent.{strongEnd} Please read the above carefully before proceeding. This is an irreversible action, and {strongStart}you will no longer be able to use the same email on edX.{strongEnd}'),
+      gettext('{strongStart}Warning: Account deletion is permanent.{strongEnd} Please read the above carefully before proceeding. This is an irreversible action, and {strongStart}you will no longer be able to use the same email on {platformName}.{strongEnd}'),
       {
         strongStart: '<strong>',
         strongEnd: '</strong>',
+        platformName: this.props.platformName,
+      },
+    );
+
+    const noteDeletion = StringUtils.interpolate(
+      gettext('Please note: Deletion of your account and personal data is permanent and cannot be undone. {platformName} will not be able to recover your account or the data that is deleted.'),
+      {
+        platformName: this.props.platformName,
+      },
+    );
+
+    const bodyDeletion = StringUtils.interpolate(
+      gettext('Once your account is deleted, you cannot use it to take courses on the {platformName} app, {siteName}, or any other site hosted by {platformName}.'),
+      {
+        platformName: this.props.platformName,
+        siteName: this.props.siteName,
       },
     );
 
     return (
       <div className="account-deletion-details">
         <p className="account-settings-header-subtitle">{ gettext('We’re sorry to see you go!') }</p>
-        <p className="account-settings-header-subtitle">{ gettext('Please note: Deletion of your account and personal data is permanent and cannot be undone. EdX will not be able to recover your account or the data that is deleted.') }</p>
-        <p className="account-settings-header-subtitle">{ gettext('Once your account is deleted, you cannot use it to take courses on the edX app, edx.org, or any other site hosted by edX. This includes access to edx.org from your employer’s or university’s system and access to private sites offered by MIT Open Learning, Wharton Executive Education, and Harvard Medical School.') }</p>
+        <p className="account-settings-header-subtitle">{noteDeletion}</p>
+        <p className="account-settings-header-subtitle">{bodyDeletion}</p>
         <p
           className="account-settings-header-subtitle"
           dangerouslySetInnerHTML={{ __html: loseAccessText }}
@@ -125,7 +141,12 @@ export class StudentAccountDeletion extends React.Component {
             open
           />
         }
-        {deletionModalOpen && <StudentAccountDeletionModal onClose={this.closeDeletionModal} />}
+        {deletionModalOpen && <StudentAccountDeletionModal
+          onClose={this.closeDeletionModal}
+          platformName={this.props.platformName}
+          siteName={this.props.siteName}
+          lmsUrlRoot={this.props.lmsUrlRoot}
+        />}
       </div>
     );
   }
@@ -136,4 +157,13 @@ StudentAccountDeletion.propTypes = {
   socialAccountLinks: PropTypes.shape({
     providers: PropTypes.arrayOf(PropTypes.object),
   }).isRequired,
+  platformName: PropTypes.string,
+  siteName: PropTypes.string,
+  lmsUrlRoot: PropTypes.string,
+};
+
+StudentAccountDeletion.defaultProps = {
+  platformName: '',
+  siteName: '',
+  lmsUrlRoot: '',
 };

--- a/lms/static/js/student_account/components/StudentAccountDeletion.jsx
+++ b/lms/static/js/student_account/components/StudentAccountDeletion.jsx
@@ -100,7 +100,10 @@ export class StudentAccountDeletion extends React.Component {
       <div className="account-deletion-details">
         <p className="account-settings-header-subtitle">{ gettext('We’re sorry to see you go!') }</p>
         <p className="account-settings-header-subtitle">{noteDeletion}</p>
-        <p className="account-settings-header-subtitle">{bodyDeletion}</p>
+        <p className="account-settings-header-subtitle">
+              <span>{bodyDeletion} </span>
+              <span>{ gettext('This includes access to edx.org from your employer’s or university’s system and access to private sites offered by MIT Open Learning, Wharton Executive Education, and Harvard Medical School.') }</span>
+        </p>
         <p
           className="account-settings-header-subtitle"
           dangerouslySetInnerHTML={{ __html: loseAccessText }}

--- a/lms/static/js/student_account/components/StudentAccountDeletion.jsx
+++ b/lms/static/js/student_account/components/StudentAccountDeletion.jsx
@@ -145,7 +145,7 @@ export class StudentAccountDeletion extends React.Component {
           onClose={this.closeDeletionModal}
           platformName={this.props.platformName}
           siteName={this.props.siteName}
-          lmsUrlRoot={this.props.lmsUrlRoot}
+          mktgRootLink={this.props.mktgRootLink}
         />}
       </div>
     );
@@ -159,11 +159,11 @@ StudentAccountDeletion.propTypes = {
   }).isRequired,
   platformName: PropTypes.string,
   siteName: PropTypes.string,
-  lmsUrlRoot: PropTypes.string,
+  mktgRootLink: PropTypes.string,
 };
 
 StudentAccountDeletion.defaultProps = {
   platformName: '',
   siteName: '',
-  lmsUrlRoot: '',
+  mktgRootLink: '',
 };

--- a/lms/static/js/student_account/components/StudentAccountDeletion.jsx
+++ b/lms/static/js/student_account/components/StudentAccountDeletion.jsx
@@ -97,13 +97,12 @@ export class StudentAccountDeletion extends React.Component {
     );
 
     const bodyDeletion2 = StringUtils.interpolate(
-      gettext('This includes access to {siteName} from your employer’s or university’s system and access to private sites offered by {additionalSiteSpecificDeletionText}.'),
+      gettext('This includes access to {siteName} from your employer’s or university’s system{additionalSiteSpecificDeletionText}.'),
       {
         siteName: this.props.siteName,
         additionalSiteSpecificDeletionText: this.props.additionalSiteSpecificDeletionText,
       },
     );
-
 
     return (
       <div className="account-deletion-details">

--- a/lms/static/js/student_account/components/StudentAccountDeletion.jsx
+++ b/lms/static/js/student_account/components/StudentAccountDeletion.jsx
@@ -96,13 +96,22 @@ export class StudentAccountDeletion extends React.Component {
       },
     );
 
+    const bodyDeletion2 = StringUtils.interpolate(
+      gettext('This includes access to {siteName} from your employer’s or university’s system and access to private sites offered by {additionalSiteSpecificDeletionText}.'),
+      {
+        siteName: this.props.siteName,
+        additionalSiteSpecificDeletionText: this.props.additionalSiteSpecificDeletionText,
+      },
+    );
+
+
     return (
       <div className="account-deletion-details">
         <p className="account-settings-header-subtitle">{ gettext('We’re sorry to see you go!') }</p>
         <p className="account-settings-header-subtitle">{noteDeletion}</p>
         <p className="account-settings-header-subtitle">
               <span>{bodyDeletion} </span>
-              <span>{ gettext('This includes access to edx.org from your employer’s or university’s system and access to private sites offered by MIT Open Learning, Wharton Executive Education, and Harvard Medical School.') }</span>
+              <span>{bodyDeletion2}</span>
         </p>
         <p
           className="account-settings-header-subtitle"
@@ -146,9 +155,10 @@ export class StudentAccountDeletion extends React.Component {
         }
         {deletionModalOpen && <StudentAccountDeletionModal
           onClose={this.closeDeletionModal}
+          additionalSiteSpecificDeletionText={this.props.additionalSiteSpecificDeletionText}
+          mktgRootLink={this.props.mktgRootLink}
           platformName={this.props.platformName}
           siteName={this.props.siteName}
-          mktgRootLink={this.props.mktgRootLink}
         />}
       </div>
     );
@@ -160,13 +170,15 @@ StudentAccountDeletion.propTypes = {
   socialAccountLinks: PropTypes.shape({
     providers: PropTypes.arrayOf(PropTypes.object),
   }).isRequired,
+  additionalSiteSpecificDeletionText: PropTypes.string,
+  mktgRootLink: PropTypes.string,
   platformName: PropTypes.string,
   siteName: PropTypes.string,
-  mktgRootLink: PropTypes.string,
 };
 
 StudentAccountDeletion.defaultProps = {
+  additionalSiteSpecificDeletionText: '',
+  mktgRootLink: '',
   platformName: '',
   siteName: '',
-  mktgRootLink: '',
 };

--- a/lms/static/js/student_account/components/StudentAccountDeletionModal.jsx
+++ b/lms/static/js/student_account/components/StudentAccountDeletionModal.jsx
@@ -31,7 +31,7 @@ class StudentAccountDeletionConfirmationModal extends React.Component {
     this.props.onClose();
 
     removeLoggedInCookies();
-    window.location.href = 'https://www.edx.org';
+    window.location.href = this.props.lmsUrlRoot;
   }
 
   deleteAccount() {
@@ -101,6 +101,21 @@ class StudentAccountDeletionConfirmationModal extends React.Component {
       },
     );
 
+    const noteDeletion = StringUtils.interpolate(
+      gettext('You have selected “Delete my account.” Deletion of your account and personal data is permanent and cannot be undone. {platformName} will not be able to recover your account or the data that is deleted.'),
+      {
+        platformName: this.props.platformName,
+      },
+    );
+
+    const bodyDeletion = StringUtils.interpolate(
+      gettext('If you proceed, you will be unable to use this account to take courses on the {platformName} app, {siteName}, or any other site hosted by {platformName}.'),
+      {
+        platformName: this.props.platformName,
+        siteName: this.props.siteName,
+      },
+    );
+
     return (
       <div className="delete-confirmation-wrapper">
         <Modal
@@ -137,8 +152,8 @@ class StudentAccountDeletionConfirmationModal extends React.Component {
                       <Icon id="delete-confirmation-body-warning-icon" className={['fa', 'fa-exclamation-triangle']} />
                     </div>
                     <div className="alert-content">
-                      <h3 className="alert-title">{ gettext('You have selected “Delete my account.” Deletion of your account and personal data is permanent and cannot be undone. EdX will not be able to recover your account or the data that is deleted.') }</h3>
-                      <p>{ gettext('If you proceed, you will be unable to use this account to take courses on the edX app, edx.org, or any other site hosted by edX. This includes access to edx.org from your employer’s or university’s system and access to private sites offered by MIT Open Learning, Wharton Executive Education, and Harvard Medical School.') }</p>
+                      <h3 className="alert-title">{noteDeletion}</h3>
+                      <p>{bodyDeletion}</p>
                       <p dangerouslySetInnerHTML={{ __html: loseAccessText }} />
                     </div>
                   </div>
@@ -198,10 +213,16 @@ class StudentAccountDeletionConfirmationModal extends React.Component {
 
 StudentAccountDeletionConfirmationModal.propTypes = {
   onClose: PropTypes.func,
+  platformName: PropTypes.string,
+  siteName: PropTypes.string,
+  lmsUrlRoot: PropTypes.string,
 };
 
 StudentAccountDeletionConfirmationModal.defaultProps = {
   onClose: () => {},
+  platformName: "",
+  siteName: "",
+  lmsUrlRoot: "",
 };
 
 export default StudentAccountDeletionConfirmationModal;

--- a/lms/static/js/student_account/components/StudentAccountDeletionModal.jsx
+++ b/lms/static/js/student_account/components/StudentAccountDeletionModal.jsx
@@ -116,6 +116,15 @@ class StudentAccountDeletionConfirmationModal extends React.Component {
       },
     );
 
+    const bodyDeletion2 = StringUtils.interpolate(
+      gettext('This includes access to {siteName} from your employer’s or university’s system and access to private sites offered by {additionalSiteSpecificDeletionText}.'),
+      {
+        siteName: this.props.siteName,
+        additionalSiteSpecificDeletionText: this.props.additionalSiteSpecificDeletionText,
+      },
+    );
+
+
     return (
       <div className="delete-confirmation-wrapper">
         <Modal
@@ -155,7 +164,7 @@ class StudentAccountDeletionConfirmationModal extends React.Component {
                       <h3 className="alert-title">{noteDeletion}</h3>
                       <p>
                         <span>{bodyDeletion} </span>
-                        <span>{ gettext('This includes access to edx.org from your employer’s or university’s system and access to private sites offered by MIT Open Learning, Wharton Executive Education, and Harvard Medical School.') }</span>
+                        <span>{bodyDeletion2}</span>
                       </p>
                       <p dangerouslySetInnerHTML={{ __html: loseAccessText }} />
                     </div>
@@ -216,16 +225,18 @@ class StudentAccountDeletionConfirmationModal extends React.Component {
 
 StudentAccountDeletionConfirmationModal.propTypes = {
   onClose: PropTypes.func,
+  additionalSiteSpecificDeletionText: PropTypes.string,
+  mktgRootLink: PropTypes.string,
   platformName: PropTypes.string,
   siteName: PropTypes.string,
-  mktgRootLink: PropTypes.string,
 };
 
 StudentAccountDeletionConfirmationModal.defaultProps = {
   onClose: () => {},
+  additionalSiteSpecificDeletionText: "",
+  mktgRootLink: "",
   platformName: "",
   siteName: "",
-  mktgRootLink: "",
 };
 
 export default StudentAccountDeletionConfirmationModal;

--- a/lms/static/js/student_account/components/StudentAccountDeletionModal.jsx
+++ b/lms/static/js/student_account/components/StudentAccountDeletionModal.jsx
@@ -117,7 +117,7 @@ class StudentAccountDeletionConfirmationModal extends React.Component {
     );
 
     const bodyDeletion2 = StringUtils.interpolate(
-      gettext('This includes access to {siteName} from your employer’s or university’s system and access to private sites offered by {additionalSiteSpecificDeletionText}.'),
+      gettext('This includes access to {siteName} from your employer’s or university’s system{additionalSiteSpecificDeletionText}.'),
       {
         siteName: this.props.siteName,
         additionalSiteSpecificDeletionText: this.props.additionalSiteSpecificDeletionText,

--- a/lms/static/js/student_account/components/StudentAccountDeletionModal.jsx
+++ b/lms/static/js/student_account/components/StudentAccountDeletionModal.jsx
@@ -31,7 +31,7 @@ class StudentAccountDeletionConfirmationModal extends React.Component {
     this.props.onClose();
 
     removeLoggedInCookies();
-    window.location.href = this.props.lmsUrlRoot;
+    window.location.href = this.props.mktgRootLink;
   }
 
   deleteAccount() {
@@ -215,14 +215,14 @@ StudentAccountDeletionConfirmationModal.propTypes = {
   onClose: PropTypes.func,
   platformName: PropTypes.string,
   siteName: PropTypes.string,
-  lmsUrlRoot: PropTypes.string,
+  mktgRootLink: PropTypes.string,
 };
 
 StudentAccountDeletionConfirmationModal.defaultProps = {
   onClose: () => {},
   platformName: "",
   siteName: "",
-  lmsUrlRoot: "",
+  mktgRootLink: "",
 };
 
 export default StudentAccountDeletionConfirmationModal;

--- a/lms/static/js/student_account/components/StudentAccountDeletionModal.jsx
+++ b/lms/static/js/student_account/components/StudentAccountDeletionModal.jsx
@@ -153,7 +153,10 @@ class StudentAccountDeletionConfirmationModal extends React.Component {
                     </div>
                     <div className="alert-content">
                       <h3 className="alert-title">{noteDeletion}</h3>
-                      <p>{bodyDeletion}</p>
+                      <p>
+                        <span>{bodyDeletion} </span>
+                        <span>{ gettext('This includes access to edx.org from your employer’s or university’s system and access to private sites offered by MIT Open Learning, Wharton Executive Education, and Harvard Medical School.') }</span>
+                      </p>
                       <p dangerouslySetInnerHTML={{ __html: loseAccessText }} />
                     </div>
                   </div>

--- a/lms/templates/student_account/account_settings.html
+++ b/lms/templates/student_account/account_settings.html
@@ -79,7 +79,7 @@ from openedx.core.djangoapps.user_api.accounts.utils import is_secondary_email_f
      window.isActive = ${ user.is_active | n, dump_js_escaped_json };
      window.platformName = "${ platform_name | n, js_escaped_string }";
      window.siteName = "${ static.get_value('SITE_NAME', settings.SITE_NAME) | n, js_escaped_string }";
-     window.lmsUrlRoot = "${ static.get_value('LMS_ROOT_URL', settings.LMS_ROOT_URL) | n, js_escaped_string }";
+     window.mktgRootLink = "${ static.marketing_link('ROOT') | n, js_escaped_string }";
 </script>
 <%static:webpack entry="StudentAccountDeletionInitializer">
 </%static:webpack>

--- a/lms/templates/student_account/account_settings.html
+++ b/lms/templates/student_account/account_settings.html
@@ -77,7 +77,7 @@ from openedx.core.djangoapps.user_api.accounts.utils import is_secondary_email_f
 <script type="text/javascript">
      window.auth = ${ auth | n, dump_js_escaped_json };
      window.isActive = ${ user.is_active | n, dump_js_escaped_json };
-     window.additionalSiteSpecificDeletionText = "${ static.get_value('SITE_SPECIFIC_DELETION_TEXT', 'MIT Open Learning, Wharton Executive Education, and Harvard Medical School.') | n, js_escaped_string }";
+     window.additionalSiteSpecificDeletionText = "${ static.get_value('SITE_SPECIFIC_DELETION_TEXT', _(' and access to private sites offered by MIT Open Learning, Wharton Executive Education, and Harvard Medical School')) | n, js_escaped_string }";
      window.mktgRootLink = "${ static.marketing_link('ROOT') | n, js_escaped_string }";
      window.platformName = "${ platform_name | n, js_escaped_string }";
      window.siteName = "${ static.get_value('SITE_NAME', settings.SITE_NAME) | n, js_escaped_string }";

--- a/lms/templates/student_account/account_settings.html
+++ b/lms/templates/student_account/account_settings.html
@@ -77,9 +77,11 @@ from openedx.core.djangoapps.user_api.accounts.utils import is_secondary_email_f
 <script type="text/javascript">
      window.auth = ${ auth | n, dump_js_escaped_json };
      window.isActive = ${ user.is_active | n, dump_js_escaped_json };
+     window.additionalSiteSpecificDeletionText = "${ static.get_value('SITE_SPECIFIC_DELETION_TEXT', 'MIT Open Learning, Wharton Executive Education, and Harvard Medical School.') | n, js_escaped_string }";
+     window.mktgRootLink = "${ static.marketing_link('ROOT') | n, js_escaped_string }";
      window.platformName = "${ platform_name | n, js_escaped_string }";
      window.siteName = "${ static.get_value('SITE_NAME', settings.SITE_NAME) | n, js_escaped_string }";
-     window.mktgRootLink = "${ static.marketing_link('ROOT') | n, js_escaped_string }";
+
 </script>
 <%static:webpack entry="StudentAccountDeletionInitializer">
 </%static:webpack>

--- a/lms/templates/student_account/account_settings.html
+++ b/lms/templates/student_account/account_settings.html
@@ -77,6 +77,9 @@ from openedx.core.djangoapps.user_api.accounts.utils import is_secondary_email_f
 <script type="text/javascript">
      window.auth = ${ auth | n, dump_js_escaped_json };
      window.isActive = ${ user.is_active | n, dump_js_escaped_json };
+     window.platformName = "${ platform_name | n, js_escaped_string }";
+     window.siteName = "${ static.get_value('SITE_NAME', settings.SITE_NAME) | n, js_escaped_string }";
+     window.lmsUrlRoot = "${ static.get_value('LMS_ROOT_URL', settings.LMS_ROOT_URL) | n, js_escaped_string }";
 </script>
 <%static:webpack entry="StudentAccountDeletionInitializer">
 </%static:webpack>


### PR DESCRIPTION
Right now, the account deletion components have hardcoded the site name and platform name. As it can be seen in the next two images.

![image](https://user-images.githubusercontent.com/22335041/63368318-a897e080-c34b-11e9-8c9b-4b258d2fbf26.png)
![image](https://user-images.githubusercontent.com/22335041/63368374-c402eb80-c34b-11e9-8076-45497d25bfda.png)

With this change, the components will use the site name and platform name defined in the settings:

![image](https://user-images.githubusercontent.com/22335041/63381671-2b7a6480-c367-11e9-973f-bf9a3c3a65c3.png)

![image](https://user-images.githubusercontent.com/22335041/63381739-4baa2380-c367-11e9-8dd2-d2da310763f1.png)


