### PR TITLE
BOM-1117

### DIFF
--- a/cms/djangoapps/api/urls.py
+++ b/cms/djangoapps/api/urls.py
@@ -7,5 +7,5 @@ from __future__ import absolute_import
 from django.conf.urls import include, url
 
 urlpatterns = [
-    url(r'^v1/', include('cms.djangoapps.api.v1.urls', namespace='v1')),
+    url(r'^v1/', include('cms.djangoapps.api.v1.urls', namespace='v1', app_name='v1')),
 ]

--- a/cms/urls.py
+++ b/cms/urls.py
@@ -56,7 +56,7 @@ urlpatterns = [
         contentstore.views.component_handler, name='component_handler'),
     url(r'^xblock/resource/(?P<block_type>[^/]*)/(?P<uri>.*)$',
         openedx.core.djangoapps.common_views.xblock.xblock_resource, name='xblock_resource_url'),
-    url(r'', include('openedx.core.djangoapps.xblock.rest_api.urls', namespace='xblock_api')),
+    url(r'', include('openedx.core.djangoapps.xblock.rest_api.urls', namespace='xblock_api', app_name='xblock_api')),
     url(r'^not_found$', contentstore.views.not_found, name='not_found'),
     url(r'^server_error$', contentstore.views.server_error, name='server_error'),
     url(r'^organizations$', OrganizationListView.as_view(), name='organizations'),
@@ -80,7 +80,7 @@ urlpatterns = [
 
     # For redirecting to help pages.
     url(r'^help_token/', include('help_tokens.urls')),
-    url(r'^api/', include('cms.djangoapps.api.urls', namespace='api')),
+    url(r'^api/', include('cms.djangoapps.api.urls', namespace='api', app_name='api')),
 
     # restful api
     url(r'^$', contentstore.views.howitworks, name='homepage'),
@@ -246,7 +246,7 @@ if settings.FEATURES.get('CERTIFICATES_HTML_VIEW'):
     ]
 
 # Maintenance Dashboard
-urlpatterns.append(url(r'^maintenance/', include('maintenance.urls', namespace='maintenance')))
+urlpatterns.append(url(r'^maintenance/', include('maintenance.urls', namespace='maintenance', app_name='maintenance')))
 
 if settings.DEBUG:
     try:

--- a/lms/djangoapps/course_goals/urls.py
+++ b/lms/djangoapps/course_goals/urls.py
@@ -13,5 +13,5 @@ router.register(r'course_goals', CourseGoalViewSet, base_name='course_goal')
 
 app_name = 'course_goals'
 urlpatterns = [
-    url(r'^v0/', include(router.urls, namespace='v0')),
+    url(r'^v0/', include(router.urls, namespace='v0', app_name='v0')),
 ]

--- a/lms/djangoapps/experiments/urls.py
+++ b/lms/djangoapps/experiments/urls.py
@@ -14,5 +14,5 @@ router.register(r'key-value', views.ExperimentKeyValueViewSet, base_name='key_va
 app_name = 'experiments'
 urlpatterns = [
     url(r'^v0/custom/REV-934/', views_custom.Rev934.as_view(), name='rev_934'),
-    url(r'^v0/', include(router.urls, namespace='v0')),
+    url(r'^v0/', include(router.urls, namespace='v0', app_name='v0')),
 ]

--- a/lms/urls.py
+++ b/lms/urls.py
@@ -140,7 +140,10 @@ urlpatterns = [
 
     url(r'^dashboard/', include('learner_dashboard.urls')),
     url(r'^api/experiments/', include('experiments.urls', namespace='api_experiments')),
-    url(r'^api/discounts/', include('openedx.features.discounts.urls', namespace='api_discounts')),
+    url(
+        r'^api/discounts/',
+        include('openedx.features.discounts.urls', namespace='api_discounts', app_name='api_discounts')
+    ),
 ]
 
 if settings.FEATURES.get('ENABLE_MOBILE_REST_API'):
@@ -273,7 +276,7 @@ urlpatterns += [
     ),
 
     # New (Blockstore-based) XBlock REST API
-    url(r'', include('openedx.core.djangoapps.xblock.rest_api.urls', namespace='xblock_api')),
+    url(r'', include('openedx.core.djangoapps.xblock.rest_api.urls', namespace='xblock_api', app_name='xblock_api')),
 
     url(
         r'^courses/{}/xqueue/(?P<userid>[^/]*)/(?P<mod_id>.*?)/(?P<dispatch>[^/]*)$'.format(
@@ -520,7 +523,7 @@ urlpatterns += [
     ),
 
     # Cohorts management API
-    url(r'^api/cohorts/', include('openedx.core.djangoapps.course_groups.urls', namespace='api_cohorts')),
+    url(r'^api/cohorts/', include('openedx.core.djangoapps.course_groups.urls', namespace='api_cohorts', app_name='api_cohorts')),
 
     # Cohorts management
     url(
@@ -810,7 +813,7 @@ if settings.FEATURES.get('ENABLE_OAUTH2_PROVIDER'):
         # These URLs contain the django-oauth2-provider default behavior.  It exists to provide
         # URLs for django-oauth2-provider to call using reverse() with the oauth2 namespace, and
         # also to maintain support for views that have not yet been wrapped in dispatch views.
-        url(r'^oauth2/', include('edx_oauth2_provider.urls', namespace='oauth2')),
+        url(r'^oauth2/', include('edx_oauth2_provider.urls', namespace='oauth2', app_name='oauth2')),
         # The /_o/ prefix exists to provide a target for code in django-oauth-toolkit that
         # uses reverse() with the 'oauth2_provider' namespace.  Developers should not access these
         # views directly, but should rather use the wrapped views at /oauth2/

--- a/openedx/core/lib/api/tests/test_authentication.py
+++ b/openedx/core/lib/api/tests/test_authentication.py
@@ -57,7 +57,7 @@ class OAuth2AuthenticationDebug(authentication.OAuth2AuthenticationAllowInactive
 
 
 urlpatterns = [
-    url(r'^oauth2/', include('provider.oauth2.urls', namespace='oauth2')),
+    url(r'^oauth2/', include('provider.oauth2.urls', namespace='oauth2', app_name='oauth2')),
     url(
         r'^oauth2-test/$',
         MockView.as_view(authentication_classes=[authentication.OAuth2AuthenticationAllowInactiveUser])


### PR DESCRIPTION
Specifying a namespace in django.conf.urls.include() without providing an app_name is deprecated.
Adding the app_name attribute in the included module.

### Please consider the following when opening a pull request:

- Link to the relevant JIRA ticket(s) and tag any relevant team(s).
- Squash your changes down into one or more discrete commits.
  In each commit, include description that could help a developer
  several months from now.
- If running `make upgrade`, run _as close to the time of merging as possible_
  to avoid accidentally downgrading someone else's package.
  Put the output of `make upgrade` in its own separate commit,
  decoupled from other code changes.
- Aim for comprehensive test coverage, but remember that
  automated testing isn't a substitute for manual verification.
- Carefully consider naming, code organization, dependencies when adding new code.
  Code that is amenable to refactoring and improvement benefits all platform developers,
  especially given the size and scope of edx-platform.
  Consult existing Architectural Decision Records (ADRs),
  including those concerning the app(s) you are changing and
  [those concerning edx-platform as a whole](https://github.com/edx/edx-platform/tree/master/docs/decisions).
