### PR TITLE
SE-1841 remove unused defaults

### DIFF
--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -1733,8 +1733,6 @@ RETIRED_EMAIL_FMT = lambda settings: settings.RETIRED_EMAIL_PREFIX + '{}@' + set
 derived('RETIRED_USERNAME_FMT', 'RETIRED_EMAIL_FMT')
 RETIRED_USER_SALTS = ['abc', '123']
 RETIREMENT_SERVICE_WORKER_USERNAME = 'RETIREMENT_SERVICE_USER'
-RETIREMENT_SERVICE_USER_EMAIL = "retirement_worker@example.com"
-RETIREMENT_SERVICE_USER_NAME = "retirement_worker"
 
 # These states are the default, but are designed to be overridden in configuration.
 RETIREMENT_STATES = [

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -3956,8 +3956,6 @@ RETIRED_EMAIL_FMT = lambda settings: settings.RETIRED_EMAIL_PREFIX + '{}@' + set
 derived('RETIRED_USERNAME_FMT', 'RETIRED_EMAIL_FMT')
 RETIRED_USER_SALTS = ['abc', '123']
 RETIREMENT_SERVICE_WORKER_USERNAME = 'RETIREMENT_SERVICE_USER'
-RETIREMENT_SERVICE_USER_EMAIL = "retirement_worker@example.com"
-RETIREMENT_SERVICE_USER_NAME = "retirement_worker"
 
 # These states are the default, but are designed to be overridden in configuration.
 RETIREMENT_STATES = [


### PR DESCRIPTION
This reverts commit 814d1bf52df7f0dd804adc16725c05f0c79b9c35.

`RETIREMENT_SERVICE_USER_NAME` is not used in edx-platform. `EDXAPP_RETIREMENT_SERVICE_USER_NAME` is used in configuration, and this is passed through to edx-platform django config as `RETIREMENT_SERVICE_WORKER_USERNAME` (already has a default).

`RETIREMENT_SERVICE_USER_EMAIL` is only used in edx/configuration [here](https://github.com/edx/configuration/blob/5806881b0071aeef355054e7b658855fc22e4035/playbooks/roles/edxapp/defaults/main.yml#L1717) to create the service worker users - this is not passed through to edx-platform django config at all.

Removing them to avoid confusion with other documented variables, or accidentally depending on variables that are never overridden.

CC @syedimranhassan as author who introduced those variables - you may have more context for the original addition of these and want to comment.

**JIRA tickets**: [OSPR-4064](https://openedx.atlassian.net/browse/OSPR-4064)

**Testing instructions**:

- verify that the above explanation checks out. See also discussion on https://github.com/edx/configuration/pull/5619
- verify that these two variables are not passed through to edx-platform and are not used anywhere else, and thus do not need to be present as defaults.

**Reviewers**:

- [ ] @giovannicimolin 
- [ ] edX reviewer TBD