### PR TITLE
Adds settings for celery task auto discovery

### DIFF
--- a/lms/djangoapps/verify_student/apps.py
+++ b/lms/djangoapps/verify_student/apps.py
@@ -18,3 +18,4 @@ class VerifyStudentConfig(AppConfig):
         Connect signal handlers.
         """
         from . import signals  # pylint: disable=unused-variable
+        from . import tasks    # pylint: disable=unused-variable

--- a/lms/djangoapps/verify_student/tasks.py
+++ b/lms/djangoapps/verify_student/tasks.py
@@ -11,8 +11,8 @@ from celery import Task, task
 from celery.states import FAILURE
 from django.conf import settings
 from django.core.mail import EmailMessage
+
 from edxmako.shortcuts import render_to_string
-from lms.djangoapps.verify_student.models import SoftwareSecurePhotoVerification
 from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
 
 ACE_ROUTING_KEY = getattr(settings, 'ACE_ROUTING_KEY', None)
@@ -41,8 +41,9 @@ class BaseSoftwareSecureTask(Task):
             'response_ok': boolean, indicating if the response was ok
             'response_text': string, indicating the response text in case of failure.
         """
-        user_verification_id = kwargs['user_verification_id']
-        user_verification = SoftwareSecurePhotoVerification.objects.get(id=user_verification_id)
+        from .models import SoftwareSecurePhotoVerification
+
+        user_verification = SoftwareSecurePhotoVerification.objects.get(id=kwargs['user_verification_id'])
         if retval['response_ok']:
             user_verification.mark_submit()
             log.info(
@@ -60,6 +61,8 @@ class BaseSoftwareSecureTask(Task):
         with "must_retry" so that it can be retried latter.
         """
         if self.max_retries == self.request.retries and status == FAILURE:
+            from .models import SoftwareSecurePhotoVerification
+
             user_verification_id = kwargs['user_verification_id']
             user_verification = SoftwareSecurePhotoVerification.objects.get(id=user_verification_id)
             user_verification.mark_must_retry()
@@ -110,6 +113,8 @@ def send_request_to_ss_for_user(self, user_verification_id, copy_id_photo_from):
     Returns:
         request.Response
     """
+    from .models import SoftwareSecurePhotoVerification
+
     user_verification = SoftwareSecurePhotoVerification.objects.get(id=user_verification_id)
     log.info('=>New Verification Task Received %r', user_verification.user.username)
     try:

--- a/lms/djangoapps/verify_student/tests/test_utils.py
+++ b/lms/djangoapps/verify_student/tests/test_utils.py
@@ -8,13 +8,18 @@ import unittest
 from datetime import timedelta
 
 import ddt
+import mock
 from django.conf import settings
 from django.utils import timezone
 from mock import patch
 from pytest import mark
 
 from lms.djangoapps.verify_student.models import ManualVerification, SoftwareSecurePhotoVerification, SSOVerification
-from lms.djangoapps.verify_student.utils import most_recent_verification, verification_for_datetime
+from lms.djangoapps.verify_student.utils import (
+    most_recent_verification,
+    submit_request_to_ss,
+    verification_for_datetime
+)
 from student.tests.factories import UserFactory
 
 FAKE_SETTINGS = {
@@ -143,3 +148,21 @@ class TestVerifyStudentUtils(unittest.TestCase):
             self.assertEqual(most_recent, sso_verification)
         else:
             self.assertEqual(most_recent, manual_verification)
+
+    @mock.patch('lms.djangoapps.verify_student.utils.log')
+    @mock.patch(
+        'lms.djangoapps.verify_student.tasks.send_request_to_ss_for_user.delay', mock.Mock(side_effect=Exception('error'))
+    )
+    def test_submit_request_to_ss(self, mock_log):
+        """Tests that we log appropriate information when celery task creation fails."""
+        user = UserFactory.create()
+        attempt = SoftwareSecurePhotoVerification.objects.create(user=user)
+        attempt.mark_ready()
+        submit_request_to_ss(user_verification=attempt, copy_id_photo_from=None)
+
+        mock_log.error.assert_called_with(
+            "Software Secure submit request %r failed, result: %s",
+            user.username,
+            'error'
+        )
+        self.assertTrue(attempt.status, SoftwareSecurePhotoVerification.STATUS.must_retry)

--- a/lms/djangoapps/verify_student/tests/test_views.py
+++ b/lms/djangoapps/verify_student/tests/test_views.py
@@ -1749,7 +1749,7 @@ class TestPhotoVerificationResultsCallback(ModuleStoreTestCase, TestVerification
         mock.Mock(side_effect=mocked_has_valid_signature)
     )
     @patch('lms.djangoapps.verify_student.views.log.error')
-    @patch('lms.djangoapps.verify_student.utils.SailthruClient.send')
+    @patch('sailthru.sailthru_client.SailthruClient.send')
     def test_passed_status_template(self, mock_sailthru_send, mock_log_error):
         """
         Test for verification passed.
@@ -1791,7 +1791,7 @@ class TestPhotoVerificationResultsCallback(ModuleStoreTestCase, TestVerification
         mock.Mock(side_effect=mocked_has_valid_signature)
     )
     @patch('lms.djangoapps.verify_student.views.log.error')
-    @patch('lms.djangoapps.verify_student.utils.SailthruClient.send')
+    @patch('sailthru.sailthru_client.SailthruClient.send')
     def test_first_time_verification(self, mock_sailthru_send, mock_log_error):  # pylint: disable=unused-argument
         """
         Test for verification passed if the learner does not have any previous verification


### PR DESCRIPTION
~~The auto-discovery of the celery task fails randomly, so I am adding it in the sequence of modules to import when the worker starts.~~

Relative imports and automatic name generation don’t go well together, so if you’re using relative imports you should set the name explicitly.

https://docs.celeryproject.org/en/stable/userguide/tasks.html#task-naming-relative-imports


This would be a two-step process -- This is the first part and the second would to change the relative import.  