### PR TITLE
Unauthenticated Contact Us improvements

### DIFF
--- a/lms/djangoapps/support/static/support/jsx/logged_out_user.jsx
+++ b/lms/djangoapps/support/static/support/jsx/logged_out_user.jsx
@@ -18,26 +18,19 @@ function LoggedOutUser({ platformName, loginQuery, supportEmail }) {
       </div>
 
       <div className="row">
-        <div className="col-sm-12">
+        <div className="col-sm-6">
           <a href={`/login${loginQuery}`} className="btn btn-primary btn-signin">{gettext('Sign in')}</a>
+        </div>
+        <div className="col-sm-6">
+          <a className="btn btn-secondary" href={`/register${loginQuery}`}>
+            {gettext('Create an Account')}
+          </a>
         </div>
       </div>
 
       <div className="row">
         <div className="col-sm-12">
-          <a className="create-account" href={`/register${loginQuery}`}>
-            {StringUtils.interpolate(
-              // FIXME: not all platforms start with a vowel
-              gettext('Create an {platform} account'),
-              { platform: platformName },
-            )}
-          </a>
-          <p className="create-account-note">
-            {StringUtils.interpolate(
-              gettext('If you are unable to access your account contact us via email using {email}.'),
-              { email: supportEmail },
-            )}
-          </p>
+          <a href="/password_assistance" type="button" class="forgot-password field-link">{gettext('Need help logging in?')}</a>
         </div>
       </div>
     </div>

--- a/lms/djangoapps/support/tests/test_views.py
+++ b/lms/djangoapps/support/tests/test_views.py
@@ -65,6 +65,22 @@ class SupportViewManageUserTests(SupportViewTestCase):
         super(SupportViewManageUserTests, self).setUp()
         SupportStaffRole().add_users(self.user)
 
+    def test_get_contact_us(self):
+        """
+        Tests Support View contact us Page
+        """
+        url = reverse('support:contact_us')
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 200)
+
+    def test_get_password_assistance(self):
+        """
+        Tests password assistance
+        """
+        url = '/password_assistance'
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 200)
+
     def test_get_support_form(self):
         """
         Tests Support View to return Manage User Form

--- a/lms/static/js/spec/student_account/access_spec.js
+++ b/lms/static/js/spec/student_account/access_spec.js
@@ -179,8 +179,8 @@
                 // Simulate a click on the reset password link
                     view.resetPassword();
 
-                // Verify that the login-anchor is hidden
-                    expect($('#login-anchor')).toHaveClass('hidden');
+                // Verify that the login-form is hidden
+                    expect($('#login-form')).toHaveClass('hidden');
 
                 // Verify that the password reset form is not hidden
                     expect($('#password-reset-form')).not.toHaveClass('hidden');

--- a/lms/static/js/student_account/views/AccessView.js
+++ b/lms/static/js/student_account/views/AccessView.js
@@ -128,7 +128,12 @@
                 },
 
                 loadForm: function(type) {
-                    var loadFunc = _.bind(this.load[type], this);
+                    var loadFunc;
+                    if (type === 'reset') {
+                        loadFunc = _.bind(this.load.login, this);
+                        loadFunc(this.formDescriptions.login);
+                    }
+                    loadFunc = _.bind(this.load[type], this);
                     loadFunc(this.formDescriptions[type]);
                 },
 
@@ -225,7 +230,7 @@
                 },
 
                 passwordEmailSent: function() {
-                    var $loginAnchorElement = $('#login-anchor');
+                    var $loginAnchorElement = $('#login-form');
                     this.element.hide($(this.el).find('#password-reset-anchor'));
                     this.element.show($loginAnchorElement);
                     this.element.scrollTop($loginAnchorElement);
@@ -236,7 +241,7 @@
                         category: 'user-engagement'
                     });
 
-                    this.element.hide($(this.el).find('#login-anchor'));
+                    this.element.hide($(this.el).find('#login-form'));
                     this.loadForm('reset');
                     this.element.scrollTop($('#password-reset-anchor'));
                 },

--- a/lms/static/sass/views/_support.scss
+++ b/lms/static/sass/views/_support.scss
@@ -241,7 +241,7 @@
     font-weight: $font-regular;
   }
 
-  .help-button {
+  .help-button, .btn-secondary {
     margin-bottom: $baseline;
     height: $baseline * 2;
     font-weight: $font-regular;

--- a/lms/templates/student_account/access.underscore
+++ b/lms/templates/student_account/access.underscore
@@ -7,7 +7,7 @@
 </section>
 
 <section id="password-reset-anchor" class="form-type">
-    <div id="password-reset-form" class="form-wrapper hidden"></div>
+    <div id="password-reset-form" class="form-wrapper <% if ( mode !== 'reset' ) { %>hidden<% } %>"></div>
 </section>
 
 <section id="institution_login-anchor" class="form-type">

--- a/openedx/core/djangoapps/user_authn/urls.py
+++ b/openedx/core/djangoapps/user_authn/urls.py
@@ -20,4 +20,6 @@ urlpatterns += [
         {'initial_mode': 'login'}, name='signin_user'),
     url(r'^register$', login_form.login_and_registration_form,
         {'initial_mode': 'register'}, name='register_user'),
+    url(r'^password_assistance', login_form.login_and_registration_form,
+        {'initial_mode': 'reset'}, name='password_assistance'),
 ]


### PR DESCRIPTION
### [PROD-1478](https://openedx.atlassian.net/browse/PROD-1478)

### Description
Update the Contact Us page for unauthenticated users. Primarily, we want to remove references to the info@edx.org email. Instead, we can display to users the 3 options for login:

1. Create account
2. Log in
3. Having trouble logging in

![image](https://user-images.githubusercontent.com/52413434/80968850-19c3e900-8e32-11ea-893c-c30e26a8293f.png)

### Reviewers
- [x] @awaisdar001 
- [x] @saadyousafarbi 

### Post Review
 - [ ] Squash & Rebase commit