### PR TITLE
Change version of social-auth-app-django

### DIFF
--- a/common/djangoapps/third_party_auth/pipeline.py
+++ b/common/djangoapps/third_party_auth/pipeline.py
@@ -209,6 +209,11 @@ def get(request):
     """Gets the running pipeline's data from the passed request."""
     strategy = social_django.utils.load_strategy(request)
     token = strategy.session_get('partial_pipeline_token')
+
+    if not token:
+        strategy.session_set('partial_pipeline_token', strategy.session_get('partial_pipeline_token_'))
+        token = strategy.session_get('partial_pipeline_token')
+
     partial_object = strategy.partial_load(token)
     pipeline_data = None
     if partial_object:
@@ -559,6 +564,10 @@ def ensure_user_information(strategy, auth_entry, backend=None, user=None, socia
         saml_providers_list = list(provider.Registry.get_enabled_by_backend_name('tpa-saml'))
         return (current_provider and
                 current_provider.slug in [saml_provider.slug for saml_provider in saml_providers_list])
+
+    if current_partial:
+        strategy.session_set('partial_pipeline_token_', current_partial.token)
+        strategy.storage.partial.store(current_partial)
 
     if not user:
         # Use only email for user existence check in case of saml provider

--- a/common/djangoapps/third_party_auth/tests/specs/base.py
+++ b/common/djangoapps/third_party_auth/tests/specs/base.py
@@ -542,6 +542,8 @@ class IntegrationTest(testutil.TestCase, test.TestCase, HelperMixin):
         request.backend.auth_complete = mock.MagicMock(return_value=self.fake_auth_complete(strategy))
         request.user = self.create_user_models_for_existing_account(
             strategy, 'user@example.com', 'password', self.get_username(), skip_social_auth=True)
+        partial_pipeline_token = strategy.session_get('partial_pipeline_token')
+        partial_data = strategy.storage.partial.load(partial_pipeline_token)
 
         # Instrument the pipeline to get to the dashboard with the full
         # expected state.
@@ -561,24 +563,14 @@ class IntegrationTest(testutil.TestCase, test.TestCase, HelperMixin):
 
         # We should be redirected back to the complete page, setting
         # the "logged in" cookie for the marketing site.
-        self.assert_logged_in_cookie_redirect(actions.do_complete(
-            request.backend, social_views._do_login, request.user, None,  # pylint: disable=protected-access
-            redirect_field_name=auth.REDIRECT_FIELD_NAME, request=request
-        ))
+        self.assert_logged_in_cookie_redirect(self.do_complete(strategy, request, partial_pipeline_token, partial_data))
 
         # Set the cookie and try again
         self.set_logged_in_cookies(request)
 
         # Fire off the auth pipeline to link.
         self.assert_redirect_after_pipeline_completes(
-            actions.do_complete(
-                request.backend,
-                social_views._do_login,  # pylint: disable=protected-access
-                request.user,
-                None,
-                redirect_field_name=auth.REDIRECT_FIELD_NAME,
-                request=request
-            )
+            self.do_complete(strategy, request, partial_pipeline_token, partial_data)
         )
 
         # Now we expect to be in the linked state, with a backend entry.
@@ -694,6 +686,9 @@ class IntegrationTest(testutil.TestCase, test.TestCase, HelperMixin):
         strategy.request.backend.auth_complete = mock.MagicMock(return_value=self.fake_auth_complete(strategy))
         user = self.create_user_models_for_existing_account(
             strategy, 'user@example.com', 'password', self.get_username())
+        partial_pipeline_token = strategy.session_get('partial_pipeline_token')
+        partial_data = strategy.storage.partial.load(partial_pipeline_token)
+
         self.assert_social_auth_exists_for_user(user, strategy)
         self.assertTrue(user.is_active)
 
@@ -734,7 +729,8 @@ class IntegrationTest(testutil.TestCase, test.TestCase, HelperMixin):
         self.set_logged_in_cookies(request)
 
         self.assert_redirect_after_pipeline_completes(
-            actions.do_complete(request.backend, social_views._do_login, user=user, request=request))
+            self.do_complete(strategy, request, partial_pipeline_token, partial_data, user)
+        )
         self.assert_account_settings_context_looks_correct(account_settings_context(request))
 
     def test_signin_fails_if_account_not_active(self):
@@ -793,6 +789,8 @@ class IntegrationTest(testutil.TestCase, test.TestCase, HelperMixin):
         request, strategy = self.get_request_and_strategy(
             auth_entry=pipeline.AUTH_ENTRY_REGISTER, redirect_uri='social:complete')
         strategy.request.backend.auth_complete = mock.MagicMock(return_value=self.fake_auth_complete(strategy))
+        partial_pipeline_token = strategy.session_get('partial_pipeline_token')
+        partial_data = strategy.storage.partial.load(partial_pipeline_token)
 
         # Begin! Grab the registration page and check the login control on it.
         self.assert_register_response_before_pipeline_looks_correct(self.client.get('/register'))
@@ -846,15 +844,13 @@ class IntegrationTest(testutil.TestCase, test.TestCase, HelperMixin):
 
         # We should be redirected back to the complete page, setting
         # the "logged in" cookie for the marketing site.
-        self.assert_logged_in_cookie_redirect(actions.do_complete(
-            request.backend, social_views._do_login, request.user, None,  # pylint: disable=protected-access
-            redirect_field_name=auth.REDIRECT_FIELD_NAME, request=request
-        ))
+        self.assert_logged_in_cookie_redirect(self.do_complete(strategy, request, partial_pipeline_token, partial_data))
 
         # Set the cookie and try again
         self.set_logged_in_cookies(request)
         self.assert_redirect_after_pipeline_completes(
-            actions.do_complete(strategy.request.backend, social_views._do_login, user=created_user, request=request))
+            self.do_complete(strategy, request, partial_pipeline_token, partial_data, created_user)
+        )
         # Now the user has been redirected to the dashboard. Their third party account should now be linked.
         self.assert_social_auth_exists_for_user(created_user, strategy)
         self.assert_account_settings_context_looks_correct(account_settings_context(request), linked=True)
@@ -973,6 +969,19 @@ class IntegrationTest(testutil.TestCase, test.TestCase, HelperMixin):
         it here so we can force collisions in a polymorphic way.
         """
         raise NotImplementedError
+
+    def do_complete(self, strategy, request, partial_pipeline_token, partial_data, user=None):
+        """
+        Makes sure that strategy store includes the partial data object before
+        calling actions.do_complete
+        """
+        strategy.storage.partial.store(partial_data)
+        if not user:
+            user = request.user
+        return actions.do_complete(
+            request.backend, social_views._do_login, user, None,  # pylint: disable=protected-access
+            redirect_field_name=auth.REDIRECT_FIELD_NAME, request=request, partial_token=partial_pipeline_token
+        )
 
 
 # pylint: disable=abstract-method

--- a/common/djangoapps/third_party_auth/tests/specs/test_linkedin.py
+++ b/common/djangoapps/third_party_auth/tests/specs/test_linkedin.py
@@ -4,6 +4,15 @@ from __future__ import absolute_import
 from third_party_auth.tests.specs import base
 
 
+def get_localized_name(name):
+    """Returns the localizedName from the name object"""
+    locale = "{}_{}".format(
+        name["preferredLocale"]["language"],
+        name["preferredLocale"]["country"]
+    )
+    return name['localized'].get(locale, '')
+
+
 class LinkedInOauth2IntegrationTest(base.Oauth2IntegrationTest):
     """Integration tests for provider.LinkedInOauth2."""
 
@@ -21,11 +30,29 @@ class LinkedInOauth2IntegrationTest(base.Oauth2IntegrationTest):
         'expires_in': 'expires_in_value',
     }
     USER_RESPONSE_DATA = {
-        'lastName': 'lastName_value',
+        'lastName': {
+            "localized": {
+                "en_US": "Doe"
+            },
+            "preferredLocale": {
+                "country": "US",
+                "language": "en"
+            }
+        },
         'id': 'id_value',
-        'firstName': 'firstName_value',
+        'firstName': {
+            "localized": {
+                "en_US": "Doe"
+            },
+            "preferredLocale": {
+                "country": "US",
+                "language": "en"
+            }
+        },
     }
 
     def get_username(self):
         response_data = self.get_response_data()
-        return response_data.get('firstName') + response_data.get('lastName')
+        first_name = get_localized_name(response_data.get('firstName'))
+        last_name = get_localized_name(response_data.get('lastName'))
+        return first_name + last_name

--- a/common/djangoapps/third_party_auth/tests/utils.py
+++ b/common/djangoapps/third_party_auth/tests/utils.py
@@ -98,7 +98,7 @@ class ThirdPartyOAuthTestMixinFacebook(object):
 class ThirdPartyOAuthTestMixinGoogle(object):
     """Tests oauth with the Google backend"""
     BACKEND = "google-oauth2"
-    USER_URL = "https://www.googleapis.com/plus/v1/people/me"
+    USER_URL = "https://www.googleapis.com/oauth2/v3/userinfo"
     # In google-oauth2 responses, the "email" field is used as the user's identifier
     UID_FIELD = "email"
 

--- a/requirements/edx/base.in
+++ b/requirements/edx/base.in
@@ -133,8 +133,8 @@ pyuca==1.1                          # For more accurate sorting of translated co
 recommender-xblock                  # https://github.com/edx/RecommenderXBlock
 rest-condition                      # DRF's recommendation for supporting complex permissions
 rfc6266-parser                      # Used to generate Content-Disposition headers.
-social-auth-app-django<3.0.0
-social-auth-core<2.0.0
+social-auth-app-django==3.1.0
+social-auth-core==3.2.0
 pysrt                               # Support for SubRip subtitle files, used in the video XModule
 pytz                                # Time zone information database
 PyYAML                              # Used to parse XModule resource templates

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -227,8 +227,8 @@ simplejson==3.17.0
 singledispatch==3.4.0.3
 six==1.13.0
 slumber==0.7.1            # via edx-bulk-grades, edx-enterprise, edx-rest-api-client
-social-auth-app-django==2.1.0
-social-auth-core==1.7.0
+social-auth-app-django==3.1.0
+social-auth-core==3.2.0
 sorl-thumbnail==12.3
 sortedcontainers==2.1.0
 soupsieve==1.9.5          # via beautifulsoup4

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -305,8 +305,8 @@ singledispatch==3.4.0.3
 six==1.13.0
 slumber==0.7.1
 snowballstemmer==2.0.0    # via sphinx
-social-auth-app-django==2.1.0
-social-auth-core==1.7.0
+social-auth-app-django==3.1.0
+social-auth-core==3.2.0
 sorl-thumbnail==12.3
 sortedcontainers==2.1.0
 soupsieve==1.9.5

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -292,8 +292,8 @@ simplejson==3.17.0
 singledispatch==3.4.0.3
 six==1.13.0
 slumber==0.7.1
-social-auth-app-django==2.1.0
-social-auth-core==1.7.0
+social-auth-app-django==3.1.0
+social-auth-core==3.2.0
 sorl-thumbnail==12.3
 sortedcontainers==2.1.0
 soupsieve==1.9.5


### PR DESCRIPTION
Microsoft social login is not working on edx mobile app. The issue is fixed in newer version of social-auth-app-django.

We are not passing response object as keyword argument in [do_auth](https://github.com/edx/edx-platform/blob/32c29b0d8f1d81233601c595857535a9ce88b24e/common/djangoapps/student/views/management.py#L705)
```python
File "/edx/app/edxapp/edx-platform/common/djangoapps/student/views/management.py", line 705, in create_account_with_params
    pipeline_user = request.backend.do_auth(social_access_token, user=user)
  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/social_core/utils.py", line 252, in wrapper
    return func(*args, **kwargs)
  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/social_core/backends/oauth.py", line 410, in do_auth
    data = self.user_data(access_token, *args, **kwargs)
  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/social_core/backends/azuread.py", line 80, in user_data
    id_token = response.get('id_token')
AttributeError: 'NoneType' object has no attribute 'get'
```
[In the version we are using](https://github.com/python-social-auth/social-core/blob/1.7.0/social_core/backends/azuread.py#L78-L80) response object is required
```python
    def user_data(self, access_token, *args, **kwargs):
        response = kwargs.get('response')
        id_token = response.get('id_token')
```
[In newer version this problem is fixed](https://github.com/python-social-auth/social-core/blob/3.2.0/social_core/backends/azuread.py#L78-L83) by making response optional
```python
def user_data(self, access_token, *args, **kwargs):
        response = kwargs.get('response')
        if response and response.get('id_token'):
            id_token = response.get('id_token')
        else:
            id_token = access_token
```

[PROD-718](https://openedx.atlassian.net/browse/PROD-718)