### PR TITLE
Show graded icons in more places

### DIFF
--- a/common/lib/xmodule/xmodule/lti_module.py
+++ b/common/lib/xmodule/xmodule/lti_module.py
@@ -345,7 +345,8 @@ class LTIModule(LTIFields, LTI20ModuleMixin, XModule):
         ]
     }
     css = {'scss': [resource_string(__name__, 'css/lti/lti.scss')]}
-    js_module_name = "LTI"
+    js_module_name = 'LTI'
+    icon_class = 'problem'
 
     def get_input_fields(self):
         # LTI provides a list of default parameters that might be passed as

--- a/openedx/features/course_experience/templates/course_experience/course-outline-fragment.html
+++ b/openedx/features/course_experience/templates/course_experience/course-outline-fragment.html
@@ -79,7 +79,7 @@ reset_deadlines_banner_displayed = False
                                 class="subsection-text outline-button"
                                 id="${ subsection['id'] }"
                             >
-                            % if num_graded_problems and not (subsection.get('format') or 'special_exam_info' in subsection):
+                            % if graded and scored and 'special_exam_info' not in subsection:
                                       <span class="icon fa fa-pencil-square-o" aria-hidden="true"></span>
                             % endif
                                       <h4 class="subsection-title">

--- a/openedx/features/course_experience/utils.py
+++ b/openedx/features/course_experience/utils.py
@@ -149,8 +149,10 @@ def get_course_outline_block_tree(request, course_id, user=None):
         """
         is_scored = block.get('has_score') and block.get('weight', 1) > 0
         is_graded = block.get('graded')
+        is_countable = block.get('type') not in ('lti', 'lti_consumer')
+        is_graded_problem = is_scored and is_graded and is_countable
 
-        num_graded_problems = 1 if is_scored and is_graded else 0
+        num_graded_problems = 1 if is_graded_problem else 0
         num_graded_problems += sum(recurse_num_graded_problems(child) for child in block.get('children', []))
 
         block['num_graded_problems'] = num_graded_problems
@@ -186,7 +188,9 @@ def get_course_outline_block_tree(request, course_id, user=None):
         'discussion',
         'drag-and-drop-v2',
         'poll',
-        'word_cloud'
+        'word_cloud',
+        'lti',
+        'lti_consumer',
     ]
     all_blocks = get_blocks(
         request,

--- a/requirements/edx/github.in
+++ b/requirements/edx/github.in
@@ -92,7 +92,7 @@ git+https://github.com/edx/crowdsourcehinter.git@2178ac72891392106ffef389651aef3
 -e git+https://github.com/edx/RateXBlock.git@2.0#egg=rate-xblock
 -e git+https://github.com/edx/DoneXBlock.git@2.0.2#egg=done-xblock
 -e git+https://github.com/edx-solutions/xblock-google-drive.git@2d176468e33c0713c911b563f8f65f7cf232f5b6#egg=xblock-google-drive
-git+https://github.com/edx/xblock-lti-consumer.git@v1.2.5#egg=lti_consumer-xblock==1.2.5
+git+https://github.com/edx/xblock-lti-consumer.git@v1.2.6#egg=lti_consumer-xblock==1.2.6
 
 
 # Third Party XBlocks


### PR DESCRIPTION
In the course outline, if a subsection has any graded content, show a graded icon (the pencil icon).

Also, show the graded icon for LTI xmodule units (xblocks is a different repo, but will get same treatment).

https://openedx.atlassian.net/browse/AA-75