### PR TITLE
BOM-931: explicitly setting strings to unicode

### DIFF
--- a/common/test/acceptance/tests/video/test_studio_video_editor.py
+++ b/common/test/acceptance/tests/video/test_studio_video_editor.py
@@ -447,8 +447,8 @@ class VideoEditorTest(CMSVideoBaseTest):
         self._create_video_component()
 
         langs_info = [
-            ('zh_HANS', 'simplified_chinese.srt', '在线学习是革'),
-            ('zh_HANT', 'traditional_chinese.srt', '在線學習是革')
+            ('zh_HANS', 'simplified_chinese.srt', u'在线学习是革'),
+            ('zh_HANT', 'traditional_chinese.srt', u'在線學習是革')
         ]
 
         for lang_code, lang_file, lang_text in langs_info:

--- a/common/test/acceptance/tests/video/test_studio_video_editor.py
+++ b/common/test/acceptance/tests/video/test_studio_video_editor.py
@@ -101,7 +101,7 @@ class VideoEditorTest(CMSVideoBaseTest):
         self.video.upload_translation('chinese_transcripts.srt', 'zh')
         self.save_unit_settings()
         self.assertTrue(self.video.is_captions_visible())
-        unicode_text = "好 各位同学".decode('utf-8')
+        unicode_text = u"好 各位同学"
         self.assertIn(unicode_text, self.video.captions_text)
         self.edit_component()
         self.open_advanced_tab()
@@ -150,7 +150,7 @@ class VideoEditorTest(CMSVideoBaseTest):
         self.video.upload_translation('1mb_transcripts.srt', 'uk')
         self.save_unit_settings()
         self.video.wait_for(self.video.is_captions_visible, 'Captions are visible', timeout=10)
-        unicode_text = "Привіт, edX вітає вас.".decode('utf-8')
+        unicode_text = u"Привіт, edX вітає вас."
         self.assertIn(unicode_text, self.video.captions_lines())
 
     def test_translations_download_works_w_saving(self):
@@ -181,9 +181,9 @@ class VideoEditorTest(CMSVideoBaseTest):
         self.open_advanced_tab()
         self.assertEqual(self.video.translations(), ['zh', 'uk'])
         self.assertEqual(list(self.video.caption_languages.keys()), ['zh', 'uk'])
-        zh_unicode_text = "好 各位同学".decode('utf-8')
+        zh_unicode_text = u"好 各位同学"
         self.assertTrue(self.video.download_translation('zh', zh_unicode_text))
-        uk_unicode_text = "Привіт, edX вітає вас.".decode('utf-8')
+        uk_unicode_text = u"Привіт, edX вітає вас."
         self.assertTrue(self.video.download_translation('uk', uk_unicode_text))
 
     def test_translations_download_works_wo_saving(self):
@@ -204,9 +204,9 @@ class VideoEditorTest(CMSVideoBaseTest):
         self.open_advanced_tab()
         self.video.upload_translation('uk_transcripts.srt', 'uk')
         self.video.upload_translation('chinese_transcripts.srt', 'zh')
-        zh_unicode_text = "好 各位同学".decode('utf-8')
+        zh_unicode_text = u"好 各位同学"
         self.assertTrue(self.video.download_translation('zh', zh_unicode_text))
-        uk_unicode_text = "Привіт, edX вітає вас.".decode('utf-8')
+        uk_unicode_text = u"Привіт, edX вітає вас."
         self.assertTrue(self.video.download_translation('uk', uk_unicode_text))
 
     def test_translations_remove_works_wo_saving(self):
@@ -293,7 +293,7 @@ class VideoEditorTest(CMSVideoBaseTest):
         self.video.upload_translation('chinese_transcripts.srt', 'zh')
         self.save_unit_settings()
         self.assertTrue(self.video.is_captions_visible())
-        unicode_text = "好 各位同学".decode('utf-8')
+        unicode_text = u"好 各位同学"
         self.assertIn(unicode_text, self.video.captions_text)
         self.edit_component()
         self.open_advanced_tab()
@@ -301,7 +301,7 @@ class VideoEditorTest(CMSVideoBaseTest):
         self.video.replace_translation('zh', 'uk', 'uk_transcripts.srt')
         self.save_unit_settings()
         self.assertTrue(self.video.is_captions_visible())
-        unicode_text = "Привіт, edX вітає вас.".decode('utf-8')
+        unicode_text = u"Привіт, edX вітає вас."
         self.assertIn(unicode_text, self.video.captions_text)
 
     def test_replace_translation_wo_save(self):
@@ -325,7 +325,7 @@ class VideoEditorTest(CMSVideoBaseTest):
         self.video.replace_translation('zh', 'uk', 'uk_transcripts.srt')
         self.save_unit_settings()
         self.assertTrue(self.video.is_captions_visible())
-        unicode_text = "Привіт, edX вітає вас.".decode('utf-8')
+        unicode_text = u"Привіт, edX вітає вас."
         self.assertIn(unicode_text, self.video.captions_text)
 
     def test_translation_upload_remove_upload(self):
@@ -352,7 +352,7 @@ class VideoEditorTest(CMSVideoBaseTest):
         self.video.upload_translation('uk_transcripts.srt', 'zh')
         self.save_unit_settings()
         self.assertTrue(self.video.is_captions_visible())
-        unicode_text = "Привіт, edX вітає вас.".decode('utf-8')
+        unicode_text = u"Привіт, edX вітає вас."
         self.assertIn(unicode_text, self.video.captions_text)
 
     def test_select_language_twice(self):
@@ -397,7 +397,7 @@ class VideoEditorTest(CMSVideoBaseTest):
         self.video.upload_translation('chinese_transcripts.srt', 'ab')
         self.save_unit_settings()
         self.assertTrue(self.video.is_captions_visible())
-        unicode_text = "好 各位同学".decode('utf-8')
+        unicode_text = u"好 各位同学"
         self.assertIn(unicode_text, self.video.captions_text)
         self.assertEqual(list(self.video.caption_languages.keys()), [u'ab', u'uk'])
         self.assertEqual(list(self.video.caption_languages.keys())[0], 'ab')
@@ -419,7 +419,7 @@ class VideoEditorTest(CMSVideoBaseTest):
         self.video.upload_translation('chinese_transcripts_with_BOM.srt', 'zh')
         self.save_unit_settings()
         self.assertTrue(self.video.is_captions_visible())
-        unicode_text = "莎拉·佩林 (Sarah Palin)".decode('utf-8')
+        unicode_text = u"莎拉·佩林 (Sarah Palin)"
         self.assertIn(unicode_text, self.video.captions_lines())
 
     def test_simplified_and_traditional_chinese_transcripts_uploading(self):
@@ -458,9 +458,9 @@ class VideoEditorTest(CMSVideoBaseTest):
             self.save_unit_settings()
             self.assertTrue(self.video.is_captions_visible())
             # If there is only one language then there will be no subtitle/captions menu
-            if lang_code == 'zh_HANT':
+            if lang_code == u'zh_HANT':
                 self.video.select_language(lang_code)
-            unicode_text = lang_text.decode('utf-8')
+            unicode_text = lang_text
             self.assertIn(unicode_text, self.video.captions_text)
 
         self.assertEqual(self.video.caption_languages, {'zh_HANS': 'Simplified Chinese', 'zh_HANT': 'Traditional Chinese'})

--- a/common/test/acceptance/tests/video/test_video_module.py
+++ b/common/test/acceptance/tests/video/test_video_module.py
@@ -248,7 +248,7 @@ class YouTubeVideoTest(VideoBaseTest):
         self.video.show_captions()
 
         # Verify that we see "好 各位同学" text in the transcript
-        unicode_text = "好 各位同学".decode('utf-8')
+        unicode_text = u"好 各位同学"
         self.assertIn(unicode_text, self.video.captions_text)
 
     def test_cc_button(self):
@@ -333,7 +333,7 @@ class YouTubeVideoTest(VideoBaseTest):
         self.navigate_to_video()
 
         # check if we can download transcript in "srt" format that has text "好 各位同学"
-        unicode_text = "好 各位同学".decode('utf-8')
+        unicode_text = u"好 各位同学"
         self.assertTrue(self.video.downloaded_transcript_contains_text('srt', unicode_text))
 
     def test_download_button_two_transcript_languages(self):
@@ -364,11 +364,11 @@ class YouTubeVideoTest(VideoBaseTest):
         self.assertTrue(self.video.select_language('zh'))
 
         # check if we see "好 各位同学" text in the captions
-        unicode_text = "好 各位同学".decode('utf-8')
+        unicode_text = u"好 各位同学"
         self.assertIn(unicode_text, self.video.captions_text)
 
         # check if we can download transcript in "srt" format that has text "好 各位同学"
-        unicode_text = "好 各位同学".decode('utf-8')
+        unicode_text = u"好 各位同学"
         self.assertTrue(self.video.downloaded_transcript_contains_text('srt', unicode_text))
 
     def test_fullscreen_video_alignment_on_transcript_toggle(self):
@@ -600,7 +600,7 @@ class YouTubeVideoTest(VideoBaseTest):
         self._verify_closed_caption_text('Welcome to edX.')
 
         self.video.select_language('zh')
-        unicode_text = "我们今天要讲的题目是".decode('utf-8')
+        unicode_text = u"我们今天要讲的题目是"
         self.video.click_transcript_line(line_no=1)
         self._verify_closed_caption_text(unicode_text)
 
@@ -752,11 +752,10 @@ class YouTubeVideoTest(VideoBaseTest):
         self.assets.extend(['simplified_chinese.srt', 'traditional_chinese.srt'])
         self.navigate_to_video()
 
-        langs = {'zh_HANS': '在线学习是革', 'zh_HANT': '在線學習是革'}
-        for lang_code, text in langs.items():
+        langs = {'zh_HANS': u'在线学习是革', 'zh_HANT': u'在線學習是革'}
+        for lang_code, unicode_text in langs.items():
             self.video.scroll_to_button("transcript_button")
             self.assertTrue(self.video.select_language(lang_code))
-            unicode_text = text.decode('utf-8')
             self.assertIn(unicode_text, self.video.captions_text)
             self.assertTrue(self.video.downloaded_transcript_contains_text('srt', unicode_text))
 
@@ -836,11 +835,11 @@ class Html5VideoTest(VideoBaseTest):
         self.navigate_to_video()
 
         # check if we see "好 各位同学" text in the captions
-        unicode_text = "好 各位同学".decode('utf-8')
+        unicode_text = u"好 各位同学"
         self.assertIn(unicode_text, self.video.captions_text)
 
         # check if we can download transcript in "srt" format that has text "好 各位同学"
-        unicode_text = "好 各位同学".decode('utf-8')
+        unicode_text = u"好 各位同学"
         self.assertTrue(self.video.downloaded_transcript_contains_text('srt', unicode_text))
 
     def test_download_button_two_transcript_languages(self):
@@ -873,12 +872,12 @@ class Html5VideoTest(VideoBaseTest):
         self.assertTrue(self.video.select_language('zh'))
 
         # check if we see "好 各位同学" text in the captions
-        unicode_text = "好 各位同学".decode('utf-8')
+        unicode_text = u"好 各位同学"
 
         self.assertIn(unicode_text, self.video.captions_text)
 
         # Then I can download transcript in "srt" format that has text "好 各位同学"
-        unicode_text = "好 各位同学".decode('utf-8')
+        unicode_text = u"好 各位同学"
         self.assertTrue(self.video.downloaded_transcript_contains_text('srt', unicode_text))
 
     def test_cc_button_with_english_transcript(self):
@@ -921,7 +920,7 @@ class Html5VideoTest(VideoBaseTest):
         self.video.show_captions()
 
         # check if we see "好 各位同学" text in the captions
-        unicode_text = "好 各位同学".decode('utf-8')
+        unicode_text = u"好 各位同学"
         self.assertIn(unicode_text, self.video.captions_text)
 
     def test_video_rendering(self):


### PR DESCRIPTION
Instead of calling decode on strings, this PR explicity sets those strings to unicode by using the 'u' prefix.