### PR TITLE
Suppress grade on dashboard

### DIFF
--- a/common/djangoapps/util/course.py
+++ b/common/djangoapps/util/course.py
@@ -10,6 +10,7 @@ import six.moves.urllib.error
 import six.moves.urllib.parse
 import six.moves.urllib.request
 from django.conf import settings
+from django.utils.timezone import now
 
 from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
 
@@ -73,3 +74,9 @@ def has_certificates_enabled(course):
     if not settings.FEATURES.get('CERTIFICATES_HTML_VIEW', False):
         return False
     return course.cert_html_view_enabled
+
+
+def should_display_grade(end_date):
+    if end_date and end_date < now().replace(hour=0, minute=0, second=0, microsecond=0):
+        return True
+    return False

--- a/lms/templates/dashboard/_dashboard_certificate_information.html
+++ b/lms/templates/dashboard/_dashboard_certificate_information.html
@@ -4,6 +4,7 @@
 from django.utils.translation import ugettext as _
 from openedx.core.djangolib.markup import HTML, Text
 from course_modes.models import CourseMode
+from util.course import should_display_grade
 %>
 <%namespace name='static' file='../static_content.html'/>
 
@@ -44,9 +45,11 @@ else:
     </div>
   % else:
     <div class="message message-status ${status_css_class} is-shown">
-      <p class="message-copy">${_("Your final grade:")}
-        <span class="grade-value">${"{0:.0f}%".format(float(cert_status['grade'])*100)}</span>.
-
+      <p class="message-copy">
+        % if should_display_grade(course_overview.end):
+            ${_("Your final grade:")}
+            <span class="grade-value">${"{0:.0f}%".format(float(cert_status['grade'])*100)}</span>.
+        % endif
         % if cert_status['status'] == 'notpassing':
           % if enrollment.mode != 'audit':
             ${_("Grade required for a {cert_name_short}:").format(cert_name_short=cert_name_short)}


### PR DESCRIPTION
Learners should not be able to view final grade before course end date.Suppress the grade achieved so far till course end date on dashboard.

[PROD-701](https://openedx.atlassian.net/browse/PROD-701)
