### PR TITLE
Fixes `NoReverseMatch` exception.

### DIFF
--- a/lms/djangoapps/discussion/django_comment_client/utils.py
+++ b/lms/djangoapps/discussion/django_comment_client/utils.py
@@ -691,10 +691,9 @@ def permalink(content):
     else:
         course_id = content['course_id']
     if content['type'] == 'thread':
-        return reverse('discussion.views.single_thread',
-                       args=[course_id, content['commentable_id'], content['id']])
+        return reverse('single_thread', args=[course_id, content['commentable_id'], content['id']])
     else:
-        return reverse('discussion.views.single_thread',
+        return reverse('single_thread',
                        args=[course_id, content['commentable_id'], content['thread_id']]) + '#' + content['id']
 
 


### PR DESCRIPTION
Fix the exception for `NoReverseMatch`. 
```
django.urls.exceptions:NoReverseMatch: Reverse for 'discussion.views.single_thread' not found. 'discussion.views.single_thread' is not a valid view function or pattern name.
Traceback (most recent call last):
File "/edx/app/edxapp/edx-platform/manage.py", line 123, in <module>
File "/edx/app/edxapp/venvs/edxapp/lib/python3.5/site-packages/django/core/management/_init_.py", line 364, in execute_from_command_line
File "/edx/app/edxapp/venvs/edxapp/lib/python3.5/site-packages/django/core/management/_init_.py", line 356, in execute
File "/edx/app/edxapp/venvs/edxapp/lib/python3.5/site-packages/djcelery/management/commands/celery.py", line 21, in run_from_argv
File "/edx/app/edxapp/venvs/edxapp/lib/python3.5/site-packages/celery/bin/celery.py", line 793, in execute_from_commandline
File "/edx/app/edxapp/venvs/edxapp/lib/python3.5/site-packages/celery/bin/base.py", line 311, in execute_from_commandline
File "/edx/app/edxapp/venvs/edxapp/lib/python3.5/site-packages/celery/bin/celery.py", line 785, in handle_argv
File "/edx/app/edxapp/venvs/edxapp/lib/python3.5/site-packages/celery/bin/celery.py", line 717, in execute
File "/edx/app/edxapp/venvs/edxapp/lib/python3.5/site-packages/celery/bin/worker.py", line 179, in run_from_argv
File "/edx/app/edxapp/venvs/edxapp/lib/python3.5/site-packages/celery/bin/base.py", line 274, in _call_
File "/edx/app/edxapp/venvs/edxapp/lib/python3.5/site-packages/celery/bin/worker.py", line 212, in run
File "/edx/app/edxapp/venvs/edxapp/lib/python3.5/site-packages/celery/worker/_init_.py", line 206, in start
File "/edx/app/edxapp/venvs/edxapp/lib/python3.5/site-packages/celery/bootsteps.py", line 123, in start
File "/edx/app/edxapp/venvs/edxapp/lib/python3.5/site-packages/celery/bootsteps.py", line 374, in start
File "/edx/app/edxapp/venvs/edxapp/lib/python3.5/site-packages/celery/worker/consumer.py", line 280, in start
File "/edx/app/edxapp/venvs/edxapp/lib/python3.5/site-packages/celery/bootsteps.py", line 123, in start
File "/edx/app/edxapp/venvs/edxapp/lib/python3.5/site-packages/celery/worker/consumer.py", line 884, in start
File "/edx/app/edxapp/venvs/edxapp/lib/python3.5/site-packages/celery/worker/loops.py", line 76, in asynloop
File "/edx/app/edxapp/venvs/edxapp/lib/python3.5/site-packages/kombu/async/hub.py", line 340, in create_loop
File "/edx/app/edxapp/venvs/edxapp/lib/python3.5/site-packages/celery/concurrency/asynpool.py", line 420, in _event_process_exit
File "/edx/app/edxapp/venvs/edxapp/lib/python3.5/site-packages/billiard/pool.py", line 1260, in maintain_pool
File "/edx/app/edxapp/venvs/edxapp/lib/python3.5/site-packages/billiard/pool.py", line 1252, in _maintain_pool
File "/edx/app/edxapp/venvs/edxapp/lib/python3.5/site-packages/billiard/pool.py", line 1237, in _repopulate_pool
File "/edx/app/edxapp/venvs/edxapp/lib/python3.5/site-packages/celery/concurrency/asynpool.py", line 415, in _create_worker_process
File "/edx/app/edxapp/venvs/edxapp/lib/python3.5/site-packages/billiard/pool.py", line 1068, in _create_worker_process
File "/edx/app/edxapp/venvs/edxapp/lib/python3.5/site-packages/billiard/process.py", line 137, in start
File "/edx/app/edxapp/venvs/edxapp/lib/python3.5/site-packages/billiard/forking.py", line 105, in _init_
File "/edx/app/edxapp/venvs/edxapp/lib/python3.5/site-packages/billiard/process.py", line 292, in _bootstrap
File "/edx/app/edxapp/venvs/edxapp/lib/python3.5/site-packages/billiard/pool.py", line 295, in run
File "/edx/app/edxapp/venvs/edxapp/lib/python3.5/site-packages/billiard/pool.py", line 367, in workloop
File "/edx/app/edxapp/venvs/edxapp/lib/python3.5/site-packages/celery/app/trace.py", line 349, in _fast_trace_task
File "/edx/app/edxapp/venvs/edxapp/lib/python3.5/site-packages/celery/app/trace.py", line 240, in trace_task
File "/edx/app/edxapp/venvs/edxapp/lib/python3.5/site-packages/newrelic/hooks/application_celery.py", line 85, in wrapper
File "/edx/app/edxapp/venvs/edxapp/lib/python3.5/site-packages/celery/app/trace.py", line 438, in _protected_call_
File "/edx/app/edxapp/edx-platform/lms/djangoapps/discussion/tasks.py", line 71, in send_ace_message
File "/edx/app/edxapp/edx-platform/lms/djangoapps/discussion/tasks.py", line 167, in _build_message_context
File "/edx/app/edxapp/edx-platform/lms/djangoapps/discussion/tasks.py", line 181, in _get_thread_url
File "/edx/app/edxapp/edx-platform/lms/djangoapps/discussion/django_comment_client/utils.py", line 695, in permalink
File "/edx/app/edxapp/venvs/edxapp/src/django-wiki/wiki/models/_init_.py", line 91, in reverse
File "/edx/app/edxapp/venvs/edxapp/lib/python3.5/site-packages/newrelic/hooks/framework_django.py", line 642, in wrapper
File "/edx/app/edxapp/venvs/edxapp/lib/python3.5/site-packages/newrelic/hooks/framework_django.py", line 641, in execute
File "/edx/app/edxapp/venvs/edxapp/lib/python3.5/site-packages/newrelic/hooks/framework_django.py", line 642, in wrapper
File "/edx/app/edxapp/venvs/edxapp/lib/python3.5/site-packages/newrelic/hooks/framework_django.py", line 641, in execute
File "/edx/app/edxapp/venvs/edxapp/lib/python3.5/site-packages/django/urls/base.py", line 91, in reverse
File "/edx/app/edxapp/venvs/edxapp/lib/python3.5/site-packages/django/urls/resolvers.py", line 497, in _reverse_with_prefix
```
[PROD-1224](https://openedx.atlassian.net/browse/PROD-1224)