### PR TITLE
Git should ignore private.in/private.txt requirements files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,8 @@
 # and so should not be destroyed by "make clean".
 # start-noclean
 requirements/private.txt
+requirements/edx/private.in
+requirements/edx/private.txt
 lms/envs/private.py
 cms/envs/private.py
 # end-noclean


### PR DESCRIPTION
As described in [`requirements/edx/private.readme`](https://github.com/edx/edx-platform/blob/4a932718f1cb0d0c6874a5be47f4ee6e6dfda0c7/requirements/edx/private.readme), users can put custom python requirements into `requirements/edx/private.in` and then auto-generate `private.txt` to specify any custom requirements for their devstack or installation.

For some reason, those files weren't being .gitignored correctly, so anyone who uses that feature will risk accidentally committing those files. This fixes that.