### PR TITLE
edX logo is not loading on invalid cert view

### DIFF
--- a/lms/djangoapps/certificates/views/webview.py
+++ b/lms/djangoapps/certificates/views/webview.py
@@ -482,7 +482,7 @@ def render_html_view(request, user_id, course_id):
 
     # Kick the user back to the "Invalid" screen if the feature is disabled globally
     if not settings.FEATURES.get('CERTIFICATES_HTML_VIEW', False):
-        return _render_invalid_certificate(course_id, platform_name, configuration)
+        return _render_invalid_certificate(request, course_id, platform_name, configuration)
 
     # Load the course and user objects
     try:
@@ -497,7 +497,7 @@ def render_html_view(request, user_id, course_id):
             u"%d. Specific error: %s"
         )
         log.info(error_str, course_id, user_id, str(exception))
-        return _render_invalid_certificate(course_id, platform_name, configuration)
+        return _render_invalid_certificate(request, course_id, platform_name, configuration)
 
     # Kick the user back to the "Invalid" screen if the feature is disabled for the course
     if not course.cert_html_view_enabled:
@@ -506,7 +506,7 @@ def render_html_view(request, user_id, course_id):
             course_id,
             user_id,
         )
-        return _render_invalid_certificate(course_id, platform_name, configuration)
+        return _render_invalid_certificate(request, course_id, platform_name, configuration)
 
     # Load user's certificate
     user_certificate = _get_user_certificate(request, user, course_key, course, preview_mode)
@@ -516,7 +516,7 @@ def render_html_view(request, user_id, course_id):
             user_id,
             course_id,
         )
-        return _render_invalid_certificate(course_id, platform_name, configuration)
+        return _render_invalid_certificate(request, course_id, platform_name, configuration)
 
     # Get the active certificate configuration for this course
     # If we do not have an active certificate, we'll need to send the user to the "Invalid" screen
@@ -528,7 +528,7 @@ def render_html_view(request, user_id, course_id):
             course_id,
             user_id,
         )
-        return _render_invalid_certificate(course_id, platform_name, configuration)
+        return _render_invalid_certificate(request, course_id, platform_name, configuration)
 
     # Get data from Discovery service that will be necessary for rendering this Certificate.
     catalog_data = _get_catalog_data_for_course(course_key)
@@ -658,9 +658,15 @@ def _get_custom_template_and_language(course_id, course_mode, course_language):
         return (None, None)
 
 
-def _render_invalid_certificate(course_id, platform_name, configuration):
+def _render_invalid_certificate(request, course_id, platform_name, configuration):
+    """
+    Renders the invalid certificate view with default header and footer.
+    """
     context = {}
     _update_context_with_basic_info(context, course_id, platform_name, configuration)
+    # Add certificate header/footer data to current context
+    context.update(get_certificate_header_context(is_secure=request.is_secure()))
+    context.update(get_certificate_footer_context())
     return render_to_response(INVALID_CERTIFICATE_TEMPLATE_PATH, context)
 
 


### PR DESCRIPTION
### Description

[PROD-611](https://openedx.atlassian.net/browse/PROD-611)

edX logo image is not loading on invalid certificate view because context is not been updated with the logo image for invalid cert view. To overcome it, context is updated before rendering invalid cert.
**Before this change:**
<img width="1255" alt="Screen Shot 2019-08-30 at 3 36 39 PM" src="https://user-images.githubusercontent.com/15120237/64018390-ba486780-cb45-11e9-931d-4a7409d2de19.png">
**After this change:**
<img width="1244" alt="Screen Shot 2019-08-30 at 4 23 35 PM" src="https://user-images.githubusercontent.com/15120237/64018409-c6342980-cb45-11e9-899c-41aa64807590.png">
