### PR TITLE
Dark launch: Fix 1+N queries in third party auth config fetching

### DIFF
--- a/common/djangoapps/third_party_auth/provider.py
+++ b/common/djangoapps/third_party_auth/provider.py
@@ -45,8 +45,7 @@ class Registry(object):
     @classmethod
     def _enabled_providers(cls):
         """
-        Helper method that returns a generator used to iterate over all providers
-        of the current site.
+        Generator returning all enabled providers of the current site.
 
         Provider configurations are partitioned on site + some key (backend
         name in the case of OAuth, slug for SAML, and consumer key for LTI).
@@ -145,21 +144,6 @@ class Registry(object):
         Yields:
             Instances of ProviderConfig.
         """
-        if backend_name in _PSA_OAUTH2_BACKENDS:
-            oauth2_backend_names = OAuth2ProviderConfig.key_values('backend_name', flat=True)
-            for oauth2_backend_name in oauth2_backend_names:
-                provider = OAuth2ProviderConfig.current(oauth2_backend_name)
-                if provider.backend_name == backend_name and provider.enabled_for_current_site:
-                    yield provider
-        elif backend_name in _PSA_SAML_BACKENDS and SAMLConfiguration.is_enabled(
-                Site.objects.get_current(get_current_request()), 'default'):
-            idp_names = SAMLProviderConfig.key_values('slug', flat=True)
-            for idp_name in idp_names:
-                provider = SAMLProviderConfig.current(idp_name)
-                if provider.backend_name == backend_name and provider.enabled_for_current_site:
-                    yield provider
-        elif backend_name in _LTI_BACKENDS:
-            for consumer_key in LTIProviderConfig.key_values('lti_consumer_key', flat=True):
-                provider = LTIProviderConfig.current(consumer_key)
-                if provider.backend_name == backend_name and provider.enabled_for_current_site:
-                    yield provider
+        for provider in cls._enabled_providers():
+            if provider.backend_name == backend_name:
+                yield provider

--- a/common/djangoapps/third_party_auth/tests/test_provider.py
+++ b/common/djangoapps/third_party_auth/tests/test_provider.py
@@ -177,7 +177,6 @@ class RegistryTest(testutil.TestCase):
         mock_set_custom_metric.assert_any_call('temp_tpa_enabled_all_dark_launch_mismatch',
                                                'old[]new[%s]' % configs[2].id)
 
-
     def test_mixed_providers(self):
         """
         Verify that multiple providers types can be configured at same time.

--- a/common/djangoapps/third_party_auth/tests/test_provider.py
+++ b/common/djangoapps/third_party_auth/tests/test_provider.py
@@ -168,6 +168,18 @@ class RegistryTest(testutil.TestCase):
         # in zero enabled providers for site_a).
         self.assertEqual([p.name for p in provider.Registry.enabled()], ["Site A second"])
 
+    def test_mixed_providers(self):
+        """
+        Verify that multiple providers types can be configured at same time.
+        """
+        self.enable_saml()
+        self.configure_saml_provider(enabled=True, slug="saml-slug", name="Some SAML")
+        self.configure_google_provider(enabled=True)
+        self.configure_lti_provider(enabled=True)
+
+        configs = provider.Registry.enabled()
+        self.assertEqual({p.backend_name for p in configs}, {'tpa-saml', 'google-oauth2', 'lti'})
+
     def test_get_returns_enabled_provider(self):
         google_provider = self.configure_google_provider(enabled=True)
         self.assertEqual(google_provider.id, provider.Registry.get(google_provider.provider_id).id)

--- a/requirements/edx/base.in
+++ b/requirements/edx/base.in
@@ -103,6 +103,7 @@ mailsnake                           # Needed for mailchimp (mailing djangoapp)
 mako==1.0.2                         # Primary template language used for server-side page rendering
 Markdown                            # Convert text markup to HTML; used in capa problems, forums, and course wikis
 mongoengine==0.10.0                 # Object-document mapper for MongoDB, used in the LMS dashboard
+more-itertools                      # Additional utilities for working with iterators
 mysqlclient                         # Driver for the default production relational database
 newrelic                            # New Relic agent for performance monitoring
 nodeenv                             # Utility for managing Node.js environments; we use this for deployments and testing

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -160,7 +160,7 @@ maxminddb==1.5.2          # via geoip2
 mock==3.0.5               # via -c requirements/edx/../constraints.txt, -r requirements/edx/paver.txt, xblock-drag-and-drop-v2, xblock-poll
 git+https://github.com/edx/MongoDBProxy.git@d92bafe9888d2940f647a7b2b2383b29c752f35a#egg=MongoDBProxy==0.1.0+edx.2  # via -r requirements/edx/github.in
 mongoengine==0.10.0       # via -r requirements/edx/base.in
-more-itertools==8.2.0     # via -r requirements/edx/paver.txt, zipp
+more-itertools==8.2.0     # via -r requirements/edx/base.in, -r requirements/edx/paver.txt, zipp
 mpmath==1.1.0             # via sympy
 mysqlclient==1.4.6        # via -r requirements/edx/base.in
 newrelic==5.12.0.140      # via -r requirements/edx/base.in, edx-django-utils


### PR DESCRIPTION
Dark launch comparison of a fix for the 1+N issue on the login page. Old implementation is still run and the results used, but if there are discrepancies with the new implementation, logs metrics and debugging info to New Relic.

This should also fix an issue with configs shadowing each other across sites, but we only have configs for one site in Production, so I'm not expecting the comparison to trip over that.