### PR TITLE
Fix CorruptGridFile in Python 3 tests BOM-375

### DIFF
--- a/cms/djangoapps/contentstore/tests/test_contentstore.py
+++ b/cms/djangoapps/contentstore/tests/test_contentstore.py
@@ -149,7 +149,7 @@ class ImportRequiredTestCases(ContentStoreTestCase):
         # asset in the course. (i.e. _invalid_displayname_subs-esLhHcdKGWvKs.srt)
         asset_key = course.id.make_asset_key('asset', 'sample_asset.srt')
         content = StaticContent(
-            asset_key, expected_displayname, 'application/text', 'test',
+            asset_key, expected_displayname, 'application/text', b'test',
         )
         content_store.save(content)
 
@@ -159,7 +159,7 @@ class ImportRequiredTestCases(ContentStoreTestCase):
 
         # Verify both assets have similar `displayname` after saving.
         for asset in assets:
-            self.assertEquals(asset['displayname'], expected_displayname)
+            self.assertEqual(asset['displayname'], expected_displayname)
 
         # Test course export does not fail
         root_dir = path(mkdtemp_clean())
@@ -500,7 +500,7 @@ class ImportRequiredTestCases(ContentStoreTestCase):
         # Create a module, and ensure that its `data` field is empty
         word_cloud = ItemFactory.create(parent_location=parent.location, category="word_cloud", display_name="untitled")
         del word_cloud.data
-        self.assertEquals(word_cloud.data, '')
+        self.assertEqual(word_cloud.data, '')
 
         # Export the course
         root_dir = path(mkdtemp_clean())
@@ -511,7 +511,7 @@ class ImportRequiredTestCases(ContentStoreTestCase):
         imported_word_cloud = self.store.get_item(course_id.make_usage_key('word_cloud', 'untitled'))
 
         # It should now contain empty data
-        self.assertEquals(imported_word_cloud.data, '')
+        self.assertEqual(imported_word_cloud.data, '')
 
     def test_html_export_roundtrip(self):
         """
@@ -708,7 +708,7 @@ class MiscCourseTests(ContentStoreTestCase):
         # Create an asset with slash `invalid_displayname` '
         asset_key = self.course.id.make_asset_key('asset', "fake_asset.txt")
         content = StaticContent(
-            asset_key, invalid_displayname, 'application/text', 'test',
+            asset_key, invalid_displayname, 'application/text', b'test',
         )
         content_store.save(content)
 
@@ -766,7 +766,7 @@ class MiscCourseTests(ContentStoreTestCase):
             asset_path = 'sample_asset_{}.txt'.format(i)
             asset_key = self.course.id.make_asset_key('asset', asset_path)
             content = StaticContent(
-                asset_key, asset_displayname, 'application/text', 'test',
+                asset_key, asset_displayname, 'application/text', b'test',
             )
             content_store.save(content)
 
@@ -776,7 +776,7 @@ class MiscCourseTests(ContentStoreTestCase):
 
         # Verify both assets have similar 'displayname' after saving.
         for asset in assets:
-            self.assertEquals(asset['displayname'], asset_displayname)
+            self.assertEqual(asset['displayname'], asset_displayname)
 
         # Now export the course to a tempdir and test that it contains assets.
         root_dir = path(mkdtemp_clean())
@@ -1000,7 +1000,7 @@ class MiscCourseTests(ContentStoreTestCase):
         """
         asset_key = self.course.id.make_asset_key('asset', 'sample_static.html')
         content = StaticContent(
-            asset_key, "Fake asset", "application/text", "test",
+            asset_key, "Fake asset", "application/text", b"test",
         )
         contentstore().save(content)
 
@@ -1082,7 +1082,7 @@ class MiscCourseTests(ContentStoreTestCase):
         # add an asset
         asset_key = self.course.id.make_asset_key('asset', 'sample_static.html')
         content = StaticContent(
-            asset_key, "Fake asset", "application/text", "test",
+            asset_key, "Fake asset", "application/text", b"test",
         )
         contentstore().save(content)
         assets, count = contentstore().get_all_content_for_course(self.course.id)
@@ -1207,7 +1207,7 @@ class ContentStoreTest(ContentStoreTestCase):
         test_course_data = self.assert_created_course()
         course_id = _get_course_id(self.store, test_course_data)
         course_module = self.store.get_course(course_id)
-        self.assertEquals(course_module.language, 'hr')
+        self.assertEqual(course_module.language, 'hr')
 
     def test_create_course_with_dots(self):
         """Test new course creation with dots in the name"""
@@ -1640,7 +1640,7 @@ class ContentStoreTest(ContentStoreTestCase):
         # Import a course with wiki_slug == location.course
         import_course_from_xml(self.store, self.user.id, TEST_DATA_DIR, ['toy'], target_id=target_id)
         course_module = self.store.get_course(target_id)
-        self.assertEquals(course_module.wiki_slug, 'toy')
+        self.assertEqual(course_module.wiki_slug, 'toy')
 
         # But change the wiki_slug if it is a different course.
         target_id = self.store.make_course_key('MITx', '111', '2013_Spring')
@@ -1655,12 +1655,12 @@ class ContentStoreTest(ContentStoreTestCase):
         # Import a course with wiki_slug == location.course
         import_course_from_xml(self.store, self.user.id, TEST_DATA_DIR, ['toy'], target_id=target_id)
         course_module = self.store.get_course(target_id)
-        self.assertEquals(course_module.wiki_slug, 'MITx.111.2013_Spring')
+        self.assertEqual(course_module.wiki_slug, 'MITx.111.2013_Spring')
 
         # Now try importing a course with wiki_slug == '{0}.{1}.{2}'.format(location.org, location.course, location.run)
         import_course_from_xml(self.store, self.user.id, TEST_DATA_DIR, ['two_toys'], target_id=target_id)
         course_module = self.store.get_course(target_id)
-        self.assertEquals(course_module.wiki_slug, 'MITx.111.2013_Spring')
+        self.assertEqual(course_module.wiki_slug, 'MITx.111.2013_Spring')
 
     def test_import_metadata_with_attempts_empty_string(self):
         import_course_from_xml(self.store, self.user.id, TEST_DATA_DIR, ['simple'], create_if_not_present=True)
@@ -1797,13 +1797,13 @@ class ContentStoreTest(ContentStoreTestCase):
         course_key = _get_course_id(self.store, self.course_data)
         _create_course(self, course_key, self.course_data)
         course_module = self.store.get_course(course_key)
-        self.assertEquals(course_module.wiki_slug, 'MITx.111.2013_Spring')
+        self.assertEqual(course_module.wiki_slug, 'MITx.111.2013_Spring')
 
     def test_course_handler_with_invalid_course_key_string(self):
         """Test viewing the course overview page with invalid course id"""
 
         response = self.client.get_html('/course/edX/test')
-        self.assertEquals(response.status_code, 404)
+        self.assertEqual(response.status_code, 404)
 
 
 class MetadataSaveTestCase(ContentStoreTestCase):
@@ -1933,7 +1933,7 @@ class RerunCourseTest(ContentStoreTestCase):
             'should_display': True,
         }
         for field_name, expected_value in six.iteritems(expected_states):
-            self.assertEquals(getattr(rerun_state, field_name), expected_value)
+            self.assertEqual(getattr(rerun_state, field_name), expected_value)
 
         # Verify that the creator is now enrolled in the course.
         self.assertTrue(CourseEnrollment.is_enrolled(self.user, destination_course_key))
@@ -2023,7 +2023,7 @@ class RerunCourseTest(ContentStoreTestCase):
 
         # Verify that the course rerun action is marked failed
         rerun_state = CourseRerunState.objects.find_first(course_key=destination_course_key)
-        self.assertEquals(rerun_state.state, CourseRerunUIStateManager.State.FAILED)
+        self.assertEqual(rerun_state.state, CourseRerunUIStateManager.State.FAILED)
         self.assertIn("Cannot find a course at", rerun_state.message)
 
         # Verify that the creator is not enrolled in the course.
@@ -2071,7 +2071,7 @@ class RerunCourseTest(ContentStoreTestCase):
             source_course = CourseFactory.create()
             destination_course_key = self.post_rerun_request(source_course.id)
             rerun_state = CourseRerunState.objects.find_first(course_key=destination_course_key)
-            self.assertEquals(rerun_state.state, CourseRerunUIStateManager.State.FAILED)
+            self.assertEqual(rerun_state.state, CourseRerunUIStateManager.State.FAILED)
             self.assertIn(error_message, rerun_state.message)
 
     def test_rerun_error_trunc_message(self):
@@ -2090,7 +2090,7 @@ class RerunCourseTest(ContentStoreTestCase):
             with mock.patch('traceback.format_exc', return_value=message_too_long):
                 destination_course_key = self.post_rerun_request(source_course.id)
             rerun_state = CourseRerunState.objects.find_first(course_key=destination_course_key)
-            self.assertEquals(rerun_state.state, CourseRerunUIStateManager.State.FAILED)
+            self.assertEqual(rerun_state.state, CourseRerunUIStateManager.State.FAILED)
             self.assertTrue(rerun_state.message.endswith("traceback"))
             self.assertEqual(len(rerun_state.message), CourseRerunState.MAX_MESSAGE_LENGTH)
 
@@ -2112,7 +2112,7 @@ class RerunCourseTest(ContentStoreTestCase):
         source_course = self.store.get_course(source_course_key)
 
         # Verify created course's wiki_slug.
-        self.assertEquals(source_course.wiki_slug, source_wiki_slug)
+        self.assertEqual(source_course.wiki_slug, source_wiki_slug)
 
         destination_course_data = course_data
         destination_course_data['run'] = '2013_Rerun'
@@ -2128,7 +2128,7 @@ class RerunCourseTest(ContentStoreTestCase):
         )
 
         # Verify rerun course's wiki_slug.
-        self.assertEquals(destination_course.wiki_slug, destination_wiki_slug)
+        self.assertEqual(destination_course.wiki_slug, destination_wiki_slug)
 
 
 class ContentLicenseTest(ContentStoreTestCase):
@@ -2144,8 +2144,9 @@ class ContentLicenseTest(ContentStoreTestCase):
         export_course_to_xml(self.store, content_store, self.course.id, root_dir, u'test_license')
         fname = "{block}.xml".format(block=self.course.scope_ids.usage_id.block_id)
         run_file_path = root_dir / "test_license" / "course" / fname
-        run_xml = etree.parse(run_file_path.open())
-        self.assertEqual(run_xml.getroot().get("license"), "creative-commons: BY SA")
+        with run_file_path.open() as f:
+            run_xml = etree.parse(f)
+            self.assertEqual(run_xml.getroot().get("license"), "creative-commons: BY SA")
 
     def test_video_license_export(self):
         content_store = contentstore()
@@ -2157,8 +2158,9 @@ class ContentLicenseTest(ContentStoreTestCase):
         export_course_to_xml(self.store, content_store, self.course.id, root_dir, u'test_license')
         fname = "{block}.xml".format(block=video_descriptor.scope_ids.usage_id.block_id)
         video_file_path = root_dir / "test_license" / "video" / fname
-        video_xml = etree.parse(video_file_path.open())
-        self.assertEqual(video_xml.getroot().get("license"), "all-rights-reserved")
+        with video_file_path.open() as f:
+            video_xml = etree.parse(f)
+            self.assertEqual(video_xml.getroot().get("license"), "all-rights-reserved")
 
     def test_license_import(self):
         course_items = import_course_from_xml(

--- a/common/lib/xmodule/xmodule/assetstore/__init__.py
+++ b/common/lib/xmodule/xmodule/assetstore/__init__.py
@@ -306,3 +306,9 @@ class CourseAssetsFromStorage(object):
         Iterates over the items of the asset dict.
         """
         return six.iteritems(self.asset_md)
+
+    def items(self):
+        """
+        Iterates over the items of the asset dict. (Python 3 naming convention)
+        """
+        return self.iteritems()

--- a/common/lib/xmodule/xmodule/assetstore/tests/test_asset_xml.py
+++ b/common/lib/xmodule/xmodule/assetstore/tests/test_asset_xml.py
@@ -36,7 +36,7 @@ class TestAssetXml(unittest.TestCase):
 
         # Read in the XML schema definition and make a validator.
         xsd_path = path(__file__).realpath().parent / xsd_filename
-        with open(xsd_path, 'r') as f:
+        with open(xsd_path, 'rb') as f:
             schema_root = etree.XML(f.read())
         schema = etree.XMLSchema(schema_root)
         self.xmlparser = etree.XMLParser(schema=schema)

--- a/common/lib/xmodule/xmodule/contentstore/mongo.py
+++ b/common/lib/xmodule/xmodule/contentstore/mongo.py
@@ -127,6 +127,7 @@ class MongoContentStore(ContentStore):
             if as_stream:
                 fp = self.fs.get(content_id)
                 # Need to replace dict IDs with SON for chunk lookup to work under Python 3
+                # because field order can be different and mongo cares about the order
                 if isinstance(fp._id, dict):
                     fp._file['_id'] = content_id
                 thumbnail_location = getattr(fp, 'thumbnail_location', None)
@@ -145,6 +146,7 @@ class MongoContentStore(ContentStore):
             else:
                 with self.fs.get(content_id) as fp:
                     # Need to replace dict IDs with SON for chunk lookup to work under Python 3
+                    # because field order can be different and mongo cares about the order
                     if isinstance(fp._id, dict):
                         fp._file['_id'] = content_id
                     thumbnail_location = getattr(fp, 'thumbnail_location', None)
@@ -405,6 +407,7 @@ class MongoContentStore(ContentStore):
                 asset_key = AssetKey.from_string(asset_key)
                 __, asset_key = self.asset_db_key(asset_key)
             # Need to replace dict IDs with SON for chunk lookup to work under Python 3
+            # because field order can be different and mongo cares about the order
             if isinstance(source_content._id, dict):
                 source_content._file['_id'] = asset_key.copy()
             asset_key['org'] = dest_course_key.org

--- a/common/lib/xmodule/xmodule/contentstore/mongo.py
+++ b/common/lib/xmodule/xmodule/contentstore/mongo.py
@@ -126,6 +126,9 @@ class MongoContentStore(ContentStore):
         try:
             if as_stream:
                 fp = self.fs.get(content_id)
+                # Need to replace dict IDs with SON for chunk lookup to work under Python 3
+                if isinstance(fp._id, dict):
+                    fp._file['_id'] = content_id
                 thumbnail_location = getattr(fp, 'thumbnail_location', None)
                 if thumbnail_location:
                     thumbnail_location = location.course_key.make_asset_key(
@@ -141,6 +144,9 @@ class MongoContentStore(ContentStore):
                 )
             else:
                 with self.fs.get(content_id) as fp:
+                    # Need to replace dict IDs with SON for chunk lookup to work under Python 3
+                    if isinstance(fp._id, dict):
+                        fp._file['_id'] = content_id
                     thumbnail_location = getattr(fp, 'thumbnail_location', None)
                     if thumbnail_location:
                         thumbnail_location = location.course_key.make_asset_key(
@@ -398,6 +404,9 @@ class MongoContentStore(ContentStore):
             if isinstance(asset_key, six.string_types):
                 asset_key = AssetKey.from_string(asset_key)
                 __, asset_key = self.asset_db_key(asset_key)
+            # Need to replace dict IDs with SON for chunk lookup to work under Python 3
+            if isinstance(source_content._id, dict):
+                source_content._file['_id'] = asset_key.copy()
             asset_key['org'] = dest_course_key.org
             asset_key['course'] = dest_course_key.course
             if getattr(dest_course_key, 'deprecated', False):  # remove the run if exists

--- a/common/lib/xmodule/xmodule/modulestore/split_mongo/mongo_connection.py
+++ b/common/lib/xmodule/xmodule/modulestore/split_mongo/mongo_connection.py
@@ -239,7 +239,10 @@ class CourseStructureCache(object):
             pickled_data = zlib.decompress(compressed_pickled_data)
             tagger.measure('uncompressed_size', len(pickled_data))
 
-            return pickle.loads(pickled_data, encoding='latin-1')
+            if six.PY2:
+                return pickle.loads(pickled_data)
+            else:
+                return pickle.loads(pickled_data, encoding='latin-1')
 
     def set(self, key, structure, course_context=None):
         """Given a structure, will pickle, compress, and write to cache."""

--- a/common/lib/xmodule/xmodule/modulestore/split_mongo/mongo_connection.py
+++ b/common/lib/xmodule/xmodule/modulestore/split_mongo/mongo_connection.py
@@ -239,7 +239,7 @@ class CourseStructureCache(object):
             pickled_data = zlib.decompress(compressed_pickled_data)
             tagger.measure('uncompressed_size', len(pickled_data))
 
-            return pickle.loads(pickled_data)
+            return pickle.loads(pickled_data, encoding='latin-1')
 
     def set(self, key, structure, course_context=None):
         """Given a structure, will pickle, compress, and write to cache."""
@@ -247,7 +247,7 @@ class CourseStructureCache(object):
             return None
 
         with TIMER.timer("CourseStructureCache.set", course_context) as tagger:
-            pickled_data = pickle.dumps(structure, pickle.HIGHEST_PROTOCOL)
+            pickled_data = pickle.dumps(structure, 2)  # Protocol can't be incremented until cache is cleared
             tagger.measure('uncompressed_size', len(pickled_data))
 
             # 1 = Fastest (slightly larger results)

--- a/common/lib/xmodule/xmodule/modulestore/tests/test_assetstore.py
+++ b/common/lib/xmodule/xmodule/modulestore/tests/test_assetstore.py
@@ -89,9 +89,9 @@ class TestSortedAssetList(unittest.TestCase):
 
     def test_find(self):
         asset_key = self.course_key.make_asset_key('asset', 'asset.txt')
-        self.assertEquals(self.sorted_asset_list_by_filename.find(asset_key), 0)
+        self.assertEqual(self.sorted_asset_list_by_filename.find(asset_key), 0)
         asset_key_last = self.course_key.make_asset_key('asset', 'weather_patterns.bmp')
-        self.assertEquals(
+        self.assertEqual(
             self.sorted_asset_list_by_filename.find(asset_key_last), len(AssetStoreTestData.all_asset_data) - 1
         )
 
@@ -190,8 +190,8 @@ class TestMongoAssetMetadataStorage(TestCase):
             # Find the asset's metadata and confirm it's the same.
             found_asset_md = store.find_asset_metadata(new_asset_loc)
             self.assertIsNotNone(found_asset_md)
-            self.assertEquals(new_asset_md, found_asset_md)
-            self.assertEquals(len(store.get_all_asset_metadata(course.id, 'asset')), 1)
+            self.assertEqual(new_asset_md, found_asset_md)
+            self.assertEqual(len(store.get_all_asset_metadata(course.id, 'asset')), 1)
 
     @ddt.data(*MODULESTORE_SETUPS)
     def test_delete(self, storebuilder):
@@ -202,13 +202,13 @@ class TestMongoAssetMetadataStorage(TestCase):
             course = CourseFactory.create(modulestore=store)
             new_asset_loc = course.id.make_asset_key('asset', 'burnside.jpg')
             # Attempt to delete an asset that doesn't exist.
-            self.assertEquals(store.delete_asset_metadata(new_asset_loc, ModuleStoreEnum.UserID.test), 0)
-            self.assertEquals(len(store.get_all_asset_metadata(course.id, 'asset')), 0)
+            self.assertEqual(store.delete_asset_metadata(new_asset_loc, ModuleStoreEnum.UserID.test), 0)
+            self.assertEqual(len(store.get_all_asset_metadata(course.id, 'asset')), 0)
 
             new_asset_md = self._make_asset_metadata(new_asset_loc)
             store.save_asset_metadata(new_asset_md, ModuleStoreEnum.UserID.test)
-            self.assertEquals(store.delete_asset_metadata(new_asset_loc, ModuleStoreEnum.UserID.test), 1)
-            self.assertEquals(len(store.get_all_asset_metadata(course.id, 'asset')), 0)
+            self.assertEqual(store.delete_asset_metadata(new_asset_loc, ModuleStoreEnum.UserID.test), 1)
+            self.assertEqual(len(store.get_all_asset_metadata(course.id, 'asset')), 0)
 
     @ddt.data(*MODULESTORE_SETUPS)
     def test_find_non_existing_assets(self, storebuilder):
@@ -231,7 +231,7 @@ class TestMongoAssetMetadataStorage(TestCase):
             course = CourseFactory.create(modulestore=store)
             # Find existing asset metadata.
             asset_md = store.get_all_asset_metadata(course.id, 'asset')
-            self.assertEquals(asset_md, [])
+            self.assertEqual(asset_md, [])
 
     @ddt.data(*MODULESTORE_SETUPS)
     def test_find_assets_in_non_existent_course(self, storebuilder):
@@ -261,11 +261,11 @@ class TestMongoAssetMetadataStorage(TestCase):
             new_asset_md = self._make_asset_metadata(new_asset_loc)
             # Add asset metadata.
             store.save_asset_metadata(new_asset_md, ModuleStoreEnum.UserID.test)
-            self.assertEquals(len(store.get_all_asset_metadata(course.id, 'asset')), 1)
+            self.assertEqual(len(store.get_all_asset_metadata(course.id, 'asset')), 1)
             # Add *the same* asset metadata.
             store.save_asset_metadata(new_asset_md, ModuleStoreEnum.UserID.test)
             # Still one here?
-            self.assertEquals(len(store.get_all_asset_metadata(course.id, 'asset')), 1)
+            self.assertEqual(len(store.get_all_asset_metadata(course.id, 'asset')), 1)
 
     @ddt.data(*MODULESTORE_SETUPS)
     def test_different_asset_types(self, storebuilder):
@@ -278,8 +278,8 @@ class TestMongoAssetMetadataStorage(TestCase):
             new_asset_md = self._make_asset_metadata(new_asset_loc)
             # Add asset metadata.
             store.save_asset_metadata(new_asset_md, ModuleStoreEnum.UserID.test)
-            self.assertEquals(len(store.get_all_asset_metadata(course.id, 'vrml')), 1)
-            self.assertEquals(len(store.get_all_asset_metadata(course.id, 'asset')), 0)
+            self.assertEqual(len(store.get_all_asset_metadata(course.id, 'vrml')), 1)
+            self.assertEqual(len(store.get_all_asset_metadata(course.id, 'asset')), 0)
 
     @ddt.data(*MODULESTORE_SETUPS)
     def test_asset_types_with_other_field_names(self, storebuilder):
@@ -292,10 +292,10 @@ class TestMongoAssetMetadataStorage(TestCase):
             new_asset_md = self._make_asset_metadata(new_asset_loc)
             # Add asset metadata.
             store.save_asset_metadata(new_asset_md, ModuleStoreEnum.UserID.test)
-            self.assertEquals(len(store.get_all_asset_metadata(course.id, 'course_id')), 1)
-            self.assertEquals(len(store.get_all_asset_metadata(course.id, 'asset')), 0)
+            self.assertEqual(len(store.get_all_asset_metadata(course.id, 'course_id')), 1)
+            self.assertEqual(len(store.get_all_asset_metadata(course.id, 'asset')), 0)
             all_assets = store.get_all_asset_metadata(course.id, 'course_id')
-            self.assertEquals(all_assets[0].asset_id.path, new_asset_loc.path)
+            self.assertEqual(all_assets[0].asset_id.path, new_asset_loc.path)
 
     @ddt.data(*MODULESTORE_SETUPS)
     def test_lock_unlock_assets(self, storebuilder):
@@ -314,12 +314,12 @@ class TestMongoAssetMetadataStorage(TestCase):
             # Find the same course and check its locked status.
             updated_asset_md = store.find_asset_metadata(new_asset_loc)
             self.assertIsNotNone(updated_asset_md)
-            self.assertEquals(updated_asset_md.locked, not locked_state)
+            self.assertEqual(updated_asset_md.locked, not locked_state)
             # Now flip it back.
             store.set_asset_metadata_attr(new_asset_loc, "locked", locked_state, ModuleStoreEnum.UserID.test)
             reupdated_asset_md = store.find_asset_metadata(new_asset_loc)
             self.assertIsNotNone(reupdated_asset_md)
-            self.assertEquals(reupdated_asset_md.locked, locked_state)
+            self.assertEqual(reupdated_asset_md.locked, locked_state)
 
     ALLOWED_ATTRS = (
         ('pathname', '/new/path'),
@@ -362,7 +362,7 @@ class TestMongoAssetMetadataStorage(TestCase):
                 updated_asset_md = store.find_asset_metadata(new_asset_loc)
                 self.assertIsNotNone(updated_asset_md)
                 self.assertIsNotNone(getattr(updated_asset_md, attribute, None))
-                self.assertEquals(getattr(updated_asset_md, attribute, None), value)
+                self.assertEqual(getattr(updated_asset_md, attribute, None), value)
 
     @ddt.data(*MODULESTORE_SETUPS)
     def test_set_disallowed_attrs(self, storebuilder):
@@ -383,7 +383,7 @@ class TestMongoAssetMetadataStorage(TestCase):
                 self.assertIsNotNone(updated_asset_md)
                 self.assertIsNotNone(getattr(updated_asset_md, attribute, None))
                 # Make sure that the attribute is unchanged from its original value.
-                self.assertEquals(getattr(updated_asset_md, attribute, None), original_attr_val)
+                self.assertEqual(getattr(updated_asset_md, attribute, None), original_attr_val)
 
     @ddt.data(*MODULESTORE_SETUPS)
     def test_set_unknown_attrs(self, storebuilder):
@@ -403,7 +403,7 @@ class TestMongoAssetMetadataStorage(TestCase):
                 self.assertIsNotNone(updated_asset_md)
                 # Make sure the unknown field was *not* added.
                 with self.assertRaises(AttributeError):
-                    self.assertEquals(getattr(updated_asset_md, attribute), value)
+                    self.assertEqual(getattr(updated_asset_md, attribute), value)
 
     @ddt.data(*MODULESTORE_SETUPS)
     def test_save_one_different_asset(self, storebuilder):
@@ -417,9 +417,9 @@ class TestMongoAssetMetadataStorage(TestCase):
                 self._make_asset_metadata(asset_key)
             )
             store.save_asset_metadata(new_asset_thumbnail, ModuleStoreEnum.UserID.test)
-            self.assertEquals(len(store.get_all_asset_metadata(course.id, 'different')), 1)
-            self.assertEquals(store.delete_asset_metadata(asset_key, ModuleStoreEnum.UserID.test), 1)
-            self.assertEquals(len(store.get_all_asset_metadata(course.id, 'different')), 0)
+            self.assertEqual(len(store.get_all_asset_metadata(course.id, 'different')), 1)
+            self.assertEqual(store.delete_asset_metadata(asset_key, ModuleStoreEnum.UserID.test), 1)
+            self.assertEqual(len(store.get_all_asset_metadata(course.id, 'different')), 0)
 
     @ddt.data(*MODULESTORE_SETUPS)
     def test_find_different(self, storebuilder):
@@ -443,8 +443,8 @@ class TestMongoAssetMetadataStorage(TestCase):
         Check asset type/path values.
         """
         for idx, asset in enumerate(orig):
-            self.assertEquals(assets[idx].asset_id.asset_type, asset[0])
-            self.assertEquals(assets[idx].asset_id.path, asset[1])
+            self.assertEqual(assets[idx].asset_id.asset_type, asset[0])
+            self.assertEqual(assets[idx].asset_id.path, asset[1])
 
     @ddt.data(*MODULESTORE_SETUPS)
     def test_get_multiple_types(self, storebuilder):
@@ -470,17 +470,17 @@ class TestMongoAssetMetadataStorage(TestCase):
                 ('asset', self.regular_assets),
             ):
                 assets = store.get_all_asset_metadata(course.id, asset_type)
-                self.assertEquals(len(assets), len(asset_list))
+                self.assertEqual(len(assets), len(asset_list))
                 self._check_asset_values(assets, asset_list)
 
-            self.assertEquals(len(store.get_all_asset_metadata(course.id, 'not_here')), 0)
-            self.assertEquals(len(store.get_all_asset_metadata(course.id, None)), 4)
+            self.assertEqual(len(store.get_all_asset_metadata(course.id, 'not_here')), 0)
+            self.assertEqual(len(store.get_all_asset_metadata(course.id, None)), 4)
 
             assets = store.get_all_asset_metadata(
                 course.id, None, start=0, maxresults=-1,
                 sort=('displayname', ModuleStoreEnum.SortOrder.ascending)
             )
-            self.assertEquals(len(assets), len(self.alls))
+            self.assertEqual(len(assets), len(self.alls))
             self._check_asset_values(assets, self.alls)
 
     @ddt.data(*MODULESTORE_SETUPS)
@@ -510,17 +510,17 @@ class TestMongoAssetMetadataStorage(TestCase):
                 ('asset', self.regular_assets),
             ):
                 assets = store.get_all_asset_metadata(course.id, asset_type)
-                self.assertEquals(len(assets), len(asset_list))
+                self.assertEqual(len(assets), len(asset_list))
                 self._check_asset_values(assets, asset_list)
 
-            self.assertEquals(len(store.get_all_asset_metadata(course.id, 'not_here')), 0)
-            self.assertEquals(len(store.get_all_asset_metadata(course.id, None)), 4)
+            self.assertEqual(len(store.get_all_asset_metadata(course.id, 'not_here')), 0)
+            self.assertEqual(len(store.get_all_asset_metadata(course.id, None)), 4)
 
             assets = store.get_all_asset_metadata(
                 course.id, None, start=0, maxresults=-1,
                 sort=('displayname', ModuleStoreEnum.SortOrder.ascending)
             )
-            self.assertEquals(len(assets), len(self.alls))
+            self.assertEqual(len(assets), len(self.alls))
             self._check_asset_values(assets, self.alls)
 
     @ddt.data(*MODULESTORE_SETUPS)
@@ -553,17 +553,17 @@ class TestMongoAssetMetadataStorage(TestCase):
                 ('vrml', self.vrmls),
             ):
                 assets = store.get_all_asset_metadata(course1.id, asset_type)
-                self.assertEquals(len(assets), len(asset_list))
+                self.assertEqual(len(assets), len(asset_list))
                 self._check_asset_values(assets, asset_list)
 
-            self.assertEquals(len(store.get_all_asset_metadata(course1.id, 'asset')), 0)
-            self.assertEquals(len(store.get_all_asset_metadata(course1.id, None)), 3)
+            self.assertEqual(len(store.get_all_asset_metadata(course1.id, 'asset')), 0)
+            self.assertEqual(len(store.get_all_asset_metadata(course1.id, None)), 3)
 
             assets = store.get_all_asset_metadata(
                 course1.id, None, start=0, maxresults=-1,
                 sort=('displayname', ModuleStoreEnum.SortOrder.ascending)
             )
-            self.assertEquals(len(assets), len(self.differents + self.vrmls))
+            self.assertEqual(len(assets), len(self.differents + self.vrmls))
             self._check_asset_values(assets, self.differents + self.vrmls)
 
     @ddt.data(*MODULESTORE_SETUPS)
@@ -579,7 +579,7 @@ class TestMongoAssetMetadataStorage(TestCase):
             )
             store.save_asset_metadata(new_asset_thumbnail, ModuleStoreEnum.UserID.test)
 
-            self.assertEquals(len(store.get_all_asset_metadata(course.id, 'different')), 1)
+            self.assertEqual(len(store.get_all_asset_metadata(course.id, 'different')), 1)
 
     @ddt.data(*MODULESTORE_SETUPS)
     def test_get_all_assets_with_paging(self, storebuilder):
@@ -621,38 +621,38 @@ class TestMongoAssetMetadataStorage(TestCase):
                     )
                     num_expected_results = sort_test[2][i]
                     expected_filename = sort_test[1][2 * i]
-                    self.assertEquals(len(asset_page), num_expected_results)
-                    self.assertEquals(asset_page[0].asset_id.path, expected_filename)
+                    self.assertEqual(len(asset_page), num_expected_results)
+                    self.assertEqual(asset_page[0].asset_id.path, expected_filename)
                     if num_expected_results == 2:
                         expected_filename = sort_test[1][(2 * i) + 1]
-                        self.assertEquals(asset_page[1].asset_id.path, expected_filename)
+                        self.assertEqual(asset_page[1].asset_id.path, expected_filename)
 
             # Now fetch everything.
             asset_page = store.get_all_asset_metadata(
                 course2.id, 'asset', start=0, sort=('displayname', ModuleStoreEnum.SortOrder.ascending)
             )
-            self.assertEquals(len(asset_page), 5)
-            self.assertEquals(asset_page[0].asset_id.path, 'code.tgz')
-            self.assertEquals(asset_page[1].asset_id.path, 'demo.swf')
-            self.assertEquals(asset_page[2].asset_id.path, 'dog.png')
-            self.assertEquals(asset_page[3].asset_id.path, 'roman_history.pdf')
-            self.assertEquals(asset_page[4].asset_id.path, 'weather_patterns.bmp')
+            self.assertEqual(len(asset_page), 5)
+            self.assertEqual(asset_page[0].asset_id.path, 'code.tgz')
+            self.assertEqual(asset_page[1].asset_id.path, 'demo.swf')
+            self.assertEqual(asset_page[2].asset_id.path, 'dog.png')
+            self.assertEqual(asset_page[3].asset_id.path, 'roman_history.pdf')
+            self.assertEqual(asset_page[4].asset_id.path, 'weather_patterns.bmp')
 
             # Some odd conditions.
             asset_page = store.get_all_asset_metadata(
                 course2.id, 'asset', start=100, sort=('uploadDate', ModuleStoreEnum.SortOrder.ascending)
             )
-            self.assertEquals(len(asset_page), 0)
+            self.assertEqual(len(asset_page), 0)
             asset_page = store.get_all_asset_metadata(
                 course2.id, 'asset', start=3, maxresults=0,
                 sort=('displayname', ModuleStoreEnum.SortOrder.ascending)
             )
-            self.assertEquals(len(asset_page), 0)
+            self.assertEqual(len(asset_page), 0)
             asset_page = store.get_all_asset_metadata(
                 course2.id, 'asset', start=3, maxresults=-12345,
                 sort=('displayname', ModuleStoreEnum.SortOrder.descending)
             )
-            self.assertEquals(len(asset_page), 2)
+            self.assertEqual(len(asset_page), 2)
 
     @ddt.data('XML_MODULESTORE_BUILDER', 'MIXED_MODULESTORE_BUILDER')
     def test_xml_not_yet_implemented(self, storebuilderName):
@@ -663,8 +663,8 @@ class TestMongoAssetMetadataStorage(TestCase):
         with storebuilder.build(contentstore=None) as (__, store):
             course_key = store.make_course_key("org", "course", "run")
             asset_key = course_key.make_asset_key('asset', 'foo.jpg')
-            self.assertEquals(store.find_asset_metadata(asset_key), None)
-            self.assertEquals(store.get_all_asset_metadata(course_key, 'asset'), [])
+            self.assertEqual(store.find_asset_metadata(asset_key), None)
+            self.assertEqual(store.get_all_asset_metadata(course_key, 'asset'), [])
 
     @ddt.data(*MODULESTORE_SETUPS)
     def test_copy_all_assets_same_modulestore(self, storebuilder):
@@ -675,16 +675,16 @@ class TestMongoAssetMetadataStorage(TestCase):
             course1 = CourseFactory.create(modulestore=store)
             course2 = CourseFactory.create(modulestore=store)
             self.setup_assets(course1.id, None, store)
-            self.assertEquals(len(store.get_all_asset_metadata(course1.id, 'asset')), 2)
-            self.assertEquals(len(store.get_all_asset_metadata(course2.id, 'asset')), 0)
+            self.assertEqual(len(store.get_all_asset_metadata(course1.id, 'asset')), 2)
+            self.assertEqual(len(store.get_all_asset_metadata(course2.id, 'asset')), 0)
             store.copy_all_asset_metadata(course1.id, course2.id, ModuleStoreEnum.UserID.test * 101)
-            self.assertEquals(len(store.get_all_asset_metadata(course1.id, 'asset')), 2)
+            self.assertEqual(len(store.get_all_asset_metadata(course1.id, 'asset')), 2)
             all_assets = store.get_all_asset_metadata(
                 course2.id, 'asset', sort=('displayname', ModuleStoreEnum.SortOrder.ascending)
             )
-            self.assertEquals(len(all_assets), 2)
-            self.assertEquals(all_assets[0].asset_id.path, 'pic1.jpg')
-            self.assertEquals(all_assets[1].asset_id.path, 'shout.ogg')
+            self.assertEqual(len(all_assets), 2)
+            self.assertEqual(all_assets[0].asset_id.path, 'pic1.jpg')
+            self.assertEqual(all_assets[1].asset_id.path, 'shout.ogg')
 
     @ddt.data(*MODULESTORE_SETUPS)
     def test_copy_all_assets_from_course_with_no_assets(self, storebuilder):
@@ -695,12 +695,12 @@ class TestMongoAssetMetadataStorage(TestCase):
             course1 = CourseFactory.create(modulestore=store)
             course2 = CourseFactory.create(modulestore=store)
             store.copy_all_asset_metadata(course1.id, course2.id, ModuleStoreEnum.UserID.test * 101)
-            self.assertEquals(len(store.get_all_asset_metadata(course1.id, 'asset')), 0)
-            self.assertEquals(len(store.get_all_asset_metadata(course2.id, 'asset')), 0)
+            self.assertEqual(len(store.get_all_asset_metadata(course1.id, 'asset')), 0)
+            self.assertEqual(len(store.get_all_asset_metadata(course2.id, 'asset')), 0)
             all_assets = store.get_all_asset_metadata(
                 course2.id, 'asset', sort=('displayname', ModuleStoreEnum.SortOrder.ascending)
             )
-            self.assertEquals(len(all_assets), 0)
+            self.assertEqual(len(all_assets), 0)
 
     @ddt.data(
         ('mongo', 'split'),
@@ -718,12 +718,12 @@ class TestMongoAssetMetadataStorage(TestCase):
             with mixed_store.default_store(to_store):
                 course2 = CourseFactory.create(modulestore=mixed_store)
             self.setup_assets(course1.id, None, mixed_store)
-            self.assertEquals(len(mixed_store.get_all_asset_metadata(course1.id, 'asset')), 2)
-            self.assertEquals(len(mixed_store.get_all_asset_metadata(course2.id, 'asset')), 0)
+            self.assertEqual(len(mixed_store.get_all_asset_metadata(course1.id, 'asset')), 2)
+            self.assertEqual(len(mixed_store.get_all_asset_metadata(course2.id, 'asset')), 0)
             mixed_store.copy_all_asset_metadata(course1.id, course2.id, ModuleStoreEnum.UserID.test * 102)
             all_assets = mixed_store.get_all_asset_metadata(
                 course2.id, 'asset', sort=('displayname', ModuleStoreEnum.SortOrder.ascending)
             )
-            self.assertEquals(len(all_assets), 2)
-            self.assertEquals(all_assets[0].asset_id.path, 'pic1.jpg')
-            self.assertEquals(all_assets[1].asset_id.path, 'shout.ogg')
+            self.assertEqual(len(all_assets), 2)
+            self.assertEqual(all_assets[0].asset_id.path, 'pic1.jpg')
+            self.assertEqual(all_assets[1].asset_id.path, 'shout.ogg')

--- a/common/lib/xmodule/xmodule/modulestore/tests/test_xml.py
+++ b/common/lib/xmodule/xmodule/modulestore/tests/test_xml.py
@@ -42,7 +42,7 @@ class TestXMLModuleStore(TestCase):
         # uniquification of names, would raise a UnicodeError. It no longer does.
 
         # Ensure that there really is a non-ASCII character in the course.
-        with open(os.path.join(DATA_DIR, "toy/sequential/vertical_sequential.xml")) as xmlf:
+        with open(os.path.join(DATA_DIR, "toy/sequential/vertical_sequential.xml"), 'rb') as xmlf:
             xml = xmlf.read()
             with self.assertRaises(UnicodeDecodeError):
                 xml.decode('ascii')


### PR DESCRIPTION
[BOM-375](https://openedx.atlassian.net/browse/BOM-375)

The way in which dictionary keys are returned in an arbitrary order changed between Python 2.7 and 3.5, and gridfs apparently depended on the 2.7 behavior (even upgrading to the latest version doesn't seem to fix this).  For gridfs entries which come back with a dictionary ID, we now convert that to a SON ID before using it to fetch any of its chunks.

Also fixed a few other problems encountered while working on the tests this had broken:

* Switched the deprecated `assertEquals` to non-deprecated `assertEqual`
* Explicitly made bytes some literals and file reads which were implicitly that way under 2.7 but switched to Unicode by default in 3.5
* Added `items()` to a class which acts like a dictionary so `six.iteritems()` works with it under Python 3
* Explicitly use Python 2 compatible pickle settings for the course structure cache, so any existing objects in it should still work if extracted in a Python 3 production server