### PR TITLE
[BB-112] Fix the unpredictable order randomization issue with randomized content blocks

### DIFF
--- a/common/lib/xmodule/xmodule/tests/test_library_content.py
+++ b/common/lib/xmodule/xmodule/tests/test_library_content.py
@@ -272,9 +272,8 @@ class LibraryContentModuleTestMixin(object):
         Helper method that changes the max_count of self.lc_block, refreshes
         children, and asserts that the number of selected children equals the count provided.
         """
-        # Clear the cache (only needed because we skip saving/re-loading the block) pylint: disable=protected-access
-        if hasattr(self.lc_block._xmodule, '_selected_set'):
-            del self.lc_block._xmodule._selected_set
+        # Construct the XModule for the descriptor, if not present already.
+        self.lc_block._xmodule  # pylint: disable=pointless-statement,protected-access
         self.lc_block.max_count = count
         selected = self.lc_block.get_child_descriptors()
         self.assertEqual(len(selected), count)
@@ -287,7 +286,7 @@ class TestLibraryContentModuleNoSearchIndex(LibraryContentModuleTestMixin, Libra
     Tests for library container when no search index is available.
     Tests fallback low-level CAPA problem introspection
     """
-    pass
+    pass  # pylint: disable=unnecessary-pass
 
 
 search_index_mock = Mock(spec=SearchEngine)  # pylint: disable=invalid-name
@@ -365,8 +364,8 @@ class TestLibraryContentAnalytics(LibraryContentTest):
         Check that a LibraryContentModule analytics event was published by self.lc_block.
         """
         self.assertTrue(self.publisher.called)
-        self.assertTrue(len(self.publisher.call_args[0]), 3)
-        _, event_name, event_data = self.publisher.call_args[0]
+        self.assertTrue(len(self.publisher.call_args[0]), 3)  # pylint: disable=unsubscriptable-object
+        _, event_name, event_data = self.publisher.call_args[0]  # pylint: disable=unsubscriptable-object
         self.assertEqual(event_name, "edx.librarycontentblock.content.{}".format(event_type))
         self.assertEqual(event_data["location"], six.text_type(self.lc_block.location))
         return event_data
@@ -397,8 +396,6 @@ class TestLibraryContentAnalytics(LibraryContentTest):
 
         # Now increase max_count so that one more child will be added:
         self.lc_block.max_count = 2
-        # Clear the cache (only needed because we skip saving/re-loading the block) pylint: disable=protected-access
-        del self.lc_block._xmodule._selected_set
         children = self.lc_block.get_child_descriptors()
         self.assertEqual(len(children), 2)
         child, new_child = children if children[0].location == child.location else reversed(children)
@@ -478,8 +475,6 @@ class TestLibraryContentAnalytics(LibraryContentTest):
         self.lc_block.get_child_descriptors()  # This line is needed in the test environment or the change has no effect
         self.publisher.reset_mock()  # Clear the "assigned" event that was just published.
         self.lc_block.max_count = 0
-        # Clear the cache (only needed because we skip saving/re-loading the block) pylint: disable=protected-access
-        del self.lc_block._xmodule._selected_set
 
         # Check that the event says that one block was removed, leaving no blocks left:
         children = self.lc_block.get_child_descriptors()
@@ -497,8 +492,6 @@ class TestLibraryContentAnalytics(LibraryContentTest):
         # Start by assigning two blocks to the student:
         self.lc_block.get_child_descriptors()  # This line is needed in the test environment or the change has no effect
         self.lc_block.max_count = 2
-        # Clear the cache (only needed because we skip saving/re-loading the block) pylint: disable=protected-access
-        del self.lc_block._xmodule._selected_set
         initial_blocks_assigned = self.lc_block.get_child_descriptors()
         self.assertEqual(len(initial_blocks_assigned), 2)
         self.publisher.reset_mock()  # Clear the "assigned" event that was just published.
@@ -512,8 +505,6 @@ class TestLibraryContentAnalytics(LibraryContentTest):
         self.library.children = [keep_block_lib_usage_key]
         self.store.update_item(self.library, self.user_id)
         self.lc_block.refresh_children()
-        # Clear the cache (only needed because we skip saving/re-loading the block) pylint: disable=protected-access
-        del self.lc_block._xmodule._selected_set
 
         # Check that the event says that one block was removed, leaving one block left:
         children = self.lc_block.get_child_descriptors()

--- a/lms/djangoapps/course_blocks/api.py
+++ b/lms/djangoapps/course_blocks/api.py
@@ -40,6 +40,7 @@ def get_course_block_access_transformers(user):
     """
     course_block_access_transformers = [
         library_content.ContentLibraryTransformer(),
+        library_content.ContentLibraryOrderTransformer(),
         start_date.StartDateTransformer(),
         ContentTypeGateTransformer(),
         user_partitions.UserPartitionTransformer(),

--- a/lms/djangoapps/course_blocks/transformers/library_content.py
+++ b/lms/djangoapps/course_blocks/transformers/library_content.py
@@ -4,6 +4,7 @@ Content Library Transformer.
 
 
 import json
+import random
 
 import six
 from eventtracking import tracker
@@ -102,7 +103,8 @@ class ContentLibraryTransformer(FilteringTransformerMixin, BlockStructureTransfo
                 # Save back any changes
                 if any(block_keys[changed] for changed in ('invalid', 'overlimit', 'added')):
                     state_dict['selected'] = list(selected)
-                    StudentModule.save_state(
+                    random.shuffle(state_dict['selected'])
+                    StudentModule.save_state(  # pylint: disable=no-value-for-parameter
                         student=usage_info.user,
                         course_id=usage_info.course_key,
                         module_state_key=block_key,

--- a/lms/djangoapps/course_blocks/transformers/library_content.py
+++ b/lms/djangoapps/course_blocks/transformers/library_content.py
@@ -242,8 +242,9 @@ class ContentLibraryOrderTransformer(BlockStructureTransformer):
                 # before ordering the blocks.
                 if current_children_blocks != current_selected_blocks:
                     logger.info(
-                        u'Mismatch between the children of %s in the stored state and the actual children',
-                        str(block_key)
+                        u'Mismatch between the children of %s in the stored state and the actual children for user %s',
+                        str(block_key),
+                        usage_info.user.username
                     )
                     previous_count = len(current_selected_blocks.intersection(current_children_blocks))
                     mode = block_structure.get_xblock_field(block_key, 'mode')

--- a/lms/djangoapps/course_blocks/transformers/tests/test_library_content.py
+++ b/lms/djangoapps/course_blocks/transformers/tests/test_library_content.py
@@ -1,6 +1,7 @@
 """
 Tests for ContentLibraryTransformer.
 """
+import mock
 
 
 from six.moves import range
@@ -10,7 +11,7 @@ from openedx.core.djangoapps.content.block_structure.transformers import BlockSt
 from student.tests.factories import CourseEnrollmentFactory
 
 from ...api import get_course_blocks
-from ..library_content import ContentLibraryTransformer
+from ..library_content import ContentLibraryTransformer, ContentLibraryOrderTransformer
 from .helpers import CourseStructureTestCase
 
 
@@ -165,5 +166,132 @@ class ContentLibraryTransformerTestCase(CourseStructureTestCase):
                     selected_vertical,
                     selected_child,
                 ),
+                u"Expected 'selected' equality failed in iteration {}.".format(i)
+            )
+
+
+class ContentLibraryOrderTransformerTestCase(CourseStructureTestCase):
+    """
+    ContentLibraryOrderTransformer Test
+    """
+    TRANSFORMER_CLASS_TO_TEST = ContentLibraryOrderTransformer
+
+    def setUp(self):
+        """
+        Setup course structure and create user for content library order transformer test.
+        """
+        super(ContentLibraryOrderTransformerTestCase, self).setUp()
+        self.course_hierarchy = self.get_course_hierarchy()
+        self.blocks = self.build_course(self.course_hierarchy)
+        self.course = self.blocks['course']
+        clear_course_from_cache(self.course.id)
+
+        # Enroll user in course.
+        CourseEnrollmentFactory.create(user=self.user, course_id=self.course.id, is_active=True)
+
+    def get_course_hierarchy(self):
+        """
+        Get a course hierarchy to test with.
+        """
+        return [{
+            'org': 'ContentLibraryTransformer',
+            'course': 'CL101F',
+            'run': 'test_run',
+            '#type': 'course',
+            '#ref': 'course',
+            '#children': [
+                {
+                    '#type': 'chapter',
+                    '#ref': 'chapter1',
+                    '#children': [
+                        {
+                            '#type': 'sequential',
+                            '#ref': 'lesson1',
+                            '#children': [
+                                {
+                                    '#type': 'vertical',
+                                    '#ref': 'vertical1',
+                                    '#children': [
+                                        {
+                                            'metadata': {'category': 'library_content'},
+                                            '#type': 'library_content',
+                                            '#ref': 'library_content1',
+                                            '#children': [
+                                                {
+                                                    'metadata': {'display_name': "CL Vertical 2"},
+                                                    '#type': 'vertical',
+                                                    '#ref': 'vertical2',
+                                                    '#children': [
+                                                        {
+                                                            'metadata': {'display_name': "HTML1"},
+                                                            '#type': 'html',
+                                                            '#ref': 'html1',
+                                                        }
+                                                    ]
+                                                },
+                                                {
+                                                    'metadata': {'display_name': "CL Vertical 3"},
+                                                    '#type': 'vertical',
+                                                    '#ref': 'vertical3',
+                                                    '#children': [
+                                                        {
+                                                            'metadata': {'display_name': "HTML2"},
+                                                            '#type': 'html',
+                                                            '#ref': 'html2',
+                                                        }
+                                                    ]
+                                                },
+                                                {
+                                                    'metadata': {'display_name': "CL Vertical 4"},
+                                                    '#type': 'vertical',
+                                                    '#ref': 'vertical4',
+                                                    '#children': [
+                                                        {
+                                                            'metadata': {'display_name': "HTML3"},
+                                                            '#type': 'html',
+                                                            '#ref': 'html3',
+                                                        }
+                                                    ]
+                                                }
+                                            ]
+                                        }
+                                    ],
+                                }
+                            ],
+                        }
+                    ],
+                }
+            ]
+        }]
+
+    @mock.patch('lms.djangoapps.course_blocks.transformers.library_content.get_student_module_as_dict')
+    def test_content_library_randomize(self, mocked):
+        """
+        Test whether the order of the children blocks matches the order of the selected blocks when
+        course has content library section
+        """
+        mocked.return_value = {
+            'selected': [
+                ['vertical', 'vertical_vertical3'],
+                ['vertical', 'vertical_vertical2'],
+                ['vertical', 'vertical_vertical4'],
+            ]
+        }
+        for i in range(5):
+            trans_block_structure = get_course_blocks(
+                self.user,
+                self.course.location,
+                self.transformers,
+            )
+            children = []
+            for block_key in trans_block_structure.topological_traversal():
+                if block_key.block_type == 'library_content':
+                    children = trans_block_structure.get_children(block_key)
+                    break
+
+            expected_children = ['vertical_vertical3', 'vertical_vertical2', 'vertical_vertical4']
+            self.assertEqual(
+                expected_children,
+                [child.block_id for child in children],
                 u"Expected 'selected' equality failed in iteration {}.".format(i)
             )

--- a/lms/djangoapps/course_blocks/transformers/tests/test_library_content.py
+++ b/lms/djangoapps/course_blocks/transformers/tests/test_library_content.py
@@ -1,10 +1,10 @@
 """
 Tests for ContentLibraryTransformer.
 """
-import mock
 
 
 from six.moves import range
+import mock
 
 from openedx.core.djangoapps.content.block_structure.api import clear_course_from_cache
 from openedx.core.djangoapps.content.block_structure.transformers import BlockStructureTransformers

--- a/setup.py
+++ b/setup.py
@@ -53,6 +53,7 @@ setup(
         ],
         "openedx.block_structure_transformer": [
             "library_content = lms.djangoapps.course_blocks.transformers.library_content:ContentLibraryTransformer",
+            "library_content_randomize = lms.djangoapps.course_blocks.transformers.library_content:ContentLibraryOrderTransformer",
             "split_test = lms.djangoapps.course_blocks.transformers.split_test:SplitTestTransformer",
             "start_date = lms.djangoapps.course_blocks.transformers.start_date:StartDateTransformer",
             "user_partitions = lms.djangoapps.course_blocks.transformers.user_partitions:UserPartitionTransformer",


### PR DESCRIPTION
This PR (supersedes PR #20723, which was reverted in PR #21222, and  PR #18675 which was merged and then reverted due to [issues](https://github.com/edx/edx-platform/pull/18675#discussion_r282153049)) contains changes to the Randomized Content Block XBlock. The XBlock has unpredictable randomization of the order of the selected child blocks due to the usage of sets, which are unordered, for storing the selected blocks. This becomes apparent when all the available child blocks in a library are chosen for a Randomized Content Block to randomize just the order of the child blocks. 

This PR modifies the XBlock to store the selected child blocks in a list after randomly shuffling them.

To guard against the exceptions seen after PR #18675 was merged, this PR also adds defensive checks for such error conditions and redoes the selection if the selected children blocks stored in the `StudentModule` no longer match the current children of the current library_content block. It also logs a message when this happens.

@ormsbee had mentioned [here](https://github.com/edx/edx-platform/pull/21222#issue-301245295) that a better testing plan was needed before this could be merged and deployed. However, there has be no progress on that front and this PR is to restart that conversation.

**JIRA tickets**:  [OSPR-4149](https://openedx.atlassian.net/browse/OSPR-4149)

**Dependencies**: None

**Sandbox URL**:  TBD
**Merge deadline**: None

**Testing instructions**:

1. Login to the CMS as a user who can create and edit courses.
1. Create a library with a few child components.
1. Add a unit to a course.
1. Add a Randomized Content Block to the unit.
1. Select the library created above as the source for this XBlock.
1. Select all types of children to be shown.
1. Specify the total number of components present in the library as the number of components to display.
1. Save the unit and publish it.
1. Register a few students to this course.
1. Navigate to the unit containing this Randomized Content Block.
1. Verify that the order of the content blocks are randomized for every student.
1. Also verify that the same order of children blocks is returned by the `course_blocks` API for that randomized content block.

**Reviewers**
- [ ] @kaizoku 
- [ ] edX reviewer[s] TBD (@ormsbee maybe?)
