### PR TITLE
BOM-614: AssertionError: Lists differ Fix 2 and 3

### DIFF
--- a/common/djangoapps/pipeline_mako/tests/test_render.py
+++ b/common/djangoapps/pipeline_mako/tests/test_render.py
@@ -39,7 +39,7 @@ class RequireJSPathOverridesTest(TestCase):
     def test_requirejs_path_overrides(self):
         result = render_require_js_path_overrides(self.OVERRIDES)
         # To make the string comparision easy remove the whitespaces
-        self.assertEqual(list(map(str.strip, result.splitlines())), self.OVERRIDES_JS)
+        self.assertCountEqual(list(map(str.strip, result.splitlines())), self.OVERRIDES_JS)
 
 
 @skipUnless(settings.ROOT_URLCONF == 'lms.urls', 'Test only valid in LMS')


### PR DESCRIPTION
There are 3 places this error occurs, there are two related fixes in this repo:

Fixing: AssertionError: Lists differ: ['<sc[85 chars]', "'text': 'js/vendor/text',", "'jquery': 'co[136 chars]pt>'] != ['<sc[85 chars]', "'jquery': 'common/j…

and Fixing:  AssertionError: Lists differ: [['1'], ['name_with_icon']] != [['name_with_icon'], ['1']] First differing element 0: ['1'] ['name_with_icon'] - [['1…

Since the asserted equal items are created by iterating through a dict, the resulting list is ordered differently due to differences between how dicts are ordered in python 2.7 and 3.5. The commit changes sorts the lists before running assertEqual.
