### PR TITLE
[BD-6] async is a keyword in python>=3.7

### DIFF
--- a/common/djangoapps/pipeline_mako/templates/mako/inline_js.html
+++ b/common/djangoapps/pipeline_mako/templates/mako/inline_js.html
@@ -1,9 +1,13 @@
+<%page expression_filter="h"/>
+<%! from openedx.core.djangolib.js_utils import dump_js_escaped_json %>
 <script \
-% if async:
+% if context.get('async', default=None):
 async \
 % endif
-if defer:
+% if defer:
 defer \
+% endif
 type="text/javascript" charset="utf-8">
-    ${source | safe}
+    ## xss-lint: disable=mako-invalid-html-filter
+    ${source | n, dump_js_escaped_json}
 </script>

--- a/common/djangoapps/pipeline_mako/templates/mako/js.html
+++ b/common/djangoapps/pipeline_mako/templates/mako/js.html
@@ -1,5 +1,6 @@
+<%page expression_filter="h"/>
 <script \
-% if async:
+% if context.get('async', default=None):
 async \
 % endif
 % if defer:


### PR DESCRIPTION
the new keyword async is causing errors when we run this with python 3.8.
https://docs.python.org/3/whatsnew/3.7.html 

I tried in the first place, to change the definition of that value in the place where the context is defined, but it seems that it is taken from https://github.com/jazzband/django-pipeline,

This solves many problems for lms and cms tests that were making the jenkins workers get timeout.

That template have not seen changed since 2012, so I had to do additional changes in the templates in order to pass the xsslint checks:

[mako-missing-default](https://edx.readthedocs.io/projects/edx-developer-guide/en/latest/preventing_xss/preventing_xss.html#mako-missing-default)
[mako-invalid-html-filter](https://edx.readthedocs.io/projects/edx-developer-guide/en/latest/preventing_xss/preventing_xss.html#mako-invalid-html-filter)

I am not sure about the remove of the `safe` filter.

But I didn't found information about the 'safe' filter. It is probably that the now default 'h' filter is enough/

## Reviewers
- [ ] @awais786 
- [x] @ericfab179 


