### PR TITLE
ARCHBOM-1141: constrain pip-tools<5.0.0

### DIFF
--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -73,6 +73,9 @@ pandas==0.22.0
 # path 13.2.0 drops support for Python 3.5
 path<13.2.0
 
+# ARCHBOM-1141: pip-tools upgrade requires pip upgrade
+pip-tools<5.0.0
+
 # BOM-1430: pytest 5.4.0 breaks reporting sometimes: https://github.com/pytest-dev/pytest/issues/6925
 pytest<5.4.0
 

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -215,7 +215,7 @@ pbr==5.4.5                # via -r requirements/edx/testing.txt, stevedore
 pdfminer.six==20200402    # via -r requirements/edx/testing.txt
 piexif==1.1.3             # via -r requirements/edx/testing.txt
 pillow==7.1.1             # via -r requirements/edx/testing.txt, edx-enterprise, edx-organizations
-pip-tools==4.5.1          # via -r requirements/edx/pip-tools.txt
+pip-tools==4.5.1          # via -c requirements/edx/../constraints.txt, -r requirements/edx/pip-tools.txt
 pkgconfig==1.5.1          # via -r requirements/edx/testing.txt, xmlsec
 pluggy==0.13.1            # via -r requirements/edx/testing.txt, diff-cover, pytest, tox
 polib==1.1.0              # via -r requirements/edx/testing.txt, edx-i18n-tools

--- a/requirements/edx/pip-tools.txt
+++ b/requirements/edx/pip-tools.txt
@@ -5,5 +5,5 @@
 #    make upgrade
 #
 click==7.1.1              # via pip-tools
-pip-tools==4.5.1          # via -r requirements/edx/pip-tools.in
+pip-tools==4.5.1          # via -c requirements/edx/../constraints.txt, -r requirements/edx/pip-tools.in
 six==1.14.0               # via -r requirements/edx/pip-tools.in, pip-tools


### PR DESCRIPTION
See ARCHBOM-1141 for details.  Effort required to upgrade pip.

ARCHBOM-1141: