### PR TITLE
[REV-733] check if discount expired

### DIFF
--- a/common/djangoapps/course_modes/tests/test_views.py
+++ b/common/djangoapps/course_modes/tests/test_views.py
@@ -412,19 +412,24 @@ class CourseModeViewTest(CatalogIntegrationMixin, UrlResetMixin, ModuleStoreTest
         url = reverse('create_mode', args=[six.text_type(self.course.id)])
         response = self.client.get(url, parameters)
 
+        CourseEnrollmentFactory(
+            is_active=True,
+            course_id=self.course.id,
+            user=self.user
+        )
+
         response = self.client.get(
             reverse('course_modes_choose', args=[six.text_type(self.course.id)]),
             follow=False,
         )
 
-        bannerText = u'''<div class="first-purchase-offer-banner"><span class="first-purchase-offer-banner-bold">
-                     15% off your first upgrade.</span> Discount automatically applied.</div>'''
+        banner = u'''<div class="first-purchase-offer-banner">'''
         button = u'''<button type="submit" name="verified_mode">
                     <span>Pursue a Verified Certificate</span>
                     (<span class="upgrade-price-string">$8.50 USD</span>
                     <del> <span class="upgrade-price-string">$10 USD</span></del>)
                     </button>'''
-        self.assertContains(response, bannerText, html=True)
+        self.assertContains(response, banner)
         self.assertContains(response, button, html=True)
 
     @unittest.skipUnless(settings.ROOT_URLCONF == 'lms.urls', 'Test only valid in lms')

--- a/lms/static/sass/features/_course-experience.scss
+++ b/lms/static/sass/features/_course-experience.scss
@@ -33,6 +33,11 @@
       color: #23419F;
   }
 
+  a {
+    color: #00496f;
+    text-decoration: underline;
+    font-weight: bold;
+  }
 }
 
 // Course call to action message

--- a/lms/static/sass/views/_verification.scss
+++ b/lms/static/sass/views/_verification.scss
@@ -2261,10 +2261,18 @@
     font-size: 16px;
     border-radius: 7px;
     padding: 20px;
+    line-height: 1.5;
 
     .first-purchase-offer-banner-bold {
       font-weight: bold;
       color: #23419f;
+    }
+
+    a {
+      color: #00496f;
+      text-decoration: underline !important;
+      font-weight: bold;
+      border-bottom: none;
     }
   }
 }

--- a/openedx/features/discounts/applicability.py
+++ b/openedx/features/discounts/applicability.py
@@ -10,9 +10,10 @@ not other discounts like coupons or enterprise/program offers configured in ecom
 """
 from __future__ import absolute_import
 
-from datetime import datetime
+from datetime import datetime, timedelta
 
 from crum import get_current_request, impersonate
+from django.utils import timezone
 import pytz
 
 from course_modes.models import CourseMode
@@ -43,7 +44,40 @@ DISCOUNT_APPLICABILITY_FLAG = WaffleFlag(
 DISCOUNT_APPLICABILITY_HOLDBACK = 'first_purchase_discount_holdback'
 
 
-def can_receive_discount(user, course):  # pylint: disable=unused-argument
+def get_discount_expiration_date(user, course):
+    """
+    Returns the date when the discount expires for the user.
+    Returns none if the user is not enrolled.
+    """
+    course_enrollment = CourseEnrollment.objects.filter(
+        user=user,
+        course=course.id,
+        mode__in=CourseMode.UPSELL_TO_VERIFIED_MODES
+    )
+    if len(course_enrollment) != 1:
+        return None
+
+    enrollment = course_enrollment.first()
+    try:
+        # Content availability date is equivalent to max(enrollment date, course start date)
+        # for most people. Using the schedule date will provide flexibility to deal with
+        # more complex business rules in the future.
+        content_availability_date = enrollment.schedule.start
+        # We have anecdotally observed a case where the schedule.start was
+        # equal to the course start, but should have been equal to the enrollment start
+        # https://openedx.atlassian.net/browse/PROD-58
+        # This section is meant to address that case
+        if enrollment.created and course.start:
+            if (content_availability_date.date() == course.start.date() and
+               course.start < enrollment.created < timezone.now()):
+                content_availability_date = enrollment.created
+    except CourseEnrollment.schedule.RelatedObjectDoesNotExist:
+        content_availability_date = max(enrollment.created, course.start)
+
+    return content_availability_date + timedelta(weeks=1)
+
+
+def can_receive_discount(user, course, discount_expiration_date=None):
     """
     Check all the business logic about whether this combination of user and course
     can receive a discount.
@@ -54,6 +88,16 @@ def can_receive_discount(user, course):  # pylint: disable=unused-argument
             return False
 
     # TODO: Add additional conditions to return False here
+
+    # Check if discount has expired
+    if not discount_expiration_date:
+        discount_expiration_date = get_discount_expiration_date(user, course)
+
+    if discount_expiration_date is None:
+        return False
+
+    if discount_expiration_date < timezone.now():
+        return False
 
     # Course end date needs to be in the future
     if course.has_ended():

--- a/openedx/features/discounts/tests/test_applicability.py
+++ b/openedx/features/discounts/tests/test_applicability.py
@@ -53,6 +53,12 @@ class TestApplicability(ModuleStoreTestCase):
         """
         Ensure first purchase offer banner only displays for courses with a non-expired verified mode
         """
+        CourseEnrollmentFactory(
+            is_active=True,
+            course_id=self.course.id,
+            user=self.user
+        )
+
         applicability = can_receive_discount(user=self.user, course=self.course)
         self.assertEqual(applicability, True)
 
@@ -86,6 +92,12 @@ class TestApplicability(ModuleStoreTestCase):
         """
         Ensure that only users who have not already purchased courses receive the discount.
         """
+        CourseEnrollmentFactory(
+            is_active=True,
+            course_id=self.course.id,
+            user=self.user
+        )
+
         for mode in existing_enrollments:
             CourseEnrollmentFactory.create(mode=mode, user=self.user)
 
@@ -102,6 +114,12 @@ class TestApplicability(ModuleStoreTestCase):
         """
         Ensure that only users who have not already purchased courses receive the discount.
         """
+        CourseEnrollmentFactory(
+            is_active=True,
+            course_id=self.course.id,
+            user=self.user
+        )
+
         if entitlement_mode is not None:
             CourseEntitlementFactory.create(mode=entitlement_mode, user=self.user)
 

--- a/openedx/features/discounts/utils.py
+++ b/openedx/features/discounts/utils.py
@@ -9,7 +9,7 @@ from openedx.core.djangolib.markup import HTML
 from .applicability import can_receive_discount, discount_percentage
 
 
-def format_strikeout_price(user, course, base_price=None):
+def format_strikeout_price(user, course, base_price=None, check_for_discount=True):
     """
     Return a formatted price, including a struck-out original price if a discount applies, and also
         whether a discount was applied, as the tuple (formatted_price, has_discount).
@@ -19,7 +19,7 @@ def format_strikeout_price(user, course, base_price=None):
 
     original_price = format_course_price(base_price)
 
-    if can_receive_discount(user, course):
+    if not check_for_discount or can_receive_discount(user, course):
         discount_price = base_price * ((100.0 - discount_percentage()) / 100)
         if discount_price == int(discount_price):
             discount_price = format_course_price("{:0.0f}".format(discount_price))


### PR DESCRIPTION
https://openedx.atlassian.net/browse/REV-733

[REV-733]: https://openedx.atlassian.net/browse/REV-733
Track Selection:
<img width="1236" alt="Screen Shot 2019-10-11 at 10 27 52 AM" src="https://user-images.githubusercontent.com/5958221/66659985-6a63c280-ec12-11e9-975e-79c284740fcd.png">

Course Home:
<img width="863" alt="Screen Shot 2019-10-11 at 10 26 58 AM" src="https://user-images.githubusercontent.com/5958221/66659986-6a63c280-ec12-11e9-9178-08bab264363c.png">

Question: the new and original price in the brackets [] are in reverse order from what we tested, but this is the formatting we are using on the track selection and course home upgrade buttons. Do we want to stick with this formatting for the banner or change the formatting on the other buttons?
