### PR TITLE
BOM-1141 Upgrade social-auth-app-django

### DIFF
--- a/requirements/edx/base.in
+++ b/requirements/edx/base.in
@@ -131,7 +131,6 @@ pyuca                               # For more accurate sorting of translated co
 recommender-xblock                  # https://github.com/edx/RecommenderXBlock
 rest-condition                      # DRF's recommendation for supporting complex permissions
 rfc6266-parser                      # Used to generate Content-Disposition headers.
-social-auth-app-django
 social-auth-core
 pysrt                               # Support for SubRip subtitle files, used in the video XModule
 pytz                                # Time zone information database

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -15,6 +15,7 @@
 -e git+https://github.com/edx/RateXBlock.git@2.0#egg=rate-xblock
 -e common/lib/safe_lxml
 -e common/lib/sandbox-packages
+-e git+https://github.com/python-social-auth/social-app-django.git@c00d23c2b45c3317bd35b15ad1b959338689cef8#egg=social_django
 -e common/lib/symmath
 -e openedx/core/lib/xblock_builtin/xblock_discussion
 -e git+https://github.com/edx-solutions/xblock-google-drive.git@2d176468e33c0713c911b563f8f65f7cf232f5b6#egg=xblock-google-drive
@@ -105,7 +106,7 @@ edx-django-release-util==0.3.3
 edx-django-sites-extensions==2.4.2
 edx-django-utils==2.0.3
 edx-drf-extensions==2.4.5
-edx-enterprise==2.0.48
+edx-enterprise==2.0.49
 edx-i18n-tools==0.5.0
 edx-milestones==0.2.6
 edx-oauth2-provider==1.3.1
@@ -221,7 +222,6 @@ shortuuid==0.5.0          # via edx-django-oauth2-provider
 simplejson==3.17.0
 six==1.14.0
 slumber==0.7.1            # via edx-bulk-grades, edx-enterprise, edx-rest-api-client
-social-auth-app-django==3.1.0
 social-auth-core==3.2.0
 sorl-thumbnail==12.5.0
 sortedcontainers==2.1.0

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -15,6 +15,7 @@
 -e git+https://github.com/edx/RateXBlock.git@2.0#egg=rate-xblock
 -e common/lib/safe_lxml
 -e common/lib/sandbox-packages
+-e git+https://github.com/python-social-auth/social-app-django.git@c00d23c2b45c3317bd35b15ad1b959338689cef8#egg=social_django
 -e common/lib/symmath
 -e openedx/core/lib/xblock_builtin/xblock_discussion
 -e git+https://github.com/edx-solutions/xblock-google-drive.git@2d176468e33c0713c911b563f8f65f7cf232f5b6#egg=xblock-google-drive
@@ -116,7 +117,7 @@ edx-django-release-util==0.3.3
 edx-django-sites-extensions==2.4.2
 edx-django-utils==2.0.3
 edx-drf-extensions==2.4.5
-edx-enterprise==2.0.48
+edx-enterprise==2.0.49
 edx-i18n-tools==0.5.0
 edx-lint==1.3.0
 edx-milestones==0.2.6
@@ -283,7 +284,6 @@ singledispatch==3.4.0.3
 six==1.14.0
 slumber==0.7.1
 snowballstemmer==2.0.0    # via sphinx
-social-auth-app-django==3.1.0
 social-auth-core==3.2.0
 sorl-thumbnail==12.5.0
 sortedcontainers==2.1.0

--- a/requirements/edx/github.in
+++ b/requirements/edx/github.in
@@ -61,6 +61,10 @@ git+https://github.com/edx/MongoDBProxy.git@d92bafe9888d2940f647a7b2b2383b29c752
 -e git+https://github.com/dementrock/pystache_custom.git@776973740bdaad83a3b029f96e415a7d1e8bec2f#egg=pystache_custom-dev
 -e git+https://github.com/jazkarta/edx-jsme.git@690dbf75441fa91c7c4899df0b83d77f7deb5458#egg=edx-jsme
 
+# Forked to get Django 2.2 support from unreleased master branch from social-app-django repo.
+# This can be removed once an official social-auth-app-django Pypi release with Django 2.2 support is available in the future.
+-e git+https://github.com/python-social-auth/social-app-django.git@c00d23c2b45c3317bd35b15ad1b959338689cef8#egg=social-auth-app-django
+
 # Forked to get Django 1.10+ compat that is in origin BitBucket repo, without an official build.
 # This can go away when we update auth to not use django-rest-framework-oauth
 git+https://github.com/edx/django-oauth-plus.git@b9b64a3ac24fd11f471763c88462bbf3c53e46e6#egg=django-oauth-plus==2.2.9.edx-4

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -15,6 +15,7 @@
 -e git+https://github.com/edx/RateXBlock.git@2.0#egg=rate-xblock
 -e common/lib/safe_lxml
 -e common/lib/sandbox-packages
+-e git+https://github.com/python-social-auth/social-app-django.git@c00d23c2b45c3317bd35b15ad1b959338689cef8#egg=social_django
 -e common/lib/symmath
 -e openedx/core/lib/xblock_builtin/xblock_discussion
 -e git+https://github.com/edx-solutions/xblock-google-drive.git@2d176468e33c0713c911b563f8f65f7cf232f5b6#egg=xblock-google-drive
@@ -113,7 +114,7 @@ edx-django-release-util==0.3.3
 edx-django-sites-extensions==2.4.2
 edx-django-utils==2.0.3
 edx-drf-extensions==2.4.5
-edx-enterprise==2.0.48
+edx-enterprise==2.0.49
 edx-i18n-tools==0.5.0
 edx-lint==1.3.0
 edx-milestones==0.2.6
@@ -271,7 +272,6 @@ simplejson==3.17.0
 singledispatch==3.4.0.3
 six==1.14.0
 slumber==0.7.1
-social-auth-app-django==3.1.0
 social-auth-core==3.2.0
 sorl-thumbnail==12.5.0
 sortedcontainers==2.1.0


### PR DESCRIPTION
**Ticket:** [BOM-1141](https://openedx.atlassian.net/browse/BOM-1141)

### Description: 
Added the link to latest master commit of GitHub for Django 2.2 support.