### PR TITLE
Updated border color on login page fields

### DIFF
--- a/lms/static/sass/views/_login-register.scss
+++ b/lms/static/sass/views/_login-register.scss
@@ -87,7 +87,8 @@
     color: $uxpl-gray-dark;
   }
 
-  a, label {
+  a,
+  label {
     @extend %expand-clickable-area;
   }
 
@@ -445,12 +446,13 @@
 
     select {
       background: transparent;
-      opacity: 0.85;
-      border: none;
-      outline: solid 1px $gray-l3;
+      border: 1px solid $gray;
       cursor: pointer;
+      -webkit-appearance: none;
+      -webkit-border-radius: 0;
 
-      &:active, &:focus {
+      &:active,
+      &:focus {
         outline: auto;
       }
     }
@@ -481,6 +483,7 @@
 
   .input-block {
     width: 100%;
+    border-color: $gray;
   }
 
   .input-inline {


### PR DESCRIPTION
## [PROD-726](https://openedx.atlassian.net/browse/PROD-726)

There are two text input boxes (for email and password). The border color is #c8c8c8.  That color has luminance contrast of 1.67:1 vs. the background color (#ffffff).  Problem:For WCAG 2.1 there is a new rule that says interactive elements need to be noticeable, which means their edges need to have a minimum of 3:1 contrast vs. the background. 

This PR fix this issue by changing the border color for the text input boxes to a darker grey.

### Before
<img width="548" alt="Screenshot 2020-01-21 at 4 07 06 PM" src="https://user-images.githubusercontent.com/26253150/72799996-2f891600-3c68-11ea-9dfd-8c5828b868a7.png">

### After
<img width="548" alt="Screenshot 2020-01-21 at 4 00 01 PM" src="https://user-images.githubusercontent.com/26253150/72799986-2c8e2580-3c68-11ea-8dca-79e04d27c4a8.png">



