### PR TITLE
Fixing templates for double escaping.

### DIFF
--- a/openedx/core/djangoapps/schedules/templates/schedules/edx_ace/courseupdate/email/body.html
+++ b/openedx/core/djangoapps/schedules/templates/schedules/edx_ace/courseupdate/email/body.html
@@ -16,10 +16,10 @@
         <td>
             <p>
                 {% blocktrans trimmed asvar tmsg %}
-                    We hope you're enjoying {start_strong}{{ course_name }}{end_strong}!
-                    We want to let you know what you can look forward to in week {{ week_num }}:
+                    We hope you're enjoying {start_strong}{course_name}{end_strong}!
+                    We want to let you know what you can look forward to in week {week_num}:
                 {% endblocktrans %}
-                {% interpolate_html tmsg start_strong='<strong>'|safe end_strong='</strong>'|safe %}
+                {% interpolate_html tmsg start_strong='<strong>'|safe end_strong='</strong>'|safe course_name=course_name|force_escape|safe week_num=week_num|force_escape|safe %}
                 <ul>
                     {% for highlight in week_highlights %}
                         <li>{{ highlight }}</li>

--- a/openedx/core/djangoapps/schedules/templates/schedules/edx_ace/recurringnudge_day10/email/body.html
+++ b/openedx/core/djangoapps/schedules/templates/schedules/edx_ace/recurringnudge_day10/email/body.html
@@ -36,10 +36,10 @@
                 {% endfilter %}
                 {% else %}
                     {% blocktrans trimmed asvar tmsg %}
-                        Many {{ platform_name }} learners in {start_strong}{{course_name}}{end_strong} are completing more problems every week, and
+                        Many {platform_name} learners in {start_strong}{course_name}{end_strong} are completing more problems every week, and
                         participating in the discussion forums. What do you want to do to keep learning?
                     {% endblocktrans %}
-                    {% interpolate_html tmsg start_strong='<strong>'|safe end_strong='</strong>'|safe %}
+                    {% interpolate_html tmsg start_strong='<strong>'|safe end_strong='</strong>'|safe course_name=course_name|force_escape|safe platform_name=platform_name|force_escape|safe %}
                 {% endif %}
             </p>
             {# xss-lint: disable=django-trans-missing-escape #}

--- a/openedx/core/djangoapps/schedules/templates/schedules/edx_ace/recurringnudge_day3/email/body.html
+++ b/openedx/core/djangoapps/schedules/templates/schedules/edx_ace/recurringnudge_day3/email/body.html
@@ -29,16 +29,16 @@
             <p>
                 {% if course_ids|length > 1 %}
                     {% blocktrans trimmed asvar tmsg %}
-                        Remember when you enrolled in {start_strong}{{ course_name }}{end_strong}, and other courses on {{ platform_name }}? We do, and we’re glad
+                        Remember when you enrolled in {start_strong}{course_name}{end_strong}, and other courses on {platform_name}? We do, and we’re glad
                         to have you! Come see what everyone is learning.
                     {% endblocktrans %}
-                    {% interpolate_html tmsg start_strong='<strong>'|safe end_strong='</strong>'|safe %}
+                    {% interpolate_html tmsg start_strong='<strong>'|safe end_strong='</strong>'|safe course_name=course_name|force_escape|safe platform_name=platform_name|force_escape|safe %}
                 {% else %}
                     {% blocktrans trimmed asvar tmsg %}
-                        Remember when you enrolled in {start_strong}{{ course_name }}{end_strong} on {{ platform_name }}? We do, and we’re glad
+                        Remember when you enrolled in {start_strong}{course_name}{end_strong} on {platform_name}? We do, and we’re glad
                         to have you! Come see what everyone is learning.
                     {% endblocktrans %}
-                    {% interpolate_html tmsg start_strong='<strong>'|safe end_strong='</strong>'|safe %}
+                    {% interpolate_html tmsg start_strong='<strong>'|safe end_strong='</strong>'|safe course_name=course_name|force_escape|safe platform_name=platform_name|force_escape|safe %}
                 {% endif %}
             </p>
             {# xss-lint: disable=django-trans-missing-escape #}

--- a/openedx/core/djangoapps/schedules/templates/schedules/edx_ace/upgradereminder/email/body.html
+++ b/openedx/core/djangoapps/schedules/templates/schedules/edx_ace/upgradereminder/email/body.html
@@ -44,11 +44,11 @@
                     {% interpolate_html tmsg start_strong='<strong>'|safe end_strong='</strong>'|safe %}
                 {% else %}
                     {% blocktrans trimmed asvar tmsg %}
-                        We hope you are enjoying learning with us so far in {start_strong}{{ first_course_name }}{end_strong}! A
+                        We hope you are enjoying learning with us so far in {start_strong}{first_course_name}{end_strong}! A
                         verified certificate allows you to highlight your new knowledge and skills. An
-                        {{ platform_name }} certificate is official and easily shareable.
+                        {platform_name} certificate is official and easily shareable.
                     {% endblocktrans %}
-                    {% interpolate_html tmsg start_strong='<strong>'|safe end_strong='</strong>'|safe %}
+                    {% interpolate_html tmsg start_strong='<strong>'|safe end_strong='</strong>'|safe first_course_name=first_course_name|force_escape|safe platform_name=platform_name|force_escape|safe %}
                 {% endif %}
             </p>
             <p>


### PR DESCRIPTION
Some of the email templates are escaped
in such a way that could potentially cause
double escaping i.e via django default behavior
and other via interpolate_html tag. Fixing it
by only applying escape via tag.

PROD-810
