### PR TITLE
Reducing play button opacity to improve viewing experience.

### DIFF
--- a/common/lib/xmodule/xmodule/css/video/display.scss
+++ b/common/lib/xmodule/xmodule/css/video/display.scss
@@ -201,6 +201,7 @@ $cool-dark: rgb(79, 89, 93); // UXPL cool dark
       left: 50%;
       font-size: 4em;
       cursor: pointer;
+      opacity: 0.1;
 
       &::after {
         background: $white;


### PR DESCRIPTION
This patch lowers the opacity for play button
enabling learners unhindered learning experience
on video pause.

PROD_1231

On mouseout
<img width="1312" alt="Screen Shot 2020-03-20 at 11 32 37 PM" src="https://user-images.githubusercontent.com/373677/77195944-4cc15000-6b04-11ea-9502-2ab03f00208b.png">

On mouseover
<img width="1049" alt="Screen Shot 2020-03-20 at 11 33 15 PM" src="https://user-images.githubusercontent.com/373677/77196032-6cf10f00-6b04-11ea-8368-58230fe8833d.png">


