### PR TITLE
add missing annotation tokens to course api toggles

### DIFF
--- a/lms/djangoapps/course_api/blocks/toggles.py
+++ b/lms/djangoapps/course_api/blocks/toggles.py
@@ -9,14 +9,17 @@ from openedx.core.djangoapps.waffle_utils import CourseWaffleFlag, WaffleFlag, W
 COURSE_BLOCKS_API_NAMESPACE = WaffleFlagNamespace(name=u'course_blocks_api')
 
 # Waffle flag to hide access denial message.
-# .. toggle_name: HIDE_ACCESS_DENIALS_FLAG
-# .. toggle_type: waffle_flag
+# .. toggle_name: course_blocks_api.hide_access_denials
+# .. toggle_implementation: WaffleFlag
 # .. toggle_default: False
 # .. toggle_description: ??
 # .. toggle_category: course api
 # .. toggle_use_cases: incremental_release, open_edx
 # .. toggle_creation_date: 2019-04-10
 # .. toggle_expiration_date: ??
+# .. toggle_warnings: ??
+# .. toggle_tickets: ??
+# .. toggle_status: ??
 HIDE_ACCESS_DENIALS_FLAG = WaffleFlag(
     waffle_namespace=COURSE_BLOCKS_API_NAMESPACE,
     flag_name=u'hide_access_denials',
@@ -24,14 +27,17 @@ HIDE_ACCESS_DENIALS_FLAG = WaffleFlag(
 )
 
 # Waffle course override to rewrite video URLs for videos that have encodings available.
-# .. toggle_name: ENABLE_VIDEO_URL_REWRITE
-# .. toggle_type: waffle_flag
+# .. toggle_name: course_blocks_api.enable_video_url_rewrite
+# .. toggle_implementation: CourseWaffleFlag
 # .. toggle_default: False
 # .. toggle_description: Controlled rollout for video URL re-write utility to serve videos from edX CDN.
 # .. toggle_category: course api
 # .. toggle_use_cases: incremental_release
 # .. toggle_creation_date: 2019-09-24
 # .. toggle_expiration_date: ??
+# .. toggle_warnings: ??
+# .. toggle_tickets: ??
+# .. toggle_status: ??
 ENABLE_VIDEO_URL_REWRITE = CourseWaffleFlag(
     waffle_namespace=COURSE_BLOCKS_API_NAMESPACE,
     flag_name="enable_video_url_rewrite",


### PR DESCRIPTION
These annotations were added today and caused the feature toggle reporting utility to fail. In a separate PR, I will include the code_annotations linter as part of the `quality` check in our CI pipelines. @DawoudSheraz I'm not sure what values need to go into some of these slots, so I left them as `??`. Could you update them?