### PR TITLE
 ARCHBOM-1093: Fix unit test enable-migrations

### DIFF
--- a/cms/envs/test.py
+++ b/cms/envs/test.py
@@ -132,10 +132,10 @@ DATABASES = {
     },
 }
 
-if os.environ.get('DISABLE_MIGRATIONS'):
-    # Create tables directly from apps' models. This can be removed once we upgrade
-    # to Django 1.9, which allows setting MIGRATION_MODULES to None in order to skip migrations.
-    MIGRATION_MODULES = NoOpMigrationModules()
+# if os.environ.get('DISABLE_MIGRATIONS'):
+#     # Create tables directly from apps' models. This can be removed once we upgrade
+#     # to Django 1.9, which allows setting MIGRATION_MODULES to None in order to skip migrations.
+#     MIGRATION_MODULES = NoOpMigrationModules()
 
 LMS_BASE = "localhost:8000"
 LMS_ROOT_URL = "http://{}".format(LMS_BASE)

--- a/cms/envs/test.py
+++ b/cms/envs/test.py
@@ -132,11 +132,6 @@ DATABASES = {
     },
 }
 
-# if os.environ.get('DISABLE_MIGRATIONS'):
-#     # Create tables directly from apps' models. This can be removed once we upgrade
-#     # to Django 1.9, which allows setting MIGRATION_MODULES to None in order to skip migrations.
-#     MIGRATION_MODULES = NoOpMigrationModules()
-
 LMS_BASE = "localhost:8000"
 LMS_ROOT_URL = "http://{}".format(LMS_BASE)
 FEATURES['PREVIEW_LMS_BASE'] = "preview.localhost"

--- a/docs/guides/testing/testing.rst
+++ b/docs/guides/testing/testing.rst
@@ -161,6 +161,10 @@ against a database created by applying the migrations instead, use the
 
     paver test_system -s lms --enable-migrations
 
+To see the migration output, use::
+
+    paver test_system -s lms --enable-migrations --verbose --disable_capture
+
 To run a single django test class use this command::
 
     paver test_system -t lms/djangoapps/courseware/tests/tests.py::ActivateLoginTest

--- a/lms/djangoapps/commerce/migrations/0001_data__add_ecommerce_service_user.py
+++ b/lms/djangoapps/commerce/migrations/0001_data__add_ecommerce_service_user.py
@@ -2,6 +2,7 @@
 
 
 from django.conf import settings
+from django.contrib.auth import get_user_model
 from django.contrib.auth.models import User
 from django.db import migrations, models
 
@@ -10,6 +11,7 @@ EMAIL = USERNAME + '@fake.email'
 
 def forwards(apps, schema_editor):
     """Add the service user."""
+    User = get_user_model()
     user, created = User.objects.get_or_create(username=USERNAME, email=EMAIL)
     if created:
         user.set_unusable_password()
@@ -20,6 +22,11 @@ def backwards(apps, schema_editor):
     User.objects.get(username=USERNAME, email=EMAIL).delete()
 
 class Migration(migrations.Migration):
+
+    dependencies = [
+        migrations.swappable_dependency(settings.AUTH_USER_MODEL),
+        ('user_api', '0002_retirementstate_userretirementstatus'),
+    ]
 
     operations = [
         migrations.RunPython(forwards, backwards),

--- a/lms/djangoapps/courseware/migrations/0011_csm_id_bigint.py
+++ b/lms/djangoapps/courseware/migrations/0011_csm_id_bigint.py
@@ -15,6 +15,9 @@ class CsmBigInt(AlterField):
     level and the coursewarehistoryextended_studentmodulehistoryextended table is in a different database
     '''
     def database_forwards(self, app_label, schema_editor, from_state, to_state):
+        if schema_editor.connection.is_in_memory_db():
+            # sqlite3 doesn't support 'MODIFY', so skipping during tests
+            return
         to_model = to_state.apps.get_model(app_label, self.model_name)
         if schema_editor.connection.alias == 'student_module_history':
             if settings.FEATURES["ENABLE_CSMH_EXTENDED"]:

--- a/lms/envs/test.py
+++ b/lms/envs/test.py
@@ -193,11 +193,6 @@ DATABASES = {
     },
 }
 
-# if os.environ.get('DISABLE_MIGRATIONS'):
-#     # Create tables directly from apps' models. This can be removed once we upgrade
-#     # to Django 1.9, which allows setting MIGRATION_MODULES to None in order to skip migrations.
-#     MIGRATION_MODULES = NoOpMigrationModules()
-
 CACHES = {
     # This is the cache used for most things.
     # In staging/prod envs, the sessions also live here.

--- a/lms/envs/test.py
+++ b/lms/envs/test.py
@@ -193,10 +193,10 @@ DATABASES = {
     },
 }
 
-if os.environ.get('DISABLE_MIGRATIONS'):
-    # Create tables directly from apps' models. This can be removed once we upgrade
-    # to Django 1.9, which allows setting MIGRATION_MODULES to None in order to skip migrations.
-    MIGRATION_MODULES = NoOpMigrationModules()
+# if os.environ.get('DISABLE_MIGRATIONS'):
+#     # Create tables directly from apps' models. This can be removed once we upgrade
+#     # to Django 1.9, which allows setting MIGRATION_MODULES to None in order to skip migrations.
+#     MIGRATION_MODULES = NoOpMigrationModules()
 
 CACHES = {
     # This is the cache used for most things.

--- a/openedx/core/lib/api/tests/test_authentication.py
+++ b/openedx/core/lib/api/tests/test_authentication.py
@@ -45,7 +45,6 @@ class MockView(APIView):  # pylint: disable=missing-docstring
 
 
 urlpatterns = [
-    url(r'^oauth2/', include(('provider.oauth2.urls', 'oauth2'), namespace='oauth2')),
     url(
         r'^oauth2-inactive-test/$',
         MockView.as_view(authentication_classes=[authentication.BearerAuthenticationAllowInactiveUser])

--- a/pavelib/utils/test/suites/pytest_suite.py
+++ b/pavelib/utils/test/suites/pytest_suite.py
@@ -126,8 +126,8 @@ class SystemTestSuite(PytestSuite):
         self.eval_attr = kwargs.get('eval_attr', None)
         self.test_id = kwargs.get('test_id', self._default_test_id)
         self.fasttest = kwargs.get('fasttest', False)
-
-        self.processes = 0
+        self.disable_migrations = kwargs.get('disable_migrations', True)
+        self.processes = kwargs.get('processes', None)
         self.randomize = kwargs.get('randomize', None)
         self.settings = kwargs.get('settings', Env.TEST_SETTINGS)
         self.xdist_ip_addresses = kwargs.get('xdist_ip_addresses', None)
@@ -163,12 +163,22 @@ class SystemTestSuite(PytestSuite):
             'pytest',
             '--ds={}'.format('{}.envs.{}'.format(self.root, self.settings)),
             "--junitxml={}".format(self.xunit_report),
-            '-vvv',
-            '-s',
-            '--create-db',
-            '--migrations',
         ])
         cmd.extend(self.test_options_flags)
+        if self.verbosity < 1:
+            cmd.append("--quiet")
+        elif self.verbosity > 1:
+            # currently only two verbosity settings are supported, so using `-vvv`
+            # in place of `--verbose`, because it is needed to see migrations.
+            cmd.append("-vvv")
+
+        if self.disable_capture:
+            cmd.append("-s")
+
+        # TODO: Restore option
+        # if not self.disable_migrations:
+        if True:
+            cmd.append("--migrations")
 
         if self.xdist_ip_addresses:
             cmd.append('--dist=loadscope')
@@ -287,7 +297,9 @@ class LibTestSuite(PytestSuite):
         if self.verbosity < 1:
             cmd.append("--quiet")
         elif self.verbosity > 1:
-            cmd.append("--verbose")
+            # currently only two verbosity settings are supported, so using `-vvv`
+            # in place of `--verbose`, because it is needed to see migrations.
+            cmd.append("-vvv")
         if self.disable_capture:
             cmd.append("-s")
 

--- a/pavelib/utils/test/suites/pytest_suite.py
+++ b/pavelib/utils/test/suites/pytest_suite.py
@@ -127,7 +127,7 @@ class SystemTestSuite(PytestSuite):
         self.test_id = kwargs.get('test_id', self._default_test_id)
         self.fasttest = kwargs.get('fasttest', False)
 
-        self.processes = kwargs.get('processes', None)
+        self.processes = 0
         self.randomize = kwargs.get('randomize', None)
         self.settings = kwargs.get('settings', Env.TEST_SETTINGS)
         self.xdist_ip_addresses = kwargs.get('xdist_ip_addresses', None)
@@ -163,15 +163,13 @@ class SystemTestSuite(PytestSuite):
             'pytest',
             '--ds={}'.format('{}.envs.{}'.format(self.root, self.settings)),
             "--junitxml={}".format(self.xunit_report),
+            '-vvv',
+            '-s',
+            '--create-db',
+            '--migrations',
         ])
         cmd.extend(self.test_options_flags)
-        if self.verbosity < 1:
-            cmd.append("--quiet")
-        elif self.verbosity > 1:
-            cmd.append("--verbose")
 
-        if self.disable_capture:
-            cmd.append("-s")
         if self.xdist_ip_addresses:
             cmd.append('--dist=loadscope')
             if self.processes <= 0:

--- a/pavelib/utils/test/suites/pytest_suite.py
+++ b/pavelib/utils/test/suites/pytest_suite.py
@@ -175,9 +175,7 @@ class SystemTestSuite(PytestSuite):
         if self.disable_capture:
             cmd.append("-s")
 
-        # TODO: Restore option
-        # if not self.disable_migrations:
-        if True:
+        if not self.disable_migrations:
             cmd.append("--migrations")
 
         if self.xdist_ip_addresses:

--- a/pavelib/utils/test/suites/python_suite.py
+++ b/pavelib/utils/test/suites/python_suite.py
@@ -20,15 +20,15 @@ class PythonTestSuite(TestSuite):
     def __init__(self, *args, **kwargs):
         super(PythonTestSuite, self).__init__(*args, **kwargs)
         self.opts = kwargs
-        self.disable_migrations = kwargs.get('disable_migrations', True)
+        self.disable_migrations = False
         self.fasttest = kwargs.get('fasttest', False)
         self.subsuites = kwargs.get('subsuites', self._default_subsuites)
 
     def __enter__(self):
         super(PythonTestSuite, self).__enter__()
 
-        if self.disable_migrations:
-            os.environ['DISABLE_MIGRATIONS'] = '1'
+        # if self.disable_migrations:
+        #     os.environ['DISABLE_MIGRATIONS'] = '1'
 
         if not (self.fasttest or self.skip_clean):
             test_utils.clean_test_files()

--- a/pavelib/utils/test/suites/python_suite.py
+++ b/pavelib/utils/test/suites/python_suite.py
@@ -20,15 +20,15 @@ class PythonTestSuite(TestSuite):
     def __init__(self, *args, **kwargs):
         super(PythonTestSuite, self).__init__(*args, **kwargs)
         self.opts = kwargs
-        self.disable_migrations = False
+        self.disable_migrations = kwargs.get('disable_migrations', True)
         self.fasttest = kwargs.get('fasttest', False)
         self.subsuites = kwargs.get('subsuites', self._default_subsuites)
 
     def __enter__(self):
         super(PythonTestSuite, self).__enter__()
 
-        # if self.disable_migrations:
-        #     os.environ['DISABLE_MIGRATIONS'] = '1'
+        if self.disable_migrations:
+            os.environ['DISABLE_MIGRATIONS'] = '1'
 
         if not (self.fasttest or self.skip_clean):
             test_utils.clean_test_files()


### PR DESCRIPTION
Fix enable-migrations for unit tests.

ARCHBOM-1093

**Note:** This shouldn't change anything for Jenkins, but just enables someone to run this locally. 