### PR TITLE
Resubmit Photo-Verification button must appear in approval box.

### DIFF
--- a/lms/djangoapps/verify_student/services.py
+++ b/lms/djangoapps/verify_student/services.py
@@ -12,6 +12,7 @@ from django.urls import reverse
 from django.utils.translation import ugettext as _
 
 from course_modes.models import CourseMode
+from lms.djangoapps.verify_student.utils import is_verification_expiring_soon
 from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
 from student.models import User
 
@@ -213,7 +214,8 @@ class IDVerificationService(object):
 
         elif attempt.status == 'approved':
             user_status['status'] = 'approved'
-            if getattr(attempt, 'expiry_date', None):
+            expiration_datetime = cls.get_expiration_datetime(user, ['approved'])
+            if getattr(attempt, 'expiry_date', None) and is_verification_expiring_soon(expiration_datetime):
                 user_status['verification_expiry'] = attempt.expiry_date.date().strftime("%m/%d/%Y")
 
         elif attempt.status in ['submitted', 'approved', 'must_retry']:

--- a/lms/static/sass/multicourse/_dashboard.scss
+++ b/lms/static/sass/multicourse/_dashboard.scss
@@ -1250,6 +1250,18 @@
       border-bottom-color: $verified-color-lvl4;
     }
 
+    .action-reverify {
+      @extend %btn-primary-error;
+      @extend %t-weight4;
+
+      display: block;
+
+      @include font-size(14);
+    }
+
+    .btn-reverify {
+      margin-top: ($baseline/2);
+    }
     .deco-arrow {
       @include triangle(($baseline/2), $verified-color-lvl4, up);
     }

--- a/lms/templates/dashboard/_dashboard_status_verification.html
+++ b/lms/templates/dashboard/_dashboard_status_verification.html
@@ -11,7 +11,10 @@ from django.utils.translation import ugettext as _
             <span class="title status-title">${_("Current Verification Status: Approved")}</span>
             <p class="status-note">${_("Your edX verification has been approved. Your verification is effective for one year after submission.")}</p>
             %if verification_expiry:
-                <p class="status-note"><span><b>${_("Warning")}: </b></span><i>${_("Your photo verification expires on {verification_expiry}.Approved verification photos are required to earn a certificate and to take a proctored exam. It can take up to 3 days to re-verify, so please re-verify at least a week before any proctored events.").format(verification_expiry=verification_expiry)}</i></p>
+                <p class="status-note"><span><b>${_("Warning")}: </b></span><i>${_("Your photo verification expires on {verification_expiry}. Please be aware photo verification can take up to three days once initiated and you will not be able to earn a certificate or take a proctored exam until approved.").format(verification_expiry=verification_expiry)}</i></p>
+                <div class="btn-reverify">
+                    <a href="${reverse('verify_student_reverify')}" class="action action-reverify">${_("Resubmit Verification")}</a>
+                </div>
             %endif
         </li>
     %elif verification_status == 'pending':
@@ -43,7 +46,7 @@ from django.utils.translation import ugettext as _
         <li class="status status-verification is-denied">
             <span class="title status-title">${_("Current Verification Status: Expired")}</span>
             <p class="status-note">${_("Your verification has expired. To receive a verified certificate, you must submit a new photo of yourself and your government-issued photo ID before the verification deadline for your course.")}</p>
-            <p class="status-note"><span><b>${_("Warning")}: </b></span><i>${_("Approved verification photos are required to earn a certificate and to take a proctored exam. It can take up to 3 days to re-verify, so please re-verify at least a week before any proctored events.")}</i></p>
+            <p class="status-note"><span><b>${_("Warning")}: </b></span><i>${_(" Please be aware photo verification can take up to three days once initiated and you will not be able to earn a certificate or take a proctored exam until approved.")}</i></p>
             <div class="btn-reverify">
                 <a href="${reverse('verify_student_reverify')}" class="action action-reverify">${_("Resubmit Verification")}</a>
             </div>


### PR DESCRIPTION
### Description

[PROD-769](https://openedx.atlassian.net/browse/PROD-769)

Currently, Resubmit photo-verification button is not been displayed
inside the approval box on dashboard.In order to allow a learner to
resubmit before expire it must be displayed in it.
For the case when the verification expiry doesn't lie under 4 weeks:
<img width="310" alt="approved" src="https://user-images.githubusercontent.com/15120237/68849513-08f0b100-06f4-11ea-853b-29efa63276e1.png">
For the case when verification expiry lie under 4 weeks(In this case, warning displaying expiry date and resubmit button would appear) :
<img width="305" alt="warning" src="https://user-images.githubusercontent.com/15120237/68849543-19089080-06f4-11ea-993e-bef4654ccc01.png">


