### PR TITLE
Fix A11y issues on Team Management tab

### DIFF
--- a/lms/djangoapps/teams/static/teams/templates/manage.underscore
+++ b/lms/djangoapps/teams/static/teams/templates/manage.underscore
@@ -27,7 +27,7 @@
                     "users to teams."
                 ) %>
             </p>
-            <div class="upload-team-csv btn action action-primary">
+            <button class="upload-team-csv btn action action-primary">
                 <input
                     id="upload-team-csv-input"
                     type="file"
@@ -35,7 +35,7 @@
                     class="input-overlay-hack"
                 />
                 <%- gettext("Upload Memberships") %>
-            </div>
+            </button>
             <!-- We need to describe the format of the CSV here (TODO MST-49) -->
             <div class="page-banner" hidden>
                 <div class="alert alert-danger" role="alert">

--- a/lms/static/sass/views/_teams.scss
+++ b/lms/static/sass/views/_teams.scss
@@ -552,6 +552,7 @@
 
     &:focus {
       border: inherit;
+      box-shadow: none;
     }
     display: inline-block;
     text-shadow: none;

--- a/lms/static/sass/views/_teams.scss
+++ b/lms/static/sass/views/_teams.scss
@@ -550,6 +550,9 @@
   .action-primary {
     @extend %btn-primary-blue;
 
+    &:focus {
+      border: inherit;
+    }
     display: inline-block;
     text-shadow: none;
   }


### PR DESCRIPTION
**Reasoning**
This PR seeks to improve accessibility on the Team Management tab by standardizing focus behavior and styling of controls on the page.

**Changes**
- Allow the upload membership button to receive focus by changing it from a `<div>` to a `<button>`
- Fix button border styling to avoid resizing buttons on focus
- Remove box shadow from focus styling

**Note**
- UX improvements will be addressed in a [separate story](https://openedx.atlassian.net/browse/EDUCATOR-4950), including enable/disable behavior of buttons

JIRA: [EDUCATOR-4949](https://openedx.atlassian.net/browse/EDUCATOR-4949)
FYI: @edx/masters-devs 