### PR TITLE
Add xblock.v1 and xmodule.v1 entrypoints for NonStaffErrorDescriptor

### DIFF
--- a/common/lib/xmodule/setup.py
+++ b/common/lib/xmodule/setup.py
@@ -12,6 +12,7 @@ XMODULES = [
     "image = xmodule.backcompat_module:TranslateCustomTagDescriptor",
     "library_content = xmodule.library_content_module:LibraryContentDescriptor",
     "error = xmodule.error_module:ErrorDescriptor",
+    "nonstaff_error = xmodule.error_module:NonStaffErrorDescriptor",
     "poll_question = xmodule.poll_module:PollDescriptor",
     "problemset = xmodule.seq_module:SequenceDescriptor",
     "randomize = xmodule.randomize_module:RandomizeDescriptor",


### PR DESCRIPTION
If an error occurs while rendering an xmodule, the LMS chokes with the
following error if accessed by a non admin user.

In the admin user case the existing line that registers ErrorDescriptor
ensures that everything works. But for the non admin case we need this
additional directive.
```
Traceback (most recent call last):
  File "/openedx/edx-platform/lms/djangoapps/courseware/views/index.py", line 153, in get
    return self.render(request)
  File "/openedx/edx-platform/lms/djangoapps/courseware/views/index.py", line 217, in render
    return render_to_response('courseware/courseware.html', self._create_courseware_context(request))
  File "/openedx/edx-platform/lms/djangoapps/courseware/views/index.py", line 468, in _create_courseware_context
    courseware_context['fragment'] = self.section.render(self.view, section_context)
  File "/usr/local/lib/python2.7/site-packages/xblock/core.py", line 202, in render
    return self.runtime.render(self, view, context)
  File "/openedx/edx-platform/common/lib/xmodule/xmodule/x_module.py", line 1914, in render
    return self.__getattr__('render')(block, view_name, context)
  File "/openedx/edx-platform/common/lib/xmodule/xmodule/x_module.py", line 1335, in render
    return super(MetricsMixin, self).render(block, view_name, context=context)
  File "/usr/local/lib/python2.7/site-packages/xblock/runtime.py", line 831, in render
    frag = view_fn(context)
  File "/openedx/edx-platform/common/lib/xmodule/xmodule/seq_module.py", line 262, in student_view
    return self._student_or_public_view(context, prereq_met, prereq_meta_info, banner_text)
  File "/openedx/edx-platform/common/lib/xmodule/xmodule/seq_module.py", line 343, in _student_or_public_view
    items = self._render_student_view_for_items(context, display_items, fragment, view) if prereq_met else []
  File "/openedx/edx-platform/common/lib/xmodule/xmodule/seq_module.py", line 485, in _render_student_view_for_items
    rendered_item = item.render(view, context)
  File "/usr/local/lib/python2.7/site-packages/xblock/core.py", line 202, in render
    return self.runtime.render(self, view, context)
  File "/openedx/edx-platform/common/lib/xmodule/xmodule/x_module.py", line 1914, in render
    return self.__getattr__('render')(block, view_name, context)
  File "/openedx/edx-platform/common/lib/xmodule/xmodule/x_module.py", line 1335, in render
    return super(MetricsMixin, self).render(block, view_name, context=context)
  File "/usr/local/lib/python2.7/site-packages/xblock/runtime.py", line 831, in render
    frag = view_fn(context)
  File "/openedx/edx-platform/common/lib/xmodule/xmodule/vertical_block.py", line 118, in student_view
    return self._student_or_public_view(context, STUDENT_VIEW)
  File "/openedx/edx-platform/common/lib/xmodule/xmodule/vertical_block.py", line 85, in _student_or_public_view
    rendered_child = child.render(view, child_block_context)
  File "/usr/local/lib/python2.7/site-packages/xblock/core.py", line 202, in render
    return self.runtime.render(self, view, context)
  File "/openedx/edx-platform/common/lib/xmodule/xmodule/x_module.py", line 1914, in render
    return self.__getattr__('render')(block, view_name, context)
  File "/openedx/edx-platform/common/lib/xmodule/xmodule/x_module.py", line 1335, in render
    return super(MetricsMixin, self).render(block, view_name, context=context)
  File "/usr/local/lib/python2.7/site-packages/xblock/runtime.py", line 831, in render
    frag = view_fn(context)
  File "/openedx/edx-platform/common/lib/xmodule/xmodule/library_content_module.py", line 314, in student_view
    rendered_child = displayable.render(STUDENT_VIEW, child_context)
  File "/usr/local/lib/python2.7/site-packages/xblock/core.py", line 202, in render
    return self.runtime.render(self, view, context)
  File "/openedx/edx-platform/common/lib/xmodule/xmodule/x_module.py", line 1914, in render
    return self.__getattr__('render')(block, view_name, context)
  File "/openedx/edx-platform/common/lib/xmodule/xmodule/x_module.py", line 1335, in render
    return super(MetricsMixin, self).render(block, view_name, context=context)
  File "/usr/local/lib/python2.7/site-packages/xblock/runtime.py", line 835, in render
    updated_frag = self.wrap_xblock(block, view_name, frag, context)
  File "/openedx/edx-platform/common/lib/xmodule/xmodule/x_module.py", line 1287, in wrap_xblock
    frag = wrapper(block, view, frag, context)
  File "/openedx/edx-platform/openedx/core/lib/xblock_utils/__init__.py", line 155, in wrap_xblock
    add_webpack_to_fragment(frag, class_name)
  File "/openedx/edx-platform/common/lib/xmodule/xmodule/util/xmodule_django.py", line 28, in add_webpack_to_fragment
    for chunk in webpack_loader.utils.get_files(bundle_name, extension, config):
  File "/usr/local/lib/python2.7/site-packages/webpack_loader/utils.py", line 31, in get_files
    return list(_get_bundle(bundle_name, extension, config))
  File "/usr/local/lib/python2.7/site-packages/webpack_loader/utils.py", line 23, in _get_bundle
    bundle = get_loader(config).get_bundle(bundle_name)
  File "/usr/local/lib/python2.7/site-packages/webpack_loader/loader.py", line 83, in get_bundle
    raise WebpackBundleLookupError('Cannot resolve bundle {0}.'.format(bundle_name))
WebpackBundleLookupError: Cannot resolve bundle NonStaffErrorModule.
```