### PR TITLE
changed verification email type to html

### DIFF
--- a/lms/djangoapps/verify_student/tasks.py
+++ b/lms/djangoapps/verify_student/tasks.py
@@ -8,8 +8,7 @@ from smtplib import SMTPException
 
 from celery import task
 from django.conf import settings
-from django.core.mail import send_mail
-
+from django.core.mail import EmailMessage
 from edxmako.shortcuts import render_to_string
 from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
 
@@ -31,12 +30,8 @@ def send_verification_status_email(context):
     dest_addr = context.get('email')
 
     try:
-        send_mail(
-            subject,
-            message,
-            from_addr,
-            [dest_addr],
-            fail_silently=False
-        )
+        msg = EmailMessage(subject, message, from_addr, [dest_addr])
+        msg.content_subtype = 'html'
+        msg.send(fail_silently=False)
     except SMTPException:
         log.warning(u"Failure in sending verification status e-mail to %s", dest_addr)

--- a/lms/djangoapps/verify_student/tests/test_views.py
+++ b/lms/djangoapps/verify_student/tests/test_views.py
@@ -1779,6 +1779,7 @@ class TestPhotoVerificationResultsCallback(ModuleStoreTestCase):
         self.assertIsNone(old_verification.expiry_email_date)
         self.assertEqual(response.content.decode('utf-8'), 'OK!')
         self.assertEqual(len(mail.outbox), 1)
+        self.assertEqual(mail.outbox[0].content_subtype, 'html')
 
     @patch(
         'lms.djangoapps.verify_student.ssencrypt.has_valid_signature',
@@ -1813,6 +1814,7 @@ class TestPhotoVerificationResultsCallback(ModuleStoreTestCase):
         self.assertEqual(attempt.expiry_date.date(), expiry_date.date())
         self.assertEqual(response.content.decode('utf-8'), 'OK!')
         self.assertEqual(len(mail.outbox), 1)
+        self.assertEqual(mail.outbox[0].content_subtype, 'html')
 
     @patch(
         'lms.djangoapps.verify_student.ssencrypt.has_valid_signature',
@@ -1844,6 +1846,7 @@ class TestPhotoVerificationResultsCallback(ModuleStoreTestCase):
         self.assertEqual(attempt.error_msg, u'[{"photoIdReasons": ["Not provided"]}]')
         self.assertEqual(response.content.decode('utf-8'), 'OK!')
         self.assertEqual(len(mail.outbox), 1)
+        self.assertEqual(mail.outbox[0].content_subtype, 'html')
 
     @patch(
         'lms.djangoapps.verify_student.ssencrypt.has_valid_signature',


### PR DESCRIPTION
[PROD-1424](https://openedx.atlassian.net/browse/PROD-1424)

This PR fixes the issue in which HTML in.` verification failed email` was not rendering properly and HTML tags were visible in email content. 