### PR TITLE
ENT-2580 | added sleep of 1 second in create_orders_for_old_enterprise_course_en…

### DIFF
--- a/lms/djangoapps/commerce/management/commands/create_orders_for_old_enterprise_course_enrollment.py
+++ b/lms/djangoapps/commerce/management/commands/create_orders_for_old_enterprise_course_enrollment.py
@@ -3,8 +3,9 @@ Management command to
 ./manage.py lms create_orders_for_old_enterprise_course_enrollment
 ./manage.py lms create_orders_for_old_enterprise_course_enrollment --start-index=0 --end-index=100
 ./manage.py lms create_orders_for_old_enterprise_course_enrollment --start-index=0 --end-index=100 --batch-size=20
+./manage.py lms create_orders_for_old_enterprise_course_enrollment --start-index=0 --end-index=100 --sleep-time=1.5
 """
-
+import time
 import traceback
 from textwrap import dedent
 
@@ -16,9 +17,9 @@ from opaque_keys.edx.keys import CourseKey
 from requests import Timeout
 from slumber.exceptions import HttpServerError, SlumberBaseException
 
+from enterprise.models import EnterpriseCourseEnrollment
 from student.models import CourseEnrollment
 from openedx.core.djangoapps.commerce.utils import ecommerce_api_client
-from enterprise.models import EnterpriseCourseEnrollment
 
 from util.query import use_read_replica_if_available
 
@@ -181,7 +182,7 @@ class Command(BaseCommand):
         )
         return success, new, failed, invalid, non_paid, order_numbers
 
-    def _sync(self, enrollments_queryset, enrollments_count, enrollments_batch_size):
+    def _sync(self, enrollments_queryset, enrollments_count, enrollments_batch_size, sleep_time):
         """
             Syncs a single site
         """
@@ -220,6 +221,9 @@ class Command(BaseCommand):
                 invalid_enrollments += invalid
                 non_paid_enrollments += non_paid
                 new_created_order_numbers += order_numbers
+                self.stdout.write(u'\t\tsleeping for {} second/seconds'.format(sleep_time))
+                time.sleep(sleep_time)
+
             self.stdout.write(
                 u'\tSuccessfully synced enrollments batch from {start} to {end}'.format(
                     start=offset, end=offset + enrollments_query_batch_size,
@@ -258,6 +262,14 @@ class Command(BaseCommand):
             type=int,
             help='Size of enrollments batch to be sent to ecommerce',
         )
+        parser.add_argument(
+            '--sleep-time',
+            action='store',
+            dest='sleep_time',
+            type=float,
+            default=1,
+            help='Sleep time in seconds between update of batches'
+        )
 
     def handle(self, *args, **options):
         """
@@ -266,13 +278,14 @@ class Command(BaseCommand):
         start_index = options['start_index']
         end_index = options['end_index']
         batch_size = options['batch_size']
+        sleep_time = options['sleep_time']
 
         try:
             self.stdout.write(u'Command execution started with options = {}.'.format(options))
             enrollments_queryset = self._get_enrollments_queryset(start_index, end_index)
             enrollments_count = enrollments_queryset.count()
             self.stdout.write(u'Total Enrollments count to process: {count}'.format(count=enrollments_count))
-            self._sync(enrollments_queryset, enrollments_count, batch_size)
+            self._sync(enrollments_queryset, enrollments_count, batch_size, sleep_time)
 
         except Exception as ex:
             traceback.print_exc()

--- a/lms/djangoapps/commerce/management/commands/tests/test_create_orders_for_old_enterprise_course_enrollmnet.py
+++ b/lms/djangoapps/commerce/management/commands/tests/test_create_orders_for_old_enterprise_course_enrollmnet.py
@@ -89,6 +89,7 @@ class TestEnterpriseCourseEnrollmentCreateOldOrder(TestCase):
             '--start-index=5',
             '--end-index=20',
             '--batch-size=10',
+            '--sleep-time=0.5',
             stdout=out
         )
         output = out.getvalue()


### PR DESCRIPTION
…rollment command so that we should not hit ecommerce API more that 60 calls per minute.