### PR TITLE
patch jquery's extend

### DIFF
--- a/cms/static/cms/js/require-config.js
+++ b/cms/static/cms/js/require-config.js
@@ -134,6 +134,7 @@
             'draggabilly': 'js/vendor/draggabilly',
             'hls': 'common/js/vendor/hls',
             'lang_edx': 'js/src/lang_edx',
+            'jquery_extend_patch': 'js/src/jquery_extend_patch',
 
             // externally hosted files
             mathjax: 'https://cdn.jsdelivr.net/npm/mathjax@2.7.5/MathJax.js?config=TeX-MML-AM_HTMLorMML&delayStartupUntil=configured',  // eslint-disable-line max-len
@@ -345,8 +346,13 @@
                     'rangeslider', 'share-annotator', 'richText-annotator', 'reply-annotator',
                     'tags-annotator', 'flagging-annotator', 'grouping-annotator', 'diacritic-annotator',
                     'openseadragon', 'jquery-Watch', 'catch', 'handlebars', 'URI']
-            }
+            },
             // end of annotation tool files
+
+            // patch for jquery's extend
+            'jquery_extend_patch': {
+                deps: ['jquery']
+            }
         }
     });
 }).call(this, require, define);

--- a/cms/static/js/factories/base.js
+++ b/cms/static/js/factories/base.js
@@ -1,7 +1,7 @@
 // We can't convert this to an es6 module until all factories that use it have been converted out
 // of RequireJS
 define(['js/base', 'cms/js/main', 'js/src/logger', 'datepair', 'accessibility',
-    'ieshim', 'tooltip_manager', 'lang_edx', 'js/models/course'],
+    'ieshim', 'tooltip_manager', 'lang_edx', 'js/models/course', 'jquery_extend_patch'],
     function() {
         'use strict';
     }

--- a/common/static/js/src/jquery_extend_patch.js
+++ b/common/static/js/src/jquery_extend_patch.js
@@ -1,0 +1,83 @@
+/*
+
+`extend` function of jquery (jQuery < 3.4.0) is known to have Prototype Pollution vulnerability.
+This IIFE is used to rebind `extend` function with its patched implementation.
+
+TODO: Remove this file and all its uses after upgrading to version >= 3.4.0
+
+*/
+
+(function(){
+    
+    jQuery.extend = jQuery.fn.extend = function() {
+        var options, name, src, copy, copyIsArray, clone,
+            target = arguments[ 0 ] || {},
+            i = 1,
+            length = arguments.length,
+            deep = false;
+    
+        // Handle a deep copy situation
+        if ( typeof target === "boolean" ) {
+            deep = target;
+    
+            // Skip the boolean and the target
+            target = arguments[ i ] || {};
+            i++;
+        }
+    
+        // Handle case when target is a string or something (possible in deep copy)
+        if ( typeof target !== "object" && !jQuery.isFunction( target ) ) {
+            target = {};
+        }
+    
+        // Extend jQuery itself if only one argument is passed
+        if ( i === length ) {
+            target = this;
+            i--;
+        }
+    
+        for ( ; i < length; i++ ) {
+    
+            // Only deal with non-null/undefined values
+            if ( ( options = arguments[ i ] ) != null ) {
+    
+                // Extend the base object
+                for ( name in options ) {
+                    copy = options[ name ];
+    
+                    // Prevent Object.prototype pollution
+                    // Prevent never-ending loop
+                    if ( name === "__proto__" || target === copy ) {
+                        continue;
+                    }
+    
+                    // Recurse if we're merging plain objects or arrays
+                    if ( deep && copy && ( jQuery.isPlainObject( copy ) ||
+                        ( copyIsArray = Array.isArray( copy ) ) ) ) {
+                        src = target[ name ];
+    
+                        // Ensure proper type for the source value
+                        if ( copyIsArray && !Array.isArray( src ) ) {
+                            clone = [];
+                        } else if ( !copyIsArray && !jQuery.isPlainObject( src ) ) {
+                            clone = {};
+                        } else {
+                            clone = src;
+                        }
+                        copyIsArray = false;
+    
+                        // Never move original objects, clone them
+                        target[ name ] = jQuery.extend( deep, clone, copy );
+    
+                    // Don't bring in undefined values
+                    } else if ( copy !== undefined ) {
+                        target[ name ] = copy;
+                    }
+                }
+            }
+        }
+    
+        // Return the modified object
+        return target;
+    };
+})();

--- a/lms/templates/main.html
+++ b/lms/templates/main.html
@@ -209,6 +209,7 @@ from pipeline_mako import render_require_js_path_overrides
   <script type="text/javascript" src="${static.url('js/utils/navigation.js')}" charset="utf-8"></script>
   <script type="text/javascript" src="${static.url('js/header/header.js')}"></script>
   <%static:optional_include_mako file="body-extra.html" is_theming_enabled="True" />
+  <script type="text/javascript" src="${static.url('js/src/jquery_extend_patch.js')}"></script>
 </body>
 </html>
 


### PR DESCRIPTION
## [PROD-497](https://openedx.atlassian.net/browse/PROD-497)

### Description

`extend` function of jquery (jQuery < 3.4.0) is known to have Prototype Pollution vulnerability.
This PR is made in an effort to rebind `extend` function with its patched implementation.

### Sandbox
- [ ] https://jquery.sandbox.edx.org

### Test on the Sandbox
- Go to any page and open console
- `$.extend(true, {}, JSON.parse('{"__proto__": {"test": true}}') ); console.log( "test" in {} );` would return `false` if function has been patched and `true` otherwise.

 

### Reviewers
- [x] @awaisdar001 
- [ ] @asadazam93 
 
### Post-review
- [ ] Rebase and squash commits