### PR TITLE
Handle deprecation warn by importing right class.

### DIFF
--- a/lms/djangoapps/discussion/django_comment_client/utils.py
+++ b/lms/djangoapps/discussion/django_comment_client/utils.py
@@ -13,8 +13,7 @@ from django.db import connection
 from django.http import HttpResponse
 from django.urls import reverse
 from django.utils.deprecation import MiddlewareMixin
-from opaque_keys.edx.keys import CourseKey, UsageKey
-from opaque_keys.edx.locations import i4xEncoder
+from opaque_keys.edx.keys import CourseKey, i4xEncoder, UsageKey
 from pytz import UTC
 from six import text_type
 from six.moves import map

--- a/lms/djangoapps/instructor_task/tests/test_tasks.py
+++ b/lms/djangoapps/instructor_task/tests/test_tasks.py
@@ -14,7 +14,7 @@ import ddt
 from celery.states import FAILURE, SUCCESS
 from django.utils.translation import ugettext_noop
 from mock import MagicMock, Mock, patch
-from opaque_keys.edx.locations import i4xEncoder
+from opaque_keys.edx.keys import i4xEncoder
 from six.moves import range
 
 from course_modes.models import CourseMode


### PR DESCRIPTION
I have changed import 
from
`from opaque_keys.edx.locations import i4xEncoder` 
to
`from opaque_keys.edx.keys import i4xEncoder`

to avoid the deprecation warn in [opaque_keys/edx/locations.py#L18-L28](https://github.com/edx/opaque-keys/blob/16deefc71ab4f53b68bc4cfa1415bfe02adfa38a/opaque_keys/edx/locations.py#L18-L28). 

* https://github.com/edx/edx-platform/pull/23402/commits/65094cbf3572e0b6c511016fcfac6dcd09ec8bec 2.82M / last 7 days


[PROD-1327](https://openedx.atlassian.net/browse/PROD-1327)
