### PR TITLE
Fix unit link to courseware MFE

### DIFF
--- a/lms/djangoapps/courseware/views/index.py
+++ b/lms/djangoapps/courseware/views/index.py
@@ -482,7 +482,12 @@ class CoursewareIndex(View):
                 table_of_contents['previous_of_active_section'],
                 table_of_contents['next_of_active_section'],
             )
-            courseware_context['unit'] = section_context.get('activate_block_id', '')
+            possible_unit = section_context.get('activate_block_id', '') or ''
+            # technically, this could be any block id (typically, the id of the current subsection),
+            # so we want to be sure to only pass through a unit because it'll be used to create a link
+            # to the new courseware MFE unit
+            if 'type@vertical' in possible_unit:
+                courseware_context['unit'] = possible_unit
             courseware_context['fragment'] = self.section.render(self.view, section_context)
 
             if self.section.position and self.section.has_children:


### PR DESCRIPTION
When we create links based on the activate_unit_id request variable, we should make sure that it's actually a unit id.

Otherwise, the link to the new courseware MFE might erroneously load a sequence inside a sequence.

