### PR TITLE
EDUCATOR-4870: Add teams service function to lookup teamset

### DIFF
--- a/lms/djangoapps/teams/api.py
+++ b/lms/djangoapps/teams/api.py
@@ -15,6 +15,7 @@ from lms.djangoapps.discussion.django_comment_client.utils import has_discussion
 from lms.djangoapps.teams.models import CourseTeam
 from student.models import CourseEnrollment
 from student.roles import CourseInstructorRole, CourseStaffRole
+from xmodule.modulestore.django import modulestore
 
 logger = logging.getLogger(__name__)
 
@@ -278,3 +279,28 @@ def get_team_for_user_course_topic(user, course_id, topic_id):
             membership__user__username=user.username,
             topic_id=topic_id,
         ).first()
+
+
+def get_teamset(course_id, teamset_id):
+    """
+    Returns the TeamsetConfig associated with this course_id and teamset_id
+
+    If course_id is invalid, raises a ValueError
+    If the course associated with course_id is not found, returns None
+    If the teamset associated with teamset_id is not found, returns None
+    """
+    try:
+        course_key = CourseKey.from_string(course_id)
+    except InvalidKeyError:
+        raise ValueError(u"The supplied course id {course_id} is not valid.".format(
+            course_id=course_id
+        ))
+
+    course_module = modulestore().get_course(course_key)
+    if course_module is None:
+        return None
+
+    try:
+        return course_module.teamsets_by_id[teamset_id]
+    except KeyError:
+        return None

--- a/lms/djangoapps/teams/api.py
+++ b/lms/djangoapps/teams/api.py
@@ -246,9 +246,9 @@ def can_user_create_team_in_topic(user, course_id, topic_id):
     )
 
 
-def get_team_for_user_course_topic(user, course_id, topic_id):
+def get_team_for_user_course_teamset(user, course_id, teamset_id):
     """
-    Returns the matching CourseTeam for the given user, course, and topic
+    Returns the matching CourseTeam for the given user, course, and teamset
 
     If course_id is invalid, a ValueError is raised
     """
@@ -262,7 +262,7 @@ def get_team_for_user_course_topic(user, course_id, topic_id):
         return CourseTeam.objects.get(
             course_id=course_key,
             membership__user__username=user.username,
-            topic_id=topic_id,
+            topic_id=teamset_id,
         )
     except CourseTeam.DoesNotExist:
         return None
@@ -272,12 +272,12 @@ def get_team_for_user_course_topic(user, course_id, topic_id):
         logger.error(msg.format(
             username=user.username,
             course=course_id,
-            topic=topic_id,
+            topic=teamset_id,
         ))
         return CourseTeam.objects.filter(
             course_id=course_key,
             membership__user__username=user.username,
-            topic_id=topic_id,
+            topic_id=teamset_id,
         ).first()
 
 

--- a/lms/djangoapps/teams/services.py
+++ b/lms/djangoapps/teams/services.py
@@ -10,6 +10,10 @@ class TeamsService(object):
         from . import api
         return api.get_team_for_user_course_teamset(user, course_id, teamset_id)
 
+    def get_teamset(self, course_id, teamset_id):
+        from . import api
+        return api.get_teamset(course_id, teamset_id)
+
     def get_team_detail_url(self, team):
         """ Returns the url to the detail view for the given team """
         teams_dashboard_url = reverse('teams_dashboard', kwargs={'course_id': team.course_id})

--- a/lms/djangoapps/teams/services.py
+++ b/lms/djangoapps/teams/services.py
@@ -6,9 +6,9 @@ from django.urls import reverse
 
 class TeamsService(object):
     """ Functions to provide teams functionality to XBlocks"""
-    def get_team(self, user, course_id, topic_id):
+    def get_team(self, user, course_id, teamset_id):
         from . import api
-        return api.get_team_for_user_course_topic(user, course_id, topic_id)
+        return api.get_team_for_user_course_teamset(user, course_id, teamset_id)
 
     def get_team_detail_url(self, team):
         """ Returns the url to the detail view for the given team """

--- a/lms/djangoapps/teams/tests/test_services.py
+++ b/lms/djangoapps/teams/tests/test_services.py
@@ -3,10 +3,11 @@
 Tests for any Teams app services
 """
 
-
-from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
 from openedx.core.djangoapps.catalog.tests.factories import CourseRunFactory
+from openedx.core.lib.teams_config import TeamsConfig
 from student.tests.factories import CourseEnrollmentFactory, UserFactory
+from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
+from xmodule.modulestore.tests.factories import CourseFactory
 
 from lms.djangoapps.teams.services import TeamsService
 from lms.djangoapps.teams.tests.factories import CourseTeamFactory
@@ -48,3 +49,20 @@ class TeamsServiceTests(ModuleStoreTestCase):
                 self.team.team_id,
             ]
         )
+
+    def test_get_teamset(self):
+        course = CourseFactory.create(
+            teams_configuration=TeamsConfig({
+                "max_team_size": 10,
+                "topics": [
+                    {
+                        "name": u"Topic 1",
+                        "id": "topic_id",
+                        "description": u"Description",
+                    }
+                ]
+            })
+        )
+        teamset = self.service.get_teamset(str(course.id), 'topic_id')
+        self.assertEqual(teamset.name, "Topic 1")
+        self.assertEqual(teamset.description, "Description")


### PR DESCRIPTION
prep for [EDUCATOR-4870: Change 'teamless' message to include teamset name](https://openedx.atlassian.net/browse/EDUCATOR-4870)

Add function to TeamsService that allows the ORA Xblock to look up the teamset name to display a more helpful name when the user is not in a team in the block's teamset

Also, made some nonfunctional changes to the service and api to try to minimize the use of the tear `topic` in favor of `teamset`