### PR TITLE
[BD-14] Fix broken tests due to invalid field name

### DIFF
--- a/openedx/core/djangoapps/content_libraries/permissions.py
+++ b/openedx/core/djangoapps/content_libraries/permissions.py
@@ -17,7 +17,7 @@ is_global_staff = is_user_active & rules.is_staff
 # Does the user have at least read permission for the specified library?
 has_explicit_read_permission_for_library = (
     ManyRelation(
-        'contentlibrarypermission',
+        'permission_grants',
         (Attribute('user', lambda user: user) | Relation('group', in_current_groups))
     )
     # We don't check 'access_level' here because all access levels grant read permission
@@ -25,7 +25,7 @@ has_explicit_read_permission_for_library = (
 # Does the user have at least author permission for the specified library?
 has_explicit_author_permission_for_library = (
     ManyRelation(
-        'contentlibrarypermission',
+        'permission_grants',
         (Attribute('user', lambda user: user) | Relation('group', in_current_groups)) & (
             Attribute('access_level', ContentLibraryPermission.AUTHOR_LEVEL) |
             Attribute('access_level', ContentLibraryPermission.ADMIN_LEVEL)
@@ -35,7 +35,7 @@ has_explicit_author_permission_for_library = (
 # Does the user have admin permission for the specified library?
 has_explicit_admin_permission_for_library = (
     ManyRelation(
-        'contentlibrarypermission',
+        'permission_grants',
         (Attribute('user', lambda user: user) | Relation('group', in_current_groups)) &
         Attribute('access_level', ContentLibraryPermission.ADMIN_LEVEL)
     )


### PR DESCRIPTION
`ContentLibraryPermission` refers to `ContentLibrary` with a `related_name` of `permission_grants`, which should be used in ManyRelation instead of the lowercase model name (see [docs](https://bridgekeeper.readthedocs.io/en/latest/api/rules.html#bridgekeeper.rules.ManyRelation))

**Testing instructions**:
This PR changes a blockstore based API, which is not part of the devstack yet. To test this:
- From the blockstore directory, run `make testserver` to start a test-specific instance. 
- From `make studio-shell` run: `EDXAPP_RUN_BLOCKSTORE_TESTS=1 python -Wd -m pytest --ds=cms.envs.test openedx/core/djangoapps/content_libraries/tests/`

**Reviewers**
- [x] @bradenmacdonald 
- [ ] edX reviewer[s] TBD