### PR TITLE
Rename order in CreditRequirement (3/3)

### DIFF
--- a/common/djangoapps/util/tests/test_db.py
+++ b/common/djangoapps/util/tests/test_db.py
@@ -222,7 +222,6 @@ class MigrationTests(TestCase):
     Tests for migrations.
     """
 
-    @unittest.skip("Need to skip as part of a 3-release rollout to rename a field in the credit app. This will be unskipped in DE-1823.")
     @override_settings(MIGRATION_MODULES={})
     def test_migrations_are_in_sync(self):
         """

--- a/openedx/core/djangoapps/credit/migrations/0008_creditrequirement_remove_order.py
+++ b/openedx/core/djangoapps/credit/migrations/0008_creditrequirement_remove_order.py
@@ -1,0 +1,18 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('credit', '0007_creditrequirement_copy_values'),
+    ]
+
+    operations = [
+        migrations.RemoveField(
+            model_name='creditrequirement',
+            name='order',
+        ),
+    ]


### PR DESCRIPTION
Creating a new PR after rebasing @pwnage101's branch.

This stage does the following:

- Includes a migration to delete the old column.
- Remove the test skip for `test_migrations_are_in_sync`

DE-1823

Testing plan detailed in https://openedx.atlassian.net/wiki/spaces/DE/pages/1065681172/Patterns+For+Renaming+Django+Model+Fields#PatternsForRenamingDjangoModelFields-RolloutPlanForCreditRequirement.orderIntheLMS