### PR TITLE
AA-194: Updating edx-when version

### DIFF
--- a/lms/djangoapps/course_home_api/dates/v1/views.py
+++ b/lms/djangoapps/course_home_api/dates/v1/views.py
@@ -15,7 +15,6 @@ from lms.djangoapps.courseware.courses import get_course_date_blocks, get_course
 from lms.djangoapps.courseware.date_summary import TodaysDate, verified_upgrade_deadline_link
 from lms.djangoapps.course_home_api.dates.v1.serializers import DatesTabSerializer
 from lms.djangoapps.course_home_api.toggles import course_home_mfe_dates_tab_is_active
-from openedx.core.djangoapps.enrollments.api import get_enrollment
 from openedx.features.course_experience.utils import dates_banner_should_display
 from openedx.features.content_type_gating.models import ContentTypeGatingConfig
 

--- a/lms/djangoapps/courseware/date_summary.py
+++ b/lms/djangoapps/courseware/date_summary.py
@@ -259,7 +259,6 @@ class CourseStartDate(DateSummary):
     Displays the start date of the course.
     """
     css_class = 'start-date'
-    title = ugettext_lazy('Course Starts')
 
     @property
     def date(self):
@@ -272,6 +271,13 @@ class CourseStartDate(DateSummary):
     @property
     def date_type(self):
         return 'course-start-date'
+
+    @property
+    def title(self):
+        enrollment = CourseEnrollment.get_enrollment(self.user, self.course_id)
+        if enrollment and self.course.end and enrollment.created > self.course.end:
+            return ugettext_lazy('Enrollment Date')
+        return ugettext_lazy('Course Starts')
 
     def register_alerts(self, request, course):
         """

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -114,7 +114,7 @@ edx-sga==0.11.0           # via -r requirements/edx/base.in
 edx-submissions==3.1.10   # via -r requirements/edx/base.in, ora2
 edx-tincan-py35==0.0.5    # via edx-enterprise
 edx-user-state-client==1.2.0  # via -r requirements/edx/base.in
-edx-when==1.2.7           # via -r requirements/edx/base.in, edx-proctoring
+edx-when==1.2.8           # via -r requirements/edx/base.in, edx-proctoring
 edxval==1.3.5             # via -r requirements/edx/base.in
 elasticsearch==1.9.0      # via edx-search
 enmerkar-underscore==1.0.0  # via -r requirements/edx/base.in

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -128,7 +128,7 @@ edx-sphinx-theme==1.5.0   # via -r requirements/edx/development.in
 edx-submissions==3.1.10   # via -r requirements/edx/testing.txt, ora2
 edx-tincan-py35==0.0.5    # via -r requirements/edx/testing.txt, edx-enterprise
 edx-user-state-client==1.2.0  # via -r requirements/edx/testing.txt
-edx-when==1.2.7           # via -r requirements/edx/testing.txt, edx-proctoring
+edx-when==1.2.8           # via -r requirements/edx/testing.txt, edx-proctoring
 edxval==1.3.5             # via -r requirements/edx/testing.txt
 elasticsearch==1.9.0      # via -r requirements/edx/testing.txt, edx-search
 enmerkar-underscore==1.0.0  # via -r requirements/edx/testing.txt

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -124,7 +124,7 @@ edx-sga==0.11.0           # via -r requirements/edx/base.txt
 edx-submissions==3.1.10   # via -r requirements/edx/base.txt, ora2
 edx-tincan-py35==0.0.5    # via -r requirements/edx/base.txt, edx-enterprise
 edx-user-state-client==1.2.0  # via -r requirements/edx/base.txt
-edx-when==1.2.7           # via -r requirements/edx/base.txt, edx-proctoring
+edx-when==1.2.8           # via -r requirements/edx/base.txt, edx-proctoring
 edxval==1.3.5             # via -r requirements/edx/base.txt
 elasticsearch==1.9.0      # via -r requirements/edx/base.txt, edx-search
 enmerkar-underscore==1.0.0  # via -r requirements/edx/base.txt


### PR DESCRIPTION
Updating edx-when version to pull in a change related to not
returning dates if the enrollment happened after course end
(if no enrollment end date is set)

This also contains a change to move the text from Course Starts to Enrollment Date if the enrollment date is after the course end date.

https://github.com/edx/edx-when/pull/55