### PR TITLE
Video Transcripts setting not preserved

### DIFF
--- a/common/lib/xmodule/xmodule/js/src/video/09_video_caption.js
+++ b/common/lib/xmodule/xmodule/js/src/video/09_video_caption.js
@@ -36,13 +36,15 @@
                 'previousLanguageMenuItem', 'nextLanguageMenuItem', 'handleCaptionToggle',
                 'showClosedCaptions', 'hideClosedCaptions', 'toggleClosedCaptions',
                 'updateCaptioningCookie', 'handleCaptioningCookie', 'handleTranscriptToggle',
-                'listenForDragDrop'
+                'listenForDragDrop', 'handleTranscriptCookie', 'updateTranscriptCookie'
             );
+
             this.state = state;
             this.state.videoCaption = this;
             this.renderElements();
             this.handleCaptioningCookie();
             this.listenForDragDrop();
+            this.handleTranscriptCookie();
 
             return $.Deferred().resolve().promise();
         };
@@ -1142,11 +1144,12 @@
             */
             toggle: function(event) {
                 event.preventDefault();
-
                 if (this.state.el.hasClass('closed')) {
                     this.hideCaptions(false, true, true);
+                    this.updateTranscriptCookie(true);
                 } else {
                     this.hideCaptions(true, true, true);
+                    this.updateTranscriptCookie(false);
                 }
             },
 
@@ -1228,6 +1231,31 @@
                     });
                 } else {
                     $.cookie('show_closed_captions', null, {
+                        path: '/'
+                    });
+                }
+            },
+            handleTranscriptCookie: function() {
+                if ($.cookie('show_transcript') === null) {
+                    return;
+                }
+                if ($.cookie('show_transcript') !== 'false') {
+                    this.state.hideCaptions = false;
+                    // keep it going until turned off or in case of null initially change to true
+                    this.updateTranscriptCookie(true);
+                } else {
+                    this.state.hideCaptions = true;
+                }
+                this.hideCaptions(this.state.hideCaptions, true, true);
+            },
+            updateTranscriptCookie: function(showTranscript) {
+                if (showTranscript) {
+                    $.cookie('show_transcript', 'true', {
+                        expires: 3650,
+                        path: '/'
+                    });
+                } else {
+                    $.cookie('show_transcript', 'false', {
                         path: '/'
                     });
                 }

--- a/common/test/acceptance/tests/video/test_studio_video_module.py
+++ b/common/test/acceptance/tests/video/test_studio_video_module.py
@@ -288,6 +288,22 @@ class CMSVideoTest(CMSVideoBaseTest):
 
         self.assertTrue(self.video.is_captions_visible())
 
+    def test_transcript_state_is_saved_on_reload(self):
+        """
+        Scenario: Transcripts state is preserved
+        Given I have created a Video component with subtitles
+        And I have toggled off the transcript
+        After page reload transcript is already off
+        Then when I view the video it does show the captions
+        """
+        self._create_course_unit(subtitles=True)
+        self.video.click_player_button('transcript_button')
+        self.assertFalse(self.video.is_captions_visible())
+        self.video.click_player_button('transcript_button')
+        self.assertTrue(self.video.is_captions_visible())
+        self.browser.refresh()
+        self.assertTrue(self.video.is_captions_visible())
+
     def test_caption_line_focus(self):
         """
         Scenario: When enter key is pressed on a caption, an outline shows around it


### PR DESCRIPTION
[PROD-920](https://openedx.atlassian.net/browse/PROD-920)


When switching from one video to another the setting for the right side transcripts is not remembered. We need to turn this off for each video to hide the transcript

[Sandbox](https://pr23041.sandbox.edx.org/courses/course-v1:edX+DemoX+Demo_Course/courseware/d8a6192ade314473a78242dfeedfbf5b/edx_introduction/?activate_block_id=block-v1%3AedX%2BDemoX%2BDemo_Course%2Btype%40sequential%2Bblock%40edx_introduction) 

### Steps to reproduce:

1. Go to a video in a course. Either turn on or off the scrolling interactive captions
2. Play video
3. Go to another video, the selection just made (on or off) should have remained, however currently it defaults to a previous selection

### Fix
Created mechanism to store the transcript settings in cookies, as the same mechanism is being used for Closed Captions.