### PR TITLE
ENT-2724 | removed get_cache_key and using it from edx-django-utils.

### DIFF
--- a/openedx/features/enterprise_support/api.py
+++ b/openedx/features/enterprise_support/api.py
@@ -18,12 +18,13 @@ from django.urls import reverse
 from django.utils.http import urlencode
 from django.utils.translation import ugettext as _
 from edx_django_utils.cache import TieredCache
+from edx_django_utils.cache.utils import get_cache_key
 from edx_rest_api_client.client import EdxRestApiClient
 from slumber.exceptions import HttpClientError, HttpNotFoundError, HttpServerError
 
 from openedx.core.djangoapps.oauth_dispatch.jwt import create_jwt_for_user
 from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
-from openedx.features.enterprise_support.utils import get_cache_key, get_data_consent_share_cache_key
+from openedx.features.enterprise_support.utils import get_data_consent_share_cache_key
 from third_party_auth.pipeline import get as get_partial_pipeline
 from third_party_auth.provider import Registry
 

--- a/openedx/features/enterprise_support/tests/test_api.py
+++ b/openedx/features/enterprise_support/tests/test_api.py
@@ -3,12 +3,9 @@ Test the enterprise support APIs.
 """
 
 
-import mock
-
 import ddt
 import httpretty
-from six.moves.urllib.parse import parse_qs  # pylint: disable=import-error
-
+import mock
 from consent.models import DataSharingConsent
 from django.conf import settings
 from django.contrib.auth.models import User
@@ -16,6 +13,9 @@ from django.core.cache import cache
 from django.http import HttpResponseRedirect
 from django.test.utils import override_settings
 from django.urls import reverse
+from edx_django_utils.cache.utils import get_cache_key
+from six.moves.urllib.parse import parse_qs
+
 from openedx.core.djangoapps.site_configuration.tests.factories import SiteFactory
 from openedx.core.djangolib.testing.utils import CacheIsolationTestCase, skip_unless_lms
 from openedx.features.enterprise_support.api import (
@@ -35,7 +35,7 @@ from openedx.features.enterprise_support.api import (
 from openedx.features.enterprise_support.tests import FEATURES_WITH_ENTERPRISE_ENABLED
 from openedx.features.enterprise_support.tests.factories import EnterpriseCustomerUserFactory
 from openedx.features.enterprise_support.tests.mixins.enterprise import EnterpriseServiceMockMixin
-from openedx.features.enterprise_support.utils import clear_data_consent_share_cache, get_cache_key
+from openedx.features.enterprise_support.utils import clear_data_consent_share_cache
 from student.tests.factories import UserFactory
 
 

--- a/openedx/features/enterprise_support/utils.py
+++ b/openedx/features/enterprise_support/utils.py
@@ -3,14 +3,13 @@ Utility methods for Enterprise
 """
 
 
-import hashlib
 import json
 
-import six
 from crum import get_current_request
 from django.conf import settings
 from django.utils.translation import ugettext as _
 from edx_django_utils.cache import TieredCache
+from edx_django_utils.cache.utils import get_cache_key
 from enterprise.models import EnterpriseCustomerUser
 from social_django.models import UserSocialAuth
 
@@ -19,30 +18,6 @@ from lms.djangoapps.branding.api import get_privacy_url
 from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
 from openedx.core.djangoapps.user_authn.cookies import standard_cookie_settings
 from openedx.core.djangolib.markup import HTML, Text
-
-
-def get_cache_key(**kwargs):
-    """
-    Get MD5 encoded cache key for given arguments.
-
-    Here is the format of key before MD5 encryption.
-        key1:value1__key2:value2 ...
-
-    Example:
-        >>> get_cache_key(site_domain="example.com", resource="enterprise-learner")
-        # Here is key format for above call
-        # "site_domain:example.com__resource:enterprise-learner"
-        a54349175618ff1659dee0978e3149ca
-
-    Arguments:
-        **kwargs: Key word arguments that need to be present in cache key.
-
-    Returns:
-         An MD5 encoded key uniquely identified by the key word arguments.
-    """
-    key = '__'.join(['{}:{}'.format(item, value) for item, value in six.iteritems(kwargs)])
-
-    return hashlib.md5(key.encode('utf-8')).hexdigest()
 
 
 def get_data_consent_share_cache_key(user_id, course_id):


### PR DESCRIPTION
removed get_cache_key and using it from edx-django-utils.