### PR TITLE
EDUCATOR-5068: 'Upload Membership' button stuck as inactive after uploading and navigating

### DIFF
--- a/lms/djangoapps/teams/static/teams/js/views/manage.js
+++ b/lms/djangoapps/teams/static/teams/js/views/manage.js
@@ -33,6 +33,7 @@
                     this.$el,
                     HtmlUtils.template(manageTemplate)({})
                 );
+                this.delegateEvents(this.events);
                 return this;
             },
 


### PR DESCRIPTION
[EDUCATOR-5068](https://openedx.atlassian.net/browse/EDUCATOR-5068)
@edx/masters-devs-gta 

I'm gonna be honest, I don't fully understand this issue. Here's my understanding of what is happening:
1) Navigate to the teams tab
   - The whole TeamsTabView is created and rendered. At this point, the button works perfectly.
2) Navigate to a Topic through the Browse Tab, or a Team though the My Teams tab.
   - This will (i think?) get rid of the DOM created by the TeamsTabView? The TeamsTabView will go away somehow. I don't know
3) Navigate, using the breadcrumb, back to the TeamsTabView
   - The page will re-render? But for some reason the events aren't bound? So now, manually re-bind the events

When we create the ManageView, we bind the events to some part of the DOM, which is good and all, but then we remove that DOM but don't update the events, so the ManageView's events are either unbound or bound to something that doesn't exist anymore, and when we re-render, we're creating new DOM that the view doesn't know about? I think? 

Anyway, this PR makes the manage tab rebind events on a re-render, and it seems to fix the issue.