### PR TITLE
Remove YouTube logo from footer.

### DIFF
--- a/lms/djangoapps/branding/tests/test_api.py
+++ b/lms/djangoapps/branding/tests/test_api.py
@@ -146,8 +146,6 @@ class TestFooter(TestCase):
                  'icon-class': 'fa-facebook-square', 'title': 'Facebook'},
                 {'url': '#', 'action': 'Follow \xe9dX on Twitter', 'name': 'twitter',
                  'icon-class': 'fa-twitter-square', 'title': 'Twitter'},
-                {'url': '#', 'action': 'Subscribe to the \xe9dX YouTube channel',
-                 'name': 'youtube', 'icon-class': 'fa-youtube-square', 'title': 'Youtube'},
                 {'url': '#', 'action': 'Follow \xe9dX on LinkedIn', 'name': 'linkedin',
                  'icon-class': 'fa-linkedin-square', 'title': 'LinkedIn'},
                 {'url': '#', 'action': 'Follow \xe9dX on Google+', 'name': 'google_plus',

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -2578,7 +2578,7 @@ SOCIAL_SHARING_SETTINGS = {
 SOCIAL_MEDIA_FOOTER_NAMES = [
     "facebook",
     "twitter",
-    "youtube",
+    # "youtube", see PROD-816 for more details
     "linkedin",
     "google_plus",
     "reddit",


### PR DESCRIPTION
Current YouTube logo is not compliant with YouTube's branding guidelines and we may risk having our Youtube API keys revoked. We will add it back after working with UX/Marketing to ensure the design is compliant as well as understanding the usage of that button.

PROD-816
