### PR TITLE
Load XBlockToXModuleShim for Studio Tabs page

### DIFF
--- a/cms/static/js/factories/edit_tabs.js
+++ b/cms/static/js/factories/edit_tabs.js
@@ -4,6 +4,7 @@ import * as xmoduleLoader from 'xmodule';
 import './base';
 import 'cms/js/main';
 import 'xblock/cms.runtime.v1';
+import 'xmodule/js/src/xmodule'; // Force the XBlockToXModuleShim to load for Static Tabs
 
 'use strict';
 export default function EditTabsFactory(courseLocation, explicitUrl) {


### PR DESCRIPTION
The studio tabs page had a race condition when loading many static tabs.
The result was that those tabs couldn't be deleted. By requiring the
`xmodule` module, we force the EditTabsFactory to load
XBlockToXModuleShim before it's needed.