### PR TITLE
[BD-10] [DEPR-83] Remove course_experience.use_bootstrap waffle flag

### DIFF
--- a/openedx/features/course_experience/__init__.py
+++ b/openedx/features/course_experience/__init__.py
@@ -72,9 +72,6 @@ UPGRADE_DEADLINE_MESSAGE = CourseWaffleFlag(WAFFLE_FLAG_NAMESPACE, 'upgrade_dead
 # .. toggle_status: supported
 LATEST_UPDATE_FLAG = CourseWaffleFlag(WAFFLE_FLAG_NAMESPACE, 'latest_update')
 
-# Waffle flag to enable the use of Bootstrap for course experience pages
-USE_BOOTSTRAP_FLAG = CourseWaffleFlag(WAFFLE_FLAG_NAMESPACE, 'use_bootstrap', flag_undefined_default=True)
-
 # Waffle flag to enable anonymous access to a course
 SEO_WAFFLE_FLAG_NAMESPACE = WaffleFlagNamespace(name='seo')
 COURSE_ENABLE_UNENROLLED_ACCESS_FLAG = CourseWaffleFlag(SEO_WAFFLE_FLAG_NAMESPACE, 'enable_anonymous_courseware_access')

--- a/openedx/features/course_experience/views/course_home.py
+++ b/openedx/features/course_experience/views/course_home.py
@@ -41,7 +41,6 @@ from .. import (
     COURSE_ENABLE_UNENROLLED_ACCESS_FLAG,
     LATEST_UPDATE_FLAG,
     SHOW_UPGRADE_MSG_ON_COURSE_HOME,
-    USE_BOOTSTRAP_FLAG
 )
 from ..utils import get_course_outline_block_tree, get_resume_block
 from .course_dates import CourseDatesFragmentView
@@ -71,9 +70,9 @@ class CourseHomeView(CourseTabView):
 
     def uses_bootstrap(self, request, course, tab):
         """
-        Returns true if the USE_BOOTSTRAP Waffle flag is enabled.
+        Always render this tab with bootstrap.
         """
-        return USE_BOOTSTRAP_FLAG.is_enabled(course.id)
+        return True
 
     def render_to_fragment(self, request, course=None, tab=None, **kwargs):
         course_id = six.text_type(course.id)

--- a/openedx/features/course_experience/views/course_reviews.py
+++ b/openedx/features/course_experience/views/course_reviews.py
@@ -19,8 +19,6 @@ from openedx.core.djangoapps.plugin_api.views import EdxFragmentView
 from openedx.features.course_experience import default_course_url_name
 from student.models import CourseEnrollment
 
-from .. import USE_BOOTSTRAP_FLAG
-
 
 class CourseReviewsView(CourseTabView):
     """
@@ -36,9 +34,9 @@ class CourseReviewsView(CourseTabView):
 
     def uses_bootstrap(self, request, course, tab):
         """
-        Returns true if the USE_BOOTSTRAP Waffle flag is enabled.
+        Always render this tab with bootstrap.
         """
-        return USE_BOOTSTRAP_FLAG.is_enabled(course.id)
+        return True
 
     def render_to_fragment(self, request, course=None, tab=None, **kwargs):
         course_id = six.text_type(course.id)

--- a/openedx/features/course_experience/views/course_updates.py
+++ b/openedx/features/course_experience/views/course_updates.py
@@ -20,8 +20,6 @@ from lms.djangoapps.courseware.views.views import CourseTabView
 from openedx.core.djangoapps.plugin_api.views import EdxFragmentView
 from openedx.features.course_experience import default_course_url_name
 
-from .. import USE_BOOTSTRAP_FLAG
-
 STATUS_VISIBLE = 'visible'
 STATUS_DELETED = 'deleted'
 
@@ -68,9 +66,9 @@ class CourseUpdatesView(CourseTabView):
 
     def uses_bootstrap(self, request, course, tab):
         """
-        Returns true if the USE_BOOTSTRAP Waffle flag is enabled.
+        Always render this tab with bootstrap.
         """
-        return USE_BOOTSTRAP_FLAG.is_enabled(course.id)
+        return True
 
     def render_to_fragment(self, request, course=None, tab=None, **kwargs):
         course_id = six.text_type(course.id)


### PR DESCRIPTION
Related to https://openedx.atlassian.net/browse/DEPR-83.

This PRs deletes course_experience.use_bootstrap and removes all the non-bootstrap path. 

Now bootstrap always is enabled  in course experience pages.

## Reviewers
- [ ] @amalbas 
- [x] @abutterworth 