### PR TITLE
EDUCATOR-4952: Allow Users to join one team per open teamset

### DIFF
--- a/common/test/acceptance/tests/lms/test_teams.py
+++ b/common/test/acceptance/tests/lms/test_teams.py
@@ -1896,7 +1896,7 @@ class TeamPageTest(TeamsTabBase):
         """
         self._set_team_configuration_and_membership(membership_team_index=0, visit_team_index=1)
         self.team_page.visit()
-        self.assertEqual(self.team_page.join_team_message, 'You already belong to another team.')
+        self.assertEqual(self.team_page.join_team_message, 'You already belong to another team in this team set.')
         self.assert_team_details(num_members=0, is_member=False)
 
     def test_team_full_message(self):

--- a/lms/djangoapps/teams/api.py
+++ b/lms/djangoapps/teams/api.py
@@ -12,7 +12,7 @@ from opaque_keys.edx.keys import CourseKey
 
 from course_modes.models import CourseMode
 from lms.djangoapps.discussion.django_comment_client.utils import has_discussion_privileges
-from lms.djangoapps.teams.models import CourseTeam
+from lms.djangoapps.teams.models import CourseTeam, CourseTeamMembership
 from openedx.core.lib.teams_config import TeamsetType
 from student.models import CourseEnrollment, anonymous_id_for_user
 from student.roles import CourseInstructorRole, CourseStaffRole

--- a/lms/djangoapps/teams/api.py
+++ b/lms/djangoapps/teams/api.py
@@ -12,7 +12,7 @@ from opaque_keys.edx.keys import CourseKey
 
 from course_modes.models import CourseMode
 from lms.djangoapps.discussion.django_comment_client.utils import has_discussion_privileges
-from lms.djangoapps.teams.models import CourseTeam, CourseTeamMembership
+from lms.djangoapps.teams.models import CourseTeam
 from openedx.core.lib.teams_config import TeamsetType
 from student.models import CourseEnrollment, anonymous_id_for_user
 from student.roles import CourseInstructorRole, CourseStaffRole

--- a/lms/djangoapps/teams/models.py
+++ b/lms/djangoapps/teams/models.py
@@ -299,7 +299,7 @@ class CourseTeamMembership(models.Model):
         self.team.reset_team_size()
 
     @classmethod
-    def get_memberships(cls, username=None, course_ids=None, team_id=None):
+    def get_memberships(cls, username=None, course_ids=None, team_ids=None):
         """
         Get a queryset of memberships.
 
@@ -313,8 +313,8 @@ class CourseTeamMembership(models.Model):
             queryset = queryset.filter(user__username=username)
         if course_ids is not None:
             queryset = queryset.filter(team__course_id__in=course_ids)
-        if team_id is not None:
-            queryset = queryset.filter(team__team_id=team_id)
+        if team_ids is not None:
+            queryset = queryset.filter(team__team_id__in=team_ids)
 
         return queryset
 
@@ -360,3 +360,12 @@ class CourseTeamMembership(models.Model):
         emit_team_event('edx.team.activity_updated', membership.team.course_id, {
             'team_id': membership.team.team_id,
         })
+
+    @classmethod
+    def is_user_on_team(cls, user, team):
+        """ Is `user` on `team`?"""
+        try:
+            cls.objects.get(user=user, team=team)
+        except ObjectDoesNotExist:
+            return False
+        return True

--- a/lms/djangoapps/teams/static/teams/js/spec/views/team_profile_header_actions_spec.js
+++ b/lms/djangoapps/teams/static/teams/js/spec/views/team_profile_header_actions_spec.js
@@ -21,7 +21,8 @@ define([
                 id: teamId,
                 name: teamName,
                 membership: membership,
-                url: createTeamsUrl(teamId)
+                url: createTeamsUrl(teamId),
+                topic_id: 'topic-id'
             };
         };
 
@@ -116,7 +117,9 @@ define([
                     requests,
                     'GET',
                     TeamSpecHelpers.testContext.teamMembershipsUrl + '?' + $.param({
-                        username: currentUsername, course_id: TeamSpecHelpers.testCourseID
+                        username: currentUsername,
+                        course_id: TeamSpecHelpers.testCourseID,
+                        teamset_id: 'topic-id'
                     })
                 );
 
@@ -163,14 +166,16 @@ define([
                     requests,
                     'GET',
                     TeamSpecHelpers.testContext.teamMembershipsUrl + '?' + $.param({
-                        username: currentUsername, course_id: TeamSpecHelpers.testCourseID
+                        username: currentUsername,
+                        course_id: TeamSpecHelpers.testCourseID,
+                        teamset_id: 'topic-id'
                     })
                 );
 
                 // current user is a member of another team so we should see the correct message
                 AjaxHelpers.respondWithJson(requests, {count: 1});
                 expect(view.$('.action.action-primary').length).toEqual(0);
-                expect(view.$('.join-team-message').text().trim()).toBe(view.alreadyMemberMessage);
+                expect(view.$('.join-team-message').text().trim()).toBe(view.alreadyTeamsetMemberMessage);
             });
 
             it('shows team full message', function() {
@@ -210,7 +215,9 @@ define([
                     requests,
                     'GET',
                     TeamSpecHelpers.testContext.teamMembershipsUrl + '?' + $.param({
-                        username: currentUsername, course_id: TeamSpecHelpers.testCourseID
+                        username: currentUsername,
+                        course_id: TeamSpecHelpers.testCourseID,
+                        teamset_id: 'topic-id'
                     })
                 );
 
@@ -241,7 +248,9 @@ define([
                     requests,
                     'GET',
                     TeamSpecHelpers.testContext.teamMembershipsUrl + '?' + $.param({
-                        username: currentUsername, course_id: TeamSpecHelpers.testCourseID
+                        username: currentUsername,
+                        course_id: TeamSpecHelpers.testCourseID,
+                        teamset_id: 'topic-id'
                     })
                 );
 
@@ -270,7 +279,9 @@ define([
                     requests,
                     'GET',
                     TeamSpecHelpers.testContext.teamMembershipsUrl + '?' + $.param({
-                        username: currentUsername, course_id: TeamSpecHelpers.testCourseID
+                        username: currentUsername,
+                        course_id: TeamSpecHelpers.testCourseID,
+                        teamset_id: 'topic-id'
                     })
                 );
 

--- a/lms/djangoapps/teams/static/teams/js/views/team_profile_header_actions.js
+++ b/lms/djangoapps/teams/static/teams/js/views/team_profile_header_actions.js
@@ -12,7 +12,7 @@
             return Backbone.View.extend({
 
                 errorMessage: gettext('An error occurred. Try again.'),
-                alreadyMemberMessage: gettext('You already belong to another team.'),
+                alreadyTeamsetMemberMessage: gettext('You already belong to another team in this team set.'),
                 teamFullMessage: gettext('This team is full.'),
                 notJoinInstructorManagedTeam: gettext('Cannot join instructor managed team'),
 
@@ -41,9 +41,9 @@
 
                         // if user is the member of current team then we wouldn't show anything
                         if (!info.memberOfCurrentTeam) {
-                            if (info.alreadyMember) {
+                            if (info.alreadyInTeamset) {
                                 showJoinButton = false;
-                                message = info.memberOfCurrentTeam ? '' : view.alreadyMemberMessage;
+                                message = info.memberOfCurrentTeam ? '' : view.alreadyTeamsetMemberMessage;
                             } else if (!teamHasSpace) {
                                 showJoinButton = false;
                                 message = view.teamFullMessage;
@@ -90,7 +90,7 @@
                 getUserTeamInfo: function(username, courseMaxTeamSize) {
                     var deferred = $.Deferred();
                     var info = {
-                        alreadyMember: false,
+                        alreadyInTeamset: false,
                         memberOfCurrentTeam: false,
                         teamHasSpace: false,
                         isAdminOrStaff: false,
@@ -108,7 +108,7 @@
                     info.isInstructorManagedTopic = isInstructorManagedTopic;
 
                     if (info.memberOfCurrentTeam) {
-                        info.alreadyMember = true;
+                        info.alreadyInTeamset = true;
                         info.memberOfCurrentTeam = true;
                         deferred.resolve(info);
                     } else {
@@ -117,9 +117,13 @@
                             $.ajax({
                                 type: 'GET',
                                 url: view.context.teamMembershipsUrl,
-                                data: {username: username, course_id: view.context.courseID}
+                                data: {
+                                    username: username,
+                                    course_id: view.context.courseID,
+                                    teamset_id: view.model.get('topic_id')
+                                }
                             }).done(function(data) {
-                                info.alreadyMember = (data.count > 0);
+                                info.alreadyInTeamset = (data.count > 0);
                                 info.memberOfCurrentTeam = false;
                                 info.teamHasSpace = teamHasSpace;
                                 deferred.resolve(info);

--- a/lms/djangoapps/teams/tests/test_models.py
+++ b/lms/djangoapps/teams/tests/test_models.py
@@ -191,13 +191,13 @@ class TeamMembershipTest(SharedModuleStoreTestCase):
         (None, None, None, 3),
         ('user1', None, None, 2),
         ('user1', [COURSE_KEY1], None, 1),
-        ('user1', None, 'team1', 1),
+        ('user1', None, ['team1'], 1),
         ('user2', None, None, 1),
     )
     @ddt.unpack
-    def test_get_memberships(self, username, course_ids, team_id, expected_count):
+    def test_get_memberships(self, username, course_ids, team_ids, expected_count):
         self.assertEqual(
-            CourseTeamMembership.get_memberships(username=username, course_ids=course_ids, team_id=team_id).count(),
+            CourseTeamMembership.get_memberships(username=username, course_ids=course_ids, team_ids=team_ids).count(),
             expected_count
         )
 

--- a/lms/djangoapps/teams/views.py
+++ b/lms/djangoapps/teams/views.py
@@ -1009,6 +1009,13 @@ class MembershipListView(ExpandableFieldViewMixin, GenericAPIView):
               specified team. The requesting user must be staff or enrolled in
               the course associated with the team.
 
+            * teamset_id: Returns membership records only for the specified teamset.
+              if teamset_id is specified, course_id must also be specified.
+              teamset_id and team_id are mutually exclusive. For open and public_managed
+              teamsets, the user must be staff or enrolled in the course. For
+              private_managed teamsets, the user must be course staff, or a member of the
+              specified teamset.
+
             * course_id: Returns membership records only for the specified
               course. Username must have access to this course, or else team_id
               must be in this course.
@@ -1172,10 +1179,10 @@ class MembershipListView(ExpandableFieldViewMixin, GenericAPIView):
                     status=status.HTTP_404_NOT_FOUND
                 )
             teamset_teams = CourseTeam.objects.filter(course_id=requested_course_key, topic_id=teamset_id)
-            teams_with_access = list(filter(
-                lambda team: has_specific_team_access(request.user, team),
-                teamset_teams
-            ))
+            teams_with_access = [
+                team for team in teamset_teams
+                if has_specific_team_access(request.user, team)
+            ]
             if not teams_with_access:
                 return Response(
                     build_api_error(ugettext_noop("No teamset found in given course with given id")),


### PR DESCRIPTION
[EDUCATOR-4952](https://openedx.atlassian.net/browse/EDUCATOR-4952)
@edx/masters-devs 

Allow users to join one team per teamset. (Users are only able to join or leave open teamsets)

This is enabled by adding a teamset_id parameter to the team membership listing endpoint.
the new parameter is mutually exclusive with team_id to avoid having to resolve potential mismatches. it also requires course_id, since otherwise we can't look up the teamset. 

### Message when user is in a team in this teamset already
![already in teamset](https://user-images.githubusercontent.com/1639231/76801714-916b8500-67ac-11ea-8359-379578c9a9c6.png)

###This is a different teamset so we can join! 
![join other teamset](https://user-images.githubusercontent.com/1639231/76801719-92041b80-67ac-11ea-8cf6-0d0cf8855a74.png)

