### PR TITLE
Updated the django-ratelimit to add support for Django 2.2

### DIFF
--- a/lms/djangoapps/oauth2_handler/tests.py
+++ b/lms/djangoapps/oauth2_handler/tests.py
@@ -140,11 +140,13 @@ class IDTokenTest(BaseTestMixin, IDTokenTestCase):
         self.assertTrue(claims['administrator'])
 
     def test_rate_limit_token(self):
-        with mock.patch('openedx.core.djangoapps.oauth_dispatch.views.AccessTokenView.ratelimit_rate', '1/m'):
-            response = self.get_access_token_response('openid profile permissions')
-            self.assertEqual(response.status_code, 200)
-            response = self.get_access_token_response('openid profile permissions')
-            self.assertEqual(response.status_code, 403)
+
+        response = self.get_access_token_response('openid profile permissions')
+        self.assertEqual(response.status_code, 200)
+        response = self.get_access_token_response('openid profile permissions')
+        self.assertEqual(response.status_code, 200)
+        response = self.get_access_token_response('openid profile permissions')
+        self.assertEqual(response.status_code, 403)
 
 
 class UserInfoTest(BaseTestMixin, UserInfoTestCase):

--- a/lms/envs/test.py
+++ b/lms/envs/test.py
@@ -599,3 +599,7 @@ ACCOUNT_MICROFRONTEND_URL = "http://account-mfe/"
 DASHBOARD_COURSE_LIMIT = 250
 
 PROCTORING_SETTINGS = {}
+
+############### Settings for Django Rate limit #####################
+
+RATELIMIT_RATE = '2/m'

--- a/requirements/edx/base.in
+++ b/requirements/edx/base.in
@@ -52,7 +52,6 @@ django-mysql
 django-oauth-toolkit                # Provides oAuth2 capabilities for Django
 django-pipeline
 django-pyfs
-django-ratelimit
 django-ratelimit-backend
 django-require
 django-sekizai

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -7,6 +7,7 @@
 -e git+https://github.com/edx/acid-block.git@98aecba94ecbfa934e2d00262741c0ea9f557fc9#egg=acid-xblock
 -e common/lib/capa
 -e git+https://github.com/edx/codejail.git@4127fc4bd5775cc72aee8d7f0a70e31405e22439#egg=codejail
+-e git+https://github.com/jsocol/django-ratelimit.git@72edbe8949fbf6699848e5847645a1998f121d46#egg=ratelimit
 -e git+https://github.com/edx/django-wiki.git@v0.0.25#egg=django-wiki
 -e git+https://github.com/edx/DoneXBlock.git@2.0.1#egg=done-xblock
 -e git+https://github.com/jazkarta/edx-jsme.git@690dbf75441fa91c7c4899df0b83d77f7deb5458#egg=edx-jsme
@@ -76,7 +77,6 @@ django-object-actions==2.0.0  # via edx-enterprise
 django-pipeline==1.7.0
 django-pyfs==2.1
 django-ratelimit-backend==2.0
-django-ratelimit==2.0.0
 django-require==1.0.11
 django-sekizai==1.1.0
 django-ses==0.8.14

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -7,6 +7,7 @@
 -e git+https://github.com/edx/acid-block.git@98aecba94ecbfa934e2d00262741c0ea9f557fc9#egg=acid-xblock
 -e common/lib/capa
 -e git+https://github.com/edx/codejail.git@4127fc4bd5775cc72aee8d7f0a70e31405e22439#egg=codejail
+-e git+https://github.com/jsocol/django-ratelimit.git@72edbe8949fbf6699848e5847645a1998f121d46#egg=ratelimit
 -e git+https://github.com/edx/django-wiki.git@v0.0.25#egg=django-wiki
 -e git+https://github.com/edx/DoneXBlock.git@2.0.1#egg=done-xblock
 -e git+https://github.com/jazkarta/edx-jsme.git@690dbf75441fa91c7c4899df0b83d77f7deb5458#egg=edx-jsme
@@ -87,7 +88,6 @@ django-object-actions==2.0.0
 django-pipeline==1.7.0
 django-pyfs==2.1
 django-ratelimit-backend==2.0
-django-ratelimit==2.0.0
 django-require==1.0.11
 django-sekizai==1.1.0
 django-ses==0.8.14

--- a/requirements/edx/github.in
+++ b/requirements/edx/github.in
@@ -60,6 +60,7 @@ git+https://github.com/edx/openedx-chem.git@ff4e3a03d3c7610e47a9af08eb648d8aabe2
 git+https://github.com/edx/MongoDBProxy.git@d92bafe9888d2940f647a7b2b2383b29c752f35a#egg=MongoDBProxy==0.1.0+edx.2
 -e git+https://github.com/dementrock/pystache_custom.git@776973740bdaad83a3b029f96e415a7d1e8bec2f#egg=pystache_custom-dev
 -e git+https://github.com/jazkarta/edx-jsme.git@690dbf75441fa91c7c4899df0b83d77f7deb5458#egg=edx-jsme
+-e git+https://github.com/jsocol/django-ratelimit.git@72edbe8949fbf6699848e5847645a1998f121d46#egg=ratelimit
 
 # Forked to get Django 2.2 support from unreleased master branch from social-app-django repo.
 # This can be removed once an official social-auth-app-django Pypi release with Django 2.2 support is available in the future.

--- a/requirements/edx/testing.in
+++ b/requirements/edx/testing.in
@@ -48,4 +48,3 @@ tox                       # virtualenv management for tests
 tox-battery               # Makes tox aware of requirements file changes
 transifex-client          # Command-line interface for the Transifex localization service
 unidiff                   # Required by coverage_pytest_plugin
-

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -7,6 +7,7 @@
 -e git+https://github.com/edx/acid-block.git@98aecba94ecbfa934e2d00262741c0ea9f557fc9#egg=acid-xblock
 -e common/lib/capa
 -e git+https://github.com/edx/codejail.git@4127fc4bd5775cc72aee8d7f0a70e31405e22439#egg=codejail
+-e git+https://github.com/jsocol/django-ratelimit.git@72edbe8949fbf6699848e5847645a1998f121d46#egg=ratelimit
 -e git+https://github.com/edx/django-wiki.git@v0.0.25#egg=django-wiki
 -e git+https://github.com/edx/DoneXBlock.git@2.0.1#egg=done-xblock
 -e git+https://github.com/jazkarta/edx-jsme.git@690dbf75441fa91c7c4899df0b83d77f7deb5458#egg=edx-jsme
@@ -84,7 +85,6 @@ django-object-actions==2.0.0
 django-pipeline==1.7.0
 django-pyfs==2.1
 django-ratelimit-backend==2.0
-django-ratelimit==2.0.0
 django-require==1.0.11
 django-sekizai==1.1.0
 django-ses==0.8.14


### PR DESCRIPTION
Relevant JIRA issue can be found [here](https://openedx.atlassian.net/browse/BOM-1144).
Make upgrade is still in progress on this PR.

[Documentation](https://github.com/jsocol/django-ratelimit/blob/master/docs/usage.rst)