### PR TITLE
Improve logging when a CAPA problem fails to display HTML

### DIFF
--- a/common/lib/xmodule/xmodule/capa_base.py
+++ b/common/lib/xmodule/xmodule/capa_base.py
@@ -557,7 +557,14 @@ class CapaMixin(ScorableXBlockMixin, CapaFields):
 
         `err` is the Exception encountered while rendering the problem HTML.
         """
-        log.exception(text_type(err))
+        problem_display_name = self.display_name_with_default
+        problem_location = text_type(self.location)
+        log.exception(
+            u"ProblemGetHtmlError: %r, %r, %s",
+            problem_display_name,
+            problem_location,
+            text_type(err)
+        )
 
         # TODO (vshnayder): another switch on DEBUG.
         if self.runtime.DEBUG:
@@ -615,7 +622,11 @@ class CapaMixin(ScorableXBlockMixin, CapaFields):
                 html += self.lcp.get_html()
             except Exception:
                 # Couldn't do it. Give up.
-                log.exception("Unable to generate html from LoncapaProblem")
+                log.exception(
+                    u"ProblemGetHtmlError: Unable to generate html from LoncapaProblem: !r, !r",
+                    problem_display_name,
+                    problem_location
+                )
                 raise
 
         return html


### PR DESCRIPTION
[PROD-860](https://openedx.atlassian.net/browse/PROD-860)

This PR will log information about the spcific problem which failed so that it is easier to find the problem and trace the error. 

```
2019-10-30 08:57:02,387 ERROR 2897 [edx.courseware] [user 9] capa_base.py:566 - ProblemGetHtmlError: u'Checkboxes', u'block-v1:edX+DemoX+Demo_Course+type@problem+block@4f480491b894412bb5f6834aba355cd1', integer division or modulo by zero
Traceback (most recent call last):
  File "/edx/app/edxapp/edx-platform/common/lib/xmodule/xmodule/capa_base.py", line 722, in get_problem_html
    1/0
ZeroDivisionError: integer division or modulo by zero
```

```
2019-10-30 08:57:02,387 ERROR 2897 [edx.courseware] [user 9] capa_base.py:566 - Unable to generate html from LoncapaProblem: u'Checkboxes', u'block-v1:edX+DemoX+Demo_Course+type@problem+block@4f480491b894412bb5f6834aba355cd1', integer division or modulo by zero
Traceback (most recent call last):
  File "/edx/app/edxapp/edx-platform/common/lib/xmodule/xmodule/capa_base.py", line 722, in get_problem_html
    1/0
ZeroDivisionError: integer division or modulo by zero
```