### PR TITLE
Constrain two more requirements.

### DIFF
--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -72,3 +72,9 @@ drf-yasg==1.16
 
 # 2.0.0 is a dummy package, because faulthandler has been incorporated into pytest 5.0
 pytest-faulthandler<2.0.0
+
+# faulthandler is part of core python staring with python 3.3
+faulthandler; python_version == "2.7"
+
+# Numpy 1.17.0 only supports python >= 3.5
+numpy<1.17.0

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -135,7 +135,7 @@ glob2==0.7
 gunicorn==19.9.0
 help-tokens==1.0.4
 html5lib==1.0.1
-httplib2==0.13.0          # via oauth2, zendesk
+httplib2==0.13.1          # via oauth2, zendesk
 idna==2.8
 inflection==0.3.1         # via drf-yasg
 ipaddress==1.0.22
@@ -212,8 +212,9 @@ requests-oauthlib==1.1.0
 requests==2.22.0
 rest-condition==1.0.3
 rfc6266-parser==0.0.5.post2
-ruamel.ordereddict==0.4.13 ; python_version == "2.7"  # via ruamel.yaml
-ruamel.yaml==0.15.100     # via drf-yasg
+ruamel.ordereddict==0.4.14 ; python_version == "2.7"  # via ruamel.yaml
+ruamel.yaml.clib==0.1.0   # via ruamel.yaml
+ruamel.yaml==0.16.0       # via drf-yasg
 rules==2.0.1
 s3transfer==0.1.13        # via boto3
 sailthru-client==2.2.3

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -150,7 +150,7 @@ event-tracking==0.2.9
 execnet==1.6.1
 factory_boy==2.8.1
 faker==2.0.0
-faulthandler==3.1
+faulthandler==3.1 ; python_version == "2.7"
 feedparser==5.1.3
 filelock==3.0.12
 firebase-token-generator==1.3.2
@@ -169,11 +169,11 @@ glob2==0.7
 gunicorn==19.9.0
 help-tokens==1.0.4
 html5lib==1.0.1
-httplib2==0.13.0
+httplib2==0.13.1
 httpretty==0.9.6
 idna==2.8
 imagesize==1.1.0          # via sphinx
-importlib-metadata==0.18
+importlib-metadata==0.19
 inflect==2.1.0
 inflection==0.3.1
 ipaddress==1.0.22
@@ -282,8 +282,9 @@ requests-oauthlib==1.1.0
 requests==2.22.0
 rest-condition==1.0.3
 rfc6266-parser==0.0.5.post2
-ruamel.ordereddict==0.4.13 ; python_version == "2.7"
-ruamel.yaml==0.15.100
+ruamel.ordereddict==0.4.14 ; python_version == "2.7"
+ruamel.yaml.clib==0.1.0
+ruamel.yaml==0.16.0
 rules==2.0.1
 s3transfer==0.1.13
 sailthru-client==2.2.3
@@ -325,7 +326,7 @@ unidiff==0.5.5
 uritemplate==3.0.0
 urllib3==1.23
 user-util==0.1.5
-virtualenv==16.7.1
+virtualenv==16.7.2
 voluptuous==0.11.5
 vulture==1.0
 watchdog==0.9.0

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -145,7 +145,7 @@ event-tracking==0.2.9
 execnet==1.6.1            # via pytest-xdist
 factory_boy==2.8.1
 faker==2.0.0              # via factory-boy
-faulthandler==3.1         # via pytest-faulthandler
+faulthandler==3.1 ; python_version == "2.7"  # via pytest-faulthandler
 feedparser==5.1.3
 filelock==3.0.12          # via tox
 firebase-token-generator==1.3.2
@@ -164,10 +164,10 @@ glob2==0.7
 gunicorn==19.9.0
 help-tokens==1.0.4
 html5lib==1.0.1
-httplib2==0.13.0
+httplib2==0.13.1
 httpretty==0.9.6
 idna==2.8
-importlib-metadata==0.18  # via pluggy, tox
+importlib-metadata==0.19  # via pluggy, tox
 inflect==2.1.0
 inflection==0.3.1
 ipaddress==1.0.22
@@ -273,8 +273,9 @@ requests-oauthlib==1.1.0
 requests==2.22.0
 rest-condition==1.0.3
 rfc6266-parser==0.0.5.post2
-ruamel.ordereddict==0.4.13 ; python_version == "2.7"
-ruamel.yaml==0.15.100
+ruamel.ordereddict==0.4.14 ; python_version == "2.7"
+ruamel.yaml.clib==0.1.0
+ruamel.yaml==0.16.0
 rules==2.0.1
 s3transfer==0.1.13
 sailthru-client==2.2.3
@@ -312,7 +313,7 @@ unidiff==0.5.5
 uritemplate==3.0.0
 urllib3==1.23
 user-util==0.1.5
-virtualenv==16.7.1        # via tox
+virtualenv==16.7.2        # via tox
 voluptuous==0.11.5
 watchdog==0.9.0
 wcwidth==0.1.7            # via pytest


### PR DESCRIPTION
Both python 3 related but different reasons. numpy dropped python 3
support and faulthandler was pulled into python in python 3.3