### PR TITLE
fix: Improving access check in CoursewareInformation view

### DIFF
--- a/openedx/core/djangoapps/courseware_api/serializers.py
+++ b/openedx/core/djangoapps/courseware_api/serializers.py
@@ -83,11 +83,15 @@ class CourseInfoSerializer(serializers.Serializer):  # pylint: disable=abstract-
     start_type = serializers.CharField()
     pacing = serializers.CharField()
     enrollment = serializers.DictField()
-    user_has_access = serializers.BooleanField()
-    user_has_staff_access = serializers.BooleanField()
     tabs = serializers.SerializerMethodField()
     verified_mode = serializers.SerializerMethodField()
     show_calculator = serializers.BooleanField()
+    is_staff = serializers.BooleanField()
+    can_load_courseware = serializers.BooleanField()
+
+    # TODO: TNL-7053 Legacy: Delete these two once ready to contract
+    user_has_access = serializers.BooleanField()
+    user_has_staff_access = serializers.BooleanField()
 
     def __init__(self, *args, **kwargs):
         """

--- a/openedx/core/djangoapps/courseware_api/views.py
+++ b/openedx/core/djangoapps/courseware_api/views.py
@@ -126,8 +126,8 @@ class CoursewareInformation(RetrieveAPIView):
         overview.can_load_course = self._check_access(self.request.user, overview)
         overview.is_staff = has_access(self.request.user, 'staff', overview).has_access
 
-        overview.user_has_access = overview.can_load_course # TODO: TNL-7053 Legacy: Delete once ready to contract
-        overview.user_has_staff_access = overview.is_staff # TODO: TNL-7053 Legacy: Delete once ready to contract
+        overview.user_has_access = overview.can_load_course  # TODO: TNL-7053 Legacy: Delete once ready to contract
+        overview.user_has_staff_access = overview.is_staff  # TODO: TNL-7053 Legacy: Delete once ready to contract
 
         return overview
 

--- a/openedx/core/djangoapps/courseware_api/views.py
+++ b/openedx/core/djangoapps/courseware_api/views.py
@@ -80,8 +80,11 @@ class CoursewareInformation(RetrieveAPIView):
 
     serializer_class = CourseInfoSerializer
 
-    def _check_access(self, user, overview):
-        if has_access(user, 'staff', overview):
+    def _check_access(self, user, overview, is_staff=None):
+        if is_staff is None:
+            is_staff = has_access(user, 'staff', overview)
+
+        if is_staff:
             return True
 
         # We can only trust has_access in its false case because it doesn't check everything we
@@ -122,8 +125,8 @@ class CoursewareInformation(RetrieveAPIView):
             )
         overview.enrollment = {'mode': mode, 'is_active': is_active}
 
-        overview.can_load_course = self._check_access(self.request.user, overview)
         overview.is_staff = has_access(self.request.user, 'staff', overview).has_access
+        overview.can_load_course = self._check_access(self.request.user, overview, overview.is_staff)
 
         overview.user_has_access = overview.can_load_course  # TODO: TNL-7053 Legacy: Delete once ready to contract
         overview.user_has_staff_access = overview.is_staff  # TODO: TNL-7053 Legacy: Delete once ready to contract

--- a/openedx/core/djangoapps/courseware_api/views.py
+++ b/openedx/core/djangoapps/courseware_api/views.py
@@ -80,6 +80,27 @@ class CoursewareInformation(RetrieveAPIView):
 
     serializer_class = CourseInfoSerializer
 
+    def _check_access(self, user, overview):
+        if has_access(user, 'staff', overview):
+            return True
+
+        # We can only trust has_access in its false case because it doesn't check everything we
+        # need to check.
+        if not has_access(user, 'load', overview):
+            return False
+
+        has_public_access = allow_public_access(overview, [COURSE_VISIBILITY_PUBLIC])
+        if user.is_anonymous and not has_public_access:
+            return False
+
+        if not CourseEnrollment.is_enrolled(user, overview.id) and not has_public_access:
+            return False
+
+        # if is_survey_required_and_unanswered(user, course):
+            # TODO: This.
+
+        return True
+
     def get_object(self):
         """
         Return the requested course object, if the user has appropriate
@@ -91,6 +112,7 @@ class CoursewareInformation(RetrieveAPIView):
             self.request.user.username,
             CourseKey.from_string(self.kwargs['course_key_string']),
         )
+
         if self.request.user.is_anonymous:
             mode = None
             is_active = False
@@ -99,14 +121,14 @@ class CoursewareInformation(RetrieveAPIView):
                 overview.effective_user,
                 overview.id
             )
-
         overview.enrollment = {'mode': mode, 'is_active': is_active}
-        if not is_active:
-            user_has_access = allow_public_access(overview, [COURSE_VISIBILITY_PUBLIC])
-        else:
-            user_has_access = True
-        overview.user_has_access = user_has_access
-        overview.user_has_staff_access = has_access(self.request.user, 'staff', overview).has_access
+
+        overview.can_load_course = self._check_access(self.request.user, overview)
+        overview.is_staff = has_access(self.request.user, 'staff', overview).has_access
+
+        overview.user_has_access = overview.can_load_course # TODO: TNL-7053 Legacy: Delete once ready to contract
+        overview.user_has_staff_access = overview.is_staff # TODO: TNL-7053 Legacy: Delete once ready to contract
+
         return overview
 
     def get_serializer_context(self):

--- a/openedx/core/djangoapps/courseware_api/views.py
+++ b/openedx/core/djangoapps/courseware_api/views.py
@@ -80,10 +80,7 @@ class CoursewareInformation(RetrieveAPIView):
 
     serializer_class = CourseInfoSerializer
 
-    def _check_access(self, user, overview, is_staff=None):
-        if is_staff is None:
-            is_staff = has_access(user, 'staff', overview)
-
+    def _check_access(self, user, overview, is_staff):
         if is_staff:
             return True
 
@@ -126,10 +123,11 @@ class CoursewareInformation(RetrieveAPIView):
         overview.enrollment = {'mode': mode, 'is_active': is_active}
 
         overview.is_staff = has_access(self.request.user, 'staff', overview).has_access
-        overview.can_load_course = self._check_access(self.request.user, overview, overview.is_staff)
+        overview.can_load_courseware = self._check_access(self.request.user, overview, overview.is_staff)
 
-        overview.user_has_access = overview.can_load_course  # TODO: TNL-7053 Legacy: Delete once ready to contract
-        overview.user_has_staff_access = overview.is_staff  # TODO: TNL-7053 Legacy: Delete once ready to contract
+        # TODO: TNL-7053 Legacy: Delete these two once ready to contract
+        overview.user_has_access = overview.can_load_courseware
+        overview.user_has_staff_access = overview.is_staff
 
         return overview
 

--- a/openedx/core/djangoapps/courseware_api/views.py
+++ b/openedx/core/djangoapps/courseware_api/views.py
@@ -89,12 +89,11 @@ class CoursewareInformation(RetrieveAPIView):
         if not has_access(user, 'load', overview):
             return False
 
-        has_public_access = allow_public_access(overview, [COURSE_VISIBILITY_PUBLIC])
-        if user.is_anonymous and not has_public_access:
-            return False
-
-        if not CourseEnrollment.is_enrolled(user, overview.id) and not has_public_access:
-            return False
+        # Anonymous or unenrolled users
+        if user.is_anonymous or not CourseEnrollment.is_enrolled(user, overview.id):
+            # do not have access if the course is not public
+            if not allow_public_access(overview, [COURSE_VISIBILITY_PUBLIC]):
+                return False
 
         # if is_survey_required_and_unanswered(user, course):
             # TODO: This.


### PR DESCRIPTION
TNL-7053

We weren’t using `has_access` to check user access, which meant we were missing out on a bunch of checks around dates, etc.  This PR adds a local `_check_access` function to `CoursewareInformation`.  Ideally we would add this into access.py, but we’re adding it here for now to avoid any unexpected regressions in editing more commonly used code.  

This should ultimately be folded into our access system properly - I'd like to get some pointers on the right shape for adding something like this to access.py.  I think it makes sense to add a "can_load_courseware_mfe" function, though I don't really like adding "mfe" to the end of it.  I see functions in there for mobile, and for the about page, etc., so maybe that's appropriate.  Curious what others think.

Because the MFE relies on "user_has_access" and "user_has_staff_access", we're leave those properties in the overview until the MFE no longer uses them.  There are TODOs to "contract" and remove those keys.

I'm also interested in opinions on the efficiency of this code - I think there are a few places we might be making duplicate queries.  Optimizing it might make the code less readable...
