### PR TITLE
ARCH-1253: switch login_user errors to 400

### DIFF
--- a/openedx/core/djangoapps/user_authn/config/waffle.py
+++ b/openedx/core/djangoapps/user_authn/config/waffle.py
@@ -3,11 +3,37 @@ Waffle flags and switches for user authn.
 """
 from __future__ import absolute_import
 
-from openedx.core.djangoapps.waffle_utils import WaffleSwitchNamespace
+from openedx.core.djangoapps.waffle_utils import WaffleSwitch, WaffleSwitchNamespace
 
-WAFFLE_NAMESPACE = u'user_authn'
+_WAFFLE_NAMESPACE = u'user_authn'
+_WAFFLE_SWITCH_NAMESPACE = WaffleSwitchNamespace(name=_WAFFLE_NAMESPACE, log_prefix=u'UserAuthN: ')
 
-# If this switch is enabled then users must be sign in using their allowed domain SSO account
-ENABLE_LOGIN_USING_THIRDPARTY_AUTH_ONLY = 'enable_login_using_thirdparty_auth_only'
+# .. toggle_name: user_authn.enable_login_using_thirdparty_auth_only
+# .. toggle_implementation: WaffleSwitch
+# .. toggle_default: False
+# .. toggle_description: When enabled, users must be sign in using their allowed domain SSO account.
+# .. toggle_category: authn
+# .. toggle_use_cases: incremental_release
+# .. toggle_creation_date: 2019-11-20
+# .. toggle_expiration_date: 2020-01-31
+# .. toggle_warnings: Requires THIRD_PARTY_AUTH_ONLY_DOMAIN to also be set.
+# .. toggle_tickets: ENT-2461
+# .. toggle_status: supported
+ENABLE_LOGIN_USING_THIRDPARTY_AUTH_ONLY = WaffleSwitch(
+    _WAFFLE_SWITCH_NAMESPACE, 'enable_login_using_thirdparty_auth_only'
+)
 
-waffle = WaffleSwitchNamespace(name=WAFFLE_NAMESPACE, log_prefix=u'UserAuthN: ')
+# .. toggle_name: user_authn.update_login_user_error_status_code
+# .. toggle_implementation: WaffleSwitch
+# .. toggle_default: False
+# .. toggle_description: Changes auth failures (non-SSO) from 200 to 400.
+# .. toggle_category: authn
+# .. toggle_use_cases: incremental_release
+# .. toggle_creation_date: 2019-11-21
+# .. toggle_expiration_date: 2020-01-31
+# .. toggle_warnings: Causes backward incompatible change. Document before removing.
+# .. toggle_tickets: ARCH-1253
+# .. toggle_status: supported
+UPDATE_LOGIN_USER_ERROR_STATUS_CODE = WaffleSwitch(
+    _WAFFLE_SWITCH_NAMESPACE, 'update_login_user_error_status_code'
+)

--- a/openedx/core/djangoapps/user_authn/urls_common.py
+++ b/openedx/core/djangoapps/user_authn/urls_common.py
@@ -37,7 +37,6 @@ urlpatterns = [
     # Login
     url(r'^login_post$', login.login_user, name='login_post'),
     url(r'^login_ajax$', login.login_user, name="login"),
-    url(r'^login_ajax/(?P<error>[^/]*)$', login.login_user),
 
     # Moved from user_api/legacy_urls.py
     # `user_api` prefix is preserved for backwards compatibility.


### PR DESCRIPTION
**IMPORTANT:**
- This can land, but to not turn on switch until /login_post clean-up has landed.

**Description:**

The APIs using login_user are currently not following the API
conventions for non-SSO related authentication errors, by returning a
200 status code for errors.

In addition to switching the status code from 200 => 400 for
authentication failures, the following minor changes were made:
- Document and refactor an existing authn switch.
- Remove an unused url definition for login_ajax + error.

BREAKING CHANGE: This changes /login_post and /login_ajax to return
400, rather than 200, when success=False in the returned JSON (for
non-SSO related authentication errors).

To remove risk around this change, it was added behind a waffle switch
named `user_authn.update_login_user_error_status_code`.

A breaking change was made, rather than introducing /login_ajax_new,
in order to more quickly get to our end goal of the current clean-up
effort of having a single function for login. If this breaks any
callers, we may fix or abandon this change altogether.

ARCH-1253

### Please consider the following when opening a pull request:

- Link to the relevant JIRA ticket(s) and tag any relevant team(s).
- Squash your changes down into one or more discrete commits.
  In each commit, include description that could help a developer
  several months from now.
- If running `make upgrade`, run _as close to the time of merging as possible_
  to avoid accidentally downgrading someone else's package.
  Put the output of `make upgrade` in its own separate commit,
  decoupled from other code changes.
- Aim for comprehensive test coverage, but remember that
  automated testing isn't a substitute for manual verification.
- Carefully consider naming, code organization, dependencies when adding new code.
  Code that is amenable to refactoring and improvement benefits all platform developers,
  especially given the size and scope of edx-platform.
  Consult existing Architectural Decision Records (ADRs),
  including those concerning the app(s) you are changing and
  [those concerning edx-platform as a whole](https://github.com/edx/edx-platform/tree/master/docs/decisions).
