### PR TITLE
SE-2092 Send user_logged_in when Mobile API user detail requested

### DIFF
--- a/lms/djangoapps/mobile_api/testutils.py
+++ b/lms/djangoapps/mobile_api/testutils.py
@@ -81,13 +81,13 @@ class MobileAPITestCase(ModuleStoreTestCase, APITestCase):
         self.login()
         self.enroll(course_id)
 
-    def api_response(self, reverse_args=None, expected_response_code=200, data=None, **kwargs):
+    def api_response(self, reverse_args=None, expected_response_code=200, data=None, follow=False, **kwargs):
         """
         Helper method for calling endpoint, verifying and returning response.
         If expected_response_code is None, doesn't verify the response' status_code.
         """
         url = self.reverse_url(reverse_args, **kwargs)
-        response = self.url_method(url, data=data, **kwargs)
+        response = self.url_method(url, data=data, follow=follow)
         if expected_response_code is not None:
             self.assertEqual(response.status_code, expected_response_code)
         return response
@@ -103,9 +103,9 @@ class MobileAPITestCase(ModuleStoreTestCase, APITestCase):
             reverse_args.update({'api_version': kwargs.get('api_version', self.api_version)})
         return reverse(self.REVERSE_INFO['name'], kwargs=reverse_args)
 
-    def url_method(self, url, data=None, **kwargs):  # pylint: disable=unused-argument
+    def url_method(self, url, data=None, **kwargs):
         """Base implementation that returns response from the GET method of the URL."""
-        return self.client.get(url, data=data)
+        return self.client.get(url, data=data, **kwargs)
 
 
 class MobileAuthTestMixin(object):

--- a/lms/djangoapps/mobile_api/users/tests.py
+++ b/lms/djangoapps/mobile_api/users/tests.py
@@ -61,6 +61,21 @@ class TestUserDetailApi(MobileAPITestCase, MobileAuthUserTestMixin):
         self.assertEqual(response.data['username'], self.user.username)
         self.assertEqual(response.data['email'], self.user.email)
 
+    @ddt.data(API_V05, API_V1)
+    def test_last_loggedin_updated(self, api_version):
+        """Verify that a user's last logged in value updates after hitting the my_user_info endpoint"""
+        self.login()
+
+        self.user.refresh_from_db()
+        last_login_before = self.user.last_login
+
+        # just hit the api endpoint; we don't care about the response here (tested previously)
+        self.api_response(api_version=api_version)
+
+        self.user.refresh_from_db()
+        last_login_after = self.user.last_login
+        assert last_login_after > last_login_before
+
 
 @ddt.ddt
 class TestUserInfoApi(MobileAPITestCase, MobileAuthTestMixin):
@@ -85,8 +100,8 @@ class TestUserInfoApi(MobileAPITestCase, MobileAuthTestMixin):
         self.user.refresh_from_db()
         last_login_before = self.user.last_login
 
-        # just hit the api endpoint; we don't care about the response here (tested previously)
-        self.api_response(expected_response_code=302, api_version=api_version)
+        # just follow the api endpoint; we don't care about the response here (tested previously)
+        self.api_response(api_version=api_version, follow=True)
 
         self.user.refresh_from_db()
         last_login_after = self.user.last_login

--- a/lms/djangoapps/mobile_api/users/views.py
+++ b/lms/djangoapps/mobile_api/users/views.py
@@ -69,6 +69,12 @@ class UserDetail(generics.RetrieveAPIView):
     serializer_class = UserSerializer
     lookup_field = 'username'
 
+    def get(self, request, *args, **kwargs):
+        # update user's last logged in from here because
+        # updating it from the oauth2 related code is too complex
+        user_logged_in.send(sender=User, user=request.user, request=request)
+        return super(UserDetail, self).get(request, *args, **kwargs)
+
     def get_serializer_context(self):
         context = super(UserDetail, self).get_serializer_context()
         context['api_version'] = self.kwargs.get('api_version')
@@ -337,7 +343,4 @@ def my_user_info(request, api_version):
     """
     Redirect to the currently-logged-in user's info page
     """
-    # update user's last logged in from here because
-    # updating it from the oauth2 related code is too complex
-    user_logged_in.send(sender=User, user=request.user, request=request)
     return redirect("user-detail", api_version=api_version, username=request.user.username)


### PR DESCRIPTION
Ensures the user's last_logged_in date is updated when users login to the iOS app for the first time, and when they re-launch the app without explicitly logging in.

The iOS mobile app hits the `/api/mobile/v1/my_user_info` endpoint when authenticating with the username+password, but uses the `/api/mobile/v1/users/<username>` endpoint when the application is re-launched with an authentication token. This change ensures the last logged-in date updates in both these cases.

**JIRA tickets**:  [OSPR-4074](https://openedx.atlassian.net/browse/OSPR-4074)

**Discussions**: bugfix for https://github.com/edx/edx-platform/pull/21610

**Sandbox URL**: TBD - sandbox is being provisioned.

**Merge deadline**: None

**Testing instructions**:

1. Login to the LMS admin as a superuser and view the last logged in time for a normal user.
1. Login to the iOS mobile app as the above normal user.
1. Refresh the admin page and verify that the last logged in time has updated.
1. Close the iOS mobile app, and re-launch.
1. Refresh the admin page and verify that the last logged in time has updated (again).

**Reviewers**
- [ ] @swalladge 
- [ ] edX reviewer[s] TBD
