### PR TITLE
[BD-10] Add uses_pattern_library property to EdxFragmentView

### DIFF
--- a/openedx/core/djangoapps/plugin_api/views.py
+++ b/openedx/core/djangoapps/plugin_api/views.py
@@ -21,6 +21,7 @@ class EdxFragmentView(FragmentView):
     The base class of all Open edX fragment views.
     """
     page_title = None
+    _uses_pattern_library = True
 
     @staticmethod
     def get_css_dependencies(group):
@@ -84,7 +85,8 @@ class EdxFragmentView(FragmentView):
         Creates the base context for rendering a fragment as a standalone page.
         """
         return {
-            'uses_pattern_library': True,
+            'uses_pattern_library': self.uses_pattern_library,
+            'uses_bootstrap': not self.uses_pattern_library,
             'disable_accordion': True,
             'allow_iframing': True,
             'disable_header': True,
@@ -140,3 +142,10 @@ class EdxFragmentView(FragmentView):
             template = 'fragments/standalone-page-v1.html'
 
         return render_to_response(template, context)
+
+    @property
+    def uses_pattern_library(self):
+        """
+        Returns true if this fragment is rendered with edx-pattern-library.
+        """
+        return self._uses_pattern_library


### PR DESCRIPTION
Create uses_pattern_library property in EdxFragmentViews in use that to create the base context of the templates in the standalone version of the fragment.

With this change, the only thing that we need to change the uses_pattern_library configuration in the context is to add `_uses_pattern_library = False` to the class. 

This should be removed once we remove completely the usage of pattern library

### Possible problems: 
I called this uses_pattern_library instead of uses_bootstrap because there is a method in the CourseTabView fragment called [uses_bootstrap](https://github.com/edx/edx-platform/blob/d95e8724d8a6d9742c86996b4a5efe4f1a750342/lms/djangoapps/courseware/views/views.py#L710), that checks for the [uses_bootstrap property](https://github.com/edx/edx-platform/blob/972c7f3bc1594fc11f367fb2fffd7ced29b7bf00/common/lib/xmodule/xmodule/tabs.py#L115) of the tab.

## Reviewers
- [ ] @felipemontoya 
- [ ]  @amalbas 