### PR TITLE
Use authsource instead of auth_source for compatibilities with pymongo

### DIFF
--- a/common/djangoapps/track/backends/mongodb.py
+++ b/common/djangoapps/track/backends/mongodb.py
@@ -29,7 +29,7 @@ class MongoBackend(BaseBackend):
           - `password`: collection user password
           - `database`: name of the database
           - `collection`: name of the collection
-          - 'auth_source': name of the authentication database
+          - 'authsource': name of the authentication database
           - `extra`: parameters to pymongo.MongoClient not listed above
 
         """
@@ -47,7 +47,7 @@ class MongoBackend(BaseBackend):
         db_name = kwargs.get('database', 'track')
         collection_name = kwargs.get('collection', 'events')
 
-        auth_source = kwargs.get('auth_source') or None
+        auth_source = kwargs.get('authsource') or None
 
         # Other mongo connection arguments
         extra = kwargs.get('extra', {})

--- a/common/lib/xmodule/xmodule/mongo_utils.py
+++ b/common/lib/xmodule/xmodule/mongo_utils.py
@@ -37,7 +37,7 @@ def connect_to_mongodb(
         mongo_client_class = pymongo.MongoClient
 
     # If the MongoDB server uses a separate authentication database that should be specified here
-    auth_source = kwargs.pop('auth_source', '') or None
+    auth_source = kwargs.get('authsource', '') or None
 
     # If read_preference is given as a name of a valid ReadPreference.<NAME> constant
     # such as "SECONDARY_PREFERRED", convert it. Otherwise pass it through unchanged.


### PR DESCRIPTION
This PR is related with the PR in which was added support for MongoDB authentication database
https://github.com/edx/edx-platform/pull/20819

And a PR in configuration https://github.com/edx/configuration/pull/5482
As was explained in the PR in the configuration, pymongo expects the value authsource instead of auth_source. With this change there is not need to remove that value from the kwargs.


