### PR TITLE
Fix unregistered celery task: course_structures

### DIFF
--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -1141,6 +1141,7 @@ CELERY_IMPORTS = (
     'cms.djangoapps.contentstore.tasks',
     'openedx.core.djangoapps.bookmarks.tasks',
     'openedx.core.djangoapps.ccxcon.tasks',
+    'openedx.core.djangoapps.content.course_structures.tasks',
 )
 
 # Message configuration

--- a/openedx/core/djangoapps/api_admin/tests/test_views.py
+++ b/openedx/core/djangoapps/api_admin/tests/test_views.py
@@ -5,6 +5,7 @@ import json
 
 import ddt
 import httpretty
+from mock import patch
 from django.conf import settings
 from django.test import TestCase
 from django.test.utils import override_settings
@@ -367,7 +368,8 @@ class CatalogEditViewTest(CatalogTest):
         self.assertRedirects(response, reverse('api_admin:catalog-edit', kwargs={'catalog_id': self.catalog.id}))
 
     @httpretty.activate
-    def test_edit_invalid(self):
+    @patch('openedx.core.djangoapps.content.course_structures.tasks.update_course_structure')
+    def test_edit_invalid(self, _mock_task):
         self.mock_catalog_endpoint(self.catalog.attributes, catalog_id=self.catalog.id)
         new_attributes = dict(self.catalog.attributes, **{'delete-catalog': 'off', 'name': ''})
         response = self.client.post(self.url, new_attributes)


### PR DESCRIPTION
Fix KeyError exception when the task `course_structures.tasks.update_course_structure` is received.

This is a similar to edx#21297 and edx#21305.
