### PR TITLE
AA-152: Course Start Date for PLS

### DIFF
--- a/lms/djangoapps/courseware/date_summary.py
+++ b/lms/djangoapps/courseware/date_summary.py
@@ -248,7 +248,11 @@ class CourseStartDate(DateSummary):
 
     @property
     def date(self):
-        return self.course.start
+        if not self.course.self_paced:
+            return self.course.start
+        else:
+            enrollment = CourseEnrollment.get_enrollment(self.user, self.course_id)
+            return max(enrollment.created, self.course.start) if enrollment else self.course.start
 
     @property
     def date_type(self):

--- a/lms/templates/dashboard/_dashboard_course_listing.html
+++ b/lms/templates/dashboard/_dashboard_course_listing.html
@@ -108,6 +108,7 @@ from util.course import get_link_for_about_page, get_encoded_course_sharing_utm_
           <span class="info-university">${course_overview.display_org_with_default} - </span>
           <span class="info-course-id">${course_overview.display_number_with_default}</span>
           <%
+            enrollment_date = course_overview.self_paced and enrollment and enrollment.created
             if course_overview.start_date_is_still_default:
                 container_string = _("Coming Soon")
                 course_date = None
@@ -118,7 +119,7 @@ from util.course import get_link_for_about_page, get_encoded_course_sharing_utm_
                     course_date = course_overview.end
                 elif course_overview.has_started():
                     container_string = _("Started - {date}")
-                    course_date = course_overview.dashboard_start_display
+                    course_date = enrollment_date or course_overview.dashboard_start_display
                 elif course_overview.starts_within(days=5):
                     container_string = _("Starts - {date}")
                     course_date = course_overview.dashboard_start_display


### PR DESCRIPTION
Updated the displayed start date for a learner in a self paced course
that appears in the Learner Dashboard and the Dates tab.
Used the max of the course start date and the learner's enrollment date