### PR TITLE
Redirect to learning microfrontend, except for exams

### DIFF
--- a/lms/djangoapps/courseware/tests/test_views.py
+++ b/lms/djangoapps/courseware/tests/test_views.py
@@ -304,19 +304,9 @@ class IndexQueryTestCase(ModuleStoreTestCase):
                 self.assertEqual(response.status_code, 200)
 
 
-@ddt.ddt
-class ViewsTestCase(ModuleStoreTestCase):
-    """
-    Tests for views.py methods.
-    """
-    YESTERDAY = 'yesterday'
-    DATES = {
-        YESTERDAY: datetime.now(UTC) - timedelta(days=1),
-        None: None,
-    }
-
+class BaseViewsTestCase(ModuleStoreTestCase):
     def setUp(self):
-        super(ViewsTestCase, self).setUp()
+        super(BaseViewsTestCase, self).setUp()
         self.course = CourseFactory.create(display_name=u'teꜱᴛ course', run="Testing_course")
         with self.store.bulk_operations(self.course.id):
             self.chapter = ItemFactory.create(
@@ -375,6 +365,25 @@ class ViewsTestCase(ModuleStoreTestCase):
 
         # refresh the course from the modulestore so that it has children
         self.course = modulestore().get_course(self.course.id)
+
+    def _create_global_staff_user(self):
+        """
+        Create global staff user and log them in
+        """
+        self.global_staff = GlobalStaffFactory.create()  # pylint: disable=attribute-defined-outside-init
+        self.assertTrue(self.client.login(username=self.global_staff.username, password=TEST_PASSWORD))
+
+
+@ddt.ddt
+class ViewsTestCase(BaseViewsTestCase):
+    """
+    Tests for views.py methods.
+    """
+    YESTERDAY = 'yesterday'
+    DATES = {
+        YESTERDAY: datetime.now(UTC) - timedelta(days=1),
+        None: None,
+    }
 
     def test_index_success(self):
         response = self._verify_index_response()
@@ -442,13 +451,6 @@ class ViewsTestCase(ModuleStoreTestCase):
         self.assertEqual(response.status_code, 200)
         self.assertNotContains(response, 'Problem 1')
         self.assertNotContains(response, 'Problem 2')
-
-    def _create_global_staff_user(self):
-        """
-        Create global staff user and log them in
-        """
-        self.global_staff = GlobalStaffFactory.create()  # pylint: disable=attribute-defined-outside-init
-        self.assertTrue(self.client.login(username=self.global_staff.username, password=TEST_PASSWORD))
 
     def _create_url_for_enroll_staff(self):
         """
@@ -3348,3 +3350,50 @@ class TestShowCoursewareMFE(TestCase):
             '/block-v1:OpenEdX+MFE+2020+type@sequential+block@Introduction'
             '/block-v1:OpenEdX+MFE+2020+type@vertical+block@Getting_To_Know_You'
         )
+
+
+@patch.dict('django.conf.settings.FEATURES', {'ENABLE_COURSEWARE_MICROFRONTEND': True})
+@ddt.ddt
+class MFERedirectTests(BaseViewsTestCase):
+    def _get_urls(self):
+        lms_url = reverse(
+            'courseware_section',
+            kwargs={
+                'course_id': str(self.course_key),
+                'chapter': str(self.chapter.location.block_id),
+                'section': str(self.section2.location.block_id),
+            }
+        )
+        mfe_url = '{}/course/{}/{}'.format(
+            settings.LEARNING_MICROFRONTEND_URL,
+            self.course_key,
+            self.section2.location
+        )
+        return lms_url, mfe_url
+
+    def test_learner_redirect(self):
+        # learners will be redirected when the waffle flag is set
+        lms_url, mfe_url = self._get_urls()
+
+        with override_waffle_flag(REDIRECT_TO_COURSEWARE_MICROFRONTEND, True):
+            assert self.client.get(lms_url).url == mfe_url
+
+    def test_staff_no_redirect(self):
+        # global staff will never be redirected
+        lms_url, mfe_url = self._get_urls()
+
+        self._create_global_staff_user()
+        assert self.client.get(lms_url).status_code == 200
+
+        with override_waffle_flag(REDIRECT_TO_COURSEWARE_MICROFRONTEND, True):
+            assert self.client.get(lms_url).status_code == 200
+
+    def test_exam_no_redirect(self):
+        # exams will not redirect to the mfe, for the time being
+        self.section2.is_time_limited = True
+        self.store.update_item(self.section2, self.user.id)
+
+        lms_url, mfe_url = self._get_urls()
+
+        with override_waffle_flag(REDIRECT_TO_COURSEWARE_MICROFRONTEND, True):
+            assert self.client.get(lms_url).status_code == 200

--- a/lms/djangoapps/courseware/views/index.py
+++ b/lms/djangoapps/courseware/views/index.py
@@ -30,13 +30,7 @@ from opaque_keys.edx.keys import CourseKey, UsageKey
 from web_fragments.fragment import Fragment
 
 from edxmako.shortcuts import render_to_response, render_to_string
-from lms.djangoapps.courseware.courses import allow_public_access
-from lms.djangoapps.courseware.exceptions import CourseAccessRedirect
-from lms.djangoapps.courseware.toggles import (
-    COURSEWARE_MICROFRONTEND_COURSE_TEAM_PREVIEW,
-    should_redirect_to_courseware_microfrontend,
-)
-from lms.djangoapps.courseware.url_helpers import get_microfrontend_url
+from lms.djangoapps.courseware.exceptions import CourseAccessRedirect, Redirect
 from lms.djangoapps.experiments.utils import get_experiment_user_metadata_context
 from lms.djangoapps.gating.api import get_entrance_exam_score_ratio, get_entrance_exam_usage_key
 from lms.djangoapps.grades.api import CourseGradeFactory
@@ -62,7 +56,13 @@ from xmodule.modulestore.django import modulestore
 from xmodule.x_module import PUBLIC_VIEW, STUDENT_VIEW
 
 from ..access import has_access
-from ..courses import check_course_access, get_course_with_access, get_current_child, get_studio_url
+from ..courses import (
+    allow_public_access,
+    check_course_access,
+    get_course_with_access,
+    get_current_child,
+    get_studio_url
+)
 from ..entrance_exams import (
     course_has_entrance_exam,
     get_entrance_exam_content,
@@ -73,6 +73,8 @@ from ..masquerade import check_content_start_date_for_masquerade_user, setup_mas
 from ..model_data import FieldDataCache
 from ..module_render import get_module_for_descriptor, toc_for_course
 from ..permissions import MASQUERADE_AS_STUDENT
+from ..toggles import COURSEWARE_MICROFRONTEND_COURSE_TEAM_PREVIEW, should_redirect_to_courseware_microfrontend
+from ..url_helpers import get_microfrontend_url
 
 from .views import CourseTabView
 
@@ -185,6 +187,22 @@ class CoursewareIndex(View):
         # Set the user in the request to the effective user.
         self.request.user = self.effective_user
 
+    def _redirect_to_learning_mfe(self, request):
+        """
+        Redirect to the new courseware micro frontend,
+        unless this is a time limited exam.
+
+        TODO: remove this once exams work in the new MFE.
+        """
+        if (not self.section.is_time_limited) \
+                and should_redirect_to_courseware_microfrontend(self.course_key) \
+                and not request.user.is_staff:
+            url = get_microfrontend_url(
+                self.course_key,
+                self.section.location
+            )
+            raise Redirect(url)
+
     def render(self, request):
         """
         Render the index page.
@@ -201,6 +219,7 @@ class CoursewareIndex(View):
                 self._redirect_if_not_requested_section()
                 self._save_positions()
                 self._prefetch_and_bind_section()
+                self._redirect_to_learning_mfe(request)
 
             check_content_start_date_for_masquerade_user(self.course_key, self.effective_user, request,
                                                          self.course.start, self.chapter.start, self.section.start)

--- a/lms/djangoapps/courseware/views/index.py
+++ b/lms/djangoapps/courseware/views/index.py
@@ -191,12 +191,17 @@ class CoursewareIndex(View):
         """
         Redirect to the new courseware micro frontend,
         unless this is a time limited exam.
-
-        TODO: remove this once exams work in the new MFE.
         """
-        if (not getattr(self.section, 'is_time_limited', False)) \
-                and should_redirect_to_courseware_microfrontend(self.course_key) \
-                and not request.user.is_staff:
+        # learners should redirect, if the waffle flag is set
+        if should_redirect_to_courseware_microfrontend(self.course_key):
+            # but exams should not redirect to the mfe until they're supported
+            if getattr(self.section, 'is_time_limited', False):
+                return
+
+            # and staff will not redirect, either
+            if self.is_staff:
+                return
+
             url = get_microfrontend_url(
                 self.course_key,
                 self.section.location

--- a/lms/djangoapps/courseware/views/index.py
+++ b/lms/djangoapps/courseware/views/index.py
@@ -194,7 +194,7 @@ class CoursewareIndex(View):
 
         TODO: remove this once exams work in the new MFE.
         """
-        if (not self.section.is_time_limited) \
+        if (not getattr(self.section, 'is_time_limited', False)) \
                 and should_redirect_to_courseware_microfrontend(self.course_key) \
                 and not request.user.is_staff:
             url = get_microfrontend_url(

--- a/openedx/core/djangoapps/content/course_overviews/models.py
+++ b/openedx/core/djangoapps/content/course_overviews/models.py
@@ -780,6 +780,20 @@ class CourseOverview(TimeStampedModel):
         return self._original_course.textbooks
 
     @property
+    def pdf_textbooks(self):
+        """
+        TODO: move this to the model.
+        """
+        return self._original_course.pdf_textbooks
+
+    @property
+    def html_textbooks(self):
+        """
+        TODO: move this to the model.
+        """
+        return self._original_course.html_textbooks
+
+    @property
     def hide_progress_tab(self):
         """
         TODO: move this to the model.

--- a/openedx/core/djangoapps/courseware_api/serializers.py
+++ b/openedx/core/djangoapps/courseware_api/serializers.py
@@ -107,7 +107,7 @@ class CourseInfoSerializer(serializers.Serializer):  # pylint: disable=abstract-
         tabs = []
         for priority, tab in enumerate(get_course_tab_list(course_overview.effective_user, course_overview)):
             tabs.append({
-                'title': tab.title,
+                'title': tab.title or tab.get('name'),
                 'slug': tab.tab_id,
                 'priority': priority,
                 'type': tab.type,

--- a/openedx/core/djangoapps/courseware_api/serializers.py
+++ b/openedx/core/djangoapps/courseware_api/serializers.py
@@ -107,7 +107,7 @@ class CourseInfoSerializer(serializers.Serializer):  # pylint: disable=abstract-
         tabs = []
         for priority, tab in enumerate(get_course_tab_list(course_overview.effective_user, course_overview)):
             tabs.append({
-                'title': tab.title or tab.get('name'),
+                'title': tab.title or tab.get('name', ''),
                 'slug': tab.tab_id,
                 'priority': priority,
                 'type': tab.type,


### PR DESCRIPTION
[TNL-6982](https://openedx.atlassian.net/browse/TNL-6982) and [TNL-7045](https://openedx.atlassian.net/browse/TNL-7045)


Automatically redirects learners to the Learning microfrontend, when the `REDIRECT_TO_COURSEWARE_MICROFRONTEND` is enabled.

Global staff will never be redirected.

Timed exams will not redirect, because they currently aren't supported by the MFE.



Also fixes [TNL-7112](https://openedx.atlassian.net/browse/TNL-7112) and [TNL-7113](https://openedx.atlassian.net/browse/TNL-7113)
