### PR TITLE
Don't return duplicated programs for course_staff user

### DIFF
--- a/lms/djangoapps/program_enrollments/rest_api/v1/tests/test_views.py
+++ b/lms/djangoapps/program_enrollments/rest_api/v1/tests/test_views.py
@@ -1425,18 +1425,52 @@ class UserProgramReadOnlyAccessGetTests(EnrollmentsDataMixin, APITestCase):
         assert len(response.data) == 1
         mock_get_programs.assert_called_once_with(course=self.course_id)
 
-    def test_course_staff_of_multiple_courses(self):
-        other_course_key = CourseKey.from_string('course-v1:edX+ToyX+Other_Course')
+    @ddt.data(
+        (
+            ['garbage-program'],
+            ['garbage-life']
+        ),
+        (
+            ['garbage-program', 'garbage-life'],
+            ['garbage-program', 'garbage-life']
+        )
+    )
+    @ddt.unpack
+    def test_course_staff_of_multiple_courses(
+        self,
+        program_slugs_to_return_first,
+        program_slugs_to_return_second
+    ):
+        def find_program_by_marketing_slug(slug, program_list):
+            for program in program_list:
+                if program['marketing_slug'] == slug:
+                    return program
+            return None
 
+        other_course_key = CourseKey.from_string('course-v1:edX+ToyX+Other_Course')
+        CourseOverviewFactory(id=other_course_key)
+        CourseRunFactory.create(key=text_type(other_course_key))
         CourseEnrollmentFactory.create(course_id=other_course_key, user=self.course_staff)
         CourseStaffRole(other_course_key).add_users(self.course_staff)
-
         self.client.login(username=self.course_staff.username, password=self.password)
+
+        programs_to_return_first = [
+            find_program_by_marketing_slug(
+                p_slug,
+                self.mock_program_data
+            ) for p_slug in program_slugs_to_return_first
+        ]
+        programs_to_return_second = [
+            find_program_by_marketing_slug(
+                p_slug,
+                self.mock_program_data
+            ) for p_slug in program_slugs_to_return_second
+        ]
 
         with mock.patch(
             _VIEW_PATCH_FORMAT.format('get_programs'),
             autospec=True,
-            side_effect=[[self.mock_program_data[0]], [self.mock_program_data[2]]]
+            side_effect=[programs_to_return_first, programs_to_return_second]
         ) as mock_get_programs:
             response = self.client.get(reverse(self.view_name) + '?type=masters')
 

--- a/lms/djangoapps/program_enrollments/rest_api/v1/views.py
+++ b/lms/djangoapps/program_enrollments/rest_api/v1/views.py
@@ -763,14 +763,14 @@ class UserProgramReadOnlyAccessView(DeveloperErrorViewMixin, PaginatedAPIView):
         This function would take a list of course runs the user is staff of, and then
         try to get the Masters program associated with each course_runs.
         """
-        program_list = []
+        program_dict = {}
         for course_key in self.get_course_keys_user_is_staff_for(user):
             course_run_programs = get_programs(course=course_key)
             for course_run_program in course_run_programs:
                 if course_run_program and course_run_program.get('type').lower() == program_type_filter:
-                    program_list.append(course_run_program)
+                    program_dict[course_run_program['uuid']] = course_run_program
 
-        return program_list
+        return program_dict.values()
 
 
 class ProgramCourseEnrollmentOverviewView(


### PR DESCRIPTION
Fix the bug where we return many programs if the number of courses the staff user is enrolled in are many

See the issue better demo'd at the screenshot below:
<img width="718" alt="Screen Shot 2019-12-18 at 3 19 02 PM" src="https://user-images.githubusercontent.com/16839373/71195366-c7f03d00-225b-11ea-96fe-ce1766964eef.png">

@edx/masters-devs Please help review