### PR TITLE
Ensure that photo verification data is correctly typed.

### DIFF
--- a/lms/djangoapps/verify_student/management/commands/retry_failed_photo_verifications.py
+++ b/lms/djangoapps/verify_student/management/commands/retry_failed_photo_verifications.py
@@ -31,7 +31,7 @@ class Command(BaseCommand):
             dest='verification_ids',
             action='store',
             nargs='+',
-            type=int,
+            type=str,
             help='verifications id used to retry verification'
         )
 

--- a/lms/djangoapps/verify_student/models.py
+++ b/lms/djangoapps/verify_student/models.py
@@ -837,7 +837,7 @@ class SoftwareSecurePhotoVerification(PhotoVerification):
         face_aes_key = codecs.decode(face_aes_key_str, 'hex')
         rsa_key_str = settings.VERIFY_STUDENT["SOFTWARE_SECURE"]["RSA_PUBLIC_KEY"]
         rsa_encrypted_face_aes_key = rsa_encrypt(face_aes_key, rsa_key_str)
-        return base64.b64encode(rsa_encrypted_face_aes_key)
+        return base64.b64encode(rsa_encrypted_face_aes_key).decode('utf-8')
 
     def create_request(self, copy_id_photo_from=None):
         """

--- a/lms/djangoapps/verify_student/ssencrypt.py
+++ b/lms/djangoapps/verify_student/ssencrypt.py
@@ -176,7 +176,7 @@ def generate_signed_message(method, headers_dict, body_dict, access_key, secret_
 
     # hmac needs a byte string for it's starting key, can't be unicode.
     hashed = hmac.new(secret_key.encode('utf-8'), message.encode('utf-8'), sha256)
-    signature = binascii.b2a_base64(hashed.digest()).rstrip(b'\n')
+    signature = binascii.b2a_base64(hashed.digest()).rstrip(b'\n').decode('utf-8')
     authorization_header = u"SSI {}:{}".format(access_key, signature)
 
     message += '\n'


### PR DESCRIPTION
There were cases where we needed to encode things to codecs other than
ascii.  In these cases, python returns byte strings but we needed them
to be unicode so that they serialize correctly later when we combine
them with other unicode strings.

### Please consider the following when opening a pull request:

- Link to the relevant JIRA ticket(s) and tag any relevant team(s).
- Squash your changes down into one or more discrete commits.
  In each commit, include description that could help a developer
  several months from now.
- If running `make upgrade`, run _as close to the time of merging as possible_
  to avoid accidentally downgrading someone else's package.
  Put the output of `make upgrade` in its own separate commit,
  decoupled from other code changes.
- Aim for comprehensive test coverage, but remember that
  automated testing isn't a substitute for manual verification.
- Carefully consider naming, code organization, dependencies when adding new code.
  Code that is amenable to refactoring and improvement benefits all platform developers,
  especially given the size and scope of edx-platform.
  Consult existing Architectural Decision Records (ADRs),
  including those concerning the app(s) you are changing and
  [those concerning edx-platform as a whole](https://github.com/edx/edx-platform/tree/master/docs/decisions).
