### PR TITLE
EDUCATOR-4920 Control permission to REST endpoint

### DIFF
--- a/openedx/core/lib/teams_config.py
+++ b/openedx/core/lib/teams_config.py
@@ -308,6 +308,13 @@ class TeamsetConfig(object):
         except (KeyError, ValueError):
             return TeamsetType.get_default()
 
+    @cached_property
+    def is_private_managed(self):
+        """
+        Returns true if teamsettype is private_managed
+        """
+        return self.teamset_type == TeamsetType.private_managed
+
 
 class TeamsetType(Enum):
     """


### PR DESCRIPTION
[Related ticket](https://openedx.atlassian.net/browse/EDUCATOR-4920)
Control access to REST endpoint for private_managed courses.