### PR TITLE
Revert "updated confirm_email field type"

### DIFF
--- a/openedx/core/djangoapps/user_authn/utils.py
+++ b/openedx/core/djangoapps/user_authn/utils.py
@@ -58,12 +58,3 @@ def generate_password(length=12, chars=string.ascii_letters + string.digits):
     password += choice(string.ascii_letters)
     password += ''.join([choice(chars) for _i in range(length - 2)])
     return password
-
-
-def is_registration_api_v1(request):
-    """
-    Checks if registration api is v1
-    :param request:
-    :return: Bool
-    """
-    return 'v1' in request.get_full_path() and 'register' not in request.get_full_path()

--- a/openedx/core/djangoapps/user_authn/views/register.py
+++ b/openedx/core/djangoapps/user_authn/views/register.py
@@ -48,7 +48,7 @@ from openedx.core.djangoapps.user_api.accounts.api import (
     get_username_existence_validation_error,
     get_username_validation_error
 )
-from openedx.core.djangoapps.user_authn.utils import generate_password, is_registration_api_v1
+from openedx.core.djangoapps.user_authn.utils import generate_password
 from openedx.core.djangoapps.user_api.preferences import api as preferences_api
 from openedx.core.djangoapps.user_authn.cookies import set_logged_in_cookies
 from openedx.core.djangoapps.user_authn.views.registration_form import (
@@ -157,10 +157,6 @@ def create_account_with_params(request, params):
         'REGISTRATION_EXTRA_FIELDS',
         getattr(settings, 'REGISTRATION_EXTRA_FIELDS', {})
     )
-    if is_registration_api_v1(request):
-        if 'confirm_email' in extra_fields:
-            del extra_fields['confirm_email']
-
     # registration via third party (Google, Facebook) using mobile application
     # doesn't use social auth pipeline (no redirect uri(s) etc involved).
     # In this case all related info (required for account linking)

--- a/openedx/core/djangoapps/user_authn/views/tests/test_register.py
+++ b/openedx/core/djangoapps/user_authn/views/tests/test_register.py
@@ -1894,7 +1894,7 @@ class RegistrationViewTestV2(RegistrationViewTestV1):
             {"confirm_email": "required"},
             {
                 "name": "confirm_email",
-                "type": "email",
+                "type": "text",
                 "required": True,
                 "label": "Confirm Email",
                 "errorMessages": {


### PR DESCRIPTION
Reverts edx/edx-platform#24205

We are seeing failures for our customers, rolling back changes related to this confirm email field to restore access.