### PR TITLE
Drop RUN_AS_ANALYTICS_SERVER_ENABLED

### DIFF
--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -158,12 +158,6 @@ FEATURES = {
     # Set to hide the courses list on the Learner Dashboard if they are not enrolled in any courses yet.
     'HIDE_DASHBOARD_COURSES_UNTIL_ACTIVATED': False,
 
-    # enable analytics server.
-    # WARNING: THIS SHOULD ALWAYS BE SET TO FALSE UNDER NORMAL
-    # LMS OPERATION. See analytics.py for details about what
-    # this does.
-    'RUN_AS_ANALYTICS_SERVER_ENABLED': False,
-
     # Give a UI to show a student's submission history in a problem by the
     # Staff Debug tool.
     'ENABLE_STUDENT_HISTORY_VIEW': True,

--- a/lms/urls.py
+++ b/lms/urls.py
@@ -830,11 +830,6 @@ if settings.FEATURES.get('ENABLE_INSTRUCTOR_BACKGROUND_TASKS'):
         ),
     ]
 
-if settings.FEATURES.get('RUN_AS_ANALYTICS_SERVER_ENABLED'):
-    urlpatterns += [
-        url(r'^edinsights_service/', include('edinsights.core.urls')),
-    ]
-
 if settings.FEATURES.get('ENABLE_DEBUG_RUN_PYTHON'):
     urlpatterns += [
         url(r'^debug/run_python$', debug_views.run_python),


### PR DESCRIPTION
This is an ancient feature flag that uses an archived and unsupported support library (edinsights, edx/insights).

https://openedx.atlassian.net/browse/DEPR-44