### PR TITLE
Add the appropriate auth classes to courseware api views

### DIFF
--- a/openedx/core/djangoapps/courseware_api/views.py
+++ b/openedx/core/djangoapps/courseware_api/views.py
@@ -13,6 +13,8 @@ from rest_framework.views import APIView
 
 from course_modes.models import CourseMode
 from edxnotes.helpers import is_feature_enabled
+from edx_rest_framework_extensions.auth.jwt.authentication import JwtAuthentication
+from edx_rest_framework_extensions.auth.session.authentication import SessionAuthenticationAllowInactiveUser
 from lms.djangoapps.course_api.api import course_detail
 from lms.djangoapps.courseware.access import has_access
 from lms.djangoapps.courseware.courses import check_course_access
@@ -192,6 +194,11 @@ class CoursewareInformation(RetrieveAPIView):
         * 404 if the course is not available or cannot be seen.
     """
 
+    authentication_classes = (
+        JwtAuthentication,
+        SessionAuthenticationAllowInactiveUser,
+    )
+
     serializer_class = CourseInfoSerializer
 
     def get_object(self):
@@ -243,6 +250,12 @@ class SequenceMetadata(DeveloperErrorViewMixin, APIView):
           another user specifies a username other than their own.
         * 404 if the course is not available or cannot be seen.
     """
+
+    authentication_classes = (
+        JwtAuthentication,
+        SessionAuthenticationAllowInactiveUser,
+    )
+
     def get(self, request, usage_key_string, *args, **kwargs):
         """
         Return response to a GET request.


### PR DESCRIPTION
Allows users who are logged in but have not activated their accounts to be considered authenticated for the purpose of the courseware api.

This fixes what in effect is a bug: users who create an account were not able to access the learning mfe until they click the activate button in the email sent to them.