### PR TITLE
Unpin django-model-utils and mysqlclient

### DIFF
--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -22,9 +22,6 @@ django-cors-headers<3.0.0
 # It seems like django-countries > 5.5 may cause performance issues for us.
 django-countries==5.5
 
-# Version 4.0.0 dropped support for Django < 2.0.1
-django-model-utils<4.0.0
-
 # django-storages version 1.9 drops support for boto storage backend.
 django-storages<1.9
 
@@ -60,9 +57,6 @@ matplotlib<3.1
 
 # mock version 4.0.0 drops support for python 3.5
 mock<4.0.0
-
-# mysqlclient 1.5 is scheduled to change internal APIs used by Django 1.11
-mysqlclient<1.5
 
 # oauthlib>3.0.1 causes test failures
 oauthlib==3.0.1

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -65,10 +65,10 @@ django-filter==2.2.0      # via -r requirements/edx/base.in, edx-enterprise
 django-ipware==2.1.0      # via -r requirements/edx/base.in, edx-enterprise, edx-proctoring
 django-js-asset==1.2.2    # via django-mptt
 git+https://gitlab.com/Ayub-khan/django-method-override.git@5270af321be2e576d8e8b3c4191711a19975c356#egg=django-method-override==1.0.4  # via -r requirements/edx/github.in
-django-model-utils==3.2.0  # via -c requirements/edx/../constraints.txt, -r requirements/edx/base.in, django-user-tasks, edx-bulk-grades, edx-celeryutils, edx-completion, edx-enterprise, edx-milestones, edx-organizations, edx-proctoring, edx-rbac, edx-submissions, edx-when, edxval, ora2, super-csv
+django-model-utils==3.2.0  # via -r requirements/edx/base.in, django-user-tasks, edx-bulk-grades, edx-celeryutils, edx-completion, edx-enterprise, edx-milestones, edx-organizations, edx-proctoring, edx-rbac, edx-submissions, edx-when, edxval, ora2, super-csv
 django-mptt==0.11.0       # via -r requirements/edx/base.in, django-wiki
 django-multi-email-field==0.6.1  # via edx-enterprise
-django-mysql==3.3.0       # via -r requirements/edx/base.in
+django-mysql==3.4.0       # via -r requirements/edx/base.in
 django-oauth-toolkit==1.3.2  # via -r requirements/edx/base.in
 django-object-actions==2.0.0  # via edx-enterprise
 django-pipeline==1.7.0    # via -r requirements/edx/base.in
@@ -161,7 +161,7 @@ git+https://github.com/edx/MongoDBProxy.git@d92bafe9888d2940f647a7b2b2383b29c752
 mongoengine==0.10.0       # via -r requirements/edx/base.in
 more-itertools==8.2.0     # via -r requirements/edx/paver.txt, zipp
 mpmath==1.1.0             # via sympy
-mysqlclient==1.4.6        # via -c requirements/edx/../constraints.txt, -r requirements/edx/base.in
+mysqlclient==1.4.6        # via -r requirements/edx/base.in
 newrelic==5.12.0.140      # via -r requirements/edx/base.in, edx-django-utils
 nltk==3.5                 # via -r requirements/edx/../edx-sandbox/shared.txt, chem
 nodeenv==1.3.5            # via -r requirements/edx/base.in
@@ -238,7 +238,7 @@ text-unidecode==1.3       # via python-slugify
 tqdm==4.45.0              # via -r requirements/edx/../edx-sandbox/shared.txt, nltk
 unicodecsv==0.14.1        # via -r requirements/edx/base.in, edx-enterprise
 uritemplate==3.0.1        # via coreapi, drf-yasg
-urllib3==1.25.8           # via -r requirements/edx/paver.txt, elasticsearch, geoip2, requests
+urllib3==1.25.9           # via -r requirements/edx/paver.txt, elasticsearch, geoip2, requests
 user-util==0.1.5          # via -r requirements/edx/base.in
 voluptuous==0.11.7        # via ora2
 watchdog==0.10.2          # via -r requirements/edx/paver.txt

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -77,10 +77,10 @@ django-filter==2.2.0      # via -r requirements/edx/testing.txt, edx-enterprise
 django-ipware==2.1.0      # via -r requirements/edx/testing.txt, edx-enterprise, edx-proctoring
 django-js-asset==1.2.2    # via -r requirements/edx/testing.txt, django-mptt
 git+https://gitlab.com/Ayub-khan/django-method-override.git@5270af321be2e576d8e8b3c4191711a19975c356#egg=django-method-override==1.0.4  # via -r requirements/edx/testing.txt
-django-model-utils==3.2.0  # via -c requirements/edx/../constraints.txt, -r requirements/edx/testing.txt, django-user-tasks, edx-bulk-grades, edx-celeryutils, edx-completion, edx-enterprise, edx-milestones, edx-organizations, edx-proctoring, edx-rbac, edx-submissions, edx-when, edxval, ora2, super-csv
+django-model-utils==3.2.0  # via -r requirements/edx/testing.txt, django-user-tasks, edx-bulk-grades, edx-celeryutils, edx-completion, edx-enterprise, edx-milestones, edx-organizations, edx-proctoring, edx-rbac, edx-submissions, edx-when, edxval, ora2, super-csv
 django-mptt==0.11.0       # via -r requirements/edx/testing.txt, django-wiki
 django-multi-email-field==0.6.1  # via -r requirements/edx/testing.txt, edx-enterprise
-django-mysql==3.3.0       # via -r requirements/edx/testing.txt
+django-mysql==3.4.0       # via -r requirements/edx/testing.txt
 django-oauth-toolkit==1.3.2  # via -r requirements/edx/testing.txt
 django-object-actions==2.0.0  # via -r requirements/edx/testing.txt, edx-enterprise
 django-pipeline==1.7.0    # via -r requirements/edx/testing.txt
@@ -195,7 +195,7 @@ git+https://github.com/edx/MongoDBProxy.git@d92bafe9888d2940f647a7b2b2383b29c752
 mongoengine==0.10.0       # via -r requirements/edx/testing.txt
 more-itertools==8.2.0     # via -r requirements/edx/testing.txt, pytest, zipp
 mpmath==1.1.0             # via -r requirements/edx/testing.txt, sympy
-mysqlclient==1.4.6        # via -c requirements/edx/../constraints.txt, -r requirements/edx/testing.txt
+mysqlclient==1.4.6        # via -r requirements/edx/testing.txt
 newrelic==5.12.0.140      # via -r requirements/edx/testing.txt, edx-django-utils
 nltk==3.5                 # via -r requirements/edx/testing.txt, chem
 nodeenv==1.3.5            # via -r requirements/edx/testing.txt
@@ -314,9 +314,9 @@ typed-ast==1.4.1          # via -r requirements/edx/testing.txt, astroid
 unicodecsv==0.14.1        # via -r requirements/edx/testing.txt, edx-enterprise
 unidiff==0.5.5            # via -r requirements/edx/testing.txt, coverage-pytest-plugin
 uritemplate==3.0.1        # via -r requirements/edx/testing.txt, coreapi, drf-yasg
-urllib3==1.25.8           # via -r requirements/edx/testing.txt, elasticsearch, geoip2, requests, selenium, transifex-client
+urllib3==1.25.9           # via -r requirements/edx/testing.txt, elasticsearch, geoip2, requests, selenium, transifex-client
 user-util==0.1.5          # via -r requirements/edx/testing.txt
-virtualenv==20.0.17       # via -r requirements/edx/testing.txt, tox
+virtualenv==20.0.18       # via -r requirements/edx/testing.txt, tox
 voluptuous==0.11.7        # via -r requirements/edx/testing.txt, ora2
 vulture==1.4              # via -r requirements/edx/development.in
 watchdog==0.10.2          # via -r requirements/edx/testing.txt

--- a/requirements/edx/paver.txt
+++ b/requirements/edx/paver.txt
@@ -24,7 +24,7 @@ python-memcached==1.59    # via -r requirements/edx/paver.in
 requests==2.23.0          # via -r requirements/edx/paver.in
 six==1.14.0               # via edx-opaque-keys, libsass, mock, paver, python-memcached, stevedore
 stevedore==1.32.0         # via -r requirements/edx/paver.in, edx-opaque-keys
-urllib3==1.25.8           # via requests
+urllib3==1.25.9           # via requests
 watchdog==0.10.2          # via -r requirements/edx/paver.in
 wrapt==1.11.2             # via -c requirements/edx/../constraints.txt, -r requirements/edx/paver.in
 zipp==1.0.0               # via -c requirements/edx/../constraints.txt, importlib-metadata

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -75,10 +75,10 @@ django-filter==2.2.0      # via -r requirements/edx/base.txt, edx-enterprise
 django-ipware==2.1.0      # via -r requirements/edx/base.txt, edx-enterprise, edx-proctoring
 django-js-asset==1.2.2    # via -r requirements/edx/base.txt, django-mptt
 git+https://gitlab.com/Ayub-khan/django-method-override.git@5270af321be2e576d8e8b3c4191711a19975c356#egg=django-method-override==1.0.4  # via -r requirements/edx/base.txt
-django-model-utils==3.2.0  # via -c requirements/edx/../constraints.txt, -r requirements/edx/base.txt, django-user-tasks, edx-bulk-grades, edx-celeryutils, edx-completion, edx-enterprise, edx-milestones, edx-organizations, edx-proctoring, edx-rbac, edx-submissions, edx-when, edxval, ora2, super-csv
+django-model-utils==3.2.0  # via -r requirements/edx/base.txt, django-user-tasks, edx-bulk-grades, edx-celeryutils, edx-completion, edx-enterprise, edx-milestones, edx-organizations, edx-proctoring, edx-rbac, edx-submissions, edx-when, edxval, ora2, super-csv
 django-mptt==0.11.0       # via -r requirements/edx/base.txt, django-wiki
 django-multi-email-field==0.6.1  # via -r requirements/edx/base.txt, edx-enterprise
-django-mysql==3.3.0       # via -r requirements/edx/base.txt
+django-mysql==3.4.0       # via -r requirements/edx/base.txt
 django-object-actions==2.0.0  # via -r requirements/edx/base.txt, edx-enterprise
 django-pipeline==1.7.0    # via -r requirements/edx/base.txt
 django-pyfs==2.1          # via -r requirements/edx/base.txt
@@ -186,7 +186,7 @@ git+https://github.com/edx/MongoDBProxy.git@d92bafe9888d2940f647a7b2b2383b29c752
 mongoengine==0.10.0       # via -r requirements/edx/base.txt
 more-itertools==8.2.0     # via -r requirements/edx/base.txt, -r requirements/edx/coverage.txt, pytest, zipp
 mpmath==1.1.0             # via -r requirements/edx/base.txt, sympy
-mysqlclient==1.4.6        # via -c requirements/edx/../constraints.txt, -r requirements/edx/base.txt
+mysqlclient==1.4.6        # via -r requirements/edx/base.txt
 newrelic==5.12.0.140      # via -r requirements/edx/base.txt, edx-django-utils
 nltk==3.5                 # via -r requirements/edx/base.txt, chem
 nodeenv==1.3.5            # via -r requirements/edx/base.txt
@@ -292,9 +292,9 @@ typed-ast==1.4.1          # via astroid
 unicodecsv==0.14.1        # via -r requirements/edx/base.txt, edx-enterprise
 unidiff==0.5.5            # via -r requirements/edx/testing.in, coverage-pytest-plugin
 uritemplate==3.0.1        # via -r requirements/edx/base.txt, coreapi, drf-yasg
-urllib3==1.25.8           # via -r requirements/edx/base.txt, elasticsearch, geoip2, requests, selenium, transifex-client
+urllib3==1.25.9           # via -r requirements/edx/base.txt, elasticsearch, geoip2, requests, selenium, transifex-client
 user-util==0.1.5          # via -r requirements/edx/base.txt
-virtualenv==20.0.17       # via tox
+virtualenv==20.0.18       # via tox
 voluptuous==0.11.7        # via -r requirements/edx/base.txt, ora2
 watchdog==0.10.2          # via -r requirements/edx/base.txt
 wcwidth==0.1.9            # via pytest

--- a/scripts/xblock/requirements.txt
+++ b/scripts/xblock/requirements.txt
@@ -8,4 +8,4 @@ certifi==2020.4.5.1       # via requests
 chardet==3.0.4            # via requests
 idna==2.9                 # via requests
 requests==2.23.0          # via -r scripts/xblock/requirements.in
-urllib3==1.25.8           # via requests
+urllib3==1.25.9           # via requests


### PR DESCRIPTION
No changes in versions. These were pinned because they drop support for Django<2.2 (or were planning on it, in the latter case.)