### PR TITLE
Django2 shopping_cart: temporary test fix

### DIFF
--- a/lms/djangoapps/shoppingcart/admin.py
+++ b/lms/djangoapps/shoppingcart/admin.py
@@ -33,7 +33,8 @@ class SoftDeleteCouponAdmin(admin.ModelAdmin):
 
     def get_actions(self, request):
         actions = super(SoftDeleteCouponAdmin, self).get_actions(request)
-        del actions['delete_selected']
+        if 'delete_selected' in actions:
+            del actions['delete_selected']
         return actions
 
     def really_delete_selected(self, request, queryset):


### PR DESCRIPTION
Ticket Desc [BOM-1492](https://openedx.atlassian.net/browse/BOM-1492)

```
def get_actions(self, request):
        actions = super(SoftDeleteCouponAdmin, self).get_actions(request)
>       del actions['delete_selected']
E       KeyError: 'delete_selected'
```
In django2.2 old approach for admin is not working. But this app is going to be remove so this fix is enough for passing tests.

Before del check key exists in list.

