### PR TITLE
Restrict when courseware api can show the upgrade sock

### DIFF
--- a/openedx/core/djangoapps/courseware_api/serializers.py
+++ b/openedx/core/djangoapps/courseware_api/serializers.py
@@ -61,6 +61,7 @@ class CourseInfoSerializer(serializers.Serializer):  # pylint: disable=abstract-
     Compare this with CourseDetailSerializer.
     """
 
+    can_show_upgrade_sock = serializers.BooleanField()
     content_type_gating_enabled = serializers.BooleanField()
     course_expired_message = serializers.CharField()
     effort = serializers.CharField()

--- a/openedx/core/djangoapps/courseware_api/views.py
+++ b/openedx/core/djangoapps/courseware_api/views.py
@@ -20,6 +20,7 @@ from lms.djangoapps.courseware.access import has_access
 from lms.djangoapps.courseware.courses import check_course_access
 from lms.djangoapps.courseware.module_render import get_module_by_usage_id
 from lms.djangoapps.courseware.tabs import get_course_tab_list
+from lms.djangoapps.courseware.utils import can_show_verified_upgrade
 from lms.djangoapps.courseware.utils import verified_upgrade_deadline_link
 from openedx.core.lib.api.view_utils import DeveloperErrorViewMixin
 from openedx.features.content_type_gating.models import ContentTypeGatingConfig
@@ -81,6 +82,12 @@ class CoursewareMeta:
             user=self.effective_user,
             course_key=self.course_key,
         )
+
+    @property
+    def can_show_upgrade_sock(self):
+        enrollment = CourseEnrollment.get_enrollment(self.effective_user, self.course_key)
+        can_show = can_show_verified_upgrade(self.effective_user, enrollment)
+        return can_show
 
     @property
     def can_load_courseware(self):


### PR DESCRIPTION
https://github.com/edx/edx-platform/blob/master/openedx/features/course_experience/views/course_sock.py#L32

I thought about modifying `verified_mode` to only return data if `can_show_verified_upgrade`, but that data is used in other places, so I opted to be specific for now.