### PR TITLE
Handle the caching of responses between Python 2 and Python 3.

### DIFF
--- a/common/djangoapps/track/middleware.py
+++ b/common/djangoapps/track/middleware.py
@@ -36,28 +36,6 @@ META_KEY_TO_CONTEXT_KEY = {
 }
 
 
-class ResponseLoggingMiddleware(object):
-    """
-    A debugging middleware for the purpose of understanding what the current state of the response
-    is at this point in the stack.
-    """
-
-    def process_response(self, _request, response):
-        """
-        Logs the response at the current point in the middleware stack for debugging purposes.
-        """
-        try:
-            log.info('Logging response for debugging purposes: %r', response)
-            log.info('Response container data: %r', response._container)  # pylint: disable=protected-access
-            log.info('Container types: %r', [type(el) for el in response._container])  # pylint: disable=protected-access
-
-        except:  # pylint: disable=bare-except
-            # If this causes an error, we don't want it to bubble up since this is just for logging.
-            log.exception('Error logging response object')
-
-        return response
-
-
 class TrackMiddleware(object):
     """
     Tracks all requests made, as well as setting up context for other server

--- a/common/djangoapps/util/cache.py
+++ b/common/djangoapps/util/cache.py
@@ -79,7 +79,7 @@ def cache_if_anonymous(*get_parameters):
 
                 if response:
                     # A hack to ensure that the response data is a valid text type for both Python 2 and 3.
-                    response_content = response._container.copy()  # pylint: disable=protected-member
+                    response_content = list(response._container)  # pylint: disable=protected-member
                     response.content = b''
                     for item in response_content:
                         response.write(item)

--- a/common/djangoapps/util/cache.py
+++ b/common/djangoapps/util/cache.py
@@ -77,13 +77,13 @@ def cache_if_anonymous(*get_parameters):
 
                 response = cache.get(cache_key)  # pylint: disable=maybe-no-member
 
-                # A hack to ensure that the response data is a valid text type for both Python 2 and 3.
-                response_content = response._container.copy()  # pylint: disable=protected-member
-                response.content = b''
-                for item in response_content:
-                    response.write(item)
-
-                if not response:
+                if response:
+                    # A hack to ensure that the response data is a valid text type for both Python 2 and 3.
+                    response_content = response._container.copy()  # pylint: disable=protected-member
+                    response.content = b''
+                    for item in response_content:
+                        response.write(item)
+                else:
                     response = view_func(request, *args, **kwargs)
                     cache.set(cache_key, response, 60 * 3)  # pylint: disable=maybe-no-member
 

--- a/common/djangoapps/util/cache.py
+++ b/common/djangoapps/util/cache.py
@@ -76,6 +76,13 @@ def cache_if_anonymous(*get_parameters):
                         })
 
                 response = cache.get(cache_key)  # pylint: disable=maybe-no-member
+
+                # A hack to ensure that the response data is a valid text type for both Python 2 and 3.
+                response_content = response._container.copy()  # pylint: disable=protected-member
+                response.content = b''
+                for item in response_content:
+                    response.write(item)
+
                 if not response:
                     response = view_func(request, *args, **kwargs)
                     cache.set(cache_key, response, 60 * 3)  # pylint: disable=maybe-no-member

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -1444,9 +1444,6 @@ MIDDLEWARE_CLASSES = [
     'lms.djangoapps.discussion.django_comment_client.middleware.AjaxExceptionMiddleware',
     'django.middleware.common.CommonMiddleware',
 
-    # Debugging Middleware. Remove once Python 3 has been deployed.
-    'track.middleware.ResponseLoggingMiddleware',
-
     'django.contrib.sites.middleware.CurrentSiteMiddleware',
     'edx_rest_framework_extensions.auth.jwt.middleware.JwtAuthCookieMiddleware',
 


### PR DESCRIPTION
Cached responses in the Python 2 version break when we deploy Python 3 because the response content is cached as bytestrings and then pulled out of the response as a unicode string. Django expects the content to always be bytestrings.

This fix pulls out the data from the underlying data structure and rewrites it to the response to allow Django's implementation to coerce the content into the correct type.