### PR TITLE
[BD-10] [DEPR-75] Remove pattern library of course-outline-fragment.html

### DIFF
--- a/lms/static/sass/features/_course-experience.scss
+++ b/lms/static/sass/features/_course-experience.scss
@@ -412,6 +412,16 @@
       }
     }
   }
+
+  .fa-chevron-right {
+    transform: rotateY(0deg) #{"/*rtl: rotateY(180deg)*/"};
+    font-size: inherit;
+
+    &.fa-rotate-90 {
+      transform: rotate(90deg) #{"/*rtl: rotate(90deg)*/"};
+      font-size: inherit;
+    }
+  }
 }
 
 #expand-collapse-outline-all-button {

--- a/openedx/features/course_experience/views/course_outline.py
+++ b/openedx/features/course_experience/views/course_outline.py
@@ -45,6 +45,7 @@ class CourseOutlineFragmentView(EdxFragmentView):
     """
     Course outline fragment to be shown in the unified course view.
     """
+    _uses_pattern_library = False
 
     def render_to_fragment(self, request, course_id, user_is_enrolled=True, **kwargs):  # pylint: disable=arguments-differ
         """


### PR DESCRIPTION
@abutterworth 
Ticket on jira: https://openedx.atlassian.net/browse/DEPR-75
Remove use of pattern library on course_experience/course-outline-fragment.html and use bootstrap.
To work properly need the changes of this PR: https://github.com/edx/edx-platform/pull/24027
It's tested on mobile and RTL content.
![outlinePatternLibrary](https://user-images.githubusercontent.com/36944773/82504071-25fda680-9ac0-11ea-8fc8-aaad5a0aa3a6.jpg)
![outlineBootstrap](https://user-images.githubusercontent.com/36944773/82504072-272ed380-9ac0-11ea-9f1f-8cd97bdf80d8.jpg)
