### PR TITLE
EDUCATOR-4903. Bump edx-bulk-grades to 0.6.7

### DIFF
--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -94,7 +94,7 @@ drf-yasg==1.17.0          # via -c requirements/edx/../constraints.txt, edx-api-
 edx-ace==0.1.14           # via -r requirements/edx/base.in
 edx-analytics-data-api-client==0.15.5  # via -r requirements/edx/base.in
 edx-api-doc-tools==1.0.2  # via -r requirements/edx/base.in
-edx-bulk-grades==0.6.6    # via -r requirements/edx/base.in, staff-graded-xblock
+edx-bulk-grades==0.6.7    # via -r requirements/edx/base.in, staff-graded-xblock
 edx-ccx-keys==1.0.1       # via -r requirements/edx/base.in
 edx-celeryutils==0.4.0    # via -r requirements/edx/base.in, super-csv
 edx-completion==3.1.1     # via -r requirements/edx/base.in

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -106,7 +106,7 @@ drf-yasg==1.17.0          # via -c requirements/edx/../constraints.txt, -r requi
 edx-ace==0.1.14           # via -r requirements/edx/testing.txt
 edx-analytics-data-api-client==0.15.5  # via -r requirements/edx/testing.txt
 edx-api-doc-tools==1.0.2  # via -r requirements/edx/testing.txt
-edx-bulk-grades==0.6.6    # via -r requirements/edx/testing.txt, staff-graded-xblock
+edx-bulk-grades==0.6.7    # via -r requirements/edx/testing.txt, staff-graded-xblock
 edx-ccx-keys==1.0.1       # via -r requirements/edx/testing.txt
 edx-celeryutils==0.4.0    # via -r requirements/edx/testing.txt, super-csv
 edx-completion==3.1.1     # via -r requirements/edx/testing.txt

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -102,7 +102,7 @@ drf-yasg==1.17.0          # via -c requirements/edx/../constraints.txt, -r requi
 edx-ace==0.1.14           # via -r requirements/edx/base.txt
 edx-analytics-data-api-client==0.15.5  # via -r requirements/edx/base.txt
 edx-api-doc-tools==1.0.2  # via -r requirements/edx/base.txt
-edx-bulk-grades==0.6.6    # via -r requirements/edx/base.txt, staff-graded-xblock
+edx-bulk-grades==0.6.7    # via -r requirements/edx/base.txt, staff-graded-xblock
 edx-ccx-keys==1.0.1       # via -r requirements/edx/base.txt
 edx-celeryutils==0.4.0    # via -r requirements/edx/base.txt, super-csv
 edx-completion==3.1.1     # via -r requirements/edx/base.txt


### PR DESCRIPTION
New release of edx-bulk-grades is at version 0.6.7. Need to update platform to reflect that.