### PR TITLE
PROD-1236: Change URL returned for generated certificates to use UUID.

### DIFF
--- a/lms/djangoapps/certificates/api.py
+++ b/lms/djangoapps/certificates/api.py
@@ -69,7 +69,8 @@ def format_certificate_for_user(username, cert):
             "is_passing": is_passing_status(cert.status),
             "is_pdf_certificate": bool(cert.download_url),
             "download_url": (
-                cert.download_url or get_certificate_url(cert.user.id, cert.course_id, user_certificate=cert)
+                cert.download_url or get_certificate_url(cert.user.id, cert.course_id, uuid=cert.verify_uuid,
+                                                         user_certificate=cert)
                 if cert.status == CertificateStatuses.downloadable
                 else None
             ),

--- a/lms/djangoapps/certificates/apis/v0/tests/test_views.py
+++ b/lms/djangoapps/certificates/apis/v0/tests/test_views.py
@@ -381,6 +381,6 @@ class CertificatesListRestApiTest(AuthAndScopesTestMixin, SharedModuleStoreTestC
             requesting_user=self.student,
             requested_user=self.student,
         )
-        kwargs = {"user_id": str(self.student.id), "course_id": six.text_type(self.course.id)}
-        expected_download_url = reverse('certificates:html_view', kwargs=kwargs)
+        kwargs = {"certificate_uuid": self.cert.verify_uuid}
+        expected_download_url = reverse('certificates:render_cert_by_uuid', kwargs=kwargs)
         self.assert_success_response_for_student(response, download_url=expected_download_url)

--- a/lms/djangoapps/certificates/apis/v0/views.py
+++ b/lms/djangoapps/certificates/apis/v0/views.py
@@ -13,7 +13,7 @@ from edx_rest_framework_extensions.auth.session.authentication import SessionAut
 from opaque_keys import InvalidKeyError
 from opaque_keys.edx.keys import CourseKey
 from rest_condition import C
-from rest_framework.generics import GenericAPIView
+from rest_framework.views import APIView
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
 
@@ -28,7 +28,7 @@ log = logging.getLogger(__name__)
 User = get_user_model()
 
 
-class CertificatesDetailView(GenericAPIView):
+class CertificatesDetailView(APIView):
     """
         **Use Case**
 
@@ -143,14 +143,13 @@ class CertificatesDetailView(GenericAPIView):
         )
 
 
-class CertificatesListView(GenericAPIView):
+class CertificatesListView(APIView):
     """REST API endpoints for listing certificates."""
     authentication_classes = (
         JwtAuthentication,
         OAuth2AuthenticationAllowInactiveUserDeprecated,
         SessionAuthenticationAllowInactiveUser,
     )
-
     permission_classes = (
         C(IsAuthenticated) & (
             C(permissions.NotJwtRestrictedApplication) |
@@ -239,7 +238,6 @@ class CertificatesListView(GenericAPIView):
                     'download_url': user_cert.get('download_url'),
                     'grade': user_cert.get('grade'),
                 })
-
         return Response(user_certs)
 
     def _viewable_by_requestor(self, request, username):


### PR DESCRIPTION
This provides consistency across different APIs that return certificate URLs.

### Please consider the following when opening a pull request:

- Link to the relevant JIRA ticket(s) and tag any relevant team(s).
- Squash your changes down into one or more discrete commits.
  In each commit, include description that could help a developer
  several months from now.
- If running `make upgrade`, run _as close to the time of merging as possible_
  to avoid accidentally downgrading someone else's package.
  Put the output of `make upgrade` in its own separate commit,
  decoupled from other code changes.
- Aim for comprehensive test coverage, but remember that
  automated testing isn't a substitute for manual verification.
- Carefully consider naming, code organization, dependencies when adding new code.
  Code that is amenable to refactoring and improvement benefits all platform developers,
  especially given the size and scope of edx-platform.
  Consult existing Architectural Decision Records (ADRs),
  including those concerning the app(s) you are changing and
  [those concerning edx-platform as a whole](https://github.com/edx/edx-platform/tree/master/docs/decisions).
