### PR TITLE
remove small job queue condition for bulk email task

### DIFF
--- a/lms/djangoapps/bulk_email/tasks.py
+++ b/lms/djangoapps/bulk_email/tasks.py
@@ -195,10 +195,6 @@ def perform_delegate_email_batches(entry_id, course_id, task_input, action_name)
     total_recipients = combined_set.count()
 
     routing_key = settings.BULK_EMAIL_ROUTING_KEY
-    # if there are few enough emails, send them through a different queue
-    # to avoid large courses blocking emails to self and staff
-    if total_recipients <= settings.BULK_EMAIL_JOB_SIZE_THRESHOLD:
-        routing_key = settings.BULK_EMAIL_ROUTING_KEY_SMALL_JOBS
 
     # Weird things happen if we allow empty querysets as input to emailing subtasks
     # The task appears to hang at "0 out of 0 completed" and never finishes.


### PR DESCRIPTION
### [PROD-976](https://openedx.atlassian.net/browse/PROD-976)

### Description
This PR is removing the condition that selects the queues for bulk email tasks based on the number of recipients. For the count less than the threshold, all the tasks were being queued in the default queue, which is the most populated queue. Previously, there used to a queue for the small email count task, but it was removed later, which resulted in the tasks being sent to the default queue. The course teams expect that email to fewer people will be sent quickly. To achieve this, all the email tasks will now be sent to high mem queue which will ensure a quick turnaround.