### PR TITLE
Removed the deprecated app_name usage from lms/urls.py BOM-1155

### DIFF
--- a/lms/urls.py
+++ b/lms/urls.py
@@ -149,7 +149,7 @@ if settings.FEATURES.get('ENABLE_MOBILE_REST_API'):
 
 if settings.FEATURES.get('ENABLE_OPENBADGES'):
     urlpatterns += [
-        url(r'^api/badges/v1/', include('badges.api.urls', app_name='badges', namespace='badges_api')),
+        url(r'^api/badges/v1/', include(('badges.api.urls', 'badges'), namespace='badges_api')),
     ]
 
 urlpatterns += [


### PR DESCRIPTION
Relevant JIRA issue can be found [here](https://openedx.atlassian.net/browse/BOM-1155).