### PR TITLE
ARCHBOM-1263: enhance code owner middleware

### DIFF
--- a/lms/djangoapps/monitoring/middleware.py
+++ b/lms/djangoapps/monitoring/middleware.py
@@ -2,7 +2,7 @@
 Middleware for monitoring the LMS
 """
 import logging
-from django.urls import resolve
+from django.urls import Resolver404, resolve
 from edx_django_utils.cache import DEFAULT_REQUEST_CACHE
 from edx_django_utils.monitoring import set_custom_metric
 
@@ -31,7 +31,9 @@ class CodeOwnerMetricMiddleware:
         return response
 
     def process_view(self, request, view_func, view_args, view_kwargs):
-        self._set_owner_metrics_for_view_func(view_func)
+        self._set_view_func_compare_metric(view_func)
+
+    _VIEW_FUNC_MODULE_METRIC_CACHE_KEY = '{}.view_func_module_metric'.format(__file__)
 
     def _set_owner_metrics_for_request(self, request):
         """
@@ -42,37 +44,29 @@ class CodeOwnerMetricMiddleware:
 
         try:
             view_func, _, _ = resolve(request.path)
-            self._set_owner_metrics_for_view_func(view_func)
-        except Exception as e:
-            set_custom_metric('code_owner_mapping_error', e)
-
-    _VIEW_FUNC_MODULE_METRIC_CACHE_KEY = '{}.view_func_module_metric'.format(__file__)
-
-    def _set_owner_metrics_for_view_func(self, view_func):
-        """
-        Set custom metrics for the code_owner of the view if configured to do so.
-        """
-        if not is_code_owner_mappings_configured():
-            return
-
-        try:
             view_func_module = view_func.__module__
-            self._set_view_func_compare_metric(view_func_module)
+            DEFAULT_REQUEST_CACHE.set(self._VIEW_FUNC_MODULE_METRIC_CACHE_KEY, view_func_module)
             set_custom_metric('view_func_module', view_func_module)
             code_owner = get_code_owner_from_module(view_func_module)
             if code_owner:
                 set_custom_metric('code_owner', code_owner)
+        except Resolver404:
+            set_custom_metric('code_owner_mapping_error', "Couldn't resolve view for request path {}".format(request.path))
         except Exception as e:
             set_custom_metric('code_owner_mapping_error', e)
 
-    def _set_view_func_compare_metric(self, view_func_module):
+    def _set_view_func_compare_metric(self, view_func):
         """
         Set temporary metric to ensure that the view_func of `process_view` always matches
         the one from using `resolve` on the request.
         """
-        cached_response = DEFAULT_REQUEST_CACHE.get_cached_response(self._VIEW_FUNC_MODULE_METRIC_CACHE_KEY)
-        if cached_response.is_found:
-            view_func_compare = 'success' if view_func_module == cached_response.value else view_func_module
+        try:
+            view_func_module = view_func.__module__
+            cached_response = DEFAULT_REQUEST_CACHE.get_cached_response(self._VIEW_FUNC_MODULE_METRIC_CACHE_KEY)
+            if cached_response.is_found:
+                view_func_compare = 'success' if view_func_module == cached_response.value else view_func_module
+            else:
+                view_func_compare = 'missing'
             set_custom_metric('temp_view_func_compare', view_func_compare)
-        else:
-            DEFAULT_REQUEST_CACHE.set(self._VIEW_FUNC_MODULE_METRIC_CACHE_KEY, view_func_module)
+        except Exception as e:
+            set_custom_metric('temp_view_func_compare_error', e)

--- a/lms/djangoapps/monitoring/middleware.py
+++ b/lms/djangoapps/monitoring/middleware.py
@@ -2,6 +2,8 @@
 Middleware for monitoring the LMS
 """
 import logging
+from django.urls import resolve
+from edx_django_utils.cache import DEFAULT_REQUEST_CACHE
 from edx_django_utils.monitoring import set_custom_metric
 
 from .utils import get_code_owner_from_module, is_code_owner_mappings_configured
@@ -24,21 +26,53 @@ class CodeOwnerMetricMiddleware:
         self.get_response = get_response
 
     def __call__(self, request):
+        self._set_owner_metrics_for_request(request)
         response = self.get_response(request)
         return response
 
     def process_view(self, request, view_func, view_args, view_kwargs):
+        self._set_owner_metrics_for_view_func(view_func)
+
+    def _set_owner_metrics_for_request(self, request):
         """
-        Set custom metric for the code_owner of the view if configured to do so.
+        Uses the request path to find the view_func and then sets code owner metrics based on the view.
+        """
+        if not is_code_owner_mappings_configured():
+            return
+
+        try:
+            view_func, _, _ = resolve(request.path)
+            self._set_owner_metrics_for_view_func(view_func)
+        except Exception as e:
+            set_custom_metric('code_owner_mapping_error', e)
+
+    _VIEW_FUNC_MODULE_METRIC_CACHE_KEY = '{}.view_func_module_metric'.format(__file__)
+
+    def _set_owner_metrics_for_view_func(self, view_func):
+        """
+        Set custom metrics for the code_owner of the view if configured to do so.
         """
         if not is_code_owner_mappings_configured():
             return
 
         try:
             view_func_module = view_func.__module__
+            self._set_view_func_compare_metric(view_func_module)
             set_custom_metric('view_func_module', view_func_module)
             code_owner = get_code_owner_from_module(view_func_module)
             if code_owner:
                 set_custom_metric('code_owner', code_owner)
         except Exception as e:
             set_custom_metric('code_owner_mapping_error', e)
+
+    def _set_view_func_compare_metric(self, view_func_module):
+        """
+        Set temporary metric to ensure that the view_func of `process_view` always matches
+        the one from using `resolve` on the request.
+        """
+        cached_response = DEFAULT_REQUEST_CACHE.get_cached_response(self._VIEW_FUNC_MODULE_METRIC_CACHE_KEY)
+        if cached_response.is_found:
+            view_func_compare = 'success' if view_func_module == cached_response.value else view_func_module
+            set_custom_metric('temp_view_func_compare', view_func_compare)
+        else:
+            DEFAULT_REQUEST_CACHE.set(self._VIEW_FUNC_MODULE_METRIC_CACHE_KEY, view_func_module)

--- a/lms/djangoapps/monitoring/tests/mock_views.py
+++ b/lms/djangoapps/monitoring/tests/mock_views.py
@@ -1,0 +1,14 @@
+"""
+Mock views with a different module to enable testing of mapping
+code_owner to modules. Trying to mock __module__ on a view was
+getting too complex.
+"""
+from rest_framework.views import APIView
+
+
+class MockViewTest(APIView):
+    pass
+
+
+class MockViewAnotherTest(APIView):
+    pass

--- a/lms/djangoapps/monitoring/tests/mock_views.py
+++ b/lms/djangoapps/monitoring/tests/mock_views.py
@@ -7,8 +7,7 @@ from rest_framework.views import APIView
 
 
 class MockViewTest(APIView):
-    pass
-
-
-class MockViewAnotherTest(APIView):
+    """
+    Mock view for use in testing.
+    """
     pass

--- a/lms/djangoapps/monitoring/tests/test_middleware.py
+++ b/lms/djangoapps/monitoring/tests/test_middleware.py
@@ -2,36 +2,39 @@
 Tests for the LMS monitoring middleware
 """
 import ddt
-import timeit
-from django.test import override_settings
+from django.conf.urls import url
+from django.test import override_settings, RequestFactory
+from edx_django_utils.cache import RequestCache
 from mock import call, patch, Mock
+from rest_framework.views import APIView
 from unittest import TestCase
 from unittest.mock import ANY
 
 from lms.djangoapps.monitoring.middleware import CodeOwnerMetricMiddleware
+from lms.djangoapps.monitoring.tests.mock_views import MockViewAnotherTest, MockViewTest
 from lms.djangoapps.monitoring.utils import _process_code_owner_mappings
 
 
-class MockWithMockModule():
-    """
-    Mock object with a mocked __module__ method.
-    """
-    def __init__(self, mocked_module_name):
-        self._mocked_module_name = mocked_module_name
+class MockMiddlewareViewTest(APIView):
+    pass
 
-    def __getattribute__(self, name):
-        if name == '__module__':
-            return self._mocked_module_name
-        return super().__getattribute__(name)
 
+urlpatterns = [
+    url(r'^middleware-test/$', MockMiddlewareViewTest.as_view()),
+    url(r'^test/$', MockViewTest.as_view()),
+    url(r'^another-test/$', MockViewAnotherTest.as_view()),
+]
 
 @ddt.ddt
 class CodeOwnerMetricMiddlewareTests(TestCase):
     """
     Tests for the LMS monitoring utility functions
     """
+    urls = 'lms.djangoapps.monitoring.tests.test_middleware.test_urls'
+
     def setUp(self):
         super().setUp()
+        RequestCache.clear_all_namespaces()
         self.mock_get_response = Mock()
         self.middleware = CodeOwnerMetricMiddleware(self.mock_get_response)
 
@@ -43,48 +46,70 @@ class CodeOwnerMetricMiddlewareTests(TestCase):
         request = Mock()
         self.assertEqual(self.middleware(request), 'test-response')
 
-    @override_settings(CODE_OWNER_MAPPINGS={
-        'team-red': [
-            'openedx.core.djangoapps.xblock',
-        ],
-        'team-blue': [
-            'common.djangoapps.xblock_django',
-        ],
-    })
+    @override_settings(
+        CODE_OWNER_MAPPINGS={
+            'team-red': ['openedx.core.djangoapps.xblock'],
+            'team-blue': ['common.djangoapps.xblock_django'],
+        },
+        ROOT_URLCONF=__name__
+    )
     @patch('lms.djangoapps.monitoring.middleware.set_custom_metric')
     @ddt.data(
-        ('xblock', 'team-red'),
-        ('openedx.core.djangoapps', None),
-        ('openedx.core.djangoapps.xblock.views', 'team-red'),
-        ('xblock_django', 'team-blue'),
-        ('common.djangoapps.xblock_django', 'team-blue'),
+        ('/test/', 'lms.djangoapps.monitoring.tests.mock_views', 'team-red'),
     )
     @ddt.unpack
-    def test_code_owner_mapping_hits_and_misses(
-        self, view_func_module, expected_owner, mock_set_custom_metric
+    def test_process_request_code_owner_mapping_hits_and_misses(
+        self, request_path, expected_module, expected_owner, mock_set_custom_metric
     ):
         with patch('lms.djangoapps.monitoring.utils._PATH_TO_CODE_OWNER_MAPPINGS', _process_code_owner_mappings()):
-            mock_view_func = MockWithMockModule(view_func_module)
-            self.middleware.process_view(None, mock_view_func, None, None)
+            request = RequestFactory().get(request_path)
+            self.middleware(request)
             self._assert_code_owner_custom_metrics(
-                view_func_module, mock_set_custom_metric, expected_code_owner=expected_owner
+                expected_module, mock_set_custom_metric, expected_code_owner=expected_owner
             )
 
-    @patch('lms.djangoapps.monitoring.middleware.set_custom_metric')
-    def test_code_owner_no_mappings(self, mock_set_custom_metric):
-        mock_view_func = MockWithMockModule('xblock')
-        self.middleware.process_view(None, mock_view_func, None, None)
-        mock_set_custom_metric.assert_not_called()
-
-    @override_settings(CODE_OWNER_MAPPINGS=['invalid_setting_as_list'])
-    @patch('lms.djangoapps.monitoring.middleware.set_custom_metric')
-    def test_load_config_with_invalid_dict(self, mock_set_custom_metric):
-        with patch('lms.djangoapps.monitoring.utils._PATH_TO_CODE_OWNER_MAPPINGS', _process_code_owner_mappings()):
-            mock_view_func = MockWithMockModule('xblock')
-            self.middleware.process_view(None, mock_view_func, None, None)
-            self._assert_code_owner_custom_metrics(
-                'xblock', mock_set_custom_metric, has_error=True
-            )
+    # @override_settings(CODE_OWNER_MAPPINGS={
+    #     'team-red': [
+    #         'openedx.core.djangoapps.xblock',
+    #     ],
+    #     'team-blue': [
+    #         'common.djangoapps.xblock_django',
+    #     ],
+    # })
+    # @patch('lms.djangoapps.monitoring.middleware.set_custom_metric')
+    # @ddt.data(
+    #     ('xblock', 'team-red'),
+    #     ('openedx.core.djangoapps', None),
+    #     ('openedx.core.djangoapps.xblock.views', 'team-red'),
+    #     ('xblock_django', 'team-blue'),
+    #     ('common.djangoapps.xblock_django', 'team-blue'),
+    # )
+    # @ddt.unpack
+    # def test_code_owner_mapping_hits_and_misses(
+    #     self, view_func_module, expected_owner, mock_set_custom_metric
+    # ):
+    #     with patch('lms.djangoapps.monitoring.utils._PATH_TO_CODE_OWNER_MAPPINGS', _process_code_owner_mappings()):
+    #         mock_view_func = MockViewWithMockModule(view_func_module)
+    #         self.middleware.process_view(None, mock_view_func, None, None)
+    #         self._assert_code_owner_custom_metrics(
+    #             view_func_module, mock_set_custom_metric, expected_code_owner=expected_owner
+    #         )
+    #
+    # @patch('lms.djangoapps.monitoring.middleware.set_custom_metric')
+    # def test_code_owner_no_mappings(self, mock_set_custom_metric):
+    #     mock_view_func = MockViewWithMockModule('xblock')
+    #     self.middleware.process_view(None, mock_view_func, None, None)
+    #     mock_set_custom_metric.assert_not_called()
+    #
+    # @override_settings(CODE_OWNER_MAPPINGS=['invalid_setting_as_list'])
+    # @patch('lms.djangoapps.monitoring.middleware.set_custom_metric')
+    # def test_load_config_with_invalid_dict(self, mock_set_custom_metric):
+    #     with patch('lms.djangoapps.monitoring.utils._PATH_TO_CODE_OWNER_MAPPINGS', _process_code_owner_mappings()):
+    #         mock_view_func = MockViewWithMockModule('xblock')
+    #         self.middleware.process_view(None, mock_view_func, None, None)
+    #         self._assert_code_owner_custom_metrics(
+    #             'xblock', mock_set_custom_metric, has_error=True
+    #         )
 
     def _assert_code_owner_custom_metrics(
         self, view_func_module, mock_set_custom_metric, expected_code_owner=None, has_error=False,

--- a/lms/djangoapps/monitoring/tests/test_middleware.py
+++ b/lms/djangoapps/monitoring/tests/test_middleware.py
@@ -25,6 +25,7 @@ urlpatterns = [
     url(r'^test/$', MockViewTest.as_view()),
 ]
 
+
 @ddt.ddt
 class CodeOwnerMetricMiddlewareTests(TestCase):
     """
@@ -94,7 +95,7 @@ class CodeOwnerMetricMiddlewareTests(TestCase):
 
     @override_settings(
         CODE_OWNER_MAPPINGS=['invalid_setting_as_list'],
-        ROOT_URLCONF = __name__,
+        ROOT_URLCONF=__name__,
     )
     @patch('lms.djangoapps.monitoring.middleware.set_custom_metric')
     def test_load_config_with_invalid_dict(self, mock_set_custom_metric):

--- a/lms/djangoapps/monitoring/tests/test_middleware.py
+++ b/lms/djangoapps/monitoring/tests/test_middleware.py
@@ -4,6 +4,7 @@ Tests for the LMS monitoring middleware
 import ddt
 from django.conf.urls import url
 from django.test import override_settings, RequestFactory
+from django.urls import resolve
 from edx_django_utils.cache import RequestCache
 from mock import call, patch, Mock
 from rest_framework.views import APIView
@@ -11,7 +12,7 @@ from unittest import TestCase
 from unittest.mock import ANY
 
 from lms.djangoapps.monitoring.middleware import CodeOwnerMetricMiddleware
-from lms.djangoapps.monitoring.tests.mock_views import MockViewAnotherTest, MockViewTest
+from lms.djangoapps.monitoring.tests.mock_views import MockViewTest
 from lms.djangoapps.monitoring.utils import _process_code_owner_mappings
 
 
@@ -22,7 +23,6 @@ class MockMiddlewareViewTest(APIView):
 urlpatterns = [
     url(r'^middleware-test/$', MockMiddlewareViewTest.as_view()),
     url(r'^test/$', MockViewTest.as_view()),
-    url(r'^another-test/$', MockViewAnotherTest.as_view()),
 ]
 
 @ddt.ddt
@@ -46,78 +46,119 @@ class CodeOwnerMetricMiddlewareTests(TestCase):
         request = Mock()
         self.assertEqual(self.middleware(request), 'test-response')
 
+    _REQUEST_PATH_TO_MODULE_PATH = {
+        '/middleware-test/': 'test_middleware',
+        '/test/': 'lms.djangoapps.monitoring.tests.mock_views',
+    }
+
     @override_settings(
-        CODE_OWNER_MAPPINGS={
-            'team-red': ['openedx.core.djangoapps.xblock'],
-            'team-blue': ['common.djangoapps.xblock_django'],
-        },
-        ROOT_URLCONF=__name__
+        CODE_OWNER_MAPPINGS={'team-red': ['lms.djangoapps.monitoring.tests.mock_views']},
+        ROOT_URLCONF=__name__,
     )
     @patch('lms.djangoapps.monitoring.middleware.set_custom_metric')
     @ddt.data(
-        ('/test/', 'lms.djangoapps.monitoring.tests.mock_views', 'team-red'),
+        ('/middleware-test/', None),
+        ('/test/', 'team-red'),
     )
     @ddt.unpack
-    def test_process_request_code_owner_mapping_hits_and_misses(
-        self, request_path, expected_module, expected_owner, mock_set_custom_metric
+    def test_code_owner_mapping_hits_and_misses(
+        self, request_path, expected_owner, mock_set_custom_metric
     ):
         with patch('lms.djangoapps.monitoring.utils._PATH_TO_CODE_OWNER_MAPPINGS', _process_code_owner_mappings()):
             request = RequestFactory().get(request_path)
             self.middleware(request)
+            view_func, _, _ = resolve(request_path)
+            self.middleware.process_view(None, view_func, None, None)
+            expected_view_func_module = self._REQUEST_PATH_TO_MODULE_PATH[request_path]
             self._assert_code_owner_custom_metrics(
-                expected_module, mock_set_custom_metric, expected_code_owner=expected_owner
+                expected_view_func_module, mock_set_custom_metric, expected_code_owner=expected_owner
             )
 
-    # @override_settings(CODE_OWNER_MAPPINGS={
-    #     'team-red': [
-    #         'openedx.core.djangoapps.xblock',
-    #     ],
-    #     'team-blue': [
-    #         'common.djangoapps.xblock_django',
-    #     ],
-    # })
-    # @patch('lms.djangoapps.monitoring.middleware.set_custom_metric')
-    # @ddt.data(
-    #     ('xblock', 'team-red'),
-    #     ('openedx.core.djangoapps', None),
-    #     ('openedx.core.djangoapps.xblock.views', 'team-red'),
-    #     ('xblock_django', 'team-blue'),
-    #     ('common.djangoapps.xblock_django', 'team-blue'),
-    # )
-    # @ddt.unpack
-    # def test_code_owner_mapping_hits_and_misses(
-    #     self, view_func_module, expected_owner, mock_set_custom_metric
-    # ):
-    #     with patch('lms.djangoapps.monitoring.utils._PATH_TO_CODE_OWNER_MAPPINGS', _process_code_owner_mappings()):
-    #         mock_view_func = MockViewWithMockModule(view_func_module)
-    #         self.middleware.process_view(None, mock_view_func, None, None)
-    #         self._assert_code_owner_custom_metrics(
-    #             view_func_module, mock_set_custom_metric, expected_code_owner=expected_owner
-    #         )
-    #
-    # @patch('lms.djangoapps.monitoring.middleware.set_custom_metric')
-    # def test_code_owner_no_mappings(self, mock_set_custom_metric):
-    #     mock_view_func = MockViewWithMockModule('xblock')
-    #     self.middleware.process_view(None, mock_view_func, None, None)
-    #     mock_set_custom_metric.assert_not_called()
-    #
-    # @override_settings(CODE_OWNER_MAPPINGS=['invalid_setting_as_list'])
-    # @patch('lms.djangoapps.monitoring.middleware.set_custom_metric')
-    # def test_load_config_with_invalid_dict(self, mock_set_custom_metric):
-    #     with patch('lms.djangoapps.monitoring.utils._PATH_TO_CODE_OWNER_MAPPINGS', _process_code_owner_mappings()):
-    #         mock_view_func = MockViewWithMockModule('xblock')
-    #         self.middleware.process_view(None, mock_view_func, None, None)
-    #         self._assert_code_owner_custom_metrics(
-    #             'xblock', mock_set_custom_metric, has_error=True
-    #         )
+    @patch('lms.djangoapps.monitoring.middleware.set_custom_metric')
+    def test_code_owner_no_mappings(self, mock_set_custom_metric):
+        request = RequestFactory().get('/test/')
+        self.middleware(request)
+        mock_set_custom_metric.assert_not_called()
+
+    @override_settings(
+        CODE_OWNER_MAPPINGS={'team-red': ['lms.djangoapps.monitoring.tests.mock_views']},
+    )
+    @patch('lms.djangoapps.monitoring.middleware.set_custom_metric')
+    def test_no_resolver_for_request_path(self, mock_set_custom_metric):
+        with patch('lms.djangoapps.monitoring.utils._PATH_TO_CODE_OWNER_MAPPINGS', _process_code_owner_mappings()):
+            request = RequestFactory().get('/bad/path/')
+            self.middleware(request)
+            self._assert_code_owner_custom_metrics(
+                None, mock_set_custom_metric, has_error=True
+            )
+
+    @override_settings(
+        CODE_OWNER_MAPPINGS=['invalid_setting_as_list'],
+        ROOT_URLCONF = __name__,
+    )
+    @patch('lms.djangoapps.monitoring.middleware.set_custom_metric')
+    def test_load_config_with_invalid_dict(self, mock_set_custom_metric):
+        with patch('lms.djangoapps.monitoring.utils._PATH_TO_CODE_OWNER_MAPPINGS', _process_code_owner_mappings()):
+            request = RequestFactory().get('/test/')
+            self.middleware(request)
+            expected_view_func_module = self._REQUEST_PATH_TO_MODULE_PATH['/test/']
+            self._assert_code_owner_custom_metrics(
+                expected_view_func_module, mock_set_custom_metric, has_error=True
+            )
+
+    @override_settings(
+        CODE_OWNER_MAPPINGS={'team-red': ['lms.djangoapps.monitoring.tests.mock_views']},
+        ROOT_URLCONF=__name__,
+    )
+    @patch('lms.djangoapps.monitoring.middleware.set_custom_metric')
+    def test_failed_compare_in_process_view(self, mock_set_custom_metric):
+        """
+        Tests that the process_view gets the same function.  This is to conservatively
+        test that the resolve method results in all the same metrics.
+        """
+        class MockWithMockModule():
+            """
+            Added inside function to enable quick clean-up when this is removed.
+            """
+            def __init__(self, mocked_module_name):
+                self._mocked_module_name = mocked_module_name
+
+            def __getattribute__(self, name):
+                if name == '__module__':
+                    return self._mocked_module_name
+                return super().__getattribute__(name)
+
+        with patch('lms.djangoapps.monitoring.utils._PATH_TO_CODE_OWNER_MAPPINGS', _process_code_owner_mappings()):
+            request_path = '/test/'
+            expected_owner = 'team-red'
+            request = RequestFactory().get(request_path)
+            self.middleware(request)
+            expected_view_func_module = self._REQUEST_PATH_TO_MODULE_PATH[request_path]
+            mock_view_func = MockWithMockModule('different.module')
+            self.middleware.process_view(None, mock_view_func, None, None)
+            self._assert_code_owner_custom_metrics(
+                expected_view_func_module, mock_set_custom_metric, expected_code_owner=expected_owner,
+                process_view_func=mock_view_func,
+            )
 
     def _assert_code_owner_custom_metrics(
         self, view_func_module, mock_set_custom_metric, expected_code_owner=None, has_error=False,
+        process_view_func=None,
     ):
         call_list = []
-        call_list.append(call('view_func_module', view_func_module))
+        if view_func_module:
+            call_list.append(call('view_func_module', view_func_module))
         if expected_code_owner:
             call_list.append(call('code_owner', expected_code_owner))
         if has_error:
             call_list.append(call('code_owner_mapping_error', ANY))
+        if view_func_module and not has_error:
+            if process_view_func:
+                call_list.append(call('temp_view_func_compare', process_view_func.__module__))
+            else:
+                call_list.append(call('temp_view_func_compare', 'success'))
         mock_set_custom_metric.assert_has_calls(call_list)
+        self.assertEqual(
+            len(mock_set_custom_metric.call_args_list), len(call_list),
+            'Expected calls {} vs actual calls {}'.format(call_list, mock_set_custom_metric.call_args_list)
+        )

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -1494,6 +1494,9 @@ MIDDLEWARE = [
     'edx_django_utils.cache.middleware.RequestCacheMiddleware',
     'edx_django_utils.monitoring.middleware.MonitoringCustomMetricsMiddleware',
 
+    # Generate code ownership metrics. Keep this immediately after RequestCacheMiddleware.
+    'lms.djangoapps.monitoring.middleware.CodeOwnerMetricMiddleware',
+
     # Cookie monitoring
     'openedx.core.lib.request_utils.CookieMetricsMiddleware',
 
@@ -1576,7 +1579,6 @@ MIDDLEWARE = [
 
     # Outputs monitoring metrics for a request.
     'edx_rest_framework_extensions.middleware.RequestMetricsMiddleware',
-    'lms.djangoapps.monitoring.middleware.CodeOwnerMetricMiddleware',
 
     'edx_rest_framework_extensions.auth.jwt.middleware.EnsureJWTAuthSettingsMiddleware',
 


### PR DESCRIPTION
* Move middleware higher.
* Move code owner metric mapping while processing request, using `resolve` on the `request.path`.
* To be conservative, temporarily add `temp_view_func_compare` to ensure the `resolve` view function is the same that we got from `process_view`.
  * This will be cleaned up in a follow-up PR when all checks out.