### PR TITLE
log section and subsection information during URL retrieval failure

### DIFF
--- a/cms/djangoapps/contentstore/utils.py
+++ b/cms/djangoapps/contentstore/utils.py
@@ -546,7 +546,15 @@ def get_sibling_urls(subsection):
             break
         last_block = block
     if not prev_loc:
-        sections = section.get_parent().get_children()
+        try:
+            sections = section.get_parent().get_children()
+        except AttributeError:
+            log.error(u"Error retrieving URLs in subsection {subsection} included in section {section}".format(
+                section=section.location,
+                subsection=subsection.location
+            ))
+            raise
+
         try:
             prev_section = sections[sections.index(section) - 1]
             prev_loc = prev_section.get_children()[-1].get_children()[-1].location


### PR DESCRIPTION
### [PROD-1026](https://openedx.atlassian.net/browse/PROD-1026)

### Description
This PR is adding the logs to get the section & subsection information when the URL retrieval is failed on the unit page. Here are the traceback and sample logs:

```  File "/edx/app/edxapp/edx-platform/cms/djangoapps/contentstore/views/component.py", line 150, in container_handler
    prev_url, next_url = get_sibling_urls(subsection)
  File "/edx/app/edxapp/edx-platform/cms/djangoapps/contentstore/utils.py", line 549, in get_sibling_urls
    sections = section.get_parent().get_children()
AttributeError: 'NoneType' object has no attribute 'get_children'
```


```
utils.py:555 - Error retrieving URLs in subsection block-v1:ed999+ed989+2019_T2+type@sequential+block@1efeb40cbf83448da2aeb8cb69856fd7 included in section block-v1:ed999+ed989+2019_T2+type@course+block@course
```
