### PR TITLE
[BD-5] [BB-2503] Add Username column into ORA data report

### DIFF
--- a/lms/djangoapps/instructor_task/tasks_helper/misc.py
+++ b/lms/djangoapps/instructor_task/tasks_helper/misc.py
@@ -282,7 +282,10 @@ def ora2_data_with_deanonymized_usernames(header, rows):
     ``Username`` column, which contains deanonymized usernames.
     """
 
-    anonymized_id_index = header.index("Anonymized Student ID")
+    try:
+        anonymized_id_index = header.index("Anonymized Student ID")
+    except ValueError:
+        return header, rows
 
     anonymized_ids = {row[anonymized_id_index] for row in rows}
     users = (

--- a/lms/djangoapps/instructor_task/tests/test_tasks_helper.py
+++ b/lms/djangoapps/instructor_task/tests/test_tasks_helper.py
@@ -2784,9 +2784,8 @@ class TestInstructorOra2Report(SharedModuleStoreTestCase):
                 self.assertEqual(response, UPDATE_STATUS_FAILED)
 
     def test_report_stores_results(self):
-        with freeze_time('2001-01-01 00:00:00'):
-            test_header = ['field1', 'field2']
-            test_rows = [['row1_field1', 'row1_field2'], ['row2_field1', 'row2_field2']]
+        test_header = ['field1', 'field2']
+        test_rows = [['row1_field1', 'row1_field2'], ['row2_field1', 'row2_field2']]
 
         with patch('lms.djangoapps.instructor_task.tasks_helper.runner._get_current_task') as mock_current_task:
             mock_current_task.return_value = self.current_task
@@ -2798,9 +2797,11 @@ class TestInstructorOra2Report(SharedModuleStoreTestCase):
                 with patch(
                     'lms.djangoapps.instructor_task.models.DjangoStorageReportStore.store_rows'
                 ) as mock_store_rows:
-                    return_val = upload_ora2_data(None, None, self.course.id, None, 'generated')
+                    with freeze_time('2001-01-01 00:00:00'):
+                        return_val = upload_ora2_data(None, None, self.course.id, None, 'generated')
 
-                    timestamp_str = datetime.now(UTC).strftime('%Y-%m-%d-%H%M')
+                        timestamp_str = datetime.now(UTC).strftime('%Y-%m-%d-%H%M')
+
                     course_id_string = quote(text_type(self.course.id).replace('/', '_'))
                     filename = u'{}_ORA_data_{}.csv'.format(course_id_string, timestamp_str)
 


### PR DESCRIPTION
This PR adds `Username` field to the `ORA` data report. Currently, report contains only `Anonymized Student ID`.

[Report example before this change.](https://github.com/edx/edx-platform/files/4722869/TEST3_TEST3_TEST3_ORA_data_2020-06-03-0640.csv.tar.gz)

[Report example after this change.](https://github.com/edx/edx-platform/files/4722866/TEST3_TEST3_TEST3_ORA_data_2020-06-03-0811.csv.tar.gz)



**JIRA tickets**:
- [TNL-7273](https://openedx.atlassian.net/browse/TNL-7273)
- [OSPR-4638](https://openedx.atlassian.net/browse/OSPR-4638)

**Discussions**: None

**Dependencies**: None

**Merge deadline**: None

**Sandbox URL**: TBD - sandbox is being provisioned.

**Testing instructions**:

1. Checkout your `edx-platform` to this branch.
2. Restart `lms` service, if it didn't restart automatically.
3. Create course with `ORA` block or add it to any existing course.
4. Respond to questions in this block with a few users.
5. As a course staff, go to `<Your course>` -> `Instructor` -> `Data Download` (it's a tab in `Instructor Dashboard`) -> click `Generate ORA Data Report` button.
6. If you're testing this using docker devstack, you're unable to download report from the interface. You can find it inside container, in `/tmp/edx-s3/grades/` directory.
7. In downloaded report, you should see new column, `Username`. 

**Author notes and concerns**:

1. I still wait for Marco's answer in ticket comments. Final report form depends on his answer.
2. I don't know if this comment useful:
    ```
    # We perform this step here because don't want to modify ORA runtime
    ```
    Initially it was a little confusing for me why didn't we decide to change `edx-submissions` API response. Probably, it should be obvious for experienced developer.
3. `TestInstructorOra2Report` needs some changes, and probably `ora2_data_with_deanonymized_usernames` also should be covered.

**Reviewers**
- [ ] @giovannicimolin 
- [ ] edX reviewer[s] TBD