### PR TITLE
Team Management Upload A11y Improvements

### DIFF
--- a/lms/djangoapps/teams/static/teams/js/spec/views/manage_spec.js
+++ b/lms/djangoapps/teams/static/teams/js/spec/views/manage_spec.js
@@ -11,7 +11,7 @@ define([
     describe('Team Management Dashboard', function() {
         var view;
         var uploadFile = new File([], 'empty-test-file.csv');
-        var mockUploadClickEvent = {target: {files: [uploadFile]}};
+        var mockFileSelectEvent = {target: {files: [uploadFile]}};
 
         beforeEach(function() {
             setFixtures('<div class="teams-container"></div>');
@@ -24,13 +24,14 @@ define([
         });
 
         it('can render itself', function() {
-            expect(_.strip(view.$('.download-team-csv').text())).toEqual('Download Memberships');
-            expect(_.strip(view.$('.upload-team-csv').text())).toEqual('Upload Memberships');
+            expect(_.strip(view.$('#download-team-csv').text())).toEqual('Download Memberships');
+            expect(_.strip(view.$('#upload-team-csv').text())).toEqual('Upload Memberships');
         });
 
         it('can handle a successful file upload', function() {
             var requests = AjaxHelpers.requests(this);
-            view.uploadCsv(mockUploadClickEvent);
+            view.setTeamMembershipCsv(mockFileSelectEvent);
+            view.uploadCsv();
             AjaxHelpers.expectRequest(requests, 'POST', view.csvUploadUrl);
             AjaxHelpers.respondWithJson(requests, {});
             expect(view.handleCsvUploadSuccess).toHaveBeenCalled();
@@ -38,15 +39,11 @@ define([
 
         it('can handle a failed file upload', function() {
             var requests = AjaxHelpers.requests(this);
-            view.uploadCsv(mockUploadClickEvent);
+            view.setTeamMembershipCsv(mockFileSelectEvent);
+            view.uploadCsv();
             AjaxHelpers.expectRequest(requests, 'POST', view.csvUploadUrl);
             AjaxHelpers.respondWithError(requests);
             expect(view.handleCsvUploadFailure).toHaveBeenCalled();
-        });
-
-        it('should clear input file after upload to allow reuploading', function() {
-            view.uploadCsv(mockUploadClickEvent);
-            expect(view.$('#upload-team-csv-input').prop('value')).toEqual('');
         });
     });
 });

--- a/lms/djangoapps/teams/static/teams/js/views/manage.js
+++ b/lms/djangoapps/teams/static/teams/js/views/manage.js
@@ -64,8 +64,7 @@
             handleCsvUploadSuccess: function(data) {
                 TeamUtils.showInfoBanner(data.message, false);
 
-                // This handler is currently unimplemented (TODO MST-44)
-                // this.teamEvents.trigger('teams:update', {});
+                // Implement a teams:update event (TODO MST-44)
             },
 
             handleCsvUploadFailure: function(jqXHR) {

--- a/lms/djangoapps/teams/static/teams/js/views/manage.js
+++ b/lms/djangoapps/teams/static/teams/js/views/manage.js
@@ -45,20 +45,19 @@
             },
 
             uploadCsv: function() {
-                var self = this;
                 var formData = new FormData();
                 formData.append('csv', this.membershipFile);
 
                 return $.ajax({
                     type: 'POST',
-                    url: self.csvUploadUrl,
+                    url: this.csvUploadUrl,
                     data: formData,
                     processData: false,  // tell jQuery not to process the data
                     contentType: false   // tell jQuery not to set contentType
                 }).done(
-                    self.handleCsvUploadSuccess
+                    this.handleCsvUploadSuccess
                 ).fail(
-                    self.handleCsvUploadFailure
+                    this.handleCsvUploadFailure
                 );
             },
 

--- a/lms/djangoapps/teams/static/teams/js/views/manage.js
+++ b/lms/djangoapps/teams/static/teams/js/views/manage.js
@@ -18,7 +18,7 @@
 
             events: {
                 'click #download-team-csv-input': 'downloadCsv',
-                'change #upload-team-csv-input': ViewUtils.withDisabledElement('uploadCsv')
+                'click #upload-team-csv': ViewUtils.withDisabledElement('uploadCsv')
             },
 
             initialize: function(options) {
@@ -39,15 +39,13 @@
                 window.location.href = this.csvDownloadUrl;
             },
 
-            uploadCsv: function(event) {
-                var file = event.target.files[0];
+            uploadCsv: function() {
+                var file = $('#upload-team-csv-input')[0].files[0];
                 var self = this;
                 var formData = new FormData();
 
-                // clear selected file to allow re-uploading
-                $(event.target).prop('value', '');
-
                 formData.append('csv', file);  // xss-lint: disable=javascript-jquery-append
+
                 return $.ajax({
                     type: 'POST',
                     url: self.csvUploadUrl,
@@ -65,7 +63,7 @@
                 TeamUtils.showInfoBanner(data.message, false);
 
                 // This handler is currently unimplemented (TODO MST-44)
-                this.teamEvents.trigger('teams:update', {});
+                // this.teamEvents.trigger('teams:update', {});
             },
 
             handleCsvUploadFailure: function(jqXHR) {

--- a/lms/djangoapps/teams/static/teams/js/views/manage.js
+++ b/lms/djangoapps/teams/static/teams/js/views/manage.js
@@ -46,7 +46,7 @@
 
             uploadCsv: function() {
                 var formData = new FormData();
-                formData.append('csv', this.membershipFile);
+                formData.append('csv', this.membershipFile);  // xss-lint: disable=javascript-jquery-append
 
                 return $.ajax({
                     type: 'POST',

--- a/lms/djangoapps/teams/static/teams/js/views/manage.js
+++ b/lms/djangoapps/teams/static/teams/js/views/manage.js
@@ -17,7 +17,8 @@
             },
 
             events: {
-                'click #download-team-csv-input': 'downloadCsv',
+                'click #download-team-csv': 'downloadCsv',
+                'change #upload-team-csv-input': 'setTeamMembershipCsv',
                 'click #upload-team-csv': ViewUtils.withDisabledElement('uploadCsv')
             },
 
@@ -39,12 +40,14 @@
                 window.location.href = this.csvDownloadUrl;
             },
 
+            setTeamMembershipCsv: function(event) {
+                this.membershipFile = event.target.files[0];
+            },
+
             uploadCsv: function() {
-                var file = $('#upload-team-csv-input')[0].files[0];
                 var self = this;
                 var formData = new FormData();
-
-                formData.append('csv', file);  // xss-lint: disable=javascript-jquery-append
+                formData.append('csv', this.membershipFile);
 
                 return $.ajax({
                     type: 'POST',

--- a/lms/djangoapps/teams/static/teams/js/views/manage.js
+++ b/lms/djangoapps/teams/static/teams/js/views/manage.js
@@ -42,6 +42,13 @@
 
             setTeamMembershipCsv: function(event) {
                 this.membershipFile = event.target.files[0];
+
+                // enable the upload button when a file is selected
+                if (this.membershipFile) {
+                    $('#upload-team-csv').removeClass('is-disabled').attr('aria-disabled', false);
+                } else {
+                    $('#upload-team-csv').addClass('is-disabled').attr('aria-disabled', true);
+                }
             },
 
             uploadCsv: function() {

--- a/lms/djangoapps/teams/static/teams/templates/manage.underscore
+++ b/lms/djangoapps/teams/static/teams/templates/manage.underscore
@@ -11,7 +11,7 @@
                 ) %>
             </p>
             <button
-                id="download-team-csv-input"
+                id="download-team-csv"
                 class="download-team-csv action action-primary"
             >
                 <%- gettext("Download Memberships") %>
@@ -27,13 +27,15 @@
                     "users to teams."
                 ) %>
             </p>
-            <button class="upload-team-csv btn action action-primary">
-                <input
-                    id="upload-team-csv-input"
-                    type="file"
-                    accept="text/csv"
-                    class="input-overlay-hack"
-                />
+            <input
+                id="upload-team-csv-input"
+                type="file"
+                accept="text/csv"
+            />
+            <button
+                id="upload-team-csv"
+                class="btn action action-primary"
+            >
                 <%- gettext("Upload Memberships") %>
             </button>
             <!-- We need to describe the format of the CSV here (TODO MST-49) -->

--- a/lms/djangoapps/teams/static/teams/templates/manage.underscore
+++ b/lms/djangoapps/teams/static/teams/templates/manage.underscore
@@ -34,7 +34,8 @@
             />
             <button
                 id="upload-team-csv"
-                class="btn action action-primary"
+                class="btn action action-primary is-disabled"
+                aria-disabled="true"
             >
                 <%- gettext("Upload Memberships") %>
             </button>

--- a/lms/static/sass/views/_teams.scss
+++ b/lms/static/sass/views/_teams.scss
@@ -356,8 +356,12 @@
   .team-management {
     padding: 1%;
 
-    h3, p, .action, .team-management-section, input {
-        margin-bottom: 2%;
+    h3,
+    p,
+    .action,
+    .team-management-section,
+    input {
+      margin-bottom: 2%;
     }
 
     #upload-team-csv {
@@ -365,7 +369,8 @@
     }
   }
 
-  .team-profile, .team-management {
+  .team-profile,
+  .team-management {
     .page-content-main {
       display: inline-block;
       width: flex-grid(8, 12);
@@ -544,6 +549,7 @@
       border: inherit;
       box-shadow: none;
     }
+
     display: inline-block;
     text-shadow: none;
   }

--- a/lms/static/sass/views/_teams.scss
+++ b/lms/static/sass/views/_teams.scss
@@ -356,22 +356,12 @@
   .team-management {
     padding: 1%;
 
-    h3, p, .action, .team-management-section {
+    h3, p, .action, .team-management-section, input {
         margin-bottom: 2%;
     }
 
-    .input-overlay-hack {
-      position: absolute;
-      height: 100%;
-      width: 100%;
-      opacity: 0;
-      top: 0;
-      left: 0;
-      cursor: pointer;
-    }
-
-    .upload-team-csv {
-      position: relative;
+    #upload-team-csv {
+      display: block;
     }
   }
 


### PR DESCRIPTION
JIRA: [EDUCATOR-4977](https://openedx.atlassian.net/browse/EDUCATOR-4977)

**Context:** on the team management tab, instructors can assign team memberships by upload a CSV file with membership mappings. The current layout uses a hack to style the file `input` by hiding it behind a `div` and proxying clicks to the `input` element. This gives us greater styling control at the cost of losing a lot of built-in styling/navigating behavior that would come from more semantic markup.

**Change:** expose the file selector input for team management upload section to improve accessibility, disable upload button when no file selected.

**Benefits/tradeoffs:** at the cost of an additional click, we gain the ability to select and upload files easily with keyboard navigation, see the file name, select a different file for upload, and fix an earlier tab focus order bug as well as decrease code complexity.

![team-mgmt-proposed](https://user-images.githubusercontent.com/12944465/77691108-bca75e80-6f7a-11ea-99ef-775886fa96de.png)

FYI: @edx/masters-devs 