### PR TITLE
Auto load any keys/values from the yaml config file.

### DIFF
--- a/cms/envs/production.py
+++ b/cms/envs/production.py
@@ -38,6 +38,9 @@ CONFIG_FILE = get_env_setting('STUDIO_CFG')
 with codecs.open(CONFIG_FILE, encoding='utf-8') as f:
     __config__ = yaml.safe_load(f)
 
+    # Add the key/values from config into the global namespace of this module.
+    vars().update(__config__)
+
     # ENV_TOKENS and AUTH_TOKENS are included for reverse compatability.
     # Removing them may break plugins that rely on them.
     ENV_TOKENS = __config__

--- a/cms/envs/production.py
+++ b/cms/envs/production.py
@@ -8,6 +8,7 @@ This is the default template for our main set of AWS servers.
 
 
 import codecs
+import copy
 import os
 import yaml
 
@@ -38,13 +39,20 @@ CONFIG_FILE = get_env_setting('STUDIO_CFG')
 with codecs.open(CONFIG_FILE, encoding='utf-8') as f:
     __config__ = yaml.safe_load(f)
 
-    # Add the key/values from config into the global namespace of this module.
-    vars().update(__config__)
-
     # ENV_TOKENS and AUTH_TOKENS are included for reverse compatability.
     # Removing them may break plugins that rely on them.
     ENV_TOKENS = __config__
     AUTH_TOKENS = __config__
+
+    # Add the key/values from config into the global namespace of this module.
+    # But don't override the FEATURES dict because we do that in an additive way.
+    __config_copy__ = copy.deepcopy(__config__)
+    if 'FEATURES' in __config_copy__:
+        del __config_copy__['FEATURES']
+
+    if 'EVENT_TRACKING_BACKENDS' in __config_copy__:
+        del __config_copy__['EVENT_TRACKING_BACKENDS']
+    vars().update(__config_copy__)
 
 
 # A file path to a YAML file from which to load all the code revisions currently deployed

--- a/cms/envs/production.py
+++ b/cms/envs/production.py
@@ -47,11 +47,20 @@ with codecs.open(CONFIG_FILE, encoding='utf-8') as f:
     # Add the key/values from config into the global namespace of this module.
     # But don't override the FEATURES dict because we do that in an additive way.
     __config_copy__ = copy.deepcopy(__config__)
-    if 'FEATURES' in __config_copy__:
-        del __config_copy__['FEATURES']
 
-    if 'EVENT_TRACKING_BACKENDS' in __config_copy__:
-        del __config_copy__['EVENT_TRACKING_BACKENDS']
+    KEYS_WITH_MERGED_VALUES = [
+        'FEATURES',
+        'TRACKING_BACKENDS',
+        'EVENT_TRACKING_BACKENDS',
+        'JWT_AUTH',
+        'CELERY_QUEUES',
+        'MKTG_URL_LINK_MAP',
+        'MKTG_URL_OVERRIDES',
+    ]
+    for key in KEYS_WITH_MERGED_VALUES:
+        if key in __config_copy__:
+            del __config_copy__[key]
+
     vars().update(__config_copy__)
 
 

--- a/lms/envs/production.py
+++ b/lms/envs/production.py
@@ -50,6 +50,9 @@ CONFIG_FILE = get_env_setting('LMS_CFG')
 with codecs.open(CONFIG_FILE, encoding='utf-8') as f:
     __config__ = yaml.safe_load(f)
 
+    # Add the key/values from config into the global namespace of this module.
+    vars().update(__config__)
+
     # ENV_TOKENS and AUTH_TOKENS are included for reverse compatability.
     # Removing them may break plugins that rely on them.
     ENV_TOKENS = __config__

--- a/lms/envs/production.py
+++ b/lms/envs/production.py
@@ -19,6 +19,7 @@ Common traits:
 
 
 import codecs
+import copy
 import datetime
 import os
 
@@ -50,13 +51,21 @@ CONFIG_FILE = get_env_setting('LMS_CFG')
 with codecs.open(CONFIG_FILE, encoding='utf-8') as f:
     __config__ = yaml.safe_load(f)
 
-    # Add the key/values from config into the global namespace of this module.
-    vars().update(__config__)
-
     # ENV_TOKENS and AUTH_TOKENS are included for reverse compatability.
     # Removing them may break plugins that rely on them.
     ENV_TOKENS = __config__
     AUTH_TOKENS = __config__
+
+    # Add the key/values from config into the global namespace of this module.
+    # But don't override the FEATURES dict because we do that in an additive way.
+    __config_copy__ = copy.deepcopy(__config__)
+    if 'FEATURES' in __config_copy__:
+        del __config_copy__['FEATURES']
+
+    if 'EVENT_TRACKING_BACKENDS' in __config_copy__:
+        del __config_copy__['EVENT_TRACKING_BACKENDS']
+    vars().update(__config_copy__)
+
 
 # A file path to a YAML file from which to load all the code revisions currently deployed
 REVISION_CONFIG_FILE = get_env_setting('REVISION_CFG')

--- a/lms/envs/production.py
+++ b/lms/envs/production.py
@@ -59,11 +59,20 @@ with codecs.open(CONFIG_FILE, encoding='utf-8') as f:
     # Add the key/values from config into the global namespace of this module.
     # But don't override the FEATURES dict because we do that in an additive way.
     __config_copy__ = copy.deepcopy(__config__)
-    if 'FEATURES' in __config_copy__:
-        del __config_copy__['FEATURES']
 
-    if 'EVENT_TRACKING_BACKENDS' in __config_copy__:
-        del __config_copy__['EVENT_TRACKING_BACKENDS']
+    KEYS_WITH_MERGED_VALUES = [
+        'FEATURES',
+        'TRACKING_BACKENDS',
+        'EVENT_TRACKING_BACKENDS',
+        'JWT_AUTH',
+        'CELERY_QUEUES',
+        'MKTG_URL_LINK_MAP',
+        'MKTG_URL_OVERRIDES',
+    ]
+    for key in KEYS_WITH_MERGED_VALUES:
+        if key in __config_copy__:
+            del __config_copy__[key]
+
     vars().update(__config_copy__)
 
 


### PR DESCRIPTION
This should allow us to remove all the boilerplate code in this file
where a name is pulled from the config dict and put into the top level
namespace of the settings module.

We do this first so that any logic that adds more complex or dynamic
keys will still run and is safe.

Now that this is here we can start removing any simple boilerplate.