### PR TITLE
Studio export/import bug with problems having more than one pre-tag in problem.

### DIFF
--- a/common/lib/xmodule/xmodule/raw_module.py
+++ b/common/lib/xmodule/xmodule/raw_module.py
@@ -25,7 +25,7 @@ class RawMixin(object):
 
     @classmethod
     def definition_from_xml(cls, xml_object, system):
-        pre_tag_data = [etree.tostring(pre_tag_info) for pre_tag_info in xml_object.findall('pre')]
+        pre_tag_data = [etree.tostring(pre_tag_info) for pre_tag_info in xml_object.findall('.//pre')]
         data = etree.tostring(xml_object, pretty_print=True, encoding='unicode')
         if pre_tag_data:
             for index, pre_tag in enumerate(re.findall(PRE_TAG_REGEX, data)):


### PR DESCRIPTION
### [PROD-1250](https://openedx.atlassian.net/browse/PROD-1250)

### Description
This PR is concerned with the issues faced by Harvard courses regarding missing units. This was caused by the recent `pre_tag` changes made in this [PR](https://github.com/edx/edx-platform/pull/22195) to cater for the spacing of code within a `pre_tag`. The problem occurs when we have multiple `pre_tags` within the same problem in different subelements.
As we are using `tag name` to get all occurrences, it is stated here that only elements within the same subelement are matched. Hence we have to use `XPath` to get all occurrences of `pre_tags` within the subtree.


![Screenshot from 2020-02-10 12-32-18](https://user-images.githubusercontent.com/30112155/74129542-ab400800-4c01-11ea-9f25-7e149d207be7.png)
[Link for documentation](http://effbot.org/zone/element.htm#searching-for-subelements)

### Example
`<problem><p>The spacing of the following code is important:</p><pre><code class="lang-r">library(limma)\nX = model.matrix(~pd$Status)\netc.....</code></pre><p/><p>Placeholder text:</p><div><pre><code class="lang-r">library(limma)\nX = model.matrix(~pd$Status)\netc.....</code></pre></div><numericalresponse answer="0"><responseparam type="tolerance" default="0.025"/><formulaequationinput label="Label"/></numericalresponse></problem>`

If we use **tag name** to find all `xml_object.findall('.//pre')` we get the following output:
`[<Element pre at 0x7fdc5e6b2508>]`

if we use **regex** to find all `xml_object.findall('.//pre')` we get following output:
`[<Element pre at 0x7fdc8c0b7488>, <Element pre at 0x7fdc8c0b7e48>]`

_**Elements within same subtree are captured when using tag name, but to capture all of them within a subtree, we have to use regex.**_

### Instructions

- Create a new course
- Create a blank advanced-editor problem, and paste the following (contains 2 pre tags): 
```
<problem>
<p>The spacing of the following code is important:</p>
<pre><code class="lang-r">library(limma)
X = model.matrix(~pd$Status)
etc.....</code></pre>
<p/>
<p>Placeholder text:</p>
<div><pre><code class="lang-r">library(limma)
X = model.matrix(~pd$Status)
etc.....</code></pre></div>
<numericalresponse answer="0">
<responseparam type="tolerance" default="0.025"/>
<formulaequationinput label="Label"/>
</numericalresponse>
</problem> 
```

- View the published view (as expected.)
- Export course from Studio
- Re-import back into the same course
- View exercise
- Verify the problem content is same (indentation is maintained)

### Sandbox
https://studio-pr23055.sandbox.edx.org

### Reviewers
 - [x] @awaisdar001 
 - [x] @DawoudSheraz 

### Post Review
 - [x] Squash & Rebase commits