### PR TITLE
Fix Unregistered Task

### DIFF
--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -1065,7 +1065,10 @@ WEBPACK_CONFIG_PATH = 'webpack.prod.config.js'
 ################################# CELERY ######################################
 
 # Auto discover tasks fails to detect contentstore tasks
-CELERY_IMPORTS = ('cms.djangoapps.contentstore.tasks')
+CELERY_IMPORTS = (
+    'cms.djangoapps.contentstore.tasks',
+    'openedx.core.djangoapps.bookmarks.tasks'
+)
 
 # Message configuration
 

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -2075,6 +2075,7 @@ DEBUG_TOOLBAR_PATCH_SETTINGS = False
 # Tasks are only registered when the module they are defined in is imported.
 CELERY_IMPORTS = (
     'openedx.core.djangoapps.programs.tasks.v1.tasks',
+    'openedx.core.djangoapps.bookmarks.tasks'
 )
 
 # Message configuration

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -2075,7 +2075,6 @@ DEBUG_TOOLBAR_PATCH_SETTINGS = False
 # Tasks are only registered when the module they are defined in is imported.
 CELERY_IMPORTS = (
     'openedx.core.djangoapps.programs.tasks.v1.tasks',
-    'openedx.core.djangoapps.bookmarks.tasks'
 )
 
 # Message configuration


### PR DESCRIPTION
openedx.core.djangoapps.bookmarks.tasks.update_xblock_cache task is not getting autodiscovered by celery and needs to be imported explicitly. 

When using celery with django, the [autodiscover_tasks](https://github.com/edx/edx-platform/blob/713d64e1e212a0a651c5ec6d337658cc1e6eb133/lms/celery.py#L24) function registers all decorated tasks within the task module inside each `INSTALLED_APPS` entry. The app `openedx.core.djangoapps.bookmarks` is not present in INSTALLED_APPS.

The problem seemed to be initially related to [relative imports and automatic naming](https://docs.celeryproject.org/en/latest/userguide/tasks.html#automatic-naming-and-relative-imports) but the name is [explicitly provided for this task](https://github.com/edx/edx-platform/blob/353d006839c21ebde789f12851e5cc9cd425435a/openedx/core/djangoapps/bookmarks/tasks.py#L147)


[PROD-284](https://openedx.atlassian.net/browse/PROD-284)