### PR TITLE
Bump xblock-lti-consumer to 1.2.6

### DIFF
--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -149,7 +149,7 @@ lazy==1.4                 # via -r requirements/edx/paver.txt, acid-xblock, ora2
 lepl==5.1.3               # via rfc6266-parser
 libsass==0.10.0           # via -r requirements/edx/paver.txt, ora2
 loremipsum==1.0.5         # via ora2
-git+https://github.com/edx/xblock-lti-consumer.git@v1.2.5#egg=lti_consumer-xblock==1.2.5  # via -r requirements/edx/github.in
+git+https://github.com/edx/xblock-lti-consumer.git@v1.2.6#egg=lti_consumer-xblock==1.2.6  # via -r requirements/edx/github.in
 lxml==4.5.0               # via -r requirements/edx/../edx-sandbox/shared.txt, capa, edxval, lti-consumer-xblock, ora2, safe-lxml, xblock, xmlsec
 mailsnake==1.6.4          # via -r requirements/edx/base.in
 mako==1.0.2               # via -r requirements/edx/base.in, acid-xblock, lti-consumer-xblock, xblock-google-drive, xblock-utils

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -179,7 +179,7 @@ lazy==1.4                 # via -r requirements/edx/testing.txt, acid-xblock, bo
 lepl==5.1.3               # via -r requirements/edx/testing.txt, rfc6266-parser
 libsass==0.10.0           # via -r requirements/edx/testing.txt, ora2
 loremipsum==1.0.5         # via -r requirements/edx/testing.txt, ora2
-git+https://github.com/edx/xblock-lti-consumer.git@v1.2.5#egg=lti_consumer-xblock==1.2.5  # via -r requirements/edx/testing.txt
+git+https://github.com/edx/xblock-lti-consumer.git@v1.2.6#egg=lti_consumer-xblock==1.2.6  # via -r requirements/edx/testing.txt
 lxml==4.5.0               # via -r requirements/edx/testing.txt, capa, edxval, lti-consumer-xblock, ora2, pyquery, safe-lxml, xblock, xmlsec
 m2r==0.2.1                # via sphinxcontrib-openapi
 mailsnake==1.6.4          # via -r requirements/edx/testing.txt

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -172,7 +172,7 @@ lazy==1.4                 # via -r requirements/edx/base.txt, acid-xblock, bok-c
 lepl==5.1.3               # via -r requirements/edx/base.txt, rfc6266-parser
 libsass==0.10.0           # via -r requirements/edx/base.txt, ora2
 loremipsum==1.0.5         # via -r requirements/edx/base.txt, ora2
-git+https://github.com/edx/xblock-lti-consumer.git@v1.2.5#egg=lti_consumer-xblock==1.2.5  # via -r requirements/edx/base.txt
+git+https://github.com/edx/xblock-lti-consumer.git@v1.2.6#egg=lti_consumer-xblock==1.2.6  # via -r requirements/edx/base.txt
 lxml==4.5.0               # via -r requirements/edx/base.txt, capa, edxval, lti-consumer-xblock, ora2, pyquery, safe-lxml, xblock, xmlsec
 mailsnake==1.6.4          # via -r requirements/edx/base.txt
 mako==1.0.2               # via -r requirements/edx/base.txt, acid-xblock, lti-consumer-xblock, xblock-google-drive, xblock-utils


### PR DESCRIPTION
This adds a graded icon for LTI units. This was meant to go into a recent commit, but I only updated github.in not the txt requirement files.

https://openedx.atlassian.net/browse/AA-75