### PR TITLE
Rmove the extra configurabilty logic for reset buttons.

### DIFF
--- a/common/lib/xmodule/xmodule/capa_base.py
+++ b/common/lib/xmodule/xmodule/capa_base.py
@@ -190,14 +190,12 @@ class CapaFields(object):
         scope=Scope.settings,
         default=False
     )
-    reset_key = "DEFAULT_SHOW_RESET_BUTTON"
-    default_reset_button = getattr(settings, reset_key) if hasattr(settings, reset_key) else False
     show_reset_button = Boolean(
         display_name=_("Show Reset Button"),
         help=_("Determines whether a 'Reset' button is shown so the user may reset their answer. "
                "A default value can be set in Advanced Settings."),
         scope=Scope.settings,
-        default=default_reset_button
+        default=False
     )
     rerandomize = Randomization(
         display_name=_("Randomization"),

--- a/common/lib/xmodule/xmodule/modulestore/inheritance.py
+++ b/common/lib/xmodule/xmodule/modulestore/inheritance.py
@@ -3,7 +3,6 @@ Support for inheritance of fields down an XBlock hierarchy.
 """
 from __future__ import absolute_import
 
-from django.conf import settings
 from django.utils import timezone
 
 from xmodule.partitions.partitions import UserPartition
@@ -189,8 +188,6 @@ class InheritanceMixin(XBlockMixin):
         scope=Scope.settings
     )
 
-    reset_key = "DEFAULT_SHOW_RESET_BUTTON"
-    default_reset_button = getattr(settings, reset_key) if hasattr(settings, reset_key) else False
     show_reset_button = Boolean(
         display_name=_("Show Reset Button for Problems"),
         help=_(
@@ -199,7 +196,7 @@ class InheritanceMixin(XBlockMixin):
             "this course-wide setting is changed."
         ),
         scope=Scope.settings,
-        default=default_reset_button
+        default=False
     )
     edxnotes = Boolean(
         display_name=_("Enable Student Notes"),


### PR DESCRIPTION
The `DEFAULT_SHOW_RESET_BUTTON` is not actually referenced anywhere
other than in these two places where it's read.  As far as I can tell,
nothing sets this value so it's always going to fallback to false.

Since this mixin is imported during startup, removing this unblocks
testing on python3 where it can fail to start up if the settings haven't
fully loaded before you try to access them.