### PR TITLE
Fix LMS API URL in CMS configuration

### DIFF
--- a/cms/envs/devstack_docker.py
+++ b/cms/envs/devstack_docker.py
@@ -9,7 +9,7 @@ LOGGING['handlers']['local'] = LOGGING['handlers']['tracking'] = {
 
 LOGGING['loggers']['tracking']['handlers'] = ['console']
 
-LMS_BASE = 'localhost:18000'
+LMS_BASE = 'edx.devstack.lms:18000'
 CMS_BASE = 'localhost:18010'
 LMS_ROOT_URL = 'http://{}'.format(LMS_BASE)
 
@@ -21,7 +21,7 @@ FEATURES.update({
 
 CREDENTIALS_SERVICE_USERNAME = 'credentials_worker'
 
-OAUTH_OIDC_ISSUER = '{}/oauth2'.format(LMS_ROOT_URL)
+OAUTH_OIDC_ISSUER = 'http://localhost:18000/oauth2'
 
 JWT_AUTH.update({
     'JWT_SECRET_KEY': 'lms-secret',


### PR DESCRIPTION
 In our docker setup, two different containers keep LMS and CMS, so the LMS API URL should be the address of its container, not localhost.
    
Updating LMS_ROOT_URL to anything else than localhost breaks the JWT authentication because JWT_ISSUER must be "localhost:18000". In order to fix that, JWT_ISSUER values was also updated accordingly in this pull request.