### PR TITLE
Add condition to fix incorrect set schedules

### DIFF
--- a/openedx/features/course_duration_limits/access.py
+++ b/openedx/features/course_duration_limits/access.py
@@ -118,6 +118,11 @@ def get_user_course_expiration_date(user, course):
             if (content_availability_date.date() == course.start.date() and
                course.start < enrollment.created < timezone.now()):
                 content_availability_date = enrollment.created
+            # If course teams change the course start date, set the content_availability_date
+            # to max of enrollment or course start date
+            elif (content_availability_date.date() < course.start.date() and
+                  content_availability_date.date() < enrollment.created.date()):
+                content_availability_date = max(enrollment.created, course.start)
     except CourseEnrollment.schedule.RelatedObjectDoesNotExist:
         content_availability_date = max(enrollment.created, course.start)
 


### PR DESCRIPTION
Previously we observed a case where the `schedule.start_date` was equal to the `course start`, but should have been equal to the `enrollment start`. Fix for that was added here https://github.com/edx/edx-platform/pull/19968

``` python
if (content_availability_date.date() == course.start.date() and
    course.start < enrollment.created < timezone.now()):
        content_availability_date = enrollment.created
```

We recently got another case where `schedule.start_date` was set to `course start` but the course team changed the course start date which didn't satisfy the above check. Adding another check to handle this issue

PROD Ticket: https://openedx.atlassian.net/browse/PROD-1198