### PR TITLE
Instantiate idv attempt with a string photo_id_key.

### DIFF
--- a/lms/djangoapps/verify_student/models.py
+++ b/lms/djangoapps/verify_student/models.py
@@ -688,7 +688,7 @@ class SoftwareSecurePhotoVerification(PhotoVerification):
 
         # Update our record fields
         if six.PY3:
-            self.photo_id_key = codecs.encode(rsa_encrypted_aes_key, 'base64')
+            self.photo_id_key = codecs.encode(rsa_encrypted_aes_key, 'base64').decode('utf-8')
         else:
             self.photo_id_key = rsa_encrypted_aes_key.encode('base64')
 


### PR DESCRIPTION
When we run the management command, the photo_id_key is retrieved
through the orm and so is represented as a string.  However, when we do
the initial attempt, the object is instantiated and we refer to the key
without having decoded it.  The photo_id_key is sent as a part of the
request to software secure.  And if we have a byte representation their
signature checking will fail.

This is why the management command worked even when the site didn't.
It was getting a cleaned key via the orm.

