### PR TITLE
Removing flaky tests

### DIFF
--- a/openedx/features/enterprise_support/tests/test_middleware.py
+++ b/openedx/features/enterprise_support/tests/test_middleware.py
@@ -49,20 +49,3 @@ class EnterpriseMiddlewareTest(TestCase):
         self.client.logout()
         self.client.get(self.dashboard)
         assert self.client.session.get('enterprise_customer') is None
-
-    def test_enterprise_customer(self):
-        """The `enterprise_customer` gets set in the session."""
-        self.client.get(self.dashboard)
-        assert self.client.session.get('enterprise_customer') == self.enterprise_customer
-
-    def test_enterprise_customer_cached(self):
-        """The middleware doesn't attempt to refill `enterprise_customer` if it already exists in the session."""
-        assert not self.mock_enterprise_customer_from_api.called
-
-        # First call populates the session by calling the API.
-        self.client.get(self.dashboard)
-        assert self.mock_enterprise_customer_from_api.call_count == 1
-
-        # Second same call has no need to call the API because the session already contains the data.
-        self.client.get(self.dashboard)
-        assert self.mock_enterprise_customer_from_api.call_count == 1


### PR DESCRIPTION
These tests fail intermittently. The related jira ticket to remove flaky test can be found at: https://openedx.atlassian.net/browse/ENT-2479

The tests fail with error log output of: SafeCookieData BWC parse error: 'm3i1v99yuohzsbyjhfp4i9nktjrq4i05'
The error seems to be something to do with safe_cookie_string

