### PR TITLE
Revert "ENT-2437 | get_enterprise_customer_for_learner method replaced with e…"

### DIFF
--- a/common/djangoapps/third_party_auth/tests/specs/test_testshib.py
+++ b/common/djangoapps/third_party_auth/tests/specs/test_testshib.py
@@ -159,10 +159,12 @@ class TestShibIntegrationTest(SamlIntegrationTestUtilities, IntegrationTestMixin
     }
 
     @patch('openedx.features.enterprise_support.api.enterprise_customer_for_request')
-    @patch('openedx.core.djangoapps.user_api.accounts.settings_views.enterprise_customer_for_request')
+    @patch('openedx.features.enterprise_support.api.get_enterprise_customer_for_learner')
+    @patch('openedx.core.djangoapps.user_api.accounts.settings_views.get_enterprise_customer_for_learner')
     def test_full_pipeline_succeeds_for_unlinking_testshib_account(
         self,
-        mock_enterprise_customer_for_request_settings_view,
+        mock_get_enterprise_customer_for_learner_settings_view,
+        mock_get_enterprise_customer_for_learner,
         mock_enterprise_customer_for_request,
     ):
 
@@ -197,7 +199,8 @@ class TestShibIntegrationTest(SamlIntegrationTestUtilities, IntegrationTestMixin
             'identity_provider': 'saml-default',
         }
         mock_enterprise_customer_for_request.return_value = enterprise_customer_data
-        mock_enterprise_customer_for_request_settings_view.return_value = enterprise_customer_data
+        mock_get_enterprise_customer_for_learner.return_value = enterprise_customer_data
+        mock_get_enterprise_customer_for_learner_settings_view.return_value = enterprise_customer_data
 
         # Instrument the pipeline to get to the dashboard with the full expected state.
         self.client.get(

--- a/openedx/core/djangoapps/user_api/accounts/settings_views.py
+++ b/openedx/core/djangoapps/user_api/accounts/settings_views.py
@@ -31,7 +31,7 @@ from openedx.core.djangoapps.user_api.accounts.toggles import (
 from openedx.core.djangoapps.user_api.preferences.api import get_user_preferences
 from openedx.core.lib.edx_api_utils import get_edx_api_data
 from openedx.core.lib.time_zone_utils import TIME_ZONE_CHOICES
-from openedx.features.enterprise_support.api import enterprise_customer_for_request
+from openedx.features.enterprise_support.api import get_enterprise_customer_for_learner
 from openedx.features.enterprise_support.utils import update_account_settings_context_for_enterprise
 from student.models import UserProfile
 from third_party_auth import pipeline
@@ -147,7 +147,7 @@ def account_settings_context(request):
         'beta_language': beta_language,
     }
 
-    enterprise_customer = enterprise_customer_for_request(request)
+    enterprise_customer = get_enterprise_customer_for_learner(user=request.user)
     update_account_settings_context_for_enterprise(context, enterprise_customer, user)
 
     if third_party_auth.is_enabled():

--- a/openedx/core/djangoapps/user_api/accounts/tests/test_api.py
+++ b/openedx/core/djangoapps/user_api/accounts/tests/test_api.py
@@ -90,7 +90,7 @@ class TestAccountApi(UserSettingsEventTestMixin, EmailTemplateTagMixin, Retireme
         self.staff_user = UserFactory(is_staff=True, password=self.password)
         self.reset_tracker()
 
-        enterprise_patcher = patch('openedx.features.enterprise_support.api.enterprise_customer_for_request')
+        enterprise_patcher = patch('openedx.features.enterprise_support.api.get_enterprise_customer_for_learner')
         enterprise_learner_patcher = enterprise_patcher.start()
         enterprise_learner_patcher.return_value = {}
         self.addCleanup(enterprise_learner_patcher.stop)
@@ -236,7 +236,7 @@ class TestAccountApi(UserSettingsEventTestMixin, EmailTemplateTagMixin, Retireme
         account_settings = get_account_settings(self.default_request)[0]
         self.assertEqual(level_of_education, account_settings["level_of_education"])
 
-    @patch('openedx.features.enterprise_support.api.enterprise_customer_for_request')
+    @patch('openedx.features.enterprise_support.api.get_enterprise_customer_for_learner')
     @patch('openedx.features.enterprise_support.utils.third_party_auth.provider.Registry.get')
     @ddt.data(
         *itertools.product(

--- a/openedx/core/djangoapps/user_api/accounts/tests/test_settings_views.py
+++ b/openedx/core/djangoapps/user_api/accounts/tests/test_settings_views.py
@@ -67,8 +67,8 @@ class AccountSettingsViewTest(ThirdPartyAuthTestMixin, SiteMixin, ProgramsApiCon
         MessageMiddleware().process_request(self.request)
         messages.error(self.request, 'Facebook is already in use.', extra_tags='Auth facebook')
 
-    @mock.patch('openedx.features.enterprise_support.api.enterprise_customer_for_request')
-    def test_context(self, mock_enterprise_customer_for_request):
+    @mock.patch('openedx.features.enterprise_support.api.get_enterprise_customer_for_learner')
+    def test_context(self, mock_get_enterprise_customer_for_learner):
         self.request.site = SiteFactory.create()
         UserPreferenceFactory(user=self.user, key='pref-lang', value='lt-lt')
         DarkLangConfig(
@@ -78,7 +78,7 @@ class AccountSettingsViewTest(ThirdPartyAuthTestMixin, SiteMixin, ProgramsApiCon
             beta_languages='lt-lt',
             enable_beta_languages=True
         ).save()
-        mock_enterprise_customer_for_request.return_value = {}
+        mock_get_enterprise_customer_for_learner.return_value = {}
 
         with override_settings(LANGUAGES=[EN, LT_LT], LANGUAGE_CODE='en'):
             context = account_settings_context(self.request)
@@ -113,17 +113,17 @@ class AccountSettingsViewTest(ThirdPartyAuthTestMixin, SiteMixin, ProgramsApiCon
             expected_beta_language = {'code': 'lt-lt', 'name': settings.LANGUAGE_DICT.get('lt-lt')}
             self.assertEqual(context['beta_language'], expected_beta_language)
 
-    @mock.patch('openedx.core.djangoapps.user_api.accounts.settings_views.enterprise_customer_for_request')
+    @mock.patch('openedx.core.djangoapps.user_api.accounts.settings_views.get_enterprise_customer_for_learner')
     @mock.patch('openedx.features.enterprise_support.utils.third_party_auth.provider.Registry.get')
     def test_context_for_enterprise_learner(
-            self, mock_get_auth_provider, mock_enterprise_customer_for_request
+            self, mock_get_auth_provider, mock_get_enterprise_customer_for_learner
     ):
         dummy_enterprise_customer = {
             'uuid': 'real-ent-uuid',
             'name': 'Dummy Enterprise',
             'identity_provider': 'saml-ubc'
         }
-        mock_enterprise_customer_for_request.return_value = dummy_enterprise_customer
+        mock_get_enterprise_customer_for_learner.return_value = dummy_enterprise_customer
         self.request.site = SiteFactory.create()
         mock_get_auth_provider.return_value.sync_learner_profile_data = True
         context = account_settings_context(self.request)

--- a/openedx/features/enterprise_support/api.py
+++ b/openedx/features/enterprise_support/api.py
@@ -560,6 +560,17 @@ def get_enterprise_learner_data(user):
             return enterprise_learner_data['results']
 
 
+@enterprise_is_enabled(otherwise={})
+def get_enterprise_customer_for_learner(user):
+    """
+    Return enterprise customer to whom given learner belongs.
+    """
+    enterprise_learner_data = get_enterprise_learner_data(user)
+    if enterprise_learner_data:
+        return enterprise_learner_data[0]['enterprise_customer']
+    return {}
+
+
 def get_consent_notification_data(enterprise_customer):
     """
     Returns the consent notification data from DataSharingConsentPage modal

--- a/openedx/features/enterprise_support/utils.py
+++ b/openedx/features/enterprise_support/utils.py
@@ -8,7 +8,6 @@ import json
 
 import six
 
-from crum import get_current_request
 import third_party_auth
 from django.conf import settings
 from django.utils.translation import ugettext as _
@@ -259,8 +258,8 @@ def get_enterprise_readonly_account_fields(user):
     Returns a set of account fields that are read-only for enterprise users.
     """
     # TODO circular dependency between enterprise_support.api and enterprise_support.utils
-    from openedx.features.enterprise_support.api import enterprise_customer_for_request
-    enterprise_customer = enterprise_customer_for_request(get_current_request())
+    from openedx.features.enterprise_support.api import get_enterprise_customer_for_learner
+    enterprise_customer = get_enterprise_customer_for_learner(user)
 
     enterprise_readonly_account_fields = list(settings.ENTERPRISE_READONLY_ACCOUNT_FIELDS)
 


### PR DESCRIPTION
Reverts edx/edx-platform#22207

We think this PR causes some test failures in python3, reverting it to check.