### PR TITLE
Fix JSON parsing in edxnotes.helpers BOM-990

### DIFF
--- a/common/lib/capa/capa/safe_exec/safe_exec.py
+++ b/common/lib/capa/capa/safe_exec/safe_exec.py
@@ -47,7 +47,8 @@ lazymod_py_file = lazymod.__file__
 if lazymod_py_file.endswith("c"):
     lazymod_py_file = lazymod_py_file[:-1]
 
-lazymod_py = open(lazymod_py_file).read()
+with open(lazymod_py_file) as f:
+    lazymod_py = f.read()
 
 LAZY_IMPORTS = [lazymod_py]
 for name, modname in ASSUMED_IMPORTS:

--- a/lms/djangoapps/edxnotes/helpers.py
+++ b/lms/djangoapps/edxnotes/helpers.py
@@ -344,7 +344,7 @@ def get_notes(request, course, page=DEFAULT_PAGE, page_size=DEFAULT_PAGE_SIZE, t
     response = send_request(request.user, course.id, page, page_size, path, text)
 
     try:
-        collection = json.loads(response.content)
+        collection = json.loads(response.content.decode('utf-8'))
     except ValueError:
         log.error(u"Invalid JSON response received from notes api: response_content=%s", response.content)
         raise EdxNotesParseError(_("Invalid JSON response received from notes api."))

--- a/lms/djangoapps/edxnotes/tests.py
+++ b/lms/djangoapps/edxnotes/tests.py
@@ -340,7 +340,7 @@ class EdxNotesHelpersTest(ModuleStoreTestCase):
                     }
                 ]
             }
-        )
+        ).encode('utf-8')
 
         six.assertCountEqual(
             self,
@@ -410,7 +410,7 @@ class EdxNotesHelpersTest(ModuleStoreTestCase):
         """
         Tests the result if incorrect json is received.
         """
-        mock_get.return_value.content = "Error"
+        mock_get.return_value.content = b"Error"
         self.assertRaises(EdxNotesParseError, helpers.get_notes, self.request, self.course)
 
     @patch("edxnotes.helpers.requests.get", autospec=True)
@@ -418,7 +418,7 @@ class EdxNotesHelpersTest(ModuleStoreTestCase):
         """
         Tests the result if an empty response is received.
         """
-        mock_get.return_value.content = json.dumps({})
+        mock_get.return_value.content = json.dumps({}).encode('utf-8')
         self.assertRaises(EdxNotesParseError, helpers.get_notes, self.request, self.course)
 
     @patch("edxnotes.helpers.requests.get", autospec=True)
@@ -447,7 +447,7 @@ class EdxNotesHelpersTest(ModuleStoreTestCase):
                     u"updated": datetime(2014, 11, 19, 8, 6, 16, 00000).isoformat(),
                 }
             ]
-        })
+        }).encode('utf-8')
 
         six.assertCountEqual(
             self,
@@ -517,7 +517,7 @@ class EdxNotesHelpersTest(ModuleStoreTestCase):
         """
         Tests the result if incorrect json is received.
         """
-        mock_get.return_value.content = "Error"
+        mock_get.return_value.content = b"Error"
         self.assertRaises(EdxNotesParseError, helpers.get_notes, self.request, self.course)
 
     @patch("edxnotes.helpers.requests.get", autospec=True)
@@ -525,7 +525,7 @@ class EdxNotesHelpersTest(ModuleStoreTestCase):
         """
         Tests the result if incorrect data structure is received.
         """
-        mock_get.return_value.content = json.dumps({"1": 2})
+        mock_get.return_value.content = json.dumps({"1": 2}).encode('utf-8')
         self.assertRaises(EdxNotesParseError, helpers.get_notes, self.request, self.course)
 
     @patch("edxnotes.helpers.requests.get", autospec=True)
@@ -533,7 +533,7 @@ class EdxNotesHelpersTest(ModuleStoreTestCase):
         """
         Tests no results.
         """
-        mock_get.return_value.content = json.dumps(NOTES_API_EMPTY_RESPONSE)
+        mock_get.return_value.content = json.dumps(NOTES_API_EMPTY_RESPONSE).encode('utf-8')
         six.assertCountEqual(
             self,
             NOTES_VIEW_EMPTY_RESPONSE,
@@ -1206,7 +1206,7 @@ class EdxNotesRetireAPITest(ModuleStoreTestCase):
         """
         Tests that 204 response is received on success.
         """
-        mock_post.return_value.content = ''
+        mock_post.return_value.content = b''
         mock_post.return_value.status_code = 204
         headers = self._build_jwt_headers(self.superuser)
         response = self.client.post(


### PR DESCRIPTION
[BOM-990](https://openedx.atlassian.net/browse/BOM-990)

The content of responses are in bytes, `json.loads()` expects text.  This is a case where substituting `simplejson` isn't straightforward because the module exports a class used elsewhere which derives from one in the `json` module.  So fixed to decode the bytes correctly and update all the test mocks to provide the correct data type.

Also fixed a warning in `safe_exec` about a file that was left open after reading it.