### PR TITLE
(Problem Input) should always be LTR

### DIFF
--- a/common/lib/xmodule/xmodule/css/capa/display.scss
+++ b/common/lib/xmodule/xmodule/css/capa/display.scss
@@ -852,6 +852,15 @@ div.problem {
 
   }
 
+  .inputtype.formulaequationinput {
+    > div {
+      input {
+        direction: ltr;
+        @include text-align(left);
+      }
+    }
+  }
+
   .trailing_text {
     @include margin-right($baseline/2);
 


### PR DESCRIPTION
Problem input should always be LTR (even with UI of RTL languages) to avoid the below issue:

**Before:**
![00before](https://user-images.githubusercontent.com/17448993/84297893-effb9180-ab56-11ea-92a8-dd31a4d77859.png)

**After:**
![00after](https://user-images.githubusercontent.com/17448993/84297761-c0e52000-ab56-11ea-8b0b-77bd985544b7.png)
