### PR TITLE
Update xblock-poll with Python 3 fix

### DIFF
--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -251,7 +251,7 @@ webencodings==0.5.1       # via html5lib
 webob==1.8.5              # via xblock
 wrapt==1.10.5
 git+https://github.com/edx-solutions/xblock-drag-and-drop-v2@v2.2.6#egg=xblock-drag-and-drop-v2==2.2.6
-git+https://github.com/open-craft/xblock-poll@8e78663fdd3c1d79571eb753d1c601729e9a9325#egg=xblock-poll==1.9.0
+git+https://github.com/jmbowman/xblock-poll@8e78663fdd3c1d79571eb753d1c601729e9a9325#egg=xblock-poll==1.9.0
 xblock-utils==1.2.2
 xblock==1.2.9
 xmlsec==1.3.3             # via python3-saml

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -251,7 +251,7 @@ webencodings==0.5.1       # via html5lib
 webob==1.8.5              # via xblock
 wrapt==1.10.5
 git+https://github.com/edx-solutions/xblock-drag-and-drop-v2@v2.2.6#egg=xblock-drag-and-drop-v2==2.2.6
-git+https://github.com/open-craft/xblock-poll@6894592402fd180db864bfce539f17bac6443866#egg=xblock-poll==1.9.0
+git+https://github.com/open-craft/xblock-poll@8e78663fdd3c1d79571eb753d1c601729e9a9325#egg=xblock-poll==1.9.0
 xblock-utils==1.2.2
 xblock==1.2.9
 xmlsec==1.3.3             # via python3-saml

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -344,7 +344,7 @@ websocket-client==0.56.0
 werkzeug==0.16.0
 wrapt==1.10.5
 git+https://github.com/edx-solutions/xblock-drag-and-drop-v2@v2.2.6#egg=xblock-drag-and-drop-v2==2.2.6
-git+https://github.com/open-craft/xblock-poll@6894592402fd180db864bfce539f17bac6443866#egg=xblock-poll==1.9.0
+git+https://github.com/open-craft/xblock-poll@8e78663fdd3c1d79571eb753d1c601729e9a9325#egg=xblock-poll==1.9.0
 xblock-utils==1.2.2
 xblock==1.2.9
 xmlsec==1.3.3

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -344,7 +344,7 @@ websocket-client==0.56.0
 werkzeug==0.16.0
 wrapt==1.10.5
 git+https://github.com/edx-solutions/xblock-drag-and-drop-v2@v2.2.6#egg=xblock-drag-and-drop-v2==2.2.6
-git+https://github.com/open-craft/xblock-poll@8e78663fdd3c1d79571eb753d1c601729e9a9325#egg=xblock-poll==1.9.0
+git+https://github.com/jmbowman/xblock-poll@8e78663fdd3c1d79571eb753d1c601729e9a9325#egg=xblock-poll==1.9.0
 xblock-utils==1.2.2
 xblock==1.2.9
 xmlsec==1.3.3

--- a/requirements/edx/github.in
+++ b/requirements/edx/github.in
@@ -92,5 +92,5 @@ git+https://github.com/edx/xblock-lti-consumer.git@v1.2.2#egg=lti_consumer-xbloc
 # Third Party XBlocks
 
 git+https://github.com/joestump/python-oauth2.git@b94f69b1ad195513547924e380d9265133e995fa#egg=oauth2
-git+https://github.com/open-craft/xblock-poll@6894592402fd180db864bfce539f17bac6443866#egg=xblock-poll==1.9.0
+git+https://github.com/open-craft/xblock-poll@8e78663fdd3c1d79571eb753d1c601729e9a9325#egg=xblock-poll==1.9.0
 git+https://github.com/edx-solutions/xblock-drag-and-drop-v2@v2.2.6#egg=xblock-drag-and-drop-v2==2.2.6

--- a/requirements/edx/github.in
+++ b/requirements/edx/github.in
@@ -92,5 +92,5 @@ git+https://github.com/edx/xblock-lti-consumer.git@v1.2.2#egg=lti_consumer-xbloc
 # Third Party XBlocks
 
 git+https://github.com/joestump/python-oauth2.git@b94f69b1ad195513547924e380d9265133e995fa#egg=oauth2
-git+https://github.com/open-craft/xblock-poll@8e78663fdd3c1d79571eb753d1c601729e9a9325#egg=xblock-poll==1.9.0
+git+https://github.com/jmbowman/xblock-poll@8e78663fdd3c1d79571eb753d1c601729e9a9325#egg=xblock-poll==1.9.0
 git+https://github.com/edx-solutions/xblock-drag-and-drop-v2@v2.2.6#egg=xblock-drag-and-drop-v2==2.2.6

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -326,7 +326,7 @@ websocket-client==0.56.0  # via docker
 werkzeug==0.16.0          # via moto
 wrapt==1.10.5
 git+https://github.com/edx-solutions/xblock-drag-and-drop-v2@v2.2.6#egg=xblock-drag-and-drop-v2==2.2.6
-git+https://github.com/open-craft/xblock-poll@8e78663fdd3c1d79571eb753d1c601729e9a9325#egg=xblock-poll==1.9.0
+git+https://github.com/jmbowman/xblock-poll@8e78663fdd3c1d79571eb753d1c601729e9a9325#egg=xblock-poll==1.9.0
 xblock-utils==1.2.2
 xblock==1.2.9
 xmlsec==1.3.3

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -326,7 +326,7 @@ websocket-client==0.56.0  # via docker
 werkzeug==0.16.0          # via moto
 wrapt==1.10.5
 git+https://github.com/edx-solutions/xblock-drag-and-drop-v2@v2.2.6#egg=xblock-drag-and-drop-v2==2.2.6
-git+https://github.com/open-craft/xblock-poll@6894592402fd180db864bfce539f17bac6443866#egg=xblock-poll==1.9.0
+git+https://github.com/open-craft/xblock-poll@8e78663fdd3c1d79571eb753d1c601729e9a9325#egg=xblock-poll==1.9.0
 xblock-utils==1.2.2
 xblock==1.2.9
 xmlsec==1.3.3


### PR DESCRIPTION
Update to a commit on our open PR on the xblock-poll repository to fix a Python 3 issue that was missed because it depends on edx-platform code in a way that the test suite couldn't exercise.