### PR TITLE
Fix export_olx command issue

### DIFF
--- a/cms/djangoapps/contentstore/management/commands/export_olx.py
+++ b/cms/djangoapps/contentstore/management/commands/export_olx.py
@@ -92,9 +92,7 @@ def export_course_to_directory(course_key, root_dir):
     # The safest characters are A-Z, a-z, 0-9, <underscore>, <period> and <hyphen>.
     # We represent the first four with \w.
     # TODO: Once we support courses with unicode characters, we will need to revisit this.
-    replacement_char = u'-'
-    course_dir = replacement_char.join([course.id.org, course.id.course, course.id.run])
-    course_dir = re.sub(r'[^\w\.\-]', replacement_char, course_dir)
+    course_dir = course.url_name
 
     export_course_to_xml(store, None, course.id, root_dir, course_dir)
 

--- a/cms/djangoapps/contentstore/management/commands/tests/test_export_olx.py
+++ b/cms/djangoapps/contentstore/management/commands/tests/test_export_olx.py
@@ -70,7 +70,7 @@ class TestCourseExportOlx(ModuleStoreTestCase):
     def check_export_file(self, tar_file, course_key):
         """Check content of export file."""
         names = tar_file.getnames()
-        dirname = "{0.org}-{0.course}-{0.run}".format(course_key)
+        dirname = modulestore().get_course(course_key).url_name
         self.assertIn(dirname, names)
         # Check if some of the files are present, without being exhaustive.
         self.assertIn("{}/about".format(dirname), names)


### PR DESCRIPTION

**Description:** 
`export_olx` is a shell command to export courses into a tar file. It was not working due to directory structure conflicts and was giving the following error:

`fs.errors.ResourceNotFound: resource 'course/static/cd93ec03-0488-4640-b1aa-3142df222156-en.srt' not found`

`export_olx` is using the [create_transcript_xml](https://github.com/edx/edx-val/blob/master/edxval/api.py#L958) method of [edx-val](https://github.com/edx/edx-val/tree/master/edxval) that requires specific directory structure before copying the course in the target folder. Due to the target directory name mismatch between edx-val requirement and edx export_olx command, an error has occurred. 

I have fixed it by changing the target course dir name to resolve conflicts. 

**Command:**
_`./manage.py cms export_olx <your_course_id> --output <output_file_name>.tar.gz`_

**Stack Trace:**
```
Traceback (most recent call last):
  File "/edx/app/edxapp/edx-platform/manage.py", line 123, in <module>
    execute_from_command_line([sys.argv[0]] + django_args)
  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/django/core/management/__init__.py", line 364, in execute_from_command_line
    utility.execute()
  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/django/core/management/__init__.py", line 356, in execute
    self.fetch_command(subcommand).run_from_argv(self.argv)
  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/django/core/management/base.py", line 283, in run_from_argv
    self.execute(*args, **cmd_options)
  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/django/core/management/base.py", line 330, in execute
    output = self.handle(*args, **options)
  File "/edx/app/edxapp/edx-platform/cms/djangoapps/contentstore/management/commands/export_olx.py", line 60, in handle
    export_course_to_tarfile(course_key, filename)
  File "/edx/app/edxapp/edx-platform/cms/djangoapps/contentstore/management/commands/export_olx.py", line 78, in export_course_to_tarfile
    course_dir = export_course_to_directory(course_key, tmp_dir)
  File "/edx/app/edxapp/edx-platform/cms/djangoapps/contentstore/management/commands/export_olx.py", line 98, in export_course_to_directory
    export_course_to_xml(store, None, course.id, root_dir, course_dir)
  File "/edx/app/edxapp/edx-platform/common/lib/xmodule/xmodule/modulestore/xml_exporter.py", line 343, in export_course_to_xml
    CourseExportManager(modulestore, contentstore, course_key, root_dir, course_dir).export()
  File "/edx/app/edxapp/edx-platform/common/lib/xmodule/xmodule/modulestore/xml_exporter.py", line 170, in export
    courselike.add_xml_to_node(root)
  File "/edx/app/edxapp/edx-platform/common/lib/xmodule/xmodule/xml_module.py", line 583, in add_xml_to_node
    super(XmlParserMixin, self).add_xml_to_node(node)  # pylint: disable=bad-super-call
  File "/edx/app/edxapp/edx-platform/common/lib/xmodule/xmodule/x_module.py", line 1134, in add_xml_to_node
    xml_string = self.export_to_xml(self.runtime.export_fs)
  File "/edx/app/edxapp/edx-platform/common/lib/xmodule/xmodule/xml_module.py", line 572, in export_to_xml
    super(XmlDescriptor, self).add_xml_to_node(node)
  File "/edx/app/edxapp/edx-platform/common/lib/xmodule/xmodule/xml_module.py", line 431, in add_xml_to_node
    xml_object = self.definition_to_xml(self.runtime.export_fs)
  File "/edx/app/edxapp/edx-platform/common/lib/xmodule/xmodule/course_module.py", line 1154, in definition_to_xml
    xml_object = super(CourseDescriptor, self).definition_to_xml(resource_fs)
  File "/edx/app/edxapp/edx-platform/common/lib/xmodule/xmodule/seq_module.py", line 692, in definition_to_xml
    self.runtime.add_block_as_child_node(child, xml_object)
  File "/edx/app/edxapp/edx-platform/common/lib/xmodule/xmodule/x_module.py", line 1531, in add_block_as_child_node
    block.add_xml_to_node(child)
  File "/edx/app/edxapp/edx-platform/common/lib/xmodule/xmodule/xml_module.py", line 583, in add_xml_to_node
    super(XmlParserMixin, self).add_xml_to_node(node)  # pylint: disable=bad-super-call
  File "/edx/app/edxapp/edx-platform/common/lib/xmodule/xmodule/x_module.py", line 1134, in add_xml_to_node
    xml_string = self.export_to_xml(self.runtime.export_fs)
  File "/edx/app/edxapp/edx-platform/common/lib/xmodule/xmodule/xml_module.py", line 572, in export_to_xml
    super(XmlDescriptor, self).add_xml_to_node(node)
  File "/edx/app/edxapp/edx-platform/common/lib/xmodule/xmodule/xml_module.py", line 431, in add_xml_to_node
    xml_object = self.definition_to_xml(self.runtime.export_fs)
  File "/edx/app/edxapp/edx-platform/common/lib/xmodule/xmodule/seq_module.py", line 692, in definition_to_xml
    self.runtime.add_block_as_child_node(child, xml_object)
  File "/edx/app/edxapp/edx-platform/common/lib/xmodule/xmodule/x_module.py", line 1531, in add_block_as_child_node
    block.add_xml_to_node(child)
  File "/edx/app/edxapp/edx-platform/common/lib/xmodule/xmodule/xml_module.py", line 583, in add_xml_to_node
    super(XmlParserMixin, self).add_xml_to_node(node)  # pylint: disable=bad-super-call
  File "/edx/app/edxapp/edx-platform/common/lib/xmodule/xmodule/x_module.py", line 1134, in add_xml_to_node
    xml_string = self.export_to_xml(self.runtime.export_fs)
  File "/edx/app/edxapp/edx-platform/common/lib/xmodule/xmodule/xml_module.py", line 572, in export_to_xml
    super(XmlDescriptor, self).add_xml_to_node(node)
  File "/edx/app/edxapp/edx-platform/common/lib/xmodule/xmodule/xml_module.py", line 431, in add_xml_to_node
    xml_object = self.definition_to_xml(self.runtime.export_fs)
  File "/edx/app/edxapp/edx-platform/common/lib/xmodule/xmodule/seq_module.py", line 692, in definition_to_xml
    self.runtime.add_block_as_child_node(child, xml_object)
  File "/edx/app/edxapp/edx-platform/common/lib/xmodule/xmodule/x_module.py", line 1531, in add_block_as_child_node
    block.add_xml_to_node(child)
  File "/edx/app/edxapp/edx-platform/common/lib/xmodule/xmodule/xml_module.py", line 431, in add_xml_to_node
    xml_object = self.definition_to_xml(self.runtime.export_fs)
  File "/edx/app/edxapp/edx-platform/common/lib/xmodule/xmodule/vertical_block.py", line 179, in definition_to_xml
    self.runtime.add_block_as_child_node(child, xml_object)
  File "/edx/app/edxapp/edx-platform/common/lib/xmodule/xmodule/x_module.py", line 1531, in add_block_as_child_node
    block.add_xml_to_node(child)
  File "/edx/app/edxapp/edx-platform/common/lib/xmodule/xmodule/xml_module.py", line 583, in add_xml_to_node
    super(XmlParserMixin, self).add_xml_to_node(node)  # pylint: disable=bad-super-call
  File "/edx/app/edxapp/edx-platform/common/lib/xmodule/xmodule/x_module.py", line 1134, in add_xml_to_node
    xml_string = self.export_to_xml(self.runtime.export_fs)
  File "/edx/app/edxapp/edx-platform/common/lib/xmodule/xmodule/xml_module.py", line 572, in export_to_xml
    super(XmlDescriptor, self).add_xml_to_node(node)
  File "/edx/app/edxapp/edx-platform/common/lib/xmodule/xmodule/xml_module.py", line 431, in add_xml_to_node
    xml_object = self.definition_to_xml(self.runtime.export_fs)
  File "/edx/app/edxapp/edx-platform/common/lib/xmodule/xmodule/video_module/video_module.py", line 752, in definition_to_xml
    course_id=unicode(self.runtime.course_id.for_branch(None))
  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/edxval/api.py", line 918, in export_to_xml
    return create_transcripts_xml(video_id, video_el, resource_fs, static_dir)
  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/edxval/api.py", line 978, in create_transcripts_xml
    static_dir=combine(u'course', static_dir)  # File system should not start from /draft directory.
  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/edxval/api.py", line 943, in create_transcript_file
    create_file_in_fs(transcript_content, transcript_filename, resource_fs, static_dir)
  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/edxval/utils.py", line 198, in create_file_in_fs
    with file_system.open(combine(static_dir, file_name), 'wb') as f:
  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/fs/osfs.py", line 386, in open
    **options
  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/fs/error_tools.py", line 82, in __exit__
    traceback
  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/fs/osfs.py", line 386, in open
    **options
fs.errors.ResourceNotFound: resource 'course/static/cd93ec03-0488-4640-b1aa-3142df222156-en.srt' not found

```
