### PR TITLE
[BD-6] Fix test for python3.8

### DIFF
--- a/common/lib/capa/capa/safe_exec/tests/test_safe_exec.py
+++ b/common/lib/capa/capa/safe_exec/tests/test_safe_exec.py
@@ -199,7 +199,10 @@ class TestUpdateHash(unittest.TestCase):
 
         """
         d1 = {k: 1 for k in "abcdefghijklmnopqrstuvwxyz"}
-        d2 = dict(d1)
+        d2 = {k: 1 for k in "bcdefghijklmnopqrstuvwxyza"}
+        # TODO: remove the next lines once we are in python3.8
+        # since python3.8 dict preserve the order of insertion
+        # and therefore d2 and d1 keys are already in different order.
         for i in range(10000):
             d2[i] = 1
         for i in range(10000):


### PR DESCRIPTION
Initialize dicts with different order in order to have the keys in different order for python3.8.

Changed in version 3.7: Dictionary order is guaranteed to be insertion order. This behavior was an implementation detail of CPython from 3.6.
https://docs.python.org/3.7/library/stdtypes.html#typesmapping

This solves the tests from capa.capa.safe_exec.tests.test_safe_exec in python3.8

## Reviewers
- [x] @awais786 
- [ ] @ericfab179 
