### PR TITLE
removed edx-pattern-library from JS bundles

### DIFF
--- a/common/lib/xmodule/xmodule/js/karma_xmodule.conf.js
+++ b/common/lib/xmodule/xmodule/js/karma_xmodule.conf.js
@@ -61,25 +61,24 @@ var options = {
     ],
 
     libraryFiles: [
-        {pattern: 'common_static/edx-pattern-library/js/**/*.js'},
         {pattern: 'common_static/edx-ui-toolkit/js/**/*.js'}
     ],
 
     // Make sure the patterns in sourceFiles and specFiles do not match the same file.
     // Otherwise Istanbul which is used for coverage tracking will cause tests to not run.
     sourceFiles: [
-        { pattern: 'src/xmodule.js', included: true, ignoreCoverage: true }, // To prevent getting instrumented twice.
+        {pattern: 'src/xmodule.js', included: true, ignoreCoverage: true}, // To prevent getting instrumented twice.
         // Load these before the xmodules that use them
-        { pattern: 'src/javascript_loader.js', included: true },
-        { pattern: 'src/collapsible.js', included: true },
+        {pattern: 'src/javascript_loader.js', included: true},
+        {pattern: 'src/collapsible.js', included: true},
         // Load everything else
         {pattern: 'src/**/!(video)/!(poll|time).js', included: true}
     ],
 
     specFiles: [
         {pattern: 'spec/helper.js', included: true, ignoreCoverage: true}, // Helper which depends on source files.
-        { pattern: 'spec/**/!(video)/*.js', included: true },
-        { pattern: 'spec/!(time_spec|video_helper).js', included: true }
+        {pattern: 'spec/**/!(video)/*.js', included: true},
+        {pattern: 'spec/!(time_spec|video_helper).js', included: true}
     ],
 
     fixtureFiles: [

--- a/common/static/common/js/karma.common.conf.js
+++ b/common/static/common/js/karma.common.conf.js
@@ -60,7 +60,6 @@ var commonsChunkPluginIndex = webpackConfig[0].plugins.findIndex(function(plugin
 var commonFiles = {
     libraryFiles: [
         {pattern: 'common/js/vendor/**/*.js'},
-        {pattern: 'edx-pattern-library/js/**/*.js'},
         {pattern: 'edx-ui-toolkit/js/**/*.js'},
         {pattern: 'xmodule_js/common_static/common/js/**/!(*spec).js'},
         {pattern: 'xmodule_js/common_static/js/**/!(*spec).js'},


### PR DESCRIPTION
Remove edx-pattern-library javascript from bundles - [https://openedx.atlassian.net/browse/DEPR-91](DEPR-91).

Reviewer: @abutterworth 