### PR TITLE
EDUCATOR-4938: Teams Tab does not consider Teamset max_size

### DIFF
--- a/lms/djangoapps/teams/serializers.py
+++ b/lms/djangoapps/teams/serializers.py
@@ -176,6 +176,7 @@ class BaseTopicSerializer(serializers.Serializer):  # pylint: disable=abstract-m
     name = serializers.CharField()
     id = serializers.CharField()  # pylint: disable=invalid-name
     type = serializers.CharField()
+    max_team_size = serializers.IntegerField()
 
 
 class TopicSerializer(BaseTopicSerializer):  # pylint: disable=abstract-method

--- a/lms/djangoapps/teams/static/teams/js/models/topic.js
+++ b/lms/djangoapps/teams/static/teams/js/models/topic.js
@@ -10,7 +10,8 @@
                 description: '',
                 team_count: 0,
                 id: '',
-                type: 'open'
+                type: 'open',
+                max_team_size: null
             },
 
             initialize: function(options) {
@@ -20,6 +21,13 @@
             isInstructorManaged: function() {
                 var topicType = this.get('type');
                 return topicType === 'public_managed' || topicType === 'private_managed';
+            },
+
+            getMaxTeamSize: function(courseMaxTeamSize) {
+                if (this.isInstructorManaged()) {
+                    return null;
+                }
+                return this.get('max_team_size') || courseMaxTeamSize;
             }
         });
         return Topic;

--- a/lms/djangoapps/teams/static/teams/js/spec/views/team_card_spec.js
+++ b/lms/djangoapps/teams/static/teams/js/spec/views/team_card_spec.js
@@ -2,13 +2,14 @@ define(['jquery',
     'underscore',
     'moment',
     'teams/js/views/team_card',
-    'teams/js/models/team'],
-    function($, _, moment, TeamCardView, Team) {
+    'teams/js/models/team',
+    'teams/js/models/topic'],
+    function($, _, moment, TeamCardView, Team, Topic) {
         'use strict';
 
         describe('TeamCardView', function() {
             var createTeamCardView, view;
-            createTeamCardView = function() {
+            createTeamCardView = function(topicOptions) {
                 var model = new Team({
                         id: 'test-team',
                         name: 'Test Team',
@@ -21,14 +22,17 @@ define(['jquery',
                         language: 'en',
                         membership: []
                     }),
+                    topic = new Topic(_.extend({id: 'test-topic'}, topicOptions)),
                     TeamCardClass = TeamCardView.extend({
-                        maxTeamSize: '100',
+                        courseMaxTeamSize: '100',
                         srInfo: {
                             id: 'test-sr-id',
                             text: 'Screenreader text'
                         },
                         countries: {us: 'United States of America'},
-                        languages: {en: 'English'}
+                        languages: {en: 'English'},
+                        // eslint-disable-next-line no-unused-vars
+                        getTopic: function(topicId) { return $.Deferred().resolve(topic); }
                     });
                 return new TeamCardClass({
                     model: model

--- a/lms/djangoapps/teams/static/teams/js/spec/views/team_profile_header_actions_spec.js
+++ b/lms/djangoapps/teams/static/teams/js/spec/views/team_profile_header_actions_spec.js
@@ -42,7 +42,8 @@ define([
                             username: currentUsername
                         })
                     }),
-                    topicOptions = topicMaxTeamSize ? {max_team_size: topicMaxTeamSize} : {},
+                    topicOptions = typeof topicMaxTeamSize !== 'undefined' ?
+                        {max_team_size: topicMaxTeamSize} : {},
                     topic = isInstructorManagedTopic ?
                         TeamSpecHelpers.createMockInstructorManagedTopic(topicOptions) :
                         TeamSpecHelpers.createMockTopic(topicOptions);
@@ -213,10 +214,41 @@ define([
                     })
                 );
 
-                // User is not a mamber of any teams
+                // User is not a member of any teams
                 AjaxHelpers.respondWithJson(requests, {count: 0});
 
                 // Course-level size is 1, but Teamset size is 2, so that should take precedence
+                // and we should see the Join Team Button
+                expect(view.$('.action.action-primary').length).toEqual(1);
+            });
+
+            it('behaves correctly if the teamset max size is set to 0', function() {
+                var requests = AjaxHelpers.requests(this);
+                var currentUsername = 'ma1';
+                // Teamset = 0, Course = 2
+                var view = createHeaderActionsView(
+                    requests,
+                    2,
+                    'ma1',
+                    createTeamModelData('teamA', 'teamAlpha', createMembershipData('ma')),
+                    false,
+                    false,
+                    0
+                );
+
+                // Team should not be considered full
+                AjaxHelpers.expectRequest(
+                    requests,
+                    'GET',
+                    TeamSpecHelpers.testContext.teamMembershipsUrl + '?' + $.param({
+                        username: currentUsername, course_id: TeamSpecHelpers.testCourseID
+                    })
+                );
+
+                // User is not a member of any teams
+                AjaxHelpers.respondWithJson(requests, {count: 0});
+
+                // Course-level size is 1 and Teamset size is 0, so course-level value should be used
                 // and we should see the Join Team Button
                 expect(view.$('.action.action-primary').length).toEqual(1);
             });

--- a/lms/djangoapps/teams/static/teams/js/spec/views/team_profile_header_actions_spec.js
+++ b/lms/djangoapps/teams/static/teams/js/spec/views/team_profile_header_actions_spec.js
@@ -26,14 +26,26 @@ define([
         };
 
         createHeaderActionsView =
-            function(requests, maxTeamSize, currentUsername, teamModelData, showEditButton, isInstructorManagedTopic) {
+            function(
+                requests,
+                courseMaxTeamSize,
+                currentUsername,
+                teamModelData,
+                showEditButton,
+                isInstructorManagedTopic,
+                topicMaxTeamSize
+            ) {
                 var model = new TeamModel(teamModelData, {parse: true}),
                     context = TeamSpecHelpers.createMockContext({
-                        maxTeamSize: maxTeamSize,
+                        courseMaxTeamSize: courseMaxTeamSize,
                         userInfo: TeamSpecHelpers.createMockUserInfo({
                             username: currentUsername
                         })
-                    });
+                    }),
+                    topicOptions = topicMaxTeamSize ? {max_team_size: topicMaxTeamSize} : {},
+                    topic = isInstructorManagedTopic ?
+                        TeamSpecHelpers.createMockInstructorManagedTopic(topicOptions) :
+                        TeamSpecHelpers.createMockTopic(topicOptions);
 
                 return new TeamProfileHeaderActionsView(
                     {
@@ -41,9 +53,7 @@ define([
                         teamEvents: TeamSpecHelpers.teamEvents,
                         context: context,
                         model: model,
-                        topic: isInstructorManagedTopic ?
-                            TeamSpecHelpers.createMockInstructorManagedTopic() :
-                            TeamSpecHelpers.createMockTopic(),
+                        topic: topic,
                         showEditButton: showEditButton
                     }
                 ).render();
@@ -178,6 +188,37 @@ define([
 
                 // there should be no request made
                 AjaxHelpers.expectNoRequests(requests);
+            });
+
+            it('correctly resolves teamset-level max_size and course-level max_size', function() {
+                var requests = AjaxHelpers.requests(this);
+                var currentUsername = 'ma1';
+                // Teamset maxSize = 2, Course maxSize = 1
+                var view = createHeaderActionsView(
+                    requests,
+                    1,
+                    'ma1',
+                    createTeamModelData('teamA', 'teamAlpha', createMembershipData('ma')),
+                    false,
+                    false,
+                    2
+                );
+
+                // Team should not be considered full with one member
+                AjaxHelpers.expectRequest(
+                    requests,
+                    'GET',
+                    TeamSpecHelpers.testContext.teamMembershipsUrl + '?' + $.param({
+                        username: currentUsername, course_id: TeamSpecHelpers.testCourseID
+                    })
+                );
+
+                // User is not a mamber of any teams
+                AjaxHelpers.respondWithJson(requests, {count: 0});
+
+                // Course-level size is 1, but Teamset size is 2, so that should take precedence
+                // and we should see the Join Team Button
+                expect(view.$('.action.action-primary').length).toEqual(1);
             });
 
             it('shows not join instructor managed team message', function() {

--- a/lms/djangoapps/teams/static/teams/js/spec/views/team_profile_spec.js
+++ b/lms/djangoapps/teams/static/teams/js/spec/views/team_profile_spec.js
@@ -127,11 +127,21 @@ define([
         });
 
         describe('TeamDetailsView', function() {
-            var assertTeamDetails = function(view, members, memberOfTeam) {
+            var assertTeamDetails = function(view, members, memberOfTeam, isManagedTeam) {
+                var expectedMemberMsg;
                 expect(view.$('.team-detail-header').text()).toBe('Team Details');
                 expect(view.$('.team-country').text()).toContain('United States');
                 expect(view.$('.team-language').text()).toContain('English');
-                expect(view.$('.team-capacity').text()).toContain(members + ' / 6 Members');
+                if (isManagedTeam) {
+                    if (members === 1) {
+                        expectedMemberMsg = '1 Member';
+                    } else {
+                        expectedMemberMsg = members + ' Members';
+                    }
+                } else {
+                    expectedMemberMsg = members + ' / 6 Members';
+                }
+                expect(view.$('.team-capacity').text()).toContain(expectedMemberMsg);
                 expect(view.$('.team-member').length).toBe(members);
                 expect(Boolean(view.$('.leave-team-link').length)).toBe(memberOfTeam);
             };
@@ -143,7 +153,7 @@ define([
                         country: 'US',
                         language: 'en'
                     });
-                    assertTeamDetails(view, 0, false);
+                    assertTeamDetails(view, 0, false, false);
                     expect(view.$('.team-user-membership-status').length).toBe(0);
 
                     // Verify that the leave team link is not present.
@@ -166,7 +176,7 @@ define([
                         language: 'en',
                         membership: DEFAULT_MEMBERSHIP
                     });
-                    assertTeamDetails(view, 1, true);
+                    assertTeamDetails(view, 1, true, false);
                     expect(view.$('.team-user-membership-status').text().trim()).toBe('You are a member of this team.');
 
                     // assert tooltip text.
@@ -184,9 +194,9 @@ define([
                     var view = createTeamProfileView(
                         requests, {country: 'US', language: 'en', membership: DEFAULT_MEMBERSHIP}
                     );
-                    assertTeamDetails(view, 1, true);
+                    assertTeamDetails(view, 1, true, false);
                     clickLeaveTeam(requests, view, {cancel: false});
-                    assertTeamDetails(view, 0, false);
+                    assertTeamDetails(view, 0, false, false);
                 });
 
                 it('student can not leave instructor managed team', function() {
@@ -196,7 +206,7 @@ define([
                         requests, {country: 'US', language: 'en', membership: DEFAULT_MEMBERSHIP}, true
                     );
                     // When a student is in a team of an instructor-managed topic, he can't see the leave team button.
-                    assertTeamDetails(view, 1, false);
+                    assertTeamDetails(view, 1, false, true);
                 });
 
                 it("wouldn't do anything if user click on Cancel button on dialog", function() {
@@ -205,9 +215,9 @@ define([
                     var view = createTeamProfileView(
                         requests, {country: 'US', language: 'en', membership: DEFAULT_MEMBERSHIP}
                     );
-                    assertTeamDetails(view, 1, true);
+                    assertTeamDetails(view, 1, true, false);
                     clickLeaveTeam(requests, view, {cancel: true});
-                    assertTeamDetails(view, 1, true);
+                    assertTeamDetails(view, 1, true, false);
                 });
 
                 it('shows correct error messages', function() {

--- a/lms/djangoapps/teams/static/teams/js/spec/views/teams_spec.js
+++ b/lms/djangoapps/teams/static/teams/js/spec/views/teams_spec.js
@@ -1,9 +1,10 @@
 define([
+    'jquery',
     'backbone',
     'teams/js/collections/team',
     'teams/js/views/teams',
     'teams/js/spec_helpers/team_spec_helpers'
-], function(Backbone, TeamCollection, TeamsView, TeamSpecHelpers) {
+], function($, Backbone, TeamCollection, TeamsView, TeamSpecHelpers) {
     'use strict';
     var createTeamsView;
     describe('Teams View', function() {
@@ -12,7 +13,13 @@ define([
         });
 
         createTeamsView = function(options) {
-            return new TeamsView({
+            var MockTeamsView = TeamsView.extend({
+                // eslint-disable-next-line no-unused-vars
+                getTopic: function(topicId) {
+                    return $.Deferred().resolve(TeamSpecHelpers.createMockTopic({}));
+                }
+            });
+            return new MockTeamsView({
                 el: '.teams-container',
                 collection: options.teams || TeamSpecHelpers.createMockTeams(),
                 showActions: true,

--- a/lms/djangoapps/teams/static/teams/js/spec/views/topic_card_spec.js
+++ b/lms/djangoapps/teams/static/teams/js/spec/views/topic_card_spec.js
@@ -12,7 +12,8 @@ define(['jquery',
                         id: 'renewables',
                         name: 'Renewable Energy',
                         description: 'Explore how changes in <ⓡⓔⓝⓔⓦⓐⓑⓛⓔ> ʎƃɹǝuǝ will affect our lives.',
-                        team_count: 34
+                        team_count: 34,
+                        max_team_size: 20
                     })
                 });
             };

--- a/lms/djangoapps/teams/static/teams/js/spec_helpers/team_spec_helpers.js
+++ b/lms/djangoapps/teams/static/teams/js/spec_helpers/team_spec_helpers.js
@@ -277,7 +277,7 @@ define([
         hasOpenTopic: true,
         hasPublicManagedTopic: false,
         hasManagedTopic: false,
-        maxTeamSize: 6,
+        courseMaxTeamSize: 6,
         languages: testLanguages,
         countries: testCountries,
         topicUrl: '/api/team/v0/topics/topic_id,' + testCourseID,

--- a/lms/djangoapps/teams/static/teams/js/views/my_teams.js
+++ b/lms/djangoapps/teams/static/teams/js/views/my_teams.js
@@ -25,12 +25,8 @@
                     return this;
                 },
 
-                getTopicType: function(topicId) {
-                    var deferred = $.Deferred();
-                    this.getTopic(topicId).done(function(topic) {
-                        deferred.resolve(topic.get('type'));
-                    });
-                    return deferred.promise();
+                getTopic: function(topicId) {
+                    return this.getTopic(topicId);
                 },
 
                 createHeaderView: function() {

--- a/lms/djangoapps/teams/static/teams/js/views/team_card.js
+++ b/lms/djangoapps/teams/static/teams/js/views/team_card.js
@@ -158,8 +158,8 @@
             },
             // eslint-disable-next-line no-unused-vars
             getTopic: function(topicId) {
-                // This function will be overrwritten in the extended class in
-                // That will in turn be overwritten by functions in TopicTeamsView and MyTeamsView
+                // This function will be overrwritten in the extended class
+                // that will in turn be overwritten by functions in TopicTeamsView and MyTeamsView
                 return null;
             }
         });

--- a/lms/djangoapps/teams/static/teams/js/views/team_card.js
+++ b/lms/djangoapps/teams/static/teams/js/views/team_card.js
@@ -34,34 +34,31 @@
             className: 'team-members',
 
             initialize: function(options) {
-                this.getTopicType = options.getTopicType;
+                this.getTopic = options.getTopic;
                 this.topicId = options.topicId;
-                this.maxTeamSize = options.maxTeamSize;
+                this.courseMaxTeamSize = options.courseMaxTeamSize;
                 this.memberships = options.memberships;
             },
 
             render: function() {
                 var view = this;
-                this.getTopicType(this.topicId).done(function(topicType) {
-                    view.renderMessage(topicType !== 'open');
+                this.getTopic(this.topicId).done(function(topic) {
+                    view.renderMessage(topic.getMaxTeamSize(view.courseMaxTeamSize));
                 }).fail(function() {
-                    view.renderMessage(false);
+                    view.renderMessage(view.courseMaxTeamSize);
                 });
                 return view;
             },
 
-            renderMessage: function(topicIsManaged) {
+            renderMessage: function(maxTeamSize) {
                 var allMemberships = _(this.memberships).sortBy(function(member) {
                         return new Date(member.last_activity_at);
                     }).reverse(),
-                    displayableMemberships = allMemberships.slice(0, 5),
-                    maxMemberCount = this.maxTeamSize;
+                    displayableMemberships = allMemberships.slice(0, 5);
                 HtmlUtils.setHtml(
                     this.$el,
                     HtmlUtils.template(teamMembershipDetailsTemplate)({
-                        membership_message: TeamUtils.teamCapacityText(
-                            allMemberships.length,
-                            topicIsManaged ? null : maxMemberCount),
+                        membership_message: TeamUtils.teamCapacityText(allMemberships.length, maxTeamSize),
                         memberships: displayableMemberships,
                         has_additional_memberships: displayableMemberships.length < allMemberships.length,
                         /* Translators: "and others" refers to fact that additional
@@ -127,9 +124,9 @@
                 this.detailViews = [
                     new TeamMembershipView({
                         memberships: this.model.get('membership'),
-                        maxTeamSize: this.maxTeamSize,
+                        courseMaxTeamSize: this.courseMaxTeamSize,
                         topicId: this.model.get('topic_id'),
-                        getTopicType: this.getTopicType
+                        getTopic: this.getTopic
                     }),
                     new TeamCountryLanguageView({
                         model: this.model,
@@ -160,12 +157,10 @@
                 return '#teams/' + this.model.get('topic_id') + '/' + this.model.get('id');
             },
             // eslint-disable-next-line no-unused-vars
-            getTopicType: function(topicId) {
-                // This function will be overrwritten in the extended class in TeamsView
+            getTopic: function(topicId) {
+                // This function will be overrwritten in the extended class in
                 // That will in turn be overwritten by functions in TopicTeamsView and MyTeamsView
-                var deferred = $.Deferred();
-                deferred.resolve('open');
-                return deferred.promise();
+                return null;
             }
         });
         return TeamCardView;

--- a/lms/djangoapps/teams/static/teams/js/views/team_profile.js
+++ b/lms/djangoapps/teams/static/teams/js/views/team_profile.js
@@ -41,7 +41,8 @@
                         discussionTopicID = this.model.get('discussion_topic_id'),
                         isMember = TeamUtils.isUserMemberOfTeam(memberships, this.context.userInfo.username),
                         isAdminOrStaff = this.context.userInfo.privileged || this.context.userInfo.staff,
-                        isInstructorManagedTopic = TeamUtils.isInstructorManagedTopic(this.topic.attributes.type);
+                        isInstructorManagedTopic = TeamUtils.isInstructorManagedTopic(this.topic.attributes.type),
+                        maxTeamSize = this.topic.getMaxTeamSize(this.context.courseMaxTeamSize);
 
                     var showLeaveLink = isMember && (isAdminOrStaff || !isInstructorManagedTopic);
 
@@ -53,10 +54,10 @@
                             readOnly: !(this.context.userInfo.privileged || isMember),
                             country: this.countries[this.model.get('country')],
                             language: this.languages[this.model.get('language')],
-                            membershipText: TeamUtils.teamCapacityText(memberships.length, this.context.maxTeamSize),
+                            membershipText: TeamUtils.teamCapacityText(memberships.length, maxTeamSize),
                             isMember: isMember,
                             showLeaveLink: showLeaveLink,
-                            hasCapacity: memberships.length < this.context.maxTeamSize,
+                            hasCapacity: maxTeamSize && (memberships.length < maxTeamSize),
                             hasMembers: memberships.length >= 1
                         })
                     );

--- a/lms/djangoapps/teams/static/teams/js/views/team_profile_header_actions.js
+++ b/lms/djangoapps/teams/static/teams/js/views/team_profile_header_actions.js
@@ -36,7 +36,7 @@
                         message,
                         showJoinButton,
                         teamHasSpace;
-                    this.getUserTeamInfo(username, this.context.maxTeamSize).done(function(info) {
+                    this.getUserTeamInfo(username, this.context.courseMaxTeamSize).done(function(info) {
                         teamHasSpace = info.teamHasSpace;
 
                         // if user is the member of current team then we wouldn't show anything
@@ -87,7 +87,7 @@
                     });
                 },
 
-                getUserTeamInfo: function(username, maxTeamSize) {
+                getUserTeamInfo: function(username, courseMaxTeamSize) {
                     var deferred = $.Deferred();
                     var info = {
                         alreadyMember: false,
@@ -96,11 +96,16 @@
                         isAdminOrStaff: false,
                         isInstructorManagedTopic: false
                     };
-                    var teamHasSpace = this.model.get('membership').length < maxTeamSize;
+
+                    // this.topic.getMaxTeamSize() will return null for a managed team,
+                    // but the size is considered to be arbitarily large.
+                    var isInstructorManagedTopic = TeamUtils.isInstructorManagedTopic(this.topic.attributes.type);
+                    var teamHasSpace = isInstructorManagedTopic ||
+                        (this.model.get('membership').length < this.topic.getMaxTeamSize(courseMaxTeamSize));
 
                     info.memberOfCurrentTeam = TeamUtils.isUserMemberOfTeam(this.model.get('membership'), username);
                     info.isAdminOrStaff = this.context.userInfo.privileged || this.context.userInfo.staff;
-                    info.isInstructorManagedTopic = TeamUtils.isInstructorManagedTopic(this.topic.attributes.type);
+                    info.isInstructorManagedTopic = isInstructorManagedTopic;
 
                     if (info.memberOfCurrentTeam) {
                         info.alreadyMember = true;

--- a/lms/djangoapps/teams/static/teams/js/views/teams.js
+++ b/lms/djangoapps/teams/static/teams/js/views/teams.js
@@ -22,20 +22,19 @@
                 this.context = options.context;
                 this.itemViewClass = TeamCardView.extend({
                     router: options.router,
-                    maxTeamSize: this.context.maxTeamSize,
+                    courseMaxTeamSize: this.context.courseMaxTeamSize,
                     srInfo: this.srInfo,
                     countries: TeamUtils.selectorOptionsArrayToHashWithBlank(this.context.countries),
                     languages: TeamUtils.selectorOptionsArrayToHashWithBlank(this.context.languages),
-                    getTopicType: function(topicId) { return view.getTopicType(topicId); }
+                    getTopic: function(topicId) { return view.getTopic(topicId); }
                 });
                 PaginatedView.prototype.initialize.call(this);
             },
 
             // eslint-disable-next-line no-unused-vars
-            getTopicType: function(topicId) {
-                var deferred = $.Deferred();
-                deferred.resolve('open');
-                return deferred.promise();
+            getTopic: function(topicId) {
+                // This must be overwritten in extending classes.
+                return null;
             }
         });
         return TeamsView;

--- a/lms/djangoapps/teams/static/teams/js/views/topic_teams.js
+++ b/lms/djangoapps/teams/static/teams/js/views/topic_teams.js
@@ -104,9 +104,9 @@
                 });
             },
 
-            getTopicType: function(topicId) { // eslint-disable-line no-unused-vars
+            getTopic: function(topicId) { // eslint-disable-line no-unused-vars
                 var deferred = $.Deferred();
-                deferred.resolve(this.model.get('type'));
+                deferred.resolve(this.model);
                 return deferred.promise();
             }
         });

--- a/lms/djangoapps/teams/templates/teams/teams.html
+++ b/lms/djangoapps/teams/templates/teams/teams.html
@@ -55,7 +55,7 @@ from openedx.core.djangolib.js_utils import (
         teamMembershipDetailUrl: '${team_membership_detail_url | n, js_escaped_string}',
         myTeamsUrl: '${my_teams_url | n, js_escaped_string}',
         teamMembershipManagementUrl: '${team_membership_management_url | n, js_escaped_string}',
-        maxTeamSize: ${course.teams_configuration.default_max_team_size | n, dump_js_escaped_json},
+        courseMaxTeamSize: ${course.teams_configuration.default_max_team_size | n, dump_js_escaped_json},
         languages: ${languages | n, dump_js_escaped_json},
         countries: ${countries | n, dump_js_escaped_json},
         teamsBaseUrl: '${teams_base_url | n, js_escaped_string}'

--- a/lms/djangoapps/teams/tests/test_serializers.py
+++ b/lms/djangoapps/teams/tests/test_serializers.py
@@ -88,7 +88,14 @@ class TopicSerializerTestCase(SerializerTestCase):
             )
             self.assertEqual(
                 serializer.data,
-                {u'name': u'Tøpic', u'description': u'The bést topic!', u'id': u'0', u'team_count': 0, u'type': u'open'}
+                {
+                    u'name': u'Tøpic',
+                    u'description': u'The bést topic!',
+                    u'id': u'0',
+                    u'team_count': 0,
+                    u'type': u'open',
+                    u'max_team_size': None
+                }
             )
 
     def test_topic_with_team_count(self):
@@ -106,7 +113,14 @@ class TopicSerializerTestCase(SerializerTestCase):
             )
             self.assertEqual(
                 serializer.data,
-                {u'name': u'Tøpic', u'description': u'The bést topic!', u'id': u'0', u'team_count': 1, u'type': u'open'}
+                {
+                    u'name': u'Tøpic',
+                    u'description': u'The bést topic!',
+                    u'id': u'0',
+                    u'team_count': 1,
+                    u'type': u'open',
+                    u'max_team_size': None
+                }
             )
 
     def test_scoped_within_course(self):
@@ -127,7 +141,14 @@ class TopicSerializerTestCase(SerializerTestCase):
             )
             self.assertEqual(
                 serializer.data,
-                {u'name': u'Tøpic', u'description': u'The bést topic!', u'id': u'0', u'team_count': 1, u'type': u'open'}
+                {
+                    u'name': u'Tøpic',
+                    u'description': u'The bést topic!',
+                    u'id': u'0',
+                    u'team_count': 1,
+                    u'type': u'open',
+                    u'max_team_size': None
+                }
             )
 
 
@@ -158,6 +179,7 @@ class BaseTopicSerializerTestCase(SerializerTestCase):
                 'description': 'The bést topic! {}'.format(i),
                 'id': six.text_type(i),
                 'type': 'open',
+                'max_team_size': i + 10
             }
             for i in six.moves.range(num_topics)
         ]


### PR DESCRIPTION
[EDUCATOR-4938](https://openedx.atlassian.net/browse/EDUCATOR-4938)

The teams tab backbone app did not respect the teamset-level max_team_size and always went with the value defined on the course run. Now, if there is a teamset-level max_team_size, it will override the course-level value.

I took a lot of screenshots.

# Team Cards:
### No course-level or teamset-level, defaults to 50 (for an open teamset)
![no_course_no_ts](https://user-images.githubusercontent.com/1639231/76547534-b8038600-6463-11ea-8475-0d1ed40de09c.png)

### Course-level is 30, no teamset-level
![30_course_no_ts](https://user-images.githubusercontent.com/1639231/76547532-b8038600-6463-11ea-8790-91d958d38b07.png)

### Course-level is 30, overridden by teamset-level 40
![30_course_40_ts](https://user-images.githubusercontent.com/1639231/76547531-b8038600-6463-11ea-981b-43d0b59a8c77.png)

### For completeness' sake, no course-level, teamset is 40
![no_course_40_ts](https://user-images.githubusercontent.com/1639231/76547533-b8038600-6463-11ea-87fb-61124eeccb38.png)

# Team Profile (course-level still set at 30):

### Teamset size set to 4, can join team
![3_of_4](https://user-images.githubusercontent.com/1639231/76547845-40822680-6464-11ea-92e6-47d340fa1101.png)

### Teamset size sent to 3, can't join team 
![3_of_3](https://user-images.githubusercontent.com/1639231/76547842-40822680-6464-11ea-8acc-6021449c96ea.png)

