### PR TITLE
Remove the auth_source kwarg in connect_to_mongodb, since we're now r…

### DIFF
--- a/common/lib/xmodule/xmodule/mongo_utils.py
+++ b/common/lib/xmodule/xmodule/mongo_utils.py
@@ -48,6 +48,11 @@ def connect_to_mongodb(
     # If the MongoDB server uses a separate authentication database that should be specified here
     auth_source = kwargs.get('authsource', '') or None
 
+    # sanitize a kwarg which may be present and is no longer expected
+    # AED 2020-03-02 TODO: Remove this when 'auth_source' will no longer exist in kwargs
+    if 'auth_source' in kwargs:
+        kwargs.pop('auth_source')
+
     # If read_preference is given as a name of a valid ReadPreference.<NAME>
     # constant such as "SECONDARY_PREFERRED" or a mongo mode such as
     # "secondaryPreferred", convert it. Otherwise pass it through unchanged.


### PR DESCRIPTION
…elying on authsource (no underscore) and the pymongo Database init does not expect and will not tolerate an auth_source kwarg.

This PR bridges the gap between the release of https://github.com/edx/edx-platform/pull/21984/files and https://github.com/edx/configuration/pull/5482/files
