### PR TITLE
Allow certification regenration for existing honor certificates

### DIFF
--- a/lms/djangoapps/certificates/queue.py
+++ b/lms/djangoapps/certificates/queue.py
@@ -291,7 +291,8 @@ class XQueueCertInterface(object):
         mode_is_verified = enrollment_mode in GeneratedCertificate.VERIFIED_CERTS_MODES
         user_is_verified = IDVerificationService.user_is_verified(student)
         cert_mode = enrollment_mode
-        is_eligible_for_certificate = is_whitelisted or CourseMode.is_eligible_for_certificate(enrollment_mode)
+        is_eligible_for_certificate = is_whitelisted or CourseMode.is_eligible_for_certificate(enrollment_mode,
+                                                                                               cert_status)
         unverified = False
         # For credit mode generate verified certificate
         if cert_mode in (CourseMode.CREDIT_MODE, CourseMode.MASTERS):

--- a/lms/djangoapps/certificates/tests/test_support_views.py
+++ b/lms/djangoapps/certificates/tests/test_support_views.py
@@ -8,11 +8,14 @@ import json
 
 import ddt
 import six
+from mock import patch
 from django.conf import settings
 from django.test.utils import override_settings
 from django.urls import reverse
 from opaque_keys.edx.keys import CourseKey
 
+from lms.djangoapps.grades.tests.utils import mock_passing_grade
+from lms.djangoapps.certificates import api
 from lms.djangoapps.certificates.models import CertificateInvalidation, CertificateStatuses, GeneratedCertificate
 from lms.djangoapps.certificates.tests.factories import CertificateInvalidationFactory
 from openedx.core.djangoapps.content.course_overviews.tests.factories import CourseOverviewFactory
@@ -21,6 +24,7 @@ from student.roles import GlobalStaff, SupportStaffRole
 from student.tests.factories import UserFactory
 from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
 from xmodule.modulestore.tests.factories import CourseFactory
+
 
 FEATURES_WITH_CERTS_ENABLED = settings.FEATURES.copy()
 FEATURES_WITH_CERTS_ENABLED['CERTIFICATES_HTML_VIEW'] = True
@@ -298,6 +302,23 @@ class CertificateRegenerateTests(CertificateSupportTestCase):
         # we'd expect that the certificate status will be "notpassing"
         cert = GeneratedCertificate.eligible_certificates.get(user=self.student)
         self.assertEqual(cert.status, CertificateStatuses.notpassing)
+
+    @patch('lms.djangoapps.certificates.queue.XQueueCertInterface._generate_cert')
+    def test_regenerate_certificate_for_honor_mode(self, mock_generate_cert):
+        """Test web certificate regenration for the users who have earned the
+           certificate in honor mode
+        """
+        self.cert.mode = 'honor'
+        self.cert.download_url = ''
+        self.cert.save()
+
+        with mock_passing_grade(percent=0.75):
+            with patch('course_modes.models.CourseMode.mode_for_course') as mock_mode_for_course:
+                mock_mode_for_course.return_value = 'honor'
+                api.regenerate_user_certificates(self.student, self.course.id,
+                                                 course=self.course)
+
+                mock_generate_cert.assert_called()
 
     def test_regenerate_certificate_missing_params(self):
         # Missing username


### PR DESCRIPTION
staff should be able to regenerate certificates for the students
who have already earned the certificate using honor mode

Prod-612