### PR TITLE
Fix DeprecationWarning: count is deprecated. Use Collection.count_documents instead

### DIFF
--- a/common/lib/xmodule/xmodule/modulestore/mongo/draft.py
+++ b/common/lib/xmodule/xmodule/modulestore/mongo/draft.py
@@ -196,7 +196,7 @@ class DraftModuleStore(MongoModuleStore):
             # b/c we don't want the payload, I'm copying the guts of get_items here
             query = self._course_key_to_son(dest_course_id)
             query['_id.category'] = {'$nin': ['course', 'about']}
-            if self.collection.find(query).limit(1).count() > 0:
+            if self.collection.count_documents(query, limit=1) > 0:
                 raise DuplicateCourseError(
                     dest_course_id,
                     "Course at destination {0} is not an empty course. "

--- a/common/lib/xmodule/xmodule/modulestore/tests/test_split_modulestore.py
+++ b/common/lib/xmodule/xmodule/modulestore/tests/test_split_modulestore.py
@@ -2235,12 +2235,12 @@ class TestSchema(SplitModuleTest):
         db_connection = modulestore().db_connection
         for collection in [db_connection.course_index, db_connection.structures, db_connection.definitions]:
             self.assertEqual(
-                collection.find({'schema_version': {'$exists': False}}).count(),
+                collection.count_documents({'schema_version': {'$exists': False}}),
                 0,
                 "{0.name} has records without schema_version".format(collection)
             )
             self.assertEqual(
-                collection.find({'schema_version': {'$ne': SplitMongoModuleStore.SCHEMA_VERSION}}).count(),
+                collection.count_documents({'schema_version': {'$ne': SplitMongoModuleStore.SCHEMA_VERSION}}),
                 0,
                 "{0.name} has records with wrong schema_version".format(collection)
             )


### PR DESCRIPTION
This PR contributes to the elimination of deprecation warnings, specifically the one mentioned above and reported in the [Warnings Report](https://build.testeng.edx.org/job/edx-platform-python-pipeline-master/warning_5freport_5fall_2ehtml/).

Changed collection.find(filter).count() to collection.count_documents(filter) in the following file:

- common/lib/xmodule/xmodule/modulestore/tests/test_split_modulestore.py

And collection.find(filter).limit(1).count() to collection.count_documents(filter, limit=1) in the following file:

- common/lib/xmodule/xmodule/modulestore/mongo/draft.py

The method count_documents is part of the collection, not the cursor (find returns a cursor), according to [StackOverflow](https://stackoverflow.com/questions/56303331/warning-message-in-pymongo-count-is-deprecated). Because of that after changing count, I removed the calling to the find method and use the _filter_ parameter in count_documents. Also, I removed _limit_ because count_documents accepts  _limit_ parameter.

This warning occurs due to deprecation: [Pymongo count_documents](https://pymongo.readthedocs.io/en/3.9.0/api/pymongo/collection.html#pymongo.collection.Collection.count_documents)

@felipemontoya 
@morenol 
