### PR TITLE
ENT-2626: Stop hitting enterprise API in case of 404 error

### DIFF
--- a/lms/djangoapps/static_template_view/views.py
+++ b/lms/djangoapps/static_template_view/views.py
@@ -94,6 +94,7 @@ def render_press_release(request, slug):
 
 @fix_crum_request
 def render_404(request, exception):
+    request.view_name = '404'
     return HttpResponseNotFound(render_to_string('static_templates/404.html', {}, request=request))
 
 

--- a/openedx/features/enterprise_support/tests/test_utils.py
+++ b/openedx/features/enterprise_support/tests/test_utils.py
@@ -1,0 +1,46 @@
+"""
+Test the enterprise support utils.
+"""
+
+
+import mock
+import ddt
+
+from django.test import TestCase
+from django.test.utils import override_settings
+from django.urls import reverse
+
+from openedx.core.djangolib.testing.utils import skip_unless_lms
+from openedx.features.enterprise_support.tests import FEATURES_WITH_ENTERPRISE_ENABLED
+from student.tests.factories import UserFactory
+
+
+@ddt.ddt
+@override_settings(FEATURES=FEATURES_WITH_ENTERPRISE_ENABLED)
+@skip_unless_lms
+class TestEnterpriseUtils(TestCase):
+    """
+    Test enterprise support utils.
+    """
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.user = UserFactory.create(password='password')
+        super(TestEnterpriseUtils, cls).setUpTestData()
+
+    @ddt.data(
+        ('notfoundpage', 0),
+        (reverse('dashboard'), 1),
+    )
+    @ddt.unpack
+    def test_enterprise_customer_for_request_called_on_404(self, resource, expected_calls):
+        """
+        Test enterprise customer API is not called from 404 page
+        """
+        self.client.login(username=self.user.username, password='password')
+
+        with mock.patch(
+            'openedx.features.enterprise_support.api.enterprise_customer_for_request'
+        ) as mock_customer_request:
+            self.client.get(resource)
+            self.assertEqual(mock_customer_request.call_count, expected_calls)

--- a/openedx/features/enterprise_support/utils.py
+++ b/openedx/features/enterprise_support/utils.py
@@ -316,6 +316,11 @@ def get_enterprise_learner_generic_name(request):
     """
     # Prevent a circular import. This function makes sense to be in this module though. And see function description.
     from openedx.features.enterprise_support.api import enterprise_customer_for_request
+
+    # ENT-2626: For 404 pages we don't need to perform these actions.
+    if getattr(request, 'view_name', None) == '404':
+        return
+
     enterprise_customer = enterprise_customer_for_request(request)
 
     return (


### PR DESCRIPTION
It appears there are many cases when we are hitting 404 views very frequently resulting in 429 errors due to API throttling. These APIs are being called when we render user account dropdown(user_dropdown.html)

This PR has changes to stop hitting enterprise API when 404 page is rendering.

### Please consider the following when opening a pull request:

- Link to the relevant JIRA ticket(s) and tag any relevant team(s).
- Squash your changes down into one or more discrete commits.
  In each commit, include description that could help a developer
  several months from now.
- If running `make upgrade`, run _as close to the time of merging as possible_
  to avoid accidentally downgrading someone else's package.
  Put the output of `make upgrade` in its own separate commit,
  decoupled from other code changes.
- Aim for comprehensive test coverage, but remember that
  automated testing isn't a substitute for manual verification.
- Carefully consider naming, code organization, dependencies when adding new code.
  Code that is amenable to refactoring and improvement benefits all platform developers,
  especially given the size and scope of edx-platform.
  Consult existing Architectural Decision Records (ADRs),
  including those concerning the app(s) you are changing and
  [those concerning edx-platform as a whole](https://github.com/edx/edx-platform/tree/master/docs/decisions).
