### PR TITLE
BOM-891: mako template fixes

### DIFF
--- a/openedx/core/djangolib/tests/test_js_utils.py
+++ b/openedx/core/djangolib/tests/test_js_utils.py
@@ -14,6 +14,7 @@ from openedx.core.djangolib.js_utils import dump_js_escaped_json, js_escaped_str
 import six  # pylint: disable=ungrouped-imports
 import re
 
+
 class TestJSUtils(TestCase):
     """
     Test JS utils
@@ -145,7 +146,7 @@ class TestJSUtils(TestCase):
         self.assertIn("&#34;test_tuple&#34;: [1, 2, 3]", out)
         self.assertIn("&#34;test_number&#34;: 3.5", out)
         self.assertIn("&#34;test_bool&#34;: false", out)
-        self.assertIn("&#34;test_string&#34;: &#34;test-=&amp;\\\\;&#39;\\&#34;&lt;&gt;\\u2603&#34",out)
+        self.assertIn("&#34;test_string&#34;: &#34;test-=&amp;\\\\;&#39;\\&#34;&lt;&gt;\\u2603&#34", out)
         self.assertIn(u"data-test-string='test-=&amp;\\;&#39;&#34;&lt;&gt;☃'", out)
         self.assertIn("data-test-tuple='[1, 2, 3]'", out)
         self.assertIn("data-test-number='3.5'", out)
@@ -153,13 +154,13 @@ class TestJSUtils(TestCase):
 
         expected_string_for_js_in_dict = r'''test-=\u0026\\;'\"\u003c\u003e\u2603'''
         self._validate_expectation_of_string_for_js(test_dict['test_string'], expected_string_for_js_in_dict)
-        location_of_dict_in_out = output=re.search("var test_dict.*}",out)
-        var_dict_in_out = out[output.span()[0]:output.span()[1]]
+        location_of_dict_in_out = re.search("var test_dict.*}", out)
+        var_dict_in_out = out[location_of_dict_in_out.span()[0]:location_of_dict_in_out.span()[1]]
         self.assertIn('"test_number": 3.5', var_dict_in_out)
         self.assertIn('"test_string": "test-=\\u0026\\\\;\'\\"\\u003c\\u003e\\u2603"', var_dict_in_out)
         self.assertIn('"test_tuple": [1, 2, 3]', var_dict_in_out)
         self.assertIn('"test_bool": false', var_dict_in_out)
-        
+
         expected_string_for_js = u"test\\u002D\\u003D\\u0026\\u005C\\u003B\\u0027\\u0022\\u003C\\u003E☃"
         self._validate_expectation_of_string_for_js(test_dict['test_string'], expected_string_for_js)
         self.assertIn("var test_string = '" + expected_string_for_js + "'", out)

--- a/openedx/core/djangolib/tests/test_js_utils.py
+++ b/openedx/core/djangolib/tests/test_js_utils.py
@@ -12,7 +12,7 @@ from mako.template import Template
 
 from openedx.core.djangolib.js_utils import dump_js_escaped_json, js_escaped_string
 import six  # pylint: disable=ungrouped-imports
-
+import re
 
 class TestJSUtils(TestCase):
     """
@@ -97,14 +97,14 @@ class TestJSUtils(TestCase):
         parsed from json where applicable.
         """
         test_dict = {
-            'test_string': u'test-=&\\;\'"<>☃'.encode(encoding='utf-8'),
+            'test_string': u'test-=&\\;\'"<>☃',
             'test_tuple': (1, 2, 3),
             'test_number': 3.5,
             'test_bool': False,
         }
 
         template = Template(
-            """
+            u"""
                 <%!
                 import json
                 from openedx.core.djangolib.js_utils import (
@@ -142,23 +142,27 @@ class TestJSUtils(TestCase):
         )
         expected_attr_json_for_html = "data-test-dict='" + expected_json_for_html + "'"
         self._validate_expectation_of_json_for_html(test_dict, expected_json_for_html)
-        self.assertIn(expected_attr_json_for_html, out)
+        self.assertIn("&#34;test_tuple&#34;: [1, 2, 3]", out)
+        self.assertIn("&#34;test_number&#34;: 3.5", out)
+        self.assertIn("&#34;test_bool&#34;: false", out)
+        self.assertIn("&#34;test_string&#34;: &#34;test-=&amp;\\\\;&#39;\\&#34;&lt;&gt;\\u2603&#34",out)
         self.assertIn(u"data-test-string='test-=&amp;\\;&#39;&#34;&lt;&gt;☃'", out)
         self.assertIn("data-test-tuple='[1, 2, 3]'", out)
         self.assertIn("data-test-number='3.5'", out)
         self.assertIn("data-test-bool='false'", out)
+
         expected_string_for_js_in_dict = r'''test-=\u0026\\;'\"\u003c\u003e\u2603'''
         self._validate_expectation_of_string_for_js(test_dict['test_string'], expected_string_for_js_in_dict)
-        self.assertIn(
-            (
-                'var test_dict = {"test_bool": false, "test_number": 3.5, '
-                '"test_tuple": [1, 2, 3], "test_string": "' + expected_string_for_js_in_dict + '"}'
-            ), out)
-        expected_string_for_js = r"test\u002D\u003D\u0026\u005C\u003B\u0027\u0022\u003C\u003E☃"
+        location_of_dict_in_out = output=re.search("var test_dict.*}",out)
+        var_dict_in_out = out[output.span()[0]:output.span()[1]]
+        self.assertIn('"test_number": 3.5', var_dict_in_out)
+        self.assertIn('"test_string": "test-=\\u0026\\\\;\'\\"\\u003c\\u003e\\u2603"', var_dict_in_out)
+        self.assertIn('"test_tuple": [1, 2, 3]', var_dict_in_out)
+        self.assertIn('"test_bool": false', var_dict_in_out)
+        
+        expected_string_for_js = u"test\\u002D\\u003D\\u0026\\u005C\\u003B\\u0027\\u0022\\u003C\\u003E☃"
         self._validate_expectation_of_string_for_js(test_dict['test_string'], expected_string_for_js)
-        self.assertIn(
-            "var test_string = '" + expected_string_for_js.decode(encoding='utf-8') + "'",
-            out)
+        self.assertIn("var test_string = '" + expected_string_for_js + "'", out)
         self.assertIn("var test_none_string = ''", out)
         self.assertIn("var test_tuple = [1, 2, 3]", out)
         self.assertIn("var test_number = 3.5", out)
@@ -188,7 +192,7 @@ class TestJSUtils(TestCase):
         # tuples become arrays in json, so it is parsed to a list that is
         # switched back to a tuple before comparing
         parsed_expected_dict['test_tuple'] = tuple(parsed_expected_dict['test_tuple'])
-        self.assertEqual(test_dict['test_string'].decode(encoding='utf-8'), parsed_expected_dict['test_string'])
+        self.assertEqual(test_dict['test_string'], parsed_expected_dict['test_string'])
         self.assertEqual(test_dict['test_tuple'], parsed_expected_dict['test_tuple'])
         self.assertEqual(test_dict['test_number'], parsed_expected_dict['test_number'])
         self.assertEqual(test_dict['test_bool'], parsed_expected_dict['test_bool'])
@@ -209,4 +213,4 @@ class TestJSUtils(TestCase):
 
         """
         parsed_expected_string = json.loads('"' + expected_string_for_js + '"')
-        self.assertEqual(test_string.decode(encoding='utf-8'), parsed_expected_string)
+        self.assertEqual(test_string, parsed_expected_string)

--- a/openedx/core/djangolib/tests/test_js_utils.py
+++ b/openedx/core/djangolib/tests/test_js_utils.py
@@ -4,6 +4,7 @@
 Tests for js_utils.py
 """
 from __future__ import absolute_import
+import re
 import six.moves.html_parser  # pylint: disable=import-error
 import json
 from unittest import TestCase
@@ -12,7 +13,6 @@ from mako.template import Template
 
 from openedx.core.djangolib.js_utils import dump_js_escaped_json, js_escaped_string
 import six  # pylint: disable=ungrouped-imports
-import re
 
 
 class TestJSUtils(TestCase):
@@ -141,7 +141,6 @@ class TestJSUtils(TestCase):
             r"&#34;test_tuple&#34;: [1, 2, 3], &#34;test_string&#34;: "
             r"&#34;test-=&amp;\\;&#39;\&#34;&lt;&gt;\u2603&#34;}"
         )
-        expected_attr_json_for_html = "data-test-dict='" + expected_json_for_html + "'"
         self._validate_expectation_of_json_for_html(test_dict, expected_json_for_html)
         self.assertIn("&#34;test_tuple&#34;: [1, 2, 3]", out)
         self.assertIn("&#34;test_number&#34;: 3.5", out)


### PR DESCRIPTION
Due to different in how dict is ordered between py2 and py3, mako output is different. The test was changed to ensure mako outputs correct output, but allows for difference in order due to dict diffs.