### PR TITLE
Replace references to 'log.warn' with 'log.warning'

### DIFF
--- a/lms/djangoapps/certificates/views/webview.py
+++ b/lms/djangoapps/certificates/views/webview.py
@@ -397,7 +397,7 @@ def _track_certificate_events(request, context, course, user, user_certificate):
                 }
             )
         else:
-            log.warn(
+            log.warning(
                 u"Could not find badge for %s on course %s.",
                 user.id,
                 course_key,

--- a/openedx/core/djangoapps/course_groups/partition_scheme.py
+++ b/openedx/core/djangoapps/course_groups/partition_scheme.py
@@ -61,7 +61,7 @@ class CohortPartitionScheme(object):
             # if we have a match but the partition doesn't match the requested
             # one it means the mapping is invalid.  the previous state of the
             # partition configuration may have been modified.
-            log.warn(
+            log.warning(
                 u"partition mismatch in CohortPartitionScheme: %r",
                 {
                     "requested_partition_id": user_partition.id,
@@ -79,7 +79,7 @@ class CohortPartitionScheme(object):
             # if we have a match but the group doesn't exist in the partition,
             # it means the mapping is invalid.  the previous state of the
             # partition configuration may have been modified.
-            log.warn(
+            log.warning(
                 u"group not found in CohortPartitionScheme: %r",
                 {
                     "requested_partition_id": user_partition.id,

--- a/openedx/core/djangoapps/course_groups/tests/test_partition_scheme.py
+++ b/openedx/core/djangoapps/course_groups/tests/test_partition_scheme.py
@@ -228,8 +228,8 @@ class TestCohortPartitionScheme(ModuleStoreTestCase):
         # warning)
         with patch('openedx.core.djangoapps.course_groups.partition_scheme.log') as mock_log:
             self.assert_student_in_group(None, new_user_partition)
-            self.assertTrue(mock_log.warn.called)
-            self.assertRegex(mock_log.warn.call_args[0][0], 'group not found')
+            self.assertTrue(mock_log.warning.called)
+            self.assertRegex(mock_log.warning.call_args[0][0], 'group not found')
 
     def test_missing_partition(self):
         """
@@ -253,8 +253,8 @@ class TestCohortPartitionScheme(ModuleStoreTestCase):
         # scheme returns None (and logs a warning).
         with patch('openedx.core.djangoapps.course_groups.partition_scheme.log') as mock_log:
             self.assert_student_in_group(None, new_user_partition)
-            self.assertTrue(mock_log.warn.called)
-            self.assertRegex(mock_log.warn.call_args[0][0], 'partition mismatch')
+            self.assertTrue(mock_log.warning.called)
+            self.assertRegex(mock_log.warning.call_args[0][0], 'partition mismatch')
 
 
 class TestExtension(django.test.TestCase):

--- a/openedx/core/djangoapps/enrollments/api.py
+++ b/openedx/core/djangoapps/enrollments/api.py
@@ -266,7 +266,7 @@ def update_enrollment(
     enrollment = _data_api().update_course_enrollment(username, course_id, mode=mode, is_active=is_active)
     if enrollment is None:
         msg = u"Course Enrollment not found for user {user} in course {course}".format(user=username, course=course_id)
-        log.warn(msg)
+        log.warning(msg)
         raise errors.EnrollmentNotFoundError(msg)
     else:
         if enrollment_attributes is not None:
@@ -455,7 +455,7 @@ def validate_course_mode(course_id, mode, is_active=None, include_expired=False)
             course_id=course_id,
             available=", ".join(available_modes)
         )
-        log.warn(msg)
+        log.warning(msg)
         raise errors.CourseModeNotFoundError(msg, course_enrollment_info)
 
 

--- a/openedx/core/djangoapps/enrollments/data.py
+++ b/openedx/core/djangoapps/enrollments/data.py
@@ -143,7 +143,7 @@ def create_course_enrollment(username, course_id, mode, is_active):
         user = User.objects.get(username=username)
     except User.DoesNotExist:
         msg = u"Not user with username '{username}' found.".format(username=username)
-        log.warn(msg)
+        log.warning(msg)
         raise UserNotFoundError(msg)
 
     try:
@@ -181,7 +181,7 @@ def update_course_enrollment(username, course_id, mode=None, is_active=None):
         user = User.objects.get(username=username)
     except User.DoesNotExist:
         msg = u"Not user with username '{username}' found.".format(username=username)
-        log.warn(msg)
+        log.warning(msg)
         raise UserNotFoundError(msg)
 
     try:
@@ -272,7 +272,7 @@ def _get_user(username):
         return User.objects.get(username=username)
     except User.DoesNotExist:
         msg = u"Not user with username '{username}' found.".format(username=username)
-        log.warn(msg)
+        log.warning(msg)
         raise UserNotFoundError(msg)
 
 
@@ -295,17 +295,17 @@ def _invalid_attribute(attributes):
     for attribute in attributes:
         if "namespace" not in attribute:
             msg = u"'namespace' not in enrollment attribute"
-            log.warn(msg)
+            log.warning(msg)
             invalid_attributes.append("namespace")
             raise InvalidEnrollmentAttribute(msg)
         if "name" not in attribute:
             msg = u"'name' not in enrollment attribute"
-            log.warn(msg)
+            log.warning(msg)
             invalid_attributes.append("name")
             raise InvalidEnrollmentAttribute(msg)
         if "value" not in attribute:
             msg = u"'value' not in enrollment attribute"
-            log.warn(msg)
+            log.warning(msg)
             invalid_attributes.append("value")
             raise InvalidEnrollmentAttribute(msg)
 

--- a/openedx/core/djangoapps/user_api/partition_schemes.py
+++ b/openedx/core/djangoapps/user_api/partition_schemes.py
@@ -65,7 +65,7 @@ class RandomUserPartitionScheme(object):
                 group = user_partition.get_group(int(group_id))
             except NoSuchUserPartitionGroupError:
                 # jsa: we can turn off warnings here if this is an expected case.
-                log.warn(
+                log.warning(
                     u"group not found in RandomUserPartitionScheme: %r",
                     {
                         "requested_partition_id": user_partition.id,


### PR DESCRIPTION
to remove some `DeprecationWarning`s from the logs
as the former method as been deprecated since Python 3.3 [1][2].

- [1] https://github.com/python/cpython/blob/3.3/Lib/logging/__init__.py#L1252-L1253
- [2] https://stackoverflow.com/a/15655674