### PR TITLE
Fix breadcrumb titles

### DIFF
--- a/openedx/core/djangoapps/site_configuration/helpers.py
+++ b/openedx/core/djangoapps/site_configuration/helpers.py
@@ -226,8 +226,6 @@ def page_title_breadcrumbs(*crumbs, **kwargs):
     """
     platform_name = get_value('platform_name', settings.PLATFORM_NAME)
     separator = kwargs.get("separator", " | ")
-    crumbs = [c for c in crumbs if c is not None]
-    if crumbs:
-        return u'{}{}{}'.format(separator.join(crumbs), separator, platform_name)
-    else:
-        return platform_name
+    crumbs = [c for c in crumbs if c]
+    crumbs.append(platform_name)
+    return separator.join(crumbs)


### PR DESCRIPTION
The homepage title appeared in the browser bar as "| PLATFORM_NAME".
This is because the `page_title_breadcrumbs` helper function was being
called with an empty string breadcrumb.

The attached image shows the title before the proposed change.

![home title](https://user-images.githubusercontent.com/44319/67475519-a6f1de00-f656-11e9-89e2-de01fd024c68.png)
