### PR TITLE
BOM-749: Fixing error in test_certificates.py

### DIFF
--- a/cms/djangoapps/contentstore/views/certificates.py
+++ b/cms/djangoapps/contentstore/views/certificates.py
@@ -237,6 +237,8 @@ class CertificateManager(object):
         Deserialize from a JSON representation into a Certificate object.
         'value' should be either a Certificate instance, or a valid JSON string
         """
+        if not six.PY2 and not isinstance(value, six.integer_types):
+            value = value.decode('utf-8')
 
         # Ensure the schema fieldset meets our expectations
         for key in ("name", "description", "version"):

--- a/cms/djangoapps/contentstore/views/certificates.py
+++ b/cms/djangoapps/contentstore/views/certificates.py
@@ -237,7 +237,7 @@ class CertificateManager(object):
         Deserialize from a JSON representation into a Certificate object.
         'value' should be either a Certificate instance, or a valid JSON string
         """
-        if not six.PY2 and not isinstance(value, six.integer_types):
+        if not six.PY2 and isinstance(value, bytes):
             value = value.decode('utf-8')
 
         # Ensure the schema fieldset meets our expectations


### PR DESCRIPTION
Fixing: a bytes-like object is required, not 'str'