### PR TITLE
clean up toggle annotations

### DIFF
--- a/lms/djangoapps/bulk_email/models.py
+++ b/lms/djangoapps/bulk_email/models.py
@@ -462,11 +462,18 @@ class CourseAuthorization(models.Model):
         return u"Course '{}': Instructor Email {}Enabled".format(text_type(self.course_id), not_en)
 
 
-# .. toggle_name: require_course_email_auth .. toggle_type: ConfigurationModel .. toggle_default: True (enabled) ..
-# toggle_description: If the flag is enabled, course-specific authorization is required, and the course_id is either
-# not provided or not authorixed, the feature is not available. .. toggle_category: bulk email .. toggle_use_cases:
-# open_edx .. toggle_creation_date: 2016-05-05 .. toggle_expiration_date: None .. toggle_warnings: None ..
-# toggle_tickets: None .. toggle_status: supported
+# .. toggle_name: require_course_email_auth
+# .. toggle_type: configuration_model
+# .. toggle_default: True (enabled)
+# .. toggle_description: If the flag is enabled, course-specific authorization is required, and the course_id is either
+# not provided or not authorixed, the feature is not available.
+# .. toggle_category: bulk email
+# .. toggle_use_cases:  open_edx
+# .. toggle_creation_date: 2016-05-05
+# .. toggle_expiration_date: None
+# .. toggle_warnings: None
+# .. toggle_tickets: None
+# .. toggle_status: supported
 class BulkEmailFlag(ConfigurationModel):
     """
     Enables site-wide configuration for the bulk_email feature.

--- a/lms/djangoapps/experiments/utils.py
+++ b/lms/djangoapps/experiments/utils.py
@@ -35,10 +35,12 @@ logger = logging.getLogger(__name__)
 experiments_namespace = WaffleFlagNamespace(name=u'experiments')
 
 # .. toggle_name: experiments.add_programs
-# .. toggle_type: feature_flag
+# .. toggle_type: waffle_flag
 # .. toggle_default: False
 # .. toggle_description: Toggle for adding the current course's program information to user metadata
 # .. toggle_category: experiments
+# .. toggle_use_cases: monitored_rollout
+# .. toggle_creation_date: 2019-2-25
 # .. toggle_expiration_date: None
 # .. toggle_warnings: None
 # .. toggle_tickets: REVEM-63, REVEM-198
@@ -50,10 +52,12 @@ PROGRAM_INFO_FLAG = WaffleFlag(
 )
 
 # .. toggle_name: experiments.add_dashboard_info
-# .. toggle_type: feature_flag
+# .. toggle_type: waffle_flag
 # .. toggle_default: False
 # .. toggle_description: Toggle for adding info about each course to the dashboard metadata
 # .. toggle_category: experiments
+# .. toggle_use_cases: monitored_rollout
+# .. toggle_creation_date: 2019-3-28
 # .. toggle_expiration_date: None
 # .. toggle_warnings: None
 # .. toggle_tickets: REVEM-118

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -98,7 +98,7 @@ FEATURES = {
     'ENABLE_TEXTBOOK': True,
 
     # .. toggle_name: ENABLE_STUDENT_NOTES
-    # .. toggle_type: feature_flag
+    # .. toggle_type: waffle_flag
     # .. toggle_default: True
     # .. toggle_description: Enables the Student Notes API and UI.
     # .. toggle_category: ????
@@ -128,7 +128,7 @@ FEATURES = {
     'ENABLE_MASQUERADE': True,  # allow course staff to change to student view of courseware
 
     # .. toggle_name: ENABLE_SYSADMIN_DASHBOARD
-    # .. toggle_type: feature_flag
+    # .. toggle_type: waffle_flag
     # .. toggle_default: False
     # .. toggle_description: enables dashboard at /syadmin/ for django staff, for seeing overview of system status, for deleting and loading courses, for seeing log of git imports of courseware.
     # .. toggle_category: admin
@@ -193,7 +193,7 @@ FEATURES = {
     'ENABLE_VERIFIED_CERTIFICATES': False,
 
     # .. toggle_name: DISABLE_HONOR_CERTIFICATES
-    # .. toggle_type: feature_flag
+    # .. toggle_type: waffle_flag
     # .. toggle_default: False
     # .. toggle_description: Set to True to disable honor certificates. Typically used when your installation only allows verified certificates, like courses.edx.org.
     # .. toggle_category: certificates
@@ -202,6 +202,7 @@ FEATURES = {
     # .. toggle_expiration_date: None
     # .. toggle_tickets: https://openedx.atlassian.net/browse/PROD-269
     # .. toggle_status: supported
+    # .. toggle_warnings: ???
     'DISABLE_HONOR_CERTIFICATES': False,  # Toggle to disable honor certificates
 
     # for acceptance and load testing

--- a/scripts/generate-feature-toggle-annotation-report.sh
+++ b/scripts/generate-feature-toggle-annotation-report.sh
@@ -7,6 +7,6 @@
 
 pip install -r requirements/edx/paver.txt -r requirements/edx/testing.txt
 rm -Rf reports/*
-code_annotations static_find_annotations --config_file=../$CODE_ANNOTATION_CONFIG_PATH --no_lint
+code_annotations static_find_annotations --config_file=../$CODE_ANNOTATION_CONFIG_PATH
 mkdir -p ../$CODE_ANNOTATION_OUTPUT_PATH
 cp reports/* ../$CODE_ANNOTATION_OUTPUT_PATH/lms-annotations.yml


### PR DESCRIPTION
I found a few incomplete feature toggle annotation sets, as well as one that wasn't split correctly (one annotation per line). In the case of `lms/djangoapps/experiments/utils.py`, I added the data that was removed in https://github.com/edx/edx-platform/pull/20880/files so that the annotation report tool could finish processing the annotations. Some other annotations I was unsure about, so I used `???` which I have seen elsewhere in the codebase.

In order to make sure that we catch incomplete annotations in the future, I removed the `--no-lint` flag when we call code-annotations to create a feature toggle report.