### PR TITLE
ENT-2500 Bypass multiple enterprise selection page for SAML user

### DIFF
--- a/lms/static/js/student_account/views/AccessView.js
+++ b/lms/static/js/student_account/views/AccessView.js
@@ -138,6 +138,8 @@
                             method: data.method,
                             url: data.submit_url
                         });
+                        var isTpaSaml = this.thirdPartyAuth && this.thirdPartyAuth.finishAuthUrl ?
+                          this.thirdPartyAuth.finishAuthUrl.indexOf('tpa-saml') >= 0 : false;
 
                         this.subview.login = new LoginView({
                             fields: data.fields,
@@ -160,7 +162,7 @@
                         this.listenTo(this.subview.login, 'password-help', this.resetPassword);
 
                     // Listen for 'auth-complete' event so we can enroll/redirect the user appropriately.
-                        if (this.isMultipleUserEnterprisesFeatureEnabled === true) {
+                        if (this.isMultipleUserEnterprisesFeatureEnabled === true && !isTpaSaml) {
                             this.listenTo(this.subview.login, 'auth-complete', this.loginComplete);
                         } else {
                             this.listenTo(this.subview.login, 'auth-complete', this.authComplete);


### PR DESCRIPTION
**Requirement:**
When a user logged in via SAML he should not be taken to multiple enterprise selection page.
**Previous Functionality:**
When a user logged in via SAML and map his edx account with SAML, he is taken to multiple enterprise selection page.
**Functionality After this PR:**
When a user logged in via SAML and map his edx account with SAML, he will not be taken to multiple enterprise selection page.



### Please consider the following when opening a pull request:

- Link to the relevant JIRA ticket(s) and tag any relevant team(s).
- Squash your changes down into one or more discrete commits.
  In each commit, include description that could help a developer
  several months from now.
- If running `make upgrade`, run _as close to the time of merging as possible_
  to avoid accidentally downgrading someone else's package.
  Put the output of `make upgrade` in its own separate commit,
  decoupled from other code changes.
- Aim for comprehensive test coverage, but remember that
  automated testing isn't a substitute for manual verification.
- Carefully consider naming, code organization, dependencies when adding new code.
  Code that is amenable to refactoring and improvement benefits all platform developers,
  especially given the size and scope of edx-platform.
  Consult existing Architectural Decision Records (ADRs),
  including those concerning the app(s) you are changing and
  [those concerning edx-platform as a whole](https://github.com/edx/edx-platform/tree/master/docs/decisions).
