### PR TITLE
Fixed the studio breadcrumbs to show the current chapter/section name.

### DIFF
--- a/cms/djangoapps/contentstore/views/tests/test_container_page.py
+++ b/cms/djangoapps/contentstore/views/tests/test_container_page.py
@@ -88,11 +88,11 @@ class ContainerPageTestCase(StudioPageTestCase, LibraryTestCase):
                     u'data-locator="{0}" data-course-key="{0.course_key}">'.format(draft_container.location)
                 ),
                 expected_breadcrumbs=(
-                    u'<a href="/course/{course}{section_parameters}">Week 1</a>.*'
                     u'<a href="/course/{course}{subsection_parameters}">Lesson 1</a>.*'
+                    u'<a href="/container/{unit_parameters}">Unit</a>.*'
                 ).format(
                     course=re.escape(six.text_type(self.course.id)),
-                    section_parameters=re.escape(u'?show={}'.format(http.urlquote(self.chapter.location))),
+                    unit_parameters=re.escape(str(self.vertical.location)),
                     subsection_parameters=re.escape(u'?show={}'.format(http.urlquote(self.sequential.location))),
                 ),
             )

--- a/cms/templates/container.html
+++ b/cms/templates/container.html
@@ -90,7 +90,7 @@ from openedx.core.djangolib.markup import HTML, Text
                 <ol>
                 % for block in ancestor_xblocks:
                     <li class="nav-item">
-                        <span class="title label">${block['block'].display_name_with_default}
+                        <span class="title label">${block['title']}
                             <span class="icon fa fa-caret-down ui-toggle-dd" aria-hidden="true"></span>
                         </span>
                         % if not block['is_last']:


### PR DESCRIPTION
[TNL-7099](https://openedx.atlassian.net/browse/TNL-7099)

Current experience:
<img width="861" alt="Screen Shot 2020-03-10 at 9 35 15 AM" src="https://user-images.githubusercontent.com/6515020/76317404-88614c00-62b2-11ea-81c0-cf974f621467.png">

Changed experience:
<img width="861" alt="Screen Shot 2020-03-10 at 9 33 09 AM" src="https://user-images.githubusercontent.com/6515020/76317220-35879480-62b2-11ea-933b-d7262d6a4e21.png">
