### PR TITLE
use has_access to determine user access to course metadata

### DIFF
--- a/openedx/core/djangoapps/courseware_api/views.py
+++ b/openedx/core/djangoapps/courseware_api/views.py
@@ -101,11 +101,7 @@ class CoursewareInformation(RetrieveAPIView):
             )
 
         overview.enrollment = {'mode': mode, 'is_active': is_active}
-        if not is_active:
-            user_has_access = allow_public_access(overview, [COURSE_VISIBILITY_PUBLIC])
-        else:
-            user_has_access = True
-        overview.user_has_access = user_has_access
+        overview.user_has_access = has_access(self.request.user, 'load', overview).has_access
         overview.user_has_staff_access = has_access(self.request.user, 'staff', overview).has_access
         return overview
 


### PR DESCRIPTION
Leverage common access logic in courseware metadata endpoint to return more accurate value for `user_has_access`. TNL-7053