### PR TITLE
Upgrade, specifically edx-ora2 for increased upload limit

### DIFF
--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -736,7 +736,7 @@ AUTHENTICATION_BACKENDS = [
     'bridgekeeper.backends.RulePermissionBackend',
 ]
 
-STUDENT_FILEUPLOAD_MAX_SIZE = 20 * 1000 * 1000  # 20 MB
+STUDENT_FILEUPLOAD_MAX_SIZE = 4 * 1000 * 1000  # 4 MB
 MAX_FILEUPLOADS_PER_INPUT = 20
 
 # Set request limits for maximum size of a request body and maximum number of GET/POST parameters. (>=Django 1.10)

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -171,7 +171,7 @@ nodeenv==1.1.1
 numpy==1.16.5
 git+https://github.com/joestump/python-oauth2.git@b94f69b1ad195513547924e380d9265133e995fa#egg=oauth2
 oauthlib==2.1.0
-git+https://github.com/edx/edx-ora2.git@2.2.7#egg=ora2==2.2.7
+git+https://github.com/edx/edx-ora2.git@2.3.0#egg=ora2==2.3.0
 path.py==8.2.1
 pathtools==0.1.2
 paver==1.3.4

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -59,7 +59,7 @@ click-log==0.3.2
 click==7.0
 code-annotations==0.3.2
 colorama==0.4.1
-configparser==3.8.1
+configparser==4.0.1
 contextlib2==0.5.5
 cookies==2.2.1
 coreapi==2.3.3
@@ -221,7 +221,7 @@ nodeenv==1.1.1
 numpy==1.16.5
 git+https://github.com/joestump/python-oauth2.git@b94f69b1ad195513547924e380d9265133e995fa#egg=oauth2
 oauthlib==2.1.0
-git+https://github.com/edx/edx-ora2.git@2.2.7#egg=ora2==2.2.7
+git+https://github.com/edx/edx-ora2.git@2.3.0#egg=ora2==2.3.0
 packaging==19.1
 path.py==8.2.1
 pathlib2==2.3.4

--- a/requirements/edx/github.in
+++ b/requirements/edx/github.in
@@ -81,7 +81,7 @@ git+https://github.com/edx/bridgekeeper.git@4e34894e4ac5d0467ed1901811a81fd87ee0
 # Our libraries:
 -e git+https://github.com/edx/codejail.git@ed3d36c27913254a23273da95ad627a1bbbffa44#egg=codejail
 -e git+https://github.com/edx/acid-block.git@e46f9cda8a03e121a00c7e347084d142d22ebfb7#egg=acid-xblock
-git+https://github.com/edx/edx-ora2.git@2.2.7#egg=ora2==2.2.7
+git+https://github.com/edx/edx-ora2.git@2.3.0#egg=ora2==2.3.0
 git+https://github.com/edx/RecommenderXBlock.git@1.4.1#egg=recommender-xblock==1.4.1
 git+https://github.com/edx/crowdsourcehinter.git@a7ffc85b134b7d8909bf1fefd23dbdb8eb28e467#egg=crowdsourcehinter-xblock==0.2
 -e git+https://github.com/edx/RateXBlock.git@367e19c0f6eac8a5f002fd0f1559555f8e74bfff#egg=rate-xblock

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -57,7 +57,7 @@ click-log==0.3.2          # via edx-lint
 click==7.0
 code-annotations==0.3.2
 colorama==0.4.1           # via radon
-configparser==3.8.1       # via entrypoints, flake8, importlib-metadata, pylint
+configparser==4.0.1       # via entrypoints, flake8, importlib-metadata, pylint
 contextlib2==0.5.5
 cookies==2.2.1            # via moto
 coreapi==2.3.3
@@ -214,7 +214,7 @@ nodeenv==1.1.1
 numpy==1.16.5
 git+https://github.com/joestump/python-oauth2.git@b94f69b1ad195513547924e380d9265133e995fa#egg=oauth2
 oauthlib==2.1.0
-git+https://github.com/edx/edx-ora2.git@2.2.7#egg=ora2==2.2.7
+git+https://github.com/edx/edx-ora2.git@2.3.0#egg=ora2==2.3.0
 packaging==19.1           # via caniusepython3, tox
 path.py==8.2.1
 pathlib2==2.3.4           # via importlib-metadata, pytest, pytest-django


### PR DESCRIPTION
@edx/masters-devs @dabdul-hathi
Ticket: https://openedx.atlassian.net/browse/EDUCATOR-4635

https://github.com/edx/edx-ora2/pull/1260 increases the upload limit from 10MB to 20MB. This PR pulls in that new package version.

Also, this PR reverts "Increase assignment upload limit from 4MB to 20MB (#21589)", which was my previous attempt at this change.
