### PR TITLE
[PROD-1404] - handle DeprecationWarning for usage_key.course_key for logs cleanup.

### DIFF
--- a/lms/djangoapps/courseware/user_state_client.py
+++ b/lms/djangoapps/courseware/user_state_client.py
@@ -247,7 +247,7 @@ class DjangoXBlockUserStateClient(XBlockUserStateClient):
             try:
                 student_module, created = StudentModule.objects.get_or_create(
                     student=user,
-                    course_id=usage_key.course_key,
+                    course_id=usage_key.context_key,
                     module_state_key=usage_key,
                     defaults={
                         'state': json.dumps(state),
@@ -260,7 +260,7 @@ class DjangoXBlockUserStateClient(XBlockUserStateClient):
                 # process. This seems to happen frequently, and ignoring it is the
                 # best course of action for now
                 log.warning(u"set_many: IntegrityError for student {} - course_id {} - usage key {}".format(
-                    user, repr(six.text_type(usage_key.course_key)), usage_key
+                    user, repr(six.text_type(usage_key.context_key)), usage_key
                 ))
                 return
 
@@ -283,7 +283,7 @@ class DjangoXBlockUserStateClient(XBlockUserStateClient):
                     # The UPDATE above failed. Log information - but ignore the error.
                     # See https://openedx.atlassian.net/browse/TNL-5365
                     log.warning(u"set_many: IntegrityError for student {} - course_id {} - usage key {}".format(
-                        user, repr(six.text_type(usage_key.course_key)), usage_key
+                        user, repr(six.text_type(usage_key.context_key)), usage_key
                     ))
                     log.warning(u"set_many: All {} block keys: {}".format(
                         len(block_keys_to_state), list(block_keys_to_state.keys())


### PR DESCRIPTION
### [PROD-1404](https://openedx.atlassian.net/browse/PROD-1404)

Log cleanup PR (**65,711** logs generated in **24** hours)

`DeprecationWarning: Use .context_key instead of .course_key`
