### PR TITLE
Renamed OAuth2Authentication to BearerAuthentication

### DIFF
--- a/common/djangoapps/course_modes/api/v1/views.py
+++ b/common/djangoapps/course_modes/api/v1/views.py
@@ -16,7 +16,7 @@ from rest_framework.response import Response
 
 from course_modes.api.serializers import CourseModeSerializer
 from course_modes.models import CourseMode
-from openedx.core.lib.api.authentication import OAuth2AuthenticationAllowInactiveUser
+from openedx.core.lib.api.authentication import BearerAuthenticationAllowInactiveUser
 from openedx.core.lib.api.parsers import MergePatchParser
 
 log = logging.getLogger(__name__)
@@ -29,7 +29,7 @@ class CourseModesMixin(object):
     """
     authentication_classes = (
         JwtAuthentication,
-        OAuth2AuthenticationAllowInactiveUser,
+        BearerAuthenticationAllowInactiveUser,
         SessionAuthenticationAllowInactiveUser,
     )
     # When not considering JWT conditions, this permission class grants access

--- a/common/djangoapps/third_party_auth/api/views.py
+++ b/common/djangoapps/third_party_auth/api/views.py
@@ -19,8 +19,8 @@ from rest_framework.views import APIView
 from social_django.models import UserSocialAuth
 
 from openedx.core.lib.api.authentication import (
-    OAuth2Authentication,
-    OAuth2AuthenticationAllowInactiveUser
+    BearerAuthentication,
+    BearerAuthenticationAllowInactiveUser
 )
 from openedx.core.lib.api.permissions import ApiKeyHeaderPermission
 from third_party_auth import pipeline
@@ -67,7 +67,7 @@ class BaseUserView(APIView):
     authentication_classes = (
         # Users may want to view/edit the providers used for authentication before they've
         # activated their account, so we allow inactive users.
-        OAuth2AuthenticationAllowInactiveUser,
+        BearerAuthenticationAllowInactiveUser,
         SessionAuthenticationAllowInactiveUser,
     )
     throttle_classes = [ProviderSustainedThrottle, ProviderBurstThrottle]
@@ -335,7 +335,7 @@ class UserMappingView(ListAPIView):
             * remote_id: The Id from third party auth provider
     """
     authentication_classes = (
-        JwtAuthentication, OAuth2Authentication,
+        JwtAuthentication, BearerAuthentication,
     )
 
     serializer_class = serializers.UserMappingSerializer
@@ -402,7 +402,7 @@ class ThirdPartyAuthUserStatusView(APIView):
     user with respect to the third party auth providers configured in the system.
     """
     authentication_classes = (
-        JwtAuthentication, OAuth2AuthenticationAllowInactiveUser, SessionAuthenticationAllowInactiveUser
+        JwtAuthentication, BearerAuthenticationAllowInactiveUser, SessionAuthenticationAllowInactiveUser
     )
     permission_classes = (permissions.IsAuthenticated,)
 

--- a/lms/djangoapps/badges/api/views.py
+++ b/lms/djangoapps/badges/api/views.py
@@ -12,7 +12,7 @@ from rest_framework.exceptions import APIException
 
 from badges.models import BadgeAssertion
 from openedx.core.djangoapps.user_api.permissions import is_field_shared_factory
-from openedx.core.lib.api.authentication import OAuth2AuthenticationAllowInactiveUser
+from openedx.core.lib.api.authentication import BearerAuthenticationAllowInactiveUser
 
 from .serializers import BadgeAssertionSerializer
 
@@ -94,7 +94,7 @@ class UserBadgeAssertions(generics.ListAPIView):
     """
     serializer_class = BadgeAssertionSerializer
     authentication_classes = (
-        OAuth2AuthenticationAllowInactiveUser,
+        BearerAuthenticationAllowInactiveUser,
         SessionAuthenticationAllowInactiveUser
     )
     permission_classes = (is_field_shared_factory("accomplishments_shared"),)

--- a/lms/djangoapps/bulk_enroll/views.py
+++ b/lms/djangoapps/bulk_enroll/views.py
@@ -18,7 +18,7 @@ from lms.djangoapps.instructor.views.api import students_update_enrollment
 from openedx.core.djangoapps.course_groups.cohorts import add_user_to_cohort, get_cohort_by_name
 from openedx.core.djangoapps.course_groups.models import CourseUserGroup
 from openedx.core.djangoapps.enrollments.views import EnrollmentUserThrottle
-from openedx.core.lib.api.authentication import OAuth2Authentication
+from openedx.core.lib.api.authentication import BearerAuthentication
 from openedx.core.lib.api.permissions import IsStaff
 from util.disable_rate_limit import can_disable_rate_limit
 
@@ -68,7 +68,7 @@ class BulkEnrollView(APIView):
         to the 'before' and 'after' states.
     """
 
-    authentication_classes = (JwtAuthentication, OAuth2Authentication,)
+    authentication_classes = (JwtAuthentication, BearerAuthentication,)
     permission_classes = (IsStaff,)
     throttle_classes = (EnrollmentUserThrottle,)
 

--- a/lms/djangoapps/ccx/api/v0/views.py
+++ b/lms/djangoapps/ccx/api/v0/views.py
@@ -353,7 +353,7 @@ class CCXListView(GenericAPIView):
     """
     authentication_classes = (
         JwtAuthentication,
-        authentication.OAuth2AuthenticationAllowInactiveUser,
+        authentication.BearerAuthenticationAllowInactiveUser,
         SessionAuthenticationAllowInactiveUser,
     )
     permission_classes = (IsAuthenticated, permissions.IsMasterCourseStaffInstructor)
@@ -612,7 +612,7 @@ class CCXDetailView(GenericAPIView):
 
     authentication_classes = (
         JwtAuthentication,
-        authentication.OAuth2AuthenticationAllowInactiveUser,
+        authentication.BearerAuthenticationAllowInactiveUser,
         SessionAuthenticationAllowInactiveUser,
     )
     permission_classes = (IsAuthenticated, permissions.IsCourseStaffInstructor)

--- a/lms/djangoapps/certificates/apis/v0/views.py
+++ b/lms/djangoapps/certificates/apis/v0/views.py
@@ -21,7 +21,7 @@ from lms.djangoapps.certificates.api import get_certificate_for_user, get_certif
 from openedx.core.djangoapps.certificates.api import certificates_viewable_for_course
 from openedx.core.djangoapps.content.course_overviews.models import CourseOverview
 from openedx.core.djangoapps.user_api.accounts.api import visible_fields
-from openedx.core.lib.api.authentication import OAuth2AuthenticationAllowInactiveUser
+from openedx.core.lib.api.authentication import BearerAuthenticationAllowInactiveUser
 
 
 log = logging.getLogger(__name__)
@@ -85,7 +85,7 @@ class CertificatesDetailView(APIView):
 
     authentication_classes = (
         JwtAuthentication,
-        OAuth2AuthenticationAllowInactiveUser,
+        BearerAuthenticationAllowInactiveUser,
         SessionAuthenticationAllowInactiveUser,
     )
 
@@ -147,7 +147,7 @@ class CertificatesListView(APIView):
     """REST API endpoints for listing certificates."""
     authentication_classes = (
         JwtAuthentication,
-        OAuth2AuthenticationAllowInactiveUser,
+        BearerAuthenticationAllowInactiveUser,
         SessionAuthenticationAllowInactiveUser,
     )
     permission_classes = (

--- a/lms/djangoapps/commerce/api/v0/views.py
+++ b/lms/djangoapps/commerce/api/v0/views.py
@@ -23,7 +23,7 @@ from openedx.core.djangoapps.embargo import api as embargo_api
 from openedx.core.djangoapps.enrollments.api import add_enrollment
 from openedx.core.djangoapps.enrollments.views import EnrollmentCrossDomainSessionAuth
 from openedx.core.djangoapps.user_api.preferences.api import update_email_opt_in
-from openedx.core.lib.api.authentication import OAuth2AuthenticationAllowInactiveUser
+from openedx.core.lib.api.authentication import BearerAuthenticationAllowInactiveUser
 from student.models import CourseEnrollment
 from student.signals import SAILTHRU_AUDIT_PURCHASE
 from util.json_request import JsonResponse
@@ -40,7 +40,7 @@ class BasketsView(APIView):
 
     # LMS utilizes User.user_is_active to indicate email verification, not whether an account is active. Sigh!
     authentication_classes = (JwtAuthentication,
-                              OAuth2AuthenticationAllowInactiveUser,
+                              BearerAuthenticationAllowInactiveUser,
                               EnrollmentCrossDomainSessionAuth)
     permission_classes = (IsAuthenticated,)
 

--- a/lms/djangoapps/commerce/api/v1/views.py
+++ b/lms/djangoapps/commerce/api/v1/views.py
@@ -13,7 +13,7 @@ from rest_framework.authentication import SessionAuthentication
 from rest_framework.generics import ListAPIView, RetrieveUpdateAPIView
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.views import APIView
-from openedx.core.lib.api.authentication import OAuth2Authentication
+from openedx.core.lib.api.authentication import BearerAuthentication
 
 from course_modes.models import CourseMode
 from openedx.core.djangoapps.commerce.utils import ecommerce_api_client
@@ -30,7 +30,7 @@ log = logging.getLogger(__name__)
 
 class CourseListView(ListAPIView):
     """ List courses and modes. """
-    authentication_classes = (JwtAuthentication, OAuth2Authentication, SessionAuthentication,)
+    authentication_classes = (JwtAuthentication, BearerAuthentication, SessionAuthentication,)
     permission_classes = (IsAuthenticated,)
     serializer_class = CourseSerializer
     pagination_class = None
@@ -44,7 +44,7 @@ class CourseRetrieveUpdateView(PutAsCreateMixin, RetrieveUpdateAPIView):
     lookup_field = 'id'
     lookup_url_kwarg = 'course_id'
     model = CourseMode
-    authentication_classes = (JwtAuthentication, OAuth2Authentication, SessionAuthentication,)
+    authentication_classes = (JwtAuthentication, BearerAuthentication, SessionAuthentication,)
     permission_classes = (ApiKeyOrModelPermission,)
     serializer_class = CourseSerializer
 

--- a/lms/djangoapps/courseware/module_render.py
+++ b/lms/djangoapps/courseware/module_render.py
@@ -68,7 +68,7 @@ from openedx.core.djangoapps.crawlers.models import CrawlersConfig
 from openedx.core.djangoapps.credit.services import CreditService
 from openedx.core.djangoapps.util.user_utils import SystemUser
 from openedx.core.djangolib.markup import HTML
-from openedx.core.lib.api.authentication import OAuth2AuthenticationAllowInactiveUser
+from openedx.core.lib.api.authentication import BearerAuthenticationAllowInactiveUser
 from openedx.core.lib.api.view_utils import view_auth_classes
 from openedx.core.lib.gating.services import GatingService
 from openedx.core.lib.license import wrap_with_license
@@ -1033,7 +1033,7 @@ def handle_xblock_callback(request, course_id, usage_id, handler, suffix=None):
     # to avoid introducing backwards-incompatible changes.
     # You can see https://github.com/edx/XBlock/pull/383 for more details.
     else:
-        authentication_classes = (JwtAuthentication, OAuth2AuthenticationAllowInactiveUser)
+        authentication_classes = (JwtAuthentication, BearerAuthenticationAllowInactiveUser)
         authenticators = [auth() for auth in authentication_classes]
 
         for authenticator in authenticators:

--- a/lms/djangoapps/discussion/rest_api/views.py
+++ b/lms/djangoapps/discussion/rest_api/views.py
@@ -56,7 +56,7 @@ from openedx.core.djangoapps.django_comment_common.utils import (
 )
 from openedx.core.djangoapps.user_api.accounts.permissions import CanReplaceUsername, CanRetireUser
 from openedx.core.djangoapps.user_api.models import UserRetirementStatus
-from openedx.core.lib.api.authentication import OAuth2AuthenticationAllowInactiveUser
+from openedx.core.lib.api.authentication import BearerAuthenticationAllowInactiveUser
 
 from openedx.core.lib.api.parsers import MergePatchParser
 from openedx.core.lib.api.view_utils import DeveloperErrorViewMixin, view_auth_classes
@@ -753,7 +753,7 @@ class CourseDiscussionSettingsAPIView(DeveloperErrorViewMixin, APIView):
     """
     authentication_classes = (
         JwtAuthentication,
-        OAuth2AuthenticationAllowInactiveUser,
+        BearerAuthenticationAllowInactiveUser,
         SessionAuthenticationAllowInactiveUser,
     )
     parser_classes = (JSONParser, MergePatchParser,)
@@ -888,7 +888,7 @@ class CourseDiscussionRolesAPIView(DeveloperErrorViewMixin, APIView):
     """
     authentication_classes = (
         JwtAuthentication,
-        OAuth2AuthenticationAllowInactiveUser,
+        BearerAuthenticationAllowInactiveUser,
         SessionAuthenticationAllowInactiveUser,
     )
     permission_classes = (permissions.IsAuthenticated, permissions.IsAdminUser)

--- a/lms/djangoapps/experiments/views_custom.py
+++ b/lms/djangoapps/experiments/views_custom.py
@@ -19,7 +19,7 @@ from rest_framework.views import APIView
 from openedx.core.djangoapps.content.course_overviews.models import CourseOverview
 from openedx.core.djangoapps.cors_csrf.decorators import ensure_csrf_cookie_cross_domain
 from openedx.core.djangoapps.waffle_utils import WaffleFlag, WaffleFlagNamespace
-from openedx.core.lib.api.authentication import OAuth2AuthenticationAllowInactiveUser
+from openedx.core.lib.api.authentication import BearerAuthenticationAllowInactiveUser
 from openedx.core.lib.api.permissions import ApiKeyHeaderPermissionIsAuthenticated
 from openedx.core.lib.api.view_utils import DeveloperErrorViewMixin
 
@@ -100,7 +100,7 @@ class Rev934(DeveloperErrorViewMixin, APIView):
 
     authentication_classes = (
         JwtAuthentication,
-        OAuth2AuthenticationAllowInactiveUser,
+        BearerAuthenticationAllowInactiveUser,
         SessionAuthenticationAllowInactiveUser,
     )
     permission_classes = (ApiKeyHeaderPermissionIsAuthenticated,)

--- a/lms/djangoapps/grades/rest_api/v1/views.py
+++ b/lms/djangoapps/grades/rest_api/v1/views.py
@@ -16,7 +16,7 @@ from lms.djangoapps.courseware.access import has_access
 from lms.djangoapps.grades.api import CourseGradeFactory, clear_prefetched_course_grades, prefetch_course_grades
 from lms.djangoapps.grades.rest_api.serializers import GradingPolicySerializer
 from lms.djangoapps.grades.rest_api.v1.utils import CourseEnrollmentPagination, GradeViewMixin
-from openedx.core.lib.api.authentication import OAuth2AuthenticationAllowInactiveUser
+from openedx.core.lib.api.authentication import BearerAuthenticationAllowInactiveUser
 from openedx.core.lib.api.view_utils import PaginatedAPIView, get_course_key, verify_course_exists
 from xmodule.modulestore.django import modulestore
 
@@ -91,7 +91,7 @@ class CourseGradesView(GradeViewMixin, PaginatedAPIView):
     """
     authentication_classes = (
         JwtAuthentication,
-        OAuth2AuthenticationAllowInactiveUser,
+        BearerAuthenticationAllowInactiveUser,
         SessionAuthenticationAllowInactiveUser,
     )
 
@@ -171,7 +171,7 @@ class CourseGradingPolicy(GradeViewMixin, ListAPIView):
 
     authentication_classes = (
         JwtAuthentication,
-        OAuth2AuthenticationAllowInactiveUser,
+        BearerAuthenticationAllowInactiveUser,
         SessionAuthenticationAllowInactiveUser,
     )
 

--- a/lms/djangoapps/instructor/views/api.py
+++ b/lms/djangoapps/instructor/views/api.py
@@ -94,7 +94,7 @@ from openedx.core.djangoapps.django_comment_common.models import (
 from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
 from openedx.core.djangoapps.user_api.preferences.api import get_user_preference, set_user_preference
 from openedx.core.djangolib.markup import HTML, Text
-from openedx.core.lib.api.authentication import OAuth2AuthenticationAllowInactiveUser
+from openedx.core.lib.api.authentication import BearerAuthenticationAllowInactiveUser
 from openedx.core.lib.api.view_utils import DeveloperErrorViewMixin
 from shoppingcart.models import (
     Coupon,
@@ -1474,7 +1474,7 @@ class CohortCSV(DeveloperErrorViewMixin, APIView):
     """
     authentication_classes = (
         JwtAuthentication,
-        OAuth2AuthenticationAllowInactiveUser,
+        BearerAuthenticationAllowInactiveUser,
         SessionAuthenticationAllowInactiveUser,
     )
     permission_classes = (permissions.IsAuthenticated, permissions.IsAdminUser)

--- a/lms/djangoapps/program_enrollments/rest_api/v1/views.py
+++ b/lms/djangoapps/program_enrollments/rest_api/v1/views.py
@@ -47,7 +47,7 @@ from openedx.core.djangoapps.catalog.utils import (
     normalize_program_type
 )
 from openedx.core.djangoapps.content.course_overviews.models import CourseOverview
-from openedx.core.lib.api.authentication import OAuth2AuthenticationAllowInactiveUser
+from openedx.core.lib.api.authentication import BearerAuthenticationAllowInactiveUser
 from openedx.core.lib.api.view_utils import DeveloperErrorViewMixin, PaginatedAPIView
 from student.helpers import get_resume_urls_for_enrollments
 from student.models import CourseEnrollment
@@ -328,7 +328,7 @@ class ProgramEnrollmentsView(
     """
     authentication_classes = (
         JwtAuthentication,
-        OAuth2AuthenticationAllowInactiveUser,
+        BearerAuthenticationAllowInactiveUser,
         SessionAuthenticationAllowInactiveUser,
     )
     permission_classes = (permissions.JWT_RESTRICTED_APPLICATION_OR_USER_ACCESS,)
@@ -472,7 +472,7 @@ class ProgramCourseEnrollmentsView(
     """
     authentication_classes = (
         JwtAuthentication,
-        OAuth2AuthenticationAllowInactiveUser,
+        BearerAuthenticationAllowInactiveUser,
         SessionAuthenticationAllowInactiveUser,
     )
     permission_classes = (permissions.JWT_RESTRICTED_APPLICATION_OR_USER_ACCESS,)
@@ -614,7 +614,7 @@ class ProgramCourseGradesView(
     """
     authentication_classes = (
         JwtAuthentication,
-        OAuth2AuthenticationAllowInactiveUser,
+        BearerAuthenticationAllowInactiveUser,
         SessionAuthenticationAllowInactiveUser,
     )
     permission_classes = (permissions.JWT_RESTRICTED_APPLICATION_OR_USER_ACCESS,)
@@ -695,7 +695,7 @@ class UserProgramReadOnlyAccessView(DeveloperErrorViewMixin, PaginatedAPIView):
     """
     authentication_classes = (
         JwtAuthentication,
-        OAuth2AuthenticationAllowInactiveUser,
+        BearerAuthenticationAllowInactiveUser,
         SessionAuthenticationAllowInactiveUser,
     )
     permission_classes = (IsAuthenticated,)
@@ -874,7 +874,7 @@ class ProgramCourseEnrollmentOverviewView(
     """
     authentication_classes = (
         JwtAuthentication,
-        OAuth2AuthenticationAllowInactiveUser,
+        BearerAuthenticationAllowInactiveUser,
         SessionAuthenticationAllowInactiveUser,
     )
     permission_classes = (IsAuthenticated,)
@@ -983,7 +983,7 @@ class EnrollmentDataResetView(APIView):
     """
     authentication_classes = (
         JwtAuthentication,
-        OAuth2AuthenticationAllowInactiveUser,
+        BearerAuthenticationAllowInactiveUser,
         SessionAuthenticationAllowInactiveUser,
     )
     permission_classes = (permissions.JWT_RESTRICTED_APPLICATION_OR_USER_ACCESS,)

--- a/lms/djangoapps/teams/views.py
+++ b/lms/djangoapps/teams/views.py
@@ -26,7 +26,7 @@ from rest_framework.generics import GenericAPIView
 from rest_framework.response import Response
 from rest_framework.reverse import reverse
 from rest_framework.views import APIView
-from openedx.core.lib.api.authentication import OAuth2Authentication
+from openedx.core.lib.api.authentication import BearerAuthentication
 
 from lms.djangoapps.courseware.courses import get_course_with_access, has_access
 from lms.djangoapps.discussion.django_comment_client.utils import has_discussion_privileges
@@ -367,8 +367,8 @@ class TeamsListView(ExpandableFieldViewMixin, GenericAPIView):
             If the specified course does not exist, a 404 error is returned.
     """
 
-    # OAuth2Authentication must come first to return a 401 for unauthenticated users
-    authentication_classes = (OAuth2Authentication, SessionAuthentication)
+    # BearerAuthentication must come first to return a 401 for unauthenticated users
+    authentication_classes = (BearerAuthentication, SessionAuthentication)
     permission_classes = (permissions.IsAuthenticated,)
     serializer_class = CourseTeamSerializer
 
@@ -696,7 +696,7 @@ class TeamsDetailView(ExpandableFieldViewMixin, RetrievePatchAPIView):
             If the user is logged in and the team does not exist, a 404 is returned.
 
     """
-    authentication_classes = (OAuth2Authentication, SessionAuthentication)
+    authentication_classes = (BearerAuthentication, SessionAuthentication)
     permission_classes = (permissions.IsAuthenticated, IsStaffOrPrivilegedOrReadOnly, IsEnrolledOrIsStaff,)
     lookup_field = 'team_id'
     serializer_class = CourseTeamSerializer
@@ -791,7 +791,7 @@ class TopicListView(GenericAPIView):
                   those teams whose members are outside of institutions affliation.
     """
 
-    authentication_classes = (OAuth2Authentication, SessionAuthentication)
+    authentication_classes = (BearerAuthentication, SessionAuthentication)
     permission_classes = (permissions.IsAuthenticated,)
     pagination_class = TopicsPagination
 
@@ -922,7 +922,7 @@ class TopicDetailView(APIView):
                   those teams whose members are outside of institutions affliation.
     """
 
-    authentication_classes = (OAuth2Authentication, SessionAuthentication)
+    authentication_classes = (BearerAuthentication, SessionAuthentication)
     permission_classes = (permissions.IsAuthenticated,)
 
     def get(self, request, topic_id, course_id):
@@ -1082,7 +1082,7 @@ class MembershipListView(ExpandableFieldViewMixin, GenericAPIView):
             another user to a team.
     """
 
-    authentication_classes = (OAuth2Authentication, SessionAuthentication)
+    authentication_classes = (BearerAuthentication, SessionAuthentication)
     permission_classes = (permissions.IsAuthenticated,)
     serializer_class = MembershipSerializer
 
@@ -1295,7 +1295,7 @@ class MembershipDetailView(ExpandableFieldViewMixin, GenericAPIView):
             If the membership does not exist, a 404 error is returned.
     """
 
-    authentication_classes = (OAuth2Authentication, SessionAuthentication)
+    authentication_classes = (BearerAuthentication, SessionAuthentication)
     permission_classes = (permissions.IsAuthenticated,)
 
     serializer_class = MembershipSerializer
@@ -1365,7 +1365,7 @@ class MembershipBulkManagementView(GenericAPIView):
     View for uploading and downloading team membership CSVs.
     """
 
-    authentication_classes = (OAuth2Authentication, SessionAuthentication)
+    authentication_classes = (BearerAuthentication, SessionAuthentication)
     permission_classes = (permissions.IsAuthenticated,)
 
     def get(self, request, **_kwargs):

--- a/openedx/core/djangoapps/api_admin/api/v1/views.py
+++ b/openedx/core/djangoapps/api_admin/api/v1/views.py
@@ -8,7 +8,7 @@ from edx_rest_framework_extensions.auth.jwt.authentication import JwtAuthenticat
 from rest_framework.authentication import SessionAuthentication
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.generics import ListAPIView
-from openedx.core.lib.api.authentication import OAuth2Authentication
+from openedx.core.lib.api.authentication import BearerAuthentication
 
 from openedx.core.djangoapps.api_admin.api.v1 import serializers as api_access_serializers
 from openedx.core.djangoapps.api_admin.models import ApiAccessRequest
@@ -50,7 +50,7 @@ class ApiAccessRequestView(ListAPIView):
             "previous": null
         }
     """
-    authentication_classes = (JwtAuthentication, OAuth2Authentication, SessionAuthentication,)
+    authentication_classes = (JwtAuthentication, BearerAuthentication, SessionAuthentication,)
     permission_classes = (IsAuthenticated, )
     serializer_class = api_access_serializers.ApiAccessRequestSerializer
     filter_backends = (IsOwnerOrStaffFilterBackend, DjangoFilterBackend)

--- a/openedx/core/djangoapps/auth_exchange/views.py
+++ b/openedx/core/djangoapps/auth_exchange/views.py
@@ -30,7 +30,7 @@ from rest_framework.views import APIView
 from openedx.core.djangoapps.auth_exchange.forms import AccessTokenExchangeForm
 from openedx.core.djangoapps.oauth_dispatch import adapters
 from openedx.core.djangoapps.oauth_dispatch.api import create_dot_access_token
-from openedx.core.lib.api.authentication import OAuth2AuthenticationAllowInactiveUser
+from openedx.core.lib.api.authentication import BearerAuthenticationAllowInactiveUser
 
 
 class AccessTokenExchangeBase(APIView):
@@ -131,7 +131,7 @@ class LoginWithAccessTokenView(APIView):
     """
     View for exchanging an access token for session cookies
     """
-    authentication_classes = (OAuth2AuthenticationAllowInactiveUser,)
+    authentication_classes = (BearerAuthenticationAllowInactiveUser,)
     permission_classes = (permissions.IsAuthenticated,)
 
     @staticmethod

--- a/openedx/core/djangoapps/bookmarks/views.py
+++ b/openedx/core/djangoapps/bookmarks/views.py
@@ -23,7 +23,7 @@ from rest_framework.generics import ListCreateAPIView
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
-from openedx.core.lib.api.authentication import OAuth2Authentication
+from openedx.core.lib.api.authentication import BearerAuthentication
 from openedx.core.djangoapps.bookmarks.api import BookmarksLimitReachedError
 from openedx.core.lib.api.permissions import IsUserInUrl
 from openedx.core.lib.url_utils import unquote_slashes
@@ -100,7 +100,7 @@ class BookmarksViewMixin(object):
 class BookmarksListView(ListCreateAPIView, BookmarksViewMixin):
     """REST endpoints for lists of bookmarks."""
 
-    authentication_classes = (OAuth2Authentication, SessionAuthentication,)
+    authentication_classes = (BearerAuthentication, SessionAuthentication,)
     pagination_class = BookmarksPagination
     permission_classes = (permissions.IsAuthenticated,)
     serializer_class = BookmarkSerializer
@@ -292,7 +292,7 @@ class BookmarksDetailView(APIView, BookmarksViewMixin):
         if the bookmark does not exist.
     """
 
-    authentication_classes = (OAuth2Authentication, SessionAuthentication)
+    authentication_classes = (BearerAuthentication, SessionAuthentication)
     permission_classes = (permissions.IsAuthenticated, IsUserInUrl)
 
     serializer_class = BookmarkSerializer

--- a/openedx/core/djangoapps/course_groups/views.py
+++ b/openedx/core/djangoapps/course_groups/views.py
@@ -28,7 +28,7 @@ from rest_framework.serializers import Serializer
 from lms.djangoapps.courseware.courses import get_course, get_course_with_access
 from edxmako.shortcuts import render_to_response
 from openedx.core.djangoapps.course_groups.models import CohortMembership
-from openedx.core.lib.api.authentication import OAuth2AuthenticationAllowInactiveUser
+from openedx.core.lib.api.authentication import BearerAuthenticationAllowInactiveUser
 from openedx.core.lib.api.view_utils import DeveloperErrorViewMixin
 from student.auth import has_course_author_access
 from util.json_request import JsonResponse, expect_json
@@ -429,7 +429,7 @@ class APIPermissions(GenericAPIView):
     """
     authentication_classes = (
         JwtAuthentication,
-        OAuth2AuthenticationAllowInactiveUser,
+        BearerAuthenticationAllowInactiveUser,
         SessionAuthenticationAllowInactiveUser,
     )
     permission_classes = (permissions.IsAuthenticated, permissions.IsAdminUser)

--- a/openedx/core/djangoapps/credit/views.py
+++ b/openedx/core/djangoapps/credit/views.py
@@ -18,7 +18,7 @@ from rest_framework import generics, mixins, permissions, views, viewsets
 from rest_framework.authentication import SessionAuthentication
 from rest_framework.exceptions import ValidationError
 from rest_framework.response import Response
-from openedx.core.lib.api.authentication import OAuth2Authentication
+from openedx.core.lib.api.authentication import BearerAuthentication
 from six import text_type
 
 from openedx.core.djangoapps.credit.api import create_credit_request
@@ -45,7 +45,7 @@ from openedx.core.lib.api.mixins import PutAsCreateMixin
 from openedx.core.lib.api.permissions import IsStaffOrOwner
 
 log = logging.getLogger(__name__)
-AUTHENTICATION_CLASSES = (JwtAuthentication, OAuth2Authentication, SessionAuthentication,)
+AUTHENTICATION_CLASSES = (JwtAuthentication, BearerAuthentication, SessionAuthentication,)
 
 
 class CreditProviderViewSet(viewsets.ReadOnlyModelViewSet):

--- a/openedx/core/djangoapps/enrollments/views.py
+++ b/openedx/core/djangoapps/enrollments/views.py
@@ -30,7 +30,7 @@ from openedx.core.djangoapps.enrollments.serializers import CourseEnrollmentsApi
 from openedx.core.djangoapps.user_api.accounts.permissions import CanRetireUser
 from openedx.core.djangoapps.user_api.models import UserRetirementStatus
 from openedx.core.djangoapps.user_api.preferences.api import update_email_opt_in
-from openedx.core.lib.api.authentication import OAuth2AuthenticationAllowInactiveUser
+from openedx.core.lib.api.authentication import BearerAuthenticationAllowInactiveUser
 from openedx.core.lib.api.permissions import ApiKeyHeaderPermission, ApiKeyHeaderPermissionIsAuthenticated
 from openedx.core.lib.api.view_utils import DeveloperErrorViewMixin
 from openedx.core.lib.exceptions import CourseNotFoundError
@@ -168,7 +168,7 @@ class EnrollmentView(APIView, ApiKeyPermissionMixIn):
 
     authentication_classes = (
         JwtAuthentication,
-        OAuth2AuthenticationAllowInactiveUser,
+        BearerAuthenticationAllowInactiveUser,
         SessionAuthenticationAllowInactiveUser,
     )
     permission_classes = (ApiKeyHeaderPermissionIsAuthenticated,)
@@ -243,7 +243,7 @@ class EnrollmentUserRolesView(APIView):
     """
     authentication_classes = (
         JwtAuthentication,
-        OAuth2AuthenticationAllowInactiveUser,
+        BearerAuthenticationAllowInactiveUser,
         EnrollmentCrossDomainSessionAuth,
     )
     permission_classes = (ApiKeyHeaderPermissionIsAuthenticated,)
@@ -612,7 +612,7 @@ class EnrollmentListView(APIView, ApiKeyPermissionMixIn):
     """
     authentication_classes = (
         JwtAuthentication,
-        OAuth2AuthenticationAllowInactiveUser,
+        BearerAuthenticationAllowInactiveUser,
         EnrollmentCrossDomainSessionAuth,
     )
     permission_classes = (ApiKeyHeaderPermissionIsAuthenticated,)
@@ -940,7 +940,7 @@ class CourseEnrollmentsApiListView(DeveloperErrorViewMixin, ListAPIView):
     """
     authentication_classes = (
         JwtAuthentication,
-        OAuth2AuthenticationAllowInactiveUser,
+        BearerAuthenticationAllowInactiveUser,
         SessionAuthenticationAllowInactiveUser,
     )
     permission_classes = (permissions.IsAdminUser,)

--- a/openedx/core/djangoapps/profile_images/views.py
+++ b/openedx/core/djangoapps/profile_images/views.py
@@ -20,7 +20,7 @@ from six import text_type
 
 from openedx.core.djangoapps.user_api.accounts.image_helpers import get_profile_image_names, set_has_profile_image
 from openedx.core.djangoapps.user_api.errors import UserNotFound
-from openedx.core.lib.api.authentication import OAuth2AuthenticationAllowInactiveUser
+from openedx.core.lib.api.authentication import BearerAuthenticationAllowInactiveUser
 from openedx.core.lib.api.parsers import TypedFileUploadParser
 from openedx.core.lib.api.permissions import IsUserInUrl
 from openedx.core.lib.api.view_utils import DeveloperErrorViewMixin
@@ -115,7 +115,7 @@ class ProfileImageView(DeveloperErrorViewMixin, APIView):
     parser_classes = (MultiPartParser, FormParser, TypedFileUploadParser)
     authentication_classes = (
         JwtAuthentication,
-        OAuth2AuthenticationAllowInactiveUser,
+        BearerAuthenticationAllowInactiveUser,
         SessionAuthenticationAllowInactiveUser,
     )
     permission_classes = (permissions.IsAuthenticated, IsUserInUrl)

--- a/openedx/core/djangoapps/user_api/accounts/views.py
+++ b/openedx/core/djangoapps/user_api/accounts/views.py
@@ -49,7 +49,7 @@ from openedx.core.djangoapps.profile_images.images import remove_profile_images
 from openedx.core.djangoapps.user_api.accounts.image_helpers import get_profile_image_names, set_has_profile_image
 from openedx.core.djangoapps.user_authn.exceptions import AuthFailedError
 from openedx.core.djangolib.oauth2_retirement_utils import retire_dop_oauth2_models, retire_dot_oauth2_models
-from openedx.core.lib.api.authentication import OAuth2AuthenticationAllowInactiveUser
+from openedx.core.lib.api.authentication import BearerAuthenticationAllowInactiveUser
 from openedx.core.lib.api.parsers import MergePatchParser
 from student.models import (
     AccountRecovery,
@@ -267,7 +267,7 @@ class AccountViewSet(ViewSet):
             If the update is successful, updated user account data is returned.
     """
     authentication_classes = (
-        JwtAuthentication, OAuth2AuthenticationAllowInactiveUser, SessionAuthenticationAllowInactiveUser
+        JwtAuthentication, BearerAuthenticationAllowInactiveUser, SessionAuthenticationAllowInactiveUser
     )
     permission_classes = (permissions.IsAuthenticated,)
     parser_classes = (MergePatchParser,)

--- a/openedx/core/djangoapps/user_api/preferences/views.py
+++ b/openedx/core/djangoapps/user_api/preferences/views.py
@@ -14,7 +14,7 @@ from rest_framework import permissions, status
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
-from openedx.core.lib.api.authentication import OAuth2AuthenticationAllowInactiveUser
+from openedx.core.lib.api.authentication import BearerAuthenticationAllowInactiveUser
 from openedx.core.lib.api.parsers import MergePatchParser
 from openedx.core.lib.api.permissions import IsUserInUrlOrStaff
 
@@ -91,7 +91,7 @@ class PreferencesView(APIView):
     """
     authentication_classes = (
         JwtAuthentication,
-        OAuth2AuthenticationAllowInactiveUser,
+        BearerAuthenticationAllowInactiveUser,
         SessionAuthenticationAllowInactiveUser,
     )
     permission_classes = (permissions.IsAuthenticated, IsUserInUrlOrStaff)
@@ -202,7 +202,7 @@ class PreferencesDetailView(APIView):
             If the update is successful, an HTTP 204 "No Content" response is
             returned with no additional content.
     """
-    authentication_classes = (OAuth2AuthenticationAllowInactiveUser, SessionAuthenticationAllowInactiveUser)
+    authentication_classes = (BearerAuthenticationAllowInactiveUser, SessionAuthenticationAllowInactiveUser)
     permission_classes = (permissions.IsAuthenticated, IsUserInUrlOrStaff)
 
     def get(self, request, username, preference_key):

--- a/openedx/core/djangoapps/user_api/verification_api/views.py
+++ b/openedx/core/djangoapps/user_api/verification_api/views.py
@@ -5,7 +5,7 @@ from django.http import Http404
 from edx_rest_framework_extensions.auth.jwt.authentication import JwtAuthentication
 from rest_framework.authentication import SessionAuthentication
 from rest_framework.generics import RetrieveAPIView
-from openedx.core.lib.api.authentication import OAuth2Authentication
+from openedx.core.lib.api.authentication import BearerAuthentication
 
 from lms.djangoapps.verify_student.models import ManualVerification, SoftwareSecurePhotoVerification, SSOVerification
 from lms.djangoapps.verify_student.utils import most_recent_verification
@@ -19,7 +19,7 @@ from openedx.core.lib.api.permissions import IsStaffOrOwner
 
 class IDVerificationStatusView(RetrieveAPIView):
     """ IDVerificationStatus detail endpoint. """
-    authentication_classes = (JwtAuthentication, OAuth2Authentication, SessionAuthentication,)
+    authentication_classes = (JwtAuthentication, BearerAuthentication, SessionAuthentication,)
     permission_classes = (IsStaffOrOwner,)
 
     def get_serializer(self, *args, **kwargs):

--- a/openedx/core/lib/api/authentication.py
+++ b/openedx/core/lib/api/authentication.py
@@ -159,3 +159,17 @@ class BearerAuthenticationAllowInactiveUser(BearerAuthentication):
     """
 
     allow_inactive_users = True
+
+
+class OAuth2Authentication(BearerAuthentication):
+    """
+    Creating temperary class cause things outside of edx-platform need OAuth2Authentication.
+    This will be removed when repos outside edx-platform import BearerAuthentiction instead.
+    """
+
+
+class OAuth2AuthenticationAllowInactiveUser(BearerAuthenticationAllowInactiveUser):
+    """
+    Creating temperary class cause things outside of edx-platform need OAuth2Authentication.
+    This will be removed when repos outside edx-platform import BearerAuthentiction instead.
+    """

--- a/openedx/core/lib/api/authentication.py
+++ b/openedx/core/lib/api/authentication.py
@@ -20,9 +20,9 @@ OAUTH2_USER_NOT_ACTIVE_ERROR = 'user_not_active'
 logger = logging.getLogger(__name__)
 
 
-class OAuth2Authentication(BaseAuthentication):
+class BearerAuthentication(BaseAuthentication):
     """
-    OAuth 2 authentication backend using either `django-oauth2-provider` or 'django-oauth-toolkit'
+    BearerAuthentication backend using either `django-oauth2-provider` or 'django-oauth-toolkit'
     """
 
     www_authenticate_realm = 'api'
@@ -40,7 +40,7 @@ class OAuth2Authentication(BaseAuthentication):
         fails.
         """
 
-        set_custom_metric("OAuth2Authentication", "Failed")  # default value
+        set_custom_metric("BearerAuthentication", "Failed")  # default value
         auth = get_authorization_header(request).split()
 
         if len(auth) == 1:
@@ -54,19 +54,13 @@ class OAuth2Authentication(BaseAuthentication):
 
         if auth and auth[0].lower() == b'bearer':
             access_token = auth[1].decode('utf8')
-            set_custom_metric('OAuth2Authentication_token_location', 'bearer-in-header')
-        elif 'access_token' in request.POST:
-            access_token = request.POST['access_token']
-            set_custom_metric('OAuth2Authentication_token_location', 'post-token')
         else:
-            set_custom_metric("OAuth2Authentication", "None")
+            set_custom_metric("BearerAuthentication", "None")
             return None
-
-        set_custom_metric("OAuth2Authentication_token_parts", len(access_token.split('.')))
 
         user, token = self.authenticate_credentials(access_token)
 
-        set_custom_metric("OAuth2Authentication", "Success")
+        set_custom_metric("BearerAuthentication", "Success")
 
         return user, token
 
@@ -100,13 +94,13 @@ class OAuth2Authentication(BaseAuthentication):
             user = token.user
             # Check to make sure the users have activated their account (by confirming their email)
             if not self.allow_inactive_users and not user.is_active:
-                set_custom_metric("OAuth2Authentication_user_active", False)
+                set_custom_metric("BearerAuthentication_user_active", False)
                 msg = 'User inactive or deleted: %s' % user.get_username()
                 raise AuthenticationFailed({
                     'error_code': OAUTH2_USER_NOT_ACTIVE_ERROR,
                     'developer_message': msg})
             else:
-                set_custom_metric("OAuth2Authentication_user_active", True)
+                set_custom_metric("BearerAuthentication_user_active", True)
 
             return user, token
 
@@ -117,15 +111,15 @@ class OAuth2Authentication(BaseAuthentication):
         """
         dot_token_return = self._get_dot_token(access_token)
         if dot_token_return is not None:
-            set_custom_metric('OAuth2Authentication_token_type', 'dot')
+            set_custom_metric('BearerAuthentication_token_type', 'dot')
             return dot_token_return
 
         dop_token_return = self._get_dop_token(access_token)
         if dop_token_return is not None:
-            set_custom_metric('OAuth2Authentication_token_type', 'dop')
+            set_custom_metric('BearerAuthentication_token_type', 'dop')
             return dop_token_return
 
-        set_custom_metric('OAuth2Authentication_token_type', 'None')
+        set_custom_metric('BearerAuthentication_token_type', 'None')
         return None
 
     def _get_dop_token(self, access_token):
@@ -152,7 +146,7 @@ class OAuth2Authentication(BaseAuthentication):
         return 'Bearer realm="%s"' % self.www_authenticate_realm
 
 
-class OAuth2AuthenticationAllowInactiveUser(OAuth2Authentication):
+class BearerAuthenticationAllowInactiveUser(BearerAuthentication):
     """
     Currently, is_active field on the user is coupled
     with whether or not the user has verified ownership of their claimed email address.

--- a/openedx/core/lib/api/tests/test_authentication.py
+++ b/openedx/core/lib/api/tests/test_authentication.py
@@ -182,13 +182,6 @@ class OAuth2AllowInActiveUsersTests(TestCase):
         response = self.get_with_bearer_token(self.OAUTH2_BASE_TESTING_URL, token=self.dot_access_token.token)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
-    def test_post_form_passing_auth_url_transport(self):
-        """Ensure GETing form over OAuth with correct client credentials in form data succeed"""
-        response = self.csrf_client.post(
-            self.OAUTH2_BASE_TESTING_URL,
-            data={'access_token': self.access_token.token}
-        )
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
 
     def test_get_form_failing_auth_url_transport(self):
         """Ensure GETing form over OAuth with correct client credentials in query fails when DEBUG is False"""

--- a/openedx/core/lib/api/tests/test_authentication.py
+++ b/openedx/core/lib/api/tests/test_authentication.py
@@ -1,6 +1,6 @@
 """
 Tests for OAuth2.  This module is copied from django-rest-framework-oauth
-(tests/test_authentication.py) and updated to use our subclass of OAuth2Authentication.
+(tests/test_authentication.py) and updated to use our subclass of BearerAuthentication.
 """
 
 
@@ -50,11 +50,11 @@ urlpatterns = [
     url(r'^oauth2/', include(('provider.oauth2.urls', 'oauth2'), namespace='oauth2')),
     url(
         r'^oauth2-inactive-test/$',
-        MockView.as_view(authentication_classes=[authentication.OAuth2AuthenticationAllowInactiveUser])
+        MockView.as_view(authentication_classes=[authentication.BearerAuthenticationAllowInactiveUser])
     ),
     url(
         r'^oauth2-test/$',
-        MockView.as_view(authentication_classes=[authentication.OAuth2Authentication])
+        MockView.as_view(authentication_classes=[authentication.BearerAuthentication])
     )
 ]
 
@@ -265,12 +265,12 @@ class OAuth2AllowInActiveUsersTests(TestCase):
         self.check_error_codes(response, status_code=status.HTTP_401_UNAUTHORIZED, error_code=token_error.error_code)
 
 
-class OAuth2AuthenticationTests(OAuth2AllowInActiveUsersTests):  # pylint: disable=test-inherits-tests
+class BearerAuthenticationTests(OAuth2AllowInActiveUsersTests):  # pylint: disable=test-inherits-tests
 
     OAUTH2_BASE_TESTING_URL = '/oauth2-test/'
 
     def setUp(self):
-        super(OAuth2AuthenticationTests, self).setUp()
+        super(BearerAuthenticationTests, self).setUp()
         # Since this is testing back to previous version, user should be set to true
         self.user.is_active = True
         self.user.save()

--- a/openedx/core/lib/api/tests/test_authentication.py
+++ b/openedx/core/lib/api/tests/test_authentication.py
@@ -182,7 +182,6 @@ class OAuth2AllowInActiveUsersTests(TestCase):
         response = self.get_with_bearer_token(self.OAUTH2_BASE_TESTING_URL, token=self.dot_access_token.token)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
-
     def test_get_form_failing_auth_url_transport(self):
         """Ensure GETing form over OAuth with correct client credentials in query fails when DEBUG is False"""
         query = urlencode({'access_token': self.access_token.token})

--- a/openedx/core/lib/api/view_utils.py
+++ b/openedx/core/lib/api/view_utils.py
@@ -23,7 +23,7 @@ from rest_framework.views import APIView
 from six import text_type, iteritems
 
 from openedx.core.djangoapps.content.course_overviews.models import CourseOverview
-from openedx.core.lib.api.authentication import OAuth2AuthenticationAllowInactiveUser
+from openedx.core.lib.api.authentication import BearerAuthenticationAllowInactiveUser
 from openedx.core.lib.api.permissions import IsUserInUrl
 
 
@@ -120,7 +120,7 @@ def view_auth_classes(is_user=False, is_authenticated=True):
         """
         func_or_class.authentication_classes = (
             JwtAuthentication,
-            OAuth2AuthenticationAllowInactiveUser,
+            BearerAuthenticationAllowInactiveUser,
             SessionAuthenticationAllowInactiveUser
         )
         func_or_class.permission_classes = ()

--- a/openedx/features/discounts/views.py
+++ b/openedx/features/discounts/views.py
@@ -18,7 +18,7 @@ from experiments.models import ExperimentData
 from openedx.core.djangoapps.content.course_overviews.models import CourseOverview
 from openedx.core.djangoapps.cors_csrf.decorators import ensure_csrf_cookie_cross_domain
 from openedx.core.djangoapps.oauth_dispatch.jwt import create_jwt_for_user
-from openedx.core.lib.api.authentication import OAuth2AuthenticationAllowInactiveUser
+from openedx.core.lib.api.authentication import BearerAuthenticationAllowInactiveUser
 from openedx.core.lib.api.permissions import ApiKeyHeaderPermissionIsAuthenticated
 from openedx.core.lib.api.view_utils import DeveloperErrorViewMixin
 
@@ -59,7 +59,7 @@ class CourseUserDiscount(DeveloperErrorViewMixin, APIView):
             "jwt": xxxxxxxx.xxxxxxxx.xxxxxxx
         }
     """
-    authentication_classes = (JwtAuthentication, OAuth2AuthenticationAllowInactiveUser,
+    authentication_classes = (JwtAuthentication, BearerAuthenticationAllowInactiveUser,
                               SessionAuthenticationAllowInactiveUser,)
     permission_classes = (ApiKeyHeaderPermissionIsAuthenticated,)
 
@@ -130,7 +130,7 @@ class CourseUserDiscountWithUserParam(DeveloperErrorViewMixin, APIView):
             "jwt": xxxxxxxx.xxxxxxxx.xxxxxxx
         }
     """
-    authentication_classes = (JwtAuthentication, OAuth2AuthenticationAllowInactiveUser,
+    authentication_classes = (JwtAuthentication, BearerAuthenticationAllowInactiveUser,
                               SessionAuthenticationAllowInactiveUser,)
     permission_classes = (ApiKeyHeaderPermissionIsAuthenticated, IsAdminUser)
 

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -100,7 +100,7 @@ edx-api-doc-tools==1.0.2
 edx-bulk-grades==0.6.6
 edx-ccx-keys==1.0.0
 edx-celeryutils==0.3.2
-edx-completion==3.0.2
+edx-completion==3.0.3
 edx-django-oauth2-provider==1.3.5
 edx-django-release-util==0.3.6
 edx-django-sites-extensions==2.4.3

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -112,7 +112,7 @@ edx-api-doc-tools==1.0.2
 edx-bulk-grades==0.6.6
 edx-ccx-keys==1.0.0
 edx-celeryutils==0.3.2
-edx-completion==3.0.2
+edx-completion==3.0.3
 edx-django-oauth2-provider==1.3.5
 edx-django-release-util==0.3.6
 edx-django-sites-extensions==2.4.3

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -108,7 +108,7 @@ edx-api-doc-tools==1.0.2
 edx-bulk-grades==0.6.6
 edx-ccx-keys==1.0.0
 edx-celeryutils==0.3.2
-edx-completion==3.0.2
+edx-completion==3.0.3
 edx-django-oauth2-provider==1.3.5
 edx-django-release-util==0.3.6
 edx-django-sites-extensions==2.4.3


### PR DESCRIPTION
and removing unneeded metrics

Since OAuth2Authentication only supports oauth2 with bearer token, it was decided the BearerAuthentication name makes more sense. 

There is another class called bearerAuthentication in edx-drf-extensions. As part of this change, that is also being removed(its not used anywhere).