### PR TITLE
Create flag for Courseware MFE staff rollout.

### DIFF
--- a/lms/djangoapps/courseware/toggles.py
+++ b/lms/djangoapps/courseware/toggles.py
@@ -12,7 +12,7 @@ WAFFLE_FLAG_NAMESPACE = WaffleFlagNamespace(name='courseware')
 # .. toggle_name: courseware.redirect_to_microfrontend
 # .. toggle_implementation: CourseWaffleFlag
 # .. toggle_default: False
-# .. toggle_description: Supports staged rollout of a new micro-frontend-based implementation of the courseware page.
+# .. toggle_description: Supports staged rollout to students for a new micro-frontend-based implementation of the courseware page.
 # .. toggle_category: micro-frontend
 # .. toggle_use_cases: incremental_release, open_edx
 # .. toggle_creation_date: 2020-01-29
@@ -22,9 +22,25 @@ WAFFLE_FLAG_NAMESPACE = WaffleFlagNamespace(name='courseware')
 # .. toggle_status: supported
 REDIRECT_TO_COURSEWARE_MICROFRONTEND = CourseWaffleFlag(WAFFLE_FLAG_NAMESPACE, 'redirect_to_microfrontend')
 
+# Waffle flag to display a link for the new learner experience to course teams without redirecting students.
+#
+# .. toggle_name: courseware.microfrontend_course_team_preview
+# .. toggle_implementation: CourseWaffleFlag
+# .. toggle_default: False
+# .. toggle_description: Supports staged rollout to course teams of a new micro-frontend-based implementation of the courseware page.
+# .. toggle_category: micro-frontend
+# .. toggle_use_cases: incremental_release, open_edx
+# .. toggle_creation_date: 2020-03-09
+# .. toggle_expiration_date: 2020-12-31
+# .. toggle_warnings: Also set settings.LEARNING_MICROFRONTEND_URL and ENABLE_COURSEWARE_MICROFRONTEND.
+# .. toggle_tickets: TNL-6982
+# .. toggle_status: supported
+COURSEWARE_MICROFRONTEND_COURSE_TEAM_PREVIEW = CourseWaffleFlag(WAFFLE_FLAG_NAMESPACE, 'microfrontend_course_team_preview')
+
 
 def should_redirect_to_courseware_microfrontend(course_key):
     return (
         settings.FEATURES.get('ENABLE_COURSEWARE_MICROFRONTEND') and
+        (not course_key.deprecated) and  # Old Mongo courses not supported
         REDIRECT_TO_COURSEWARE_MICROFRONTEND.is_enabled(course_key)
     )


### PR DESCRIPTION
Create the COURSEWARE_MICROFRONTEND_COURSE_TEAM_PREVIEW
CourseWaffleFlag (courseware.microfrontend_course_team_preview) to
enable us to roll out the new Courseware MFE as a preview to
select course teams without affecting their students. TNL-7117

This commit also fixes an issue where these links are shown in Old
Mongo courses (TNL-7116). Old Mongo is marked for deprecation
(DEPR-58), and is not intended to ever be supported by the new MFE.