### PR TITLE
Use six to reraise a capa error.

### DIFF
--- a/common/lib/capa/capa/capa_problem.py
+++ b/common/lib/capa/capa/capa_problem.py
@@ -897,7 +897,7 @@ class LoncapaProblem(object):
             except Exception as err:
                 log.exception("Error while execing script code: " + all_code)
                 msg = Text("Error while executing script code: %s" % str(err))
-                raise responsetypes.LoncapaProblemError(msg)
+                six.reraise(responsetypes.LoncapaProblemError, responsetypes.LoncapaProblemError(msg))
 
         # Store code source in context, along with the Python path needed to run it correctly.
         context['script_code'] = all_code


### PR DESCRIPTION
I believe the error we were seeing is due to not using `six` to reraise the exception.