### PR TITLE
[CR-2057]: Changing email placeholder

### DIFF
--- a/openedx/core/djangoapps/user_authn/views/login_form.py
+++ b/openedx/core/djangoapps/user_authn/views/login_form.py
@@ -91,10 +91,6 @@ def get_login_session_form(request):
     # meant to hold the user's email address.
     email_label = _("Email")
 
-    # Translators: This example email address is used as a placeholder in
-    # a field on the login form meant to hold the user's email address.
-    email_placeholder = _("example@domain.com")
-
     # Translators: These instructions appear on the login form, immediately
     # below a field meant to hold the user's email address.
     email_instructions = _("The email address you used to register with {platform_name}").format(
@@ -105,7 +101,6 @@ def get_login_session_form(request):
         "email",
         field_type="email",
         label=email_label,
-        placeholder=email_placeholder,
         instructions=email_instructions,
         restrictions={
             "min_length": accounts.EMAIL_MIN_LENGTH,

--- a/openedx/core/djangoapps/user_authn/views/login_form.py
+++ b/openedx/core/djangoapps/user_authn/views/login_form.py
@@ -89,15 +89,15 @@ def get_login_session_form(request):
 
     # Translators: This label appears above a field on the login form
     # meant to hold the user's email address.
-    email_label = _(u"Email")
+    email_label = _("Email")
 
     # Translators: This example email address is used as a placeholder in
     # a field on the login form meant to hold the user's email address.
-    email_placeholder = _(u"username@domain.com")
+    email_placeholder = _("example@domain.com")
 
     # Translators: These instructions appear on the login form, immediately
     # below a field meant to hold the user's email address.
-    email_instructions = _(u"The email address you used to register with {platform_name}").format(
+    email_instructions = _("The email address you used to register with {platform_name}").format(
         platform_name=configuration_helpers.get_value('PLATFORM_NAME', settings.PLATFORM_NAME)
     )
 

--- a/openedx/core/djangoapps/user_authn/views/tests/test_login.py
+++ b/openedx/core/djangoapps/user_authn/views/tests/test_login.py
@@ -811,7 +811,6 @@ class LoginSessionViewTest(ApiTestCase):
                 "type": "email",
                 "required": True,
                 "label": "Email",
-                "placeholder": "example@domain.com",
                 "instructions": "The email address you used to register with {platform_name}".format(
                     platform_name=settings.PLATFORM_NAME
                 ),

--- a/openedx/core/djangoapps/user_authn/views/tests/test_login.py
+++ b/openedx/core/djangoapps/user_authn/views/tests/test_login.py
@@ -811,8 +811,8 @@ class LoginSessionViewTest(ApiTestCase):
                 "type": "email",
                 "required": True,
                 "label": "Email",
-                "placeholder": "username@domain.com",
-                "instructions": u"The email address you used to register with {platform_name}".format(
+                "placeholder": "example@domain.com",
+                "instructions": "The email address you used to register with {platform_name}".format(
                     platform_name=settings.PLATFORM_NAME
                 ),
                 "restrictions": {

--- a/openedx/core/djangoapps/user_authn/views/tests/test_login.py
+++ b/openedx/core/djangoapps/user_authn/views/tests/test_login.py
@@ -811,6 +811,7 @@ class LoginSessionViewTest(ApiTestCase):
                 "type": "email",
                 "required": True,
                 "label": "Email",
+                "placeholder": "",
                 "instructions": "The email address you used to register with {platform_name}".format(
                     platform_name=settings.PLATFORM_NAME
                 ),


### PR DESCRIPTION
The current placeholder is confusing to users and results in many trying
to login with their username. The change in this PR hopefully decreases that
confusion.