### PR TITLE
Swap deprecated box-sizing mixin with the box-sizing property

### DIFF
--- a/cms/static/sass/_base.scss
+++ b/cms/static/sass/_base.scss
@@ -70,7 +70,7 @@ h1 {
 
 .wrapper {
   @include clearfix();
-  @include box-sizing(border-box);
+  box-sizing: border-box;
 
   width: 100%;
 }
@@ -432,7 +432,7 @@ dl {
 
 .content-primary,
 .content-supplementary {
-  @include box-sizing(border-box);
+  box-sizing: border-box;
 }
 
 // +Layout - Primary Content
@@ -674,7 +674,7 @@ hr.divider {
 // lean/simple modal window
 .content-modal {
   @include border-bottom-radius(2px);
-  @include box-sizing(border-box);
+  box-sizing: border-box;
 
   position: relative;
   display: none;
@@ -714,7 +714,7 @@ hr.divider {
   }
 
   img {
-    @include box-sizing(border-box);
+    box-sizing: border-box;
 
     width: 100%;
     overflow-y: scroll;

--- a/cms/static/sass/_base.scss
+++ b/cms/static/sass/_base.scss
@@ -70,8 +70,8 @@ h1 {
 
 .wrapper {
   @include clearfix();
-  box-sizing: border-box;
 
+  box-sizing: border-box;
   width: 100%;
 }
 
@@ -674,8 +674,8 @@ hr.divider {
 // lean/simple modal window
 .content-modal {
   @include border-bottom-radius(2px);
-  box-sizing: border-box;
 
+  box-sizing: border-box;
   position: relative;
   display: none;
   width: 700px;
@@ -715,7 +715,6 @@ hr.divider {
 
   img {
     box-sizing: border-box;
-
     width: 100%;
     overflow-y: scroll;
     padding: ($baseline/10);

--- a/cms/static/sass/_reset.scss
+++ b/cms/static/sass/_reset.scss
@@ -3,7 +3,7 @@
 
 // not ready for this yet, but this should be done as things get cleaner
 // * {
-// 	@include box-sizing(border-box);
+// 	box-sizing: border-box;
 // }
 
 // better text rendering/kerning through SVG

--- a/cms/static/sass/elements/_forms.scss
+++ b/cms/static/sass/elements/_forms.scss
@@ -34,6 +34,7 @@ input[type="email"],
 input[type="password"],
 textarea.text {
   box-sizing: border-box;
+
   @include linear-gradient($gray-l5, $white);
 
   @extend %t-copy-sub2;
@@ -448,9 +449,7 @@ form {
 // ====================
 input.search {
   padding: 6px 15px 8px 30px;
-
   box-sizing: border-box;
-
   border: 1px solid $darkGrey;
   border-radius: 20px;
   background: url('#{$static-path}/images/search-icon.png') no-repeat 8px 7px #edf1f5;
@@ -485,9 +484,7 @@ code {
   width: 100%;
   min-height: 80px;
   padding: 10px;
-
   box-sizing: border-box;
-
   border: 1px solid $mediumGrey;
 
   @include linear-gradient(top, rgba(255, 255, 255, 0), rgba(255, 255, 255, 0.3));

--- a/cms/static/sass/elements/_forms.scss
+++ b/cms/static/sass/elements/_forms.scss
@@ -33,7 +33,7 @@ input[type="text"],
 input[type="email"],
 input[type="password"],
 textarea.text {
-  @include box-sizing(border-box);
+  box-sizing: border-box;
   @include linear-gradient($gray-l5, $white);
 
   @extend %t-copy-sub2;
@@ -143,7 +143,7 @@ form {
   }
 
   .note {
-    @include box-sizing(border-box);
+    box-sizing: border-box;
 
     // note with actions
     &.has-actions {
@@ -449,7 +449,7 @@ form {
 input.search {
   padding: 6px 15px 8px 30px;
 
-  @include box-sizing(border-box);
+  box-sizing: border-box;
 
   border: 1px solid $darkGrey;
   border-radius: 20px;
@@ -486,7 +486,7 @@ code {
   min-height: 80px;
   padding: 10px;
 
-  @include box-sizing(border-box);
+  box-sizing: border-box;
 
   border: 1px solid $mediumGrey;
 

--- a/cms/static/sass/elements/_header.scss
+++ b/cms/static/sass/elements/_header.scss
@@ -13,6 +13,7 @@
 
   header.primary {
     box-sizing: border-box;
+
     @include clearfix();
 
     max-width: $fg-max-width;
@@ -49,7 +50,6 @@
   .nav-account,
   .nav-pitch {
     box-sizing: border-box;
-
     display: inline-block;
     vertical-align: middle;
   }

--- a/cms/static/sass/elements/_header.scss
+++ b/cms/static/sass/elements/_header.scss
@@ -12,7 +12,7 @@
   background: $white;
 
   header.primary {
-    @include box-sizing(border-box);
+    box-sizing: border-box;
     @include clearfix();
 
     max-width: $fg-max-width;
@@ -48,7 +48,7 @@
   .nav-course,
   .nav-account,
   .nav-pitch {
-    @include box-sizing(border-box);
+    box-sizing: border-box;
 
     display: inline-block;
     vertical-align: middle;

--- a/cms/static/sass/elements/_icons.scss
+++ b/cms/static/sass/elements/_icons.scss
@@ -37,7 +37,7 @@
 
   // OPTION: add this class for a visual hanging display
   &.is-hanging {
-    @include box-sizing(border-box);
+    box-sizing: border-box;
 
     @extend %ui-depth2;
 

--- a/cms/static/sass/elements/_layout.scss
+++ b/cms/static/sass/elements/_layout.scss
@@ -209,7 +209,7 @@
 
 .content-primary,
 .content-supplementary {
-  @include box-sizing(border-box);
+  box-sizing: border-box;
 }
 
 // 3/4 - 1/4 two col layout

--- a/cms/static/sass/elements/_modal-window.scss
+++ b/cms/static/sass/elements/_modal-window.scss
@@ -11,7 +11,7 @@
   .modal-window {
     @extend %ui-depth3;
 
-    @include box-sizing(border-box);
+    box-sizing: border-box;
 
     position: absolute;
     width: 50%;

--- a/cms/static/sass/elements/_modal-window.scss
+++ b/cms/static/sass/elements/_modal-window.scss
@@ -12,7 +12,6 @@
     @extend %ui-depth3;
 
     box-sizing: border-box;
-
     position: absolute;
     width: 50%;
     box-shadow: 0 0 7px $shadow-d1;

--- a/cms/static/sass/elements/_modules.scss
+++ b/cms/static/sass/elements/_modules.scss
@@ -150,7 +150,7 @@
         @extend %btn-primary-green;
 
         .name {
-          @include box-sizing(border-box);
+          box-sizing: border-box;
 
           display: block;
           color: $white;

--- a/cms/static/sass/elements/_modules.scss
+++ b/cms/static/sass/elements/_modules.scss
@@ -151,7 +151,6 @@
 
         .name {
           box-sizing: border-box;
-
           display: block;
           color: $white;
         }

--- a/cms/static/sass/elements/_navigation.scss
+++ b/cms/static/sass/elements/_navigation.scss
@@ -100,9 +100,7 @@ nav {
 
   .nav-sub {
     border-radius: 2px;
-
     box-sizing: border-box;
-
     box-shadow: 0 1px 1px $shadow-l1;
     position: relative;
     width: 100%;

--- a/cms/static/sass/elements/_navigation.scss
+++ b/cms/static/sass/elements/_navigation.scss
@@ -101,7 +101,7 @@ nav {
   .nav-sub {
     border-radius: 2px;
 
-    @include box-sizing(border-box);
+    box-sizing: border-box;
 
     box-shadow: 0 1px 1px $shadow-l1;
     position: relative;

--- a/cms/static/sass/elements/_sock.scss
+++ b/cms/static/sass/elements/_sock.scss
@@ -74,7 +74,7 @@
     // shared elements
     .support,
     .feedback {
-      @include box-sizing(border-box);
+      box-sizing: border-box;
 
       .title {
         @extend %t-title6;

--- a/cms/static/sass/elements/_system-feedback.scss
+++ b/cms/static/sass/elements/_system-feedback.scss
@@ -10,6 +10,7 @@
 
 .message-status {
   @include border-top-radius(2px);
+
   box-sizing: border-box;
 
   @extend %t-strong;
@@ -416,6 +417,7 @@
 
     .notification {
       box-sizing: border-box;
+
       @include clearfix();
 
       width: 100%;
@@ -449,6 +451,7 @@
 
     .notification {
       box-sizing: border-box;
+
       @include clearfix();
 
       width: 100%;
@@ -473,6 +476,7 @@
 
 .notification {
   box-sizing: border-box;
+
   @include clearfix();
 
   margin: 0 auto;
@@ -603,7 +607,6 @@
   @extend %ui-depth2;
 
   box-sizing: border-box;
-
   box-shadow: 0 1px 1px $white, inset 0 2px 2px $shadow-d1, inset 0 -4px 1px $blue;
   position: relative;
   overflow: hidden;
@@ -664,6 +667,7 @@
 // adopted alerts
 .alert {
   box-sizing: border-box;
+
   @include clearfix();
 
   margin: 0 auto;
@@ -922,7 +926,6 @@ body.uxdesign.alerts {
   .content-primary,
   .content-supplementary {
     box-sizing: border-box;
-
     float: left;
   }
 

--- a/cms/static/sass/elements/_system-feedback.scss
+++ b/cms/static/sass/elements/_system-feedback.scss
@@ -10,7 +10,7 @@
 
 .message-status {
   @include border-top-radius(2px);
-  @include box-sizing(border-box);
+  box-sizing: border-box;
 
   @extend %t-strong;
 
@@ -52,7 +52,7 @@
 .wrapper-notification,
 .wrapper-alert,
 .prompt {
-  @include box-sizing(border-box);
+  box-sizing: border-box;
 
   .copy {
     @extend %t-copy-sub1;
@@ -415,7 +415,7 @@
     padding: ($baseline/2) $baseline;
 
     .notification {
-      @include box-sizing(border-box);
+      box-sizing: border-box;
       @include clearfix();
 
       width: 100%;
@@ -448,7 +448,7 @@
     padding: $baseline;
 
     .notification {
-      @include box-sizing(border-box);
+      box-sizing: border-box;
       @include clearfix();
 
       width: 100%;
@@ -472,7 +472,7 @@
 }
 
 .notification {
-  @include box-sizing(border-box);
+  box-sizing: border-box;
   @include clearfix();
 
   margin: 0 auto;
@@ -602,7 +602,7 @@
 .wrapper-alert {
   @extend %ui-depth2;
 
-  @include box-sizing(border-box);
+  box-sizing: border-box;
 
   box-shadow: 0 1px 1px $white, inset 0 2px 2px $shadow-d1, inset 0 -4px 1px $blue;
   position: relative;
@@ -663,7 +663,7 @@
 
 // adopted alerts
 .alert {
-  @include box-sizing(border-box);
+  box-sizing: border-box;
   @include clearfix();
 
   margin: 0 auto;
@@ -921,7 +921,7 @@
 body.uxdesign.alerts {
   .content-primary,
   .content-supplementary {
-    @include box-sizing(border-box);
+    box-sizing: border-box;
 
     float: left;
   }

--- a/cms/static/sass/elements/_system-help.scss
+++ b/cms/static/sass/elements/_system-help.scss
@@ -3,7 +3,7 @@
 
 // view introductions - common greeting/starting points for the UI
 .content .introduction {
-  @include box-sizing(border-box);
+  box-sizing: border-box;
 
   margin-bottom: $baseline;
 

--- a/cms/static/sass/elements/_system-help.scss
+++ b/cms/static/sass/elements/_system-help.scss
@@ -4,7 +4,6 @@
 // view introductions - common greeting/starting points for the UI
 .content .introduction {
   box-sizing: border-box;
-
   margin-bottom: $baseline;
 
   .title {

--- a/cms/static/sass/elements/_xblocks.scss
+++ b/cms/static/sass/elements/_xblocks.scss
@@ -35,7 +35,6 @@
   // UI: xblock header primary for main title and xblock actions
   .xblock-header-primary {
     box-sizing: border-box;
-
     border-bottom: 1px solid $gray-l4;
     border-radius: ($baseline/5) ($baseline/5) 0 0;
     min-height: ($baseline*2.5);
@@ -542,7 +541,6 @@
       @extend %t-strong;
 
       box-sizing: border-box;
-
       display: inline-block;
       padding: ($baseline/2);
       width: 49%;
@@ -555,7 +553,6 @@
       @extend %t-strong;
 
       box-sizing: border-box;
-
       display: inline-block;
       padding: ($baseline/2);
       width: 49%;

--- a/cms/static/sass/elements/_xblocks.scss
+++ b/cms/static/sass/elements/_xblocks.scss
@@ -34,7 +34,7 @@
 
   // UI: xblock header primary for main title and xblock actions
   .xblock-header-primary {
-    @include box-sizing(border-box);
+    box-sizing: border-box;
 
     border-bottom: 1px solid $gray-l4;
     border-radius: ($baseline/5) ($baseline/5) 0 0;
@@ -541,7 +541,7 @@
       @extend %t-action3;
       @extend %t-strong;
 
-      @include box-sizing(border-box);
+      box-sizing: border-box;
 
       display: inline-block;
       padding: ($baseline/2);
@@ -554,7 +554,7 @@
       @extend %t-action4;
       @extend %t-strong;
 
-      @include box-sizing(border-box);
+      box-sizing: border-box;
 
       display: inline-block;
       padding: ($baseline/2);
@@ -749,7 +749,7 @@
     // TYPE: enumerated lists of metadata sets
     .metadata-list-enum {
       * {
-        @include box-sizing(border-box);
+        box-sizing: border-box;
       }
 
       // label
@@ -819,7 +819,7 @@
     // TYPE: Dict
     .metadata-dict {
       * {
-        @include box-sizing(border-box);
+        box-sizing: border-box;
       }
 
       // label

--- a/cms/static/sass/elements/_xmodules.scss
+++ b/cms/static/sass/elements/_xmodules.scss
@@ -188,7 +188,7 @@
     // TYPE: enumerated video lists of metadata sets
     .metadata-videolist-enum {
       * {
-        @include box-sizing(border-box);
+        box-sizing: border-box;
       }
     }
 
@@ -233,7 +233,7 @@
     .list-input.settings-list {
       .metadata-video-translations {
         * {
-          @include box-sizing(border-box);
+          box-sizing: border-box;
         }
 
         // label

--- a/cms/static/sass/views/_account.scss
+++ b/cms/static/sass/views/_account.scss
@@ -56,14 +56,14 @@
 
   .content-primary,
   .content-supplementary {
-    @include box-sizing(border-box);
+    box-sizing: border-box;
   }
 
   .content-primary {
     @extend .ui-col-wide;
 
     form {
-      @include box-sizing(border-box);
+      box-sizing: border-box;
 
       box-shadow: 0 1px 2px $shadow-l1;
       border-radius: 2px;

--- a/cms/static/sass/views/_account.scss
+++ b/cms/static/sass/views/_account.scss
@@ -64,7 +64,6 @@
 
     form {
       box-sizing: border-box;
-
       box-shadow: 0 1px 2px $shadow-l1;
       border-radius: 2px;
       width: 100%;

--- a/cms/static/sass/views/_assets.scss
+++ b/cms/static/sass/views/_assets.scss
@@ -4,7 +4,7 @@
 .view-uploads {
   .content-primary,
   .content-supplementary {
-    @include box-sizing(border-box);
+    box-sizing: border-box;
   }
 
   .content-primary {

--- a/cms/static/sass/views/_certificates.scss
+++ b/cms/static/sass/views/_certificates.scss
@@ -14,7 +14,6 @@
   .content-primary,
   .content-supplementary {
     box-sizing: border-box;
-
     float: left;
   }
 
@@ -116,7 +115,6 @@
 
         li {
           box-sizing: border-box;
-
           display: table-cell;
           margin-right: 1%;
           padding: ($baseline/4) 0;
@@ -216,7 +214,6 @@
 
     .collection-edit {
       box-sizing: border-box;
-
       border-radius: 2px;
       width: 100%;
       background: $white;

--- a/cms/static/sass/views/_certificates.scss
+++ b/cms/static/sass/views/_certificates.scss
@@ -13,7 +13,7 @@
 .view-certificates {
   .content-primary,
   .content-supplementary {
-    @include box-sizing(border-box);
+    box-sizing: border-box;
 
     float: left;
   }
@@ -115,7 +115,7 @@
         margin: ($baseline/4) 0 ($baseline/2) $baseline;
 
         li {
-          @include box-sizing(border-box);
+          box-sizing: border-box;
 
           display: table-cell;
           margin-right: 1%;
@@ -215,7 +215,7 @@
     }
 
     .collection-edit {
-      @include box-sizing(border-box);
+      box-sizing: border-box;
 
       border-radius: 2px;
       width: 100%;

--- a/cms/static/sass/views/_course-create.scss
+++ b/cms/static/sass/views/_course-create.scss
@@ -8,7 +8,6 @@
   .content-primary,
   .content-supplementary {
     box-sizing: border-box;
-
     float: left;
   }
 

--- a/cms/static/sass/views/_course-create.scss
+++ b/cms/static/sass/views/_course-create.scss
@@ -7,7 +7,7 @@
   // --------------------
   .content-primary,
   .content-supplementary {
-    @include box-sizing(border-box);
+    box-sizing: border-box;
 
     float: left;
   }

--- a/cms/static/sass/views/_dashboard.scss
+++ b/cms/static/sass/views/_dashboard.scss
@@ -366,7 +366,6 @@
     &.has-status {
       .course-status {
         box-sizing: border-box;
-
         display: inline-block;
         vertical-align: middle;
         width: flex-grid(3, 9);
@@ -445,7 +444,6 @@
   // UI: individual course listings
   .course-item {
     box-sizing: border-box;
-
     width: flex-grid(9, 9);
     position: relative;
     border-bottom: 1px solid $gray-l2;
@@ -459,7 +457,6 @@
     .course-link,
     .course-actions {
       box-sizing: border-box;
-
       display: inline-block;
       vertical-align: middle;
     }
@@ -536,7 +533,6 @@
       // view live button
       .view-button {
         box-sizing: border-box;
-
         padding: ($baseline/2);
       }
 

--- a/cms/static/sass/views/_dashboard.scss
+++ b/cms/static/sass/views/_dashboard.scss
@@ -17,7 +17,7 @@
   // basic layout
   .content-primary,
   .content-supplementary {
-    @include box-sizing(border-box);
+    box-sizing: border-box;
   }
 
   .content-primary {
@@ -365,7 +365,7 @@
     // CASE: has status
     &.has-status {
       .course-status {
-        @include box-sizing(border-box);
+        box-sizing: border-box;
 
         display: inline-block;
         vertical-align: middle;
@@ -444,7 +444,7 @@
 
   // UI: individual course listings
   .course-item {
-    @include box-sizing(border-box);
+    box-sizing: border-box;
 
     width: flex-grid(9, 9);
     position: relative;
@@ -458,7 +458,7 @@
 
     .course-link,
     .course-actions {
-      @include box-sizing(border-box);
+      box-sizing: border-box;
 
       display: inline-block;
       vertical-align: middle;
@@ -535,7 +535,7 @@
 
       // view live button
       .view-button {
-        @include box-sizing(border-box);
+        box-sizing: border-box;
 
         padding: ($baseline/2);
       }

--- a/cms/static/sass/views/_export-git.scss
+++ b/cms/static/sass/views/_export-git.scss
@@ -7,7 +7,6 @@
   .content-primary,
   .content-supplementary {
     box-sizing: border-box;
-
     float: left;
   }
 

--- a/cms/static/sass/views/_export-git.scss
+++ b/cms/static/sass/views/_export-git.scss
@@ -6,7 +6,7 @@
   // UI: basic layout
   .content-primary,
   .content-supplementary {
-    @include box-sizing(border-box);
+    box-sizing: border-box;
 
     float: left;
   }
@@ -61,7 +61,7 @@
 
   // UI: export controls
   .export-git-controls {
-    @include box-sizing(border-box);
+    box-sizing: border-box;
 
     @extend %ui-window;
 

--- a/cms/static/sass/views/_export.scss
+++ b/cms/static/sass/views/_export.scss
@@ -6,7 +6,7 @@
   // UI: basic layout
   .content-primary,
   .content-supplementary {
-    @include box-sizing(border-box);
+    box-sizing: border-box;
   }
 
   .content-primary {
@@ -27,7 +27,7 @@
 
   // UI: export controls
   .export-controls {
-    @include box-sizing(border-box);
+    box-sizing: border-box;
 
     @extend %ui-window;
 

--- a/cms/static/sass/views/_group-configuration.scss
+++ b/cms/static/sass/views/_group-configuration.scss
@@ -4,6 +4,7 @@
   .content-primary,
   .content-supplementary {
     box-sizing: border-box;
+
     @include float(left);
   }
 
@@ -130,6 +131,7 @@
 
           li {
             box-sizing: border-box;
+
             @include margin-right(1%);
 
             display: table-cell;
@@ -154,6 +156,7 @@
 
           li {
             box-sizing: border-box;
+
             @include margin-right(1%);
 
             display: table-cell;
@@ -289,7 +292,6 @@
 
       .collection-edit {
         box-sizing: border-box;
-
         border-radius: 2px;
         width: 100%;
         background: $white;

--- a/cms/static/sass/views/_group-configuration.scss
+++ b/cms/static/sass/views/_group-configuration.scss
@@ -3,7 +3,7 @@
 .view-group-configurations {
   .content-primary,
   .content-supplementary {
-    @include box-sizing(border-box);
+    box-sizing: border-box;
     @include float(left);
   }
 
@@ -129,7 +129,7 @@
           width: 70%;
 
           li {
-            @include box-sizing(border-box);
+            box-sizing: border-box;
             @include margin-right(1%);
 
             display: table-cell;
@@ -153,7 +153,7 @@
           width: 70%;
 
           li {
-            @include box-sizing(border-box);
+            box-sizing: border-box;
             @include margin-right(1%);
 
             display: table-cell;
@@ -288,7 +288,7 @@
       }
 
       .collection-edit {
-        @include box-sizing(border-box);
+        box-sizing: border-box;
 
         border-radius: 2px;
         width: 100%;

--- a/cms/static/sass/views/_import.scss
+++ b/cms/static/sass/views/_import.scss
@@ -4,7 +4,7 @@
 .view-import {
   .content-primary,
   .content-supplementary {
-    @include box-sizing(border-box);
+    box-sizing: border-box;
   }
 
   .content-primary {
@@ -26,7 +26,7 @@
 
   // UI: import form
   .import-form {
-    @include box-sizing(border-box);
+    box-sizing: border-box;
 
     @extend %ui-window;
 

--- a/cms/static/sass/views/_index.scss
+++ b/cms/static/sass/views/_index.scss
@@ -10,7 +10,7 @@
     .wrapper-content-header,
     .wrapper-content-features,
     .wrapper-content-cta {
-      @include box-sizing(border-box);
+      box-sizing: border-box;
 
       margin: 0;
       padding: 0 $baseline;
@@ -139,14 +139,14 @@
         padding: 0 0 ($baseline*2) 0;
 
         .img {
-          @include box-sizing(border-box);
+          box-sizing: border-box;
 
           float: left;
           width: flex-grid(3, 12);
           margin-right: flex-gutter();
 
           a {
-            @include box-sizing(border-box);
+            box-sizing: border-box;
 
             box-shadow: 0 1px ($baseline/10) $shadow-l1;
             position: relative;
@@ -228,7 +228,7 @@
             margin: ($baseline*1.5) 0 0 0;
 
             .proofpoint {
-              @include box-sizing(border-box);
+              box-sizing: border-box;
               @include transition(all $tmg-f2 ease-in-out 0s);
 
               border-radius: ($baseline/4);

--- a/cms/static/sass/views/_index.scss
+++ b/cms/static/sass/views/_index.scss
@@ -11,7 +11,6 @@
     .wrapper-content-features,
     .wrapper-content-cta {
       box-sizing: border-box;
-
       margin: 0;
       padding: 0 $baseline;
       position: relative;
@@ -140,14 +139,12 @@
 
         .img {
           box-sizing: border-box;
-
           float: left;
           width: flex-grid(3, 12);
           margin-right: flex-gutter();
 
           a {
             box-sizing: border-box;
-
             box-shadow: 0 1px ($baseline/10) $shadow-l1;
             position: relative;
             top: 0;
@@ -229,6 +226,7 @@
 
             .proofpoint {
               box-sizing: border-box;
+
               @include transition(all $tmg-f2 ease-in-out 0s);
 
               border-radius: ($baseline/4);

--- a/cms/static/sass/views/_outline.scss
+++ b/cms/static/sass/views/_outline.scss
@@ -72,7 +72,7 @@
   // --------------------
   .content-primary,
   .content-supplementary {
-    @include box-sizing(border-box);
+    box-sizing: border-box;
   }
 
   .content-primary {

--- a/cms/static/sass/views/_settings.scss
+++ b/cms/static/sass/views/_settings.scss
@@ -12,7 +12,7 @@
 
   .content-primary,
   .content-supplementary {
-    @include box-sizing(border-box);
+    box-sizing: border-box;
   }
 
   .content-primary {
@@ -31,7 +31,7 @@
 
   .message-status {
     @include border-top-radius(2px);
-    @include box-sizing(border-box);
+    box-sizing: border-box;
 
     @extend %t-strong;
 
@@ -296,7 +296,7 @@
       // enumerated/grouped lists
       &.enum {
         .field-group {
-          @include box-sizing(border-box);
+          box-sizing: border-box;
 
           border-radius: 3px;
           background: $gray-l5;
@@ -410,7 +410,7 @@
           .link-courseURL {
             @extend %t-copy-lead1;
 
-            @include box-sizing(border-box);
+            box-sizing: border-box;
 
             display: block;
             width: 100%;
@@ -514,7 +514,7 @@
     // specific fields - video
     #field-course-introduction-video {
       .input-existing {
-        @include box-sizing(border-box);
+        box-sizing: border-box;
 
         border-radius: 3px;
         background: $gray-l5;
@@ -618,7 +618,7 @@
       }
 
       .new-grade-button {
-        @include box-sizing(border-box);
+        box-sizing: border-box;
         @include linear-gradient(top, rgba(255, 255, 255, 0.8), rgba(255, 255, 255, 0));
 
         box-shadow: 0 1px 0 rgba(255, 255, 255, 0.3) inset;
@@ -644,7 +644,7 @@
       }
 
       .grade-slider {
-        @include box-sizing(border-box);
+        box-sizing: border-box;
 
         width: flex-grid(8, 9);
         display: inline-block;
@@ -1131,7 +1131,7 @@
       .CodeMirror {
         @extend %t-copy-base;
 
-        @include box-sizing(border-box);
+        box-sizing: border-box;
 
         box-shadow: 0 1px 2px $shadow-l1 inset;
 

--- a/cms/static/sass/views/_settings.scss
+++ b/cms/static/sass/views/_settings.scss
@@ -31,6 +31,7 @@
 
   .message-status {
     @include border-top-radius(2px);
+
     box-sizing: border-box;
 
     @extend %t-strong;
@@ -297,7 +298,6 @@
       &.enum {
         .field-group {
           box-sizing: border-box;
-
           border-radius: 3px;
           background: $gray-l5;
           padding: $baseline;
@@ -411,7 +411,6 @@
             @extend %t-copy-lead1;
 
             box-sizing: border-box;
-
             display: block;
             width: 100%;
             overflow: hidden;
@@ -515,7 +514,6 @@
     #field-course-introduction-video {
       .input-existing {
         box-sizing: border-box;
-
         border-radius: 3px;
         background: $gray-l5;
         padding: ($baseline/2);
@@ -619,6 +617,7 @@
 
       .new-grade-button {
         box-sizing: border-box;
+
         @include linear-gradient(top, rgba(255, 255, 255, 0.8), rgba(255, 255, 255, 0));
 
         box-shadow: 0 1px 0 rgba(255, 255, 255, 0.3) inset;
@@ -645,7 +644,6 @@
 
       .grade-slider {
         box-sizing: border-box;
-
         width: flex-grid(8, 9);
         display: inline-block;
         vertical-align: middle;
@@ -1132,7 +1130,6 @@
         @extend %t-copy-base;
 
         box-sizing: border-box;
-
         box-shadow: 0 1px 2px $shadow-l1 inset;
 
         @include linear-gradient($lightGrey, tint($lightGrey, 90%));

--- a/cms/static/sass/views/_static-pages.scss
+++ b/cms/static/sass/views/_static-pages.scss
@@ -6,7 +6,7 @@
   // page structure
   .content-primary,
   .content-supplementary {
-    @include box-sizing(border-box);
+    box-sizing: border-box;
 
     float: left;
   }
@@ -233,7 +233,7 @@
 
     // uses similar styling as assets.scss, unit.scss
     .wrapper-component-action-header {
-      @include box-sizing(border-box);
+      box-sizing: border-box;
 
       position: absolute;
       width: 100%;
@@ -400,7 +400,7 @@
   }
 
   .page-contents {
-    @include box-sizing(border-box);
+    box-sizing: border-box;
     @include linear-gradient(top, rgba(255, 255, 255, 0), rgba(255, 255, 255, 0.3));
 
     @extend %t-copy-sub1;

--- a/cms/static/sass/views/_static-pages.scss
+++ b/cms/static/sass/views/_static-pages.scss
@@ -7,7 +7,6 @@
   .content-primary,
   .content-supplementary {
     box-sizing: border-box;
-
     float: left;
   }
 
@@ -234,7 +233,6 @@
     // uses similar styling as assets.scss, unit.scss
     .wrapper-component-action-header {
       box-sizing: border-box;
-
       position: absolute;
       width: 100%;
       padding: $baseline/4 $baseline/2;
@@ -401,6 +399,7 @@
 
   .page-contents {
     box-sizing: border-box;
+
     @include linear-gradient(top, rgba(255, 255, 255, 0), rgba(255, 255, 255, 0.3));
 
     @extend %t-copy-sub1;

--- a/cms/static/sass/views/_textbooks.scss
+++ b/cms/static/sass/views/_textbooks.scss
@@ -4,7 +4,7 @@
 .view-textbooks {
   .content-primary,
   .content-supplementary {
-    @include box-sizing(border-box);
+    box-sizing: border-box;
   }
 
   .content-primary {
@@ -122,7 +122,7 @@
       }
 
       .edit-textbook {
-        @include box-sizing(border-box);
+        box-sizing: border-box;
 
         border-radius: 2px;
         width: 100%;

--- a/cms/static/sass/views/_textbooks.scss
+++ b/cms/static/sass/views/_textbooks.scss
@@ -123,7 +123,6 @@
 
       .edit-textbook {
         box-sizing: border-box;
-
         border-radius: 2px;
         width: 100%;
         background: $white;

--- a/cms/static/sass/views/_users.scss
+++ b/cms/static/sass/views/_users.scss
@@ -6,7 +6,7 @@
   // LAYOUT: page
   .content-primary,
   .content-supplementary {
-    @include box-sizing(border-box);
+    box-sizing: border-box;
   }
 
   .content-primary {
@@ -71,7 +71,7 @@
   .user-item,
   .item-metadata,
   .item-actions {
-    @include box-sizing(border-box);
+    box-sizing: border-box;
   }
 
   .user-list {

--- a/cms/static/sass/views/_video-upload.scss
+++ b/cms/static/sass/views/_video-upload.scss
@@ -1,7 +1,7 @@
 .view-video-uploads {
   .content-primary,
   .content-supplementary {
-    @include box-sizing(border-box);
+    box-sizing: border-box;
   }
 
   .nav-actions {

--- a/common/lib/xmodule/xmodule/css/capa/display.scss
+++ b/common/lib/xmodule/xmodule/css/capa/display.scss
@@ -130,10 +130,10 @@ h2 {
   display: block;
 }
 
-iframe[seamless]{
+iframe[seamless] {
   overflow: hidden;
   padding: 0;
-  border: 0px none transparent;
+  border: 0 none transparent;
   background-color: transparent;
 }
 
@@ -157,7 +157,8 @@ div.problem {
     padding: 0;
     width: auto;
 
-    canvas, img {
+    canvas,
+    img {
       page-break-inside: avoid;
     }
   }

--- a/common/lib/xmodule/xmodule/css/capa/display.scss
+++ b/common/lib/xmodule/xmodule/css/capa/display.scss
@@ -209,7 +209,7 @@ div.problem {
   width: 100px;
 
   label {
-    @include box-sizing(border-box);
+    box-sizing: border-box;
 
     display: inline-block;
     clear: both;
@@ -231,7 +231,7 @@ div.problem {
   }
 
   fieldset {
-    @include box-sizing(border-box);
+    box-sizing: border-box;
   }
 
   input[type="radio"],
@@ -775,7 +775,7 @@ div.problem {
 .problem {
   .capa_inputtype.textline, .inputtype.formulaequationinput {
     input {
-      @include box-sizing(border-box);
+      box-sizing: border-box;
 
       border: 2px solid $gray-l4;
       border-radius: 3px;
@@ -1284,7 +1284,7 @@ div.problem {
 
       a.full {
         @include position(absolute, 0 0 1px 0);
-        @include box-sizing(border-box);
+        box-sizing: border-box;
 
         display: block;
         padding: ($baseline/5);

--- a/common/lib/xmodule/xmodule/css/html/edit.scss
+++ b/common/lib/xmodule/xmodule/css/html/edit.scss
@@ -3,7 +3,7 @@
   @include clearfix();
 
   .CodeMirror {
-    @include box-sizing(border-box);
+    box-sizing: border-box;
 
     height: 435px;
   }

--- a/common/lib/xmodule/xmodule/css/tabs/codemirror.scss
+++ b/common/lib/xmodule/xmodule/css/tabs/codemirror.scss
@@ -2,7 +2,7 @@
   @include clearfix();
 
   .CodeMirror {
-    @include box-sizing(border-box);
+    box-sizing: border-box;
 
     width: 100%;
     position: relative;

--- a/common/lib/xmodule/xmodule/css/tabs/tabs.scss
+++ b/common/lib/xmodule/xmodule/css/tabs/tabs.scss
@@ -23,7 +23,7 @@
 
 
   .edit-header {
-    @include box-sizing(border-box);
+    box-sizing: border-box;
 
     padding: 18px $baseline;
     top: 0 !important; // ugly override for second level tab override

--- a/common/lib/xmodule/xmodule/css/video/display.scss
+++ b/common/lib/xmodule/xmodule/css/video/display.scss
@@ -928,7 +928,7 @@ $cool-dark: rgb(79, 89, 93); // UXPL cool dark
       width: 25%;
       padding: lh();
 
-      @include box-sizing(border-box);
+      box-sizing: border-box;
       @include transition(none);
 
       background: $black;

--- a/common/static/sass/_mixins.scss
+++ b/common/static/sass/_mixins.scss
@@ -114,8 +114,8 @@
 // used for page/view-level wrappers (for centering/grids)
 %ui-wrapper {
   @include clearfix();
-  box-sizing: border-box;
 
+  box-sizing: border-box;
   width: 100%;
 }
 
@@ -199,6 +199,7 @@
 // ====================
 %ui-btn {
   box-sizing: border-box;
+
   @include transition(color $tmg-f2 ease-in-out 0s, border-color $tmg-f2 ease-in-out 0s, background $tmg-f2 ease-in-out 0s, box-shadow $tmg-f2 ease-in-out 0s);
 
   display: inline-block;
@@ -441,7 +442,6 @@
 // ====================
 %cont-truncated {
   box-sizing: border-box;
-
   overflow: hidden;
   white-space: nowrap;
   text-overflow: ellipsis;

--- a/common/static/sass/_mixins.scss
+++ b/common/static/sass/_mixins.scss
@@ -114,7 +114,7 @@
 // used for page/view-level wrappers (for centering/grids)
 %ui-wrapper {
   @include clearfix();
-  @include box-sizing(border-box);
+  box-sizing: border-box;
 
   width: 100%;
 }
@@ -198,7 +198,7 @@
 // +UI - Buttons - Extends
 // ====================
 %ui-btn {
-  @include box-sizing(border-box);
+  box-sizing: border-box;
   @include transition(color $tmg-f2 ease-in-out 0s, border-color $tmg-f2 ease-in-out 0s, background $tmg-f2 ease-in-out 0s, box-shadow $tmg-f2 ease-in-out 0s);
 
   display: inline-block;
@@ -440,7 +440,7 @@
 // +Content - Text Truncate - Extend
 // ====================
 %cont-truncated {
-  @include box-sizing(border-box);
+  box-sizing: border-box;
 
   overflow: hidden;
   white-space: nowrap;

--- a/common/static/sass/neat/grid/_fill-parent.scss
+++ b/common/static/sass/neat/grid/_fill-parent.scss
@@ -2,6 +2,6 @@
   width: 100%;
 
   @if $border-box-sizing == false {
-    @include box-sizing(border-box);
+    box-sizing: border-box;
   }
 }

--- a/common/static/sass/neat/grid/_grid.scss
+++ b/common/static/sass/neat/grid/_grid.scss
@@ -1,5 +1,5 @@
 @if $border-box-sizing == true {
   * {
-    @include box-sizing(border-box);
+    box-sizing: border-box;
   }
 }

--- a/lms/static/sass/_shame.scss
+++ b/lms/static/sass/_shame.scss
@@ -7,7 +7,7 @@
 
 // extends btn
 %m-btn {
-  @include box-sizing(border-box);
+  box-sizing: border-box;
   @include transition(color $tmg-f2 ease-in-out, background $tmg-f2 ease-in-out, box-shadow $tmg-f2 ease-in-out);
 
   display: inline-block;

--- a/lms/static/sass/_shame.scss
+++ b/lms/static/sass/_shame.scss
@@ -8,6 +8,7 @@
 // extends btn
 %m-btn {
   box-sizing: border-box;
+
   @include transition(color $tmg-f2 ease-in-out, background $tmg-f2 ease-in-out, box-shadow $tmg-f2 ease-in-out);
 
   display: inline-block;

--- a/lms/static/sass/base/_base.scss
+++ b/lms/static/sass/base/_base.scss
@@ -145,6 +145,7 @@ a:visited:not(.btn) {
 
 .container {
   @include clearfix();
+
   box-sizing: border-box;
 
   @include media-breakpoint-up(md) {

--- a/lms/static/sass/base/_base.scss
+++ b/lms/static/sass/base/_base.scss
@@ -145,7 +145,7 @@ a:visited:not(.btn) {
 
 .container {
   @include clearfix();
-  @include box-sizing(border-box);
+  box-sizing: border-box;
 
   @include media-breakpoint-up(md) {
     margin: 0 auto;

--- a/lms/static/sass/base/_extends.scss
+++ b/lms/static/sass/base/_extends.scss
@@ -151,7 +151,6 @@
 // extends - content - text overflow by ellipsis
 %cont-truncated {
   box-sizing: border-box;
-
   overflow: hidden;
   white-space: nowrap;
   text-overflow: ellipsis;

--- a/lms/static/sass/base/_extends.scss
+++ b/lms/static/sass/base/_extends.scss
@@ -150,7 +150,7 @@
 
 // extends - content - text overflow by ellipsis
 %cont-truncated {
-  @include box-sizing(border-box);
+  box-sizing: border-box;
 
   overflow: hidden;
   white-space: nowrap;

--- a/lms/static/sass/base/_mixins.scss
+++ b/lms/static/sass/base/_mixins.scss
@@ -62,8 +62,8 @@
 // extends - UI - used for page/view-level wrappers (for centering/grids)
 %ui-wrapper {
   @include clearfix();
-  box-sizing: border-box;
 
+  box-sizing: border-box;
   width: 100%;
 }
 
@@ -177,7 +177,6 @@
 // extends - text - text overflow by ellipsis
 %text-truncated {
   box-sizing: border-box;
-
   overflow: hidden;
   white-space: nowrap;
   text-overflow: ellipsis;

--- a/lms/static/sass/base/_mixins.scss
+++ b/lms/static/sass/base/_mixins.scss
@@ -62,7 +62,7 @@
 // extends - UI - used for page/view-level wrappers (for centering/grids)
 %ui-wrapper {
   @include clearfix();
-  @include box-sizing(border-box);
+  box-sizing: border-box;
 
   width: 100%;
 }
@@ -176,7 +176,7 @@
 
 // extends - text - text overflow by ellipsis
 %text-truncated {
-  @include box-sizing(border-box);
+  box-sizing: border-box;
 
   overflow: hidden;
   white-space: nowrap;

--- a/lms/static/sass/course/_gradebook.scss
+++ b/lms/static/sass/course/_gradebook.scss
@@ -27,9 +27,7 @@ div.gradebook-wrapper {
       width: 100%;
       height: 27px;
       padding: 0 ($baseline*0.75) 0 35px;
-
       box-sizing: border-box;
-
       border-radius: 13px;
       border: 1px solid $table-border-color;
       background: url('#{$static-path}/images/search-icon.png') no-repeat 9px center $gray-l6;

--- a/lms/static/sass/course/_gradebook.scss
+++ b/lms/static/sass/course/_gradebook.scss
@@ -28,7 +28,7 @@ div.gradebook-wrapper {
       height: 27px;
       padding: 0 ($baseline*0.75) 0 35px;
 
-      @include box-sizing(border-box);
+      box-sizing: border-box;
 
       border-radius: 13px;
       border: 1px solid $table-border-color;

--- a/lms/static/sass/course/_profile.scss
+++ b/lms/static/sass/course/_profile.scss
@@ -51,7 +51,6 @@
           input {
             &[type="text"] {
               box-sizing: border-box;
-
               margin: lh(0.5) 0;
               width: 100%;
             }
@@ -160,8 +159,8 @@
 
       > a {
         @include button(simple, $button-color);
-        box-sizing: border-box;
 
+        box-sizing: border-box;
         border-radius: 3px;
         font: normal 15px/1.6rem $font-family-sans-serif;
         letter-spacing: 0;
@@ -278,8 +277,8 @@
 
         .hd {
           @include border-right(1px dashed #ddd);
-          box-sizing: border-box;
 
+          box-sizing: border-box;
           display: table-cell;
           letter-spacing: 0;
           margin: 0;

--- a/lms/static/sass/course/_profile.scss
+++ b/lms/static/sass/course/_profile.scss
@@ -50,7 +50,7 @@
 
           input {
             &[type="text"] {
-              @include box-sizing(border-box);
+              box-sizing: border-box;
 
               margin: lh(0.5) 0;
               width: 100%;
@@ -160,7 +160,7 @@
 
       > a {
         @include button(simple, $button-color);
-        @include box-sizing(border-box);
+        box-sizing: border-box;
 
         border-radius: 3px;
         font: normal 15px/1.6rem $font-family-sans-serif;
@@ -278,7 +278,7 @@
 
         .hd {
           @include border-right(1px dashed #ddd);
-          @include box-sizing(border-box);
+          box-sizing: border-box;
 
           display: table-cell;
           letter-spacing: 0;

--- a/lms/static/sass/course/_tabs.scss
+++ b/lms/static/sass/course/_tabs.scss
@@ -1,6 +1,5 @@
 div.static_tab_wrapper {
   box-sizing: border-box;
-
   padding: 2em 2.5em;
 
   h1 {

--- a/lms/static/sass/course/_tabs.scss
+++ b/lms/static/sass/course/_tabs.scss
@@ -1,5 +1,5 @@
 div.static_tab_wrapper {
-  @include box-sizing(border-box);
+  box-sizing: border-box;
 
   padding: 2em 2.5em;
 

--- a/lms/static/sass/course/_textbook.scss
+++ b/lms/static/sass/course/_textbook.scss
@@ -21,7 +21,6 @@ div.book-wrapper {
     @extend .tran;
 
     box-sizing: border-box;
-
     padding: ($baseline/2) 0;
     border-radius: 3px 0 0 3px;
     border: 1px solid $gray-l3;
@@ -128,9 +127,7 @@ div.book-wrapper {
             background-color: rgba(#000, 0.7);
             background-position: center;
             background-repeat: no-repeat;
-
             box-sizing: border-box;
-
             display: table;
             height: 100%;
             opacity: 0;

--- a/lms/static/sass/course/_textbook.scss
+++ b/lms/static/sass/course/_textbook.scss
@@ -20,7 +20,7 @@ div.book-wrapper {
     @extend .sidebar;
     @extend .tran;
 
-    @include box-sizing(border-box);
+    box-sizing: border-box;
 
     padding: ($baseline/2) 0;
     border-radius: 3px 0 0 3px;
@@ -129,7 +129,7 @@ div.book-wrapper {
             background-position: center;
             background-repeat: no-repeat;
 
-            @include box-sizing(border-box);
+            box-sizing: border-box;
 
             display: table;
             height: 100%;

--- a/lms/static/sass/course/base/_base.scss
+++ b/lms/static/sass/course/base/_base.scss
@@ -109,9 +109,7 @@ input[type="password"] {
   border: 1px solid $border-color-2;
   border-radius: 0;
   box-shadow: 0 1px 0 0 rgba(255, 255, 255, 0.6), inset 0 0 3px 0 $shadow-l1;
-
   box-sizing: border-box;
-
   font: normal 1em $font-family-sans-serif;
   height: 35px;
   padding: ($baseline/4) 12px;

--- a/lms/static/sass/course/base/_base.scss
+++ b/lms/static/sass/course/base/_base.scss
@@ -110,7 +110,7 @@ input[type="password"] {
   border-radius: 0;
   box-shadow: 0 1px 0 0 rgba(255, 255, 255, 0.6), inset 0 0 3px 0 $shadow-l1;
 
-  @include box-sizing(border-box);
+  box-sizing: border-box;
 
   font: normal 1em $font-family-sans-serif;
   height: 35px;

--- a/lms/static/sass/course/courseware/_amplifier.scss
+++ b/lms/static/sass/course/courseware/_amplifier.scss
@@ -13,7 +13,7 @@ section.tool-wrapper {
   div#graph-container {
     background: none;
 
-    @include box-sizing(border-box);
+    box-sizing: border-box;
 
     display: table-cell;
     padding: lh();
@@ -82,7 +82,7 @@ section.tool-wrapper {
     border-right: 1px solid darken(#002b36, 6%);
     box-shadow: 1px 0 0 lighten(#002b36, 6%), inset 0 0 0 4px darken(#094959, 6%);
 
-    @include box-sizing(border-box);
+    box-sizing: border-box;
 
     display: table-cell;
     padding: lh();

--- a/lms/static/sass/course/courseware/_amplifier.scss
+++ b/lms/static/sass/course/courseware/_amplifier.scss
@@ -12,9 +12,7 @@ section.tool-wrapper {
 
   div#graph-container {
     background: none;
-
     box-sizing: border-box;
-
     display: table-cell;
     padding: lh();
     vertical-align: top;
@@ -81,9 +79,7 @@ section.tool-wrapper {
     background: darken(#073642, 2%);
     border-right: 1px solid darken(#002b36, 6%);
     box-shadow: 1px 0 0 lighten(#002b36, 6%), inset 0 0 0 4px darken(#094959, 6%);
-
     box-sizing: border-box;
-
     display: table-cell;
     padding: lh();
     vertical-align: top;

--- a/lms/static/sass/course/courseware/_sidebar.scss
+++ b/lms/static/sass/course/courseware/_sidebar.scss
@@ -24,7 +24,7 @@
     .course-navigation {
       .button-chapter {
         @include transition(all $tmg-s3 ease-in-out);
-        @include box-sizing(border-box);
+        box-sizing: border-box;
         @include linear-gradient(top, $sidebar-chapter-bg-top, $sidebar-chapter-bg-bottom);
         @include transition(background-color 0.1s linear 0s);
 

--- a/lms/static/sass/course/courseware/_sidebar.scss
+++ b/lms/static/sass/course/courseware/_sidebar.scss
@@ -24,7 +24,9 @@
     .course-navigation {
       .button-chapter {
         @include transition(all $tmg-s3 ease-in-out);
+
         box-sizing: border-box;
+
         @include linear-gradient(top, $sidebar-chapter-bg-top, $sidebar-chapter-bg-bottom);
         @include transition(background-color 0.1s linear 0s);
 

--- a/lms/static/sass/course/instructor/_instructor_2.scss
+++ b/lms/static/sass/course/instructor/_instructor_2.scss
@@ -737,6 +737,7 @@
       .member-list-widget {
         .header {
           box-sizing: border-box;
+
           @include border-top-radius(3);
 
           position: relative;
@@ -759,7 +760,6 @@
 
         .info {
           box-sizing: border-box;
-
           padding: ($baseline/2);
           border: 1px solid $light-gray;
           color: $lighter-base-font-color;
@@ -798,6 +798,7 @@
 
         .bottom-bar {
           box-sizing: border-box;
+
           @include border-bottom-radius(3);
 
           position: relative;

--- a/lms/static/sass/course/instructor/_instructor_2.scss
+++ b/lms/static/sass/course/instructor/_instructor_2.scss
@@ -736,7 +736,7 @@
 
       .member-list-widget {
         .header {
-          @include box-sizing(border-box);
+          box-sizing: border-box;
           @include border-top-radius(3);
 
           position: relative;
@@ -758,7 +758,7 @@
         }
 
         .info {
-          @include box-sizing(border-box);
+          box-sizing: border-box;
 
           padding: ($baseline/2);
           border: 1px solid $light-gray;
@@ -768,7 +768,7 @@
         }
 
         .member-list {
-          @include box-sizing(border-box);
+          box-sizing: border-box;
 
           table {
             width: 100%;
@@ -797,7 +797,7 @@
         }
 
         .bottom-bar {
-          @include box-sizing(border-box);
+          box-sizing: border-box;
           @include border-bottom-radius(3);
 
           position: relative;

--- a/lms/static/sass/course/layout/_courseware_header.scss
+++ b/lms/static/sass/course/layout/_courseware_header.scss
@@ -1,5 +1,6 @@
 .wrapper-course-material {
   @include clearfix();
+
   box-sizing: border-box;
 
   @extend %ui-print-excluded;
@@ -103,9 +104,7 @@
       border: 1px solid transparent;
       border-color: theme-color("primary");
       border-radius: 3px;
-
       box-sizing: border-box;
-
       box-shadow: 0 1px 0 0 rgba(255, 255, 255, 0.6);
       color: theme-color("inverse");
       display: inline-block;

--- a/lms/static/sass/course/layout/_courseware_header.scss
+++ b/lms/static/sass/course/layout/_courseware_header.scss
@@ -1,6 +1,6 @@
 .wrapper-course-material {
   @include clearfix();
-  @include box-sizing(border-box);
+  box-sizing: border-box;
 
   @extend %ui-print-excluded;
 
@@ -104,7 +104,7 @@
       border-color: theme-color("primary");
       border-radius: 3px;
 
-      @include box-sizing(border-box);
+      box-sizing: border-box;
 
       box-shadow: 0 1px 0 0 rgba(255, 255, 255, 0.6);
       color: theme-color("inverse");

--- a/lms/static/sass/course/modules/_calculator.scss
+++ b/lms/static/sass/course/modules/_calculator.scss
@@ -68,7 +68,7 @@
     form {
       @extend .clearfix;
 
-      @include box-sizing(border-box);
+      box-sizing: border-box;
 
       padding: lh();
 
@@ -82,7 +82,7 @@
         border-radius: 0;
         box-shadow: none;
 
-        @include box-sizing(border-box);
+        box-sizing: border-box;
 
         color: $black;
         float: left;
@@ -113,7 +113,7 @@
         border: 1px solid $white;
         box-shadow: none;
 
-        @include box-sizing(border-box);
+        box-sizing: border-box;
 
         color: $black;
         float: left;
@@ -148,7 +148,7 @@
           border: none;
           box-shadow: none;
 
-          @include box-sizing(border-box);
+          box-sizing: border-box;
 
           font-size: 16px;
           padding: 10px;

--- a/lms/static/sass/course/modules/_calculator.scss
+++ b/lms/static/sass/course/modules/_calculator.scss
@@ -69,7 +69,6 @@
       @extend .clearfix;
 
       box-sizing: border-box;
-
       padding: lh();
 
       .calc-output-label {
@@ -81,9 +80,7 @@
         border: 1px solid $white;
         border-radius: 0;
         box-shadow: none;
-
         box-sizing: border-box;
-
         color: $black;
         float: left;
         font-size: 30px;
@@ -112,9 +109,7 @@
         background: $white;
         border: 1px solid $white;
         box-shadow: none;
-
         box-sizing: border-box;
-
         color: $black;
         float: left;
         font-size: 16px;
@@ -147,9 +142,7 @@
           direction: ltr;  // Almost all of the real-world calculators are LTR
           border: none;
           box-shadow: none;
-
           box-sizing: border-box;
-
           font-size: 16px;
           padding: 10px;
           -webkit-appearance: none;

--- a/lms/static/sass/course/wiki/_create.scss
+++ b/lms/static/sass/course/wiki/_create.scss
@@ -17,14 +17,12 @@ form#wiki_revision {
     @extend textarea;
 
     box-sizing: border-box;
-
     font-family: monospace;
     margin-bottom: $baseline;
   }
 
   textarea {
     box-sizing: border-box;
-
     margin-bottom: $baseline;
     min-height: 450px;
     width: 100%;

--- a/lms/static/sass/course/wiki/_create.scss
+++ b/lms/static/sass/course/wiki/_create.scss
@@ -16,14 +16,14 @@ form#wiki_revision {
   .CodeMirror {
     @extend textarea;
 
-    @include box-sizing(border-box);
+    box-sizing: border-box;
 
     font-family: monospace;
     margin-bottom: $baseline;
   }
 
   textarea {
-    @include box-sizing(border-box);
+    box-sizing: border-box;
 
     margin-bottom: $baseline;
     min-height: 450px;

--- a/lms/static/sass/course/wiki/_sidebar.scss
+++ b/lms/static/sass/course/wiki/_sidebar.scss
@@ -27,7 +27,6 @@ div#wiki_panel {
 
     input[type="text"] {
       box-sizing: border-box;
-
       display: block;
       width: 100%;
       margin-bottom: lh(0.5);

--- a/lms/static/sass/course/wiki/_sidebar.scss
+++ b/lms/static/sass/course/wiki/_sidebar.scss
@@ -26,7 +26,7 @@ div#wiki_panel {
     }
 
     input[type="text"] {
-      @include box-sizing(border-box);
+      box-sizing: border-box;
 
       display: block;
       width: 100%;

--- a/lms/static/sass/course/wiki/_wiki.scss
+++ b/lms/static/sass/course/wiki/_wiki.scss
@@ -151,7 +151,7 @@
     padding: 40px 0 40px 40px;
     color: $body-color;
 
-    @include box-sizing(border-box);
+    box-sizing: border-box;
   }
 
   &.view .main-article {
@@ -239,7 +239,7 @@
     width: flex-grid(3);
     padding: 40px;
 
-    @include box-sizing(border-box);
+    box-sizing: border-box;
 
     .timestamp {
       margin-top: ($baseline*0.75);

--- a/lms/static/sass/course/wiki/_wiki.scss
+++ b/lms/static/sass/course/wiki/_wiki.scss
@@ -150,7 +150,6 @@
     width: flex-grid(9);
     padding: 40px 0 40px 40px;
     color: $body-color;
-
     box-sizing: border-box;
   }
 
@@ -238,7 +237,6 @@
     float: left;
     width: flex-grid(3);
     padding: 40px;
-
     box-sizing: border-box;
 
     .timestamp {

--- a/lms/static/sass/elements/_controls.scss
+++ b/lms/static/sass/elements/_controls.scss
@@ -2,7 +2,7 @@
 // ====================
 
 %btn {
-  @include box-sizing(border-box);
+  box-sizing: border-box;
   @include transition(color $tmg-f2 ease-in-out, background $tmg-f2 ease-in-out, box-shadow $tmg-f2 ease-in-out);
 
   display: inline-block;
@@ -336,7 +336,7 @@
 // imitating the pattern library
 // starts with overrides
 %btn-pl-default-base {
-  @include box-sizing(border-box);
+  box-sizing: border-box;
 
   @extend %t-copy-base;
 

--- a/lms/static/sass/elements/_controls.scss
+++ b/lms/static/sass/elements/_controls.scss
@@ -3,6 +3,7 @@
 
 %btn {
   box-sizing: border-box;
+
   @include transition(color $tmg-f2 ease-in-out, background $tmg-f2 ease-in-out, box-shadow $tmg-f2 ease-in-out);
 
   display: inline-block;

--- a/lms/static/sass/elements/_system-feedback.scss
+++ b/lms/static/sass/elements/_system-feedback.scss
@@ -207,7 +207,7 @@
 
 .message-status {
   @include border-top-radius(2px);
-  @include box-sizing(border-box);
+  box-sizing: border-box;
 
   @extend %t-strong;
 
@@ -247,7 +247,7 @@
 .wrapper-notification,
 .wrapper-alert,
 .prompt {
-  @include box-sizing(border-box);
+  box-sizing: border-box;
 
   .copy {
     @extend %t-copy-sub1;
@@ -544,7 +544,7 @@
     padding: ($baseline/2) $baseline;
 
     .notification {
-      @include box-sizing(border-box);
+      box-sizing: border-box;
       @include clearfix();
 
       width: 100%;
@@ -578,7 +578,7 @@
     padding: $baseline;
 
     .notification {
-      @include box-sizing(border-box);
+      box-sizing: border-box;
       @include clearfix();
 
       width: 100%;
@@ -602,7 +602,7 @@
 }
 
 .notification {
-  @include box-sizing(border-box);
+  box-sizing: border-box;
   @include clearfix();
 
   margin: 0 auto;
@@ -732,7 +732,7 @@
 .wrapper-alert {
   @extend %ui-depth2;
 
-  @include box-sizing(border-box);
+  box-sizing: border-box;
 
   box-shadow: 0 1px 1px $white, inset 0 2px 2px $shadow-d1, inset 0 -4px 1px $blue;
   position: relative;
@@ -793,7 +793,7 @@
 
 // adopted alerts
 .alert:not(.pattern-library-shim) {
-  @include box-sizing(border-box);
+  box-sizing: border-box;
   @include clearfix();
 
   margin: 0 auto;
@@ -1055,7 +1055,7 @@
 body.uxdesign.alerts {
   .content-primary,
   .content-supplementary {
-    @include box-sizing(border-box);
+    box-sizing: border-box;
 
     float: left;
   }

--- a/lms/static/sass/elements/_system-feedback.scss
+++ b/lms/static/sass/elements/_system-feedback.scss
@@ -207,6 +207,7 @@
 
 .message-status {
   @include border-top-radius(2px);
+
   box-sizing: border-box;
 
   @extend %t-strong;
@@ -545,6 +546,7 @@
 
     .notification {
       box-sizing: border-box;
+
       @include clearfix();
 
       width: 100%;
@@ -579,6 +581,7 @@
 
     .notification {
       box-sizing: border-box;
+
       @include clearfix();
 
       width: 100%;
@@ -603,6 +606,7 @@
 
 .notification {
   box-sizing: border-box;
+
   @include clearfix();
 
   margin: 0 auto;
@@ -733,7 +737,6 @@
   @extend %ui-depth2;
 
   box-sizing: border-box;
-
   box-shadow: 0 1px 1px $white, inset 0 2px 2px $shadow-d1, inset 0 -4px 1px $blue;
   position: relative;
   overflow: hidden;
@@ -794,6 +797,7 @@
 // adopted alerts
 .alert:not(.pattern-library-shim) {
   box-sizing: border-box;
+
   @include clearfix();
 
   margin: 0 auto;
@@ -1056,7 +1060,6 @@ body.uxdesign.alerts {
   .content-primary,
   .content-supplementary {
     box-sizing: border-box;
-
     float: left;
   }
 

--- a/lms/static/sass/features/_bookmarks-v1.scss
+++ b/lms/static/sass/features/_bookmarks-v1.scss
@@ -8,7 +8,6 @@ $bookmarked-icon: "\f02e"; // .fa-bookmark
 
   > div {
     box-sizing: border-box;
-
     display: inline-block;
   }
 }

--- a/lms/static/sass/features/_bookmarks-v1.scss
+++ b/lms/static/sass/features/_bookmarks-v1.scss
@@ -7,7 +7,7 @@ $bookmarked-icon: "\f02e"; // .fa-bookmark
   padding: ($baseline/4);
 
   > div {
-    @include box-sizing(border-box);
+    box-sizing: border-box;
 
     display: inline-block;
   }

--- a/lms/static/sass/features/_learner-profile.scss
+++ b/lms/static/sass/features/_learner-profile.scss
@@ -262,7 +262,7 @@
   .profile-self {
     .wrapper-profile-field-account-privacy {
       @include clearfix();
-      @include box-sizing(border-box);
+      box-sizing: border-box;
 
       width: 100%;
       margin: 0 auto;

--- a/lms/static/sass/features/_learner-profile.scss
+++ b/lms/static/sass/features/_learner-profile.scss
@@ -262,8 +262,8 @@
   .profile-self {
     .wrapper-profile-field-account-privacy {
       @include clearfix();
-      box-sizing: border-box;
 
+      box-sizing: border-box;
       width: 100%;
       margin: 0 auto;
       border-bottom: 1px solid $gray-l3;

--- a/lms/static/sass/multicourse/_about_pages.scss
+++ b/lms/static/sass/multicourse/_about_pages.scss
@@ -52,7 +52,7 @@
 
       .logo {
         @include border-right(1px solid rgb(200, 200, 200));
-        @include box-sizing(border-box);
+        box-sizing: border-box;
         @include float(left);
 
         height: 115px;
@@ -70,7 +70,7 @@
       }
 
       h2.mission-quote {
-        @include box-sizing(border-box);
+        box-sizing: border-box;
         @include float(right);
 
         font-style: italic;
@@ -107,7 +107,7 @@
       }
 
       .photo {
-        @include box-sizing(border-box);
+        box-sizing: border-box;
 
         background: rgb(255, 255, 255);
         border: 1px solid rgb(210, 210, 210);
@@ -123,7 +123,7 @@
       }
 
       > article {
-        @include box-sizing(border-box);
+        box-sizing: border-box;
         @include float(left);
         @include padding-left($baseline);
 
@@ -171,7 +171,7 @@
     nav.categories {
       border: 1px solid rgb(220, 220, 220);
 
-      @include box-sizing(border-box);
+      box-sizing: border-box;
       @include float(left);
       @include margin-left(flex-gutter());
 
@@ -245,7 +245,7 @@
         background: rgb(255, 255, 255);
         border: 1px solid rgb(120, 120, 120);
 
-        @include box-sizing(border-box);
+        box-sizing: border-box;
         @include float(left);
 
         height: 140px;
@@ -292,7 +292,7 @@
     margin: 0 auto;
 
     .photo {
-      @include box-sizing(border-box);
+      box-sizing: border-box;
 
       background: rgb(255, 255, 255);
       border: 1px solid rgb(210, 210, 210);
@@ -308,7 +308,7 @@
     }
 
     .contacts {
-      @include box-sizing(border-box);
+      box-sizing: border-box;
       @include float(left);
       @include padding-left(40px);
 

--- a/lms/static/sass/multicourse/_about_pages.scss
+++ b/lms/static/sass/multicourse/_about_pages.scss
@@ -52,7 +52,9 @@
 
       .logo {
         @include border-right(1px solid rgb(200, 200, 200));
+
         box-sizing: border-box;
+
         @include float(left);
 
         height: 115px;
@@ -71,6 +73,7 @@
 
       h2.mission-quote {
         box-sizing: border-box;
+
         @include float(right);
 
         font-style: italic;
@@ -108,7 +111,6 @@
 
       .photo {
         box-sizing: border-box;
-
         background: rgb(255, 255, 255);
         border: 1px solid rgb(210, 210, 210);
         margin-top: 37px;
@@ -124,6 +126,7 @@
 
       > article {
         box-sizing: border-box;
+
         @include float(left);
         @include padding-left($baseline);
 
@@ -170,8 +173,8 @@
 
     nav.categories {
       border: 1px solid rgb(220, 220, 220);
-
       box-sizing: border-box;
+
       @include float(left);
       @include margin-left(flex-gutter());
 
@@ -244,8 +247,8 @@
       .article-cover {
         background: rgb(255, 255, 255);
         border: 1px solid rgb(120, 120, 120);
-
         box-sizing: border-box;
+
         @include float(left);
 
         height: 140px;
@@ -293,7 +296,6 @@
 
     .photo {
       box-sizing: border-box;
-
       background: rgb(255, 255, 255);
       border: 1px solid rgb(210, 210, 210);
       padding: 1px;
@@ -309,6 +311,7 @@
 
     .contacts {
       box-sizing: border-box;
+
       @include float(left);
       @include padding-left(40px);
 

--- a/lms/static/sass/multicourse/_account.scss
+++ b/lms/static/sass/multicourse/_account.scss
@@ -109,7 +109,7 @@
 
   .container,
   .introduction {
-    @include box-sizing(border-box);
+    box-sizing: border-box;
     @include clearfix();
 
     margin: 0 auto;
@@ -231,7 +231,7 @@
   // basic layout
   .content,
   aside {
-    @include box-sizing(border-box);
+    box-sizing: border-box;
 
     margin: $baseline 0 0 0;
   }
@@ -625,7 +625,7 @@
 
   // forms - messages/status
   .status {
-    @include box-sizing(border-box);
+    box-sizing: border-box;
 
     margin: 0 0 $baseline 0;
     border-bottom: 3px solid shade($yellow, 10%);
@@ -813,7 +813,7 @@
 
     box-shadow: inset 0 -1px 2px 0 tint($red, 85%);
 
-    @include box-sizing(border-box);
+    box-sizing: border-box;
 
     margin: $baseline 0 ($baseline/2) 0 !important;
     padding: $baseline;

--- a/lms/static/sass/multicourse/_account.scss
+++ b/lms/static/sass/multicourse/_account.scss
@@ -110,6 +110,7 @@
   .container,
   .introduction {
     box-sizing: border-box;
+
     @include clearfix();
 
     margin: 0 auto;
@@ -232,7 +233,6 @@
   .content,
   aside {
     box-sizing: border-box;
-
     margin: $baseline 0 0 0;
   }
 
@@ -626,7 +626,6 @@
   // forms - messages/status
   .status {
     box-sizing: border-box;
-
     margin: 0 0 $baseline 0;
     border-bottom: 3px solid shade($yellow, 10%);
     padding: $baseline $baseline;
@@ -812,9 +811,7 @@
     @extend %body-text;
 
     box-shadow: inset 0 -1px 2px 0 tint($red, 85%);
-
     box-sizing: border-box;
-
     margin: $baseline 0 ($baseline/2) 0 !important;
     padding: $baseline;
     border: none;

--- a/lms/static/sass/multicourse/_course_about.scss
+++ b/lms/static/sass/multicourse/_course_about.scss
@@ -28,7 +28,7 @@
       border: 1px solid $border-color-3;
       box-shadow: 0 4px 25px 0 rgba(0, 0, 0, 0.5);
 
-      @include box-sizing(border-box);
+      box-sizing: border-box;
       @include clearfix();
 
       margin: 0 auto;
@@ -47,7 +47,7 @@
       }
 
       .intro {
-        @include box-sizing(border-box);
+        box-sizing: border-box;
         @include clearfix();
 
         display: table-cell;
@@ -125,7 +125,7 @@
           a.register,
           a.add-to-cart {
             @include button(shiny, $button-color);
-            @include box-sizing(border-box);
+            box-sizing: border-box;
 
             border-radius: 3px;
             display: block;
@@ -155,7 +155,7 @@
 
           strong {
             @include button(shiny, $button-color);
-            @include box-sizing(border-box);
+            box-sizing: border-box;
 
             border-radius: 3px;
             display: block;
@@ -179,7 +179,7 @@
             background: $button-archive-color;
             border: 1px solid darken($button-archive-color, 50%);
 
-            @include box-sizing(border-box);
+            box-sizing: border-box;
 
             color: darken($button-archive-color, 50%);
             display: block;
@@ -208,7 +208,7 @@
       .media {
         background: transparent;
 
-        @include box-sizing(border-box);
+        box-sizing: border-box;
 
         display: table-cell;
         padding: 20px;
@@ -411,7 +411,7 @@
 
   .course-sidebar {
     @include media-breakpoint-up(dm) {
-      @include box-sizing(border-box);
+      box-sizing: border-box;
       @include float(left);
 
       width: flex-grid(4);
@@ -498,7 +498,7 @@
       }
 
       .social-sharing {
-        @include box-sizing(border-box);
+        box-sizing: border-box;
         @include float(left);
 
         height: 44px;
@@ -524,7 +524,7 @@
           border-radius: 4px;
           box-shadow: 0 4px 25px 0 rgba(0, 0, 0, 0.5);
 
-          @include box-sizing(border-box);
+          box-sizing: border-box;
 
           color: rgb(255, 255, 255);
 

--- a/lms/static/sass/multicourse/_course_about.scss
+++ b/lms/static/sass/multicourse/_course_about.scss
@@ -27,8 +27,8 @@
       background: $course-header-bg;
       border: 1px solid $border-color-3;
       box-shadow: 0 4px 25px 0 rgba(0, 0, 0, 0.5);
-
       box-sizing: border-box;
+
       @include clearfix();
 
       margin: 0 auto;
@@ -48,6 +48,7 @@
 
       .intro {
         box-sizing: border-box;
+
         @include clearfix();
 
         display: table-cell;
@@ -125,8 +126,8 @@
           a.register,
           a.add-to-cart {
             @include button(shiny, $button-color);
-            box-sizing: border-box;
 
+            box-sizing: border-box;
             border-radius: 3px;
             display: block;
             font: normal 1.2rem/1.6rem $font-family-sans-serif;
@@ -155,8 +156,8 @@
 
           strong {
             @include button(shiny, $button-color);
-            box-sizing: border-box;
 
+            box-sizing: border-box;
             border-radius: 3px;
             display: block;
 
@@ -178,9 +179,7 @@
           span.add-to-cart {
             background: $button-archive-color;
             border: 1px solid darken($button-archive-color, 50%);
-
             box-sizing: border-box;
-
             color: darken($button-archive-color, 50%);
             display: block;
             letter-spacing: 1px;
@@ -207,9 +206,7 @@
 
       .media {
         background: transparent;
-
         box-sizing: border-box;
-
         display: table-cell;
         padding: 20px;
         position: relative;
@@ -412,6 +409,7 @@
   .course-sidebar {
     @include media-breakpoint-up(dm) {
       box-sizing: border-box;
+
       @include float(left);
 
       width: flex-grid(4);
@@ -499,6 +497,7 @@
 
       .social-sharing {
         box-sizing: border-box;
+
         @include float(left);
 
         height: 44px;
@@ -523,9 +522,7 @@
           border: 1px solid rgba(0, 0, 0, 0.5);
           border-radius: 4px;
           box-shadow: 0 4px 25px 0 rgba(0, 0, 0, 0.5);
-
           box-sizing: border-box;
-
           color: rgb(255, 255, 255);
 
           @include float(right);

--- a/lms/static/sass/multicourse/_courses.scss
+++ b/lms/static/sass/multicourse/_courses.scss
@@ -416,6 +416,7 @@ $facet-background-color: #007db8;
   .search-facets {
     @include fill-parent();
     @include omega();
+
     box-sizing: border-box;
 
     @extend %ui-depth1;
@@ -521,7 +522,9 @@ $facet-background-color: #007db8;
       .count {
         @include right($baseline*0.6);
         @include text-align(right);
+
         box-sizing: border-box;
+
         @include transition(all 0.2s ease-out);
 
         position: absolute;

--- a/lms/static/sass/multicourse/_courses.scss
+++ b/lms/static/sass/multicourse/_courses.scss
@@ -416,7 +416,7 @@ $facet-background-color: #007db8;
   .search-facets {
     @include fill-parent();
     @include omega();
-    @include box-sizing(border-box);
+    box-sizing: border-box;
 
     @extend %ui-depth1;
 
@@ -521,7 +521,7 @@ $facet-background-color: #007db8;
       .count {
         @include right($baseline*0.6);
         @include text-align(right);
-        @include box-sizing(border-box);
+        box-sizing: border-box;
         @include transition(all 0.2s ease-out);
 
         position: absolute;

--- a/lms/static/sass/multicourse/_dashboard.scss
+++ b/lms/static/sass/multicourse/_dashboard.scss
@@ -55,7 +55,7 @@
 
       // UI: individual course item
       .course {
-        @include box-sizing(box);
+        box-sizing: box;
         @include transition(all 0.15s linear 0s);
         @include clearfix();
 
@@ -73,7 +73,7 @@
             overflow: hidden;
 
             .cover {
-              @include box-sizing(border-box);
+              box-sizing: border-box;
               @include transition(all 0.15s linear 0s);
               @include float(left);
 
@@ -227,7 +227,7 @@
 
             // UI: course item actions
             .action {
-              @include box-sizing(border-box);
+              box-sizing: border-box;
               @include margin-right($baseline/2);
               @include float(right);
 
@@ -299,7 +299,7 @@
                 .actions-dropdown-list {
                   @extend %ui-no-list;
 
-                  @include box-sizing(border-box);
+                  box-sizing: border-box;
 
                   display: table;
                   box-shadow: 0 1px 1px $shadow-l1;
@@ -376,7 +376,7 @@
             width: flex-grid(8);
 
             @include float(left);
-            @include box-sizing(border-box);
+            box-sizing: border-box;
 
             p {
               color: $lighter-base-font-color;
@@ -892,7 +892,7 @@
           }
 
           .btn {
-            @include box-sizing(border-box);
+            box-sizing: border-box;
             @include float(left);
 
             border-radius: 3px;
@@ -1007,7 +1007,7 @@
           .action-certificate .btn {
             @extend %btn-inherited-primary;
 
-            @include box-sizing(border-box);
+            box-sizing: border-box;
 
             padding: 7px $baseline*0.75;
             float: none;
@@ -1158,7 +1158,7 @@
     border: 1px solid theme-color('primary');
     box-shadow: 0 1px 8px 0 $shadow-l1;
 
-    @include box-sizing(border-box);
+    box-sizing: border-box;
 
     color: $white;
     font-family: $font-family-sans-serif;
@@ -1391,7 +1391,7 @@ p.course-block {
 }
 
 .enter-course-blocked {
-  @include box-sizing(border-box);
+  box-sizing: border-box;
   @include float(right);
 
   display: block;

--- a/lms/static/sass/multicourse/_dashboard.scss
+++ b/lms/static/sass/multicourse/_dashboard.scss
@@ -56,6 +56,7 @@
       // UI: individual course item
       .course {
         box-sizing: box;
+
         @include transition(all 0.15s linear 0s);
         @include clearfix();
 
@@ -74,6 +75,7 @@
 
             .cover {
               box-sizing: border-box;
+
               @include transition(all 0.15s linear 0s);
               @include float(left);
 
@@ -228,6 +230,7 @@
             // UI: course item actions
             .action {
               box-sizing: border-box;
+
               @include margin-right($baseline/2);
               @include float(right);
 
@@ -300,7 +303,6 @@
                   @extend %ui-no-list;
 
                   box-sizing: border-box;
-
                   display: table;
                   box-shadow: 0 1px 1px $shadow-l1;
                   position: relative;
@@ -376,6 +378,7 @@
             width: flex-grid(8);
 
             @include float(left);
+
             box-sizing: border-box;
 
             p {
@@ -893,6 +896,7 @@
 
           .btn {
             box-sizing: border-box;
+
             @include float(left);
 
             border-radius: 3px;
@@ -1008,7 +1012,6 @@
             @extend %btn-inherited-primary;
 
             box-sizing: border-box;
-
             padding: 7px $baseline*0.75;
             float: none;
             border-radius: 3px;
@@ -1157,9 +1160,7 @@
     background-color: theme-color('primary');
     border: 1px solid theme-color('primary');
     box-shadow: 0 1px 8px 0 $shadow-l1;
-
     box-sizing: border-box;
-
     color: $white;
     font-family: $font-family-sans-serif;
     display: inline-block;
@@ -1392,6 +1393,7 @@ p.course-block {
 
 .enter-course-blocked {
   box-sizing: border-box;
+
   @include float(right);
 
   display: block;

--- a/lms/static/sass/multicourse/_help.scss
+++ b/lms/static/sass/multicourse/_help.scss
@@ -5,7 +5,7 @@
     nav.categories {
       border: 1px solid rgb(220, 220, 220);
 
-      @include box-sizing(border-box);
+      box-sizing: border-box;
       @include float(left);
       @include margin-left(flex-gutter());
 

--- a/lms/static/sass/multicourse/_help.scss
+++ b/lms/static/sass/multicourse/_help.scss
@@ -4,8 +4,8 @@
 
     nav.categories {
       border: 1px solid rgb(220, 220, 220);
-
       box-sizing: border-box;
+
       @include float(left);
       @include margin-left(flex-gutter());
 

--- a/lms/static/sass/multicourse/_home.scss
+++ b/lms/static/sass/multicourse/_home.scss
@@ -10,7 +10,6 @@ $course-search-input-height: ($button-size);
 
   > .container {
     box-sizing: border-box;
-
     width: flex-grid(12);
   }
 
@@ -43,7 +42,9 @@ $course-search-input-height: ($button-size);
     .title {
       @include span-columns(8);
       @include shift(2);
+
       box-sizing: border-box;
+
       @include transition(all 0.2s linear 0s);
 
       position: relative;
@@ -81,7 +82,9 @@ $course-search-input-height: ($button-size);
 
       > .heading-group {
         @include left(0);
+
         box-sizing: border-box;
+
         @include transition(all 0.2s linear 0s);
         @include text-align(left);
 
@@ -171,6 +174,7 @@ $course-search-input-height: ($button-size);
       border: 1px solid $border-color-3;
 
       @include border-left(0);
+
       box-sizing: border-box;
       // box-shadow: 0 4px 25px 0 rgba(0, 0, 0, 0.5);
       height: 120px;
@@ -200,9 +204,7 @@ $course-search-input-height: ($button-size);
 
           border-radius: 4px;
           box-shadow: 0 1px 12px 0 $shadow-d1;
-
           box-sizing: border-box;
-
           border: 2px solid rgba(255, 255, 255, 0.8);
           height: 60px;
 
@@ -261,7 +263,6 @@ $course-search-input-height: ($button-size);
 
   .highlighted-courses {
     box-sizing: border-box;
-
     margin-bottom: ($baseline*2);
     position: relative;
     width: flex-grid(12);
@@ -457,11 +458,11 @@ $course-search-input-height: ($button-size);
 
     &.university-partners2x6 {
       box-sizing: border-box;
-
       width: flex-grid(12, 12);
 
       .partners {
         box-sizing: border-box;
+
         @include clearfix();
         @include margin-left(60px);
 
@@ -469,7 +470,6 @@ $course-search-input-height: ($button-size);
 
         .partner {
           box-sizing: border-box;
-
           width: flex-grid(2, 12);
           display: block;
 
@@ -551,7 +551,6 @@ $course-search-input-height: ($button-size);
 
     .news {
       box-sizing: border-box;
-
       box-shadow: inset 0 0 3px 0 rgba(0, 0, 0, 0.15);
       padding: 20px;
       width: flex-grid(12);
@@ -566,8 +565,8 @@ $course-search-input-height: ($button-size);
         > article {
           border: 1px dotted transparent;
           border-color: $border-color-2;
-
           box-sizing: border-box;
+
           @include clearfix();
           @include float(left);
           @include margin-right(flex-gutter());
@@ -591,9 +590,7 @@ $course-search-input-height: ($button-size);
 
           .post-graphics {
             border: 1px solid $border-color-1;
-
             box-sizing: border-box;
-
             display: block;
 
             @include float(left);

--- a/lms/static/sass/multicourse/_home.scss
+++ b/lms/static/sass/multicourse/_home.scss
@@ -9,7 +9,7 @@ $course-search-input-height: ($button-size);
   padding: 0;
 
   > .container {
-    @include box-sizing(border-box);
+    box-sizing: border-box;
 
     width: flex-grid(12);
   }
@@ -43,7 +43,7 @@ $course-search-input-height: ($button-size);
     .title {
       @include span-columns(8);
       @include shift(2);
-      @include box-sizing(border-box);
+      box-sizing: border-box;
       @include transition(all 0.2s linear 0s);
 
       position: relative;
@@ -81,7 +81,7 @@ $course-search-input-height: ($button-size);
 
       > .heading-group {
         @include left(0);
-        @include box-sizing(border-box);
+        box-sizing: border-box;
         @include transition(all 0.2s linear 0s);
         @include text-align(left);
 
@@ -171,7 +171,7 @@ $course-search-input-height: ($button-size);
       border: 1px solid $border-color-3;
 
       @include border-left(0);
-      @include box-sizing(border-box);
+      box-sizing: border-box;
       // box-shadow: 0 4px 25px 0 rgba(0, 0, 0, 0.5);
       height: 120px;
 
@@ -201,7 +201,7 @@ $course-search-input-height: ($button-size);
           border-radius: 4px;
           box-shadow: 0 1px 12px 0 $shadow-d1;
 
-          @include box-sizing(border-box);
+          box-sizing: border-box;
 
           border: 2px solid rgba(255, 255, 255, 0.8);
           height: 60px;
@@ -260,7 +260,7 @@ $course-search-input-height: ($button-size);
   }
 
   .highlighted-courses {
-    @include box-sizing(border-box);
+    box-sizing: border-box;
 
     margin-bottom: ($baseline*2);
     position: relative;
@@ -456,19 +456,19 @@ $course-search-input-height: ($button-size);
     }
 
     &.university-partners2x6 {
-      @include box-sizing(border-box);
+      box-sizing: border-box;
 
       width: flex-grid(12, 12);
 
       .partners {
-        @include box-sizing(border-box);
+        box-sizing: border-box;
         @include clearfix();
         @include margin-left(60px);
 
         padding: 12px 0;
 
         .partner {
-          @include box-sizing(border-box);
+          box-sizing: border-box;
 
           width: flex-grid(2, 12);
           display: block;
@@ -550,7 +550,7 @@ $course-search-input-height: ($button-size);
     }
 
     .news {
-      @include box-sizing(border-box);
+      box-sizing: border-box;
 
       box-shadow: inset 0 0 3px 0 rgba(0, 0, 0, 0.15);
       padding: 20px;
@@ -567,7 +567,7 @@ $course-search-input-height: ($button-size);
           border: 1px dotted transparent;
           border-color: $border-color-2;
 
-          @include box-sizing(border-box);
+          box-sizing: border-box;
           @include clearfix();
           @include float(left);
           @include margin-right(flex-gutter());
@@ -592,7 +592,7 @@ $course-search-input-height: ($button-size);
           .post-graphics {
             border: 1px solid $border-color-1;
 
-            @include box-sizing(border-box);
+            box-sizing: border-box;
 
             display: block;
 

--- a/lms/static/sass/multicourse/_jobs.scss
+++ b/lms/static/sass/multicourse/_jobs.scss
@@ -89,7 +89,7 @@
     }
 
     .jobs-sidebar {
-      @include box-sizing(border-box);
+      box-sizing: border-box;
 
       border: 1px solid rgb(220, 220, 220);
 

--- a/lms/static/sass/multicourse/_jobs.scss
+++ b/lms/static/sass/multicourse/_jobs.scss
@@ -90,7 +90,6 @@
 
     .jobs-sidebar {
       box-sizing: border-box;
-
       border: 1px solid rgb(220, 220, 220);
 
       @include float(left);

--- a/lms/static/sass/multicourse/_media-kit.scss
+++ b/lms/static/sass/multicourse/_media-kit.scss
@@ -4,16 +4,13 @@ $white: rgb(255, 255, 255);
 
 .mediakit {
   box-sizing: border-box;
-
   margin: 0 auto;
   padding: ($baseline*3) 0;
   width: 980px;
 
   .wrapper-mediakit {
     border-radius: 4px;
-
     box-sizing: border-box;
-
     box-shadow: 0 1px 10px 0 $shadow-l1;
     margin: ($baseline*3) 0 0 0;
     border: 1px solid $border-color;
@@ -112,7 +109,6 @@ $white: rgb(255, 255, 255);
 
     article {
       box-sizing: border-box;
-
       width: 500px;
 
       @include margin-right($baseline);
@@ -121,9 +117,7 @@ $white: rgb(255, 255, 255);
 
     aside {
       border-radius: 2px;
-
       box-sizing: border-box;
-
       box-shadow: 0 1px 4px 0 $shadow;
       width: 330px;
 
@@ -157,7 +151,6 @@ $white: rgb(255, 255, 255);
 
       figure {
         box-sizing: border-box;
-
         background: $white;
         width: 100%;
 
@@ -182,9 +175,7 @@ $white: rgb(255, 255, 255);
   // library section
   .library {
     border-radius: 2px;
-
     box-sizing: border-box;
-
     box-shadow: 0 1px 4px 0 $shadow;
     border: 3px solid tint($light-gray, 50%);
     padding: 0;
@@ -220,7 +211,6 @@ $white: rgb(255, 255, 255);
 
       li {
         box-sizing: border-box;
-
         overflow-y: auto;
 
         @include float(left);
@@ -237,9 +227,7 @@ $white: rgb(255, 255, 255);
       figure {
         a {
           border-radius: 2px;
-
           box-sizing: border-box;
-
           box-shadow: 0 1px 2px 0 $shadow-l1;
           display: block;
           min-height: 380px;

--- a/lms/static/sass/multicourse/_media-kit.scss
+++ b/lms/static/sass/multicourse/_media-kit.scss
@@ -3,7 +3,7 @@ $baseline: 20px;
 $white: rgb(255, 255, 255);
 
 .mediakit {
-  @include box-sizing(border-box);
+  box-sizing: border-box;
 
   margin: 0 auto;
   padding: ($baseline*3) 0;
@@ -12,7 +12,7 @@ $white: rgb(255, 255, 255);
   .wrapper-mediakit {
     border-radius: 4px;
 
-    @include box-sizing(border-box);
+    box-sizing: border-box;
 
     box-shadow: 0 1px 10px 0 $shadow-l1;
     margin: ($baseline*3) 0 0 0;
@@ -111,7 +111,7 @@ $white: rgb(255, 255, 255);
     }
 
     article {
-      @include box-sizing(border-box);
+      box-sizing: border-box;
 
       width: 500px;
 
@@ -122,7 +122,7 @@ $white: rgb(255, 255, 255);
     aside {
       border-radius: 2px;
 
-      @include box-sizing(border-box);
+      box-sizing: border-box;
 
       box-shadow: 0 1px 4px 0 $shadow;
       width: 330px;
@@ -156,7 +156,7 @@ $white: rgb(255, 255, 255);
       }
 
       figure {
-        @include box-sizing(border-box);
+        box-sizing: border-box;
 
         background: $white;
         width: 100%;
@@ -183,7 +183,7 @@ $white: rgb(255, 255, 255);
   .library {
     border-radius: 2px;
 
-    @include box-sizing(border-box);
+    box-sizing: border-box;
 
     box-shadow: 0 1px 4px 0 $shadow;
     border: 3px solid tint($light-gray, 50%);
@@ -219,7 +219,7 @@ $white: rgb(255, 255, 255);
       list-style: none;
 
       li {
-        @include box-sizing(border-box);
+        box-sizing: border-box;
 
         overflow-y: auto;
 
@@ -238,7 +238,7 @@ $white: rgb(255, 255, 255);
         a {
           border-radius: 2px;
 
-          @include box-sizing(border-box);
+          box-sizing: border-box;
 
           box-shadow: 0 1px 2px 0 $shadow-l1;
           display: block;

--- a/lms/static/sass/multicourse/_press_release.scss
+++ b/lms/static/sass/multicourse/_press_release.scss
@@ -37,7 +37,7 @@
       border: 1px solid rgb(220, 220, 220);
       border-radius: 10px;
 
-      @include box-sizing(border-box);
+      box-sizing: border-box;
 
       box-shadow: 0 2px 16px 0 $shadow-l1;
       margin: 0 auto;

--- a/lms/static/sass/multicourse/_press_release.scss
+++ b/lms/static/sass/multicourse/_press_release.scss
@@ -36,9 +36,7 @@
     > article {
       border: 1px solid rgb(220, 220, 220);
       border-radius: 10px;
-
       box-sizing: border-box;
-
       box-shadow: 0 2px 16px 0 $shadow-l1;
       margin: 0 auto;
       padding: 80px 80px 40px;

--- a/lms/static/sass/search/_search.scss
+++ b/lms/static/sass/search/_search.scss
@@ -1,5 +1,5 @@
 .search-bar {
-  @include box-sizing(border-box);
+  box-sizing: border-box;
 
   position: relative;
 
@@ -10,7 +10,7 @@
   .search-field {
     @extend %t-weight2;
 
-    @include box-sizing(border-box);
+    box-sizing: border-box;
 
     top: 5px;
     width: 100%;
@@ -24,7 +24,7 @@
   .cancel-button:hover {
     @extend %t-regular;
 
-    @include box-sizing(border-box);
+    box-sizing: border-box;
     @include right(0);
 
     display: block;

--- a/lms/static/sass/search/_search.scss
+++ b/lms/static/sass/search/_search.scss
@@ -1,6 +1,5 @@
 .search-bar {
   box-sizing: border-box;
-
   position: relative;
 
   .search-field-wrapper {
@@ -11,7 +10,6 @@
     @extend %t-weight2;
 
     box-sizing: border-box;
-
     top: 5px;
     width: 100%;
     border-radius: 4px;
@@ -25,6 +23,7 @@
     @extend %t-regular;
 
     box-sizing: border-box;
+
     @include right(0);
 
     display: block;

--- a/lms/static/sass/shared-v2/_components.scss
+++ b/lms/static/sass/shared-v2/_components.scss
@@ -145,7 +145,7 @@
 
 .wrapper-preview-menu {
   @include clearfix();
-  @include box-sizing(border-box);
+  box-sizing: border-box;
 
   margin: 0 auto;
   padding: ($baseline*0.75) 20px;

--- a/lms/static/sass/shared-v2/_components.scss
+++ b/lms/static/sass/shared-v2/_components.scss
@@ -145,8 +145,8 @@
 
 .wrapper-preview-menu {
   @include clearfix();
-  box-sizing: border-box;
 
+  box-sizing: border-box;
   margin: 0 auto;
   padding: ($baseline*0.75) 20px;
   background-color: theme-color("primary");

--- a/lms/static/sass/shared/_course_filter.scss
+++ b/lms/static/sass/shared/_course_filter.scss
@@ -6,7 +6,7 @@
 
     box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.4), inset 0 0 0 -1px rgba(255, 255, 255, 0.4);
 
-    @include box-sizing(border-box);
+    box-sizing: border-box;
 
     border: 1px solid rgb(190, 190, 190);
     border-bottom-color: rgb(200, 200, 200);
@@ -38,7 +38,7 @@
 
         border-radius: 4px;
 
-        @include box-sizing(border-box);
+        box-sizing: border-box;
 
         box-shadow: 0 1px 0 0 rgba(255, 255, 255, 0.4), inset 0 1px 0 0 rgba(255, 255, 255, 0.6);
         border: 1px solid rgb(200, 200, 200);

--- a/lms/static/sass/shared/_course_filter.scss
+++ b/lms/static/sass/shared/_course_filter.scss
@@ -5,9 +5,7 @@
     @include background-image(linear-gradient(-90deg, rgb(250, 250, 250), rgb(230, 230, 230)));
 
     box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.4), inset 0 0 0 -1px rgba(255, 255, 255, 0.4);
-
     box-sizing: border-box;
-
     border: 1px solid rgb(190, 190, 190);
     border-bottom-color: rgb(200, 200, 200);
     border-top: none;
@@ -37,9 +35,7 @@
         @include background-image(linear-gradient(-90deg, rgb(250,250,250) 0%, rgb(245,245,245) 50%, rgb(235,235,235) 50%, rgb(230,230,230) 100%));
 
         border-radius: 4px;
-
         box-sizing: border-box;
-
         box-shadow: 0 1px 0 0 rgba(255, 255, 255, 0.4), inset 0 1px 0 0 rgba(255, 255, 255, 0.6);
         border: 1px solid rgb(200, 200, 200);
         color: $body-color;

--- a/lms/static/sass/shared/_course_object.scss
+++ b/lms/static/sass/shared/_course_object.scss
@@ -22,7 +22,7 @@
       border: 1px solid $border-color-1;
       border-radius: 2px;
 
-      @include box-sizing(border-box);
+      box-sizing: border-box;
 
       box-shadow: 0 1px 10px 0 rgba(0, 0, 0, 0.15), inset 0 0 0 1px rgba(255, 255, 255, 0.9);
       margin-bottom: ($baseline*1.5);
@@ -160,7 +160,7 @@
         .info-link {
           border-left: 1px solid rgba(150, 150, 150, 0.5);
 
-          @include box-sizing(border-box);
+          box-sizing: border-box;
 
           color: $body-color;
           display: inline-block;
@@ -203,7 +203,7 @@
         }
 
         .desc {
-          @include box-sizing(border-box);
+          box-sizing: border-box;
 
           height: 120px;
           overflow: hidden;
@@ -222,7 +222,7 @@
         }
 
         .bottom {
-          @include box-sizing(border-box);
+          box-sizing: border-box;
 
           padding: 0 10px 10px;
           width: 100%;

--- a/lms/static/sass/shared/_course_object.scss
+++ b/lms/static/sass/shared/_course_object.scss
@@ -21,9 +21,7 @@
       background: $body-bg;
       border: 1px solid $border-color-1;
       border-radius: 2px;
-
       box-sizing: border-box;
-
       box-shadow: 0 1px 10px 0 rgba(0, 0, 0, 0.15), inset 0 0 0 1px rgba(255, 255, 255, 0.9);
       margin-bottom: ($baseline*1.5);
       position: relative;
@@ -159,9 +157,7 @@
 
         .info-link {
           border-left: 1px solid rgba(150, 150, 150, 0.5);
-
           box-sizing: border-box;
-
           color: $body-color;
           display: inline-block;
           font: bold 1.6em/1.2em $font-family-sans-serif;
@@ -204,7 +200,6 @@
 
         .desc {
           box-sizing: border-box;
-
           height: 120px;
           overflow: hidden;
           padding: 10px 10px 12px;
@@ -223,7 +218,6 @@
 
         .bottom {
           box-sizing: border-box;
-
           padding: 0 10px 10px;
           width: 100%;
 

--- a/lms/static/sass/shared/_footer-edx.scss
+++ b/lms/static/sass/shared/_footer-edx.scss
@@ -167,6 +167,7 @@ footer#footer-edx-v3 {
 
   .footer-content-wrapper {
     @include outer-container;
+
     box-sizing: border-box;
   }
 

--- a/lms/static/sass/shared/_footer-edx.scss
+++ b/lms/static/sass/shared/_footer-edx.scss
@@ -167,7 +167,7 @@ footer#footer-edx-v3 {
 
   .footer-content-wrapper {
     @include outer-container;
-    @include box-sizing(border-box);
+    box-sizing: border-box;
   }
 
   p {

--- a/lms/static/sass/shared/_footer.scss
+++ b/lms/static/sass/shared/_footer.scss
@@ -14,7 +14,9 @@
 
   footer#footer-openedx {
     @include clearfix();
+
     box-sizing: border-box;
+
     @include outer-container;
 
     margin: 0 auto;

--- a/lms/static/sass/shared/_footer.scss
+++ b/lms/static/sass/shared/_footer.scss
@@ -14,7 +14,7 @@
 
   footer#footer-openedx {
     @include clearfix();
-    @include box-sizing(border-box);
+    box-sizing: border-box;
     @include outer-container;
 
     margin: 0 auto;

--- a/lms/static/sass/shared/_forms.scss
+++ b/lms/static/sass/shared/_forms.scss
@@ -34,7 +34,7 @@ input[type="tel"] {
   border-radius: 3px;
   box-shadow: 0 1px 0 0 rgba(255, 255, 255, 0.6), inset 0 0 3px 0 $shadow-l1;
 
-  @include box-sizing(border-box);
+  box-sizing: border-box;
 
   font: italic 300 1rem/1.6rem $serif;
   height: 35px;

--- a/lms/static/sass/shared/_forms.scss
+++ b/lms/static/sass/shared/_forms.scss
@@ -33,9 +33,7 @@ input[type="tel"] {
   border: 1px solid $border-color-2;
   border-radius: 3px;
   box-shadow: 0 1px 0 0 rgba(255, 255, 255, 0.6), inset 0 0 3px 0 $shadow-l1;
-
   box-sizing: border-box;
-
   font: italic 300 1rem/1.6rem $serif;
   height: 35px;
   padding: ($baseline/4) 12px;

--- a/lms/static/sass/shared/_header.scss
+++ b/lms/static/sass/shared/_header.scss
@@ -95,9 +95,7 @@
       @include background-image($button-bg-image);
 
       background-color: $button-bg-color;
-
       box-sizing: border-box;
-
       box-shadow: 0 1px 0 0 rgba(255, 255, 255, 0.6);
       color: $body-color;
       display: inline-block;
@@ -264,9 +262,7 @@
         > a {
           border: 1px solid transparent;
           border-radius: 3px;
-
           box-sizing: border-box;
-
           color: $link-color;
           cursor: pointer;
           display: block;
@@ -402,7 +398,6 @@
 
   /* Temp. fix until applied globally */
   box-sizing: border-box;
-
   position: relative;
   width: 100%;
   border-bottom: 1px solid $gray-l1;
@@ -411,8 +406,8 @@
 
   .wrapper-header {
     @include clearfix();
-    box-sizing: border-box;
 
+    box-sizing: border-box;
     height: 74px;
     margin: 0 auto;
     padding: 17px 0;
@@ -519,9 +514,7 @@
       @include background-image($button-bg-image);
 
       background-color: $button-bg-color;
-
       box-sizing: border-box;
-
       box-shadow: 0 1px 0 0 rgba(255, 255, 255, 0.6);
       color: $body-color;
       font-family: $header-sans-serif;
@@ -679,9 +672,7 @@
         > a {
           border: 1px solid transparent;
           border-radius: 3px;
-
           box-sizing: border-box;
-
           color: $link-color;
           cursor: pointer;
           display: block;

--- a/lms/static/sass/shared/_header.scss
+++ b/lms/static/sass/shared/_header.scss
@@ -96,7 +96,7 @@
 
       background-color: $button-bg-color;
 
-      @include box-sizing(border-box);
+      box-sizing: border-box;
 
       box-shadow: 0 1px 0 0 rgba(255, 255, 255, 0.6);
       color: $body-color;
@@ -265,7 +265,7 @@
           border: 1px solid transparent;
           border-radius: 3px;
 
-          @include box-sizing(border-box);
+          box-sizing: border-box;
 
           color: $link-color;
           cursor: pointer;
@@ -401,7 +401,7 @@
   @extend %ui-depth1;
 
   /* Temp. fix until applied globally */
-  @include box-sizing(border-box);
+  box-sizing: border-box;
 
   position: relative;
   width: 100%;
@@ -411,7 +411,7 @@
 
   .wrapper-header {
     @include clearfix();
-    @include box-sizing(border-box);
+    box-sizing: border-box;
 
     height: 74px;
     margin: 0 auto;
@@ -520,7 +520,7 @@
 
       background-color: $button-bg-color;
 
-      @include box-sizing(border-box);
+      box-sizing: border-box;
 
       box-shadow: 0 1px 0 0 rgba(255, 255, 255, 0.6);
       color: $body-color;
@@ -680,7 +680,7 @@
           border: 1px solid transparent;
           border-radius: 3px;
 
-          @include box-sizing(border-box);
+          box-sizing: border-box;
 
           color: $link-color;
           cursor: pointer;

--- a/lms/static/sass/views/_homepage.scss
+++ b/lms/static/sass/views/_homepage.scss
@@ -23,7 +23,7 @@ $learn-more-horizontal-position: calc(50% - 100px); // calculate the left positi
     }
 
     .course {
-      @include box-sizing(border-box);
+      box-sizing: border-box;
       @include transition(all $tmg-f3 linear 0s);
 
       position: relative;
@@ -58,7 +58,7 @@ $learn-more-horizontal-position: calc(50% - 100px); // calculate the left positi
 
         .learn-more {
           @include left($learn-more-horizontal-position);
-          @include box-sizing(border-box);
+          box-sizing: border-box;
 
           @extend %ui-depth2;
 

--- a/lms/static/sass/views/_homepage.scss
+++ b/lms/static/sass/views/_homepage.scss
@@ -24,6 +24,7 @@ $learn-more-horizontal-position: calc(50% - 100px); // calculate the left positi
 
     .course {
       box-sizing: border-box;
+
       @include transition(all $tmg-f3 linear 0s);
 
       position: relative;
@@ -58,6 +59,7 @@ $learn-more-horizontal-position: calc(50% - 100px); // calculate the left positi
 
         .learn-more {
           @include left($learn-more-horizontal-position);
+
           box-sizing: border-box;
 
           @extend %ui-depth2;

--- a/lms/static/sass/views/_login-register.scss
+++ b/lms/static/sass/views/_login-register.scss
@@ -56,7 +56,7 @@
 }
 
 .login-register-content {
-  @include box-sizing(border-box);
+  box-sizing: border-box;
   @include outer-container;
 
   width: 100%;
@@ -116,7 +116,7 @@
 
   /* Temp. fix until applied globally */
   > {
-    @include box-sizing(border-box);
+    box-sizing: border-box;
   }
 
 
@@ -141,7 +141,7 @@
     overflow: hidden;
 
     .headline {
-      @include box-sizing(border-box);
+      box-sizing: border-box;
       @include font-size(35);
 
       padding: 0 10px;
@@ -153,7 +153,7 @@
     }
 
     .tagline {
-      @include box-sizing(border-box);
+      box-sizing: border-box;
       @include font-size(24);
 
       padding: 0 10px;
@@ -215,7 +215,7 @@
 
   .form-type,
   .toggle-form {
-    @include box-sizing(border-box);
+    box-sizing: border-box;
 
     max-width: 600px;
     min-width: 250px;
@@ -652,7 +652,7 @@
 
   /** Error Container - from _account.scss **/
   .status {
-    @include box-sizing(border-box);
+    box-sizing: border-box;
 
     margin: 0 0 25px;
     border-bottom: 3px solid shade($yellow, 10%);
@@ -746,7 +746,7 @@
 }
 
 .finish-auth {
-  @include box-sizing(border-box);
+  box-sizing: border-box;
   @include outer-container;
   $grid-columns: 12;
 
@@ -755,7 +755,7 @@
   width: 100%;
 
   .finish-auth-inner {
-    @include box-sizing(border-box);
+    box-sizing: border-box;
 
     max-width: 650px;
     margin: 1em auto;

--- a/lms/static/sass/views/_login-register.scss
+++ b/lms/static/sass/views/_login-register.scss
@@ -57,6 +57,7 @@
 
 .login-register-content {
   box-sizing: border-box;
+
   @include outer-container;
 
   width: 100%;
@@ -142,6 +143,7 @@
 
     .headline {
       box-sizing: border-box;
+
       @include font-size(35);
 
       padding: 0 10px;
@@ -154,6 +156,7 @@
 
     .tagline {
       box-sizing: border-box;
+
       @include font-size(24);
 
       padding: 0 10px;
@@ -216,7 +219,6 @@
   .form-type,
   .toggle-form {
     box-sizing: border-box;
-
     max-width: 600px;
     min-width: 250px;
     margin: 0 auto;
@@ -653,7 +655,6 @@
   /** Error Container - from _account.scss **/
   .status {
     box-sizing: border-box;
-
     margin: 0 0 25px;
     border-bottom: 3px solid shade($yellow, 10%);
     padding: 25px;
@@ -747,6 +748,7 @@
 
 .finish-auth {
   box-sizing: border-box;
+
   @include outer-container;
   $grid-columns: 12;
 
@@ -756,7 +758,6 @@
 
   .finish-auth-inner {
     box-sizing: border-box;
-
     max-width: 650px;
     margin: 1em auto;
   }

--- a/lms/static/sass/views/_text-me-the-app.scss
+++ b/lms/static/sass/views/_text-me-the-app.scss
@@ -1,5 +1,6 @@
 .text-me-content {
   box-sizing: border-box;
+
   @include outer-container;
 
   width: 100%;

--- a/lms/static/sass/views/_text-me-the-app.scss
+++ b/lms/static/sass/views/_text-me-the-app.scss
@@ -1,5 +1,5 @@
 .text-me-content {
-  @include box-sizing(border-box);
+  box-sizing: border-box;
   @include outer-container;
 
   width: 100%;

--- a/lms/static/sass/views/_verification.scss
+++ b/lms/static/sass/views/_verification.scss
@@ -54,7 +54,7 @@
 
   // reset: box-sizing (making things so right its scary)
   * {
-    @include box-sizing(border-box);
+    box-sizing: border-box;
   }
 
   // reset: typography
@@ -1374,7 +1374,7 @@
   }
 
   .content-supplementary {
-    @include box-sizing(border-box);
+    box-sizing: border-box;
     @include outer-container;
     @include span-columns(12);
 

--- a/lms/static/sass/views/_verification.scss
+++ b/lms/static/sass/views/_verification.scss
@@ -1375,6 +1375,7 @@
 
   .content-supplementary {
     box-sizing: border-box;
+
     @include outer-container;
     @include span-columns(12);
 


### PR DESCRIPTION
Fixes all the warnings when building assets.

<img width="860" alt="Screen Shot 2020-05-06 at 4 18 35 PM" src="https://user-images.githubusercontent.com/1615421/81224156-43f1e400-8fb5-11ea-8456-90bb51424cfa.png">
