### PR TITLE
fix incorrect score display for blank problem

### DIFF
--- a/common/lib/xmodule/xmodule/capa_module.py
+++ b/common/lib/xmodule/xmodule/capa_module.py
@@ -113,6 +113,7 @@ class ProblemBlock(
         except Exception as err:
             html = self.handle_fatal_lcp_error(err if show_detailed_errors else None)
         else:
+            self.set_score(self.score_from_lcp(self.lcp))
             html = self.get_html()
         fragment = Fragment(html)
         add_webpack_to_fragment(fragment, 'ProblemBlockPreview')


### PR DESCRIPTION
### [PROD-659](https://openedx.atlassian.net/browse/PROD-659)

### Description
When a blank common/advanced problem is created, the possible points are 0. However, when the problem is populated with the question(s), then saving the problem doesn't update the score. This PR attempts to fix that behavior by setting/updating the score when rendering the CAPA problem.