### PR TITLE
ENT-2269: Added ability to logout from IDP when logout flow is triggered from learner portal

### DIFF
--- a/common/djangoapps/third_party_auth/models.py
+++ b/common/djangoapps/third_party_auth/models.py
@@ -673,6 +673,13 @@ class SAMLProviderConfig(ProviderConfig):
         """ Get social auth uid from remote id by prepending idp_slug to the remote id """
         return '{}:{}'.format(self.slug, remote_id)
 
+    def get_setting(self, name):
+        """ Get the value of a setting, or raise KeyError """
+        if self.other_settings:
+            other_settings = json.loads(self.other_settings)
+            return other_settings[name]
+        raise KeyError
+
     def get_config(self):
         """
         Return a SAMLIdentityProvider instance for use by SAMLAuthBackend.

--- a/common/djangoapps/third_party_auth/pipeline.py
+++ b/common/djangoapps/third_party_auth/pipeline.py
@@ -83,6 +83,7 @@ from social_core.pipeline import partial
 from social_core.pipeline.social_auth import associate_by_email
 from social_core.utils import module_member, slugify
 
+import third_party_auth
 from edxmako.shortcuts import render_to_string
 from lms.djangoapps.verify_student.models import SSOVerification
 from lms.djangoapps.verify_student.utils import earliest_allowed_verification_date
@@ -218,6 +219,21 @@ def get(request):
     if partial_object:
         pipeline_data = {'kwargs': partial_object.kwargs, 'backend': partial_object.backend}
     return pipeline_data
+
+
+def get_idp_logout_url_from_running_pipeline(request):
+    """
+    Returns: IdP's logout url associated with running pipeline
+    """
+    if third_party_auth.is_enabled():
+        running_pipeline = get(request)
+        if running_pipeline:
+            tpa_provider = provider.Registry.get_from_pipeline(running_pipeline)
+            if tpa_provider:
+                try:
+                    return tpa_provider.get_setting('logout_url')
+                except KeyError:
+                    logger.info(u'[THIRD_PARTY_AUTH] idP [%s] logout_url setting not defined', tpa_provider.name)
 
 
 def get_real_social_auth_object(request):

--- a/common/djangoapps/third_party_auth/tests/test_pipeline.py
+++ b/common/djangoapps/third_party_auth/tests/test_pipeline.py
@@ -1,13 +1,18 @@
 """Unit tests for third_party_auth/pipeline.py."""
 
 
+import json
+import ddt
+import mock
 import unittest
 
 from third_party_auth import pipeline
 from third_party_auth.tests import testutil
+from third_party_auth.tests.testutil import simulate_running_pipeline
 
 
 @unittest.skipUnless(testutil.AUTH_FEATURE_ENABLED, testutil.AUTH_FEATURES_KEY + ' not enabled')
+@ddt.ddt
 class ProviderUserStateTestCase(testutil.TestCase):
     """Tests ProviderUserState behavior."""
 
@@ -15,3 +20,32 @@ class ProviderUserStateTestCase(testutil.TestCase):
         google_provider = self.configure_google_provider(enabled=True)
         state = pipeline.ProviderUserState(google_provider, object(), None)
         self.assertEqual(google_provider.provider_id + '_unlink_form', state.get_unlink_form_name())
+
+    @ddt.data(
+        ('saml', 'tpa-saml'),
+        ('oauth', 'google-oauth2'),
+    )
+    @ddt.unpack
+    def test_get_idp_logout_url_from_running_pipeline(self, idp_type, backend_name):
+        """
+        Test idp logout url setting for running pipeline
+        """
+        self.enable_saml()
+        idp_slug = "test"
+        idp_config = {"logout_url": "http://example.com/logout"}
+        getattr(self, 'configure_{idp_type}_provider'.format(idp_type=idp_type))(
+            enabled=True,
+            name="Test Provider",
+            slug=idp_slug,
+            backend_name=backend_name,
+            other_settings=json.dumps(idp_config)
+        )
+        request = mock.MagicMock()
+        kwargs = {
+            "response": {
+                "idp_name": idp_slug
+            }
+        }
+        with simulate_running_pipeline("third_party_auth.pipeline", backend_name, **kwargs):
+            logout_url = pipeline.get_idp_logout_url_from_running_pipeline(request)
+            self.assertEqual(idp_config['logout_url'], logout_url)

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -3843,7 +3843,7 @@ BLOCKSTORE_API_URL = 'http://localhost:18250/api/v1/'
 XBLOCK_RUNTIME_V2_EPHEMERAL_DATA_CACHE = 'default'
 
 ########################## LEARNER PORTAL ##############################
-LEARNER_PORTAL_URL_ROOT = 'https://learner-portal-localhost:18000'
+LEARNER_PORTAL_URL_ROOT = 'http://localhost:8734'
 
 ######################### MICROSITE ###############################
 MICROSITE_ROOT_DIR = '/edx/app/edxapp/edx-microsite'

--- a/lms/templates/logout.html
+++ b/lms/templates/logout.html
@@ -5,30 +5,45 @@
 {% block title %}{% trans "Signed Out" as tmsg %}{{ tmsg | force_escape }} | {{ block.super }}{% endblock %}
 
 {% block body %}
-    {% if enterprise_target %}
-        {% comment %}
-            For enterprise SSO flow we intentionally drop learner's session.
-            We are showing this signin message instead of logout message
-            to avoid any confusion for learner in that case.
-        {% endcomment %}
-        <h1>{% trans "We are signing you in." as tmsg %}{{ tmsg | force_escape }}</h1>
-
-        <p style="text-align: center; margin-bottom: 20px;">
-            {% filter force_escape %}
-            {% blocktrans %}
-              This may take a minute. If you are not redirected, go to the home page.
-            {% endblocktrans %}
-            {% endfilter %}
-        </p>
-    {% else %}
+    {% if show_tpa_logout_link %}
         <h1>{% trans "You have signed out." as tmsg %}{{ tmsg | force_escape }}</h1>
 
         <p style="text-align: center; margin-bottom: 20px;">
-            {% blocktrans trimmed asvar signout_msg1 %}
-              If you are not redirected within 5 seconds, {start_anchor}click here to go to the home page{end_anchor}.
+            {% blocktrans trimmed asvar sso_signout_msg %}
+              {start_anchor}Click here{end_anchor} to delete your single signed on (SSO) session.
             {% endblocktrans %}
-            {% interpolate_html signout_msg1 start_anchor='<a href="'|add:target|add:'">'|safe end_anchor='</a>'|safe %}
+            {% interpolate_html sso_signout_msg start_anchor='<a href="'|add:tpa_logout_url|add:'">'|safe end_anchor='</a>'|safe %}
         </p>
+
+    {% else %}
+        {% if enterprise_target %}
+            {% comment %}
+                For enterprise SSO flow we intentionally drop learner's session.
+                We are showing this signin message instead of logout message
+                to avoid any confusion for learner in that case.
+            {% endcomment %}
+            <h1>{% trans "We are signing you in." as tmsg %}{{ tmsg | force_escape }}</h1>
+
+            <p style="text-align: center; margin-bottom: 20px;">
+                {% filter force_escape %}
+                {% blocktrans %}
+                  This may take a minute. If you are not redirected, go to the home page.
+                {% endblocktrans %}
+                {% endfilter %}
+            </p>
+        {% else %}
+            <h1>{% trans "You have signed out." as tmsg %}{{ tmsg | force_escape }}</h1>
+
+            <p style="text-align: center; margin-bottom: 20px;">
+                {% blocktrans trimmed asvar signout_msg1 %}
+                  If you are not redirected within 5 seconds, {start_anchor}click here to go to the home page{end_anchor}.
+                {% endblocktrans %}
+                {% interpolate_html signout_msg1 start_anchor='<a href="'|add:target|add:'">'|safe end_anchor='</a>'|safe %}
+            </p>
+        {% endif %}
+
+        <script type="text/javascript" src="{% static 'js/jquery.allLoaded.js' %}"></script>
+        <script type="text/javascript" src="{% static 'js/logout.js' %}"></script>
     {% endif %}
 
     <div id="iframeContainer" style="visibility: hidden" data-redirect-url="{{ target }}">
@@ -37,6 +52,4 @@
         {% endfor %}
     </div>
 
-    <script type="text/javascript" src="{% static 'js/jquery.allLoaded.js' %}"></script>
-    <script type="text/javascript" src="{% static 'js/logout.js' %}"></script>
 {% endblock body %}


### PR DESCRIPTION
This PR has changes to logout from IDP when logout flow is triggered from learner portal and IDP of current SSO session has `logout_url` set in other settings(OAuth) or advanced settings(SAML).

### Please consider the following when opening a pull request:

- Link to the relevant JIRA ticket(s) and tag any relevant team(s).
- Squash your changes down into one or more discrete commits.
  In each commit, include description that could help a developer
  several months from now.
- If running `make upgrade`, run _as close to the time of merging as possible_
  to avoid accidentally downgrading someone else's package.
  Put the output of `make upgrade` in its own separate commit,
  decoupled from other code changes.
- Aim for comprehensive test coverage, but remember that
  automated testing isn't a substitute for manual verification.
- Carefully consider naming, code organization, dependencies when adding new code.
  Code that is amenable to refactoring and improvement benefits all platform developers,
  especially given the size and scope of edx-platform.
  Consult existing Architectural Decision Records (ADRs),
  including those concerning the app(s) you are changing and
  [those concerning edx-platform as a whole](https://github.com/edx/edx-platform/tree/master/docs/decisions).
