### PR TITLE
EDUCATOR-5009: create new permission that checks specific teams access

### DIFF
--- a/lms/djangoapps/teams/tests/test_views.py
+++ b/lms/djangoapps/teams/tests/test_views.py
@@ -1216,7 +1216,8 @@ class TestDetailTeamAPI(TeamAPITestCase):
 
     @ddt.unpack
     @ddt.data(
-        ('student_enrolled', 200),
+        ('student_unenrolled', 403),
+        ('student_enrolled', 404),
         ('student_masters_not_on_team', 200),
         ('student_masters', 200),
         ('staff', 200)
@@ -1226,8 +1227,6 @@ class TestDetailTeamAPI(TeamAPITestCase):
         As different users, check if we can request the masters_only team detail.
         Only staff and users within the organization_protection bubble should be able to get info about
         an organization_protected team, or be able to tell that it exists.
-
-        TODO: student_enrolled should not be able to see this data
         """
         team = self.get_team_detail(
             self.masters_only_team.team_id,
@@ -1239,10 +1238,11 @@ class TestDetailTeamAPI(TeamAPITestCase):
 
     @ddt.unpack
     @ddt.data(
-        ('student_enrolled', 200),
-        ('student_masters', 200),
+        ('student_unenrolled', 403),
+        ('student_enrolled', 404),
+        ('student_masters', 404),
         ('student_on_team_1_private_set_1', 200),
-        ('student_on_team_2_private_set_1', 200),
+        ('student_on_team_2_private_set_1', 404),
         ('staff', 200)
     )
     def test_teamset_types(self, requesting_user, expected_response):
@@ -1250,8 +1250,6 @@ class TestDetailTeamAPI(TeamAPITestCase):
         As different users, check if we can request the masters_only team detail.
         Only staff or users enrolled in the team should be able to get info about a private_managed team,
         or even be able to tell that it exists.
-
-        TODO: Only staff and sot1ps1 should be able to get any information about team_1_in_private_teamset_1
         """
         team = self.get_team_detail(
             self.team_1_in_private_teamset_1.team_id,
@@ -1313,7 +1311,8 @@ class TestDeleteTeamAPI(EventTestMixin, TeamAPITestCase):
 
     @ddt.unpack
     @ddt.data(
-        ('student_enrolled', 403),
+        ('student_unenrolled', 403),
+        ('student_enrolled', 404),
         ('student_masters_not_on_team', 403),
         ('student_masters', 403),
         ('staff', 204)
@@ -1323,12 +1322,6 @@ class TestDeleteTeamAPI(EventTestMixin, TeamAPITestCase):
         As different users, try to delete the masters-only team.
         Only staff should be able to delete this team, and people outside the bubble shouldn't be able to
         tell that it even exists.
-
-        TODO: This leaks info - if you try to request a team that doesn't exist you get a 404,
-        but you get a 403 if it exists and you can't delete it.
-        Change the behavior so that either the 403 takes precedence
-        ("You can't do any deletes, we didn't even check if it exists"), or only show the 403
-        if the user has_specific_access to the team
         """
         self.delete_team(
             self.masters_only_team.team_id,
@@ -1338,9 +1331,10 @@ class TestDeleteTeamAPI(EventTestMixin, TeamAPITestCase):
 
     @ddt.unpack
     @ddt.data(
-        ('student_enrolled', 403),
+        ('student_unenrolled', 403),
+        ('student_enrolled', 404),
         ('student_on_team_1_private_set_1', 403),
-        ('student_on_team_2_private_set_1', 403),
+        ('student_on_team_2_private_set_1', 404),
         ('staff', 204)
     )
     def test_teamset_type(self, requesting_user, expected_status):
@@ -1348,8 +1342,6 @@ class TestDeleteTeamAPI(EventTestMixin, TeamAPITestCase):
         As different users, try to delete a private_managed team
         Only staff should be able to delete a private_managed team, and only they and users enrolled in that
         team should even be able to tell that it exists.
-
-        TODO: Same as `test_organization_protection_status`
         """
         self.delete_team(
             self.team_1_in_private_teamset_1.team_id,
@@ -1435,7 +1427,8 @@ class TestUpdateTeamAPI(EventTestMixin, TeamAPITestCase):
 
     @ddt.unpack
     @ddt.data(
-        ('student_enrolled', 403),
+        ('student_unenrolled', 403),
+        ('student_enrolled', 404),
         ('student_masters_not_on_team', 403),
         ('student_masters', 403),
         ('staff', 200)
@@ -1445,12 +1438,6 @@ class TestUpdateTeamAPI(EventTestMixin, TeamAPITestCase):
         As different users, try to modify the masters-only team.
         Only staff should be able to modify this team, and people outside the bubble shouldn't be able to
         tell that it even exists.
-
-        TODO: This leaks info - if you try to request a team that doesn't exist you get a 404,
-        but you get a 403 if it exists and you can't modify it.
-        Change the behavior so that either the 403 takes precedence
-        ("You can't do any modifications, we didn't even check if it exists"), or only show the 403
-        if the user has_specific_access to the team
         """
         team = self.patch_team_detail(
             self.masters_only_team.team_id,
@@ -1463,9 +1450,10 @@ class TestUpdateTeamAPI(EventTestMixin, TeamAPITestCase):
 
     @ddt.unpack
     @ddt.data(
-        ('student_enrolled', 403),
+        ('student_unenrolled', 403),
+        ('student_enrolled', 404),
         ('student_on_team_1_private_set_1', 403),
-        ('student_on_team_2_private_set_1', 403),
+        ('student_on_team_2_private_set_1', 404),
         ('staff', 200)
     )
     def test_teamset_type(self, requesting_user, expected_status):
@@ -1473,8 +1461,6 @@ class TestUpdateTeamAPI(EventTestMixin, TeamAPITestCase):
         As different users, try to modify a private_managed team
         Only staff should be able to modify a private_managed team, and only they and users enrolled in that
         team should even be able to tell that it exists.
-
-        TODO: Same as `test_organization_protection_status`
         """
         team = self.patch_team_detail(
             self.team_1_in_private_teamset_1.team_id,

--- a/lms/djangoapps/teams/views.py
+++ b/lms/djangoapps/teams/views.py
@@ -626,6 +626,19 @@ class IsStaffOrPrivilegedOrReadOnly(IsStaffOrReadOnly):
         )
 
 
+class HasSpecificTeamAccess(permissions.BasePermission):
+    """
+    Permission that checks if the user has access to a specific team.
+    If the user doesn't have access to the team, the endpoint should behave as if
+    the team does not exist,
+    """
+
+    def has_object_permission(self, request, view, obj):
+        if not has_specific_team_access(request.user, obj):
+            raise Http404
+        return True
+
+
 class TeamsDetailView(ExpandableFieldViewMixin, RetrievePatchAPIView):
     """
         **Use Cases**
@@ -724,7 +737,12 @@ class TeamsDetailView(ExpandableFieldViewMixin, RetrievePatchAPIView):
 
     """
     authentication_classes = (BearerAuthentication, SessionAuthentication)
-    permission_classes = (permissions.IsAuthenticated, IsStaffOrPrivilegedOrReadOnly, IsEnrolledOrIsStaff,)
+    permission_classes = (
+        permissions.IsAuthenticated,
+        IsEnrolledOrIsStaff,
+        HasSpecificTeamAccess,
+        IsStaffOrPrivilegedOrReadOnly,
+    )
     lookup_field = 'team_id'
     serializer_class = CourseTeamSerializer
     parser_classes = (MergePatchParser,)


### PR DESCRIPTION
@edx/masters-devs-gta 

[EDUCATOR-5009](https://openedx.atlassian.net/browse/EDUCATOR-5009)

I added a new Permission class, HasSpecificTeamAccess. It seems the teensiest bit hacky because it's not /really/ a permission, but it's a simple way to check teams access and raise a 404 if the user doesn't have access to the specified team.

I also changed the order of permissions:

-permissions.IsAuthenticated, -> If the user isn't authenticated, stop here, 403
-IsEnrolledOrIsStaff, -> If the user isn't in the team, or staff, stop here, they also get a 403
-HasSpecificTeamAccess, -> Check if the user has access to this team so that we can throw a 404 and pretend the team doesn't exist
-IsStaffOrPrivilegedOrReadOnly -> move this to the rear. this raises a 403 if you aren't staff and you're calling delete or patch, but we want to check has access first, before we give away that the team exists.

Nicely for me, this one change takes care of all methods in this view. Thanks, DRF!


