### PR TITLE
Don't try to typset mathjax if Hub has not loaded.

### DIFF
--- a/common/static/common/js/discussion/utils.js
+++ b/common/static/common/js/discussion/utils.js
@@ -485,7 +485,7 @@
         };
 
         DiscussionUtil.typesetMathJax = function(element) {
-            if (typeof MathJax !== 'undefined' && MathJax !== null) {
+            if (typeof MathJax !== 'undefined' && MathJax !== null && MathJax.Hub !== 'undefined') {
                 MathJax.Hub.Queue(['Typeset', MathJax.Hub, element[0]]);
             }
         };


### PR DESCRIPTION
In our tests there are times when Mathjax has been initialized but
Hub is still undefied.  In this case don't queue up typesetting.

Try to deal with errors like this: https://build.testeng.edx.org/job/edx-platform-js-pr/69871/testReport/junit/Javascript/Firefox/DiscussionThreadProfileView__body_with_1_images_and_untruncated_text/
