### PR TITLE
Speed up courseware api response times

### DIFF
--- a/openedx/core/djangoapps/courseware_api/tests/test_views.py
+++ b/openedx/core/djangoapps/courseware_api/tests/test_views.py
@@ -7,6 +7,7 @@ from datetime import datetime
 import ddt
 import mock
 from django.conf import settings
+from django.db import transaction
 
 from lms.djangoapps.courseware.access_utils import ACCESS_DENIED, ACCESS_GRANTED
 from lms.djangoapps.courseware.tabs import ExternalLinkCourseTab
@@ -82,7 +83,8 @@ class CourseApiTestViews(BaseCoursewareTests):
             if not logged_in:
                 self.client.logout()
             if enrollment_mode:
-                CourseEnrollment.enroll(self.user, self.course.id, enrollment_mode)
+                with transaction.atomic():
+                    CourseEnrollment.enroll(self.user, self.course.id, enrollment_mode)
             response = self.client.get(self.url)
             assert response.status_code == 200
             if enrollment_mode:

--- a/openedx/core/lib/defer.py
+++ b/openedx/core/lib/defer.py
@@ -1,0 +1,83 @@
+"""
+This module creates a default ThreadPoolExecutor for the process
+and exposes some convenience functions for using the executor.
+"""
+from concurrent.futures import ThreadPoolExecutor, wait
+
+from django.utils.functional import cached_property
+
+# on python 3.5, max_workers defaults to (number of cpu cores * 5)
+# which is probably too high, considering every process will have a threadpool
+_POOL = ThreadPoolExecutor(max_workers=4)
+
+NOT_DONE = object()
+
+__all__ = ('defer', 'wait', 'PrefetchCachedProperties', 'FutureProxy')
+
+
+def defer(func, *args, **kwargs):
+    """
+    Execute a function using the global threadpool.
+    If `proxy_result=True`, returns a FutureProxy,
+    otherwise, returns a Future
+    """
+    proxy_result = kwargs.pop('proxy_result', False)
+    fut = _POOL.submit(func, *args, **kwargs)
+    if proxy_result:
+        fut = FutureProxy(fut)
+    return fut
+
+
+class PrefetchCachedProperties:
+    """
+    Mixin class that will asynchronously prefetch all cached_properties on the object
+    """
+    def __init__(self, *args, **kwargs):  # pylint: disable=unused-argument
+        to_prefetch = []
+        klass = self.__class__
+        for attr in dir(self):
+            if isinstance(getattr(klass, attr), cached_property):
+                to_prefetch.append(attr)
+        self._to_prefetch = to_prefetch
+
+    def prefetch(self):
+        """
+        Prefetch cached properties, using the global threadpool.
+        """
+        results = []
+        for attr in self._to_prefetch:
+            results.append(_POOL.submit(getattr, self, attr))
+        wait(results)
+
+
+class FutureProxy:
+    """
+    Object that wraps a future and automatically waits for the result
+    """
+    def __init__(self, fut):
+        self.fut = fut
+        self._result = NOT_DONE
+
+    def _check_done(self):
+        if self._result is NOT_DONE:
+            self._result = self.fut.result()
+
+    def __getattr__(self, attr):
+        self._check_done()
+        return getattr(self._result, attr)
+
+    def __getitem__(self, item):
+        self._check_done()
+        return self._result[item]
+
+    def __contains__(self, item):
+        self._check_done()
+        return item in self._result
+
+    def __iter__(self):
+        self._check_done()
+        return iter(self._result)
+
+    def __bool__(self):
+        self._check_done()
+        return bool(self._result)


### PR DESCRIPTION
This reduces response times for the `/api/courseware/course/{course_key}` endpoint by up to 70%.

It will parallelize accessing each item in the response, using a new process-global threadpool in `openedx.core.lib.defer`.

