### PR TITLE
Fix course enroll button on program details.

### DIFF
--- a/lms/static/js/learner_dashboard/views/course_enroll_view.js
+++ b/lms/static/js/learner_dashboard/views/course_enroll_view.js
@@ -48,7 +48,7 @@ class CourseEnrollView extends Backbone.View {
   handleEnroll() {
     // Enrollment click event handled here
     if (this.model.get('is_mobile_only') !== true) {
-      const courseRunKey = $('.run-select').val() || this.model.get('course_run_key');
+      const courseRunKey = this.$el.find('.run-select').val() || this.model.get('course_run_key');
       this.model.updateCourseRun(courseRunKey);
       if (this.model.get('is_enrolled')) {
         // Create the enrollment.


### PR DESCRIPTION
If there is no dropdown for a course but there is another course in program which have a dropdown, $('.run-select').val() returns that run's value. Fixed by using $el.

PROD-1217
