### PR TITLE
[BD-10] [DEPR-70] Remove pattern library of discussion/views.py

### DIFF
--- a/common/static/common/templates/discussion/templates.underscore
+++ b/common/static/common/templates/discussion/templates.underscore
@@ -140,7 +140,7 @@
         <input id='edit-discussion-forum-title' aria-describedby="field_help_title" type="text" class="edit-post-title field-input" name="title" value="<%- title %>">
     </label>
 </div>
-<div class="form-row post-field">
+<div class="post-field">
     <p class="sr-only field-help" id="edit-post-editor-description"><%- gettext('Edit your post below.') %></p>
     <div class="edit-post-body" aria-describedby="edit-post-editor-description" name="body"><%- body %></div>
 </div>
@@ -241,9 +241,7 @@
 <div class="edit-post-form">
     <h<%- startHeader %>><%- gettext("Editing response") %></h<%- startHeader %>>
     <ul class="edit-post-form-errors"></ul>
-    <div class="form-row">
-        <div class="edit-post-body" name="body" data-id="<%- id %>"><%- body %></div>
-    </div>
+      <div class="edit-post-body" name="body" data-id="<%- id %>"><%- body %></div>
     <button type="submit" id="edit-response-submit"class="btn btn-primary post-update"><%- gettext("Update response") %></button>
     <button class="btn btn-outline-primary post-cancel"><%- gettext("Cancel") %></button>
 </div>
@@ -290,9 +288,7 @@
 <div class="edit-post-form" id="comment_<%- id %>">
     <h<%- startHeader %> ><%- gettext("Editing comment") %></h<%- startHeader%>>
     <ul class="edit-comment-form-errors"></ul>
-    <div class="form-row">
-        <div class="edit-comment-body" name="body" data-id="<%- id %>"><%- body %></div>
-    </div>
+      <div class="edit-comment-body" name="body" data-id="<%- id %>"><%- body %></div>
     <button type="submit" id="edit-comment-submit" class="btn btn-primary post-update"><%- gettext("Update comment") %></button>
     <button class="btn btn-outline-primary post-cancel"><%- gettext("Cancel") %></button>
 </div>

--- a/lms/djangoapps/discussion/views.py
+++ b/lms/djangoapps/discussion/views.py
@@ -697,6 +697,8 @@ class DiscussionBoardFragmentView(EdxFragmentView):
     """
     Component implementation of the discussion board.
     """
+    _uses_pattern_library = False
+
     def render_to_fragment(
         self,
         request,
@@ -760,7 +762,7 @@ class DiscussionBoardFragmentView(EdxFragmentView):
             log.warning('Forum is in maintenance mode')
             html = render_to_string('discussion/maintenance_fragment.html', {
                 'disable_courseware_js': True,
-                'uses_pattern_library': True,
+                'uses_bootstrap': True,
             })
             fragment = Fragment(html)
             self.add_fragment_resource_urls(fragment)
@@ -774,7 +776,7 @@ class DiscussionBoardFragmentView(EdxFragmentView):
             )
             html = render_to_string('discussion/discussion_private_fragment.html', {
                 'disable_courseware_js': True,
-                'uses_pattern_library': True,
+                'uses_bootstrap': True,
             })
             fragment = Fragment(html)
             self.add_fragment_resource_urls(fragment)

--- a/lms/static/sass/bootstrap/_components.scss
+++ b/lms/static/sass/bootstrap/_components.scss
@@ -45,3 +45,57 @@
   text-decoration: underline;
   font-weight: bold;
 }
+
+.alert-error {
+  box-shadow: inset 0 0 0 4px $palette-error-back;
+
+  .alert-copy:last-child {
+    margin-bottom: 0;
+  }
+}
+
+.alert-error .alert-icon {
+  align-self: center;
+  color: $white;
+  background-color: $palette-error-accent;
+  display: none;
+  border-radius: 50%;
+  padding: 0.625rem;
+
+  @include media-breakpoint-up(md) {
+    display: block;
+  }
+}
+
+.alert-message-with-action {
+  @include media-breakpoint-up(md) {
+    width: 80%;
+    padding: 1.25rem;
+    padding-top: 0;
+    padding-bottom: 0;
+  }
+
+  .alert-copy {
+    display: inline-block;
+    vertical-align: sub;
+  }
+}
+
+// Discussion
+.discussion {
+  .btn-link {
+    border-color: transparent
+  }
+
+  .breadcrumbs {
+    font-size: 0.875rem;
+
+    .all-topics {
+      border: none;
+    }
+  }
+
+  .field-label-text {
+    font-size: 1rem
+  }
+}

--- a/lms/static/sass/bootstrap/_legacy.scss
+++ b/lms/static/sass/bootstrap/_legacy.scss
@@ -143,6 +143,9 @@ $state-danger-text: $black !default;
 $state-danger-bg: #f2dede !default;
 $state-danger-border: darken($state-danger-bg, 5%) !default;
 
+$palette-error-accent: #cb0712;
+$palette-error-back: #feeced;
+
 // logo colors
 $micromasters-color: #005585 !default;
 $zebra-stripe-color: rgb(249, 250, 252) !default;


### PR DESCRIPTION
@abutterworth 
Ticket on jira: https://openedx.atlassian.net/browse/DEPR-70
Remove use of pattern library on lms/djangoapps/discussion/views.py and use bootstrap. 
To work properly need the changes of this PR: https://github.com/edx/edx-platform/pull/24027
It's tested on mobile and RTL content.
![discussionBoardPatternLibrary](https://user-images.githubusercontent.com/36944773/82379167-12810b80-99ec-11ea-9bfd-fe1fd6da3776.jpg)
![discussionBoardBoostrap](https://user-images.githubusercontent.com/36944773/82379172-157bfc00-99ec-11ea-92d1-26d885394abe.jpg)
![AddPostPatternLibrary](https://user-images.githubusercontent.com/36944773/82379178-17de5600-99ec-11ea-9276-fa0dc4a34a39.jpg)
![AddPostBootstrap](https://user-images.githubusercontent.com/36944773/82379179-19a81980-99ec-11ea-9536-d05fcba22464.jpg)
![privateDiscPatternLibrary](https://user-images.githubusercontent.com/36944773/82379186-1ca30a00-99ec-11ea-9bd8-bd13c451fb1c.jpg)
![private-bootstrap](https://user-images.githubusercontent.com/36944773/83561729-ee3e2800-a4dd-11ea-945e-b3e3bb94db75.jpg)
![maintenancePatternLibrary](https://user-images.githubusercontent.com/36944773/82379207-24fb4500-99ec-11ea-908f-01ffa1b4f970.jpg)
![maintenance-bootstrap](https://user-images.githubusercontent.com/36944773/83561741-f302dc00-a4dd-11ea-91cb-3833f59f5aa8.jpg)

