### PR TITLE
Fix naive offset-naive/aware error in asset compilation [CRI-191]

### DIFF
--- a/openedx/core/lib/xblock_pipeline/finder.py
+++ b/openedx/core/lib/xblock_pipeline/finder.py
@@ -9,6 +9,7 @@ from django.contrib.staticfiles import utils
 from django.contrib.staticfiles.finders import BaseFinder
 from django.contrib.staticfiles.storage import FileSystemStorage
 from django.core.files.storage import Storage
+from django.utils import timezone
 from pkg_resources import resource_exists, resource_filename, resource_isdir, resource_listdir
 from xblock.core import XBlock
 
@@ -80,19 +81,19 @@ class XBlockPackageStorage(Storage):
         """
         Returns a URL to the package resource.
         """
-        return datetime.fromtimestamp(os.path.getatime(self.path(name)))
+        return datetime.fromtimestamp(os.path.getatime(self.path(name)), timezone.utc)
 
     def get_created_time(self, name):
         """
         Returns the created time of the package resource.
         """
-        return datetime.fromtimestamp(os.path.getctime(self.path(name)))
+        return datetime.fromtimestamp(os.path.getctime(self.path(name)), timezone.utc)
 
     def get_modified_time(self, name):
         """
         Returns the modified time of the resource.
         """
-        return datetime.fromtimestamp(os.path.getmtime(self.path(name)))
+        return datetime.fromtimestamp(os.path.getmtime(self.path(name)), timezone.utc)
 
     def url(self, name):
         """


### PR DESCRIPTION
The XBlockPackageStorage used to return offset-naive datetime objects
which were compared to offset-aware objects when we ran static asset
collection:

    ./manage.py lms collectstatic

Close CRI-191 (which is a Juniper issue, cc @nedbat)