### PR TITLE
Add Studio note about mktg site delay

### DIFF
--- a/cms/djangoapps/contentstore/tests/test_course_settings.py
+++ b/cms/djangoapps/contentstore/tests/test_course_settings.py
@@ -285,6 +285,7 @@ class CourseDetailsViewTest(CourseTestCase, MilestonesTestCaseMixin):
 
         with mock.patch.dict('django.conf.settings.FEATURES', {
             'ENABLE_PUBLISHER': True,
+            'ENABLE_MKTG_SITE': True,
             'ENTRANCE_EXAMS': False,
             'ENABLE_PREREQUISITE_COURSES': False
         }):

--- a/cms/djangoapps/contentstore/views/course.py
+++ b/cms/djangoapps/contentstore/views/course.py
@@ -1051,6 +1051,11 @@ def settings_handler(request, course_key_string):
                 'ENABLE_PUBLISHER',
                 settings.FEATURES.get('ENABLE_PUBLISHER', False)
             )
+            marketing_enabled = configuration_helpers.get_value_for_org(
+                course_module.location.org,
+                'ENABLE_MKTG_SITE',
+                settings.FEATURES.get('ENABLE_MKTG_SITE', False)
+            )
             enable_extended_course_details = configuration_helpers.get_value_for_org(
                 course_module.location.org,
                 'ENABLE_EXTENDED_COURSE_DETAILS',
@@ -1080,6 +1085,7 @@ def settings_handler(request, course_key_string):
                 'video_thumbnail_image_url': course_image_url(course_module, 'video_thumbnail_image'),
                 'details_url': reverse_course_url('settings_handler', course_key),
                 'about_page_editable': about_page_editable,
+                'marketing_enabled': marketing_enabled,
                 'short_description_editable': short_description_editable,
                 'sidebar_html_enabled': sidebar_html_enabled,
                 'upload_asset_url': upload_asset_url,

--- a/cms/templates/settings.html
+++ b/cms/templates/settings.html
@@ -85,7 +85,7 @@ CMS.URL.UPLOAD_ASSET = '${upload_asset_url | n, js_escaped_string}'
             </li>
           </ol>
 
-          % if about_page_editable:
+          % if not marketing_enabled:
           <div class="note note-promotion note-promotion-courseURL has-actions">
             <h3 class="title">${_("Course Summary Page")} <span class="tip">${_("(for student enrollment and access)")}</span></h3>
             <div class="copy">
@@ -115,7 +115,7 @@ CMS.URL.UPLOAD_ASSET = '${upload_asset_url | n, js_escaped_string}'
           </div>
           % endif
 
-          % if not about_page_editable:
+          % if marketing_enabled:
           <div class="notice notice-incontext notice-workflow">
             <h3 class="title">${_("Promoting Your Course with {platform_name}").format(platform_name=settings.PLATFORM_NAME)}</h3>
             <div class="copy">
@@ -123,6 +123,9 @@ CMS.URL.UPLOAD_ASSET = '${upload_asset_url | n, js_escaped_string}'
                 'Your course summary page will not be viewable until your course '
                 'has been announced. To provide content for the page and preview '
                 'it, follow the instructions provided by your Program Manager.')}
+                ${_(
+                'Please note that changes here may take up to a business day to '
+                'appear on your course summary page.')}
               </p>
             </div>
           </div>


### PR DESCRIPTION
Add a note when marketing site is enabled that there is a delay from changes in Studio appearing on the marketing site.

https://openedx.atlassian.net/browse/DISCO-1356

![Screenshot from 2019-09-18 16-14-07](https://user-images.githubusercontent.com/1196901/65182728-f0d01e80-da2f-11e9-88ca-3ca514ee8271.png)

