### PR TITLE
Fix padding on discount banner for small screens

### DIFF
--- a/lms/static/sass/features/_course-experience.scss
+++ b/lms/static/sass/features/_course-experience.scss
@@ -31,8 +31,6 @@
   .first-purchase-offer-banner-bold {
       font-weight: bold;
       color: #23419F;
-      margin-right: 3px;
-      margin-left: 5px;
   }
 
 }

--- a/lms/static/sass/views/_verification.scss
+++ b/lms/static/sass/views/_verification.scss
@@ -2265,8 +2265,6 @@
     .first-purchase-offer-banner-bold {
       font-weight: bold;
       color: #23419f;
-      margin-right: 3px;
-      margin-left: 5px;
     }
   }
 }


### PR DESCRIPTION
REV-918

Small screens:
<img width="309" alt="Screen Shot 2019-08-29 at 12 03 57 PM" src="https://user-images.githubusercontent.com/14864970/63968260-4cc90800-ca6d-11e9-806d-e885a654b516.png">

Large screens:
<img width="538" alt="Screen Shot 2019-08-29 at 12 04 11 PM" src="https://user-images.githubusercontent.com/14864970/63968263-4f2b6200-ca6d-11e9-91cd-3deec11d4cc7.png">


