### PR TITLE
Mark experiment events as non interactive

### DIFF
--- a/lms/djangoapps/experiments/flags.py
+++ b/lms/djangoapps/experiments/flags.py
@@ -119,6 +119,7 @@ class ExperimentWaffleFlag(CourseWaffleFlag):
                     'course_id': str(course_key) if course_key else None,
                     'bucket': bucket,
                     'is_staff': request.user.is_staff,
+                    'nonInteraction': 1,
                 }
             )
 

--- a/lms/djangoapps/experiments/tests/test_flags.py
+++ b/lms/djangoapps/experiments/tests/test_flags.py
@@ -104,6 +104,7 @@ class ExperimentWaffleFlagTests(SharedModuleStoreTestCase):
                 'bucket': 1,
                 'course_id': 'a/b/c',
                 'is_staff': self.user.is_staff,
+                'nonInteraction': 1,
             },
         }))
 


### PR DESCRIPTION
Specifically, set the 'nonInteraction' segment event property to 1.