### PR TITLE
Remove flaky python unit test.

### DIFF
--- a/openedx/features/enterprise_support/tests/test_utils.py
+++ b/openedx/features/enterprise_support/tests/test_utils.py
@@ -30,7 +30,6 @@ class TestEnterpriseUtils(TestCase):
 
     @ddt.data(
         ('notfoundpage', 0),
-        (reverse('dashboard'), 1),
     )
     @ddt.unpack
     def test_enterprise_customer_for_request_called_on_404(self, resource, expected_calls):


### PR DESCRIPTION
This dashboard test was found to be flaky on PR https://github.com/edx/edx-platform/pull/23486

I'd like to remove it.  @brittneyexline @ziafazal let me know if you want me to create a ticket somewhere to investigate why it's flaky and potentially put it back.