### PR TITLE
Python 2 builtin datatype 'file' was removed in Python 3

### DIFF
--- a/openedx/core/apidocs.py
+++ b/openedx/core/apidocs.py
@@ -10,6 +10,11 @@ from drf_yasg.utils import swagger_auto_schema as drf_swagger_auto_schema
 from drf_yasg.views import get_schema_view
 from rest_framework import permissions
 
+try:
+    file
+except NameError:  # Python 3
+    from io import IOBase as file
+
 # -- Code that will eventually be in another openapi-helpers repo -------------
 
 


### PR DESCRIPTION
__file__ was removed in Python 3 so this change is proposed to deliver equivalent functionality in both Python 2 and Python 3.
* https://portingguide.readthedocs.io/en/latest/builtins.html#removed-file

### Please consider the following when opening a pull request:

- Link to the relevant JIRA ticket(s) and tag any relevant team(s).
- Squash your changes down into one or more discrete commits.
  In each commit, include description that could help a developer
  several months from now.
- If running `make upgrade`, run _as close to the time of merging as possible_
  to avoid accidentally downgrading someone else's package.
  Put the output of `make upgrade` in its own separate commit,
  decoupled from other code changes.
- Aim for comprehensive test coverage, but remember that
  automated testing isn't a substitute for manual verification.
- Carefully consider naming, code organization, dependencies when adding new code.
  Code that is amenable to refactoring and improvement benefits all platform developers,
  especially given the size and scope of edx-platform.
  Consult existing Architectural Decision Records (ADRs),
  including those concerning the app(s) you are changing and
  [those concerning edx-platform as a whole](https://github.com/edx/edx-platform/tree/master/docs/decisions).
