### PR TITLE
Downgrade pandas and python-dateutil

### DIFF
--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -52,15 +52,15 @@ mysqlclient<1.5
 requests-oauthlib==1.1.0
 oauthlib==2.1.0
 
+# Version 0.23.0 requires python-dateuil>=2.5.0
+pandas==0.22.0
+
+# Upgrading to 2.5.3 on 2020-01-03 triggered "'tzlocal' object has no attribute '_std_offset'" errors in production
+python-dateutil==2.4.0
+
 # python3-saml 1.6.0 breaks unittests in common/djangoapps/third_party_auth/tests/test_views.py::SAMLMetadataTest
 python3-saml==1.5.0
 
 # transifex-client 0.13.5 and 0.13.6 pin six and urllib3 to old versions needlessly
 #   https://github.com/transifex/transifex-client/issues/252
 transifex-client==0.13.4
-
-# moving constraint from base.in to constraints.txt
-python-dateutil<2.6.0
-
-#higher releases require python>3.5
-pandas<0.25.0

--- a/requirements/edx-sandbox/py35.in
+++ b/requirements/edx-sandbox/py35.in
@@ -7,8 +7,6 @@
 #   * confirm that it has no system requirements beyond what we already install
 #   * run "make upgrade" to update the detailed requirements files
 
--c ../constraints.txt
-
 -r shared.txt                       # Dependencies in common with LMS and Studio
 matplotlib==2.2.4                   # 2D plotting library
 networkx==2.2                       # Utilities for creating, manipulating, and studying network graphs

--- a/requirements/edx-sandbox/py35.txt
+++ b/requirements/edx-sandbox/py35.txt
@@ -22,7 +22,7 @@ nltk==3.4.5
 numpy==1.16.5
 pycparser==2.19
 pyparsing==2.2.0
-python-dateutil==2.5.3    # via matplotlib
+python-dateutil==2.8.1    # via matplotlib
 pytz==2019.3              # via matplotlib
 random2==1.0.1
 scipy==1.2.1

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -192,7 +192,7 @@ pymongo==3.9.0
 pynliner==0.8.0
 pyparsing==2.2.0          # via pycontracts
 pysrt==1.1.1
-python-dateutil==2.5.3
+python-dateutil==2.4.0
 python-levenshtein==0.12.0
 python-memcached==1.59
 python-slugify==4.0.0     # via code-annotations

--- a/requirements/edx/coverage.txt
+++ b/requirements/edx/coverage.txt
@@ -13,10 +13,10 @@ jinja2==2.10.3            # via diff-cover, jinja2-pluralize
 markupsafe==1.1.1         # via jinja2
 more-itertools==8.0.2     # via zipp
 numpy==1.18.0             # via pandas
-pandas==0.24.2
+pandas==0.22.0
 pluggy==0.13.1            # via diff-cover
 pygments==2.5.2           # via diff-cover
-python-dateutil==2.5.3    # via pandas
+python-dateutil==2.4.0    # via pandas
 pytz==2019.3              # via pandas
 six==1.13.0               # via diff-cover
 zipp==0.6.0               # via importlib-metadata

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -209,7 +209,7 @@ git+https://github.com/joestump/python-oauth2.git@b94f69b1ad195513547924e380d926
 oauthlib==2.1.0
 git+https://github.com/edx/edx-ora2.git@2.5.4#egg=ora2==2.5.4
 packaging==19.2
-pandas==0.24.2
+pandas==0.22.0
 path.py==8.2.1
 pathlib2==2.3.5
 pathtools==0.1.2
@@ -256,7 +256,7 @@ pytest-metadata==1.8.0
 pytest-randomly==3.2.0
 pytest-xdist==1.31.0
 pytest==5.3.2
-python-dateutil==2.5.3
+python-dateutil==2.4.0
 python-levenshtein==0.12.0
 python-memcached==1.59
 python-slugify==4.0.0

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -201,7 +201,7 @@ git+https://github.com/joestump/python-oauth2.git@b94f69b1ad195513547924e380d926
 oauthlib==2.1.0
 git+https://github.com/edx/edx-ora2.git@2.5.4#egg=ora2==2.5.4
 packaging==19.2           # via pytest, tox
-pandas==0.24.2
+pandas==0.22.0
 path.py==8.2.1
 pathlib2==2.3.5           # via pytest
 pathtools==0.1.2
@@ -245,7 +245,7 @@ pytest-metadata==1.8.0    # via pytest-json-report
 pytest-randomly==3.2.0
 pytest-xdist==1.31.0
 pytest==5.3.2
-python-dateutil==2.5.3
+python-dateutil==2.4.0
 python-levenshtein==0.12.0
 python-memcached==1.59
 python-slugify==4.0.0


### PR DESCRIPTION
Downgrade pandas to a version that works with the version of python-dateutil we were previously using; the new one has some incompatibility with DRF serialization that we still need to investigate, triggering errors in production.

Also stop imposing the constraints file on the sandbox requirements, so it can keep the newer version of python-dateutil it was already using.  It doesn't look like any of its other dependencies were previously being constrained by the file.