### PR TITLE
check for too long data in task_input field

### DIFF
--- a/lms/djangoapps/instructor/views/api.py
+++ b/lms/djangoapps/instructor/views/api.py
@@ -185,7 +185,7 @@ def common_exceptions_400(func):
             message = _('User does not exist.')
         except MultipleObjectsReturned:
             message = _('Found a conflict with given identifier. Please try an alternative identifier')
-        except (AlreadyRunningError, QueueConnectionError) as err:
+        except (AlreadyRunningError, QueueConnectionError, AttributeError) as err:
             message = six.text_type(err)
 
         if use_json:

--- a/lms/djangoapps/instructor_task/models.py
+++ b/lms/djangoapps/instructor_task/models.py
@@ -28,6 +28,7 @@ from django.conf import settings
 from django.contrib.auth.models import User
 from django.core.files.base import ContentFile
 from django.db import models, transaction
+from django.utils.translation import ugettext as _
 from opaque_keys.edx.django.models import CourseKeyField
 from six import text_type
 
@@ -38,6 +39,7 @@ logger = logging.getLogger(__name__)
 # define custom states used by InstructorTask
 QUEUING = 'QUEUING'
 PROGRESS = 'PROGRESS'
+TASK_INPUT_LENGTH = 10000
 
 
 class InstructorTask(models.Model):
@@ -100,6 +102,17 @@ class InstructorTask(models.Model):
         # create the task_id here, and pass it into celery:
         task_id = str(uuid4())
         json_task_input = json.dumps(task_input)
+
+        # check length of task_input, and return an exception if it's too long
+        if len(json_task_input) > TASK_INPUT_LENGTH:
+            logger.error(
+                u'Task input longer than: `%s` for `%s` of course: `%s`',
+                TASK_INPUT_LENGTH,
+                task_type,
+                course_id
+            )
+            error_msg = _('An error has occurred. Task was not created.')
+            raise AttributeError(error_msg)
 
         # create the task, then save it:
         instructor_task = cls(

--- a/lms/djangoapps/instructor_task/tests/test_models.py
+++ b/lms/djangoapps/instructor_task/tests/test_models.py
@@ -14,8 +14,27 @@ from mock import patch
 from opaque_keys.edx.locator import CourseLocator
 
 from common.test.utils import MockS3Mixin
-from lms.djangoapps.instructor_task.models import ReportStore
+from lms.djangoapps.instructor_task.models import InstructorTask, ReportStore, TASK_INPUT_LENGTH
 from lms.djangoapps.instructor_task.tests.test_base import TestReportMixin
+
+
+class TestInstructorTasksModel(TestCase):
+    """
+    Test validations in instructor task model
+    """
+    def test_task_input_valid_length(self):
+        """
+        Test allowed length of task_input field
+        """
+        task_input = 's' * TASK_INPUT_LENGTH
+        with self.assertRaises(AttributeError):
+            InstructorTask.create(
+                course_id='dummy_course_id',
+                task_type='dummy type',
+                task_key='dummy key',
+                task_input=task_input,
+                requester='dummy requester',
+            )
 
 
 class ReportStoreTestMixin(object):


### PR DESCRIPTION
# [PROD-495](https://openedx.atlassian.net/browse/PROD-495)

### Description

Adding a validation check on `task_input` field of `instructor_task` table. This check would prevent the addition of too long data in this field.

### Testing
- [x] Unit

### Reviewers
- [ ] @ormsbee 
- [x] @awaisdar001 

### Post-review
- [x] Rebase and squash commits