### PR TITLE
Fix errors when running runserver in python 3.

### DIFF
--- a/cms/envs/production.py
+++ b/cms/envs/production.py
@@ -116,8 +116,7 @@ EDX_PLATFORM_REVISION = ENV_TOKENS.get('EDX_PLATFORM_REVISION', EDX_PLATFORM_REV
 # STATIC_URL_BASE specifies the base url to use for static files
 STATIC_URL_BASE = ENV_TOKENS.get('STATIC_URL_BASE', None)
 if STATIC_URL_BASE:
-    # collectstatic will fail if STATIC_URL is a unicode string
-    STATIC_URL = STATIC_URL_BASE.encode('ascii')
+    STATIC_URL = STATIC_URL_BASE
     if not STATIC_URL.endswith("/"):
         STATIC_URL += "/"
     STATIC_URL += 'studio/'

--- a/common/djangoapps/student/migrations/0022_indexing_in_courseenrollment.py
+++ b/common/djangoapps/student/migrations/0022_indexing_in_courseenrollment.py
@@ -14,6 +14,6 @@ class Migration(migrations.Migration):
     operations = [
         migrations.AddIndex(
             model_name='courseenrollment',
-            index=models.Index(fields=[b'user', b'-created'], name='student_cou_user_id_b19dcd_idx'),
+            index=models.Index(fields=['user', '-created'], name='student_cou_user_id_b19dcd_idx'),
         ),
     ]

--- a/lms/envs/production.py
+++ b/lms/envs/production.py
@@ -137,8 +137,7 @@ if STATIC_ROOT_BASE:
 # STATIC_URL_BASE specifies the base url to use for static files
 STATIC_URL_BASE = ENV_TOKENS.get('STATIC_URL_BASE', None)
 if STATIC_URL_BASE:
-    # collectstatic will fail if STATIC_URL is a unicode string
-    STATIC_URL = STATIC_URL_BASE.encode('ascii')
+    STATIC_URL = STATIC_URL_BASE
     if not STATIC_URL.endswith("/"):
         STATIC_URL += "/"
 


### PR DESCRIPTION
- The fields need to be unicode not bytes.  In python 2 it was auto
converting.
- The static url base has been allowed to be a unicode string for a
while.

There is one more issue not fixed here with django-debug-toolbar-mongo.