### PR TITLE
EDUCATOR-5069: Display student key in csv export

### DIFF
--- a/lms/djangoapps/teams/csv.py
+++ b/lms/djangoapps/teams/csv.py
@@ -52,8 +52,8 @@ def _lookup_team_membership_data(course):
     Returns a list of dicts, in the following form:
     [
         {
-            'user': If the user is enrolled in this course as a part of a program, this will be <external_user_key>
-                    otherwise <username>,
+            'user': If the user is enrolled in this course as a part of a program,
+                    this will be <external_user_key> if the user has one, otherwise <username>,
             'mode': <student enrollment mode for the given course>,
             <teamset id>: <team name> for each teamset in which the given user is on a team
         }

--- a/lms/djangoapps/teams/csv.py
+++ b/lms/djangoapps/teams/csv.py
@@ -6,6 +6,7 @@ import csv
 from collections import Counter
 
 from django.contrib.auth.models import User
+from django.db.models import Prefetch
 
 from lms.djangoapps.teams.api import (
     OrganizationProtectionStatus,
@@ -13,7 +14,7 @@ from lms.djangoapps.teams.api import (
     ORGANIZATION_PROTECTED_MODES
 )
 from lms.djangoapps.teams.models import CourseTeam, CourseTeamMembership
-from lms.djangoapps.program_enrollments.models import ProgramEnrollment
+from lms.djangoapps.program_enrollments.models import ProgramCourseEnrollment, ProgramEnrollment
 from student.models import CourseEnrollment
 from .utils import emit_team_event
 
@@ -51,27 +52,67 @@ def _lookup_team_membership_data(course):
     Returns a list of dicts, in the following form:
     [
         {
-            'user': <username>,
+            'user': If the user is enrolled in this course as a part of a program, this will be <external_user_key>
+                    otherwise <username>,
             'mode': <student enrollment mode for the given course>,
             <teamset id>: <team name> for each teamset in which the given user is on a team
         }
         for student in course
     ]
     """
-    course_students = CourseEnrollment.objects.users_enrolled_in(course.id).order_by('username')
-    CourseEnrollment.bulk_fetch_enrollment_states(course_students, course.id)
-
+    # Get course enrollments and team memberships for the given course
+    course_enrollments = _fetch_course_enrollments_with_related_models(course.id)
     course_team_memberships = CourseTeamMembership.objects.filter(
         team__course_id=course.id
     ).select_related('team', 'user').all()
     teamset_memberships_by_user = _group_teamset_memberships_by_user(course_team_memberships)
+
     team_membership_data = []
-    for user in course_students:
-        student_row = teamset_memberships_by_user.get(user, dict())
-        student_row['user'] = user.username
-        student_row['mode'], _ = CourseEnrollment.enrollment_mode_for_user(user, course.id)
+    for course_enrollment in course_enrollments:
+        # This dict contains all the user's team memberships keyed by teamset
+        student_row = teamset_memberships_by_user.get(course_enrollment.user, dict())
+        student_row['user'] = _get_displayed_user_identifier(course_enrollment)
+        student_row['mode'] = course_enrollment.mode
         team_membership_data.append(student_row)
     return team_membership_data
+
+
+def _fetch_course_enrollments_with_related_models(course_id):
+    """
+    Look up active course enrollments for this course. Fetch the user.
+    Fetch the ProgramCourseEnrollment and ProgramEnrollment if any of the CourseEnrollments are associated with
+        a program enrollment (so we have access to an external_user_id if it exists).
+    Order by the username of the enrolled user.
+
+    Returns a QuerySet
+    """
+    return CourseEnrollment.objects.filter(
+        course_id=course_id,
+        is_active=True
+    ).prefetch_related(
+        Prefetch(
+            'programcourseenrollment_set',
+            queryset=ProgramCourseEnrollment.objects.select_related('program_enrollment')
+        )
+    ).select_related(
+        'user'
+    ).order_by('user__username')
+
+
+def _get_displayed_user_identifier(course_enrollment):
+    """
+    If a user is enrolled in the course as a part of a program and the program identifies them
+        with an external_user_key, use that as the value of the 'user' column.
+    Otherwise, use the user's username.
+    """
+    program_course_enrollments = course_enrollment.programcourseenrollment_set
+    if program_course_enrollments.exists():
+        # A user should only have one or zero ProgramCourseEnrollments associated with a given CourseEnrollment
+        program_course_enrollment = program_course_enrollments.all()[0]
+        external_user_key = program_course_enrollment.program_enrollment.external_user_key
+        if external_user_key:
+            return external_user_key
+    return course_enrollment.user.username
 
 
 def _group_teamset_memberships_by_user(course_team_memberships):


### PR DESCRIPTION
[EDUCATOR-5069: Display student key in csv export](https://openedx.atlassian.net/browse/EDUCATOR-5069)

In the teams csv download, if a user is enrolled in the course as a part of a program, and their program enrollment has an associated `external_user_key`, use that `external_user_key` rather than username to identify the user in the 'user' column of the csv export.

I also added some tests for uploading a csv that identifies a user by their `external_user_key`, which is already implemented

@edx/masters-devs-gta 