### PR TITLE
Ratelimit password reset by email instead of IP.

### DIFF
--- a/common/djangoapps/util/request_rate_limiter.py
+++ b/common/djangoapps/util/request_rate_limiter.py
@@ -48,7 +48,7 @@ class PasswordResetEmailRateLimiter(RequestRateLimiter):
         """
         return '%s-%s-%s' % (
             self.reset_email_cache_prefix,
-            self.get_ip(request),
+            self.get_email(request),
             dt.strftime('%Y%m%d%H%M'),
         )
 
@@ -57,3 +57,12 @@ class PasswordResetEmailRateLimiter(RequestRateLimiter):
         Returns timeout for cache keys.
         """
         return self.cache_timeout_seconds
+
+    def get_email(self, request):
+        """
+        Returns email id for cache key.
+        """
+        user = request.user
+        # Prefer logged-in user's email
+        email = user.email if user.is_authenticated else request.POST.get('email')
+        return email

--- a/openedx/core/djangoapps/user_authn/views/password_reset.py
+++ b/openedx/core/djangoapps/user_authn/views/password_reset.py
@@ -43,7 +43,7 @@ from student.forms import send_account_recovery_email_for_user
 from student.models import AccountRecovery
 from util.json_request import JsonResponse
 from util.password_policy_validators import normalize_password, validate_password
-from util.request_rate_limiter import BadRequestRateLimiter, PasswordResetEmailRateLimiter
+from util.request_rate_limiter import PasswordResetEmailRateLimiter
 
 SETTING_CHANGE_INITIATED = 'edx.user.settings.change_initiated'
 
@@ -242,11 +242,15 @@ def password_reset(request):
     """
     Attempts to send a password reset e-mail.
     """
-    # Add some rate limiting here by re-using the RateLimitMixin as a helper class
-    limiter = BadRequestRateLimiter()
-    if limiter.is_rate_limit_exceeded(request):
-        AUDIT_LOG.warning("Rate limit exceeded in password_reset")
-        return HttpResponseForbidden()
+
+    password_reset_email_limiter = PasswordResetEmailRateLimiter()
+
+    if password_reset_email_limiter.is_rate_limit_exceeded(request):
+        AUDIT_LOG.warning("Password reset rate limit exceeded")
+        return HttpResponse(
+            _("Your previous request is in progress, please try again in a few moments."),
+            status=403
+        )
 
     form = PasswordResetFormNoActive(request.POST)
     if form.is_valid():
@@ -269,7 +273,7 @@ def password_reset(request):
     else:
         # bad user? tick the rate limiter counter
         AUDIT_LOG.info("Bad password_reset user passed in.")
-        limiter.tick_request_counter(request)
+        password_reset_email_limiter.tick_request_counter(request)
 
     return JsonResponse({
         'success': True,


### PR DESCRIPTION
Also changed `password_reset` endpoint rate limit configuration to 1/minute from 30/5 minutes.

PROD-1427