### PR TITLE
Justify the course banner text to improve usablity

### DIFF
--- a/lms/templates/dashboard/_dashboard_course_listing.html
+++ b/lms/templates/dashboard/_dashboard_course_listing.html
@@ -458,7 +458,7 @@ from util.course import get_link_for_about_page, get_encoded_course_sharing_utm_
         % if course_mode_info and course_mode_info['show_upsell'] and not entitlement:
           <div class="message message-upsell has-actions is-shown">
             <div class="wrapper-extended">
-              <p class="message-copy" align="justify">
+              <p class="message-copy" align="auto">
                 <b class="message-copy-bold">
                   ${_("Pursue a {cert_name_long} to highlight the knowledge and skills you gain in this course.").format(cert_name_long=cert_name_long)}
                 </b><br>


### PR DESCRIPTION
## [PROD-1034](https://openedx.atlassian.net/browse/PROD-1034)
### Description

Course banner text is justified from both sides which is creating extra spaces between the text ultimately impacting on usability.To improve it, its alignment is modified and now it is no longer affecting usability.