### PR TITLE
AA-73 courseware nonetype error

### DIFF
--- a/lms/djangoapps/courseware/tests/test_views.py
+++ b/lms/djangoapps/courseware/tests/test_views.py
@@ -273,8 +273,8 @@ class IndexQueryTestCase(ModuleStoreTestCase):
     NUM_PROBLEMS = 20
 
     @ddt.data(
-        (ModuleStoreEnum.Type.mongo, 10, 174),
-        (ModuleStoreEnum.Type.split, 4, 172),
+        (ModuleStoreEnum.Type.mongo, 10, 172),
+        (ModuleStoreEnum.Type.split, 4, 170),
     )
     @ddt.unpack
     def test_index_query_counts(self, store_type, expected_mongo_query_count, expected_mysql_query_count):
@@ -2600,6 +2600,7 @@ class TestIndexView(ModuleStoreTestCase):
                 expected_should_show_enroll_button
             )
 
+    @RELATIVE_DATES_FLAG.override(active=True)
     def test_reset_deadlines_banner_is_present_when_viewing_courseware(self):
         user = UserFactory()
         course = CourseFactory.create(self_paced=True)

--- a/lms/djangoapps/courseware/views/index.py
+++ b/lms/djangoapps/courseware/views/index.py
@@ -458,17 +458,17 @@ class CoursewareIndex(View):
 
         allow_anonymous = allow_public_access(self.course, [COURSE_VISIBILITY_PUBLIC])
         display_reset_dates_banner = False
-        if not allow_anonymous:  # pylint: disable=too-many-nested-blocks
+        if not allow_anonymous and RELATIVE_DATES_FLAG.is_enabled(self.course.id):  # pylint: disable=too-many-nested-blocks
             course_overview = CourseOverview.objects.get(id=str(self.course_key))
             end_date = getattr(course_overview, 'end_date')
-            if not end_date or timezone.now() < end_date:
+            if course_overview.self_paced and (not end_date or timezone.now() < end_date):
                 if (CourseEnrollment.objects.filter(
                     course=course_overview, user=request.user, mode=CourseMode.VERIFIED
                 ).exists()):
                     course_block_tree = get_course_outline_block_tree(
                         request, str(self.course_key), request.user
                     )
-                    course_sections = course_block_tree.get('children')
+                    course_sections = course_block_tree.get('children', [])
                     for section in course_sections:
                         if display_reset_dates_banner:
                             break


### PR DESCRIPTION
- ensure logic for displaying reset dealines banner in courseware
  only shows if the course is self paced and handles the situation
  where no sequentials exist.