### PR TITLE
Switch to django-celery upstream and make upgrade.

### DIFF
--- a/requirements/edx/base.in
+++ b/requirements/edx/base.in
@@ -38,6 +38,7 @@ contextlib2                         # We need contextlib2.ExitStack so we can st
 defusedxml
 Django<1.12                         # Web application framework
 django-babel-underscore             # underscore template extractor for django-babel (internationalization utilities)
+django-celery                       # Only used for the CacheBackend for celery results
 django-config-models>=1.0.0         # Configuration models for Django allowing config management with auditing
 django-cors-headers                 # Used to allow to configure CORS headers for cross-domain requests
 django-countries                    # Country data for Django forms and model fields

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -55,7 +55,7 @@ defusedxml==0.5.0         # via -r requirements/edx/base.in, djangorestframework
 git+https://github.com/django-compressor/django-appconf@1526a842ee084b791aa66c931b3822091a442853#egg=django-appconf  # via -r requirements/edx/github.in, django-statici18n
 django-babel-underscore==0.5.2  # via -r requirements/edx/base.in
 django-babel==0.6.2       # via django-babel-underscore
-git+https://github.com/edx/django-celery.git@756cb57aad765cb2b0d37372c1855b8f5f37e6b0#egg=django-celery==3.2.1+edx.2  # via -r requirements/edx/github.in
+django-celery==3.3.1      # via -r requirements/edx/base.in
 django-classy-tags==1.0.0  # via django-sekizai
 django-config-models==2.0.0  # via -r requirements/edx/base.in, edx-enterprise
 django-cors-headers==2.5.3  # via -c requirements/edx/../constraints.txt, -r requirements/edx/base.in
@@ -117,7 +117,7 @@ edx-sga==0.10.0           # via -r requirements/edx/base.in
 edx-submissions==3.0.4    # via -r requirements/edx/base.in, ora2
 edx-tincan-py35==0.0.5    # via edx-enterprise
 edx-user-state-client==1.1.2  # via -r requirements/edx/base.in
-edx-when==1.0.4           # via -r requirements/edx/base.in, edx-proctoring
+edx-when==1.0.5           # via -r requirements/edx/base.in, edx-proctoring
 edxval==1.2.4             # via -r requirements/edx/base.in
 elasticsearch==1.9.0      # via edx-search
 enum34==1.1.9             # via edxval

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -66,7 +66,7 @@ distlib==0.3.0            # via -r requirements/edx/testing.txt, virtualenv
 git+https://github.com/django-compressor/django-appconf@1526a842ee084b791aa66c931b3822091a442853#egg=django-appconf  # via -r requirements/edx/testing.txt, django-statici18n
 django-babel-underscore==0.5.2  # via -r requirements/edx/testing.txt
 django-babel==0.6.2       # via -r requirements/edx/testing.txt, django-babel-underscore
-git+https://github.com/edx/django-celery.git@756cb57aad765cb2b0d37372c1855b8f5f37e6b0#egg=django-celery==3.2.1+edx.2  # via -r requirements/edx/testing.txt
+django-celery==3.3.1      # via -r requirements/edx/testing.txt
 django-classy-tags==1.0.0  # via -r requirements/edx/testing.txt, django-sekizai
 django-config-models==2.0.0  # via -r requirements/edx/testing.txt, edx-enterprise
 django-cors-headers==2.5.3  # via -c requirements/edx/../constraints.txt, -r requirements/edx/testing.txt
@@ -131,7 +131,7 @@ edx-sphinx-theme==1.5.0   # via -r requirements/edx/development.in
 edx-submissions==3.0.4    # via -r requirements/edx/testing.txt, ora2
 edx-tincan-py35==0.0.5    # via -r requirements/edx/testing.txt, edx-enterprise
 edx-user-state-client==1.1.2  # via -r requirements/edx/testing.txt
-edx-when==1.0.4           # via -r requirements/edx/testing.txt, edx-proctoring
+edx-when==1.0.5           # via -r requirements/edx/testing.txt, edx-proctoring
 edxval==1.2.4             # via -r requirements/edx/testing.txt
 elasticsearch==1.9.0      # via -r requirements/edx/testing.txt, edx-search
 entrypoints==0.3          # via -r requirements/edx/testing.txt, flake8

--- a/requirements/edx/github.in
+++ b/requirements/edx/github.in
@@ -66,10 +66,6 @@ git+https://github.com/edx/MongoDBProxy.git@d92bafe9888d2940f647a7b2b2383b29c752
 # This can be removed once an official social-auth-app-django Pypi release with Django 2.2 support is available in the future.
 -e git+https://github.com/python-social-auth/social-app-django.git@c00d23c2b45c3317bd35b15ad1b959338689cef8#egg=social-auth-app-django
 
-# Why a django-celery fork? To add Django 1.11 compatibility to the abandoned repo.
-# This dependency will be removed by the Celery 4 upgrade: https://openedx.atlassian.net/browse/PLAT-1684
-git+https://github.com/edx/django-celery.git@756cb57aad765cb2b0d37372c1855b8f5f37e6b0#egg=django-celery==3.2.1+edx.2
-
 # Why install sorl-thumbnail directly from github? To use the latest, Django 2.2 compatible version that is not available on PyPi yet.
 # This dependency will be removed after package is updated at PyPi
 git+https://github.com/jazzband/sorl-thumbnail.git@13bedfb7d2970809eda597e3ef79318a6fa80ac2#egg=sorl-thumbnail

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -65,7 +65,7 @@ distlib==0.3.0            # via virtualenv
 git+https://github.com/django-compressor/django-appconf@1526a842ee084b791aa66c931b3822091a442853#egg=django-appconf  # via -r requirements/edx/base.txt, django-statici18n
 django-babel-underscore==0.5.2  # via -r requirements/edx/base.txt
 django-babel==0.6.2       # via -r requirements/edx/base.txt, django-babel-underscore
-git+https://github.com/edx/django-celery.git@756cb57aad765cb2b0d37372c1855b8f5f37e6b0#egg=django-celery==3.2.1+edx.2  # via -r requirements/edx/base.txt
+django-celery==3.3.1      # via -r requirements/edx/base.txt
 django-classy-tags==1.0.0  # via -r requirements/edx/base.txt, django-sekizai
 django-config-models==2.0.0  # via -r requirements/edx/base.txt, edx-enterprise
 django-cors-headers==2.5.3  # via -c requirements/edx/../constraints.txt, -r requirements/edx/base.txt
@@ -126,7 +126,7 @@ edx-sga==0.10.0           # via -r requirements/edx/base.txt
 edx-submissions==3.0.4    # via -r requirements/edx/base.txt, ora2
 edx-tincan-py35==0.0.5    # via -r requirements/edx/base.txt, edx-enterprise
 edx-user-state-client==1.1.2  # via -r requirements/edx/base.txt
-edx-when==1.0.4           # via -r requirements/edx/base.txt, edx-proctoring
+edx-when==1.0.5           # via -r requirements/edx/base.txt, edx-proctoring
 edxval==1.2.4             # via -r requirements/edx/base.txt
 elasticsearch==1.9.0      # via -r requirements/edx/base.txt, edx-search
 entrypoints==0.3          # via flake8


### PR DESCRIPTION
Instead of removing django-celery entirely, switch to using upstream for the use case of using the django-celery CacheBackend for celery results.

https://openedx.atlassian.net/browse/BOM-1157