### PR TITLE
Track grades for Blockstore content, emit tracking logs

### DIFF
--- a/common/djangoapps/track/contexts.py
+++ b/common/djangoapps/track/contexts.py
@@ -4,7 +4,7 @@ from __future__ import absolute_import
 import logging
 
 from opaque_keys import InvalidKeyError
-from opaque_keys.edx.keys import CourseKey
+from opaque_keys.edx.keys import CourseKey, LearningContextKey
 from six import text_type
 
 from openedx.core.lib.request_utils import COURSE_REGEX
@@ -40,20 +40,55 @@ def course_context_from_course_id(course_id):
     """
     Creates a course context from a `course_id`.
 
+    For newer parts of the system (i.e. Blockstore-based libraries/courses/etc.)
+    use context_dict_for_learning_context instead of this method.
+
     Example Returned Context::
 
         {
             'course_id': 'org/course/run',
             'org_id': 'org'
         }
+    """
+    context_dict = context_dict_for_learning_context(course_id)
+    # Remove the newer 'context_id' field for now in this method so we're not
+    # adding a new field to the course tracking logs
+    del context_dict['context_id']
+    return context_dict
+
+
+def context_dict_for_learning_context(context_key):
+    """
+    Creates a tracking log context dictionary for the given learning context
+    key, which may be None, a CourseKey, a content library key, or any other
+    type of LearningContextKey.
+
+    Example Returned Context Dict::
+
+        {
+            'context_id': 'course-v1:org+course+run',
+            'course_id': 'course-v1:org+course+run',
+            'org_id': 'org'
+        }
+
+    Example 2::
+
+        {
+            'context_id': 'lib:edX:a-content-library',
+            'course_id': '',
+            'org_id': 'edX'
+        }
 
     """
-    if course_id is None:
-        return {'course_id': '', 'org_id': ''}
-
-    # TODO: Make this accept any CourseKey, and serialize it using .to_string
-    assert isinstance(course_id, CourseKey)
-    return {
-        'course_id': text_type(course_id),
-        'org_id': course_id.org,
+    context_dict = {
+        'context_id': text_type(context_key) if context_key else '',
+        'course_id': '',
+        'org_id': '',
     }
+    if context_key is not None:
+        assert isinstance(context_key, LearningContextKey)
+        if context_key.is_course:
+            context_dict['course_id'] = text_type(context_key)
+        if hasattr(context_key, 'org'):
+            context_dict['org_id'] = context_key.org
+    return context_dict

--- a/lms/djangoapps/grades/management/commands/recalculate_subsection_grades.py
+++ b/lms/djangoapps/grades/management/commands/recalculate_subsection_grades.py
@@ -63,6 +63,9 @@ class Command(BaseCommand):
         set_event_transaction_type(PROBLEM_SUBMITTED_EVENT_TYPE)
         kwargs = {'modified__range': (modified_start, modified_end), 'module_type': 'problem'}
         for record in StudentModule.objects.filter(**kwargs):
+            if not record.course_id.is_course:
+                # This is not a course, so we don't store subsection grades for it.
+                continue
             task_args = {
                 "user_id": record.student_id,
                 "course_id": six.text_type(record.course_id),
@@ -78,6 +81,9 @@ class Command(BaseCommand):
 
         kwargs = {'created_at__range': (modified_start, modified_end)}
         for record in Submission.objects.filter(**kwargs):
+            if not record.student_item.course_id.is_course:
+                # This is not a course, so ignore it
+                continue
             task_args = {
                 "user_id": user_by_anonymous_id(record.student_item.student_id).id,
                 "anonymous_user_id": record.student_item.student_id,

--- a/lms/djangoapps/grades/management/commands/tests/test_recalculate_subsection_grades.py
+++ b/lms/djangoapps/grades/management/commands/tests/test_recalculate_subsection_grades.py
@@ -10,6 +10,7 @@ import ddt
 import six
 from django.conf import settings
 from mock import MagicMock, patch
+from opaque_keys.edx.keys import CourseKey
 from pytz import utc
 
 from lms.djangoapps.grades.constants import ScoreDatabaseTableEnum
@@ -40,7 +41,7 @@ class TestRecalculateSubsectionGrades(HasCourseWithProblemsMixin, ModuleStoreTes
         submission = MagicMock()
         submission.student_item = MagicMock(
             student_id="anonymousID",
-            course_id='x/y/z',
+            course_id=CourseKey.from_string('course-v1:x+y+z'),
             item_id='abc',
         )
         submission.created_at = utc.localize(datetime.strptime('2016-08-23 16:43', DATE_FORMAT))
@@ -55,7 +56,7 @@ class TestRecalculateSubsectionGrades(HasCourseWithProblemsMixin, ModuleStoreTes
     def test_csm(self, task_mock, id_mock, csm_mock):
         csm_record = MagicMock()
         csm_record.student_id = "ID"
-        csm_record.course_id = "x/y/z"
+        csm_record.course_id = CourseKey.from_string('course-v1:x+y+z')
         csm_record.module_state_key = "abc"
         csm_record.modified = utc.localize(datetime.strptime('2016-08-23 16:43', DATE_FORMAT))
         csm_mock.objects.filter.return_value = [csm_record]
@@ -67,7 +68,7 @@ class TestRecalculateSubsectionGrades(HasCourseWithProblemsMixin, ModuleStoreTes
         self.command.handle(modified_start='2016-08-25 16:42', modified_end='2018-08-25 16:44')
         kwargs = {
             "user_id": "ID",
-            "course_id": u'x/y/z',
+            "course_id": u'course-v1:x+y+z',
             "usage_id": u'abc',
             "only_if_higher": False,
             "expected_modified_time": to_timestamp(utc.localize(datetime.strptime('2016-08-23 16:43', DATE_FORMAT))),

--- a/lms/djangoapps/grades/signals/handlers.py
+++ b/lms/djangoapps/grades/signals/handlers.py
@@ -8,6 +8,7 @@ from logging import getLogger
 
 import six
 from django.dispatch import receiver
+from opaque_keys.edx.keys import LearningContextKey
 from submissions.models import score_reset, score_set
 from xblock.scorable import ScorableXBlockMixin, Score
 
@@ -220,6 +221,9 @@ def enqueue_subsection_update(sender, **kwargs):  # pylint: disable=unused-argum
     enqueueing a subsection update operation to occur asynchronously.
     """
     events.grade_updated(**kwargs)
+    context_key = LearningContextKey.from_string(kwargs['course_id'])
+    if not context_key.is_course:
+        return  # If it's not a course, it has no subsections, so skip the subsection grading update
     recalculate_subsection_grade_v3.apply_async(
         kwargs=dict(
             user_id=kwargs['user_id'],

--- a/lms/djangoapps/lti_provider/signals.py
+++ b/lms/djangoapps/lti_provider/signals.py
@@ -6,6 +6,7 @@ import logging
 
 from django.conf import settings
 from django.dispatch import receiver
+from opaque_keys.edx.keys import LearningContextKey
 
 import lti_provider.outcomes as outcomes
 from lms.djangoapps.grades.api import signals as grades_signals
@@ -46,6 +47,13 @@ def score_changed_handler(sender, **kwargs):  # pylint: disable=unused-argument
     user_id = kwargs.get('user_id', None)
     course_id = kwargs.get('course_id', None)
     usage_id = kwargs.get('usage_id', None)
+
+    # Make sure this came from a course because this code only works with courses
+    if not course_id:
+        return
+    context_key = LearningContextKey.from_string(course_id)
+    if not context_key.is_course:
+        return  # This is a content library or something else...
 
     if None not in (points_earned, points_possible, user_id, course_id):
         course_key, usage_key = parse_course_and_usage_keys(course_id, usage_id)

--- a/openedx/core/djangoapps/xblock/runtime/shims.py
+++ b/openedx/core/djangoapps/xblock/runtime/shims.py
@@ -317,6 +317,19 @@ class RuntimeShim(object):
             result['default_value'] = field.to_json(field.default)
         return result
 
+    def track_function(self, title, event_info):
+        """
+        Publish an event to the tracking log.
+
+        This is deprecated in favor of runtime.publish
+        See https://git.io/JeGLf and https://git.io/JeGLY for context.
+        """
+        warnings.warn(
+            "runtime.track_function is deprecated. Use runtime.publish() instead.",
+            DeprecationWarning, stacklevel=2,
+        )
+        self.publish(self._active_block, title, event_info)
+
     @property
     def user_location(self):
         """


### PR DESCRIPTION
Follow up to https://github.com/edx/edx-platform/pull/21630 . This one allows Blockstore-hosted XBlocks to emit grades and tracking log events. Completion tracking will come in a separate PR since it builds on this but also requires changes to an external package as well as a DB migration.

The goal of this is to store scores for individual blocks in CSM, but not to impact the broader persistent grades / subsection grades feature which should just ignore these non-course scores.

### Test instructions

Manual test:
* Run Blockstore (`cd blockstore; make easyserver`)
* Install the very latest commit of [Ramshackle](https://github.com/open-craft/ramshackle/)
* Log in to Studio and the LMS
* Go to http://localhost:18010/ramshackle/ and create a content library with a capa problem
* Submit an answer
* Find that problem's entry in http://localhost:18000/admin/courseware/studentmodule/ and verify that its "grade" and "max grade" are updated (without this PR they will be blank)
* Verify that the LMS log output a tracking event like this, with `context.context_id` set and `context.course_id` blank:
    ```
    2019-09-17 22:48:55,462 INFO 31833 [tracking] [user None] logger.py:50 - 
       {
    "username": "",
    "event_type": "problem_check",
    "ip": "172.18.0.1",
    "agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/76.0.3809.132 Safari/537.36",
    "host": "localhost:18000",
    "referer": "http://d3749cj02gkez2.cloudfront.net/xblock-bootstrap.html",
    "accept_language": "en;q=1.0, en;q=0.9",
    "event": {
        "submission": {...},
        "success": "correct",
        "grade": 1,
        "correct_map": {...},
        "state": {...},
        "answers": {
        "lb:LX:test-creation2:problem:problem1_2_1": "choice_1"
        },
        "attempts": 4,
        "max_grade": 1,
        "problem_id": "lb:LX:test-creation2:problem:problem1"
    },
    "event_source": "server",
    "context": {
        "user_id": 9,
        "org_id": "LX",
        "asides": {},
        "context_id": "lib:LX:test-creation2",
        "course_id": "",
        "path": "/api/xblock/v2/xblocks/lb:LX:test-creation2:problem:problem1/handler/9-7453c2d14d7d0cf90ca8/xmodule_handler/problem_check"
    },
    "time": "2019-09-17T22:48:55.462504+00:00",
    "page": "x_module"
    }

    ```

Management command impact:
* Verify that the `recalculate_subsection_grades` task runs correctly by running `./manage.py lms recalculate_subsection_grades --modified_start '2019-01-01 16:43' --modified_end '2019-12-25 16:43'`

Unit tests:
* Run `make testserver` from the `blockstore` dir, then from both `lms-shell` and `studio-shell`, run:
    ```
    EDXAPP_RUN_BLOCKSTORE_TESTS=1 python -Wd -m pytest --ds=lms.envs.test openedx/core/lib/blockstore_api/ openedx/core/djangolib/tests/test_blockstore_cache.py openedx/core/djangoapps/content_libraries/tests/ common/lib/xmodule/xmodule/tests/test_unit_block.py
    ```
(Change `lms.envs.test` to `cms.envs.test` when running in `studio-shell`)