### PR TITLE
BOM-913

### DIFF
--- a/lms/djangoapps/instructor/tests/views/test_instructor_dashboard.py
+++ b/lms/djangoapps/instructor/tests/views/test_instructor_dashboard.py
@@ -267,7 +267,7 @@ class TestInstructorDashboard(ModuleStoreTestCase, LoginEnrollmentTestCase, XssT
             response = self.client.get(self.url)
         self.assertNotIn(
             TestInstructorDashboard.GRADEBOOK_LEARNER_COUNT_MESSAGE,
-            response.content
+            response.content.decode('utf-8')
         )
         self.assertContains(response, 'View Gradebook')
 
@@ -431,7 +431,8 @@ class TestInstructorDashboard(ModuleStoreTestCase, LoginEnrollmentTestCase, XssT
 
             self.assertEquals(
                 expected_result,
-                'CCX Coaches are able to create their own Custom Courses based on this course' in response.content
+                'CCX Coaches are able to create their own Custom Courses based on this course'
+                in response.content.decode('utf-8')
             )
 
     def test_grade_cutoffs(self):

--- a/lms/djangoapps/instructor/views/instructor_dashboard.py
+++ b/lms/djangoapps/instructor/views/instructor_dashboard.py
@@ -7,6 +7,7 @@ from __future__ import absolute_import
 import datetime
 import logging
 import uuid
+from functools import reduce  # pylint: disable=redefined-builtin
 
 import pytz
 import six
@@ -32,8 +33,6 @@ from xblock.fields import ScopeIds
 from bulk_email.api import is_bulk_email_feature_enabled
 from class_dashboard.dashboard_data import get_array_section_has_problem, get_section_display_name
 from course_modes.models import CourseMode, CourseModesArchive
-from lms.djangoapps.courseware.access import has_access
-from lms.djangoapps.courseware.courses import get_course_by_id, get_studio_url
 from edxmako.shortcuts import render_to_response
 from lms.djangoapps.certificates import api as certs_api
 from lms.djangoapps.certificates.models import (
@@ -44,6 +43,8 @@ from lms.djangoapps.certificates.models import (
     CertificateWhitelist,
     GeneratedCertificate
 )
+from lms.djangoapps.courseware.access import has_access
+from lms.djangoapps.courseware.courses import get_course_by_id, get_studio_url
 from lms.djangoapps.courseware.module_render import get_module_by_usage_id
 from lms.djangoapps.discussion.django_comment_client.utils import available_division_schemes, has_forum_access
 from lms.djangoapps.grades.api import is_writable_gradebook_enabled


### PR DESCRIPTION
reduce functions moves into functools in py3. Fixed the import.

Code was breaking 
```
section_data['grade_cutoffs'] = reduce(advance, sorted_cutoffs, "")[:-2]
```

PR fixed all tests `lms/djangoapps/instructor/tests/views/test_instructor_dashboard.py`