### PR TITLE
Stop logging deprecation warnings outside devstack

### DIFF
--- a/cms/wsgi.py
+++ b/cms/wsgi.py
@@ -8,9 +8,6 @@ It exposes a module-level variable named ``application``. Django's
 ``WSGI_APPLICATION`` setting.
 """
 
-from openedx.core.lib.logsettings import log_python_warnings
-log_python_warnings()
-
 # Patch the xml libs before anything else.
 from safe_lxml import defuse_xml_libs
 defuse_xml_libs()

--- a/lms/wsgi.py
+++ b/lms/wsgi.py
@@ -8,9 +8,6 @@ It exposes a module-level variable named ``application``. Django's
 ``WSGI_APPLICATION`` setting.
 """
 
-from openedx.core.lib.logsettings import log_python_warnings
-log_python_warnings()
-
 # Patch the xml libs
 from safe_lxml import defuse_xml_libs
 defuse_xml_libs()

--- a/lms/wsgi_apache_lms.py
+++ b/lms/wsgi_apache_lms.py
@@ -5,9 +5,6 @@ This module contains the WSGI application used for Apache deployment.
 It exposes a module-level variable named ``application``.
 """
 
-from openedx.core.lib.logsettings import log_python_warnings
-log_python_warnings()
-
 # Patch the xml libs before anything else.
 from safe_lxml import defuse_xml_libs
 defuse_xml_libs()


### PR DESCRIPTION
The upgrade to Django 2.2 has caused a spike in production logging due to `RemovedInDjango30Warning` deprecation warnings.  For now, turn off logging of `DeprecationWarning`, `ImportWarning`, and `PendingDeprecationWarning` whenever we're using WSGI (they'll continue to be logged in devstack).  We may eventually want this behind an easily flipped toggle, but for now just remove it to get this resolved quickly.