### PR TITLE
Increase xdist worker startup timeout

### DIFF
--- a/scripts/xdist/pytest_worker_manager.py
+++ b/scripts/xdist/pytest_worker_manager.py
@@ -29,7 +29,7 @@ class PytestWorkerManager():
     """
     Responsible for spinning up and terminating EC2 workers to be used with pytest-xdist
     """
-    WORKER_BOOTUP_TIMEOUT_MINUTES = 5
+    WORKER_BOOTUP_TIMEOUT_MINUTES = 10
     WORKER_SSH_ATTEMPTS = 10
     MAX_RUN_WORKER_RETRIES = 7
 


### PR DESCRIPTION
Try this workaround while waiting for a more efficient solution via https://openedx.atlassian.net/servicedesk/customer/portal/15/DOS-428 .  I've seen some of the jobs that failed to get enough workers slowly get more until ultimately timing out at the 5 minute point ([example](https://build.testeng.edx.org/job/edx-platform-python-pipeline-master/2689/execution/node/84/log/)).  Try extending this to 10 minutes to see if it increases the percentage of jobs that ultimately get enough workers to run.