### PR TITLE
Remove reads from old column

### DIFF
--- a/openedx/core/djangoapps/schedules/tests/test_resolvers.py
+++ b/openedx/core/djangoapps/schedules/tests/test_resolvers.py
@@ -120,7 +120,7 @@ class TestCourseUpdateResolver(SchedulesResolverTestMixin, ModuleStoreTestCase):
         return CourseUpdateResolver(
             async_send_task=Mock(name='async_send_task'),
             site=self.site_config.site,
-            target_datetime=enrollment.schedule.start,
+            target_datetime=enrollment.schedule.start_date,
             day_offset=-7,
             bin_num=CourseUpdateResolver.bin_num_for_user_id(self.user.id),
         )

--- a/openedx/core/djangoapps/schedules/tests/test_signals.py
+++ b/openedx/core/djangoapps/schedules/tests/test_signals.py
@@ -155,7 +155,7 @@ class CreateScheduleTests(SharedModuleStoreTestCase):
         mock_get_current_site.return_value = site
         course = _create_course_run(self_paced=True, start_day_offset=5)  # course starts in future
         enrollment = CourseEnrollmentFactory(course_id=course.id, mode=CourseMode.AUDIT)
-        assert _strip_secs(enrollment.schedule.start) == _strip_secs(course.start)
+        assert _strip_secs(enrollment.schedule.start_date) == _strip_secs(course.start)
 
     @override_waffle_flag(CREATE_SCHEDULE_WAFFLE_FLAG, True)
     def test_course_already_started(self, mock_get_current_site):
@@ -167,7 +167,7 @@ class CreateScheduleTests(SharedModuleStoreTestCase):
         mock_get_current_site.return_value = site
         course = _create_course_run(self_paced=True, start_day_offset=-5)  # course already started
         enrollment = CourseEnrollmentFactory(course_id=course.id, mode=CourseMode.AUDIT)
-        assert _strip_secs(enrollment.schedule.start) == _strip_secs(enrollment.created)
+        assert _strip_secs(enrollment.schedule.start_date) == _strip_secs(enrollment.created)
 
 
 @ddt.ddt

--- a/openedx/features/course_duration_limits/access.py
+++ b/openedx/features/course_duration_limits/access.py
@@ -109,7 +109,7 @@ def get_user_course_expiration_date(user, course):
         # Content availability date is equivalent to max(enrollment date, course start date)
         # for most people. Using the schedule date will provide flexibility to deal with
         # more complex business rules in the future.
-        content_availability_date = enrollment.schedule.start
+        content_availability_date = enrollment.schedule.start_date
         # We have anecdotally observed a case where the schedule.start was
         # equal to the course start, but should have been equal to the enrollment start
         # https://openedx.atlassian.net/browse/PROD-58

--- a/openedx/features/course_duration_limits/access.py
+++ b/openedx/features/course_duration_limits/access.py
@@ -110,7 +110,7 @@ def get_user_course_expiration_date(user, course):
         # for most people. Using the schedule date will provide flexibility to deal with
         # more complex business rules in the future.
         content_availability_date = enrollment.schedule.start_date
-        # We have anecdotally observed a case where the schedule.start was
+        # We have anecdotally observed a case where the schedule.start_date was
         # equal to the course start, but should have been equal to the enrollment start
         # https://openedx.atlassian.net/browse/PROD-58
         # This section is meant to address that case

--- a/openedx/features/course_experience/tests/views/test_course_home.py
+++ b/openedx/features/course_experience/tests/views/test_course_home.py
@@ -465,7 +465,7 @@ class TestCourseHomePageAccess(CourseHomePageTestCase):
 
         user = UserFactory.create(password=self.TEST_PASSWORD)
         ScheduleFactory(
-            start=THREE_YEARS_AGO,
+            start_date=THREE_YEARS_AGO,
             enrollment__mode=CourseMode.VERIFIED,
             enrollment__course_id=course.id,
             enrollment__user=user
@@ -499,7 +499,7 @@ class TestCourseHomePageAccess(CourseHomePageTestCase):
 
         user = role_factory.create(password=self.TEST_PASSWORD, course_key=course.id)
         ScheduleFactory(
-            start=THREE_YEARS_AGO,
+            start_date=THREE_YEARS_AGO,
             enrollment__mode=CourseMode.AUDIT,
             enrollment__course_id=course.id,
             enrollment__user=user
@@ -555,7 +555,7 @@ class TestCourseHomePageAccess(CourseHomePageTestCase):
 
         user = role_factory.create(password=self.TEST_PASSWORD)
         ScheduleFactory(
-            start=THREE_YEARS_AGO,
+            start_date=THREE_YEARS_AGO,
             enrollment__mode=CourseMode.AUDIT,
             enrollment__course_id=course.id,
             enrollment__user=user
@@ -587,7 +587,7 @@ class TestCourseHomePageAccess(CourseHomePageTestCase):
         audit_user = UserFactory(password=self.TEST_PASSWORD)
         self.client.login(username=audit_user.username, password=self.TEST_PASSWORD)
         audit_enrollment = CourseEnrollment.enroll(audit_user, course.id, mode=CourseMode.AUDIT)
-        ScheduleFactory(start=THREE_YEARS_AGO + timedelta(days=1), enrollment=audit_enrollment)
+        ScheduleFactory(start_date=THREE_YEARS_AGO + timedelta(days=1), enrollment=audit_enrollment)
 
         response = self.client.get(url)
 
@@ -657,7 +657,7 @@ class TestCourseHomePageAccess(CourseHomePageTestCase):
         audit_user = UserFactory(password=self.TEST_PASSWORD)
         self.client.login(username=audit_user.username, password=self.TEST_PASSWORD)
         audit_enrollment = CourseEnrollment.enroll(audit_user, course.id, mode=CourseMode.AUDIT)
-        ScheduleFactory(start=THREE_YEARS_AGO, enrollment=audit_enrollment)
+        ScheduleFactory(start_date=THREE_YEARS_AGO, enrollment=audit_enrollment)
         FBEEnrollmentExclusion.objects.create(
             enrollment=audit_enrollment
         )


### PR DESCRIPTION
This PR is part of column rename in Schedules app. DE-1825
It removes reads from old field `start` in schedules. 
