### PR TITLE
BOM-372

### DIFF
--- a/common/lib/xmodule/xmodule/contentstore/mongo.py
+++ b/common/lib/xmodule/xmodule/contentstore/mongo.py
@@ -91,7 +91,6 @@ class MongoContentStore(ContentStore):
         # Then you can upload as many versions as you like and access by date or version. Because we use
         # the location as the _id, we must delete before adding (there's no replace method in gridFS)
         self.delete(content_id)  # delete is a noop if the entry doesn't exist; so, don't waste time checking
-
         thumbnail_location = content.thumbnail_location.to_deprecated_list_repr() if content.thumbnail_location else None
         with self.fs.new_file(_id=content_id, filename=six.text_type(content.location), content_type=content.content_type,
                               displayname=content.name, content_son=content_son,
@@ -99,7 +98,7 @@ class MongoContentStore(ContentStore):
                               import_path=content.import_path,
                               # getattr b/c caching may mean some pickled instances don't have attr
                               locked=getattr(content, 'locked', False)) as fp:
-            if hasattr(content.data, '__iter__'):
+            if hasattr(content.data, '__iter__') and not isinstance(content.data, bytes):
                 for chunk in content.data:
                     fp.write(chunk)
             else:
@@ -119,7 +118,6 @@ class MongoContentStore(ContentStore):
     @autoretry_read()
     def find(self, location, throw_on_not_found=True, as_stream=False):
         content_id, __ = self.asset_db_key(location)
-
         try:
             if as_stream:
                 fp = self.fs.get(content_id)


### PR DESCRIPTION
This fixes the error but later causes the following error
self = <gridfs.grid_file.GridOut object at 0x7f4541f380b8>

    def readchunk(self):
        """Reads a chunk at a time. If the current position is within a
        chunk the remainder of the chunk is returned.
        """
        self._ensure_file()
        received = len(self.__buffer)
        chunk_data = EMPTY
        chunk_size = int(self.chunk_size)
    
        if received > 0:
            chunk_data = self.__buffer
        elif self.__position < int(self.length):
            chunk_number = int((received + self.__position) / chunk_size)
            chunk = self.__chunks.find_one({"files_id": self._id,
                                            "n": chunk_number})
            if not chunk:
>               raise CorruptGridFile("no chunk #%d" % chunk_number)
E               gridfs.errors.CorruptGridFile: no chunk #0

/root/edxapp_toxenv/py35-django111/lib/python3.5/site-packages/gridfs/grid_file.py:456: CorruptGridFile