### PR TITLE
Fixed error message check on 403

### DIFF
--- a/lms/static/js/student_account/AccountsClient.js
+++ b/lms/static/js/student_account/AccountsClient.js
@@ -15,7 +15,7 @@ const deactivate = (password) => fetch('/api/user/v1/accounts/deactivate_logout/
     return response;
   }
 
-  throw new Error(response);
+  throw new Error(response.status);
 });
 
 export {

--- a/lms/static/js/student_account/components/StudentAccountDeletionModal.jsx
+++ b/lms/static/js/student_account/components/StudentAccountDeletionModal.jsx
@@ -52,9 +52,8 @@ class StudentAccountDeletionConfirmationModal extends React.Component {
   }
 
   failedSubmission(error) {
-    const { status } = error;
-    const title = status === 403 ? gettext('Password is incorrect') : gettext('Unable to delete account');
-    const body = status === 403 ? gettext('Please re-enter your password.') : gettext('Sorry, there was an error trying to process your request. Please try again later.');
+    const title = error.message === '403' ? gettext('Password is incorrect') : gettext('Unable to delete account');
+    const body = error.message === '403' ? gettext('Please re-enter your password.') : gettext('Sorry, there was an error trying to process your request. Please try again later.');
 
     this.setState({
       passwordSubmitted: false,


### PR DESCRIPTION
## [PROD-1394](https://openedx.atlassian.net/browse/PROD-1394)

### Description
Fixed the error check on 403 forbidden. The Error Object cannot be passed another object. It expects a string. I have passed the error object the response status code which is used to display the type of error message.

**Sandbox**
https://prod-1394.sandbox.edx.org/account/settings

Try to delete account using an incorrect password and confirm that the correct error message is displayed

### Reviewers
If you've been tagged for review, please check your corresponding box once you've given the :+1:.
- [ ] @awaisdar001 
- [ ] @AhtishamShahid 

### Post-review
- [ ] Rebase and squash commits