### PR TITLE
Change the default values for permissions

### DIFF
--- a/cms/envs/devstack.py
+++ b/cms/envs/devstack.py
@@ -19,6 +19,14 @@ DEFAULT_TEMPLATE_ENGINE['OPTIONS']['debug'] = DEBUG
 SITE_NAME = 'localhost:8001'
 HTTPS = 'off'
 
+# which access.py permission name to check in order to determine if a course is visible in
+# the course catalog.
+COURSE_CATALOG_VISIBILITY_PERMISSION = 'see_in_catalog'
+
+# which access.py permission name to check in order to determine if a course about page is
+# visible.
+COURSE_ABOUT_VISIBILITY_PERMISSION = 'see_about_page'
+
 ################################ LOGGERS ######################################
 
 

--- a/lms/envs/devstack.py
+++ b/lms/envs/devstack.py
@@ -39,6 +39,14 @@ IDA_LOGOUT_URI_LIST = [
     'http://localhost:18381/logout/',  # discovery
 ]
 
+# which access.py permission name to check in order to determine if a course is visible in
+# the course catalog.
+COURSE_CATALOG_VISIBILITY_PERMISSION = 'see_in_catalog'
+
+# which access.py permission name to check in order to determine if a course about page is
+# visible.
+COURSE_ABOUT_VISIBILITY_PERMISSION = 'see_about_page'
+
 ################################ LOGGERS ######################################
 
 LOG_OVERRIDES = [


### PR DESCRIPTION
**Note** This PR doesn't add any feature or change any behavior. Feel free to close the PR if not required.

### Background:
While I was working on course visibility settings, I followed the documentation but couldn't achieve the desired behavior. No matter what setting I set in course advanced settings, course was always visible in the catalog. After searching on net for some time, I came to know (from a google group I guess) that I have to change the permission values.
Therefore I had to change the permission values in my `private.py` file.

### Description
This PR changes the values of `COURSE_CATALOG_VISIBILITY_PERMISSION` and
`COURSE_ABOUT_VISIBILITY_PERMISSION` to the permissions that will
actually depict the desired behaviors. I think it makes more sense that I don't have to change the settings to achieve the behavior described in the documentation. 
It's just my personal opinion. Feel free to close the PR if its unnecessary. 