### PR TITLE
[CRI-174] [BB-2402] Fix LTI issues due to duplicated Content-Length header

### DIFF
--- a/lms/djangoapps/lti_provider/outcomes.py
+++ b/lms/djangoapps/lti_provider/outcomes.py
@@ -168,7 +168,8 @@ def sign_and_send_replace_result(assignment, xml):
         consumer_key,
         consumer_secret,
         signature_method='HMAC-SHA1',
-        force_include_body=True
+        force_include_body=True,
+        decoding=None,
     )
 
     headers = {'content-type': 'application/xml'}


### PR DESCRIPTION
The `python-swiftclient` library automatically [monkeypatches the code in the requests library](https://opendev.org/openstack/python-swiftclient/src/branch/master/swiftclient/client.py#L84-L93) if it is imported. It replaces the requests library's code for preparing in a header such that headers are no longer coerced to the native string format in Python. 

This worked fine in Python 2 but in Python 3 it causes a duplicate Content-Length header to be inserted, one with the header key as b'Content-Length' and the other as u'Content-Length'. The OAuth1 code creates the headers as bytes, while the requests library inserts the same header as unicode. With the [unpatched requests `prepare_headers` code](https://github.com/psf/requests/blob/c7e0fc087ceeadb8b4c84a0953a422c474093d6d/requests/models.py#L442-L451) they would be both be coorced to unicode, however the patched version doesn't do that, causing the duplicate header. 

This change indirectly solves this issue in this particular case by setting the `decoding` parameter to `None` thus skipping the unicode->bytes conversion of headers in [this step|https://github.com/oauthlib/oauthlib/blob/575638ce7ddb8727e08980235ccd82152af85703/oauthlib/oauth1/rfc5849/__init__.py#L320-L327]. 

The swiftclient library is indirectly imported by ORA2.

**JIRA tickets**: CRI-174

**Discussions**: https://openedx.slack.com/archives/CSAC4QHC7/p1589887829057500?thread_ts=1589809391.048800&cid=CSAC4QHC7

**Sandbox URL**: TBD - sandbox is being provisioned.

**Merge deadline**: ASAP

**Testing instructions**:

1. [Set up LTI on the Open edX LMS](https://edx.readthedocs.io/projects/edx-installing-configuring-and-running/en/latest/configuration/lti/)
2. Configure an LTI embed in an external LMS, or just use [this tool](https://lti.tools/saltire/) for testing.
3. Embed a graded problem/section of a course. 
4. Submit the problem in the external LMS or test tool.
5. Check that the grade has been correctly applied. 

**Author notes and concerns**:
This doesn't really fix the monkey-patching and I'm not entirely clear if it's necessary anymore. That history needs to be investigated I guess. 

The only case I've found for duplicate headers so far is for Content-Length since in the case of certain kinds of auth, that is calculated twice, and appended twice. Normally the second time overwrites the first, but here it was one because one was added as bytes and the other as unicode. Could there be other cases or uses where this error will crop up?

**Reviewers**
- [ ] @giovannicimolin 
- [ ] edX reviewer[s] TBD

**Settings**
```yaml
EDXAPP_FEATURES:
  ENABLE_COMBINED_LOGIN_REGISTRATION: true
  ENABLE_LTI_PROVIDER: true
```