### PR TITLE
Ignore bad cached data.

### DIFF
--- a/lms/djangoapps/mobile_api/middleware.py
+++ b/lms/djangoapps/mobile_api/middleware.py
@@ -9,6 +9,7 @@ from django.conf import settings
 from django.core.cache import cache
 from django.http import HttpResponse
 from pytz import UTC
+import six
 
 from mobile_api.mobile_platform import MobilePlatform
 from mobile_api.models import AppVersionConfig
@@ -104,13 +105,13 @@ class AppVersionUpgrade(object):
                 cached_data = cache.get_many([last_supported_date_cache_key, latest_version_cache_key])
 
                 last_supported_date = cached_data.get(last_supported_date_cache_key)
-                if not last_supported_date:
+                if last_supported_date != self.NO_LAST_SUPPORTED_DATE and not isinstance(last_supported_date, datetime):
                     last_supported_date = self._get_last_supported_date(platform.NAME, platform.version)
                     cache.set(last_supported_date_cache_key, last_supported_date, self.CACHE_TIMEOUT)
                 request_cache_dict[self.LAST_SUPPORTED_DATE_HEADER] = last_supported_date
 
                 latest_version = cached_data.get(latest_version_cache_key)
-                if not latest_version:
+                if not (latest_version and isinstance(latest_version, six.text_type)):
                     latest_version = self._get_latest_version(platform.NAME)
                     cache.set(latest_version_cache_key, latest_version, self.CACHE_TIMEOUT)
                 request_cache_dict[self.LATEST_VERSION_HEADER] = latest_version


### PR DESCRIPTION
When migrating from python 2 to 3 we can get in a situation where the
cache has data that the new version of python can't read.  In this case
drop the bad data and re-cache the correct data.

### Please consider the following when opening a pull request:

- Link to the relevant JIRA ticket(s) and tag any relevant team(s).
- Squash your changes down into one or more discrete commits.
  In each commit, include description that could help a developer
  several months from now.
- If running `make upgrade`, run _as close to the time of merging as possible_
  to avoid accidentally downgrading someone else's package.
  Put the output of `make upgrade` in its own separate commit,
  decoupled from other code changes.
- Aim for comprehensive test coverage, but remember that
  automated testing isn't a substitute for manual verification.
- Carefully consider naming, code organization, dependencies when adding new code.
  Code that is amenable to refactoring and improvement benefits all platform developers,
  especially given the size and scope of edx-platform.
  Consult existing Architectural Decision Records (ADRs),
  including those concerning the app(s) you are changing and
  [those concerning edx-platform as a whole](https://github.com/edx/edx-platform/tree/master/docs/decisions).
