### PR TITLE
Making the regex that gets the index courses more secure

### DIFF
--- a/openedx/core/djangoapps/content/course_overviews/models.py
+++ b/openedx/core/djangoapps/content/course_overviews/models.py
@@ -584,7 +584,7 @@ class CourseOverview(TimeStampedModel):
             # In rare cases, courses belonging to the same org may be accidentally assigned
             # an org code with a different casing (e.g., Harvardx as opposed to HarvardX).
             # Case-insensitive matching allows us to deal with this kind of dirty data.
-            course_overviews = course_overviews.filter(org__iregex=r'(' + '|'.join(orgs) + ')')
+            course_overviews = course_overviews.filter(org__iregex=r'(^' + '$|^'.join(orgs) + '$)')
 
         if filter_:
             course_overviews = course_overviews.filter(**filter_)


### PR DESCRIPTION
In any page that looks up relevant courses to the user,  it is possible to find courses that don't belong to  a valid org. For example, if we have two orgs called “EXAMPLE” and “EXA”,  on two different microsites, looking up for courses would return the same for both orgs.

We modified the regular expression to match strictly complete orgs name and not substrings. 