### PR TITLE
Limit the last_name field to 30 chars.

### DIFF
--- a/common/djangoapps/student/admin.py
+++ b/common/djangoapps/student/admin.py
@@ -320,6 +320,8 @@ class UserChangeForm(BaseUserChangeForm):
     Override the default UserChangeForm such that the password field
     does not contain a link to a 'change password' form.
     """
+    last_name = forms.CharField(max_length=30, required=False)
+
     def __init__(self, *args, **kwargs):
         super(UserChangeForm, self).__init__(*args, **kwargs)
 


### PR DESCRIPTION
We don't use this field in edx-platform since we rely on UserProfile
instead.  But we need to do this to prevent accidental incorrect use of
this field.  Django adds a migration between 1.11 and 2.2 to increase
the length of this field that we are opting to skip.  This change
enforces the old limit.