### PR TITLE
Fixing render_to_response deprecated in Django 3

### DIFF
--- a/openedx/core/djangoapps/plugin_api/views.py
+++ b/openedx/core/djangoapps/plugin_api/views.py
@@ -8,7 +8,7 @@ import logging
 from django.conf import settings
 from django.contrib.staticfiles.storage import staticfiles_storage
 from django.http import HttpResponse
-from django.shortcuts import render_to_response
+from django.shortcuts import render
 from web_fragments.views import FragmentView
 
 from edxmako.shortcuts import is_any_marketing_link_set, is_marketing_link_set, marketing_link
@@ -141,7 +141,11 @@ class EdxFragmentView(FragmentView):
         else:
             template = 'fragments/standalone-page-v1.html'
 
-        return render_to_response(template, context)
+        return render(
+            request=request,
+            template_name=template,
+            context=context
+        )
 
     @property
     def uses_pattern_library(self):

--- a/openedx/features/learner_profile/views/learner_profile.py
+++ b/openedx/features/learner_profile/views/learner_profile.py
@@ -6,7 +6,7 @@ from django.contrib.auth.decorators import login_required
 from django.contrib.staticfiles.storage import staticfiles_storage
 from django.core.exceptions import ObjectDoesNotExist
 from django.http import Http404
-from django.shortcuts import redirect, render_to_response
+from django.shortcuts import redirect, render
 from django.urls import reverse
 from django.utils.translation import ugettext as _
 from django.views.decorators.http import require_http_methods
@@ -51,9 +51,10 @@ def learner_profile(request, username):
 
     try:
         context = learner_profile_context(request, username, request.user.is_staff)
-        return render_to_response(
-            'learner_profile/learner_profile.html',
-            context
+        return render(
+            request=request,
+            template_name='learner_profile/learner_profile.html',
+            context=context
         )
     except (UserNotAuthorized, UserNotFound, ObjectDoesNotExist):
         raise Http404


### PR DESCRIPTION
Fixing RemovedInDjango30Warnings

**Background:** The `django.shortcuts` method `render_to_response` became deprecated in [Django 1.3](https://docs.djangoproject.com/en/3.0/releases/1.3/), when  `render` was introduced.

Per the documentation:

> render() is the same as a call to render_to_response() with a context_instance argument that forces the use of a RequestContext.

Both return an `HttpResponse` object.

**Context:** We changed two statements: An import line and the call to the method, adding explicit parameter names to improve readability.

**Before:**
```
from django.shortcuts import get_object_or_404, render_to_response
...
return render_to_response("teams/teams.html", context)


```

**After**
```
from django.shortcuts import get_object_or_404, render
...
return render(
            request=request,
            template_name="teams/teams.html",
            context=context
        )

```

@felipemontoya 