### PR TITLE
add private.in to .gitignore to align with the instructions in requir…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 # and so should not be destroyed by "make clean".
 # start-noclean
 requirements/private.txt
+requirements/edx/private.in
 requirements/edx/private.txt
 lms/envs/private.py
 cms/envs/private.py


### PR DESCRIPTION
…ements/edx/private.readme

In the [private.readme file](https://github.com/edx/edx-platform/blob/master/requirements/edx/private.readme), the instructions state that we should add a _private.in_ file to our local checkout of edx-platform to manage dependencies for our local environments. However, _private.in_ is not listed in our _.gitignore_, so I have added it here.