### PR TITLE
Increase requests limit for logistration rate limit.

### DIFF
--- a/common/djangoapps/util/request_rate_limiter.py
+++ b/common/djangoapps/util/request_rate_limiter.py
@@ -101,3 +101,11 @@ class PasswordResetEmailRateLimiter(RequestRateLimiter):
         """
         for key in self.keys_to_check(request):
             self.cache_incr(key)
+
+
+class LoginAndRegisterRateLimiter(RequestRateLimiter):
+    """
+    Rate limiting backend for login and register endpoint which
+    allows 50 requests per IP for every 5 minutes.
+    """
+    requests = 50

--- a/openedx/core/djangoapps/user_authn/views/login_form.py
+++ b/openedx/core/djangoapps/user_authn/views/login_form.py
@@ -35,7 +35,7 @@ from student.helpers import get_next_url_for_login_page
 from third_party_auth import pipeline
 from third_party_auth.decorators import xframe_allow_whitelisted
 from util.password_policy_validators import DEFAULT_MAX_PASSWORD_LENGTH
-from util.request_rate_limiter import BadRequestRateLimiter
+from util.request_rate_limiter import LoginAndRegisterRateLimiter
 
 log = logging.getLogger(__name__)
 
@@ -138,7 +138,7 @@ def login_and_registration_form(request, initial_mode="login"):
 
     """
 
-    limiter = BadRequestRateLimiter()
+    limiter = LoginAndRegisterRateLimiter()
     if limiter.is_rate_limit_exceeded(request):
         log.warning("Rate limit exceeded in login and registration with initial mode [%s]", initial_mode)
         return HttpResponseForbidden("Rate limit exceeded")

--- a/openedx/core/djangoapps/user_authn/views/tests/test_logistration.py
+++ b/openedx/core/djangoapps/user_authn/views/tests/test_logistration.py
@@ -75,10 +75,10 @@ class LoginAndRegistrationTest(ThirdPartyAuthTestMixin, UrlResetMixin, ModuleSto
 
     def test_login_and_registration_form_ratelimited(self):
         """
-        Test that login enpoint allow only 30 requests for every 5 minutes.
+        Test that login enpoint allow only 50 requests for every 5 minutes.
         """
         login_url = reverse('signin_user')
-        for i in range(30):
+        for i in range(50):
             response = self.client.get(login_url)
             self.assertEqual(response.status_code, 200)
 


### PR DESCRIPTION
We have implemented rate limiting on logistration which caused e2e failures, fixed by increasing the limit to 50 requests for every 5 minutes instead of 30.