### PR TITLE
add find_order_dependent_test_failures.py script

### DIFF
--- a/scripts/xdist/find_order_dependent_test_failures.py
+++ b/scripts/xdist/find_order_dependent_test_failures.py
@@ -82,7 +82,7 @@ def main(log_file, test_suite, fast, verbose):
         return
 
     if fast_option:
-        print('No tests failed locally with --fast option.  Try --slow.')
+        print('No tests failed locally with --fast option. Try running again with --slow to include more tests.')
         return
 
     print('No tests failed locally.')
@@ -118,7 +118,7 @@ def _strip_console_for_tests_with_failure(log_file, test_suite):
                     # fast option will only take one test per class or module, in case
                     # the failure is a setup/teardown failure.
                     test_base = '::'.join(test.split('::')[:-1])
-                    if not test_base in test_base_included:
+                    if test_base not in test_base_included:
                         worker_test_dict[worker_num_string].append(test)
                         test_base_included[test_base] = True
                 elif (not fast_option or (fast_option and pass_fail_string == 'FAILED')):

--- a/scripts/xdist/find_order_dependent_test_failures.py
+++ b/scripts/xdist/find_order_dependent_test_failures.py
@@ -1,0 +1,182 @@
+"""
+This script can be used to find the fewest number of tests required to get a
+failure, in cases where a test failure is dependent on test order.
+
+The script performs the following:
+1. It strips the console log of a pytest-xdist Jenkins run into the test
+lists of each pytest worker until it finds the first failure.
+2. It makes sure that running the single failing test doesn't fail on its
+own.
+3. It then finds the fewest number of tests required to continue to see the
+failure, and outputs the pytest command needed to replicate.
+
+Sample usage::
+
+    python scripts/xdist/find_dependent_test_failures.py --log-file console.txt --test-suite lms-unit
+
+"""
+
+
+import io
+import os
+import re
+import shutil
+import tempfile
+
+import click
+
+OUTPUT_FOLDER_NAME = "worker_list_files"
+
+
+@click.command()
+@click.option(
+    '--log-file',
+    help="File name of console log .txt file from a Jenkins build "
+    "that ran pytest-xdist. This can be acquired by running: "
+    "curl -o console.txt https://build.testeng.edx.org/job/JOBNAME/BUILDNUMBER/consoleText",
+    required=True
+)
+@click.option(
+    '--test-suite',
+    help="Test suite that the pytest worker ran.",
+    type=click.Choice(['lms-unit', 'cms-unit', 'commonlib-unit']),
+    required=True
+)
+def main(log_file, test_suite):
+    _clean_output_folder()
+
+    failing_test_list = _strip_console_for_tests_with_failure(log_file, test_suite)
+
+    if not failing_test_list:
+        print('No failures found in log file.')
+        return
+
+    if _get_pytest_command_if_failures(failing_test_list[-1:], 'SINGLE'):
+        print("Single test failed. Failures not dependent on order.")
+        return
+
+    test_list_with_failures, pytest_command = _find_fewest_tests_with_failures(failing_test_list, 'ALL')
+    if test_list_with_failures:
+        print('Found failures running {} tests.'.format(len(test_list_with_failures)))
+        print('Use: {}'.format(pytest_command))
+        return
+
+    print('No tests failed locally.')
+
+
+def _clean_output_folder():
+    if os.path.isdir(OUTPUT_FOLDER_NAME):
+        shutil.rmtree(OUTPUT_FOLDER_NAME)
+    os.mkdir(OUTPUT_FOLDER_NAME)
+
+
+def _strip_console_for_tests_with_failure(log_file, test_suite):
+    """
+    Returns list of tests ending with a failing test, or None if no failures found.
+    """
+    worker_test_dict = {}
+    failing_worker_num = None
+    with io.open(log_file, 'r') as console_file:
+        for line in console_file:
+            regex_search = re.search(r'\[gw(\d+)] (PASSED|FAILED|SKIPPED|ERROR)'.format(test_suite), line)
+            if regex_search:
+                worker_num_string = regex_search.group(1)
+                pass_fail_string = regex_search.group(2)
+                if worker_num_string not in worker_test_dict:
+                    worker_test_dict[worker_num_string] = []
+                line_parts = line.split()
+                pass_fail_index = line_parts.index(pass_fail_string)
+                # test is not always found at the same index in the list
+                test = line_parts[pass_fail_index + 1]
+                if test_suite == "commonlib-unit":
+                    if "pavelib" not in test and not test.startswith('scripts'):
+                        test = u"common/lib/{}".format(test)
+                worker_test_dict[worker_num_string].append(test)
+                if pass_fail_string == 'FAILED':
+                    failing_worker_num = worker_num_string
+                    break
+    if failing_worker_num:
+        return worker_test_dict[failing_worker_num]
+
+
+def _get_pytest_command(output_file_name):
+    """
+    Return the pytest command to run.
+    """
+    return "pytest -p 'no:randomly' `cat {}`".format(output_file_name)
+
+
+def _run_tests_and_check_for_failures(output_file_name):
+    """
+    Runs tests and returns True if failures are found.
+    """
+    pytest_command = _get_pytest_command(output_file_name)
+    test_output = os.popen(pytest_command).read()
+    failures_search = re.search(r'=== (\d+) failed', test_output)
+    return bool(failures_search) and int(failures_search.group(1)) > 0
+
+
+def _get_pytest_command_if_failures(test_list, test_type):
+    """
+    Run the test list to see if there are any failures.
+
+    Returns the pytest command to run if failures are found.
+    """
+    print("Testing {}, includes {} test(s)...".format(test_type, len(test_list)))
+    output_file_name = "{}/failing_test_list_{}_{}.txt".format(
+        OUTPUT_FOLDER_NAME, test_type, len(test_list)
+    )
+    dirname, basename = os.path.split(output_file_name)
+    temp_file = tempfile.NamedTemporaryFile(prefix=basename, dir=dirname, delete=False)
+
+    with io.open(temp_file.name, 'w') as output_file:
+        for line in test_list:
+            output_file.write(line + "\n")
+    temp_file.close()
+
+    if _run_tests_and_check_for_failures(temp_file.name):
+        os.rename(temp_file.name, output_file_name)
+        print('- test failures found.')
+        return _get_pytest_command(output_file_name)
+
+    os.remove(temp_file.name)
+    print('- all tests passed.')
+    return None
+
+
+def _find_fewest_tests_with_failures(test_list, test_type):
+    """
+    Recursively tests half the tests, finding the smallest number of tests to obtain a failure.
+
+    Returns:
+        (test_list, pytest_command): Tuple with the smallest test_list and the pytest_command
+            to be used for testing. Returns (None, None) if no failures are found.
+    """
+    if len(test_list) <= 1:
+        return None, None
+
+    pytest_command = _get_pytest_command_if_failures(test_list, test_type)
+    if not pytest_command:
+        return None, None
+
+    if len(test_list) == 2:
+        return test_list, pytest_command
+
+    half_tests_num = round((len(test_list) - 1) / 2)
+    failing_test = test_list[-1:]
+    test_list_a = test_list[0:half_tests_num] + failing_test
+    test_list_b = test_list[half_tests_num:]
+    failing_test_list_a, pytest_command_a = _find_fewest_tests_with_failures(test_list_a, 'GROUP-A')
+    if failing_test_list_a:
+        return failing_test_list_a, pytest_command_a
+
+    failing_test_list_b, pytest_command_b = _find_fewest_tests_with_failures(test_list_b, 'GROUP-B')
+    if failing_test_list_b:
+        return failing_test_list_b, pytest_command_b
+
+    return test_list, pytest_command
+
+
+if __name__ == "__main__":
+    main()
+

--- a/scripts/xdist/find_order_dependent_test_failures.py
+++ b/scripts/xdist/find_order_dependent_test_failures.py
@@ -161,13 +161,13 @@ def _create_and_check_test_files_for_failures(test_list, test_type):
     """
     print("Testing {}, includes {} test(s)...".format(test_type, len(test_list)))
     global test_suite_option
-    output_file_name = "{}/{}_failing_test_list_{}_{}.txt".format(
+    output_file_name = "{}_failing_test_list_{}_{}.txt".format(
         OUTPUT_FOLDER_NAME, test_suite_option, test_type, len(test_list)
     )
-    dirname, basename = os.path.split(output_file_name)
+    output_file_path = os.path.join(OUTPUT_FOLDER_NAME, output_file_name)
     # Note: We don't really need a temporary file, and could just output the tests directly
     # to the command line, but this keeps the verbose  output cleaner.
-    temp_file = tempfile.NamedTemporaryFile(prefix=basename, dir=dirname, delete=False)
+    temp_file = tempfile.NamedTemporaryFile(prefix=output_file_name, dir=OUTPUT_FOLDER_NAME, delete=False)
 
     with io.open(temp_file.name, 'w') as output_file:
         for line in test_list:
@@ -175,9 +175,9 @@ def _create_and_check_test_files_for_failures(test_list, test_type):
     temp_file.close()
 
     if _run_tests_and_check_for_failures(temp_file.name):
-        os.rename(temp_file.name, output_file_name)
+        os.rename(temp_file.name, output_file_path)
         print('- test failures found.')
-        return _get_pytest_command(output_file_name)
+        return _get_pytest_command(output_file_path)
 
     os.remove(temp_file.name)
     print('- no failures found.')
@@ -214,6 +214,8 @@ def _find_fewest_tests_with_failures(test_list, test_type):
     if failing_test_list_b:
         return failing_test_list_b, pytest_command_b
 
+    # This could occur if there is a complex set of dependencies where the
+    # original list fails, but neither of its halves (A or B) fail.
     return test_list, pytest_command
 
 

--- a/scripts/xdist/find_order_dependent_test_failures.py
+++ b/scripts/xdist/find_order_dependent_test_failures.py
@@ -26,6 +26,9 @@ import tempfile
 import click
 
 OUTPUT_FOLDER_NAME = "worker_list_files"
+test_suite_option = None
+fast_option = None
+verbose_option = None
 
 
 @click.command()
@@ -42,7 +45,24 @@ OUTPUT_FOLDER_NAME = "worker_list_files"
     type=click.Choice(['lms-unit', 'cms-unit', 'commonlib-unit']),
     required=True
 )
-def main(log_file, test_suite):
+@click.option(
+    '--fast/--slow',
+    help="Fast looks for issues in setup/teardown by running one test per class or file.",
+    default=True
+)
+@click.option(
+    '--verbose/--quiet',
+    help="Verbose includes the test output.",
+    default=None
+)
+def main(log_file, test_suite, fast, verbose):
+    global test_suite_option
+    global fast_option
+    global verbose_option
+    test_suite_option = test_suite
+    fast_option = fast
+    verbose_option = verbose
+
     _clean_output_folder()
 
     failing_test_list = _strip_console_for_tests_with_failure(log_file, test_suite)
@@ -51,7 +71,7 @@ def main(log_file, test_suite):
         print('No failures found in log file.')
         return
 
-    if _get_pytest_command_if_failures(failing_test_list[-1:], 'SINGLE'):
+    if _create_and_check_test_files_for_failures(failing_test_list[-1:], 'SINGLE'):
         print("Single test failed. Failures not dependent on order.")
         return
 
@@ -59,6 +79,10 @@ def main(log_file, test_suite):
     if test_list_with_failures:
         print('Found failures running {} tests.'.format(len(test_list_with_failures)))
         print('Use: {}'.format(pytest_command))
+        return
+
+    if fast_option:
+        print('No tests failed locally with --fast option.  Try --slow.')
         return
 
     print('No tests failed locally.')
@@ -74,24 +98,31 @@ def _strip_console_for_tests_with_failure(log_file, test_suite):
     """
     Returns list of tests ending with a failing test, or None if no failures found.
     """
+    global fast_option
     worker_test_dict = {}
+    test_base_included = {}
     failing_worker_num = None
     with io.open(log_file, 'r') as console_file:
         for line in console_file:
-            regex_search = re.search(r'\[gw(\d+)] (PASSED|FAILED|SKIPPED|ERROR)'.format(test_suite), line)
+            regex_search = re.search(r'\[gw(\d+)] (PASSED|FAILED|SKIPPED|ERROR) (\S+)'.format(test_suite), line)
             if regex_search:
                 worker_num_string = regex_search.group(1)
                 pass_fail_string = regex_search.group(2)
                 if worker_num_string not in worker_test_dict:
                     worker_test_dict[worker_num_string] = []
-                line_parts = line.split()
-                pass_fail_index = line_parts.index(pass_fail_string)
-                # test is not always found at the same index in the list
-                test = line_parts[pass_fail_index + 1]
+                test = regex_search.group(3)
                 if test_suite == "commonlib-unit":
                     if "pavelib" not in test and not test.startswith('scripts'):
                         test = u"common/lib/{}".format(test)
-                worker_test_dict[worker_num_string].append(test)
+                if fast_option and pass_fail_string == 'PASSED':
+                    # fast option will only take one test per class or module, in case
+                    # the failure is a setup/teardown failure.
+                    test_base = '::'.join(test.split('::')[:-1])
+                    if not test_base in test_base_included:
+                        worker_test_dict[worker_num_string].append(test)
+                        test_base_included[test_base] = True
+                elif (not fast_option or (fast_option and pass_fail_string == 'FAILED')):
+                    worker_test_dict[worker_num_string].append(test)
                 if pass_fail_string == 'FAILED':
                     failing_worker_num = worker_num_string
                     break
@@ -110,23 +141,32 @@ def _run_tests_and_check_for_failures(output_file_name):
     """
     Runs tests and returns True if failures are found.
     """
+    global verbose_option
     pytest_command = _get_pytest_command(output_file_name)
     test_output = os.popen(pytest_command).read()
+    if verbose_option:
+        print(test_output)
     failures_search = re.search(r'=== (\d+) failed', test_output)
     return bool(failures_search) and int(failures_search.group(1)) > 0
 
 
-def _get_pytest_command_if_failures(test_list, test_type):
+def _create_and_check_test_files_for_failures(test_list, test_type):
     """
     Run the test list to see if there are any failures.
+
+    Keeps around any test files that produced a failure, and deletes
+    the passing files.
 
     Returns the pytest command to run if failures are found.
     """
     print("Testing {}, includes {} test(s)...".format(test_type, len(test_list)))
-    output_file_name = "{}/failing_test_list_{}_{}.txt".format(
-        OUTPUT_FOLDER_NAME, test_type, len(test_list)
+    global test_suite_option
+    output_file_name = "{}/{}_failing_test_list_{}_{}.txt".format(
+        OUTPUT_FOLDER_NAME, test_suite_option, test_type, len(test_list)
     )
     dirname, basename = os.path.split(output_file_name)
+    # Note: We don't really need a temporary file, and could just output the tests directly
+    # to the command line, but this keeps the verbose  output cleaner.
     temp_file = tempfile.NamedTemporaryFile(prefix=basename, dir=dirname, delete=False)
 
     with io.open(temp_file.name, 'w') as output_file:
@@ -140,7 +180,7 @@ def _get_pytest_command_if_failures(test_list, test_type):
         return _get_pytest_command(output_file_name)
 
     os.remove(temp_file.name)
-    print('- all tests passed.')
+    print('- no failures found.')
     return None
 
 
@@ -155,7 +195,7 @@ def _find_fewest_tests_with_failures(test_list, test_type):
     if len(test_list) <= 1:
         return None, None
 
-    pytest_command = _get_pytest_command_if_failures(test_list, test_type)
+    pytest_command = _create_and_check_test_files_for_failures(test_list, test_type)
     if not pytest_command:
         return None, None
 
@@ -179,4 +219,3 @@ def _find_fewest_tests_with_failures(test_list, test_type):
 
 if __name__ == "__main__":
     main()
-


### PR DESCRIPTION
**Reviewer Note:** Since this was unplanned, we should probably do minimal changes and we can iterate in the future.

In the case that that are order dependent failures on Jenkins, this
script can be used to automatically find the set of tests required to
continue to get the failure.

It is a simple 2 step process:
1. Get the console output from Jenkins.
2. Run the script.

Sample usage and output:
```
root@lms:/edx/app/edxapp/edx-platform# curl -o console.txt https://build.testeng.edx.org/view/edx-platform-master-tests/job/edx-platform-python-pipeline-master/3339/consoleText
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100 12.9M    0 12.9M    0     0  6061k      0 --:--:--  0:00:02 --:--:-- 6068k

root@lms:/edx/app/edxapp/edx-platform# python scripts/xdist/find_order_dependent_test_failures.py --log-file console.txt --test-suite lms-unit 
Testing SINGLE, includes 1 test(s)...
- all tests passed.
Testing ALL, includes 131 test(s)...
- test failures found.
Testing GROUP-A, includes 66 test(s)...
- test failures found.
Testing GROUP-A, includes 33 test(s)...
- test failures found.
Testing GROUP-A, includes 17 test(s)...
- test failures found.
Testing GROUP-A, includes 9 test(s)...
- all tests passed.
Testing GROUP-B, includes 9 test(s)...
- test failures found.
Testing GROUP-A, includes 5 test(s)...
- test failures found.
Testing GROUP-A, includes 3 test(s)...
- test failures found.
Testing GROUP-A, includes 2 test(s)...
- all tests passed.
Testing GROUP-B, includes 2 test(s)...
- test failures found.
Found failures running 2 tests.
Use: pytest -p 'no:randomly' `cat worker_list_files/failing_test_list_GROUP-B_2.txt`
```