### PR TITLE
Skip date comments on all bok-choy DB dumps

### DIFF
--- a/scripts/reset-test-db.sh
+++ b/scripts/reset-test-db.sh
@@ -93,7 +93,7 @@ rebuild_cache_for_db() {
 
     # dump_data does not dump the django_migrations table so we do it separately.
     echo "Saving the django_migrations table of the $db bok_choy DB to the filesystem."
-    mysqldump $MYSQL_HOST -u root --no-create-info "${databases["$db"]}" django_migrations > $DB_CACHE_DIR/bok_choy_migrations_data_$db.sql
+    mysqldump $MYSQL_HOST -u root --no-create-info --skip-comments --skip-dump-date "${databases["$db"]}" django_migrations > $DB_CACHE_DIR/bok_choy_migrations_data_$db.sql
 }
 
 for db in "${database_order[@]}"; do


### PR DESCRIPTION
In the script used to create the bok-choy database cache files, we've been passing in the parameters to omit timestamps that change for every run in some of the mysqldump commands but not all of them.  Use them consistently so we can stop creating new redundant automated bok-choy DB cache PRs on almost every merge to edx-platform.