### PR TITLE
Revert "ENT-1849: Removed EnterpriseMiddleware"

### DIFF
--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -1511,6 +1511,9 @@ MIDDLEWARE_CLASSES = [
 
     'waffle.middleware.WaffleMiddleware',
 
+    # Inserts Enterprise content.
+    'openedx.features.enterprise_support.middleware.EnterpriseMiddleware',
+
     # Enables force_django_cache_miss functionality for TieredCache.
     'edx_django_utils.cache.middleware.TieredCacheMiddleware',
 

--- a/openedx/features/enterprise_support/api.py
+++ b/openedx/features/enterprise_support/api.py
@@ -450,9 +450,7 @@ def enterprise_customer_for_request(request):
     if 'enterprise_customer' in request.session:
         return enterprise_customer_from_cache(request=request)
     else:
-        enterprise_customer = enterprise_customer_from_api(request)
-        request.session['enterprise_customer'] = enterprise_customer
-        return enterprise_customer
+        return enterprise_customer_from_api(request)
 
 
 @enterprise_is_enabled(otherwise=False)

--- a/openedx/features/enterprise_support/middleware.py
+++ b/openedx/features/enterprise_support/middleware.py
@@ -1,0 +1,30 @@
+"""
+Middleware for the Enterprise feature.
+
+The Enterprise feature must be turned on for this middleware to have any effect.
+"""
+
+from __future__ import absolute_import
+
+from django.core.exceptions import MiddlewareNotUsed
+from openedx.features.enterprise_support import api
+
+
+class EnterpriseMiddleware(object):
+    """
+    Middleware that adds Enterprise-related content to the request.
+    """
+
+    def __init__(self):
+        """
+        We don't need to use this middleware if the Enterprise feature isn't enabled.
+        """
+        if not api.enterprise_enabled():
+            raise MiddlewareNotUsed()
+
+    def process_request(self, request):
+        """
+        Fill the request with Enterprise-related content.
+        """
+        if 'enterprise_customer' not in request.session and request.user.is_authenticated:
+            request.session['enterprise_customer'] = api.enterprise_customer_for_request(request)

--- a/openedx/features/enterprise_support/tests/test_api.py
+++ b/openedx/features/enterprise_support/tests/test_api.py
@@ -253,7 +253,6 @@ class TestEnterpriseApi(EnterpriseServiceMockMixin, CacheIsolationTestCase):
 
         # Verify that the method `enterprise_customer_for_request` returns no
         # enterprise customer if the enterprise customer API throws 404.
-        del dummy_request.session['enterprise_customer']
         self.mock_get_enterprise_customer('real-ent-uuid', {'detail': 'Not found.'}, 404)
         enterprise_customer = enterprise_customer_for_request(dummy_request)
         self.assertIsNone(enterprise_customer)
@@ -288,36 +287,6 @@ class TestEnterpriseApi(EnterpriseServiceMockMixin, CacheIsolationTestCase):
             mock.MagicMock(GET={}, COOKIES={}, user=self.user, site=1)
         )
         self.assertEqual(enterprise_customer, {'real': 'enterprisecustomer'})
-
-    def test_enterprise_customer_for_request_with_session(self):
-        """
-        Verify enterprise_customer_for_request stores and retrieves data from session appropriately
-        """
-        dummy_request = mock.MagicMock(session={}, user=self.user)
-        enterprise_data = {'name': 'dummy-enterprise-customer', 'uuid': '8dc65e66-27c9-447b-87ff-ede6d66e3a5d'}
-
-        # Verify enterprise customer data fetched from API when it is not available in session
-        with mock.patch(
-                'openedx.features.enterprise_support.api.enterprise_customer_from_api',
-                return_value=enterprise_data
-        ):
-            self.assertEqual(dummy_request.session.get('enterprise_customer'), None)
-            enterprise_customer = enterprise_customer_for_request(dummy_request)
-            self.assertEqual(enterprise_customer, enterprise_data)
-            self.assertEqual(dummy_request.session.get('enterprise_customer'), enterprise_data)
-
-        # Verify enterprise customer data fetched from session for subsequent calls
-        with mock.patch(
-                'openedx.features.enterprise_support.api.enterprise_customer_from_api',
-                return_value=enterprise_data
-        ) as mock_enterprise_customer_from_api, mock.patch(
-                'openedx.features.enterprise_support.api.enterprise_customer_from_cache',
-                return_value=enterprise_data
-        ) as mock_enterprise_customer_from_cache:
-            enterprise_customer = enterprise_customer_for_request(dummy_request)
-            self.assertEqual(enterprise_customer, enterprise_data)
-            self.assertEqual(mock_enterprise_customer_from_api.called, False)
-            self.assertEqual(mock_enterprise_customer_from_cache.called, True)
 
     def check_data_sharing_consent(self, consent_required=False, consent_url=None):
         """

--- a/openedx/features/enterprise_support/tests/test_middleware.py
+++ b/openedx/features/enterprise_support/tests/test_middleware.py
@@ -1,0 +1,51 @@
+"""
+Tests for Enterprise middleware.
+"""
+
+from __future__ import absolute_import
+
+import mock
+
+from django.test import TestCase
+from django.test.utils import override_settings
+from django.urls import reverse
+from openedx.core.djangolib.testing.utils import skip_unless_lms
+from openedx.features.enterprise_support.tests import (
+    FAKE_ENTERPRISE_CUSTOMER,
+    FEATURES_WITH_ENTERPRISE_ENABLED,
+    factories
+)
+from student.tests.factories import UserFactory
+
+
+@override_settings(FEATURES=FEATURES_WITH_ENTERPRISE_ENABLED)
+@skip_unless_lms
+class EnterpriseMiddlewareTest(TestCase):
+    """
+    Test for `EnterpriseMiddleware`.
+    """
+
+    def setUp(self):
+        """Initiate commonly needed objects."""
+        super(EnterpriseMiddlewareTest, self).setUp()
+
+        # Customer & Learner details.
+        self.user = UserFactory.create(username='username', password='password')
+        self.enterprise_customer = FAKE_ENTERPRISE_CUSTOMER
+        self.enterprise_learner = factories.EnterpriseCustomerUserFactory(user_id=self.user.id)
+
+        # Request details.
+        self.client.login(username='username', password='password')
+        self.dashboard = reverse('dashboard')
+
+        # Mocks.
+        patcher = mock.patch('openedx.features.enterprise_support.api.enterprise_customer_from_api')
+        self.mock_enterprise_customer_from_api = patcher.start()
+        self.mock_enterprise_customer_from_api.return_value = self.enterprise_customer
+        self.addCleanup(patcher.stop)
+
+    def test_anonymous_user(self):
+        """The `enterprise_customer` is not set in the session if the user is anonymous."""
+        self.client.logout()
+        self.client.get(self.dashboard)
+        assert self.client.session.get('enterprise_customer') is None


### PR DESCRIPTION
Reverting this PR to see if it fixes broken e2e test.

Failing Test 
`regression.tests.lms.test_graded_problem.GradedProblemTest.test_graded_problem`

Error Message
```
Could not load page '<regression.pages.studio.import_course_page.ImportCoursePageExtended object at 0x7f143fe679d0>' at URL 'https://margaret:hamilton@studio.stage.edx.org/import/course-v1:edx+E2E-1000+fall'
-------------------- >> begin captured logging << --------------------
bok_choy.browser: INFO: Using local browser: firefox [Default is firefox]
bok_choy.browser: INFO: Using default firefox profile
urllib3.connectionpool: DEBUG: Starting new HTTP connection (1): 127.0.0.1:55529
urllib3.connectionpool: DEBUG: http://127.0.0.1:55529 "POST /session HTTP/1.1" 200 516
urllib3.connectionpool: DEBUG: http://127.0.0.1:55529 "POST /session/110e14e3-c587-4078-af5c-00d945766b2e/window/rect HTTP/1.1" 200 49
urllib3.connectionpool: DEBUG: http://127.0.0.1:55529 "POST /session/110e14e3-c587-4078-af5c-00d945766b2e/window/rect HTTP/1.1" 200 50
urllib3.connectionpool: DEBUG: http://127.0.0.1:55529 "POST /session/110e14e3-c587-4078-af5c-00d945766b2e/execute/sync HTTP/1.1" 200 37
urllib3.connectionpool: DEBUG: Starting new HTTPS connection (1): courses.stage.edx.org:443
urllib3.connectionpool: DEBUG: https://courses.stage.edx.org:443 "GET /login HTTP/1.1" 200 None
urllib3.connectionpool: DEBUG: https://courses.stage.edx.org:443 "POST /user_api/v1/account/login_session/ HTTP/1.1" 200 0
urllib3.connectionpool: DEBUG: http://127.0.0.1:55529 "POST /session/110e14e3-c587-4078-af5c-00d945766b2e/url HTTP/1.1" 200 15
urllib3.connectionpool: DEBUG: http://127.0.0.1:55529 "POST /session/110e14e3-c587-4078-af5c-00d945766b2e/cookie HTTP/1.1" 200 15
urllib3.connectionpool: DEBUG: http://127.0.0.1:55529 "POST /session/110e14e3-c587-4078-af5c-00d945766b2e/cookie HTTP/1.1" 200 15
urllib3.connectionpool: DEBUG: http://127.0.0.1:55529 "POST /session/110e14e3-c587-4078-af5c-00d945766b2e/cookie HTTP/1.1" 200 15
urllib3.connectionpool: DEBUG: http://127.0.0.1:55529 "POST /session/110e14e3-c587-4078-af5c-00d945766b2e/cookie HTTP/1.1" 200 15
urllib3.connectionpool: DEBUG: http://127.0.0.1:55529 "POST /session/110e14e3-c587-4078-af5c-00d945766b2e/cookie HTTP/1.1" 200 15
urllib3.connectionpool: DEBUG: http://127.0.0.1:55529 "POST /session/110e14e3-c587-4078-af5c-00d945766b2e/cookie HTTP/1.1" 200 15
urllib3.connectionpool: DEBUG: http://127.0.0.1:55529 "POST /session/110e14e3-c587-4078-af5c-00d945766b2e/cookie HTTP/1.1" 200 15
urllib3.connectionpool: DEBUG: http://127.0.0.1:55529 "POST /session/110e14e3-c587-4078-af5c-00d945766b2e/cookie HTTP/1.1" 200 15
urllib3.connectionpool: DEBUG: http://127.0.0.1:55529 "POST /session/110e14e3-c587-4078-af5c-00d945766b2e/url HTTP/1.1" 200 15
urllib3.connectionpool: DEBUG: http://127.0.0.1:55529 "POST /session/110e14e3-c587-4078-af5c-00d945766b2e/url HTTP/1.1" 500 672
bok_choy.page_object: WARNING: Unexpected page load exception:
Traceback (most recent call last):
  File "/home/jenkins/workspace/edx-e2e-tests/venv/local/lib/python2.7/site-packages/bok_choy/page_object.py", line 329, in visit
    self.browser.get(self.url)
  File "/home/jenkins/workspace/edx-e2e-tests/venv/local/lib/python2.7/site-packages/selenium/webdriver/remote/webdriver.py", line 332, in get
    self.execute(Command.GET, {'url': url})
  File "/home/jenkins/workspace/edx-e2e-tests/venv/local/lib/python2.7/site-packages/selenium/webdriver/remote/webdriver.py", line 320, in execute
    self.error_handler.check_response(response)
  File "/home/jenkins/workspace/edx-e2e-tests/venv/local/lib/python2.7/site-packages/selenium/webdriver/remote/errorhandler.py", line 242, in check_response
    raise exception_class(message, screen, stacktrace)
WebDriverException: Message: Reached error page: about:neterror?e=redirectLoop&u=https%3A//courses.stage.edx.org/login%3Fnext%3Dhttps%253A%252F%252Fstudio.stage.edx.org%252Fimport%252Fcourse-v1%253Aedx%252BE2E-1000%252Bfall&c=UTF-8&f=regular&d=Firefox%20has%20detected%20that%20the%20server%20is%20redirecting%20the%20request%20for%20this%20address%20in%20a%20way%20that%20will%20never%20complete.

--------------------- >> end captured logging << ---------------------
Stacktrace
  File "/usr/lib/python2.7/unittest/case.py", line 320, in run
    self.setUp()
  File "/home/jenkins/workspace/edx-e2e-tests/regression/tests/lms/test_graded_problem.py", line 36, in setUp
    self.import_page.visit()
  File "/home/jenkins/workspace/edx-e2e-tests/venv/local/lib/python2.7/site-packages/bok_choy/page_object.py", line 333, in visit
    self, self.url
'Could not load page \'<regression.pages.studio.import_course_page.ImportCoursePageExtended object at 0x7f143fe679d0>\' at URL \'https://margaret:hamilton@studio.stage.edx.org/import/course-v1:edx+E2E-1000+fall\'\n-------------------- >> begin captured logging << --------------------\nbok_choy.browser: INFO: Using local browser: firefox [Default is firefox]\nbok_choy.browser: INFO: Using default firefox profile\nurllib3.connectionpool: DEBUG: Starting new HTTP connection (1): 127.0.0.1:55529\nurllib3.connectionpool: DEBUG: http://127.0.0.1:55529 "POST /session HTTP/1.1" 200 516\nurllib3.connectionpool: DEBUG: http://127.0.0.1:55529 "POST /session/110e14e3-c587-4078-af5c-00d945766b2e/window/rect HTTP/1.1" 200 49\nurllib3.connectionpool: DEBUG: http://127.0.0.1:55529 "POST /session/110e14e3-c587-4078-af5c-00d945766b2e/window/rect HTTP/1.1" 200 50\nurllib3.connectionpool: DEBUG: http://127.0.0.1:55529 "POST /session/110e14e3-c587-4078-af5c-00d945766b2e/execute/sync HTTP/1.1" 200 37\nurllib3.connectionpool: DEBUG: Starting new HTTPS connection (1): courses.stage.edx.org:443\nurllib3.connectionpool: DEBUG: https://courses.stage.edx.org:443 "GET /login HTTP/1.1" 200 None\nurllib3.connectionpool: DEBUG: https://courses.stage.edx.org:443 "POST /user_api/v1/account/login_session/ HTTP/1.1" 200 0\nurllib3.connectionpool: DEBUG: http://127.0.0.1:55529 "POST /session/110e14e3-c587-4078-af5c-00d945766b2e/url HTTP/1.1" 200 15\nurllib3.connectionpool: DEBUG: http://127.0.0.1:55529 "POST /session/110e14e3-c587-4078-af5c-00d945766b2e/cookie HTTP/1.1" 200 15\nurllib3.connectionpool: DEBUG: http://127.0.0.1:55529 "POST /session/110e14e3-c587-4078-af5c-00d945766b2e/cookie HTTP/1.1" 200 15\nurllib3.connectionpool: DEBUG: http://127.0.0.1:55529 "POST /session/110e14e3-c587-4078-af5c-00d945766b2e/cookie HTTP/1.1" 200 15\nurllib3.connectionpool: DEBUG: http://127.0.0.1:55529 "POST /session/110e14e3-c587-4078-af5c-00d945766b2e/cookie HTTP/1.1" 200 15\nurllib3.connectionpool: DEBUG: http://127.0.0.1:55529 "POST /session/110e14e3-c587-4078-af5c-00d945766b2e/cookie HTTP/1.1" 200 15\nurllib3.connectionpool: DEBUG: http://127.0.0.1:55529 "POST /session/110e14e3-c587-4078-af5c-00d945766b2e/cookie HTTP/1.1" 200 15\nurllib3.connectionpool: DEBUG: http://127.0.0.1:55529 "POST /session/110e14e3-c587-4078-af5c-00d945766b2e/cookie HTTP/1.1" 200 15\nurllib3.connectionpool: DEBUG: http://127.0.0.1:55529 "POST /session/110e14e3-c587-4078-af5c-00d945766b2e/cookie HTTP/1.1" 200 15\nurllib3.connectionpool: DEBUG: http://127.0.0.1:55529 "POST /session/110e14e3-c587-4078-af5c-00d945766b2e/url HTTP/1.1" 200 15\nurllib3.connectionpool: DEBUG: http://127.0.0.1:55529 "POST /session/110e14e3-c587-4078-af5c-00d945766b2e/url HTTP/1.1" 500 672\nbok_choy.page_object: WARNING: Unexpected page load exception:\nTraceback (most recent call last):\n  File "/home/jenkins/workspace/edx-e2e-tests/venv/local/lib/python2.7/site-packages/bok_choy/page_object.py", line 329, in visit\n    self.browser.get(self.url)\n  File "/home/jenkins/workspace/edx-e2e-tests/venv/local/lib/python2.7/site-packages/selenium/webdriver/remote/webdriver.py", line 332, in get\n    self.execute(Command.GET, {\'url\': url})\n  File "/home/jenkins/workspace/edx-e2e-tests/venv/local/lib/python2.7/site-packages/selenium/webdriver/remote/webdriver.py", line 320, in execute\n    self.error_handler.check_response(response)\n  File "/home/jenkins/workspace/edx-e2e-tests/venv/local/lib/python2.7/site-packages/selenium/webdriver/remote/errorhandler.py", line 242, in check_response\n    raise exception_class(message, screen, stacktrace)\nWebDriverException: Message: Reached error page: about:neterror?e=redirectLoop&u=https%3A//courses.stage.edx.org/login%3Fnext%3Dhttps%253A%252F%252Fstudio.stage.edx.org%252Fimport%252Fcourse-v1%253Aedx%252BE2E-1000%252Bfall&c=UTF-8&f=regular&d=Firefox%20has%20detected%20that%20the%20server%20is%20redirecting%20the%20request%20for%20this%20address%20in%20a%20way%20that%20will%20never%20complete.\n\n--------------------- >> end captured logging << ---------------------'
```