### PR TITLE
Add condition to check whether the user has requested a change to the…

### DIFF
--- a/cms/djangoapps/contentstore/tests/test_course_settings.py
+++ b/cms/djangoapps/contentstore/tests/test_course_settings.py
@@ -1242,6 +1242,31 @@ class CourseMetadataEditingTest(CourseTestCase):
             )
             self.assertIsNone(test_model)
 
+    @ddt.data(True, False)
+    @override_waffle_flag(ENABLE_PROCTORING_PROVIDER_OVERRIDES, False)
+    def test_validate_update_allows_changes_to_settings_when_proctoring_provider_disabled(self, staff_user):
+        """
+        Course staff can modify Advanced Settings when the proctoring_provider settings is not available (i.e. when
+        the ENABLE_PROCTORING_PROVIDER_OVERRIDES is not enabled for the course). This ensures that our restrictions
+        on changing the proctoring_provider do not inhibit users from changing Advanced Settings when the
+        proctoring_provider setting is not available.
+        """
+        # It doesn't matter what the field is - just check that we can change any field.
+        field_name = "enable_proctored_exams"
+        course = CourseFactory.create(start=datetime.datetime.now(UTC) - datetime.timedelta(days=1))
+        user = UserFactory.create(is_staff=staff_user)
+
+        did_validate, errors, test_model = CourseMetadata.validate_and_update_from_json(
+            course,
+            {
+                field_name: {"value": True},
+            },
+            user=user
+        )
+        self.assertTrue(did_validate)
+        self.assertEqual(len(errors), 0)
+        self.assertIn(field_name, test_model)
+
     @override_settings(
         PROCTORING_BACKENDS={
             'DEFAULT': 'test_proctoring_provider',


### PR DESCRIPTION
[PROD-1761](https://openedx.atlassian.net/browse/PROD-1761)

Add condition to check whether the user has requested a change to the proctoring_provider Advanced Setting. In the case that the setting is not available (i.e. the ENABLE_PROCTORING_PROVIDER_OVERRIDES waffle flag is not enabled for the course), the requested proctornig_provider will be None. We should consider, in this case, that the user has not requested a change to the proctoring_provider setting and therefore should not prevent the user from saving course settings if the other conditions for preventing changes to the proctoring_provider setting are met.