### PR TITLE
Fix docstring of retrieve_last_sitewide_block_completed

### DIFF
--- a/openedx/core/djangoapps/user_api/accounts/utils.py
+++ b/openedx/core/djangoapps/user_api/accounts/utils.py
@@ -111,7 +111,7 @@ def _is_valid_social_username(value):
 def retrieve_last_sitewide_block_completed(user):
     """
     Completion utility
-    From a string 'username' or object User retrieve
+    From a given User object retrieve
     the last course block marked as 'completed' and construct a URL
 
     :param user: obj(User)


### PR DESCRIPTION
I noticed that this method has a wrong docstring since this commit was applied.

https://github.com/edx/edx-platform/commit/39f48a8c1038afffba5ef93076630edf03a61e8d#diff-f54d6af700cd824d3a8dd386ba32fb14L111