### PR TITLE
Only set due dates on graded content

### DIFF
--- a/openedx/core/djangoapps/course_date_signals/handlers.py
+++ b/openedx/core/djangoapps/course_date_signals/handlers.py
@@ -58,9 +58,10 @@ def extract_dates_from_course(course):
                 items = [section]
                 while items:
                     next_item = items.pop()
-                    # TODO: Once studio can manually set relative dates,
-                    # we would need to manually check for them here
-                    date_items.append((next_item.location, {'due': time_per_week * (idx + 1)}))
+                    if next_item.graded:
+                        # TODO: Once studio can manually set relative dates,
+                        # we would need to manually check for them here
+                        date_items.append((next_item.location, {'due': time_per_week * (idx + 1)}))
                     items.extend(next_item.get_children())
     else:
         date_items = []


### PR DESCRIPTION
When a self paced course was published and we were configured to automatically space out due dates among its sections, we were accidentally setting due dates on ungraded content. Which limited access to it.

https://openedx.atlassian.net/browse/AA-162

No tests because this whole djangoapp doesn't have them(?!) and I didn't want to build a whole scaffolding for a one line fix. I tested locally.