### PR TITLE
remove old_format from team config tests

### DIFF
--- a/common/lib/xmodule/xmodule/tests/test_course_module.py
+++ b/common/lib/xmodule/xmodule/tests/test_course_module.py
@@ -295,7 +295,13 @@ class TeamsConfigurationTestCase(unittest.TestCase):
         topic_id = "topic_id_{}".format(next_num)
         name = "Name {}".format(next_num)
         description = "Description {}".format(next_num)
-        return {"name": name, "description": description, "id": topic_id}
+        return {
+            "name": name,
+            "description": description,
+            "id": topic_id,
+            "type": "open",
+            "max_team_size": None
+        }
 
     def test_teams_enabled_new_course(self):
         # Make sure we can detect when no teams exist.
@@ -341,7 +347,7 @@ class TeamsConfigurationTestCase(unittest.TestCase):
         self.add_team_configuration(max_team_size=4, topics=topics)
         self.assertTrue(self.course.teams_enabled)
         expected_teamsets_data = [
-            teamset.cleaned_data_old_format
+            teamset.cleaned_data
             for teamset in self.course.teamsets
         ]
         self.assertEqual(expected_teamsets_data, topics)

--- a/lms/djangoapps/teams/tests/test_serializers.py
+++ b/lms/djangoapps/teams/tests/test_serializers.py
@@ -198,7 +198,7 @@ class BaseTopicSerializerTestCase(SerializerTestCase):
         """
         with self.assertNumQueries(num_queries):
             page = Paginator(
-                self.course.teams_configuration.cleaned_data_old_format['topics'],
+                self.course.teams_configuration.cleaned_data['teamsets'],
                 self.PAGE_SIZE,
             ).page(1)
             # pylint: disable=not-callable

--- a/openedx/core/lib/teams_config.py
+++ b/openedx/core/lib/teams_config.py
@@ -84,21 +84,6 @@ class TeamsConfig(object):
             ]
         }
 
-    @cached_property
-    def cleaned_data_old_format(self):
-        """
-        JSON-friendly dictionary containing cleaned data from this TeamsConfig,
-        excluding newly added fields.
-
-        Here for backwards compatibility; to be removed (TODO MST-40).
-        """
-        return {
-            'max_team_size': self.default_max_team_size,
-            'topics': [
-                teamset.cleaned_data_old_format for teamset in self.teamsets
-            ]
-        }
-
     @property
     def is_enabled(self):
         """
@@ -244,20 +229,6 @@ class TeamsetConfig(object):
             'description': self.description,
             'max_team_size': self.max_team_size,
             'type': self.teamset_type.value,
-        }
-
-    @cached_property
-    def cleaned_data_old_format(self):
-        """
-        JSON-friendly dictionary containing cleaned data from this TeamsConfig,
-        excluding newly added fields.
-
-        Here for backwards compatibility; to be removed (TODO MST-40).
-        """
-        return {
-            'id': self.teamset_id,
-            'name': self.name,
-            'description': self.description,
         }
 
     @cached_property


### PR DESCRIPTION
Update tests that reference the teams config `cleaned_data_old_format`.
Updated mock teamset shape to update new format.
Re: EDUCATOR-4956
@edx/masters-devs-gta