### PR TITLE
BOM-951

### DIFF
--- a/openedx/core/djangoapps/waffle_utils/migrations/0001_initial.py
+++ b/openedx/core/djangoapps/waffle_utils/migrations/0001_initial.py
@@ -23,7 +23,7 @@ class Migration(migrations.Migration):
                 ('enabled', models.BooleanField(default=False, verbose_name='Enabled')),
                 ('waffle_flag', models.CharField(max_length=255, db_index=True)),
                 ('course_id', CourseKeyField(max_length=255, db_index=True)),
-                ('override_choice', models.CharField(default=b'on', max_length=3, choices=[(b'on', 'Force On'), (b'off', 'Force Off')])),
+                ('override_choice', models.CharField(default=u'on', max_length=3, choices=[(u'on', u'Force On'), (u'off', u'Force Off')])),
                 ('changed_by', models.ForeignKey(on_delete=django.db.models.deletion.PROTECT, editable=False, to=settings.AUTH_USER_MODEL, null=True, verbose_name='Changed by')),
             ],
             options={

--- a/openedx/core/djangoapps/waffle_utils/models.py
+++ b/openedx/core/djangoapps/waffle_utils/models.py
@@ -20,7 +20,7 @@ class WaffleFlagCourseOverrideModel(ConfigurationModel):
 
     .. no_pii:
     """
-    OVERRIDE_CHOICES = Choices(('on', _('Force On')), ('off', _('Force Off')))
+    OVERRIDE_CHOICES = Choices((u'on', _(u'Force On')), (u'off', _(u'Force Off')))
     ALL_CHOICES = OVERRIDE_CHOICES + Choices('unset')
 
     KEY_FIELDS = ('waffle_flag', 'course_id')


### PR DESCRIPTION
waffle_utils: Explicitly Set fields to unicode to avoid migration
Updated migrations and model. 