### PR TITLE
Unpin super-csv and allow it to be upgraded.

### DIFF
--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -67,9 +67,6 @@ python-dateutil==2.4.0
 # python3-saml 1.6.0 breaks unittests in common/djangoapps/third_party_auth/tests/test_views.py::SAMLMetadataTest
 python3-saml==1.5.0
 
-# CR-1912: Check if super-csv 0.9.7 is breaking grade export
-super-csv==0.9.6
-
 # oauthlib>3.0.1 causes test failures
 oauthlib==3.0.1
 

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -55,7 +55,7 @@ defusedxml==0.5.0         # via -r requirements/edx/base.in, djangorestframework
 git+https://github.com/django-compressor/django-appconf@1526a842ee084b791aa66c931b3822091a442853#egg=django-appconf  # via -r requirements/edx/github.in, django-statici18n
 git+https://github.com/edx/django-babel-underscore.git@37705f7377a4d0a4e673f1431895ce28a8860cd7#egg=django-babel-underscore==0.6.0  # via -r requirements/edx/github.in
 git+https://github.com/Zegocover/enmerkar.git@dbc113798aa4beabdfa2d00e6fef48248eb0f185#egg=django-babel==0.6.3.dev0  # via -r requirements/edx/github.in
-django-celery==3.3.1      # via -r requirements/edx/base.in, super-csv
+django-celery==3.3.1      # via -r requirements/edx/base.in
 django-classy-tags==1.0.0  # via django-sekizai
 django-config-models==2.0.0  # via -r requirements/edx/base.in, edx-enterprise
 django-cors-headers==2.5.3  # via -c requirements/edx/../constraints.txt, -r requirements/edx/base.in
@@ -229,7 +229,7 @@ soupsieve==2.0            # via beautifulsoup4
 sqlparse==0.3.1           # via -r requirements/edx/base.in
 staff-graded-xblock==0.7  # via -r requirements/edx/base.in
 stevedore==1.32.0         # via -r requirements/edx/base.in, -r requirements/edx/paver.txt, code-annotations, edx-ace, edx-enterprise, edx-opaque-keys
-super-csv==0.9.6          # via -c requirements/edx/../constraints.txt, -r requirements/edx/base.in, edx-bulk-grades
+super-csv==0.9.7          # via -r requirements/edx/base.in, edx-bulk-grades
 sympy==1.5.1              # via symmath
 testfixtures==6.14.0      # via edx-enterprise
 text-unidecode==1.3       # via python-slugify

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -66,7 +66,7 @@ distlib==0.3.0            # via -r requirements/edx/testing.txt, virtualenv
 git+https://github.com/django-compressor/django-appconf@1526a842ee084b791aa66c931b3822091a442853#egg=django-appconf  # via -r requirements/edx/testing.txt, django-statici18n
 git+https://github.com/edx/django-babel-underscore.git@37705f7377a4d0a4e673f1431895ce28a8860cd7#egg=django-babel-underscore==0.6.0  # via -r requirements/edx/testing.txt
 git+https://github.com/Zegocover/enmerkar.git@dbc113798aa4beabdfa2d00e6fef48248eb0f185#egg=django-babel==0.6.3.dev0  # via -r requirements/edx/testing.txt
-django-celery==3.3.1      # via -r requirements/edx/testing.txt, super-csv
+django-celery==3.3.1      # via -r requirements/edx/testing.txt
 django-classy-tags==1.0.0  # via -r requirements/edx/testing.txt, django-sekizai
 django-config-models==2.0.0  # via -r requirements/edx/testing.txt, edx-enterprise
 django-cors-headers==2.5.3  # via -c requirements/edx/../constraints.txt, -r requirements/edx/testing.txt
@@ -299,7 +299,7 @@ sphinxcontrib-serializinghtml==1.1.4  # via sphinx
 sqlparse==0.3.1           # via -r requirements/edx/testing.txt, django-debug-toolbar
 staff-graded-xblock==0.7  # via -r requirements/edx/testing.txt
 stevedore==1.32.0         # via -r requirements/edx/testing.txt, code-annotations, edx-ace, edx-enterprise, edx-opaque-keys
-super-csv==0.9.6          # via -c requirements/edx/../constraints.txt, -r requirements/edx/testing.txt, edx-bulk-grades
+super-csv==0.9.7          # via -r requirements/edx/testing.txt, edx-bulk-grades
 sympy==1.5.1              # via -r requirements/edx/testing.txt, symmath
 testfixtures==6.14.0      # via -r requirements/edx/testing.txt, edx-enterprise
 text-unidecode==1.3       # via -r requirements/edx/testing.txt, faker, python-slugify

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -65,7 +65,7 @@ distlib==0.3.0            # via virtualenv
 git+https://github.com/django-compressor/django-appconf@1526a842ee084b791aa66c931b3822091a442853#egg=django-appconf  # via -r requirements/edx/base.txt, django-statici18n
 git+https://github.com/edx/django-babel-underscore.git@37705f7377a4d0a4e673f1431895ce28a8860cd7#egg=django-babel-underscore==0.6.0  # via -r requirements/edx/base.txt
 git+https://github.com/Zegocover/enmerkar.git@dbc113798aa4beabdfa2d00e6fef48248eb0f185#egg=django-babel==0.6.3.dev0  # via -r requirements/edx/base.txt
-django-celery==3.3.1      # via -r requirements/edx/base.txt, super-csv
+django-celery==3.3.1      # via -r requirements/edx/base.txt
 django-classy-tags==1.0.0  # via -r requirements/edx/base.txt, django-sekizai
 django-config-models==2.0.0  # via -r requirements/edx/base.txt, edx-enterprise
 django-cors-headers==2.5.3  # via -c requirements/edx/../constraints.txt, -r requirements/edx/base.txt
@@ -277,7 +277,7 @@ soupsieve==2.0            # via -r requirements/edx/base.txt, beautifulsoup4
 sqlparse==0.3.1           # via -r requirements/edx/base.txt
 staff-graded-xblock==0.7  # via -r requirements/edx/base.txt
 stevedore==1.32.0         # via -r requirements/edx/base.txt, code-annotations, edx-ace, edx-enterprise, edx-opaque-keys
-super-csv==0.9.6          # via -c requirements/edx/../constraints.txt, -r requirements/edx/base.txt, edx-bulk-grades
+super-csv==0.9.7          # via -r requirements/edx/base.txt, edx-bulk-grades
 sympy==1.5.1              # via -r requirements/edx/base.txt, symmath
 testfixtures==6.14.0      # via -r requirements/edx/base.txt, -r requirements/edx/testing.in, edx-enterprise
 text-unidecode==1.3       # via -r requirements/edx/base.txt, faker, python-slugify


### PR DESCRIPTION
We pinned this because we thought this might have caused a grades download issue, but it doesn't seem to be the case.