### PR TITLE
Fix discussion template for translations.

### DIFF
--- a/common/static/common/templates/discussion/templates.underscore
+++ b/common/static/common/templates/discussion/templates.underscore
@@ -565,7 +565,7 @@
 </script>
 <script aria-hidden="true" type="text/template" id="inline-discussion-template">
 <section class="discussion inline-discussion" data-discussion-id="<%- discussionId %>">
-    <div class="add_post_btn_container <%if (read_only) {%>is-hidden<%} %>">
+    <div class="add_post_btn_container <% if (read_only) { %> is-hidden <% } %>">
         <button class="btn-link new-post-btn"><%- gettext("Add a Post") %></button>
     </div>
 


### PR DESCRIPTION
A parsing error was causing underscore template
not to be processed during message
extractions phase and to be available on transifex.

PROD-1504