### PR TITLE
Only delete latest grade override if it came from proctoring

### DIFF
--- a/lms/djangoapps/grades/constants.py
+++ b/lms/djangoapps/grades/constants.py
@@ -15,3 +15,4 @@ class ScoreDatabaseTableEnum(object):
 class GradeOverrideFeatureEnum(object):
     proctoring = 'PROCTORING'
     gradebook = 'GRADEBOOK'
+    grade_import = 'grade-import'


### PR DESCRIPTION
... on proctored exam attempt deletion

JIRA:EDUCATOR-4642

This adds more specificity to when a PersistentSubsectionGradeOverride can be deleted via the grades API; different "systems" which create and update these overrides should not delete one another's overrides. They will instead only be allowed to delete their own overrides.

Note that this doesn't address potentially unexpected circumstances around different systems clobbering one another's overrides with updates. It's still quite possible for overrides to clobber one another from different systems.