### PR TITLE
 Fixing unicode decode error.

### DIFF
--- a/common/lib/capa/capa/responsetypes.py
+++ b/common/lib/capa/capa/responsetypes.py
@@ -19,7 +19,6 @@ import inspect
 import json
 import logging
 import numbers
-import random2 as random
 import re
 import sys
 import textwrap
@@ -29,26 +28,27 @@ from collections import namedtuple
 from datetime import datetime
 from sys import float_info
 
-import html5lib
-import numpy
 import requests
 import six
-# specific library imports
-from calc import UndefinedVariable, UnmatchedParenthesis, evaluator
 from django.utils.encoding import python_2_unicode_compatible
-from lxml import etree
-from lxml.html.soupparser import fromstring as fromstring_bs  # uses Beautiful Soup!!! FIXME?
-from pyparsing import ParseException
 from pytz import UTC
-from shapely.geometry import MultiPoint, Point
 from six import text_type
 from six.moves import map, range, zip
 
 import capa.safe_exec as safe_exec
 import capa.xqueue_interface as xqueue_interface
+import html5lib
+import numpy
+import random2 as random
+# specific library imports
+from calc import UndefinedVariable, UnmatchedParenthesis, evaluator
+from lxml import etree
+from lxml.html.soupparser import fromstring as fromstring_bs  # uses Beautiful Soup!!! FIXME?
 from openedx.core.djangolib.markup import HTML, Text
 from openedx.core.lib import edx_six
 from openedx.core.lib.grade_utils import round_away_from_zero
+from pyparsing import ParseException
+from shapely.geometry import MultiPoint, Point
 
 from . import correctmap
 from .registry import TagRegistry
@@ -3010,7 +3010,7 @@ class ExternalResponse(LoncapaResponse):
             rxml = self.do_external_request('get_answers', {})
             exans = json.loads(rxml.find('expected').text)
         except Exception as err:  # pylint: disable=broad-except
-            log.error('Error %s', err)
+            log.error('ProblemGetAnswer: Error %s', err)
             if self.capa_system.DEBUG:
                 msg = HTML('<span class="inline-error">{}</span>').format(err)
                 exans = [''] * len(self.answer_ids)

--- a/common/lib/capa/capa/tests/helpers.py
+++ b/common/lib/capa/capa/tests/helpers.py
@@ -1,7 +1,6 @@
 """Tools for helping with testing capa."""
 
 from __future__ import absolute_import
-
 import gettext
 import io
 import os

--- a/common/lib/capa/capa/tests/test_answer_pool.py
+++ b/common/lib/capa/capa/tests/test_answer_pool.py
@@ -6,13 +6,13 @@ Tests the logic of the "answer-pool" attribute, e.g.
 from __future__ import absolute_import
 
 import textwrap
-import unittest
+from django.test import TestCase
 
 from capa.responsetypes import LoncapaProblemError
 from capa.tests.helpers import new_loncapa_problem, test_capa_system
 
 
-class CapaAnswerPoolTest(unittest.TestCase):
+class CapaAnswerPoolTest(TestCase):
     """Capa Answer Pool Test"""
     def setUp(self):
         super(CapaAnswerPoolTest, self).setUp()

--- a/common/lib/capa/capa/tests/test_capa_problem.py
+++ b/common/lib/capa/capa/tests/test_capa_problem.py
@@ -4,7 +4,7 @@ Test capa problem.
 from __future__ import absolute_import
 
 import textwrap
-import unittest
+from django.test import TestCase
 
 import ddt
 import six
@@ -17,7 +17,7 @@ from openedx.core.djangolib.markup import HTML
 
 
 @ddt.ddt
-class CAPAProblemTest(unittest.TestCase):
+class CAPAProblemTest(TestCase):
     """ CAPA problem related tests"""
 
     @ddt.unpack
@@ -462,7 +462,7 @@ class CAPAProblemTest(unittest.TestCase):
 
 
 @ddt.ddt
-class CAPAMultiInputProblemTest(unittest.TestCase):
+class CAPAMultiInputProblemTest(TestCase):
     """ TestCase for CAPA problems with multiple inputtypes """
 
     def capa_problem(self, xml):
@@ -606,7 +606,7 @@ class CAPAMultiInputProblemTest(unittest.TestCase):
 
 
 @ddt.ddt
-class CAPAProblemReportHelpersTest(unittest.TestCase):
+class CAPAProblemReportHelpersTest(TestCase):
     """ TestCase for CAPA methods for finding question labels and answer text """
 
     @ddt.data(
@@ -738,5 +738,5 @@ class CAPAProblemReportHelpersTest(unittest.TestCase):
         )
 
         # Ensure that the answer is a string so that the dict returned from this
-        # function can eventualy be serialized to json without issues.
+        # function can eventually be serialized to json without issues.
         self.assertIsInstance(problem.get_question_answers()['1_solution_1'], six.text_type)

--- a/common/lib/capa/capa/tests/test_hint_functionality.py
+++ b/common/lib/capa/capa/tests/test_hint_functionality.py
@@ -5,7 +5,7 @@ Tests of extended hints
 
 from __future__ import absolute_import
 
-import unittest
+from django.test import TestCase
 
 from ddt import data, ddt, unpack
 
@@ -18,7 +18,7 @@ from capa.tests.helpers import load_fixture, new_loncapa_problem
 # For out many ddt data cases, prefer a compact form of { .. }
 
 
-class HintTest(unittest.TestCase):
+class HintTest(TestCase):
     """Base class for tests of extended hinting functionality."""
 
     def correctness(self, problem_id, choice):
@@ -44,8 +44,10 @@ class TextInputHintsTest(HintTest):
     """
     Test Text Input Hints Test
     """
-    xml = load_fixture('extended_hints_text_input.xml')
-    problem = new_loncapa_problem(xml)
+    def setUp(self):
+        super(TextInputHintsTest, self).setUp()
+        xml = load_fixture('extended_hints_text_input.xml')
+        self.problem = new_loncapa_problem(xml)
 
     def test_tracking_log(self):
         """Test that the tracking log comes out right."""
@@ -96,8 +98,10 @@ class TextInputHintsTest(HintTest):
 @ddt
 class TextInputExtendedHintsCaseInsensitive(HintTest):
     """Test Text Input Extended hints Case Insensitive"""
-    xml = load_fixture('extended_hints_text_input.xml')
-    problem = new_loncapa_problem(xml)
+    def setUp(self):
+        super(TextInputExtendedHintsCaseInsensitive, self).setUp()
+        xml = load_fixture('extended_hints_text_input.xml')
+        self.problem = new_loncapa_problem(xml)
 
     @data(
         {'problem_id': u'1_5_1', 'choice': 'abc', 'expected_string': ''},  # wrong answer yielding no hint
@@ -128,8 +132,11 @@ class TextInputExtendedHintsCaseInsensitive(HintTest):
 @ddt
 class TextInputExtendedHintsCaseSensitive(HintTest):
     """Sometimes the semantics can be encoded in the class name."""
-    xml = load_fixture('extended_hints_text_input.xml')
-    problem = new_loncapa_problem(xml)
+
+    def setUp(self):
+        super(TextInputExtendedHintsCaseSensitive, self).setUp()
+        xml = load_fixture('extended_hints_text_input.xml')
+        self.problem = new_loncapa_problem(xml)
 
     @data(
         {'problem_id': u'1_6_1', 'choice': 'abc', 'expected_string': ''},
@@ -158,8 +165,10 @@ class TextInputExtendedHintsCompatible(HintTest):
     """
     Compatibility test with mixed old and new style additional_answer tags.
     """
-    xml = load_fixture('extended_hints_text_input.xml')
-    problem = new_loncapa_problem(xml)
+    def setUp(self):
+        super(TextInputExtendedHintsCompatible, self).setUp()
+        xml = load_fixture('extended_hints_text_input.xml')
+        self.problem = new_loncapa_problem(xml)
 
     @data(
         {'problem_id': u'1_7_1', 'choice': 'A', 'correct': 'correct',
@@ -183,8 +192,10 @@ class TextInputExtendedHintsRegex(HintTest):
     """
     Extended hints where the answer is regex mode.
     """
-    xml = load_fixture('extended_hints_text_input.xml')
-    problem = new_loncapa_problem(xml)
+    def setUp(self):
+        super(TextInputExtendedHintsRegex, self).setUp()
+        xml = load_fixture('extended_hints_text_input.xml')
+        self.problem = new_loncapa_problem(xml)
 
     @data(
         {'problem_id': u'1_8_1', 'choice': 'ABwrong', 'correct': 'incorrect', 'expected_string': ''},
@@ -219,8 +230,10 @@ class NumericInputHintsTest(HintTest):
     """
     This class consists of a suite of test cases to be run on the numeric input problem represented by the XML below.
     """
-    xml = load_fixture('extended_hints_numeric_input.xml')
-    problem = new_loncapa_problem(xml)          # this problem is properly constructed
+    def setUp(self):
+        super(NumericInputHintsTest, self).setUp()
+        xml = load_fixture('extended_hints_numeric_input.xml')
+        self.problem = new_loncapa_problem(xml)          # this problem is properly constructed
 
     def test_tracking_log(self):
         self.get_hint(u'1_2_1', u'1.141')
@@ -259,8 +272,10 @@ class CheckboxHintsTest(HintTest):
     """
     This class consists of a suite of test cases to be run on the checkbox problem represented by the XML below.
     """
-    xml = load_fixture('extended_hints_checkbox.xml')
-    problem = new_loncapa_problem(xml)          # this problem is properly constructed
+    def setUp(self):
+        super(CheckboxHintsTest, self).setUp()
+        xml = load_fixture('extended_hints_checkbox.xml')
+        self.problem = new_loncapa_problem(xml)          # this problem is properly constructed
 
     @data(
         {'problem_id': u'1_2_1', 'choice': [u'choice_0'],
@@ -356,7 +371,10 @@ class CheckboxHintsTestTracking(HintTest):
         </choiceresponse>
     </problem>
     """
-    problem = new_loncapa_problem(xml)
+
+    def setUp(self):
+        super(CheckboxHintsTestTracking, self).setUp()
+        self.problem = new_loncapa_problem(self.xml)
 
     def test_tracking_log(self):
         """Test checkbox tracking log - by far the most complicated case"""
@@ -419,8 +437,9 @@ class MultpleChoiceHintsTest(HintTest):
     """
     This class consists of a suite of test cases to be run on the multiple choice problem represented by the XML below.
     """
-    xml = load_fixture('extended_hints_multiple_choice.xml')
-    problem = new_loncapa_problem(xml)
+    def setUp(self):
+        xml = load_fixture('extended_hints_multiple_choice.xml')
+        self.problem = new_loncapa_problem(xml)
 
     def test_tracking_log(self):
         """Test that the tracking log comes out right."""
@@ -459,8 +478,9 @@ class MultpleChoiceHintsWithHtmlTest(HintTest):
     This class consists of a suite of test cases to be run on the multiple choice problem represented by the XML below.
 
     """
-    xml = load_fixture('extended_hints_multiple_choice_with_html.xml')
-    problem = new_loncapa_problem(xml)
+    def setUp(self):
+        xml = load_fixture('extended_hints_multiple_choice_with_html.xml')
+        self.problem = new_loncapa_problem(xml)
 
     def test_tracking_log(self):
         """Test that the tracking log comes out right."""
@@ -492,8 +512,9 @@ class DropdownHintsTest(HintTest):
     """
     This class consists of a suite of test cases to be run on the drop down problem represented by the XML below.
     """
-    xml = load_fixture('extended_hints_dropdown.xml')
-    problem = new_loncapa_problem(xml)
+    def setUp(self):
+        xml = load_fixture('extended_hints_dropdown.xml')
+        self.problem = new_loncapa_problem(xml)
 
     def test_tracking_log(self):
         """Test that the tracking log comes out right."""

--- a/common/lib/capa/capa/tests/test_html_render.py
+++ b/common/lib/capa/capa/tests/test_html_render.py
@@ -5,7 +5,7 @@ from __future__ import absolute_import
 
 import os
 import textwrap
-import unittest
+from django.test import TestCase
 
 import ddt
 import mock
@@ -20,7 +20,7 @@ from .response_xml_factory import CustomResponseXMLFactory, StringResponseXMLFac
 
 
 @ddt.ddt
-class CapaHtmlRenderTest(unittest.TestCase):
+class CapaHtmlRenderTest(TestCase):
     """
     CAPA HTML rendering tests class.
     """

--- a/common/lib/capa/capa/tests/test_responsetypes.py
+++ b/common/lib/capa/capa/tests/test_responsetypes.py
@@ -10,11 +10,9 @@ import json
 import os
 import random2 as random
 import textwrap
-import unittest
 import zipfile
-from six import StringIO
 from datetime import datetime
-
+from django.test import TestCase
 import mock
 import pyparsing
 import requests
@@ -46,7 +44,7 @@ from capa.util import convert_files_to_filenames
 from capa.xqueue_interface import dateformat
 
 
-class ResponseTest(unittest.TestCase):
+class ResponseTest(TestCase):
     """Base class for tests of capa responses."""
 
     xml_factory_class = None

--- a/common/lib/capa/capa/tests/test_shuffle.py
+++ b/common/lib/capa/capa/tests/test_shuffle.py
@@ -2,13 +2,13 @@
 from __future__ import absolute_import, print_function
 
 import textwrap
-import unittest
+from django.test import TestCase
 
 from capa.responsetypes import LoncapaProblemError
 from capa.tests.helpers import new_loncapa_problem, test_capa_system
 
 
-class CapaShuffleTest(unittest.TestCase):
+class CapaShuffleTest(TestCase):
     """Capa problem tests for shuffling and choice-name masking."""
 
     def setUp(self):

--- a/common/lib/capa/capa/tests/test_targeted_feedback.py
+++ b/common/lib/capa/capa/tests/test_targeted_feedback.py
@@ -6,14 +6,14 @@ i.e. those with the <multiplechoiceresponse> element
 from __future__ import absolute_import
 
 import textwrap
-import unittest
+from django.test import TestCase
 
 # Changes formatting of empty elements; import here to avoid test order dependence
 import xmodule.modulestore.xml  # pylint: disable=unused-import
 from capa.tests.helpers import load_fixture, new_loncapa_problem, test_capa_system
 
 
-class CapaTargetedFeedbackTest(unittest.TestCase):
+class CapaTargetedFeedbackTest(TestCase):
     '''
     Testing class
     '''

--- a/common/lib/xmodule/xmodule/tests/test_capa_module.py
+++ b/common/lib/xmodule/xmodule/tests/test_capa_module.py
@@ -13,7 +13,7 @@ import os
 import random
 import textwrap
 import unittest
-
+from django.test import TestCase
 import ddt
 import requests
 import six
@@ -180,7 +180,7 @@ if submission[0] == '':
 
 
 @ddt.ddt
-class ProblemBlockTest(unittest.TestCase):
+class ProblemBlockTest(TestCase):
 
     def setUp(self):
         super(ProblemBlockTest, self).setUp()
@@ -2079,7 +2079,7 @@ class ProblemBlockTest(unittest.TestCase):
 
 
 @ddt.ddt
-class ProblemBlockXMLTest(unittest.TestCase):
+class ProblemBlockXMLTest(TestCase):
     sample_checkbox_problem_xml = textwrap.dedent("""
         <problem>
             <p>Title</p>
@@ -2873,7 +2873,7 @@ class ProblemBlockXMLTest(unittest.TestCase):
             self._create_descriptor(sample_invalid_xml, name="Invalid XML")
 
 
-class ComplexEncoderTest(unittest.TestCase):
+class ComplexEncoderTest(TestCase):
 
     def test_default(self):
         """
@@ -2885,7 +2885,7 @@ class ComplexEncoderTest(unittest.TestCase):
         self.assertEqual(expected_str, json_str[1:-1])  # ignore quotes
 
 
-class ProblemCheckTrackingTest(unittest.TestCase):
+class ProblemCheckTrackingTest(TestCase):
     """
     Ensure correct tracking information is included in events emitted during problem checks.
     """
@@ -3208,7 +3208,7 @@ class ProblemCheckTrackingTest(unittest.TestCase):
         self.assertTrue(problem.runtime.replace_jump_to_id_urls.called)
 
 
-class ProblemBlockReportGenerationTest(unittest.TestCase):
+class ProblemBlockReportGenerationTest(TestCase):
     """
     Ensure that Capa report generation works correctly
     """

--- a/common/lib/xmodule/xmodule/tests/test_delay_between_attempts.py
+++ b/common/lib/xmodule/xmodule/tests/test_delay_between_attempts.py
@@ -11,8 +11,7 @@ from __future__ import absolute_import
 
 import datetime
 import textwrap
-import unittest
-
+from django.test import TestCase
 from mock import Mock
 from opaque_keys.edx.locator import BlockUsageLocator, CourseLocator
 from pytz import UTC
@@ -120,7 +119,7 @@ class CapaFactoryWithDelay(object):
         return module
 
 
-class XModuleQuizAttemptsDelayTest(unittest.TestCase):
+class XModuleQuizAttemptsDelayTest(TestCase):
     """
     Class to test delay between quiz attempts.
     """


### PR DESCRIPTION
### [PROD-1000](https://openedx.atlassian.net/browse/PROD-1000) 

The error was caused by implicit typecasting by python2 `.replace` method which tries to decode byte strings into code points to convert data into Unicode. Byte strings have a `decode` method that converts bytes into code points (which is called implicitly).

 Here are some Examples.
 ```
 > text = 'example to replace text: $foo.'
 > text.replace(u'$foo', u'edX')
 > u'example to replace text: edX.' # Implicit typecasting using decode method to convert bytes into unicode.

 > text = 'example to replace text: $foo.'
 > text.replace('$foo', u'edX')
 > u'example to replace text: edX.' # Same here

 > text = u'example to replace text: $foo.' # Unicode string
 > text.replace('$foo', 'edX')
 > u'example to replace text: edX.' # Same here

 > text = 'example to replace text: $foo.'
 > text.replace('$foo', "edX")
 > 'example to replace text: edX.'

 Problem: When there is a type mismatch. Either there is one Unicode string amoung the byte strings or a byte string among the Unicode strings.

 > text = u'example to replace text: $foo.' # Unicode string
 > text.replace('$foo','\xe2\x98\x82')
 > UnicodeDecodeError: 'ascii' codec can't decode byte 0xe2 in position 0: ordinal not in range(128)

 > text = 'example to replace text: $foo.'
 > text.replace(u'$foo','\xe2\x98\x82')
 > UnicodeDecodeError: 'ascii' codec can't decode byte 0xe2 in position 0: ordinal not in range(128)

 > text = 'example to replace text: $foo.'
 > text.replace('$foo','\xe2\x98\x82')
 > 'example to replace text: \xe2\x98\x82.'
 ```
This PR also introduces `capa.enable_contextualize_text_v2` wafflag flag to quickly revert incase of an emergency. 



