### PR TITLE
Downgrade transifex-client to upgrade other packages

### DIFF
--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -19,10 +19,6 @@ pysqlite ; python_version == "2.7"
 #   https://github.com/jazzband/pip-tools/issues/852
 pip-tools==3.8.0
 
-# six is at 1.12.0, but transifex-client requires ==1.11.0
-# https://github.com/transifex/transifex-client/issues/252
-six==1.11.0
-
 # Convert text markup to HTML; used in capa problems, forums, and course wikis; pin Markdown version as tests failed for its upgrade to latest release
 Markdown==2.6.11
 
@@ -33,8 +29,9 @@ mysqlclient<1.5
 # Can be removed when we get to Python 3.
 pylint-plugin-utils==0.3
 
-# transifex-client 0.13.6 requires urllib3<1.24, but requests will pull in urllib3==1.24 (https://github.com/transifex/transifex-client/pull/241/files)
-urllib3<1.24
+# transifex-client 0.13.5 and 0.13.6 pin six and urllib3 to old versions needlessly
+#   https://github.com/transifex/transifex-client/issues/252
+transifex-client==0.13.4
 
 # Bumping requests-oauthlib to 1.2 updates oauthlib to 3.0.0, which changes a response code in certain cases
 # This causes a test to fail. Before fixing, we would need to make sure mobile apps are functional with this change
@@ -54,9 +51,6 @@ scipy<=1.2.1
 # Unless we constrain pytest to <4.6.0, it may break all tests inside of
 # xmodule.tests.test_resource_templates.ResourceTemplatesTests See TE-2391 for details.
 pytest<4.6.0
-
-# transifex-client 0.13.6 requires python-slugify 1.2.6, but the latest version is 3.0.2
-python-slugify==1.2.6
 
 # 1.2.3 breaks unittest in
 # lms.djangoapps.course_api.tests.test_views.CourseListSearchViewTest.test_list_all_with_search_term

--- a/requirements/edx-sandbox/base.txt
+++ b/requirements/edx-sandbox/base.txt
@@ -28,7 +28,7 @@ python-dateutil==2.8.0    # via matplotlib
 pytz==2019.2              # via matplotlib
 scipy==0.14.0
 singledispatch==3.4.0.3
-six==1.11.0
+six==1.12.0
 subprocess32==3.5.4       # via matplotlib
 sympy==0.7.1
 

--- a/requirements/edx-sandbox/shared.txt
+++ b/requirements/edx-sandbox/shared.txt
@@ -14,4 +14,4 @@ networkx==1.7
 nltk==3.4.5
 pycparser==2.19           # via cffi
 singledispatch==3.4.0.3   # via nltk
-six==1.11.0               # via cryptography, nltk, singledispatch
+six==1.12.0               # via cryptography, nltk, singledispatch

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -200,7 +200,7 @@ python-dateutil==2.4.0
 python-levenshtein==0.12.0
 python-memcached==1.59
 python-openid==2.2.5 ; python_version == "2.7"  # via social-auth-core
-python-slugify==1.2.6     # via code-annotations
+python-slugify==3.0.3     # via code-annotations
 python-swiftclient==3.8.0
 python3-saml==1.5.0
 pytz==2019.2
@@ -225,7 +225,7 @@ shapely==1.6.4.post2
 shortuuid==0.5.0          # via edx-django-oauth2-provider
 simplejson==3.16.0        # via mailsnake, sailthru-client
 singledispatch==3.4.0.3
-six==1.11.0
+six==1.12.0
 slumber==0.7.1            # via edx-bulk-grades, edx-enterprise, edx-rest-api-client
 social-auth-app-django==2.1.0
 social-auth-core==1.7.0
@@ -238,10 +238,11 @@ stevedore==1.30.1
 super-csv==0.9.1
 sympy==1.4
 testfixtures==6.10.0      # via edx-enterprise
+text-unidecode==1.2       # via python-slugify
 tincan==0.0.5             # via edx-enterprise
 unicodecsv==0.14.1
 uritemplate==3.0.0        # via coreapi, drf-yasg
-urllib3==1.23
+urllib3==1.25.3
 user-util==0.1.5
 voluptuous==0.11.7
 watchdog==0.9.0

--- a/requirements/edx/coverage.in
+++ b/requirements/edx/coverage.in
@@ -14,4 +14,3 @@
 
 coverage==5.0a6                     # Code coverage testing for Python
 diff-cover==0.9.8                   # Automatically find diff lines that need test coverage
-six==1.11.0                         # Pinned because diff-cover needs it, but later transifex-client says ==1.11.0

--- a/requirements/edx/coverage.txt
+++ b/requirements/edx/coverage.txt
@@ -11,4 +11,4 @@ jinja2-pluralize==0.3.0   # via diff-cover
 jinja2==2.10.1            # via diff-cover, jinja2-pluralize
 markupsafe==1.1.1         # via jinja2
 pygments==2.4.2           # via diff-cover
-six==1.11.0
+six==1.12.0               # via diff-cover

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -273,7 +273,7 @@ python-dateutil==2.4.0
 python-levenshtein==0.12.0
 python-memcached==1.59
 python-openid==2.2.5 ; python_version == "2.7"
-python-slugify==1.2.6
+python-slugify==3.0.3
 python-swiftclient==3.8.0
 python3-saml==1.5.0
 pytz==2019.2
@@ -301,7 +301,7 @@ shapely==1.6.4.post2
 shortuuid==0.5.0
 simplejson==3.16.0
 singledispatch==3.4.0.3
-six==1.11.0
+six==1.12.0
 slumber==0.7.1
 snakefood==1.4
 snowballstemmer==1.9.0    # via sphinx
@@ -323,13 +323,12 @@ tincan==0.0.5
 toml==0.10.0
 tox-battery==0.5.1
 tox==3.13.2
-transifex-client==0.13.6
+transifex-client==0.13.4
 typing==3.7.4
 unicodecsv==0.14.1
-unidecode==1.1.1
 unidiff==0.5.5
 uritemplate==3.0.0
-urllib3==1.23
+urllib3==1.25.3
 user-util==0.1.5
 virtualenv==16.7.3
 voluptuous==0.11.7

--- a/requirements/edx/paver.in
+++ b/requirements/edx/paver.in
@@ -24,5 +24,3 @@ requests                            # Simple interface for making HTTP requests
 stevedore                           # Support for runtime plugins, used for XBlocks and edx-platform Django app plugins
 watchdog                            # Used in paver watch_assets
 wrapt==1.10.5                       # Decorator utilities used in the @timed paver task decorator
-
-six==1.11.0                         # Pinned because a few things here need it, but later transifex-client says ==1.11.0

--- a/requirements/edx/paver.txt
+++ b/requirements/edx/paver.txt
@@ -22,9 +22,9 @@ pymongo==2.9.1
 python-memcached==1.59
 pyyaml==5.1.2             # via watchdog
 requests==2.22.0
-six==1.11.0
+six==1.12.0               # via edx-opaque-keys, libsass, paver, python-memcached, stevedore
 stevedore==1.30.1
-urllib3==1.23             # via requests
+urllib3==1.25.3           # via requests
 watchdog==0.9.0
 wrapt==1.10.5
 

--- a/requirements/edx/pip-tools.txt
+++ b/requirements/edx/pip-tools.txt
@@ -6,4 +6,4 @@
 #
 click==7.0                # via pip-tools
 pip-tools==3.8.0
-six==1.11.0
+six==1.12.0

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -264,7 +264,7 @@ python-dateutil==2.4.0
 python-levenshtein==0.12.0
 python-memcached==1.59
 python-openid==2.2.5 ; python_version == "2.7"
-python-slugify==1.2.6
+python-slugify==3.0.3
 python-swiftclient==3.8.0
 python3-saml==1.5.0
 pytz==2019.2
@@ -292,7 +292,7 @@ shapely==1.6.4.post2
 shortuuid==0.5.0
 simplejson==3.16.0
 singledispatch==3.4.0.3
-six==1.11.0
+six==1.12.0
 slumber==0.7.1
 social-auth-app-django==2.1.0
 social-auth-core==1.7.0
@@ -305,18 +305,17 @@ stevedore==1.30.1
 super-csv==0.9.1
 sympy==1.4
 testfixtures==6.10.0
-text-unidecode==1.2       # via faker
+text-unidecode==1.2
 tincan==0.0.5
 toml==0.10.0              # via tox
 tox-battery==0.5.1
 tox==3.13.2
-transifex-client==0.13.6
+transifex-client==0.13.4
 typing==3.7.4             # via flake8
 unicodecsv==0.14.1
-unidecode==1.1.1          # via python-slugify
 unidiff==0.5.5
 uritemplate==3.0.0
-urllib3==1.23
+urllib3==1.25.3
 user-util==0.1.5
 virtualenv==16.7.3        # via tox
 voluptuous==0.11.7


### PR DESCRIPTION
`transifex-client` pinned all its dependencies in 0.13.5 to work around a short-lived incompatibility between `requests` and `urllib3`, and has been constraining us to outdated versions of 3 packages ever since.  Downgrade it to prior to this change, this shouldn't lose us any real functionality.  For details, see https://github.com/transifex/transifex-client/issues/211#issuecomment-516406430