### PR TITLE
fix student squash migrations

### DIFF
--- a/common/djangoapps/student/migrations/0001_squashed_0031_auto_20200317_1122.py
+++ b/common/djangoapps/student/migrations/0001_squashed_0031_auto_20200317_1122.py
@@ -516,4 +516,10 @@ class Migration(migrations.Migration):
                 'abstract': False,
             },
         ),
+        migrations.AlterField(
+            model_name='courseenrollment',
+            name='course',
+            field=models.ForeignKey(db_constraint=False, on_delete=django.db.models.deletion.DO_NOTHING,
+                                    to='course_overviews.CourseOverview'),
+        ),
     ]


### PR DESCRIPTION
There was a missing migration from the original squash.

Normally, we wouldn't want to update an existing migration, but I _think_ we should correct the squash.  It will only affect freshly provisioned dbs since the original squash landed.  We can communicate this out as necessary.