### PR TITLE
Resolve errors in browser console caused by Instructor Dashboard

### DIFF
--- a/lms/static/js/instructor_dashboard/instructor_dashboard.js
+++ b/lms/static/js/instructor_dashboard/instructor_dashboard.js
@@ -179,9 +179,6 @@ such that the value can be defined later than this assignment (file load order).
                 constructor: window.InstructorDashboard.sections.Email,
                 $element: idashContent.find('.' + CSS_IDASH_SECTION + '#send_email')
             }, {
-                constructor: window.InstructorDashboard.sections.InstructorAnalytics,
-                $element: idashContent.find('.' + CSS_IDASH_SECTION + '#instructor_analytics')
-            }, {
                 constructor: window.InstructorDashboard.sections.Metrics,
                 $element: idashContent.find('.' + CSS_IDASH_SECTION + '#metrics')
             }, {

--- a/lms/static/js/instructor_dashboard/instructor_dashboard.js
+++ b/lms/static/js/instructor_dashboard/instructor_dashboard.js
@@ -214,7 +214,11 @@ such that the value can be defined later than this assignment (file load order).
             constructor = _arg.constructor;
             $element = _arg.$element;
             return plantTimeout(0, sectionsHaveLoaded.waitFor(function() {
-                return new constructor($element);
+                if ($element[0]) {
+                    return new constructor($element);
+                } else {
+                    return null;
+                }
             }));
         });
     };


### PR DESCRIPTION
This PR is to fix an annoying log that keeps showing in the browser's console when opening Instructor Dashboard:
![001](https://user-images.githubusercontent.com/17448993/84412877-8ba10680-ac18-11ea-9ea0-e7f071866d76.png)

------------------

1- Related code for `InstructorAnalytics` has been removed a long time ago https://github.com/edx/edx-platform/pull/9003. This is causing TypeError to be logged:
![002](https://user-images.githubusercontent.com/17448993/84412887-8f348d80-ac18-11ea-8e06-1030b2462fe1.png)


---------------------
2- Instructor dashboard does not always show all supported tabs (for example, Certificate tab is not available when the course doesn't include a certificate). This is causing `Uncaught Failed Element Selection` error to keep logged
![003](https://user-images.githubusercontent.com/17448993/84412901-93f94180-ac18-11ea-9366-71d6edbc3504.png)
