### PR TITLE
REST API for managing Content Library bundle links

### DIFF
--- a/openedx/core/djangoapps/content_libraries/library_bundle.py
+++ b/openedx/core/djangoapps/content_libraries/library_bundle.py
@@ -18,6 +18,7 @@ from openedx.core.djangoapps.xblock.runtime.olx_parsing import (
 )
 from openedx.core.djangolib.blockstore_cache import (
     BundleCache,
+    get_bundle_direct_links_with_cache,
     get_bundle_files_cached,
     get_bundle_file_metadata_with_cache,
     get_bundle_version_number,
@@ -298,6 +299,12 @@ class LibraryBundle(object):
             if getattr(file_, 'modified', False):
                 has_unpublished_changes = True
                 break
+
+        if not has_unpublished_changes:
+            # Check if any links have changed:
+            old_links = set(get_bundle_direct_links_with_cache(self.bundle_uuid).items())
+            new_links = set(get_bundle_direct_links_with_cache(self.bundle_uuid, draft_name=self.draft_name).items())
+            has_unpublished_changes = new_links != old_links
 
         published_file_paths = set(f.path for f in get_bundle_files_cached(self.bundle_uuid))
         draft_file_paths = set(f.path for f in draft_files)

--- a/openedx/core/djangoapps/content_libraries/serializers.py
+++ b/openedx/core/djangoapps/content_libraries/serializers.py
@@ -84,6 +84,32 @@ class LibraryXBlockTypeSerializer(serializers.Serializer):
     display_name = serializers.CharField()
 
 
+class LibraryBundleLinkSerializer(serializers.Serializer):
+    """
+    Serializer for a link from a content library blockstore bundle to another
+    blockstore bundle.
+    """
+    id = serializers.SlugField()  # Link name
+    bundle_uuid = serializers.UUIDField(format='hex_verbose', read_only=True)
+    # What version of this bundle we are currently linking to.
+    # This is never NULL but can optionally be set to null when creating a new link, which means "use latest version."
+    version = serializers.IntegerField(allow_null=True)
+    # What the latest version of the linked bundle is:
+    # (if latest_version > version), the link can be "updated" to the latest version.
+    latest_version = serializers.IntegerField(read_only=True)
+    # Opaque key: If the linked bundle is a library or other learning context whose opaque key we can deduce, then this
+    # is the key. If we don't know what type of blockstore bundle this link is pointing to, then this is blank.
+    opaque_key = serializers.CharField()
+
+
+class LibraryBundleLinkUpdateSerializer(serializers.Serializer):
+    """
+    Serializer for updating an existing link in a content library blockstore
+    bundle.
+    """
+    version = serializers.IntegerField(allow_null=True)
+
+
 class LibraryXBlockCreationSerializer(serializers.Serializer):
     """
     Serializer for adding a new XBlock to a content library

--- a/openedx/core/djangoapps/content_libraries/tests/base.py
+++ b/openedx/core/djangoapps/content_libraries/tests/base.py
@@ -3,12 +3,12 @@
 Tests for Blockstore-based Content Libraries
 """
 from contextlib import contextmanager
+from io import BytesIO
 import unittest
 
 from django.conf import settings
 from organizations.models import Organization
 from rest_framework.test import APITestCase, APIClient
-import six
 
 from student.tests.factories import UserFactory
 from openedx.core.djangolib.testing.utils import skip_unless_cms
@@ -20,6 +20,7 @@ URL_PREFIX = '/api/libraries/v2/'
 URL_LIB_CREATE = URL_PREFIX
 URL_LIB_DETAIL = URL_PREFIX + '{lib_key}/'  # Get data about a library, update or delete library
 URL_LIB_BLOCK_TYPES = URL_LIB_DETAIL + 'block_types/'  # Get the list of XBlock types that can be added to this library
+URL_LIB_LINKS = URL_LIB_DETAIL + 'links/'  # Get the list of links in this library, or add a new one
 URL_LIB_COMMIT = URL_LIB_DETAIL + 'commit/'  # Commit (POST) or revert (DELETE) all pending changes to this library
 URL_LIB_BLOCKS = URL_LIB_DETAIL + 'blocks/'  # Get the list of XBlocks in this library, or add a new one
 URL_LIB_TEAM = URL_LIB_DETAIL + 'team/'  # Get the list of users/groups authorized to use this library
@@ -66,7 +67,7 @@ class ContentLibrariesRestApiTest(APITestCase):
 
     @classmethod
     def setUpClass(cls):
-        super(ContentLibrariesRestApiTest, cls).setUpClass()
+        super().setUpClass()
         cls.user = UserFactory.create(username="Bob", email="bob@example.com", password="edx")
         # Create a collection using Blockstore API directly only because there
         # is not yet any Studio REST API for doing so:
@@ -78,7 +79,7 @@ class ContentLibrariesRestApiTest(APITestCase):
         )
 
     def setUp(self):
-        super(ContentLibrariesRestApiTest, self).setUp()
+        super().setUp()
         self.clients_by_user = {}
         self.client.login(username=self.user.username, password="edx")
 
@@ -141,6 +142,23 @@ class ContentLibrariesRestApiTest(APITestCase):
     def _delete_library(self, lib_key, expect_response=200):
         """ Delete an existing library """
         return self._api('delete', URL_LIB_DETAIL.format(lib_key=lib_key), None, expect_response)
+
+    def _get_library_links(self, lib_key):
+        """ Get the links of the specified content library """
+        return self._api('get', URL_LIB_LINKS.format(lib_key=lib_key), None, expect_response=200)
+
+    def _link_to_library(self, lib_key, link_id, other_library_key, version=None):
+        """
+        Modify the library identified by lib_key to create a named link to
+        other_library_key. This allows you to use XBlocks from other_library in
+        lib. Optionally specify a version to link to.
+        """
+        data = {
+            "id": link_id,
+            "opaque_key": other_library_key,
+            "version": version,
+        }
+        return self._api('post', URL_LIB_LINKS.format(lib_key=lib_key), data, expect_response=200)
 
     def _commit_library_changes(self, lib_key, expect_response=200):
         """ Commit changes to an existing library """
@@ -220,8 +238,8 @@ class ContentLibrariesRestApiTest(APITestCase):
 
         content should be a binary string.
         """
-        assert isinstance(content, six.binary_type)
-        file_handle = six.BytesIO(content)
+        assert isinstance(content, bytes)
+        file_handle = BytesIO(content)
         url = URL_LIB_BLOCK_ASSET_FILE.format(block_key=block_key, file_name=file_name)
         response = self.client.put(url, data={"content": file_handle})
         self.assertEqual(

--- a/openedx/core/djangoapps/content_libraries/urls.py
+++ b/openedx/core/djangoapps/content_libraries/urls.py
@@ -20,6 +20,10 @@ urlpatterns = [
             url(r'^$', views.LibraryDetailsView.as_view()),
             # Get the list of XBlock types that can be added to this library
             url(r'^block_types/$', views.LibraryBlockTypesView.as_view()),
+            # Get the list of Blockstore Bundle Links for this library, or add a new one:
+            url(r'^links/$', views.LibraryLinksView.as_view()),
+            # Update or delete a link:
+            url(r'^links/(?P<link_id>[^/]+)/$', views.LibraryLinkDetailView.as_view()),
             # Get the list of XBlocks in this library, or add a new one:
             url(r'^blocks/$', views.LibraryBlocksView.as_view()),
             # Commit (POST) or revert (DELETE) all pending changes to this library:

--- a/openedx/core/lib/blockstore_api/methods.py
+++ b/openedx/core/lib/blockstore_api/methods.py
@@ -264,7 +264,7 @@ def get_bundle_version_links(bundle_uuid, version_number):
     Get a dictionary of the links in the specified bundle version
     """
     if version_number == 0:
-        return []
+        return {}
     version_url = api_url('bundle_versions', str(bundle_uuid) + ',' + str(version_number))
     version_info = api_request('get', version_url)
     return {


### PR DESCRIPTION
This adds some simple new REST APIs that can be used to create, read, update, and delete "links" from a content library to other content libraries.

One can use these links to import content (XBlocks) into a library without copying the content.

Note that this feature was already fully supported by Blockstore and the XBlock runtime; it's just that to use it prior to this required one to use the (lower-level) Blockstore REST API directly to create the links. Now there is a somewhat higher-level API built in to Studio, using "content library" abstractions instead of Blockstore primitives.

The easiest way to test this functionality is to use the latest version of [Ramshackle](https://github.com/open-craft/ramshackle), which has been updated to be able to consume these APIs and display a UI for managing links:
<img width="645" alt="ramshackle-screenshot" src="https://user-images.githubusercontent.com/945577/75512624-e9318000-59a6-11ea-93e4-ddd8bb1a2a36.png">
*^ Yes, it's ugly but this is a developer tool :)*

Once a link has been created using Ramshackle, you can go into any container XBlock in the same library and use the OLX editor to `xblock-include` any XBlock definition from the linked library, by specifying the link's ID/name as the `source` attribute of the include:

<img width="594" alt="xblock-include" src="https://user-images.githubusercontent.com/945577/75512718-2e55b200-59a7-11ea-8ad2-09869dbc94d2.png">

In the screenshot above, a problem from some existing library is linked into this library with the link named "test5".

TODO (all done):
- [x] Add tests
- [x] Fix https://github.com/edx/blockstore/issues/54 which makes this barely usable unless you know how to work around it.