### PR TITLE
Python 3: Regex bulk changes

### DIFF
--- a/cms/djangoapps/contentstore/tests/test_contentstore.py
+++ b/cms/djangoapps/contentstore/tests/test_contentstore.py
@@ -676,10 +676,8 @@ class MiscCourseTests(ContentStoreTestCase):
 
         # just pick one vertical
         resp = self.client.get_html(get_url('container_handler', self.vert_loc))
-        self.assertEqual(resp.status_code, 200)
-
         for expected in expected_types:
-            self.assertIn(expected, resp.content.decode('utf-8'))
+            self.assertContains(resp, expected)
 
     @ddt.data("<script>alert(1)</script>", "alert('hi')", "</script><script>alert(1)</script>")
     def test_container_handler_xss_prevent(self, malicious_code):
@@ -687,9 +685,8 @@ class MiscCourseTests(ContentStoreTestCase):
         Test that XSS attack is prevented
         """
         resp = self.client.get_html(get_url('container_handler', self.vert_loc) + '?action=' + malicious_code)
-        self.assertEqual(resp.status_code, 200)
         # Test that malicious code does not appear in html
-        self.assertNotIn(malicious_code, resp.content.decode('utf-8'))
+        self.assertNotContains(resp, malicious_code)
 
     def test_advanced_components_in_edit_unit(self):
         # This could be made better, but for now let's just assert that we see the advanced modules mentioned in the

--- a/cms/djangoapps/contentstore/tests/test_course_listing.py
+++ b/cms/djangoapps/contentstore/tests/test_course_listing.py
@@ -93,8 +93,7 @@ class TestCourseListing(ModuleStoreTestCase):
         """
         message = u"Are you staff on an existing {studio_name} course?".format(studio_name=settings.STUDIO_SHORT_NAME)
         response = self.client.get('/home')
-        self.assertEqual(response.status_code, 200)
-        self.assertIn(message, response.content.decode(response.charset))
+        self.assertContains(response, message)
 
     def test_get_course_list(self):
         """

--- a/cms/djangoapps/contentstore/tests/test_export_git.py
+++ b/cms/djangoapps/contentstore/tests/test_export_git.py
@@ -88,7 +88,7 @@ class TestExportGit(CourseTestCase):
         modulestore().update_item(self.course_module, self.user.id)
 
         response = self.client.get('{}?action=push'.format(self.test_url))
-        self.assertIn('Export Failed:', response.content.decode('utf-8'))
+        self.assertContains(response, 'Export Failed:')
 
     def test_exception_translation(self):
         """
@@ -107,7 +107,7 @@ class TestExportGit(CourseTestCase):
 
         self.make_bare_repo_with_course('test_repo')
         response = self.client.get('{}?action=push'.format(self.test_url))
-        self.assertIn('Export Succeeded', response.content.decode('utf-8'))
+        self.assertContains(response, 'Export Succeeded')
 
     def test_repo_with_dots(self):
         """
@@ -115,7 +115,7 @@ class TestExportGit(CourseTestCase):
         """
         self.make_bare_repo_with_course('test.repo')
         response = self.client.get('{}?action=push'.format(self.test_url))
-        self.assertIn('Export Succeeded', response.content.decode('utf-8'))
+        self.assertContains(response, 'Export Succeeded')
 
     def test_dirty_repo(self):
         """

--- a/cms/djangoapps/contentstore/tests/test_export_git.py
+++ b/cms/djangoapps/contentstore/tests/test_export_git.py
@@ -65,19 +65,17 @@ class TestExportGit(CourseTestCase):
         if course hasn't set giturl.
         """
         response = self.client.get(self.test_url)
-        self.assertEqual(200, response.status_code)
-        self.assertIn(
+        self.assertContains(
+            response,
             ('giturl must be defined in your '
              'course settings before you can export to git.'),
-            response.content.decode('utf-8')
         )
 
         response = self.client.get('{}?action=push'.format(self.test_url))
-        self.assertEqual(200, response.status_code)
-        self.assertIn(
+        self.assertContains(
+            response,
             ('giturl must be defined in your '
              'course settings before you can export to git.'),
-            response.content.decode('utf-8')
         )
 
     def test_course_export_failures(self):

--- a/cms/djangoapps/contentstore/tests/test_export_git.py
+++ b/cms/djangoapps/contentstore/tests/test_export_git.py
@@ -98,7 +98,7 @@ class TestExportGit(CourseTestCase):
         modulestore().update_item(self.course_module, self.user.id)
 
         response = self.client.get('{}?action=push'.format(self.test_url))
-        self.assertNotIn('django.utils.functional.__proxy__', response.content.decode('utf-8'))
+        self.assertNotContains(response, 'django.utils.functional.__proxy__')
 
     def test_course_export_success(self):
         """

--- a/cms/djangoapps/contentstore/tests/tests.py
+++ b/cms/djangoapps/contentstore/tests/tests.py
@@ -319,7 +319,7 @@ class AuthTestCase(ContentStoreTestCase):
         is turned off
         """
         response = self.client.get(reverse('homepage'))
-        self.assertNotIn('<a class="action action-signup" href="/signup">Sign Up</a>', response.content)
+        self.assertNotContains(response, '<a class="action action-signup" href="/signup">Sign Up</a>')
 
     @mock.patch.dict(settings.FEATURES, {"ALLOW_PUBLIC_ACCOUNT_CREATION": False})
     def test_signup_button_login_page(self):
@@ -328,7 +328,7 @@ class AuthTestCase(ContentStoreTestCase):
         is turned off
         """
         response = self.client.get(reverse('login'))
-        self.assertNotIn('<a class="action action-signup" href="/signup">Sign Up</a>', response.content)
+        self.assertNotContains(response, '<a class="action action-signup" href="/signup">Sign Up</a>')
 
     @mock.patch.dict(settings.FEATURES, {"ALLOW_PUBLIC_ACCOUNT_CREATION": False})
     def test_signup_link_login_page(self):

--- a/cms/djangoapps/contentstore/tests/tests.py
+++ b/cms/djangoapps/contentstore/tests/tests.py
@@ -188,8 +188,7 @@ class AuthTestCase(ContentStoreTestCase):
             resp = self._login(self.email, 'wrong_password{0}'.format(i))
             self.assertEqual(resp.status_code, 403)
         resp = self._login(self.email, 'wrong_password')
-        self.assertEqual(resp.status_code, 403)
-        self.assertIn('Too many failed login attempts.', resp.content)
+        self.assertContains(resp, 'Too many failed login attempts.', status_code=403)
 
     @override_settings(MAX_FAILED_LOGIN_ATTEMPTS_ALLOWED=3)
     @override_settings(MAX_FAILED_LOGIN_ATTEMPTS_LOCKOUT_PERIOD_SECS=2)
@@ -241,12 +240,11 @@ class AuthTestCase(ContentStoreTestCase):
         # we want to test the rendering of the activation page when the user isn't logged in
         self.client.logout()
         resp = self._activate_user(self.email)
-        self.assertEqual(resp.status_code, 200)
 
         # check the the HTML has links to the right login page. Note that this is merely a content
         # check and thus could be fragile should the wording change on this page
         expected = 'You can now <a href="' + reverse('login') + '">sign in</a>.'
-        self.assertIn(expected, resp.content.decode('utf-8'))
+        self.assertContains(resp, expected)
 
     def test_private_pages_auth(self):
         """Make sure pages that do require login work."""

--- a/cms/djangoapps/contentstore/tests/tests.py
+++ b/cms/djangoapps/contentstore/tests/tests.py
@@ -202,19 +202,19 @@ class AuthTestCase(ContentStoreTestCase):
 
             for i in range(3):
                 resp = self._login(self.email, 'wrong_password{0}'.format(i))
-                self.assertEqual(resp.status_code, 403)
-                self.assertIn(
+                self.assertContains(
+                    resp,
                     'Email or password is incorrect.',
-                    resp.content
+                    status_code=403,
                 )
 
             # now the account should be locked
 
             resp = self._login(self.email, 'wrong_password')
-            self.assertEqual(resp.status_code, 403)
-            self.assertIn(
+            self.assertContains(
+                resp,
                 'This account has been temporarily locked due to excessive login failures.',
-                resp.content
+                status_code=403,
             )
 
             with freeze_time('2100-01-01'):
@@ -222,10 +222,10 @@ class AuthTestCase(ContentStoreTestCase):
 
             # make sure the failed attempt counter gets reset on successful login
             resp = self._login(self.email, 'wrong_password')
-            self.assertEqual(resp.status_code, 403)
-            self.assertIn(
+            self.assertContains(
+                resp,
                 'Email or password is incorrect.',
-                resp.content
+                status_code=403,
             )
 
             # account should not be locked out after just one attempt

--- a/cms/djangoapps/contentstore/views/tests/test_certificates.py
+++ b/cms/djangoapps/contentstore/views/tests/test_certificates.py
@@ -349,8 +349,7 @@ class CertificatesListHandlerTestCase(
             self._url(),
             data=CERTIFICATE_JSON
         )
-        self.assertEqual(response.status_code, 403)
-        self.assertIn("error", response.content)
+        self.assertContains(response, "error", status_code=403)
 
     def test_audit_course_mode_is_skipped(self):
         """

--- a/cms/djangoapps/contentstore/views/tests/test_course_index.py
+++ b/cms/djangoapps/contentstore/views/tests/test_course_index.py
@@ -311,7 +311,7 @@ class TestCourseIndex(CourseTestCase):
         self.assertEqual(response.status_code, 200)
 
         # Assert that 'display_course_number' is being set to "" (as display_coursenumber was None).
-        self.assertIn('display_course_number: ""', response.content)
+        self.assertContains(response, 'display_course_number: ""')
 
 
 @ddt.ddt
@@ -648,7 +648,7 @@ class TestCourseReIndex(CourseTestCase):
         response = self.client.get(index_url, {}, HTTP_ACCEPT='application/json')
 
         # A course with the default release date should display as "Unscheduled"
-        self.assertIn(self.SUCCESSFUL_RESPONSE, response.content)
+        self.assertContains(response, self.SUCCESSFUL_RESPONSE)
         self.assertEqual(response.status_code, 200)
 
         response = self.client.post(index_url, {}, HTTP_ACCEPT='application/json')
@@ -677,7 +677,7 @@ class TestCourseReIndex(CourseTestCase):
         response = self.client.get(index_url, {}, CONTENT_TYPE='')
 
         # A course with the default release date should display as "Unscheduled"
-        self.assertIn(self.SUCCESSFUL_RESPONSE, response.content)
+        self.assertContains(response, self.SUCCESSFUL_RESPONSE)
         self.assertEqual(response.status_code, 200)
 
     @mock.patch('xmodule.html_module.HtmlBlock.index_dictionary')

--- a/cms/djangoapps/contentstore/views/tests/test_item.py
+++ b/cms/djangoapps/contentstore/views/tests/test_item.py
@@ -160,7 +160,7 @@ class GetItemTest(ItemTest):
         resp = self._get_preview(usage_key, data)
         self.assertEqual(resp.status_code, expected_code)
         if content_contains:
-            self.assertIn(content_contains, resp.content)
+            self.assertContains(resp, content_contains, status_code=expected_code)
         return resp
 
     @ddt.data(
@@ -1615,8 +1615,7 @@ class TestEditItem(TestEditItemSetup):
             self.seq2_update_url,
             data={'children': [six.text_type(unit_1_key)]}
         )
-        self.assertEqual(resp.status_code, 400)
-        self.assertIn("Invalid data, possibly caused by concurrent authors", resp.content)
+        self.assertContains(resp, "Invalid data, possibly caused by concurrent authors", status_code=400)
 
         # verify children
         self.assertListEqual(
@@ -1640,8 +1639,7 @@ class TestEditItem(TestEditItemSetup):
             self.seq2_update_url,
             data={'children': [six.text_type(unit_1_key)]}
         )
-        self.assertEqual(resp.status_code, 400)
-        self.assertIn("Invalid data, possibly caused by concurrent authors", resp.content)
+        self.assertContains(resp, "Invalid data, possibly caused by concurrent authors", status_code=400)
 
         # verify children
         self.assertListEqual(

--- a/cms/djangoapps/contentstore/views/tests/test_library.py
+++ b/cms/djangoapps/contentstore/views/tests/test_library.py
@@ -257,8 +257,8 @@ class UnitTestLibraries(CourseTestCase):
 
         response = self.client.get(make_url_for_lib(lib.location.library_key))
         self.assertEqual(response.status_code, 200)
-        self.assertIn("<html", response.content)
-        self.assertIn(lib.display_name.encode('utf-8'), response.content)
+        self.assertContains(response, "<html")
+        self.assertContains(response, lib.display_name)
 
     @ddt.data('library-v1:Nonexistent+library', 'course-v1:Org+Course', 'course-v1:Org+Course+Run', 'invalid')
     def test_invalid_keys(self, key_str):

--- a/cms/djangoapps/contentstore/views/tests/test_library.py
+++ b/cms/djangoapps/contentstore/views/tests/test_library.py
@@ -341,4 +341,4 @@ class UnitTestLibraries(CourseTestCase):
         # Now extra_user should apear in the list:
         response = self.client.get(manage_users_url)
         self.assertEqual(response.status_code, 200)
-        self.assertIn(extra_user.username, response.content.decode('utf-8'))
+        self.assertContains(response, extra_user.username)

--- a/cms/djangoapps/contentstore/views/tests/test_library.py
+++ b/cms/djangoapps/contentstore/views/tests/test_library.py
@@ -328,7 +328,7 @@ class UnitTestLibraries(CourseTestCase):
         response = self.client.get(manage_users_url)
         self.assertEqual(response.status_code, 200)
         # extra_user has not been assigned to the library so should not show up in the list:
-        self.assertNotIn(extra_user.username, response.content.decode('utf-8'))
+        self.assertNotContains(response, extra_user.username)
 
         # Now add extra_user to the library:
         user_details_url = reverse_course_url(

--- a/cms/djangoapps/contentstore/views/tests/test_tabs.py
+++ b/cms/djangoapps/contentstore/views/tests/test_tabs.py
@@ -70,8 +70,7 @@ class TabsPageTests(CourseTestCase):
         """Basic check that the Pages page responds correctly"""
 
         resp = self.client.get_html(self.url)
-        self.assertEqual(resp.status_code, 200)
-        self.assertIn('course-nav-list', resp.content.decode('utf-8'))
+        self.assertContains(resp, 'course-nav-list')
 
     def test_reorder_tabs(self):
         """Test re-ordering of tabs"""

--- a/cms/djangoapps/contentstore/views/tests/test_videos.py
+++ b/cms/djangoapps/contentstore/views/tests/test_videos.py
@@ -325,10 +325,10 @@ class VideosHandlerTestCase(VideoUploadTestMixin, CourseTestCase):
         response = self.client.get(self.url)
         self.assertEqual(response.status_code, 200)
         self.assertRegexpMatches(response["Content-Type"], "^text/html(;.*)?$")
-        self.assertIn(_get_default_video_image_url(), response.content.decode('utf-8'))
+        self.assertContains(response, _get_default_video_image_url())
         # Crude check for presence of data in returned HTML
         for video in self.previous_uploads:
-            self.assertIn(video["edx_video_id"], response.content.decode('utf-8'))
+            self.assertContains(response, video["edx_video_id"])
         self.assertNotContains(response, 'video_upload_pagination')
 
     @override_waffle_flag(ENABLE_VIDEO_UPLOAD_PAGINATION, active=True)
@@ -338,7 +338,7 @@ class VideosHandlerTestCase(VideoUploadTestMixin, CourseTestCase):
         """
         response = self.client.get(self.url)
         self.assertEqual(response.status_code, 200)
-        self.assertIn('video_upload_pagination', response.content.decode('utf-8'))
+        self.assertContains(response, 'video_upload_pagination')
 
     def test_post_non_json(self):
         response = self.client.post(self.url, {"files": []})

--- a/cms/djangoapps/contentstore/views/tests/test_videos.py
+++ b/cms/djangoapps/contentstore/views/tests/test_videos.py
@@ -329,7 +329,7 @@ class VideosHandlerTestCase(VideoUploadTestMixin, CourseTestCase):
         # Crude check for presence of data in returned HTML
         for video in self.previous_uploads:
             self.assertIn(video["edx_video_id"], response.content.decode('utf-8'))
-        self.assertNotIn('video_upload_pagination', response.content.decode('utf-8'))
+        self.assertNotContains(response, 'video_upload_pagination')
 
     @override_waffle_flag(ENABLE_VIDEO_UPLOAD_PAGINATION, active=True)
     def test_get_html_paginated(self):

--- a/cms/djangoapps/contentstore/views/tests/test_videos.py
+++ b/cms/djangoapps/contentstore/views/tests/test_videos.py
@@ -781,10 +781,11 @@ class VideosHandlerTestCase(VideoUploadTestMixin, CourseTestCase):
         self.assertEqual(response.status_code, 200)
 
         # Verify that course video button is present in the response if videos transcript feature is enabled.
-        self.assertEqual(
-            '<button class="button course-video-settings-button">' in response.content.decode('utf-8'),
-            is_video_transcript_enabled
-        )
+        button_html = '<button class="button course-video-settings-button">'
+        if is_video_transcript_enabled:
+            self.assertContains(response, button_html)
+        else:
+            self.assertNotContains(response, button_html)
 
 
 @ddt.ddt

--- a/cms/djangoapps/maintenance/tests.py
+++ b/cms/djangoapps/maintenance/tests.py
@@ -289,7 +289,7 @@ class TestAnnouncementsViews(MaintenanceViewTestCase):
         """
         url = reverse("maintenance:announcement_index")
         response = self.client.get(url)
-        self.assertIn('<div class="announcement-container">', response.content.decode('utf-8'))
+        self.assertContains(response, '<div class="announcement-container">')
 
     def test_create(self):
         """
@@ -308,7 +308,7 @@ class TestAnnouncementsViews(MaintenanceViewTestCase):
         announcement.save()
         url = reverse("maintenance:announcement_edit", kwargs={"pk": announcement.pk})
         response = self.client.get(url)
-        self.assertIn('<div class="wrapper-form announcement-container">', response.content.decode('utf-8'))
+        self.assertContains(response, '<div class="wrapper-form announcement-container">')
         self.client.post(url, {"content": "Test Edit Announcement", "active": True})
         announcement = Announcement.objects.get(pk=announcement.pk)
         self.assertEquals(announcement.content, "Test Edit Announcement")

--- a/common/djangoapps/third_party_auth/tests/specs/base.py
+++ b/common/djangoapps/third_party_auth/tests/specs/base.py
@@ -121,10 +121,10 @@ class HelperMixin(object):
 
     def assert_json_failure_response_is_missing_social_auth(self, response):
         """Asserts failure on /login for missing social auth looks right."""
-        self.assertEqual(403, response.status_code)
-        self.assertIn(
+        self.assertContains(
+            response,
             u"successfully signed in to your %s account, but this account isn&#39;t linked" % self.provider.name,
-            response.content.decode(response.charset)
+            status_code=403,
         )
 
     def assert_json_failure_response_is_username_collision(self, response):

--- a/lms/djangoapps/branding/tests/test_page.py
+++ b/lms/djangoapps/branding/tests/test_page.py
@@ -202,15 +202,15 @@ class IndexPageCourseCardsSortingTests(ModuleStoreTestCase):
         response = self.client.get('/')
         self.assertEqual(response.status_code, 200)
         # assert that the course discovery UI is not present
-        self.assertNotIn('Search for a course', response.content)
+        self.assertNotContains(response, 'Search for a course')
 
         # check the /courses view
         response = self.client.get(reverse('courses'))
         self.assertEqual(response.status_code, 200)
 
         # assert that the course discovery UI is not present
-        self.assertNotIn('Search for a course', response.content)
-        self.assertNotIn('<aside aria-label="Refine Your Search" class="search-facets phone-menu">', response.content)
+        self.assertNotContains(response, 'Search for a course')
+        self.assertNotContains(response, '<aside aria-label="Refine Your Search" class="search-facets phone-menu">')
 
         # make sure we have the special css class on the section
         self.assertContains(response, '<div class="courses no-course-discovery"')

--- a/lms/djangoapps/branding/tests/test_page.py
+++ b/lms/djangoapps/branding/tests/test_page.py
@@ -148,11 +148,10 @@ class PreRequisiteCourseCatalog(ModuleStoreTestCase, LoginEnrollmentTestCase, Mi
         set_prerequisite_courses(course.id, pre_requisite_courses)
 
         resp = self.client.get('/')
-        self.assertEqual(resp.status_code, 200)
 
         # make sure both courses are visible in the catalog
-        self.assertIn('pre requisite course', resp.content)
-        self.assertIn('course that has pre requisite', resp.content)
+        self.assertContains(resp, 'pre requisite course')
+        self.assertContains(resp, 'course that has pre requisite')
 
 
 class IndexPageCourseCardsSortingTests(ModuleStoreTestCase):

--- a/lms/djangoapps/branding/tests/test_page.py
+++ b/lms/djangoapps/branding/tests/test_page.py
@@ -213,7 +213,7 @@ class IndexPageCourseCardsSortingTests(ModuleStoreTestCase):
         self.assertNotIn('<aside aria-label="Refine Your Search" class="search-facets phone-menu">', response.content)
 
         # make sure we have the special css class on the section
-        self.assertIn('<div class="courses no-course-discovery"', response.content)
+        self.assertContains(response, '<div class="courses no-course-discovery"')
 
     @patch('student.views.management.render_to_response', RENDER_MOCK)
     @patch('lms.djangoapps.courseware.views.views.render_to_response', RENDER_MOCK)
@@ -226,16 +226,16 @@ class IndexPageCourseCardsSortingTests(ModuleStoreTestCase):
         response = self.client.get('/')
         self.assertEqual(response.status_code, 200)
         # assert that the course discovery UI is not present
-        self.assertIn('Search for a course', response.content)
+        self.assertContains(response, 'Search for a course')
 
         # check the /courses view
         response = self.client.get(reverse('courses'))
         self.assertEqual(response.status_code, 200)
 
         # assert that the course discovery UI is present
-        self.assertIn('Search for a course', response.content)
-        self.assertIn('<aside aria-label="Refine Your Search" class="search-facets phone-menu">', response.content)
-        self.assertIn('<div class="courses"', response.content)
+        self.assertContains(response, 'Search for a course')
+        self.assertContains(response, '<aside aria-label="Refine Your Search" class="search-facets phone-menu">')
+        self.assertContains(response, '<div class="courses"')
 
     @patch('student.views.management.render_to_response', RENDER_MOCK)
     @patch('lms.djangoapps.courseware.views.views.render_to_response', RENDER_MOCK)

--- a/lms/djangoapps/branding/tests/test_views.py
+++ b/lms/djangoapps/branding/tests/test_views.py
@@ -48,9 +48,8 @@ class TestFooter(CacheIsolationTestCase):
         with with_comprehensive_theme_context(theme):
             resp = self._get_footer(accepts=accepts)
 
-        self.assertEqual(resp.status_code, 200)
         self.assertEqual(resp["Content-Type"], content_type)
-        self.assertIn(content, resp.content.decode('utf-8'))
+        self.assertContains(resp, content)
 
     @mock.patch.dict(settings.FEATURES, {'ENABLE_FOOTER_MOBILE_APP_LINKS': True})
     @ddt.data("edx.org", None)
@@ -159,8 +158,7 @@ class TestFooter(CacheIsolationTestCase):
         with with_comprehensive_theme_context(theme):
             resp = self._get_footer(accepts="text/html", params={'language': language})
 
-        self.assertEqual(resp.status_code, 200)
-        self.assertIn(static_path, resp.content.decode('utf-8'))
+        self.assertContains(resp, static_path)
 
     @ddt.data(
         # OpenEdX
@@ -179,12 +177,10 @@ class TestFooter(CacheIsolationTestCase):
             params = {'show-openedx-logo': 1} if show_logo else {}
             resp = self._get_footer(accepts="text/html", params=params)
 
-        self.assertEqual(resp.status_code, 200)
-
         if show_logo:
-            self.assertIn('alt="Powered by Open edX"', resp.content.decode('utf-8'))
+            self.assertContains(resp, 'alt="Powered by Open edX"')
         else:
-            self.assertNotIn('alt="Powered by Open edX"', resp.content.decode('utf-8'))
+            self.assertNotContains(resp, 'alt="Powered by Open edX"')
 
     @ddt.data(
         # OpenEdX
@@ -202,12 +198,10 @@ class TestFooter(CacheIsolationTestCase):
             params = {'include-dependencies': 1} if include_dependencies else {}
             resp = self._get_footer(accepts="text/html", params=params)
 
-        self.assertEqual(resp.status_code, 200)
-
         if include_dependencies:
-            self.assertIn("vendor", resp.content.decode('utf-8'))
+            self.assertContains(resp, "vendor",)
         else:
-            self.assertNotIn("vendor", resp.content.decode('utf-8'))
+            self.assertNotContains(resp, "vendor")
 
     @ddt.data(
         # OpenEdX
@@ -239,7 +233,7 @@ class TestFooter(CacheIsolationTestCase):
             selected_language = language if language else 'en'
             self._verify_language_selector(resp, selected_language)
         else:
-            self.assertNotIn('footer-language-selector', resp.content.decode('utf-8'))
+            self.assertNotContains(resp, 'footer-language-selector')
 
     def test_no_supported_accept_type(self):
         self._set_feature_flag(True)

--- a/lms/djangoapps/branding/tests/test_views.py
+++ b/lms/djangoapps/branding/tests/test_views.py
@@ -315,4 +315,4 @@ class TestIndex(SiteMixin, TestCase):
         self.use_site(self.site_other)
         self.client.login(username=self.user.username, password="password")
         response = self.client.get(reverse("dashboard"))
-        self.assertContains(response, self.site_configuration_other.values["MKTG_URLS"]["ROOT"])
+        self.assertIn(self.site_configuration_other.values["MKTG_URLS"]["ROOT"], response.content.decode('utf-8'))

--- a/lms/djangoapps/branding/tests/test_views.py
+++ b/lms/djangoapps/branding/tests/test_views.py
@@ -315,4 +315,4 @@ class TestIndex(SiteMixin, TestCase):
         self.use_site(self.site_other)
         self.client.login(username=self.user.username, password="password")
         response = self.client.get(reverse("dashboard"))
-        self.assertIn(self.site_configuration_other.values["MKTG_URLS"]["ROOT"], response.content.decode('utf-8'))
+        self.assertContains(response, self.site_configuration_other.values["MKTG_URLS"]["ROOT"])

--- a/lms/djangoapps/bulk_email/tests/test_course_optout.py
+++ b/lms/djangoapps/bulk_email/tests/test_course_optout.py
@@ -57,7 +57,7 @@ class TestOptoutCourseEmails(ModuleStoreTestCase):
         response = self.client.get(url)
         email_section = '<div class="vert-left send-email" id="section-send-email">'
         # If this fails, it is likely because BulkEmailFlag.is_enabled() is set to False
-        self.assertIn(email_section, response.content.decode('utf-8'))
+        self.assertContains(response, email_section)
 
     def test_optout_course(self):
         """

--- a/lms/djangoapps/bulk_email/tests/test_email.py
+++ b/lms/djangoapps/bulk_email/tests/test_email.py
@@ -100,7 +100,7 @@ class EmailSendFromDashboardTestCase(SharedModuleStoreTestCase):
         response = self.client.get(url)
         email_section = '<div class="vert-left send-email" id="section-send-email">'
         # If this fails, it is likely because bulk_email.api.is_bulk_email_feature_enabled is set to False
-        self.assertIn(email_section, response.content)
+        self.assertContains(response, email_section)
 
     @classmethod
     def setUpClass(cls):

--- a/lms/djangoapps/bulk_email/tests/test_signals.py
+++ b/lms/djangoapps/bulk_email/tests/test_signals.py
@@ -60,7 +60,7 @@ class TestOptoutCourseEmailsBySignal(ModuleStoreTestCase):
         email_section = '<div class="vert-left send-email" id="section-send-email">'
 
         # If this fails, it is likely because BulkEmailFlag.is_enabled() is set to False
-        self.assertIn(email_section, response.content)
+        self.assertContains(response, email_section)
 
         test_email = {
             'action': 'Send email',

--- a/lms/djangoapps/bulk_enroll/tests/test_views.py
+++ b/lms/djangoapps/bulk_enroll/tests/test_views.py
@@ -349,10 +349,10 @@ class BulkEnrollmentTest(ModuleStoreTestCase, LoginEnrollmentTestCase, APITestCa
             'courses': self.course_key,
             'cohorts': "cohort1,cohort2"
         })
-        self.assertEqual(response.status_code, 400)
-        self.assertIn(
+        self.assertContains(
+            response,
             'If provided, the cohorts and courses should have equal number of items.',
-            response.content.decode('utf-8')
+            status_code=400,
         )
 
     def test_fail_on_missing_cohorts(self):
@@ -366,10 +366,13 @@ class BulkEnrollmentTest(ModuleStoreTestCase, LoginEnrollmentTestCase, APITestCa
             'cohorts': 'cohort1',
             'courses': self.course_key
         })
-        self.assertEqual(response.status_code, 400)
-        self.assertIn(u'cohort {cohort_name} not found in course {course_id}.'.format(
-            cohort_name='cohort1', course_id=self.course_key
-        ), response.content.decode('utf-8'))
+        self.assertContains(
+            response,
+            u'cohort {cohort_name} not found in course {course_id}.'.format(
+                cohort_name='cohort1', course_id=self.course_key
+            ),
+            status_code=400,
+        )
 
     def test_allow_cohorts_when_enrolling(self):
         """

--- a/lms/djangoapps/bulk_enroll/tests/test_views.py
+++ b/lms/djangoapps/bulk_enroll/tests/test_views.py
@@ -383,8 +383,7 @@ class BulkEnrollmentTest(ModuleStoreTestCase, LoginEnrollmentTestCase, APITestCa
             'cohorts': 'cohort1',
             'courses': self.course_key
         })
-        self.assertEqual(response.status_code, 400)
-        self.assertIn('Cohorts can only be used for enrollments.', response.content.decode('utf-8'))
+        self.assertContains(response, 'Cohorts can only be used for enrollments.', status_code=400)
 
     def test_add_to_valid_cohort(self):
         config_course_cohorts(self.course, is_cohorted=True, manual_cohorts=["cohort1", "cohort2"])

--- a/lms/djangoapps/certificates/tests/test_views.py
+++ b/lms/djangoapps/certificates/tests/test_views.py
@@ -295,7 +295,7 @@ class CertificatesViewsSiteTests(ModuleStoreTestCase):
         self.assertIn(
             'My Platform Site offers interactive online classes and MOOCs.', response.content.decode('utf-8')
         )
-        self.assertIn('About My Platform Site', response.content.decode('utf-8'))
+        self.assertContains(response, 'About My Platform Site')
 
     @override_settings(FEATURES=FEATURES_WITH_CERTS_ENABLED)
     def test_html_view_site_configuration_missing(self):
@@ -305,7 +305,7 @@ class CertificatesViewsSiteTests(ModuleStoreTestCase):
         )
         self._add_course_certificates(count=1, signatory_count=2)
         response = self.client.get(test_url)
-        self.assertIn('edX', response.content.decode('utf-8'))
+        self.assertContains(response, 'edX')
         self.assertNotContains(response, 'My Platform Site')
         self.assertNotIn(
             'This should not survive being overwritten by static content', response.content.decode('utf-8')

--- a/lms/djangoapps/certificates/tests/test_views.py
+++ b/lms/djangoapps/certificates/tests/test_views.py
@@ -306,7 +306,7 @@ class CertificatesViewsSiteTests(ModuleStoreTestCase):
         self._add_course_certificates(count=1, signatory_count=2)
         response = self.client.get(test_url)
         self.assertIn('edX', response.content.decode('utf-8'))
-        self.assertNotIn('My Platform Site', response.content.decode('utf-8'))
+        self.assertNotContains(response, 'My Platform Site')
         self.assertNotIn(
             'This should not survive being overwritten by static content', response.content.decode('utf-8')
         )

--- a/lms/djangoapps/certificates/tests/test_views.py
+++ b/lms/djangoapps/certificates/tests/test_views.py
@@ -289,11 +289,13 @@ class CertificatesViewsSiteTests(ModuleStoreTestCase):
         )
         self._add_course_certificates(count=1, signatory_count=2)
         response = self.client.get(test_url)
-        self.assertIn(
-            'awarded this My Platform Site Honor Code Certificate of Completion', response.content.decode('utf-8')
+        self.assertContains(
+            response,
+            'awarded this My Platform Site Honor Code Certificate of Completion',
         )
-        self.assertIn(
-            'My Platform Site offers interactive online classes and MOOCs.', response.content.decode('utf-8')
+        self.assertContains(
+            response,
+            'My Platform Site offers interactive online classes and MOOCs.'
         )
         self.assertContains(response, 'About My Platform Site')
 
@@ -307,6 +309,7 @@ class CertificatesViewsSiteTests(ModuleStoreTestCase):
         response = self.client.get(test_url)
         self.assertContains(response, 'edX')
         self.assertNotContains(response, 'My Platform Site')
-        self.assertNotIn(
-            'This should not survive being overwritten by static content', response.content.decode('utf-8')
+        self.assertNotContains(
+            response,
+            'This should not survive being overwritten by static content',
         )

--- a/lms/djangoapps/certificates/tests/test_webview_views.py
+++ b/lms/djangoapps/certificates/tests/test_webview_views.py
@@ -637,7 +637,7 @@ class CertificatesViewsTests(CommonCertificatesTestCase, CacheIsolationTestCase)
             self.assertIn("Invalid Certificate", response.content.decode('utf-8'))
             self.assertIn("Cannot Find Certificate", response.content.decode('utf-8'))
             self.assertIn("We cannot find a certificate with this URL or ID number.", response.content.decode('utf-8'))
-            self.assertNotIn(str(self.cert.verify_uuid), response.content.decode('utf-8'))
+            self.assertNotContains(response, str(self.cert.verify_uuid))
 
     @override_settings(FEATURES=FEATURES_WITH_CERTS_ENABLED)
     def test_html_view_for_invalid_certificate(self):
@@ -772,7 +772,7 @@ class CertificatesViewsTests(CommonCertificatesTestCase, CacheIsolationTestCase)
         )
 
         response = self.client.get(test_url)
-        self.assertNotIn('test_course_title_0', response.content.decode('utf-8'))
+        self.assertNotContains(response, 'test_course_title_0')
         self.assertIn('refundable course', response.content.decode('utf-8'))
 
     @override_settings(FEATURES=FEATURES_WITH_CERTS_ENABLED)
@@ -829,8 +829,8 @@ class CertificatesViewsTests(CommonCertificatesTestCase, CacheIsolationTestCase)
             course_id=six.text_type(self.course.id)
         )
         response = self.client.get(test_url)
-        self.assertNotIn('Signatory_Name 0', response.content.decode('utf-8'))
-        self.assertNotIn('Signatory_Title 0', response.content.decode('utf-8'))
+        self.assertNotContains(response, 'Signatory_Name 0')
+        self.assertNotContains(response, 'Signatory_Title 0')
 
     @override_settings(FEATURES=FEATURES_WITH_CERTS_ENABLED)
     def test_render_html_view_is_html_escaped(self):
@@ -857,7 +857,7 @@ class CertificatesViewsTests(CommonCertificatesTestCase, CacheIsolationTestCase)
             course_id=six.text_type(self.course.id)
         )
         response = self.client.get(test_url)
-        self.assertNotIn('<script>', response.content.decode('utf-8'))
+        self.assertNotContains(response, '<script>')
         self.assertIn('&lt;script&gt;course_title&lt;/script&gt;', response.content.decode('utf-8'))
 
     @override_settings(FEATURES=FEATURES_WITH_CERTS_DISABLED)
@@ -1531,7 +1531,7 @@ class CertificatesViewsTests(CommonCertificatesTestCase, CacheIsolationTestCase)
         if include_effort:
             self.assertIn('hours of effort: 40', response.content.decode('utf-8'))
         else:
-            self.assertNotIn('hours of effort', response.content.decode('utf-8'))
+            self.assertNotContains(response, 'hours of effort')
 
     @ddt.data(True, False)
     @patch('lms.djangoapps.certificates.views.webview.get_course_run_details')

--- a/lms/djangoapps/certificates/tests/test_webview_views.py
+++ b/lms/djangoapps/certificates/tests/test_webview_views.py
@@ -942,14 +942,14 @@ class CertificatesViewsTests(CommonCertificatesTestCase, CacheIsolationTestCase)
         CourseStaffRole(self.course.id).add_users(self.user)
 
         response = self.client.get(test_url + '?preview=honor')
-        self.assertNotIn(self.course.display_name.encode('utf-8'), response.content)
+        self.assertNotContains(response, self.course.display_name.encode('utf-8'))
         self.assertIn('course_title_0', response.content.decode('utf-8'))
         self.assertIn('Signatory_Title 0', response.content.decode('utf-8'))
 
         # mark certificate inactive but accessing in preview mode.
         self._add_course_certificates(count=1, signatory_count=2, is_active=False)
         response = self.client.get(test_url + '?preview=honor')
-        self.assertNotIn(self.course.display_name.encode('utf-8'), response.content)
+        self.assertNotContains(response, self.course.display_name.encode('utf-8'))
         self.assertIn('course_title_0', response.content.decode('utf-8'))
         self.assertIn('Signatory_Title 0', response.content.decode('utf-8'))
 
@@ -970,7 +970,7 @@ class CertificatesViewsTests(CommonCertificatesTestCase, CacheIsolationTestCase)
         # user has already has certificate generated for 'honor' mode
         # so let's try to preview in 'verified' mode.
         response = self.client.get(test_url + '?preview=verified')
-        self.assertNotIn(self.course.display_name.encode('utf-8'), response.content)
+        self.assertNotContains(response, self.course.display_name.encode('utf-8'))
         self.assertIn('course_title_0', response.content.decode('utf-8'))
         self.assertIn('Signatory_Title 0', response.content.decode('utf-8'))
 

--- a/lms/djangoapps/certificates/tests/test_webview_views.py
+++ b/lms/djangoapps/certificates/tests/test_webview_views.py
@@ -273,9 +273,9 @@ class CertificatesViewsTests(CommonCertificatesTestCase, CacheIsolationTestCase)
             ).encode('utf-8'),),
             ('pfCertificationUrl', self.request.build_absolute_uri(test_url),),
         ])
-        self.assertIn(
+        self.assertContains(
+            response,
             js_escaped_string(self.linkedin_url.format(params=urlencode(params))),
-            response.content.decode('utf-8')
         )
 
     @override_settings(FEATURES=FEATURES_WITH_CERTS_ENABLED)
@@ -300,9 +300,9 @@ class CertificatesViewsTests(CommonCertificatesTestCase, CacheIsolationTestCase)
             ).encode('utf-8'),),
             ('pfCertificationUrl', 'http://test.localhost' + test_url,),
         ])
-        self.assertIn(
+        self.assertContains(
+            response,
             js_escaped_string(self.linkedin_url.format(params=urlencode(params))),
-            response.content.decode('utf-8')
         )
 
     @override_settings(FEATURES=FEATURES_WITH_CERTS_ENABLED)
@@ -414,20 +414,13 @@ class CertificatesViewsTests(CommonCertificatesTestCase, CacheIsolationTestCase)
             course_id=six.text_type(self.course.id)
         )
         response = self.client.get(test_url)
-        content = response.content.decode(response.charset)
-        self.assertIn(
+        self.assertContains(
+            response,
             'a course of study offered by test_organization, an online learning initiative of test organization',
-            content
         )
-        self.assertNotIn(
-            'a course of study offered by testorg',
-            content
-        )
-        self.assertIn(
-            u'<title>test_organization {} Certificate |'.format(self.course.number, ),
-            content
-        )
-        self.assertIn('logo_test1.png', content)
+        self.assertNotContains(response, 'a course of study offered by testorg')
+        self.assertContains(response, u'<title>test_organization {} Certificate |'.format(self.course.number, ))
+        self.assertContains(response, 'logo_test1.png')
 
     @ddt.data(True, False)
     @patch('lms.djangoapps.certificates.views.webview.get_completion_badge')
@@ -503,63 +496,33 @@ class CertificatesViewsTests(CommonCertificatesTestCase, CacheIsolationTestCase)
         response = self.client.get(test_url, HTTP_HOST='test.localhost')
 
         # Test an item from basic info
-        self.assertIn(
-            'Terms of Service &amp; Honor Code',
-            response.content.decode('utf-8')
-        )
-        self.assertIn(
-            'Certificate ID Number',
-            response.content.decode('utf-8')
-        )
+        self.assertContains(response, 'Terms of Service &amp; Honor Code')
+        self.assertContains(response, 'Certificate ID Number')
         # Test an item from html cert configuration
-        self.assertIn(
-            '<a class="logo" href="http://test_site.localhost">',
-            response.content.decode('utf-8')
-        )
+        self.assertContains(response, '<a class="logo" href="http://test_site.localhost">')
         # Test an item from course info
-        self.assertIn(
-            'course_title_0',
-            response.content.decode('utf-8')
-        )
+        self.assertContains(response, 'course_title_0')
         # Test an item from user info
-        self.assertIn(
-            u"{fullname}, you earned a certificate!".format(fullname=self.user.profile.name),
-            response.content.decode('utf-8')
-        )
+        self.assertContains(response, u"{fullname}, you earned a certificate!".format(fullname=self.user.profile.name))
         # Test an item from social info
-        self.assertIn(
-            "Post on Facebook",
-            response.content.decode('utf-8')
-        )
-        self.assertIn(
-            "Share on Twitter",
-            response.content.decode('utf-8')
-        )
+        self.assertContains(response, "Post on Facebook")
+        self.assertContains(response, "Share on Twitter")
         # Test an item from certificate/org info
-        self.assertIn(
+        self.assertContains(
+            response,
             u"a course of study offered by {partner_short_name}, "
             "an online learning initiative of "
             "{partner_long_name}.".format(
                 partner_short_name=short_org_name,
                 partner_long_name=long_org_name,
             ),
-            response.content.decode('utf-8')
         )
         # Test item from badge info
-        self.assertIn(
-            "Add to Mozilla Backpack",
-            response.content.decode('utf-8')
-        )
+        self.assertContains(response, "Add to Mozilla Backpack")
         # Test item from site configuration
-        self.assertIn(
-            "http://www.test-site.org/about-us",
-            response.content.decode('utf-8')
-        )
+        self.assertContains(response, "http://www.test-site.org/about-us")
         # Test course overrides
-        self.assertIn(
-            "/static/certificates/images/course_override_logo.png",
-            response.content.decode('utf-8')
-        )
+        self.assertContains(response, "/static/certificates/images/course_override_logo.png")
 
     @override_settings(FEATURES=FEATURES_WITH_CERTS_ENABLED)
     def test_render_html_view_valid_certificate(self):
@@ -1006,7 +969,7 @@ class CertificatesViewsTests(CommonCertificatesTestCase, CacheIsolationTestCase)
             day=expected_date.day,
             year=expected_date.year
         )
-        self.assertIn(date, response.content.decode(response.charset))
+        self.assertContains(response, date)
 
     @override_settings(FEATURES=FEATURES_WITH_CERTS_ENABLED)
     def test_render_html_view_invalid_certificate_configuration(self):

--- a/lms/djangoapps/certificates/tests/test_webview_views.py
+++ b/lms/djangoapps/certificates/tests/test_webview_views.py
@@ -319,8 +319,8 @@ class CertificatesViewsTests(CommonCertificatesTestCase, CacheIsolationTestCase)
         test_url = get_certificate_url(course_id=self.cert.course_id, uuid=self.cert.verify_uuid)
         response = self.client.get(test_url, HTTP_HOST='test.localhost')
         self.assertEqual(response.status_code, 200)
-        self.assertIn("Post on Facebook", response.content.decode('utf-8'))
-        self.assertIn('test_facebook_my_site', response.content.decode('utf-8'))
+        self.assertContains(response, "Post on Facebook")
+        self.assertContains(response, 'test_facebook_my_site')
 
     @override_settings(FEATURES=FEATURES_WITH_CERTS_ENABLED)
     @ddt.data(
@@ -569,19 +569,19 @@ class CertificatesViewsTests(CommonCertificatesTestCase, CacheIsolationTestCase)
             course_id=six.text_type(self.course.id)
         )
         response = self.client.get(test_url)
-        self.assertIn(str(self.cert.verify_uuid), response.content.decode('utf-8'))
+        self.assertContains(response, str(self.cert.verify_uuid))
 
         # Hit any "verified" mode-specific branches
         self.cert.mode = 'verified'
         self.cert.save()
         response = self.client.get(test_url)
-        self.assertIn(str(self.cert.verify_uuid), response.content.decode('utf-8'))
+        self.assertContains(response, str(self.cert.verify_uuid))
 
         # Hit any 'xseries' mode-specific branches
         self.cert.mode = 'xseries'
         self.cert.save()
         response = self.client.get(test_url)
-        self.assertIn(str(self.cert.verify_uuid), response.content.decode('utf-8'))
+        self.assertContains(response, str(self.cert.verify_uuid))
 
     @override_settings(FEATURES=FEATURES_WITH_CERTS_ENABLED)
     def test_render_certificate_only_for_downloadable_status(self):
@@ -597,15 +597,15 @@ class CertificatesViewsTests(CommonCertificatesTestCase, CacheIsolationTestCase)
 
         # Validate certificate
         response = self.client.get(test_url)
-        self.assertIn(str(self.cert.verify_uuid), response.content.decode('utf-8'))
+        self.assertContains(response, str(self.cert.verify_uuid))
 
         # Change status to 'generating' and validate that Certificate Web View returns "Invalid Certificate"
         self.cert.status = CertificateStatuses.generating
         self.cert.save()
         response = self.client.get(test_url)
-        self.assertIn("Invalid Certificate", response.content.decode('utf-8'))
-        self.assertIn("Cannot Find Certificate", response.content.decode('utf-8'))
-        self.assertIn("We cannot find a certificate with this URL or ID number.", response.content.decode('utf-8'))
+        self.assertContains(response, "Invalid Certificate")
+        self.assertContains(response, "Cannot Find Certificate")
+        self.assertContains(response, "We cannot find a certificate with this URL or ID number.")
 
     @ddt.data(
         (CertificateStatuses.downloadable, True),
@@ -632,11 +632,11 @@ class CertificatesViewsTests(CommonCertificatesTestCase, CacheIsolationTestCase)
         response = self.client.get(test_url)
 
         if eligible_for_certificate:
-            self.assertIn(str(self.cert.verify_uuid), response.content.decode('utf-8'))
+            self.assertContains(response, str(self.cert.verify_uuid))
         else:
-            self.assertIn("Invalid Certificate", response.content.decode('utf-8'))
-            self.assertIn("Cannot Find Certificate", response.content.decode('utf-8'))
-            self.assertIn("We cannot find a certificate with this URL or ID number.", response.content.decode('utf-8'))
+            self.assertContains(response, "Invalid Certificate")
+            self.assertContains(response, "Cannot Find Certificate")
+            self.assertContains(response, "We cannot find a certificate with this URL or ID number.")
             self.assertNotContains(response, str(self.cert.verify_uuid))
 
     @override_settings(FEATURES=FEATURES_WITH_CERTS_ENABLED)
@@ -652,14 +652,14 @@ class CertificatesViewsTests(CommonCertificatesTestCase, CacheIsolationTestCase)
 
         # Validate certificate
         response = self.client.get(test_url)
-        self.assertIn(str(self.cert.verify_uuid), response.content.decode('utf-8'))
+        self.assertContains(response, str(self.cert.verify_uuid))
 
         # invalidate certificate and verify that "Cannot Find Certificate" is returned
         self.cert.invalidate()
         response = self.client.get(test_url)
-        self.assertIn("Invalid Certificate", response.content.decode('utf-8'))
-        self.assertIn("Cannot Find Certificate", response.content.decode('utf-8'))
-        self.assertIn("We cannot find a certificate with this URL or ID number.", response.content.decode('utf-8'))
+        self.assertContains(response, "Invalid Certificate")
+        self.assertContains(response, "Cannot Find Certificate")
+        self.assertContains(response, "We cannot find a certificate with this URL or ID number.")
 
     @override_settings(FEATURES=FEATURES_WITH_CERTS_ENABLED)
     def test_html_lang_attribute_is_dynamic_for_invalid_certificate_html_view(self):
@@ -677,12 +677,12 @@ class CertificatesViewsTests(CommonCertificatesTestCase, CacheIsolationTestCase)
         user_language = 'fr'
         self.client.cookies[settings.LANGUAGE_COOKIE] = user_language
         response = self.client.get(test_url)
-        self.assertIn('<html class="no-js" lang="fr">', response.content.decode('utf-8'))
+        self.assertContains(response, '<html class="no-js" lang="fr">')
 
         user_language = 'ar'
         self.client.cookies[settings.LANGUAGE_COOKIE] = user_language
         response = self.client.get(test_url)
-        self.assertIn('<html class="no-js" lang="ar">', response.content.decode('utf-8'))
+        self.assertContains(response, '<html class="no-js" lang="ar">')
 
     @override_settings(FEATURES=FEATURES_WITH_CERTS_ENABLED)
     def test_html_lang_attribute_is_dynamic_for_certificate_html_view(self):
@@ -698,12 +698,12 @@ class CertificatesViewsTests(CommonCertificatesTestCase, CacheIsolationTestCase)
         user_language = 'fr'
         self.client.cookies[settings.LANGUAGE_COOKIE] = user_language
         response = self.client.get(test_url)
-        self.assertIn('<html class="no-js" lang="fr">', response.content.decode('utf-8'))
+        self.assertContains(response, '<html class="no-js" lang="fr">')
 
         user_language = 'ar'
         self.client.cookies[settings.LANGUAGE_COOKIE] = user_language
         response = self.client.get(test_url)
-        self.assertIn('<html class="no-js" lang="ar">', response.content.decode('utf-8'))
+        self.assertContains(response, '<html class="no-js" lang="ar">')
 
     @override_settings(FEATURES=FEATURES_WITH_CERTS_ENABLED)
     def test_html_view_for_non_viewable_certificate_and_for_student_user(self):
@@ -730,9 +730,9 @@ class CertificatesViewsTests(CommonCertificatesTestCase, CacheIsolationTestCase)
             course_id=six.text_type(self.course.id)
         )
         response = self.client.get(test_url)
-        self.assertIn("Invalid Certificate", response.content.decode('utf-8'))
-        self.assertIn("Cannot Find Certificate", response.content.decode('utf-8'))
-        self.assertIn("We cannot find a certificate with this URL or ID number.", response.content.decode('utf-8'))
+        self.assertContains(response, "Invalid Certificate")
+        self.assertContains(response, "Cannot Find Certificate")
+        self.assertContains(response, "We cannot find a certificate with this URL or ID number.")
 
     @override_settings(FEATURES=FEATURES_WITH_CERTS_ENABLED)
     def test_render_html_view_with_valid_signatories(self):
@@ -743,11 +743,11 @@ class CertificatesViewsTests(CommonCertificatesTestCase, CacheIsolationTestCase)
         )
 
         response = self.client.get(test_url)
-        self.assertIn('course_title_0', response.content.decode('utf-8'))
-        self.assertIn('Signatory_Name 0', response.content.decode('utf-8'))
-        self.assertIn('Signatory_Title 0', response.content.decode('utf-8'))
-        self.assertIn('Signatory_Organization 0', response.content.decode('utf-8'))
-        self.assertIn('/static/certificates/images/demo-sig0.png', response.content.decode('utf-8'))
+        self.assertContains(response, 'course_title_0')
+        self.assertContains(response, 'Signatory_Name 0')
+        self.assertContains(response, 'Signatory_Title 0')
+        self.assertContains(response, 'Signatory_Organization 0')
+        self.assertContains(response, '/static/certificates/images/demo-sig0.png')
 
     @override_settings(FEATURES=FEATURES_WITH_CERTS_ENABLED)
     def test_course_display_name_not_override_with_course_title(self):
@@ -773,7 +773,7 @@ class CertificatesViewsTests(CommonCertificatesTestCase, CacheIsolationTestCase)
 
         response = self.client.get(test_url)
         self.assertNotContains(response, 'test_course_title_0')
-        self.assertIn('refundable course', response.content.decode('utf-8'))
+        self.assertContains(response, 'refundable course')
 
     @override_settings(FEATURES=FEATURES_WITH_CERTS_ENABLED)
     def test_course_display_overrides(self):
@@ -794,8 +794,8 @@ class CertificatesViewsTests(CommonCertificatesTestCase, CacheIsolationTestCase)
         self.store.update_item(self.course, self.user.id)
 
         response = self.client.get(test_url)
-        self.assertIn('overridden_number', response.content.decode('utf-8'))
-        self.assertIn('overridden_org', response.content.decode('utf-8'))
+        self.assertContains(response, 'overridden_number')
+        self.assertContains(response, 'overridden_org')
 
     @override_settings(FEATURES=FEATURES_WITH_CERTS_ENABLED)
     def test_certificate_view_without_org_logo(self):
@@ -858,7 +858,7 @@ class CertificatesViewsTests(CommonCertificatesTestCase, CacheIsolationTestCase)
         )
         response = self.client.get(test_url)
         self.assertNotContains(response, '<script>')
-        self.assertIn('&lt;script&gt;course_title&lt;/script&gt;', response.content.decode('utf-8'))
+        self.assertContains(response, '&lt;script&gt;course_title&lt;/script&gt;')
 
     @override_settings(FEATURES=FEATURES_WITH_CERTS_DISABLED)
     def test_render_html_view_disabled_feature_flag_returns_static_url(self):
@@ -875,7 +875,7 @@ class CertificatesViewsTests(CommonCertificatesTestCase, CacheIsolationTestCase)
             course_id="missing/course/key"
         )
         response = self.client.get(test_url)
-        self.assertIn('invalid', response.content.decode('utf-8'))
+        self.assertContains(response, 'invalid')
 
     @override_settings(FEATURES=FEATURES_WITH_CERTS_ENABLED)
     def test_render_html_view_invalid_user(self):
@@ -885,7 +885,7 @@ class CertificatesViewsTests(CommonCertificatesTestCase, CacheIsolationTestCase)
             course_id=six.text_type(self.course.id)
         )
         response = self.client.get(test_url)
-        self.assertIn('invalid', response.content.decode('utf-8'))
+        self.assertContains(response, 'invalid')
 
     @override_settings(FEATURES=FEATURES_WITH_CERTS_ENABLED)
     def test_render_html_view_non_int_user(self):
@@ -908,7 +908,7 @@ class CertificatesViewsTests(CommonCertificatesTestCase, CacheIsolationTestCase)
         self.assertListEqual(list(GeneratedCertificate.eligible_certificates.all()), [])
 
         response = self.client.get(test_url)
-        self.assertIn('invalid', response.content.decode('utf-8'))
+        self.assertContains(response, 'invalid')
 
     @override_settings(FEATURES=FEATURES_WITH_CERTS_ENABLED, PLATFORM_NAME=u'Űńíćődé Űńívéŕśítӳ')
     def test_render_html_view_with_unicode_platform_name(self):
@@ -937,21 +937,21 @@ class CertificatesViewsTests(CommonCertificatesTestCase, CacheIsolationTestCase)
         response = self.client.get(test_url + '?preview=honor')
         # accessing certificate web view in preview mode without
         # staff or instructor access should show invalid certificate
-        self.assertIn('Cannot Find Certificate', response.content.decode('utf-8'))
+        self.assertContains(response, 'Cannot Find Certificate')
 
         CourseStaffRole(self.course.id).add_users(self.user)
 
         response = self.client.get(test_url + '?preview=honor')
         self.assertNotContains(response, self.course.display_name.encode('utf-8'))
-        self.assertIn('course_title_0', response.content.decode('utf-8'))
-        self.assertIn('Signatory_Title 0', response.content.decode('utf-8'))
+        self.assertContains(response, 'course_title_0')
+        self.assertContains(response, 'Signatory_Title 0')
 
         # mark certificate inactive but accessing in preview mode.
         self._add_course_certificates(count=1, signatory_count=2, is_active=False)
         response = self.client.get(test_url + '?preview=honor')
         self.assertNotContains(response, self.course.display_name.encode('utf-8'))
-        self.assertIn('course_title_0', response.content.decode('utf-8'))
-        self.assertIn('Signatory_Title 0', response.content.decode('utf-8'))
+        self.assertContains(response, 'course_title_0')
+        self.assertContains(response, 'Signatory_Title 0')
 
     @override_settings(FEATURES=FEATURES_WITH_CERTS_ENABLED)
     def test_render_html_view_with_preview_mode_when_user_already_has_cert(self):
@@ -971,8 +971,8 @@ class CertificatesViewsTests(CommonCertificatesTestCase, CacheIsolationTestCase)
         # so let's try to preview in 'verified' mode.
         response = self.client.get(test_url + '?preview=verified')
         self.assertNotContains(response, self.course.display_name.encode('utf-8'))
-        self.assertIn('course_title_0', response.content.decode('utf-8'))
-        self.assertIn('Signatory_Title 0', response.content.decode('utf-8'))
+        self.assertContains(response, 'course_title_0')
+        self.assertContains(response, 'Signatory_Title 0')
 
     @override_settings(FEATURES=FEATURES_WITH_CERTS_ENABLED)
     @ddt.data(
@@ -1019,7 +1019,7 @@ class CertificatesViewsTests(CommonCertificatesTestCase, CacheIsolationTestCase)
             course_id=six.text_type(self.course.id)
         )
         response = self.client.get(test_url)
-        self.assertIn("Invalid Certificate", response.content.decode('utf-8'))
+        self.assertContains(response, "Invalid Certificate")
 
     @override_settings(FEATURES=FEATURES_WITH_CERTS_ENABLED)
     def test_render_500_view_invalid_certificate_configuration(self):
@@ -1031,7 +1031,7 @@ class CertificatesViewsTests(CommonCertificatesTestCase, CacheIsolationTestCase)
             course_id=six.text_type(self.course.id)
         )
         response = self.client.get(test_url + "?preview=honor")
-        self.assertIn("Invalid Certificate Configuration", response.content.decode('utf-8'))
+        self.assertContains(response, "Invalid Certificate Configuration")
 
         # Verify that Exception is raised when certificate is not in the preview mode
         with self.assertRaises(Exception):
@@ -1529,7 +1529,7 @@ class CertificatesViewsTests(CommonCertificatesTestCase, CacheIsolationTestCase)
         response = self.client.get(test_url)
         self.assertEqual(response.status_code, 200)
         if include_effort:
-            self.assertIn('hours of effort: 40', response.content.decode('utf-8'))
+            self.assertContains(response, 'hours of effort: 40')
         else:
             self.assertNotContains(response, 'hours of effort')
 

--- a/lms/djangoapps/certificates/tests/test_webview_views.py
+++ b/lms/djangoapps/certificates/tests/test_webview_views.py
@@ -318,7 +318,6 @@ class CertificatesViewsTests(CommonCertificatesTestCase, CacheIsolationTestCase)
         self._add_course_certificates(count=1, signatory_count=1, is_active=True)
         test_url = get_certificate_url(course_id=self.cert.course_id, uuid=self.cert.verify_uuid)
         response = self.client.get(test_url, HTTP_HOST='test.localhost')
-        self.assertEqual(response.status_code, 200)
         self.assertContains(response, "Post on Facebook")
         self.assertContains(response, 'test_facebook_my_site')
 

--- a/lms/djangoapps/course_wiki/tests/test_middleware.py
+++ b/lms/djangoapps/course_wiki/tests/test_middleware.py
@@ -32,5 +32,5 @@ class TestWikiAccessMiddleware(ModuleStoreTestCase):
     def test_url_tranform(self):
         """Test that the correct prefix ('/courses/<course_id>') is added to the urls in the wiki."""
         response = self.client.get('/courses/edx/math101/2014/wiki/math101/')
-        self.assertIn('/courses/edx/math101/2014/wiki/math101/_edit/', response.content)
-        self.assertIn('/courses/edx/math101/2014/wiki/math101/_settings/', response.content)
+        self.assertContains(response, '/courses/edx/math101/2014/wiki/math101/_edit/')
+        self.assertContains(response, '/courses/edx/math101/2014/wiki/math101/_settings/')

--- a/lms/djangoapps/courseware/tests/test_about.py
+++ b/lms/djangoapps/courseware/tests/test_about.py
@@ -96,11 +96,10 @@ class AboutTestCase(LoginEnrollmentTestCase, SharedModuleStoreTestCase, EventTra
         """
         url = reverse('about_course', args=[text_type(self.course.id)])
         resp = self.client.get(url)
-        self.assertEqual(resp.status_code, 200)
-        self.assertIn("OOGIE BLOOGIE", resp.content.decode('utf-8'))
+        self.assertContains(resp, "OOGIE BLOOGIE")
 
         # Check that registration button is present
-        self.assertIn(REG_STR, resp.content.decode('utf-8'))
+        self.assertContains(resp, REG_STR)
 
     def test_logged_in(self):
         """
@@ -109,8 +108,7 @@ class AboutTestCase(LoginEnrollmentTestCase, SharedModuleStoreTestCase, EventTra
         self.setup_user()
         url = reverse('about_course', args=[text_type(self.course.id)])
         resp = self.client.get(url)
-        self.assertEqual(resp.status_code, 200)
-        self.assertIn("OOGIE BLOOGIE", resp.content.decode('utf-8'))
+        self.assertContains(resp, "OOGIE BLOOGIE")
 
     def test_already_enrolled(self):
         """
@@ -121,9 +119,8 @@ class AboutTestCase(LoginEnrollmentTestCase, SharedModuleStoreTestCase, EventTra
         self.enroll(self.course, True)
         url = reverse('about_course', args=[text_type(self.course.id)])
         resp = self.client.get(url)
-        self.assertEqual(resp.status_code, 200)
-        self.assertIn("You are enrolled in this course", resp.content.decode('utf-8'))
-        self.assertIn("View Course", resp.content.decode('utf-8'))
+        self.assertContains(resp, "You are enrolled in this course")
+        self.assertContains(resp, "View Course")
 
     @override_settings(COURSE_ABOUT_VISIBILITY_PERMISSION="see_about_page")
     def test_visible_about_page_settings(self):
@@ -132,8 +129,7 @@ class AboutTestCase(LoginEnrollmentTestCase, SharedModuleStoreTestCase, EventTra
         """
         url = reverse('about_course', args=[text_type(self.course_with_about.id)])
         resp = self.client.get(url)
-        self.assertEqual(resp.status_code, 200)
-        self.assertIn("WITH ABOUT", resp.content.decode('utf-8'))
+        self.assertContains(resp, "WITH ABOUT")
 
         url = reverse('about_course', args=[text_type(self.course_without_about.id)])
         resp = self.client.get(url)
@@ -163,8 +159,7 @@ class AboutTestCase(LoginEnrollmentTestCase, SharedModuleStoreTestCase, EventTra
         url = reverse('about_course', args=[text_type(self.course.id)])
         resp = self.client.get(url)
         # should not be redirected
-        self.assertEqual(resp.status_code, 200)
-        self.assertIn("OOGIE BLOOGIE", resp.content.decode('utf-8'))
+        self.assertContains(resp, "OOGIE BLOOGIE")
 
     @patch.dict(settings.FEATURES, {'ENABLE_COURSE_HOME_REDIRECT': True})
     @patch.dict(settings.FEATURES, {'ENABLE_MKTG_SITE': False})
@@ -177,8 +172,7 @@ class AboutTestCase(LoginEnrollmentTestCase, SharedModuleStoreTestCase, EventTra
         url = reverse('about_course', args=[text_type(self.course.id)])
         resp = self.client.get(url)
         # should not be redirected
-        self.assertEqual(resp.status_code, 200)
-        self.assertIn("OOGIE BLOOGIE", resp.content.decode('utf-8'))
+        self.assertContains(resp, "OOGIE BLOOGIE")
 
     @patch.dict(settings.FEATURES, {'ENABLE_PREREQUISITE_COURSES': True})
     def test_pre_requisite_course(self):
@@ -249,11 +243,10 @@ class AboutTestCase(LoginEnrollmentTestCase, SharedModuleStoreTestCase, EventTra
             with override_waffle_flag(COURSE_ENABLE_UNENROLLED_ACCESS_FLAG, active=True):
                 url = reverse('about_course', args=[text_type(self.course.id)])
                 resp = self.client.get(url)
-        self.assertEqual(resp.status_code, 200)
         if course_visibility == COURSE_VISIBILITY_PUBLIC or course_visibility == COURSE_VISIBILITY_PUBLIC_OUTLINE:
-            self.assertIn("View Course", resp.content.decode('utf-8'))
+            self.assertContains(resp, "View Course")
         else:
-            self.assertIn("Enroll Now", resp.content.decode('utf-8'))
+            self.assertContains(resp, "Enroll Now")
 
 
 class AboutTestCaseXML(LoginEnrollmentTestCase, ModuleStoreTestCase):
@@ -292,15 +285,13 @@ class AboutTestCaseXML(LoginEnrollmentTestCase, ModuleStoreTestCase):
         self.setup_user()
         url = reverse('about_course', args=[text_type(self.xml_course_id)])
         resp = self.client.get(url)
-        self.assertEqual(resp.status_code, 200)
-        self.assertIn(self.xml_data, resp.content.decode('utf-8'))
+        self.assertContains(resp, self.xml_data)
 
     @patch.dict('django.conf.settings.FEATURES', {'DISABLE_START_DATES': False})
     def test_anonymous_user_xml(self):
         url = reverse('about_course', args=[text_type(self.xml_course_id)])
         resp = self.client.get(url)
-        self.assertEqual(resp.status_code, 200)
-        self.assertIn(self.xml_data, resp.content.decode('utf-8'))
+        self.assertContains(resp, self.xml_data)
 
 
 class AboutWithCappedEnrollmentsTestCase(LoginEnrollmentTestCase, SharedModuleStoreTestCase):
@@ -323,8 +314,7 @@ class AboutWithCappedEnrollmentsTestCase(LoginEnrollmentTestCase, SharedModuleSt
         self.setup_user()
         url = reverse('about_course', args=[text_type(self.course.id)])
         resp = self.client.get(url)
-        self.assertEqual(resp.status_code, 200)
-        self.assertIn('<a href="#" class="register">', resp.content.decode('utf-8'))
+        self.assertContains(resp, '<a href="#" class="register">')
 
         self.enroll(self.course, verify=True)
 
@@ -339,15 +329,14 @@ class AboutWithCappedEnrollmentsTestCase(LoginEnrollmentTestCase, SharedModuleSt
 
         # Get the about page again and make sure that the page says that the course is full
         resp = self.client.get(url)
-        self.assertEqual(resp.status_code, 200)
-        self.assertIn("Course is full", resp.content.decode('utf-8'))
+        self.assertContains(resp, "Course is full")
 
         # Try to enroll as well
         result = self.enroll(self.course)
         self.assertFalse(result)
 
         # Check that registration button is not present
-        self.assertNotIn(REG_STR, resp.content.decode('utf-8'))
+        self.assertNotContains(resp, REG_STR)
 
 
 class AboutWithInvitationOnly(SharedModuleStoreTestCase):
@@ -370,11 +359,10 @@ class AboutWithInvitationOnly(SharedModuleStoreTestCase):
 
         url = reverse('about_course', args=[text_type(self.course.id)])
         resp = self.client.get(url)
-        self.assertEqual(resp.status_code, 200)
-        self.assertIn("Enrollment in this course is by invitation only", resp.content.decode('utf-8'))
+        self.assertContains(resp, "Enrollment in this course is by invitation only")
 
         # Check that registration button is not present
-        self.assertNotIn(REG_STR, resp.content.decode('utf-8'))
+        self.assertNotContains(response, REG_STR)
 
     def test_invitation_only_but_allowed(self):
         """
@@ -388,11 +376,10 @@ class AboutWithInvitationOnly(SharedModuleStoreTestCase):
 
         url = reverse('about_course', args=[text_type(self.course.id)])
         resp = self.client.get(url)
-        self.assertEqual(resp.status_code, 200)
-        self.assertIn(u"Enroll Now", resp.content.decode('utf-8'))
+        self.assertContains(resp, u"Enroll Now")
 
         # Check that registration button is present
-        self.assertIn(REG_STR, resp.content.decode('utf-8'))
+        self.assertContains(resp, REG_STR)
 
 
 class AboutWithClosedEnrollment(ModuleStoreTestCase):
@@ -422,19 +409,17 @@ class AboutWithClosedEnrollment(ModuleStoreTestCase):
     def test_closed_enrollmement(self):
         url = reverse('about_course', args=[text_type(self.course.id)])
         resp = self.client.get(url)
-        self.assertEqual(resp.status_code, 200)
-        self.assertIn("Enrollment is Closed", resp.content.decode('utf-8'))
+        self.assertContains(resp, "Enrollment is Closed")
 
         # Check that registration button is not present
-        self.assertNotIn(REG_STR, resp.content.decode('utf-8'))
+        self.assertNotContains(response, REG_STR)
 
     def test_course_price_is_not_visble_in_sidebar(self):
         url = reverse('about_course', args=[text_type(self.course.id)])
         resp = self.client.get(url)
-        self.assertEqual(resp.status_code, 200)
         # course price is not visible ihe course_about page when the course
         # mode is not set to honor
-        self.assertNotIn('<span class="important-dates-item-text">$10</span>', resp.content.decode('utf-8'))
+        self.assertNotContains(response, '<span class="important-dates-item-text">$10</span>')
 
 
 @ddt.ddt
@@ -472,12 +457,11 @@ class AboutSidebarHTMLTestCase(SharedModuleStoreTestCase):
                 )
             url = reverse('about_course', args=[text_type(self.course.id)])
             resp = self.client.get(url)
-            self.assertEqual(resp.status_code, 200)
             if waffle_switch_value and itemfactory_display_name and itemfactory_data:
-                self.assertIn('<section class="about-sidebar-html">', resp.content.decode('utf-8'))
-                self.assertIn(itemfactory_data, resp.content.decode('utf-8'))
+                self.assertContains(resp, '<section class="about-sidebar-html">')
+                self.assertContains(resp, itemfactory_data)
             else:
-                self.assertNotIn('<section class="about-sidebar-html">', resp.content.decode('utf-8'))
+                self.assertNotContains(response, '<section class="about-sidebar-html">')
 
 
 @patch.dict(settings.FEATURES, {'ENABLE_SHOPPING_CART': True})
@@ -527,8 +511,7 @@ class AboutPurchaseCourseTestCase(LoginEnrollmentTestCase, SharedModuleStoreTest
         """
         url = reverse('about_course', args=[text_type(self.course.id)])
         resp = self.client.get(url)
-        self.assertEqual(resp.status_code, 200)
-        self.assertIn("Add buyme to Cart <span>($10 USD)</span>", resp.content.decode('utf-8'))
+        self.assertContains(resp, "Add buyme to Cart <span>($10 USD)</span>")
 
     def test_logged_in(self):
         """
@@ -537,8 +520,7 @@ class AboutPurchaseCourseTestCase(LoginEnrollmentTestCase, SharedModuleStoreTest
         self.setup_user()
         url = reverse('about_course', args=[text_type(self.course.id)])
         resp = self.client.get(url)
-        self.assertEqual(resp.status_code, 200)
-        self.assertIn("Add buyme to Cart <span>($10 USD)</span>", resp.content.decode('utf-8'))
+        self.assertContains(resp, "Add buyme to Cart <span>($10 USD)</span>")
 
     def test_already_in_cart(self):
         """
@@ -551,9 +533,8 @@ class AboutPurchaseCourseTestCase(LoginEnrollmentTestCase, SharedModuleStoreTest
 
         url = reverse('about_course', args=[text_type(self.course.id)])
         resp = self.client.get(url)
-        self.assertEqual(resp.status_code, 200)
-        self.assertIn("This course is in your", resp.content.decode('utf-8'))
-        self.assertNotIn("Add buyme to Cart <span>($10 USD)</span>", resp.content.decode('utf-8'))
+        self.assertContains(resp, "This course is in your")
+        self.assertNotContains(response, "Add buyme to Cart <span>($10 USD)</span>")
 
     def test_already_enrolled(self):
         """
@@ -569,10 +550,9 @@ class AboutPurchaseCourseTestCase(LoginEnrollmentTestCase, SharedModuleStoreTest
         url = reverse('about_course', args=[text_type(self.course.id)])
 
         resp = self.client.get(url)
-        self.assertEqual(resp.status_code, 200)
-        self.assertIn("You are enrolled in this course", resp.content.decode('utf-8'))
-        self.assertIn("View Course", resp.content.decode('utf-8'))
-        self.assertNotIn("Add buyme to Cart <span>($10 USD)</span>", resp.content.decode('utf-8'))
+        self.assertContains(resp, "You are enrolled in this course")
+        self.assertContains(resp, "View Course")
+        self.assertNotContains(response, "Add buyme to Cart <span>($10 USD)</span>")
 
     def test_closed_enrollment(self):
         """
@@ -583,13 +563,12 @@ class AboutPurchaseCourseTestCase(LoginEnrollmentTestCase, SharedModuleStoreTest
 
         url = reverse('about_course', args=[text_type(self.closed_course.id)])
         resp = self.client.get(url)
-        self.assertEqual(resp.status_code, 200)
-        self.assertIn("Enrollment is Closed", resp.content.decode('utf-8'))
-        self.assertNotIn("Add closed to Cart <span>($10 USD)</span>", resp.content.decode('utf-8'))
+        self.assertContains(resp, "Enrollment is Closed")
+        self.assertNotContains(response, "Add closed to Cart <span>($10 USD)</span>")
 
         # course price is visible ihe course_about page when the course
         # mode is set to honor and it's price is set
-        self.assertIn('<span class="important-dates-item-text">$10</span>', resp.content.decode('utf-8'))
+        self.assertContains(resp, '<span class="important-dates-item-text">$10</span>')
 
     def test_invitation_only(self):
         """
@@ -602,8 +581,7 @@ class AboutPurchaseCourseTestCase(LoginEnrollmentTestCase, SharedModuleStoreTest
 
         url = reverse('about_course', args=[text_type(course.id)])
         resp = self.client.get(url)
-        self.assertEqual(resp.status_code, 200)
-        self.assertIn("Enrollment in this course is by invitation only", resp.content.decode('utf-8'))
+        self.assertContains(resp, "Enrollment in this course is by invitation only")
 
     def test_enrollment_cap(self):
         """
@@ -621,8 +599,7 @@ class AboutPurchaseCourseTestCase(LoginEnrollmentTestCase, SharedModuleStoreTest
         self.setup_user()
         url = reverse('about_course', args=[text_type(course.id)])
         resp = self.client.get(url)
-        self.assertEqual(resp.status_code, 200)
-        self.assertIn("Add buyme to Cart <span>($10 USD)</span>", resp.content.decode('utf-8'))
+        self.assertContains(resp, "Add buyme to Cart <span>($10 USD)</span>")
 
         # note that we can't call self.enroll here since that goes through
         # the Django student views, which doesn't allow for enrollments
@@ -640,9 +617,8 @@ class AboutPurchaseCourseTestCase(LoginEnrollmentTestCase, SharedModuleStoreTest
 
         # Get the about page again and make sure that the page says that the course is full
         resp = self.client.get(url)
-        self.assertEqual(resp.status_code, 200)
-        self.assertIn("Course is full", resp.content.decode('utf-8'))
-        self.assertNotIn("Add buyme to Cart ($10)", resp.content.decode('utf-8'))
+        self.assertContains(resp, "Course is full")
+        self.assertNotContains(response, "Add buyme to Cart ($10)")
 
     def test_free_course_display(self):
         """
@@ -654,9 +630,8 @@ class AboutPurchaseCourseTestCase(LoginEnrollmentTestCase, SharedModuleStoreTest
         url = reverse('about_course', args=[text_type(course.id)])
 
         resp = self.client.get(url)
-        self.assertEqual(resp.status_code, 200)
-        self.assertNotIn("Add free to Cart (Free)", resp.content.decode('utf-8'))
-        self.assertNotIn('<p class="important-dates-item-title">Price</p>', resp.content.decode('utf-8'))
+        self.assertNotContains(response, "Add free to Cart (Free)")
+        self.assertNotContains(response, '<p class="important-dates-item-title">Price</p>')
 
 
 class CourseAboutTestCaseCCX(SharedModuleStoreTestCase, LoginEnrollmentTestCase):

--- a/lms/djangoapps/courseware/tests/test_about.py
+++ b/lms/djangoapps/courseware/tests/test_about.py
@@ -362,7 +362,7 @@ class AboutWithInvitationOnly(SharedModuleStoreTestCase):
         self.assertContains(resp, "Enrollment in this course is by invitation only")
 
         # Check that registration button is not present
-        self.assertNotContains(response, REG_STR)
+        self.assertNotContains(resp, REG_STR)
 
     def test_invitation_only_but_allowed(self):
         """
@@ -412,14 +412,14 @@ class AboutWithClosedEnrollment(ModuleStoreTestCase):
         self.assertContains(resp, "Enrollment is Closed")
 
         # Check that registration button is not present
-        self.assertNotContains(response, REG_STR)
+        self.assertNotContains(resp, REG_STR)
 
     def test_course_price_is_not_visble_in_sidebar(self):
         url = reverse('about_course', args=[text_type(self.course.id)])
         resp = self.client.get(url)
         # course price is not visible ihe course_about page when the course
         # mode is not set to honor
-        self.assertNotContains(response, '<span class="important-dates-item-text">$10</span>')
+        self.assertNotContains(resp, '<span class="important-dates-item-text">$10</span>')
 
 
 @ddt.ddt
@@ -461,7 +461,7 @@ class AboutSidebarHTMLTestCase(SharedModuleStoreTestCase):
                 self.assertContains(resp, '<section class="about-sidebar-html">')
                 self.assertContains(resp, itemfactory_data)
             else:
-                self.assertNotContains(response, '<section class="about-sidebar-html">')
+                self.assertNotContains(resp, '<section class="about-sidebar-html">')
 
 
 @patch.dict(settings.FEATURES, {'ENABLE_SHOPPING_CART': True})
@@ -534,7 +534,7 @@ class AboutPurchaseCourseTestCase(LoginEnrollmentTestCase, SharedModuleStoreTest
         url = reverse('about_course', args=[text_type(self.course.id)])
         resp = self.client.get(url)
         self.assertContains(resp, "This course is in your")
-        self.assertNotContains(response, "Add buyme to Cart <span>($10 USD)</span>")
+        self.assertNotContains(resp, "Add buyme to Cart <span>($10 USD)</span>")
 
     def test_already_enrolled(self):
         """
@@ -552,7 +552,7 @@ class AboutPurchaseCourseTestCase(LoginEnrollmentTestCase, SharedModuleStoreTest
         resp = self.client.get(url)
         self.assertContains(resp, "You are enrolled in this course")
         self.assertContains(resp, "View Course")
-        self.assertNotContains(response, "Add buyme to Cart <span>($10 USD)</span>")
+        self.assertNotContains(resp, "Add buyme to Cart <span>($10 USD)</span>")
 
     def test_closed_enrollment(self):
         """
@@ -564,7 +564,7 @@ class AboutPurchaseCourseTestCase(LoginEnrollmentTestCase, SharedModuleStoreTest
         url = reverse('about_course', args=[text_type(self.closed_course.id)])
         resp = self.client.get(url)
         self.assertContains(resp, "Enrollment is Closed")
-        self.assertNotContains(response, "Add closed to Cart <span>($10 USD)</span>")
+        self.assertNotContains(resp, "Add closed to Cart <span>($10 USD)</span>")
 
         # course price is visible ihe course_about page when the course
         # mode is set to honor and it's price is set
@@ -618,7 +618,7 @@ class AboutPurchaseCourseTestCase(LoginEnrollmentTestCase, SharedModuleStoreTest
         # Get the about page again and make sure that the page says that the course is full
         resp = self.client.get(url)
         self.assertContains(resp, "Course is full")
-        self.assertNotContains(response, "Add buyme to Cart ($10)")
+        self.assertNotContains(resp, "Add buyme to Cart ($10)")
 
     def test_free_course_display(self):
         """
@@ -630,8 +630,8 @@ class AboutPurchaseCourseTestCase(LoginEnrollmentTestCase, SharedModuleStoreTest
         url = reverse('about_course', args=[text_type(course.id)])
 
         resp = self.client.get(url)
-        self.assertNotContains(response, "Add free to Cart (Free)")
-        self.assertNotContains(response, '<p class="important-dates-item-title">Price</p>')
+        self.assertNotContains(resp, "Add free to Cart (Free)")
+        self.assertNotContains(resp, '<p class="important-dates-item-title">Price</p>')
 
 
 class CourseAboutTestCaseCCX(SharedModuleStoreTestCase, LoginEnrollmentTestCase):

--- a/lms/djangoapps/courseware/tests/test_course_info.py
+++ b/lms/djangoapps/courseware/tests/test_course_info.py
@@ -61,9 +61,8 @@ class CourseInfoTestCase(EnterpriseTestConsentRequired, LoginEnrollmentTestCase,
         self.setup_user()
         url = reverse('info', args=[text_type(self.course.id)])
         resp = self.client.get(url)
-        self.assertEqual(resp.status_code, 200)
-        self.assertIn(b"OOGIE BLOOGIE", resp.content)
-        self.assertIn(b"You are not currently enrolled in this course", resp.content)
+        self.assertContains(resp, "OOGIE BLOOGIE")
+        self.assertContains(resp, "You are not currently enrolled in this course")
 
     def test_logged_in_enrolled(self):
         self.enroll(self.course)
@@ -389,15 +388,13 @@ class CourseInfoTestCaseXML(LoginEnrollmentTestCase, ModuleStoreTestCase):
         self.setup_user()
         url = reverse('info', args=[text_type(self.xml_course_key)])
         resp = self.client.get(url)
-        self.assertEqual(resp.status_code, 200)
-        self.assertIn(self.xml_data, resp.content)
+        self.assertContains(resp, self.xml_data)
 
     @mock.patch.dict('django.conf.settings.FEATURES', {'DISABLE_START_DATES': False})
     def test_anonymous_user_xml(self):
         url = reverse('info', args=[text_type(self.xml_course_key)])
         resp = self.client.get(url)
-        self.assertEqual(resp.status_code, 200)
-        self.assertNotIn(self.xml_data, resp.content)
+        self.assertNotContains(resp, self.xml_data)
 
 
 @override_settings(FEATURES=dict(settings.FEATURES, EMBARGO=False))

--- a/lms/djangoapps/courseware/tests/test_date_summary.py
+++ b/lms/djangoapps/courseware/tests/test_date_summary.py
@@ -61,7 +61,7 @@ class CourseDateSummaryTest(SharedModuleStoreTestCase):
         self.client.login(username=user.username, password=TEST_PASSWORD)
         url = reverse('info', args=(course.id,))
         response = self.client.get(url)
-        self.assertNotIn(b'date-summary', response.content)
+        self.assertNotContains(response, 'date-summary', status_code=302)
 
     def test_course_home_logged_out(self):
         course = create_course_run()

--- a/lms/djangoapps/courseware/tests/test_entrance_exam.py
+++ b/lms/djangoapps/courseware/tests/test_entrance_exam.py
@@ -552,7 +552,7 @@ class EntranceExamTestCases(LoginEnrollmentTestCase, ModuleStoreTestCase, Milest
             'problem_check',
         )
         self.assertEqual(response.status_code, 200)
-        self.assertIn('entrance_exam_passed', response.content.decode('utf-8'))
+        self.assertContains(response, 'entrance_exam_passed')
 
     def _assert_chapter_loaded(self, course, chapter):
         """

--- a/lms/djangoapps/courseware/tests/test_entrance_exam.py
+++ b/lms/djangoapps/courseware/tests/test_entrance_exam.py
@@ -327,10 +327,9 @@ class EntranceExamTestCases(LoginEnrollmentTestCase, ModuleStoreTestCase, Milest
             }
         )
         resp = self.client.get(url)
-        self.assertEqual(resp.status_code, 200)
-        self.assertIn(
+        self.assertContains(
+            resp,
             u'To access course materials, you must score {}% or higher'.format(minimum_score_pct),
-            resp.content.decode(resp.charset)
         )
         self.assertIn(u'Your current score is 20%.', resp.content.decode(resp.charset))
 

--- a/lms/djangoapps/courseware/tests/test_entrance_exam.py
+++ b/lms/djangoapps/courseware/tests/test_entrance_exam.py
@@ -274,7 +274,7 @@ class EntranceExamTestCases(LoginEnrollmentTestCase, ModuleStoreTestCase, Milest
         resp = self.client.get(url)
         self.assertRedirects(resp, expected_url, status_code=302, target_status_code=200)
         resp = self.client.get(expected_url)
-        self.assertIn('Exam Vertical - Unit 1', resp.content)
+        self.assertContains(resp, 'Exam Vertical - Unit 1')
 
     def test_get_entrance_exam_content(self):
         """
@@ -304,8 +304,7 @@ class EntranceExamTestCases(LoginEnrollmentTestCase, ModuleStoreTestCase, Milest
             }
         )
         resp = self.client.get(url)
-        self.assertEqual(resp.status_code, 200)
-        self.assertIn('To access course materials, you must score', resp.content)
+        self.assertContains(resp, 'To access course materials, you must score')
 
     def test_entrance_exam_requirement_message_with_correct_percentage(self):
         """
@@ -378,9 +377,9 @@ class EntranceExamTestCases(LoginEnrollmentTestCase, ModuleStoreTestCase, Milest
         answer_entrance_exam_problem(self.course, self.request, self.problem_2)
 
         resp = self.client.get(url)
-        self.assertNotIn('To access course materials, you must score', resp.content)
-        self.assertIn(u'Your score is 100%. You have passed the entrance exam.', resp.content.decode(resp.charset))
-        self.assertIn('Lesson 1', resp.content)
+        self.assertNotContains(resp, 'To access course materials, you must score')
+        self.assertContains(resp, u'Your score is 100%. You have passed the entrance exam.')
+        self.assertContains(resp, 'Lesson 1')
 
     def test_entrance_exam_gating(self):
         """

--- a/lms/djangoapps/courseware/tests/test_masquerade.py
+++ b/lms/djangoapps/courseware/tests/test_masquerade.py
@@ -330,17 +330,13 @@ class TestStaffMasqueradeAsSpecificStudent(StaffMasqueradeTestCase, ProblemSubmi
         # Log in as staff, and check we can see the info page.
         self.login_staff()
         response = self.get_course_info_page()
-        self.assertEqual(response.status_code, 200)
-        content = response.content.decode('utf-8')
-        self.assertIn("OOGIE BLOOGIE", content)
+        self.assertContains(response, "OOGIE BLOOGIE")
 
         # Masquerade as the student,enable the self paced configuration, and check we can see the info page.
         SelfPacedConfiguration(enable_course_home_improvements=True).save()
         self.update_masquerade(role='student', user_name=self.student_user.username)
         response = self.get_course_info_page()
-        self.assertEqual(response.status_code, 200)
-        content = response.content.decode('utf-8')
-        self.assertIn("OOGIE BLOOGIE", content)
+        self.assertContains(response, "OOGIE BLOOGIE")
 
     @ddt.data(
         'john',  # Non-unicode username

--- a/lms/djangoapps/courseware/tests/test_navigation.py
+++ b/lms/djangoapps/courseware/tests/test_navigation.py
@@ -242,7 +242,7 @@ class TestNavigation(SharedModuleStoreTestCase, LoginEnrollmentTestCase):
             kwargs={'course_id': test_course_id}
         )
         response = self.assert_request_status_code(200, url)
-        self.assertIn("No content has been added to this course", response.content.decode('utf-8'))
+        self.assertContains(response, "No content has been added to this course")
 
         section = ItemFactory.create(
             parent_location=self.test_course.location,
@@ -254,7 +254,7 @@ class TestNavigation(SharedModuleStoreTestCase, LoginEnrollmentTestCase):
         )
         response = self.assert_request_status_code(200, url)
         self.assertNotContains(response, "No content has been added to this course")
-        self.assertIn("New Section", response.content.decode('utf-8'))
+        self.assertContains(response, "New Section")
 
         subsection = ItemFactory.create(
             parent_location=section.location,
@@ -265,7 +265,7 @@ class TestNavigation(SharedModuleStoreTestCase, LoginEnrollmentTestCase):
             kwargs={'course_id': test_course_id}
         )
         response = self.assert_request_status_code(200, url)
-        self.assertIn("New Subsection", response.content.decode('utf-8'))
+        self.assertContains(response, "New Subsection")
         self.assertNotContains(response, "sequence-nav")
 
         ItemFactory.create(

--- a/lms/djangoapps/courseware/tests/test_navigation.py
+++ b/lms/djangoapps/courseware/tests/test_navigation.py
@@ -253,7 +253,7 @@ class TestNavigation(SharedModuleStoreTestCase, LoginEnrollmentTestCase):
             kwargs={'course_id': test_course_id}
         )
         response = self.assert_request_status_code(200, url)
-        self.assertNotIn("No content has been added to this course", response.content.decode('utf-8'))
+        self.assertNotContains(response, "No content has been added to this course")
         self.assertIn("New Section", response.content.decode('utf-8'))
 
         subsection = ItemFactory.create(
@@ -266,7 +266,7 @@ class TestNavigation(SharedModuleStoreTestCase, LoginEnrollmentTestCase):
         )
         response = self.assert_request_status_code(200, url)
         self.assertIn("New Subsection", response.content.decode('utf-8'))
-        self.assertNotIn("sequence-nav", response.content.decode('utf-8'))
+        self.assertNotContains(response, "sequence-nav")
 
         ItemFactory.create(
             parent_location=subsection.location,

--- a/lms/djangoapps/courseware/tests/test_password_reset.py
+++ b/lms/djangoapps/courseware/tests/test_password_reset.py
@@ -51,7 +51,7 @@ class TestPasswordReset(LoginEnrollmentTestCase):
         """
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.context_data['validlink'], valid_link)
-        self.assertIn(error_message, response.content)
+        self.assertContains(response, error_message)
 
     @override_settings(AUTH_PASSWORD_VALIDATORS=[
         create_validator_config('util.password_policy_validators.MinimumLengthValidator', {'min_length': 6})

--- a/lms/djangoapps/courseware/tests/test_password_reset.py
+++ b/lms/djangoapps/courseware/tests/test_password_reset.py
@@ -91,7 +91,7 @@ class TestPasswordReset(LoginEnrollmentTestCase):
             'new_password2': 'foofoo',
         }, follow=True)
 
-        self.assertIn(success_msg, resp.content)
+        self.assertContains(resp, success_msg)
 
     @ddt.data(
         ('foo', 'foobar', 'Error in resetting your password. Please try again.'),

--- a/lms/djangoapps/courseware/tests/test_tabs.py
+++ b/lms/djangoapps/courseware/tests/test_tabs.py
@@ -253,14 +253,12 @@ class StaticTabDateTestCase(LoginEnrollmentTestCase, SharedModuleStoreTestCase):
         self.setup_user()
         url = reverse('static_tab', args=[text_type(self.course.id), 'new_tab'])
         resp = self.client.get(url)
-        self.assertEqual(resp.status_code, 200)
-        self.assertIn("OOGIE BLOOGIE", resp.content.decode('utf-8'))
+        self.assertContains(resp, "OOGIE BLOOGIE")
 
     def test_anonymous_user(self):
         url = reverse('static_tab', args=[text_type(self.course.id), 'new_tab'])
         resp = self.client.get(url)
-        self.assertEqual(resp.status_code, 200)
-        self.assertIn("OOGIE BLOOGIE", resp.content.decode('utf-8'))
+        self.assertContains(resp, "OOGIE BLOOGIE")
 
     def test_invalid_course_key(self):
         self.setup_user()
@@ -328,15 +326,13 @@ class StaticTabDateTestCaseXML(LoginEnrollmentTestCase, ModuleStoreTestCase):
         self.setup_user()
         url = reverse('static_tab', args=[text_type(self.xml_course_key), self.xml_url])
         resp = self.client.get(url)
-        self.assertEqual(resp.status_code, 200)
-        self.assertIn(self.xml_data, resp.content.decode('utf-8'))
+        self.assertContains(resp, self.xml_data)
 
     @patch.dict('django.conf.settings.FEATURES', {'DISABLE_START_DATES': False})
     def test_anonymous_user_xml(self):
         url = reverse('static_tab', args=[text_type(self.xml_course_key), self.xml_url])
         resp = self.client.get(url)
-        self.assertEqual(resp.status_code, 200)
-        self.assertIn(self.xml_data, resp.content.decode('utf-8'))
+        self.assertContains(resp, self.xml_data)
 
 
 @patch.dict('django.conf.settings.FEATURES', {'ENTRANCE_EXAMS': True})

--- a/lms/djangoapps/courseware/tests/test_views.py
+++ b/lms/djangoapps/courseware/tests/test_views.py
@@ -480,7 +480,7 @@ class ViewsTestCase(ModuleStoreTestCase):
         shoppingcart.models.PaidCourseRegistration.add_to_order(cart, course.id)
         response = self.client.get(reverse('about_course', args=[six.text_type(course.id)]))
         self.assertEqual(response.status_code, 200)
-        self.assertIn(in_cart_span, response.content)
+        self.assertContains(response, in_cart_span)
 
     def assert_enrollment_link_present(self, is_anonymous):
         """
@@ -729,8 +729,8 @@ class ViewsTestCase(ModuleStoreTestCase):
                 response_content = HTMLParser().unescape(response.content)
                 expected_time = datetime.now() + timedelta(hours=hour_diff)
                 expected_tz = expected_time.strftime('%Z')
-                self.assertIn(expected_tz, response_content)
-                self.assertIn(str(expected_time), response_content)
+                self.assertContains(response, expected_tz)
+                self.assertContains(response, str(expected_time))
 
     def _email_opt_in_checkbox(self, response, org_name_string=None):
         """Check if the email opt-in checkbox appears in the response content."""
@@ -749,7 +749,7 @@ class ViewsTestCase(ModuleStoreTestCase):
         response = self.client.get(url)
         # This is a static page, so just assert that it is returned correctly
         self.assertEqual(response.status_code, 200)
-        self.assertIn('Financial Assistance Application', response.content)
+        self.assertContains(response, 'Financial Assistance Application')
 
     @ddt.data(([CourseMode.AUDIT, CourseMode.VERIFIED], CourseMode.AUDIT, True, YESTERDAY),
               ([CourseMode.AUDIT, CourseMode.VERIFIED], CourseMode.VERIFIED, True, None),
@@ -837,7 +837,7 @@ class ViewsTestCase(ModuleStoreTestCase):
         response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
 
-        self.assertIn(str(course), response.content)
+        self.assertContains(response, str(course))
 
     def _submit_financial_assistance_form(self, data):
         """Submit a financial assistance request."""
@@ -2644,7 +2644,7 @@ class TestIndexViewCompleteOnView(ModuleStoreTestCase, CompletionWaffleTestMixin
         self.assertTrue(self.client.login(username=self.user.username, password='test'))
 
         response = self.client.get(self.section_1_url)
-        self.assertIn('data-mark-completed-on-view-after-delay', response.content)
+        self.assertContains(response, 'data-mark-completed-on-view-after-delay')
         self.assertEqual(response.content.count("data-mark-completed-on-view-after-delay"), 2)
 
         request = self.request_factory.post(
@@ -2662,7 +2662,7 @@ class TestIndexViewCompleteOnView(ModuleStoreTestCase, CompletionWaffleTestMixin
         self.assertEqual(json.loads(response.content.decode('utf-8')), {'result': "ok"})
 
         response = self.client.get(self.section_1_url)
-        self.assertIn('data-mark-completed-on-view-after-delay', response.content)
+        self.assertContains(response, 'data-mark-completed-on-view-after-delay')
         self.assertEqual(response.content.count("data-mark-completed-on-view-after-delay"), 1)
 
         request = self.request_factory.post(
@@ -2735,7 +2735,7 @@ class TestIndexViewWithVerticalPositions(ModuleStoreTestCase):
         """
         Asserts that the expected position and the position in the response are the same
         """
-        self.assertIn('data-position="{}"'.format(expected_position), response.content)
+        self.assertContains(response, 'data-position="{}"'.format(expected_position))
 
     @ddt.data(("-1", 1), ("0", 1), ("-0", 1), ("2", 2), ("5", 1))
     @ddt.unpack
@@ -2799,7 +2799,7 @@ class TestIndexViewWithGating(ModuleStoreTestCase, MilestonesTestCaseMixin):
             )
         )
         self.assertEqual(response.status_code, 200)
-        self.assertIn("Content Locked", response.content)
+        self.assertContains(response, "Content Locked")
 
 
 class TestIndexViewWithCourseDurationLimits(ModuleStoreTestCase):
@@ -2885,8 +2885,7 @@ class TestRenderXBlock(RenderXBlockTestMixin, ModuleStoreTestCase, CompletionWaf
         Test XBlockRendering with invalid usage key
         """
         response = self.get_response(usage_key='some_invalid_usage_key')
-        self.assertEqual(response.status_code, 404)
-        self.assertIn('Page not found', response.content)
+        self.assertContains(response, 'Page not found', status_code=404)
 
     def get_response(self, usage_key, url_encoded_params=None):
         """
@@ -2906,7 +2905,7 @@ class TestRenderXBlock(RenderXBlockTestMixin, ModuleStoreTestCase, CompletionWaf
 
         response = self.get_response(usage_key=self.html_block.location)
         self.assertEqual(response.status_code, 200)
-        self.assertIn('data-enable-completion-on-view-service="false"', response.content)
+        self.assertContains(response, 'data-enable-completion-on-view-service="false"')
         self.assertNotIn('data-mark-completed-on-view-after-delay', response.content)
 
     def test_render_xblock_with_completion_service_enabled(self):
@@ -2920,8 +2919,8 @@ class TestRenderXBlock(RenderXBlockTestMixin, ModuleStoreTestCase, CompletionWaf
 
         response = self.get_response(usage_key=self.html_block.location)
         self.assertEqual(response.status_code, 200)
-        self.assertIn('data-enable-completion-on-view-service="true"', response.content)
-        self.assertIn('data-mark-completed-on-view-after-delay', response.content)
+        self.assertContains(response, 'data-enable-completion-on-view-service="true"')
+        self.assertContains(response, 'data-mark-completed-on-view-after-delay')
 
         request = RequestFactoryNoCsrf().post(
             '/',
@@ -2940,12 +2939,12 @@ class TestRenderXBlock(RenderXBlockTestMixin, ModuleStoreTestCase, CompletionWaf
 
         response = self.get_response(usage_key=self.html_block.location)
         self.assertEqual(response.status_code, 200)
-        self.assertIn('data-enable-completion-on-view-service="false"', response.content)
+        self.assertContains(response, 'data-enable-completion-on-view-service="false"')
         self.assertNotIn('data-mark-completed-on-view-after-delay', response.content)
 
         response = self.get_response(usage_key=self.problem_block.location)
         self.assertEqual(response.status_code, 200)
-        self.assertIn('data-enable-completion-on-view-service="false"', response.content)
+        self.assertContains(response, 'data-enable-completion-on-view-service="false"')
         self.assertNotIn('data-mark-completed-on-view-after-delay', response.content)
 
 

--- a/lms/djangoapps/courseware/tests/test_views.py
+++ b/lms/djangoapps/courseware/tests/test_views.py
@@ -2386,7 +2386,7 @@ class TestIndexView(ModuleStoreTestCase):
                 }
             ) + '?activate_block_id=test_block_id'
         )
-        self.assertIn("Activate Block ID: test_block_id", response.content.decode('utf-8'))
+        self.assertContains(response, "Activate Block ID: test_block_id")
 
     @ddt.data(
         [False, COURSE_VISIBILITY_PRIVATE, CourseUserType.ANONYMOUS, False],

--- a/lms/djangoapps/courseware/tests/test_views.py
+++ b/lms/djangoapps/courseware/tests/test_views.py
@@ -2270,12 +2270,12 @@ class GenerateUserCertTests(ModuleStoreTestCase):
         # If user try to access without login should see a bad request status code with message
         self.client.logout()
         resp = self.client.post(self.url)
-        self.assertEqual(resp.status_code, HttpResponseBadRequest.status_code)
         self.assertContains(
             resp,
             u"You must be signed in to {platform_name} to create a certificate.".format(
-               platform_name=settings.PLATFORM_NAME
-            )
+                platform_name=settings.PLATFORM_NAME
+            ),
+            status_code=HttpResponseBadRequest.status_code,
         )
 
 

--- a/lms/djangoapps/courseware/tests/test_views.py
+++ b/lms/djangoapps/courseware/tests/test_views.py
@@ -2358,7 +2358,7 @@ class TestIndexView(ModuleStoreTestCase):
             )
         )
         # Trigger the assertions embedded in the ViewCheckerBlocks
-        self.assertEqual(response.content.decode('utf-8').count("ViewCheckerPassed"), 3)
+        self.assertContains(response, "ViewCheckerPassed", count=3)
 
     @XBlock.register_temp_plugin(ActivateIDCheckerBlock, 'id_checker')
     def test_activate_block_id(self):
@@ -2644,7 +2644,7 @@ class TestIndexViewCompleteOnView(ModuleStoreTestCase, CompletionWaffleTestMixin
 
         response = self.client.get(self.section_1_url)
         self.assertContains(response, 'data-mark-completed-on-view-after-delay')
-        self.assertEqual(response.content.count("data-mark-completed-on-view-after-delay"), 2)
+        self.assertContains(response, 'data-mark-completed-on-view-after-delay', count=2)
 
         request = self.request_factory.post(
             '/',
@@ -2662,7 +2662,7 @@ class TestIndexViewCompleteOnView(ModuleStoreTestCase, CompletionWaffleTestMixin
 
         response = self.client.get(self.section_1_url)
         self.assertContains(response, 'data-mark-completed-on-view-after-delay')
-        self.assertEqual(response.content.count("data-mark-completed-on-view-after-delay"), 1)
+        self.assertContains(response, 'data-mark-completed-on-view-after-delay', count=1)
 
         request = self.request_factory.post(
             '/',

--- a/lms/djangoapps/courseware/tests/test_views.py
+++ b/lms/djangoapps/courseware/tests/test_views.py
@@ -395,8 +395,8 @@ class ViewsTestCase(ModuleStoreTestCase):
         )
         response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
-        self.assertNotIn('Problem 1', response.content)
-        self.assertNotIn('Problem 2', response.content)
+        self.assertNotContains(response, 'Problem 1')
+        self.assertNotContains(response, 'Problem 2')
 
     def _create_global_staff_user(self):
         """
@@ -467,13 +467,13 @@ class ViewsTestCase(ModuleStoreTestCase):
         self.client.logout()
         response = self.client.get(reverse('about_course', args=[six.text_type(course.id)]))
         self.assertEqual(response.status_code, 200)
-        self.assertNotIn(in_cart_span, response.content)
+        self.assertNotContains(response, in_cart_span)
 
         # authenticated user with nothing in cart
         self.assertTrue(self.client.login(username=self.user.username, password=TEST_PASSWORD))
         response = self.client.get(reverse('about_course', args=[six.text_type(course.id)]))
         self.assertEqual(response.status_code, 200)
-        self.assertNotIn(in_cart_span, response.content)
+        self.assertNotContains(response, in_cart_span)
 
         # now add the course to the cart
         cart = shoppingcart.models.Order.get_cart_for_user(self.user)
@@ -628,7 +628,7 @@ class ViewsTestCase(ModuleStoreTestCase):
         })
         response = self.client.get(url)
         # Tests that we do not get an "Invalid x" response when passing correct arguments to view
-        self.assertNotIn('Invalid', response.content)
+        self.assertNotContains(response, 'Invalid')
 
     def test_submission_history_xss(self):
         # log into a staff account
@@ -643,7 +643,7 @@ class ViewsTestCase(ModuleStoreTestCase):
             'location': '<script>alert("hello");</script>'
         })
         response = self.client.get(url)
-        self.assertNotIn('<script>', response.content)
+        self.assertNotContains(response, '<script>')
 
         # try it with a malicious user and a non-existent location
         url = reverse('submission_history', kwargs={
@@ -652,7 +652,7 @@ class ViewsTestCase(ModuleStoreTestCase):
             'location': 'dummy'
         })
         response = self.client.get(url)
-        self.assertNotIn('<script>', response.content)
+        self.assertNotContains(response, '<script>')
 
     def test_submission_history_contents(self):
         # log into a staff account
@@ -786,7 +786,7 @@ class ViewsTestCase(ModuleStoreTestCase):
         response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
 
-        self.assertNotIn(str(course.id), response.content)
+        self.assertNotContains(response, str(course.id))
 
     @patch.object(CourseOverview, 'load_from_module_store', return_value=None)
     def test_financial_assistance_form_missing_course_overview(self, _mock_course_overview):
@@ -815,7 +815,7 @@ class ViewsTestCase(ModuleStoreTestCase):
         response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
 
-        self.assertNotIn(str(course), response.content)
+        self.assertNotContains(response, str(course))
 
     def test_financial_assistance_form(self):
         """Verify that learner can get the financial aid for the course in which
@@ -2630,10 +2630,10 @@ class TestIndexViewCompleteOnView(ModuleStoreTestCase, CompletionWaffleTestMixin
         self.assertTrue(self.client.login(username=self.user.username, password='test'))
 
         response = self.client.get(self.section_1_url)
-        self.assertNotIn('data-mark-completed-on-view-after-delay', response.content)
+        self.assertNotContains(response, 'data-mark-completed-on-view-after-delay')
 
         response = self.client.get(self.section_2_url)
-        self.assertNotIn('data-mark-completed-on-view-after-delay', response.content)
+        self.assertNotContains(response, 'data-mark-completed-on-view-after-delay')
 
     @ddt.data(ModuleStoreEnum.Type.mongo, ModuleStoreEnum.Type.split)
     def test_completion_service_enabled(self, default_store):
@@ -2680,10 +2680,10 @@ class TestIndexViewCompleteOnView(ModuleStoreTestCase, CompletionWaffleTestMixin
         self.assertEqual(json.loads(response.content.decode('utf-8')), {'result': "ok"})
 
         response = self.client.get(self.section_1_url)
-        self.assertNotIn('data-mark-completed-on-view-after-delay', response.content)
+        self.assertNotContains(response, 'data-mark-completed-on-view-after-delay')
 
         response = self.client.get(self.section_2_url)
-        self.assertNotIn('data-mark-completed-on-view-after-delay', response.content)
+        self.assertNotContains(response, 'data-mark-completed-on-view-after-delay')
 
 
 @ddt.ddt
@@ -2906,7 +2906,7 @@ class TestRenderXBlock(RenderXBlockTestMixin, ModuleStoreTestCase, CompletionWaf
         response = self.get_response(usage_key=self.html_block.location)
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, 'data-enable-completion-on-view-service="false"')
-        self.assertNotIn('data-mark-completed-on-view-after-delay', response.content)
+        self.assertNotContains(response, 'data-mark-completed-on-view-after-delay')
 
     def test_render_xblock_with_completion_service_enabled(self):
         """
@@ -2940,12 +2940,12 @@ class TestRenderXBlock(RenderXBlockTestMixin, ModuleStoreTestCase, CompletionWaf
         response = self.get_response(usage_key=self.html_block.location)
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, 'data-enable-completion-on-view-service="false"')
-        self.assertNotIn('data-mark-completed-on-view-after-delay', response.content)
+        self.assertNotContains(response, 'data-mark-completed-on-view-after-delay')
 
         response = self.get_response(usage_key=self.problem_block.location)
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, 'data-enable-completion-on-view-service="false"')
-        self.assertNotIn('data-mark-completed-on-view-after-delay', response.content)
+        self.assertNotContains(response, 'data-mark-completed-on-view-after-delay')
 
 
 class TestRenderXBlockSelfPaced(TestRenderXBlock):

--- a/lms/djangoapps/courseware/tests/test_views.py
+++ b/lms/djangoapps/courseware/tests/test_views.py
@@ -333,15 +333,15 @@ class ViewsTestCase(ModuleStoreTestCase):
 
     def test_index_success(self):
         response = self._verify_index_response()
-        self.assertIn(six.text_type(self.problem2.location), response.content.decode("utf-8"))
+        self.assertContains(response, self.problem2.location)
 
         # re-access to the main course page redirects to last accessed view.
         url = reverse('courseware', kwargs={'course_id': six.text_type(self.course_key)})
         response = self.client.get(url)
         self.assertEqual(response.status_code, 302)
         response = self.client.get(response.url)
-        self.assertNotIn(six.text_type(self.problem.location), response.content.decode("utf-8"))
-        self.assertIn(six.text_type(self.problem2.location), response.content.decode("utf-8"))
+        self.assertNotContains(response, self.problem.location)
+        self.assertContains(response, self.problem2.location)
 
     def test_index_nonexistent_chapter(self):
         self._verify_index_response(expected_response_code=404, chapter_name='non-existent')
@@ -509,8 +509,7 @@ class ViewsTestCase(ModuleStoreTestCase):
 
         # Generate the course about page content
         response = self.client.get(reverse('about_course', args=[six.text_type(course.id)]))
-        self.assertEqual(response.status_code, 200)
-        self.assertIn(href, response.content.decode(response.charset))
+        self.assertContains(response, href)
 
     @ddt.data(True, False)
     def test_ecommerce_checkout(self, is_anonymous):
@@ -1950,7 +1949,7 @@ class ProgressPageShowCorrectnessTests(ProgressPageBaseTests):
         # Test individual problem scores
         if show_grades:
             # If grades are shown, we should be able to see the current problem scores.
-            self.assertIn(expected_score, response.content.decode("utf-8"))
+            self.assertContains(response, expected_score)
 
             if graded:
                 expected_summary_text = u"Problem Scores:"
@@ -1959,7 +1958,7 @@ class ProgressPageShowCorrectnessTests(ProgressPageBaseTests):
 
         else:
             # If grades are hidden, we should not be able to see the current problem scores.
-            self.assertNotIn(expected_score, response.content.decode("utf-8"))
+            self.assertNotContains(response, expected_score)
 
             if graded:
                 expected_summary_text = u"Problem scores are hidden"
@@ -1972,7 +1971,7 @@ class ProgressPageShowCorrectnessTests(ProgressPageBaseTests):
                 expected_summary_text += u'.'
 
         # Ensure that expected text is present
-        self.assertIn(expected_summary_text, response.content.decode("utf-8"))
+        self.assertContains(response, expected_summary_text)
 
         # Test overall sequential score
         if graded and max_score > 0:
@@ -1983,9 +1982,9 @@ class ProgressPageShowCorrectnessTests(ProgressPageBaseTests):
                                                      percentageString)
 
             if show_grades:
-                self.assertIn(expected_grade_summary, response.content.decode("utf-8"))
+                self.assertContains(response, expected_grade_summary)
             else:
-                self.assertNotIn(expected_grade_summary, response.content.decode("utf-8"))
+                self.assertNotContains(response, expected_grade_summary)
 
     @ddt.data(
         ('', None, False),

--- a/lms/djangoapps/dashboard/tests/test_sysadmin.py
+++ b/lms/djangoapps/dashboard/tests/test_sysadmin.py
@@ -153,8 +153,7 @@ class TestSysAdminMongoCourseImport(SysadminBaseTestCase):
 
         # Create git loaded course
         response = self._add_edx4edx()
-        self.assertIn(Text(text_type(GitImportErrorNoDir(settings.GIT_REPO_DIR))),
-                      response.content.decode('UTF-8'))
+        self.assertContains(response, Text(text_type(GitImportErrorNoDir(settings.GIT_REPO_DIR))))
 
     def test_mongo_course_add_delete(self):
         """
@@ -315,10 +314,7 @@ class TestSysAdminMongoCourseImport(SysadminBaseTestCase):
                     page
                 )
             )
-            self.assertIn(
-                u'Page {} of 2'.format(expected),
-                response.content.decode(response.charset)
-            )
+            self.assertContains(response, u'Page {} of 2'.format(expected))
 
         CourseImportLog.objects.delete()
 

--- a/lms/djangoapps/dashboard/tests/test_sysadmin.py
+++ b/lms/djangoapps/dashboard/tests/test_sysadmin.py
@@ -212,13 +212,13 @@ class TestSysAdminMongoCourseImport(SysadminBaseTestCase):
         response = self.client.get(reverse('gitlogs'))
 
         # Check that our earlier import has a log with a link to details
-        self.assertIn('/gitlogs/course-v1:MITx+edx4edx+edx4edx', response.content.decode('utf-8'))
+        self.assertContains(response, '/gitlogs/course-v1:MITx+edx4edx+edx4edx')
 
         response = self.client.get(
             reverse('gitlogs_detail', kwargs={
                 'course_id': 'course-v1:MITx+edx4edx+edx4edx'}))
 
-        self.assertIn('======&gt; IMPORTING course', response.content.decode('utf-8'))
+        self.assertContains(response, '======&gt; IMPORTING course')
 
         self._rm_edx4edx()
 
@@ -247,7 +247,7 @@ class TestSysAdminMongoCourseImport(SysadminBaseTestCase):
             with (override_settings(TIME_ZONE=timezone)):
                 date_text = get_time_display(date, tz_format, settings.TIME_ZONE)
                 response = self.client.get(reverse('gitlogs'))
-                self.assertIn(date_text, response.content.decode('UTF-8'))
+                self.assertContains(response, date_text)
 
         self._rm_edx4edx()
 
@@ -284,7 +284,7 @@ class TestSysAdminMongoCourseImport(SysadminBaseTestCase):
                 'course_id': 'course-v1:MITx+edx4edx+edx4edx'
             })
         )
-        self.assertIn('No git import logs have been recorded for this course.', response.content.decode('utf-8'))
+        self.assertContains(response, 'No git import logs have been recorded for this course.')
 
         self._rm_edx4edx()
 
@@ -358,6 +358,6 @@ class TestSysAdminMongoCourseImport(SysadminBaseTestCase):
             reverse('gitlogs_detail', kwargs={
                 'course_id': 'course-v1:MITx+edx4edx+edx4edx'
             }))
-        self.assertIn('======&gt; IMPORTING course', response.content.decode('utf-8'))
+        self.assertContains(response, '======&gt; IMPORTING course')
 
         self._rm_edx4edx()

--- a/lms/djangoapps/dashboard/tests/test_sysadmin.py
+++ b/lms/djangoapps/dashboard/tests/test_sysadmin.py
@@ -258,9 +258,9 @@ class TestSysAdminMongoCourseImport(SysadminBaseTestCase):
         response = self.client.get(
             reverse('gitlogs_detail', kwargs={
                 'course_id': 'Not/Real/Testing'}))
-        self.assertIn(
+        self.assertContains(
+            response,
             'No git import logs have been recorded for this course.',
-            response.content
         )
 
     def test_gitlog_no_logs(self):

--- a/lms/djangoapps/discussion/tests/test_views.py
+++ b/lms/djangoapps/discussion/tests/test_views.py
@@ -1559,8 +1559,7 @@ class ForumDiscussionXSSTestCase(ForumsEnableMixin, UrlResetMixin, ModuleStoreTe
         # Test that malicious code does not appear in html
         url = "%s?%s=%s" % (reverse_url, 'sort_key', malicious_code)
         resp = self.client.get(url)
-        self.assertEqual(resp.status_code, 200)
-        self.assertNotIn(malicious_code, resp.content.decode('utf-8'))
+        self.assertNotContains(resp, malicious_code)
 
     @ddt.data('"><script>alert(1)</script>', '<script>alert(1)</script>', '</script><script>alert(1)</script>')
     @patch('student.models.cc.User.from_django_user')
@@ -1582,8 +1581,7 @@ class ForumDiscussionXSSTestCase(ForumsEnableMixin, UrlResetMixin, ModuleStoreTe
         # Test that malicious code does not appear in html
         url_string = "%s?%s=%s" % (url, 'page', malicious_code)
         resp = self.client.get(url_string)
-        self.assertEqual(resp.status_code, 200)
-        self.assertNotIn(malicious_code, resp.content.decode('utf-8'))
+        self.assertNotContains(resp, malicious_code)
 
 
 class ForumDiscussionSearchUnicodeTestCase(ForumsEnableMixin, SharedModuleStoreTestCase, UnicodeTestMixin):

--- a/lms/djangoapps/edxnotes/tests.py
+++ b/lms/djangoapps/edxnotes/tests.py
@@ -1081,8 +1081,7 @@ class EdxNotesViewsTest(ModuleStoreTestCase):
         mock_search.side_effect = EdxNotesServiceUnavailable
         enable_edxnotes_for_the_course(self.course, self.user.id)
         response = self.client.get(self.notes_url, {"text": "test"})
-        self.assertEqual(response.status_code, 500)
-        self.assertIn("error", response.content)
+        self.assertContains(response, "error", status_code=500)
 
     @patch.dict("django.conf.settings.FEATURES", {"ENABLE_EDXNOTES": True})
     @patch("edxnotes.views.get_notes", autospec=True)
@@ -1094,8 +1093,7 @@ class EdxNotesViewsTest(ModuleStoreTestCase):
         mock_search.side_effect = EdxNotesParseError
         enable_edxnotes_for_the_course(self.course, self.user.id)
         response = self.client.get(self.notes_url, {"text": "test"})
-        self.assertEqual(response.status_code, 500)
-        self.assertIn("error", response.content)
+        self.assertContains(response, "error", status_code=500)
 
     @patch.dict("django.conf.settings.FEATURES", {"ENABLE_EDXNOTES": True})
     def test_get_id_token(self):

--- a/lms/djangoapps/instructor/tests/test_api.py
+++ b/lms/djangoapps/instructor/tests/test_api.py
@@ -2684,22 +2684,23 @@ class TestInstructorAPILevelsDataDump(SharedModuleStoreTestCase, LoginEnrollment
 
         # Now re_validate the same active invoice number and expect an Bad request
         response = self.assert_request_status_code(400, url, method="POST", data=data)
-        self.assertIn("This invoice is already active.", response.content.decode('utf-8'))
+        self.assertContains(response, "This invoice is already active.", status_code=400)
 
         test_data_2 = {'invoice_number': self.sale_invoice_1.id}
         response = self.assert_request_status_code(400, url, method="POST", data=test_data_2)
-        self.assertIn("Missing required event_type parameter", response.content.decode('utf-8'))
+        self.assertContains(response, "Missing required event_type parameter", status_code=400)
 
         test_data_3 = {'event_type': "re_validate"}
         response = self.assert_request_status_code(400, url, method="POST", data=test_data_3)
-        self.assertIn("Missing required invoice_number parameter", response.content.decode('utf-8'))
+        self.assertContains(response, "Missing required invoice_number parameter", status_code=400)
 
         # submitting invalid invoice number
         data['invoice_number'] = 'testing'
         response = self.assert_request_status_code(400, url, method="POST", data=data)
-        self.assertIn(
+        self.assertContains(
+            response,
             u"invoice_number must be an integer, {value} provided".format(value=data['invoice_number']),
-            response.content.decode('utf-8')
+            status_code=400,
         )
 
     def test_get_sale_order_records_features_csv(self):
@@ -2991,8 +2992,7 @@ class TestInstructorAPILevelsDataDump(SharedModuleStoreTestCase, LoginEnrollment
             submit_task_function.side_effect = error
             response = self.client.post(url, {})
 
-        self.assertEqual(response.status_code, 400)
-        self.assertIn(already_running_status, response.content.decode('utf-8'))
+        self.assertContains(response, already_running_status, status_code=400)
 
     def test_get_students_features(self):
         """
@@ -3070,8 +3070,7 @@ class TestInstructorAPILevelsDataDump(SharedModuleStoreTestCase, LoginEnrollment
             error = AlreadyRunningError(already_running_status)
             submit_task_function.side_effect = error
             response = self.client.post(url, {})
-        self.assertEqual(response.status_code, 400)
-        self.assertIn(already_running_status, response.content.decode('utf-8'))
+        self.assertContains(response, already_running_status, status_code=400)
 
     def test_get_student_exam_results(self):
         """
@@ -3093,8 +3092,7 @@ class TestInstructorAPILevelsDataDump(SharedModuleStoreTestCase, LoginEnrollment
             error = AlreadyRunningError(already_running_status)
             submit_task_function.side_effect = error
             response = self.client.post(url, {})
-            self.assertEqual(response.status_code, 400)
-            self.assertIn(already_running_status, response.content.decode('utf-8'))
+            self.assertContains(response, already_running_status, status_code=400)
 
     def test_access_course_finance_admin_with_invalid_course_key(self):
         """
@@ -3408,8 +3406,7 @@ class TestInstructorAPILevelsDataDump(SharedModuleStoreTestCase, LoginEnrollment
             mock.side_effect = AlreadyRunningError(already_running_status)
             response = self.client.post(url, {})
 
-        self.assertEqual(response.status_code, 400)
-        self.assertIn(already_running_status, response.content.decode('utf-8'))
+        self.assertContains(response, already_running_status, status_code=400)
 
     def test_get_ora2_responses_success(self):
         url = reverse('export_ora2_data', kwargs={'course_id': text_type(self.course.id)})
@@ -3429,8 +3426,7 @@ class TestInstructorAPILevelsDataDump(SharedModuleStoreTestCase, LoginEnrollment
             mock_submit_ora2_task.side_effect = AlreadyRunningError(already_running_status)
             response = self.client.post(url, {})
 
-        self.assertEqual(response.status_code, 400)
-        self.assertIn(already_running_status, response.content.decode('utf-8'))
+        self.assertContains(response, already_running_status, status_code=400)
 
     def test_get_student_progress_url(self):
         """ Test that progress_url is in the successful response. """
@@ -5176,7 +5172,7 @@ class TestCourseRegistrationCodes(SharedModuleStoreTestCase):
 
         response = self.client.post(generate_code_url, data, **{'HTTP_HOST': 'localhost'})
         self.assertEqual(response.status_code, 400, response.content.decode('utf-8'))
-        self.assertIn('Could not parse amount as', response.content.decode('utf-8'))
+        self.assertContains(response, 'Could not parse amount as', status_code=400)
 
     def test_get_historical_coupon_codes(self):
         """

--- a/lms/djangoapps/instructor/tests/test_api.py
+++ b/lms/djangoapps/instructor/tests/test_api.py
@@ -293,30 +293,27 @@ class TestCommonExceptions400(TestCase):
     def test_user_doesnotexist(self):
         self.request.is_ajax.return_value = False
         resp = view_user_doesnotexist(self.request)  # pylint: disable=assignment-from-no-return
-        self.assertEqual(resp.status_code, 400)
-        self.assertIn("User does not exist", resp.content.decode("utf-8"))
+        self.assertContains(resp, "User does not exist", status_code=400)
 
     def test_user_doesnotexist_ajax(self):
         self.request.is_ajax.return_value = True
         resp = view_user_doesnotexist(self.request)  # pylint: disable=assignment-from-no-return
-        self.assertEqual(resp.status_code, 400)
-        self.assertIn("User does not exist", resp.content.decode("utf-8"))
+        self.assertContains(resp, "User does not exist", status_code=400)
 
     @ddt.data(True, False)
     def test_alreadyrunningerror(self, is_ajax):
         self.request.is_ajax.return_value = is_ajax
         resp = view_alreadyrunningerror(self.request)  # pylint: disable=assignment-from-no-return
-        self.assertEqual(resp.status_code, 400)
-        self.assertIn("Requested task is already running", resp.content.decode("utf-8"))
+        self.assertContains(resp, "Requested task is already running", status_code=400)
 
     @ddt.data(True, False)
     def test_alreadyrunningerror_with_unicode(self, is_ajax):
         self.request.is_ajax.return_value = is_ajax
         resp = view_alreadyrunningerror_unicode(self.request)  # pylint: disable=assignment-from-no-return
-        self.assertEqual(resp.status_code, 400)
-        self.assertIn(
+        self.assertContains(
+            resp,
             u'Text with unicode chárácters',
-            resp.content.decode('utf-8')
+            status_code=400,
         )
 
     @ddt.data(True, False)
@@ -326,10 +323,10 @@ class TestCommonExceptions400(TestCase):
         """
         self.request.is_ajax.return_value = is_ajax
         resp = view_queue_connection_error(self.request)  # pylint: disable=assignment-from-no-return
-        self.assertEqual(resp.status_code, 400)
-        self.assertIn(
+        self.assertContains(
+            resp,
             'Error occured. Please try again later',
-            resp.content.decode('utf-8')
+            status_code=400,
         )
 
 

--- a/lms/djangoapps/instructor/tests/test_api.py
+++ b/lms/djangoapps/instructor/tests/test_api.py
@@ -869,7 +869,7 @@ class TestInstructorAPIBulkAccountCreationAndEnrollment(SharedModuleStoreTestCas
         user.is_active = False
         user.save()
 
-        csv_content = b"{email},{username},tester,USA".format(email=conflicting_email, username='new_test_student')
+        csv_content = "{email},{username},tester,USA".format(email=conflicting_email, username='new_test_student')
         uploaded_file = SimpleUploadedFile("temp.csv", six.b(csv_content))
         response = self.client.post(self.url, {'students_list': uploaded_file})
         self.assertEqual(response.status_code, 200)
@@ -2673,9 +2673,10 @@ class TestInstructorAPILevelsDataDump(SharedModuleStoreTestCase, LoginEnrollment
 
         # Now invalidate the same invoice number and expect an Bad request
         response = self.assert_request_status_code(400, url, method="POST", data=data)
-        self.assertIn(
+        self.assertContains(
+            response,
             "The sale associated with this invoice has already been invalidated.",
-            response.content.decode('utf-8')
+            status_code=400,
         )
 
         # now re_validate the invoice number
@@ -5171,7 +5172,6 @@ class TestCourseRegistrationCodes(SharedModuleStoreTestCase):
         }
 
         response = self.client.post(generate_code_url, data, **{'HTTP_HOST': 'localhost'})
-        self.assertEqual(response.status_code, 400, response.content.decode('utf-8'))
         self.assertContains(response, 'Could not parse amount as', status_code=400)
 
     def test_get_historical_coupon_codes(self):

--- a/lms/djangoapps/instructor/tests/test_api.py
+++ b/lms/djangoapps/instructor/tests/test_api.py
@@ -2643,7 +2643,7 @@ class TestInstructorAPILevelsDataDump(SharedModuleStoreTestCase, LoginEnrollment
         response = self.client.get(redeem_url)
         self.assertEquals(response.status_code, 200)
         # check button text
-        self.assertIn('Activate Course Enrollment', response.content.decode('utf-8'))
+        self.assertContains(response, 'Activate Course Enrollment')
 
         response = self.client.post(redeem_url)
         self.assertEquals(response.status_code, 200)
@@ -3176,7 +3176,7 @@ class TestInstructorAPILevelsDataDump(SharedModuleStoreTestCase, LoginEnrollment
         self.client.login(username=self.instructor.username, password='test')
         url = reverse('get_enrollment_report', kwargs={'course_id': text_type(self.course.id)})
         response = self.client.post(url, {})
-        self.assertIn('The detailed enrollment report is being created.', response.content.decode('utf-8'))
+        self.assertContains(response, 'The detailed enrollment report is being created.')
 
     def test_bulk_purchase_detailed_report(self):
         """
@@ -3231,7 +3231,7 @@ class TestInstructorAPILevelsDataDump(SharedModuleStoreTestCase, LoginEnrollment
 
         url = reverse('get_enrollment_report', kwargs={'course_id': text_type(self.course.id)})
         response = self.client.post(url, {})
-        self.assertIn('The detailed enrollment report is being created.', response.content.decode('utf-8'))
+        self.assertContains(response, 'The detailed enrollment report is being created.')
 
     def test_create_registration_code_without_invoice_and_order(self):
         """
@@ -3253,7 +3253,7 @@ class TestInstructorAPILevelsDataDump(SharedModuleStoreTestCase, LoginEnrollment
 
         url = reverse('get_enrollment_report', kwargs={'course_id': text_type(self.course.id)})
         response = self.client.post(url, {})
-        self.assertIn('The detailed enrollment report is being created.', response.content.decode('utf-8'))
+        self.assertContains(response, 'The detailed enrollment report is being created.')
 
     def test_invoice_payment_is_still_pending_for_registration_codes(self):
         """
@@ -3278,7 +3278,7 @@ class TestInstructorAPILevelsDataDump(SharedModuleStoreTestCase, LoginEnrollment
 
         url = reverse('get_enrollment_report', kwargs={'course_id': text_type(self.course.id)})
         response = self.client.post(url, {})
-        self.assertIn('The detailed enrollment report is being created.', response.content.decode('utf-8'))
+        self.assertContains(response, 'The detailed enrollment report is being created.')
 
     @patch('lms.djangoapps.instructor.views.api.anonymous_id_for_user', Mock(return_value='42'))
     @patch('lms.djangoapps.instructor.views.api.unique_id_for_user', Mock(return_value='41'))
@@ -3358,11 +3358,11 @@ class TestInstructorAPILevelsDataDump(SharedModuleStoreTestCase, LoginEnrollment
 
             if report_type == 'problem responses':
                 response = self.client.post(url, {'problem_location': ''})
-                self.assertIn(success_status, response.content.decode('utf-8'))
+                self.assertContains(response, success_status)
             else:
                 CourseFinanceAdminRole(self.course.id).add_users(self.instructor)
                 response = self.client.post(url, {})
-                self.assertIn(success_status, response.content.decode('utf-8'))
+                self.assertContains(response, success_status)
 
     @ddt.data(*EXECUTIVE_SUMMARY_DATA)
     @ddt.unpack
@@ -3384,7 +3384,7 @@ class TestInstructorAPILevelsDataDump(SharedModuleStoreTestCase, LoginEnrollment
         success_status = u"The {report_type} report is being created." \
                          " To view the status of the report, see Pending" \
                          " Tasks below".format(report_type=report_type)
-        self.assertIn(success_status, response.content.decode('utf-8'))
+        self.assertContains(response, success_status)
 
     @ddt.data(*EXECUTIVE_SUMMARY_DATA)
     @ddt.unpack
@@ -3415,7 +3415,7 @@ class TestInstructorAPILevelsDataDump(SharedModuleStoreTestCase, LoginEnrollment
             mock_submit_ora2_task.return_value = True
             response = self.client.post(url, {})
         success_status = "The ORA data report is being created."
-        self.assertIn(success_status, response.content.decode('utf-8'))
+        self.assertContains(response, success_status)
 
     def test_get_ora2_responses_already_running(self):
         url = reverse('export_ora2_data', kwargs={'course_id': text_type(self.course.id)})

--- a/lms/djangoapps/instructor/tests/test_api.py
+++ b/lms/djangoapps/instructor/tests/test_api.py
@@ -2783,19 +2783,17 @@ class TestInstructorAPILevelsDataDump(SharedModuleStoreTestCase, LoginEnrollment
         # visit the instructor dashboard page and
         # check that the coupon redeem count should be 0
         resp = self.client.get(instructor_dashboard)
-        self.assertEqual(resp.status_code, 200)
-        self.assertIn('Number Redeemed', resp.content.decode('utf-8'))
-        self.assertIn('<td>0</td>', resp.content.decode('utf-8'))
+        self.assertContains(resp, 'Number Redeemed')
+        self.assertContains(resp, '<td>0</td>')
 
         # now make the payment of your cart items
         self.cart.purchase()
         # visit the instructor dashboard page and
         # check that the coupon redeem count should be 1
         resp = self.client.get(instructor_dashboard)
-        self.assertEqual(resp.status_code, 200)
 
-        self.assertIn('Number Redeemed', resp.content.decode('utf-8'))
-        self.assertIn('<td>1</td>', resp.content.decode('utf-8'))
+        self.assertContains(resp, 'Number Redeemed')
+        self.assertContains(resp, '<td>1</td>')
 
     def test_get_sale_records_features_csv(self):
         """

--- a/lms/djangoapps/instructor/tests/test_ecommerce.py
+++ b/lms/djangoapps/instructor/tests/test_ecommerce.py
@@ -73,7 +73,7 @@ class TestECommerceDashboardViews(SiteMixin, SharedModuleStoreTestCase):
         """
         response = self.client.get(self.url)
         self.assertContains(response, self.ecommerce_link)
-        self.assertNotIn('Create Enrollment Report', response.content)
+        self.assertNotContains(response, 'Create Enrollment Report')
 
     def test_user_has_finance_admin_rights_in_e_commerce_tab(self):
         response = self.client.get(self.url)
@@ -90,7 +90,7 @@ class TestECommerceDashboardViews(SiteMixin, SharedModuleStoreTestCase):
         # Order/Invoice sales csv button text should not be visible in e-commerce page if the user is not finance admin
         url = reverse('instructor_dashboard', kwargs={'course_id': text_type(self.course.id)})
         response = self.client.post(url)
-        self.assertNotIn('Download All Invoices', response.content)
+        self.assertNotContains(response, 'Download All Invoices')
 
     def test_user_view_course_price(self):
         """
@@ -105,7 +105,7 @@ class TestECommerceDashboardViews(SiteMixin, SharedModuleStoreTestCase):
 
         price = course_honor_mode.min_price
         self.assertContains(response, 'Course price per seat: <span>$' + str(price) + '</span>')
-        self.assertNotIn('+ Set Price</a></span>', response.content)
+        self.assertNotContains(response, '+ Set Price</a></span>')
 
         # removing the course finance_admin role of login user
         CourseFinanceAdminRole(self.course.id).remove_users(self.instructor)
@@ -113,7 +113,7 @@ class TestECommerceDashboardViews(SiteMixin, SharedModuleStoreTestCase):
         # total amount should not be visible in e-commerce page if the user is not finance admin
         url = reverse('instructor_dashboard', kwargs={'course_id': text_type(self.course.id)})
         response = self.client.get(url)
-        self.assertNotIn('+ Set Price</a></span>', response.content)
+        self.assertNotContains(response, '+ Set Price</a></span>')
 
     def test_update_course_price_check(self):
         price = 200
@@ -214,7 +214,7 @@ class TestECommerceDashboardViews(SiteMixin, SharedModuleStoreTestCase):
         response = self.client.post(self.url)
         self.assertContains(response, '<td>ADSADASDSAD</td>')
         self.assertContains(response, '<td>A2314</td>')
-        self.assertNotIn('<td>111</td>', response.content)
+        self.assertNotContains(response, '<td>111</td>')
 
         data = {
             'code': 'A2345314', 'course_id': text_type(self.course.id),
@@ -376,7 +376,7 @@ class TestECommerceDashboardViews(SiteMixin, SharedModuleStoreTestCase):
         response = self.client.get(self.url)
         self.assertContains(response, self.ecommerce_link)
         # Coupons should show up for White Label sites with priced honor modes.
-        self.assertNotIn('Coupons List', response.content)
+        self.assertNotContains(response, 'Coupons List')
 
     def test_coupon_code_section_not_under_e_commerce_tab(self):
         """
@@ -388,7 +388,7 @@ class TestECommerceDashboardViews(SiteMixin, SharedModuleStoreTestCase):
 
         response = self.client.get(self.url)
         self.assertContains(response, self.ecommerce_link)
-        self.assertNotIn('Coupon Code List', response.content)
+        self.assertNotContains(response, 'Coupon Code List')
 
     def test_enrollment_codes_section_not_under_e_commerce_tab(self):
         """
@@ -400,7 +400,7 @@ class TestECommerceDashboardViews(SiteMixin, SharedModuleStoreTestCase):
 
         response = self.client.get(self.url)
         self.assertContains(response, self.ecommerce_link)
-        self.assertNotIn('<h3 class="hd hd-3">Enrollment Codes</h3>', response.content)
+        self.assertNotContains(response, '<h3 class="hd hd-3">Enrollment Codes</h3>')
 
     def test_enrollment_codes_section_visible_for_non_ecommerce_course(self):
         """

--- a/lms/djangoapps/instructor/tests/test_ecommerce.py
+++ b/lms/djangoapps/instructor/tests/test_ecommerce.py
@@ -52,9 +52,9 @@ class TestECommerceDashboardViews(SiteMixin, SharedModuleStoreTestCase):
         Test Pass E-commerce Tab is in the Instructor Dashboard
         """
         response = self.client.get(self.url)
-        self.assertIn(self.ecommerce_link, response.content)
+        self.assertContains(response, self.ecommerce_link)
         # Coupons should show up for White Label sites with priced honor modes.
-        self.assertIn('Coupon Code List', response.content)
+        self.assertContains(response, 'Coupon Code List')
 
     def test_reports_section_under_e_commerce_tab(self):
         """
@@ -63,8 +63,8 @@ class TestECommerceDashboardViews(SiteMixin, SharedModuleStoreTestCase):
         self.use_site(site=self.site_other)
         self.client.login(username=self.instructor.username, password="test")
         response = self.client.get(self.url)
-        self.assertIn(self.ecommerce_link, response.content)
-        self.assertIn('Create Enrollment Report', response.content)
+        self.assertContains(response, self.ecommerce_link)
+        self.assertContains(response, 'Create Enrollment Report')
 
     def test_reports_section_not_under_e_commerce_tab(self):
         """
@@ -72,17 +72,17 @@ class TestECommerceDashboardViews(SiteMixin, SharedModuleStoreTestCase):
         value
         """
         response = self.client.get(self.url)
-        self.assertIn(self.ecommerce_link, response.content)
+        self.assertContains(response, self.ecommerce_link)
         self.assertNotIn('Create Enrollment Report', response.content)
 
     def test_user_has_finance_admin_rights_in_e_commerce_tab(self):
         response = self.client.get(self.url)
-        self.assertIn(self.ecommerce_link, response.content)
+        self.assertContains(response, self.ecommerce_link)
 
         # Order/Invoice sales csv button text should render in e-commerce page
-        self.assertIn('Total Credit Card Purchases', response.content)
-        self.assertIn('Download All Credit Card Purchases', response.content)
-        self.assertIn('Download All Invoices', response.content)
+        self.assertContains(response, 'Total Credit Card Purchases')
+        self.assertContains(response, 'Download All Credit Card Purchases')
+        self.assertContains(response, 'Download All Invoices')
 
         # removing the course finance_admin role of login user
         CourseFinanceAdminRole(self.course.id).remove_users(self.instructor)
@@ -98,13 +98,13 @@ class TestECommerceDashboardViews(SiteMixin, SharedModuleStoreTestCase):
         the instructor dashboard
         """
         response = self.client.get(self.url)
-        self.assertIn(self.ecommerce_link, response.content)
+        self.assertContains(response, self.ecommerce_link)
 
         # Total amount html should render in e-commerce page, total amount will be 0
         course_honor_mode = CourseMode.mode_for_course(self.course.id, 'honor')
 
         price = course_honor_mode.min_price
-        self.assertIn('Course price per seat: <span>$' + str(price) + '</span>', response.content)
+        self.assertContains(response, 'Course price per seat: <span>$' + str(price) + '</span>')
         self.assertNotIn('+ Set Price</a></span>', response.content)
 
         # removing the course finance_admin role of login user
@@ -130,13 +130,13 @@ class TestECommerceDashboardViews(SiteMixin, SharedModuleStoreTestCase):
         set_course_price_url = reverse('set_course_mode_price', kwargs={'course_id': text_type(self.course.id)})
         data = {'course_price': price, 'currency': 'usd'}
         response = self.client.post(set_course_price_url, data)
-        self.assertIn('CourseMode price updated successfully', response.content)
+        self.assertContains(response, 'CourseMode price updated successfully')
 
         # Course A updated total amount should be visible in e-commerce page if the user is finance admin
         url = reverse('instructor_dashboard', kwargs={'course_id': text_type(self.course.id)})
         response = self.client.get(url)
 
-        self.assertIn('Course price per seat: <span>$' + str(price) + '</span>', response.content)
+        self.assertContains(response, 'Course price per seat: <span>$' + str(price) + '</span>')
 
     def test_user_admin_set_course_price(self):
         """
@@ -148,20 +148,21 @@ class TestECommerceDashboardViews(SiteMixin, SharedModuleStoreTestCase):
 
         # Value Error course price should be a numeric value
         response = self.client.post(set_course_price_url, data)
-        self.assertIn("Please Enter the numeric value for the course price", response.content)
+        self.assertContains(response, "Please Enter the numeric value for the course price", status_code=400)
 
         # validation check passes and course price is successfully added
         data['course_price'] = 100
         response = self.client.post(set_course_price_url, data)
-        self.assertIn("CourseMode price updated successfully", response.content)
+        self.assertContains(response, "CourseMode price updated successfully")
 
         course_honor_mode = CourseMode.objects.get(mode_slug='honor')
         course_honor_mode.delete()
         # Course Mode not exist with mode slug honor
         response = self.client.post(set_course_price_url, data)
-        self.assertIn(
+        self.assertContains(
+            response,
             u"CourseMode with the mode slug({mode_slug}) DoesNotExist".format(mode_slug='honor'),
-            response.content
+            status_code=400,
         )
 
     def test_add_coupon(self):
@@ -180,9 +181,9 @@ class TestECommerceDashboardViews(SiteMixin, SharedModuleStoreTestCase):
             )
         }
         response = self.client.post(add_coupon_url, data)
-        self.assertIn(
+        self.assertContains(
+            response,
             u"coupon with the coupon code ({code}) added successfully".format(code=data['code']),
-            response.content
         )
 
         #now add the coupon with the wrong value in the expiration_date
@@ -193,18 +194,26 @@ class TestECommerceDashboardViews(SiteMixin, SharedModuleStoreTestCase):
             'expiration_date': expiration_date.strftime('"%d/%m/%Y')
         }
         response = self.client.post(add_coupon_url, data)
-        self.assertIn("Please enter the date in this format i-e month/day/year", response.content)
+        self.assertContains(
+            response,
+            "Please enter the date in this format i-e month/day/year",
+            status_code=400,
+        )
 
         data = {
             'code': 'A2314', 'course_id': text_type(self.course.id),
             'description': 'asdsasda', 'created_by': self.instructor, 'discount': 99
         }
         response = self.client.post(add_coupon_url, data)
-        self.assertIn(u"coupon with the coupon code ({code}) already exist".format(code='A2314'), response.content)
+        self.assertContains(
+            response,
+            u"coupon with the coupon code ({code}) already exist".format(code='A2314'),
+            status_code=400,
+        )
 
         response = self.client.post(self.url)
-        self.assertIn('<td>ADSADASDSAD</td>', response.content)
-        self.assertIn('<td>A2314</td>', response.content)
+        self.assertContains(response, '<td>ADSADASDSAD</td>')
+        self.assertContains(response, '<td>A2314</td>')
         self.assertNotIn('<td>111</td>', response.content)
 
         data = {
@@ -212,11 +221,15 @@ class TestECommerceDashboardViews(SiteMixin, SharedModuleStoreTestCase):
             'description': 'asdsasda', 'created_by': self.instructor, 'discount': 199
         }
         response = self.client.post(add_coupon_url, data)
-        self.assertIn("Please Enter the Coupon Discount Value Less than or Equal to 100", response.content)
+        self.assertContains(
+            response,
+            "Please Enter the Coupon Discount Value Less than or Equal to 100",
+            status_code=400,
+        )
 
         data['discount'] = '25%'
         response = self.client.post(add_coupon_url, data=data)
-        self.assertIn('Please Enter the Integer Value for Coupon Discount', response.content)
+        self.assertContains(response, 'Please Enter the Integer Value for Coupon Discount', status_code=400)
 
         course_registration = CourseRegistrationCode(
             code='Vs23Ws4j', course_id=text_type(self.course.id), created_by=self.instructor,
@@ -227,7 +240,7 @@ class TestECommerceDashboardViews(SiteMixin, SharedModuleStoreTestCase):
         data['code'] = 'Vs23Ws4j'
         response = self.client.post(add_coupon_url, data)
         msg = u"The code ({code}) that you have tried to define is already in use as a registration code"
-        self.assertIn(msg.format(code=data['code']), response.content)
+        self.assertContains(response, msg.format(code=data['code']), status_code=400)
 
     def test_delete_coupon(self):
         """
@@ -241,33 +254,35 @@ class TestECommerceDashboardViews(SiteMixin, SharedModuleStoreTestCase):
         coupon.save()
 
         response = self.client.post(self.url)
-        self.assertIn('<td>AS452</td>', response.content)
+        self.assertContains(response, '<td>AS452</td>')
 
         # URL for remove_coupon
         delete_coupon_url = reverse('remove_coupon', kwargs={'course_id': text_type(self.course.id)})
         response = self.client.post(delete_coupon_url, {'id': coupon.id})
-        self.assertIn(
+        self.assertContains(
+            response,
             u'coupon with the coupon id ({coupon_id}) updated successfully'.format(coupon_id=coupon.id),
-            response.content
         )
 
         coupon.is_active = False
         coupon.save()
 
         response = self.client.post(delete_coupon_url, {'id': coupon.id})
-        self.assertIn(
+        self.assertContains(
+            response,
             u'coupon with the coupon id ({coupon_id}) is already inactive'.format(coupon_id=coupon.id),
-            response.content
+            status_code=400,
         )
 
         response = self.client.post(delete_coupon_url, {'id': 24454})
-        self.assertIn(
+        self.assertContains(
+            response,
             u'coupon with the coupon id ({coupon_id}) DoesNotExist'.format(coupon_id=24454),
-            response.content
+            status_code=400,
         )
 
         response = self.client.post(delete_coupon_url, {'id': ''})
-        self.assertIn('coupon id is None', response.content)
+        self.assertContains(response, 'coupon id is None', status_code=400)
 
     def test_get_coupon_info(self):
         """
@@ -282,28 +297,30 @@ class TestECommerceDashboardViews(SiteMixin, SharedModuleStoreTestCase):
         # URL for edit_coupon_info
         edit_url = reverse('get_coupon_info', kwargs={'course_id': text_type(self.course.id)})
         response = self.client.post(edit_url, {'id': coupon.id})
-        self.assertIn(
+        self.assertContains(
+            response,
             u'coupon with the coupon id ({coupon_id}) updated successfully'.format(coupon_id=coupon.id),
-            response.content
         )
-        self.assertIn(coupon.display_expiry_date, response.content)
+        self.assertContains(response, coupon.display_expiry_date)
 
         response = self.client.post(edit_url, {'id': 444444})
-        self.assertIn(
+        self.assertContains(
+            response,
             u'coupon with the coupon id ({coupon_id}) DoesNotExist'.format(coupon_id=444444),
-            response.content
+            status_code=400,
         )
 
         response = self.client.post(edit_url, {'id': ''})
-        self.assertIn('coupon id not found"', response.content)
+        self.assertContains(response, 'coupon id not found"', status_code=400)
 
         coupon.is_active = False
         coupon.save()
 
         response = self.client.post(edit_url, {'id': coupon.id})
-        self.assertIn(
+        self.assertContains(
+            response,
             u"coupon with the coupon id ({coupon_id}) is already inactive".format(coupon_id=coupon.id),
-            response.content
+            status_code=400,
         )
 
     def test_update_coupon(self):
@@ -316,7 +333,7 @@ class TestECommerceDashboardViews(SiteMixin, SharedModuleStoreTestCase):
         )
         coupon.save()
         response = self.client.post(self.url)
-        self.assertIn('<td>AS452</td>', response.content)
+        self.assertContains(response, '<td>AS452</td>')
         data = {
             'coupon_id': coupon.id, 'code': 'AS452', 'discount': '10', 'description': 'updated_description',
             'course_id': text_type(coupon.course_id)
@@ -330,15 +347,19 @@ class TestECommerceDashboardViews(SiteMixin, SharedModuleStoreTestCase):
         )
 
         response = self.client.post(self.url)
-        self.assertIn('<td>updated_description</td>', response.content)
+        self.assertContains(response, '<td>updated_description</td>')
 
         data['coupon_id'] = 1000  # Coupon Not Exist with this ID
         response = self.client.post(update_coupon_url, data=data)
-        self.assertIn(u'coupon with the coupon id ({coupon_id}) DoesNotExist'.format(coupon_id=1000), response.content)
+        self.assertContains(
+            response,
+            u'coupon with the coupon id ({coupon_id}) DoesNotExist'.format(coupon_id=1000),
+            status_code=400,
+        )
 
         data['coupon_id'] = ''  # Coupon id is not provided
         response = self.client.post(update_coupon_url, data=data)
-        self.assertIn('coupon id not found', response.content)
+        self.assertContains(response, 'coupon id not found', status_code=400)
 
     def test_verified_course(self):
         """Verify the e-commerce panel shows up for verified courses as well, without Coupons """
@@ -353,7 +374,7 @@ class TestECommerceDashboardViews(SiteMixin, SharedModuleStoreTestCase):
 
         # Get the response value, ensure the Coupon section is not included.
         response = self.client.get(self.url)
-        self.assertIn(self.ecommerce_link, response.content)
+        self.assertContains(response, self.ecommerce_link)
         # Coupons should show up for White Label sites with priced honor modes.
         self.assertNotIn('Coupons List', response.content)
 
@@ -366,7 +387,7 @@ class TestECommerceDashboardViews(SiteMixin, SharedModuleStoreTestCase):
         CourseMode.objects.filter(course_id=self.course.id).update(sku='test_sku')
 
         response = self.client.get(self.url)
-        self.assertIn(self.ecommerce_link, response.content)
+        self.assertContains(response, self.ecommerce_link)
         self.assertNotIn('Coupon Code List', response.content)
 
     def test_enrollment_codes_section_not_under_e_commerce_tab(self):
@@ -378,7 +399,7 @@ class TestECommerceDashboardViews(SiteMixin, SharedModuleStoreTestCase):
         CourseMode.objects.filter(course_id=self.course.id).update(sku='test_sku')
 
         response = self.client.get(self.url)
-        self.assertIn(self.ecommerce_link, response.content)
+        self.assertContains(response, self.ecommerce_link)
         self.assertNotIn('<h3 class="hd hd-3">Enrollment Codes</h3>', response.content)
 
     def test_enrollment_codes_section_visible_for_non_ecommerce_course(self):
@@ -387,5 +408,5 @@ class TestECommerceDashboardViews(SiteMixin, SharedModuleStoreTestCase):
         e-commerce course
         """
         response = self.client.get(self.url)
-        self.assertIn(self.ecommerce_link, response.content)
-        self.assertIn('<h3 class="hd hd-3">Enrollment Codes</h3>', response.content)
+        self.assertContains(response, self.ecommerce_link)
+        self.assertContains(response, '<h3 class="hd hd-3">Enrollment Codes</h3>')

--- a/lms/djangoapps/instructor/tests/test_ecommerce.py
+++ b/lms/djangoapps/instructor/tests/test_ecommerce.py
@@ -341,9 +341,9 @@ class TestECommerceDashboardViews(SiteMixin, SharedModuleStoreTestCase):
         # URL for update_coupon
         update_coupon_url = reverse('update_coupon', kwargs={'course_id': text_type(self.course.id)})
         response = self.client.post(update_coupon_url, data=data)
-        self.assertIn(
+        self.assertContains(
+            response,
             u'coupon with the coupon id ({coupon_id}) updated Successfully'.format(coupon_id=coupon.id),
-            response.content
         )
 
         response = self.client.post(self.url)

--- a/lms/djangoapps/instructor/tests/test_email.py
+++ b/lms/djangoapps/instructor/tests/test_email.py
@@ -66,7 +66,7 @@ class TestNewInstructorDashboardEmailViewMongoBacked(SharedModuleStoreTestCase):
         BulkEmailFlag.objects.create(enabled=False)
         # Assert that the URL for the email view is not in the response
         response = self.client.get(self.url)
-        self.assertNotIn(self.email_link, response.content)
+        self.assertNotContains(response, self.email_link)
 
     # Flag is enabled, but we require course auth and haven't turned it on for this course
     def test_course_not_authorized(self):
@@ -75,7 +75,7 @@ class TestNewInstructorDashboardEmailViewMongoBacked(SharedModuleStoreTestCase):
         self.assertFalse(is_bulk_email_feature_enabled(self.course.id))
         # Assert that the URL for the email view is not in the response
         response = self.client.get(self.url)
-        self.assertNotIn(self.email_link, response.content)
+        self.assertNotContains(response, self.email_link)
 
     # Flag is enabled, we require course auth and turn it on for this course
     def test_course_authorized(self):
@@ -84,7 +84,7 @@ class TestNewInstructorDashboardEmailViewMongoBacked(SharedModuleStoreTestCase):
         self.assertFalse(is_bulk_email_feature_enabled(self.course.id))
         # Assert that the URL for the email view is not in the response
         response = self.client.get(self.url)
-        self.assertNotIn(self.email_link, response.content)
+        self.assertNotContains(response, self.email_link)
 
         # Authorize the course to use email
         cauth = CourseAuthorization(course_id=self.course.id, email_enabled=True)
@@ -108,7 +108,7 @@ class TestNewInstructorDashboardEmailViewMongoBacked(SharedModuleStoreTestCase):
         self.assertTrue(is_bulk_email_enabled_for_course(self.course.id))
         # Assert that the URL for the email view IS NOT in the response
         response = self.client.get(self.url)
-        self.assertNotIn(self.email_link, response.content)
+        self.assertNotContains(response, self.email_link)
 
 
 class TestNewInstructorDashboardEmailViewXMLBacked(SharedModuleStoreTestCase):
@@ -149,10 +149,10 @@ class TestNewInstructorDashboardEmailViewXMLBacked(SharedModuleStoreTestCase):
     def test_email_flag_true_mongo_false(self):
         BulkEmailFlag.objects.create(enabled=True, require_course_email_auth=False)
         response = self.client.get(self.url)
-        self.assertNotIn(self.email_link, response.content)
+        self.assertNotContains(response, self.email_link, status_code=404)
 
     # The flag is disabled and the course is not Mongo-backed (should not work)
     def test_email_flag_false_mongo_false(self):
         BulkEmailFlag.objects.create(enabled=False, require_course_email_auth=False)
         response = self.client.get(self.url)
-        self.assertNotIn(self.email_link, response.content)
+        self.assertNotContains(response, self.email_link, status_code=404)

--- a/lms/djangoapps/instructor/tests/test_email.py
+++ b/lms/djangoapps/instructor/tests/test_email.py
@@ -55,10 +55,10 @@ class TestNewInstructorDashboardEmailViewMongoBacked(SharedModuleStoreTestCase):
         self.assertTrue(is_bulk_email_feature_enabled(self.course.id))
         # Assert that the URL for the email view is in the response
         response = self.client.get(self.url)
-        self.assertIn(self.email_link, response.content)
+        self.assertContains(response, self.email_link)
 
         send_to_label = '<div class="send_to_list">Send to:</div>'
-        self.assertIn(send_to_label, response.content)
+        self.assertContains(response, send_to_label)
         self.assertEqual(response.status_code, 200)
 
     # The course is Mongo-backed but the flag is disabled (should not work)
@@ -94,7 +94,7 @@ class TestNewInstructorDashboardEmailViewMongoBacked(SharedModuleStoreTestCase):
         self.assertTrue(is_bulk_email_feature_enabled(self.course.id))
         # Assert that the URL for the email view is in the response
         response = self.client.get(self.url)
-        self.assertIn(self.email_link, response.content)
+        self.assertContains(response, self.email_link)
 
     # Flag is disabled, but course is authorized
     def test_course_authorized_feature_off(self):

--- a/lms/djangoapps/instructor/tests/test_proctoring.py
+++ b/lms/djangoapps/instructor/tests/test_proctoring.py
@@ -135,7 +135,7 @@ class TestProctoringDashboardViews(SharedModuleStoreTestCase):
         self.setup_course(True, True)
         response = self.client.get(self.url)
         # the default backend does not support the review dashboard
-        self.assertNotIn('Review Dashboard', response.content)
+        self.assertNotContains(response, 'Review Dashboard')
 
         backend = TestBackendProvider()
         config = apps.get_app_config('edx_proctoring')

--- a/lms/djangoapps/instructor/tests/test_proctoring.py
+++ b/lms/djangoapps/instructor/tests/test_proctoring.py
@@ -148,7 +148,7 @@ class TestProctoringDashboardViews(SharedModuleStoreTestCase):
                 backend='test',
             )
             response = self.client.get(self.url)
-            self.assertIn('Review Dashboard', response.content)
+            self.assertContains(response, 'Review Dashboard')
 
     def _assert_proctoring_tab_available(self, available):
         """

--- a/lms/djangoapps/instructor/tests/test_spoc_gradebook.py
+++ b/lms/djangoapps/instructor/tests/test_spoc_gradebook.py
@@ -136,10 +136,10 @@ class TestLetterCutoffPolicy(TestGradebook):
 
     def test_styles(self):
 
-        self.assertIn(u"grade_A {color:green;}", self.response.content.decode(self.response.charset))
-        self.assertIn(u"grade_B {color:Chocolate;}", self.response.content.decode(self.response.charset))
-        self.assertIn(u"grade_C {color:DarkSlateGray;}", self.response.content.decode(self.response.charset))
-        self.assertIn(u"grade_D {color:DarkSlateGray;}", self.response.content.decode(self.response.charset))
+        self.assertContains(self.response, u"grade_A {color:green;}")
+        self.assertContains(self.response, u"grade_B {color:Chocolate;}")
+        self.assertContains(self.response, u"grade_C {color:DarkSlateGray;}")
+        self.assertContains(self.response, u"grade_D {color:DarkSlateGray;}")
 
     def test_assigned_grades(self):
         # Users 9-10 have >= 90% on Homeworks [2]

--- a/lms/djangoapps/instructor/tests/views/test_instructor_dashboard.py
+++ b/lms/djangoapps/instructor/tests/views/test_instructor_dashboard.py
@@ -246,9 +246,9 @@ class TestInstructorDashboard(ModuleStoreTestCase, LoginEnrollmentTestCase, XssT
         numbers of learners.
         """
         response = self.client.get(self.url)
-        self.assertIn(
+        self.assertContains(
+            response,
             self.GRADEBOOK_LEARNER_COUNT_MESSAGE,
-            response.content
         )
         self.assertContains(response, 'View Gradebook')
 

--- a/lms/djangoapps/instructor/tests/views/test_instructor_dashboard.py
+++ b/lms/djangoapps/instructor/tests/views/test_instructor_dashboard.py
@@ -323,7 +323,7 @@ class TestInstructorDashboard(ModuleStoreTestCase, LoginEnrollmentTestCase, XssT
         self.assertContains(response, '<th scope="row">Professional</th>')
 
         # dashboard link hidden
-        self.assertNotIn(self.get_dashboard_enrollment_message(), response.content.decode(response.charset))
+        self.assertNotContains(response, self.get_dashboard_enrollment_message())
 
     @patch.dict(settings.FEATURES, {'DISPLAY_ANALYTICS_ENROLLMENTS': True})
     @override_settings(ANALYTICS_DASHBOARD_URL='')

--- a/lms/djangoapps/instructor/tests/views/test_instructor_dashboard.py
+++ b/lms/djangoapps/instructor/tests/views/test_instructor_dashboard.py
@@ -215,7 +215,7 @@ class TestInstructorDashboard(ModuleStoreTestCase, LoginEnrollmentTestCase, XssT
         staff = StaffFactory(course_key=self.course.id)
         self.client.login(username=staff.username, password="test")
         response = self.client.get(self.url)
-        self.assertNotIn('<h4 class="hd hd-4">Adjust all enrolled learners', response.content)
+        self.assertNotContains(response, '<h4 class="hd hd-4">Adjust all enrolled learners')
         self.assertContains(response, '<h4 class="hd hd-4">View a specific learner&#39;s grades and progress')
 
     @patch(
@@ -305,7 +305,7 @@ class TestInstructorDashboard(ModuleStoreTestCase, LoginEnrollmentTestCase, XssT
         """
         response = self.client.get(self.url)
         # no enrollment information should be visible
-        self.assertNotIn('<h3 class="hd hd-3">Enrollment Information</h3>', response.content)
+        self.assertNotContains(response, '<h3 class="hd hd-3">Enrollment Information</h3>')
 
     @patch.dict(settings.FEATURES, {'DISPLAY_ANALYTICS_ENROLLMENTS': True})
     @override_settings(ANALYTICS_DASHBOARD_URL='')
@@ -349,10 +349,10 @@ class TestInstructorDashboard(ModuleStoreTestCase, LoginEnrollmentTestCase, XssT
         response = self.client.get(self.url)
 
         # enrollment information hidden
-        self.assertNotIn('<th scope="row">Verified</th>', response.content)
-        self.assertNotIn('<th scope="row">Audit</th>', response.content)
-        self.assertNotIn('<th scope="row">Honor</th>', response.content)
-        self.assertNotIn('<th scope="row">Professional</th>', response.content)
+        self.assertNotContains(response, '<th scope="row">Verified</th>')
+        self.assertNotContains(response, '<th scope="row">Audit</th>')
+        self.assertNotContains(response, '<th scope="row">Honor</th>')
+        self.assertNotContains(response, '<th scope="row">Professional</th>')
 
         # link to dashboard shown
         expected_message = self.get_dashboard_enrollment_message()
@@ -366,7 +366,7 @@ class TestInstructorDashboard(ModuleStoreTestCase, LoginEnrollmentTestCase, XssT
         """
         response = self.client.get(self.url)
         analytics_section = '<li class="nav-item"><a href="" data-section="instructor_analytics">Analytics</a></li>'
-        self.assertNotIn(analytics_section, response.content)
+        self.assertNotContains(response, analytics_section)
 
     @override_settings(ANALYTICS_DASHBOARD_URL='http://example.com')
     @override_settings(ANALYTICS_DASHBOARD_NAME='Example')
@@ -479,7 +479,7 @@ class TestInstructorDashboard(ModuleStoreTestCase, LoginEnrollmentTestCase, XssT
         )
 
         response = self.client.get(self.url)
-        self.assertNotIn(ora_section, response.content)
+        self.assertNotContains(response, ora_section)
 
         ItemFactory.create(parent_location=self.course.location, category="openassessment")
         response = self.client.get(self.url)

--- a/lms/djangoapps/instructor/tests/views/test_instructor_dashboard.py
+++ b/lms/djangoapps/instructor/tests/views/test_instructor_dashboard.py
@@ -180,8 +180,8 @@ class TestInstructorDashboard(ModuleStoreTestCase, LoginEnrollmentTestCase, XssT
         )
 
         response = self.client.get(url)
-        self.assertIn('<option value="role1">role1</option>', response.content)
-        self.assertIn('<option value="role2">role2</option>', response.content)
+        self.assertContains(response, '<option value="role1">role1</option>')
+        self.assertContains(response, '<option value="role2">role2</option>')
 
     def test_membership_default_role(self):
         """
@@ -197,9 +197,9 @@ class TestInstructorDashboard(ModuleStoreTestCase, LoginEnrollmentTestCase, XssT
         )
 
         response = self.client.get(url)
-        self.assertIn('<option value="Learner">Learner</option>', response.content)
-        self.assertIn('<option value="Support">Support</option>', response.content)
-        self.assertIn('<option value="Partner">Partner</option>', response.content)
+        self.assertContains(response, '<option value="Learner">Learner</option>')
+        self.assertContains(response, '<option value="Support">Support</option>')
+        self.assertContains(response, '<option value="Partner">Partner</option>')
 
     def test_student_admin_staff_instructor(self):
         """
@@ -208,15 +208,15 @@ class TestInstructorDashboard(ModuleStoreTestCase, LoginEnrollmentTestCase, XssT
         """
         # Original (instructor) user can see both specific grades, and course-wide grade adjustment tools
         response = self.client.get(self.url)
-        self.assertIn('<h4 class="hd hd-4">Adjust all enrolled learners', response.content)
-        self.assertIn('<h4 class="hd hd-4">View a specific learner&#39;s grades and progress', response.content)
+        self.assertContains(response, '<h4 class="hd hd-4">Adjust all enrolled learners')
+        self.assertContains(response, '<h4 class="hd hd-4">View a specific learner&#39;s grades and progress')
 
         # But staff user can only see specific grades
         staff = StaffFactory(course_key=self.course.id)
         self.client.login(username=staff.username, password="test")
         response = self.client.get(self.url)
         self.assertNotIn('<h4 class="hd hd-4">Adjust all enrolled learners', response.content)
-        self.assertIn('<h4 class="hd hd-4">View a specific learner&#39;s grades and progress', response.content)
+        self.assertContains(response, '<h4 class="hd hd-4">View a specific learner&#39;s grades and progress')
 
     @patch(
         'lms.djangoapps.instructor.views.instructor_dashboard.settings.WRITABLE_GRADEBOOK_URL',
@@ -231,8 +231,8 @@ class TestInstructorDashboard(ModuleStoreTestCase, LoginEnrollmentTestCase, XssT
             response = self.client.get(self.url)
 
         expected_gradebook_url = 'http://gradebook.local.edx.org/{}'.format(self.course.id)
-        self.assertIn(expected_gradebook_url, response.content)
-        self.assertIn('View Gradebook', response.content)
+        self.assertContains(response, expected_gradebook_url)
+        self.assertContains(response, 'View Gradebook')
 
     GRADEBOOK_LEARNER_COUNT_MESSAGE = (
         'Note: This feature is available only to courses with a small number ' +
@@ -250,7 +250,7 @@ class TestInstructorDashboard(ModuleStoreTestCase, LoginEnrollmentTestCase, XssT
             self.GRADEBOOK_LEARNER_COUNT_MESSAGE,
             response.content
         )
-        self.assertIn('View Gradebook', response.content)
+        self.assertContains(response, 'View Gradebook')
 
     @patch(
         'lms.djangoapps.instructor.views.instructor_dashboard.settings.WRITABLE_GRADEBOOK_URL',
@@ -269,7 +269,7 @@ class TestInstructorDashboard(ModuleStoreTestCase, LoginEnrollmentTestCase, XssT
             TestInstructorDashboard.GRADEBOOK_LEARNER_COUNT_MESSAGE,
             response.content
         )
-        self.assertIn('View Gradebook', response.content)
+        self.assertContains(response, 'View Gradebook')
 
     def test_default_currency_in_the_html_response(self):
         """
@@ -278,7 +278,7 @@ class TestInstructorDashboard(ModuleStoreTestCase, LoginEnrollmentTestCase, XssT
         CourseFinanceAdminRole(self.course.id).add_users(self.instructor)
         total_amount = PaidCourseRegistration.get_total_amount_of_purchased_item(self.course.id)
         response = self.client.get(self.url)
-        self.assertIn('${amount}'.format(amount=total_amount), response.content)
+        self.assertContains(response, '${amount}'.format(amount=total_amount))
 
     def test_course_name_xss(self):
         """Test that the instructor dashboard correctly escapes course names
@@ -295,7 +295,7 @@ class TestInstructorDashboard(ModuleStoreTestCase, LoginEnrollmentTestCase, XssT
         CourseFinanceAdminRole(self.course.id).add_users(self.instructor)
         total_amount = PaidCourseRegistration.get_total_amount_of_purchased_item(self.course.id)
         response = self.client.get(self.url)
-        self.assertIn('{currency}{amount}'.format(currency='Rs', amount=total_amount), response.content)
+        self.assertContains(response, '{currency}{amount}'.format(currency='Rs', amount=total_amount))
 
     @patch.dict(settings.FEATURES, {'DISPLAY_ANALYTICS_ENROLLMENTS': False})
     @override_settings(ANALYTICS_DASHBOARD_URL='')
@@ -316,11 +316,11 @@ class TestInstructorDashboard(ModuleStoreTestCase, LoginEnrollmentTestCase, XssT
         response = self.client.get(self.url)
 
         # enrollment information visible
-        self.assertIn('<h4 class="hd hd-4">Enrollment Information</h4>', response.content)
-        self.assertIn('<th scope="row">Verified</th>', response.content)
-        self.assertIn('<th scope="row">Audit</th>', response.content)
-        self.assertIn('<th scope="row">Honor</th>', response.content)
-        self.assertIn('<th scope="row">Professional</th>', response.content)
+        self.assertContains(response, '<h4 class="hd hd-4">Enrollment Information</h4>')
+        self.assertContains(response, '<th scope="row">Verified</th>')
+        self.assertContains(response, '<th scope="row">Audit</th>')
+        self.assertContains(response, '<th scope="row">Honor</th>')
+        self.assertContains(response, '<th scope="row">Professional</th>')
 
         # dashboard link hidden
         self.assertNotIn(self.get_dashboard_enrollment_message(), response.content.decode(response.charset))
@@ -376,7 +376,7 @@ class TestInstructorDashboard(ModuleStoreTestCase, LoginEnrollmentTestCase, XssT
         """
         response = self.client.get(self.url)
         analytics_section = '<li class="nav-item"><button type="button" class="btn-link instructor_analytics" data-section="instructor_analytics">Analytics</button></li>'  # pylint: disable=line-too-long
-        self.assertIn(analytics_section, response.content)
+        self.assertContains(response, analytics_section)
 
         # link to dashboard shown
         expected_message = self.get_dashboard_analytics_message()
@@ -408,7 +408,7 @@ class TestInstructorDashboard(ModuleStoreTestCase, LoginEnrollmentTestCase, XssT
         bulk_purchase_total = CourseRegCodeItem.get_total_amount_of_purchased_item(self.course.id)
         total_amount = single_purchase_total + bulk_purchase_total
         response = self.client.get(self.url)
-        self.assertIn('{currency}{amount}'.format(currency='$', amount=total_amount), response.content)
+        self.assertContains(response, '{currency}{amount}'.format(currency='$', amount=total_amount))
 
     @ddt.data(
         (True, True, True),
@@ -439,7 +439,7 @@ class TestInstructorDashboard(ModuleStoreTestCase, LoginEnrollmentTestCase, XssT
         Verify that grade cutoffs are displayed in the correct order.
         """
         response = self.client.get(self.url)
-        self.assertIn('D: 0.5, C: 0.57, B: 0.63, A: 0.75', response.content)
+        self.assertContains(response, 'D: 0.5, C: 0.57, B: 0.63, A: 0.75')
 
     @patch('lms.djangoapps.instructor.views.gradebook_api.MAX_STUDENTS_PER_PAGE_GRADE_BOOK', 2)
     def test_calculate_page_info(self):
@@ -483,7 +483,7 @@ class TestInstructorDashboard(ModuleStoreTestCase, LoginEnrollmentTestCase, XssT
 
         ItemFactory.create(parent_location=self.course.location, category="openassessment")
         response = self.client.get(self.url)
-        self.assertIn(ora_section, response.content)
+        self.assertContains(response, ora_section)
 
     def test_open_response_assessment_page_orphan(self):
         """

--- a/lms/djangoapps/instructor_task/tests/test_tasks_helper.py
+++ b/lms/djangoapps/instructor_task/tests/test_tasks_helper.py
@@ -768,7 +768,7 @@ class TestInstructorDetailedEnrollmentReport(TestReportMixin, InstructorTaskCour
         response = self.client.get(redeem_url)
         self.assertEquals(response.status_code, 200)
         # check button text
-        self.assertIn('Activate Course Enrollment', response.content.decode('utf-8'))
+        self.assertContains(response, 'Activate Course Enrollment')
 
         response = self.client.post(redeem_url)
         self.assertEquals(response.status_code, 200)
@@ -802,7 +802,7 @@ class TestInstructorDetailedEnrollmentReport(TestReportMixin, InstructorTaskCour
         response = self.client.get(redeem_url)
         self.assertEquals(response.status_code, 200)
         # check button text
-        self.assertIn('Activate Course Enrollment', response.content.decode('utf-8'))
+        self.assertContains(response, 'Activate Course Enrollment')
 
         response = self.client.post(redeem_url)
         self.assertEquals(response.status_code, 200)
@@ -843,7 +843,7 @@ class TestInstructorDetailedEnrollmentReport(TestReportMixin, InstructorTaskCour
         response = self.client.get(redeem_url)
         self.assertEquals(response.status_code, 200)
         # check button text
-        self.assertIn('Activate Course Enrollment', response.content.decode('utf-8'))
+        self.assertContains(response, 'Activate Course Enrollment')
 
         response = self.client.post(redeem_url)
         self.assertEquals(response.status_code, 200)
@@ -1328,7 +1328,7 @@ class TestExecutiveSummaryReport(TestReportMixin, InstructorTaskCourseTestCase):
         response = self.client.get(redeem_url)
         self.assertEquals(response.status_code, 200)
         # check button text
-        self.assertIn('Activate Course Enrollment', response.content.decode('utf-8'))
+        self.assertContains(response, 'Activate Course Enrollment')
 
         response = self.client.post(redeem_url)
         self.assertEquals(response.status_code, 200)

--- a/lms/djangoapps/mobile_api/course_info/tests.py
+++ b/lms/djangoapps/mobile_api/course_info/tests.py
@@ -75,7 +75,7 @@ class TestUpdates(MobileAPITestCase, MobileAuthTestMixin, MobileCourseAccessTest
         response = self.api_response(api_version=api_version)
 
         # verify static URLs are replaced in the content returned by the API
-        self.assertNotIn("\"/static/", response.content.decode('utf-8'))
+        self.assertNotContains(response, "\"/static/")
 
         # verify static URLs remain in the underlying content
         underlying_updates = modulestore().get_item(updates_usage_key)

--- a/lms/djangoapps/shoppingcart/tests/test_configuration_overrides.py
+++ b/lms/djangoapps/shoppingcart/tests/test_configuration_overrides.py
@@ -111,13 +111,11 @@ class TestOrderHistoryOnSiteDashboard(SiteMixin, ModuleStoreTestCase):
         receipt_url_cert = reverse('shoppingcart.views.show_receipt', kwargs={'ordernum': self.certificate_order_id})
         receipt_url_donation = reverse('shoppingcart.views.show_receipt', kwargs={'ordernum': self.donation_order_id})
 
-        # We need to decode because of these chars: © & ▸
-        content = response.content.decode('utf-8')
-        self.assertIn(receipt_url_course, content)
-        self.assertNotIn(receipt_url_course2, content)
-        self.assertNotIn(receipt_url, content)
-        self.assertNotIn(receipt_url_cert, content)
-        self.assertNotIn(receipt_url_donation, content)
+        self.assertContains(response, receipt_url_course)
+        self.assertNotContains(response, receipt_url_course2)
+        self.assertNotContains(response, receipt_url)
+        self.assertNotContains(response, receipt_url_cert)
+        self.assertNotContains(response, receipt_url_donation)
 
     def test_shows_orders_with_non_site_courses_only_when_no_configuration_override_exists(self):
         self.use_site(self.site_other)
@@ -133,11 +131,9 @@ class TestOrderHistoryOnSiteDashboard(SiteMixin, ModuleStoreTestCase):
             kwargs={'ordernum': self.courseless_donation_order_id},
         )
 
-        # We need to decode because of these chars: © & ▸
-        content = response.content.decode('utf-8')
-        self.assertNotIn(receipt_url_course, content)
-        self.assertNotIn(receipt_url_course2, content)
-        self.assertIn(receipt_url, content)
-        self.assertIn(receipt_url_cert, content)
-        self.assertIn(receipt_url_donation, content)
-        self.assertIn(receipt_url_courseless_donation, content)
+        self.assertNotContains(response, receipt_url_course)
+        self.assertNotContains(response, receipt_url_course2)
+        self.assertContains(response, receipt_url)
+        self.assertContains(response, receipt_url_cert)
+        self.assertContains(response, receipt_url_donation)
+        self.assertContains(response, receipt_url_courseless_donation)

--- a/lms/djangoapps/shoppingcart/tests/test_payment_fake.py
+++ b/lms/djangoapps/shoppingcart/tests/test_payment_fake.py
@@ -57,7 +57,7 @@ class PaymentFakeViewTest(TestCase):
 
         # Expect that we were served the payment page
         # (not the error page)
-        self.assertIn("Payment Form", resp.content.decode('utf-8'))
+        self.assertContains(resp, "Payment Form")
 
     def test_rejects_invalid_signature(self):
 
@@ -74,7 +74,7 @@ class PaymentFakeViewTest(TestCase):
         )
 
         # Expect that we got an error
-        self.assertIn("Error", resp.content.decode('utf-8'))
+        self.assertContains(resp, "Error")
 
     def test_sends_valid_signature(self):
 

--- a/lms/djangoapps/shoppingcart/tests/test_views.py
+++ b/lms/djangoapps/shoppingcart/tests/test_views.py
@@ -2160,8 +2160,7 @@ class CSVReportViewsTest(SharedModuleStoreTestCase):
         self.assertEqual(template, 'shoppingcart/download_report.html')
         self.assertFalse(context['total_count_error'])
         self.assertTrue(context['date_fmt_error'])
-        self.assertIn("There was an error in your date input.  It should be formatted as YYYY-MM-DD",
-                      response.content.decode('UTF-8'))
+        self.assertContains(response, "There was an error in your date input.  It should be formatted as YYYY-MM-DD")
 
     def test_report_csv_itemized(self):
         report_type = 'itemized_purchase_report'

--- a/lms/djangoapps/shoppingcart/tests/test_views.py
+++ b/lms/djangoapps/shoppingcart/tests/test_views.py
@@ -1847,28 +1847,28 @@ class RegistrationCodeRedemptionCourseEnrollment(SharedModuleStoreTestCase):
         response = self.client.get(redeem_url)
         self.assertEquals(response.status_code, 200)
         # check button text
-        self.assertIn('Activate Course Enrollment', response.content)
+        self.assertContains(response, 'Activate Course Enrollment')
 
         #now activate the user by enrolling him/her to the course
         response = self.client.post(redeem_url)
         self.assertEquals(response.status_code, 200)
-        self.assertIn('View Dashboard', response.content)
+        self.assertContains(response, 'View Dashboard')
 
         #now check that the registration code has already been redeemed and user is already registered in the course
         RegistrationCodeRedemption.objects.filter(registration_code__code=registration_code)
         response = self.client.get(redeem_url)
         self.assertEquals(len(RegistrationCodeRedemption.objects.filter(registration_code__code=registration_code)), 1)
-        self.assertIn("You&#39;ve clicked a link for an enrollment code that has already been used.", response.content)
+        self.assertContains(response, "You&#39;ve clicked a link for an enrollment code that has already been used.")
 
         #now check that the registration code has already been redeemed
         response = self.client.post(redeem_url)
-        self.assertIn("You&#39;ve clicked a link for an enrollment code that has already been used.", response.content)
+        self.assertContains(response, "You&#39;ve clicked a link for an enrollment code that has already been used.")
 
         #now check the response of the dashboard page
         dashboard_url = reverse('dashboard')
         response = self.client.get(dashboard_url)
         self.assertEquals(response.status_code, 200)
-        self.assertIn(self.course.display_name.encode('utf-8'), response.content)
+        self.assertContains(response, self.course.display_name.encode('utf-8'))
 
 
 @ddt.ddt
@@ -2176,7 +2176,7 @@ class CSVReportViewsTest(SharedModuleStoreTestCase):
                                                                     'requested_report': report_type})
         self.assertEqual(response['Content-Type'], 'text/csv')
         report = initialize_report(report_type, start_date, end_date)
-        self.assertIn(",".join(report.header()), response.content)
+        self.assertContains(response, ",".join(report.header()))
         self.assertIn(
             ",1,purchased,1,40.00,40.00,usd,Registration for Course: Robot Super Course,",
             response.content
@@ -2197,7 +2197,7 @@ class CSVReportViewsTest(SharedModuleStoreTestCase):
                                                                     'requested_report': report_type})
         self.assertEqual(response['Content-Type'], 'text/csv')
         report = initialize_report(report_type, start_date, end_date, start_letter, end_letter)
-        self.assertIn(",".join(report.header()), response.content)
+        self.assertContains(response, ",".join(report.header()))
 
 
 class UtilFnsTest(TestCase):

--- a/lms/djangoapps/shoppingcart/tests/test_views.py
+++ b/lms/djangoapps/shoppingcart/tests/test_views.py
@@ -631,7 +631,7 @@ class ShoppingCartViewsTests(SharedModuleStoreTestCase, XssTestMixin):
         response = self.client.get(redeem_url)
         self.assertEquals(response.status_code, 200)
         # check button text
-        self.assertIn('Activate Course Enrollment', response.content.decode('utf-8'))
+        self.assertContains(response, 'Activate Course Enrollment')
 
         #now activate the user by enrolling him/her to the course
         response = self.client.post(redeem_url)
@@ -662,7 +662,7 @@ class ShoppingCartViewsTests(SharedModuleStoreTestCase, XssTestMixin):
         response = self.client.get(redeem_url)
         self.assertEquals(response.status_code, 200)
         # check button text
-        self.assertIn('Activate Course Enrollment', response.content.decode('utf-8'))
+        self.assertContains(response, 'Activate Course Enrollment')
 
         #now activate the user by enrolling him/her to the course
         response = self.client.post(redeem_url)
@@ -1134,7 +1134,7 @@ class ShoppingCartViewsTests(SharedModuleStoreTestCase, XssTestMixin):
         response = self.client.get(redeem_url)
         self.assertEquals(response.status_code, 200)
         # check button text
-        self.assertIn('Activate Course Enrollment', response.content.decode('utf-8'))
+        self.assertContains(response, 'Activate Course Enrollment')
 
         #now activate the user by enrolling him/her to the course
         response = self.client.post(redeem_url)
@@ -1324,7 +1324,7 @@ class ShoppingCartViewsTests(SharedModuleStoreTestCase, XssTestMixin):
         #now activate the user by enrolling him/her to the course
         response = self.client.post(redeem_url)
         self.assertEquals(response.status_code, 200)
-        self.assertIn('View Dashboard', response.content.decode('utf-8'))
+        self.assertContains(response, 'View Dashboard')
 
         # now view the receipt page again to see if any registration codes
         # has been expired or not
@@ -2146,7 +2146,7 @@ class CSVReportViewsTest(SharedModuleStoreTestCase):
         self.assertEqual(template, 'shoppingcart/download_report.html')
         self.assertFalse(context['total_count_error'])
         self.assertFalse(context['date_fmt_error'])
-        self.assertIn("Download CSV Reports", response.content.decode('UTF-8'))
+        self.assertContains(response, "Download CSV Reports")
 
     @patch('shoppingcart.views.render_to_response', render_mock)
     def test_report_csv_bad_date(self):

--- a/lms/djangoapps/static_template_view/tests/test_views.py
+++ b/lms/djangoapps/static_template_view/tests/test_views.py
@@ -45,8 +45,8 @@ class MarketingSiteViewTests(TestCase):
         configuration = {test_header_key: test_header, test_content_key: test_content}
         with with_site_configuration_context(configuration=configuration):
             response = self.client.get(reverse("about"))
-        self.assertIn(test_header.encode('utf-8'), response.content)
-        self.assertIn(test_content.encode('utf-8'), response.content)
+        self.assertContains(response, test_header)
+        self.assertContains(response, test_content)
 
     def test_about_with_site_configuration_and_html(self):
         """
@@ -60,8 +60,8 @@ class MarketingSiteViewTests(TestCase):
         configuration = {test_header_key: test_header, test_content_key: test_content}
         with with_site_configuration_context(configuration=configuration):
             response = self.client.get(reverse("about"))
-        self.assertIn(test_header.encode('utf-8'), response.content)
-        self.assertIn(test_content.encode('utf-8'), response.content)
+        self.assertContains(response, test_header)
+        self.assertContains(response, test_content)
 
     def test_404(self):
         """

--- a/lms/djangoapps/survey/tests/test_views.py
+++ b/lms/djangoapps/survey/tests/test_views.py
@@ -81,10 +81,9 @@ class SurveyViewsTests(ModuleStoreTestCase):
         Asserts that an authenticated user can see the survey
         """
         resp = self.client.get(self.view_url)
-        self.assertEquals(resp.status_code, 200)
 
         # is the SurveyForm html present in the HTML response?
-        self.assertIn(self.test_form, resp.content)
+        self.assertContains(resp, self.test_form)
 
     def test_unauthenticated_survey_postback(self):
         """

--- a/lms/djangoapps/teams/tests/test_views.py
+++ b/lms/djangoapps/teams/tests/test_views.py
@@ -180,17 +180,17 @@ class TestDashboard(SharedModuleStoreTestCase):
         # Check that initially list of user teams in course one is empty
         course_one_teams_url = reverse('teams_dashboard', args=[self.course.id])
         response = self.client.get(course_one_teams_url)
-        self.assertIn('"teams": {"count": 0', response.content)  # pylint: disable=unicode-format-string
+        self.assertContains(response, '"teams": {"count": 0')  # pylint: disable=unicode-format-string
         # Add user to a course one team
         course_one_team.add_user(self.user)
 
         # Check that list of user teams in course one is not empty, it is one now
         response = self.client.get(course_one_teams_url)
-        self.assertIn('"teams": {"count": 1', response.content)  # pylint: disable=unicode-format-string
+        self.assertContains(response, '"teams": {"count": 1')  # pylint: disable=unicode-format-string
         # Check that list of user teams in course two is still empty
         course_two_teams_url = reverse('teams_dashboard', args=[course_two.id])
         response = self.client.get(course_two_teams_url)
-        self.assertIn('"teams": {"count": 0', response.content)  # pylint: disable=unicode-format-string
+        self.assertContains(response, '"teams": {"count": 0')  # pylint: disable=unicode-format-string
 
 
 class TeamAPITestCase(APITestCase, SharedModuleStoreTestCase):

--- a/lms/djangoapps/verify_student/tests/test_fake_software_secure.py
+++ b/lms/djangoapps/verify_student/tests/test_fake_software_secure.py
@@ -78,7 +78,5 @@ class SoftwareSecureFakeViewEnabledTest(SoftwareSecureFakeViewTest):
             '/verify_student/software-secure-fake-response'
         )
 
-        self.assertEqual(response.status_code, 200)
-        content = response.content.decode('utf8')
-        self.assertIn('EdX-ID', content)
-        self.assertIn('results_callback', content)
+        self.assertContains(response, 'EdX-ID')
+        self.assertContains(response, 'results_callback')

--- a/lms/djangoapps/verify_student/tests/test_views.py
+++ b/lms/djangoapps/verify_student/tests/test_views.py
@@ -1340,7 +1340,7 @@ class TestCreateOrderView(ModuleStoreTestCase):
     @patch.dict(settings.FEATURES, {'AUTOMATIC_VERIFY_STUDENT_IDENTITY_FOR_TESTING': True})
     def test_invalid_amount(self):
         response = self._create_order('1.a', self.course_id, expect_status_code=400)
-        self.assertIn('Selected price is not valid number.', response.content.decode('utf-8'))
+        self.assertContains(response, 'Selected price is not valid number.', status_code=400)
 
     @patch.dict(settings.FEATURES, {'AUTOMATIC_VERIFY_STUDENT_IDENTITY_FOR_TESTING': True})
     def test_invalid_mode(self):
@@ -1348,7 +1348,11 @@ class TestCreateOrderView(ModuleStoreTestCase):
         course_id = 'Fake/999/Test_Course'
         CourseFactory.create(org='Fake', number='999', display_name='Test Course')
         response = self._create_order('50', course_id, expect_status_code=400)
-        self.assertIn('This course doesn\'t support paid certificates', response.content.decode('utf-8'))
+        self.assertContains(
+            response,
+            'This course doesn\'t support paid certificates',
+            status_code=400,
+        )
 
     @patch.dict(settings.FEATURES, {'AUTOMATIC_VERIFY_STUDENT_IDENTITY_FOR_TESTING': True})
     def test_create_order_fail_with_get(self):
@@ -1672,8 +1676,7 @@ class TestPhotoVerificationResultsCallback(ModuleStoreTestCase):
             HTTP_AUTHORIZATION='test BBBBBBBBBBBBBBBBBBBB: testing',
             HTTP_DATE='testdate'
         )
-        self.assertIn('Invalid JSON', response.content.decode('utf-8'))
-        self.assertEqual(response.status_code, 400)
+        self.assertContains(response, 'Invalid JSON', status_code=400)
 
     def test_invalid_dict(self):
         """
@@ -1687,8 +1690,7 @@ class TestPhotoVerificationResultsCallback(ModuleStoreTestCase):
             HTTP_AUTHORIZATION='test BBBBBBBBBBBBBBBBBBBB:testing',
             HTTP_DATE='testdate'
         )
-        self.assertIn('JSON should be dict', response.content.decode('utf-8'))
-        self.assertEqual(response.status_code, 400)
+        self.assertContains(response, 'JSON should be dict', status_code=400)
 
     @patch(
         'lms.djangoapps.verify_student.ssencrypt.has_valid_signature',
@@ -1712,8 +1714,7 @@ class TestPhotoVerificationResultsCallback(ModuleStoreTestCase):
             HTTP_AUTHORIZATION='test testing:testing',
             HTTP_DATE='testdate'
         )
-        self.assertIn('Access key invalid', response.content.decode('utf-8'))
-        self.assertEqual(response.status_code, 400)
+        self.assertContains(response, 'Access key invalid', status_code=400)
 
     @patch(
         'lms.djangoapps.verify_student.ssencrypt.has_valid_signature',
@@ -1737,8 +1738,7 @@ class TestPhotoVerificationResultsCallback(ModuleStoreTestCase):
             HTTP_AUTHORIZATION='test BBBBBBBBBBBBBBBBBBBB:testing',
             HTTP_DATE='testdate'
         )
-        self.assertIn('edX ID Invalid-Id not found', response.content.decode('utf-8'))
-        self.assertEqual(response.status_code, 400)
+        self.assertContains(response, 'edX ID Invalid-Id not found', status_code=400)
 
     @patch(
         'lms.djangoapps.verify_student.ssencrypt.has_valid_signature',
@@ -1896,7 +1896,7 @@ class TestPhotoVerificationResultsCallback(ModuleStoreTestCase):
             HTTP_AUTHORIZATION='test BBBBBBBBBBBBBBBBBBBB:testing',
             HTTP_DATE='testdate'
         )
-        self.assertIn('Result Unknown not understood', response.content.decode('utf-8'))
+        self.assertContains(response, 'Result Unknown not understood', status_code=400)
 
 
 class TestReverifyView(TestCase):

--- a/openedx/core/djangoapps/credit/tests/test_views.py
+++ b/openedx/core/djangoapps/credit/tests/test_views.py
@@ -160,8 +160,7 @@ class CreditCourseViewSetTests(AuthMixin, UserMixin, TestCase):
 
         # POSTs without a CSRF token should fail.
         response = client.post(self.path, data=json.dumps(data), content_type=JSON)
-        self.assertEqual(response.status_code, 403)
-        self.assertIn('CSRF', response.content)
+        self.assertContains(response, 'CSRF', status_code=403)
 
         # Retrieve a CSRF token
         response = client.get('/')

--- a/openedx/core/djangoapps/enrollments/tests/test_views.py
+++ b/openedx/core/djangoapps/enrollments/tests/test_views.py
@@ -565,8 +565,7 @@ class EnrollmentTest(EnrollmentTestMixin, ModuleStoreTestCase, APITestCase, Ente
             },
             format='json'
         )
-        self.assertEqual(resp.status_code, status.HTTP_400_BAD_REQUEST)
-        self.assertIn("No course ", resp.content.decode('utf-8'))
+        self.assertContains(resp, "No course ", status_code=status.HTTP_400_BAD_REQUEST)
 
     def test_enrollment_throttle_for_user(self):
         """Make sure a user requests do not exceed the maximum number of requests"""

--- a/openedx/core/djangoapps/user_api/accounts/tests/test_settings_views.py
+++ b/openedx/core/djangoapps/user_api/accounts/tests/test_settings_views.py
@@ -163,7 +163,7 @@ class AccountSettingsViewTest(ThirdPartyAuthTestMixin, SiteMixin, ProgramsApiCon
         response = self.client.get(path=view_path)
 
         for attribute in self.FIELDS:
-            self.assertIn(attribute, response.content)
+            self.assertContains(response, attribute)
 
     def test_header_with_programs_listing_enabled(self):
         """
@@ -256,7 +256,7 @@ class AccountSettingsViewTest(ThirdPartyAuthTestMixin, SiteMixin, ProgramsApiCon
             # Test with waffle flag active and site setting disabled, does not redirect
             response = self.client.get(path=old_url_path)
             for attribute in self.FIELDS:
-                self.assertIn(attribute, response.content)
+                self.assertContains(response, attribute)
 
             # Test with waffle flag active and site setting enabled, redirects to microfrontend
             site_domain = 'othersite.example.com'

--- a/openedx/core/djangoapps/user_authn/views/tests/test_views.py
+++ b/openedx/core/djangoapps/user_authn/views/tests/test_views.py
@@ -872,5 +872,4 @@ class AccountCreationTestCaseWithSiteOverrides(SiteMixin, TestCase):
         ALLOW_PUBLIC_ACCOUNT_CREATION flag is turned off
         """
         response = self.client.get(reverse('signin_user'))
-        self.assertNotIn(u'<a class="btn-neutral" href="/register?next=%2Fdashboard">Register</a>',
-                         response.content.decode(response.charset))
+        self.assertNotContains(response, u'<a class="btn-neutral" href="/register?next=%2Fdashboard">Register</a>')

--- a/openedx/features/announcements/tests/test_announcements.py
+++ b/openedx/features/announcements/tests/test_announcements.py
@@ -54,8 +54,8 @@ class TestGlobalAnnouncements(TestCase):
     def test_feature_flag_disabled(self):
         """Ensures that the default settings effectively disables the feature"""
         response = self.client.get('/dashboard')
-        self.assertNotIn('AnnouncementsView', response.content)
-        self.assertNotIn('<div id="announcements"', response.content)
+        self.assertNotContains(response, 'AnnouncementsView')
+        self.assertNotContains(response, '<div id="announcements"')
 
     def test_feature_flag_enabled(self):
         """Ensures that enabling the flag, enables the feature"""
@@ -87,7 +87,7 @@ class TestGlobalAnnouncements(TestCase):
         """
         url = reverse("announcements:page", kwargs={"page": 1})
         response = self.client.get(url)
-        self.assertNotIn("Inactive Announcement", response.content)
+        self.assertNotContains(response, "Inactive Announcement")
 
     def test_formatted(self):
         """

--- a/openedx/features/announcements/tests/test_announcements.py
+++ b/openedx/features/announcements/tests/test_announcements.py
@@ -60,7 +60,7 @@ class TestGlobalAnnouncements(TestCase):
     def test_feature_flag_enabled(self):
         """Ensures that enabling the flag, enables the feature"""
         response = self.client.get('/dashboard')
-        self.assertIn('AnnouncementsView', response.content)
+        self.assertContains(response, 'AnnouncementsView')
 
     def test_pagination(self):
         url = reverse("announcements:page", kwargs={"page": 1})
@@ -79,7 +79,7 @@ class TestGlobalAnnouncements(TestCase):
         """
         url = reverse("announcements:page", kwargs={"page": 1})
         response = self.client.get(url)
-        self.assertIn("Active Announcement", response.content)
+        self.assertContains(response, "Active Announcement")
 
     def test_inactive(self):
         """
@@ -95,4 +95,4 @@ class TestGlobalAnnouncements(TestCase):
         """
         url = reverse("announcements:page", kwargs={"page": 1})
         response = self.client.get(url)
-        self.assertIn("<strong>Formatted Announcement</strong>", response.content)
+        self.assertContains(response, "<strong>Formatted Announcement</strong>")

--- a/openedx/features/course_duration_limits/tests/test_course_expiration.py
+++ b/openedx/features/course_duration_limits/tests/test_course_expiration.py
@@ -221,7 +221,7 @@ class CourseExpirationTestCase(ModuleStoreTestCase):
         if show_expiration_banner:
             self.assertContains(response, banner_text)
         else:
-            self.assertNotIn(banner_text, response.content)
+            self.assertNotContains(response, banner_text)
 
     def update_masquerade(self, role='student', group_id=None, username=None, user_partition_id=None):
         """
@@ -283,7 +283,7 @@ class CourseExpirationTestCase(ModuleStoreTestCase):
         self.assertEqual(response.status_code, 200)
         six.assertCountEqual(self, response.redirect_chain, [])
         banner_text = 'You lose all access to this course, including your progress,'
-        self.assertNotIn(banner_text, response.content)
+        self.assertNotContains(response, banner_text)
 
     @mock.patch("openedx.features.course_duration_limits.access.get_course_run_details")
     def test_masquerade_expired(self, mock_get_course_run_details):
@@ -370,7 +370,7 @@ class CourseExpirationTestCase(ModuleStoreTestCase):
         self.assertEqual(response.status_code, 200)
         six.assertCountEqual(self, response.redirect_chain, [])
         banner_text = 'This learner does not have access to this course. Their access expired on'
-        self.assertNotIn(banner_text, response.content)
+        self.assertNotContains(response, banner_text)
 
     @mock.patch("openedx.features.course_duration_limits.access.get_course_run_details")
     @ddt.data(
@@ -419,4 +419,4 @@ class CourseExpirationTestCase(ModuleStoreTestCase):
         self.assertEqual(response.status_code, 200)
         six.assertCountEqual(self, response.redirect_chain, [])
         banner_text = 'This learner does not have access to this course. Their access expired on'
-        self.assertNotIn(banner_text, response.content)
+        self.assertNotContains(response, banner_text)

--- a/openedx/features/course_duration_limits/tests/test_course_expiration.py
+++ b/openedx/features/course_duration_limits/tests/test_course_expiration.py
@@ -219,7 +219,7 @@ class CourseExpirationTestCase(ModuleStoreTestCase):
         six.assertCountEqual(self, response.redirect_chain, [])
         banner_text = 'You lose all access to this course, including your progress,'
         if show_expiration_banner:
-            self.assertIn(banner_text, response.content)
+            self.assertContains(response, banner_text)
         else:
             self.assertNotIn(banner_text, response.content)
 
@@ -319,7 +319,7 @@ class CourseExpirationTestCase(ModuleStoreTestCase):
         self.assertEqual(response.status_code, 200)
         six.assertCountEqual(self, response.redirect_chain, [])
         banner_text = 'This learner does not have access to this course. Their access expired on'
-        self.assertIn(banner_text, response.content)
+        self.assertContains(response, banner_text)
 
     @mock.patch("openedx.features.course_duration_limits.access.get_course_run_details")
     @ddt.data(

--- a/openedx/features/course_experience/tests/views/test_course_home.py
+++ b/openedx/features/course_experience/tests/views/test_course_home.py
@@ -962,7 +962,7 @@ class CourseHomeFragmentViewTests(ModuleStoreTestCase):
 
     def assert_upgrade_message_not_displayed(self):
         response = self.client.get(self.url)
-        self.assertNotIn('section-upgrade', response.content)
+        self.assertNotContains(response, 'section-upgrade')
 
     def assert_upgrade_message_displayed(self):
         response = self.client.get(self.url)

--- a/openedx/features/course_experience/tests/views/test_course_home.py
+++ b/openedx/features/course_experience/tests/views/test_course_home.py
@@ -966,10 +966,10 @@ class CourseHomeFragmentViewTests(ModuleStoreTestCase):
 
     def assert_upgrade_message_displayed(self):
         response = self.client.get(self.url)
-        self.assertIn('section-upgrade', response.content)
+        self.assertContains(response, 'section-upgrade')
         url = EcommerceService().get_checkout_page_url(self.verified_mode.sku)
-        self.assertIn('<a class="btn-brand btn-upgrade"', response.content)
-        self.assertIn(url, response.content)
+        self.assertContains(response, '<a class="btn-brand btn-upgrade"')
+        self.assertContains(response, url)
         self.assertIn(
             u"Upgrade (<span class='price'>${price}</span>)".format(price=self.verified_mode.min_price),
             response.content.decode(response.charset)

--- a/openedx/features/course_experience/tests/views/test_course_home.py
+++ b/openedx/features/course_experience/tests/views/test_course_home.py
@@ -970,9 +970,9 @@ class CourseHomeFragmentViewTests(ModuleStoreTestCase):
         url = EcommerceService().get_checkout_page_url(self.verified_mode.sku)
         self.assertContains(response, '<a class="btn-brand btn-upgrade"')
         self.assertContains(response, url)
-        self.assertIn(
+        self.assertContains(
+            response,
             u"Upgrade (<span class='price'>${price}</span>)".format(price=self.verified_mode.min_price),
-            response.content.decode(response.charset)
         )
 
     def test_no_upgrade_message_if_logged_out(self):
@@ -1012,5 +1012,4 @@ class CourseHomeFragmentViewTests(ModuleStoreTestCase):
         with SHOW_UPGRADE_MSG_ON_COURSE_HOME.override(True):
             response = self.client.get(self.url)
 
-        content = response.content.decode(response.charset)
-        assert "<span>DISCOUNT_PRICE</span>" in content
+        self.assertContains(response, "<span>DISCOUNT_PRICE</span>")

--- a/openedx/features/course_experience/tests/views/test_course_outline.py
+++ b/openedx/features/course_experience/tests/views/test_course_outline.py
@@ -126,16 +126,16 @@ class TestCourseOutlinePage(SharedModuleStoreTestCase):
 
             self.assertTrue(course.children)
             for chapter in course.children:
-                self.assertIn(chapter.display_name, response_content)
+                self.assertContains(response, chapter.display_name)
                 self.assertTrue(chapter.children)
                 for sequential in chapter.children:
-                    self.assertIn(sequential.display_name, response_content)
+                    self.assertContains(response, sequential.display_name)
                     if sequential.graded:
-                        self.assertIn(sequential.due.strftime(u'%Y-%m-%d %H:%M:%S'), response_content)
-                        self.assertIn(sequential.format, response_content)
+                        self.assertContains(response, sequential.due.strftime(u'%Y-%m-%d %H:%M:%S'))
+                        self.assertContains(response, sequential.format)
                     self.assertTrue(sequential.children)
                     for vertical in sequential.children:
-                        self.assertIn(vertical.display_name, response_content)
+                        self.assertContains(response, vertical.display_name)
 
 
 class TestCourseOutlinePageWithPrerequisites(SharedModuleStoreTestCase, MilestonesTestCaseMixin):

--- a/openedx/features/course_experience/tests/views/test_course_outline.py
+++ b/openedx/features/course_experience/tests/views/test_course_outline.py
@@ -121,9 +121,6 @@ class TestCourseOutlinePage(SharedModuleStoreTestCase):
 
             url = course_home_url(course)
             response = self.client.get(url)
-            self.assertEqual(response.status_code, 200)
-            response_content = response.content.decode("utf-8")
-
             self.assertTrue(course.children)
             for chapter in course.children:
                 self.assertContains(response, chapter.display_name)

--- a/openedx/features/course_experience/tests/views/test_course_sock.py
+++ b/openedx/features/course_experience/tests/views/test_course_sock.py
@@ -103,8 +103,7 @@ class TestCourseSockView(SharedModuleStoreTestCase):
     )
     def test_upgrade_message_discount(self):
         response = self.client.get(course_home_url(self.verified_course))
-        content = response.content.decode(response.charset)
-        assert "<span>DISCOUNT_PRICE</span>" in content
+        self.assertContains(response, "<span>DISCOUNT_PRICE</span>")
 
     def assert_verified_sock_is_visible(self, course, response):
         return self.assertContains(response, TEST_VERIFICATION_SOCK_LOCATOR, html=False)

--- a/openedx/features/learner_profile/tests/views/test_learner_profile.py
+++ b/openedx/features/learner_profile/tests/views/test_learner_profile.py
@@ -115,7 +115,7 @@ class LearnerProfileViewTest(SiteMixin, UrlResetMixin, ModuleStoreTestCase):
         response = self.client.get(path=profile_path)
 
         for attribute in self.CONTEXT_DATA:
-            self.assertIn(attribute, response.content)
+            self.assertContains(response, attribute)
 
     def test_redirect_view(self):
         with override_waffle_flag(REDIRECT_TO_PROFILE_MICROFRONTEND, active=True):
@@ -124,7 +124,7 @@ class LearnerProfileViewTest(SiteMixin, UrlResetMixin, ModuleStoreTestCase):
             # Test with waffle flag active and site setting disabled, does not redirect
             response = self.client.get(path=profile_path)
             for attribute in self.CONTEXT_DATA:
-                self.assertIn(attribute, response.content)
+                self.assertContains(response, attribute)
 
             # Test with waffle flag active and site setting enabled, redirects to microfrontend
             site_domain = 'othersite.example.com'


### PR DESCRIPTION
The following lists the Regex replacements made using Visual Studio.

1. **assertIn -> assertContains**
    - **Commit:** `Python-3: assertIn(..response.content) -> assertContains`
    - **Replaces:** `self.assertIn\((.*)\, response.content\)`
    - **With:** `self.assertContains(response, $1)`

2. **assertNotIn -> assertNotContains**
    - **Commit:** `Python-3: assertNotIn(..response.content) -> assertNotContains`
    - **Replaces:** `self.assertNotIn\((.*)\, response.content\)`
    - **With:** `self.assertNotContains(response, $1)`

3. **assertContains Consistency**
    -  **Commit:** `self.assertIn\((.*)\, response.content.decode\(\'utf-8\'\)\)`
    - **Replaces:** `self.assertNotIn\((.*)\, response.content.decode\(\'utf-8\'\)\)`
    - **With:** `self.assertContains(response, $1)`

4. **assertNotContains Consistency**
    - **Commit:** `Python 3: assertNotIn -> assertNotContains consistency`
    - **Replaces:** `self.assertNotIn\((.*)\, response.content.decode\(\'utf-8\'\)\)`
    - **With:** `self.assertNotContains(response, $1)`

5. **response.content.count -> assertContains**
    - **Commit:** `assertEqual(response.content.count -> assertContains(..`
    - **Replaces:** `self.assertEqual\(response\.content\.count\((.*)\), (.*)\)`
    - **With:** `self.assertContains(response, $1, count=$2)`

6. **Multi-line replacement**
    - **Commit:** `multi-line regex replacement of assertIn and assertNotIn`
    - **Replaces:** `self\.assertIn\(\n(.*)\,\n(\s*)resp\.content(.*)(\s*)\)`
    - **With:** `self.assertContains(\n$2resp,\n$1,$4)`
