### PR TITLE
Django2: Add to tox.ini's envlist

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{35,36,37}-django{111,20,21}
+envlist = py{35,36,37}-django{111,20,21,22}
 
 # This is needed to prevent the lms, cms, and openedx packages inside the "Open
 # edX" package (defined in setup.py) from getting installed into site-packages


### PR DESCRIPTION
Adding Django2.2 to tox.ini's envlist so we can run these tests on Jenkins.