### PR TITLE
Added 'with' statement to close file before returning

### DIFF
--- a/openedx/core/djangoapps/site_configuration/management/commands/create_or_update_site_configuration.py
+++ b/openedx/core/djangoapps/site_configuration/management/commands/create_or_update_site_configuration.py
@@ -17,7 +17,8 @@ LOG = logging.getLogger(__name__)
 
 
 def load_json_from_file(filename):
-    return json.load(codecs.open(filename, encoding='utf-8'))
+    with codecs.open(filename, encoding='utf-8') as file:
+        return json.load(file)
 
 
 class Command(BaseCommand):


### PR DESCRIPTION
Removed 3 ResourceWarnings from #24060, adding a "with" statement to close the input file after returning, following [PEP 343](https://www.python.org/dev/peps/pep-0343/)

We had 
```
def load_json_from_file(filename):
    return json.load(codecs.open(filename, encoding='utf-8'))
```

While the existing line is short and concise, open files should be closed, as advised on the [Python 3 documentation on I/O](https://docs.python.org/3/tutorial/inputoutput.html):
> It is good practice to use the with keyword when dealing with file objects. The advantage is that the file is properly closed after its suite finishes, even if an exception is raised at some point. Using with is also much shorter than writing equivalent try-finally blocks


Therefore, we change it to:
```
def load_json_from_file(filename):
    with codecs.open(filename, encoding='utf-8') as file:
        return json.load(file)
```

@felipemontoya 
@Alec4r