### PR TITLE
ENT-2597: Use encodeURIComponent instead of encodeURI

### DIFF
--- a/lms/static/js/spec/student_account/multiple_enterprise_spec.js
+++ b/lms/static/js/spec/student_account/multiple_enterprise_spec.js
@@ -9,7 +9,7 @@ define([
         describe('MultipleEnterpriseInterface', function() {
             var LEARNER_URL = '/enterprise/api/v1/enterprise-learner/?username=test-learner',
                 NEXT_URL = '/dashboard',
-                REDIRECT_URL = '/enterprise/select/active/?success_url=/dashboard';
+                REDIRECT_URL = '/enterprise/select/active/?success_url=%2Fdashboard';
 
             beforeEach(function() {
                 // Mock the redirect call

--- a/lms/static/js/student_account/multiple_enterprise.js
+++ b/lms/static/js/student_account/multiple_enterprise.js
@@ -18,7 +18,7 @@
              * @param  {string} nextUrl The URL to redirect to after multiple enterprise selection.
              */
             check: function(nextUrl) {
-                var redirectUrl = this.urls.multipleEnterpriseUrl + encodeURI(nextUrl);
+                var redirectUrl = this.urls.multipleEnterpriseUrl + encodeURIComponent(nextUrl);
                 var username = Utils.userFromEdxUserCookie().username;
                 var next = nextUrl || '/';
                 $.ajax({


### PR DESCRIPTION
We should use encodeURIComponent instead of encodeURI when encoding part of uri like querystring. encodeURI does not encode `+` sign. For example a query string parameter like `scope=user_id+profile+email` is not encoded by `encodeURI` which results in invalid url on select multiple enterprise page.

### Please consider the following when opening a pull request:

- Link to the relevant JIRA ticket(s) and tag any relevant team(s).
- Squash your changes down into one or more discrete commits.
  In each commit, include description that could help a developer
  several months from now.
- If running `make upgrade`, run _as close to the time of merging as possible_
  to avoid accidentally downgrading someone else's package.
  Put the output of `make upgrade` in its own separate commit,
  decoupled from other code changes.
- Aim for comprehensive test coverage, but remember that
  automated testing isn't a substitute for manual verification.
- Carefully consider naming, code organization, dependencies when adding new code.
  Code that is amenable to refactoring and improvement benefits all platform developers,
  especially given the size and scope of edx-platform.
  Consult existing Architectural Decision Records (ADRs),
  including those concerning the app(s) you are changing and
  [those concerning edx-platform as a whole](https://github.com/edx/edx-platform/tree/master/docs/decisions).
