### PR TITLE
Fixes for celery worker Python 3 bugs

### DIFF
--- a/common/lib/xmodule/xmodule/video_module/transcripts_utils.py
+++ b/common/lib/xmodule/xmodule/video_module/transcripts_utils.py
@@ -661,9 +661,11 @@ class Transcript(object):
                 try:
                     # With error handling (set to 'ERROR_RAISE'), we will be getting
                     # the exception if something went wrong in parsing the transcript.
+                    if isinstance(content, text_type):
+                        content = content.encode('utf-8')
                     srt_subs = SubRipFile.from_string(
                         # Skip byte order mark(BOM) character
-                        content.encode('utf-8').decode('utf-8-sig'),
+                        content.decode('utf-8-sig'),
                         error_handling=SubRipFile.ERROR_RAISE
                     )
                 except Error as ex:   # Base exception from pysrt

--- a/lms/djangoapps/courseware/views/views.py
+++ b/lms/djangoapps/courseware/views/views.py
@@ -294,9 +294,9 @@ def yt_video_metadata(request):
             status_code = res.status_code
             if res.status_code == 200:
                 try:
-                    res = res.json()
-                    if res.get('items', []):
-                        response = res
+                    res_json = res.json()
+                    if res_json.get('items', []):
+                        response = res_json
                     else:
                         logging.warning(u'Unable to find the items in response. Following response '
                                         u'was received: {res}'.format(res=res.text))

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -251,7 +251,7 @@ webencodings==0.5.1       # via html5lib
 webob==1.8.5              # via xblock
 wrapt==1.10.5
 git+https://github.com/edx-solutions/xblock-drag-and-drop-v2@v2.2.6#egg=xblock-drag-and-drop-v2==2.2.6
-git+https://github.com/open-craft/xblock-poll@add89e14558c30f3c8dc7431e5cd6536fff6d941#egg=xblock-poll==1.5.1
+git+https://github.com/open-craft/xblock-poll@6894592402fd180db864bfce539f17bac6443866#egg=xblock-poll==1.9.0
 xblock-utils==1.2.2
 xblock==1.2.9
 xmlsec==1.3.3             # via python3-saml

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -344,7 +344,7 @@ websocket-client==0.56.0
 werkzeug==0.16.0
 wrapt==1.10.5
 git+https://github.com/edx-solutions/xblock-drag-and-drop-v2@v2.2.6#egg=xblock-drag-and-drop-v2==2.2.6
-git+https://github.com/open-craft/xblock-poll@add89e14558c30f3c8dc7431e5cd6536fff6d941#egg=xblock-poll==1.5.1
+git+https://github.com/open-craft/xblock-poll@6894592402fd180db864bfce539f17bac6443866#egg=xblock-poll==1.9.0
 xblock-utils==1.2.2
 xblock==1.2.9
 xmlsec==1.3.3

--- a/requirements/edx/github.in
+++ b/requirements/edx/github.in
@@ -92,5 +92,5 @@ git+https://github.com/edx/xblock-lti-consumer.git@v1.2.1#egg=lti_consumer-xbloc
 # Third Party XBlocks
 
 git+https://github.com/joestump/python-oauth2.git@b94f69b1ad195513547924e380d9265133e995fa#egg=oauth2
-git+https://github.com/open-craft/xblock-poll@add89e14558c30f3c8dc7431e5cd6536fff6d941#egg=xblock-poll==1.5.1
+git+https://github.com/open-craft/xblock-poll@6894592402fd180db864bfce539f17bac6443866#egg=xblock-poll==1.9.0
 git+https://github.com/edx-solutions/xblock-drag-and-drop-v2@v2.2.6#egg=xblock-drag-and-drop-v2==2.2.6

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -326,7 +326,7 @@ websocket-client==0.56.0  # via docker
 werkzeug==0.16.0          # via moto
 wrapt==1.10.5
 git+https://github.com/edx-solutions/xblock-drag-and-drop-v2@v2.2.6#egg=xblock-drag-and-drop-v2==2.2.6
-git+https://github.com/open-craft/xblock-poll@add89e14558c30f3c8dc7431e5cd6536fff6d941#egg=xblock-poll==1.5.1
+git+https://github.com/open-craft/xblock-poll@6894592402fd180db864bfce539f17bac6443866#egg=xblock-poll==1.9.0
 xblock-utils==1.2.2
 xblock==1.2.9
 xmlsec==1.3.3


### PR DESCRIPTION
Fixes for 3 issues we found in celery workers under Python 3 in production:

* We forgot to upgrade xblock-poll to a version with the Python 3 support fixes
* A function in transcript_utils.py sometimes gets bytes instead of Unicode, cope with both
* A warning in yt_video_metadata() tried accessing the original response which had already been replaced with its parsed JSON content; assign to a temp variable instead