### PR TITLE
PROD-1633: fix highlights error case

### DIFF
--- a/openedx/core/djangoapps/schedules/content_highlights.py
+++ b/openedx/core/djangoapps/schedules/content_highlights.py
@@ -134,7 +134,10 @@ def _section_has_highlights(section):
 
 
 def _get_sections_with_highlights(course_module):
-    return list(filter(_section_has_highlights, course_module.get_children()))
+    if course_module:
+        return list(filter(_section_has_highlights, course_module.get_children()))
+    else:
+        return []
 
 
 def _get_highlights_for_week(sections, week_num, course_key):


### PR DESCRIPTION
When calculating course highlights, if we didn't manage to get a course module, we were previously throwing an exception. Handle that more gracefully.

With this change, we'll end up throwing a CourseUpdateDoesNotExist, which the surrounding code should be able to handle.