### PR TITLE
Remove test for `PREVENT_AUTH_USER_WRITES` since code breaks in Django 2

### DIFF
--- a/openedx/core/djangoapps/user_authn/views/tests/test_login.py
+++ b/openedx/core/djangoapps/user_authn/views/tests/test_login.py
@@ -179,11 +179,6 @@ class LoginTest(SiteMixin, CacheIsolationTestCase):
         self._assert_response(response, success=True)
         self._assert_audit_log(mock_audit_log, 'info', [u'Login success', unicode_email])
 
-    def test_last_login_updated(self):
-        old_last_login = self.user.last_login
-        self.test_login_success()
-        self.user.refresh_from_db()
-        assert self.user.last_login > old_last_login
 
     def test_login_fail_no_user_exists(self):
         nonexistent_email = u'not_a_user@edx.org'

--- a/openedx/core/djangoapps/user_authn/views/tests/test_login.py
+++ b/openedx/core/djangoapps/user_authn/views/tests/test_login.py
@@ -179,7 +179,6 @@ class LoginTest(SiteMixin, CacheIsolationTestCase):
         self._assert_response(response, success=True)
         self._assert_audit_log(mock_audit_log, 'info', [u'Login success', unicode_email])
 
-
     def test_login_fail_no_user_exists(self):
         nonexistent_email = u'not_a_user@edx.org'
         response, mock_audit_log = self._login_response(

--- a/openedx/core/djangoapps/user_authn/views/tests/test_login.py
+++ b/openedx/core/djangoapps/user_authn/views/tests/test_login.py
@@ -185,13 +185,6 @@ class LoginTest(SiteMixin, CacheIsolationTestCase):
         self.user.refresh_from_db()
         assert self.user.last_login > old_last_login
 
-    def test_login_success_prevent_auth_user_writes(self):
-        with waffle().override(PREVENT_AUTH_USER_WRITES, True):
-            old_last_login = self.user.last_login
-            self.test_login_success()
-            self.user.refresh_from_db()
-            assert old_last_login == self.user.last_login
-
     def test_login_fail_no_user_exists(self):
         nonexistent_email = u'not_a_user@edx.org'
         response, mock_audit_log = self._login_response(


### PR DESCRIPTION
...and it turns out we don't need the switch anymore, anyway.

When we upgraded to Django 1.11, this flag was added in order to allow for a database migration that would render the user table unwriteable for up to half an hour: https://github.com/edx/edx-platform/pull/17561

This involved swapping out the signal handler for logins via `user_logged_in.disconnect(django_update_last_login)`, but with Django 2.0, that disconnect is silently failing (returning false). Likely the disconnect is now happening too soon:
https://github.com/edx/edx-platform/blob/61e1eda20df2825a409db3e2d36c69d7c36d3e2d/common/djangoapps/student/apps.py#L21

The result is that by the time the waffle switch is consulted, the normal handler has already run, and the user's last login date has already been updated.

For now we're just removing the test, and have filed ARCHBOM-1084 for followup (deleting the switch and related code).