### PR TITLE
[PROD-1404] - fix getargspec() DeprecationWarning for inspect to cleanup logs.

### DIFF
--- a/common/lib/xmodule/xmodule/graders.py
+++ b/common/lib/xmodule/xmodule/graders.py
@@ -151,7 +151,7 @@ def invalid_args(func, argdict):
     Given a function and a dictionary of arguments, returns a set of arguments
     from argdict that aren't accepted by func
     """
-    args, _, keywords, _ = inspect.getargspec(func)
+    args, _, keywords, _, _, _, _ = inspect.getfullargspec(func)
     if keywords:
         return set()  # All accepted
     return set(argdict) - set(args)


### PR DESCRIPTION
### [PROD-1404](https://openedx.atlassian.net/browse/PROD-1404)

Log cleanup PR (**66,326** logs generated in **24** hours)

`DeprecationWarning: inspect.getargspec() is deprecated, use inspect.signature() instead`

Using **inspect.getfullargspec** as per documentation https://docs.python.org/3/library/inspect.html#inspect.getfullargspec