### PR TITLE
Fix image cropping and submission for photo ID verify.

### DIFF
--- a/lms/static/js/verify_student/views/webcam_photo_view.js
+++ b/lms/static/js/verify_student/views/webcam_photo_view.js
@@ -55,9 +55,7 @@
                      if (this.stream) {
                          video = this.getVideo();
                          canvas = this.getCanvas();
-                         canvas.width = video.videoWidth;
-                         canvas.height = video.videoHeight;
-                         canvas.getContext('2d').drawImage(video, 0, 0);
+                         canvas.getContext('2d').drawImage(video, 0, 0, canvas.width, canvas.height);
                          video.pause();
                          return true;
                      }


### PR DESCRIPTION
Using the available video resolution increasing the image and request size and server started failing requests. Fixed it by using canvas width and height which is **640X480**.

**Sandbox:** https://social-auth.sandbox.edx.org/verify_student/reverify

PROD-499