### PR TITLE
[BD-6] Update sorl-thumbnail dependency

### DIFF
--- a/requirements/edx/base.in
+++ b/requirements/edx/base.in
@@ -143,6 +143,7 @@ simplejson
 sailthru-client==2.2.3              # For Sailthru integration
 Shapely                             # Geometry library, used for image click regions in capa
 six                                 # Utilities for supporting Python 2 & 3 in the same codebase
+sorl-thumbnail
 sortedcontainers                    # Provides SortedKeyList, used for lists of XBlock assets
 sqlparse                            # Required by Django to run migrations.RunSQL
 stevedore                           # Support for runtime plugins, used for XBlocks and edx-platform Django app plugins

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -162,9 +162,9 @@ mongoengine==0.10.0       # via -r requirements/edx/base.in
 more-itertools==8.3.0     # via -r requirements/edx/paver.txt, zipp
 mpmath==1.1.0             # via sympy
 mysqlclient==1.4.6        # via -r requirements/edx/base.in
-newrelic==5.12.1.141      # via -r requirements/edx/base.in, edx-django-utils
+newrelic==5.14.0.142      # via -r requirements/edx/base.in, edx-django-utils
 nltk==3.5                 # via -r requirements/edx/../edx-sandbox/shared.txt, chem
-nodeenv==1.3.5            # via -r requirements/edx/base.in
+nodeenv==1.4.0            # via -r requirements/edx/base.in
 numpy==1.18.4             # via chem, openedx-calc, scipy
 oauthlib==3.0.1           # via -c requirements/edx/../constraints.txt, -r requirements/edx/base.in, django-oauth-toolkit, lti-consumer-xblock, requests-oauthlib, social-auth-core
 openedx-calc==1.0.9       # via -r requirements/edx/base.in
@@ -223,7 +223,7 @@ simplejson==3.17.0        # via -r requirements/edx/base.in, sailthru-client, su
 six==1.15.0               # via -r requirements/edx/../edx-sandbox/shared.txt, -r requirements/edx/base.in, -r requirements/edx/paver.txt, analytics-python, bleach, cryptography, django-appconf, django-classy-tags, django-countries, django-pyfs, django-sekizai, django-simple-history, django-statici18n, drf-yasg, edx-ace, edx-ccx-keys, edx-django-release-util, edx-drf-extensions, edx-enterprise, edx-i18n-tools, edx-milestones, edx-opaque-keys, edx-rbac, edx-search, event-tracking, fs, fs-s3fs, help-tokens, html5lib, isodate, libsass, mock, openedx-calc, packaging, paver, pycontracts, pyjwkest, python-dateutil, python-memcached, python-swiftclient, social-auth-app-django, social-auth-core, stevedore, xblock
 slumber==0.7.1            # via edx-bulk-grades, edx-enterprise, edx-rest-api-client
 social-auth-core==3.3.3   # via -r requirements/edx/base.in, social-auth-app-django
-git+https://github.com/jazzband/sorl-thumbnail.git@13bedfb7d2970809eda597e3ef79318a6fa80ac2#egg=sorl-thumbnail  # via -r requirements/edx/github.in
+sorl-thumbnail==12.6.3    # via -r requirements/edx/base.in
 sortedcontainers==2.1.0   # via -r requirements/edx/base.in, pdfminer.six
 soupsieve==2.0.1          # via beautifulsoup4
 sqlparse==0.3.1           # via -r requirements/edx/base.in, django

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -195,9 +195,9 @@ mongoengine==0.10.0       # via -r requirements/edx/testing.txt
 more-itertools==8.3.0     # via -r requirements/edx/testing.txt, pytest, zipp
 mpmath==1.1.0             # via -r requirements/edx/testing.txt, sympy
 mysqlclient==1.4.6        # via -r requirements/edx/testing.txt
-newrelic==5.12.1.141      # via -r requirements/edx/testing.txt, edx-django-utils
+newrelic==5.14.0.142      # via -r requirements/edx/testing.txt, edx-django-utils
 nltk==3.5                 # via -r requirements/edx/testing.txt, chem
-nodeenv==1.3.5            # via -r requirements/edx/testing.txt
+nodeenv==1.4.0            # via -r requirements/edx/testing.txt
 numpy==1.18.4             # via -r requirements/edx/testing.txt, chem, openedx-calc, scipy
 oauthlib==3.0.1           # via -c requirements/edx/../constraints.txt, -r requirements/edx/testing.txt, django-oauth-toolkit, lti-consumer-xblock, requests-oauthlib, social-auth-core
 openedx-calc==1.0.9       # via -r requirements/edx/testing.txt
@@ -282,7 +282,7 @@ six==1.15.0               # via -r requirements/edx/pip-tools.txt, -r requiremen
 slumber==0.7.1            # via -r requirements/edx/testing.txt, edx-bulk-grades, edx-enterprise, edx-rest-api-client
 snowballstemmer==2.0.0    # via sphinx
 social-auth-core==3.3.3   # via -r requirements/edx/testing.txt, social-auth-app-django
-git+https://github.com/jazzband/sorl-thumbnail.git@13bedfb7d2970809eda597e3ef79318a6fa80ac2#egg=sorl-thumbnail  # via -r requirements/edx/testing.txt
+sorl-thumbnail==12.6.3    # via -r requirements/edx/testing.txt
 sortedcontainers==2.1.0   # via -r requirements/edx/testing.txt, pdfminer.six
 soupsieve==2.0.1          # via -r requirements/edx/testing.txt, beautifulsoup4
 sphinx==3.0.4             # via edx-sphinx-theme, sphinxcontrib-httpdomain
@@ -316,7 +316,7 @@ virtualenv==20.0.21       # via -r requirements/edx/testing.txt, tox
 voluptuous==0.11.7        # via -r requirements/edx/testing.txt, ora2
 vulture==1.5              # via -r requirements/edx/development.in
 watchdog==0.10.2          # via -r requirements/edx/testing.txt
-wcwidth==0.2.2            # via -r requirements/edx/testing.txt, pytest
+wcwidth==0.2.3            # via -r requirements/edx/testing.txt, pytest
 web-fragments==0.3.2      # via -r requirements/edx/testing.txt, staff-graded-xblock, xblock, xblock-utils
 webencodings==0.5.1       # via -r requirements/edx/testing.txt, bleach, html5lib
 webob==1.8.6              # via -r requirements/edx/testing.txt, xblock, xmodule

--- a/requirements/edx/github.in
+++ b/requirements/edx/github.in
@@ -75,9 +75,6 @@ git+https://github.com/Zegocover/enmerkar.git@dbc113798aa4beabdfa2d00e6fef48248e
 # This can be removed once an official social-auth-app-django Pypi release with Django 2.2 support is available in the future.
 -e git+https://github.com/python-social-auth/social-app-django.git@c00d23c2b45c3317bd35b15ad1b959338689cef8#egg=social-auth-app-django
 
-# Why install sorl-thumbnail directly from github? To use a Django 2.2 compatible version before Python 3.5 support was dropped
-git+https://github.com/jazzband/sorl-thumbnail.git@13bedfb7d2970809eda597e3ef79318a6fa80ac2#egg=sorl-thumbnail
-
 # Our libraries:
 -e git+https://github.com/edx/codejail.git@4127fc4bd5775cc72aee8d7f0a70e31405e22439#egg=codejail
 -e git+https://github.com/edx/acid-block.git@98aecba94ecbfa934e2d00262741c0ea9f557fc9#egg=acid-xblock

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -187,9 +187,9 @@ mongoengine==0.10.0       # via -r requirements/edx/base.txt
 more-itertools==8.3.0     # via -r requirements/edx/base.txt, -r requirements/edx/coverage.txt, pytest, zipp
 mpmath==1.1.0             # via -r requirements/edx/base.txt, sympy
 mysqlclient==1.4.6        # via -r requirements/edx/base.txt
-newrelic==5.12.1.141      # via -r requirements/edx/base.txt, edx-django-utils
+newrelic==5.14.0.142      # via -r requirements/edx/base.txt, edx-django-utils
 nltk==3.5                 # via -r requirements/edx/base.txt, chem
-nodeenv==1.3.5            # via -r requirements/edx/base.txt
+nodeenv==1.4.0            # via -r requirements/edx/base.txt
 numpy==1.18.4             # via -r requirements/edx/base.txt, chem, openedx-calc, scipy
 oauthlib==3.0.1           # via -c requirements/edx/../constraints.txt, -r requirements/edx/base.txt, django-oauth-toolkit, lti-consumer-xblock, requests-oauthlib, social-auth-core
 openedx-calc==1.0.9       # via -r requirements/edx/base.txt
@@ -270,7 +270,7 @@ singledispatch==3.4.0.3   # via -r requirements/edx/testing.in
 six==1.15.0               # via -r requirements/edx/base.txt, -r requirements/edx/coverage.txt, analytics-python, astroid, bleach, bok-choy, cryptography, diff-cover, django-appconf, django-classy-tags, django-countries, django-pyfs, django-sekizai, django-simple-history, django-statici18n, drf-yasg, edx-ace, edx-ccx-keys, edx-django-release-util, edx-drf-extensions, edx-enterprise, edx-i18n-tools, edx-lint, edx-milestones, edx-opaque-keys, edx-rbac, edx-search, event-tracking, freezegun, fs, fs-s3fs, help-tokens, html5lib, httpretty, isodate, libsass, mando, mock, openedx-calc, packaging, pathlib2, paver, pycontracts, pyjwkest, pytest-xdist, python-dateutil, python-memcached, python-swiftclient, singledispatch, social-auth-app-django, social-auth-core, stevedore, tox, transifex-client, virtualenv, xblock
 slumber==0.7.1            # via -r requirements/edx/base.txt, edx-bulk-grades, edx-enterprise, edx-rest-api-client
 social-auth-core==3.3.3   # via -r requirements/edx/base.txt, social-auth-app-django
-git+https://github.com/jazzband/sorl-thumbnail.git@13bedfb7d2970809eda597e3ef79318a6fa80ac2#egg=sorl-thumbnail  # via -r requirements/edx/base.txt
+sorl-thumbnail==12.6.3    # via -r requirements/edx/base.txt
 sortedcontainers==2.1.0   # via -r requirements/edx/base.txt, pdfminer.six
 soupsieve==2.0.1          # via -r requirements/edx/base.txt, beautifulsoup4
 sqlparse==0.3.1           # via -r requirements/edx/base.txt, django
@@ -294,7 +294,7 @@ user-util==0.2            # via -r requirements/edx/base.txt
 virtualenv==20.0.21       # via tox
 voluptuous==0.11.7        # via -r requirements/edx/base.txt, ora2
 watchdog==0.10.2          # via -r requirements/edx/base.txt
-wcwidth==0.2.2            # via pytest
+wcwidth==0.2.3            # via pytest
 web-fragments==0.3.2      # via -r requirements/edx/base.txt, staff-graded-xblock, xblock, xblock-utils
 webencodings==0.5.1       # via -r requirements/edx/base.txt, bleach, html5lib
 webob==1.8.6              # via -r requirements/edx/base.txt, xblock, xmodule


### PR DESCRIPTION
Move sorl-thumbnail dependencie from github.in to base.in since PyPi version is now compatible with Django 2.2 and python 3.5.

**Reviewers**
- [ ] @awais786 
- [ ] @morenol
