### PR TITLE
[BD-5] [BB-2503] Add 'ENABLE_ORA_USERNAMES_ON_DATA_EXPORT' feature toggle

### DIFF
--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -478,6 +478,19 @@ FEATURES = {
     # .. toggle_status: supported
     # .. toggle_warnings: None
     'ENABLE_ORA_USER_STATE_UPLOAD_DATA': False,
+
+    # .. toggle_name: ENABLE_ORA_USERNAMES_ON_DATA_EXPORT
+    # .. toggle_implementation: DjangoSetting
+    # .. toggle_default: False
+    # .. toggle_description: Set to True to add deanonymized usernames to ORA data report.
+    # .. toggle_category: ora
+    # .. toggle_use_cases: incremental_release
+    # .. toggle_creation_date: 2020-06-11
+    # .. toggle_expiration_date: None
+    # .. toggle_tickets: https://openedx.atlassian.net/browse/TNL-7273
+    # .. toggle_status: supported
+    # .. toggle_warnings: None
+    'ENABLE_ORA_USERNAMES_ON_DATA_EXPORT': False,
 }
 
 # Settings for the course reviews tool template and identification key, set either to None to disable course reviews


### PR DESCRIPTION
This PR adds `ENABLE_ORA_USERNAMES_ON_DATA_EXPORT` feature toggle in common settings file, that allows to enable deanonymized usernames feature implemented in https://github.com/edx/edx-ora2/pull/1425.

~Also, `ora2` package version bumped, and all dependencies updated with `make upgrade`.~
Bumped in https://github.com/edx/edx-platform/pull/24221.

**JIRA tickets**:
- [TNL-7273](https://openedx.atlassian.net/browse/TNL-7273)
- [OSPR-4688](https://openedx.atlassian.net/browse/OSPR-4688)

**Discussions**: None

**Dependencies**: depends on https://github.com/edx/edx-ora2/pull/1425

**Merge deadline**: None

**Sandbox URL**: TBD - sandbox is being provisioned.

**Testing instructions**:

1. Checkout your `edx-platform` to this branch.
2. Restart `lms` service, if it didn't restart automatically.
3. Check if toggle present in features setting:
    3.1 `make lms-shell` from `devstack` directory of your docker devstack. 
    3.2 `python manage.py lms shell`
    3.3 `FEATURES` setting must contain new toggle:
```
>>> from django.conf import settings
>>> settings.FEATURES['ENABLE_ORA_USERNAMES_ON_DATA_EXPORT']
False
```
4. If you set toggle to `True`, you should be able to deanonymized usernames in ORA data report.


**Author notes and concerns**: None

**Reviewers**
- [ ] @giovannicimolin 
- [ ] edX reviewer[s] TBD