### PR TITLE
zamir/prod 1214/upload video to s3 locally

### DIFF
--- a/openedx/core/djangoapps/video_pipeline/config/waffle.py
+++ b/openedx/core/djangoapps/video_pipeline/config/waffle.py
@@ -3,13 +3,14 @@ This module contains configuration settings via waffle flags
 for the Video Pipeline app.
 """
 
-from openedx.core.djangoapps.waffle_utils import WaffleFlagNamespace, CourseWaffleFlag
+from openedx.core.djangoapps.waffle_utils import CourseWaffleFlag, WaffleFlag, WaffleFlagNamespace
 
 # Videos Namespace
 WAFFLE_NAMESPACE = 'videos'
 
 # Waffle flag telling whether youtube is deprecated.
 DEPRECATE_YOUTUBE = 'deprecate_youtube'
+ENABLE_DEVSTACK_VIDEO_UPLOADS = 'enable_devstack_video_uploads'
 
 
 def waffle_flags():
@@ -21,5 +22,10 @@ def waffle_flags():
         DEPRECATE_YOUTUBE: CourseWaffleFlag(
             waffle_namespace=namespace,
             flag_name=DEPRECATE_YOUTUBE
+        ),
+        ENABLE_DEVSTACK_VIDEO_UPLOADS: WaffleFlag(
+            waffle_namespace=namespace,
+            flag_name=ENABLE_DEVSTACK_VIDEO_UPLOADS,
+            flag_undefined_default=False
         )
     }


### PR DESCRIPTION
Add integration settings to enable upload of videos from from studio. Settings enable user to connect to s3 bucket using mfa and assume role functionality.

Note: Documentation details are on the ticket

[PROD-1214](https://openedx.atlassian.net/browse/PROD-1214)