### PR TITLE
modify URL generation in tinymce editor

### DIFF
--- a/common/lib/xmodule/xmodule/js/spec/html/edit_spec.js
+++ b/common/lib/xmodule/xmodule/js/spec/html/edit_spec.js
@@ -1,5 +1,5 @@
 describe('HTMLEditingDescriptor', function() {
-  beforeEach(() => window.baseUrl = "/static/deadbeef");
+  beforeEach(() => window.baseUrl = "/static/deadbeef/");
   afterEach(() => delete window.baseUrl);
   describe('Visual HTML Editor', function() {
     beforeEach(function() {
@@ -47,6 +47,10 @@ describe('HTMLEditingDescriptor', function() {
       this.descriptor.getVisualEditor().setContent(editorData)
       const savedContent = this.descriptor.getVisualEditor().getContent()
       expect(savedContent).toEqual(expectedData);
+    });
+    it('Editor base URL does not contain double slash', function(){
+      const editor = this.descriptor.getVisualEditor();
+      expect(editor.editorManager.baseURL).not.toContain('//');
     });
   });
   describe('Raw HTML Editor', function() {

--- a/common/lib/xmodule/xmodule/js/src/html/edit.js
+++ b/common/lib/xmodule/xmodule/js/src/html/edit.js
@@ -88,7 +88,7 @@
         This is a workaround for the fact that tinyMCE's baseURL property is not getting correctly set on AWS
         instances (like sandbox). It is not necessary to explicitly set baseURL when running locally.
          */
-        tinyMCE.baseURL = baseUrl + "/js/vendor/tinymce/js/tinymce";
+        tinyMCE.baseURL = baseUrl + "js/vendor/tinymce/js/tinymce";
 
         /*
         This is necessary for the LMS bulk e-mail acceptance test. In that particular scenario,
@@ -96,7 +96,7 @@
          */
         tinyMCE.suffix = ".min";
         this.tiny_mce_textarea = $(".tiny-mce", this.element).tinymce({
-          script_url: baseUrl + "/js/vendor/tinymce/js/tinymce/tinymce.full.min.js",
+          script_url: baseUrl + "js/vendor/tinymce/js/tinymce/tinymce.full.min.js",
           font_formats: _getFonts(),
           theme: "modern",
           skin: 'studio-tmce4',
@@ -126,7 +126,7 @@
           visual: false,
           plugins: "textcolor, link, image, codemirror",
           codemirror: {
-            path: baseUrl + "/js/vendor"
+            path: baseUrl + "js/vendor"
           },
           image_advtab: true,
 
@@ -1204,7 +1204,7 @@
         Translators: this is a toolbar button tooltip from the raw HTML editor displayed in the browser when a user needs to edit HTML
          */
         title: gettext('Code block'),
-        image: baseUrl + "/images/ico-tinymce-code.png",
+        image: baseUrl + "images/ico-tinymce-code.png",
         onclick: function() {
           return ed.formatter.toggle('code');
         }


### PR DESCRIPTION
### [PROD-1179](https://openedx.atlassian.net/browse/PROD-1179)

### Description
This PR is changing the way TinyMCE base URL is set in the platform. During the setting of a few URLs in the editor, double slashes were being added to the URLs. This didn't cause an issue when the assets were being served from the CDN(that's how Django handles static URLs). However, when the assets were served from S3, the double slash result in an incorrect URL and returned 403 error in the Instructor tab's email section.

By convention, the STATIC_URL always ends in a slash if it is a non-empty value([Reference](https://docs.djangoproject.com/en/2.2/ref/settings/#std:setting-STATIC_URL)) which is also true for the platform. The same STATIC_URL was being assigned in baseUrl var in the [main.html](https://github.com/edx/edx-platform/blob/master/lms/templates/main.html#L116-L123). baseUrl is used in TinyMCE URLs setting, but the strings being concatenated to it started with `/` which resulted in double slash.

### Testing

Sandbox URL : https://tinymce.sandbox.edx.org/courses/course-v1:edX+Test101+course/course/

1. Go to Instructor tab of any course on the LMS and visit the `Email` section. 
2. On the editor, click the HTML button. View the logs/network tab and see the static assets being obtained.
3. Observe the assets URL will not contain any double slash.
4. Run the following command in the console to see that there are no double slashes: `tinyMCE.EditorManager.baseURL`


### Reviewers
 - [x] @awaisdar001 
 - [x] @asadazam93 

### Post Review
 - [x] Squash & Rebase commits