### PR TITLE
Add error in logging

### DIFF
--- a/common/lib/xmodule/xmodule/capa_base.py
+++ b/common/lib/xmodule/xmodule/capa_base.py
@@ -620,12 +620,13 @@ class CapaMixin(ScorableXBlockMixin, CapaFields):
             html = warning
             try:
                 html += self.lcp.get_html()
-            except Exception:
+            except Exception as error:
                 # Couldn't do it. Give up.
                 log.exception(
-                    u"ProblemGetHtmlError: Unable to generate html from LoncapaProblem: !r, !r",
+                    u"ProblemGetHtmlError: Unable to generate html from LoncapaProblem: %r, %r, %s",
                     problem_display_name,
-                    problem_location
+                    problem_location,
+                    text_type(error)
                 )
                 raise
 


### PR DESCRIPTION
Follow up of https://github.com/edx/edx-platform/pull/22182; 
This PR fixes 
Syntex error in logging 
Adds error while logging an exception. 


```
2019-10-31 18:05:01,021 ERROR 1699 [capa.util] [user 9] util.py:127 - ContextualizeTextError: text(<type 'str'>): $val1, context_key(<type 'str'>): $val1, context_value(<type 'str'>): True, Error: integer division or modulo by zero
```
LOG-2
```
2019-10-31 05:47:13,930 ERROR 2282 [edx.courseware] [user 9] capa_base.py:631 - ProblemGetHtmlError: Unable to generate html from LoncapaProblem: u'Problem9', u'block-v1:edX+DemoX+Demo_Course+type@problem+block@732696c54cf64f498b0ce03d0767bb0a', 'ascii' codec can't decode byte 0xe2 in position 27: ordinal not in range(128)
Traceback (most recent call last):
  File "/edx/app/edxapp/edx-platform/common/lib/xmodule/xmodule/capa_base.py", line 718, in get_problem_html
    html = self.lcp.get_html()
  File "/edx/app/edxapp/edx-platform/common/lib/capa/capa/capa_problem.py", line 739, in get_html
    self.context
  File "/edx/app/edxapp/edx-platform/common/lib/capa/capa/util.py", line 124, in contextualize_text
    text = text.replace(context_key, context_value)
UnicodeDecodeError: 'ascii' codec can't decode byte 0xe2 in position 27: ordinal not in range(128)
```