### PR TITLE
 [BD-10] [DEPR-65][DEPR-74] Remove pattern library of course_bookmarks.py

### DIFF
--- a/lms/static/sass/bootstrap/_layouts.scss
+++ b/lms/static/sass/bootstrap/_layouts.scss
@@ -51,7 +51,7 @@
   display: flex;
   flex-wrap: wrap;
   border-bottom: 1px solid $border-color;
-  padding: $baseline $baseline*2;
+  padding: $baseline;
 
   .page-header-search {
     @include margin-right($baseline);
@@ -107,7 +107,7 @@
 }
 
 .page-content {
-  padding: $baseline*2;
+  padding: $baseline;
 
   // Adjust styles for desktop sized screens
   @include media-breakpoint-up(md) {

--- a/lms/static/sass/bootstrap/_legacy.scss
+++ b/lms/static/sass/bootstrap/_legacy.scss
@@ -73,6 +73,21 @@ $grid-breakpoints-lg: 992px !default;
   }
 }
 
+// Flexible grid
+$gw-column: 80px !default;
+$gw-gutter: 20px !default;
+$fg-column: $gw-column !default;
+$fg-gutter: $gw-gutter !default;
+$fg-max-columns: 12 !default;
+$fg-max-width: 1400px !default;
+$fg-min-width: 810px !default;
+
+@function flex-grid($columns, $container-columns: $fg-max-columns) {
+  $width: $columns * $fg-column + ($columns - 1) * $fg-gutter;
+  $container-width: $container-columns * $fg-column + ($container-columns - 1) * $fg-gutter;
+  @return percentage($width / $container-width);
+}
+
 // ----------------------------
 // #FONTS
 // ----------------------------

--- a/lms/static/sass/bootstrap/elements/_pagination.scss
+++ b/lms/static/sass/bootstrap/elements/_pagination.scss
@@ -1,0 +1,132 @@
+// Copied from elements/_pagination.scss
+
+.pagination {
+  @include clearfix();
+
+  display: inline-block;
+  width: flex-grid(3, 12); // TODO: remove flex-grid
+
+  &.pagination-compact {
+    @include text-align(right);
+  }
+
+  &.pagination-full {
+    display: block;
+    width: flex-grid(4, 12); // TODO: remove flex-grid
+    margin: $baseline auto;
+  }
+
+  .nav-item {
+    position: relative;
+    display: inline-block;
+    vertical-align: middle;
+  }
+
+  .nav-link {
+    display: block;
+    border: 0;
+    background-image: none;
+    background-color: transparent;
+    padding: ($baseline/2) ($baseline*0.75);
+
+    &.previous {
+      margin-right: ($baseline/2);
+    }
+
+    &.next {
+      margin-left: ($baseline/2);
+    }
+
+    &:hover {
+      background-color: theme-color("primary");
+      background-image: none;
+      border-radius: 3px;
+      color: $white;
+    }
+
+    &.is-disabled {
+      background-color: transparent;
+      color: theme-color("disabled");
+      pointer-events: none;
+    }
+  }
+
+  .nav-label {
+    @extend .sr-only;
+  }
+
+  .pagination-form,
+  .current-page,
+  .page-divider,
+  .total-pages {
+    display: inline-block;
+  }
+
+  .current-page,
+  .page-number-input,
+  .total-pages {
+    width: ($baseline*2.5);
+    vertical-align: middle;
+    margin: 0 ($baseline*0.75);
+    padding: ($baseline/4);
+    text-align: center;
+    color: theme-color("dark");
+  }
+
+  .current-page {
+    position: absolute;
+
+    @include left(-($baseline/4));
+  }
+
+  .page-divider {
+    vertical-align: middle;
+    color: theme-color("dark");
+  }
+
+  .pagination-form {
+    position: relative;
+    z-index: 100;
+
+    .page-number-label,
+    .submit-pagination-form {
+      @extend .sr-only;
+    }
+
+    .page-number-input {
+      border: 1px solid transparent;
+      border-bottom: 1px dotted $gray;
+      border-radius: 0;
+      box-shadow: none;
+      background: none;
+
+      &:hover {
+        background-color: $white;
+        opacity: 0.6;
+      }
+
+      &:focus {
+        opacity: 1;
+        box-shadow: 0 0 3px $black inset;
+        background-color: $white;
+        border: 1px solid transparent;
+        border-radius: 3px;
+      }
+    }
+  }
+}
+
+// styles for search/pagination metadata and sorting
+.listing-tools {
+  color: theme-color("dark");
+
+  label { // override
+    color: inherit;
+    font-size: inherit;
+    cursor: auto;
+  }
+
+  .listing-sort-select {
+    border: 0;
+  }
+}

--- a/lms/static/sass/bootstrap/lms-main.scss
+++ b/lms/static/sass/bootstrap/lms-main.scss
@@ -22,6 +22,7 @@ $static-path: '../..';
 @import './elements/progress-circle';
 @import './elements/program-card';
 @import 'elements/icons';
+@import './elements/pagination';
 
 // Features
 @import 'features/bookmarks';

--- a/lms/static/sass/features/_bookmarks.scss
+++ b/lms/static/sass/features/_bookmarks.scss
@@ -23,10 +23,10 @@ $bookmarked-icon: "\f02e"; // .fa-bookmark
       margin-bottom: $baseline;
 
       &:hover {
-        border-color: palette(primary, base);
+        border-color: theme-color("primary");
 
         .list-item-breadcrumbtrail {
-          color: palette(primary, base);
+          color: theme-color("primary");
         }
       }
     }
@@ -48,7 +48,7 @@ $bookmarked-icon: "\f02e"; // .fa-bookmark
       position: relative;
       top: -7px;
       font-family: FontAwesome;
-      color: palette(primary, base);
+      color: theme-color("primary");
     }
 
     .list-item-content {

--- a/lms/static/sass/features/_bookmarks.scss
+++ b/lms/static/sass/features/_bookmarks.scss
@@ -29,6 +29,11 @@ $bookmarked-icon: "\f02e"; // .fa-bookmark
           color: theme-color("primary");
         }
       }
+
+      .fa-caret-right {
+        transform: rotateY(0deg) #{"/*rtl: rotateY(180deg)*/"};
+        font-size: inherit;
+      }
     }
 
     .results-list-item-view {
@@ -70,9 +75,8 @@ $bookmarked-icon: "\f02e"; // .fa-bookmark
       vertical-align: middle;
 
       .fa-arrow-right {
-        @include rtl {
-          @include transform(rotate(180deg));
-        }
+        transform: rotateY(0deg) #{"/*rtl: rotateY(180deg)*/"};
+        font-size: inherit;
       }
     }
   }

--- a/openedx/features/course_bookmarks/templates/course_bookmarks/course-bookmarks.html
+++ b/openedx/features/course_bookmarks/templates/course_bookmarks/course-bookmarks.html
@@ -1,6 +1,6 @@
 ## mako
 
-<%! main_css = "style-main-v2" %>
+<%! main_css = "css/bootstrap/lms-main.css" %>
 
 <%page expression_filter="h"/>
 <%inherit file="../main.html" />

--- a/openedx/features/course_bookmarks/views/course_bookmarks.py
+++ b/openedx/features/course_bookmarks/views/course_bookmarks.py
@@ -56,7 +56,7 @@ class CourseBookmarksView(View):
             'course_url': course_url,
             'bookmarks_fragment': bookmarks_fragment,
             'disable_courseware_js': True,
-            'uses_pattern_library': True,
+            'uses_bootstrap': True,
         }
         return render_to_response('course_bookmarks/course-bookmarks.html', context)
 

--- a/openedx/features/course_bookmarks/views/course_bookmarks.py
+++ b/openedx/features/course_bookmarks/views/course_bookmarks.py
@@ -65,6 +65,8 @@ class CourseBookmarksFragmentView(EdxFragmentView):
     """
     Fragment view that shows a user's bookmarks for a course.
     """
+    _uses_pattern_library = False
+
     def render_to_fragment(self, request, course_id=None, **kwargs):
         """
         Renders the user's course bookmarks as a fragment.


### PR DESCRIPTION
@abutterworth
Tickets on jira: https://openedx.atlassian.net/browse/DEPR-65
https://openedx.atlassian.net/browse/DEPR-74
Remove use of pattern library of openedx/features/course_bookmarks/views/course_bookmarks.py
Based on this PR by Adam: https://github.com/edx/edx-platform/pull/22599
I made adjustments for RTL and the fragment view.
Test URL1: /courses/<course_id>/bookmarks/
URL2: /courses/<course_id>/bookmarks/bookmarks_fragment
It's tested on mobile and RTL content.
![bookmark-empty-pattern](https://user-images.githubusercontent.com/36944773/84811275-3aa36080-afd2-11ea-9302-b02c499e677a.jpg)
![bookmark-empty-bootstrap](https://user-images.githubusercontent.com/36944773/84811281-3e36e780-afd2-11ea-9392-f976bb195d8b.jpg)
![bookmark-pattern](https://user-images.githubusercontent.com/36944773/84811286-40994180-afd2-11ea-9de6-e82e6dab80fd.jpg)
![bookmark-bootstrap](https://user-images.githubusercontent.com/36944773/84811298-442cc880-afd2-11ea-91af-2a9918953106.jpg)
![bookmark-fragment-pattern](https://user-images.githubusercontent.com/36944773/84811314-4abb4000-afd2-11ea-9a0e-d30085d42fda.jpg)
![bookmark-fragment-bootstrap](https://user-images.githubusercontent.com/36944773/84811320-4d1d9a00-afd2-11ea-83c2-b1dab49f8382.jpg)
