### PR TITLE
Fix the last bok-choy shard in Python 3

### DIFF
--- a/scripts/generic-ci-tests.sh
+++ b/scripts/generic-ci-tests.sh
@@ -194,7 +194,7 @@ case "$TEST_SUITE" in
                 ;;
 
             25|"noshard")
-                $TOX paver test_bokchoy --eval-attr="(shard>=$SHARD or not shard) and not a11y" $PAVER_ARGS
+                $TOX paver test_bokchoy --eval-attr="(not shard or shard>=$SHARD) and not a11y" $PAVER_ARGS
                 ;;
 
             # Default case because if we later define another bok-choy shard on Jenkins


### PR DESCRIPTION
The bok-choy tests in shard 25 haven't been running because there was an error in processing the test selection expression used by `pytest-attrib`.  Due to implementation details, it is apparently pickier about the order of operations under Python 3 than Python 2; the following error was being generated:

```
14:29:32  DEFAULT_STORE=split SAVED_SOURCE_DIR='/home/jenkins/workspace/edx-platform-python3-bokchoy-pipeline-pr/test_root/log/shard_25' SCREENSHOT_DIR='/home/jenkins/workspace/edx-platform-python3-bokchoy-pipeline-pr/test_root/log/shard_25' BOK_CHOY_HAR_DIR='/home/jenkins/workspace/edx-platform-python3-bokchoy-pipeline-pr/test_root/log/shard_25/hars' BOKCHOY_A11Y_CUSTOM_RULES_FILE='/home/jenkins/workspace/edx-platform-python3-bokchoy-pipeline-pr/node_modules/edx-custom-a11y-rules/lib/custom_a11y_rules.js' SELENIUM_DRIVER_LOG_DIR='/home/jenkins/workspace/edx-platform-python3-bokchoy-pipeline-pr/test_root/log/shard_25' VERIFY_XSS='False' python -Wd -m pytest /home/jenkins/workspace/edx-platform-python3-bokchoy-pipeline-pr/common/test/acceptance/tests --junitxml=/home/jenkins/workspace/edx-platform-python3-bokchoy-pipeline-pr/reports/bok_choy/shard_25/xunit.xml --verbose -a '(shard>=25 or not shard) and not a11y'[32m
14:29:32  ========================================
14:29:32   Running tests for bok-choy 
14:29:32  ========================================
14:29:32  [39;49;00m============================= test session starts ==============================
14:29:32  platform linux -- Python 3.5.2, pytest-4.5.0, py-1.8.0, pluggy-0.13.0 -- /home/jenkins/edxapp_toxenv/py35-django111/bin/python
14:29:32  cachedir: /home/jenkins/edxapp_toxenv/py35-django111/.pytest_cache
14:29:32  rootdir: /home/jenkins/workspace/edx-platform-python3-bokchoy-pipeline-pr/common/test, inifile: pytest.ini
14:29:32  plugins: coverage-pytest-plugin-0.1, faulthandler-1.6.0, attrib-0.1.3, xdist-1.30.0, forked-1.1.3, django-3.6.0, cov-2.7.1
14:29:36  collecting ... collected 1277 items
14:29:36  
14:29:36  - generated xml file: /home/jenkins/workspace/edx-platform-python3-bokchoy-pipeline-pr/reports/bok_choy/shard_25/xunit.xml -
14:29:36  ========================= no tests ran in 3.92 seconds =========================
14:29:36  /home/jenkins/edxapp_toxenv/py35-django111/lib/python3.5/site-packages/_pytest/assertion/rewrite.py:8: PendingDeprecationWarning: the imp module is deprecated in favour of importlib; see the module's documentation for alternative uses
14:29:36    import imp
14:29:36  Traceback (most recent call last):
14:29:36    File "/home/jenkins/edxapp_toxenv/py35-django111/lib/python3.5/site-packages/_pytest/main.py", line 205, in wrap_session
14:29:36      session.exitstatus = doit(config, session) or 0
14:29:36    File "/home/jenkins/edxapp_toxenv/py35-django111/lib/python3.5/site-packages/_pytest/main.py", line 248, in _main
14:29:36      config.hook.pytest_collection(session=session)
14:29:36    File "/home/jenkins/edxapp_toxenv/py35-django111/lib/python3.5/site-packages/pluggy/hooks.py", line 286, in __call__
14:29:36      return self._hookexec(self, self.get_hookimpls(), kwargs)
14:29:36    File "/home/jenkins/edxapp_toxenv/py35-django111/lib/python3.5/site-packages/pluggy/manager.py", line 92, in _hookexec
14:29:36      return self._inner_hookexec(hook, methods, kwargs)
14:29:36    File "/home/jenkins/edxapp_toxenv/py35-django111/lib/python3.5/site-packages/pluggy/manager.py", line 86, in <lambda>
14:29:36      firstresult=hook.spec.opts.get("firstresult") if hook.spec else False,
14:29:36    File "/home/jenkins/edxapp_toxenv/py35-django111/lib/python3.5/site-packages/pluggy/callers.py", line 208, in _multicall
14:29:36      return outcome.get_result()
14:29:36    File "/home/jenkins/edxapp_toxenv/py35-django111/lib/python3.5/site-packages/pluggy/callers.py", line 80, in get_result
14:29:36      raise ex[1].with_traceback(ex[2])
14:29:36    File "/home/jenkins/edxapp_toxenv/py35-django111/lib/python3.5/site-packages/pluggy/callers.py", line 187, in _multicall
14:29:36      res = hook_impl.function(*args)
14:29:36    File "/home/jenkins/edxapp_toxenv/py35-django111/lib/python3.5/site-packages/_pytest/main.py", line 258, in pytest_collection
14:29:36      return session.perform_collect()
14:29:36    File "/home/jenkins/edxapp_toxenv/py35-django111/lib/python3.5/site-packages/_pytest/main.py", line 497, in perform_collect
14:29:36      session=self, config=self.config, items=items
14:29:36    File "/home/jenkins/edxapp_toxenv/py35-django111/lib/python3.5/site-packages/pluggy/hooks.py", line 286, in __call__
14:29:36      return self._hookexec(self, self.get_hookimpls(), kwargs)
14:29:36    File "/home/jenkins/edxapp_toxenv/py35-django111/lib/python3.5/site-packages/pluggy/manager.py", line 92, in _hookexec
14:29:36      return self._inner_hookexec(hook, methods, kwargs)
14:29:36    File "/home/jenkins/edxapp_toxenv/py35-django111/lib/python3.5/site-packages/pluggy/manager.py", line 86, in <lambda>
14:29:36      firstresult=hook.spec.opts.get("firstresult") if hook.spec else False,
14:29:36    File "/home/jenkins/edxapp_toxenv/py35-django111/lib/python3.5/site-packages/pluggy/callers.py", line 208, in _multicall
14:29:36      return outcome.get_result()
14:29:36    File "/home/jenkins/edxapp_toxenv/py35-django111/lib/python3.5/site-packages/pluggy/callers.py", line 80, in get_result
14:29:36      raise ex[1].with_traceback(ex[2])
14:29:36    File "/home/jenkins/edxapp_toxenv/py35-django111/lib/python3.5/site-packages/pluggy/callers.py", line 187, in _multicall
14:29:36      res = hook_impl.function(*args)
14:29:36    File "/home/jenkins/edxapp_toxenv/py35-django111/lib/python3.5/site-packages/pytest_attrib/plugin.py", line 23, in pytest_collection_modifyitems
14:29:36      if attrexpr and not match_attr(colitem, attrexpr):
14:29:36    File "/home/jenkins/edxapp_toxenv/py35-django111/lib/python3.5/site-packages/pytest_attrib/plugin.py", line 34, in match_attr
14:29:36      return eval(expr, {}, AttrMapping(item))
14:29:36    File "<string>", line 1, in <module>
14:29:36  TypeError: unorderable types: NoneType() >= int()
```

To avoid this, check if the shard attribute is present before attempting any comparisons with it.