### PR TITLE
Update  'create team?' prompt check in topic teams to look in teamset

### DIFF
--- a/lms/djangoapps/teams/static/teams/js/spec/views/topic_teams_spec.js
+++ b/lms/djangoapps/teams/static/teams/js/spec/views/topic_teams_spec.js
@@ -7,17 +7,14 @@ define([
 ], function(Backbone, _, TopicTeamsView, TeamSpecHelpers, PageHelpers) {
     'use strict';
     describe('Topic Teams View', function() {
-        var createTopicTeamsView = function(options, isInstructorManagedTopic) {
-            var myTeamsCollection;
+        var createTopicTeamsView = function(options, isInstructorManagedTopic, showActions=true) {
             options = options || {}; // eslint-disable-line no-param-reassign
-            myTeamsCollection = options.myTeamsCollection || TeamSpecHelpers.createMockTeams({results: []});
             return new TopicTeamsView({
                 el: '.teams-container',
                 model: isInstructorManagedTopic ?
                     TeamSpecHelpers.createMockInstructorManagedTopic() : TeamSpecHelpers.createMockTopic(),
-                collection: options.teams || TeamSpecHelpers.createMockTeams(),
-                myTeamsCollection: myTeamsCollection,
-                showActions: true,
+                collection: options.teams || TeamSpecHelpers.createMockTeams({ results: [] }),
+                showActions: showActions,
                 context: _.extend({}, TeamSpecHelpers.testContext, options)
             }).render();
         };
@@ -51,7 +48,8 @@ define([
                 teamsView = createTopicTeamsView({
                     teams: TeamSpecHelpers.createMockTeams({
                         results: testTeamData
-                    })
+                    }),
+                    showTeams: false,
                 });
             var footerEl = teamsView.$('.teams-paging-footer');
             expect(teamsView.$('.teams-paging-header').text()).toMatch('Showing 1-5 out of 6 total');
@@ -59,7 +57,7 @@ define([
             expect(footerEl).not.toHaveClass('hidden');
 
             TeamSpecHelpers.verifyCards(teamsView, testTeamData);
-            verifyActions(teamsView);
+            verifyActions(teamsView, { showOptions: false });
         });
 
         it('can browse all teams', function() {
@@ -85,10 +83,10 @@ define([
             );
         });
 
-        it('does not show actions for a user already in a team', function() {
-            var options = {myTeamsCollection: TeamSpecHelpers.createMockTeams()};
+        it('does not show actions for a user already in a team in the teamset', function() {
+            var options = {collection: TeamSpecHelpers.createMockTeams()};
             var teamsView = createTopicTeamsView(options);
-            verifyActions(teamsView, {showActions: false});
+            verifyActions(teamsView);
         });
 
         it('does not show actions for a student in an instructor managed topic', function() {
@@ -102,7 +100,7 @@ define([
                     privileged: true,
                     staff: false
                 },
-                myTeamsCollection: TeamSpecHelpers.createMockTeams()
+                collection: TeamSpecHelpers.createMockTeams()
             };
             var teamsView = createTopicTeamsView(options);
             verifyActions(teamsView, {showActions: true});
@@ -114,7 +112,7 @@ define([
                     privileged: false,
                     staff: true
                 },
-                myTeamsCollection: TeamSpecHelpers.createMockTeams()
+                collection: TeamSpecHelpers.createMockTeams()
             };
             var teamsView = createTopicTeamsView(options);
             verifyActions(teamsView, {showActions: true});

--- a/lms/djangoapps/teams/static/teams/js/spec/views/topic_teams_spec.js
+++ b/lms/djangoapps/teams/static/teams/js/spec/views/topic_teams_spec.js
@@ -7,14 +7,14 @@ define([
 ], function(Backbone, _, TopicTeamsView, TeamSpecHelpers, PageHelpers) {
     'use strict';
     describe('Topic Teams View', function() {
-        var createTopicTeamsView = function(options, isInstructorManagedTopic, showActions=true) {
+        var createTopicTeamsView = function(options, isInstructorManagedTopic) {
             options = options || {}; // eslint-disable-line no-param-reassign
             return new TopicTeamsView({
                 el: '.teams-container',
                 model: isInstructorManagedTopic ?
                     TeamSpecHelpers.createMockInstructorManagedTopic() : TeamSpecHelpers.createMockTopic(),
                 collection: options.teams || TeamSpecHelpers.createMockTeams({ results: [] }),
-                showActions: showActions,
+                myTopicTeamsCollection: options.myTopicTeamsCollection || TeamSpecHelpers.createMockTeams({ results: [] }),
                 context: _.extend({}, TeamSpecHelpers.testContext, options)
             }).render();
         };
@@ -25,10 +25,7 @@ define([
                     'If you still can\'t find a team to join, create a new team in this topic.',
                 title = teamsView.$('.title').text().trim(),
                 message = teamsView.$('.copy').text().trim();
-            if (!options) {
-                options = {showActions: true}; // eslint-disable-line no-param-reassign
-            }
-
+            options = options || { showActions: true };
             if (options.showActions) {
                 expect(title).toBe(expectedTitle);
                 expect(message).toBe(expectedMessage);
@@ -44,20 +41,20 @@ define([
         });
 
         it('can render itself', function() {
-            var testTeamData = TeamSpecHelpers.createMockTeamData(1, 5),
-                teamsView = createTopicTeamsView({
-                    teams: TeamSpecHelpers.createMockTeams({
-                        results: testTeamData
-                    }),
-                    showTeams: false,
-                });
+            var testTeamData = TeamSpecHelpers.createMockTeamData(1, 5);
+            var options = {
+                teams: TeamSpecHelpers.createMockTeams({
+                    results: testTeamData
+                })
+            };
+            var teamsView = createTopicTeamsView(options);
             var footerEl = teamsView.$('.teams-paging-footer');
             expect(teamsView.$('.teams-paging-header').text()).toMatch('Showing 1-5 out of 6 total');
             expect(footerEl.text()).toMatch('1\\s+out of\\s+\/\\s+2'); // eslint-disable-line no-useless-escape
             expect(footerEl).not.toHaveClass('hidden');
 
             TeamSpecHelpers.verifyCards(teamsView, testTeamData);
-            verifyActions(teamsView, { showOptions: false });
+            verifyActions(teamsView);
         });
 
         it('can browse all teams', function() {
@@ -84,9 +81,9 @@ define([
         });
 
         it('does not show actions for a user already in a team in the teamset', function() {
-            var options = {collection: TeamSpecHelpers.createMockTeams()};
+            var options = {myTopicTeamsCollection: TeamSpecHelpers.createMockTeams()};
             var teamsView = createTopicTeamsView(options);
-            verifyActions(teamsView);
+            verifyActions(teamsView, { showActions: false });
         });
 
         it('does not show actions for a student in an instructor managed topic', function() {
@@ -100,7 +97,7 @@ define([
                     privileged: true,
                     staff: false
                 },
-                collection: TeamSpecHelpers.createMockTeams()
+                myTopicTeamsCollection: TeamSpecHelpers.createMockTeams()
             };
             var teamsView = createTopicTeamsView(options);
             verifyActions(teamsView, {showActions: true});
@@ -112,7 +109,7 @@ define([
                     privileged: false,
                     staff: true
                 },
-                collection: TeamSpecHelpers.createMockTeams()
+                myTopicTeamsCollection: TeamSpecHelpers.createMockTeams()
             };
             var teamsView = createTopicTeamsView(options);
             verifyActions(teamsView, {showActions: true});

--- a/lms/djangoapps/teams/static/teams/js/spec/views/topic_teams_spec.js
+++ b/lms/djangoapps/teams/static/teams/js/spec/views/topic_teams_spec.js
@@ -13,8 +13,10 @@ define([
                 el: '.teams-container',
                 model: isInstructorManagedTopic ?
                     TeamSpecHelpers.createMockInstructorManagedTopic() : TeamSpecHelpers.createMockTopic(),
-                collection: options.teams || TeamSpecHelpers.createMockTeams({ results: [] }),
-                myTopicTeamsCollection: options.myTopicTeamsCollection || TeamSpecHelpers.createMockTeams({ results: [] }),
+                collection: options.teams || TeamSpecHelpers.createMockTeams({results: []}),
+                myTopicTeamsCollection: (
+                  options.myTopicTeamsCollection || TeamSpecHelpers.createMockTeams({results: []})
+                ),
                 context: _.extend({}, TeamSpecHelpers.testContext, options)
             }).render();
         };
@@ -25,7 +27,7 @@ define([
                     'If you still can\'t find a team to join, create a new team in this topic.',
                 title = teamsView.$('.title').text().trim(),
                 message = teamsView.$('.copy').text().trim();
-            options = options || { showActions: true };
+            options = options || {showActions: true}; // eslint-disable-line no-param-reassign
             if (options.showActions) {
                 expect(title).toBe(expectedTitle);
                 expect(message).toBe(expectedMessage);
@@ -83,7 +85,7 @@ define([
         it('does not show actions for a user already in a team in the teamset', function() {
             var options = {myTopicTeamsCollection: TeamSpecHelpers.createMockTeams()};
             var teamsView = createTopicTeamsView(options);
-            verifyActions(teamsView, { showActions: false });
+            verifyActions(teamsView, {showActions: false});
         });
 
         it('does not show actions for a student in an instructor managed topic', function() {

--- a/lms/djangoapps/teams/static/teams/js/views/teams_tab.js
+++ b/lms/djangoapps/teams/static/teams/js/views/teams_tab.js
@@ -380,12 +380,24 @@
                 createTeamsListView: function(options) {
                     var topic = options.topic,
                         collection = options.collection,
+                        myTopicTeamsCollection = new TeamCollection(
+                          this.context.userInfo.teams,
+                          {
+                              teamEvents: this.teamEvents,
+                              course_id: this.context.courseID,
+                              username: this.context.userInfo.username,
+                              topic_id: topic.get('id'),
+                              perPage: 5,
+                              parse: true,
+                              url: this.context.myTeamsUrl
+                          }
+                        ),
                         teamsView = new TopicTeamsView({
                             router: this.router,
                             context: this.context,
                             model: topic,
                             collection: collection,
-                            myTeamsCollection: this.myTeamsCollection,
+                            myTopicTeamsCollection: myTopicTeamsCollection,
                             showSortControls: options.showSortControls
                         }),
                         searchFieldView = new SearchFieldView({

--- a/lms/djangoapps/teams/static/teams/js/views/teams_tab.js
+++ b/lms/djangoapps/teams/static/teams/js/views/teams_tab.js
@@ -381,16 +381,16 @@
                     var topic = options.topic,
                         collection = options.collection,
                         myTopicTeamsCollection = new TeamCollection(
-                          this.context.userInfo.teams,
-                          {
-                              teamEvents: this.teamEvents,
-                              course_id: this.context.courseID,
-                              username: this.context.userInfo.username,
-                              topic_id: topic.get('id'),
-                              perPage: 5,
-                              parse: true,
-                              url: this.context.myTeamsUrl
-                          }
+                            this.context.userInfo.teams,
+                            {
+                                teamEvents: this.teamEvents,
+                                course_id: this.context.courseID,
+                                username: this.context.userInfo.username,
+                                topic_id: topic.get('id'),
+                                perPage: 5,
+                                parse: true,
+                                url: this.context.myTeamsUrl
+                            }
                         ),
                         teamsView = new TopicTeamsView({
                             router: this.router,

--- a/lms/djangoapps/teams/static/teams/js/views/topic_teams.js
+++ b/lms/djangoapps/teams/static/teams/js/views/topic_teams.js
@@ -32,7 +32,7 @@
                 return this.context.userInfo.staff
                     || this.context.userInfo.privileged
                     || (!TeamUtils.isInstructorManagedTopic(this.model.attributes.type)
-                        && this.collection.length === 0);
+                        && this.options.myTopicTeamsCollection.length === 0);
             },
 
             render: function() {

--- a/lms/djangoapps/teams/static/teams/js/views/topic_teams.js
+++ b/lms/djangoapps/teams/static/teams/js/views/topic_teams.js
@@ -21,7 +21,6 @@
                 this.options = _.extend({}, options);
                 this.showSortControls = options.showSortControls;
                 this.context = options.context;
-                this.myTeamsCollection = options.myTeamsCollection;
                 TeamsView.prototype.initialize.call(this, options);
             },
 
@@ -33,7 +32,7 @@
                 return this.context.userInfo.staff
                     || this.context.userInfo.privileged
                     || (!TeamUtils.isInstructorManagedTopic(this.model.attributes.type)
-                        && this.myTeamsCollection.length === 0);
+                        && this.collection.length === 0);
             },
 
             render: function() {


### PR DESCRIPTION
Update the check in topic_teams for whether to show the team actions to check the "collection" (teams in the topic/teamset) rather than "myTeamsCollection" which is across the whole class.

Small unit test updates to accommodate.

JIRA: https://openedx.atlassian.net/browse/EDUCATOR-5062

@edx/masters-devs-gta