### PR TITLE
Certification verification enabled

### DIFF
--- a/lms/djangoapps/verify_student/models.py
+++ b/lms/djangoapps/verify_student/models.py
@@ -940,7 +940,7 @@ class SoftwareSecurePhotoVerification(PhotoVerification):
             settings.VERIFY_STUDENT["SOFTWARE_SECURE"]["API_URL"],
             headers=headers,
             data=simplejson.dumps(body, indent=2, sort_keys=True, ensure_ascii=False).encode('utf-8'),
-            verify=False
+            verify=True
         )
 
         log.info(u"Sent request to Software Secure for receipt ID %s.", self.receipt_id)


### PR DESCRIPTION
Previously software secure was using self sign certificates.
Now they are not using it that's why we are enabling ssl
certificate verfication.

PROD-1395