### PR TITLE
Factoring redirects out of check_course_access so it can be used with courseware_api

### DIFF
--- a/lms/djangoapps/courseware/access_response.py
+++ b/lms/djangoapps/courseware/access_response.py
@@ -216,17 +216,6 @@ class NoAllowedPartitionGroupsError(AccessError):
         super(NoAllowedPartitionGroupsError, self).__init__(error_code, developer_message, user_message)
 
 
-class SurveyRequiredAccessError(AccessError):
-    """
-    Access denied because the user has not completed a required survey
-    """
-    def __init__(self):
-        error_code = "survey_required"
-        developer_message = u"User must complete a survey"
-        user_message = _(u"You must complete a survey")
-        super(SurveyRequiredAccessError, self).__init__(error_code, developer_message, user_message)
-
-
 class EnrollmentRequiredAccessError(AccessError):
     """
     Access denied because the user must be enrolled in the course

--- a/lms/djangoapps/courseware/access_response.py
+++ b/lms/djangoapps/courseware/access_response.py
@@ -225,3 +225,14 @@ class EnrollmentRequiredAccessError(AccessError):
         developer_message = u"User must be enrolled in the course"
         user_message = _(u"You must be enrolled in the course")
         super(EnrollmentRequiredAccessError, self).__init__(error_code, developer_message, user_message)
+
+
+class AuthenticationRequiredAccessError(AccessError):
+    """
+    Access denied because the user must be authenticated to see it
+    """
+    def __init__(self):
+        error_code = "authentication_required"
+        developer_message = u"User must be authenticated to view the course"
+        user_message = _(u"You must be logged in to see this course")
+        super(AuthenticationRequiredAccessError, self).__init__(error_code, developer_message, user_message)

--- a/lms/djangoapps/courseware/access_response.py
+++ b/lms/djangoapps/courseware/access_response.py
@@ -214,3 +214,25 @@ class NoAllowedPartitionGroupsError(AccessError):
         error_code = "no_allowed_user_groups"
         developer_message = u"Group access for {} excludes all students".format(partition.name)
         super(NoAllowedPartitionGroupsError, self).__init__(error_code, developer_message, user_message)
+
+
+class SurveyRequiredAccessError(AccessError):
+    """
+    Access denied because the user has not completed a required survey
+    """
+    def __init__(self):
+        error_code = "survey_required"
+        developer_message = u"User must complete a survey"
+        user_message = _(u"You must complete a survey")
+        super(SurveyRequiredAccessError, self).__init__(error_code, developer_message, user_message)
+
+
+class EnrollmentRequiredAccessError(AccessError):
+    """
+    Access denied because the user must be enrolled in the course
+    """
+    def __init__(self):
+        error_code = "enrollment_required"
+        developer_message = u"User must be enrolled in the course"
+        user_message = _(u"You must be enrolled in the course")
+        super(EnrollmentRequiredAccessError, self).__init__(error_code, developer_message, user_message)

--- a/lms/djangoapps/courseware/access_utils.py
+++ b/lms/djangoapps/courseware/access_utils.py
@@ -114,8 +114,7 @@ def check_enrollment(user, course):
     Returns:
         AccessResponse: Either ACCESS_GRANTED or EnrollmentRequiredAccessError.
     """
-    if not check_public_access(course, [COURSE_VISIBILITY_PUBLIC]) and
-        CourseEnrollment.is_enrolled(user, course.id):
+    if not check_public_access(course, [COURSE_VISIBILITY_PUBLIC]) and CourseEnrollment.is_enrolled(user, course.id):
         return EnrollmentRequiredAccessError()
 
     return ACCESS_GRANTED

--- a/lms/djangoapps/courseware/access_utils.py
+++ b/lms/djangoapps/courseware/access_utils.py
@@ -13,7 +13,8 @@ from pytz import UTC
 from lms.djangoapps.courseware.access_response import (
     AccessResponse,
     StartDateError,
-    EnrollmentRequiredAccessError
+    EnrollmentRequiredAccessError,
+    AuthenticationRequiredAccessError,
 )
 from lms.djangoapps.courseware.masquerade import get_course_masquerade, is_masquerading_as_student
 from openedx.core.djangoapps.util.user_messages import PageLevelMessages
@@ -136,7 +137,7 @@ def check_authentication(user, course):
     if check_public_access(course, [COURSE_VISIBILITY_PUBLIC]):
         return ACCESS_GRANTED
 
-    return ACCESS_DENIED
+    return AuthenticationRequiredAccessError()
 
 
 def check_public_access(course, visibilities):

--- a/lms/djangoapps/courseware/access_utils.py
+++ b/lms/djangoapps/courseware/access_utils.py
@@ -20,7 +20,6 @@ from openedx.features.course_experience import (
 )
 from student.models import CourseEnrollment
 from student.roles import CourseBetaTesterRole
-from survey.utils import is_survey_required_and_unanswered
 from xmodule.util.xmodule_django import get_current_request_hostname
 DEBUG_ACCESS = False
 log = getLogger(__name__)
@@ -116,19 +115,6 @@ def check_enrollment(user, course):
     """
     if not check_public_access(course, [COURSE_VISIBILITY_PUBLIC]) and CourseEnrollment.is_enrolled(user, course.id):
         return EnrollmentRequiredAccessError()
-
-    return ACCESS_GRANTED
-
-
-def check_survey(user, course):
-    """
-    Check if the user must answer a survey before accessing a course
-
-    Returns:
-        AccessResponse: Either ACCESS_GRANTED or SurveyRequiredAccessError.
-    """
-    if is_survey_required_and_unanswered(user, course):
-        return SurveyRequiredAccessError()
 
     return ACCESS_GRANTED
 

--- a/lms/djangoapps/courseware/access_utils.py
+++ b/lms/djangoapps/courseware/access_utils.py
@@ -21,6 +21,8 @@ from openedx.features.course_experience import (
 from student.models import CourseEnrollment
 from student.roles import CourseBetaTesterRole
 from xmodule.util.xmodule_django import get_current_request_hostname
+from xmodule.course_module import COURSE_VISIBILITY_PUBLIC
+
 DEBUG_ACCESS = False
 log = getLogger(__name__)
 

--- a/lms/djangoapps/courseware/access_utils.py
+++ b/lms/djangoapps/courseware/access_utils.py
@@ -121,10 +121,10 @@ def check_enrollment(user, course):
     Returns:
         AccessResponse: Either ACCESS_GRANTED or EnrollmentRequiredAccessError.
     """
-    if CourseEnrollment.is_enrolled(user, course.id):
+    if check_public_access(course, [COURSE_VISIBILITY_PUBLIC]):
         return ACCESS_GRANTED
 
-    if check_public_access(course, [COURSE_VISIBILITY_PUBLIC]):
+    if CourseEnrollment.is_enrolled(user, course.id):
         return ACCESS_GRANTED
 
     return EnrollmentRequiredAccessError()

--- a/lms/djangoapps/courseware/access_utils.py
+++ b/lms/djangoapps/courseware/access_utils.py
@@ -112,6 +112,7 @@ def check_course_open_for_learner(user, course):
         return ACCESS_GRANTED
     return check_start_date(user, course.days_early_for_beta, course.start, course.id)
 
+
 def check_enrollment(user, course):
     """
     Check if the course requires a learner to be enrolled for access.

--- a/lms/djangoapps/courseware/access_utils.py
+++ b/lms/djangoapps/courseware/access_utils.py
@@ -131,6 +131,12 @@ def check_enrollment(user, course):
 
 
 def check_authentication(user, course):
+    """
+    Grants access if the user is authenticated, or if the course allows public access.
+
+    Returns:
+        AccessResponse: Either ACCESS_GRANTED or AuthenticationRequiredAccessError
+    """
     if user.is_authenticated:
         return ACCESS_GRANTED
 

--- a/lms/djangoapps/courseware/courses.py
+++ b/lms/djangoapps/courseware/courses.py
@@ -230,6 +230,10 @@ def check_course_access_with_redirect(course, user, action, check_if_enrolled=Fa
         if isinstance(access_response, EnrollmentRequiredAccessError):
             raise CourseAccessRedirect(reverse('about_course', args=[six.text_type(course.id)]))
 
+        # Redirect if user must be authenticated to view the content
+        if isinstance(access_response, AuthenticationRequiredAccessError):
+            raise CourseAccessRedirect(reverse('about_course', args=[six.text_type(course.id)]))
+
         # Redirect if the user must answer a survey before entering the course.
         if isinstance(access_response, SurveyRequiredAccessError):
             raise CourseAccessRedirect(reverse('course_survey', args=[six.text_type(course.id)]))

--- a/lms/djangoapps/courseware/courses.py
+++ b/lms/djangoapps/courseware/courses.py
@@ -46,7 +46,7 @@ from lms.djangoapps.courseware.model_data import FieldDataCache
 from lms.djangoapps.courseware.module_render import get_module
 from edxmako.shortcuts import render_to_string
 from lms.djangoapps.certificates import api as certs_api
-from lms.djangoapps.courseware.access_utils import check_enrollment, check_public_access,
+from lms.djangoapps.courseware.access_utils import check_enrollment, check_public_access
 from lms.djangoapps.courseware.courseware_access_exception import CoursewareAccessException
 from lms.djangoapps.courseware.exceptions import CourseAccessRedirect
 from openedx.core.djangoapps.content.course_overviews.models import CourseOverview

--- a/lms/djangoapps/courseware/courses.py
+++ b/lms/djangoapps/courseware/courses.py
@@ -27,9 +27,10 @@ import branding
 from course_modes.models import CourseMode
 from lms.djangoapps.courseware.access import has_access
 from lms.djangoapps.courseware.access_response import (
+    AuthenticationRequiredAccessError,
+    EnrollmentRequiredAccessError,
     MilestoneAccessError,
     StartDateError,
-    EnrollmentRequiredAccessError,
 )
 from lms.djangoapps.courseware.date_summary import (
     CertificateAvailableDate,

--- a/lms/djangoapps/courseware/courses.py
+++ b/lms/djangoapps/courseware/courses.py
@@ -186,7 +186,6 @@ def check_course_access(course, user, action, check_if_enrolled=False, check_sur
         # This access_response will be ACCESS_GRANTED
         return access_response
 
-
     # Allow staff full access to the course even if other checks fail
     nonstaff_access_response = _check_nonstaff_access()
     if not nonstaff_access_response:

--- a/lms/djangoapps/courseware/courses.py
+++ b/lms/djangoapps/courseware/courses.py
@@ -159,7 +159,7 @@ def check_course_access(course, user, action, check_if_enrolled=False, check_sur
     check_survey_complete: If true, additionally verifies that the user has completed the survey.
     """
     # Allow staff full access to the course even if not enrolled
-    staff_access_response = has_access(user, 'staff', course.id):
+    staff_access_response = has_access(user, 'staff', course.id)
     if staff_access_response:
         return staff_access_response
 

--- a/lms/djangoapps/courseware/courses.py
+++ b/lms/djangoapps/courseware/courses.py
@@ -149,6 +149,7 @@ def get_course_overview_with_access(user, action, course_key, check_if_enrolled=
     check_course_access_with_redirect(course_overview, user, action, check_if_enrolled)
     return course_overview
 
+
 def check_course_access(course, user, action, check_if_enrolled=False, check_survey_complete=True, check_if_authenticated=False):
     """
     Check that the user has the access to perform the specified action

--- a/lms/djangoapps/courseware/courses.py
+++ b/lms/djangoapps/courseware/courses.py
@@ -26,7 +26,12 @@ from six import text_type
 import branding
 from course_modes.models import CourseMode
 from lms.djangoapps.courseware.access import has_access
-from lms.djangoapps.courseware.access_response import MilestoneAccessError, StartDateError
+from lms.djangoapps.courseware.access_response import (
+    MilestoneAccessError,
+    StartDateError,
+    SurveyRequiredAccessError,
+    EnrollmentRequiredAccessError,
+)
 from lms.djangoapps.courseware.date_summary import (
     CertificateAvailableDate,
     CourseAssignmentDate,
@@ -42,6 +47,11 @@ from lms.djangoapps.courseware.model_data import FieldDataCache
 from lms.djangoapps.courseware.module_render import get_module
 from edxmako.shortcuts import render_to_string
 from lms.djangoapps.certificates import api as certs_api
+from lms.djangoapps.courseware.access_utils import (
+    check_survey,
+    check_enrollment,
+    check_public_access,
+)
 from lms.djangoapps.courseware.courseware_access_exception import CoursewareAccessException
 from lms.djangoapps.courseware.exceptions import CourseAccessRedirect
 from openedx.core.djangoapps.content.course_overviews.models import CourseOverview
@@ -118,7 +128,7 @@ def get_course_with_access(user, action, course_key, depth=0, check_if_enrolled=
       be plugged in as additional callback checks for different actions.
     """
     course = get_course_by_id(course_key, depth)
-    check_course_access(course, user, action, check_if_enrolled, check_survey_complete)
+    check_course_access_with_redirect(course, user, action, check_if_enrolled, check_survey_complete)
     return course
 
 
@@ -137,9 +147,8 @@ def get_course_overview_with_access(user, action, course_key, check_if_enrolled=
         course_overview = CourseOverview.get_from_id(course_key)
     except CourseOverview.DoesNotExist:
         raise Http404("Course not found.")
-    check_course_access(course_overview, user, action, check_if_enrolled)
+    check_course_access_with_redirect(course_overview, user, action, check_if_enrolled)
     return course_overview
-
 
 def check_course_access(course, user, action, check_if_enrolled=False, check_survey_complete=True):
     """
@@ -150,13 +159,42 @@ def check_course_access(course, user, action, check_if_enrolled=False, check_sur
     check_survey_complete: If true, additionally verifies that the user has completed the survey.
     """
     # Allow staff full access to the course even if not enrolled
-    if has_access(user, 'staff', course.id):
-        return
+    staff_access_response = has_access(user, 'staff', course.id):
+    if staff_access_response:
+        return staff_access_response
 
+    access_response = has_access(user, action, course, course.id)
+    if not access_response:
+        return access_response
+
+    if check_if_enrolled:
+        enrollment_access_response = check_enrollment(user, course.id)
+        if not enrollment_access_response:
+            return enrollment_access_response
+
+    # Redirect if the user must answer a survey before entering the course.
+    if check_survey_complete and action == 'load':
+        survey_access_response = check_survey(user, course)
+        if not survey_access_response:
+            return survey_access_response
+
+    # This access_response will be ACCESS_GRANTED
+    return access_response
+
+
+def check_course_access_with_redirect(course, user, action, check_if_enrolled=False, check_survey_complete=True):
+    """
+    Check that the user has the access to perform the specified action
+    on the course (CourseDescriptor|CourseOverview).
+
+    check_if_enrolled: If true, additionally verifies that the user is enrolled.
+    check_survey_complete: If true, additionally verifies that the user has completed the survey.
+    """
     request = get_current_request()
     check_content_start_date_for_masquerade_user(course.id, user, request, course.start)
 
-    access_response = has_access(user, action, course, course.id)
+    access_response = check_course_access(course, user, action, check_if_enrolled, check_survey_complete)
+
     if not access_response:
         # Redirect if StartDateError
         if isinstance(access_response, StartDateError):
@@ -183,19 +221,17 @@ def check_course_access(course, user, action, check_if_enrolled=False, check_sur
                 dashboard_url=reverse('dashboard'),
             ), access_response)
 
+        # Redirect if the user is not enrolled and must be to see content
+        if isinstance(access_response, EnrollmentRequiredAccessError):
+            raise CourseAccessRedirect(reverse('about_course', args=[six.text_type(course.id)]))
+
+        # Redirect if the user must answer a survey before entering the course.
+        if isinstance(access_response, SurveyRequiredAccessError):
+            raise CourseAccessRedirect(reverse('course_survey', args=[six.text_type(course.id)]))
+
         # Deliberately return a non-specific error message to avoid
         # leaking info about access control settings
         raise CoursewareAccessException(access_response)
-
-    if check_if_enrolled:
-        # If the user is not enrolled, redirect them to the about page
-        if not CourseEnrollment.is_enrolled(user, course.id):
-            raise CourseAccessRedirect(reverse('about_course', args=[six.text_type(course.id)]))
-
-    # Redirect if the user must answer a survey before entering the course.
-    if check_survey_complete and action == 'load':
-        if is_survey_required_and_unanswered(user, course):
-            raise CourseAccessRedirect(reverse('course_survey', args=[six.text_type(course.id)]))
 
 
 def can_self_enroll_in_course(course_key):
@@ -746,13 +782,3 @@ def get_course_chapter_ids(course_key):
         log.exception('Failed to retrieve course from modulestore.')
         return []
     return [six.text_type(chapter_key) for chapter_key in chapter_keys if chapter_key.block_type == 'chapter']
-
-
-def allow_public_access(course, visibilities):
-    """
-    This checks if the unenrolled access waffle flag for the course is set
-    and the course visibility matches any of the input visibilities.
-    """
-    unenrolled_access_flag = COURSE_ENABLE_UNENROLLED_ACCESS_FLAG.is_enabled(course.id)
-    allow_access = unenrolled_access_flag and course.course_visibility in visibilities
-    return allow_access

--- a/lms/djangoapps/courseware/courses.py
+++ b/lms/djangoapps/courseware/courses.py
@@ -163,7 +163,7 @@ def check_course_access(course, user, action, check_if_enrolled=False, check_sur
         return access_response
 
     if check_if_enrolled:
-        enrollment_access_response = check_enrollment(user, course.id)
+        enrollment_access_response = check_enrollment(user, course)
         if not enrollment_access_response:
             return enrollment_access_response
 

--- a/lms/djangoapps/courseware/courses.py
+++ b/lms/djangoapps/courseware/courses.py
@@ -29,7 +29,6 @@ from lms.djangoapps.courseware.access import has_access
 from lms.djangoapps.courseware.access_response import (
     MilestoneAccessError,
     StartDateError,
-    SurveyRequiredAccessError,
     EnrollmentRequiredAccessError,
 )
 from lms.djangoapps.courseware.date_summary import (
@@ -47,11 +46,7 @@ from lms.djangoapps.courseware.model_data import FieldDataCache
 from lms.djangoapps.courseware.module_render import get_module
 from edxmako.shortcuts import render_to_string
 from lms.djangoapps.certificates import api as certs_api
-from lms.djangoapps.courseware.access_utils import (
-    check_survey,
-    check_enrollment,
-    check_public_access,
-)
+from lms.djangoapps.courseware.access_utils import check_enrollment, check_public_access,
 from lms.djangoapps.courseware.courseware_access_exception import CoursewareAccessException
 from lms.djangoapps.courseware.exceptions import CourseAccessRedirect
 from openedx.core.djangoapps.content.course_overviews.models import CourseOverview
@@ -62,7 +57,7 @@ from openedx.features.course_duration_limits.access import AuditExpiredError
 from openedx.features.course_experience import COURSE_ENABLE_UNENROLLED_ACCESS_FLAG, RELATIVE_DATES_FLAG
 from static_replace import replace_static_urls
 from student.models import CourseEnrollment
-from survey.utils import is_survey_required_and_unanswered
+from survey.utils import SurveyRequiredAccessError, is_survey_required_and_unanswered
 from util.date_utils import strftime_localized
 from xmodule.modulestore.django import modulestore
 from xmodule.modulestore.exceptions import ItemNotFoundError
@@ -174,7 +169,7 @@ def check_course_access(course, user, action, check_if_enrolled=False, check_sur
 
     # Redirect if the user must answer a survey before entering the course.
     if check_survey_complete and action == 'load':
-        survey_access_response = check_survey(user, course)
+        survey_access_response = is_survey_required_and_unanswered(user, course)
         if not survey_access_response:
             return survey_access_response
 

--- a/lms/djangoapps/courseware/courses.py
+++ b/lms/djangoapps/courseware/courses.py
@@ -109,7 +109,7 @@ def get_course_by_id(course_key, depth=0):
         raise Http404(u"Course not found: {}.".format(six.text_type(course_key)))
 
 
-def get_course_with_access(user, action, course_key, depth=0, check_if_enrolled=False, check_survey_complete=True):
+def get_course_with_access(user, action, course_key, depth=0, check_if_enrolled=False, check_survey_complete=True, check_if_authenticated=False):
     """
     Given a course_key, look up the corresponding course descriptor,
     check that the user has the access to perform the specified action
@@ -128,7 +128,7 @@ def get_course_with_access(user, action, course_key, depth=0, check_if_enrolled=
       be plugged in as additional callback checks for different actions.
     """
     course = get_course_by_id(course_key, depth)
-    check_course_access_with_redirect(course, user, action, check_if_enrolled, check_survey_complete)
+    check_course_access_with_redirect(course, user, action, check_if_enrolled, check_survey_complete, check_if_authenticated)
     return course
 
 
@@ -188,7 +188,7 @@ def check_course_access(course, user, action, check_if_enrolled=False, check_sur
     return access_response
 
 
-def check_course_access_with_redirect(course, user, action, check_if_enrolled=False, check_survey_complete=True):
+def check_course_access_with_redirect(course, user, action, check_if_enrolled=False, check_survey_complete=True, check_if_authenticated=False):
     """
     Check that the user has the access to perform the specified action
     on the course (CourseDescriptor|CourseOverview).
@@ -199,7 +199,7 @@ def check_course_access_with_redirect(course, user, action, check_if_enrolled=Fa
     request = get_current_request()
     check_content_start_date_for_masquerade_user(course.id, user, request, course.start)
 
-    access_response = check_course_access(course, user, action, check_if_enrolled, check_survey_complete)
+    access_response = check_course_access(course, user, action, check_if_enrolled, check_survey_complete, check_if_authenticated)
 
     if not access_response:
         # Redirect if StartDateError

--- a/lms/djangoapps/courseware/courses.py
+++ b/lms/djangoapps/courseware/courses.py
@@ -50,7 +50,6 @@ from lms.djangoapps.certificates import api as certs_api
 from lms.djangoapps.courseware.access_utils import (
     check_authentication,
     check_enrollment,
-    check_public_access
 )
 from lms.djangoapps.courseware.courseware_access_exception import CoursewareAccessException
 from lms.djangoapps.courseware.exceptions import CourseAccessRedirect
@@ -238,15 +237,15 @@ def check_course_access_with_redirect(course, user, action, check_if_enrolled=Fa
 
         # Redirect if the user is not enrolled and must be to see content
         if isinstance(access_response, EnrollmentRequiredAccessError):
-            raise CourseAccessRedirect(reverse('about_course', args=[six.text_type(course.id)]))
+            raise CourseAccessRedirect(reverse('about_course', args=[str(course.id)]))
 
         # Redirect if user must be authenticated to view the content
         if isinstance(access_response, AuthenticationRequiredAccessError):
-            raise CourseAccessRedirect(reverse('about_course', args=[six.text_type(course.id)]))
+            raise CourseAccessRedirect(reverse('about_course', args=[str(course.id)]))
 
         # Redirect if the user must answer a survey before entering the course.
         if isinstance(access_response, SurveyRequiredAccessError):
-            raise CourseAccessRedirect(reverse('course_survey', args=[six.text_type(course.id)]))
+            raise CourseAccessRedirect(reverse('course_survey', args=[str(course.id)]))
 
         # Deliberately return a non-specific error message to avoid
         # leaking info about access control settings

--- a/lms/djangoapps/courseware/views/index.py
+++ b/lms/djangoapps/courseware/views/index.py
@@ -162,10 +162,11 @@ class CoursewareIndex(View):
                 self.is_staff = has_access(request.user, 'staff', self.course)
 
                 # There's only one situation where we want to show the public view
-                if (not self.is_staff and
-                    self.enable_unenrolled_access and
-                    self.course.course_visibility == COURSE_VISIBILITY_PUBLIC and
-                    not CourseEnrollment.is_enrolled(request.user, self.course_key)
+                if (
+                        not self.is_staff and
+                        self.enable_unenrolled_access and
+                        self.course.course_visibility == COURSE_VISIBILITY_PUBLIC and
+                        not CourseEnrollment.is_enrolled(request.user, self.course_key)
                 ):
                     self.view = PUBLIC_VIEW
 

--- a/lms/djangoapps/courseware/views/index.py
+++ b/lms/djangoapps/courseware/views/index.py
@@ -7,7 +7,6 @@ View for Courseware Index
 
 import logging
 
-from datetime import timedelta
 import six
 import six.moves.urllib as urllib  # pylint: disable=import-error
 import six.moves.urllib.error  # pylint: disable=import-error
@@ -20,7 +19,6 @@ from django.db import transaction
 from django.http import Http404
 from django.template.context_processors import csrf
 from django.urls import reverse
-from django.utils import timezone
 from django.utils.decorators import method_decorator
 from django.utils.functional import cached_property
 from django.utils.translation import ugettext as _
@@ -32,7 +30,6 @@ from opaque_keys import InvalidKeyError
 from opaque_keys.edx.keys import CourseKey, UsageKey
 from web_fragments.fragment import Fragment
 
-from course_modes.models import CourseMode
 from edxmako.shortcuts import render_to_response, render_to_string
 from lms.djangoapps.courseware.exceptions import CourseAccessRedirect, Redirect
 from lms.djangoapps.experiments.utils import get_experiment_user_metadata_context
@@ -52,7 +49,6 @@ from openedx.features.course_experience import (
     RELATIVE_DATES_FLAG,
 )
 from openedx.features.course_experience.urls import COURSE_HOME_VIEW_NAME
-from openedx.features.course_experience.utils import get_course_outline_block_tree
 from openedx.features.course_experience.utils import reset_deadlines_banner_should_display
 from openedx.features.course_experience.views.course_sock import CourseSockFragmentView
 from openedx.features.enterprise_support.api import data_sharing_consent_required

--- a/lms/djangoapps/courseware/views/index.py
+++ b/lms/djangoapps/courseware/views/index.py
@@ -65,9 +65,9 @@ from xmodule.modulestore.django import modulestore
 from xmodule.x_module import PUBLIC_VIEW, STUDENT_VIEW
 
 from ..access import has_access
+from ..access_utils import check_public_access
 from ..courses import (
-    allow_public_access,
-    check_course_access,
+    check_course_access_with_redirect,
     get_course_with_access,
     get_current_child,
     get_studio_url
@@ -163,7 +163,7 @@ class CoursewareIndex(View):
                 if self.enable_unenrolled_access:
                     # Check if the user is considered enrolled (i.e. is an enrolled learner or staff).
                     try:
-                        check_course_access(
+                        check_course_access_with_redirect(
                             self.course, request.user, 'load', check_if_enrolled=True,
                         )
                     except CourseAccessRedirect as exception:
@@ -250,7 +250,7 @@ class CoursewareIndex(View):
                 'email_opt_in': False,
             })
 
-            allow_anonymous = allow_public_access(self.course, [COURSE_VISIBILITY_PUBLIC])
+            allow_anonymous = check_public_access(self.course, [COURSE_VISIBILITY_PUBLIC])
 
             if not allow_anonymous:
                 PageLevelMessages.register_warning_message(
@@ -462,7 +462,7 @@ class CoursewareIndex(View):
         )
         staff_access = self.is_staff
 
-        allow_anonymous = allow_public_access(self.course, [COURSE_VISIBILITY_PUBLIC])
+        allow_anonymous = check_public_access(self.course, [COURSE_VISIBILITY_PUBLIC])
         display_reset_dates_banner = False
         if not allow_anonymous and RELATIVE_DATES_FLAG.is_enabled(self.course.id):
             display_reset_dates_banner = reset_deadlines_banner_should_display(self.course_key, request)

--- a/lms/djangoapps/courseware/views/views.py
+++ b/lms/djangoapps/courseware/views/views.py
@@ -82,7 +82,7 @@ from lms.djangoapps.ccx.custom_exception import CCXLocatorValidationException
 from lms.djangoapps.certificates import api as certs_api
 from lms.djangoapps.certificates.models import CertificateStatuses
 from lms.djangoapps.commerce.utils import EcommerceService
-from lms.djangoapps.courseware.courses import allow_public_access
+from lms.djangoapps.courseware.access_utils import check_public_access
 from lms.djangoapps.courseware.exceptions import CourseAccessRedirect, Redirect
 from lms.djangoapps.experiments.utils import get_experiment_user_metadata_context
 from lms.djangoapps.grades.api import CourseGradeFactory
@@ -620,7 +620,7 @@ class CourseTabView(EdxFragmentView):
         """
         Register messages to be shown to the user if they have limited access.
         """
-        allow_anonymous = allow_public_access(course, [COURSE_VISIBILITY_PUBLIC])
+        allow_anonymous = check_public_access(course, [COURSE_VISIBILITY_PUBLIC])
 
         if request.user.is_anonymous and not allow_anonymous:
             if CourseTabView.course_open_for_learner_enrollment(course):
@@ -981,7 +981,7 @@ def course_about(request, course_id):
 
         sidebar_html_enabled = course_experience_waffle().is_enabled(ENABLE_COURSE_ABOUT_SIDEBAR_HTML)
 
-        allow_anonymous = allow_public_access(course, [COURSE_VISIBILITY_PUBLIC, COURSE_VISIBILITY_PUBLIC_OUTLINE])
+        allow_anonymous = check_public_access(course, [COURSE_VISIBILITY_PUBLIC, COURSE_VISIBILITY_PUBLIC_OUTLINE])
 
         # This local import is due to the circularity of lms and openedx references.
         # This may be resolved by using stevedore to allow web fragments to be used

--- a/lms/djangoapps/survey/tests/test_utils.py
+++ b/lms/djangoapps/survey/tests/test_utils.py
@@ -9,7 +9,7 @@ from django.contrib.auth.models import User
 from django.test.client import Client
 
 from survey.models import SurveyForm
-from survey.utils import is_survey_required_and_unanswered, is_survey_required_for_course
+from survey.utils import check_survey_required_and_unanswered, is_survey_required_for_course
 from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
 from xmodule.modulestore.tests.factories import CourseFactory
 
@@ -91,28 +91,28 @@ class SurveyModelsTests(ModuleStoreTestCase):
         """
         Assert that a new course which has a required survey but user has not answered it yet
         """
-        self.assertTrue(is_survey_required_and_unanswered(self.student, self.course))
+        self.assertFalse(check_survey_required_and_unanswered(self.student, self.course))
 
         temp_course = CourseFactory.create(
             course_survey_required=False
         )
-        self.assertFalse(is_survey_required_and_unanswered(self.student, temp_course))
+        self.assertTrue(check_survey_required_and_unanswered(self.student, temp_course))
 
         temp_course = CourseFactory.create(
             course_survey_required=True,
             course_survey_name="NonExisting"
         )
-        self.assertFalse(is_survey_required_and_unanswered(self.student, temp_course))
+        self.assertTrue(check_survey_required_and_unanswered(self.student, temp_course))
 
     def test_user_has_answered_required_survey(self):
         """
         Assert that a new course which has a required survey and user has answers for it
         """
         self.survey.save_user_answers(self.student, self.student_answers, None)
-        self.assertFalse(is_survey_required_and_unanswered(self.student, self.course))
+        self.assertTrue(check_survey_required_and_unanswered(self.student, self.course))
 
     def test_staff_must_answer_survey(self):
         """
         Assert that someone with staff level permissions does not have to answer the survey
         """
-        self.assertFalse(is_survey_required_and_unanswered(self.staff, self.course))
+        self.assertTrue(check_survey_required_and_unanswered(self.staff, self.course))

--- a/lms/djangoapps/survey/utils.py
+++ b/lms/djangoapps/survey/utils.py
@@ -4,7 +4,8 @@ Utilities for determining whether or not a survey needs to be completed.
 
 
 from lms.djangoapps.courseware.access import has_access
-from lms.djangoapps.courseware.access_response import AccessError, ACCESS_GRANTED
+from lms.djangoapps.courseware.access_response import AccessError
+from lms.djangoapps.courseware.access_utils import ACCESS_GRANTED
 from survey.models import SurveyAnswer, SurveyForm
 
 

--- a/lms/djangoapps/survey/utils.py
+++ b/lms/djangoapps/survey/utils.py
@@ -4,7 +4,19 @@ Utilities for determining whether or not a survey needs to be completed.
 
 
 from lms.djangoapps.courseware.access import has_access
+from lms.djangoapps.courseware.access_response import AccessError, ACCESS_GRANTED
 from survey.models import SurveyAnswer, SurveyForm
+
+
+class SurveyRequiredAccessError(AccessError):
+    """
+    Access denied because the user has not completed a required survey
+    """
+    def __init__(self):
+        error_code = "survey_required"
+        developer_message = u"User must complete a survey"
+        user_message = _(u"You must complete a survey")
+        super(SurveyRequiredAccessError, self).__init__(error_code, developer_message, user_message)
 
 
 def is_survey_required_for_course(course_descriptor):
@@ -14,7 +26,7 @@ def is_survey_required_for_course(course_descriptor):
 
     # Check to see that the survey is required in the CourseDescriptor.
     if not getattr(course_descriptor, 'course_survey_required', False):
-        return False
+        return SurveyRequiredAccessError()
 
     # Check that the specified Survey for the course exists.
     return SurveyForm.get(course_descriptor.course_survey_name, throw_if_not_found=False)
@@ -22,23 +34,26 @@ def is_survey_required_for_course(course_descriptor):
 
 def is_survey_required_and_unanswered(user, course_descriptor):
     """
-    Returns whether a user is required to answer the survey and has yet to do so.
+    Checks whether a user is required to answer the survey and has yet to do so.
+
+    Returns:
+        AccessResponse: Either ACCESS_GRANTED or SurveyRequiredAccessError.
     """
 
     if not is_survey_required_for_course(course_descriptor):
-        return False
+        return SurveyRequiredAccessError()
 
     # anonymous users do not need to answer the survey
     if user.is_anonymous:
-        return False
+        return SurveyRequiredAccessError()
 
     # course staff do not need to answer survey
     has_staff_access = has_access(user, 'staff', course_descriptor)
     if has_staff_access:
-        return False
+        return SurveyRequiredAccessError()
 
     # survey is required and it exists, let's see if user has answered the survey
     survey = SurveyForm.get(course_descriptor.course_survey_name)
     answered_survey = SurveyAnswer.do_survey_answers_exist(survey, user)
     if not answered_survey:
-        return True
+        return ACCESS_GRANTED

--- a/openedx/core/djangoapps/courseware_api/serializers.py
+++ b/openedx/core/djangoapps/courseware_api/serializers.py
@@ -88,12 +88,8 @@ class CourseInfoSerializer(serializers.Serializer):  # pylint: disable=abstract-
     verified_mode = serializers.SerializerMethodField()
     show_calculator = serializers.BooleanField()
     is_staff = serializers.BooleanField()
-    can_load_courseware = serializers.BooleanField()
+    can_load_courseware = serializers.DictField()
     notes = serializers.SerializerMethodField()
-
-    # TODO: TNL-7053 Legacy: Delete these two once ready to contract
-    user_has_access = serializers.BooleanField()
-    user_has_staff_access = serializers.BooleanField()
 
     def __init__(self, *args, **kwargs):
         """

--- a/openedx/core/djangoapps/courseware_api/tests/test_views.py
+++ b/openedx/core/djangoapps/courseware_api/tests/test_views.py
@@ -87,7 +87,7 @@ class CourseApiTestViews(BaseCoursewareTests):
                 assert enrollment['is_active']
                 assert len(response.data['tabs']) == 4
             elif enable_anonymous and not logged_in:
-                check_public_access.assert_called_once()
+                check_public_access.assert_called() # multiple checks use this handler
                 assert response.data['enrollment']['mode'] is None
                 assert response.data['user_has_access']
             else:

--- a/openedx/core/djangoapps/courseware_api/tests/test_views.py
+++ b/openedx/core/djangoapps/courseware_api/tests/test_views.py
@@ -74,7 +74,7 @@ class CourseApiTestViews(BaseCoursewareTests):
     def test_course_metadata(self, logged_in, enrollment_mode, enable_anonymous):
         check_public_access = mock.Mock()
         check_public_access.return_value = enable_anonymous
-        with mock.patch('openedx.core.djangoapps.courseware.access_utils.check_public_access', check_public_access):
+        with mock.patch('lms.djangoapps.courseware.access_utils.check_public_access', check_public_access):
             if not logged_in:
                 self.client.logout()
             if enrollment_mode:

--- a/openedx/core/djangoapps/courseware_api/tests/test_views.py
+++ b/openedx/core/djangoapps/courseware_api/tests/test_views.py
@@ -87,7 +87,8 @@ class CourseApiTestViews(BaseCoursewareTests):
                 assert enrollment['is_active']
                 assert len(response.data['tabs']) == 4
             elif enable_anonymous and not logged_in:
-                check_public_access.assert_called() # multiple checks use this handler
+                # multiple checks use this handler
+                check_public_access.assert_called()
                 assert response.data['enrollment']['mode'] is None
                 assert response.data['user_has_access']
             else:

--- a/openedx/core/djangoapps/courseware_api/tests/test_views.py
+++ b/openedx/core/djangoapps/courseware_api/tests/test_views.py
@@ -90,9 +90,9 @@ class CourseApiTestViews(BaseCoursewareTests):
                 # multiple checks use this handler
                 check_public_access.assert_called()
                 assert response.data['enrollment']['mode'] is None
-                assert response.data['user_has_access']
+                assert response.data['can_load_courseware']['has_access']
             else:
-                assert not response.data['user_has_access']
+                assert not response.data['can_load_courseware']['has_access']
 
 
 class SequenceApiTestViews(BaseCoursewareTests):

--- a/openedx/core/djangoapps/courseware_api/views.py
+++ b/openedx/core/djangoapps/courseware_api/views.py
@@ -61,7 +61,8 @@ class CoursewareInformation(RetrieveAPIView):
         * enrollment: Enrollment status of authenticated user
             * mode: `audit`, `verified`, etc
             * is_active: boolean
-        * user_has_access: Whether the user can view the course
+        * can_load_course: Whether the user can view the course (AccessResponse object)
+        * is_staff: Whether the user has staff access to the course
 
     **Parameters:**
 

--- a/openedx/core/djangoapps/courseware_api/views.py
+++ b/openedx/core/djangoapps/courseware_api/views.py
@@ -103,7 +103,7 @@ class CoursewareInformation(RetrieveAPIView):
         overview.enrollment = {'mode': mode, 'is_active': is_active}
 
         overview.is_staff = has_access(self.request.user, 'staff', overview).has_access
-        overview.can_load_courseware = check_course_access(overview, self.request.user, 'load', check_if_enrolled=True).has_access
+        overview.can_load_courseware = check_course_access(overview, self.request.user, 'load', check_if_enrolled=True, check_survey_complete=False, check_if_authenticated=True).has_access
         # TODO: If can_load_courseware is false add error codes to an error messages object
 
         # TODO: TNL-7053 Legacy: Delete these two once ready to contract

--- a/openedx/core/djangoapps/courseware_api/views.py
+++ b/openedx/core/djangoapps/courseware_api/views.py
@@ -103,12 +103,14 @@ class CoursewareInformation(RetrieveAPIView):
         overview.enrollment = {'mode': mode, 'is_active': is_active}
 
         overview.is_staff = has_access(self.request.user, 'staff', overview).has_access
-        overview.can_load_courseware = check_course_access(overview, self.request.user, 'load', check_if_enrolled=True, check_survey_complete=False, check_if_authenticated=True).has_access
-        # TODO: If can_load_courseware is false add error codes to an error messages object
-
-        # TODO: TNL-7053 Legacy: Delete these two once ready to contract
-        overview.user_has_access = overview.can_load_courseware
-        overview.user_has_staff_access = overview.is_staff
+        overview.can_load_courseware = check_course_access(
+            overview,
+            self.request.user,
+            'load',
+            check_if_enrolled=True,
+            check_survey_complete=False,
+            check_if_authenticated=True,
+        ).to_json()
 
         return overview
 

--- a/openedx/features/course_experience/views/course_home_messages.py
+++ b/openedx/features/course_experience/views/course_home_messages.py
@@ -25,7 +25,7 @@ from lms.djangoapps.course_goals.api import (
     valid_course_goals_ordered
 )
 from lms.djangoapps.course_goals.models import GOAL_KEY_CHOICES
-from lms.djangoapps.courseware.courses import allow_public_access
+from lms.djangoapps.courseware.access_utils import check_public_access
 from openedx.core.djangoapps.plugin_api.views import EdxFragmentView
 from openedx.core.djangolib.markup import HTML, Text
 from openedx.features.course_experience import CourseHomeMessages
@@ -111,7 +111,7 @@ def _register_course_home_messages(request, course, user_access, course_start_da
     """
     Register messages to be shown in the course home content page.
     """
-    allow_anonymous = allow_public_access(course, [COURSE_VISIBILITY_PUBLIC])
+    allow_anonymous = check_public_access(course, [COURSE_VISIBILITY_PUBLIC])
 
     if user_access['is_anonymous'] and not allow_anonymous:
         sign_in_or_register_text = (_(u'{sign_in_link} or {register_link} and then enroll in this course.')


### PR DESCRIPTION
TNL-7053

The courseware_api view will use check_course_access - which now returns AccessResponse objects, and all other uses of check_course_access will now use check_course_access_with_redirect, which is a drop-in replacement for the original check_course_access implementation.

We also added a few new helpers to access_utils:
- check_public_access is a replacement for allow_public_access, which now returns AccessResponse objects
- check_enrollment checks if the learner is enrolled, and uses check_public_access to account for COURSE_ENABLE_UNENROLLED_ACCESS_FLAG
- check_survey checks whether there is a required survey that the learner must complete prior to accessing the course.

There are two new kinds of AccessError subclasses:
- SurveyRequiredAccessError
- EnrollmentRequiredAccessError