### PR TITLE
Update coverage versions for who-tests-what hacking

### DIFF
--- a/requirements/edx/coverage.in
+++ b/requirements/edx/coverage.in
@@ -12,5 +12,5 @@
 
 -c ../constraints.txt
 
-coverage==5.0a6                     # Code coverage testing for Python
+coverage==5.0b1                     # Code coverage testing for Python
 diff-cover==0.9.8                   # Automatically find diff lines that need test coverage

--- a/requirements/edx/coverage.txt
+++ b/requirements/edx/coverage.txt
@@ -6,7 +6,7 @@
 #
 configparser==4.0.2       # via importlib-metadata
 contextlib2==0.6.0.post1  # via importlib-metadata
-coverage==5.0a6
+coverage==5.0b1
 diff-cover==0.9.8
 importlib-metadata==0.23  # via inflect
 inflect==3.0.2            # via jinja2-pluralize

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -61,7 +61,7 @@ contextlib2==0.6.0.post1
 cookies==2.2.1
 coreapi==2.3.3
 coreschema==0.0.4
-coverage==5.0a6
+coverage==5.0b1
 git+https://github.com/nedbat/coverage_pytest_plugin.git@29de030251471e200ff255eb9e549218cd60e872#egg=coverage_pytest_plugin==0.0
 git+https://github.com/edx/crowdsourcehinter.git@a7ffc85b134b7d8909bf1fefd23dbdb8eb28e467#egg=crowdsourcehinter-xblock==0.2
 cryptography==2.8

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -60,8 +60,8 @@ contextlib2==0.6.0.post1
 cookies==2.2.1            # via moto
 coreapi==2.3.3
 coreschema==0.0.4
-coverage==5.0a6
-git+https://github.com/nedbat/coverage_pytest_plugin.git@29de030251471e200ff255eb9e549218cd60e872#egg=coverage_pytest_plugin==0.0
+coverage==5.0b1
+git+https://github.com/nedbat/coverage_pytest_plugin.git@b4012f8afa4ae8f4835d078f60555d00090325de#egg=coverage_pytest_plugin==0.0
 git+https://github.com/edx/crowdsourcehinter.git@a7ffc85b134b7d8909bf1fefd23dbdb8eb28e467#egg=crowdsourcehinter-xblock==0.2
 cryptography==2.8
 cssselect==1.1.0


### PR DESCRIPTION
The coverage version shouldn't matter, but why not use the latest?

The plugin version fixes an encoding issue.
