### PR TITLE
render content and log the error when getting sibling urls

### DIFF
--- a/cms/djangoapps/contentstore/utils.py
+++ b/cms/djangoapps/contentstore/utils.py
@@ -550,7 +550,7 @@ def get_sibling_urls(subsection):
             # section.get_parent SHOULD return the course, but for some reason, it might not
             sections = section.get_parent().get_children()
         except AttributeError:
-            log.error(u"Error retrieving URLs in subsection {subsection} included in section {section}".format(
+            log.error(u"URL Retrieval Error # 1: subsection {subsection} included in section {section}".format(
                 section=section.location,
                 subsection=subsection.location
             ))
@@ -563,12 +563,19 @@ def get_sibling_urls(subsection):
             except IndexError:
                 pass
     if not next_loc:
-        sections = section.get_parent().get_children()
         try:
-            next_section = sections[sections.index(section) + 1]
-            next_loc = next_section.get_children()[0].get_children()[0].location
-        except IndexError:
-            pass
+            sections = section.get_parent().get_children()
+        except AttributeError:
+            log.error(u"URL Retrieval Error # 2: subsection {subsection} included in section {section}".format(
+                section=section.location,
+                subsection=subsection.location
+            ))
+        else:
+            try:
+                next_section = sections[sections.index(section) + 1]
+                next_loc = next_section.get_children()[0].get_children()[0].location
+            except IndexError:
+                pass
     if prev_loc:
         prev_url = reverse_usage_url('container_handler', prev_loc)
     if next_loc:


### PR DESCRIPTION
### [PROD-1026](https://openedx.atlassian.net/browse/PROD-1026)

### Description
This PR is performing the following updates(extension of https://github.com/edx/edx-platform/pull/22371):

1. Modify the error logs when getting the sibling URLs on the studio's content editor page.
2. Render the page despite the URL retrieval failure(but log the information)

`edx.devstack.studio  | 2019-11-25 09:51:01,774 ERROR 2699 [contentstore.utils] [user 2] utils.py:556 - URL Retrieval Error # 1: subsection block-v1:ed999+ed989+2019_T2+type@sequential+block@0dbbf8fa0de7459fa4147f3252316709 included in section block-v1:ed999+ed989+2019_T2+type@course+block@course`


`edx.devstack.studio  | 2019-11-25 09:51:01,775 ERROR 2699 [contentstore.utils] [user 2] utils.py:572 - URL Retrieval Error # 2: subsection block-v1:ed999+ed989+2019_T2+type@sequential+block@0dbbf8fa0de7459fa4147f3252316709 included in section block-v1:ed999+ed989+2019_T2+type@course+block@course
`

### Reviewers
 - [x] @awaisdar001 