### PR TITLE
EDUCATOR-4670 - pr 1 - remove usage of persistsubsectionoride history

### DIFF
--- a/lms/djangoapps/grades/api.py
+++ b/lms/djangoapps/grades/api.py
@@ -110,7 +110,7 @@ def undo_override_subsection_grade(user_id, course_key_or_id, usage_key_or_id, f
 
     if override is not None and (
             not feature or not override.system or feature == override.system):
-        override.delete(feature=feature)
+        override.delete()
     else:
         return
 

--- a/lms/djangoapps/grades/rest_api/v1/tests/test_gradebook_views.py
+++ b/lms/djangoapps/grades/rest_api/v1/tests/test_gradebook_views.py
@@ -29,7 +29,6 @@ from lms.djangoapps.grades.models import (
     BlockRecordList,
     PersistentSubsectionGrade,
     PersistentSubsectionGradeOverride,
-    PersistentSubsectionGradeOverrideHistory,
     PersistentCourseGrade,
 )
 from lms.djangoapps.grades.rest_api.v1.tests.mixins import GradeViewTestMixin
@@ -1580,14 +1579,6 @@ class GradebookBulkUpdateViewTest(GradebookViewTestBase):
                 for field_name in expected_grades._fields:
                     expected_value = getattr(expected_grades, field_name)
                     self.assertEqual(expected_value, getattr(grade, field_name))
-
-            update_records = PersistentSubsectionGradeOverrideHistory.objects.filter(user=request_user)
-            self.assertEqual(update_records.count(), 3)
-            for audit_item in update_records:
-                self.assertEqual(audit_item.user, request_user)
-                self.assertIsNotNone(audit_item.created)
-                self.assertEqual(audit_item.feature, GradeOverrideFeatureEnum.gradebook)
-                self.assertEqual(audit_item.action, PersistentSubsectionGradeOverrideHistory.CREATE_OR_UPDATE)
 
     def test_update_failing_grade(self):
         """

--- a/lms/djangoapps/grades/tests/test_models.py
+++ b/lms/djangoapps/grades/tests/test_models.py
@@ -28,7 +28,6 @@ from lms.djangoapps.grades.models import (
     PersistentCourseGrade,
     PersistentSubsectionGrade,
     PersistentSubsectionGradeOverride,
-    PersistentSubsectionGradeOverrideHistory,
     VisibleBlocks
 )
 from student.tests.factories import UserFactory
@@ -326,9 +325,6 @@ class PersistentSubsectionGradeTest(GradesModelTestCase):
         self.assertEqual(0, override.earned_graded_override)
         self.assertEqual(grade.possible_all, override.possible_all_override)
         self.assertEqual(grade.possible_graded, override.possible_graded_override)
-
-        # An override history record should be created
-        self.assertEqual(1, PersistentSubsectionGradeOverrideHistory.objects.filter(override_id=override.id).count())
 
     def _assert_tracker_emitted_event(self, tracker_mock, grade):
         """

--- a/lms/djangoapps/grades/tests/test_services.py
+++ b/lms/djangoapps/grades/tests/test_services.py
@@ -14,8 +14,7 @@ from mock import call, patch
 from lms.djangoapps.grades.constants import GradeOverrideFeatureEnum
 from lms.djangoapps.grades.models import (
     PersistentSubsectionGrade,
-    PersistentSubsectionGradeOverride,
-    PersistentSubsectionGradeOverrideHistory
+    PersistentSubsectionGradeOverride
 )
 from lms.djangoapps.grades.services import GradesService
 from student.tests.factories import UserFactory
@@ -148,12 +147,6 @@ class GradesServiceTests(ModuleStoreTestCase):
             'earned_graded_override': override.earned_graded_override
         })
 
-    def _verify_override_history(self, override_history, history_action):
-        self.assertIsNone(override_history.user)
-        self.assertIsNotNone(override_history.created)
-        self.assertEqual(override_history.feature, GradeOverrideFeatureEnum.proctoring)
-        self.assertEqual(override_history.action, history_action)
-
     @ddt.data(
         {
             'earned_all': 0.0,
@@ -203,8 +196,6 @@ class GradesServiceTests(ModuleStoreTestCase):
                 score_db_table=ScoreDatabaseTableEnum.overrides
             )
         )
-        override_history = PersistentSubsectionGradeOverrideHistory.objects.filter(override_id=override_obj.id).first()
-        self._verify_override_history(override_history, PersistentSubsectionGradeOverrideHistory.CREATE_OR_UPDATE)
 
     def test_override_subsection_grade_no_psg(self):
         """
@@ -254,8 +245,6 @@ class GradesServiceTests(ModuleStoreTestCase):
                 score_db_table=ScoreDatabaseTableEnum.overrides
             )
         )
-        override_history = PersistentSubsectionGradeOverrideHistory.objects.filter(override_id=override_obj.id).first()
-        self._verify_override_history(override_history, PersistentSubsectionGradeOverrideHistory.CREATE_OR_UPDATE)
 
     @freeze_time('2017-01-01')
     def test_undo_override_subsection_grade(self):
@@ -286,8 +275,6 @@ class GradesServiceTests(ModuleStoreTestCase):
                 score_db_table=ScoreDatabaseTableEnum.overrides
             )
         )
-        override_history = PersistentSubsectionGradeOverrideHistory.objects.filter(override_id=override_id).first()
-        self._verify_override_history(override_history, PersistentSubsectionGradeOverrideHistory.DELETE)
 
     def test_undo_override_subsection_grade_across_features(self):
         """


### PR DESCRIPTION
https://openedx.atlassian.net/browse/EDUCATOR-4670

Since we added Django simple history for persistencesubsectiongradeoverride table, we need to remove the table used for manual history. 
This is a first pr that removes the usage of this table. The following pr will drop the model.
