### PR TITLE
Guard highlights against null module

### DIFF
--- a/openedx/core/djangoapps/schedules/content_highlights.py
+++ b/openedx/core/djangoapps/schedules/content_highlights.py
@@ -124,9 +124,12 @@ def _get_course_module(course_descriptor, user):
     field_data_cache = FieldDataCache.cache_for_descriptor_descendents(
         course_descriptor.id, user, course_descriptor, depth=1, read_only=True,
     )
-    return get_module_for_descriptor(
+    course_module = get_module_for_descriptor(
         user, request, course_descriptor, field_data_cache, course_descriptor.id, course=course_descriptor,
     )
+    if not course_module:
+        raise CourseUpdateDoesNotExist('Course module {} not found'.format(course_descriptor.id))
+    return course_module
 
 
 def _section_has_highlights(section):
@@ -134,10 +137,7 @@ def _section_has_highlights(section):
 
 
 def _get_sections_with_highlights(course_module):
-    if course_module:
-        return list(filter(_section_has_highlights, course_module.get_children()))
-    else:
-        return []
+    return list(filter(_section_has_highlights, course_module.get_children()))
 
 
 def _get_highlights_for_week(sections, week_num, course_key):


### PR DESCRIPTION
Sometimes a course module will not exist and was causing exceptions in our weekly highlights mail code. This will hopefully guard against that a bit better.