### PR TITLE
Correct team count for private team-sets in Teams tab

### DIFF
--- a/lms/djangoapps/teams/api.py
+++ b/lms/djangoapps/teams/api.py
@@ -268,25 +268,6 @@ def _get_team_filter_query(topic_id_set, course_id, organization_protection_stat
     return filter_query
 
 
-def get_private_team_ids_to_exclude(user, course_module):
-    """
-    Get the list of team ids that should be excluded from the response.
-    Staff can see all private teams.
-    Users should not be able to see teams in private teamsets that they are not a member of.
-    """
-    if has_access(user, 'staff', course_module.id):
-        return set()
-
-    private_teamset_ids = [ts.teamset_id for ts in course_module.teamsets if ts.is_private_managed]
-    excluded_team_ids = CourseTeam.objects.filter(
-        course_id=course_module.id,
-        topic_id__in=private_teamset_ids
-    ).exclude(
-        membership__user=user
-    ).values_list('team_id', flat=True)
-    return set(excluded_team_ids)
-
-
 def get_teams_with_visibility(user, topic_id_set, course_id, organization_protection_status):
     """ Get teams taking into account user visibility privelages """
     # Filter by topics, course, and protection status

--- a/lms/djangoapps/teams/api.py
+++ b/lms/djangoapps/teams/api.py
@@ -268,8 +268,8 @@ def _get_team_filter_query(topic_id_set, course_id, organization_protection_stat
     return filter_query
 
 
-def get_teams_with_visibility(user, topic_id_set, course_id, organization_protection_status):
-    """ Get teams taking into account user visibility privileges """
+def get_teams_accessible_by_user(user, topic_id_set, course_id, organization_protection_status):
+    """ Get teams taking for a user, taking into account user visibility privileges """
     # Filter by topics, course, and protection status
     filter_query = _get_team_filter_query(topic_id_set, course_id, organization_protection_status)
 
@@ -291,7 +291,7 @@ def add_team_count(user, topics, course_id, organization_protection_status):
     This allows for a more efficient single query.
     """
     topic_ids = [topic['id'] for topic in topics]
-    teams_query_set = get_teams_with_visibility(
+    teams_query_set = get_teams_accessible_by_user(
         user,
         topic_ids,
         course_id,

--- a/lms/djangoapps/teams/api.py
+++ b/lms/djangoapps/teams/api.py
@@ -274,11 +274,11 @@ def get_teams_accessible_by_user(user, topic_id_set, course_id, organization_pro
     filter_query = _get_team_filter_query(topic_id_set, course_id, organization_protection_status)
 
     # Staff gets unfiltered list of teams
-    course_module = modulestore().get_course(course_id)
-    if has_access(user, 'staff', course_module.id):
+    if has_access(user, 'staff', course_id):
         return CourseTeam.objects.filter(**filter_query)
 
     # Private teams should be hidden unless the student is a member
+    course_module = modulestore().get_course(course_id)
     private_teamset_ids = [ts.teamset_id for ts in course_module.teamsets if ts.is_private_managed]
     return CourseTeam.objects.filter(**filter_query).exclude(
         Q(topic_id__in=private_teamset_ids), ~Q(membership__user=user)

--- a/lms/djangoapps/teams/api.py
+++ b/lms/djangoapps/teams/api.py
@@ -269,7 +269,7 @@ def _get_team_filter_query(topic_id_set, course_id, organization_protection_stat
 
 
 def get_teams_with_visibility(user, topic_id_set, course_id, organization_protection_status):
-    """ Get teams taking into account user visibility privelages """
+    """ Get teams taking into account user visibility privileges """
     # Filter by topics, course, and protection status
     filter_query = _get_team_filter_query(topic_id_set, course_id, organization_protection_status)
 

--- a/lms/djangoapps/teams/serializers.py
+++ b/lms/djangoapps/teams/serializers.py
@@ -11,7 +11,7 @@ from django.contrib.auth.models import User
 from django_countries import countries
 from rest_framework import serializers
 
-from lms.djangoapps.teams.api import add_team_count, get_team_count_query_set
+from lms.djangoapps.teams.api import add_team_count, get_teams_with_visibility
 from lms.djangoapps.teams.models import CourseTeam, CourseTeamMembership
 from openedx.core.djangoapps.user_api.accounts.serializers import UserReadOnlySerializer
 from openedx.core.lib.api.fields import ExpandableField
@@ -194,7 +194,8 @@ class TopicSerializer(BaseTopicSerializer):  # pylint: disable=abstract-method
         if 'team_count' in topic:
             return topic['team_count']
         else:
-            return get_team_count_query_set(
+            return get_teams_with_visibility(
+                self.context.get('user'),
                 [topic['id']],
                 self.context['course_id'],
                 self.context.get('organization_protection_status')

--- a/lms/djangoapps/teams/serializers.py
+++ b/lms/djangoapps/teams/serializers.py
@@ -209,7 +209,12 @@ class BulkTeamCountTopicListSerializer(serializers.ListSerializer):  # pylint: d
     def to_representation(self, obj):  # pylint: disable=arguments-differ
         """Adds team_count to each topic. """
         data = super(BulkTeamCountTopicListSerializer, self).to_representation(obj)
-        add_team_count(data, self.context['course_id'], self.context.get('organization_protection_status'))
+        add_team_count(
+            self.context['request'].user,
+            data,
+            self.context['course_id'],
+            self.context.get('organization_protection_status')
+        )
         return data
 
 

--- a/lms/djangoapps/teams/serializers.py
+++ b/lms/djangoapps/teams/serializers.py
@@ -11,7 +11,7 @@ from django.contrib.auth.models import User
 from django_countries import countries
 from rest_framework import serializers
 
-from lms.djangoapps.teams.api import add_team_count, get_teams_with_visibility
+from lms.djangoapps.teams.api import add_team_count, get_teams_accessible_by_user
 from lms.djangoapps.teams.models import CourseTeam, CourseTeamMembership
 from openedx.core.djangoapps.user_api.accounts.serializers import UserReadOnlySerializer
 from openedx.core.lib.api.fields import ExpandableField
@@ -194,7 +194,7 @@ class TopicSerializer(BaseTopicSerializer):  # pylint: disable=abstract-method
         if 'team_count' in topic:
             return topic['team_count']
         else:
-            return get_teams_with_visibility(
+            return get_teams_accessible_by_user(
                 self.context.get('user'),
                 [topic['id']],
                 self.context['course_id'],

--- a/lms/djangoapps/teams/tests/test_api.py
+++ b/lms/djangoapps/teams/tests/test_api.py
@@ -351,7 +351,7 @@ class TeamAccessTests(SharedModuleStoreTestCase):
         ('user_unenrolled', 3),
     )
     @ddt.unpack
-    def test_team_counter_get_team_count_query_set(self, username, expected_count):
+    def test_team_counter_get_teams_with_visibility(self, username, expected_count):
         user = self.users[username]
         try:
             organization_protection_status = teams_api.user_organization_protection_status(
@@ -361,7 +361,8 @@ class TeamAccessTests(SharedModuleStoreTestCase):
         except ValueError:
             self.assertFalse(CourseEnrollment.is_enrolled(user, COURSE_KEY1))
             return
-        teams_query_set = teams_api.get_team_count_query_set(
+        teams_query_set = teams_api.get_teams_with_visibility(
+            user,
             [self.topic_id],
             COURSE_KEY1,
             organization_protection_status

--- a/lms/djangoapps/teams/tests/test_api.py
+++ b/lms/djangoapps/teams/tests/test_api.py
@@ -351,7 +351,7 @@ class TeamAccessTests(SharedModuleStoreTestCase):
         ('user_unenrolled', 3),
     )
     @ddt.unpack
-    def test_team_counter_get_teams_with_visibility(self, username, expected_count):
+    def test_team_counter_get_teams_accessible_by_user(self, username, expected_count):
         user = self.users[username]
         try:
             organization_protection_status = teams_api.user_organization_protection_status(
@@ -361,7 +361,7 @@ class TeamAccessTests(SharedModuleStoreTestCase):
         except ValueError:
             self.assertFalse(CourseEnrollment.is_enrolled(user, COURSE_KEY1))
             return
-        teams_query_set = teams_api.get_teams_with_visibility(
+        teams_query_set = teams_api.get_teams_accessible_by_user(
             user,
             [self.topic_id],
             COURSE_KEY1,

--- a/lms/djangoapps/teams/tests/test_api.py
+++ b/lms/djangoapps/teams/tests/test_api.py
@@ -392,6 +392,7 @@ class TeamAccessTests(SharedModuleStoreTestCase):
             'id': self.topic_id
         }
         teams_api.add_team_count(
+            user,
             [topic],
             COURSE_KEY1,
             organization_protection_status

--- a/lms/djangoapps/teams/tests/test_serializers.py
+++ b/lms/djangoapps/teams/tests/test_serializers.py
@@ -79,9 +79,9 @@ class TopicSerializerTestCase(SerializerTestCase):
     def test_topic_with_no_team_count(self):
         """
         Verifies that the `TopicSerializer` correctly displays a topic with a
-        team count of 0, and that it only takes one SQL query.
+        team count of 0, and that it takes a known number of SQL queries.
         """
-        with self.assertNumQueries(1):
+        with self.assertNumQueries(2):
             serializer = TopicSerializer(
                 self.course.teamsets[0].cleaned_data,
                 context={'course_id': self.course.id},
@@ -101,12 +101,12 @@ class TopicSerializerTestCase(SerializerTestCase):
     def test_topic_with_team_count(self):
         """
         Verifies that the `TopicSerializer` correctly displays a topic with a
-        positive team count, and that it only takes one SQL query.
+        positive team count, and that it takes a known number of SQL queries.
         """
         CourseTeamFactory.create(
             course_id=self.course.id, topic_id=self.course.teamsets[0].teamset_id
         )
-        with self.assertNumQueries(1):
+        with self.assertNumQueries(2):
             serializer = TopicSerializer(
                 self.course.teamsets[0].cleaned_data,
                 context={'course_id': self.course.id},
@@ -134,7 +134,7 @@ class TopicSerializerTestCase(SerializerTestCase):
         )
         CourseTeamFactory.create(course_id=self.course.id, topic_id=duplicate_topic[u'id'])
         CourseTeamFactory.create(course_id=second_course.id, topic_id=duplicate_topic[u'id'])
-        with self.assertNumQueries(1):
+        with self.assertNumQueries(2):
             serializer = TopicSerializer(
                 self.course.teamsets[0].cleaned_data,
                 context={'course_id': self.course.id},

--- a/lms/djangoapps/teams/tests/test_views.py
+++ b/lms/djangoapps/teams/tests/test_views.py
@@ -1947,8 +1947,8 @@ class TestDetailTopicAPI(TeamAPITestCase):
     @ddt.unpack
     @ddt.data(
         ('student_enrolled', 404, None),
-        ('student_on_team_1_private_set_1', 200, 2),
-        ('student_on_team_2_private_set_1', 200, 2),
+        ('student_on_team_1_private_set_1', 200, 1),
+        ('student_on_team_2_private_set_1', 200, 1),
         ('student_masters', 404, None),
         ('staff', 200, 2)
     )

--- a/lms/djangoapps/teams/views.py
+++ b/lms/djangoapps/teams/views.py
@@ -52,6 +52,7 @@ from .api import (
     can_user_modify_team,
     can_user_create_team_in_topic,
     get_assignments_for_team,
+    get_teams_with_visibility,
     get_private_team_ids_to_exclude,
     has_course_staff_privileges,
     has_specific_team_access,
@@ -1008,7 +1009,7 @@ class TopicListView(GenericAPIView):
             page = self.paginate_queryset(topics)
             serializer = TopicSerializer(
                 page,
-                context={'course_id': course_id},
+                context={'course_id': course_id, 'user': request.user},
                 many=True,
             )
         else:
@@ -1141,7 +1142,8 @@ class TopicDetailView(APIView):
             topic.cleaned_data,
             context={
                 'course_id': course_id,
-                'organization_protection_status': organization_protection_status
+                'organization_protection_status': organization_protection_status,
+                'user': request.user
             }
         )
         return Response(serializer.data)

--- a/lms/djangoapps/teams/views.py
+++ b/lms/djangoapps/teams/views.py
@@ -444,10 +444,6 @@ class TeamsListView(ExpandableFieldViewMixin, GenericAPIView):
                 )
                 return Response(error, status=status.HTTP_400_BAD_REQUEST)
 
-            if course_module.teamsets_by_id[topic_id].is_private_managed \
-                    and not has_access(request.user, 'staff', course_key):
-                result_filter.update({'membership__user__username': request.user})
-
             result_filter.update({'topic_id': topic_id})
 
         organization_protection_status = user_organization_protection_status(

--- a/lms/djangoapps/teams/views.py
+++ b/lms/djangoapps/teams/views.py
@@ -52,7 +52,6 @@ from .api import (
     can_user_modify_team,
     can_user_create_team_in_topic,
     get_assignments_for_team,
-    get_teams_with_visibility,
     has_course_staff_privileges,
     has_specific_team_access,
     has_specific_teamset_access,

--- a/lms/djangoapps/teams/views.py
+++ b/lms/djangoapps/teams/views.py
@@ -1029,6 +1029,7 @@ class TopicListView(GenericAPIView):
 
         return response
 
+
 def _filter_hidden_private_teamsets(user, teamsets, course_module):
     """
     Return a filtered list of teamsets, removing any private teamsets that a user doesn't have access to.


### PR DESCRIPTION
**TL;DR** Fix team/topic visibility UI quirks in the Teams > Browse tab

**What Changed?**
- Fixes [team count so it reflects visibility of user](https://openedx.atlassian.net/browse/EDUCATOR-5010)
- Modified Teams API endpoint `add_team_count` now requires user information to determine visibility
- Don't show a learner private team-sets they are not a member of (fixes [this sorting bug](https://openedx.atlassian.net/browse/EDUCATOR-5100))
- Fixes a bug that caused search issues in private team-sets (and spawned [this story](https://openedx.atlassian.net/browse/EDUCATOR-5107))
- Refactors query for excluding private teams to use more minimal `Q` queries
- **Note:** Necessarily introduces an additional SQL query because we need to query the course config to determine which team-sets are private

**Jira:** [EDUCATOR-5010](https://openedx.atlassian.net/browse/EDUCATOR-5010) and some more
**FYI:** @edx/masters-devs-gta 