### PR TITLE
ENT-2535: Added link to error message displayed when TPA only user login from FPA form

### DIFF
--- a/openedx/core/djangoapps/user_authn/views/login.py
+++ b/openedx/core/djangoapps/user_authn/views/login.py
@@ -16,6 +16,7 @@ from django.contrib.auth import login as django_login
 from django.contrib.auth.decorators import login_required
 from django.contrib.auth.models import User
 from django.http import HttpRequest, HttpResponse
+from django.urls import reverse
 from django.utils.decorators import method_decorator
 from django.utils.translation import ugettext as _
 from django.views.decorators.csrf import csrf_exempt, csrf_protect, ensure_csrf_cookie
@@ -292,11 +293,19 @@ def _check_user_auth_flow(site, user):
 
         # If user belongs to allowed domain and not whitelisted then user must login through allowed domain SSO
         if user_domain == allowed_domain and not AllowedAuthUser.objects.filter(site=site, email=user.email).exists():
-            msg = _(
-                u'As an {allowed_domain} user, You must login with your {allowed_domain} {provider} account.'
-            ).format(
+            msg = Text(_(
+                u'As {allowed_domain} user, You must login with your {allowed_domain} '
+                u'{link_start}{provider} account{link_end}.'
+            )).format(
                 allowed_domain=allowed_domain,
-                provider=site.configuration.get_value('THIRD_PARTY_AUTH_ONLY_PROVIDER')
+                link_start=HTML("<a href='{tpa_provider_link}'>").format(
+                    tpa_provider_link='{dashboard_url}?tpa_hint={tpa_hint}'.format(
+                        dashboard_url=reverse('dashboard'),
+                        tpa_hint=site.configuration.get_value('THIRD_PARTY_AUTH_HINT'),
+                    )
+                ),
+                provider=site.configuration.get_value('THIRD_PARTY_AUTH_ONLY_PROVIDER'),
+                link_end=HTML("</a>")
             )
             raise AuthFailedError(msg)
 

--- a/openedx/core/djangoapps/user_authn/views/tests/test_login.py
+++ b/openedx/core/djangoapps/user_authn/views/tests/test_login.py
@@ -616,6 +616,7 @@ class LoginTest(SiteMixin, CacheIsolationTestCase):
         },
     )
     @ddt.unpack
+    @skip_unless_lms
     def test_login_for_user_auth_flow(
         self,
         switch_enabled,
@@ -629,6 +630,7 @@ class LoginTest(SiteMixin, CacheIsolationTestCase):
         Verify that `login._check_user_auth_flow` works as expected.
         """
         provider = 'Google'
+        provider_tpa_hint = 'saml-test'
         username = 'batman'
         user_email = '{username}@{domain}'.format(username=username, domain=user_domain)
         user = self._create_user(username, user_email)
@@ -636,6 +638,7 @@ class LoginTest(SiteMixin, CacheIsolationTestCase):
             'SITE_NAME': allowed_domain,
             'THIRD_PARTY_AUTH_ONLY_DOMAIN': allowed_domain,
             'THIRD_PARTY_AUTH_ONLY_PROVIDER': provider,
+            'THIRD_PARTY_AUTH_HINT': provider_tpa_hint,
         }
 
         with ENABLE_LOGIN_USING_THIRDPARTY_AUTH_ONLY.override(switch_enabled):
@@ -647,10 +650,14 @@ class LoginTest(SiteMixin, CacheIsolationTestCase):
                 else:
                     AllowedAuthUser.objects.filter(site=site, email=user.email).delete()
 
-                value = None if success else u'As an {0} user, You must login with your {0} {1} account.'.format(
-                    allowed_domain,
-                    provider
-                )
+                if success:
+                    value = None
+                else:
+                    value = u'As {0} user, You must login with your {0} <a href=\'{1}\'>{2} account</a>.'.format(
+                        allowed_domain,
+                        '{}?tpa_hint={}'.format(reverse("dashboard"), provider_tpa_hint),
+                        provider,
+                    )
                 response, __ = self._login_response(user.email, self.password)
                 self._assert_response(
                     response,


### PR DESCRIPTION
Added link SAML flow in error message displayed when TPA only user login from FPA login page. This would allow users to initial SAML flow by clicking on the link instead of find social auth buttons on login page.

### Please consider the following when opening a pull request:

- Link to the relevant JIRA ticket(s) and tag any relevant team(s).
- Squash your changes down into one or more discrete commits.
  In each commit, include description that could help a developer
  several months from now.
- If running `make upgrade`, run _as close to the time of merging as possible_
  to avoid accidentally downgrading someone else's package.
  Put the output of `make upgrade` in its own separate commit,
  decoupled from other code changes.
- Aim for comprehensive test coverage, but remember that
  automated testing isn't a substitute for manual verification.
- Carefully consider naming, code organization, dependencies when adding new code.
  Code that is amenable to refactoring and improvement benefits all platform developers,
  especially given the size and scope of edx-platform.
  Consult existing Architectural Decision Records (ADRs),
  including those concerning the app(s) you are changing and
  [those concerning edx-platform as a whole](https://github.com/edx/edx-platform/tree/master/docs/decisions).
