### PR TITLE
fixed visibility state for self paced

### DIFF
--- a/cms/djangoapps/contentstore/views/item.py
+++ b/cms/djangoapps/contentstore/views/item.py
@@ -1428,10 +1428,10 @@ def _compute_visibility_state(xblock, child_info, is_unit_with_changes, is_cours
             return VisibilityState.live if is_live else VisibilityState.needs_attention
         else:
             return VisibilityState.ready if not is_unscheduled else VisibilityState.needs_attention
-    if is_unscheduled:
-        return VisibilityState.unscheduled
-    elif is_live:
+    if is_live:
         return VisibilityState.live
+    elif is_unscheduled:
+        return VisibilityState.unscheduled
     else:
         return VisibilityState.ready
 

--- a/cms/djangoapps/contentstore/views/tests/test_item.py
+++ b/cms/djangoapps/contentstore/views/tests/test_item.py
@@ -3118,6 +3118,18 @@ class TestXBlockPublishingInfo(ItemTest):
         xblock_info = self._get_xblock_info(empty_chapter.location)
         self._verify_visibility_state(xblock_info, VisibilityState.unscheduled)
 
+    @ddt.data(ModuleStoreEnum.Type.mongo, ModuleStoreEnum.Type.split)
+    def test_chapter_self_paced_default_start_date(self, store_type):
+        course = CourseFactory.create(default_store=store_type)
+        course.self_paced = True
+        self.store.update_item(course, self.user.id)
+        chapter = self._create_child(course, 'chapter', "Test Chapter")
+        sequential = self._create_child(chapter, 'sequential', "Test Sequential")
+        self._create_child(sequential, 'vertical', "Published Unit", publish_item=True)
+        self._set_release_date(chapter.location, DEFAULT_START_DATE)
+        xblock_info = self._get_xblock_info(chapter.location)
+        self._verify_visibility_state(xblock_info, VisibilityState.live)
+
     def test_empty_sequential(self):
         chapter = self._create_child(self.course, 'chapter', "Test Chapter")
         self._create_child(chapter, 'sequential', "Empty Sequential")


### PR DESCRIPTION
## [PROD-1336](https://openedx.atlassian.net/browse/PROD-1336)

### Description
If a course is self paced and live there is no need to check for the schedule of the course first so I have placed the is_live check first.

**Sandbox**
https://prod-13361.sandbox.edx.org/

Steps to Test:

- Create a self paced course with start date in the past.
- Create one unit (a chapter, sequential and a vertical)
- Publish the unit
- View the unit on studio course outline it should be coloured blue 

### Reviewers
If you've been tagged for review, please check your corresponding box once you've given the :+1:.
- [ ] @saadyousafarbi 
- [ ] @AhtishamShahid 

### Post-review
- [ ] Rebase and squash commits