### PR TITLE
two csv upload team-creation bugs

### DIFF
--- a/lms/djangoapps/teams/csv.py
+++ b/lms/djangoapps/teams/csv.py
@@ -228,6 +228,9 @@ class TeamMembershipImportManager(object):
                     topic_id=teamset_id
                 )
                 team.save()
+                self.existing_course_teams[(team_name, teamset_id)] = team
+            else:
+                team = self.existing_course_teams[(team_name, teamset_id)]
             team.add_user(user)
             emit_team_event(
                 'edx.team.learner_added',

--- a/lms/djangoapps/teams/tests/test_views.py
+++ b/lms/djangoapps/teams/tests/test_views.py
@@ -1773,17 +1773,17 @@ class TestBulkMembershipManagement(TeamAPITestCase):
     def test_upload_only_existing_courses(self):
         self.create_and_enroll_student(username='a_user')
         self.create_and_enroll_student(username='b_user')
-        self.existing_team_1 = CourseTeamFactory.create(course_id=self.test_course_1.id, topic_id='topic_1')
-        self.existing_team_2 = CourseTeamFactory.create(course_id=self.test_course_1.id, topic_id='topic_2')
+        existing_team_1 = CourseTeamFactory.create(course_id=self.test_course_1.id, topic_id='topic_1')
+        existing_team_2 = CourseTeamFactory.create(course_id=self.test_course_1.id, topic_id='topic_2')
 
         csv_content = 'user,mode,topic_1,topic_2' + '\n'
         csv_content += 'a_user, masters,{},{}'.format(
-            self.existing_team_1.name,
-            self.existing_team_2.name
+            existing_team_1.name,
+            existing_team_2.name
         ) + '\n'
         csv_content += 'b_user, masters,{},{}'.format(
-            self.existing_team_1.name,
-            self.existing_team_2.name
+            existing_team_1.name,
+            existing_team_2.name
         ) + '\n'
         csv_file = SimpleUploadedFile('test_file.csv', csv_content.encode('utf8'), content_type='text/csv')
         self.client.login(username=self.users['course_staff'].username, password=self.users['course_staff'].password)

--- a/lms/djangoapps/teams/tests/test_views.py
+++ b/lms/djangoapps/teams/tests/test_views.py
@@ -1755,6 +1755,10 @@ class TestBulkMembershipManagement(TeamAPITestCase):
                        201, method='post',
                        data={'csv': csv_file}, user='staff'
                        )
+        self.assertEqual(
+            CourseTeam.objects.filter(name='team 2', course_id=self.test_course_1.id).count(),
+            2
+        )
 
     def test_upload_non_existing_user(self):
         csv_content = 'user,mode,topic_0' + '\n'
@@ -1765,3 +1769,29 @@ class TestBulkMembershipManagement(TeamAPITestCase):
                        400, method='post',
                        data={'csv': csv_file}, user='staff'
                        )
+
+    def test_upload_only_existing_courses(self):
+        self.create_and_enroll_student(username='a_user')
+        self.create_and_enroll_student(username='b_user')
+        self.existing_team_1 = CourseTeamFactory.create(course_id=self.test_course_1.id, topic_id='topic_1')
+        self.existing_team_2 = CourseTeamFactory.create(course_id=self.test_course_1.id, topic_id='topic_2')
+
+        csv_content = 'user,mode,topic_1,topic_2' + '\n'
+        csv_content += 'a_user, masters,{},{}'.format(
+            self.existing_team_1.name,
+            self.existing_team_2.name
+        ) + '\n'
+        csv_content += 'b_user, masters,{},{}'.format(
+            self.existing_team_1.name,
+            self.existing_team_2.name
+        ) + '\n'
+        csv_file = SimpleUploadedFile('test_file.csv', csv_content.encode('utf8'), content_type='text/csv')
+        self.client.login(username=self.users['course_staff'].username, password=self.users['course_staff'].password)
+        with self.assertRaises(UnboundLocalError):
+            self.make_call(
+                reverse('team_membership_bulk_management', args=[self.good_course_id]),
+                201,
+                method='post',
+                data={'csv': csv_file},
+                user='staff'
+            )

--- a/lms/djangoapps/teams/tests/test_views.py
+++ b/lms/djangoapps/teams/tests/test_views.py
@@ -1757,7 +1757,7 @@ class TestBulkMembershipManagement(TeamAPITestCase):
                        )
         self.assertEqual(
             CourseTeam.objects.filter(name='team 2', course_id=self.test_course_1.id).count(),
-            2
+            1
         )
 
     def test_upload_non_existing_user(self):
@@ -1787,11 +1787,10 @@ class TestBulkMembershipManagement(TeamAPITestCase):
         ) + '\n'
         csv_file = SimpleUploadedFile('test_file.csv', csv_content.encode('utf8'), content_type='text/csv')
         self.client.login(username=self.users['course_staff'].username, password=self.users['course_staff'].password)
-        with self.assertRaises(UnboundLocalError):
-            self.make_call(
-                reverse('team_membership_bulk_management', args=[self.good_course_id]),
-                201,
-                method='post',
-                data={'csv': csv_file},
-                user='staff'
-            )
+        self.make_call(
+            reverse('team_membership_bulk_management', args=[self.good_course_id]),
+            201,
+            method='post',
+            data={'csv': csv_file},
+            user='staff'
+        )


### PR DESCRIPTION
@edx/masters-devs 
Bugfix: 

In the csv upload, specifying a team that already exists will cause an UnboundLocalError
also, if a team that is newly created is specified multiple times (for multiple users) each one will create a new team rather than using the same team.