### PR TITLE
remove bulk write of CourseAccessRoleAssignment

### DIFF
--- a/lms/djangoapps/program_enrollments/api/tests/test_writing.py
+++ b/lms/djangoapps/program_enrollments/api/tests/test_writing.py
@@ -426,9 +426,14 @@ class WriteProgramCourseEnrollmentTest(EnrollmentTestMixin):
         self.create_program_and_course_enrollments('learner-1', user=self.student_1)
         self.create_program_and_course_enrollments('learner-2', user=self.student_2)
         self.create_program_and_course_enrollments('learner-3', user=None)
-        enrollment = self.create_program_and_course_enrollments('learner-4', user=None)
+        learner_4_enrollment = self.create_program_and_course_enrollments('learner-4', user=None)
+        learner_5_enrollment = self.create_program_and_course_enrollments('learner-5', user=None)
         CourseAccessRoleAssignment.objects.create(
-            enrollment=enrollment,
+            enrollment=learner_4_enrollment,
+            role=ProgramCourseEnrollmentRoles.COURSE_STAFF,
+        )
+        CourseAccessRoleAssignment.objects.create(
+            enrollment=learner_5_enrollment,
             role=ProgramCourseEnrollmentRoles.COURSE_STAFF,
         )
         course_enrollment_requests = [
@@ -436,6 +441,7 @@ class WriteProgramCourseEnrollmentTest(EnrollmentTestMixin):
             self.course_enrollment_request('learner-2', CourseStatuses.ACTIVE, False),
             self.course_enrollment_request('learner-3', CourseStatuses.ACTIVE, True),
             self.course_enrollment_request('learner-4', CourseStatuses.ACTIVE, False),
+            self.course_enrollment_request('learner-5', CourseStatuses.ACTIVE, True),
         ]
         write_program_course_enrollments(
             self.program_uuid,
@@ -452,9 +458,13 @@ class WriteProgramCourseEnrollmentTest(EnrollmentTestMixin):
 
         # CourseAccessRoleAssignment objects are created/revoked for enrollments with no linked user
         pending_role_assingments = CourseAccessRoleAssignment.objects.all()
-        assert pending_role_assingments.count() == 1
+        assert pending_role_assingments.count() == 2
         pending_role_assingments.get(
             enrollment__program_enrollment__external_user_key='learner-3',
+            enrollment__course_key=self.course_id
+        )
+        pending_role_assingments.get(
+            enrollment__program_enrollment__external_user_key='learner-5',
             enrollment__course_key=self.course_id
         )
 

--- a/lms/djangoapps/program_enrollments/api/writing.py
+++ b/lms/djangoapps/program_enrollments/api/writing.py
@@ -437,7 +437,6 @@ def _assign_course_staff_role(course_key, enrollments, staff_assignments):
         enrollments (list): ProgramCourseEnrollments to update
         staff_assignments (dict): Maps an enrollment's external key to a course staff value
     """
-    role_assignments_to_save = []
     enrollment_role_assignments_to_delete = []
     for enrollment in enrollments:
         if enrollment.course_key != course_key:
@@ -454,15 +453,12 @@ def _assign_course_staff_role(course_key, enrollments, staff_assignments):
                 CourseStaffRole(course_key).remove_users(user)
         else:
             if course_staff is True:
-                role_assignments_to_save.append(CourseAccessRoleAssignment(
+                CourseAccessRoleAssignment.objects.update_or_create(
                     enrollment=enrollment,
                     role=ProgramCourseEnrollmentRoles.COURSE_STAFF
-                ))
+                )
             elif course_staff is False:
                 enrollment_role_assignments_to_delete.append(enrollment)
-
-    if role_assignments_to_save:
-        CourseAccessRoleAssignment.objects.bulk_create(role_assignments_to_save)
 
     if enrollment_role_assignments_to_delete:
         CourseAccessRoleAssignment.objects.filter(


### PR DESCRIPTION
@edx/masters-devs-cosmonauts 

## [MST-233](https://openedx.atlassian.net/browse/MST-233?atlOrigin=eyJpIjoiOGYwZDdjNmQ3ODk0NDZlNGJmNjczYTlhOGU5NTk1ZDQiLCJwIjoiaiJ9)

Fixes issues with doing bulk_create on records that potentially already exist.  I opted to just avoid bulk create on this model alltogether to avoid adding complexity between the create and update paths.