### PR TITLE
Short Circuit Digest preferences call on Discussion Home Page

### DIFF
--- a/lms/djangoapps/discussion/static/discussion/js/spec/discussion_board_view_spec.js
+++ b/lms/djangoapps/discussion/static/discussion/js/spec/discussion_board_view_spec.js
@@ -1,4 +1,4 @@
-/* globals Discussion, DiscussionCourseSettings */
+/* globals Discussion, DiscussionCourseSettings, DiscussionUser, DiscussionUtil */
 (function(define) {
     'use strict';
     define(
@@ -26,9 +26,32 @@
                         discussion: discussion,
                         courseSettings: courseSettings
                     });
+                    window.ENABLE_FORUM_DAILY_DIGEST = true;
+                    window.user = new DiscussionUser({
+                        id: 99
+                    });
 
                     return discussionBoardView;
                 };
+
+                describe('goHome view', function() {
+                    it('Ensure no ajax request when digests are unavailable', function() {
+                        var discussionBoardView = createDiscussionBoardView();
+                        spyOn(DiscussionUtil, 'safeAjax').and.callThrough();
+                        window.ENABLE_FORUM_DAILY_DIGEST = false;
+
+                        discussionBoardView.goHome();
+                        expect(DiscussionUtil.safeAjax).not.toHaveBeenCalled();
+                    });
+                    it('Verify the ajax request when digests are available', function() {
+                        var discussionBoardView = createDiscussionBoardView();
+                        discussionBoardView.render();
+                        spyOn(DiscussionUtil, 'safeAjax').and.callThrough();
+
+                        discussionBoardView.goHome();
+                        expect(DiscussionUtil.safeAjax).toHaveBeenCalled();
+                    });
+                });
 
                 describe('Thread List View', function() {
                     it('should ensure the mode is all', function() {

--- a/lms/djangoapps/discussion/static/discussion/js/views/discussion_board_view.js
+++ b/lms/djangoapps/discussion/static/discussion/js/views/discussion_board_view.js
@@ -133,13 +133,22 @@
             },
 
             goHome: function() {
-                var url = DiscussionUtil.urlFor('notifications_status', window.user.get('id'));
                 HtmlUtils.append(this.$('.forum-content').empty(), HtmlUtils.template(discussionHomeTemplate)({}));
                 this.$('.forum-nav-thread-list a').removeClass('is-active').find('.sr')
-                    .remove();
+                  .remove();
+                this.setupForumDigestSettings(window.user.get('id'));
+            },
+            setupForumDigestSettings: function(userId) {
+                if (window.ENABLE_FORUM_DAILY_DIGEST === false) {
+                    return;
+                }
                 this.$('input.email-setting').bind('click', this.discussionThreadListView.updateEmailNotifications);
+                this.getUserNotificationSettings(userId);
+            },
+
+            getUserNotificationSettings: function(userId) {
                 DiscussionUtil.safeAjax({
-                    url: url,
+                    url: DiscussionUtil.urlFor('notifications_status', userId),
                     type: 'GET',
                     success: function(response) {
                         $('input.email-setting').prop('checked', response.status);


### PR DESCRIPTION
The PR fixes the issue that makes an ajax call to forum digest for checking user's preferences when forums digest is disabled. 

This is related to  _PROD-1490_ in which we investigated that there is an ajax call to forum digest URL for checking user preferences.

[PROD-1503](https://openedx.atlassian.net/browse/PROD-1503)