### PR TITLE
Styling updates to Studio Unit Page Sequence navigation

### DIFF
--- a/cms/static/sass/elements-v2/_header.scss
+++ b/cms/static/sass/elements-v2/_header.scss
@@ -132,7 +132,7 @@
 
     .nav-account-user {
       .title {
-        max-width: ($baseline*6.5);
+        max-width: ($baseline*10.5);
         display: inline-block;
         max-width: 84%;
         overflow: hidden;

--- a/cms/static/sass/elements/_forms.scss
+++ b/cms/static/sass/elements/_forms.scss
@@ -395,7 +395,7 @@ form {
 
     display: inline-block;
     vertical-align: middle;
-    max-width: 80%;
+    max-width: 70%;
   }
 
   .incontext-editor-open-action,

--- a/cms/static/sass/elements/_header.scss
+++ b/cms/static/sass/elements/_header.scss
@@ -213,7 +213,7 @@
 
     .nav-account-user {
       .title {
-        max-width: ($baseline*6.5);
+        max-width: ($baseline*10.5);
 
         > .label {
           display: inline-block;

--- a/cms/static/sass/elements/_layout.scss
+++ b/cms/static/sass/elements/_layout.scss
@@ -98,7 +98,7 @@
     // layout with breadcrumb navigation
     &.has-navigation {
       .nav-actions {
-        bottom: $baseline;
+        top: -($baseline*2);
       }
 
       .navigation-item {

--- a/cms/static/sass/elements/_navigation.scss
+++ b/cms/static/sass/elements/_navigation.scss
@@ -210,7 +210,8 @@ nav {
 .jump-nav {
   .nav-item {
     display: inline-block;
-    margin-bottom: 20px;
+    margin-bottom: 5px;
+
 
     .title {
       &:hover,
@@ -252,7 +253,7 @@ $seq-nav-height: 40px;
   @extend .topbar;
 
   background-color: #fff;
-  margin: 0 auto $baseline;
+  margin: 0 auto;
   position: relative;
   border-bottom: none;
   z-index: 0;
@@ -494,6 +495,32 @@ $seq-nav-height: 40px;
 
       .icon {
         color: $seq-nav-icon-color;
+      }
+    }
+  }
+
+  // FontAwesome rtl chevron next - Learning Sequence Nav
+  .fa-chevron-next {
+    &::before {
+      @if $bi-app-direction == ltr {
+        content: "\f054"; // .fa-chevron-right
+      }
+
+      @else if $bi-app-direction == rtl {
+        content: "\f053"; // .fa-chevron-left
+      }
+    }
+  }
+
+  // FontAwesome rtl chevron prev - - Learning Sequence Nav
+  .fa-chevron-prev {
+    &::before {
+      @if $bi-app-direction == ltr {
+        content: "\f053"; // .fa-chevron-left
+      }
+
+      @else if $bi-app-direction == rtl {
+        content: "\f054"; // .fa-chevron-right
       }
     }
   }


### PR DESCRIPTION
**Changes:** 
(Also shown visually below) 
1.  Updated Studio header to account for longer usernames with overflow
2. Reduced padding between breadcrumbs and page title.
3. Reduced with of long page titles from 80% to 70% to avoid having page level sessions collide with page actions on the right. 
4. Minor update to ensure next / previous actions show their icons
5. Minor update to ensure active and hover sequence list items show the blue border-bottom
6. Moved up the right side page actions on breadcrumb pages. 

**JIRA:** https://openedx.atlassian.net/browse/TNL-7090

**Current Experience:** 
![image](https://user-images.githubusercontent.com/2023680/74607933-0616ab00-50ab-11ea-8e39-6415d79f02c1.png)

**Updated Experience**
![image](https://user-images.githubusercontent.com/2023680/74608002-85a47a00-50ab-11ea-96c6-d6e3d678fe45.png)

