### PR TITLE
Swap courseware-mfe CourseWaffleFlag with ExperimentWaffleFlag

### DIFF
--- a/lms/djangoapps/courseware/tests/test_views.py
+++ b/lms/djangoapps/courseware/tests/test_views.py
@@ -3260,7 +3260,7 @@ class TestShowCoursewareMFE(TestCase):
     * user is member of the course team
     * whether the course_key is an old Mongo style of key
     * the COURSEWARE_MICROFRONTEND_COURSE_TEAM_PREVIEW CourseWaffleFlag
-    * the REDIRECT_TO_COURSEWARE_MICROFRONTEND CourseWaffleFlag
+    * the REDIRECT_TO_COURSEWARE_MICROFRONTEND ExperimentWaffleFlag
 
     Giving us theoretically 2^6 = 64 states. >_<
     """

--- a/lms/djangoapps/courseware/toggles.py
+++ b/lms/djangoapps/courseware/toggles.py
@@ -3,14 +3,15 @@ Toggles for courseware in-course experience.
 """
 
 from django.conf import settings
-from openedx.core.djangoapps.waffle_utils import CourseWaffleFlag, ExperimentWaffleFlag, WaffleFlagNamespace
+from lms.djangoapps.experiments.flags import ExperimentWaffleFlag
+from openedx.core.djangoapps.waffle_utils import CourseWaffleFlag, WaffleFlagNamespace
 
 # Namespace for courseware waffle flags.
 WAFFLE_FLAG_NAMESPACE = WaffleFlagNamespace(name='courseware')
 
 # Waffle flag to redirect to another learner profile experience.
 # .. toggle_name: courseware.redirect_to_microfrontend
-# .. toggle_implementation: CourseWaffleFlag
+# .. toggle_implementation: ExperimentWaffleFlag
 # .. toggle_default: False
 # .. toggle_description: Supports staged rollout to students for a new micro-frontend-based implementation of the courseware page.
 # .. toggle_category: micro-frontend

--- a/lms/djangoapps/courseware/toggles.py
+++ b/lms/djangoapps/courseware/toggles.py
@@ -3,7 +3,7 @@ Toggles for courseware in-course experience.
 """
 
 from django.conf import settings
-from openedx.core.djangoapps.waffle_utils import CourseWaffleFlag, WaffleFlagNamespace
+from openedx.core.djangoapps.waffle_utils import CourseWaffleFlag, ExperimentWaffleFlag, WaffleFlagNamespace
 
 # Namespace for courseware waffle flags.
 WAFFLE_FLAG_NAMESPACE = WaffleFlagNamespace(name='courseware')
@@ -20,7 +20,7 @@ WAFFLE_FLAG_NAMESPACE = WaffleFlagNamespace(name='courseware')
 # .. toggle_warnings: Also set settings.LEARNING_MICROFRONTEND_URL and ENABLE_COURSEWARE_MICROFRONTEND.
 # .. toggle_tickets: TNL-6982
 # .. toggle_status: supported
-REDIRECT_TO_COURSEWARE_MICROFRONTEND = CourseWaffleFlag(WAFFLE_FLAG_NAMESPACE, 'redirect_to_microfrontend')
+REDIRECT_TO_COURSEWARE_MICROFRONTEND = ExperimentWaffleFlag(WAFFLE_FLAG_NAMESPACE, 'courseware-mfe')
 
 # Waffle flag to display a link for the new learner experience to course teams without redirecting students.
 #

--- a/lms/djangoapps/courseware/toggles.py
+++ b/lms/djangoapps/courseware/toggles.py
@@ -10,7 +10,7 @@ from openedx.core.djangoapps.waffle_utils import CourseWaffleFlag, WaffleFlagNam
 WAFFLE_FLAG_NAMESPACE = WaffleFlagNamespace(name='courseware')
 
 # Waffle flag to redirect to another learner profile experience.
-# .. toggle_name: courseware.redirect_to_microfrontend
+# .. toggle_name: courseware.courseware_mfe
 # .. toggle_implementation: ExperimentWaffleFlag
 # .. toggle_default: False
 # .. toggle_description: Supports staged rollout to students for a new micro-frontend-based implementation of the courseware page.
@@ -19,9 +19,9 @@ WAFFLE_FLAG_NAMESPACE = WaffleFlagNamespace(name='courseware')
 # .. toggle_creation_date: 2020-01-29
 # .. toggle_expiration_date: 2020-12-31
 # .. toggle_warnings: Also set settings.LEARNING_MICROFRONTEND_URL and ENABLE_COURSEWARE_MICROFRONTEND.
-# .. toggle_tickets: TNL-6982
+# .. toggle_tickets: TNL-7000
 # .. toggle_status: supported
-REDIRECT_TO_COURSEWARE_MICROFRONTEND = ExperimentWaffleFlag(WAFFLE_FLAG_NAMESPACE, 'courseware-mfe')
+REDIRECT_TO_COURSEWARE_MICROFRONTEND = ExperimentWaffleFlag(WAFFLE_FLAG_NAMESPACE, 'courseware_mfe')
 
 # Waffle flag to display a link for the new learner experience to course teams without redirecting students.
 #

--- a/lms/djangoapps/courseware/views/index.py
+++ b/lms/djangoapps/courseware/views/index.py
@@ -79,7 +79,11 @@ from ..masquerade import check_content_start_date_for_masquerade_user, setup_mas
 from ..model_data import FieldDataCache
 from ..module_render import get_module_for_descriptor, toc_for_course
 from ..permissions import MASQUERADE_AS_STUDENT
-from ..toggles import COURSEWARE_MICROFRONTEND_COURSE_TEAM_PREVIEW, should_redirect_to_courseware_microfrontend
+from ..toggles import (
+    COURSEWARE_MICROFRONTEND_COURSE_TEAM_PREVIEW,
+    REDIRECT_TO_COURSEWARE_MICROFRONTEND,
+    should_redirect_to_courseware_microfrontend
+)
 from ..url_helpers import get_microfrontend_url
 
 from .views import CourseTabView
@@ -715,9 +719,9 @@ def show_courseware_mfe_link(user, staff_access, course_key):
     # course team preview CourseWaffleFlag for this course *or* if we've turned
     # on the redirect for your students.
     mfe_enabled_for_course_team = COURSEWARE_MICROFRONTEND_COURSE_TEAM_PREVIEW.is_enabled(course_key)
-    mfe_enabled_for_students = should_redirect_to_courseware_microfrontend(course_key)
+    mfe_experiment_enabled_for_course = REDIRECT_TO_COURSEWARE_MICROFRONTEND.is_enabled_for_course(course_key)
 
-    if staff_access and (mfe_enabled_for_course_team or mfe_enabled_for_students):
+    if staff_access and (mfe_enabled_for_course_team or mfe_experiment_enabled_for_course):
         return True
 
     return False

--- a/lms/djangoapps/courseware/views/index.py
+++ b/lms/djangoapps/courseware/views/index.py
@@ -82,7 +82,7 @@ from ..permissions import MASQUERADE_AS_STUDENT
 from ..toggles import (
     COURSEWARE_MICROFRONTEND_COURSE_TEAM_PREVIEW,
     REDIRECT_TO_COURSEWARE_MICROFRONTEND,
-    should_redirect_to_courseware_microfrontend
+    should_redirect_to_courseware_microfrontend,
 )
 from ..url_helpers import get_microfrontend_url
 

--- a/lms/djangoapps/courseware/views/index.py
+++ b/lms/djangoapps/courseware/views/index.py
@@ -719,7 +719,7 @@ def show_courseware_mfe_link(user, staff_access, course_key):
     # course team preview CourseWaffleFlag for this course *or* if we've turned
     # on the redirect for your students.
     mfe_enabled_for_course_team = COURSEWARE_MICROFRONTEND_COURSE_TEAM_PREVIEW.is_enabled(course_key)
-    mfe_experiment_enabled_for_course = REDIRECT_TO_COURSEWARE_MICROFRONTEND.is_enabled_for_course(course_key)
+    mfe_experiment_enabled_for_course = REDIRECT_TO_COURSEWARE_MICROFRONTEND.is_experiment_on(course_key)
 
     if staff_access and (mfe_enabled_for_course_team or mfe_experiment_enabled_for_course):
         return True

--- a/lms/djangoapps/experiments/flags.py
+++ b/lms/djangoapps/experiments/flags.py
@@ -138,6 +138,9 @@ class ExperimentWaffleFlag(CourseWaffleFlag):
     def is_enabled_without_course_context(self):
         return self.is_enabled()
 
+    def is_enabled_for_course(self, course_key=None):
+        return super().is_enabled(course_key)
+
     @contextmanager
     def override(self, active=True, bucket=1):  # pylint: disable=arguments-differ
         from mock import patch

--- a/lms/djangoapps/experiments/flags.py
+++ b/lms/djangoapps/experiments/flags.py
@@ -138,7 +138,7 @@ class ExperimentWaffleFlag(CourseWaffleFlag):
     def is_enabled_without_course_context(self):
         return self.is_enabled()
 
-    def is_enabled_for_course(self, course_key=None):
+    def is_experiment_on(self, course_key=None):
         return super().is_enabled(course_key)
 
     @contextmanager


### PR DESCRIPTION
TNL-7000

Use `ExperimentWaffleFlag` instead of `CourseWaffleFlag` for its user bucketing functionality. [More info here](https://openedx.atlassian.net/wiki/spaces/AC/pages/1250623700/Bucketing+users+for+an+experiment).

Relates to #23016 