### PR TITLE
ARCHBOM-1236: split new relic app

### DIFF
--- a/docs/decisions/0005-split-newrelic-app.rst
+++ b/docs/decisions/0005-split-newrelic-app.rst
@@ -19,7 +19,7 @@ Decision
 
 We will employ a "hacked" solution to set the NewRelic app name per transaction. This is considered a reasonable "hack" by NewRelic, but NewRelic dashboards are their more general recommendation.
 
-We will define the mappings from request path to new app name in code. This mapping handler can be configured using a new setting, ``NEWRELIC_PATH_TO_APP_NAME_SUFFIX_HANDLER``.  The handler should take a request path and return None for the default mapping, or a suffix to be appended to the default app name. Providing the mapping as a setting enables quick rollback, and enables mapping overrides for the Open edX community.
+We will define the mappings from request path to new app name in code using a configurable mapping handler function. This mapping handler can be configured using a new setting, ``NEWRELIC_PATH_TO_APP_NAME_SUFFIX_HANDLER``, which will contain a string path to the handler function. The handler will take a request path and return None for the default mapping, or a suffix to be appended to the default app name. Providing the mapping as a setting enables quick rollback, and enables alternate mapping overrides for the Open edX community.
 
 Consequences
 ============
@@ -28,13 +28,15 @@ In order for this solution to work, we must disable gunicorn instrumentation. Th
 
 Additionally, the mapping code from request path to NewRelic app name happens before the transaction is initiated, and the time taken for the mapping is **not** accounted for in the transaction time. We will ensure this code performs well via unit tests.
 
+By allowing the mapping handler to only return a suffix, it means that the original app name will be used as part of the final app name.
+
 Rejected Alternatives
 =====================
 
-Defining mapping code in config
--------------------------------
+Defining mapping in config
+--------------------------
 
-Defining the mapping code in code, rather than in config directly, has the following pros/cons::
+An alternative to providing mappings through a handler function could have been to provide the mapping in configuration as a list of regex strings and their corresponding suffix. The proposed solution of defining the mappings through a handler function has the following pros/cons:
 
 **Pros:**
 

--- a/docs/decisions/0005-split-newrelic-app.rst
+++ b/docs/decisions/0005-split-newrelic-app.rst
@@ -1,0 +1,60 @@
+Split NewRelic App
+******************
+
+Status
+======
+
+Accepted
+
+Context
+=======
+
+When using NewRelic, edx-platform as a monolithic APM app has the following issues:
+
+* Errors or other data can get lost in Overview due to the number of different types of transactions
+* Overview is not helpful for most teams that care about different parts of the app.
+
+Decision
+========
+
+We will employ a "hacked" solution to set the NewRelic app name per transaction. This is considered a reasonable "hack" by NewRelic, but NewRelic dashboards are their more general recommendation.
+
+We will define the mappings from request path to new app name in code. This mapping handler can be configured using a new setting, ``NEWRELIC_PATH_TO_APP_NAME_SUFFIX_HANDLER``.  The handler should take a request path and return None for the default mapping, or a suffix to be appended to the default app name. Providing the mapping as a setting enables quick rollback, and enables mapping overrides for the Open edX community.
+
+Consequences
+============
+
+In order for this solution to work, we must disable gunicorn instrumentation. This prevents the transaction and app name from being set before reaching Django. This means that NewRelic will no longer provide data for gunicorn, and we will need to ensure that this data is monitored appropriately in other ways.
+
+Additionally, the mapping code from request path to NewRelic app name happens before the transaction is initiated, and the time taken for the mapping is **not** accounted for in the transaction time. We will ensure this code performs well via unit tests.
+
+Rejected Alternatives
+=====================
+
+Defining mapping code in config
+-------------------------------
+
+Defining the mapping code in code, rather than in config directly, has the following pros/cons::
+
+**Pros:**
+
+* Enables unit tests for correctness
+* Enables unit test for performance of mapping code
+* Uses simple config (i.e. a string, rather than a complex object)
+
+**Cons:**
+
+* Updated mapping requires code change rather than config change
+* Enabling rollback requires multiple mapping handlers
+
+Defining mapping during routing
+-------------------------------
+
+In the future, with Kubernetes, it may make sense to provide this mapping in the same place as other url routing. We could consider spinning up different containers for each desired mapping, which would enable gunicorn intrumentation, and might be closer to a more traditional use of NewRelic.
+
+Because we are not yet using Kubernetes, this type of solution is premature at this time.
+
+Using NewRelic custom dashboards
+--------------------------------
+
+The out-of-the-box dashboard for NewRelic APM provides us much of what we need today with no additional work. There are some features of NewRelic that can only be done at the application level, like bounded alerts. In the future, as we get better at other types of alerting and creating custom dashboards, we can revisit this decision if necessary.

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -3916,3 +3916,17 @@ GITHUB_REPO_ROOT = '/edx/var/edxapp/data'
 
 ##################### SUPPORT URL ############################
 SUPPORT_HOW_TO_UNENROLL_LINK = ''
+
+################### MONITORING ###############################
+# .. toggle_name: NEWRELIC_PATH_TO_APP_NAME_SUFFIX_HANDLER
+# .. toggle_implementation: DjangoSetting
+# .. toggle_default: None
+# .. toggle_description: Dot notation path to a function that maps request paths to a NewRelic app name suffix.
+# .. toggle_category: monitoring
+# .. toggle_use_cases: open_edx, incremental_release
+# .. toggle_creation_date: 2020-05-26
+# .. toggle_expiration_date: None
+# .. toggle_tickets: None
+# .. toggle_status: supported
+# .. toggle_warnings: None
+NEWRELIC_PATH_TO_APP_NAME_SUFFIX_HANDLER = None

--- a/lms/lib/edx_customizations.py
+++ b/lms/lib/edx_customizations.py
@@ -1,0 +1,36 @@
+"""
+Edx customizations for the LMS.
+
+Note: In order to enable rollout of new mappings from request path to
+  NewRelic app name suffix via config, this module may contain multiple
+  implementations (the current and the last).  This enables quick rollback
+  via config.
+
+TODO: Move this file out of edx-platform and into a plugin.
+
+"""
+import re
+from enum import Enum
+
+
+class AppNameSuffix(Enum):
+    bom_squad = 'bom-squad'
+
+
+SINGLE_REQUEST_PATH_REGEX_TO_SUFFIX_MAPPINGS = [
+    # /api-admin/api/v1/api_access_request/
+    (re.compile(r'^\/api-admin\/api\/v1\/api_access_request\/?$'), AppNameSuffix.bom_squad),
+]
+
+
+def newrelic_single_app_name_suffix_handler(request_path):
+    """
+    Takes a request path and returns the mapped NewRelic app name suffix if any is found.
+
+    This implementation has a single mapping for initial rollout testing.
+    """
+    for path_regex, suffix in SINGLE_REQUEST_PATH_REGEX_TO_SUFFIX_MAPPINGS:
+        if path_regex.search(request_path):
+            return suffix.value
+
+    return None

--- a/lms/lib/edx_customizations.py
+++ b/lms/lib/edx_customizations.py
@@ -6,7 +6,20 @@ Note: In order to enable rollout of new mappings from request path to
   implementations (the current and the last).  This enables quick rollback
   via config.
 
-TODO: Move this file out of edx-platform and into a plugin.
+TODO:
+1. Move this file out of edx-platform and into a plugin.
+2. The following may move into an ADR at that time.
+
+Decisions:
+
+* We’ll start with a team-based split of the LMS at first, rather than domain based.
+  * We can always change it to a different orientation if that has issues.
+* All new apps should have apdex and error alerting routed to a team.
+
+Goals:
+
+* Enables simpler alerting and on-call configuration for team ownership inside edx-platform.
+* All parts of edx-platform should be owned and nothing should end up in the default app.
 
 """
 import re

--- a/lms/lib/monitoring.py
+++ b/lms/lib/monitoring.py
@@ -1,0 +1,57 @@
+"""
+Monitoring utilities for the LMS.
+
+Note: In order to enable rollout of new request path to NewRelic app name
+    suffix mappings via config, and simple rollback, this module may
+    contain multiple implementations (the current and the last).
+
+"""
+import logging
+import re
+from enum import Enum
+
+from django.conf import settings
+from django.utils.module_loading import import_string
+
+log = logging.getLogger(__name__)
+
+
+class AppNameSuffix(Enum):
+    bom_squad = 'bom-squad'
+
+
+SINGLE_REQUEST_PATH_REGEX_TO_SUFFIX_MAPPINGS = [
+    # /api-admin/api/v1/api_access_request/
+    (re.compile(r'^\/api-admin\/api\/v1\/api_access_request\/?$'), AppNameSuffix.bom_squad),
+]
+
+
+def newrelic_single_app_name_suffix_handler(request_path):
+    """
+    Takes a request path and returns the mapped NewRelic app name suffix if any is found.
+
+    This implementation has a single mapping for initial rollout testing.
+    """
+    for path_regex, suffix in SINGLE_REQUEST_PATH_REGEX_TO_SUFFIX_MAPPINGS:
+        if path_regex.search(request_path):
+            return suffix.value
+
+    return None
+
+def get_configured_newrelic_app_name_suffix_handler():
+    """
+    Returns configured handler as function, imported from setting, or None if
+    not configured or on import error.
+    """
+    if not settings.NEWRELIC_PATH_TO_APP_NAME_SUFFIX_HANDLER:
+        return None
+
+    try:
+        return import_string(settings.NEWRELIC_PATH_TO_APP_NAME_SUFFIX_HANDLER)
+
+    except ImportError as e:
+        log.error('Could not import NEWRELIC_PATH_TO_APP_NAME_SUFFIX_HANDLER with value %s: %s.' % (
+            settings.NEWRELIC_PATH_TO_APP_NAME_SUFFIX_HANDLER, e
+        ))
+
+    return None

--- a/lms/lib/monitoring.py
+++ b/lms/lib/monitoring.py
@@ -1,42 +1,13 @@
 """
 Monitoring utilities for the LMS.
-
-Note: In order to enable rollout of new request path to NewRelic app name
-    suffix mappings via config, and simple rollback, this module may
-    contain multiple implementations (the current and the last).
-
 """
 import logging
-import re
-from enum import Enum
 
 from django.conf import settings
 from django.utils.module_loading import import_string
 
 log = logging.getLogger(__name__)
 
-
-class AppNameSuffix(Enum):
-    bom_squad = 'bom-squad'
-
-
-SINGLE_REQUEST_PATH_REGEX_TO_SUFFIX_MAPPINGS = [
-    # /api-admin/api/v1/api_access_request/
-    (re.compile(r'^\/api-admin\/api\/v1\/api_access_request\/?$'), AppNameSuffix.bom_squad),
-]
-
-
-def newrelic_single_app_name_suffix_handler(request_path):
-    """
-    Takes a request path and returns the mapped NewRelic app name suffix if any is found.
-
-    This implementation has a single mapping for initial rollout testing.
-    """
-    for path_regex, suffix in SINGLE_REQUEST_PATH_REGEX_TO_SUFFIX_MAPPINGS:
-        if path_regex.search(request_path):
-            return suffix.value
-
-    return None
 
 def get_configured_newrelic_app_name_suffix_handler():
     """

--- a/lms/lib/monitoring.py
+++ b/lms/lib/monitoring.py
@@ -2,9 +2,10 @@
 Monitoring utilities for the LMS.
 """
 import logging
-
+import time
 from django.conf import settings
 from django.utils.module_loading import import_string
+from edx_django_utils.monitoring import set_custom_metric
 
 log = logging.getLogger(__name__)
 
@@ -26,3 +27,36 @@ def get_configured_newrelic_app_name_suffix_handler():
         ))
 
     return None
+
+
+# load and cache the mapping handler
+newrelic_app_name_suffix_handler = get_configured_newrelic_app_name_suffix_handler()
+
+
+def set_new_relic_app_name(environ):
+    """
+    Sets the NewRelic app name based on environ['PATH_INFO'].
+    """
+    if not newrelic_app_name_suffix_handler:
+        return
+    if 'PATH_INFO' not in environ:
+        return
+    if 'newrelic.app_name' not in environ:
+        return
+
+    try:
+        before_time = time.perf_counter()
+        request_path = environ.get('PATH_INFO')
+        suffix = newrelic_app_name_suffix_handler(request_path)
+        if suffix:
+            new_app_name = "{}-{}".format(environ['newrelic.app_name'], suffix)
+            environ['newrelic.app_name'] = new_app_name
+            # We may remove this metric later, but for now, it can be used to confirm that
+            # the updated_app_name matches the app name, and that these set_custom_metric
+            # calls are making it to the appropriate transaction.
+            set_custom_metric('updated_app_name', new_app_name)
+        after_time = time.perf_counter()
+        # Tracking the time can be used to enable alerting if this ever gets too large.
+        set_custom_metric('suffix_mapping_time', round(after_time - before_time, 4))
+    except Exception as e:
+        set_custom_metric('suffix_mapping_error', e)

--- a/lms/lib/tests/test_edx_customizations.py
+++ b/lms/lib/tests/test_edx_customizations.py
@@ -1,0 +1,40 @@
+"""
+Tests for the edX specific customizations of the LMS
+"""
+import ddt
+import timeit
+from unittest import TestCase
+
+from lms.lib.edx_customizations import newrelic_single_app_name_suffix_handler
+
+
+@ddt.ddt
+class EdxCustomizationsTests(TestCase):
+    """
+    Tests for the edX specific customizations for the LMS
+    """
+
+    @ddt.data(
+        ('/api-admin/api/v1/api_access_request', 'bom-squad'),
+        ('/api-admin/api/v1/api_access_request/', 'bom-squad'),
+        ('/api-admin/api/v1/other/', None),
+    )
+    @ddt.unpack
+    def test_newrelic_single_app_name_suffix_handler(self, request_path, expected_suffix):
+        """
+        Tests the mappings from request_path to suffix.
+        """
+        actual_suffix = newrelic_single_app_name_suffix_handler(request_path)
+        self.assertEqual(expected_suffix, actual_suffix)
+
+    def test_unmapped_mapping_handler_speed(self):
+        """
+        Tests the performance of a path that is unmapped.
+
+        Note: This time is unaccounted for in NewRelic, so we need this to be fast.
+            Exactly how fast is another question, so the assertion is flexible.
+        """
+        unmapped_path = '/api-admin/api/v1/api_access_requests'  # Note: 's' at end makes it unmapped
+        self.assertIsNone(newrelic_single_app_name_suffix_handler(unmapped_path))
+        time = timeit.timeit(lambda: newrelic_single_app_name_suffix_handler(unmapped_path), number=1000)
+        self.assertTrue(time < 0.005, 'Mapping is too slow for 1000 transactions.')

--- a/lms/lib/tests/test_monitoring.py
+++ b/lms/lib/tests/test_monitoring.py
@@ -1,14 +1,12 @@
 """
 Tests for the LMS monitoring utilities
 """
-
 import ddt
-import timeit
 from django.test.utils import override_settings
 from mock import patch
 from unittest import TestCase
 
-from lms.lib.monitoring import get_configured_newrelic_app_name_suffix_handler, newrelic_single_app_name_suffix_handler
+from lms.lib.monitoring import get_configured_newrelic_app_name_suffix_handler
 
 
 def mock_test_handler(request_path):
@@ -22,32 +20,6 @@ class MonitoringTests(TestCase):
     """
     Tests for the LMS monitoring utility functions
     """
-
-    @ddt.data(
-        ('/api-admin/api/v1/api_access_request', 'bom-squad'),
-        ('/api-admin/api/v1/api_access_request/', 'bom-squad'),
-        ('/api-admin/api/v1/other/', None),
-    )
-    @ddt.unpack
-    def test_newrelic_single_app_name_suffix_handler(self, request_path, expected_suffix):
-        """
-        Tests the mappings from request_path to suffix.
-        """
-        actual_suffix = newrelic_single_app_name_suffix_handler(request_path)
-        self.assertEqual(expected_suffix, actual_suffix)
-
-    def test_unmapped_mapping_handler_speed(self):
-        """
-        Tests the performance of a path that is unmapped.
-
-        Note: This time is unaccounted for in NewRelic, so we need this to be fast.
-            Exactly how fast is another question, so the assertion is flexible.
-        """
-        unmapped_path = '/api-admin/api/v1/api_access_requests'  # Note: 's' at end makes it unmapped
-        self.assertIsNone(newrelic_single_app_name_suffix_handler(unmapped_path))
-        time = timeit.timeit(lambda: newrelic_single_app_name_suffix_handler(unmapped_path), number=1000)
-        self.assertTrue(time < 0.005, 'Mapping is too slow for 1000 transactions.')
-
     @override_settings(NEWRELIC_PATH_TO_APP_NAME_SUFFIX_HANDLER='lms.lib.tests.test_monitoring.mock_test_handler')
     def test_app_name_suffix_handler_valid_configuration(self):
         """

--- a/lms/lib/tests/test_monitoring.py
+++ b/lms/lib/tests/test_monitoring.py
@@ -1,0 +1,76 @@
+"""
+Tests for the LMS monitoring utilities
+"""
+
+import ddt
+import timeit
+from django.test.utils import override_settings
+from mock import patch
+from unittest import TestCase
+
+from lms.lib.monitoring import get_configured_newrelic_app_name_suffix_handler, newrelic_single_app_name_suffix_handler
+
+
+def mock_test_handler(request_path):
+    """
+    Mock test handler function used to verify configuration, returns the provided path.
+    """
+    return request_path
+
+@ddt.ddt
+class MonitoringTests(TestCase):
+    """
+    Tests for the LMS monitoring utility functions
+    """
+
+    @ddt.data(
+        ('/api-admin/api/v1/api_access_request', 'bom-squad'),
+        ('/api-admin/api/v1/api_access_request/', 'bom-squad'),
+        ('/api-admin/api/v1/other/', None),
+    )
+    @ddt.unpack
+    def test_newrelic_single_app_name_suffix_handler(self, request_path, expected_suffix):
+        """
+        Tests the mappings from request_path to suffix.
+        """
+        actual_suffix = newrelic_single_app_name_suffix_handler(request_path)
+        self.assertEqual(expected_suffix, actual_suffix)
+
+    def test_unmapped_mapping_handler_speed(self):
+        """
+        Tests the performance of a path that is unmapped.
+
+        Note: This time is unaccounted for in NewRelic, so we need this to be fast.
+            Exactly how fast is another question, so the assertion is flexible.
+        """
+        unmapped_path = '/api-admin/api/v1/api_access_requests'  # Note: 's' at end makes it unmapped
+        self.assertIsNone(newrelic_single_app_name_suffix_handler(unmapped_path))
+        time = timeit.timeit(lambda: newrelic_single_app_name_suffix_handler(unmapped_path), number=1000)
+        self.assertTrue(time < 0.005, 'Mapping is too slow for 1000 transactions.')
+
+    @override_settings(NEWRELIC_PATH_TO_APP_NAME_SUFFIX_HANDLER='lms.lib.tests.test_monitoring.mock_test_handler')
+    def test_app_name_suffix_handler_valid_configuration(self):
+        """
+        Tests getting handler with a valid configuration.
+        """
+        returns_path_handler = get_configured_newrelic_app_name_suffix_handler()
+        self.assertEqual(returns_path_handler('/test/path'), '/test/path')
+
+    @override_settings(NEWRELIC_PATH_TO_APP_NAME_SUFFIX_HANDLER='lms.lib.tests.invalid_mock_handler')
+    @patch('lms.lib.monitoring.log')
+    def test_app_name_suffix_handler_invalid_configuration(self, mock_logger):
+        handler = get_configured_newrelic_app_name_suffix_handler()
+        self.assertIsNone(handler)
+        mock_logger.error.assert_called_with(
+            (
+                'Could not import NEWRELIC_PATH_TO_APP_NAME_SUFFIX_HANDLER with value '
+                'lms.lib.tests.invalid_mock_handler: Module "lms.lib.tests" does not '
+                'define a "invalid_mock_handler" attribute/class.'
+            )
+        )
+
+    @patch('lms.lib.monitoring.log')
+    def test_app_name_suffix_handler_no_configuration(self, mock_logger):
+        handler = get_configured_newrelic_app_name_suffix_handler()
+        self.assertIsNone(handler)
+        mock_logger.error.assert_not_called()

--- a/lms/tests.py
+++ b/lms/tests.py
@@ -8,7 +8,6 @@ from django.conf import settings
 from django.test import TestCase
 
 from edxmako import LOOKUP, add_lookup
-from wsgi import application
 
 log = logging.getLogger(__name__)
 
@@ -31,9 +30,3 @@ class LmsModuleTests(TestCase):
         response = self.client.get('/api-docs/')
         self.assertEqual(200, response.status_code)
 
-
-class WsgiTests(TestCase):
-    """
-    Tests set up of the WSGI Application.
-    """
-    # TODO: Implement tests

--- a/lms/tests.py
+++ b/lms/tests.py
@@ -36,3 +36,4 @@ class WsgiTests(TestCase):
     """
     Tests set up of the WSGI Application.
     """
+    # TODO: Implement tests

--- a/lms/tests.py
+++ b/lms/tests.py
@@ -8,6 +8,7 @@ from django.conf import settings
 from django.test import TestCase
 
 from edxmako import LOOKUP, add_lookup
+from wsgi import application
 
 log = logging.getLogger(__name__)
 
@@ -29,3 +30,9 @@ class LmsModuleTests(TestCase):
         """
         response = self.client.get('/api-docs/')
         self.assertEqual(200, response.status_code)
+
+
+class WsgiTests(TestCase):
+    """
+    Tests set up of the WSGI Application.
+    """

--- a/lms/wsgi.py
+++ b/lms/wsgi.py
@@ -45,9 +45,9 @@ class WsgiApp:
     def __call__(self, environ, start_response):
         path_info = environ.get('PATH_INFO')
         log.error("WsgiApp path_info={}".format(path_info))
-        raise Exception("WsgiApp path_info={}".format(path_info))
-        if path_info.rstrip('/') == '/foo':
-            environ['newrelic.app_name'] = 'foo'
+        if path_info.rstrip('/') == '/login':
+            environ['newrelic.app_name'] = 'sandbox-robrap-edxapp-lms-login'
+            log.error('Trying to change newrelic app name')
         elif path_info.rstrip('/') == '/bar':
             environ['newrelic.app_name'] = 'bar'
         return self.application(environ, start_response)

--- a/lms/wsgi.py
+++ b/lms/wsgi.py
@@ -31,25 +31,58 @@ modulestore()
 
 # This application object is used by the development server
 # as well as any WSGI server configured to use this file.
-from django.core.wsgi import get_wsgi_application
-_application = get_wsgi_application()
-
-
 import logging
-log = logging.getLogger(__name__)
+from django.conf import settings
+from django.core.wsgi import get_wsgi_application
+from edx_django_utils.monitoring import set_custom_metric
 
+from lms.lib.monitoring import get_configured_newrelic_app_name_suffix_handler, newrelic_single_app_name_suffix_handler
+
+log = logging.getLogger(__name__)
+_application = get_wsgi_application()
+_newrelic_app_name_suffix_handler = get_configured_newrelic_app_name_suffix_handler()
 
 class WsgiApp:
+    """
+    Custom WsgiApp enables overriding of the NewRelic app name as needed.
+    """
     def __init__(self, application):
         self.application = application
+
+    def _set_new_relic_app_name(self):
+        if not _newrelic_app_name_suffix_handler:
+            return
+
+        try:
+            path_info = environ.get('PATH_INFO')
+
+            settings.
+            log.error("WsgiApp path_info={}".format(path_info))
+            if path_info.rstrip('/') == '/login':
+                environ['newrelic.app_name'] = 'sandbox-robrap-edxapp-lms-login'
+                log.error('Trying to change newrelic app name')
+            elif path_info.rstrip('/') == '/bar':
+                environ['newrelic.app_name'] = 'bar'
+
     def __call__(self, environ, start_response):
-        path_info = environ.get('PATH_INFO')
-        log.error("WsgiApp path_info={}".format(path_info))
-        if path_info.rstrip('/') == '/login':
-            environ['newrelic.app_name'] = 'sandbox-robrap-edxapp-lms-login'
-            log.error('Trying to change newrelic app name')
-        elif path_info.rstrip('/') == '/bar':
-            environ['newrelic.app_name'] = 'bar'
+        if _newrelic_app_name_suffix_handler:
+            try:
+                path_info = environ.get('PATH_INFO')
+
+                settings.
+                log.error("WsgiApp path_info={}".format(path_info))
+                if path_info.rstrip('/') == '/login':
+                    environ['newrelic.app_name'] = 'sandbox-robrap-edxapp-lms-login'
+                    log.error('Trying to change newrelic app name')
+                elif path_info.rstrip('/') == '/bar':
+                    environ['newrelic.app_name'] = 'bar'
+            except Exception as e:
+                try:
+                    set_custom_metric('wsgi_mapping_error', e)
+                except:
+                    pass
+
         return self.application(environ, start_response)
+
 
 application = WsgiApp(_application)

--- a/lms/wsgi.py
+++ b/lms/wsgi.py
@@ -32,4 +32,24 @@ modulestore()
 # This application object is used by the development server
 # as well as any WSGI server configured to use this file.
 from django.core.wsgi import get_wsgi_application
-application = get_wsgi_application()
+_application = get_wsgi_application()
+
+
+import logging
+log = logging.getLogger(__name__)
+
+
+class WsgiApp:
+    def __init__(self, application):
+        self.application = application
+    def __call__(self, environ, start_response):
+        path_info = environ.get('PATH_INFO')
+        log.error("WsgiApp path_info={}".format(path_info))
+        raise Exception("WsgiApp path_info={}".format(path_info))
+        if path_info.rstrip('/') == '/foo':
+            environ['newrelic.app_name'] = 'foo'
+        elif path_info.rstrip('/') == '/bar':
+            environ['newrelic.app_name'] = 'bar'
+        return self.application(environ, start_response)
+
+application = WsgiApp(_application)

--- a/lms/wsgi.py
+++ b/lms/wsgi.py
@@ -32,15 +32,16 @@ modulestore()
 # This application object is used by the development server
 # as well as any WSGI server configured to use this file.
 import logging
-from django.conf import settings
+import time
 from django.core.wsgi import get_wsgi_application
 from edx_django_utils.monitoring import set_custom_metric
 
-from lms.lib.monitoring import get_configured_newrelic_app_name_suffix_handler, newrelic_single_app_name_suffix_handler
+from lms.lib.monitoring import get_configured_newrelic_app_name_suffix_handler
 
 log = logging.getLogger(__name__)
 _application = get_wsgi_application()
 _newrelic_app_name_suffix_handler = get_configured_newrelic_app_name_suffix_handler()
+
 
 class WsgiApp:
     """
@@ -50,38 +51,34 @@ class WsgiApp:
         self.application = application
 
     def _set_new_relic_app_name(self):
+        """
+        Sets the NewRelic app name based on the path, when path is mapped to a suffix.
+        """
         if not _newrelic_app_name_suffix_handler:
             return
 
         try:
-            path_info = environ.get('PATH_INFO')
-
-            settings.
-            log.error("WsgiApp path_info={}".format(path_info))
-            if path_info.rstrip('/') == '/login':
-                environ['newrelic.app_name'] = 'sandbox-robrap-edxapp-lms-login'
-                log.error('Trying to change newrelic app name')
-            elif path_info.rstrip('/') == '/bar':
-                environ['newrelic.app_name'] = 'bar'
+            request_path = environ.get('PATH_INFO')
+            before_time = time.perf_counter()
+            suffix = _newrelic_app_name_suffix_handler(request_path)
+            if suffix:
+                new_app_name = "{}-{}".format(environ['newrelic.app_name'], suffix)
+                environ['newrelic.app_name'] = new_app_name
+                # We may remove this metric later, but for now, it can be used to confirm that
+                # the updated_app_name matches the app name, and that these set_custom_metric
+                # calls are making it to the appropriate transaction.
+                set_custom_metric('updated_app_name', new_app_name)
+            after_time = time.perf_counter()
+            # Tracking the time can be used to enable alerting if this ever gets too large.
+            set_custom_metric('suffix_mapping_time', after_time - before_time)
+        except Exception as e:
+            set_custom_metric('suffix_mapping_error', e)
 
     def __call__(self, environ, start_response):
-        if _newrelic_app_name_suffix_handler:
-            try:
-                path_info = environ.get('PATH_INFO')
-
-                settings.
-                log.error("WsgiApp path_info={}".format(path_info))
-                if path_info.rstrip('/') == '/login':
-                    environ['newrelic.app_name'] = 'sandbox-robrap-edxapp-lms-login'
-                    log.error('Trying to change newrelic app name')
-                elif path_info.rstrip('/') == '/bar':
-                    environ['newrelic.app_name'] = 'bar'
-            except Exception as e:
-                try:
-                    set_custom_metric('wsgi_mapping_error', e)
-                except:
-                    pass
-
+        try:
+            self._set_new_relic_app_name()
+        except Exception:
+            log.exception("Unexpected error setting the NewRelic app name.")
         return self.application(environ, start_response)
 
 


### PR DESCRIPTION
This is code for splitting the monolithic edx-platform NewRelic app into multiple NewRelic apps.

This initial phase only splits out a single URL, but we will iterate if all goes well with additional mappings for bom-squad.

See the ADR for more explanation.

FYI: @bderusha @ormsbee 