### PR TITLE
Stop commerce API from deleting Masters course modes

### DIFF
--- a/lms/djangoapps/commerce/api/v1/models.py
+++ b/lms/djangoapps/commerce/api/v1/models.py
@@ -107,8 +107,20 @@ class Course(object):
             merged_modes.add(merged_mode)
             merged_mode_keys.add(merged_mode.mode_slug)
 
-        deleted_modes = set(existing_modes.keys()) - merged_mode_keys
-        self._deleted_modes = [existing_modes[mode] for mode in deleted_modes]
+        # Masters degrees are not sold through the eCommerce site.
+        # So, Masters course modes are not included in PUT calls to this API,
+        # and their omission which would normally cause them to be deleted.
+        # We don't want that to happen, but for the time being,
+        # we cannot include in Masters modes in the PUT calls from eCommerce.
+        # So, here's hack to handle Masters course modes, along with any other
+        # modes that end up in that boat.
+        MODES_TO_NOT_DELETE = {
+            CourseMode.MASTERS,
+        }
+
+        modes_to_delete = set(existing_modes.keys()) - merged_mode_keys
+        modes_to_delete -= MODES_TO_NOT_DELETE
+        self._deleted_modes = [existing_modes[mode] for mode in modes_to_delete]
         self.modes = list(merged_modes)
 
     @classmethod

--- a/lms/djangoapps/commerce/api/v1/permissions.py
+++ b/lms/djangoapps/commerce/api/v1/permissions.py
@@ -24,6 +24,6 @@ class IsAuthenticatedOrActivationOverridden(BasePermission):
         if not request.user.is_authenticated and is_account_activation_requirement_disabled():
             try:
                 request.user = User.objects.get(id=request.session._session_cache['_auth_user_id'])
-            except DoesNotExist:
+            except User.DoesNotExist:
                 pass
         return request.user.is_authenticated


### PR DESCRIPTION
re-opened Kyle's original PR - this is the LMS-centric fix of https://openedx.atlassian.net/browse/EDUCATOR-4191 