### PR TITLE
BOM-923 Project Xblock Recommber integration tests fix

### DIFF
--- a/openedx/tests/xblock_integration/test_recommender.py
+++ b/openedx/tests/xblock_integration/test_recommender.py
@@ -6,9 +6,9 @@ recommender system
 from __future__ import absolute_import
 
 import codecs
+from io import BytesIO
 import itertools
-import json
-from six import StringIO
+import simplejson as json
 import unittest
 from copy import deepcopy
 
@@ -651,14 +651,12 @@ class TestRecommenderFileUploading(TestRecommender):
         happens or is rejected as expected.
         """
         if 'magic_number' in test_case:
-            if six.PY2:
-                f_handler = StringIO(codecs.decode(test_case['magic_number'], 'hex_codec'))
-            else:
-                f_handler = StringIO(codecs.decode(test_case['magic_number'], 'hex_codec').decode('utf-8'))
+            f_handler = BytesIO(codecs.decode(test_case['magic_number'], 'hex_codec'))
         elif content is not None:
-            f_handler = StringIO(json.dumps(content, sort_keys=True))
+            f_handler = BytesIO(
+                json.dumps(content, sort_keys=True) if six.PY2 else json.dumps(content, sort_keys=True).encode('utf-8'))
         else:
-            f_handler = StringIO('')
+            f_handler = BytesIO(b'')
 
         f_handler.content_type = test_case['mimetypes']
         f_handler.name = 'file' + test_case['suffixes']


### PR DESCRIPTION
Python3 json can not work with bytes type input so used simplejson
instead of python json which works with both bytes and unicode
type input.
Previously we mistakenly updated StringIO to six.String io. which
caused the failure of the tests. Used io.BytesIO to fix the issues as
assci character bytes can not be converted to unicode.
