### PR TITLE
Fix timer text wrapping on smaller screens

### DIFF
--- a/lms/static/sass/course/layout/_courseware_preview.scss
+++ b/lms/static/sass/course/layout/_courseware_preview.scss
@@ -83,7 +83,10 @@ $proctoring-banner-text-size: 14px;
 
     .exam-text {
       display: inline-block;
-      width: calc(100% - 250px);
+
+      @include media-breakpoint-up(md) {
+        width: calc(100% - 250px);
+      }
     }
 
     a {

--- a/lms/templates/courseware/proctored-exam-status.underscore
+++ b/lms/templates/courseware/proctored-exam-status.underscore
@@ -6,17 +6,6 @@
                 .replace(/>/g, '&gt;')
         }
     %>
-    <div class='exam-text js-exam-text' data-show-long="true">
-        <% // xss-lint: disable=underscore-not-escaped %>
-        <%= interpolate_text(gettext('You are taking "{exam_link}" as {exam_type}. '), {exam_link: "<a href='" + exam_url_path + "'>"+gtLtEscape(exam_display_name)+"</a>", exam_type: (!_.isUndefined(arguments[0].exam_type)) ? exam_type : gettext('a timed exam')}) %>
-        <span class="js-exam-additional-text" aria-hidden="false">
-            <%- gettext('The timer on the right shows the time remaining in the exam.') %>
-            <%- gettext('To receive credit for problems, you must select "Submit" for each problem before you select "End My Exam".') %>
-        </span>
-        <button class="js-toggle-show-more btn btn-link" data-show-more-text="<%- gettext('Show More') %>" data-show-less-text="<%- gettext('Show Less') %>">
-            <%- gettext('Show Less') %>
-        </button>
-    </div>
     <div id="turn_in_exam_id" class="pull-right turn_in_exam" role="region" aria-label="<%- gettext('Exam timer and end exam button')%>">
         <span>
             <% if(attempt_status !== 'ready_to_submit') {%>
@@ -35,5 +24,16 @@
                 <i class="fa fa-eye-slash" aria-hidden="true"></i>
             </button>
         </span>
+    </div>
+    <div class='exam-text js-exam-text' data-show-long="true">
+        <% // xss-lint: disable=underscore-not-escaped %>
+        <%= interpolate_text(gettext('You are taking "{exam_link}" as {exam_type}. '), {exam_link: "<a href='" + exam_url_path + "'>"+gtLtEscape(exam_display_name)+"</a>", exam_type: (!_.isUndefined(arguments[0].exam_type)) ? exam_type : gettext('a timed exam')}) %>
+        <span class="js-exam-additional-text" aria-hidden="false">
+            <%- gettext('The timer on the right shows the time remaining in the exam.') %>
+            <%- gettext('To receive credit for problems, you must select "Submit" for each problem before you select "End My Exam".') %>
+        </span>
+        <button class="js-toggle-show-more btn btn-link" data-show-more-text="<%- gettext('Show More') %>" data-show-less-text="<%- gettext('Show Less') %>">
+            <%- gettext('Show Less') %>
+        </button>
     </div>
 </div>


### PR DESCRIPTION
This fixes wrapping the `exam-text` on smaller screens, which prevents users from viewing the exam's content.

**JIRA tickets**: [OSPR-3955](https://openedx.atlassian.net/browse/OSPR-3955)

**Dependencies**: None

**Screenshots**:
Before:
![before](https://user-images.githubusercontent.com/3189670/70205863-dbf95200-1725-11ea-9c03-0215879bcdc3.png)

After:
![after](https://user-images.githubusercontent.com/3189670/70205870-df8cd900-1725-11ea-8b9c-94a7e6ac5601.png)


**Sandbox URL**: [direct link to the exam](https://pr22446.sandbox.opencraft.hosting/courses/course-v1:test+test+test/courseware/c4465ee39dd84acba8034435304fb304/622aef0d2f3f497094c5e54329b144a7/?activate_block_id=block-v1%3Atest%2Btest%2Btest%2Btype%40sequential%2Bblock%40622aef0d2f3f497094c5e54329b144a7)

**Merge deadline**: None

**Testing instructions**:
1. Rebuild static files (`make lms-static && make lms-restart`).
1. Set `ENABLE_SPECIAL_EXAMS` to `true` in `{lms,cms}.env.json`.
1. Set up a [timed exam](https://edx.readthedocs.io/projects/edx-partner-course-staff/en/latest/course_features/timed_exams.html).
1. Start the course and check that for screens under 768px the text is no longer wrapped, but it's placed under the timer.

**Reviewers**
- [x] @viadanna (this has already been reviewed as a part of the theme change)
- [ ] @bradenmacdonald 
- [ ] edX reviewer[s] TBD

**Settings**
```yaml
EDXAPP_FEATURES:
  ENABLE_SPECIAL_EXAMS: true
```