### PR TITLE
Ignore `ResourceWarning`

### DIFF
--- a/openedx/core/lib/logsettings.py
+++ b/openedx/core/lib/logsettings.py
@@ -122,6 +122,7 @@ def log_python_warnings():
     warnings.filterwarnings('ignore', 'Not importing directory ')
     warnings.filterwarnings('ignore', 'Setting _field_data is deprecated')
     warnings.filterwarnings('ignore', 'Setting _field_data via the constructor is deprecated')
+    warnings.filterwarnings('ignore', '.*unclosed.*', category=ResourceWarning)
     try:
         # There are far too many of these deprecation warnings in startup to output for every management command;
         # suppress them until we've fixed at least the most common ones as reported by the test suite


### PR DESCRIPTION
Ignore `ResourceWarning` to clear noise in logs until we replace `EdxRestApiClient` with `OAuthAPIClient`. We have too many warnings like this
unclosed <ssl.SSLSocket fd=33, family=AddressFamily.AF_INET, type=SocketKind.SOCK_STREAM, proto=6, laddr=('*.*.*', 47040), raddr=('*.*.*.*', 443)

### Please consider the following when opening a pull request:

- Link to the relevant JIRA ticket(s) and tag any relevant team(s).
- Squash your changes down into one or more discrete commits.
  In each commit, include description that could help a developer
  several months from now.
- If running `make upgrade`, run _as close to the time of merging as possible_
  to avoid accidentally downgrading someone else's package.
  Put the output of `make upgrade` in its own separate commit,
  decoupled from other code changes.
- Aim for comprehensive test coverage, but remember that
  automated testing isn't a substitute for manual verification.
- Carefully consider naming, code organization, dependencies when adding new code.
  Code that is amenable to refactoring and improvement benefits all platform developers,
  especially given the size and scope of edx-platform.
  Consult existing Architectural Decision Records (ADRs),
  including those concerning the app(s) you are changing and
  [those concerning edx-platform as a whole](https://github.com/edx/edx-platform/tree/master/docs/decisions).
