### PR TITLE
BB-1471: Allow redirection to any course page from course home

### DIFF
--- a/lms/djangoapps/courseware/views/views.py
+++ b/lms/djangoapps/courseware/views/views.py
@@ -24,7 +24,7 @@ from django.db.models import Q, prefetch_related_objects
 from django.http import Http404, HttpResponse, HttpResponseBadRequest, HttpResponseForbidden
 from django.shortcuts import redirect
 from django.template.context_processors import csrf
-from django.urls import reverse
+from django.urls import NoReverseMatch, reverse
 from django.utils.decorators import method_decorator
 from django.utils.http import urlquote_plus
 from django.utils.text import slugify
@@ -392,9 +392,9 @@ def course_root(request, course_id):
         try:
             course_home_url = reverse(course_home_behaviour, kwargs={'course_id': course_id})
             return redirect(course_home_url)
-        except:
+        except NoReverseMatch:
             logging.warn(
-                'COURSE_HOME_BEHAVIOUR incorrectly configured. The request url doesn\'t exist: %s',
+                u'COURSE_HOME_BEHAVIOUR incorrectly configured. The request url doesn\'t exist: %s',
                 course_home_behaviour
             )
 

--- a/lms/djangoapps/courseware/views/views.py
+++ b/lms/djangoapps/courseware/views/views.py
@@ -402,6 +402,9 @@ def course_root(request, course_id):
     return course_info(request, course_id)
 
 
+@ensure_csrf_cookie
+@ensure_valid_course_key
+@data_sharing_consent_required
 def course_info(request, course_id):
     """
     Display the course's info.html, or 404 if there is no such course.
@@ -438,6 +441,10 @@ def course_info(request, course_id):
         return None
 
     course_key = CourseKey.from_string(course_id)
+
+    # If the unified course experience is enabled, redirect to the "Course" tab
+    if UNIFIED_COURSE_TAB_FLAG.is_enabled(course_key):
+        return redirect(reverse(course_home_url_name(course_key), args=[course_id]))
 
     with modulestore().bulk_operations(course_key):
         course = get_course_with_access(request.user, 'load', course_key)

--- a/lms/urls.py
+++ b/lms/urls.py
@@ -307,12 +307,12 @@ urlpatterns += [
         name='enroll_staff',
     ),
 
-    #Inside the course
+    # Course root url
     url(
         r'^courses/{}/$'.format(
             settings.COURSE_ID_PATTERN,
         ),
-        courseware_views.course_info,
+        courseware_views.course_root,
         name='course_root',
     ),
     url(


### PR DESCRIPTION
This PR adds a configuration that allows direct redirection from the course home to any course page.

**JIRA tickets**: [OSPR-3820](https://openedx.atlassian.net/browse/OSPR-3820).

**Sandbox URL**: TBD - sandbox is being provisioned.

**Merge deadline**: None.

**Testing instructions:**

1. Checkout this branch.
1. Set `course_experience.unified_course_tab` on [WaffleFlag settings](http://localhost:8000/admin/waffle/flag/).
1. Go to a course's main page and check that it redirects to /course page with the unified course experience.
1. Disable the WaffleFlag, and add the following variable to the [SiteConfiguration Settings](http://localhost:8000/admin/site_configuration/siteconfiguration/):

```
{
    ...
    "COURSE_HOME_BEHAVIOUR": "courseware"
}
```

1. Check if navigating to a course's home page redirect's to the courseware (http://localhost:8000/courses/course-v1:edX+DemoX+Demo_Course/).
1. Test changing that setting to `info`, `about` and `course`, and assert that the correct redirections are made.
1. Set `COURSE_HOME_BEHAVIOUR` to `thisdoesntexist` and check that the page defaults to the original behaviour (showing the course info page) and logs a warning to the console.

**Author notes and concerns**:
1. I'm not sure `SiteConfiguration` is the best place for this setting.
2. This function is partially covered by tests, I can create more unit tests if required.

**Reviewer:**
- [ ] @xitij2000 
- [ ] edX reviewer[s] TBD