### PR TITLE
Fix most frequent deprecation warnings

### DIFF
--- a/common/lib/xmodule/xmodule/contentstore/mongo.py
+++ b/common/lib/xmodule/xmodule/contentstore/mongo.py
@@ -245,9 +245,9 @@ class MongoContentStore(ContentStore):
                 ('{}.name'.format(prefix), {'$regex': ASSET_IGNORE_REGEX}),
             ])
             items = self.fs_files.find(query)
-            assets_to_delete = assets_to_delete + items.count()
             for asset in items:
                 self.fs.delete(asset[prefix])
+                assets_to_delete += 1
 
             self.fs_files.remove(query)
         return assets_to_delete

--- a/common/lib/xmodule/xmodule/modulestore/django.py
+++ b/common/lib/xmodule/xmodule/modulestore/django.py
@@ -368,7 +368,7 @@ class ModuleI18nService(object):
         if block:
             xblock_class = getattr(block, 'unmixed_class', block.__class__)
             xblock_resource = xblock_class.__module__
-            xblock_locale_dir = '/translations'
+            xblock_locale_dir = 'translations'
             xblock_locale_path = resource_filename(xblock_resource, xblock_locale_dir)
             xblock_domain = 'text'
             selected_language = get_language()

--- a/common/lib/xmodule/xmodule/modulestore/mongo/base.py
+++ b/common/lib/xmodule/xmodule/modulestore/mongo/base.py
@@ -1314,8 +1314,11 @@ class MongoModuleStore(ModuleStoreDraftAndPublished, ModuleStoreWriteBase, Mongo
             ('_id.category', 'course'),
         ])
         courses = self.collection.find(course_search_location, projection={'_id': True})
-        if courses.count() > 0:
-            raise DuplicateCourseError(course_id, courses[0]['_id'])
+        try:
+            course = courses.next()
+            raise DuplicateCourseError(course_id, course['_id'])
+        except StopIteration:
+            pass
 
         with self.bulk_operations(course_id):
             xblock = self.create_item(user_id, course_id, 'course', course_id.run, fields=fields, **kwargs)

--- a/common/lib/xmodule/xmodule/modulestore/tests/factories.py
+++ b/common/lib/xmodule/xmodule/modulestore/tests/factories.py
@@ -618,7 +618,7 @@ def mongo_uses_error_check(store):
 @contextmanager
 def check_mongo_calls_range(max_finds=float("inf"), min_finds=0, max_sends=None, min_sends=None):
     """
-    Instruments the given store to count the number of calls to find (incl find_one) and the number
+    Instruments the given store to count the number of calls to find (incl find_one and count_documents) and the number
     of calls to send_message which is for insert, update, and remove (if you provide num_sends). At the
     end of the with statement, it compares the counts to the bounds provided in the arguments.
 
@@ -629,7 +629,7 @@ def check_mongo_calls_range(max_finds=float("inf"), min_finds=0, max_sends=None,
     """
     with check_sum_of_calls(
         pymongo.collection.Collection,
-        ['find'],
+        ['find', 'count_documents'],
         max_finds,
         min_finds,
     ):

--- a/pavelib/i18n.py
+++ b/pavelib/i18n.py
@@ -77,17 +77,12 @@ def i18n_generate_strict():
 
 @task
 @needs("pavelib.i18n.i18n_extract")
-@cmdopts([
-    ("settings=", "s", "The settings to use (defaults to devstack)"),
-])
 @timed
-def i18n_dummy(options):
+def i18n_dummy():
     """
     Simulate international translation by generating dummy strings
     corresponding to source strings.
     """
-    settings = options.get('settings', DEFAULT_SETTINGS)
-
     sh("i18n_tool dummy")
     # Need to then compile the new dummy strings
     sh("i18n_tool generate")

--- a/pavelib/paver_tests/test_i18n.py
+++ b/pavelib/paver_tests/test_i18n.py
@@ -156,7 +156,7 @@ class TestI18nDummy(PaverTestCase):
         """
         self.reset_task_messages()
         os.environ['NO_PREREQ_INSTALL'] = "true"
-        call_task('pavelib.i18n.i18n_dummy', options={"settings": Env.TEST_SETTINGS})
+        call_task('pavelib.i18n.i18n_dummy')
         self.assertEqual(
             self.task_messages,
             [


### PR DESCRIPTION
Fixed the most frequently occurring deprecation warnings, which were causing over half of the 34,140 deprecation warnings raised during the unit tests:

* `Use of .. or absolute path in a resource path is not allowed and will raise exceptions in a future release` - most of these were due to a single mis-configured resource path with a leading slash.
* `count is deprecated. Use Collection.count_documents instead.` - I added a handful of simple workarounds for this pymongo deprecation that shouldn't increase the query counts

Also did some cleanup of unused code in pavelib after the recent split of the new `i18n_compilejs` command from `i18n_dummy`. (This had caused a diff-quality failure on the first commit.)