### PR TITLE
The Python 2 cmp() builtin was removed in Python 3

### DIFF
--- a/common/djangoapps/util/views.py
+++ b/common/djangoapps/util/views.py
@@ -4,6 +4,7 @@ import json
 import logging
 import sys
 from functools import wraps
+from operator import itemgetter
 
 import calc
 import crum
@@ -188,7 +189,7 @@ def parse_accept_header(accept):
             else:
                 media_params.append((key, value))
         result.append((media_type, tuple(media_params), q))
-    result.sort(lambda x, y: -cmp(x[2], y[2]))
+    result.sort(key=itemgetter(2), reverse=True)
     return result
 
 


### PR DESCRIPTION
__cmp()__ was removed in Python 3 so this modification is proposed to achieve identical results on both Python 2 and Python 3.
* https://portingguide.readthedocs.io/en/latest/comparisons.html
* https://docs.python.org/3/howto/sorting.html

### Please consider the following when opening a pull request:

- Link to the relevant JIRA ticket(s) and tag any relevant team(s).
- Squash your changes down into one or more discrete commits.
  In each commit, include description that could help a developer
  several months from now.
- If running `make upgrade`, run _as close to the time of merging as possible_
  to avoid accidentally downgrading someone else's package.
  Put the output of `make upgrade` in its own separate commit,
  decoupled from other code changes.
- Aim for comprehensive test coverage, but remember that
  automated testing isn't a substitute for manual verification.
- Carefully consider naming, code organization, dependencies when adding new code.
  Code that is amenable to refactoring and improvement benefits all platform developers,
  especially given the size and scope of edx-platform.
  Consult existing Architectural Decision Records (ADRs),
  including those concerning the app(s) you are changing and
  [those concerning edx-platform as a whole](https://github.com/edx/edx-platform/tree/master/docs/decisions).
