### PR TITLE
MST-264 Fix bug for course staff user in unrelated course

### DIFF
--- a/lms/djangoapps/program_enrollments/rest_api/v1/tests/test_views.py
+++ b/lms/djangoapps/program_enrollments/rest_api/v1/tests/test_views.py
@@ -1490,13 +1490,16 @@ class UserProgramReadOnlyAccessGetTests(EnrollmentsDataMixin, APITestCase):
         with mock.patch(
             _VIEW_PATCH_FORMAT.format('get_programs'),
             autospec=True,
-            return_value=[self.mock_program_data[0]]
+            side_effect=[[self.mock_program_data[0]], []]
         ) as mock_get_programs:
             response = self.client.get(reverse(self.view_name) + '?type=masters')
 
         assert status.HTTP_200_OK == response.status_code
         assert len(response.data) == 1
-        mock_get_programs.assert_called_once_with(course=self.course_id)
+        mock_get_programs.assert_has_calls([
+            mock.call(course=self.course_id),
+            mock.call(uuids=[]),
+        ], any_order=True)
 
     def _enroll_user_into_course_as_course_staff(self, user, course_key_string):
         """
@@ -1555,7 +1558,7 @@ class UserProgramReadOnlyAccessGetTests(EnrollmentsDataMixin, APITestCase):
         with mock.patch(
             _VIEW_PATCH_FORMAT.format('get_programs'),
             autospec=True,
-            side_effect=[programs_to_return_first, programs_to_return_second]
+            side_effect=[[], programs_to_return_first, programs_to_return_second]
         ) as mock_get_programs:
             response = self.client.get(reverse(self.view_name) + '?type=masters')
 

--- a/lms/djangoapps/program_enrollments/rest_api/v1/views.py
+++ b/lms/djangoapps/program_enrollments/rest_api/v1/views.py
@@ -709,15 +709,17 @@ class UserProgramReadOnlyAccessView(DeveloperErrorViewMixin, PaginatedAPIView):
 
         if request_user.is_staff:
             programs = get_programs_by_type(request.site, requested_program_type)
-        elif self.is_course_staff(request_user):
-            programs = self.get_programs_user_is_course_staff_for(request_user, requested_program_type)
         else:
-            program_enrollments = fetch_program_enrollments_by_student(
-                user=request.user,
-                program_enrollment_statuses=ProgramEnrollmentStatuses.__ACTIVE__,
-            )
-            uuids = [enrollment.program_uuid for enrollment in program_enrollments]
-            programs = get_programs(uuids=uuids) or []
+            # Check if the user is a course staff of any course which is a part of a program.
+            programs = self.get_programs_user_is_course_staff_for(request_user, requested_program_type)
+            if not programs:
+                # Now check program enrollments for purely as a learner
+                program_enrollments = fetch_program_enrollments_by_student(
+                    user=request.user,
+                    program_enrollment_statuses=ProgramEnrollmentStatuses.__ACTIVE__,
+                )
+                uuids = [enrollment.program_uuid for enrollment in program_enrollments]
+                programs = get_programs(uuids=uuids) or []
 
         programs_in_which_user_has_access = [
             {'uuid': program['uuid'], 'slug': program['marketing_slug']}
@@ -725,13 +727,6 @@ class UserProgramReadOnlyAccessView(DeveloperErrorViewMixin, PaginatedAPIView):
         ]
 
         return Response(programs_in_which_user_has_access, status.HTTP_200_OK)
-
-    def is_course_staff(self, user):
-        """
-        Returns true if the user is a course_staff member of any course within a program
-        """
-        staff_course_keys = self.get_course_keys_user_is_staff_for(user)
-        return len(staff_course_keys)
 
     def get_course_keys_user_is_staff_for(self, user):
         """


### PR DESCRIPTION
Fix the wrong assumption that a course_staff of a course not related to programs should be in course_staff logic

For details, see MST-264 comments sections

@edx/masters-devs-cosmonauts Please help review