### PR TITLE
SE-1496 install configparser from github instead

### DIFF
--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -59,7 +59,7 @@ click-log==0.3.2
 click==7.0
 code-annotations==0.3.2
 colorama==0.4.1
-git+https://github.com/jaraco/configparser.git@v4.0.1#egg=configparser==4.0.1
+configparser==4.0.2
 contextlib2==0.5.5
 cookies==2.2.1
 coreapi==2.3.3

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -59,7 +59,7 @@ click-log==0.3.2
 click==7.0
 code-annotations==0.3.2
 colorama==0.4.1
-configparser==4.0.1
+git+https://github.com/jaraco/configparser.git@v4.0.1#egg=configparser==4.0.1
 contextlib2==0.5.5
 cookies==2.2.1
 coreapi==2.3.3

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -57,7 +57,7 @@ click-log==0.3.2          # via edx-lint
 click==7.0
 code-annotations==0.3.2
 colorama==0.4.1           # via radon
-git+https://github.com/jaraco/configparser.git@v4.0.1#egg=configparser==4.0.1       # via entrypoints, flake8, importlib-metadata, pylint
+configparser==4.0.2       # via entrypoints, flake8, importlib-metadata, pylint
 contextlib2==0.5.5
 cookies==2.2.1            # via moto
 coreapi==2.3.3

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -57,7 +57,7 @@ click-log==0.3.2          # via edx-lint
 click==7.0
 code-annotations==0.3.2
 colorama==0.4.1           # via radon
-configparser==4.0.1       # via entrypoints, flake8, importlib-metadata, pylint
+git+https://github.com/jaraco/configparser.git@v4.0.1#egg=configparser==4.0.1       # via entrypoints, flake8, importlib-metadata, pylint
 contextlib2==0.5.5
 cookies==2.2.1            # via moto
 coreapi==2.3.3


### PR DESCRIPTION
pypi release was pulled for a low priority issue (not related to security or major broken functionality): https://github.com/jaraco/configparser/issues/45#issuecomment-530595951


**JIRA tickets**: [OSPR-3845](https://openedx.atlassian.net/browse/OSPR-3845)

**Dependencies**: None

**Screenshots**: Always include screenshots if there is any change to the UI.

**Sandbox URL**: TBD - sandbox is being provisioned.

**Merge deadline**: ASAP - this breaks deployments and tests on master

**Testing instructions**:

1. run tests and deployment
2. confirm in both cases that configparser 4.0.1 was installed correctly

**Author notes and concerns**:


**Reviewers**
- [ ] @clemente 
- [ ] edX reviewer[s] TBD

**Settings**
```yaml
```