### PR TITLE
Disable caching in forum home

### DIFF
--- a/lms/djangoapps/discussion/views.py
+++ b/lms/djangoapps/discussion/views.py
@@ -18,6 +18,7 @@ from django.template.loader import render_to_string
 from django.urls import reverse
 from django.utils.translation import get_language_bidi
 from django.utils.translation import ugettext_lazy as _
+from django.views.decorators.cache import cache_control
 from django.views.decorators.csrf import ensure_csrf_cookie
 from django.views.decorators.http import require_GET, require_http_methods
 from edx_django_utils.monitoring import function_trace
@@ -253,6 +254,7 @@ def inline_discussion(request, course_key, discussion_id):
     })
 
 
+@cache_control(no_cache=True, no_store=True, must_revalidate=True)
 @login_required
 @use_bulk_ops
 def forum_form_discussion(request, course_key):


### PR DESCRIPTION
This PR adds `Cache-Control: no-cache, no-store, must-revalidate` header to the response on discussions. This prevents browsers and intermediary proxies from serving stale content when browsing the forum.

**Sandbox URL**: https://pr21402.sandbox.opencraft.hosting/

**Testing instructions**:

1. Navigate to the forum on a course and open up the Developer Tools in your browser.
2. Check the `forum/` response headers for `cache-control`

![image](https://user-images.githubusercontent.com/5691347/63456036-6bebe800-c424-11e9-9e5c-e65d1cbc5028.png)

**Reviewers**
- [x] @xitij2000 
- [ ] edX reviewer[s] TBD