### PR TITLE
[BB-2059] Remove deprecated city field from student features report

### DIFF
--- a/lms/djangoapps/instructor_analytics/basic.py
+++ b/lms/djangoapps/instructor_analytics/basic.py
@@ -97,6 +97,7 @@ def enrolled_students_features(course_key, features):
     """
     include_cohort_column = 'cohort' in features
     include_team_column = 'team' in features
+    include_city_column = 'city' in features
     include_enrollment_mode = 'enrollment_mode' in features
     include_verification_status = 'verification_status' in features
     include_program_enrollments = 'external_user_key' in features
@@ -151,6 +152,13 @@ def enrolled_students_features(course_key, features):
             meta_dict = json.loads(profile.meta) if profile.meta else {}
             for meta_feature, meta_key in meta_features:
                 student_dict[meta_feature] = meta_dict.get(meta_key)
+
+            # There are two separate places where the city value can be stored,
+            # one used by account settings and the other used by the registration form.
+            # If the account settings value (meta.city) is set, it takes precedence.
+            meta_city = meta_dict.get('city')
+            if include_city_column and meta_city:
+                student_dict['city'] = meta_city
 
         if include_cohort_column:
             # Note that we use student.course_groups.all() here instead of


### PR DESCRIPTION
This PR updates the student features report to pull from UserProfile.meta['city'] if it is set, in favor over `UserProfile.city`.

**Context**:
There are two distinct ways to store a city for users in edx-platform: one directly in `UserProfile.city`, and another in `UserProfile.meta`.

`UserProfile.meta` is used by adding `"city"` to the `extended_profile_fields`. This is then available via the account settings editor. The `UserProfile.city` field is not used or available via the account settings page.

Conversely to use a City field in the registration form, the `REGISTRATION_EXTRA_FIELDS["city"]` must be configured, and then entries are stored in `UserProfile.city`, which can't later be edited from the account settings page since it's [not included in the field set](https://github.com/edx/edx-platform/blob/0db4fb0ffe8ef568a9cae2b1c5da92065bbdd5e6/openedx/core/djangoapps/user_api/accounts/settings_views.py#L112).

Since the `UserProfile.meta['city']` field is not set unless specifically configured, we choose this over the `UserProfile.city` field when generating the student features report.

**Dependencies**: None

**Testing instructions**:

1. Add `"extended_profile_fields":"city"` (to the SiteConfiguration)[http://localhost:18000/admin/site_configuration/siteconfiguration/1/change/]
2. Set `{"city": "Test City"}` in the `UserProfile.meta` field for a (test user)[http://localhost:18000/admin/auth/user/5/change/].
3. Generate a report of student profiles with the "Download profile information as CSV" button in the instructor view for the [edX DemoX Course](http://localhost:18000/courses/course-v1:edX+DemoX+Demo_Course/instructor#view-data_download).
4. Check that the "city" field is filled in from the value set in step #2.

**Reviewers**
- [ ] (@lgp171188)
- [ ] edX reviewer[s] TBD