### PR TITLE
bugfix remove course pre requisite only if is not entrance exam

### DIFF
--- a/cms/djangoapps/contentstore/tests/test_course_settings.py
+++ b/cms/djangoapps/contentstore/tests/test_course_settings.py
@@ -482,6 +482,73 @@ class CourseDetailsViewTest(CourseTestCase, MilestonesTestCaseMixin):
         self.assertTrue(course.entrance_exam_enabled)
         self.assertEqual(course.entrance_exam_minimum_score_pct, .5)
 
+    @unittest.skipUnless(settings.FEATURES.get('ENTRANCE_EXAMS', False), True)
+    @mock.patch.dict("django.conf.settings.FEATURES", {'ENABLE_PREREQUISITE_COURSES': True})
+    def test_entrance_after_changing_other_setting(self):
+        """
+       Test entrance exam is not deactivated when prerequisites removed.
+
+        This test ensures that the entrance milestone is not deactivated after
+        course details are saves without pre requisite courses active.
+
+        The test was implemented after a bug fixing, correcting the behaviour
+        that every time course details were saved,
+        if there wasn't any pre requisite course in the POST
+        the view just deleted all the pre requisite courses, including entrance exam,
+        despite the fact that the entrance_exam_enabled was True.
+        This test ensures that the entrance milestone is not deactivated after
+        course details are saves without pre requisite courses active. The test was
+        implemented after a bug fixing, correcting the behaviour that every time
+        course details were saved, if there wasn't any pre requisite course in the POST
+        the view just deleted all the pre requisite courses, including entrance exam,
+        despite the fact that the entrance_exam_enabled was True.
+        """
+        self.assertFalse(milestones_helpers.any_unfulfilled_milestones(self.course.id, self.user.id),
+                         msg='The initial empty state should be: no entrance exam')
+
+        settings_details_url = get_url(self.course.id)
+        data = {
+            'entrance_exam_enabled': 'true',
+            'entrance_exam_minimum_score_pct': '60',
+            'syllabus': 'none',
+            'short_description': 'empty',
+            'overview': '',
+            'effort': '',
+            'intro_video': '',
+            'start_date': '2012-01-01',
+            'end_date': '2012-12-31',
+        }
+        response = self.client.post(
+            settings_details_url,
+            data=json.dumps(data),
+            content_type='application/json',
+            HTTP_ACCEPT='application/json'
+        )
+
+        self.assertEquals(response.status_code, 200)
+        course = modulestore().get_course(self.course.id)
+        self.assertTrue(course.entrance_exam_enabled)
+        self.assertEquals(course.entrance_exam_minimum_score_pct, .60)
+
+        self.assertTrue(milestones_helpers.any_unfulfilled_milestones(self.course.id, self.user.id),
+                        msg='The entrance exam should be required.')
+
+        # Call the settings handler again then ensure it didn't delete the settings of the entrance exam
+        data.update({
+            'start_date': '2018-01-01',
+            'end_date': '{year}-12-31'.format(year=datetime.datetime.now().year + 4),
+        })
+        response = self.client.post(
+            settings_details_url,
+            data=json.dumps(data),
+            content_type='application/json',
+            HTTP_ACCEPT='application/json'
+        )
+        self.assertEquals(response.status_code, 200)
+
+        self.assertTrue(milestones_helpers.any_unfulfilled_milestones(self.course.id, self.user.id),
+                        msg='The entrance exam should be required.')
+
     def test_editable_short_description_fetch(self):
         settings_details_url = get_url(self.course.id)
 

--- a/cms/djangoapps/contentstore/tests/test_course_settings.py
+++ b/cms/djangoapps/contentstore/tests/test_course_settings.py
@@ -486,21 +486,15 @@ class CourseDetailsViewTest(CourseTestCase, MilestonesTestCaseMixin):
     @mock.patch.dict("django.conf.settings.FEATURES", {'ENABLE_PREREQUISITE_COURSES': True})
     def test_entrance_after_changing_other_setting(self):
         """
-       Test entrance exam is not deactivated when prerequisites removed.
+        Test entrance exam is not deactivated when prerequisites removed.
 
         This test ensures that the entrance milestone is not deactivated after
-        course details are saves without pre requisite courses active.
+        course details are saves without pre-requisite courses active.
 
         The test was implemented after a bug fixing, correcting the behaviour
         that every time course details were saved,
-        if there wasn't any pre requisite course in the POST
-        the view just deleted all the pre requisite courses, including entrance exam,
-        despite the fact that the entrance_exam_enabled was True.
-        This test ensures that the entrance milestone is not deactivated after
-        course details are saves without pre requisite courses active. The test was
-        implemented after a bug fixing, correcting the behaviour that every time
-        course details were saved, if there wasn't any pre requisite course in the POST
-        the view just deleted all the pre requisite courses, including entrance exam,
+        if there wasn't any pre-requisite course in the POST
+        the view just deleted all the pre-requisite courses, including entrance exam,
         despite the fact that the entrance_exam_enabled was True.
         """
         assert not milestones_helpers.any_unfulfilled_milestones(self.course.id, self.user.id), \

--- a/cms/djangoapps/contentstore/tests/test_course_settings.py
+++ b/cms/djangoapps/contentstore/tests/test_course_settings.py
@@ -503,8 +503,8 @@ class CourseDetailsViewTest(CourseTestCase, MilestonesTestCaseMixin):
         the view just deleted all the pre requisite courses, including entrance exam,
         despite the fact that the entrance_exam_enabled was True.
         """
-        self.assertFalse(milestones_helpers.any_unfulfilled_milestones(self.course.id, self.user.id),
-                         msg='The initial empty state should be: no entrance exam')
+        assert not milestones_helpers.any_unfulfilled_milestones(self.course.id, self.user.id), \
+            'The initial empty state should be: no entrance exam'
 
         settings_details_url = get_url(self.course.id)
         data = {
@@ -525,13 +525,13 @@ class CourseDetailsViewTest(CourseTestCase, MilestonesTestCaseMixin):
             HTTP_ACCEPT='application/json'
         )
 
-        self.assertEquals(response.status_code, 200)
+        assert response.status_code == 200
         course = modulestore().get_course(self.course.id)
-        self.assertTrue(course.entrance_exam_enabled)
-        self.assertEquals(course.entrance_exam_minimum_score_pct, .60)
+        assert course.entrance_exam_enabled
+        assert course.entrance_exam_minimum_score_pct == .60
 
-        self.assertTrue(milestones_helpers.any_unfulfilled_milestones(self.course.id, self.user.id),
-                        msg='The entrance exam should be required.')
+        assert milestones_helpers.any_unfulfilled_milestones(self.course.id, self.user.id), \
+            'The entrance exam should be required.'
 
         # Call the settings handler again then ensure it didn't delete the settings of the entrance exam
         data.update({
@@ -544,10 +544,9 @@ class CourseDetailsViewTest(CourseTestCase, MilestonesTestCaseMixin):
             content_type='application/json',
             HTTP_ACCEPT='application/json'
         )
-        self.assertEquals(response.status_code, 200)
-
-        self.assertTrue(milestones_helpers.any_unfulfilled_milestones(self.course.id, self.user.id),
-                        msg='The entrance exam should be required.')
+        assert response.status_code == 200
+        assert milestones_helpers.any_unfulfilled_milestones(self.course.id, self.user.id), \
+            'The entrance exam should be required.'
 
     def test_editable_short_description_fetch(self):
         settings_details_url = get_url(self.course.id)

--- a/cms/djangoapps/contentstore/views/course.py
+++ b/cms/djangoapps/contentstore/views/course.py
@@ -56,7 +56,9 @@ from common.djangoapps.util.milestones_helpers import (
     is_prerequisite_courses_enabled,
     is_valid_course_key,
     remove_prerequisite_course,
-    set_prerequisite_courses
+    set_prerequisite_courses,
+    get_namespace_choices,
+    generate_milestone_namespace
 )
 from common.djangoapps.util.string_utils import _has_non_ascii_characters
 from common.djangoapps.xblock_django.api import deprecated_xblocks
@@ -1254,7 +1256,12 @@ def settings_handler(request, course_key_string):  # lint-amnesty, pylint: disab
                         # None is chosen, so remove the course prerequisites
                         course_milestones = milestones_api.get_course_milestones(course_key=course_key, relationship="requires")  # lint-amnesty, pylint: disable=line-too-long
                         for milestone in course_milestones:
-                            remove_prerequisite_course(course_key, milestone)
+                            ee_milestone_namespace = generate_milestone_namespace(
+                                get_namespace_choices().get('ENTRANCE_EXAM'),
+                                course_key
+                            )
+                            if not milestone["namespace"] == ee_milestone_namespace:
+                                remove_prerequisite_course(course_key, milestone)
 
                 # If the entrance exams feature has been enabled, we'll need to check for some
                 # feature-specific settings and handle them accordingly

--- a/cms/djangoapps/contentstore/views/course.py
+++ b/cms/djangoapps/contentstore/views/course.py
@@ -1254,7 +1254,10 @@ def settings_handler(request, course_key_string):  # lint-amnesty, pylint: disab
                         set_prerequisite_courses(course_key, prerequisite_course_keys)
                     else:
                         # None is chosen, so remove the course prerequisites
-                        course_milestones = milestones_api.get_course_milestones(course_key=course_key, relationship="requires")  # lint-amnesty, pylint: disable=line-too-long
+                        course_milestones = milestones_api.get_course_milestones(
+                            course_key=course_key,
+                            relationship="requires",
+                        )
                         for milestone in course_milestones:
                             ee_milestone_namespace = generate_milestone_namespace(
                                 get_namespace_choices().get('ENTRANCE_EXAM'),

--- a/cms/djangoapps/contentstore/views/course.py
+++ b/cms/djangoapps/contentstore/views/course.py
@@ -1235,7 +1235,7 @@ def settings_handler(request, course_key_string):  # lint-amnesty, pylint: disab
                     )
 
             return render_to_response('settings.html', settings_context)
-        elif 'application/json' in request.META.get('HTTP_ACCEPT', ''):
+        elif 'application/json' in request.META.get('HTTP_ACCEPT', ''):  # pylint: disable=too-many-nested-blocks
             if request.method == 'GET':
                 course_details = CourseDetails.fetch(course_key)
                 return JsonResponse(
@@ -1259,11 +1259,11 @@ def settings_handler(request, course_key_string):  # lint-amnesty, pylint: disab
                             relationship="requires",
                         )
                         for milestone in course_milestones:
-                            ee_milestone_namespace = generate_milestone_namespace(
+                            entrance_exam_namespace = generate_milestone_namespace(
                                 get_namespace_choices().get('ENTRANCE_EXAM'),
                                 course_key
                             )
-                            if not milestone["namespace"] == ee_milestone_namespace:
+                            if milestone["namespace"] != entrance_exam_namespace:
                                 remove_prerequisite_course(course_key, milestone)
 
                 # If the entrance exams feature has been enabled, we'll need to check for some


### PR DESCRIPTION
This is a bug fix for Entrance Exams management in Schedule & Details  page.

The error is easy to reproduce:
You need to make sure that the following `FEATURES` flags are enabled:

```
"FEATURES":
    "MILESTONES_APP": true,
    "ENABLE_PREREQUISITE_COURSES": true,
    "ENTRANCE_EXAMS": true
```
* Go to or create a new course, then go to "Schedule and Details" , enable an entrance exam for the course, you can leave the default score or change it.
* Go to Content -> Outline and fill the entrance exam with a couple of courses, then create a normal unit in the course.
* Go to the LMS and Enroll in the course with a new learner (without any staff privilege). You will only be able to see the entrance exam.
* Go to Studio again, same course and then "Schedule and Details" change the enrollment date or any other data and save. 

When you go back to the LMS, you will find out that the entrance exam is disabled now, and you can see all the course content, but in the "Schedule and Details" is still active.

What happens in the background, is that there is a bug in the settings handlers that is there is any pre requisite course set, iterates over all pre requisites and deletes them, but the problem is Entrance Exams are a type of pre requisite since they belong to the milestones app, and is getting deleted too. 

The fix check the milestone namespace, and if it's an Entrance Exam skips it.

Co-Authored-By: Omar Al-Ithawi <i@omardo.com>


