### PR TITLE
ARCH-1253: logistration using login user - take 2

### DIFF
--- a/common/djangoapps/third_party_auth/tests/specs/base.py
+++ b/common/djangoapps/third_party_auth/tests/specs/base.py
@@ -130,11 +130,10 @@ class HelperMixin(object):
 
     def assert_json_failure_response_is_missing_social_auth(self, response):
         """Asserts failure on /login for missing social auth looks right."""
-        self.assertContains(
-            response,
-            u"successfully signed in to your %s account, but this account isn&#39;t linked" % self.provider.name,
-            status_code=403,
-        )
+        self.assertEqual(403, response.status_code)
+        payload = json.loads(response.content.decode('utf-8'))
+        self.assertFalse(payload.get('success'))
+        self.assertEqual(payload.get('error_code'), 'third-party-auth-with-no-linked-account')
 
     def assert_json_failure_response_is_username_collision(self, response):
         """Asserts the json response indicates a username collision."""

--- a/openedx/core/djangoapps/user_authn/views/login_form.py
+++ b/openedx/core/djangoapps/user_authn/views/login_form.py
@@ -77,6 +77,20 @@ def _apply_third_party_auth_overrides(request, form_desc):
                 )
 
 
+# .. toggle_name: FEATURES[ENABLE_LOGIN_POST_WITHOUT_SHIM]
+# .. toggle_implementation: DjangoSetting
+# .. toggle_default: False
+# .. toggle_description: Toggle for enabling login post without shim_student_view (using `login_api`).
+# .. toggle_category: n/a
+# .. toggle_use_cases: incremental_release
+# .. toggle_creation_date: 2019-12-10
+# .. toggle_expiration_date: 2020-06-01
+# .. toggle_warnings: n/a
+# .. toggle_tickets: ARCH-1253
+# .. toggle_status: supported
+ENABLE_LOGIN_POST_WITHOUT_SHIM = 'ENABLE_LOGIN_POST_WITHOUT_SHIM'
+
+
 def get_login_session_form(request):
     """Return a description of the login form.
 
@@ -91,7 +105,12 @@ def get_login_session_form(request):
         HttpResponse
 
     """
-    form_desc = FormDescription("post", reverse("user_api_login_session"))
+    if settings.FEATURES.get(ENABLE_LOGIN_POST_WITHOUT_SHIM):
+        submit_url = reverse("login_api")
+    else:
+        submit_url = reverse("user_api_login_session")
+
+    form_desc = FormDescription("post", submit_url)
     _apply_third_party_auth_overrides(request, form_desc)
 
     # Translators: This label appears above a field on the login form


### PR DESCRIPTION
use login_ajax for logistration

- use login_ajax (in place of login_session with shim)
for logistration's call to login POST
- add toggle for using login_ajax from logistration
  - FEATURES['ENABLE_LOGIN_POST_WITHOUT_SHIM']
- add custom metrics for redirect_url
- update test for third-party auth error_code 

NOTE: The error_code `third-party-auth-with-no-linked-account`
was introduced in JSON in this earlier PR:
https://github.com/edx/edx-platform/pull/22452/files

ARCH-1253

**Remove Shim Plan:**
- Wait for toggle code to be deployed (Stage/Prod)
    - https://github.com/edx/edx-platform/pull/22511 [MERGED]
- Merge enabling toggles (once toggle code deployed) and test
    - https://github.com/edx/edx-internal/pull/1337 [Stage]
    - https://github.com/edx/edx-internal/pull/1338 [Prod]
    - https://github.com/edx/edge-internal/pull/168 [Edge]
- Ensure the following:
    - No problems/errors going to shimless login_ajax
    - No POST calls should be going to /login_session once toggle fully enabled
    - Check redirect_url metrics introduced in https://github.com/edx/edx-platform/pull/22511
- Merge remove shim - Part 1 + 2
    - https://github.com/edx/edx-platform/pull/22488
- Once Part 1 + 2 are in Production
    - Remove Part 1 + 2 from Part 3 PR, then merge
    - https://github.com/edx/edx-platform/pull/22517
- Create and merge 3 revert PRs for toggle configs in internals

### Please consider the following when opening a pull request:

- Link to the relevant JIRA ticket(s) and tag any relevant team(s).
- Squash your changes down into one or more discrete commits.
  In each commit, include description that could help a developer
  several months from now.
- If running `make upgrade`, run _as close to the time of merging as possible_
  to avoid accidentally downgrading someone else's package.
  Put the output of `make upgrade` in its own separate commit,
  decoupled from other code changes.
- Aim for comprehensive test coverage, but remember that
  automated testing isn't a substitute for manual verification.
- Carefully consider naming, code organization, dependencies when adding new code.
  Code that is amenable to refactoring and improvement benefits all platform developers,
  especially given the size and scope of edx-platform.
  Consult existing Architectural Decision Records (ADRs),
  including those concerning the app(s) you are changing and
  [those concerning edx-platform as a whole](https://github.com/edx/edx-platform/tree/master/docs/decisions).
