### PR TITLE
Add waffle for hiding bulk management in masters courses

### DIFF
--- a/lms/djangoapps/grades/api.py
+++ b/lms/djangoapps/grades/api.py
@@ -15,7 +15,7 @@ from six import text_type
 from lms.djangoapps.grades import constants, context, course_data, events
 # Grades APIs that should NOT belong within the Grades subsystem
 # TODO move Gradebook to be an external feature outside of core Grades
-from lms.djangoapps.grades.config.waffle import is_writable_gradebook_enabled
+from lms.djangoapps.grades.config.waffle import is_writable_gradebook_enabled, gradebook_can_see_bulk_management
 # Public Grades Factories
 from lms.djangoapps.grades.course_grade_factory import CourseGradeFactory
 from lms.djangoapps.grades.models_api import *

--- a/lms/djangoapps/grades/config/waffle.py
+++ b/lms/djangoapps/grades/config/waffle.py
@@ -17,6 +17,7 @@ DISABLE_REGRADE_ON_POLICY_CHANGE = u'disable_regrade_on_policy_change'
 REJECTED_EXAM_OVERRIDES_GRADE = u'rejected_exam_overrides_grade'
 ENFORCE_FREEZE_GRADE_AFTER_COURSE_END = u'enforce_freeze_grade_after_course_end'
 WRITABLE_GRADEBOOK = u'writable_gradebook'
+BULK_MANAGEMENT = u'bulk_management'
 
 
 def waffle():
@@ -49,6 +50,11 @@ def waffle_flags():
             WRITABLE_GRADEBOOK,
             flag_undefined_default=True,
         ),
+        BULK_MANAGEMENT: CourseWaffleFlag(
+            namespace,
+            BULK_MANAGEMENT,
+            flag_undefined_default=False,
+        ),
     }
 
 
@@ -57,3 +63,12 @@ def is_writable_gradebook_enabled(course_key):
     Returns whether the writable gradebook app is enabled for the given course.
     """
     return waffle_flags()[WRITABLE_GRADEBOOK].is_enabled(course_key)
+
+
+def gradebook_can_see_bulk_management(course_key):
+    """
+    Returns whether bulk management features should be visible for the given course.
+
+    (provided that course contains a masters track, as of this writing)
+    """
+    return waffle_flags()[BULK_MANAGEMENT].is_enabled(course_key)

--- a/lms/djangoapps/grades/rest_api/v1/gradebook_views.py
+++ b/lms/djangoapps/grades/rest_api/v1/gradebook_views.py
@@ -26,6 +26,7 @@ from lms.djangoapps.grades.api import constants as grades_constants
 from lms.djangoapps.grades.api import context as grades_context
 from lms.djangoapps.grades.api import events as grades_events
 from lms.djangoapps.grades.api import is_writable_gradebook_enabled, prefetch_course_and_subsection_grades
+from lms.djangoapps.grades.api import gradebook_can_see_bulk_management as can_see_bulk_management
 from lms.djangoapps.grades.course_data import CourseData
 from lms.djangoapps.grades.grade_utils import are_grades_frozen
 # TODO these imports break abstraction of the core Grades layer. This code needs
@@ -276,6 +277,7 @@ class CourseGradingView(BaseCourseView):
                 'assignment_types': self._get_assignment_types(course),
                 'subsections': self._get_subsections(course, graded_only),
                 'grades_frozen': are_grades_frozen(course_key),
+                'can_see_bulk_management': can_see_bulk_management(course_key),
             }
             return Response(results)
 

--- a/lms/djangoapps/grades/rest_api/v1/tests/test_gradebook_views.py
+++ b/lms/djangoapps/grades/rest_api/v1/tests/test_gradebook_views.py
@@ -197,6 +197,7 @@ class CourseGradingViewTest(SharedModuleStoreTestCase, APITestCase):
                 },
             ],
             'grades_frozen': False,
+            'can_see_bulk_management': False,
         }
 
     def test_student_fails(self):


### PR DESCRIPTION
This is a Master's course-only feature which we want to be sensitive about how we're rolling out to partners, so as not to overly surprise anyone.