### PR TITLE
a11y: add role to FPD banner

### DIFF
--- a/common/djangoapps/course_modes/tests/test_views.py
+++ b/common/djangoapps/course_modes/tests/test_views.py
@@ -423,7 +423,7 @@ class CourseModeViewTest(CatalogIntegrationMixin, UrlResetMixin, ModuleStoreTest
             follow=False,
         )
 
-        banner = u'''<div class="first-purchase-offer-banner">'''
+        banner = u'''<div class="first-purchase-offer-banner" role="note">'''
         button = u'''<button type="submit" name="verified_mode">
                     <span>Pursue a Verified Certificate</span>
                     (<span class="upgrade-price-string">$8.50 USD</span>

--- a/openedx/features/course_experience/tests/views/test_course_home.py
+++ b/openedx/features/course_experience/tests/views/test_course_home.py
@@ -437,7 +437,7 @@ class TestCourseHomePageAccess(CourseHomePageTestCase):
         response = self.client.get(url)
         discount_expiration_date = get_discount_expiration_date(user, self.course).strftime(u'%B %d')
         upgrade_link = verified_upgrade_deadline_link(user=user, course=self.course)
-        bannerText = u'''<div class="first-purchase-offer-banner">
+        bannerText = u'''<div class="first-purchase-offer-banner" role="note">
              <span class="first-purchase-offer-banner-bold">
              Upgrade by {discount_expiration_date} and save {percentage}% [{strikeout_price}]</span>
              <br>Discount will be automatically applied at checkout. <a href="{upgrade_link}">Upgrade Now</a>

--- a/openedx/features/discounts/utils.py
+++ b/openedx/features/discounts/utils.py
@@ -110,7 +110,8 @@ def get_first_purchase_offer_banner_fragment(user, course):
                 a_close=HTML('</a>'),
                 br=HTML('<br>'),
                 banner_open=HTML(
-                    '<div class="first-purchase-offer-banner"><span class="first-purchase-offer-banner-bold">'
+                    '<div class="first-purchase-offer-banner" role="note">'
+                    '<span class="first-purchase-offer-banner-bold">'
                 ),
                 discount_expiration_date=discount_expiration_date.strftime(u'%B %d'),
                 percentage=discount_percentage(course),


### PR DESCRIPTION
Added `role=note` for screen reader navigation. 