### PR TITLE
[WIP] Management command to launch a grade report

### DIFF
--- a/lms/djangoapps/grades/management/commands/generate_csv_grade_reports.py
+++ b/lms/djangoapps/grades/management/commands/generate_csv_grade_reports.py
@@ -3,48 +3,64 @@
 Command to automatically produce the grade reports as CSV files.
 The reports and the destination location are the same as the "Generate grade report" button
 which is available in the instructor dashboard.
-The files must be retrieved manually.
+The files must be retrieved manually from the instructor dashboard.
+
+Note: this is a prototype, a proof of concept. Code is still ugly. When we check that the
+approach works as expected, we'll work on the elegant solution to be sent upstream.
 """
 
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 import csv
+import logging
 
 from django.contrib.auth.models import User
 from django.core.management.base import BaseCommand
 
 import lms.djangoapps.instructor_task.api
+from lms.djangoapps.instructor_task.tasks import calculate_grades_csv
+from lms.djangoapps.instructor_task.api_helper import _reserve_task
 from lms.djangoapps.grades.tasks import recalculate_course_and_subsection_grades_for_user
 from openedx.core.lib.command_utils import get_mutually_exclusive_required_option, parse_course_keys
 from xmodule.modulestore.django import modulestore
 
+from util.db import outer_atomic
 
-# FIXME implement this in a clean way, or remove the requirement of passsing a request object
-class FakeRequestWithUser:
-    user = None
-    META = {}
+LOGGER = logging.getLogger(__name__)
 
-    def __init__(self, user):
-        self.user = user
-        self.META['SERVER_NAME'] = 'afakehostname'
-        self.META['HTTP_X_FORWARDED_PROTO'] = 'https'
-        self.META['REMOTE_ADDR'] = '127.0.0.1'
-
-    def is_secure(self):
-        # yes, very
-        return True
-
-    def get_host(self):
-        return "afakehostname"
+# Used in v1
+# class FakeRequestWithUser:
+#     user = None
+#     META = {}
+#
+#     def __init__(self, user):
+#         self.user = user
+#         self.META['SERVER_NAME'] = 'afakehostname'
+#         self.META['HTTP_X_FORWARDED_PROTO'] = 'https'
+#         self.META['REMOTE_ADDR'] = '127.0.0.1'
+#
+#     def is_secure(self):
+#         # yes, very
+#         return True
+#
+#     def get_host(self):
+#         return "afakehostname"
 
 
 class Command(BaseCommand):
     """
-    FIXME: write.
-    Example usage:
-        $ ./manage.py lms recalculate_learner_grades learner_courses_to_recalculate.csv
+    Management command to launch the generation of a grade report task.
     """
-    help = 'FIXME: add.    Recalculates a user\'s grades for a course, for every user in a csv of (user, course) pairs'
+    help = """
+    Launch a grade report task for the chosen courses.
+    It has the same effect as clicking the button in the Instructor Dashboard. The grade reports can be
+    downloaded from the Instructor Dashboard.
+
+    It's particularly useful in a cron job when there are many courses whose grades need to be exported daily.
+
+    Example usage:
+        $ ./manage.py lms generate_csv_grade_reports --requester adminstaff --courses course-v1:edX+DemoX+Demo_Course course-v1:DCL+TE1+2018-01
+    """
 
     def add_arguments(self, parser):
         parser.add_argument(
@@ -59,11 +75,19 @@ class Command(BaseCommand):
             action='store_true',
             default=False,
         )
+        parser.add_argument(
+            '--requester',
+            help='Username of user that appears as requester of the grade report.',
+            type=str,
+            required=True,
+        )
 
     def handle(self, *args, **options):
-        user = User.objects.get(username='edx')  # FIXME
+        user = User.objects.get(username=options['requester'])
+        LOGGER.info("Launching reports from username %s", user.username)
         for course_key in self._get_course_keys(options):
-            print("Generating report", course_key)
+            LOGGER.info("Launching report for course %s", course_key)
+
             # v1, works:
             # request = FakeRequestWithUser(user=user)
             # lms.djangoapps.instructor_task.api.submit_calculate_grades_csv(request, course_key)
@@ -89,26 +113,18 @@ class Command(BaseCommand):
             #     _handle_instructor_task_failure(instructor_task, error)
 
             # v4: like v3 but overwriting data to reduce calling internal methods:
-            # FIXME: maybe move into api_helper, so that calling private methods be fine
-            from lms.djangoapps.instructor_task.tasks import calculate_grades_csv
-            from lms.djangoapps.instructor_task.api_helper import _reserve_task
-            from util.db import outer_atomic
+            # Could be moved into api_helper, so that calling private methods be fine
             with outer_atomic():
                 # check to see if task is already running, and reserve it otherwise:
                 instructor_task = _reserve_task(course_key, 'grade_course', "", {}, user)
             task_id = instructor_task.task_id
             # overwriting (testing)
             task_args = [instructor_task.id, {'request_info': {}, 'task_id': task_id}]
-            print("task_args (overwritten):", task_args)
+            # print("task_args (overwritten):", task_args)
             try:
                 calculate_grades_csv.apply_async(task_args, task_id=task_id)
-        
             except Exception as error:
                 _handle_instructor_task_failure(instructor_task, error)
-
-
-
-
 
     def _get_course_keys(self, options):
         """

--- a/lms/djangoapps/grades/management/commands/generate_csv_grade_reports.py
+++ b/lms/djangoapps/grades/management/commands/generate_csv_grade_reports.py
@@ -1,0 +1,69 @@
+"""
+Command to automatically produce the grade reports as CSV files.
+The reports and the destination location are the same as the "Generate grade report" button
+which is available in the instructor dashboard.
+The files must be retrieved manually.
+"""
+
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+import csv
+
+from django.contrib.auth.models import User
+from django.core.management.base import BaseCommand
+
+import lms.djangoapps.instructor_task.api
+from lms.djangoapps.grades.tasks import recalculate_course_and_subsection_grades_for_user
+from openedx.core.lib.command_utils import get_mutually_exclusive_required_option, parse_course_keys
+from xmodule.modulestore.django import modulestore
+
+class Command(BaseCommand):
+    """
+    FIXME: write.
+    Example usage:
+        $ ./manage.py lms recalculate_learner_grades learner_courses_to_recalculate.csv
+    """
+    help = 'FIXME: add.    Recalculates a user\'s grades for a course, for every user in a csv of (user, course) pairs'
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            '--courses',
+            dest='courses',
+            nargs='+',
+            help='List of (space separated) courses to report (each to a separate CSV).',
+        )
+        parser.add_argument(
+            '--all_courses',
+            help='Generate grade reports for all courses.',
+            action='store_true',
+            default=False,
+        )
+
+    def handle(self, *args, **options):
+        user = User.objects.get(username='edx')  # FIXME
+        for course_key in self._get_course_keys(options):
+            print("Generating report", course_key)
+
+            # FIXME implement this in a clean way, or remove the requirement of passsing a request object
+            class FakeRequestWithUser:
+                user = None
+                META = {}
+                def __init__(self, user):
+                    self.user = user
+                    self.META['REMOTE_ADDR'] = '127.0.0.1'
+
+            request = FakeRequestWithUser(user=user)
+            lms.djangoapps.instructor_task.api.submit_calculate_grades_csv(request, course_key)
+
+
+    def _get_course_keys(self, options):
+        """
+        Return a list of courses that need grade reports.
+        """
+        courses_mode = get_mutually_exclusive_required_option(options, 'courses', 'all_courses')
+        if courses_mode == 'all_courses':
+            course_keys = [course.id for course in modulestore().get_course_summaries()]
+        elif courses_mode == 'courses':
+            course_keys = parse_course_keys(options['courses'])
+        return course_keys
+

--- a/lms/djangoapps/grades/management/commands/generate_csv_grade_reports.py
+++ b/lms/djangoapps/grades/management/commands/generate_csv_grade_reports.py
@@ -19,7 +19,7 @@ from django.core.management.base import BaseCommand
 
 import lms.djangoapps.instructor_task.api
 from lms.djangoapps.instructor_task.tasks import calculate_grades_csv
-from lms.djangoapps.instructor_task.api_helper import _reserve_task
+from lms.djangoapps.instructor_task.api_helper import _reserve_task, _handle_instructor_task_failure
 from lms.djangoapps.grades.tasks import recalculate_course_and_subsection_grades_for_user
 from openedx.core.lib.command_utils import get_mutually_exclusive_required_option, parse_course_keys
 from xmodule.modulestore.django import modulestore
@@ -92,35 +92,14 @@ class Command(BaseCommand):
             # request = FakeRequestWithUser(user=user)
             # lms.djangoapps.instructor_task.api.submit_calculate_grades_csv(request, course_key)
 
-            # v2, expanding „request“:
-            # from lms.djangoapps.instructor_task.tasks import calculate_grades_csv
-            # submit_task(request, 'grade_course', calculate_grades_csv, course_key, {}, "")
-
-            # v3. expanding „request“ still more, and a lot of bad copy+paste, and some forbidden calls
-            # from lms.djangoapps.instructor_task.tasks import calculate_grades_csv
-            # from lms.djangoapps.instructor_task.api_helper import _reserve_task, _get_xmodule_instance_args
-            # from util.db import outer_atomic
-            # with outer_atomic():
-            #     # check to see if task is already running, and reserve it otherwise:
-            #     instructor_task = _reserve_task(course_key, 'grade_course', "", {}, user)
-            # task_id = instructor_task.task_id
-            # task_args = [instructor_task.id, _get_xmodule_instance_args(request, task_id)]
-            # print("task_args are:", task_args)
-            # try:
-            #     calculate_grades_csv.apply_async(task_args, task_id=task_id)
-            # 
-            # except Exception as error:
-            #     _handle_instructor_task_failure(instructor_task, error)
-
-            # v4: like v3 but overwriting data to reduce calling internal methods:
-            # Could be moved into api_helper, so that calling private methods be fine
+            # v2: doesn't use a fake request object, but it calls private methods (bad)
+            # We propose to move this code to a new function in instructor_task/api_helper.py
+            # or even to integrate it with the current submit_task() there
             with outer_atomic():
                 # check to see if task is already running, and reserve it otherwise:
                 instructor_task = _reserve_task(course_key, 'grade_course', "", {}, user)
             task_id = instructor_task.task_id
-            # overwriting (testing)
             task_args = [instructor_task.id, {'request_info': {}, 'task_id': task_id}]
-            # print("task_args (overwritten):", task_args)
             try:
                 calculate_grades_csv.apply_async(task_args, task_id=task_id)
             except Exception as error:


### PR DESCRIPTION
**Work in progress**.
This pull request serves to ask to edX:
- is there interest in merging this feature?
- what changes would need to happen to merge it upstream? In particular, what Python APIs can we contribute
---

This PR adds a `generate_csv_grade_reports` management command that launches the grade report for the selected course (or for all courses). It's equivalent to clicking the `Generate grade report` button in the instructor dashboard, but since it's a management command it can be automated in a cron job to launch these reports every day. This is specially useful to launch reports during the night, when the server load is lower (since those reports are resource-intensive). 

To run it:
`./manage.py lms generate_csv_grade_reports --requester adminstaff --courses course-v1:edX+DemoX+Demo_Course course-v1:DCL+TE1+2018-01`

**JIRA tickets**: unknown. This is SE-1643 internally

**Dependencies**: None

**Screenshots**: None

**Sandbox URL**: N/A.

**Merge deadline**: None

**Testing instructions**:

1. See command above. Use your username as requester (tasks need to have an owner)
2. Go to that course's instructor dashboard. You'll see a newly launched grade report job
3. Wait until it finishes. You'll be able to download the report in the same way as if you had clicked the button yourself
4. Repeat tests for: two or more courses (comma-separated), or all courses. TODO: more detailed test instructions for this 

**Author notes and concerns**:

The code works, but it's still ugly because it calls private methods from `api_helper.py`. We'd like to validate the approach before we add new APIs.

Some next steps/options are:
1. the current [submit_task](https://github.com/open-craft/edx-platform/blob/dbdde489c6f05b93689e3e7645394b29ea0e5763/lms/djangoapps/instructor_task/api_helper.py#L428) requires a `request` object to extract the username. We could change the function signature so that it accept a `request` object or, if it's None, a username
2. or we could add a parallel function, like `submit_task` but without requiring a `request` object. This could be in `api.py` (besides `ap_helper.py`)
3. or pass a fake `request` object and avoid changing the `api_helper` code

Other major direction changes would be:
- to be able to launch a grade report without specifying any username. Let it be shown as *admin* or *system*
- to make this management command be able to automate any type of report, not only the grade report
- to add a web UI to customize the automatic launching of reports 

**Reviewers**
- [ ] @swalladge
- [ ] edX reviewer[s] TBD
