### PR TITLE
[BD-6] Update dicts order to fix tests

### DIFF
--- a/cms/djangoapps/contentstore/tests/test_course_settings.py
+++ b/cms/djangoapps/contentstore/tests/test_course_settings.py
@@ -613,10 +613,10 @@ class CourseGradingTest(CourseTestCase):
                 GRADING_POLICY_CHANGED_EVENT_TYPE,
                 {
                     'course_id': six.text_type(self.course.id),
-                    'event_transaction_type': 'edx.grades.grading_policy_changed',
-                    'grading_policy_hash': policy_hash,
                     'user_id': six.text_type(self.user.id),
+                    'grading_policy_hash': policy_hash,
                     'event_transaction_id': 'mockUUID',
+                    'event_transaction_type': 'edx.grades.grading_policy_changed',
                 }
             ) for policy_hash in {grading_policy_1, grading_policy_2, grading_policy_3}
         ])

--- a/common/djangoapps/pipeline_mako/tests/test_render.py
+++ b/common/djangoapps/pipeline_mako/tests/test_render.py
@@ -17,8 +17,8 @@ class RequireJSPathOverridesTest(TestCase):
 
     OVERRIDES = {
         'jquery': 'common/js/vendor/jquery.js',
-        'backbone': 'common/js/vendor/backbone.js',
-        'text': 'js/vendor/text.js'
+        'text': 'js/vendor/text.js',
+        'backbone': 'common/js/vendor/backbone.js'
     }
 
     OVERRIDES_JS = [


### PR DESCRIPTION
**Description**
Change some tests dict order to fix assertion after python 3.7 change of preserving insertion order in dicts.

https://docs.python.org/3.7/library/stdtypes.html#typesmapping
"Dictionaries preserve insertion order. Note that updating a key does not affect the order. Keys added after deletion are inserted at the end."

These changes will solve the following issues:
https://openedx.atlassian.net/browse/BOM-1745
https://openedx.atlassian.net/browse/BOM-1744

**Reviewers**
- [ ] @awais786 
- [ ] @morenol
