### PR TITLE
Reword photo verification instrutions

### DIFF
--- a/lms/templates/verify_student/face_photo_step.underscore
+++ b/lms/templates/verify_student/face_photo_step.underscore
@@ -3,12 +3,12 @@
     <div class="requirements">
         <h2 class="title"><%- gettext( "What You Need for Verification" ) %></h2>
         <div class="requirement">
-            <h3 class="title"><%- gettext( "Webcam" ) %></h3>
-            <p class="copy"><%- gettext( "You need a computer or cell phone that has a webcam. When you receive a browser prompt, make sure that you allow access to the camera." ) %></p>
+            <h3 class="title"><%- gettext( "Device with Camera" ) %></h3>
+            <p class="copy"><%- gettext( "You need a device that has a webcam. If you receive a browser prompt for access to your camera, please make sure to click 'Allow'." ) %></p>
         </div>
         <div class="requirement">
             <h3 class="title"><%- gettext( "Photo Identification" ) %></h3>
-            <p class="copy"><%- gettext( "You need a driver's license, passport, or other government-issued ID that has your name and photo." ) %></p>
+            <p class="copy"><%- gettext( "You need a valid ID that contains your full name and photo." ) %></p>
         </div>
     </div>
 
@@ -28,10 +28,9 @@
             <ul class="list-help">
               <li class="help-item"><%- gettext( "Your face is well-lit." ) %></li>
               <li class="help-item"><%- gettext( "Your entire face fits inside the frame." ) %></li>
-              <li class="help-item"><%- gettext( "The photo of your face matches the photo on your ID." ) %></li>
             </ul>
 
-            <p class="copy-extra"><%=  HtmlUtils.interpolateHtml( gettext( "To use the current photo, select the Take Photo button {icon}. To take another photo, select the Retake Photo button {icon}." ), { icon: HtmlUtils.HTML('<span class="example">(<span class="icon fa fa-camera" aria-hidden="true"></span><span class="sr">icon</span>)</span>') } ) %></p>
+            <p class="copy-extra"><%=  HtmlUtils.interpolateHtml( gettext( "To take the photo of your face, click on the camera button {icon}. If you need to try again, click 'Retake Photo'." ), { icon: HtmlUtils.HTML('<span class="example">(<span class="icon fa fa-camera" aria-hidden="true"></span><span class="sr">icon</span>)</span>') } ) %></p>
           </div>
         </div>
 
@@ -42,7 +41,7 @@
               <dt class="faq-question">
                 <%- _.sprintf( gettext( "Why does %(platformName)s need my photo?" ), { platformName: platformName } ) %>
               </dt>
-              <dd class="faq-answer"><%- gettext( "As part of the verification process, you take a photo of both your face and a government-issued photo ID. Our authorization service confirms your identity by comparing the photo you take with the photo on your ID." ) %></dd>
+              <dd class="faq-answer"><%- gettext( "We use your verification photos to confirm your identity and ensure the validity of your certificate." ) %></dd>
               <dt class="faq-question">
                 <%- _.sprintf( gettext( "What does %(platformName)s do with this photo?" ), { platformName: platformName } ) %>
               </dt>

--- a/lms/templates/verify_student/face_photo_step.underscore
+++ b/lms/templates/verify_student/face_photo_step.underscore
@@ -46,7 +46,7 @@
                 <%- _.sprintf( gettext( "What does %(platformName)s do with this photo?" ), { platformName: platformName } ) %>
               </dt>
               <dd class="faq-answer">
-                <%- _.sprintf( gettext( "We use the highest levels of security available to encrypt your photo and send it to our authorization service for review. Your photo and information are not saved or visible anywhere on %(platformName)s after the verification process is complete." ), { platformName: platformName } ) %>
+                <%- _.sprintf( gettext( "We securely encrypt your photo and send it to our authorization service for review. Your photo and information are not saved or visible anywhere on %(platformName)s after the verification process is complete." ), { platformName: platformName } ) %>
               </dd>
               <dt class="faq-question">
                 <%- gettext( "What if I can't see the camera image, or if I can't see my photo do determine which side is visible?" ) %>

--- a/lms/templates/verify_student/id_photo_step.underscore
+++ b/lms/templates/verify_student/id_photo_step.underscore
@@ -41,7 +41,7 @@
                 <%- _.sprintf( gettext( "What does %(platformName)s do with this photo?" ), { platformName: platformName } ) %>
               </dt>
               <dd class="faq-answer">
-                <%- _.sprintf( gettext( "We use the highest levels of security available to encrypt your photo and send it to our authorization service for review. Your photo and information are not saved or visible anywhere on %(platformName)s after the verification process is complete." ), { platformName: platformName } ) %>
+                <%- _.sprintf( gettext( "We securely encrypt your photo and send it to our authorization service for review. Your photo and information are not saved or visible anywhere on %(platformName)s after the verification process is complete." ), { platformName: platformName } ) %>
               </dd>
               <dt class="faq-question">
                 <%- gettext( "What if I can't see the camera image, or if I can't see my photo do determine which side is visible?" ) %>

--- a/lms/templates/verify_student/id_photo_step.underscore
+++ b/lms/templates/verify_student/id_photo_step.underscore
@@ -2,7 +2,7 @@
   <div class="idphoto view">
     <h3 class="title"><%- gettext( "Take a Photo of Your ID" ) %></h3>
     <div class="instruction">
-      <p><%- gettext("Use your webcam to take a photo of your ID. We will match this photo with the photo of your face and the name on your account.") %></p>
+      <p><%- gettext("Use your webcam to take a photo of your ID.") %></p>
     </div>
 
     <div class="wrapper-task">
@@ -10,7 +10,7 @@
 
       <div class="wrapper-help">
          <div class="help help-task photo-tips idtips">
-          <p class="photo-tip"><%- gettext( "You need an ID with your name and photo. A driver's license, passport, or other government-issued IDs are all acceptable." ) %></p>
+          <p class="photo-tip"><%- gettext( "You need an ID with your name and photo. A driver's license, passport, or ID are all acceptable." ) %></p>
 
           <h4 class="title"><%- gettext( "Tips on taking a successful photo" ) %></h4>
 
@@ -35,7 +35,7 @@
                 <%- _.sprintf( gettext( "Why does %(platformName)s need my photo?" ), { platformName: platformName } ) %>
               </dt>
               <dd class="faq-answer">
-                <%- gettext( "As part of the verification process, you take a photo of both your face and a government-issued photo ID. Our authorization service confirms your identity by comparing the photo you take with the photo on your ID." ) %>
+                <%- gettext( "As part of the verification process, you take a photo of both your face and a photo ID. Our authorization service confirms your identity by comparing the photo you take with the photo on your ID." ) %>
               </dd>
               <dt class="faq-question">
                 <%- _.sprintf( gettext( "What does %(platformName)s do with this photo?" ), { platformName: platformName } ) %>

--- a/lms/templates/verify_student/review_photos_step.underscore
+++ b/lms/templates/verify_student/review_photos_step.underscore
@@ -25,7 +25,6 @@
             <h5 class="title"><%- gettext( "Photo requirements:" ) %></h5>
             <ul class="list-help list-tips copy">
               <li class="tip"><%- gettext( "Does the photo of you show your whole face?" ) %></li>
-              <li class="tip"><%- gettext( "Does the photo of you match your ID photo?" ) %></li>
               <li class="tip"><%- gettext( "Is your name on your ID readable?" ) %></li>
               <li class="tip"><%- _.sprintf(  gettext( "Does the name on your ID match your account name: %(fullName)s?" ), { fullName: fullName } ) %>
                 <div class="help-tip is-expandable">


### PR DESCRIPTION
@edx/masters-devs 

Pending review from Learner Support (in-ticket).

### First commit: Reword photo verification instructions 

For [EDUCATOR-5012](https://openedx.atlassian.net/browse/EDUCATOR-5012), reword photo verification instructions based on the suggestions in [this doc](https://docs.google.com/document/d/1QsykwnvwNYWyH85hO54DZ2iaVaXK-5xdj4sL9pR8uRI/edit). Changes:

* Clarify device requirements.
* Clarify that one's photo does not need to exactly match the photo on their ID.
* Clarify why we need the photo.
* Clarify that the ID need not be government issued.

#### What the updated page looks like:

![take-your-photo](https://user-images.githubusercontent.com/3628148/78807002-7649fa80-7991-11ea-9314-b55b41938e70.png)
![take-a-photo-of-your-id](https://user-images.githubusercontent.com/3628148/78806999-75b16400-7991-11ea-90a0-4ec72f37c232.png)
![review-your-photos png](https://user-images.githubusercontent.com/3628148/78806998-7518cd80-7991-11ea-8ab1-3b7357a5d04f.png)


______________________________________________________

### Second commit: Make photo encryption statement sound less gimmicky.

I did this at my own discretion. I changed `""We use the highest levels of security available to encrypt your photo..."` to `""We securely encrypt your photo..."`. The former statement sound gimmicky and, at least to me, is completely nonsensical. Let me know if you think this specific change should be reverted.
