### PR TITLE
EDUCATOR-5001: Don't return private teamsets unless user has access to them

### DIFF
--- a/lms/djangoapps/teams/tests/test_views.py
+++ b/lms/djangoapps/teams/tests/test_views.py
@@ -1491,19 +1491,19 @@ class TestListTopicsAPI(TeamAPITestCase):
     """Test cases for the topic listing endpoint."""
 
     @ddt.data(
-        (None, 401),
-        ('student_inactive', 401),
-        ('student_unenrolled', 403),
-        ('student_enrolled', 200),
-        ('staff', 200),
-        ('course_staff', 200),
-        ('community_ta', 200),
+        (None, 401, None),
+        ('student_inactive', 401, None),
+        ('student_unenrolled', 403, None),
+        ('student_enrolled', 200, 4),
+        ('staff', 200, 6),
+        ('course_staff', 200, 6),
+        ('community_ta', 200, 4),
     )
     @ddt.unpack
-    def test_access(self, user, status):
+    def test_access(self, user, status, expected_topics_count):
         topics = self.get_topics_list(status, {'course_id': str(self.test_course_1.id)}, user=user)
         if status == 200:
-            self.assertEqual(topics['count'], self.topics_count)
+            self.assertEqual(topics['count'], expected_topics_count)
 
     @ddt.data('A+BOGUS+COURSE', 'A/BOGUS/COURSE')
     def test_invalid_course_key(self, course_id):
@@ -1513,14 +1513,11 @@ class TestListTopicsAPI(TeamAPITestCase):
         self.get_topics_list(400)
 
     @ddt.data(
-        (None, 200, ['Coal Power', 'Nuclear Power', 'private_topic_1_name', 'private_topic_2_name',
-                     u'Sólar power', 'Wind Power'], 'name'),
-        ('name', 200, ['Coal Power', 'Nuclear Power', 'private_topic_1_name', 'private_topic_2_name',
-                       u'Sólar power', 'Wind Power'], 'name'),
+        (None, 200, ['Coal Power', 'Nuclear Power', u'Sólar power', 'Wind Power'], 'name'),
+        ('name', 200, ['Coal Power', 'Nuclear Power', u'Sólar power', 'Wind Power'], 'name'),
         # Note that "Nuclear Power" will have 2 teams. "Coal Power" "Wind Power" and "Solar Power"
         # all have 1 team. The secondary sort is alphabetical by name.
-        ('team_count', 200, ['Nuclear Power', 'Coal Power', u'Sólar power', 'Wind Power',
-                             'private_topic_1_name', 'private_topic_2_name'], 'team_count'),
+        ('team_count', 200, ['Nuclear Power', 'Coal Power', u'Sólar power', 'Wind Power'], 'team_count'),
         ('no_such_field', 400, [], None),
     )
     @ddt.unpack
@@ -1620,10 +1617,10 @@ class TestListTopicsAPI(TeamAPITestCase):
 
     @ddt.unpack
     @ddt.data(
-        ('student_enrolled', 2),
-        ('student_on_team_1_private_set_1', 2),
-        ('student_on_team_2_private_set_1', 2),
-        ('student_masters', 2),
+        ('student_enrolled', 0),
+        ('student_on_team_1_private_set_1', 1),
+        ('student_on_team_2_private_set_1', 1),
+        ('student_masters', 0),
         ('staff', 2)
     )
     def test_teamset_type(self, requesting_user, expected_private_teamsets):
@@ -1632,9 +1629,6 @@ class TestListTopicsAPI(TeamAPITestCase):
 
         Staff should be able to see both teamsets, and anyone enrolled in a private teamset should see that and
         only that teamset
-
-        TODO: student_enrolled and student_masters should see no private teamsets.
-        sot1ps1 and sot2ps3 should only see their teamset
         """
         topics = self.get_topics_list(
             data={'course_id': str(self.test_course_1.id)},
@@ -1644,6 +1638,23 @@ class TestListTopicsAPI(TeamAPITestCase):
             topic['name'] for topic in topics['results'] if topic['type'] == 'private_managed'
         ]
         self.assertEqual(len(private_teamsets_returned), expected_private_teamsets)
+
+    @ddt.unpack
+    @ddt.data(
+        ('student_on_team_1_private_set_1', 2),
+        ('student_on_team_2_private_set_1', 2),
+        ('staff', 2)
+    )
+    def test_private_teamset_team_count(self, requesting_user, expected_team_count):
+        """
+        TODO: the two students should probably not see that there's another team that they don't see
+        """
+        topics = self.get_topics_list(
+            data={'course_id': self.test_course_1.id},
+            user=requesting_user
+        )
+        private_teamset_1 = [topic for topic in topics['results'] if topic['name'] == 'private_topic_1_name'][0]
+        self.assertEqual(private_teamset_1['team_count'], expected_team_count)
 
 
 @ddt.ddt

--- a/lms/djangoapps/teams/tests/test_views.py
+++ b/lms/djangoapps/teams/tests/test_views.py
@@ -1650,7 +1650,7 @@ class TestListTopicsAPI(TeamAPITestCase):
         TODO: the two students should probably not see that there's another team that they don't see
         """
         topics = self.get_topics_list(
-            data={'course_id': self.test_course_1.id},
+            data={'course_id': str(self.test_course_1.id)},
             user=requesting_user
         )
         private_teamset_1 = [topic for topic in topics['results'] if topic['name'] == 'private_topic_1_name'][0]

--- a/lms/djangoapps/teams/views.py
+++ b/lms/djangoapps/teams/views.py
@@ -963,7 +963,6 @@ class TopicListView(GenericAPIView):
         Return a filtered list of teamsets, removing any private teamsets that a user doesn't have access to.
         Follows the same logic as `has_specific_teamset_access` but in bulk rather than for one teamset at a time
         """
-        # import pdb; pdb.set_trace()
         if has_course_staff_privileges(self.request.user, course_module.id):
             return teamsets
         private_teamset_ids = [teamset.teamset_id for teamset in course_module.teamsets if teamset.is_private_managed]


### PR DESCRIPTION
@edx/masters-devs-gta 


[EDUCATOR-5001](https://openedx.atlassian.net/browse/EDUCATOR-5001)

When listing teamsets, don't include private teamsets that the requesting user doesn't have access to.