### PR TITLE
Remove obsolete field type BOM-996

### DIFF
--- a/common/lib/capa/capa/customrender.py
+++ b/common/lib/capa/capa/customrender.py
@@ -167,7 +167,7 @@ class ClarificationRenderer(object):
         self.system = system
         # Get any text content found inside this tag prior to the first child tag. It may be a string or None type.
         initial_text = xml.text if xml.text else ''
-        self.inner_html = initial_text + ''.join(etree.tostring(element, encoding='unicode') for element in xml)
+        self.inner_html = initial_text + u''.join(etree.tostring(element, encoding='unicode') for element in xml)
         self.tail = xml.tail
 
     def get_html(self):

--- a/common/lib/capa/capa/customrender.py
+++ b/common/lib/capa/capa/customrender.py
@@ -167,7 +167,7 @@ class ClarificationRenderer(object):
         self.system = system
         # Get any text content found inside this tag prior to the first child tag. It may be a string or None type.
         initial_text = xml.text if xml.text else ''
-        self.inner_html = initial_text + ''.join(etree.tostring(element) for element in xml)
+        self.inner_html = initial_text + ''.join(etree.tostring(element, encoding='unicode') for element in xml)
         self.tail = xml.tail
 
     def get_html(self):

--- a/lms/djangoapps/courseware/fields.py
+++ b/lms/djangoapps/courseware/fields.py
@@ -5,7 +5,6 @@ Custom fields
 from __future__ import absolute_import
 
 from django.db.models.fields import AutoField
-from django.db.models.fields.related import OneToOneField
 
 
 class UnsignedBigIntAutoField(AutoField):
@@ -27,25 +26,7 @@ class UnsignedBigIntAutoField(AutoField):
         else:
             return None
 
-    # rel_db_type was added in Django 1.10. For versions before, use UnsignedBigIntOneToOneField.
     def rel_db_type(self, connection):
-        if connection.settings_dict['ENGINE'] == 'django.db.backends.mysql':
-            return "bigint UNSIGNED"
-        elif connection.settings_dict['ENGINE'] == 'django.db.backends.sqlite3':
-            return "integer"
-        elif connection.settings_dict['ENGINE'] == 'django.db.backends.postgresql_psycopg2':
-            return "BIGSERIAL"
-        else:
-            return None
-
-
-class UnsignedBigIntOneToOneField(OneToOneField):
-    """
-    An unsigned 8-byte integer one-to-one foreign key to a unsigned 8-byte integer id field.
-
-    Should only be necessary for versions of Django < 1.10.
-    """
-    def db_type(self, connection):
         if connection.settings_dict['ENGINE'] == 'django.db.backends.mysql':
             return "bigint UNSIGNED"
         elif connection.settings_dict['ENGINE'] == 'django.db.backends.sqlite3':

--- a/lms/djangoapps/grades/migrations/0013_persistentsubsectiongradeoverride.py
+++ b/lms/djangoapps/grades/migrations/0013_persistentsubsectiongradeoverride.py
@@ -3,8 +3,6 @@ from __future__ import absolute_import, unicode_literals
 
 from django.db import migrations, models
 
-from lms.djangoapps.courseware.fields import UnsignedBigIntOneToOneField
-
 
 class Migration(migrations.Migration):
 
@@ -23,7 +21,7 @@ class Migration(migrations.Migration):
                 ('possible_all_override', models.FloatField(null=True, blank=True)),
                 ('earned_graded_override', models.FloatField(null=True, blank=True)),
                 ('possible_graded_override', models.FloatField(null=True, blank=True)),
-                ('grade', UnsignedBigIntOneToOneField(related_name='override', to='grades.PersistentSubsectionGrade')),
+                ('grade', models.OneToOneField(related_name='override', to='grades.PersistentSubsectionGrade')),
             ],
         ),
     ]

--- a/lms/djangoapps/grades/models.py
+++ b/lms/djangoapps/grades/models.py
@@ -29,7 +29,7 @@ from opaque_keys.edx.keys import CourseKey, UsageKey
 from simple_history.models import HistoricalRecords
 from six.moves import map
 
-from lms.djangoapps.courseware.fields import UnsignedBigIntAutoField, UnsignedBigIntOneToOneField
+from lms.djangoapps.courseware.fields import UnsignedBigIntAutoField
 from lms.djangoapps.grades import constants, events
 from openedx.core.lib.cache_utils import get_cache
 
@@ -655,7 +655,7 @@ class PersistentSubsectionGradeOverride(models.Model):
     class Meta(object):
         app_label = "grades"
 
-    grade = UnsignedBigIntOneToOneField(PersistentSubsectionGrade, related_name='override')
+    grade = models.OneToOneField(PersistentSubsectionGrade, related_name='override')
 
     # Created/modified timestamps prevent race-conditions when using with async rescoring tasks
     created = models.DateTimeField(auto_now_add=True, db_index=True)

--- a/pavelib/paver_tests/test_paver_bok_choy_cmds.py
+++ b/pavelib/paver_tests/test_paver_bok_choy_cmds.py
@@ -33,6 +33,7 @@ class TestPaverBokChoyCmd(unittest.TestCase):
 
         expected_statement = [
             "DEFAULT_STORE={}".format(store),
+            "SAVED_SOURCE_DIR='{}/test_root/log{}'".format(REPO_DIR, shard_str),
             "SCREENSHOT_DIR='{}/test_root/log{}'".format(REPO_DIR, shard_str),
             "BOK_CHOY_HAR_DIR='{}/test_root/log{}/hars'".format(REPO_DIR, shard_str),
             "BOKCHOY_A11Y_CUSTOM_RULES_FILE='{}/{}'".format(

--- a/pavelib/utils/test/suites/bokchoy_suite.py
+++ b/pavelib/utils/test/suites/bokchoy_suite.py
@@ -300,6 +300,7 @@ class BokChoyTestSuite(TestSuite):
         # screenshots and XUnit XML reports
         cmd = [
             "DEFAULT_STORE={}".format(self.default_store),
+            "SAVED_SOURCE_DIR='{}'".format(self.log_dir),
             "SCREENSHOT_DIR='{}'".format(self.log_dir),
             "BOK_CHOY_HAR_DIR='{}'".format(self.har_dir),
             "BOKCHOY_A11Y_CUSTOM_RULES_FILE='{}'".format(self.a11y_file),


### PR DESCRIPTION
This addresses an [issue](https://github.com/edx/edx-platform/pull/22187#issuecomment-548248789) that @awais786 found while working on [BOM-996](https://openedx.atlassian.net/browse/BOM-996) (and includes his fix from #22197 ).  Django determines valid fields for `select_related()` in querysets by inspecting the fields in the model and reverse relations from `OneToOneField`s in other models, but it seems that under Python 3 the reverse relationship from this subclass of `OneToOneField` wasn't being considered.  We no longer need it with Django 1.11+, so reverting it back to be a standard `OneToOneField`.

Also configured paver to save the page source when bok-choy tests fail (this is a relatively new bok-choy feature).