### PR TITLE
Fix escaping of html tags.

### DIFF
--- a/openedx/core/djangoapps/user_authn/views/login.py
+++ b/openedx/core/djangoapps/user_authn/views/login.py
@@ -115,7 +115,7 @@ def _enforce_password_policy_compliance(request, user):
     except password_policy_compliance.NonCompliantPasswordException as e:
         send_password_reset_email_for_user(user, request)
         # Prevent the login attempt.
-        raise AuthFailedError(six.text_type(e))
+        raise AuthFailedError(HTML(six.text_type(e)))
 
 
 def _generate_not_activated_message(user):


### PR DESCRIPTION
Using six.text_type() is converting
MarkSafe object created using HTML
function to simple string which is
essential for html tags interpolation.
Applying escaping via Text function on
this string object is causing escaping
of html tags.

PROD-834
