### PR TITLE
[BD-6] Remove constraint from mako

### DIFF
--- a/requirements/edx/base.in
+++ b/requirements/edx/base.in
@@ -106,7 +106,7 @@ jsonfield2                          # Django model field for validated JSON; use
 laboratory                          # Library for testing that code refactors/infrastructure changes produce identical results
 lti-consumer-xblock
 mailsnake                           # Needed for mailchimp (mailing djangoapp)
-mako==1.0.2                         # Primary template language used for server-side page rendering
+mako                                # Primary template language used for server-side page rendering
 Markdown                            # Convert text markup to HTML; used in capa problems, forums, and course wikis
 mongoengine==0.10.0                 # Object-document mapper for MongoDB, used in the LMS dashboard
 mysqlclient                         # Driver for the default production relational database

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -149,7 +149,7 @@ loremipsum==1.0.5         # via ora2
 lti-consumer-xblock==1.4.2  # via -r requirements/edx/base.in
 lxml==4.5.0               # via -c requirements/edx/../constraints.txt, -r requirements/edx/../edx-sandbox/shared.txt, capa, edxval, lti-consumer-xblock, ora2, safe-lxml, xblock, xmlsec
 mailsnake==1.6.4          # via -r requirements/edx/base.in
-mako==1.0.2               # via -r requirements/edx/base.in, acid-xblock, lti-consumer-xblock, xblock-google-drive, xblock-utils
+mako==1.1.3               # via -r requirements/edx/base.in, acid-xblock, lti-consumer-xblock, xblock-google-drive, xblock-utils
 markdown==2.6.11          # via -c requirements/edx/../constraints.txt, -r requirements/edx/base.in, django-wiki, staff-graded-xblock, xblock-poll
 markey==0.8               # via enmerkar-underscore
 markupsafe==1.1.1         # via -r requirements/edx/paver.txt, chem, jinja2, mako, xblock

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -181,7 +181,7 @@ lti-consumer-xblock==1.4.2  # via -r requirements/edx/testing.txt
 lxml==4.5.0               # via -c requirements/edx/../constraints.txt, -r requirements/edx/testing.txt, capa, edxval, lti-consumer-xblock, ora2, pyquery, safe-lxml, xblock, xmlsec
 m2r==0.2.1                # via sphinxcontrib-openapi
 mailsnake==1.6.4          # via -r requirements/edx/testing.txt
-mako==1.0.2               # via -r requirements/edx/testing.txt, acid-xblock, lti-consumer-xblock, xblock-google-drive, xblock-utils
+mako==1.1.3               # via -r requirements/edx/testing.txt, acid-xblock, lti-consumer-xblock, xblock-google-drive, xblock-utils
 mando==0.6.4              # via -r requirements/edx/testing.txt, radon
 markdown==2.6.11          # via -c requirements/edx/../constraints.txt, -r requirements/edx/testing.txt, django-wiki, staff-graded-xblock, xblock-poll
 markey==0.8               # via -r requirements/edx/testing.txt, enmerkar-underscore

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -174,7 +174,7 @@ loremipsum==1.0.5         # via -r requirements/edx/base.txt, ora2
 lti-consumer-xblock==1.4.2  # via -r requirements/edx/base.txt
 lxml==4.5.0               # via -c requirements/edx/../constraints.txt, -r requirements/edx/base.txt, capa, edxval, lti-consumer-xblock, ora2, pyquery, safe-lxml, xblock, xmlsec
 mailsnake==1.6.4          # via -r requirements/edx/base.txt
-mako==1.0.2               # via -r requirements/edx/base.txt, acid-xblock, lti-consumer-xblock, xblock-google-drive, xblock-utils
+mako==1.1.3               # via -r requirements/edx/base.txt, acid-xblock, lti-consumer-xblock, xblock-google-drive, xblock-utils
 mando==0.6.4              # via radon
 markdown==2.6.11          # via -c requirements/edx/../constraints.txt, -r requirements/edx/base.txt, django-wiki, staff-graded-xblock, xblock-poll
 markey==0.8               # via -r requirements/edx/base.txt, enmerkar-underscore


### PR DESCRIPTION
Remove constraint from mako in order to use a version compatible with python 3.8

This is the changelog of mako: https://docs.makotemplates.org/en/latest/changelog.html

This solves these tests for python3.8

pytest common/lib/capa/capa/tests/test_capa_problem.py


## Reviewers
- [ ] @ericfab179 
- [ ] @awais786 