### PR TITLE
Move to bridgekeeper upstream.

### DIFF
--- a/openedx/core/djangoapps/content_libraries/permissions.py
+++ b/openedx/core/djangoapps/content_libraries/permissions.py
@@ -17,17 +17,16 @@ is_global_staff = is_user_active & rules.is_staff
 # Does the user have at least read permission for the specified library?
 has_explicit_read_permission_for_library = (
     ManyRelation(
-        # In newer versions of bridgekeeper, the 1st and 3rd arguments below aren't needed.
-        'permission_grants', 'contentlibrarypermission', ContentLibraryPermission,
-        Attribute('user', lambda user: user) | Relation('group', Group, in_current_groups)
+        'contentlibrarypermission',
+        (Attribute('user', lambda user: user) | Relation('group', in_current_groups))
     )
     # We don't check 'access_level' here because all access levels grant read permission
 )
 # Does the user have at least author permission for the specified library?
 has_explicit_author_permission_for_library = (
     ManyRelation(
-        'permission_grants', 'contentlibrarypermission', ContentLibraryPermission,
-        (Attribute('user', lambda user: user) | Relation('group', Group, in_current_groups)) & (
+        'contentlibrarypermission',
+        (Attribute('user', lambda user: user) | Relation('group', in_current_groups)) & (
             Attribute('access_level', ContentLibraryPermission.AUTHOR_LEVEL) |
             Attribute('access_level', ContentLibraryPermission.ADMIN_LEVEL)
         )
@@ -36,8 +35,8 @@ has_explicit_author_permission_for_library = (
 # Does the user have admin permission for the specified library?
 has_explicit_admin_permission_for_library = (
     ManyRelation(
-        'permission_grants', 'contentlibrarypermission', ContentLibraryPermission,
-        (Attribute('user', lambda user: user) | Relation('group', Group, in_current_groups)) &
+        'contentlibrarypermission',
+        (Attribute('user', lambda user: user) | Relation('group', in_current_groups)) &
         Attribute('access_level', ContentLibraryPermission.ADMIN_LEVEL)
     )
 )

--- a/requirements/edx/base.in
+++ b/requirements/edx/base.in
@@ -33,6 +33,7 @@ bleach                              # Allowed-list-based HTML sanitizing library
 boto==2.39.0                        # Deprecated version of the AWS SDK; we should stop using this
 boto3==1.4.8                        # Amazon Web Services SDK for Python
 botocore==1.8.17                    # via boto3, s3transfer
+bridgekeeper                        # Used for determining permissions for courseware.
 celery                              # Asynchronous task execution library
 contextlib2                         # We need contextlib2.ExitStack so we can stop using contextlib.nested which doesn't exist in python 3
 defusedxml

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -34,7 +34,7 @@ bleach==3.1.5             # via -r requirements/edx/base.in, edx-enterprise, lti
 boto3==1.4.8              # via -r requirements/edx/base.in, fs-s3fs
 boto==2.39.0              # via -r requirements/edx/base.in, django-ses, edxval, ora2
 botocore==1.8.17          # via -r requirements/edx/base.in, boto3, s3transfer
-git+https://github.com/edx/bridgekeeper.git@2423e8d8788c2132ebeec509e1a7b17e1f5b9364#egg=bridgekeeper==0.0  # via -r requirements/edx/github.in
+bridgekeeper==0.8         # via -r requirements/edx/base.in
 celery==3.1.26.post2      # via -c requirements/edx/../constraints.txt, -r requirements/edx/base.in, django-celery, django-user-tasks, edx-celeryutils, edx-enterprise
 certifi==2020.4.5.1       # via -r requirements/edx/paver.txt, requests
 cffi==1.14.0              # via -r requirements/edx/../edx-sandbox/shared.txt, cryptography

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -38,7 +38,7 @@ bok-choy==1.1.1           # via -r requirements/edx/testing.txt
 boto3==1.4.8              # via -r requirements/edx/testing.txt, fs-s3fs
 boto==2.39.0              # via -r requirements/edx/testing.txt, django-ses, edxval, ora2
 botocore==1.8.17          # via -r requirements/edx/testing.txt, boto3, s3transfer
-git+https://github.com/edx/bridgekeeper.git@2423e8d8788c2132ebeec509e1a7b17e1f5b9364#egg=bridgekeeper==0.0  # via -r requirements/edx/testing.txt
+bridgekeeper==0.8         # via -r requirements/edx/testing.txt
 celery==3.1.26.post2      # via -c requirements/edx/../constraints.txt, -r requirements/edx/testing.txt, django-celery, django-user-tasks, edx-celeryutils, edx-enterprise
 certifi==2020.4.5.1       # via -r requirements/edx/testing.txt, requests
 cffi==1.14.0              # via -r requirements/edx/testing.txt, cryptography

--- a/requirements/edx/github.in
+++ b/requirements/edx/github.in
@@ -78,11 +78,6 @@ git+https://github.com/Zegocover/enmerkar.git@dbc113798aa4beabdfa2d00e6fef48248e
 # Why install sorl-thumbnail directly from github? To use a Django 2.2 compatible version before Python 3.5 support was dropped
 git+https://github.com/jazzband/sorl-thumbnail.git@13bedfb7d2970809eda597e3ef79318a6fa80ac2#egg=sorl-thumbnail
 
-# Forked to fix predicate inversion and keep support for Django 1.1 alive
-# Once https://github.com/excitedleigh/bridgekeeper/pull/10 is merged, and we get to django 2, we can
-# remove this fork
-git+https://github.com/edx/bridgekeeper.git@2423e8d8788c2132ebeec509e1a7b17e1f5b9364#egg=bridgekeeper==0.0
-
 # Our libraries:
 -e git+https://github.com/edx/codejail.git@4127fc4bd5775cc72aee8d7f0a70e31405e22439#egg=codejail
 -e git+https://github.com/edx/acid-block.git@98aecba94ecbfa934e2d00262741c0ea9f557fc9#egg=acid-xblock

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -37,7 +37,7 @@ bok-choy==1.1.1           # via -r requirements/edx/testing.in
 boto3==1.4.8              # via -r requirements/edx/base.txt, fs-s3fs
 boto==2.39.0              # via -r requirements/edx/base.txt, django-ses, edxval, ora2
 botocore==1.8.17          # via -r requirements/edx/base.txt, boto3, s3transfer
-git+https://github.com/edx/bridgekeeper.git@2423e8d8788c2132ebeec509e1a7b17e1f5b9364#egg=bridgekeeper==0.0  # via -r requirements/edx/base.txt
+bridgekeeper==0.8         # via -r requirements/edx/base.txt
 celery==3.1.26.post2      # via -c requirements/edx/../constraints.txt, -r requirements/edx/base.txt, django-celery, django-user-tasks, edx-celeryutils, edx-enterprise
 certifi==2020.4.5.1       # via -r requirements/edx/base.txt, requests
 cffi==1.14.0              # via -r requirements/edx/base.txt, cryptography


### PR DESCRIPTION
We are getting rid of our own bridgekeeper fork now that we've merged the one change we needed and moved onto Python 3.5.

https://openedx.atlassian.net/browse/ARCHBOM-1114