### PR TITLE
Update matplotlib and numpy in codejail sandbox.

### DIFF
--- a/requirements/edx-sandbox/base.in
+++ b/requirements/edx-sandbox/base.in
@@ -10,12 +10,11 @@
 -c ../constraints.txt
 
 -r shared.txt                       # Dependencies in common with LMS and Studio
-matplotlib==1.5.3                   # 2D plotting library
-numpy==1.6.2                        # Numeric array processing utilities; used by scipy
+matplotlib==2.2.4                   # 2D plotting library
+numpy==1.7.2                        # Numeric array processing utilities; used by scipy
 pyparsing==2.2.0                    # Python Parsing module
 scipy==0.14.0                       # Math, science, and engineering library
 sympy==0.7.1                        # Symbolic math library
-tornado<6.0                         # via matplotlib; tornado dropped support for Python 2.7 and 3.4 with version 6.0
 git+https://github.com/edx/openedx-calc.git@e9b698c85ad1152002bc0868f475f153dce88952#egg=calc==0.4
 git+https://github.com/edx/openedx-chem.git@ff4e3a03d3c7610e47a9af08eb648d8aabe2eb18#egg=chem==1.0.0
 

--- a/requirements/edx-sandbox/base.txt
+++ b/requirements/edx-sandbox/base.txt
@@ -7,21 +7,21 @@
 common/lib/sandbox-packages
 common/lib/symmath
 asn1crypto==0.24.0
-backports-abc==0.5        # via tornado
+backports.functools-lru-cache==1.5  # via matplotlib
 git+https://github.com/edx/openedx-calc.git@e9b698c85ad1152002bc0868f475f153dce88952#egg=calc==0.4
 cffi==1.12.3
 git+https://github.com/edx/openedx-chem.git@ff4e3a03d3c7610e47a9af08eb648d8aabe2eb18#egg=chem==1.0.0
 cryptography==2.7
 cycler==0.10.0            # via matplotlib
 enum34==1.1.6
-futures==3.3.0 ; python_version == "2.7"  # via tornado
 ipaddress==1.0.22
+kiwisolver==1.1.0         # via matplotlib
 lxml==3.8.0
 markupsafe==1.1.1
-matplotlib==1.5.3
+matplotlib==2.2.4
 networkx==1.7
 nltk==3.4.4
-numpy==1.6.2
+numpy==1.7.2
 pycparser==2.19
 pyparsing==2.2.0
 python-dateutil==2.8.0    # via matplotlib
@@ -29,5 +29,8 @@ pytz==2019.1              # via matplotlib
 scipy==0.14.0
 singledispatch==3.4.0.3
 six==1.11.0
+subprocess32==3.5.4       # via matplotlib
 sympy==0.7.1
-tornado==5.1.1
+
+# The following packages are considered to be unsafe in a requirements file:
+# setuptools==41.0.1        # via kiwisolver


### PR DESCRIPTION
This version of matplot lib is the last one that supports Python 2 and Has support for Python 3.