### PR TITLE
Fix transcript status for VEDA videos

### DIFF
--- a/cms/templates/js/video-transcripts.underscore
+++ b/cms/templates/js/video-transcripts.underscore
@@ -5,7 +5,7 @@
         </br>
         <span class='message-error'><%- error_description %></span>
     <% }%>
-<% } else { %>
+<% } else if (!transcripts.length){ %>
     <span class='transcripts-empty-text'><%- gettext('No transcript uploaded.') %></span>
 <% }%>
 </br>


### PR DESCRIPTION
Add a transcription length check for old VEDA videos so it doesn't show "No transcript uploaded" in cases where transcript status was not properly updated but video transcripts exist. 