### PR TITLE
Fix: KeyError: 'source' when parsing HTML5 videos

### DIFF
--- a/common/lib/xmodule/xmodule/video_module/video_module.py
+++ b/common/lib/xmodule/xmodule/video_module/video_module.py
@@ -617,6 +617,8 @@ class VideoBlock(
         video_block = runtime.construct_xblock_from_class(cls, keys)
         field_data = cls.parse_video_xml(node)
         for key, val in field_data.items():
+            if key not in cls.fields:
+                continue  # parse_video_xml returns some old non-fields like 'source'
             setattr(video_block, key, cls.fields[key].from_json(val))
         # Don't use VAL in the new runtime:
         video_block.edx_video_id = None


### PR DESCRIPTION
This fixes a bug that causes the video XBlock parsing to break in the new XBlock runtime if:
* the `html5_sources` field is set, and
* the `download_video` field is not set

The error is:
```
  File "/edx/app/edxapp/edx-platform/openedx/core/djangoapps/xblock/rest_api/views.py", line 52, in render_block_view
    block = load_block(usage_key, request.user)
  File "/edx/app/edxapp/edx-platform/openedx/core/djangoapps/xblock/api.py", line 84, in load_block
    return runtime.get_block(usage_key)
  File "/edx/app/edxapp/edx-platform/openedx/core/djangoapps/xblock/runtime/blockstore_runtime.py", line 70, in get_block
    block = block_class.parse_xml_new_runtime(xml_node, runtime=self, keys=keys)
  File "/edx/app/edxapp/edx-platform/common/lib/xmodule/xmodule/video_module/video_module.py", line 620, in parse_xml_new_runtime
    setattr(video_block, key, cls.fields[key].from_json(val))
KeyError: 'source'
```

The reason for the error is that `parse_video_xml()` will sometimes return a `source` attribute in its `field_data` return value, even though `source` is not a video field (anymore).  This then causes an error when trying to look up `cls.fields['source']`

A workaround in the meantime is to add `download_video="false"` to the OLX.