### PR TITLE
[BD-6] Use transifex-client fork

### DIFF
--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -97,10 +97,6 @@ python-dateutil==2.4.0
 # stevedore 2.0.0 requires python >= 3.6
 stevedore<2.0.0
 
-# transifex-client 0.13.5 and 0.13.6 needlessly pin six and urllib3, 0.13.7 does so for python-slugify
-#   https://github.com/transifex/transifex-client/issues/252
-transifex-client==0.13.4
-
 # Constraint from astroid 2.3.3
 wrapt==1.11.*
 

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -146,6 +146,8 @@ fs-s3fs==0.1.8            # via -r requirements/edx/testing.txt, django-pyfs
 fs==2.0.18                # via -r requirements/edx/testing.txt, django-pyfs, fs-s3fs, xblock
 future==0.18.2            # via -r requirements/edx/testing.txt, django-ses, edx-celeryutils, edx-enterprise, pycontracts, pyjwkest, radon
 geoip2==3.0.0             # via -r requirements/edx/testing.txt
+gitdb==4.0.5              # via gitpython
+gitpython==3.1.3          # via transifex-client
 glob2==0.7                # via -r requirements/edx/testing.txt
 gunicorn==20.0.4          # via -r requirements/edx/testing.txt
 help-tokens==1.1.2        # via -r requirements/edx/testing.txt
@@ -279,6 +281,7 @@ simplejson==3.17.0        # via -r requirements/edx/testing.txt, sailthru-client
 singledispatch==3.4.0.3   # via -r requirements/edx/testing.txt
 six==1.15.0               # via -r requirements/edx/pip-tools.txt, -r requirements/edx/testing.txt, analytics-python, astroid, bleach, bok-choy, chem, crowdsourcehinter-xblock, cryptography, diff-cover, django-classy-tags, django-countries, django-pyfs, django-sekizai, django-simple-history, django-statici18n, drf-yasg, edx-ace, edx-ccx-keys, edx-django-release-util, edx-drf-extensions, edx-enterprise, edx-i18n-tools, edx-lint, edx-milestones, edx-opaque-keys, edx-rbac, edx-search, edx-sphinx-theme, event-tracking, freezegun, fs, fs-s3fs, help-tokens, html5lib, httpretty, isodate, jsonschema, libsass, mando, mock, openedx-calc, packaging, pathlib2, paver, pip-tools, pycontracts, pyjwkest, pytest-xdist, python-dateutil, python-memcached, python-swiftclient, singledispatch, social-auth-app-django, social-auth-core, sphinxcontrib-httpdomain, stevedore, tox, transifex-client, virtualenv, xblock
 slumber==0.7.1            # via -r requirements/edx/testing.txt, edx-bulk-grades, edx-enterprise, edx-rest-api-client
+smmap==3.0.4              # via gitdb
 snowballstemmer==2.0.0    # via sphinx
 social-auth-core==3.3.3   # via -r requirements/edx/testing.txt, social-auth-app-django
 sorl-thumbnail==12.6.3    # via -r requirements/edx/testing.txt
@@ -304,7 +307,7 @@ toml==0.10.1              # via -r requirements/edx/testing.txt, tox
 tox-battery==0.6.1        # via -r requirements/edx/testing.txt
 tox==3.15.2               # via -r requirements/edx/testing.txt, tox-battery
 tqdm==4.46.1              # via -r requirements/edx/testing.txt, nltk
-transifex-client==0.13.4  # via -c requirements/edx/../constraints.txt, -r requirements/edx/testing.txt
+git+https://github.com/edx/transifex-client.git@1660e05cb4a608a420b23f569c329ba3ff13b175#egg=transifex-client  # via -r requirements/edx/testing.in
 typed-ast==1.4.1          # via -r requirements/edx/testing.txt, astroid
 unicodecsv==0.14.1        # via -r requirements/edx/testing.txt, edx-enterprise
 unidiff==0.6.0            # via -r requirements/edx/testing.txt, coverage-pytest-plugin

--- a/requirements/edx/testing.in
+++ b/requirements/edx/testing.in
@@ -47,5 +47,7 @@ singledispatch            # Backport of functools.singledispatch from Python 3.4
 testfixtures              # Provides a LogCapture utility used by several tests
 tox                       # virtualenv management for tests
 tox-battery               # Makes tox aware of requirements file changes
-transifex-client          # Command-line interface for the Transifex localization service
+# Transifex fork used for compatibilities with python3.8, move to pypi release once
+# https://github.com/transifex/transifex-client/pull/293 gets merged and released
+git+https://github.com/edx/transifex-client.git@1660e05cb4a608a420b23f569c329ba3ff13b175#egg=transifex-client
 unidiff                   # Required by coverage_pytest_plugin

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -142,6 +142,8 @@ fs-s3fs==0.1.8            # via -r requirements/edx/base.txt, django-pyfs
 fs==2.0.18                # via -r requirements/edx/base.txt, django-pyfs, fs-s3fs, xblock
 future==0.18.2            # via -r requirements/edx/base.txt, django-ses, edx-celeryutils, edx-enterprise, pycontracts, pyjwkest, radon
 geoip2==3.0.0             # via -r requirements/edx/base.txt
+gitdb==4.0.5              # via gitpython
+gitpython==3.1.3          # via transifex-client
 glob2==0.7                # via -r requirements/edx/base.txt
 gunicorn==20.0.4          # via -r requirements/edx/base.txt
 help-tokens==1.1.2        # via -r requirements/edx/base.txt
@@ -268,6 +270,7 @@ simplejson==3.17.0        # via -r requirements/edx/base.txt, sailthru-client, s
 singledispatch==3.4.0.3   # via -r requirements/edx/testing.in
 six==1.15.0               # via -r requirements/edx/base.txt, -r requirements/edx/coverage.txt, analytics-python, astroid, bleach, bok-choy, chem, crowdsourcehinter-xblock, cryptography, diff-cover, django-classy-tags, django-countries, django-pyfs, django-sekizai, django-simple-history, django-statici18n, drf-yasg, edx-ace, edx-ccx-keys, edx-django-release-util, edx-drf-extensions, edx-enterprise, edx-i18n-tools, edx-lint, edx-milestones, edx-opaque-keys, edx-rbac, edx-search, event-tracking, freezegun, fs, fs-s3fs, help-tokens, html5lib, httpretty, isodate, libsass, mando, mock, openedx-calc, packaging, pathlib2, paver, pycontracts, pyjwkest, pytest-xdist, python-dateutil, python-memcached, python-swiftclient, singledispatch, social-auth-app-django, social-auth-core, stevedore, tox, transifex-client, virtualenv, xblock
 slumber==0.7.1            # via -r requirements/edx/base.txt, edx-bulk-grades, edx-enterprise, edx-rest-api-client
+smmap==3.0.4              # via gitdb
 social-auth-core==3.3.3   # via -r requirements/edx/base.txt, social-auth-app-django
 sorl-thumbnail==12.6.3    # via -r requirements/edx/base.txt
 sortedcontainers==2.2.2   # via -r requirements/edx/base.txt, pdfminer.six
@@ -283,7 +286,7 @@ toml==0.10.1              # via tox
 tox-battery==0.6.1        # via -r requirements/edx/testing.in
 tox==3.15.2               # via -r requirements/edx/testing.in, tox-battery
 tqdm==4.46.1              # via -r requirements/edx/base.txt, nltk
-transifex-client==0.13.4  # via -c requirements/edx/../constraints.txt, -r requirements/edx/testing.in
+git+https://github.com/edx/transifex-client.git@1660e05cb4a608a420b23f569c329ba3ff13b175#egg=transifex-client  # via -r requirements/edx/testing.in
 typed-ast==1.4.1          # via astroid
 unicodecsv==0.14.1        # via -r requirements/edx/base.txt, edx-enterprise
 unidiff==0.6.0            # via -r requirements/edx/testing.in, coverage-pytest-plugin


### PR DESCRIPTION
Upgrade transifex-client version.

This is only made in order to run the tests with a transifex-client version compatible with python3.8

The actual problem that we have in edx-platform is that the last version of transifex-client has as constraint python-slugify<2.0.0 which is not compatible with the current requierements of edx-platform on the other hand, the current version used in edx-platform is not compatible with python3.8

## Reviewers
- [ ] @awais786 
- [ ] @ericfab179 