### PR TITLE
Added edx-when's FieldData

### DIFF
--- a/lms/djangoapps/courseware/module_render.py
+++ b/lms/djangoapps/courseware/module_render.py
@@ -888,6 +888,7 @@ def get_module_for_descriptor_internal(user, descriptor, student_data, course_id
         system,
         user.id,
         [
+            partial(DateLookupFieldData, course_id=course_id, user=user),
             partial(OverrideFieldData.wrap, user, course),
             partial(LmsFieldData, student_data=student_data),
         ],

--- a/lms/djangoapps/courseware/tests/test_module_render.py
+++ b/lms/djangoapps/courseware/tests/test_module_render.py
@@ -26,6 +26,7 @@ from edx_oauth2_provider.tests.factories import AccessTokenFactory, ClientFactor
 from edx_proctoring.api import create_exam, create_exam_attempt, update_attempt_status
 from edx_proctoring.runtime import set_runtime_service
 from edx_proctoring.tests.test_services import MockCertificateService, MockCreditService, MockGradesService
+from edx_when.field_data import DateLookupFieldData
 from freezegun import freeze_time
 from milestones.tests.utils import MilestonesTestCaseMixin
 from mock import MagicMock, Mock, patch
@@ -493,10 +494,14 @@ class ModuleRenderTestCase(SharedModuleStoreTestCase, LoginEnrollmentTestCase):
             OverrideFieldData
         )
 
-        # the OverrideFieldData should point to the original unwrapped field_data
-        self.assertIs(
+        # the OverrideFieldData should point to the date FieldData
+        self.assertIsInstance(
             # pylint: disable=protected-access
             descriptor._field_data._authored_data._source.fallback,
+            DateLookupFieldData
+        )
+        self.assertIs(
+            descriptor._field_data._authored_data._source.fallback._defaults,
             descriptor._unwrapped_field_data
         )
 

--- a/lms/djangoapps/courseware/testutils.py
+++ b/lms/djangoapps/courseware/testutils.py
@@ -156,9 +156,9 @@ class RenderXBlockTestMixin(six.with_metaclass(ABCMeta, object)):
         return response
 
     @ddt.data(
-        ('vertical_block', ModuleStoreEnum.Type.mongo, 11),
+        ('vertical_block', ModuleStoreEnum.Type.mongo, 13),
         ('vertical_block', ModuleStoreEnum.Type.split, 6),
-        ('html_block', ModuleStoreEnum.Type.mongo, 12),
+        ('html_block', ModuleStoreEnum.Type.mongo, 14),
         ('html_block', ModuleStoreEnum.Type.split, 6),
     )
     @ddt.unpack
@@ -215,7 +215,7 @@ class RenderXBlockTestMixin(six.with_metaclass(ABCMeta, object)):
         Helper method used by test_success_enrolled_staff because one test
         class using this mixin has an increased number of mongo (only) queries.
         """
-        return 5
+        return 9
 
     def test_success_unenrolled_staff(self):
         self.setup_course()

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -119,7 +119,7 @@ edx-search==1.2.2
 git+https://github.com/mitodl/edx-sga.git@3828ba9e413080a81b907a3381e5ffa05e063f81#egg=edx-sga==0.8.3
 edx-submissions==2.1.1
 edx-user-state-client==1.1.1
-edx-when==0.1.6
+edx-when==0.2
 edxval==1.1.25
 elasticsearch==1.9.0      # via edx-search
 enum34==1.1.6

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -146,7 +146,7 @@ git+https://github.com/mitodl/edx-sga.git@3828ba9e413080a81b907a3381e5ffa05e063f
 edx-sphinx-theme==1.5.0
 edx-submissions==2.1.1
 edx-user-state-client==1.1.1
-edx-when==0.1.6
+edx-when==0.2
 edxval==1.1.25
 elasticsearch==1.9.0
 entrypoints==0.3

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -141,7 +141,7 @@ edx-search==1.2.2
 git+https://github.com/mitodl/edx-sga.git@3828ba9e413080a81b907a3381e5ffa05e063f81#egg=edx-sga==0.8.3
 edx-submissions==2.1.1
 edx-user-state-client==1.1.1
-edx-when==0.1.6
+edx-when==0.2
 edxval==1.1.25
 elasticsearch==1.9.0
 entrypoints==0.3          # via flake8


### PR DESCRIPTION
[EDUCATOR-4554](https://openedx.atlassian.net/browse/EDUCATOR-4554)

This fixes a bug where extended due dates were visible in the outline but not reflected on the courseware pages, resulting in problems not being submittable past the due date.

In order for edx-when to work on courseware pages, it has to be more careful about field inheritance, which version 0.2 achieves.
