### PR TITLE
Remove this test because it is flaky.

### DIFF
--- a/common/test/acceptance/tests/lms/test_programs.py
+++ b/common/test/acceptance/tests/lms/test_programs.py
@@ -83,17 +83,6 @@ class ProgramListingPageTest(ProgramPageBase):
 
         self.listing_page = ProgramListingPage(self.browser)
 
-    def test_no_enrollments(self):
-        """Verify that no cards appear when the user has no enrollments."""
-        self.auth(enroll=False)
-        self.stub_catalog_api(self.programs, self.pathways)
-        self.cache_programs()
-
-        self.listing_page.visit()
-
-        self.assertTrue(self.listing_page.is_sidebar_present)
-        self.assertFalse(self.listing_page.are_cards_present)
-
     def test_no_programs(self):
         """
         Verify that no cards appear when the user has enrollments


### PR DESCRIPTION
It failed and passed on the same commit.  The failure was that the page
timed out, so it could be fixed by making that page performant.  I'd
rather not increase the timeout for the page to load as the bokchoy
tests are already very slow.

I'm also not sure why this test needs to exist.  I would think that this
could be tested on the underlying function without testing at the UI
layer.

Failing build: https://build.testeng.edx.org/job/edx-platform-python3-bokchoy-pipeline-pr/569/
Passing build: https://build.testeng.edx.org/job/edx-platform-python3-bokchoy-pipeline-pr/573/

### Please consider the following when opening a pull request:

- Link to the relevant JIRA ticket(s) and tag any relevant team(s).
- Squash your changes down into one or more discrete commits.
  In each commit, include description that could help a developer
  several months from now.
- If running `make upgrade`, run _as close to the time of merging as possible_
  to avoid accidentally downgrading someone else's package.
  Put the output of `make upgrade` in its own separate commit,
  decoupled from other code changes.
- Aim for comprehensive test coverage, but remember that
  automated testing isn't a substitute for manual verification.
- Carefully consider naming, code organization, dependencies when adding new code.
  Code that is amenable to refactoring and improvement benefits all platform developers,
  especially given the size and scope of edx-platform.
  Consult existing Architectural Decision Records (ADRs),
  including those concerning the app(s) you are changing and
  [those concerning edx-platform as a whole](https://github.com/edx/edx-platform/tree/master/docs/decisions).
