### PR TITLE
Upgrade and constrain things for python 3 on Juniper Branch

### DIFF
--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -99,3 +99,6 @@ wrapt==1.11.*
 
 # zipp 2.0.0 requires Python >= 3.6
 zipp==1.0.0
+
+# Matplotlib 3.1 requires Python 3.6
+matplotlib<3.1

--- a/requirements/edx-sandbox/base.in
+++ b/requirements/edx-sandbox/base.in
@@ -17,11 +17,11 @@
 
 -r shared.txt                       # Dependencies in common with LMS and Studio
 matplotlib==2.2.4                   # 2D plotting library
-numpy==1.7.2                        # Numeric array processing utilities; used by scipy
+numpy==1.16.5                       # Numeric array processing utilities; used by scipy
 pyparsing==2.2.0                    # Python Parsing module
 random2                             # Implementation of random module that works identically under Python 2 and 3
-scipy==0.14.0                       # Math, science, and engineering library
-sympy==0.7.1                        # Symbolic math library
+scipy==1.2.1                        # Math, science, and engineering library
+sympy==1.4                          # Symbolic math library
 git+https://github.com/edx/openedx-calc.git@e9b698c85ad1152002bc0868f475f153dce88952#egg=calc==0.4
 git+https://github.com/edx/openedx-chem.git@ff4e3a03d3c7610e47a9af08eb648d8aabe2eb18#egg=chem==1.0.0
 


### PR DESCRIPTION
sympy needs to be at a newer version for python3.