### PR TITLE
Added logs for investigation

### DIFF
--- a/lms/djangoapps/courseware/courses.py
+++ b/lms/djangoapps/courseware/courses.py
@@ -136,6 +136,7 @@ def get_course_overview_with_access(user, action, course_key, check_if_enrolled=
     try:
         course_overview = CourseOverview.get_from_id(course_key)
     except CourseOverview.DoesNotExist:
+        log.info("Could't find the course overview for course id: {id}".format(id=course_key))
         raise Http404("Course not found.")
     check_course_access(course_overview, user, action, check_if_enrolled)
     return course_overview

--- a/openedx/core/djangoapps/content/course_overviews/models.py
+++ b/openedx/core/djangoapps/content/course_overviews/models.py
@@ -346,16 +346,24 @@ class CourseOverview(TimeStampedModel):
         """
         try:
             course_overview = cls.objects.select_related('image_set').get(id=course_id)
+            string_course_id = six.text_type(course_id)
+            if course_overview and 'BerkeleyX/LUCS' in string_course_id:
+                log.info("course overview object received for course id: {id}".format(id=course_id))
             if course_overview.version < cls.VERSION:
                 # Reload the overview from the modulestore to update the version
+                if 'BerkeleyX/LUCS' in string_course_id:
+                    log.info("Getting latest version for the course id: {id}".format(id=course_id))
                 course_overview = cls.load_from_module_store(course_id)
         except cls.DoesNotExist:
+            log.info("Unable to find the course overview object course id: {id}".format(id=course_id))
             course_overview = None
 
         # Regenerate the thumbnail images if they're missing (either because
         # they were never generated, or because they were flushed out after
         # a change to CourseOverviewImageConfig.
         if course_overview and not hasattr(course_overview, 'image_set'):
+            if 'BerkeleyX/LUCS' in string_course_id:
+                log.info("Creating course overview image course id: {id}".format(id=course_id))
             CourseOverviewImageSet.create(course_overview)
 
         return course_overview or cls.load_from_module_store(course_id)


### PR DESCRIPTION
PROD-1222
Courses are available in the studio in course overview table. Adding logs to investigate why  course detail end point says course not found.