### PR TITLE
Fix deprecated drag and drop grading BOM-774

### DIFF
--- a/common/lib/sandbox-packages/verifiers/draganddrop.py
+++ b/common/lib/sandbox-packages/verifiers/draganddrop.py
@@ -287,7 +287,7 @@ class DragAndDrop(object):
     def __init__(self, correct_answer, user_answer):
         """ Populates DragAndDrop variables from user_answer and correct_answer.
         If correct_answer is dict, converts it to list.
-        Correct answer in dict form is simpe structure for fast and simple
+        Correct answer in dict form is simple structure for fast and simple
         grading. Example of correct answer dict example::
 
             correct_answer = {'name4': 't1',
@@ -340,7 +340,8 @@ class DragAndDrop(object):
         # Convert from dict answer format to list format.
         if isinstance(correct_answer, dict):
             tmp = []
-            for key, value in correct_answer.items():
+            for key in sorted(correct_answer.keys()):
+                value = correct_answer[key]
                 tmp.append({
                     'draggables': [key],
                     'targets': [value],


### PR DESCRIPTION
[BOM-774](https://openedx.atlassian.net/browse/BOM-774).

I'm not sure if we even use this deprecated capa drag & drop problem type anymore, but the upgrade to Python 3 revealed that one format of correct answer specification (as a dictionary) could result in incorrect grading.  This seems like it would have been breaking for any nontrivial usage under Python 2 as well, so I presume we just don't have any instances of this in prod using that parameter format.  Fixed the test by sorting the dictionary keys before comparing against the list of student answers.