### PR TITLE
Verification enabled for the software  secure

### DIFF
--- a/lms/djangoapps/verify_student/tasks.py
+++ b/lms/djangoapps/verify_student/tasks.py
@@ -114,11 +114,12 @@ def send_request_to_ss_for_user(self, user_verification_id, copy_id_photo_from):
     log.info('=>New Verification Task Received %r', user_verification.user.username)
     try:
         headers, body = user_verification.create_request(copy_id_photo_from)
+        # checkout PROD-1395 for detail why we are adding system certificate paths for verification.
         response = requests.post(
             settings.VERIFY_STUDENT["SOFTWARE_SECURE"]["API_URL"],
             headers=headers,
             data=simplejson.dumps(body, indent=2, sort_keys=True, ensure_ascii=False).encode('utf-8'),
-            verify=False
+            verify=settings.VERIFY_STUDENT["SOFTWARE_SECURE"]['CERT_VERIFICATION_PATH']
         )
         return {
             'response_ok': getattr(response, 'ok', False),

--- a/lms/djangoapps/verify_student/tests/test_models.py
+++ b/lms/djangoapps/verify_student/tests/test_models.py
@@ -43,6 +43,7 @@ iwIDAQAB
         "AWS_ACCESS_KEY": "FAKEACCESSKEY",
         "AWS_SECRET_KEY": "FAKESECRETKEY",
         "S3_BUCKET": "fake-bucket",
+        "CERT_VERIFICATION_PATH": False,
     },
     "DAYS_GOOD_FOR": 10,
 }

--- a/lms/djangoapps/verify_student/tests/test_views.py
+++ b/lms/djangoapps/verify_student/tests/test_views.py
@@ -1489,6 +1489,7 @@ class TestSubmitPhotosForVerification(MockS3BotoMixin, TestVerificationBase):
             "AWS_ACCESS_KEY": "c987c7efe35c403caa821f7328febfa1",
             "AWS_SECRET_KEY": "fc595fc657c04437bb23495d8fe64881",
             "S3_BUCKET": "test.example.com",
+            "CERT_VERIFICATION_PATH": False,
         },
         "DAYS_GOOD_FOR": 10,
     })


### PR DESCRIPTION
Software secure SSL chain is broken. Software secure server is only sending 1 certificate instead of 2 . Intermediate certificate is missing and that certificate also does not exist in the certificate authority(CA) list. So we are downloading the Intermediate certificate and adding it to systems CA list(https://github.com/edx/configuration/pull/5728).

Request by default uses it own CA list for verification. But we need to use system CA list that's why we are passing system CA list path to verify. 

For more detail PROD-1395


How to test ?

1. ssh to https://dos-883.sandbox.edx.org/
2. Go to python shell inside the lms-shell and execute the following command
         **requests.get(URL, verify='/etc/ssl/certs/ca-certificates.crt')**
