### PR TITLE
Add coaching aside to edx.org theme dashboard.

### DIFF
--- a/lms/static/sass/multicourse/_dashboard.scss
+++ b/lms/static/sass/multicourse/_dashboard.scss
@@ -568,6 +568,30 @@
       }
     }
 
+    .wrapper-coaching {
+      border: 1px solid $border-color-l3;
+      margin: 20px 0;
+
+      .coaching-signup {
+        padding: 20px;
+
+        .coaching-prompt {
+          font-size: 20px;
+          line-height: 28px;
+          font-weight: bold;
+        }
+
+        .coaching-link .btn-neutral {
+          display: block;
+          text-align: center;
+          margin: 20px 20px 0 20px;
+          border-radius: 20px;
+          padding: 10px;
+          border: 1px solid theme-color('primary');
+        }
+      }
+    }
+
     .profile-sidebar {
       ul {
         padding: 0;

--- a/themes/edx.org/lms/templates/dashboard.html
+++ b/themes/edx.org/lms/templates/dashboard.html
@@ -288,6 +288,22 @@ from student.models import CourseEnrollment
       </div>
   % endif
 
+  <% account_mfe_url = getattr(settings, 'ACCOUNT_MICROFRONTEND_URL', '') or '' %>
+  % if plugins.get("coaching", {}).get("show_coaching_aside"):
+    <div class="wrapper-coaching">
+        <div class="coaching-signup">
+            <div class="coaching-prompt">
+                ${_("Take advantage of free coaching!")}
+            </div>
+            <div class="coaching-link">
+                <a class="btn-neutral" href="${account_mfe_url}">
+                  ${_("Get Started")}
+                </a>
+            </div>
+        </div>
+    </div>
+  % endif
+
   % if display_sidebar_on_dashboard:
     <section class="profile-sidebar" id="profile-sidebar" role="region" aria-label="Account Status Info">
       <header class="profile">


### PR DESCRIPTION
Adds coaching link to sidebar of the edx.org course dashboard.

Desktop:
![Screenshot_2020-03-18 Dashboard Your Platform Name Here](https://user-images.githubusercontent.com/6179874/76988984-07dac500-691c-11ea-8dd0-33efe8de78cb.png)

Mobile:
![Screenshot_2020-03-18 Dashboard Your Platform Name Here(1)](https://user-images.githubusercontent.com/6179874/76988986-090bf200-691c-11ea-982f-bc3ef7ad7a96.png)
