### PR TITLE
Import private.py in devstack_docker.py files instead of devstack.py

### DIFF
--- a/cms/envs/devstack.py
+++ b/cms/envs/devstack.py
@@ -183,11 +183,6 @@ plugin_settings.add_plugins(__name__, plugin_constants.ProjectType.CMS, plugin_c
 
 OPENAPI_CACHE_TIMEOUT = 0
 
-###############################################################################
-# See if the developer has any local overrides.
-if os.path.isfile(join(dirname(abspath(__file__)), 'private.py')):
-    from .private import *  # pylint: disable=import-error,wildcard-import
-
 #####################################################################
 # Lastly, run any migrations, if needed.
 MODULESTORE = convert_module_store_setting_if_needed(MODULESTORE)

--- a/cms/envs/devstack_docker.py
+++ b/cms/envs/devstack_docker.py
@@ -26,3 +26,8 @@ JWT_AUTH.update({
     'JWT_SECRET_KEY': 'lms-secret',
     'JWT_AUDIENCE': 'lms-key',
 })
+
+###############################################################################
+# See if the developer has any local overrides.
+if os.path.isfile(join(dirname(abspath(__file__)), 'private.py')):
+    from .private import *  # pylint: disable=import-error,wildcard-import

--- a/lms/envs/devstack.py
+++ b/lms/envs/devstack.py
@@ -283,11 +283,6 @@ REST_FRAMEWORK['DEFAULT_RENDERER_CLASSES'] += (
 OPENAPI_CACHE_TIMEOUT = 0
 
 #####################################################################
-# See if the developer has any local overrides.
-if os.path.isfile(join(dirname(abspath(__file__)), 'private.py')):
-    from .private import *  # pylint: disable=import-error,wildcard-import
-
-#####################################################################
 # Lastly, run any migrations, if needed.
 MODULESTORE = convert_module_store_setting_if_needed(MODULESTORE)
 

--- a/lms/envs/devstack_docker.py
+++ b/lms/envs/devstack_docker.py
@@ -85,6 +85,11 @@ SYSTEM_WIDE_ROLE_CLASSES.extend(['system_wide_roles.SystemWideRoleAssignment'])
 if FEATURES['ENABLE_ENTERPRISE_INTEGRATION']:
     SYSTEM_WIDE_ROLE_CLASSES.extend(['enterprise.SystemWideEnterpriseUserRoleAssignment'])
 
+#####################################################################
+# See if the developer has any local overrides.
+if os.path.isfile(join(dirname(abspath(__file__)), 'private.py')):
+    from .private import *  # pylint: disable=import-error,wildcard-import
+
 ########################## THEMING  #######################
 # If you want to enable theming in devstack, uncomment this section and add any relevant
 # theme directories to COMPREHENSIVE_THEME_DIRS


### PR DESCRIPTION
**Background**: I use private.py a lot in my devstack for my private configurations. But issues are raised when I need to change/override a setting that is defined in `devstack_docker.py` file. Since that file's contents are loaded after `private.py`, my `private.py` is useless against the settings in `devstack_docker.py`.

**Description**: Now that the devstack is dockerized, I think it makes more sense to import the `private.py` in the `devstack_docker.py` files i.e. at the end of configuration files hierarchy.