### PR TITLE
Remove lang cookie for mobile app requests.

### DIFF
--- a/openedx/core/djangoapps/lang_pref/middleware.py
+++ b/openedx/core/djangoapps/lang_pref/middleware.py
@@ -71,12 +71,12 @@ class LanguagePreferenceMiddleware(object):
 
             # If set, set the user_pref in the LANGUAGE_COOKIE
             if user_pref and not is_request_from_mobile_app(request):
-                    response.set_cookie(
-                        settings.LANGUAGE_COOKIE,
-                        value=user_pref,
-                        domain=settings.SESSION_COOKIE_DOMAIN,
-                        max_age=COOKIE_DURATION,
-                    )
+                response.set_cookie(
+                    settings.LANGUAGE_COOKIE,
+                    value=user_pref,
+                    domain=settings.SESSION_COOKIE_DOMAIN,
+                    max_age=COOKIE_DURATION,
+                )
             else:
                 response.delete_cookie(
                     settings.LANGUAGE_COOKIE,

--- a/openedx/core/djangoapps/lang_pref/middleware.py
+++ b/openedx/core/djangoapps/lang_pref/middleware.py
@@ -70,8 +70,7 @@ class LanguagePreferenceMiddleware(object):
                     pass
 
             # If set, set the user_pref in the LANGUAGE_COOKIE
-            if user_pref:
-                if not is_request_from_mobile_app(request):
+            if user_pref and not is_request_from_mobile_app(request):
                     response.set_cookie(
                         settings.LANGUAGE_COOKIE,
                         value=user_pref,


### PR DESCRIPTION
Responses for mobile app requests must not include language preference cookie.

PROD-1107
