### PR TITLE
EDUCATOR-5043: remove grades from program progress page

### DIFF
--- a/lms/static/js/learner_dashboard/models/course_card_model.js
+++ b/lms/static/js/learner_dashboard/models/course_card_model.js
@@ -38,24 +38,6 @@ class CourseCardModel extends Backbone.Model {
     return desiredCourseRun;
   }
 
-//   EDUCATOR-5043
-//   getCourseRunWithHighestGrade(grades) {
-//     const allEnrolledCourseRuns = this.context.course_runs.filter(run => run.is_enrolled);
-//     if (allEnrolledCourseRuns.length <= 1) {
-//       return null;
-//     }
-
-//     allEnrolledCourseRuns.sort((a, b) => (grades[a.key] || 0) - (grades[b.key] || 0));
-//     return allEnrolledCourseRuns[allEnrolledCourseRuns.length - 1];
-//   }
-
-//   updateCourseRunWithHighestGrade(grades) {
-//     const courseRunWithHighestGrade = this.getCourseRunWithHighestGrade(grades);
-//     if (courseRunWithHighestGrade) {
-//       this.setActiveCourseRun(courseRunWithHighestGrade, this.context.user_preferences);
-//     }
-//   }
-
   isEnrolledInSession() {
     // Returns true if the user is currently enrolled in a session of the course
     return this.context.course_runs.find(run => run.is_enrolled) !== undefined;

--- a/lms/static/js/learner_dashboard/models/course_card_model.js
+++ b/lms/static/js/learner_dashboard/models/course_card_model.js
@@ -38,22 +38,23 @@ class CourseCardModel extends Backbone.Model {
     return desiredCourseRun;
   }
 
-  getCourseRunWithHighestGrade(grades) {
-    const allEnrolledCourseRuns = this.context.course_runs.filter(run => run.is_enrolled);
-    if (allEnrolledCourseRuns.length <= 1) {
-      return null;
-    }
+//   EDUCATOR-5043
+//   getCourseRunWithHighestGrade(grades) {
+//     const allEnrolledCourseRuns = this.context.course_runs.filter(run => run.is_enrolled);
+//     if (allEnrolledCourseRuns.length <= 1) {
+//       return null;
+//     }
 
-    allEnrolledCourseRuns.sort((a, b) => (grades[a.key] || 0) - (grades[b.key] || 0));
-    return allEnrolledCourseRuns[allEnrolledCourseRuns.length - 1];
-  }
+//     allEnrolledCourseRuns.sort((a, b) => (grades[a.key] || 0) - (grades[b.key] || 0));
+//     return allEnrolledCourseRuns[allEnrolledCourseRuns.length - 1];
+//   }
 
-  updateCourseRunWithHighestGrade(grades) {
-    const courseRunWithHighestGrade = this.getCourseRunWithHighestGrade(grades);
-    if (courseRunWithHighestGrade) {
-      this.setActiveCourseRun(courseRunWithHighestGrade, this.context.user_preferences);
-    }
-  }
+//   updateCourseRunWithHighestGrade(grades) {
+//     const courseRunWithHighestGrade = this.getCourseRunWithHighestGrade(grades);
+//     if (courseRunWithHighestGrade) {
+//       this.setActiveCourseRun(courseRunWithHighestGrade, this.context.user_preferences);
+//     }
+//   }
 
   isEnrolledInSession() {
     // Returns true if the user is currently enrolled in a session of the course

--- a/lms/static/js/learner_dashboard/spec/course_card_view_spec.js
+++ b/lms/static/js/learner_dashboard/spec/course_card_view_spec.js
@@ -14,9 +14,9 @@ describe('Course Card View', () => {
     const programData = $.extend({}, data);
     const context = {
       courseData: {
-        grades: {
-          'course-v1:WageningenX+FFESx+1T2017': 0.8,
-        },
+        // grades: {
+        //   'course-v1:WageningenX+FFESx+1T2017': 0.8,
+        // },
       },
       collectionCourseStatus,
     };
@@ -88,10 +88,10 @@ describe('Course Card View', () => {
     expect(view).toBeDefined();
   });
 
-  it('should render final grade if course is completed', () => {
+  it('should not render final grade even if course has been completed', () => {
     view.remove();
     setupView(course, true);
-    expect(view.$('.grade-display').text()).toEqual('80%');
+    expect(view.$('.final-grade').length).toEqual(0);
   });
 
   it('should not render final grade if course has not been completed', () => {

--- a/lms/static/js/learner_dashboard/spec/course_card_view_spec.js
+++ b/lms/static/js/learner_dashboard/spec/course_card_view_spec.js
@@ -13,11 +13,7 @@ describe('Course Card View', () => {
   const setupView = (data, isEnrolled, collectionCourseStatus) => {
     const programData = $.extend({}, data);
     const context = {
-      courseData: {
-        // grades: {
-        //   'course-v1:WageningenX+FFESx+1T2017': 0.8,
-        // },
-      },
+      courseData: {},
       collectionCourseStatus,
     };
 
@@ -86,18 +82,6 @@ describe('Course Card View', () => {
 
   it('should exist', () => {
     expect(view).toBeDefined();
-  });
-
-  it('should not render final grade even if course has been completed', () => {
-    view.remove();
-    setupView(course, true);
-    expect(view.$('.final-grade').length).toEqual(0);
-  });
-
-  it('should not render final grade if course has not been completed', () => {
-    view.remove();
-    setupView(course, true, 'in_progress');
-    expect(view.$('.final-grade').length).toEqual(0);
   });
 
   it('should render the course card based on the data not enrolled', () => {

--- a/lms/static/js/learner_dashboard/spec/program_details_view_spec.js
+++ b/lms/static/js/learner_dashboard/spec/program_details_view_spec.js
@@ -461,9 +461,9 @@ describe('Program Details Header View', () => {
           ],
         },
       ],
-      grades: {
-        'course-v1:Testx+DOGx002+1T2016': 0.9,
-      },
+    //   grades: {
+    //     'course-v1:Testx+DOGx002+1T2016': 0.9,
+    //   },
     },
     urls: {
       program_listing_url: '/dashboard/programs/',

--- a/lms/static/js/learner_dashboard/spec/program_details_view_spec.js
+++ b/lms/static/js/learner_dashboard/spec/program_details_view_spec.js
@@ -461,9 +461,6 @@ describe('Program Details Header View', () => {
           ],
         },
       ],
-    //   grades: {
-    //     'course-v1:Testx+DOGx002+1T2016': 0.9,
-    //   },
     },
     urls: {
       program_listing_url: '/dashboard/programs/',

--- a/lms/static/js/learner_dashboard/views/course_card_view.js
+++ b/lms/static/js/learner_dashboard/views/course_card_view.js
@@ -27,11 +27,12 @@ class CourseCardView extends Backbone.View {
       this.enrollModel.urlRoot = this.urlModel.get('commerce_api_url');
     }
     this.context = options.context || {};
-    if (this.context.collectionCourseStatus === 'completed') {
-      this.model.updateCourseRunWithHighestGrade(this.context.courseData.grades);
-    }
-    this.grade = this.context.courseData.grades[this.model.get('course_run_key')];
-    this.grade = Math.round(this.grade * 100);
+    // if (this.context.collectionCourseStatus === 'completed') {
+    //   this.model.updateCourseRunWithHighestGrade(this.context.courseData.grades);
+    // }
+    // EDUCATOR-5043
+    // this.grade = this.context.courseData.grades[this.model.get('course_run_key')];
+    // this.grade = Math.round(this.grade * 100);
     this.collectionCourseStatus = this.context.collectionCourseStatus || '';
     this.entitlement = this.model.get('user_entitlement');
 
@@ -58,7 +59,7 @@ class CourseCardView extends Backbone.View {
     this.enrollView = new CourseEnrollView({
       $parentEl: this.$('.course-actions'),
       model: this.model,
-      grade: this.grade,
+      // grade: this.grade,
       collectionCourseStatus: this.collectionCourseStatus,
       urlModel: this.urlModel,
       enrollModel: this.enrollModel,

--- a/lms/static/js/learner_dashboard/views/course_card_view.js
+++ b/lms/static/js/learner_dashboard/views/course_card_view.js
@@ -27,12 +27,6 @@ class CourseCardView extends Backbone.View {
       this.enrollModel.urlRoot = this.urlModel.get('commerce_api_url');
     }
     this.context = options.context || {};
-    // if (this.context.collectionCourseStatus === 'completed') {
-    //   this.model.updateCourseRunWithHighestGrade(this.context.courseData.grades);
-    // }
-    // EDUCATOR-5043
-    // this.grade = this.context.courseData.grades[this.model.get('course_run_key')];
-    // this.grade = Math.round(this.grade * 100);
     this.collectionCourseStatus = this.context.collectionCourseStatus || '';
     this.entitlement = this.model.get('user_entitlement');
 
@@ -59,7 +53,6 @@ class CourseCardView extends Backbone.View {
     this.enrollView = new CourseEnrollView({
       $parentEl: this.$('.course-actions'),
       model: this.model,
-      // grade: this.grade,
       collectionCourseStatus: this.collectionCourseStatus,
       urlModel: this.urlModel,
       enrollModel: this.enrollModel,

--- a/lms/static/js/learner_dashboard/views/course_enroll_view.js
+++ b/lms/static/js/learner_dashboard/views/course_enroll_view.js
@@ -21,8 +21,6 @@ class CourseEnrollView extends Backbone.View {
     this.$parentEl = options.$parentEl;
     this.enrollModel = options.enrollModel;
     this.urlModel = options.urlModel;
-    // EDUCATOR-5043
-    // this.grade = options.grade;
     this.collectionCourseStatus = options.collectionCourseStatus;
     this.render();
   }
@@ -31,7 +29,6 @@ class CourseEnrollView extends Backbone.View {
     let filledTemplate;
     const context = this.model.toJSON();
     if (this.$parentEl && this.enrollModel) {
-      // context.grade = this.grade;
       context.collectionCourseStatus = this.collectionCourseStatus;
       filledTemplate = this.tpl(context);
       HtmlUtils.setHtml(this.$el, filledTemplate);

--- a/lms/static/js/learner_dashboard/views/course_enroll_view.js
+++ b/lms/static/js/learner_dashboard/views/course_enroll_view.js
@@ -21,7 +21,8 @@ class CourseEnrollView extends Backbone.View {
     this.$parentEl = options.$parentEl;
     this.enrollModel = options.enrollModel;
     this.urlModel = options.urlModel;
-    this.grade = options.grade;
+    // EDUCATOR-5043
+    // this.grade = options.grade;
     this.collectionCourseStatus = options.collectionCourseStatus;
     this.render();
   }
@@ -30,7 +31,7 @@ class CourseEnrollView extends Backbone.View {
     let filledTemplate;
     const context = this.model.toJSON();
     if (this.$parentEl && this.enrollModel) {
-      context.grade = this.grade;
+      // context.grade = this.grade;
       context.collectionCourseStatus = this.collectionCourseStatus;
       filledTemplate = this.tpl(context);
       HtmlUtils.setHtml(this.$el, filledTemplate);

--- a/lms/templates/learner_dashboard/course_enroll.underscore
+++ b/lms/templates/learner_dashboard/course_enroll.underscore
@@ -1,11 +1,5 @@
 <% if (is_enrolled && collectionCourseStatus === 'completed') { %>
-    <%
-        // Commented out for EDUCATOR-5043
-        // <div class="final-grade">
-        //    <div class="grade-header"><%- gettext('Final Grade') %><span class="sr"><%- StringUtils.interpolate(gettext('for {courseName}'), {courseName: title}) %></span></div>
-        //    <div class="grade-display"><%- grade %>%</div>
-        // </div>
-    %>
+    <% // do nothing %>
 <% } else if (is_enrolled && (typeof expired === 'undefined' || expired === false)) { %>
     <a href="<%- course_url %>" class="view-course-button btn-brand btn cta-primary">
         <% if (is_course_ended) { %>

--- a/lms/templates/learner_dashboard/course_enroll.underscore
+++ b/lms/templates/learner_dashboard/course_enroll.underscore
@@ -1,8 +1,11 @@
 <% if (is_enrolled && collectionCourseStatus === 'completed') { %>
-    <div class="final-grade">
-        <div class="grade-header"><%- gettext('Final Grade') %><span class="sr"><%- StringUtils.interpolate(gettext('for {courseName}'), {courseName: title}) %></span></div>
-        <div class="grade-display"><%- grade %>%</div>
-    </div>
+    <%
+        // Commented out for EDUCATOR-5043
+        // <div class="final-grade">
+        //    <div class="grade-header"><%- gettext('Final Grade') %><span class="sr"><%- StringUtils.interpolate(gettext('for {courseName}'), {courseName: title}) %></span></div>
+        //    <div class="grade-display"><%- grade %>%</div>
+        // </div>
+    %>
 <% } else if (is_enrolled && (typeof expired === 'undefined' || expired === false)) { %>
     <a href="<%- course_url %>" class="view-course-button btn-brand btn cta-primary">
         <% if (is_course_ended) { %>

--- a/lms/templates/learner_dashboard/course_enroll.underscore
+++ b/lms/templates/learner_dashboard/course_enroll.underscore
@@ -1,58 +1,58 @@
-<% if (is_enrolled && collectionCourseStatus === 'completed') { %>
-    <% // do nothing %>
-<% } else if (is_enrolled && (typeof expired === 'undefined' || expired === false)) { %>
-    <a href="<%- course_url %>" class="view-course-button btn-brand btn cta-primary">
-        <% if (is_course_ended) { %>
-            <%- gettext('View Archived Course') %>
+<% if (!(is_enrolled && collectionCourseStatus === 'completed')) { %>
+    <% if (is_enrolled && (typeof expired === 'undefined' || expired === false)) { %>
+        <a href="<%- course_url %>" class="view-course-button btn-brand btn cta-primary">
+            <% if (is_course_ended) { %>
+                <%- gettext('View Archived Course') %>
+            <% } else { %>
+                <%- gettext('View Course') %>
+            <% } %>
+        </a>
+    <% } else if (!user_entitlement) { %>
+        <% if (enrollable_course_runs.length > 0) { %>
+            <% if (enrollable_course_runs.length > 1) { %>
+                <div class="run-select-container">
+                    <label class="select-choice" for="select-<%- course_key %>-run">
+                        <%- gettext('Select a session:') %>
+                    </label>
+                    <select id="select-<%- course_key %>-run" class="run-select field-input input-select" autocomplete="off">
+                        <% _.each (enrollable_course_runs, function(courseRun) { %>
+                            <option
+                                value="<%- courseRun.key %>"
+                                <% if (key === courseRun.key) { %>
+                                    selected="selected"
+                                <% }%>
+                            >
+                                <%- courseRun.dateString %>
+                            </option>
+                        <% }); %>
+                    </select>
+                </div>
+            <% } %>
+            <div class="enroll-button">
+                <% if (typeof is_mobile_only != 'undefined' && is_mobile_only === true) { %>
+                <a href="edxapp://enroll?course_id=<%- course_run_key %>&email_opt_in=true" class="enroll-course-button btn-brand btn cta-primary">
+                    <%- gettext('Enroll Now') %>
+                </a>
+                <% } else { %>
+                <button type="button" class="btn-brand btn cta-primary">
+                    <%- gettext('Enroll Now') %>
+                </button>
+                <% } %>
+            </div>
+        <% } else if (upcoming_course_runs.length > 0) {%>
+            <div class="no-action-message">
+                <%- gettext('Coming Soon') %>
+            </div>
+            <div class="enrollment-opens">
+                <%- gettext('Enrollment Opens on') %>
+                <span class="enrollment-open-date">
+                    <%- upcoming_course_runs[0].enrollment_open_date %>
+                </span>
+            </div>
         <% } else { %>
-            <%- gettext('View Course') %>
-        <% } %>
-    </a>
-<% } else if (!user_entitlement) { %>
-    <% if (enrollable_course_runs.length > 0) { %>
-        <% if (enrollable_course_runs.length > 1) { %>
-            <div class="run-select-container">
-                <label class="select-choice" for="select-<%- course_key %>-run">
-                    <%- gettext('Select a session:') %>
-                </label>
-                <select id="select-<%- course_key %>-run" class="run-select field-input input-select" autocomplete="off">
-                    <% _.each (enrollable_course_runs, function(courseRun) { %>
-                        <option
-                            value="<%- courseRun.key %>"
-                            <% if (key === courseRun.key) { %>
-                                selected="selected"
-                            <% }%>
-                        >
-                            <%- courseRun.dateString %>
-                        </option>
-                    <% }); %>
-                </select>
+            <div class="no-action-message">
+                <%- gettext('Not Currently Available') %>
             </div>
         <% } %>
-        <div class="enroll-button">
-            <% if (typeof is_mobile_only != 'undefined' && is_mobile_only === true) { %>
-            <a href="edxapp://enroll?course_id=<%- course_run_key %>&email_opt_in=true" class="enroll-course-button btn-brand btn cta-primary">
-                <%- gettext('Enroll Now') %>
-            </a>
-            <% } else { %>
-            <button type="button" class="btn-brand btn cta-primary">
-                <%- gettext('Enroll Now') %>
-            </button>
-            <% } %>
-        </div>
-    <% } else if (upcoming_course_runs.length > 0) {%>
-        <div class="no-action-message">
-            <%- gettext('Coming Soon') %>
-        </div>
-        <div class="enrollment-opens">
-            <%- gettext('Enrollment Opens on') %>
-            <span class="enrollment-open-date">
-                <%- upcoming_course_runs[0].enrollment_open_date %>
-            </span>
-        </div>
-    <% } else { %>
-        <div class="no-action-message">
-            <%- gettext('Not Currently Available') %>
-        </div>
     <% } %>
 <% } %>

--- a/openedx/core/djangoapps/programs/tests/factories.py
+++ b/openedx/core/djangoapps/programs/tests/factories.py
@@ -13,4 +13,3 @@ class ProgressFactory(factory.Factory):
     completed = 0
     in_progress = 0
     not_started = 0
-    grades = dict()

--- a/openedx/core/djangoapps/programs/tests/test_utils.py
+++ b/openedx/core/djangoapps/programs/tests/test_utils.py
@@ -151,7 +151,7 @@ class TestProgramProgressMeter(TestCase):
         self.assertEqual(meter.engaged_programs, [program])
         self._assert_progress(
             meter,
-            ProgressFactory(uuid=program['uuid'], in_progress=1, grades={course_run_key: 0.0})
+            ProgressFactory(uuid=program['uuid'], in_progress=1)
         )
         self.assertEqual(list(meter.completed_programs_with_available_dates.keys()), [])
 
@@ -250,7 +250,6 @@ class TestProgramProgressMeter(TestCase):
                 completed=[],
                 in_progress=[program['courses'][0]],
                 not_started=[],
-                grades={course_run_key: 0.0},
             )
         ]
 
@@ -287,7 +286,6 @@ class TestProgramProgressMeter(TestCase):
                 completed=[],
                 in_progress=[program['courses'][0]],
                 not_started=[],
-                grades={course_run_key: 0.0},
             )
         ]
 
@@ -329,7 +327,6 @@ class TestProgramProgressMeter(TestCase):
                 completed=0,
                 in_progress=1 if offset in [None, 1] else 0,
                 not_started=1 if offset in [-1] else 0,
-                grades={course_run_key: 0.0},
             )
         ]
 
@@ -369,13 +366,9 @@ class TestProgramProgressMeter(TestCase):
         programs = data[:2]
         self.assertEqual(meter.engaged_programs, programs)
 
-        grades = {
-            newer_course_run_key: 0.0,
-            older_course_run_key: 0.0,
-        }
         self._assert_progress(
             meter,
-            *(ProgressFactory(uuid=program['uuid'], in_progress=1, grades=grades) for program in programs)
+            *(ProgressFactory(uuid=program['uuid'], in_progress=1) for program in programs)
         )
         self.assertEqual(list(meter.completed_programs_with_available_dates.keys()), [])
 
@@ -441,14 +434,9 @@ class TestProgramProgressMeter(TestCase):
         programs = data[:3]
         self.assertEqual(meter.engaged_programs, programs)
 
-        grades = {
-            solo_course_run_key: 0.0,
-            shared_course_run_key: 0.0,
-        }
-
         self._assert_progress(
             meter,
-            *(ProgressFactory(uuid=program['uuid'], in_progress=1, grades=grades) for program in programs)
+            *(ProgressFactory(uuid=program['uuid'], in_progress=1) for program in programs)
         )
         self.assertEqual(list(meter.completed_programs_with_available_dates.keys()), [])
 
@@ -509,7 +497,7 @@ class TestProgramProgressMeter(TestCase):
         _, program_uuid = data[0], data[0]['uuid']
         self._assert_progress(
             meter,
-            ProgressFactory(uuid=program_uuid, in_progress=1, not_started=1, grades={first_course_run_key: 0.0})
+            ProgressFactory(uuid=program_uuid, in_progress=1, not_started=1)
         )
         self.assertEqual(list(meter.completed_programs_with_available_dates.keys()), [])
 
@@ -521,10 +509,6 @@ class TestProgramProgressMeter(TestCase):
             ProgressFactory(
                 uuid=program_uuid,
                 in_progress=2,
-                grades={
-                    first_course_run_key: 0.0,
-                    second_course_run_key: 0.0,
-                },
             )
         )
         self.assertEqual(list(meter.completed_programs_with_available_dates.keys()), [])
@@ -538,10 +522,6 @@ class TestProgramProgressMeter(TestCase):
                 uuid=program_uuid,
                 completed=1,
                 in_progress=1,
-                grades={
-                    first_course_run_key: 0.0,
-                    second_course_run_key: 0.0,
-                }
             )
         )
         self.assertEqual(list(meter.completed_programs_with_available_dates.keys()), [])
@@ -556,10 +536,6 @@ class TestProgramProgressMeter(TestCase):
                 uuid=program_uuid,
                 completed=1,
                 in_progress=1,
-                grades={
-                    first_course_run_key: 0.0,
-                    second_course_run_key: 0.0,
-                }
             )
         )
         self.assertEqual(list(meter.completed_programs_with_available_dates.keys()), [])
@@ -573,10 +549,6 @@ class TestProgramProgressMeter(TestCase):
             ProgressFactory(
                 uuid=program_uuid,
                 completed=2,
-                grades={
-                    first_course_run_key: 0.0,
-                    second_course_run_key: 0.0,
-                }
             )
         )
         self.assertEqual(list(meter.completed_programs_with_available_dates.keys()), [program_uuid])
@@ -607,7 +579,7 @@ class TestProgramProgressMeter(TestCase):
         _, program_uuid = data[0], data[0]['uuid']
         self._assert_progress(
             meter,
-            ProgressFactory(uuid=program_uuid, completed=1, grades={course_run_key: 0.0})
+            ProgressFactory(uuid=program_uuid, completed=1)
         )
         self.assertEqual(list(meter.completed_programs_with_available_dates.keys()), [program_uuid])
 
@@ -724,38 +696,6 @@ class TestProgramProgressMeter(TestCase):
         meter = ProgramProgressMeter(self.site, self.user)
         mock_completed_course_runs.return_value = [{'course_run_id': course_run_key, 'type': CourseMode.VERIFIED}]
         self.assertEqual(meter._is_course_complete(course), True)
-
-    def test_course_grade_results(self, mock_get_programs):
-        grade_percent = .8
-        with mock_passing_grade(percent=grade_percent):
-            course_run_key = generate_course_run_key()
-            data = [
-                ProgramFactory(
-                    courses=[
-                        CourseFactory(course_runs=[
-                            CourseRunFactory(key=course_run_key),
-                        ]),
-                    ]
-                )
-            ]
-            mock_get_programs.return_value = data
-
-            self._create_enrollments(course_run_key)
-
-            meter = ProgramProgressMeter(self.site, self.user)
-
-            program = data[0]
-            expected = [
-                ProgressFactory(
-                    uuid=program['uuid'],
-                    completed=[],
-                    in_progress=[program['courses'][0]],
-                    not_started=[],
-                    grades={course_run_key: grade_percent},
-                )
-            ]
-
-            self.assertEqual(meter.progress(count_only=False), expected)
 
     def test_detail_url_for_mobile_only(self, mock_get_programs):
         """

--- a/openedx/core/djangoapps/programs/utils.py
+++ b/openedx/core/djangoapps/programs/utils.py
@@ -26,7 +26,6 @@ from entitlements.models import CourseEntitlement
 from lms.djangoapps.certificates import api as certificate_api
 from lms.djangoapps.certificates.models import GeneratedCertificate
 from lms.djangoapps.commerce.utils import EcommerceService
-from lms.djangoapps.grades.api import CourseGradeFactory
 from openedx.core.djangoapps.catalog.utils import get_fulfillable_course_runs_for_entitlement, get_programs
 from openedx.core.djangoapps.certificates.api import available_date_for_certificate
 from openedx.core.djangoapps.commerce.utils import ecommerce_api_client
@@ -113,8 +112,6 @@ class ProgramProgressMeter(object):
 
         self.entitlements = list(CourseEntitlement.unexpired_entitlements_for_user(self.user))
         self.course_uuids = [str(entitlement.course_uuid) for entitlement in self.entitlements]
-
-        self.course_grade_factory = CourseGradeFactory()
 
         if uuid:
             self.programs = [get_programs(uuid=uuid)]
@@ -270,17 +267,11 @@ class ProgramProgressMeter(object):
                 else:
                     not_started.append(course)
 
-            grades = {}
-            for run in self.course_run_ids:
-                grade = self.course_grade_factory.read(self.user, course_key=CourseKey.from_string(run))
-                grades[run] = grade.percent
-
             progress.append({
                 'uuid': program_copy['uuid'],
                 'completed': len(completed) if count_only else completed,
                 'in_progress': len(in_progress) if count_only else in_progress,
                 'not_started': len(not_started) if count_only else not_started,
-                'grades': grades,
             })
 
         return progress


### PR DESCRIPTION
[EDUCATOR-5043: Performance Issue with ProgramsFragmentView.get](https://openedx.atlassian.net/browse/EDUCATOR-5043)

The ProgramProgressMeter was causing significant slowness when looking up grades for a single user with a huge number of enrollments. We decided, for now, to just remove the grade display from this page, since the status (completed, in progress, not started) seems sufficient.