### PR TITLE
Updated requirements by make upgrade

### DIFF
--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -147,7 +147,7 @@ lazy==1.4                 # via -r requirements/edx/paver.txt, acid-xblock, ora2
 lepl==5.1.3               # via rfc6266-parser
 libsass==0.10.0           # via -r requirements/edx/paver.txt, ora2
 loremipsum==1.0.5         # via ora2
-git+https://github.com/edx/xblock-lti-consumer.git@v1.2.3#egg=lti_consumer-xblock==1.2.3  # via -r requirements/edx/github.in
+git+https://github.com/edx/xblock-lti-consumer.git@v1.2.4#egg=lti_consumer-xblock==1.2.4  # via -r requirements/edx/github.in
 lxml==4.5.0               # via -r requirements/edx/../edx-sandbox/shared.txt, capa, edxval, lti-consumer-xblock, ora2, safe-lxml, xblock, xmlsec
 mailsnake==1.6.4          # via -r requirements/edx/base.in
 mako==1.0.2               # via -r requirements/edx/base.in, acid-xblock, lti-consumer-xblock, xblock-google-drive, xblock-utils

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -177,7 +177,7 @@ lazy==1.4                 # via -r requirements/edx/testing.txt, acid-xblock, bo
 lepl==5.1.3               # via -r requirements/edx/testing.txt, rfc6266-parser
 libsass==0.10.0           # via -r requirements/edx/testing.txt, ora2
 loremipsum==1.0.5         # via -r requirements/edx/testing.txt, ora2
-git+https://github.com/edx/xblock-lti-consumer.git@v1.2.3#egg=lti_consumer-xblock==1.2.3  # via -r requirements/edx/testing.txt
+git+https://github.com/edx/xblock-lti-consumer.git@v1.2.4#egg=lti_consumer-xblock==1.2.4  # via -r requirements/edx/testing.txt
 lxml==4.5.0               # via -r requirements/edx/testing.txt, capa, edxval, lti-consumer-xblock, ora2, pyquery, safe-lxml, xblock, xmlsec
 m2r==0.2.1                # via sphinxcontrib-openapi
 mailsnake==1.6.4          # via -r requirements/edx/testing.txt

--- a/requirements/edx/github.in
+++ b/requirements/edx/github.in
@@ -91,7 +91,7 @@ git+https://github.com/edx/crowdsourcehinter.git@a7ffc85b134b7d8909bf1fefd23dbdb
 -e git+https://github.com/edx/RateXBlock.git@2.0#egg=rate-xblock
 -e git+https://github.com/edx/DoneXBlock.git@2.0.1#egg=done-xblock
 -e git+https://github.com/edx-solutions/xblock-google-drive.git@2d176468e33c0713c911b563f8f65f7cf232f5b6#egg=xblock-google-drive
-git+https://github.com/edx/xblock-lti-consumer.git@v1.2.3#egg=lti_consumer-xblock==1.2.3
+git+https://github.com/edx/xblock-lti-consumer.git@v1.2.4#egg=lti_consumer-xblock==1.2.4
 
 
 # Third Party XBlocks

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -170,7 +170,7 @@ lazy==1.4                 # via -r requirements/edx/base.txt, acid-xblock, bok-c
 lepl==5.1.3               # via -r requirements/edx/base.txt, rfc6266-parser
 libsass==0.10.0           # via -r requirements/edx/base.txt, ora2
 loremipsum==1.0.5         # via -r requirements/edx/base.txt, ora2
-git+https://github.com/edx/xblock-lti-consumer.git@v1.2.3#egg=lti_consumer-xblock==1.2.3  # via -r requirements/edx/base.txt
+git+https://github.com/edx/xblock-lti-consumer.git@v1.2.4#egg=lti_consumer-xblock==1.2.4  # via -r requirements/edx/base.txt
 lxml==4.5.0               # via -r requirements/edx/base.txt, capa, edxval, lti-consumer-xblock, ora2, pyquery, safe-lxml, xblock, xmlsec
 mailsnake==1.6.4          # via -r requirements/edx/base.txt
 mako==1.0.2               # via -r requirements/edx/base.txt, acid-xblock, lti-consumer-xblock, xblock-google-drive, xblock-utils


### PR DESCRIPTION
In this PR dependencies are updated mainly for `lti-consumer` to bump up it's version to `1.2.4`, by running `make upgrade`