### PR TITLE
Add another attribute to CourseOverview to support the Teams tab

### DIFF
--- a/openedx/core/djangoapps/content/course_overviews/models.py
+++ b/openedx/core/djangoapps/content/course_overviews/models.py
@@ -821,6 +821,13 @@ class CourseOverview(TimeStampedModel):
         """
         return self._original_course.course_visibility
 
+    @property
+    def teams_enabled(self):
+        """
+        TODO: move this to the model.
+        """
+        return self._original_course.teams_enabled
+
     def __str__(self):
         """Represent ourselves with the course key."""
         return six.text_type(self.id)


### PR DESCRIPTION
Further work for TNL-7113

The various kinds of static tabs look for different attributes on the course. Since we're using `CourseOverview`s instead of course objects, we have to proxy these attributes.
