### PR TITLE
[PROD-1230] - syncing certificates on course update on credential side.

### DIFF
--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -1403,6 +1403,9 @@ INSTALLED_APPS = [
     # Catalog integration
     'openedx.core.djangoapps.catalog',
 
+    # Programs support
+    'openedx.core.djangoapps.programs.apps.ProgramsConfig',
+
     # django-oauth-toolkit
     'oauth2_provider',
 

--- a/openedx/core/djangoapps/models/config/waffle.py
+++ b/openedx/core/djangoapps/models/config/waffle.py
@@ -1,0 +1,39 @@
+"""
+This module contains various configuration settings via
+waffle switches for the course_details view.
+"""
+
+
+from openedx.core.djangoapps.waffle_utils import (
+    CourseWaffleFlag,
+    WaffleFlagNamespace,
+    WaffleSwitchNamespace
+)
+
+COURSE_DETAIL_WAFFLE_NAMESPACE = 'course_detail'
+COURSE_DETAIL_WAFFLE_FLAG_NAMESPACE = WaffleFlagNamespace(name=COURSE_DETAIL_WAFFLE_NAMESPACE)
+WAFFLE_SWITCHES = WaffleSwitchNamespace(name=COURSE_DETAIL_WAFFLE_NAMESPACE)
+
+# Course Override Flag
+COURSE_DETAIL_UPDATE_CERTIFICATE_DATE = u'course_detail_update_certificate_date'
+
+
+def waffle_flags():
+    """
+    Returns the namespaced, cached, audited Waffle flags dictionary for course detail.
+    """
+    return {
+        COURSE_DETAIL_UPDATE_CERTIFICATE_DATE: CourseWaffleFlag(
+            waffle_namespace=COURSE_DETAIL_WAFFLE_NAMESPACE,
+            flag_name=COURSE_DETAIL_UPDATE_CERTIFICATE_DATE,
+            flag_undefined_default=False,
+        )
+    }
+
+
+def enable_course_detail_update_certificate_date(course_id):
+    """
+    Returns True if course_detail_update_certificate_date course override flag is enabled,
+    otherwise False.
+    """
+    return waffle_flags()[COURSE_DETAIL_UPDATE_CERTIFICATE_DATE].is_enabled(course_id)

--- a/openedx/core/djangoapps/models/course_details.py
+++ b/openedx/core/djangoapps/models/course_details.py
@@ -6,8 +6,11 @@ CourseDetails
 import logging
 import re
 
+import six
 from django.conf import settings
 
+from openedx.core.djangoapps.models.config.waffle import enable_course_detail_update_certificate_date
+from openedx.core.djangoapps.signals.signals import COURSE_CERT_DATE_CHANGE
 from openedx.core.djangolib.markup import HTML
 from openedx.core.lib.courses import course_image_url
 from xmodule.fields import Date
@@ -243,6 +246,8 @@ class CourseDetails(object):
         if converted != descriptor.certificate_available_date:
             dirty = True
             descriptor.certificate_available_date = converted
+            if enable_course_detail_update_certificate_date(course_key):
+                COURSE_CERT_DATE_CHANGE.send_robust(sender=cls, course_key=six.text_type(course_key))
 
         if 'course_image_name' in jsondict and jsondict['course_image_name'] != descriptor.course_image:
             descriptor.course_image = jsondict['course_image_name']

--- a/openedx/core/djangoapps/programs/tests/test_signals.py
+++ b/openedx/core/djangoapps/programs/tests/test_signals.py
@@ -6,12 +6,17 @@ This module contains tests for programs-related signals and signal handlers.
 import mock
 from django.test import TestCase
 from opaque_keys.edx.keys import CourseKey
-
 from openedx.core.djangoapps.programs.signals import (
-    handle_course_cert_awarded, handle_course_cert_changed, handle_course_cert_revoked
+    handle_course_cert_awarded,
+    handle_course_cert_changed,
+    handle_course_cert_date_change,
+    handle_course_cert_revoked
 )
 from openedx.core.djangoapps.signals.signals import (
-    COURSE_CERT_AWARDED, COURSE_CERT_CHANGED, COURSE_CERT_REVOKED
+    COURSE_CERT_AWARDED,
+    COURSE_CERT_CHANGED,
+    COURSE_CERT_DATE_CHANGE,
+    COURSE_CERT_REVOKED
 )
 from openedx.core.djangoapps.site_configuration.tests.factories import SiteConfigurationFactory
 from openedx.core.djangolib.testing.utils import skip_unless_lms
@@ -224,3 +229,59 @@ class CertRevokedReceiverTest(TestCase):
         self.assertEqual(mock_is_learner_issuance_enabled.call_count, 1)
         self.assertEqual(mock_task.call_count, 1)
         self.assertEqual(mock_task.call_args[0], (TEST_USERNAME, TEST_COURSE_KEY))
+
+
+@skip_unless_lms
+@mock.patch('openedx.core.djangoapps.programs.tasks.v1.tasks.update_certificate_visible_date_on_course_update.delay')
+@mock.patch(
+    'openedx.core.djangoapps.credentials.models.CredentialsApiConfig.is_learner_issuance_enabled',
+    new_callable=mock.PropertyMock,
+    return_value=False,
+)
+class CourseCertAvailableDateChangedReceiverTest(TestCase):
+    """
+    Tests for the `handle_course_cert_date_change` signal handler function.
+    """
+
+    @property
+    def signal_kwargs(self):
+        """
+        DRY helper.
+        """
+        return {
+            'sender': self.__class__,
+            'course_key': TEST_COURSE_KEY,
+        }
+
+    def test_signal_received(self, mock_is_learner_issuance_enabled, mock_task):  # pylint: disable=unused-argument
+        """
+        Ensures the receiver function is invoked when COURSE_CERT_DATE_CHANGE is
+        sent.
+
+        Suboptimal: because we cannot mock the receiver function itself (due
+        to the way django signals work), we mock a configuration call that is
+        known to take place inside the function.
+        """
+        COURSE_CERT_DATE_CHANGE.send(**self.signal_kwargs)
+        self.assertEqual(mock_is_learner_issuance_enabled.call_count, 1)
+
+    def test_programs_disabled(self, mock_is_learner_issuance_enabled, mock_task):
+        """
+        Ensures that the receiver function does nothing when the credentials API
+        configuration is not enabled.
+        """
+        handle_course_cert_date_change(**self.signal_kwargs)
+        self.assertEqual(mock_is_learner_issuance_enabled.call_count, 1)
+        self.assertEqual(mock_task.call_count, 0)
+
+    def test_programs_enabled(self, mock_is_learner_issuance_enabled, mock_task):
+        """
+        Ensures that the receiver function invokes the expected celery task
+        when the credentials API configuration is enabled.
+        """
+        mock_is_learner_issuance_enabled.return_value = True
+
+        handle_course_cert_date_change(**self.signal_kwargs)
+
+        self.assertEqual(mock_is_learner_issuance_enabled.call_count, 1)
+        self.assertEqual(mock_task.call_count, 1)

--- a/openedx/core/djangoapps/signals/signals.py
+++ b/openedx/core/djangoapps/signals/signals.py
@@ -14,6 +14,8 @@ COURSE_GRADE_CHANGED = Signal(providing_args=["user", "course_grade", "course_ke
 COURSE_CERT_CHANGED = Signal(providing_args=["user", "course_key", "mode", "status"])
 COURSE_CERT_AWARDED = Signal(providing_args=["user", "course_key", "mode", "status"])
 COURSE_CERT_REVOKED = Signal(providing_args=["user", "course_key", "mode", "status"])
+COURSE_CERT_DATE_CHANGE = Signal(providing_args=["course_key"])
+
 
 # Signal that indicates that a user has passed a course.
 COURSE_GRADE_NOW_PASSED = Signal(


### PR DESCRIPTION
### [PROD-1230](https://openedx.atlassian.net/browse/PROD-1230)

### Description
In the credentials service certificate available date is called visible_date. Whenever a `generatedCertificate` is updated or saved the first time, it sets the visible date to certificate available date (available in studio settings). There is a limitation in our code and that is if the course team decides to change the `certificate_available_date` it is not reflected in the credentials service for all the certificates that were awarded before that change and have been pushed to credentials service.

This is causing problems because a learner is able to see the certificate on their dashboard but the change is not reflected on their learner record in credential service. We should figure out a mechanism to push changes made to `certificate_available_date` in CourseOverview object to user course credentials in Credentials Service.

### Fix

Whenever a course update takes place with `certificate_available_date`, update all certificates for the course with updated `certificate_avaialable_date`.

### Sandbox
N/A

### Reviewers
If you've been tagged for review, please check your corresponding box once you've given the 👍.

- [x] @awaisdar001  
- [x] @DawoudSheraz  
- [x] @asadazam93   

### Post-review
- [x] Rebase and squash commits