### PR TITLE
Address 1+N django_site queries on login page by comparing keys directly

### DIFF
--- a/common/djangoapps/third_party_auth/models.py
+++ b/common/djangoapps/third_party_auth/models.py
@@ -332,7 +332,7 @@ class ProviderConfig(ConfigurationModel):
         """
         Determines if the provider is able to be used with the current site.
         """
-        return self.enabled and self.site == Site.objects.get_current(get_current_request())
+        return self.enabled and self.site_id == Site.objects.get_current(get_current_request()).id
 
 
 class OAuth2ProviderConfig(ProviderConfig):

--- a/common/djangoapps/third_party_auth/tests/test_provider.py
+++ b/common/djangoapps/third_party_auth/tests/test_provider.py
@@ -92,7 +92,7 @@ class RegistryTest(testutil.TestCase):
         self.assertEqual(len(enabled_slugs), 100)
         # Should not involve any queries for Site, or at least should not *scale* with number of providers
         all_queries = [q['sql'] for q in cq.captured_queries]
-        django_site_queries = list(filter(lambda sql: re_django_site_query.search(sql), all_queries))
+        django_site_queries = list(filter(re_django_site_query.search, all_queries))
         self.assertEqual(len(django_site_queries), 0)  # previously was 100 (1 for each provider)
 
     def test_providers_displayed_for_login(self):

--- a/common/djangoapps/third_party_auth/tests/test_provider.py
+++ b/common/djangoapps/third_party_auth/tests/test_provider.py
@@ -83,17 +83,18 @@ class RegistryTest(testutil.TestCase):
         re_django_site_query = re.compile(r'FROM\s+"django_site"')
 
         self.enable_saml()
-        for i in range(100):
+        provider_count = 5
+        for i in range(provider_count):
             self.configure_saml_provider(enabled=True, slug="saml-slug-%s" % i)
 
         with CaptureQueriesContext(connections[DEFAULT_DB_ALIAS]) as cq:
             enabled_slugs = {p.slug for p in provider.Registry.enabled()}
 
-        self.assertEqual(len(enabled_slugs), 100)
+        self.assertEqual(len(enabled_slugs), provider_count)
         # Should not involve any queries for Site, or at least should not *scale* with number of providers
         all_queries = [q['sql'] for q in cq.captured_queries]
         django_site_queries = list(filter(re_django_site_query.search, all_queries))
-        self.assertEqual(len(django_site_queries), 0)  # previously was 100 (1 for each provider)
+        self.assertEqual(len(django_site_queries), 0)  # previously was == provider_count (1 for each provider)
 
     def test_providers_displayed_for_login(self):
         """

--- a/common/djangoapps/third_party_auth/tests/test_provider.py
+++ b/common/djangoapps/third_party_auth/tests/test_provider.py
@@ -1,9 +1,12 @@
 """Unit tests for provider.py."""
 
 
+import re
 import unittest
 
 from django.contrib.sites.models import Site
+from django.db import connections, DEFAULT_DB_ALIAS
+from django.test.utils import CaptureQueriesContext
 from mock import Mock, patch
 
 from openedx.core.djangoapps.site_configuration.tests.test_util import with_site_configuration
@@ -74,6 +77,22 @@ class RegistryTest(testutil.TestCase):
 
         with patch('third_party_auth.provider._PSA_OAUTH2_BACKENDS', backend_names):
             self.assertEqual(sorted(provider_names), [prov.name for prov in provider.Registry.enabled()])
+
+    def test_enabled_doesnt_query_site(self):
+        """Regression test for 1+N queries for django_site (ARCHBOM-1139)"""
+        re_from_ds = re.compile(r'FROM\s+"django_site"')
+
+        self.enable_saml()
+        for i in range(100):
+            self.configure_saml_provider(enabled=True, slug="saml-slug-%s" % i)
+
+        with CaptureQueriesContext(connections[DEFAULT_DB_ALIAS]) as cq:
+            enabled_slugs = {p.slug for p in provider.Registry.enabled()}
+
+        self.assertEqual(len(enabled_slugs), 100)
+        # Should not involve any queries for Site, or at least should not *scale* with number of providers
+        django_site_queries = [q['sql'] for q in cq.captured_queries if re_from_ds.search(q['sql'])]
+        self.assertLessEqual(len(django_site_queries), 5)  # 5 just a low number for future-proofing
 
     def test_providers_displayed_for_login(self):
         """


### PR DESCRIPTION
Rather than fetching the Site for every provider in a loop, just look at the ID of the site.

Added regression test for when there are 100 providers, showing 100 requests before and 0 requests after.

(This punts on the question of site-shadowing that https://github.com/edx/edx-platform/pull/23824 tried to solve.)