### PR TITLE
ensure anonymous_id is persisted for each team member in a team

### DIFF
--- a/lms/djangoapps/teams/api.py
+++ b/lms/djangoapps/teams/api.py
@@ -381,7 +381,7 @@ def anonymous_user_ids_for_team(user, team):
         ))
 
     return sorted([
-        anonymous_id_for_user(user=team_member, course_id=team.course_id, save=False)
+        anonymous_id_for_user(user=team_member, course_id=team.course_id, save=True)
         for team_member in team.users.all()
     ])
 

--- a/lms/djangoapps/teams/tests/test_api.py
+++ b/lms/djangoapps/teams/tests/test_api.py
@@ -14,7 +14,7 @@ from lms.djangoapps.teams import api as teams_api
 from lms.djangoapps.teams.models import CourseTeam
 from lms.djangoapps.teams.tests.factories import CourseTeamFactory
 from openedx.core.lib.teams_config import TeamsConfig, TeamsetType
-from student.models import CourseEnrollment
+from student.models import CourseEnrollment, AnonymousUserId
 from student.roles import CourseStaffRole
 from student.tests.factories import CourseEnrollmentFactory, UserFactory
 from xmodule.modulestore.tests.django_utils import SharedModuleStoreTestCase
@@ -190,6 +190,7 @@ class PythonAPITests(SharedModuleStoreTestCase):
         A learner should be able to get the anonymous user IDs of their team members
         """
         team_anonymous_user_ids = teams_api.anonymous_user_ids_for_team(self.user1, self.team1)
+        self.assertTrue(AnonymousUserId.objects.get(user=self.user1, course_id=self.team1.course_id))
         self.assertEqual(len(self.team1.users.all()), len(team_anonymous_user_ids))
 
     def test_anonymous_user_ids_for_team_not_on_team(self):


### PR DESCRIPTION
**Description**
Ensure that team members identities are persisted as AnonymousUserId records 

Resolves: https://openedx.atlassian.net/browse/EDUCATOR-5088

@edx/masters-devs-gta 
