### PR TITLE
ENT-2710: Improved enterprise target regex

### DIFF
--- a/openedx/core/djangoapps/user_authn/views/logout.py
+++ b/openedx/core/djangoapps/user_authn/views/logout.py
@@ -106,7 +106,7 @@ class LogoutView(TemplateView):
         Args: url(str): url path
         """
         unquoted_url = parse.unquote_plus(parse.quote(url))
-        return bool(re.match(r'^/enterprise/[a-z0-9\-]+/course', unquoted_url))
+        return bool(re.match(r'^/enterprise(/handle_consent_enrollment)?/[a-z0-9\-]+/course', unquoted_url))
 
     def _show_tpa_logout_link(self, target, referrer):
         """

--- a/openedx/features/enterprise_support/tests/test_logout.py
+++ b/openedx/features/enterprise_support/tests/test_logout.py
@@ -46,6 +46,8 @@ class EnterpriseLogoutTests(EnterpriseServiceMockMixin, CacheIsolationTestCase, 
         ('invalid-url', False),
         ('/enterprise/c5dad9a7-741c-4841-868f-850aca3ff848/course/Microsoft+DAT206x/enroll/', True),
         ('%2Fenterprise%2Fc5dad9a7-741c-4841-868f-850aca3ff848%2Fcourse%2FMicrosoft%2BDAT206x%2Fenroll%2F', True),
+        ('/enterprise/handle_consent_enrollment/efd91463-dc40-4882-aeb9-38202131e7b2/course', True),
+        ('%2Fenterprise%2Fhandle_consent_enrollment%2Fefd91463-dc40-4882-aeb9-38202131e7b2%2Fcourse', True),
     )
     @ddt.unpack
     def test_logout_enterprise_target(self, redirect_url, enterprise_target):


### PR DESCRIPTION
Improved enterprise target regex to include missing
`/enterprise/handle_consent_enrollment/{uuid}/course/ endpoint`.
ENT-2710