### PR TITLE
enable video url re-write flag for all the courses

### DIFF
--- a/lms/djangoapps/course_api/blocks/toggles.py
+++ b/lms/djangoapps/course_api/blocks/toggles.py
@@ -41,5 +41,5 @@ HIDE_ACCESS_DENIALS_FLAG = WaffleFlag(
 ENABLE_VIDEO_URL_REWRITE = CourseWaffleFlag(
     waffle_namespace=COURSE_BLOCKS_API_NAMESPACE,
     flag_name="enable_video_url_rewrite",
-    flag_undefined_default=False
+    flag_undefined_default=True
 )


### PR DESCRIPTION
### [PROD-762](https://openedx.atlassian.net/browse/PROD-762)

### Description
This PR is only turning on the **ENABLE_VIDEO_URL_REWRITE**,  by default, for all the courses. This flag was introduced in https://github.com/edx/edx-platform/pull/21617/ and was turned on in https://github.com/edx/edx-platform/pull/22181 but caused KeyError on the production. The bug was fixed in https://github.com/edx/edx-platform/pull/22194/ and the flag is now ready to be activated again for all the courses.

### Reviewers 
 - [x] @awaisdar001

### Post Review
 - [x] Squash & Rebase commits