### PR TITLE
Revert "Support a URL address as FOOTER_ORGANIZATION_LOGO"

### DIFF
--- a/lms/djangoapps/branding/api.py
+++ b/lms/djangoapps/branding/api.py
@@ -486,12 +486,13 @@ def _absolute_url_staticfile(is_secure, name):
         unicode
 
     """
-    # In production, the static file name will be an absolute
-    # URL pointing to a CDN. In this case, we can just return the URL.
-    if six.moves.urllib.parse.urlparse(name).netloc:
-        return name
-
     url_path = staticfiles_storage.url(name)
+
+    # In production, the static files URL will be an absolute
+    # URL pointing to a CDN.  If this happens, we can just
+    # return the URL.
+    if six.moves.urllib.parse.urlparse(url_path).netloc:
+        return url_path
 
     # For local development, the returned URL will be relative,
     # so we need to make it absolute.

--- a/lms/djangoapps/branding/tests/test_views.py
+++ b/lms/djangoapps/branding/tests/test_views.py
@@ -9,7 +9,7 @@ import mock
 import six
 from django.conf import settings
 from django.contrib.auth.models import User
-from django.test import TestCase, override_settings
+from django.test import TestCase
 from django.urls import reverse
 
 from branding.models import BrandingApiConfig
@@ -109,10 +109,13 @@ class TestFooter(CacheIsolationTestCase):
     def test_absolute_urls_with_cdn(self):
         self._set_feature_flag(True)
 
-        # Requesting footer while we have overridden FOOTER_ORGANIZATION_IMAGE
-        # with an absolute url
-        cdn_url = u"http://cdn.example.com/static/image.png"
-        with override_settings(FOOTER_ORGANIZATION_IMAGE=cdn_url):
+        # Ordinarily, we'd use `override_settings()` to override STATIC_URL,
+        # which is what the staticfiles storage backend is using to construct the URL.
+        # Unfortunately, other parts of the system are caching this value on module
+        # load, which can cause other tests to fail.  To ensure that this change
+        # doesn't affect other tests, we patch the `url()` method directly instead.
+        cdn_url = "http://cdn.example.com/static/image.png"
+        with mock.patch('branding.api.staticfiles_storage.url', return_value=cdn_url):
             resp = self._get_footer()
 
         self.assertEqual(resp.status_code, 200)


### PR DESCRIPTION
Reverts edx/edx-platform#20001 due to a bug introduced with broken footer images on edx.org [PROD-510](https://openedx.atlassian.net/browse/PROD-510)