### PR TITLE
conditional logs to find the inconsistent block id in MITx course

### DIFF
--- a/openedx/features/course_experience/utils.py
+++ b/openedx/features/course_experience/utils.py
@@ -3,6 +3,8 @@ Common utilities for the course experience, including course outline.
 """
 from __future__ import absolute_import
 
+import logging
+
 from completion.models import BlockCompletion
 from django.utils.translation import ugettext as _
 from opaque_keys.edx.keys import CourseKey
@@ -21,6 +23,8 @@ from openedx.features.discounts.applicability import (
 )
 from openedx.features.discounts.utils import format_strikeout_price
 from xmodule.modulestore.django import modulestore
+
+log = logging.getLogger(__name__)
 
 
 @request_cached()
@@ -44,7 +48,16 @@ def get_course_outline_block_tree(request, course_id, user=None):
 
         for i in range(len(children)):
             child_id = block['children'][i]
-            child_detail = populate_children(all_blocks[child_id], all_blocks)
+            try:
+                child_detail = populate_children(all_blocks[child_id], all_blocks)
+            except TypeError:
+                if u"MITx+6.002x+MITx_2012_Alumni" in course_outline_root_block[id]:
+                    log.info(u"PopulateChildrenError for Child: {child} in block:{block} at index:{index}".format(
+                        child=child_id,
+                        block=block['id'],
+                        index=i
+                    ))
+                raise
             block['children'][i] = child_detail
 
         return block


### PR DESCRIPTION
### [PROD-964](https://openedx.atlassian.net/browse/PROD-964)

### Description
This PR is adding conditional logs for the MITx course which is failing to load on its course outline page. One of the blocks' id is `ReturnDict` which should not be the case. The log attempts to save the id of the parent block, the child block with invalid ID and the index location of the child block. The index is being logged to check if the structure data is outdated(comparing it with local import).

```
utils.py:60 - Child: block-v1:ed999+ed989+2019_T2+type@chapter+block@3717a5e2899e446c8a4c78e9df2bddd8 in block:block-v1:ed999+ed989+2019_T2+type@course+block@course at index:0
```