### PR TITLE
Fix Jenkins virtualenv issue that masked stale dependency

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -61,7 +61,8 @@ pull: ## update the Docker image used by "make shell"
 	docker pull edxops/edxapp:latest
 
 requirements: ## install development environment requirements
-	pip install -qr requirements/edx/development.txt --exists-action w
+	pip install -qr requirements/edx/pip-tools.txt
+	pip-sync -q requirements/edx/development.txt requirements/edx/private.*
 
 shell: ## launch a bash shell in a Docker container with all edx-platform dependencies installed
 	docker run -it -e "NO_PYTHON_UNINSTALL=1" -e "PIP_INDEX_URL=https://pypi.python.org/simple" -e TERM \

--- a/scripts/jenkins-common.sh
+++ b/scripts/jenkins-common.sh
@@ -45,6 +45,12 @@ fi
 # Activate the Python virtualenv
 source $VENV_PATH/edx-venv/bin/activate
 
+# Hack to fix up egg-link files given that the virtualenv is not relocatable
+sed -i "s|^/home/jenkins/shallow-clone|`pwd`|" -- \
+    $VENV_PATH/edx-venv/lib/python*/site-packages/*.egg-link
+pip install -qr requirements/edx/pip-tools.txt
+pip-sync -q requirements/edx/testing.txt requirements/edx/django.txt
+
 # add the node packages dir to PATH
 PATH=$PATH:node_modules/.bin
 

--- a/scripts/xdist/prepare_xdist_nodes.sh
+++ b/scripts/xdist/prepare_xdist_nodes.sh
@@ -12,13 +12,13 @@ python scripts/xdist/pytest_worker_manager.py -a up -n ${XDIST_NUM_WORKERS} \
 
 # Install the correct version of Django depending on which tox environment (if any) is in use
 if [[ -z ${TOXENV+x} ]] || [[ ${TOXENV} == 'null' ]]; then
-    DJANGO_REQUIREMENT="-r requirements/edx/django.txt"
+    DJANGO_REQUIREMENT="requirements/edx/django.txt"
 elif [[ ${TOXENV} == *'django20'* ]]; then
-    DJANGO_REQUIREMENT="-r requirements/edx/django20.txt"
+    DJANGO_REQUIREMENT="requirements/edx/django20.txt"
 elif [[ ${TOXENV} == *'django21'* ]]; then
-    DJANGO_REQUIREMENT="-r requirements/edx/django21.txt"
+    DJANGO_REQUIREMENT="requirements/edx/django21.txt"
 elif [[ ${TOXENV} == *'django22'* ]]; then
-    DJANGO_REQUIREMENT="-r requirements/edx/django.txt"
+    DJANGO_REQUIREMENT="requirements/edx/django.txt"
 fi
 
 ip_list=$(<pytest_worker_ips.txt)
@@ -27,10 +27,7 @@ do
     worker_reqs_cmd="ssh -o StrictHostKeyChecking=no jenkins@$ip
     'git clone --branch master --depth 1 -q https://github.com/edx/edx-platform.git; cd edx-platform;
     git fetch -fq origin ${XDIST_GIT_REFSPEC}; git checkout -q ${XDIST_GIT_BRANCH};
-    rm -rf /home/jenkins/edx-venv-${PYTHON_VERSION}/edx-venv;
-    tar -C /home/jenkins/edx-venv-${PYTHON_VERSION} -xf /home/jenkins/edx-venv_clean-${PYTHON_VERSION}.tar.gz;
-    source ../edx-venv-${PYTHON_VERSION}/edx-venv/bin/activate;
-    pip install -q ${DJANGO_REQUIREMENT} -r requirements/edx/testing.txt; mkdir reports' & "
+    scripts/xdist/setup_worker.sh -p $PYTHON_VERSION -d $DJANGO_REQUIREMENT' & "
 
     cmd=$cmd$worker_reqs_cmd
 done

--- a/scripts/xdist/setup_worker.sh
+++ b/scripts/xdist/setup_worker.sh
@@ -18,6 +18,10 @@ rm -rf $venv
 tar -C $venv_parent -xf /home/jenkins/edx-venv_clean-${PYTHON_VERSION}.tar.gz
 source $venv/bin/activate
 
-pip install -q -r ${DJANGO_REQUIREMENT} -r requirements/edx/testing.txt
+# Hack to fix up egg-link files given that the virtualenv is not relocatable
+sed -i "s|\(^/home/jenkins\)/shallow-clone|\1/edx-platform|" -- \
+    $venv/lib/python*/site-packages/*.egg-link
+pip install -qr requirements/edx/pip-tools.txt
+pip-sync -q requirements/edx/testing.txt "${DJANGO_REQUIREMENT}"
 
 mkdir reports

--- a/scripts/xdist/setup_worker.sh
+++ b/scripts/xdist/setup_worker.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+# Set up worker node.
+
+while getopts 'p:d:' opt; do
+    case "$opt" in
+	p) PYTHON_VERSION="$OPTARG";;
+	d) DJANGO_REQUIREMENT="$OPTARG";;
+	[?])
+	    print >&2 "Usage: $0 -p python-version -d django-reqs-file"
+	    exit 1
+            ;;
+    esac
+done
+
+venv_parent=/home/jenkins/edx-venv-${PYTHON_VERSION}
+venv=$venv_parent/edx-venv
+rm -rf $venv
+tar -C $venv_parent -xf /home/jenkins/edx-venv_clean-${PYTHON_VERSION}.tar.gz
+source $venv/bin/activate
+
+pip install -q -r ${DJANGO_REQUIREMENT} -r requirements/edx/testing.txt
+
+mkdir reports


### PR DESCRIPTION
This fixes a dependency management issue on Jenkins by using `pip-sync` rather than `pip install`, since the latter leaves stale dependencies in the copy of the cached virtualenv.