### PR TITLE
ENT-2798: Added more info to log in SSO request/response flow

### DIFF
--- a/common/djangoapps/third_party_auth/admin.py
+++ b/common/djangoapps/third_party_auth/admin.py
@@ -9,9 +9,8 @@ from django import forms
 from django.contrib import admin
 from django.db import transaction
 from django.urls import reverse
+from django.utils.html import format_html
 from django.utils.translation import ugettext_lazy as _
-
-from openedx.core.djangolib.markup import HTML
 
 from .models import (
     _PSA_OAUTH2_BACKENDS,
@@ -102,9 +101,8 @@ class SAMLProviderConfigAdmin(KeyedConfigurationModelAdmin):
 
         update_url = reverse('admin:{}_{}_add'.format(self.model._meta.app_label, self.model._meta.model_name))
         update_url += '?source={}'.format(instance.pk)
-        return HTML(u'<a href="{}">{}</a>').format(update_url, instance.name)
+        return format_html(u'<a href="{}">{}</a>', update_url, instance.name)
 
-    name_with_update_link.allow_tags = True
     name_with_update_link.short_description = u'Name'
 
     def has_data(self, inst):
@@ -119,9 +117,8 @@ class SAMLProviderConfigAdmin(KeyedConfigurationModelAdmin):
     def mode(self, inst):
         """ Indicate if debug_mode is enabled or not"""
         if inst.debug_mode:
-            return '<span style="color: red;">Debug</span>'
+            return format_html('<span style="color: red;">Debug</span>')
         return "Normal"
-    mode.allow_tags = True
 
     def save_model(self, request, obj, form, change):
         """
@@ -151,11 +148,10 @@ class SAMLConfigurationAdmin(KeyedConfigurationModelAdmin):
         public_key = inst.get_setting('SP_PUBLIC_CERT')
         private_key = inst.get_setting('SP_PRIVATE_KEY')
         if not public_key or not private_key:
-            return HTML(u'<em>Key pair incomplete/missing</em>')
+            return format_html(u'<em>Key pair incomplete/missing</em>')
         pub1, pub2 = public_key[0:10], public_key[-10:]
         priv1, priv2 = private_key[0:10], private_key[-10:]
-        return HTML(u'Public: {}…{}<br>Private: {}…{}').format(pub1, pub2, priv1, priv2)
-    key_summary.allow_tags = True
+        return format_html(u'Public: {}…{}<br>Private: {}…{}', pub1, pub2, priv1, priv2)
 
 admin.site.register(SAMLConfiguration, SAMLConfigurationAdmin)
 

--- a/common/djangoapps/third_party_auth/tests/specs/test_testshib.py
+++ b/common/djangoapps/third_party_auth/tests/specs/test_testshib.py
@@ -308,16 +308,25 @@ class TestShibIntegrationTest(SamlIntegrationTestUtilities, IntegrationTestMixin
             # logs - one for the request and one for the response
             self.assertEqual(mock_log.call_count, 4)
 
-            (msg, action_type, idp_name, xml), _kwargs = mock_log.call_args_list[0]
+            expected_next_url = "/dashboard"
+            (msg, action_type, idp_name, request_data, next_url, xml), _kwargs = mock_log.call_args_list[0]
             self.assertTrue(msg.startswith(u"SAML login %s"))
             self.assertEqual(action_type, "request")
             self.assertEqual(idp_name, self.PROVIDER_IDP_SLUG)
+            self.assertDictContainsSubset(
+                {"idp": idp_name, "auth_entry": "login", "next": expected_next_url},
+                request_data
+            )
+            self.assertEqual(next_url, expected_next_url)
             self.assertIn('<samlp:AuthnRequest', xml)
 
-            (msg, action_type, idp_name, xml), _kwargs = mock_log.call_args_list[1]
+            (msg, action_type, idp_name, response_data, next_url, xml), _kwargs = mock_log.call_args_list[1]
             self.assertTrue(msg.startswith(u"SAML login %s"))
             self.assertEqual(action_type, "response")
             self.assertEqual(idp_name, self.PROVIDER_IDP_SLUG)
+            self.assertDictContainsSubset({"RelayState": idp_name}, response_data)
+            self.assertIn('SAMLResponse', response_data)
+            self.assertEqual(next_url, expected_next_url)
             self.assertIn('<saml2p:Response', xml)
         else:
             self.assertFalse(mock_log.called)

--- a/openedx/core/djangoapps/schedules/admin.py
+++ b/openedx/core/djangoapps/schedules/admin.py
@@ -7,11 +7,11 @@ from django import forms
 from django.contrib import admin
 from django.db.models import F
 from django.urls import reverse
+from django.utils.html import format_html
 from django.utils.translation import ugettext_lazy as _
 from opaque_keys.edx.keys import CourseKey
 
 from openedx.core.djangoapps.content.course_overviews.models import CourseOverview
-from openedx.core.djangolib.markup import HTML
 
 from . import models
 
@@ -151,23 +151,23 @@ class ScheduleAdmin(admin.ModelAdmin):
     experience_display.short_descriptions = _('Experience')
 
     def username(self, obj):
-        return HTML('<a href="{}">{}</a>').format(
+        return format_html(
+            '<a href="{}">{}</a>',
             reverse("admin:auth_user_change", args=(obj.enrollment.user.id,)),
             obj.enrollment.user.username
         )
 
-    username.allow_tags = True
     username.short_description = _('Username')
 
     def course_id(self, obj):
-        return HTML('<a href="{}">{}</a>').format(
+        return format_html(
+            '<a href="{}">{}</a>',
             reverse("admin:course_overviews_courseoverview_change", args=(
                 obj.enrollment.course_id,
             )),
             obj.enrollment.course_id
         )
 
-    course_id.allow_tags = True
     course_id.short_description = _('Course ID')
 
     def get_queryset(self, request):

--- a/openedx/core/djangoapps/user_api/admin.py
+++ b/openedx/core/djangoapps/user_api/admin.py
@@ -115,7 +115,6 @@ class UserRetirementStatusAdmin(admin.ModelAdmin):
             return format_html('')
 
     retirement_actions.short_description = _('Actions')
-    retirement_actions.allow_tags = True
 
     def get_actions(self, request):
         """


### PR DESCRIPTION
Added more info to log in SSO request/response flow
Fixed django admin links on model's link fields which are broken due to django 2.2 upgrade.
ENT-2798