### PR TITLE
Disable changing special exam type after release date

### DIFF
--- a/cms/djangoapps/contentstore/views/item.py
+++ b/cms/djangoapps/contentstore/views/item.py
@@ -1249,7 +1249,7 @@ def create_xblock_info(xblock, data=None, metadata=None, include_ancestor_info=F
 
                 xblock_info.update({
                     'is_proctored_exam': xblock.is_proctored_exam,
-                    'was_ever_proctored_exam': _was_xblock_ever_proctored_exam(
+                    'was_ever_special_exam': _was_xblock_ever_special_exam(
                         course, xblock
                     ),
                     'online_proctoring_rules': rules_url,
@@ -1303,15 +1303,15 @@ def create_xblock_info(xblock, data=None, metadata=None, include_ancestor_info=F
     return xblock_info
 
 
-def _was_xblock_ever_proctored_exam(course, xblock):
+def _was_xblock_ever_special_exam(course, xblock):
     """
-    Determine whether this XBlock is or was ever configured as a proctored exam.
+    Determine whether this XBlock is or was ever configured as a special exam.
 
-    If this block is *not* currently a proctored exam, the best way for us to tell
-    whether it was was *ever* configured as a proctored exam is by checking whether
-    the proctoring backend has an exam record associated with the block's ID.
+    If this block is *not* currently a special exam, the best way for us to tell
+    whether it was was *ever* configured as a special exam is by checking whether
+    edx-proctoring has an exam record associated with the block's ID.
     If an exception is not raised, then we know that such a record exists,
-    indicating that this *was* once a proctored exam.
+    indicating that this *was* once a special exam.
 
     Arguments:
         course (CourseDescriptor)
@@ -1319,7 +1319,7 @@ def _was_xblock_ever_proctored_exam(course, xblock):
 
     Returns: bool
     """
-    if xblock.is_proctored_exam:
+    if xblock.is_time_limited:
         return True
     try:
         get_exam_by_content_id(course.id, xblock.location)

--- a/cms/djangoapps/contentstore/views/tests/test_item.py
+++ b/cms/djangoapps/contentstore/views/tests/test_item.py
@@ -2786,9 +2786,9 @@ class TestXBlockInfo(ItemTest):
 
 
 @patch.dict('django.conf.settings.FEATURES', {'ENABLE_SPECIAL_EXAMS': True})
-class TestProctoredXBlockInfo(ItemTest):
+class TestSpecialExamXBlockInfo(ItemTest):
     """
-    Unit tests for XBlock outline handling, specific to proctored exam XBlocks.
+    Unit tests for XBlock outline handling, specific to special exam XBlocks.
     """
     patch_get_exam_configuration_dashboard_url = patch.object(
         item_module, 'get_exam_configuration_dashboard_url', return_value='test_url'
@@ -2827,7 +2827,7 @@ class TestProctoredXBlockInfo(ItemTest):
     @patch_get_exam_configuration_dashboard_url
     @patch_does_backend_support_onboarding
     @patch_get_exam_by_content_id_success
-    def test_proctored_exam_xblock_info(
+    def test_special_exam_xblock_info(
             self,
             mock_get_exam_by_content_id,
             _mock_does_backend_support_onboarding,
@@ -2850,20 +2850,20 @@ class TestProctoredXBlockInfo(ItemTest):
             include_children_predicate=ALWAYS,
         )
         # exam proctoring should be enabled and time limited.
-        assert xblock_info['is_proctored_exam']
-        assert xblock_info['was_ever_proctored_exam']
-        assert xblock_info['is_time_limited']
+        assert xblock_info['is_proctored_exam'] is True
+        assert xblock_info['was_ever_special_exam'] is True
+        assert xblock_info['is_time_limited'] is True
         assert xblock_info['default_time_limit_minutes'] == 100
         assert xblock_info['proctoring_exam_configuration_link'] == 'test_url'
-        assert xblock_info['supports_onboarding']
-        assert not xblock_info['is_onboarding_exam']
+        assert xblock_info['supports_onboarding'] is True
+        assert xblock_info['is_onboarding_exam'] is False
         mock_get_exam_configuration_dashboard_url.assert_called_with(self.course.id, xblock_info['id'])
         assert mock_get_exam_by_content_id.call_count == 0
 
     @patch_get_exam_configuration_dashboard_url
     @patch_does_backend_support_onboarding
     @patch_get_exam_by_content_id_success
-    def test_xblock_was_ever_proctored_exam(
+    def test_xblock_was_ever_special_exam(
             self,
             mock_get_exam_by_content_id,
             _mock_does_backend_support_onboarding_patch,
@@ -2875,8 +2875,7 @@ class TestProctoredXBlockInfo(ItemTest):
             display_name="Test Lesson 1",
             user_id=self.user.id,
             is_proctored_exam=False,
-            is_time_limited=True,
-            default_time_limit_minutes=100,
+            is_time_limited=False,
             is_onboarding_exam=False,
         )
         sequential = modulestore().get_item(sequential.location)
@@ -2885,7 +2884,7 @@ class TestProctoredXBlockInfo(ItemTest):
             include_child_info=True,
             include_children_predicate=ALWAYS,
         )
-        assert xblock_info['was_ever_proctored_exam']
+        assert xblock_info['was_ever_special_exam'] is True
         assert mock_get_exam_by_content_id.call_count == 1
 
     @patch_get_exam_configuration_dashboard_url
@@ -2903,8 +2902,7 @@ class TestProctoredXBlockInfo(ItemTest):
             display_name="Test Lesson 1",
             user_id=self.user.id,
             is_proctored_exam=False,
-            is_time_limited=True,
-            default_time_limit_minutes=100,
+            is_time_limited=False,
             is_onboarding_exam=False,
         )
         sequential = modulestore().get_item(sequential.location)
@@ -2913,7 +2911,7 @@ class TestProctoredXBlockInfo(ItemTest):
             include_child_info=True,
             include_children_predicate=ALWAYS,
         )
-        assert not xblock_info['was_ever_proctored_exam']
+        assert xblock_info['was_ever_special_exam'] is False
         assert mock_get_exam_by_content_id.call_count == 1
 
 

--- a/cms/static/js/views/modals/course_outline_modals.js
+++ b/cms/static/js/views/modals/course_outline_modals.js
@@ -311,7 +311,17 @@ define(['jquery', 'backbone', 'underscore', 'gettext', 'js/views/baseview',
                 xblockInfo: this.model,
                 xblockType: this.options.xblockType,
                 enable_proctored_exam: this.options.enable_proctored_exams,
-                enable_timed_exam: this.options.enable_timed_exams
+                enable_timed_exam: this.options.enable_timed_exams,
+                is_special_exam: xblockInfo.get('is_time_limited'),
+                is_proctored_exam: xblockInfo.get('is_proctored_exam'),
+                is_practice_exam: xblockInfo.get('is_practice_exam'),
+                is_onboarding_exam: xblockInfo.get('is_onboarding_exam'),
+                is_timed_exam: is_special_exam && !(
+                    is_proctored_exam || is_practice_exam || is_onboarding_exam
+                ),
+                special_exam_locked_in: (
+                    xblockInfo.get('released_to_students') && xblockInfo.get('was_ever_special_exam')
+                )
             }, this.getContext()));
 
             HtmlUtils.setHtml(this.$el, HtmlUtils.HTML(html));

--- a/cms/static/js/views/modals/course_outline_modals.js
+++ b/cms/static/js/views/modals/course_outline_modals.js
@@ -308,26 +308,23 @@ define(['jquery', 'backbone', 'underscore', 'gettext', 'js/views/baseview',
 
         render: function() {
             var xblockInfo = this.model;
-            var is_time_limited = xblockInfo.get('is_time_limited');
-            var is_proctored_exam = xblockInfo.get('is_proctored_exam');
-            var is_practice_exam = xblockInfo.get('is_practice_exam');
-            var is_onboarding_exam = xblockInfo.get('is_onboarding_exam');
-            var is_timed_exam = is_time_limited && !(
-                is_proctored_exam || is_practice_exam || is_onboarding_exam
-            )
+            var isTimeLimited = xblockInfo.get('is_time_limited');
+            var isProctoredExam = xblockInfo.get('is_proctored_exam');
+            var isPracticeExam = xblockInfo.get('is_practice_exam');
+            var isOnboardingExam = xblockInfo.get('is_onboarding_exam');
             var html = this.template($.extend({}, {
                 xblockInfo: xblockInfo,
                 xblockType: this.options.xblockType,
-                enable_proctored_exam: this.options.enable_proctored_exams,
-                enable_timed_exam: this.options.enable_timed_exams,
-                is_special_exam: is_time_limited,
-                is_proctored_exam: is_proctored_exam,
-                is_practice_exam: is_practice_exam,
-                is_onboarding_exam: is_onboarding_exam,
-                is_timed_exam: is_time_limited && !(
-                    is_proctored_exam || is_practice_exam || is_onboarding_exam
+                enableProctoredExams: this.options.enable_proctored_exams,
+                enableTimedExams: this.options.enable_timed_exams,
+                isSpecialExam: isTimeLimited,
+                isProctoredExam: isProctoredExam,
+                isPracticeExam: isPracticeExam,
+                isOnboardingExam: isOnboardingExam,
+                isTimedExam: isTimeLimited && !(
+                    isProctoredExam || isPracticeExam || isOnboardingExam
                 ),
-                special_exam_locked_in: (
+                specialExamLockedIn: (
                     xblockInfo.get('released_to_students') && xblockInfo.get('was_ever_special_exam')
                 )
             }, this.getContext()));

--- a/cms/static/js/views/modals/course_outline_modals.js
+++ b/cms/static/js/views/modals/course_outline_modals.js
@@ -307,16 +307,24 @@ define(['jquery', 'backbone', 'underscore', 'gettext', 'js/views/baseview',
         },
 
         render: function() {
+            var xblockInfo = this.model;
+            var is_time_limited = xblockInfo.get('is_time_limited');
+            var is_proctored_exam = xblockInfo.get('is_proctored_exam');
+            var is_practice_exam = xblockInfo.get('is_practice_exam');
+            var is_onboarding_exam = xblockInfo.get('is_onboarding_exam');
+            var is_timed_exam = is_time_limited && !(
+                is_proctored_exam || is_practice_exam || is_onboarding_exam
+            )
             var html = this.template($.extend({}, {
-                xblockInfo: this.model,
+                xblockInfo: xblockInfo,
                 xblockType: this.options.xblockType,
                 enable_proctored_exam: this.options.enable_proctored_exams,
                 enable_timed_exam: this.options.enable_timed_exams,
-                is_special_exam: xblockInfo.get('is_time_limited'),
-                is_proctored_exam: xblockInfo.get('is_proctored_exam'),
-                is_practice_exam: xblockInfo.get('is_practice_exam'),
-                is_onboarding_exam: xblockInfo.get('is_onboarding_exam'),
-                is_timed_exam: is_special_exam && !(
+                is_special_exam: is_time_limited,
+                is_proctored_exam: is_proctored_exam,
+                is_practice_exam: is_practice_exam,
+                is_onboarding_exam: is_onboarding_exam,
+                is_timed_exam: is_time_limited && !(
                     is_proctored_exam || is_practice_exam || is_onboarding_exam
                 ),
                 special_exam_locked_in: (

--- a/cms/templates/js/timed-examination-preference-editor.underscore
+++ b/cms/templates/js/timed-examination-preference-editor.underscore
@@ -2,36 +2,72 @@
     <h3 class="modal-section-title"><%- gettext('Set as a Special Exam') %></h3>
     <div class="modal-section-content has-actions">
         <div class="list-fields list-input exam-types" role="group" aria-label="<%- gettext('Exam Types') %>">
+            <%
+                var is_special_exam = xblockInfo.get('is_time_limited');
+                var is_proctored_exam = xblockInfo.get('is_proctored_exam')
+                var is_practice_exam = xblockInfo.get('is_practice_exam');
+                var is_onboarding_exam = xblockInfo.get('is_onboarding_exam');
+                var is_timed_exam = is_special_exam && !(
+                    is_proctored_exam || is_practice_exam || is_onboarding_exam
+                );
+                var special_exam_locked_in = (
+                    xblockInfo.get('released_to_students') && xblockInfo.get('was_ever_special_exam')
+                );
+            %>
+            <% if (special_exam_locked_in && !is_special_exam) { %>
+                <div class="summary-message summary-message-warning">
+                    <span class="icon fa fa-exclamation-triangle" aria-hidden="true"></span>
+                    <p class="copy">
+                        <%- gettext("This subsection was released to learners as a special exam, but was reverted back to a basic exam. You may not configure it as a special exam now. Contact edX Support for assistance.") %>
+                    </p>
+                </div>
+            <% } %>
+            <% if (special_exam_locked_in && is_special_exam) { %>
+                <div class="summary-message summary-message-warning">
+                    <span class="icon fa fa-exclamation-triangle" aria-hidden="true"></span>
+                    <p class="copy">
+                        <%- gettext("This special exam has been released to learners. You may not convert it to another type of special exam. You may revert this subsection back to being a basic exam by selecting 'None', but you will NOT be able to configure it as a special exam in the future.") %>
+                    </p>
+                </div>
+            <% } %>
             <label class="label no-descriptive-text">
                 <input type="radio" name="exam_type" class="input input-radio no_special_exam" checked="checked"/>
                 <%- gettext('None') %>
             </label>
             <label class="label">
                 <input type="radio" name="exam_type" class="input input-radio timed_exam"
-                    aria-describedby="timed-exam-description" />
+                    aria-describedby="timed-exam-description" 
+                    <%- special_exam_locked_in && !is_timed_exam ? 'disabled' : '' %>
+                />
                 <%- gettext('Timed') %>
             </label>
             <p class='field-message' id='timed-exam-description'> <%- gettext('Use a timed exam to limit the time learners can spend on problems in this subsection. Learners must submit answers before the time expires. You can allow additional time for individual learners through the Instructor Dashboard.') %> </p>
             <% if (enable_proctored_exam) { %>
                 <label class="label">
                     <input type="radio" name="exam_type" class="input input-radio proctored_exam"
-                        aria-describedby="proctored-exam-description" />
+                        aria-describedby="proctored-exam-description"
+                        <%- special_exam_locked_in && !is_proctored_exam ? 'disabled' : '' %>
+                    />
                     <%- gettext('Proctored') %>
                 </label>
                 <p class='field-message' id='proctored-exam-description'> <%- gettext('Proctored exams are timed and they record video of each learner taking the exam. The videos are then reviewed to ensure that learners follow all examination rules.') %> </p>
-                
+
                 <% var supports_onboarding = xblockInfo.get('supports_onboarding'); %>
                 <% if (supports_onboarding) { %>
                     <label class="label">
                         <input type="radio" name="exam_type" class="input input-radio onboarding_exam"
-                            aria-describedby="onboarding-exam-description"/>
+                            aria-describedby="onboarding-exam-description"
+                            <%- special_exam_locked_in && !is_onboarding_exam ? 'disabled' : '' %>
+                        />
                         <%- gettext('Onboarding') %>
                     </label>
                     <p class='field-message' id='onboarding-exam-description'> <%- gettext("Use Onboarding to introduce learners to proctoring, verify their identity, and create an onboarding profile. Learners must complete the onboarding profile step prior to taking a proctored exam. Profile reviews take 2+ business days.") %> </p>
                 <% } else { %>
                     <label class="label">
                         <input type="radio" name="exam_type" class="input input-radio practice_exam"
-                            aria-describedby="practice-exam-description"/>
+                            aria-describedby="practice-exam-description"
+                            <%- special_exam_locked_in && !is_practice_exam ? 'disabled' : '' %>
+                        />
                         <%- gettext('Practice Proctored') %>
                     </label>
                     <p class='field-message' id='practice-exam-description'> <%- gettext("Use a practice proctored exam to introduce learners to the proctoring tools and processes. Results of a practice exam do not affect a learner's grade.") %> </p>

--- a/cms/templates/js/timed-examination-preference-editor.underscore
+++ b/cms/templates/js/timed-examination-preference-editor.underscore
@@ -2,18 +2,6 @@
     <h3 class="modal-section-title"><%- gettext('Set as a Special Exam') %></h3>
     <div class="modal-section-content has-actions">
         <div class="list-fields list-input exam-types" role="group" aria-label="<%- gettext('Exam Types') %>">
-            <%
-                var is_special_exam = xblockInfo.get('is_time_limited');
-                var is_proctored_exam = xblockInfo.get('is_proctored_exam')
-                var is_practice_exam = xblockInfo.get('is_practice_exam');
-                var is_onboarding_exam = xblockInfo.get('is_onboarding_exam');
-                var is_timed_exam = is_special_exam && !(
-                    is_proctored_exam || is_practice_exam || is_onboarding_exam
-                );
-                var special_exam_locked_in = (
-                    xblockInfo.get('released_to_students') && xblockInfo.get('was_ever_special_exam')
-                );
-            %>
             <% if (special_exam_locked_in && !is_special_exam) { %>
                 <div class="summary-message summary-message-warning">
                     <span class="icon fa fa-exclamation-triangle" aria-hidden="true"></span>

--- a/cms/templates/js/timed-examination-preference-editor.underscore
+++ b/cms/templates/js/timed-examination-preference-editor.underscore
@@ -2,7 +2,7 @@
     <h3 class="modal-section-title"><%- gettext('Set as a Special Exam') %></h3>
     <div class="modal-section-content has-actions">
         <div class="list-fields list-input exam-types" role="group" aria-label="<%- gettext('Exam Types') %>">
-            <% if (special_exam_locked_in && !is_special_exam) { %>
+            <% if (specialExamLockedIn && !isSpecialExam) { %>
                 <div class="summary-message summary-message-warning">
                     <span class="icon fa fa-exclamation-triangle" aria-hidden="true"></span>
                     <p class="copy">
@@ -10,7 +10,7 @@
                     </p>
                 </div>
             <% } %>
-            <% if (special_exam_locked_in && is_special_exam) { %>
+            <% if (specialExamLockedIn && isSpecialExam) { %>
                 <div class="summary-message summary-message-warning">
                     <span class="icon fa fa-exclamation-triangle" aria-hidden="true"></span>
                     <p class="copy">
@@ -25,16 +25,16 @@
             <label class="label">
                 <input type="radio" name="exam_type" class="input input-radio timed_exam"
                     aria-describedby="timed-exam-description" 
-                    <%- special_exam_locked_in && !is_timed_exam ? 'disabled' : '' %>
+                    <%- specialExamLockedIn && !isTimedExam ? 'disabled' : '' %>
                 />
                 <%- gettext('Timed') %>
             </label>
             <p class='field-message' id='timed-exam-description'> <%- gettext('Use a timed exam to limit the time learners can spend on problems in this subsection. Learners must submit answers before the time expires. You can allow additional time for individual learners through the Instructor Dashboard.') %> </p>
-            <% if (enable_proctored_exam) { %>
+            <% if (enableProctoredExams) { %>
                 <label class="label">
                     <input type="radio" name="exam_type" class="input input-radio proctored_exam"
                         aria-describedby="proctored-exam-description"
-                        <%- special_exam_locked_in && (!is_proctored_exam || is_onboarding_exam) ? 'disabled' : '' %>
+                        <%- specialExamLockedIn && (!isProctoredExam || isOnboardingExam) ? 'disabled' : '' %>
                     />
                     <%- gettext('Proctored') %>
                 </label>
@@ -45,7 +45,7 @@
                     <label class="label">
                         <input type="radio" name="exam_type" class="input input-radio onboarding_exam"
                             aria-describedby="onboarding-exam-description"
-                            <%- special_exam_locked_in && !is_onboarding_exam ? 'disabled' : '' %>
+                            <%- specialExamLockedIn && !isOnboardingExam ? 'disabled' : '' %>
                         />
                         <%- gettext('Onboarding') %>
                     </label>
@@ -54,7 +54,7 @@
                     <label class="label">
                         <input type="radio" name="exam_type" class="input input-radio practice_exam"
                             aria-describedby="practice-exam-description"
-                            <%- special_exam_locked_in && !is_practice_exam ? 'disabled' : '' %>
+                            <%- specialExamLockedIn && !isPracticeExam ? 'disabled' : '' %>
                         />
                         <%- gettext('Practice Proctored') %>
                     </label>

--- a/cms/templates/js/timed-examination-preference-editor.underscore
+++ b/cms/templates/js/timed-examination-preference-editor.underscore
@@ -34,7 +34,7 @@
                 <label class="label">
                     <input type="radio" name="exam_type" class="input input-radio proctored_exam"
                         aria-describedby="proctored-exam-description"
-                        <%- special_exam_locked_in && !is_proctored_exam ? 'disabled' : '' %>
+                        <%- special_exam_locked_in && (!is_proctored_exam || is_onboarding_exam) ? 'disabled' : '' %>
                     />
                     <%- gettext('Proctored') %>
                 </label>


### PR DESCRIPTION
## Overview

Jira: [MST-258](https://openedx.atlassian.net/browse/MST-258)
This builds upon a [previous PR](https://github.com/edx/edx-platform/pull/24040).
Team: @edx/masters-devs-cosmonauts @bseverino 

## Breaking change

If you make an exam "special" (proctored/practice/onboarding/timed),  then after the exam is released, the following constraints exist:
* You may not later change it to a different kind of of "special" (e.g, practice -> proctored), and
* If you change it back to "not special", you may never make it "special" again.

*This includes timed exams*, not just proctored ones. [Here is an edX-internal Slack thread discussing the reasoning for that](https://edx-internal.slack.com/archives/CMHFVDN82/p1591115567010300).

## Still needs doing
* Confirm that my latest commit (titled "refactoring") doesn't break the PR. I was struggling to get Studio assets to compile and could not test changes to `.js` files.
* JS tests - probably quite minimal. Might not even be necessary, as most of the changes are in the Underscore template.
* Notification of others about the breaking change? @dabdul-hathi
* Should we update the [edX ReadTheDocs for proctored exams](https://github.com/edx/edx-documentation/blob/master/en_us/course_authors/source/proctored_exams/pt_create.rst)?
* Make a ticket for validating this on the server-side as well?

## Screenshots

### Section that is currently configured with proctoring
![mst-258_proctored-exam_2](https://user-images.githubusercontent.com/3628148/83682380-d9cb5f80-a5b1-11ea-8e21-178b82ba396e.png)

### Section that was once configured with proctoring, but now is not
![mst-258_was-proctored-now-basic-exam](https://user-images.githubusercontent.com/3628148/83682430-dd5ee680-a5b1-11ea-898c-f37d7b5fc89a.png)
