### PR TITLE
Add migration to populate site_values in SiteConfigurationHistory

### DIFF
--- a/openedx/core/djangoapps/site_configuration/migrations/0005_populate_siteconfig_history_site_values.py
+++ b/openedx/core/djangoapps/site_configuration/migrations/0005_populate_siteconfig_history_site_values.py
@@ -1,0 +1,29 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations
+
+forward_sql = """
+UPDATE
+    site_configuration_siteconfigurationhistory
+SET
+    site_values = '{}';
+"""
+
+reverse_sql = """
+UPDATE
+    site_configuration_siteconfigurationhistory
+SET
+    site_values = '';
+"""
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('site_configuration', '0004_add_site_values_field'),
+    ]
+
+    operations = [
+        migrations.RunSQL(forward_sql, reverse_sql=reverse_sql),
+    ]


### PR DESCRIPTION
Right now the ORM is very unhappy about the JSONField `site_values`
in SiteConfigurationHistory containing non-JSON (empty strings).  We
cannot even write a data migration using the ORM to populate the field
because that causes a JSONDeserializationError.  Therefore, we must
bypass the ORM and populate the values with raw SQL.

DENG-18

---

Testing in devstack:

DB state before migration:
```
mysql> select site_values from site_configuration_siteconfigurationhistory;
+-------------+
| site_values |
+-------------+
|             |
|             |
+-------------+
2 rows in set (0.00 sec)
```

Running the migration:
```
root@lms:/edx/app/edxapp/edx-platform# python manage.py cms migrate
...
Operations to perform:
  Apply all migrations: admin, announcements, api_admin, assessment, auth, block_structure, bookmarks, catalog, celery_utils, completion, consent, content_libraries, content_type_gating, contentserver, contentstore, contenttypes, cornerstone, course_action_state, course_creators, course_date_signals, course_duration_limits, course_groups, course_modes, course_overviews, courseware, coursewarehistoryextended, crawlers, credit, dark_lang, database_fixups, degreed, discounts, django_comment_common, django_notify, djcelery, edx_oauth2_provider, edx_proctoring, edx_when, edx_zoom, edxval, embargo, enterprise, entitlements, experiments, integrated_channel, lx_pathway_plugin, milestones, oauth2, oauth2_provider, oauth_dispatch, organizations, problem_builder, redirects, sap_success_factors, schedules, self_paced, sessions, site_configuration, sites, static_replace, student, submissions, survey, system_wide_roles, tagging, theming, track, user_api, user_authn, user_tasks, verified_track_content, verify_student, video_config, video_pipeline, waffle, waffle_utils, wiki, workflow, xapi, xblock_config, xblock_django
Running migrations:
  Applying site_configuration.0005_populate_siteconfig_history_site_values... OK
```


DB state after migration:
```
mysql> select site_values from site_configuration_siteconfigurationhistory;
+-------------+
| site_values |
+-------------+
| {}          |
| {}          |
+-------------+
2 rows in set (0.00 sec)
```

Running the reverse migration:
```
root@lms:/edx/app/edxapp/edx-platform# python manage.py cms migrate site_configuration 0004_add_site_values_field
...
Operations to perform:
  Target specific migration: 0004_add_site_values_field, from site_configuration
Running migrations:
  Rendering model states... DONE
  Unapplying site_configuration.0005_populate_siteconfig_history_site_values... OK
```


DB state after reverse migration:
```
mysql> select site_values from site_configuration_siteconfigurationhistory;
+-------------+
| site_values |
+-------------+
|             |
|             |
+-------------+
2 rows in set (0.00 sec)
```