### PR TITLE
Add logs to verify audit cert cutoff date

### DIFF
--- a/lms/djangoapps/certificates/queue.py
+++ b/lms/djangoapps/certificates/queue.py
@@ -375,6 +375,7 @@ class XQueueCertInterface(object):
         # already marked as ineligible -- we don't want to mark
         # existing audit certs as ineligible.
         cutoff = settings.AUDIT_CERT_CUTOFF_DATE
+        LOGGER.info(u"Audit certificates cutoff date {}".format(cutoff))
         if (cutoff and cert.created_date >= cutoff) and not is_eligible_for_certificate:
             cert.status = status.audit_passing if passing else status.audit_notpassing
             cert.save()


### PR DESCRIPTION
Users were awarded audit certificate recently. Adding logs to verify that cutoff date for awarding certificate is correct

[PROD-978](https://openedx.atlassian.net/browse/PROD-978)

