### PR TITLE
Fixed bytes in filename

### DIFF
--- a/cms/djangoapps/contentstore/views/transcripts_ajax.py
+++ b/cms/djangoapps/contentstore/views/transcripts_ajax.py
@@ -264,7 +264,7 @@ def download_transcripts(request):
 
     # Construct an HTTP response
     response = HttpResponse(content, content_type=mimetype)
-    response['Content-Disposition'] = u'attachment; filename="{filename}"'.format(filename=filename.encode('utf-8'))
+    response['Content-Disposition'] = u'attachment; filename="{filename}"'.format(filename=filename)
     return response
 
 


### PR DESCRIPTION
## [PROD-1127](https://openedx.atlassian.net/browse/PROD-1127)

### Description
Fixed the "b" in download transcript filename when downloading the transcript from studio.

### Reviewers
If you've been tagged for review, please check your corresponding box once you've given the :+1:.
- [ ] @awaisdar001 
- [ ] @DawoudSheraz 

### Post-review
- [ ] Rebase and squash commits