### PR TITLE
Fixing python3 ordering issue in acceptance tests.

### DIFF
--- a/common/test/acceptance/tests/lms/test_account_settings.py
+++ b/common/test/acceptance/tests/lms/test_account_settings.py
@@ -195,11 +195,11 @@ class AccountSettingsPageTest(AccountSettingsTestMixin, AcceptanceTest):
             },
             {
                 'title': 'Social Media Links',
-                'fields': [
+                'fields': sorted([
                     'Twitter Link',
                     'Facebook Link',
                     'LinkedIn Link',
-                ]
+                ])
             },
             {
                 'title': 'Delete My Account',
@@ -207,7 +207,9 @@ class AccountSettingsPageTest(AccountSettingsTestMixin, AcceptanceTest):
             },
         ]
 
-        self.assertEqual(self.account_settings_page.sections_structure(), expected_sections_structure)
+        sections_structure = self.account_settings_page.sections_structure()
+        sections_structure[2]['fields'] = sorted(sections_structure[2]['fields'])
+        self.assertEqual(sections_structure, expected_sections_structure)
 
     def _test_readonly_field(self, field_id, title, value):
         """

--- a/common/test/acceptance/tests/lms/test_learner_profile.py
+++ b/common/test/acceptance/tests/lms/test_learner_profile.py
@@ -491,10 +491,22 @@ class OwnLearnerProfilePageTest(LearnerProfileTestMixin, AcceptanceTest):
         self.assert_default_image_has_public_access(profile_page)
 
         profile_page.upload_file(filename='generic_csv.csv')
-        self.assertEqual(
-            profile_page.profile_image_message,
-            "The file must be one of the following types: .gif, .png, .jpeg, .jpg."
+        self.assertIn(
+            "The file must be one of the following types:", profile_page.profile_image_message,
         )
+        self.assertIn(
+            ".png", profile_page.profile_image_message,
+        )
+        self.assertIn(
+            ".gif", profile_page.profile_image_message,
+        )
+        self.assertIn(
+            ".jpeg", profile_page.profile_image_message,
+        )
+        self.assertIn(
+            ".jpg", profile_page.profile_image_message,
+        )
+
         profile_page.visit()
         self.assertTrue(profile_page.profile_has_default_image)
 

--- a/common/test/acceptance/tests/video/test_studio_video_editor.py
+++ b/common/test/acceptance/tests/video/test_studio_video_editor.py
@@ -179,8 +179,8 @@ class VideoEditorTest(CMSVideoBaseTest):
         self.save_unit_settings()
         self.edit_component()
         self.open_advanced_tab()
-        self.assertEqual(self.video.translations(), ['zh', 'uk'])
-        self.assertEqual(list(self.video.caption_languages.keys()), ['zh', 'uk'])
+        self.assertEqual(sorted(self.video.translations()), sorted(['zh', 'uk']))
+        self.assertEqual(sorted(list(self.video.caption_languages.keys())), sorted(['zh', 'uk']))
         zh_unicode_text = u"好 各位同学"
         self.assertTrue(self.video.download_translation('zh', zh_unicode_text))
         uk_unicode_text = u"Привіт, edX вітає вас."
@@ -399,8 +399,8 @@ class VideoEditorTest(CMSVideoBaseTest):
         self.assertTrue(self.video.is_captions_visible())
         unicode_text = u"好 各位同学"
         self.assertIn(unicode_text, self.video.captions_text)
-        self.assertEqual(list(self.video.caption_languages.keys()), [u'ab', u'uk'])
-        self.assertEqual(list(self.video.caption_languages.keys())[0], 'ab')
+        self.assertEqual(sorted(list(self.video.caption_languages.keys())), sorted([u'ab', u'uk']))
+        self.assertEqual(sorted(list(self.video.caption_languages.keys()))[0], 'ab')
 
     def test_upload_transcript_with_BOM(self):
         """


### PR DESCRIPTION
Tests failing due the list order issues.
https://openedx.atlassian.net/browse/BOM-935

### Please consider the following when opening a pull request:

- Link to the relevant JIRA ticket(s) and tag any relevant team(s).
- Squash your changes down into one or more discrete commits.
  In each commit, include description that could help a developer
  several months from now.
- If running `make upgrade`, run _as close to the time of merging as possible_
  to avoid accidentally downgrading someone else's package.
  Put the output of `make upgrade` in its own separate commit,
  decoupled from other code changes.
- Aim for comprehensive test coverage, but remember that
  automated testing isn't a substitute for manual verification.
- Carefully consider naming, code organization, dependencies when adding new code.
  Code that is amenable to refactoring and improvement benefits all platform developers,
  especially given the size and scope of edx-platform.
  Consult existing Architectural Decision Records (ADRs),
  including those concerning the app(s) you are changing and
  [those concerning edx-platform as a whole](https://github.com/edx/edx-platform/tree/master/docs/decisions).
