### PR TITLE
Fixed \n escape issue in import-export

### DIFF
--- a/cms/djangoapps/contentstore/views/tests/test_import_export.py
+++ b/cms/djangoapps/contentstore/views/tests/test_import_export.py
@@ -1059,7 +1059,8 @@ class TestCourseExportImportProblem(CourseTestCase):
             category='problem',
             display_name='Test Problem',
             publish_item=publish_item,
-            data='<problem><pre><code>x=10</code></pre><multiplechoiceresponse></multiplechoiceresponse></problem>',
+            data='<problem><pre><code>x=10 print("hello \n")</code></pre>'
+                 '<multiplechoiceresponse></multiplechoiceresponse></problem>',
         )
 
     def get_problem_content(self, block_location):
@@ -1075,10 +1076,9 @@ class TestCourseExportImportProblem(CourseTestCase):
         """
         Asserts that problems' data is as expected with pre-tag content maintained.
         """
-        expected_problem_content = '<problem>\n  <pre><code>x=10</code></pre>\n' \
-                                   '  <multiplechoiceresponse/>\n</problem>\n'
+        expected_problem_content = '<problem>\n  <pre>\n    <code>x=10 print("hello \n")</code>\n  </pre>\n  ' \
+                                   '<multiplechoiceresponse/>\n</problem>\n'
         problem_content = self.get_problem_content(course_location)
-
         self.assertEqual(expected_problem_content, problem_content)
 
     def test_problem_content_on_course_export_import(self):

--- a/common/lib/xmodule/xmodule/raw_module.py
+++ b/common/lib/xmodule/xmodule/raw_module.py
@@ -29,7 +29,7 @@ class RawMixin(object):
         data = etree.tostring(xml_object, pretty_print=True, encoding='unicode')
         if pre_tag_data:
             for index, pre_tag in enumerate(re.findall(PRE_TAG_REGEX, data)):
-                data = re.sub(re.escape(pre_tag), pre_tag_data[index].decode(), data)
+                data = re.sub(pre_tag, pre_tag_data[index].decode(), data)
         return {'data': data}, []
 
     def definition_to_xml(self, resource_fs):


### PR DESCRIPTION
### [PROD-1232](https://openedx.atlassian.net/browse/PROD-1232)

### Issue :
on import of course which contains a problem with `<pre><code> print ('hello \n')</code></pre>`  in its  xml. `\n` is removed and replaced with next line . it was caused due to https://github.com/edx/edx-platform/pull/22195
 
### Test:
To test this functionality export course which contains a problem with `<pre><code> print ('hello \n')</code></pre>` and import it again . 
See that `\n` is present in code.

### [Sandbox](https://ahtishamshahid.sandbox.edx.org/courses/course-v1:edX+DemoX+Demo_Course/courseware/8169f050b3e14514b24a995c25395b49/7c79dc10ecb44cb2bb464ace4d7ae2a1/1?activate_block_id=block-v1%3AedX%2BDemoX%2BDemo_Course%2Btype%40vertical%2Bblock%406438c50f19924b8db444ec31261d097b)