### PR TITLE
[BD-10] [DEPR-72] Remove pattern library of course_search.py

### DIFF
--- a/lms/static/sass/features/_course-experience.scss
+++ b/lms/static/sass/features/_course-experience.scss
@@ -538,19 +538,20 @@
       background: $gray-100;
     }
   }
+}
 
-  .breadcrumbs {
-    font-size: 0.875rem;
+// Course Breadcrumbs
+.has-breadcrumbs .breadcrumbs {
+  font-size: 0.875rem;
 
-    .nav-item {
-      @include margin-left($baseline/4);
-    }
+  .nav-item {
+    @include margin-left($baseline/4);
+  }
 
-    .fa-angle-right {
-      transform: rotateY(0deg) #{"/*rtl: rotateY(180deg)*/"};
+  .fa-angle-right {
+    transform: rotateY(0deg) #{"/*rtl: rotateY(180deg)*/"};
 
-      @include margin-left($baseline/4);
-    }
+    @include margin-left($baseline/4);
   }
 }
 

--- a/openedx/features/course_search/templates/course_search/course-search-fragment.html
+++ b/openedx/features/course_search/templates/course_search/course-search-fragment.html
@@ -36,17 +36,19 @@ from openedx.features.course_experience import course_home_page_title
         </div>
         <div class="page-header-secondary">
             <div class="page-header-search">
-                <form class="search-form" role="search">
-                    <label class="field-label sr-only" for="search" id="search-hint">${_('Search the course')}</label>
+                <form class="search-form input-group" role="search">
                     <input
-                            class="field-input input-text search-field"
+                            class="field-input input-text search-field form-control"
                             type="search"
                             name="query"
                             id="search"
                             value="${query}"
                             placeholder="${_('Search the course')}"
                     />
-                    <button class="btn btn-small search-button" type="submit">${_('Search')}</button>
+                    <label class="field-label sr-only" for="search" id="search-hint">${_('Search the course')}</label>
+                    <div class="input-group-append input-group-btn">
+                        <button class="btn btn-outline-primary search-button" type="submit">${_('Search')}</button>
+                    </div>
                 </form>
             </div>
         </div>

--- a/openedx/features/course_search/views/course_search.py
+++ b/openedx/features/course_search/views/course_search.py
@@ -40,11 +40,19 @@ class CourseSearchView(CourseTabView):
         home_fragment_view = CourseSearchFragmentView()
         return home_fragment_view.render_to_fragment(request, course_id=course_id, **kwargs)
 
+    def uses_bootstrap(self, request, course, tab):
+        """
+        Always render this tab with bootstrap
+        """
+        return True
+
 
 class CourseSearchFragmentView(EdxFragmentView):
     """
     A fragment to render the home page for a course.
     """
+    _uses_pattern_library = False
+
     def render_to_fragment(self, request, course_id=None, **kwargs):
         """
         Renders the course's home page as a fragment.
@@ -62,7 +70,7 @@ class CourseSearchFragmentView(EdxFragmentView):
             'course_url': course_url,
             'query': request.GET.get('query', ''),
             'disable_courseware_js': True,
-            'uses_pattern_library': True,
+            'uses_bootstrap': True,
         }
         html = render_to_string('course_search/course-search-fragment.html', context)
         return Fragment(html)


### PR DESCRIPTION
@abutterworth
Ticket on jira: https://openedx.atlassian.net/browse/DEPR-72 
Remove use of pattern library of course_search/views/course_search.py
As discussed in https://openedx.atlassian.net/browse/DEPR-69, we override the uses_bootstrap in CourseSearchView.
Test URL: courses/<course-id>/search/home_fragment
It's tested on mobile and RTL content.
![search-fragment-pattern](https://user-images.githubusercontent.com/36944773/84078837-30181400-a99f-11ea-9c36-17ad54917f12.jpg)
![course-search-fragment-bootstrap](https://user-images.githubusercontent.com/36944773/86862485-e5b5b000-c08e-11ea-8c84-c5bcb449cf69.jpg)

