### PR TITLE
Display profile name in gradebook api

### DIFF
--- a/lms/djangoapps/grades/rest_api/v1/gradebook_views.py
+++ b/lms/djangoapps/grades/rest_api/v1/gradebook_views.py
@@ -496,7 +496,7 @@ class GradebookView(GradeViewMixin, PaginatedAPIView):
             kwargs=dict(course_id=text_type(course.id), student_id=user.id)
         )
         user_entry['user_id'] = user.id
-        user_entry['full_name'] = user.get_full_name()
+        user_entry['full_name'] = user.profile.name
 
         external_user_key = self._get_external_user_key(user, course.id)
         if external_user_key:


### PR DESCRIPTION
Currently the gradebook API displays the user full name that is stored in the built-in Django auth_user which is empty by default unless we change that on the django admin console. Since we store all the user data in UserProfile (auth_userprofile), this change is done to get the full name from that table.