### PR TITLE
EDUCATOR 5042: Learner's Private Team Appears When Learner Browses all Team Sets

### DIFF
--- a/lms/djangoapps/teams/tests/test_views.py
+++ b/lms/djangoapps/teams/tests/test_views.py
@@ -977,19 +977,21 @@ class TestListTeamsAPI(EventTestMixin, TeamAPITestCase):
         unprotected_team_in_private_teamset.add_user(self.users['student_enrolled'])
 
         # make some more users and put them in the solar team.
-        self.create_and_enroll_student(username='another_student')
-        self.create_and_enroll_student(username='yet_another_student')
-        self.solar_team.add_user(self.users['another_student'])
-        self.solar_team.add_user(self.users['yet_another_student'])
+        another_student_username = 'another_student'
+        yet_another_student_username = 'yet_another_student'
+        self.create_and_enroll_student(username=another_student_username)
+        self.create_and_enroll_student(username=yet_another_student_username)
+        self.solar_team.add_user(self.users[another_student_username])
+        self.solar_team.add_user(self.users[yet_another_student_username])
 
-        teams = self.get_teams_list(data={'topic_id': 'topic_0'}, user='student_enrolled')
+        teams = self.get_teams_list(data={'topic_id': self.solar_team.topic_id}, user='student_enrolled')
         team_names = [team['name'] for team in teams['results']]
         team_names.sort()
         self.assertEqual(team_names, [
             self.solar_team.name,
         ])
 
-        teams = self.get_teams_list(data={'topic_id': 'topic_0'}, user='staff')
+        teams = self.get_teams_list(data={'topic_id': self.solar_team.topic_id}, user='staff')
         team_names = [team['name'] for team in teams['results']]
         team_names.sort()
         self.assertEqual(team_names, [

--- a/lms/djangoapps/teams/tests/test_views.py
+++ b/lms/djangoapps/teams/tests/test_views.py
@@ -987,9 +987,6 @@ class TestListTeamsAPI(EventTestMixin, TeamAPITestCase):
         team_names.sort()
         self.assertEqual(team_names, [
             self.solar_team.name,
-            self.solar_team.name,
-            self.solar_team.name,
-            unprotected_team_in_private_teamset.name,
         ])
 
         teams = self.get_teams_list(data={'topic_id': 'topic_0'}, user='staff')

--- a/lms/djangoapps/teams/tests/test_views.py
+++ b/lms/djangoapps/teams/tests/test_views.py
@@ -967,6 +967,10 @@ class TestListTeamsAPI(EventTestMixin, TeamAPITestCase):
         )
 
     def test_duplicates_and_nontopic_private_teamsets(self):
+        """
+        Test for a bug where non-admin users would have their private memberships returned from this endpoint
+        despite the topic, and duplicate entries for teams in the topic that was being queried (EDUCATOR-5042)
+        """
         # create a team in a private teamset and add a user
         unprotected_team_in_private_teamset = CourseTeamFactory.create(
             name='unprotected_team_in_private_teamset',


### PR DESCRIPTION
[EDUCATOR 5042: Learner's Private Team Appears When Learner Browses all Team Sets](https://openedx.atlassian.net/browse/EDUCATOR-5042)
@edx/masters-devs-gta 

If a user who was 
1- not staff 
2- enrolled in a private team
navigated to the 'browse' tab and went to any topic, they would always see their private team, no matter which teamset they were looking at.

This was caused by my attempt to filter out private teams from the TeamsListView. I `or`ed two QuerySets, thinking that it would create a queryset that contained the Teams contained within both querysets. That's not what that does! It creates a new Queryet, that `or`s together the queries and re-evaluates that query. In this case, it resulted in a query that not only always returned your private team memberships, but also returned multiples of each team in the teamset you were looking at. Specifically, it returned one copy per member of that team. To be honest, i'm not 100% sure why (other than "some sql `join` shenanegans"). This wasn't ever noticed, because hey, the Teams backbone app handled that weird behavior perfectly.

Anyway, I changed the logic to be much simpler and we now no longer have to deal with this.