### PR TITLE
AA-158: Fix date ordering for multiple events on the same date

### DIFF
--- a/lms/djangoapps/courseware/courses.py
+++ b/lms/djangoapps/courseware/courses.py
@@ -461,7 +461,17 @@ def get_course_date_blocks(course, user, request=None, include_access=False,
     Return the list of blocks to display on the course info page,
     sorted by date.
     """
-    block_classes = [
+    blocks = []
+    if RELATIVE_DATES_FLAG.is_enabled(course.id):
+        blocks.append(CourseExpiredDate(course, user))
+        blocks.extend(get_course_assignment_date_blocks(
+            course, user, request, num_return=num_assignments,
+            include_access=include_access, include_past_dates=include_past_dates,
+        ))
+
+    # Adding these in after the assignment blocks so in the case multiple blocks have the same date,
+    # these blocks will be sorted to come after the assignments. See https://openedx.atlassian.net/browse/AA-158
+    default_block_classes = [
         CourseEndDate,
         CourseStartDate,
         TodaysDate,
@@ -469,15 +479,9 @@ def get_course_date_blocks(course, user, request=None, include_access=False,
         VerifiedUpgradeDeadlineDate,
     ]
     if not course.self_paced and certs_api.get_active_web_certificate(course):
-        block_classes.insert(0, CertificateAvailableDate)
+        default_block_classes.insert(0, CertificateAvailableDate)
 
-    blocks = [cls(course, user) for cls in block_classes]
-    if RELATIVE_DATES_FLAG.is_enabled(course.id):
-        blocks.append(CourseExpiredDate(course, user))
-        blocks.extend(get_course_assignment_date_blocks(
-            course, user, request, num_return=num_assignments,
-            include_access=include_access, include_past_dates=include_past_dates,
-        ))
+    blocks.extend([cls(course, user) for cls in default_block_classes])
 
     return sorted((b for b in blocks if b.date and (b.is_enabled or include_past_dates)), key=date_block_key_fn)
 

--- a/lms/djangoapps/courseware/tests/test_date_summary.py
+++ b/lms/djangoapps/courseware/tests/test_date_summary.py
@@ -551,7 +551,10 @@ class CourseDateSummaryTest(SharedModuleStoreTestCase):
         CourseEnrollmentFactory(course_id=course.id, user=verified_user, mode=CourseMode.VERIFIED)
         course.certificate_available_date = datetime.now(utc) + timedelta(days=7)
         enable_course_certificates(course)
-        CertificateAvailableDate(course, audit_user)
+        expected_blocks = [
+            CourseEndDate, CourseStartDate, TodaysDate, VerificationDeadlineDate, CertificateAvailableDate
+        ]
+        self.assert_block_types(course, verified_user, expected_blocks)
         for block in (CertificateAvailableDate(course, audit_user), CertificateAvailableDate(course, verified_user)):
             self.assertIsNotNone(course.certificate_available_date)
             self.assertEqual(block.date, course.certificate_available_date)


### PR DESCRIPTION
This change will prefer putting assignments before other course
events (such as end date or verification deadline date) in the
case where they share the same date.