### PR TITLE
SE-1496 conditionally re-enable user change password form in admin

### DIFF
--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -329,6 +329,19 @@ FEATURES = {
     'SHOW_FOOTER_LANGUAGE_SELECTOR': False,
     'ENABLE_ENROLLMENT_RESET': False,
     'DISABLE_MOBILE_COURSE_AVAILABLE': False,
+
+    # .. toggle_name: ENABLE_CHANGE_USER_PASSWORD_ADMIN
+    # .. toggle_implementation: DjangoSetting
+    # .. toggle_default: False
+    # .. toggle_description: Set to True to enable changing a user password through django admin. This is disabled by default because enabling allows a method to bypass password policy.
+    # .. toggle_category: admin
+    # .. toggle_use_cases: open_edx
+    # .. toggle_creation_date: 2020-02-21
+    # .. toggle_expiration_date: None
+    # .. toggle_tickets: 'https://github.com/edx/edx-platform/pull/21616'
+    # .. toggle_status: supported
+    # .. toggle_warnings: None
+    'ENABLE_CHANGE_USER_PASSWORD_ADMIN': False,
 }
 
 ENABLE_JASMINE = False

--- a/cms/urls.py
+++ b/cms/urls.py
@@ -215,8 +215,9 @@ if settings.FEATURES.get('ENABLE_SERVICE_STATUS'):
 
 # The password pages in the admin tool are disabled so that all password
 # changes go through our user portal and follow complexity requirements.
+if not settings.FEATURES.get('ENABLE_CHANGE_USER_PASSWORD_ADMIN'):
+    urlpatterns.append(url(r'^admin/auth/user/\d+/password/$', handler404))
 urlpatterns.append(url(r'^admin/password_change/$', handler404))
-urlpatterns.append(url(r'^admin/auth/user/\d+/password/$', handler404))
 urlpatterns.append(url(r'^admin/', admin.site.urls))
 
 # enable entrance exams

--- a/common/djangoapps/student/admin.py
+++ b/common/djangoapps/student/admin.py
@@ -5,6 +5,7 @@ from functools import wraps
 
 from config_models.admin import ConfigurationModelAdmin
 from django import forms
+from django.conf import settings
 from django.contrib import admin
 from django.contrib.admin.sites import NotRegistered
 from django.contrib.admin.utils import unquote
@@ -289,13 +290,17 @@ class UserChangeForm(BaseUserChangeForm):
     Override the default UserChangeForm such that the password field
     does not contain a link to a 'change password' form.
     """
-    password = ReadOnlyPasswordHashField(
-        label=_("Password"),
-        help_text=_(
-            "Raw passwords are not stored, so there is no way to see this "
-            "user's password."
-        ),
-    )
+    def __init__(self, *args, **kwargs):
+        super(UserChangeForm, self).__init__(*args, **kwargs)
+
+        if not settings.FEATURES.get('ENABLE_CHANGE_USER_PASSWORD_ADMIN'):
+            self.fields["password"] = ReadOnlyPasswordHashField(
+                label=_("Password"),
+                help_text=_(
+                    "Raw passwords are not stored, so there is no way to see this "
+                    "user's password."
+                ),
+            )
 
 
 class UserAdmin(BaseUserAdmin):

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -403,6 +403,19 @@ FEATURES = {
     # Enable feature to remove enrollments and users. Used to reset state of master's integration environments
     'ENABLE_ENROLLMENT_RESET': False,
     'DISABLE_MOBILE_COURSE_AVAILABLE': False,
+
+    # .. toggle_name: ENABLE_CHANGE_USER_PASSWORD_ADMIN
+    # .. toggle_implementation: DjangoSetting
+    # .. toggle_default: False
+    # .. toggle_description: Set to True to enable changing a user password through django admin. This is disabled by default because enabling allows a method to bypass password policy.
+    # .. toggle_category: admin
+    # .. toggle_use_cases: open_edx
+    # .. toggle_creation_date: 2020-02-21
+    # .. toggle_expiration_date: None
+    # .. toggle_tickets: 'https://github.com/edx/edx-platform/pull/21616'
+    # .. toggle_status: supported
+    # .. toggle_warnings: None
+    'ENABLE_CHANGE_USER_PASSWORD_ADMIN': False,
 }
 
 # Settings for the course reviews tool template and identification key, set either to None to disable course reviews

--- a/lms/urls.py
+++ b/lms/urls.py
@@ -773,11 +773,17 @@ if settings.FEATURES.get('ENABLE_STUDENT_HISTORY_VIEW'):
 
 if settings.DEBUG or settings.FEATURES.get('ENABLE_DJANGO_ADMIN_SITE'):
     # Jasmine and admin
+
+    # The password pages in the admin tool are disabled so that all password
+    # changes go through our user portal and follow complexity requirements.
+    # The form to change another user's password is conditionally enabled
+    # for backwards compatibility.
+    if not settings.FEATURES.get('ENABLE_CHANGE_USER_PASSWORD_ADMIN'):
+        urlpatterns += [
+            url(r'^admin/auth/user/\d+/password/$', handler404),
+        ]
     urlpatterns += [
-        # The password pages in the admin tool are disabled so that all password
-        # changes go through our user portal and follow complexity requirements.
         url(r'^admin/password_change/$', handler404),
-        url(r'^admin/auth/user/\d+/password/$', handler404),
         # We are enforcing users to login through third party auth in site's
         # login page so we are disabling the admin panel's login page.
         url(r'^admin/login/$', redirect_to_lms_login),


### PR DESCRIPTION
This PR enables setting/changing a user's password from the django admin, gated
behind a django setting FEATURES flag.

Using a django settings option because this affects entries to urls.py, which require a server restart to take effect. Using a waffle switch is misleading, because toggling it without restarting the server afterwards would leave the platform in an invalid state.

This behaviour was disabled across https://github.com/edx/edx-platform/pull/18970 and https://github.com/edx/edx-platform/pull/18972.

We want to re-enable it because our clients use this feature.

**JIRA tickets**: [OSPR-3840](https://openedx.atlassian.net/browse/OSPR-3840)

**Dependencies**: None

**Sandbox URL**: 


-    LMS: https://pr21616.sandbox.opencraft.hosting/
-    Studio: https://studio.pr21616.sandbox.opencraft.hosting/



**Merge deadline**: None

**Testing instructions**:

1. login to the admin on the **lms** as a superuser
2. navigate the admin change page for a user (eg `/admin/auth/user/1/change/`)
3. verify that there is no link to a password change form in the description
   for the password field. (You should not see " but you can change the
   password using this form.")
4. change the current url from .../change/ to .../password/ (eg.
   `/admin/auth/user/1/password/`)
5. verify that a 404 page is displayed
6. repeat steps 2 - 5 on the **cms**
7. add/change the FEATURES: ENABLE_CHANGE_USER_PASSWORD_ADMIN flag to true in the lms config.
9. restart the cms and lms apps (reboot the server or run
   `/edx/bin/supervisorctl restart lms: cms:` from a shell).
10. log in to the admin on the **lms** as a superuser
11. navigate the admin change page for a user (eg `/admin/auth/user/1/change/`)
12. verify that a link to a password change form ("but you can change the
   password using this form") is visible.
13. click the form link and verify that the page loads correctly and the user
    password can be changed
14. repeat the previous 4 steps from the **cms** admin.

**Author notes and concerns**:


**Reviewers**
- [x] @clemente 
- [x] edX reviewer[s] TBD

**Settings**
```yaml
EDXAPP_FEATURES:
  ENABLE_CHANGE_USER_PASSWORD_ADMIN: false
```