### PR TITLE
Adds compilejs task to paver.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,6 +51,7 @@ pull_translations: ## pull translations from Transifex
 	git clean -fdX conf/locale/rtl
 	git clean -fdX conf/locale/eo
 	i18n_tool validate
+	paver i18n_compilejs
 
 detect_changed_source_translations: ## check if translation files are up-to-date
 	i18n_tool changed

--- a/pavelib/i18n.py
+++ b/pavelib/i18n.py
@@ -92,6 +92,22 @@ def i18n_dummy(options):
     # Need to then compile the new dummy strings
     sh("i18n_tool generate")
 
+
+@task
+@needs(
+    "pavelib.prereqs.install_prereqs",
+    "pavelib.i18n.i18n_validate_gettext",
+)
+@cmdopts([
+    ("settings=", "s", "The settings to use (defaults to devstack)"),
+])
+@timed
+def i18n_compilejs(options):
+    """
+    Generating djangojs.mo file using django-statici18n
+    """
+    settings = options.get('settings', DEFAULT_SETTINGS)
+
     # Generate static i18n JS files.
     for system in ['lms', 'cms']:
         sh(django_cmd(system, settings, 'compilejsi18n'))

--- a/pavelib/paver_tests/test_i18n.py
+++ b/pavelib/paver_tests/test_i18n.py
@@ -163,6 +163,34 @@ class TestI18nDummy(PaverTestCase):
                 u'i18n_tool extract',
                 u'i18n_tool dummy',
                 u'i18n_tool generate',
+            ]
+        )
+
+
+class TestI18nCompileJS(PaverTestCase):
+    """
+    Test the Paver i18n_compilejs task.
+    """
+    def setUp(self):
+        super(TestI18nCompileJS, self).setUp()
+
+        # Mock the paver @needs decorator for i18n_extract
+        self._mock_paver_needs = patch.object(pavelib.i18n.i18n_extract, 'needs').start()
+        self._mock_paver_needs.return_value = 0
+
+        # Cleanup mocks
+        self.addCleanup(self._mock_paver_needs.stop)
+
+    def test_i18n_compilejs(self):
+        """
+        Test the "i18n_compilejs" task.
+        """
+        self.reset_task_messages()
+        os.environ['NO_PREREQ_INSTALL'] = "true"
+        call_task('pavelib.i18n.i18n_compilejs', options={"settings": Env.TEST_SETTINGS})
+        self.assertEqual(
+            self.task_messages,
+            [
                 u'python manage.py lms --settings={} compilejsi18n'.format(Env.TEST_SETTINGS),
                 u'python manage.py cms --settings={} compilejsi18n'.format(Env.TEST_SETTINGS),
             ]


### PR DESCRIPTION
This patch adds compilejs
management command to be executed
on pull translations enabling
availability of js/jsx translations
for  lms/cms code.

PROD-960
