### PR TITLE
Print experiment in output so incorrect usage is easier to recognize

### DIFF
--- a/scripts/stable_bucketer
+++ b/scripts/stable_bucketer
@@ -65,7 +65,13 @@ def main(args, env):
     if abbrev is None:
         abbrev = abbreviate(my_args.exp)
 
-    print("{user} is in bucket: {bucket}".format(user=my_args.user, bucket=bucket))
+    print(
+        "For experiment {exp}, {user} is in bucket: {bucket}".format(
+            exp=my_args.exp,
+            user=my_args.user,
+            bucket=bucket,
+        )
+    )
     if my_args.print_args:
         print("* Args:\n\t{my_args}\n* Computed:\n\tdigest: {digest} - hash: {hashed} - {abbrev}".format(**vars()))
         return 0


### PR DESCRIPTION
Print experiment in output so incorrect usage like passing just a username instead of experiment name is easier to recognize

> $ scripts/stable_bucketer bjh
> For experiment bjh, bholt is in bucket: 1
> Generated names:
>     bholt-bjh-0-rx3c5
>     bholt-bjh-1-pkkrx