### PR TITLE
Always store transformers_schema_version as text BOM-576

### DIFF
--- a/openedx/core/djangoapps/content/block_structure/tests/test_manager.py
+++ b/openedx/core/djangoapps/content/block_structure/tests/test_manager.py
@@ -127,8 +127,9 @@ class TestBlockStructureManager(UsageKeyFactoryMixin, ChildrenMapTestMixin, Test
         if expect_modulestore_called:
             self.assertGreater(self.modulestore.get_items_call_count, 0)
         else:
-            self.assertEquals(self.modulestore.get_items_call_count, 0)
-        self.assertEquals(self.cache.set_call_count, 1 if expect_cache_updated else 0)
+            assert self.modulestore.get_items_call_count == 0
+        expected_count = 1 if expect_cache_updated else 0
+        assert self.cache.set_call_count == expected_count
 
     def test_get_transformed(self):
         with mock_registered_transformers(self.registered_transformers):
@@ -174,7 +175,7 @@ class TestBlockStructureManager(UsageKeyFactoryMixin, ChildrenMapTestMixin, Test
     def test_get_collected_cached(self):
         self.collect_and_verify(expect_modulestore_called=True, expect_cache_updated=True)
         self.collect_and_verify(expect_modulestore_called=False, expect_cache_updated=False)
-        self.assertEquals(TestTransformer1.collect_call_count, 1)
+        assert TestTransformer1.collect_call_count == 1
 
     def test_get_collected_error_raised(self):
         with waffle().override(RAISE_ERROR_WHEN_NOT_FOUND, active=True):
@@ -186,13 +187,14 @@ class TestBlockStructureManager(UsageKeyFactoryMixin, ChildrenMapTestMixin, Test
     def test_update_collected_if_needed(self, with_storage_backing):
         with waffle().override(STORAGE_BACKING_FOR_CACHE, active=with_storage_backing):
             with mock_registered_transformers(self.registered_transformers):
-                self.assertEquals(TestTransformer1.collect_call_count, 0)
+                assert TestTransformer1.collect_call_count == 0
 
                 self.bs_manager.update_collected_if_needed()
-                self.assertEquals(TestTransformer1.collect_call_count, 1)
+                assert TestTransformer1.collect_call_count == 1
 
                 self.bs_manager.update_collected_if_needed()
-                self.assertEquals(TestTransformer1.collect_call_count, 1 if with_storage_backing else 2)
+                expected_count = 1 if with_storage_backing else 2
+                assert TestTransformer1.collect_call_count == expected_count
 
                 self.collect_and_verify(expect_modulestore_called=False, expect_cache_updated=False)
 
@@ -211,16 +213,16 @@ class TestBlockStructureManager(UsageKeyFactoryMixin, ChildrenMapTestMixin, Test
         TestTransformer1.READ_VERSION -= 1
         self.collect_and_verify(expect_modulestore_called=False, expect_cache_updated=False)
 
-        self.assertEquals(TestTransformer1.collect_call_count, 2)
+        assert TestTransformer1.collect_call_count == 2
 
     def test_get_collected_structure_version(self):
         self.collect_and_verify(expect_modulestore_called=True, expect_cache_updated=True)
         BlockStructureBlockData.VERSION += 1
         self.collect_and_verify(expect_modulestore_called=True, expect_cache_updated=True)
-        self.assertEquals(TestTransformer1.collect_call_count, 2)
+        assert TestTransformer1.collect_call_count == 2
 
     def test_clear(self):
         self.collect_and_verify(expect_modulestore_called=True, expect_cache_updated=True)
         self.bs_manager.clear()
         self.collect_and_verify(expect_modulestore_called=True, expect_cache_updated=True)
-        self.assertEquals(TestTransformer1.collect_call_count, 2)
+        assert TestTransformer1.collect_call_count == 2

--- a/openedx/core/djangoapps/content/block_structure/tests/test_store.py
+++ b/openedx/core/djangoapps/content/block_structure/tests/test_store.py
@@ -87,6 +87,6 @@ class TestBlockStructureStore(UsageKeyFactoryMixin, ChildrenMapTestMixin, CacheI
         else:
             timeout = BlockStructureConfiguration.DEFAULT_CACHE_TIMEOUT_IN_SECONDS
 
-        self.assertEquals(self.mock_cache.timeout_from_last_call, 0)
+        assert self.mock_cache.timeout_from_last_call == 0
         self.store.add(self.block_structure)
-        self.assertEquals(self.mock_cache.timeout_from_last_call, timeout)
+        assert self.mock_cache.timeout_from_last_call == timeout

--- a/openedx/core/djangoapps/content/block_structure/transformer_registry.py
+++ b/openedx/core/djangoapps/content/block_structure/transformer_registry.py
@@ -52,7 +52,7 @@ class TransformerRegistry(PluginManager):
             hash_obj.update(transformer.name().encode('utf-8'))
             hash_obj.update(six.b(str(transformer.WRITE_VERSION)))
 
-        return b64encode(hash_obj.digest())
+        return b64encode(hash_obj.digest()).decode('utf-8')
 
     @classmethod
     def find_unregistered(cls, transformers):


### PR DESCRIPTION
[BOM-576](https://openedx.atlassian.net/browse/BOM-576)

The `transformers_schema_version` field was sometimes being treated as Unicode text and at other times as bytes; this prevented lookup of keys in the cache under Python 3.  Fixed to always be Unicode.  The cache is process-local, so no migration work needed in that regard.