### PR TITLE
BOM-1027

### DIFF
--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -85,3 +85,6 @@ edx-drf-extensions==2.4.0
 
 # Constraining this since the newer versions require Python 3
 more-itertools==5.0.0
+
+# Constraining this Gunicorn requires Python 3.x >= 3.4.
+gunicorn<20.0.0

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -57,7 +57,7 @@ django-babel-underscore==0.5.2
 django-babel==0.6.2       # via django-babel-underscore
 git+https://github.com/edx/django-celery.git@756cb57aad765cb2b0d37372c1855b8f5f37e6b0#egg=django-celery==3.2.1+edx.2
 django-classy-tags==0.9.0  # via django-sekizai
-django-config-models==1.0.1
+django-config-models==1.0.3
 django-cors-headers==2.1.0
 django-countries==4.6.1
 django-crum==0.7.4
@@ -103,9 +103,9 @@ edx-completion==3.0.1
 edx-django-oauth2-provider==1.3.5
 edx-django-release-util==0.3.2
 edx-django-sites-extensions==2.3.1
-edx-django-utils==2.0.1
+edx-django-utils==2.0.2
 edx-drf-extensions==2.4.0
-edx-enterprise==2.0.16
+edx-enterprise==2.0.17
 edx-i18n-tools==0.4.8
 edx-milestones==0.2.5
 edx-oauth2-provider==1.3.1
@@ -176,7 +176,7 @@ path.py==8.2.1
 pathtools==0.1.2
 paver==1.3.4
 pbr==5.4.3
-pdfminer.six==20191107
+pdfminer.six==20191110
 piexif==1.0.2
 pillow==6.2.1
 pkgconfig==1.5.1          # via xmlsec
@@ -186,7 +186,7 @@ py2neo==3.1.2
 pycontracts==1.7.1
 pycountry==19.8.18
 pycparser==2.19
-pycryptodome==3.9.1       # via pdfminer.six
+pycryptodome==3.9.2       # via pdfminer.six
 pycryptodomex==3.4.7
 pygments==2.4.2
 pygraphviz==1.5
@@ -242,7 +242,7 @@ text-unidecode==1.3       # via python-slugify
 tincan==0.0.5             # via edx-enterprise
 unicodecsv==0.14.1
 uritemplate==3.0.0        # via coreapi, drf-yasg
-urllib3==1.25.6
+urllib3==1.25.7
 user-util==0.1.5
 voluptuous==0.11.7
 watchdog==0.9.0
@@ -255,7 +255,7 @@ git+https://github.com/open-craft/xblock-poll@add89e14558c30f3c8dc7431e5cd6536ff
 xblock-utils==1.2.2
 xblock==1.2.8
 xmlsec==1.3.3             # via python3-saml
-xss-utils==0.1.1
+xss-utils==0.1.2
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools==41.6.0        # via fs, lazy, python-levenshtein

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -77,7 +77,7 @@ django-babel-underscore==0.5.2
 django-babel==0.6.2
 git+https://github.com/edx/django-celery.git@756cb57aad765cb2b0d37372c1855b8f5f37e6b0#egg=django-celery==3.2.1+edx.2
 django-classy-tags==0.9.0
-django-config-models==1.0.1
+django-config-models==1.0.3
 django-cors-headers==2.1.0
 django-countries==4.6.1
 django-crum==0.7.4
@@ -125,9 +125,9 @@ edx-completion==3.0.1
 edx-django-oauth2-provider==1.3.5
 edx-django-release-util==0.3.2
 edx-django-sites-extensions==2.3.1
-edx-django-utils==2.0.1
+edx-django-utils==2.0.2
 edx-drf-extensions==2.4.0
-edx-enterprise==2.0.16
+edx-enterprise==2.0.17
 edx-i18n-tools==0.4.8
 edx-lint==1.3.0
 edx-milestones==0.2.5
@@ -228,7 +228,7 @@ pathlib2==2.3.5
 pathtools==0.1.2
 paver==1.3.4
 pbr==5.4.3
-pdfminer.six==20191107
+pdfminer.six==20191110
 piexif==1.0.2
 pillow==6.2.1
 pip-tools==4.2.0
@@ -243,7 +243,7 @@ pycodestyle==2.5.0
 pycontracts==1.7.1
 pycountry==19.8.18
 pycparser==2.19
-pycryptodome==3.9.1
+pycryptodome==3.9.2
 pycryptodomex==3.4.7
 pyflakes==2.1.1
 pygments==2.4.2
@@ -264,7 +264,7 @@ pysqlite==2.8.3 ; python_version == "2.7"
 pysrt==1.1.1
 pytest-attrib==0.1.3
 git+https://github.com/nedbat/pytest-cov.git@nedbat/cov5-combine#egg=pytest-cov==0.0
-pytest-django==3.6.0
+pytest-django==3.7.0
 pytest-faulthandler==1.6.0
 pytest-forked==1.1.3
 pytest-randomly==1.2.3
@@ -330,7 +330,7 @@ typing==3.7.4.1
 unicodecsv==0.14.1
 unidiff==0.5.5
 uritemplate==3.0.0
-urllib3==1.25.6
+urllib3==1.25.7
 user-util==0.1.5
 virtualenv==16.7.7
 voluptuous==0.11.7
@@ -349,7 +349,7 @@ xblock-utils==1.2.2
 xblock==1.2.8
 xmlsec==1.3.3
 xmltodict==0.12.0
-xss-utils==0.1.1
+xss-utils==0.1.2
 zipp==0.6.0
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/requirements/edx/paver.txt
+++ b/requirements/edx/paver.txt
@@ -25,7 +25,7 @@ pyyaml==5.1.2             # via watchdog
 requests==2.22.0
 six==1.13.0               # via edx-opaque-keys, libsass, mock, paver, python-memcached, stevedore
 stevedore==1.31.0
-urllib3==1.25.6           # via requests
+urllib3==1.25.7           # via requests
 watchdog==0.9.0
 wrapt==1.10.5
 

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -76,7 +76,7 @@ django-babel-underscore==0.5.2
 django-babel==0.6.2
 git+https://github.com/edx/django-celery.git@756cb57aad765cb2b0d37372c1855b8f5f37e6b0#egg=django-celery==3.2.1+edx.2
 django-classy-tags==0.9.0
-django-config-models==1.0.1
+django-config-models==1.0.3
 django-cors-headers==2.1.0
 django-countries==4.6.1
 django-crum==0.7.4
@@ -122,9 +122,9 @@ edx-completion==3.0.1
 edx-django-oauth2-provider==1.3.5
 edx-django-release-util==0.3.2
 edx-django-sites-extensions==2.3.1
-edx-django-utils==2.0.1
+edx-django-utils==2.0.2
 edx-drf-extensions==2.4.0
-edx-enterprise==2.0.16
+edx-enterprise==2.0.17
 edx-i18n-tools==0.4.8
 edx-lint==1.3.0
 edx-milestones==0.2.5
@@ -219,7 +219,7 @@ pathlib2==2.3.5
 pathtools==0.1.2
 paver==1.3.4
 pbr==5.4.3
-pdfminer.six==20191107
+pdfminer.six==20191110
 piexif==1.0.2
 pillow==6.2.1
 pkgconfig==1.5.1
@@ -233,7 +233,7 @@ pycodestyle==2.5.0
 pycontracts==1.7.1
 pycountry==19.8.18
 pycparser==2.19
-pycryptodome==3.9.1
+pycryptodome==3.9.2
 pycryptodomex==3.4.7
 pyflakes==2.1.1           # via flake8
 pygments==2.4.2
@@ -252,7 +252,7 @@ pysqlite==2.8.3 ; python_version == "2.7"
 pysrt==1.1.1
 pytest-attrib==0.1.3
 git+https://github.com/nedbat/pytest-cov.git@nedbat/cov5-combine#egg=pytest-cov==0.0
-pytest-django==3.6.0
+pytest-django==3.7.0
 pytest-faulthandler==1.6.0
 pytest-forked==1.1.3      # via pytest-xdist
 pytest-randomly==1.2.3
@@ -313,7 +313,7 @@ typing==3.7.4.1           # via flake8
 unicodecsv==0.14.1
 unidiff==0.5.5
 uritemplate==3.0.0
-urllib3==1.25.6
+urllib3==1.25.7
 user-util==0.1.5
 virtualenv==16.7.7        # via tox
 voluptuous==0.11.7
@@ -331,7 +331,7 @@ xblock-utils==1.2.2
 xblock==1.2.8
 xmlsec==1.3.3
 xmltodict==0.12.0         # via moto
-xss-utils==0.1.1
+xss-utils==0.1.2
 zipp==0.6.0
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/scripts/xblock/requirements.txt
+++ b/scripts/xblock/requirements.txt
@@ -8,4 +8,4 @@ certifi==2019.9.11        # via requests
 chardet==3.0.4            # via requests
 idna==2.8                 # via requests
 requests==2.22.0
-urllib3==1.25.6           # via requests
+urllib3==1.25.7           # via requests


### PR DESCRIPTION
https://openedx.atlassian.net/browse/BOM-1027

guincorn just released its version on 9th-nov-2019 (20.0.0)
and it requires Python 3.x >= 3.4.
so adding constraint < 20.0.0

fixing `make upgrade`

### Please consider the following when opening a pull request:

- Link to the relevant JIRA ticket(s) and tag any relevant team(s).
- Squash your changes down into one or more discrete commits.
  In each commit, include description that could help a developer
  several months from now.
- If running `make upgrade`, run _as close to the time of merging as possible_
  to avoid accidentally downgrading someone else's package.
  Put the output of `make upgrade` in its own separate commit,
  decoupled from other code changes.
- Aim for comprehensive test coverage, but remember that
  automated testing isn't a substitute for manual verification.
- Carefully consider naming, code organization, dependencies when adding new code.
  Code that is amenable to refactoring and improvement benefits all platform developers,
  especially given the size and scope of edx-platform.
  Consult existing Architectural Decision Records (ADRs),
  including those concerning the app(s) you are changing and
  [those concerning edx-platform as a whole](https://github.com/edx/edx-platform/tree/master/docs/decisions).
