### PR TITLE
update ORA version to use user state service

### DIFF
--- a/lms/djangoapps/courseware/module_render.py
+++ b/lms/djangoapps/courseware/module_render.py
@@ -57,6 +57,7 @@ from lms.djangoapps.courseware.masquerade import (
 from lms.djangoapps.courseware.model_data import DjangoKeyValueStore, FieldDataCache
 from edxmako.shortcuts import render_to_string
 from lms.djangoapps.courseware.field_overrides import OverrideFieldData
+from lms.djangoapps.courseware.services import UserStateService
 from lms.djangoapps.grades.api import GradesUtilService
 from lms.djangoapps.grades.api import signals as grades_signals
 from lms.djangoapps.lms_xblock.field_data import LmsFieldData
@@ -819,6 +820,7 @@ def get_module_system_for_user(
             'bookmarks': BookmarksService(user=user),
             'gating': GatingService(),
             'grade_utils': GradesUtilService(course_id=course_id),
+            'user_state': UserStateService(),
         },
         get_user_role=lambda: get_user_role(user, course_id),
         descriptor_runtime=descriptor._runtime,  # pylint: disable=protected-access

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -171,7 +171,7 @@ nodeenv==1.3.3
 numpy==1.16.5
 git+https://github.com/joestump/python-oauth2.git@b94f69b1ad195513547924e380d9265133e995fa#egg=oauth2
 oauthlib==2.1.0
-git+https://github.com/edx/edx-ora2.git@2.4.7#egg=ora2==2.4.7
+git+https://github.com/edx/edx-ora2.git@2.5.0#egg=ora2==2.5.0
 path.py==8.2.1
 pathtools==0.1.2
 paver==1.3.4
@@ -236,7 +236,7 @@ sqlparse==0.3.0
 staff-graded-xblock==0.5
 stevedore==1.31.0
 super-csv==0.9.6
-sympy==1.4
+sympy==1.5
 testfixtures==6.10.3      # via edx-enterprise
 text-unidecode==1.3       # via python-slugify
 tincan==0.0.5             # via edx-enterprise

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -221,7 +221,7 @@ nodeenv==1.3.3
 numpy==1.16.5
 git+https://github.com/joestump/python-oauth2.git@b94f69b1ad195513547924e380d9265133e995fa#egg=oauth2
 oauthlib==2.1.0
-git+https://github.com/edx/edx-ora2.git@2.4.7#egg=ora2==2.4.7
+git+https://github.com/edx/edx-ora2.git@2.5.0#egg=ora2==2.5.0
 packaging==19.2
 path.py==8.2.1
 pathlib2==2.3.5
@@ -318,7 +318,7 @@ sqlparse==0.3.0
 staff-graded-xblock==0.5
 stevedore==1.31.0
 super-csv==0.9.6
-sympy==1.4
+sympy==1.5
 testfixtures==6.10.3
 text-unidecode==1.3
 tincan==0.0.5
@@ -332,7 +332,7 @@ unidiff==0.5.5
 uritemplate==3.0.0
 urllib3==1.25.7
 user-util==0.1.5
-virtualenv==16.7.8
+virtualenv==16.7.9
 voluptuous==0.11.7
 vulture==1.2
 watchdog==0.9.0

--- a/requirements/edx/github.in
+++ b/requirements/edx/github.in
@@ -81,7 +81,7 @@ git+https://github.com/edx/bridgekeeper.git@4e34894e4ac5d0467ed1901811a81fd87ee0
 # Our libraries:
 -e git+https://github.com/edx/codejail.git@6bc47025359a4d6ecf2b6b5776ff99959094d2cc#egg=codejail
 -e git+https://github.com/edx/acid-block.git@98aecba94ecbfa934e2d00262741c0ea9f557fc9#egg=acid-xblock
-git+https://github.com/edx/edx-ora2.git@2.4.7#egg=ora2==2.4.7
+git+https://github.com/edx/edx-ora2.git@2.5.0#egg=ora2==2.5.0
 git+https://github.com/edx/crowdsourcehinter.git@a7ffc85b134b7d8909bf1fefd23dbdb8eb28e467#egg=crowdsourcehinter-xblock==0.2
 -e git+https://github.com/edx/RateXBlock.git@2.0#egg=rate-xblock
 -e git+https://github.com/edx/DoneXBlock.git@2.0.1#egg=done-xblock

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -212,7 +212,7 @@ nodeenv==1.3.3
 numpy==1.16.5
 git+https://github.com/joestump/python-oauth2.git@b94f69b1ad195513547924e380d9265133e995fa#egg=oauth2
 oauthlib==2.1.0
-git+https://github.com/edx/edx-ora2.git@2.4.7#egg=ora2==2.4.7
+git+https://github.com/edx/edx-ora2.git@2.5.0#egg=ora2==2.5.0
 packaging==19.2           # via caniusepython3, tox
 path.py==8.2.1
 pathlib2==2.3.5
@@ -301,7 +301,7 @@ sqlparse==0.3.0
 staff-graded-xblock==0.5
 stevedore==1.31.0
 super-csv==0.9.6
-sympy==1.4
+sympy==1.5
 testfixtures==6.10.3
 text-unidecode==1.3
 tincan==0.0.5
@@ -315,7 +315,7 @@ unidiff==0.5.5
 uritemplate==3.0.0
 urllib3==1.25.7
 user-util==0.1.5
-virtualenv==16.7.8        # via tox
+virtualenv==16.7.9        # via tox
 voluptuous==0.11.7
 watchdog==0.9.0
 wcwidth==0.1.7            # via pytest


### PR DESCRIPTION
### [PROD-1053](https://openedx.atlassian.net/browse/PROD-1053)

### Description
This PR is performing the following:
1. Making user state service, added in https://github.com/edx/edx-platform/pull/22425, a part of runtime services.
2. Upgrade ORA to **2.5.0** to bring in changes that use the user state service(https://github.com/edx/edx-ora2/pull/1312).