### PR TITLE
Support anonymous users with new (Blockstore-based) XBlock Runtime

### DIFF
--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -2093,7 +2093,10 @@ PROCTORING_SETTINGS = {}
 
 ################## BLOCKSTORE RELATED SETTINGS  #########################
 BLOCKSTORE_PUBLIC_URL_ROOT = 'http://localhost:18250'
-BLOCKSTORE_API_URL = 'http://localhost:18250/api/v1'
+BLOCKSTORE_API_URL = 'http://localhost:18250/api/v1/'
+# Which of django's caches to use for storing anonymous user state for XBlocks
+# in the blockstore-based XBlock runtime
+XBLOCK_RUNTIME_V2_EPHEMERAL_DATA_CACHE = 'default'
 
 ###################### LEARNER PORTAL ################################
 LEARNER_PORTAL_URL_ROOT = 'https://learner-portal-localhost:18000'

--- a/common/lib/xmodule/xmodule/capa_module.py
+++ b/common/lib/xmodule/xmodule/capa_module.py
@@ -119,6 +119,20 @@ class ProblemBlock(
         shim_xmodule_js(fragment, 'Problem')
         return fragment
 
+    def public_view(self, context):
+        """
+        Return the view seen by users who aren't logged in or who aren't
+        enrolled in the course.
+        """
+        if getattr(self.runtime, 'suppports_state_for_anonymous_users', False):
+            # The new XBlock runtime can generally support capa problems for users who aren't logged in, so show the
+            # normal student_view. To prevent anonymous users from viewing specific problems, adjust course policies
+            # and/or content groups.
+            return self.student_view(context)
+        else:
+            # Show a message that this content requires users to login/enroll.
+            return super(ProblemBlock, self).public_view(context)
+
     def author_view(self, context):
         """
         Renders the Studio preview view.

--- a/common/lib/xmodule/xmodule/unit_block.py
+++ b/common/lib/xmodule/xmodule/unit_block.py
@@ -52,6 +52,8 @@ class UnitBlock(XBlock):
         result.add_content('</div>')
         return result
 
+    public_view = student_view
+
     def index_dictionary(self):
         """
         Return dictionary prepared with module content and type for indexing, so

--- a/common/lib/xmodule/xmodule/video_module/video_module.py
+++ b/common/lib/xmodule/xmodule/video_module/video_module.py
@@ -252,6 +252,9 @@ class VideoBlock(
         """
         Returns a fragment that contains the html for the public view
         """
+        if getattr(self.runtime, 'suppports_state_for_anonymous_users', False):
+            # The new runtime can support anonymous users as fully as regular users:
+            return self.student_view(context)
         return Fragment(self.get_html(view=PUBLIC_VIEW))
 
     def get_html(self, view=STUDENT_VIEW):
@@ -610,12 +613,8 @@ class VideoBlock(
         field_data = cls.parse_video_xml(node)
         for key, val in field_data.items():
             setattr(video_block, key, cls.fields[key].from_json(val))
-        # Update VAL with info extracted from `xml_object`
-        video_block.edx_video_id = video_block.import_video_info_into_val(
-            node,
-            runtime.resources_fs,
-            keys.usage_id.context_key,
-        )
+        # Don't use VAL in the new runtime:
+        video_block.edx_video_id = None
         return video_block
 
     @classmethod

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -3834,7 +3834,10 @@ MAILCHIMP_NEW_USER_LIST_ID = ""
 
 ########################## BLOCKSTORE #####################################
 BLOCKSTORE_PUBLIC_URL_ROOT = 'http://localhost:18250'
-BLOCKSTORE_API_URL = 'http://localhost:18250/api/v1'
+BLOCKSTORE_API_URL = 'http://localhost:18250/api/v1/'
+# Which of django's caches to use for storing anonymous user state for XBlocks
+# in the blockstore-based XBlock runtime
+XBLOCK_RUNTIME_V2_EPHEMERAL_DATA_CACHE = 'default'
 
 ########################## LEARNER PORTAL ##############################
 LEARNER_PORTAL_URL_ROOT = 'https://learner-portal-localhost:18000'

--- a/lms/envs/test.py
+++ b/lms/envs/test.py
@@ -239,6 +239,7 @@ CACHES = {
 RUN_BLOCKSTORE_TESTS = os.environ.get('EDXAPP_RUN_BLOCKSTORE_TESTS', 'no').lower() in ('true', 'yes', '1')
 BLOCKSTORE_API_URL = os.environ.get('EDXAPP_BLOCKSTORE_API_URL', "http://edx.devstack.blockstore-test:18251/api/v1/")
 BLOCKSTORE_API_AUTH_TOKEN = os.environ.get('EDXAPP_BLOCKSTORE_API_AUTH_TOKEN', 'edxapp-test-key')
+XBLOCK_RUNTIME_V2_EPHEMERAL_DATA_CACHE = 'blockstore'  # This must be set to a working cache for the tests to pass
 
 # Dummy secret key for dev
 SECRET_KEY = '85920908f28904ed733fe576320db18cabd7b6cd'

--- a/openedx/core/djangoapps/content_libraries/tests/user_state_block.py
+++ b/openedx/core/djangoapps/content_libraries/tests/user_state_block.py
@@ -1,0 +1,52 @@
+# -*- coding: utf-8 -*-
+"""
+Block for testing variously scoped XBlock fields.
+"""
+from __future__ import absolute_import, division, print_function, unicode_literals
+import json
+
+from webob import Response
+from xblock.core import XBlock, Scope
+from xblock import fields
+
+
+class UserStateTestBlock(XBlock):
+    """
+    Block for testing variously scoped XBlock fields.
+    """
+    BLOCK_TYPE = "user-state-test"
+    has_score = False
+
+    display_name = fields.String(scope=Scope.content, name='User State Test Block')
+    # User-specific fields:
+    user_str = fields.String(scope=Scope.user_state, default='default value')  # This usage, one user
+    uss_str = fields.String(scope=Scope.user_state_summary, default='default value')  # This usage, all users
+    pref_str = fields.String(scope=Scope.preferences, default='default value')  # Block type, one user
+    user_info_str = fields.String(scope=Scope.user_info, default='default value')  # All blocks, one user
+
+    @XBlock.json_handler
+    def set_user_state(self, data, suffix):  # pylint: disable=unused-argument
+        """
+        Set the user-scoped fields
+        """
+        self.user_str = data["user_str"]
+        self.uss_str = data["uss_str"]
+        self.pref_str = data["pref_str"]
+        self.user_info_str = data["user_info_str"]
+        return {}
+
+    @XBlock.handler
+    def get_user_state(self, request, suffix=None):  # pylint: disable=unused-argument
+        """
+        Get the various user-scoped fields of this XBlock.
+        """
+        return Response(
+            json.dumps({
+                "user_str": self.user_str,
+                "uss_str": self.uss_str,
+                "pref_str": self.pref_str,
+                "user_info_str": self.user_info_str,
+            }),
+            content_type='application/json',
+            charset='UTF-8',
+        )

--- a/openedx/core/djangoapps/xblock/api.py
+++ b/openedx/core/djangoapps/xblock/api.py
@@ -24,7 +24,7 @@ from openedx.core.djangoapps.xblock.learning_context.manager import get_learning
 from openedx.core.djangoapps.xblock.runtime.blockstore_runtime import BlockstoreXBlockRuntime, xml_for_definition
 from openedx.core.djangoapps.xblock.runtime.runtime import XBlockRuntimeSystem
 from openedx.core.djangolib.blockstore_cache import BundleCache
-from .utils import get_secure_token_for_xblock_handler
+from .utils import get_secure_token_for_xblock_handler, get_xblock_id_for_anonymous_user
 
 log = logging.getLogger(__name__)
 
@@ -160,11 +160,9 @@ def render_block_view(block, view_name, user):  # pylint: disable=unused-argumen
     """
     Get the HTML, JS, and CSS needed to render the given XBlock view.
 
-    The difference between this method and calling
+    The only difference between this method and calling
         load_block().render(view_name)
-    is that this method will automatically save any changes to field data that
-    resulted from rendering the view. If you don't want that, call .render()
-    directly.
+    is that this method can fall back from 'author_view' to 'student_view'
 
     Returns a Fragment.
     """
@@ -179,14 +177,10 @@ def render_block_view(block, view_name, user):  # pylint: disable=unused-argumen
         else:
             raise
 
-    # TODO: save any changed user state fields
-    # TODO: if the view is anything other than student_view and we're not in the LMS, save any changed
-    # content/settings/children fields.
-
     return fragment
 
 
-def get_handler_url(usage_key, handler_name, user_id):
+def get_handler_url(usage_key, handler_name, user):
     """
     A method for getting the URL to any XBlock handler. The URL must be usable
     without any authentication (no cookie, no OAuth/JWT), and may expire. (So
@@ -202,26 +196,30 @@ def get_handler_url(usage_key, handler_name, user_id):
     Params:
         usage_key       - Usage Key (Opaque Key object or string)
         handler_name    - Name of the handler or a dummy name like 'any_handler'
-        user_id         - User ID or XBlockRuntimeSystem.ANONYMOUS_USER
+        user            - Django User (registered or anonymous)
 
     This view does not check/care if the XBlock actually exists.
     """
     usage_key_str = six.text_type(usage_key)
     site_root_url = get_xblock_app_config().get_site_root_url()
-    if user_id is None:
+    if not user:
         raise TypeError("Cannot get handler URLs without specifying a specific user ID.")
-    elif user_id == XBlockRuntimeSystem.ANONYMOUS_USER:
-        raise NotImplementedError("handler links for anonymous users are not yet implemented")  # TODO: implement
+    elif user.is_authenticated:
+        user_id = user.id
+    elif user.is_anonymous:
+        user_id = get_xblock_id_for_anonymous_user(user)
     else:
-        # Normal case: generate a token-secured URL for this handler, specific
-        # to this user and this XBlock.
-        secure_token = get_secure_token_for_xblock_handler(user_id, usage_key_str)
-        path = reverse('xblock_api:xblock_handler', kwargs={
-            'usage_key_str': usage_key_str,
-            'user_id': user_id,
-            'secure_token': secure_token,
-            'handler_name': handler_name,
-        })
+        raise ValueError("Invalid user value")
+    # Now generate a token-secured URL for this handler, specific to this user
+    # and this XBlock:
+    secure_token = get_secure_token_for_xblock_handler(user_id, usage_key_str)
+    # Now generate the URL to that handler:
+    path = reverse('xblock_api:xblock_handler', kwargs={
+        'usage_key_str': usage_key_str,
+        'user_id': user_id,
+        'secure_token': secure_token,
+        'handler_name': handler_name,
+    })
     # We must return an absolute URL. We can't just use
     # rest_framework.reverse.reverse to get the absolute URL because this method
     # can be called by the XBlock from python as well and in that case we don't

--- a/openedx/core/djangoapps/xblock/rest_api/urls.py
+++ b/openedx/core/djangoapps/xblock/rest_api/urls.py
@@ -20,7 +20,7 @@ urlpatterns = [
             url(r'^handler_url/(?P<handler_name>[\w\-]+)/$', views.get_handler_url),
             # call one of this block's handlers
             url(
-                r'^handler/(?P<user_id>\d+)-(?P<secure_token>\w+)/(?P<handler_name>[\w\-]+)/(?P<suffix>.+)?$',
+                r'^handler/(?P<user_id>\w+)-(?P<secure_token>\w+)/(?P<handler_name>[\w\-]+)/(?P<suffix>.+)?$',
                 views.xblock_handler,
                 name='xblock_handler',
             ),

--- a/openedx/core/djangoapps/xblock/rest_api/views.py
+++ b/openedx/core/djangoapps/xblock/rest_api/views.py
@@ -42,7 +42,7 @@ def block_metadata(request, usage_key_str):
 
 
 @api_view(['GET'])
-@view_auth_classes(is_authenticated=True)
+@view_auth_classes(is_authenticated=False)
 @permission_classes((permissions.AllowAny, ))  # Permissions are handled at a lower level, by the learning context
 def render_block_view(request, usage_key_str, view_name):
     """
@@ -57,7 +57,7 @@ def render_block_view(request, usage_key_str, view_name):
 
 
 @api_view(['GET'])
-@view_auth_classes(is_authenticated=True)
+@view_auth_classes(is_authenticated=False)
 def get_handler_url(request, usage_key_str, handler_name):
     """
     Get an absolute URL which can be used (without any authentication) to call
@@ -66,7 +66,7 @@ def get_handler_url(request, usage_key_str, handler_name):
     The URL will expire but is guaranteed to be valid for a minimum of 2 days.
     """
     usage_key = UsageKey.from_string(usage_key_str)
-    handler_url = _get_handler_url(usage_key, handler_name, request.user.id)
+    handler_url = _get_handler_url(usage_key, handler_name, request.user)
     return Response({"handler_url": handler_url})
 
 
@@ -84,7 +84,6 @@ def xblock_handler(request, user_id, secure_token, usage_key_str, handler_name, 
     auth token included in the URL (see below). As a result it can be exempt
     from CSRF, session auth, and JWT/OAuth.
     """
-    user_id = int(user_id)  # User ID comes from the URL, not session auth
     usage_key = UsageKey.from_string(usage_key_str)
 
     # To support sandboxed XBlocks, custom frontends, and other use cases, we
@@ -94,13 +93,31 @@ def xblock_handler(request, user_id, secure_token, usage_key_str, handler_name, 
     if not validate_secure_token_for_xblock_handler(user_id, usage_key_str, secure_token):
         raise PermissionDenied("Invalid/expired auth token.")
     if request.user.is_authenticated:
-        # The user authenticated twice, e.g. with session auth and the token
-        # So just make sure the session auth matches the token
-        if request.user.id != user_id:
+        # The user authenticated twice, e.g. with session auth and the token.
+        # This can happen if not running the XBlock in a sandboxed iframe.
+        # Just make sure the session auth matches the token:
+        if request.user.id != int(user_id):
             raise AuthenticationFailed("Authentication conflict.")
         user = request.user
+    elif user_id.isdigit():
+        # This is a normal (integer) user ID for a registered user.
+        # This is the "normal" way this view gets used, with a sandboxed iframe.
+        user = User.objects.get(pk=int(user_id))
+    elif user_id.startswith("anon"):
+        # This is a non-registered (anonymous) user:
+        assert request.user.is_anonymous
+        assert not hasattr(request.user, 'xblock_id_for_anonymous_user')
+        user = request.user  # An AnonymousUser
+        # Since this particular view usually gets called from a sandboxed iframe
+        # we won't have access to the LMS session data for this user (the iframe
+        # has a new, empty session). So we need to save the identifier for this
+        # anonymous user (from the URL) on the user object, so that the runtime
+        # can get it (instead of generating a new one and saving it into this
+        # new empty session)
+        # See djangoapps.xblock.utils.get_xblock_id_for_anonymous_user()
+        user.xblock_id_for_anonymous_user = user_id
     else:
-        user = User.objects.get(pk=user_id)
+        raise AuthenticationFailed("Invalid user ID format.")
 
     request_webob = DjangoWebobRequest(request)  # Convert from django request to the webob format that XBlocks expect
     block = load_block(usage_key, user)

--- a/openedx/core/djangoapps/xblock/runtime/ephemeral_field_data.py
+++ b/openedx/core/djangoapps/xblock/runtime/ephemeral_field_data.py
@@ -1,0 +1,62 @@
+"""
+An :class:`~xblock.runtime.KeyValueStore` that stores data in the django cache
+
+This is used for low-priority ephemeral student state data:
+* Anonymous users browsing and previewing content
+* Studio authors testing out XBlocks
+
+We could also store this data in django sessions, but its a bit tricky to access
+session data during any requests which don't have any cookies or other normal
+authentication mechanisms (like XBlock handler calls from within XBlock <iframe>
+sandboxes). And keeping this storage completely separate from django session
+data and registered user XBlock state reduces the potential for security
+problems. We expect the data in this store to be low-value and free of
+personally identifiable information (PII) so if some security bug results in one
+user accessing a different user's entries in this particular store, it's not a
+big deal.
+"""
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+from django.conf import settings
+from django.core.cache import caches
+from xblock.runtime import KeyValueStore
+
+
+FIELD_DATA_TIMEOUT = None  # keep in cache indefinitely, until cache needs pruning
+
+
+class NotFound(object):
+    """
+    This class is a unique value that can be stored in a cache to indicate "not found"
+    """
+    # Store the class itself, not an instance of it.
+
+
+class EphemeralKeyValueStore(KeyValueStore):
+    """
+    An XBlock field data key-value store that is backed by the django cache
+    """
+    def _wrap_key(self, key):
+        """
+        Expand the given XBlock key tuple to a format we can use as a key.
+        """
+        return u"ephemeral-xblock:{}".format(repr(tuple(key)))
+
+    @property
+    def _cache(self):
+        return caches[settings.XBLOCK_RUNTIME_V2_EPHEMERAL_DATA_CACHE]
+
+    def get(self, key):
+        value = self._cache.get(self._wrap_key(key), default=NotFound)
+        if value is NotFound:
+            raise KeyError  # Normal, this is how we indicate a value is not found
+        return value
+
+    def set(self, key, value):
+        self._cache.set(self._wrap_key(key), value, timeout=FIELD_DATA_TIMEOUT)
+
+    def delete(self, key):
+        self._cache.delete(self._wrap_key(key))
+
+    def has(self, key):
+        return self._cache.get(self._wrap_key(key), default=NotFound) is not NotFound

--- a/openedx/core/djangoapps/xblock/runtime/shims.py
+++ b/openedx/core/djangoapps/xblock/runtime/shims.py
@@ -62,10 +62,14 @@ class RuntimeShim(object):
         """
         Get an anonymized identifier for this user.
         """
-        # TODO: Change this to a runtime service or method so that we can have
+        # To do? Change this to a runtime service or method so that we can have
         # access to the context_key without relying on self._active_block.
-        if self.user_id is None:
-            raise NotImplementedError("TODO: anonymous ID for anonymous users.")
+        if self.user.is_anonymous:
+            # This is an anonymous user, and the self.user_id value is already
+            # an anonymous string. It's not anonymized per course, but we don't
+            # really care since this user's XBlock data is ephemeral and is only
+            # kept around for a day or two anyways.
+            return self.user_id
         #### TEMPORARY IMPLEMENTATION:
         # TODO: Update student.models.AnonymousUserId to have a 'context_key'
         # column instead of 'course_key' (no DB migration needed). Then change
@@ -279,13 +283,8 @@ class RuntimeShim(object):
             "    is_staff = user.opt_attrs.get('edx-platform.user_is_staff')",
             DeprecationWarning, stacklevel=2,
         )
-        if self.user_id:
-            from django.contrib.auth import get_user_model
-            try:
-                user = get_user_model().objects.get(id=self.user_id)
-            except get_user_model().DoesNotExist:
-                return False
-            return user.is_staff
+        if self.user and self.user.is_authenticated:
+            return self.user.is_staff
         return False
 
     @cached_property
@@ -368,7 +367,7 @@ class RuntimeShim(object):
         # Many CSS styles for former XModules use
         # .xmodule_display.xmodule_VideoBlock
         # as their selector, so add those classes:
-        if view == 'student_view':
+        if view in ('student_view', 'public_view'):
             css_classes.append('xmodule_display')
         elif view == 'studio_view':
             css_classes.append('xmodule_edit')

--- a/openedx/core/djangoapps/xblock/utils.py
+++ b/openedx/core/djangoapps/xblock/utils.py
@@ -6,7 +6,9 @@ import hashlib
 import hmac
 import math
 import time
+from uuid import uuid4
 
+import crum
 from django.conf import settings
 from six import text_type
 
@@ -67,3 +69,32 @@ def validate_secure_token_for_xblock_handler(user_id, block_key_str, token):
     # All computations happen above this line so this function always takes a
     # constant time to produce its answer (security best practice).
     return bool(result1 or result2)
+
+
+def get_xblock_id_for_anonymous_user(user):
+    """
+    Get a unique string that identifies the current anonymous (not logged in)
+    user. (This is different than the "anonymous user ID", which is an
+    anonymized identifier for a logged in user.)
+
+    Note that this ID is a string, not an int. It is guaranteed to be in a
+    unique namespace that won't collide with "normal" user IDs, even when
+    they are converted to a string.
+    """
+    if not user or not user.is_anonymous:
+        raise TypeError("get_xblock_id_for_anonymous_user() is only for anonymous (not logged in) users.")
+    if hasattr(user, 'xblock_id_for_anonymous_user'):
+        # If code elsewhere (like the xblock_handler API endpoint) has stored
+        # the key on the AnonymousUser object, just return that - it supersedes
+        # everything else:
+        return user.xblock_id_for_anonymous_user
+    # We use the session to track (and create if needed) a unique ID for this anonymous user:
+    current_request = crum.get_current_request()
+    if current_request and current_request.session:
+        # Make sure we have a key for this user:
+        if "xblock_id_for_anonymous_user" not in current_request.session:
+            new_id = "anon{}".format(uuid4().hex[:20])
+            current_request.session["xblock_id_for_anonymous_user"] = new_id
+        return current_request.session["xblock_id_for_anonymous_user"]
+    else:
+        raise RuntimeError("Cannot get a user ID for an anonymous user outside of an HTTP request context.")


### PR DESCRIPTION
This PR updates the new (blockstore-based) XBlock runtime (python API + REST API) so that it can store state for anonymous (non-registered) users. This can be used to allow people to preview course content (or library content, or any other learning context) without having to register an account.

Implementation details:
* Anonymous users are assigned a unique ID (like `anon42c08f9996194e2a9339`) which gets stored in the django session.
   - `block.scope_ids.user_id` and `block.runtime.anonymous_student_id` will both return this value.
* User state for anonymous users is stored in the django cache and automatically expires after two days.
* There is no mechanism for upgrading to a registered account and keeping user state since the user state store for anonymous users (`EphemeralKeyValueStore`) is completely different than the one for registered users (`DjangoKeyValueStore`/"CSM"), and has no "list all keys" functionality.
* "User State Summary" field values are shared among \[recently active] anonymous users but are not shared with registered users.

This also fixes the _Studio_ behavior of XBlocks in the new runtime so that they store user state in the cache too, very similar to the way Studio today stores user state in the session. (Before this PR, user state for Studio testing of XBlocks was just stored in a dict that was destroyed after each request-response cycle.)

## Manual test instructions

Make sure [blockstore](https://github.com/open-craft/blockstore) is running.

Install/update the very latest version of [Ramshackle](https://github.com/open-craft/ramshackle#readme).

Check out this branch and restart Studio/LMS.

Go to http://localhost:18010/ramshackle/ and find or create a `drag-and-drop-v2` XBlock in a content library. Click on "Actions" then right-click "this link" for testing anonymously and open it in an incognito window:
<img width="578" alt="ramshackle" src="https://user-images.githubusercontent.com/945577/70104467-f1219400-15f2-11ea-909f-41cfce3da70c.png">

Drag some items around then refresh the page or open the same URL in another tab (in the same incognito session) and notice that the state is preserved.

Then try with other XBlock types - `problem`, `video`, `html`, etc.

## Running the test suite instructions

Unit tests that require blockstore currently do not run automatically because devstack doesn't yet ship with Blockstore. You need to run them manually:

First, from the `blockstore` directory, run `make testserver` to start a Blockstore instance for testing.

Then from `make studio-shell` run the following:
```
EDXAPP_RUN_BLOCKSTORE_TESTS=1 python -Wd -m pytest --ds=cms.envs.test openedx/core/lib/blockstore_api/ openedx/core/djangolib/tests/test_blockstore_cache.py openedx/core/djangoapps/content_libraries/tests/
```

Then from `make lms-shell` run the same command but with `cms.envs.test` changed to `lms.envs.test`