### PR TITLE
Fix flaky test in Catalog Integration Configuration Model

### DIFF
--- a/openedx/core/djangoapps/catalog/management/commands/tests/test_create_catalog_integrations.py
+++ b/openedx/core/djangoapps/catalog/management/commands/tests/test_create_catalog_integrations.py
@@ -5,11 +5,13 @@ Test cases for catalog_integrations command.
 from django.test import TestCase
 from django.core.management import call_command, CommandError
 
+from openedx.core.djangolib.testing.utils import CacheIsolationTestCase
+
 from openedx.core.djangoapps.catalog.models import CatalogIntegration
 from openedx.core.djangoapps.catalog.tests.mixins import CatalogIntegrationMixin
 
 
-class TestCreateCatalogIntegrations(CatalogIntegrationMixin, TestCase):
+class TestCreateCatalogIntegrations(CatalogIntegrationMixin, CacheIsolationTestCase):
     """ Test the create_catalog_integrations command """
 
     def test_without_required(self):


### PR DESCRIPTION
This is a change to fix the flaky test observed by https://build.testeng.edx.org/job/edx-platform-python-pipeline-master/2972/, which resulted a revert of PR which is not related.

The root cause of this flakiness is due to the TieredCache library used by Configuration Model, which is not cleared after each test case. Needed to manually clear such cache for each test in this test suite

@edx/masters-devs Please review