### PR TITLE
Updated the file handler input method according the codec output - BOM-926

### DIFF
--- a/openedx/tests/xblock_integration/test_recommender.py
+++ b/openedx/tests/xblock_integration/test_recommender.py
@@ -6,9 +6,9 @@ recommender system
 from __future__ import absolute_import
 
 import codecs
-from io import BytesIO
 import itertools
-import simplejson as json
+import json
+from six import StringIO, BytesIO
 import unittest
 from copy import deepcopy
 
@@ -651,12 +651,14 @@ class TestRecommenderFileUploading(TestRecommender):
         happens or is rejected as expected.
         """
         if 'magic_number' in test_case:
-            f_handler = BytesIO(codecs.decode(test_case['magic_number'], 'hex_codec'))
+            if six.PY2:
+                f_handler = StringIO(codecs.decode(test_case['magic_number'], 'hex_codec'))
+            else:
+                f_handler = BytesIO(codecs.decode(test_case['magic_number'], 'hex_codec'))
         elif content is not None:
-            f_handler = BytesIO(
-                json.dumps(content, sort_keys=True) if six.PY2 else json.dumps(content, sort_keys=True).encode('utf-8'))
+            f_handler = StringIO(json.dumps(content, sort_keys=True))
         else:
-            f_handler = BytesIO(b'')
+            f_handler = StringIO('')
 
         f_handler.content_type = test_case['mimetypes']
         f_handler.name = 'file' + test_case['suffixes']


### PR DESCRIPTION
Relevant JIRA issue can be found [here](https://openedx.atlassian.net/browse/BOM-926).
PR fixes the `bytes` output from `codecs` by adding `BytesIO` instead of `StringIO` from `six` for the specific case with minimum changes to the previous state (#21809 )