### PR TITLE
fix variable in feature toggle script

### DIFF
--- a/scripts/generate-feature-toggle-annotation-report.sh
+++ b/scripts/generate-feature-toggle-annotation-report.sh
@@ -8,5 +8,5 @@
 pip install -r requirements/edx/paver.txt -r requirements/edx/testing.txt
 rm -Rf reports/*
 code_annotations static_find_annotations --config_file=../$CODE_ANNOTATION_CONFIG_PATH
-mkdir -p ../$CODE_ANNOTATION_OUTPUT_PATH
-cp reports/* ../$CODE_ANNOTATION_OUTPUT_PATH/lms-annotations.yml
+mkdir -p ../$SCRIPT_OUTPUT_PATH
+cp reports/* ../$SCRIPT_OUTPUT_PATH/lms-annotations.yml


### PR DESCRIPTION
The DSL for the `generate-prod-code-annotation-report` job didn't actually set the `CODE_ANNOTATION_OUTPUT_PATH` variable, so bash resolved it to empty, which still allowed the script to pass, but was not correct. Fixing it to use `SCRIPT_OUTPUT_PATH` which is actually defined in the DSL.

