### PR TITLE
Rename values in SiteConfiguration/History (3/3)

### DIFF
--- a/common/djangoapps/util/tests/test_db.py
+++ b/common/djangoapps/util/tests/test_db.py
@@ -223,8 +223,7 @@ class MigrationTests(TestCase):
     """
 
     @unittest.skip(
-        "Need to skip as part of renaming a field in schedules app. This will be unskipped in DE-1825.  ALSO need to "
-        "skip as part of renaming a field in the site_configuration app.  This will be unskipped in DENG-18."
+        "Need to skip as part of renaming a field in schedules app. This will be unskipped in DE-1825."
     )
     @override_settings(MIGRATION_MODULES={})
     def test_migrations_are_in_sync(self):

--- a/openedx/core/djangoapps/site_configuration/migrations/0007_remove_values_field.py
+++ b/openedx/core/djangoapps/site_configuration/migrations/0007_remove_values_field.py
@@ -1,0 +1,22 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('site_configuration', '0006_copy_values_to_site_values'),
+    ]
+
+    operations = [
+        migrations.RemoveField(
+            model_name='siteconfiguration',
+            name='values',
+        ),
+        migrations.RemoveField(
+            model_name='siteconfigurationhistory',
+            name='values',
+        ),
+    ]


### PR DESCRIPTION
https://openedx.atlassian.net/browse/DE-1826

This stage does the following:

- Includes a migration to delete the old `values` column.
- Remove the test skip for `test_migrations_are_in_sync`

**Stage 1**: #22692 #23144 (first attempt, second attempt)
**Stage 2**: #22709 #22851 #23206 #23214 #23224 #23236 #23306 (first attempt, first attempt again, revert, second attempt, revert, fix-forward, third attempt)
**Stage 3**: this PR