### PR TITLE
Feanil/revert login rate limiting

### DIFF
--- a/common/djangoapps/util/request_rate_limiter.py
+++ b/common/djangoapps/util/request_rate_limiter.py
@@ -101,11 +101,3 @@ class PasswordResetEmailRateLimiter(RequestRateLimiter):
         """
         for key in self.keys_to_check(request):
             self.cache_incr(key)
-
-
-class LoginAndRegisterRateLimiter(RequestRateLimiter):
-    """
-    Rate limiting backend for login and register endpoint which
-    allows 50 requests per IP for every 5 minutes.
-    """
-    requests = 50

--- a/openedx/core/djangoapps/user_authn/views/login_form.py
+++ b/openedx/core/djangoapps/user_authn/views/login_form.py
@@ -35,7 +35,7 @@ from student.helpers import get_next_url_for_login_page
 from third_party_auth import pipeline
 from third_party_auth.decorators import xframe_allow_whitelisted
 from util.password_policy_validators import DEFAULT_MAX_PASSWORD_LENGTH
-from util.request_rate_limiter import LoginAndRegisterRateLimiter
+from util.request_rate_limiter import BadRequestRateLimiter
 
 log = logging.getLogger(__name__)
 
@@ -138,7 +138,7 @@ def login_and_registration_form(request, initial_mode="login"):
 
     """
 
-    limiter = LoginAndRegisterRateLimiter()
+    limiter = BadRequestRateLimiter()
     if limiter.is_rate_limit_exceeded(request):
         log.warning("Rate limit exceeded in login and registration with initial mode [%s]", initial_mode)
         return HttpResponseForbidden("Rate limit exceeded")

--- a/openedx/core/djangoapps/user_authn/views/login_form.py
+++ b/openedx/core/djangoapps/user_authn/views/login_form.py
@@ -7,7 +7,6 @@ import logging
 import six
 from django.conf import settings
 from django.contrib import messages
-from django.http import HttpResponseForbidden
 from django.shortcuts import redirect
 from django.urls import reverse
 from django.utils.translation import ugettext as _
@@ -35,7 +34,6 @@ from student.helpers import get_next_url_for_login_page
 from third_party_auth import pipeline
 from third_party_auth.decorators import xframe_allow_whitelisted
 from util.password_policy_validators import DEFAULT_MAX_PASSWORD_LENGTH
-from util.request_rate_limiter import BadRequestRateLimiter
 
 log = logging.getLogger(__name__)
 
@@ -137,12 +135,6 @@ def login_and_registration_form(request, initial_mode="login"):
         initial_mode (string): Either "login" or "register".
 
     """
-
-    limiter = BadRequestRateLimiter()
-    if limiter.is_rate_limit_exceeded(request):
-        log.warning("Rate limit exceeded in login and registration with initial mode [%s]", initial_mode)
-        return HttpResponseForbidden("Rate limit exceeded")
-
     # Determine the URL to redirect to following login/registration/third_party_auth
     redirect_to = get_next_url_for_login_page(request)
 
@@ -237,8 +229,6 @@ def login_and_registration_form(request, initial_mode="login"):
 
     response = render_to_response('student_account/login_and_register.html', context)
     handle_enterprise_cookies_for_logistration(request, response, context)
-
-    limiter.tick_request_counter(request)
 
     return response
 

--- a/openedx/core/djangoapps/user_authn/views/tests/test_logistration.py
+++ b/openedx/core/djangoapps/user_authn/views/tests/test_logistration.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 """ Tests for Logistration views. """
 
-from datetime import datetime, timedelta
+
 from http.cookies import SimpleCookie
 
 import ddt
@@ -17,8 +17,6 @@ from django.test.client import RequestFactory
 from django.test.utils import override_settings
 from django.urls import reverse
 from django.utils.translation import ugettext as _
-from freezegun import freeze_time
-from pytz import UTC
 from six.moves.urllib.parse import urlencode  # pylint: disable=import-error
 
 from course_modes.models import CourseMode
@@ -72,25 +70,6 @@ class LoginAndRegistrationTest(ThirdPartyAuthTestMixin, UrlResetMixin, ModuleSto
         response = self.client.get(reverse(url_name))
         expected_data = u'"initial_mode": "{mode}"'.format(mode=initial_mode)
         self.assertContains(response, expected_data)
-
-    def test_login_and_registration_form_ratelimited(self):
-        """
-        Test that login enpoint allow only 30 requests for every 5 minutes.
-        """
-        login_url = reverse('signin_user')
-        for i in range(30):
-            response = self.client.get(login_url)
-            self.assertEqual(response.status_code, 200)
-
-        # then the rate limiter should kick in and give a HttpForbidden response
-        response = self.client.get(login_url)
-        self.assertEqual(response.status_code, 403)
-
-        # now reset the time to 6 mins from now in future in order to unblock
-        reset_time = datetime.now(UTC) + timedelta(seconds=361)
-        with freeze_time(reset_time):
-            response = self.client.get(login_url)
-            self.assertEqual(response.status_code, 200)
 
     @ddt.data("signin_user", "register_user")
     def test_login_and_registration_form_already_authenticated(self, url_name):

--- a/openedx/core/djangoapps/user_authn/views/tests/test_logistration.py
+++ b/openedx/core/djangoapps/user_authn/views/tests/test_logistration.py
@@ -75,10 +75,10 @@ class LoginAndRegistrationTest(ThirdPartyAuthTestMixin, UrlResetMixin, ModuleSto
 
     def test_login_and_registration_form_ratelimited(self):
         """
-        Test that login enpoint allow only 50 requests for every 5 minutes.
+        Test that login enpoint allow only 30 requests for every 5 minutes.
         """
         login_url = reverse('signin_user')
-        for i in range(50):
+        for i in range(30):
             response = self.client.get(login_url)
             self.assertEqual(response.status_code, 200)
 


### PR DESCRIPTION
Reverting this code because we're seeing login issues on e2e stage with the following error:

```
2020-05-21 15:58:47,958 ERROR 17944 [edx.student] [user None] login.py:449 - {'value': Markup('Too many failed login attempts. Try again later.'), 'success': False}
Traceback (most recent call last):
  File "/edx/app/edxapp/edx-platform/openedx/core/djangoapps/user_authn/views/login.py", line 206, in _authenticate_first_party
    request=request
  File "/edx/app/edxapp/venvs/edxapp/lib/python3.5/site-packages/django/contrib/auth/__init__.py", line 73, in authenticate
    user = backend.authenticate(request, **credentials)
  File "/edx/app/edxapp/venvs/edxapp/lib/python3.5/site-packages/ratelimitbackend/backends.py", line 40, in authenticate
    raise RateLimitException('Rate-limit reached', counts)
ratelimitbackend.exceptions.RateLimitException: Rate-limit reached
During handling of the above exception, another exception occurred:
Traceback (most recent call last):
  File "/edx/app/edxapp/edx-platform/openedx/core/djangoapps/user_authn/views/login.py", line 419, in login_user
    possibly_authenticated_user = _authenticate_first_party(request, user, third_party_auth_requested)
  File "/edx/app/edxapp/edx-platform/openedx/core/djangoapps/user_authn/views/login.py", line 211, in _authenticate_first_party
    raise AuthFailedError(_('Too many failed login attempts. Try again later.'))
openedx.core.djangoapps.user_authn.exceptions.AuthFailedError
```