### PR TITLE
ARCH-1269: upgrade edx-drf-extensions to 2.4.5

### DIFF
--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -3440,7 +3440,6 @@ JWT_AUTH = {
     ],
     'JWT_AUTH_COOKIE_HEADER_PAYLOAD': 'edx-jwt-cookie-header-payload',
     'JWT_AUTH_COOKIE_SIGNATURE': 'edx-jwt-cookie-signature',
-    'JWT_AUTH_REFRESH_COOKIE': 'edx-jwt-refresh-cookie',
 }
 
 EDX_DRF_EXTENSIONS = {

--- a/openedx/core/djangoapps/oauth_dispatch/toggles.py
+++ b/openedx/core/djangoapps/oauth_dispatch/toggles.py
@@ -4,10 +4,9 @@ Feature toggle code for oauth_dispatch.
 
 from __future__ import absolute_import
 
-from edx_rest_framework_extensions.config import SWITCH_ENFORCE_JWT_SCOPES
+from edx_rest_framework_extensions.config import OAUTH_TOGGLE_NAMESPACE, SWITCH_ENFORCE_JWT_SCOPES
 
 from openedx.core.djangoapps.waffle_utils import WaffleSwitch, WaffleSwitchNamespace
 
-WAFFLE_NAMESPACE = 'oauth2'
-OAUTH2_SWITCHES = WaffleSwitchNamespace(name=WAFFLE_NAMESPACE)
-ENFORCE_JWT_SCOPES = WaffleSwitch(OAUTH2_SWITCHES, SWITCH_ENFORCE_JWT_SCOPES)
+
+ENFORCE_JWT_SCOPES = WaffleSwitch(WaffleSwitchNamespace(name=OAUTH_TOGGLE_NAMESPACE), SWITCH_ENFORCE_JWT_SCOPES)

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -77,12 +77,6 @@ numpy<1.17.0
 #  jsondiff==1.2.0 (from -r requirements/edx/base.txt (line 146))
 jsondiff==1.1.1
 
-
-# Constraining this because when we rolled it to edx.org production
-# we had a lot of memory issues and gunicorn workers started running
-# out of memory.  ARCH-1210
-edx-drf-extensions==2.4.0
-
 # Constraining this since the newer versions require Python 3
 more-itertools==5.0.0
 

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -104,7 +104,7 @@ edx-django-oauth2-provider==1.3.5
 edx-django-release-util==0.3.2
 edx-django-sites-extensions==2.3.1
 edx-django-utils==2.0.2
-edx-drf-extensions==2.4.0
+edx-drf-extensions==2.4.5
 edx-enterprise==2.0.17
 edx-i18n-tools==0.4.8
 edx-milestones==0.2.5

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -126,7 +126,7 @@ edx-django-oauth2-provider==1.3.5
 edx-django-release-util==0.3.2
 edx-django-sites-extensions==2.3.1
 edx-django-utils==2.0.2
-edx-drf-extensions==2.4.0
+edx-drf-extensions==2.4.5
 edx-enterprise==2.0.17
 edx-i18n-tools==0.4.8
 edx-lint==1.3.0

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -123,7 +123,7 @@ edx-django-oauth2-provider==1.3.5
 edx-django-release-util==0.3.2
 edx-django-sites-extensions==2.3.1
 edx-django-utils==2.0.2
-edx-drf-extensions==2.4.0
+edx-drf-extensions==2.4.5
 edx-enterprise==2.0.17
 edx-i18n-tools==0.4.8
 edx-lint==1.3.0


### PR DESCRIPTION
- Upgrade edx-drf-extensions to 2.4.5
- Removed constraint to 2.4.0, because 2.4.2 introduces a workaround for
ARCH-1210 by putting the problematic code behind a django setting.
- Remove unused JWT_AUTH_REFRESH_COOKIE setting.

ARCH-418, ARCH-1269, ARCH-1044

### Please consider the following when opening a pull request:

- Link to the relevant JIRA ticket(s) and tag any relevant team(s).
- Squash your changes down into one or more discrete commits.
  In each commit, include description that could help a developer
  several months from now.
- If running `make upgrade`, run _as close to the time of merging as possible_
  to avoid accidentally downgrading someone else's package.
  Put the output of `make upgrade` in its own separate commit,
  decoupled from other code changes.
- Aim for comprehensive test coverage, but remember that
  automated testing isn't a substitute for manual verification.
- Carefully consider naming, code organization, dependencies when adding new code.
  Code that is amenable to refactoring and improvement benefits all platform developers,
  especially given the size and scope of edx-platform.
  Consult existing Architectural Decision Records (ADRs),
  including those concerning the app(s) you are changing and
  [those concerning edx-platform as a whole](https://github.com/edx/edx-platform/tree/master/docs/decisions).
