### PR TITLE
ENT-2725 added support for enrolment urls in multiple enterprise case

### DIFF
--- a/lms/static/js/student_account/multiple_enterprise.js
+++ b/lms/static/js/student_account/multiple_enterprise.js
@@ -5,7 +5,8 @@
 
             urls: {
                 learners: '/enterprise/api/v1/enterprise-learner/',
-                multipleEnterpriseUrl: '/enterprise/select/active/?success_url='
+                multipleEnterpriseUrl: '/enterprise/select/active/?success_url=',
+                enterpriseActivationUrl: '/enterprise/select/active'
             },
 
             headers: {
@@ -15,12 +16,17 @@
             /**
              * Fetch the learner data, then redirect the user to a enterprise selection page if multiple
              * enterprises were found.
-             * @param  {string} nextUrl The URL to redirect to after multiple enterprise selection.
+             * @param  {string} nextUrl The URL to redirect to after multiple enterprise selection or incase
+             * the selection page is bypassed e.g. when dealing with direct enrolment urls.
              */
             check: function(nextUrl) {
-                var redirectUrl = this.urls.multipleEnterpriseUrl + encodeURIComponent(nextUrl);
+                var view = this;
+                var selectionPageUrl = this.urls.multipleEnterpriseUrl + encodeURIComponent(nextUrl);
                 var username = Utils.userFromEdxUserCookie().username;
                 var next = nextUrl || '/';
+                var enterpriseInUrl = this.getEnterpriseFromUrl(nextUrl);
+                var userInEnterprise = false;
+                var userWithMultipleEnterprises = false;
                 $.ajax({
                     url: this.urls.learners + '?username=' + username,
                     type: 'GET',
@@ -28,22 +34,53 @@
                     headers: this.headers,
                     context: this
                 }).fail(function() {
-                    this.redirect(next);
+                    view.redirect(next);
                 }).done(function(response) {
-                    if (response.count > 1 && redirectUrl) {
-                        this.redirect(redirectUrl);
+                    userWithMultipleEnterprises = (response.count > 1);
+                    if (userWithMultipleEnterprises) {
+                        if (enterpriseInUrl) {
+                            userInEnterprise = view.checkEnterpriseExists(response, enterpriseInUrl);
+                            if (userInEnterprise) {
+                                view.activate(enterpriseInUrl).fail(function() {
+                                    view.redirect(selectionPageUrl);
+                                }).done(function() {
+                                    view.redirect(next);
+                                });
+                            }
+                        }
+                        view.redirect(selectionPageUrl);
                     } else {
-                        this.redirect(next);
+                        view.redirect(next);
                     }
                 });
             },
 
-            /**
-             * Redirect to a URL.
-             * @param  {string} url The URL to redirect to.
-             */
             redirect: function(url) {
                 window.location.href = url;
+            },
+
+            activate: function(enterprise) {
+                return $.ajax({
+                    url: this.urls.enterpriseActivationUrl,
+                    method: 'POST',
+                    headers: {'X-CSRFToken': $.cookie('csrftoken')},
+                    data: {enterprise: enterprise}
+                });
+            },
+
+            getEnterpriseFromUrl: function(url) {
+                var regex;
+                regex = RegExp('/enterprise/.*/course/.*/enroll');
+                if (typeof url !== 'string' || !regex.test(url)) {
+                    return void(0);
+                }
+                return url.split('/')[2];
+            },
+
+            checkEnterpriseExists: function(response, enterprise) {
+                return response.results.some(function(item) {
+                    return item.enterprise_customer.uuid === enterprise;
+                });
             }
         };
 


### PR DESCRIPTION
Description: This PR adds support for bypassing the multiple enterprise selection page when a user uses an enrolment URL while logged out.

JIRA: https://openedx.atlassian.net/browse/ENT-2725

Decision chart: https://docs.google.com/document/d/1YI62i7qhTesL5soV7RCF7eEZ9wz0H3wyV_eSEWOoMp4/edit?usp=sharing