### PR TITLE
SE-1463 Allow overriding broker heartbeat

### DIFF
--- a/cms/envs/production.py
+++ b/cms/envs/production.py
@@ -96,8 +96,8 @@ CELERY_RESULT_BACKEND = 'djcelery.backends.cache:CacheBackend'
 
 # When the broker is behind an ELB, use a heartbeat to refresh the
 # connection and to detect if it has been dropped.
-BROKER_HEARTBEAT = 60.0
-BROKER_HEARTBEAT_CHECKRATE = 2
+BROKER_HEARTBEAT = ENV_TOKENS.get('BROKER_HEARTBEAT', 60.0)
+BROKER_HEARTBEAT_CHECKRATE = ENV_TOKENS.get('BROKER_HEARTBEAT_CHECKRATE', 2)
 
 # Each worker should only fetch one message at a time
 CELERYD_PREFETCH_MULTIPLIER = 1

--- a/lms/envs/production.py
+++ b/lms/envs/production.py
@@ -108,8 +108,8 @@ CELERY_RESULT_BACKEND = 'djcelery.backends.cache:CacheBackend'
 
 # When the broker is behind an ELB, use a heartbeat to refresh the
 # connection and to detect if it has been dropped.
-BROKER_HEARTBEAT = 60.0
-BROKER_HEARTBEAT_CHECKRATE = 2
+BROKER_HEARTBEAT = ENV_TOKENS.get('BROKER_HEARTBEAT', 60.0)
+BROKER_HEARTBEAT_CHECKRATE = ENV_TOKENS.get('BROKER_HEARTBEAT_CHECKRATE', 2)
 
 # Each worker should only fetch one message at a time
 CELERYD_PREFETCH_MULTIPLIER = 1


### PR DESCRIPTION
BROKER_HEARTBEAT appears to interfere with the celery worker
configuration. If we want to disable or change the heartbeat interval,
It must be from these configuration options.

Just setting --without-heartbeat and/or --heartbeat-interval on the
workers does not fully work (it only disables the worker event heartbeats). Eg. --without-heartbeat disables sending
event heartbeats, but BROKER_HEARTBEAT = 60 means that the connection will get
a 60s amqp heartbeat interval negotiated.

**JIRA tickets**: [OSPR-3826](https://openedx.atlassian.net/browse/OSPR-3826)

**Dependencies**: None

**Sandbox URL**: 


-    LMS: https://pr21567.sandbox.opencraft.hosting/
-    Studio: https://studio.pr21567.sandbox.opencraft.hosting/


**Merge deadline**: None

**Testing instructions**:

1. Change the variables `BROKER_HEARTBEAT` to 0, and deploy edxapp
2. ensure that the heartbeat config for the rabbitmq server is set to 0
3. run the workers
4. verify that rabbitmq connections are negotiated with heartbeats disabled.
5. Change the variables `BROKER_HEARTBEAT` to 600, and deploy edxapp
6. run the workers
7. verify that rabbitmq connections are negotiated with heartbeats set to 600s.

The change can be verified on the sandbox by tailing the worker logs and verifying
that the socket closed errors happen with a lesser frequency than 3 minutes per
worker.

**Reviewers**
- [x] @viadanna 
- [ ] edX reviewer[s] TBD

**Settings**
```yaml
EDXAPP_LMS_ENV_EXTRA:
  BROKER_HEARTBEAT: 0
  BROKER_HEARTBEAT_CHECKRATE: 1
EDXAPP_CMS_ENV_EXTRA:
  BROKER_HEARTBEAT: 0
  BROKER_HEARTBEAT_CHECKRATE: 1
```
