### PR TITLE
Update shard assignments for bokchoy.

### DIFF
--- a/common/test/acceptance/tests/discussion/test_cohort_management.py
+++ b/common/test/acceptance/tests/discussion/test_cohort_management.py
@@ -688,7 +688,7 @@ class CohortConfigurationTest(EventsTestMixin, UniqueCourseTest, CohortTestMixin
         self.cohort_management_page.a11y_audit.check_for_accessibility_errors()
 
 
-@attr(shard=6)
+@attr(shard=15)
 class CohortContentGroupAssociationTest(UniqueCourseTest, CohortTestMixin):
     """
     Tests for linking between content groups and cohort in the instructor dashboard.

--- a/common/test/acceptance/tests/discussion/test_discussion_management.py
+++ b/common/test/acceptance/tests/discussion/test_discussion_management.py
@@ -103,7 +103,7 @@ class BaseDividedDiscussionTest(UniqueCourseTest, CohortTestMixin):
         self.assertIn("Your changes have been saved.", confirmation_message)
 
 
-@attr(shard=6)
+@attr(shard=15)
 class DividedDiscussionTopicsTest(BaseDividedDiscussionTest):
     """
     Tests for dividing the inline and course-wide discussion topics.

--- a/common/test/acceptance/tests/lms/test_lms_instructor_dashboard.py
+++ b/common/test/acceptance/tests/lms/test_lms_instructor_dashboard.py
@@ -125,7 +125,7 @@ class BulkEmailTest(BaseInstructorDashboardTest):
         self.send_email_page.a11y_audit.check_for_accessibility_errors()
 
 
-@attr(shard=3)
+@attr(shard=20)
 class AutoEnrollmentWithCSVTest(BaseInstructorDashboardTest):
     """
     End-to-end tests for Auto-Registration and enrollment functionality via CSV file.

--- a/common/test/acceptance/tests/lms/test_lms_problems.py
+++ b/common/test/acceptance/tests/lms/test_lms_problems.py
@@ -415,7 +415,7 @@ class ProblemSubmitButtonPastDueTest(ProblemsTest):
         problem_page.wait_for_submit_disabled()
 
 
-@attr(shard=9)
+@attr(shard=19)
 class ProblemExtendedHintTest(ProblemHintTest, EventsTestMixin):
     """
     Test that extended hint features plumb through to the page html and tracking log.

--- a/common/test/acceptance/tests/lms/test_lms_user_preview.py
+++ b/common/test/acceptance/tests/lms/test_lms_user_preview.py
@@ -102,6 +102,7 @@ class StaffViewToggleTest(CourseWithoutContentGroupsTest):
         self.assertFalse(course_page.has_tab('Instructor'))
 
 
+@attr(shard=20)
 class CourseWithContentGroupsTest(StaffViewTest):
     """
     Verifies that changing the "View this course as" selector works properly for content groups.
@@ -182,7 +183,6 @@ class CourseWithContentGroupsTest(StaffViewTest):
             )
         )
 
-    @attr(shard=20)
     def test_staff_sees_all_problems(self):
         """
         Scenario: Staff see all problems
@@ -198,7 +198,6 @@ class CourseWithContentGroupsTest(StaffViewTest):
             [self.alpha_text, self.beta_text, self.audit_text, self.everyone_text]
         )
 
-    @attr(shard=3)
     def test_student_not_in_content_group(self):
         """
         Scenario: When previewing as a learner, only content visible to all is shown
@@ -212,7 +211,6 @@ class CourseWithContentGroupsTest(StaffViewTest):
         course_page.set_staff_view_mode('Learner')
         verify_expected_problem_visibility(self, course_page, [self.everyone_text])
 
-    @attr(shard=3)
     def test_as_student_in_alpha(self):
         """
         Scenario: When previewing as a learner in group alpha, only content visible to alpha is shown
@@ -226,7 +224,6 @@ class CourseWithContentGroupsTest(StaffViewTest):
         course_page.set_staff_view_mode('Learner in alpha')
         verify_expected_problem_visibility(self, course_page, [self.alpha_text, self.everyone_text])
 
-    @attr(shard=3)
     def test_as_student_in_beta(self):
         """
         Scenario: When previewing as a learner in group beta, only content visible to beta is shown
@@ -240,7 +237,6 @@ class CourseWithContentGroupsTest(StaffViewTest):
         course_page.set_staff_view_mode('Learner in beta')
         verify_expected_problem_visibility(self, course_page, [self.beta_text, self.everyone_text])
 
-    @attr(shard=3)
     def test_as_student_in_audit(self):
         """
         Scenario: When previewing as a learner in the audit enrollment track, only content visible to audit is shown

--- a/common/test/acceptance/tests/lms/test_problem_types.py
+++ b/common/test/acceptance/tests/lms/test_problem_types.py
@@ -619,7 +619,7 @@ class AnnotationProblemTypeTest(AnnotationProblemTypeBase, ProblemTypeTestMixin)
     """
     Standard tests for the Annotation Problem Type
     """
-    shard = 24
+    shard = 20
     pass
 
 
@@ -668,7 +668,7 @@ class CheckboxProblemTypeTest(CheckboxProblemTypeBase, ProblemTypeTestMixin, Cha
     """
     Standard tests for the Checkbox Problem Type
     """
-    shard = 24
+    shard = 18
 
     def test_can_show_answer(self):
         """
@@ -803,7 +803,7 @@ class MultipleChoiceProblemResetCorrectnessAfterChangingAnswerTest(MultipleChoic
     """
     Tests for Multiple choice problem with changing answers
     """
-    shard = 24
+    shard = 18
 
     @ddt.data(['correct', '1/1 point (ungraded)'], ['incorrect', '0/1 point (ungraded)'])
     @ddt.unpack
@@ -1105,7 +1105,7 @@ class RadioProblemTypeTestNonRandomized(RadioProblemTypeBase, NonRandomizedProbl
     """
     Tests for non-randomized radio problem
     """
-    shard = 24
+    shard = 8
 
     def get_problem(self):
         """
@@ -1159,7 +1159,7 @@ class DropdownProblemTypeTest(DropDownProblemTypeBase, ProblemTypeTestMixin, Cha
     """
     Standard tests for the Dropdown Problem Type
     """
-    shard = 24
+    shard = 8
     pass
 
 
@@ -1168,7 +1168,7 @@ class DropDownProblemTypeTestNonRandomized(DropDownProblemTypeBase, NonRandomize
     """
     Tests for non-randomized Dropdown problem
     """
-    shard = 24
+    shard = 8
 
     def get_problem(self):
         """
@@ -1243,7 +1243,7 @@ class StringProblemTypeTest(StringProblemTypeBase, ProblemTypeTestMixin):
     """
     Standard tests for the String Problem Type
     """
-    shard = 24
+    shard = 8
     pass
 
 
@@ -1559,7 +1559,7 @@ class ScriptProblemTypeTest(ScriptProblemTypeBase, ProblemTypeTestMixin):
     """
     Standard tests for the Script Problem Type
     """
-    shard = 24
+    shard = 20
     pass
 
 
@@ -1568,7 +1568,7 @@ class ScriptProblemResetAfterAnswerTest(ScriptProblemTypeBase):
     """
     Test Script problem by resetting answers
     """
-    shard = 24
+    shard = 8
 
     @ddt.data(['correct', 'incorrect'], ['incorrect', 'correct'])
     @ddt.unpack
@@ -1614,7 +1614,7 @@ class ScriptProblemTypeTestNonRandomized(ScriptProblemTypeBase, NonRandomizedPro
     """
     Tests for non-randomized Script problem
     """
-    shard = 24
+    shard = 8
 
     def get_problem(self):
         """
@@ -1841,7 +1841,7 @@ class RadioTextProblemTypeTest(RadioTextProblemTypeBase, ProblemTypeTestMixin):
     """
     Standard tests for the Radio Text Problem Type
     """
-    shard = 24
+    shard = 8
     pass
 
 
@@ -1850,7 +1850,7 @@ class RadioTextProblemResetCorrectnessAfterChangingAnswerTest(RadioTextProblemTy
     """
     Tests for Radio Text problem with changing answers
     """
-    shard = 24
+    shard = 18
 
     @ddt.data(['correct', '1/1 point (ungraded)'], ['incorrect', '0/1 point (ungraded)'])
     @ddt.unpack

--- a/common/test/acceptance/tests/lms/test_teams.py
+++ b/common/test/acceptance/tests/lms/test_teams.py
@@ -591,7 +591,7 @@ class BrowseTopicsTest(TeamsTabBase):
             self.topics_page.visit()
 
 
-@attr(shard=5)
+@attr(shard=4)
 @ddt.ddt
 class BrowseTeamsWithinTopicTest(TeamsTabBase):
     """
@@ -991,7 +991,7 @@ class TeamFormActions(TeamsTabBase):
         )
 
 
-@attr(shard=5)
+@attr(shard=4)
 @ddt.ddt
 class CreateTeamTest(TeamFormActions):
     """

--- a/common/test/acceptance/tests/studio/test_studio_container.py
+++ b/common/test/acceptance/tests/studio/test_studio_container.py
@@ -185,7 +185,7 @@ class DeleteComponentTest(NestedVerticalTest):
         self.delete_and_verify(group_a_item_1_delete_index, expected_ordering)
 
 
-@attr(shard=16)
+@attr(shard=19)
 class EditContainerTest(NestedVerticalTest):
     """
     Tests of editing a container.
@@ -621,7 +621,7 @@ class ContentGroupVisibilityModalTest(BaseGroupConfigurationsTest):
         self.remove_missing_groups(visibility_editor, self.html_component)
 
 
-@attr(shard=3)
+@attr(shard=20)
 class EnrollmentTrackVisibilityModalTest(BaseGroupConfigurationsTest):
     """
     Tests of the visibility settings modal for components on the unit
@@ -1120,7 +1120,7 @@ class UnitPublishingTest(ContainerBase):
     #     self.assertEqual('discussion', self.courseware.xblock_component_type(1))
 
 
-@attr(shard=3)
+@attr(shard=20)
 class DisplayNameTest(ContainerBase):
     """
     Test consistent use of display_name_with_default

--- a/common/test/acceptance/tests/studio/test_studio_discussion_component.py
+++ b/common/test/acceptance/tests/studio/test_studio_discussion_component.py
@@ -15,7 +15,7 @@ class DiscussionComponentTest(ContainerBase):
     Feature: CMS.Component Adding
     As a course author, I want to be able to add and edit Discussion component
     """
-    shard = 14
+    shard = 20
 
     def setUp(self, is_staff=True):
         """

--- a/common/test/acceptance/tests/studio/test_studio_grading.py
+++ b/common/test/acceptance/tests/studio/test_studio_grading.py
@@ -15,7 +15,7 @@ class GradingPageTest(StudioCourseTest):
     """
     Bockchoy tests to add/edit grade settings in studio.
     """
-    shard = 13
+    shard = 23
 
     url = None
     GRACE_FIELD_CSS = "#course-grading-graceperiod"

--- a/common/test/acceptance/tests/studio/test_studio_outline.py
+++ b/common/test/acceptance/tests/studio/test_studio_outline.py
@@ -81,7 +81,7 @@ class CourseOutlineTest(StudioCourseTest):
         verify_ordering(self, outline_page, expected_ordering)
 
 
-@attr(shard=3)
+@attr(shard=20)
 class CourseOutlineDragAndDropTest(CourseOutlineTest):
     """
     Tests of drag and drop within the outline page.
@@ -924,7 +924,7 @@ class StaffLockTest(CourseOutlineTest):
         self._remove_staff_lock_and_verify_warning(subsection, False)
 
 
-@attr(shard=14)
+@attr(shard=20)
 class EditNamesTest(CourseOutlineTest):
     """
     Feature: Click-to-edit section/subsection names
@@ -1127,7 +1127,7 @@ class CreateSectionsTest(CourseOutlineTest):
         self.assertTrue(unit_page.is_inline_editing_display_name())
 
 
-@attr(shard=14)
+@attr(shard=4)
 class DeleteContentTest(CourseOutlineTest):
     """
     Feature: Deleting sections/subsections/units
@@ -1453,7 +1453,7 @@ class ExpandCollapseEmptyTest(CourseOutlineTest):
         self.assertFalse(self.course_outline_page.section_at(0).is_collapsed)
 
 
-@attr(shard=14)
+@attr(shard=20)
 class DefaultStatesEmptyTest(CourseOutlineTest):
     """
     Feature: Misc course outline default states/actions when starting with an empty course
@@ -1478,7 +1478,7 @@ class DefaultStatesEmptyTest(CourseOutlineTest):
         self.assertTrue(self.course_outline_page.bottom_add_section_button.is_present())
 
 
-@attr(shard=14)
+@attr(shard=4)
 class DefaultStatesContentTest(CourseOutlineTest):
     """
     Feature: Misc course outline default states/actions when starting with a course with content
@@ -1876,7 +1876,7 @@ class SelfPacedOutlineTest(CourseOutlineTest):
 
 class CourseStatusOutlineTest(CourseOutlineTest):
     """Test the course outline status section."""
-    shard = 6
+    shard = 8
 
     def setUp(self):
         super(CourseStatusOutlineTest, self).setUp()

--- a/common/test/acceptance/tests/studio/test_studio_settings.py
+++ b/common/test/acceptance/tests/studio/test_studio_settings.py
@@ -381,7 +381,7 @@ class StudioSubsectionSettingsA11yTest(StudioCourseTest):
         self.course_outline.a11y_audit.check_for_accessibility_errors()
 
 
-@attr(shard=16)
+@attr(shard=15)
 class StudioSettingsImageUploadTest(StudioCourseTest):
     """
     Class to test course settings image uploads.

--- a/common/test/acceptance/tests/video/test_video_events.py
+++ b/common/test/acceptance/tests/video/test_video_events.py
@@ -153,7 +153,7 @@ class VideoHLSEventsTest(VideoEventsTestMixin):
     """
     Test video player event emission for HLS video
     """
-    shard = 16
+    shard = 19
 
     def test_event_data_for_hls(self):
         """


### PR DESCRIPTION
Based on latest runs after all flaky and low value tests have been removed.

We should see a 2-3 minute reduction on all bokchoy builds as a result.