### PR TITLE
Minor fixes for blockstore runtime

### DIFF
--- a/common/lib/xmodule/xmodule/video_module/video_module.py
+++ b/common/lib/xmodule/xmodule/video_module/video_module.py
@@ -23,6 +23,7 @@ from operator import itemgetter
 import six
 from django.conf import settings
 from lxml import etree
+from opaque_keys.edx.keys import CourseKey
 from opaque_keys.edx.locator import AssetLocator
 from web_fragments.fragment import Fragment
 from xblock.completable import XBlockCompletionMode
@@ -200,6 +201,8 @@ class VideoBlock(
         return waffle_flags()[DEPRECATE_YOUTUBE].is_enabled(self.location.course_key)
 
     def youtube_disabled_for_course(self):
+        if not isinstance(self.location.course_key, CourseKey):
+            return False  # Only courses have this flag
         if CourseYoutubeBlockedFlag.feature_enabled(self.location.course_key):
             return True
         else:

--- a/openedx/core/djangoapps/xblock/rest_api/views.py
+++ b/openedx/core/djangoapps/xblock/rest_api/views.py
@@ -27,6 +27,7 @@ User = get_user_model()
 
 
 @api_view(['GET'])
+@view_auth_classes(is_authenticated=False)
 @permission_classes((permissions.AllowAny, ))  # Permissions are handled at a lower level, by the learning context
 def block_metadata(request, usage_key_str):
     """
@@ -39,6 +40,7 @@ def block_metadata(request, usage_key_str):
 
 
 @api_view(['GET'])
+@view_auth_classes(is_authenticated=True)
 @permission_classes((permissions.AllowAny, ))  # Permissions are handled at a lower level, by the learning context
 def render_block_view(request, usage_key_str, view_name):
     """


### PR DESCRIPTION
* The code in the video XBlock's `youtube_disabled_for_course` method was giving an error when accessed in a Blockstore content library, since it expects `self.location.course_key` to be a `CourseKey`
* Two REST API methods were missing the decorator that lets them work with OAuth; they only supported session auth.