### PR TITLE
SE-1155 [Campus.il] fix crashes on non-ascii in usernames for ccx enrollments

### DIFF
--- a/lms/djangoapps/ccx/tests/test_views.py
+++ b/lms/djangoapps/ccx/tests/test_views.py
@@ -89,7 +89,7 @@ def setup_students_and_grades(context):
         context.student = student = UserFactory.create()
         CourseEnrollmentFactory.create(user=student, course_id=context.course.id)
 
-        context.student2 = student2 = UserFactory.create()
+        context.student2 = student2 = UserFactory.create(username=u'u\u0131\u028c\u0279\u0250\u026f')
         CourseEnrollmentFactory.create(user=student2, course_id=context.course.id)
 
         # create grades for self.student as if they'd submitted the ccx

--- a/lms/djangoapps/ccx/utils.py
+++ b/lms/djangoapps/ccx/utils.py
@@ -260,14 +260,14 @@ def ccx_students_enrolling_center(action, identifiers, email_students, course_ke
                 if student:
                     must_enroll = student in staff or student in admins or student == coach
             except CCXUserValidationException as exp:
-                log.info("%s", exp)
-                errors.append("{0}".format(exp))
+                log.info(u"%s", exp)
+                errors.append(u"{0}".format(exp))
                 continue
 
             if CourseEnrollment.objects.is_course_full(ccx_course_overview) and not must_enroll:
                 error = _(u'The course is full: the limit is {max_student_enrollments_allowed}').format(
                     max_student_enrollments_allowed=ccx_course_overview.max_student_enrollments_allowed)
-                log.info("%s", error)
+                log.info(u"%s", error)
                 errors.append(error)
                 break
             enroll_email(course_key, email, auto_enroll=True, email_students=email_students, email_params=email_params)
@@ -276,8 +276,8 @@ def ccx_students_enrolling_center(action, identifiers, email_students, course_ke
             try:
                 email, __ = get_valid_student_with_email(identifier)
             except CCXUserValidationException as exp:
-                log.info("%s", exp)
-                errors.append("{0}".format(exp))
+                log.info(u"%s", exp)
+                errors.append(u"{0}".format(exp))
                 continue
             unenroll_email(course_key, email, email_students=email_students, email_params=email_params)
     return errors

--- a/lms/djangoapps/ccx/views.py
+++ b/lms/djangoapps/ccx/views.py
@@ -552,7 +552,8 @@ def ccx_grades_csv(request, course, ccx=None):
                 }
 
                 row_percents = [percents.get(label, 0.0) for label in header]
-                rows.append([student.id, student.email, student.username,
+                rows.append([student.id, student.email.encode('utf-8'),
+                             student.username.encode('utf-8'),
                              course_grade.percent] + row_percents)
 
         buf = StringIO()


### PR DESCRIPTION
Currently, non-ascii characters in ccx enrollments textbox crash the server when bulk enrolling/unenrolling, and non-ascii chars in usernames crash the server when downloading student grades for a ccx course.

Additionally, the log calls would crash with a traceback (while not affecting the program flow).

It appears to be related to invalid mixing of `str` and `unicode` types in python2.

This PR aims to fix these issues.

**JIRA tickets**: [OSPR-3766](https://openedx.atlassian.net/browse/OSPR-3766)

**Dependencies**: None

**Sandbox URL**: 


-    LMS: https://pr21248.sandbox.opencraft.hosting/
-    Studio: https://studio.pr21248.sandbox.opencraft.hosting/



**Merge deadline**: None

**Testing instructions**:

1. enable CCX and unicode usernames (see settings below)
2. create a CCX course and make sure there is at least one unit in the base course
3. register a new user with a username that contains non-ascii characters
4. navigate to the ccx coach dashboard
5. enter a username that contains non-ascii characters and also does not exist in the system
6. click 'enroll'
7. verify that the server doesn't crash and correctly replies with "Could not find a user with name or email "<username here>""
8. enter the username of the previously registered user
9. click 'enroll'
10. verify that the user has been enrolled
11. navigate to the 'Student Admin' tab
12. click 'Download student grades'
13. verify that the csv file is correctly generated and downloads (note that if the non-ascii text includes text from a RTL language, you may need to open with a spreadsheet application rather than just a text editor to view it properly) 
14. navigate back to the ccx enrollment tab
15. enter the previously registered username
16. click 'unenroll'
17. verify correctly unenrolls
18. enter another username that contains non-ascii characters
19. click 'unenroll'
20. verify that correct error message is shown and no server crash
21. check the lms-logs - there should be no tracebacks from logging calls crashing


**Author notes and concerns**:


**Reviewers**
- [x] @pomegranited 
- [ ] edX reviewer[s] TBD

**Settings**
```yaml
EDXAPP_FEATURES:
  CUSTOM_COURSES_EDX: true
  ENABLE_UNICODE_USERNAME: true
```