### PR TITLE
ENT-2535: Changed site configuration name to avoid conflict with existing configuration

### DIFF
--- a/openedx/core/djangoapps/user_authn/views/login.py
+++ b/openedx/core/djangoapps/user_authn/views/login.py
@@ -301,7 +301,7 @@ def _check_user_auth_flow(site, user):
                 link_start=HTML("<a href='{tpa_provider_link}'>").format(
                     tpa_provider_link='{dashboard_url}?tpa_hint={tpa_hint}'.format(
                         dashboard_url=reverse('dashboard'),
-                        tpa_hint=site.configuration.get_value('THIRD_PARTY_AUTH_HINT'),
+                        tpa_hint=site.configuration.get_value('THIRD_PARTY_AUTH_ONLY_HINT'),
                     )
                 ),
                 provider=site.configuration.get_value('THIRD_PARTY_AUTH_ONLY_PROVIDER'),

--- a/openedx/core/djangoapps/user_authn/views/tests/test_login.py
+++ b/openedx/core/djangoapps/user_authn/views/tests/test_login.py
@@ -638,7 +638,7 @@ class LoginTest(SiteMixin, CacheIsolationTestCase):
             'SITE_NAME': allowed_domain,
             'THIRD_PARTY_AUTH_ONLY_DOMAIN': allowed_domain,
             'THIRD_PARTY_AUTH_ONLY_PROVIDER': provider,
-            'THIRD_PARTY_AUTH_HINT': provider_tpa_hint,
+            'THIRD_PARTY_AUTH_ONLY_HINT': provider_tpa_hint,
         }
 
         with ENABLE_LOGIN_USING_THIRDPARTY_AUTH_ONLY.override(switch_enabled):


### PR DESCRIPTION
Changed `THIRD_PARTY_AUTH_HINT` configuration name to `THIRD_PARTY_AUTH_ONLY_HINT ` since `THIRD_PARTY_AUTH_HINT` is being already used.

### Please consider the following when opening a pull request:

- Link to the relevant JIRA ticket(s) and tag any relevant team(s).
- Squash your changes down into one or more discrete commits.
  In each commit, include description that could help a developer
  several months from now.
- If running `make upgrade`, run _as close to the time of merging as possible_
  to avoid accidentally downgrading someone else's package.
  Put the output of `make upgrade` in its own separate commit,
  decoupled from other code changes.
- Aim for comprehensive test coverage, but remember that
  automated testing isn't a substitute for manual verification.
- Carefully consider naming, code organization, dependencies when adding new code.
  Code that is amenable to refactoring and improvement benefits all platform developers,
  especially given the size and scope of edx-platform.
  Consult existing Architectural Decision Records (ADRs),
  including those concerning the app(s) you are changing and
  [those concerning edx-platform as a whole](https://github.com/edx/edx-platform/tree/master/docs/decisions).
