### PR TITLE
Fix Targeted Feedback HTML

### DIFF
--- a/common/lib/capa/capa/customrender.py
+++ b/common/lib/capa/capa/customrender.py
@@ -11,8 +11,8 @@ from __future__ import absolute_import
 import logging
 import re
 import xml.sax.saxutils as saxutils
-from cgi import escape as cgi_escape
 
+from django.utils import html
 from lxml import etree
 
 from .registry import TagRegistry
@@ -126,9 +126,10 @@ class TargetedFeedbackRenderer(object):
         Return the contents of this tag, rendered to html, as an etree element.
         """
         # xss-lint: disable=python-wrap-html
-        html = '<section class="targeted-feedback-span"><span>{}</span></section>'.format(etree.tostring(self.xml))
+        html_str = '<section class="targeted-feedback-span"><span>{}</span></section>'.format(
+            etree.tostring(self.xml, encoding='unicode'))
         try:
-            xhtml = etree.XML(html)
+            xhtml = etree.XML(html_str)
 
         except Exception as err:  # pylint: disable=broad-except
             if self.system.DEBUG:
@@ -140,7 +141,7 @@ class TargetedFeedbackRenderer(object):
                         <p>Failed to construct targeted feedback from <pre>{html}</pre></p>
                       </div>
                     </html>
-                """.format(err=cgi_escape(err), html=cgi_escape(html))
+                """.format(err=html.escape(err), html=html.escape(html_str))
                 log.error(msg)
                 return etree.XML(msg)
             else:


### PR DESCRIPTION
`etree.tostring()` returns bytes instead of string which when converted back to XML, to be rendered as etree element, presents stray characters.

[PROD-1116](https://openedx.atlassian.net/browse/PROD-1116)

#### NOTES:
cgi.escape is deprecated, so I have replaced it with html.escape based on deprecation warning 
