### PR TITLE
ARCHBOM-1304: add migration for flags using flag_undefined_default=True

### DIFF
--- a/cms/djangoapps/contentstore/config/waffle.py
+++ b/cms/djangoapps/contentstore/config/waffle.py
@@ -33,6 +33,7 @@ ENABLE_PROCTORING_PROVIDER_OVERRIDES = CourseWaffleFlag(
     flag_undefined_default=False
 )
 
+# TODO: After removing this flag, add a migration to remove waffle flag in a follow-up deployment.
 ENABLE_CHECKLISTS_QUALITY = CourseWaffleFlag(
     waffle_namespace=waffle_flags(),
     flag_name=u'enable_checklists_quality',

--- a/cms/djangoapps/contentstore/migrations/0005_add_enable_checklists_quality_waffle_flag.py
+++ b/cms/djangoapps/contentstore/migrations/0005_add_enable_checklists_quality_waffle_flag.py
@@ -1,0 +1,25 @@
+# -*- coding: utf-8 -*-
+from __future__ import absolute_import, unicode_literals
+
+from django.db import migrations
+
+from cms.djangoapps.contentstore.config.waffle import ENABLE_CHECKLISTS_QUALITY
+
+
+def create_flag(apps, schema_editor):
+    Flag = apps.get_model('waffle', 'Flag')
+    # Replacement for flag_undefined_default=True on flag definition
+    Flag.objects.get_or_create(name=ENABLE_CHECKLISTS_QUALITY.namespaced_flag_name, defaults={'everyone': True})
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ('contentstore', '0004_remove_push_notification_configmodel_table'),
+        ('waffle', '0001_initial'),
+    ]
+
+    operations = [
+        # Do not remove the flag for rollback.  We don't want to lose original if
+        # it already existed, and it won't hurt if it was created.
+        migrations.RunPython(create_flag, reverse_code=migrations.RunPython.noop),
+    ]

--- a/lms/djangoapps/grades/config/waffle.py
+++ b/lms/djangoapps/grades/config/waffle.py
@@ -34,17 +34,20 @@ def waffle_flags():
     namespace = WaffleFlagNamespace(name=WAFFLE_NAMESPACE, log_prefix=u'Grades: ')
     return {
         # By default, enable rejected exam grade overrides. Can be disabled on a course-by-course basis.
+        # TODO: After removing this flag, add a migration to remove waffle flag in a follow-up deployment.
         REJECTED_EXAM_OVERRIDES_GRADE: CourseWaffleFlag(
             namespace,
             REJECTED_EXAM_OVERRIDES_GRADE,
             flag_undefined_default=True,
         ),
+        # TODO: After removing this flag, add a migration to remove waffle flag in a follow-up deployment.
         ENFORCE_FREEZE_GRADE_AFTER_COURSE_END: CourseWaffleFlag(
             namespace,
             ENFORCE_FREEZE_GRADE_AFTER_COURSE_END,
             flag_undefined_default=True,
         ),
         # Have this course override flag so we can selectively turn off the gradebook for courses.
+        # TODO: After removing this flag, add a migration to remove waffle flag in a follow-up deployment.
         WRITABLE_GRADEBOOK: CourseWaffleFlag(
             namespace,
             WRITABLE_GRADEBOOK,

--- a/lms/djangoapps/grades/migrations/0018_add_waffle_flag_defaults.py
+++ b/lms/djangoapps/grades/migrations/0018_add_waffle_flag_defaults.py
@@ -1,0 +1,38 @@
+# -*- coding: utf-8 -*-
+from __future__ import absolute_import, unicode_literals
+
+from django.db import migrations
+
+from lms.djangoapps.grades.config.waffle import (
+    ENFORCE_FREEZE_GRADE_AFTER_COURSE_END,
+    REJECTED_EXAM_OVERRIDES_GRADE,
+    WRITABLE_GRADEBOOK,
+    waffle_flags,
+)
+
+
+def create_flag(apps, schema_editor):
+    Flag = apps.get_model('waffle', 'Flag')
+    # Replacement for flag_undefined_default=True on flag definition
+    Flag.objects.get_or_create(
+        name=waffle_flags()[REJECTED_EXAM_OVERRIDES_GRADE].namespaced_flag_name, defaults={'everyone': True}
+    )
+    Flag.objects.get_or_create(
+        name=waffle_flags()[ENFORCE_FREEZE_GRADE_AFTER_COURSE_END].namespaced_flag_name, defaults={'everyone': True}
+    )
+    Flag.objects.get_or_create(
+        name=waffle_flags()[WRITABLE_GRADEBOOK].namespaced_flag_name, defaults={'everyone': True}
+    )
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ('grades', '0017_delete_manual_psgoverride_table'),
+        ('waffle', '0001_initial'),
+    ]
+
+    operations = [
+        # Do not remove the flags for rollback.  We don't want to lose originals if
+        # they already existed, and it won't hurt if they are created.
+        migrations.RunPython(create_flag, reverse_code=migrations.RunPython.noop),
+    ]


### PR DESCRIPTION
In order to enable us to remove flag_undefined_default, this
updates flags according to alternatives documented in:
https://github.com/edx/edx-platform/blob/master/openedx/core/djangoapps/waffle_utils/docs/decisions/0001-refactor-waffle-flag-default.rst

These flags were updated with a migration:
- enable_checklists_quality
- REJECTED_EXAM_OVERRIDES_GRADE
- ENFORCE_FREEZE_GRADE_AFTER_COURSE_END
- WRITABLE_GRADEBOOK

ARCHBOM-1304