### PR TITLE
Fix DeprecationWarning: The 'warn' method is deprecated, use 'warning' instead

### DIFF
--- a/lms/djangoapps/courseware/module_render.py
+++ b/lms/djangoapps/courseware/module_render.py
@@ -1090,7 +1090,7 @@ def get_module_by_usage_id(request, course_id, usage_id, disable_staff_debug_inf
         descriptor = modulestore().get_item(usage_key)
         descriptor_orig_usage_key, descriptor_orig_version = modulestore().get_block_original_usage(usage_key)
     except ItemNotFoundError:
-        log.warn(
+        log.warning(
             u"Invalid location for course id %s: %s",
             usage_key.course_key,
             usage_key
@@ -1236,7 +1236,7 @@ def xblock_view(request, course_id, usage_id, view_name):
             the second is the resource description
     """
     if not settings.FEATURES.get('ENABLE_XBLOCK_VIEW_ENDPOINT', False):
-        log.warn("Attempt to use deactivated XBlock view endpoint -"
+        log.warning("Attempt to use deactivated XBlock view endpoint -"
                  " see FEATURES['ENABLE_XBLOCK_VIEW_ENDPOINT']")
         raise Http404
 

--- a/lms/djangoapps/courseware/module_render.py
+++ b/lms/djangoapps/courseware/module_render.py
@@ -1237,7 +1237,7 @@ def xblock_view(request, course_id, usage_id, view_name):
     """
     if not settings.FEATURES.get('ENABLE_XBLOCK_VIEW_ENDPOINT', False):
         log.warning("Attempt to use deactivated XBlock view endpoint -"
-                 " see FEATURES['ENABLE_XBLOCK_VIEW_ENDPOINT']")
+                    " see FEATURES['ENABLE_XBLOCK_VIEW_ENDPOINT']")
         raise Http404
 
     try:

--- a/lms/djangoapps/experiments/utils.py
+++ b/lms/djangoapps/experiments/utils.py
@@ -84,29 +84,29 @@ def check_and_get_upgrade_link_and_date(user, enrollment=None, course=None):
     if enrollment:
         if course and enrollment.course_id != course.id:
             logger.warning(u'{} refers to a different course than {} which was supplied. Enrollment course id={}, '
-                        u'repr={!r}, deprecated={}. Course id={}, repr={!r}, deprecated={}.'
-                        .format(enrollment,
-                                course,
-                                enrollment.course_id,
-                                enrollment.course_id,
-                                enrollment.course_id.deprecated,
-                                course.id,
-                                course.id,
-                                course.id.deprecated
-                                )
-                        )
+                           u'repr={!r}, deprecated={}. Course id={}, repr={!r}, deprecated={}.'
+                           .format(enrollment,
+                                   course,
+                                   enrollment.course_id,
+                                   enrollment.course_id,
+                                   enrollment.course_id.deprecated,
+                                   course.id,
+                                   course.id,
+                                   course.id.deprecated
+                                   )
+                           )
             return (None, None, None)
 
         if enrollment.user_id != user.id:
             logger.warning(u'{} refers to a different user than {} which was supplied. Enrollment user id={}, repr={!r}. '
-                        u'User id={}, repr={!r}.'.format(enrollment,
-                                                         user,
-                                                         enrollment.user_id,
-                                                         enrollment.user_id,
-                                                         user.id,
-                                                         user.id,
-                                                         )
-                        )
+                           u'User id={}, repr={!r}.'.format(enrollment,
+                                                            user,
+                                                            enrollment.user_id,
+                                                            enrollment.user_id,
+                                                            user.id,
+                                                            user.id,
+                                                            )
+                           )
             return (None, None, None)
 
     if enrollment is None:

--- a/lms/djangoapps/experiments/utils.py
+++ b/lms/djangoapps/experiments/utils.py
@@ -98,7 +98,8 @@ def check_and_get_upgrade_link_and_date(user, enrollment=None, course=None):
             return (None, None, None)
 
         if enrollment.user_id != user.id:
-            logger.warning(u'{} refers to a different user than {} which was supplied. Enrollment user id={}, repr={!r}. '
+            logger.warning(u'{} refers to a different user than {} which was supplied. '
+                           u'Enrollment user id={}, repr={!r}. '
                            u'User id={}, repr={!r}.'.format(enrollment,
                                                             user,
                                                             enrollment.user_id,

--- a/lms/djangoapps/experiments/utils.py
+++ b/lms/djangoapps/experiments/utils.py
@@ -78,12 +78,12 @@ def check_and_get_upgrade_link_and_date(user, enrollment=None, course=None):
     otherwise, returns None for both the link and date.
     """
     if enrollment is None and course is None:
-        logger.warn(u'Must specify either an enrollment or a course')
+        logger.warning(u'Must specify either an enrollment or a course')
         return (None, None, None)
 
     if enrollment:
         if course and enrollment.course_id != course.id:
-            logger.warn(u'{} refers to a different course than {} which was supplied. Enrollment course id={}, '
+            logger.warning(u'{} refers to a different course than {} which was supplied. Enrollment course id={}, '
                         u'repr={!r}, deprecated={}. Course id={}, repr={!r}, deprecated={}.'
                         .format(enrollment,
                                 course,
@@ -98,7 +98,7 @@ def check_and_get_upgrade_link_and_date(user, enrollment=None, course=None):
             return (None, None, None)
 
         if enrollment.user_id != user.id:
-            logger.warn(u'{} refers to a different user than {} which was supplied. Enrollment user id={}, repr={!r}. '
+            logger.warning(u'{} refers to a different user than {} which was supplied. Enrollment user id={}, repr={!r}. '
                         u'User id={}, repr={!r}.'.format(enrollment,
                                                          user,
                                                          enrollment.user_id,
@@ -225,7 +225,7 @@ def is_enrolled_in_course_run(course_run, enrollment_course_ids):
         course_run_key = CourseKey.from_string(key)
         return course_run_key in enrollment_course_ids
     except InvalidKeyError:
-        logger.warn(
+        logger.warning(
             u'Unable to determine if user was enrolled since the course key {} is invalid'.format(key)
         )
         return False  # Invalid course run key. Assume user is not enrolled.

--- a/lms/djangoapps/lti_provider/outcomes.py
+++ b/lms/djangoapps/lti_provider/outcomes.py
@@ -37,7 +37,7 @@ def store_outcome_parameters(request_params, user, lti_consumer):
             # the LTI consumer that the request comes from then we may be able
             # to figure out the result service URL. As it stands, though, this
             # is a badly-formed LTI request
-            log.warn(
+            log.warning(
                 u"Outcome Service: lis_outcome_service_url parameter missing "
                 u"from scored assignment; we will be unable to return a score. "
                 u"Request parameters: %s",


### PR DESCRIPTION
I wanted to make a **byte-sized contribution** but there were no Jira tickets so we decided, thanks to a conversation with @jmbowman through the Open Edx Community #incr (Slack) channel, to collaborate in the elimination of warnings listed in [**Warnings Report**](https://build.testeng.edx.org/job/edx-platform-python-pipeline-master/warning_5freport_5fall_2ehtml/)

This PR contributes to the elimination of deprecation warnings, specifically the one mentioned above and reported in the **Warnings Report**.

Changed logger.warn to logger.warning in the following files:

- lms/djangoapps/experiments/utils.py

- lms/djangoapps/lti_provider/outcomes.py

- lms/djangoapps/courseware/module_render.py


This warning occurs due to deprecation in python 3.4+: [Python Logger: Logger.warning](https://docs.python.org/3.5/library/logging.html#logging.Logger.warning)

@felipemontoya 
@morenol 