### PR TITLE
Reverting to last stable version of edx-enterprise

### DIFF
--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -91,3 +91,6 @@ jsondiff==1.1.1
 # 5.0.0.124 is raising 500 errors
 # TODO: remove this once the problem is fixed
 newrelic<5.0
+
+# Pinning edx-enterprise to last stable version
+edx-enterprise==1.8.8

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -106,7 +106,7 @@ edx-django-release-util==0.3.1
 edx-django-sites-extensions==2.3.1
 edx-django-utils==2.0.0
 edx-drf-extensions==2.4.0
-edx-enterprise==1.9.0
+edx-enterprise==1.8.8
 edx-i18n-tools==0.4.8
 edx-milestones==0.2.3
 edx-oauth2-provider==1.3.0
@@ -215,7 +215,7 @@ rest-condition==1.0.3
 rfc6266-parser==0.0.5.post2
 ruamel.ordereddict==0.4.14 ; python_version == "2.7"  # via ruamel.yaml
 ruamel.yaml.clib==0.1.2   # via ruamel.yaml
-ruamel.yaml==0.16.2       # via drf-yasg
+ruamel.yaml==0.16.4       # via drf-yasg
 rules==2.1
 s3transfer==0.1.13        # via boto3
 sailthru-client==2.2.3

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -130,7 +130,7 @@ edx-django-release-util==0.3.1
 edx-django-sites-extensions==2.3.1
 edx-django-utils==2.0.0
 edx-drf-extensions==2.4.0
-edx-enterprise==1.9.0
+edx-enterprise==1.8.8
 edx-i18n-tools==0.4.8
 edx-lint==1.3.0
 edx-milestones==0.2.3
@@ -289,7 +289,7 @@ rest-condition==1.0.3
 rfc6266-parser==0.0.5.post2
 ruamel.ordereddict==0.4.14 ; python_version == "2.7"
 ruamel.yaml.clib==0.1.2
-ruamel.yaml==0.16.2
+ruamel.yaml==0.16.4
 rules==2.1
 s3transfer==0.1.13
 sailthru-client==2.2.3
@@ -331,7 +331,7 @@ unidiff==0.5.5
 uritemplate==3.0.0
 urllib3==1.23
 user-util==0.1.5
-virtualenv==16.7.2
+virtualenv==16.7.3
 voluptuous==0.11.7
 vulture==1.0
 watchdog==0.9.0

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -126,7 +126,7 @@ edx-django-release-util==0.3.1
 edx-django-sites-extensions==2.3.1
 edx-django-utils==2.0.0
 edx-drf-extensions==2.4.0
-edx-enterprise==1.9.0
+edx-enterprise==1.8.8
 edx-i18n-tools==0.4.8
 edx-lint==1.3.0
 edx-milestones==0.2.3
@@ -280,7 +280,7 @@ rest-condition==1.0.3
 rfc6266-parser==0.0.5.post2
 ruamel.ordereddict==0.4.14 ; python_version == "2.7"
 ruamel.yaml.clib==0.1.2
-ruamel.yaml==0.16.2
+ruamel.yaml==0.16.4
 rules==2.1
 s3transfer==0.1.13
 sailthru-client==2.2.3
@@ -318,7 +318,7 @@ unidiff==0.5.5
 uritemplate==3.0.0
 urllib3==1.23
 user-util==0.1.5
-virtualenv==16.7.2        # via tox
+virtualenv==16.7.3        # via tox
 voluptuous==0.11.7
 watchdog==0.9.0
 wcwidth==0.1.7            # via pytest


### PR DESCRIPTION
This is in response to https://github.com/edx/edx-platform/pull/21258.