### PR TITLE
fix invalid choices in toggle annotations

### DIFF
--- a/openedx/features/course_experience/__init__.py
+++ b/openedx/features/course_experience/__init__.py
@@ -43,7 +43,7 @@ SHOW_REVIEWS_TOOL_FLAG = CourseWaffleFlag(WAFFLE_FLAG_NAMESPACE, 'show_reviews_t
 # .. toggle_default: False
 # .. toggle_description: Used to determine whether or not to use course goals for the particular course.
 # .. toggle_category: course_experience
-# .. toggle_use_cases: opt_out?, monitored_rollout?
+# .. toggle_use_cases: opt_out, monitored_rollout
 # .. toggle_creation_date: 2017-09-11
 # .. toggle_expiration_date: ???
 # .. toggle_warnings: N/A
@@ -63,7 +63,7 @@ UPGRADE_DEADLINE_MESSAGE = CourseWaffleFlag(WAFFLE_FLAG_NAMESPACE, 'upgrade_dead
 # .. toggle_default: False
 # .. toggle_description: Used to switch between 'welcome message' and 'latest update' on the course home page.
 # .. toggle_category: course_experience
-# .. toggle_use_cases: opt_out?
+# .. toggle_use_cases: opt_out
 # .. toggle_creation_date: 2017-09-11
 # .. toggle_expiration_date: ???
 # .. toggle_warnings: This is meant to be configured using waffle_utils course override only.  Either do not create the actual waffle flag, or be sure to unset the flag even for Superusers.


### PR DESCRIPTION
Fixing feature toggle related code annotations that were causing the  `generate-prod-code-annotation-report` job to fail.

Errors:
```
07:35:39 Search failed due to linting errors!
07:35:39 3 errors:
07:35:39 ---------------------------------
07:35:39 openedx/features/course_experience/__init__.py::46: "opt_out?" is not a valid choice for ".. toggle_use_cases:". Expected one of ['incremental_release', 'launch_date', 'monitored_rollout', 'graceful_degradation', 'beta_testing', 'vip', 'opt_out', 'open_edx'].
07:35:39 openedx/features/course_experience/__init__.py::46: "monitored_rollout?" is not a valid choice for ".. toggle_use_cases:". Expected one of ['incremental_release', 'launch_date', 'monitored_rollout', 'graceful_degradation', 'beta_testing', 'vip', 'opt_out', 'open_edx'].
07:35:39 openedx/features/course_experience/__init__.py::66: "opt_out?" is not a valid choice for ".. toggle_use_cases:". Expected one of ['incremental_release', 'launch_date', 'monitored_rollout', 'graceful_degradation', 'beta_testing', 'vip', 'opt_out', 'open_edx'].
```