### PR TITLE
Upgrade proctoring

### DIFF
--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -111,7 +111,7 @@ edx-oauth2-provider==1.3.1
 edx-opaque-keys[django]==2.0.1
 edx-organizations==3.0.0
 edx-proctoring-proctortrack==1.0.5
-edx-proctoring==2.2.7
+edx-proctoring==2.2.8
 edx-rbac==1.1.0           # via edx-enterprise
 edx-rest-api-client==3.0.2
 edx-search==1.2.2

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -124,7 +124,7 @@ edx-oauth2-provider==1.3.1
 edx-opaque-keys[django]==2.0.1
 edx-organizations==3.0.0
 edx-proctoring-proctortrack==1.0.5
-edx-proctoring==2.2.7
+edx-proctoring==2.2.8
 edx-rbac==1.1.0
 edx-rest-api-client==3.0.2
 edx-search==1.2.2

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -120,7 +120,7 @@ edx-oauth2-provider==1.3.1
 edx-opaque-keys[django]==2.0.1
 edx-organizations==3.0.0
 edx-proctoring-proctortrack==1.0.5
-edx-proctoring==2.2.7
+edx-proctoring==2.2.8
 edx-rbac==1.1.0
 edx-rest-api-client==3.0.2
 edx-search==1.2.2


### PR DESCRIPTION
Impact is that for proctoring backends which support in-exam keepalive
ping messages to ensure the monitoring software is running while
learners have access to proctored exams, we will no longer send ping
requests while the learner is on the ready_to_submit page. These pings
have caused issues for some of our learners in the past, in that some
learners idle on this page waiting for a slow-to-shut-down
application. Pinging while the app is shutting down may've caused
spurious false positives for suspicious learner behavior, and we lose
little integrity by enabling the learner to continue to see the
non-exam-content interstitial, so we're relaxing this rule.

JIRA:CR-1597

### Please consider the following when opening a pull request:

- Link to the relevant JIRA ticket(s) and tag any relevant team(s).
- Squash your changes down into one or more discrete commits.
  In each commit, include description that could help a developer
  several months from now.
- If running `make upgrade`, run _as close to the time of merging as possible_
  to avoid accidentally downgrading someone else's package.
  Put the output of `make upgrade` in its own separate commit,
  decoupled from other code changes.
- Aim for comprehensive test coverage, but remember that
  automated testing isn't a substitute for manual verification.
- Carefully consider naming, code organization, dependencies when adding new code.
  Code that is amenable to refactoring and improvement benefits all platform developers,
  especially given the size and scope of edx-platform.
  Consult existing Architectural Decision Records (ADRs),
  including those concerning the app(s) you are changing and
  [those concerning edx-platform as a whole](https://github.com/edx/edx-platform/tree/master/docs/decisions).
