### PR TITLE
CRI-196 Quiet deprecation warnings from imp and courseware modules

### DIFF
--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -40,7 +40,7 @@ When refering to XBlocks, we use the entry-point name. For example,
 
 # pylint: disable=unused-import, useless-suppression, wrong-import-order, wrong-import-position
 
-import imp
+import importlib.util
 import os
 import sys
 from datetime import timedelta
@@ -1623,10 +1623,8 @@ OPTIONAL_APPS = (
 for app_name, insert_before in OPTIONAL_APPS:
     # First attempt to only find the module rather than actually importing it,
     # to avoid circular references - only try to import if it can't be found
-    # by find_module, which doesn't work with import hooks
-    try:
-        imp.find_module(app_name)
-    except ImportError:
+    # by find_spec, which doesn't work with import hooks
+    if importlib.util.find_spec(app_name) is None:
         try:
             __import__(app_name)
         except ImportError:

--- a/lms/djangoapps/bulk_email/views.py
+++ b/lms/djangoapps/bulk_email/views.py
@@ -11,7 +11,7 @@ from django.contrib.auth.models import User
 from django.http import Http404
 
 from bulk_email.models import Optout
-from courseware.courses import get_course_by_id
+from lms.djangoapps.courseware.courses import get_course_by_id
 from edxmako.shortcuts import render_to_response
 from lms.djangoapps.discussion.notification_prefs.views import (
     UsernameCipher,

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -29,7 +29,7 @@ Longer TODO:
 # pylint: disable=invalid-name, wrong-import-position
 
 
-import imp
+import importlib.util
 import sys
 import os
 
@@ -3181,10 +3181,8 @@ OPTIONAL_APPS = [
 for app_name, insert_before in OPTIONAL_APPS:
     # First attempt to only find the module rather than actually importing it,
     # to avoid circular references - only try to import if it can't be found
-    # by find_module, which doesn't work with import hooks
-    try:
-        imp.find_module(app_name)
-    except ImportError:
+    # by find_spec, which doesn't work with import hooks
+    if importlib.util.find_spec(app_name) is None:
         try:
             __import__(app_name)
         except ImportError:


### PR DESCRIPTION
The "imp" module is deprecated and should be replaced by "importlib". As
a consequence, loading the django settings used to raise deprecation
warnings:

    DeprecationWarning: the imp module is deprecated in favour of
    importlib; see the module's documentation for alternative uses

It should be noted that python 3.5.1 ships with an older release of
distutils which still relies on the imp module. Thus, users of python
3.5.1 (for instance: edx.org developers) will continue to see the
deprecation warning for some time, despite this patch. We suggest
upgrading to python 3.5.9.

Also, we quiet in this PR a lingering warning due to incorrect import of the courseware module.

This addresses two thirds of CRI-196.