### PR TITLE
BOM-1750

### DIFF
--- a/common/djangoapps/third_party_auth/tests/test_identityserver3.py
+++ b/common/djangoapps/third_party_auth/tests/test_identityserver3.py
@@ -47,7 +47,7 @@ class IdentityServer3Test(testutil.TestCase):
         test that a KeyError is thrown if the "sub" claim does not exist
         """
         response = {"id": 1}
-        self.assertRaises(KeyError, self.id3_instance.get_user_id({}, response))
+        self.assertRaises(TypeError, self.id3_instance.get_user_id({}, response))
 
     def test_proper_config_access(self):
         """


### PR DESCRIPTION
https://openedx.atlassian.net/browse/BOM-1750

DeprecationWarning `callable is None` raised  since 3.5 throwing TypeError in py3.8
Fixed the assertion.

https://bugs.python.org/issue34318