### PR TITLE
add proctoring escalation contact setting

### DIFF
--- a/cms/djangoapps/contentstore/tests/test_course_settings.py
+++ b/cms/djangoapps/contentstore/tests/test_course_settings.py
@@ -881,6 +881,32 @@ class CourseMetadataEditingTest(CourseTestCase):
         test_model = CourseMetadata.fetch(self.fullcourse)
         self.assertNotIn('giturl', test_model)
 
+    @override_settings(
+        PROCTORING_BACKENDS={
+            'DEFAULT': 'test_proctoring_provider',
+            'proctortrack': {}
+        },
+    )
+    def test_fetch_proctoring_escalation_email_present(self):
+        """
+        If 'proctortrack' is an available provider, show the escalation email setting
+        """
+        test_model = CourseMetadata.fetch(self.fullcourse)
+        self.assertIn('proctoring_escalation_email', test_model)
+
+    @override_settings(
+        PROCTORING_BACKENDS={
+            'DEFAULT': 'test_proctoring_provider',
+            'alternate_provider': {}
+        },
+    )
+    def test_fetch_proctoring_escalation_email_not_present(self):
+        """
+        If 'proctortrack' is not an available provider, don't show the escalation email setting
+        """
+        test_model = CourseMetadata.fetch(self.fullcourse)
+        self.assertNotIn('proctoring_escalation_email', test_model)
+
     @patch.dict(settings.FEATURES, {'ENABLE_EXPORT_GIT': False})
     def test_validate_update_filtered_off(self):
         """
@@ -1353,6 +1379,101 @@ class CourseMetadataEditingTest(CourseTestCase):
             user=self.user
         )
         self.assertNotIn(field_name, test_model)
+
+    @ddt.data(True, False)
+    @override_settings(
+        PROCTORING_BACKENDS={
+            'DEFAULT': 'test_proctoring_provider',
+            'test_proctoring_provider': {},
+            'proctortrack': {}
+        }
+    )
+    @override_waffle_flag(ENABLE_PROCTORING_PROVIDER_OVERRIDES, True)
+    def test_validate_update_requires_escalation_email_for_proctortrack(self, include_blank_email):
+        json_data = {
+            "proctoring_provider": {"value": 'proctortrack'},
+        }
+        if include_blank_email:
+            json_data["proctoring_escalation_email"] = {"value": ""}
+
+        did_validate, errors, test_model = CourseMetadata.validate_and_update_from_json(
+            self.course,
+            json_data,
+            user=self.user
+        )
+        self.assertFalse(did_validate)
+        self.assertEqual(len(errors), 1)
+        self.assertIsNone(test_model)
+        self.assertEqual(
+            errors[0].get('message'),
+            'Provider \'proctortrack\' requires an exam escalation contact.'
+        )
+
+    @override_settings(
+        PROCTORING_BACKENDS={
+            'DEFAULT': 'test_proctoring_provider',
+            'test_proctoring_provider': {},
+            'proctortrack': {}
+        }
+    )
+    @override_waffle_flag(ENABLE_PROCTORING_PROVIDER_OVERRIDES, True)
+    def test_validate_update_does_not_require_escalation_email_by_default(self):
+        did_validate, errors, test_model = CourseMetadata.validate_and_update_from_json(
+            self.course,
+            {
+                "proctoring_provider": {"value": "test_proctoring_provider"},
+            },
+            user=self.user
+        )
+        self.assertTrue(did_validate)
+        self.assertEqual(len(errors), 0)
+        self.assertIn('proctoring_provider', test_model)
+
+    @override_settings(
+        PROCTORING_BACKENDS={
+            'DEFAULT': 'proctortrack',
+            'proctortrack': {}
+        }
+    )
+    @override_waffle_flag(ENABLE_PROCTORING_PROVIDER_OVERRIDES, True)
+    def test_validate_update_cannot_unset_escalation_email_when_proctortrack_is_provider(self):
+        course = CourseFactory.create()
+        CourseMetadata.update_from_dict({"proctoring_provider": 'proctortrack'}, course, self.user)
+        did_validate, errors, test_model = CourseMetadata.validate_and_update_from_json(
+            course,
+            {
+                "proctoring_escalation_email": {"value": ""},
+            },
+            user=self.user
+        )
+        self.assertFalse(did_validate)
+        self.assertEqual(len(errors), 1)
+        self.assertIsNone(test_model)
+        self.assertEqual(
+            errors[0].get('message'),
+            'Provider \'proctortrack\' requires an exam escalation contact.'
+        )
+
+    @override_settings(
+        PROCTORING_BACKENDS={
+            'DEFAULT': 'proctortrack',
+            'proctortrack': {}
+        }
+    )
+    @override_waffle_flag(ENABLE_PROCTORING_PROVIDER_OVERRIDES, True)
+    def test_validate_update_set_proctortrack_provider_with_valid_escalation_email(self):
+        did_validate, errors, test_model = CourseMetadata.validate_and_update_from_json(
+            self.course,
+            {
+                "proctoring_provider": {"value": "proctortrack"},
+                "proctoring_escalation_email": {"value": "foo@bar.com"},
+            },
+            user=self.user
+        )
+        self.assertTrue(did_validate)
+        self.assertEqual(len(errors), 0)
+        self.assertIn('proctoring_provider', test_model)
+        self.assertIn('proctoring_escalation_email', test_model)
 
     def test_create_zendesk_tickets_present_for_edx_staff(self):
         """

--- a/common/lib/xmodule/xmodule/course_module.py
+++ b/common/lib/xmodule/xmodule/course_module.py
@@ -12,6 +12,7 @@ import dateutil.parser
 import requests
 import six
 from django.conf import settings
+from django.core.validators import validate_email
 from lazy import lazy
 from lxml import etree
 from path import Path as path
@@ -81,6 +82,18 @@ class StringOrDate(Date):
             return value
         else:
             return result
+
+
+class EmailString(String):
+    """
+    Parse String with email validation
+    """
+    def from_json(self, value):
+        if value:
+            validate_email(value)
+            return value
+        else:
+            return None
 
 
 edx_xml_parser = etree.XMLParser(dtd_validation=False, load_dtd=False,
@@ -874,6 +887,17 @@ class CourseFields(object):
             ),
         ),
         scope=Scope.settings,
+    )
+
+    proctoring_escalation_email = EmailString(
+        display_name=_("Proctortrack Exam Escalation Contact"),
+        help=_(
+            "Required if 'proctortrack' is selected as your proctoring provider. "
+            "Enter an email address to be contacted by the support team whenever there are escalations "
+            "(e.g. appeals, delayed reviews, etc.)."
+        ),
+        default=None,
+        scope=Scope.settings
     )
 
     allow_proctoring_opt_out = Boolean(


### PR DESCRIPTION
### [MST-273](https://openedx.atlassian.net/browse/MST-273)

@edx/masters-devs-cosmonauts 

Adds a new setting for 'Proctortrack Exam Escalation Contact'

- This setting will only appear is 'proctortrack' is available as a provider
- Escalation email is required if 'proctortrack' is chosen as the provider

screenshots:
<img width="1305" alt="Screen Shot 2020-06-18 at 9 08 40 AM" src="https://user-images.githubusercontent.com/5661461/85026003-22ece900-b146-11ea-8220-120f9cc7752d.png">

invalid email format
<img width="1441" alt="Screen Shot 2020-06-18 at 9 08 55 AM" src="https://user-images.githubusercontent.com/5661461/85026032-297b6080-b146-11ea-8c5c-5d874a2858e9.png">

missing contact email
<img width="1430" alt="Screen Shot 2020-06-18 at 9 09 13 AM" src="https://user-images.githubusercontent.com/5661461/85026042-2c765100-b146-11ea-82a7-5202e1a7c86b.png">
