### PR TITLE
ARCH-1253: remove unused login ajax error url

### DIFF
--- a/openedx/core/djangoapps/user_authn/urls_common.py
+++ b/openedx/core/djangoapps/user_authn/urls_common.py
@@ -37,7 +37,6 @@ urlpatterns = [
     # Login
     url(r'^login_post$', login.login_user, name='login_post'),
     url(r'^login_ajax$', login.login_user, name="login"),
-    url(r'^login_ajax/(?P<error>[^/]*)$', login.login_user),
 
     # Moved from user_api/legacy_urls.py
     # `user_api` prefix is preserved for backwards compatibility.


### PR DESCRIPTION
**Notes:**
* This url was added as part of the initial commit (was `login/` at the time). See https://github.com/edx/edx-platform/blame/ef1bc239712c0cd83becf4d191c86462fa8bd649/urls.py
* The following NewRelic search turned up no hits for this url:
```
SELECT count(*) FROM Transaction
WHERE request.uri LIKE '/login_ajax%' FACET request.uri SINCE 6 weeks ago
```

ARCH-1253

### Please consider the following when opening a pull request:

- Link to the relevant JIRA ticket(s) and tag any relevant team(s).
- Squash your changes down into one or more discrete commits.
  In each commit, include description that could help a developer
  several months from now.
- If running `make upgrade`, run _as close to the time of merging as possible_
  to avoid accidentally downgrading someone else's package.
  Put the output of `make upgrade` in its own separate commit,
  decoupled from other code changes.
- Aim for comprehensive test coverage, but remember that
  automated testing isn't a substitute for manual verification.
- Carefully consider naming, code organization, dependencies when adding new code.
  Code that is amenable to refactoring and improvement benefits all platform developers,
  especially given the size and scope of edx-platform.
  Consult existing Architectural Decision Records (ADRs),
  including those concerning the app(s) you are changing and
  [those concerning edx-platform as a whole](https://github.com/edx/edx-platform/tree/master/docs/decisions).
