### PR TITLE
Fixed - " AttributeError: 'str' object has no attribute 'decode' " - BOM-922

### DIFF
--- a/common/lib/xmodule/xmodule/video_module/transcripts_utils.py
+++ b/common/lib/xmodule/xmodule/video_module/transcripts_utils.py
@@ -579,8 +579,6 @@ def get_video_transcript_content(edx_video_id, language_code):
     edx_video_id = clean_video_id(edx_video_id)
     if edxval_api and edx_video_id:
         transcript = edxval_api.get_video_transcript_data(edx_video_id, language_code)
-        if transcript and 'content' in transcript:
-            transcript['content'] = transcript['content'].decode('utf-8')
 
     return transcript
 


### PR DESCRIPTION
Due to some changes in the codebase, this decoding isn't required anymore.
Relevant JIRA issue can be found [here](https://openedx.atlassian.net/browse/BOM-922).