### PR TITLE
Do not hide all the elements of the units with graded problems to anonymous users

### DIFF
--- a/common/lib/xmodule/xmodule/seq_module.py
+++ b/common/lib/xmodule/xmodule/seq_module.py
@@ -520,13 +520,6 @@ class SequenceModule(SequenceFields, ProctoringFields, XModule):
             item_type = item.get_icon_class()
             usage_id = item.scope_ids.usage_id
 
-            if item_type == 'problem' and not is_user_authenticated:
-                log.info(
-                    'Problem [%s] was not rendered because anonymous access is not allowed for graded content',
-                    usage_id
-                )
-                continue
-
             show_bookmark_button = False
             is_bookmarked = False
 


### PR DESCRIPTION
Right now the units of a public course are hidden if there is at least a graded activity in them. This is done because a [change](https://github.com/edx/edx-platform/commit/69eeca61d8002e3280f9c069d18d09bdf24453df) that was done before the implementation of [public_view](https://github.com/edx/edx-platform/pull/19284) mechanism for unenrolled users.

I think that since those components don;t have implemented the public_view, it is safe to do this change.



After this change, this is how it looks a unit with a checkbox component and a video.
![image](https://user-images.githubusercontent.com/22335041/69372385-fb00da00-0c77-11ea-91d3-6a8af030fed9.png)



## How to test:

- Create a course. 
- Add a unit with a graded component
- Enable public access
- Access in LMS that unit from a public user. 

### Current behaviour:
The units with graded component are hidden. Somehow the subsections of the course are broken when it is accessed using the links in course outline

### Expected behaviour: 
Graded components display a message saying that it is only accessible from enrolled users.
