### PR TITLE
Redirect to the view names directly.

### DIFF
--- a/lms/djangoapps/branding/views.py
+++ b/lms/djangoapps/branding/views.py
@@ -43,7 +43,7 @@ def index(request):
         if configuration_helpers.get_value(
                 'ALWAYS_REDIRECT_HOMEPAGE_TO_DASHBOARD_FOR_AUTHENTICATED_USER',
                 settings.FEATURES.get('ALWAYS_REDIRECT_HOMEPAGE_TO_DASHBOARD_FOR_AUTHENTICATED_USER', True)):
-            return redirect(reverse('dashboard'))
+            return redirect('dashboard')
 
     enable_mktg_site = configuration_helpers.get_value(
         'ENABLE_MKTG_SITE',
@@ -62,7 +62,7 @@ def index(request):
     # keep specialized logic for Edge until we can migrate over Edge to fully use
     # configuration.
     if domain and 'edge.edx.org' in domain:
-        return redirect(reverse("signin_user"))
+        return redirect("signin_user")
 
     #  we do not expect this case to be reached in cases where
     #  marketing and edge are enabled


### PR DESCRIPTION
The `marketing_urls` returns a string but Django expects a bytestring in Python 3.