### PR TITLE
ARCH-1253: remove UPDATE_LOGIN_USER_ERROR_STATUS_CODE toggle

### DIFF
--- a/common/djangoapps/third_party_auth/tests/specs/base.py
+++ b/common/djangoapps/third_party_auth/tests/specs/base.py
@@ -123,7 +123,7 @@ class HelperMixin(object):
 
     def assert_json_failure_response_is_inactive_account(self, response):
         """Asserts failure on /login for inactive account looks right."""
-        self.assertEqual(200, response.status_code)  # Yes, it's a 200 even though it's a failure.
+        self.assertEqual(400, response.status_code)
         payload = json.loads(response.content.decode('utf-8'))
         self.assertFalse(payload.get('success'))
         self.assertIn('In order to sign in, you need to activate your account.', payload.get('value'))

--- a/openedx/core/djangoapps/user_authn/config/waffle.py
+++ b/openedx/core/djangoapps/user_authn/config/waffle.py
@@ -22,18 +22,3 @@ _WAFFLE_SWITCH_NAMESPACE = WaffleSwitchNamespace(name=_WAFFLE_NAMESPACE, log_pre
 ENABLE_LOGIN_USING_THIRDPARTY_AUTH_ONLY = WaffleSwitch(
     _WAFFLE_SWITCH_NAMESPACE, 'enable_login_using_thirdparty_auth_only'
 )
-
-# .. toggle_name: user_authn.update_login_user_error_status_code
-# .. toggle_implementation: WaffleSwitch
-# .. toggle_default: False
-# .. toggle_description: Changes auth failures (non-SSO) from 200 to 400.
-# .. toggle_category: authn
-# .. toggle_use_cases: incremental_release
-# .. toggle_creation_date: 2019-11-21
-# .. toggle_expiration_date: 2020-01-31
-# .. toggle_warnings: Causes backward incompatible change. Document before removing.
-# .. toggle_tickets: ARCH-1253
-# .. toggle_status: supported
-UPDATE_LOGIN_USER_ERROR_STATUS_CODE = WaffleSwitch(
-    _WAFFLE_SWITCH_NAMESPACE, 'update_login_user_error_status_code'
-)

--- a/openedx/core/djangoapps/user_authn/views/login.py
+++ b/openedx/core/djangoapps/user_authn/views/login.py
@@ -34,10 +34,7 @@ from openedx.core.djangoapps.user_authn.cookies import refresh_jwt_cookies, set_
 from openedx.core.djangoapps.user_authn.exceptions import AuthFailedError
 from openedx.core.djangoapps.util.user_messages import PageLevelMessages
 from openedx.core.djangoapps.user_authn.views.password_reset import send_password_reset_email_for_user
-from openedx.core.djangoapps.user_authn.config.waffle import (
-    ENABLE_LOGIN_USING_THIRDPARTY_AUTH_ONLY,
-    UPDATE_LOGIN_USER_ERROR_STATUS_CODE
-)
+from openedx.core.djangoapps.user_authn.config.waffle import ENABLE_LOGIN_USING_THIRDPARTY_AUTH_ONLY
 from openedx.core.djangolib.markup import HTML, Text
 from openedx.core.lib.api.view_utils import require_post_params
 from student.models import LoginFailures, AllowedAuthUser, UserProfile
@@ -406,11 +403,7 @@ def login_user(request):
         return response
     except AuthFailedError as error:
         log.exception(error.get_response())
-        # original code returned a 200 status code with status=False for errors. This flag
-        # is used for rolling out a transition to using a 400 status code for errors, which
-        # is a breaking-change, but will hopefully be a tolerable breaking-change.
-        status = 400 if UPDATE_LOGIN_USER_ERROR_STATUS_CODE.is_enabled() else 200
-        response = JsonResponse(error.get_response(), status=status)
+        response = JsonResponse(error.get_response(), status=400)
         set_custom_metric('login_user_auth_failed_error', True)
         set_custom_metric('login_user_response_status', response.status_code)
         return response


### PR DESCRIPTION
**Note:** We can let this clean-up sit for a bit before merging, but just wanted to prepare it.

The toggle UPDATE_LOGIN_USER_ERROR_STATUS_CODE was added to roll out a
breaking change for `login_user` auth errors to return a 400 rather than
a 200.

This toggle was enabled in Production on 12/5/2019 with seemingly no
adverse affects.

ARCH-1253

### Please consider the following when opening a pull request:

- Link to the relevant JIRA ticket(s) and tag any relevant team(s).
- Squash your changes down into one or more discrete commits.
  In each commit, include description that could help a developer
  several months from now.
- If running `make upgrade`, run _as close to the time of merging as possible_
  to avoid accidentally downgrading someone else's package.
  Put the output of `make upgrade` in its own separate commit,
  decoupled from other code changes.
- Aim for comprehensive test coverage, but remember that
  automated testing isn't a substitute for manual verification.
- Carefully consider naming, code organization, dependencies when adding new code.
  Code that is amenable to refactoring and improvement benefits all platform developers,
  especially given the size and scope of edx-platform.
  Consult existing Architectural Decision Records (ADRs),
  including those concerning the app(s) you are changing and
  [those concerning edx-platform as a whole](https://github.com/edx/edx-platform/tree/master/docs/decisions).
