### PR TITLE
Management command for rewriting social auth uids

### DIFF
--- a/lms/djangoapps/program_enrollments/management/commands/migrate_saml_uids.py
+++ b/lms/djangoapps/program_enrollments/management/commands/migrate_saml_uids.py
@@ -68,7 +68,11 @@ class Command(BaseCommand):
             auth.uid = '{slug}:{uid}'.format(slug=slug, uid=uid)
             auth.save()
             updated += 1
-        not_previously_linked = reduce(lambda count, mapping: count + (not email_map[mapping['email']]['updated']), uid_mappings, 0)
+
+        not_previously_linked = 0
+        for mapping in uid_mappings:
+            not_previously_linked += not email_map[mapping['email']]['updated']
+
         log.info(
             'Number of users with {slug} UserSocialAuth records for which there was no mapping in the provided file: {missed}'.format(
                 slug=slug,

--- a/lms/djangoapps/program_enrollments/management/commands/migrate_saml_uids.py
+++ b/lms/djangoapps/program_enrollments/management/commands/migrate_saml_uids.py
@@ -48,7 +48,7 @@ class Command(BaseCommand):
             uid_mappings = json.load(f)
         slug = options['saml_provider_slug']
 
-        email_map = { m['email']: {'uid': m['student_key'], 'updated': False, 'counted': False } for m in uid_mappings }
+        email_map = {m['email']: {'uid': m['student_key'], 'updated': False, 'counted': False} for m in uid_mappings}
         user_queryset = User.objects.prefetch_related('social_auth').filter(social_auth__uid__startswith=slug + ':')
         users = [u for u in user_queryset]
 
@@ -85,14 +85,16 @@ class Command(BaseCommand):
             'Number of users with {slug} UserSocialAuth records for which there was no mapping in the provided file: {missed}'.format(
                 slug=slug,
                 missed=missed
-        ))
+            )
+        )
         log.info(
             'Number of users identified in the mapping file without {slug} UserSocialAuth records: {not_previously_linked}'.format(
                 slug=slug,
                 not_previously_linked=not_previously_linked
-        ))
-        log.info('Number of mappings in the mapping file where the identified user has already been processed: {duplicated_in_mapping}'.format(
-            duplicated_in_mapping=duplicated_in_mapping
-        ))
-
-
+            )
+        )
+        log.info(
+            'Number of mappings in the mapping file where the identified user has already been processed: {duplicated_in_mapping}'.format(
+                duplicated_in_mapping=duplicated_in_mapping
+            )
+        )

--- a/lms/djangoapps/program_enrollments/management/commands/migrate_saml_uids.py
+++ b/lms/djangoapps/program_enrollments/management/commands/migrate_saml_uids.py
@@ -1,0 +1,55 @@
+"""
+Management command to re-write UIDs identifying learners in external organizations' systems
+
+Intented for use in production environments, to help support migration
+of existing SSO learners into our most-recent program enrollment flow
+without needing to manually re-link their account.
+"""
+from __future__ import absolute_import, unicode_literals
+
+import logging
+from textwrap import dedent
+
+from django.contrib.auth import get_user_model
+from django.core.management.base import BaseCommand
+
+log = logging.getLogger(__name__)
+
+
+class Command(BaseCommand):
+    """
+    Updates UserSocialAuth records to use UIDs provided in the supplied JSON file
+
+    Example usage:
+        $ ./manage.py lms migrate_saml_uids.py \
+          --uid-mapping=change@my.uid:4045A285AF596D8589C24841657CA3D8,me@too.uid:4045A285AF596D8589C24841657CA3D9 \
+          --saml-provider-slug=default
+    """
+    help = dedent(__doc__).strip()
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            '--uid-mapping',
+            help='comma-separated list of email:uid mappings'
+        )
+        parser.add_argument(
+            '--saml-provider-slug',
+            help='slug of SAMLProvider for which records should be updated'
+        )
+
+    def handle(self, *args, **options):
+        """
+        Performs the re-writing
+        """
+        User = get_user_model()
+        pairs = options['uid_mapping'].split(',')
+        slug = options['saml_provider_slug']
+
+        for pair in pairs:
+            uid_list = pair.split(':')
+            email = uid_list[0]
+            uid = uid_list[1]
+            user = User.objects.prefetch_related('social_auth').get(email=email)
+            auth = user.social_auth.filter(uid__startswith=slug)[0]
+            auth.uid = '{slug}:{uid}'.format(slug=slug, uid=uid)
+            auth.save()

--- a/lms/djangoapps/program_enrollments/management/commands/tests/test_migrate_saml_uids.py
+++ b/lms/djangoapps/program_enrollments/management/commands/tests/test_migrate_saml_uids.py
@@ -149,3 +149,16 @@ class TestMigrateSamlUids(TestCase):
         for ind, auth in enumerate(auths):
             auth.refresh_from_db()
             assert auth.uid == self._format_slug_urn_pair(self.provider_slug, new_urn + six.text_type(ind))
+
+    @patch(_COMMAND_PATH + '.log')
+    def test_learner_duplicated_in_mapping(self, mock_log):
+        auth = UserSocialAuthFactory()
+        email = auth.user.email
+        new_urn = '9001'
+
+        mock_info = mock_log.info
+
+        self._call_command('[{}]'.format(
+            ','.join([self._format_email_uid_pair(email, new_urn) for _ in range(5)])
+        ))
+        mock_info.assert_any_call('Number of mappings in the mapping file where the identified user has already been processed: 4')

--- a/lms/djangoapps/program_enrollments/management/commands/tests/test_migrate_saml_uids.py
+++ b/lms/djangoapps/program_enrollments/management/commands/tests/test_migrate_saml_uids.py
@@ -39,8 +39,25 @@ class TestMigrateSamlUids(TestCase):
         super(TestMigrateSamlUids, cls).setUpClass()
         cls.command = migrate_saml_uids.Command()
 
+    def _format_email_uid_pair(self, email, uid):
+       return '{{"email":"{email}","student_key":"{new_urn}"}}'.format(email=email, new_urn=uid)
+
+
     def _format_single_email_uid_pair_json(self, email, uid):
-        return '[{{"email":"{email}","student_key":"{new_urn}"}}]'.format(email=email, new_urn=uid)
+        return '[{obj}]'.format(
+            obj=self._format_email_uid_pair(email, uid)
+        )
+
+    def _call_command(self, data):
+        with patch(
+                _COMMAND_PATH + '.open',
+                mock_open(read_data=data)
+        ) as _:
+            call_command(
+                self.command,
+                uid_mapping='./foo.json',
+                saml_provider_slug=self.provider_slug
+            )
 
     def _format_slug_urn_pair(self, slug, urn):
         return '{slug}:{urn}'.format(slug=slug, urn=urn)
@@ -50,16 +67,72 @@ class TestMigrateSamlUids(TestCase):
         auth = UserSocialAuthFactory.create(slug=self.provider_slug)
         email = auth.user.email
         old_uid = auth.uid
-        with patch(
-                _COMMAND_PATH + '.open',
-                mock_open(read_data=self._format_single_email_uid_pair_json(email, new_urn))
-        ) as pat:
-            call_command(
-                self.command,
-                uid_mapping='./foo.json',
-                saml_provider_slug=self.provider_slug
-            )
+
+        self._call_command(self._format_single_email_uid_pair_json(email, new_urn))
 
         auth.refresh_from_db()
         assert auth.uid == self._format_slug_urn_pair(self.provider_slug, new_urn)
         assert not auth.uid == old_uid
+
+    def test_post_save_occurs(self):
+        """
+        Test the signals downstream of this update are called with appropriate arguments
+        """
+        auth = UserSocialAuthFactory.create(slug=self.provider_slug)
+        new_urn = '9001'
+        email = auth.user.email
+
+        with patch('lms.djangoapps.program_enrollments.signals.matriculate_learner') as signal_handler_mock:
+            self._call_command(self._format_single_email_uid_pair_json(email, new_urn))
+            assert signal_handler_mock.called
+            # first positional arg matches the user whose auth was updated
+            assert signal_handler_mock.call_args[0][0].id == auth.user.id
+            # second positional arg matches the urn we changed
+            assert signal_handler_mock.call_args[0][1] == self._format_slug_urn_pair(self.provider_slug, new_urn)
+
+    def test_multiple_social_auth_records(self):
+        """
+        Test we only alter one UserSocialAuth record if a learner has two
+        """
+        auth1 = UserSocialAuthFactory.create(slug=self.provider_slug)
+        auth2 = UserSocialAuthFactory.create(
+            slug=self.provider_slug,
+            user=auth1.user
+        )
+        new_urn = '9001'
+        email = auth1.user.email
+
+        assert email == auth2.user.email
+
+        self._call_command(self._format_single_email_uid_pair_json(email, new_urn))
+        auths = UserSocialAuth.objects.filter(
+            user__email=email,
+            uid=self._format_slug_urn_pair(self.provider_slug, new_urn)
+        )
+        assert auths.count() == 1
+
+    @patch(_COMMAND_PATH + '.log')
+    def test_learner_without_social_auth_records(self, mock_log):
+        user = UserFactory()
+        email = user.email
+        new_urn = '9001'
+
+        mock_info = mock_log.info
+
+        self._call_command(self._format_single_email_uid_pair_json(email, new_urn))
+        mock_info.assert_any_call('Number of users identified in the mapping file without {slug} UserSocialAuth records: 1'.format(
+            slug=self.provider_slug
+        ))
+
+    @patch(_COMMAND_PATH + '.log')
+    def test_learner_missed_by_mapping_file(self, mock_log):
+        auth = UserSocialAuthFactory()
+        email = auth.user.email
+        new_urn = '9001'
+
+        mock_info = mock_log.info
+
+        self._call_command(self._format_single_email_uid_pair_json('different' + email, new_urn))
+        mock_info.assert_any_call('Number of users with {slug} UserSocialAuth records for which there was no mapping in the provided file: 1'.format(
+            slug=self.provider_slug
+        ))

--- a/lms/djangoapps/program_enrollments/management/commands/tests/test_migrate_saml_uids.py
+++ b/lms/djangoapps/program_enrollments/management/commands/tests/test_migrate_saml_uids.py
@@ -1,0 +1,59 @@
+"""
+Tests for the migrate_saml_uids management command.
+"""
+from __future__ import absolute_import
+
+from django.core.management import call_command
+from django.test import TestCase
+
+from factory import LazyAttributeSequence, SubFactory
+from factory.django import DjangoModelFactory
+from lms.djangoapps.program_enrollments.management.commands import migrate_saml_uids
+from social_django.models import UserSocialAuth
+from student.tests.factories import UserFactory
+
+
+class UserSocialAuthFactory(DjangoModelFactory):
+    """
+    Factory for UserSocialAuth records.
+    """
+    class Meta(object):
+        model = UserSocialAuth
+    user = SubFactory(UserFactory)
+    uid = LazyAttributeSequence(lambda o, n: '%s:%d' % (o.slug, n))
+
+    class Params(object):
+        slug = 'gatech'
+
+
+class TestMigrateSamlUids(TestCase):
+    """
+    Test migrate_saml_uids command.
+    """
+    provider_slug = 'gatech'
+
+    @classmethod
+    def setUpClass(cls):
+        super(TestMigrateSamlUids, cls).setUpClass()
+        cls.command = migrate_saml_uids.Command()
+
+    def _format_email_uid_pair(self, email, uid):
+        return '{email}:{uid}'.format(email=email, uid=uid)
+
+    def _format_slug_urn_pair(self, slug, urn):
+        return '{slug}:{urn}'.format(slug=slug, urn=urn)
+
+    def test_single_mapping(self):
+        new_urn = '9001'
+        auth = UserSocialAuthFactory.create(slug=self.provider_slug)
+        email = auth.user.email
+        old_uid = auth.uid
+        call_command(
+            self.command,
+            uid_mapping=self._format_email_uid_pair(email, new_urn),
+            saml_provider_slug=self.provider_slug
+        )
+
+        auth.refresh_from_db()
+        assert auth.uid == self._format_slug_urn_pair(self.provider_slug, new_urn)
+        assert not auth.uid == old_uid

--- a/lms/djangoapps/program_enrollments/management/commands/tests/test_migrate_saml_uids.py
+++ b/lms/djangoapps/program_enrollments/management/commands/tests/test_migrate_saml_uids.py
@@ -16,6 +16,7 @@ from student.tests.factories import UserFactory
 
 _COMMAND_PATH = 'lms.djangoapps.program_enrollments.management.commands.migrate_saml_uids'
 
+
 class UserSocialAuthFactory(DjangoModelFactory):
     """
     Factory for UserSocialAuth records.
@@ -41,8 +42,7 @@ class TestMigrateSamlUids(TestCase):
         cls.command = migrate_saml_uids.Command()
 
     def _format_email_uid_pair(self, email, uid):
-       return '{{"email":"{email}","student_key":"{new_urn}"}}'.format(email=email, new_urn=uid)
-
+        return '{{"email":"{email}","student_key":"{new_urn}"}}'.format(email=email, new_urn=uid)
 
     def _format_single_email_uid_pair_json(self, email, uid):
         return '[{obj}]'.format(


### PR DESCRIPTION
This management command will help us support migrating an SSO provider
from one configured user identifier to another, which may be necessary
when previous choices of UID aren't as stable as needed.

Things I'd like to do before switching this from a draft PR:

-  ~move the iteration to a batch update~ EDIT: we can't do that because we really need Django signals to fire downstream of this
- [x] a couple of corner case test cases:
  - [x] two different UserSocialAuth records for the same learner
  - [x] learner with no UserSocialAuth records
  - [x] learner with social auth records which aren't provided in the mapping file

JIRA:EDUCATOR-4701