### PR TITLE
Upgrade xblock-drag-and-drop-v2 to 2.2.10

### DIFF
--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -243,7 +243,7 @@ web-fragments==0.3.1      # via -r requirements/edx/base.in, staff-graded-xblock
 webencodings==0.5.1       # via bleach, html5lib
 webob==1.8.6              # via xblock, xmodule
 wrapt==1.11.2             # via -c requirements/edx/../constraints.txt, -r requirements/edx/paver.txt
-git+https://github.com/edx-solutions/xblock-drag-and-drop-v2@v2.2.9#egg=xblock-drag-and-drop-v2==2.2.9  # via -r requirements/edx/github.in
+git+https://github.com/edx-solutions/xblock-drag-and-drop-v2@v2.2.10#egg=xblock-drag-and-drop-v2==2.2.10  # via -r requirements/edx/github.in
 git+https://github.com/open-craft/xblock-poll@da2d8fd21791a7af128595cf82bee83ee579e00f#egg=xblock-poll==1.9.6  # via -r requirements/edx/github.in
 xblock-utils==2.0.0       # via -r requirements/edx/base.in, edx-sga, lti-consumer-xblock, staff-graded-xblock, xblock-drag-and-drop-v2, xblock-google-drive
 xblock==1.2.9             # via -r requirements/edx/base.in, acid-xblock, crowdsourcehinter-xblock, done-xblock, edx-completion, edx-sga, edx-user-state-client, edx-when, lti-consumer-xblock, ora2, rate-xblock, staff-graded-xblock, xblock-discussion, xblock-drag-and-drop-v2, xblock-google-drive, xblock-poll, xblock-utils

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -322,7 +322,7 @@ web-fragments==0.3.1      # via -r requirements/edx/testing.txt, staff-graded-xb
 webencodings==0.5.1       # via -r requirements/edx/testing.txt, bleach, html5lib
 webob==1.8.6              # via -r requirements/edx/testing.txt, xblock, xmodule
 wrapt==1.11.2             # via -c requirements/edx/../constraints.txt, -r requirements/edx/testing.txt, astroid
-git+https://github.com/edx-solutions/xblock-drag-and-drop-v2@v2.2.9#egg=xblock-drag-and-drop-v2==2.2.9  # via -r requirements/edx/testing.txt
+git+https://github.com/edx-solutions/xblock-drag-and-drop-v2@v2.2.10#egg=xblock-drag-and-drop-v2==2.2.10  # via -r requirements/edx/testing.txt
 git+https://github.com/open-craft/xblock-poll@da2d8fd21791a7af128595cf82bee83ee579e00f#egg=xblock-poll==1.9.6  # via -r requirements/edx/testing.txt
 xblock-utils==2.0.0       # via -r requirements/edx/testing.txt, edx-sga, lti-consumer-xblock, staff-graded-xblock, xblock-drag-and-drop-v2, xblock-google-drive
 xblock==1.2.9             # via -r requirements/edx/testing.txt, acid-xblock, crowdsourcehinter-xblock, done-xblock, edx-completion, edx-sga, edx-user-state-client, edx-when, lti-consumer-xblock, ora2, rate-xblock, staff-graded-xblock, xblock-discussion, xblock-drag-and-drop-v2, xblock-google-drive, xblock-poll, xblock-utils

--- a/requirements/edx/github.in
+++ b/requirements/edx/github.in
@@ -99,5 +99,5 @@ git+https://github.com/edx/xblock-lti-consumer.git@v1.2.5#egg=lti_consumer-xbloc
 
 git+https://github.com/joestump/python-oauth2.git@b94f69b1ad195513547924e380d9265133e995fa#egg=oauth2
 git+https://github.com/open-craft/xblock-poll@da2d8fd21791a7af128595cf82bee83ee579e00f#egg=xblock-poll==1.9.6
-git+https://github.com/edx-solutions/xblock-drag-and-drop-v2@v2.2.9#egg=xblock-drag-and-drop-v2==2.2.9
+git+https://github.com/edx-solutions/xblock-drag-and-drop-v2@v2.2.10#egg=xblock-drag-and-drop-v2==2.2.10
 git+https://github.com/django-compressor/django-appconf@1526a842ee084b791aa66c931b3822091a442853#egg=django-appconf

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -299,7 +299,7 @@ web-fragments==0.3.1      # via -r requirements/edx/base.txt, staff-graded-xbloc
 webencodings==0.5.1       # via -r requirements/edx/base.txt, bleach, html5lib
 webob==1.8.6              # via -r requirements/edx/base.txt, xblock, xmodule
 wrapt==1.11.2             # via -c requirements/edx/../constraints.txt, -r requirements/edx/base.txt, astroid
-git+https://github.com/edx-solutions/xblock-drag-and-drop-v2@v2.2.9#egg=xblock-drag-and-drop-v2==2.2.9  # via -r requirements/edx/base.txt
+git+https://github.com/edx-solutions/xblock-drag-and-drop-v2@v2.2.10#egg=xblock-drag-and-drop-v2==2.2.10  # via -r requirements/edx/base.txt
 git+https://github.com/open-craft/xblock-poll@da2d8fd21791a7af128595cf82bee83ee579e00f#egg=xblock-poll==1.9.6  # via -r requirements/edx/base.txt
 xblock-utils==2.0.0       # via -r requirements/edx/base.txt, edx-sga, lti-consumer-xblock, staff-graded-xblock, xblock-drag-and-drop-v2, xblock-google-drive
 xblock==1.2.9             # via -r requirements/edx/base.txt, acid-xblock, crowdsourcehinter-xblock, done-xblock, edx-completion, edx-sga, edx-user-state-client, edx-when, lti-consumer-xblock, ora2, rate-xblock, staff-graded-xblock, xblock-discussion, xblock-drag-and-drop-v2, xblock-google-drive, xblock-poll, xblock-utils


### PR DESCRIPTION
TNL-7184

Upgrades the platform to the latest version of the drag and drop V2 XBlock.  This fixes a bug where we were over-reporting certain feedback events.  ('feedback.opened')