### PR TITLE
Add support for metadata files that have more than one SAML Signing Key.

### DIFF
--- a/common/djangoapps/third_party_auth/tasks.py
+++ b/common/djangoapps/third_party_auth/tasks.py
@@ -173,6 +173,14 @@ def _parse_metadata_xml(xml, entity_id):
     public_key = sso_desc.findtext("./{}//{}".format(
         etree.QName(SAML_XML_NS, "KeyDescriptor"), "{http://www.w3.org/2000/09/xmldsig#}X509Certificate"
     ))
+    signing_public_key = sso_desc.findtext("./{}{}//{}".format(
+        etree.QName(SAML_XML_NS, "KeyDescriptor"),
+        "[@use='signing']",
+        "{http://www.w3.org/2000/09/xmldsig#}X509Certificate"
+    ))
+    if signing_public_key and public_key != signing_public_key:
+        public_key = signing_public_key
+
     if not public_key:
         raise MetadataParseError("Public Key missing. Expected an <X509Certificate>")
     public_key = public_key.replace(" ", "")


### PR DESCRIPTION
###  Add support for metadata files that have more than one SAML Signing Key.

### **Description**

This PR adds support for metadata files that have more than one key, this is typical of instances of the ADSF from Microsoft. It modifies the fetching process of the SAML metadata by storing the signing key if there is one specified explicitly.