### PR TITLE
Add db settings overrides

### DIFF
--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -719,6 +719,17 @@ DATABASES = {
         'PORT': '3306',
         'USER': 'edxapp001'
     },
+    'celery_worker': {
+        'ATOMIC_REQUESTS': True,
+        'CONN_MAX_AGE': 0,
+        'ENGINE': 'django.db.backends.mysql',
+        'HOST': 'localhost',
+        'NAME': 'edxapp',
+        'OPTIONS': {},
+        'PASSWORD': 'password',
+        'PORT': '3306',
+        'USER': 'edxapp001'
+    },
     'read_replica': {
         'CONN_MAX_AGE': 0,
         'ENGINE': 'django.db.backends.mysql',

--- a/cms/envs/production.py
+++ b/cms/envs/production.py
@@ -375,6 +375,18 @@ USER_TASKS_ARTIFACT_STORAGE = COURSE_IMPORT_EXPORT_STORAGE
 
 DATABASES = AUTH_TOKENS['DATABASES']
 
+# If DB_CONFIG_OVERRIDE_DEFAULT is set, use the named config instead of default
+# Useful for overriding the config for the celery workers
+DB_CONFIG_OVERRIDE_DEFAULT = os.environ.get('DB_CONFIG_OVERRIDE_DEFAULT', None)
+if DB_CONFIG_OVERRIDE_DEFAULT:
+    DATABASES['default'] = DATABASES[DB_CONFIG_OVERRIDE_DEFAULT]
+
+# If DB_CONFIG_OVERRIDE_STUDENT_MODULE_HISTORY is set, use the named config instead of student_module_history
+# Useful for overriding the config for the celery workers
+DB_CONFIG_OVERRIDE_STUDENT_MODULE_HISTORY = os.environ.get('DB_CONFIG_OVERRIDE_STUDENT_MODULE_HISTORY', None)
+if DB_CONFIG_OVERRIDE_STUDENT_MODULE_HISTORY:
+    DATABASES['student_module_history'] = DATABASES[DB_CONFIG_OVERRIDE_STUDENT_MODULE_HISTORY]
+
 # The normal database user does not have enough permissions to run migrations.
 # Migrations are run with separate credentials, given as DB_MIGRATION_*
 # environment variables

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -1043,6 +1043,17 @@ DATABASES = {
         'PORT': '3306',
         'USER': 'edxapp001'
     },
+    'celery_worker': {
+        'ATOMIC_REQUESTS': True,
+        'CONN_MAX_AGE': 0,
+        'ENGINE': 'django.db.backends.mysql',
+        'HOST': 'localhost',
+        'NAME': 'edxapp',
+        'OPTIONS': {},
+        'PASSWORD': 'password',
+        'PORT': '3306',
+        'USER': 'edxapp001'
+    },
     'read_replica': {
         'CONN_MAX_AGE': 0,
         'ENGINE': 'django.db.backends.mysql',

--- a/lms/envs/production.py
+++ b/lms/envs/production.py
@@ -545,6 +545,18 @@ FILE_UPLOAD_STORAGE_PREFIX = ENV_TOKENS.get('FILE_UPLOAD_STORAGE_PREFIX', FILE_U
 # function in util/query.py, which is useful for very large database reads
 DATABASES = AUTH_TOKENS['DATABASES']
 
+# If DB_CONFIG_OVERRIDE_DEFAULT is set, use the named config instead of default
+# Useful for overriding the config for the celery workers
+DB_CONFIG_OVERRIDE_DEFAULT = os.environ.get('DB_CONFIG_OVERRIDE_DEFAULT', None)
+if DB_CONFIG_OVERRIDE_DEFAULT and DATABASES.has_key(DB_CONFIG_OVERRIDE_DEFAULT):
+    DATABASES['default'] = DATABASES[DB_CONFIG_OVERRIDE_DEFAULT]
+
+# If DB_CONFIG_OVERRIDE_STUDENT_MODULE_HISTORY is set, use the named config instead of student_module_history
+# Useful for overriding the config for the celery workers
+DB_CONFIG_OVERRIDE_STUDENT_MODULE_HISTORY = os.environ.get('DB_CONFIG_OVERRIDE_STUDENT_MODULE_HISTORY', None)
+if DB_CONFIG_OVERRIDE_STUDENT_MODULE_HISTORY and DATABASES.has_key(DB_CONFIG_OVERRIDE_STUDENT_MODULE_HISTORY):
+    DATABASES['student_module_history'] = DATABASES[DB_CONFIG_OVERRIDE_STUDENT_MODULE_HISTORY]
+
 # The normal database user does not have enough permissions to run migrations.
 # Migrations are run with separate credentials, given as DB_MIGRATION_*
 # environment variables


### PR DESCRIPTION
Add ability to specify an alternate DB config to use so we can more
easily see traffic from workers in tools like RDS Performance Insights