### PR TITLE
fix logs condition

### DIFF
--- a/openedx/features/course_experience/utils.py
+++ b/openedx/features/course_experience/utils.py
@@ -51,7 +51,7 @@ def get_course_outline_block_tree(request, course_id, user=None):
             try:
                 child_detail = populate_children(all_blocks[child_id], all_blocks)
             except TypeError:
-                if u"MITx+6.002x+MITx_2012_Alumni" in course_outline_root_block[id]:
+                if u"MITx+6.002x+MITx_2012_Alumni" in course_outline_root_block['id']:
                     log.info(u"PopulateChildrenError for Child: {child} in block:{block} at index:{index}".format(
                         child=child_id,
                         block=block['id'],


### PR DESCRIPTION
### [PROD-964](https://openedx.atlassian.net/browse/PROD-964)

### Description
The previous logs PR(https://github.com/edx/edx-platform/pull/22404) had a syntax error that didn't trigger the logs. This PR is fixing that error.

```
utils.py:59 - PopulateChildrenError for Child: block-v1:myOrg+pd379+2019_T2+type@chapter+block@8397cd89ccef477094b39f2f8355582e in block:block-v1:myOrg+pd379+2019_T2+type@course+block@course at index:0
```