### PR TITLE
EDUCATOR-4976 (Part 2): Tests for current behavior

### DIFF
--- a/lms/djangoapps/teams/tests/test_views.py
+++ b/lms/djangoapps/teams/tests/test_views.py
@@ -1637,7 +1637,7 @@ class TestListTopicsAPI(TeamAPITestCase):
         sot1ps1 and sot2ps3 should only see their teamset
         """
         topics = self.get_topics_list(
-            data={'course_id': self.test_course_1.id},
+            data={'course_id': str(self.test_course_1.id)},
             user=requesting_user
         )
         private_teamsets_returned = [


### PR DESCRIPTION
@edx/masters-devs-gta 

Part Two of [EDUCATOR-4976](https://openedx.atlassian.net/browse/EDUCATOR-4976)

Add a suite of tests to teams test_views.py to explicitly document the behavior of each endpoint wrt/ organization_protected and teamset type privacy.

I've added detailed docstrings to each test with TODOs that I believe capture the issues discovered in each test.

Some endpoints openly leak private data, but some are a bit more subtle.

The requirement , as I understand it to be, is: 
- No one oustide of the organization protected "bubble" should be able to see information about organization_protected teams, _or be able to identify their existence at all_

- No one should be able to see that private teamsets exist _in any way_, unless they are staff, or they are enrolled in a private_managed team. In that case, they can see the teamset and their own team, but _cannot identify the existence of any other teams in that teamset in any way_

Many endpoints have small info leaks where rather than giving out information about a team or teamset, they return status codes that give away the existence of certain teams (for example, requests to nonexistant teams return a 404, but requests to teams you shouldn't know about return 403).

These may be small, but are still potential security concerns.


