### PR TITLE
[REV-774] Show content type gating upsell when a limited access learner tries to access a timed exam

### DIFF
--- a/common/lib/xmodule/xmodule/seq_module.py
+++ b/common/lib/xmodule/xmodule/seq_module.py
@@ -14,6 +14,7 @@ from functools import reduce
 from pkg_resources import resource_string
 
 import six
+from django.contrib.auth.models import User
 from lxml import etree
 from opaque_keys.edx.keys import UsageKey
 from pytz import UTC
@@ -196,6 +197,7 @@ class SequenceModule(SequenceFields, ProctoringFields, XModule):
     def __init__(self, *args, **kwargs):
         super(SequenceModule, self).__init__(*args, **kwargs)
 
+        self.gated_sequence_fragment = None
         # If position is specified in system, then use that instead.
         position = getattr(self.system, 'position', None)
         if position is not None:
@@ -277,6 +279,30 @@ class SequenceModule(SequenceFields, ProctoringFields, XModule):
         prereq_met = True
         prereq_meta_info = {}
 
+        # Content type gating for FBE previously only gated individual blocks
+        # This was an issue because audit learners could start a timed exam and then be unable to complete the exam
+        # even if they later upgrade because the timer would have expired.
+        # For this reason we check if content gating is enabled for the user and gate the entire sequence in that case
+        # This functionality still needs to be replicated in the frontend-app-learning courseware MFE
+        # The ticket to track this is https://openedx.atlassian.net/browse/REV-1220
+        # Note that this will break compatability with using sequences outside of edx-platform
+        # but we are ok with this for now
+        if self.is_time_limited:
+            try:
+                user = User.objects.get(id=self.runtime.user_id)
+                # importing here to avoid a circular import
+                from openedx.features.content_type_gating.models import ContentTypeGatingConfig
+                from openedx.features.content_type_gating.helpers import CONTENT_GATING_PARTITION_ID
+                if ContentTypeGatingConfig.enabled_for_enrollment(user=user, course_key=self.runtime.course_id):
+                    # Get the content type gating locked content fragment to render for this sequence
+                    partition = self.descriptor._get_user_partition(CONTENT_GATING_PARTITION_ID)  # pylint: disable=protected-access
+                    user_group = partition.scheme.get_group_for_user(self.runtime.course_id, user, partition)
+                    self.gated_sequence_fragment = partition.access_denied_fragment(
+                        self.descriptor, user, user_group, []
+                    )
+            except User.DoesNotExist:
+                pass
+
         if self._required_prereq():
             if self.runtime.user_is_staff:
                 banner_text = _('This subsection is unlocked for learners when they meet the prerequisite requirements.')
@@ -290,6 +316,7 @@ class SequenceModule(SequenceFields, ProctoringFields, XModule):
                 banner_text, special_html = special_html_view
                 if special_html and not masquerading_as_specific_student:
                     return Fragment(special_html)
+
         return self._student_or_public_view(context, prereq_met, prereq_meta_info, banner_text)
 
     def public_view(self, context):
@@ -317,7 +344,7 @@ class SequenceModule(SequenceFields, ProctoringFields, XModule):
         staff is masquerading.
         """
         _ = self.runtime.service(self, "i18n").ugettext
-        if self.is_time_limited:
+        if self.is_time_limited and not self.gated_sequence_fragment:
             special_exam_html = self._time_limited_student_view()
             if special_exam_html:
                 banner_text = _("This exam is hidden from the learner.")
@@ -369,6 +396,7 @@ class SequenceModule(SequenceFields, ProctoringFields, XModule):
             )
 
         items = self._render_student_view_for_items(context, display_items, fragment, view) if prereq_met else []
+
         params = {
             'items': items,
             'element_id': self.location.html_id(),
@@ -383,8 +411,12 @@ class SequenceModule(SequenceFields, ProctoringFields, XModule):
             'save_position': view != PUBLIC_VIEW,
             'show_completion': view != PUBLIC_VIEW,
             'gated_content': self._get_gated_content_info(prereq_met, prereq_meta_info),
+            'sequence_name': self.display_name,
             'exclude_units': context.get('exclude_units', False)
         }
+        if self.gated_sequence_fragment:
+            params['gated_sequence_fragment'] = self.gated_sequence_fragment.content
+
         return params
 
     def _student_or_public_view(self, context, prereq_met, prereq_meta_info, banner_text=None, view=STUDENT_VIEW):

--- a/lms/templates/seq_module.html
+++ b/lms/templates/seq_module.html
@@ -21,6 +21,7 @@
     </div>
   % endif
   % endif
+  % if not gated_sequence_fragment:
   <div class="sequence-nav">
     <button class="sequence-nav-button button-previous">
       <span class="icon fa fa-chevron-prev" aria-hidden="true"></span>
@@ -98,9 +99,15 @@
       </ol>
     </nav>
   </div>
+  % endif
   % if not exclude_units:
   % if gated_content['gated']:
     <%include file="_gated_content.html" args="prereq_url=gated_content['prereq_url'], prereq_section_name=gated_content['prereq_section_name'], gated_section_name=gated_content['gated_section_name']"/>
+  % elif gated_sequence_fragment:
+    <h2 class="hd hd-2 unit-title">
+        ${sequence_name}<span class="sr">${_("Content Locked")}</span>
+    </h2>
+    ${gated_sequence_fragment | n, decode.utf8}
   % else:
   <div class="sr-is-focusable" tabindex="-1"></div>
 


### PR DESCRIPTION
Otherwise, these learners could start the timer and then be unable to take the exam once they have access to the content
Before:
<img width="1416" alt="Screen Shot 2020-06-15 at 10 53 10 AM" src="https://user-images.githubusercontent.com/5958221/84674453-ed9f8b80-aef8-11ea-8872-b71086943349.png">
After:
<img width="1408" alt="Screen Shot 2020-06-15 at 11 10 55 AM" src="https://user-images.githubusercontent.com/5958221/84674455-ed9f8b80-aef8-11ea-89f9-14f8f5a38987.png">

Course Outline:
Don't think anything needs to be done here
Mobile:
I believe timed exams don't show up here anyway, so this should probably be fine?
Course API:
I don't think the html change would affect this

New Courseware MFE:
Have done a little bit of discovery into this, product will get back to me in terms of whether I should do the additional work for that as part of this ticket or another ticket
