### PR TITLE
BOM-156 | Fixes for response decoding (Python 3.5)

### DIFF
--- a/lms/djangoapps/courseware/tests/test_about.py
+++ b/lms/djangoapps/courseware/tests/test_about.py
@@ -97,10 +97,10 @@ class AboutTestCase(LoginEnrollmentTestCase, SharedModuleStoreTestCase, EventTra
         url = reverse('about_course', args=[text_type(self.course.id)])
         resp = self.client.get(url)
         self.assertEqual(resp.status_code, 200)
-        self.assertIn("OOGIE BLOOGIE", resp.content)
+        self.assertIn("OOGIE BLOOGIE", resp.content.decode('utf-8'))
 
         # Check that registration button is present
-        self.assertIn(REG_STR, resp.content)
+        self.assertIn(REG_STR, resp.content.decode('utf-8'))
 
     def test_logged_in(self):
         """
@@ -110,7 +110,7 @@ class AboutTestCase(LoginEnrollmentTestCase, SharedModuleStoreTestCase, EventTra
         url = reverse('about_course', args=[text_type(self.course.id)])
         resp = self.client.get(url)
         self.assertEqual(resp.status_code, 200)
-        self.assertIn("OOGIE BLOOGIE", resp.content)
+        self.assertIn("OOGIE BLOOGIE", resp.content.decode('utf-8'))
 
     def test_already_enrolled(self):
         """
@@ -122,8 +122,8 @@ class AboutTestCase(LoginEnrollmentTestCase, SharedModuleStoreTestCase, EventTra
         url = reverse('about_course', args=[text_type(self.course.id)])
         resp = self.client.get(url)
         self.assertEqual(resp.status_code, 200)
-        self.assertIn("You are enrolled in this course", resp.content)
-        self.assertIn("View Course", resp.content)
+        self.assertIn("You are enrolled in this course", resp.content.decode('utf-8'))
+        self.assertIn("View Course", resp.content.decode('utf-8'))
 
     @override_settings(COURSE_ABOUT_VISIBILITY_PERMISSION="see_about_page")
     def test_visible_about_page_settings(self):
@@ -133,7 +133,7 @@ class AboutTestCase(LoginEnrollmentTestCase, SharedModuleStoreTestCase, EventTra
         url = reverse('about_course', args=[text_type(self.course_with_about.id)])
         resp = self.client.get(url)
         self.assertEqual(resp.status_code, 200)
-        self.assertIn("WITH ABOUT", resp.content)
+        self.assertIn("WITH ABOUT", resp.content.decode('utf-8'))
 
         url = reverse('about_course', args=[text_type(self.course_without_about.id)])
         resp = self.client.get(url)
@@ -164,7 +164,7 @@ class AboutTestCase(LoginEnrollmentTestCase, SharedModuleStoreTestCase, EventTra
         resp = self.client.get(url)
         # should not be redirected
         self.assertEqual(resp.status_code, 200)
-        self.assertIn("OOGIE BLOOGIE", resp.content)
+        self.assertIn("OOGIE BLOOGIE", resp.content.decode('utf-8'))
 
     @patch.dict(settings.FEATURES, {'ENABLE_COURSE_HOME_REDIRECT': True})
     @patch.dict(settings.FEATURES, {'ENABLE_MKTG_SITE': False})
@@ -178,7 +178,7 @@ class AboutTestCase(LoginEnrollmentTestCase, SharedModuleStoreTestCase, EventTra
         resp = self.client.get(url)
         # should not be redirected
         self.assertEqual(resp.status_code, 200)
-        self.assertIn("OOGIE BLOOGIE", resp.content)
+        self.assertIn("OOGIE BLOOGIE", resp.content.decode('utf-8'))
 
     @patch.dict(settings.FEATURES, {'ENABLE_PREREQUISITE_COURSES': True})
     def test_pre_requisite_course(self):
@@ -251,9 +251,9 @@ class AboutTestCase(LoginEnrollmentTestCase, SharedModuleStoreTestCase, EventTra
                 resp = self.client.get(url)
         self.assertEqual(resp.status_code, 200)
         if course_visibility == COURSE_VISIBILITY_PUBLIC or course_visibility == COURSE_VISIBILITY_PUBLIC_OUTLINE:
-            self.assertIn("View Course", resp.content)
+            self.assertIn("View Course", resp.content.decode('utf-8'))
         else:
-            self.assertIn("Enroll Now", resp.content)
+            self.assertIn("Enroll Now", resp.content.decode('utf-8'))
 
 
 class AboutTestCaseXML(LoginEnrollmentTestCase, ModuleStoreTestCase):
@@ -300,7 +300,7 @@ class AboutTestCaseXML(LoginEnrollmentTestCase, ModuleStoreTestCase):
         url = reverse('about_course', args=[text_type(self.xml_course_id)])
         resp = self.client.get(url)
         self.assertEqual(resp.status_code, 200)
-        self.assertIn(self.xml_data, resp.content)
+        self.assertIn(self.xml_data, resp.content.decode('utf-8'))
 
 
 class AboutWithCappedEnrollmentsTestCase(LoginEnrollmentTestCase, SharedModuleStoreTestCase):
@@ -324,10 +324,11 @@ class AboutWithCappedEnrollmentsTestCase(LoginEnrollmentTestCase, SharedModuleSt
         url = reverse('about_course', args=[text_type(self.course.id)])
         resp = self.client.get(url)
         self.assertEqual(resp.status_code, 200)
-        self.assertIn('<a href="#" class="register">', resp.content)
+        self.assertIn('<a href="#" class="register">', resp.content.decode('utf-8'))
 
         self.enroll(self.course, verify=True)
 
+        # pylint: disable=attribute-defined-outside-init
         # create a new account since the first account is already enrolled in the course
         self.email = 'foo_second@test.com'
         self.password = 'bar'
@@ -339,14 +340,14 @@ class AboutWithCappedEnrollmentsTestCase(LoginEnrollmentTestCase, SharedModuleSt
         # Get the about page again and make sure that the page says that the course is full
         resp = self.client.get(url)
         self.assertEqual(resp.status_code, 200)
-        self.assertIn("Course is full", resp.content)
+        self.assertIn("Course is full", resp.content.decode('utf-8'))
 
         # Try to enroll as well
         result = self.enroll(self.course)
         self.assertFalse(result)
 
         # Check that registration button is not present
-        self.assertNotIn(REG_STR, resp.content)
+        self.assertNotIn(REG_STR, resp.content.decode('utf-8'))
 
 
 class AboutWithInvitationOnly(SharedModuleStoreTestCase):
@@ -370,10 +371,10 @@ class AboutWithInvitationOnly(SharedModuleStoreTestCase):
         url = reverse('about_course', args=[text_type(self.course.id)])
         resp = self.client.get(url)
         self.assertEqual(resp.status_code, 200)
-        self.assertIn("Enrollment in this course is by invitation only", resp.content)
+        self.assertIn("Enrollment in this course is by invitation only", resp.content.decode('utf-8'))
 
         # Check that registration button is not present
-        self.assertNotIn(REG_STR, resp.content)
+        self.assertNotIn(REG_STR, resp.content.decode('utf-8'))
 
     def test_invitation_only_but_allowed(self):
         """
@@ -391,7 +392,7 @@ class AboutWithInvitationOnly(SharedModuleStoreTestCase):
         self.assertIn(u"Enroll Now", resp.content.decode('utf-8'))
 
         # Check that registration button is present
-        self.assertIn(REG_STR, resp.content)
+        self.assertIn(REG_STR, resp.content.decode('utf-8'))
 
 
 class AboutWithClosedEnrollment(ModuleStoreTestCase):
@@ -422,10 +423,10 @@ class AboutWithClosedEnrollment(ModuleStoreTestCase):
         url = reverse('about_course', args=[text_type(self.course.id)])
         resp = self.client.get(url)
         self.assertEqual(resp.status_code, 200)
-        self.assertIn("Enrollment is Closed", resp.content)
+        self.assertIn("Enrollment is Closed", resp.content.decode('utf-8'))
 
         # Check that registration button is not present
-        self.assertNotIn(REG_STR, resp.content)
+        self.assertNotIn(REG_STR, resp.content.decode('utf-8'))
 
     def test_course_price_is_not_visble_in_sidebar(self):
         url = reverse('about_course', args=[text_type(self.course.id)])
@@ -433,7 +434,7 @@ class AboutWithClosedEnrollment(ModuleStoreTestCase):
         self.assertEqual(resp.status_code, 200)
         # course price is not visible ihe course_about page when the course
         # mode is not set to honor
-        self.assertNotIn('<span class="important-dates-item-text">$10</span>', resp.content)
+        self.assertNotIn('<span class="important-dates-item-text">$10</span>', resp.content.decode('utf-8'))
 
 
 @ddt.ddt
@@ -473,10 +474,10 @@ class AboutSidebarHTMLTestCase(SharedModuleStoreTestCase):
             resp = self.client.get(url)
             self.assertEqual(resp.status_code, 200)
             if waffle_switch_value and itemfactory_display_name and itemfactory_data:
-                self.assertIn('<section class="about-sidebar-html">', resp.content)
-                self.assertIn(itemfactory_data, resp.content)
+                self.assertIn('<section class="about-sidebar-html">', resp.content.decode('utf-8'))
+                self.assertIn(itemfactory_data, resp.content.decode('utf-8'))
             else:
-                self.assertNotIn('<section class="about-sidebar-html">', resp.content)
+                self.assertNotIn('<section class="about-sidebar-html">', resp.content.decode('utf-8'))
 
 
 @patch.dict(settings.FEATURES, {'ENABLE_SHOPPING_CART': True})
@@ -527,7 +528,7 @@ class AboutPurchaseCourseTestCase(LoginEnrollmentTestCase, SharedModuleStoreTest
         url = reverse('about_course', args=[text_type(self.course.id)])
         resp = self.client.get(url)
         self.assertEqual(resp.status_code, 200)
-        self.assertIn("Add buyme to Cart <span>($10 USD)</span>", resp.content)
+        self.assertIn("Add buyme to Cart <span>($10 USD)</span>", resp.content.decode('utf-8'))
 
     def test_logged_in(self):
         """
@@ -537,7 +538,7 @@ class AboutPurchaseCourseTestCase(LoginEnrollmentTestCase, SharedModuleStoreTest
         url = reverse('about_course', args=[text_type(self.course.id)])
         resp = self.client.get(url)
         self.assertEqual(resp.status_code, 200)
-        self.assertIn("Add buyme to Cart <span>($10 USD)</span>", resp.content)
+        self.assertIn("Add buyme to Cart <span>($10 USD)</span>", resp.content.decode('utf-8'))
 
     def test_already_in_cart(self):
         """
@@ -551,8 +552,8 @@ class AboutPurchaseCourseTestCase(LoginEnrollmentTestCase, SharedModuleStoreTest
         url = reverse('about_course', args=[text_type(self.course.id)])
         resp = self.client.get(url)
         self.assertEqual(resp.status_code, 200)
-        self.assertIn("This course is in your", resp.content)
-        self.assertNotIn("Add buyme to Cart <span>($10 USD)</span>", resp.content)
+        self.assertIn("This course is in your", resp.content.decode('utf-8'))
+        self.assertNotIn("Add buyme to Cart <span>($10 USD)</span>", resp.content.decode('utf-8'))
 
     def test_already_enrolled(self):
         """
@@ -569,9 +570,9 @@ class AboutPurchaseCourseTestCase(LoginEnrollmentTestCase, SharedModuleStoreTest
 
         resp = self.client.get(url)
         self.assertEqual(resp.status_code, 200)
-        self.assertIn("You are enrolled in this course", resp.content)
-        self.assertIn("View Course", resp.content)
-        self.assertNotIn("Add buyme to Cart <span>($10 USD)</span>", resp.content)
+        self.assertIn("You are enrolled in this course", resp.content.decode('utf-8'))
+        self.assertIn("View Course", resp.content.decode('utf-8'))
+        self.assertNotIn("Add buyme to Cart <span>($10 USD)</span>", resp.content.decode('utf-8'))
 
     def test_closed_enrollment(self):
         """
@@ -583,12 +584,12 @@ class AboutPurchaseCourseTestCase(LoginEnrollmentTestCase, SharedModuleStoreTest
         url = reverse('about_course', args=[text_type(self.closed_course.id)])
         resp = self.client.get(url)
         self.assertEqual(resp.status_code, 200)
-        self.assertIn("Enrollment is Closed", resp.content)
-        self.assertNotIn("Add closed to Cart <span>($10 USD)</span>", resp.content)
+        self.assertIn("Enrollment is Closed", resp.content.decode('utf-8'))
+        self.assertNotIn("Add closed to Cart <span>($10 USD)</span>", resp.content.decode('utf-8'))
 
         # course price is visible ihe course_about page when the course
         # mode is set to honor and it's price is set
-        self.assertIn('<span class="important-dates-item-text">$10</span>', resp.content)
+        self.assertIn('<span class="important-dates-item-text">$10</span>', resp.content.decode('utf-8'))
 
     def test_invitation_only(self):
         """
@@ -602,7 +603,7 @@ class AboutPurchaseCourseTestCase(LoginEnrollmentTestCase, SharedModuleStoreTest
         url = reverse('about_course', args=[text_type(course.id)])
         resp = self.client.get(url)
         self.assertEqual(resp.status_code, 200)
-        self.assertIn("Enrollment in this course is by invitation only", resp.content)
+        self.assertIn("Enrollment in this course is by invitation only", resp.content.decode('utf-8'))
 
     def test_enrollment_cap(self):
         """
@@ -621,7 +622,7 @@ class AboutPurchaseCourseTestCase(LoginEnrollmentTestCase, SharedModuleStoreTest
         url = reverse('about_course', args=[text_type(course.id)])
         resp = self.client.get(url)
         self.assertEqual(resp.status_code, 200)
-        self.assertIn("Add buyme to Cart <span>($10 USD)</span>", resp.content)
+        self.assertIn("Add buyme to Cart <span>($10 USD)</span>", resp.content.decode('utf-8'))
 
         # note that we can't call self.enroll here since that goes through
         # the Django student views, which doesn't allow for enrollments
@@ -640,8 +641,8 @@ class AboutPurchaseCourseTestCase(LoginEnrollmentTestCase, SharedModuleStoreTest
         # Get the about page again and make sure that the page says that the course is full
         resp = self.client.get(url)
         self.assertEqual(resp.status_code, 200)
-        self.assertIn("Course is full", resp.content)
-        self.assertNotIn("Add buyme to Cart ($10)", resp.content)
+        self.assertIn("Course is full", resp.content.decode('utf-8'))
+        self.assertNotIn("Add buyme to Cart ($10)", resp.content.decode('utf-8'))
 
     def test_free_course_display(self):
         """
@@ -654,8 +655,8 @@ class AboutPurchaseCourseTestCase(LoginEnrollmentTestCase, SharedModuleStoreTest
 
         resp = self.client.get(url)
         self.assertEqual(resp.status_code, 200)
-        self.assertNotIn("Add free to Cart (Free)", resp.content)
-        self.assertNotIn('<p class="important-dates-item-title">Price</p>', resp.content)
+        self.assertNotIn("Add free to Cart (Free)", resp.content.decode('utf-8'))
+        self.assertNotIn('<p class="important-dates-item-title">Price</p>', resp.content.decode('utf-8'))
 
 
 class CourseAboutTestCaseCCX(SharedModuleStoreTestCase, LoginEnrollmentTestCase):


### PR DESCRIPTION
Test cases fix for `TypeError: a bytes-like object is required, not 'str'`