### PR TITLE
BOM-788

### DIFF
--- a/common/lib/capa/capa/tests/test_html_render.py
+++ b/common/lib/capa/capa/tests/test_html_render.py
@@ -140,7 +140,7 @@ class CapaHtmlRenderTest(unittest.TestCase):
         # expect the javascript is still present in the rendered html
         self.assertIn(
             "<script type=\"text/javascript\">function(){}</script>",
-            etree.tostring(rendered_html)
+            etree.tostring(rendered_html).decode('utf-8')
         )
 
     def test_render_response_xml(self):


### PR DESCRIPTION
python3 compatibility: etree returns a bytes type string so in py3 we need to decode it
to compare with a unicode string.