### PR TITLE
BOM-614: AssertionError: Lists differ Fix 1

### DIFF
--- a/common/lib/capa/capa/tests/test_shuffle.py
+++ b/common/lib/capa/capa/tests/test_shuffle.py
@@ -3,6 +3,7 @@ from __future__ import absolute_import, print_function
 
 import textwrap
 import unittest
+import six
 
 from capa.responsetypes import LoncapaProblemError
 from capa.tests.helpers import new_loncapa_problem, test_capa_system
@@ -58,7 +59,10 @@ class CapaShuffleTest(unittest.TestCase):
         response = list(problem.responders.values())[0]
         self.assertFalse(response.has_mask())
         self.assertTrue(response.has_shuffle())
-        self.assertEqual(response.unmask_order(), ['choice_0', 'choice_aaa', 'choice_1', 'choice_ddd'])
+        if six.PY2:
+            self.assertEqual(response.unmask_order(), ['choice_0', 'choice_aaa', 'choice_1', 'choice_ddd'])
+        else:
+            self.assertEqual(response.unmask_order(), ['choice_1', 'choice_aaa', 'choice_0', 'choice_ddd'])
 
     def test_shuffle_different_seed(self):
         xml_str = textwrap.dedent("""


### PR DESCRIPTION
There are 4 places this error occurs:

Fixing: AssertionError: Lists differ: ['choice_1', 'choice_aaa', 'choice_0', 'choice_ddd'] != ['choice_0', 'choice_aaa', 'choice_1', 'choice_ddd']

Underlying code or MultipleChoice problem is using random.shuffle to shuffle the answers displayed to user. Random.shuffle outputs can be different for between python 2.7 and python 3.5. The change here asserts different random output(based on set seed) for each version of python.