### PR TITLE
ENT-1849: Added caller info to the exception message

### DIFF
--- a/lms/djangoapps/support/views/contact_us.py
+++ b/lms/djangoapps/support/views/contact_us.py
@@ -40,8 +40,8 @@ class ContactUsView(View):
         if request.user.is_authenticated:
             context['course_id'] = request.session.get('course_id', '')
             context['user_enrollments'] = CourseEnrollment.enrollments_for_user_with_overviews_preload(request.user)
-            enterprise_learner_data = enterprise_api.get_enterprise_learner_data(user=request.user)
-            if enterprise_learner_data:
+            enterprise_customer = enterprise_api.enterprise_customer_for_request(request)
+            if enterprise_customer:
                 tags.append('enterprise_learner')
 
         context['tags'] = tags

--- a/openedx/features/enterprise_support/api.py
+++ b/openedx/features/enterprise_support/api.py
@@ -5,6 +5,7 @@ from __future__ import absolute_import
 
 import logging
 from functools import wraps
+import traceback
 
 from django.conf import settings
 from django.contrib.auth.models import User
@@ -256,9 +257,10 @@ class EnterpriseApiClient(object):
             response = endpoint().get(**querystring)
         except (HttpClientError, HttpServerError):
             LOGGER.exception(
-                u'Failed to get enterprise-learner for user [%s] with client user [%s]',
+                u'Failed to get enterprise-learner for user [%s] with client user [%s]. Caller: %s',
                 user.username,
-                self.user.username
+                self.user.username,
+                "".join(traceback.format_stack())
             )
             return None
 


### PR DESCRIPTION
Added caller info to the exception message to debug ENT-1849. Existing traceback does not help with debugging.
Replaced `get_enterprise_learner_data` method call with `enterprise_customer_for_request` to get enterprise customer data from cache or session instead of hitting API.

### Please consider the following when opening a pull request:

- Link to the relevant JIRA ticket(s) and tag any relevant team(s).
- Squash your changes down into one or more discrete commits.
  In each commit, include description that could help a developer
  several months from now.
- If running `make upgrade`, run _as close to the time of merging as possible_
  to avoid accidentally downgrading someone else's package.
  Put the output of `make upgrade` in its own separate commit,
  decoupled from other code changes.
- Aim for comprehensive test coverage, but remember that
  automated testing isn't a substitute for manual verification.
- Carefully consider naming, code organization, dependencies when adding new code.
  Code that is amenable to refactoring and improvement benefits all platform developers,
  especially given the size and scope of edx-platform.
  Consult existing Architectural Decision Records (ADRs),
  including those concerning the app(s) you are changing and
  [those concerning edx-platform as a whole](https://github.com/edx/edx-platform/tree/master/docs/decisions).
