### PR TITLE
Check contentlibrary permissions only if user is logged in

### DIFF
--- a/openedx/core/djangoapps/content_libraries/permissions.py
+++ b/openedx/core/djangoapps/content_libraries/permissions.py
@@ -56,7 +56,7 @@ perms[CAN_LEARN_FROM_THIS_CONTENT_LIBRARY] = (
     # Regular users can learn if the library allows public learning:
     Attribute('allow_public_learning', True) |
     # Users/groups who are explicitly granted permission can learn from the library:
-    has_explicit_read_permission_for_library
+    (is_user_active & has_explicit_read_permission_for_library)
 )
 
 # Is the user allowed to create content libraries?

--- a/openedx/core/tests/test_admin_view.py
+++ b/openedx/core/tests/test_admin_view.py
@@ -41,7 +41,6 @@ class TestAdminView(TestCase):
             response = self.client.get(reverse('admin:login'))
             assert response.url == '/login?next=/admin'
             assert response.status_code == 302
-        
         with ENABLE_LOGIN_USING_THIRDPARTY_AUTH_ONLY.override(False):
             response = self.client.get(reverse('admin:login'))
             assert response.template_name == ['admin/login.html']

--- a/openedx/core/tests/test_admin_view.py
+++ b/openedx/core/tests/test_admin_view.py
@@ -41,3 +41,7 @@ class TestAdminView(TestCase):
             response = self.client.get(reverse('admin:login'))
             assert response.url == '/login?next=/admin'
             assert response.status_code == 302
+        
+        with ENABLE_LOGIN_USING_THIRDPARTY_AUTH_ONLY.override(False):
+            response = self.client.get(reverse('admin:login'))
+            assert response.template_name == ['admin/login.html']


### PR DESCRIPTION
This PR fix a bug with `contentlibrary` permissions being checked for anonymous user which result in a exception.

When accessing Django admin with `ENABLE_LOGIN_USING_THIRDPARTY_AUTH_ONLY = False`, django admin app is building every permissions, and Bridgekeeper tries to cast `AnonymousUser` into an `int` while building permissions, which result in an exception.

Exception with updated test:

```
# pytest openedx/core/tests/test_admin_view.py

self = <openedx.core.tests.test_admin_view.TestAdminView testMethod=test_admin_login_redirect>

    def test_admin_login_redirect(self):
        with ENABLE_LOGIN_USING_THIRDPARTY_AUTH_ONLY.override(True):
            response = self.client.get(reverse('admin:login'))
            assert response.url == '/login?next=/admin'
            assert response.status_code == 302

        with ENABLE_LOGIN_USING_THIRDPARTY_AUTH_ONLY.override(False):
>           response = self.client.get(reverse('admin:login'))

openedx/core/tests/test_admin_view.py:46:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
../venvs/edxapp/lib/python3.5/site-packages/django/test/client.py:535: in get
    response = super().get(path, data=data, secure=secure, **extra)
../venvs/edxapp/lib/python3.5/site-packages/django/test/client.py:347: in get
    **extra,
../venvs/edxapp/lib/python3.5/site-packages/django/test/client.py:422: in generic
    return self.request(**r)
../venvs/edxapp/lib/python3.5/site-packages/django/test/client.py:503: in request
    raise exc_value
../venvs/edxapp/lib/python3.5/site-packages/django/core/handlers/exception.py:34: in inner
    response = get_response(request)
../venvs/edxapp/lib/python3.5/site-packages/django/core/handlers/base.py:115: in _get_response
    response = self.process_exception_by_middleware(e, request)
../venvs/edxapp/lib/python3.5/site-packages/django/core/handlers/base.py:113: in _get_response
    response = wrapped_callback(request, *callback_args, **callback_kwargs)
/usr/lib/python3.5/contextlib.py:30: in inner
    return func(*args, **kwds)
openedx/core/djangoapps/user_authn/views/login.py:482: in redirect_to_lms_login
    return admin.site.login(request)
../venvs/edxapp/lib/python3.5/site-packages/django/views/decorators/cache.py:44: in _wrapped_view_func
    response = view_func(request, *args, **kwargs)
../venvs/edxapp/lib/python3.5/site-packages/django/contrib/admin/sites.py:383: in login
    **self.each_context(request),
../venvs/edxapp/lib/python3.5/site-packages/django/contrib/admin/sites.py:302: in each_context
    'available_apps': self.get_app_list(request),
../venvs/edxapp/lib/python3.5/site-packages/django/contrib/admin/sites.py:474: in get_app_list
    app_dict = self._build_app_dict(request)
../venvs/edxapp/lib/python3.5/site-packages/django/contrib/admin/sites.py:419: in _build_app_dict
    has_module_perms = model_admin.has_module_permission(request)
../venvs/edxapp/lib/python3.5/site-packages/django/contrib/admin/options.py:537: in has_module_permission
    return request.user.has_module_perms(self.opts.app_label)
../venvs/edxapp/lib/python3.5/site-packages/django/contrib/auth/models.py:423: in has_module_perms
    return _user_has_module_perms(self, module)
../venvs/edxapp/lib/python3.5/site-packages/django/contrib/auth/models.py:197: in _user_has_module_perms
    if backend.has_module_perms(user, app_label):
../venvs/edxapp/lib/python3.5/site-packages/bridgekeeper/backends.py:38: in has_module_perms
    if rule.is_possible_for(user):
../venvs/edxapp/lib/python3.5/site-packages/bridgekeeper/rules.py:85: in is_possible_for
    return self.query(user) is not EMPTY
../venvs/edxapp/lib/python3.5/site-packages/bridgekeeper/rules.py:191: in query
    right = self.right.query(user)
../venvs/edxapp/lib/python3.5/site-packages/bridgekeeper/rules.py:521: in query
    return Q(**{self.query_attr + '__in': self.model.objects.filter(related_q)})
../venvs/edxapp/lib/python3.5/site-packages/django/db/models/manager.py:82: in manager_method
    return getattr(self.get_queryset(), name)(*args, **kwargs)
../venvs/edxapp/lib/python3.5/site-packages/django/db/models/query.py:892: in filter
    return self._filter_or_exclude(False, *args, **kwargs)
../venvs/edxapp/lib/python3.5/site-packages/django/db/models/query.py:910: in _filter_or_exclude
    clone.query.add_q(Q(*args, **kwargs))
../venvs/edxapp/lib/python3.5/site-packages/django/db/models/sql/query.py:1290: in add_q
    clause, _ = self._add_q(q_object, self.used_aliases)
../venvs/edxapp/lib/python3.5/site-packages/django/db/models/sql/query.py:1312: in _add_q
    current_negated, allow_joins, split_subq, simple_col)
../venvs/edxapp/lib/python3.5/site-packages/django/db/models/sql/query.py:1318: in _add_q
    split_subq=split_subq, simple_col=simple_col,
../venvs/edxapp/lib/python3.5/site-packages/django/db/models/sql/query.py:1251: in build_filter
    condition = self.build_lookup(lookups, col, value)
../venvs/edxapp/lib/python3.5/site-packages/django/db/models/sql/query.py:1116: in build_lookup
    lookup = lookup_class(lhs, rhs)
../venvs/edxapp/lib/python3.5/site-packages/django/db/models/lookups.py:20: in __init__
    self.rhs = self.get_prep_lookup()
../venvs/edxapp/lib/python3.5/site-packages/django/db/models/fields/related_lookups.py:115: in get_prep_lookup
    self.rhs = target_field.get_prep_value(self.rhs)
../venvs/edxapp/lib/python3.5/site-packages/django/db/models/fields/__init__.py:972: in get_prep_value
    return int(value)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

self = <django.contrib.auth.models.AnonymousUser object at 0x7f4ebe973ba8>

    def __int__(self):
>       raise TypeError('Cannot cast AnonymousUser to int. Are you trying to use it in place of User?')
E       TypeError: Cannot cast AnonymousUser to int. Are you trying to use it in place of User?

../venvs/edxapp/lib/python3.5/site-packages/django/contrib/auth/models.py:388: TypeError
```

Fixed permission: 

```python
CAN_LEARN_FROM_THIS_CONTENT_LIBRARY = 'content_libraries.learn_from_library'
perms[CAN_LEARN_FROM_THIS_CONTENT_LIBRARY] = (
    # Global staff can learn from any library:
    is_global_staff |
    # Regular users can learn if the library allows public learning:
    Attribute('allow_public_learning', True) |
    # Users/groups who are explicitly granted permission can learn from the library:
    (is_user_active & has_explicit_read_permission_for_library)
)
```

`has_explicit_read_permission_for_library` should be called only with `is_user_active` since this rule will try to use `AnonymousUser` as a real user and execute some database lookup with it.

**JIRA tickets**: [CRI-188](https://openedx.atlassian.net/projects/CRI/issues/CRI-188)

**Sandbox URL**: [LMS](https://pr23814.sandbox.opencraft.hosting/) / [Studio](https://studio.pr23814.sandbox.opencraft.hosting/)

**Merge deadline**: None

**Testing instructions**:

- Set up devstack with default settings and go to http://localhost:18000/admin without being logged in
- You should see Django login form

**Reviewers**:

- [ ] @pomegranited 
- [ ] edX TBD