### PR TITLE
Fix DRF deprecation warnings

### DIFF
--- a/cms/djangoapps/api/v1/urls.py
+++ b/cms/djangoapps/api/v1/urls.py
@@ -10,5 +10,5 @@ from .views.course_runs import CourseRunViewSet
 app_name = 'cms.djangoapps.api.v1'
 
 router = DefaultRouter()
-router.register(r'course_runs', CourseRunViewSet, base_name='course_run')
+router.register(r'course_runs', CourseRunViewSet, basename='course_run')
 urlpatterns = router.urls

--- a/cms/djangoapps/api/v1/views/course_runs.py
+++ b/cms/djangoapps/api/v1/views/course_runs.py
@@ -7,7 +7,7 @@ from edx_rest_framework_extensions.auth.jwt.authentication import JwtAuthenticat
 from opaque_keys.edx.keys import CourseKey
 from rest_framework import parsers, permissions, status, viewsets
 from rest_framework.authentication import SessionAuthentication
-from rest_framework.decorators import detail_route
+from rest_framework.decorators import action
 from rest_framework.response import Response
 
 from contentstore.views.course import _accessible_courses_iter, get_course_and_check_access
@@ -74,7 +74,8 @@ class CourseRunViewSet(viewsets.GenericViewSet):
         serializer.save()
         return Response(serializer.data, status=status.HTTP_201_CREATED)
 
-    @detail_route(
+    @action(
+        detail=True,
         methods=['post', 'put'],
         parser_classes=(parsers.FormParser, parsers.MultiPartParser,),
         serializer_class=CourseRunImageSerializer)
@@ -85,7 +86,7 @@ class CourseRunViewSet(viewsets.GenericViewSet):
         serializer.save()
         return Response(serializer.data)
 
-    @detail_route(methods=['post'])
+    @action(detail=True, methods=['post'])
     def rerun(self, request, *args, **kwargs):
         course_run = self.get_object()
         serializer = CourseRunRerunSerializer(course_run, data=request.data, context=self.get_serializer_context())

--- a/common/djangoapps/entitlements/api/v1/urls.py
+++ b/common/djangoapps/entitlements/api/v1/urls.py
@@ -6,7 +6,7 @@ from rest_framework.routers import DefaultRouter
 from .views import EntitlementEnrollmentViewSet, EntitlementViewSet
 
 router = DefaultRouter()
-router.register(r'entitlements', EntitlementViewSet, base_name='entitlements')
+router.register(r'entitlements', EntitlementViewSet, basename='entitlements')
 
 ENROLLMENTS_VIEW = EntitlementEnrollmentViewSet.as_view({
     'post': 'create',

--- a/lms/djangoapps/course_goals/urls.py
+++ b/lms/djangoapps/course_goals/urls.py
@@ -9,7 +9,7 @@ from rest_framework import routers
 from .views import CourseGoalViewSet
 
 router = routers.DefaultRouter()
-router.register(r'course_goals', CourseGoalViewSet, base_name='course_goal')
+router.register(r'course_goals', CourseGoalViewSet, basename='course_goal')
 
 urlpatterns = [
     url(r'^v0/', include((router.urls, "api"), namespace='v0')),

--- a/lms/djangoapps/discussion/notifier_api/urls.py
+++ b/lms/djangoapps/discussion/notifier_api/urls.py
@@ -9,7 +9,7 @@ from rest_framework import routers
 from lms.djangoapps.discussion.notifier_api.views import NotifierUsersViewSet
 
 notifier_api_router = routers.DefaultRouter()
-notifier_api_router.register(r'users', NotifierUsersViewSet, base_name="notifier_users")
+notifier_api_router.register(r'users', NotifierUsersViewSet, basename="notifier_users")
 
 urlpatterns = [
     url(r'^v1/', include(notifier_api_router.urls)),

--- a/lms/djangoapps/discussion/rest_api/urls.py
+++ b/lms/djangoapps/discussion/rest_api/urls.py
@@ -20,8 +20,8 @@ from lms.djangoapps.discussion.rest_api.views import (
 )
 
 ROUTER = SimpleRouter()
-ROUTER.register("threads", ThreadViewSet, base_name="thread")
-ROUTER.register("comments", CommentViewSet, base_name="comment")
+ROUTER.register("threads", ThreadViewSet, basename="thread")
+ROUTER.register("comments", CommentViewSet, basename="comment")
 
 urlpatterns = [
     url(

--- a/lms/djangoapps/experiments/routers.py
+++ b/lms/djangoapps/experiments/routers.py
@@ -23,7 +23,7 @@ class DefaultRouter(routers.DefaultRouter):
             initkwargs={'suffix': 'List'}
         ),
         # Dynamically generated list routes.
-        # Generated using @list_route decorator
+        # Generated using @action(detail=False) decorator
         # on methods of the viewset.
         DynamicRoute(
             url=r'^{prefix}/{lookup}{trailing_slash}$',
@@ -45,7 +45,7 @@ class DefaultRouter(routers.DefaultRouter):
             initkwargs={'suffix': 'Instance'}
         ),
         # Dynamically generated detail routes.
-        # Generated using @detail_route decorator on methods of the viewset.
+        # Generated using @action(detail=True) decorator on methods of the viewset.
         DynamicRoute(
             url=r'^{prefix}/{lookup}{trailing_slash}$',
             name='{basename}-detail',

--- a/lms/djangoapps/experiments/urls.py
+++ b/lms/djangoapps/experiments/urls.py
@@ -8,8 +8,8 @@ from django.conf.urls import include, url
 from experiments import routers, views, views_custom
 
 router = routers.DefaultRouter()
-router.register(r'data', views.ExperimentDataViewSet, base_name='data')
-router.register(r'key-value', views.ExperimentKeyValueViewSet, base_name='key_value')
+router.register(r'data', views.ExperimentDataViewSet, basename='data')
+router.register(r'key-value', views.ExperimentKeyValueViewSet, basename='key_value')
 
 urlpatterns = [
     url(r'^v0/custom/REV-934/', views_custom.Rev934.as_view(), name='rev_934'),


### PR DESCRIPTION
Fix all deprecation warnings generated by Django REST Framework during the unit tests:

* ``The `base_name` argument is pending deprecation in favor of `basename`.`` (86 occurrences)
* `` `detail_route` is deprecated and will be removed in 3.10 in favor of `action`, which accepts a `detail` bool. Use `@action(detail=True)` instead.`` (18 occurrences)