### PR TITLE
ENT-1688: Changed logout message on on logout screen for Enterprise SSO flow

### DIFF
--- a/lms/templates/logout.html
+++ b/lms/templates/logout.html
@@ -5,14 +5,31 @@
 {% block title %}{% trans "Signed Out" as tmsg %}{{ tmsg | force_escape }} | {{ block.super }}{% endblock %}
 
 {% block body %}
-    <h1>{% trans "You have signed out." as tmsg %}{{ tmsg | force_escape }}</h1>
+    {% if enterprise_target %}
+        {% comment %}
+            For enterprise SSO flow we intentionally drop learner's session.
+            We are showing this signin message instead of logout message
+            to avoid any confusion for learner in that case.
+        {% endcomment %}
+        <h1>{% trans "We are signing you in." as tmsg %}{{ tmsg | force_escape }}</h1>
 
-    <p style="text-align: center; margin-bottom: 20px;">
-        {% blocktrans trimmed asvar signout_msg1 %}
-          If you are not redirected within 5 seconds, {start_anchor}click here to go to the home page{end_anchor}.
-        {% endblocktrans %}
-        {% interpolate_html signout_msg1 start_anchor='<a href="{{ target }}">'|safe end_anchor='</a>'|safe %}
-    </p>
+        <p style="text-align: center; margin-bottom: 20px;">
+            {% filter force_escape %}
+            {% blocktrans %}
+              This may take a minute. If you are not redirected, go to the home page.
+            {% endblocktrans %}
+            {% endfilter %}
+        </p>
+    {% else %}
+        <h1>{% trans "You have signed out." as tmsg %}{{ tmsg | force_escape }}</h1>
+
+        <p style="text-align: center; margin-bottom: 20px;">
+            {% blocktrans trimmed asvar signout_msg1 %}
+              If you are not redirected within 5 seconds, {start_anchor}click here to go to the home page{end_anchor}.
+            {% endblocktrans %}
+            {% interpolate_html signout_msg1 start_anchor='<a href="'|add:target|add:'">'|safe end_anchor='</a>'|safe %}
+        </p>
+    {% endif %}
 
     <div id="iframeContainer" style="visibility: hidden" data-redirect-url="{{ target }}">
         {% for uri in logout_uris %}

--- a/openedx/core/djangoapps/user_authn/views/logout.py
+++ b/openedx/core/djangoapps/user_authn/views/logout.py
@@ -1,6 +1,8 @@
 """ Views related to logout. """
 from __future__ import absolute_import
 
+import re
+
 import edx_oauth2_provider
 import six.moves.urllib.parse as parse  # pylint: disable=import-error
 from django.conf import settings
@@ -98,6 +100,15 @@ class LogoutView(TemplateView):
         new_query_string = urlencode(query_params, doseq=True)
         return urlunsplit((scheme, netloc, path, new_query_string, fragment))
 
+    def _is_enterprise_target(self, url):
+        """
+        Check if url belongs to enterprise app
+
+        Args: url(str): url path
+        """
+        unquoted_url = parse.unquote_plus(parse.quote(url))
+        return bool(re.match(r'^/enterprise/[a-z0-9\-]+/course', unquoted_url))
+
     def get_context_data(self, **kwargs):
         context = super(LogoutView, self).get_context_data(**kwargs)
 
@@ -122,9 +133,11 @@ class LogoutView(TemplateView):
             if not referrer or (referrer and not uri.startswith(referrer)):
                 logout_uris.append(self._build_logout_url(uri))
 
+        target = self.target
         context.update({
-            'target': self.target,
+            'target': target,
             'logout_uris': logout_uris,
+            'enterprise_target': self._is_enterprise_target(target),
         })
 
         return context

--- a/openedx/features/enterprise_support/tests/test_logout.py
+++ b/openedx/features/enterprise_support/tests/test_logout.py
@@ -1,0 +1,64 @@
+"""
+Tests for logout for enterprise flow
+"""
+from __future__ import absolute_import
+
+import ddt
+import mock
+
+from django.test.utils import override_settings
+from django.urls import reverse
+
+from openedx.core.djangolib.testing.utils import CacheIsolationTestCase, skip_unless_lms
+from openedx.features.enterprise_support.api import enterprise_enabled
+from openedx.features.enterprise_support.tests import (
+    FAKE_ENTERPRISE_CUSTOMER,
+    FEATURES_WITH_ENTERPRISE_ENABLED,
+    factories
+)
+from openedx.features.enterprise_support.tests.mixins.enterprise import EnterpriseServiceMockMixin
+from student.tests.factories import UserFactory
+from util.testing import UrlResetMixin
+
+
+@ddt.ddt
+@override_settings(FEATURES=FEATURES_WITH_ENTERPRISE_ENABLED)
+@skip_unless_lms
+class EnterpriseLogoutTests(EnterpriseServiceMockMixin, CacheIsolationTestCase, UrlResetMixin):
+    """ Tests for the enterprise logout functionality. """
+
+    def setUp(self):
+        super(EnterpriseLogoutTests, self).setUp()
+        self.user = UserFactory()
+
+        self.enterprise_customer = FAKE_ENTERPRISE_CUSTOMER
+        self.enterprise_learner = factories.EnterpriseCustomerUserFactory(user_id=self.user.id)
+
+        self.client.login(username=self.user.username, password='test')
+        patcher = mock.patch('openedx.features.enterprise_support.api.enterprise_customer_from_api')
+        self.mock_enterprise_customer_from_api = patcher.start()
+        self.mock_enterprise_customer_from_api.return_value = self.enterprise_customer
+        self.addCleanup(patcher.stop)
+
+    @ddt.data(
+        ('https%3A%2F%2Ftest.edx.org%2Fcourses', False),
+        ('/courses/course-v1:ARTS+D1+2018_T/course/', False),
+        ('invalid-url', False),
+        ('/enterprise/c5dad9a7-741c-4841-868f-850aca3ff848/course/Microsoft+DAT206x/enroll/', True),
+        ('%2Fenterprise%2Fc5dad9a7-741c-4841-868f-850aca3ff848%2Fcourse%2FMicrosoft%2BDAT206x%2Fenroll%2F', True),
+    )
+    @ddt.unpack
+    def test_logout_enterprise_target(self, redirect_url, enterprise_target):
+        url = '{logout_path}?redirect_url={redirect_url}'.format(
+            logout_path=reverse('logout'),
+            redirect_url=redirect_url
+        )
+        self.assertTrue(enterprise_enabled())
+        response = self.client.get(url, HTTP_HOST='testserver')
+        expected = {
+            'enterprise_target': enterprise_target,
+        }
+        self.assertDictContainsSubset(expected, response.context_data)
+
+        if enterprise_target:
+            self.assertContains(response, 'We are signing you in.')


### PR DESCRIPTION
Changed logout message on logout screen for Enterprise SSO flow. Current message confuses learner when they are already signed in and access their course from B2B site.
ENT-1688

### Please consider the following when opening a pull request:

- Link to the relevant JIRA ticket(s) and tag any relevant team(s).
- Squash your changes down into one or more discrete commits.
  In each commit, include description that could help a developer
  several months from now.
- If running `make upgrade`, run _as close to the time of merging as possible_
  to avoid accidentally downgrading someone else's package.
  Put the output of `make upgrade` in its own separate commit,
  decoupled from other code changes.
- Aim for comprehensive test coverage, but remember that
  automated testing isn't a substitute for manual verification.
- Carefully consider naming, code organization, dependencies when adding new code.
  Code that is amenable to refactoring and improvement benefits all platform developers,
  especially given the size and scope of edx-platform.
  Consult existing Architectural Decision Records (ADRs),
  including those concerning the app(s) you are changing and
  [those concerning edx-platform as a whole](https://github.com/edx/edx-platform/tree/master/docs/decisions).
