### PR TITLE
Don't try to show anonymous users the first-purchase discount

### DIFF
--- a/openedx/features/discounts/applicability.py
+++ b/openedx/features/discounts/applicability.py
@@ -69,6 +69,9 @@ def can_receive_discount(user, course):  # pylint: disable=unused-argument
     if DiscountRestrictionConfig.disabled_for_course_stacked_config(course):
         return False
 
+    if user.is_anonymous:
+        return False
+
     # Don't allow users who have enrolled in any courses in non-upsellable
     # modes
     if CourseEnrollment.objects.filter(user=user).exclude(mode__in=CourseMode.UPSELL_TO_VERIFIED_MODES).exists():


### PR DESCRIPTION
This fixes errors like:
```
    Oct 10 12:46:07 ip-10-2-10-15 [service_variant=lms][django.request][env:prod-edx-edxapp] ERROR [ip-10-2-10-15  31278] [user None] [exception.py:135] - Internal Server Error: /courses/course-v1:HarvardX+1962USRx+3T2019/discussions/settings
    Traceback (most recent call last):
    File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/django/core/handlers/exception.py", line 41, in inner
        response = get_response(request)
    File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/django/core/handlers/base.py", line 249, in _legacy_get_response
        response = self._get_response(request)
    File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/django/core/handlers/base.py", line 187, in _get_response
        response = self.process_exception_by_middleware(e, request)
    File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/django/core/handlers/base.py", line 185, in _get_response
        response = wrapped_callback(request, *callback_args, **callback_kwargs)
    File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/django/utils/decorators.py", line 185, in inner
        return func(*args, **kwargs)
    File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/newrelic/hooks/framework_django.py", line 539, in wrapper
        return wrapped(*args, **kwargs)
    File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/django/views/decorators/http.py", line 40, in inner
        return func(request, *args, **kwargs)
    File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/django/utils/decorators.py", line 149, in _wrapped_view
        response = view_func(request, *args, **kwargs)
    File "/edx/app/edxapp/edx-platform/common/djangoapps/util/json_request.py", line 55, in parse_json_into_request
        return view_function(request, *args, **kwargs)
    File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/django/contrib/auth/decorators.py", line 23, in _wrapped_view
        return view_func(request, *args, **kwargs)
    File "/edx/app/edxapp/edx-platform/lms/djangoapps/discussion/views.py", line 936, in course_discussions_settings_handler
        course, discussion_settings
    File "/edx/app/edxapp/edx-platform/lms/djangoapps/discussion/views.py", line 957, in get_divided_discussions
        all_discussions = utils.get_discussion_categories_ids(course, None, include_all=True)
    File "/edx/app/edxapp/edx-platform/lms/djangoapps/discussion/django_comment_client/utils.py", line 485, in get_discussion_categories_ids
        xblock.discussion_id for xblock in get_accessible_discussion_xblocks(course, user, include_all=include_all)
    File "/edx/app/edxapp/edx-platform/lms/djangoapps/discussion/django_comment_client/utils.py", line 146, in get_accessible_discussion_xblocks
        return get_accessible_discussion_xblocks_by_course_id(course.id, user, include_all=include_all)
    File "/edx/app/edxapp/edx-platform/openedx/core/lib/cache_utils.py", line 73, in decorator
        result = wrapped(*args, **kwargs)
    File "/edx/app/edxapp/edx-platform/lms/djangoapps/discussion/django_comment_client/utils.py", line 159, in get_accessible_discussion_xblocks_by_course_id
        if has_required_keys(xblock) and (include_all or has_access(user, 'load', xblock, course_id))
    File "/edx/app/edxapp/edx-platform/lms/djangoapps/courseware/access.py", line 158, in has_access
        return _has_access_descriptor(user, action, obj, course_key)
    File "/edx/app/edxapp/edx-platform/lms/djangoapps/courseware/access.py", line 572, in _has_access_descriptor
        return _dispatch(checkers, action, user, descriptor)
    File "/edx/app/edxapp/edx-platform/lms/djangoapps/courseware/access.py", line 669, in _dispatch
        result = table[action]()
    File "/edx/app/edxapp/edx-platform/lms/djangoapps/courseware/access.py", line 543, in can_load
        group_access_response = _has_group_access(descriptor, user, course_key)
    File "/edx/app/edxapp/edx-platform/lms/djangoapps/courseware/access.py", line 513, in _has_group_access
        user_fragment=partition.access_denied_fragment(descriptor, user, user_group, allowed_groups),
    File "/edx/app/edxapp/edx-platform/openedx/features/content_type_gating/partitions.py", line 98, in access_denied_fragment
        upgrade_price, _ = format_strikeout_price(user, course)
    File "/edx/app/edxapp/edx-platform/openedx/features/discounts/utils.py", line 22, in format_strikeout_price
        if can_receive_discount(user, course):
    File "/edx/app/edxapp/edx-platform/openedx/features/discounts/applicability.py", line 74, in can_receive_discount
        if CourseEnrollment.objects.filter(user=user).exclude(mode__in=CourseMode.UPSELL_TO_VERIFIED_MODES).exists():
    File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/django/db/models/manager.py", line 85, in manager_method
        return getattr(self.get_queryset(), name)(*args, **kwargs)
    File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/django/db/models/query.py", line 787, in filter
        return self._filter_or_exclude(False, *args, **kwargs)
    File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/django/db/models/query.py", line 805, in _filter_or_exclude
        clone.query.add_q(Q(*args, **kwargs))
    File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/django/db/models/sql/query.py", line 1250, in add_q
        clause, _ = self._add_q(q_object, self.used_aliases)
    File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/django/db/models/sql/query.py", line 1276, in _add_q
        allow_joins=allow_joins, split_subq=split_subq,
    File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/django/db/models/sql/query.py", line 1206, in build_filter
        condition = lookup_class(lhs, value)
    File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/django/db/models/lookups.py", line 24, in __init__
        self.rhs = self.get_prep_lookup()
    File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/django/db/models/fields/related_lookups.py", line 112, in get_prep_lookup
        self.rhs = target_field.get_prep_value(self.rhs)
    File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/django/db/models/fields/__init__.py", line 966, in get_prep_value
        return int(value)
    TypeError: int() argument must be a string or a number, not 'AnonymousUser'
```
This is tracked in https://openedx.atlassian.net/browse/REV-988
[REV-988]


[REV-988]: https://openedx.atlassian.net/browse/REV-988