### PR TITLE
Disable changing proctored exam type after release date (Back-end)

### DIFF
--- a/cms/djangoapps/contentstore/views/item.py
+++ b/cms/djangoapps/contentstore/views/item.py
@@ -15,7 +15,12 @@ from django.core.exceptions import PermissionDenied
 from django.http import Http404, HttpResponse, HttpResponseBadRequest
 from django.utils.translation import ugettext as _
 from django.views.decorators.http import require_http_methods
-from edx_proctoring.api import does_backend_support_onboarding, get_exam_configuration_dashboard_url
+from edx_proctoring.api import (
+    does_backend_support_onboarding,
+    get_exam_by_content_id,
+    get_exam_configuration_dashboard_url
+)
+from edx_proctoring.exceptions import ProctoredExamNotFoundException
 from help_tokens.core import HelpUrlExpert
 from opaque_keys.edx.keys import CourseKey
 from opaque_keys.edx.locator import LibraryUsageLocator
@@ -1242,8 +1247,22 @@ def create_xblock_info(xblock, data=None, metadata=None, include_ancestor_info=F
                 else:
                     show_review_rules = True
 
+                # If this block is not currently a proctored exam,
+                # the best way for us to tell whether it was was *ever* configured
+                # as a proctored exam is by checking whether there is an exam record
+                # associated with the block's ID.
+                # If an exception is not raised, then we know that such a record
+                # exists, indicating that this *was* once a proctored exam.
+                was_ever_proctored_exam = True
+                if not xblock.is_proctored_exam:
+                    try:
+                        get_exam_by_content_id(course.id, xblock_info['id'])
+                    except ProctoredExamNotFoundException:
+                        was_ever_proctored_exam = False
+
                 xblock_info.update({
                     'is_proctored_exam': xblock.is_proctored_exam,
+                    'was_ever_proctored_exam': was_ever_proctored_exam,
                     'online_proctoring_rules': rules_url,
                     'is_practice_exam': xblock.is_practice_exam,
                     'is_onboarding_exam': xblock.is_onboarding_exam,

--- a/cms/djangoapps/contentstore/views/item.py
+++ b/cms/djangoapps/contentstore/views/item.py
@@ -1247,22 +1247,11 @@ def create_xblock_info(xblock, data=None, metadata=None, include_ancestor_info=F
                 else:
                     show_review_rules = True
 
-                # If this block is not currently a proctored exam,
-                # the best way for us to tell whether it was was *ever* configured
-                # as a proctored exam is by checking whether there is an exam record
-                # associated with the block's ID.
-                # If an exception is not raised, then we know that such a record
-                # exists, indicating that this *was* once a proctored exam.
-                was_ever_proctored_exam = True
-                if not xblock.is_proctored_exam:
-                    try:
-                        get_exam_by_content_id(course.id, xblock_info['id'])
-                    except ProctoredExamNotFoundException:
-                        was_ever_proctored_exam = False
-
                 xblock_info.update({
                     'is_proctored_exam': xblock.is_proctored_exam,
-                    'was_ever_proctored_exam': was_ever_proctored_exam,
+                    'was_ever_proctored_exam': _was_xblock_ever_proctored_exam(
+                        course, xblock
+                    ),
                     'online_proctoring_rules': rules_url,
                     'is_practice_exam': xblock.is_practice_exam,
                     'is_onboarding_exam': xblock.is_onboarding_exam,
@@ -1312,6 +1301,32 @@ def create_xblock_info(xblock, data=None, metadata=None, include_ancestor_info=F
         xblock_info['user_partition_info'] = get_visibility_partition_info(xblock, course=course)
 
     return xblock_info
+
+
+def _was_xblock_ever_proctored_exam(course, xblock):
+    """
+    Determine whether this XBlock is or was ever configured as a proctored exam.
+
+    If this block is *not* currently a proctored exam, the best way for us to tell
+    whether it was was *ever* configured as a proctored exam is by checking whether
+    the proctoring backend has an exam record associated with the block's ID.
+    If an exception is not raised, then we know that such a record exists,
+    indicating that this *was* once a proctored exam.
+
+    Arguments:
+        course (CourseDescriptor)
+        xblock (XBlock)
+
+    Returns: bool
+    """
+    if xblock.is_proctored_exam:
+        return True
+    try:
+        get_exam_by_content_id(course.id, xblock.location)
+    except ProctoredExamNotFoundException:
+        return False
+    else:
+        return True
 
 
 def add_container_page_publishing_info(xblock, xblock_info):


### PR DESCRIPTION
In the interest of getting something in review, I'm going to split the backend and frontend into two PRs. This PR just exposes the field that the front end will use to implement the client-side validation. I'm working on the frontend-end piece [a follow-up PR](https://github.com/edx/edx-platform/pull/24118).

Commit message:
```
Expose was_ever_proctored_exam dict entry on xblock_info

In a follow-up PR, this entry will be used to validate
on the client-side that a block that *is* or *ever was*
a proctored/practice/onboarding exam cannot be configured
as a different proctored/practice/onboarding exam, as that
has led to problematic exam configuration states between
edX and proctoring providers.

MST-285
```

https://openedx.atlassian.net/browse/MST-258
@edx/masters-devs-cosmonauts 

