### PR TITLE
[WIP] Redirect to MKTG site after user activation

### DIFF
--- a/common/djangoapps/student/tests/test_activate_account.py
+++ b/common/djangoapps/student/tests/test_activate_account.py
@@ -147,3 +147,21 @@ class TestActivateAccount(TestCase):
             self.assertRedirects(response, login_page_url)
             self.assertContains(response, SYSTEM_MAINTENANCE_MSG)
             self._assert_user_active_state(expected_active_state=False)
+
+    @override_settings(MKTG_URLS={"ROOT": "https://www.test.com/", "ACTIVATION": "activate"})
+    @patch.dict(settings.FEATURES, {"ENABLE_MKTG_SITE": True})
+    def test_account_activation_redirect_to_mktg_site(self):
+        redirect_url= "{mktg_root}{activate}".format(
+            mktg_root="https://www.test.com/",
+            activate="activate",
+        )
+        self._assert_user_active_state(expected_active_state=False)
+        self.login()
+        response = self.client.get(reverse('activate', args=[self.registration.activation_key]))
+        self._assert_user_active_state(expected_active_state=True)
+        self.assertRedirects(
+            response,
+            redirect_url,
+            fetch_redirect_response=False
+        )
+

--- a/common/djangoapps/student/views/management.py
+++ b/common/djangoapps/student/views/management.py
@@ -36,6 +36,7 @@ from opaque_keys.edx.keys import CourseKey
 from pytz import UTC
 from six import text_type
 
+from edxmako.shortcuts import marketing_link
 import track.views
 from bulk_email.models import Optout
 from course_modes.models import CourseMode
@@ -552,6 +553,13 @@ def activate_account(request, key):
                 ),
                 extra_tags='account-activation aa-icon',
             )
+    if settings.FEATURES.get('ENABLE_MKTG_SITE'):
+        post_activation = marketing_link('ACTIVATION')
+
+        # marketing_link returns '#' if it is not found a match for the name
+        # passed as argument.
+        if post_activation != '#':
+            return redirect(post_activation)
 
     return redirect('dashboard')
 


### PR DESCRIPTION
Right now, when a user activates her account, she is redirected to /dashboard. 

With this change, it is added the capability to add a custom redirect if we define `ACTIVATION`(I'm ok if we use other name for that) in MKTG_URLS.

I don't see a place where I could add a documentation for the keys of the MKTG_URLS dict.

## How to test:
1) Enable MKTG site, by turning on the feature flag: ENABLE_MKTG_SITE
2) Configure MKTG_URLS with something like {"ROOT": "https://www.example.com/", "ACTIVATION": "custom/path"}
3) Create an user and then activate its account, the user should be redirected to https://www.example.com/custom/path
