### PR TITLE
Adding user_has_staff_access to course metadata response.

### DIFF
--- a/openedx/core/djangoapps/courseware_api/serializers.py
+++ b/openedx/core/djangoapps/courseware_api/serializers.py
@@ -84,6 +84,7 @@ class CourseInfoSerializer(serializers.Serializer):  # pylint: disable=abstract-
     pacing = serializers.CharField()
     enrollment = serializers.DictField()
     user_has_access = serializers.BooleanField()
+    user_has_staff_access = serializers.BooleanField()
     tabs = serializers.SerializerMethodField()
     verified_mode = serializers.SerializerMethodField()
 

--- a/openedx/core/djangoapps/courseware_api/views.py
+++ b/openedx/core/djangoapps/courseware_api/views.py
@@ -10,6 +10,7 @@ from rest_framework.response import Response
 from rest_framework.views import APIView
 
 from lms.djangoapps.course_api.api import course_detail
+from lms.djangoapps.courseware.access import has_access
 from lms.djangoapps.courseware.courses import allow_public_access
 from lms.djangoapps.courseware.module_render import get_module_by_usage_id
 from student.models import CourseEnrollment
@@ -105,6 +106,7 @@ class CoursewareInformation(RetrieveAPIView):
         else:
             user_has_access = True
         overview.user_has_access = user_has_access
+        overview.user_has_staff_access = has_access(self.request.user, 'staff', overview).has_access
         return overview
 
     def get_serializer_context(self):


### PR DESCRIPTION
Related to: https://openedx.atlassian.net/browse/TNL-7109

We use this value in the client to understand whether or not we should be showing staff-only parts of the UI to the user.

I chose not to express this as a new permission for the TNL ticket, as our current use case is temporary and I didn't want to add an access check for a temporary flag to lms/djangoapps/courseware/access.py.  

I didn't write a test for this case as it would essentially be a test of whether access.py is working correctly, which doesn't seem particularly high value.