### PR TITLE
Allow Block Structures Collect to work in Studio.

### DIFF
--- a/cms/lib/xblock/runtime.py
+++ b/cms/lib/xblock/runtime.py
@@ -2,9 +2,12 @@
 XBlock runtime implementations for edX Studio
 """
 
+import logging
 
 import six
 from django.urls import reverse
+
+log = logging.getLogger(__name__)
 
 
 def handler_url(block, handler_name, suffix='', query='', thirdparty=False):
@@ -13,7 +16,7 @@ def handler_url(block, handler_name, suffix='', query='', thirdparty=False):
     """
 
     if thirdparty:
-        raise NotImplementedError("edX Studio doesn't support third-party xblock handler urls")
+        log.warning("edX Studio doesn't support third-party handler urls for XBlock %s", type(block))
 
     url = reverse('component_handler', kwargs={
         'usage_key_string': six.text_type(block.scope_ids.usage_id),

--- a/lms/djangoapps/lms_xblock/runtime.py
+++ b/lms/djangoapps/lms_xblock/runtime.py
@@ -28,7 +28,13 @@ def handler_url(block, handler_name, suffix='', query='', thirdparty=False):
     """
     This method matches the signature for `xblock.runtime:Runtime.handler_url()`
 
-    See :method:`xblock.runtime:Runtime.handler_url`
+    :param block: The block to generate the url for
+    :param handler_name: The handler on that block that the url should resolve to
+    :param suffix: Any path suffix that should be added to the handler url
+    :param query: Any query string that should be added to the handler url
+        (which should not include an initial ? or &)
+    :param thirdparty: If true, return a fully-qualified URL instead of relative
+        URL. This is useful for URLs to be used by third-party services.
     """
     view_name = 'xblock_handler'
     if handler_name:

--- a/openedx/core/djangoapps/xblock/runtime/runtime.py
+++ b/openedx/core/djangoapps/xblock/runtime/runtime.py
@@ -101,7 +101,8 @@ class XBlockRuntime(RuntimeShim, Runtime):
         Get the URL to a specific handler.
         """
         if thirdparty:
-            raise NotImplementedError("thirdparty handlers are not supported by this runtime.")
+            log.warning("thirdparty handlers are not supported by this runtime for XBlock %s.", type(block))
+
         url = self.system.handler_url(usage_key=block.scope_ids.usage_id, handler_name=handler_name, user=self.user)
         if suffix:
             if not url.endswith('/'):


### PR DESCRIPTION
The collect process was broken before this commit because Studio's runtime does not permit handler_url invocation on "thirdparty" XBlocks.

PROD-1393