### PR TITLE
Updated regex and tests

### DIFF
--- a/common/static/js/spec/utility_spec.js
+++ b/common/static/js/spec/utility_spec.js
@@ -36,5 +36,9 @@ describe('utility.rewriteCdnLinksToStatic', function() {
           rewriteCdnLinksToStatic( // eslint-disable-line no-undef
             '<img src="https://prod-edxapp.edx-cdn.org/assets/foo.x"/>')
         ).toBe('<img src="/static/foo.x"/>');
+        expect(
+          rewriteCdnLinksToStatic( // eslint-disable-line no-undef
+            '<img src="//prod-edxapp.edx-cdn.org/assets/v1/TestCourse_6.0x/foo.x"/>')
+        ).toBe('<img src="/static/foo.x"/>');
     });
 });

--- a/common/static/js/src/utility.js
+++ b/common/static/js/src/utility.js
@@ -42,6 +42,6 @@ window.rewriteStaticLinks = function(content, from, to) {
 // Utility method for replacing absolute URLs
 window.rewriteCdnLinksToStatic = function(content) {
     'use strict';
-    var regex = new RegExp('((https?:)?[/][/](www.)?[-a-zA-Z0-9@:%._+~#=]{2,256}[a-z]{2,6}([-a-zA-Z0-9@:%_+~#?&//=]*)|[a-z-]{14})[/]', 'g');// eslint-disable-line max-len
+    var regex = new RegExp('((https?:)?[/][/](www.)?[-a-zA-Z0-9@:%._+~#=]{2,256}[a-z]{2,6}([-a-zA-Z0-9@:%._+~#?&//=]*)|[a-z-]{14})[/]', 'g');// eslint-disable-line max-len
     return content.replace(regex, '/static/');
 };


### PR DESCRIPTION
## [PROD-498](https://openedx.atlassian.net/browse/PROD-498)

### Description
This pr fixes the unchanged part of direct links to static URL. The previous regex used for replacing the CDN URL doesn’t cater dot (.) sign in between the URL, specifically in the course key. Due to this, some part of the URL is changed to static whereas other parts containing dot(.) sign remains unchanged.

**Sandbox**
https://studio-prod-498.sandbox.edx.org/course_info/course-v1:static_Cdn_3.X+CS1032+2019_1#

### Reviewers
If you've been tagged for review, please check your corresponding box once you've given the :+1:.
- [ ] Code review: @DawoudSheraz 
- [ ] Code review: @asadazam93 

### Post-review
- [ ] Rebase and squash commits