### PR TITLE
We don't run into this case anymore so remove it.

### DIFF
--- a/common/djangoapps/course_modes/models.py
+++ b/common/djangoapps/course_modes/models.py
@@ -191,13 +191,6 @@ class CourseMode(models.Model):
         unique_together = ('course', 'mode_slug', 'currency')
 
     def __init__(self, *args, **kwargs):
-        if 'course_id' in kwargs:
-            course_id = kwargs['course_id']
-            if isinstance(course_id, str):
-                kwargs['course_id'] = CourseKey.from_string(course_id)
-                call_location = "\n".join("%30s : %s:%d" % (t[3], t[1], t[2]) for t in inspect.stack()[::-1])
-                log.warning("Forced to coerce course_id in CourseMode instantiation: %s", call_location)
-
         super(CourseMode, self).__init__(*args, **kwargs)
 
     def clean(self):

--- a/common/djangoapps/student/models.py
+++ b/common/djangoapps/student/models.py
@@ -1126,13 +1126,6 @@ class CourseEnrollment(models.Model):
         ordering = ('user', 'course')
 
     def __init__(self, *args, **kwargs):
-        if 'course_id' in kwargs:
-            course_id = kwargs['course_id']
-            if isinstance(course_id, str):
-                kwargs['course_id'] = CourseKey.from_string(course_id)
-                call_location = "\n".join("%30s : %s:%d" % (t[3], t[1], t[2]) for t in inspect.stack()[::-1])
-                log.warning("Forced to coerce course_id in CourseEnrollment instantiation: %s", call_location)
-
         super(CourseEnrollment, self).__init__(*args, **kwargs)
 
         # Private variable for storing course_overview to minimize calls to the database.


### PR DESCRIPTION
This was added in here as a shim to catch places that were still using
the old version of these models that had an attribute called course_id
instead of the `course` foreign key.  After monitoring production for
two weeks, we can be pretty confident that we've caught most places that
do this.  Removing this code since it should no longer be needed.