### PR TITLE
[BD-10] Remove unused course sock URL.

### DIFF
--- a/openedx/features/course_experience/urls.py
+++ b/openedx/features/course_experience/urls.py
@@ -59,11 +59,6 @@ urlpatterns = [
         name='openedx.course_experience.latest_update_fragment_view',
     ),
     url(
-        r'course_sock_fragment$',
-        CourseSockFragmentView.as_view(),
-        name='openedx.course_experience.course_sock_fragment_view',
-    ),
-    url(
         r'^dismiss_welcome_message$',
         dismiss_welcome_message,
         name='openedx.course_experience.dismiss_welcome_message',


### PR DESCRIPTION
The CourseSockFragmentView standalone view is not being used. 

In fact it is throwing
```
TypeError: render_to_fragment() missing 1 required positional argument: 'course'
```

You can check that in the devstack using this URL:

http://localhost:18000/courses/course-v1:edX+DemoX+Demo_Course/course/course_sock_fragment

## Reviewers
- [x] @abutterworth 
- [ ] @amalbas 

