### PR TITLE
Added new auth class

### DIFF
--- a/common/djangoapps/course_modes/api/v1/views.py
+++ b/common/djangoapps/course_modes/api/v1/views.py
@@ -16,7 +16,7 @@ from rest_framework.response import Response
 
 from course_modes.api.serializers import CourseModeSerializer
 from course_modes.models import CourseMode
-from openedx.core.lib.api.authentication import OAuth2AuthenticationAllowInactiveUser
+from openedx.core.lib.api.authentication import OAuth2AuthenticationAllowInactiveUserDeprecated
 from openedx.core.lib.api.parsers import MergePatchParser
 
 log = logging.getLogger(__name__)
@@ -29,7 +29,7 @@ class CourseModesMixin(object):
     """
     authentication_classes = (
         JwtAuthentication,
-        OAuth2AuthenticationAllowInactiveUser,
+        OAuth2AuthenticationAllowInactiveUserDeprecated,
         SessionAuthenticationAllowInactiveUser,
     )
     # When not considering JWT conditions, this permission class grants access

--- a/common/djangoapps/third_party_auth/api/views.py
+++ b/common/djangoapps/third_party_auth/api/views.py
@@ -19,7 +19,7 @@ from rest_framework.views import APIView
 from social_django.models import UserSocialAuth
 
 from openedx.core.lib.api.authentication import (
-    OAuth2AuthenticationDeprecated, 
+    OAuth2AuthenticationDeprecated,
     OAuth2AuthenticationAllowInactiveUserDeprecated
 )
 from openedx.core.lib.api.permissions import ApiKeyHeaderPermission

--- a/common/djangoapps/third_party_auth/api/views.py
+++ b/common/djangoapps/third_party_auth/api/views.py
@@ -18,7 +18,10 @@ from rest_framework.response import Response
 from rest_framework.views import APIView
 from social_django.models import UserSocialAuth
 
-from openedx.core.lib.api.authentication import OAuth2AuthenticationDeprecated, OAuth2AuthenticationAllowInactiveUserDeprecated
+from openedx.core.lib.api.authentication import (
+    OAuth2AuthenticationDeprecated, 
+    OAuth2AuthenticationAllowInactiveUserDeprecated
+)
 from openedx.core.lib.api.permissions import ApiKeyHeaderPermission
 from third_party_auth import pipeline
 from third_party_auth.api import serializers

--- a/common/djangoapps/third_party_auth/api/views.py
+++ b/common/djangoapps/third_party_auth/api/views.py
@@ -18,7 +18,7 @@ from rest_framework.response import Response
 from rest_framework.views import APIView
 from social_django.models import UserSocialAuth
 
-from openedx.core.lib.api.authentication import OAuth2AuthenticationDeprecated, OAuth2AuthenticationAllowInactiveUser
+from openedx.core.lib.api.authentication import OAuth2AuthenticationDeprecated, OAuth2AuthenticationAllowInactiveUserDeprecated
 from openedx.core.lib.api.permissions import ApiKeyHeaderPermission
 from third_party_auth import pipeline
 from third_party_auth.api import serializers
@@ -64,7 +64,7 @@ class BaseUserView(APIView):
     authentication_classes = (
         # Users may want to view/edit the providers used for authentication before they've
         # activated their account, so we allow inactive users.
-        OAuth2AuthenticationAllowInactiveUser,
+        OAuth2AuthenticationAllowInactiveUserDeprecated,
         SessionAuthenticationAllowInactiveUser,
     )
     throttle_classes = [ProviderSustainedThrottle, ProviderBurstThrottle]
@@ -399,7 +399,7 @@ class ThirdPartyAuthUserStatusView(APIView):
     user with respect to the third party auth providers configured in the system.
     """
     authentication_classes = (
-        JwtAuthentication, OAuth2AuthenticationAllowInactiveUser, SessionAuthenticationAllowInactiveUser
+        JwtAuthentication, OAuth2AuthenticationAllowInactiveUserDeprecated, SessionAuthenticationAllowInactiveUser
     )
     permission_classes = (permissions.IsAuthenticated,)
 

--- a/lms/djangoapps/badges/api/views.py
+++ b/lms/djangoapps/badges/api/views.py
@@ -12,7 +12,7 @@ from rest_framework.exceptions import APIException
 
 from badges.models import BadgeAssertion
 from openedx.core.djangoapps.user_api.permissions import is_field_shared_factory
-from openedx.core.lib.api.authentication import OAuth2AuthenticationAllowInactiveUser
+from openedx.core.lib.api.authentication import OAuth2AuthenticationAllowInactiveUserDeprecated
 
 from .serializers import BadgeAssertionSerializer
 
@@ -94,7 +94,7 @@ class UserBadgeAssertions(generics.ListAPIView):
     """
     serializer_class = BadgeAssertionSerializer
     authentication_classes = (
-        OAuth2AuthenticationAllowInactiveUser,
+        OAuth2AuthenticationAllowInactiveUserDeprecated,
         SessionAuthenticationAllowInactiveUser
     )
     permission_classes = (is_field_shared_factory("accomplishments_shared"),)

--- a/lms/djangoapps/ccx/api/v0/views.py
+++ b/lms/djangoapps/ccx/api/v0/views.py
@@ -353,7 +353,7 @@ class CCXListView(GenericAPIView):
     """
     authentication_classes = (
         JwtAuthentication,
-        authentication.OAuth2AuthenticationAllowInactiveUser,
+        authentication.OAuth2AuthenticationAllowInactiveUserDeprecated,
         SessionAuthenticationAllowInactiveUser,
     )
     permission_classes = (IsAuthenticated, permissions.IsMasterCourseStaffInstructor)
@@ -612,7 +612,7 @@ class CCXDetailView(GenericAPIView):
 
     authentication_classes = (
         JwtAuthentication,
-        authentication.OAuth2AuthenticationAllowInactiveUser,
+        authentication.OAuth2AuthenticationAllowInactiveUserDeprecated,
         SessionAuthenticationAllowInactiveUser,
     )
     permission_classes = (IsAuthenticated, permissions.IsCourseStaffInstructor)

--- a/lms/djangoapps/certificates/apis/v0/views.py
+++ b/lms/djangoapps/certificates/apis/v0/views.py
@@ -21,7 +21,7 @@ from lms.djangoapps.certificates.api import get_certificate_for_user, get_certif
 from openedx.core.djangoapps.certificates.api import certificates_viewable_for_course
 from openedx.core.djangoapps.content.course_overviews.models import CourseOverview
 from openedx.core.djangoapps.user_api.accounts.api import visible_fields
-from openedx.core.lib.api.authentication import OAuth2AuthenticationAllowInactiveUser
+from openedx.core.lib.api.authentication import OAuth2AuthenticationAllowInactiveUserDeprecated
 
 
 log = logging.getLogger(__name__)
@@ -85,7 +85,7 @@ class CertificatesDetailView(GenericAPIView):
 
     authentication_classes = (
         JwtAuthentication,
-        OAuth2AuthenticationAllowInactiveUser,
+        OAuth2AuthenticationAllowInactiveUserDeprecated,
         SessionAuthenticationAllowInactiveUser,
     )
 
@@ -147,7 +147,7 @@ class CertificatesListView(GenericAPIView):
     """REST API endpoints for listing certificates."""
     authentication_classes = (
         JwtAuthentication,
-        OAuth2AuthenticationAllowInactiveUser,
+        OAuth2AuthenticationAllowInactiveUserDeprecated,
         SessionAuthenticationAllowInactiveUser,
     )
 

--- a/lms/djangoapps/commerce/api/v0/views.py
+++ b/lms/djangoapps/commerce/api/v0/views.py
@@ -23,7 +23,7 @@ from openedx.core.djangoapps.embargo import api as embargo_api
 from openedx.core.djangoapps.enrollments.api import add_enrollment
 from openedx.core.djangoapps.enrollments.views import EnrollmentCrossDomainSessionAuth
 from openedx.core.djangoapps.user_api.preferences.api import update_email_opt_in
-from openedx.core.lib.api.authentication import OAuth2AuthenticationAllowInactiveUser
+from openedx.core.lib.api.authentication import OAuth2AuthenticationAllowInactiveUserDeprecated
 from student.models import CourseEnrollment
 from student.signals import SAILTHRU_AUDIT_PURCHASE
 from util.json_request import JsonResponse
@@ -40,7 +40,7 @@ class BasketsView(APIView):
 
     # LMS utilizes User.user_is_active to indicate email verification, not whether an account is active. Sigh!
     authentication_classes = (JwtAuthentication,
-                              OAuth2AuthenticationAllowInactiveUser,
+                              OAuth2AuthenticationAllowInactiveUserDeprecated,
                               EnrollmentCrossDomainSessionAuth)
     permission_classes = (IsAuthenticated,)
 

--- a/lms/djangoapps/courseware/module_render.py
+++ b/lms/djangoapps/courseware/module_render.py
@@ -68,7 +68,7 @@ from openedx.core.djangoapps.crawlers.models import CrawlersConfig
 from openedx.core.djangoapps.credit.services import CreditService
 from openedx.core.djangoapps.util.user_utils import SystemUser
 from openedx.core.djangolib.markup import HTML
-from openedx.core.lib.api.authentication import OAuth2AuthenticationAllowInactiveUser
+from openedx.core.lib.api.authentication import OAuth2AuthenticationAllowInactiveUserDeprecated
 from openedx.core.lib.api.view_utils import view_auth_classes
 from openedx.core.lib.gating.services import GatingService
 from openedx.core.lib.license import wrap_with_license
@@ -1033,7 +1033,7 @@ def handle_xblock_callback(request, course_id, usage_id, handler, suffix=None):
     # to avoid introducing backwards-incompatible changes.
     # You can see https://github.com/edx/XBlock/pull/383 for more details.
     else:
-        authentication_classes = (JwtAuthentication, OAuth2AuthenticationAllowInactiveUser)
+        authentication_classes = (JwtAuthentication, OAuth2AuthenticationAllowInactiveUserDeprecated)
         authenticators = [auth() for auth in authentication_classes]
 
         for authenticator in authenticators:

--- a/lms/djangoapps/discussion/rest_api/views.py
+++ b/lms/djangoapps/discussion/rest_api/views.py
@@ -5,6 +5,7 @@ Discussion API views
 
 import logging
 
+from django.conf import settings
 from django.contrib.auth.models import User
 from django.core.exceptions import ValidationError
 from edx_rest_framework_extensions.auth.jwt.authentication import JwtAuthentication

--- a/lms/djangoapps/discussion/rest_api/views.py
+++ b/lms/djangoapps/discussion/rest_api/views.py
@@ -55,7 +55,7 @@ from openedx.core.djangoapps.django_comment_common.utils import (
 )
 from openedx.core.djangoapps.user_api.accounts.permissions import CanReplaceUsername, CanRetireUser
 from openedx.core.djangoapps.user_api.models import UserRetirementStatus
-from openedx.core.lib.api.authentication import OAuth2AuthenticationAllowInactiveUser
+from openedx.core.lib.api.authentication import OAuth2AuthenticationAllowInactiveUserDeprecated
 from openedx.core.lib.api.parsers import MergePatchParser
 from openedx.core.lib.api.view_utils import DeveloperErrorViewMixin, view_auth_classes
 from util.json_request import JsonResponse
@@ -751,7 +751,7 @@ class CourseDiscussionSettingsAPIView(DeveloperErrorViewMixin, APIView):
     """
     authentication_classes = (
         JwtAuthentication,
-        OAuth2AuthenticationAllowInactiveUser,
+        OAuth2AuthenticationAllowInactiveUserDeprecated,
         SessionAuthenticationAllowInactiveUser,
     )
     parser_classes = (JSONParser, MergePatchParser,)
@@ -886,7 +886,7 @@ class CourseDiscussionRolesAPIView(DeveloperErrorViewMixin, APIView):
     """
     authentication_classes = (
         JwtAuthentication,
-        OAuth2AuthenticationAllowInactiveUser,
+        OAuth2AuthenticationAllowInactiveUserDeprecated,
         SessionAuthenticationAllowInactiveUser,
     )
     permission_classes = (permissions.IsAuthenticated, permissions.IsAdminUser)

--- a/lms/djangoapps/discussion/rest_api/views.py
+++ b/lms/djangoapps/discussion/rest_api/views.py
@@ -55,7 +55,10 @@ from openedx.core.djangoapps.django_comment_common.utils import (
 )
 from openedx.core.djangoapps.user_api.accounts.permissions import CanReplaceUsername, CanRetireUser
 from openedx.core.djangoapps.user_api.models import UserRetirementStatus
-from openedx.core.lib.api.authentication import OAuth2AuthenticationAllowInactiveUserDeprecated
+from openedx.core.lib.api.authentication import (
+    OAuth2AuthenticationAllowInactiveUserDeprecated,
+    OAuth2AuthenticationAllowInactiveUser
+    )
 from openedx.core.lib.api.parsers import MergePatchParser
 from openedx.core.lib.api.view_utils import DeveloperErrorViewMixin, view_auth_classes
 from util.json_request import JsonResponse
@@ -63,6 +66,18 @@ from xmodule.modulestore.django import modulestore
 
 log = logging.getLogger(__name__)
 
+if getattr(settings, "DISCUSSION_USE_NEW_OAUTH2_CLASS", False):
+    _discussion_configured_authentication_classes = (
+        JwtAuthentication,
+        OAuth2AuthenticationAllowInactiveUser,
+        SessionAuthenticationAllowInactiveUser,
+    )
+else:
+    _discussion_configured_authentication_classes = (
+        JwtAuthentication,
+        OAuth2AuthenticationAllowInactiveUserDeprecated,
+        SessionAuthenticationAllowInactiveUser,
+    )
 
 @view_auth_classes()
 class CourseView(DeveloperErrorViewMixin, APIView):
@@ -749,11 +764,7 @@ class CourseDiscussionSettingsAPIView(DeveloperErrorViewMixin, APIView):
         * available_division_schemes: A list of available division schemes for the course.
 
     """
-    authentication_classes = (
-        JwtAuthentication,
-        OAuth2AuthenticationAllowInactiveUserDeprecated,
-        SessionAuthenticationAllowInactiveUser,
-    )
+    authentication_classes = _discussion_configured_authentication_classes
     parser_classes = (JSONParser, MergePatchParser,)
     permission_classes = (permissions.IsAuthenticated, permissions.IsAdminUser)
 
@@ -884,11 +895,7 @@ class CourseDiscussionRolesAPIView(DeveloperErrorViewMixin, APIView):
 
         * division_scheme: The division scheme used by the course.
     """
-    authentication_classes = (
-        JwtAuthentication,
-        OAuth2AuthenticationAllowInactiveUserDeprecated,
-        SessionAuthenticationAllowInactiveUser,
-    )
+    authentication_classes = _discussion_configured_authentication_classes
     permission_classes = (permissions.IsAuthenticated, permissions.IsAdminUser)
 
     def _get_request_kwargs(self, course_id, rolename):

--- a/lms/djangoapps/discussion/rest_api/views.py
+++ b/lms/djangoapps/discussion/rest_api/views.py
@@ -59,7 +59,7 @@ from openedx.core.djangoapps.user_api.models import UserRetirementStatus
 from openedx.core.lib.api.authentication import (
     OAuth2AuthenticationAllowInactiveUserDeprecated,
     OAuth2AuthenticationAllowInactiveUser
-    )
+)
 from openedx.core.lib.api.parsers import MergePatchParser
 from openedx.core.lib.api.view_utils import DeveloperErrorViewMixin, view_auth_classes
 from util.json_request import JsonResponse
@@ -79,6 +79,7 @@ else:
         OAuth2AuthenticationAllowInactiveUserDeprecated,
         SessionAuthenticationAllowInactiveUser,
     )
+
 
 @view_auth_classes()
 class CourseView(DeveloperErrorViewMixin, APIView):

--- a/lms/djangoapps/discussion/rest_api/views.py
+++ b/lms/djangoapps/discussion/rest_api/views.py
@@ -67,6 +67,17 @@ from xmodule.modulestore.django import modulestore
 
 log = logging.getLogger(__name__)
 
+# .. toggle_name: DISCUSSION_USE_NEW_OAUTH2_CLASS
+# .. toggle_implementation: DjangoSetting
+# .. toggle_default: False
+# .. toggle_description: Toggle for replacing a deprecated class with its replacement
+# .. toggle_category: n/a
+# .. toggle_use_cases: Monitored Rollout
+# .. toggle_creation_date: 2020-01-31
+# .. toggle_expiration_date: 2020-02-28
+# .. toggle_warnings: None
+# .. toggle_tickets: BOM-1037
+# .. toggle_status: supported
 if getattr(settings, "DISCUSSION_USE_NEW_OAUTH2_CLASS", False):
     _discussion_configured_authentication_classes = (
         JwtAuthentication,

--- a/lms/djangoapps/experiments/views_custom.py
+++ b/lms/djangoapps/experiments/views_custom.py
@@ -19,7 +19,7 @@ from rest_framework.views import APIView
 from openedx.core.djangoapps.content.course_overviews.models import CourseOverview
 from openedx.core.djangoapps.cors_csrf.decorators import ensure_csrf_cookie_cross_domain
 from openedx.core.djangoapps.waffle_utils import WaffleFlag, WaffleFlagNamespace
-from openedx.core.lib.api.authentication import OAuth2AuthenticationAllowInactiveUser
+from openedx.core.lib.api.authentication import OAuth2AuthenticationAllowInactiveUserDeprecated
 from openedx.core.lib.api.permissions import ApiKeyHeaderPermissionIsAuthenticated
 from openedx.core.lib.api.view_utils import DeveloperErrorViewMixin
 
@@ -100,7 +100,7 @@ class Rev934(DeveloperErrorViewMixin, APIView):
 
     authentication_classes = (
         JwtAuthentication,
-        OAuth2AuthenticationAllowInactiveUser,
+        OAuth2AuthenticationAllowInactiveUserDeprecated,
         SessionAuthenticationAllowInactiveUser,
     )
     permission_classes = (ApiKeyHeaderPermissionIsAuthenticated,)

--- a/lms/djangoapps/grades/rest_api/v1/views.py
+++ b/lms/djangoapps/grades/rest_api/v1/views.py
@@ -16,7 +16,7 @@ from lms.djangoapps.courseware.access import has_access
 from lms.djangoapps.grades.api import CourseGradeFactory, clear_prefetched_course_grades, prefetch_course_grades
 from lms.djangoapps.grades.rest_api.serializers import GradingPolicySerializer
 from lms.djangoapps.grades.rest_api.v1.utils import CourseEnrollmentPagination, GradeViewMixin
-from openedx.core.lib.api.authentication import OAuth2AuthenticationAllowInactiveUser
+from openedx.core.lib.api.authentication import OAuth2AuthenticationAllowInactiveUserDeprecated
 from openedx.core.lib.api.view_utils import PaginatedAPIView, get_course_key, verify_course_exists
 from xmodule.modulestore.django import modulestore
 
@@ -91,7 +91,7 @@ class CourseGradesView(GradeViewMixin, PaginatedAPIView):
     """
     authentication_classes = (
         JwtAuthentication,
-        OAuth2AuthenticationAllowInactiveUser,
+        OAuth2AuthenticationAllowInactiveUserDeprecated,
         SessionAuthenticationAllowInactiveUser,
     )
 
@@ -171,7 +171,7 @@ class CourseGradingPolicy(GradeViewMixin, ListAPIView):
 
     authentication_classes = (
         JwtAuthentication,
-        OAuth2AuthenticationAllowInactiveUser,
+        OAuth2AuthenticationAllowInactiveUserDeprecated,
         SessionAuthenticationAllowInactiveUser,
     )
 

--- a/lms/djangoapps/instructor/views/api.py
+++ b/lms/djangoapps/instructor/views/api.py
@@ -94,7 +94,7 @@ from openedx.core.djangoapps.django_comment_common.models import (
 from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
 from openedx.core.djangoapps.user_api.preferences.api import get_user_preference, set_user_preference
 from openedx.core.djangolib.markup import HTML, Text
-from openedx.core.lib.api.authentication import OAuth2AuthenticationAllowInactiveUser
+from openedx.core.lib.api.authentication import OAuth2AuthenticationAllowInactiveUserDeprecated
 from openedx.core.lib.api.view_utils import DeveloperErrorViewMixin
 from shoppingcart.models import (
     Coupon,
@@ -1474,7 +1474,7 @@ class CohortCSV(DeveloperErrorViewMixin, APIView):
     """
     authentication_classes = (
         JwtAuthentication,
-        OAuth2AuthenticationAllowInactiveUser,
+        OAuth2AuthenticationAllowInactiveUserDeprecated,
         SessionAuthenticationAllowInactiveUser,
     )
     permission_classes = (permissions.IsAuthenticated, permissions.IsAdminUser)

--- a/lms/djangoapps/program_enrollments/rest_api/v1/views.py
+++ b/lms/djangoapps/program_enrollments/rest_api/v1/views.py
@@ -47,7 +47,7 @@ from openedx.core.djangoapps.catalog.utils import (
     normalize_program_type
 )
 from openedx.core.djangoapps.content.course_overviews.models import CourseOverview
-from openedx.core.lib.api.authentication import OAuth2AuthenticationAllowInactiveUser
+from openedx.core.lib.api.authentication import OAuth2AuthenticationAllowInactiveUserDeprecated
 from openedx.core.lib.api.view_utils import DeveloperErrorViewMixin, PaginatedAPIView
 from student.helpers import get_resume_urls_for_enrollments
 from student.models import CourseEnrollment
@@ -328,7 +328,7 @@ class ProgramEnrollmentsView(
     """
     authentication_classes = (
         JwtAuthentication,
-        OAuth2AuthenticationAllowInactiveUser,
+        OAuth2AuthenticationAllowInactiveUserDeprecated,
         SessionAuthenticationAllowInactiveUser,
     )
     permission_classes = (permissions.JWT_RESTRICTED_APPLICATION_OR_USER_ACCESS,)
@@ -472,7 +472,7 @@ class ProgramCourseEnrollmentsView(
     """
     authentication_classes = (
         JwtAuthentication,
-        OAuth2AuthenticationAllowInactiveUser,
+        OAuth2AuthenticationAllowInactiveUserDeprecated,
         SessionAuthenticationAllowInactiveUser,
     )
     permission_classes = (permissions.JWT_RESTRICTED_APPLICATION_OR_USER_ACCESS,)
@@ -614,7 +614,7 @@ class ProgramCourseGradesView(
     """
     authentication_classes = (
         JwtAuthentication,
-        OAuth2AuthenticationAllowInactiveUser,
+        OAuth2AuthenticationAllowInactiveUserDeprecated,
         SessionAuthenticationAllowInactiveUser,
     )
     permission_classes = (permissions.JWT_RESTRICTED_APPLICATION_OR_USER_ACCESS,)
@@ -695,7 +695,7 @@ class UserProgramReadOnlyAccessView(DeveloperErrorViewMixin, PaginatedAPIView):
     """
     authentication_classes = (
         JwtAuthentication,
-        OAuth2AuthenticationAllowInactiveUser,
+        OAuth2AuthenticationAllowInactiveUserDeprecated,
         SessionAuthenticationAllowInactiveUser,
     )
     permission_classes = (IsAuthenticated,)
@@ -874,7 +874,7 @@ class ProgramCourseEnrollmentOverviewView(
     """
     authentication_classes = (
         JwtAuthentication,
-        OAuth2AuthenticationAllowInactiveUser,
+        OAuth2AuthenticationAllowInactiveUserDeprecated,
         SessionAuthenticationAllowInactiveUser,
     )
     permission_classes = (IsAuthenticated,)
@@ -983,7 +983,7 @@ class EnrollmentDataResetView(APIView):
     """
     authentication_classes = (
         JwtAuthentication,
-        OAuth2AuthenticationAllowInactiveUser,
+        OAuth2AuthenticationAllowInactiveUserDeprecated,
         SessionAuthenticationAllowInactiveUser,
     )
     permission_classes = (permissions.JWT_RESTRICTED_APPLICATION_OR_USER_ACCESS,)

--- a/openedx/core/djangoapps/auth_exchange/views.py
+++ b/openedx/core/djangoapps/auth_exchange/views.py
@@ -30,7 +30,7 @@ from rest_framework.views import APIView
 from openedx.core.djangoapps.auth_exchange.forms import AccessTokenExchangeForm
 from openedx.core.djangoapps.oauth_dispatch import adapters
 from openedx.core.djangoapps.oauth_dispatch.api import create_dot_access_token
-from openedx.core.lib.api.authentication import OAuth2AuthenticationAllowInactiveUser
+from openedx.core.lib.api.authentication import OAuth2AuthenticationAllowInactiveUserDeprecated
 
 
 class AccessTokenExchangeBase(APIView):
@@ -131,7 +131,7 @@ class LoginWithAccessTokenView(APIView):
     """
     View for exchanging an access token for session cookies
     """
-    authentication_classes = (OAuth2AuthenticationAllowInactiveUser,)
+    authentication_classes = (OAuth2AuthenticationAllowInactiveUserDeprecated,)
     permission_classes = (permissions.IsAuthenticated,)
 
     @staticmethod

--- a/openedx/core/djangoapps/course_groups/views.py
+++ b/openedx/core/djangoapps/course_groups/views.py
@@ -28,7 +28,7 @@ from rest_framework.serializers import Serializer
 from lms.djangoapps.courseware.courses import get_course, get_course_with_access
 from edxmako.shortcuts import render_to_response
 from openedx.core.djangoapps.course_groups.models import CohortMembership
-from openedx.core.lib.api.authentication import OAuth2AuthenticationAllowInactiveUser
+from openedx.core.lib.api.authentication import OAuth2AuthenticationAllowInactiveUserDeprecated
 from openedx.core.lib.api.view_utils import DeveloperErrorViewMixin
 from student.auth import has_course_author_access
 from util.json_request import JsonResponse, expect_json
@@ -429,7 +429,7 @@ class APIPermissions(GenericAPIView):
     """
     authentication_classes = (
         JwtAuthentication,
-        OAuth2AuthenticationAllowInactiveUser,
+        OAuth2AuthenticationAllowInactiveUserDeprecated,
         SessionAuthenticationAllowInactiveUser,
     )
     permission_classes = (permissions.IsAuthenticated, permissions.IsAdminUser)

--- a/openedx/core/djangoapps/enrollments/views.py
+++ b/openedx/core/djangoapps/enrollments/views.py
@@ -30,7 +30,7 @@ from openedx.core.djangoapps.enrollments.serializers import CourseEnrollmentsApi
 from openedx.core.djangoapps.user_api.accounts.permissions import CanRetireUser
 from openedx.core.djangoapps.user_api.models import UserRetirementStatus
 from openedx.core.djangoapps.user_api.preferences.api import update_email_opt_in
-from openedx.core.lib.api.authentication import OAuth2AuthenticationAllowInactiveUser
+from openedx.core.lib.api.authentication import OAuth2AuthenticationAllowInactiveUserDeprecated
 from openedx.core.lib.api.permissions import ApiKeyHeaderPermission, ApiKeyHeaderPermissionIsAuthenticated
 from openedx.core.lib.api.view_utils import DeveloperErrorViewMixin
 from openedx.core.lib.exceptions import CourseNotFoundError
@@ -168,7 +168,7 @@ class EnrollmentView(APIView, ApiKeyPermissionMixIn):
 
     authentication_classes = (
         JwtAuthentication,
-        OAuth2AuthenticationAllowInactiveUser,
+        OAuth2AuthenticationAllowInactiveUserDeprecated,
         SessionAuthenticationAllowInactiveUser,
     )
     permission_classes = (ApiKeyHeaderPermissionIsAuthenticated,)
@@ -243,7 +243,7 @@ class EnrollmentUserRolesView(APIView):
     """
     authentication_classes = (
         JwtAuthentication,
-        OAuth2AuthenticationAllowInactiveUser,
+        OAuth2AuthenticationAllowInactiveUserDeprecated,
         EnrollmentCrossDomainSessionAuth,
     )
     permission_classes = (ApiKeyHeaderPermissionIsAuthenticated,)
@@ -612,7 +612,7 @@ class EnrollmentListView(APIView, ApiKeyPermissionMixIn):
     """
     authentication_classes = (
         JwtAuthentication,
-        OAuth2AuthenticationAllowInactiveUser,
+        OAuth2AuthenticationAllowInactiveUserDeprecated,
         EnrollmentCrossDomainSessionAuth,
     )
     permission_classes = (ApiKeyHeaderPermissionIsAuthenticated,)
@@ -940,7 +940,7 @@ class CourseEnrollmentsApiListView(DeveloperErrorViewMixin, ListAPIView):
     """
     authentication_classes = (
         JwtAuthentication,
-        OAuth2AuthenticationAllowInactiveUser,
+        OAuth2AuthenticationAllowInactiveUserDeprecated,
         SessionAuthenticationAllowInactiveUser,
     )
     permission_classes = (permissions.IsAdminUser,)

--- a/openedx/core/djangoapps/profile_images/views.py
+++ b/openedx/core/djangoapps/profile_images/views.py
@@ -20,7 +20,7 @@ from six import text_type
 
 from openedx.core.djangoapps.user_api.accounts.image_helpers import get_profile_image_names, set_has_profile_image
 from openedx.core.djangoapps.user_api.errors import UserNotFound
-from openedx.core.lib.api.authentication import OAuth2AuthenticationAllowInactiveUser
+from openedx.core.lib.api.authentication import OAuth2AuthenticationAllowInactiveUserDeprecated
 from openedx.core.lib.api.parsers import TypedFileUploadParser
 from openedx.core.lib.api.permissions import IsUserInUrl
 from openedx.core.lib.api.view_utils import DeveloperErrorViewMixin
@@ -115,7 +115,7 @@ class ProfileImageView(DeveloperErrorViewMixin, APIView):
     parser_classes = (MultiPartParser, FormParser, TypedFileUploadParser)
     authentication_classes = (
         JwtAuthentication,
-        OAuth2AuthenticationAllowInactiveUser,
+        OAuth2AuthenticationAllowInactiveUserDeprecated,
         SessionAuthenticationAllowInactiveUser,
     )
     permission_classes = (permissions.IsAuthenticated, IsUserInUrl)

--- a/openedx/core/djangoapps/user_api/accounts/views.py
+++ b/openedx/core/djangoapps/user_api/accounts/views.py
@@ -49,7 +49,7 @@ from openedx.core.djangoapps.profile_images.images import remove_profile_images
 from openedx.core.djangoapps.user_api.accounts.image_helpers import get_profile_image_names, set_has_profile_image
 from openedx.core.djangoapps.user_authn.exceptions import AuthFailedError
 from openedx.core.djangolib.oauth2_retirement_utils import retire_dop_oauth2_models, retire_dot_oauth2_models
-from openedx.core.lib.api.authentication import OAuth2AuthenticationAllowInactiveUser
+from openedx.core.lib.api.authentication import OAuth2AuthenticationAllowInactiveUserDeprecated
 from openedx.core.lib.api.parsers import MergePatchParser
 from student.models import (
     AccountRecovery,
@@ -267,7 +267,7 @@ class AccountViewSet(ViewSet):
             If the update is successful, updated user account data is returned.
     """
     authentication_classes = (
-        JwtAuthentication, OAuth2AuthenticationAllowInactiveUser, SessionAuthenticationAllowInactiveUser
+        JwtAuthentication, OAuth2AuthenticationAllowInactiveUserDeprecated, SessionAuthenticationAllowInactiveUser
     )
     permission_classes = (permissions.IsAuthenticated,)
     parser_classes = (MergePatchParser,)

--- a/openedx/core/djangoapps/user_api/preferences/views.py
+++ b/openedx/core/djangoapps/user_api/preferences/views.py
@@ -14,7 +14,7 @@ from rest_framework import permissions, status
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
-from openedx.core.lib.api.authentication import OAuth2AuthenticationAllowInactiveUser
+from openedx.core.lib.api.authentication import OAuth2AuthenticationAllowInactiveUserDeprecated
 from openedx.core.lib.api.parsers import MergePatchParser
 from openedx.core.lib.api.permissions import IsUserInUrlOrStaff
 
@@ -91,7 +91,7 @@ class PreferencesView(APIView):
     """
     authentication_classes = (
         JwtAuthentication,
-        OAuth2AuthenticationAllowInactiveUser,
+        OAuth2AuthenticationAllowInactiveUserDeprecated,
         SessionAuthenticationAllowInactiveUser,
     )
     permission_classes = (permissions.IsAuthenticated, IsUserInUrlOrStaff)
@@ -202,7 +202,7 @@ class PreferencesDetailView(APIView):
             If the update is successful, an HTTP 204 "No Content" response is
             returned with no additional content.
     """
-    authentication_classes = (OAuth2AuthenticationAllowInactiveUser, SessionAuthenticationAllowInactiveUser)
+    authentication_classes = (OAuth2AuthenticationAllowInactiveUserDeprecated, SessionAuthenticationAllowInactiveUser)
     permission_classes = (permissions.IsAuthenticated, IsUserInUrlOrStaff)
 
     def get(self, request, username, preference_key):

--- a/openedx/core/lib/api/authentication.py
+++ b/openedx/core/lib/api/authentication.py
@@ -260,11 +260,11 @@ class OAuth2Authentication(BaseAuthentication):
 
 class OAuth2AuthenticationAllowInactiveUser(OAuth2Authentication):
     """
-    Currently is_active field on the user is coupled
+    Currently, is_active field on the user is coupled
     with whether or not the user has verified ownership of their claimed email address.
     Once is_active is decoupled from verified_email, we will no longer need this
     class override.
-    But until then, this authentication class ensures that the user is logged in,
+    Until then, this authentication class ensures that the user is logged in,
     but does not require that their account "is_active".
     This class can be used for an OAuth2-accessible endpoint that allows users to access
     that endpoint without having their email verified.  For example, this is used

--- a/openedx/core/lib/api/authentication.py
+++ b/openedx/core/lib/api/authentication.py
@@ -136,7 +136,7 @@ class OAuth2Authentication(BaseAuthentication):
     www_authenticate_realm = 'api'
 
     # currently, active users are users that confirm their email.
-    # a subclass could override `allow_inactive_users` to enable access without email confirmation, 
+    # a subclass could override `allow_inactive_users` to enable access without email confirmation,
     # like in the case of mobile users.
     allow_inactive_users = False
 

--- a/openedx/core/lib/api/authentication.py
+++ b/openedx/core/lib/api/authentication.py
@@ -36,16 +36,19 @@ class OAuth2AuthenticationDeprecated(OAuth2AuthenticationDeprecatedBase):
         """
         set_custom_metric("OAuth2AuthenticationDeprecated", "Failed")
 
-        auth = get_authorization_header(request).split()
+        try:
+            auth = get_authorization_header(request).split()
 
-        if auth and len(auth) == 2 and auth[0].lower() == b'bearer':
-            access_token = auth[1].decode('utf8')
-            set_custom_metric('OAuth2Authentication_token_location', 'bearer-in-header')
-        elif 'access_token' in request.POST:
-            access_token = request.POST['access_token']
-            set_custom_metric('OAuth2Authentication_token_location', 'post-token')
+            if auth and len(auth) == 2 and auth[0].lower() == b'bearer':
+                access_token = auth[1].decode('utf8')
+                set_custom_metric('OAuth2Authentication_token_location', 'bearer-in-header')
+            elif 'access_token' in request.POST:
+                access_token = request.POST['access_token']
+                set_custom_metric('OAuth2Authentication_token_location', 'post-token')
 
-        set_custom_metric("OAuth2Authentication_token_parts", len(access_token.split('.')))
+            set_custom_metric("OAuth2Authentication_token_parts", len(access_token.split('.')))
+        except:
+            set_custom_metric('OAuth2Authentication_metric_error','True')
 
         output = super(OAuth2AuthenticationDeprecated, self).authenticate(request)
         if output is None:

--- a/openedx/core/lib/api/authentication.py
+++ b/openedx/core/lib/api/authentication.py
@@ -47,8 +47,8 @@ class OAuth2AuthenticationDeprecated(OAuth2AuthenticationDeprecatedBase):
                 set_custom_metric('OAuth2Authentication_token_location', 'post-token')
 
             set_custom_metric("OAuth2Authentication_token_parts", len(access_token.split('.')))
-        except:
-            set_custom_metric('OAuth2Authentication_metric_error','True')
+        except:  # pylint: disable=bare-except
+            set_custom_metric('OAuth2Authentication_metric_error', 'True')
 
         output = super(OAuth2AuthenticationDeprecated, self).authenticate(request)
         if output is None:

--- a/openedx/core/lib/api/authentication.py
+++ b/openedx/core/lib/api/authentication.py
@@ -1,6 +1,5 @@
 """ Common Authentication Handlers used across projects. """
 
-
 import logging
 
 import django.utils.timezone
@@ -35,20 +34,14 @@ class OAuth2AuthenticationDeprecated(OAuth2AuthenticationDeprecatedBase):
         fails.
         """
         set_custom_metric("OAuth2AuthenticationDeprecated", "Failed")
-
         try:
             auth = get_authorization_header(request).split()
+            set_custom_metric('OAuth2Authentication_token_location', 'unknown')
 
             if auth and len(auth) == 2 and auth[0].lower() == b'bearer':
-                access_token = auth[1].decode('utf8')
                 set_custom_metric('OAuth2Authentication_token_location', 'bearer-in-header')
-            elif 'access_token' in request.POST:
-                access_token = request.POST['access_token']
-                set_custom_metric('OAuth2Authentication_token_location', 'post-token')
-
-            set_custom_metric("OAuth2Authentication_token_parts", len(access_token.split('.')))
-        except:  # pylint: disable=bare-except
-            set_custom_metric('OAuth2Authentication_metric_error', 'True')
+        except Exception:  # pylint: disable=broad-except
+            pass
 
         output = super(OAuth2AuthenticationDeprecated, self).authenticate(request)
         if output is None:

--- a/openedx/core/lib/api/authentication.py
+++ b/openedx/core/lib/api/authentication.py
@@ -204,7 +204,7 @@ class OAuth2Authentication(BaseAuthentication):
             })
         else:
             user = token.user
-            # Check to make sure the users have activated their account(by confirming their email)
+            # Check to make sure the users have activated their account (by confirming their email)
             if not self.allow_inactive_users and not user.is_active:
                 set_custom_metric("OAuth2Authentication_user_active", False)
                 msg = 'User inactive or deleted: %s' % user.get_username()
@@ -264,8 +264,7 @@ class OAuth2AuthenticationAllowInactiveUser(OAuth2Authentication):
     with whether or not the user has verified ownership of their claimed email address.
     Once is_active is decoupled from verified_email, we will no longer need this
     class override.
-    Until then, this authentication class ensures that the user is logged in,
-    but does not require that their account "is_active".
+
     This class can be used for an OAuth2-accessible endpoint that allows users to access
     that endpoint without having their email verified.  For example, this is used
     for mobile endpoints.

--- a/openedx/core/lib/api/tests/test_authentication.py
+++ b/openedx/core/lib/api/tests/test_authentication.py
@@ -50,7 +50,7 @@ class MockView(APIView):  # pylint: disable=missing-docstring
 # This is the a change we've made from the django-rest-framework-oauth version
 # of these tests.  We're subclassing our custom OAuth2AuthenticationAllowInactiveUser
 # instead of OAuth2Authentication.
-class OAuth2AuthenticationDebug(authentication.OAuth2AuthenticationAllowInactiveUser):
+class OAuth2AuthenticationDebug(authentication.OAuth2AuthenticationAllowInactiveUserDeprecated):
     allow_query_params_token = True
 
 
@@ -58,7 +58,7 @@ urlpatterns = [
     url(r'^oauth2/', include(('provider.oauth2.urls', 'oauth2'), namespace='oauth2')),
     url(
         r'^oauth2-deprecated-test/$',
-        MockView.as_view(authentication_classes=[authentication.OAuth2AuthenticationAllowInactiveUser])
+        MockView.as_view(authentication_classes=[authentication.OAuth2AuthenticationAllowInactiveUserDeprecated])
     ),
     url(
         r'^oauth2-test/$',
@@ -69,7 +69,7 @@ urlpatterns = [
     url(
         r'^oauth2-with-scope-test/$',
         MockView.as_view(
-            authentication_classes=[authentication.OAuth2AuthenticationAllowInactiveUser],
+            authentication_classes=[authentication.OAuth2AuthenticationAllowInactiveUserDeprecated],
             permission_classes=[permissions.TokenHasReadWriteScope]
         )
     ),

--- a/openedx/core/lib/api/tests/test_authentication.py
+++ b/openedx/core/lib/api/tests/test_authentication.py
@@ -59,15 +59,15 @@ urlpatterns = [
     url(
         r'^oauth2-deprecated-test/$',
         MockView.as_view(authentication_classes=[authentication.OAuth2AuthenticationAllowInactiveUserDeprecated])
-    ),
-        url(
+        ),
+    url(
         r'^oauth2-inactive-test/$',
         MockView.as_view(authentication_classes=[authentication.OAuth2AuthenticationAllowInactiveUser])
-    ),
+        ),
     url(
         r'^oauth2-test/$',
         MockView.as_view(authentication_classes=[authentication.OAuth2Authentication])
-    ),
+        ),
     # TODO(jinder): remove url when OAuth2AuthenticationDeprecated is fully removed
     url(r'^oauth2-test-debug/$', MockView.as_view(authentication_classes=[OAuth2AuthenticationDebug])),
     url(

--- a/openedx/core/lib/api/tests/test_authentication.py
+++ b/openedx/core/lib/api/tests/test_authentication.py
@@ -60,6 +60,10 @@ urlpatterns = [
         r'^oauth2-deprecated-test/$',
         MockView.as_view(authentication_classes=[authentication.OAuth2AuthenticationAllowInactiveUserDeprecated])
     ),
+        url(
+        r'^oauth2-inactive-test/$',
+        MockView.as_view(authentication_classes=[authentication.OAuth2AuthenticationAllowInactiveUser])
+    ),
     url(
         r'^oauth2-test/$',
         MockView.as_view(authentication_classes=[authentication.OAuth2Authentication])
@@ -79,12 +83,12 @@ urlpatterns = [
 @ddt.ddt  # pylint: disable=missing-docstring
 @unittest.skipUnless(settings.FEATURES.get("ENABLE_OAUTH2_PROVIDER"), "OAuth2 not enabled")
 @override_settings(ROOT_URLCONF=__name__)
-class OAuth2AllowInActiveUsersTests(TestCase):
+class OAuth2AllowInActiveUsersDeprecatedTests(TestCase):
 
     OAUTH2_BASE_TESTING_URL = '/oauth2-deprecated-test/'
 
     def setUp(self):
-        super(OAuth2AllowInActiveUsersTests, self).setUp()
+        super(OAuth2AllowInActiveUsersDeprecatedTests, self).setUp()
         self.dop_adapter = adapters.DOPAdapter()
         self.dot_adapter = adapters.DOTAdapter()
         self.csrf_client = APIClient(enforce_csrf_checks=True)
@@ -313,7 +317,7 @@ class OAuth2AllowInActiveUsersTests(TestCase):
         self.assertEqual(response.status_code, scope_statuses.write_status)
 
 
-class OAuth2AuthenticationTests(OAuth2AllowInActiveUsersTests):  # pylint: disable=test-inherits-tests
+class OAuth2AuthenticationTests(OAuth2AllowInActiveUsersDeprecatedTests):  # pylint: disable=test-inherits-tests
 
     OAUTH2_BASE_TESTING_URL = '/oauth2-test/'
 
@@ -321,4 +325,15 @@ class OAuth2AuthenticationTests(OAuth2AllowInActiveUsersTests):  # pylint: disab
         super(OAuth2AuthenticationTests, self).setUp()
         # Since this is testing back to previous version, user should be set to true
         self.user.is_active = True
+        self.user.save()
+
+
+class OAuth2AllowInActiveUsersTests(OAuth2AllowInActiveUsersDeprecatedTests):  # pylint: disable=test-inherits-tests
+
+    OAUTH2_BASE_TESTING_URL = '/oauth2-inactive-test/'
+
+    def setUp(self):
+        super(OAuth2AllowInActiveUsersTests, self).setUp()
+        # Since this is testing back to previous version, user should be set to true
+        self.user.is_active = False
         self.user.save()

--- a/openedx/core/lib/api/tests/test_authentication.py
+++ b/openedx/core/lib/api/tests/test_authentication.py
@@ -59,15 +59,15 @@ urlpatterns = [
     url(
         r'^oauth2-deprecated-test/$',
         MockView.as_view(authentication_classes=[authentication.OAuth2AuthenticationAllowInactiveUserDeprecated])
-        ),
+    ),
     url(
         r'^oauth2-inactive-test/$',
         MockView.as_view(authentication_classes=[authentication.OAuth2AuthenticationAllowInactiveUser])
-        ),
+    ),
     url(
         r'^oauth2-test/$',
         MockView.as_view(authentication_classes=[authentication.OAuth2Authentication])
-        ),
+    ),
     # TODO(jinder): remove url when OAuth2AuthenticationDeprecated is fully removed
     url(r'^oauth2-test-debug/$', MockView.as_view(authentication_classes=[OAuth2AuthenticationDebug])),
     url(

--- a/openedx/core/lib/api/tests/test_authentication.py
+++ b/openedx/core/lib/api/tests/test_authentication.py
@@ -57,7 +57,7 @@ class OAuth2AuthenticationDebug(authentication.OAuth2AuthenticationAllowInactive
 urlpatterns = [
     url(r'^oauth2/', include(('provider.oauth2.urls', 'oauth2'), namespace='oauth2')),
     url(
-        r'^oauth2-deprecated-test/$',
+        r'^oauth2-inactive-deprecated-test/$',
         MockView.as_view(authentication_classes=[authentication.OAuth2AuthenticationAllowInactiveUserDeprecated])
     ),
     url(
@@ -85,7 +85,7 @@ urlpatterns = [
 @override_settings(ROOT_URLCONF=__name__)
 class OAuth2AllowInActiveUsersDeprecatedTests(TestCase):
 
-    OAUTH2_BASE_TESTING_URL = '/oauth2-deprecated-test/'
+    OAUTH2_BASE_TESTING_URL = '/oauth2-inactive-deprecated-test/'
 
     def setUp(self):
         super(OAuth2AllowInActiveUsersDeprecatedTests, self).setUp()
@@ -331,9 +331,3 @@ class OAuth2AuthenticationTests(OAuth2AllowInActiveUsersDeprecatedTests):  # pyl
 class OAuth2AllowInActiveUsersTests(OAuth2AllowInActiveUsersDeprecatedTests):  # pylint: disable=test-inherits-tests
 
     OAUTH2_BASE_TESTING_URL = '/oauth2-inactive-test/'
-
-    def setUp(self):
-        super(OAuth2AllowInActiveUsersTests, self).setUp()
-        # Since this is testing back to previous version, user should be set to true
-        self.user.is_active = False
-        self.user.save()

--- a/openedx/core/lib/api/view_utils.py
+++ b/openedx/core/lib/api/view_utils.py
@@ -23,7 +23,7 @@ from rest_framework.views import APIView
 from six import text_type, iteritems
 
 from openedx.core.djangoapps.content.course_overviews.models import CourseOverview
-from openedx.core.lib.api.authentication import OAuth2AuthenticationAllowInactiveUser
+from openedx.core.lib.api.authentication import OAuth2AuthenticationAllowInactiveUserDeprecated
 from openedx.core.lib.api.permissions import IsUserInUrl
 
 
@@ -120,7 +120,7 @@ def view_auth_classes(is_user=False, is_authenticated=True):
         """
         func_or_class.authentication_classes = (
             JwtAuthentication,
-            OAuth2AuthenticationAllowInactiveUser,
+            OAuth2AuthenticationAllowInactiveUserDeprecated,
             SessionAuthenticationAllowInactiveUser
         )
         func_or_class.permission_classes = ()

--- a/openedx/features/discounts/views.py
+++ b/openedx/features/discounts/views.py
@@ -18,7 +18,7 @@ from experiments.models import ExperimentData
 from openedx.core.djangoapps.content.course_overviews.models import CourseOverview
 from openedx.core.djangoapps.cors_csrf.decorators import ensure_csrf_cookie_cross_domain
 from openedx.core.djangoapps.oauth_dispatch.jwt import create_jwt_for_user
-from openedx.core.lib.api.authentication import OAuth2AuthenticationAllowInactiveUser
+from openedx.core.lib.api.authentication import OAuth2AuthenticationAllowInactiveUserDeprecated
 from openedx.core.lib.api.permissions import ApiKeyHeaderPermissionIsAuthenticated
 from openedx.core.lib.api.view_utils import DeveloperErrorViewMixin
 
@@ -59,7 +59,7 @@ class CourseUserDiscount(DeveloperErrorViewMixin, APIView):
             "jwt": xxxxxxxx.xxxxxxxx.xxxxxxx
         }
     """
-    authentication_classes = (JwtAuthentication, OAuth2AuthenticationAllowInactiveUser,
+    authentication_classes = (JwtAuthentication, OAuth2AuthenticationAllowInactiveUserDeprecated,
                               SessionAuthenticationAllowInactiveUser,)
     permission_classes = (ApiKeyHeaderPermissionIsAuthenticated,)
 
@@ -130,7 +130,7 @@ class CourseUserDiscountWithUserParam(DeveloperErrorViewMixin, APIView):
             "jwt": xxxxxxxx.xxxxxxxx.xxxxxxx
         }
     """
-    authentication_classes = (JwtAuthentication, OAuth2AuthenticationAllowInactiveUser,
+    authentication_classes = (JwtAuthentication, OAuth2AuthenticationAllowInactiveUserDeprecated,
                               SessionAuthenticationAllowInactiveUser,)
     permission_classes = (ApiKeyHeaderPermissionIsAuthenticated, IsAdminUser)
 


### PR DESCRIPTION
- Created new class called OAuth2AuthenticationAllowInactiveUser, which replaces old class with same name
- Renames previous  OAuth2AuthenticationAllowInactiveUser to  OAuth2AuthenticationAllowInactiveUserDeprecated
- Replaced all imports of  OAuth2AuthenticationAllowInactiveUser to call deprecated class instead
- Adds toggle to discussions that switches to new class
