### PR TITLE
Fix invalid POST in test_module_render.py

### DIFF
--- a/lms/djangoapps/courseware/tests/test_module_render.py
+++ b/lms/djangoapps/courseware/tests/test_module_render.py
@@ -388,7 +388,7 @@ class ModuleRenderTestCase(SharedModuleStoreTestCase, LoginEnrollmentTestCase):
         self.assertEqual(200, response.status_code)
         self.assertEqual(json.loads(response.content.decode('utf-8')), {'success': True})
 
-        response = self.client.post(dispatch_url, {'position': None})
+        response = self.client.post(dispatch_url, {'position': ''})
         self.assertEqual(200, response.status_code)
         self.assertEqual(json.loads(response.content.decode('utf-8')), {'success': True})
 


### PR DESCRIPTION
This looks like the last failing unit test under Django 2.2.  One of a series of such failures resulting from Django no longer accepting `None` as POST data (since you can't really get it from a real request), most of which were already fixed by the Arbisoft team in the last few days.