### PR TITLE
Add five seconds step to video slider

### DIFF
--- a/common/lib/xmodule/xmodule/js/spec/video/video_progress_slider_spec.js
+++ b/common/lib/xmodule/xmodule/js/spec/video/video_progress_slider_spec.js
@@ -30,7 +30,8 @@
                         min: 0,
                         max: null,
                         slide: state.videoProgressSlider.onSlide,
-                        stop: state.videoProgressSlider.onStop
+                        stop: state.videoProgressSlider.onStop,
+                        step: 5
                     });
                 });
 

--- a/common/lib/xmodule/xmodule/js/src/video/06_video_progress_slider.js
+++ b/common/lib/xmodule/xmodule/js/src/video/06_video_progress_slider.js
@@ -120,6 +120,7 @@ function() {
             edx.HtmlUtils.HTML('<div class="ui-slider-handle progress-handle"></div>')
         );
 
+        // xss-lint: disable=javascript-jquery-append
         this.videoProgressSlider.el.append(sliderContents.text);
 
         this.videoProgressSlider.slider = this.videoProgressSlider.el
@@ -128,7 +129,8 @@ function() {
                 min: this.config.startTime,
                 max: this.config.endTime,
                 slide: this.videoProgressSlider.onSlide,
-                stop: this.videoProgressSlider.onStop
+                stop: this.videoProgressSlider.onStop,
+                step: 5
             });
 
         this.videoProgressSlider.sliderProgress = this.videoProgressSlider
@@ -327,6 +329,7 @@ function() {
                     msg = ngettext('%(value)s second', '%(value)s seconds', value);
                     break;
                 }
+                // xss-lint: disable=javascript-interpolate
                 return interpolate(msg, {value: value}, true);
             };
 


### PR DESCRIPTION
### Description

[PROD-159](https://openedx.atlassian.net/browse/PROD-159)

Currently, video is moving one second ahead or behind on each right and left arrow key respectively.In order to make it compliant with the industry standards like Youtube,its step is adjusted to five seconds.