### PR TITLE
FIX: Show error message for non authenticated users

### DIFF
--- a/common/lib/xmodule/xmodule/seq_module.py
+++ b/common/lib/xmodule/xmodule/seq_module.py
@@ -519,13 +519,6 @@ class SequenceModule(SequenceFields, ProctoringFields, XModule):
             item_type = item.get_icon_class()
             usage_id = item.scope_ids.usage_id
 
-            if item_type == 'problem' and not is_user_authenticated:
-                log.info(
-                    'Problem [%s] was not rendered because anonymous access is not allowed for graded content',
-                    usage_id
-                )
-                continue
-
             show_bookmark_button = False
             is_bookmarked = False
 


### PR DESCRIPTION
**Background**
If we enable course wiki access (documentation link: https://edx.readthedocs.io/projects/edx-installing-configuring-and-running/en/latest/configuration/enable_public_course.html#enabling-public-course-content), It states in the limitations section (https://edx.readthedocs.io/projects/edx-installing-configuring-and-running/en/latest/configuration/enable_public_course.html#enabling-public-course-content) that unenrolled users (logged-in and not-logged-in) will see an error messages instead of the "problem" blocks.

**Expected behavior**
If we enable the public access feature by following the documentation, a non-enrolled user should see an error message stating that he/she needs to register or sign in and then enroll to see the problem.

**Actual Behavior**
- A user who is logged in but not enrolled sees the error message just as expected
![image](https://user-images.githubusercontent.com/42166091/73162412-892d8c80-410f-11ea-9e59-fdd472e32f82.png)
- A user who is not logged in does not see the message and the unit is instead skipped. If the unit with the problem is the last unit then an empty unit is displayed.
![image](https://user-images.githubusercontent.com/42166091/73162450-a2ced400-410f-11ea-9dfc-decd621a806f.png)

**Steps to reproduce**
- Make a course
- Make it publicly available (https://edx.readthedocs.io/projects/edx-installing-configuring-and-running/en/latest/configuration/enable_public_course.html)
- Add problem and simple xBlocks in it.
- Try to access the units with problems in it (while not enrolled and not logged in).