### PR TITLE
add credentials saving in VAL

### DIFF
--- a/cms/djangoapps/contentstore/views/tests/test_transcript_settings.py
+++ b/cms/djangoapps/contentstore/views/tests/test_transcript_settings.py
@@ -15,6 +15,11 @@ from contentstore.tests.utils import CourseTestCase
 from contentstore.utils import reverse_course_url
 from contentstore.views.transcript_settings import TranscriptionProviderErrorType, validate_transcript_credentials
 from openedx.core.djangoapps.profile_images.tests.helpers import make_image_file
+from openedx.core.djangoapps.video_pipeline.config.waffle import (
+    SAVE_CREDENTIALS_IN_VAL,
+    waffle_flags
+)
+from openedx.core.djangoapps.waffle_utils.testutils import override_waffle_flag
 from student.roles import CourseStaffRole
 
 
@@ -99,6 +104,56 @@ class TranscriptCredentialsTest(CourseTestCase):
         Tests that transcript credentials handler works as expected.
         """
         mock_update_credentials.return_value = update_credentials_response
+        transcript_credentials_url = self.get_url_for_course_key(self.course.id)
+        response = self.client.post(
+            transcript_credentials_url,
+            data=json.dumps(request_payload),
+            content_type='application/json'
+        )
+        self.assertEqual(response.status_code, expected_status_code)
+        self.assertEqual(response.content.decode('utf-8'), expected_response)
+
+    @override_waffle_flag(waffle_flags()[SAVE_CREDENTIALS_IN_VAL], True)
+    @ddt.data(
+        (
+            {
+                'provider': '3PlayMedia',
+                'api_key': '11111',
+                'api_secret_key': '44444'
+            },
+            {'error_type': TranscriptionProviderErrorType.INVALID_CREDENTIALS},
+            400,
+            '{\n  "error": "The information you entered is incorrect."\n}'
+        ),
+        (
+            {
+                'provider': 'Cielo24',
+                'api_key': '12345',
+                'username': 'test_user'
+            },
+            {'error_type': None},
+            200,
+            ''
+        ),
+        (
+            {
+                'provider': '3PlayMedia',
+                'api_key': '12345',
+                'api_secret_key': '44444'
+            },
+            {'error_type': None},
+            200,
+            ''
+        )
+    )
+    @ddt.unpack
+    @patch('edxval.api.create_or_update_transcript_credentials')
+    def test_val_transcript_credentials_handler(self, request_payload, update_credentials_response,
+                                                expected_status_code, expected_response, api_patch):
+        """
+        Test that credentials handler works fine with VAL api endpoint.
+        """
+        api_patch.return_value = update_credentials_response
         transcript_credentials_url = self.get_url_for_course_key(self.course.id)
         response = self.client.post(
             transcript_credentials_url,

--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -2085,6 +2085,17 @@ VIDEO_TRANSCRIPTS_SETTINGS = dict(
 
 VIDEO_TRANSCRIPTS_MAX_AGE = 31536000
 
+############################ TRANSCRIPT PROVIDERS SETTINGS ########################
+
+# Note: These settings will also exist in video-encode-manager, so any update here
+# should also be done there. Additionally, the BASE & LOGIN URL will be overridden at
+# deployment as the actual URL is different from sandboxing URL.
+CIELO24_SETTINGS = dict(
+    CIELO24_API_VERSION=1,
+    CIELO24_BASE_API_URL="https://sandbox.cielo24.com/api",
+    CIELO24_LOGIN_URL="https://sandbox.cielo24.com/api/account/login"
+)
+
 ##### shoppingcart Payment #####
 PAYMENT_SUPPORT_EMAIL = 'billing@example.com'
 

--- a/openedx/core/djangoapps/video_pipeline/config/waffle.py
+++ b/openedx/core/djangoapps/video_pipeline/config/waffle.py
@@ -11,6 +11,7 @@ WAFFLE_NAMESPACE = 'videos'
 # Waffle flag telling whether youtube is deprecated.
 DEPRECATE_YOUTUBE = 'deprecate_youtube'
 ENABLE_DEVSTACK_VIDEO_UPLOADS = 'enable_devstack_video_uploads'
+SAVE_CREDENTIALS_IN_VAL = 'save_credentials_in_val'
 
 
 def waffle_flags():
@@ -26,6 +27,11 @@ def waffle_flags():
         ENABLE_DEVSTACK_VIDEO_UPLOADS: WaffleFlag(
             waffle_namespace=namespace,
             flag_name=ENABLE_DEVSTACK_VIDEO_UPLOADS,
+            flag_undefined_default=False
+        ),
+        SAVE_CREDENTIALS_IN_VAL: CourseWaffleFlag(
+            waffle_namespace=namespace,
+            flag_name=SAVE_CREDENTIALS_IN_VAL,
             flag_undefined_default=False
         )
     }

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -106,7 +106,7 @@ edx-enterprise==3.0.3     # via -r requirements/edx/base.in
 edx-i18n-tools==0.5.0     # via ora2
 edx-milestones==0.2.6     # via -r requirements/edx/base.in
 edx-opaque-keys[django]==2.0.2  # via -r requirements/edx/paver.txt, edx-bulk-grades, edx-ccx-keys, edx-completion, edx-drf-extensions, edx-enterprise, edx-milestones, edx-organizations, edx-proctoring, edx-user-state-client, edx-when, xmodule
-edx-organizations==4.0.0  # via -r requirements/edx/base.in
+edx-organizations==5.0.0  # via -r requirements/edx/base.in
 edx-proctoring-proctortrack==1.0.5  # via -r requirements/edx/base.in
 edx-proctoring==2.3.3     # via -r requirements/edx/base.in, edx-proctoring-proctortrack
 edx-rbac==1.1.2           # via edx-enterprise
@@ -117,7 +117,7 @@ edx-submissions==3.0.6    # via -r requirements/edx/base.in, ora2
 edx-tincan-py35==0.0.5    # via edx-enterprise
 edx-user-state-client==1.1.2  # via -r requirements/edx/base.in
 edx-when==1.1.5           # via -r requirements/edx/base.in, edx-proctoring
-edxval==1.2.6             # via -r requirements/edx/base.in
+edxval==1.2.8             # via -r requirements/edx/base.in
 elasticsearch==1.9.0      # via edx-search
 enum34==1.1.10            # via edxval
 event-tracking==0.3.0     # via -r requirements/edx/base.in, edx-proctoring, edx-search

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -119,7 +119,7 @@ edx-i18n-tools==0.5.0     # via -r requirements/edx/testing.txt, ora2
 edx-lint==1.4.1           # via -r requirements/edx/testing.txt
 edx-milestones==0.2.6     # via -r requirements/edx/testing.txt
 edx-opaque-keys[django]==2.0.2  # via -r requirements/edx/testing.txt, edx-bulk-grades, edx-ccx-keys, edx-completion, edx-drf-extensions, edx-enterprise, edx-milestones, edx-organizations, edx-proctoring, edx-user-state-client, edx-when, xmodule
-edx-organizations==4.0.0  # via -r requirements/edx/testing.txt
+edx-organizations==5.0.0  # via -r requirements/edx/testing.txt
 edx-proctoring-proctortrack==1.0.5  # via -r requirements/edx/testing.txt
 edx-proctoring==2.3.3     # via -r requirements/edx/testing.txt, edx-proctoring-proctortrack
 edx-rbac==1.1.2           # via -r requirements/edx/testing.txt, edx-enterprise
@@ -131,7 +131,7 @@ edx-submissions==3.0.6    # via -r requirements/edx/testing.txt, ora2
 edx-tincan-py35==0.0.5    # via -r requirements/edx/testing.txt, edx-enterprise
 edx-user-state-client==1.1.2  # via -r requirements/edx/testing.txt
 edx-when==1.1.5           # via -r requirements/edx/testing.txt, edx-proctoring
-edxval==1.2.6             # via -r requirements/edx/testing.txt
+edxval==1.2.8             # via -r requirements/edx/testing.txt
 elasticsearch==1.9.0      # via -r requirements/edx/testing.txt, edx-search
 entrypoints==0.3          # via -r requirements/edx/testing.txt, flake8
 enum34==1.1.10            # via -r requirements/edx/testing.txt, edxval

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -115,7 +115,7 @@ edx-i18n-tools==0.5.0     # via -r requirements/edx/base.txt, -r requirements/ed
 edx-lint==1.4.1           # via -r requirements/edx/testing.in
 edx-milestones==0.2.6     # via -r requirements/edx/base.txt
 edx-opaque-keys[django]==2.0.2  # via -r requirements/edx/base.txt, edx-bulk-grades, edx-ccx-keys, edx-completion, edx-drf-extensions, edx-enterprise, edx-milestones, edx-organizations, edx-proctoring, edx-user-state-client, edx-when, xmodule
-edx-organizations==4.0.0  # via -r requirements/edx/base.txt
+edx-organizations==5.0.0  # via -r requirements/edx/base.txt
 edx-proctoring-proctortrack==1.0.5  # via -r requirements/edx/base.txt
 edx-proctoring==2.3.3     # via -r requirements/edx/base.txt, edx-proctoring-proctortrack
 edx-rbac==1.1.2           # via -r requirements/edx/base.txt, edx-enterprise
@@ -126,7 +126,7 @@ edx-submissions==3.0.6    # via -r requirements/edx/base.txt, ora2
 edx-tincan-py35==0.0.5    # via -r requirements/edx/base.txt, edx-enterprise
 edx-user-state-client==1.1.2  # via -r requirements/edx/base.txt
 edx-when==1.1.5           # via -r requirements/edx/base.txt, edx-proctoring
-edxval==1.2.6             # via -r requirements/edx/base.txt
+edxval==1.2.8             # via -r requirements/edx/base.txt
 elasticsearch==1.9.0      # via -r requirements/edx/base.txt, edx-search
 entrypoints==0.3          # via flake8
 enum34==1.1.10            # via -r requirements/edx/base.txt, edxval


### PR DESCRIPTION
### [PROD-1396](https://openedx.atlassian.net/browse/PROD-1396)

### Description
This PR is adding the capability to store transcript credentials in VAL. These credentials are currently stored in VEDA. The functionality is behind a course waffle flag, `SAVE_CREDENTIALS_IN_VAL` in videos workspace and translates to `videos.save_credentials_in_val`. The API being used was added in https://github.com/edx/edx-val/pull/210 and the related settings are also being added in this PR. This PR is also bringing in the changes from https://github.com/edx/edx-val/pull/211