### PR TITLE
Cache site config per-request to reduce DB queries from template render

### DIFF
--- a/openedx/core/djangoapps/site_configuration/helpers.py
+++ b/openedx/core/djangoapps/site_configuration/helpers.py
@@ -3,12 +3,17 @@ Helpers methods for site configuration.
 """
 
 from django.conf import settings
-from edx_django_utils.cache import RequestCache
+from openedx.core.lib.cache_utils import request_cached
 
 
-def _uncached_get_current_site_configuration():
+@request_cached("site_config")
+def get_current_site_configuration():
     """
-    Uncached implementation of get_current_site_configuration.
+    Return configuration for the current site.
+
+    Returns:
+         (openedx.core.djangoapps.site_configuration.models.SiteConfiguration): SiteConfiguration instance associated
+         with the current site.
     """
     # Import is placed here to avoid circular import
     from openedx.core.djangoapps.theming.helpers import get_current_site
@@ -20,25 +25,6 @@ def _uncached_get_current_site_configuration():
         return getattr(site, "configuration", None)
     except SiteConfiguration.DoesNotExist:
         return None
-
-
-def get_current_site_configuration():
-    """
-    Return configuration for the current site.
-
-    Returns:
-         (openedx.core.djangoapps.site_configuration.models.SiteConfiguration): SiteConfiguration instance associated
-         with the current site.
-    """
-    dummy_key = "singleton"
-    cache = RequestCache("site_config")
-    response = cache.get_cached_response(dummy_key)
-    if response.is_found:
-        return response.value
-    else:
-        config = _uncached_get_current_site_configuration()
-        cache.set(dummy_key, config)
-        return config
 
 
 def is_site_configuration_enabled():

--- a/openedx/core/djangoapps/site_configuration/helpers.py
+++ b/openedx/core/djangoapps/site_configuration/helpers.py
@@ -2,19 +2,14 @@
 Helpers methods for site configuration.
 """
 
-
 from django.conf import settings
+from edx_django_utils.cache import RequestCache
 
 
-def get_current_site_configuration():
+def _uncached_get_current_site_configuration():
     """
-    Return configuration for the current site.
-
-    Returns:
-         (openedx.core.djangoapps.site_configuration.models.SiteConfiguration): SiteConfiguration instance associated
-         with the current site.
+    Uncached implementation of get_current_site_configuration.
     """
-
     # Import is placed here to avoid circular import
     from openedx.core.djangoapps.theming.helpers import get_current_site
     site = get_current_site()
@@ -25,6 +20,25 @@ def get_current_site_configuration():
         return getattr(site, "configuration", None)
     except SiteConfiguration.DoesNotExist:
         return None
+
+
+def get_current_site_configuration():
+    """
+    Return configuration for the current site.
+
+    Returns:
+         (openedx.core.djangoapps.site_configuration.models.SiteConfiguration): SiteConfiguration instance associated
+         with the current site.
+    """
+    dummy_key = "singleton"
+    cache = RequestCache("site_config")
+    response = cache.get_cached_response(dummy_key)
+    if response.is_found:
+        return response.value
+    else:
+        config = _uncached_get_current_site_configuration()
+        cache.set(dummy_key, config)
+        return config
 
 
 def is_site_configuration_enabled():

--- a/openedx/core/djangoapps/site_configuration/helpers.py
+++ b/openedx/core/djangoapps/site_configuration/helpers.py
@@ -2,6 +2,7 @@
 Helpers methods for site configuration.
 """
 
+
 from django.conf import settings
 from openedx.core.lib.cache_utils import request_cached
 
@@ -15,6 +16,7 @@ def get_current_site_configuration():
          (openedx.core.djangoapps.site_configuration.models.SiteConfiguration): SiteConfiguration instance associated
          with the current site.
     """
+
     # Import is placed here to avoid circular import
     from openedx.core.djangoapps.theming.helpers import get_current_site
     site = get_current_site()


### PR DESCRIPTION
ARCHBOM-1139: We were seeing about 150 queries to the django_site table and over 200 to memcached just to load the login page. A lot of these are via mako template rendering, but there are other sources, and this will hopefully nip it in the bud.