### PR TITLE
[BB-1504] Fix the automatic enrollment issue for inactive user

### DIFF
--- a/lms/djangoapps/instructor/enrollment.py
+++ b/lms/djangoapps/instructor/enrollment.py
@@ -137,7 +137,7 @@ def enroll_email(course_id, student_email, auto_enroll=False, email_students=Fal
     """
     previous_state = EmailEnrollmentState(course_id, student_email)
     enrollment_obj = None
-    if previous_state.user:
+    if previous_state.user and User.objects.get(email=student_email).is_active:
         # if the student is currently unenrolled, don't enroll them in their
         # previous mode
 


### PR DESCRIPTION
When a user registers an account and then is enrolled in a course by the instructor before completing the email validation, the course shows up in the dashboard of the unverified, logged-in user. This contrasts with the behavior observed when the user is enrolled before the account is created - the user is unable to see the enrolled course before verifying the email address.

This PR adds a check for the email validation before enrolling the user.

**JIRA tickets**: [OSPR-3832](https://openedx.atlassian.net/browse/OSPR-3832)
**Dependencies**: None
**Sandbox URL**: https://pr21594.sandbox.opencraft.hosting/
**Merge deadline**: None

**Testing instructions**:
1. Register and create a new account in the LMS. Do not verify the email address.
1. Stay logged in as that user.
1. Enroll the user created in the previous step, in a course via the Instructor dashboard in a separate, isolated browser session.
1. Refresh the dashboard of the logged-in user with unverified email address. Without the fix, the enrolled course shows up in the user's dashboard . With the fix, the course shows up in the unverified user's dashboard only after the email verification is done.

While the unverified user can still navigate to the public courses and enroll, this issue breaks the expected behaviour with invitation-only (and optionally, private) courses.

**Reviewers**
- [ ] @Agrendalath 
- [ ] @bradenmacdonald 
