### PR TITLE
Removes enterprise filter for account recovery banner

### DIFF
--- a/common/djangoapps/student/views/dashboard.py
+++ b/common/djangoapps/student/views/dashboard.py
@@ -40,7 +40,7 @@ from openedx.core.djangoapps.plugins.plugin_contexts import get_plugins_view_con
 from openedx.core.djangoapps.programs.models import ProgramsApiConfig
 from openedx.core.djangoapps.programs.utils import ProgramDataExtender, ProgramProgressMeter
 from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
-from openedx.core.djangoapps.user_api.accounts.utils import is_secondary_email_feature_enabled_for_user
+from openedx.core.djangoapps.user_api.accounts.utils import is_secondary_email_feature_enabled
 from openedx.core.djangoapps.util.maintenance_banner import add_maintenance_banner
 from openedx.core.djangoapps.waffle_utils import WaffleFlag, WaffleFlagNamespace
 from openedx.core.djangolib.markup import HTML, Text
@@ -655,7 +655,7 @@ def student_dashboard(request):
     enterprise_message = get_dashboard_consent_notification(request, user, course_enrollments)
 
     recovery_email_message = recovery_email_activation_message = None
-    if is_secondary_email_feature_enabled_for_user(user=user):
+    if is_secondary_email_feature_enabled():
         try:
             pending_email = PendingSecondaryEmailChange.objects.get(user=user)
         except PendingSecondaryEmailChange.DoesNotExist:

--- a/lms/templates/student_account/account_settings.html
+++ b/lms/templates/student_account/account_settings.html
@@ -10,7 +10,7 @@ from django.utils.translation import ugettext as _
 from openedx.core.djangolib.js_utils import dump_js_escaped_json, js_escaped_string
 from openedx.core.djangolib.markup import HTML
 from webpack_loader.templatetags.webpack_loader import render_bundle
-from openedx.core.djangoapps.user_api.accounts.utils import is_secondary_email_feature_enabled_for_user
+from openedx.core.djangoapps.user_api.accounts.utils import is_secondary_email_feature_enabled
 %>
 
 <%inherit file="/main.html" />
@@ -47,7 +47,7 @@ from openedx.core.djangoapps.user_api.accounts.utils import is_secondary_email_f
         edxSupportUrl = '${ edx_support_url | n, js_escaped_string }',
         extendedProfileFields = ${ extended_profile_fields | n, dump_js_escaped_json },
         displayAccountDeletion = ${ enable_account_deletion | n, dump_js_escaped_json};
-        isSecondaryEmailFeatureEnabled = ${ bool(is_secondary_email_feature_enabled_for_user(user)) | n, dump_js_escaped_json },
+        isSecondaryEmailFeatureEnabled = ${ bool(is_secondary_email_feature_enabled()) | n, dump_js_escaped_json },
 
     AccountSettingsFactory(
         fieldsData,

--- a/openedx/core/djangoapps/user_api/accounts/serializers.py
+++ b/openedx/core/djangoapps/user_api/accounts/serializers.py
@@ -16,7 +16,7 @@ from six import text_type
 from lms.djangoapps.badges.utils import badges_enabled
 from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
 from openedx.core.djangoapps.user_api import errors
-from openedx.core.djangoapps.user_api.accounts.utils import is_secondary_email_feature_enabled_for_user
+from openedx.core.djangoapps.user_api.accounts.utils import is_secondary_email_feature_enabled
 from openedx.core.djangoapps.user_api.models import RetirementState, UserPreference, UserRetirementStatus
 from openedx.core.djangoapps.user_api.serializers import ReadOnlyFieldsSerializerMixin
 from student.models import LanguageProficiency, SocialLink, UserProfile
@@ -172,7 +172,7 @@ class UserReadOnlySerializer(serializers.Serializer):
                 }
             )
 
-        if is_secondary_email_feature_enabled_for_user(user):
+        if is_secondary_email_feature_enabled():
             data.update(
                 {
                     "secondary_email": account_recovery.secondary_email if account_recovery else None,

--- a/openedx/core/djangoapps/user_api/accounts/utils.py
+++ b/openedx/core/djangoapps/user_api/accounts/utils.py
@@ -192,18 +192,6 @@ def is_secondary_email_feature_enabled():
     return waffle.switch_is_active(ENABLE_SECONDARY_EMAIL_FEATURE_SWITCH)
 
 
-def is_secondary_email_feature_enabled_for_user(user):
-    """
-    Checks to see if secondary email feature is enabled for the given user.
-
-    Returns:
-        Boolean value representing the status of secondary email feature.
-    """
-    # import is placed here to avoid cyclic import.
-    from openedx.features.enterprise_support.utils import is_enterprise_learner
-    return is_secondary_email_feature_enabled() and is_enterprise_learner(user)
-
-
 def is_multiple_user_enterprises_feature_enabled():
     """
     Checks to see if the django-waffle switch for enabling the multiple user enterprises feature is active


### PR DESCRIPTION
Previously code was only showing banner for enterprise
learners. This patch would remove this restriction
and is available to all edX learners provided that
'enable_secondary_email_feature' is switched on.

PROD-1477