### PR TITLE
Moved django-method-override to tox

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -92,6 +92,6 @@ upgrade: ## update the pip requirements files to use the latest releases satisfy
 	# Post process all of the files generated above to work around open pip-tools issues
 	scripts/post-pip-compile.sh $(REQ_FILES:=.txt)
 	# Let tox control the Django version & django-oauth-toolkit version for tests
-	grep -e "^django==" -e "^django-oauth-toolkit==" requirements/edx/base.txt > requirements/edx/django.txt
-	sed '/^[dD]jango==/d;/^django-oauth-toolkit==/d' requirements/edx/testing.txt > requirements/edx/testing.tmp
+	grep -e "^django==" -e "^django-oauth-toolkit==" -e "^django-method-override==" requirements/edx/base.txt > requirements/edx/django.txt
+	sed '/^[dD]jango==/d;/^django-oauth-toolkit==/d;/^django-method-override==/d' requirements/edx/testing.txt > requirements/edx/testing.tmp
 	mv requirements/edx/testing.tmp requirements/edx/testing.txt

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -106,7 +106,7 @@ edx-django-release-util==0.3.6
 edx-django-sites-extensions==2.4.3
 edx-django-utils==2.0.4
 edx-drf-extensions==2.4.6
-edx-enterprise==2.3.5
+edx-enterprise==2.3.6
 edx-i18n-tools==0.5.0
 edx-milestones==0.2.6
 edx-oauth2-provider==1.3.1

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -117,7 +117,7 @@ edx-django-release-util==0.3.6
 edx-django-sites-extensions==2.4.3
 edx-django-utils==2.0.4
 edx-drf-extensions==2.4.6
-edx-enterprise==2.3.5
+edx-enterprise==2.3.6
 edx-i18n-tools==0.5.0
 edx-lint==1.3.0
 edx-milestones==0.2.6

--- a/requirements/edx/django.txt
+++ b/requirements/edx/django.txt
@@ -1,2 +1,3 @@
+django-method-override==0.2.0
 django-oauth-toolkit==1.1.3
 django==1.11.28

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -74,7 +74,6 @@ django-fernet-fields==0.6
 django-filter==2.2.0
 django-ipware==2.1.0
 django-js-asset==1.2.2
-django-method-override==0.2.0
 django-model-utils==3.0.0
 django-mptt==0.11.0
 django-multi-email-field==0.6.1
@@ -113,7 +112,7 @@ edx-django-release-util==0.3.6
 edx-django-sites-extensions==2.4.3
 edx-django-utils==2.0.4
 edx-drf-extensions==2.4.6
-edx-enterprise==2.3.5
+edx-enterprise==2.3.6
 edx-i18n-tools==0.5.0
 edx-lint==1.3.0
 edx-milestones==0.2.6

--- a/tox.ini
+++ b/tox.ini
@@ -72,6 +72,7 @@ deps =
     django20: Django>=2.0,<2.1
     django21: Django>=2.1,<2.2
     django20,django21: git+https://github.com/jazzband/django-oauth-toolkit.git@bf1525e85a06929016b1fe35d863e62e58124a2f#egg=oauth2_provider
+    django20,django21: django-method-override==1.0.4
     -r requirements/edx/testing.txt
 whitelist_externals =
     /bin/bash


### PR DESCRIPTION
JIRA: [BOM-1163](https://openedx.atlassian.net/browse/BOM-1163)

-  Moved django-method-override to djnago.txt from testing.txt
-  For testing with Django 2+, tox will use latest version of django-method-override