### PR TITLE
add api function and teams service

### DIFF
--- a/lms/djangoapps/lms_xblock/runtime.py
+++ b/lms/djangoapps/lms_xblock/runtime.py
@@ -13,6 +13,7 @@ from edx_django_utils.cache import DEFAULT_REQUEST_CACHE
 from badges.service import BadgingService
 from badges.utils import badges_enabled
 from lms.djangoapps.lms_xblock.models import XBlockAsidesConfig
+from lms.djangoapps.teams.services import TeamsService
 from openedx.core.djangoapps.user_api.course_tag import api as user_course_tag_api
 from openedx.core.lib.url_utils import quote_slashes
 from openedx.core.lib.xblock_utils import wrap_xblock_aside, xblock_local_resource_url
@@ -155,6 +156,7 @@ class LmsModuleSystem(ModuleSystem):  # pylint: disable=abstract-method
         if badges_enabled():
             services['badging'] = BadgingService(course_id=kwargs.get('course_id'), modulestore=store)
         self.request_token = kwargs.pop('request_token', None)
+        services['teams'] = TeamsService()
         super(LmsModuleSystem, self).__init__(**kwargs)
 
     def handler_url(self, *args, **kwargs):

--- a/lms/djangoapps/teams/api.py
+++ b/lms/djangoapps/teams/api.py
@@ -245,6 +245,7 @@ def can_user_create_team_in_topic(user, course_id, topic_id):
         has_course_staff_privileges(user, course_id)
     )
 
+
 def get_team_for_user_and_course(user, course_id):
     """
     Returns the team that the given user is on in the course, or None

--- a/lms/djangoapps/teams/api.py
+++ b/lms/djangoapps/teams/api.py
@@ -9,7 +9,6 @@ from enum import Enum
 from django.db.models import Count
 from opaque_keys import InvalidKeyError
 from opaque_keys.edx.keys import CourseKey
-from xmodule.modulestore.django import modulestore
 
 from course_modes.models import CourseMode
 from lms.djangoapps.discussion.django_comment_client.utils import has_discussion_privileges
@@ -254,13 +253,8 @@ def get_team_for_user_and_course(user, course_id):
     """
     try:
         course_key = CourseKey.from_string(course_id)
-        course_module = modulestore().get_course(course_key)
     except InvalidKeyError:
         raise ValueError(u"The supplied course id {course_id} is not valid.".format(
-            course_id=course_id
-        ))
-    if course_module is None:
-        raise ValueError(u"The supplied course {course_id} was not found.".format(
             course_id=course_id
         ))
 

--- a/lms/djangoapps/teams/api.py
+++ b/lms/djangoapps/teams/api.py
@@ -7,6 +7,9 @@ import logging
 from enum import Enum
 
 from django.db.models import Count
+from opaque_keys import InvalidKeyError
+from opaque_keys.edx.keys import CourseKey
+from xmodule.modulestore.django import modulestore
 
 from course_modes.models import CourseMode
 from lms.djangoapps.discussion.django_comment_client.utils import has_discussion_privileges
@@ -241,3 +244,26 @@ def can_user_create_team_in_topic(user, course_id, topic_id):
         (not is_instructor_managed_topic(topic_id)) or
         has_course_staff_privileges(user, course_id)
     )
+
+def get_team_for_user_and_course(user, course_id):
+    """
+    Returns the team that the given user is on in the course, or None
+
+    If course_id does not exist, a ValueError is raised
+    """
+    try:
+        course_key = CourseKey.from_string(course_id)
+        course_module = modulestore().get_course(course_key)
+    except InvalidKeyError:
+        raise ValueError(u"The supplied course id {course_id} is not valid.".format(
+            course_id=course_id
+        ))
+    if course_module is None:
+        raise ValueError(u"The supplied course {course_id} was not found.".format(
+            course_id=course_id
+        ))
+
+    return CourseTeam.objects.filter(
+        course_id=course_key,
+        membership__user__username=user.username,
+    ).first()

--- a/lms/djangoapps/teams/services.py
+++ b/lms/djangoapps/teams/services.py
@@ -1,3 +1,4 @@
+""" Services to expose the Teams API to XBlocks """
 from __future__ import absolute_import
 
 

--- a/lms/djangoapps/teams/services.py
+++ b/lms/djangoapps/teams/services.py
@@ -1,8 +1,19 @@
 """ Services to expose the Teams API to XBlocks """
 from __future__ import absolute_import
 
+from django.urls import reverse
+
 
 class TeamsService(object):
     def get_team(self, user, course_id):
         from . import api
         return api.get_team_for_user_and_course(user, course_id)
+
+    def get_team_detail_url(self, team):
+        teams_dashboard_url = reverse('teams_dashboard', kwargs={'course_id': team.course_id})
+        # Unfortunately required since this URL resolution is done in a Backbone view
+        return "{teams_dashboard_url}#teams/{topic_id}/{team_id}".format(
+            teams_dashboard_url=teams_dashboard_url,
+            topic_id=team.topic_id,
+            team_id=team.team_id,
+        )

--- a/lms/djangoapps/teams/services.py
+++ b/lms/djangoapps/teams/services.py
@@ -1,0 +1,7 @@
+from __future__ import absolute_import
+
+
+class TeamsService(object):
+    def get_team(self, user, course_id):
+        from . import api
+        return api.get_team_for_user_and_course(user, course_id)

--- a/lms/djangoapps/teams/services.py
+++ b/lms/djangoapps/teams/services.py
@@ -11,6 +11,7 @@ class TeamsService(object):
         return api.get_team_for_user_and_course(user, course_id)
 
     def get_team_detail_url(self, team):
+        """ Returns the url to the detail view for the given team """
         teams_dashboard_url = reverse('teams_dashboard', kwargs={'course_id': team.course_id})
         # Unfortunately required since this URL resolution is done in a Backbone view
         return "{teams_dashboard_url}#teams/{topic_id}/{team_id}".format(

--- a/lms/djangoapps/teams/services.py
+++ b/lms/djangoapps/teams/services.py
@@ -5,6 +5,7 @@ from django.urls import reverse
 
 
 class TeamsService(object):
+    """ Functions to provide teams functionality to XBlocks"""
     def get_team(self, user, course_id):
         from . import api
         return api.get_team_for_user_and_course(user, course_id)

--- a/lms/djangoapps/teams/tests/factories.py
+++ b/lms/djangoapps/teams/tests/factories.py
@@ -25,6 +25,7 @@ class CourseTeamFactory(DjangoModelFactory):
         django_get_or_create = ('team_id',)
 
     team_id = factory.Sequence('team-{0}'.format)
+    topic_id = factory.Sequence('topic-{0}'.format)
     discussion_topic_id = factory.LazyAttribute(lambda a: uuid4().hex)
     name = factory.Sequence(u"Awesome Team {0}".format)
     description = "A simple description"

--- a/lms/djangoapps/teams/tests/test_api.py
+++ b/lms/djangoapps/teams/tests/test_api.py
@@ -83,24 +83,23 @@ class PythonAPITests(SharedModuleStoreTestCase):
         self.assertTrue(teams_api.discussion_visible_by_user('DO_NOT_EXISTS', self.user3))
 
     def test_get_team(self):
-        with patch('lms.djangoapps.teams.api.modulestore'):
-            # Course 1
-            user1_team = teams_api.get_team_for_user_and_course(self.user1, str(COURSE_KEY1))
-            user2_team = teams_api.get_team_for_user_and_course(self.user2, str(COURSE_KEY1))
-            user3_team = teams_api.get_team_for_user_and_course(self.user3, str(COURSE_KEY1))
+        # Course 1
+        user1_team = teams_api.get_team_for_user_and_course(self.user1, str(COURSE_KEY1))
+        user2_team = teams_api.get_team_for_user_and_course(self.user2, str(COURSE_KEY1))
+        user3_team = teams_api.get_team_for_user_and_course(self.user3, str(COURSE_KEY1))
 
-            self.assertEqual(user1_team, self.team1)
-            self.assertEqual(user2_team, self.team1)
-            self.assertEqual(user3_team, None)
+        self.assertEqual(user1_team, self.team1)
+        self.assertEqual(user2_team, self.team1)
+        self.assertEqual(user3_team, None)
 
-            # Course 2
-            user1_team = teams_api.get_team_for_user_and_course(self.user1, str(COURSE_KEY2))
-            user2_team = teams_api.get_team_for_user_and_course(self.user2, str(COURSE_KEY2))
-            user3_team = teams_api.get_team_for_user_and_course(self.user3, str(COURSE_KEY2))
+        # Course 2
+        user1_team = teams_api.get_team_for_user_and_course(self.user1, str(COURSE_KEY2))
+        user2_team = teams_api.get_team_for_user_and_course(self.user2, str(COURSE_KEY2))
+        user3_team = teams_api.get_team_for_user_and_course(self.user3, str(COURSE_KEY2))
 
-            self.assertEqual(user1_team, None)
-            self.assertEqual(user2_team, None)
-            self.assertEqual(user3_team, self.team2)
+        self.assertEqual(user1_team, None)
+        self.assertEqual(user2_team, None)
+        self.assertEqual(user3_team, self.team2)
 
     def test_get_team_invalid_course(self):
         invalid_course_id = 'lol!()#^$&course'

--- a/lms/djangoapps/teams/tests/test_api.py
+++ b/lms/djangoapps/teams/tests/test_api.py
@@ -7,6 +7,7 @@ from __future__ import absolute_import, unicode_literals
 import unittest
 from uuid import uuid4
 
+from mock import patch
 import ddt
 from opaque_keys.edx.keys import CourseKey
 
@@ -80,6 +81,37 @@ class PythonAPITests(SharedModuleStoreTestCase):
         self.assertTrue(teams_api.discussion_visible_by_user(self.team2.discussion_topic_id, self.user1))
         self.assertTrue(teams_api.discussion_visible_by_user(self.team2.discussion_topic_id, self.user2))
         self.assertTrue(teams_api.discussion_visible_by_user('DO_NOT_EXISTS', self.user3))
+
+    def test_get_team(self):
+        with patch('lms.djangoapps.teams.api.modulestore'):
+            # Course 1
+            user1_team = teams_api.get_team_for_user_and_course(self.user1, str(COURSE_KEY1))
+            user2_team = teams_api.get_team_for_user_and_course(self.user2, str(COURSE_KEY1))
+            user3_team = teams_api.get_team_for_user_and_course(self.user3, str(COURSE_KEY1))
+
+            self.assertEqual(user1_team, self.team1)
+            self.assertEqual(user2_team, self.team1)
+            self.assertEqual(user3_team, None)
+
+            # Course 2
+            user1_team = teams_api.get_team_for_user_and_course(self.user1, str(COURSE_KEY2))
+            user2_team = teams_api.get_team_for_user_and_course(self.user2, str(COURSE_KEY2))
+            user3_team = teams_api.get_team_for_user_and_course(self.user3, str(COURSE_KEY2))
+
+            self.assertEqual(user1_team, None)
+            self.assertEqual(user2_team, None)
+            self.assertEqual(user3_team, self.team2)
+
+    def test_get_team_invalid_course(self):
+        invalid_course_id = 'lol!()#^$&course'
+        message ='The supplied course id lol!()#^$&course is not valid'
+        with self.assertRaisesMessage(ValueError, message):
+            teams_api.get_team_for_user_and_course(self.user1, invalid_course_id)
+
+    def test_get_team_course_not_found(self):
+        message ='The supplied course ' + str(COURSE_KEY1) + ' was not found'
+        with self.assertRaisesMessage(ValueError, message):
+            teams_api.get_team_for_user_and_course(self.user1, str(COURSE_KEY1))
 
 
 @ddt.ddt

--- a/lms/djangoapps/teams/tests/test_api.py
+++ b/lms/djangoapps/teams/tests/test_api.py
@@ -104,12 +104,12 @@ class PythonAPITests(SharedModuleStoreTestCase):
 
     def test_get_team_invalid_course(self):
         invalid_course_id = 'lol!()#^$&course'
-        message ='The supplied course id lol!()#^$&course is not valid'
+        message = 'The supplied course id lol!()#^$&course is not valid'
         with self.assertRaisesMessage(ValueError, message):
             teams_api.get_team_for_user_and_course(self.user1, invalid_course_id)
 
     def test_get_team_course_not_found(self):
-        message ='The supplied course ' + str(COURSE_KEY1) + ' was not found'
+        message = 'The supplied course ' + str(COURSE_KEY1) + ' was not found'
         with self.assertRaisesMessage(ValueError, message):
             teams_api.get_team_for_user_and_course(self.user1, str(COURSE_KEY1))
 

--- a/lms/djangoapps/teams/tests/test_api.py
+++ b/lms/djangoapps/teams/tests/test_api.py
@@ -109,9 +109,8 @@ class PythonAPITests(SharedModuleStoreTestCase):
             teams_api.get_team_for_user_and_course(self.user1, invalid_course_id)
 
     def test_get_team_course_not_found(self):
-        message = 'The supplied course ' + str(COURSE_KEY1) + ' was not found'
-        with self.assertRaisesMessage(ValueError, message):
-            teams_api.get_team_for_user_and_course(self.user1, str(COURSE_KEY1))
+        team = teams_api.get_team_for_user_and_course(self.user1, 'nonsense/garbage/nonexistant')
+        self.assertIsNone(team)
 
 
 @ddt.ddt

--- a/lms/djangoapps/teams/tests/test_api.py
+++ b/lms/djangoapps/teams/tests/test_api.py
@@ -7,7 +7,6 @@ from __future__ import absolute_import, unicode_literals
 import unittest
 from uuid import uuid4
 
-from mock import patch
 import ddt
 from opaque_keys.edx.keys import CourseKey
 

--- a/lms/djangoapps/teams/tests/test_services.py
+++ b/lms/djangoapps/teams/tests/test_services.py
@@ -1,0 +1,38 @@
+# -*- coding: utf-8 -*-
+"""
+Tests for any Teams app services
+"""
+from __future__ import absolute_import, unicode_literals
+
+from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
+from openedx.core.djangoapps.catalog.tests.factories import CourseRunFactory
+
+from lms.djangoapps.teams.services import TeamsService
+from lms.djangoapps.teams.tests.factories import CourseTeamFactory
+
+class TeamsServiceTests(ModuleStoreTestCase):
+    """ Tests for the TeamsService """
+
+    def setUp(self):
+        super(TeamsServiceTests, self).setUp()
+        self.course_run = CourseRunFactory.create()
+        self.team = CourseTeamFactory.create(course_id=self.course_run['key'])
+        self.service = TeamsService()
+
+    def test_get_team_detail_url(self):
+        # edx.org/courses/blah/teams/#teams/topic_id/team_id
+        team_detail_url = self.service.get_team_detail_url(self.team)
+        split_url = team_detail_url.split('/')
+        self.assertEquals(
+            split_url[1:],
+            [
+                'courses',
+                str(self.course_run['key']),
+                'teams',
+                '#teams',
+                self.team.topic_id,
+                self.team.team_id,
+            ]
+        )
+        
+

--- a/lms/djangoapps/teams/tests/test_services.py
+++ b/lms/djangoapps/teams/tests/test_services.py
@@ -10,6 +10,7 @@ from openedx.core.djangoapps.catalog.tests.factories import CourseRunFactory
 from lms.djangoapps.teams.services import TeamsService
 from lms.djangoapps.teams.tests.factories import CourseTeamFactory
 
+
 class TeamsServiceTests(ModuleStoreTestCase):
     """ Tests for the TeamsService """
 
@@ -34,5 +35,3 @@ class TeamsServiceTests(ModuleStoreTestCase):
                 self.team.team_id,
             ]
         )
-        
-

--- a/lms/djangoapps/teams/tests/test_services.py
+++ b/lms/djangoapps/teams/tests/test_services.py
@@ -24,7 +24,7 @@ class TeamsServiceTests(ModuleStoreTestCase):
         # edx.org/courses/blah/teams/#teams/topic_id/team_id
         team_detail_url = self.service.get_team_detail_url(self.team)
         split_url = team_detail_url.split('/')
-        self.assertEquals(
+        self.assertEqual(
             split_url[1:],
             [
                 'courses',


### PR DESCRIPTION
[EDUCATOR-4838](https://openedx.atlassian.net/browse/EDUCATOR-4838
)

Add API function to return student's course team (for now students have only one team per course)
Add TeamsService to provide access to api call, and provide the new TeamsService to XBlocks
