### PR TITLE
REV-935 mobile upsell and tests

### DIFF
--- a/lms/djangoapps/experiments/tests/test_views_custom.py
+++ b/lms/djangoapps/experiments/tests/test_views_custom.py
@@ -9,24 +9,59 @@ from rest_framework.test import APITestCase
 from lms.djangoapps.course_blocks.transformers.tests.helpers import ModuleStoreTestCase
 from student.tests.factories import UserFactory
 
+from openedx.core.djangoapps.waffle_utils.testutils import override_waffle_flag
+from xmodule.modulestore.tests.factories import CourseFactory
+
+from lms.djangoapps.experiments.views_custom import MOBILE_UPSELL_FLAG
+
 CROSS_DOMAIN_REFERER = 'https://ecommerce.edx.org'
 
 
-class Rev934Tests(APITestCase, ModuleStoreTestCase):
-    def test_logged_in(self):
+class Rev934LoggedOutTests(APITestCase):
+    def test_not_logged_in(self):
         """Test mobile app upsell API"""
         url = reverse('api_experiments:rev_934')
-        user = UserFactory()
 
         # Not-logged-in returns 401
         response = self.client.get(url)
         self.assertEqual(response.status_code, 401)
 
-        # No-course-id returns show_upsell false
+
+class Rev934Tests(APITestCase, ModuleStoreTestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        super(Rev934Tests, cls).setUpClass()
+        cls.url = reverse('api_experiments:rev_934')
+
+    def setUp(self):
+        super(Rev934Tests, self).setUp()
+        user = UserFactory()
         self.client.login(
             username=user.username,
             password=UserFactory._DEFAULT_PASSWORD,  # pylint: disable=protected-access
         )
-        response = self.client.get(url)
+
+    @override_waffle_flag(MOBILE_UPSELL_FLAG, active=False)
+    def test_flag_off(self):
+        response = self.client.get(self.url)
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.data['show_upsell'], False)
+        self.assertEqual(response.data['upsell_flag'], False)
+
+    @override_waffle_flag(MOBILE_UPSELL_FLAG, active=True)
+    def test_no_course_id(self):
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, 400)
+
+    @override_waffle_flag(MOBILE_UPSELL_FLAG, active=True)
+    def test_bad_course_id(self):
+        response = self.client.get(self.url + "?course_id=junk")
+        self.assertEqual(response.status_code, 400)
+
+    @override_waffle_flag(MOBILE_UPSELL_FLAG, active=True)
+    def test_simple_course(self):
+        course = CourseFactory.create()
+        response = self.client.get(self.url, {'course_id': course.id})
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.data['show_upsell'], True)

--- a/lms/djangoapps/experiments/tests/test_views_custom.py
+++ b/lms/djangoapps/experiments/tests/test_views_custom.py
@@ -7,7 +7,6 @@ from uuid import uuid4
 import six
 
 from django.urls import reverse
-from mock import Mock, patch
 from rest_framework.test import APITestCase
 
 from course_modes.tests.factories import CourseModeFactory
@@ -15,16 +14,7 @@ from lms.djangoapps.course_blocks.transformers.tests.helpers import ModuleStoreT
 from student.tests.factories import UserFactory
 
 from openedx.core.djangoapps.waffle_utils.testutils import override_waffle_flag
-from xmodule.modulestore.tests.factories import CourseFactory, SampleCourseFactory, ToyCourseFactory
-
-# from openedx.core.djangoapps.catalog.tests.factories import (
-#     CourseFactory,
-#     CourseRunFactory,
-#     EntitlementFactory,
-#     ProgramFactory,
-#     SeatFactory,
-#     generate_course_run_key
-# )
+from xmodule.modulestore.tests.factories import CourseFactory
 
 from lms.djangoapps.experiments.views_custom import MOBILE_UPSELL_FLAG
 
@@ -33,7 +23,7 @@ CROSS_DOMAIN_REFERER = 'https://ecommerce.edx.org'
 
 class Rev934LoggedOutTests(APITestCase):
     def test_not_logged_in(self):
-        """Test mobile app upsell API"""
+        """Test mobile app upsell API is not available if not logged in"""
         url = reverse('api_experiments:rev_934')
 
         # Not-logged-in returns 401
@@ -42,7 +32,7 @@ class Rev934LoggedOutTests(APITestCase):
 
 
 class Rev934Tests(APITestCase, ModuleStoreTestCase):
-
+    """Test mobile app upsell API"""
     @classmethod
     def setUpClass(cls):
         super(Rev934Tests, cls).setUpClass()
@@ -90,13 +80,22 @@ class Rev934Tests(APITestCase, ModuleStoreTestCase):
     @override_waffle_flag(MOBILE_UPSELL_FLAG, active=True)
     def test_course(self):
         course = CourseFactory.create(run='test', display_name='test')
-        CourseModeFactory.create(mode_slug="verified", course_id=course.id, min_price=10, sku=six.text_type(uuid4().hex))
+        CourseModeFactory.create(
+            mode_slug="verified",
+            course_id=course.id,
+            min_price=10,
+            sku=six.text_type(uuid4().hex)
+        )
 
         response = self.client.get(self.url, {'course_id': course.id})
         self.assertEqual(response.status_code, 200)
+        result = response.data
+        self.assertTrue('basket_url' in result)
+        self.assertTrue(bool(result['basket_url']))
         expected = {
             'show_upsell': True,
             'price': u'$10',
-            'basket_url': u'/verify_student/upgrade/org.0/course_0/test/',
+            # 'basket_url': u'/verify_student/upgrade/org.0/course_0/test/',
+            'basket_url': result['basket_url'],
         }
         self.assertEqual(response.data, expected)

--- a/lms/djangoapps/experiments/tests/test_views_custom.py
+++ b/lms/djangoapps/experiments/tests/test_views_custom.py
@@ -72,7 +72,7 @@ class Rev934Tests(APITestCase, ModuleStoreTestCase):
             'show_upsell': False,
             'upsell_flag': True,
             'experiment_bucket': 1,
-            'upsell_mode': True,
+            'user_upsell': True,
             'basket_link': None,  # No sku means no basket link so no upsell
         }
         self.assertEqual(response.data, expected)

--- a/lms/djangoapps/experiments/tests/test_views_custom.py
+++ b/lms/djangoapps/experiments/tests/test_views_custom.py
@@ -40,7 +40,7 @@ class Rev934Tests(APITestCase, ModuleStoreTestCase):
 
     def setUp(self):
         super(Rev934Tests, self).setUp()
-        user = UserFactory(username='robot-mue-1-6pnjv')  # robot-mue-0-l23fi
+        user = UserFactory(username='robot-mue-1-6pnjv')  # Username that hashes to bucket 1
         self.client.login(
             username=user.username,
             password=UserFactory._DEFAULT_PASSWORD,  # pylint: disable=protected-access
@@ -95,7 +95,7 @@ class Rev934Tests(APITestCase, ModuleStoreTestCase):
         expected = {
             'show_upsell': True,
             'price': u'$10',
-            # 'basket_url': u'/verify_student/upgrade/org.0/course_0/test/',
             'basket_url': result['basket_url'],
+            # Example basket_url: u'/verify_student/upgrade/org.0/course_0/test/'
         }
         self.assertEqual(response.data, expected)

--- a/lms/djangoapps/experiments/tests/test_views_custom.py
+++ b/lms/djangoapps/experiments/tests/test_views_custom.py
@@ -90,7 +90,7 @@ class Rev934Tests(APITestCase, ModuleStoreTestCase):
         response = self.client.get(self.url, {'course_id': course.id})
         self.assertEqual(response.status_code, 200)
         result = response.data
-        self.assertTrue('basket_url' in result)
+        self.assertIn('basket_url', result)
         self.assertTrue(bool(result['basket_url']))
         expected = {
             'show_upsell': True,

--- a/lms/djangoapps/experiments/views_custom.py
+++ b/lms/djangoapps/experiments/views_custom.py
@@ -5,7 +5,6 @@ The Discount API Views should return information about discounts that apply to t
 # -*- coding: utf-8 -*-
 
 from __future__ import absolute_import
-from datetime import datetime
 import six
 
 from django.utils.decorators import method_decorator
@@ -25,7 +24,7 @@ from openedx.core.lib.api.permissions import ApiKeyHeaderPermissionIsAuthenticat
 from openedx.core.lib.api.view_utils import DeveloperErrorViewMixin
 
 from lms.djangoapps.courseware.date_summary import verified_upgrade_link_is_valid
-from course_modes.models import get_cosmetic_verified_display_price, CourseMode
+from course_modes.models import get_cosmetic_verified_display_price
 from lms.djangoapps.commerce.utils import EcommerceService
 from lms.djangoapps.experiments.stable_bucketing import stable_bucketing_hash_group
 from student.models import CourseEnrollment

--- a/lms/djangoapps/experiments/views_custom.py
+++ b/lms/djangoapps/experiments/views_custom.py
@@ -117,7 +117,7 @@ class Rev934(DeveloperErrorViewMixin, APIView):
 
         course_id = request.GET.get('course_id')
         try:
-            course_key = CourseKey.from_string(course_id)  # if course_id else None
+            course_key = CourseKey.from_string(course_id)
         except InvalidKeyError:
             return HttpResponseBadRequest("Missing or invalid course_id")
 

--- a/lms/djangoapps/experiments/views_custom.py
+++ b/lms/djangoapps/experiments/views_custom.py
@@ -8,7 +8,7 @@ from __future__ import absolute_import
 import six
 
 from django.utils.decorators import method_decorator
-from django.http import HttpResponse, HttpResponseBadRequest
+from django.http import HttpResponseBadRequest
 from edx_rest_framework_extensions.auth.jwt.authentication import JwtAuthentication
 from edx_rest_framework_extensions.auth.session.authentication import SessionAuthenticationAllowInactiveUser
 from opaque_keys import InvalidKeyError
@@ -24,8 +24,7 @@ from openedx.core.lib.api.permissions import ApiKeyHeaderPermissionIsAuthenticat
 from openedx.core.lib.api.view_utils import DeveloperErrorViewMixin
 
 from course_modes.models import get_cosmetic_verified_display_price, CourseMode
-from lms.djangoapps.commerce.utils import EcommerceService  # pylint: disable=import-error
-from lms.djangoapps.experiments.utils import check_and_get_upgrade_link_and_date  # get_base_experiment_metadata_context
+from lms.djangoapps.commerce.utils import EcommerceService
 from lms.djangoapps.experiments.stable_bucketing import stable_bucketing_hash_group
 from student.models import CourseEnrollment
 from track import segment
@@ -126,7 +125,6 @@ class Rev934(DeveloperErrorViewMixin, APIView):
         user = request.user
 
         enrollment = None
-        user_enrollments = None
         upsell_mode = True
         try:
             enrollment = CourseEnrollment.objects.select_related(

--- a/lms/djangoapps/experiments/views_custom.py
+++ b/lms/djangoapps/experiments/views_custom.py
@@ -24,6 +24,7 @@ from openedx.core.lib.api.authentication import OAuth2AuthenticationAllowInactiv
 from openedx.core.lib.api.permissions import ApiKeyHeaderPermissionIsAuthenticated
 from openedx.core.lib.api.view_utils import DeveloperErrorViewMixin
 
+from lms.djangoapps.courseware.date_summary import verified_upgrade_link_is_valid
 from course_modes.models import get_cosmetic_verified_display_price, CourseMode
 from lms.djangoapps.commerce.utils import EcommerceService
 from lms.djangoapps.experiments.stable_bucketing import stable_bucketing_hash_group
@@ -129,8 +130,7 @@ class Rev934(DeveloperErrorViewMixin, APIView):
             enrollment = CourseEnrollment.objects.select_related(
                 'course'
             ).get(user_id=user.id, course_id=course.id)
-            upgrade_valid = datetime.now(utc).date() <= enrollment.upgrade_deadline.date()
-            user_upsell = upgrade_valid and enrollment.mode in CourseMode.UPSELL_TO_VERIFIED_MODES
+            user_upsell = verified_upgrade_link_is_valid(enrollment)
         except CourseEnrollment.DoesNotExist:
             user_upsell = True
 


### PR DESCRIPTION
There are sure to be more test cases to write but this has enough bug fixes and improvements to warrant releasing for the mobile team to test and develop on, notably:

- Now requires course id to be correctly encoded in the url params
- Only checks entitlements of the course in question
- Better source for the basket url
