### PR TITLE
Added reverse_sql method attribute to avoid sql operation error YONK-1588

### DIFF
--- a/common/djangoapps/django_comment_common/migrations/0008_role_user_index.py
+++ b/common/djangoapps/django_comment_common/migrations/0008_role_user_index.py
@@ -12,6 +12,6 @@ class Migration(migrations.Migration):
 
     operations = [
         migrations.RunSQL(
-            'CREATE INDEX dcc_role_users_user_role_idx ON django_comment_client_role_users(user_id, role_id);'
-        ),
+            'CREATE INDEX dcc_role_users_user_role_idx ON django_comment_client_role_users(user_id, role_id);',
+            reverse_sql='DROP INDEX dcc_role_users_user_role_idx ON django_comment_client_role_users;'),
     ]


### PR DESCRIPTION
reverse_sql to `CREATE INDEX` was missing in this migration which has been added now to avoid a possible `sql operation` error in future. This is needed to fix the case to revert this migration which will result in reverting the migration with out dropping created index. 
[YONK-1588](https://openedx.atlassian.net/browse/YONK-1588)