### PR TITLE
Fix UnicodeEncodeError in dashboard sharing links

### DIFF
--- a/lms/templates/dashboard/_dashboard_course_listing.html
+++ b/lms/templates/dashboard/_dashboard_course_listing.html
@@ -2,8 +2,8 @@
 
 <%!
 import six
-from six.moves.urllib import parse as urllib
 
+from django.utils.http import urlencode, urlquote_plus
 from django.utils.translation import ugettext as _
 from django.utils.translation import ungettext
 from django.urls import reverse
@@ -227,7 +227,7 @@ from util.course import get_link_for_about_page, get_encoded_course_sharing_utm_
                         <%
                           facebook_share_url = u"{url}?{utm_params}".format(url=share_url, utm_params=encoded_utm_parameters['facebook'])
                           share_text = _("I'm taking {course_name} online with {facebook_brand}. Check it out!").format(course_name=course_overview.display_name_with_default, facebook_brand=share_settings.get('FACEBOOK_BRAND', 'edX.org'))
-                          query_params = urllib.urlencode((('u', facebook_share_url), ('quote', share_text),))
+                          query_params = urlencode((('u', facebook_share_url), ('quote', share_text),))
                           facebook_url = 'https://www.facebook.com/sharer/sharer.php?{query}'.format(query=query_params)
                           share_msg = _("Share {course_name} on Facebook").format(course_name=course_overview.display_name_with_default)
                         %>
@@ -249,8 +249,8 @@ from util.course import get_link_for_about_page, get_encoded_course_sharing_utm_
                         <%
                           twitter_share_url = u"{url}?{utm_params}".format(url=share_url, utm_params=encoded_utm_parameters['twitter'])
                           default_share_text = _("I'm taking {course_name} online with {twitter_brand}. Check it out!").format(course_name=course_overview.display_name_with_default, twitter_brand=share_settings.get('TWITTER_BRAND', '@edxonline'))
-                          share_text = urllib.quote_plus(share_settings.get('DASHBOARD_TWITTER_TEXT', default_share_text))
-                          twitter_url = 'https://twitter.com/intent/tweet?text=' + share_text + '%20' + urllib.quote_plus(twitter_share_url)
+                          share_text = urlquote_plus(share_settings.get('DASHBOARD_TWITTER_TEXT', default_share_text))
+                          twitter_url = u'https://twitter.com/intent/tweet?text=' + share_text + u'%20' + urlquote_plus(twitter_share_url)
                           share_msg = _("Share {course_name} on Twitter").format(course_name=course_overview.display_name_with_default)
                         %>
                         <a


### PR DESCRIPTION
The attempted fix at Python 3 compatibility for this introduced a `UnicodeEncodeError` when the link text includes non-ASCII text.  Switch instead to the Django wrapper functions that explicitly convert to UTF-8 first.