### PR TITLE
[BD-10] [DEPR-79] Remove pattern library of mobile/course-dates-fragment.html

### DIFF
--- a/openedx/features/course_experience/views/course_dates.py
+++ b/openedx/features/course_experience/views/course_dates.py
@@ -47,6 +47,7 @@ class CourseDatesFragmentMobileView(CourseDatesFragmentView):
     mechanism to automatically create/recreate session with the server for all
     authenticated requests if the server returns 404.
     """
+    _uses_pattern_library = False
     template_name = 'course_experience/mobile/course-dates-fragment.html'
 
     def get(self, request, *args, **kwargs):


### PR DESCRIPTION
@abutterworth
Ticket on jira: https://openedx.atlassian.net/browse/DEPR-79
Remove use of pattern library on mobile/course-dates-fragment.html.
Test URL: /courses/<COURSE_ID>/course/mobile_dates_fragment
The template course_experience/course-dates-fragment.html is loaded on course home so it will be changed in ticket DEPR-83
It's tested on mobile and RTL content.
![mobileDatesPatternLibrary](https://user-images.githubusercontent.com/36944773/83436831-338e2700-a404-11ea-9e50-08d4b2077d5d.jpg)
![mobileDatesBootstrap](https://user-images.githubusercontent.com/36944773/83436834-34bf5400-a404-11ea-9f05-853238e3dff0.jpg)

