### PR TITLE
BOM-1324: add constraint for edx-drf-extensions

### DIFF
--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -82,3 +82,6 @@ django-storages<1.9
 
 # Support was dropped for Python 3.5, Django 2.0, Django 2.1, DRF 3.7
 drf-yasg<1.17.1
+
+# BOM-1324: This constraint will be removed separately once 3.0.0 is out
+edx-drf-extensions<3.0.0


### PR DESCRIPTION
There is a planned edx-drf-extension update to 3.0.0 to remove the
toggle used for ENFORCE_JWT_SCOPES. Currently, edx-platform is dependent
on the this toggle. This constraint will keep other `make upgrade` PRs
working in the short window before the edx-paltform PR to remove the
same toggle can land.

BOM-1324

### Please consider the following when opening a pull request:

- Link to the relevant JIRA ticket(s) and tag any relevant team(s).
- Squash your changes down into one or more discrete commits.
  In each commit, include description that could help a developer
  several months from now.
- If running `make upgrade`, run _as close to the time of merging as possible_
  to avoid accidentally downgrading someone else's package.
  Put the output of `make upgrade` in its own separate commit,
  decoupled from other code changes.
- Aim for comprehensive test coverage, but remember that
  automated testing isn't a substitute for manual verification.
- Carefully consider naming, code organization, dependencies when adding new code.
  Code that is amenable to refactoring and improvement benefits all platform developers,
  especially given the size and scope of edx-platform.
  Consult existing Architectural Decision Records (ADRs),
  including those concerning the app(s) you are changing and
  [those concerning edx-platform as a whole](https://github.com/edx/edx-platform/tree/master/docs/decisions).
