### PR TITLE
Fixing p3 test due to dict ordering

### DIFF
--- a/common/lib/xmodule/xmodule/tests/test_video.py
+++ b/common/lib/xmodule/xmodule/tests/test_video.py
@@ -21,6 +21,7 @@ import shutil
 import unittest
 from tempfile import mkdtemp
 from uuid import uuid4
+from collections import OrderedDict
 
 import ddt
 import six
@@ -731,7 +732,8 @@ class VideoExportTestCase(VideoBlockTestBase):
         self.descriptor.download_track = True
         self.descriptor.html5_sources = ['http://www.example.com/source.mp4', 'http://www.example.com/source1.ogg']
         self.descriptor.download_video = True
-        self.descriptor.transcripts = {'ua': 'ukrainian_translation.srt', 'ge': 'german_translation.srt'}
+        self.descriptor.transcripts = OrderedDict(
+                (('ge', 'german_translation.srt'), ('ua', 'ukrainian_translation.srt')))
         self.descriptor.edx_video_id = edx_video_id
         self.descriptor.runtime.course_id = MagicMock()
 

--- a/common/lib/xmodule/xmodule/video_module/video_module.py
+++ b/common/lib/xmodule/xmodule/video_module/video_module.py
@@ -711,7 +711,7 @@ class VideoBlock(
             ele.set('src', self.handout)
             xml.append(ele)
 
-        transcripts = {}
+        transcripts = OrderedDict()
         if self.transcripts is not None:
             transcripts.update(self.transcripts)
 


### PR DESCRIPTION
text_export_to_xml was failing about 50% of the time due to changes in how dict is ordered in python 3. 