### PR TITLE
Fix unregistered celery task

### DIFF
--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -1067,7 +1067,8 @@ WEBPACK_CONFIG_PATH = 'webpack.prod.config.js'
 # Auto discover tasks fails to detect contentstore tasks
 CELERY_IMPORTS = (
     'cms.djangoapps.contentstore.tasks',
-    'openedx.core.djangoapps.bookmarks.tasks'
+    'openedx.core.djangoapps.bookmarks.tasks',
+    'openedx.core.djangoapps.ccxcon.tasks',
 )
 
 # Message configuration

--- a/openedx/core/djangoapps/ccxcon/tasks.py
+++ b/openedx/core/djangoapps/ccxcon/tasks.py
@@ -14,7 +14,7 @@ from openedx.core.djangoapps.ccxcon import api
 log = get_task_logger(__name__)
 
 
-@task()
+@task(name='openedx.core.djangoapps.ccxcon.tasks.update_ccxcon')
 def update_ccxcon(course_id, cur_retry=0):
     """
     Pass through function to update course information on CCXCon.


### PR DESCRIPTION
openedx.core.djangoapps.ccxcon.tasks.update_ccxcon task is not getting autodiscovered by celery and needs to be imported explicitly.

When using celery with django, the [autodiscover_tasks](https://github.com/edx/edx-platform/blob/713d64e1e212a0a651c5ec6d337658cc1e6eb133/lms/celery.py#L24) function registers all decorated tasks within the task module inside each `INSTALLED_APPS` entry. The app openedx.core.djangoapps.ccxcon is not present in `INSTALLED_APPS`.

I have added an explicit name for the task to avoid the automatic naming and relative import problem in the future. For more context read [this](https://docs.celeryproject.org/en/latest/userguide/tasks.html#automatic-naming-and-relative-imports)

[PROD-283](https://openedx.atlassian.net/browse/PROD-283)