### PR TITLE
[BD-6] Use Pypi release of social-app-django

### DIFF
--- a/requirements/edx/base.in
+++ b/requirements/edx/base.in
@@ -147,6 +147,7 @@ simplejson
 sailthru-client==2.2.3              # For Sailthru integration
 Shapely                             # Geometry library, used for image click regions in capa
 six                                 # Utilities for supporting Python 2 & 3 in the same codebase
+social-auth-app-django
 sorl-thumbnail
 sortedcontainers                    # Provides SortedKeyList, used for lists of XBlock assets
 sqlparse                            # Required by Django to run migrations.RunSQL

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -15,7 +15,6 @@
 -e git+https://github.com/edx/RateXBlock.git@2.0#egg=rate-xblock  # via -r requirements/edx/github.in
 -e common/lib/safe_lxml  # via -r requirements/edx/local.in
 -e common/lib/sandbox-packages  # via -r requirements/edx/local.in
--e git+https://github.com/python-social-auth/social-app-django.git@c00d23c2b45c3317bd35b15ad1b959338689cef8#egg=social-auth-app-django  # via -r requirements/edx/github.in
 -e common/lib/symmath  # via -r requirements/edx/local.in
 -e openedx/core/lib/xblock_builtin/xblock_discussion  # via -r requirements/edx/local.in
 -e git+https://github.com/edx-solutions/xblock-google-drive.git@2d176468e33c0713c911b563f8f65f7cf232f5b6#egg=xblock-google-drive  # via -r requirements/edx/github.in
@@ -221,6 +220,7 @@ shapely==1.7.0            # via -r requirements/edx/base.in
 simplejson==3.17.0        # via -r requirements/edx/base.in, sailthru-client, super-csv, xblock-utils
 six==1.15.0               # via -r requirements/edx/../edx-sandbox/shared.txt, -r requirements/edx/base.in, -r requirements/edx/paver.txt, analytics-python, bleach, chem, crowdsourcehinter-xblock, cryptography, django-classy-tags, django-countries, django-pyfs, django-sekizai, django-simple-history, django-statici18n, drf-yasg, edx-ace, edx-ccx-keys, edx-django-release-util, edx-drf-extensions, edx-enterprise, edx-i18n-tools, edx-milestones, edx-opaque-keys, edx-rbac, edx-search, event-tracking, fs, fs-s3fs, help-tokens, html5lib, isodate, libsass, mock, openedx-calc, packaging, paver, pycontracts, pyjwkest, python-dateutil, python-memcached, python-swiftclient, social-auth-app-django, social-auth-core, stevedore, xblock
 slumber==0.7.1            # via edx-bulk-grades, edx-enterprise, edx-rest-api-client
+social-auth-app-django==3.4.0  # via -r requirements/edx/base.in
 social-auth-core==3.3.3   # via -r requirements/edx/base.in, social-auth-app-django
 sorl-thumbnail==12.6.3    # via -r requirements/edx/base.in
 sortedcontainers==2.2.2   # via -r requirements/edx/base.in, pdfminer.six

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -15,7 +15,6 @@
 -e git+https://github.com/edx/RateXBlock.git@2.0#egg=rate-xblock  # via -r requirements/edx/testing.txt
 -e common/lib/safe_lxml  # via -r requirements/edx/testing.txt
 -e common/lib/sandbox-packages  # via -r requirements/edx/testing.txt
--e git+https://github.com/python-social-auth/social-app-django.git@c00d23c2b45c3317bd35b15ad1b959338689cef8#egg=social-auth-app-django  # via -r requirements/edx/testing.txt
 -e common/lib/symmath  # via -r requirements/edx/testing.txt
 -e openedx/core/lib/xblock_builtin/xblock_discussion  # via -r requirements/edx/testing.txt
 -e git+https://github.com/edx-solutions/xblock-google-drive.git@2d176468e33c0713c911b563f8f65f7cf232f5b6#egg=xblock-google-drive  # via -r requirements/edx/testing.txt
@@ -283,6 +282,7 @@ six==1.15.0               # via -r requirements/edx/pip-tools.txt, -r requiremen
 slumber==0.7.1            # via -r requirements/edx/testing.txt, edx-bulk-grades, edx-enterprise, edx-rest-api-client
 smmap==3.0.4              # via -r requirements/edx/testing.txt, gitdb
 snowballstemmer==2.0.0    # via sphinx
+social-auth-app-django==3.4.0  # via -r requirements/edx/testing.txt
 social-auth-core==3.3.3   # via -r requirements/edx/testing.txt, social-auth-app-django
 sorl-thumbnail==12.6.3    # via -r requirements/edx/testing.txt
 sortedcontainers==2.2.2   # via -r requirements/edx/testing.txt, pdfminer.six

--- a/requirements/edx/github.in
+++ b/requirements/edx/github.in
@@ -61,10 +61,6 @@ git+https://github.com/edx/MongoDBProxy.git@d92bafe9888d2940f647a7b2b2383b29c752
 # The latest 2.0.0 release doesn't yet support Django 2.2, this commit from master does
 -e git+https://github.com/jsocol/django-ratelimit.git@72edbe8949fbf6699848e5847645a1998f121d46#egg=ratelimit
 
-# Forked to get Django 2.2 support from unreleased master branch from social-app-django repo.
-# This can be removed once an official social-auth-app-django Pypi release with Django 2.2 support is available in the future.
--e git+https://github.com/python-social-auth/social-app-django.git@c00d23c2b45c3317bd35b15ad1b959338689cef8#egg=social-auth-app-django
-
 # Our libraries:
 -e git+https://github.com/edx/codejail.git@4127fc4bd5775cc72aee8d7f0a70e31405e22439#egg=codejail
 -e git+https://github.com/edx/acid-block.git@98aecba94ecbfa934e2d00262741c0ea9f557fc9#egg=acid-xblock

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -15,7 +15,6 @@
 -e git+https://github.com/edx/RateXBlock.git@2.0#egg=rate-xblock  # via -r requirements/edx/base.txt
 -e common/lib/safe_lxml  # via -r requirements/edx/base.txt
 -e common/lib/sandbox-packages  # via -r requirements/edx/base.txt
--e git+https://github.com/python-social-auth/social-app-django.git@c00d23c2b45c3317bd35b15ad1b959338689cef8#egg=social-auth-app-django  # via -r requirements/edx/base.txt
 -e common/lib/symmath  # via -r requirements/edx/base.txt
 -e openedx/core/lib/xblock_builtin/xblock_discussion  # via -r requirements/edx/base.txt
 -e git+https://github.com/edx-solutions/xblock-google-drive.git@2d176468e33c0713c911b563f8f65f7cf232f5b6#egg=xblock-google-drive  # via -r requirements/edx/base.txt
@@ -271,6 +270,7 @@ singledispatch==3.4.0.3   # via -r requirements/edx/testing.in
 six==1.15.0               # via -r requirements/edx/base.txt, -r requirements/edx/coverage.txt, analytics-python, astroid, bleach, bok-choy, chem, crowdsourcehinter-xblock, cryptography, diff-cover, django-classy-tags, django-countries, django-pyfs, django-sekizai, django-simple-history, django-statici18n, drf-yasg, edx-ace, edx-ccx-keys, edx-django-release-util, edx-drf-extensions, edx-enterprise, edx-i18n-tools, edx-lint, edx-milestones, edx-opaque-keys, edx-rbac, edx-search, event-tracking, freezegun, fs, fs-s3fs, help-tokens, html5lib, httpretty, isodate, libsass, mando, mock, openedx-calc, packaging, pathlib2, paver, pycontracts, pyjwkest, pytest-xdist, python-dateutil, python-memcached, python-swiftclient, singledispatch, social-auth-app-django, social-auth-core, stevedore, tox, transifex-client, virtualenv, xblock
 slumber==0.7.1            # via -r requirements/edx/base.txt, edx-bulk-grades, edx-enterprise, edx-rest-api-client
 smmap==3.0.4              # via gitdb
+social-auth-app-django==3.4.0  # via -r requirements/edx/base.txt
 social-auth-core==3.3.3   # via -r requirements/edx/base.txt, social-auth-app-django
 sorl-thumbnail==12.6.3    # via -r requirements/edx/base.txt
 sortedcontainers==2.2.2   # via -r requirements/edx/base.txt, pdfminer.six


### PR DESCRIPTION
Move social-app-django from github to base requirement, since PyPi version is now compatible with the platform.

https://openedx.atlassian.net/browse/BOM-1676