### PR TITLE
Fix quote Unicode data

### DIFF
--- a/cms/templates/widgets/header.html
+++ b/cms/templates/widgets/header.html
@@ -21,7 +21,7 @@
       % if context_course:
       <%
             course_key = context_course.id
-            url_encoded_course_key = quote(six.text_type(course_key), safe='')
+            url_encoded_course_key = quote(six.text_type(course_key).encode('utf-8'), safe='')
             index_url = reverse('course_handler', kwargs={'course_key_string': six.text_type(course_key)})
             course_team_url = reverse('course_team_handler', kwargs={'course_key_string': six.text_type(course_key)})
             assets_url = reverse('assets_handler', kwargs={'course_key_string': six.text_type(course_key)})


### PR DESCRIPTION
Fix trying to quote Unicode data to turn it into URL-safe bytes. This fixes the error by Encoding the string to bytes first.

```
>>> import six
>>> from six.moves.urllib.parse import quote

>>> test_course_key = u'course-v1:EPFLx+mécanique-newtonX+3T2020'

>>> quote(six.text_type(test_course_key), safe='') ## The actual error
/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/urllib.py:1298: UnicodeWarning: Unicode equal comparison failed to convert both arguments to Unicode - interpreting them as being unequal
  return ''.join(map(quoter, s))
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/urllib.py", line 1298, in quote
    return ''.join(map(quoter, s))
KeyError: u'\xe9'

>>> quote(six.text_type(test_course_key).encode('utf-8'), safe='')
'course-v1%3AEPFLx%2Bm%C3%A9canique-newtonX%2B3T2020'

>>> test_course_key = u'course-v1:edX+DemoX+Demo_Course'

>>> quote(six.text_type(test_course_key), safe='')
'course-v1%3AedX%2BDemoX%2BDemo_Course'

>>> quote(six.text_type(test_course_key).encode('utf-8'), safe='')
'course-v1%3AedX%2BDemoX%2BDemo_Course'
```

[PROD-977](https://openedx.atlassian.net/browse/PROD-977)
[urllib.html#urllib.quote](https://docs.python.org/2/library/urllib.html#urllib.quote)
Related PR: https://github.com/edx/edx-platform/pull/22188