### PR TITLE
BOM-897: add get_courses permission check with role

### DIFF
--- a/lms/djangoapps/course_api/api.py
+++ b/lms/djangoapps/course_api/api.py
@@ -71,25 +71,6 @@ def course_detail(request, username, course_key):
     )
 
 
-def _filter_by_role(course_queryset, user, roles):
-    """
-    Filters a course queryset by the roles for which the user has access.
-    """
-    # Global staff have access to all courses. Filter course roles for non-global staff only.
-    if not user.is_staff:
-        if roles:
-            for role in roles:
-                # Filter the courses again to return only the courses for which the user has each specified role.
-                course_queryset = LazySequence(
-                    (
-                        course for course in course_queryset
-                        if has_access(user, role, course.id)
-                    ),
-                    est_len=len(course_queryset)
-                )
-    return course_queryset
-
-
 def _filter_by_search(course_queryset, search_term):
     """
     Filters a course queryset by the specified search term.
@@ -118,7 +99,7 @@ def _filter_by_search(course_queryset, search_term):
     )
 
 
-def list_courses(request, username, org=None, roles=None, filter_=None, search_term=None):
+def list_courses(request, username, org=None, role=None, filter_=None, search_term=None):
     """
     Yield all available courses.
 
@@ -139,10 +120,10 @@ def list_courses(request, username, org=None, roles=None, filter_=None, search_t
             If specified, visible `CourseOverview` objects are filtered
             such that only those belonging to the organization with the provided
             org code (e.g., "HarvardX") are returned. Case-insensitive.
-        roles (list of strings):
+        role (string):
             If specified, visible `CourseOverview` objects are filtered
-            such that only those for which the user has the specified role(s)
-            are returned. Multiple role parameters can be specified.
+            such that only those for which the user has the specified role
+            are returned.
         filter_ (dict):
             If specified, visible `CourseOverview` objects are filtered
             by the given key-value pairs.
@@ -153,8 +134,7 @@ def list_courses(request, username, org=None, roles=None, filter_=None, search_t
         Yield `CourseOverview` objects representing the collection of courses.
     """
     user = get_effective_user(request.user, username)
-    course_qs = get_courses(user, org=org, filter_=filter_)
-    course_qs = _filter_by_role(course_qs, user, roles)
+    course_qs = get_courses(user, org=org, filter_=filter_, role=role)
     course_qs = _filter_by_search(course_qs, search_term)
     return course_qs
 

--- a/lms/djangoapps/course_api/forms.py
+++ b/lms/djangoapps/course_api/forms.py
@@ -53,7 +53,7 @@ class CourseListGetForm(UsernameValidatorMixin, Form):
     search_term = CharField(required=False)
     username = CharField(required=False)
     org = CharField(required=False)
-    role = MultiValueField(required=False)
+    role = CharField(required=False)
 
     # white list of all supported filter fields
     filter_type = namedtuple('filter_type', ['param_name', 'field_name'])

--- a/lms/djangoapps/course_api/tests/test_forms.py
+++ b/lms/djangoapps/course_api/tests/test_forms.py
@@ -68,7 +68,7 @@ class TestCourseListGetForm(FormTestMixin, UsernameTestMixin, SharedModuleStoreT
         self.cleaned_data = {
             'username': user.username,
             'org': '',
-            'role': set([]),
+            'role': '',
             'mobile': None,
             'search_term': '',
             'filter_': None,

--- a/lms/djangoapps/course_api/tests/test_views.py
+++ b/lms/djangoapps/course_api/tests/test_views.py
@@ -210,7 +210,7 @@ class CourseListViewTestCaseMultipleCourses(CourseApiTestViewMixin, ModuleStoreT
                 u"testing course_api.views.CourseListView with filter_={}".format(filter_),
             )
 
-    def test_filter_by_roles_global_staff(self):
+    def test_filter_by_role_global_staff(self):
         """
         Verify that global staff are always returned all courses irregardless of role filter.
         """
@@ -219,16 +219,16 @@ class CourseListViewTestCaseMultipleCourses(CourseApiTestViewMixin, ModuleStoreT
         # Create a second course to be filtered out of queries.
         alternate_course = self.create_course(org=md5(self.course.org.encode('utf-8')).hexdigest())
 
-        # Request the courses as the staff user with the different roles specified.
-        for roles in ('', 'staff', 'staff,instructor'):
-            filtered_response = self.verify_response(params={'username': self.staff_user.username, 'role': roles})
+        # Request the courses as the staff user with the different role specified.
+        for role in ('', 'staff', 'instructor'):
+            filtered_response = self.verify_response(params={'username': self.staff_user.username, 'role': role})
             # Both courses should be returned in the course list.
             for org in [self.course.org, alternate_course.org]:
                 self.assertTrue(
                     any(course['org'] == org for course in filtered_response.data['results'])
                 )
 
-    def test_filter_by_roles_non_staff(self):
+    def test_filter_by_role_non_staff(self):
         """
         Verify that a non-staff user can't access CourseOverviews by role.
         """
@@ -238,9 +238,9 @@ class CourseListViewTestCaseMultipleCourses(CourseApiTestViewMixin, ModuleStoreT
         filtered_response = self.verify_response(params={'username': self.honor_user.username, 'role': 'staff'})
         self.assertEqual(len(filtered_response.data['results']), 0)
 
-    def test_filter_by_roles_course_staff(self):
+    def test_filter_by_role_course_staff(self):
         """
-        Verify that CourseOverviews are filtered by the provided roles.
+        Verify that CourseOverviews are filtered by the provided role.
         """
         # Make this user a course staff user for the course.
         course_staff_user = self.create_user(username='course_staff', is_staff=False)
@@ -274,13 +274,6 @@ class CourseListViewTestCaseMultipleCourses(CourseApiTestViewMixin, ModuleStoreT
         })
         self.assertEqual(len(filtered_response.data['results']), 1)
         self.assertEqual(filtered_response.data['results'][0]['org'], alternate_course.org)
-
-        # The honor user does *not* have the course staff -or- instructor role on any courses.
-        filtered_response = self.verify_response(params={
-            'username': self.honor_user.username,
-            'role': 'staff,instructor'
-        })
-        self.assertEqual(len(filtered_response.data['results']), 0)
 
         # The course instructor user has the inferred course staff role on one course.
         self.setup_user(course_instructor_user)

--- a/lms/djangoapps/course_api/views.py
+++ b/lms/djangoapps/course_api/views.py
@@ -192,7 +192,7 @@ class CourseListView(DeveloperErrorViewMixin, ListAPIView):
         role (optional):
             If specified, visible `CourseOverview` objects are filtered
             such that only those for which the user has the specified role
-            are returned. Multiple role parameters can be specified.
+            are returned.
             Case-insensitive.
 
     **Returns**
@@ -249,7 +249,7 @@ class CourseListView(DeveloperErrorViewMixin, ListAPIView):
             self.request,
             form.cleaned_data['username'],
             org=form.cleaned_data['org'],
-            roles=form.cleaned_data['role'],
+            role=form.cleaned_data['role'],
             filter_=form.cleaned_data['filter_'],
             search_term=form.cleaned_data['search_term']
         )

--- a/lms/djangoapps/courseware/courses.py
+++ b/lms/djangoapps/courseware/courses.py
@@ -457,7 +457,7 @@ def get_course_syllabus_section(course, section_key):
     raise KeyError("Invalid about key " + str(section_key))
 
 
-def get_courses(user, org=None, filter_=None):
+def get_courses(user, org=None, filter_=None, role=None):
     """
     Return a LazySequence of courses available, optionally filtered by org code (case-insensitive).
     """
@@ -474,10 +474,13 @@ def get_courses(user, org=None, filter_=None):
         'image_set'
     )
 
-    permission_name = configuration_helpers.get_value(
-        'COURSE_CATALOG_VISIBILITY_PERMISSION',
-        settings.COURSE_CATALOG_VISIBILITY_PERMISSION
-    )
+    if role in ['staff', 'instructor']:
+        permission_name = role
+    else:
+        permission_name = configuration_helpers.get_value(
+            'COURSE_CATALOG_VISIBILITY_PERMISSION',
+            settings.COURSE_CATALOG_VISIBILITY_PERMISSION
+        )
 
     return LazySequence(
         (c for c in courses if has_access(user, permission_name, c)),


### PR DESCRIPTION
Rather than making multiple permission checks for CourseListView by
role, we instead trump the permission check with a role based check.

Additionally, only accepts one role for simplification.

BOM-897

### Please consider the following when opening a pull request:

- Link to the relevant JIRA ticket(s) and tag any relevant team(s).
- Squash your changes down into one or more discrete commits.
  In each commit, include description that could help a developer
  several months from now.
- If running `make upgrade`, run _as close to the time of merging as possible_
  to avoid accidentally downgrading someone else's package.
  Put the output of `make upgrade` in its own separate commit,
  decoupled from other code changes.
- Aim for comprehensive test coverage, but remember that
  automated testing isn't a substitute for manual verification.
- Carefully consider naming, code organization, dependencies when adding new code.
  Code that is amenable to refactoring and improvement benefits all platform developers,
  especially given the size and scope of edx-platform.
  Consult existing Architectural Decision Records (ADRs),
  including those concerning the app(s) you are changing and
  [those concerning edx-platform as a whole](https://github.com/edx/edx-platform/tree/master/docs/decisions).
