### PR TITLE
SE-2589 fix AttributeError: 'LibraryLocatorV2' object has no attribute 'make_asset_key'

### DIFF
--- a/common/lib/xmodule/xmodule/video_module/video_module.py
+++ b/common/lib/xmodule/xmodule/video_module/video_module.py
@@ -56,7 +56,7 @@ from .transcripts_utils import (
     VideoTranscriptsMixin,
     clean_video_id,
     get_html5_ids,
-    get_transcript_for_video,
+    get_transcript,
     subs_filename
 )
 from .video_handlers import VideoStudentViewHandlers, VideoStudioViewHandlers
@@ -593,12 +593,7 @@ class VideoBlock(
         possible_sub_ids = [self.sub, self.youtube_id_1_0] + get_html5_ids(self.html5_sources)
         for sub_id in possible_sub_ids:
             try:
-                get_transcript_for_video(
-                    self.location,
-                    subs_id=sub_id,
-                    file_name=sub_id,
-                    language=u'en'
-                )
+                _, sub_id, _ = get_transcript(self, lang=u'en', output_format=Transcript.TXT)
                 transcripts_info['transcripts'] = dict(transcripts_info['transcripts'], en=sub_id)
                 break
             except NotFoundError:
@@ -1029,10 +1024,7 @@ class VideoBlock(
         def _update_transcript_for_index(language=None):
             """ Find video transcript - if not found, don't update index """
             try:
-                transcripts = self.get_transcripts_info()
-                transcript = self.get_transcript(
-                    transcripts, transcript_format='txt', lang=language
-                )[0].replace("\n", " ")
+                transcript = get_transcript(self, lang=language, output_format=Transcript.TXT)[0].replace("\n", " ")
                 transcript_index_name = "transcript_{}".format(language if language else self.transcript_language)
                 video_body.update({transcript_index_name: transcript})
             except NotFoundError:


### PR DESCRIPTION
Previously, getting transcripts for a video stored in blockstore through the xblock rest api was broken:

```
File "/edx/app/edxapp/edx-platform/openedx/core/djangoapps/xblock/rest_api/views.py", line 44, in block_metadata
metadata_dict = get_block_metadata(block, includes=includes)
File "/edx/app/edxapp/edx-platform/openedx/core/djangoapps/xblock/api.py", line 105, in get_block_metadata
data["index_dictionary"] = block.index_dictionary()
File "/edx/app/edxapp/edx-platform/common/lib/xmodule/xmodule/video_module/video_module.py", line 1050, in index_dictionary
_update_transcript_for_index(language)
File "/edx/app/edxapp/edx-platform/common/lib/xmodule/xmodule/video_module/video_module.py", line 1037, in _update_transcript_for_index
transcripts, transcript_format='txt', lang=language
File "/edx/app/edxapp/edx-platform/common/lib/xmodule/xmodule/video_module/transcripts_utils.py", line 816, in get_transcript
data = Transcript.asset(self.location, transcript_name, lang).data.decode('utf-8')
File "/edx/app/edxapp/edx-platform/common/lib/xmodule/xmodule/video_module/transcripts_utils.py", line 702, in asset
return Transcript.get_asset(location, asset_filename)
File "/edx/app/edxapp/edx-platform/common/lib/xmodule/xmodule/video_module/transcripts_utils.py", line 709, in get_asset
return contentstore().find(Transcript.asset_location(location, filename))
File "/edx/app/edxapp/edx-platform/common/lib/xmodule/xmodule/video_module/transcripts_utils.py", line 719, in asset_location
return StaticContent.compute_location(location.course_key, filename)
File "/edx/app/edxapp/edx-platform/common/lib/xmodule/xmodule/contentstore/content.py", line 84, in compute_location
return course_key.make_asset_key(
AttributeError: 'LibraryLocatorV2' object has no attribute 'make_asset_key'
```

There were two `get_transcript` methods. The broken one that is being used here (`VideoTranscriptsMixin.get_transcript`) is stripped out in this PR - it has been superseded by `transcripts_utils.get_transcript`. The latter includes support for blockstore and VAL, while the former did not.


**JIRA tickets**: [OSPR-4470](https://openedx.atlassian.net/browse/OSPR-4470)

**Dependencies**: None

**Sandbox URL**: TBD - sandbox is being provisioned.

**Merge deadline**: None

**Testing instructions**:

1. install [ramshackle](https://github.com/open-craft/ramshackle)
1. attempt to edit a video using ramshackle where the transcripts are stored in blockstore
1. verify that it loads in ramshackle without 500 errors from studio api.


**Author notes**:

- it's unknown if the `VideoTranscriptsMixin.get_transcript` method is designed to be a public method to be used in eg. external xblocks. I could only find the one reference to it in edx-platform though. If required, we can readd the method and make it a simple wrapper for `transcripts_utils.get_transcript` for backwards compat.
- see comments further down for potential breaking changes

**Reviewers**
- [x] @arbrandes
- [ ] @bradenmacdonald 
- [x] edX reviewer[s] TBD

**Settings**
```yaml
```
