### PR TITLE
Fix issue w/ staff toolbar's Insights link

### DIFF
--- a/lms/templates/preview_menu.html
+++ b/lms/templates/preview_menu.html
@@ -31,7 +31,9 @@ show_preview_menu = course and can_masquerade and supports_preview_menu
         protocol = 'https'
     else:
         protocol = 'http'
-    insights_base_url = settings.ANALYTICS_DASHBOARD_URL
+    insights_base_url = ''
+    if settings.ANALYTICS_DASHBOARD_URL:
+        insights_base_url = settings.ANALYTICS_DASHBOARD_URL + '/courses'
     studio_base_url = ''
     if settings.CMS_BASE:
         studio_base_url = protocol + '://' + settings.CMS_BASE


### PR DESCRIPTION
since the configuration value does _not_ include the `/courses` bit in
either stage or prod.

Note: The value for prod contains a trailing slash, while stage does not
:shrug:

I tested locally that this should work with either config
(trailing slash or not).