### PR TITLE
Fix problematic mock in instructor_task tests BOM-403

### DIFF
--- a/lms/djangoapps/instructor_task/api_helper.py
+++ b/lms/djangoapps/instructor_task/api_helper.py
@@ -265,6 +265,13 @@ def _handle_instructor_task_failure(instructor_task, error):
     raise QueueConnectionError()
 
 
+def _get_async_result(task_id):
+    """
+    Use this minor indirection to facilitate mocking the AsyncResult in tests.
+    """
+    return AsyncResult(task_id)
+
+
 def get_updated_instructor_task(task_id):
     """
     Returns InstructorTask object corresponding to a given `task_id`.
@@ -282,7 +289,7 @@ def get_updated_instructor_task(task_id):
     # if the task is not already known to be done, then we need to query
     # the underlying task's result object:
     if instructor_task.task_state not in READY_STATES:
-        result = AsyncResult(task_id)
+        result = _get_async_result(task_id)
         _update_instructor_task(instructor_task, result)
 
     return instructor_task

--- a/lms/djangoapps/instructor_task/tests/test_views.py
+++ b/lms/djangoapps/instructor_task/tests/test_views.py
@@ -158,7 +158,7 @@ class InstructorTaskReportTest(InstructorTaskTestCase):
         """
         Provides mock result to caller of instructor_task_status, and returns resulting output.
         """
-        with patch('celery.result.AsyncResult.__new__') as mock_result_ctor:
+        with patch('lms.djangoapps.instructor_task.api_helper._get_async_result') as mock_result_ctor:
             mock_result_ctor.return_value = mock_result
             response = self._get_instructor_task_status(task_id)
         output = json.loads(response.content.decode('utf-8'))


### PR DESCRIPTION
A helper method used in several of the tests in this file used an unsupported mock of `__new__` which could break other tests run after it by leaving `AsyncResult` in a state where it couldn't be properly initialized.  This only caused a warning under Python 2, but became an error in Python 3.  Added a better target for the patch.

It looks like dozens of tests were impacted by this, the bulk of the ones failing with `TypeError: object() takes no parameters`.  The first few tickets to fix this were closed as "already fixed" because the other test modules all passed in isolation, it was only when run after this mock that they'd start failing.