### PR TITLE
SE-1553 conditionally run migration on CSMH Extended table

### DIFF
--- a/lms/djangoapps/courseware/migrations/0011_csm_id_bigint.py
+++ b/lms/djangoapps/courseware/migrations/0011_csm_id_bigint.py
@@ -3,6 +3,7 @@
 from __future__ import unicode_literals
 
 import courseware.fields
+from django.conf import settings
 from django.db import migrations
 from django.db.migrations import AlterField
 
@@ -15,7 +16,8 @@ class CsmBigInt(AlterField):
     def database_forwards(self, app_label, schema_editor, from_state, to_state):
         to_model = to_state.apps.get_model(app_label, self.model_name)
         if schema_editor.connection.alias == 'student_module_history':
-            schema_editor.execute("ALTER TABLE `coursewarehistoryextended_studentmodulehistoryextended` MODIFY `student_module_id` bigint UNSIGNED NOT NULL;")
+            if settings.FEATURES["ENABLE_CSMH_EXTENDED"]:
+              schema_editor.execute("ALTER TABLE `coursewarehistoryextended_studentmodulehistoryextended` MODIFY `student_module_id` bigint UNSIGNED NOT NULL;")
         elif self.allow_migrate_model(schema_editor.connection.alias, to_model):
             schema_editor.execute("ALTER TABLE `courseware_studentmodule` MODIFY `id` bigint UNSIGNED AUTO_INCREMENT NOT NULL;")
 


### PR DESCRIPTION
This PR conditionally runs the CSM BIGINT migration on the CSMH_EXTENDED table,
since this is an optional feature and the table isn't guaranteed to exist.

Currently, this issue is breaking provisioning master sandboxes for us. cf. https://github.com/edx/edx-platform/pull/21493#issuecomment-529009456

**JIRA tickets**: [OSPR-3849](https://openedx.atlassian.net/browse/OSPR-3849)

**Dependencies**: None

**Sandbox URL**: 

-    LMS: https://pr21677.sandbox.opencraft.hosting/
-    Studio: https://studio.pr21677.sandbox.opencraft.hosting/


**Merge deadline**: None

**Testing instructions**:

1. note that other master sandboxes are failing on this migration
1. verify that this sandbox provisions successfully with this branch and
   the ENABLE_CSMH_EXTENDED feature is off.

**Author notes and concerns**:

**Reviewers**
- [x] @bradenmacdonald
- [ ] edX reviewer[s] TBD

**Settings**
```yaml
EDXAPP_FEATURES:
  ENABLE_CSMH_EXTENDED: false
```