### PR TITLE
ENT-2740 | Flaky tests due to UNIQUE constraint failed on enterprise_enterprisecourseenrollment.id

### DIFF
--- a/lms/djangoapps/commerce/management/commands/tests/test_create_orders_for_old_enterprise_course_enrollmnet.py
+++ b/lms/djangoapps/commerce/management/commands/tests/test_create_orders_for_old_enterprise_course_enrollmnet.py
@@ -30,7 +30,6 @@ class TestEnterpriseCourseEnrollmentCreateOldOrder(TestCase):
     def setUpTestData(cls):
         super(TestEnterpriseCourseEnrollmentCreateOldOrder, cls).setUpTestData()
         UserFactory(username=TEST_ECOMMERCE_WORKER)
-        cls.enrollment_count = 30
         cls._create_enterprise_course_enrollments(30)
 
     @classmethod
@@ -74,7 +73,10 @@ class TestEnterpriseCourseEnrollmentCreateOldOrder(TestCase):
                 output
             )
         )
-        self.assertEqual(mock_create_manual_enrollment_orders.call_count, 4)  # batch of 4 (10, 10, 10, 2)
+        # There are total 32 enrollments so there would be 4 batches (i.e: [10, 10, 10, 2])
+        # as there are 2 enrollments in last batch and that 2 enrollments are not valid enrollment to process,
+        # so _create_manual_enrollment_orders will not be called for last batch.
+        self.assertEqual(mock_create_manual_enrollment_orders.call_count, 3)
 
     @patch('lms.djangoapps.commerce.management.commands.create_orders_for_old_enterprise_course_enrollment'
            '.Command._create_manual_enrollment_orders')

--- a/openedx/features/enterprise_support/tests/factories.py
+++ b/openedx/features/enterprise_support/tests/factories.py
@@ -71,6 +71,5 @@ class EnterpriseCourseEnrollmentFactory(factory.django.DjangoModelFactory):
 
         model = EnterpriseCourseEnrollment
 
-    id = factory.LazyAttribute(lambda x: FAKER.random_int(min=1))  # pylint: disable=no-member
     course_id = factory.LazyAttribute(lambda x: FAKER.slug())  # pylint: disable=no-member
     enterprise_customer_user = factory.SubFactory(EnterpriseCustomerUserFactory)


### PR DESCRIPTION
fixing flakiness of tests due to redundant id created by `faker`.