### PR TITLE
EDUCATOR-4877: Implement stubbed API functions using new config values

### DIFF
--- a/lms/djangoapps/discussion/django_comment_client/tests/group_id.py
+++ b/lms/djangoapps/discussion/django_comment_client/tests/group_id.py
@@ -170,7 +170,10 @@ class NonCohortedTopicGroupIdTestMixin(GroupIdAssertionMixin):
         self._assert_comments_service_called_without_group_id(mock_request)
 
     def test_team_discussion_id_not_cohorted(self, mock_request):
-        team = CourseTeamFactory(course_id=self.course.id)
+        team = CourseTeamFactory(
+            course_id=self.course.id,
+            topic_id='topic-id'
+        )
 
         team.add_user(self.student)
         self.call_view(mock_request, team.discussion_topic_id, self.student, None)

--- a/lms/djangoapps/discussion/django_comment_client/tests/utils.py
+++ b/lms/djangoapps/discussion/django_comment_client/tests/utils.py
@@ -12,6 +12,7 @@ from openedx.core.djangoapps.django_comment_common.utils import (
     seed_permissions_roles,
     set_course_discussion_settings
 )
+from openedx.core.lib.teams_config import TeamsConfig
 from student.tests.factories import CourseEnrollmentFactory, UserFactory
 from util.testing import UrlResetMixin
 from xmodule.modulestore import ModuleStoreEnum
@@ -44,7 +45,14 @@ class CohortedTestCase(ForumsEnableMixin, UrlResetMixin, SharedModuleStoreTestCa
             cohort_config={
                 "cohorted": True,
                 "cohorted_discussions": ["cohorted_topic"]
-            }
+            },
+            teams_configuration=TeamsConfig({
+                'topics': [{
+                    'id': 'topic-id',
+                    'name': 'Topic Name',
+                    'description': 'Topic',
+                }]
+            })
         )
         cls.course.discussion_topics["cohorted topic"] = {"id": "cohorted_topic"}
         cls.course.discussion_topics["non-cohorted topic"] = {"id": "non_cohorted_topic"}

--- a/lms/djangoapps/teams/tests/test_api.py
+++ b/lms/djangoapps/teams/tests/test_api.py
@@ -3,7 +3,6 @@
 Tests for Python APIs of the Teams app
 """
 
-import unittest
 from uuid import uuid4
 
 import ddt
@@ -14,15 +13,18 @@ from course_modes.models import CourseMode
 from lms.djangoapps.teams import api as teams_api
 from lms.djangoapps.teams.models import CourseTeam
 from lms.djangoapps.teams.tests.factories import CourseTeamFactory
+from openedx.core.lib.teams_config import TeamsConfig, TeamsetType
 from student.models import CourseEnrollment
 from student.roles import CourseStaffRole
 from student.tests.factories import CourseEnrollmentFactory, UserFactory
 from xmodule.modulestore.tests.django_utils import SharedModuleStoreTestCase
+from xmodule.modulestore.tests.factories import CourseFactory
 
 COURSE_KEY1 = CourseKey.from_string('edx/history/1')
-COURSE_KEY2 = CourseKey.from_string('edx/history/2')
+COURSE_KEY2 = CourseKey.from_string('edx/math/1')
 TOPIC1 = 'topic-1'
 TOPIC2 = 'topic-2'
+TOPIC3 = 'topic-3'
 
 DISCUSSION_TOPIC_ID = uuid4().hex
 
@@ -39,6 +41,34 @@ class PythonAPITests(SharedModuleStoreTestCase):
         cls.user2 = UserFactory.create(username='user2')
         cls.user3 = UserFactory.create(username='user3')
         cls.user4 = UserFactory.create(username='user4')
+
+        topic_data = [
+            (TOPIC1, TeamsetType.private_managed.value),
+            (TOPIC2, TeamsetType.open.value),
+            (TOPIC3, TeamsetType.public_managed.value)
+        ]
+        topics = [
+            {
+                'id': topic_id,
+                'name': 'name-' + topic_id,
+                'description': 'desc-' + topic_id,
+                'type': teamset_type
+            } for topic_id, teamset_type in topic_data
+        ]
+        teams_config_1 = TeamsConfig({'topics': [topics[0]]})
+        teams_config_2 = TeamsConfig({'topics': [topics[1], topics[2]]})
+        cls.course1 = CourseFactory(
+            org=COURSE_KEY1.org,
+            course=COURSE_KEY1.course,
+            run=COURSE_KEY1.run,
+            teams_configuration=teams_config_1,
+        )
+        cls.course2 = CourseFactory(
+            org=COURSE_KEY2.org,
+            course=COURSE_KEY2.course,
+            run=COURSE_KEY2.run,
+            teams_configuration=teams_config_2,
+        )
 
         for user in (cls.user1, cls.user2, cls.user3, cls.user4):
             CourseEnrollmentFactory.create(user=user, course_id=COURSE_KEY1)
@@ -63,6 +93,7 @@ class PythonAPITests(SharedModuleStoreTestCase):
             team_id='team2a',
             topic_id=TOPIC2
         )
+        cls.team3 = CourseTeamFactory(course_id=COURSE_KEY2, team_id='team3', topic_id=TOPIC3)
 
         cls.team1.add_user(cls.user1)
         cls.team1.add_user(cls.user2)
@@ -78,13 +109,23 @@ class PythonAPITests(SharedModuleStoreTestCase):
         team = teams_api.get_team_by_discussion(DISCUSSION_TOPIC_ID)
         self.assertEqual(team, self.team1)
 
-    @unittest.skip("This functionality is not yet implemented")
     def test_is_team_discussion_private_is_private(self):
         self.assertTrue(teams_api.is_team_discussion_private(self.team1))
 
     def test_is_team_discussion_private_is_public(self):
         self.assertFalse(teams_api.is_team_discussion_private(None))
         self.assertFalse(teams_api.is_team_discussion_private(self.team2))
+        self.assertFalse(teams_api.is_team_discussion_private(self.team3))
+
+    def test_is_instructor_managed_team(self):
+        self.assertTrue(teams_api.is_instructor_managed_team(self.team1))
+        self.assertFalse(teams_api.is_instructor_managed_team(self.team2))
+        self.assertTrue(teams_api.is_instructor_managed_team(self.team3))
+
+    def test_is_instructor_managed_topic(self):
+        self.assertTrue(teams_api.is_instructor_managed_topic(COURSE_KEY1, TOPIC1))
+        self.assertFalse(teams_api.is_instructor_managed_topic(COURSE_KEY2, TOPIC2))
+        self.assertTrue(teams_api.is_instructor_managed_topic(COURSE_KEY2, TOPIC3))
 
     def test_user_is_a_team_member(self):
         self.assertTrue(teams_api.user_is_a_team_member(self.user1, self.team1))

--- a/lms/djangoapps/teams/tests/test_views.py
+++ b/lms/djangoapps/teams/tests/test_views.py
@@ -886,7 +886,7 @@ class TestCreateTeamAPI(EventTestMixin, TeamAPITestCase):
             name="Fully specified team",
             course=self.test_course_1,
             description="Another fantastic team",
-            topic_id='great-topic',
+            topic_id='topic_1',
             country='CA',
             language='fr'
         ), user=creator)
@@ -930,7 +930,7 @@ class TestCreateTeamAPI(EventTestMixin, TeamAPITestCase):
             'name': 'Fully specified team',
             'language': 'fr',
             'country': 'CA',
-            'topic_id': 'great-topic',
+            'topic_id': 'topic_1',
             'course_id': str(self.test_course_1.id),
             'description': 'Another fantastic team',
             'organization_protected': False,

--- a/lms/djangoapps/teams/views.py
+++ b/lms/djangoapps/teams/views.py
@@ -527,7 +527,7 @@ class TeamsListView(ExpandableFieldViewMixin, GenericAPIView):
             return Response(status=status.HTTP_403_FORBIDDEN)
 
         topic_id = request.data.get('topic_id')
-        if not can_user_create_team_in_topic(request.user, course_id, topic_id):
+        if not can_user_create_team_in_topic(request.user, course_key, topic_id):
             return Response(
                 build_api_error(ugettext_noop("You can't create a team in an instructor managed topic.")),
                 status=status.HTTP_403_FORBIDDEN

--- a/openedx/core/djangoapps/util/testing.py
+++ b/openedx/core/djangoapps/util/testing.py
@@ -10,6 +10,7 @@ from openedx.core.djangoapps.course_groups.tests.helpers import CohortFactory
 from openedx.core.djangoapps.django_comment_common.models import Role
 from openedx.core.djangoapps.django_comment_common.utils import seed_permissions_roles
 from openedx.core.djangoapps.user_api.tests.factories import UserCourseTagFactory
+from openedx.core.lib.teams_config import TeamsConfig
 from student.tests.factories import CourseEnrollmentFactory, UserFactory
 from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
 from xmodule.modulestore.tests.factories import CourseFactory, ItemFactory
@@ -51,7 +52,14 @@ class ContentGroupTestCase(ModuleStoreTestCase):
                 }]
             },
             cohort_config={'cohorted': True},
-            discussion_topics={}
+            discussion_topics={},
+            teams_configuration=TeamsConfig({
+                'topics': [{
+                    'id': 'topic_id',
+                    'name': 'topic_name',
+                    'description': 'topic_desc',
+                }]
+            })
         )
 
         seed_permissions_roles(self.course.id)


### PR DESCRIPTION
@edx/masters-devs 
[EDUCATOR-4877](https://openedx.atlassian.net/browse/EDUCATOR-4877)

implement the `is_team_discussion_private`, `is_instructor_managed_topic`, and `is_instructor_managed_topic` api functions which previously only returned `False`

Implement the functions by looking up the teams config for the course and looking at the `TeamsetType` for the specific team/set