### PR TITLE
ENT-1705: Use user's first name as username

### DIFF
--- a/common/djangoapps/third_party_auth/saml.py
+++ b/common/djangoapps/third_party_auth/saml.py
@@ -249,8 +249,7 @@ class SapSuccessFactorsIdentityProvider(EdXSAMLIdentityProvider):
 
     # Define the relationships between SAPSF record fields and Open edX logistration fields.
     default_field_mapping = {
-        'username': 'username',
-        'firstName': 'first_name',
+        'firstName': ['username', 'first_name'],
         'lastName': 'last_name',
         'defaultFullName': 'fullname',
         'email': 'email',
@@ -285,10 +284,14 @@ class SapSuccessFactorsIdentityProvider(EdXSAMLIdentityProvider):
         field_mapping = self.field_mappings
         value_defaults = self.conf.get('attr_defaults', {})
         value_defaults = {key: value_defaults.get(value, '') for key, value in self.defaults_value_mapping.items()}
-        registration_fields = {
-            edx_name: response['d'].get(odata_name, value_defaults.get(odata_name, ''))
-            for odata_name, edx_name in field_mapping.items()
-        }
+        registration_fields = {}
+        for odata_name, edx_name in field_mapping.items():
+            if isinstance(edx_name, list):
+                for value in edx_name:
+                    registration_fields[value] = response['d'].get(odata_name, value_defaults.get(odata_name, ''))
+            else:
+                registration_fields[edx_name] = response['d'].get(odata_name, value_defaults.get(odata_name, ''))
+
         value_mapping = self.value_mappings
         for field, value in registration_fields.items():
             if field in value_mapping and value in value_mapping[field]:
@@ -488,6 +491,8 @@ class SapSuccessFactorsIdentityProvider(EdXSAMLIdentityProvider):
         if self.invalid_configuration():
             return basic_details
         user_id = basic_details['username']
+        # endpoint_url is constructed from field_mappings setting of SAML Provider config.
+        # We convert field_mappings to make comma separated list of the fields which needs to be pulled from BizX
         fields = ','.join(self.field_mappings)
         endpoint_url = '{root_url}User(userId=\'{user_id}\')?$select={fields}'.format(
             root_url=self.odata_api_root_url,
@@ -497,9 +502,7 @@ class SapSuccessFactorsIdentityProvider(EdXSAMLIdentityProvider):
         client = self.get_bizx_odata_api_client(user_id=user_id)
         if not client:
             return basic_details
-        transaction_data = {
-            'token_data': client.token_data
-        }
+
         try:
             response = client.get(
                 endpoint_url,
@@ -517,14 +520,9 @@ class SapSuccessFactorsIdentityProvider(EdXSAMLIdentityProvider):
             }
             self.log_bizx_api_exception(transaction_data, err)
             return basic_details
-        registration_fields = self.get_registration_fields(response)
-        # This statement is here for debugging purposes and should be removed when ENT-1500 is resolved.
-        if user_id != registration_fields.get('username'):
-            log.info(u'loggedinuser_id %s is different from BizX username %s',
-                     user_id,
-                     registration_fields.get('username'))
 
-        return registration_fields
+        log.info(u'[THIRD_PARTY_AUTH] BizX Odata response for user [%s] %s', user_id, response)
+        return self.get_registration_fields(response)
 
 
 def get_saml_idp_choices():

--- a/common/djangoapps/third_party_auth/tests/specs/test_testshib.py
+++ b/common/djangoapps/third_party_auth/tests/specs/test_testshib.py
@@ -375,7 +375,7 @@ class SuccessFactorsIntegrationTest(SamlIntegrationTestUtilities, IntegrationTes
     # assertion metadata. Rather, they will be fetched from the mocked SAPSuccessFactors API.
     USER_EMAIL = "john@smith.com"
     USER_NAME = "John Smith"
-    USER_USERNAME = "jsmith"
+    USER_USERNAME = "John"
 
     def setUp(self):
         """
@@ -426,7 +426,7 @@ class SuccessFactorsIntegrationTest(SamlIntegrationTestUtilities, IntegrationTes
         # Mock the call to the SAP SuccessFactors OData user endpoint
         ODATA_USER_URL = (
             'http://api.successfactors.com/odata/v2/User(userId=\'myself\')'
-            '?$select=username,firstName,lastName,defaultFullName,email'
+            '?$select=firstName,lastName,defaultFullName,email'
         )
 
         def user_callback(request, _uri, headers):
@@ -525,7 +525,7 @@ class SuccessFactorsIntegrationTest(SamlIntegrationTestUtilities, IntegrationTes
         # Mock the call to the SAP SuccessFactors OData user endpoint
         ODATA_USER_URL = (
             'http://api.successfactors.com/odata/v2/User(userId=\'myself\')'
-            '?$select=username,firstName,country,lastName,defaultFullName,email'
+            '?$select=firstName,country,lastName,defaultFullName,email'
         )
 
         def user_callback(request, _uri, headers):


### PR DESCRIPTION
Changes to use user's first name as username for SAP Success Factors SSO. These changes allow us to specify multiple edX field mapping for bizX fields.
For example to map bizX first name to both edX username and first name fields we can define fields mapping like this 
`'firstName': ['username', 'first_name'],`
ENT-1705

### Please consider the following when opening a pull request:

- Link to the relevant JIRA ticket(s) and tag any relevant team(s).
- Squash your changes down into one or more discrete commits.
  In each commit, include description that could help a developer
  several months from now.
- If running `make upgrade`, run _as close to the time of merging as possible_
  to avoid accidentally downgrading someone else's package.
  Put the output of `make upgrade` in its own separate commit,
  decoupled from other code changes.
- Aim for comprehensive test coverage, but remember that
  automated testing isn't a substitute for manual verification.
- Carefully consider naming, code organization, dependencies when adding new code.
  Code that is amenable to refactoring and improvement benefits all platform developers,
  especially given the size and scope of edx-platform.
  Consult existing Architectural Decision Records (ADRs),
  including those concerning the app(s) you are changing and
  [those concerning edx-platform as a whole](https://github.com/edx/edx-platform/tree/master/docs/decisions).
