### PR TITLE
Add existence check on secondary email

### DIFF
--- a/common/djangoapps/student/views/management.py
+++ b/common/djangoapps/student/views/management.py
@@ -621,14 +621,6 @@ def validate_secondary_email(user, new_email):
     if new_email == user.email:
         raise ValueError(_('Cannot be same as your sign in email address.'))
 
-    # Make sure that secondary email address is not same as any of the primary emails currently in use or retired
-    if email_exists_or_retired(new_email):
-        raise ValueError(
-            _("It looks like {email} belongs to an existing account. Try again with a different email address.").format(
-                email=new_email
-            )
-        )
-
     message = get_secondary_email_validation_error(new_email)
     if message:
         raise ValueError(message)

--- a/openedx/core/djangoapps/user_api/accounts/api.py
+++ b/openedx/core/djangoapps/user_api/accounts/api.py
@@ -218,13 +218,21 @@ def _validate_secondary_email(user, data, field_errors):
     if "secondary_email" not in data:
         return
 
+    secondary_email = data["secondary_email"]
+
     try:
-        student_views.validate_secondary_email(user, data["secondary_email"])
+        student_views.validate_secondary_email(user, secondary_email)
     except ValueError as err:
         field_errors["secondary_email"] = {
             "developer_message": u"Error thrown from validate_secondary_email: '{}'".format(text_type(err)),
             "user_message": text_type(err)
         }
+    else:
+        # Don't process with sending email to given new email, if it is already associated with
+        # an account. User must see same success message with no error.
+        # This is so that this endpoint cannot be used to determine if an email is valid or not.
+        if email_exists_or_retired(secondary_email):
+            del data["secondary_email"]
 
 
 def _validate_name_change(user_profile, data, field_errors):


### PR DESCRIPTION
Moves the existence check for secondary (recovery) email to validate
method. If the email already exists, silently remove it from the set of
data to be updated. This parallels the existing behavior for updating
the primary email.

ENT-1913