### PR TITLE
Restrict api to staff users

### DIFF
--- a/lms/djangoapps/certificates/apis/v0/views.py
+++ b/lms/djangoapps/certificates/apis/v0/views.py
@@ -12,7 +12,7 @@ from edx_rest_framework_extensions.auth.session.authentication import SessionAut
 from opaque_keys import InvalidKeyError
 from opaque_keys.edx.keys import CourseKey
 from rest_condition import C
-from rest_framework.permissions import IsAuthenticated
+from rest_framework.permissions import IsAuthenticated, IsAdminUser
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
@@ -158,6 +158,7 @@ class CertificatesListView(APIView):
                 permissions.JwtHasUserFilterForRequestedUser
             )
         ),
+        IsAdminUser,
     )
 
     required_scopes = ['certificates:read']


### PR DESCRIPTION
There is a need to restrict the certificate detail api to be accessed by admin users.
For details please visit https://openedx.atlassian.net/browse/PROD-1238