### PR TITLE
Limiting dataset for notify_credentials job

### DIFF
--- a/openedx/core/djangoapps/credentials/management/commands/notify_credentials.py
+++ b/openedx/core/djangoapps/credentials/management/commands/notify_credentials.py
@@ -16,6 +16,7 @@ import math
 import sys
 import time
 
+from datetime import datetime, timedelta
 import dateutil.parser
 from django.contrib.auth.models import User
 from django.core.management.base import BaseCommand, CommandError
@@ -138,6 +139,11 @@ class Command(BaseCommand):
             help="Number of items to query at once.",
         )
         parser.add_argument(
+            '--auto',
+            action='store_true',
+            help='Use to run the management command periodically',
+        )
+        parser.add_argument(
             '--args-from-database',
             action='store_true',
             help='Use arguments from the NotifyCredentialsConfig model instead of the command line.',
@@ -164,11 +170,20 @@ class Command(BaseCommand):
         if options['args_from_database']:
             options = self.get_args_from_database()
 
+        if options['auto']:
+            options['end_date'] = datetime.now().replace(hour=0, minute=0, second=0, microsecond=0)
+            options['start_date'] = options['end_date'] - timedelta(days=1)
+
         log.info(
-            u"notify_credentials starting, dry-run=%s, site=%s, delay=%d seconds",
+            u"notify_credentials starting, dry-run=%s, site=%s, delay=%d seconds, page_size=%d, "
+            u"from=%s, to=%s, execution=%s",
             options['dry_run'],
             options['site'],
-            options['delay']
+            options['delay'],
+            options['page_size'],
+            options['start_date'] if options['start_date'] else 'NA',
+            options['end_date'] if options['end_date'] else 'NA',
+            'auto' if options['auto'] else 'manual',
         )
 
         try:

--- a/openedx/core/djangoapps/credentials/management/commands/tests/test_notify_credentials.py
+++ b/openedx/core/djangoapps/credentials/management/commands/tests/test_notify_credentials.py
@@ -13,6 +13,7 @@ from django.test import TestCase, override_settings
 from freezegun import freeze_time
 
 from lms.djangoapps.certificates.tests.factories import GeneratedCertificateFactory
+from lms.djangoapps.certificates.models import GeneratedCertificate
 from lms.djangoapps.grades.models import PersistentCourseGrade
 from openedx.core.djangoapps.credentials.models import NotifyCredentialsConfig
 from openedx.core.djangoapps.site_configuration.tests.factories import SiteConfigurationFactory
@@ -59,6 +60,35 @@ class TestNotifyCredentials(TestCase):
         self.assertTrue(mock_send.called)
         self.assertEqual(list(mock_send.call_args[0][0]), [self.cert1, self.cert2])
         self.assertEqual(list(mock_send.call_args[0][1]), [self.grade1, self.grade2])
+
+    @freeze_time(datetime(2017, 5, 2))
+    @mock.patch(COMMAND_MODULE + '.Command.send_notifications')
+    def test_auto_execution(self, mock_send):
+        cert_filter_args = {}
+
+        with freeze_time(datetime(2017, 5, 1)):
+            cert1 = GeneratedCertificateFactory(user=self.user, course_id='course-v1:edX+Test+11')
+        with freeze_time(datetime(2017, 5, 2)):
+            cert2 = GeneratedCertificateFactory(user=self.user, course_id='course-v1:edX+Test+22')
+
+        with freeze_time(datetime(2017, 5, 1)):
+            grade1 = PersistentCourseGrade.objects.create(user_id=self.user.id, course_id='course-v1:edX+Test+11',
+                                                          percent_grade=1)
+        with freeze_time(datetime(2017, 5, 2)):
+            grade2 = PersistentCourseGrade.objects.create(user_id=self.user.id, course_id='course-v1:edX+Test+22',
+                                                          percent_grade=1)
+
+        total_certificates = GeneratedCertificate.objects.filter(**cert_filter_args).order_by('modified_date')  # pylint: disable=no-member
+        total_grades = PersistentCourseGrade.objects.all()
+
+        call_command(Command(), '--auto')
+
+        self.assertTrue(mock_send.called)
+        self.assertListEqual(list(mock_send.call_args[0][0]), [cert1, cert2])
+        self.assertListEqual(list(mock_send.call_args[0][1]), [grade1, grade2])
+
+        self.assertLessEqual(len(list(mock_send.call_args[0][0])), len(total_certificates))
+        self.assertLessEqual(len(list(mock_send.call_args[0][1])), len(total_grades))
 
     @mock.patch(COMMAND_MODULE + '.Command.send_notifications')
     def test_date_args(self, mock_send):


### PR DESCRIPTION
notify_credentials job when executed without
any restriction consumes a lot of memory
because of huge dataset that  makes
it unsuable to be executed periodically.
This patch would time bound it to only work
on last day dataset.

PROD-1190