### PR TITLE
Only store bytes to s3 via boto2.

### DIFF
--- a/lms/djangoapps/instructor_task/models.py
+++ b/lms/djangoapps/instructor_task/models.py
@@ -279,6 +279,11 @@ class DjangoStorageReportStore(ReportStore):
         object, ready to be read from the beginning.
         """
         path = self.path_to(course_id, filename)
+        # See https://github.com/boto/boto/issues/2868
+        # Boto doesn't play nice with unicod in python3
+        if not six.PY2:
+            buff = ContentFile(buff.read().encode('utf-8'))
+
         self.storage.save(path, buff)
 
     def store_rows(self, course_id, filename, rows):


### PR DESCRIPTION
https://github.com/boto/boto/issues/2868

In python 3 contentfile can act like a file but return unicode strings.
Boto doesn't like that and it causes issues when encoding the bytes for
transfer to s3.

### Please consider the following when opening a pull request:

- Link to the relevant JIRA ticket(s) and tag any relevant team(s).
- Squash your changes down into one or more discrete commits.
  In each commit, include description that could help a developer
  several months from now.
- If running `make upgrade`, run _as close to the time of merging as possible_
  to avoid accidentally downgrading someone else's package.
  Put the output of `make upgrade` in its own separate commit,
  decoupled from other code changes.
- Aim for comprehensive test coverage, but remember that
  automated testing isn't a substitute for manual verification.
- Carefully consider naming, code organization, dependencies when adding new code.
  Code that is amenable to refactoring and improvement benefits all platform developers,
  especially given the size and scope of edx-platform.
  Consult existing Architectural Decision Records (ADRs),
  including those concerning the app(s) you are changing and
  [those concerning edx-platform as a whole](https://github.com/edx/edx-platform/tree/master/docs/decisions).
