### PR TITLE
ARCHBOM-1026: fix diff quality

### DIFF
--- a/pavelib/quality.py
+++ b/pavelib/quality.py
@@ -1031,11 +1031,11 @@ def run_diff_quality(
             )
         )
         return True
-    except BuildFailure as error_message:
-        if is_percentage_failure(error_message):
+    except BuildFailure as failure:
+        if is_percentage_failure(failure.args):
             return False
         else:
-            fail_quality('diff_quality', 'FAILURE: {}'.format(error_message))
+            fail_quality('diff_quality', 'FAILURE: {}'.format(failure))
 
 
 def is_percentage_failure(error_message):


### PR DESCRIPTION
Here is a Jenkins build with [missing Test Results for diff quality failure](https://build.testeng.edx.org/job/edx-platform-quality-pipeline-pr/15614/).

Here is a Jenkins build with the same code as above and the addition of my fix from this PR with [Test Results including diff quality failure](https://build.testeng.edx.org/job/edx-platform-quality-pipeline-pr/15620/).

**Additional Notes**
* I wish the full "Diff Quality Report" from the left sidebar were available in junit xml style so the link wouldn't provide only a vague message like: "FAILURE: Pylint violation(s) were found in the lines of code that were added or changed.".  Maybe a quicker fix would be to add the text "See the 'Diff Quality Report' in the sidebar for more details."?
* I did not add a test.  I can add one in a follow-up PR.

This PR fixes the error in this stracktrace found at the [end of the quality log](https://build.testeng.edx.org/job/edx-platform-quality-pipeline-pr/15614/artifact/test_root/log/run_quality.out.log/*view*/):
```
Traceback (most recent call last):
  File "/home/jenkins/edx-venv-3.5/edx-venv/lib/python3.5/site-packages/paver/tasks.py", line 201, in _run_task
    return do_task()
  File "/home/jenkins/edx-venv-3.5/edx-venv/lib/python3.5/site-packages/paver/tasks.py", line 198, in do_task
    return func(**kw)
  File "/home/jenkins/workspace/edx-platform-quality-pipeline-pr/pavelib/utils/timer.py", line 40, in timed
    return wrapped(*args, **kwargs)
  File "/home/jenkins/workspace/edx-platform-quality-pipeline-pr/pavelib/quality.py", line 989, in run_quality
    dquality_dir=dquality_dir
  File "/home/jenkins/workspace/edx-platform-quality-pipeline-pr/pavelib/quality.py", line 1036, in run_diff_quality
    if is_percentage_failure(error_message):
  File "/home/jenkins/workspace/edx-platform-quality-pipeline-pr/pavelib/quality.py", line 1048, in is_percentage_failure
    if "Subprocess return code: 1" not in error_message:
TypeError: argument of type 'BuildFailure' is not iterable
```