### PR TITLE
Logs cleanup

### DIFF
--- a/common/djangoapps/student/tasks.py
+++ b/common/djangoapps/student/tasks.py
@@ -43,10 +43,6 @@ def send_activation_email(self, msg_string, from_address=None):
     try:
         with emulate_http_request(site=site, user=user):
             ace.send(msg)
-        # Log that the Activation Email has been sent to user without an exception
-        log.info("Activation Email has been sent to User {user_email}".format(
-            user_email=dest_addr
-        ))
     except RecoverableChannelDeliveryError:
         log.info('Retrying sending email to user {dest_addr}, attempt # {attempt} of {max_attempts}'.format(
             dest_addr=dest_addr,
@@ -67,6 +63,5 @@ def send_activation_email(self, msg_string, from_address=None):
             'Unable to send activation email to user from "%s" to "%s"',
             from_address,
             dest_addr,
-            exc_info=True
         )
         raise Exception

--- a/common/djangoapps/student/tests/test_email.py
+++ b/common/djangoapps/student/tests/test_email.py
@@ -199,8 +199,8 @@ class ActivationEmailTests(EmailTemplateTagMixin, CacheIsolationTestCase):
                             self.assertEqual(user.is_active, True)
                             self.assertEqual(email.called, False, msg='method should not have been called')
 
-    @patch('student.tasks.log')
-    def test_send_email_to_inactive_user(self, mock_log):
+    @patch('student.views.management.compose_activation_email')
+    def test_send_email_to_inactive_user(self, email):
         """
         Tests that when an inactive user logs-in using the social auth, system
         sends an activation email to the user.
@@ -212,11 +212,7 @@ class ActivationEmailTests(EmailTemplateTagMixin, CacheIsolationTestCase):
         with patch('edxmako.request_context.get_current_request', return_value=request):
             with patch('third_party_auth.pipeline.running', return_value=False):
                 inactive_user_view(request)
-                mock_log.info.assert_called_with(
-                    "Activation Email has been sent to User {user_email}".format(
-                        user_email=inactive_user.email
-                    )
-                )
+                self.assertEqual(email.called, True, msg='method should have been called')
 
 
 @unittest.skipUnless(settings.ROOT_URLCONF == 'lms.urls', "Test only valid in LMS")

--- a/common/djangoapps/student/tests/test_tasks.py
+++ b/common/djangoapps/student/tests/test_tasks.py
@@ -85,7 +85,6 @@ class SendActivationEmailTestCase(TestCase):
             'Unable to send activation email to user from "%s" to "%s"',
             from_address,
             self.student.email,
-            exc_info=True
         )
 
         # Assert that nothing else was logged


### PR DESCRIPTION

[134k instances in the last 24 hours. ](http://splunk.edx.org/en-US/app/search/search?q=search%20index%3Dprod-edx%20%22Activation%20Email%20has%20been%20sent%20to%20User%22&earliest=-24h%40h&latest=now&display.page.search.mode=smart&dispatch.sample_ratio=1&sid=1585072606.813514)
Removing non-critical log. 

[PROD-1327](https://openedx.atlassian.net/browse/PROD-1327)