### PR TITLE
Allow one letter extra fields

### DIFF
--- a/openedx/core/djangoapps/user_authn/views/registration_form.py
+++ b/openedx/core/djangoapps/user_authn/views/registration_form.py
@@ -181,7 +181,6 @@ class AccountCreationForm(forms.Form):
                 error_messages={"required": _("You must accept the terms of service.")}
             )
 
-        # TODO: These messages don't say anything about minimum length
         error_message_dict = {
             "level_of_education": _("A level of education is required"),
             "gender": _("Your gender is required"),
@@ -202,7 +201,7 @@ class AccountCreationForm(forms.Form):
                         )
                 else:
                     required = field_value == "required"
-                    min_length = 1 if field_name in ("gender", "level_of_education") else 2
+                    min_length = 1
                     error_message = error_message_dict.get(
                         field_name,
                         _("You are missing one or more required fields")


### PR DESCRIPTION
Some existing or custom extra fields may be actually shorter than 2 letters (e.g. [cities](https://en.wikipedia.org/wiki/List_of_short_place_names)). This decreases the `min_length` of these fields to `1`.

**JIRA tickets**: [OSPR-3793](https://openedx.atlassian.net/browse/OSPR-3793)

**Merge deadline**: None

**Testing instructions**:

1. Set `city` to `required` in `lms.env.json` and restart LMS.
1. Register with one-letter city on `master` branch.
1. Register with one-letter city on this branch.

**Reviewers**
- [x] @giovannicimolin 
- [ ] edX reviewer[s] TBD

