### PR TITLE
Make settings regex non greedy.

### DIFF
--- a/pavelib/utils/envs.py
+++ b/pavelib/utils/envs.py
@@ -281,7 +281,7 @@ class Env(object):
         """
         django_setting_value = cls.get_django_setting(django_setting, system, settings)
         pattern = re.compile(
-            u"[\"']{setting}[\"']: [\"'](?P<setting_value>.*)[\"']".format(setting=nested_django_setting)
+            u"[\"']{setting}[\"']: [\"'](?P<setting_value>.*?)[\"']".format(setting=nested_django_setting)
         )
         match = pattern.search(django_setting_value)
         if match:


### PR DESCRIPTION
I'm surprised this didn't cause an issue before but as far as I can
figure this should always be non-greedy.  I think it worked before
because the items we were looking for was previously the last item
in the list but that is no longer the case in python 3 because of
dictionary order changes.

### Please consider the following when opening a pull request:

- Link to the relevant JIRA ticket(s) and tag any relevant team(s).
- Squash your changes down into one or more discrete commits.
  In each commit, include description that could help a developer
  several months from now.
- If running `make upgrade`, run _as close to the time of merging as possible_
  to avoid accidentally downgrading someone else's package.
  Put the output of `make upgrade` in its own separate commit,
  decoupled from other code changes.
- Aim for comprehensive test coverage, but remember that
  automated testing isn't a substitute for manual verification.
- Carefully consider naming, code organization, dependencies when adding new code.
  Code that is amenable to refactoring and improvement benefits all platform developers,
  especially given the size and scope of edx-platform.
  Consult existing Architectural Decision Records (ADRs),
  including those concerning the app(s) you are changing and
  [those concerning edx-platform as a whole](https://github.com/edx/edx-platform/tree/master/docs/decisions).
