### PR TITLE
change pipeline api client to OAuthApiClient

### DIFF
--- a/openedx/core/djangoapps/video_pipeline/api.py
+++ b/openedx/core/djangoapps/video_pipeline/api.py
@@ -46,7 +46,7 @@ def update_3rd_party_transcription_service_credentials(**credentials_payload):
                 is_updated = True
             else:
                 is_updated = False
-                error_response = response.text
+                error_response = json.loads(response.text)
                 log.error(error_message.format(
                     credentials_payload.get('org'),
                     credentials_payload.get('provider'),

--- a/openedx/core/djangoapps/video_pipeline/api.py
+++ b/openedx/core/djangoapps/video_pipeline/api.py
@@ -31,30 +31,34 @@ def update_3rd_party_transcription_service_credentials(**credentials_payload):
     pipeline_integration = VideoPipelineIntegration.current()
     if pipeline_integration.enabled:
         try:
-            video_pipeline_user = pipeline_integration.get_service_user()
             oauth_client = Application.objects.get(name=pipeline_integration.client_name)
         except ObjectDoesNotExist:
             return error_response, is_updated
 
         client = create_video_pipeline_api_client(
-            user=video_pipeline_user,
-            api_client_id=oauth_client.client_id,
-            api_client_secret=oauth_client.client_secret,
-            api_url=pipeline_integration.api_url
+            oauth_client.client_id,
+            oauth_client.client_secret
         )
-
+        error_message = "Unable to update transcript credentials -- org={}, provider={}, response={}"
         try:
-            client.transcript_credentials.post(credentials_payload)
-            is_updated = True
+            response = client.request("POST", pipeline_integration.api_url, json=credentials_payload)
+            if response.ok:
+                is_updated = True
+            else:
+                is_updated = False
+                error_response = response.text
+                log.error(error_message.format(
+                    credentials_payload.get('org'),
+                    credentials_payload.get('provider'),
+                    response.text
+                ))
         except HttpClientError as ex:
             is_updated = False
-            log.exception(
-                ('[video-pipeline-service] Unable to update transcript credentials '
-                 u'-- org=%s -- provider=%s -- response=%s.'),
+            log.exception(error_message.format(
                 credentials_payload.get('org'),
                 credentials_payload.get('provider'),
-                ex.content,
-            )
+                ex.content
+            ))
             error_response = json.loads(ex.content)
 
     return error_response, is_updated

--- a/openedx/core/djangoapps/video_pipeline/utils.py
+++ b/openedx/core/djangoapps/video_pipeline/utils.py
@@ -1,21 +1,17 @@
 """
 Utils for video_pipeline app.
 """
+from django.conf import settings
 
-from edx_rest_api_client.client import EdxRestApiClient
-
-from openedx.core.djangoapps.oauth_dispatch.jwt import create_jwt_for_user
+from edx_rest_api_client.client import OAuthAPIClient
 
 
-def create_video_pipeline_api_client(user, api_client_id, api_client_secret, api_url):
+def create_video_pipeline_api_client(api_client_id, api_client_secret):
     """
     Returns an API client which can be used to make Video Pipeline API requests.
 
     Arguments:
-        user(User): A requesting user.
         api_client_id(unicode): Video pipeline client id.
         api_client_secret(unicode): Video pipeline client secret.
-        api_url(unicode): It is video pipeline's API URL.
     """
-    jwt_token = create_jwt_for_user(user, secret=api_client_secret, aud=api_client_id)
-    return EdxRestApiClient(api_url, jwt=jwt_token)
+    return OAuthAPIClient(settings.LMS_ROOT_URL, api_client_id, api_client_secret)


### PR DESCRIPTION
### [PROD-1632](https://openedx.atlassian.net/browse/PROD-1632)

### Description
The video pipeline API is using [EdxRestApiClient](https://github.com/edx/edx-rest-api-client/blob/master/edx_rest_api_client/client.py#L286) to communicate with VEDA. However, this communication pipeline has been broken for a while. This client is also deprecated. Moreover, the client doesn't work with VEM API locally. In an attempt to have VEM communication mechanism ready beforehand and to update the existing workflow to work with VEDA, the API client has been updated to use [OAuthApiClient](https://github.com/edx/edx-rest-api-client/blob/master/edx_rest_api_client/client.py#L181)