### PR TITLE
Update the LMS courses API for staff permissions

### DIFF
--- a/lms/djangoapps/course_api/api.py
+++ b/lms/djangoapps/course_api/api.py
@@ -38,9 +38,13 @@ def get_effective_user(requesting_user, target_username):
     """
     if target_username == requesting_user.username:
         return requesting_user
+    # This is the default behavior if username is not specified as a query parameter
+    # which is why the is_staff check is happening inside of here.
     elif target_username == '':
+        if requesting_user.is_staff:
+            return requesting_user
         return AnonymousUser()
-    elif can_view_courses_for_username(requesting_user, target_username):
+    elif target_username and can_view_courses_for_username(requesting_user, target_username):
         return User.objects.get(username=target_username)
     else:
         raise PermissionDenied()


### PR DESCRIPTION
We want to allow staff to see all courses in the LMS.
This changes the behavior from staff being treated like
an AnonymousUser (unless an username query parameter is
provided) to being treated like staff.

I also added in some tests for the other paths in this
function that did not seem to be tested.