### PR TITLE
Remove empty signatories from certificate.

### DIFF
--- a/lms/templates/certificates/_accomplishment-rendering.html
+++ b/lms/templates/certificates/_accomplishment-rendering.html
@@ -46,15 +46,17 @@ course_mode_class = course_mode if course_mode else ''
                         <div class="list-signatories">
                             % if certificate_data:
                                 % for signatory in certificate_data.get('signatories', []):
-                                <div class="signatory">
-                                    <img class="signatory-signature" src="${static.url(signatory['signature_image_path'])}" alt="${signatory['name']}">
+                                    % if signatory.get('signature_image_path'):
+                                        <div class="signatory">
+                                            <img class="signatory-signature" src="${static.url(signatory['signature_image_path'])}" alt="${signatory['name']}">
 
-                                    <h4 class="signatory-name hd-5">${signatory['name']}</h4>
-                                    <p class="signatory-credentials copy copy-micro">
-                                        <span class="role">${signatory['title']}</span>
-                                        <span class="organization">${signatory['organization']}</span>
-                                    </p>
-                                </div>
+                                            <h4 class="signatory-name hd-5">${signatory['name']}</h4>
+                                            <p class="signatory-credentials copy copy-micro">
+                                                <span class="role">${signatory['title']}</span>
+                                                <span class="organization">${signatory['organization']}</span>
+                                            </p>
+                                        </div>
+                                    % endif
                                 % endfor
                             % endif
                         </div>


### PR DESCRIPTION
### Description

[PROD-319](https://openedx.atlassian.net/browse/PROD-319)

Empty signatories are shown as broken images on the certs which is affecting user experience.To improve it, empty signatories are filtered before rendering the cert.