### PR TITLE
ARCH-1253: remove unused /login_post endpoint

### DIFF
--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -2156,16 +2156,3 @@ DISABLE_DEPRECATED_SIGNIN_URL = False
 # .. toggle_tickets: ARCH-1253
 # .. toggle_status: supported
 DISABLE_DEPRECATED_SIGNUP_URL = False
-
-# .. toggle_name: DISABLE_DEPRECATED_LOGIN_POST
-# .. toggle_implementation: DjangoSetting
-# .. toggle_default: False
-# .. toggle_description: Toggle for removing the deprecated /login_post url.
-# .. toggle_category: n/a
-# .. toggle_use_cases: incremental_release
-# .. toggle_creation_date: 2019-12-02
-# .. toggle_expiration_date: 2020-06-01
-# .. toggle_warnings: This url can be removed once it no longer has any real traffic. Note: We have permission to remove for traffic from user_agent including `mitx-quantum`.
-# .. toggle_tickets: ARCH-1253
-# .. toggle_status: supported
-DISABLE_DEPRECATED_LOGIN_POST = False

--- a/openedx/core/djangoapps/user_authn/urls_common.py
+++ b/openedx/core/djangoapps/user_authn/urls_common.py
@@ -62,13 +62,6 @@ urlpatterns = [
 
 ]
 
-if not getattr(settings, 'DISABLE_DEPRECATED_LOGIN_POST', False):
-    # TODO: Remove login_post once it no longer has real traffic.
-    #   It was only used by old Studio sign-in and some miscellaneous callers, which should no longer be in use.
-    urlpatterns += [
-        url(r'^login_post$', login.login_user, name='login_post'),
-    ]
-
 # password reset django views (see above for password reset views)
 urlpatterns += [
     url(


### PR DESCRIPTION
- retires toggle DISABLE_DEPRECATED_LOGIN_POST
- permanently removes /login_post

Now that studio signin has been retired, we are able to remove the
unused /login_post endpoint.

ARCH-1253

Note: Traffic has already drained from all environments, including Prod.  So, rather than disabling, removing code, and then re-enabling, we're directly removing.

NewRelic query:
```
SELECT * FROM Transaction WHERE request.uri = '/login_post' AND request_user_agent NOT LIKE '%mitx-quantum%' SINCE 7 days ago
```
NOTE: The mitx-quantum traffic is already failing due to CSRF issues.

### Please consider the following when opening a pull request:

- Link to the relevant JIRA ticket(s) and tag any relevant team(s).
- Squash your changes down into one or more discrete commits.
  In each commit, include description that could help a developer
  several months from now.
- If running `make upgrade`, run _as close to the time of merging as possible_
  to avoid accidentally downgrading someone else's package.
  Put the output of `make upgrade` in its own separate commit,
  decoupled from other code changes.
- Aim for comprehensive test coverage, but remember that
  automated testing isn't a substitute for manual verification.
- Carefully consider naming, code organization, dependencies when adding new code.
  Code that is amenable to refactoring and improvement benefits all platform developers,
  especially given the size and scope of edx-platform.
  Consult existing Architectural Decision Records (ADRs),
  including those concerning the app(s) you are changing and
  [those concerning edx-platform as a whole](https://github.com/edx/edx-platform/tree/master/docs/decisions).
