### PR TITLE
ARCHBOM-1105: fix direct assignment error

### DIFF
--- a/lms/djangoapps/certificates/migrations/0001_initial.py
+++ b/lms/djangoapps/certificates/migrations/0001_initial.py
@@ -35,7 +35,7 @@ class Migration(migrations.Migration):
             fields=[
                 ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
                 ('mode', models.CharField(help_text='The course mode for this badge image. For example, "verified" or "honor".', unique=True, max_length=125)),
-                ('icon', models.ImageField(help_text='Badge images must be square PNG files. The file size should be under 250KB.', upload_to=b'badges', validators=[validate_badge_image])),
+                ('icon', models.ImageField(help_text='Badge images must be square PNG files. The file size should be under 250KB.', upload_to='badges', validators=[validate_badge_image])),
                 ('default', models.BooleanField(default=False, help_text='Set this value to True if you want this image to be the default image for any course modes that do not have a specified badge image. You can have only one default image.')),
             ],
         ),

--- a/openedx/core/djangoapps/api_admin/migrations/0002_auto_20160325_1604.py
+++ b/openedx/core/djangoapps/api_admin/migrations/0002_auto_20160325_1604.py
@@ -14,7 +14,7 @@ def add_api_access_group(apps, schema_editor):
 
     group, __ = Group.objects.get_or_create(name=API_GROUP_NAME)
     api_content_type = ContentType.objects.get_for_model(ApiAccessRequest)
-    group.permissions = Permission.objects.filter(content_type=api_content_type)
+    group.permissions.set(Permission.objects.filter(content_type=api_content_type))
     group.save()
 
 


### PR DESCRIPTION
Fix for:
TypeError: Direct assignment to the forward side of a many-to-many set
is prohibited. Use permissions.set() instead.

ARCHBOM-1105