### PR TITLE
SE-2634 [LX-1342] Fix crashes in yt_video_metadata

### DIFF
--- a/common/lib/xmodule/xmodule/video_module/video_handlers.py
+++ b/common/lib/xmodule/xmodule/video_module/video_handlers.py
@@ -391,6 +391,10 @@ class VideoStudentViewHandlers(object):
         runtime uses a similar REST API that's not an XBlock handler.
         """
         from lms.djangoapps.courseware.views.views import load_metadata_from_youtube
+        if not self.youtube_id_1_0:
+            # TODO: more informational response to explain that yt_video_metadata not supported for non-youtube videos.
+            return Response('{}', status=400)
+
         metadata, status_code = load_metadata_from_youtube(video_id=self.youtube_id_1_0, request=request)
         response = Response(json.dumps(metadata), status=status_code)
         response.content_type = 'application/json'

--- a/lms/djangoapps/courseware/views/views.py
+++ b/lms/djangoapps/courseware/views/views.py
@@ -308,7 +308,16 @@ def load_metadata_from_youtube(video_id, request):
         yt_timeout = settings.YOUTUBE.get('TEST_TIMEOUT', 1500) / 1000  # converting milli seconds to seconds
 
         headers = {}
-        http_referer = request.META.get('HTTP_REFERER')
+        http_referer = None
+
+        try:
+            # This raises an attribute error if called from the xblock yt_video_metadata handler, which passes
+            # a webob request instead of a django request.
+            http_referer = request.META.get('HTTP_REFERER')
+        except AttributeError:
+            # So here, let's assume it's a webob request and access the referer the webob way.
+            http_referer = request.referer
+
         if http_referer:
             headers['Referer'] = http_referer
 


### PR DESCRIPTION
- yt_video_metadata returned a generic non-json-api-friendly 500 error
  when called on a non-youtube video
- load_metadata_from_youtube was crashing when called from the xblock
  yt_video_metadata endpoint. It passes a webob request, which has a
  different api for retrieving the http referer.

**Jira tickets**: [OSPR-4710](https://openedx.atlassian.net/browse/OSPR-4710)

**Dependencies**: None

**Sandbox URL**: TBD - sandbox is being provisioned.

**Merge deadline**: None

**Testing instructions**:

1. add a youtube video xblock to blockstore
2. call the xblock yt_video_metadata endpoint
3. verify that you get a 200 response with json information
4. add a non-youtube video xblock to blockstore
5. call the xblock yt_video_metadata endpoint
6. verify that you don't get a 500 error (TODO: verify what kind of error you should get)

**Author notes and concerns**:

- Unsure what kind of response should be sent when youtube metadata is requested via the api for non-youtube videos.

**Reviewers**
- [ ] @symbolist 
- [x] edX reviewer[s] TBD

**Settings**
```yaml
```