### PR TITLE
BOM-916

### DIFF
--- a/common/djangoapps/terrain/stubs/http.py
+++ b/common/djangoapps/terrain/stubs/http.py
@@ -104,13 +104,17 @@ class StubHttpRequestHandler(BaseHTTPRequestHandler, object):
         Retrieve the request POST parameters from the client as a dictionary.
         If no POST parameters can be interpreted, return an empty dict.
         """
-        contents = self.request_content
+
+        if isinstance(self.request_content, bytes):
+            contents = self.request_content.decode('utf-8')
+        else:
+            contents = self.request_content
 
         # The POST dict will contain a list of values for each key.
         # None of our parameters are lists, however, so we map [val] --> val
         # If the list contains multiple entries, we pick the first one
         try:
-            post_dict = six.moves.urllib.parse.parse_qs(contents.decode('utf-8'), keep_blank_values=True)
+            post_dict = six.moves.urllib.parse.parse_qs(contents, keep_blank_values=True)
             return {
                 key: list_val[0]
                 for key, list_val in post_dict.items()

--- a/common/djangoapps/terrain/stubs/tests/test_xqueue_stub.py
+++ b/common/djangoapps/terrain/stubs/tests/test_xqueue_stub.py
@@ -4,6 +4,7 @@ Unit tests for stub XQueue implementation.
 
 from __future__ import absolute_import
 
+import ast
 import json
 import unittest
 
@@ -166,6 +167,10 @@ class StubXQueueServiceTest(unittest.TestCase):
             'xqueue_header': expected_header,
             'xqueue_body': expected_body,
         }
-
         # Check that the POST request was made with the correct params
-        self.post.assert_called_with(callback_url, data=expected_callback_dict)
+        self.assertEqual(self.post.call_args[1]['data']['xqueue_body'], expected_callback_dict['xqueue_body'])
+        self.assertEqual(
+            ast.literal_eval(self.post.call_args[1]['data']['xqueue_header']),
+            ast.literal_eval(expected_callback_dict['xqueue_header'])
+        )
+        self.assertEqual(self.post.call_args[0][0], callback_url)


### PR DESCRIPTION
Fixed double decoding issue.
Fixed the mock.assertMethod. Dict keys were coming different order.

This PR fixed all 11 failures in `common/djangoapps/terrain/stubs/tests/` folder.