### PR TITLE
Upgrade django-babel-underscore BOM-1069

### DIFF
--- a/requirements/edx/base.in
+++ b/requirements/edx/base.in
@@ -37,7 +37,6 @@ celery                              # Asynchronous task execution library
 contextlib2                         # We need contextlib2.ExitStack so we can stop using contextlib.nested which doesn't exist in python 3
 defusedxml
 Django<1.12                         # Web application framework
-django-babel-underscore             # underscore template extractor for django-babel (internationalization utilities)
 django-celery                       # Only used for the CacheBackend for celery results
 django-config-models>=1.0.0         # Configuration models for Django allowing config management with auditing
 django-cors-headers                 # Used to allow to configure CORS headers for cross-domain requests

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -53,8 +53,8 @@ ddt==1.3.0                # via xblock-drag-and-drop-v2, xblock-poll
 decorator==4.4.2          # via pycontracts
 defusedxml==0.5.0         # via -r requirements/edx/base.in, djangorestframework-xml, ora2, python3-openid, python3-saml, safe-lxml, social-auth-core
 git+https://github.com/django-compressor/django-appconf@1526a842ee084b791aa66c931b3822091a442853#egg=django-appconf  # via -r requirements/edx/github.in, django-statici18n
-django-babel-underscore==0.5.2  # via -r requirements/edx/base.in
-django-babel==0.6.2       # via django-babel-underscore
+git+https://github.com/edx/django-babel-underscore.git@37705f7377a4d0a4e673f1431895ce28a8860cd7#egg=django-babel-underscore==0.6.0  # via -r requirements/edx/github.in
+git+https://github.com/Zegocover/enmerkar.git@dbc113798aa4beabdfa2d00e6fef48248eb0f185#egg=django-babel==0.6.3.dev0  # via -r requirements/edx/github.in
 django-celery==3.3.1      # via -r requirements/edx/base.in, super-csv
 django-classy-tags==1.0.0  # via django-sekizai
 django-config-models==2.0.0  # via -r requirements/edx/base.in, edx-enterprise
@@ -92,7 +92,7 @@ docopt==0.6.2             # via xmodule
 docutils==0.16            # via botocore
 drf-jwt==1.14.0           # via -c requirements/edx/../constraints.txt, edx-drf-extensions
 drf-yasg==1.17.0          # via -c requirements/edx/../constraints.txt, edx-api-doc-tools
-edx-ace==0.1.13           # via -r requirements/edx/base.in
+edx-ace==0.1.14           # via -r requirements/edx/base.in
 edx-analytics-data-api-client==0.15.5  # via -r requirements/edx/base.in
 edx-api-doc-tools==1.0.2  # via -r requirements/edx/base.in
 edx-bulk-grades==0.6.6    # via -r requirements/edx/base.in, staff-graded-xblock

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -64,8 +64,8 @@ defusedxml==0.5.0         # via -r requirements/edx/testing.txt, djangorestframe
 diff-cover==2.6.0         # via -r requirements/edx/testing.txt
 distlib==0.3.0            # via -r requirements/edx/testing.txt, virtualenv
 git+https://github.com/django-compressor/django-appconf@1526a842ee084b791aa66c931b3822091a442853#egg=django-appconf  # via -r requirements/edx/testing.txt, django-statici18n
-django-babel-underscore==0.5.2  # via -r requirements/edx/testing.txt
-django-babel==0.6.2       # via -r requirements/edx/testing.txt, django-babel-underscore
+git+https://github.com/edx/django-babel-underscore.git@37705f7377a4d0a4e673f1431895ce28a8860cd7#egg=django-babel-underscore==0.6.0  # via -r requirements/edx/testing.txt
+git+https://github.com/Zegocover/enmerkar.git@dbc113798aa4beabdfa2d00e6fef48248eb0f185#egg=django-babel==0.6.3.dev0  # via -r requirements/edx/testing.txt
 django-celery==3.3.1      # via -r requirements/edx/testing.txt, super-csv
 django-classy-tags==1.0.0  # via -r requirements/edx/testing.txt, django-sekizai
 django-config-models==2.0.0  # via -r requirements/edx/testing.txt, edx-enterprise
@@ -104,7 +104,7 @@ docopt==0.6.2             # via -r requirements/edx/testing.txt, xmodule
 docutils==0.16            # via -r requirements/edx/testing.txt, botocore, m2r, sphinx
 drf-jwt==1.14.0           # via -c requirements/edx/../constraints.txt, -r requirements/edx/testing.txt, edx-drf-extensions
 drf-yasg==1.17.0          # via -c requirements/edx/../constraints.txt, -r requirements/edx/testing.txt, edx-api-doc-tools
-edx-ace==0.1.13           # via -r requirements/edx/testing.txt
+edx-ace==0.1.14           # via -r requirements/edx/testing.txt
 edx-analytics-data-api-client==0.15.5  # via -r requirements/edx/testing.txt
 edx-api-doc-tools==1.0.2  # via -r requirements/edx/testing.txt
 edx-bulk-grades==0.6.6    # via -r requirements/edx/testing.txt, staff-graded-xblock

--- a/requirements/edx/github.in
+++ b/requirements/edx/github.in
@@ -62,6 +62,12 @@ git+https://github.com/edx/MongoDBProxy.git@d92bafe9888d2940f647a7b2b2383b29c752
 -e git+https://github.com/jazkarta/edx-jsme.git@690dbf75441fa91c7c4899df0b83d77f7deb5458#egg=edx-jsme
 -e git+https://github.com/jsocol/django-ratelimit.git@72edbe8949fbf6699848e5847645a1998f121d46#egg=ratelimit
 
+# This fork adds django>1.11 and django<3 compatibility for django-babel-underscore. Enmerkar is
+# being installed from github to add backward compatibility for django1.11 as named versions are not
+# backward compatible.
+git+https://github.com/edx/django-babel-underscore.git@37705f7377a4d0a4e673f1431895ce28a8860cd7#egg=django-babel-underscore==0.6.0
+git+https://github.com/Zegocover/enmerkar.git@dbc113798aa4beabdfa2d00e6fef48248eb0f185#egg=django-babel==0.6.3.dev0
+
 # Forked to get Django 2.2 support from unreleased master branch from social-app-django repo.
 # This can be removed once an official social-auth-app-django Pypi release with Django 2.2 support is available in the future.
 -e git+https://github.com/python-social-auth/social-app-django.git@c00d23c2b45c3317bd35b15ad1b959338689cef8#egg=social-auth-app-django

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -63,8 +63,8 @@ defusedxml==0.5.0         # via -r requirements/edx/base.txt, djangorestframewor
 diff-cover==2.6.0         # via -r requirements/edx/coverage.txt
 distlib==0.3.0            # via virtualenv
 git+https://github.com/django-compressor/django-appconf@1526a842ee084b791aa66c931b3822091a442853#egg=django-appconf  # via -r requirements/edx/base.txt, django-statici18n
-django-babel-underscore==0.5.2  # via -r requirements/edx/base.txt
-django-babel==0.6.2       # via -r requirements/edx/base.txt, django-babel-underscore
+git+https://github.com/edx/django-babel-underscore.git@37705f7377a4d0a4e673f1431895ce28a8860cd7#egg=django-babel-underscore==0.6.0  # via -r requirements/edx/base.txt
+git+https://github.com/Zegocover/enmerkar.git@dbc113798aa4beabdfa2d00e6fef48248eb0f185#egg=django-babel==0.6.3.dev0  # via -r requirements/edx/base.txt
 django-celery==3.3.1      # via -r requirements/edx/base.txt, super-csv
 django-classy-tags==1.0.0  # via -r requirements/edx/base.txt, django-sekizai
 django-config-models==2.0.0  # via -r requirements/edx/base.txt, edx-enterprise
@@ -100,7 +100,7 @@ docopt==0.6.2             # via -r requirements/edx/base.txt, xmodule
 docutils==0.16            # via -r requirements/edx/base.txt, botocore
 drf-jwt==1.14.0           # via -c requirements/edx/../constraints.txt, -r requirements/edx/base.txt, edx-drf-extensions
 drf-yasg==1.17.0          # via -c requirements/edx/../constraints.txt, -r requirements/edx/base.txt, edx-api-doc-tools
-edx-ace==0.1.13           # via -r requirements/edx/base.txt
+edx-ace==0.1.14           # via -r requirements/edx/base.txt
 edx-analytics-data-api-client==0.15.5  # via -r requirements/edx/base.txt
 edx-api-doc-tools==1.0.2  # via -r requirements/edx/base.txt
 edx-bulk-grades==0.6.6    # via -r requirements/edx/base.txt, staff-graded-xblock


### PR DESCRIPTION
We upgraded these before in https://github.com/edx/edx-platform/pull/23119 along with django-countries (which released a new version just before that), but had to revert in https://github.com/edx/edx-platform/pull/23237 because of a performance regression in the admin page for EnterpriseCustomer.  We think django-countries was the culprit and have pinned it, so trying these two again by themselves.