### PR TITLE
Ensure setup.cfg is only ASCII.  CRI-169

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -16,10 +16,10 @@ python_files = tests.py test_*.py tests_*.py *_tests.py __init__.py
 [pycodestyle]
 # error codes: https://pycodestyle.readthedocs.io/en/latest/intro.html#error-codes
 # E501: line too long
-# E265: block comment should start with ‘# ‘
+# E265: block comment should start with '# '
 #   We ignore this because pep8 used to erroneously lump E266 into it also.
 #   We should probably fix these now.
-# E266: too many leading ‘#’ for block comment
+# E266: too many leading '#' for block comment
 #   We have lots of comments that look like "##### HEADING #####" which violate
 #   this rule, because they don't have a space after the first #. However,
 #   they're still perfectly reasonable comments, so we disable this rule.


### PR DESCRIPTION
I don't understand why this file needs to be ASCII, or why it was only a
problem recently for one installer, since this has been in this file
since 2014.  But CRI-169 has a stack trace, and it's easy enough to make
the file ASCII.