### PR TITLE
Unpin freezegun and upgrade.

### DIFF
--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -34,9 +34,6 @@ drf-jwt==1.14.0
 # Upgrading to 2.12.0 breaks several test classes due to API changes, need to update our code accordingly
 factory-boy==2.8.1
 
-# Newer versions need a more recent version of python-dateutil
-freezegun==0.3.12
-
 # 4.0.0 dropped support for Python 3.5
 inflect<4.0.0
 
@@ -60,9 +57,6 @@ pandas==0.22.0
 
 # path 13.2.0 drops support for Python 3.5
 path<13.2.0
-
-# Upgrading to 2.5.3 on 2020-01-03 triggered "'tzlocal' object has no attribute '_std_offset'" errors in production
-python-dateutil==2.4.0
 
 # python3-saml 1.6.0 breaks unittests in common/djangoapps/third_party_auth/tests/test_views.py::SAMLMetadataTest
 python3-saml==1.5.0

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -102,8 +102,8 @@ edx-completion==3.1.1     # via -r requirements/edx/base.in
 edx-django-release-util==0.3.6  # via -r requirements/edx/base.in
 edx-django-sites-extensions==2.4.3  # via -r requirements/edx/base.in
 edx-django-utils==3.0     # via -r requirements/edx/base.in, django-config-models, edx-drf-extensions, edx-enterprise, edx-rest-api-client
-edx-drf-extensions==4.0.1  # via -r requirements/edx/base.in, edx-completion, edx-enterprise, edx-organizations, edx-proctoring, edx-rbac, edx-when, edxval
-edx-enterprise==2.5.1     # via -r requirements/edx/base.in
+edx-drf-extensions==4.0.2  # via -r requirements/edx/base.in, edx-completion, edx-enterprise, edx-organizations, edx-proctoring, edx-rbac, edx-when, edxval
+edx-enterprise==2.5.2     # via -r requirements/edx/base.in
 edx-i18n-tools==0.5.0     # via ora2
 edx-milestones==0.2.6     # via -r requirements/edx/base.in
 edx-opaque-keys[django]==2.0.1  # via -r requirements/edx/paver.txt, edx-bulk-grades, edx-ccx-keys, edx-completion, edx-drf-extensions, edx-enterprise, edx-milestones, edx-organizations, edx-proctoring, edx-user-state-client, edx-when, xmodule
@@ -193,7 +193,7 @@ pymongo==3.9.0            # via -r requirements/edx/base.in, -r requirements/edx
 pynliner==0.8.0           # via -r requirements/edx/base.in
 pyparsing==2.2.0          # via calc, chem, packaging, pycontracts
 pysrt==1.1.2              # via -r requirements/edx/base.in, edxval
-python-dateutil==2.4.0    # via -c requirements/edx/../constraints.txt, -r requirements/edx/base.in, analytics-python, botocore, edx-ace, edx-drf-extensions, edx-enterprise, edx-proctoring, ora2, xblock
+python-dateutil==2.8.1    # via -r requirements/edx/base.in, analytics-python, botocore, edx-ace, edx-drf-extensions, edx-enterprise, edx-proctoring, ora2, xblock
 python-levenshtein==0.12.0  # via -r requirements/edx/base.in
 python-memcached==1.59    # via -r requirements/edx/paver.txt
 python-slugify==4.0.0     # via code-annotations

--- a/requirements/edx/coverage.txt
+++ b/requirements/edx/coverage.txt
@@ -16,7 +16,7 @@ numpy==1.18.1             # via pandas
 pandas==0.22.0            # via -c requirements/edx/../constraints.txt, -r requirements/edx/coverage.in
 pluggy==0.13.1            # via diff-cover
 pygments==2.6.1           # via diff-cover
-python-dateutil==2.4.0    # via -c requirements/edx/../constraints.txt, pandas
+python-dateutil==2.8.1    # via pandas
 pytz==2019.3              # via pandas
 six==1.14.0               # via diff-cover, python-dateutil
 zipp==1.0.0               # via -c requirements/edx/../constraints.txt, importlib-metadata

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -114,8 +114,8 @@ edx-completion==3.1.1     # via -r requirements/edx/testing.txt
 edx-django-release-util==0.3.6  # via -r requirements/edx/testing.txt
 edx-django-sites-extensions==2.4.3  # via -r requirements/edx/testing.txt
 edx-django-utils==3.0     # via -r requirements/edx/testing.txt, django-config-models, edx-drf-extensions, edx-enterprise, edx-rest-api-client
-edx-drf-extensions==4.0.1  # via -r requirements/edx/testing.txt, edx-completion, edx-enterprise, edx-organizations, edx-proctoring, edx-rbac, edx-when, edxval
-edx-enterprise==2.5.1     # via -r requirements/edx/testing.txt
+edx-drf-extensions==4.0.2  # via -r requirements/edx/testing.txt, edx-completion, edx-enterprise, edx-organizations, edx-proctoring, edx-rbac, edx-when, edxval
+edx-enterprise==2.5.2     # via -r requirements/edx/testing.txt
 edx-i18n-tools==0.5.0     # via -r requirements/edx/testing.txt, ora2
 edx-lint==1.4.1           # via -r requirements/edx/testing.txt
 edx-milestones==0.2.6     # via -r requirements/edx/testing.txt
@@ -143,7 +143,7 @@ faker==4.0.1              # via -r requirements/edx/testing.txt, factory-boy
 filelock==3.0.12          # via -r requirements/edx/testing.txt, tox, virtualenv
 flake8-polyfill==1.0.2    # via -r requirements/edx/testing.txt, radon
 flake8==3.7.9             # via -r requirements/edx/testing.txt, flake8-polyfill
-freezegun==0.3.12         # via -c requirements/edx/../constraints.txt, -r requirements/edx/testing.txt
+freezegun==0.3.15         # via -r requirements/edx/testing.txt
 fs-s3fs==0.1.8            # via -r requirements/edx/testing.txt, django-pyfs
 fs==2.0.18                # via -r requirements/edx/testing.txt, django-pyfs, fs-s3fs, xblock
 future==0.18.2            # via -r requirements/edx/testing.txt, django-ses, edx-celeryutils, edx-enterprise, pycontracts, pyjwkest, radon
@@ -250,7 +250,7 @@ pytest-metadata==1.8.0    # via -r requirements/edx/testing.txt, pytest-json-rep
 pytest-randomly==3.2.1    # via -r requirements/edx/testing.txt
 pytest-xdist==1.31.0      # via -r requirements/edx/testing.txt
 pytest==5.3.5             # via -r requirements/edx/testing.txt, pytest-attrib, pytest-cov, pytest-django, pytest-forked, pytest-json-report, pytest-metadata, pytest-randomly, pytest-xdist
-python-dateutil==2.4.0    # via -c requirements/edx/../constraints.txt, -r requirements/edx/testing.txt, analytics-python, botocore, edx-ace, edx-drf-extensions, edx-enterprise, edx-proctoring, faker, freezegun, ora2, pandas, xblock
+python-dateutil==2.8.1    # via -r requirements/edx/testing.txt, analytics-python, botocore, edx-ace, edx-drf-extensions, edx-enterprise, edx-proctoring, faker, freezegun, ora2, pandas, xblock
 python-levenshtein==0.12.0  # via -r requirements/edx/testing.txt
 python-memcached==1.59    # via -r requirements/edx/testing.txt
 python-slugify==4.0.0     # via -r requirements/edx/testing.txt, code-annotations, transifex-client
@@ -313,7 +313,7 @@ unidiff==0.5.5            # via -r requirements/edx/testing.txt, coverage-pytest
 uritemplate==3.0.1        # via -r requirements/edx/testing.txt, coreapi, drf-yasg
 urllib3==1.25.8           # via -r requirements/edx/testing.txt, elasticsearch, geoip2, requests, selenium, transifex-client
 user-util==0.1.5          # via -r requirements/edx/testing.txt
-virtualenv==20.0.9        # via -r requirements/edx/testing.txt, tox
+virtualenv==20.0.10       # via -r requirements/edx/testing.txt, tox
 voluptuous==0.11.7        # via -r requirements/edx/testing.txt, ora2
 vulture==1.3              # via -r requirements/edx/development.in
 watchdog==0.10.2          # via -r requirements/edx/testing.txt

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -110,8 +110,8 @@ edx-completion==3.1.1     # via -r requirements/edx/base.txt
 edx-django-release-util==0.3.6  # via -r requirements/edx/base.txt
 edx-django-sites-extensions==2.4.3  # via -r requirements/edx/base.txt
 edx-django-utils==3.0     # via -r requirements/edx/base.txt, django-config-models, edx-drf-extensions, edx-enterprise, edx-rest-api-client
-edx-drf-extensions==4.0.1  # via -r requirements/edx/base.txt, edx-completion, edx-enterprise, edx-organizations, edx-proctoring, edx-rbac, edx-when, edxval
-edx-enterprise==2.5.1     # via -r requirements/edx/base.txt
+edx-drf-extensions==4.0.2  # via -r requirements/edx/base.txt, edx-completion, edx-enterprise, edx-organizations, edx-proctoring, edx-rbac, edx-when, edxval
+edx-enterprise==2.5.2     # via -r requirements/edx/base.txt
 edx-i18n-tools==0.5.0     # via -r requirements/edx/base.txt, -r requirements/edx/testing.in, ora2
 edx-lint==1.4.1           # via -r requirements/edx/testing.in
 edx-milestones==0.2.6     # via -r requirements/edx/base.txt
@@ -138,7 +138,7 @@ faker==4.0.1              # via factory-boy
 filelock==3.0.12          # via tox, virtualenv
 flake8-polyfill==1.0.2    # via radon
 flake8==3.7.9             # via flake8-polyfill
-freezegun==0.3.12         # via -c requirements/edx/../constraints.txt, -r requirements/edx/testing.in
+freezegun==0.3.15         # via -r requirements/edx/testing.in
 fs-s3fs==0.1.8            # via -r requirements/edx/base.txt, django-pyfs
 fs==2.0.18                # via -r requirements/edx/base.txt, django-pyfs, fs-s3fs, xblock
 future==0.18.2            # via -r requirements/edx/base.txt, django-ses, edx-celeryutils, edx-enterprise, pycontracts, pyjwkest, radon
@@ -238,7 +238,7 @@ pytest-metadata==1.8.0    # via pytest-json-report
 pytest-randomly==3.2.1    # via -r requirements/edx/testing.in
 pytest-xdist==1.31.0      # via -r requirements/edx/testing.in
 pytest==5.3.5             # via -r requirements/edx/testing.in, pytest-attrib, pytest-cov, pytest-django, pytest-forked, pytest-json-report, pytest-metadata, pytest-randomly, pytest-xdist
-python-dateutil==2.4.0    # via -c requirements/edx/../constraints.txt, -r requirements/edx/base.txt, -r requirements/edx/coverage.txt, analytics-python, botocore, edx-ace, edx-drf-extensions, edx-enterprise, edx-proctoring, faker, freezegun, ora2, pandas, xblock
+python-dateutil==2.8.1    # via -r requirements/edx/base.txt, -r requirements/edx/coverage.txt, analytics-python, botocore, edx-ace, edx-drf-extensions, edx-enterprise, edx-proctoring, faker, freezegun, ora2, pandas, xblock
 python-levenshtein==0.12.0  # via -r requirements/edx/base.txt
 python-memcached==1.59    # via -r requirements/edx/base.txt
 python-slugify==4.0.0     # via -r requirements/edx/base.txt, code-annotations, transifex-client
@@ -291,7 +291,7 @@ unidiff==0.5.5            # via -r requirements/edx/testing.in, coverage-pytest-
 uritemplate==3.0.1        # via -r requirements/edx/base.txt, coreapi, drf-yasg
 urllib3==1.25.8           # via -r requirements/edx/base.txt, elasticsearch, geoip2, requests, selenium, transifex-client
 user-util==0.1.5          # via -r requirements/edx/base.txt
-virtualenv==20.0.9        # via tox
+virtualenv==20.0.10       # via tox
 voluptuous==0.11.7        # via -r requirements/edx/base.txt, ora2
 watchdog==0.10.2          # via -r requirements/edx/base.txt
 wcwidth==0.1.8            # via pytest


### PR DESCRIPTION
https://openedx.atlassian.net/browse/BOM-1151

The latest working version of `freezegun` also requires a version of `python-dateutil` >= 2.7. I also unpinned that because it was several minor versions behind. I'm not sure how best to detect or monitor those errors in production.