### PR TITLE
log exception for further context

### DIFF
--- a/common/lib/xmodule/xmodule/capa_base.py
+++ b/common/lib/xmodule/xmodule/capa_base.py
@@ -441,6 +441,7 @@ class CapaMixin(ScorableXBlockMixin, CapaFields):
         })
 
     def handle_fatal_lcp_error(self, error):
+        log.exception(u"LcpFatalError Encountered for {block}".format(block=str(self.location)))
         if error:
             return(
                 HTML(u'<p>Error formatting HTML for problem:</p><p><pre style="color:red">{msg}</pre></p>').format(


### PR DESCRIPTION
### [PROD-1000](https://openedx.atlassian.net/browse/PROD-1000)

### Description
Logging the exception before the rendering of the error to get more context on the problem. 

```
Traceback (most recent call last):
  File "/edx/app/edxapp/edx-platform/common/lib/capa/capa/capa_problem.py", line 895, in _extract_context
    unsafely=self.capa_system.can_execute_unsafe_code(),
  File "/edx/app/edxapp/edx-platform/common/lib/capa/capa/safe_exec/safe_exec.py", line 166, in safe_exec
    raise exception
SafeExecException: AttributeError: 'module' object has no attribute 'Matrix'
 ```