### PR TITLE
EDUCATOR-4821 | Upgrade edx-bulk-grades to 0.6.5

### DIFF
--- a/requirements/edx/base.in
+++ b/requirements/edx/base.in
@@ -69,6 +69,7 @@ djangorestframework-jwt
 drf-yasg                            # Replacement for django-rest-swagger
 edx-ace==0.1.10
 edx-analytics-data-api-client
+edx-bulk-grades                     # LMS REST API for managing bulk grading operations
 edx-ccx-keys
 edx-celeryutils
 edx-completion
@@ -158,4 +159,3 @@ XBlock                              # Courseware component architecture
 xblock-utils                        # Provides utilities used by the Discussion XBlock
 xss-utils                           # https://github.com/edx/edx-platform/pull/20633 Fix XSS via Translations
 geoip2==2.9.0                       # Python API for the GeoIP web services and databases
-edx-bulk-grades                     # LMS REST API for managing bulk grading operations

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -96,7 +96,7 @@ docutils==0.15.2          # via botocore
 drf-yasg==1.16
 edx-ace==0.1.10
 edx-analytics-data-api-client==0.15.3
-edx-bulk-grades==0.6.4
+edx-bulk-grades==0.6.5
 edx-ccx-keys==1.0.0
 edx-celeryutils==0.3.0
 edx-completion==3.0.2

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -118,7 +118,7 @@ docutils==0.15.2
 drf-yasg==1.16
 edx-ace==0.1.10
 edx-analytics-data-api-client==0.15.3
-edx-bulk-grades==0.6.4
+edx-bulk-grades==0.6.5
 edx-ccx-keys==1.0.0
 edx-celeryutils==0.3.0
 edx-completion==3.0.2

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -115,7 +115,7 @@ docutils==0.15.2
 drf-yasg==1.16
 edx-ace==0.1.10
 edx-analytics-data-api-client==0.15.3
-edx-bulk-grades==0.6.4
+edx-bulk-grades==0.6.5
 edx-ccx-keys==1.0.0
 edx-celeryutils==0.3.0
 edx-completion==3.0.2


### PR DESCRIPTION
**Fixes https://openedx.atlassian.net/browse/EDUCATOR-4821**
* Upgrades `edx-bulk-grades` to https://github.com/edx/edx-bulk-grades/releases/tag/0.6.5
* PyPI: https://pypi.org/project/edx-bulk-grades/0.6.5/
