### PR TITLE
enable video url rewrite flag

### DIFF
--- a/lms/djangoapps/course_api/blocks/toggles.py
+++ b/lms/djangoapps/course_api/blocks/toggles.py
@@ -41,5 +41,5 @@ HIDE_ACCESS_DENIALS_FLAG = WaffleFlag(
 ENABLE_VIDEO_URL_REWRITE = CourseWaffleFlag(
     waffle_namespace=COURSE_BLOCKS_API_NAMESPACE,
     flag_name="enable_video_url_rewrite",
-    flag_undefined_default=False
+    flag_undefined_default=True
 )


### PR DESCRIPTION
### [PROD-762](https://openedx.atlassian.net/browse/PROD-762)

### Description
This PR is only turning on the **ENABLE_VIDEO_URL_REWRITE**,  by default, for all the courses. This flag was introduced in https://github.com/edx/edx-platform/pull/21617/ but wasn't turned on, primarily to validate the fix on the production before making it public to all the courses. I am not removing the flag in its entirety because if a course team doesn't want the URL re-write facility, they can whitelist themselves by adding a waffle flag course override.

### Reviewers
 - [x] @awaisdar001 

### Post Review
 - [x] Squash & Rebase commits