### PR TITLE
Improve repr() and admin for program_enrollments models

### DIFF
--- a/lms/djangoapps/program_enrollments/admin.py
+++ b/lms/djangoapps/program_enrollments/admin.py
@@ -1,10 +1,9 @@
-# -*- coding: utf-8 -*-
 """
 Admin tool for the Program Enrollments models
 """
-
-
 from django.contrib import admin
+from django.urls import reverse
+from django.utils.html import format_html
 
 from lms.djangoapps.program_enrollments.models import ProgramCourseEnrollment, ProgramEnrollment
 
@@ -13,18 +12,93 @@ class ProgramEnrollmentAdmin(admin.ModelAdmin):
     """
     Admin tool for the ProgramEnrollment model
     """
-    list_display = ('id', 'user', 'external_user_key', 'program_uuid', 'curriculum_uuid', 'status')
+    # Config for instance listing.
+    list_display = (
+        'id',
+        'status',
+        'user',
+        'external_user_key',
+        'program_uuid',
+        'curriculum_uuid',
+    )
     list_filter = ('status',)
+    search_fields = ('user__username', 'external_user_key', 'program_uuid')
+
+    # Config for instance editor.
     raw_id_fields = ('user',)
-    search_fields = ('user__username',)
+
+
+def _pce_pe_id(pce):
+    """
+    Generate a link to edit program enrollment, with ID and status in link text.
+    """
+    pe = pce.program_enrollment
+    if not pe:
+        return None
+    link_url = reverse(
+        "admin:program_enrollments_programenrollment_change",
+        args=[pe.id],
+    )
+    link_text = "id={pe.id:05} ({pe.status})".format(pe=pe)
+    return format_html("<a href={}>{}</a>", link_url, link_text)
+
+
+def _pce_pe_user(pce):
+    return pce.program_enrollment.user
+
+
+def _pce_pe_external_user_key(pce):
+    return pce.program_enrollment.external_user_key
+
+
+def _pce_pe_program_uuid(pce):
+    return pce.program_enrollment.program_uuid
+
+
+def _pce_ce(pce):
+    """
+    Generate text for course enrollment, including ID and is_active value.
+    """
+    enrollment = pce.course_enrollment
+    if not enrollment:
+        return None
+    active_string = "Active" if enrollment.is_active else "Inactive"
+    return "id={enrollment.id:09} ({active_string})".format(
+        enrollment=enrollment, active_string=active_string
+    )
+
+
+_pce_pe_id.short_description = "Program Enrollment"
+_pce_pe_user.short_description = "Pgm Enrollment: User"
+_pce_pe_external_user_key.short_description = "Pgm Enrollment: Ext User Key"
+_pce_pe_program_uuid.short_description = "Pgm Enrollment: Pgm UUID"
+_pce_ce.short_description = "Course Enrollment"
 
 
 class ProgramCourseEnrollmentAdmin(admin.ModelAdmin):
     """
     Admin tool for the ProgramCourseEnrollment model
     """
-    list_display = ('id', 'program_enrollment', 'course_enrollment', 'course_key', 'status')
-    list_filter = ('course_key',)
+    # Config for instance listing.
+    list_display = (
+        'id',
+        'status',
+        _pce_pe_id,
+        _pce_pe_user,
+        _pce_pe_external_user_key,
+        _pce_pe_program_uuid,
+        _pce_ce,
+        'course_key',
+    )
+    list_filter = ('status', 'course_key')
+    search_fields = (
+        'program_enrollment__user__username',
+        'program_enrollment__external_user_key',
+        'program_enrollment__program_uuid',
+        'course_key',
+    )
+
+    # Config for instance editor.
     raw_id_fields = ('program_enrollment', 'course_enrollment')
 
 

--- a/lms/djangoapps/program_enrollments/models.py
+++ b/lms/djangoapps/program_enrollments/models.py
@@ -17,7 +17,7 @@ from student.models import CourseEnrollment
 from .constants import ProgramCourseEnrollmentStatuses, ProgramEnrollmentStatuses
 
 
-class ProgramEnrollment(TimeStampedModel):  # pylint: disable=model-missing-unicode
+class ProgramEnrollment(TimeStampedModel):
     """
     This is a model for Program Enrollments from the registrar service
 
@@ -78,8 +78,20 @@ class ProgramEnrollment(TimeStampedModel):  # pylint: disable=model-missing-unic
     def __str__(self):
         return '[ProgramEnrollment id={}]'.format(self.id)
 
+    def __repr__(self):
+        return (
+            "<ProgramEnrollment"    # pylint: disable=missing-format-attribute
+            " id={self.id}"
+            " user={self.user!r}"
+            " external_user_key={self.external_user_key!r}"
+            " program_uuid={self.program_uuid!r}"
+            " curriculum_uuid={self.curriculum_uuid!r}"
+            " status={self.status!r}"
+            ">"
+        ).format(self=self)
 
-class ProgramCourseEnrollment(TimeStampedModel):  # pylint: disable=model-missing-unicode
+
+class ProgramCourseEnrollment(TimeStampedModel):
     """
     This is a model to represent a learner's enrollment in a course
     in the context of a program from the registrar service
@@ -126,3 +138,14 @@ class ProgramCourseEnrollment(TimeStampedModel):  # pylint: disable=model-missin
 
     def __str__(self):
         return '[ProgramCourseEnrollment id={}]'.format(self.id)
+
+    def __repr__(self):
+        return (
+            "<ProgramCourseEnrollment"  # pylint: disable=missing-format-attribute
+            " id={self.id}"
+            " program_enrollment={self.program_enrollment!r}"
+            " course_enrollment=<{self.course_enrollment}>"
+            " course_key={self.course_key}"
+            " status={self.status!r}"
+            ">"
+        ).format(self=self)

--- a/lms/djangoapps/program_enrollments/tests/test_admin.py
+++ b/lms/djangoapps/program_enrollments/tests/test_admin.py
@@ -24,20 +24,13 @@ class ProgramEnrollmentAdminTests(TestCase):
 
     def test_program_enrollment_admin(self):
         request = mock.Mock()
-
         expected_list_display = (
-            'id', 'user', 'external_user_key', 'program_uuid', 'curriculum_uuid', 'status'
+            'id', 'status', 'user', 'external_user_key', 'program_uuid', 'curriculum_uuid'
         )
         assert expected_list_display == self.program_admin.get_list_display(request)
         expected_raw_id_fields = ('user',)
         assert expected_raw_id_fields == self.program_admin.raw_id_fields
 
     def test_program_course_enrollment_admin(self):
-        request = mock.Mock()
-
-        expected_list_display = (
-            'id', 'program_enrollment', 'course_enrollment', 'course_key', 'status'
-        )
-        assert expected_list_display == self.program_course_admin.get_list_display(request)
         expected_raw_id_fields = ('program_enrollment', 'course_enrollment')
         assert expected_raw_id_fields == self.program_course_admin.raw_id_fields

--- a/lms/djangoapps/program_enrollments/tests/test_models.py
+++ b/lms/djangoapps/program_enrollments/tests/test_models.py
@@ -3,7 +3,7 @@ Unit tests for ProgramEnrollment models.
 """
 
 
-from uuid import uuid4
+from uuid import UUID
 
 import ddt
 from django.db.utils import IntegrityError
@@ -12,10 +12,11 @@ from edx_django_utils.cache import RequestCache
 from opaque_keys.edx.keys import CourseKey
 
 from course_modes.models import CourseMode
-from lms.djangoapps.program_enrollments.models import ProgramCourseEnrollment, ProgramEnrollment
-from openedx.core.djangoapps.catalog.tests.factories import generate_course_run_key
 from openedx.core.djangoapps.content.course_overviews.tests.factories import CourseOverviewFactory
 from student.tests.factories import CourseEnrollmentFactory, UserFactory
+
+from ..models import ProgramEnrollment
+from .factories import ProgramCourseEnrollmentFactory, ProgramEnrollmentFactory
 
 
 class ProgramEnrollmentModelTests(TestCase):
@@ -27,11 +28,11 @@ class ProgramEnrollmentModelTests(TestCase):
         Set up the test data used in the specific tests
         """
         super(ProgramEnrollmentModelTests, self).setUp()
-        self.user = UserFactory.create()
-        self.program_uuid = uuid4()
-        self.other_program_uuid = uuid4()
-        self.curriculum_uuid = uuid4()
-        self.enrollment = ProgramEnrollment.objects.create(
+        self.user = UserFactory(username="rocko")
+        self.program_uuid = UUID("88888888-4444-2222-1111-000000000000")
+        self.other_program_uuid = UUID("88888888-4444-3333-1111-000000000000")
+        self.curriculum_uuid = UUID("77777777-4444-2222-1111-000000000000")
+        self.enrollment = ProgramEnrollmentFactory(
             user=self.user,
             external_user_key='abc',
             program_uuid=self.program_uuid,
@@ -39,12 +40,24 @@ class ProgramEnrollmentModelTests(TestCase):
             status='enrolled'
         )
 
+    def test_str_and_repr(self):
+        """
+        Make sure str() and repr() work correctly on instances of this model.
+        """
+        assert str(self.enrollment) == "[ProgramEnrollment id=1]"
+        assert repr(self.enrollment) == (
+            "<ProgramEnrollment id=1 user=<User: rocko> external_user_key='abc'"
+            " program_uuid=UUID('88888888-4444-2222-1111-000000000000')"
+            " curriculum_uuid=UUID('77777777-4444-2222-1111-000000000000')"
+            " status='enrolled'>"
+        )
+
     def test_unique_external_key_program_curriculum(self):
         """
         A record with the same (external_user_key, program_uuid, curriculum_uuid) cannot be duplicated.
         """
         with self.assertRaises(IntegrityError):
-            _ = ProgramEnrollment.objects.create(
+            _ = ProgramEnrollmentFactory(
                 user=None,
                 external_user_key='abc',
                 program_uuid=self.program_uuid,
@@ -57,7 +70,7 @@ class ProgramEnrollmentModelTests(TestCase):
         A record with the same (user, program_uuid, curriculum_uuid) cannot be duplicated.
         """
         with self.assertRaises(IntegrityError):
-            _ = ProgramEnrollment.objects.create(
+            _ = ProgramEnrollmentFactory(
                 user=self.user,
                 external_user_key=None,
                 program_uuid=self.program_uuid,
@@ -104,17 +117,37 @@ class ProgramCourseEnrollmentModelTests(TestCase):
         """
         super(ProgramCourseEnrollmentModelTests, self).setUp()
         RequestCache.clear_all_namespaces()
-        self.user = UserFactory.create()
-        self.program_uuid = uuid4()
-        self.program_enrollment = ProgramEnrollment.objects.create(
+        self.user = UserFactory(username="rocko")
+        self.program_uuid = UUID("88888888-4444-2222-1111-000000000000")
+        self.curriculum_uuid = UUID("77777777-4444-2222-1111-000000000000")
+        self.program_enrollment = ProgramEnrollmentFactory(
             user=self.user,
             external_user_key='abc',
             program_uuid=self.program_uuid,
-            curriculum_uuid=uuid4(),
+            curriculum_uuid=self.curriculum_uuid,
             status='enrolled'
         )
-        self.course_key = CourseKey.from_string(generate_course_run_key())
+        self.course_key = CourseKey.from_string("course-v1:blah+blah+blah")
         CourseOverviewFactory(id=self.course_key)
+
+    def test_str_and_repr(self):
+        """
+        Make sure str() and repr() work correctly on instances of this model.
+        """
+        pce = self._create_completed_program_course_enrollment()
+        assert str(pce) == "[ProgramCourseEnrollment id=1]"
+        # The course enrollment contains timestamp information,
+        # so to avoid dealing with that, let's just test the parts of the repr()
+        # that come before that.
+        assert (
+            "<ProgramCourseEnrollment id=1"
+            " program_enrollment=<ProgramEnrollment id=1 user=<User: rocko>"
+            " external_user_key='abc'"
+            " program_uuid=UUID('88888888-4444-2222-1111-000000000000')"
+            " curriculum_uuid=UUID('77777777-4444-2222-1111-000000000000')"
+            " status='enrolled'>"
+            " course_enrollment=<[CourseEnrollment] rocko: course-v1:blah+blah+blah"
+        ) in repr(pce)
 
     def test_duplicate_enrollments_allowed(self):
         """
@@ -123,7 +156,7 @@ class ProgramCourseEnrollmentModelTests(TestCase):
         same course_enrollment
         """
         pce = self._create_completed_program_course_enrollment()
-        ProgramCourseEnrollment.objects.create(
+        ProgramCourseEnrollmentFactory(
             program_enrollment=pce.program_enrollment,
             course_key="course-v1:dummy+value+101",
             course_enrollment=pce.course_enrollment,
@@ -137,7 +170,7 @@ class ProgramCourseEnrollmentModelTests(TestCase):
         """
         pce = self._create_waiting_program_course_enrollment()
         with self.assertRaises(IntegrityError):
-            ProgramCourseEnrollment.objects.create(
+            ProgramCourseEnrollmentFactory(
                 program_enrollment=pce.program_enrollment,
                 course_key=pce.course_key,
                 course_enrollment=None,
@@ -151,7 +184,7 @@ class ProgramCourseEnrollmentModelTests(TestCase):
             user=self.user,
             mode=CourseMode.MASTERS
         )
-        program_course_enrollment = ProgramCourseEnrollment.objects.create(
+        program_course_enrollment = ProgramCourseEnrollmentFactory(
             program_enrollment=self.program_enrollment,
             course_key=self.course_key,
             course_enrollment=course_enrollment,
@@ -161,7 +194,7 @@ class ProgramCourseEnrollmentModelTests(TestCase):
 
     def _create_waiting_program_course_enrollment(self):
         """ helper function create program course enrollment with no lms user """
-        return ProgramCourseEnrollment.objects.create(
+        return ProgramCourseEnrollmentFactory(
             program_enrollment=self.program_enrollment,
             course_key=self.course_key,
             course_enrollment=None,


### PR DESCRIPTION
Intended to ease debugging of program enrollment issues.

https://openedx.atlassian.net/browse/MST-193

@edx/masters-devs 

____________________________________
### Program Course Enrollments

I've split the program course enrollments admin into more columns. Clicking on the `Program Enrollment` cells will bring you to a change view for that program enrollment. I didn't do this for `Course Enrollment` or `User` because clicking those links would give you a 403 on Stage or Prod.

**Before:** Program course enrollments
![program-course-enrollments_before](https://user-images.githubusercontent.com/3628148/76982199-ed9be980-6911-11ea-8a15-893f2b970ea9.png)

**After:** Program course enrollments
![program-course-enrollments_after](https://user-images.githubusercontent.com/3628148/76982198-ed035300-6911-11ea-8359-ed2f766d3cde.png)

__________________________________
### Program Enrollments

Program enrollments admin is basically the same as before, except that the `status` column has been moved to the left to match the program course enrollments admin.

**Before:** Program enrollments
![program-enrollments_before](https://user-images.githubusercontent.com/3628148/76982202-ee348000-6911-11ea-83c9-3f89db21cf63.png)

**After:** Program enrollments
![program-enrollments_after](https://user-images.githubusercontent.com/3628148/76982200-ed9be980-6911-11ea-959d-d756cad3458c.png)
