### PR TITLE
Revert "Upgrade edx-lint"

### DIFF
--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -29,7 +29,7 @@ appdirs==1.4.3
 argh==0.26.2
 argparse==1.4.0
 asn1crypto==0.24.0
-astroid==1.6.6
+astroid==1.5.3
 atomicwrites==1.3.0
 attrs==17.4.0
 aws-xray-sdk==0.95
@@ -131,7 +131,7 @@ edx-django-utils==2.0.0
 edx-drf-extensions==2.4.0
 edx-enterprise==1.10.8
 edx-i18n-tools==0.4.8
-edx-lint==1.4.0
+edx-lint==1.3.0
 edx-milestones==0.2.3
 edx-oauth2-provider==1.3.1
 edx-opaque-keys[django]==2.0.0
@@ -251,9 +251,9 @@ pyinotify==0.9.6
 pyjwkest==1.3.2
 pyjwt==1.5.2
 pylint-celery==0.3
-pylint-django==0.11.1
+pylint-django==0.7.2
 pylint-plugin-utils==0.3
-pylint==1.9.5
+pylint==1.7.6
 pymongo==2.9.1
 pynliner==0.8.0
 pyparsing==2.2.0

--- a/requirements/edx/testing.in
+++ b/requirements/edx/testing.in
@@ -24,7 +24,7 @@ code-annotations          # Perform code annotation checking, such as for PII an
 cssselect                 # Used to extract HTML fragments via CSS selectors in 2 test cases and pyquery
 ddt                       # Run a test case multiple times with different input; used in many, many of our tests
 edx-i18n-tools>=0.4.6     # Commands for developers and translators to extract, compile and validate translations
-edx-lint==1.4.0           # pylint extensions for Open edX repositories
+edx-lint==1.3.0           # pylint extensions for Open edX repositories
 factory_boy==2.8.1        # Library for creating test fixtures, used in many tests
 freezegun                 # Allows tests to mock the output of assorted datetime module functions
 httpretty                 # Library for mocking HTTP requests, used in many tests

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -28,7 +28,7 @@ appdirs==1.4.3
 argh==0.26.2
 argparse==1.4.0           # via caniusepython3
 asn1crypto==0.24.0
-astroid==1.6.6            # via pylint, pylint-celery
+astroid==1.5.3            # via pylint, pylint-celery
 atomicwrites==1.3.0       # via pytest
 attrs==17.4.0
 aws-xray-sdk==0.95        # via moto
@@ -127,7 +127,7 @@ edx-django-utils==2.0.0
 edx-drf-extensions==2.4.0
 edx-enterprise==1.10.8
 edx-i18n-tools==0.4.8
-edx-lint==1.4.0
+edx-lint==1.3.0
 edx-milestones==0.2.3
 edx-oauth2-provider==1.3.1
 edx-opaque-keys[django]==2.0.0
@@ -242,9 +242,9 @@ pygraphviz==1.5
 pyjwkest==1.3.2
 pyjwt==1.5.2
 pylint-celery==0.3        # via edx-lint
-pylint-django==0.11.1     # via edx-lint
+pylint-django==0.7.2      # via edx-lint
 pylint-plugin-utils==0.3  # via pylint-celery, pylint-django
-pylint==1.9.5             # via edx-lint, pylint-celery, pylint-django
+pylint==1.7.6             # via edx-lint, pylint-celery, pylint-django
 pymongo==2.9.1
 pynliner==0.8.0
 pyparsing==2.2.0

--- a/scripts/Jenkinsfiles/quality
+++ b/scripts/Jenkinsfiles/quality
@@ -45,7 +45,7 @@ pipeline {
     options {
         sendSplunkConsoleLog()
         timestamps()
-        timeout(120)
+        timeout(60)
     }
     stages {
         stage('Mark build as pending on Github') {


### PR DESCRIPTION
Quality (pylint lms, to be precise) jobs are seg faulting and hanging. I suspect one of the libraries upgraded in this PR is the culprit. Let's revert and see if it fixes things, and then fix forward.

Error msg in Jenkins:
```
00:00:45.900  Finding pylint violations and storing in report...
00:15:30.730  Cannot contact EC2 (us-east-1) - jenkins-worker (i-0d5b347e35b7f58c9): java.lang.InterruptedException
00:23:50.076  Segmentation fault
00:23:50.099  sh: 1: touch: Cannot allocate memory
00:23:50.099  sh: 1: Cannot fork
00:59:17.947  Could not connect to EC2 (us-east-1) - jenkins-worker (i-0d5b347e35b7f58c9) to send interrupt signal to process
```