### PR TITLE
Notes css is missing for tab pages

### DIFF
--- a/lms/templates/courseware/static_tab.html
+++ b/lms/templates/courseware/static_tab.html
@@ -25,6 +25,7 @@ ${HTML(fragment.foot_html())}
 <%block name="pagetitle">${_(tab['name'])} | ${course.display_number_with_default}</%block>
 
 <%include file="/courseware/course_navigation.html" args="active_page=active_page" />
+<%static:css group='style-student-notes'/>
 
 <main id="main" aria-label="Content" tabindex="-1">
     <section class="container"


### PR DESCRIPTION
style-student-notes is only added in courseware.html but it is missing for custom tab pages.

It is appearing as :
![missing css](https://user-images.githubusercontent.com/40633976/65856882-23591000-e37c-11e9-9a28-d4887e759266.png)

Expected:
![expected](https://user-images.githubusercontent.com/40633976/65856891-29e78780-e37c-11e9-985a-decc8ef4796f.png)


[PROD-687](https://openedx.atlassian.net/browse/PROD-687)
