### PR TITLE
Enable auto start for HLS if autoadvance is set

### DIFF
--- a/common/lib/xmodule/xmodule/js/src/video/02_html5_hls_video.js
+++ b/common/lib/xmodule/xmodule/js/src/video/02_html5_hls_video.js
@@ -42,7 +42,12 @@
                 if (config.browserIsSafari) {
                     this.videoEl.attr('src', config.videoSources[0]);
                 } else {
-                    this.hls = new HLS({autoStartLoad: false});
+                    // load auto start if auto_advance is enabled
+                    if (config.state.auto_advance) {
+                        this.hls = new HLS({autoStartLoad: true});
+                    } else {
+                        this.hls = new HLS({autoStartLoad: false});
+                    }
                     this.hls.loadSource(config.videoSources[0]);
                     this.hls.attachMedia(this.video);
 


### PR DESCRIPTION
Currently, the auto advance feature does not play the next video if the course has a HLS (or m3u8) video type. This PR enables auto start for HLS videos if auto advance feature is set.

**JIRA Tickets:** [OSPR-3969](https://openedx.atlassian.net/browse/OSPR-3969)

**Dependencies:** None

**Sandbox URL:** TBD - sandbox is being provisioned.

**Testing instructions:**

1. Create a course with consecutive units containing videos. Add a m3u8 (HLS) video in the second unit.
2. Ensure "ENABLE_AUTOADVANCE_VIDEOS" is set to true in lms.env.json file.
3. Set the enable video auto-advance flag in Advanced settings in studio.
4. Enroll into the course from lms and start course.
5. Verify that at the end of the first video, the next unit is loaded automatically and the video starts playing

**Reviewers:**

- [ ] @pomegranited 

- [ ] edX reviewer[s] TBD