### PR TITLE
BOM 1087  django-mysql version bump

### DIFF
--- a/requirements/edx/base.in
+++ b/requirements/edx/base.in
@@ -48,7 +48,7 @@ django-ipware                       # Get the client's real IP address
 django-method-override
 django-model-utils
 django-mptt
-django-mysql==2.4.1
+django-mysql
 django-oauth-toolkit                # Provides oAuth2 capabilities for Django
 django-pipeline
 django-pyfs

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -68,7 +68,7 @@ django-method-override==0.2.0
 django-model-utils==3.0.0
 django-mptt==0.10.0
 django-multi-email-field==0.5.1  # via edx-enterprise
-django-mysql==2.4.1
+django-mysql==3.3.0
 git+https://github.com/edx/django-oauth-plus.git@b9b64a3ac24fd11f471763c88462bbf3c53e46e6#egg=django-oauth-plus==2.2.9.edx-4
 django-oauth-toolkit==1.1.3
 django-object-actions==2.0.0  # via edx-enterprise

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -81,7 +81,7 @@ django-method-override==0.2.0
 django-model-utils==3.0.0
 django-mptt==0.10.0
 django-multi-email-field==0.5.1
-django-mysql==2.4.1
+django-mysql==3.3.0
 git+https://github.com/edx/django-oauth-plus.git@b9b64a3ac24fd11f471763c88462bbf3c53e46e6#egg=django-oauth-plus==2.2.9.edx-4
 django-oauth-toolkit==1.1.3
 django-object-actions==2.0.0

--- a/requirements/edx/testing.in
+++ b/requirements/edx/testing.in
@@ -25,7 +25,8 @@ ddt                       # Run a test case multiple times with different input;
 edx-i18n-tools>=0.4.6     # Commands for developers and translators to extract, compile and validate translations
 edx-lint==1.3.0           # pylint extensions for Open edX repositories
 factory_boy==2.8.1        # Library for creating test fixtures, used in many tests
-freezegun                 # Allows tests to mock the output of assorted datetime module functions
+# Pinning the freezegun version because 0.3.13 is causing failures which have also been reported on the git repo by public.
+freezegun==0.3.12         # Allows tests to mock the output of assorted datetime module functions
 httpretty                 # Library for mocking HTTP requests, used in many tests
 isort                     # For checking and fixing the order of imports
 moto==1.3.1               # Lets tests mock AWS access via the boto library

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -79,7 +79,7 @@ django-method-override==0.2.0
 django-model-utils==3.0.0
 django-mptt==0.10.0
 django-multi-email-field==0.5.1
-django-mysql==2.4.1
+django-mysql==3.3.0
 git+https://github.com/edx/django-oauth-plus.git@b9b64a3ac24fd11f471763c88462bbf3c53e46e6#egg=django-oauth-plus==2.2.9.edx-4
 django-oauth-toolkit==1.1.3
 django-object-actions==2.0.0


### PR DESCRIPTION
**Ticket:** [BOM-1087](https://openedx.atlassian.net/browse/BOM-1087)

### Description
Removed the version constraint for django-mysql
Also pinned the freezegun version to 0.3.12 as the latest version is causing failures.