### PR TITLE
EDUCATOR-4900: TopicsListView needs a queryset attribute

### DIFF
--- a/lms/djangoapps/teams/views.py
+++ b/lms/djangoapps/teams/views.py
@@ -794,6 +794,7 @@ class TopicListView(GenericAPIView):
     authentication_classes = (BearerAuthentication, SessionAuthentication)
     permission_classes = (permissions.IsAuthenticated,)
     pagination_class = TopicsPagination
+    queryset = []
 
     def get(self, request):
         """GET /api/team/v0/topics/?course_id={course_id}"""


### PR DESCRIPTION
[EDUCATOR-4900](https://openedx.atlassian.net/browse/EDUCATOR-4900)

I went with the simple solution. Theoretically, we could pull the topic lookup into a "get_queryset" method, but it doesn't really gain us much. The small bandaid seems sufficient. 