### PR TITLE
Removed confirm email after SSO

### DIFF
--- a/openedx/core/djangoapps/user_authn/views/registration_form.py
+++ b/openedx/core/djangoapps/user_authn/views/registration_form.py
@@ -1087,6 +1087,17 @@ class RegistrationFormFactory(object):
                                     instructions="",
                                 )
 
+                    # Hide the confirm_email field
+                    form_desc.override_field_properties(
+                        "confirm_email",
+                        default="",
+                        field_type="hidden",
+                        required=False,
+                        label="",
+                        instructions="",
+                        restrictions={}
+                    )
+
                     # Hide the password field
                     form_desc.override_field_properties(
                         "password",


### PR DESCRIPTION
[PROD-1679](https://openedx.atlassian.net/browse/PROD-1679)

This PR removes confirm email field on SSO registration form.