### PR TITLE
BOM-928: Fixing test error due to dict ordering

### DIFF
--- a/common/lib/capa/capa/tests/test_inputtypes.py
+++ b/common/lib/capa/capa/tests/test_inputtypes.py
@@ -784,10 +784,16 @@ class MatlabTest(unittest.TestCase):
 
         output = self.the_input.get_html()
         output_string = etree.tostring(output).decode('utf-8')
-        self.assertRegex(output_string, "div.*mwAudioPlaceHolder")
-        self.assertRegex(output_string, "audio.*Audio is not supported.*audio")
-        self.assertRegex(output_string, "div.*Right click.*href.*media.*here.*click.*download.*div")
-        self.assertRegex(output_string, "div .*style=.*ul.*div")
+        if six.PY2:
+            self.assertRegexpMatches(output_string, "div.*mwAudioPlaceHolder")
+            self.assertRegexpMatches(output_string, "audio.*Audio is not supported.*audio")
+            self.assertRegexpMatches(output_string, "div.*Right click.*href.*media.*here.*click.*download.*div")
+            self.assertRegexpMatches(output_string, "div .*style=.*ul.*div")
+        else:
+            self.assertRegex(output_string, "div.*mwAudioPlaceHolder")
+            self.assertRegex(output_string, "audio.*Audio is not supported.*audio")
+            self.assertRegex(output_string, "div.*Right click.*href.*media.*here.*click.*download.*div")
+            self.assertRegex(output_string, "div .*style=.*ul.*div")
         # check that exception is raised during parsing for html.
         self.the_input.capa_system.render_template = lambda *args: "<aaa"
         with self.assertRaises(etree.XMLSyntaxError):

--- a/common/lib/capa/capa/tests/test_inputtypes.py
+++ b/common/lib/capa/capa/tests/test_inputtypes.py
@@ -754,7 +754,7 @@ class MatlabTest(unittest.TestCase):
         output_string = output_string.replace('<div>{', '')
         output_list = output_string.split(',')
         for index, value in enumerate(output_list):
-            output_list[index] = value.replace('u\'','\'').strip()
+            output_list[index] = value.replace('u\'', '\'').strip()
 
         expected_string = u"""
         \'matlab_editor_js\': \'/dummy-static/js/vendor/CodeMirror/octave.js\',
@@ -766,7 +766,7 @@ class MatlabTest(unittest.TestCase):
         \'describedby_html\': Markup(\'aria-describedby="status_prob_1_2"\')"""
         expected_list = (textwrap.dedent(expected_string).replace('\n', ' ').strip()).split(',')
         for index, value in enumerate(expected_list):
-            expected_list[index] = value.replace('u\'','\'').strip()
+            expected_list[index] = value.replace('u\'', '\'').strip()
         six.assertCountEqual(self, output_list, expected_list)
 
         # test html, that is correct HTML5 html, but is not parsable by XML parser.
@@ -790,11 +790,11 @@ class MatlabTest(unittest.TestCase):
         assert element_tags.count('audio') == 1
         audio_index = element_tags.index('audio')
 
-        six.assertCountEqual(self,element_keys[audio_index],['autobuffer', 'controls', 'autoplay', 'src'])
+        six.assertCountEqual(self, element_keys[audio_index], ['autobuffer', 'controls', 'autoplay', 'src'])
         self.assertEqual(elements[audio_index].get('src'), 'data:audio/wav;base64=')
         self.assertEqual(elements[audio_index].text, 'Audio is not supported on this browser.')
         href_index = element_keys.index(['href'])
-        self.assertEqual(elements[href_index].get('href'),'https://endpoint.mss-mathworks.com/media/filename.wav')
+        self.assertEqual(elements[href_index].get('href'), 'https://endpoint.mss-mathworks.com/media/filename.wav')
         id_index = element_keys.index(['id'])
         self.assertEqual(elements[id_index].get('id'), 'mwAudioPlaceHolder')
         output_string = etree.tostring(output).decode('utf-8')

--- a/common/lib/capa/capa/tests/test_inputtypes.py
+++ b/common/lib/capa/capa/tests/test_inputtypes.py
@@ -768,7 +768,10 @@ class MatlabTest(unittest.TestCase):
         expected_list = (textwrap.dedent(expected_string).replace('\n', ' ').strip()).split(',')
         for index, value in enumerate(expected_list):
             expected_list[index] = value.strip()
-        self.assertCountEqual(output_list,expected_list)
+        if six.PY2:
+            self.assertItemsEqual(output_list,expected_list)
+        else:
+            self.assertCountEqual(output_list,expected_list)
 
         # test html, that is correct HTML5 html, but is not parsable by XML parser.
         old_render_template = self.the_input.capa_system.render_template

--- a/common/lib/capa/capa/tests/test_inputtypes.py
+++ b/common/lib/capa/capa/tests/test_inputtypes.py
@@ -751,13 +751,13 @@ class MatlabTest(unittest.TestCase):
         output_string = etree.tostring(output).decode('utf-8')
         self.assertIn('}</div>', output_string)
         self.assertIn('<div>{', output_string)
-        output_string = output_string.replace('}</div>','')
-        output_string = output_string.replace('<div>{','')
+        output_string = output_string.replace('}</div>', '')
+        output_string = output_string.replace('<div>{',' ')
         output_list = output_string.split(',')
         for index, value in enumerate(output_list):
             output_list[index] = value.strip()
-        
-        expected_string = """
+
+        expected_string = u"""
         \'matlab_editor_js\': \'/dummy-static/js/vendor/CodeMirror/octave.js\',
         \'value\': \'print "good evening"\', \'hidden\': \'\',
         \'msg\': \'Submitted. As soon as a response is returned, this message will be replaced by that feedback.\',
@@ -769,9 +769,9 @@ class MatlabTest(unittest.TestCase):
         for index, value in enumerate(expected_list):
             expected_list[index] = value.strip()
         if six.PY2:
-            self.assertItemsEqual(output_list,expected_list)
+            self.assertItemsEqual(output_list, expected_list)
         else:
-            self.assertCountEqual(output_list,expected_list)
+            self.assertCountEqual(output_list, expected_list)
 
         # test html, that is correct HTML5 html, but is not parsable by XML parser.
         old_render_template = self.the_input.capa_system.render_template

--- a/common/lib/capa/capa/tests/test_inputtypes.py
+++ b/common/lib/capa/capa/tests/test_inputtypes.py
@@ -752,7 +752,7 @@ class MatlabTest(unittest.TestCase):
         self.assertIn('}</div>', output_string)
         self.assertIn('<div>{', output_string)
         output_string = output_string.replace('}</div>', '')
-        output_string = output_string.replace('<div>{',' ')
+        output_string = output_string.replace('<div>{', '')
         output_list = output_string.split(',')
         for index, value in enumerate(output_list):
             output_list[index] = value.strip()
@@ -760,11 +760,11 @@ class MatlabTest(unittest.TestCase):
         expected_string = u"""
         \'matlab_editor_js\': \'/dummy-static/js/vendor/CodeMirror/octave.js\',
         \'value\': \'print "good evening"\', \'hidden\': \'\',
-        \'msg\': \'Submitted. As soon as a response is returned, this message will be replaced by that feedback.\',
+        \'msg\': u\'Submitted. As soon as a response is returned, this message will be replaced by that feedback.\',
         \'status\': Status(\'queued\'), \'response_data\': {}, \'queue_msg\': \'\', \'mode\': \'\',
         \'id\': \'prob_1_2\', \'queue_len\': \'3\', \'tabsize\': 4, \'STATIC_URL\': \'/dummy-static/\',
         \'linenumbers\': \'true\', \'cols\': \'80\', \'button_enabled\': True, \'rows\': \'10\',
-        \'describedby_html\': Markup(\'aria-describedby="status_prob_1_2"\')"""
+        \'describedby_html\': Markup(u\'aria-describedby="status_prob_1_2"\')"""
         expected_list = (textwrap.dedent(expected_string).replace('\n', ' ').strip()).split(',')
         for index, value in enumerate(expected_list):
             expected_list[index] = value.strip()

--- a/common/lib/capa/capa/tests/test_inputtypes.py
+++ b/common/lib/capa/capa/tests/test_inputtypes.py
@@ -799,10 +799,6 @@ class MatlabTest(unittest.TestCase):
         self.assertEqual(elements[id_index].get('id'), 'mwAudioPlaceHolder')
         output_string = etree.tostring(output).decode('utf-8')
 
-        six.assertRegex(self, output_string, "div.*mwAudioPlaceHolder")
-        six.assertRegex(self, output_string, "audio.*Audio is not supported.*audio")
-        six.assertRegex(self, output_string, "div.*Right click.*href.*media.*here.*click.*download.*div")
-        six.assertRegex(self, output_string, "div .*style=.*ul.*div")
         # check that exception is raised during parsing for html.
         self.the_input.capa_system.render_template = lambda *args: "<aaa"
         with self.assertRaises(etree.XMLSyntaxError):

--- a/common/lib/xmodule/xmodule/tests/test_xml_module.py
+++ b/common/lib/xmodule/xmodule/tests/test_xml_module.py
@@ -382,7 +382,8 @@ class TestSerialize(unittest.TestCase):
         assert serialize_field('false') == 'false'
         assert serialize_field('fAlse') == 'fAlse'
         assert serialize_field('hat box') == 'hat box'
-        assert serialize_field({'bar': 'hat', 'frog': 'green'}) == '{"bar": "hat", "frog": "green"}'
+        serialized_dict = serialize_field({'bar': 'hat', 'frog': 'green'})
+        assert serialized_dict == '{"bar": "hat", "frog": "green"}' or serialized_dict == '{"frog": "green", "bar": "hat"}'
         assert serialize_field([3.5, 5.6]) == '[3.5, 5.6]'
         assert serialize_field(['foo', 'bar']) == '["foo", "bar"]'
         assert serialize_field("2012-12-31T23:59:59Z") == '2012-12-31T23:59:59Z'

--- a/common/lib/xmodule/xmodule/video_module/video_module.py
+++ b/common/lib/xmodule/xmodule/video_module/video_module.py
@@ -669,30 +669,30 @@ class VideoBlock(
         if youtube_string and youtube_string != '1.00:3_yD_cEKoCk':
             xml.set('youtube', six.text_type(youtube_string))
         xml.set('url_name', self.url_name)
-        attrs = {
-            'display_name': self.display_name,
-            'show_captions': json.dumps(self.show_captions),
-            'start_time': self.start_time,
-            'end_time': self.end_time,
-            'sub': self.sub,
-            'download_track': json.dumps(self.download_track),
-            'download_video': json.dumps(self.download_video),
-        }
-        for key, value in attrs.items():
+        attrs = [
+            ('display_name', self.display_name),
+            ('show_captions', json.dumps(self.show_captions)),
+            ('start_time', self.start_time),
+            ('end_time', self.end_time),
+            ('sub', self.sub),
+            ('download_track', json.dumps(self.download_track)),
+            ('download_video', json.dumps(self.download_video))
+        ]
+        for attr in attrs:
             # Mild workaround to ensure that tests pass -- if a field
             # is set to its default value, we don't write it out.
-            if value:
-                if key in self.fields and self.fields[key].is_set_on(self):
+            if attr[1]:
+                if attr[0] in self.fields and self.fields[attr[0]].is_set_on(self):
                     try:
-                        xml.set(key, six.text_type(value))
+                        xml.set(attr[0], six.text_type(attr[1]))
                     except UnicodeDecodeError:
-                        exception_message = format_xml_exception_message(self.location, key, value)
+                        exception_message = format_xml_exception_message(self.location, attr[0], attr[1])
                         log.exception(exception_message)
                         # If exception is UnicodeDecodeError set value using unicode 'utf-8' scheme.
                         log.info("Setting xml value using 'utf-8' scheme.")
-                        xml.set(key, six.text_type(value, 'utf-8'))
+                        xml.set(attr[0], six.text_type(attr[1], 'utf-8'))
                     except ValueError:
-                        exception_message = format_xml_exception_message(self.location, key, value)
+                        exception_message = format_xml_exception_message(self.location, attr[0], attr[1])
                         log.exception(exception_message)
                         raise
 

--- a/common/lib/xmodule/xmodule/video_module/video_module.py
+++ b/common/lib/xmodule/xmodule/video_module/video_module.py
@@ -678,21 +678,21 @@ class VideoBlock(
             ('download_track', json.dumps(self.download_track)),
             ('download_video', json.dumps(self.download_video))
         ]
-        for attr in attrs:
+        for key, value in attrs:
             # Mild workaround to ensure that tests pass -- if a field
             # is set to its default value, we don't write it out.
-            if attr[1]:
-                if attr[0] in self.fields and self.fields[attr[0]].is_set_on(self):
+            if value:
+                if key in self.fields and self.fields[key].is_set_on(self):
                     try:
-                        xml.set(attr[0], six.text_type(attr[1]))
+                        xml.set(key, six.text_type(value))
                     except UnicodeDecodeError:
-                        exception_message = format_xml_exception_message(self.location, attr[0], attr[1])
+                        exception_message = format_xml_exception_message(self.location, key, value)
                         log.exception(exception_message)
                         # If exception is UnicodeDecodeError set value using unicode 'utf-8' scheme.
                         log.info("Setting xml value using 'utf-8' scheme.")
-                        xml.set(attr[0], six.text_type(attr[1], 'utf-8'))
+                        xml.set(key, six.text_type(value, 'utf-8'))
                     except ValueError:
-                        exception_message = format_xml_exception_message(self.location, attr[0], attr[1])
+                        exception_message = format_xml_exception_message(self.location, key, value)
                         log.exception(exception_message)
                         raise
 


### PR DESCRIPTION
Fixing test that checks correct html creation. It was failing due to diff dict order under python3.