### PR TITLE
add multiple correct values check for Dropdown problems

### DIFF
--- a/common/lib/xmodule/xmodule/capa_module.py
+++ b/common/lib/xmodule/xmodule/capa_module.py
@@ -344,7 +344,7 @@ class ProblemBlock(
 
     def max_score(self):
         """
-        Return the problem's max score
+        Return the problem's max score if problem is instantiated successfully, else return max score of 0.
         """
         from capa.capa_problem import LoncapaProblem, LoncapaSystem
         capa_system = LoncapaSystem(
@@ -363,16 +363,22 @@ class ProblemBlock(
             xqueue=None,
             matlab_api_key=None,
         )
-        lcp = LoncapaProblem(
-            problem_text=self.data,
-            id=self.location.html_id(),
-            capa_system=capa_system,
-            capa_module=self,
-            state={},
-            seed=1,
-            minimal_init=True,
-        )
-        return lcp.get_max_score()
+        try:
+            lcp = LoncapaProblem(
+                problem_text=self.data,
+                id=self.location.html_id(),
+                capa_system=capa_system,
+                capa_module=self,
+                state={},
+                seed=1,
+                minimal_init=True,
+            )
+        except responsetypes.LoncapaProblemError:
+            log.exception(u"LcpFatalError for block {} while getting max score".format(str(self.location)))
+            maximum_score = 0
+        else:
+            maximum_score = lcp.get_max_score()
+        return maximum_score
 
     def generate_report_data(self, user_state_iterator, limit_responses=None):
         """

--- a/common/lib/xmodule/xmodule/tests/test_capa_module.py
+++ b/common/lib/xmodule/xmodule/tests/test_capa_module.py
@@ -2871,6 +2871,27 @@ class ProblemBlockXMLTest(unittest.TestCase):
         with self.assertRaises(etree.XMLSyntaxError):
             self._create_descriptor(sample_invalid_xml, name="Invalid XML")
 
+    def test_invalid_dropdown_xml(self):
+        """
+        Verify the capa problem cannot be created from dropdown xml with multiple correct answers.
+        """
+        problem_xml = textwrap.dedent("""
+        <problem>
+            <optionresponse>
+              <p>You can use this template as a guide to the simple editor markdown and OLX markup to use for dropdown problems. Edit this component to replace this template with your own assessment.</p>
+            <label>Add the question text, or prompt, here. This text is required.</label>
+            <description>You can add an optional tip or note related to the prompt like this. </description>
+            <optioninput>
+                <option correct="False">an incorrect answer</option>
+                <option correct="True">the correct answer</option>
+                <option correct="True">an incorrect answer</option>
+              </optioninput>
+            </optionresponse>
+        </problem>
+        """)
+        with self.assertRaises(Exception):
+            CapaFactory.create(xml=problem_xml)
+
 
 class ComplexEncoderTest(unittest.TestCase):
 

--- a/lms/djangoapps/grades/tests/test_transformer.py
+++ b/lms/djangoapps/grades/tests/test_transformer.py
@@ -347,6 +347,35 @@ class GradesTransformerTestCase(CourseStructureTestCase):
             max_score=2,
         )
 
+    def test_max_score_for_invalid_dropdown_problem(self):
+        """
+        Verify that for an invalid dropdown problem, the max score is set to zero.
+        """
+        problem_data = u'''
+        <problem>
+            <optionresponse>
+              <p>You can use this template as a guide to the simple editor markdown and OLX markup to use for dropdown problems. Edit this component to replace this template with your own assessment.</p>
+            <label>Add the question text, or prompt, here. This text is required.</label>
+            <description>You can add an optional tip or note related to the prompt like this. </description>
+            <optioninput>
+                <option correct="False">an incorrect answer</option>
+                <option correct="True">the correct answer</option>
+                <option correct="True">an incorrect answer</option>
+              </optioninput>
+            </optionresponse>
+        </problem>
+        '''
+
+        blocks = self.build_course_with_problems(problem_data)
+        block_structure = get_course_blocks(self.student, blocks['course'].location, self.transformers)
+
+        self.assert_collected_transformer_block_fields(
+            block_structure,
+            blocks['problem'].location,
+            self.TRANSFORMER_CLASS_TO_TEST,
+            max_score=0,
+        )
+
     def test_course_version_not_collected_in_old_mongo(self):
         blocks = self.build_course_with_problems()
         block_structure = get_course_blocks(self.student, blocks[u'course'].location, self.transformers)


### PR DESCRIPTION
### [PROD-347](https://openedx.atlassian.net/browse/PROD-347)

### Description
The drop-down problems in our platform allow only one correct answer. However, if a course team authors a DD problem with multiple correct answers, the problem created behaves unexpectedly and causes a lot of confusion for both the course team & the learners. The internal format(mentioned below) doesn't allow the multiple correct answers as lxml Invalides the tree for multiple correct attributes. 

**Internal format**
``` 
<optionresponse>
    <label>What type of data is age?</label>
    <optioninput options="('Nominal','Discrete','Continuous')"
     correct="Continuous"></optioninput>
  </optionresponse>
```

The issue is happening for the following format where correct attribute is part of option tag:
``` 
<problem>
<optionresponse>
  <p>You can use this template as a guide to the simple editor markdown and OLX markup to use for dropdown problems. Edit this component to replace this template with your own assessment.</p>
<label>Add the question text, or prompt, here. This text is required.</label>
<description>You can add an optional tip or note related to the prompt like this. </description>
<optioninput>
    <option correct="False">an incorrect answer</option>
    <option correct="True">the correct answer</option>
    <option correct="True">an incorrect answer</option>
  </optioninput>
</optionresponse>
</problem>
```

The changes of this PR add a check when converting the new XML to internal XML that validates if the dropdown is valid or not. If not, the `LoncapaProblemError` is raised. This will also flag all the existing DD problems authored with multiple correct answers.


### Sandbox
 - https://studio-dropdown.sandbox.edx.org/home/

### Testing Instructions

1. Visit the sandbox
2. Go to any unit and add a drop down problem.
3. Edit the problem and add multiple correct answers.
4. Once saved, observe the error mentioning the DD problems can only have one correct answer.
5. Publish & visit the LMS. The problem will not be rendered. 
6. Open Staff Debug Info section and check that the problem will have the max score of zero.
7. Visit the progress page and ensure it loads properly(as it is using grades transformer which relies on an individual block's call of max score method to get the score)
8. Now, visit the studio again and edit the problem so that there is only one correct answer.
9. The problem will render correctly on both LMS & Studio.

### Reviewers
 - [x] @awaisdar001 
 - [x] @asadazam93 

### Post Review
 - [x] Squash & Rebase commits
