### PR TITLE
fix: fragment includes should include files in themes if they exist

### DIFF
--- a/common/djangoapps/pipeline_mako/templates/static_content.html
+++ b/common/djangoapps/pipeline_mako/templates/static_content.html
@@ -92,7 +92,7 @@ dirs = settings.DEFAULT_TEMPLATE_ENGINE['DIRS']
 theme = get_current_theme()
 if theme:
     dirs = list(dirs)
-    dirs.insert(0, theme.path / 'templates')
+    dirs.append(theme.path / 'templates')
 engine = Engine(dirs=dirs)
 loader = Loader(engine)
 


### PR DESCRIPTION
Appending the theme path to `dirs` rather than inserting it at the beginning causes it to be the source used if it exists. This fixes comprehensive theming for all templates that use `<%static:include path="${path}" />`
