### PR TITLE
Fix parsing of Unicode capa XML BOM-611

### DIFF
--- a/common/lib/capa/capa/capa_problem.py
+++ b/common/lib/capa/capa/capa_problem.py
@@ -185,6 +185,9 @@ class LoncapaProblem(object):
         self.problem_text = problem_text
 
         # parse problem XML file into an element tree
+        if isinstance(problem_text, six.text_type):
+            # etree chokes on Unicode XML with an encoding declaration
+            problem_text = problem_text.encode('utf-8')
         self.tree = etree.XML(problem_text)
 
         self.make_xml_compatible(self.tree)


### PR DESCRIPTION
[BOM-611](https://openedx.atlassian.net/browse/BOM-611)

`lxml.etree` chokes on Unicode XML strings with a declared encoding, and one of our test cases uses a literal with such an encoding which is bytes in Python 2 but Unicode in Python 3.  This seems like an important data sanitation use case, so fixing the parsing to handle it.