### PR TITLE
Remove UTM params from password reset link.

### DIFF
--- a/common/djangoapps/student/forms.py
+++ b/common/djangoapps/student/forms.py
@@ -49,7 +49,7 @@ def send_password_reset_email_for_user(user, request, preferred_email=None):
         'request': request,  # Used by google_analytics_tracking_pixel
         # TODO: This overrides `platform_name` from `get_base_template_context` to make the tests passes
         'platform_name': configuration_helpers.get_value('PLATFORM_NAME', settings.PLATFORM_NAME),
-        'reset_link': '{protocol}://{site}{link}'.format(
+        'reset_link': '{protocol}://{site}{link}?track=pwreset'.format(
             protocol='https' if request.is_secure() else 'http',
             site=configuration_helpers.get_value('SITE_NAME', settings.SITE_NAME),
             link=reverse('password_reset_confirm', kwargs={

--- a/common/templates/student/edx_ace/passwordreset/email/body.html
+++ b/common/templates/student/edx_ace/passwordreset/email/body.html
@@ -36,7 +36,23 @@
                 ## xss-lint: disable=django-trans-missing-escape
                 {% trans "Change my Password" as course_cta_text %}
 
-                {% include "ace_common/edx_ace/common/return_to_course_cta.html" with course_cta_text=course_cta_text course_cta_url=reset_link %}
+                {# email client support for style sheets is pretty spotty, so we have to inline all of these styles #}
+                <a href="{{ reset_link }}" style="
+                    color: #ffffff;
+                    text-decoration: none;
+                    border-radius: 4px;
+                    -webkit-border-radius: 4px;
+                    -moz-border-radius: 4px;
+                    background-color: #005686;
+                    border-top: 12px solid #005686;
+                    border-bottom: 12px solid #005686;
+                    border-right: 50px solid #005686;
+                    border-left: 50px solid #005686;
+                    display: inline-block;
+                ">
+                    {# old email clients require the use of the font tag :( #}
+                    <font color="#ffffff"><b>{{ course_cta_text }}</b></font>
+                </a>
             {% endif %}
         </td>
     </tr>


### PR DESCRIPTION
This type of email is just a transactional message and should not be crediting revenue to email. Removed UTM parameters and added `?track=pwreset` query param.

PROD-482