### PR TITLE
Django2 CSMH: Database Router update

### DIFF
--- a/openedx/core/lib/django_courseware_routers.py
+++ b/openedx/core/lib/django_courseware_routers.py
@@ -10,20 +10,32 @@ class StudentModuleHistoryExtendedRouter(object):
 
     DATABASE_NAME = 'student_module_history'
 
-    def _is_csmh(self, model):
+    def _is_csm(self, model):
         """
-        Return True if ``model`` is courseware.StudentModuleHistoryExtended.
+        Return True if ``model`` is courseware.models.StudentModule.
+        """
+        return (
+            model._meta.app_label == 'courseware' and
+            type(model).__name__ == 'StudentModule'
+        )
+
+    def _is_csm_h(self, model):
+        """
+        Return True if ``model`` is coursewarehistoryextended.models.StudentModuleHistoryExtended.
         """
         return (
             model._meta.app_label == 'coursewarehistoryextended' and
-            model.__name__ == 'StudentModuleHistoryExtended'
+            (
+                type(model).__name__ == 'StudentModuleHistoryExtended' or
+                getattr(model, '__name__', '') == 'StudentModuleHistoryExtended'
+            )
         )
 
     def db_for_read(self, model, **hints):  # pylint: disable=unused-argument
         """
         Use the StudentModuleHistoryExtendedRouter.DATABASE_NAME if the model is StudentModuleHistoryExtended.
         """
-        if self._is_csmh(model):
+        if self._is_csm_h(model):
             return self.DATABASE_NAME
         else:
             return None
@@ -32,16 +44,21 @@ class StudentModuleHistoryExtendedRouter(object):
         """
         Use the StudentModuleHistoryExtendedRouter.DATABASE_NAME if the model is StudentModuleHistoryExtended.
         """
-        if self._is_csmh(model):
+        if self._is_csm_h(model):
             return self.DATABASE_NAME
         else:
             return None
 
     def allow_relation(self, obj1, obj2, **hints):  # pylint: disable=unused-argument
         """
-        Disable relations if the model is StudentModuleHistoryExtended.
+        Manage relations if the model is StudentModuleHistoryExtended.
         """
-        if self._is_csmh(obj1) or self._is_csmh(obj2):
+        # Allow relation between CSM and CSMH (this cross-database relationship is declared with db_constraint=False).
+        if self._is_csm(obj1) and self._is_csm_h(obj2):
+            return True
+
+        # Prevent any other relations with CSMH since CSMH is in its own different database.
+        elif self._is_csm_h(obj1) or self._is_csm_h(obj2):
             return False
         return None
 
@@ -51,7 +68,7 @@ class StudentModuleHistoryExtendedRouter(object):
         """
         if model_name is not None:
             model = hints.get('model')
-            if model is not None and self._is_csmh(model):
+            if model is not None and self._is_csm_h(model):
                 return db == self.DATABASE_NAME
         if db == self.DATABASE_NAME:
             return False


### PR DESCRIPTION
The [Django 2.1 release notes](https://docs.djangoproject.com/en/3.0/releases/2.1/) say:

> The database router allow_relation() method is called in more cases. Improperly written routers may need to be updated accordingly.

This resulted in [failures](https://build.testeng.edx.org/job/edx-platform-django-2.2-python-pipeline-pr/4/) due to:

1. assuming that all models had a `__name__` attribute.
2. prevention of the Django-faked relation between CSM (StudentModule) and CSMH (StudentModuleHistoryExtended).

This PR fixes both issues in the [StudentModuleHistoryExtendedRouter](https://github.com/edx/edx-platform/blob/8dfcdc3281e0931dfb8ccc8a3ac5b4499ca0269e/openedx/core/lib/django_courseware_routers.py#L6) Django [Database Router](https://docs.djangoproject.com/en/3.0/topics/db/multi-db/#automatic-database-routing).