### PR TITLE
Delete flaky test test_comment_deletion_as_student

### DIFF
--- a/common/test/acceptance/tests/discussion/test_discussion.py
+++ b/common/test/acceptance/tests/discussion/test_discussion.py
@@ -583,16 +583,6 @@ class DiscussionCommentDeletionTest(BaseDiscussionTestCase):
         )
         view.push()
 
-    def test_comment_deletion_as_student(self):
-        self.setup_user()
-        self.setup_view()
-        page = self.create_single_thread_page("comment_deletion_test_thread")
-        page.visit()
-        self.assertTrue(page.is_comment_deletable("comment_self_author"))
-        self.assertTrue(page.is_comment_visible("comment_other_author"))
-        self.assertFalse(page.is_comment_deletable("comment_other_author"))
-        page.delete_comment("comment_self_author")
-
     def test_comment_deletion_as_moderator(self):
         self.setup_user(roles=['Moderator'])
         self.setup_view()


### PR DESCRIPTION
This test has been flaky in the past; I turned up TNLARCHIVE-530 and
TNLARCHIVE-2147 in JIRA while verifying no one else had actually
gotten it.

Corresponding ticket to fix up this test: openedx.atlassian.net/servicedesk/customer/portal/9/CR-1278

@edx/masters-devs