### PR TITLE
Remove unnecessary check.

### DIFF
--- a/lms/djangoapps/certificates/apis/v0/views.py
+++ b/lms/djangoapps/certificates/apis/v0/views.py
@@ -280,10 +280,7 @@ class CertificatesListView(APIView):
                 # add certificate into viewable certificate list only if it's a PDF certificate
                 # or there is an active certificate configuration.
                 if course_certificate['is_pdf_certificate'] or course_overview.has_any_active_web_certificate:
-                    course_display_name = course_overview.display_name
-                    if not course_overview.pk:
-                        course_display_name = course_overview.display_name_with_default
-                    course_certificate['course_display_name'] = course_display_name
+                    course_certificate['course_display_name'] = course_overview.display_name_with_default
                     course_certificate['course_organization'] = course_overview.display_org_with_default
                     viewable_certificates.append(course_certificate)
 


### PR DESCRIPTION
If `courseoverview.display_name` is set we don't get it from block and we can remove this unnecessary check.

Here is the reference code for `block_metadata_utils.display_name_with_default` https://github.com/edx/edx-platform/blob/81ab740efd69c74f5d4040ccb1af729ed588e474/common/lib/xmodule/xmodule/block_metadata_utils.py#L21-L46