### PR TITLE
Updated the Mako Loader to remove deprecated methods

### DIFF
--- a/common/djangoapps/edxmako/makoloader.py
+++ b/common/djangoapps/edxmako/makoloader.py
@@ -75,8 +75,12 @@ class MakoLoader(object):
                 return source, file_path
 
     def load_template_source(self, template_name, template_dirs=None):
-        # Just having this makes the template load as an instance, instead of a class.
-        return self.base_loader.load_template_source(template_name, template_dirs)
+        for origin in self.base_loader.get_template_sources(template_name, template_dirs):
+            try:
+                return self.base_loader.get_contents(origin), origin.name
+            except TemplateDoesNotExist:
+                pass
+        raise TemplateDoesNotExist(template_name)
 
     def reset(self):
         self.base_loader.reset()

--- a/common/djangoapps/pipeline_mako/templates/static_content.html
+++ b/common/djangoapps/pipeline_mako/templates/static_content.html
@@ -85,6 +85,7 @@ except:
 <%def name="include(path)"><%
 from django.conf import settings
 from django.template.engine import Engine
+from django.template import TemplateDoesNotExist
 from django.template.loaders.filesystem import Loader
 from openedx.core.djangoapps.theming.helpers import get_current_theme
 dirs = settings.DEFAULT_TEMPLATE_ENGINE['DIRS']
@@ -93,7 +94,18 @@ if theme:
     dirs = list(dirs)
     dirs.insert(0, theme.path / 'templates')
 engine = Engine(dirs=dirs)
-source, template_path = Loader(engine).load_template_source(path)
+loader = Loader(engine)
+
+source = None
+for origin in loader.get_template_sources(path, dirs):
+    try:
+        source = loader.get_contents(origin)
+    except TemplateDoesNotExist:
+        pass
+
+if not source:
+    raise TemplateDoesNotExist(path)
+
 %>${source | n, decode.utf8}</%def>
 
 <%def name="studiofrontend(entry)">


### PR DESCRIPTION
Relevant JIRA issue can be found [here](https://openedx.atlassian.net/browse/BOM-1131).
Changes made here assume that we're still going to support `Django 1.11` and in `Django 1.11` the [loader](https://github.com/django/django/blob/stable/1.11.x/django/template/loaders/base.py) still uses `load_template` and `load_template_source` 