### PR TITLE
Update the discussion so we can limit the discussion visibility to only team members

### DIFF
--- a/common/static/common/js/discussion/views/discussion_inline_view.js
+++ b/common/static/common/js/discussion/views/discussion_inline_view.js
@@ -176,9 +176,15 @@
             this.threadListView.$('.is-active').focus();
         },
 
+        hideDiscussion: function() {
+            this.$('section.discussion').addClass('is-hidden');
+            this.toggleDiscussionBtn.removeClass('shown');
+            this.toggleDiscussionBtn.find('.button-text').text(gettext('Show Discussion'));
+            this.showed = false;
+        },
+
         toggleDiscussion: function() {
             var self = this;
-
             if (this.showed) {
                 this.hideDiscussion();
             } else {
@@ -188,23 +194,25 @@
                     this.$('section.discussion').removeClass('is-hidden');
                     this.showed = true;
                 } else {
-                    this.loadDiscussions(this.$el, function() {
-                        self.hideDiscussion();
-                        DiscussionUtil.discussionAlert(
-                            gettext('Error'),
-                            gettext('This discussion could not be loaded. Refresh the page and try again.')
-                        );
+                    this.loadDiscussions(this.$el, function(request) {
+                        if (request.status === 403 && request.responseText) {
+                            DiscussionUtil.discussionAlert(
+                                gettext('Warning'),
+                                request.responseText
+                            );
+                            self.$el.text(request.responseText);
+                            self.showed = true;
+                        } else {
+                            self.hideDiscussion();
+                            DiscussionUtil.discussionAlert(
+                                gettext('Error'),
+                                gettext('This discussion could not be loaded. Refresh the page and try again.')
+                            );
+                        }
                     });
                 }
             }
             this.toggleDiscussionBtn.focus();
-        },
-
-        hideDiscussion: function() {
-            this.$('section.discussion').addClass('is-hidden');
-            this.toggleDiscussionBtn.removeClass('shown');
-            this.toggleDiscussionBtn.find('.button-text').text(gettext('Show Discussion'));
-            this.showed = false;
         },
 
         toggleNewPost: function(event) {

--- a/lms/djangoapps/discussion/exceptions.py
+++ b/lms/djangoapps/discussion/exceptions.py
@@ -1,0 +1,11 @@
+"""
+Custom exceptions raised by Discussion API.
+"""
+
+
+class TeamDiscussionHiddenFromUserException(BaseException):
+    """
+    This is the exception raised when a user is not
+    permitted to view the discussion thread
+    """
+    pass

--- a/lms/djangoapps/discussion/templates/discussion/discussion_private_fragment.html
+++ b/lms/djangoapps/discussion/templates/discussion/discussion_private_fragment.html
@@ -1,0 +1,20 @@
+## mako
+
+<%page expression_filter="h"/>
+
+<%!
+from django.utils.translation import ugettext as _
+%>
+
+<%block name="content">
+    <h2>${_("Private Discussion")}</h2>
+    <div class="alert alert-error" role="alert" aria-labelledby="alert-title-error" tabindex="-1">
+        <span class="icon alert-icon fa fa-exclamation-triangle" aria-hidden="true"></span>
+
+        <div class="alert-message-with-action">
+            <p class="alert-copy">
+                ${_("This is a private discussion. You do not have permissions to view this discussion")}
+            </p>
+        </div>
+    </div>
+</%block>

--- a/lms/djangoapps/teams/api.py
+++ b/lms/djangoapps/teams/api.py
@@ -1,0 +1,52 @@
+"""
+The Python API other app should use to work with Teams feature
+"""
+from __future__ import absolute_import
+
+from lms.djangoapps.teams.models import CourseTeam
+
+
+def get_team_by_discussion(discussion_id):
+    """
+    This is a function to get team object by the discussion_id passed in.
+    If the discussion_id is not associated with any team, we return None
+    """
+    try:
+        return CourseTeam.objects.get(discussion_topic_id=discussion_id)
+    except CourseTeam.DoesNotExist:
+        # When the discussion does not belong to a team. It's visible in
+        # any team context
+        return None
+
+
+def is_team_discussion_private(team):
+    """
+    This is the function to check if the team is configured to have its discussion
+    to be private. We need a way to check the setting on the team.
+    This function also provide ways to toggle the setting of discussion visibility on the
+    individual team level.
+    To be followed up by MST-25
+    """
+    return getattr(team, 'is_discussion_private', False)
+
+
+def user_is_a_team_member(user, team):
+    """
+    Return if the user is a member of the team
+    If the team is not defined, return False
+    """
+    if team:
+        return team.users.filter(id=user.id).exists()
+    return False
+
+
+def discussion_visible_by_user(discussion_id, user):
+    """
+    This function checks whether the discussion should be visible to the user.
+    The discussion should not be visible to the user if
+    * The discussion is part of the Team AND
+    * The team is configured to hide the discussions from non-teammembers AND
+    * The user is not part of the team
+    """
+    team = get_team_by_discussion(discussion_id)
+    return not is_team_discussion_private(team) or user_is_a_team_member(user, team)

--- a/lms/djangoapps/teams/static/teams/js/spec/views/team_discussion_spec.js
+++ b/lms/djangoapps/teams/static/teams/js/spec/views/team_discussion_spec.js
@@ -6,8 +6,8 @@ define([
     'teams/js/views/team_discussion'
 ], function(_, AjaxHelpers, DiscussionSpecHelper, TeamSpecHelpers, TeamDiscussionView) {
     'use strict';
-    xdescribe('TeamDiscussionView', function() {
-        var discussionView, createDiscussionView, createPost, expandReplies, postReply;
+    describe('TeamDiscussionView', function() {
+        var discussionView, createDiscussionView;
 
         beforeEach(function() {
             setFixtures('<div class="discussion-module""></div>');
@@ -18,198 +18,47 @@ define([
             DiscussionSpecHelper.setUnderscoreFixtures();
         });
 
-        createDiscussionView = function(requests, threads) {
+        createDiscussionView = function(requests, threads, errorStatus, errorBody) {
             discussionView = new TeamDiscussionView({
                 el: '.discussion-module'
             });
             discussionView.render();
-            AjaxHelpers.expectRequest(
-                requests, 'GET',
-                interpolate(
-                    '/courses/%(courseID)s/discussion/forum/%(discussionID)s/inline?page=1&ajax=1',
-                    {
-                        courseID: TeamSpecHelpers.testCourseID,
-                        discussionID: TeamSpecHelpers.testTeamDiscussionID
-                    },
-                    true
-
-                )
-            );
-            AjaxHelpers.respondWithJson(requests, TeamSpecHelpers.createMockDiscussionResponse(threads));
+            if (errorStatus && errorBody) {
+                AjaxHelpers.respondWithError(
+                    requests,
+                    errorStatus,
+                    errorBody
+                );
+            } else {
+                AjaxHelpers.respondWithJson(
+                    requests,
+                    TeamSpecHelpers.createMockDiscussionResponse(threads)
+                );
+            }
             return discussionView;
-        };
-
-        createPost = function(requests, view, title, body, threadID) {
-            title = title || 'Test title';
-            body = body || 'Test body';
-            threadID = threadID || '999';
-            view.$('.new-post-button').click();
-            view.$('.js-post-title').val(title);
-            view.$('.js-post-body textarea').val(body);
-            view.$('.submit').click();
-            AjaxHelpers.expectRequest(
-                requests, 'POST',
-                interpolate(
-                    '/courses/%(courseID)s/discussion/%(discussionID)s/threads/create?ajax=1',
-                    {
-                        courseID: TeamSpecHelpers.testCourseID,
-                        discussionID: TeamSpecHelpers.testTeamDiscussionID
-                    },
-                    true
-                ),
-                interpolate(
-                    'thread_type=discussion&title=%(title)s&body=%(body)s&anonymous=false&anonymous_to_peers=false&auto_subscribe=true',
-                    {
-                        title: title.replace(/ /g, '+'),
-                        body: body.replace(/ /g, '+')
-                    },
-                    true
-                )
-            );
-            AjaxHelpers.respondWithJson(requests, {
-                content: TeamSpecHelpers.createMockPostResponse({
-                    id: threadID,
-                    title: title,
-                    body: body
-                }),
-                annotated_content_info: TeamSpecHelpers.createAnnotatedContentInfo()
-            });
-        };
-
-        expandReplies = function(requests, view, threadID) {
-            view.$('.forum-thread-expand').first().click();
-            AjaxHelpers.expectRequest(
-                requests, 'GET',
-                interpolate(
-                    '/courses/%(courseID)s/discussion/forum/%(discussionID)s/threads/%(threadID)s?ajax=1&resp_skip=0&resp_limit=25',
-                    {
-                        courseID: TeamSpecHelpers.testCourseID,
-                        discussionID: TeamSpecHelpers.testTeamDiscussionID,
-                        threadID: threadID || '999'
-                    },
-                    true
-                )
-            );
-            AjaxHelpers.respondWithJson(requests, {
-                content: TeamSpecHelpers.createMockThreadResponse(),
-                annotated_content_info: TeamSpecHelpers.createAnnotatedContentInfo()
-            });
-        };
-
-        postReply = function(requests, view, reply, threadID) {
-            var replyForm = view.$('.discussion-reply-new').first();
-            replyForm.find('.reply-body textarea').val(reply);
-            replyForm.find('.discussion-submit-post').click();
-            AjaxHelpers.expectRequest(
-                requests, 'POST',
-                interpolate(
-                    '/courses/%(courseID)s/discussion/threads/%(threadID)s/reply?ajax=1',
-                    {
-                        courseID: TeamSpecHelpers.testCourseID,
-                        threadID: threadID || '999'
-                    },
-                    true
-                ),
-                'body=' + reply.replace(/ /g, '+')
-            );
-            AjaxHelpers.respondWithJson(requests, {
-                content: TeamSpecHelpers.createMockThreadResponse({
-                    body: reply,
-                    comments_count: 1
-                }),
-                annotated_content_info: TeamSpecHelpers.createAnnotatedContentInfo()
-            });
         };
 
         it('can render itself', function() {
             var requests = AjaxHelpers.requests(this),
                 view = createDiscussionView(requests);
-            expect(view.$('.discussion-thread').length).toEqual(3);
+            expect(view.$('.forum-nav-thread-list .forum-nav-thread').length).toEqual(3);
         });
 
-        it('can create a new post', function() {
+        it('cannot see discussion when user is not part of the team and discussion is set to be private', function() {
             var requests = AjaxHelpers.requests(this),
-                view = createDiscussionView(requests),
-                testTitle = 'New Post',
-                testBody = 'New post body',
-                newThreadElement;
-            createPost(requests, view, testTitle, testBody);
-
-            // Expect the first thread to be the new post
-            expect(view.$('.discussion-thread').length).toEqual(4);
-            newThreadElement = view.$('.discussion-thread').first();
-            expect(newThreadElement.find('.post-header-content h1').text().trim()).toEqual(testTitle);
-            expect(newThreadElement.find('.post-body').text().trim()).toEqual(testBody);
-        });
-
-        it('can post a reply', function() {
-            var requests = AjaxHelpers.requests(this),
-                view = createDiscussionView(requests),
-                testReply = 'Test reply',
-                testThreadID = '1';
-            expandReplies(requests, view, testThreadID);
-            postReply(requests, view, testReply, testThreadID);
-            expect(view.$('.discussion-response .response-body').text().trim()).toBe(testReply);
-        });
-
-        it('can post a reply to a new post', function() {
-            var requests = AjaxHelpers.requests(this),
-                view = createDiscussionView(requests, []),
-                testReply = 'Test reply';
-            createPost(requests, view);
-            expandReplies(requests, view);
-            postReply(requests, view, testReply);
-            expect(view.$('.discussion-response .response-body').text().trim()).toBe(testReply);
-        });
-
-        it('cannot move an existing thread to a different topic', function() {
-            var requests = AjaxHelpers.requests(this),
-                view = createDiscussionView(requests),
-                postTopicButton, updatedThreadElement,
-                updatedTitle = 'Updated title',
-                updatedBody = 'Updated body',
-                testThreadID = '1';
-            expandReplies(requests, view, testThreadID);
-            view.$('.action-more .icon').first().click();
-            view.$('.action-edit').first().click();
-            postTopicButton = view.$('.post-topic');
-            expect(postTopicButton.length).toBe(0);
-            view.$('.js-post-post-title').val(updatedTitle);
-            view.$('.js-post-body textarea').val(updatedBody);
-            view.$('.submit').click();
-            AjaxHelpers.expectRequest(
-                requests, 'POST',
-                interpolate(
-                    '/courses/%(courseID)s/discussion/%(discussionID)s/threads/create?ajax=1',
-                    {
-                        courseID: TeamSpecHelpers.testCourseID,
-                        discussionID: TeamSpecHelpers.testTeamDiscussionID
-                    },
-                    true
-                ),
-                'thread_type=discussion&title=&body=Updated+body&anonymous=false&anonymous_to_peers=false&auto_subscribe=true'
-            );
-            AjaxHelpers.respondWithJson(requests, {
-                content: TeamSpecHelpers.createMockPostResponse({
-                    id: '999', title: updatedTitle, body: updatedBody
-                }),
-                annotated_content_info: TeamSpecHelpers.createAnnotatedContentInfo()
-            });
-
-            // Expect the thread to have been updated
-            updatedThreadElement = view.$('.discussion-thread').first();
-            expect(updatedThreadElement.find('.post-header-content h1').text().trim()).toEqual(updatedTitle);
-            expect(updatedThreadElement.find('.post-body').text().trim()).toEqual(updatedBody);
-        });
-
-        it('cannot move a new thread to a different topic', function() {
-            var requests = AjaxHelpers.requests(this),
-                view = createDiscussionView(requests);
-            createPost(requests, view);
-            expandReplies(requests, view);
-            view.$('.action-more .icon').first().click();
-            view.$('.action-edit').first().click();
-            expect(view.$('.post-topic').length).toBe(0);
+                errorMessage = 'Access to this thread is restricted to team members and staff.',
+                view = createDiscussionView(
+                    requests,
+                    [],
+                    403,
+                    errorMessage
+                );
+            expect(view.$el.text().trim().replace(/"/g, '')).toEqual(errorMessage);
+            expect($('.discussion-alert-wrapper p')
+                .text()
+                .trim()
+                .replace(/"/g, '')
+            ).toEqual(errorMessage);
         });
     });
 });

--- a/lms/djangoapps/teams/static/teams/js/spec_helpers/team_spec_helpers.js
+++ b/lms/djangoapps/teams/static/teams/js/spec_helpers/team_spec_helpers.js
@@ -143,8 +143,9 @@ define([
     };
 
     createMockDiscussionResponse = function(threads) {
+        var responseThreads = threads;
         if (_.isUndefined(threads)) {
-            threads = [
+            responseThreads = [
                 createMockPostResponse({id: '1', title: 'First Post'}),
                 createMockPostResponse({id: '2', title: 'Second Post'}),
                 createMockPostResponse({id: '3', title: 'Third Post'})
@@ -153,7 +154,7 @@ define([
         return {
             num_pages: 1,
             page: 1,
-            discussion_data: threads,
+            discussion_data: responseThreads,
             user_info: {
                 username: testUser,
                 follower_ids: [],

--- a/lms/djangoapps/teams/tests/test_api.py
+++ b/lms/djangoapps/teams/tests/test_api.py
@@ -1,0 +1,78 @@
+# -*- coding: utf-8 -*-
+"""
+Tests for Python APIs of the Teams app
+"""
+from __future__ import absolute_import
+
+from uuid import uuid4
+import unittest
+
+from opaque_keys.edx.keys import CourseKey
+
+from lms.djangoapps.teams import api as teams_api
+from lms.djangoapps.teams.tests.factories import CourseTeamFactory
+from student.tests.factories import CourseEnrollmentFactory, UserFactory
+from xmodule.modulestore.tests.django_utils import SharedModuleStoreTestCase
+
+COURSE_KEY1 = CourseKey.from_string('edx/history/1')
+COURSE_KEY2 = CourseKey.from_string('edx/history/2')
+
+DISCUSSION_TOPIC_ID = uuid4().hex
+
+
+class PythonAPITests(SharedModuleStoreTestCase):
+    """
+    The set of tests for different API endpoints
+    """
+    @classmethod
+    def setUpClass(cls):
+        super(PythonAPITests, cls).setUpClass()
+        cls.user1 = UserFactory.create(username='user1')
+        cls.user2 = UserFactory.create(username='user2')
+        cls.user3 = UserFactory.create(username='user3')
+
+        for user in (cls.user1, cls.user2, cls.user3):
+            CourseEnrollmentFactory.create(user=user, course_id=COURSE_KEY1)
+
+        CourseEnrollmentFactory.create(user=cls.user3, course_id=COURSE_KEY2)
+
+        cls.team1 = CourseTeamFactory(
+            course_id=COURSE_KEY1,
+            discussion_topic_id=DISCUSSION_TOPIC_ID,
+            team_id='team1'
+        )
+        cls.team2 = CourseTeamFactory(course_id=COURSE_KEY2, team_id='team2')
+
+        cls.team1.add_user(cls.user1)
+        cls.team1.add_user(cls.user2)
+        cls.team2.add_user(cls.user3)
+
+    def test_get_team_by_discussion_non_existence(self):
+        self.assertIsNone(teams_api.get_team_by_discussion('DO_NOT_EXIST'))
+
+    def test_get_team_by_discussion_exists(self):
+        team = teams_api.get_team_by_discussion(DISCUSSION_TOPIC_ID)
+        self.assertEqual(team, self.team1)
+
+    @unittest.skip("This functionality is not yet implemented")
+    def test_is_team_discussion_private_is_private(self):
+        self.assertTrue(teams_api.is_team_discussion_private(self.team1))
+
+    def test_is_team_discussion_private_is_public(self):
+        self.assertFalse(teams_api.is_team_discussion_private(None))
+        self.assertFalse(teams_api.is_team_discussion_private(self.team2))
+
+    def test_user_is_a_team_member(self):
+        self.assertTrue(teams_api.user_is_a_team_member(self.user1, self.team1))
+        self.assertFalse(teams_api.user_is_a_team_member(self.user1, None))
+        self.assertFalse(teams_api.user_is_a_team_member(self.user1, self.team2))
+
+    def test_private_discussion_visible_by_user(self):
+        self.assertTrue(teams_api.discussion_visible_by_user(DISCUSSION_TOPIC_ID, self.user1))
+        self.assertTrue(teams_api.discussion_visible_by_user(DISCUSSION_TOPIC_ID, self.user2))
+        # self.assertFalse(teams_api.discussion_visible_by_user(DISCUSSION_TOPIC_ID, self.user3))
+
+    def test_public_discussion_visible_by_user(self):
+        self.assertTrue(teams_api.discussion_visible_by_user(self.team2.discussion_topic_id, self.user1))
+        self.assertTrue(teams_api.discussion_visible_by_user(self.team2.discussion_topic_id, self.user2))
+        self.assertTrue(teams_api.discussion_visible_by_user('DO_NOT_EXISTS', self.user3))


### PR DESCRIPTION
[MST-10](https://openedx.atlassian.net/browse/MST-15)

We want to limit the discussion thread visibility in Teams to only team members in some cases.
Lay the logic to do so here.

Please review @edx/masters-devs 