### PR TITLE
Fix creation of LTIProviderConfig object in admin

### DIFF
--- a/common/djangoapps/third_party_auth/models.py
+++ b/common/djangoapps/third_party_auth/models.py
@@ -223,9 +223,9 @@ class ProviderConfig(ConfigurationModel):
         abstract = True
 
     def clean(self):
-        """ Ensure that either `icon_class` or `icon_image` is set """
+        """ Ensure that at most `icon_class` or `icon_image` is set """
         super(ProviderConfig, self).clean()
-        if bool(self.icon_class) == bool(self.icon_image):
+        if bool(self.icon_class) and bool(self.icon_image):
             raise ValidationError('Either an icon class or an icon image must be given (but not both)')
 
     @property


### PR DESCRIPTION
When attempting to create a "Provider Configuration (LTI)" object in the
django admin, the following 500 error was being triggered:

    "Either an icon class or an icon image must be given (but not both)"

This was caused by the `clean()` method of the mother class
(OAuth2ProviderConfig) which checked whether at least the icon_class XOR
icon_list attribute was well defined. In the case of the
LTIProviderConfig objects it isn't, but that's ok because this object
is not meant to be displayed in the login form.

To resolve this issue, we modify the `clean()` method to also check for
the `visible` attribute, and we set this attribute to false in the
LTIProviderConfig class. As a consequence, the entire `visible` column
is dropped from the database. This is okay because it was otherwise
unused.

Close CRI-205.

1. I would appreciate it if someone familiar with the matter (cc @nasthagiri) could take a look at this and confirm that the `visible` column can be dropped from the LTIProviderConfig table.
2. Also, we should be careful not to delete the 0002_remove_ltiproviderconfig_visible migration when we eventually delete the squashed 1-26 migrations for this app.
3. This pull request is for resolving a Juniper-related issue (cc @nedbat).