### PR TITLE
ENT-2268: Added signal handler for COURSE_GRADE_NOW_PASSED

### DIFF
--- a/lms/djangoapps/certificates/signals.py
+++ b/lms/djangoapps/certificates/signals.py
@@ -62,7 +62,7 @@ def _listen_for_certificate_whitelist_append(sender, instance, **kwargs):  # pyl
 
 
 @receiver(COURSE_GRADE_NOW_PASSED, dispatch_uid="new_passing_learner")
-def _listen_for_passing_grade(sender, user, course_id, **kwargs):  # pylint: disable=unused-argument
+def listen_for_passing_grade(sender, user, course_id, **kwargs):  # pylint: disable=unused-argument
     """
     Listen for a learner passing a course, send cert generation task,
     downstream signal from COURSE_GRADE_CHANGED

--- a/lms/djangoapps/grades/tests/test_course_grade_factory.py
+++ b/lms/djangoapps/grades/tests/test_course_grade_factory.py
@@ -100,21 +100,21 @@ class TestCourseGradeFactory(GradeTestBase):
         with self.assertNumQueries(4), mock_get_score(1, 2):
             _assert_read(expected_pass=False, expected_percent=0)  # start off with grade of 0
 
-        num_queries = 47
+        num_queries = 51
         with self.assertNumQueries(num_queries), mock_get_score(1, 2):
             grade_factory.update(self.request.user, self.course, force_update_subsections=True)
 
         with self.assertNumQueries(5):
             _assert_read(expected_pass=True, expected_percent=0.5)  # updated to grade of .5
 
-        num_queries = 9
+        num_queries = 13
         with self.assertNumQueries(num_queries), mock_get_score(1, 4):
             grade_factory.update(self.request.user, self.course, force_update_subsections=False)
 
         with self.assertNumQueries(5):
             _assert_read(expected_pass=True, expected_percent=0.5)  # NOT updated to grade of .25
 
-        num_queries = 26
+        num_queries = 30
         with self.assertNumQueries(num_queries), mock_get_score(2, 2):
             grade_factory.update(self.request.user, self.course, force_update_subsections=True)
 

--- a/openedx/features/enterprise_support/tests/test_signals.py
+++ b/openedx/features/enterprise_support/tests/test_signals.py
@@ -10,6 +10,7 @@ from mock import patch
 from edx_django_utils.cache import TieredCache
 from opaque_keys.edx.keys import CourseKey
 
+from lms.djangoapps.certificates.signals import listen_for_passing_grade
 from student.tests.factories import UserFactory
 from openedx.core.djangoapps.signals.signals import COURSE_GRADE_NOW_PASSED
 from openedx.features.enterprise_support.tests.factories import (
@@ -125,3 +126,4 @@ class EnterpriseSupportSignals(TestCase):
                 'course_run_id': self.course_id
             }
             mock_task_apply.assert_called_once_with(kwargs=task_kwargs)
+            COURSE_GRADE_NOW_PASSED.connect(listen_for_passing_grade, dispatch_uid='new_passing_learner')

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -106,7 +106,7 @@ edx-django-release-util==0.3.1
 edx-django-sites-extensions==2.3.1
 edx-django-utils==2.0.0
 edx-drf-extensions==2.4.0
-edx-enterprise==1.10.4
+edx-enterprise==1.10.7
 edx-i18n-tools==0.4.8
 edx-milestones==0.2.3
 edx-oauth2-provider==1.3.1

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -129,7 +129,7 @@ edx-django-release-util==0.3.1
 edx-django-sites-extensions==2.3.1
 edx-django-utils==2.0.0
 edx-drf-extensions==2.4.0
-edx-enterprise==1.10.4
+edx-enterprise==1.10.7
 edx-i18n-tools==0.4.8
 edx-lint==1.3.0
 edx-milestones==0.2.3

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -125,7 +125,7 @@ edx-django-release-util==0.3.1
 edx-django-sites-extensions==2.3.1
 edx-django-utils==2.0.0
 edx-drf-extensions==2.4.0
-edx-enterprise==1.10.4
+edx-enterprise==1.10.7
 edx-i18n-tools==0.4.8
 edx-lint==1.3.0
 edx-milestones==0.2.3


### PR DESCRIPTION
Added signal handler for COURSE_GRADE_NOW_PASSED to trigger single learner data [transmission task](https://github.com/edx/edx-enterprise/blob/d7f9128668fe0075c87f1d96043b2d03aeb9410b/integrated_channels/integrated_channel/tasks.py#L82) in edx-enterprise.

### Please consider the following when opening a pull request:

- Link to the relevant JIRA ticket(s) and tag any relevant team(s).
- Squash your changes down into one or more discrete commits.
  In each commit, include description that could help a developer
  several months from now.
- If running `make upgrade`, run _as close to the time of merging as possible_
  to avoid accidentally downgrading someone else's package.
  Put the output of `make upgrade` in its own separate commit,
  decoupled from other code changes.
- Aim for comprehensive test coverage, but remember that
  automated testing isn't a substitute for manual verification.
- Carefully consider naming, code organization, dependencies when adding new code.
  Code that is amenable to refactoring and improvement benefits all platform developers,
  especially given the size and scope of edx-platform.
  Consult existing Architectural Decision Records (ADRs),
  including those concerning the app(s) you are changing and
  [those concerning edx-platform as a whole](https://github.com/edx/edx-platform/tree/master/docs/decisions).
