### PR TITLE
Revert "Allow Block Structures Collect to work in Studio"

### DIFF
--- a/common/lib/xmodule/xmodule/video_module/video_module.py
+++ b/common/lib/xmodule/xmodule/video_module/video_module.py
@@ -1138,7 +1138,7 @@ class VideoBlock(
 
         available_translations = self.available_translations(self.get_transcripts_info())
         transcripts = {
-            lang: self.runtime.handler_url(self, 'transcript', 'download', query="lang=" + lang)
+            lang: self.runtime.handler_url(self, 'transcript', 'download', query="lang=" + lang, thirdparty=True)
             for lang in available_translations
         }
 


### PR DESCRIPTION
Reverts edx/edx-platform#23263

`thirdparty` flag is used to build complete URLs for transcripts, by removing it; a relative URL is returned which broke the transcripts in edX mobile apps.

See [PROD-1393](https://openedx.atlassian.net/browse/PROD-1393) for more details.