### PR TITLE
constrain ddt<1.4.0

### DIFF
--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -13,6 +13,9 @@
 # (although it is advertised in the changelog as 3.1.26.)
 celery>=3.1.25,<4.0.0
 
+# Constrain until https://github.com/datadriventests/ddt/issues/83 is fixed.
+ddt<1.4.0
+
 # Stay on the latest LTS release of Django
 Django<2.3
 


### PR DESCRIPTION
Constrain ddt<1.4.0 until this issue is fixed:
- https://github.com/datadriventests/ddt/issues/83