### PR TITLE
DISCO-1222: Allow switching course numbers for reruns

### DIFF
--- a/cms/djangoapps/api/v1/serializers/course_runs.py
+++ b/cms/djangoapps/api/v1/serializers/course_runs.py
@@ -8,6 +8,7 @@ import six
 from django.contrib.auth import get_user_model
 from django.db import transaction
 from django.utils.translation import ugettext_lazy as _
+from opaque_keys import InvalidKeyError
 from rest_framework import serializers
 from rest_framework.fields import empty
 
@@ -168,29 +169,40 @@ class CourseRunCreateSerializer(CourseRunSerializer):
 class CourseRunRerunSerializer(CourseRunSerializerCommonFieldsMixin, CourseRunTeamSerializerMixin,
                                serializers.Serializer):
     title = serializers.CharField(source='display_name', required=False)
+    number = serializers.CharField(source='id.course', required=False)
     run = serializers.CharField(source='id.run')
 
-    def validate_run(self, value):
+    def validate(self, attrs):
         course_run_key = self.instance.id
+        _id = attrs.get('id')
+        number = _id.get('course', course_run_key.course)
+        run = _id['run']
         store = modulestore()
-        with store.default_store('split'):
-            new_course_run_key = store.make_course_key(course_run_key.org, course_run_key.course, value)
+        try:
+            with store.default_store('split'):
+                new_course_run_key = store.make_course_key(course_run_key.org, number, run)
+        except InvalidKeyError:
+            raise serializers.ValidationError(
+                u'Invalid key supplied. Ensure there are no special characters in the Course Number.'
+            )
         if store.has_course(new_course_run_key, ignore_case=True):
-            raise serializers.ValidationError(u'Course run {key} already exists'.format(key=new_course_run_key))
-        return value
+            raise serializers.ValidationError(
+                {'run': u'Course run {key} already exists'.format(key=new_course_run_key)}
+            )
+        return attrs
 
     def update(self, instance, validated_data):
         course_run_key = instance.id
         _id = validated_data.pop('id')
+        number = _id.get('course', course_run_key.course)
+        run = _id['run']
         team = validated_data.pop('team', [])
         user = self.context['request'].user
         fields = {
             'display_name': instance.display_name
         }
         fields.update(validated_data)
-        new_course_run_key = rerun_course(
-            user, course_run_key, course_run_key.org, course_run_key.course, _id['run'], fields, False
-        )
+        new_course_run_key = rerun_course(user, course_run_key, course_run_key.org, number, run, fields, False)
 
         course_run = get_course_and_check_access(new_course_run_key, user)
         self.update_team(course_run, team)


### PR DESCRIPTION
We want to allow Course Number to be a parameter when creating a rerun so it is able to be different from the previous runs of the course. This will allow us to change course numbers in course metadata and have the new course number reflected in studio. This helps eliminate the need for creating a secondary course with the correct number and creating runs there and then needing to move them around in course metadata to have the proper parent/child relationships.