### PR TITLE
Workaround the error in find_question_label.

### DIFF
--- a/common/lib/capa/capa/capa_problem.py
+++ b/common/lib/capa/capa/capa_problem.py
@@ -565,7 +565,6 @@ class LoncapaProblem(object):
         try:
             prompt = self.problem_data[answer_id].get('label')
         except KeyError:
-            prompt = self.problem_data.get(answer_id, {}).get('label')
             log.error(
                 'KeyError: answer_id: %s, Problem data: %s, problem: %s',
                 (answer_id, self.problem_data, etree.tostring(self.tree))

--- a/common/lib/capa/capa/capa_problem.py
+++ b/common/lib/capa/capa/capa_problem.py
@@ -562,12 +562,15 @@ class LoncapaProblem(object):
         """
         _ = get_gettext(self.capa_system.i18n)
         # Some questions define a prompt with this format:   >>This is a prompt<<
-        log_error = False
         try:
             prompt = self.problem_data[answer_id].get('label')
         except KeyError:
-            log_error = True
             prompt = self.problem_data.get(answer_id, {}).get('label')
+            log.error(
+                'KeyError: answer_id: %s, Problem data: %s, problem: %s',
+                (answer_id, self.problem_data, etree.tostring(self.tree))
+            )
+            raise
 
         if prompt:
             question_text = prompt.striptags()
@@ -612,11 +615,6 @@ class LoncapaProblem(object):
                 question_nr = int(answer_id.split('_')[-2]) - 1
                 question_text = _("Question {0}").format(question_nr)
 
-        if log_error:
-            log.error(
-                'KeyError: answer_id: %s, Problem data: %s, question_text: %s',
-                (answer_id, self.problem_data, question_text)
-            )
         return question_text
 
     def find_answer_text(self, answer_id, current_answer):


### PR DESCRIPTION
Workaround the error in `find_question_label`.
This is a temporary log, which will give us information and unblock the course team. 

```
2020-03-02 07:26:18,761 ERROR 2456 [celery.worker.job] [user None] log.py:282 - Task lms.djangoapps.instructor_task.tasks.calculate_problem_responses_csv[8db8f674-5d1d-410c-bdf6-f12ee568b9b5] raised unexpected: AssertionError()
Traceback (most recent call last):
  File "/edx/app/edxapp/venvs/edxapp/lib/python3.5/site-packages/celery/app/trace.py", line 240, in trace_task
    R = retval = fun(*args, **kwargs)
  File "/edx/app/edxapp/venvs/edxapp/lib/python3.5/site-packages/newrelic/hooks/application_celery.py", line 85, in wrapper
    return wrapped(*args, **kwargs)
  File "/edx/app/edxapp/venvs/edxapp/lib/python3.5/site-packages/celery/app/trace.py", line 438, in __protected_call__
    return self.run(*args, **kwargs)
  File "/edx/app/edxapp/edx-platform/lms/djangoapps/instructor_task/tasks.py", line 173, in calculate_problem_responses_csv
    return run_main_task(entry_id, task_fn, action_name)
  File "/edx/app/edxapp/edx-platform/lms/djangoapps/instructor_task/tasks_helper/runner.py", line 120, in run_main_task
    task_progress = task_fcn(entry_id, course_id, task_input, action_name)
  File "/edx/app/edxapp/edx-platform/lms/djangoapps/instructor_task/tasks_helper/grades.py", line 782, in generate
    usage_key_str=problem_location
  File "/edx/app/edxapp/edx-platform/lms/djangoapps/instructor_task/tasks_helper/grades.py", line 719, in _build_student_data
    for username, state in block.generate_report_data(user_state_iterator, max_count):
  File "/edx/app/edxapp/edx-platform/common/lib/xmodule/xmodule/capa_module.py", line 470, in generate_report_data
    question_text = lcp.find_question_label(answer_id)
  File "/edx/app/edxapp/edx-platform/common/lib/capa/capa/capa_problem.py", line 586, in find_question_label
    assert len(xml_elems) == 1
AssertionError
```
[PROD-1326](https://openedx.atlassian.net/browse/PROD-1326)


fyi -- @asadazam93 
