### PR TITLE
Updated the social link creation to return social links sorted - BOM-958

### DIFF
--- a/common/test/acceptance/pages/lms/fields.py
+++ b/common/test/acceptance/pages/lms/fields.py
@@ -4,6 +4,7 @@ Mixins for fields.
 """
 from __future__ import absolute_import
 
+import six
 from bok_choy.promise import EmptyPromise
 
 from common.test.acceptance.tests.helpers import get_selected_option_text, select_option_by_text
@@ -69,9 +70,9 @@ class FieldsMixin(object):
         Return the title of a field.
         """
         self.wait_for_field(field_id)
-
-        query = self.q(css=u'.u-field-{} .u-field-title'.format(field_id))
-        return query.text[0] if query.present else None
+        # pylint: disable=unicode-format-string
+        query = self.q(css=six.u('.u-field-{} .u-field-title').format(field_id))
+        return sorted(query.text)[0] if query.present else None
 
     def message_for_field(self, field_id):
         """

--- a/common/test/acceptance/tests/lms/test_account_settings.py
+++ b/common/test/acceptance/tests/lms/test_account_settings.py
@@ -407,11 +407,11 @@ class AccountSettingsPageTest(AccountSettingsTestMixin, AcceptanceTest):
         Test behaviour of one of the social media links field.
         """
         self._test_text_field(
-            u'social_links',
-            u'Twitter Link',
+            six.u('social_links'),
+            six.u('Facebook Link'),
             self.social_link,
-            u'www.google.com/invalidlink',
-            [u'https://www.twitter.com/edX', self.social_link],
+            six.u('www.google.com/invalidlink)'),
+            [six.u('https://www.twitter.com/edX'), self.social_link],
         )
 
     def test_linked_accounts(self):


### PR DESCRIPTION
Relevant JIRA issue can found [here](https://openedx.atlassian.net/browse/BOM-958).

Updated the `title_for_field` method to return the generated social links sorted for consistency and updated the relevant test accordingly.