### PR TITLE
 Breaking change: .load(), .unload(), and .error() removed

### DIFF
--- a/cms/static/js/views/instructor_info.js
+++ b/cms/static/js/views/instructor_info.js
@@ -42,10 +42,10 @@ define([
                 });
 
                 // Avoid showing broken image on mistyped/nonexistent image
-                this.$el.find('img').error(function() {
+                this.$el.find('img').on('error', function() {
                     $(this).hide();
                 });
-                this.$el.find('img').load(function() {
+                this.$el.find('img').on('load', function() {
                     $(this).show();
                 });
             },

--- a/cms/static/js/views/settings/main.js
+++ b/cms/static/js/views/settings/main.js
@@ -36,10 +36,10 @@ define(['js/views/validation', 'codemirror', 'underscore', 'jquery', 'jquery.ui'
                    this.$el.find('.set-date').datepicker({dateFormat: 'm/d/yy'});
 
         // Avoid showing broken image on mistyped/nonexistent image
-                   this.$el.find('img').error(function() {
+                   this.$el.find('img').on('error', function() {
                        $(this).hide();
                    });
-                   this.$el.find('img').load(function() {
+                   this.$el.find('img').on('load', function() {
                        $(this).show();
                    });
 

--- a/common/static/js/capa/drag_and_drop/base_image.js
+++ b/common/static/js/capa/drag_and_drop/base_image.js
@@ -22,7 +22,7 @@
             });
 
             state.baseImageEl.attr('src', state.config.baseImage);
-            state.baseImageEl.load(function() {
+            state.baseImageEl.on('load', function() {
                 $baseImageElContainer.css({
                     width: this.width,
                     height: this.height
@@ -37,7 +37,7 @@
 
                 state.baseImageLoaded = true;
             });
-            state.baseImageEl.error(function() {
+            state.baseImageEl.on('error', function() {
                 console.log('ERROR: Image "' + state.config.baseImage + '" was not found!');
                 $baseImageElContainer.html(
                 '<span style="color: red;">' +

--- a/common/static/js/capa/drag_and_drop/draggables.js
+++ b/common/static/js/capa/drag_and_drop/draggables.js
@@ -37,7 +37,7 @@
                 draggableObj.iconEl = $('<div></div>');
                 draggableObj.iconImgEl = $('<img />');
                 draggableObj.iconImgEl.attr('src', draggableObj.originalConfigObj.icon);
-                draggableObj.iconImgEl.load(function() {
+                draggableObj.iconImgEl.on('load', function() {
                     draggableObj.iconEl.css({
                         position: 'absolute',
                         width: draggableObj.iconWidthSmall,
@@ -196,7 +196,7 @@
 
                 draggableObj.iconImgEl = $('<img />');
                 draggableObj.iconImgEl.attr('src', obj.icon);
-                draggableObj.iconImgEl.load(function() {
+                draggableObj.iconImgEl.on('load', function() {
                     draggableObj.iconWidth = this.width;
                     draggableObj.iconHeight = this.height;
 

--- a/lms/static/js/jquery.allLoaded.js
+++ b/lms/static/js/jquery.allLoaded.js
@@ -27,7 +27,7 @@
                 this.unbind(handler);
             };
 
-            return $elems.load(handler);
+            return $elems.on('load', handler);
         }
     });
 })(jQuery);

--- a/openedx/features/course_experience/static/course_experience/js/CourseTalkReviews.js
+++ b/openedx/features/course_experience/static/course_experience/js/CourseTalkReviews.js
@@ -12,7 +12,7 @@ export class CourseTalkReviews {  // eslint-disable-line import/prefer-default-e
     // Initialize page to the read reviews view
     self.currentSrc = options.readSrc;
     $.getScript(options.readSrc, () => { // eslint-disable-line func-names
-      $('iframe').load(() => {
+      $('iframe').on('load', () => {
         $(options.loadIcon).hide();
       });
     });
@@ -33,7 +33,7 @@ export class CourseTalkReviews {  // eslint-disable-line import/prefer-default-e
       // Toggle the new coursetalk script object
       self.currentSrc = switchToReadView ? options.readSrc : options.writeSrc;
       $.getScript(self.currentSrc, () => { // eslint-disable-line func-names
-        $('iframe').load(() => {
+        $('iframe').on('load', () => {
           $(options.loadIcon).hide();
         });
       });


### PR DESCRIPTION
Part of : Update Jquery from 2.2.4 to 3.4.1