### PR TITLE
BOM-939 Update pickle procotol version.

### DIFF
--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -837,7 +837,7 @@ COURSES_WITH_UNSAFE_CODE = []
 DEBUG = False
 SESSION_COOKIE_SECURE = False
 SESSION_SAVE_EVERY_REQUEST = False
-SESSION_SERIALIZER = 'openedx.core.lib.session_serializers.PickleV2Serializer'
+SESSION_SERIALIZER = 'openedx.core.lib.session_serializers.PickleSerializer'
 SESSION_COOKIE_DOMAIN = ""
 SESSION_COOKIE_NAME = 'sessionid'
 

--- a/common/lib/xmodule/xmodule/modulestore/split_mongo/mongo_connection.py
+++ b/common/lib/xmodule/xmodule/modulestore/split_mongo/mongo_connection.py
@@ -256,7 +256,7 @@ class CourseStructureCache(object):
             return None
 
         with TIMER.timer("CourseStructureCache.set", course_context) as tagger:
-            pickled_data = pickle.dumps(structure, 2)  # Protocol can't be incremented until cache is cleared
+            pickled_data = pickle.dumps(structure, 4)  # Protocol can't be incremented until cache is cleared
             tagger.measure('uncompressed_size', len(pickled_data))
 
             # 1 = Fastest (slightly larger results)

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -1100,7 +1100,7 @@ DEBUG = False
 USE_TZ = True
 SESSION_COOKIE_SECURE = False
 SESSION_SAVE_EVERY_REQUEST = False
-SESSION_SERIALIZER = 'openedx.core.lib.session_serializers.PickleV2Serializer'
+SESSION_SERIALIZER = 'openedx.core.lib.session_serializers.PickleSerializer'
 SESSION_COOKIE_DOMAIN = ""
 SESSION_COOKIE_NAME = 'sessionid'
 

--- a/openedx/core/lib/cache_utils.py
+++ b/openedx/core/lib/cache_utils.py
@@ -153,7 +153,7 @@ class process_cached(object):  # pylint: disable=invalid-name
 
 def zpickle(data):
     """Given any data structure, returns a zlib compressed pickled serialization."""
-    return zlib.compress(pickle.dumps(data, 2))  # Keep this constant as we upgrade from python 2 to 3.
+    return zlib.compress(pickle.dumps(data, 4))  # Keep this constant as we upgrade from python 2 to 3.
 
 
 def zunpickle(zdata):

--- a/openedx/core/lib/session_serializers.py
+++ b/openedx/core/lib/session_serializers.py
@@ -7,16 +7,15 @@ import six
 
 class PickleV2Serializer(object):
     """
-    Lock the pickle serializer to version 2 of the protocol
-    because we don't want python 2 to be able to read session
-    data written by python3 while both are running at the same
-    time in production.
+    Set the pickle protocol version explicitly because we don't want
+    to have session thrashing when we upgrade to newer versions of
+    python.
 
     Based on the PickleSerializer built into django:
     https://github.com/django/django/blob/master/django/contrib/sessions/serializers.py
     """
 
-    protocol = 2
+    protocol = 4
 
     def dumps(self, obj):
         """
@@ -28,10 +27,4 @@ class PickleV2Serializer(object):
         """
         Return a python object from pickled data.
         """
-        if six.PY2:
-            # Params used below don't exist in python 2
-            return pickle.loads(data)
-        else:
-            # See notes here about pickling python2 objects in python3
-            # https://docs.python.org/3/library/pickle.html#pickle.Unpickler
-            return pickle.loads(data, encoding='latin1')  # pylint: disable=unexpected-keyword-arg
+        return pickle.loads(data)

--- a/openedx/core/lib/session_serializers.py
+++ b/openedx/core/lib/session_serializers.py
@@ -5,7 +5,7 @@ import pickle
 import six
 
 
-class PickleV2Serializer(object):
+class PickleSerializer(object):
     """
     Set the pickle protocol version explicitly because we don't want
     to have session thrashing when we upgrade to newer versions of


### PR DESCRIPTION
Updating to the current highest number instead of making it the default
which is highest know by the language.  This is beacuse when we update
between python versions if there is a new proctocol version, we don't
want that to cause cache thrashing as we try to load things from the
various caches.  We can get into a situation where new machines pickle
things with a newer versions of the procotocl, put them in the cache and
then break older machines that don't know about the new protocol
version.