### PR TITLE
[BB-1847] Simple theme improvements and customizations

### DIFF
--- a/lms/static/sass/_header.scss
+++ b/lms/static/sass/_header.scss
@@ -166,6 +166,7 @@
           cursor: pointer;
           text-decoration: none;
         }
+
         a.sign-in-btn {
           background-color: $btn-sign-in-bg;
           color: $btn-sign-in-color;

--- a/lms/static/sass/_header.scss
+++ b/lms/static/sass/_header.scss
@@ -11,7 +11,7 @@
   padding-bottom: $baseline/2;
   border-bottom: 1px solid theme-color("primary");
   box-shadow: 0 1px 5px 0 rgba(0, 0, 0, 0.1);
-  background: theme-color("inverse");
+  background: $header-bg;
   line-height: 1.5;
 
   @include media-breakpoint-up(lg) {

--- a/lms/static/sass/_header.scss
+++ b/lms/static/sass/_header.scss
@@ -9,7 +9,7 @@
   position: relative;
   overflow: hidden;
   padding-bottom: $baseline/2;
-  border-bottom: 1px solid theme-color("primary");
+  border-bottom: 1px solid $header-border-bottom-color;
   box-shadow: 0 1px 5px 0 rgba(0, 0, 0, 0.1);
   background: $header-bg;
   line-height: 1.5;

--- a/lms/static/sass/_header.scss
+++ b/lms/static/sass/_header.scss
@@ -162,20 +162,34 @@
           cursor: pointer;
           text-decoration: none;
         }
+        a.sign-in-btn {
+          background-color: $btn-sign-in-bg;
+          color: $btn-sign-in-color;
+          border: 1px solid $btn-sign-in-border-color;
 
-        a.sign-in-btn,
+          &:hover {
+            background-color: $btn-sign-in-hover-bg;
+            color: $btn-sign-in-hover-color;
+            border-color: $btn-sign-in-hover-border-color;
+          }
+        }
+
         .nav-item a.shopping-cart {
           background-color: theme-color("primary");
           color: theme-color("inverse");
           border: 1px solid theme-color("inverse");
-          font-weight: $font-weight-normal;
-          padding: $baseline/4 $baseline;
 
           &:hover {
             background-color: theme-color("inverse");
             color: theme-color("primary");
             border-color: theme-color("primary");
           }
+        }
+
+        a.sign-in-btn,
+        .nav-item a.shopping-cart {
+          font-weight: $font-weight-normal;
+          padding: $baseline/4 $baseline;
         }
 
         a.register-btn {

--- a/lms/static/sass/_header.scss
+++ b/lms/static/sass/_header.scss
@@ -109,7 +109,7 @@
           margin: 0;
 
           a {
-            color: theme-color("secondary");
+            color: $header-main-nav-item-link-color;
             padding: $baseline*0.35 $baseline*1.25 19px;
             font-weight: $font-weight-normal;
             display: inline-block;
@@ -120,12 +120,12 @@
             &.active,
             &:hover {
               border-bottom-style: solid;
-              border-bottom-color: theme-color("primary");
+              border-bottom-color: $header-main-nav-active-item-border-bottom-color;
             }
 
             &:hover {
               cursor: pointer;
-              border-bottom-color: theme-color("primary");
+              border-bottom-color: $header-main-nav-active-item-border-bottom-color;
             }
           }
         }
@@ -148,8 +148,12 @@
           }
 
           a {
-            color: theme-color("dark");
+            color: $header-secondary-nav-item-link-color;
             font-weight: $font-weight-normal;
+          }
+
+          .dropdown-nav-item a {
+            color: $user-dropdown-link-color;
           }
         }
 
@@ -218,6 +222,10 @@
           padding: $baseline/2;
           text-decoration: none;
           cursor: pointer;
+        }
+
+        span {
+          color: $header-secondary-nav-item-link-color;
         }
 
         .dropdown-user-menu {

--- a/lms/static/sass/_header.scss
+++ b/lms/static/sass/_header.scss
@@ -53,7 +53,7 @@
       @include margin($baseline*0.8, 0, 0, $baseline);
 
       font-size: $font-size-sm;
-      color: theme-color("dark");
+      color: $courseware-course-header-color;
       line-height: 1em;
       display: none;
 

--- a/lms/static/sass/_header.scss
+++ b/lms/static/sass/_header.scss
@@ -193,13 +193,15 @@
         }
 
         a.register-btn {
-          background: theme-color("inverse");
-          color: theme-color("primary");
+          background: $btn-register-bg;
+          color: $btn-register-color;
           font-weight: $font-weight-normal;
+          border-color: $btn-register-border-color;
 
           &:hover {
-            background-color: theme-color("primary");
-            color: theme-color("inverse");
+            background-color: $btn-register-hover-bg;
+            color: $btn-register-hover-color;
+            border-color: $btn-register-hover-border-color;
           }
         }
 

--- a/lms/static/sass/bootstrap/_footer.scss
+++ b/lms/static/sass/bootstrap/_footer.scss
@@ -58,7 +58,12 @@
 
       margin: -2px 0 8px;
       font-size: .8em;
-      color: $gray;
+
+      @if variable-exists(footer-color) {
+        color: $footer-color;
+      } else {
+        color: $gray;
+      }
     }
 
     .footer-about-openedx {

--- a/lms/static/sass/bootstrap/_footer.scss
+++ b/lms/static/sass/bootstrap/_footer.scss
@@ -23,10 +23,20 @@
         .nav-link {
           text-decoration: none;
           padding: 0;
-          color: $gray-900;
-
+          @if variable-exists(footer-colophon-link-color) {
+            color: $footer-colophon-link-color;
+          } @else {
+            color: $gray-900;
+          }
           &:hover {
-            color: theme-color("primary");
+            @if variable-exists(footer-colophon-link-hover-color) {
+              color: $footer-colophon-link-hover-color;
+            } @else {
+              color: theme-color("primary");
+            }
+            @if variable-exists(footer-colophon-link-hover-border-bottom-color) {
+              border-bottom: 1px dotted $footer-colophon-link-hover-border-bottom-color;
+            }
           }
         }
       }

--- a/lms/static/sass/bootstrap/_footer.scss
+++ b/lms/static/sass/bootstrap/_footer.scss
@@ -3,11 +3,15 @@
 
 .wrapper-footer {
   box-shadow: 0 -1px 5px 0 $shadow-l1;
+
   @if variable-exists(footer-border-top-color) {
     border-top: 1px solid $footer-border-top-color;
-  } @else {
+  }
+
+  @else {
     border-top: 1px solid $navbar-light-disabled-color;
   }
+
   background-color: $footer-bg;
   margin-top: $baseline/2;
   padding: $baseline;
@@ -27,17 +31,24 @@
         .nav-link {
           text-decoration: none;
           padding: 0;
+
           @if variable-exists(footer-colophon-link-color) {
             color: $footer-colophon-link-color;
-          } @else {
+          }
+
+          @else {
             color: $gray-900;
           }
+
           &:hover {
             @if variable-exists(footer-colophon-link-hover-color) {
               color: $footer-colophon-link-hover-color;
-            } @else {
+            }
+
+            @else {
               color: theme-color("primary");
             }
+
             @if variable-exists(footer-colophon-link-hover-border-bottom-color) {
               border-bottom: 1px dotted $footer-colophon-link-hover-border-bottom-color;
             }
@@ -55,9 +66,11 @@
           padding: 0;
           margin-right: $baseline/4;
           font-size: .8em;
+
           @if variable-exists(footer-legal-link-color) {
             color: $footer-legal-link-color;
           }
+
           @if variable-exists(footer-legal-link-hover-border-bottom-color) {
             &:hover {
               border-bottom: 1px dotted $footer-legal-link-hover-border-bottom-color;
@@ -83,7 +96,9 @@
 
       @if variable-exists(footer-color) {
         color: $footer-color;
-      } else {
+      }
+
+      @else {
         color: $gray;
       }
     }

--- a/lms/static/sass/bootstrap/_footer.scss
+++ b/lms/static/sass/bootstrap/_footer.scss
@@ -51,6 +51,14 @@
           padding: 0;
           margin-right: $baseline/4;
           font-size: .8em;
+          @if variable-exists(footer-legal-link-color) {
+            color: $footer-legal-link-color;
+          }
+          @if variable-exists(footer-legal-link-hover-border-bottom-color) {
+            &:hover {
+              border-bottom: 1px dotted $footer-legal-link-hover-border-bottom-color;
+            }
+          }
         }
       }
 

--- a/lms/static/sass/bootstrap/_footer.scss
+++ b/lms/static/sass/bootstrap/_footer.scss
@@ -3,7 +3,11 @@
 
 .wrapper-footer {
   box-shadow: 0 -1px 5px 0 $shadow-l1;
-  border-top: 1px solid $navbar-light-disabled-color;
+  @if variable-exists(footer-border-top-color) {
+    border-top: 1px solid $footer-border-top-color;
+  } @else {
+    border-top: 1px solid $navbar-light-disabled-color;
+  }
   background-color: $footer-bg;
   margin-top: $baseline/2;
   padding: $baseline;

--- a/lms/static/sass/bootstrap/_footer.scss
+++ b/lms/static/sass/bootstrap/_footer.scss
@@ -4,7 +4,7 @@
 .wrapper-footer {
   box-shadow: 0 -1px 5px 0 $shadow-l1;
   border-top: 1px solid $navbar-light-disabled-color;
-  background-color: $body-bg;
+  background-color: $footer-bg;
   margin-top: $baseline/2;
   padding: $baseline;
   font-family: $font-family-sans-serif;

--- a/lms/static/sass/bootstrap/_layouts.scss
+++ b/lms/static/sass/bootstrap/_layouts.scss
@@ -34,7 +34,7 @@
       &:hover {
         .nav-link {
           border-bottom-color: $courseware-course-tab-nav-link-hover-border-bottom-color;
-          color: $courseware-course-tab-nav-link-hover-color
+          color: $courseware-course-tab-nav-link-hover-color;
         }
       }
     }

--- a/lms/static/sass/bootstrap/_layouts.scss
+++ b/lms/static/sass/bootstrap/_layouts.scss
@@ -27,14 +27,14 @@
         border-style: solid;
         border-width: 0 0 $baseline/5 0;
         border-bottom-color: transparent;
-        color: theme-color("secondary");
+        color: $courseware-course-tab-nav-link-color;
       }
 
       &.active,
       &:hover {
         .nav-link {
-          border-bottom-color: theme-color("primary");
-          color: theme-color("primary");
+          border-bottom-color: $courseware-course-tab-nav-link-hover-border-bottom-color;
+          color: $courseware-course-tab-nav-link-hover-color
         }
       }
     }

--- a/lms/static/sass/course/_auto-cert.scss
+++ b/lms/static/sass/course/_auto-cert.scss
@@ -13,7 +13,11 @@
   .auto-cert-message {
     margin: $baseline 0;
     padding: $baseline;
-    border-left: 3px solid $m-blue-d1;
+    @if variable-exists(progress-auto-cert-message-border-color) {
+      border-left: 3px solid $progress-auto-cert-message-border-color;
+    } @else {
+      border-left: 3px solid $m-blue-d1;
+    }
     background: $gray-l5;
 
     .has-actions {

--- a/lms/static/sass/course/_auto-cert.scss
+++ b/lms/static/sass/course/_auto-cert.scss
@@ -13,11 +13,15 @@
   .auto-cert-message {
     margin: $baseline 0;
     padding: $baseline;
+
     @if variable-exists(progress-auto-cert-message-border-color) {
       border-left: 3px solid $progress-auto-cert-message-border-color;
-    } @else {
+    }
+
+    @else {
       border-left: 3px solid $m-blue-d1;
     }
+
     background: $gray-l5;
 
     .has-actions {

--- a/lms/static/sass/course/_profile.scss
+++ b/lms/static/sass/course/_profile.scss
@@ -311,6 +311,10 @@
             .hd {
               color: $gray-d1;
 
+              a {
+                @extend %progress-page-link;
+              }
+
               span {
                 color: $gray-d2;
                 font-size: em(14);

--- a/lms/static/sass/course/layout/_courseware_header.scss
+++ b/lms/static/sass/course/layout/_courseware_header.scss
@@ -48,7 +48,7 @@
         @extend %t-title7;
         @extend %t-regular;
 
-        color: theme-color("dark");
+        color: $courseware-course-tab-nav-link-color;
         display: block;
         text-align: center;
         text-decoration: none;
@@ -57,8 +57,9 @@
         &:hover,
         &:focus,
         &.active {
-          color: theme-color("primary");
+          color: $courseware-course-tab-nav-link-hover-color;
           border-bottom-style: solid;
+          border-bottom-color: $courseware-course-tab-nav-link-hover-border-bottom-color;
           background-color: transparent;
         }
       }

--- a/lms/static/sass/course/wiki/_wiki.scss
+++ b/lms/static/sass/course/wiki/_wiki.scss
@@ -49,7 +49,11 @@
         height: 100%;
         text-overflow: ellipsis;
         white-space: nowrap;
-        color: $link-color;
+        @if variable-exists(wiki-breadcrumb-link-color) {
+          color: $wiki-breadcrumb-link-color;
+        } @else {
+          color: $link-color;
+        }
       }
 
       &::after {
@@ -152,6 +156,11 @@
     color: $body-color;
 
     @include box-sizing(border-box);
+
+    p a, td a {
+      @extend %wiki-article-link;
+    }
+
   }
 
   &.view .main-article {
@@ -273,6 +282,8 @@
           color: $uxpl-blue-hover-active;
           font-weight: bold;
         }
+
+        @extend %wiki-nav-tab-link;
       }
     }
   }
@@ -285,11 +296,13 @@
     li {
       &.active {
         a {
+
           color: $uxpl-blue-hover-active;
           font-weight: bold;
           background-color: $light-gray1;
           border-color: $uxpl-blue-hover-active;
-          border-left: 4px solid
+          border-left: 4px solid;
+          @extend %wiki-nav-tab-active-link;
         }
       }
     }
@@ -315,6 +328,7 @@
         color: $uxpl-blue-hover-active;
         font-weight: bold;
       }
+      @extend %wiki-nav-tab-link;
     }
   }
 

--- a/lms/static/sass/course/wiki/_wiki.scss
+++ b/lms/static/sass/course/wiki/_wiki.scss
@@ -49,9 +49,12 @@
         height: 100%;
         text-overflow: ellipsis;
         white-space: nowrap;
+
         @if variable-exists(wiki-breadcrumb-link-color) {
           color: $wiki-breadcrumb-link-color;
-        } @else {
+        }
+
+        @else {
           color: $link-color;
         }
       }
@@ -157,7 +160,8 @@
 
     @include box-sizing(border-box);
 
-    p a, td a {
+    p a,
+    td a {
       @extend %wiki-article-link;
     }
 
@@ -302,6 +306,7 @@
           background-color: $light-gray1;
           border-color: $uxpl-blue-hover-active;
           border-left: 4px solid;
+
           @extend %wiki-nav-tab-active-link;
         }
       }
@@ -328,6 +333,7 @@
         color: $uxpl-blue-hover-active;
         font-weight: bold;
       }
+
       @extend %wiki-nav-tab-link;
     }
   }

--- a/lms/static/sass/features/_course-experience.scss
+++ b/lms/static/sass/features/_course-experience.scss
@@ -314,7 +314,7 @@
 
     // Course outline accordion / link
     a.outline-button {
-        @extend %course-outline-link;
+      @extend %course-outline-link;
     }
 
     .outline-button {
@@ -330,7 +330,9 @@
       .fa {
         @if variable-exists(course-outline-chevron-color) {
           color: $course-outline-chevron-color;
-        } @else {
+        }
+
+        @else {
           color: $blue;
         }
       }
@@ -417,7 +419,9 @@
 
   @if variable-exists(btn-expand-collapse-outline-color) {
     color: $btn-expand-collapse-outline-color;
-  } @else {
+  }
+
+  @else {
     color: $black;
   }
 

--- a/lms/static/sass/features/_course-experience.scss
+++ b/lms/static/sass/features/_course-experience.scss
@@ -309,6 +309,10 @@
     list-style-type: none;
 
     // Course outline accordion / link
+    a.outline-button {
+        @extend %course-outline-link;
+    }
+
     .outline-button {
       display: block;
       padding: 10px 0 10px 2px;
@@ -320,7 +324,11 @@
       cursor: pointer;
 
       .fa {
-        color: $blue;
+        @if variable-exists(course-outline-chevron-color) {
+          color: $course-outline-chevron-color;
+        } @else {
+          color: $blue;
+        }
       }
 
       .prerequisites-icon {

--- a/lms/static/sass/features/_course-experience.scss
+++ b/lms/static/sass/features/_course-experience.scss
@@ -17,6 +17,10 @@
     &:not(:first-child) {
       margin-top: $baseline;
     }
+
+    a {
+      @extend %course-sidebar-link;
+    }
   }
 }
 
@@ -406,7 +410,17 @@
 #expand-collapse-outline-all-button {
   float: right;
   background-color: $white;
-  color: $black;
+
+  @if variable-exists(btn-expand-collapse-outline-border-color) {
+    border-color: $btn-expand-collapse-outline-border-color;
+  }
+
+  @if variable-exists(btn-expand-collapse-outline-color) {
+    color: $btn-expand-collapse-outline-color;
+  } @else {
+    color: $black;
+  }
+
   cursor: pointer;
 }
 
@@ -508,6 +522,10 @@
       }
     }
   }
+}
+
+#course-container .action-resume-course {
+  @extend %btn-resume-course;
 }
 
 // Course Reviews Page

--- a/lms/static/sass/multicourse/_dashboard.scss
+++ b/lms/static/sass/multicourse/_dashboard.scss
@@ -135,6 +135,9 @@
               flex-basis: 100%;
               padding-top: $baseline/2;
 
+              a.course-target-link {
+                @extend %dashboard-course-card-title-link;
+              }
               a, span {
                 font: -apple-system-short-headline !important;
                 @extend %t-title3;
@@ -400,6 +403,8 @@
             @extend %btn-pl-white-base;
 
             @include float(right);
+
+            @extend %dashboard-btn-enter-course;
 
             &.archived {
               @extend %btn-pl-default-base;

--- a/lms/static/sass/multicourse/_home.scss
+++ b/lms/static/sass/multicourse/_home.scss
@@ -18,6 +18,9 @@ $course-search-input-height: ($button-size);
     @include linear-gradient($homepage__header--gradient__color--alpha, $homepage__header--gradient__color--bravo);
     @include clearfix();
 
+    @if variable-exists(homepage-header-hero-bg) {
+      background-color: $homepage-header-hero-bg;
+    }
     background-size: cover;
     background-image: $homepage-bg-image;
     box-shadow: 0 1px 0 0 $course-header-bg, inset 0 -1px 5px 0 $shadow-l1;
@@ -93,6 +96,9 @@ $course-search-input-height: ($button-size);
         h1 {
           @include text-align(left);
 
+          @if variable-exists(homepage-header-hero-title-color) {
+            color: $homepage-header-hero-title-color;
+          }
           margin-bottom: 0;
           text-shadow: 0 1px rgba(255, 255, 255, 0.6);
           text-transform: none;
@@ -101,6 +107,9 @@ $course-search-input-height: ($button-size);
         p {
           @extend h2;
 
+          @if variable-exists(homepage-header-hero-subtitle-color) {
+            color: $homepage-header-hero-subtitle-color;
+          }
           margin-bottom: 0;
           text-transform: none;
           font-style: italic;

--- a/lms/static/sass/partials/lms/theme/_shared-variables.scss
+++ b/lms/static/sass/partials/lms/theme/_shared-variables.scss
@@ -1,6 +1,7 @@
 @import 'edx-bootstrap/sass/open-edx/theme';
 
 $header-bg: theme-color("inverse") !default;
+$header-border-bottom-color: theme-color("primary") !default;
 
 $btn-sign-in-bg: theme-color("primary") !default;
 $btn-sign-in-color: theme-color("inverse") !default;

--- a/lms/static/sass/partials/lms/theme/_shared-variables.scss
+++ b/lms/static/sass/partials/lms/theme/_shared-variables.scss
@@ -102,3 +102,6 @@ $user-dropdown-link-color: theme-color("dark") !default;
 }
 
 $courseware-course-header-color: theme-color("dark") !default;
+$courseware-course-tab-nav-link-color: theme-color("secondary") !default;
+$courseware-course-tab-nav-link-hover-color: theme-color("primary") !default;
+$courseware-course-tab-nav-link-hover-border-bottom-color: theme-color("primary") !default;

--- a/lms/static/sass/partials/lms/theme/_shared-variables.scss
+++ b/lms/static/sass/partials/lms/theme/_shared-variables.scss
@@ -10,4 +10,12 @@ $btn-sign-in-hover-bg: theme-color("inverse") !default;
 $btn-sign-in-hover-color: theme-color("primary") !default;
 $btn-sign-in-hover-border-color: theme-color("primary") !default;
 
+$btn-register-bg: theme-color("inverse") !default;
+$btn-register-color: theme-color("primary") !default;
+$btn-register-border-color: theme-color("primary") !default;
+
+$btn-register-hover-bg: theme-color("primary") !default;
+$btn-register-hover-color: theme-color("inverse") !default;
+$btn-register-hover-border-color: theme-color("primary") !default;
+
 $footer-bg: $body-bg !default;

--- a/lms/static/sass/partials/lms/theme/_shared-variables.scss
+++ b/lms/static/sass/partials/lms/theme/_shared-variables.scss
@@ -105,3 +105,14 @@ $courseware-course-header-color: theme-color("dark") !default;
 $courseware-course-tab-nav-link-color: theme-color("secondary") !default;
 $courseware-course-tab-nav-link-hover-color: theme-color("primary") !default;
 $courseware-course-tab-nav-link-hover-border-bottom-color: theme-color("primary") !default;
+
+%course-outline-link {
+  @if variable-exists(course-outline-link-color) {
+    color: $course-outline-link-color;
+  }
+  @if variable-exists(course-outline-link-hover-color) {
+    &:hover, &:focus, &:active {
+      color: $course-outline-link-hover-color;
+    }
+  }
+}

--- a/lms/static/sass/partials/lms/theme/_shared-variables.scss
+++ b/lms/static/sass/partials/lms/theme/_shared-variables.scss
@@ -1,3 +1,5 @@
 @import 'edx-bootstrap/sass/open-edx/theme';
 
 $header-bg: theme-color("inverse") !default;
+
+$footer-bg: $body-bg !default;

--- a/lms/static/sass/partials/lms/theme/_shared-variables.scss
+++ b/lms/static/sass/partials/lms/theme/_shared-variables.scss
@@ -153,3 +153,35 @@ $course-outline-tools-link-hover-color: theme-color("primary") !default;
     }
   }
 }
+
+%wiki-nav-tab-active-link {
+  @if variable-exists(wiki-nav-tab-active-link-color) {
+    color: $wiki-nav-tab-active-link-color;
+  }
+
+  @if variable-exists(wiki-nav-tab-active-link-border-color) {
+    border-color: $wiki-nav-tab-active-link-border-color;
+  }
+}
+
+%wiki-nav-tab-link {
+  @if variable-exists(wiki-nav-tab-link-color) {
+    color: $wiki-nav-tab-link-color;
+  }
+  @if variable-exists(wiki-nav-tab-link-hover-color) {
+    &:hover, &:focus, &:active {
+      color: $wiki-nav-tab-link-hover-color;
+    }
+  }
+}
+
+%wiki-article-link {
+  @if variable-exists(wiki-article-link-color) {
+    color: $wiki-article-link-color;
+  }
+  @if variable-exists(wiki-article-link-hover-color) {
+    &:hover, &:focus, &:active {
+      color: $wiki-article-link-hover-color;
+    }
+  }
+}

--- a/lms/static/sass/partials/lms/theme/_shared-variables.scss
+++ b/lms/static/sass/partials/lms/theme/_shared-variables.scss
@@ -59,3 +59,9 @@ $logistration-form-link-color: theme-color("primary") !default;
     }
   }
 }
+
+$header-main-nav-active-item-border-bottom-color: theme-color("primary") !default;
+$header-main-nav-item-link-color: theme-color("secondary") !default;
+
+$header-secondary-nav-item-link-color: theme-color("dark") !default;
+$user-dropdown-link-color: theme-color("dark") !default;

--- a/lms/static/sass/partials/lms/theme/_shared-variables.scss
+++ b/lms/static/sass/partials/lms/theme/_shared-variables.scss
@@ -65,3 +65,38 @@ $header-main-nav-item-link-color: theme-color("secondary") !default;
 
 $header-secondary-nav-item-link-color: theme-color("dark") !default;
 $user-dropdown-link-color: theme-color("dark") !default;
+
+%dashboard-course-card-title-link {
+  @if variable-exists(dashboard-course-card-title-link-color) {
+    color: $dashboard-course-card-title-link-color;
+  }
+  @if variable-exists(dashboard-course-card-title-link-hover-color) {
+    &:hover, &:active, &:focus {
+      color: $dashboard-course-card-title-link-hover-color;
+    }
+  }
+}
+
+%dashboard-btn-enter-course {
+  @if variable-exists(dashboard-btn-enter-course-bg) {
+    background-color: $dashboard-btn-enter-course-bg;
+  }
+  @if variable-exists(dashboard-btn-enter-course-color) {
+    color: $dashboard-btn-enter-course-color;
+  }
+  @if variable-exists(dashboard-btn-enter-course-border-color) {
+    border-color: $dashboard-btn-enter-course-border-color;
+  }
+
+  &:hover, &:active, &:focus {
+    @if variable-exists(dashboard-btn-enter-course-hover-bg) {
+      background-color: $dashboard-btn-enter-course-hover-bg;
+    }
+    @if variable-exists(dashboard-btn-enter-course-hover-color) {
+      color: $dashboard-btn-enter-course-hover-color;
+    }
+    @if variable-exists(dashboard-btn-enter-course-hover-border-color) {
+      border-color: $dashboard-btn-enter-course-hover-border-color;
+    }
+  }
+}

--- a/lms/static/sass/partials/lms/theme/_shared-variables.scss
+++ b/lms/static/sass/partials/lms/theme/_shared-variables.scss
@@ -1,1 +1,3 @@
 @import 'edx-bootstrap/sass/open-edx/theme';
+
+$header-bg: theme-color("inverse") !default;

--- a/lms/static/sass/partials/lms/theme/_shared-variables.scss
+++ b/lms/static/sass/partials/lms/theme/_shared-variables.scss
@@ -19,3 +19,42 @@ $btn-register-hover-color: theme-color("inverse") !default;
 $btn-register-hover-border-color: theme-color("primary") !default;
 
 $footer-bg: $body-bg !default;
+
+$logistration-form-link-color: theme-color("primary") !default;
+
+%logistration-form-link {
+  @if variable-exists(logistration-form-link-color) {
+    color: $logistration-form-link-color;
+  }
+  @if variable-exists(logistration-form-link-hover-color) {
+    &:hover, &:active {
+      color: $logistration-form-link-hover-color;
+    }
+  }
+}
+
+%logistration-form-btn-action-primary {
+  @if variable-exists(logistration-form-btn-primary-bg) {
+    background: $logistration-form-btn-primary-bg;
+    box-shadow: none; // required because there is a blue shadow by default
+  }
+  @if variable-exists(logistration-form-btn-primary-color) {
+    color: $logistration-form-btn-primary-color;
+  }
+  @if variable-exists(logistration-form-btn-primary-border-color) {
+    border-color: $logistration-form-btn-primary-border-color;
+  }
+
+  &:hover, &:focus, &:active {
+    @if variable-exists(logistration-form-btn-primary-hover-bg) {
+        background: $logistration-form-btn-primary-hover-bg;
+        box-shadow: none; // required because there is a blue shadow by default
+    }
+    @if variable-exists(logistration-form-btn-primary-hover-color) {
+      color: $logistration-form-btn-primary-hover-color;
+    }
+    @if variable-exists(logistration-form-btn-primary-hover-border-color) {
+      border-color: $logistration-form-btn-primary-hover-border-color;
+    }
+  }
+}

--- a/lms/static/sass/partials/lms/theme/_shared-variables.scss
+++ b/lms/static/sass/partials/lms/theme/_shared-variables.scss
@@ -27,8 +27,10 @@ $logistration-form-link-color: theme-color("primary") !default;
   @if variable-exists(logistration-form-link-color) {
     color: $logistration-form-link-color;
   }
+
   @if variable-exists(logistration-form-link-hover-color) {
-    &:hover, &:active {
+    &:hover,
+    &:active {
       color: $logistration-form-link-hover-color;
     }
   }
@@ -39,21 +41,27 @@ $logistration-form-link-color: theme-color("primary") !default;
     background: $logistration-form-btn-primary-bg;
     box-shadow: none; // required because there is a blue shadow by default
   }
+
   @if variable-exists(logistration-form-btn-primary-color) {
     color: $logistration-form-btn-primary-color;
   }
+
   @if variable-exists(logistration-form-btn-primary-border-color) {
     border-color: $logistration-form-btn-primary-border-color;
   }
 
-  &:hover, &:focus, &:active {
+  &:hover,
+  &:focus,
+  &:active {
     @if variable-exists(logistration-form-btn-primary-hover-bg) {
-        background: $logistration-form-btn-primary-hover-bg;
-        box-shadow: none; // required because there is a blue shadow by default
+      background: $logistration-form-btn-primary-hover-bg;
+      box-shadow: none; // required because there is a blue shadow by default
     }
+
     @if variable-exists(logistration-form-btn-primary-hover-color) {
       color: $logistration-form-btn-primary-hover-color;
     }
+
     @if variable-exists(logistration-form-btn-primary-hover-border-color) {
       border-color: $logistration-form-btn-primary-hover-border-color;
     }
@@ -70,8 +78,11 @@ $user-dropdown-link-color: theme-color("dark") !default;
   @if variable-exists(dashboard-course-card-title-link-color) {
     color: $dashboard-course-card-title-link-color;
   }
+
   @if variable-exists(dashboard-course-card-title-link-hover-color) {
-    &:hover, &:active, &:focus {
+    &:hover,
+    &:active,
+    &:focus {
       color: $dashboard-course-card-title-link-hover-color;
     }
   }
@@ -81,20 +92,26 @@ $user-dropdown-link-color: theme-color("dark") !default;
   @if variable-exists(dashboard-btn-enter-course-bg) {
     background-color: $dashboard-btn-enter-course-bg;
   }
+
   @if variable-exists(dashboard-btn-enter-course-color) {
     color: $dashboard-btn-enter-course-color;
   }
+
   @if variable-exists(dashboard-btn-enter-course-border-color) {
     border-color: $dashboard-btn-enter-course-border-color;
   }
 
-  &:hover, &:active, &:focus {
+  &:hover,
+  &:active,
+  &:focus {
     @if variable-exists(dashboard-btn-enter-course-hover-bg) {
       background-color: $dashboard-btn-enter-course-hover-bg;
     }
+
     @if variable-exists(dashboard-btn-enter-course-hover-color) {
       color: $dashboard-btn-enter-course-hover-color;
     }
+
     @if variable-exists(dashboard-btn-enter-course-hover-border-color) {
       border-color: $dashboard-btn-enter-course-hover-border-color;
     }
@@ -110,8 +127,11 @@ $courseware-course-tab-nav-link-hover-border-bottom-color: theme-color("primary"
   @if variable-exists(course-outline-link-color) {
     color: $course-outline-link-color;
   }
+
   @if variable-exists(course-outline-link-hover-color) {
-    &:hover, &:focus, &:active {
+    &:hover,
+    &:focus,
+    &:active {
       color: $course-outline-link-hover-color;
     }
   }
@@ -123,8 +143,11 @@ $course-outline-tools-link-hover-color: theme-color("primary") !default;
   @if variable-exists(course-sidebar-link-color) {
     color: $course-sidebar-link-color;
   }
+
   @if variable-exists(course-sidebar-link-hover-color) {
-    &:hover, &:focus, &:active {
+    &:hover,
+    &:focus,
+    &:active {
       color: $course-sidebar-link-hover-color;
     }
   }
@@ -134,20 +157,26 @@ $course-outline-tools-link-hover-color: theme-color("primary") !default;
   @if variable-exists(btn-resume-course-bg) {
     background-color: $btn-resume-course-bg;
   }
+
   @if variable-exists(btn-resume-course-color) {
     color: $btn-resume-course-color;
   }
+
   @if variable-exists(btn-resume-course-border-color) {
     border-color: $btn-resume-course-border-color;
   }
 
-  &:hover, &:active, &:focus {
+  &:hover,
+  &:active,
+  &:focus {
     @if variable-exists(btn-resume-course-hover-bg) {
       background-color: $btn-resume-course-hover-bg;
     }
+
     @if variable-exists(btn-resume-course-hover-color) {
       color: $btn-resume-course-hover-color;
     }
+
     @if variable-exists(btn-resume-course-hover-border-color) {
       border-color: $btn-resume-course-hover-border-color;
     }
@@ -168,8 +197,11 @@ $course-outline-tools-link-hover-color: theme-color("primary") !default;
   @if variable-exists(wiki-nav-tab-link-color) {
     color: $wiki-nav-tab-link-color;
   }
+
   @if variable-exists(wiki-nav-tab-link-hover-color) {
-    &:hover, &:focus, &:active {
+    &:hover,
+    &:focus,
+    &:active {
       color: $wiki-nav-tab-link-hover-color;
     }
   }
@@ -179,8 +211,11 @@ $course-outline-tools-link-hover-color: theme-color("primary") !default;
   @if variable-exists(wiki-article-link-color) {
     color: $wiki-article-link-color;
   }
+
   @if variable-exists(wiki-article-link-hover-color) {
-    &:hover, &:focus, &:active {
+    &:hover,
+    &:focus,
+    &:active {
       color: $wiki-article-link-hover-color;
     }
   }
@@ -190,8 +225,11 @@ $course-outline-tools-link-hover-color: theme-color("primary") !default;
   @if variable-exists(progress-page-link-color) {
     color: $progress-page-link-color;
   }
+
   @if variable-exists(progress-page-link-hover-color) {
-    &:hover, &:focus, &:active {
+    &:hover,
+    &:focus,
+    &:active {
       color: $progress-page-link-hover-color;
     }
   }
@@ -210,7 +248,9 @@ $course-outline-tools-link-hover-color: theme-color("primary") !default;
     border-color: $btn-account-settings-border-color;
   }
 
-  &:hover, &:active, &:focus {
+  &:hover,
+  &:active,
+  &:focus {
     @if variable-exists(btn-account-settings-hover-bg) {
       background-color: $btn-account-settings-hover-bg;
     }

--- a/lms/static/sass/partials/lms/theme/_shared-variables.scss
+++ b/lms/static/sass/partials/lms/theme/_shared-variables.scss
@@ -116,3 +116,40 @@ $courseware-course-tab-nav-link-hover-border-bottom-color: theme-color("primary"
     }
   }
 }
+
+$course-outline-tools-link-hover-color: theme-color("primary") !default;
+
+%course-sidebar-link {
+  @if variable-exists(course-sidebar-link-color) {
+    color: $course-sidebar-link-color;
+  }
+  @if variable-exists(course-sidebar-link-hover-color) {
+    &:hover, &:focus, &:active {
+      color: $course-sidebar-link-hover-color;
+    }
+  }
+}
+
+%btn-resume-course {
+  @if variable-exists(btn-resume-course-bg) {
+    background-color: $btn-resume-course-bg;
+  }
+  @if variable-exists(btn-resume-course-color) {
+    color: $btn-resume-course-color;
+  }
+  @if variable-exists(btn-resume-course-border-color) {
+    border-color: $btn-resume-course-border-color;
+  }
+
+  &:hover, &:active, &:focus {
+    @if variable-exists(btn-resume-course-hover-bg) {
+      background-color: $btn-resume-course-hover-bg;
+    }
+    @if variable-exists(btn-resume-course-hover-color) {
+      color: $btn-resume-course-hover-color;
+    }
+    @if variable-exists(btn-resume-course-hover-border-color) {
+      border-color: $btn-resume-course-hover-border-color;
+    }
+  }
+}

--- a/lms/static/sass/partials/lms/theme/_shared-variables.scss
+++ b/lms/static/sass/partials/lms/theme/_shared-variables.scss
@@ -2,4 +2,12 @@
 
 $header-bg: theme-color("inverse") !default;
 
+$btn-sign-in-bg: theme-color("primary") !default;
+$btn-sign-in-color: theme-color("inverse") !default;
+$btn-sign-in-border-color: theme-color("inverse") !default;
+
+$btn-sign-in-hover-bg: theme-color("inverse") !default;
+$btn-sign-in-hover-color: theme-color("primary") !default;
+$btn-sign-in-hover-border-color: theme-color("primary") !default;
+
 $footer-bg: $body-bg !default;

--- a/lms/static/sass/partials/lms/theme/_shared-variables.scss
+++ b/lms/static/sass/partials/lms/theme/_shared-variables.scss
@@ -1,0 +1,1 @@
+@import 'edx-bootstrap/sass/open-edx/theme';

--- a/lms/static/sass/partials/lms/theme/_shared-variables.scss
+++ b/lms/static/sass/partials/lms/theme/_shared-variables.scss
@@ -196,3 +196,31 @@ $course-outline-tools-link-hover-color: theme-color("primary") !default;
     }
   }
 }
+
+%btn-account-settings-page {
+  @if variable-exists(btn-account-settings-bg) {
+    background-color: $btn-account-settings-bg;
+  }
+
+  @if variable-exists(btn-account-settings-color) {
+    color: $btn-account-settings-color;
+  }
+
+  @if variable-exists(btn-account-settings-border-color) {
+    border-color: $btn-account-settings-border-color;
+  }
+
+  &:hover, &:active, &:focus {
+    @if variable-exists(btn-account-settings-hover-bg) {
+      background-color: $btn-account-settings-hover-bg;
+    }
+
+    @if variable-exists(btn-account-settings-hover-color) {
+      color: $btn-account-settings-hover-color;
+    }
+
+    @if variable-exists(btn-account-settings-hover-border-color) {
+      border-color: $btn-account-settings-hover-border-color;
+    }
+  }
+}

--- a/lms/static/sass/partials/lms/theme/_shared-variables.scss
+++ b/lms/static/sass/partials/lms/theme/_shared-variables.scss
@@ -185,3 +185,14 @@ $course-outline-tools-link-hover-color: theme-color("primary") !default;
     }
   }
 }
+
+%progress-page-link {
+  @if variable-exists(progress-page-link-color) {
+    color: $progress-page-link-color;
+  }
+  @if variable-exists(progress-page-link-hover-color) {
+    &:hover, &:focus, &:active {
+      color: $progress-page-link-hover-color;
+    }
+  }
+}

--- a/lms/static/sass/partials/lms/theme/_shared-variables.scss
+++ b/lms/static/sass/partials/lms/theme/_shared-variables.scss
@@ -100,3 +100,5 @@ $user-dropdown-link-color: theme-color("dark") !default;
     }
   }
 }
+
+$courseware-course-header-color: theme-color("dark") !default;

--- a/lms/static/sass/partials/lms/theme/_variables-v1.scss
+++ b/lms/static/sass/partials/lms/theme/_variables-v1.scss
@@ -17,6 +17,7 @@
 // ----------------------------
 // #CONFIG
 // ----------------------------
+@import 'shared-variables';
 $static-path: '..' !default;
 
 

--- a/lms/static/sass/partials/lms/theme/_variables.scss
+++ b/lms/static/sass/partials/lms/theme/_variables.scss
@@ -1,3 +1,4 @@
 // Default bootstrap theming
 
 @import 'edx-bootstrap/sass/open-edx/theme';
+@import 'shared-variables';

--- a/lms/static/sass/shared/_footer.scss
+++ b/lms/static/sass/shared/_footer.scss
@@ -125,7 +125,11 @@
     .copyright {
       margin: -2px 0 8px 0;
       font-size: em(11);
-      color: $gray; // WCAG 2.0 AA requirements
+      @if variable-exists(footer-color) {
+          color: $footer-color;
+      } @else {
+          color: $gray; // WCAG 2.0 AA requirements
+      }
 
       @include text-align(left);
     }

--- a/lms/static/sass/shared/_footer.scss
+++ b/lms/static/sass/shared/_footer.scss
@@ -7,7 +7,12 @@
   @extend %ui-print-excluded;
 
   box-shadow: 0 -1px 5px 0 $shadow-l1;
-  border-top: 1px solid tint($m-gray, 50%);
+
+  @if variable-exists(footer-border-top-color) {
+    border-top: 1px solid $footer-border-top-color;
+  } @else {
+    border-top: 1px solid tint($m-gray, 50%);
+  }
   padding: 25px ($baseline/2) ($baseline*1.5) ($baseline/2);
   background: $footer-bg;
   clear: both;

--- a/lms/static/sass/shared/_footer.scss
+++ b/lms/static/sass/shared/_footer.scss
@@ -69,10 +69,21 @@
           margin-right: ($baseline*0.75);
 
           a {
-            color: tint($black, 20%);
+            @if variable-exists(footer-colophon-link-color) {
+              color: $footer-colophon-link-color;
+            } @else {
+              color: tint($black, 20%);
+            }
 
             &:hover, &:focus, &:active {
-              color: $link-color;
+              @if variable-exists(footer-colophon-link-hover-color) {
+                color: $footer-colophon-link-hover-color;
+              } @else {
+                color: $link-color;
+              }
+              @if variable-exists(footer-colophon-link-hover-border-bottom-color) {
+                border-bottom-color: $footer-colophon-link-hover-border-bottom-color;
+              }
             }
           }
 

--- a/lms/static/sass/shared/_footer.scss
+++ b/lms/static/sass/shared/_footer.scss
@@ -10,9 +10,12 @@
 
   @if variable-exists(footer-border-top-color) {
     border-top: 1px solid $footer-border-top-color;
-  } @else {
+  }
+
+  @else {
     border-top: 1px solid tint($m-gray, 50%);
   }
+
   padding: 25px ($baseline/2) ($baseline*1.5) ($baseline/2);
   background: $footer-bg;
   clear: both;
@@ -37,17 +40,23 @@
       @include transition(link-color 0.15s ease-in-out 0s, border 0.15s ease-in-out 0s);
 
       border-bottom: none;
+
       @if variable-exists(footer-legal-link-color) {
         color: $footer-legal-link-color;
-      } @else {
+      }
+
+      @else {
         color: $link-color;
       }
+
       text-decoration: none !important;
 
       &:hover, &:focus, &:active {
         @if variable-exists(footer-legal-link-hover-border-bottom-color) {
           border-bottom: 1px dotted $footer-legal-link-hover-border-bottom-color;
-        } @else {
+        }
+
+        @else {
           border-bottom: 1px dotted $link-color;
         }
       }
@@ -84,16 +93,21 @@
           a {
             @if variable-exists(footer-colophon-link-color) {
               color: $footer-colophon-link-color;
-            } @else {
+            }
+
+            @else {
               color: tint($black, 20%);
             }
 
             &:hover, &:focus, &:active {
               @if variable-exists(footer-colophon-link-hover-color) {
                 color: $footer-colophon-link-hover-color;
-              } @else {
+              }
+
+              @else {
                 color: $link-color;
               }
+
               @if variable-exists(footer-colophon-link-hover-border-bottom-color) {
                 border-bottom-color: $footer-colophon-link-hover-border-bottom-color;
               }
@@ -149,10 +163,13 @@
     .copyright {
       margin: -2px 0 8px 0;
       font-size: em(11);
+
       @if variable-exists(footer-color) {
-          color: $footer-color;
-      } @else {
-          color: $gray; // WCAG 2.0 AA requirements
+        color: $footer-color;
+      }
+
+      @else {
+        color: $gray; // WCAG 2.0 AA requirements
       }
 
       @include text-align(left);

--- a/lms/static/sass/shared/_footer.scss
+++ b/lms/static/sass/shared/_footer.scss
@@ -9,7 +9,7 @@
   box-shadow: 0 -1px 5px 0 $shadow-l1;
   border-top: 1px solid tint($m-gray, 50%);
   padding: 25px ($baseline/2) ($baseline*1.5) ($baseline/2);
-  background: $body-bg;
+  background: $footer-bg;
   clear: both;
 
   footer#footer-openedx {

--- a/lms/static/sass/shared/_footer.scss
+++ b/lms/static/sass/shared/_footer.scss
@@ -32,11 +32,19 @@
       @include transition(link-color 0.15s ease-in-out 0s, border 0.15s ease-in-out 0s);
 
       border-bottom: none;
-      color: $link-color;
+      @if variable-exists(footer-legal-link-color) {
+        color: $footer-legal-link-color;
+      } @else {
+        color: $link-color;
+      }
       text-decoration: none !important;
 
       &:hover, &:focus, &:active {
-        border-bottom: 1px dotted $link-color;
+        @if variable-exists(footer-legal-link-hover-border-bottom-color) {
+          border-bottom: 1px dotted $footer-legal-link-hover-border-bottom-color;
+        } @else {
+          border-bottom: 1px dotted $link-color;
+        }
       }
     }
 

--- a/lms/static/sass/views/_account-settings.scss
+++ b/lms/static/sass/views/_account-settings.scss
@@ -88,7 +88,9 @@
 
           @if variable-exists(account-settings-nav-hover-border-bottom-color) {
             border-bottom-color: $account-settings-nav-hover-border-bottom-color;
-          } @else {
+          }
+
+          @else {
             border-bottom-color: $courseware-border-bottom-color;
           }
         }
@@ -96,7 +98,9 @@
         &.active {
           @if variable-exists(account-settings-nav-border-bottom-color) {
             border-bottom-color: $account-settings-nav-border-bottom-color;
-          } @else {
+          }
+
+          @else {
             border-bottom-color: theme-color("dark");
           }
         }
@@ -178,9 +182,12 @@
 
                 @if variable-exists(account-settings-form-caret-color) {
                   border-top: 7px solid $account-settings-form-caret-color;
-                } @else {
+                }
+
+                @else {
                   border-top: 7px solid $blue;
                 }
+
                 position: absolute;
                 right: 10px;
                 bottom: 20px;

--- a/lms/static/sass/views/_account-settings.scss
+++ b/lms/static/sass/views/_account-settings.scss
@@ -85,11 +85,20 @@
         &:hover,
         &:focus {
           text-decoration: none;
-          border-bottom-color: $courseware-border-bottom-color;
+
+          @if variable-exists(account-settings-nav-hover-border-bottom-color) {
+            border-bottom-color: $account-settings-nav-hover-border-bottom-color;
+          } @else {
+            border-bottom-color: $courseware-border-bottom-color;
+          }
         }
 
         &.active {
-          border-bottom-color: theme-color("dark");
+          @if variable-exists(account-settings-nav-border-bottom-color) {
+            border-bottom-color: $account-settings-nav-border-bottom-color;
+          } @else {
+            border-bottom-color: theme-color("dark");
+          }
         }
       }
     }
@@ -166,7 +175,12 @@
                 content: "";
                 border-left: 6px solid transparent;
                 border-right: 6px solid transparent;
-                border-top: 7px solid $blue;
+
+                @if variable-exists(account-settings-form-caret-color) {
+                  border-top: 7px solid $account-settings-form-caret-color;
+                } @else {
+                  border-top: 7px solid $blue;
+                }
                 position: absolute;
                 right: 10px;
                 bottom: 20px;
@@ -213,6 +227,8 @@
             color: $blue;
             padding: 11px 14px;
             line-height: normal;
+
+            @extend %btn-account-settings-page;
           }
         }
 
@@ -502,6 +518,8 @@
         padding: 11px 14px;
         line-height: normal;
         margin: 20px 0;
+
+        @extend %btn-account-settings-page;
       }
 
       .paragon__modal-open {

--- a/lms/static/sass/views/_homepage.scss
+++ b/lms/static/sass/views/_homepage.scss
@@ -27,7 +27,11 @@ $learn-more-horizontal-position: calc(50% - 100px); // calculate the left positi
       @include transition(all $tmg-f3 linear 0s);
 
       position: relative;
-      border-bottom: 3px solid $action-primary-bg;
+      @if variable-exists(homepage-course-card-border-bottom-color) {
+        border-bottom: 3px solid $homepage-course-card-border-bottom-color;
+      } @else {
+        border-bottom: 3px solid $action-primary-bg;
+      }
       box-shadow: 0 1px 10px 0 $black-t0, inset 0 0 0 1px $white-t3;
       background: $body-bg;
       width: 100%;
@@ -69,8 +73,16 @@ $learn-more-horizontal-position: calc(50% - 100px); // calculate the left positi
           height: ($baseline*2.5);
           border-color: theme-color("primary");
           border-radius: 3px;
-          background: theme-color("primary");
-          color: $white;
+          @if variable-exists(homepage-course-card-btn-learn-more-bg) {
+            background: $homepage-course-card-btn-learn-more-bg;
+          } @else {
+            background: theme-color("primary");
+          }
+          @if variable-exists(homepage-course-card-btn-learn-more-color) {
+            color: $homepage-course-card-btn-learn-more-color;
+          } @else {
+            color: $white;
+          }
           line-height: ($baseline*2.5);
           text-align: center;
           opacity: 0;
@@ -117,7 +129,11 @@ $learn-more-horizontal-position: calc(50% - 100px); // calculate the left positi
           margin: ($baseline*0.25) 0 ($baseline*1.75) 0;
           padding: 0 ($baseline*0.75);
           height: $course-title-height;
-          color: $link-color;
+          @if variable-exists(homepage-course-card-title-color) {
+            color: $homepage-course-card-title-color;
+          } @else {
+            color: $link-color;
+          }
         }
 
         .course-date {

--- a/lms/static/sass/views/_homepage.scss
+++ b/lms/static/sass/views/_homepage.scss
@@ -27,11 +27,15 @@ $learn-more-horizontal-position: calc(50% - 100px); // calculate the left positi
       @include transition(all $tmg-f3 linear 0s);
 
       position: relative;
+
       @if variable-exists(homepage-course-card-border-bottom-color) {
         border-bottom: 3px solid $homepage-course-card-border-bottom-color;
-      } @else {
+      }
+
+      @else {
         border-bottom: 3px solid $action-primary-bg;
       }
+
       box-shadow: 0 1px 10px 0 $black-t0, inset 0 0 0 1px $white-t3;
       background: $body-bg;
       width: 100%;
@@ -73,16 +77,23 @@ $learn-more-horizontal-position: calc(50% - 100px); // calculate the left positi
           height: ($baseline*2.5);
           border-color: theme-color("primary");
           border-radius: 3px;
+
           @if variable-exists(homepage-course-card-btn-learn-more-bg) {
             background: $homepage-course-card-btn-learn-more-bg;
-          } @else {
+          }
+
+          @else {
             background: theme-color("primary");
           }
+
           @if variable-exists(homepage-course-card-btn-learn-more-color) {
             color: $homepage-course-card-btn-learn-more-color;
-          } @else {
+          }
+
+          @else {
             color: $white;
           }
+
           line-height: ($baseline*2.5);
           text-align: center;
           opacity: 0;
@@ -129,9 +140,12 @@ $learn-more-horizontal-position: calc(50% - 100px); // calculate the left positi
           margin: ($baseline*0.25) 0 ($baseline*1.75) 0;
           padding: 0 ($baseline*0.75);
           height: $course-title-height;
+
           @if variable-exists(homepage-course-card-title-color) {
             color: $homepage-course-card-title-color;
-          } @else {
+          }
+
+          @else {
             color: $link-color;
           }
         }

--- a/lms/static/sass/views/_login-register.scss
+++ b/lms/static/sass/views/_login-register.scss
@@ -74,7 +74,11 @@
     margin-top: $baseline;
     letter-spacing: normal;
     font-family: $font-family-sans-serif;
-    color: $uxpl-blue-hover-active;
+    @if variable-exists(logistration-form-header-color) {
+      color: $logistration-form-header-color;
+    } @else {
+      color: $uxpl-blue-hover-active;
+    }
   }
 
   h3 {
@@ -93,7 +97,8 @@
   }
 
   a {
-    text-decoration: underline;
+      text-decoration: underline;
+      @extend %logistration-form-link;
   }
 }
 
@@ -384,7 +389,7 @@
       text-decoration: none;
       text-shadow: none;
       font-family: $font-family-sans-serif;
-
+      @extend %logistration-form-link;
       &:hover,
       &:focus {
         text-decoration: underline;
@@ -501,7 +506,7 @@
 
   .action-primary {
     @extend %btn-primary-blue;
-
+    @extend %logistration-form-btn-action-primary;
     padding: 1ex 1em;
     text-transform: none;
     font-weight: 600;
@@ -895,4 +900,3 @@
 body.open-modal {
   overflow: hidden;
 }
-

--- a/lms/static/sass/views/_login-register.scss
+++ b/lms/static/sass/views/_login-register.scss
@@ -74,9 +74,12 @@
     margin-top: $baseline;
     letter-spacing: normal;
     font-family: $font-family-sans-serif;
+
     @if variable-exists(logistration-form-header-color) {
       color: $logistration-form-header-color;
-    } @else {
+    }
+
+    @else {
       color: $uxpl-blue-hover-active;
     }
   }
@@ -97,8 +100,9 @@
   }
 
   a {
-      text-decoration: underline;
-      @extend %logistration-form-link;
+    text-decoration: underline;
+
+    @extend %logistration-form-link;
   }
 }
 
@@ -389,7 +393,9 @@
       text-decoration: none;
       text-shadow: none;
       font-family: $font-family-sans-serif;
+
       @extend %logistration-form-link;
+
       &:hover,
       &:focus {
         text-decoration: underline;
@@ -507,6 +513,7 @@
   .action-primary {
     @extend %btn-primary-blue;
     @extend %logistration-form-btn-action-primary;
+
     padding: 1ex 1em;
     text-transform: none;
     font-weight: 600;


### PR DESCRIPTION
This PR adds fixes and additional SASS variables to the default Open edX theme in order to apply styles uniformly to bootstrap and non-bootstrap pages and also easily customize the colors and styles. This includes the changes that were demonstrated during the October 2019 community hangouts.

**JIRA tickets**: None

**Discussions**: https://discuss.openedx.org/t/open-edx-theming-improvements-and-simplification/461

**Dependencies**: None

**Sandbox URL**: TBD - sandbox is being provisioned.

**Merge deadline**: None

**Testing instructions**:
1. Clone the source branch of this PR.
1. Compile the default theme and verify that it looks and behaves similar to the current vanilla theme.
2. Customize the theming by providing values for the SASS variables for the newly added variables and verify that they work as expected and are applied uniformly.  [This skeleton theme](https://github.com/open-craft/edx-simple-theme/tree/guruprasad/BB-1847-new-simple-theme-skeleton) with the variables added in `lms/static/sass/common-variables.scss` can be used for testing. An example `common-variables.scss` file is [here](https://gist.github.com/giovannicimolin/96d5859673b0dd4b70fd6f95ee652d3f).

**Author notes, concerns and questions**:
1. The biggest challenge in this work is to retain the existing defaults while providing a way to easily customize the colors and styles. In many cases, the defaults are defined in external libraries (edX patter library for example) or using mixins, inheritance, hard-coded SASS variables and are available in only one of the two theming systems. So duplicating the default definitions is often required to make the styles apply uniformly across the systems. A way to avoid this is to use SASS conditions like `@if variable-exists(my-custom-variable)` to conditionally use the new SASS variables. But that will become unmaintainable and ugly when used for a lot of variables.
1. A lot of the SASS variables added in this PR, target specific elements of various pages and hence are tightly coupled to the current UI implementation. When more components get migrated to React microfrontends, which is likely to have its own theming, the UI changes will break the changes made here. Even if it is possible to fix the issues, 3 theming systems will be in use till the whole codebase is updated to use a single theming system and that is likely going to take a lot of time.
1. Is there a better way to do this? These changes were initially created for a theme skeleton to be used along with the `simple-theme` role in the configuration repository. However, we want to upstream the changes so that everyone benefits from the changes and also to reduce the maintenance work required to keep the theme skeleton working for every new release of Open edX.

    One option that we considered was to propose including this as one of the default themes that ship in the edx-platform codebase, however, that would also mean that the improvements made for this will not be usable by most users of the platform unless they specifically switch to this theme.
1. The default theme defines a color palette which has colors like `primary`, `inverse`, `dark`, `light` etc. defined. However, these are neither used everywhere consistently nor there are guidelines for where to use each of those. In some places, some SASS color variables are used and there are comments which indicate that they are used to meet the WCAG guidelines. But these are not used everywhere and hence it is not clear if those can and should be overridden.

**Known issues and limitations**:
* This PR doesn't attempt to add customizations for every page in the LMS or every element in all the pages it customizes. It only tries to allow get an uniform application of colors. The details of what pages can be themed and what cannot be is mentioned in [this review comment](https://github.com/edx/edx-platform/pull/22543#pullrequestreview-362180360).
* If possible, I will try to add similar customizations to a few more low-hanging fruits.
* The `stylelint` checks are failing in the files modified by this PR but all the errors corresponding to the modified lines have been fixed. But the linter still lists the errors in other unmodified lines in those files.
* If in the future, someone else changes the pages customized by this PR but does not use allow customization for any new changes, those will look odd and out of place. So the style of changes made by this PR will not be very useful if it is a one-off change and all the future changes don't care about the customizability.

**Reviewers**
- [ ] @giovannicimolin 
- [ ] edX reviewer[s] TBD