### PR TITLE
Fix invocation of (edx.)HtmlUtils.ensureHtml

### DIFF
--- a/lms/templates/login.html
+++ b/lms/templates/login.html
@@ -116,7 +116,7 @@ from openedx.core.djangolib.js_utils import js_escaped_string, dump_js_escaped_j
           removeClass('is-disabled').
           attr('aria-disabled', false).
           prop('disabled', false).
-          html(HtmlUtils.ensureHtml(content).toString());
+          html(edx.HtmlUtils.ensureHtml(content).toString());
       }
       else {
         $submitButton.


### PR DESCRIPTION
Without this the following JS error occurs:

    Uncaught ReferenceError: HtmlUtils is not defined
        at toggleSubmitButton (login:658)