### PR TITLE
ENT-1961 | Making the manual enrollment reason field optional via con…

### DIFF
--- a/lms/djangoapps/instructor/tests/views/test_instructor_dashboard.py
+++ b/lms/djangoapps/instructor/tests/views/test_instructor_dashboard.py
@@ -158,6 +158,31 @@ class TestInstructorDashboard(ModuleStoreTestCase, LoginEnrollmentTestCase, XssT
             content('#field-course-organization b').contents()[0].strip()
         )
 
+    @ddt.data(True, False)
+    def test_membership_reason_field_visibility(self, enbale_reason_field):
+        """
+        Verify that reason field is enabled by site configuration flag 'ENABLE_MANUAL_ENROLLMENT_REASON_FIELD'
+        """
+
+        configuration_values = {
+            "ENABLE_MANUAL_ENROLLMENT_REASON_FIELD": enbale_reason_field
+        }
+        site = Site.objects.first()
+        SiteConfiguration.objects.create(site=site, values=configuration_values, enabled=True)
+
+        url = reverse(
+            'instructor_dashboard',
+            kwargs={
+                'course_id': six.text_type(self.course_info.id)
+            }
+        )
+        response = self.client.get(url)
+        reason_field = '<textarea rows="2" id="reason-field-id" name="reason-field" placeholder="Reason" spellcheck="false"></textarea>'  # pylint: disable=line-too-long
+        if enbale_reason_field:
+            self.assertContains(response, reason_field)
+        else:
+            self.assertNotContains(response, reason_field)
+
     def test_membership_site_configuration_role(self):
         """
         Verify that the role choices set via site configuration are loaded in the membership tab

--- a/lms/djangoapps/instructor/views/instructor_dashboard.py
+++ b/lms/djangoapps/instructor/views/instructor_dashboard.py
@@ -550,7 +550,8 @@ def _section_membership(course, access):
             'update_forum_role_membership',
             kwargs={'course_id': six.text_type(course_key)}
         ),
-        'enrollment_role_choices': enrollment_role_choices
+        'enrollment_role_choices': enrollment_role_choices,
+        'is_reason_field_enabled': configuration_helpers.get_value('ENABLE_MANUAL_ENROLLMENT_REASON_FIELD', False)
     }
     return section_data
 

--- a/lms/static/js/instructor_dashboard/membership.js
+++ b/lms/static/js/instructor_dashboard/membership.js
@@ -603,7 +603,7 @@ such that the value can be defined later than this assignment (file load order).
             this.$request_response_error = this.$container.find('.request-response-error');
             this.$enrollment_button.click(function(event) {
                 var sendData;
-                if (!batchEnroll.$reason_field.val()) {
+                if (batchEnroll.$reason_field.length && !batchEnroll.$reason_field.val()) {
                     batchEnroll.fail_with_error(gettext('Reason field should not be left blank.'));
                     return false;
                 }

--- a/lms/templates/instructor/instructor_dashboard_2/membership.html
+++ b/lms/templates/instructor/instructor_dashboard_2/membership.html
@@ -24,12 +24,14 @@ from openedx.core.djangolib.markup import HTML, Text
         </label>
     </div>
 
-    <label>
-        ${_("Enter the reason why the students are to be manually enrolled or unenrolled.")}
-        ${_("This cannot be left blank and will be recorded and presented in Enrollment Reports.")}
-        ${_("Therefore, please give enough detail to account for this action.")}
-        <textarea rows="2" id="reason-field-id" name="reason-field" placeholder="${_('Reason')}" spellcheck="false"></textarea>
-    </label>
+    % if section_data['is_reason_field_enabled']:
+        <label>
+            ${_("Enter the reason why the students are to be manually enrolled or unenrolled.")}
+            ${_("This cannot be left blank and will be recorded and presented in Enrollment Reports.")}
+            ${_("Therefore, please give enough detail to account for this action.")}
+            <textarea rows="2" id="reason-field-id" name="reason-field" placeholder="${_('Reason')}" spellcheck="false"></textarea>
+        </label>
+    %endif
     <div class="enroll-option">
         <label class="has-hint">
             <input type="checkbox" name="auto-enroll" id="auto-enroll" value="Auto-Enroll" checked="yes" aria-describedby="heading-batch-enrollment">


### PR DESCRIPTION
…figuration flag `ENABLE_MANUAL_ENROLLMENT_REASON_FIELD`.

### Please consider the following when opening a pull request:

- Link to the relevant JIRA ticket(s) and tag any relevant team(s).
- Squash your changes down into one or more discrete commits.
  In each commit, include description that could help a developer
  several months from now.
- If running `make upgrade`, run _as close to the time of merging as possible_
  to avoid accidentally downgrading someone else's package.
  Put the output of `make upgrade` in its own separate commit,
  decoupled from other code changes.
- Aim for comprehensive test coverage, but remember that
  automated testing isn't a substitute for manual verification.
- Carefully consider naming, code organization, dependencies when adding new code.
  Code that is amenable to refactoring and improvement benefits all platform developers,
  especially given the size and scope of edx-platform.
  Consult existing Architectural Decision Records (ADRs),
  including those concerning the app(s) you are changing and
  [those concerning edx-platform as a whole](https://github.com/edx/edx-platform/tree/master/docs/decisions).
