### PR TITLE
Unpin more outdated dependencies

### DIFF
--- a/pavelib/prereqs.py
+++ b/pavelib/prereqs.py
@@ -201,6 +201,7 @@ PACKAGES_TO_UNINSTALL = [
     "django-oauth2-provider",       # Because now it's called edx-django-oauth2-provider.
     "edx-oauth2-provider",          # Because it moved from github to pypi
     "i18n-tools",                   # Because now it's called edx-i18n-tools
+    "moto",                         # Because we no longer use it and it conflicts with recent jsondiff versions
     "python-saml",                  # Because python3-saml shares the same directory name
     "pdfminer",                     # Replaced by pdfminer.six, which shares the same directory name
     "pytest-faulthandler",          # Because it was bundled into pytest

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -28,6 +28,9 @@ django-model-utils<4.0.0
 # acceptance.tests.lms.test_lms_course_discovery.CourseDiscoveryTest.test_search
 edx-search==1.2.2
 
+# Upgrading to 2.12.0 breaks several test classes due to API changes, need to update our code accordingly
+factory-boy==2.8.1
+
 # Version 0.3.13 broke the timing returned by python3-saml OneLogin_Saml2_Utils.now()
 freezegun==0.3.12
 

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -23,9 +23,6 @@ django-method-override<1.0.0
 # Version 4.0.0 dropped support for Django < 2.0.1
 django-model-utils<4.0.0
 
-# 1.16.1 requires djangorestframework>=3.8
-drf-yasg==1.16
-
 # 1.2.3 breaks unittest in
 # lms.djangoapps.course_api.tests.test_views.CourseListSearchViewTest.test_list_all_with_search_term
 # acceptance.tests.lms.test_lms_course_discovery.CourseDiscoveryTest.test_search
@@ -61,7 +58,7 @@ python-dateutil==2.4.0
 # python3-saml 1.6.0 breaks unittests in common/djangoapps/third_party_auth/tests/test_views.py::SAMLMetadataTest
 python3-saml==1.5.0
 
-# transifex-client 0.13.5 and 0.13.6 pin six and urllib3 to old versions needlessly
+# transifex-client 0.13.5 and 0.13.6 needlessly pin six and urllib3, 0.13.7 does so for python-slugify
 #   https://github.com/transifex/transifex-client/issues/252
 transifex-client==0.13.4
 

--- a/requirements/edx/base.in
+++ b/requirements/edx/base.in
@@ -111,10 +111,10 @@ newrelic                            # New Relic agent for performance monitoring
 nodeenv                             # Utility for managing Node.js environments; we use this for deployments and testing
 oauthlib                            # OAuth specification support for authenticating via LTI or other Open edX services
 pdfminer.six                        # Used in shoppingcart for extracting/parsing pdf text
-piexif==1.0.2                       # Exif image metadata manipulation, used in the profile_images app
+piexif                              # Exif image metadata manipulation, used in the profile_images app
 Pillow                              # Image manipulation library; used for course assets, profile images, invoice PDFs, etc.
 py2neo<4.0.0                        # Used to communicate with Neo4j, which is used internally for modulestore inspection
-PyContracts==1.7.1
+PyContracts
 pycountry
 pycryptodomex
 pygments                            # Used to support colors in paver command output

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -44,6 +44,8 @@ git+https://github.com/edx/openedx-chem.git@ff4e3a03d3c7610e47a9af08eb648d8aabe2
 click==7.0                # via code-annotations, user-util
 code-annotations==0.3.3   # via edx-enterprise
 contextlib2==0.6.0.post1
+coreapi==2.3.3            # via drf-yasg
+coreschema==0.0.4         # via coreapi, drf-yasg
 git+https://github.com/edx/crowdsourcehinter.git@a7ffc85b134b7d8909bf1fefd23dbdb8eb28e467#egg=crowdsourcehinter-xblock==0.2
 cryptography==2.8
 cssutils==1.0.2           # via pynliner
@@ -54,7 +56,7 @@ git+https://github.com/django-compressor/django-appconf@1526a842ee084b791aa66c93
 django-babel-underscore==0.5.2
 django-babel==0.6.2       # via django-babel-underscore
 git+https://github.com/edx/django-celery.git@756cb57aad765cb2b0d37372c1855b8f5f37e6b0#egg=django-celery==3.2.1+edx.2
-django-classy-tags==0.9.0  # via django-sekizai
+django-classy-tags==1.0.0  # via django-sekizai
 django-config-models==1.0.4
 django-cors-headers==2.5.3
 django-countries==5.5
@@ -76,7 +78,7 @@ django-pyfs==2.1
 django-ratelimit-backend==2.0
 django-ratelimit==2.0.0
 django-require==1.0.11
-django-sekizai==1.0.0
+django-sekizai==1.1.0
 django-ses==0.8.14
 django-simple-history==2.8.0
 django-splash==0.2.5
@@ -102,10 +104,10 @@ edx-celeryutils==0.3.1
 edx-completion==3.0.2
 edx-django-oauth2-provider==1.3.5
 edx-django-release-util==0.3.3
-edx-django-sites-extensions==2.4.2
+edx-django-sites-extensions==2.4.3
 edx-django-utils==2.0.3
 edx-drf-extensions==2.4.5
-edx-enterprise==2.1.0
+edx-enterprise==2.1.1
 edx-i18n-tools==0.5.0
 edx-milestones==0.2.6
 edx-oauth2-provider==1.3.1
@@ -114,14 +116,14 @@ edx-organizations==2.2.0
 edx-proctoring-proctortrack==1.0.5
 edx-proctoring==2.2.4
 edx-rbac==1.0.5           # via edx-enterprise
-edx-rest-api-client==2.0.0
+edx-rest-api-client==3.0.0
 edx-search==1.2.2
 edx-sga==0.10.0
 edx-submissions==3.0.3
 edx-tincan-py35==0.0.5    # via edx-enterprise
 edx-user-state-client==1.1.2
 edx-when==0.5.2
-edxval==1.2.1
+edxval==1.2.2
 elasticsearch==1.9.0      # via edx-search
 enum34==1.1.6             # via edxval
 event-tracking==0.3.0
@@ -139,7 +141,8 @@ importlib-metadata==1.4.0
 inflection==0.3.1         # via drf-yasg
 ipaddress==1.0.23
 isodate==0.6.0            # via python3-saml
-jinja2==2.10.3            # via code-annotations
+itypes==1.1.0             # via coreapi
+jinja2==2.10.3            # via code-annotations, coreschema
 jmespath==0.9.4           # via boto3, botocore
 jsondiff==1.2.0           # via edx-enterprise
 jsonfield==2.0.2
@@ -176,7 +179,7 @@ path==13.1.0
 pathtools==0.1.2
 paver==1.3.4
 pbr==5.4.4
-pdfminer.six==20200104
+pdfminer.six==20200121
 piexif==1.1.3
 pillow==7.0.0
 pkgconfig==1.5.1          # via xmlsec
@@ -194,7 +197,7 @@ pyjwt==1.5.2
 pymongo==3.9.0
 pynliner==0.8.0
 pyparsing==2.2.0          # via packaging, pycontracts
-pysrt==1.1.1
+pysrt==1.1.2
 python-dateutil==2.4.0
 python-levenshtein==0.12.0
 python-memcached==1.59
@@ -212,6 +215,8 @@ requests-oauthlib==1.1.0
 requests==2.22.0
 rest-condition==1.0.3
 rfc6266-parser==0.0.6
+ruamel.yaml.clib==0.2.0   # via ruamel.yaml
+ruamel.yaml==0.16.6       # via drf-yasg
 rules==2.2
 s3transfer==0.1.13        # via boto3
 sailthru-client==2.2.3
@@ -234,13 +239,14 @@ sympy==1.5.1
 testfixtures==6.10.3      # via edx-enterprise
 text-unidecode==1.3       # via python-slugify
 unicodecsv==0.14.1
-urllib3==1.25.7
+uritemplate==3.0.1        # via coreapi, drf-yasg
+urllib3==1.25.8
 user-util==0.1.5
 voluptuous==0.11.7
 watchdog==0.9.0
 web-fragments==0.3.1
 webencodings==0.5.1       # via bleach, html5lib
-webob==1.8.5              # via xblock
+webob==1.8.6              # via xblock
 wrapt==1.11.2
 git+https://github.com/edx-solutions/xblock-drag-and-drop-v2@v2.2.8#egg=xblock-drag-and-drop-v2==2.2.8
 git+https://github.com/open-craft/xblock-poll@3c7dcaf6c933d914188f0740a60711603f948d26#egg=xblock-poll==1.9.1

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -92,7 +92,7 @@ djangorestframework-xml==1.4.0  # via edx-enterprise
 djangorestframework==3.9.4
 docopt==0.6.2
 docutils==0.16            # via botocore
-drf-yasg==1.16            # via edx-api-doc-tools
+drf-yasg==1.17.0          # via edx-api-doc-tools
 edx-ace==0.1.13
 edx-analytics-data-api-client==0.15.3
 edx-api-doc-tools==1.0.2
@@ -127,7 +127,7 @@ enum34==1.1.6             # via edxval
 event-tracking==0.3.0
 fs-s3fs==0.1.8
 fs==2.0.18
-future==0.18.2            # via django-ses, edx-celeryutils, edx-enterprise, pyjwkest
+future==0.18.2            # via django-ses, edx-celeryutils, edx-enterprise, pycontracts, pyjwkest
 geoip2==3.0.0
 glob2==0.7
 gunicorn==20.0.4
@@ -135,6 +135,8 @@ help-tokens==1.0.5
 html5lib==1.0.1
 httplib2==0.16.0
 idna==2.8
+importlib-metadata==1.4.0
+inflection==0.3.1         # via drf-yasg
 ipaddress==1.0.23
 isodate==0.6.0            # via python3-saml
 jinja2==2.10.3            # via code-annotations
@@ -143,7 +145,7 @@ jsondiff==1.2.0           # via edx-enterprise
 jsonfield==2.0.2
 kombu==3.0.37             # via celery
 laboratory==1.0.2
-lazy==1.1
+lazy==1.4
 lepl==5.1.3               # via rfc6266-parser
 libsass==0.10.0
 loremipsum==1.0.5
@@ -158,6 +160,7 @@ maxminddb==1.5.2          # via geoip2
 mock==3.0.5
 git+https://github.com/edx/MongoDBProxy.git@d92bafe9888d2940f647a7b2b2383b29c752f35a#egg=MongoDBProxy==0.1.0+edx.2
 mongoengine==0.10.0
+more-itertools==8.1.0
 mpmath==1.1.0             # via sympy
 mysqlclient==1.4.6
 newrelic==5.4.1.134
@@ -167,18 +170,20 @@ numpy==1.18.1             # via scipy
 git+https://github.com/joestump/python-oauth2.git@b94f69b1ad195513547924e380d9265133e995fa#egg=oauth2
 oauthlib==2.1.0
 git+https://github.com/edx/edx-ora2.git@2.6.0#egg=ora2==2.6.0
-path.py==8.2.1
+packaging==20.0           # via drf-yasg
+path.py==12.4.0           # via edx-enterprise, edx-i18n-tools
+path==13.1.0
 pathtools==0.1.2
 paver==1.3.4
 pbr==5.4.4
 pdfminer.six==20200104
-piexif==1.0.2
+piexif==1.1.3
 pillow==7.0.0
 pkgconfig==1.5.1          # via xmlsec
 polib==1.1.0              # via edx-i18n-tools
 psutil==1.2.1
 py2neo==3.1.2
-pycontracts==1.7.1
+pycontracts==1.8.12
 pycountry==19.8.18
 pycparser==2.19
 pycryptodome==3.9.4       # via pdfminer.six
@@ -188,7 +193,7 @@ pyjwkest==1.3.2
 pyjwt==1.5.2
 pymongo==3.9.0
 pynliner==0.8.0
-pyparsing==2.2.0          # via pycontracts
+pyparsing==2.2.0          # via packaging, pycontracts
 pysrt==1.1.1
 python-dateutil==2.4.0
 python-levenshtein==0.12.0
@@ -236,13 +241,14 @@ watchdog==0.9.0
 web-fragments==0.3.1
 webencodings==0.5.1       # via bleach, html5lib
 webob==1.8.5              # via xblock
-wrapt==1.10.5
+wrapt==1.11.2
 git+https://github.com/edx-solutions/xblock-drag-and-drop-v2@v2.2.8#egg=xblock-drag-and-drop-v2==2.2.8
 git+https://github.com/open-craft/xblock-poll@3c7dcaf6c933d914188f0740a60711603f948d26#egg=xblock-poll==1.9.1
 xblock-utils==1.2.4
 xblock==1.2.9
 xmlsec==1.3.3             # via python3-saml
 xss-utils==0.1.2
+zipp==1.0.0
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -142,7 +142,7 @@ entrypoints==0.3
 enum34==1.1.6
 event-tracking==0.3.0
 execnet==1.7.1
-factory-boy==2.12.0
+factory-boy==2.8.1
 faker==4.0.0
 filelock==3.0.12
 flake8-polyfill==1.0.2

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -105,7 +105,7 @@ djangorestframework-xml==1.4.0
 djangorestframework==3.9.4
 docopt==0.6.2
 docutils==0.16
-drf-yasg==1.16
+drf-yasg==1.17.0
 edx-ace==0.1.13
 edx-analytics-data-api-client==0.15.3
 edx-api-doc-tools==1.0.2
@@ -142,7 +142,7 @@ entrypoints==0.3
 enum34==1.1.6
 event-tracking==0.3.0
 execnet==1.7.1
-factory_boy==2.8.1
+factory-boy==2.12.0
 faker==4.0.0
 filelock==3.0.12
 flake8-polyfill==1.0.2
@@ -176,7 +176,7 @@ jsonschema==3.2.0         # via sphinxcontrib-openapi
 kombu==3.0.37
 laboratory==1.0.2
 lazy-object-proxy==1.4.3
-lazy==1.1
+lazy==1.4
 lepl==5.1.3
 libsass==0.10.0
 loremipsum==1.0.5
@@ -207,13 +207,14 @@ oauthlib==2.1.0
 git+https://github.com/edx/edx-ora2.git@2.6.0#egg=ora2==2.6.0
 packaging==20.0
 pandas==0.22.0
-path.py==8.2.1
+path.py==12.4.0
+path==13.1.0
 pathlib2==2.3.5
 pathtools==0.1.2
 paver==1.3.4
 pbr==5.4.4
 pdfminer.six==20200104
-piexif==1.0.2
+piexif==1.1.3
 pillow==7.0.0
 pip-tools==4.3.0
 pkgconfig==1.5.1
@@ -223,7 +224,7 @@ psutil==1.2.1
 py2neo==3.1.2
 py==1.8.1
 pycodestyle==2.5.0
-pycontracts==1.7.1
+pycontracts==1.8.12
 pycountry==19.8.18
 pycparser==2.19
 pycryptodome==3.9.4
@@ -322,7 +323,7 @@ wcwidth==0.1.8
 web-fragments==0.3.1
 webencodings==0.5.1
 webob==1.8.5
-wrapt==1.10.5
+wrapt==1.11.2
 git+https://github.com/edx-solutions/xblock-drag-and-drop-v2@v2.2.8#egg=xblock-drag-and-drop-v2==2.2.8
 git+https://github.com/open-craft/xblock-poll@3c7dcaf6c933d914188f0740a60711603f948d26#egg=xblock-poll==1.9.1
 xblock-utils==1.2.4

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -66,7 +66,7 @@ git+https://github.com/django-compressor/django-appconf@1526a842ee084b791aa66c93
 django-babel-underscore==0.5.2
 django-babel==0.6.2
 git+https://github.com/edx/django-celery.git@756cb57aad765cb2b0d37372c1855b8f5f37e6b0#egg=django-celery==3.2.1+edx.2
-django-classy-tags==0.9.0
+django-classy-tags==1.0.0
 django-config-models==1.0.4
 django-cors-headers==2.5.3
 django-countries==5.5
@@ -89,7 +89,7 @@ django-pyfs==2.1
 django-ratelimit-backend==2.0
 django-ratelimit==2.0.0
 django-require==1.0.11
-django-sekizai==1.0.0
+django-sekizai==1.1.0
 django-ses==0.8.14
 django-simple-history==2.8.0
 django-splash==0.2.5
@@ -115,10 +115,10 @@ edx-celeryutils==0.3.1
 edx-completion==3.0.2
 edx-django-oauth2-provider==1.3.5
 edx-django-release-util==0.3.3
-edx-django-sites-extensions==2.4.2
+edx-django-sites-extensions==2.4.3
 edx-django-utils==2.0.3
 edx-drf-extensions==2.4.5
-edx-enterprise==2.1.0
+edx-enterprise==2.1.1
 edx-i18n-tools==0.5.0
 edx-lint==1.3.0
 edx-milestones==0.2.6
@@ -128,7 +128,7 @@ edx-organizations==2.2.0
 edx-proctoring-proctortrack==1.0.5
 edx-proctoring==2.2.4
 edx-rbac==1.0.5
-edx-rest-api-client==2.0.0
+edx-rest-api-client==3.0.0
 edx-search==1.2.2
 edx-sga==0.10.0
 edx-sphinx-theme==1.5.0
@@ -136,7 +136,7 @@ edx-submissions==3.0.3
 edx-tincan-py35==0.0.5
 edx-user-state-client==1.1.2
 edx-when==0.5.2
-edxval==1.2.1
+edxval==1.2.2
 elasticsearch==1.9.0
 entrypoints==0.3
 enum34==1.1.6
@@ -213,10 +213,10 @@ pathlib2==2.3.5
 pathtools==0.1.2
 paver==1.3.4
 pbr==5.4.4
-pdfminer.six==20200104
+pdfminer.six==20200121
 piexif==1.1.3
 pillow==7.0.0
-pip-tools==4.3.0
+pip-tools==4.4.0
 pkgconfig==1.5.1
 pluggy==0.13.1
 polib==1.1.0
@@ -243,7 +243,7 @@ pynliner==0.8.0
 pyparsing==2.2.0
 pyquery==1.4.1
 pyrsistent==0.15.7        # via jsonschema
-pysrt==1.1.1
+pysrt==1.1.2
 pytest-attrib==0.1.3
 pytest-cov==2.8.1
 pytest-django==3.8.0
@@ -252,7 +252,7 @@ pytest-json-report==1.2.1
 pytest-metadata==1.8.0
 pytest-randomly==3.2.1
 pytest-xdist==1.31.0
-pytest==5.3.3
+pytest==5.3.4
 python-dateutil==2.4.0
 python-levenshtein==0.12.0
 python-memcached==1.59
@@ -272,7 +272,7 @@ requests==2.22.0
 rest-condition==1.0.3
 rfc6266-parser==0.0.6
 ruamel.yaml.clib==0.2.0
-ruamel.yaml==0.16.5
+ruamel.yaml==0.16.6
 rules==2.2
 s3transfer==0.1.13
 sailthru-client==2.2.3
@@ -313,7 +313,7 @@ transifex-client==0.13.4
 unicodecsv==0.14.1
 unidiff==0.5.5
 uritemplate==3.0.1
-urllib3==1.25.7
+urllib3==1.25.8
 user-util==0.1.5
 virtualenv==16.7.9
 voluptuous==0.11.7
@@ -322,7 +322,7 @@ watchdog==0.9.0
 wcwidth==0.1.8
 web-fragments==0.3.1
 webencodings==0.5.1
-webob==1.8.5
+webob==1.8.6
 wrapt==1.11.2
 git+https://github.com/edx-solutions/xblock-drag-and-drop-v2@v2.2.8#egg=xblock-drag-and-drop-v2==2.2.8
 git+https://github.com/open-craft/xblock-poll@3c7dcaf6c933d914188f0740a60711603f948d26#egg=xblock-poll==1.9.1

--- a/requirements/edx/paver.in
+++ b/requirements/edx/paver.in
@@ -11,11 +11,11 @@
 -c ../constraints.txt
 
 edx-opaque-keys                     # Create and introspect course and xblock identities
-lazy==1.1                           # Lazily-evaluated attributes for Python objects
+lazy                                # Lazily-evaluated attributes for Python objects
 libsass==0.10.0                     # Python bindings for the LibSass CSS compiler
 markupsafe                          # XML/HTML/XHTML Markup safe strings
 mock                                # Stub out code with mock objects and make assertions about how they have been used
-path.py==8.2.1                      # Easier manipulation of filesystem paths
+path                                # Easier manipulation of filesystem paths
 paver                               # Build, distribution and deployment scripting tool
 psutil==1.2.1                       # Library for retrieving information on running processes and system utilization
 pymongo==3.9.0                      # via edx-opaque-keys
@@ -23,4 +23,4 @@ python-memcached                    # Python interface to the memcached memory c
 requests                            # Simple interface for making HTTP requests
 stevedore                           # Support for runtime plugins, used for XBlocks and edx-platform Django app plugins
 watchdog                            # Used in paver watch_assets
-wrapt==1.10.5                       # Decorator utilities used in the @timed paver task decorator
+wrapt                               # Decorator utilities used in the @timed paver task decorator

--- a/requirements/edx/paver.txt
+++ b/requirements/edx/paver.txt
@@ -9,11 +9,13 @@ certifi==2019.11.28       # via requests
 chardet==3.0.4            # via requests
 edx-opaque-keys==2.0.1
 idna==2.8                 # via requests
-lazy==1.1
+importlib-metadata==1.4.0  # via path
+lazy==1.4
 libsass==0.10.0
 markupsafe==1.1.1
 mock==3.0.5
-path.py==8.2.1
+more-itertools==8.1.0     # via zipp
+path==13.1.0
 pathtools==0.1.2          # via watchdog
 paver==1.3.4
 pbr==5.4.4                # via stevedore
@@ -26,7 +28,5 @@ six==1.14.0               # via edx-opaque-keys, libsass, mock, paver, python-me
 stevedore==1.31.0
 urllib3==1.25.7           # via requests
 watchdog==0.9.0
-wrapt==1.10.5
-
-# The following packages are considered to be unsafe in a requirements file:
-# setuptools
+wrapt==1.11.2
+zipp==1.0.0               # via importlib-metadata

--- a/requirements/edx/paver.txt
+++ b/requirements/edx/paver.txt
@@ -26,7 +26,7 @@ pyyaml==5.3               # via watchdog
 requests==2.22.0
 six==1.14.0               # via edx-opaque-keys, libsass, mock, paver, python-memcached, stevedore
 stevedore==1.31.0
-urllib3==1.25.7           # via requests
+urllib3==1.25.8           # via requests
 watchdog==0.9.0
 wrapt==1.11.2
 zipp==1.0.0               # via importlib-metadata

--- a/requirements/edx/pip-tools.txt
+++ b/requirements/edx/pip-tools.txt
@@ -5,5 +5,5 @@
 #    make upgrade
 #
 click==7.0                # via pip-tools
-pip-tools==4.3.0
+pip-tools==4.4.0
 six==1.14.0

--- a/requirements/edx/testing.in
+++ b/requirements/edx/testing.in
@@ -24,7 +24,7 @@ cssselect                 # Used to extract HTML fragments via CSS selectors in 
 ddt                       # Run a test case multiple times with different input; used in many, many of our tests
 edx-i18n-tools>=0.4.6     # Commands for developers and translators to extract, compile and validate translations
 edx-lint==1.3.0           # pylint extensions for Open edX repositories
-factory_boy               # Library for creating test fixtures, used in many tests
+factory-boy               # Library for creating test fixtures, used in many tests
 # Pinning the freezegun version because 0.3.13 is causing failures which have also been reported on the git repo by public.
 freezegun                 # Allows tests to mock the output of assorted datetime module functions
 httpretty                 # Library for mocking HTTP requests, used in many tests

--- a/requirements/edx/testing.in
+++ b/requirements/edx/testing.in
@@ -24,9 +24,9 @@ cssselect                 # Used to extract HTML fragments via CSS selectors in 
 ddt                       # Run a test case multiple times with different input; used in many, many of our tests
 edx-i18n-tools>=0.4.6     # Commands for developers and translators to extract, compile and validate translations
 edx-lint==1.3.0           # pylint extensions for Open edX repositories
-factory_boy==2.8.1        # Library for creating test fixtures, used in many tests
+factory_boy               # Library for creating test fixtures, used in many tests
 # Pinning the freezegun version because 0.3.13 is causing failures which have also been reported on the git repo by public.
-freezegun==0.3.12         # Allows tests to mock the output of assorted datetime module functions
+freezegun                 # Allows tests to mock the output of assorted datetime module functions
 httpretty                 # Library for mocking HTTP requests, used in many tests
 isort                     # For checking and fixing the order of imports
 pycodestyle               # Checker for compliance with the Python style guide (PEP 8)

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -102,7 +102,7 @@ djangorestframework-xml==1.4.0
 djangorestframework==3.9.4
 docopt==0.6.2
 docutils==0.16
-drf-yasg==1.16
+drf-yasg==1.17.0
 edx-ace==0.1.13
 edx-analytics-data-api-client==0.15.3
 edx-api-doc-tools==1.0.2
@@ -138,7 +138,7 @@ entrypoints==0.3          # via flake8
 enum34==1.1.6
 event-tracking==0.3.0
 execnet==1.7.1            # via pytest-xdist
-factory_boy==2.8.1
+factory-boy==2.12.0
 faker==4.0.0              # via factory-boy
 filelock==3.0.12          # via tox
 flake8-polyfill==1.0.2    # via radon
@@ -170,7 +170,7 @@ jsonfield==2.0.2
 kombu==3.0.37
 laboratory==1.0.2
 lazy-object-proxy==1.4.3  # via astroid
-lazy==1.1
+lazy==1.4
 lepl==5.1.3
 libsass==0.10.0
 loremipsum==1.0.5
@@ -197,15 +197,16 @@ numpy==1.18.1
 git+https://github.com/joestump/python-oauth2.git@b94f69b1ad195513547924e380d9265133e995fa#egg=oauth2
 oauthlib==2.1.0
 git+https://github.com/edx/edx-ora2.git@2.6.0#egg=ora2==2.6.0
-packaging==20.0           # via pytest, tox
+packaging==20.0
 pandas==0.22.0
-path.py==8.2.1
+path.py==12.4.0
+path==13.1.0
 pathlib2==2.3.5           # via pytest
 pathtools==0.1.2
 paver==1.3.4
 pbr==5.4.4
 pdfminer.six==20200104
-piexif==1.0.2
+piexif==1.1.3
 pillow==7.0.0
 pkgconfig==1.5.1
 pluggy==0.13.1
@@ -214,7 +215,7 @@ psutil==1.2.1
 py2neo==3.1.2
 py==1.8.1                 # via pytest, tox
 pycodestyle==2.5.0
-pycontracts==1.7.1
+pycontracts==1.8.12
 pycountry==19.8.18
 pycparser==2.19
 pycryptodome==3.9.4
@@ -300,7 +301,7 @@ wcwidth==0.1.8            # via pytest
 web-fragments==0.3.1
 webencodings==0.5.1
 webob==1.8.5
-wrapt==1.10.5
+wrapt==1.11.2
 git+https://github.com/edx-solutions/xblock-drag-and-drop-v2@v2.2.8#egg=xblock-drag-and-drop-v2==2.2.8
 git+https://github.com/open-craft/xblock-poll@3c7dcaf6c933d914188f0740a60711603f948d26#egg=xblock-poll==1.9.1
 xblock-utils==1.2.4

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -138,7 +138,7 @@ entrypoints==0.3          # via flake8
 enum34==1.1.6
 event-tracking==0.3.0
 execnet==1.7.1            # via pytest-xdist
-factory-boy==2.12.0
+factory-boy==2.8.1
 faker==4.0.0              # via factory-boy
 filelock==3.0.12          # via tox
 flake8-polyfill==1.0.2    # via radon

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -49,8 +49,8 @@ click==7.0
 code-annotations==0.3.3
 colorama==0.4.3           # via radon
 contextlib2==0.6.0.post1
-coreapi==2.3.3            # via drf-yasg
-coreschema==0.0.4         # via coreapi, drf-yasg
+coreapi==2.3.3
+coreschema==0.0.4
 coverage==5.0.3
 git+https://github.com/nedbat/coverage_pytest_plugin.git@29de030251471e200ff255eb9e549218cd60e872#egg=coverage_pytest_plugin==0.0
 git+https://github.com/edx/crowdsourcehinter.git@a7ffc85b134b7d8909bf1fefd23dbdb8eb28e467#egg=crowdsourcehinter-xblock==0.2
@@ -65,7 +65,7 @@ git+https://github.com/django-compressor/django-appconf@1526a842ee084b791aa66c93
 django-babel-underscore==0.5.2
 django-babel==0.6.2
 git+https://github.com/edx/django-celery.git@756cb57aad765cb2b0d37372c1855b8f5f37e6b0#egg=django-celery==3.2.1+edx.2
-django-classy-tags==0.9.0
+django-classy-tags==1.0.0
 django-config-models==1.0.4
 django-cors-headers==2.5.3
 django-countries==5.5
@@ -87,7 +87,7 @@ django-pyfs==2.1
 django-ratelimit-backend==2.0
 django-ratelimit==2.0.0
 django-require==1.0.11
-django-sekizai==1.0.0
+django-sekizai==1.1.0
 django-ses==0.8.14
 django-simple-history==2.8.0
 django-splash==0.2.5
@@ -112,10 +112,10 @@ edx-celeryutils==0.3.1
 edx-completion==3.0.2
 edx-django-oauth2-provider==1.3.5
 edx-django-release-util==0.3.3
-edx-django-sites-extensions==2.4.2
+edx-django-sites-extensions==2.4.3
 edx-django-utils==2.0.3
 edx-drf-extensions==2.4.5
-edx-enterprise==2.1.0
+edx-enterprise==2.1.1
 edx-i18n-tools==0.5.0
 edx-lint==1.3.0
 edx-milestones==0.2.6
@@ -125,14 +125,14 @@ edx-organizations==2.2.0
 edx-proctoring-proctortrack==1.0.5
 edx-proctoring==2.2.4
 edx-rbac==1.0.5
-edx-rest-api-client==2.0.0
+edx-rest-api-client==3.0.0
 edx-search==1.2.2
 edx-sga==0.10.0
 edx-submissions==3.0.3
 edx-tincan-py35==0.0.5
 edx-user-state-client==1.1.2
 edx-when==0.5.2
-edxval==1.2.1
+edxval==1.2.2
 elasticsearch==1.9.0
 entrypoints==0.3          # via flake8
 enum34==1.1.6
@@ -157,11 +157,11 @@ httpretty==0.9.7
 idna==2.8
 importlib-metadata==1.4.0
 inflect==3.0.2
-inflection==0.3.1         # via drf-yasg
+inflection==0.3.1
 ipaddress==1.0.23
 isodate==0.6.0
 isort==4.3.21
-itypes==1.1.0             # via coreapi
+itypes==1.1.0
 jinja2-pluralize==0.3.0
 jinja2==2.10.3
 jmespath==0.9.4
@@ -205,7 +205,7 @@ pathlib2==2.3.5           # via pytest
 pathtools==0.1.2
 paver==1.3.4
 pbr==5.4.4
-pdfminer.six==20200104
+pdfminer.six==20200121
 piexif==1.1.3
 pillow==7.0.0
 pkgconfig==1.5.1
@@ -232,7 +232,7 @@ pymongo==3.9.0
 pynliner==0.8.0
 pyparsing==2.2.0
 pyquery==1.4.1
-pysrt==1.1.1
+pysrt==1.1.2
 pytest-attrib==0.1.3
 pytest-cov==2.8.1
 pytest-django==3.8.0
@@ -241,7 +241,7 @@ pytest-json-report==1.2.1
 pytest-metadata==1.8.0    # via pytest-json-report
 pytest-randomly==3.2.1
 pytest-xdist==1.31.0
-pytest==5.3.3
+pytest==5.3.4
 python-dateutil==2.4.0
 python-levenshtein==0.12.0
 python-memcached==1.59
@@ -260,8 +260,8 @@ requests-oauthlib==1.1.0
 requests==2.22.0
 rest-condition==1.0.3
 rfc6266-parser==0.0.6
-ruamel.yaml.clib==0.2.0   # via ruamel.yaml
-ruamel.yaml==0.16.5       # via drf-yasg
+ruamel.yaml.clib==0.2.0
+ruamel.yaml==0.16.6
 rules==2.2
 s3transfer==0.1.13
 sailthru-client==2.2.3
@@ -291,8 +291,8 @@ tox==3.14.3
 transifex-client==0.13.4
 unicodecsv==0.14.1
 unidiff==0.5.5
-uritemplate==3.0.1        # via coreapi, drf-yasg
-urllib3==1.25.7
+uritemplate==3.0.1
+urllib3==1.25.8
 user-util==0.1.5
 virtualenv==16.7.9        # via tox
 voluptuous==0.11.7
@@ -300,7 +300,7 @@ watchdog==0.9.0
 wcwidth==0.1.8            # via pytest
 web-fragments==0.3.1
 webencodings==0.5.1
-webob==1.8.5
+webob==1.8.6
 wrapt==1.11.2
 git+https://github.com/edx-solutions/xblock-drag-and-drop-v2@v2.2.8#egg=xblock-drag-and-drop-v2==2.2.8
 git+https://github.com/open-craft/xblock-poll@3c7dcaf6c933d914188f0740a60711603f948d26#egg=xblock-poll==1.9.1

--- a/scripts/xblock/requirements.txt
+++ b/scripts/xblock/requirements.txt
@@ -8,4 +8,4 @@ certifi==2019.11.28       # via requests
 chardet==3.0.4            # via requests
 idna==2.8                 # via requests
 requests==2.22.0
-urllib3==1.25.7           # via requests
+urllib3==1.25.8           # via requests


### PR DESCRIPTION
Unpin several more outdated dependencies whose changelogs don't contain any significant backwards incompatible changes.  Also add "moto" to the list of packages to uninstall from existing environments, since it requires a jsondiff version that clashes with the one we now use (triggering a harmless but distracting warning on dependency updates).

We can potentially stop using `path.py`/`path` altogether by switching to `pathlib` in the Python 3 standard library, but that merits a separate PR of its own.

Also, note that I'm not actually unpinning `freezegun`; different PRs restricted it in both `constraints.txt` and `test.in`, I'm just removing the latter redundant constraint.