### PR TITLE
updated ora2 version to 2.5.6

### DIFF
--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -71,7 +71,7 @@ django-mysql==2.4.1
 git+https://github.com/edx/django-oauth-plus.git@b9b64a3ac24fd11f471763c88462bbf3c53e46e6#egg=django-oauth-plus==2.2.9.edx-4
 django-oauth-toolkit==1.1.3
 django-object-actions==2.0.0  # via edx-enterprise
-django-pipeline==1.6.14
+django-pipeline==1.7.0
 django-pyfs==2.1
 django-ratelimit-backend==1.1.1
 django-ratelimit==2.0.0
@@ -104,7 +104,7 @@ edx-django-release-util==0.3.2
 edx-django-sites-extensions==2.4.2
 edx-django-utils==2.0.2
 edx-drf-extensions==2.4.5
-edx-enterprise==2.0.37
+edx-enterprise==2.0.38
 edx-i18n-tools==0.5.0
 edx-milestones==0.2.6
 edx-oauth2-provider==1.3.1
@@ -120,7 +120,7 @@ edx-submissions==3.0.3
 edx-tincan-py35==0.0.5    # via edx-enterprise
 edx-user-state-client==1.1.2
 edx-when==0.5.2
-edxval==1.1.33
+edxval==1.2.0
 elasticsearch==1.9.0      # via edx-search
 enum34==1.1.6             # via edxval
 event-tracking==0.3.0
@@ -168,12 +168,12 @@ nodeenv==1.3.3
 numpy==1.18.0             # via scipy
 git+https://github.com/joestump/python-oauth2.git@b94f69b1ad195513547924e380d9265133e995fa#egg=oauth2
 oauthlib==2.1.0
-git+https://github.com/edx/edx-ora2.git@2.5.4#egg=ora2==2.5.4
+git+https://github.com/edx/edx-ora2.git@2.5.6#egg=ora2==2.5.6
 path.py==8.2.1
 pathtools==0.1.2
 paver==1.3.4
 pbr==5.4.4
-pdfminer.six==20191110
+pdfminer.six==20200104
 piexif==1.0.2
 pillow==7.0.0
 pkgconfig==1.5.1          # via xmlsec
@@ -230,7 +230,7 @@ sqlparse==0.3.0
 staff-graded-xblock==0.6
 stevedore==1.31.0
 super-csv==0.9.6
-sympy==1.5
+sympy==1.5.1
 testfixtures==6.10.3      # via edx-enterprise
 text-unidecode==1.3       # via python-slugify
 unicodecsv==0.14.1

--- a/requirements/edx/coverage.txt
+++ b/requirements/edx/coverage.txt
@@ -4,7 +4,7 @@
 #
 #    make upgrade
 #
-coverage==5.0.1
+coverage==5.0.2
 diff-cover==2.5.0
 importlib-metadata==1.3.0  # via pluggy
 inflect==3.0.2            # via jinja2-pluralize

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -53,7 +53,7 @@ contextlib2==0.6.0.post1
 cookies==2.2.1
 coreapi==2.3.3
 coreschema==0.0.4
-coverage==5.0.1
+coverage==5.0.2
 git+https://github.com/nedbat/coverage_pytest_plugin.git@29de030251471e200ff255eb9e549218cd60e872#egg=coverage_pytest_plugin==0.0
 git+https://github.com/edx/crowdsourcehinter.git@a7ffc85b134b7d8909bf1fefd23dbdb8eb28e467#egg=crowdsourcehinter-xblock==0.2
 cryptography==2.8
@@ -84,7 +84,7 @@ django-mysql==2.4.1
 git+https://github.com/edx/django-oauth-plus.git@b9b64a3ac24fd11f471763c88462bbf3c53e46e6#egg=django-oauth-plus==2.2.9.edx-4
 django-oauth-toolkit==1.1.3
 django-object-actions==2.0.0
-django-pipeline==1.6.14
+django-pipeline==1.7.0
 django-pyfs==2.1
 django-ratelimit-backend==1.1.1
 django-ratelimit==2.0.0
@@ -118,7 +118,7 @@ edx-django-release-util==0.3.2
 edx-django-sites-extensions==2.4.2
 edx-django-utils==2.0.2
 edx-drf-extensions==2.4.5
-edx-enterprise==2.0.37
+edx-enterprise==2.0.38
 edx-i18n-tools==0.5.0
 edx-lint==1.3.0
 edx-milestones==0.2.6
@@ -136,7 +136,7 @@ edx-submissions==3.0.3
 edx-tincan-py35==0.0.5
 edx-user-state-client==1.1.2
 edx-when==0.5.2
-edxval==1.1.33
+edxval==1.2.0
 elasticsearch==1.9.0
 entrypoints==0.3
 enum34==1.1.6
@@ -207,15 +207,15 @@ nodeenv==1.3.3
 numpy==1.18.0
 git+https://github.com/joestump/python-oauth2.git@b94f69b1ad195513547924e380d9265133e995fa#egg=oauth2
 oauthlib==2.1.0
-git+https://github.com/edx/edx-ora2.git@2.5.4#egg=ora2==2.5.4
-packaging==19.2
-pandas==0.22.0
+git+https://github.com/edx/edx-ora2.git@2.5.6#egg=ora2==2.5.6
+packaging==20.0
+pandas==0.24.2
 path.py==8.2.1
 pathlib2==2.3.5
 pathtools==0.1.2
 paver==1.3.4
 pbr==5.4.4
-pdfminer.six==20191110
+pdfminer.six==20200104
 piexif==1.0.2
 pillow==7.0.0
 pip-tools==4.3.0
@@ -307,7 +307,7 @@ sqlparse==0.3.0
 staff-graded-xblock==0.6
 stevedore==1.31.0
 super-csv==0.9.6
-sympy==1.5
+sympy==1.5.1
 testfixtures==6.10.3
 text-unidecode==1.3
 toml==0.10.0

--- a/requirements/edx/github.in
+++ b/requirements/edx/github.in
@@ -81,7 +81,7 @@ git+https://github.com/edx/bridgekeeper.git@4e34894e4ac5d0467ed1901811a81fd87ee0
 # Our libraries:
 -e git+https://github.com/edx/codejail.git@6bc47025359a4d6ecf2b6b5776ff99959094d2cc#egg=codejail
 -e git+https://github.com/edx/acid-block.git@98aecba94ecbfa934e2d00262741c0ea9f557fc9#egg=acid-xblock
-git+https://github.com/edx/edx-ora2.git@2.5.4#egg=ora2==2.5.4
+git+https://github.com/edx/edx-ora2.git@2.5.6#egg=ora2==2.5.6
 git+https://github.com/edx/crowdsourcehinter.git@a7ffc85b134b7d8909bf1fefd23dbdb8eb28e467#egg=crowdsourcehinter-xblock==0.2
 -e git+https://github.com/edx/RateXBlock.git@2.0#egg=rate-xblock
 -e git+https://github.com/edx/DoneXBlock.git@2.0.1#egg=done-xblock

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -52,7 +52,7 @@ contextlib2==0.6.0.post1
 cookies==2.2.1            # via moto
 coreapi==2.3.3
 coreschema==0.0.4
-coverage==5.0.1
+coverage==5.0.2
 git+https://github.com/nedbat/coverage_pytest_plugin.git@29de030251471e200ff255eb9e549218cd60e872#egg=coverage_pytest_plugin==0.0
 git+https://github.com/edx/crowdsourcehinter.git@a7ffc85b134b7d8909bf1fefd23dbdb8eb28e467#egg=crowdsourcehinter-xblock==0.2
 cryptography==2.8
@@ -82,7 +82,7 @@ django-mysql==2.4.1
 git+https://github.com/edx/django-oauth-plus.git@b9b64a3ac24fd11f471763c88462bbf3c53e46e6#egg=django-oauth-plus==2.2.9.edx-4
 django-oauth-toolkit==1.1.3
 django-object-actions==2.0.0
-django-pipeline==1.6.14
+django-pipeline==1.7.0
 django-pyfs==2.1
 django-ratelimit-backend==1.1.1
 django-ratelimit==2.0.0
@@ -115,7 +115,7 @@ edx-django-release-util==0.3.2
 edx-django-sites-extensions==2.4.2
 edx-django-utils==2.0.2
 edx-drf-extensions==2.4.5
-edx-enterprise==2.0.37
+edx-enterprise==2.0.38
 edx-i18n-tools==0.5.0
 edx-lint==1.3.0
 edx-milestones==0.2.6
@@ -132,7 +132,7 @@ edx-submissions==3.0.3
 edx-tincan-py35==0.0.5
 edx-user-state-client==1.1.2
 edx-when==0.5.2
-edxval==1.1.33
+edxval==1.2.0
 elasticsearch==1.9.0
 entrypoints==0.3          # via flake8
 enum34==1.1.6
@@ -199,15 +199,15 @@ nodeenv==1.3.3
 numpy==1.18.0
 git+https://github.com/joestump/python-oauth2.git@b94f69b1ad195513547924e380d9265133e995fa#egg=oauth2
 oauthlib==2.1.0
-git+https://github.com/edx/edx-ora2.git@2.5.4#egg=ora2==2.5.4
-packaging==19.2           # via pytest, tox
-pandas==0.22.0
+git+https://github.com/edx/edx-ora2.git@2.5.6#egg=ora2==2.5.6
+packaging==20.0           # via pytest, tox
+pandas==0.24.2
 path.py==8.2.1
 pathlib2==2.3.5           # via pytest
 pathtools==0.1.2
 paver==1.3.4
 pbr==5.4.4
-pdfminer.six==20191110
+pdfminer.six==20200104
 piexif==1.0.2
 pillow==7.0.0
 pkgconfig==1.5.1
@@ -286,7 +286,7 @@ sqlparse==0.3.0
 staff-graded-xblock==0.6
 stevedore==1.31.0
 super-csv==0.9.6
-sympy==1.5
+sympy==1.5.1
 testfixtures==6.10.3
 text-unidecode==1.3
 toml==0.10.0              # via tox


### PR DESCRIPTION
In edX-Platform ORA file uploads don't show the names of the files for following: [PROD-1093](https://openedx.atlassian.net/browse/PROD-1093)

This PR fixes this issue by an updating version to `2.5.6` of ORA2 in which this issue is fixed.