### PR TITLE
block_structure python-3 upgrade

### DIFF
--- a/openedx/core/djangoapps/content/block_structure/tests/test_transformer_registry.py
+++ b/openedx/core/djangoapps/content/block_structure/tests/test_transformer_registry.py
@@ -72,7 +72,7 @@ class TransformerRegistryTestCase(TestCase):
         # hash with TestTransformer1
         with mock_registered_transformers([TestTransformer1]):
             version_hash_1 = TransformerRegistry.get_write_version_hash()
-            self.assertEqual(version_hash_1.decode('utf-8'), '+2nc5o2YRerVfAtItQBQ/6jVkkw=')
+            self.assertEqual(version_hash_1, '+2nc5o2YRerVfAtItQBQ/6jVkkw=')
 
             # should return the same value again
             self.assertEqual(version_hash_1, TransformerRegistry.get_write_version_hash())
@@ -80,5 +80,5 @@ class TransformerRegistryTestCase(TestCase):
         # hash with TestTransformer1 and TestTransformer2
         with mock_registered_transformers([TestTransformer1, TestTransformer2]):
             version_hash_2 = TransformerRegistry.get_write_version_hash()
-            self.assertEqual(version_hash_2.decode('utf-8'), '5GwhvmSM9hknjUslzPnKDA5QaCo=')
+            self.assertEqual(version_hash_2, '5GwhvmSM9hknjUslzPnKDA5QaCo=')
             self.assertNotEqual(version_hash_1, version_hash_2)

--- a/openedx/core/djangoapps/content/block_structure/transformer_registry.py
+++ b/openedx/core/djangoapps/content/block_structure/transformer_registry.py
@@ -49,7 +49,7 @@ class TransformerRegistry(PluginManager):
 
         sorted_transformers = sorted(cls.get_registered_transformers(), key=lambda t: t.name())
         for transformer in sorted_transformers:
-            hash_obj.update(transformer.name().encode('utf-8'))
+            hash_obj.update(six.b(transformer.name()))
             hash_obj.update(six.b(str(transformer.WRITE_VERSION)))
 
         return b64encode(hash_obj.digest()).decode('utf-8')


### PR DESCRIPTION
This PR fixes the remaining python-3 errors in the `block_structure` django app.