### PR TITLE
Hide display titles for vertical blocks embedded in microfrontends

### DIFF
--- a/common/lib/xmodule/xmodule/vertical_block.py
+++ b/common/lib/xmodule/xmodule/vertical_block.py
@@ -98,6 +98,7 @@ class VerticalBlock(SequenceFields, XModuleFields, StudioEditableBlock, XmlParse
         if view == STUDENT_VIEW:
             fragment_context.update({
                 'show_bookmark_button': child_context.get('show_bookmark_button', not is_child_of_vertical),
+                'is_microfrontend_embed': child_context.get('is_microfrontend_embed', False),
                 'bookmarked': child_context['bookmarked'],
                 'bookmark_id': u"{},{}".format(
                     child_context['username'], six.text_type(self.location)),  # pylint: disable=no-member

--- a/common/lib/xmodule/xmodule/vertical_block.py
+++ b/common/lib/xmodule/xmodule/vertical_block.py
@@ -98,7 +98,7 @@ class VerticalBlock(SequenceFields, XModuleFields, StudioEditableBlock, XmlParse
         if view == STUDENT_VIEW:
             fragment_context.update({
                 'show_bookmark_button': child_context.get('show_bookmark_button', not is_child_of_vertical),
-                'is_microfrontend_embed': child_context.get('is_microfrontend_embed', False),
+                'show_title': child_context.get('show_title', True),
                 'bookmarked': child_context['bookmarked'],
                 'bookmark_id': u"{},{}".format(
                     child_context['username'], six.text_type(self.location)),  # pylint: disable=no-member

--- a/lms/djangoapps/courseware/views/views.py
+++ b/lms/djangoapps/courseware/views/views.py
@@ -1586,8 +1586,8 @@ def render_xblock(request, usage_key_string, check_if_enrolled=True):
         )
 
         student_view_context = request.GET.dict()
-        student_view_context['show_bookmark_button'] = request.GET.get('show_bookmark_button', '0') == '1' # default false
-        student_view_context['show_title'] = request.GET.get('show_title', '1') == '1' # default true
+        student_view_context['show_bookmark_button'] = request.GET.get('show_bookmark_button', '0') == '1'  # default false
+        student_view_context['show_title'] = request.GET.get('show_title', '1') == '1'  # default true
 
         enable_completion_on_view_service = False
         completion_service = block.runtime.service(block, 'completion')

--- a/lms/djangoapps/courseware/views/views.py
+++ b/lms/djangoapps/courseware/views/views.py
@@ -1588,6 +1588,13 @@ def render_xblock(request, usage_key_string, check_if_enrolled=True):
         student_view_context = request.GET.dict()
         student_view_context['show_bookmark_button'] = False
 
+        # xBlocks iframed into the learning microfrontend application will
+        # not render some parts of an xblock template (notably unit_title
+        # in vert_module.html). The variable name is_microfrontend_embed
+        # is used instead of adding specific flags like show_unit_title to
+        # help keep track of why certain features may be rendered or not.
+        student_view_context['is_microfrontend_embed'] = bool(request.GET.get('is_microfrontend_embed', False))
+
         enable_completion_on_view_service = False
         completion_service = block.runtime.service(block, 'completion')
         if completion_service and completion_service.completion_tracking_enabled():

--- a/lms/djangoapps/courseware/views/views.py
+++ b/lms/djangoapps/courseware/views/views.py
@@ -1586,14 +1586,8 @@ def render_xblock(request, usage_key_string, check_if_enrolled=True):
         )
 
         student_view_context = request.GET.dict()
-        student_view_context['show_bookmark_button'] = False
-
-        # xBlocks iframed into the learning microfrontend application will
-        # not render some parts of an xblock template (notably unit_title
-        # in vert_module.html). The variable name is_microfrontend_embed
-        # is used instead of adding specific flags like show_unit_title to
-        # help keep track of why certain features may be rendered or not.
-        student_view_context['is_microfrontend_embed'] = bool(request.GET.get('is_microfrontend_embed', False))
+        student_view_context['show_bookmark_button'] = request.GET.get('show_bookmark_button', '0') == '1' # default false
+        student_view_context['show_title'] = request.GET.get('show_title', '1') == '1' # default true
 
         enable_completion_on_view_service = False
         completion_service = block.runtime.service(block, 'completion')

--- a/lms/djangoapps/courseware/views/views.py
+++ b/lms/djangoapps/courseware/views/views.py
@@ -1586,8 +1586,8 @@ def render_xblock(request, usage_key_string, check_if_enrolled=True):
         )
 
         student_view_context = request.GET.dict()
-        student_view_context['show_bookmark_button'] = request.GET.get('show_bookmark_button', '0') == '1'  # default false
-        student_view_context['show_title'] = request.GET.get('show_title', '1') == '1'  # default true
+        student_view_context['show_bookmark_button'] = request.GET.get('show_bookmark_button', '0') == '1'
+        student_view_context['show_title'] = request.GET.get('show_title', '1') == '1'
 
         enable_completion_on_view_service = False
         completion_service = block.runtime.service(block, 'completion')

--- a/lms/templates/vert_module.html
+++ b/lms/templates/vert_module.html
@@ -1,11 +1,11 @@
 <%page expression_filter="h"/>
 <%! from openedx.core.djangolib.markup import HTML %>
-%if unit_title:
-  <h2 class="hd hd-2 unit-title">${unit_title}</h2>
-% endif
 
-% if show_bookmark_button:
-    <%include file='bookmark_button.html' args="bookmark_id=bookmark_id, is_bookmarked=bookmarked"/>
+%if unit_title and not is_microfrontend_embed:
+  <h2 class="hd hd-2 unit-title">${unit_title}</h2>
+  % if show_bookmark_button:
+  <%include file='bookmark_button.html' args="bookmark_id=bookmark_id, is_bookmarked=bookmarked"/>
+  % endif
 % endif
 
 <div class="vert-mod">

--- a/lms/templates/vert_module.html
+++ b/lms/templates/vert_module.html
@@ -1,11 +1,12 @@
 <%page expression_filter="h"/>
 <%! from openedx.core.djangolib.markup import HTML %>
 
-%if unit_title and not is_microfrontend_embed:
+%if unit_title and show_title:
   <h2 class="hd hd-2 unit-title">${unit_title}</h2>
-  % if show_bookmark_button:
+% endif
+
+% if show_bookmark_button:
   <%include file='bookmark_button.html' args="bookmark_id=bookmark_id, is_bookmarked=bookmarked"/>
-  % endif
 % endif
 
 <div class="vert-mod">


### PR DESCRIPTION
Relates to TNL-7048. Since bookmarking is handled in the learning microfrontend, it needs to also manage the display of a unit title. The new boolean get parameter is_microfrontend_embed is used in the vertical block template to hide the unit title.

This feature is leveraged here https://github.com/edx/frontend-app-learning/pull/11

![image](https://user-images.githubusercontent.com/1615421/73682363-3fecb800-468e-11ea-950b-bdf20fcc1454.png)
