### PR TITLE
Add Studio warning for deprecated course keys

### DIFF
--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -387,6 +387,23 @@ FEATURES = {
     # .. toggle_status: supported
     # .. toggle_warnings: None
     'ENABLE_ORA_USER_STATE_UPLOAD_DATA': False,
+
+    # .. toggle_name: DEPRECATE_OLD_COURSE_KEYS_IN_STUDIO
+    # .. toggle_implementation: DjangoSetting
+    # .. toggle_default: True
+    # .. toggle_description: Warn about removing support for deprecated course keys.
+    #      To enable, set to True.
+    #      To disable, set to False.
+    #      To enable with a custom support deadline, set to an ISO-8601 date string:
+    #        eg: '2020-09-01'
+    # .. toggle_category: n/a
+    # .. toggle_use_cases: incremental_release
+    # .. toggle_creation_date: 2020-06-12
+    # .. toggle_expiration_date: 2020-09-01
+    # .. toggle_warnings: This can be removed once support is removed for deprecated course keys.
+    # .. toggle_tickets: https://openedx.atlassian.net/browse/DEPR-58
+    # .. toggle_status: supported
+    'DEPRECATE_OLD_COURSE_KEYS_IN_STUDIO': True,
 }
 
 ENABLE_JASMINE = False

--- a/cms/templates/base.html
+++ b/cms/templates/base.html
@@ -118,6 +118,7 @@ from openedx.core.release import RELEASE_LINE
       % endif
 
       <div id="page-alert">
+        <%include file="widgets/deprecated-course-key-warning.html" args="course=context_course" />
       <%block name="page_alert"></%block>
       </div>
 

--- a/cms/templates/widgets/deprecated-course-key-warning.html
+++ b/cms/templates/widgets/deprecated-course-key-warning.html
@@ -1,0 +1,49 @@
+<%page args="course=None" expression_filter="h" />
+<%!
+from datetime import datetime
+from datetime import date
+
+from django.conf import settings
+from django.utils.translation import ugettext as _
+
+from openedx.core.djangolib.translation_utils import translate_date
+
+DEFAULT_LANGUAGE = getattr(settings, 'LANGUAGE_CODE', 'en')
+IS_ENABLED = settings.FEATURES.get('DEPRECATE_OLD_COURSE_KEYS_IN_STUDIO', True)
+%>
+<%
+is_visible = IS_ENABLED and course and course.id.deprecated
+if is_visible:
+    try:
+        expiration_date = datetime.strptime(IS_ENABLED, "%Y-%m-%d")
+    except TypeError as error:
+        expiration_message = _('Support will be removed in an upcoming release.')
+    else:
+        language = getattr(course, 'language', None) or DEFAULT_LANGUAGE
+        expiration_date = date(expiration_date.year, expiration_date.month, expiration_date.day)
+        expiration_date = translate_date(expiration_date, language=language)
+        expiration_message = _("Support will be removed on {expiration_date}.").format(
+            expiration_date=expiration_date,
+        )
+    is_visible = True
+%>
+% if is_visible:
+  <div class="wrapper wrapper-alert wrapper-alert-warning is-shown">
+    <div class="alert announcement">
+      <span class="feedback-symbol fa fa-warning" aria-hidden="true"></span>
+      <span class="sr">${_("Warning")}</span>
+      <div class="copy">
+        <h2 class="title title-3 warning-heading-text">
+          ${_("This course uses a legacy storage format.")}
+        </h2>
+        <p>
+          ${expiration_message}
+          ${_(
+            "Please reach out to your support team contact, "
+            "if you have any additional questions or concerns."
+          )}
+        </p>
+      </div>
+    </div>
+  </div>
+% endif


### PR DESCRIPTION
in preparation of dropping support for them entirely.

Re: timing: We will _not_ be going live with this on edx.org at launch;
we'll override this setting on our own installs, initially.

We do, however, want to get this merged ASAP, so that it can still be
pulled into Juniper. That will allow us to drop support in time for the
Koa Named Release, while still providing community operators with a full
Named Release cycle to handle deprecation on their installations.

There are two existing alert classes to chose from (CC: @marcotuts):
- `error` [1]
- `warning` [2]

References:
- [0] TNL-7097
- [1] ![Screenshot_2020-06-12_12-51-07](https://user-images.githubusercontent.com/7300975/84541126-9ce72300-acab-11ea-9a06-bdb0851001d4.png)
- [2] ![Screenshot_2020-06-12_13-46-10](https://user-images.githubusercontent.com/7300975/84544965-32d27c00-acb3-11ea-8421-474340ddf3bb.png)
