### PR TITLE
adding speech output for completion checkmarks

### DIFF
--- a/lms/templates/seq_module.html
+++ b/lms/templates/seq_module.html
@@ -61,6 +61,9 @@
                 style="color:green"
                 aria-hidden="true"
               ></span>
+              % if item['complete']:
+                <span class="sr">${_("Completed")}</span>
+              %endif
             % endif
             <span class="fa fa-fw fa-bookmark bookmark-icon ${"is-hidden" if not item['bookmarked'] else "bookmarked"}" aria-hidden="true"></span>
             <div class="sequence-tooltip sr"><span class="sr">${item['type']}&nbsp;</span>${item['page_title']}<span class="sr bookmark-icon-sr">&nbsp;${_("Bookmarked") if item['bookmarked'] else ""}</span></div>

--- a/openedx/features/course_experience/templates/course_experience/course-outline-fragment.html
+++ b/openedx/features/course_experience/templates/course_experience/course-outline-fragment.html
@@ -40,7 +40,8 @@ self_paced = context.get('self_paced', False)
                         <span class="fa fa-chevron-right ${ 'fa-rotate-90' if section_is_auto_opened else '' }" aria-hidden="true"></span>
                         <h3 class="section-title">${ section['display_name'] }</h3>
             % if section.get('complete'):
-                            <span class="complete-checkmark fa fa-check"></span>
+                            <span class="complete-checkmark fa fa-check" aria-hidden="true"></span>
+                            <span class="sr">${_("Completed")}</span>
             % endif
                     </button>
                     <ol class="outline-item accordion-panel ${ '' if section_is_auto_opened else 'is-hidden' }"
@@ -82,7 +83,8 @@ self_paced = context.get('self_paced', False)
                                             ${ subsection['display_name'] }
                                         </h4>
                     % if subsection.get('complete'):
-                                        <span class="complete-checkmark fa fa-check"></span>
+                                        <span class="complete-checkmark fa fa-check" aria-hidden="true"></span>
+                                        <span class="sr">${_("Completed")}</span>
                     % endif
                 % endif
                                         <div class="details">
@@ -173,7 +175,9 @@ self_paced = context.get('self_paced', False)
                                               </div>
                                             </div>
                         % if vertical.get('complete'):
-                                                <span class="complete-checkmark fa fa-check"></span>
+                                                <span class="complete-checkmark fa fa-check" aria-hidden="true"></span>
+                                                <span class="sr">${_("Completed")}</span>
+
                         % endif
                                         </a>
                                     </li>


### PR DESCRIPTION
### [PROD-519](https://openedx.atlassian.net/browse/PROD-519)

### Description
In edx-platform, the completion of a section/sub-section/unit on the course outline and unit completion in the courseware is indicated by a green checkmark. This checkmark is only visible to the naked eye and doesn't provide any feedback when reading through screen readers. This PR adds the speech output for the checkmarks beside them so that any learner using the screen reader will be notified of the completion.


### Reviewers
 - [x] @wittjeff 

### Sandbox
 - https://checkmark.sandbox.edx.org/courses/course-v1:edX+DemoX+Demo_Course/course/

### Post Review
 - [x] Squash & Rebase commits