### PR TITLE
add AppConfig for catalog

### DIFF
--- a/openedx/core/djangoapps/catalog/__init__.py
+++ b/openedx/core/djangoapps/catalog/__init__.py
@@ -1,0 +1,1 @@
+default_app_config = 'openedx.core.djangoapps.catalog.apps.CatalogConfig'

--- a/openedx/core/djangoapps/catalog/apps.py
+++ b/openedx/core/djangoapps/catalog/apps.py
@@ -1,0 +1,9 @@
+"""
+Configuration for Catalog
+"""
+from django.apps import AppConfig
+
+
+class CatalogConfig(AppConfig):
+    name = 'openedx.core.djangoapps.catalog'
+    verbose_name = "Catalog"


### PR DESCRIPTION
ARCHBOM-1105

Note: Enterprise squash migrations were not work because of this missing AppConfig.