### PR TITLE
BOM-1145 : Django 2.2 Supported version of sorl-thumbnail

### DIFF
--- a/requirements/edx-sandbox/py35.txt
+++ b/requirements/edx-sandbox/py35.txt
@@ -26,7 +26,7 @@ python-dateutil==2.8.1    # via matplotlib
 pytz==2019.3              # via matplotlib
 random2==1.0.1
 scipy==1.2.1
-six==1.13.0
+six==1.14.0
 sympy==1.4
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/requirements/edx-sandbox/shared.txt
+++ b/requirements/edx-sandbox/shared.txt
@@ -9,4 +9,4 @@ cryptography==2.8
 lxml==4.4.2
 nltk==3.4.5
 pycparser==2.19           # via cffi
-six==1.13.0               # via cryptography, nltk
+six==1.14.0               # via cryptography, nltk

--- a/requirements/edx/base.in
+++ b/requirements/edx/base.in
@@ -144,7 +144,6 @@ simplejson
 sailthru-client==2.2.3              # For Sailthru integration
 Shapely                             # Geometry library, used for image click regions in capa
 six                                 # Utilities for supporting Python 2 & 3 in the same codebase
-sorl-thumbnail                      # Image thumbnail management
 sortedcontainers                    # Provides SortedKeyList, used for lists of XBlock assets
 sqlparse                            # Required by Django to run migrations.RunSQL
 stevedore                           # Support for runtime plugins, used for XBlocks and edx-platform Django app plugins

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -103,9 +103,9 @@ edx-completion==3.0.2
 edx-django-oauth2-provider==1.3.5
 edx-django-release-util==0.3.3
 edx-django-sites-extensions==2.4.2
-edx-django-utils==2.0.2
+edx-django-utils==2.0.3
 edx-drf-extensions==2.4.5
-edx-enterprise==2.0.48
+edx-enterprise==2.0.49
 edx-i18n-tools==0.5.0
 edx-milestones==0.2.6
 edx-oauth2-provider==1.3.1
@@ -121,7 +121,7 @@ edx-submissions==3.0.3
 edx-tincan-py35==0.0.5    # via edx-enterprise
 edx-user-state-client==1.1.2
 edx-when==0.5.2
-edxval==1.2.0
+edxval==1.2.1
 elasticsearch==1.9.0      # via edx-search
 enum34==1.1.6             # via edxval
 event-tracking==0.3.0
@@ -133,7 +133,7 @@ glob2==0.7
 gunicorn==20.0.4
 help-tokens==1.0.5
 html5lib==1.0.1
-httplib2==0.15.0
+httplib2==0.16.0
 idna==2.8
 inflection==0.3.1         # via drf-yasg
 ipaddress==1.0.23
@@ -219,11 +219,11 @@ semantic-version==2.8.4   # via edx-drf-extensions
 shapely==1.6.4.post2
 shortuuid==0.5.0          # via edx-django-oauth2-provider
 simplejson==3.17.0
-six==1.13.0
+six==1.14.0
 slumber==0.7.1            # via edx-bulk-grades, edx-enterprise, edx-rest-api-client
 social-auth-app-django==3.1.0
 social-auth-core==3.2.0
-sorl-thumbnail==12.5.0
+git+https://github.com/jazzband/sorl-thumbnail.git@13bedfb7d2970809eda597e3ef79318a6fa80ac2#egg=sorl-thumbnail
 sortedcontainers==2.1.0
 soupsieve==1.9.5          # via beautifulsoup4
 sqlparse==0.3.0

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -121,7 +121,7 @@ edx-submissions==3.0.3
 edx-tincan-py35==0.0.5    # via edx-enterprise
 edx-user-state-client==1.1.2
 edx-when==0.5.2
-edxval==1.2.1
+edxval==1.2.0
 elasticsearch==1.9.0      # via edx-search
 enum34==1.1.6             # via edxval
 event-tracking==0.3.0

--- a/requirements/edx/coverage.txt
+++ b/requirements/edx/coverage.txt
@@ -18,5 +18,5 @@ pluggy==0.13.1            # via diff-cover
 pygments==2.5.2           # via diff-cover
 python-dateutil==2.4.0    # via pandas
 pytz==2019.3              # via pandas
-six==1.13.0               # via diff-cover
+six==1.14.0               # via diff-cover
 zipp==1.0.0               # via importlib-metadata

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -117,9 +117,9 @@ edx-completion==3.0.2
 edx-django-oauth2-provider==1.3.5
 edx-django-release-util==0.3.3
 edx-django-sites-extensions==2.4.2
-edx-django-utils==2.0.2
+edx-django-utils==2.0.3
 edx-drf-extensions==2.4.5
-edx-enterprise==2.0.48
+edx-enterprise==2.0.49
 edx-i18n-tools==0.5.0
 edx-lint==1.3.0
 edx-milestones==0.2.6
@@ -137,7 +137,7 @@ edx-submissions==3.0.3
 edx-tincan-py35==0.0.5
 edx-user-state-client==1.1.2
 edx-when==0.5.2
-edxval==1.2.0
+edxval==1.2.1
 elasticsearch==1.9.0
 entrypoints==0.3
 enum34==1.1.6
@@ -157,7 +157,7 @@ glob2==0.7
 gunicorn==20.0.4
 help-tokens==1.0.5
 html5lib==1.0.1
-httplib2==0.15.0
+httplib2==0.16.0
 httpretty==0.9.7
 idna==2.8
 imagesize==1.2.0          # via sphinx
@@ -286,12 +286,12 @@ shapely==1.6.4.post2
 shortuuid==0.5.0
 simplejson==3.17.0
 singledispatch==3.4.0.3
-six==1.13.0
+six==1.14.0
 slumber==0.7.1
 snowballstemmer==2.0.0    # via sphinx
 social-auth-app-django==3.1.0
 social-auth-core==3.2.0
-sorl-thumbnail==12.5.0
+git+https://github.com/jazzband/sorl-thumbnail.git@13bedfb7d2970809eda597e3ef79318a6fa80ac2#egg=sorl-thumbnail
 sortedcontainers==2.1.0
 soupsieve==1.9.5
 sphinx==2.3.1             # via edx-sphinx-theme, sphinxcontrib-httpdomain

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -137,7 +137,7 @@ edx-submissions==3.0.3
 edx-tincan-py35==0.0.5
 edx-user-state-client==1.1.2
 edx-when==0.5.2
-edxval==1.2.1
+edxval==1.2.0
 elasticsearch==1.9.0
 entrypoints==0.3
 enum34==1.1.6

--- a/requirements/edx/github.in
+++ b/requirements/edx/github.in
@@ -73,7 +73,7 @@ git+https://github.com/edx/django-rest-framework-oauth.git@0a43e8525f1e3048efe4b
 # This dependency will be removed by the Celery 4 upgrade: https://openedx.atlassian.net/browse/PLAT-1684
 git+https://github.com/edx/django-celery.git@756cb57aad765cb2b0d37372c1855b8f5f37e6b0#egg=django-celery==3.2.1+edx.2
 
-# Why a sorl-thumbnail fork? To add Django 2.2 compatibility to the abandoned repo.
+# Why install sorl-thumbnail directly from github? To use the latest, Django 2.2 compatible version that is not available on PyPi yet.
 # This dependency will be removed after package is updated at PyPi
 git+https://github.com/jazzband/sorl-thumbnail.git@13bedfb7d2970809eda597e3ef79318a6fa80ac2#egg=sorl-thumbnail
 

--- a/requirements/edx/github.in
+++ b/requirements/edx/github.in
@@ -73,6 +73,10 @@ git+https://github.com/edx/django-rest-framework-oauth.git@0a43e8525f1e3048efe4b
 # This dependency will be removed by the Celery 4 upgrade: https://openedx.atlassian.net/browse/PLAT-1684
 git+https://github.com/edx/django-celery.git@756cb57aad765cb2b0d37372c1855b8f5f37e6b0#egg=django-celery==3.2.1+edx.2
 
+# Why a sorl-thumbnail fork? To add Django 2.2 compatibility to the abandoned repo.
+# This dependency will be removed after package is updated at PyPi
+git+https://github.com/jazzband/sorl-thumbnail.git@13bedfb7d2970809eda597e3ef79318a6fa80ac2#egg=sorl-thumbnail
+
 # Forked to fix predicate inversion
 # Once https://github.com/excitedleigh/bridgekeeper/pull/10 is merged, and we get to django 2, we can
 # remove this fork

--- a/requirements/edx/paver.txt
+++ b/requirements/edx/paver.txt
@@ -22,7 +22,7 @@ pymongo==3.9.0
 python-memcached==1.59
 pyyaml==5.3               # via watchdog
 requests==2.22.0
-six==1.13.0               # via edx-opaque-keys, libsass, mock, paver, python-memcached, stevedore
+six==1.14.0               # via edx-opaque-keys, libsass, mock, paver, python-memcached, stevedore
 stevedore==1.31.0
 urllib3==1.25.7           # via requests
 watchdog==0.9.0

--- a/requirements/edx/pip-tools.txt
+++ b/requirements/edx/pip-tools.txt
@@ -6,4 +6,4 @@
 #
 click==7.0                # via pip-tools
 pip-tools==4.3.0
-six==1.13.0
+six==1.14.0

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -114,9 +114,9 @@ edx-completion==3.0.2
 edx-django-oauth2-provider==1.3.5
 edx-django-release-util==0.3.3
 edx-django-sites-extensions==2.4.2
-edx-django-utils==2.0.2
+edx-django-utils==2.0.3
 edx-drf-extensions==2.4.5
-edx-enterprise==2.0.48
+edx-enterprise==2.0.49
 edx-i18n-tools==0.5.0
 edx-lint==1.3.0
 edx-milestones==0.2.6
@@ -133,7 +133,7 @@ edx-submissions==3.0.3
 edx-tincan-py35==0.0.5
 edx-user-state-client==1.1.2
 edx-when==0.5.2
-edxval==1.2.0
+edxval==1.2.1
 elasticsearch==1.9.0
 entrypoints==0.3          # via flake8
 enum34==1.1.6
@@ -153,7 +153,7 @@ glob2==0.7
 gunicorn==20.0.4
 help-tokens==1.0.5
 html5lib==1.0.1
-httplib2==0.15.0
+httplib2==0.16.0
 httpretty==0.9.7
 idna==2.8
 importlib-metadata==1.4.0
@@ -275,11 +275,11 @@ shapely==1.6.4.post2
 shortuuid==0.5.0
 simplejson==3.17.0
 singledispatch==3.4.0.3
-six==1.13.0
+six==1.14.0
 slumber==0.7.1
 social-auth-app-django==3.1.0
 social-auth-core==3.2.0
-sorl-thumbnail==12.5.0
+git+https://github.com/jazzband/sorl-thumbnail.git@13bedfb7d2970809eda597e3ef79318a6fa80ac2#egg=sorl-thumbnail
 sortedcontainers==2.1.0
 soupsieve==1.9.5
 sqlparse==0.3.0

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -133,7 +133,7 @@ edx-submissions==3.0.3
 edx-tincan-py35==0.0.5
 edx-user-state-client==1.1.2
 edx-when==0.5.2
-edxval==1.2.1
+edxval==1.2.0
 elasticsearch==1.9.0
 entrypoints==0.3          # via flake8
 enum34==1.1.6


### PR DESCRIPTION
Ticket: [BOM-1145](https://openedx.atlassian.net/browse/BOM-1145)

Description:
Added the link to latest master commit of GitHub for Django 2.2 support.