### PR TITLE
Create UI for CSV team management

### DIFF
--- a/lms/djangoapps/teams/api_urls.py
+++ b/lms/djangoapps/teams/api_urls.py
@@ -7,6 +7,7 @@ from django.conf import settings
 from django.conf.urls import url
 
 from .views import (
+    MembershipBulkManagementView,
     MembershipDetailView,
     MembershipListView,
     TeamsDetailView,
@@ -56,5 +57,12 @@ urlpatterns = [
         ),
         MembershipDetailView.as_view(),
         name="team_membership_detail"
+    ),
+    url(
+        r'^v0/bulk_team_membership/{course_id_pattern}$'.format(
+            course_id_pattern=settings.COURSE_ID_PATTERN,
+        ),
+        MembershipBulkManagementView.as_view(),
+        name="team_membership_bulk_management"
     )
 ]

--- a/lms/djangoapps/teams/csv.py
+++ b/lms/djangoapps/teams/csv.py
@@ -1,0 +1,21 @@
+"""
+CSV processing and generation utilities for Teams LMS app.
+"""
+
+
+def load_team_membership_csv(course, response):
+    """
+    Load a CSV detailing course membership.
+
+    Arguments:
+        course (CourseDescriptor): Course module for which CSV
+            download has been requested.
+        response (HttpResponse): Django response object to which
+            the CSV content will be written.
+    """
+    # This function needs to be implemented (TODO MST-31).
+    _ = course
+    not_implemented_message = (
+        "Team membership CSV download is not yet implemented."
+    )
+    response.write(not_implemented_message + "\n")

--- a/lms/djangoapps/teams/static/teams/js/models/topic.js
+++ b/lms/djangoapps/teams/static/teams/js/models/topic.js
@@ -9,11 +9,17 @@
                 name: '',
                 description: '',
                 team_count: 0,
-                id: ''
+                id: '',
+                type: 'open'
             },
 
             initialize: function(options) {
                 this.url = options.url;
+            },
+
+            isInstructorManaged: function() {
+                var topicType = this.get('type');
+                return topicType === 'public_managed' || topicType === 'private_managed';
             }
         });
         return Topic;

--- a/lms/djangoapps/teams/static/teams/js/spec/views/manage_spec.js
+++ b/lms/djangoapps/teams/static/teams/js/spec/views/manage_spec.js
@@ -1,0 +1,47 @@
+define([
+    'jquery',
+    'backbone',
+    'underscore',
+    'teams/js/views/manage',
+    'teams/js/spec_helpers/team_spec_helpers',
+    'edx-ui-toolkit/js/utils/spec-helpers/ajax-helpers'
+], function($, Backbone, _, ManageView, TeamSpecHelpers, AjaxHelpers) {
+    'use strict';
+
+    describe('Team Management Dashboard', function() {
+        var view;
+        var uploadFile = new File([], 'empty-test-file.csv');
+        var mockUploadClickEvent = {target: {files: [uploadFile]}};
+
+        beforeEach(function() {
+            setFixtures('<div class="teams-container"></div>');
+            view = new ManageView({
+                teamEvents: TeamSpecHelpers.teamEvents,
+                teamMembershipManagementUrl: '/manage-test-url'
+            }).render();
+            spyOn(view, 'handleCsvUploadSuccess');
+            spyOn(view, 'handleCsvUploadFailure');
+        });
+
+        it('can render itself', function() {
+            expect(_.strip(view.$('.download-team-csv').text())).toEqual('Download Memberships');
+            expect(_.strip(view.$('.upload-team-csv').text())).toEqual('Upload Memberships');
+        });
+
+        it('can handle a successful file upload', function() {
+            var requests = AjaxHelpers.requests(this);
+            view.uploadCsv(mockUploadClickEvent);
+            AjaxHelpers.expectRequest(requests, 'POST', view.csvUploadUrl);
+            AjaxHelpers.respondWithJson(requests, {});
+            expect(view.handleCsvUploadSuccess).toHaveBeenCalled();
+        });
+
+        it('can handle a failed file upload', function() {
+            var requests = AjaxHelpers.requests(this);
+            view.uploadCsv(mockUploadClickEvent);
+            AjaxHelpers.expectRequest(requests, 'POST', view.csvUploadUrl);
+            AjaxHelpers.respondWithError(requests);
+            expect(view.handleCsvUploadFailure).toHaveBeenCalled();
+        });
+    });
+});

--- a/lms/djangoapps/teams/static/teams/js/spec/views/teams_tab_spec.js
+++ b/lms/djangoapps/teams/static/teams/js/spec/views/teams_tab_spec.js
@@ -1,14 +1,14 @@
 define([
     'jquery',
+    'underscore',
     'backbone',
     'logger',
     'edx-ui-toolkit/js/utils/spec-helpers/spec-helpers',
     'edx-ui-toolkit/js/utils/spec-helpers/ajax-helpers',
     'common/js/spec_helpers/page_helpers',
     'teams/js/views/teams_tab',
-    'teams/js/spec_helpers/team_spec_helpers',
-    'underscore'
-], function($, Backbone, Logger, SpecHelpers, AjaxHelpers, PageHelpers, TeamsTabView, TeamSpecHelpers, _) {
+    'teams/js/spec_helpers/team_spec_helpers'
+], function($, _, Backbone, Logger, SpecHelpers, AjaxHelpers, PageHelpers, TeamsTabView, TeamSpecHelpers) {
     'use strict';
 
     describe('TeamsTab', function() {
@@ -227,6 +227,53 @@ define([
                 expect(teamsTabView.readOnlyDiscussion({
                     attributes: {membership: []}
                 })).toBe(true);
+            });
+        });
+
+        describe('Manage Tab', function() {
+            var manageTabSelector = '.page-content-nav>.nav-item[data-url=manage]';
+            var noManagedData = TeamSpecHelpers.createMockTopicData(1, 2);
+            var withManagedData = TeamSpecHelpers.createMockTopicData(1, 2);
+            var topicsNoManaged, topicsWithManaged;
+
+            topicsNoManaged = {
+                count: 2,
+                num_pages: 1,
+                current_page: 1,
+                start: 0,
+                results: noManagedData
+            };
+            withManagedData[1].type = 'public_managed';
+            topicsWithManaged = {
+                count: 2,
+                num_pages: 1,
+                current_page: 1,
+                start: 0,
+                results: withManagedData
+            };
+
+            it('is not visible to unprivileged users', function() {
+                var teamsTabView = createTeamsTabView(this, {
+                    userInfo: TeamSpecHelpers.createMockUserInfo({privileged: false}),
+                    topics: topicsNoManaged
+                });
+                expect(teamsTabView.$(manageTabSelector).length).toBe(0);
+            });
+
+            it('is not visible when there are no managed topics', function() {
+                var teamsTabView = createTeamsTabView(this, {
+                    userInfo: TeamSpecHelpers.createMockUserInfo({privileged: true}),
+                    topics: topicsNoManaged
+                });
+                expect(teamsTabView.$(manageTabSelector).length).toBe(0);
+            });
+
+            it('is visible to privileged users when there is a managed topic', function() {
+                var teamsTabView = createTeamsTabView(this, {
+                    userInfo: TeamSpecHelpers.createMockUserInfo({privileged: true}),
+                    topics: topicsWithManaged
+                });
+                expect(teamsTabView.$(manageTabSelector).length).toBe(1);
             });
         });
 

--- a/lms/djangoapps/teams/static/teams/js/views/manage.js
+++ b/lms/djangoapps/teams/static/teams/js/views/manage.js
@@ -1,0 +1,72 @@
+(function(define) {
+    'use strict';
+    define([
+        'backbone',
+        'underscore',
+        'gettext',
+        'edx-ui-toolkit/js/utils/html-utils',
+        'common/js/components/utils/view_utils',
+        'teams/js/views/team_utils',
+        'text!teams/templates/manage.underscore'
+    ], function(Backbone, _, gettext, HtmlUtils, ViewUtils, TeamUtils, manageTemplate) {
+        var ManageView = Backbone.View.extend({
+
+            srInfo: {
+                id: 'heading-manage',
+                text: gettext('Manage')
+            },
+
+            events: {
+                'click #download-team-csv-input': ViewUtils.withDisabledElement('downloadCsv'),
+                'change #upload-team-csv-input': ViewUtils.withDisabledElement('uploadCsv')
+            },
+
+            initialize: function(options) {
+                this.teamEvents = options.teamEvents;
+                this.csvUploadUrl = options.teamMembershipManagementUrl;
+                this.csvDownloadUrl = options.teamMembershipManagementUrl;
+            },
+
+            render: function() {
+                HtmlUtils.setHtml(
+                    this.$el,
+                    HtmlUtils.template(manageTemplate)({})
+                );
+                return this;
+            },
+
+            downloadCsv: function() {
+                window.location.href = this.csvDownloadUrl;
+            },
+
+            uploadCsv: function(event) {
+                var file = event.target.files[0];
+                var self = this;
+                var formData = new FormData();
+
+                formData.append('csv', file);  // xss-lint: disable=javascript-jquery-append
+                return $.ajax({
+                    type: 'POST',
+                    url: self.csvUploadUrl,
+                    data: formData,
+                    processData: false,  // tell jQuery not to process the data
+                    contentType: false   // tell jQuery not to set contentType
+                }).done(
+                    self.handleCsvUploadSuccess
+                ).fail(
+                    self.handleCsvUploadFailure
+                );
+            },
+
+            handleCsvUploadSuccess: function() {
+                // This handler is currently unimplemented (TODO MST-44)
+                this.teamEvents.trigger('teams:update', {});
+            },
+
+            handleCsvUploadFailure: function() {
+                // This handler is currently unimplemented (TODO MST-44)
+            }
+        });
+        return ManageView;
+    });
+}).call(this, define || RequireJS.define);

--- a/lms/djangoapps/teams/static/teams/js/views/teams_tab.js
+++ b/lms/djangoapps/teams/static/teams/js/views/teams_tab.js
@@ -20,6 +20,7 @@
         'teams/js/views/topics',
         'teams/js/views/team_profile',
         'teams/js/views/my_teams',
+        'teams/js/views/manage',
         'teams/js/views/topic_teams',
         'teams/js/views/edit_team',
         'teams/js/views/edit_team_members',
@@ -29,8 +30,9 @@
         'text!teams/templates/teams_tab.underscore'],
         function(Backbone, $, _, gettext, HtmlUtils, StringUtils, SearchFieldView, HeaderView, HeaderModel,
                   TopicModel, TopicCollection, TeamModel, TeamCollection, MyTeamsCollection, TeamAnalytics,
-                  TeamsTabbedView, TopicsView, TeamProfileView, MyTeamsView, TopicTeamsView, TeamEditView,
-                  TeamMembersEditView, TeamProfileHeaderActionsView, TeamUtils, InstructorToolsView, teamsTemplate) {
+                  TeamsTabbedView, TopicsView, TeamProfileView, MyTeamsView, ManageView, TopicTeamsView,
+                  TeamEditView, TeamMembersEditView, TeamProfileHeaderActionsView, TeamUtils, InstructorToolsView,
+                  teamsTemplate) {
             var TeamsHeaderModel = HeaderModel.extend({
                 initialize: function() {
                     _.extend(this.defaults, {nav_aria_label: gettext('Topics')});
@@ -59,7 +61,7 @@
 
             var TeamTabView = Backbone.View.extend({
                 initialize: function(options) {
-                    var router;
+                    var router, tabsList;
                     this.context = options.context;
                     // This slightly tedious approach is necessary
                     // to use regular expressions within Backbone
@@ -78,10 +80,9 @@
                         ['topics/:topic_id/search(/)', _.bind(this.searchTeams, this)],
                         ['topics/:topic_id/create-team(/)', _.bind(this.newTeam, this)],
                         ['teams/:topic_id/:team_id(/)', _.bind(this.browseTeam, this)],
-                        // eslint-disable-next-line no-useless-escape
-                        [new RegExp('^(browse)\/?$'), _.bind(this.goToTab, this)],
-                        // eslint-disable-next-line no-useless-escape
-                        [new RegExp('^(my-teams)\/?$'), _.bind(this.goToTab, this)]
+                        [new RegExp('^(browse)/?$'), _.bind(this.goToTab, this)],
+                        [new RegExp('^(my-teams)/?$'), _.bind(this.goToTab, this)],
+                        [new RegExp('^(manage)/?$'), _.bind(this.goToTab, this)]
                     ], function(route) {
                         router.route.apply(router, route);
                     });
@@ -133,21 +134,38 @@
                         collection: this.topicsCollection
                     });
 
+                    this.manageView = new ManageView({
+                        router: this.router,
+                        teamEvents: this.teamEvents,
+                        teamMembershipManagementUrl: this.context.teamMembershipManagementUrl
+                    });
+
+                    tabsList = [{
+                        title: gettext('My Team'),
+                        url: 'my-teams',
+                        view: this.myTeamsView
+                    }, {
+                        title: gettext('Browse'),
+                        url: 'browse',
+                        view: this.topicsView
+                    }];
+                    if (this.canViewManageTab()) {
+                        tabsList.push({
+                            title: gettext('Manage'),
+                            url: 'manage',
+                            view: this.manageView
+                        });
+                    }
+
                     this.mainView = this.tabbedView = this.createViewWithHeader({
                         title: gettext('Teams'),
-                        description: gettext('See all teams in your course, organized by topic. ' +
-                            'Join a team to collaborate with other learners who are interested' +
-                            'in the same topic as you are.'),
+                        description: gettext(
+                            'See all teams in your course, organized by topic. ' +
+                            'Join a team to collaborate with other learners who are ' +
+                            'interested in the same topic as you are.'
+                        ),
                         mainView: new TeamsTabbedView({
-                            tabs: [{
-                                title: gettext('My Team'),
-                                url: 'my-teams',
-                                view: this.myTeamsView
-                            }, {
-                                title: gettext('Browse'),
-                                url: 'browse',
-                                view: this.topicsView
-                            }],
+                            tabs: tabsList,
                             router: this.router
                         })
                     });
@@ -239,8 +257,10 @@
                         view.mainView = view.createViewWithHeader({
                             topic: topic,
                             title: gettext('Create a New Team'),
-                            description: gettext("Create a new team if you can't find an existing team to join, " +
-                                'or if you would like to learn with friends you know.'),
+                            description: gettext(
+                                'Create a new team if you can\'t find an existing team to join, ' +
+                                'or if you would like to learn with friends you know.'
+                            ),
                             breadcrumbs: view.createBreadcrumbs(topic),
                             mainView: new TeamEditView({
                                 action: 'create',
@@ -274,8 +294,10 @@
                         });
                         editViewWithHeader = self.createViewWithHeader({
                             title: gettext('Edit Team'),
-                            description: gettext('If you make significant changes, ' +
-                                'make sure you notify members of the team before making these changes.'),
+                            description: gettext(
+                                'If you make significant changes, ' +
+                                'make sure you notify members of the team before making these changes.'
+                            ),
                             breadcrumbs: self.createBreadcrumbs(topic, team),
                             mainView: view,
                             topic: topic,
@@ -304,8 +326,10 @@
                             mainView: view,
                             breadcrumbs: self.createBreadcrumbs(topic, team),
                             title: gettext('Membership'),
-                            description: gettext('You can remove members from this team, ' +
-                                "especially if they have not participated in the team's activity."),
+                            description: gettext(
+                                'You can remove members from this team, ' +
+                                'especially if they have not participated in the team\'s activity.'
+                            ),
                             topic: topic,
                             team: team
                         }
@@ -457,6 +481,31 @@
 
                 canEditTeam: function() {
                     return this.context.userInfo.privileged || this.context.userInfo.staff;
+                },
+
+
+                /**
+                 * Returns whether the "Manage" tab should be shown to the user.
+                 */
+                canViewManageTab: function() {
+                    return this.canManageTeams() && this.anyInstructorManagedTopics();
+                },
+
+                /**
+                 * Returns whether a user has permission to manage teams through CSV
+                 * upload & download in the "Manage" tab.
+                 */
+                canManageTeams: function() {
+                    return this.canEditTeam();
+                },
+
+                /**
+                 * Returns whether _any_ of the topics are instructor-managed.
+                 */
+                anyInstructorManagedTopics: function() {
+                    return this.topicsCollection.some(
+                        function(topic) { return topic.isInstructorManaged(); }
+                    );
                 },
 
                 createBreadcrumbs: function(topic, team) {

--- a/lms/djangoapps/teams/static/teams/js/views/topic_teams.js
+++ b/lms/djangoapps/teams/static/teams/js/views/topic_teams.js
@@ -1,13 +1,14 @@
 (function(define) {
     'use strict';
     define([
+        'underscore',
         'backbone',
         'gettext',
+        'edx-ui-toolkit/js/utils/html-utils',
         'teams/js/views/teams',
         'common/js/components/views/paging_header',
-        'text!teams/templates/team-actions.underscore',
-        'underscore'
-    ], function(Backbone, gettext, TeamsView, PagingHeader, teamActionsTemplate, _) {
+        'text!teams/templates/team-actions.underscore'
+    ], function(_, Backbone, gettext, HtmlUtils, TeamsView, PagingHeader, teamActionsTemplate) {
         var TopicTeamsView = TeamsView.extend({
             events: {
                 'click a.browse-teams': 'browseTeams',
@@ -34,9 +35,10 @@
             render: function() {
                 var self = this;
                 this.collection.refresh().done(function() {
+                    var message;
                     TeamsView.prototype.render.call(self);
                     if (self.canUserCreateTeam()) {
-                        var message = interpolate_text( // eslint-disable-line vars-on-top, no-undef
+                        message = interpolate_text(  // eslint-disable-line no-undef
                                 // Translators: this string is shown at the bottom of the teams page
                                 // to find a team to join or else to create a new one. There are three
                                 // links that need to be included in the message:
@@ -45,10 +47,12 @@
                                 // 3. create a new team
                                 // Be careful to start each link with the appropriate start indicator
                                 // (e.g. {browse_span_start} for #1) and finish it with {span_end}.
-                                _.escape(gettext('{browse_span_start}Browse teams in other topics{span_end} or ' +
-                                '{search_span_start}search teams{span_end} in this topic. ' +
-                                "If you still can't find a team to join, " +
-                                '{create_span_start}create a new team in this topic{span_end}.')),
+                                _.escape(gettext(
+                                    '{browse_span_start}Browse teams in other ' +
+                                    'topics{span_end} or {search_span_start}search teams{span_end} ' +
+                                    'in this topic. If you still can\'t find a team to join, ' +
+                                    '{create_span_start}create a new team in this topic{span_end}.'
+                                )),
                             {
                                 browse_span_start: '<a class="browse-teams" href="">',
                                 search_span_start: '<a class="search-teams" href="">',
@@ -56,8 +60,10 @@
                                 span_end: '</a>'
                             }
                             );
-                        // eslint-disable-next-line max-len
-                        self.$el.append(_.template(teamActionsTemplate)({message: message})); // xss-lint: disable=javascript-jquery-append
+                        HtmlUtils.append(
+                            self.$el,
+                            HtmlUtils.template(teamActionsTemplate)({message: message})
+                        );
                     }
                 });
                 return this;

--- a/lms/djangoapps/teams/static/teams/js/views/topics.js
+++ b/lms/djangoapps/teams/static/teams/js/views/topics.js
@@ -1,13 +1,13 @@
 (function(define) {
     'use strict';
     define([
+        'underscore',
         'gettext',
         'teams/js/views/topic_card',
         'teams/js/views/team_utils',
         'common/js/components/views/paging_header',
-        'common/js/components/views/paginated_view',
-        'underscore'
-    ], function(gettext, TopicCardView, TeamUtils, PagingHeader, PaginatedView, _) {
+        'common/js/components/views/paginated_view'
+    ], function(_, gettext, TopicCardView, TeamUtils, PagingHeader, PaginatedView) {
         var TopicsView = PaginatedView.extend({
             type: 'topics',
 

--- a/lms/djangoapps/teams/static/teams/templates/manage.underscore
+++ b/lms/djangoapps/teams/static/teams/templates/manage.underscore
@@ -1,0 +1,42 @@
+<div class="team-management">
+    <div class="page-content-main">
+        <div class="team-management-section">
+            <h3 class="team-detail-header">
+                <%- gettext("View Current Team Memberships") %>
+            </h3>
+            <p>
+                <%- gettext(
+                    "Click to download a comma-separated values (CSV) file that, " +
+                    "for each user, lists the team they are on for each topic."
+                ) %>
+            </p>
+            <button
+                id="download-team-csv-input"
+                class="download-team-csv action action-primary"
+            >
+                <%- gettext("Download Memberships") %>
+            </button>
+        </div>
+        <div class="team-management-section">
+            <h3 class="team-detail-header">
+                <%- gettext("Assign Team Memberships") %>
+            </h3>
+            <p>
+                <%- gettext(
+                    "Click to upload a comma-separated values (CSV) file to assign " +
+                    "users to teams."
+                ) %>
+            </p>
+            <div class="upload-team-csv btn action action-primary">
+                <input
+                    id="upload-team-csv-input"
+                    type="file"
+                    accept="text/csv"
+                    class="input-overlay-hack"
+                />
+                <%- gettext("Upload Memberships") %>
+            </div>
+            <!-- We need to describe the format of the CSV here (TODO MST-49) -->
+        </div>
+    </div>
+</div>

--- a/lms/djangoapps/teams/templates/teams/teams.html
+++ b/lms/djangoapps/teams/templates/teams/teams.html
@@ -51,6 +51,7 @@ from openedx.core.djangolib.js_utils import (
         teamMembershipsUrl: '${team_memberships_url | n, js_escaped_string}',
         teamMembershipDetailUrl: '${team_membership_detail_url | n, js_escaped_string}',
         myTeamsUrl: '${my_teams_url | n, js_escaped_string}',
+        teamMembershipManagementUrl: '${team_membership_management_url | n, js_escaped_string}',
         maxTeamSize: ${course.teams_configuration.default_max_team_size | n, dump_js_escaped_json},
         languages: ${languages | n, dump_js_escaped_json},
         countries: ${countries | n, dump_js_escaped_json},

--- a/lms/djangoapps/teams/tests/test_api.py
+++ b/lms/djangoapps/teams/tests/test_api.py
@@ -13,9 +13,9 @@ from opaque_keys.edx.keys import CourseKey
 from course_modes.models import CourseMode
 from lms.djangoapps.teams import api as teams_api
 from lms.djangoapps.teams.tests.factories import CourseTeamFactory
-from student.tests.factories import CourseEnrollmentFactory, UserFactory
 from student.models import CourseEnrollment
 from student.roles import CourseStaffRole
+from student.tests.factories import CourseEnrollmentFactory, UserFactory
 from xmodule.modulestore.tests.django_utils import SharedModuleStoreTestCase
 
 COURSE_KEY1 = CourseKey.from_string('edx/history/1')

--- a/lms/djangoapps/teams/tests/test_serializers.py
+++ b/lms/djangoapps/teams/tests/test_serializers.py
@@ -154,10 +154,10 @@ class BaseTopicSerializerTestCase(SerializerTestCase):
         """
         topics = [
             {
-                u'name': u'Tøpic {}'.format(i),
-                u'description': u'The bést topic! {}'.format(i),
-                u'id': six.text_type(i),
-                u'type': u'open'
+                'name': 'Tøpic {}'.format(i),
+                'description': 'The bést topic! {}'.format(i),
+                'id': six.text_type(i),
+                'type': 'open',
             }
             for i in six.moves.range(num_topics)
         ]

--- a/lms/static/lms/js/spec/main.js
+++ b/lms/static/lms/js/spec/main.js
@@ -819,6 +819,7 @@
         'teams/js/spec/views/edit_team_members_spec.js',
         'teams/js/spec/views/edit_team_spec.js',
         'teams/js/spec/views/instructor_tools_spec.js',
+        'teams/js/spec/views/manage_spec.js',
         'teams/js/spec/views/my_teams_spec.js',
         'teams/js/spec/views/team_card_spec.js',
         'teams/js/spec/views/team_discussion_spec.js',

--- a/lms/static/sass/views/_teams.scss
+++ b/lms/static/sass/views/_teams.scss
@@ -353,7 +353,29 @@
     }
   }
 
-  .team-profile {
+  .team-management {
+    padding: 1%;
+
+    h3, p, .action, .team-management-section {
+        margin-bottom: 2%;
+    }
+
+    .input-overlay-hack {
+      position: absolute;
+      height: 100%;
+      width: 100%;
+      opacity: 0;
+      top: 0;
+      left: 0;
+      cursor: pointer;
+    }
+
+    .upload-team-csv {
+      position: relative;
+    }
+  }
+
+  .team-profile, .team-management {
     .page-content-main {
       display: inline-block;
       width: flex-grid(8, 12);


### PR DESCRIPTION
Adds "Manage" sub-tab to course "Teams" tab with UI for downloading and uploading team
membership CSVs. The upload and download functionality are currently not implemented.

The new tab only appears when the user is course staff and the course has at least one instructor-managed team-set, which is not the case for any existing courses, so not current course staff will see this change.

https://openedx.atlassian.net/browse/MST-41
@edx/masters-devs 

Follow-up tickets: https://openedx.atlassian.net/browse/MST-44, https://openedx.atlassian.net/browse/MST-49