### PR TITLE
EDUCATOR-4995: text search returns private teamsets for anyone in bubble

### DIFF
--- a/lms/djangoapps/teams/tests/test_views.py
+++ b/lms/djangoapps/teams/tests/test_views.py
@@ -824,10 +824,10 @@ class TestListTeamsAPI(EventTestMixin, TeamAPITestCase):
 
     @ddt.unpack
     @ddt.data(
-        ('student_on_team_1_private_set_1', True, True, True),
-        ('student_on_team_2_private_set_1', True, True, True),
+        ('student_on_team_1_private_set_1', True, False, False),
+        ('student_on_team_2_private_set_1', False, True, False),
         ('student_enrolled', False, False, False),
-        ('student_masters', True, True, True),
+        ('student_masters', False, False, False),
         ('staff', True, True, True),
     )
     def test_text_search_private_teamset(self, user, can_see_private_1_1, can_see_private_1_2, can_see_private_2_1):

--- a/lms/djangoapps/teams/tests/test_views.py
+++ b/lms/djangoapps/teams/tests/test_views.py
@@ -835,10 +835,6 @@ class TestListTeamsAPI(EventTestMixin, TeamAPITestCase):
         When doing a text search as different users, will private_managed teams show up?
         Only staff should be able to see all private_managed teams.
         Students enrolled in a private_managed teams should be able to see their team, and no others.
-
-        TODO: Currently, anyone within the organization_protected bubble can see all private teams regardless of
-        team membership. If our test data contained a non-protected private_managed topic, everyone would see that
-        as well.
         """
         self.reset_search_index()
         result = self.get_teams_list(


### PR DESCRIPTION
@edx/masters-devs-gta 

[EDUCATOR-4995](https://openedx.atlassian.net/browse/EDUCATOR-4995
)
Remove results from text search results that the requester does not have access to.

I'm not super happy with this result, but I'm not sure how else to achieve it. looking through the edx-search docs, it doesn't seem like it supports a 'field__in' operator, so I can't specify a whitelist of team ids nor a blacklist of bad team_ids. 

Suggestions gladly accepted.