### PR TITLE
Downgrade to pytest-django 3.8.0 for now

### DIFF
--- a/lms/djangoapps/commerce/management/commands/tests/test_create_orders_for_old_enterprise_course_enrollmnet.py
+++ b/lms/djangoapps/commerce/management/commands/tests/test_create_orders_for_old_enterprise_course_enrollmnet.py
@@ -27,8 +27,7 @@ class TestEnterpriseCourseEnrollmentCreateOldOrder(TestCase):
     """
 
     @classmethod
-    def setUpClass(cls):
-        super(TestEnterpriseCourseEnrollmentCreateOldOrder, cls).setUpClass()
+    def setUpTestData(cls):
         UserFactory(username=TEST_ECOMMERCE_WORKER)
         cls.enrollment_count = 30
         cls._create_enterprise_course_enrollments(30)

--- a/lms/djangoapps/commerce/management/commands/tests/test_create_orders_for_old_enterprise_course_enrollmnet.py
+++ b/lms/djangoapps/commerce/management/commands/tests/test_create_orders_for_old_enterprise_course_enrollmnet.py
@@ -28,6 +28,7 @@ class TestEnterpriseCourseEnrollmentCreateOldOrder(TestCase):
 
     @classmethod
     def setUpTestData(cls):
+        super(TestEnterpriseCourseEnrollmentCreateOldOrder, cls).setUpTestData()
         UserFactory(username=TEST_ECOMMERCE_WORKER)
         cls.enrollment_count = 30
         cls._create_enterprise_course_enrollments(30)

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -67,6 +67,10 @@ path<13.2.0
 # BOM-1430: pytest 5.4.0 breaks reporting sometimes: https://github.com/pytest-dev/pytest/issues/6925
 pytest<5.4.0
 
+# pytest-django 3.9.0 has a fix for pytest 5.4.0+ that breaks cleanup after failed tests in earlier pytest versions
+# https://github.com/pytest-dev/pytest-django/issues/824
+pytest-django<3.9.0
+
 # Upgrading to 2.5.3 on 2020-01-03 triggered "'tzlocal' object has no attribute '_std_offset'" errors in production
 python-dateutil==2.4.0
 

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -244,7 +244,7 @@ pyrsistent==0.16.0        # via jsonschema
 pysrt==1.1.2              # via -r requirements/edx/testing.txt, edxval
 pytest-attrib==0.1.3      # via -r requirements/edx/testing.txt
 pytest-cov==2.8.1         # via -r requirements/edx/testing.txt
-pytest-django==3.9.0      # via -r requirements/edx/testing.txt
+pytest-django==3.8.0      # via -r requirements/edx/testing.txt
 pytest-forked==1.1.3      # via -r requirements/edx/testing.txt, pytest-xdist
 pytest-json-report==1.2.1  # via -r requirements/edx/testing.txt
 pytest-metadata==1.8.0    # via -r requirements/edx/testing.txt, pytest-json-report

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -232,7 +232,7 @@ pyquery==1.4.1            # via -r requirements/edx/testing.in
 pysrt==1.1.2              # via -r requirements/edx/base.txt, edxval
 pytest-attrib==0.1.3      # via -r requirements/edx/testing.in
 pytest-cov==2.8.1         # via -r requirements/edx/testing.in
-pytest-django==3.9.0      # via -r requirements/edx/testing.in
+pytest-django==3.8.0      # via -r requirements/edx/testing.in
 pytest-forked==1.1.3      # via pytest-xdist
 pytest-json-report==1.2.1  # via -r requirements/edx/testing.in
 pytest-metadata==1.8.0    # via pytest-json-report


### PR DESCRIPTION
We'll upgrade this again along with pytest once https://github.com/pytest-dev/pytest/issues/6925 is resolved.