### PR TITLE
PROD-1113: Fix retry_failed_photo_verifications.

### DIFF
--- a/lms/djangoapps/verify_student/management/commands/retry_failed_photo_verifications.py
+++ b/lms/djangoapps/verify_student/management/commands/retry_failed_photo_verifications.py
@@ -46,7 +46,8 @@ class Command(BaseCommand):
 
         sspv_retry_config = SSPVerificationRetryConfig.current()
         if not sspv_retry_config.enabled:
-            raise CommandError('SSPVerificationRetryConfig is disabled, but --args-from-database was requested.')
+            log.warning('SSPVerificationRetryConfig is disabled or empty, but --args-from-database was requested.')
+            return {}
 
         # We don't need fancy shell-style whitespace/quote handling - none of our arguments are complicated
         argv = sspv_retry_config.arguments.split()

--- a/lms/djangoapps/verify_student/management/commands/tests/test_verify_student.py
+++ b/lms/djangoapps/verify_student/management/commands/tests/test_verify_student.py
@@ -73,10 +73,14 @@ class TestVerifyStudentCommand(MockS3Mixin, TestCase):
         """Test management command arguments injected from config model."""
         # Nothing in the database, should default to disabled
 
-        # pylint: disable=deprecated-method, useless-suppression
-        with self.assertRaisesRegex(CommandError, 'SSPVerificationRetryConfig is disabled*'):
+        with LogCapture(LOGGER_NAME) as log:
             call_command('retry_failed_photo_verifications', '--args-from-database')
-
+            log.check_present(
+                (
+                    LOGGER_NAME, 'WARNING',
+                    u"SSPVerificationRetryConfig is disabled or empty, but --args-from-database was requested."
+                ),
+            )
         # Add a config
         config = SSPVerificationRetryConfig.current()
         config.arguments = '--verification-ids 1 2 3'


### PR DESCRIPTION
Allow the management command to work when --args-from-database is specified, but the database is empty.

### Please consider the following when opening a pull request:

- Link to the relevant JIRA ticket(s) and tag any relevant team(s).
- Squash your changes down into one or more discrete commits.
  In each commit, include description that could help a developer
  several months from now.
- If running `make upgrade`, run _as close to the time of merging as possible_
  to avoid accidentally downgrading someone else's package.
  Put the output of `make upgrade` in its own separate commit,
  decoupled from other code changes.
- Aim for comprehensive test coverage, but remember that
  automated testing isn't a substitute for manual verification.
- Carefully consider naming, code organization, dependencies when adding new code.
  Code that is amenable to refactoring and improvement benefits all platform developers,
  especially given the size and scope of edx-platform.
  Consult existing Architectural Decision Records (ADRs),
  including those concerning the app(s) you are changing and
  [those concerning edx-platform as a whole](https://github.com/edx/edx-platform/tree/master/docs/decisions).
