### PR TITLE
add encoded video key check in video transformer

### DIFF
--- a/lms/djangoapps/course_api/blocks/transformers/tests/test_video_urls.py
+++ b/lms/djangoapps/course_api/blocks/transformers/tests/test_video_urls.py
@@ -80,7 +80,8 @@ class TestVideoBlockURLTransformer(ModuleStoreTestCase):
                     'url': 'https://1234abcd.cloudfront.net/ABCD1234abcd.mp4',
                     'file_size': 0
                 }
-            }
+            },
+            'only_on_web': False
         }
         video_block_key = self.course_key.make_usage_key('video', 'sample_video')
         pre_transform_data = self.get_pre_transform_data(video_block_key)
@@ -109,7 +110,8 @@ class TestVideoBlockURLTransformer(ModuleStoreTestCase):
                     'url': 'https://1234abcd.third_part_cdn.com/ABCD1234abcd.mp4',
                     'file_size': 0
                 }
-            }
+            },
+            'only_on_web': False
         }
         video_block_key = self.course_key.make_usage_key('video', 'sample_video')
         pre_transform_data = self.get_pre_transform_data(video_block_key)
@@ -121,3 +123,18 @@ class TestVideoBlockURLTransformer(ModuleStoreTestCase):
 
         for video_format, video_url in six.iteritems(post_transform_data):
             self.assertEqual(pre_transform_data[video_format], video_url)
+
+    @mock.patch('xmodule.video_module.VideoBlock.student_view_data')
+    def test_no_rewrite_for_web_only_videos(self, mock_video_data):
+        """
+        Verify no rewrite attempt is made for the videos
+        available on web only.
+        """
+        mock_video_data.return_value = {
+            'only_on_web': True
+        }
+        video_block_key = self.course_key.make_usage_key('video', 'sample_video')
+        pre_transform_data = self.get_pre_transform_data(video_block_key)
+        self.collect_and_transform()
+        post_transform_data = self.get_post_transform_data(video_block_key)
+        self.assertDictEqual(pre_transform_data, post_transform_data)

--- a/lms/djangoapps/course_api/blocks/transformers/video_urls.py
+++ b/lms/djangoapps/course_api/blocks/transformers/video_urls.py
@@ -46,7 +46,12 @@ class VideoBlockURLTransformer(BlockStructureTransformer):
             )
             if not student_view_data:
                 return
-            encoded_videos = student_view_data['encoded_videos']
+
+            # web-only videos don't contain any video information for native clients
+            only_on_web = student_view_data.get('only_on_web')
+            if only_on_web:
+                continue
+            encoded_videos = student_view_data.get('encoded_videos')
             for video_format, video_data in six.iteritems(encoded_videos):
                 if video_format in self.VIDEO_FORMAT_EXCEPTIONS:
                     continue


### PR DESCRIPTION
### [PROD-870](https://openedx.atlassian.net/browse/PROD-870)

### Description
This PR is adding a check to the video URL rewrite transformer. For the videos that are available on the web only, the student view data doesn't return any other information. Only the following dictionary is returned:
`{'only_on_web': True}`

This resulted in KeyError when the waffle flag was activated for all the courses. To fix that behavior, a check for the `encoded_videos` key has been added. If the key is non-existent, skip re-writing.

### Sandbox
 - https://studio-videourl.sandbox.edx.org/course/course-v1:DX+SM870+2019_T2
 - [API URL](https://videourl.sandbox.edx.org/api/courses/v2/blocks/block-v1:DX+SM870+2019_T2+type@course+block@course/?all_blocks=true&depth=all&student_view_data=video)

### Instructions
 - Add a video on the course in the sandbox
 - Make it web-only(from advanced tab of the video component)
 - Publish the course
 - Verify the component has been published successfully from the LMS
 - Visit the API URL. The URL will open without any problem
 - Verify the web-only video's data doesn't contain encoded_video information

**NOTE**: If you plan to make a new course, add `course_blocks_api.enable_video_url_rewrite` waffle course override for that course through admin for re-write to kick-in.

### Reviewers
 - [x] @awaisdar001 
 - [x] @noraiz-anwar 

### Post Review
 - [x] Squash & Rebase commits