### PR TITLE
SE-1071 send user_logged_in signal from my_user_info

### DIFF
--- a/lms/djangoapps/mobile_api/users/tests.py
+++ b/lms/djangoapps/mobile_api/users/tests.py
@@ -77,6 +77,21 @@ class TestUserInfoApi(MobileAPITestCase, MobileAuthTestMixin):
         response = self.api_response(expected_response_code=302, api_version=api_version)
         self.assertIn(self.username, response['location'])
 
+    @ddt.data(API_V05, API_V1)
+    def test_last_loggedin_updated(self, api_version):
+        """Verify that a user's last logged in value updates after hitting the my_user_info endpoint"""
+        self.login()
+
+        self.user.refresh_from_db()
+        last_login_before = self.user.last_login
+
+        # just hit the api endpoint; we don't care about the response here (tested previously)
+        self.api_response(expected_response_code=302, api_version=api_version)
+
+        self.user.refresh_from_db()
+        last_login_after = self.user.last_login
+        assert last_login_after > last_login_before
+
 
 @ddt.ddt
 @override_settings(MKTG_URLS={'ROOT': 'dummy-root'})

--- a/lms/djangoapps/mobile_api/users/views.py
+++ b/lms/djangoapps/mobile_api/users/views.py
@@ -5,6 +5,7 @@ Views for user API
 from __future__ import absolute_import
 
 import six
+from django.contrib.auth.signals import user_logged_in
 from django.shortcuts import redirect
 from django.utils import dateparse
 from opaque_keys import InvalidKeyError
@@ -14,6 +15,7 @@ from rest_framework.decorators import api_view
 from rest_framework.response import Response
 from xblock.fields import Scope
 from xblock.runtime import KeyValueStore
+from django.contrib.auth.models import User
 
 from lms.djangoapps.courseware.access import is_mobile_available_for_user
 from lms.djangoapps.courseware.courses import get_current_child
@@ -336,4 +338,7 @@ def my_user_info(request, api_version):
     """
     Redirect to the currently-logged-in user's info page
     """
+    # update user's last logged in from here because
+    # updating it from the oauth2 related code is too complex
+    user_logged_in.send(sender=User, user=request.user, request=request)
     return redirect("user-detail", api_version=api_version, username=request.user.username)


### PR DESCRIPTION
A user's last logged in value isn't updated when the user logs in
through the oauth2 flow from the ios mobile app. Here we must send the
user_logged_in signal manually. It's implemented in the my_user_info
mobile rest api endpoint because adding it to where the oauth2 flow
happens is to complex (the platform doesn't know which user just logged in because it just delegates to the respective oauth2 libraries). It appears that the iOS app hits this endpoint once after a
successful login, so it should have the same effect.

CC @saeedbashir We would be interested to hear your opinion on this method or if you have suggestions for how better to implement this from the perspective of the iOS app login flow.

**JIRA tickets**:  [OSPR-3839](https://openedx.atlassian.net/browse/OSPR-3839)

**Dependencies**: None

**Sandbox URL**: 

-    LMS: https://se-1071.sandbox.opencraft.hosting/
-    Studio: https://studio.se-1071.sandbox.opencraft.hosting/


**Merge deadline**: None

**Testing instructions**:

1. login to the lms admin as a superuser and view the last logged in time for a normal user
2. log in to the ios mobile app as the above normal user
3. refresh the admin page and verify that the last logged in time has updated


**Author notes and concerns**:


**Reviewers**
- [x] @pomegranited 
- [ ] edX reviewer[s] TBD

**Settings**
```yaml
EDXAPP_FEATURES:
  ENABLE_THIRD_PARTY_AUTH: true
  ENABLE_MOBILE_REST_API: true
```