### PR TITLE
EDUCATOR-4979. Bump ora2 verstion to 2.6.22

### DIFF
--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -168,7 +168,7 @@ numpy==1.18.2             # via chem, openedx-calc, scipy
 git+https://github.com/joestump/python-oauth2.git@b94f69b1ad195513547924e380d9265133e995fa#egg=oauth2  # via -r requirements/edx/github.in
 oauthlib==3.0.1           # via -c requirements/edx/../constraints.txt, -r requirements/edx/base.in, django-oauth-toolkit, lti-consumer-xblock, requests-oauthlib, social-auth-core
 openedx-calc==1.0.7       # via -r requirements/edx/base.in
-git+https://github.com/edx/edx-ora2.git@2.6.21#egg=ora2==2.6.21  # via -r requirements/edx/github.in
+git+https://github.com/edx/edx-ora2.git@2.6.22#egg=ora2==2.6.22  # via -r requirements/edx/github.in
 packaging==20.3           # via drf-yasg
 path.py==12.4.0           # via edx-enterprise, edx-i18n-tools, ora2, xmodule
 path==13.1.0              # via -c requirements/edx/../constraints.txt, -r requirements/edx/paver.txt, path.py

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -202,7 +202,7 @@ numpy==1.18.2             # via -r requirements/edx/testing.txt, chem, openedx-c
 git+https://github.com/joestump/python-oauth2.git@b94f69b1ad195513547924e380d9265133e995fa#egg=oauth2  # via -r requirements/edx/testing.txt
 oauthlib==3.0.1           # via -c requirements/edx/../constraints.txt, -r requirements/edx/testing.txt, django-oauth-toolkit, lti-consumer-xblock, requests-oauthlib, social-auth-core
 openedx-calc==1.0.7       # via -r requirements/edx/testing.txt
-git+https://github.com/edx/edx-ora2.git@2.6.21#egg=ora2==2.6.21  # via -r requirements/edx/testing.txt
+git+https://github.com/edx/edx-ora2.git@2.6.22#egg=ora2==2.6.22  # via -r requirements/edx/testing.txt
 packaging==20.3           # via -r requirements/edx/testing.txt, drf-yasg, pytest, sphinx, tox
 pandas==0.22.0            # via -c requirements/edx/../constraints.txt, -r requirements/edx/testing.txt
 path.py==12.4.0           # via -r requirements/edx/testing.txt, edx-enterprise, edx-i18n-tools, ora2, xmodule

--- a/requirements/edx/github.in
+++ b/requirements/edx/github.in
@@ -87,7 +87,7 @@ git+https://gitlab.com/Ayub-khan/django-method-override.git@5270af321be2e576d8e8
 # Our libraries:
 -e git+https://github.com/edx/codejail.git@4127fc4bd5775cc72aee8d7f0a70e31405e22439#egg=codejail
 -e git+https://github.com/edx/acid-block.git@98aecba94ecbfa934e2d00262741c0ea9f557fc9#egg=acid-xblock
-git+https://github.com/edx/edx-ora2.git@2.6.21#egg=ora2==2.6.21
+git+https://github.com/edx/edx-ora2.git@2.6.22#egg=ora2==2.6.22
 git+https://github.com/edx/crowdsourcehinter.git@a7ffc85b134b7d8909bf1fefd23dbdb8eb28e467#egg=crowdsourcehinter-xblock==0.2
 -e git+https://github.com/edx/RateXBlock.git@2.0#egg=rate-xblock
 -e git+https://github.com/edx/DoneXBlock.git@2.0.1#egg=done-xblock

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -193,7 +193,7 @@ numpy==1.18.2             # via -r requirements/edx/base.txt, -r requirements/ed
 git+https://github.com/joestump/python-oauth2.git@b94f69b1ad195513547924e380d9265133e995fa#egg=oauth2  # via -r requirements/edx/base.txt
 oauthlib==3.0.1           # via -c requirements/edx/../constraints.txt, -r requirements/edx/base.txt, django-oauth-toolkit, lti-consumer-xblock, requests-oauthlib, social-auth-core
 openedx-calc==1.0.7       # via -r requirements/edx/base.txt
-git+https://github.com/edx/edx-ora2.git@2.6.21#egg=ora2==2.6.21  # via -r requirements/edx/base.txt
+git+https://github.com/edx/edx-ora2.git@2.6.22#egg=ora2==2.6.22  # via -r requirements/edx/base.txt
 packaging==20.3           # via -r requirements/edx/base.txt, drf-yasg, pytest, tox
 pandas==0.22.0            # via -c requirements/edx/../constraints.txt, -r requirements/edx/coverage.txt
 path.py==12.4.0           # via -r requirements/edx/base.txt, edx-enterprise, edx-i18n-tools, ora2, xmodule


### PR DESCRIPTION
[JIRA](https://openedx.atlassian.net/browse/EDUCATOR-4979)
Bump ora2 version to 2.6.22 to take advantage of the new models.