### PR TITLE
add static links re-write for demnadhint tag

### DIFF
--- a/common/lib/xmodule/xmodule/capa_base.py
+++ b/common/lib/xmodule/xmodule/capa_base.py
@@ -681,7 +681,7 @@ class CapaMixin(ScorableXBlockMixin, CapaFields):
                     )
                 ),
                 # Course-authored HTML demand hints are supported.
-                hint_text=HTML(get_inner_html_from_xpath(demand_hints[counter]))
+                hint_text=HTML(self.runtime.replace_urls(get_inner_html_from_xpath(demand_hints[counter])))
             )
             counter += 1
 

--- a/common/lib/xmodule/xmodule/tests/test_capa_module.py
+++ b/common/lib/xmodule/xmodule/tests/test_capa_module.py
@@ -1611,6 +1611,37 @@ class ProblemBlockTest(unittest.TestCase):
         self.assertEqual(result['hint_index'], 0)
         self.assertFalse(result['should_enable_next_hint'])
 
+    def test_image_hint(self):
+        """
+        Test the hint button shows an image without the static url.
+        """
+        test_xml = """
+            <problem>
+            <p>That is the question</p>
+            <multiplechoiceresponse>
+              <choicegroup type="MultipleChoice">
+                <choice correct="false">Alpha <choicehint>A hint</choicehint>
+                </choice>
+                <choice correct="true">Beta</choice>
+              </choicegroup>
+            </multiplechoiceresponse>
+            <demandhint>
+              <hint>
+                <img src="/static/7b1d74b2383b7d25a70ae4991190c222_28-collection-of-dark-souls-bonfire-clipart-high-quality-free-_1200-1386.jpeg"> </img>
+                You can add an optional hint like this. Problems that have a hint include a hint button, and this text appears the first time learners select the button.</hint>
+            </demandhint>
+            </problem>"""
+        module = CapaFactory.create(xml=test_xml)
+        module.get_problem_html()  # ignoring html result
+        context = module.system.render_template.call_args[0][1]
+        self.assertTrue(context['demand_hint_possible'])
+        self.assertTrue(context['should_enable_next_hint'])
+
+        # Check the AJAX call that gets the hint by index
+        result = module.get_demand_hint(0)
+        self.assertEqual(result['hint_index'], 0)
+        self.assertFalse(result['should_enable_next_hint'])
+
     def test_demand_hint_logging(self):
         def mock_location_text(self):
             """


### PR DESCRIPTION
### [PROD-884](https://openedx.atlassian.net/browse/PROD-884)

### Description
When the img is being inserted under <demandhint> the edX server is not capable of transforming the /static/ image to a valid URL. 

This problem seems impacting only images displayed under demandhint

### Reviewers
- [ ] @DawoudSheraz 
- [x] @saadyousafarbi 

### Post Review
 - [x] Squash & Rebase commit