### PR TITLE
Fix more deprecation warnings

### DIFF
--- a/common/djangoapps/third_party_auth/tasks.py
+++ b/common/djangoapps/third_party_auth/tasks.py
@@ -150,7 +150,7 @@ def _parse_metadata_xml(xml, entity_id):
         entity_desc = xml.find(
             ".//{}[@entityID='{}']".format(etree.QName(SAML_XML_NS, 'EntityDescriptor'), entity_id)
         )
-        if not entity_desc:
+        if entity_desc is None:
             raise MetadataParseError(u"Can't find EntityDescriptor for entityID {}".format(entity_id))
 
     expires_at = None
@@ -163,7 +163,7 @@ def _parse_metadata_xml(xml, entity_id):
             expires_at = cache_expires
 
     sso_desc = entity_desc.find(etree.QName(SAML_XML_NS, "IDPSSODescriptor"))
-    if not sso_desc:
+    if sso_desc is None:
         raise MetadataParseError("IDPSSODescriptor missing")
     if 'urn:oasis:names:tc:SAML:2.0:protocol' not in sso_desc.get("protocolSupportEnumeration"):
         raise MetadataParseError("This IdP does not support SAML 2.0")

--- a/common/lib/xmodule/xmodule/contentstore/mongo.py
+++ b/common/lib/xmodule/xmodule/contentstore/mongo.py
@@ -380,8 +380,8 @@ class MongoContentStore(ContentStore):
                 raise AttributeError("{} is a protected attribute.".format(attr))
         asset_db_key, __ = self.asset_db_key(location)
         # catch upsert error and raise NotFoundError if asset doesn't exist
-        result = self.fs_files.update({'_id': asset_db_key}, {"$set": attr_dict}, upsert=False)
-        if not result.get('updatedExisting', True):
+        result = self.fs_files.update_one({'_id': asset_db_key}, {"$set": attr_dict}, upsert=False)
+        if result.matched_count == 0:
             raise NotFoundError(asset_db_key)
 
     @autoretry_read()

--- a/common/lib/xmodule/xmodule/modulestore/mongo/base.py
+++ b/common/lib/xmodule/xmodule/modulestore/mongo/base.py
@@ -1484,14 +1484,12 @@ class MongoModuleStore(ModuleStoreDraftAndPublished, ModuleStoreWriteBase, Mongo
         bulk_record.dirty = True
         # See http://www.mongodb.org/display/DOCS/Updating for
         # atomic update syntax
-        result = self.collection.update(
+        result = self.collection.update_one(
             {'_id': location.to_deprecated_son()},
             {'$set': update},
-            multi=False,
             upsert=allow_not_found,
-            w=1,  # wait until primary commits
         )
-        if result['n'] == 0:
+        if result.matched_count == 0 and result.upserted_id is None:
             raise ItemNotFoundError(location)
 
     def _update_ancestors(self, location, update):
@@ -1621,10 +1619,9 @@ class MongoModuleStore(ModuleStoreDraftAndPublished, ModuleStoreWriteBase, Mongo
                     bulk_record.dirty = True
                     # The parent is an orphan, so remove all the children including
                     # the location whose parent we are looking for from orphan parent
-                    self.collection.update(
+                    self.collection.update_one(
                         {'_id': parent_loc.to_deprecated_son()},
                         {'$set': {'definition.children': []}},
-                        multi=False,
                         upsert=True,
                     )
                 elif ancestor_loc.block_type == 'course':
@@ -1819,13 +1816,13 @@ class MongoModuleStore(ModuleStoreDraftAndPublished, ModuleStoreWriteBase, Mongo
             else:
                 # Course exists, so create matching assets document.
                 course_assets = {'course_id': six.text_type(course_key), 'assets': {}}
-                doc_id = self.asset_collection.insert(course_assets)
+                doc_id = self.asset_collection.insert_one(course_assets).inserted_id
         elif isinstance(course_assets['assets'], list):
             # This record is in the old course assets format.
             # Ensure that no data exists before updating the format.
             assert len(course_assets['assets']) == 0
             # Update the format to a dict.
-            self.asset_collection.update(
+            self.asset_collection.update_one(
                 {'_id': doc_id},
                 {'$set': {'assets': {}}}
             )
@@ -1859,7 +1856,7 @@ class MongoModuleStore(ModuleStoreDraftAndPublished, ModuleStoreWriteBase, Mongo
             updates_by_type[self._make_mongo_asset_key(asset_type)] = list(assets)
 
         # Update the document.
-        self.asset_collection.update(
+        self.asset_collection.update_one(
             {'_id': course_assets.doc_id},
             {'$set': updates_by_type}
         )
@@ -1911,7 +1908,7 @@ class MongoModuleStore(ModuleStoreDraftAndPublished, ModuleStoreWriteBase, Mongo
         dest_assets = {'assets': source_assets.asset_md.copy(), 'course_id': six.text_type(dest_course_key)}
         self.asset_collection.delete_many({'course_id': six.text_type(dest_course_key)})
         # Update the document.
-        self.asset_collection.insert(dest_assets)
+        self.asset_collection.insert_one(dest_assets)
 
     @contract(asset_key='AssetKey', attr_dict=dict, user_id='int|long')
     def set_asset_metadata_attrs(self, asset_key, attr_dict, user_id):
@@ -1939,7 +1936,7 @@ class MongoModuleStore(ModuleStoreDraftAndPublished, ModuleStoreWriteBase, Mongo
         # Generate a Mongo doc from the metadata and update the course asset info.
         all_assets[asset_idx] = md.to_storable()
 
-        self.asset_collection.update(
+        self.asset_collection.update_one(
             {'_id': course_assets.doc_id},
             {"$set": {self._make_mongo_asset_key(asset_key.asset_type): all_assets}}
         )
@@ -1963,7 +1960,7 @@ class MongoModuleStore(ModuleStoreDraftAndPublished, ModuleStoreWriteBase, Mongo
         all_asset_info.pop(asset_idx)
 
         # Update the document.
-        self.asset_collection.update(
+        self.asset_collection.update_one(
             {'_id': course_assets.doc_id},
             {'$set': {self._make_mongo_asset_key(asset_key.asset_type): all_asset_info}}
         )

--- a/common/lib/xmodule/xmodule/modulestore/mongo/draft.py
+++ b/common/lib/xmodule/xmodule/modulestore/mongo/draft.py
@@ -447,7 +447,7 @@ class DraftModuleStore(MongoModuleStore):
             bulk_record = self._get_bulk_ops_record(location.course_key)
             bulk_record.dirty = True
             try:
-                self.collection.insert(item)
+                self.collection.insert_one(item)
             except pymongo.errors.DuplicateKeyError:
                 # prevent re-creation of DRAFT versions, unless explicitly requested to ignore
                 if not ignore_if_draft:

--- a/common/lib/xmodule/xmodule/modulestore/split_mongo/mongo_connection.py
+++ b/common/lib/xmodule/xmodule/modulestore/split_mongo/mongo_connection.py
@@ -423,7 +423,7 @@ class MongoConnection(object):
         """
         with TIMER.timer("insert_structure", course_context) as tagger:
             tagger.measure("blocks", len(structure["blocks"]))
-            self.structures.insert(structure_to_mongo(structure, course_context))
+            self.structures.insert_one(structure_to_mongo(structure, course_context))
 
     def get_course_index(self, key, ignore_case=False):
         """
@@ -504,7 +504,7 @@ class MongoConnection(object):
         """
         with TIMER.timer("insert_course_index", course_context):
             course_index['last_update'] = datetime.datetime.now(pytz.utc)
-            self.course_index.insert(course_index)
+            self.course_index.insert_one(course_index)
 
     def update_course_index(self, course_index, from_index=None, course_context=None):
         """
@@ -527,7 +527,7 @@ class MongoConnection(object):
                     'run': course_index['run'],
                 }
             course_index['last_update'] = datetime.datetime.now(pytz.utc)
-            self.course_index.update(query, course_index, upsert=False,)
+            self.course_index.replace_one(query, course_index, upsert=False,)
 
     def delete_course_index(self, course_key):
         """
@@ -566,7 +566,7 @@ class MongoConnection(object):
         with TIMER.timer("insert_definition", course_context) as tagger:
             tagger.measure('fields', len(definition['fields']))
             tagger.tag(block_type=definition['block_type'])
-            self.definitions.insert(definition)
+            self.definitions.insert_one(definition)
 
     def ensure_indexes(self):
         """

--- a/common/lib/xmodule/xmodule/modulestore/tests/factories.py
+++ b/common/lib/xmodule/xmodule/modulestore/tests/factories.py
@@ -637,7 +637,7 @@ def check_mongo_calls_range(max_finds=float("inf"), min_finds=0, max_sends=None,
             with check_sum_of_calls(
                 pymongo.collection.Collection,
                 # mongo < 2.6 uses insert, update, delete and _do_batched_insert. >= 2.6 _do_batched_write
-                ['insert', 'update', 'bulk_write', '_delete'],
+                ['insert_one', 'replace_one', 'update_one', 'bulk_write', '_delete'],
                 max_sends if max_sends is not None else float("inf"),
                 min_sends if min_sends is not None else 0,
             ):

--- a/common/lib/xmodule/xmodule/modulestore/tests/test_mixed_modulestore.py
+++ b/common/lib/xmodule/xmodule/modulestore/tests/test_mixed_modulestore.py
@@ -1624,7 +1624,7 @@ class TestMixedModuleStore(CommonMixedModuleStoreSetup):
 
         mongo_store = self.store._get_modulestore_for_courselike(course_id)  # pylint: disable=protected-access
         # add another parent (unit) "vertical_x1b" for problem "problem_x1a_1"
-        mongo_store.collection.update(
+        mongo_store.collection.update_one(
             self.vertical_x1b.to_deprecated_son('_id.'),
             {'$push': {'definition.children': six.text_type(self.problem_x1a_1)}}
         )
@@ -1874,11 +1874,11 @@ class TestMixedModuleStore(CommonMixedModuleStoreSetup):
         self.assertEqual(len(set(found_orphans)), 2)
 
         # add orphan vertical and sequential as another parents of problem "problem_x1a_1"
-        mongo_store.collection.update(
+        mongo_store.collection.update_one(
             orphan_sequential.to_deprecated_son('_id.'),
             {'$push': {'definition.children': six.text_type(self.problem_x1a_1)}}
         )
-        mongo_store.collection.update(
+        mongo_store.collection.update_one(
             orphan_vertical.to_deprecated_son('_id.'),
             {'$push': {'definition.children': six.text_type(self.problem_x1a_1)}}
         )
@@ -1889,7 +1889,7 @@ class TestMixedModuleStore(CommonMixedModuleStoreSetup):
             self.assertEqual(parent, self.vertical_x1a)
 
         # now add valid published vertical as another parent of problem
-        mongo_store.collection.update(
+        mongo_store.collection.update_one(
             self.sequential_x1.to_deprecated_son('_id.'),
             {'$push': {'definition.children': six.text_type(self.problem_x1a_1)}}
         )

--- a/setup.cfg
+++ b/setup.cfg
@@ -8,6 +8,7 @@ filterwarnings =
     default
     ignore:No request passed to the backend, unable to rate-limit:UserWarning
     ignore::xblock.exceptions.FieldDataDeprecationWarning
+junit_family = xunit2
 norecursedirs = .* *.egg build conf dist node_modules test_root cms/envs lms/envs
 python_classes =
 python_files = tests.py test_*.py tests_*.py *_tests.py __init__.py


### PR DESCRIPTION
Fix more commonly occurring deprecation warnings:

* `update is deprecated. Use replace_one, update_one or update_many instead.` (pymongo, 8,328 occurrences)
* `insert is deprecated. Use insert_one or insert_many instead`. (pymongo, 2,311 occurrences)
* `The behavior of this method will change in future versions. Use specific 'len(elem)' or 'elem is not None' test instead.` (lxml, 36 ocurrences)
* `The 'junit_family' default value will change to 'xunit2' in pytest 6.0. Add 'junit_family=xunit1' to your pytest.ini file to keep the current format in future versions of pytest and silence this warning.` (pytest, 6 occurrences)