### PR TITLE
Fixed exception in VisibleBlocks.bulk_create due to incorrect argument passed 

### DIFF
--- a/lms/djangoapps/grades/models.py
+++ b/lms/djangoapps/grades/models.py
@@ -232,7 +232,7 @@ class VisibleBlocks(models.Model):
         only for those that aren't already created.
         """
         cached_records = cls.bulk_read(user_id, course_key)
-        non_existent_brls = {brl.hash_value for brl in block_record_lists if brl.hash_value not in cached_records}
+        non_existent_brls = {brl for brl in block_record_lists if brl.hash_value not in cached_records}
         cls.bulk_create(user_id, course_key, non_existent_brls)
 
     @classmethod


### PR DESCRIPTION
In the following lines in the `VisibleBlocks.bulk_get_or_create` method, a set of hash_value(s) is created and stored in `non_existent_brls`. Then this set is onto the `VisibleBlocks.bulk_create` method as the `block_record_lists` argument

```
non_existent_brls = {brl.hash_value for brl in block_record_lists if brl.hash_value not in cached_records}
cls.bulk_create(user_id, course_key, non_existent_brls)
```

In the bulk_create method, this set is iterated over and then used to create `VisibleBlocks` objects by trying to use attributes of `brl` which currently is a hash_value i.e. a string.

```
created = cls.objects.bulk_create([
            VisibleBlocks(
                blocks_json=brl.json_value,
                hashed=brl.hash_value,
                course_id=course_key,
            )
            for brl in block_record_lists
        ])
```

Thus the solution was to replace `brl.hash_value` in `bulk_get_or_create` with only `brl`