### PR TITLE
Fixing notify credentials job

### DIFF
--- a/openedx/core/djangoapps/credentials/management/commands/notify_credentials.py
+++ b/openedx/core/djangoapps/credentials/management/commands/notify_credentials.py
@@ -64,9 +64,10 @@ def paged_query(queryset, delay, page_size):
 
         if delay and page:
             time.sleep(delay)
-
-        for i, item in enumerate(subquery, start=1):
-            yield page_start + i, item
+        index = 0
+        for item in subquery.iterator():
+            index += 1
+            yield page_start + index, item
 
 
 class Command(BaseCommand):


### PR DESCRIPTION
When queryset is evaluated it cache the object as well in queryset cache. We have currently a lot of objects of certs and grade and caching them takes a lot of memory. So if we don't cache these objects that will save us some memory. That's why I have used get method separately to avoid the caching.   

PROD-987
