### PR TITLE
Fix YouTube stub under Python 3 BOM-930

### DIFF
--- a/common/djangoapps/terrain/stubs/youtube.py
+++ b/common/djangoapps/terrain/stubs/youtube.py
@@ -105,7 +105,7 @@ class StubYouTubeHandler(StubHttpRequestHandler):
                 # We need to do this every time because Google sometimes sends different responses
                 # as part of their own experiments, which has caused our tests to become "flaky"
                 self.log_message("Getting iframe api from youtube.com")
-                iframe_api_response = requests.get('https://www.youtube.com/iframe_api').content.strip("\n")
+                iframe_api_response = requests.get('https://www.youtube.com/iframe_api').content.strip(b"\n")
                 self.send_response(200, content=iframe_api_response, headers={'Content-type': 'text/html'})
 
         else:


### PR DESCRIPTION
The response content consists of bytes, so the `strip()` argument must be also.  Should fix many of the bok-choy test failures under Python 3.