### PR TITLE
Fix graph traversal under Python 3

### DIFF
--- a/common/lib/xmodule/xmodule/x_module.py
+++ b/common/lib/xmodule/xmodule/x_module.py
@@ -1259,7 +1259,7 @@ class XModuleDescriptor(XModuleDescriptorToXBlockMixin, HTMLSnippet, ResourceTem
         """
         return (hasattr(other, 'scope_ids') and
                 self.scope_ids == other.scope_ids and
-                list(self.fields.keys()) == list(other.fields.keys()) and
+                set(self.fields.keys()) == set(other.fields.keys()) and
                 all(getattr(self, field.name) == getattr(other, field.name)
                     for field in self.fields.values()))
 


### PR DESCRIPTION
Our graph traversal functions assumed immutable, hashable nodes, but XModule descriptors are actually mutable, and Python 3 now flags it as an error when we try using the traversal functions with them.  Fixed the traversal functions to not require hashable nodes; this is a little less efficient, but more correct (and we only seem to use these in a handful of places, to the extent that it didn't even come up during automated tests).

In the process, I noticed that the XModule descriptor equality function implicitly depended on consistent ordering of the field dictionary keys, which isn't necessarily true under Python 3.5; fixed to compare sets instead so the order is irrelevant.