### PR TITLE
[BD-6] Attempt to fix db sync problem for python3.8

### DIFF
--- a/common/djangoapps/course_modes/migrations/0011_change_regex_for_comma_separated_ints.py
+++ b/common/djangoapps/course_modes/migrations/0011_change_regex_for_comma_separated_ints.py
@@ -18,11 +18,11 @@ class Migration(migrations.Migration):
         migrations.AlterField(
             model_name='coursemode',
             name='suggested_prices',
-            field=models.CharField(blank=True, default=u'', max_length=255, validators=[django.core.validators.RegexValidator(re.compile('^\d+(?:\,\d+)*\Z'), code='invalid', message='Enter only digits separated by commas.')]),
+            field=models.CharField(blank=True, default=u'', max_length=255, validators=[django.core.validators.RegexValidator(re.compile('^\d+(?:{escaped_comma}\d+)*\Z'.format(escaped_comma=re.escape(','))), code='invalid', message='Enter only digits separated by commas.')]),
         ),
         migrations.AlterField(
             model_name='coursemodesarchive',
             name='suggested_prices',
-            field=models.CharField(blank=True, default=u'', max_length=255, validators=[django.core.validators.RegexValidator(re.compile('^\d+(?:\,\d+)*\Z'), code='invalid', message='Enter only digits separated by commas.')]),
+            field=models.CharField(blank=True, default=u'', max_length=255, validators=[django.core.validators.RegexValidator(re.compile('^\d+(?:{escaped_comma}\d+)*\Z'.format(escaped_comma=re.escape(','))), code='invalid', message='Enter only digits separated by commas.')]),
         ),
     ]

--- a/common/djangoapps/course_modes/migrations/0012_historicalcoursemode.py
+++ b/common/djangoapps/course_modes/migrations/0012_historicalcoursemode.py
@@ -30,7 +30,7 @@ class Migration(migrations.Migration):
                 ('_expiration_datetime', models.DateTimeField(blank=True, db_column=u'expiration_datetime', default=None, help_text='OPTIONAL: After this date/time, users will no longer be able to enroll in this mode. Leave this blank if users can enroll in this mode until enrollment closes for the course.', null=True, verbose_name='Upgrade Deadline')),
                 ('expiration_datetime_is_explicit', models.BooleanField(default=False)),
                 ('expiration_date', models.DateField(blank=True, default=None, null=True)),
-                ('suggested_prices', models.CharField(blank=True, default=u'', max_length=255, validators=[django.core.validators.RegexValidator(re.compile('^\\d+(?:\\,\\d+)*\\Z'), code='invalid', message='Enter only digits separated by commas.')])),
+                ('suggested_prices', models.CharField(blank=True, default=u'', max_length=255, validators=[django.core.validators.RegexValidator(re.compile('^\\d+(?:{escaped_comma}\\d+)*\\Z'.format(escaped_comma=re.escape(','))), code='invalid', message='Enter only digits separated by commas.')])),
                 ('description', models.TextField(blank=True, null=True)),
                 ('sku', models.CharField(blank=True, help_text='OPTIONAL: This is the SKU (stock keeping unit) of this mode in the external ecommerce service.  Leave this blank if the course has not yet been migrated to the ecommerce service.', max_length=255, null=True, verbose_name=u'SKU')),
                 ('bulk_sku', models.CharField(blank=True, default=None, help_text='This is the bulk SKU (stock keeping unit) of this mode in the external ecommerce service.', max_length=255, null=True, verbose_name=u'Bulk SKU')),


### PR DESCRIPTION
BOM-1749

While running edx-platform with python3.8, Django is asking to run `makemigrations`

The cause of this is that In [python 3.7](https://docs.python.org/3/whatsnew/3.7.html):

> Change re.escape() to only escape regex special characters instead of escaping all characters other than ASCII letters, numbers, and '_'. (Contributed by Serhiy Storchaka in bpo-29995.)


So, in python 3.5: 
re.escape(',') -> `'\,'` and in python 3.8 re.escape(',') -> `','`

Therefore,  validate_comma_separated_integer_list which uses that has a different string value for python 3.5 and python 3.8, not sure which is the right way to solve this. But this one passes the tests in both python versions.

## Reviewers
- [ ] @awais786 
- [ ] @ericfab179 