### PR TITLE
[PROD-1404] - Remove unnecessary log.

### DIFF
--- a/lms/djangoapps/instructor_task/tasks_helper/grades.py
+++ b/lms/djangoapps/instructor_task/tasks_helper/grades.py
@@ -671,19 +671,6 @@ class CourseGradeReport(object):
             is_whitelisted,
             bulk_certs.certificates_by_user.get(user.id),
         )
-        TASK_LOG.info(
-            u'Student certificate eligibility: %s '
-            u'(user=%s, course_id=%s, grade_percent=%s letter_grade=%s gradecutoffs=%s, allow_certificate=%s, '
-            u'is_whitelisted=%s)',
-            certificate_info[0],
-            user,
-            context.course_id,
-            course_grade.percent,
-            course_grade.letter_grade,
-            context.course.grade_cutoffs,
-            user.profile.allow_certificate,
-            is_whitelisted,
-        )
         return certificate_info
 
     def _rows_for_users(self, context, users):


### PR DESCRIPTION
### [PROD-1404](https://openedx.atlassian.net/browse/PROD-1404)

Log cleanup PR (**193,879** logs generated in **24** hours)

Log for student certificate when processing CourseGradeReport. We don't need to log every single user's certificate info to Splunk, a high number of non-critical logs generated. 