### PR TITLE
[PROD-1440] - Update Done xblock to latest version.

### DIFF
--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -9,7 +9,7 @@
 -e git+https://github.com/edx/codejail.git@4127fc4bd5775cc72aee8d7f0a70e31405e22439#egg=codejail  # via -r requirements/edx/github.in
 -e git+https://github.com/jsocol/django-ratelimit.git@72edbe8949fbf6699848e5847645a1998f121d46#egg=ratelimit  # via -r requirements/edx/github.in
 -e git+https://github.com/edx/django-wiki.git@0.0.27#egg=django-wiki  # via -r requirements/edx/github.in
--e git+https://github.com/edx/DoneXBlock.git@2.0.1#egg=done-xblock  # via -r requirements/edx/github.in
+-e git+https://github.com/edx/DoneXBlock.git@2.0.2#egg=done-xblock  # via -r requirements/edx/github.in
 -e git+https://github.com/jazkarta/edx-jsme.git@690dbf75441fa91c7c4899df0b83d77f7deb5458#egg=edx-jsme  # via -r requirements/edx/github.in
 -e .  # via -r requirements/edx/local.in
 -e git+https://github.com/dementrock/pystache_custom.git@776973740bdaad83a3b029f96e415a7d1e8bec2f#egg=pystache_custom-dev  # via -r requirements/edx/github.in

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -9,7 +9,7 @@
 -e git+https://github.com/edx/codejail.git@4127fc4bd5775cc72aee8d7f0a70e31405e22439#egg=codejail  # via -r requirements/edx/testing.txt
 -e git+https://github.com/jsocol/django-ratelimit.git@72edbe8949fbf6699848e5847645a1998f121d46#egg=ratelimit  # via -r requirements/edx/testing.txt
 -e git+https://github.com/edx/django-wiki.git@0.0.27#egg=django-wiki  # via -r requirements/edx/testing.txt
--e git+https://github.com/edx/DoneXBlock.git@2.0.1#egg=done-xblock  # via -r requirements/edx/testing.txt
+-e git+https://github.com/edx/DoneXBlock.git@2.0.2#egg=done-xblock  # via -r requirements/edx/testing.txt
 -e git+https://github.com/jazkarta/edx-jsme.git@690dbf75441fa91c7c4899df0b83d77f7deb5458#egg=edx-jsme  # via -r requirements/edx/testing.txt
 -e .  # via -r requirements/edx/testing.txt
 -e git+https://github.com/dementrock/pystache_custom.git@776973740bdaad83a3b029f96e415a7d1e8bec2f#egg=pystache_custom-dev  # via -r requirements/edx/testing.txt

--- a/requirements/edx/github.in
+++ b/requirements/edx/github.in
@@ -90,7 +90,7 @@ git+https://gitlab.com/Ayub-khan/django-method-override.git@5270af321be2e576d8e8
 git+https://github.com/edx/edx-ora2.git@2.6.25#egg=ora2==2.6.25
 git+https://github.com/edx/crowdsourcehinter.git@2178ac72891392106ffef389651aef374177d294#egg=crowdsourcehinter-xblock==0.4
 -e git+https://github.com/edx/RateXBlock.git@2.0#egg=rate-xblock
--e git+https://github.com/edx/DoneXBlock.git@2.0.1#egg=done-xblock
+-e git+https://github.com/edx/DoneXBlock.git@2.0.2#egg=done-xblock
 -e git+https://github.com/edx-solutions/xblock-google-drive.git@2d176468e33c0713c911b563f8f65f7cf232f5b6#egg=xblock-google-drive
 git+https://github.com/edx/xblock-lti-consumer.git@v1.2.5#egg=lti_consumer-xblock==1.2.5
 

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -9,7 +9,7 @@
 -e git+https://github.com/edx/codejail.git@4127fc4bd5775cc72aee8d7f0a70e31405e22439#egg=codejail  # via -r requirements/edx/base.txt
 -e git+https://github.com/jsocol/django-ratelimit.git@72edbe8949fbf6699848e5847645a1998f121d46#egg=ratelimit  # via -r requirements/edx/base.txt
 -e git+https://github.com/edx/django-wiki.git@0.0.27#egg=django-wiki  # via -r requirements/edx/base.txt
--e git+https://github.com/edx/DoneXBlock.git@2.0.1#egg=done-xblock  # via -r requirements/edx/base.txt
+-e git+https://github.com/edx/DoneXBlock.git@2.0.2#egg=done-xblock  # via -r requirements/edx/base.txt
 -e git+https://github.com/jazkarta/edx-jsme.git@690dbf75441fa91c7c4899df0b83d77f7deb5458#egg=edx-jsme  # via -r requirements/edx/base.txt
 -e .  # via -r requirements/edx/base.txt
 -e git+https://github.com/dementrock/pystache_custom.git@776973740bdaad83a3b029f96e415a7d1e8bec2f#egg=pystache_custom-dev  # via -r requirements/edx/base.txt


### PR DESCRIPTION
### [PROD-1440](https://github.com/edx/DoneXBlock/pull/6)

Update [Done xblock](https://github.com/edx/DoneXBlock) after handling `xblock.fragment DeprecationWarning` in this [PR](https://github.com/edx/DoneXBlock/pull/6) and drafting new [release](https://github.com/edx/DoneXBlock/releases/tag/2.0.2)