### PR TITLE
Suppress first-purchase-discount on mobile

### DIFF
--- a/openedx/features/discounts/applicability.py
+++ b/openedx/features/discounts/applicability.py
@@ -91,7 +91,7 @@ def get_discount_expiration_date(user, course):
     return discount_expiration_date
 
 
-def can_receive_discount(user, course, discount_expiration_date=None):
+def can_receive_discount(user, course, discount_expiration_date=None, mobile_app=False):
     """
     Check all the business logic about whether this combination of user and course
     can receive a discount.
@@ -100,6 +100,9 @@ def can_receive_discount(user, course, discount_expiration_date=None):
     with impersonate(user):
         if not DISCOUNT_APPLICABILITY_FLAG.is_enabled():
             return False
+
+    if mobile_app:  # HACK: suppress on mobile, cleanup with REV-999
+        return False
 
     # TODO: Add additional conditions to return False here
 

--- a/openedx/features/discounts/views.py
+++ b/openedx/features/discounts/views.py
@@ -73,6 +73,8 @@ class CourseUserDiscount(DeveloperErrorViewMixin, APIView):
         course_key = CourseKey.from_string(course_key_string)
         course = CourseOverview.get_from_id(course_key)
         discount_applicable = can_receive_discount(user=request.user, course=course)
+        # HACK: Disable discount for mobile payment test
+        discount_applicable = discount_applicable and request.COOKIES.get('REV_934', None) != 'mobile'
         discount_percent = discount_percentage()
         payload = {'discount_applicable': discount_applicable, 'discount_percent': discount_percent}
         return Response({
@@ -136,6 +138,8 @@ class CourseUserDiscountWithUserParam(DeveloperErrorViewMixin, APIView):
         course = CourseOverview.get_from_id(course_key)
         user = User.objects.get(id=user_id)
         discount_applicable = can_receive_discount(user=user, course=course)
+        # HACK: Disable discount for mobile payment test
+        discount_applicable = discount_applicable and request.COOKIES.get('REV_934', None) != 'mobile'
         discount_percent = discount_percentage()
         payload = {'discount_applicable': discount_applicable, 'discount_percent': discount_percent}
         return Response({

--- a/openedx/features/discounts/views.py
+++ b/openedx/features/discounts/views.py
@@ -72,9 +72,9 @@ class CourseUserDiscount(DeveloperErrorViewMixin, APIView):
         """
         course_key = CourseKey.from_string(course_key_string)
         course = CourseOverview.get_from_id(course_key)
-        discount_applicable = can_receive_discount(user=request.user, course=course)
-        # HACK: Disable discount for mobile payment test
-        discount_applicable = discount_applicable and request.COOKIES.get('REV_934', None) != 'mobile'
+          # HACK: suppress on mobile, cleanup with REV-999
+        mobile_app = request.COOKIES.get('REV_934', None) == 'mobile'
+        discount_applicable = can_receive_discount(user=request.user, course=course, mobile_app=mobile_app)
         discount_percent = discount_percentage()
         payload = {'discount_applicable': discount_applicable, 'discount_percent': discount_percent}
         return Response({
@@ -137,9 +137,9 @@ class CourseUserDiscountWithUserParam(DeveloperErrorViewMixin, APIView):
         course_key = CourseKey.from_string(course_key_string)
         course = CourseOverview.get_from_id(course_key)
         user = User.objects.get(id=user_id)
-        discount_applicable = can_receive_discount(user=user, course=course)
-        # HACK: Disable discount for mobile payment test
-        discount_applicable = discount_applicable and request.COOKIES.get('REV_934', None) != 'mobile'
+          # HACK: suppress on mobile, cleanup with REV-999
+        mobile_app = request.COOKIES.get('REV_934', None) == 'mobile'
+        discount_applicable = can_receive_discount(user=user, course=course, mobile_app=mobile_app)
         discount_percent = discount_percentage()
         payload = {'discount_applicable': discount_applicable, 'discount_percent': discount_percent}
         return Response({


### PR DESCRIPTION
Because mobile users aren't messaged about it in the app they aren't really part of that experiment; all the discount would do is muddle the results we see in the mobile experiment, so we're suppressing the discount for the test.  (If both first-purchase-discount and mobile payments are implemented "for real", we would need to make them work together, of course.)