### PR TITLE
Change switch to waffle flag.

### DIFF
--- a/lms/djangoapps/instructor_task/config/waffle.py
+++ b/lms/djangoapps/instructor_task/config/waffle.py
@@ -3,23 +3,36 @@ This module contains various configuration settings via
 waffle switches for the instructor_task app.
 """
 
+from openedx.core.djangoapps.waffle_utils import CourseWaffleFlag, WaffleFlagNamespace, WaffleSwitchNamespace
 
-from openedx.core.djangoapps.waffle_utils import WaffleFlagNamespace, WaffleSwitchNamespace
-
-WAFFLE_NAMESPACE = u'instructor_task'
+WAFFLE_NAMESPACE = 'instructor_task'
 INSTRUCTOR_TASK_WAFFLE_FLAG_NAMESPACE = WaffleFlagNamespace(name=WAFFLE_NAMESPACE)
 WAFFLE_SWITCHES = WaffleSwitchNamespace(name=WAFFLE_NAMESPACE)
 
 # Waffle switches
-OPTIMIZE_GET_LEARNERS_FOR_COURSE = u'optimize_get_learners_for_course'
-GENERATE_GRADE_REPORT_VERIFIED_ONLY = u'generate_grade_report_for_verified_only'
+OPTIMIZE_GET_LEARNERS_FOR_COURSE = 'optimize_get_learners_for_course'
+
+# Course override flags
+GENERATE_PROBLEM_GRADE_REPORT_VERIFIED_ONLY = 'generate_problem_grade_report_verified_only'
+GENERATE_COURSE_GRADE_REPORT_VERIFIED_ONLY = 'generate_course_grade_report_verified_only'
 
 
 def waffle_flags():
     """
     Returns the namespaced, cached, audited Waffle flags dictionary for Grades.
     """
-    return {}
+    return {
+        GENERATE_PROBLEM_GRADE_REPORT_VERIFIED_ONLY: CourseWaffleFlag(
+            waffle_namespace=INSTRUCTOR_TASK_WAFFLE_FLAG_NAMESPACE,
+            flag_name=GENERATE_PROBLEM_GRADE_REPORT_VERIFIED_ONLY,
+            flag_undefined_default=False,
+        ),
+        GENERATE_COURSE_GRADE_REPORT_VERIFIED_ONLY: CourseWaffleFlag(
+            waffle_namespace=INSTRUCTOR_TASK_WAFFLE_FLAG_NAMESPACE,
+            flag_name=GENERATE_COURSE_GRADE_REPORT_VERIFIED_ONLY,
+            flag_undefined_default=False,
+        ),
+    }
 
 
 def optimize_get_learners_switch_enabled():
@@ -29,9 +42,19 @@ def optimize_get_learners_switch_enabled():
     return WAFFLE_SWITCHES.is_enabled(OPTIMIZE_GET_LEARNERS_FOR_COURSE)
 
 
-def generate_grade_report_for_verified_only():
+def problem_grade_report_verified_only(course_id):
     """
-    Returns True if waffle switch is enabled that indicates generate grading reports only for
-    verified learners.
+    Returns True if problem grade reports should only
+    return rows for verified students in the given course,
+    False otherwise.
     """
-    return WAFFLE_SWITCHES.is_enabled(GENERATE_GRADE_REPORT_VERIFIED_ONLY)
+    return waffle_flags()[GENERATE_PROBLEM_GRADE_REPORT_VERIFIED_ONLY].is_enabled(course_id)
+
+
+def course_grade_report_verified_only(course_id):
+    """
+    Returns True if problem grade reports should only
+    return rows for verified students in the given course,
+    False otherwise.
+    """
+    return waffle_flags()[GENERATE_COURSE_GRADE_REPORT_VERIFIED_ONLY].is_enabled(course_id)


### PR DESCRIPTION
This PR changes the Waffle Switch to CourseOverride Flag for Course Grade Reports and Problem Grade Reports.

### New Waffle flag CourseOverrides
**flag_undefined_default: False**
* _instructor_task.generate_course_grade_report_verified_only_
* _instructor_task.generate_problem_grade_report_verified_only_


Admin Model:
[waffleflagcourseoverridemodel](http://localhost:18000/admin/waffle_utils/waffleflagcourseoverridemodel/)