### PR TITLE
Fix Python 3 bug in LTI stub server BOM-1006

### DIFF
--- a/common/djangoapps/terrain/stubs/lti.py
+++ b/common/djangoapps/terrain/stubs/lti.py
@@ -267,7 +267,7 @@ class StubLtiHandler(StubHttpRequestHandler):
         # Calculate and encode body hash. See http://oauth.googlecode.com/svn/spec/ext/body_hash/1.0/oauth-bodyhash.html
         sha1 = hashlib.sha1()
         sha1.update(body.encode('utf-8'))
-        oauth_body_hash = six.text_type(base64.b64encode(sha1.digest()))
+        oauth_body_hash = base64.b64encode(sha1.digest()).decode('utf-8')
         mock_request = mock.Mock(
             uri=six.text_type(six.moves.urllib.parse.unquote(url)),
             headers=headers,

--- a/common/test/acceptance/tests/lms/test_lms_lti.py
+++ b/common/test/acceptance/tests/lms/test_lms_lti.py
@@ -19,7 +19,7 @@ from ...pages.lms.courseware import CoursewarePage, LTIContentIframe
 from ..helpers import UniqueCourseTest, auto_auth, select_option_by_text
 
 
-class TestLTIConusmer(UniqueCourseTest):
+class TestLTIConsumer(UniqueCourseTest):
     """
     Base class for tests of LTI xblock in the LMS.
     """
@@ -29,7 +29,7 @@ class TestLTIConusmer(UniqueCourseTest):
     host = os.environ.get('BOK_CHOY_HOSTNAME', '127.0.0.1')
 
     def setUp(self):
-        super(TestLTIConusmer, self).setUp()
+        super(TestLTIConsumer, self).setUp()
         self.courseware_page = CoursewarePage(self.browser, self.course_id)
         self.lti_iframe = LTIContentIframe(self.browser, self.course_id)
         self.tab_nav = TabNavPage(self.browser)

--- a/lms/djangoapps/grades/tasks.py
+++ b/lms/djangoapps/grades/tasks.py
@@ -139,6 +139,9 @@ def recalculate_course_and_subsection_grades_for_user(self, **kwargs):  # pylint
     Recalculates the course grade and all subsection grades
     for the given ``user`` and ``course_key`` keyword arguments.
     """
+    if 'lms.djangoapps.grades.apps.GradesConfig' not in settings.INSTALLED_APPS:
+        # This task errors when run in-process during Studio tests, just skip it
+        return
     user_id = kwargs.get('user_id')
     course_key_str = kwargs.get('course_key')
 


### PR DESCRIPTION
@Ayub-Khan identified the basic problem in #22242 , this PR just fixes the underlying cause in the LTI stub server after I drilled down a little further.  It turns out that in Python 2, `six.text_type(b'abc')` yields `u'abc'`, but under Python 3 it yields `"b'abc'"`.  I also fixed a typo and an error that I found in the studio logs while debugging this.