### PR TITLE
Fixes for the blockstore API client / XBlock runtime under python 3

### DIFF
--- a/openedx/core/djangoapps/content_libraries/tests/test_content_libraries.py
+++ b/openedx/core/djangoapps/content_libraries/tests/test_content_libraries.py
@@ -152,7 +152,7 @@ class ContentLibrariesTest(ContentLibrariesRestApiTest):
         handler_url = self._get_block_handler_url(block_id, "xmodule_handler") + "problem_get"
         problem_get_response = self.client.get(handler_url)
         self.assertEqual(problem_get_response.status_code, 200)
-        self.assertIn("You have used 0 of 5 attempts", problem_get_response.content)
+        self.assertIn("You have used 0 of 5 attempts", problem_get_response.content.decode('utf-8'))
 
         # Now delete the block:
         self.assertEqual(self._get_library(lib_id)["has_unpublished_deletes"], False)

--- a/openedx/core/djangoapps/content_libraries/tests/test_runtime.py
+++ b/openedx/core/djangoapps/content_libraries/tests/test_runtime.py
@@ -235,7 +235,7 @@ class ContentLibraryXBlockUserStateTest(ContentLibraryContentTestMixin, TestCase
 
         submit_result = client.post(problem_check_url, data={problem_key: "choice_3"})
         self.assertEqual(submit_result.status_code, 200)
-        submit_data = json.loads(submit_result.content)
+        submit_data = json.loads(submit_result.content.decode('utf-8'))
         self.assertDictContainsSubset({
             "current_score": 0,
             "total_possible": 1,
@@ -251,7 +251,7 @@ class ContentLibraryXBlockUserStateTest(ContentLibraryContentTestMixin, TestCase
         # And submit a correct answer:
         submit_result = client.post(problem_check_url, data={problem_key: "choice_1"})
         self.assertEqual(submit_result.status_code, 200)
-        submit_data = json.loads(submit_result.content)
+        submit_data = json.loads(submit_result.content.decode('utf-8'))
         self.assertDictContainsSubset({
             "current_score": 1,
             "total_possible": 1,

--- a/openedx/core/djangoapps/content_libraries/views.py
+++ b/openedx/core/djangoapps/content_libraries/views.py
@@ -46,11 +46,11 @@ def convert_exceptions(fn):
             log.exception("XBlock not found in content library")
             raise NotFound
         except api.LibraryBlockAlreadyExists as exc:
-            log.exception(exc.message)
-            raise ValidationError(exc.message)
+            log.exception(str(exc))
+            raise ValidationError(str(exc))
         except api.InvalidNameError as exc:
-            log.exception(exc.message)
-            raise ValidationError(exc.message)
+            log.exception(str(exc))
+            raise ValidationError(str(exc))
     return wrapped_fn
 
 

--- a/openedx/core/djangoapps/xblock/runtime/shims.py
+++ b/openedx/core/djangoapps/xblock/runtime/shims.py
@@ -76,8 +76,8 @@ class RuntimeShim(object):
         # class in opaque-keys that accepts either old CourseKeys or new
         # LearningContextKeys.
         hasher = hashlib.md5()
-        hasher.update(settings.SECRET_KEY)
-        hasher.update(six.text_type(self.user_id))
+        hasher.update(settings.SECRET_KEY.encode('utf-8'))
+        hasher.update(six.text_type(self.user_id).encode('utf-8'))
         digest = hasher.hexdigest()
         return digest
 

--- a/openedx/core/djangolib/blockstore_cache.py
+++ b/openedx/core/djangolib/blockstore_cache.py
@@ -167,7 +167,7 @@ def get_bundle_draft_files_cached(bundle_uuid, draft_name):
     cache_key = ('bundle_draft_files', )
     result = bundle_cache.get(cache_key)
     if result is None:
-        result = blockstore_api.get_bundle_files(bundle_uuid, use_draft=draft_name)
+        result = list(blockstore_api.get_bundle_files(bundle_uuid, use_draft=draft_name))
         bundle_cache.set(cache_key, result)
     return result
 

--- a/openedx/core/lib/blockstore_api/methods.py
+++ b/openedx/core/lib/blockstore_api/methods.py
@@ -297,7 +297,7 @@ def get_bundle_files_dict(bundle_uuid, use_draft=None):
 
 def get_bundle_files(bundle_uuid, use_draft=None):
     """
-    Get a flat list of all the files in the specified bundle or draft.
+    Get an iterator over all the files in the specified bundle or draft.
     """
     return get_bundle_files_dict(bundle_uuid, use_draft).values()
 

--- a/openedx/core/lib/blockstore_api/tests/test_blockstore_api.py
+++ b/openedx/core/lib/blockstore_api/tests/test_blockstore_api.py
@@ -112,31 +112,31 @@ class BlockstoreApiClientTest(unittest.TestCase):
         self.assertEqual(draft, draft3)
 
         # Write a file into the bundle:
-        api.write_draft_file(draft.uuid, "test.txt", "initial version")
+        api.write_draft_file(draft.uuid, "test.txt", b"initial version")
         # Now the file should be visible in the draft:
         draft_contents = api.get_bundle_file_data(bundle.uuid, "test.txt", use_draft=draft.name)
-        self.assertEqual(draft_contents, "initial version")
+        self.assertEqual(draft_contents, b"initial version")
         api.commit_draft(draft.uuid)
 
         # Write a new version into the draft:
-        api.write_draft_file(draft.uuid, "test.txt", "modified version")
+        api.write_draft_file(draft.uuid, "test.txt", b"modified version")
         published_contents = api.get_bundle_file_data(bundle.uuid, "test.txt")
-        self.assertEqual(published_contents, "initial version")
+        self.assertEqual(published_contents, b"initial version")
         draft_contents2 = api.get_bundle_file_data(bundle.uuid, "test.txt", use_draft=draft.name)
-        self.assertEqual(draft_contents2, "modified version")
+        self.assertEqual(draft_contents2, b"modified version")
         # Now delete the draft:
         api.delete_draft(draft.uuid)
         draft_contents3 = api.get_bundle_file_data(bundle.uuid, "test.txt", use_draft=draft.name)
         # Confirm the file is now reset:
-        self.assertEqual(draft_contents3, "initial version")
+        self.assertEqual(draft_contents3, b"initial version")
 
         # Finaly, test the get_bundle_file* methods:
         file_info1 = api.get_bundle_file_metadata(bundle.uuid, "test.txt")
         self.assertEqual(file_info1.path, "test.txt")
-        self.assertEqual(file_info1.size, len("initial version"))
+        self.assertEqual(file_info1.size, len(b"initial version"))
         self.assertEqual(file_info1.hash_digest, "a45a5c6716276a66c4005534a51453ab16ea63c4")
 
-        self.assertEqual(api.get_bundle_files(bundle.uuid), [file_info1])
+        self.assertEqual(list(api.get_bundle_files(bundle.uuid)), [file_info1])
         self.assertEqual(api.get_bundle_files_dict(bundle.uuid), {
             "test.txt": file_info1,
         })


### PR DESCRIPTION
This fixes some python3-related errors that were breaking the content libraries v2 API and the blockstore-based XBlock runtime.

These issues were being caught by the test suite, but this part of the test suite is only run when the `EDXAPP_RUN_BLOCKSTORE_TESTS` environment variable is set, because it requires a running instance of blockstore, which isn't yet available in the default devstack install nor on CI.


## How to run the tests manually to verify the fix

First, from the `blockstore` directory, run `make testserver` to start a Blockstore instance for testing.

Then from `make studio-shell` run the following:
```
EDXAPP_RUN_BLOCKSTORE_TESTS=1 python -Wd -m pytest --ds=cms.envs.test openedx/core/lib/blockstore_api/ openedx/core/djangolib/tests/test_blockstore_cache.py openedx/core/djangoapps/content_libraries/tests/
```

Then from `make lms-shell` run the same command but with `cms.envs.test` changed to `lms.envs.test`