### PR TITLE
Fix assertions failing under Python 3 BOM-668

### DIFF
--- a/common/djangoapps/terrain/stubs/http.py
+++ b/common/djangoapps/terrain/stubs/http.py
@@ -104,7 +104,7 @@ class StubHttpRequestHandler(BaseHTTPRequestHandler, object):
         Retrieve the request POST parameters from the client as a dictionary.
         If no POST parameters can be interpreted, return an empty dict.
         """
-        contents = self.request_content.decode()
+        contents = self.request_content
 
         # The POST dict will contain a list of values for each key.
         # None of our parameters are lists, however, so we map [val] --> val

--- a/openedx/core/djangoapps/schedules/resolvers.py
+++ b/openedx/core/djangoapps/schedules/resolvers.py
@@ -340,7 +340,7 @@ class CourseUpdateResolver(BinnedSchedulesBaseResolver):
     experience_filter = Q(experience__experience_type=ScheduleExperience.EXPERIENCES.course_updates)
 
     def schedules_for_bin(self):
-        week_num = abs(self.day_offset) / 7
+        week_num = abs(self.day_offset) // 7
         schedules = self.get_schedules_with_target_date_by_bin_and_orgs(
             order_by='enrollment__course',
         )


### PR DESCRIPTION
Fixed a few failures of the form `AssertionError: False is not true`:

* Two different Unicode fixes for `terrain.stubs.http` went in around the same time and clashed with each other, I reverted one of them.
* Fixed a division operation to keep working as it did before.
* Fixed a test of Unicode password normalization to use a login path that actually normalizes the password.  This worked before because the old normalization rules in Python 2.7's Unicode data didn't make any changes to the particular password used here (but that changed with the newer data in Python 3.5).