### PR TITLE
Remove most references to old teams config scheme

### DIFF
--- a/common/test/acceptance/tests/lms/test_teams.py
+++ b/common/test/acceptance/tests/lms/test_teams.py
@@ -103,15 +103,15 @@ class TeamsTabBase(EventsTestMixin, ForumsConfigMixin, UniqueCourseTest):
         )
         return json.loads(response.text)
 
-    def set_team_configuration(self, configuration, enroll_in_course=True, global_staff=False):
+    def set_team_configuration(self, configuration_data, enroll_in_course=True, global_staff=False):
         """
         Sets team configuration on the course and calls auto-auth on the user.
         """
         #pylint: disable=attribute-defined-outside-init
         self.course_fixture = CourseFixture(**self.course_info)
-        if configuration:
+        if configuration_data:
             self.course_fixture.add_advanced_settings(
-                {u"teams_configuration": {u"value": configuration}}
+                {u"teams_configuration": {u"value": configuration_data}}
             )
         self.course_fixture.install()
 

--- a/common/test/acceptance/tests/lms/test_teams.py
+++ b/common/test/acceptance/tests/lms/test_teams.py
@@ -534,8 +534,14 @@ class BrowseTopicsTest(TeamsTabBase):
         """
         initial_description = "A" + " really" * 50 + " long description"
         self.set_team_configuration(
-            {u"max_team_size": 1, u"topics": [{"name": "", "id": "", "description": initial_description}]}
+            {
+                u"max_team_size": 1,
+                u"topics": [
+                    {"id": "long-description-topic", "description": initial_description},
+                ]
+            }
         )
+        import pdb;pdb.set_trace()
         self.topics_page.visit()
         truncated_description = self.topics_page.topic_descriptions[0]
         self.assertLess(len(truncated_description), len(initial_description))

--- a/common/test/acceptance/tests/lms/test_teams.py
+++ b/common/test/acceptance/tests/lms/test_teams.py
@@ -541,7 +541,6 @@ class BrowseTopicsTest(TeamsTabBase):
                 ]
             }
         )
-        import pdb;pdb.set_trace()
         self.topics_page.visit()
         truncated_description = self.topics_page.topic_descriptions[0]
         self.assertLess(len(truncated_description), len(initial_description))

--- a/lms/djangoapps/discussion/django_comment_client/base/tests.py
+++ b/lms/djangoapps/discussion/django_comment_client/base/tests.py
@@ -47,6 +47,7 @@ from openedx.core.djangoapps.django_comment_common.utils import (
     set_course_discussion_settings
 )
 from openedx.core.djangoapps.waffle_utils.testutils import WAFFLE_TABLES
+from openedx.core.lib.teams_config import TeamsConfig
 from student.roles import CourseStaffRole, UserBasedRole
 from student.tests.factories import CourseAccessRoleFactory, CourseEnrollmentFactory, UserFactory
 from track.middleware import TrackMiddleware
@@ -1440,10 +1441,10 @@ class TeamsPermissionsTestCase(ForumsEnableMixin, UrlResetMixin, SharedModuleSto
     def setUpClass(cls):
         # pylint: disable=super-method-not-called
         with super(TeamsPermissionsTestCase, cls).setUpClassAndTestData():
-            teams_configuration = {
+            teams_config_data = {
                 'topics': [{'id': "topic_id", 'name': 'Solar Power', 'description': 'Solar power is hot'}]
             }
-            cls.course = CourseFactory.create(teams_configuration=teams_configuration)
+            cls.course = CourseFactory.create(teams_configuration=TeamsConfig(teams_config_data))
 
     @classmethod
     def setUpTestData(cls):

--- a/lms/djangoapps/instructor/tests/test_api.py
+++ b/lms/djangoapps/instructor/tests/test_api.py
@@ -67,6 +67,7 @@ from openedx.core.djangoapps.django_comment_common.models import FORUM_ROLE_COMM
 from openedx.core.djangoapps.django_comment_common.utils import seed_permissions_roles
 from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
 from openedx.core.djangoapps.site_configuration.tests.mixins import SiteMixin
+from openedx.core.lib.teams_config import TeamsConfig
 from openedx.core.lib.xblock_utils import grade_histogram
 from shoppingcart.models import (
     Coupon,
@@ -3033,9 +3034,9 @@ class TestInstructorAPILevelsDataDump(SharedModuleStoreTestCase, LoginEnrollment
         has teams enabled, and does not when the course does not have teams enabled
         """
         if has_teams:
-            self.course = CourseFactory.create(teams_configuration={
-                'max_size': 2, 'topics': [{'topic-id': 'topic', 'name': 'Topic', 'description': 'A Topic'}]
-            })
+            self.course = CourseFactory.create(teams_configuration=TeamsConfig({
+                'max_size': 2, 'topics': [{'id': 'topic', 'name': 'Topic', 'description': 'A Topic'}]
+            }))
             course_instructor = InstructorFactory(course_key=self.course.id)
             self.client.login(username=course_instructor.username, password='test')
 

--- a/lms/djangoapps/instructor_task/tests/test_tasks_helper.py
+++ b/lms/djangoapps/instructor_task/tests/test_tasks_helper.py
@@ -75,6 +75,7 @@ from openedx.core.djangoapps.course_groups.tests.helpers import CohortFactory
 from openedx.core.djangoapps.credit.tests.factories import CreditCourseFactory
 from openedx.core.djangoapps.user_api.partition_schemes import RandomUserPartitionScheme
 from openedx.core.djangoapps.util.testing import ContentGroupTestCase, TestConditionalContent
+from openedx.core.lib.teams_config import TeamsConfig
 from shoppingcart.models import (
     Coupon,
     CourseRegistrationCode,
@@ -94,6 +95,12 @@ from xmodule.partitions.partitions import Group, UserPartition
 
 from ..models import ReportStore
 from ..tasks_helper.utils import UPDATE_STATUS_FAILED, UPDATE_STATUS_SUCCEEDED
+
+
+_TEAMS_CONFIG = TeamsConfig({
+    'max_size': 2,
+    'topics': [{'id': 'topic', 'name': 'Topic', 'description': 'A Topic'}],
+})
 
 
 class InstructorGradeReportTestCase(TestReportMixin, InstructorTaskCourseTestCase):
@@ -403,9 +410,7 @@ class TestInstructorGradeReport(InstructorGradeReportTestCase):
             course = CourseFactory.create(
                 cohort_config={'cohorted': True, 'auto_cohort': True, 'auto_cohort_groups': ['cohort 1', 'cohort 2']},
                 user_partitions=[experiment_partition],
-                teams_configuration={
-                    'max_size': 2, 'topics': [{'topic-id': 'topic', 'name': 'Topic', 'description': 'A Topic'}]
-                },
+                teams_configuration=_TEAMS_CONFIG,
             )
         _ = CreditCourseFactory(course_key=course.id)
 
@@ -451,9 +456,7 @@ class TestTeamGradeReport(InstructorGradeReportTestCase):
 
     def setUp(self):
         super(TestTeamGradeReport, self).setUp()
-        self.course = CourseFactory.create(teams_configuration={
-            'max_size': 2, 'topics': [{'topic-id': 'topic', 'name': 'Topic', 'description': 'A Topic'}]
-        })
+        self.course = CourseFactory.create(teams_configuration=_TEAMS_CONFIG)
         self.student1 = UserFactory.create()
         CourseEnrollment.enroll(self.student1, self.course.id)
         self.student2 = UserFactory.create()
@@ -1547,9 +1550,7 @@ class TestTeamStudentReport(TestReportMixin, InstructorTaskCourseTestCase):
 
     def setUp(self):
         super(TestTeamStudentReport, self).setUp()
-        self.course = CourseFactory.create(teams_configuration={
-            'max_size': 2, 'topics': [{'topic-id': 'topic', 'name': 'Topic', 'description': 'A Topic'}]
-        })
+        self.course = CourseFactory.create(teams_configuration=_TEAMS_CONFIG)
         self.student1 = UserFactory.create()
         CourseEnrollment.enroll(self.student1, self.course.id)
         self.student2 = UserFactory.create()

--- a/lms/djangoapps/teams/templates/teams/teams.html
+++ b/lms/djangoapps/teams/templates/teams/teams.html
@@ -51,7 +51,7 @@ from openedx.core.djangolib.js_utils import (
         teamMembershipsUrl: '${team_memberships_url | n, js_escaped_string}',
         teamMembershipDetailUrl: '${team_membership_detail_url | n, js_escaped_string}',
         myTeamsUrl: '${my_teams_url | n, js_escaped_string}',
-        maxTeamSize: ${course.teams_max_size | n, dump_js_escaped_json},
+        maxTeamSize: ${course.teams_configuration.default_max_team_size | n, dump_js_escaped_json},
         languages: ${languages | n, dump_js_escaped_json},
         countries: ${countries | n, dump_js_escaped_json},
         teamsBaseUrl: '${teams_base_url | n, js_escaped_string}'

--- a/lms/djangoapps/teams/tests/test_serializers.py
+++ b/lms/djangoapps/teams/tests/test_serializers.py
@@ -10,6 +10,7 @@ from django.test.client import RequestFactory
 
 from lms.djangoapps.teams.serializers import BulkTeamCountTopicSerializer, MembershipSerializer, TopicSerializer
 from lms.djangoapps.teams.tests.factories import CourseTeamFactory, CourseTeamMembershipFactory
+from openedx.core.lib.teams_config import TeamsConfig
 from student.tests.factories import CourseEnrollmentFactory, UserFactory
 from xmodule.modulestore.tests.django_utils import SharedModuleStoreTestCase
 from xmodule.modulestore.tests.factories import CourseFactory
@@ -25,10 +26,10 @@ class SerializerTestCase(SharedModuleStoreTestCase):
         """
         super(SerializerTestCase, self).setUp()
         self.course = CourseFactory.create(
-            teams_configuration={
+            teams_configuration=TeamsConfig({
                 "max_team_size": 10,
                 "topics": [{u'name': u'Tøpic', u'description': u'The bést topic!', u'id': u'0'}]
-            }
+            }),
         )
 
 
@@ -41,7 +42,7 @@ class MembershipSerializerTestCase(SerializerTestCase):
         super(MembershipSerializerTestCase, self).setUp()
         self.team = CourseTeamFactory.create(
             course_id=self.course.id,
-            topic_id=self.course.teams_topics[0]['id']
+            topic_id=self.course.teamsets[0].teamset_id,
         )
         self.user = UserFactory.create()
         CourseEnrollmentFactory.create(user=self.user, course_id=self.course.id)
@@ -81,7 +82,10 @@ class TopicSerializerTestCase(SerializerTestCase):
         team count of 0, and that it only takes one SQL query.
         """
         with self.assertNumQueries(1):
-            serializer = TopicSerializer(self.course.teams_topics[0], context={'course_id': self.course.id})
+            serializer = TopicSerializer(
+                self.course.teamsets[0].cleaned_data_old_format,
+                context={'course_id': self.course.id},
+            )
             self.assertEqual(
                 serializer.data,
                 {u'name': u'Tøpic', u'description': u'The bést topic!', u'id': u'0', u'team_count': 0}
@@ -92,9 +96,14 @@ class TopicSerializerTestCase(SerializerTestCase):
         Verifies that the `TopicSerializer` correctly displays a topic with a
         positive team count, and that it only takes one SQL query.
         """
-        CourseTeamFactory.create(course_id=self.course.id, topic_id=self.course.teams_topics[0]['id'])
+        CourseTeamFactory.create(
+            course_id=self.course.id, topic_id=self.course.teamsets[0].teamset_id
+        )
         with self.assertNumQueries(1):
-            serializer = TopicSerializer(self.course.teams_topics[0], context={'course_id': self.course.id})
+            serializer = TopicSerializer(
+                self.course.teamsets[0].cleaned_data_old_format,
+                context={'course_id': self.course.id},
+            )
             self.assertEqual(
                 serializer.data,
                 {u'name': u'Tøpic', u'description': u'The bést topic!', u'id': u'0', u'team_count': 1}
@@ -102,17 +111,20 @@ class TopicSerializerTestCase(SerializerTestCase):
 
     def test_scoped_within_course(self):
         """Verify that team count is scoped within a course."""
-        duplicate_topic = self.course.teams_topics[0]
+        duplicate_topic = self.course.teamsets[0].cleaned_data_old_format
         second_course = CourseFactory.create(
-            teams_configuration={
+            teams_configuration=TeamsConfig({
                 "max_team_size": 10,
                 "topics": [duplicate_topic]
-            }
+            }),
         )
         CourseTeamFactory.create(course_id=self.course.id, topic_id=duplicate_topic[u'id'])
         CourseTeamFactory.create(course_id=second_course.id, topic_id=duplicate_topic[u'id'])
         with self.assertNumQueries(1):
-            serializer = TopicSerializer(self.course.teams_topics[0], context={'course_id': self.course.id})
+            serializer = TopicSerializer(
+                self.course.teamsets[0].cleaned_data_old_format,
+                context={'course_id': self.course.id},
+            )
             self.assertEqual(
                 serializer.data,
                 {u'name': u'Tøpic', u'description': u'The bést topic!', u'id': u'0', u'team_count': 1}
@@ -140,16 +152,17 @@ class BaseTopicSerializerTestCase(SerializerTestCase):
         Helper method to set up topics on the course.  Returns a list of
         created topics.
         """
-        self.course.teams_configuration['topics'] = []
         topics = [
             {u'name': u'Tøpic {}'.format(i), u'description': u'The bést topic! {}'.format(i), u'id': six.text_type(i)}
             for i in six.moves.range(num_topics)
         ]
-        for i in six.moves.range(num_topics):
-            topic_id = six.text_type(i)
-            self.course.teams_configuration['topics'].append(topics[i])
+        for topic in topics:
             for _ in six.moves.range(teams_per_topic):
-                CourseTeamFactory.create(course_id=self.course.id, topic_id=topic_id)
+                CourseTeamFactory.create(course_id=self.course.id, topic_id=topic['id'])
+        self.course.teams_configuration = TeamsConfig({
+            'max_team_size': self.course.teams_configuration.default_max_team_size,
+            'topics': topics,
+        })
         return topics
 
     def assert_serializer_output(self, topics, num_teams_per_topic, num_queries):
@@ -157,7 +170,10 @@ class BaseTopicSerializerTestCase(SerializerTestCase):
         Verify that the serializer produced the expected topics.
         """
         with self.assertNumQueries(num_queries):
-            page = Paginator(self.course.teams_topics, self.PAGE_SIZE).page(1)
+            page = Paginator(
+                self.course.teams_configuration.cleaned_data_old_format['topics'],
+                self.PAGE_SIZE,
+            ).page(1)
             # pylint: disable=not-callable
             serializer = self.serializer(instance=page, context={'course_id': self.course.id})
             self.assertEqual(
@@ -170,7 +186,7 @@ class BaseTopicSerializerTestCase(SerializerTestCase):
         Verify that we return no results and make no SQL queries for a page
         with no topics.
         """
-        self.course.teams_configuration['topics'] = []
+        self.course.teams_configuration = TeamsConfig({'topics': []})
         self.assert_serializer_output([], num_teams_per_topic=0, num_queries=0)
 
 
@@ -216,10 +232,10 @@ class BulkTeamCountTopicSerializerTestCase(BaseTopicSerializerTestCase):
         first_course_topics = self.setup_topics(num_topics=self.NUM_TOPICS, teams_per_topic=teams_per_topic)
         duplicate_topic = first_course_topics[0]
         second_course = CourseFactory.create(
-            teams_configuration={
+            teams_configuration=TeamsConfig({
                 "max_team_size": 10,
                 "topics": [duplicate_topic]
-            }
+            }),
         )
         CourseTeamFactory.create(course_id=second_course.id, topic_id=duplicate_topic[u'id'])
         self.assert_serializer_output(first_course_topics, num_teams_per_topic=teams_per_topic, num_queries=1)
@@ -229,23 +245,6 @@ class BulkTeamCountTopicSerializerTestCase(BaseTopicSerializerTestCase):
         result = first.copy()
         result.update(second)
         return result
-
-    def setup_topics(self, num_topics=5, teams_per_topic=0):
-        """
-        Helper method to set up topics on the course.  Returns a list of
-        created topics.
-        """
-        self.course.teams_configuration['topics'] = []
-        topics = [
-            {u'name': u'Tøpic {}'.format(i), u'description': u'The bést topic! {}'.format(i), u'id': six.text_type(i)}
-            for i in six.moves.range(num_topics)
-        ]
-        for i in six.moves.range(num_topics):
-            topic_id = six.text_type(i)
-            self.course.teams_configuration['topics'].append(topics[i])
-            for _ in six.moves.range(teams_per_topic):
-                CourseTeamFactory.create(course_id=self.course.id, topic_id=topic_id)
-        return topics
 
     def assert_serializer_output(self, topics, num_teams_per_topic, num_queries):
         """
@@ -263,5 +262,5 @@ class BulkTeamCountTopicSerializerTestCase(BaseTopicSerializerTestCase):
         Verify that we return no results and make no SQL queries for a page
         with no topics.
         """
-        self.course.teams_configuration['topics'] = []
+        self.course.teams_configuration = TeamsConfig({'topics': []})
         self.assert_serializer_output([], num_teams_per_topic=0, num_queries=0)

--- a/lms/djangoapps/teams/tests/test_views.py
+++ b/lms/djangoapps/teams/tests/test_views.py
@@ -25,6 +25,7 @@ from common.test.utils import skip_signal
 from lms.djangoapps.courseware.tests.factories import StaffFactory
 from openedx.core.djangoapps.django_comment_common.models import FORUM_ROLE_COMMUNITY_TA, Role
 from openedx.core.djangoapps.django_comment_common.utils import seed_permissions_roles
+from openedx.core.lib.teams_config import TeamsConfig
 from student.models import CourseEnrollment
 from student.tests.factories import AdminFactory, CourseEnrollmentFactory, UserFactory
 from util.testing import EventTestMixin
@@ -46,7 +47,7 @@ class TestDashboard(SharedModuleStoreTestCase):
     def setUpClass(cls):
         super(TestDashboard, cls).setUpClass()
         cls.course = CourseFactory.create(
-            teams_configuration={
+            teams_configuration=TeamsConfig({
                 "max_team_size": 10,
                 "topics": [
                     {
@@ -56,7 +57,7 @@ class TestDashboard(SharedModuleStoreTestCase):
                     }
                     for topic_id in range(cls.NUM_TOPICS)
                 ]
-            }
+            })
         )
 
     def setUp(self):
@@ -158,7 +159,7 @@ class TestDashboard(SharedModuleStoreTestCase):
 
         # Create a course two
         course_two = CourseFactory.create(
-            teams_configuration={
+            teams_configuration=TeamsConfig({
                 "max_team_size": 1,
                 "topics": [
                     {
@@ -167,7 +168,7 @@ class TestDashboard(SharedModuleStoreTestCase):
                         "description": "Description for test topic for course two."
                     }
                 ]
-            }
+            })
         )
 
         # Login and enroll user in both course course
@@ -204,7 +205,7 @@ class TeamAPITestCase(APITestCase, SharedModuleStoreTestCase):
     def setUpClass(cls):
         # pylint: disable=super-method-not-called
         with super(TeamAPITestCase, cls).setUpClassAndTestData():
-            teams_configuration_1 = {
+            teams_configuration_1 = TeamsConfig({
                 'topics':
                 [
                     {
@@ -213,7 +214,7 @@ class TeamAPITestCase(APITestCase, SharedModuleStoreTestCase):
                         'description': u'Description for topic {}.'.format(i)
                     } for i, name in enumerate([u'Sólar power', 'Wind Power', 'Nuclear Power', 'Coal Power'])
                 ]
-            }
+            })
             cls.test_course_1 = CourseFactory.create(
                 org='TestX',
                 course='TS101',
@@ -221,7 +222,7 @@ class TeamAPITestCase(APITestCase, SharedModuleStoreTestCase):
                 teams_configuration=teams_configuration_1
             )
 
-            teams_configuration_2 = {
+            teams_configuration_2 = TeamsConfig({
                 'topics':
                 [
                     {
@@ -241,7 +242,7 @@ class TeamAPITestCase(APITestCase, SharedModuleStoreTestCase):
                     },
                 ],
                 'max_team_size': 1
-            }
+            })
             cls.test_course_2 = CourseFactory.create(
                 org='MIT',
                 course='6.002x',

--- a/openedx/core/lib/tests/test_teams_config.py
+++ b/openedx/core/lib/tests/test_teams_config.py
@@ -91,14 +91,14 @@ class TeamsConfigTests(TestCase):
             },
             {
                 # Team-set should be dropped due to invalid ID.
-                "id": "Not a slug.",
-                "name": "Assignment about slugs",
+                "id": "the character & cannot be in an ID",
+                "name": "Assignment about ampersands",
             },
             {
                 # All fields invalid except ID;
                 # Team-set will exist but have all fallbacks.
-                "id": "horses",
-                "name": {"assignment", "about", "horses"},
+                "id": "_1. How quickly daft-jumping zebras vex",
+                "name": {"assignment", "about", "zebras"},
                 "description": object(),
                 "max_team_size": -1000,
                 "type": "matrix",
@@ -115,8 +115,8 @@ class TeamsConfigTests(TestCase):
         "max_team_size": None,
         "team_sets": [
             {
-                "id": "horses",
-                "name": "horses",
+                "id": "_1. How quickly daft-jumping zebras vex",
+                "name": "_1. How quickly daft-jumping zebras vex",
                 "description": "",
                 "max_team_size": None,
                 "type": "open",
@@ -202,3 +202,11 @@ class TeamsConfigTests(TestCase):
         assert '987' in config_repr
         assert 'open' in config_repr
         assert 'hedgehogs' in config_repr
+
+    def test_teamset_int_id(self):
+        """
+        Assert integer teaset IDs are treated as strings,
+        for backwards compatibility.
+        """
+        teamset = TeamsetConfig({"id": 5})
+        assert teamset.teamset_id == "5"


### PR DESCRIPTION
This is a follow up from MST-16, which was commited in 3858036.

Changes:
* Enrich course teams_configuration from a plain Dict   to a custom XBlock field that uses the new TeamsConfig  wrapper class.
* Remove teams_conf property from course, as the previous change made it redundant.
* Update teams_enabled implementation.
* Remove teams_max_size field from course, which is  no longer semantically correct, as max team size
  is now defined on a teamset level.
* Remove teams_topics in order to discourage use of raw teams config dict.
* Add convenience properties teamsets and teamsets_by_id to course.
* Allow periods and spaces in teamset IDs to avoid breaking existing course teams.

Some parts of the code still use the old raw config data (identifiable by searching "cleaned_data_old_format"), which we expect to be slowly factored away as we build new teams features. MST-40 has been created to remove any remaining references if necessary.

@edx/masters-devs 
https://openedx.atlassian.net/browse/MST-18