### PR TITLE
Fix RemovedInDjango30Warning: cookie_date() is deprecated in favor of http_date(), which follows the format of the latest RFC

### DIFF
--- a/openedx/core/djangoapps/user_authn/cookies.py
+++ b/openedx/core/djangoapps/user_authn/cookies.py
@@ -12,7 +12,7 @@ from django.conf import settings
 from django.contrib.auth.models import User
 from django.dispatch import Signal
 from django.urls import NoReverseMatch, reverse
-from django.utils.http import cookie_date
+from django.utils.http import http_date
 from edx_rest_framework_extensions.auth.jwt import cookies as jwt_cookies
 from edx_rest_framework_extensions.auth.jwt.constants import JWT_DELIMITER
 from oauth2_provider.models import Application
@@ -113,7 +113,7 @@ def _set_expires_in_cookie_settings(cookie_settings, expires_in):
     based on the value of expires_in.
     """
     expires_time = time.time() + expires_in
-    expires = cookie_date(expires_time)
+    expires = http_date(expires_time)
 
     cookie_settings.update({
         'max_age': expires_in,


### PR DESCRIPTION
I wanted to make a **byte-sized contribution** but there were no Jira tickets so we decided, thanks to a conversation with @jmbowman through the Open Edx Community #incr (Slack) channel, to collaborate in the elimination of warnings listed in [**Warnings Report**](https://build.testeng.edx.org/job/edx-platform-python-pipeline-master/warning_5freport_5fall_2ehtml/)

This PR contributes to the elimination of RemovedInDjango30Warnings, specifically the one mentioned above and reported in the **Warnings Report**

Changed cookie_date to http_date in the following file:

- openedx/core/djangoapps/user_authn/cookies.py

This warning occurs due to deprecation since Django 2.1: [cookie_date](https://docs.djangoproject.com/en/2.2/ref/utils/#django.utils.http.cookie_date)

@felipemontoya 
@morenol 