### PR TITLE
Fix Pavelib prereqs.

### DIFF
--- a/pavelib/prereqs.py
+++ b/pavelib/prereqs.py
@@ -103,7 +103,7 @@ def prereq_cache(cache_name, paths, install_func):
     cache_file_path = os.path.join(PREREQS_STATE_DIR, "{}.sha1".format(cache_filename))
     old_hash = None
     if os.path.isfile(cache_file_path):
-        with io.open(cache_file_path, "rb") as cache_file:
+        with io.open(cache_file_path, "r") as cache_file:
             old_hash = cache_file.read()
 
     # Compare the old hash to the new hash


### PR DESCRIPTION
During running python unit tests using `paver test_system` I noticed the requirements are installed every time I run the tests. Digging deeper into this, I found out that while comparing `new_hash != old_hash` the data type are mismatched. 

`compute_fingerprint(paths)`  returns `str` type but while reading the `old_hash = cache_file.read()` retuned `bytes` string. 

In this PR, I have changed the file read operation from `rb` to `r`. 

[PROD-1322](https://openedx.atlassian.net/browse/PROD-1322)