### PR TITLE
Add Dropdown for grade reports in data download

### DIFF
--- a/common/test/acceptance/pages/lms/instructor_dashboard.py
+++ b/common/test/acceptance/pages/lms/instructor_dashboard.py
@@ -12,7 +12,12 @@ from bok_choy.page_object import PageObject
 from bok_choy.promise import EmptyPromise, Promise
 
 from common.test.acceptance.pages.lms.course_page import CoursePage
-from common.test.acceptance.tests.helpers import get_options, get_selected_option_text, select_option_by_text
+from common.test.acceptance.tests.helpers import (
+    get_options,
+    get_selected_option_text,
+    select_option_by_text,
+    select_option_by_value
+)
 
 
 class InstructorDashboardPage(CoursePage):
@@ -1100,6 +1105,11 @@ class DataDownloadPage(PageObject):
         return self.q(css='input[name=list-profiles]')
 
     @property
+    def submit_grade_report_button(self):
+        """Returns the "Submit" grade report button."""
+        return self.q(css='input[name="submit-grade-report"]')
+
+    @property
     def enrolled_student_profile_button_present(self):
         """
         Checks for the presence of Enrolled Student Profile Button
@@ -1114,32 +1124,55 @@ class DataDownloadPage(PageObject):
         return self.q(css='input[name="dump-gradeconf"]')
 
     @property
-    def generate_grade_report_button(self):
-        """
-        Returns the "Generate Grade Report" button.
-        """
-        return self.q(css='input[name=calculate-grades-csv]')
-
-    @property
-    def generate_problem_report_button(self):
-        """
-        Returns the "Generate Problem Grade Report" button.
-        """
-        return self.q(css='input[name=problem-grade-report]')
-
-    @property
     def report_download_links(self):
         """
         Returns the download links for the current page.
         """
         return self.q(css="#report-downloads-table .file-download-link>a")
 
-    @property
-    def generate_ora2_response_report_button(self):
+    def generate_course_grade_report_for_all_learners(self):
         """
-        Returns the ORA2 response download button for the current page.
+        Select Grade report for all learners from the dropdown and return submit report button.
         """
-        return self.q(css='input[name=export-ora2-data]')
+        self.select_report_from_dropdown(report_value='calculate-grades-csv')
+        return self.submit_grade_report_button.click()
+
+    def generate_course_grade_report_for_verified_learners(self):
+        """
+        Select Grade report for verified learners from the dropdown and return submit report button.
+        """
+        self.select_report_from_dropdown(report_value='calculate-grades-csv-verified')
+        return self.submit_grade_report_button.click()
+
+    def generate_problem_report_for_all_learners(self):
+        """
+        Select Problem report for all learners from the dropdown and return submit report button.
+        """
+        self.select_report_from_dropdown(report_value='problem-grade-report')
+        return self.submit_grade_report_button.click()
+
+    def generate_problem_report_for_verified_learners(self):
+        """
+        Select Problem report for verified learners from the dropdown and return submit report button.
+        """
+        self.select_report_from_dropdown(report_value='problem-grade-report-verified')
+        return self.submit_grade_report_button.click()
+
+    def generate_ora2_response_report(self):
+        """
+        Select ORA2 data report from the dropdown and return submit report button.
+        """
+        self.select_report_from_dropdown(report_value='export-ora2-data')
+        return self.submit_grade_report_button.click()
+
+    def select_report_from_dropdown(self, report_value):
+        """Selects the specified report from the dropdown of grade reports."""
+        reports_select = self.q(css='#grade-reports')
+        select_option_by_value(reports_select, report_value)
+        expected_report_selected = self.q(css='#grade-reports option[value="{}"]'.format(report_value)).selected
+        EmptyPromise(
+            lambda: expected_report_selected is True, 'Grade report is set to {}'.format(report_value)
+        ).fulfill()
 
     def wait_for_available_report(self):
         """

--- a/common/test/acceptance/tests/lms/test_lms_courseware.py
+++ b/common/test/acceptance/tests/lms/test_lms_courseware.py
@@ -188,7 +188,7 @@ class ProctoredExamTest(UniqueCourseTest):
 
     def _login_as_a_verified_user(self):
         """
-        login as a verififed user
+        login as a verified user
         """
 
         auto_auth(

--- a/common/test/acceptance/tests/lms/test_lms_instructor_dashboard.py
+++ b/common/test/acceptance/tests/lms/test_lms_instructor_dashboard.py
@@ -27,6 +27,7 @@ from common.test.acceptance.pages.studio.overview import CourseOutlinePage as St
 from common.test.acceptance.tests.helpers import (
     EventsTestMixin,
     UniqueCourseTest,
+    auto_auth,
     create_multiple_choice_problem,
     disable_animations,
     get_modal_alert
@@ -297,7 +298,7 @@ class ProctoredExamsTest(BaseInstructorDashboardTest):
 
     def _login_as_a_verified_user(self):
         """
-        login as a verififed user
+        login as a verified user
         """
 
         self._auto_auth(self.USERNAME, self.EMAIL, False)
@@ -392,6 +393,7 @@ class DataDownloadsTest(BaseInstructorDashboardTest):
     def setUp(self):
         super(DataDownloadsTest, self).setUp()
         self.course_fixture = CourseFixture(**self.course_info).install()
+
         self.instructor_username, self.instructor_id, __, __ = self.log_in_as_instructor(
             course_access_roles=['data_researcher']
         )
@@ -443,38 +445,78 @@ class DataDownloadsTest(BaseInstructorDashboardTest):
         self.verify_report_requested_event(report_name)
         self.verify_report_download(report_name)
 
-    def test_grade_report_download(self):
+    def test_grade_report_download_all_learners(self):
         """
-        Scenario: Verify that an instructor can download a grade report
+        Scenario: Verify that an instructor can download a grade report for all learners
 
         Given that I am an instructor
         And I visit the instructor dashboard's "Data Downloads" tab
-        And I click on the "Generate Grade Report" button
+        I select "Grade Report: All Learners" from the dropdown.
+        And then I click on the "Submit" button right next to the dropdown.
         Then a report should be generated
         And a report requested event should be emitted
         When I click on the report
         Then a report downloaded event should be emitted
         """
-        report_name = u"grade_report"
-        self.data_download_section.generate_grade_report_button.click()
+        report_name = "grade_report_all_learners"
+        self.data_download_section.generate_course_grade_report_for_all_learners()
         self.data_download_section.wait_for_available_report()
         self.verify_report_requested_event(report_name)
         self.verify_report_download(report_name)
 
-    def test_problem_grade_report_download(self):
+    def test_grade_report_download_verified_learners(self):
         """
-        Scenario: Verify that an instructor can download a problem grade report
+        Scenario: Verify that an instructor can download a grade report for verified learners.
 
         Given that I am an instructor
         And I visit the instructor dashboard's "Data Downloads" tab
-        And I click on the "Generate Problem Grade Report" button
+        I select "Grade Report: Verified Learners Only" from the dropdown.
+        And then I click on the "Submit" button right next to the dropdown.
         Then a report should be generated
         And a report requested event should be emitted
         When I click on the report
         Then a report downloaded event should be emitted
         """
-        report_name = u"problem_grade_report"
-        self.data_download_section.generate_problem_report_button.click()
+        report_name = "grade_report_verified_learners"
+        self.data_download_section.generate_course_grade_report_for_verified_learners()
+        self.data_download_section.wait_for_available_report()
+        self.verify_report_requested_event(report_name)
+        self.verify_report_download(report_name)
+
+    def test_problem_grade_report_download_all_learners(self):
+        """
+        Scenario: Verify that an instructor can download a problem grade report for all learners.
+
+        Given that I am an instructor
+        And I visit the instructor dashboard's "Data Downloads" tab
+        I select "Problem Report: All Learners" from the dropdown
+        And then I click on the "Submit" button right next to the dropdown.
+        Then a report should be generated
+        And a report requested event should be emitted
+        When I click on the report
+        Then a report downloaded event should be emitted
+        """
+        report_name = "problem_grade_report_all_learners"
+        self.data_download_section.generate_problem_report_for_all_learners()
+        self.data_download_section.wait_for_available_report()
+        self.verify_report_requested_event(report_name)
+        self.verify_report_download(report_name)
+
+    def test_problem_grade_report_download_verified_learners(self):
+        """
+        Scenario: Verify that an instructor can download a problem grade report for verified learners.
+
+        Given that I am an instructor
+        And I visit the instructor dashboard's "Data Downloads" tab
+        I select "Problem Report: Verified Learners Only" from the dropdown
+        And then I click on the "Submit" button right next to the dropdown.
+        Then a report should be generated
+        And a report requested event should be emitted
+        When I click on the report
+        Then a report downloaded event should be emitted
+        """
+        report_name = "problem_grade_report_verified_learners"
+        self.data_download_section.generate_problem_report_for_verified_learners()
         self.data_download_section.wait_for_available_report()
         self.verify_report_requested_event(report_name)
         self.verify_report_download(report_name)
@@ -485,11 +527,12 @@ class DataDownloadsTest(BaseInstructorDashboardTest):
 
         Given that I am an instructor
         And I visit the instructor dashboard's "Data Downloads" tab
-        And I click on the "Download ORA2 Responses" button
+        I select "ORA Data Report" from the dropdown.
+        And then I click on the "Submit" button right next to the dropdown.
         Then a report should be generated
         """
-        report_name = u"ORA_data"
-        self.data_download_section.generate_ora2_response_report_button.click()
+        report_name = "ORA_data"
+        self.data_download_section.generate_ora2_response_report()
         self.data_download_section.wait_for_available_report()
         self.verify_report_download(report_name)
 

--- a/lms/djangoapps/grades/course_grade_factory.py
+++ b/lms/djangoapps/grades/course_grade_factory.py
@@ -108,7 +108,6 @@ class CourseGradeFactory(object):
         course_data = CourseData(
             user=None, course=course, collected_block_structure=collected_block_structure, course_key=course_key,
         )
-        stats_tags = [u'action:{}'.format(course_data.course_key)]
         for user in users:
             yield self._iter_grade_result(user, course_data, force_update)
 

--- a/lms/djangoapps/instructor/views/instructor_dashboard.py
+++ b/lms/djangoapps/instructor/views/instructor_dashboard.py
@@ -32,6 +32,7 @@ from xblock.fields import ScopeIds
 from bulk_email.api import is_bulk_email_feature_enabled
 from course_modes.models import CourseMode, CourseModesArchive
 from edxmako.shortcuts import render_to_response
+from instructor_task.config.waffle import new_ui_for_data_download_csv_reports
 from lms.djangoapps.certificates import api as certs_api
 from lms.djangoapps.certificates.models import (
     CertificateGenerationConfiguration,
@@ -55,10 +56,7 @@ from openedx.core.lib.url_utils import quote_slashes
 from openedx.core.lib.xblock_utils import wrap_xblock
 from shoppingcart.models import Coupon, CourseRegCodeItem, PaidCourseRegistration
 from student.models import CourseEnrollment
-from student.roles import (
-    CourseFinanceAdminRole, CourseInstructorRole,
-    CourseSalesAdminRole, CourseStaffRole
-)
+from student.roles import CourseFinanceAdminRole, CourseInstructorRole, CourseSalesAdminRole, CourseStaffRole
 from util.json_request import JsonResponse
 from xmodule.html_module import HtmlBlock
 from xmodule.modulestore.django import modulestore
@@ -232,7 +230,6 @@ def instructor_dashboard_2(request, course_id):
     )
 
     certificate_invalidations = CertificateInvalidation.get_certificate_invalidations(course_key)
-
     context = {
         'course': course,
         'studio_url': get_studio_url(course, 'course'),
@@ -243,6 +240,7 @@ def instructor_dashboard_2(request, course_id):
         'certificate_invalidations': certificate_invalidations,
         'generate_certificate_exceptions_url': generate_certificate_exceptions_url,
         'generate_bulk_certificate_exceptions_url': generate_bulk_certificate_exceptions_url,
+        'enable_new_ui_for_csv_reports': new_ui_for_data_download_csv_reports(course_key),
         'certificate_exception_view_url': certificate_exception_view_url,
         'certificate_invalidation_view_url': certificate_invalidation_view_url,
         'xqa_server': settings.FEATURES.get('XQA_SERVER', "http://your_xqa_server.com"),

--- a/lms/djangoapps/instructor_task/api.py
+++ b/lms/djangoapps/instructor_task/api.py
@@ -22,6 +22,7 @@ from lms.djangoapps.instructor_task.api_helper import (
     check_entrance_exam_problems_for_rescoring,
     encode_entrance_exam_and_student_input,
     encode_problem_and_student_input,
+    encode_task_input,
     submit_task
 )
 from lms.djangoapps.instructor_task.models import InstructorTask
@@ -345,7 +346,7 @@ def submit_calculate_grades_csv(request, course_key):
     """
     task_type = 'grade_course'
     task_class = calculate_grades_csv
-    task_input = {}
+    task_input = encode_task_input(request.POST)
     task_key = ""
 
     return submit_task(request, task_type, task_class, course_key, task_input, task_key)
@@ -358,7 +359,7 @@ def submit_problem_grade_report(request, course_key):
     """
     task_type = 'grade_problems'
     task_class = calculate_problem_grade_report
-    task_input = {}
+    task_input = encode_task_input(request.POST)
     task_key = ""
     return submit_task(request, task_type, task_class, course_key, task_input, task_key)
 

--- a/lms/djangoapps/instructor_task/api_helper.py
+++ b/lms/djangoapps/instructor_task/api_helper.py
@@ -425,6 +425,16 @@ def encode_entrance_exam_and_student_input(usage_key, student=None):
     return task_input, task_key
 
 
+def encode_task_input(data):
+    """Encode optional data into task input."""
+    task_input = {}
+
+    if 'verified_learners_only' in data:
+        task_input['verified_learners_only'] = text_type(data.get('verified_learners_only')).lower() == 'true'
+
+    return task_input
+
+
 def submit_task(request, task_type, task_class, course_key, task_input, task_key):
     """
     Helper method to submit a task.

--- a/lms/djangoapps/instructor_task/config/waffle.py
+++ b/lms/djangoapps/instructor_task/config/waffle.py
@@ -4,7 +4,7 @@ waffle switches for the instructor_task app.
 """
 
 
-from openedx.core.djangoapps.waffle_utils import WaffleFlagNamespace, WaffleSwitchNamespace
+from openedx.core.djangoapps.waffle_utils import CourseWaffleFlag, WaffleFlagNamespace, WaffleSwitchNamespace
 
 WAFFLE_NAMESPACE = u'instructor_task'
 INSTRUCTOR_TASK_WAFFLE_FLAG_NAMESPACE = WaffleFlagNamespace(name=WAFFLE_NAMESPACE)
@@ -12,14 +12,21 @@ WAFFLE_SWITCHES = WaffleSwitchNamespace(name=WAFFLE_NAMESPACE)
 
 # Waffle switches
 OPTIMIZE_GET_LEARNERS_FOR_COURSE = u'optimize_get_learners_for_course'
-GENERATE_GRADE_REPORT_VERIFIED_ONLY = u'generate_grade_report_for_verified_only'
+DATA_DOWNLOAD_REPORTS_NEW_UI = 'data_download_reports_new_ui'
 
 
 def waffle_flags():
     """
     Returns the namespaced, cached, audited Waffle flags dictionary for Grades.
     """
-    return {}
+    namespace = WaffleFlagNamespace(name=WAFFLE_NAMESPACE, log_prefix='Instructor Task: ')
+    return {
+        DATA_DOWNLOAD_REPORTS_NEW_UI: CourseWaffleFlag(
+            namespace,
+            DATA_DOWNLOAD_REPORTS_NEW_UI,
+            flag_undefined_default=True,
+        ),
+    }
 
 
 def optimize_get_learners_switch_enabled():
@@ -29,9 +36,8 @@ def optimize_get_learners_switch_enabled():
     return WAFFLE_SWITCHES.is_enabled(OPTIMIZE_GET_LEARNERS_FOR_COURSE)
 
 
-def generate_grade_report_for_verified_only():
+def new_ui_for_data_download_csv_reports(course_key):
     """
-    Returns True if waffle switch is enabled that indicates generate grading reports only for
-    verified learners.
+    Returns whether new UI is enabled for CSV reports in instructor dashboard for a given course.
     """
-    return WAFFLE_SWITCHES.is_enabled(GENERATE_GRADE_REPORT_VERIFIED_ONLY)
+    return waffle_flags()[DATA_DOWNLOAD_REPORTS_NEW_UI].is_enabled(course_key)

--- a/lms/djangoapps/instructor_task/tests/test_base.py
+++ b/lms/djangoapps/instructor_task/tests/test_base.py
@@ -352,8 +352,8 @@ class TestReportMixin(object):
                 contain data which is the subset of actual csv rows.
         """
         report_store = ReportStore.from_config(config_name='GRADES_DOWNLOAD')
-        report_csv_filename = report_store.links_for(self.course.id)[file_index][0]
-        report_path = report_store.path_to(self.course.id, report_csv_filename)
+        report_csv_filename = report_store.links_for(course_id=self.course.id)[file_index][0]
+        report_path = report_store.path_to(course_id=self.course.id, filename=report_csv_filename)
         with report_store.storage.open(report_path) as csv_file:
             # Expand the dict reader generator so we don't lose it's content
             csv_rows = [row for row in unicodecsv.DictReader(csv_file, encoding='utf-8-sig')]

--- a/lms/djangoapps/instructor_task/tests/test_integration.py
+++ b/lms/djangoapps/instructor_task/tests/test_integration.py
@@ -635,7 +635,7 @@ class TestGradeReportConditionalContent(TestReportMixin, TestConditionalContent,
         self.submit_student_answer(self.student_b.username, problem_b_url, [OPTION_1, OPTION_2])
 
         with patch('lms.djangoapps.instructor_task.tasks_helper.runner._get_current_task'):
-            result = CourseGradeReport.generate(None, None, self.course.id, None, 'graded')
+            result = CourseGradeReport.generate(None, None, self.course.id, {}, 'graded')
             self.verify_csv_task_success(result)
             self.verify_grades_in_csv(
                 [
@@ -668,7 +668,7 @@ class TestGradeReportConditionalContent(TestReportMixin, TestConditionalContent,
         self.submit_student_answer(self.student_a.username, problem_a_url, [OPTION_1, OPTION_1])
 
         with patch('lms.djangoapps.instructor_task.tasks_helper.runner._get_current_task'):
-            result = CourseGradeReport.generate(None, None, self.course.id, None, 'graded')
+            result = CourseGradeReport.generate(None, None, self.course.id, {}, 'graded')
             self.verify_csv_task_success(result)
             self.verify_grades_in_csv(
                 [

--- a/lms/static/sass/course/instructor/_instructor_2.scss
+++ b/lms/static/sass/course/instructor/_instructor_2.scss
@@ -275,6 +275,11 @@
     @include idashbutton(#eee);
   }
 
+  select {
+      border: 1px solid $light-gray;
+      height: 34px;
+  }
+
   .instructor_dash_glob_info {
     position: absolute;
 

--- a/lms/static/sass/course/instructor/_instructor_2.scss
+++ b/lms/static/sass/course/instructor/_instructor_2.scss
@@ -251,7 +251,7 @@
     @include margin-left(1px);
     @include font-size(14);
 
-    font-family: verdana,arial,sans-serif;
+    font-family: verdana, arial, sans-serif;
     color: #333;
 
     .slick-cell {
@@ -276,8 +276,8 @@
   }
 
   select {
-      border: 1px solid $light-gray;
-      height: 34px;
+    border: 1px solid $light-gray;
+    height: 34px;
   }
 
   .instructor_dash_glob_info {

--- a/lms/templates/instructor/instructor_dashboard_2/data_download.html
+++ b/lms/templates/instructor/instructor_dashboard_2/data_download.html
@@ -5,6 +5,17 @@ from django.utils.translation import ugettext as _
 from openedx.core.djangolib.markup import HTML, Text
 %>
 
+<%
+grade_report_downloads_available = settings.FEATURES.get('ALLOW_COURSE_STAFF_GRADE_DOWNLOADS') or section_data['access']['admin']
+report_urls = {
+    'grade_course': section_data['calculate_grades_csv_url'],
+    'grade_problem': section_data['problem_grade_report_url'],
+    'grade_ora': section_data['export_ora2_data_url'],
+}
+def get_url_for_report(report_type):
+    return report_urls[report_type]
+%>
+
 <div class="data-download-container action-type-container">
   <div class="request-response-error msg msg-error copy" id="data-request-response-error"></div>
 
@@ -91,13 +102,44 @@ from openedx.core.djangolib.markup import HTML, Text
   %endif
   <div class="data-display-table profile-data-display-table" id="data-student-profiles-table"></div>
 
-  %if settings.FEATURES.get('ALLOW_COURSE_STAFF_GRADE_DOWNLOADS') or section_data['access']['admin']:
-    <p>${_("Click to generate a CSV grade report for all currently enrolled students.")}</p>
-    <p>
-      <input type="button" name="calculate-grades-csv" class="async-report-btn" value="${_("Generate Grade Report")}" data-endpoint="${ section_data['calculate_grades_csv_url'] }"/>
-      <input type="button" name="problem-grade-report" class="async-report-btn" value="${_("Generate Problem Grade Report")}" data-endpoint="${ section_data['problem_grade_report_url'] }"/>
-      <input type="button" name="export-ora2-data" class="async-report-btn" value="${_("Generate ORA Data Report")}" data-endpoint="${ section_data['export_ora2_data_url'] }"/>
-    </p>
+  %if grade_report_downloads_available:
+    %if enable_new_ui_for_csv_reports:
+      <p>${_("Generate a grade report of currently enrolled students: ")}</p>
+      <p>
+        <label><span class="sr">${_("Choose Grade Report")}</span>
+          <select id="grade-reports" class="input select report-selector">
+            <option data-endpoint="${ get_url_for_report('grade_course') }"
+              data-verified_learners_only="true"
+              value="calculate-grades-csv-verified">${_('Grade Report: Verified Learners Only')}
+            </option>
+            <option data-endpoint="${ get_url_for_report('grade_course') }"
+              data-verified_learners_only="false"
+              value="calculate-grades-csv">${_('Grade Report: All Learners')}
+            </option>
+            <option data-endpoint="${ get_url_for_report('grade_problem') }"
+              data-verified_learners_only="true"
+              value="problem-grade-report-verified">${_('Problem Report: Verified Learners Only')}
+            </option>
+            <option data-endpoint="${ get_url_for_report('grade_problem') }"
+              data-verified_learners_only="false"
+              value="problem-grade-report">${_('Problem Report: All Learners')}
+            </option>
+            <option data-endpoint="${ get_url_for_report('grade_ora') }"
+              value="export-ora2-data">${_('ORA Data Report')}
+            </option>
+          </select>
+        </label>
+        <input type="button" name="submit-grade-report" class="async-report-submit" value="Generate CSV" />
+      </p>
+
+    %else:
+      <p>${_("Click to generate a CSV grade report for all currently enrolled students.")}</p>
+      <p>
+        <input type="button" name="calculate-grades-csv" class="async-report-btn" value="${_("Generate Grade Report")}" data-endpoint="${ section_data['calculate_grades_csv_url'] }"/>
+        <input type="button" name="problem-grade-report" class="async-report-btn" value="${_("Generate Problem Grade Report")}" data-endpoint="${ section_data['problem_grade_report_url'] }"/>
+        <input type="button" name="export-ora2-data" class="async-report-btn" value="${_("Generate ORA Data Report")}" data-endpoint="${ section_data['export_ora2_data_url'] }"/>
+      </p>
+    %endif
   %endif
 
     <div class="request-response msg msg-confirm copy" id="report-request-response"></div>


### PR DESCRIPTION
Course teams have the choice to run for CSV reports for Verified only or all 
-
[PROD-1309](https://openedx.atlassian.net/browse/PROD-1309)
 * Added CourseWaffleFlag `instructor_task.data_download_reports_new_ui` for courses which would like to opt-out.


**How to test**
 https://awaisdar001.sandbox.edx.org/courses/course-v1:edX+DemoX+Demo_Course

Go to the URL & login.
Click Instructor Tab => Data Download

FYI -- @edx/sustaining-mavericks