### PR TITLE
Upgrade edx-ace and edx-django-sites-extensions

### DIFF
--- a/common/djangoapps/student/tests/test_email.py
+++ b/common/djangoapps/student/tests/test_email.py
@@ -292,7 +292,7 @@ class EmailChangeRequestTests(EventTestMixin, EmailTemplateTagMixin, CacheIsolat
         """
         self.assertEqual(self.do_email_validation(self.user.email), 'Old email is the same as the new email.')
 
-    @patch('django.core.mail.send_mail')
+    @patch('django.core.mail.EmailMultiAlternatives.send')
     def test_email_failure(self, send_mail):
         """
         Test the return value if sending the email for the user to click fails.
@@ -590,7 +590,7 @@ class SecondaryEmailChangeRequestTests(EventTestMixin, EmailTemplateTagMixin, Ca
         for email in ('bad_email', 'bad_email@', '@bad_email'):
             self.assertEqual(self.do_email_validation(email), 'Valid e-mail address required.')
 
-    @patch('django.core.mail.send_mail')
+    @patch('django.core.mail.EmailMultiAlternatives.send')
     def test_email_failure(self, send_mail):
         """
         Test the return value if sending the email for the user to click fails.

--- a/openedx/core/djangoapps/user_api/accounts/tests/test_api.py
+++ b/openedx/core/djangoapps/user_api/accounts/tests/test_api.py
@@ -367,7 +367,7 @@ class TestAccountApi(UserSettingsEventTestMixin, EmailTemplateTagMixin, CreateAc
         self.assertIn("Valid e-mail address required.", field_errors["email"]["developer_message"])
         self.assertIn("Full Name cannot contain the following characters: < >", field_errors["name"]["user_message"])
 
-    @patch('django.core.mail.send_mail')
+    @patch('django.core.mail.EmailMultiAlternatives.send')
     @patch('student.views.management.render_to_string', Mock(side_effect=mock_render_to_string, autospec=True))
     def test_update_sending_email_fails(self, send_mail):
         """Test what happens if all validation checks pass, but sending the email for email change fails."""

--- a/requirements/edx/base.in
+++ b/requirements/edx/base.in
@@ -67,7 +67,7 @@ django-webpack-loader               # Used to wire webpack bundles into the djan
 djangorestframework==3.7.7
 djangorestframework-jwt
 drf-yasg                            # Replacement for django-rest-swagger
-edx-ace==0.1.10
+edx-ace
 edx-analytics-data-api-client
 edx-bulk-grades                     # LMS REST API for managing bulk grading operations
 edx-ccx-keys
@@ -75,7 +75,7 @@ edx-celeryutils
 edx-completion
 edx-django-oauth2-provider
 edx-django-release-util             # Release utils for the edx release pipeline
-edx-django-sites-extensions==2.3.1
+edx-django-sites-extensions
 edx-django-utils
 edx-drf-extensions
 edx-enterprise

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -25,7 +25,7 @@ aniso8601==8.0.0          # via tincan
 anyjson==0.3.3            # via kombu
 appdirs==1.4.3            # via fs
 argh==0.26.2
-attrs==17.4.0
+attrs==19.3.0
 babel==1.3
 backports.functools-lru-cache==1.6.1  # via soupsieve
 beautifulsoup4==4.8.1     # via pynliner
@@ -42,7 +42,7 @@ cffi==1.13.2
 chardet==3.0.4
 git+https://github.com/edx/openedx-chem.git@ff4e3a03d3c7610e47a9af08eb648d8aabe2eb18#egg=chem==1.0.0
 click==7.0                # via code-annotations, user-util
-code-annotations==0.3.2   # via edx-enterprise
+code-annotations==0.3.3   # via edx-enterprise
 contextlib2==0.6.0.post1
 coreapi==2.3.3            # via drf-yasg
 coreschema==0.0.4         # via coreapi, drf-yasg
@@ -94,7 +94,7 @@ djangorestframework==3.7.7
 docopt==0.6.2
 docutils==0.15.2          # via botocore
 drf-yasg==1.16
-edx-ace==0.1.10
+edx-ace==0.1.13
 edx-analytics-data-api-client==0.15.3
 edx-bulk-grades==0.6.6
 edx-ccx-keys==1.0.0
@@ -102,7 +102,7 @@ edx-celeryutils==0.3.1
 edx-completion==3.0.2
 edx-django-oauth2-provider==1.3.5
 edx-django-release-util==0.3.2
-edx-django-sites-extensions==2.3.1
+edx-django-sites-extensions==2.4.2
 edx-django-utils==2.0.2
 edx-drf-extensions==2.4.5
 edx-enterprise==2.0.31

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -30,7 +30,7 @@ argh==0.26.2
 argparse==1.4.0
 astroid==1.5.3
 atomicwrites==1.3.0
-attrs==17.4.0
+attrs==19.3.0
 aws-xray-sdk==0.95
 babel==1.3
 backports.functools-lru-cache==1.6.1
@@ -54,7 +54,7 @@ chardet==3.0.4
 git+https://github.com/edx/openedx-chem.git@ff4e3a03d3c7610e47a9af08eb648d8aabe2eb18#egg=chem==1.0.0
 click-log==0.3.2
 click==7.0
-code-annotations==0.3.2
+code-annotations==0.3.3
 colorama==0.4.3
 configparser==4.0.2
 contextlib2==0.6.0.post1
@@ -116,7 +116,7 @@ docker==4.1.0
 docopt==0.6.2
 docutils==0.15.2
 drf-yasg==1.16
-edx-ace==0.1.10
+edx-ace==0.1.13
 edx-analytics-data-api-client==0.15.3
 edx-bulk-grades==0.6.6
 edx-ccx-keys==1.0.0
@@ -124,7 +124,7 @@ edx-celeryutils==0.3.1
 edx-completion==3.0.2
 edx-django-oauth2-provider==1.3.5
 edx-django-release-util==0.3.2
-edx-django-sites-extensions==2.3.1
+edx-django-sites-extensions==2.4.2
 edx-django-utils==2.0.2
 edx-drf-extensions==2.4.5
 edx-enterprise==2.0.31

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -29,7 +29,7 @@ argh==0.26.2
 argparse==1.4.0           # via caniusepython3
 astroid==1.5.3            # via pylint, pylint-celery
 atomicwrites==1.3.0       # via pytest
-attrs==17.4.0
+attrs==19.3.0
 aws-xray-sdk==0.95        # via moto
 babel==1.3
 backports.functools-lru-cache==1.6.1
@@ -53,7 +53,7 @@ chardet==3.0.4
 git+https://github.com/edx/openedx-chem.git@ff4e3a03d3c7610e47a9af08eb648d8aabe2eb18#egg=chem==1.0.0
 click-log==0.3.2          # via edx-lint
 click==7.0
-code-annotations==0.3.2
+code-annotations==0.3.3
 colorama==0.4.3           # via radon
 configparser==4.0.2
 contextlib2==0.6.0.post1
@@ -113,7 +113,7 @@ docker==4.1.0             # via moto
 docopt==0.6.2
 docutils==0.15.2
 drf-yasg==1.16
-edx-ace==0.1.10
+edx-ace==0.1.13
 edx-analytics-data-api-client==0.15.3
 edx-bulk-grades==0.6.6
 edx-ccx-keys==1.0.0
@@ -121,7 +121,7 @@ edx-celeryutils==0.3.1
 edx-completion==3.0.2
 edx-django-oauth2-provider==1.3.5
 edx-django-release-util==0.3.2
-edx-django-sites-extensions==2.3.1
+edx-django-sites-extensions==2.4.2
 edx-django-utils==2.0.2
 edx-drf-extensions==2.4.5
 edx-enterprise==2.0.31


### PR DESCRIPTION
Remove the pins on `edx-ace` and `edx-django-sites-extensions` so we can upgrade to recent releases that added support for Django 2.2.