### PR TITLE
filter out disabled saml provider configs 

### DIFF
--- a/lms/djangoapps/program_enrollments/tests/test_utils.py
+++ b/lms/djangoapps/program_enrollments/tests/test_utils.py
@@ -5,6 +5,7 @@ from __future__ import absolute_import
 
 from uuid import uuid4
 
+import ddt
 import pytest
 from django.core.cache import cache
 from organizations.tests.factories import OrganizationFactory
@@ -25,6 +26,7 @@ from student.tests.factories import UserFactory
 from third_party_auth.tests.factories import SAMLProviderConfigFactory
 
 
+@ddt.ddt
 class GetPlatformUserTests(CacheIsolationTestCase):
     """
     Tests for the get_platform_user function
@@ -127,7 +129,8 @@ class GetPlatformUserTests(CacheIsolationTestCase):
         with pytest.raises(ProviderDoesNotExistException):
             get_user_by_program_id(self.external_user_id, self.program_uuid)
 
-    def test_multiple_active_saml_providers(self):
+    @ddt.data(True, False)
+    def test_multiple_saml_providers(self, second_config_enabled):
         """
         If multiple samlprovider records exist with the same organization
         an exception is raised
@@ -138,7 +141,7 @@ class GetPlatformUserTests(CacheIsolationTestCase):
         self.create_social_auth_entry(self.user, provider, self.external_user_id)
 
         # create a second active config for the same organization
-        SAMLProviderConfigFactory.create(organization=organization, slug='foox')
+        SAMLProviderConfigFactory.create(organization=organization, slug='foox', enabled=second_config_enabled)
 
         with pytest.raises(ProviderConfigurationException):
             get_user_by_program_id(self.external_user_id, self.program_uuid)

--- a/lms/djangoapps/program_enrollments/tests/test_utils.py
+++ b/lms/djangoapps/program_enrollments/tests/test_utils.py
@@ -143,5 +143,9 @@ class GetPlatformUserTests(CacheIsolationTestCase):
         # create a second active config for the same organization
         SAMLProviderConfigFactory.create(organization=organization, slug='foox', enabled=second_config_enabled)
 
-        with pytest.raises(ProviderConfigurationException):
+        try:
             get_user_by_program_id(self.external_user_id, self.program_uuid)
+        except ProviderConfigurationException:
+            self.assertTrue(second_config_enabled, 'Unexpected error when second config is disabled')
+        else:
+            self.assertFalse(second_config_enabled, 'Expected error was not raised when second config is enabled')

--- a/lms/djangoapps/program_enrollments/utils.py
+++ b/lms/djangoapps/program_enrollments/utils.py
@@ -98,7 +98,7 @@ def get_provider_slug(organization):
         ProviderConfigurationException
     """
     try:
-        return organization.samlproviderconfig_set.current_set().get().provider_id.strip('saml-')
+        return organization.samlproviderconfig_set.current_set().get(enabled=True).provider_id.strip('saml-')
     except SAMLProviderConfig.DoesNotExist:
         log.error(u'No SAML provider found for organization id [%s]', organization.id)
         raise ProviderDoesNotExistException


### PR DESCRIPTION
@edx/masters-neem 
[EDUCATOR-4589](https://openedx.atlassian.net/browse/EDUCATOR-4589
)
`current_set()` doesn't know or care about `enabled` so we need to filter for that