### PR TITLE
ARCHBOM-1291: Removing flaky test

### DIFF
--- a/openedx/features/enterprise_support/tests/test_utils.py
+++ b/openedx/features/enterprise_support/tests/test_utils.py
@@ -30,7 +30,6 @@ class TestEnterpriseUtils(TestCase):
 
     @ddt.data(
         ('notfoundpage', 0),
-        (reverse('dashboard'), 1),
     )
     @ddt.unpack
     def test_enterprise_customer_for_request_called_on_404(self, resource, expected_calls):


### PR DESCRIPTION
The removed test fails in: https://build.testeng.edx.org/job/edx-platform-python-pipeline-master/3656/ and https://build.testeng.edx.org/job/edx-platform-python-pipeline-master/3660/

The test is being removed according to these directions: 
https://openedx.atlassian.net/wiki/spaces/TE/pages/161427235/Flaky+Test+Process

Link to Jira ticket for this flacky test: https://openedx.atlassian.net/servicedesk/customer/portal/9/CR-2337?created=true