### PR TITLE
[BD-10] [DEPR-83][DEPR-81] Remove pattern library of course_home.py

### DIFF
--- a/openedx/features/course_experience/views/course_home.py
+++ b/openedx/features/course_experience/views/course_home.py
@@ -84,6 +84,7 @@ class CourseHomeFragmentView(EdxFragmentView):
     """
     A fragment to render the home page for a course.
     """
+    _uses_pattern_library = False
 
     def _get_resume_course_info(self, request, course_id):
         """
@@ -258,7 +259,7 @@ class CourseHomeFragmentView(EdxFragmentView):
             'update_message_fragment': update_message_fragment,
             'course_sock_fragment': course_sock_fragment,
             'disable_courseware_js': True,
-            'uses_pattern_library': True,
+            'uses_bootstrap': True,
             'upgrade_price': upgrade_price,
             'upgrade_url': upgrade_url,
             'has_discount': has_discount,


### PR DESCRIPTION
@abutterworth
Tickets on jira: https://openedx.atlassian.net/browse/DEPR-83 , https://openedx.atlassian.net/browse/DEPR-81
Remove use of pattern library of course_experience/views/course_home.py
Test URL: courses/<course-id>/course/home_fragment
The remove of the waffle flag USE_BOOTSTRAP_FLAG is in the PR: #24111
Course outline (#24044), updates (#24062), welcome message (#24077) and dates (#24111) sections have already been fixed in other PR
It's tested on mobile and RTL content.
![home-fragment-pattern](https://user-images.githubusercontent.com/36944773/83905104-b70e8780-a726-11ea-9b2d-52521273d7e1.jpg)
![home-boostrap](https://user-images.githubusercontent.com/36944773/83905107-b83fb480-a726-11ea-9e04-e08600a29881.jpg)
