### PR TITLE
ENT-2524: Unmarked name field of content gating partition for translation

### DIFF
--- a/openedx/features/content_type_gating/partitions.py
+++ b/openedx/features/content_type_gating/partitions.py
@@ -65,7 +65,9 @@ def create_content_gating_partition(course):
 
     partition = content_gate_scheme.create_user_partition(
         id=CONTENT_GATING_PARTITION_ID,
-        name=_(u"Feature-based Enrollments"),
+        # Content gating partition name should not be marked for translations
+        # edX mobile apps expect it in english
+        name=u"Feature-based Enrollments",
         description=_(u"Partition for segmenting users by access to gated content types"),
         parameters={"course_id": six.text_type(course.id)}
     )


### PR DESCRIPTION
Unmarked name field in content gating partition for translation. edX mobile apps expect it in english. If value of name field of content gating partition is not `Feature-based Enrollments` string literal mobile apps ignore gating restriction and try to pull content of the block which cause a lot of 404 errors for all those blocks which are gated in particular course.
ENT-2524

### Please consider the following when opening a pull request:

- Link to the relevant JIRA ticket(s) and tag any relevant team(s).
- Squash your changes down into one or more discrete commits.
  In each commit, include description that could help a developer
  several months from now.
- If running `make upgrade`, run _as close to the time of merging as possible_
  to avoid accidentally downgrading someone else's package.
  Put the output of `make upgrade` in its own separate commit,
  decoupled from other code changes.
- Aim for comprehensive test coverage, but remember that
  automated testing isn't a substitute for manual verification.
- Carefully consider naming, code organization, dependencies when adding new code.
  Code that is amenable to refactoring and improvement benefits all platform developers,
  especially given the size and scope of edx-platform.
  Consult existing Architectural Decision Records (ADRs),
  including those concerning the app(s) you are changing and
  [those concerning edx-platform as a whole](https://github.com/edx/edx-platform/tree/master/docs/decisions).
