### PR TITLE
Prevent 500 error when viewing malformed unit page

### DIFF
--- a/cms/djangoapps/contentstore/utils.py
+++ b/cms/djangoapps/contentstore/utils.py
@@ -547,19 +547,21 @@ def get_sibling_urls(subsection):
         last_block = block
     if not prev_loc:
         try:
+            # section.get_parent SHOULD return the course, but for some reason, it might not
             sections = section.get_parent().get_children()
         except AttributeError:
             log.error(u"Error retrieving URLs in subsection {subsection} included in section {section}".format(
                 section=section.location,
                 subsection=subsection.location
             ))
-            raise
-
-        try:
-            prev_section = sections[sections.index(section) - 1]
-            prev_loc = prev_section.get_children()[-1].get_children()[-1].location
-        except IndexError:
-            pass
+            # This should not be a fatal error. The worst case is that the navigation on the unit page
+            # won't display a link to a previous unit.
+        else:
+            try:
+                prev_section = sections[sections.index(section) - 1]
+                prev_loc = prev_section.get_children()[-1].get_children()[-1].location
+            except IndexError:
+                pass
     if not next_loc:
         sections = section.get_parent().get_children()
         try:


### PR DESCRIPTION
[PROD-1026](https://openedx.atlassian.net/browse/PROD-1026)

### Please consider the following when opening a pull request:

- Link to the relevant JIRA ticket(s) and tag any relevant team(s).
- Squash your changes down into one or more discrete commits.
  In each commit, include description that could help a developer
  several months from now.
- If running `make upgrade`, run _as close to the time of merging as possible_
  to avoid accidentally downgrading someone else's package.
  Put the output of `make upgrade` in its own separate commit,
  decoupled from other code changes.
- Aim for comprehensive test coverage, but remember that
  automated testing isn't a substitute for manual verification.
- Carefully consider naming, code organization, dependencies when adding new code.
  Code that is amenable to refactoring and improvement benefits all platform developers,
  especially given the size and scope of edx-platform.
  Consult existing Architectural Decision Records (ADRs),
  including those concerning the app(s) you are changing and
  [those concerning edx-platform as a whole](https://github.com/edx/edx-platform/tree/master/docs/decisions).
