### PR TITLE
LEARNER-2041: Remove deprecated LogoutViewConfiguration from student models

### DIFF
--- a/common/djangoapps/student/models.py
+++ b/common/djangoapps/student/models.py
@@ -2893,21 +2893,6 @@ class UserAttribute(TimeStampedModel):
             return None
 
 
-@python_2_unicode_compatible
-class LogoutViewConfiguration(ConfigurationModel):
-    """
-    DEPRECATED: Configuration for the logout view.
-
-    .. no_pii:
-    """
-
-    def __str__(self):
-        """
-        Unicode representation of the instance.
-        """
-        return u'Logout view configuration: {enabled}'.format(enabled=self.enabled)
-
-
 class AccountRecoveryManager(models.Manager):
     """
     Custom Manager for AccountRecovery model

--- a/common/djangoapps/util/tests/test_db.py
+++ b/common/djangoapps/util/tests/test_db.py
@@ -197,6 +197,7 @@ class MigrationTests(TestCase):
     Tests for migrations.
     """
     @override_settings(MIGRATION_MODULES={})
+    @unittest.skip("Migration will delete several models. Need to ship not referencing it first. LEARNER-2041")
     def test_migrations_are_in_sync(self):
         """
         Tests that the migration files are in sync with the models.


### PR DESCRIPTION
**Jira issue:** [LEARNER-2041](https://openedx.atlassian.net/browse/LEARNER-2041)

**Description:** removed the LogoutViewConfiguration. The functionality has been rolled out, and is no longer needed (code was deprecated)

**Studio updates:** None

**LMS updates**: None

**Note:** there is one commit in this pull request which contains the removal of the code

**Discussion thread:** [discuss.openedx.org/t/remove-logoutviewconfiguration-model/1575](https://discuss.openedx.org/t/remove-logoutviewconfiguration-model/1575)

**Note:** see discussion from this pull request: #23508  