### PR TITLE
allow user to edit fullname if no social auth record exists

### DIFF
--- a/openedx/core/djangoapps/user_api/accounts/settings_views.py
+++ b/openedx/core/djangoapps/user_api/accounts/settings_views.py
@@ -148,7 +148,7 @@ def account_settings_context(request):
     }
 
     enterprise_customer = get_enterprise_customer_for_learner(user=request.user)
-    update_account_settings_context_for_enterprise(context, enterprise_customer)
+    update_account_settings_context_for_enterprise(context, enterprise_customer, user)
 
     if third_party_auth.is_enabled():
         # If the account on the third party provider is already connected with another edX account,

--- a/openedx/core/djangoapps/user_api/accounts/tests/test_settings_views.py
+++ b/openedx/core/djangoapps/user_api/accounts/tests/test_settings_views.py
@@ -27,6 +27,7 @@ from openedx.core.djangoapps.waffle_utils.testutils import override_waffle_flag
 from openedx.core.djangolib.testing.utils import skip_unless_lms
 from student.tests.factories import UserFactory
 from third_party_auth.tests.testutil import ThirdPartyAuthTestMixin
+from openedx.features.enterprise_support.utils import get_enterprise_readonly_account_fields
 
 
 @skip_unless_lms
@@ -106,7 +107,8 @@ class AccountSettingsViewTest(ThirdPartyAuthTestMixin, SiteMixin, ProgramsApiCon
             self.assertEqual(context['edx_support_url'], settings.SUPPORT_SITE_LINK)
             self.assertEqual(context['enterprise_name'], None)
             self.assertEqual(
-                context['enterprise_readonly_account_fields'], {'fields': settings.ENTERPRISE_READONLY_ACCOUNT_FIELDS}
+                context['enterprise_readonly_account_fields'],
+                {'fields': list(get_enterprise_readonly_account_fields(self.user))}
             )
             expected_beta_language = {'code': 'lt-lt', 'name': settings.LANGUAGE_DICT.get('lt-lt')}
             self.assertEqual(context['beta_language'], expected_beta_language)
@@ -152,7 +154,8 @@ class AccountSettingsViewTest(ThirdPartyAuthTestMixin, SiteMixin, ProgramsApiCon
         self.assertEqual(context['edx_support_url'], settings.SUPPORT_SITE_LINK)
         self.assertEqual(context['enterprise_name'], dummy_enterprise_customer['name'])
         self.assertEqual(
-            context['enterprise_readonly_account_fields'], {'fields': settings.ENTERPRISE_READONLY_ACCOUNT_FIELDS}
+            context['enterprise_readonly_account_fields'],
+            {'fields': list(get_enterprise_readonly_account_fields(self.user))}
         )
 
     def test_view(self):


### PR DESCRIPTION
**Description:** Allow an enterprise learner to update `fullname` if  that learner is has no `UserSocialAuth` record whether the `Sync learner profile data` is enabled or disabled by `Identity Provider`.

**JIRA:** [ENT-1964
](https://openedx.atlassian.net/browse/ENT-1964)

**Testing:**
1. Create an enterprise customer
2. Set an `Identity Provider` with enterprise customer
3. Link a user to enterprise customer
4. For `Identity Provider` enable `Sync learner profile data` 
5. Go to `http://localhost:18000/account/settings` and you should be able to update the `Full Name`
6. Now create a `UserSocialAuth` record manually from `http://localhost:18000/admin/social_django/usersocialauth/` or using an `Identity Provider`, for example `KeyCloak`. The record should be created for user in step 3.
7. Now go to `http://localhost:18000/account/settings` and you should not be able to update the `Full Name` because user's social auth record exists.

### Please consider the following when opening a pull request:

- Link to the relevant JIRA ticket(s) and tag any relevant team(s).
- Squash your changes down into one or more discrete commits.
  In each commit, include description that could help a developer
  several months from now.
- If running `make upgrade`, run _as close to the time of merging as possible_
  to avoid accidentally downgrading someone else's package.
  Put the output of `make upgrade` in its own separate commit,
  decoupled from other code changes.
- Aim for comprehensive test coverage, but remember that
  automated testing isn't a substitute for manual verification.
- Carefully consider naming, code organization, dependencies when adding new code.
  Code that is amenable to refactoring and improvement benefits all platform developers,
  especially given the size and scope of edx-platform.
  Consult existing Architectural Decision Records (ADRs),
  including those concerning the app(s) you are changing and
  [those concerning edx-platform as a whole](https://github.com/edx/edx-platform/tree/master/docs/decisions).
