### PR TITLE
Revert the proctoring email template change

### DIFF
--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -113,7 +113,7 @@ edx-oauth2-provider==1.3.1
 edx-opaque-keys[django]==2.0.1
 edx-organizations==2.2.0
 edx-proctoring-proctortrack==1.0.5
-edx-proctoring==2.2.5
+edx-proctoring==2.2.6
 edx-rbac==1.0.5           # via edx-enterprise
 edx-rest-api-client==3.0.2
 edx-search==1.2.2

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -125,7 +125,7 @@ edx-oauth2-provider==1.3.1
 edx-opaque-keys[django]==2.0.1
 edx-organizations==2.2.0
 edx-proctoring-proctortrack==1.0.5
-edx-proctoring==2.2.5
+edx-proctoring==2.2.6
 edx-rbac==1.0.5
 edx-rest-api-client==3.0.2
 edx-search==1.2.2

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -121,7 +121,7 @@ edx-oauth2-provider==1.3.1
 edx-opaque-keys[django]==2.0.1
 edx-organizations==2.2.0
 edx-proctoring-proctortrack==1.0.5
-edx-proctoring==2.2.5
+edx-proctoring==2.2.6
 edx-rbac==1.0.5
 edx-rest-api-client==3.0.2
 edx-search==1.2.2


### PR DESCRIPTION
### Please consider the following when opening a pull request:
https://openedx.atlassian.net/browse/PROD-1045
Revert the email template change back in edx-proctoring v2.2.1. That change updated email sent to users with RPNowV4 proctoring solution as well. That is undesired.
Revert for now so we can implement a Proctoring service specific set of email templates.

@edx/masters-devs Please help review