### PR TITLE
Update edx-django-release-util to fix a bug in ordering.

### DIFF
--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -101,7 +101,7 @@ edx-ccx-keys==1.0.0
 edx-celeryutils==0.3.1
 edx-completion==3.0.2
 edx-django-oauth2-provider==1.3.5
-edx-django-release-util==0.3.2
+edx-django-release-util==0.3.3
 edx-django-sites-extensions==2.4.2
 edx-django-utils==2.0.2
 edx-drf-extensions==2.4.5

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -115,7 +115,7 @@ edx-ccx-keys==1.0.0
 edx-celeryutils==0.3.1
 edx-completion==3.0.2
 edx-django-oauth2-provider==1.3.5
-edx-django-release-util==0.3.2
+edx-django-release-util==0.3.3
 edx-django-sites-extensions==2.4.2
 edx-django-utils==2.0.2
 edx-drf-extensions==2.4.5

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -112,7 +112,7 @@ edx-ccx-keys==1.0.0
 edx-celeryutils==0.3.1
 edx-completion==3.0.2
 edx-django-oauth2-provider==1.3.5
-edx-django-release-util==0.3.2
+edx-django-release-util==0.3.3
 edx-django-sites-extensions==2.4.2
 edx-django-utils==2.0.2
 edx-drf-extensions==2.4.5


### PR DESCRIPTION
The files generated for bokchoy db caching were generated using a `set` which no longer preserves order in Python 3.

https://openedx.atlassian.net/browse/BOM-1129