### PR TITLE
fix: Set JWT_ISSUER back to edx.devstack.lms

### DIFF
--- a/cms/envs/devstack.py
+++ b/cms/envs/devstack.py
@@ -152,7 +152,7 @@ REQUIRE_DEBUG = DEBUG
 ########################### OAUTH2 #################################
 JWT_AUTH.update({
     'JWT_SECRET_KEY': 'lms-secret',
-    'JWT_ISSUER': '{}/oauth2'.format(LMS_ROOT_URL),
+    'JWT_ISSUER': 'http://edx.devstack.lms:18000/oauth2',
     'JWT_AUDIENCE': 'lms-key',
     'JWT_PUBLIC_SIGNING_JWK_SET': (
         '{"keys": [{"kid": "devstack_key", "e": "AQAB", "kty": "RSA", "n": "smKFSYowG6nNUAdeqH1jQQnH1PmIHphzBmwJ5vRf1vu'

--- a/lms/envs/devstack.py
+++ b/lms/envs/devstack.py
@@ -265,7 +265,7 @@ LOGIN_REDIRECT_WHITELIST = [CMS_BASE]
 ###################### JWTs ######################
 # pylint: disable=unicode-format-string
 JWT_AUTH.update({
-    'JWT_ISSUER': '{}/oauth2'.format(LMS_ROOT_URL),
+    'JWT_ISSUER': 'http://edx.devstack.lms:18000/oauth2',
     'JWT_AUDIENCE': 'lms-key',
     'JWT_SECRET_KEY': 'lms-secret',
     'JWT_SIGNING_ALGORITHM': 'RS512',


### PR DESCRIPTION
This makes it match JWT_ISSUERS, which causes edx-drf-extensions to stop exploding saying the issuer doesn’t match.

This is definitely a WIP - this is not necessarily the right fix!