### PR TITLE
Fix program card for smaller screens like ipad.

### DIFF
--- a/lms/static/sass/elements/_program-card.scss
+++ b/lms/static/sass/elements/_program-card.scss
@@ -136,7 +136,7 @@
       }
 
       margin-top: -8px;
-      font-size: 1em;
+      font-size: 0.9375em;
       font-family: $font-family-sans-serif;
     }
 


### PR DESCRIPTION
Text was overflowing from card on screens containing resolution
between 768 to 810 pixels.

PROD-748

### Before fix with resolution 774 x 618:
![Screen Shot 2019-11-04 at 4 18 27 PM](https://user-images.githubusercontent.com/2851134/68117386-01285400-ff1f-11e9-967d-baab5c9fc7db.png)

### After fix with resolution 774 x 618:
![Screen Shot 2019-11-04 at 4 19 11 PM](https://user-images.githubusercontent.com/2851134/68117403-0c7b7f80-ff1f-11e9-86e7-4c3789597c06.png)
