### PR TITLE
log all social auth creation failures

### DIFF
--- a/lms/djangoapps/program_enrollments/signals.py
+++ b/lms/djangoapps/program_enrollments/signals.py
@@ -36,9 +36,12 @@ def listen_for_social_auth_creation(sender, instance, created, **kwargs):  # pyl
     try:
         matriculate_learner(instance.user, instance.uid)
     except Exception as e:
-        msg_tmpl = u'Unable to link waiting enrollments for user {}, social auth creation failed: {}'
-        logger.warning(msg_tmpl.format(instance.user, instance.uid))
-        raise e
+        logger.warning(
+            u'Unable to link waiting enrollments for user %s, social auth creation failed: %s',
+            instance.user.id,
+            e,
+        )
+        raise
 
 
 def matriculate_learner(user, uid):

--- a/lms/djangoapps/program_enrollments/tests/test_signals.py
+++ b/lms/djangoapps/program_enrollments/tests/test_signals.py
@@ -358,3 +358,27 @@ class SocialAuthEnrollmentCompletionSignalTest(CacheIsolationTestCase):
                         error_tmpl.format(self.user.id, program_course_enrollments[0].id, 'something has gone wrong')
                     )
                 )
+
+    def test_log_on_unexpected_exception(self):
+        """
+        unexpected errors as part of the account linking process should be logged and re-raised
+        """
+        program_enrollment = self._create_waiting_program_enrollment()
+        self._create_waiting_course_enrollments(program_enrollment)
+
+        with mock.patch('lms.djangoapps.program_enrollments.models.ProgramCourseEnrollment.enroll') as enrollMock:
+            enrollMock.side_effect = Exception('unexpected error')
+            with self.assertRaises(Exception):
+                with LogCapture(logger.name) as log:
+                    UserSocialAuth.objects.create(
+                        user=self.user,
+                        uid='{0}:{1}'.format(self.provider_slug, self.external_id),
+                    )
+                    error_tmpl = u'Unable to link waiting enrollments for user {}, social auth creation failed: {}'
+                    log.check_present(
+                        (
+                            logger.name,
+                            'WARNING',
+                            error_tmpl.format(self.user.id, 'unexpected error')
+                        )
+                    )

--- a/lms/djangoapps/program_enrollments/tests/test_signals.py
+++ b/lms/djangoapps/program_enrollments/tests/test_signals.py
@@ -368,17 +368,17 @@ class SocialAuthEnrollmentCompletionSignalTest(CacheIsolationTestCase):
 
         with mock.patch('lms.djangoapps.program_enrollments.models.ProgramCourseEnrollment.enroll') as enrollMock:
             enrollMock.side_effect = Exception('unexpected error')
-            with self.assertRaisesRegex(Exception, 'unexpected error'):
-                with LogCapture(logger.name) as log:
+            with LogCapture(logger.name) as log:
+                with self.assertRaisesRegex(Exception, 'unexpected error'):
                     UserSocialAuth.objects.create(
                         user=self.user,
                         uid='{0}:{1}'.format(self.provider_slug, self.external_id),
                     )
-                    error_tmpl = u'Unable to link waiting enrollments for user {}, social auth creation failed: {}'
-                    log.check_present(
-                        (
-                            logger.name,
-                            'WARNING',
-                            error_tmpl.format(self.user.id, 'unexpected error')
-                        )
+                error_tmpl = u'Unable to link waiting enrollments for user {}, social auth creation failed: {}'
+                log.check_present(
+                    (
+                        logger.name,
+                        'WARNING',
+                        error_tmpl.format(self.user.id, 'unexpected error')
                     )
+                )

--- a/lms/djangoapps/program_enrollments/tests/test_signals.py
+++ b/lms/djangoapps/program_enrollments/tests/test_signals.py
@@ -368,7 +368,7 @@ class SocialAuthEnrollmentCompletionSignalTest(CacheIsolationTestCase):
 
         with mock.patch('lms.djangoapps.program_enrollments.models.ProgramCourseEnrollment.enroll') as enrollMock:
             enrollMock.side_effect = Exception('unexpected error')
-            with self.assertRaises(Exception):
+            with self.assertRaisesRegex(Exception, 'unexpected error'):
                 with LogCapture(logger.name) as log:
                     UserSocialAuth.objects.create(
                         user=self.user,


### PR DESCRIPTION
@edx/masters-neem 

Additional logging on the social auth linking process.  Any unforeseen exceptions will be logged for visibility.