### PR TITLE
BOM-804

### DIFF
--- a/common/lib/xmodule/xmodule/modulestore/xml.py
+++ b/common/lib/xmodule/xmodule/modulestore/xml.py
@@ -119,7 +119,7 @@ class ImportSystem(XMLParsingSystem, MakoDescriptorSystem):
                         orig_name = orig_name[len(tag) + 1:-12]
                     # append the hash of the content--the first 12 bytes should be plenty.
                     orig_name = "_" + orig_name if orig_name not in (None, "") else ""
-                    xml_bytes = xml.encode('utf8')
+                    xml_bytes = xml if isinstance(xml, bytes) else xml.encode('utf-8')
                     return tag + orig_name + "_" + hashlib.sha1(xml_bytes).hexdigest()[:12]
 
                 # Fallback if there was nothing we could use:


### PR DESCRIPTION
python3 compatibility
We only need to decode utf-8-sig if its a bytes type str. In case if its a unicode content there wont be any utf-8-sig. 