### PR TITLE
Added v2 for confirm email backward compatibility

### DIFF
--- a/openedx/core/djangoapps/user_authn/urls_common.py
+++ b/openedx/core/djangoapps/user_authn/urls_common.py
@@ -27,6 +27,10 @@ urlpatterns = [
     url(r'^user_api/v1/account/registration/$', register.RegistrationView.as_view(),
         name="user_api_registration"),
 
+    # V2 is created to avoid backward compatibility issue with confirm_email
+    url(r'^user_api/v2/account/registration/$', register.RegistrationView.as_view(),
+        name="user_api_registration_v2"),
+
     # Moved from user_api/urls.py
     # `api/user` prefix is preserved for backwards compatibility.
     url(

--- a/openedx/core/djangoapps/user_authn/views/registration_form.py
+++ b/openedx/core/djangoapps/user_authn/views/registration_form.py
@@ -2,7 +2,6 @@
 Objects and utilities used to construct registration forms.
 """
 
-
 import copy
 from importlib import import_module
 import re
@@ -42,6 +41,7 @@ class TrueCheckbox(widgets.CheckboxInput):
     """
     A checkbox widget that only accepts "true" (case-insensitive) as true.
     """
+
     def value_from_datadict(self, data, files, name):
         value = data.get(name, '')
         return value.lower() == 'true'
@@ -164,12 +164,12 @@ class AccountCreationForm(forms.Form):
     )
 
     def __init__(
-            self,
-            data=None,
-            extra_fields=None,
-            extended_profile_fields=None,
-            do_third_party_auth=True,
-            tos_required=True
+        self,
+        data=None,
+        extra_fields=None,
+        extended_profile_fields=None,
+        do_third_party_auth=True,
+        tos_required=True
     ):
         super(AccountCreationForm, self).__init__(data)
 
@@ -429,6 +429,13 @@ class RegistrationFormFactory(object):
                         form_desc,
                         required=self._is_field_required(field_name)
                     )
+
+        # remove confirm_email form v1 registration form
+        if 'v1' in request.get_full_path():
+            for index, field in enumerate(form_desc.fields):
+                if field['name'] == 'confirm_email':
+                    del form_desc.fields[index]
+                    break
 
         return form_desc
 
@@ -952,7 +959,6 @@ class RegistrationFormFactory(object):
         field_type = 'checkbox'
 
         if not separate_honor_and_tos:
-
             field_type = 'plaintext'
 
             pp_link = marketing_link("PRIVACY")
@@ -1069,10 +1075,11 @@ class RegistrationFormFactory(object):
                                 field_name, default=field_overrides[field_name]
                             )
 
-                            if (field_name not in ['terms_of_service', 'honor_code']
-                                    and field_overrides[field_name]
-                                    and hide_registration_fields_except_tos):
-
+                            if (
+                                field_name not in ['terms_of_service', 'honor_code'] and
+                                field_overrides[field_name] and
+                                hide_registration_fields_except_tos
+                            ):
                                 form_desc.override_field_properties(
                                     field_name,
                                     field_type="hidden",


### PR DESCRIPTION
[PROD-1537](https://openedx.atlassian.net/browse/PROD-1537)

Added `v2` for `user_api/v1/account/registration` API endpoint to add confirm email field in the registration form and in `v1` confirm_email field will not be displayed.