### PR TITLE
remove timestamps from Jenkinsfiles

### DIFF
--- a/scripts/Jenkinsfiles/bokchoy
+++ b/scripts/Jenkinsfiles/bokchoy
@@ -30,7 +30,6 @@ pipeline {
     agent { label "jenkins-worker" }
     options {
         sendSplunkConsoleLog()
-        timestamps()
         timeout(60)
     }
     stages {

--- a/scripts/Jenkinsfiles/python
+++ b/scripts/Jenkinsfiles/python
@@ -40,7 +40,6 @@ pipeline {
     agent { label "jenkins-worker" }
     options {
         sendSplunkConsoleLog()
-        timestamps()
         timeout(60)
     }
     environment {

--- a/scripts/Jenkinsfiles/quality
+++ b/scripts/Jenkinsfiles/quality
@@ -44,7 +44,6 @@ pipeline {
     agent { label "jenkins-worker" }
     options {
         sendSplunkConsoleLog()
-        timestamps()
         timeout(60)
     }
     stages {


### PR DESCRIPTION
Once Jenkins is rebuilt with the following changes, we can remove calls to `timestamps` in individual jobs:
* https://github.com/edx/jenkins-configuration/pull/136
* https://github.com/edx/configuration/pull/5393