### PR TITLE
Allow correct gender translations for course unit prev/next buttons

### DIFF
--- a/lms/templates/seq_module.html
+++ b/lms/templates/seq_module.html
@@ -1,5 +1,5 @@
 <%page expression_filter="h"/>
-<%! from django.utils.translation import ugettext as _ %>
+<%! from django.utils.translation import pgettext, ugettext as _ %>
 
 <div id="sequence_${element_id}" class="sequence" data-id="${item_id}"
      data-position="${position}" data-ajax-url="${ajax_url}"
@@ -22,10 +22,12 @@
   <div class="sequence-nav">
     <button class="sequence-nav-button button-previous">
       <span class="icon fa fa-chevron-prev" aria-hidden="true"></span>
-      <span class="sequence-nav-button-label">${_('Previous')}</span>
+      ## Translators: A button for showing the Previous Unit
+      <span class="sequence-nav-button-label">${pgettext('unit', 'Previous')}</span>
     </button>
     <button class="sequence-nav-button button-next">
-      <span class="sequence-nav-button-label">${_('Next')}</span>
+      ## Translators: A button for showing the Next Unit
+      <span class="sequence-nav-button-label">${pgettext('unit', 'Next')}</span>
       <span class="icon fa fa-chevron-next" aria-hidden="true"></span>
     </button>
     <nav class="sequence-list-wrapper" aria-label="${_('Sequence')}">
@@ -88,10 +90,12 @@
   <nav class="sequence-bottom" aria-label="${_('Section')}">
     <button class="sequence-nav-button button-previous">
       <span class="icon fa fa-chevron-prev" aria-hidden="true"></span>
-      <span>${_('Previous')}</span>
+      ## Translators: A button for showing the Previous Unit
+      <span>${pgettext('unit', 'Previous')}</span>
     </button>
     <button class="sequence-nav-button button-next">
-      <span>${_('Next')}</span>
+      ## Translators: A button for showing the Next Unit
+      <span>${pgettext('unit', 'Next')}</span>
       <span class="icon fa fa-chevron-next" aria-hidden="true"></span>
     </button>
   </nav>


### PR DESCRIPTION
A translator of the Romanian language complained on Transifex about issues that both [Previous](https://www.transifex.com/open-edx/edx-platform/translate/#ro/mako/14756962?q=text%3Aprevious) (unit) and [Next](https://www.transifex.com/open-edx/edx-platform/translate/#ro/mako/14756963?q=text%3Anext) have no context that translators can use to provide accurate gendered translation:

> #### [Issue on Transifex](https://www.transifex.com/open-edx/edx-platform/translate/#ro/mako/14756963)
> ` @itsalexcoman`: The gender of the noun to which this adjective refers is crucial for a proper Romanian translation.


### TODO
 - [x] I have checked the a the "Next" buttons would show the next ["Unit" (aka vertical)](https://edx.readthedocs.io/projects/edx-open-learning-xml/en/latest/organizing-course/course-xml-file.html#course-verticals). Please double check that for me, since the terminology can be confusing even for those who are familiar with Open edX. 
 - [x] Since `gettext` has no awareness of gender, I've used the context-aware function `pgettext` to provide more context for the translators. 
 - [x] A `Translators` comment have been added.
 - [x] Test in my devstack (Hawthorn via clean cherry-pick) that the UI is still functional:
        <kbd>![image](https://user-images.githubusercontent.com/645156/63652666-69162d80-c76b-11e9-9206-ecfee96d24e3.png)</kbd>

 - [x] Ensure strings are being extracted properly with context
       <kbd>![image](https://user-images.githubusercontent.com/645156/63652518-bbeee580-c769-11e9-9329-d4eb4162ca0c.png)</kbd>

 - [x] Jenkins tests pass -- I suppose no new tests should be added.
 - [x] Once merged, get back to `@itsalexcoman` about the issue.

cc: @nedbat 
