### PR TITLE
BOM-529: Exception output diff fix between py2 and py3

### DIFF
--- a/cms/djangoapps/contentstore/management/commands/tests/test_fix_not_found.py
+++ b/cms/djangoapps/contentstore/management/commands/tests/test_fix_not_found.py
@@ -20,7 +20,11 @@ class TestFixNotFound(ModuleStoreTestCase):
         """
         Test fix_not_found command with no arguments
         """
-        with self.assertRaisesRegexp(CommandError, "Error: too few arguments"):
+        if six.PY2:
+            errstring = 'Error: too few arguments'
+        else:
+            errstring = 'Error: the following arguments are required: course_id'
+        with self.assertRaisesRegexp(CommandError, errstring):
             call_command('fix_not_found')
 
     def test_fix_not_found_non_split(self):


### PR DESCRIPTION
call_command outputs different text while raising exception between py2 and py3