### PR TITLE
Stop commerce API from deleting Masters course modes

### DIFF
--- a/lms/djangoapps/commerce/api/v1/models.py
+++ b/lms/djangoapps/commerce/api/v1/models.py
@@ -107,8 +107,20 @@ class Course(object):
             merged_modes.add(merged_mode)
             merged_mode_keys.add(merged_mode.mode_slug)
 
-        deleted_modes = set(existing_modes.keys()) - merged_mode_keys
-        self._deleted_modes = [existing_modes[mode] for mode in deleted_modes]
+        # Masters degrees are not sold through the eCommerce site.
+        # So, Masters course modes are not included in PUT calls to this API,
+        # and their omission which would normally cause them to be deleted.
+        # We don't want that to happen, but for the time being,
+        # we cannot include in Masters modes in the PUT calls from eCommerce.
+        # So, here's hack to handle Masters course modes, along with any other
+        # modes that end up in that boat.
+        MODES_TO_NOT_DELETE = {
+            CourseMode.MASTERS,
+        }
+
+        modes_to_delete = set(existing_modes.keys()) - merged_mode_keys
+        modes_to_delete -= MODES_TO_NOT_DELETE
+        self._deleted_modes = [existing_modes[mode] for mode in modes_to_delete]
         self.modes = list(merged_modes)
 
     @classmethod

--- a/lms/djangoapps/commerce/api/v1/permissions.py
+++ b/lms/djangoapps/commerce/api/v1/permissions.py
@@ -24,6 +24,6 @@ class IsAuthenticatedOrActivationOverridden(BasePermission):
         if not request.user.is_authenticated and is_account_activation_requirement_disabled():
             try:
                 request.user = User.objects.get(id=request.session._session_cache['_auth_user_id'])
-            except DoesNotExist:
+            except User.DoesNotExist:
                 pass
         return request.user.is_authenticated

--- a/lms/djangoapps/commerce/api/v1/tests/test_views.py
+++ b/lms/djangoapps/commerce/api/v1/tests/test_views.py
@@ -287,25 +287,46 @@ class CourseRetrieveUpdateViewTests(CourseApiViewTestMixin, ModuleStoreTestCase)
         self.assertIsNone(updated_verified_mode.expiration_datetime)
 
     def test_update_overwrite(self):
-        """ Verify that data submitted via PUT overwrites/deletes modes that are
-        not included in the body of the request. """
+        """
+        Verify that data submitted via PUT overwrites/deletes modes that are
+        not included in the body of the request, EXCEPT the Masters mode,
+        which it leaves alone.
+        """
         course_id = six.text_type(self.course.id)
-        expected_course_mode = CourseMode(
+        existing_mode = self.course_mode
+        existing_masters_mode = CourseMode.objects.create(
+            mode_slug=u'masters',
+            min_price=10000,
+            currency=u'USD',
+            sku=u'DEF456',
+            bulk_sku=u'BULK-DEF456'
+        )
+        new_mode = CourseMode(
             mode_slug=u'credit',
             min_price=500,
             currency=u'USD',
             sku=u'ABC123',
             bulk_sku=u'BULK-ABC123'
         )
-        expected = self._serialize_course(self.course, [expected_course_mode])
-        path = reverse('commerce_api:v1:courses:retrieve_update', args=[course_id])
-        response = self.client.put(path, json.dumps(expected), content_type=JSON_CONTENT_TYPE)
-        self.assertEqual(response.status_code, 200)
-        actual = json.loads(response.content)
-        self.assertEqual(actual, expected)
 
-        # The existing CourseMode should have been removed.
-        self.assertFalse(CourseMode.objects.filter(id=self.course_mode.id).exists())
+        path = reverse('commerce_api:v1:courses:retrieve_update', args=[course_id])
+        data = json.dumps(self._serialize_course(self.course, [new_mode]))
+        response = self.client.put(path, data, content_type=JSON_CONTENT_TYPE)
+        self.assertEqual(response.status_code, 200)
+
+        # Check modes list in response, disregarding its order.
+        expected_dict = self._serialize_course(
+            self.course, [new_mode, existing_masters_mode]
+        )
+        expected_items = expected_dict['modes']
+        actual_items = json.loads(response.content)['modes']
+        self.assertCountEqual(actual_items, expected_items)
+
+        # The existing non-Masters CourseMode should have been removed.
+        self.assertFalse(CourseMode.objects.filter(id=existing_mode.id).exists())
+
+        # The existing Masters course mode should remain.
+        self.assertTrue(CourseMode.objects.filter(id=existing_masters_mode.id).exists())
 
     @ddt.data(*itertools.product(
         ('honor', 'audit', 'verified', 'professional', 'no-id-professional'),


### PR DESCRIPTION
@edx/masters-neem 
https://openedx.atlassian.net/browse/EDUCATOR-4191

This solution isn't my favorite, but it's the simplest I can think of, and is probably a reasonable stop-gap until we can refactor the whole course mode situation.

My analysis of the linked ticket:
* The most immediate issue is that the LMS commerce API deletes modes that aren’t included in the PUT request. It seems like that behavior is intentional, so I’m nervous to stop it from deleting omitted course modes entirely. Instead, we could handle the Masters mode as a special case, which is what this Draft PR does.
 * The ticket suggests migrating [this](https://github.com/edx/ecommerce/blob/master/ecommerce/courses/publishers.py#L93) eCommerce publishing function from the LMS commerce API to the LMS course_modes API, which does not delete modes. Although I’m not against taking that route, there are some issues with it:
     * The LMS course_modes API would require some new features that would make this migration more time-consuming than 2 story points
     * Removing the delete-if-not-included behavior may have unintended consequences. We would need to do some discovery around this.
* A deeper solution to this problem could involve figuring out why it’s fine for the Audit mode to exist in eCommerce, but no the Masters mode, and if it’s something we could reconcile.
* The true solution to this problem will hopefully be investigated as part of the Track discovery ticket: https://openedx.atlassian.net/browse/EDUCATOR-4488

Happy to hear feedback / differing opinions.

**Update**
@schenedx and I talked offline:

* We agreed that this PR's change is a hack, and would be better to avoid if possible.
* Although changing the LMS commerce API to not delete modes in general is not a viable option (due to openedX instances), it is okay to change the behavior of eCommerce to not delete modes. There are two ways to do this:
    * Use the new course modes API: Again, this would require more work on the API.
    * When publishing modes, query the commerce API to GET its modes first, then do a PUT request including the existing modes.
* Audit exists in eCommerce for historical reasons; it would be best not to introduce Masters there.

The solution we will go with is:
* When publishing modes, query the commerce API to GET its modes first, then do a PUT request including the existing modes.
* Revisit the issue as part of https://openedx.atlassian.net/browse/EDUCATOR-4488.

 