### PR TITLE
Fix multiple submissions on contact us form.

### DIFF
--- a/lms/djangoapps/support/static/support/jsx/single_support_form.jsx
+++ b/lms/djangoapps/support/static/support/jsx/single_support_form.jsx
@@ -19,6 +19,7 @@ const initialFormErrors = {
   subject: undefined,
   message: undefined,
   request: undefined,
+  forbidden: undefined,
 };
 
 class RenderForm extends React.Component {
@@ -43,6 +44,7 @@ class RenderForm extends React.Component {
       subject: gettext('Select a subject for your support request.'),
       message: gettext('Enter some details for your support request.'),
       request: gettext('Something went wrong. Please try again later.'),
+      forbidden: gettext('Your previous request is still in progress, please try again in a few minutes.'),
     };
     this.submitForm = this.submitForm.bind(this);
     this.reDirectUser = this.reDirectUser.bind(this);
@@ -141,10 +143,15 @@ class RenderForm extends React.Component {
     request.setRequestHeader('X-CSRFToken', $.cookie('csrftoken'));
     request.send(JSON.stringify(data));
     request.onreadystatechange = function success() {
-      if (request.readyState === 4 && request.status === 201) {
-        this.setState({
-          success: true,
-        });
+      if (request.readyState === 4) {
+        if (request.status === 201) {
+            this.setState({
+                success: true,
+            });
+        } else if (request.status === 429) {
+            this.updateErrorInState('request', this.formValidationErrors.forbidden);
+            this.scrollToTop();
+        }
       }
     }.bind(this);
 

--- a/openedx/core/djangoapps/zendesk_proxy/v1/views.py
+++ b/openedx/core/djangoapps/zendesk_proxy/v1/views.py
@@ -12,7 +12,7 @@ from rest_framework.views import APIView
 from openedx.core.djangoapps.zendesk_proxy.utils import create_zendesk_ticket
 
 logger = logging.getLogger(__name__)
-REQUESTS_PER_HOUR = 50
+ZENDESK_PROXY_RATE = '1/m'
 
 
 class ZendeskProxyThrottle(UserRateThrottle):
@@ -21,7 +21,7 @@ class ZendeskProxyThrottle(UserRateThrottle):
     """
 
     def __init__(self):
-        self.rate = '{}/hour'.format(REQUESTS_PER_HOUR)
+        self.rate = ZENDESK_PROXY_RATE
         super(ZendeskProxyThrottle, self).__init__()
 
 


### PR DESCRIPTION
Rate limited the zendesk proxy endpoint to 1 request per minute per user to prevent multiple submissions and showed a message to user upon 429.

PROD-1565

**Sandbox:** https://prod-1565.sandbox.edx.org/support/contact_us