### PR TITLE
Fix course:org link creation upon rerun.

### DIFF
--- a/cms/djangoapps/contentstore/tasks.py
+++ b/cms/djangoapps/contentstore/tasks.py
@@ -45,6 +45,7 @@ from models.settings.course_metadata import CourseMetadata
 from openedx.core.djangoapps.embargo.models import CountryAccessRule, RestrictedCourse
 from openedx.core.lib.extract_tar import safetar_extractall
 from student.auth import has_course_author_access
+from util.organizations_helpers import add_organization_course, get_organization_by_short_name
 from xmodule.contentstore.django import contentstore
 from xmodule.course_module import CourseFields
 from xmodule.exceptions import SerializationError
@@ -484,6 +485,8 @@ def rerun_course(source_course_key_string, destination_course_key_string, user_i
             for country_access_rule in country_access_rules:
                 clone_instance(country_access_rule, {'restricted_course': new_restricted_course})
 
+        org_data = get_organization_by_short_name(source_course_key.org)
+        add_organization_course(org_data, destination_course_key)
         return "succeeded"
 
     except DuplicateCourseError:

--- a/cms/djangoapps/contentstore/tests/test_course_create_rerun.py
+++ b/cms/djangoapps/contentstore/tests/test_course_create_rerun.py
@@ -66,10 +66,16 @@ class TestCourseListing(ModuleStoreTestCase):
         self.client.logout()
         ModuleStoreTestCase.tearDown(self)
 
+    @patch.dict('django.conf.settings.FEATURES', {'ORGANIZATIONS_APP': True})
     def test_rerun(self):
         """
         Just testing the functionality the view handler adds over the tasks tested in test_clone_course
         """
+        add_organization({
+            'name': 'Test Organization',
+            'short_name': self.source_course_key.org,
+            'description': 'Testing Organization Description',
+        })
         response = self.client.ajax_post(self.course_create_rerun_url, {
             'source_course_key': six.text_type(self.source_course_key),
             'org': self.source_course_key.org, 'course': self.source_course_key.course, 'run': 'copy',
@@ -86,6 +92,9 @@ class TestCourseListing(ModuleStoreTestCase):
         self.assertEqual(dest_course.end, source_course.end)
         self.assertEqual(dest_course.enrollment_start, None)
         self.assertEqual(dest_course.enrollment_end, None)
+        course_orgs = get_course_organizations(dest_course_key)
+        self.assertEqual(len(course_orgs), 1)
+        self.assertEqual(course_orgs[0]['short_name'], self.source_course_key.org)
 
     @ddt.data(ModuleStoreEnum.Type.mongo, ModuleStoreEnum.Type.split)
     def test_newly_created_course_has_web_certs_enabled(self, store):


### PR DESCRIPTION
Upon rerun creation from publisher course:organization link was not creating, due to which org logo was not appearing on course certificates.

Fixed by creating course:org link upon rerun.

PROD-125