### PR TITLE
[BD-10] [DEPR-68][DEPR-84] Remove pattern library of learner_dashboard/programs.py

### DIFF
--- a/lms/djangoapps/learner_dashboard/programs.py
+++ b/lms/djangoapps/learner_dashboard/programs.py
@@ -31,6 +31,8 @@ class ProgramsFragmentView(EdxFragmentView):
     """
     A fragment to program listing.
     """
+    _uses_pattern_library = False
+
     def render_to_fragment(self, request, **kwargs):
         """
         Render the program listing fragment.
@@ -82,6 +84,8 @@ class ProgramDetailsFragmentView(EdxFragmentView):
     """
     Render the program details fragment.
     """
+    _uses_pattern_library = False
+
     def render_to_fragment(self, request, program_uuid, **kwargs):
         """View details about a specific program."""
         programs_config = kwargs.get('programs_config') or ProgramsApiConfig.current()

--- a/lms/static/sass/elements/_program-card.scss
+++ b/lms/static/sass/elements/_program-card.scss
@@ -168,8 +168,6 @@
   }
 
   .progress-container {
-    max-width: inherit;
-
     .progress-bar {
       height: 5px;
       display: flex;


### PR DESCRIPTION
@abutterworth
Tickets on jira: https://openedx.atlassian.net/browse/DEPR-68 , https://openedx.atlassian.net/browse/DEPR-84
Remove use of pattern library of learner_dashboard/programs.py
Test URL1: /dashboard/programs_fragment/
Test URL2: /dashboard/programs/<program_uuid>/details_fragment/
Styles have already been fixed removing pattern library of programs.html(depr-67) and programs_details.html(depr-66)
It's tested on mobile and RTL content.
![program-list-fragment](https://user-images.githubusercontent.com/36944773/83571107-c73b2280-a4ec-11ea-96bd-b67696a09442.jpg)
![program-detail-fragment](https://user-images.githubusercontent.com/36944773/83571110-c86c4f80-a4ec-11ea-8e88-c7c5ff9b611f.jpg)
