### PR TITLE
Perform byte/string conversions where Django is no longer tolerant

### DIFF
--- a/cms/djangoapps/contentstore/views/tests/test_container_page.py
+++ b/cms/djangoapps/contentstore/views/tests/test_container_page.py
@@ -67,8 +67,12 @@ class ContainerPageTestCase(StudioPageTestCase, LibraryTestCase):
                 u'<a href="/course/{course}{subsection_parameters}">Lesson 1</a>'
             ).format(
                 course=re.escape(six.text_type(self.course.id)),
-                section_parameters=re.escape(u'?show={}'.format(http.urlquote(self.chapter.location))),
-                subsection_parameters=re.escape(u'?show={}'.format(http.urlquote(self.sequential.location))),
+                section_parameters=re.escape(u'?show={}'.format(http.urlquote(
+                    str(self.chapter.location).encode()
+                ))),
+                subsection_parameters=re.escape(u'?show={}'.format(http.urlquote(
+                    str(self.sequential.location).encode()
+                ))),
             ),
         )
 
@@ -93,7 +97,9 @@ class ContainerPageTestCase(StudioPageTestCase, LibraryTestCase):
                 ).format(
                     course=re.escape(six.text_type(self.course.id)),
                     unit_parameters=re.escape(str(self.vertical.location)),
-                    subsection_parameters=re.escape(u'?show={}'.format(http.urlquote(self.sequential.location))),
+                    subsection_parameters=re.escape(u'?show={}'.format(http.urlquote(
+                        str(self.sequential.location).encode()
+                    ))),
                 ),
             )
 

--- a/cms/djangoapps/contentstore/views/tests/test_helpers.py
+++ b/cms/djangoapps/contentstore/views/tests/test_helpers.py
@@ -27,7 +27,7 @@ class HelpersTestCase(CourseTestCase):
                                      display_name="Week 1")
         self.assertEqual(
             xblock_studio_url(chapter),
-            u'{}?show={}'.format(course_url, http.urlquote(chapter.location))
+            u'{}?show={}'.format(course_url, http.urlquote(str(chapter.location).encode()))
         )
 
         # Verify sequential URL
@@ -35,7 +35,7 @@ class HelpersTestCase(CourseTestCase):
                                         display_name="Lesson 1")
         self.assertEqual(
             xblock_studio_url(sequential),
-            u'{}?show={}'.format(course_url, http.urlquote(sequential.location))
+            u'{}?show={}'.format(course_url, http.urlquote(str(sequential.location).encode()))
         )
 
         # Verify unit URL

--- a/lms/djangoapps/discussion/notification_prefs/views.py
+++ b/lms/djangoapps/discussion/notification_prefs/views.py
@@ -71,7 +71,7 @@ class UsernameCipher(object):
         encryptor = aes_cipher.encryptor()
         padder = PKCS7(AES.block_size).padder()
         padded = padder.update(username.encode("utf-8")) + padder.finalize()
-        return urlsafe_b64encode(initialization_vector + encryptor.update(padded) + encryptor.finalize())
+        return urlsafe_b64encode(initialization_vector + encryptor.update(padded) + encryptor.finalize()).decode()
 
     @staticmethod
     def decrypt(token):

--- a/lms/djangoapps/discussion/rest_api/forms.py
+++ b/lms/djangoapps/discussion/rest_api/forms.py
@@ -167,7 +167,7 @@ class CourseDiscussionRolesForm(CourseDiscussionSettingsForm):
         (FORUM_ROLE_GROUP_MODERATOR, FORUM_ROLE_GROUP_MODERATOR),
     )
     rolename = ChoiceField(
-        ROLE_CHOICES,
+        choices=ROLE_CHOICES,
         error_messages={u"invalid_choice": u"Role '%(value)s' does not exist"}
     )
 


### PR DESCRIPTION
Not sure if there's a shorter way to coerce to bytes.

In the process, I found a use of `ChoiceField` that was still using a positional argument. So that's here too.