### PR TITLE
DjangoTranslation object doesn't have ugettext attribute

### DIFF
--- a/cms/djangoapps/contentstore/tests/test_i18n.py
+++ b/cms/djangoapps/contentstore/tests/test_i18n.py
@@ -9,7 +9,7 @@ from unittest import skip
 
 import mock
 from django.contrib.auth.models import User
-from django.utils import translation
+from django.utils import six, translation
 from django.utils.translation import get_language
 
 from contentstore.tests.utils import AjaxEnabledTestClient
@@ -94,17 +94,21 @@ class TestModuleI18nService(ModuleStoreTestCase):
 
             def __init__(self, module):
                 self.module = module
-                self.old_ugettext = module.ugettext
+                gettext_variant = 'ugettext' if six.PY2 else 'gettext'
+                self.old_ugettext = getattr(module, gettext_variant)
 
             def __enter__(self):
                 def new_ugettext(*args, **kwargs):
                     """ custom function """
                     output = self.old_ugettext(*args, **kwargs)
                     return "XYZ " + output
-                self.module.ugettext = new_ugettext
+
+                gettext_variant = 'ugettext' if six.PY2 else 'gettext'
+                setattr(self.module, gettext_variant, new_ugettext)
 
             def __exit__(self, _type, _value, _traceback):
-                self.module.ugettext = self.old_ugettext
+                gettext_variant = 'ugettext' if six.PY2 else 'gettext'
+                setattr(self.module, gettext_variant, self.old_ugettext)
 
         i18n_service = self.get_module_i18n_service(self.descriptor)
 


### PR DESCRIPTION
## [PROD-664](https://openedx.atlassian.net/browse/PROD-664)

### Description

Some of the tests are failing because DjangoTranslation object is behaving differently with py2 and py3.With py2, it has 'ugettext' attribute but with py3 it doesn't have.To make it compliant with
both versions modifications in the tests have been added so that build will not fail.