### PR TITLE
Update the LibraryLocator attribute from 'course' to 'library'

### DIFF
--- a/openedx/core/djangoapps/content/block_structure/tests/test_signals.py
+++ b/openedx/core/djangoapps/content/block_structure/tests/test_signals.py
@@ -75,7 +75,7 @@ class CourseBlocksSignalTest(ModuleStoreTestCase):
 
     @ddt.data(
         (CourseLocator(org='org', course='course', run='run'), True),
-        (LibraryLocator(org='org', course='course'), False),
+        (LibraryLocator(org='org', library='course'), False),
     )
     @ddt.unpack
     @patch('openedx.core.djangoapps.content.block_structure.tasks.update_course_in_cache_v2.apply_async')


### PR DESCRIPTION
This PR solves the deprecation warning found here:
https://build.testeng.edx.org/job/edx-platform-python-pipeline-master/warning_5freport_5fall_2ehtml/

Change:
(LibraryLocator(org='org', course='course'), False)
To:
(LibraryLocator(org='org', library='course'), False)
In the file:
openedx/core/djangoapps/content/block_structure/tests/test_signals.py

- LibraryLocator is from the opaque_keys.edx.locator module

See documentation:
https://pythonhosted.org/edx-opaque-keys/opaque_keys.edx.html#opaque_keys.edx.locator.LibraryLocator

@felipemontoya, @morenol, @Squirrel18 