### PR TITLE
SE-2483 Unhide student-generated certificates toggle

### DIFF
--- a/lms/templates/instructor/instructor_dashboard_2/certificates.html
+++ b/lms/templates/instructor/instructor_dashboard_2/certificates.html
@@ -50,7 +50,6 @@ from openedx.core.djangolib.js_utils import dump_js_escaped_json, js_escaped_str
         % endif
     </div>
 
-    % if not section_data['is_self_paced']:
     <hr />
 
     <div class="enable-certificates">
@@ -72,7 +71,6 @@ from openedx.core.djangolib.js_utils import dump_js_escaped_json, js_escaped_str
             <button class="is-disabled" disabled>${_('Enable Student-Generated Certificates')}</button>
         % endif
     </div>
-    % endif
 
     % if section_data['instructor_generation_enabled'] and not (section_data['enabled_for_course'] and section_data['html_cert_enabled']):
     <hr class="section-divider" />


### PR DESCRIPTION
Student-generated certificates are meant to be auto-enabled through
signal for self-paced courses, but it has been observed that this
behaviour is flaky. When this happens, we are left in a state where it
is impossible to enable student-generated certificates because the
section is hidden in the instructor dashboard.

Also by unconditionally displaying the toggle button, this allows more
flexibility for instructors. For example, it may be desirable for
student-generated certificates to be disabled for a self-paced course.

**JIRA tickets**: [OSPR-4389](https://openedx.atlassian.net/browse/OSPR-4389)

**External discussions**:

Others appear to be having similar issues with certificates, that may be helped by the changes in this PR:  https://discuss.openedx.org/t/certificate-link-is-not-appearing-on-instructor-dashboard/936/11

**Dependencies**: None

**Screenshots**:

![1587014540](https://user-images.githubusercontent.com/9714796/79417700-ea1f7f00-7ff1-11ea-8cc8-4ed0702edf11.png)


**Sandbox URL**: 


-    LMS: https://pr23735.sandbox.opencraft.hosting/
-    Studio: https://studio.pr23735.sandbox.opencraft.hosting/


**Merge deadline**: None

**Test instructions**:

1. Create a self-paced course (or change an existing course to be self-paced)
1. visit the instructor dashboard for the self-paced course
1. navigate to the Certificates tab
1. verify that the 'Student-Generated Certificates' section is visible along with the toggle button
1. verify that clicking the toggle button toggles this setting correctly

**Reviewers**:

- [x] @pomegranited 
- [ ] edX Reviewers TBD

**Settings**
```yaml

```
