### PR TITLE
Remove/Limit log.info

### DIFF
--- a/lms/djangoapps/program_enrollments/signals.py
+++ b/lms/djangoapps/program_enrollments/signals.py
@@ -59,7 +59,7 @@ def matriculate_learner(user, uid):
         if not authorizing_org:
             return
     except (AttributeError, ValueError):
-        logger.info('Ignoring non-saml social auth entry for user=%s', user.id)
+        logger.debug('Ignoring non-saml social auth entry for user=%s', user.id)
         return
     except SAMLProviderConfig.DoesNotExist:
         logger.warning(

--- a/openedx/core/djangoapps/enrollments/api.py
+++ b/openedx/core/djangoapps/enrollments/api.py
@@ -331,7 +331,6 @@ def get_course_enrollment_details(course_id, include_expired=False):
         log.exception(u"Error occurred while retrieving course enrollment details from the cache")
 
     if cached_enrollment_data:
-        log.info(u"Get enrollment data for course %s (cached)", course_id)
         return cached_enrollment_data
 
     course_enrollment_details = _data_api().get_course_enrollment_info(course_id, include_expired)
@@ -344,7 +343,6 @@ def get_course_enrollment_details(course_id, include_expired=False):
         log.exception(u"Error occurred while caching course enrollment details for course %s", course_id)
         raise errors.CourseEnrollmentError(u"An unexpected error occurred while retrieving course enrollment details.")
 
-    log.info(u"Get enrollment data for course %s", course_id)
     return course_enrollment_details
 
 


### PR DESCRIPTION
* https://github.com/edx/edx-platform/pull/23427/commits/e3069877af52d5f59b034a8adb178c327770d0ef This log is hit every time a learner hits course tab or the API endpoint is hit  for course 
 enrollment detail. This log is proving to be expensive (383k instance / 7 days) so This PR removes the log.  =>> [Splunk Log Instances](http://splunk.edx.org/en-US/app/search/search?s=%2FservicesNS%2Fnobody%2Fsearch%2Fsaved%2Fsearches%2FNoisy%2520Loggers&search=undefined&display.page.search.mode=fast&dispatch.sample_ratio=1&earliest=-7d%40h&latest=now&q=search%20index%3D%22prod-edx%22%20source%3D%22%2Fedx%2Fvar%2Flog%2Flms%2Fedx.log%22%20%20log_line_origin%3D%22api.py%3A347%22&display.page.search.tab=events&display.general.type=events&sid=1584445649.531294)