### PR TITLE
BOM-1491

### DIFF
--- a/common/djangoapps/student/management/tests/test_manage_group.py
+++ b/common/djangoapps/student/management/tests/test_manage_group.py
@@ -75,7 +75,7 @@ class TestManageGroupCommand(TestCase):
             for data in TEST_DATA
             for args, exception in (
                 ((), 'too few arguments' if sys.version_info.major == 2 else 'required: group_name'),  # no group name
-                (('x' * 81,), 'invalid group name'),  # invalid group name
+                (('x' * 151,), 'invalid group name'),  # invalid group name
                 ((TEST_GROUP, 'some-other-group'), 'unrecognized arguments'),  # multiple arguments
                 ((TEST_GROUP, '--some-option', 'dummy'), 'unrecognized arguments')  # unexpected option name
             )


### PR DESCRIPTION
Group name
Changed in Django 2.2:
The max_length increased from 80 to 150 characters 
Due to this AssertionError: CommandError not raised

https://docs.djangoproject.com/en/3.0/ref/contrib/auth/#django.contrib.auth.models.Group.name