### PR TITLE
Fixing error message for consistency

### DIFF
--- a/lms/djangoapps/courseware/views/views.py
+++ b/lms/djangoapps/courseware/views/views.py
@@ -1619,7 +1619,7 @@ FA_GOALS_LABEL = 'Tell us about your learning or professional goals. How will a 
 FA_EFFORT_LABEL = 'Tell us about your plans for this course. What steps will you take to help you complete ' \
                   'the course work and receive a certificate?'
 
-FA_SHORT_ANSWER_INSTRUCTIONS = _('Use between 250 and 500 words or so in your response.')
+FA_SHORT_ANSWER_INSTRUCTIONS = _('Use between 1250 and 2500 characters or so in your response.')
 
 
 @login_required

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -3463,7 +3463,7 @@ CCX_MAX_STUDENTS_ALLOWED = 200
 
 # Maximum and minimum length of answers, in characters, for the
 # financial assistance form
-FINANCIAL_ASSISTANCE_MIN_LENGTH = 250
+FINANCIAL_ASSISTANCE_MIN_LENGTH = 1250
 FINANCIAL_ASSISTANCE_MAX_LENGTH = 2500
 
 #### Registration form extension. ####

--- a/lms/static/sass/views/_financial-assistance.scss
+++ b/lms/static/sass/views/_financial-assistance.scss
@@ -150,6 +150,8 @@
   .financial-assistance-form {
     @extend .login-register;
 
+    max-width: 800px;
+
     .action-primary {
       @include float(left);
 


### PR DESCRIPTION
This patch would make financial
assistance form help message to be
consistent with implementation. Using
characters limit instead of word limit.

PROD-733
