### PR TITLE
[BB-2088] Add %%COURSE_ID%% to html block

### DIFF
--- a/common/lib/xmodule/xmodule/html_module.py
+++ b/common/lib/xmodule/xmodule/html_module.py
@@ -116,8 +116,12 @@ class HtmlBlock(
 
     def get_html(self):
         """ Returns html required for rendering the block. """
-        if self.data is not None and getattr(self.system, 'anonymous_student_id', None) is not None:
-            return self.data.replace("%%USER_ID%%", self.system.anonymous_student_id)
+        if self.data:
+            data = self.data
+            if getattr(self.runtime, 'anonymous_student_id', None):
+                data = data.replace("%%USER_ID%%", self.runtime.anonymous_student_id)
+            data = data.replace("%%COURSE_ID%%", str(self.scope_ids.usage_id.context_key))
+            return data
         return self.data
 
     def studio_view(self, _context):
@@ -459,10 +463,9 @@ class CourseInfoBlock(CourseInfoFields, HtmlBlock):
 
         # When we switch this to an XBlock, we can merge this with student_view,
         # but for now the XModule mixin requires that this method be defined.
-        if self.data != "":
-            if self.system.anonymous_student_id:
-                return self.data.replace("%%USER_ID%%", self.system.anonymous_student_id)
-            return self.data
+        data = super().get_html()
+        if data != "":
+            return data
         else:
             # This should no longer be called on production now that we are using a separate updates page
             # and using a fragment HTML file - it will be called in tests until those are removed.

--- a/common/lib/xmodule/xmodule/tests/test_html_module.py
+++ b/common/lib/xmodule/xmodule/tests/test_html_module.py
@@ -5,7 +5,7 @@ import unittest
 import ddt
 from django.test.utils import override_settings
 from mock import Mock
-from opaque_keys.edx.locator import CourseLocator
+from opaque_keys.edx.locator import BlockUsageLocator, CourseLocator
 from xblock.field_data import DictFieldData
 from xblock.fields import ScopeIds
 
@@ -98,12 +98,30 @@ class HtmlBlockCourseApiTestCase(unittest.TestCase):
 
 class HtmlBlockSubstitutionTestCase(unittest.TestCase):
 
-    def test_substitution_works(self):
+    def test_substitution_user_id(self):
         sample_xml = '''%%USER_ID%%'''
         field_data = DictFieldData({'data': sample_xml})
         module_system = get_test_system()
         module = HtmlBlock(module_system, field_data, Mock())
         self.assertEqual(module.get_html(), str(module_system.anonymous_student_id))
+
+    def test_substitution_course_id(self):
+        sample_xml = '''%%COURSE_ID%%'''
+        field_data = DictFieldData({'data': sample_xml})
+        module_system = get_test_system()
+        module = HtmlBlock(module_system, field_data, Mock())
+        course_key = CourseLocator(
+            org='some_org',
+            course='some_course',
+            run='some_run'
+        )
+        usage_key = BlockUsageLocator(
+            course_key=course_key,
+            block_type='problem',
+            block_id='block_id'
+        )
+        module.scope_ids.usage_id = usage_key
+        self.assertEqual(module.get_html(), str(course_key))
 
     def test_substitution_without_magic_string(self):
         sample_xml = '''


### PR DESCRIPTION
This adds support for replacing `%%COURSE_ID%%` keyword in built-in HTML block.

**JIRA tickets**: [OSPR-4115](https://openedx.atlassian.net/browse/OSPR-4115)

**Sandbox URL**: https://pr23174.sandbox.opencraft.hosting/

**Merge deadline**: None

**Testing instructions**:
1. Create new HTML block.
1. Place the following content inside:
   ```
   User ID: %%USER_ID%%
   Course ID: %%COURSE_ID%%
   ```
1. Confirm that both IDs have been replaced.

**Sandbox testing instructions**:
1. Log in via the [admin page](https://pr23174.sandbox.opencraft.hosting/admin/). The DB is missing `email_marketing_emailmarketingconfiguration` table, but running the migrations did not fix the problem, so I didn't debug it, as it's not related.
1. Go to [LMS](https://pr23174.sandbox.opencraft.hosting/courses/course-v1:edX+DemoX+Demo_Course/courseware/9fca584977d04885bc911ea76a9ef29e/07bc32474380492cb34f76e5f9d9a135/1?activate_block_id=block-v1%3AedX%2BDemoX%2BDemo_Course%2Btype%40vertical%2Bblock%4045c7cedb4bfe46f4a68c78787151cfb5) and [Studio](https://studio.pr23174.sandbox.opencraft.hosting/container/block-v1:edX+DemoX+Demo_Course+type@vertical+block@45c7cedb4bfe46f4a68c78787151cfb5) and confirm that the block has the keywords replaced.

**Reviewers**
- [x] @xitij2000  
- [ ] edX reviewer[s] TBD

