### PR TITLE
Adds optional setting to enable devstack theming

### DIFF
--- a/lms/envs/devstack_docker.py
+++ b/lms/envs/devstack_docker.py
@@ -86,3 +86,22 @@ SYSTEM_WIDE_ROLE_CLASSES.extend(['system_wide_roles.SystemWideRoleAssignment'])
 
 if FEATURES['ENABLE_ENTERPRISE_INTEGRATION']:
     SYSTEM_WIDE_ROLE_CLASSES.extend(['enterprise.SystemWideEnterpriseUserRoleAssignment'])
+
+########################## THEMING  #######################
+# If you want to enable theming in devstack, uncomment this section and add any relevant
+# theme directories to COMPREHENSIVE_THEME_DIRS
+
+# We have to import the private method here because production.py calls
+# derive_settings('lms.envs.production') which runs _make_mako_template_dirs with
+# the settings from production, which doesn't include these theming settings. Thus,
+# the templating engine is unable to find the themed templates because they don't exist
+# in it's path. Re-calling derive_settings doesn't work because the settings was already
+# changed from a function to a list, and it can't be derived again.
+
+# from .common import _make_mako_template_dirs
+# ENABLE_COMPREHENSIVE_THEMING = True
+# COMPREHENSIVE_THEME_DIRS = [
+#     "/edx/app/edxapp/edx-platform/themes/"
+# ]
+# TEMPLATES[1]["DIRS"] = _make_mako_template_dirs
+# derive_settings(__name__)


### PR DESCRIPTION
The mako engine isn't able to find themed templates in devstack because
the path it checks is set before we enable comprehensive theming. This
Adds a settings section to  comment out if you want to enable
theming in devstack.

### Please consider the following when opening a pull request:

- Link to the relevant JIRA ticket(s) and tag any relevant team(s).
- Squash your changes down into one or more discrete commits.
  In each commit, include description that could help a developer
  several months from now.
- If running `make upgrade`, run _as close to the time of merging as possible_
  to avoid accidentally downgrading someone else's package.
  Put the output of `make upgrade` in its own separate commit,
  decoupled from other code changes.
- Aim for comprehensive test coverage, but remember that
  automated testing isn't a substitute for manual verification.
- Carefully consider naming, code organization, dependencies when adding new code.
  Code that is amenable to refactoring and improvement benefits all platform developers,
  especially given the size and scope of edx-platform.
  Consult existing Architectural Decision Records (ADRs),
  including those concerning the app(s) you are changing and
  [those concerning edx-platform as a whole](https://github.com/edx/edx-platform/tree/master/docs/decisions).
