### PR TITLE
[CLOSED] Create Python API for program_enrollments: Part III

### DIFF
--- a/common/djangoapps/util/query.py
+++ b/common/djangoapps/util/query.py
@@ -4,9 +4,46 @@ from __future__ import absolute_import
 from django.conf import settings
 
 
+_READ_REPLICA_DB_ALIAS = "read_replica"
+
+
 def use_read_replica_if_available(queryset):
     """
     If there is a database called 'read_replica',
     use that database for the queryset / manager.
+
+    Example usage:
+        queryset = use_read_replica_if_available(SomeModel.objects.filter(...))
+
+    Arguments:
+        queryset (QuerySet)
+
+    Returns: QuerySet
     """
-    return queryset.using("read_replica") if "read_replica" in settings.DATABASES else queryset
+    return (
+        queryset.using(_READ_REPLICA_DB_ALIAS)
+        if _READ_REPLICA_DB_ALIAS in settings.DATABASES
+        else queryset
+    )
+
+
+def read_replica_or_default():
+    """
+    If there is a database called "read_replica",
+    return "read_replica", otherwise return "default".
+
+    This function is similiar to `use_read_replica_if_available`,
+    but is be more syntactically convenient for method call chaining.
+    Also, it always falls back to "default",
+    no matter what the queryset was using before.
+
+    Example usage:
+        queryset = SomeModel.objects.filter(...).using(read_replica_or_default())
+
+    Returns: str
+    """
+    return (
+        _READ_REPLICA_DB_ALIAS
+        if _READ_REPLICA_DB_ALIAS in settings.DATABASES
+        else "default"
+    )

--- a/lms/djangoapps/program_enrollments/api/__init__.py
+++ b/lms/djangoapps/program_enrollments/api/__init__.py
@@ -1,0 +1,11 @@
+"""
+Python API exposed by the proram_enrollments app to other in-process apps.
+
+The functions are split into separate files for code organization, but they
+are wildcard-imported into here so they can be imported directly from
+`lms.djangoapps.program_enrollments.api`.
+"""
+from __future__ import absolute_import
+
+from .linking import *  # pylint: disable=wildcard-import
+from .reading import *  # pylint: disable=wildcard-import

--- a/lms/djangoapps/program_enrollments/api/reading.py
+++ b/lms/djangoapps/program_enrollments/api/reading.py
@@ -1,0 +1,222 @@
+"""
+Python API functions related to reading program enrollments.
+
+Outside of this subpackage, import these functions
+from `lms.djangoapps.program_enrollments.api`.
+"""
+from __future__ import absolute_import, unicode_literals
+
+from ..models import ProgramCourseEnrollment, ProgramEnrollment
+
+_STUDENT_ARG_ERROR_MESSAGE = (
+    "user and external_user_key are both None; at least one must be provided."
+)
+_REALIZED_FILTER_ERROR_TEMPLATE = (
+    "{} and {} are mutually exclusive; at most one of them may be passed in as True."
+)
+
+
+def get_program_enrollment(
+        program_uuid,
+        user=None,
+        external_user_key=None,
+        curriculum_uuid=None,
+):
+    """
+    TODO
+    """
+    if not (user or external_user_key):
+        raise ValueError(_STUDENT_ARG_ERROR_MESSAGE)
+    filters = {
+        "user": user,
+        "external_user_key": external_user_key,
+        "curriculum_uuid": curriculum_uuid,
+    }
+    return ProgramEnrollment.objects.get(
+        program_uuid=program_uuid, **_remove_none_values(filters)
+
+    )
+
+
+def fetch_program_enrollments(
+        program_uuid,
+        curriculum_uuids=None,
+        users=None,
+        external_user_keys=None,
+        program_enrollment_statuses=None,
+        realized_only=False,
+        waiting_only=False,
+):
+    """
+    TODO
+    """
+    if realized_only and waiting_only:
+        raise ValueError(
+            _REALIZED_FILTER_ERROR_TEMPLATE.format("realized_only", "waiting_only")
+        )
+    filters = {
+        "curriculum_uuid__in": curriculum_uuids,
+        "user__in": users,
+        "external_user_key__in": external_user_keys,
+        "status__in": program_enrollment_statuses,
+    }
+    if realized_only:
+        filters["user__isnull"] = False
+    if waiting_only:
+        filters["user__isnull"] = True
+    return ProgramEnrollment.objects.filter(
+        program_uuid=program_uuid, **_remove_none_values(filters)
+    )
+
+
+def fetch_program_enrollments_by_student(
+        user=None,
+        external_user_key=None,
+        program_uuids=None,
+        curriculum_uuids=None,
+        program_enrollment_statuses=None,
+        realized_only=False,
+        waiting_only=False,
+):
+    """
+    TODO
+    """
+    if not (user or external_user_key):
+        raise ValueError(_STUDENT_ARG_ERROR_MESSAGE)
+    if realized_only and waiting_only:
+        raise ValueError(
+            _REALIZED_FILTER_ERROR_TEMPLATE.format("realized_only", "waiting_only")
+        )
+    filters = {
+        "user": user,
+        "external_user_key": external_user_key,
+        "program_uuid__in": program_uuids,
+        "curriculum_uuid__in": curriculum_uuids,
+        "status__in": program_enrollment_statuses,
+    }
+    if realized_only:
+        filters["user__isnull"] = False
+    if waiting_only:
+        filters["user__isnull"] = True
+    return ProgramEnrollment.objects.filter(**_remove_none_values(filters))
+
+
+def get_program_course_enrollment(
+        program_uuid,
+        course_key,
+        user=None,
+        external_user_key=None,
+        curriculum_uuid=None,
+        realized_only=False,
+        waiting_only=False,
+):
+    """
+    TODO
+    """
+    if not (user or external_user_key):
+        raise ValueError(_STUDENT_ARG_ERROR_MESSAGE)
+    if realized_only and waiting_only:
+        raise ValueError(
+            _REALIZED_FILTER_ERROR_TEMPLATE.format("realized_only", "waiting_only")
+        )
+    filters = {
+        "program_enrollment__user": user,
+        "program_enrollment__external_user_key": external_user_key,
+        "program_enrollment__curriculum_uuid": curriculum_uuid,
+    }
+    if realized_only:
+        filters["program_enrollment__user__isnull"] = False
+    if waiting_only:
+        filters["program_enrollment__user__isnull"] = True
+    return ProgramCourseEnrollment.objects.get(
+        program_enrollment__program_uuid=program_uuid,
+        course_key=course_key,
+        **_remove_none_values(filters)
+    )
+
+
+def fetch_program_course_enrollments(
+        program_uuid,
+        course_key,
+        curriculum_uuids=None,
+        users=None,
+        external_user_keys=None,
+        program_enrollment_statuses=None,
+        active_only=False,
+        inactive_only=False,
+        realized_only=False,
+        waiting_only=False,
+):
+    """
+    TODO
+    """
+    if active_only and inactive_only:
+        raise ValueError(
+            _REALIZED_FILTER_ERROR_TEMPLATE.format("active_only", "inactive_only")
+        )
+    if realized_only and waiting_only:
+        raise ValueError(
+            _REALIZED_FILTER_ERROR_TEMPLATE.format("realized_only", "waiting_only")
+        )
+    filters = {
+        "program_enrollment__curriculum_uuid__in": curriculum_uuids,
+        "program_enrollment__user__in": users,
+        "program_enrollment__external_user_key__in": external_user_keys,
+        "program_enrollment__status__in": program_enrollment_statuses,
+    }
+    if active_only:
+        filters["status"] = "active"
+    if inactive_only:
+        filters["status"] = "inactive"
+    if realized_only:
+        filters["program_enrollment__user__isnull"] = False
+    if waiting_only:
+        filters["program_enrollment__user__isnull"] = True
+    return ProgramCourseEnrollment.objects.filter(
+        program_enrollment__program_uuid=program_uuid,
+        course_key=course_key,
+        **_remove_none_values(filters)
+    )
+
+
+def fetch_program_course_enrollments_by_student(
+        user=None,
+        external_user_key=None,
+        program_uuids=None,
+        curriculum_uuids=None,
+        course_keys=None,
+        program_enrollment_statuses=None,
+        active_only=False,
+        inactive_only=False,
+):
+    """
+    TODO
+    """
+    if not (user or external_user_key):
+        raise ValueError(_STUDENT_ARG_ERROR_MESSAGE)
+    if active_only and inactive_only:
+        raise ValueError(
+            _REALIZED_FILTER_ERROR_TEMPLATE.format("active_only", "inactive_only")
+        )
+    filters = {
+        "program_enrollment__user": user,
+        "program_enrollment__external_user_key": external_user_key,
+        "program_enrollment__program_uuid__in": program_uuids,
+        "program_enrollment__curriculum_uuid__in": curriculum_uuids,
+        "course_key__in": course_keys,
+        "program_enrollment__status__in": program_enrollment_statuses,
+    }
+    if active_only:
+        filters["status"] = "active"
+    if inactive_only:
+        filters["status"] = "inactive"
+    return ProgramCourseEnrollment.objects.filter(**_remove_none_values(filters))
+
+
+def _remove_none_values(dictionary):
+    """
+    TODO
+    """
+    return {
+        key: value for key, value in dictionary.items() if value is not None
+    }

--- a/lms/djangoapps/program_enrollments/api/tests/test_reading.py
+++ b/lms/djangoapps/program_enrollments/api/tests/test_reading.py
@@ -1,0 +1,80 @@
+"""
+Tests for account linking Python API.
+"""
+from __future__ import absolute_import, unicode_literals
+
+from uuid import UUID
+
+from django.test import TestCase
+
+from lms.djangoapps.program_enrollments.constants import ProgramEnrollmentStatuses as PEStatuses
+from lms.djangoapps.program_enrollments.tests.factories import ProgramEnrollmentFactory
+
+from ..reading import fetch_program_enrollments
+
+
+class TestProgramEnrollmentReading(TestCase):
+    """
+    Tests for program enrollment reading functions.
+
+    TODO: This currently only tests fetch_program_enrollments by
+    external_user_key.
+    """
+    program_uuid_1 = UUID('7aeadb7d-5f48-493d-9410-84e1d36c657f')
+    program_uuid_2 = UUID('b08071d8-f803-43f6-bbf3-5ae15d393649')
+    curriculum_uuid_a = UUID('e331472e-bd26-43d0-94b8-b0063858210b')
+    curriculum_uuid_b = UUID('db717f6c-145f-43db-ad05-f9ad65eec285')
+
+    def test_fetch_by_student_key(self):
+        user_keys = set()
+        test_data = [
+            (self.program_uuid_1, self.curriculum_uuid_a, PEStatuses.ENROLLED),
+            (self.program_uuid_1, self.curriculum_uuid_b, PEStatuses.PENDING),
+            (self.program_uuid_1, self.curriculum_uuid_a, PEStatuses.ENROLLED),
+            (self.program_uuid_1, self.curriculum_uuid_b, PEStatuses.PENDING),
+            (self.program_uuid_2, self.curriculum_uuid_a, PEStatuses.ENROLLED),
+        ]
+        for i, (program_uuid, curriculum_uuid, status) in enumerate(test_data):
+            user_key = 'student-{}'.format(i)
+            ProgramEnrollmentFactory(
+                user=None,
+                external_user_key=user_key,
+                program_uuid=program_uuid,
+                curriculum_uuid=curriculum_uuid,
+                status=status,
+            )
+            user_keys.add(user_key)
+        actual_enrollments = fetch_program_enrollments(
+            program_uuid=self.program_uuid_1,
+            external_user_keys=user_keys,
+        )
+        expected_enrollments = {
+            'student-0': {
+                'curriculum_uuid': self.curriculum_uuid_a,
+                'status': 'enrolled',
+                'program_uuid': self.program_uuid_1,
+            },
+            'student-1': {
+                'curriculum_uuid': self.curriculum_uuid_b,
+                'status': 'pending',
+                'program_uuid': self.program_uuid_1,
+            },
+            'student-2': {
+                'curriculum_uuid': self.curriculum_uuid_a,
+                'status': 'enrolled',
+                'program_uuid': self.program_uuid_1,
+            },
+            'student-3': {
+                'curriculum_uuid': self.curriculum_uuid_b,
+                'status': 'pending',
+                'program_uuid': self.program_uuid_1,
+            },
+        }
+        assert expected_enrollments == {
+            enrollment.external_user_key: {
+                'curriculum_uuid': enrollment.curriculum_uuid,
+                'status': enrollment.status,
+                'program_uuid': enrollment.program_uuid,
+            }
+            for enrollment in actual_enrollments
+        }

--- a/lms/djangoapps/program_enrollments/constants.py
+++ b/lms/djangoapps/program_enrollments/constants.py
@@ -2,6 +2,7 @@
 Constants used throughout the program_enrollments app and exposed to other
 in-process apps through api.py.
 """
+from __future__ import absolute_import, unicode_literals
 
 
 class ProgramEnrollmentStatuses(object):

--- a/lms/djangoapps/program_enrollments/management/commands/expire_waiting_enrollments.py
+++ b/lms/djangoapps/program_enrollments/management/commands/expire_waiting_enrollments.py
@@ -1,5 +1,5 @@
 """ Management command to cleanup old waiting enrollments """
-from __future__ import absolute_import
+from __future__ import absolute_import, unicode_literals
 
 import logging
 
@@ -32,5 +32,5 @@ class Command(BaseCommand):
 
     def handle(self, *args, **options):
         expiration_days = options.get('expiration_days')
-        logger.info(u'Deleting waiting enrollments unmodified for %s days', expiration_days)
+        logger.info('Deleting waiting enrollments unmodified for %s days', expiration_days)
         tasks.expire_waiting_enrollments(expiration_days)

--- a/lms/djangoapps/program_enrollments/management/commands/reset_enrollment_data.py
+++ b/lms/djangoapps/program_enrollments/management/commands/reset_enrollment_data.py
@@ -4,7 +4,7 @@ a side effect of enrolling students.
 
 Intented for use in integration sandbox environments
 """
-from __future__ import absolute_import
+from __future__ import absolute_import, unicode_literals
 
 import logging
 from textwrap import dedent
@@ -52,7 +52,7 @@ class Command(BaseCommand):
         ).delete()
 
         log.info(
-            u'The following records will be deleted:\n%s\n%s\n',
+            'The following records will be deleted:\n%s\n%s\n',
             deleted_course_enrollment_models,
             deleted_program_enrollment_models,
         )
@@ -62,4 +62,4 @@ class Command(BaseCommand):
             if confirmation != 'confirm':
                 raise CommandError('User confirmation required.  No records have been modified')
 
-        log.info(u'Deleting %s records...', q1_count + q2_count)
+        log.info('Deleting %s records...', q1_count + q2_count)

--- a/lms/djangoapps/program_enrollments/management/commands/tests/test_link_program_enrollments.py
+++ b/lms/djangoapps/program_enrollments/management/commands/tests/test_link_program_enrollments.py
@@ -3,27 +3,53 @@ Tests for the link_program_enrollments management command.
 """
 from __future__ import absolute_import
 
+import mock
 from django.core.management import call_command
 from django.core.management.base import CommandError
 from django.test import TestCase
 
-from lms.djangoapps.program_enrollments.tests.test_link_program_enrollments import TestLinkProgramEnrollmentsMixin
-from lms.djangoapps.program_enrollments.management.commands.link_program_enrollments import (
-    Command,
-    INCORRECT_PARAMETER_TPL,
-    DUPLICATE_KEY_TPL,
-)
+from ..link_program_enrollments import DUPLICATE_KEY_TEMPLATE, INCORRECT_PARAMETER_TEMPLATE, Command
 
-COMMAND_PATH = 'lms.djangoapps.program_enrollments.management.commands.link_program_enrollments'
+_COMMAND_PATH = 'lms.djangoapps.program_enrollments.management.commands.link_program_enrollments'
 
 
-class TestLinkProgramEnrollmentManagementCommand(TestLinkProgramEnrollmentsMixin, TestCase):
-    """ Tests for exception behavior in the link_program_enrollments command """
+class TestLinkProgramEnrollmentManagementCommand(TestCase):
+    """
+    Test that the command calls link_program_enrollments_to_lms_users
+    correctly and handles exceptional input correctly.
+    """
 
-    def test_incorrectly_formatted_input(self):
-        with self.assertRaisesRegex(CommandError, INCORRECT_PARAMETER_TPL.format('whoops')):
-            call_command(Command(), self.program, 'learner-01:user-01', 'whoops', 'learner-03:user-03')
+    program_uuid = 'a32c5da8-fb89-4f1e-97a7-b13de9e6dfa2'
 
-    def test_repeated_user_key(self):
-        with self.assertRaisesRegex(CommandError, DUPLICATE_KEY_TPL.format('learner-01')):
-            call_command(Command(), self.program, 'learner-01:user-01', 'learner-01:user-02')
+    _LINKING_FUNCTION_MOCK_PATH = _COMMAND_PATH + ".link_program_enrollments_to_lms_users"
+
+    @mock.patch(_LINKING_FUNCTION_MOCK_PATH, autospec=True)
+    def test_good_input_calls_linking(self, mock_link):
+        call_command(
+            Command(), self.program_uuid, 'learner-01:user-01', 'learner-02:user-02'
+        )
+        mock_link.assert_called_once_with(
+            self.program_uuid,
+            {
+                'learner-01': 'user-01',
+                'learner-02': 'user-02',
+            },
+        )
+
+    def test_incorrectly_formatted_input_exception(self):
+        with self.assertRaisesRegex(
+                CommandError,
+                INCORRECT_PARAMETER_TEMPLATE.format('whoops')
+        ):
+            call_command(
+                Command(), self.program_uuid, 'learner-01:user-01', 'whoops', 'learner-03:user-03'
+            )
+
+    def test_repeated_user_key_exception(self):
+        with self.assertRaisesRegex(
+                CommandError,
+                DUPLICATE_KEY_TEMPLATE.format('learner-01'),
+        ):
+            call_command(
+                Command(), self.program_uuid, 'learner-01:user-01', 'learner-01:user-02'
+            )

--- a/lms/djangoapps/program_enrollments/models.py
+++ b/lms/djangoapps/program_enrollments/models.py
@@ -64,18 +64,6 @@ class ProgramEnrollment(TimeStampedModel):  # pylint: disable=model-missing-unic
             raise ValidationError(_('One of user or external_user_key must not be null.'))
 
     @classmethod
-    def bulk_read_by_student_key(cls, program_uuid, student_keys):
-        """
-        args:
-            program_uuid - The UUID of the program to read enrollment data of.
-            student_keys - list of student keys
-        """
-        return cls.objects.filter(
-            program_uuid=program_uuid,
-            external_user_key__in=student_keys,
-        )
-
-    @classmethod
     def retire_user(cls, user_id):
         """
         With the parameter user_id, retire the external_user_key field
@@ -204,7 +192,7 @@ class ProgramCourseEnrollment(TimeStampedModel):  # pylint: disable=model-missin
             CourseOverview.get_from_id(self.course_key)
         except CourseOverview.DoesNotExist:
             logger.warning(
-                u"User %s failed to enroll in non-existent course %s", user.id,
+                "User %s failed to enroll in non-existent course %s", user.id,
                 text_type(self.course_key),
             )
             raise NonExistentCourseError

--- a/lms/djangoapps/program_enrollments/rest_api/urls.py
+++ b/lms/djangoapps/program_enrollments/rest_api/urls.py
@@ -2,7 +2,7 @@
 Program Enrollment API URLs.
 """
 
-from __future__ import absolute_import
+from __future__ import absolute_import, unicode_literals
 
 from django.conf.urls import include, url
 

--- a/lms/djangoapps/program_enrollments/rest_api/urls.py
+++ b/lms/djangoapps/program_enrollments/rest_api/urls.py
@@ -2,7 +2,7 @@
 Program Enrollment API URLs.
 """
 
-from __future__ import absolute_import, unicode_literals
+from __future__ import absolute_import
 
 from django.conf.urls import include, url
 

--- a/lms/djangoapps/program_enrollments/rest_api/v1/constants.py
+++ b/lms/djangoapps/program_enrollments/rest_api/v1/constants.py
@@ -1,6 +1,7 @@
 """
 Constants used throughout the program_enrollments V1 API.
 """
+from __future__ import absolute_import, unicode_literals
 
 from lms.djangoapps.program_enrollments.constants import ProgramCourseEnrollmentStatuses, ProgramEnrollmentStatuses
 

--- a/lms/djangoapps/program_enrollments/rest_api/v1/serializers.py
+++ b/lms/djangoapps/program_enrollments/rest_api/v1/serializers.py
@@ -1,7 +1,7 @@
 """
 API Serializers
 """
-from __future__ import absolute_import
+from __future__ import absolute_import, unicode_literals
 
 from rest_framework import serializers
 from six import text_type
@@ -216,4 +216,4 @@ class ProgramCourseGradeError(BaseProgramCourseGrade):
         super(ProgramCourseGradeError, self).__init__(
             program_course_enrollment
         )
-        self.error = text_type(exception) if exception else u"Unknown error"
+        self.error = text_type(exception) if exception else "Unknown error"

--- a/lms/djangoapps/program_enrollments/rest_api/v1/tests/test_views.py
+++ b/lms/djangoapps/program_enrollments/rest_api/v1/tests/test_views.py
@@ -14,10 +14,10 @@ from django.contrib.auth.models import User
 from django.core.cache import cache
 from django.test import override_settings
 from django.urls import reverse
+from django.utils import timezone
 from freezegun import freeze_time
 from opaque_keys.edx.keys import CourseKey
 from organizations.tests.factories import OrganizationFactory as LMSOrganizationFactory
-from pytz import UTC
 from rest_framework import status
 from rest_framework.test import APITestCase
 from six import text_type
@@ -1367,7 +1367,7 @@ class UserProgramReadOnlyAccessGetTests(EnrollmentsDataMixin, APITestCase):
         ]
 
         cls.course_staff = InstructorFactory.create(password=cls.password, course_key=cls.course_id)
-        cls.date = datetime(2013, 1, 22, tzinfo=UTC)
+        cls.date = timezone.make_aware(datetime(2013, 1, 22))
         CourseEnrollmentFactory(
             course_id=cls.course_id,
             user=cls.course_staff,
@@ -1493,8 +1493,8 @@ class ProgramCourseEnrollmentOverviewGetTests(
         # only freeze time when defining these values and not on the whole test case
         # as test_multiple_enrollments_all_enrolled relies on actual differences in modified datetimes
         with freeze_time('2019-01-01'):
-            cls.yesterday = datetime.utcnow() - timedelta(1)
-            cls.tomorrow = datetime.utcnow() + timedelta(1)
+            cls.yesterday = timezone.now() - timedelta(1)
+            cls.tomorrow = timezone.now() + timedelta(1)
 
         cls.relative_certificate_download_url = '/download-the-certificates'
         cls.absolute_certificate_download_url = 'http://www.certificates.com/'
@@ -1825,7 +1825,7 @@ class ProgramCourseEnrollmentOverviewGetTests(
 
         # course run has not ended and user has earned a passing certificate more than 30 days ago
         certificate = self.create_generated_certificate()
-        certificate.created_date = datetime.utcnow() - timedelta(30)
+        certificate.created_date = timezone.now() - timedelta(30)
         certificate.save()
         mock_has_ended.return_value = False
 
@@ -1859,7 +1859,7 @@ class ProgramCourseEnrollmentOverviewGetTests(
 
         # course run has not ended and user has earned a passing certificate fewer than 30 days ago
         certificate = self.create_generated_certificate()
-        certificate.created_date = datetime.utcnow() - timedelta(5)
+        certificate.created_date = timezone.now() - timedelta(5)
         certificate.save()
 
         response = self.client.get(self.get_url(self.program_uuid))

--- a/lms/djangoapps/program_enrollments/rest_api/v1/urls.py
+++ b/lms/djangoapps/program_enrollments/rest_api/v1/urls.py
@@ -1,5 +1,5 @@
 """ Program Enrollments API v1 URLs. """
-from __future__ import absolute_import
+from __future__ import absolute_import, unicode_literals
 
 from django.conf.urls import url
 

--- a/lms/djangoapps/program_enrollments/rest_api/v1/urls.py
+++ b/lms/djangoapps/program_enrollments/rest_api/v1/urls.py
@@ -1,5 +1,5 @@
 """ Program Enrollments API v1 URLs. """
-from __future__ import absolute_import, unicode_literals
+from __future__ import absolute_import
 
 from django.conf.urls import url
 

--- a/lms/djangoapps/program_enrollments/signals.py
+++ b/lms/djangoapps/program_enrollments/signals.py
@@ -1,7 +1,7 @@
 """
 Signal handlers for program enrollments
 """
-from __future__ import absolute_import
+from __future__ import absolute_import, unicode_literals
 
 import logging
 
@@ -9,11 +9,13 @@ from django.db.models.signals import post_save
 from django.dispatch import receiver
 from social_django.models import UserSocialAuth
 
-from lms.djangoapps.program_enrollments.models import ProgramEnrollment
 from openedx.core.djangoapps.catalog.utils import get_programs
 from openedx.core.djangoapps.user_api.accounts.signals import USER_RETIRE_LMS_MISC
 from student.models import CourseEnrollmentException
 from third_party_auth.models import SAMLProviderConfig
+
+from .api import fetch_program_enrollments_by_student
+from .models import ProgramEnrollment
 
 logger = logging.getLogger(__name__)
 
@@ -39,7 +41,7 @@ def listen_for_social_auth_creation(sender, instance, created, **kwargs):  # pyl
         matriculate_learner(instance.user, instance.uid)
     except Exception as e:
         logger.warning(
-            u'Unable to link waiting enrollments for user %s, social auth creation failed: %s',
+            'Unable to link waiting enrollments for user %s, social auth creation failed: %s',
             instance.user.id,
             e,
         )
@@ -61,24 +63,24 @@ def matriculate_learner(user, uid):
         if not authorizing_org:
             return
     except (AttributeError, ValueError):
-        logger.info(u'Ignoring non-saml social auth entry for user=%s', user.id)
+        logger.info('Ignoring non-saml social auth entry for user=%s', user.id)
         return
     except SAMLProviderConfig.DoesNotExist:
         logger.warning(
-            u'Got incoming social auth for provider=%s but no such provider exists', provider_slug
+            'Got incoming social auth for provider=%s but no such provider exists', provider_slug
         )
         return
     except SAMLProviderConfig.MultipleObjectsReturned:
         logger.warning(
-            u'Unable to activate waiting enrollments for user=%s.'
-            u'  Multiple active SAML configurations found for slug=%s. Expected one.',
+            'Unable to activate waiting enrollments for user=%s.'
+            '  Multiple active SAML configurations found for slug=%s. Expected one.',
             user.id,
             provider_slug)
         return
 
-    incomplete_enrollments = ProgramEnrollment.objects.filter(
+    incomplete_enrollments = fetch_program_enrollments_by_student(
         external_user_key=external_user_key,
-        user=None,
+        waiting_only=True,
     ).prefetch_related('program_course_enrollments')
 
     for enrollment in incomplete_enrollments:
@@ -88,8 +90,8 @@ def matriculate_learner(user, uid):
                 continue
         except (KeyError, TypeError):
             logger.warning(
-                u'Failed to complete waiting enrollments for organization=%s.'
-                u' No catalog programs with matching authoring_organization exist.',
+                'Failed to complete waiting enrollments for organization=%s.'
+                ' No catalog programs with matching authoring_organization exist.',
                 authorizing_org.short_name
             )
             continue
@@ -101,7 +103,7 @@ def matriculate_learner(user, uid):
                 program_course_enrollment.enroll(user)
             except CourseEnrollmentException as e:
                 logger.warning(
-                    u'Failed to enroll user=%s with waiting program_course_enrollment=%s: %s',
+                    'Failed to enroll user=%s with waiting program_course_enrollment=%s: %s',
                     user.id,
                     program_course_enrollment.id,
                     e,

--- a/lms/djangoapps/program_enrollments/tasks.py
+++ b/lms/djangoapps/program_enrollments/tasks.py
@@ -1,5 +1,5 @@
 """ Tasks for program enrollments """
-from __future__ import absolute_import
+from __future__ import absolute_import, unicode_literals
 
 import logging
 from datetime import timedelta
@@ -31,21 +31,21 @@ def expire_waiting_enrollments(expiration_days):
     for program_enrollment in program_enrollments:
         program_enrollment_ids.append(program_enrollment.id)
         log.info(
-            u'Found expired program_enrollment (id=%s) for program_uuid=%s',
+            'Found expired program_enrollment (id=%s) for program_uuid=%s',
             program_enrollment.id,
             program_enrollment.program_uuid,
         )
         for course_enrollment in program_enrollment.program_course_enrollments.all():
             program_course_enrollment_ids.append(course_enrollment.id)
             log.info(
-                u'Found expired program_course_enrollment (id=%s) for program_uuid=%s, course_key=%s',
+                'Found expired program_course_enrollment (id=%s) for program_uuid=%s, course_key=%s',
                 course_enrollment.id,
                 program_enrollment.program_uuid,
                 course_enrollment.course_key,
             )
 
     deleted_enrollments = program_enrollments.delete()
-    log.info(u'Removed %s expired records: %s', deleted_enrollments[0], deleted_enrollments[1])
+    log.info('Removed %s expired records: %s', deleted_enrollments[0], deleted_enrollments[1])
 
     deleted_hist_program_enroll = ProgramEnrollment.historical_records.filter(  # pylint: disable=no-member
         id__in=program_enrollment_ids
@@ -54,10 +54,10 @@ def expire_waiting_enrollments(expiration_days):
         id__in=program_course_enrollment_ids
     ).delete()
     log.info(
-        u'Removed %s historical program_enrollment records with id in %s',
+        'Removed %s historical program_enrollment records with id in %s',
         deleted_hist_program_enroll[0], program_enrollment_ids
     )
     log.info(
-        u'Removed %s historical program_course_enrollment records with id in %s',
+        'Removed %s historical program_course_enrollment records with id in %s',
         deleted_hist_course_enroll[0], program_course_enrollment_ids
     )

--- a/lms/djangoapps/program_enrollments/tests/test_models.py
+++ b/lms/djangoapps/program_enrollments/tests/test_models.py
@@ -11,7 +11,6 @@ from django.db.utils import IntegrityError
 from django.test import TestCase
 from edx_django_utils.cache import RequestCache
 from opaque_keys.edx.keys import CourseKey
-from six.moves import range
 from testfixtures import LogCapture
 
 from course_modes.models import CourseMode
@@ -68,47 +67,6 @@ class ProgramEnrollmentModelTests(TestCase):
                 curriculum_uuid=self.curriculum_uuid,
                 status='suspended',
             )
-
-    def test_bulk_read_by_student_key(self):
-        curriculum_a = uuid4()
-        curriculum_b = uuid4()
-        enrollments = []
-        student_data = {}
-
-        for i in range(5):
-            # This will give us 4 program enrollments for self.program_uuid
-            # and 1 enrollment for self.other_program_uuid
-            user_curriculum = curriculum_b if i % 2 else curriculum_a
-            user_status = 'pending' if i % 2 else 'enrolled'
-            user_program = self.other_program_uuid if i == 4 else self.program_uuid
-            user_key = 'student-{}'.format(i)
-            enrollments.append(
-                ProgramEnrollment.objects.create(
-                    user=None,
-                    external_user_key=user_key,
-                    program_uuid=user_program,
-                    curriculum_uuid=user_curriculum,
-                    status=user_status,
-                )
-            )
-            student_data[user_key] = {'curriculum_uuid': user_curriculum}
-
-        enrollment_records = ProgramEnrollment.bulk_read_by_student_key(self.program_uuid, student_data)
-
-        expected = {
-            'student-0': {'curriculum_uuid': curriculum_a, 'status': 'enrolled', 'program_uuid': self.program_uuid},
-            'student-1': {'curriculum_uuid': curriculum_b, 'status': 'pending', 'program_uuid': self.program_uuid},
-            'student-2': {'curriculum_uuid': curriculum_a, 'status': 'enrolled', 'program_uuid': self.program_uuid},
-            'student-3': {'curriculum_uuid': curriculum_b, 'status': 'pending', 'program_uuid': self.program_uuid},
-        }
-        assert expected == {
-            enrollment.external_user_key: {
-                'curriculum_uuid': enrollment.curriculum_uuid,
-                'status': enrollment.status,
-                'program_uuid': enrollment.program_uuid,
-            }
-            for enrollment in enrollment_records
-        }
 
     def test_user_retirement(self):
         """

--- a/lms/djangoapps/program_enrollments/tests/test_signals.py
+++ b/lms/djangoapps/program_enrollments/tests/test_signals.py
@@ -2,7 +2,7 @@
 Test signal handlers for program_enrollments
 """
 
-from __future__ import absolute_import
+from __future__ import absolute_import, unicode_literals
 
 import mock
 import pytest
@@ -312,7 +312,7 @@ class SocialAuthEnrollmentCompletionSignalTest(CacheIsolationTestCase):
                 (
                     logger.name,
                     'WARNING',
-                    u'Got incoming social auth for provider={} but no such provider exists'.format('abc')
+                    'Got incoming social auth for provider={} but no such provider exists'.format('abc')
                 )
             )
 
@@ -330,8 +330,8 @@ class SocialAuthEnrollmentCompletionSignalTest(CacheIsolationTestCase):
                 uid='{0}:{1}'.format(self.provider_slug, self.external_id)
             )
             error_template = (
-                u'Failed to complete waiting enrollments for organization={}.'
-                u' No catalog programs with matching authoring_organization exist.'
+                'Failed to complete waiting enrollments for organization={}.'
+                ' No catalog programs with matching authoring_organization exist.'
             )
             log.check_present(
                 (
@@ -353,7 +353,7 @@ class SocialAuthEnrollmentCompletionSignalTest(CacheIsolationTestCase):
                         user=self.user,
                         uid='{0}:{1}'.format(self.provider_slug, self.external_id)
                     )
-                error_template = u'Failed to enroll user={} with waiting program_course_enrollment={}: {}'
+                error_template = 'Failed to enroll user={} with waiting program_course_enrollment={}: {}'
                 log.check_present(
                     (
                         logger.name,
@@ -379,7 +379,7 @@ class SocialAuthEnrollmentCompletionSignalTest(CacheIsolationTestCase):
                         user=self.user,
                         uid='{0}:{1}'.format(self.provider_slug, self.external_id),
                     )
-                error_template = u'Unable to link waiting enrollments for user {}, social auth creation failed: {}'
+                error_template = 'Unable to link waiting enrollments for user {}, social auth creation failed: {}'
                 log.check_present(
                     (
                         logger.name,

--- a/lms/djangoapps/program_enrollments/tests/test_tasks.py
+++ b/lms/djangoapps/program_enrollments/tests/test_tasks.py
@@ -1,7 +1,7 @@
 """
 Unit tests for program_course_enrollments tasks
 """
-from __future__ import absolute_import
+from __future__ import absolute_import, unicode_literals
 
 from datetime import timedelta
 
@@ -77,9 +77,9 @@ class ExpireWaitingEnrollmentsTest(TestCase):
         with LogCapture(log.name) as log_capture:
             expire_waiting_enrollments(60)
 
-            program_enrollment_message_tmpl = u'Found expired program_enrollment (id={}) for program_uuid={}'
+            program_enrollment_message_tmpl = 'Found expired program_enrollment (id={}) for program_uuid={}'
             course_enrollment_message_tmpl = (
-                u'Found expired program_course_enrollment (id={}) for program_uuid={}, course_key={}'
+                'Found expired program_course_enrollment (id={}) for program_uuid={}, course_key={}'
             )
 
             log_capture.check_present(

--- a/lms/djangoapps/program_enrollments/tests/test_utils.py
+++ b/lms/djangoapps/program_enrollments/tests/test_utils.py
@@ -1,7 +1,7 @@
 """
 Unit tests for program_enrollments utils.
 """
-from __future__ import absolute_import
+from __future__ import absolute_import, unicode_literals
 
 from uuid import uuid4
 

--- a/lms/djangoapps/program_enrollments/utils.py
+++ b/lms/djangoapps/program_enrollments/utils.py
@@ -1,7 +1,7 @@
 """
 utility functions for program enrollments
 """
-from __future__ import absolute_import
+from __future__ import absolute_import, unicode_literals
 
 import logging
 
@@ -106,11 +106,11 @@ def get_provider_slug(organization):
     try:
         provider_config = organization.samlproviderconfig_set.current_set().get(enabled=True)
     except SAMLProviderConfig.DoesNotExist:
-        log.error(u'No SAML provider found for organization id [%s]', organization.id)
+        log.error('No SAML provider found for organization id [%s]', organization.id)
         raise ProviderDoesNotExistException
     except SAMLProviderConfig.MultipleObjectsReturned:
         log.error(
-            u'Multiple active SAML configurations found for organization=%s. Expected one.',
+            'Multiple active SAML configurations found for organization=%s. Expected one.',
             organization.short_name,
         )
         raise ProviderConfigurationException

--- a/openedx/core/djangoapps/content/course_overviews/tests/factories.py
+++ b/openedx/core/djangoapps/content/course_overviews/tests/factories.py
@@ -1,8 +1,9 @@
 from __future__ import absolute_import
 
-from datetime import datetime, timedelta
+from datetime import timedelta
 import json
 
+from django.utils import timezone
 import factory
 from factory.django import DjangoModelFactory
 from opaque_keys.edx.locator import CourseLocator
@@ -39,8 +40,8 @@ class CourseOverviewFactory(DjangoModelFactory):
 
     @factory.lazy_attribute
     def start(self):
-        return datetime.now()
+        return timezone.now()
 
     @factory.lazy_attribute
     def end(self):
-        return datetime.now() + timedelta(30)
+        return timezone.now() + timedelta(30)

--- a/openedx/core/djangoapps/content/course_overviews/tests/factories.py
+++ b/openedx/core/djangoapps/content/course_overviews/tests/factories.py
@@ -1,9 +1,8 @@
 from __future__ import absolute_import
 
-from datetime import timedelta
+from datetime import datetime, timedelta
 import json
 
-from django.utils import timezone
 import factory
 from factory.django import DjangoModelFactory
 from opaque_keys.edx.locator import CourseLocator
@@ -40,8 +39,8 @@ class CourseOverviewFactory(DjangoModelFactory):
 
     @factory.lazy_attribute
     def start(self):
-        return timezone.now()
+        return datetime.now()
 
     @factory.lazy_attribute
     def end(self):
-        return timezone.now() + timedelta(30)
+        return datetime.now() + timedelta(30)


### PR DESCRIPTION
Closed in favor of https://github.com/edx/edx-platform/pull/21591
_____________________

@edx/masters-neem 
@edx/masters-devs 

This is the third in a series of commits to create a Python API for the LMS program_enrollments app. It does the following:
* Creates api/ folder.
* Moves link_program_enrollments.py to api/linking.py
* Creates api/reading.py for enrollment-fetching functions.
* Updates rest of app to use api/reading.py when it was going directly through the models before.
* Other misc. cleanup (isorting, unicode_literals, line breaks, etc).

Still to do:
* Create api/writing.py and update app to use it instead of going directly through models.
* Create api/reset.py and api/expire.py, which the management commands call out to.

Outside of the program_enrollments app, this PR also fixes some annoying test warnings coming out of CourseOverviewFactory, and adds a utility function to util.query.

Part II was merged here: https://github.com/edx/edx-platform/pull/21556

https://openedx.atlassian.net/browse/EDUCATOR-4321