### PR TITLE
fix course import issue

### DIFF
--- a/cms/djangoapps/contentstore/tasks.py
+++ b/cms/djangoapps/contentstore/tasks.py
@@ -12,7 +12,6 @@ from datetime import datetime
 from math import ceil
 from tempfile import NamedTemporaryFile, mkdtemp
 
-import six
 from celery import group
 from celery.task import task
 from celery.utils.log import get_task_logger
@@ -750,8 +749,8 @@ def import_olx(self, user_id, course_key_string, archive_path, archive_name, lan
     # Locate the uploaded OLX archive (and download it from S3 if necessary)
     # Do everything in a try-except block to make sure everything is properly cleaned up.
     data_root = path(settings.GITHUB_REPO_ROOT)
-    subdir = base64.urlsafe_b64encode(six.b(repr(courselike_key)))
-    course_dir = data_root / subdir.decode('utf-8')
+    subdir = base64.urlsafe_b64encode(repr(courselike_key))
+    course_dir = data_root / subdir
     try:
         self.status.set_state(u'Unpacking')
 

--- a/openedx/core/lib/extract_tar.py
+++ b/openedx/core/lib/extract_tar.py
@@ -73,4 +73,5 @@ def safetar_extractall(tar_file, path=".", members=None):  # pylint: disable=unu
     """
     Safe version of `tar_file.extractall()`.
     """
+    path = str(path)
     return tar_file.extractall(path, safemembers(tar_file, path))


### PR DESCRIPTION
https://openedx.atlassian.net/browse/PROD-720

This PR doesn't exactly revert https://github.com/edx/edx-platform/pull/21679.  It replaces the use of `encode("utf-8")` with `str()` as what we really want is to have a path of type str rather unicode. (in openedx/core/lib/extract_tar.py)

We would be looking to add unit test later as we need to unblock course team now.

Sandbox: https://studio-import.sandbox.edx.org