### PR TITLE
BOM-1728 : Fixed bad escape character error in Python 3.8

### DIFF
--- a/common/lib/symmath/symmath/formula.py
+++ b/common/lib/symmath/symmath/formula.py
@@ -84,7 +84,7 @@ def to_latex(expr):
     # sometimes get 'script(N)__B' or more complicated terms
     expr_s = re.sub(
         r'script([a-zA-Z0-9]+)',
-        '\\mathcal{\\1}',
+        r'\\mathcal{\\1}',
         expr_s
     )
 


### PR DESCRIPTION
Relevant JIRA : https://openedx.atlassian.net/browse/BOM-1728

`re.error: bad escape \m at position 0`
error was coming due to change introduced in Python 3.7, earlier it was just a warning

Example :
https://bugs.python.org/issue34304