### PR TITLE
Add random2 to codejails

### DIFF
--- a/requirements/edx-sandbox/base.in
+++ b/requirements/edx-sandbox/base.in
@@ -13,6 +13,7 @@
 matplotlib==2.2.4                   # 2D plotting library
 numpy==1.7.2                        # Numeric array processing utilities; used by scipy
 pyparsing==2.2.0                    # Python Parsing module
+random2                             # Implementation of random module that works identically under Python 2 and 3
 scipy==0.14.0                       # Math, science, and engineering library
 sympy==0.7.1                        # Symbolic math library
 git+https://github.com/edx/openedx-calc.git@e9b698c85ad1152002bc0868f475f153dce88952#egg=calc==0.4

--- a/requirements/edx-sandbox/base.txt
+++ b/requirements/edx-sandbox/base.txt
@@ -6,7 +6,7 @@
 #
 common/lib/sandbox-packages
 common/lib/symmath
-asn1crypto==1.1.0
+asn1crypto==1.2.0
 backports.functools-lru-cache==1.5  # via matplotlib
 git+https://github.com/edx/openedx-calc.git@e9b698c85ad1152002bc0868f475f153dce88952#egg=calc==0.4
 cffi==1.13.0
@@ -26,6 +26,7 @@ pycparser==2.19
 pyparsing==2.2.0
 python-dateutil==2.8.0    # via matplotlib
 pytz==2019.3              # via matplotlib
+random2==1.0.1
 scipy==0.14.0
 singledispatch==3.4.0.3
 six==1.12.0

--- a/requirements/edx-sandbox/shared.txt
+++ b/requirements/edx-sandbox/shared.txt
@@ -4,7 +4,7 @@
 #
 #    make upgrade
 #
-asn1crypto==1.1.0         # via cryptography
+asn1crypto==1.2.0         # via cryptography
 cffi==1.13.0              # via cryptography
 cryptography==2.7
 enum34==1.1.6             # via cryptography

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -25,7 +25,7 @@ aniso8601==8.0.0          # via tincan
 anyjson==0.3.3            # via kombu
 appdirs==1.4.3            # via fs
 argh==0.26.2
-asn1crypto==1.1.0
+asn1crypto==1.2.0
 attrs==17.4.0
 babel==1.3
 backports.functools-lru-cache==1.5  # via soupsieve

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -28,7 +28,7 @@ apipkg==1.5
 appdirs==1.4.3
 argh==0.26.2
 argparse==1.4.0
-asn1crypto==1.1.0
+asn1crypto==1.2.0
 astroid==1.5.3
 atomicwrites==1.3.0
 attrs==17.4.0

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -27,7 +27,7 @@ apipkg==1.5               # via execnet
 appdirs==1.4.3
 argh==0.26.2
 argparse==1.4.0           # via caniusepython3
-asn1crypto==1.1.0
+asn1crypto==1.2.0
 astroid==1.5.3            # via pylint, pylint-celery
 atomicwrites==1.3.0       # via pytest
 attrs==17.4.0


### PR DESCRIPTION
This was added to the server dependencies, but not the codejail dependencies.  Fix this so it'll be installed in codejails.

The asn1crypto upgrade came along for the ride via `make upgrade`, but looks harmless.  It would have been included in tomorrow's dependencies update anyway.