### PR TITLE
Archive bok-choy JUnit XML files

### DIFF
--- a/scripts/Jenkinsfiles/bokchoy
+++ b/scripts/Jenkinsfiles/bokchoy
@@ -19,7 +19,7 @@ def runBokchoyTests() {
 }
 
 def bokchoyTestCleanup() {
-    archiveArtifacts allowEmptyArchive: true, artifacts: 'reports/bok_choy/*.coverage*,test_root/log/**/*.log,test_root/log/**/*.png'
+    archiveArtifacts allowEmptyArchive: true, artifacts: 'reports/bok_choy/*.coverage*,test_root/log/**/*.log,test_root/log/**/*.png,reports/bok_choy/**/xunit.xml'
     junit '**/reports/bok_choy/**/xunit.xml'
     sendSplunkFile excludes: '', includes: '**/timing*.log', sizeLimit: '10MB'
 }


### PR DESCRIPTION
Archive the JUnit XML files generated during bok-choy test runs on Jenkins so they can be used with the `summarize_test_results.py` script in `edx-tools`.