### PR TITLE
Fixed comparison mismatch

### DIFF
--- a/common/lib/xmodule/xmodule/graders.py
+++ b/common/lib/xmodule/xmodule/graders.py
@@ -380,7 +380,7 @@ class AssignmentFormatGrader(CourseGrader):
         scores = list(grade_sheet.get(self.type, {}).values())
         breakdown = []
         labeler = get_short_labeler(self.short_label)
-        for i in range(max(self.min_count, len(scores))):
+        for i in range(max(int(float(self.min_count)), len(scores))):
             if i < len(scores) or generate_random_scores:
                 if generate_random_scores:  	# for debugging!
                     earned = random.randint(2, 15)

--- a/common/lib/xmodule/xmodule/tests/test_graders.py
+++ b/common/lib/xmodule/xmodule/tests/test_graders.py
@@ -252,6 +252,40 @@ class GraderTest(unittest.TestCase):
         self.assertEqual(len(graded['section_breakdown']), 0)
         self.assertEqual(len(graded['grade_breakdown']), 0)
 
+    def test_grade_with_string_min_count(self):
+        """
+        Test that the grading succeeds in case the min_count is set to a string
+        """
+        weighted_grader = graders.grader_from_conf([
+            {
+                'type': "Homework",
+                'min_count': '12',
+                'drop_count': 2,
+                'short_label': "HW",
+                'weight': 0.25,
+            },
+            {
+                'type': "Lab",
+                'min_count': '7',
+                'drop_count': 3,
+                'category': "Labs",
+                'weight': 0.25
+            },
+            {
+                'type': "Midterm",
+                'min_count': '0',
+                'drop_count': 0,
+                'name': "Midterm Exam",
+                'short_label': "Midterm",
+                'weight': 0.5,
+            },
+        ])
+
+        graded = weighted_grader.grade(self.test_gradesheet)
+        self.assertAlmostEqual(graded['percent'], 0.50812499999999994)
+        self.assertEqual(len(graded['section_breakdown']), (12 + 1) + (7 + 1) + 1)
+        self.assertEqual(len(graded['grade_breakdown']), 3)
+
     def test_grader_from_conf(self):
 
         # Confs always produce a graders.WeightedSubsectionsGrader, so we test this by repeating the test


### PR DESCRIPTION
## [PROD-1369](https://openedx.atlassian.net/browse/PROD-1369)

### Description
Fixed comparison mismatch error. min_count is expected to be an integer but in case it is set as a string we want to convert it to an int for the comparison. I have added a float and then int to make sure if the value is set a float it still does not produce an error. The conversion from float to integer was also necessary as range method expects an integer.

**Sandbox**
N/A

### Reviewers
If you've been tagged for review, please check your corresponding box once you've given the :+1:.
- [ ] @awaisdar001 
- [ ] @DawoudSheraz 

### Post-review
- [ ] Rebase and squash commits