### PR TITLE
Add USER_ACCOUNT_ACTIVATED signal

### DIFF
--- a/common/djangoapps/student/models.py
+++ b/common/djangoapps/student/models.py
@@ -70,6 +70,7 @@ from openedx.core.djangoapps.enrollments.api import (
     get_enrollment_attributes,
     set_enrollment_attributes
 )
+from openedx.core.djangoapps.signals.signals import USER_ACCOUNT_ACTIVATED
 from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
 from openedx.core.djangoapps.xmodule_django.models import NoneToEmptyManager
 from openedx.core.djangolib.model_mixins import DeletableByUserValue
@@ -839,6 +840,7 @@ class Registration(models.Model):
     def activate(self):
         self.user.is_active = True
         self.user.save(update_fields=['is_active'])
+        USER_ACCOUNT_ACTIVATED.send_robust(self.__class__, user=self.user)
         log.info(u'User %s (%s) account is successfully activated.', self.user.username, self.user.email)
 
 

--- a/common/djangoapps/student/tests/test_activate_account.py
+++ b/common/djangoapps/student/tests/test_activate_account.py
@@ -70,6 +70,17 @@ class TestActivateAccount(TestCase):
         self.assertTrue(self.user.is_active)
         self.assertFalse(mock_segment_identify.called)
 
+    @patch('student.models.USER_ACCOUNT_ACTIVATED')
+    def test_activation_signal(self, mock_signal):
+        """
+        Verify that USER_ACCOUNT_ACTIVATED is emitted upon account email activation.
+        """
+        assert not self.user.is_active, 'Ensure that the user starts inactive'
+        assert not mock_signal.send_robust.call_count, 'Ensure no signal is fired before activation'
+        self.registration.activate()  # Until you explicitly activate it
+        assert self.user.is_active, 'Sanity check for .activate()'
+        mock_signal.send_robust.assert_called_once_with(Registration, user=self.user)  # Ensure the signal is emitted
+
     def test_account_activation_message(self):
         """
         Verify that account correct activation message is displayed.

--- a/openedx/core/djangoapps/signals/signals.py
+++ b/openedx/core/djangoapps/signals/signals.py
@@ -33,5 +33,7 @@ COURSE_GRADE_NOW_FAILED = Signal(
     ]
 )
 
-# Signal that indicates that a user has become verified
+# Signal that indicates that a user has become verified for certificate purposes
 LEARNER_NOW_VERIFIED = Signal(providing_args=['user'])
+
+USER_ACCOUNT_ACTIVATED = Signal(providing_args=["user"])  # Signal indicating email verification


### PR DESCRIPTION
This helps plugins to listen to this signal and perform custom logic without the need to hardcode it inside the platform.

This is one of the extension points I need to make the [Course Access Groups](https://github.com/appsembler/course-access-groups) plugin possible. Next up is the [Access Control Backends (Open edX Discussions)](https://discuss.openedx.org/t/pluggable-access-control-both-viewing-and-enrolling-in-a-course/803), which is the second part to make access control modifiable by plugins.
