### PR TITLE
BOM-1006

### DIFF
--- a/common/lib/xmodule/xmodule/lti_module.py
+++ b/common/lib/xmodule/xmodule/lti_module.py
@@ -852,7 +852,7 @@ oauth_consumer_key="", oauth_signature="frVp4JuvT1mVXlxktiAUjQ7%2F1cw%3D"'}
             params=list(oauth_headers.items()),
             signature=oauth_signature
         )
-        if not oauth_body_hash in oauth_headers.get('oauth_body_hash'):
+        if oauth_body_hash not in oauth_headers.get('oauth_body_hash'):
             log.error(
                 "OAuth body hash verification failed, provided: {}, "
                 "calculated: {}, for url: {}, body is: {}".format(

--- a/common/lib/xmodule/xmodule/lti_module.py
+++ b/common/lib/xmodule/xmodule/lti_module.py
@@ -852,7 +852,7 @@ oauth_consumer_key="", oauth_signature="frVp4JuvT1mVXlxktiAUjQ7%2F1cw%3D"'}
             params=list(oauth_headers.items()),
             signature=oauth_signature
         )
-        if oauth_body_hash != oauth_headers.get('oauth_body_hash'):
+        if not oauth_body_hash in oauth_headers.get('oauth_body_hash'):
             log.error(
                 "OAuth body hash verification failed, provided: {}, "
                 "calculated: {}, for url: {}, body is: {}".format(


### PR DESCRIPTION
-python3 compatibility
-request header oauth_body_hash is a byte string inside a unicode string thats why
comparison fails. Checking calculated oauth_body_hash in header oauth_body_hash fixes the
failing issues but might not be the solution.

I was not able to find the root cause why the request header is a byte string inside a unicode string. i mean like u"b'stringvalue'". 
comparison fails with u"stringvalue" == u"b'stringvalue'"
fixed by doing u"stringvalue" in u"b'stringvalue'"