### PR TITLE
[BD-10] [DEPR-76] Remove pattern library of course-updates-fragment.html

### DIFF
--- a/lms/static/sass/features/_course-experience.scss
+++ b/lms/static/sass/features/_course-experience.scss
@@ -501,7 +501,7 @@
       border-bottom: 1px solid $border-color;
 
       .date {
-        font-size: font-size(small);
+        font-size: 0.875rem;
         font-weight: $font-light;
         float: none;
         padding-bottom: ($baseline/4);
@@ -515,6 +515,26 @@
         margin: $baseline/2;
         max-width: 100%;
       }
+    }
+
+    .well {
+      box-shadow: inset 0 1px 2px 1px $shadow;
+      padding: 1.25rem;
+      background: $gray-100;
+    }
+  }
+
+  .breadcrumbs {
+    font-size: 0.875rem;
+
+    .nav-item {
+      @include margin-left($baseline/4);
+    }
+
+    .fa-angle-right {
+      transform: rotateY(0deg) #{"/*rtl: rotateY(180deg)*/"};
+
+      @include margin-left($baseline/4);
     }
   }
 }

--- a/openedx/features/course_experience/views/course_updates.py
+++ b/openedx/features/course_experience/views/course_updates.py
@@ -82,6 +82,8 @@ class CourseUpdatesFragmentView(EdxFragmentView):
     """
     A fragment to render the updates page for a course.
     """
+    _uses_pattern_library = False
+
     def render_to_fragment(self, request, course_id=None, **kwargs):
         """
         Renders the course's home page as a fragment.


### PR DESCRIPTION
@abutterworth
Ticket on jira: https://openedx.atlassian.net/browse/DEPR-76
Remove use of pattern library on  course_experience/course-updates-fragment.html and use bootstrap.
To work properly need the changes of this PR: #24027
It's tested on mobile and RTL content.
![contentUpdatesPatternLibrary](https://user-images.githubusercontent.com/36944773/82931317-5de76c80-9f4c-11ea-9ec1-323e118d3177.jpg)
![contentUpdatesBootstrap](https://user-images.githubusercontent.com/36944773/82931319-5fb13000-9f4c-11ea-8f2f-0648084a695b.jpg)
![updatesEmptyPatternLibrary](https://user-images.githubusercontent.com/36944773/82931325-617af380-9f4c-11ea-8eec-cca00382447e.jpg)
![updatesEmptyBootstrap](https://user-images.githubusercontent.com/36944773/82931328-62ac2080-9f4c-11ea-9c48-0f8eae07682e.jpg)

