### PR TITLE
Use latest sphinxcontrib-openapi on GitHub to get a feature we need

### DIFF
--- a/docs/api/index.rst
+++ b/docs/api/index.rst
@@ -7,6 +7,5 @@ TODO: What should go here?
 See all the endpoints at :doc:`The Endpoints <gen/index>`.
 
 .. toctree::
-    :hidden:
 
     gen/index

--- a/requirements/edx/development.in
+++ b/requirements/edx/development.in
@@ -20,4 +20,6 @@ pyinotify                           # More efficient checking for runserver relo
 sphinx==1.8.5                       # Pinned because 2.0.0 release requires Python '>=3.5' but current Python is 2.7.12
 vulture                             # Detects possible dead/unused code, used in scripts/find-dead-code.sh
 modernize                           # Used to make Python 2 code more modern with the intention of eventually porting it over to Python 3.
-sphinxcontrib-openapi[markdown]
+
+# Using a github hash because the "include" feature wasn't in the latest release (0.5.0):
+git+https://github.com/sphinx-contrib/openapi.git@9306435601ae05138edea54419dd83ce9e729ad8#egg=sphinxcontrib-openapi[markdown]==0.0

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -312,7 +312,7 @@ sortedcontainers==2.1.0
 soupsieve==1.9.4
 sphinx==1.8.5
 sphinxcontrib-httpdomain==1.7.0  # via sphinxcontrib-openapi
-sphinxcontrib-openapi[markdown]==0.5.0
+git+https://github.com/sphinx-contrib/openapi.git@9306435601ae05138edea54419dd83ce9e729ad8#egg=sphinxcontrib-openapi[markdown]==0.0
 sphinxcontrib-websupport==1.1.2  # via sphinx
 sqlparse==0.3.0
 staff-graded-xblock==0.5


### PR DESCRIPTION
We had the latest released sphinxcontrib-openapi, but it didn't have the latest feature ("include"), so now we use a GitHub hash installation instead.
Also, make the TOC appear.