### PR TITLE
Fix CSS selector under Python 3 BOM-991

### DIFF
--- a/common/test/acceptance/pages/studio/container.py
+++ b/common/test/acceptance/pages/studio/container.py
@@ -660,7 +660,7 @@ class XBlockWrapper(PageObject):
 
     @property
     def editor_selector(self):
-        return '.xblock-studio_view'
+        return u'.xblock-studio_view'
 
     def _click_button(self, button_name):
         """

--- a/common/test/acceptance/pages/xblock/acid.py
+++ b/common/test/acceptance/pages/xblock/acid.py
@@ -25,8 +25,6 @@ class AcidView(PageObject):
                 is on the page.
         """
         super(AcidView, self).__init__(browser)
-        if isinstance(context_selector, six.text_type):
-            context_selector = context_selector.encode('utf-8')
         self.context_selector = context_selector
 
     def is_browser_on_page(self):

--- a/common/test/acceptance/pages/xblock/utils.py
+++ b/common/test/acceptance/pages/xblock/utils.py
@@ -12,7 +12,7 @@ def wait_for_xblock_initialization(page, xblock_css):
     """
     def _is_finished_loading():
         # Wait for the xblock javascript to finish initializing
-        is_done = page.browser.execute_script(u"return $({}).data('initialized')".format(xblock_css))
+        is_done = page.browser.execute_script(u"return $('{}').data('initialized')".format(xblock_css))
         return is_done, is_done
 
     return Promise(_is_finished_loading, 'Finished initializing the xblock.').fulfill()

--- a/common/test/acceptance/pages/xblock/utils.py
+++ b/common/test/acceptance/pages/xblock/utils.py
@@ -12,7 +12,7 @@ def wait_for_xblock_initialization(page, xblock_css):
     """
     def _is_finished_loading():
         # Wait for the xblock javascript to finish initializing
-        is_done = page.browser.execute_script(u"return $({!r}).data('initialized')".format(xblock_css))
-        return (is_done, is_done)
+        is_done = page.browser.execute_script(u"return $({}).data('initialized')".format(xblock_css))
+        return is_done, is_done
 
     return Promise(_is_finished_loading, 'Finished initializing the xblock.').fulfill()


### PR DESCRIPTION
[BOM-991](https://openedx.atlassian.net/browse/BOM-991)

This CSS selector component was getting a `b` prefix under Python 3 in the string sent to the browser, which rendered it invalid.