### PR TITLE
Hide financial assistance link for two cases

### DIFF
--- a/lms/djangoapps/courseware/course_tools.py
+++ b/lms/djangoapps/courseware/course_tools.py
@@ -114,8 +114,14 @@ class FinancialAssistanceTool(CourseTool):
         if not request.user or not CourseEnrollment.is_enrolled(request.user, course_key):
             return False
 
-        # hide if there's no course_upgrade_deadline, or one with a value in the past
         enrollment = CourseEnrollment.get_enrollment(request.user, course_key)
+
+        # hide if we're no longer in an upsell mode (already upgraded)
+        if enrollment.mode not in CourseMode.UPSELL_TO_VERIFIED_MODES:
+            return False
+
+        # (Confirm: this block may no longer be needed once we're checking UPSELL_TO_VERIFIED_MODES)
+        # hide if there's no course_upgrade_deadline, or one with a value in the past
         if enrollment.course_upgrade_deadline:
             if now > enrollment.course_upgrade_deadline:
                 return False

--- a/lms/djangoapps/courseware/course_tools.py
+++ b/lms/djangoapps/courseware/course_tools.py
@@ -119,9 +119,9 @@ class FinancialAssistanceTool(CourseTool):
         if enrollment.course_upgrade_deadline:
             if now > enrollment.course_upgrade_deadline:
                 return False
-        else: 
-           return False
-        
+        else:
+            return False
+
         return bool(course_overview.eligible_for_financial_aid)
 
     @classmethod

--- a/lms/djangoapps/courseware/course_tools.py
+++ b/lms/djangoapps/courseware/course_tools.py
@@ -120,7 +120,6 @@ class FinancialAssistanceTool(CourseTool):
         if enrollment.mode not in CourseMode.UPSELL_TO_VERIFIED_MODES:
             return False
 
-        # (Confirm: this block may no longer be needed once we're checking UPSELL_TO_VERIFIED_MODES)
         # hide if there's no course_upgrade_deadline, or one with a value in the past
         if enrollment.course_upgrade_deadline:
             if now > enrollment.course_upgrade_deadline:

--- a/lms/djangoapps/courseware/course_tools.py
+++ b/lms/djangoapps/courseware/course_tools.py
@@ -114,12 +114,14 @@ class FinancialAssistanceTool(CourseTool):
         if not request.user or not CourseEnrollment.is_enrolled(request.user, course_key):
             return False
 
-        # hide if there's a course_upgrade_enrollment in the past
+        # hide if there's no course_upgrade_deadline, or one with a value in the past
         enrollment = CourseEnrollment.get_enrollment(request.user, course_key)
         if enrollment.course_upgrade_deadline:
             if now > enrollment.course_upgrade_deadline:
                 return False
-
+        else: 
+           return False
+        
         return bool(course_overview.eligible_for_financial_aid)
 
     @classmethod

--- a/lms/djangoapps/courseware/tests/test_course_tools.py
+++ b/lms/djangoapps/courseware/tests/test_course_tools.py
@@ -163,7 +163,6 @@ class FinancialAssistanceToolTest(SharedModuleStoreTestCase):
         self.enrollment_deadline_missing.course_upgrade_deadline = None
         self.enrollment_deadline_missing.save()
 
-
     def test_tool_visible_logged_in(self):
         self.course_financial_mode.save()
         self.assertTrue(FinancialAssistanceTool().is_enabled(self.request, self.course.id))

--- a/lms/djangoapps/courseware/tests/test_course_tools.py
+++ b/lms/djangoapps/courseware/tests/test_course_tools.py
@@ -175,7 +175,7 @@ class FinancialAssistanceToolTest(SharedModuleStoreTestCase):
     def test_not_visible_when_upgrade_deadline_has_passed(self, get_enrollment_mock):
         get_enrollment_mock.return_value = self.enrollment_deadline_past
         self.assertFalse(FinancialAssistanceTool().is_enabled(self.request, self.course.id))
-        
+
     # mock the response from get_enrollment to use enrollment with no course_upgrade_deadline
     @patch('lms.djangoapps.courseware.course_tools.CourseEnrollment.get_enrollment')
     def test_not_visible_when_no_upgrade_deadline(self, get_enrollment_mock):

--- a/lms/djangoapps/courseware/tests/test_course_tools.py
+++ b/lms/djangoapps/courseware/tests/test_course_tools.py
@@ -137,14 +137,24 @@ class FinancialAssistanceToolTest(SharedModuleStoreTestCase):
         self.request = RequestFactory().request()
         crum.set_current_request(self.request)
         self.addCleanup(crum.set_current_request, None)
+
+        # baseline course enrollment, future upgrade deadline
         self.enrollment = CourseEnrollmentFactory(
             course_id=self.course.id,
             mode=CourseMode.AUDIT,
             course=self.course_overview,
         )
         self.request.user = self.enrollment.user
-        self.enrollment.course_upgrade_deadline = self.now - datetime.timedelta(days=1)
-        self.enrollment.save()
+
+        # course enrollment for mock: upgrade deadline in the past
+        self.enrollment_deadline_past = self.enrollment
+        self.enrollment_deadline_past.course_upgrade_deadline = self.now - datetime.timedelta(days=1)
+        self.enrollment_deadline_past.save()
+
+        # course enrollment for mock: no upgrade deadline
+        self.enrollment_deadline_missing = self.enrollment
+        self.enrollment_deadline_missing.course_upgrade_deadline = None
+        self.enrollment_deadline_missing.save()
 
     def test_tool_visible_logged_in(self):
         self.course_financial_mode.save()
@@ -163,7 +173,13 @@ class FinancialAssistanceToolTest(SharedModuleStoreTestCase):
     # mock the response from get_enrollment to use enrollment with course_upgrade_deadline in the past
     @patch('lms.djangoapps.courseware.course_tools.CourseEnrollment.get_enrollment')
     def test_not_visible_when_upgrade_deadline_has_passed(self, get_enrollment_mock):
-        get_enrollment_mock.return_value = self.enrollment
+        get_enrollment_mock.return_value = self.enrollment_deadline_past
+        self.assertFalse(FinancialAssistanceTool().is_enabled(self.request, self.course.id))
+        
+    # mock the response from get_enrollment to use enrollment with no course_upgrade_deadline
+    @patch('lms.djangoapps.courseware.course_tools.CourseEnrollment.get_enrollment')
+    def test_not_visible_when_no_upgrade_deadline(self, get_enrollment_mock):
+        get_enrollment_mock.return_value = self.enrollment_deadline_missing
         self.assertFalse(FinancialAssistanceTool().is_enabled(self.request, self.course.id))
 
     def test_tool_not_visible_when_end_date_passed(self):


### PR DESCRIPTION
REV-1191: hide the financial assistance link for two cases: 
- if there's no upgrade deadline (free courses don't have one)
- if the learner has already upgraded

https://openedx.atlassian.net/browse/REV-1191