### PR TITLE
Fix due date extension view.

### DIFF
--- a/lms/djangoapps/instructor/tests/test_tools.py
+++ b/lms/djangoapps/instructor/tests/test_tools.py
@@ -268,6 +268,16 @@ class TestSetDueDateExtension(ModuleStoreTestCase):
         tools.set_due_date_extension(self.course, self.week1, self.user, None)
         self.assertEqual(self.week1.due, self.due)
 
+    def test_reset_due_date_extension_with_no_enrollment(self):
+        """
+        Tests that DashboardError is raised when trying to extend due date
+        for a block given the user is not enrolled in the course.
+        """
+        user = UserFactory.create()
+        extended = datetime.datetime(2013, 12, 25, 0, 0, tzinfo=UTC)
+        with self.assertRaises(tools.DashboardError):
+            tools.set_due_date_extension(self.course, self.week3, user, extended)
+
 
 class TestDataDumps(ModuleStoreTestCase):
     """

--- a/lms/djangoapps/instructor/views/tools.py
+++ b/lms/djangoapps/instructor/views/tools.py
@@ -17,7 +17,7 @@ from pytz import UTC
 from six import string_types, text_type
 from six.moves import zip
 
-from student.models import get_user_by_username_or_email
+from student.models import get_user_by_username_or_email, CourseEnrollment
 
 
 class DashboardError(Exception):
@@ -156,9 +156,16 @@ def title_or_url(node):
 
 def set_due_date_extension(course, unit, student, due_date, actor=None, reason=''):
     """
-    Sets a due date extension. Raises DashboardError if the unit or extended
-    due date is invalid.
+    Sets a due date extension.
+
+    Raises:
+        DashboardError if the unit or extended, due date is invalid or user is
+        not enrolled in the course.
     """
+    mode, __ = CourseEnrollment.enrollment_mode_for_user(user=student, course_id=six.text_type(course.id))
+    if not mode:
+        raise DashboardError(_("Could not find student enrollment in the course."))
+
     if due_date:
         try:
             api.set_date_for_block(course.id, unit.location, 'due', due_date, user=student, reason=reason, actor=actor)


### PR DESCRIPTION
Fix an error in Due Date Extension View.

**Description**
With this PR, the user will be notified with an error message **Could not find student enrollment in the course** when the course team tries to extend the due date for a user who is not enrolled in the course. 

**Screenshot**
<img style="height:100px;width:100px;" width="1297" alt="Screen Shot 2020-03-02 at 11 50 40 AM" src="https://user-images.githubusercontent.com/4252738/75652113-14082680-5c7c-11ea-8298-d92d06beb0b0.png">

**Ticket**
[PROD-1339](https://openedx.atlassian.net/browse/PROD-1339)

FYI -- @edx/sustaining-mavericks 