### PR TITLE
Use new ENABLE_PUBLISHER feature flag

### DIFF
--- a/cms/djangoapps/contentstore/tests/test_course_settings.py
+++ b/cms/djangoapps/contentstore/tests/test_course_settings.py
@@ -240,15 +240,14 @@ class CourseDetailsViewTest(CourseTestCase, MilestonesTestCaseMixin):
         (False, True, False),
         (True, True, True),
     )
-    @override_settings(MKTG_URLS={'ROOT': 'dummy-root'})
     def test_visibility_of_entrance_exam_section(self, feature_flags):
         """
         Tests entrance exam section is available if ENTRANCE_EXAMS feature is enabled no matter any other
-        feature is enabled or disabled i.e ENABLE_MKTG_SITE.
+        feature is enabled or disabled i.e ENABLE_PUBLISHER.
         """
         with patch.dict("django.conf.settings.FEATURES", {
             'ENTRANCE_EXAMS': feature_flags[0],
-            'ENABLE_MKTG_SITE': feature_flags[1]
+            'ENABLE_PUBLISHER': feature_flags[1]
         }):
             course_details_url = get_url(self.course.id)
             resp = self.client.get_html(course_details_url)
@@ -257,12 +256,11 @@ class CourseDetailsViewTest(CourseTestCase, MilestonesTestCaseMixin):
                 b'<h3 id="heading-entrance-exam">' in resp.content
             )
 
-    @override_settings(MKTG_URLS={'ROOT': 'dummy-root'})
     def test_marketing_site_fetch(self):
         settings_details_url = get_url(self.course.id)
 
         with mock.patch.dict('django.conf.settings.FEATURES', {
-            'ENABLE_MKTG_SITE': True,
+            'ENABLE_PUBLISHER': True,
             'ENTRANCE_EXAMS': False,
             'ENABLE_PREREQUISITE_COURSES': False
         }):
@@ -416,7 +414,7 @@ class CourseDetailsViewTest(CourseTestCase, MilestonesTestCaseMixin):
     def test_regular_site_fetch(self):
         settings_details_url = get_url(self.course.id)
 
-        with mock.patch.dict('django.conf.settings.FEATURES', {'ENABLE_MKTG_SITE': False,
+        with mock.patch.dict('django.conf.settings.FEATURES', {'ENABLE_PUBLISHER': False,
                                                                'ENABLE_EXTENDED_COURSE_DETAILS': True}):
             response = self.client.get_html(settings_details_url)
             self.assertContains(response, "Course Summary Page")
@@ -1534,44 +1532,42 @@ id=\"course-enrollment-end-time\" value=\"\" placeholder=\"HH:MM\" autocomplete=
         for element in self.EDITABLE_ELEMENTS:
             self.assertNotContains(response, element)
 
-    @mock.patch.dict("django.conf.settings.FEATURES", {'ENABLE_MKTG_SITE': False})
+    @mock.patch.dict("django.conf.settings.FEATURES", {'ENABLE_PUBLISHER': False})
     def test_course_details_with_disabled_setting_global_staff(self):
         """
         Test that user enrollment end date is editable in response.
 
-        Feature flag 'ENABLE_MKTG_SITE' is not enabled.
+        Feature flag 'ENABLE_PUBLISHER' is not enabled.
         User is global staff.
         """
         self._verify_editable(self._get_course_details_response(True))
 
-    @mock.patch.dict("django.conf.settings.FEATURES", {'ENABLE_MKTG_SITE': False})
+    @mock.patch.dict("django.conf.settings.FEATURES", {'ENABLE_PUBLISHER': False})
     def test_course_details_with_disabled_setting_non_global_staff(self):
         """
         Test that user enrollment end date is editable in response.
 
-        Feature flag 'ENABLE_MKTG_SITE' is not enabled.
+        Feature flag 'ENABLE_PUBLISHER' is not enabled.
         User is non-global staff.
         """
         self._verify_editable(self._get_course_details_response(False))
 
-    @mock.patch.dict("django.conf.settings.FEATURES", {'ENABLE_MKTG_SITE': True})
-    @override_settings(MKTG_URLS={'ROOT': 'dummy-root'})
+    @mock.patch.dict("django.conf.settings.FEATURES", {'ENABLE_PUBLISHER': True})
     def test_course_details_with_enabled_setting_global_staff(self):
         """
         Test that user enrollment end date is editable in response.
 
-        Feature flag 'ENABLE_MKTG_SITE' is enabled.
+        Feature flag 'ENABLE_PUBLISHER' is enabled.
         User is global staff.
         """
         self._verify_editable(self._get_course_details_response(True))
 
-    @mock.patch.dict("django.conf.settings.FEATURES", {'ENABLE_MKTG_SITE': True})
-    @override_settings(MKTG_URLS={'ROOT': 'dummy-root'})
+    @mock.patch.dict("django.conf.settings.FEATURES", {'ENABLE_PUBLISHER': True})
     def test_course_details_with_enabled_setting_non_global_staff(self):
         """
         Test that user enrollment end date is not editable in response.
 
-        Feature flag 'ENABLE_MKTG_SITE' is enabled.
+        Feature flag 'ENABLE_PUBLISHER' is enabled.
         User is non-global staff.
         """
         self._verify_not_editable(self._get_course_details_response(False))

--- a/cms/djangoapps/contentstore/views/course.py
+++ b/cms/djangoapps/contentstore/views/course.py
@@ -1045,10 +1045,10 @@ def settings_handler(request, course_key_string):
 
             # see if the ORG of this course can be attributed to a defined configuration . In that case, the
             # course about page should be editable in Studio
-            marketing_site_enabled = configuration_helpers.get_value_for_org(
+            publisher_enabled = configuration_helpers.get_value_for_org(
                 course_module.location.org,
-                'ENABLE_MKTG_SITE',
-                settings.FEATURES.get('ENABLE_MKTG_SITE', False)
+                'ENABLE_PUBLISHER',
+                settings.FEATURES.get('ENABLE_PUBLISHER', False)
             )
             enable_extended_course_details = configuration_helpers.get_value_for_org(
                 course_module.location.org,
@@ -1056,8 +1056,8 @@ def settings_handler(request, course_key_string):
                 settings.FEATURES.get('ENABLE_EXTENDED_COURSE_DETAILS', False)
             )
 
-            about_page_editable = not marketing_site_enabled
-            enrollment_end_editable = GlobalStaff().has_user(request.user) or not marketing_site_enabled
+            about_page_editable = not publisher_enabled
+            enrollment_end_editable = GlobalStaff().has_user(request.user) or not publisher_enabled
             short_description_editable = configuration_helpers.get_value_for_org(
                 course_module.location.org,
                 'EDITABLE_SHORT_DESCRIPTION',

--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -220,6 +220,9 @@ FEATURES = {
     # in sync with the one in lms/envs/common.py
     'ENABLE_EDXNOTES': False,
 
+    # Toggle to enable coordination with the Publisher tool (keep in sync with lms/envs/common.py)
+    'ENABLE_PUBLISHER': False,
+
     # Show a new field in "Advanced settings" that can store custom data about a
     # course and that can be read from themes
     'ENABLE_OTHER_COURSE_SETTINGS': False,

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -292,6 +292,9 @@ FEATURES = {
     # Let students save and manage their annotations
     'ENABLE_EDXNOTES': False,
 
+    # Toggle to enable coordination with the Publisher tool (keep in sync with cms/envs/common.py)
+    'ENABLE_PUBLISHER': False,
+
     # Milestones application flag
     'MILESTONES_APP': False,
 


### PR DESCRIPTION
ENABLE_MKTG_SITE has been serving double duty to both indicate that
an Open edX installation is using a Drupal marketing site AND
is using the Publisher workflow tool for managing course metadata.

But now that publisher-frontend is available and the Publisher
feature is no longer tied to the marketing site, we want to tease
apart those two concerns. Hence ENABLE_PUBLISHER.

Only really used so far in Studio, to control which fields are
shown (if using Publisher, some fields are only editable in
Publisher).