### PR TITLE
Add marketing_url to courseware_api

### DIFF
--- a/openedx/core/djangoapps/courseware_api/serializers.py
+++ b/openedx/core/djangoapps/courseware_api/serializers.py
@@ -86,6 +86,7 @@ class CourseInfoSerializer(serializers.Serializer):  # pylint: disable=abstract-
     is_staff = serializers.BooleanField()
     can_load_courseware = serializers.DictField()
     notes = serializers.DictField()
+    marketing_url = serializers.CharField()
 
     def __init__(self, *args, **kwargs):
         """


### PR DESCRIPTION
This will let the courseware MFE point at a course's marketing page.

https://openedx.atlassian.net/browse/AA-137