### PR TITLE
Hide Studio's re-index button for non-global staff

### DIFF
--- a/cms/djangoapps/contentstore/views/course.py
+++ b/cms/djangoapps/contentstore/views/course.py
@@ -627,7 +627,8 @@ def course_index(request, course_key):
         lms_link = get_lms_link_for_item(course_module.location)
         reindex_link = None
         if settings.FEATURES.get('ENABLE_COURSEWARE_INDEX', False):
-            reindex_link = "/course/{course_id}/search_reindex".format(course_id=six.text_type(course_key))
+            if GlobalStaff().has_user(request.user):
+                reindex_link = "/course/{course_id}/search_reindex".format(course_id=six.text_type(course_key))
         sections = course_module.get_children()
         course_structure = _course_outline_json(request, course_module)
         locator_to_show = request.GET.get('show', None)


### PR DESCRIPTION
This commit was originally submitted in PR #19610 by @OmarIthawi. It hides the button that manually triggers courseware search re-indexing unless you're a global staff user. The rationale and discussion for this can be found at:

https://github.com/edx/edx-platform/pull/19610