### PR TITLE
Removed validation in SSO

### DIFF
--- a/openedx/core/djangoapps/user_authn/utils.py
+++ b/openedx/core/djangoapps/user_authn/utils.py
@@ -2,9 +2,9 @@
 Utility functions used during user authentication.
 """
 
-
 import random
 import string
+import third_party_auth
 
 from django.conf import settings
 from django.utils import http
@@ -67,3 +67,12 @@ def is_registration_api_v1(request):
     :return: Bool
     """
     return 'v1' in request.get_full_path() and 'register' not in request.get_full_path()
+
+
+def is_sso_request(request):
+    """
+    Checks registration request is single sign on request.
+    :param request: request Object:
+    :return: Bool
+    """
+    return third_party_auth.is_enabled() and third_party_auth.pipeline.running(request) or 'provider' in request.POST

--- a/openedx/core/djangoapps/user_authn/utils.py
+++ b/openedx/core/djangoapps/user_authn/utils.py
@@ -75,4 +75,4 @@ def is_sso_request(request):
     :param request: request Object:
     :return: Bool
     """
-    return third_party_auth.is_enabled() and third_party_auth.pipeline.running(request) or 'provider' in request.POST
+    return third_party_auth.is_enabled() and third_party_auth.pipeline.running(request)

--- a/openedx/core/djangoapps/user_authn/views/register.py
+++ b/openedx/core/djangoapps/user_authn/views/register.py
@@ -168,7 +168,7 @@ def create_account_with_params(request, params):
     is_third_party_auth_enabled = third_party_auth.is_enabled()
 
     is_sso = is_sso_request(request)
-    if is_sso:
+    if is_sso or third_party_auth_credentials_in_api:
         params["password"] = generate_password()
 
     if is_registration_api_v1(request) or is_sso:

--- a/openedx/core/djangoapps/user_authn/views/registration_form.py
+++ b/openedx/core/djangoapps/user_authn/views/registration_form.py
@@ -23,7 +23,7 @@ from edxmako.shortcuts import marketing_link
 from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
 from openedx.core.djangoapps.user_api import accounts
 from openedx.core.djangoapps.user_api.helpers import FormDescription
-from openedx.core.djangoapps.user_authn.utils import is_registration_api_v1 as is_api_v1, is_sso_request
+from openedx.core.djangoapps.user_authn.utils import is_registration_api_v1, is_sso_request
 from openedx.core.djangolib.markup import HTML, Text
 from openedx.features.enterprise_support.api import enterprise_customer_for_request
 from student.models import (
@@ -431,7 +431,7 @@ class RegistrationFormFactory(object):
                         required=self._is_field_required(field_name)
                     )
         # remove confirm_email form v1 registration form
-        if is_api_v1(request) or is_sso_request(request):
+        if is_registration_api_v1(request) or is_sso_request(request):
             for index, field in enumerate(form_desc.fields):
                 if field['name'] == 'confirm_email':
                     del form_desc.fields[index]
@@ -439,7 +439,10 @@ class RegistrationFormFactory(object):
         return form_desc
 
     def _get_registration_submit_url(self, request):
-        return reverse("user_api_registration") if is_api_v1(request) else reverse("user_api_registration_v2")
+        if is_registration_api_v1(request):
+            return reverse("user_api_registration")
+        else:
+            return reverse("user_api_registration_v2")
 
     def _add_email_field(self, form_desc, required=True):
         """Add an email field to a form description.

--- a/openedx/core/djangoapps/user_authn/views/registration_form.py
+++ b/openedx/core/djangoapps/user_authn/views/registration_form.py
@@ -23,7 +23,7 @@ from edxmako.shortcuts import marketing_link
 from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
 from openedx.core.djangoapps.user_api import accounts
 from openedx.core.djangoapps.user_api.helpers import FormDescription
-from openedx.core.djangoapps.user_authn.utils import is_registration_api_v1 as is_api_v1
+from openedx.core.djangoapps.user_authn.utils import is_registration_api_v1 as is_api_v1, is_sso_request
 from openedx.core.djangolib.markup import HTML, Text
 from openedx.features.enterprise_support.api import enterprise_customer_for_request
 from student.models import (
@@ -431,7 +431,7 @@ class RegistrationFormFactory(object):
                         required=self._is_field_required(field_name)
                     )
         # remove confirm_email form v1 registration form
-        if is_api_v1(request):
+        if is_api_v1(request) or is_sso_request(request):
             for index, field in enumerate(form_desc.fields):
                 if field['name'] == 'confirm_email':
                     del form_desc.fields[index]
@@ -1089,17 +1089,6 @@ class RegistrationFormFactory(object):
                                     label="",
                                     instructions="",
                                 )
-
-                    # Hide the confirm_email field
-                    form_desc.override_field_properties(
-                        "confirm_email",
-                        default="",
-                        field_type="hidden",
-                        required=False,
-                        label="",
-                        instructions="",
-                        restrictions={}
-                    )
 
                     # Hide the password field
                     form_desc.override_field_properties(


### PR DESCRIPTION
After activating confirm email in registration form It caused validation error because the field validation was not managed properly. After this change, if API  is V1 and registration is being done by SSO it will skip confirm email field in both View and validation part


https://prod1476.sandbox.edx.org/register#


Test Register by google and observe that confirm email is not visible and the user is registered without it.