### PR TITLE
[PROD-999] - Fixing root cause of flaky JS test for discussions.

### DIFF
--- a/common/static/common/js/discussion/utils.js
+++ b/common/static/common/js/discussion/utils.js
@@ -485,7 +485,7 @@
         };
 
         DiscussionUtil.typesetMathJax = function(element) {
-            if (typeof MathJax !== 'undefined' && MathJax !== null && MathJax.Hub !== 'undefined') {
+            if (typeof MathJax !== 'undefined' && MathJax !== null && typeof MathJax.Hub !== 'undefined') {
                 MathJax.Hub.Queue(['Typeset', MathJax.Hub, element[0]]);
             }
         };


### PR DESCRIPTION
### [PROD-999](https://openedx.atlassian.net/browse/PROD-999)

### Description
The edx-platform-js-master tests are run as part of `edx-platform` deploys. If they fail, the code will not deploy. These tests are flaky, which means that failures cannot be trusted and we have unnecessarily prevented the latest code on `edx-platform` from being deployed.