### PR TITLE
add reserved keyword linter to CI

### DIFF
--- a/db_keyword_overrides.yml
+++ b/db_keyword_overrides.yml
@@ -1,0 +1,33 @@
+# This file is used by the 'check_reserved_keywords' management command to allow specific field names to be overridden
+# when checking for conflicts with lists of restricted keywords used in various database/data warehouse tools.
+# For more information, see: https://github.com/edx/edx-django-release-util/release_util/management/commands/check_reserved_keywords.py
+#
+# overrides should be added in the following format:
+#   - ModelName.field_name
+---
+MYSQL:
+    - CornerstoneGlobalConfiguration.key
+    - CourseCompleteImageConfiguration.default
+    - DegreedEnterpriseCustomerConfiguration.key
+    - ExperimentData.key
+    - ExperimentKeyValue.key
+    - GeneratedCertificate.key
+    - HistoricalDegreedEnterpriseCustomerConfiguration.key
+    - HistoricalExperimentKeyValue.key
+    - HistoricalGeneratedCertificate.key
+    - KVStore.key
+    - LTICredential.key
+    - NotificationType.key
+    - OAuth2ProviderConfig.key
+    - ProctoredExamStudentAllowanceHistory.key
+    - ProctoredExamStudentAllowance.key
+    - SAPSuccessFactorsEnterpriseCustomerConfiguration.key
+    - Settings.interval
+    - UserCourseTag.key
+    - UserOrgTag.key
+    - UserPreference.key
+    - XAPILRSConfiguration.key
+SNOWFLAKE:
+    - CourseOverview.start
+    - HistoricalCourseOverview.start
+STITCH:

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -98,7 +98,7 @@ edx-bulk-grades==0.6.8    # via -r requirements/edx/base.in, staff-graded-xblock
 edx-ccx-keys==1.0.1       # via -r requirements/edx/base.in
 edx-celeryutils==0.4.0    # via -r requirements/edx/base.in, super-csv
 edx-completion==3.1.1     # via -r requirements/edx/base.in
-edx-django-release-util==0.4.1  # via -r requirements/edx/base.in
+edx-django-release-util==0.4.2  # via -r requirements/edx/base.in
 edx-django-sites-extensions==2.4.3  # via -r requirements/edx/base.in
 edx-django-utils==3.1     # via -r requirements/edx/base.in, django-config-models, edx-drf-extensions, edx-enterprise, edx-rest-api-client, edx-when
 edx-drf-extensions==5.0.2  # via -r requirements/edx/base.in, edx-completion, edx-enterprise, edx-organizations, edx-proctoring, edx-rbac, edx-when, edxval

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -110,7 +110,7 @@ edx-bulk-grades==0.6.8    # via -r requirements/edx/testing.txt, staff-graded-xb
 edx-ccx-keys==1.0.1       # via -r requirements/edx/testing.txt
 edx-celeryutils==0.4.0    # via -r requirements/edx/testing.txt, super-csv
 edx-completion==3.1.1     # via -r requirements/edx/testing.txt
-edx-django-release-util==0.4.1  # via -r requirements/edx/testing.txt
+edx-django-release-util==0.4.2  # via -r requirements/edx/testing.txt
 edx-django-sites-extensions==2.4.3  # via -r requirements/edx/testing.txt
 edx-django-utils==3.1     # via -r requirements/edx/testing.txt, django-config-models, edx-drf-extensions, edx-enterprise, edx-rest-api-client, edx-when
 edx-drf-extensions==5.0.2  # via -r requirements/edx/testing.txt, edx-completion, edx-enterprise, edx-organizations, edx-proctoring, edx-rbac, edx-when, edxval
@@ -244,7 +244,7 @@ pyrsistent==0.16.0        # via jsonschema
 pysrt==1.1.2              # via -r requirements/edx/testing.txt, edxval
 pytest-attrib==0.1.3      # via -r requirements/edx/testing.txt
 pytest-cov==2.8.1         # via -r requirements/edx/testing.txt
-pytest-django==3.8.0      # via -r requirements/edx/testing.txt
+pytest-django==3.9.0      # via -r requirements/edx/testing.txt
 pytest-forked==1.1.3      # via -r requirements/edx/testing.txt, pytest-xdist
 pytest-json-report==1.2.1  # via -r requirements/edx/testing.txt
 pytest-metadata==1.8.0    # via -r requirements/edx/testing.txt, pytest-json-report

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -106,7 +106,7 @@ edx-bulk-grades==0.6.8    # via -r requirements/edx/base.txt, staff-graded-xbloc
 edx-ccx-keys==1.0.1       # via -r requirements/edx/base.txt
 edx-celeryutils==0.4.0    # via -r requirements/edx/base.txt, super-csv
 edx-completion==3.1.1     # via -r requirements/edx/base.txt
-edx-django-release-util==0.4.1  # via -r requirements/edx/base.txt
+edx-django-release-util==0.4.2  # via -r requirements/edx/base.txt
 edx-django-sites-extensions==2.4.3  # via -r requirements/edx/base.txt
 edx-django-utils==3.1     # via -r requirements/edx/base.txt, django-config-models, edx-drf-extensions, edx-enterprise, edx-rest-api-client, edx-when
 edx-drf-extensions==5.0.2  # via -r requirements/edx/base.txt, edx-completion, edx-enterprise, edx-organizations, edx-proctoring, edx-rbac, edx-when, edxval
@@ -232,7 +232,7 @@ pyquery==1.4.1            # via -r requirements/edx/testing.in
 pysrt==1.1.2              # via -r requirements/edx/base.txt, edxval
 pytest-attrib==0.1.3      # via -r requirements/edx/testing.in
 pytest-cov==2.8.1         # via -r requirements/edx/testing.in
-pytest-django==3.8.0      # via -r requirements/edx/testing.in
+pytest-django==3.9.0      # via -r requirements/edx/testing.in
 pytest-forked==1.1.3      # via pytest-xdist
 pytest-json-report==1.2.1  # via -r requirements/edx/testing.in
 pytest-metadata==1.8.0    # via pytest-json-report

--- a/scripts/generic-ci-tests.sh
+++ b/scripts/generic-ci-tests.sh
@@ -135,6 +135,8 @@ case "$TEST_SUITE" in
                 run_paver_quality run_xsscommitlint || { EXIT=1; }
                 echo "Running PII checker on all Django models..."
                 run_paver_quality run_pii_check || { EXIT=1; }
+                echo "Running reserved keyword checker on all Django models..."
+                run_paver_quality check_keywords || { EXIT=1; }
                 ;;
 
         esac


### PR DESCRIPTION
This adds the reserved keyword linter into the CI flow for this app. There are currently MYSQL and SNOWFLAKE violations in the codebase, so these have been added to the override file. 

The linter requires that the `DJANGO_SETTINGS_MODULE` variable is set. The test settings file did not have a logger set up, and due to the way paver runs shell commands, we need to read through command logs to determine the outcome of the command. I added a logger (the same one used in the devstack_docker settings, and everything is working, but unfortunately the logs saved in the python unit test jobs on Jenkins have expanded from ~15KB to ~50MB. This will probably make the logs unusable to developers trying to debug their tests. Any suggestions?

Non-logging build artifacts: https://build.testeng.edx.org/job/edx-platform-python-pipeline-pr/16085/artifact/
Logging build artifacts: https://build.testeng.edx.org/job/edx-platform-python-pipeline-pr/16086/artifact/