### PR TITLE
make link_program_enrollments atomic per user

### DIFF
--- a/lms/djangoapps/program_enrollments/management/commands/link_program_enrollments.py
+++ b/lms/djangoapps/program_enrollments/management/commands/link_program_enrollments.py
@@ -159,12 +159,12 @@ class Command(BaseCommand):
         for program_course_enrollment in program_enrollment.program_course_enrollments.all():
             try:
                 program_course_enrollment.enroll(user)
-            except CourseEnrollmentException as e:
+            except CourseEnrollmentException:
                 logger.warning(COURSE_ENROLLMENT_ERR_TPL.format(
                     user=user.username,
                     course=program_course_enrollment.course_key
                 ))
-                raise e
+                raise
 
 
 def get_existing_user_message(program_enrollment, user):

--- a/lms/djangoapps/program_enrollments/management/commands/link_program_enrollments.py
+++ b/lms/djangoapps/program_enrollments/management/commands/link_program_enrollments.py
@@ -89,7 +89,7 @@ class Command(BaseCommand):
                 with transaction.atomic():
                     self.link_program_enrollment(program_enrollment, user)
             except (CourseEnrollmentException, IntegrityError):
-                logger.warning(u"Rolling back all operations for {}:{}".format(
+                logger.exception(u"Rolling back all operations for {}:{}".format(
                     external_student_key,
                     username,
                 ))
@@ -154,9 +154,9 @@ class Command(BaseCommand):
         try:
             self._link_program_enrollment(program_enrollment, user)
             self._link_course_enrollments(program_enrollment, user)
-        except IntegrityError as e:
-            logger.warning(e)
-            raise e
+        except IntegrityError:
+            logger.exception("Integrity error while linking program enrollments")
+            raise
 
     def _link_program_enrollment(self, program_enrollment, user):
         """
@@ -186,7 +186,7 @@ class Command(BaseCommand):
             for program_course_enrollment in program_enrollment.program_course_enrollments.all():
                 program_course_enrollment.enroll(user)
         except CourseEnrollmentException:
-            logger.warning(COURSE_ENROLLMENT_ERR_TPL.format(
+            logger.exception(COURSE_ENROLLMENT_ERR_TPL.format(
                 user=user.username,
                 course=program_course_enrollment.course_key
             ))

--- a/lms/djangoapps/program_enrollments/management/commands/tests/test_link_program_enrollments.py
+++ b/lms/djangoapps/program_enrollments/management/commands/tests/test_link_program_enrollments.py
@@ -274,19 +274,23 @@ class TestLinkProgramEnrollmentsErrors(TestLinkProgramEnrollmentsMixin, TestCase
         nonexistant_course = CourseKey.from_string('course-v1:edX+Zilch+Bupkis')
 
         program_enrollment_1 = self._create_waiting_enrollment(self.program, '0001')
-        self._create_waiting_course_enrollment(program_enrollment_1, nonexistant_course)
-        self._create_waiting_course_enrollment(program_enrollment_1, self.animal_course)
+        course_enrollment_1 = self._create_waiting_course_enrollment(program_enrollment_1, nonexistant_course)
+        course_enrollment_2 = self._create_waiting_course_enrollment(program_enrollment_1, self.animal_course)
 
         program_enrollment_2 = self._create_waiting_enrollment(self.program, '0002')
-        self._create_waiting_course_enrollment(program_enrollment_2, nonexistant_course)
+        self._create_waiting_course_enrollment(program_enrollment_2, self.fruit_course)
         self._create_waiting_course_enrollment(program_enrollment_2, self.animal_course)
 
-        msg_1 = COURSE_ENROLLMENT_ERR_TPL.format(user=self.user_1.username, course=nonexistant_course)
-        msg_2 = COURSE_ENROLLMENT_ERR_TPL.format(user=self.user_2.username, course=nonexistant_course)
+        msg = COURSE_ENROLLMENT_ERR_TPL.format(user=self.user_1.username, course=nonexistant_course)
         with LogCapture() as logger:
             self.call_command(self.program, ('0001', self.user_1.username), ('0002', self.user_2.username))
-            logger.check_present((COMMAND_PATH, 'WARNING', msg_1))
-            logger.check_present((COMMAND_PATH, 'WARNING', msg_2))
+            logger.check_present((COMMAND_PATH, 'WARNING', msg))
 
-        self._assert_user_enrolled_in_program_courses(self.user_1, self.program, self.animal_course)
-        self._assert_user_enrolled_in_program_courses(self.user_2, self.program, self.animal_course)
+        self._assert_no_program_enrollment(self.user_1, self.program)
+        self._assert_no_user(program_enrollment_1)
+        course_enrollment_1.refresh_from_db()
+        self.assertIsNone(course_enrollment_1.course_enrollment)
+        course_enrollment_2.refresh_from_db()
+        self.assertIsNone(course_enrollment_2.course_enrollment)
+
+        self._assert_user_enrolled_in_program_courses(self.user_2, self.program, self.animal_course, self.fruit_course)

--- a/lms/djangoapps/program_enrollments/management/commands/tests/test_link_program_enrollments.py
+++ b/lms/djangoapps/program_enrollments/management/commands/tests/test_link_program_enrollments.py
@@ -286,7 +286,7 @@ class TestLinkProgramEnrollmentsErrors(TestLinkProgramEnrollmentsMixin, TestCase
         msg = COURSE_ENROLLMENT_ERR_TPL.format(user=self.user_1.username, course=nonexistant_course)
         with LogCapture() as logger:
             self.call_command(self.program, ('0001', self.user_1.username), ('0002', self.user_2.username))
-            logger.check_present((COMMAND_PATH, 'WARNING', msg))
+            logger.check_present((COMMAND_PATH, 'ERROR', msg))
 
         self._assert_no_program_enrollment(self.user_1, self.program)
         self._assert_no_user(program_enrollment_1)
@@ -305,14 +305,10 @@ class TestLinkProgramEnrollmentsErrors(TestLinkProgramEnrollmentsMixin, TestCase
         program_enrollment_1 = self._create_waiting_enrollment(self.program, '0001')
         self._create_waiting_enrollment(self.program, '0002')
 
-        message = ('UNIQUE constraint failed: '
-                   'program_enrollments_programenrollment.user_id, '
-                   'program_enrollments_programenrollment.program_uuid, '
-                   'program_enrollments_programenrollment.curriculum_uuid')
-
+        msg = 'Integrity error while linking program enrollments'
         with LogCapture() as logger:
             self.call_command(self.program, ('0001', self.user_1.username), ('0002', self.user_2.username))
-            logger.check_present((COMMAND_PATH, 'WARNING', message))
+            logger.check_present((COMMAND_PATH, 'ERROR', msg))
 
         self._assert_no_user(program_enrollment_1)
         self._assert_program_enrollment(self.user_2, self.program, '0002')

--- a/lms/djangoapps/program_enrollments/management/commands/tests/test_link_program_enrollments.py
+++ b/lms/djangoapps/program_enrollments/management/commands/tests/test_link_program_enrollments.py
@@ -35,6 +35,7 @@ class TestLinkProgramEnrollmentsMixin(object):
     def setUpTestData(cls):  # pylint: disable=missing-docstring
         cls.command = Command()
         cls.program = uuid4()
+        cls.curriculum = uuid4()
         cls.other_program = uuid4()
         cls.fruit_course = CourseKey.from_string('course-v1:edX+Oranges+Apples')
         cls.animal_course = CourseKey.from_string('course-v1:edX+Cats+Dogs')
@@ -62,6 +63,7 @@ class TestLinkProgramEnrollmentsMixin(object):
         return ProgramEnrollmentFactory.create(
             user=None,
             program_uuid=program_uuid,
+            curriculum_uuid=self.curriculum,
             external_user_key=external_user_key,
         )
 
@@ -294,3 +296,23 @@ class TestLinkProgramEnrollmentsErrors(TestLinkProgramEnrollmentsMixin, TestCase
         self.assertIsNone(course_enrollment_2.course_enrollment)
 
         self._assert_user_enrolled_in_program_courses(self.user_2, self.program, self.animal_course, self.fruit_course)
+
+    def test_integrity_error(self):
+        existing_program_enrollment = self._create_waiting_enrollment(self.program, 'learner-0')
+        existing_program_enrollment.user = self.user_1
+        existing_program_enrollment.save()
+
+        program_enrollment_1 = self._create_waiting_enrollment(self.program, '0001')
+        self._create_waiting_enrollment(self.program, '0002')
+
+        message = ('UNIQUE constraint failed: '
+                   'program_enrollments_programenrollment.user_id, '
+                   'program_enrollments_programenrollment.program_uuid, '
+                   'program_enrollments_programenrollment.curriculum_uuid')
+
+        with LogCapture() as logger:
+            self.call_command(self.program, ('0001', self.user_1.username), ('0002', self.user_2.username))
+            logger.check_present((COMMAND_PATH, 'WARNING', message))
+
+        self._assert_no_user(program_enrollment_1)
+        self._assert_program_enrollment(self.user_2, self.program, '0002')


### PR DESCRIPTION
@edx/masters-neem 
[EDUCATOR-4588](https://openedx.atlassian.net/browse/EDUCATOR-4588
)
change the processing of each individual learner in the ``link_program_enrollments`` management command to be atomic per user.

rather than swallowing any ``courseenrollmentexception``s, cause them to roll back the transaction for the user.