### PR TITLE
Upgrade requirements, specifically ora2==2.3.1

### DIFF
--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -171,7 +171,7 @@ nodeenv==1.1.1
 numpy==1.16.5
 git+https://github.com/joestump/python-oauth2.git@b94f69b1ad195513547924e380d9265133e995fa#egg=oauth2
 oauthlib==2.1.0
-git+https://github.com/edx/edx-ora2.git@2.3.0#egg=ora2==2.3.0
+git+https://github.com/edx/edx-ora2.git@2.3.1#egg=ora2==2.3.1
 path.py==8.2.1
 pathtools==0.1.2
 paver==1.3.4

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -221,7 +221,7 @@ nodeenv==1.1.1
 numpy==1.16.5
 git+https://github.com/joestump/python-oauth2.git@b94f69b1ad195513547924e380d9265133e995fa#egg=oauth2
 oauthlib==2.1.0
-git+https://github.com/edx/edx-ora2.git@2.3.0#egg=ora2==2.3.0
+git+https://github.com/edx/edx-ora2.git@2.3.1#egg=ora2==2.3.1
 packaging==19.1
 path.py==8.2.1
 pathlib2==2.3.4

--- a/requirements/edx/github.in
+++ b/requirements/edx/github.in
@@ -81,7 +81,7 @@ git+https://github.com/edx/bridgekeeper.git@4e34894e4ac5d0467ed1901811a81fd87ee0
 # Our libraries:
 -e git+https://github.com/edx/codejail.git@ed3d36c27913254a23273da95ad627a1bbbffa44#egg=codejail
 -e git+https://github.com/edx/acid-block.git@e46f9cda8a03e121a00c7e347084d142d22ebfb7#egg=acid-xblock
-git+https://github.com/edx/edx-ora2.git@2.3.0#egg=ora2==2.3.0
+git+https://github.com/edx/edx-ora2.git@2.3.1#egg=ora2==2.3.1
 git+https://github.com/edx/RecommenderXBlock.git@1.4.1#egg=recommender-xblock==1.4.1
 git+https://github.com/edx/crowdsourcehinter.git@a7ffc85b134b7d8909bf1fefd23dbdb8eb28e467#egg=crowdsourcehinter-xblock==0.2
 -e git+https://github.com/edx/RateXBlock.git@367e19c0f6eac8a5f002fd0f1559555f8e74bfff#egg=rate-xblock

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -214,7 +214,7 @@ nodeenv==1.1.1
 numpy==1.16.5
 git+https://github.com/joestump/python-oauth2.git@b94f69b1ad195513547924e380d9265133e995fa#egg=oauth2
 oauthlib==2.1.0
-git+https://github.com/edx/edx-ora2.git@2.3.0#egg=ora2==2.3.0
+git+https://github.com/edx/edx-ora2.git@2.3.1#egg=ora2==2.3.1
 packaging==19.1           # via caniusepython3, tox
 path.py==8.2.1
 pathlib2==2.3.4           # via importlib-metadata, pytest, pytest-django


### PR DESCRIPTION
@edx/masters-devs @dabdul-hathi
Ticket: https://openedx.atlassian.net/browse/EDUCATOR-4635

The 2.3.0 ORA-2 release did not regenerate .min.js files, so the changes did not appear on Stage or
Production: https://github.com/edx/edx-ora2/pull/1261


