### PR TITLE
Fix password reset rate limiting for existing users.

### DIFF
--- a/common/djangoapps/util/request_rate_limiter.py
+++ b/common/djangoapps/util/request_rate_limiter.py
@@ -80,7 +80,7 @@ class PasswordResetEmailRateLimiter(RequestRateLimiter):
 
     def keys_to_check(self, request):
         """
-        Retun list of IP and email based keys.
+        Return list of IP and email based keys.
         """
         keys = super(PasswordResetEmailRateLimiter, self).keys_to_check(request)
 
@@ -97,7 +97,7 @@ class PasswordResetEmailRateLimiter(RequestRateLimiter):
 
     def tick_request_counter(self, request):
         """
-        Ticks any counters used to compute when rate limt has been reached
+        Ticks any counters used to compute when rate limit has been reached.
         """
         for key in self.keys_to_check(request):
             self.cache_incr(key)

--- a/openedx/core/djangoapps/user_authn/views/password_reset.py
+++ b/openedx/core/djangoapps/user_authn/views/password_reset.py
@@ -273,7 +273,8 @@ def password_reset(request):
     else:
         # bad user? tick the rate limiter counter
         AUDIT_LOG.info("Bad password_reset user passed in.")
-        password_reset_email_limiter.tick_request_counter(request)
+
+    password_reset_email_limiter.tick_request_counter(request)
 
     return JsonResponse({
         'success': True,

--- a/openedx/core/djangoapps/user_authn/views/password_reset.py
+++ b/openedx/core/djangoapps/user_authn/views/password_reset.py
@@ -247,8 +247,11 @@ def password_reset(request):
 
     if password_reset_email_limiter.is_rate_limit_exceeded(request):
         AUDIT_LOG.warning("Password reset rate limit exceeded")
-        return HttpResponse(
-            _("Your previous request is in progress, please try again in a few moments."),
+        return JsonResponse(
+            {
+                'success': False,
+                'value': _("Your previous request is in progress, please try again in a few moments.")
+            },
             status=403
         )
 


### PR DESCRIPTION
This PR is an update for https://github.com/edx/edx-platform/pull/23837.

We need to tick rate limit counter for valid user as well. Also implemented both IP and email based rate limiting for password reset endpoints as suggested by security group.

PROD-1427