### PR TITLE
Fix Blockstore XBlock Runtime's handling of occasional S3 errors (take 2)

### DIFF
--- a/openedx/core/djangoapps/xblock/runtime/blockstore_field_data.py
+++ b/openedx/core/djangoapps/xblock/runtime/blockstore_field_data.py
@@ -180,7 +180,9 @@ class BlockstoreFieldData(FieldData):
             # Otherwise, this is an anomalous get() before the XML was fully loaded:
             # This could happen if an XBlock's parse_xml() method tried to read a field before setting it,
             # if an XBlock read field data in its constructor (forbidden), or if an XBlock was loaded via
-            # some means other than runtime.get_block()
+            # some means other than runtime.get_block(). One way this can happen is if you log/print an XBlock during
+            # XML parsing, because ScopedStorageMixin.__repr__ will try to print all field values, and any fields which
+            # aren't mentioned in the XML (which are left at their default) will be "not loaded yet."
             log.exception(
                 "XBlock %s tried to read from field data (%s) that wasn't loaded from Blockstore!",
                 block.scope_ids.usage_id, name,

--- a/openedx/core/djangoapps/xblock/runtime/olx_parsing.py
+++ b/openedx/core/djangoapps/xblock/runtime/olx_parsing.py
@@ -27,6 +27,9 @@ def parse_xblock_include(include_node):
     # An XBlock include looks like:
     # <xblock-include source="link_id" definition="block_type/definition_id" usage="alias" />
     # Where "source" and "usage" are optional.
+    if include_node.tag != 'xblock-include':
+        # xss-lint: disable=python-wrap-html
+        raise BundleFormatException("Expected an <xblock-include /> XML node, but got <{}>".format(include_node.tag))
     try:
         definition_path = include_node.attrib['definition']
     except KeyError:

--- a/openedx/core/djangolib/blockstore_cache.py
+++ b/openedx/core/djangolib/blockstore_cache.py
@@ -202,8 +202,18 @@ def get_bundle_file_data_with_cache(bundle_uuid, path, bundle_version=None, draf
     cached list of files in each bundle if available.
     """
     file_info = get_bundle_file_metadata_with_cache(bundle_uuid, path, bundle_version, draft_name)
-    with requests.get(file_info.url, stream=True) as r:
-        return r.content
+    response = requests.get(file_info.url)
+    if response.status_code != 200:
+        try:
+            error_response = response.content.decode('utf-8')[:500]
+        except UnicodeDecodeError:
+            error_response = '(error details unavailable - response was not a [unicode] string)'
+        raise blockstore_api.BundleStorageError(
+            "Unexpected error ({}) trying to read {} from bundle {} using URL {}: \n{}".format(
+                response.status_code, path, bundle_uuid, file_info.url, error_response,
+            )
+        )
+    return response.content
 
 
 @lru_cache(maxsize=200)

--- a/openedx/core/djangolib/blockstore_cache.py
+++ b/openedx/core/djangolib/blockstore_cache.py
@@ -13,7 +13,6 @@ from datetime import datetime
 from uuid import UUID
 
 from django.core.cache import caches, InvalidCacheBackendError
-from django.utils.lru_cache import lru_cache
 from pytz import UTC
 import requests
 
@@ -33,7 +32,7 @@ except InvalidCacheBackendError:
 # (Note that we do usually explicitly invalidate this cache during write
 # operations though, so this setting mostly affects actions by external systems
 # on Blockstore or bugs where we left out the cache invalidation step.)
-MAX_BLOCKSTORE_CACHE_DELAY = 60
+MAX_BLOCKSTORE_CACHE_DELAY = 60 * 5
 
 
 class BundleCache(object):
@@ -144,18 +143,23 @@ def get_bundle_version_number(bundle_uuid, draft_name=None):
     return version
 
 
-@lru_cache(maxsize=200)
 def get_bundle_version_files_cached(bundle_uuid, bundle_version):
     """
     Get the files in the specified BundleVersion. Since BundleVersions are
-    immutable, this should be cached as aggressively as possible (ideally
-    it would be infinitely but we don't want to use up all available memory).
-    So this method uses lru_cache() to cache results in process-local memory.
-
-    (Note: This can't use BundleCache because BundleCache only associates data
-    with the most recent bundleversion, not a specified bundleversion)
+    immutable, this should be cached as aggressively as possible.
     """
-    return blockstore_api.get_bundle_version_files(bundle_uuid, bundle_version)
+    # Use the blockstore django cache directly; this can't use BundleCache because BundleCache only associates data
+    # with the most recent bundleversion, not a specified bundleversion
+    # This key is '_v2' to avoid reading invalid values cached by a past version of this code with no timeout.
+    cache_key = 'bundle_version_files_v2:{}:{}'.format(bundle_uuid, bundle_version)
+    result = cache.get(cache_key)
+    if result is None:
+        result = blockstore_api.get_bundle_version_files(bundle_uuid, bundle_version)
+        # Cache this result. We should be able to cache this forever, since bundle versions are immutable, but currently
+        # this result may contain signed S3 URLs which become invalid after 3600 seconds. If Blockstore is improved to
+        # return URLs that redirect to the signed S3 URLs, then this can be changed to cache forever.
+        cache.set(cache_key, result, timeout=1800)
+    return result
 
 
 def get_bundle_draft_files_cached(bundle_uuid, draft_name):
@@ -216,20 +220,22 @@ def get_bundle_file_data_with_cache(bundle_uuid, path, bundle_version=None, draf
     return response.content
 
 
-@lru_cache(maxsize=200)
 def get_bundle_version_direct_links_cached(bundle_uuid, bundle_version):
     """
     Get the direct links in the specified BundleVersion. Since BundleVersions
-    are immutable, this should be cached as aggressively as possible (ideally
-    it would be infinitely but we don't want to use up all available memory).
-    So this method uses lru_cache() to cache results in process-local memory.
-
-    (Note: This can't use BundleCache because BundleCache only associates data
-    with the most recent bundleversion, not a specified bundleversion)
+    are immutable, this should be cached as aggressively as possible.
     """
-    return {
-        link.name: link.direct for link in blockstore_api.get_bundle_version_links(bundle_uuid, bundle_version).values()
-    }
+    # Use the blockstore django cache directly; this can't use BundleCache because BundleCache only associates data
+    # with the most recent bundleversion, not a specified bundleversion
+    cache_key = 'bundle_version_direct_links:{}:{}'.format(bundle_uuid, bundle_version)
+    result = cache.get(cache_key)
+    if result is None:
+        result = {
+            link.name: link.direct
+            for link in blockstore_api.get_bundle_version_links(bundle_uuid, bundle_version).values()
+        }
+        cache.set(cache_key, result, timeout=None)  # Cache forever since bundle versions are immutable
+    return result
 
 
 def get_bundle_draft_direct_links_cached(bundle_uuid, draft_name):

--- a/openedx/core/lib/blockstore_api/__init__.py
+++ b/openedx/core/lib/blockstore_api/__init__.py
@@ -51,4 +51,5 @@ from .exceptions import (
     BundleNotFound,
     DraftNotFound,
     BundleFileNotFound,
+    BundleStorageError,
 )

--- a/openedx/core/lib/blockstore_api/exceptions.py
+++ b/openedx/core/lib/blockstore_api/exceptions.py
@@ -25,3 +25,7 @@ class DraftNotFound(NotFound):
 
 class BundleFileNotFound(NotFound):
     pass
+
+
+class BundleStorageError(BlockstoreException):
+    pass


### PR DESCRIPTION
This is a follow-up to #23241, which had to be reverted (#23386).

The main change compared to #23241 is here:

https://github.com/open-craft/edx-platform/blob/7509410ff3bdc273c33f6d9f4c041da3dd820074/openedx/core/djangolib/blockstore_cache.py#L157-L160

It turns out that caching the bundleversion data structures forever was problematic, because they [can contain signed S3 URLs](https://github.com/edx/edx-platform/blob/54e1f483cb6fae8d78c2d78942ba9210db9189ac/openedx/core/lib/blockstore_api/models.py#L61), and it seems Blockstore is using the default [`AWS_QUERYSTRING_EXPIRE`](https://django-storages.readthedocs.io/en/latest/backends/amazon-S3.html) value of 1 hour. So after one hour, we start trying to read data using an expired querystring auth param, and S3 rejects it with access denied.

I believe this bug was actually present before, but because we were using `@lru_cache` instead of memcached, the odds were somewhat low of hitting the same worker thread after an hour had passed but before the lru_cache had turned over (it was limited to 200 entries) or the worker was replaced with a new version of edx-platform.

I also made [a minor change](https://github.com/edx/edx-platform/compare/7509410ff3bdc273c33f6d9f4c041da3dd820074..7031b0cc0d79ac7ebf0df3c7ce820edb0e77a17c) to the error log to also log the HTTP status code and the full URL that failed.