### PR TITLE
Unpinning edx-sga requirement

### DIFF
--- a/requirements/edx-sandbox/base.txt
+++ b/requirements/edx-sandbox/base.txt
@@ -33,4 +33,4 @@ subprocess32==3.5.4       # via matplotlib
 sympy==0.7.1
 
 # The following packages are considered to be unsafe in a requirements file:
-# setuptools==41.5.0        # via kiwisolver
+# setuptools==41.6.0        # via kiwisolver

--- a/requirements/edx/base.in
+++ b/requirements/edx/base.in
@@ -85,6 +85,7 @@ edx-proctoring>=2.0.1
 edx-proctoring-proctortrack==1.0.5  # Intentionally and permanently pinned to ensure code changes are reviewed
 edx-rest-api-client
 edx-search
+edx-sga
 edx-submissions
 edx-user-state-client
 edx-when

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -116,11 +116,11 @@ edx-proctoring==2.1.3
 edx-rbac==1.0.3           # via edx-enterprise
 edx-rest-api-client==1.9.2
 edx-search==1.2.2
-git+https://github.com/mitodl/edx-sga.git@237ad328ba3f03d189c421073c85e48091041f8b#egg=edx-sga==0.0
+edx-sga==0.10.0
 edx-submissions==3.0.1
 edx-user-state-client==1.1.2
 edx-when==0.5.1
-edxval==1.1.28
+edxval==1.1.30
 elasticsearch==1.9.0      # via edx-search
 enum34==1.1.6
 event-tracking==0.2.9
@@ -258,4 +258,4 @@ xmlsec==1.3.3             # via python3-saml
 xss-utils==0.1.1
 
 # The following packages are considered to be unsafe in a requirements file:
-# setuptools==41.5.0        # via fs, lazy, python-levenshtein
+# setuptools==41.6.0        # via fs, lazy, python-levenshtein

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -40,7 +40,7 @@ backports.weakref==1.0.post1
 beautifulsoup4==4.8.1
 billiard==3.3.0.23
 bleach==2.1.4
-bok-choy==1.0.0
+bok-choy==1.0.1
 boto3==1.4.8
 boto==2.39.0
 botocore==1.8.17
@@ -71,7 +71,7 @@ ddt==1.2.1
 decorator==4.4.1
 defusedxml==0.5.0
 diff-cover==0.9.8
-distlib==0.2.9.post0
+distlib==0.3.0
 django-appconf==1.0.3
 django-babel-underscore==0.5.2
 django-babel==0.6.2
@@ -139,12 +139,12 @@ edx-proctoring==2.1.3
 edx-rbac==1.0.3
 edx-rest-api-client==1.9.2
 edx-search==1.2.2
-git+https://github.com/mitodl/edx-sga.git@237ad328ba3f03d189c421073c85e48091041f8b#egg=edx-sga==0.0
+edx-sga==0.10.0
 edx-sphinx-theme==1.5.0
 edx-submissions==3.0.1
 edx-user-state-client==1.1.2
 edx-when==0.5.1
-edxval==1.1.28
+edxval==1.1.30
 elasticsearch==1.9.0
 entrypoints==0.3
 enum34==1.1.6
@@ -156,7 +156,7 @@ faulthandler==3.1 ; python_version == "2.7"
 feedparser==5.1.3
 filelock==3.0.12
 flake8-polyfill==1.0.2
-flake8==3.7.8
+flake8==3.7.9
 freezegun==0.3.12
 fs-s3fs==0.1.8
 fs==2.0.18
@@ -353,4 +353,4 @@ xss-utils==0.1.1
 zipp==0.6.0
 
 # The following packages are considered to be unsafe in a requirements file:
-# setuptools==41.5.0        # via caniusepython3, fs, jsonschema, lazy, pytest, python-levenshtein, sphinx
+# setuptools==41.6.0        # via caniusepython3, fs, jsonschema, lazy, pytest, python-levenshtein, sphinx

--- a/requirements/edx/github.in
+++ b/requirements/edx/github.in
@@ -92,6 +92,5 @@ git+https://github.com/edx/xblock-lti-consumer.git@v1.2.1#egg=lti_consumer-xbloc
 # Third Party XBlocks
 
 git+https://github.com/joestump/python-oauth2.git@b94f69b1ad195513547924e380d9265133e995fa#egg=oauth2
-git+https://github.com/mitodl/edx-sga.git@237ad328ba3f03d189c421073c85e48091041f8b#egg=edx-sga==0.0
 git+https://github.com/open-craft/xblock-poll@add89e14558c30f3c8dc7431e5cd6536fff6d941#egg=xblock-poll==1.5.1
 git+https://github.com/edx-solutions/xblock-drag-and-drop-v2@v2.2.6#egg=xblock-drag-and-drop-v2==2.2.6

--- a/requirements/edx/paver.txt
+++ b/requirements/edx/paver.txt
@@ -30,4 +30,4 @@ watchdog==0.9.0
 wrapt==1.10.5
 
 # The following packages are considered to be unsafe in a requirements file:
-# setuptools==41.5.0        # via lazy
+# setuptools==41.6.0        # via lazy

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -39,7 +39,7 @@ backports.weakref==1.0.post1  # via backports.tempfile
 beautifulsoup4==4.8.1
 billiard==3.3.0.23
 bleach==2.1.4
-bok-choy==1.0.0
+bok-choy==1.0.1
 boto3==1.4.8
 boto==2.39.0
 botocore==1.8.17
@@ -70,7 +70,7 @@ ddt==1.2.1
 decorator==4.4.1
 defusedxml==0.5.0
 diff-cover==0.9.8
-distlib==0.2.9.post0      # via caniusepython3
+distlib==0.3.0            # via caniusepython3
 django-appconf==1.0.3
 django-babel-underscore==0.5.2
 django-babel==0.6.2
@@ -136,11 +136,11 @@ edx-proctoring==2.1.3
 edx-rbac==1.0.3
 edx-rest-api-client==1.9.2
 edx-search==1.2.2
-git+https://github.com/mitodl/edx-sga.git@237ad328ba3f03d189c421073c85e48091041f8b#egg=edx-sga==0.0
+edx-sga==0.10.0
 edx-submissions==3.0.1
 edx-user-state-client==1.1.2
 edx-when==0.5.1
-edxval==1.1.28
+edxval==1.1.30
 elasticsearch==1.9.0
 entrypoints==0.3          # via flake8
 enum34==1.1.6
@@ -152,7 +152,7 @@ faulthandler==3.1 ; python_version == "2.7"  # via pytest-faulthandler
 feedparser==5.1.3
 filelock==3.0.12          # via tox
 flake8-polyfill==1.0.2    # via radon
-flake8==3.7.8             # via flake8-polyfill
+flake8==3.7.9             # via flake8-polyfill
 freezegun==0.3.12
 fs-s3fs==0.1.8
 fs==2.0.18
@@ -335,4 +335,4 @@ xss-utils==0.1.1
 zipp==0.6.0
 
 # The following packages are considered to be unsafe in a requirements file:
-# setuptools==41.5.0        # via caniusepython3, fs, lazy, pytest, python-levenshtein
+# setuptools==41.6.0        # via caniusepython3, fs, lazy, pytest, python-levenshtein


### PR DESCRIPTION
Now that edx-sga has been update to be python 3 compatible, this PR moves requirement from github.in to base.in and unpins it