### PR TITLE
Disable edxnotes for blockstore runtime.

### DIFF
--- a/lms/djangoapps/edxnotes/decorators.py
+++ b/lms/djangoapps/edxnotes/decorators.py
@@ -24,6 +24,11 @@ def edxnotes(cls):
         """
         # Import is placed here to avoid model import at project startup.
         from edxnotes.helpers import generate_uid, get_edxnotes_id_token, get_public_endpoint, get_token_url, is_feature_enabled
+
+        runtime = getattr(self, 'descriptor', self).runtime
+        if not hasattr(runtime, 'modulestore'):
+            return original_get_html(self, *args, **kwargs)
+
         is_studio = getattr(self.system, "is_author_mode", False)
         course = getattr(self, 'descriptor', self).runtime.modulestore.get_course(self.runtime.course_id)
 

--- a/lms/djangoapps/edxnotes/tests.py
+++ b/lms/djangoapps/edxnotes/tests.py
@@ -172,6 +172,13 @@ class EdxNotesDecoratorTest(ModuleStoreTestCase):
         self.problem.system.is_author_mode = True
         self.assertEqual("original_get_html", self.problem.get_html())
 
+    def test_edxnotes_blockstore_runtime(self):
+        """
+        Tests that get_html is not wrapped when problem is rendered by Blockstore runtime.
+        """
+        del self.problem.descriptor.runtime.modulestore
+        self.assertEqual("original_get_html", self.problem.get_html())
+
     def test_edxnotes_harvard_notes_enabled(self):
         """
         Tests that get_html is not wrapped when Harvard Annotation Tool is enabled.


### PR DESCRIPTION
Blockstore runtime does not support courses currently and it will not have the modulestore attribute in any case.

This is part of a series of work for the [Blockstore runtime](https://github.com/edx/edx-platform/pull/20645).

Testing instructions:
* Run Blockstore (cd blockstore; make easyserver)
* Install the very latest commit of Ramshackle
* Log in to Studio and the LMS
* Go to http://localhost:18010/ramshackle/ and view the new "Learn" tab for the HtmlBlock in a Blockstore-based content library without and with this fix.
