### PR TITLE
Prevent inline discussions from pulling focus on load

### DIFF
--- a/common/static/common/js/discussion/views/discussion_inline_view.js
+++ b/common/static/common/js/discussion/views/discussion_inline_view.js
@@ -58,7 +58,7 @@
             DiscussionUtil.safeAjax({
                 $elem: this.$el,
                 $loading: this.$el,
-                takeFocus: true,
+                takeFocus: false,
                 url: url,
                 type: 'GET',
                 dataType: 'json',
@@ -212,7 +212,6 @@
                     });
                 }
             }
-            this.toggleDiscussionBtn.focus();
         },
 
         toggleNewPost: function(event) {


### PR DESCRIPTION
[TNL-7094] Remove auto focusing InlineDiscussion views on load. focusing elements as the block is loading and changing height sometimes causes the iframe to scroll to a position before the parent page can resize the frame to match the content height. Removing these unneeded auto-focus behaviors eliminates this issue.

Example bug:
![image](https://user-images.githubusercontent.com/1615421/75706340-027a4b00-5c8b-11ea-924f-2e13317f8274.png)


[TNL-7094]: https://openedx.atlassian.net/browse/TNL-7094