### PR TITLE
Remove github teams that don't map to anything useful right now.

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,28 +1,28 @@
 # This does not cover all the code in edx-platform but it's a good start.
 
 # Core
-common/djangoapps/student/                 @edx/platform-core
-common/djangoapps/third_party_auth/        @edx/platform-authn
-common/lib/xmodule/xmodule/                @edx/platform-core
-lms/djangoapps/course_api/blocks           @edx/platform-core
-lms/djangoapps/courseware/                 @edx/platform-core
-lms/djangoapps/grades/                     @edx/platform-grades
-lms/djangoapps/instructor/                 @edx/platform-core
-lms/djangoapps/instructor_task/            @edx/platform-core
-lms/djangoapps/mobile_api/                 @edx/platform-mobile
-openedx/core/djangoapps/contentserver/     @edx/platform-core
-openedx/core/djangoapps/heartbeat/         @edx/platform-core
-openedx/core/djangoapps/oauth_dispatch     @edx/platform-authn
-openedx/core/djangoapps/user_api/          @edx/platform-authn
-openedx/core/djangoapps/user_authn/        @edx/platform-authn
-openedx/features/course_experience/        @edx/platform-courseware
+common/djangoapps/student/
+common/djangoapps/third_party_auth/
+common/lib/xmodule/xmodule/
+lms/djangoapps/course_api/blocks
+lms/djangoapps/courseware/
+lms/djangoapps/grades/
+lms/djangoapps/instructor/
+lms/djangoapps/instructor_task/
+lms/djangoapps/mobile_api/
+openedx/core/djangoapps/contentserver/
+openedx/core/djangoapps/heartbeat/
+openedx/core/djangoapps/oauth_dispatch
+openedx/core/djangoapps/user_api/
+openedx/core/djangoapps/user_authn/
+openedx/features/course_experience/
 
-# Core Extensions 
-common/lib/xmodule/xmodule/capa_module.py  @edx/platform-core-extensions
-common/lib/xmodule/xmodule/html_module.py  @edx/platform-core-extensions
-common/lib/xmodule/xmodule/video_module    @edx/platform-core-extensions
-lms/djangoapps/discussion/                 @edx/platform-core-extensions
-lms/djangoapps/edxnotes                    @edx/platform-core-extensions
+# Core Extensions
+common/lib/xmodule/xmodule/capa_module.py
+common/lib/xmodule/xmodule/html_module.py
+common/lib/xmodule/xmodule/video_module
+lms/djangoapps/discussion/
+lms/djangoapps/edxnotes
 
 # Analytics
 common/djangoapps/track/                   @edx/edx-data-engineering


### PR DESCRIPTION
The core teams as conceived here don't exist and so just make noise rather than
help.