### PR TITLE
added conditional logs for RCA

### DIFF
--- a/common/lib/capa/capa/capa_problem.py
+++ b/common/lib/capa/capa/capa_problem.py
@@ -736,7 +736,8 @@ class LoncapaProblem(object):
         self.do_targeted_feedback(self.tree)
         html = contextualize_text(
             etree.tostring(self._extract_html(self.tree)).decode('utf-8'),
-            self.context
+            self.context,
+            six.text_type(self.capa_module.location)
         )
         return html
 

--- a/common/lib/capa/capa/util.py
+++ b/common/lib/capa/capa/util.py
@@ -98,7 +98,7 @@ def compare_with_tolerance(student_complex, instructor_complex, tolerance=defaul
         return abs(student_complex - instructor_complex) <= tolerance
 
 
-def contextualize_text(text, context):  # private
+def contextualize_text(text, context, problem_location=None):  # private
     """
     Takes a string with variables. E.g. $a+$b.
     Does a substitution of those variables from the context
@@ -115,17 +115,26 @@ def contextualize_text(text, context):  # private
         try:
             data_string = data_string.replace(old_value, new_value)
             return data_string
-        except Exception as error:
-            log.exception(
-                u'ContextualizeTextError: text(%s): %s, context_key(%s): %s, context_value(%s): %s, Error: %s',
-                type(text),
-                text,
-                type(context_key),
-                context_key,
-                type(context_value),
-                context_value,
-                six.text_type(error)
-            )
+        except Exception:  # pylint: disable=broad-except
+            if problem_location and problem_location == 'block-v1:MITx+CTL.SC3x+2T2019+type@problem+block@cb29c9209862423d87bef76c4ef15695':  # pylint: disable=line-too-long
+                log.error(
+                    u'ContextualizeTextError: data_string(%s), old_value(%s), new_value(%s)',
+                    type(data_string),
+                    type(old_value),
+                    type(new_value),
+                )
+                log.error(
+                    u'ContextualizeTextError: data_string: %s',
+                    data_string,
+                )
+                log.error(
+                    u'ContextualizeTextError: new_value : %s',
+                    new_value,
+                )
+                log.error(
+                    u'ContextualizeTextError: old_value: %s',
+                    old_value,
+                )
             raise
 
     if not text:


### PR DESCRIPTION
### [PROD-860](https://openedx.atlassian.net/browse/PROD-860)

### Description
This PR is adding the conditional log to find the root cause for server error for a particular block.

```
ContextualizeTextError: data_string(<type 'str'>), old_value(<type 'str'>), new_value(<type 'str'>)

ContextualizeTextError: data_string: <div>
<p> Which of the following is true about Holt-Winter model? The notation used in this question is similar to the notation in the course lectures. </p>

ContextualizeTextError: new_value : It does not include trend damping.

ContextualizeTextError: old_value: $ans_4
```