### PR TITLE
ENT-2294 | Moving utility functions in program enrollments to places …

### DIFF
--- a/lms/djangoapps/bulk_email/api.py
+++ b/lms/djangoapps/bulk_email/api.py
@@ -11,3 +11,20 @@ from bulk_email.models_api import (
     is_bulk_email_feature_enabled,
     is_user_opted_out_for_course
 )
+
+
+def get_emails_enabled(user, course_id):
+    """
+    Get whether or not emails are enabled in the context of a course.
+
+    Arguments:
+        user: the user object for which we want to check whether emails are enabled
+        course_id (string): the course id of the course
+
+    Returns:
+        (bool): True if emails are enabled for the course associated with course_id for the user;
+        False otherwise
+    """
+    if is_bulk_email_feature_enabled(course_id=course_id):
+        return not is_user_opted_out_for_course(user=user, course_id=course_id)
+    return None

--- a/lms/djangoapps/course_api/api.py
+++ b/lms/djangoapps/course_api/api.py
@@ -4,8 +4,10 @@ Course API
 
 from __future__ import absolute_import
 
+from edx_when.api import get_dates_for_course
 from django.conf import settings
 from django.contrib.auth.models import AnonymousUser, User
+from django.urls import reverse
 from rest_framework.exceptions import PermissionDenied
 import search
 import six
@@ -17,6 +19,7 @@ from lms.djangoapps.courseware.courses import (
     get_permission_for_course_about
 )
 from openedx.core.lib.api.view_utils import LazySequence
+from xmodule.modulestore.django import modulestore
 
 from .permissions import can_view_courses_for_username
 
@@ -148,3 +151,58 @@ def list_courses(request, username, org=None, roles=None, filter_=None, search_t
     course_qs = _filter_by_role(course_qs, user, roles)
     course_qs = _filter_by_search(course_qs, search_term)
     return course_qs
+
+
+def get_due_dates(request, course_key, user):
+    """
+    Get due date information for a user for blocks in a course.
+
+    Arguments:
+        request: the request object
+        course_key (CourseKey): the CourseKey for the course
+        user: the user object for which we want due date information
+
+    Returns:
+        due_dates (list): a list of dictionaries containing due date information
+            keys:
+                name: the display name of the block
+                url: the deep link to the block
+                date: the due date for the block
+    """
+    dates = get_dates_for_course(
+        course_key,
+        user,
+    )
+
+    store = modulestore()
+
+    due_dates = []
+    for (block_key, date_type), date in six.iteritems(dates):
+        if date_type == 'due':
+            block = store.get_item(block_key)
+
+            # get url to the block in the course
+            block_url = reverse('jump_to', args=[course_key, block_key])
+            block_url = request.build_absolute_uri(block_url)
+
+            due_dates.append({
+                'name': block.display_name,
+                'url': block_url,
+                'date': date,
+            })
+    return due_dates
+
+
+def get_course_run_url(request, course_id):
+    """
+    Get the URL to a course run.
+
+    Arguments:
+        request: the request object
+        course_id (string): the course id of the course
+
+    Returns:
+        (string): the URL to the course run associated with course_id
+    """
+    course_run_url = reverse('openedx.course_experience.course_home', args=[course_id])
+    return request.build_absolute_uri(course_run_url)

--- a/lms/djangoapps/program_enrollments/api/api.py
+++ b/lms/djangoapps/program_enrollments/api/api.py
@@ -10,9 +10,9 @@ away in https://openedx.atlassian.net/browse/ENT-2294
 """
 from __future__ import absolute_import, unicode_literals
 
-from lms.djangoapps.program_enrollments.rest_api.v1.utils import get_course_run_url as get_course_run_url_util
-from lms.djangoapps.program_enrollments.rest_api.v1.utils import get_due_dates as get_due_dates_util
-from lms.djangoapps.program_enrollments.rest_api.v1.utils import get_emails_enabled as get_emails_enabled_util
+from lms.djangoapps.course_api.api import get_course_run_url as get_course_run_url_util
+from lms.djangoapps.course_api.api import get_due_dates as get_due_dates_util
+from lms.djangoapps.bulk_email.api import get_emails_enabled as get_emails_enabled_util
 
 
 def get_due_dates(request, course_key, user):

--- a/lms/djangoapps/program_enrollments/rest_api/v1/tests/test_views.py
+++ b/lms/djangoapps/program_enrollments/rest_api/v1/tests/test_views.py
@@ -1717,7 +1717,7 @@ class ProgramCourseEnrollmentOverviewGetTests(
             display_name='unit_1'
         )
 
-        mock_path = _REST_API_MOCK_FMT.format('v1.utils.get_dates_for_course')
+        mock_path = _REST_API_MOCK_FMT.format('lms.djangoapps.course_api.api.get_dates_for_course')
         with mock.patch(mock_path) as mock_get_dates:
             mock_get_dates.return_value = {
                 (section_1.location, 'due'): section_1.due,

--- a/lms/djangoapps/program_enrollments/rest_api/v1/tests/test_views.py
+++ b/lms/djangoapps/program_enrollments/rest_api/v1/tests/test_views.py
@@ -1717,7 +1717,7 @@ class ProgramCourseEnrollmentOverviewGetTests(
             display_name='unit_1'
         )
 
-        mock_path = _REST_API_MOCK_FMT.format('lms.djangoapps.course_api.api.get_dates_for_course')
+        mock_path = 'lms.djangoapps.course_api.api.get_dates_for_course'
         with mock.patch(mock_path) as mock_get_dates:
             mock_get_dates.return_value = {
                 (section_1.location, 'due'): section_1.due,

--- a/lms/djangoapps/program_enrollments/rest_api/v1/utils.py
+++ b/lms/djangoapps/program_enrollments/rest_api/v1/utils.py
@@ -7,19 +7,15 @@ from __future__ import absolute_import, unicode_literals
 from datetime import datetime, timedelta
 from functools import wraps
 
-from django.urls import reverse
 from django.utils.functional import cached_property
-from edx_when.api import get_dates_for_course
 from opaque_keys.edx.keys import CourseKey
 from pytz import UTC
 from rest_framework import status
-from six import iteritems
 
 from bulk_email.api import is_bulk_email_feature_enabled, is_user_opted_out_for_course
 from lms.djangoapps.grades.rest_api.v1.utils import CourseEnrollmentPagination
 from openedx.core.djangoapps.catalog.utils import get_programs, is_course_run_in_program
 from openedx.core.lib.api.view_utils import verify_course_exists
-from xmodule.modulestore.django import modulestore
 
 from .constants import CourseRunProgressStatuses
 
@@ -118,78 +114,6 @@ def verify_course_exists_and_in_program(view_func):
             )
         return view_func(self, request, **kwargs)
     return wrapped_function
-
-
-def get_due_dates(request, course_key, user):
-    """
-    Get due date information for a user for blocks in a course.
-
-    Arguments:
-        request: the request object
-        course_key (CourseKey): the CourseKey for the course
-        user: the user object for which we want due date information
-
-    Returns:
-        due_dates (list): a list of dictionaries containing due date information
-            keys:
-                name: the display name of the block
-                url: the deep link to the block
-                date: the due date for the block
-    """
-    dates = get_dates_for_course(
-        course_key,
-        user,
-    )
-
-    store = modulestore()
-
-    due_dates = []
-    for (block_key, date_type), date in iteritems(dates):
-        if date_type == 'due':
-            block = store.get_item(block_key)
-
-            # get url to the block in the course
-            block_url = reverse('jump_to', args=[course_key, block_key])
-            block_url = request.build_absolute_uri(block_url)
-
-            due_dates.append({
-                'name': block.display_name,
-                'url': block_url,
-                'date': date,
-            })
-    return due_dates
-
-
-def get_course_run_url(request, course_id):
-    """
-    Get the URL to a course run.
-
-    Arguments:
-        request: the request object
-        course_id (string): the course id of the course
-
-    Returns:
-        (string): the URL to the course run associated with course_id
-    """
-    course_run_url = reverse('openedx.course_experience.course_home', args=[course_id])
-    return request.build_absolute_uri(course_run_url)
-
-
-def get_emails_enabled(user, course_id):
-    """
-    Get whether or not emails are enabled in the context of a course.
-
-    Arguments:
-        user: the user object for which we want to check whether emails are enabled
-        course_id (string): the course id of the course
-
-    Returns:
-        (bool): True if emails are enabled for the course associated with course_id for the user;
-        False otherwise
-    """
-    if is_bulk_email_feature_enabled(course_id=course_id):
-        return not is_user_opted_out_for_course(user=user, course_id=course_id)
-    return None
 
 
 def get_course_run_status(course_overview, certificate_info):

--- a/lms/djangoapps/program_enrollments/rest_api/v1/views.py
+++ b/lms/djangoapps/program_enrollments/rest_api/v1/views.py
@@ -24,7 +24,9 @@ from rest_framework.views import APIView
 from six import text_type
 
 from course_modes.models import CourseMode
+from lms.djangoapps.bulk_email.api import get_emails_enabled
 from lms.djangoapps.certificates.api import get_certificate_for_user
+from lms.djangoapps.course_api.api import get_course_run_url, get_due_dates
 from lms.djangoapps.grades.api import CourseGradeFactory, clear_prefetched_course_grades, prefetch_course_grades
 from lms.djangoapps.program_enrollments.api import (
     fetch_program_course_enrollments,
@@ -75,9 +77,6 @@ from .utils import (
     ProgramEnrollmentPagination,
     ProgramSpecificViewMixin,
     get_course_run_status,
-    get_course_run_url,
-    get_due_dates,
-    get_emails_enabled,
     verify_course_exists_and_in_program,
     verify_program_exists
 )


### PR DESCRIPTION
…related to the data they manipulate

../program_enrollments/api/api.py currently has some wrapper functions to allow backwards compatibility with edx-enterprise. I've updated those wrappers to use the new locations of the utils functions I've moved. I will update edx-enterprise to use the new locations, and will create a subsequent PR here in edx-platform to bump the version of edx-enterprise as well as remove these wrapper functions.

### Please consider the following when opening a pull request:

- Link to the relevant JIRA ticket(s) and tag any relevant team(s).
- Squash your changes down into one or more discrete commits.
  In each commit, include description that could help a developer
  several months from now.
- If running `make upgrade`, run _as close to the time of merging as possible_
  to avoid accidentally downgrading someone else's package.
  Put the output of `make upgrade` in its own separate commit,
  decoupled from other code changes.
- Aim for comprehensive test coverage, but remember that
  automated testing isn't a substitute for manual verification.
- Carefully consider naming, code organization, dependencies when adding new code.
  Code that is amenable to refactoring and improvement benefits all platform developers,
  especially given the size and scope of edx-platform.
  Consult existing Architectural Decision Records (ADRs),
  including those concerning the app(s) you are changing and
  [those concerning edx-platform as a whole](https://github.com/edx/edx-platform/tree/master/docs/decisions).
