### PR TITLE
Pass back the answer html as a string instead of bytes.

### DIFF
--- a/common/lib/capa/capa/capa_problem.py
+++ b/common/lib/capa/capa/capa_problem.py
@@ -485,7 +485,7 @@ class LoncapaProblem(object):
 
         # include solutions from <solution>...</solution> stanzas
         for entry in self.tree.xpath("//" + "|//".join(solution_tags)):
-            answer = etree.tostring(entry)
+            answer = etree.tostring(entry).decode('utf-8')
             if answer:
                 answer_map[entry.get('id')] = contextualize_text(answer, self.context)
 

--- a/common/lib/capa/capa/tests/test_capa_problem.py
+++ b/common/lib/capa/capa/tests/test_capa_problem.py
@@ -719,3 +719,24 @@ class CAPAProblemReportHelpersTest(unittest.TestCase):
             """
         )
         self.assertEquals(problem.find_answer_text('1_2_1', 'hide'), 'hide')
+
+    def test_get_question_answer(self):
+        problem = new_loncapa_problem(
+            """
+            <problem>
+                <optionresponse>
+                    <optioninput options="('yellow','blue','green')" correct="blue" label="Color_1"/>
+                </optionresponse>
+                <solution>
+                    <div class="detailed-solution">
+                        <p>Explanation</p>
+                        <p>Blue is the answer.</p>
+                    </div>
+                </solution>
+            </problem>
+            """
+        )
+
+        # Ensure that the answer is a string so that the dict returned from this
+        # function can eventualy be serialized to json without issues.
+        self.assertIsInstance(problem.get_question_answers()['1_solution_1'], six.text_type)


### PR DESCRIPTION
We did this already for the 'get_html' function for a capa problem but
there wasn't a test to ensure this works correctly for the
get_question_answer function that powers the show answer button.

I ran into it while doing a quick smoke test on the python 3 sandbox.

### Please consider the following when opening a pull request:

- Link to the relevant JIRA ticket(s) and tag any relevant team(s).
- Squash your changes down into one or more discrete commits.
  In each commit, include description that could help a developer
  several months from now.
- If running `make upgrade`, run _as close to the time of merging as possible_
  to avoid accidentally downgrading someone else's package.
  Put the output of `make upgrade` in its own separate commit,
  decoupled from other code changes.
- Aim for comprehensive test coverage, but remember that
  automated testing isn't a substitute for manual verification.
- Carefully consider naming, code organization, dependencies when adding new code.
  Code that is amenable to refactoring and improvement benefits all platform developers,
  especially given the size and scope of edx-platform.
  Consult existing Architectural Decision Records (ADRs),
  including those concerning the app(s) you are changing and
  [those concerning edx-platform as a whole](https://github.com/edx/edx-platform/tree/master/docs/decisions).
