### PR TITLE
Disabled copy/paste in confirm email

### DIFF
--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -2815,6 +2815,8 @@ REGISTRATION_FIELD_ORDER = [
     "gender",
     "year_of_birth",
     "level_of_education",
+    "specialty",
+    "profession"
     "company",
     "title",
     "mailing_address",

--- a/lms/static/js/student_account/views/RegisterView.js
+++ b/lms/static/js/student_account/views/RegisterView.js
@@ -274,6 +274,9 @@
                             handleInputBehavior($input);
                         }
                     });
+                    $('#register-confirm_email').bind('cut copy paste', function(e) {
+                        e.preventDefault();
+                    });
                     setTimeout(handleAutocomplete, 1000);
                 },
 

--- a/openedx/core/djangoapps/user_authn/views/registration_form.py
+++ b/openedx/core/djangoapps/user_authn/views/registration_form.py
@@ -350,10 +350,11 @@ class RegistrationFormFactory(object):
         field_order = configuration_helpers.get_value('REGISTRATION_FIELD_ORDER')
         if not field_order:
             field_order = settings.REGISTRATION_FIELD_ORDER or valid_fields
-
-        # Check that all of the valid_fields are in the field order and vice versa, if not set to the default order
+        # Check that all of the valid_fields are in the field order and vice versa,
+        # if not append missing fields at end of field order
         if set(valid_fields) != set(field_order):
-            field_order = valid_fields
+            difference = set(valid_fields).difference(set(field_order))
+            field_order.extend(difference)
 
         self.field_order = field_order
 


### PR DESCRIPTION
## [PROD-1476](https://openedx.atlassian.net/browse/PROD-1476)

Disabled copy-paste in confirm email input and on the registration page, the confirm email field position was not correct and it was not placed next to the email field which is also fixed in this PR.

There was an Issue in field ordering if even a single field is nor present in `REGISTRATION_FIELD_ORDER` it was overriding whole ordering. **So instead of overriding now, new fields are appended at the end** or order so that the expected order of fields is maintained and extra fields are appended at the end of list.


Sandbox 
https://ahtishamshahid.sandbox.edx.org/register?next=%2F