### PR TITLE
Create a custom Pickle Serializer

### DIFF
--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -829,6 +829,7 @@ COURSES_WITH_UNSAFE_CODE = []
 DEBUG = False
 SESSION_COOKIE_SECURE = False
 SESSION_SAVE_EVERY_REQUEST = False
+SESSION_SERIALIZER = 'openedx.core.lib.session_serializers.PickleV2Serializer'
 SESSION_COOKIE_DOMAIN = ""
 SESSION_COOKIE_NAME = 'sessionid'
 

--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -829,7 +829,6 @@ COURSES_WITH_UNSAFE_CODE = []
 DEBUG = False
 SESSION_COOKIE_SECURE = False
 SESSION_SAVE_EVERY_REQUEST = False
-SESSION_SERIALIZER = 'django.contrib.sessions.serializers.PickleSerializer'
 SESSION_COOKIE_DOMAIN = ""
 SESSION_COOKIE_NAME = 'sessionid'
 

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -1101,7 +1101,6 @@ DEBUG = False
 USE_TZ = True
 SESSION_COOKIE_SECURE = False
 SESSION_SAVE_EVERY_REQUEST = False
-SESSION_SERIALIZER = 'django.contrib.sessions.serializers.PickleSerializer'
 SESSION_COOKIE_DOMAIN = ""
 SESSION_COOKIE_NAME = 'sessionid'
 

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -1101,6 +1101,7 @@ DEBUG = False
 USE_TZ = True
 SESSION_COOKIE_SECURE = False
 SESSION_SAVE_EVERY_REQUEST = False
+SESSION_SERIALIZER = 'openedx.core.lib.session_serializers.PickleV2Serializer'
 SESSION_COOKIE_DOMAIN = ""
 SESSION_COOKIE_NAME = 'sessionid'
 

--- a/openedx/core/lib/session_serializers.py
+++ b/openedx/core/lib/session_serializers.py
@@ -1,0 +1,37 @@
+"""
+Custom session serializer to deal with going from python2 and python3.
+"""
+import pickle
+import six
+
+
+class PickleV2Serializer(object):
+    """
+    Lock the pickle serializer to version 2 of the protocol
+    because we don't want python 2 to be able to read session
+    data written by python3 while both are running at the same
+    time in production.
+
+    Based on the PickleSerializer built into django:
+    https://github.com/django/django/blob/master/django/contrib/sessions/serializers.py
+    """
+
+    protocol = 2
+
+    def dumps(self, obj):
+        """
+        Return a pickled representation of object.
+        """
+        return pickle.dumps(obj, self.protocol)
+
+    def loads(self, data):
+        """
+        Return a python object from pickled data.
+        """
+        if six.PY2:
+            # Params used below don't exist in python 2
+            return pickle.loads(data)
+        else:
+            # See notes here about pickling python2 objects in python3
+            # https://docs.python.org/3/library/pickle.html#pickle.Unpickler
+            return pickle.loads(data, encoding='latin1')  # pylint: disable=unexpected-keyword-arg


### PR DESCRIPTION
We need to do this because when I tride to go to the JSON serializer a
bunch of tests started failing because various parts of our code are
putting things into the session that are not JSON serializable.

We can't keep using the default pickle serializer because it defaluts to
using the highest available protocol and that will cause issues with the
python 2 to 3 upgrade since both will be running in production at the
same time.  We need to use a version of the pickle protocol that both
can use interchangably.

We also need to make sure we read with latin1 encoding to make datetimes
work correctly between the two versions of python.
### Please consider the following when opening a pull request:

- Link to the relevant JIRA ticket(s) and tag any relevant team(s).
- Squash your changes down into one or more discrete commits.
  In each commit, include description that could help a developer
  several months from now.
- If running `make upgrade`, run _as close to the time of merging as possible_
  to avoid accidentally downgrading someone else's package.
  Put the output of `make upgrade` in its own separate commit,
  decoupled from other code changes.
- Aim for comprehensive test coverage, but remember that
  automated testing isn't a substitute for manual verification.
- Carefully consider naming, code organization, dependencies when adding new code.
  Code that is amenable to refactoring and improvement benefits all platform developers,
  especially given the size and scope of edx-platform.
  Consult existing Architectural Decision Records (ADRs),
  including those concerning the app(s) you are changing and
  [those concerning edx-platform as a whole](https://github.com/edx/edx-platform/tree/master/docs/decisions).
