### PR TITLE
Adding samesite cookie option in django 2.1 and above

### DIFF
--- a/openedx/core/djangoapps/site_configuration/middleware.py
+++ b/openedx/core/djangoapps/site_configuration/middleware.py
@@ -38,32 +38,22 @@ class SessionCookieDomainOverrideMiddleware(MiddlewareMixin):
                 if key == configuration_helpers.get_value('SESSION_COOKIE_NAME', settings.SESSION_COOKIE_NAME):
                     domain = session_cookie_domain
 
+                kwargs = {'max_age': max_age,
+                          'expires': expires,
+                          'path': path,
+                          'domain': domain,
+                          'secure': secure,
+                          'httponly': httponly,
+                          }
                 # samesite flag was added in django 2.1, so only pass it in for django 2.1 or higher
                 if django.VERSION >= (2, 1):
-                    # then call down into the normal Django set_cookie method
-                    return response.set_cookie_wrapped_func(
-                        key,
-                        value,
-                        max_age=max_age,
-                        expires=expires,
-                        path=path,
-                        domain=domain,
-                        secure=secure,
-                        httponly=httponly,
-                        samesite=samesite
-                    )
-                else:
-                    # then call down into the normal Django set_cookie method
-                    return response.set_cookie_wrapped_func(
-                        key,
-                        value,
-                        max_age=max_age,
-                        expires=expires,
-                        path=path,
-                        domain=domain,
-                        secure=secure,
-                        httponly=httponly,
-                    )
+                    kwargs['samesite'] = samesite
+                # then call down into the normal Django set_cookie method
+                return response.set_cookie_wrapped_func(
+                    key,
+                    value,
+                    **kwargs
+                )
 
             # then point the HttpResponse.set_cookie to point to the wrapper and keep
             # the original around

--- a/openedx/core/djangoapps/site_configuration/middleware.py
+++ b/openedx/core/djangoapps/site_configuration/middleware.py
@@ -37,7 +37,7 @@ class SessionCookieDomainOverrideMiddleware(MiddlewareMixin):
                 # as defined in settings.SESSION_COOKIE_NAME
                 if key == configuration_helpers.get_value('SESSION_COOKIE_NAME', settings.SESSION_COOKIE_NAME):
                     domain = session_cookie_domain
-                
+
                 # samesite flag was added in django 2.1, so only pass it in for django 2.1 or higher
                 if django.VERSION >= (2, 1):
                     # then call down into the normal Django set_cookie method

--- a/openedx/core/djangoapps/site_configuration/middleware.py
+++ b/openedx/core/djangoapps/site_configuration/middleware.py
@@ -2,7 +2,7 @@
 This file contains Django middleware related to the site_configuration app.
 """
 
-
+import django
 from django.conf import settings
 from django.utils.deprecation import MiddlewareMixin
 
@@ -28,7 +28,7 @@ class SessionCookieDomainOverrideMiddleware(MiddlewareMixin):
         session_cookie_domain = configuration_helpers.get_value('SESSION_COOKIE_DOMAIN')
         if session_cookie_domain:
             def _set_cookie_wrapper(key, value='', max_age=None, expires=None, path='/', domain=None, secure=None,
-                                    httponly=False):
+                                    httponly=False, samesite=None):
                 """
                 Wrapper function for set_cookie() which applies SESSION_COOKIE_DOMAIN override
                 """
@@ -37,18 +37,33 @@ class SessionCookieDomainOverrideMiddleware(MiddlewareMixin):
                 # as defined in settings.SESSION_COOKIE_NAME
                 if key == configuration_helpers.get_value('SESSION_COOKIE_NAME', settings.SESSION_COOKIE_NAME):
                     domain = session_cookie_domain
-
-                # then call down into the normal Django set_cookie method
-                return response.set_cookie_wrapped_func(
-                    key,
-                    value,
-                    max_age=max_age,
-                    expires=expires,
-                    path=path,
-                    domain=domain,
-                    secure=secure,
-                    httponly=httponly
-                )
+                
+                # samesite flag was added in django 2.1, so only pass it in for django 2.1 or higher
+                if django.VERSION >= (2, 1):
+                    # then call down into the normal Django set_cookie method
+                    return response.set_cookie_wrapped_func(
+                        key,
+                        value,
+                        max_age=max_age,
+                        expires=expires,
+                        path=path,
+                        domain=domain,
+                        secure=secure,
+                        httponly=httponly,
+                        samesite=samesite
+                    )
+                else:
+                    # then call down into the normal Django set_cookie method
+                    return response.set_cookie_wrapped_func(
+                        key,
+                        value,
+                        max_age=max_age,
+                        expires=expires,
+                        path=path,
+                        domain=domain,
+                        secure=secure,
+                        httponly=httponly,
+                    )
 
             # then point the HttpResponse.set_cookie to point to the wrapper and keep
             # the original around

--- a/openedx/core/djangoapps/site_configuration/middleware.py
+++ b/openedx/core/djangoapps/site_configuration/middleware.py
@@ -38,17 +38,18 @@ class SessionCookieDomainOverrideMiddleware(MiddlewareMixin):
                 if key == configuration_helpers.get_value('SESSION_COOKIE_NAME', settings.SESSION_COOKIE_NAME):
                     domain = session_cookie_domain
 
-                kwargs = {'max_age': max_age,
-                          'expires': expires,
-                          'path': path,
-                          'domain': domain,
-                          'secure': secure,
-                          'httponly': httponly,
-                          }
+                kwargs = {
+                    'max_age': max_age,
+                    'expires': expires,
+                    'path': path,
+                    'domain': domain,
+                    'secure': secure,
+                    'httponly': httponly,
+                }
                 # samesite flag was added in django 2.1, so only pass it in for django 2.1 or higher
                 if django.VERSION >= (2, 1):
                     kwargs['samesite'] = samesite
-                    
+
                 # then call down into the normal Django set_cookie method
                 return response.set_cookie_wrapped_func(key, value, **kwargs)
 

--- a/openedx/core/djangoapps/site_configuration/middleware.py
+++ b/openedx/core/djangoapps/site_configuration/middleware.py
@@ -48,12 +48,9 @@ class SessionCookieDomainOverrideMiddleware(MiddlewareMixin):
                 # samesite flag was added in django 2.1, so only pass it in for django 2.1 or higher
                 if django.VERSION >= (2, 1):
                     kwargs['samesite'] = samesite
+                    
                 # then call down into the normal Django set_cookie method
-                return response.set_cookie_wrapped_func(
-                    key,
-                    value,
-                    **kwargs
-                )
+                return response.set_cookie_wrapped_func(key, value, **kwargs)
 
             # then point the HttpResponse.set_cookie to point to the wrapper and keep
             # the original around


### PR DESCRIPTION
Django 2.1 release note: Added the SESSION_COOKIE_SAMESITE setting to set the SameSite cookie flag on session cookies