### PR TITLE
Remove display table-cell on course-content container

### DIFF
--- a/lms/templates/courseware/courseware-chromeless.html
+++ b/lms/templates/courseware/courseware-chromeless.html
@@ -86,6 +86,7 @@ ${HTML(fragment.foot_html())}
     % else:
       data-enable-completion-on-view-service="false" \
     % endif
+    style="display: block; width: auto;"
   >
       <main id="main" tabindex="-1" aria-label="Content">
         ${HTML(fragment.body_html())}


### PR DESCRIPTION
TNL-7093 `.content` is a class extended (`@extend .content`) in a variety of places throughout the platform. The styles contained in .content cause layout issues on wide screens.

This PR fixes the issue by copying in the styles from .content except the problematic ones. `.content` for reference:

```
.content {
  box-sizing: border-box;
  display: table-cell;
  padding: 2em 2.5em;
  vertical-align: top;
  width: flex-grid(9) + flex-gutter();

  @media print {
    box-shadow: none;
  }
}
```

Current state:
![image](https://user-images.githubusercontent.com/1615421/75295767-746d1300-57f9-11ea-9373-3cd664e7c4ff.png)
With this PR:
![image](https://user-images.githubusercontent.com/1615421/75295784-86e74c80-57f9-11ea-8fe4-c32638242f00.png)
