### PR TITLE
api_admin python-3 upgrade

### DIFF
--- a/openedx/core/djangoapps/api_admin/tests/test_views.py
+++ b/openedx/core/djangoapps/api_admin/tests/test_views.py
@@ -138,8 +138,7 @@ class ApiRequestStatusViewTest(ApiAdminTest):
         """
         ApiAccessRequestFactory(user=self.user, status=status)
         response = self.client.get(self.url)
-        self.assertEqual(response.status_code, 200)
-        self.assertIn(expected, response.content)
+        self.assertContains(response, expected)
 
     def test_get_with_existing_application(self):
         """
@@ -149,11 +148,9 @@ class ApiRequestStatusViewTest(ApiAdminTest):
         ApiAccessRequestFactory(user=self.user, status=ApiAccessRequest.APPROVED)
         application = ApplicationFactory(user=self.user)
         response = self.client.get(self.url)
-        self.assertEqual(response.status_code, 200)
-        unicode_content = response.content.decode('utf-8')
-        self.assertIn(application.client_secret, unicode_content)
-        self.assertIn(application.client_id, unicode_content)
-        self.assertIn(application.redirect_uris, unicode_content)
+        self.assertContains(response, application.client_secret)
+        self.assertContains(response, application.client_id)
+        self.assertContains(response, application.redirect_uris)
 
     def test_get_anonymous(self):
         """Verify that users must be logged in to see the page."""
@@ -208,7 +205,7 @@ class ApiRequestStatusViewTest(ApiAdminTest):
             'name': 'test.com',
             'redirect_uris': 'not a url'
         })
-        self.assertIn('Enter a valid URL.', response.content)
+        self.assertContains(response, 'Enter a valid URL.')
 
 
 @skip_unless_lms
@@ -222,8 +219,7 @@ class ApiTosViewTest(ApiAdminTest):
         """
         url = reverse('api_admin:api-tos')
         response = self.client.get(url)
-        self.assertEqual(response.status_code, 200)
-        self.assertIn('Terms of Service', response.content)
+        self.assertContains(response, 'Terms of Service')
 
 
 class CatalogTest(ApiAdminTest):
@@ -293,8 +289,7 @@ class CatalogListViewTest(CatalogTest):
         catalog = CatalogFactory(viewers=[self.catalog_user.username])
         self.mock_catalog_endpoint({'results': [catalog.attributes]})
         response = self.client.get(self.url)
-        self.assertEqual(response.status_code, 200)
-        self.assertIn(catalog.name, response.content.decode('utf-8'))
+        self.assertContains(response, catalog.name)
 
     @httpretty.activate
     def test_get_no_catalogs(self):
@@ -346,8 +341,7 @@ class CatalogEditViewTest(CatalogTest):
     def test_get(self):
         self.mock_catalog_endpoint(self.catalog.attributes, catalog_id=self.catalog.id)
         response = self.client.get(self.url)
-        self.assertEqual(response.status_code, 200)
-        self.assertIn(self.catalog.name, response.content.decode('utf-8'))
+        self.assertContains(response, self.catalog.name)
 
     @httpretty.activate
     def test_delete(self):


### PR DESCRIPTION
This PR fixes the remaining `5` python-3 errors in the `api_admin` django app.