### PR TITLE
[BD-6] Update transifex client to use PyPi release.

### DIFF
--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -307,7 +307,7 @@ toml==0.10.1              # via -r requirements/edx/testing.txt, tox
 tox-battery==0.6.1        # via -r requirements/edx/testing.txt
 tox==3.15.2               # via -r requirements/edx/testing.txt, tox-battery
 tqdm==4.46.1              # via -r requirements/edx/testing.txt, nltk
-git+https://github.com/edx/transifex-client.git@1660e05cb4a608a420b23f569c329ba3ff13b175#egg=transifex-client  # via -r requirements/edx/testing.txt
+transifex-client==0.13.10  # via -r requirements/edx/testing.txt
 typed-ast==1.4.1          # via -r requirements/edx/testing.txt, astroid
 unicodecsv==0.14.1        # via -r requirements/edx/testing.txt, edx-enterprise
 unidiff==0.6.0            # via -r requirements/edx/testing.txt, coverage-pytest-plugin

--- a/requirements/edx/testing.in
+++ b/requirements/edx/testing.in
@@ -47,7 +47,5 @@ singledispatch            # Backport of functools.singledispatch from Python 3.4
 testfixtures              # Provides a LogCapture utility used by several tests
 tox                       # virtualenv management for tests
 tox-battery               # Makes tox aware of requirements file changes
-# Transifex fork used for compatibilities with python3.8, move to pypi release once
-# https://github.com/transifex/transifex-client/pull/293 gets merged and released
-git+https://github.com/edx/transifex-client.git@1660e05cb4a608a420b23f569c329ba3ff13b175#egg=transifex-client
+transifex-client          # Command-line interface for the Transifex localization service
 unidiff                   # Required by coverage_pytest_plugin

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -286,7 +286,7 @@ toml==0.10.1              # via tox
 tox-battery==0.6.1        # via -r requirements/edx/testing.in
 tox==3.15.2               # via -r requirements/edx/testing.in, tox-battery
 tqdm==4.46.1              # via -r requirements/edx/base.txt, nltk
-git+https://github.com/edx/transifex-client.git@1660e05cb4a608a420b23f569c329ba3ff13b175#egg=transifex-client  # via -r requirements/edx/testing.in
+transifex-client==0.13.10  # via -r requirements/edx/testing.in
 typed-ast==1.4.1          # via astroid
 unicodecsv==0.14.1        # via -r requirements/edx/base.txt, edx-enterprise
 unidiff==0.6.0            # via -r requirements/edx/testing.in, coverage-pytest-plugin


### PR DESCRIPTION
**Description**
Use transifex client from PyPi since required change was merged recently.

**Reviewers**
- [ ] @awais786 
- [ ] @morenol