### PR TITLE
fix matplotlib setup.py problem w python 3.5 ref

### DIFF
--- a/requirements/edx-sandbox/base.in
+++ b/requirements/edx-sandbox/base.in
@@ -7,5 +7,7 @@
 #   * confirm that it has no system requirements beyond what we already install
 #   * run "make upgrade" to update the detailed requirements files
 
+-c ../constraints.txt
+
 -r shared.txt                       # Dependencies in common with LMS and Studio
-matplotlib==1.3.1                   # 2D plotting library
+matplotlib==1.5.3                   # 2D plotting library

--- a/requirements/edx-sandbox/base.txt
+++ b/requirements/edx-sandbox/base.txt
@@ -11,22 +11,24 @@ common/lib/symmath
 asn1crypto==0.24.0
 backports-abc==0.5        # via tornado
 cffi==1.11.5
-cryptography==2.2.2
+cryptography==2.4.2
+cycler==0.10.0            # via matplotlib
 enum34==1.1.6
 futures==3.2.0            # via tornado
-idna==2.7
+idna==2.8
 ipaddress==1.0.22
 lxml==3.8.0
-matplotlib==1.3.1
+markupsafe==1.1.0
+matplotlib==1.5.3
 networkx==1.7
-nltk==3.3.0
-nose==1.3.7               # via matplotlib
+nltk==3.4
 numpy==1.6.2
-pycparser==2.18
+pycparser==2.19
 pyparsing==2.2.0
-python-dateutil==2.7.3    # via matplotlib
+python-dateutil==2.7.5    # via matplotlib
+pytz==2019.1              # via matplotlib
 scipy==0.14.0
-singledispatch==3.4.0.3   # via tornado
+singledispatch==3.4.0.3
 six==1.11.0
 sympy==0.7.1
-tornado==5.0.2            # via matplotlib
+tornado==5.1.1            # via matplotlib


### PR DESCRIPTION
This is a corrected pull request that address a version conflict with matplotlib which recently began looking for Python 3.x during native installations. Following is the error stack trace:

exec(compile(code, __file__, '\"'\"'exec'\"'\"'))' egg_info --egg-base pip-egg-info
         cwd: /tmp/pip-install-MD_1sB/matplotlib


    ============================================================================
    Edit setup.cfg to change the build options
    
    BUILDING MATPLOTLIB
                matplotlib: yes [1.3.1]
                    python: yes [2.7.12 (default, Nov 12 2018, 14:36:49)  [GCC
                            5.4.0 20160609]]
                  platform: yes [linux2]
    
    REQUIRED DEPENDENCIES AND EXTENSIONS
                     numpy: yes [not found. pip may install it below.]
                  dateutil: yes [dateutil was not found. It is required for date
                            axis support. pip/easy_install may attempt to
                            install it after matplotlib.]
                   tornado: yes [tornado was not found. It is required for the
                            WebAgg backend. pip/easy_install may attempt to
                            install it after matplotlib.]
                 pyparsing: yes [pyparsing was not found. It is required for
                            mathtext support. pip/easy_install may attempt to
                            install it after matplotlib.]
                     pycxx: yes [Couldn't import.  Using local copy.]
                    libagg: yes [pkg-config information for 'libagg' could not
                            be found. Using local copy.]
                  freetype: yes [version 18.1.12]
                       png: yes [version 1.2.54]
    
    OPTIONAL SUBPACKAGES
               sample_data: yes [installing]
                  toolkits: yes [installing]
                     tests: yes [nose 0.11.1 or later is required to run the
                            matplotlib test suite]
    
    OPTIONAL BACKEND EXTENSIONS
                    macosx: no  [Mac OS-X only]
                    qt4agg: no  [PyQt4 not found]
                   gtk3agg: no  [Requires pygobject to be installed.]
                 gtk3cairo: no  [Requires cairo to be installed.]
                    gtkagg: no  [Requires pygtk]
                     tkagg: no  [TKAgg requires Tkinter.]
                     wxagg: no  [requires wxPython]
                       gtk: no  [Requires pygtk]
                       agg: yes [installing]
                     cairo: no  [cairo not found]
                 windowing: no  [Microsoft Windows only]
    
    OPTIONAL LATEX DEPENDENCIES
                    dvipng: no
               ghostscript: no
                     latex: no
                   pdftops: no
    
    Traceback (most recent call last):
      File \"<string>\", line 1, in <module>
      File \"/tmp/pip-install-MD_1sB/matplotlib/setup.py\", line 268, in <module>
        **extra_args
      File \"/edx/app/edxapp/venvs/edxapp-sandbox/local/lib/python2.7/site-packages/setuptools/__init__.py\", line 144, in setup
        _install_setup_requires(attrs)
      File \"/edx/app/edxapp/venvs/edxapp-sandbox/local/lib/python2.7/site-packages/setuptools/__init__.py\", line 139, in _install_setup_requires
        dist.fetch_build_eggs(dist.setup_requires)
      File \"/edx/app/edxapp/venvs/edxapp-sandbox/local/lib/python2.7/site-packages/setuptools/dist.py\", line 717, in fetch_build_eggs
        replace_conflicting=True,
      File \"/edx/app/edxapp/venvs/edxapp-sandbox/local/lib/python2.7/site-packages/pkg_resources/__init__.py\", line 782, in resolve
        replace_conflicting=replace_conflicting
      File \"/edx/app/edxapp/venvs/edxapp-sandbox/local/lib/python2.7/site-packages/pkg_resources/__init__.py\", line 1065, in best_match
        return self.obtain(req, installer)
      File \"/edx/app/edxapp/venvs/edxapp-sandbox/local/lib/python2.7/site-packages/pkg_resources/__init__.py\", line 1077, in obtain
        return installer(requirement)
      File \"/edx/app/edxapp/venvs/edxapp-sandbox/local/lib/python2.7/site-packages/setuptools/dist.py\", line 784, in fetch_build_egg
        return cmd.easy_install(req)
      File \"/edx/app/edxapp/venvs/edxapp-sandbox/local/lib/python2.7/site-packages/setuptools/command/easy_install.py\", line 679, in easy_install
        return self.install_item(spec, dist.location, tmpdir, deps)
      File \"/edx/app/edxapp/venvs/edxapp-sandbox/local/lib/python2.7/site-packages/setuptools/command/easy_install.py\", line 705, in install_item
        dists = self.install_eggs(spec, download, tmpdir)
      File \"/edx/app/edxapp/venvs/edxapp-sandbox/local/lib/python2.7/site-packages/setuptools/command/easy_install.py\", line 890, in install_eggs
        return self.build_and_install(setup_script, setup_base)
      File \"/edx/app/edxapp/venvs/edxapp-sandbox/local/lib/python2.7/site-packages/setuptools/command/easy_install.py\", line 1158, in build_and_install
        self.run_setup(setup_script, setup_base, args)
      File \"/edx/app/edxapp/venvs/edxapp-sandbox/local/lib/python2.7/site-packages/setuptools/command/easy_install.py\", line 1144, in run_setup
        run_setup(setup_script, args)
      File \"/edx/app/edxapp/venvs/edxapp-sandbox/local/lib/python2.7/site-packages/setuptools/sandbox.py\", line 253, in run_setup
        raise
      File \"/usr/lib/python2.7/contextlib.py\", line 35, in __exit__
        self.gen.throw(type, value, traceback)
      File \"/edx/app/edxapp/venvs/edxapp-sandbox/local/lib/python2.7/site-packages/setuptools/sandbox.py\", line 195, in setup_context
        yield
      File \"/usr/lib/python2.7/contextlib.py\", line 35, in __exit__
        self.gen.throw(type, value, traceback)
      File \"/edx/app/edxapp/venvs/edxapp-sandbox/local/lib/python2.7/site-packages/setuptools/sandbox.py\", line 166, in save_modules
        saved_exc.resume()
      File \"/edx/app/edxapp/venvs/edxapp-sandbox/local/lib/python2.7/site-packages/setuptools/sandbox.py\", line 141, in resume
        six.reraise(type, exc, self._tb)
      File \"/edx/app/edxapp/venvs/edxapp-sandbox/local/lib/python2.7/site-packages/setuptools/sandbox.py\", line 154, in save_modules
        yield saved
      File \"/edx/app/edxapp/venvs/edxapp-sandbox/local/lib/python2.7/site-packages/setuptools/sandbox.py\", line 195, in setup_context
        yield
      File \"/edx/app/edxapp/venvs/edxapp-sandbox/local/lib/python2.7/site-packages/setuptools/sandbox.py\", line 250, in run_setup
        _execfile(setup_script, ns)
      File \"/edx/app/edxapp/venvs/edxapp-sandbox/local/lib/python2.7/site-packages/setuptools/sandbox.py\", line 45, in _execfile
        exec(code, globals, locals)
      File \"/tmp/easy_install-JreA1F/numpy-1.17.0rc2/setup.py\", line 31, in <module>
        try:
    RuntimeError: Python version >= 3.5 required.
    ----------------------------------------
ERROR: Command errored out with exit status 1: python setup.py egg_info Check the logs for full command output.
"}
