### PR TITLE
WIP: Enable to set title for handouts section of course home sidebar

### DIFF
--- a/common/lib/xmodule/xmodule/course_module.py
+++ b/common/lib/xmodule/xmodule/course_module.py
@@ -539,7 +539,6 @@ class CourseFields(object):
             "Enter the heading that you want students to see above your course handouts on the Course Home page. "
             "Your course handouts appear in the right panel of the page."
         ),
-        deprecated=True,
         scope=Scope.settings, default=_('Course Handouts'))
     show_timezone = Boolean(
         help=_(

--- a/openedx/features/course_experience/templates/course_experience/course-home-fragment.html
+++ b/openedx/features/course_experience/templates/course_experience/course-home-fragment.html
@@ -163,7 +163,7 @@ from openedx.features.course_experience.course_tools import HttpMethod
             % endif
             % if handouts_html:
                 <div class="section section-handouts">
-                    <h3 class="hd-6 section-title">${_("Course Handouts")}</h3>
+                    <h3 class="hd-6 section-title">${_(course.info_sidebar_name)}</h3>
                     ${HTML(handouts_html)}
                 </div>
             % endif


### PR DESCRIPTION
With this commit course staffs can set a custom title for course handouts section of course home sidebar.
**Note:** This is going to return changes committed in #15560
although this section is changed to get HTML code for its content, but this title is still remained in place and cannot be customized.
It cannot be completely removed because in most cases (if not saying all cases) no value has been set for it and course creators use it to set a `<ul>` or `<ol>` list only.

if you approve this commit that title can be removed by setting it to "" to take full control in HTML editor and also can be customized to a new value.
The default value is still "Course Handouts".

I have briefly talked about this with @nedbat yesterday

I think there should be added some tests and documentations. kindly help me to do this if the changes approved.