### PR TITLE
Fixes for type mismatches in the announcements migrations | BOM-984

### DIFF
--- a/openedx/features/announcements/migrations/0001_initial.py
+++ b/openedx/features/announcements/migrations/0001_initial.py
@@ -14,7 +14,7 @@ class Migration(migrations.Migration):
             name='Announcement',
             fields=[
                 ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
-                ('content', models.CharField(default=b'lorem ipsum', max_length=1000)),
+                ('content', models.CharField(default='lorem ipsum', max_length=1000)),
                 ('active', models.BooleanField(default=True)),
             ],
         ),


### PR DESCRIPTION
Recommendation from a Django developer is to edit any legacy migrations files (such as 0001_initial) that contain (Python 3) bytes literals, removing the b and making them string-literals in Python 3.

Editing migrations to fix this issue is safe.


### Please consider the following when opening a pull request:

- Link to the relevant JIRA ticket(s) and tag any relevant team(s).
- Squash your changes down into one or more discrete commits.
  In each commit, include description that could help a developer
  several months from now.
- If running `make upgrade`, run _as close to the time of merging as possible_
  to avoid accidentally downgrading someone else's package.
  Put the output of `make upgrade` in its own separate commit,
  decoupled from other code changes.
- Aim for comprehensive test coverage, but remember that
  automated testing isn't a substitute for manual verification.
- Carefully consider naming, code organization, dependencies when adding new code.
  Code that is amenable to refactoring and improvement benefits all platform developers,
  especially given the size and scope of edx-platform.
  Consult existing Architectural Decision Records (ADRs),
  including those concerning the app(s) you are changing and
  [those concerning edx-platform as a whole](https://github.com/edx/edx-platform/tree/master/docs/decisions).
