### PR TITLE
Don't jam LOGIN_REDIRECT_WHITELIST into devstack_docker settings

### DIFF
--- a/lms/envs/devstack_docker.py
+++ b/lms/envs/devstack_docker.py
@@ -14,7 +14,6 @@ CMS_BASE = 'localhost:18010'
 SITE_NAME = LMS_BASE
 LMS_ROOT_URL = 'http://{}'.format(LMS_BASE)
 LMS_INTERNAL_ROOT_URL = LMS_ROOT_URL
-LOGIN_REDIRECT_WHITELIST = [CMS_BASE]
 
 ECOMMERCE_PUBLIC_URL_ROOT = 'http://localhost:18130'
 ECOMMERCE_API_URL = 'http://edx.devstack.ecommerce:18130/api/v2'


### PR DESCRIPTION
We already define it in devstack, and we read private.py from devstack, so if you try to override this setting in private.py, devstack_docker.py just clobbers it.