### PR TITLE
third_party_auth python-3 upgrade

### DIFF
--- a/common/djangoapps/third_party_auth/tests/specs/base.py
+++ b/common/djangoapps/third_party_auth/tests/specs/base.py
@@ -62,11 +62,10 @@ class HelperMixin(object):
         assertions based on the provider's implementation; if you want more
         assertions in your test, override this method.
         """
-        self.assertEqual(200, response.status_code)
         # Check that the correct provider was selected.
-        self.assertIn(
+        self.assertContains(
+            response,
             u'successfully signed in with <strong>%s</strong>' % self.provider.name,
-            response.content.decode(response.charset)
         )
         # Expect that each truthy value we've prepopulated the register form
         # with is actually present.
@@ -144,11 +143,10 @@ class HelperMixin(object):
 
     def assert_login_response_before_pipeline_looks_correct(self, response):
         """Asserts a GET of /login not in the pipeline looks correct."""
-        self.assertEqual(200, response.status_code)
         # The combined login/registration page dynamically generates the login button,
         # but we can still check that the provider name is passed in the data attribute
         # for the container element.
-        self.assertIn(self.provider.name, response.content)
+        self.assertContains(response, self.provider.name)
 
     def assert_login_response_in_pipeline_looks_correct(self, response):
         """Asserts a GET of /login in the pipeline looks correct."""
@@ -186,11 +184,10 @@ class HelperMixin(object):
 
     def assert_register_response_before_pipeline_looks_correct(self, response):
         """Asserts a GET of /register not in the pipeline looks correct."""
-        self.assertEqual(200, response.status_code)
         # The combined login/registration page dynamically generates the register button,
         # but we can still check that the provider name is passed in the data attribute
         # for the container element.
-        self.assertIn(self.provider.name, response.content)
+        self.assertContains(response, self.provider.name)
 
     def assert_social_auth_does_not_exist_for_user(self, user, strategy):
         """Asserts a user does not have an auth with the expected provider."""
@@ -489,8 +486,7 @@ class IntegrationTestMixin(testutil.TestCase, test.TestCase, HelperMixin):
     def _check_login_or_register_page(self, url, url_to_return):
         """ Shared logic for _check_login_page() and _check_register_page() """
         response = self.client.get(url)
-        self.assertEqual(response.status_code, 200)
-        self.assertIn(self.PROVIDER_NAME, response.content)
+        self.assertContains(response, self.PROVIDER_NAME)
         context_data = response.context['data']['third_party_auth']
         provider_urls = {provider['id']: provider[url_to_return] for provider in context_data['providers']}
         self.assertIn(self.PROVIDER_ID, provider_urls)

--- a/common/djangoapps/third_party_auth/tests/specs/test_lti.py
+++ b/common/djangoapps/third_party_auth/tests/specs/test_lti.py
@@ -73,9 +73,8 @@ class IntegrationTestLTI(testutil.TestCase):
         self.assertEqual(login_response.status_code, 302)
         self.assertTrue(login_response['Location'].endswith(reverse('signin_user')))
         register_response = self.client.get(login_response['Location'])
-        self.assertEqual(register_response.status_code, 200)
-        self.assertIn('"currentProvider": "LTI Test Tool Consumer"', register_response.content)
-        self.assertIn('"errorMessage": null', register_response.content)
+        self.assertContains(register_response, '"currentProvider": "LTI Test Tool Consumer"')
+        self.assertContains(register_response, '"errorMessage": null')
 
         # Now complete the form:
         ajax_register_response = self.client.post(
@@ -131,9 +130,9 @@ class IntegrationTestLTI(testutil.TestCase):
         self.assertEqual(login_response.status_code, 302)
         self.assertTrue(login_response['Location'].endswith(reverse('signin_user')))
         error_response = self.client.get(login_response['Location'])
-        self.assertIn(
+        self.assertContains(
+            error_response,
             'Authentication failed: LTI parameters could not be validated.',
-            error_response.content
         )
 
     def test_can_load_consumer_secret_from_settings(self):
@@ -156,9 +155,8 @@ class IntegrationTestLTI(testutil.TestCase):
             self.assertEqual(login_response.status_code, 302)
             self.assertTrue(login_response['Location'].endswith(reverse('signin_user')))
             register_response = self.client.get(login_response['Location'])
-            self.assertEqual(register_response.status_code, 200)
-            self.assertIn(
+            self.assertContains(
+                register_response,
                 '"currentProvider": "Tool Consumer with Secret in Settings"',
-                register_response.content
             )
-            self.assertIn('"errorMessage": null', register_response.content)
+            self.assertContains(register_response, '"errorMessage": null')

--- a/common/djangoapps/third_party_auth/tests/specs/test_testshib.py
+++ b/common/djangoapps/third_party_auth/tests/specs/test_testshib.py
@@ -251,8 +251,7 @@ class TestShibIntegrationTest(SamlIntegrationTestUtilities, IntegrationTestMixin
         self.assertEqual(try_login_response['Location'], self.login_page_url)
         # When loading the login page, the user will see an error message:
         response = self.client.get(self.login_page_url)
-        self.assertEqual(response.status_code, 200)
-        self.assertIn('Authentication with TestShib is currently unavailable.', response.content)
+        self.assertContains(response, 'Authentication with TestShib is currently unavailable.')
 
     def test_login(self):
         """ Configure TestShib before running the login test """
@@ -373,10 +372,10 @@ class SuccessFactorsIntegrationTest(SamlIntegrationTestUtilities, IntegrationTes
             """
             Return a fake assertion after checking that the input is what we expect.
             """
-            self.assertIn('private_key=fake_private_key_here', _request.body)
-            self.assertIn('user_id=myself', _request.body)
-            self.assertIn('token_url=http%3A%2F%2Fsuccessfactors.com%2Foauth%2Ftoken', _request.body)
-            self.assertIn('client_id=TatVotSEiCMteSNWtSOnLanCtBGwNhGB', _request.body)
+            self.assertIn(b'private_key=fake_private_key_here', _request.body)
+            self.assertIn(b'user_id=myself', _request.body)
+            self.assertIn(b'token_url=http%3A%2F%2Fsuccessfactors.com%2Foauth%2Ftoken', _request.body)
+            self.assertIn(b'client_id=TatVotSEiCMteSNWtSOnLanCtBGwNhGB', _request.body)
             return (200, headers, 'fake_saml_assertion')
 
         httpretty.register_uri(httpretty.POST, SAPSF_ASSERTION_URL, content_type='text/plain', body=assertion_callback)
@@ -398,10 +397,10 @@ class SuccessFactorsIntegrationTest(SamlIntegrationTestUtilities, IntegrationTes
             """
             Return a fake assertion after checking that the input is what we expect.
             """
-            self.assertIn('assertion=fake_saml_assertion', _request.body)
-            self.assertIn('company_id=NCC1701D', _request.body)
-            self.assertIn('grant_type=urn%3Aietf%3Aparams%3Aoauth%3Agrant-type%3Asaml2-bearer', _request.body)
-            self.assertIn('client_id=TatVotSEiCMteSNWtSOnLanCtBGwNhGB', _request.body)
+            self.assertIn(b'assertion=fake_saml_assertion', _request.body)
+            self.assertIn(b'company_id=NCC1701D', _request.body)
+            self.assertIn(b'grant_type=urn%3Aietf%3Aparams%3Aoauth%3Agrant-type%3Asaml2-bearer', _request.body)
+            self.assertIn(b'client_id=TatVotSEiCMteSNWtSOnLanCtBGwNhGB', _request.body)
             return (200, headers, '{"access_token": "faketoken"}')
 
         httpretty.register_uri(httpretty.POST, SAPSF_TOKEN_URL, content_type='application/json', body=token_callback)

--- a/common/djangoapps/third_party_auth/tests/utils.py
+++ b/common/djangoapps/third_party_auth/tests/utils.py
@@ -135,7 +135,7 @@ def prepare_saml_response_from_xml(xml, relay_state='testshib'):
     Returns:
          (str): Base64 and URL encoded XML.
     """
-    b64encoded_xml = b64encode(xml)
+    b64encoded_xml = b64encode(xml.encode())
     return 'RelayState={relay_state}&SAMLResponse={saml_response}'.format(
         relay_state=OneLogin_Saml2_Utils.escape_url(relay_state),
         saml_response=OneLogin_Saml2_Utils.escape_url(b64encoded_xml)


### PR DESCRIPTION
This PR fixes the remaining `26` python-3 errors in the `third_party_auth` django app.