### PR TITLE
update cielo api settings

### DIFF
--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -2097,13 +2097,12 @@ VIDEO_TRANSCRIPTS_MAX_AGE = 31536000
 ############################ TRANSCRIPT PROVIDERS SETTINGS ########################
 
 # Note: These settings will also exist in video-encode-manager, so any update here
-# should also be done there. Additionally, the BASE & LOGIN URL will be overridden at
-# deployment as the actual URL is different from sandboxing URL.
-CIELO24_SETTINGS = dict(
-    CIELO24_API_VERSION=1,
-    CIELO24_BASE_API_URL="https://sandbox.cielo24.com/api",
-    CIELO24_LOGIN_URL="https://sandbox.cielo24.com/api/account/login"
-)
+# should also be done there.
+CIELO24_SETTINGS = {
+    'CIELO24_API_VERSION': 1,
+    'CIELO24_BASE_API_URL': "https://api.cielo24.com/api",
+    'CIELO24_LOGIN_URL': "https://api.cielo24.com/api/account/login"
+}
 
 ##### shoppingcart Payment #####
 PAYMENT_SUPPORT_EMAIL = 'billing@example.com'


### PR DESCRIPTION
### [ PROD-1553](https://openedx.atlassian.net/browse/PROD-1553)

### Description
- Remove cielo24 sandbox API reference. platform allows the settings override in devstack with private.py option and if needed, the cielo24 sandbox settings can be overridden there
  - This has been done with regards to the latest discoveries of using production account as the sandbox with Mechanical fidelity


