### PR TITLE
EDUCATOR-4820 Update edx-ora2 to 2.4.7

### DIFF
--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -171,7 +171,7 @@ nodeenv==1.3.3
 numpy==1.16.5
 git+https://github.com/joestump/python-oauth2.git@b94f69b1ad195513547924e380d9265133e995fa#egg=oauth2
 oauthlib==2.1.0
-git+https://github.com/edx/edx-ora2.git@2.4.6#egg=ora2==2.4.6
+git+https://github.com/edx/edx-ora2.git@2.4.7#egg=ora2==2.4.7
 path.py==8.2.1
 pathtools==0.1.2
 paver==1.3.4

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -221,7 +221,7 @@ nodeenv==1.3.3
 numpy==1.16.5
 git+https://github.com/joestump/python-oauth2.git@b94f69b1ad195513547924e380d9265133e995fa#egg=oauth2
 oauthlib==2.1.0
-git+https://github.com/edx/edx-ora2.git@2.4.6#egg=ora2==2.4.6
+git+https://github.com/edx/edx-ora2.git@2.4.7#egg=ora2==2.4.7
 packaging==19.2
 path.py==8.2.1
 pathlib2==2.3.5

--- a/requirements/edx/github.in
+++ b/requirements/edx/github.in
@@ -81,7 +81,7 @@ git+https://github.com/edx/bridgekeeper.git@4e34894e4ac5d0467ed1901811a81fd87ee0
 # Our libraries:
 -e git+https://github.com/edx/codejail.git@33758da2609bd72c2c18efc2d4bdb93596523d5e#egg=codejail
 -e git+https://github.com/edx/acid-block.git@98aecba94ecbfa934e2d00262741c0ea9f557fc9#egg=acid-xblock
-git+https://github.com/edx/edx-ora2.git@2.4.6#egg=ora2==2.4.6
+git+https://github.com/edx/edx-ora2.git@2.4.7#egg=ora2==2.4.7
 git+https://github.com/edx/crowdsourcehinter.git@a7ffc85b134b7d8909bf1fefd23dbdb8eb28e467#egg=crowdsourcehinter-xblock==0.2
 -e git+https://github.com/edx/RateXBlock.git@2.0#egg=rate-xblock
 -e git+https://github.com/edx/DoneXBlock.git@2.0.1#egg=done-xblock

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -212,7 +212,7 @@ nodeenv==1.3.3
 numpy==1.16.5
 git+https://github.com/joestump/python-oauth2.git@b94f69b1ad195513547924e380d9265133e995fa#egg=oauth2
 oauthlib==2.1.0
-git+https://github.com/edx/edx-ora2.git@2.4.6#egg=ora2==2.4.6
+git+https://github.com/edx/edx-ora2.git@2.4.7#egg=ora2==2.4.7
 packaging==19.2           # via caniusepython3, tox
 path.py==8.2.1
 pathlib2==2.3.5


### PR DESCRIPTION
Updated the referenced version of edx-ora2 to overcome dependency version mismatches