### PR TITLE
BOM-987

### DIFF
--- a/openedx/core/djangoapps/django_comment_common/migrations/0004_auto_20161117_1209.py
+++ b/openedx/core/djangoapps/django_comment_common/migrations/0004_auto_20161117_1209.py
@@ -14,6 +14,6 @@ class Migration(migrations.Migration):
         migrations.AlterField(
             model_name='forumsconfig',
             name='connection_timeout',
-            field=models.FloatField(default=5.0, help_text=b'Seconds to wait when trying to connect to the comment service.'),
+            field=models.FloatField(default=5.0, help_text=u'Seconds to wait when trying to connect to the comment service.'),
         ),
     ]

--- a/openedx/core/djangoapps/django_comment_common/migrations/0006_coursediscussionsettings_discussions_id_map.py
+++ b/openedx/core/djangoapps/django_comment_common/migrations/0006_coursediscussionsettings_discussions_id_map.py
@@ -16,6 +16,6 @@ class Migration(migrations.Migration):
         migrations.AddField(
             model_name='coursediscussionsettings',
             name='discussions_id_map',
-            field=jsonfield.fields.JSONField(blank=True, help_text=b'Key/value store mapping discussion IDs to discussion XBlock usage keys.', null=True),
+            field=jsonfield.fields.JSONField(blank=True, help_text=u'Key/value store mapping discussion IDs to discussion XBlock usage keys.', null=True),
         ),
     ]

--- a/openedx/core/djangoapps/django_comment_common/migrations/0007_discussionsidmapping.py
+++ b/openedx/core/djangoapps/django_comment_common/migrations/0007_discussionsidmapping.py
@@ -18,7 +18,7 @@ class Migration(migrations.Migration):
             name='DiscussionsIdMapping',
             fields=[
                 ('course_id', opaque_keys.edx.django.models.CourseKeyField(db_index=True, max_length=255, primary_key=True, serialize=False)),
-                ('mapping', jsonfield.fields.JSONField(help_text=b'Key/value store mapping discussion IDs to discussion XBlock usage keys.')),
+                ('mapping', jsonfield.fields.JSONField(help_text=u'Key/value store mapping discussion IDs to discussion XBlock usage keys.')),
             ],
             options={
                 'db_table': 'django_comment_common_discussionsidmapping',

--- a/openedx/core/djangoapps/django_comment_common/models.py
+++ b/openedx/core/djangoapps/django_comment_common/models.py
@@ -205,7 +205,7 @@ class ForumsConfig(ConfigurationModel):
 
     connection_timeout = models.FloatField(
         default=5.0,
-        help_text="Seconds to wait when trying to connect to the comment service.",
+        help_text=u"Seconds to wait when trying to connect to the comment service.",
     )
 
     class Meta(ConfigurationModel.Meta):
@@ -239,7 +239,7 @@ class CourseDiscussionSettings(models.Model):
     discussions_id_map = JSONField(
         null=True,
         blank=True,
-        help_text="Key/value store mapping discussion IDs to discussion XBlock usage keys.",
+        help_text=u"Key/value store mapping discussion IDs to discussion XBlock usage keys.",
     )
     always_divide_inline_discussions = models.BooleanField(default=False)
     _divided_discussions = models.TextField(db_column='divided_discussions', null=True, blank=True)  # JSON list
@@ -277,7 +277,7 @@ class DiscussionsIdMapping(models.Model):
     """
     course_id = CourseKeyField(db_index=True, primary_key=True, max_length=255)
     mapping = JSONField(
-        help_text="Key/value store mapping discussion IDs to discussion XBlock usage keys.",
+        help_text=u"Key/value store mapping discussion IDs to discussion XBlock usage keys.",
     )
 
     class Meta(object):


### PR DESCRIPTION
django_comment_common: Explicitly Set fields to unicode to avoid migration