### PR TITLE
Fix alert css for smaller viewports

### DIFF
--- a/lms/static/sass/elements/_system-feedback.scss
+++ b/lms/static/sass/elements/_system-feedback.scss
@@ -23,6 +23,7 @@
   .msg-icon {
     display: inline-block;
     vertical-align: middle;
+    margin-right: 50px;
   }
 
   .msg-content {


### PR DESCRIPTION
[PROD-1032](https://openedx.atlassian.net/browse/PROD-1032)

Alert msgs are not aligned as expected in their enclosing divs on smaller devices.To make them aligned its css is fixed so that user experience can be improved.
Before:
<img width="296" alt="Screen Shot 2020-02-24 at 6 27 55 PM" src="https://user-images.githubusercontent.com/15120237/75156211-6e146380-5733-11ea-8b12-3b02865da1b9.png">


After:
<img width="292" alt="Screen Shot 2020-02-24 at 6 27 43 PM" src="https://user-images.githubusercontent.com/15120237/75156229-77053500-5733-11ea-854f-521e91353884.png">
