### PR TITLE
ARCHBOM-1304: remove ENABLE_VIDEO_URL_REWRITE

### DIFF
--- a/lms/djangoapps/course_api/blocks/toggles.py
+++ b/lms/djangoapps/course_api/blocks/toggles.py
@@ -25,4 +25,3 @@ HIDE_ACCESS_DENIALS_FLAG = WaffleFlag(
     flag_name=u'hide_access_denials',
     flag_undefined_default=False
 )
-

--- a/lms/djangoapps/course_api/blocks/toggles.py
+++ b/lms/djangoapps/course_api/blocks/toggles.py
@@ -26,20 +26,3 @@ HIDE_ACCESS_DENIALS_FLAG = WaffleFlag(
     flag_undefined_default=False
 )
 
-# Waffle course override to rewrite video URLs for videos that have encodings available.
-# .. toggle_name: course_blocks_api.enable_video_url_rewrite
-# .. toggle_implementation: CourseWaffleFlag
-# .. toggle_default: False
-# .. toggle_description: Controlled rollout for video URL re-write utility to serve videos from edX CDN.
-# .. toggle_category: course api
-# .. toggle_use_cases: monitored_rollout
-# .. toggle_creation_date: 2019-09-24
-# .. toggle_expiration_date: ??
-# .. toggle_warnings: None
-# .. toggle_tickets: PROD-62
-# .. toggle_status: supported
-ENABLE_VIDEO_URL_REWRITE = CourseWaffleFlag(
-    waffle_namespace=COURSE_BLOCKS_API_NAMESPACE,
-    flag_name="enable_video_url_rewrite",
-    flag_undefined_default=True
-)

--- a/lms/djangoapps/course_api/blocks/transformers/blocks_api.py
+++ b/lms/djangoapps/course_api/blocks/transformers/blocks_api.py
@@ -10,7 +10,6 @@ from .block_depth import BlockDepthTransformer
 from .navigation import BlockNavigationTransformer
 from .student_view import StudentViewTransformer
 from .video_urls import VideoBlockURLTransformer
-from ..toggles import ENABLE_VIDEO_URL_REWRITE
 
 
 class BlocksAPITransformer(BlockStructureTransformer):
@@ -69,5 +68,4 @@ class BlocksAPITransformer(BlockStructureTransformer):
         BlockCountsTransformer(self.block_types_to_count).transform(usage_info, block_structure)
         BlockDepthTransformer(self.depth).transform(usage_info, block_structure)
         BlockNavigationTransformer(self.nav_depth).transform(usage_info, block_structure)
-        if ENABLE_VIDEO_URL_REWRITE.is_enabled(block_structure.root_block_usage_key.course_key):
-            VideoBlockURLTransformer().transform(usage_info, block_structure)
+        VideoBlockURLTransformer().transform(usage_info, block_structure)


### PR DESCRIPTION
The temporary waffle flag ENABLE_VIDEO_URL_REWRITE is no
longer needed, becaues the rollout is complete.
See https://openedx.atlassian.net/browse/PROD-62

ARCHBOM-1304