### PR TITLE
Allow Block Structures Collect to work in Studio

### DIFF
--- a/common/lib/xmodule/xmodule/video_module/video_module.py
+++ b/common/lib/xmodule/xmodule/video_module/video_module.py
@@ -1138,7 +1138,7 @@ class VideoBlock(
 
         available_translations = self.available_translations(self.get_transcripts_info())
         transcripts = {
-            lang: self.runtime.handler_url(self, 'transcript', 'download', query="lang=" + lang, thirdparty=True)
+            lang: self.runtime.handler_url(self, 'transcript', 'download', query="lang=" + lang)
             for lang in available_translations
         }
 


### PR DESCRIPTION
Block Structures were meant to be gathered using the LMS process,
as it's meant to be an optimized store for the LMS to use. But
there's an argument to be made for at least the Collect side of
the Collect + Transform could be a Studio concern, because it
explicitly needs to avoid user-awareness.

In either event, the collect process was broken before this
commit because Studio's runtime does not permit handler_url
invocation on "thirdparty" XBlocks. Since VideoBlock is not
really third-party (and it's questionable whether there's any
benefit to making the distinction these days), I'm just making
this change to allow Studio to run collect() without error in
the Studio process. This will fix devstack, which does not
properly route these collect() calls to the LMS process (because
celery runs in-proc by default).
