### PR TITLE
DISCO-1522: check if enrolled before congrats message

### DIFF
--- a/common/djangoapps/course_modes/tests/test_views.py
+++ b/common/djangoapps/course_modes/tests/test_views.py
@@ -199,6 +199,29 @@ class CourseModeViewTest(CatalogIntegrationMixin, UrlResetMixin, ModuleStoreTest
         else:
             self.assertNotContains(response, "Credit")
 
+    @httpretty.activate
+    @ddt.data(True, False)
+    def test_congrats_on_enrollment_message(self, create_enrollment):
+        # Create the course mode
+        CourseModeFactory.create(mode_slug='verified', course_id=self.course.id)
+
+        if create_enrollment:
+            CourseEnrollmentFactory(
+                is_active=True,
+                course_id=self.course.id,
+                user=self.user
+            )
+
+        # Check whether congratulations message is shown on the page
+        # This should *only* be shown when an enrollment exists
+        url = reverse('course_modes_choose', args=[six.text_type(self.course.id)])
+        response = self.client.get(url)
+
+        if create_enrollment:
+            self.assertContains(response, "Congratulations!  You are now enrolled in")
+        else:
+            self.assertNotContains(response, "Congratulations!  You are now enrolled in")
+
     @ddt.data('professional', 'no-id-professional')
     def test_professional_enrollment(self, mode):
         # The only course mode is professional ed

--- a/common/djangoapps/course_modes/views.py
+++ b/common/djangoapps/course_modes/views.py
@@ -191,9 +191,11 @@ class ChooseModeView(View):
             )
         )
 
-        title_content = _("Congratulations!  You are now enrolled in {course_name}").format(
-            course_name=course.display_name_with_default
-        )
+        title_content = ''
+        if enrollment_mode:
+            title_content = _("Congratulations!  You are now enrolled in {course_name}").format(
+                course_name=course.display_name_with_default
+            )
 
         context["title_content"] = title_content
 


### PR DESCRIPTION
This helps out the Verified Only case where the user
is not first enrolled as an audit learner.

https://openedx.atlassian.net/browse/DISCO-1522

### Please consider the following when opening a pull request:

- Link to the relevant JIRA ticket(s) and tag any relevant team(s).
- Squash your changes down into one or more discrete commits.
  In each commit, include description that could help a developer
  several months from now.
- If running `make upgrade`, run _as close to the time of merging as possible_
  to avoid accidentally downgrading someone else's package.
  Put the output of `make upgrade` in its own separate commit,
  decoupled from other code changes.
- Aim for comprehensive test coverage, but remember that
  automated testing isn't a substitute for manual verification.
- Carefully consider naming, code organization, dependencies when adding new code.
  Code that is amenable to refactoring and improvement benefits all platform developers,
  especially given the size and scope of edx-platform.
  Consult existing Architectural Decision Records (ADRs),
  including those concerning the app(s) you are changing and
  [those concerning edx-platform as a whole](https://github.com/edx/edx-platform/tree/master/docs/decisions).
