### PR TITLE
[WIP] SE-1406 pluggable instructor dashboard

### DIFF
--- a/lms/djangoapps/instructor/views/instructor_dashboard.py
+++ b/lms/djangoapps/instructor/views/instructor_dashboard.py
@@ -30,6 +30,7 @@ from six.moves.urllib.parse import urljoin  # pylint: disable=import-error
 from xblock.field_data import DictFieldData
 from xblock.fields import ScopeIds
 
+from openedx.core.lib.instructor_dashboard_tabs import InstructorDashboardTabPluginManager
 from bulk_email.api import is_bulk_email_feature_enabled
 from class_dashboard.dashboard_data import get_array_section_has_problem, get_section_display_name
 from course_modes.models import CourseMode, CourseModesArchive
@@ -236,9 +237,8 @@ def instructor_dashboard_2(request, course_id):
     certificate_invalidations = CertificateInvalidation.get_certificate_invalidations(course_key)
 
     # load externally registered sections
-    for entrypoint in pkg_resources.iter_entry_points(group="lms.instructor_dashboard.section"):
-        section = entrypoint.load()
-        sections.append(section(course, access))
+    for Tab in InstructorDashboardTabPluginManager.get_tabs():
+        sections.append(Tab(course, access).to_dict())
 
     context = {
         'course': course,

--- a/lms/djangoapps/instructor/views/instructor_dashboard.py
+++ b/lms/djangoapps/instructor/views/instructor_dashboard.py
@@ -8,7 +8,6 @@ import datetime
 import logging
 import uuid
 
-import pkg_resources
 import pytz
 import six
 from django.conf import settings

--- a/lms/djangoapps/instructor/views/instructor_dashboard.py
+++ b/lms/djangoapps/instructor/views/instructor_dashboard.py
@@ -8,6 +8,7 @@ import datetime
 import logging
 import uuid
 
+import pkg_resources
 import pytz
 import six
 from django.conf import settings
@@ -233,6 +234,11 @@ def instructor_dashboard_2(request, course_id):
     )
 
     certificate_invalidations = CertificateInvalidation.get_certificate_invalidations(course_key)
+
+    # load externally registered sections
+    for entrypoint in pkg_resources.iter_entry_points(group="lms.instructor_dashboard.section"):
+        section = entrypoint.load()
+        sections.append(section(course, access))
 
     context = {
         'course': course,

--- a/openedx/core/djangoapps/course_groups/views.py
+++ b/openedx/core/djangoapps/course_groups/views.py
@@ -503,6 +503,7 @@ class CohortHandler(DeveloperErrorViewMixin, APIPermissions):
             * user_partition_id: The integer identified of the UserPartition.
             * group_id: The integer identified of the specific group in the partition.
     """
+    queryset = ''
     def get(self, request, course_key_string, cohort_id=None):
         """
         Endpoint to get either one or all cohorts.
@@ -528,6 +529,8 @@ class CohortHandler(DeveloperErrorViewMixin, APIPermissions):
                                  'Please use the parent endpoint.',
                                  'wrong-endpoint')
         course_key, course = _get_course_with_access(request, course_key_string)
+
+        # TODO: add bulk import support for this
         name = request.data.get('name')
         if not name:
             raise self.api_error(status.HTTP_400_BAD_REQUEST,

--- a/openedx/core/djangoapps/course_groups/views.py
+++ b/openedx/core/djangoapps/course_groups/views.py
@@ -503,7 +503,9 @@ class CohortHandler(DeveloperErrorViewMixin, APIPermissions):
             * user_partition_id: The integer identified of the UserPartition.
             * group_id: The integer identified of the specific group in the partition.
     """
+
     queryset = ''
+
     def get(self, request, course_key_string, cohort_id=None):
         """
         Endpoint to get either one or all cohorts.

--- a/openedx/core/lib/instructor_dashboard_tabs.py
+++ b/openedx/core/lib/instructor_dashboard_tabs.py
@@ -1,0 +1,28 @@
+"""
+Tabs for the instructor dashboard.
+"""
+from __future__ import absolute_import
+
+from openedx.core.lib.plugins import PluginManager
+
+
+# Stevedore extension point namespaces
+INSTRUCTOR_DASHBOARD_TAB_NAMESPACE = 'lms.instructor_dashboard.tab'
+
+
+class InstructorDashboardTabPluginManager(PluginManager):
+    """
+    Manager for all of the course tabs that have been made available.
+
+    TODO: develop abstract base class for tabs to implement.
+    """
+    NAMESPACE = INSTRUCTOR_DASHBOARD_TAB_NAMESPACE
+
+    @classmethod
+    def get_tabs(cls):
+        """
+        Returns the list of available tabs in their canonical order.
+        """
+        tabs = list(cls.get_available_plugins().values())
+        tabs.sort(key=lambda tab: (tab.priority, tab.section_key))
+        return tabs


### PR DESCRIPTION
Work in progress!

This PR includes fixes and features to support a cohort importer prototype that
we are building at https://github.com/open-craft/cohort-manager

Things currently modified in this PR:

- prototype support for adding a plugin page to the instructor dashboard via
  package resources / entry points
- temporary fix for `'CohortHandler' should either include a 'queryset'
  attribute, or override the 'get_queryset()' method` error on accessing the
  cohorts list api.


**JIRA tickets**: [OSPR-3804](https://openedx.atlassian.net/browse/OSPR-3804)

**Dependencies**: None

**Sandbox URL**: 

-    LMS: https://pr21443.sandbox.opencraft.hosting/
-    Studio: https://studio.pr21443.sandbox.opencraft.hosting/


**Merge deadline**: None

**Testing instructions**:

- install https://github.com/open-craft/cohort-manager in the lms environment
- view the instructor dashboard for a course and verify that the new cohort manager tab is displayed

**Author notes and concerns**:

- There is currently no api method to bulk-create cohorts. This may be a useful method to consider implementing (or expanding the existing cohort create endpoint) in the future (though beyond the scope of this PR).

**Reviewers**
- [ ] @clemente 
- [ ] @bradenmacdonald 
- [ ] edX reviewer[s] TBD

**Settings**
```yaml
EDXAPP_EXTRA_REQUIREMENTS:
  - name: git+https://github.com/open-craft/cohort-manager.git@master#egg=cohort_manager
```
