### PR TITLE
fix flaky tests

### DIFF
--- a/lms/djangoapps/shoppingcart/tests/test_reports.py
+++ b/lms/djangoapps/shoppingcart/tests/test_reports.py
@@ -55,7 +55,6 @@ class ReportTypeTests(ModuleStoreTestCase):
         self.cost = 40
         self.course = CourseFactory.create(org='MITx', number='999', display_name=u'Robot Super Course')
         self.course_key = self.course.id
-        settings.COURSE_LISTINGS['default'] = [text_type(self.course_key)]
         course_mode = CourseMode(course_id=self.course_key,
                                  mode_slug="honor",
                                  mode_display_name="honor cert",


### PR DESCRIPTION
It doesn't look like this setting was required, and because it didn't
use override_settings, it broke other tests.