### PR TITLE
Removed tech email form error templates

### DIFF
--- a/lms/djangoapps/static_template_view/tests/test_views.py
+++ b/lms/djangoapps/static_template_view/tests/test_views.py
@@ -71,8 +71,6 @@ class MarketingSiteViewTests(TestCase):
         resp = self.client.get(url)
         self.assertEqual(resp.status_code, 200)
         self.assertEqual(resp['Content-Type'], 'text/html')
-        resp = self.client.get(url)
-        self.assertContains(resp, settings.TECH_SUPPORT_EMAIL)
 
     def test_500(self):
         """
@@ -92,4 +90,3 @@ class MarketingSiteViewTests(TestCase):
             ),
             status_code=500
         )
-        self.assertContains(resp, settings.TECH_SUPPORT_EMAIL, status_code=500)

--- a/lms/templates/courseware/error-message.html
+++ b/lms/templates/courseware/error-message.html
@@ -8,4 +8,5 @@ from openedx.core.djangolib.markup import HTML, Text
 <%
     tech_support_email=HTML('<a href=\"mailto:{tech_support_email}\">{tech_support_email}</a>').format(tech_support_email=static.get_tech_support_email_address())
 %>
-<p>${Text(_("We're sorry, this module is temporarily unavailable. Our staff is working to fix it as soon as possible. Please email us at {tech_support_email} to report any problems or downtime.")).format(tech_support_email=tech_support_email)}</p>
+<p>${Text(_("We're sorry, this module is temporarily unavailable. Our staff is working to fix it as soon as possible."))}</p>
+

--- a/lms/templates/static_templates/404.html
+++ b/lms/templates/static_templates/404.html
@@ -18,10 +18,9 @@ from openedx.core.djangolib.markup import HTML, Text
                 % if page_content:
                     ${page_content}
                 % else:
-                    ${Text(_('The page that you were looking for was not found. Go back to the {link_start}homepage{link_end} or let us know about any pages that may have been moved at {email}.')).format(
+                    ${Text(_('The page that you were looking for was not found. Go back to the {link_start}homepage{link_end} .')).format(
                     link_start=HTML('<a href="/">'),
-                    link_end=HTML('</a>'),
-                    email=HTML('<a href="mailto:{email}">{email}</a>').format(email=Text(static.get_tech_support_email_address()))
+                    link_end=HTML('</a>')
                     )}
                 % endif
             </%block>

--- a/lms/templates/static_templates/server-down.html
+++ b/lms/templates/static_templates/server-down.html
@@ -24,10 +24,7 @@ from openedx.core.djangolib.markup import HTML, Text
                 % if page_content:
                     ${page_content}
                 % else:
-                    ${Text(_("Our staff is currently working to get the site back up as soon as possible. "
-                    "Please email us at {tech_support_email} to report any problems or downtime.")).format(
-                    tech_support_email=HTML('<a href="mailto:{0}">{0}</a>').format(Text(static.get_tech_support_email_address()))
-                    )}
+                    ${Text(_("Our staff is currently working to get the site back up as soon as possible. "))}
                 % endif
             </%block>
         </p>

--- a/lms/templates/static_templates/server-error.html
+++ b/lms/templates/static_templates/server-error.html
@@ -24,11 +24,7 @@ from openedx.core.djangolib.markup import HTML, Text
                 % if page_content:
                     ${page_content}
                 % else:
-                    ${Text(_('Please wait a few seconds and then reload the page. If the problem persists, please email us at {email}.')).format(
-                    email=HTML('<a href="mailto:{email}">{email}</a>').format(
-                    email=Text(static.get_tech_support_email_address())
-                    )
-                    )}
+                    ${Text(_('Please wait a few seconds and then reload the page.'))}
                 % endif
             </%block>
         </p>

--- a/lms/templates/static_templates/server-overloaded.html
+++ b/lms/templates/static_templates/server-overloaded.html
@@ -20,14 +20,11 @@ from openedx.core.djangolib.markup import HTML, Text
             </%block>
         </h1>
         <p>
-            <%block name="pagecontent">
+        <%block name="pagecontent">
                 % if page_content:
                     ${page_content}
                 % else:
-                    ${Text(_("Our staff is currently working to get the site back up as soon as possible. "
-                    "Please email us at {tech_support_email} to report any problems or downtime.")).format(
-                    tech_support_email=HTML('<a href="mailto:{0}">{0}</a>').format(tech_support_email=Text(static.get_tech_support_email_address()))
-                    )}
+                    ${Text(_("Our staff is currently working to get the site back up as soon as possible. "))}
                 % endif
             </%block>
         </p>


### PR DESCRIPTION
[PROD-1412](https://openedx.atlassian.net/browse/PROD-1412)

For the maintenance/status page that comes up when the LMS is down/server errors please remove the technical@edx.org email address to help reduce the number of tickets coming into Learner Support.


