### PR TITLE
[PROD-1287] For course grade and problem grade reports, clear course enrollment caches after each batch of users is processed.

### DIFF
--- a/lms/djangoapps/instructor_task/tasks_helper/grades.py
+++ b/lms/djangoapps/instructor_task/tasks_helper/grades.py
@@ -34,6 +34,7 @@ from lms.djangoapps.instructor_task.config.waffle import (
 )
 from lms.djangoapps.teams.models import CourseTeamMembership
 from lms.djangoapps.verify_student.services import IDVerificationService
+from openedx.core.lib.cache_utils import get_cache
 from openedx.core.djangoapps.content.block_structure.api import get_course_in_cache
 from openedx.core.djangoapps.course_groups.cohorts import bulk_cache_cohorts, get_cohort, is_course_cohorted
 from openedx.core.djangoapps.user_api.course_tag.api import BulkCourseTags
@@ -811,6 +812,9 @@ class ProblemGradeReport(GradeReportBase):
         """
         for users in self._batch_users(context):
             yield self._rows_for_users(context, users)
+            # Clear the CourseEnrollment caches after each batch of users has been processed
+            get_cache('get_enrollment').clear()
+            get_cache(CourseEnrollment.MODE_CACHE_NAMESPACE).clear()
 
 
 class ProblemResponses(object):


### PR DESCRIPTION
### [PROD-1287](https://openedx.atlassian.net/browse/PROD-1287)

Working on optimizing ProblemGradeReport for OOM (Out Of Memory) error.