### PR TITLE
allow moderators to post in forum

### DIFF
--- a/lms/djangoapps/teams/static/teams/js/spec/views/team_profile_spec.js
+++ b/lms/djangoapps/teams/static/teams/js/spec/views/team_profile_spec.js
@@ -211,6 +211,16 @@ define([
                 clickLeaveTeam(requests, view, {cancel: false});
                 expect(view.$('.new-post-btn.is-hidden').length).toEqual(0);
             });
+
+            it('shows New Post button when user is a staff member or admin', function() {
+                var requests = AjaxHelpers.requests(this),
+                    view = createTeamProfileView(
+                        requests, {userInfo: TeamSpecHelpers.createMockUserInfo({staff: true})}
+                    );
+
+                view.render();
+                expect(view.$('.btn-link.new-post-btn.is-hidden').length).toEqual(0);
+            });
         });
 
         describe('TeamDetailsView', function() {

--- a/lms/djangoapps/teams/static/teams/js/views/team_profile.js
+++ b/lms/djangoapps/teams/static/teams/js/views/team_profile.js
@@ -70,7 +70,7 @@
                     );
                     this.discussionView = new TeamDiscussionView({
                         el: this.$('.discussion-module'),
-                        readOnly: !isMember
+                        readOnly: (!isMember && !isAdminOrStaff)
                     });
                     this.discussionView.render();
 


### PR DESCRIPTION
### [PROD-1688](https://openedx.atlassian.net/browse/PROD-1688)

### Description
Discussion Moderators were not able to post in team discussion forum without being added to the team as it is possible as described in the doc: https://edx.readthedocs.io/projects/edx-partner-course-staff/en/latest/course_features/teams/teams_discussions.html#ability-to-post-in-team-discussions
In this case, "add a post" button was hidden if the user is not a team member.

### Fix:
Allows Discussion Moderators to post in team discussions without being added into a team.

### Reviewers
- [ ] @asadazam93 
- [ ] @saadyousafarbi 

### Post Review
 - [ ] Squash & Rebase commit