### PR TITLE
BB-1744: Remove flaky test related to MockS3Mixin [FOLLOW-UP]

### DIFF
--- a/lms/djangoapps/verify_student/management/commands/tests/test_send_verification_expiry_email.py
+++ b/lms/djangoapps/verify_student/management/commands/tests/test_send_verification_expiry_email.py
@@ -14,12 +14,10 @@ from django.core.management import call_command, CommandError
 from django.test.utils import override_settings
 from django.utils.timezone import now
 from mock import patch
-from student.tests.factories import CourseEnrollmentFactory, UserFactory
+from student.tests.factories import UserFactory
 from testfixtures import LogCapture
-from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
-from xmodule.modulestore.tests.factories import CourseFactory
 
-from common.test.utils import MockS3Mixin, py2_only
+from common.test.utils import MockS3Mixin
 from lms.djangoapps.verify_student.models import SoftwareSecurePhotoVerification
 from lms.djangoapps.verify_student.tests.test_models import FAKE_SETTINGS, mock_software_secure_post
 
@@ -28,7 +26,7 @@ LOGGER_NAME = 'lms.djangoapps.verify_student.management.commands.send_verificati
 
 @patch.dict(settings.VERIFY_STUDENT, FAKE_SETTINGS)
 @patch('lms.djangoapps.verify_student.models.requests.post', new=mock_software_secure_post)
-class TestSendVerificationExpiryEmail(MockS3Mixin, ModuleStoreTestCase):
+class TestSendVerificationExpiryEmail(MockS3Mixin):
     """ Tests for django admin command `send_verification_expiry_email` in the verify_student module """
 
     def setUp(self):
@@ -205,30 +203,6 @@ class TestSendVerificationExpiryEmail(MockS3Mixin, ModuleStoreTestCase):
         attempt = SoftwareSecurePhotoVerification.objects.get(pk=verification.id)
         self.assertEqual(len(mail.outbox), 1)
         self.assertIsNone(attempt.expiry_email_date)
-
-    @py2_only
-    def test_user_enrolled_in_verified_course(self):
-        """
-        Test that if the user is enrolled in verified track, then after sending the default no of
-        emails, `expiry_email_date` is updated to now() so that it's filtered in the future to send
-        email again.
-
-        Does not work on python 3 with the latest mongo driver version due to class inheritance issues.
-        """
-        user = UserFactory.create()
-        course = CourseFactory()
-        CourseEnrollmentFactory.create(user=user, course_id=course.id, mode='verified')
-        today = now().replace(hour=0, minute=0, second=0, microsecond=0)
-        verification = self.create_and_submit(user)
-        verification.status = 'approved'
-        verification.expiry_date = now() - timedelta(days=self.resend_days * (self.default_no_of_emails - 1))
-        verification.expiry_email_date = today - timedelta(days=self.resend_days)
-        verification.save()
-
-        call_command('send_verification_expiry_email')
-
-        attempt = SoftwareSecurePhotoVerification.objects.get(pk=verification.id)
-        self.assertEqual(attempt.expiry_email_date, today)
 
     def test_number_of_emails_sent(self):
         """


### PR DESCRIPTION
The MockS3Mixin prevents the correct setup of the ModuleStoreTestCase and made this test fail. Since the fix for this wasn't trivial, this test was skipped on python 3, and is now being removed.

This is a follow up PR, and these changes were requested on https://github.com/edx/edx-platform/pull/21197#discussion_r360989556.

**Reviewer:**
- [x] @feanil 