### PR TITLE
update bookmarks update_xblocks_cache celery task name

### DIFF
--- a/openedx/core/djangoapps/bookmarks/tasks.py
+++ b/openedx/core/djangoapps/bookmarks/tasks.py
@@ -144,7 +144,7 @@ def _update_xblocks_cache(course_key):
                 update_block_cache_if_needed(block_cache, block_data)
 
 
-@task(name=u'openedx.core.djangoapps.bookmarks.tasks.update_xblock_cache')
+@task(name=u'openedx.core.djangoapps.bookmarks.tasks.update_xblocks_cache')
 def update_xblocks_cache(course_id):
     """
     Update the XBlocks cache for a course.


### PR DESCRIPTION
Make it match the function name.

I noticed that the task name given for celery, `update_xblock_cache` does not match the function name, `update_xblocks_cache()`. I don't think it was breaking anything, but everywhere else in the code that tasks are named (that I looked at), they match the function name. It seems like consistency is the goal and this was just an oversight with the missing 's'.