### PR TITLE
[BD-6] Fix python 3.8 compatibility

### DIFF
--- a/common/lib/xmodule/xmodule/modulestore/__init__.py
+++ b/common/lib/xmodule/xmodule/modulestore/__init__.py
@@ -32,6 +32,12 @@ from xmodule.errortracker import make_error_tracker
 
 from .exceptions import InsufficientSpecificationError, InvalidLocationError
 
+# The name of the type for patterns in re changed in Python 3.7.
+try:
+    Pattern = re._pattern_type  # pylint: disable=protected-access
+except AttributeError:
+    Pattern = re.Pattern  # pylint: disable=no-member
+
 log = logging.getLogger('edx.modulestore')
 
 new_contract('CourseKey', CourseKey)
@@ -899,7 +905,7 @@ class ModuleStoreRead(six.with_metaclass(ABCMeta, ModuleStoreAssetBase)):
         """
         if isinstance(target, list):
             return any(self._value_matches(ele, criteria) for ele in target)
-        elif isinstance(criteria, re._pattern_type):  # pylint: disable=protected-access
+        elif isinstance(criteria, Pattern):
             return criteria.search(target) is not None
         elif callable(criteria):
             return criteria(target)


### PR DESCRIPTION
BOM-1731

Currently in python3.8 tests we have this error:

```
AttributeError: module 're' has no attribute '_pattern_type' due to a change in python3.7
```

This is due to a change in python3.7

https://github.com/python/cpython/pull/1646/files

This change solves 52 of the tests that failed in the first python3.8 tests
https://build.testeng.edx.org/job/edx-platform-python-3.8-python-pipeline-pr/2/

## Reviewers
- [ ] @ericfab179 
- [ ] @awais786  