### PR TITLE
BOM-87 : py3 bug fix

### DIFF
--- a/openedx/core/djangoapps/safe_sessions/middleware.py
+++ b/openedx/core/djangoapps/safe_sessions/middleware.py
@@ -201,7 +201,7 @@ class SafeCookieData(object):
         """
         hash_func = sha256()
         for data_item in [self.version, self.session_id, user_id]:
-            hash_func.update(six.text_type(data_item))
+            hash_func.update(six.b(six.text_type(data_item)))
             hash_func.update('|')
         return hash_func.hexdigest()
 


### PR DESCRIPTION
**Description**
Error:
```
    def _compute_digest(self, user_id):
        """
        Returns hash(version | session_id | user_id |)
        """
        hash_func = sha256()
        for data_item in [self.version, self.session_id, user_id]:
>           hash_func.update(six.text_type(data_item))
E           TypeError: Unicode-objects must be encoded before hashing
openedx/core/djangoapps/safe_sessions/middleware.py:204: TypeError
```

**Reason**
**Python 2.7** hashlib library: https://docs.python.org/2.7/library/hashlib.html
update method
This works for both Asci strings and unicode strings. we were using it as asci.
**Python 3.5** hashlib library: https://docs.python.org/3.5/library/hashlib.html
update method
This only works for byte type strings.

We were sending unicode strings which were fine as it was updated by six.text_type and in both py3 and py2 unicode string was being sent but as hashlib update in py3 only works for byte type it raises error. 

**Fix**
Use six.b which converts string into bytes if py3. if py2 returns unicode. which makes this work for both.

**Example**
**Python 2.7**
![py2](https://user-images.githubusercontent.com/7721119/63169913-6459c700-c051-11e9-8d52-c3dabd6f5368.png)
**Python 3.5**
![py3](https://user-images.githubusercontent.com/7721119/63169933-72a7e300-c051-11e9-9664-e7698aeaffcb.png)


