### PR TITLE
Increase assignment upload limit from 4MB to 20MB

### DIFF
--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -736,7 +736,7 @@ AUTHENTICATION_BACKENDS = [
     'bridgekeeper.backends.RulePermissionBackend',
 ]
 
-STUDENT_FILEUPLOAD_MAX_SIZE = 4 * 1000 * 1000  # 4 MB
+STUDENT_FILEUPLOAD_MAX_SIZE = 20 * 1000 * 1000  # 20 MB
 MAX_FILEUPLOADS_PER_INPUT = 20
 
 # Set request limits for maximum size of a request body and maximum number of GET/POST parameters. (>=Django 1.10)


### PR DESCRIPTION
@edx/masters-all @edx/masters-devs @dabdul-hathi

Due to a request from a Master's partner who reports that the current 4MB limit is not enough for their degree programs.

Let me know your thoughts @edx-devops-review . If this solution is not acceptable, would it be better if we figured out a way to increase it for Master's-mode enrollments only? Or for specific course runs?

https://openedx.atlassian.net/browse/EDUCATOR-4635
See https://github.com/edx/configuration/pull/5399 for nginx change