### PR TITLE
EDUCATOR-5053

### DIFF
--- a/lms/djangoapps/teams/tests/test_views.py
+++ b/lms/djangoapps/teams/tests/test_views.py
@@ -821,6 +821,15 @@ class TestListTeamsAPI(EventTestMixin, TeamAPITestCase):
         self.assertEqual('private_topic_1_id', result['results'][0]['topic_id'])
         self.assertNotEqual([], result['results'])
 
+    def test_course_staff_getting_information_on_private_topic(self):
+        """
+        Verifies that when an admin browses to a private team set,
+         information about the teams in the teamset is returned even if the admin is not in any teams.
+        """
+        result = self.get_teams_list(data={'topic_id': 'private_topic_1_id'},
+                                     user='course_staff')
+        self.assertEqual(2, len(result['results']))
+
     @ddt.unpack
     @ddt.data(
         ('student_masters_not_on_team', 1),

--- a/lms/djangoapps/teams/views.py
+++ b/lms/djangoapps/teams/views.py
@@ -436,8 +436,10 @@ class TeamsListView(ExpandableFieldViewMixin, GenericAPIView):
                 )
                 return Response(error, status=status.HTTP_400_BAD_REQUEST)
 
-            if course_module.teamsets_by_id[topic_id].is_private_managed:
+            if course_module.teamsets_by_id[topic_id].is_private_managed \
+                    and not has_access(request.user, 'staff', course_key):
                 result_filter.update({'membership__user__username': request.user})
+
             result_filter.update({'topic_id': topic_id})
 
         organization_protection_status = user_organization_protection_status(


### PR DESCRIPTION
[Jira](https://openedx.atlassian.net/browse/EDUCATOR-5053)
Allow staff to see all teams in a private team set even without belonging to those teams.
@edx/masters-devs-gta 