### PR TITLE
Fix problem viewing when CSMH is disabled

### DIFF
--- a/lms/djangoapps/courseware/migrations/0011_csm_id_bigint.py
+++ b/lms/djangoapps/courseware/migrations/0011_csm_id_bigint.py
@@ -33,8 +33,9 @@ class Migration(migrations.Migration):
 
     dependencies = [
         ('courseware', '0010_auto_20190709_1559'),
-        ('coursewarehistoryextended', '0002_force_studentmodule_index'),
     ]
+    if settings.FEATURES["ENABLE_CSMH_EXTENDED"]:
+        dependencies.append(('coursewarehistoryextended', '0002_force_studentmodule_index'))
 
     operations = [
         CsmBigInt(


### PR DESCRIPTION
When the extended courseware module history feature is disabled
(ENABLE_CSMH_EXTENDED=false), the coursewarehistoryextended application
cannot be added to INSTALLED_APPS. Otherwise, the
StudentModuleHistoryExtended model is loaded in the project: it contains
signal receivers that automatically save objects to the student history
table. This table does not exist because the CSMH flag is disabled and
there is no student_module_history database.

So the feature flag is disabled and coursewarehistoryextended is not
part of INSTALLED_APPS: this was the default behaviour in Ironwood. To
make sure that this behaviour keeps working, we also need to make sure
that the migrations do not depend on the coursewarehistoryextended app
when the feature flag is disabled.