### PR TITLE
Fix canUserCreateTeam()

### DIFF
--- a/docs/guides/testing/testing.rst
+++ b/docs/guides/testing/testing.rst
@@ -367,7 +367,7 @@ To run JavaScript tests in a browser, run these commands::
 To debug these tests on devstack in a local browser:
 
 * first run the appropriate test_js_dev command from above which will open a browser using XQuartz
-* open http://edx.devstack.lms:19876/debug.html in your host system's browser of choice
+* open http://localhost:19876/debug.html in your host system's browser of choice
 * this will run all the tests and show you the results including details of any failures
 * you can click on an individually failing test and/or suite to re-run it by itself
 * you can now use the browser's developer tools to debug as you would any other JavaScript code

--- a/lms/djangoapps/teams/static/teams/js/spec/views/topic_teams_spec.js
+++ b/lms/djangoapps/teams/static/teams/js/spec/views/topic_teams_spec.js
@@ -86,23 +86,38 @@ define([
         });
 
         it('does not show actions for a user already in a team', function() {
-            var teamsView = createTopicTeamsView({myTeamsCollection: TeamSpecHelpers.createMockTeams()});
+            var options = {myTeamsCollection: TeamSpecHelpers.createMockTeams()};
+            var teamsView = createTopicTeamsView(options);
             verifyActions(teamsView, {showActions: false});
         });
 
         it('does not show actions for a student in an instructor managed topic', function() {
-            var teamsView = createTopicTeamsView({privileged: false}, true);
+            var teamsView = createTopicTeamsView({}, true);
             verifyActions(teamsView, {showActions: false});
         });
 
         it('shows actions for a privileged user already in a team', function() {
-            var teamsView = createTopicTeamsView({privileged: true});
-            verifyActions(teamsView);
+            var options = {
+                userInfo: {
+                    privileged: true,
+                    staff: false
+                },
+                myTeamsCollection: TeamSpecHelpers.createMockTeams()
+            };
+            var teamsView = createTopicTeamsView(options);
+            verifyActions(teamsView, {showActions: true});
         });
 
         it('shows actions for a staff user already in a team', function() {
-            var teamsView = createTopicTeamsView({privileged: false, staff: true});
-            verifyActions(teamsView);
+            var options = {
+                userInfo: {
+                    privileged: false,
+                    staff: true
+                },
+                myTeamsCollection: TeamSpecHelpers.createMockTeams()
+            };
+            var teamsView = createTopicTeamsView(options);
+            verifyActions(teamsView, {showActions: true});
         });
 
         /*

--- a/lms/djangoapps/teams/static/teams/js/views/topic_teams.js
+++ b/lms/djangoapps/teams/static/teams/js/views/topic_teams.js
@@ -30,8 +30,8 @@
                     // that they create. This means that if multiple team membership is
                     // disabled that they cannot create a new team when they already
                     // belong to one.
-                return this.context.staff
-                    || this.context.privileged
+                return this.context.userInfo.staff
+                    || this.context.userInfo.privileged
                     || (!TeamUtils.isInstructorManagedTopic(this.model.attributes.type)
                         && this.myTeamsCollection.length === 0);
             },


### PR DESCRIPTION
In canUserCreateTeam(), look in this.context.userInfo for staff/priveleged attributes.

### Please consider the following when opening a pull request:

- Link to the relevant JIRA ticket(s) and tag any relevant team(s).
- Squash your changes down into one or more discrete commits.
  In each commit, include description that could help a developer
  several months from now.
- If running `make upgrade`, run _as close to the time of merging as possible_
  to avoid accidentally downgrading someone else's package.
  Put the output of `make upgrade` in its own separate commit,
  decoupled from other code changes.
- Aim for comprehensive test coverage, but remember that
  automated testing isn't a substitute for manual verification.
- Carefully consider naming, code organization, dependencies when adding new code.
  Code that is amenable to refactoring and improvement benefits all platform developers,
  especially given the size and scope of edx-platform.
  Consult existing Architectural Decision Records (ADRs),
  including those concerning the app(s) you are changing and
  [those concerning edx-platform as a whole](https://github.com/edx/edx-platform/tree/master/docs/decisions).
