### PR TITLE
Pipe COLLECT_WHO_TESTS_WHAT through to jenkins-report.sh so that we u…

### DIFF
--- a/scripts/Jenkinsfiles/python
+++ b/scripts/Jenkinsfiles/python
@@ -155,12 +155,13 @@ pipeline {
                 }
             }
         }
-        
-        
+
+
         stage('Run coverage') {
             environment {
                 CODE_COV_TOKEN = credentials('CODE_COV_TOKEN')
                 SUBSET_JOB = "null" // Keep this variable until we can remove the $SUBSET_JOB path from .coveragerc
+                COLLECT_WHO_TESTS_WHAT = "${COLLECT_WHO_TESTS_WHAT}"
             }
             steps {
                 script {


### PR DESCRIPTION
…pload coverage contexts nightly

### Please consider the following when opening a pull request:

- Link to the relevant JIRA ticket(s) and tag any relevant team(s).
- Squash your changes down into one or more discrete commits.
  In each commit, include description that could help a developer
  several months from now.
- If running `make upgrade`, run _as close to the time of merging as possible_
  to avoid accidentally downgrading someone else's package.
  Put the output of `make upgrade` in its own separate commit,
  decoupled from other code changes.
- Aim for comprehensive test coverage, but remember that
  automated testing isn't a substitute for manual verification.
- Carefully consider naming, code organization, dependencies when adding new code.
  Code that is amenable to refactoring and improvement benefits all platform developers,
  especially given the size and scope of edx-platform.
  Consult existing Architectural Decision Records (ADRs),
  including those concerning the app(s) you are changing and
  [those concerning edx-platform as a whole](https://github.com/edx/edx-platform/tree/master/docs/decisions).
