### PR TITLE
Fix failing bokchoy test

### DIFF
--- a/common/test/acceptance/tests/lms/test_lms_course_home.py
+++ b/common/test/acceptance/tests/lms/test_lms_course_home.py
@@ -196,7 +196,7 @@ class CourseOutlineTest(UniqueCourseTest):
         self.course_fix.add_children(
             XBlockFixtureDesc('chapter', 'Test Section').add_children(
                 XBlockFixtureDesc('sequential', 'Test Subsection', metadata={
-                    'due': (datetime.now() + timedelta(days=-20)).isoformat(),
+                    'due': (datetime.now()).isoformat(),
                     'format': 'Homework'
                 }).add_children(
                     XBlockFixtureDesc('problem', 'Test Problem', data=load_data_str('multiple_choice.xml')),


### PR DESCRIPTION
The due date is set to datetime.now() - timedelta(days=-20). When the year is tested in statement 
`self.assertIn(str(datetime.now().year), due_date` it is failing because years are different when tests are run at the start of new year