### PR TITLE
Restrict cert api to staff and self user

### DIFF
--- a/lms/djangoapps/certificates/apis/v0/permissions.py
+++ b/lms/djangoapps/certificates/apis/v0/permissions.py
@@ -1,0 +1,26 @@
+"""
+This module provides a custom DRF Permission class for supporting the course certificates
+to Admin users and users whom they belongs to.
+"""
+
+from django.contrib.auth.models import User
+from rest_framework.permissions import BasePermission
+
+from openedx.core.djangoapps.user_api.models import UserPreference
+
+
+class IsOwnerOrPublicCertificates(BasePermission):
+    """
+    Method that will ensure whether the requesting user is staff or
+    the user whom the certificate belongs to
+    """
+    def has_permission(self, request, view):
+        requested_profile_username = view.kwargs.get('username')
+        # check whether requesting user is the owner of certs or not
+        if request.user.username == requested_profile_username:
+            return True
+
+        user = User.objects.get(username=requested_profile_username)
+        cert_privacy = UserPreference.get_value(user, 'visibility.course_certificates')
+
+        return cert_privacy == 'all_users'

--- a/lms/djangoapps/certificates/apis/v0/views.py
+++ b/lms/djangoapps/certificates/apis/v0/views.py
@@ -12,7 +12,7 @@ from edx_rest_framework_extensions.auth.session.authentication import SessionAut
 from opaque_keys import InvalidKeyError
 from opaque_keys.edx.keys import CourseKey
 from rest_condition import C
-from rest_framework.permissions import IsAuthenticated, IsAdminUser
+from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
@@ -22,6 +22,8 @@ from openedx.core.djangoapps.certificates.api import certificates_viewable_for_c
 from openedx.core.djangoapps.content.course_overviews.models import CourseOverview
 from openedx.core.djangoapps.user_api.accounts.api import visible_fields
 from openedx.core.lib.api.authentication import BearerAuthenticationAllowInactiveUser
+
+from .permissions import IsOwnerOrPublicCertificates
 
 log = logging.getLogger(__name__)
 User = get_user_model()
@@ -158,7 +160,7 @@ class CertificatesListView(APIView):
                 permissions.JwtHasUserFilterForRequestedUser
             )
         ),
-        IsAdminUser,
+        (C(permissions.IsStaff) | IsOwnerOrPublicCertificates),
     )
 
     required_scopes = ['certificates:read']


### PR DESCRIPTION
### Description

[PROD-1238](https://openedx.atlassian.net/browse/PROD-1238)

Cert api must be accessible by staff users, owners of the certs and to everyone if profile is public.