### PR TITLE
TE-2847 Send more Jenkins data to Splunk

### DIFF
--- a/scripts/Jenkinsfiles/bokchoy
+++ b/scripts/Jenkinsfiles/bokchoy
@@ -21,6 +21,7 @@ def runBokchoyTests() {
 def bokchoyTestCleanup() {
     archiveArtifacts allowEmptyArchive: true, artifacts: 'reports/bok_choy/*.coverage*,test_root/log/**/*.log,test_root/log/**/*.png'
     junit '**/reports/bok_choy/**/xunit.xml'
+    sendSplunkFile excludes: '', includes: '**/timing*.log', sizeLimit: '10MB'
 }
 
 def shardCount = 25
@@ -28,6 +29,7 @@ def shardCount = 25
 pipeline {
     agent { label "jenkins-worker" }
     options {
+        sendSplunkConsoleLog()
         timestamps()
         timeout(60)
     }
@@ -108,6 +110,7 @@ pipeline {
                 always {
                     script {
                         archiveArtifacts allowEmptyArchive: true, artifacts: 'reports/*.coverage'
+                        sendSplunkFile excludes: '', includes: '**/timing*.log', sizeLimit: '10MB'
                     }
                 }
             }
@@ -115,7 +118,7 @@ pipeline {
     }
     post {
         always {
-            script{
+            script {
                 if (env.ghprbPullId != null) {
                     // For PR jobs, run the edx-platform-test-notifier for PR reporting
                     build job: 'edx-platform-test-notifier', parameters: [string(name: 'REPO', value: "${REPO_NAME}"), string(name: 'PR_NUMBER', value: "${ghprbPullId}")], wait: false

--- a/scripts/Jenkinsfiles/python
+++ b/scripts/Jenkinsfiles/python
@@ -14,6 +14,7 @@ def runPythonTests() {
 
 def pythonTestCleanup() {
     archiveArtifacts allowEmptyArchive: true, artifacts: 'reports/**/*,test_root/log/**/*.log,**/nosetests.xml,*.log'
+    sendSplunkFile excludes: '', includes: '**/timing*.log', sizeLimit: '10MB'
     junit '**/nosetests.xml'
     sh '''source $HOME/edx-venv/bin/activate
     bash scripts/xdist/terminate_xdist_nodes.sh'''
@@ -38,6 +39,7 @@ def xdist_git_refspec() {
 pipeline {
     agent { label "jenkins-worker" }
     options {
+        sendSplunkConsoleLog()
         timestamps()
         timeout(60)
     }
@@ -176,6 +178,7 @@ pipeline {
                 always {
                     script {
                         archiveArtifacts allowEmptyArchive: true, artifacts: 'reports/*.coverage'
+                        sendSplunkFile excludes: '', includes: '**/timing*.log', sizeLimit: '10MB'
                         publishHTML([allowMissing: false, alwaysLinkToLastBuild: false, keepAll: true,
                             reportDir: 'reports/cover', reportFiles: 'index.html',
                             reportName: 'Coverage.py Report', reportTitles: ''])
@@ -192,7 +195,7 @@ pipeline {
     }
     post {
         always {
-            script{
+            script {
                 if (env.ghprbPullId != null) {
                     // For PR jobs, run the edx-platform-test-notifier for PR reporting
                     build job: 'edx-platform-test-notifier', parameters: [string(name: 'REPO', value: "${REPO_NAME}"), string(name: 'PR_NUMBER', value: "${ghprbPullId}")], wait: false

--- a/scripts/Jenkinsfiles/quality
+++ b/scripts/Jenkinsfiles/quality
@@ -36,12 +36,14 @@ def getTargetBranch(job_name) {
 
 def qualityTestCleanup() {
     archiveArtifacts allowEmptyArchive: true, artifacts: '**/reports/**/*,test_root/log/**/*.log,*.log'
+    sendSplunkFile excludes: '', includes: '**/timing*.log', sizeLimit: '10MB'
     junit 'reports/quality_junitxml/*.xml'
 }
 
 pipeline {
     agent { label "jenkins-worker" }
     options {
+        sendSplunkConsoleLog()
         timestamps()
         timeout(60)
     }


### PR DESCRIPTION
Pipeline jobs don't use the same global configuration we use to send console logs and paver timing logs to Splunk for freestyle jobs.  Add pipeline steps to accomplish this; documentation on these steps can be found [here](https://plugins.jenkins.io/splunk-devops-extend). (We already have this plugin installed.)