### PR TITLE
Enable access role in django admin

### DIFF
--- a/common/djangoapps/student/roles.py
+++ b/common/djangoapps/student/roles.py
@@ -312,6 +312,7 @@ class CourseCcxCoachRole(CourseRole):
         super(CourseCcxCoachRole, self).__init__(self.ROLE, *args, **kwargs)
 
 
+@register_access_role
 class CourseDataResearcherRole(CourseRole):
     """A Data Researcher"""
     ROLE = 'data_researcher'


### PR DESCRIPTION
The `data_researcher` role wasn't showing up in django admin.