### PR TITLE
history on bulk create of enrollments

### DIFF
--- a/lms/djangoapps/program_enrollments/api/tests/test_writing.py
+++ b/lms/djangoapps/program_enrollments/api/tests/test_writing.py
@@ -55,19 +55,23 @@ class WritingProgramEnrollmentTest(CacheIsolationTestCase):
 
     def test_write_program_enrollments_status_ended(self):
         """
-        Successfully updates program enrollment to status ended if requested
+        Successfully updates program enrollment to status ended if requested.
+        This also validates history records are created on both create and update.
         """
         assert ProgramEnrollment.objects.count() == 0
+        assert ProgramEnrollment.historical_records.count() == 0  # pylint: disable=no-member
         write_program_enrollments(self.program_uuid_x, [{
             'external_user_key': self.user_0,
             'status': PEStatuses.PENDING,
             'curriculum_uuid': self.curriculum_uuid_a,
         }], True, False)
         assert ProgramEnrollment.objects.count() == 1
+        assert ProgramEnrollment.historical_records.count() == 1  # pylint: disable=no-member
         write_program_enrollments(self.program_uuid_x, [{
             'external_user_key': self.user_0,
             'status': PEStatuses.ENDED,
             'curriculum_uuid': self.curriculum_uuid_a,
         }], False, True)
         assert ProgramEnrollment.objects.count() == 1
+        assert ProgramEnrollment.historical_records.count() == 2  # pylint: disable=no-member
         assert ProgramEnrollment.objects.filter(status=PEStatuses.ENDED).exists()

--- a/lms/djangoapps/program_enrollments/api/writing.py
+++ b/lms/djangoapps/program_enrollments/api/writing.py
@@ -275,11 +275,11 @@ def write_program_course_enrollments(
             to_save.append(new_course_enrollment)
             results[external_key] = new_course_enrollment.status
 
-    # Bulk-create all new program-course enrollments.
+    # Bulk-create all new program-course enrollments and corresponding history records.
     # Note: this will NOT invoke `save()` or `pre_save`/`post_save` signals!
     # See https://docs.djangoproject.com/en/1.11/ref/models/querysets/#bulk-create.
     if to_save:
-        ProgramCourseEnrollment.objects.bulk_create(to_save)
+        bulk_create_with_history(to_save, ProgramCourseEnrollment)
 
     return results
 

--- a/lms/djangoapps/program_enrollments/api/writing.py
+++ b/lms/djangoapps/program_enrollments/api/writing.py
@@ -8,6 +8,8 @@ from `lms.djangoapps.program_enrollments.api`.
 
 import logging
 
+from simple_history.utils import bulk_create_with_history
+
 from course_modes.models import CourseMode
 from openedx.core.djangoapps.content.course_overviews.models import CourseOverview
 from student.models import CourseEnrollment, NonExistentCourseError
@@ -67,7 +69,6 @@ def write_program_enrollments(program_uuid, enrollment_requests, create, update)
     # For each enrollment request, try to create/update:
     # * For creates, build up list `to_save`, which we will bulk-create afterwards.
     # * For updates, do them in place.
-    #     (TODO: Django 2.2 will add bulk-update support, which we could use here)
     # Update `results` with the new status or an error status for each operation.
     results = {}
     to_save = []
@@ -100,11 +101,11 @@ def write_program_enrollments(program_uuid, enrollment_requests, create, update)
             to_save.append(new_enrollment)
             results[external_key] = new_enrollment.status
 
-    # Bulk-create all new program enrollments.
+    # Bulk-create all new program enrollments and corresponding history records
     # Note: this will NOT invoke `save()` or `pre_save`/`post_save` signals!
     # See https://docs.djangoproject.com/en/1.11/ref/models/querysets/#bulk-create.
     if to_save:
-        ProgramEnrollment.objects.bulk_create(to_save)
+        bulk_create_with_history(to_save, ProgramEnrollment)
 
     results.update({key: ProgramOpStatuses.DUPLICATED for key in duplicated_keys})
     return results


### PR DESCRIPTION
@edx/masters-devs 

Updates bulk enrollment write to also create corresponding history records.  As-is we have no history on create since `bulk_create` by itself does not fire any save signals.

https://openedx.atlassian.net/browse/MST-175