### PR TITLE
BOM-81

### DIFF
--- a/common/lib/xmodule/xmodule/modulestore/split_mongo/split.py
+++ b/common/lib/xmodule/xmodule/modulestore/split_mongo/split.py
@@ -61,7 +61,6 @@ import hashlib
 import logging
 from collections import defaultdict
 from importlib import import_module
-from types import NoneType
 
 import six
 from bson.objectid import ObjectId
@@ -2108,7 +2107,7 @@ class SplitMongoModuleStore(SplitBulkWriteMixin, ModuleStoreWriteBase):
         Broke out guts of update_item for short-circuited internal use only
         """
         with self.bulk_operations(course_key):
-            if allow_not_found and isinstance(block_key.id, (LocalId, NoneType)):
+            if allow_not_found and isinstance(block_key.id, (LocalId, type(None))):
                 fields = {}
                 for subfields in six.itervalues(partitioned_fields):
                     fields.update(subfields)


### PR DESCRIPTION
https://openedx.atlassian.net/browse/BOM-81

Any uses of NoneType should be replaced with type(None) which should be valid in both python 2 and python 3.