### PR TITLE
Fix image cropping for photo ID verify.

### DIFF
--- a/lms/static/js/verify_student/views/webcam_photo_view.js
+++ b/lms/static/js/verify_student/views/webcam_photo_view.js
@@ -50,11 +50,14 @@
                  },
 
                  snapshot: function() {
-                     var video;
+                     var video, canvas;
 
                      if (this.stream) {
                          video = this.getVideo();
-                         this.getCanvas().getContext('2d').drawImage(video, 0, 0);
+                         canvas = this.getCanvas();
+                         canvas.width = video.videoWidth;
+                         canvas.height = video.videoHeight;
+                         canvas.getContext('2d').drawImage(video, 0, 0);
                          video.pause();
                          return true;
                      }
@@ -151,20 +154,6 @@
                      return this.imageData;
                  },
 
-                 flashObjectTag: function() {
-                     return (
-                        '<object type="application/x-shockwave-flash" ' +
-                            'id="flash_video" ' +
-                            'name="flash_video" ' +
-                            'data="/static/js/verify_student/CameraCapture.swf" ' +
-                            'width="500" ' +
-                            'height="375">' +
-                         '<param name="quality" value="high">' +
-                         '<param name="allowscriptaccess" value="sameDomain">' +
-                         '</object>'
-                     );
-                 },
-
                  getFlashObject: function() {
                      return $('#flash_video')[0];
                  },
@@ -242,10 +231,10 @@
              this.setSubmitButtonEnabled(false);
 
             // Load the template for the webcam into the DOM
-             renderedHtml = _.template($(this.template).html())(
+             renderedHtml = edx.HtmlUtils.template($(this.template).html())(
                 {backendName: this.backend.name}
             );
-             $(this.el).html(renderedHtml);
+             edx.HtmlUtils.setHtml($(this.el), renderedHtml);
 
              $resetBtn = this.$el.find('#webcam_reset_button');
              $captureBtn = this.$el.find('#webcam_capture_button');


### PR DESCRIPTION
In chrome on latest MacOS 10.14.6 image was cropping, fixed by setting video width and height to canvas.

Followed this article to fix the problem: https://www.html5rocks.com/en/tutorials/getusermedia/intro/

**Sandbox:** https://social-auth.sandbox.edx.org/verify_student/reverify

PROD-499