### PR TITLE
constrain cryptography

### DIFF
--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -20,6 +20,9 @@ cryptography<2.9
 # The CORS_ORIGIN_WHITELIST changes in a backwards incompatible way in 3.0.0, needs matching configuration repo changes
 django-cors-headers<3.0.0
 
+# It seems like django-countries > 5.5 may cause performance issues for us.
+django-countries==5.5
+
 # Version 4.0.0 dropped support for Django < 2.0.1
 django-model-utils<4.0.0
 
@@ -50,6 +53,9 @@ inflect<4.0.0
 # jsonfield2 3.1.0 drops support for python 3.5
 jsonfield2<3.1.0
 
+# kiwisolver 1.2.0 requires Python 3.6+
+kiwisolver<1.2.0
+
 # Convert text markup to HTML; used in capa problems, forums, and course wikis; pin Markdown version as tests failed for its upgrade to the latest release
 Markdown==2.6.11
 
@@ -61,6 +67,9 @@ mock<4.0.0
 
 # mysqlclient 1.5 is scheduled to change internal APIs used by Django 1.11
 mysqlclient<1.5
+
+# oauthlib>3.0.1 causes test failures
+oauthlib==3.0.1
 
 # Version 0.23.0 requires python-dateutil>=2.5.0
 pandas==0.22.0
@@ -81,9 +90,6 @@ python-dateutil==2.4.0
 # python3-saml 1.6.0 breaks unittests in common/djangoapps/third_party_auth/tests/test_views.py::SAMLMetadataTest
 python3-saml==1.5.0
 
-# oauthlib>3.0.1 causes test failures
-oauthlib==3.0.1
-
 # transifex-client 0.13.5 and 0.13.6 needlessly pin six and urllib3, 0.13.7 does so for python-slugify
 #   https://github.com/transifex/transifex-client/issues/252
 transifex-client==0.13.4
@@ -93,6 +99,3 @@ wrapt==1.11.*
 
 # zipp 2.0.0 requires Python >= 3.6
 zipp==1.0.0
-
-# It seems like django-countries > 5.5 may cause performance issues for us.
-django-countries==5.5

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -13,6 +13,10 @@
 # (although it is advertised in the changelog as 3.1.26.)
 celery>=3.1.25,<4.0.0
 
+# Need to review backward incompatible changes before upgrading.
+# See https://github.com/pyca/cryptography/blob/master/CHANGELOG.rst#29---2020-04-02
+cryptography<2.9
+
 # The CORS_ORIGIN_WHITELIST changes in a backwards incompatible way in 3.0.0, needs matching configuration repo changes
 django-cors-headers<3.0.0
 

--- a/requirements/edx-sandbox/py35.in
+++ b/requirements/edx-sandbox/py35.in
@@ -7,6 +7,8 @@
 #   * confirm that it has no system requirements beyond what we already install
 #   * run "make upgrade" to update the detailed requirements files
 
+-c ../constraints.txt
+
 -r shared.txt                       # Dependencies in common with LMS and Studio
 matplotlib==2.2.4                   # 2D plotting library
 networkx==2.2                       # Utilities for creating, manipulating, and studying network graphs

--- a/requirements/edx-sandbox/py35.txt
+++ b/requirements/edx-sandbox/py35.txt
@@ -4,25 +4,25 @@
 #
 #    make upgrade
 #
-common/lib/sandbox-packages  # via -r requirements/edx-sandbox/py35.in
-common/lib/symmath  # via -r requirements/edx-sandbox/py35.in
+-e file:///edx/app/edxapp/edx-platform/common/lib/sandbox-packages  # via -r requirements/edx-sandbox/py35.in
+-e file:///edx/app/edxapp/edx-platform/common/lib/symmath  # via -r requirements/edx-sandbox/py35.in
 git+https://github.com/edx/openedx-calc.git@e9b698c85ad1152002bc0868f475f153dce88952#egg=calc==0.4  # via -r requirements/edx-sandbox/py35.in
 cffi==1.14.0              # via -r requirements/edx-sandbox/shared.txt, cryptography
 git+https://github.com/edx/openedx-chem.git@ff4e3a03d3c7610e47a9af08eb648d8aabe2eb18#egg=chem==1.0.0  # via -r requirements/edx-sandbox/py35.in
-cryptography==2.8         # via -r requirements/edx-sandbox/shared.txt
+cryptography==2.8         # via -c requirements/edx-sandbox/../constraints.txt, -r requirements/edx-sandbox/shared.txt
 cycler==0.10.0            # via matplotlib
 decorator==4.4.2          # via networkx
-kiwisolver==1.1.0         # via matplotlib
+kiwisolver==1.1.0         # via -c requirements/edx-sandbox/../constraints.txt, matplotlib
 lxml==4.5.0               # via -r requirements/edx-sandbox/shared.txt
 markupsafe==1.1.1         # via chem
-matplotlib==2.2.4         # via -r requirements/edx-sandbox/py35.in
+matplotlib==2.2.4         # via -c requirements/edx-sandbox/../constraints.txt, -r requirements/edx-sandbox/py35.in
 mpmath==1.1.0             # via sympy
 networkx==2.2             # via -r requirements/edx-sandbox/py35.in
 nltk==3.4.5               # via -r requirements/edx-sandbox/shared.txt, chem
 numpy==1.16.5             # via -r requirements/edx-sandbox/py35.in, calc, chem, matplotlib, scipy
 pycparser==2.20           # via -r requirements/edx-sandbox/shared.txt, cffi
 pyparsing==2.2.0          # via -r requirements/edx-sandbox/py35.in, calc, chem, matplotlib
-python-dateutil==2.8.1    # via matplotlib
+python-dateutil==2.4.0    # via -c requirements/edx-sandbox/../constraints.txt, matplotlib
 pytz==2019.3              # via matplotlib
 random2==1.0.1            # via -r requirements/edx-sandbox/py35.in
 scipy==1.2.1              # via -r requirements/edx-sandbox/py35.in, calc, chem

--- a/requirements/edx-sandbox/shared.txt
+++ b/requirements/edx-sandbox/shared.txt
@@ -5,7 +5,7 @@
 #    make upgrade
 #
 cffi==1.14.0              # via cryptography
-cryptography==2.8         # via -r requirements/edx-sandbox/shared.in
+cryptography==2.8         # via -c requirements/edx-sandbox/../constraints.txt, -r requirements/edx-sandbox/shared.in
 lxml==4.5.0               # via -r requirements/edx-sandbox/shared.in
 nltk==3.4.5               # via -r requirements/edx-sandbox/shared.in
 pycparser==2.20           # via cffi


### PR DESCRIPTION
**Note:** When running `make upgrade` locally, I ran into an unrelated problem on the sandbox build because it wasn't including the py35 constraints:
```
pip._internal.exceptions.UnsupportedPythonVersion: Package 'kiwisolver' requires a different Python: 3.5.2 not in '>=3.6'
```
To make this quicker, I am going to skip this step, which means a later PR will actually update the cryptography comments showing it is now using constraints.txt.