### PR TITLE
Include bookmark info in sequence metadata.

### DIFF
--- a/common/lib/xmodule/xmodule/seq_module.py
+++ b/common/lib/xmodule/xmodule/seq_module.py
@@ -21,6 +21,7 @@ from six import text_type
 from web_fragments.fragment import Fragment
 from xblock.completable import XBlockCompletionMode
 from xblock.core import XBlock
+from xblock.exceptions import NoSuchServiceError
 from xblock.fields import Boolean, Integer, List, Scope, String
 
 from .exceptions import NotFoundError
@@ -503,9 +504,9 @@ class SequenceModule(SequenceFields, ProctoringFields, XModule):
         render_items = not context.get('exclude_units', False)
         is_user_authenticated = self.is_user_authenticated(context)
         completion_service = self.runtime.service(self, 'completion')
-        if render_items:
+        try:
             bookmarks_service = self.runtime.service(self, 'bookmarks')
-        else:
+        except NoSuchServiceError:
             bookmarks_service = None
         context['username'] = self.runtime.service(self, 'user').get_current_user().opt_attrs.get(
             'edx-platform.username')
@@ -529,7 +530,7 @@ class SequenceModule(SequenceFields, ProctoringFields, XModule):
             show_bookmark_button = False
             is_bookmarked = False
 
-            if is_user_authenticated and render_items:
+            if is_user_authenticated and bookmarks_service:
                 show_bookmark_button = True
                 is_bookmarked = bookmarks_service.is_bookmarked(usage_key=usage_id)
 

--- a/common/lib/xmodule/xmodule/tests/test_sequence.py
+++ b/common/lib/xmodule/xmodule/tests/test_sequence.py
@@ -348,6 +348,9 @@ class SequenceBlockTestCase(XModuleXmlImportTest):
         Test that the sequence metadata is returned from the
         metadata ajax handler.
         """
+        # rather than dealing with json serialization of the Mock object,
+        # let's just disable the bookmarks service
+        self.sequence_3_1.xmodule_runtime._services['bookmarks'] = None
         metadata = json.loads(self.sequence_3_1.handle_ajax('metadata', {}))
         self.assertEqual(len(metadata['items']), 3)
         self.assertEqual(metadata['tag'], 'sequential')


### PR DESCRIPTION
This will return correct bookmark status for units in the sequence, in the sequence API for courseware MFE. 

