### PR TITLE
fix: video fullscreen must not assume resizer exists

### DIFF
--- a/common/lib/xmodule/xmodule/js/src/video/04_video_full_screen.js
+++ b/common/lib/xmodule/xmodule/js/src/video/04_video_full_screen.js
@@ -188,8 +188,9 @@
                 .addClass('fa-arrows-alt');
 
             $(closedCaptionsEl).css({top: '70%', left: '5%'});
-
-            this.resizer.delta.reset().setMode('width');
+            if (this.resizer) {
+                this.resizer.delta.reset().setMode('width');
+            }
             this.el.trigger('fullscreen', [this.isFullScreen]);
         }
 
@@ -210,8 +211,9 @@
                 .addClass('fa-compress');
 
             $(closedCaptionsEl).css({top: '70%', left: '5%'});
-
-            this.resizer.delta.substract(this.videoFullScreen.updateControlsHeight(), 'height').setMode('both');
+            if (this.resizer) {
+                this.resizer.delta.substract(this.videoFullScreen.updateControlsHeight(), 'height').setMode('both');
+            }
             this.el.trigger('fullscreen', [this.isFullScreen]);
         }
 


### PR DESCRIPTION
Otherwise it fails to go fullscreen before playback. This happens because the resizer is created when video metadata is loaded. It seems that youtube video metadata is handled differently from other video formats and therefore the resizer is not initialized before playback.

### Please consider the following when opening a pull request:

- Link to the relevant JIRA ticket(s) and tag any relevant team(s).
- Squash your changes down into one or more discrete commits.
  In each commit, include description that could help a developer
  several months from now.
- If running `make upgrade`, run _as close to the time of merging as possible_
  to avoid accidentally downgrading someone else's package.
  Put the output of `make upgrade` in its own separate commit,
  decoupled from other code changes.
- Aim for comprehensive test coverage, but remember that
  automated testing isn't a substitute for manual verification.
- Carefully consider naming, code organization, dependencies when adding new code.
  Code that is amenable to refactoring and improvement benefits all platform developers,
  especially given the size and scope of edx-platform.
  Consult existing Architectural Decision Records (ADRs),
  including those concerning the app(s) you are changing and
  [those concerning edx-platform as a whole](https://github.com/edx/edx-platform/tree/master/docs/decisions).
