### PR TITLE
Generate Grade Report for Verified Learners by Default

### DIFF
--- a/common/djangoapps/student/models.py
+++ b/common/djangoapps/student/models.py
@@ -1016,12 +1016,16 @@ class CourseEnrollmentManager(models.Manager):
 
     def users_enrolled_in(self, course_id, include_inactive=False, verified_only=False):
         """
-        Return a queryset of User for every user enrolled in the course.  If
-        `include_inactive` is True, returns both active and inactive enrollees
-        for the course. Otherwise returns actively enrolled users only.
-        If 'verified_only' is True, returns report only for verified enrollees.
+        Return a queryset of User for every user enrolled in the course.
+
+        Arguments:
+            course_id (CourseLocator): course_id to return enrollees for.
+            include_inactive (boolean): is a boolean when True, returns both active and inactive enrollees
+            verified_only (boolean): is a boolean when True, returns only verified enrollees.
+
+        Returns:
+            Returns a User queryset.
         """
-        # enrolled
         filter_kwargs = {
             'courseenrollment__course_id': course_id,
         }

--- a/lms/djangoapps/instructor_task/config/waffle.py
+++ b/lms/djangoapps/instructor_task/config/waffle.py
@@ -4,7 +4,7 @@ waffle switches for the instructor_task app.
 """
 
 
-from openedx.core.djangoapps.waffle_utils import CourseWaffleFlag, WaffleFlagNamespace, WaffleSwitchNamespace
+from openedx.core.djangoapps.waffle_utils import WaffleFlagNamespace, WaffleSwitchNamespace
 
 WAFFLE_NAMESPACE = u'instructor_task'
 INSTRUCTOR_TASK_WAFFLE_FLAG_NAMESPACE = WaffleFlagNamespace(name=WAFFLE_NAMESPACE)
@@ -12,46 +12,14 @@ WAFFLE_SWITCHES = WaffleSwitchNamespace(name=WAFFLE_NAMESPACE)
 
 # Waffle switches
 OPTIMIZE_GET_LEARNERS_FOR_COURSE = u'optimize_get_learners_for_course'
-
-# Course-specific flags
-PROBLEM_GRADE_REPORT_VERIFIED_ONLY = u'problem_grade_report_verified_only'
-COURSE_GRADE_REPORT_VERIFIED_ONLY = u'course_grade_report_verified_only'
+GENERATE_GRADE_REPORT_VERIFIED_ONLY = u'generate_grade_report_for_verified_only'
 
 
 def waffle_flags():
     """
     Returns the namespaced, cached, audited Waffle flags dictionary for Grades.
     """
-    return {
-        PROBLEM_GRADE_REPORT_VERIFIED_ONLY: CourseWaffleFlag(
-            waffle_namespace=INSTRUCTOR_TASK_WAFFLE_FLAG_NAMESPACE,
-            flag_name=PROBLEM_GRADE_REPORT_VERIFIED_ONLY,
-            flag_undefined_default=False,
-        ),
-        COURSE_GRADE_REPORT_VERIFIED_ONLY: CourseWaffleFlag(
-            waffle_namespace=INSTRUCTOR_TASK_WAFFLE_FLAG_NAMESPACE,
-            flag_name=COURSE_GRADE_REPORT_VERIFIED_ONLY,
-            flag_undefined_default=False,
-        ),
-    }
-
-
-def problem_grade_report_verified_only(course_id):
-    """
-    Returns True if problem grade reports should only
-    return rows for verified students in the given course,
-    False otherwise.
-    """
-    return waffle_flags()[PROBLEM_GRADE_REPORT_VERIFIED_ONLY].is_enabled(course_id)
-
-
-def course_grade_report_verified_only(course_id):
-    """
-    Returns True if problem grade reports should only
-    return rows for verified students in the given course,
-    False otherwise.
-    """
-    return waffle_flags()[PROBLEM_GRADE_REPORT_VERIFIED_ONLY].is_enabled(course_id)
+    return {}
 
 
 def optimize_get_learners_switch_enabled():
@@ -59,3 +27,11 @@ def optimize_get_learners_switch_enabled():
     Returns True if optimize get learner switch is enabled, otherwise False.
     """
     return WAFFLE_SWITCHES.is_enabled(OPTIMIZE_GET_LEARNERS_FOR_COURSE)
+
+
+def generate_grade_report_for_verified_only():
+    """
+    Returns True if waffle switch is enabled that indicates generate grading reports only for
+    verified learners.
+    """
+    return WAFFLE_SWITCHES.is_enabled(GENERATE_GRADE_REPORT_VERIFIED_ONLY)


### PR DESCRIPTION
[PROD-968](https://openedx.atlassian.net/browse/PROD-968): Generate Grade report for verified learners only
-
The following reports (initialized from instructor dashboard) are will generate the report for verified learners when the waffle switch will be on. 

**Waffle Switch**
* `instructor_task.generate_grade_report_for_verified_only`

**Grade Reports**
* CourseGradeReport (Instructor Dashbaord -> Data Download -> Generate Grade Report)
* ProblemGradeReport (Instructor Dashbaord -> Data Download -> Generate Problem Grade Report)

**SandBox**
https://gradereport.sandbox.edx.org/

**Steps to debug on sandbox**
1. Goto https://gradereport.sandbox.edx.org/courses/course-v1:edX+DemoX+Demo_Course/instructor#view-data_download
2. Verify the switch is enabled. 
3. Generate reports and verified only verified learners are in the report. 

4. Disable the switch
5. Verify all learners are available in the report. 