### PR TITLE
Disable Audit Certs for Whitelisted Students

### DIFF
--- a/lms/djangoapps/certificates/queue.py
+++ b/lms/djangoapps/certificates/queue.py
@@ -291,8 +291,13 @@ class XQueueCertInterface(object):
         mode_is_verified = enrollment_mode in GeneratedCertificate.VERIFIED_CERTS_MODES
         user_is_verified = IDVerificationService.user_is_verified(student)
         cert_mode = enrollment_mode
-        is_eligible_for_certificate = is_whitelisted or CourseMode.is_eligible_for_certificate(enrollment_mode,
-                                                                                               cert_status)
+
+        is_eligible_for_certificate = CourseMode.is_eligible_for_certificate(enrollment_mode, cert_status)
+        if is_whitelisted and not is_eligible_for_certificate:
+            # check if audit certificates are enabled for audit mode
+            is_eligible_for_certificate = enrollment_mode != CourseMode.AUDIT or \
+                not settings.FEATURES['DISABLE_AUDIT_CERTIFICATES']
+
         unverified = False
         # For credit mode generate verified certificate
         if cert_mode in (CourseMode.CREDIT_MODE, CourseMode.MASTERS):
@@ -328,7 +333,7 @@ class XQueueCertInterface(object):
             mode_is_verified,
             generate_pdf
         )
-
+        # pylint: disable=no-member
         cert, created = GeneratedCertificate.objects.get_or_create(user=student, course_id=course_id)
 
         cert.mode = cert_mode

--- a/lms/djangoapps/certificates/tests/test_queue.py
+++ b/lms/djangoapps/certificates/tests/test_queue.py
@@ -10,6 +10,7 @@ import ddt
 import freezegun
 import pytz
 import six
+from django.conf import settings
 from django.test import TestCase
 from django.test.utils import override_settings
 from mock import Mock, patch
@@ -109,8 +110,14 @@ class XQueueCertInterfaceAddCertificateTest(ModuleStoreTestCase):
         mock_send = self.add_cert_to_queue(mode)
         self.assert_certificate_generated(mock_send, 'verified', template_name)
 
-    def test_ineligible_cert_whitelisted(self):
-        """Test that audit mode students can receive a certificate if they are whitelisted."""
+    @ddt.data((True, CertificateStatuses.audit_passing), (False, CertificateStatuses.generating))
+    @ddt.unpack
+    @override_settings(AUDIT_CERT_CUTOFF_DATE=datetime.now(pytz.UTC) - timedelta(days=1))
+    def test_ineligible_cert_whitelisted(self, disable_audit_cert, status):
+        """
+        Test that audit mode students receive a certificate if DISABLE_AUDIT_CERTIFICATES
+        feature is set to false
+        """
         # Enroll as audit
         CourseEnrollmentFactory(
             user=self.user_2,
@@ -121,17 +128,17 @@ class XQueueCertInterfaceAddCertificateTest(ModuleStoreTestCase):
         # Whitelist student
         CertificateWhitelistFactory(course_id=self.course.id, user=self.user_2)
 
-        # Generate certs
-        with mock_passing_grade():
+        features = settings.FEATURES
+        features['DISABLE_AUDIT_CERTIFICATES'] = disable_audit_cert
+        with override_settings(FEATURES=features) and mock_passing_grade():
             with patch.object(XQueueInterface, 'send_to_queue') as mock_send:
                 mock_send.return_value = (0, None)
                 self.xqueue.add_cert(self.user_2, self.course.id)
 
-        # Assert cert generated correctly
-        self.assertTrue(mock_send.called)
         certificate = GeneratedCertificate.certificate_for_student(self.user_2, self.course.id)
         self.assertIsNotNone(certificate)
         self.assertEqual(certificate.mode, 'audit')
+        self.assertEqual(certificate.status, status)
 
     def add_cert_to_queue(self, mode):
         """

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -192,6 +192,8 @@ FEATURES = {
     # .. toggle_warnings: ???
     'DISABLE_HONOR_CERTIFICATES': False,  # Toggle to disable honor certificates
 
+    'DISABLE_AUDIT_CERTIFICATES': False,  # Toggle to disable audit certificates
+
     # for acceptance and load testing
     'AUTOMATIC_AUTH_FOR_TESTING': False,
 


### PR DESCRIPTION
Ensure that certificate is not generated if a learner enrolled in audit mode is whitelisted

[PROD-978](https://openedx.atlassian.net/browse/PROD-978)
