### PR TITLE
Show Display Name advanced field again

### DIFF
--- a/common/lib/xmodule/xmodule/course_module.py
+++ b/common/lib/xmodule/xmodule/course_module.py
@@ -334,7 +334,6 @@ class CourseFields(object):
         default="Empty",
         display_name=_("Course Display Name"),
         scope=Scope.settings,
-        hide_on_enabled_publisher=True
     )
     course_edit_method = String(
         display_name=_("Course Editor"),


### PR DESCRIPTION
We had hidden it when using Publisher. But there are valid use cases for editing it, so we're adding it back again.

https://openedx.atlassian.net/browse/DISCO-1390