### PR TITLE
Change isnumeric to isdigit in NumericValidator

### DIFF
--- a/common/djangoapps/util/password_policy_validators.py
+++ b/common/djangoapps/util/password_policy_validators.py
@@ -256,7 +256,7 @@ class NumericValidator(object):
         self.min_numeric = min_numeric
 
     def validate(self, password, user=None):
-        if _validate_condition(password, lambda c: c.isnumeric(), self.min_numeric):
+        if _validate_condition(password, lambda c: c.isdigit(), self.min_numeric):
             return
         raise ValidationError(
             ungettext(


### PR DESCRIPTION
### Issue:

**NOTE:** This issue occurs only in python2. So, this PR is intended for ironwood release only.

`isnumeric()` only works on Unicode characters. If we run the command `changepassword`: 

> /edx/app/edxapp/edx-platform/manage.py lms changepassword

It gives us error:

```
Changing password for user 'test'
Password: 
Password (again): 
Traceback (most recent call last):
  File "manage.py", line 123, in <module>
    execute_from_command_line([sys.argv[0]] + django_args)
  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/django/core/management/__init__.py", line 364, in execute_from_command_line
    utility.execute()
  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/django/core/management/__init__.py", line 356, in execute
    self.fetch_command(subcommand).run_from_argv(self.argv)
  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/django/core/management/base.py", line 283, in run_from_argv
    self.execute(*args, **cmd_options)
  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/django/core/management/base.py", line 330, in execute
    output = self.handle(*args, **options)
  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/django/contrib/auth/management/commands/changepassword.py", line 65, in handle
    validate_password(p2, u)
  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/django/contrib/auth/password_validation.py", line 52, in validate_password
    validator.validate(password, user)
  File "/edx/app/edxapp/edx-platform/common/djangoapps/util/password_policy_validators.py", line 260, in validate
    if _validate_condition(password, lambda c: c.isnumeric(), self.min_numeric):
  File "/edx/app/edxapp/edx-platform/common/djangoapps/util/password_policy_validators.py", line 145, in _validate_condition
    valid_count = len([c for c in password if fn(c)])
  File "/edx/app/edxapp/edx-platform/common/djangoapps/util/password_policy_validators.py", line 260, in <lambda>
    if _validate_condition(password, lambda c: c.isnumeric(), self.min_numeric):
AttributeError: 'str' object has no attribute 'isnumeric'
```

We can use `isdigit()` it works on both `str` and `Unicode`. Django itself use `isdigit()` in it's NumericValidator. [Reference Link](https://github.com/django/django/blob/master/django/contrib/auth/password_validation.py#L196)