### PR TITLE
Revert "enable video url rewrite flag"

### DIFF
--- a/lms/djangoapps/course_api/blocks/toggles.py
+++ b/lms/djangoapps/course_api/blocks/toggles.py
@@ -41,5 +41,5 @@ HIDE_ACCESS_DENIALS_FLAG = WaffleFlag(
 ENABLE_VIDEO_URL_REWRITE = CourseWaffleFlag(
     waffle_namespace=COURSE_BLOCKS_API_NAMESPACE,
     flag_name="enable_video_url_rewrite",
-    flag_undefined_default=True
+    flag_undefined_default=False
 )


### PR DESCRIPTION
Reverts edx/edx-platform#22181 as there were a lot of KeyError after enabling the flag. Moving it back to disabled to debug why the re-write failed for certain courses. For the videos that are web-only, the student_view_data is primarily empty(with only one field `only_on_web` set to true) which is the reason for KeyError on the newRelic.