### PR TITLE
Update ORA2 version

### DIFF
--- a/requirements/edx-sandbox/base.txt
+++ b/requirements/edx-sandbox/base.txt
@@ -33,4 +33,4 @@ subprocess32==3.5.4       # via matplotlib
 sympy==0.7.1
 
 # The following packages are considered to be unsafe in a requirements file:
-# setuptools==41.6.0        # via kiwisolver
+# setuptools==42.0.0        # via kiwisolver

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -117,7 +117,7 @@ edx-rbac==1.0.3           # via edx-enterprise
 edx-rest-api-client==1.9.2
 edx-search==1.2.2
 edx-sga==0.10.0
-edx-submissions==3.0.1
+edx-submissions==3.0.2
 edx-user-state-client==1.1.2
 edx-when==0.5.2
 edxval==1.1.30
@@ -132,7 +132,7 @@ future==0.18.2            # via edx-celeryutils, edx-enterprise, pyjwkest
 futures==3.3.0 ; python_version == "2.7"  # via django-pipeline, python-swiftclient, s3transfer, xblock-utils
 geoip2==2.9.0
 glob2==0.7
-gunicorn==19.9.0
+gunicorn==19.10.0
 help-tokens==1.0.5
 html5lib==1.0.1
 httplib2==0.14.0
@@ -171,7 +171,7 @@ nodeenv==1.3.3
 numpy==1.16.5
 git+https://github.com/joestump/python-oauth2.git@b94f69b1ad195513547924e380d9265133e995fa#egg=oauth2
 oauthlib==2.1.0
-git+https://github.com/edx/edx-ora2.git@2.4.0#egg=ora2==2.4.0
+git+https://github.com/edx/edx-ora2.git@2.4.2#egg=ora2==2.4.2
 path.py==8.2.1
 pathtools==0.1.2
 paver==1.3.4
@@ -237,7 +237,7 @@ staff-graded-xblock==0.5
 stevedore==1.31.0
 super-csv==0.9.6
 sympy==1.4
-testfixtures==6.10.2      # via edx-enterprise
+testfixtures==6.10.3      # via edx-enterprise
 text-unidecode==1.3       # via python-slugify
 tincan==0.0.5             # via edx-enterprise
 unicodecsv==0.14.1
@@ -258,4 +258,4 @@ xmlsec==1.3.3             # via python3-saml
 xss-utils==0.1.2
 
 # The following packages are considered to be unsafe in a requirements file:
-# setuptools==41.6.0        # via fs, lazy, python-levenshtein
+# setuptools==42.0.0        # via fs, lazy, python-levenshtein

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -141,7 +141,7 @@ edx-rest-api-client==1.9.2
 edx-search==1.2.2
 edx-sga==0.10.0
 edx-sphinx-theme==1.5.0
-edx-submissions==3.0.1
+edx-submissions==3.0.2
 edx-user-state-client==1.1.2
 edx-when==0.5.2
 edxval==1.1.30
@@ -166,7 +166,7 @@ future==0.18.2
 futures==3.3.0 ; python_version == "2.7"
 geoip2==2.9.0
 glob2==0.7
-gunicorn==19.9.0
+gunicorn==19.10.0
 help-tokens==1.0.5
 html5lib==1.0.1
 httplib2==0.14.0
@@ -221,7 +221,7 @@ nodeenv==1.3.3
 numpy==1.16.5
 git+https://github.com/joestump/python-oauth2.git@b94f69b1ad195513547924e380d9265133e995fa#egg=oauth2
 oauthlib==2.1.0
-git+https://github.com/edx/edx-ora2.git@2.4.0#egg=ora2==2.4.0
+git+https://github.com/edx/edx-ora2.git@2.4.2#egg=ora2==2.4.2
 packaging==19.2
 path.py==8.2.1
 pathlib2==2.3.5
@@ -259,7 +259,7 @@ pymongo==2.9.1
 pynliner==0.8.0
 pyparsing==2.2.0
 pyquery==1.4.1
-pyrsistent==0.15.5        # via jsonschema
+pyrsistent==0.15.6        # via jsonschema
 pysqlite==2.8.3 ; python_version == "2.7"
 pysrt==1.1.1
 pytest-attrib==0.1.3
@@ -319,7 +319,7 @@ staff-graded-xblock==0.5
 stevedore==1.31.0
 super-csv==0.9.6
 sympy==1.4
-testfixtures==6.10.2
+testfixtures==6.10.3
 text-unidecode==1.3
 tincan==0.0.5
 toml==0.10.0
@@ -332,9 +332,9 @@ unidiff==0.5.5
 uritemplate==3.0.0
 urllib3==1.25.7
 user-util==0.1.5
-virtualenv==16.7.7
+virtualenv==16.7.8
 voluptuous==0.11.7
-vulture==1.1
+vulture==1.2
 watchdog==0.9.0
 wcwidth==0.1.7
 web-fragments==0.3.1
@@ -353,4 +353,4 @@ xss-utils==0.1.2
 zipp==0.6.0
 
 # The following packages are considered to be unsafe in a requirements file:
-# setuptools==41.6.0        # via caniusepython3, fs, jsonschema, lazy, pytest, python-levenshtein, sphinx
+# setuptools==42.0.0        # via caniusepython3, fs, jsonschema, lazy, pytest, python-levenshtein, sphinx

--- a/requirements/edx/github.in
+++ b/requirements/edx/github.in
@@ -81,7 +81,7 @@ git+https://github.com/edx/bridgekeeper.git@4e34894e4ac5d0467ed1901811a81fd87ee0
 # Our libraries:
 -e git+https://github.com/edx/codejail.git@33758da2609bd72c2c18efc2d4bdb93596523d5e#egg=codejail
 -e git+https://github.com/edx/acid-block.git@98aecba94ecbfa934e2d00262741c0ea9f557fc9#egg=acid-xblock
-git+https://github.com/edx/edx-ora2.git@2.4.0#egg=ora2==2.4.0
+git+https://github.com/edx/edx-ora2.git@2.4.2#egg=ora2==2.4.2
 git+https://github.com/edx/crowdsourcehinter.git@a7ffc85b134b7d8909bf1fefd23dbdb8eb28e467#egg=crowdsourcehinter-xblock==0.2
 -e git+https://github.com/edx/RateXBlock.git@2.0#egg=rate-xblock
 -e git+https://github.com/edx/DoneXBlock.git@2.0.1#egg=done-xblock

--- a/requirements/edx/paver.txt
+++ b/requirements/edx/paver.txt
@@ -30,4 +30,4 @@ watchdog==0.9.0
 wrapt==1.10.5
 
 # The following packages are considered to be unsafe in a requirements file:
-# setuptools==41.6.0        # via lazy
+# setuptools==42.0.0        # via lazy

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -61,7 +61,7 @@ cookies==2.2.1            # via moto
 coreapi==2.3.3
 coreschema==0.0.4
 coverage==5.0b1
-git+https://github.com/nedbat/coverage_pytest_plugin.git@b4012f8afa4ae8f4835d078f60555d00090325de#egg=coverage_pytest_plugin==0.0
+git+https://github.com/nedbat/coverage_pytest_plugin.git@29de030251471e200ff255eb9e549218cd60e872#egg=coverage_pytest_plugin==0.0
 git+https://github.com/edx/crowdsourcehinter.git@a7ffc85b134b7d8909bf1fefd23dbdb8eb28e467#egg=crowdsourcehinter-xblock==0.2
 cryptography==2.8
 cssselect==1.1.0
@@ -137,7 +137,7 @@ edx-rbac==1.0.3
 edx-rest-api-client==1.9.2
 edx-search==1.2.2
 edx-sga==0.10.0
-edx-submissions==3.0.1
+edx-submissions==3.0.2
 edx-user-state-client==1.1.2
 edx-when==0.5.2
 edxval==1.1.30
@@ -162,7 +162,7 @@ future==0.18.2
 futures==3.3.0 ; python_version == "2.7"
 geoip2==2.9.0
 glob2==0.7
-gunicorn==19.9.0
+gunicorn==19.10.0
 help-tokens==1.0.5
 html5lib==1.0.1
 httplib2==0.14.0
@@ -212,7 +212,7 @@ nodeenv==1.3.3
 numpy==1.16.5
 git+https://github.com/joestump/python-oauth2.git@b94f69b1ad195513547924e380d9265133e995fa#egg=oauth2
 oauthlib==2.1.0
-git+https://github.com/edx/edx-ora2.git@2.4.0#egg=ora2==2.4.0
+git+https://github.com/edx/edx-ora2.git@2.4.2#egg=ora2==2.4.2
 packaging==19.2           # via caniusepython3, tox
 path.py==8.2.1
 pathlib2==2.3.5
@@ -302,7 +302,7 @@ staff-graded-xblock==0.5
 stevedore==1.31.0
 super-csv==0.9.6
 sympy==1.4
-testfixtures==6.10.2
+testfixtures==6.10.3
 text-unidecode==1.3
 tincan==0.0.5
 toml==0.10.0              # via tox
@@ -315,7 +315,7 @@ unidiff==0.5.5
 uritemplate==3.0.0
 urllib3==1.25.7
 user-util==0.1.5
-virtualenv==16.7.7        # via tox
+virtualenv==16.7.8        # via tox
 voluptuous==0.11.7
 watchdog==0.9.0
 wcwidth==0.1.7            # via pytest
@@ -335,4 +335,4 @@ xss-utils==0.1.2
 zipp==0.6.0
 
 # The following packages are considered to be unsafe in a requirements file:
-# setuptools==41.6.0        # via caniusepython3, fs, lazy, pytest, python-levenshtein
+# setuptools==42.0.0        # via caniusepython3, fs, lazy, pytest, python-levenshtein


### PR DESCRIPTION
### [PROD-996](https://openedx.atlassian.net/browse/PROD-996)

### Description
This PR is bumping the ORA version to `2.4.2` to bring the changes done in https://github.com/edx/edx-ora2/pull/1298. Another important change is `submission` update which is necessary as ORA was updated to use the latest version of submission in `2.4.1`.