### PR TITLE
NullTranslations object doesn't have ugettext attribute

### DIFF
--- a/cms/djangoapps/contentstore/tests/test_i18n.py
+++ b/cms/djangoapps/contentstore/tests/test_i18n.py
@@ -12,9 +12,9 @@ from django.contrib.auth.models import User
 from django.utils import translation
 from django.utils.translation import get_language
 
-from openedx.core.lib.edx_six import get_gettext
 from contentstore.tests.utils import AjaxEnabledTestClient
 from contentstore.views.preview import _preview_module_system
+from openedx.core.lib.edx_six import get_gettext
 from xmodule.modulestore.django import ModuleI18nService
 from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
 from xmodule.modulestore.tests.factories import CourseFactory, ItemFactory


### PR DESCRIPTION
## [PROD-663](https://openedx.atlassian.net/browse/PROD-663)

### Description

Some of the tests are failing because NullTranslations object is behaving differently with py2 and py3.With py2, it has 'ugettext' attribute but with py3 it doesn't have.To make it compliant with
both versions modifications in the tests have been added so that build will not fail.