### PR TITLE
Fix DeprecationWarning: insert is deprecated. Use insert_one or insert_many instead

### DIFF
--- a/cms/djangoapps/contentstore/management/commands/tests/test_cleanup_assets.py
+++ b/cms/djangoapps/contentstore/management/commands/tests/test_cleanup_assets.py
@@ -64,9 +64,9 @@ class ExportAllCourses(ModuleStoreTestCase):
         query['_id.name'] = all_assets[0]['_id']['name']
         asset_doc = self.content_store.fs_files.find_one(query)
         asset_doc['_id']['name'] = u'._example_test.txt'
-        self.content_store.fs_files.insert(asset_doc)
+        self.content_store.fs_files.insert_one(asset_doc)
         asset_doc['_id']['name'] = u'.DS_Store'
-        self.content_store.fs_files.insert(asset_doc)
+        self.content_store.fs_files.insert_one(asset_doc)
 
         # check that now course has four assets
         all_assets, count = self.content_store.get_all_content_for_course(course.id)


### PR DESCRIPTION
I wanted to make a **byte-sized contribution** but there were no Jira tickets so we decided, thanks to a conversation with @jmbowman through the Open Edx Community #incr (Slack) channel, to collaborate in the elimination of warnings listed in [**Warnings Report**](https://build.testeng.edx.org/job/edx-platform-python-pipeline-master/warning_5freport_5fall_2ehtml/)

This PR contributes to the elimination of deprecation warnings, specifically the one mentioned above and reported in the **Warnings Report**.

Changed _insert_ to _insert_one_ in the following file:

-  cms/djangoapps/contentstore/management/commands/tests/test_cleanup_assets.py

This warning occurs due to deprecation: [Pymongo collection: insert](https://api.mongodb.com/python/current/api/pymongo/collection.html#pymongo.collection.Collection.insert)

@felipemontoya 
@morenol 