### PR TITLE
[BD-14] Limit number of blocks allowed in content libraries

### DIFF
--- a/cms/djangoapps/contentstore/views/item.py
+++ b/cms/djangoapps/contentstore/views/item.py
@@ -103,6 +103,16 @@ def _filter_entrance_exam_grader(graders):
     return graders
 
 
+def _is_library_component_limit_reached(usage_key):
+    """
+    Verify if the library has reached the maximum number of components allowed in it
+    """
+    store = modulestore()
+    parent = store.get_item(usage_key)
+    total_children = len(parent.get_children())
+    return total_children + 1 > settings.MAX_BLOCKS_PER_CONTENT_LIBRARY
+
+
 @require_http_methods(("DELETE", "GET", "PUT", "POST", "PATCH"))
 @login_required
 @expect_json
@@ -214,6 +224,18 @@ def xblock_handler(request, usage_key_string):
                     not has_studio_read_access(request.user, source_course)
             ):
                 raise PermissionDenied()
+
+            # Libraries have a maximum component limit enforced on them
+            if (isinstance(parent_usage_key, LibraryUsageLocator) and
+                    _is_library_component_limit_reached(parent_usage_key)):
+                return JsonResponse(
+                    {
+                        'error': _(u'Libraries cannot have more than {limit} components').format(
+                            limit=settings.MAX_BLOCKS_PER_CONTENT_LIBRARY
+                        )
+                    },
+                    status=400
+                )
 
             dest_usage_key = _duplicate_item(
                 parent_usage_key,
@@ -689,6 +711,16 @@ def _create_item(request):
         if category not in ['html', 'problem', 'video']:
             return HttpResponseBadRequest(
                 u"Category '%s' not supported for Libraries" % category, content_type='text/plain'
+            )
+
+        if _is_library_component_limit_reached(usage_key):
+            return JsonResponse(
+                {
+                    'error': _(u'Libraries cannot have more than {limit} components').format(
+                        limit=settings.MAX_BLOCKS_PER_CONTENT_LIBRARY
+                    )
+                },
+                status=400
             )
 
     created_block = create_xblock(

--- a/cms/djangoapps/contentstore/views/item.py
+++ b/cms/djangoapps/contentstore/views/item.py
@@ -109,7 +109,10 @@ def _is_library_component_limit_reached(usage_key):
     """
     store = modulestore()
     parent = store.get_item(usage_key)
-    total_children = len(parent.get_children())
+    if not parent.has_children:
+        # Limit cannot be applied on such items
+        return False
+    total_children = len(parent.children)
     return total_children + 1 > settings.MAX_BLOCKS_PER_CONTENT_LIBRARY
 
 

--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -2261,3 +2261,6 @@ LOGISTRATION_RATELIMIT_RATE = '100/5m'
 ##### PASSWORD RESET RATE LIMIT SETTINGS #####
 PASSWORD_RESET_IP_RATE = '1/m'
 PASSWORD_RESET_EMAIL_RATE = '2/h'
+
+######################## Setting for content libraries ########################
+MAX_BLOCKS_PER_CONTENT_LIBRARY = 1000

--- a/cms/envs/production.py
+++ b/cms/envs/production.py
@@ -531,6 +531,9 @@ RETIREMENT_SERVICE_WORKER_USERNAME = ENV_TOKENS.get(
 ############### Settings for edx-rbac  ###############
 SYSTEM_WIDE_ROLE_CLASSES = ENV_TOKENS.get('SYSTEM_WIDE_ROLE_CLASSES') or SYSTEM_WIDE_ROLE_CLASSES
 
+######################## Setting for content libraries ########################
+MAX_BLOCKS_PER_CONTENT_LIBRARY = ENV_TOKENS.get('MAX_BLOCKS_PER_CONTENT_LIBRARY', MAX_BLOCKS_PER_CONTENT_LIBRARY)
+
 ####################### Plugin Settings ##########################
 
 # This is at the bottom because it is going to load more settings after base settings are loaded

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -3931,3 +3931,6 @@ GITHUB_REPO_ROOT = '/edx/var/edxapp/data'
 
 ##################### SUPPORT URL ############################
 SUPPORT_HOW_TO_UNENROLL_LINK = ''
+
+######################## Setting for content libraries ########################
+MAX_BLOCKS_PER_CONTENT_LIBRARY = 1000

--- a/lms/envs/production.py
+++ b/lms/envs/production.py
@@ -936,6 +936,9 @@ MAINTENANCE_BANNER_TEXT = ENV_TOKENS.get('MAINTENANCE_BANNER_TEXT', None)
 ########################## limiting dashboard courses ######################
 DASHBOARD_COURSE_LIMIT = ENV_TOKENS.get('DASHBOARD_COURSE_LIMIT', None)
 
+######################## Setting for content libraries ########################
+MAX_BLOCKS_PER_CONTENT_LIBRARY = ENV_TOKENS.get('MAX_BLOCKS_PER_CONTENT_LIBRARY', MAX_BLOCKS_PER_CONTENT_LIBRARY)
+
 ############################### Plugin Settings ###############################
 
 # This is at the bottom because it is going to load more settings after base settings are loaded


### PR DESCRIPTION
This PR limits the number of XBlocks which can be a part of content libraries, to ensure predictability and avoid problematic load issues. It defaults to 1000 blocks limit right now, which can be configured if needed.

**JIRA tickets**: https://openedx.atlassian.net/browse/OSPR-4739

**Testing instructions**:
This PR changes a blockstore based API, which is not part of the devstack yet. To test this:
- From the blockstore directory, run `make testserver` to start a test-specific instance. 
- From `make studio-shell` run: `EDXAPP_RUN_BLOCKSTORE_TESTS=1 python -Wd -m pytest --ds=cms.envs.test openedx/core/djangoapps/content_libraries/tests/ cms/djangoapps/contentstore/views/tests/`
Note: You might have to apply the #24277 patch to get the blockstore tests working

**Reviewers**
- [ ] @bradenmacdonald 
- [ ] edX reviewer[s] TBD