### PR TITLE
Add alert banner to Contact Us Page with Covid-19 message

### DIFF
--- a/lms/djangoapps/support/static/support/jsx/single_support_form.jsx
+++ b/lms/djangoapps/support/static/support/jsx/single_support_form.jsx
@@ -149,6 +149,10 @@ class RenderForm extends React.Component {
     return (
       <div className="contact-us-wrapper">
 
+        <div className="alert alert-warning" role="alert" style={{ marginBottom: '1rem', padding: '1.5rem', left: '0px', fontSize: '16px', backgroundColor: '#fffaed', color: '#171C29', border: '1px solid #FFD875', borderRadius: '0.3rem' }}>
+          <div>{gettext('Due to the recent increase in interest in online education and edX, we are currently experiencing an unusually high volume of support requests. We appreciate your patience as we work to review each request. Please check the ')}<a href="https://support.edx.org/hc/en-us" className="alert-link">Help Center</a>{gettext(' as many questions may have already been answered.')}</div>
+        </div>
+
         <div className="row">
           <div className="col-sm-12">
             <h2>{gettext('Contact Us')}</h2>

--- a/lms/djangoapps/support/static/support/jsx/single_support_form.jsx
+++ b/lms/djangoapps/support/static/support/jsx/single_support_form.jsx
@@ -5,7 +5,6 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import ReactDOM from 'react-dom';
-import { StatusAlert } from '@edx/paragon';
 
 import StringUtils from 'edx-ui-toolkit/js/utils/string-utils';
 
@@ -149,24 +148,6 @@ class RenderForm extends React.Component {
 
     return (
       <div className="contact-us-wrapper">
-
-        <StatusAlert
-          alertType="info"
-          open
-          dialog={(
-            <div>
-              <span>Due to the recent increase in interest in online education and edX, we are currently experiencing an unusually high volume of support requests. We appreciate your patience as we work to review each request. Please check the </span>
-              <a
-                href="https://support.edx.org/hc/en-us"
-                target="_blank"
-                rel="noopener noreferrer"
-              >
-                Help Center
-              </a>
-              <span> as many questions may have already been answered.</span>
-            </div>
-          )}
-        />
 
         <div className="row">
           <div className="col-sm-12">

--- a/lms/djangoapps/support/static/support/jsx/single_support_form.jsx
+++ b/lms/djangoapps/support/static/support/jsx/single_support_form.jsx
@@ -149,6 +149,7 @@ class RenderForm extends React.Component {
     return (
       <div className="contact-us-wrapper">
 
+         {/* Note: not using Paragon bc component shows in the DOM but not rendered, even when using version 2.6.4. */}
         <div className="alert alert-warning" role="alert" style={{ marginBottom: '1rem', padding: '1.5rem', left: '0px', fontSize: '16px', backgroundColor: '#fffaed', color: '#171C29', border: '1px solid #FFD875', borderRadius: '0.3rem' }}>
           <div>{gettext('Due to the recent increase in interest in online education and edX, we are currently experiencing an unusually high volume of support requests. We appreciate your patience as we work to review each request. Please check the ')}<a href="https://support.edx.org/hc/en-us" className="alert-link">Help Center</a>{gettext(' as many questions may have already been answered.')}</div>
         </div>


### PR DESCRIPTION
[PROD-1480](https://openedx.atlassian.net/browse/PROD-1480).
Note: not using Paragon because it's not rendering the component, even when using the paragon version 2.6.4. 
<img width="1119" alt="Screen Shot 2020-04-28 at 3 54 48 PM" src="https://user-images.githubusercontent.com/13632680/80531480-b8e76d00-8968-11ea-8eb5-717c418ca60c.png">
