### PR TITLE
Unpin assorted dependencies

### DIFF
--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -8,6 +8,9 @@
 # pin when possible.  Writing an issue against the offending project and
 # linking to it here is good.
 
+# The CORS_ORIGIN_WHITELIST changes in a backwards incompatible way in 3.0.0, needs matching configuration repo changes
+django-cors-headers<3.0.0
+
 # Constraining this since the newer versions no longer work with the deprecated MIDDLEWARE_CLASSES setting
 django-debug-toolbar<2.0
 

--- a/requirements/edx-sandbox/py35.txt
+++ b/requirements/edx-sandbox/py35.txt
@@ -13,7 +13,7 @@ cryptography==2.8
 cycler==0.10.0            # via matplotlib
 decorator==4.4.1          # via networkx
 kiwisolver==1.1.0         # via matplotlib
-lxml==4.4.1
+lxml==4.4.2
 markupsafe==1.1.1
 matplotlib==2.2.4
 mpmath==1.1.0             # via sympy

--- a/requirements/edx-sandbox/shared.in
+++ b/requirements/edx-sandbox/shared.in
@@ -10,5 +10,5 @@
 -c ../constraints.txt
 
 cryptography                        # Implementations of assorted cryptography algorithms
-lxml==4.4.1                         # XML parser
+lxml                                # XML parser
 nltk                                # Natural language processing; used by the chem package

--- a/requirements/edx-sandbox/shared.txt
+++ b/requirements/edx-sandbox/shared.txt
@@ -6,7 +6,7 @@
 #
 cffi==1.13.2              # via cryptography
 cryptography==2.8
-lxml==4.4.1
+lxml==4.4.2
 nltk==3.4.5
 pycparser==2.19           # via cffi
 six==1.13.0               # via cryptography, nltk

--- a/requirements/edx/base.in
+++ b/requirements/edx/base.in
@@ -26,7 +26,7 @@
 # 4. If the package is not needed in production, add it to another file such
 #    as development.in or testing.in instead.
 
-analytics-python==1.2.9             # Used for Segment analytics
+analytics-python                    # Used for Segment analytics
 attrs                               # Reduces boilerplate code involving class attributes
 Babel==1.3                          # Internationalization utilities, used for date formatting in a few places
 bleach==2.1.4                       # Allowed-list-based HTML sanitizing library that escapes or strips markup and attributes; used for capa and LTI
@@ -36,10 +36,10 @@ botocore==1.8.17                    # via boto3, s3transfer
 celery==3.1.25                      # Asynchronous task execution library
 contextlib2                         # We need contextlib2.ExitStack so we can stop using contextlib.nested which doesn't exist in python 3
 defusedxml
-Django<1.12                     # Web application framework
+Django<1.12                         # Web application framework
 django-babel-underscore             # underscore template extractor for django-babel (internationalization utilities)
 django-config-models>=1.0.0         # Configuration models for Django allowing config management with auditing
-django-cors-headers==2.5.3          # Used to allow to configure CORS headers for cross-domain requests
+django-cors-headers                 # Used to allow to configure CORS headers for cross-domain requests
 django-countries                    # Country data for Django forms and model fields
 django-crum                         # Middleware that stores the current request and user in thread local storage
 django-fernet-fields                # via edx-enterprise (should be added to its setup.py)
@@ -95,6 +95,7 @@ event-tracking
 feedparser==5.1.3
 fs==2.0.18
 fs-s3fs==0.1.8
+geoip2                              # Python API for the GeoIP web services and databases
 glob2                               # Enhanced glob module, used in openedx.core.lib.rooted_paths
 gunicorn
 help-tokens
@@ -108,7 +109,7 @@ Markdown                            # Convert text markup to HTML; used in capa 
 mongoengine==0.10.0                 # Object-document mapper for MongoDB, used in the LMS dashboard
 mysqlclient                         # Driver for the default production relational database
 newrelic                            # New Relic agent for performance monitoring
-nodeenv==1.3.3                      # Utility for managing Node.js environments; we use this for deployments and testing
+nodeenv                             # Utility for managing Node.js environments; we use this for deployments and testing
 oauthlib                            # OAuth specification support for authenticating via LTI or other Open edX services
 pdfminer.six                        # Used in shoppingcart for extracting/parsing pdf text
 piexif==1.0.2                       # Exif image metadata manipulation, used in the profile_images app
@@ -127,12 +128,12 @@ python-dateutil==2.4
 python-Levenshtein
 python3-openid ; python_version>='3'
 python3-saml
-pyuca==1.1                          # For more accurate sorting of translated country names in django-countries
+pyuca                               # For more accurate sorting of translated country names in django-countries
 recommender-xblock                  # https://github.com/edx/RecommenderXBlock
 rest-condition                      # DRF's recommendation for supporting complex permissions
 rfc6266-parser                      # Used to generate Content-Disposition headers.
-social-auth-app-django==3.1.0
-social-auth-core==3.2.0
+social-auth-app-django
+social-auth-core
 pysrt                               # Support for SubRip subtitle files, used in the video XModule
 pytz                                # Time zone information database
 PyYAML                              # Used to parse XModule resource templates
@@ -144,7 +145,7 @@ simplejson
 sailthru-client==2.2.3              # For Sailthru integration
 Shapely                             # Geometry library, used for image click regions in capa
 six                                 # Utilities for supporting Python 2 & 3 in the same codebase
-sorl-thumbnail==12.3                # Image thumbnail management
+sorl-thumbnail                      # Image thumbnail management
 sortedcontainers                    # Provides SortedKeyList, used for lists of XBlock assets
 sqlparse                            # Required by Django to run migrations.RunSQL
 stevedore                           # Support for runtime plugins, used for XBlocks and edx-platform Django app plugins
@@ -156,4 +157,3 @@ web-fragments                       # Provides the ability to render fragments o
 XBlock                              # Courseware component architecture
 xblock-utils                        # Provides utilities used by the Discussion XBlock
 xss-utils                           # https://github.com/edx/edx-platform/pull/20633 Fix XSS via Translations
-geoip2==2.9.0                       # Python API for the GeoIP web services and databases

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -104,7 +104,7 @@ edx-django-release-util==0.3.2
 edx-django-sites-extensions==2.4.2
 edx-django-utils==2.0.2
 edx-drf-extensions==2.4.5
-edx-enterprise==2.0.34
+edx-enterprise==2.0.35
 edx-i18n-tools==0.5.0
 edx-milestones==0.2.6
 edx-oauth2-provider==1.3.1
@@ -127,7 +127,7 @@ feedparser==5.1.3
 fs-s3fs==0.1.8
 fs==2.0.18
 future==0.18.2            # via django-ses, edx-celeryutils, edx-enterprise, pyjwkest
-geoip2==2.9.0
+geoip2==3.0.0
 glob2==0.7
 gunicorn==20.0.4
 help-tokens==1.0.5
@@ -149,7 +149,7 @@ lepl==5.1.3               # via rfc6266-parser
 libsass==0.10.0
 loremipsum==1.0.5
 git+https://github.com/edx/xblock-lti-consumer.git@v1.2.3#egg=lti_consumer-xblock==1.2.3
-lxml==4.4.1
+lxml==4.4.2
 mailsnake==1.6.4
 mako==1.0.2
 markdown==2.6.11
@@ -199,7 +199,7 @@ python-swiftclient==3.8.1
 python3-openid==3.1.0 ; python_version >= "3"
 python3-saml==1.5.0
 pytz==2019.3
-pyuca==1.1
+pyuca==1.2
 pyyaml==5.2
 random2==1.0.1
 recommender-xblock==1.4.5
@@ -222,7 +222,7 @@ six==1.13.0
 slumber==0.7.1            # via edx-bulk-grades, edx-enterprise, edx-rest-api-client
 social-auth-app-django==3.1.0
 social-auth-core==3.2.0
-sorl-thumbnail==12.3
+sorl-thumbnail==12.5.0
 sortedcontainers==2.1.0
 soupsieve==1.9.5          # via beautifulsoup4
 sqlparse==0.3.0

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -118,7 +118,7 @@ edx-django-release-util==0.3.2
 edx-django-sites-extensions==2.4.2
 edx-django-utils==2.0.2
 edx-drf-extensions==2.4.5
-edx-enterprise==2.0.34
+edx-enterprise==2.0.35
 edx-i18n-tools==0.5.0
 edx-lint==1.3.0
 edx-milestones==0.2.6
@@ -151,7 +151,7 @@ freezegun==0.3.12
 fs-s3fs==0.1.8
 fs==2.0.18
 future==0.18.2
-geoip2==2.9.0
+geoip2==3.0.0
 glob2==0.7
 gunicorn==20.0.4
 help-tokens==1.0.5
@@ -182,7 +182,7 @@ lepl==5.1.3
 libsass==0.10.0
 loremipsum==1.0.5
 git+https://github.com/edx/xblock-lti-consumer.git@v1.2.3#egg=lti_consumer-xblock==1.2.3
-lxml==4.4.1
+lxml==4.4.2
 m2r==0.2.1                # via sphinxcontrib-openapi
 mailsnake==1.6.4
 mako==1.0.2
@@ -246,7 +246,7 @@ pyquery==1.4.1
 pyrsistent==0.15.6        # via jsonschema
 pysrt==1.1.1
 pytest-attrib==0.1.3
-git+https://github.com/nedbat/pytest-cov.git@nedbat/cov5-combine#egg=pytest-cov==0.0
+pytest-cov==2.8.1
 pytest-django==3.7.0
 pytest-forked==1.1.3
 pytest-randomly==3.2.0
@@ -260,7 +260,7 @@ python-swiftclient==3.8.1
 python3-openid==3.1.0 ; python_version >= "3"
 python3-saml==1.5.0
 pytz==2019.3
-pyuca==1.1
+pyuca==1.2
 pyyaml==5.2
 radon==4.0.0
 random2==1.0.1
@@ -287,7 +287,7 @@ slumber==0.7.1
 snowballstemmer==2.0.0    # via sphinx
 social-auth-app-django==3.1.0
 social-auth-core==3.2.0
-sorl-thumbnail==12.3
+sorl-thumbnail==12.5.0
 sortedcontainers==2.1.0
 soupsieve==1.9.5
 sphinx==2.3.1             # via edx-sphinx-theme, sphinxcontrib-httpdomain

--- a/requirements/edx/github.in
+++ b/requirements/edx/github.in
@@ -73,8 +73,8 @@ git+https://github.com/edx/django-rest-framework-oauth.git@0a43e8525f1e3048efe4b
 # This dependency will be removed by the Celery 4 upgrade: https://openedx.atlassian.net/browse/PLAT-1684
 git+https://github.com/edx/django-celery.git@756cb57aad765cb2b0d37372c1855b8f5f37e6b0#egg=django-celery==3.2.1+edx.2
 
-# Forked to add support for python2.7 and to fix predicate inversion
-# Once https://github.com/excitedleigh/bridgekeeper/pull/10 is merged, and we get to python3 and django 2, we can
+# Forked to fix predicate inversion
+# Once https://github.com/excitedleigh/bridgekeeper/pull/10 is merged, and we get to django 2, we can
 # remove this fork
 git+https://github.com/edx/bridgekeeper.git@4e34894e4ac5d0467ed1901811a81fd87ee01937#egg=bridgekeeper==0.0
 

--- a/requirements/edx/testing.in
+++ b/requirements/edx/testing.in
@@ -34,7 +34,7 @@ polib                     # Library for manipulating gettext translation files, 
 pyquery                   # jQuery-like API for retrieving fragments of HTML and XML files in tests
 pytest                    # Testing framework
 pytest-attrib             # Select tests based on attributes
-git+https://github.com/nedbat/pytest-cov.git@nedbat/cov5-combine#egg=pytest-cov==0.0
+pytest-cov                # pytest plugin for measuring code coverage
 git+https://github.com/nedbat/coverage_pytest_plugin.git@29de030251471e200ff255eb9e549218cd60e872#egg=coverage_pytest_plugin==0.0
 pytest-django             # Django support for pytest
 pytest-randomly           # pytest plugin to randomly order tests

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -115,7 +115,7 @@ edx-django-release-util==0.3.2
 edx-django-sites-extensions==2.4.2
 edx-django-utils==2.0.2
 edx-drf-extensions==2.4.5
-edx-enterprise==2.0.34
+edx-enterprise==2.0.35
 edx-i18n-tools==0.5.0
 edx-lint==1.3.0
 edx-milestones==0.2.6
@@ -147,7 +147,7 @@ freezegun==0.3.12
 fs-s3fs==0.1.8
 fs==2.0.18
 future==0.18.2
-geoip2==2.9.0
+geoip2==3.0.0
 glob2==0.7
 gunicorn==20.0.4
 help-tokens==1.0.5
@@ -176,7 +176,7 @@ lepl==5.1.3
 libsass==0.10.0
 loremipsum==1.0.5
 git+https://github.com/edx/xblock-lti-consumer.git@v1.2.3#egg=lti_consumer-xblock==1.2.3
-lxml==4.4.1
+lxml==4.4.2
 mailsnake==1.6.4
 mako==1.0.2
 mando==0.6.4              # via radon
@@ -235,7 +235,7 @@ pyparsing==2.2.0
 pyquery==1.4.1
 pysrt==1.1.1
 pytest-attrib==0.1.3
-git+https://github.com/nedbat/pytest-cov.git@nedbat/cov5-combine#egg=pytest-cov==0.0
+pytest-cov==2.8.1
 pytest-django==3.7.0
 pytest-forked==1.1.3      # via pytest-xdist
 pytest-randomly==3.2.0
@@ -249,7 +249,7 @@ python-swiftclient==3.8.1
 python3-openid==3.1.0 ; python_version >= "3"
 python3-saml==1.5.0
 pytz==2019.3
-pyuca==1.1
+pyuca==1.2
 pyyaml==5.2
 radon==4.0.0
 random2==1.0.1
@@ -275,7 +275,7 @@ six==1.13.0
 slumber==0.7.1
 social-auth-app-django==3.1.0
 social-auth-core==3.2.0
-sorl-thumbnail==12.3
+sorl-thumbnail==12.5.0
 sortedcontainers==2.1.0
 soupsieve==1.9.5
 sqlparse==0.3.0


### PR DESCRIPTION
Update an assortment of dependencies which seem low risk to unpin, because they're either already current or very close to the current version with no major breaking changes noted in the changelogs.