### PR TITLE
ARCH-1253: return json for third party auth failure

### DIFF
--- a/openedx/core/djangoapps/user_authn/views/login.py
+++ b/openedx/core/djangoapps/user_authn/views/login.py
@@ -365,7 +365,11 @@ def login_user(request):
             except AuthFailedError as e:
                 set_custom_metric('login_user_tpa_success', False)
                 set_custom_metric('login_user_tpa_failure_msg', e.value)
-                return HttpResponse(e.value, content_type="text/plain", status=403)
+
+                # user successfully authenticated with a third party provider, but has no linked Open edX account
+                response_content = e.get_response()
+                response_content['error_code'] = 'third-party-auth-with-no-linked-account'
+                return JsonResponse(response_content, status=403)
         else:
             user = _get_user_by_email(request)
 

--- a/openedx/core/djangoapps/user_authn/views/tests/test_login.py
+++ b/openedx/core/djangoapps/user_authn/views/tests/test_login.py
@@ -40,6 +40,7 @@ from openedx.core.djangolib.testing.utils import CacheIsolationTestCase, skip_un
 from openedx.core.djangoapps.site_configuration.tests.mixins import SiteMixin
 from openedx.core.lib.api.test_utils import ApiTestCase
 from student.tests.factories import RegistrationFactory, UserFactory, UserProfileFactory
+from util.json_request import JsonResponse
 from util.password_policy_validators import DEFAULT_MAX_PASSWORD_LENGTH
 
 
@@ -818,8 +819,13 @@ class StudentViewShimTest(TestCase):
         self.captured_request = None
 
     def test_third_party_auth_login_failure(self):
+        mocked_response_content = {
+            "success": False,
+            "error_code": "third-party-auth-with-no-linked-account",
+            "value": "Test message."
+        }
         view = self._shimmed_view(
-            HttpResponse(status=403),
+            JsonResponse(mocked_response_content, status=403),
             check_logged_in=True
         )
         response = view(HttpRequest())


### PR DESCRIPTION
Returning JSON from `login_user` for third party auth failures (instead of plain text) makes the response more consistent with all other `login_user` responses.

This is a breaking change.  However, the only calls to `login_user` with this failure are processed by `shim_student_view` which will in-turn remove this JSON. This improves the `login_user` response in advance of switching the logistration page to use `login_user` without `shim_student_view`.

ARCH-1253

### Please consider the following when opening a pull request:

- Link to the relevant JIRA ticket(s) and tag any relevant team(s).
- Squash your changes down into one or more discrete commits.
  In each commit, include description that could help a developer
  several months from now.
- If running `make upgrade`, run _as close to the time of merging as possible_
  to avoid accidentally downgrading someone else's package.
  Put the output of `make upgrade` in its own separate commit,
  decoupled from other code changes.
- Aim for comprehensive test coverage, but remember that
  automated testing isn't a substitute for manual verification.
- Carefully consider naming, code organization, dependencies when adding new code.
  Code that is amenable to refactoring and improvement benefits all platform developers,
  especially given the size and scope of edx-platform.
  Consult existing Architectural Decision Records (ADRs),
  including those concerning the app(s) you are changing and
  [those concerning edx-platform as a whole](https://github.com/edx/edx-platform/tree/master/docs/decisions).
