### PR TITLE
Ent-2628 Remove post_reset_login flag from the class based views.

### DIFF
--- a/openedx/core/djangoapps/user_authn/views/password_reset.py
+++ b/openedx/core/djangoapps/user_authn/views/password_reset.py
@@ -310,7 +310,6 @@ class PasswordResetConfirmWrapper(PasswordResetConfirmView):
     reset_url_token = 'set-password'
 
     def __init__(self):
-        self.post_reset_login = False
         self.platform_name = PasswordResetConfirmWrapper._get_platform_name()
         self.validlink = False
         self.user = None
@@ -467,13 +466,8 @@ class PasswordResetConfirmWrapper(PasswordResetConfirmView):
         if response:
             return response
 
-        if 'is_account_recovery' in request.GET:
-            self.post_reset_login = True
-            response = self._process_password_reset_success(request, self.token, self.uidb64,
-                                                            extra_context=self.platform_name)
-        else:
-            response = self._process_password_reset_success(request, self.token, self.uidb64,
-                                                            extra_context=self.platform_name)
+        response = self._process_password_reset_success(request, self.token, self.uidb64,
+                                                        extra_context=self.platform_name)
 
         # If password reset was unsuccessful a template response is returned (status_code 200).
         # Check if form is invalid then show an error to the user.


### PR DESCRIPTION
Relevant [Jira](https://openedx.atlassian.net/browse/ENT-2628) ticket.

**Before PR:**
Prerequisites:
1. Learner must be linked to an enterprise
2. Secondary email functionality is enabled (through the enable_secondary_email_feature waffle switch)
3. Learner has registered and activated a recovery email address

Steps to reproduce:
1. On the Sign In page, click 'need help logging in'
2. Enter the recovery email address
3. Check the email account for the recovery email and click the Reset Password link
4. Enter a new password and click Change Password
5. This will show multiple backend error.

After PR:

1. On the Sign In page, click 'need help logging in'
2. Enter the recovery email address
3. Check the email account for the recovery email and click the Reset Password link
4. Enter a new password and click Change Password
5. Password will be changed and the user can now login with the recovery email address and new password

