### PR TITLE
Allow plugins to update contexts in specific views

### DIFF
--- a/common/djangoapps/student/README.rst
+++ b/common/djangoapps/student/README.rst
@@ -14,3 +14,8 @@ Glossary
 
 More Documentation
 ==================
+
+Plugins
+-------
+Plugin Context view names (see ADR 0003-plugin-contexts.rst):
+* "course_dashboard" -> student.views.dashboard.student_dashboard

--- a/common/djangoapps/student/api.py
+++ b/common/djangoapps/student/api.py
@@ -44,6 +44,7 @@ MANUAL_ENROLLMENT_ROLE_CHOICES = configuration_helpers.get_value(
 
 COURSE_DASHBOARD_PLUGIN_VIEW_NAME = "course_dashboard"
 
+
 def create_manual_enrollment_audit(
     enrolled_by,
     user_email,

--- a/common/djangoapps/student/api.py
+++ b/common/djangoapps/student/api.py
@@ -42,6 +42,7 @@ MANUAL_ENROLLMENT_ROLE_CHOICES = configuration_helpers.get_value(
     settings.MANUAL_ENROLLMENT_ROLE_CHOICES
 )
 
+COURSE_DASHBOARD_PLUGIN_VIEW_NAME = "course_dashboard"
 
 def create_manual_enrollment_audit(
     enrolled_by,

--- a/common/djangoapps/student/views/dashboard.py
+++ b/common/djangoapps/student/views/dashboard.py
@@ -25,6 +25,7 @@ from opaque_keys.edx.keys import CourseKey
 from pytz import UTC
 from shoppingcart.models import CourseRegistrationCode, DonationConfiguration
 from six import iteritems, text_type
+from student.api import COURSE_DASHBOARD_PLUGIN_VIEW_NAME
 from student.helpers import cert_info, check_verify_status_by_course, get_resume_urls_for_enrollments
 from student.models import (
     AccountRecovery,
@@ -884,7 +885,7 @@ def student_dashboard(request):
 
     context_from_plugins = get_plugins_view_context(
         plugin_constants.ProjectType.LMS,
-        plugin_constants.PluginContexts.VIEWS.STUDENT_DASHBOARD,
+        COURSE_DASHBOARD_PLUGIN_VIEW_NAME,
         context
     )
     context.update(context_from_plugins)

--- a/common/djangoapps/student/views/dashboard.py
+++ b/common/djangoapps/student/views/dashboard.py
@@ -47,6 +47,8 @@ from openedx.core.djangoapps.catalog.utils import (
     get_visible_sessions_for_entitlement
 )
 from openedx.core.djangoapps.credit.email_utils import get_credit_provider_attribute_values, make_providers_strings
+from openedx.core.djangoapps.plugins.plugin_contexts import get_plugins_view_context
+from openedx.core.djangoapps.plugins import constants as plugin_constants
 from openedx.core.djangoapps.programs.models import ProgramsApiConfig
 from openedx.core.djangoapps.programs.utils import ProgramDataExtender, ProgramProgressMeter
 from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
@@ -879,6 +881,13 @@ def student_dashboard(request):
         'course_info': get_dashboard_course_info(user, course_enrollments),
         # TODO START: clean up as part of REVEM-199 (END)
     }
+
+    context_from_plugins = get_plugins_view_context(
+        plugin_constants.ProjectType.LMS,
+        plugin_constants.PluginContexts.VIEWS.STUDENT_DASHBOARD,
+        context
+    )
+    context.update(context_from_plugins)
 
     if ecommerce_service.is_enabled(request.user):
         context.update({

--- a/docs/decisions/0003-plugin-contexts.rst
+++ b/docs/decisions/0003-plugin-contexts.rst
@@ -7,16 +7,24 @@ Draft
 
 Context
 =======
-edx-platform contains a plugin system which allows new Django apps to be installed inside the LMS and Studio without requiring the LMS/Studio to know about them. This is what enables us to move to a small and extensible core. While we had the ability to add settings, URLs, and signal handlers in our plugins, we wasn't a any way for a plugin to affect the commonly used pages that the core was delivering. Thus a plugin couldn't change any details on the dashboard, courseware, or any other rendered page that the platform delivered.
+edx-platform contains a plugin system which allows new Django apps to be installed inside the LMS and Studio without requiring the LMS/Studio to know about them. This is what enables us to move to a small and extensible core. While we had the ability to add settings, URLs, and signal handlers in our plugins, there wasn't any way for a plugin to affect the commonly used pages that the core was delivering. Thus a plugin couldn't change any details on the dashboard, courseware, or any other rendered page that the platform delivered.
 
 Decisions
 =========
-We have added the ability to add page context additions to the plugin system. This means that a plugin will be able to add context any view where it is enabled. To support this we have decided:
+We have added the ability to add page context additions to the plugin system. This means that a plugin will be able to add context to any view where it is enabled. To support this we have decided:
 # Plugins will define a callable function that the LMS and/or studio can import and call, which will return additional context to be added.
 # Every page that a plugin wants to add context to, must add a line to add the plugin contexts directly before the render.
-# All view + plugin data will exist in the same dictionary. To better protect against dictionary key collisions, it is suggested that you prefix your new context items with your app name (e.g. return {"myapp__some_variable": True} vs {"some_variable": True})
+# Plugin context will live in a dictionary called "plugins" that will be passed into the context the templates receive. The structure will look like:
+::
+  {
+    ..existing context values
+    "plugins": {
+      "my_new_plugin": {... my_new_plugins's values ...},
+      "my_other_plugin": {... my_other_plugin's values ...},
+    }
+  }
 # Each view will have a constant name that will be defined within it's app's API.py which will be used by plugins. These must be globally unique. These will also be recorded in the rendering app's README.rst file.
-# Plugin app's may import the view name from the rendering app's api.py or just use it's string.
+# Plugin apps have the option to either use the view name strings directly or import the constants from the rendering app's api.py if the plugin is part of the edx-platform repo.
 # For now, in order to use these new context data items, we must use theming alongside this to keep the new context out of the core. This may be iterated on in the future.
 
 Implementation
@@ -26,7 +34,7 @@ In the plugin app
 ~~~~~~~~~~~~~~~~~
 Config
 ++++++
-Inside of your AppConfig your new plugin app, add a "context_config" item like below.
+Inside of your AppConfig your new plugin app, add a "view_context_config" item like below.
 * The format will be {"globally_unique_view_name": "function_inside_plugin_app"}
 * The function name & path don't need to be named anything specific, so long as they work
 * These functions will be called on **every** render of that view, so keep them efficient or memoize them if they aren't user specific.
@@ -36,7 +44,7 @@ Inside of your AppConfig your new plugin app, add a "context_config" item like b
         name = "my_app"
 
         plugin_app = {
-            "context_config": {
+            "view_context_config": {
                 "lms.djangoapp":  {
                     "course_dashboard": "my_app.context_api.get_dashboard_context"
                 }
@@ -50,9 +58,9 @@ The function that will be called by the plugin system should accept a single par
 Example:
 ::
     def my_context_function(existing_context):
-        additional_context = {"myapp__some_variable": 10}
-        if existing_context.get("some_value"):
-            additional_context.append({"myapp__some_other_variable": True})
+        additional_context = {"some_plugin_value": 10}
+        if existing_context.get("some_core_value"):
+            additional_context.append({"some_other_plugin_value": True})
         return additional_context
 
 

--- a/docs/decisions/0003-plugin-contexts.rst
+++ b/docs/decisions/0003-plugin-contexts.rst
@@ -1,0 +1,72 @@
+Plugin Contexts
+---------------
+
+Status
+======
+Draft
+
+Context
+=======
+edx-platform contains a plugin system which allows new Django apps to be installed inside the LMS and Studio without requiring the LMS/Studio to know about them. This is what enables us to move to a small and extensible core. While we had the ability to add settings, URLs, and signal handlers in our plugins, we wasn't a any way for a plugin to affect the commonly used pages that the core was delivering. Thus a plugin couldn't change any details on the dashboard, courseware, or any other rendered page that the platform delivered.
+
+Decisions
+=========
+We have added the ability to add page context additions to the plugin system. This means that a plugin will be able to add context any view where it is enabled. To support this we have decided:
+# Plugins will define a callable function that the LMS and/or studio can import and call, which will return additional context to be added.
+# Every page that a plugin wants to add context to, must add a line to add the plugin contexts directly before the render.
+# All view + plugin data will exist in the same dictionary. To better protect against dictionary key collisions, it is suggested that you prefix your new context items with your app name (e.g. return {"myapp__some_variable": True} vs {"some_variable": True})
+# Each view will have a constant name that will be defined within it's app's API.py which will be used by plugins. These must be globally unique. These will also be recorded in the rendering app's README.rst file.
+# Plugin app's may import the view name from the rendering app's api.py or just use it's string.
+# For now, in order to use these new context data items, we must use theming alongside this to keep the new context out of the core. This may be iterated on in the future.
+
+Implementation
+--------------
+
+In the plugin app
+~~~~~~~~~~~~~~~~~
+Config
+++++++
+Inside of your AppConfig your new plugin app, add a "context_config" item like below.
+* The format will be {"globally_unique_view_name": "function_inside_plugin_app"}
+* The function name & path don't need to be named anything specific, so long as they work
+* These functions will be called on **every** render of that view, so keep them efficient or memoize them if they aren't user specific.
+
+::
+    class MyAppConfig(AppConfig):
+        name = "my_app"
+
+        plugin_app = {
+            "context_config": {
+                "lms.djangoapp":  {
+                    "course_dashboard": "my_app.context_api.get_dashboard_context"
+                }
+            }
+        }
+
+Function
+++++++++
+The function that will be called by the plugin system should accept a single parameter which will be the previously existing context. It should then return a dictionary which consists of items which will be added to the context
+
+Example:
+::
+    def my_context_function(existing_context):
+        additional_context = {"myapp__some_variable": 10}
+        if existing_context.get("some_value"):
+            additional_context.append({"myapp__some_other_variable": True})
+        return additional_context
+
+
+In the core (LMS / Studio)
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+The view you wish to add context to should have the following pieces enabled:
+
+* A constant defined inside the app's for the globally unique view name.
+* The view must call lines similar to the below right before the render so that the plugin has the full context.
+::
+    context_from_plugins = get_plugins_view_context(
+        plugin_constants.ProjectType.LMS,
+        current_app.api.THIS_VIEW_NAME,
+        context
+    )
+    context.update(context_from_plugins)
+

--- a/openedx/core/djangoapps/plugins/README.rst
+++ b/openedx/core/djangoapps/plugins/README.rst
@@ -106,7 +106,7 @@ class::
 
     from django.apps import AppConfig
     from openedx.core.djangoapps.plugins.constants import (
-        ProjectType, SettingsType, PluginURLs, PluginSettings
+        ProjectType, SettingsType, PluginURLs, PluginSettings, PluginContexts
     )
     class MyAppConfig(AppConfig):
         name = u'full_python_path.my_app'
@@ -184,6 +184,19 @@ class::
                         PluginSignals.SENDER_PATH: u'full_path_to_sender_app.ModelZ',
                     }],
                 }
+            },
+
+            # Configuration setting for Plugin Contexts for this app.
+            PluginContexts.CONFIG: {
+
+                # Configure the Plugin Signals for each Project Type, as needed.
+                ProjectType.LMS: {
+
+                    # Key is the view that the app wishes to add context to and the value
+                    # is the function within the app that will return additional context
+                    # when called with the original context
+                    PluginContexts.VIEWS.STUDENT_DASHBOARD: u'my_app.context_api.get_dashboard_context'
+                }
             }
         }
 
@@ -216,6 +229,11 @@ OR use string constants when they cannot import from djangoapps.plugins::
                         u'dispatch_uid': u'my_app.my_signals.on_signal_x',
                         u'sender_path': u'full_path_to_sender_app.ModelZ',
                     }],
+                }
+            },
+            u'context_config': {
+                u'lms.djangoapp': {
+                    'student_dashboard': u'my_app.context_api.get_dashboard_context'
                 }
             }
         }

--- a/openedx/core/djangoapps/plugins/README.rst
+++ b/openedx/core/djangoapps/plugins/README.rst
@@ -231,7 +231,7 @@ OR use string constants when they cannot import from djangoapps.plugins::
                     }],
                 }
             },
-            u'context_config': {
+            u'view_context_config': {
                 u'lms.djangoapp': {
                     'student_dashboard': u'my_app.context_api.get_dashboard_context'
                 }

--- a/openedx/core/djangoapps/plugins/README.rst
+++ b/openedx/core/djangoapps/plugins/README.rst
@@ -195,7 +195,7 @@ class::
                     # Key is the view that the app wishes to add context to and the value
                     # is the function within the app that will return additional context
                     # when called with the original context
-                    PluginContexts.VIEWS.STUDENT_DASHBOARD: u'my_app.context_api.get_dashboard_context'
+                    u'course_dashboard': u'my_app.context_api.get_dashboard_context'
                 }
             }
         }
@@ -233,7 +233,7 @@ OR use string constants when they cannot import from djangoapps.plugins::
             },
             u'view_context_config': {
                 u'lms.djangoapp': {
-                    'student_dashboard': u'my_app.context_api.get_dashboard_context'
+                    'course_dashboard': u'my_app.context_api.get_dashboard_context'
                 }
             }
         }

--- a/openedx/core/djangoapps/plugins/constants.py
+++ b/openedx/core/djangoapps/plugins/constants.py
@@ -76,3 +76,19 @@ class PluginSignals(object):
 
     RELATIVE_PATH = u'relative_path'
     DEFAULT_RELATIVE_PATH = u'signals'
+
+
+class PluginContextsViews(object):
+    STUDENT_DASHBOARD = u'student_dashboard'
+
+
+class PluginContexts(object):
+    """
+    The PluginContexts enum defines dictionary field names (and defaults)
+    that can be specified by a Plugin App in order to configure the
+    additional views it would like to add context into.
+    """
+    CONFIG = u"context_config"
+
+    VIEWS = PluginContextsViews
+

--- a/openedx/core/djangoapps/plugins/constants.py
+++ b/openedx/core/djangoapps/plugins/constants.py
@@ -77,11 +77,6 @@ class PluginSignals(object):
     RELATIVE_PATH = u'relative_path'
     DEFAULT_RELATIVE_PATH = u'signals'
 
-
-class PluginContextsViews(object):
-    COURSE_DASHBOARD = u'course_dashboard'
-
-
 class PluginContexts(object):
     """
     The PluginContexts enum defines dictionary field names (and defaults)
@@ -89,6 +84,3 @@ class PluginContexts(object):
     additional views it would like to add context into.
     """
     CONFIG = u"context_config"
-
-    VIEWS = PluginContextsViews
-

--- a/openedx/core/djangoapps/plugins/constants.py
+++ b/openedx/core/djangoapps/plugins/constants.py
@@ -83,4 +83,4 @@ class PluginContexts(object):
     that can be specified by a Plugin App in order to configure the
     additional views it would like to add context into.
     """
-    CONFIG = u"context_config"
+    CONFIG = u"view_context_config"

--- a/openedx/core/djangoapps/plugins/constants.py
+++ b/openedx/core/djangoapps/plugins/constants.py
@@ -79,7 +79,7 @@ class PluginSignals(object):
 
 
 class PluginContextsViews(object):
-    STUDENT_DASHBOARD = u'student_dashboard'
+    COURSE_DASHBOARD = u'course_dashboard'
 
 
 class PluginContexts(object):

--- a/openedx/core/djangoapps/plugins/constants.py
+++ b/openedx/core/djangoapps/plugins/constants.py
@@ -77,6 +77,7 @@ class PluginSignals(object):
     RELATIVE_PATH = u'relative_path'
     DEFAULT_RELATIVE_PATH = u'signals'
 
+
 class PluginContexts(object):
     """
     The PluginContexts enum defines dictionary field names (and defaults)

--- a/openedx/core/djangoapps/plugins/docs/decisions/0003-plugin-contexts.rst
+++ b/openedx/core/djangoapps/plugins/docs/decisions/0003-plugin-contexts.rst
@@ -7,7 +7,7 @@ Draft
 
 Context
 =======
-edx-platform contains a plugin system which allows new Django apps to be installed inside the LMS and Studio without requiring the LMS/Studio to know about them. This is what enables us to move to a small and extensible core. While we had the ability to add settings, URLs, and signal handlers in our plugins, there wasn't any way for a plugin to affect the commonly used pages that the core was delivering. Thus a plugin couldn't change any details on the dashboard, courseware, or any other rendered page that the platform delivered.
+edx-platform contains a plugin system (https://github.com/edx/edx-platform/tree/master/openedx/core/djangoapps/plugins) which allows new Django apps to be installed inside the LMS and Studio without requiring the LMS/Studio to know about them. This is what enables us to move to a small and extensible core. While we had the ability to add settings, URLs, and signal handlers in our plugins, there wasn't any way for a plugin to affect the commonly used pages that the core was delivering. Thus a plugin couldn't change any details on the dashboard, courseware, or any other rendered page that the platform delivered.
 
 Decisions
 =========
@@ -34,7 +34,7 @@ In the plugin app
 ~~~~~~~~~~~~~~~~~
 Config
 ++++++
-Inside of your AppConfig your new plugin app, add a "view_context_config" item like below.
+Inside of the AppConfig of your new plugin app, add a "view_context_config" item like below.
 * The format will be {"globally_unique_view_name": "function_inside_plugin_app"}
 * The function name & path don't need to be named anything specific, so long as they work
 * These functions will be called on **every** render of that view, so keep them efficient or memoize them if they aren't user specific.
@@ -57,7 +57,7 @@ The function that will be called by the plugin system should accept a single par
 
 Example:
 ::
-    def my_context_function(existing_context):
+    def my_context_function(existing_context, *args, **kwargs):
         additional_context = {"some_plugin_value": 10}
         if existing_context.get("some_core_value"):
             additional_context.append({"some_other_plugin_value": True})

--- a/openedx/core/djangoapps/plugins/plugin_contexts.py
+++ b/openedx/core/djangoapps/plugins/plugin_contexts.py
@@ -1,0 +1,35 @@
+from importlib import import_module
+
+from logging import getLogger
+from . import constants, registry
+
+log = getLogger(__name__)
+
+
+def get_plugins_view_context(project_type, view_name, existing_context={}):
+    """
+    Returns a dict of additonal view context. Will check if any plugin apps
+    have that view in their context_config, and if so will call their
+    selected function to get their context dicts.
+    """
+    aggregate_context = {}
+
+    for app_config in registry.get_app_configs(project_type):
+        context_function_path = _get_context_function(app_config, project_type, view_name)
+        if context_function_path:
+            module_path, _, name = context_function_path.rpartition('.')
+            context_function = getattr(import_module(module_path), name)
+            plugin_context = context_function(existing_context)
+
+            # NOTE: If two plugins have try to set the same context keys, the last one
+            # called will overwrite the others.
+            aggregate_context.update(plugin_context)
+
+    return aggregate_context
+
+
+def _get_context_function(app_config, project_type, view_name):
+    plugin_config = getattr(app_config, constants.PLUGIN_APP_CLASS_ATTRIBUTE_NAME, {})
+    context_config = plugin_config.get(constants.PluginContexts.CONFIG, {})
+    project_type_settings = context_config.get(project_type, {})
+    return project_type_settings.get(view_name)

--- a/openedx/core/djangoapps/plugins/plugin_contexts.py
+++ b/openedx/core/djangoapps/plugins/plugin_contexts.py
@@ -21,7 +21,7 @@ def get_plugins_view_context(project_type, view_name, existing_context={}):
             module_path, _, name = context_function_path.rpartition('.')
             try:
                 module = import_module(module_path)
-            except ImportError, ModuleNotFoundError:
+            except (ImportError, ModuleNotFoundError):
                 log.exception("Failed to import %s plugin when creating %s context", module_path, view_name)
                 continue
             context_function = getattr(module, name, None)

--- a/openedx/core/djangoapps/plugins/plugin_contexts.py
+++ b/openedx/core/djangoapps/plugins/plugin_contexts.py
@@ -1,10 +1,11 @@
 from importlib import import_module
 
 from logging import getLogger
+
 from . import constants, registry
 
-log = getLogger(__name__)
 
+log = getLogger(__name__)
 
 def get_plugins_view_context(project_type, view_name, existing_context={}):
     """
@@ -18,11 +19,33 @@ def get_plugins_view_context(project_type, view_name, existing_context={}):
         context_function_path = _get_context_function(app_config, project_type, view_name)
         if context_function_path:
             module_path, _, name = context_function_path.rpartition('.')
-            context_function = getattr(import_module(module_path), name)
-            plugin_context = context_function(existing_context)
+            try:
+                module = import_module(module_path)
+            except ImportError, ModuleNotFoundError:
+                log.exception("Failed to import %s plugin when creating %s context", module_path, view_name)
+                continue
+            context_function = getattr(module, name, None)
+            if context_function:
+                plugin_context = context_function(existing_context)
+            else:
+                log.exception(
+                    "Failed to call %s function from %s plugin when creating %s context",
+                    name,
+                    module_path,
+                    view_name
+                )
+                continue
 
             # NOTE: If two plugins have try to set the same context keys, the last one
             # called will overwrite the others.
+            for key in plugin_context:
+                if key in aggregate_context:
+                    log.warning(
+                        "Plugin %s is overwriting the value of %s for view %s",
+                        app_config.__module__,
+                        key,
+                        view_name
+                    )
             aggregate_context.update(plugin_context)
 
     return aggregate_context


### PR DESCRIPTION
Instead of requiring views like the dashboard to know about plugins so
they can include their data in the context, this allows plugins to
define a mapping between a view and a function where the function
returns a dictionary of new context for the view. Each view would have
to purposefully enable this additional context before it could be used.
This will allow new content to be added to the pages without updating
the core with a combination of a plugin to add new context, and a theme
override of that page to use the new context.