### PR TITLE
BOM fix remaining capa module issues

### DIFF
--- a/common/lib/capa/capa/safe_exec/safe_exec.py
+++ b/common/lib/capa/capa/safe_exec/safe_exec.py
@@ -21,8 +21,10 @@ from __future__ import absolute_import, division
 import os
 os.environ["OPENBLAS_NUM_THREADS"] = "1"    # See TNL-6456
 
-import random as random_module
+import random2 as random_module
 import sys
+from six.moves import xrange
+
 random = random_module.Random(%r)
 random.Random = random_module.Random
 sys.modules['random'] = random

--- a/common/lib/capa/capa/safe_exec/tests/test_safe_exec.py
+++ b/common/lib/capa/capa/safe_exec/tests/test_safe_exec.py
@@ -5,7 +5,7 @@ from __future__ import absolute_import
 import hashlib
 import os
 import os.path
-import random
+import random2 as random
 import textwrap
 import unittest
 


### PR DESCRIPTION
Updated random to random2 in safe_exec as python3 random is different
as compared to python2 random.