### PR TITLE
Fix: new runtime was not mixing 'has_score' into XBlocks

### DIFF
--- a/openedx/core/djangoapps/xblock/runtime/mixin.py
+++ b/openedx/core/djangoapps/xblock/runtime/mixin.py
@@ -1,0 +1,19 @@
+"""
+A mixin that provides functionality and default attributes for all XBlocks in
+the new XBlock runtime.
+"""
+
+
+class LmsBlockMixin(object):
+    """
+    A mixin that provides functionality and default attributes for all XBlocks
+    in the new XBlock runtime.
+
+    These are not standard XBlock attributes but are used by the LMS (and
+    possibly Studio).
+    """
+
+    # This indicates whether the XBlock has a score (e.g. it's a problem, not
+    # static content). If it does, it should set this and provide scoring
+    # functionality by inheriting xblock.scorable.ScorableXBlockMixin
+    has_score = False

--- a/openedx/core/djangoapps/xblock/runtime/runtime.py
+++ b/openedx/core/djangoapps/xblock/runtime/runtime.py
@@ -16,6 +16,7 @@ from web_fragments.fragment import Fragment
 from courseware.model_data import DjangoKeyValueStore, FieldDataCache
 from openedx.core.djangoapps.xblock.apps import get_xblock_app_config
 from openedx.core.djangoapps.xblock.runtime.blockstore_field_data import BlockstoreFieldData
+from openedx.core.djangoapps.xblock.runtime.mixin import LmsBlockMixin
 from openedx.core.lib.xblock_utils import xblock_local_resource_url
 from xmodule.errortracker import make_error_tracker
 from .id_managers import OpaqueKeyReader
@@ -45,7 +46,8 @@ class XBlockRuntime(RuntimeShim, Runtime):
         super(XBlockRuntime, self).__init__(
             id_reader=system.id_reader,
             mixins=(
-                XBlockShim,
+                LmsBlockMixin,  # Adds Non-deprecated LMS/Studio functionality
+                XBlockShim,  # Adds deprecated LMS/Studio functionality / backwards compatibility
             ),
             services={
                 "i18n": NullI18nService(),

--- a/openedx/core/djangoapps/xblock/runtime/shims.py
+++ b/openedx/core/djangoapps/xblock/runtime/shims.py
@@ -393,3 +393,42 @@ class XBlockShim(object):
         if self.scope_ids.block_type != 'problem':
             raise AttributeError(".graded shim is only for capa")
         return False
+
+    # Attributes defined by XModuleMixin and sometimes used by the LMS
+    # Set sensible defaults.
+    # If any of these are meant to be used in new stuff (are not deprecated)
+    # they should be moved to xblock.runtime.mixin.LmsBlockMixin and documented
+    always_recalculate_grades = False
+    show_in_read_only_mode = False
+    icon_class = 'other'
+
+    def get_icon_class(self):
+        """
+        Return a css class identifying this module in the context of an icon
+        """
+        return self.icon_class
+
+    def has_dynamic_children(self):
+        """
+        Returns True if this XBlock has dynamic children for a given
+        student when the module is created. This is deprecated and discouraged.
+        """
+        return False
+
+    def get_display_items(self):
+        """
+        Returns a list of descendent XBlock instances that will display
+        immediately inside this module.
+        """
+        warnings.warn("get_display_items() is deprecated.", DeprecationWarning, stacklevel=2)
+        items = []
+        for child in self.get_children():
+            items.extend(child.displayable_items())
+        return items
+
+    def displayable_items(self):
+        """
+        Returns list of displayable modules contained by this XBlock. If this
+        module is visible, should return [self].
+        """
+        return [self]


### PR DESCRIPTION
If an XBlock doesn't declare `has_score = True/False`, then the new runtime was raising an exception when trying to save that block's user state.

```
  File "/edx/app/edxapp/edx-platform/openedx/core/djangoapps/xblock/runtime/blockstore_runtime.py", line 69, in get_block
    block.force_save_fields(block._get_fields_to_save())  # pylint: disable=protected-access
  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/xblock/mixins.py", line 270, in force_save_fields
    self._field_data.set_many(self, fields_to_save_json)
  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/xblock/mixins.py", line 235, in _field_data
    return self.runtime.service(self, 'field-data')
  File "/edx/app/edxapp/edx-platform/openedx/core/djangoapps/xblock/runtime/runtime.py", line 127, in service
    self.block_field_datas[block.scope_ids] = self._init_field_data_for_block(block)
  File "/edx/app/edxapp/edx-platform/openedx/core/djangoapps/xblock/runtime/runtime.py", line 165, in _init_field_data_for_block
    [block], course_id=context_key, user=self.user, asides=None, read_only=False,
  File "/edx/app/edxapp/edx-platform/lms/djangoapps/courseware/model_data.py", line 727, in __init__
    self.add_descriptors_to_cache(descriptors)
  File "/edx/app/edxapp/edx-platform/lms/djangoapps/courseware/model_data.py", line 734, in add_descriptors_to_cache
    self.scorable_locations.update(desc.location for desc in descriptors if desc.has_score)
  File "/edx/app/edxapp/edx-platform/lms/djangoapps/courseware/model_data.py", line 734, in <genexpr>
    self.scorable_locations.update(desc.location for desc in descriptors if desc.has_score)
AttributeError: 'ImageBlockWithMixins' object has no attribute 'has_score'
```

This fixes it by making sure that `has_score = False` is mixed in to all XBlocks in the new runtime, as it is in the current runtime.

I also added a few more attributes/methods from `XModuleMixin` to the compatibility shims in case they present similar issues.

Test instructions:
* Run the updated tests from either the LMS or Studio shell with
   ```
   EDXAPP_RUN_BLOCKSTORE_TESTS=1 python -Wd -m pytest --ds=cms.envs.test openedx/core/lib/blockstore_api/ openedx/core/djangolib/tests/test_blockstore_cache.py openedx/core/djangoapps/content_libraries/tests/ common/lib/xmodule/xmodule/tests/test_unit_block.py
   ```