### PR TITLE
Read CMS_BASE from the environment, define it explicitly as public host

### DIFF
--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -504,6 +504,7 @@ FRONTEND_LOGIN_URL = LOGIN_URL
 FRONTEND_LOGOUT_URL = lambda settings: settings.LMS_ROOT_URL + '/logout'
 derived('FRONTEND_LOGOUT_URL')
 
+# Public domain name of Studio (should be resolvable from the end-user's browser)
 CMS_BASE = 'localhost:18010'
 
 LOG_DIR = '/edx/var/log/edx'

--- a/cms/envs/production.py
+++ b/cms/envs/production.py
@@ -162,6 +162,8 @@ EMAIL_HOST = ENV_TOKENS.get('EMAIL_HOST', EMAIL_HOST)
 EMAIL_PORT = ENV_TOKENS.get('EMAIL_PORT', EMAIL_PORT)
 EMAIL_USE_TLS = ENV_TOKENS.get('EMAIL_USE_TLS', EMAIL_USE_TLS)
 
+# CMS_BASE: Public domain name of Studio (should be resolvable from the end-user's browser)
+CMS_BASE = ENV_TOKENS.get('CMS_BASE')
 LMS_BASE = ENV_TOKENS.get('LMS_BASE')
 LMS_ROOT_URL = ENV_TOKENS.get('LMS_ROOT_URL')
 LMS_INTERNAL_ROOT_URL = ENV_TOKENS.get('LMS_INTERNAL_ROOT_URL', LMS_ROOT_URL)
@@ -180,7 +182,7 @@ SITE_NAME = ENV_TOKENS['SITE_NAME']
 ALLOWED_HOSTS = [
     # TODO: bbeggs remove this before prod, temp fix to get load testing running
     "*",
-    ENV_TOKENS.get('CMS_BASE')
+    CMS_BASE,
 ]
 
 LOG_DIR = ENV_TOKENS['LOG_DIR']


### PR DESCRIPTION
One of the APIs I wrote [uses](https://github.com/edx/edx-platform/blob/1382bf8720b23b45fc2950f598540dc0a0ba3ece/openedx/core/djangoapps/xblock/apps.py#L91-L97) `settings.CMS_BASE` to build an absolute URL for Studio, and that wasn't working on edX.org stage; the value of `CMS_BASE` was correct when read in the LMS but when read in Studio was giving the default of `localhost:18010` even though `CMS_BASE` was being configured in Studio's yaml/env configuration.

This hopefully fixes a bug where the new Blockstore XBlock `handler_url` API was incorrectly returning URLs that began with `https://localhost:18010` when used on edx.org stage/prod.

I also decided to add comments to explicitly define CMS base as a public hostname (e.g. `studio.edx.org` in a prod-like environment or `localhost:18010` on devstack) and not a private hostname (e.g. `edx.devstack.studio` on devstack or `localhost:1810` in a prod-like environment), since there was some considerable ambiguity. But [it's definitely used as a public hostname in the LMS](https://github.com/edx/edx-platform/blob/b3845b2b968d116c207edbab29a6830f981ad04f/lms/djangoapps/courseware/courses.py#L524-L541), so I think it should be defined that way in Studio too for consistency.