### PR TITLE
EDUCATOR-4990 - Modify team membership via CSV upload

### DIFF
--- a/lms/djangoapps/teams/csv.py
+++ b/lms/djangoapps/teams/csv.py
@@ -109,6 +109,7 @@ class TeamMembershipImportManager(object):
         self.existing_course_team_memberships = {}
         self.existing_course_teams = {}
         self.user_count_by_team = Counter()
+        self.user_to_remove_by_team = Counter()
         self.number_of_learners_assigned = 0
 
     @property
@@ -151,9 +152,9 @@ class TeamMembershipImportManager(object):
                 row['user'] = None
                 continue
             row['user'] = user
-
             if not self.validate_user_assignment_to_team_and_teamset(row):
                 return False
+            self.remove_user_from_team_for_reassignment(row)
             row_dictionaries.append(row)
 
         if not self.validation_errors:
@@ -171,7 +172,7 @@ class TeamMembershipImportManager(object):
         for membership in CourseTeamMembership.get_memberships(course_ids=[self.course.id]):
             user_id = membership.user_id
             teamset_id = membership.team.topic_id
-            self.existing_course_team_memberships[(user_id, teamset_id)] = membership.team.id
+            self.existing_course_team_memberships[(user_id, teamset_id)] = membership.team
 
     def load_course_teams(self):
         """
@@ -279,6 +280,17 @@ class TeamMembershipImportManager(object):
         for teamset_id in self.teamset_ids:
             team_name = row[teamset_id]
             if not team_name:
+                # we will be removing a user from their current team in a given teamset
+                # decrement the team membership, if it exists
+                try:
+                    current_team_name = self.existing_course_team_memberships[(user.id, teamset_id)].name
+                    if (teamset_id, current_team_name) not in self.user_to_remove_by_team:
+                        self.user_to_remove_by_team[(teamset_id, current_team_name)] = 1
+                    else:
+                        self.user_to_remove_by_team[(teamset_id, current_team_name)] += 1
+                except KeyError:
+                    # happens when a user is not on any team in a team set
+                    pass
                 continue
             try:
                 # checks for a team inside a specific team set. This way team names can be duplicated across
@@ -286,21 +298,9 @@ class TeamMembershipImportManager(object):
                 team = self.existing_course_teams[(team_name, teamset_id)]
                 if (teamset_id, team_name) not in self.user_count_by_team:
                     self.user_count_by_team[(teamset_id, team_name)] = team.users.count()
-                if (user.id, team.topic_id) in self.existing_course_team_memberships:
-                    error_message = 'User {0} is already on a team in teamset {1}.'.format(
-                        user.username, team.topic_id
-                    )
-                    if self.add_error_and_check_if_max_exceeded(error_message):
-                        return False
             except KeyError:
-                all_teamset_user_ids = self.user_ids_by_teamset_id[teamset_id]
-                error_message = 'User {0} is already on a team in teamset {1}.'.format(
-                    user.username, teamset_id
-                )
-                if user.id in all_teamset_user_ids and self.add_error_and_check_if_max_exceeded(error_message):
-                    return False
-                else:
-                    self.user_ids_by_teamset_id[teamset_id].add(user.id)
+                pass
+
             if not self.validate_proposed_team_size_wont_exceed_maximum(team_name, teamset_id):
                 return False
         return True
@@ -315,11 +315,52 @@ class TeamMembershipImportManager(object):
             max_team_size = self.course.teams_configuration.teamsets_by_id[teamset_id].max_team_size
 
         if max_team_size is not None:
-            if self.user_count_by_team[(teamset_id, team_name)] + 1 > max_team_size:
+            key = (teamset_id, team_name)
+            if (self.user_count_by_team[key] - self.user_to_remove_by_team[key]) + 1 > max_team_size:
                 self.add_error_and_check_if_max_exceeded('Team ' + team_name + ' is full.')
                 return False
         self.user_count_by_team[(teamset_id, team_name)] += 1
         return True
+
+    def remove_user_from_team_for_reassignment(self, row):
+        """
+        Remove a user from a team if:
+        a. The user's current team is different from the team specified in csv for the same teamset (this user will
+           then be assigned to a new team in 'add_user_to_team`.
+        b. The team value in the CSV is blank - the user should be removed from the current team in teamset.
+        Also, if there is no change in user's membership, the input row's team name will be nulled out so that no
+        action will take place further in the processing chain.
+        """
+        for ts_id in self.teamset_ids:
+            if row[ts_id] is None:
+                # remove this student from the teamset
+                try:
+                    membership = CourseTeamMembership.objects.get(
+                        user_id=row['user'].id,
+                        team__topic_id=ts_id
+                    )
+                    membership.delete()
+                except CourseTeamMembership.DoesNotExist:
+                    pass
+            else:
+                # reassignment happens only if proposed team membership is different from existing team membership
+                if (row['user'].id, ts_id) in self.existing_course_team_memberships:
+                    current_user_teams_name = self.existing_course_team_memberships[row['user'].id, ts_id].name
+                    if current_user_teams_name != row[ts_id]:
+                        try:
+                            membership = CourseTeamMembership.objects.get(
+                                user_id=row['user'].id,
+                                team__topic_id=ts_id
+                            )
+                            membership.delete()
+                            del self.existing_course_team_memberships[row['user'].id, ts_id]
+                            self.user_ids_by_teamset_id[ts_id].remove(row['user'].id)
+                        except CourseTeamMembership.DoesNotExist:
+                            pass
+                    else:
+                        # the user will remain in the same team. In order to avoid validation/attempting
+                        # to readd the user, null out the team name
+                        row[ts_id] = None
 
     def add_error_and_check_if_max_exceeded(self, error_message):
         """

--- a/lms/djangoapps/teams/views.py
+++ b/lms/djangoapps/teams/views.py
@@ -1558,7 +1558,7 @@ class MembershipBulkManagementView(GenericAPIView):
         team_import_manager.set_team_membership_from_csv(inputfile_handle)
 
         if team_import_manager.import_succeeded:
-            msg = "{} learners were assigned to teams.".format(team_import_manager.number_of_learners_assigned)
+            msg = "{} learners were affected.".format(team_import_manager.number_of_learners_assigned)
             return JsonResponse({'message': msg}, status=status.HTTP_201_CREATED)
         else:
             return JsonResponse({


### PR DESCRIPTION
Use our CSV engine to modify team membership in addition to assigning.
Remove learner from team: If the instructor uploads a CSV that lists a student with a blank team value in a teamset column, and that student is already in our system on a team in that teamset, they will be removed from that team. 

Modify team membership: If the instructor uploads a CSV that lists a student with a team value in a teamset column, and they exist in our system on a different team in that teamset, they will be removed from the team they were in and put on the team specified in the CSV. This only applies within a single TeamSet. The student is not removed from teams in other teamsets.

For more details see [jira](https://openedx.atlassian.net/browse/EDUCATOR-4990)

@edx/masters-devs-gta 