### PR TITLE
[DO NOT MERGE] ARCH-1253: remove shim_student_view from LoginSession.post

### DIFF
--- a/common/djangoapps/third_party_auth/tests/specs/base.py
+++ b/common/djangoapps/third_party_auth/tests/specs/base.py
@@ -130,11 +130,10 @@ class HelperMixin(object):
 
     def assert_json_failure_response_is_missing_social_auth(self, response):
         """Asserts failure on /login for missing social auth looks right."""
-        self.assertContains(
-            response,
-            u"successfully signed in to your %s account, but this account isn&#39;t linked" % self.provider.name,
-            status_code=403,
-        )
+        self.assertEqual(403, response.status_code)
+        payload = json.loads(response.content.decode('utf-8'))
+        self.assertFalse(payload.get('success'))
+        self.assertEqual(payload.get('error_code'), 'third-party-auth-with-no-linked-account')
 
     def assert_json_failure_response_is_username_collision(self, response):
         """Asserts the json response indicates a username collision."""

--- a/lms/static/js/spec/student_account/login_spec.js
+++ b/lms/static/js/spec/student_account/login_spec.js
@@ -43,7 +43,7 @@
                     },
                     FORM_DESCRIPTION = {
                         method: 'post',
-                        submit_url: '/login_ajax',
+                        submit_url: '/user_api/v1/account/login_session/',
                         fields: [
                             {
                                 placeholder: 'username@domain.com',

--- a/lms/static/js/student_account/views/LoginView.js
+++ b/lms/static/js/student_account/views/LoginView.js
@@ -189,6 +189,14 @@
             },
 
             saveError: function(error) {
+                if (this.model.urlRoot.includes('/login_ajax')) {
+                    this.saveErrorWithoutShim(error);
+                } else {
+                    this.saveErrorWithShim(error);
+                }
+            },
+
+            saveErrorWithoutShim: function(error) {
                 var errorCode;
                 var msg;
                 if (error.status === 0) {
@@ -218,6 +226,41 @@
                     if (!this.hideAuthWarnings) {
                         this.clearFormErrors();
                         this.renderThirdPartyAuthWarning();
+                    }
+                } else {
+                    this.renderErrors(this.defaultFormErrorsTitle, this.errors);
+                }
+                this.toggleDisableButton(false);
+            },
+
+            saveErrorWithShim: function(error) {
+                var msg = error.responseText;
+                if (error.status === 0) {
+                    msg = gettext('An error has occurred. Check your Internet connection and try again.');
+                } else if (error.status === 500) {
+                    msg = gettext('An error has occurred. Try refreshing the page, or check your Internet connection.'); // eslint-disable-line max-len
+                }
+                this.errors = [
+                    StringUtils.interpolate(
+                        '<li>{msg}</li>', {
+                            msg: msg
+                        }
+                    )
+                ];
+                this.clearPasswordResetSuccess();
+
+            /* If we've gotten a 403 error, it means that we've successfully
+             * authenticated with a third-party provider, but we haven't
+             * linked the account to an EdX account.  In this case,
+             * we need to prompt the user to enter a little more information
+             * to complete the registration process.
+             */
+                if (error.status === 403 &&
+                 error.responseText === 'third-party-auth' &&
+                 this.currentProvider) {
+                    if (!this.hideAuthWarnings) {
+                        this.clearFormErrors();
+                        this.renderAuthWarning();
                     }
                 } else {
                     this.renderErrors(this.defaultFormErrorsTitle, this.errors);

--- a/openedx/core/djangoapps/user_authn/views/login_form.py
+++ b/openedx/core/djangoapps/user_authn/views/login_form.py
@@ -77,6 +77,20 @@ def _apply_third_party_auth_overrides(request, form_desc):
                 )
 
 
+# .. toggle_name: FEATURES[ENABLE_LOGIN_POST_WITHOUT_SHIM]
+# .. toggle_implementation: DjangoSetting
+# .. toggle_default: False
+# .. toggle_description: Toggle for enabling login post without shim_student_view (using `login_api`).
+# .. toggle_category: n/a
+# .. toggle_use_cases: incremental_release
+# .. toggle_creation_date: 2019-12-10
+# .. toggle_expiration_date: 2020-06-01
+# .. toggle_warnings: n/a
+# .. toggle_tickets: ARCH-1253
+# .. toggle_status: supported
+ENABLE_LOGIN_POST_WITHOUT_SHIM = 'ENABLE_LOGIN_POST_WITHOUT_SHIM'
+
+
 def get_login_session_form(request):
     """Return a description of the login form.
 
@@ -91,7 +105,12 @@ def get_login_session_form(request):
         HttpResponse
 
     """
-    form_desc = FormDescription("post", reverse("login_api"))
+    if settings.FEATURES.get(ENABLE_LOGIN_POST_WITHOUT_SHIM):
+        submit_url = reverse("login_api")
+    else:
+        submit_url = reverse("user_api_login_session")
+
+    form_desc = FormDescription("post", submit_url)
     _apply_third_party_auth_overrides(request, form_desc)
 
     # Translators: This label appears above a field on the login form

--- a/openedx/core/djangoapps/user_authn/views/login_form.py
+++ b/openedx/core/djangoapps/user_authn/views/login_form.py
@@ -85,7 +85,7 @@ def _apply_third_party_auth_overrides(request, form_desc):
 # .. toggle_use_cases: incremental_release
 # .. toggle_creation_date: 2019-12-10
 # .. toggle_expiration_date: 2020-06-01
-# .. toggle_warnings: n/a
+# .. toggle_warnings: Although shim was removed, toggle must be removed in follow-up due to green-blue deployment.
 # .. toggle_tickets: ARCH-1253
 # .. toggle_status: supported
 ENABLE_LOGIN_POST_WITHOUT_SHIM = 'ENABLE_LOGIN_POST_WITHOUT_SHIM'

--- a/openedx/core/djangoapps/user_authn/views/tests/test_login.py
+++ b/openedx/core/djangoapps/user_authn/views/tests/test_login.py
@@ -30,7 +30,6 @@ from openedx.core.djangoapps.user_api.config.waffle import PREVENT_AUTH_USER_WRI
 from openedx.core.djangoapps.user_api.accounts import EMAIL_MIN_LENGTH, EMAIL_MAX_LENGTH
 from openedx.core.djangoapps.user_authn.cookies import jwt_cookies
 from openedx.core.djangoapps.user_authn.views.login import (
-    shim_student_view,
     AllowedAuthUser,
     ENABLE_LOGIN_USING_THIRDPARTY_AUTH_ONLY
 )
@@ -785,14 +784,14 @@ class LoginSessionViewTest(ApiTestCase):
             "email": self.EMAIL,
             "password": "invalid"
         })
-        self.assertHttpForbidden(response)
+        self.assertHttpBadRequest(response)
 
         # Invalid email address
         response = self.client.post(self.url, {
             "email": "invalid@example.com",
             "password": self.PASSWORD,
         })
-        self.assertHttpForbidden(response)
+        self.assertHttpBadRequest(response)
 
     def test_missing_login_params(self):
         # Create a test user
@@ -813,71 +812,3 @@ class LoginSessionViewTest(ApiTestCase):
         # Missing both email and password
         response = self.client.post(self.url, {})
 
-
-@ddt.ddt
-class StudentViewShimTest(TestCase):
-    "Tests of the student view shim."
-    def setUp(self):
-        super(StudentViewShimTest, self).setUp()
-        self.captured_request = None
-
-    def test_third_party_auth_login_failure(self):
-        mocked_response_content = {
-            "success": False,
-            "error_code": "third-party-auth-with-no-linked-account",
-            "value": "Test message."
-        }
-        view = self._shimmed_view(
-            JsonResponse(mocked_response_content, status=403),
-            check_logged_in=True
-        )
-        response = view(HttpRequest())
-        self.assertEqual(response.status_code, 403)
-        self.assertEqual(response.content, b"third-party-auth")
-
-    def test_non_json_response(self):
-        view = self._shimmed_view(HttpResponse(content="Not a JSON dict"))
-        response = view(HttpRequest())
-        self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.content, b"Not a JSON dict")
-
-    @ddt.data("redirect", "redirect_url")
-    def test_ignore_redirect_from_json(self, redirect_key):
-        view = self._shimmed_view(
-            HttpResponse(content=json.dumps({
-                "success": True,
-                redirect_key: "/redirect"
-            }))
-        )
-        response = view(HttpRequest())
-        self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.content.decode('utf-8'), "")
-
-    def test_error_from_json(self):
-        view = self._shimmed_view(
-            HttpResponse(content=json.dumps({
-                "success": False,
-                "value": "Error!"
-            }))
-        )
-        response = view(HttpRequest())
-        self.assertEqual(response.status_code, 400)
-        self.assertEqual(response.content, b"Error!")
-
-    def test_preserve_headers(self):
-        view_response = HttpResponse()
-        view_response["test-header"] = "test"
-        view = self._shimmed_view(view_response)
-        response = view(HttpRequest())
-        self.assertEqual(response["test-header"], "test")
-
-    def test_check_logged_in(self):
-        view = self._shimmed_view(HttpResponse(), check_logged_in=True)
-        response = view(HttpRequest())
-        self.assertEqual(response.status_code, 403)
-
-    def _shimmed_view(self, response, check_logged_in=False):
-        def stub_view(request):
-            self.captured_request = request
-            return response
-        return shim_student_view(stub_view, check_logged_in=check_logged_in)


### PR DESCRIPTION
This needs to be in a separate deployment from pointing Logistration
permanently to use LoginSession.post, due to green-blue deployment.

ARCH-1253

Clean-up PR to start remove the shim.

### Please consider the following when opening a pull request:

- Link to the relevant JIRA ticket(s) and tag any relevant team(s).
- Squash your changes down into one or more discrete commits.
  In each commit, include description that could help a developer
  several months from now.
- If running `make upgrade`, run _as close to the time of merging as possible_
  to avoid accidentally downgrading someone else's package.
  Put the output of `make upgrade` in its own separate commit,
  decoupled from other code changes.
- Aim for comprehensive test coverage, but remember that
  automated testing isn't a substitute for manual verification.
- Carefully consider naming, code organization, dependencies when adding new code.
  Code that is amenable to refactoring and improvement benefits all platform developers,
  especially given the size and scope of edx-platform.
  Consult existing Architectural Decision Records (ADRs),
  including those concerning the app(s) you are changing and
  [those concerning edx-platform as a whole](https://github.com/edx/edx-platform/tree/master/docs/decisions).
