### PR TITLE
fixed language issue and added test

### DIFF
--- a/common/lib/xmodule/xmodule/js/spec/html/edit_spec.js
+++ b/common/lib/xmodule/xmodule/js/spec/html/edit_spec.js
@@ -40,6 +40,14 @@ describe('HTMLEditingDescriptor', function() {
       expect(visualEditorStub.getContent()).toEqual('text /c4x/foo/bar/asset/image.jpg');
     });
     it('Enables spellcheck', () => expect($('.html-editor iframe')[0].contentDocument.body.spellcheck).toBe(true));
+    it('Retains ascii characters', function() {
+      const editorData = '<a href="/static/Programación_Gas.pptx">fóó</a>';
+      const expectedData = '<p><a href="/static/Programación_Gas.pptx">fóó</a></p>'
+
+      this.descriptor.getVisualEditor().setContent(editorData)
+      const savedContent = this.descriptor.getVisualEditor().getContent()
+      expect(savedContent).toEqual(expectedData);
+    });
   });
   describe('Raw HTML Editor', function() {
     beforeEach(function() {

--- a/common/lib/xmodule/xmodule/js/src/html/edit.js
+++ b/common/lib/xmodule/xmodule/js/src/html/edit.js
@@ -101,6 +101,7 @@
           theme: "modern",
           skin: 'studio-tmce4',
           schema: "html5",
+          entity_encoding: "raw",
 
           /*
           Necessary to preserve relative URLs to our images.


### PR DESCRIPTION
### Fix HTML Entity breaks URL with accents

**When URL of the uploaded file is added in Html text component which contains non-ASCII characters i.e. ' ó ' in 'Programación.pptx' , the character is replaced by the encoded form which makes URL not usable.**

The issue has been fixed by adding the encoding format of HTML in the TinyMCE editor.

entity_encoding : "raw"

File upload with having name Programación Funciones.pptx
Go to a course on and Add a link to the current HTML component
Save the component
Click on the new link.

[TEST ME ON SANDBOX !](https://prod711.sandbox.edx.org/courses/course-v1:edX+DemoX+Demo_Course/courseware/d8a6192ade314473a78242dfeedfbf5b/edx_introduction/2?activate_block_id=block-v1%3AedX%2BDemoX%2BDemo_Course%2Btype%40vertical%2Bblock%40344924b5099942a98496c49654094e58)

[PROD-741](https://openedx.atlassian.net/browse/PROD-741)