### PR TITLE
TE-2862 Switch to warnings-ng Jenkins plugin

### DIFF
--- a/scripts/Jenkinsfiles/quality
+++ b/scripts/Jenkinsfiles/quality
@@ -193,10 +193,7 @@ pipeline {
                     unstash 'quality-3-reports'
                     unstash 'quality-4-reports'
                     // Check for warnings
-                    warnings canComputeNew: false, canResolveRelativePaths: false, canRunOnFailed: true, categoriesPattern: '',
-                        defaultEncoding: '', excludePattern: '', healthy: '', includePattern: '', messagesPattern: '',
-                        parserConfigurations: [[parserName: 'Pep8', pattern: 'reports/pep8/pep8.report'], [parserName: 'PyLint', pattern: 'reports/**/pylint.report']],
-                        unHealthy: ''
+                    recordIssues enabledForFailure: true, tools: [pep8(pattern: 'reports/pep8/pep8.report'), pyLint(pattern: 'reports/**/pylint.report')]
                     // Publish Quality report
                     publishHTML([allowMissing: true, alwaysLinkToLastBuild: false, keepAll: true,
                         reportDir: 'reports/metrics/',


### PR DESCRIPTION
Switch from the deprecated `Warnings` Jenkins plugin to its replacement, `Warnings Next Generation`.  Both will stay installed until we stop running Ironwood quality jobs.