### PR TITLE
BOM-354

### DIFF
--- a/cms/djangoapps/models/settings/course_grading.py
+++ b/cms/djangoapps/models/settings/course_grading.py
@@ -284,4 +284,4 @@ def hash_grading_policy(grading_policy):
         separators=(',', ':'),  # Remove spaces from separators for more compact representation
         sort_keys=True,
     )
-    return b64encode(sha1(ordered_policy).digest())
+    return b64encode(sha1(ordered_policy.encode("utf-8")).digest())


### PR DESCRIPTION
https://openedx.atlassian.net/browse/BOM-354
Fix Unicode-objects must be encoded before hashing.