### PR TITLE
Fixing django 2.1 probs in student management commands

### DIFF
--- a/common/djangoapps/student/management/commands/bulk_change_enrollment.py
+++ b/common/djangoapps/student/management/commands/bulk_change_enrollment.py
@@ -36,7 +36,7 @@ class Command(BaseCommand):
     """
 
     def add_arguments(self, parser):
-        group = parser.add_mutually_exclusive_group()
+        group = parser.add_mutually_exclusive_group(required=True)
         group.add_argument(
             '-c', '--course',
             help='The course to change enrollments in')
@@ -64,7 +64,6 @@ class Command(BaseCommand):
         to_mode = options['to_mode']
         commit = options['commit']
         course_keys = []
-
         if course_id:
             try:
                 course_key = CourseKey.from_string(course_id)

--- a/common/djangoapps/student/management/commands/manage_user.py
+++ b/common/djangoapps/student/management/commands/manage_user.py
@@ -18,13 +18,10 @@ from student.models import UserProfile
 def is_valid_django_hash(encoded):
     """
     Starting with django 2.1, the function is_password_usable no longer checks whether encode
-    is a valid password created by a django hasher(hasher in  PASSWORD_HASHERS setting)
+    is a valid password created by a django hasher (hasher in  PASSWORD_HASHERS setting)
 
     Adding this function to create constant behavior as we upgrade django versions
     """
-    if encoded is None:
-        return False
-
     try:
         identify_hasher(encoded)
     except ValueError:

--- a/common/djangoapps/student/management/commands/manage_user.py
+++ b/common/djangoapps/student/management/commands/manage_user.py
@@ -5,7 +5,7 @@ Django users, set/unset permission bits, and associate groups by name.
 
 
 from django.contrib.auth import get_user_model
-from django.contrib.auth.hashers import is_password_usable
+from django.contrib.auth.hashers import is_password_usable, identify_hasher
 from django.contrib.auth.models import Group
 from django.core.management.base import BaseCommand, CommandError
 from django.db import transaction
@@ -13,6 +13,23 @@ from django.utils.translation import gettext as _
 
 from openedx.core.djangoapps.user_authn.utils import generate_password
 from student.models import UserProfile
+
+
+def is_valid_django_hash(encoded):
+    """
+    Starting with django 2.1, the function is_password_usable no longer checks whether encode 
+    is a valid password created by a django hasher(hasher in  PASSWORD_HASHERS setting)
+
+    Adding this function to create constant behavior as we upgrade django versions
+    """
+    if encoded is None:
+        return False
+
+    try:
+        identify_hasher(encoded)
+    except ValueError:
+        return False
+    return True
 
 
 class Command(BaseCommand):
@@ -87,7 +104,7 @@ class Command(BaseCommand):
 
         if created:
             if initial_password_hash:
-                if not is_password_usable(initial_password_hash):
+                if not (is_password_usable(initial_password_hash) and is_valid_django_hash(initial_password_hash)):
                     raise CommandError('The password hash provided for user {} is invalid.'.format(username))
                 user.password = initial_password_hash
             else:

--- a/common/djangoapps/student/management/commands/manage_user.py
+++ b/common/djangoapps/student/management/commands/manage_user.py
@@ -17,7 +17,7 @@ from student.models import UserProfile
 
 def is_valid_django_hash(encoded):
     """
-    Starting with django 2.1, the function is_password_usable no longer checks whether encode 
+    Starting with django 2.1, the function is_password_usable no longer checks whether encode
     is a valid password created by a django hasher(hasher in  PASSWORD_HASHERS setting)
 
     Adding this function to create constant behavior as we upgrade django versions


### PR DESCRIPTION
This PR fixes two probs: 
1) bulk_change_enrollment requires one of agrs: org or course to be set
for it to function correctly. 
2) From django 2.1 release notes: `User.has_usable_password() and the is_password_usable() function no longer return False if the password is None or an empty string, or if the password uses a hasher that’s not in the PASSWORD_HASHERS setting. This undocumented behavior was a regression in Django 1.6 and prevented users with such passwords from requesting a password reset. Audit your code to confirm that your usage of these APIs don’t rely on the old behavior.`

I was unsure as to whether the initial_password_hash really needed the verification of being hashed by PAWWROD_HASHERS, but, I decided to be conservative and preserve existing behavior by creating a new function that performs all the functionality that was removed in django 2.1.