### PR TITLE
SE-1463 add djangoapps.heartbeat to INSTALLED_APPS by default

### DIFF
--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -1357,6 +1357,8 @@ INSTALLED_APPS = [
     'openedx.features.discounts',
     'experiments',
 
+    # so sample_task is available to celery workers
+    'openedx.core.djangoapps.heartbeat',
 ]
 
 

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -2501,7 +2501,10 @@ INSTALLED_APPS = [
 
     # edx-drf-extensions
     'csrf.apps.CsrfAppConfig',  # Enables frontend apps to retrieve CSRF tokens.
-    'xss_utils'
+    'xss_utils',
+
+    # so sample_task is available to celery workers
+    'openedx.core.djangoapps.heartbeat',
 ]
 
 ######################### CSRF #########################################


### PR DESCRIPTION
If this isn't installed, celery workers never see the sample_task used
for the extended heartbeat api call. Since the celery heartbeat check is
turned on by default, we should also make sure this djangoapp and thus
sample_task is installed by default.

Currently, the default configuration causes extended heartbeat to be broken by default.

**JIRA tickets**: [OSPR-3843](https://openedx.atlassian.net/browse/OSPR-3843)

**Dependencies**: None

**Sandbox URL**: 

-    LMS: https://pr21633.sandbox.opencraft.hosting/
-    Studio: https://studio.pr21633.sandbox.opencraft.hosting/

Note that this sandbox is deployed with the extra configuration shown at the bottom of the PR description to force using the defaults (ocim by default overrides these settings), and is deployed using the configuration branch on https://github.com/edx/configuration/pull/5400 (to make sure the variables are actually passed through).

It is expected that the sandbox extended heartbeats are successful:

- https://pr21633.sandbox.opencraft.hosting/heartbeat?extended=true
- https://studio.pr21633.sandbox.opencraft.hosting/heartbeat?extended=true

**Merge deadline**: None

**Testing instructions**:

1. deploy edx-platform **on latest master** with the default configuration (ie. no overrides/additions for the installed apps or extended heartbeat checks).
2. visit the extended heartbeat api endpoint (`/heartbeat?extended=true`)
3. verify that the celery heartbeat check is present and fails with `"message": "expired"`
4. verify that `KeyError: u'openedx.core.djangoapps.heartbeat.tasks.sample_task'` is shown in the logs
5. apply the patch from this branch and restart/redeploy the devstack.
6. visit the extended heartbeat api endpoint again
7. verify that the celery heartbeat check is present and successful.

**Author notes and concerns**:

- ~it is recommended to test this on a local devstack rather than~ the sandbox (haproxy configuration hides the response when it fails, and ocim adds overrides to installed_apps and extended heartbeat checks by default). If running on a sandbox, you will need to check the extended heartbeat api call locally on the sandbox - eg. `curl localhost:80/heartbeat?extended=true`
- confusingly, I can't currently reproduce this on my local devstack, but can consistently reproduce on sandboxes. Perhaps there is a difference with how the celery workers are set up. It might be better to test on a sandbox instead. Either way, since djangoapps.heartbeat is used by default on the platform, it should be added to installed_apps by default.

**Reviewers**
- [x] @viadanna 
- [x] edX reviewer[s] TBD

**Settings**
```yaml
EDXAPP_LMS_ENV_EXTRA:
  ADDL_INSTALLED_APPS: []
  HEARTBEAT_EXTENDED_CHECKS:
    - openedx.core.djangoapps.heartbeat.default_checks.check_celery

EDXAPP_CMS_ENV_EXTRA:
  ADDL_INSTALLED_APPS: []
  HEARTBEAT_EXTENDED_CHECKS:
    - openedx.core.djangoapps.heartbeat.default_checks.check_celery
```