### PR TITLE
The type of the attrib object wasn't actually a dict.

### DIFF
--- a/common/lib/xmodule/xmodule/tests/test_video.py
+++ b/common/lib/xmodule/xmodule/tests/test_video.py
@@ -222,21 +222,8 @@ class VideoBlockTestBase(unittest.TestCase):
         for attr in ['tag', 'attrib', 'text', 'tail']:
             expected_attr = getattr(expected, attr)
             actual_attr = getattr(xml, attr)
-
-            # This is to deal with a special issue in the video descriptor xml output.
-            # The value of the transcript attribute of the video tag is a serialized
-            # json string.  This can have comparison problems in python3 where the order
-            # of the dictionary output is not gauranteed to be the same. So the strings
-            # don't match equally.  We convert the parsed json instead so that the
-            # comparison can be correct.
-            if isinstance(expected_attr, dict) and \
-                    isinstance(actual_attr, dict) and \
-                    'transcripts' in expected_attr and \
-                    'transcripts' in actual_attr:
-                expected_attr['transcripts'] = json.loads(expected_attr['transcripts'])
-                actual_attr['transcripts'] = json.loads(actual_attr['transcripts'])
-
             self.assertEqual(expected_attr, actual_attr)
+
         self.assertEqual(get_child_tags(expected), get_child_tags(xml))
         for left, right in zip(expected, xml):
             self.assertXmlEqual(left, right)

--- a/common/lib/xmodule/xmodule/video_module/video_module.py
+++ b/common/lib/xmodule/xmodule/video_module/video_module.py
@@ -745,7 +745,7 @@ class VideoBlock(
                     xml.set('sub', '')
 
                 # Update `transcripts` attribute in the xml
-                xml.set('transcripts', json.dumps(transcripts))
+                xml.set('transcripts', json.dumps(transcripts, sort_keys=True))
 
             except edxval_api.ValVideoNotFoundError:
                 pass


### PR DESCRIPTION
It was an internal class that we can't easily compare to. So I'm opting
to just make the xml output be more consistent and ordered.  I was
hoping to avoid this since the order shouldn't matter but the juggling
we have to do to validate the unorderd data is more complication than
it's worth.

### Please consider the following when opening a pull request:

- Link to the relevant JIRA ticket(s) and tag any relevant team(s).
- Squash your changes down into one or more discrete commits.
  In each commit, include description that could help a developer
  several months from now.
- If running `make upgrade`, run _as close to the time of merging as possible_
  to avoid accidentally downgrading someone else's package.
  Put the output of `make upgrade` in its own separate commit,
  decoupled from other code changes.
- Aim for comprehensive test coverage, but remember that
  automated testing isn't a substitute for manual verification.
- Carefully consider naming, code organization, dependencies when adding new code.
  Code that is amenable to refactoring and improvement benefits all platform developers,
  especially given the size and scope of edx-platform.
  Consult existing Architectural Decision Records (ADRs),
  including those concerning the app(s) you are changing and
  [those concerning edx-platform as a whole](https://github.com/edx/edx-platform/tree/master/docs/decisions).
