### PR TITLE
BOM-356

### DIFF
--- a/cms/djangoapps/contentstore/views/item.py
+++ b/cms/djangoapps/contentstore/views/item.py
@@ -791,7 +791,7 @@ def _move_item(source_usage_key, target_parent_usage_key, user, target_index=Non
         else:
             try:
                 target_index = int(target_index) if target_index is not None else None
-                if len(target_parent.children) < target_index:
+                if target_index is not None and len(target_parent.children) < target_index:
                     error = _(u'You can not move {source_usage_key} at an invalid index ({target_index}).').format(
                         source_usage_key=text_type(source_usage_key),
                         target_index=target_index


### PR DESCRIPTION
None type comparison with int was not working in python3.
There was an issue with previous condition also. with Nonetype it was not coming into error part.