### PR TITLE
Fix CSV writing in test BOM-639

### DIFF
--- a/openedx/core/djangoapps/user_api/management/tests/test_bulk_user_org_email_optout.py
+++ b/openedx/core/djangoapps/user_api/management/tests/test_bulk_user_org_email_optout.py
@@ -3,6 +3,7 @@ Test the test_bulk_user_org_email_optout management command
 """
 from __future__ import absolute_import
 
+import io
 import os
 import tempfile
 from contextlib import contextmanager
@@ -14,7 +15,7 @@ from django.core.management import call_command
 pytestmark = pytest.mark.django_db
 
 
-CSV_DATA = """1,UniversityX
+CSV_DATA = u"""1,UniversityX
 2,CollegeX
 3,StateUX
 """
@@ -26,8 +27,8 @@ def _create_test_csv(csv_data):
     Context manager to create and populate a CSV file - and delete it after usage.
     """
     __, file_name = tempfile.mkstemp(text=True)
-    with open(file_name, 'w') as file_pointer:
-        file_pointer.write(csv_data.encode('utf-8'))
+    with io.open(file_name, 'w') as file_pointer:
+        file_pointer.write(csv_data)
     try:
         yield file_name
     finally:


### PR DESCRIPTION
Make the CSV writing work identically under Python 2.7 and 3.