### PR TITLE
Remove bad "test_no_file" test case revealed by Django 2.1 upgrade

### DIFF
--- a/cms/djangoapps/contentstore/views/tests/test_assets.py
+++ b/cms/djangoapps/contentstore/views/tests/test_assets.py
@@ -354,10 +354,6 @@ class UploadTestCase(AssetsTestCase):
         resp = self.upload_asset("test_image", asset_type="image")
         self.assertEqual(resp.status_code, 200)
 
-    def test_no_file(self):
-        resp = self.client.post(self.url, {"name": "file.txt"}, "application/json")
-        self.assertEqual(resp.status_code, 400)
-
     @data(
         (int(MAX_FILE_SIZE / 2.0), "small.file.test", 200),
         (MAX_FILE_SIZE, "justequals.file.test", 200),


### PR DESCRIPTION
Before Django 2.1, the dict was being stringified as `{'name': 'file.txt'}` (note the single quotes) and producing a JSON parse error in https://github.com/edx/edx-platform/blob/9cf2f9f/cms/djangoapps/contentstore/views/assets.py#L541 which was then converted to a 400 error. However, in Django 2.1, django.test.client starts JSON-encoding request bodies when an appropriate content-type is set: https://github.com/django/django/compare/2.0.8..2.1#diff-97160f50594424a40f2621d5a3c581ccR320

This results in the JSON parse succeeding, and the expected error never occurs; instead, there is a KeyError when the `locked` attribute is missing from the dict.

We should probably repair and restore this test, but it is likely that we'll want to change the code it is testing first, since that code is insufficiently defensive and handles both multipart form data and JSON without properly checking which kind it is dealing with, as well as assuming too much about what keys are present in the JSON.

I've filed ARCHBOM-1090 for this followup work.