### PR TITLE
force @edx.org users to login through their google account

### DIFF
--- a/openedx/core/djangoapps/user_authn/config/waffle.py
+++ b/openedx/core/djangoapps/user_authn/config/waffle.py
@@ -1,0 +1,13 @@
+"""
+Waffle flags and switches for user authn.
+"""
+from __future__ import absolute_import
+
+from openedx.core.djangoapps.waffle_utils import WaffleSwitchNamespace
+
+WAFFLE_NAMESPACE = u'user_authn'
+
+# If this switch is enabled then users must be sign in using their allowed domain SSO account
+ENABLE_LOGIN_USING_THIRDPARTY_AUTH_ONLY = 'enable_login_using_thirdparty_auth_only'
+
+waffle = WaffleSwitchNamespace(name=WAFFLE_NAMESPACE, log_prefix=u'UserAuthN: ')


### PR DESCRIPTION
**Description:** If user belongs to `edx.org` and does not exist in `AllowedAuthEdxUser` then user must login through `edx.org` Google account

**JIRA:** [ENT-2461](https://openedx.atlassian.net/browse/ENT-2461)

### Please consider the following when opening a pull request:

- Link to the relevant JIRA ticket(s) and tag any relevant team(s).
- Squash your changes down into one or more discrete commits.
  In each commit, include description that could help a developer
  several months from now.
- If running `make upgrade`, run _as close to the time of merging as possible_
  to avoid accidentally downgrading someone else's package.
  Put the output of `make upgrade` in its own separate commit,
  decoupled from other code changes.
- Aim for comprehensive test coverage, but remember that
  automated testing isn't a substitute for manual verification.
- Carefully consider naming, code organization, dependencies when adding new code.
  Code that is amenable to refactoring and improvement benefits all platform developers,
  especially given the size and scope of edx-platform.
  Consult existing Architectural Decision Records (ADRs),
  including those concerning the app(s) you are changing and
  [those concerning edx-platform as a whole](https://github.com/edx/edx-platform/tree/master/docs/decisions).
