### PR TITLE
add information for missing annotation fields

### DIFF
--- a/lms/djangoapps/course_api/blocks/toggles.py
+++ b/lms/djangoapps/course_api/blocks/toggles.py
@@ -32,12 +32,12 @@ HIDE_ACCESS_DENIALS_FLAG = WaffleFlag(
 # .. toggle_default: False
 # .. toggle_description: Controlled rollout for video URL re-write utility to serve videos from edX CDN.
 # .. toggle_category: course api
-# .. toggle_use_cases: incremental_release
+# .. toggle_use_cases: monitored_rollout
 # .. toggle_creation_date: 2019-09-24
 # .. toggle_expiration_date: ??
-# .. toggle_warnings: ??
-# .. toggle_tickets: ??
-# .. toggle_status: ??
+# .. toggle_warnings: None
+# .. toggle_tickets: PROD-62
+# .. toggle_status: supported
 ENABLE_VIDEO_URL_REWRITE = CourseWaffleFlag(
     waffle_namespace=COURSE_BLOCKS_API_NAMESPACE,
     flag_name="enable_video_url_rewrite",


### PR DESCRIPTION
### [PROD-760](https://openedx.atlassian.net/browse/PROD-760)

### Description
This PR is updating the annotation fields of the **ENABLE_VIDEO_URL_REWRITE** waffle flag. Some of the fields were missed out in the initial PR. The fields were added later by @estute but their values weren't added. This PR is only adding the right values to the annotation fields.

### Reviewers
 - [x] @estute 