### PR TITLE
Disable language preference cookie to mobile views.

### DIFF
--- a/openedx/core/djangoapps/lang_pref/middleware.py
+++ b/openedx/core/djangoapps/lang_pref/middleware.py
@@ -8,10 +8,11 @@ import logging
 from django.conf import settings
 from django.utils.translation import LANGUAGE_SESSION_KEY
 from django.utils.translation.trans_real import parse_accept_lang_header
+
 from openedx.core.djangoapps.lang_pref import COOKIE_DURATION, LANGUAGE_HEADER, LANGUAGE_KEY
 from openedx.core.djangoapps.user_api.errors import UserAPIInternalError, UserAPIRequestError
 from openedx.core.djangoapps.user_api.preferences.api import get_user_preference, set_user_preference
-
+from openedx.core.lib.mobile_utils import is_request_from_mobile_app
 
 log = logging.getLogger(__name__)
 
@@ -83,12 +84,13 @@ class LanguagePreferenceMiddleware(object):
                 log.info(u'setting language cookie to {lang} for the user:{username} and request url'
                          u' was {url}'.format(lang=user_pref, username=current_user.username,
                                               url=request.build_absolute_uri()))
-                response.set_cookie(
-                    settings.LANGUAGE_COOKIE,
-                    value=user_pref,
-                    domain=settings.SESSION_COOKIE_DOMAIN,
-                    max_age=COOKIE_DURATION,
-                )
+                if not is_request_from_mobile_app(request):
+                    response.set_cookie(
+                        settings.LANGUAGE_COOKIE,
+                        value=user_pref,
+                        domain=settings.SESSION_COOKIE_DOMAIN,
+                        max_age=COOKIE_DURATION,
+                    )
             else:
                 log.info(u'deleting language cookie to {lang} for the user:{username} and request url'
                          u' was {url}'.format(lang=user_pref, username=current_user.username,

--- a/openedx/core/djangoapps/lang_pref/tests/test_middleware.py
+++ b/openedx/core/djangoapps/lang_pref/tests/test_middleware.py
@@ -12,7 +12,7 @@ import six
 from django.conf import settings
 from django.contrib.sessions.middleware import SessionMiddleware
 from django.http import HttpResponse
-from django.test.client import RequestFactory
+from django.test.client import Client, RequestFactory
 from django.urls import reverse
 from django.utils.translation import LANGUAGE_SESSION_KEY
 from django.utils.translation.trans_real import parse_accept_lang_header
@@ -43,6 +43,7 @@ class TestUserPreferenceMiddleware(CacheIsolationTestCase):
         self.request.user = self.user
         self.request.META['HTTP_ACCEPT_LANGUAGE'] = 'ar;q=1.0'
         self.session_middleware.process_request(self.request)
+        self.client = Client()
 
     def test_logout_shouldnt_remove_cookie(self):
 
@@ -254,3 +255,21 @@ class TestUserPreferenceMiddleware(CacheIsolationTestCase):
 
         with self.assertNumQueries(1):
             self.middleware.process_response(self.request, response)
+
+    @mock.patch('openedx.core.djangoapps.lang_pref.middleware.is_request_from_mobile_app')
+    @mock.patch('openedx.core.djangoapps.lang_pref.middleware.get_user_preference')
+    def test_lang_pref_cookie_must_not_sent_to_mobile(self, mock_get_user_preference, mock_is_mobile_request):
+        """
+        Test to verify language preference cookie must not be set for mobile requests
+        """
+        mock_get_user_preference.return_value = 'test_value'
+        mock_is_mobile_request.return_value = True
+
+        response = self.client.get('/')
+        self.middleware.process_response(self.request, response)
+        self.assertFalse(response.cookies.get('openedx-language-preference'))
+
+        mock_is_mobile_request.return_value = False
+        response = self.client.get('/')
+        self.middleware.process_response(self.request, response)
+        self.assertTrue(response.cookies.get('openedx-language-preference'))

--- a/openedx/core/djangoapps/lang_pref/views.py
+++ b/openedx/core/djangoapps/lang_pref/views.py
@@ -12,7 +12,9 @@ from django.conf import settings
 from django.http import HttpResponse
 from django.utils.translation import LANGUAGE_SESSION_KEY
 from django.views.decorators.csrf import ensure_csrf_cookie
+
 from openedx.core.djangoapps.lang_pref import COOKIE_DURATION, LANGUAGE_KEY
+from openedx.core.lib.mobile_utils import is_request_from_mobile_app
 
 
 @ensure_csrf_cookie
@@ -26,10 +28,11 @@ def update_session_language(request):
         language = data.get(LANGUAGE_KEY, settings.LANGUAGE_CODE)
         if request.session.get(LANGUAGE_SESSION_KEY, None) != language:
             request.session[LANGUAGE_SESSION_KEY] = six.text_type(language)
-        response.set_cookie(
-            settings.LANGUAGE_COOKIE,
-            language,
-            domain=settings.SESSION_COOKIE_DOMAIN,
-            max_age=COOKIE_DURATION
-        )
+        if not is_request_from_mobile_app(request):
+            response.set_cookie(
+                settings.LANGUAGE_COOKIE,
+                language,
+                domain=settings.SESSION_COOKIE_DOMAIN,
+                max_age=COOKIE_DURATION
+            )
     return response


### PR DESCRIPTION
### Description

[PROD-782](https://openedx.atlassian.net/browse/PROD-782)

Language preference cookie is not allowing to change the site language on mobile-apps affecting user-experience.To improve it, mobile team suggested to disable the language preference cookie
for the request originated from mobile.