### PR TITLE
Improve logging against Problem grade report

### DIFF
--- a/lms/djangoapps/instructor_task/tasks_helper/runner.py
+++ b/lms/djangoapps/instructor_task/tasks_helper/runner.py
@@ -32,6 +32,19 @@ class TaskProgress(object):
         self.failed = 0
         self.preassigned = 0
 
+    @property
+    def state(self):
+        return {
+            'action_name': self.action_name,
+            'attempted': self.attempted,
+            'succeeded': self.succeeded,
+            'skipped': self.skipped,
+            'failed': self.failed,
+            'total': self.total,
+            'preassigned': self.preassigned,
+            'duration_ms': int((time() - self.start_time) * 1000),
+        }
+
     def update_task_state(self, extra_meta=None):
         """
         Update the current celery task's state to the progress state
@@ -45,16 +58,7 @@ class TaskProgress(object):
         Returns:
             dict: The current task's progress dict
         """
-        progress_dict = {
-            'action_name': self.action_name,
-            'attempted': self.attempted,
-            'succeeded': self.succeeded,
-            'skipped': self.skipped,
-            'failed': self.failed,
-            'total': self.total,
-            'preassigned': self.preassigned,
-            'duration_ms': int((time() - self.start_time) * 1000),
-        }
+        progress_dict = self.state
         if extra_meta is not None:
             progress_dict.update(extra_meta)
         _get_current_task().update_state(state=PROGRESS, meta=progress_dict)


### PR DESCRIPTION
This PR logs information on Splunk when Problem Grade task is running. It is important to know the progress of the task for bigger courses (wrt enrollment and graded content). 
There was an existing interval of 100 which I left as is, but I am happy to discuss if someone has other thoughts about that. 


Example logs. 
**In Progress Logs**
> 2019-10-22 11:37:27,219 INFO 1263 [edx.celery.task] [user 9] grades.py:524 - Task: 9dff97a2-5c78-45e5-8a4e-b930323dc48e, InstructorTask ID: 4, Course: course-v1:edX+DemoX+Demo_Course, Input: {}, Task type: problem distribution graded, Calculating Grades, {'preassigned': 0, 'failed': 0, 'step': 'Calculating Grades 100/400', 'skipped': 0, 'succeeded': 100, 'duration_ms': 63247, 'attempted': 100, 'total': 400, 'action_name': 'problem distribution graded'}

**In Progress Logs**
> 2019-10-22 11:37:27,219 INFO 1263 [edx.celery.task] [user 9] grades.py:524 - Task: 9dff97a2-5c78-45e5-8a4e-b930323dc48e, InstructorTask ID: 4, Course: course-v1:edX+DemoX+Demo_Course, Input: {}, Task type: problem distribution graded, Calculating Grades 200/400, {'preassigned': 0, 'failed': 0, 'step': 'Calculating Grades', 'skipped': 0, 'succeeded': 200, 'duration_ms': 63347, 'attempted': 200, 'total': 400, 'action_name': 'problem distribution graded'}

I just added in-progress logs, the rest of the logs triggers as they were. 

[PROD-826](https://openedx.atlassian.net/browse/PROD-826)

FYI -- @syed-awais-ali / @nadeemshahzad / @fysheets 