### PR TITLE
Update logic for topic teams action visibility

### DIFF
--- a/lms/djangoapps/teams/static/teams/js/.eslintrc.json
+++ b/lms/djangoapps/teams/static/teams/js/.eslintrc.json
@@ -1,0 +1,30 @@
+{
+  "extends": "eslint-config-edx",
+  "env": {
+    "es6": true
+  },
+  "rules": {
+    "indent": "off",
+    "comma-dangle": "off",
+    "space-before-function-paren": "off",
+    "prefer-arrow-callback": "off",
+    "no-var": "off",
+    "func-names": "off",
+    "object-shorthand": "off",
+    "object-curly-spacing": "off",
+    "lines-around-directive": "off",
+    "prefer-template": "off",
+    "prefer-rest-params": "off",
+    "max-len": "off",
+    "one-var": "off",
+    "no-multi-assign": "off",
+    "prefer-spread": "off",
+    "spaced-comment": "off",
+    "one-var-declaration-per-line": "off",
+    "no-else-return": "off",
+    "object-property-newline": "off",
+    "import/no-amd": "off",
+    "new-cap": "off",
+    "no-lonely-if": "off"
+  }
+}

--- a/lms/djangoapps/teams/static/teams/js/spec/views/topic_teams_spec.js
+++ b/lms/djangoapps/teams/static/teams/js/spec/views/topic_teams_spec.js
@@ -8,7 +8,6 @@ define([
 ], function(Backbone, _, AjaxHelpers, TopicTeamsView, TeamSpecHelpers, PageHelpers) {
   'use strict';
   describe('Topic Teams View', function() {
-
     let requests, view;
 
     const verifyTeamsetTeamsRequest = (hasTeams) => {
@@ -25,22 +24,17 @@ define([
       AjaxHelpers.respondWithJson(
         requests,
         JSON.stringify({ count: hasTeams ? 1 : 0 }),
-      )
-    }
+      );
+    };
 
-    /**
-     * Initialize the AjaxHelpers requests and render the TopicTeamsView.
-     * 
-     */
     const createTopicTeamsView = async ({
       teams,
       isInstructorManagedTopic,
       onTeamInTeamset,
       options,
     }) => new Promise((resolve) => {
-
       requests = AjaxHelpers.requests();
-      const model = isInstructorManaged
+      const model = isInstructorManagedTopic
         ? TeamSpecHelpers.createMockInstructorManagedTopic()
         : TeamSpecHelpers.createMockTopic();
 
@@ -56,7 +50,6 @@ define([
         resolve(view);
       });
     });
-
 
     /**
      * Verify whether the actions message is displayed in the element.
@@ -79,12 +72,10 @@ define([
       }
     };
 
-
     beforeEach(function() {
       setFixtures('<div class="teams-container"></div>');
       PageHelpers.preventBackboneChangingUrl();
     });
-
 
     it('can render itself', function() {
       // Unpriviledged non-staff user, not on any teams in teamset.
@@ -94,7 +85,6 @@ define([
       createTopicTeamsView({
         teams: TeamSpecHelpers.createMockTeams({ results: testTeamData }),
       }).then((teamsView) => {
-
         const footerEl = teamsView.$('.teams-paging-footer');
 
         expect(teamsView.$('.teams-paging-header').text()).toMatch('Showing 1-5 out of 6 total');
@@ -133,13 +123,17 @@ define([
     });
 
     it('does not show actions for a user already in a team in the teamset', function() {
-      createTopicTeamsView({ onTeamInTeamset: true }).then((teamsView) => {
+      createTopicTeamsView({
+        onTeamInTeamset: true
+      }).then((teamsView) => {
         verifyActions(teamsView, false);
       });
     });
 
     it('does not show actions for a student in an instructor managed topic', function() {
-      createTopicTeamsView().then((teamsView) => {
+      createTopicTeamsView({
+        isInstructorManagedTopic: true,
+      }).then((teamsView) => {
         verifyActions(teamsView, false);
       });
     });

--- a/lms/djangoapps/teams/static/teams/js/spec/views/topic_teams_spec.js
+++ b/lms/djangoapps/teams/static/teams/js/spec/views/topic_teams_spec.js
@@ -1,34 +1,76 @@
 define([
     'backbone',
     'underscore',
+    'edx-ui-toolkit/js/utils/spec-helpers/ajax-helpers',
     'teams/js/views/topic_teams',
     'teams/js/spec_helpers/team_spec_helpers',
     'common/js/spec_helpers/page_helpers'
-], function(Backbone, _, TopicTeamsView, TeamSpecHelpers, PageHelpers) {
+], function(Backbone, _, AjaxHelpers, TopicTeamsView, TeamSpecHelpers, PageHelpers) {
     'use strict';
     describe('Topic Teams View', function() {
-        var createTopicTeamsView = function(options, isInstructorManagedTopic) {
-            options = options || {}; // eslint-disable-line no-param-reassign
-            return new TopicTeamsView({
-                el: '.teams-container',
-                model: isInstructorManagedTopic ?
-                    TeamSpecHelpers.createMockInstructorManagedTopic() : TeamSpecHelpers.createMockTopic(),
-                collection: options.teams || TeamSpecHelpers.createMockTeams({results: []}),
-                myTopicTeamsCollection: (
-                  options.myTopicTeamsCollection || TeamSpecHelpers.createMockTeams({results: []})
-                ),
-                context: _.extend({}, TeamSpecHelpers.testContext, options)
-            }).render();
-        };
 
-        var verifyActions = function(teamsView, options) {
-            var expectedTitle = 'Are you having trouble finding a team to join?',
+        let requests, view;
+
+        const verifyTeamsetTeamsRequest = (hasTeams) => {
+            const {
+                testUser: username,
+                testCourseID: course_id,
+                testTopicID: teamset_id,
+            } = TeamSpecHelpers;
+            AjaxHelpers.expectRequestURL(
+                requests,
+                TeamSpecHelpers.testContext.teamMembershipsUrl,
+                { username, course_id, teamset_id },
+            );
+            AjaxHelpers.respondWithJson(
+                requests,
+                JSON.stringify({ count: hasTeams ? 1 : 0 }),
+            )
+        }
+
+        /**
+         * Initialize the AjaxHelpers requests and render the TopicTeamsView.
+         * 
+         */
+        const createTopicTeamsView = async ({
+            teams,
+            isInstructorManagedTopic,
+            onTeamInTeamset,
+            options,
+        }) => new Promise((resolve) => {
+
+            requests = AjaxHelpers.requests();
+            const model = isInstructorManaged
+                ? TeamSpecHelpers.createMockInstructorManagedTopic()
+                : TeamSpecHelpers.createMockTopic();
+
+            view = new TopicTeamsView({
+                el: '.teams-container',
+                model,
+                collection: teams || TeamSpecHelpers.createMockTeams({results: []}),
+                context: _.extend({}, TeamSpecHelpers.testContext, options)
+            });
+
+            view.render().then(() => {
+                verifyTeamsetTeamsRequest(onTeamInTeamset);
+                resolve(view);
+            });
+        });
+
+
+        /**
+         * Verify whether the actions message is displayed in the element.
+         * @param {TopicTeamsView} teamsView - parent element
+         * @param {bool=true} showActions - should the actions be shown?
+         */
+        const verifyActions = function(teamsView, showActions) {
+            const expectedTitle = 'Are you having trouble finding a team to join?',
                 expectedMessage = 'Browse teams in other topics or search teams in this topic. ' +
                     'If you still can\'t find a team to join, create a new team in this topic.',
                 title = teamsView.$('.title').text().trim(),
                 message = teamsView.$('.copy').text().trim();
-            options = options || {showActions: true}; // eslint-disable-line no-param-reassign
-            if (options.showActions) {
+
+            if (showActions === false) {
                 expect(title).toBe(expectedTitle);
                 expect(message).toBe(expectedMessage);
             } else {
@@ -37,84 +79,99 @@ define([
             }
         };
 
+
         beforeEach(function() {
             setFixtures('<div class="teams-container"></div>');
             PageHelpers.preventBackboneChangingUrl();
         });
 
-        it('can render itself', function() {
-            var testTeamData = TeamSpecHelpers.createMockTeamData(1, 5);
-            var options = {
-                teams: TeamSpecHelpers.createMockTeams({
-                    results: testTeamData
-                })
-            };
-            var teamsView = createTopicTeamsView(options);
-            var footerEl = teamsView.$('.teams-paging-footer');
-            expect(teamsView.$('.teams-paging-header').text()).toMatch('Showing 1-5 out of 6 total');
-            expect(footerEl.text()).toMatch('1\\s+out of\\s+\/\\s+2'); // eslint-disable-line no-useless-escape
-            expect(footerEl).not.toHaveClass('hidden');
 
-            TeamSpecHelpers.verifyCards(teamsView, testTeamData);
-            verifyActions(teamsView);
+        it('can render itself', function() {
+            // Unpriviledged non-staff user, not on any teams in teamset.
+            // Team is not instructor managed.
+            const testTeamData = TeamSpecHelpers.createMockTeamData(1, 5);
+
+            createTopicTeamsView({
+                teams: TeamSpecHelpers.createMockTeams({ results: testTeamData }),
+            }).then((teamsView) => {
+
+                const footerEl = teamsView.$('.teams-paging-footer');
+
+                expect(teamsView.$('.teams-paging-header').text()).toMatch('Showing 1-5 out of 6 total');
+                expect(footerEl.text()).toMatch('1\\s+out of\\s+\/\\s+2'); // eslint-disable-line no-useless-escape
+                expect(footerEl).not.toHaveClass('hidden');
+
+                TeamSpecHelpers.verifyCards(teamsView, testTeamData);
+                verifyActions(teamsView);
+            });
         });
 
         it('can browse all teams', function() {
-            var teamsView = createTopicTeamsView();
-            spyOn(Backbone.history, 'navigate');
-            teamsView.$('.browse-teams').click();
-            expect(Backbone.history.navigate.calls.mostRecent().args[0]).toBe('browse');
+            createTopicTeamsView().then((teamsView) => {
+                spyOn(Backbone.history, 'navigate');
+                teamsView.$('.browse-teams').click();
+                expect(Backbone.history.navigate.calls.mostRecent().args[0]).toBe('browse');
+            });
         });
 
         it('gives the search field focus when clicking on the search teams link', function() {
-            var teamsView = createTopicTeamsView();
-            spyOn($.fn, 'focus').and.callThrough();
-            teamsView.$('.search-teams').click();
-            expect(teamsView.$('.search-field').first().focus).toHaveBeenCalled();
+            createTopicTeamsView().then((teamsView) => {
+                spyOn($.fn, 'focus').and.callThrough();
+                teamsView.$('.search-teams').click();
+                expect(teamsView.$('.search-field').first().focus).toHaveBeenCalled();
+            });
         });
 
         it('can show the create team modal', function() {
-            var teamsView = createTopicTeamsView();
-            spyOn(Backbone.history, 'navigate');
-            teamsView.$('a.create-team').click();
-            expect(Backbone.history.navigate.calls.mostRecent().args[0]).toBe(
-                'topics/' + TeamSpecHelpers.testTopicID + '/create-team'
-            );
+            createTopicTeamsView().then((teamsView) => {
+                spyOn(Backbone.history, 'navigate');
+                teamsView.$('a.create-team').click();
+                expect(Backbone.history.navigate.calls.mostRecent().args[0]).toBe(
+                    'topics/' + TeamSpecHelpers.testTopicID + '/create-team'
+                );
+            });
         });
 
         it('does not show actions for a user already in a team in the teamset', function() {
-            var options = {myTopicTeamsCollection: TeamSpecHelpers.createMockTeams()};
-            var teamsView = createTopicTeamsView(options);
-            verifyActions(teamsView, {showActions: false});
+            createTopicTeamsView({ onTeamInTeamset: true }).then((teamsView) => {
+                verifyActions(teamsView, false);
+            });
         });
 
         it('does not show actions for a student in an instructor managed topic', function() {
-            var teamsView = createTopicTeamsView({}, true);
-            verifyActions(teamsView, {showActions: false});
+            createTopicTeamsView().then((teamsView) => {
+                verifyActions(teamsView, false);
+            });
         });
 
         it('shows actions for a privileged user already in a team', function() {
-            var options = {
+            const options = {
                 userInfo: {
                     privileged: true,
                     staff: false
                 },
-                myTopicTeamsCollection: TeamSpecHelpers.createMockTeams()
             };
-            var teamsView = createTopicTeamsView(options);
-            verifyActions(teamsView, {showActions: true});
+            createTopicTeamsView({
+                options,
+                onTeamInTeamset: true,
+            }).then((teamsView) => {
+                verifyActions(teamsView);
+            });
         });
 
         it('shows actions for a staff user already in a team', function() {
-            var options = {
+            const options = {
                 userInfo: {
                     privileged: false,
-                    staff: true
+                    staff: true,
                 },
-                myTopicTeamsCollection: TeamSpecHelpers.createMockTeams()
             };
-            var teamsView = createTopicTeamsView(options);
-            verifyActions(teamsView, {showActions: true});
+            createTopicTeamsView({
+                options,
+                onTeamInTeamset: true,
+            }).then((teamsView) => {
+                verifyActions(teamsView);
+            });
         });
 
         /*
@@ -123,7 +180,7 @@ define([
             var requests = AjaxHelpers.requests(this),
                 teamMemberships = TeamSpecHelpers.createMockTeamMemberships([]),
                 teamsView = createTopicTeamsView({ teamMemberships: teamMemberships });
-            verifyActions(teamsView, {showActions: true});
+            verifyActions(teamsView);
             teamMemberships.teamEvents.trigger('teams:update', { action: 'create' });
             teamsView.render();
             AjaxHelpers.expectRequestURL(
@@ -138,7 +195,7 @@ define([
                 }
             );
             AjaxHelpers.respondWithJson(requests, {});
-            verifyActions(teamsView, {showActions: false});
+            verifyActions(teamsView);
         });
         */
     });

--- a/lms/djangoapps/teams/static/teams/js/spec/views/topic_teams_spec.js
+++ b/lms/djangoapps/teams/static/teams/js/spec/views/topic_teams_spec.js
@@ -1,202 +1,202 @@
 define([
-    'backbone',
-    'underscore',
-    'edx-ui-toolkit/js/utils/spec-helpers/ajax-helpers',
-    'teams/js/views/topic_teams',
-    'teams/js/spec_helpers/team_spec_helpers',
-    'common/js/spec_helpers/page_helpers'
+  'backbone',
+  'underscore',
+  'edx-ui-toolkit/js/utils/spec-helpers/ajax-helpers',
+  'teams/js/views/topic_teams',
+  'teams/js/spec_helpers/team_spec_helpers',
+  'common/js/spec_helpers/page_helpers'
 ], function(Backbone, _, AjaxHelpers, TopicTeamsView, TeamSpecHelpers, PageHelpers) {
-    'use strict';
-    describe('Topic Teams View', function() {
+  'use strict';
+  describe('Topic Teams View', function() {
 
-        let requests, view;
+    let requests, view;
 
-        const verifyTeamsetTeamsRequest = (hasTeams) => {
-            const {
-                testUser: username,
-                testCourseID: course_id,
-                testTopicID: teamset_id,
-            } = TeamSpecHelpers;
-            AjaxHelpers.expectRequestURL(
-                requests,
-                TeamSpecHelpers.testContext.teamMembershipsUrl,
-                { username, course_id, teamset_id },
-            );
-            AjaxHelpers.respondWithJson(
-                requests,
-                JSON.stringify({ count: hasTeams ? 1 : 0 }),
-            )
-        }
+    const verifyTeamsetTeamsRequest = (hasTeams) => {
+      const {
+        testUser: username,
+        testCourseID: course_id,
+        testTopicID: teamset_id,
+      } = TeamSpecHelpers;
+      AjaxHelpers.expectRequestURL(
+        requests,
+        TeamSpecHelpers.testContext.teamMembershipsUrl,
+        { username, course_id, teamset_id },
+      );
+      AjaxHelpers.respondWithJson(
+        requests,
+        JSON.stringify({ count: hasTeams ? 1 : 0 }),
+      )
+    }
 
-        /**
-         * Initialize the AjaxHelpers requests and render the TopicTeamsView.
-         * 
-         */
-        const createTopicTeamsView = async ({
-            teams,
-            isInstructorManagedTopic,
-            onTeamInTeamset,
-            options,
-        }) => new Promise((resolve) => {
+    /**
+     * Initialize the AjaxHelpers requests and render the TopicTeamsView.
+     * 
+     */
+    const createTopicTeamsView = async ({
+      teams,
+      isInstructorManagedTopic,
+      onTeamInTeamset,
+      options,
+    }) => new Promise((resolve) => {
 
-            requests = AjaxHelpers.requests();
-            const model = isInstructorManaged
-                ? TeamSpecHelpers.createMockInstructorManagedTopic()
-                : TeamSpecHelpers.createMockTopic();
+      requests = AjaxHelpers.requests();
+      const model = isInstructorManaged
+        ? TeamSpecHelpers.createMockInstructorManagedTopic()
+        : TeamSpecHelpers.createMockTopic();
 
-            view = new TopicTeamsView({
-                el: '.teams-container',
-                model,
-                collection: teams || TeamSpecHelpers.createMockTeams({results: []}),
-                context: _.extend({}, TeamSpecHelpers.testContext, options)
-            });
+      view = new TopicTeamsView({
+        el: '.teams-container',
+        model,
+        collection: teams || TeamSpecHelpers.createMockTeams({results: []}),
+        context: _.extend({}, TeamSpecHelpers.testContext, options)
+      });
 
-            view.render().then(() => {
-                verifyTeamsetTeamsRequest(onTeamInTeamset);
-                resolve(view);
-            });
-        });
-
-
-        /**
-         * Verify whether the actions message is displayed in the element.
-         * @param {TopicTeamsView} teamsView - parent element
-         * @param {bool=true} showActions - should the actions be shown?
-         */
-        const verifyActions = function(teamsView, showActions) {
-            const expectedTitle = 'Are you having trouble finding a team to join?',
-                expectedMessage = 'Browse teams in other topics or search teams in this topic. ' +
-                    'If you still can\'t find a team to join, create a new team in this topic.',
-                title = teamsView.$('.title').text().trim(),
-                message = teamsView.$('.copy').text().trim();
-
-            if (showActions === false) {
-                expect(title).toBe(expectedTitle);
-                expect(message).toBe(expectedMessage);
-            } else {
-                expect(title).not.toBe(expectedTitle);
-                expect(message).not.toBe(expectedMessage);
-            }
-        };
-
-
-        beforeEach(function() {
-            setFixtures('<div class="teams-container"></div>');
-            PageHelpers.preventBackboneChangingUrl();
-        });
-
-
-        it('can render itself', function() {
-            // Unpriviledged non-staff user, not on any teams in teamset.
-            // Team is not instructor managed.
-            const testTeamData = TeamSpecHelpers.createMockTeamData(1, 5);
-
-            createTopicTeamsView({
-                teams: TeamSpecHelpers.createMockTeams({ results: testTeamData }),
-            }).then((teamsView) => {
-
-                const footerEl = teamsView.$('.teams-paging-footer');
-
-                expect(teamsView.$('.teams-paging-header').text()).toMatch('Showing 1-5 out of 6 total');
-                expect(footerEl.text()).toMatch('1\\s+out of\\s+\/\\s+2'); // eslint-disable-line no-useless-escape
-                expect(footerEl).not.toHaveClass('hidden');
-
-                TeamSpecHelpers.verifyCards(teamsView, testTeamData);
-                verifyActions(teamsView);
-            });
-        });
-
-        it('can browse all teams', function() {
-            createTopicTeamsView().then((teamsView) => {
-                spyOn(Backbone.history, 'navigate');
-                teamsView.$('.browse-teams').click();
-                expect(Backbone.history.navigate.calls.mostRecent().args[0]).toBe('browse');
-            });
-        });
-
-        it('gives the search field focus when clicking on the search teams link', function() {
-            createTopicTeamsView().then((teamsView) => {
-                spyOn($.fn, 'focus').and.callThrough();
-                teamsView.$('.search-teams').click();
-                expect(teamsView.$('.search-field').first().focus).toHaveBeenCalled();
-            });
-        });
-
-        it('can show the create team modal', function() {
-            createTopicTeamsView().then((teamsView) => {
-                spyOn(Backbone.history, 'navigate');
-                teamsView.$('a.create-team').click();
-                expect(Backbone.history.navigate.calls.mostRecent().args[0]).toBe(
-                    'topics/' + TeamSpecHelpers.testTopicID + '/create-team'
-                );
-            });
-        });
-
-        it('does not show actions for a user already in a team in the teamset', function() {
-            createTopicTeamsView({ onTeamInTeamset: true }).then((teamsView) => {
-                verifyActions(teamsView, false);
-            });
-        });
-
-        it('does not show actions for a student in an instructor managed topic', function() {
-            createTopicTeamsView().then((teamsView) => {
-                verifyActions(teamsView, false);
-            });
-        });
-
-        it('shows actions for a privileged user already in a team', function() {
-            const options = {
-                userInfo: {
-                    privileged: true,
-                    staff: false
-                },
-            };
-            createTopicTeamsView({
-                options,
-                onTeamInTeamset: true,
-            }).then((teamsView) => {
-                verifyActions(teamsView);
-            });
-        });
-
-        it('shows actions for a staff user already in a team', function() {
-            const options = {
-                userInfo: {
-                    privileged: false,
-                    staff: true,
-                },
-            };
-            createTopicTeamsView({
-                options,
-                onTeamInTeamset: true,
-            }).then((teamsView) => {
-                verifyActions(teamsView);
-            });
-        });
-
-        /*
-        // TODO: make this ready for prime time
-        it('refreshes when the team membership changes', function() {
-            var requests = AjaxHelpers.requests(this),
-                teamMemberships = TeamSpecHelpers.createMockTeamMemberships([]),
-                teamsView = createTopicTeamsView({ teamMemberships: teamMemberships });
-            verifyActions(teamsView);
-            teamMemberships.teamEvents.trigger('teams:update', { action: 'create' });
-            teamsView.render();
-            AjaxHelpers.expectRequestURL(
-                requests,
-                'foo',
-                {
-                    expand : 'team',
-                    username : 'testUser',
-                    course_id : TeamSpecHelpers.testCourseID,
-                    page : '1',
-                    page_size : '10'
-                }
-            );
-            AjaxHelpers.respondWithJson(requests, {});
-            verifyActions(teamsView);
-        });
-        */
+      view.render().then(() => {
+        verifyTeamsetTeamsRequest(onTeamInTeamset);
+        resolve(view);
+      });
     });
+
+
+    /**
+     * Verify whether the actions message is displayed in the element.
+     * @param {TopicTeamsView} teamsView - parent element
+     * @param {bool=true} showActions - should the actions be shown?
+     */
+    const verifyActions = function(teamsView, showActions) {
+      const expectedTitle = 'Are you having trouble finding a team to join?',
+        expectedMessage = 'Browse teams in other topics or search teams in this topic. ' +
+          'If you still can\'t find a team to join, create a new team in this topic.',
+        title = teamsView.$('.title').text().trim(),
+        message = teamsView.$('.copy').text().trim();
+
+      if (showActions === false) {
+        expect(title).toBe(expectedTitle);
+        expect(message).toBe(expectedMessage);
+      } else {
+        expect(title).not.toBe(expectedTitle);
+        expect(message).not.toBe(expectedMessage);
+      }
+    };
+
+
+    beforeEach(function() {
+      setFixtures('<div class="teams-container"></div>');
+      PageHelpers.preventBackboneChangingUrl();
+    });
+
+
+    it('can render itself', function() {
+      // Unpriviledged non-staff user, not on any teams in teamset.
+      // Team is not instructor managed.
+      const testTeamData = TeamSpecHelpers.createMockTeamData(1, 5);
+
+      createTopicTeamsView({
+        teams: TeamSpecHelpers.createMockTeams({ results: testTeamData }),
+      }).then((teamsView) => {
+
+        const footerEl = teamsView.$('.teams-paging-footer');
+
+        expect(teamsView.$('.teams-paging-header').text()).toMatch('Showing 1-5 out of 6 total');
+        expect(footerEl.text()).toMatch('1\\s+out of\\s+\/\\s+2'); // eslint-disable-line no-useless-escape
+        expect(footerEl).not.toHaveClass('hidden');
+
+        TeamSpecHelpers.verifyCards(teamsView, testTeamData);
+        verifyActions(teamsView);
+      });
+    });
+
+    it('can browse all teams', function() {
+      createTopicTeamsView().then((teamsView) => {
+        spyOn(Backbone.history, 'navigate');
+        teamsView.$('.browse-teams').click();
+        expect(Backbone.history.navigate.calls.mostRecent().args[0]).toBe('browse');
+      });
+    });
+
+    it('gives the search field focus when clicking on the search teams link', function() {
+      createTopicTeamsView().then((teamsView) => {
+        spyOn($.fn, 'focus').and.callThrough();
+        teamsView.$('.search-teams').click();
+        expect(teamsView.$('.search-field').first().focus).toHaveBeenCalled();
+      });
+    });
+
+    it('can show the create team modal', function() {
+      createTopicTeamsView().then((teamsView) => {
+        spyOn(Backbone.history, 'navigate');
+        teamsView.$('a.create-team').click();
+        expect(Backbone.history.navigate.calls.mostRecent().args[0]).toBe(
+          'topics/' + TeamSpecHelpers.testTopicID + '/create-team'
+        );
+      });
+    });
+
+    it('does not show actions for a user already in a team in the teamset', function() {
+      createTopicTeamsView({ onTeamInTeamset: true }).then((teamsView) => {
+        verifyActions(teamsView, false);
+      });
+    });
+
+    it('does not show actions for a student in an instructor managed topic', function() {
+      createTopicTeamsView().then((teamsView) => {
+        verifyActions(teamsView, false);
+      });
+    });
+
+    it('shows actions for a privileged user already in a team', function() {
+      const options = {
+        userInfo: {
+          privileged: true,
+          staff: false
+        },
+      };
+      createTopicTeamsView({
+        options,
+        onTeamInTeamset: true,
+      }).then((teamsView) => {
+        verifyActions(teamsView);
+      });
+    });
+
+    it('shows actions for a staff user already in a team', function() {
+      const options = {
+        userInfo: {
+          privileged: false,
+          staff: true,
+        },
+      };
+      createTopicTeamsView({
+        options,
+        onTeamInTeamset: true,
+      }).then((teamsView) => {
+        verifyActions(teamsView);
+      });
+    });
+
+    /*
+    // TODO: make this ready for prime time
+    it('refreshes when the team membership changes', function() {
+      var requests = AjaxHelpers.requests(this),
+        teamMemberships = TeamSpecHelpers.createMockTeamMemberships([]),
+        teamsView = createTopicTeamsView({ teamMemberships: teamMemberships });
+      verifyActions(teamsView);
+      teamMemberships.teamEvents.trigger('teams:update', { action: 'create' });
+      teamsView.render();
+      AjaxHelpers.expectRequestURL(
+        requests,
+        'foo',
+        {
+          expand : 'team',
+          username : 'testUser',
+          course_id : TeamSpecHelpers.testCourseID,
+          page : '1',
+          page_size : '10'
+        }
+      );
+      AjaxHelpers.respondWithJson(requests, {});
+      verifyActions(teamsView);
+    });
+    */
+  });
 });

--- a/lms/djangoapps/teams/static/teams/js/views/teams_tab.js
+++ b/lms/djangoapps/teams/static/teams/js/views/teams_tab.js
@@ -380,24 +380,11 @@
                 createTeamsListView: function(options) {
                     var topic = options.topic,
                         collection = options.collection,
-                        myTopicTeamsCollection = new TeamCollection(
-                            this.context.userInfo.teams,
-                            {
-                                teamEvents: this.teamEvents,
-                                course_id: this.context.courseID,
-                                username: this.context.userInfo.username,
-                                topic_id: topic.get('id'),
-                                perPage: 5,
-                                parse: true,
-                                url: this.context.myTeamsUrl
-                            }
-                        ),
                         teamsView = new TopicTeamsView({
                             router: this.router,
                             context: this.context,
                             model: topic,
                             collection: collection,
-                            myTopicTeamsCollection: myTopicTeamsCollection,
                             showSortControls: options.showSortControls
                         }),
                         searchFieldView = new SearchFieldView({
@@ -414,6 +401,7 @@
                             breadcrumbs: options.breadcrumbs
                         }),
                         searchUrl = 'topics/' + topic.get('id') + '/search';
+
                     // Listen to requests to sync the collection and redirect it as follows:
                     // 1. If the collection includes a search, show the search results page
                     // 2. If we're already on the search page, show the regular

--- a/lms/djangoapps/teams/static/teams/js/views/teams_tab.js
+++ b/lms/djangoapps/teams/static/teams/js/views/teams_tab.js
@@ -1,7 +1,8 @@
 (function(define) {
     'use strict';
 
-    define(['backbone',
+    define([
+        'backbone',
         'jquery',
         'underscore',
         'gettext',
@@ -27,12 +28,12 @@
         'teams/js/views/team_profile_header_actions',
         'teams/js/views/team_utils',
         'teams/js/views/instructor_tools',
-        'text!teams/templates/teams_tab.underscore'],
-        function(Backbone, $, _, gettext, HtmlUtils, StringUtils, SearchFieldView, HeaderView, HeaderModel,
-                  TopicModel, TopicCollection, TeamModel, TeamCollection, MyTeamsCollection, TeamAnalytics,
-                  TeamsTabbedView, TopicsView, TeamProfileView, MyTeamsView, ManageView, TopicTeamsView,
-                  TeamEditView, TeamMembersEditView, TeamProfileHeaderActionsView, TeamUtils, InstructorToolsView,
-                  teamsTemplate) {
+        'text!teams/templates/teams_tab.underscore'
+    ], function(Backbone, $, _, gettext, HtmlUtils, StringUtils, SearchFieldView, HeaderView, HeaderModel,
+        TopicModel, TopicCollection, TeamModel, TeamCollection, MyTeamsCollection, TeamAnalytics,
+        TeamsTabbedView, TopicsView, TeamProfileView, MyTeamsView, ManageView, TopicTeamsView,
+        TeamEditView, TeamMembersEditView, TeamProfileHeaderActionsView, TeamUtils, InstructorToolsView,
+        teamsTemplate) {
             var TeamsHeaderModel = HeaderModel.extend({
                 initialize: function() {
                     _.extend(this.defaults, {nav_aria_label: gettext('Topics')});
@@ -73,7 +74,7 @@
                         [':default', _.bind(this.routeNotFound, this)],
                         ['main', _.bind(function() {
                             // The backbone router unfortunately usurps the
-                            // default behavior of in-page-links.  This hack
+                            // default behavior of in-page-links.    This hack
                             // prevents the screen reader in-page-link from
                             // being picked up by the backbone router.
                         }, this)],
@@ -575,7 +576,7 @@
                 },
 
                 /**
-                 * Get a topic given a topic ID.  Returns a jQuery deferred
+                 * Get a topic given a topic ID.    Returns a jQuery deferred
                  * promise, since the topic may need to be fetched from the
                  * server.
                  * @param topicID the string identifier for the requested topic
@@ -583,7 +584,7 @@
                  */
                 getTopic: function(topicID) {
                     // Try finding topic in the current page of the
-                    // topicCollection.  Otherwise call the topic endpoint.
+                    // topicCollection.    Otherwise call the topic endpoint.
                     var topic = this.topicsCollection.findWhere({id: topicID}),
                         self = this,
                         deferred = $.Deferred();
@@ -607,7 +608,7 @@
                 },
 
                 /**
-                 * Get a team given a team ID.  Returns a jQuery deferred
+                 * Get a team given a team ID.    Returns a jQuery deferred
                  * promise, since the team may need to be fetched from the
                  * server.
                  * @param teamID the string identifier for the requested team
@@ -709,5 +710,6 @@
             });
 
             return TeamTabView;
-        });
+        }
+    );
 }).call(this, define || RequireJS.define);

--- a/lms/djangoapps/teams/static/teams/js/views/topic_teams.js
+++ b/lms/djangoapps/teams/static/teams/js/views/topic_teams.js
@@ -10,7 +10,32 @@
         'text!teams/templates/team-actions.underscore',
         'teams/js/views/team_utils'
     ], function(_, Backbone, gettext, HtmlUtils, TeamsView, PagingHeader, teamActionsTemplate, TeamUtils) {
-        var TopicTeamsView = TeamsView.extend({
+        // Translators: this string is shown at the bottom of the teams page
+        // to find a team to join or else to create a new one. There are three
+        // links that need to be included in the message:
+        // 1. Browse teams in other topics
+        // 2. search teams
+        // 3. create a new team
+        // Be careful to start each link with the appropriate start indicator
+        // (e.g. {browse_span_start} for #1) and finish it with {span_end}.
+        const actionsMessage = interpolate_text( // eslint-disable-line no-undef
+            _.escape(
+                gettext(
+                    '{browse_span_start}Browse teams in other ' +
+                    'topics{span_end} or {search_span_start}search teams{span_end} ' +
+                    'in this topic. If you still can\'t find a team to join, ' +
+                    '{create_span_start}create a new team in this topic{span_end}.'
+                )
+            ),
+            {
+                browse_span_start: '<a class="browse-teams" href="">',
+                search_span_start: '<a class="search-teams" href="">',
+                create_span_start: '<a class="create-team" href="">',
+                span_end: '</a>'
+            }
+        );
+
+        const TopicTeamsView = TeamsView.extend({
             events: {
                 'click a.browse-teams': 'browseTeams',
                 'click a.search-teams': 'searchTeams',
@@ -24,52 +49,65 @@
                 TeamsView.prototype.initialize.call(this, options);
             },
 
-            canUserCreateTeam: function() {
-                    // Note: non-staff and non-privileged users are automatically added to any team
-                    // that they create. This means that if multiple team membership is
-                    // disabled that they cannot create a new team when they already
-                    // belong to one.
-                return this.context.userInfo.staff
-                    || this.context.userInfo.privileged
-                    || (!TeamUtils.isInstructorManagedTopic(this.model.attributes.type)
-                        && this.options.myTopicTeamsCollection.length === 0);
+            /**
+             * Send an AJAX query checking on whether the user is in a team in the given
+             * teamset.
+             * If the response comes back with a failure, do not show actions.
+             */
+            checkIfOnTeamInTeamset: async function() {
+                return new Promise((resolve) => {
+                    $.ajax({
+                        type: 'GET',
+                        url: this.context.teamMembershipsUrl,
+                        data: {
+                            username: this.context.userInfo.username,
+                            course_id: this.context.courseID,
+                            teamset_id: this.model.get('id'),
+                        }
+                    }).done(
+                        data => resolve(data.count === 0)
+                    ).fail(
+                        //TODO: should we throw an exception here?
+                        () => resolve(false)
+                    );
+                });
+            },
+
+            /**
+             * Append the actionsMessage string to the element into the `message` key in the django template.
+             */
+            drawActions: function() {
+                HtmlUtils.append(
+                    this.$el,
+                    HtmlUtils.template(teamActionsTemplate)({ message: actionsMessage })
+                );
+            },
+
+
+            /**
+             * Try to render the actions message.
+             * Show actions if student is staff/priviledged or if the team is not instructor-managed and
+             * the student is not on a team in the teamset.
+             */
+            tryRenderActions: function() {
+                //
+                const { staff, priviledged } = this.context.userInfo;
+                if (staff || priviledged) {
+                    return this.drawActions();
+                }
+                if (TeamUtils.isInstructorManagedTopic(this.model.attributes.type)) {
+                    return null;
+                }
+                return this.checkIfOnTeamInTeamset().then(
+                    onTeamInTeamset => !onTeamInTeamset && this.drawActions()
+                );
             },
 
             render: function() {
-                var self = this;
-                this.collection.refresh().done(function() {
-                    var message;
-                    TeamsView.prototype.render.call(self);
-                    if (self.canUserCreateTeam()) {
-                        message = interpolate_text(  // eslint-disable-line no-undef
-                                // Translators: this string is shown at the bottom of the teams page
-                                // to find a team to join or else to create a new one. There are three
-                                // links that need to be included in the message:
-                                // 1. Browse teams in other topics
-                                // 2. search teams
-                                // 3. create a new team
-                                // Be careful to start each link with the appropriate start indicator
-                                // (e.g. {browse_span_start} for #1) and finish it with {span_end}.
-                                _.escape(gettext(
-                                    '{browse_span_start}Browse teams in other ' +
-                                    'topics{span_end} or {search_span_start}search teams{span_end} ' +
-                                    'in this topic. If you still can\'t find a team to join, ' +
-                                    '{create_span_start}create a new team in this topic{span_end}.'
-                                )),
-                            {
-                                browse_span_start: '<a class="browse-teams" href="">',
-                                search_span_start: '<a class="search-teams" href="">',
-                                create_span_start: '<a class="create-team" href="">',
-                                span_end: '</a>'
-                            }
-                            );
-                        HtmlUtils.append(
-                            self.$el,
-                            HtmlUtils.template(teamActionsTemplate)({message: message})
-                        );
-                    }
+                this.collection.refresh().done(() => {
+                    TeamsView.prototype.render.call(this);
+                    this.tryRenderActions();
                 });
-                return this;
             },
 
             browseTeams: function(event) {
@@ -82,17 +120,15 @@
                 event.preventDefault();
                 $searchField.focus();
                 $searchField.select();
-                $('html, body').animate({
-                    scrollTop: 0
-                }, 500);
+                $('html, body').animate({ scrollTop: 0 }, 500);
             },
 
             showCreateTeamForm: function(event) {
                 event.preventDefault();
                 Backbone.history.navigate(
-                        'topics/' + this.model.id + '/create-team',
-                        {trigger: true}
-                    );
+                    'topics/' + this.model.id + '/create-team',
+                    { trigger: true }
+                );
             },
 
             createHeaderView: function() {


### PR DESCRIPTION
# What changed?
Topic Teams page now shows action bar only if user is not on a team in the **teamset** instead of checking across the entire course.

The previous code relied on a backbone collection for membership on
teams across the course, while the new logic requires access to teams
only within the teamset.
Was unable to find an easy way to do this with the provided backbone
collections, but a suitable ajax query exists in the API.

In the process, the tests for the teams_tab also needed to be updated, as they manage a parent ajax context, and the new request was interfering in their tests.

# Also, ES6 syntax...
In the process of getting this working, I updated much of the local
syntax/formatting to ES6 in an attempt to make the code more
accessible/readable.


# Readability hint:
I attempted to split up indentation fixes from the code/logic changes by splitting them into different commits event though they were going in simultaneously...  I hope that makes this a little more readable.

![image](https://user-images.githubusercontent.com/5533134/84701271-acbc6c80-af22-11ea-91ed-c535666555cb.png)

JIRA: https://openedx.atlassian.net/browse/EDUCATOR-5062
FIY: @edx/masters-devs-gta