### PR TITLE
AA-76: Add is_allowed property to DatesSummary

### DIFF
--- a/lms/djangoapps/course_home_api/dates/v1/tests/test_views.py
+++ b/lms/djangoapps/course_home_api/dates/v1/tests/test_views.py
@@ -31,15 +31,10 @@ class DatesTabTestViews(BaseCourseHomeTests):
         response = self.client.get(self.url)
         self.assertEqual(response.status_code, 200)
 
-        # Pulling out the date blocks to check learner has access. The Verification Deadline Date
-        # should not be accessible to the audit learner, but accessible to the verified learner.
+        # Pulling out the date blocks to check learner has access.
         date_blocks = response.data.get('course_date_blocks')
-        if enrollment_mode == CourseMode.AUDIT:
-            self.assertFalse(response.data.get('learner_is_verified'))
-            self.assertTrue(any(block.get('learner_has_access') is False for block in date_blocks))
-        else:
-            self.assertTrue(response.data.get('learner_is_verified'))
-            self.assertTrue(all(block.get('learner_has_access') for block in date_blocks))
+        self.assertEqual(response.data.get('learner_is_verified'), enrollment_mode == CourseMode.VERIFIED)
+        self.assertTrue(all(block.get('learner_has_access') for block in date_blocks))
 
     @COURSE_HOME_MICROFRONTEND.override(active=True)
     @COURSE_HOME_MICROFRONTEND_DATES_TAB.override(active=True)

--- a/lms/djangoapps/courseware/tests/test_date_summary.py
+++ b/lms/djangoapps/courseware/tests/test_date_summary.py
@@ -329,6 +329,7 @@ class CourseDateSummaryTest(SharedModuleStoreTestCase):
             user = create_user()
             block = TodaysDate(course, user)
             self.assertTrue(block.is_enabled)
+            self.assertTrue(block.is_allowed)
             self.assertEqual(block.date, datetime.now(utc))
             self.assertEqual(block.title, 'current_datetime')
 
@@ -505,7 +506,7 @@ class CourseDateSummaryTest(SharedModuleStoreTestCase):
         CourseEnrollmentFactory(course_id=course.id, user=user, mode=CourseMode.AUDIT)
         block = CertificateAvailableDate(course, user)
         self.assertEqual(block.date, None)
-        self.assertFalse(block.is_enabled)
+        self.assertFalse(block.is_allowed)
 
     ## CertificateAvailableDate
     @waffle.testutils.override_switch('certificates.auto_certificate_generation', True)
@@ -517,7 +518,7 @@ class CourseDateSummaryTest(SharedModuleStoreTestCase):
         course.save()
         block = CertificateAvailableDate(course, verified_user)
         self.assertNotEqual(block.date, None)
-        self.assertFalse(block.is_enabled)
+        self.assertFalse(block.is_allowed)
 
     def test_no_certificate_available_date_for_audit_course(self):
         """
@@ -539,7 +540,7 @@ class CourseDateSummaryTest(SharedModuleStoreTestCase):
 
         # Verify Certificate Available Date is not enabled for learner.
         block = CertificateAvailableDate(course, audit_user)
-        self.assertFalse(block.is_enabled)
+        self.assertFalse(block.is_allowed)
         self.assertNotEqual(block.date, None)
 
     @waffle.testutils.override_switch('certificates.auto_certificate_generation', True)
@@ -558,7 +559,7 @@ class CourseDateSummaryTest(SharedModuleStoreTestCase):
         for block in (CertificateAvailableDate(course, audit_user), CertificateAvailableDate(course, verified_user)):
             self.assertIsNotNone(course.certificate_available_date)
             self.assertEqual(block.date, course.certificate_available_date)
-            self.assertTrue(block.is_enabled)
+            self.assertTrue(block.is_allowed)
 
     ## VerificationDeadlineDate
     def test_no_verification_deadline(self):
@@ -566,14 +567,15 @@ class CourseDateSummaryTest(SharedModuleStoreTestCase):
         user = create_user()
         CourseEnrollmentFactory(course_id=course.id, user=user, mode=CourseMode.VERIFIED)
         block = VerificationDeadlineDate(course, user)
-        self.assertFalse(block.is_enabled)
+        self.assertIsNone(block.date)
+        self.assertTrue(block.is_allowed)
 
     def test_no_verified_enrollment(self):
         course = create_course_run(days_till_start=-1)
         user = create_user()
         CourseEnrollmentFactory(course_id=course.id, user=user, mode=CourseMode.AUDIT)
         block = VerificationDeadlineDate(course, user)
-        self.assertFalse(block.is_enabled)
+        self.assertFalse(block.is_allowed)
 
     def test_verification_deadline_date_upcoming(self):
         with freeze_time('2015-01-02'):

--- a/lms/djangoapps/courseware/tests/test_views.py
+++ b/lms/djangoapps/courseware/tests/test_views.py
@@ -3083,6 +3083,7 @@ class DatesTabTestCase(ModuleStoreTestCase):
         self.course = CourseFactory.create(start=now + timedelta(days=-1), self_paced=True)
         self.course.end = now + timedelta(days=3)
 
+        ContentTypeGatingConfig.objects.create(enabled=True, enabled_as_of=datetime(2018, 1, 1))
         CourseModeFactory(course_id=self.course.id, mode_slug=CourseMode.AUDIT)
         CourseModeFactory(
             course_id=self.course.id,
@@ -3116,6 +3117,8 @@ class DatesTabTestCase(ModuleStoreTestCase):
                 due=now + timedelta(days=1),  # Setting this to tomorrow so it'll show the 'Due Next' pill
                 graded=True,
             )
+            vertical = ItemFactory.create(category='vertical', parent_location=subsection.location)
+            ItemFactory.create(category='problem', parent_location=vertical.location)
 
         with patch('lms.djangoapps.courseware.views.views.get_enrollment') as mock_get_enrollment:
             mock_get_enrollment.return_value = {
@@ -3123,7 +3126,7 @@ class DatesTabTestCase(ModuleStoreTestCase):
             }
             response = self._get_response(self.course)
             self.assertContains(response, subsection.display_name)
-            # Show the Verification Deadline for everyone
+            # Show the Verification Deadline for verified only
             self.assertContains(response, 'Verification Deadline')
             # Make sure pill exists for today's date
             self.assertContains(response, '<div class="pill today">')
@@ -3148,8 +3151,8 @@ class DatesTabTestCase(ModuleStoreTestCase):
 
             mock_set_custom_metric.assert_has_calls(expected_calls, any_order=True)
             self.assertContains(response, subsection.display_name)
-            # Show the Verification Deadline for everyone
-            self.assertContains(response, 'Verification Deadline')
+            # Don't show the Verification Deadline for audit
+            self.assertNotContains(response, 'Verification Deadline')
             # Pill doesn't exist for assignment due tomorrow
             self.assertNotContains(response, '<div class="pill due-next">')
             # Should have verified pills for audit enrollments

--- a/openedx/features/course_experience/tests/views/test_course_home.py
+++ b/openedx/features/course_experience/tests/views/test_course_home.py
@@ -219,7 +219,7 @@ class TestCourseHomePage(CourseHomePageTestCase):
 
         # Fetch the view and verify the query counts
         # TODO: decrease query count as part of REVO-28
-        with self.assertNumQueries(77, table_blacklist=QUERY_COUNT_TABLE_BLACKLIST):
+        with self.assertNumQueries(75, table_blacklist=QUERY_COUNT_TABLE_BLACKLIST):
             with check_mongo_calls(4):
                 url = course_home_url(self.course)
                 self.client.get(url)


### PR DESCRIPTION
This takes over some of the logic in the is_enabled property which previously checked two things: (1) is the date time-sensitive and (2) is the date even applicable to this course.

Now, is_enabled is only responsible for time-sensitive checks and the new is_allowed property checks applicability.

In this way, we can more cleanly separate whether a date block should show up on the dates sidebar (is_enabled and is_allowed) and the dates tab (is_allowed).

https://openedx.atlassian.net/browse/AA-76