### PR TITLE
EDUCATOR-4858: Update teams service to consider teamset/topic

### DIFF
--- a/lms/djangoapps/teams/services.py
+++ b/lms/djangoapps/teams/services.py
@@ -6,9 +6,9 @@ from django.urls import reverse
 
 class TeamsService(object):
     """ Functions to provide teams functionality to XBlocks"""
-    def get_team(self, user, course_id):
+    def get_team(self, user, course_id, topic_id):
         from . import api
-        return api.get_team_for_user_and_course(user, course_id)
+        return api.get_team_for_user_course_topic(user, course_id, topic_id)
 
     def get_team_detail_url(self, team):
         """ Returns the url to the detail view for the given team """

--- a/lms/djangoapps/teams/tests/test_api.py
+++ b/lms/djangoapps/teams/tests/test_api.py
@@ -122,7 +122,7 @@ class PythonAPITests(SharedModuleStoreTestCase):
     @mock.patch('lms.djangoapps.teams.api.CourseTeam.objects')
     def test_get_team_multiple_teams(self, mocked_manager):
         """
-        This is a test for a use case that should never happen.
+        This is a test for a use case that is very unlikely to occur.
         Currently users cannot be in multiple teams in a course, but even after we allow multiple
         teams in a course then they should still be limited to one team per topic
         """

--- a/lms/djangoapps/teams/tests/test_api.py
+++ b/lms/djangoapps/teams/tests/test_api.py
@@ -3,15 +3,16 @@
 Tests for Python APIs of the Teams app
 """
 
-
 import unittest
 from uuid import uuid4
 
 import ddt
+import mock
 from opaque_keys.edx.keys import CourseKey
 
 from course_modes.models import CourseMode
 from lms.djangoapps.teams import api as teams_api
+from lms.djangoapps.teams.models import CourseTeam
 from lms.djangoapps.teams.tests.factories import CourseTeamFactory
 from student.models import CourseEnrollment
 from student.roles import CourseStaffRole
@@ -20,10 +21,13 @@ from xmodule.modulestore.tests.django_utils import SharedModuleStoreTestCase
 
 COURSE_KEY1 = CourseKey.from_string('edx/history/1')
 COURSE_KEY2 = CourseKey.from_string('edx/history/2')
+TOPIC1 = 'topic-1'
+TOPIC2 = 'topic-2'
 
 DISCUSSION_TOPIC_ID = uuid4().hex
 
 
+@ddt.ddt
 class PythonAPITests(SharedModuleStoreTestCase):
     """
     The set of tests for different API endpoints
@@ -34,22 +38,38 @@ class PythonAPITests(SharedModuleStoreTestCase):
         cls.user1 = UserFactory.create(username='user1')
         cls.user2 = UserFactory.create(username='user2')
         cls.user3 = UserFactory.create(username='user3')
+        cls.user4 = UserFactory.create(username='user4')
 
-        for user in (cls.user1, cls.user2, cls.user3):
+        for user in (cls.user1, cls.user2, cls.user3, cls.user4):
             CourseEnrollmentFactory.create(user=user, course_id=COURSE_KEY1)
 
-        CourseEnrollmentFactory.create(user=cls.user3, course_id=COURSE_KEY2)
+        for user in (cls.user3, cls.user4):
+            CourseEnrollmentFactory.create(user=user, course_id=COURSE_KEY2)
 
         cls.team1 = CourseTeamFactory(
             course_id=COURSE_KEY1,
             discussion_topic_id=DISCUSSION_TOPIC_ID,
-            team_id='team1'
+            team_id='team1',
+            topic_id=TOPIC1,
         )
-        cls.team2 = CourseTeamFactory(course_id=COURSE_KEY2, team_id='team2')
+        cls.team1a = CourseTeamFactory(  # Same topic / team set as team1
+            course_id=COURSE_KEY1,
+            team_id='team1a',
+            topic_id=TOPIC1,
+        )
+        cls.team2 = CourseTeamFactory(course_id=COURSE_KEY2, team_id='team2', topic_id=TOPIC2)
+        cls.team2a = CourseTeamFactory(  # Same topic / team set as team2
+            course_id=COURSE_KEY2,
+            team_id='team2a',
+            topic_id=TOPIC2
+        )
 
         cls.team1.add_user(cls.user1)
         cls.team1.add_user(cls.user2)
         cls.team2.add_user(cls.user3)
+
+        cls.team1a.add_user(cls.user4)
+        cls.team2a.add_user(cls.user4)
 
     def test_get_team_by_discussion_non_existence(self):
         self.assertIsNone(teams_api.get_team_by_discussion('DO_NOT_EXIST'))
@@ -81,34 +101,48 @@ class PythonAPITests(SharedModuleStoreTestCase):
         self.assertTrue(teams_api.discussion_visible_by_user(self.team2.discussion_topic_id, self.user2))
         self.assertTrue(teams_api.discussion_visible_by_user('DO_NOT_EXISTS', self.user3))
 
-    def test_get_team(self):
-        # Course 1
-        user1_team = teams_api.get_team_for_user_and_course(self.user1, str(COURSE_KEY1))
-        user2_team = teams_api.get_team_for_user_and_course(self.user2, str(COURSE_KEY1))
-        user3_team = teams_api.get_team_for_user_and_course(self.user3, str(COURSE_KEY1))
+    @ddt.unpack
+    @ddt.data(
+        (COURSE_KEY1, TOPIC1, ['team1', 'team1', None, 'team1a']),
+        (COURSE_KEY1, TOPIC2, [None, None, None, None]),
+        (COURSE_KEY2, TOPIC1, [None, None, None, None]),
+        (COURSE_KEY2, TOPIC2, [None, None, 'team2', 'team2a']),
+    )
+    def test_get_team_for_user_course_topic(self, course_key, topic_id, expected_team_ids):
+        user1_team = teams_api.get_team_for_user_course_topic(self.user1, str(course_key), topic_id)
+        user2_team = teams_api.get_team_for_user_course_topic(self.user2, str(course_key), topic_id)
+        user3_team = teams_api.get_team_for_user_course_topic(self.user3, str(course_key), topic_id)
+        user4_team = teams_api.get_team_for_user_course_topic(self.user4, str(course_key), topic_id)
 
-        self.assertEqual(user1_team, self.team1)
-        self.assertEqual(user2_team, self.team1)
-        self.assertEqual(user3_team, None)
+        self.assertEqual(user1_team.team_id if user1_team else None, expected_team_ids[0])
+        self.assertEqual(user2_team.team_id if user2_team else None, expected_team_ids[1])
+        self.assertEqual(user3_team.team_id if user3_team else None, expected_team_ids[2])
+        self.assertEqual(user4_team.team_id if user4_team else None, expected_team_ids[3])
 
-        # Course 2
-        user1_team = teams_api.get_team_for_user_and_course(self.user1, str(COURSE_KEY2))
-        user2_team = teams_api.get_team_for_user_and_course(self.user2, str(COURSE_KEY2))
-        user3_team = teams_api.get_team_for_user_and_course(self.user3, str(COURSE_KEY2))
+    @mock.patch('lms.djangoapps.teams.CourseTeam.objects')
+    def test_get_team_multiple_teams(self, mocked_manager):
+        """
+        This is a test for a use case that should never happen.
+        Currently users cannot be in multiple teams in a course, but even after we allow multiple
+        teams in a course then they should still be limited to one team per topic
+        """
+        mocked_manager.get.side_effect = CourseTeam.MultipleObjectsReturned()
+        expected_result = "This is somehow the first team"
+        mock_qs = mock.MagicMock()
+        mock_qs.first.return_value = expected_result
+        mocked_manager.filter.return_value = mock_qs
+        result = teams_api.get_team_for_user_course_topic(self.user1, str(COURSE_KEY1), TOPIC1)
+        self.assertEqual(result, expected_result)
 
-        self.assertEqual(user1_team, None)
-        self.assertEqual(user2_team, None)
-        self.assertEqual(user3_team, self.team2)
+    def test_get_team_course_not_found(self):
+        team = teams_api.get_team_for_user_course_topic(self.user1, 'nonsense/garbage/nonexistant', 'topic')
+        self.assertIsNone(team)
 
     def test_get_team_invalid_course(self):
         invalid_course_id = 'lol!()#^$&course'
         message = 'The supplied course id lol!()#^$&course is not valid'
         with self.assertRaisesMessage(ValueError, message):
-            teams_api.get_team_for_user_and_course(self.user1, invalid_course_id)
-
-    def test_get_team_course_not_found(self):
-        team = teams_api.get_team_for_user_and_course(self.user1, 'nonsense/garbage/nonexistant')
-        self.assertIsNone(team)
+            teams_api.get_team_for_user_course_topic(self.user1, invalid_course_id, 'who-cares')
 
 
 @ddt.ddt

--- a/lms/djangoapps/teams/tests/test_api.py
+++ b/lms/djangoapps/teams/tests/test_api.py
@@ -119,7 +119,7 @@ class PythonAPITests(SharedModuleStoreTestCase):
         self.assertEqual(user3_team.team_id if user3_team else None, expected_team_ids[2])
         self.assertEqual(user4_team.team_id if user4_team else None, expected_team_ids[3])
 
-    @mock.patch('lms.djangoapps.teams.CourseTeam.objects')
+    @mock.patch('lms.djangoapps.teams.api.CourseTeam.objects')
     def test_get_team_multiple_teams(self, mocked_manager):
         """
         This is a test for a use case that should never happen.


### PR DESCRIPTION
Requirement for [EDUCATOR-4858](https://openedx.atlassian.net/browse/EDUCATOR-4858)

Modify the teams service to accept a `topic_id` parameter to filter the query by