### PR TITLE
[SE-2264] [LX-744] Return more metadata in xblock api

### DIFF
--- a/openedx/core/djangoapps/content_libraries/tests/base.py
+++ b/openedx/core/djangoapps/content_libraries/tests/base.py
@@ -32,6 +32,7 @@ URL_LIB_BLOCK_ASSET_FILE = URL_LIB_BLOCK + 'assets/{file_name}'  # Get, delete, 
 
 URL_BLOCK_RENDER_VIEW = '/api/xblock/v2/xblocks/{block_key}/view/{view_name}/'
 URL_BLOCK_GET_HANDLER_URL = '/api/xblock/v2/xblocks/{block_key}/handler_url/{handler_name}/'
+URL_BLOCK_METADATA_URL = '/api/xblock/v2/xblocks/{block_key}/'
 
 
 # Decorator for tests that require blockstore
@@ -72,9 +73,9 @@ class ContentLibrariesRestApiTest(APITestCase):
         # is not yet any Studio REST API for doing so:
         cls.collection = blockstore_api.create_collection("Content Library Test Collection")
         # Create an organization
-        cls.organization = Organization.objects.create(
-            name="Content Libraries Tachyon Exploration & Survey Team",
+        cls.organization, _ = Organization.objects.get_or_create(
             short_name="CL-TEST",
+            defaults={"name": "Content Libraries Tachyon Exploration & Survey Team"},
         )
 
     def setUp(self):

--- a/openedx/core/djangoapps/xblock/rest_api/views.py
+++ b/openedx/core/djangoapps/xblock/rest_api/views.py
@@ -34,10 +34,18 @@ User = get_user_model()
 def block_metadata(request, usage_key_str):
     """
     Get metadata about the specified block.
+
+    Accepts an "include" query parameter which must be a comma separated list of keys to include. Valid keys are
+    "index_dictionary" and "student_view_data".
     """
     usage_key = UsageKey.from_string(usage_key_str)
     block = load_block(usage_key, request.user)
-    metadata_dict = get_block_metadata(block)
+    includes = request.GET.get("include", "").split(",")
+    metadata_dict = get_block_metadata(block, includes=includes)
+    if 'children' in metadata_dict:
+        metadata_dict['children'] = [str(key) for key in metadata_dict['children']]
+    if 'editable_children' in metadata_dict:
+        metadata_dict['editable_children'] = [str(key) for key in metadata_dict['editable_children']]
     return Response(metadata_dict)
 
 


### PR DESCRIPTION
Make more metadata available via the new runtime's generic XBlock API

Without this PR, there is no [reasonable] way to get the following data for any XBlocks in the Blockstore runtime; now there is :)

* `index_dictionary`: data about the block content, for search indexing
* `student_view_data`: data-only equivalent of student_view, for use in
  custom UIs/mobile
* `children`: list of child IDs
* `editable_children`: list of child IDs in the same bundle (use case: when showing an OLX editor you want to allow editing the OLX of children in the same bundle but not linked children)

**JIRA tickets**: [OSPR-4132](https://openedx.atlassian.net/browse/OSPR-4132) SE-2264 LX-744

**Testing instructions**:

1. create some xblocks
2. call the `/api/xblock/v2/xblocks/{xblock_key}?include=index_dictionary,children` api endpoint
3. verify that the populated `index_dictionary` etc. are present in the results

**Author notes and concerns**:

This is fully generic and should be forward-compatible with any type of "learning context" that uses XBlocks, not just content libraries.

Caching could be added at any future point in time, but for now it's easy enough for the API client to manage its own caching.

This has somewhat overlapping functionality with the course blocks API, but that one is oriented toward courses with large trees (and block transformers), and won't work with blockstore libraries; nor does it make sense when our current blockstore libraries have an average of ~1-2 blocks per library.