### PR TITLE
Moved hooks around

### DIFF
--- a/cms/conftest.py
+++ b/cms/conftest.py
@@ -12,8 +12,7 @@ import os
 import contracts
 import pytest
 
-from openedx.core.pytest_hooks import pytest_json_modifyreport  # pylint: disable=unused-import
-from openedx.core.pytest_hooks import pytest_sessionfinish  # pylint: disable=unused-import
+from openedx.core.pytest_hooks import DeferPlugin
 
 
 # Patch the xml libs before anything else.
@@ -34,6 +33,9 @@ def pytest_configure(config):
     startup_module = 'cms.startup' if settings_module.startswith('cms') else 'lms.startup'
     startup = importlib.import_module(startup_module)
     startup.run()
+
+    if config.pluginmanager.hasplugin("json-report"):
+        config.pluginmanager.register(DeferPlugin())
 
 
 @pytest.fixture(autouse=True, scope='function')

--- a/conftest.py
+++ b/conftest.py
@@ -10,8 +10,6 @@ import pytest
 # avoid duplicating the implementation
 
 from cms.conftest import _django_clear_site_cache, pytest_configure  # pylint: disable=unused-import
-from openedx.core.pytest_hooks import pytest_json_modifyreport  # pylint: disable=unused-import
-from openedx.core.pytest_hooks import pytest_sessionfinish  # pylint: disable=unused-import
 
 
 # When using self.assertEquals, diffs are truncated. We don't want that, always


### PR DESCRIPTION
This change only implements pytest hooks when we know pytest_json_report plugin has
been loaded. Previously, the hooks were being loaded before plugin, thus causing errors
cause(pytest_sessionfinish needs the plugin to function.

