### PR TITLE
Update edx-val from 1.2.0 to 1.2.1

### DIFF
--- a/common/djangoapps/util/tests/test_db.py
+++ b/common/djangoapps/util/tests/test_db.py
@@ -222,6 +222,7 @@ class MigrationTests(TestCase):
     Tests for migrations.
     """
 
+    @unittest.skip("Need to skip as step 3 of a 4-release rollout to rename a field in edx-val 1.2.1. This work is part of DE-1824.")
     @override_settings(MIGRATION_MODULES={})
     def test_migrations_are_in_sync(self):
         """

--- a/requirements/edx-sandbox/py35.txt
+++ b/requirements/edx-sandbox/py35.txt
@@ -26,7 +26,7 @@ python-dateutil==2.8.1    # via matplotlib
 pytz==2019.3              # via matplotlib
 random2==1.0.1
 scipy==1.2.1
-six==1.13.0
+six==1.14.0
 sympy==1.4
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/requirements/edx-sandbox/shared.txt
+++ b/requirements/edx-sandbox/shared.txt
@@ -9,4 +9,4 @@ cryptography==2.8
 lxml==4.4.2
 nltk==3.4.5
 pycparser==2.19           # via cffi
-six==1.13.0               # via cryptography, nltk
+six==1.14.0               # via cryptography, nltk

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -103,7 +103,7 @@ edx-completion==3.0.2
 edx-django-oauth2-provider==1.3.5
 edx-django-release-util==0.3.3
 edx-django-sites-extensions==2.4.2
-edx-django-utils==2.0.2
+edx-django-utils==2.0.3
 edx-drf-extensions==2.4.5
 edx-enterprise==2.0.48
 edx-i18n-tools==0.5.0
@@ -121,7 +121,7 @@ edx-submissions==3.0.3
 edx-tincan-py35==0.0.5    # via edx-enterprise
 edx-user-state-client==1.1.2
 edx-when==0.5.2
-edxval==1.2.0
+edxval==1.2.1
 elasticsearch==1.9.0      # via edx-search
 enum34==1.1.6             # via edxval
 event-tracking==0.3.0
@@ -219,7 +219,7 @@ semantic-version==2.8.4   # via edx-drf-extensions
 shapely==1.6.4.post2
 shortuuid==0.5.0          # via edx-django-oauth2-provider
 simplejson==3.17.0
-six==1.13.0
+six==1.14.0
 slumber==0.7.1            # via edx-bulk-grades, edx-enterprise, edx-rest-api-client
 social-auth-app-django==3.1.0
 social-auth-core==3.2.0

--- a/requirements/edx/coverage.txt
+++ b/requirements/edx/coverage.txt
@@ -18,5 +18,5 @@ pluggy==0.13.1            # via diff-cover
 pygments==2.5.2           # via diff-cover
 python-dateutil==2.4.0    # via pandas
 pytz==2019.3              # via pandas
-six==1.13.0               # via diff-cover
+six==1.14.0               # via diff-cover
 zipp==1.0.0               # via importlib-metadata

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -117,7 +117,7 @@ edx-completion==3.0.2
 edx-django-oauth2-provider==1.3.5
 edx-django-release-util==0.3.3
 edx-django-sites-extensions==2.4.2
-edx-django-utils==2.0.2
+edx-django-utils==2.0.3
 edx-drf-extensions==2.4.5
 edx-enterprise==2.0.48
 edx-i18n-tools==0.5.0
@@ -137,7 +137,7 @@ edx-submissions==3.0.3
 edx-tincan-py35==0.0.5
 edx-user-state-client==1.1.2
 edx-when==0.5.2
-edxval==1.2.0
+edxval==1.2.1
 elasticsearch==1.9.0
 entrypoints==0.3
 enum34==1.1.6
@@ -286,7 +286,7 @@ shapely==1.6.4.post2
 shortuuid==0.5.0
 simplejson==3.17.0
 singledispatch==3.4.0.3
-six==1.13.0
+six==1.14.0
 slumber==0.7.1
 snowballstemmer==2.0.0    # via sphinx
 social-auth-app-django==3.1.0

--- a/requirements/edx/paver.txt
+++ b/requirements/edx/paver.txt
@@ -22,7 +22,7 @@ pymongo==3.9.0
 python-memcached==1.59
 pyyaml==5.3               # via watchdog
 requests==2.22.0
-six==1.13.0               # via edx-opaque-keys, libsass, mock, paver, python-memcached, stevedore
+six==1.14.0               # via edx-opaque-keys, libsass, mock, paver, python-memcached, stevedore
 stevedore==1.31.0
 urllib3==1.25.7           # via requests
 watchdog==0.9.0

--- a/requirements/edx/pip-tools.txt
+++ b/requirements/edx/pip-tools.txt
@@ -6,4 +6,4 @@
 #
 click==7.0                # via pip-tools
 pip-tools==4.3.0
-six==1.13.0
+six==1.14.0

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -114,7 +114,7 @@ edx-completion==3.0.2
 edx-django-oauth2-provider==1.3.5
 edx-django-release-util==0.3.3
 edx-django-sites-extensions==2.4.2
-edx-django-utils==2.0.2
+edx-django-utils==2.0.3
 edx-drf-extensions==2.4.5
 edx-enterprise==2.0.48
 edx-i18n-tools==0.5.0
@@ -133,7 +133,7 @@ edx-submissions==3.0.3
 edx-tincan-py35==0.0.5
 edx-user-state-client==1.1.2
 edx-when==0.5.2
-edxval==1.2.0
+edxval==1.2.1
 elasticsearch==1.9.0
 entrypoints==0.3          # via flake8
 enum34==1.1.6
@@ -275,7 +275,7 @@ shapely==1.6.4.post2
 shortuuid==0.5.0
 simplejson==3.17.0
 singledispatch==3.4.0.3
-six==1.13.0
+six==1.14.0
 slumber==0.7.1
 social-auth-app-django==3.1.0
 social-auth-core==3.2.0


### PR DESCRIPTION
This is step 3 of DE-1824.

Also update:
* six 1.13.0 => 1.14.0
* edx-django-utils 2.0.2 => 2.0.3
* skip test that checks all model changes have migrations.  (We defer
  this to step 4.)

### Please consider the following when opening a pull request:

- Link to the relevant JIRA ticket(s) and tag any relevant team(s).
- Squash your changes down into one or more discrete commits.
  In each commit, include description that could help a developer
  several months from now.
- If running `make upgrade`, run _as close to the time of merging as possible_
  to avoid accidentally downgrading someone else's package.
  Put the output of `make upgrade` in its own separate commit,
  decoupled from other code changes.
- Aim for comprehensive test coverage, but remember that
  automated testing isn't a substitute for manual verification.
- Carefully consider naming, code organization, dependencies when adding new code.
  Code that is amenable to refactoring and improvement benefits all platform developers,
  especially given the size and scope of edx-platform.
  Consult existing Architectural Decision Records (ADRs),
  including those concerning the app(s) you are changing and
  [those concerning edx-platform as a whole](https://github.com/edx/edx-platform/tree/master/docs/decisions).
