### PR TITLE
Stop skipping chromeless iframe resize onload event

### DIFF
--- a/lms/templates/courseware/courseware-chromeless.html
+++ b/lms/templates/courseware/courseware-chromeless.html
@@ -137,7 +137,7 @@ ${HTML(fragment.foot_html())}
         var newHeight = contentElement.offsetHeight;
         var newWidth = contentElement.offsetWidth;
 
-        if (newWidth === lastWidth && newHeight === lastHeight) {
+        if (eventType !== 'load' && newWidth === lastWidth && newHeight === lastHeight) {
           console.log('MFE', 'Ignore resize', newWidth, newHeight, eventType);
           return;
         }


### PR DESCRIPTION
in the case where the MutationObserver has already tried resizing the
iframe prior to it fully loading.