### PR TITLE
BOM-442 | Response decoding for RssProxyViewTests

### DIFF
--- a/lms/djangoapps/rss_proxy/tests/test_views.py
+++ b/lms/djangoapps/rss_proxy/tests/test_views.py
@@ -62,7 +62,7 @@ class RssProxyViewTests(TestCase):
         print(resp['Content-Type'])
         self.assertEqual(resp.status_code, 404)
         self.assertEqual(resp['Content-Type'], 'application/xml')
-        self.assertEqual(resp.content, '')
+        self.assertEqual(resp.content.decode('utf-8'), '')
 
     def test_proxy_with_non_whitelisted_url(self):
         """


### PR DESCRIPTION
Fixes for `AssertionError: b'' != ''`