### PR TITLE
Use edx-ui-toolkit for KeyCodes

### DIFF
--- a/lms/static/js/edxnotes/plugins/accessibility.js
+++ b/lms/static/js/edxnotes/plugins/accessibility.js
@@ -1,6 +1,11 @@
+/* eslint-disable */
 (function(define, undefined) {
     'use strict';
-    define(['jquery', 'underscore', 'annotator_1.2.9'], function($, _, Annotator) {
+    define(['jquery',
+            'underscore',
+            'annotator_1.2.9',
+            'edx-ui-toolkit/js/utils/constants',
+    ], function($, _, Annotator, Constants) {
     /**
      * Adds the Accessibility Plugin
      **/
@@ -50,7 +55,7 @@
                     class: 'edx-notes-focus-grabber',
                     tabindex: '-1'
                 });
-                this.annotator.wrapper.before(this.focusGrabber);
+                this.annotator.wrapper.before(this.focusGrabber); // xss-lint: disable=javascript-jquery-insertion
             },
 
             removeFocusGrabber: function() {
@@ -75,7 +80,7 @@
                     this.annotator.wrapper.after($('<div />', {
                         class: 'aria-note-description sr',
                         id: 'aria-note-description-' + id,
-                        text: Annotator.Util.escape(annotation.text)
+                        text: Annotator.Util.escape(annotation.text) // xss-lint: disable=javascript-escape
                     }));
 
                     $(annotation.highlights).attr({
@@ -192,13 +197,13 @@
             },
 
             onHighlightKeyDown: function(event) {
-                var KEY = $.ui.keyCode,
+                var key = Constants.keyCodes,
                     keyCode = event.keyCode,
                     $target = $(event.currentTarget),
                     annotation, position;
 
                 switch (keyCode) {
-                case KEY.TAB:
+                case key.tab:
                     // This happens only when coming from notes page
                     if (this.annotator.viewer.isShown()) {
                         this.annotator.element.find('.annotator-listing').focus();
@@ -206,8 +211,8 @@
                         event.stopPropagation();
                     }
                     break;
-                case KEY.ENTER:
-                case KEY.SPACE:
+                case key.enter:
+                case key.space:
                     if (!this.annotator.viewer.isShown()) {
                         position = $target.position();
                         this.showViewer(position, $target.data('annotation'));
@@ -215,7 +220,7 @@
                         event.stopPropagation();
                     }
                     break;
-                case KEY.ESCAPE:
+                case key.esc:
                     this.annotator.viewer.hide();
                     event.preventDefault();
                     event.stopPropagation();
@@ -224,14 +229,14 @@
             },
 
             onViewerKeyDown: function(event) {
-                var KEY = $.ui.keyCode,
+                var key = Constants.keyCodes,
                     keyCode = event.keyCode,
                     $target = $(event.target),
                     listing = this.annotator.element.find('.annotator-listing'),
                     tabControls;
 
                 switch (keyCode) {
-                case KEY.TAB:
+                case key.tab:
                     tabControls = this.getViewerTabControls();
                     if (event.shiftKey) { // Tabbing backwards
                         if ($target.is(listing)) {
@@ -249,15 +254,15 @@
                     event.preventDefault();
                     event.stopPropagation();
                     break;
-                case KEY.ENTER:
-                case KEY.SPACE:
+                case key.enter:
+                case key.space:
                     if ($target.hasClass('annotator-close')) {
                         this.onClose();
                         this.annotator.viewer.hide();
                         event.preventDefault();
                     }
                     break;
-                case KEY.ESCAPE:
+                case key.esc:
                     this.onClose();
                     this.annotator.viewer.hide();
                     event.preventDefault();
@@ -266,7 +271,7 @@
             },
 
             onEditorKeyDown: function(event) {
-                var KEY = $.ui.keyCode,
+                var key = Constants.keyCodes,
                     keyCode = event.keyCode,
                     $target = $(event.target),
                     editor, form, editorControls, save, cancel,
@@ -279,7 +284,7 @@
                 cancel = editorControls.find('.annotator-cancel');
 
                 switch (keyCode) {
-                case KEY.TAB:
+                case key.tab:
                     tabControls = this.getEditorTabControls();
                     if (event.shiftKey) { // Tabbing backwards
                         if ($target.is(form)) {
@@ -297,7 +302,7 @@
                     event.preventDefault();
                     event.stopPropagation();
                     break;
-                case KEY.ENTER:
+                case key.enter:
                     if ($target.is(save) || event.metaKey || event.ctrlKey) {
                         this.onClose();
                         this.annotator.editor.submit();
@@ -309,7 +314,7 @@
                     }
                     event.preventDefault();
                     break;
-                case KEY.SPACE:
+                case key.space:
                     if ($target.is(save)) {
                         this.onClose();
                         this.annotator.editor.submit();
@@ -321,7 +326,7 @@
                     }
                     event.preventDefault();
                     break;
-                case KEY.ESCAPE:
+                case key.esc:
                     this.onClose();
                     this.annotator.editor.hide();
                     event.preventDefault();


### PR DESCRIPTION
using jQuery.ui gives the following error
``` 
Uncaught TypeError: Cannot read property 'keyCode' of undefined
    at n.Plugin.Accessibility.onEditorKeyDown (notes_visibility_factory.c0cd10d10d82.js?raw:14)
    at HTMLDivElement.dispatch (lms-base-vendor.188b06b0a06d.js:2)
    at HTMLDivElement.elemData.handle (lms-base-vendor.188b06b0a06d.js:2)
    at HTMLDivElement.nrWrapper ((index):15)
```
Shifting to use edx-ui-toolkit constants to check for keycodes
[PROD-687](https://openedx.atlassian.net/browse/PROD-687)