### PR TITLE
WIP: Library Sourced Content Block

### DIFF
--- a/cms/djangoapps/contentstore/views/item.py
+++ b/cms/djangoapps/contentstore/views/item.py
@@ -67,6 +67,7 @@ from util.milestones_helpers import is_entrance_exams_enabled
 from xblock_config.models import CourseEditLTIFieldsEnabledFlag
 from xblock_django.user_service import DjangoXBlockUserService
 from xmodule.course_module import DEFAULT_START_DATE
+from xmodule.library_tools import LibraryToolsService
 from xmodule.modulestore import EdxJSONEncoder, ModuleStoreEnum
 from xmodule.modulestore.django import modulestore
 from xmodule.modulestore.draft_and_published import DIRECT_ONLY_CATEGORIES
@@ -294,6 +295,8 @@ class StudioEditModuleRuntime(object):
                 return ConfigurationService(CourseEditLTIFieldsEnabledFlag)
             if service_name == "teams_configuration":
                 return TeamsConfigurationService()
+            if service_name == "library_tools":
+                return LibraryToolsService(modulestore(), self._user.id)
         return None
 
 

--- a/common/lib/xmodule/setup.py
+++ b/common/lib/xmodule/setup.py
@@ -34,6 +34,7 @@ XBLOCKS = [
     "course_info = xmodule.html_module:CourseInfoBlock",
     "html = xmodule.html_module:HtmlBlock",
     "library = xmodule.library_root_xblock:LibraryRoot",
+    "library_sourced = xmodule.library_sourced_block:LibrarySourcedBlock",
     "problem = xmodule.capa_module:ProblemBlock",
     "static_tab = xmodule.html_module:StaticTabBlock",
     "unit = xmodule.unit_block:UnitBlock",

--- a/common/lib/xmodule/xmodule/library_content_module.py
+++ b/common/lib/xmodule/xmodule/library_content_module.py
@@ -435,7 +435,7 @@ class LibraryContentDescriptor(LibraryContentFields, MakoModuleDescriptor, XmlDe
         user_id = self.get_user_id()
         if not self.tools:
             return Response("Library Tools unavailable in current runtime.", status=400)
-        self.tools.update_children(self, user_id, user_perms)
+        self.tools.update_children(self, user_perms)
         return Response()
 
     # Copy over any overridden settings the course author may have applied to the blocks.
@@ -467,7 +467,7 @@ class LibraryContentDescriptor(LibraryContentFields, MakoModuleDescriptor, XmlDe
         user_perms = self.runtime.service(self, 'studio_user_permissions')
         if not self.tools:
             raise RuntimeError("Library tools unavailable, duplication will not be sane!")
-        self.tools.update_children(self, user_id, user_perms, version=self.source_library_version)
+        self.tools.update_children(self, user_perms, version=self.source_library_version)
 
         self._copy_overrides(store, user_id, source_block, self)
 

--- a/common/lib/xmodule/xmodule/library_sourced_block.py
+++ b/common/lib/xmodule/xmodule/library_sourced_block.py
@@ -54,6 +54,7 @@ class LibrarySourcedBlock(StudioEditableXBlockMixin, EditableChildrenMixin, XBlo
         """
         fragment = Fragment()
         # EditableChildrenMixin.render_children will render HTML that allows instructors to make edits to the children
+        # TODO: Need to disable its "Move" button too
         self.render_children(context, fragment, can_reorder=False, can_add=False)
         return fragment
 
@@ -61,26 +62,14 @@ class LibrarySourcedBlock(StudioEditableXBlockMixin, EditableChildrenMixin, XBlo
         """
         Renders the view that learners see.
         """
-        fragment = Fragment()
-        contents = []
-        child_context = {} if not context else copy(context)
-
-        for child in self.get_children():
-            rendered_child = child.render('student_view', child_context)
-            fragment.add_fragment_resources(rendered_child)
-            contents.append({
-                'id': text_type(displayable.location),
-                'content': rendered_child.content,
-            })
-
-        fragment.add_content(self.system.render_template('vert_module.html', {
-            'items': contents,
-            'xblock_context': context,
-            'show_bookmark_button': False,
-            'watched_completable_blocks': set(),
-            'completion_delay_ms': None,
-        }))
-        return fragment
+        result = Fragment()
+        child_frags = self.runtime.render_children(self, context=context)
+        result.add_resources(child_frags)
+        result.add_content('<div class="library-sourced-content">')
+        for frag in child_frags:
+            result.add_content(frag.content)
+        result.add_content('</div>')
+        return result
 
     def validate_field_data(self, validation, data):
         """

--- a/common/lib/xmodule/xmodule/library_sourced_block.py
+++ b/common/lib/xmodule/xmodule/library_sourced_block.py
@@ -1,0 +1,110 @@
+"""
+Library Sourced Content XBlock
+"""
+import logging
+
+from web_fragments.fragment import Fragment
+from xblock.core import XBlock
+from xblock.exceptions import JsonHandlerError
+from xblock.fields import Boolean, List, Scope, String
+from xblock.validation import ValidationMessage
+from xblockutils.studio_editable import StudioEditableXBlockMixin
+from xmodule.studio_editable import StudioEditableBlock as EditableChildrenMixin
+
+log = logging.getLogger(__name__)
+
+# Make '_' a no-op so we can scrape strings. Using lambda instead of
+#  `django.utils.translation.ugettext_noop` because Django cannot be imported in this file
+_ = lambda text: text
+
+
+@XBlock.wants('library_tools')  # Only needed in studio
+class LibrarySourcedBlock(StudioEditableXBlockMixin, EditableChildrenMixin, XBlock):
+    """
+    Library Sourced Content XBlock
+
+    Allows copying specific XBlocks from a Blockstore-based content library into
+    a modulestore-based course. The selected blocks are copied and become
+    children of this block.
+
+    When we implement support for Blockstore-based courses, it's expected we'll
+    use a different mechanism for importing library content into a course.
+    """
+    display_name = String(
+        help=_("The display name for this component."),
+        default="Library Sourced Content",
+        display_name=_("Display Name"),
+        scope=Scope.content,
+    )
+    source_block_ids = List(
+        display_name=_("Library Blocks List"),
+        help=_("Enter the IDs of the library XBlocks that you wish to use."),
+        scope=Scope.content,
+    )
+    editable_fields = ("display_name", "source_block_ids")
+    has_children = True
+    has_author_view = True
+
+    def __str__(self):
+        return "LibrarySourcedBlock: {}".format(self.display_name)
+
+    def author_view(self, context):
+        """
+        Renders the Studio preview view.
+        """
+        fragment = Fragment()
+        # EditableChildrenMixin.render_children will render HTML that allows instructors to make edits to the children
+        self.render_children(context, fragment, can_reorder=False, can_add=False)
+        return fragment
+
+    def student_view(self, context):
+        """
+        Renders the view that learners see.
+        """
+        fragment = Fragment()
+        contents = []
+        child_context = {} if not context else copy(context)
+
+        for child in self.get_children():
+            rendered_child = child.render('student_view', child_context)
+            fragment.add_fragment_resources(rendered_child)
+            contents.append({
+                'id': text_type(displayable.location),
+                'content': rendered_child.content,
+            })
+
+        fragment.add_content(self.system.render_template('vert_module.html', {
+            'items': contents,
+            'xblock_context': context,
+            'show_bookmark_button': False,
+            'watched_completable_blocks': set(),
+            'completion_delay_ms': None,
+        }))
+        return fragment
+
+    def validate_field_data(self, validation, data):
+        """
+        Validate this block's field data. Instead of checking fields like self.name, check the
+        fields set on data, e.g. data.name. This allows the same validation method to be re-used
+        for the studio editor. Any errors found should be added to "validation".
+        This method should not return any value or raise any exceptions.
+        All of this XBlock's fields should be found in "data", even if they aren't being changed
+        or aren't even set (i.e. are defaults).
+        """
+        if len(data.source_block_ids) > 10:
+            validation.add(ValidationMessage(ValidationMessage.ERROR, "A maximum of 10 components may be added."))
+
+    @XBlock.handler
+    def submit_studio_edits(self, *args, **kwargs):  # pylint: disable=unused-argument
+        """
+        Save changes to this block, applying edits made in Studio.
+        """
+        response = super().submit_studio_edits(*args, **kwargs)
+        # Replace our current children with the latest ones from the libraries.
+        lib_tools = self.runtime.service(self, 'library_tools')
+        try:
+            lib_tools.import_as_children(self, self.source_block_ids)
+        except Exception as err:
+            log.exception(err)
+            raise JsonHandlerError(400, "Unable to save changes - are the Library Block IDs valid and readable?")
+        return response

--- a/common/lib/xmodule/xmodule/library_sourced_block.py
+++ b/common/lib/xmodule/xmodule/library_sourced_block.py
@@ -3,6 +3,7 @@ Library Sourced Content XBlock
 """
 import logging
 
+from copy import copy
 from web_fragments.fragment import Fragment
 from xblock.core import XBlock
 from xblock.exceptions import JsonHandlerError
@@ -53,6 +54,7 @@ class LibrarySourcedBlock(StudioEditableXBlockMixin, EditableChildrenMixin, XBlo
         Renders the Studio preview view.
         """
         fragment = Fragment()
+        context = {} if not context else copy(context)  # Isolate context - without this there are weird bugs in Studio
         # EditableChildrenMixin.render_children will render HTML that allows instructors to make edits to the children
         # TODO: Need to disable its "Move" button too
         self.render_children(context, fragment, can_reorder=False, can_add=False)

--- a/common/lib/xmodule/xmodule/library_tools.py
+++ b/common/lib/xmodule/xmodule/library_tools.py
@@ -11,6 +11,7 @@ from opaque_keys.edx.locator import LibraryLocator, LibraryUsageLocator, BlockUs
 from openedx.core.djangoapps.xblock.api import load_block
 from search.search_engine_base import SearchEngine
 from student.auth import has_studio_write_access
+from xblock.fields import Scope
 from xmodule.capa_module import ProblemBlock
 from xmodule.library_content_module import ANY_CAPA_TYPE_VALUE
 from xmodule.modulestore import ModuleStoreEnum
@@ -219,36 +220,60 @@ class LibraryToolsService(object):
         orig_blocks = [load_block(UsageKey.from_string(key), user) for key in blockstore_block_ids]
 
         with self.store.bulk_operations(dest_course_key):
-            for block in orig_blocks:
-                orig_key = block.scope_ids.usage_id
+            # As we go, build a set of the IDs of the new children,
+            # so we can delete any existing children that aren't updated.
+            child_ids_updated = set()
+
+            def do_import(source_block, dest_parent_key):
+                """ Recursively import a blockstore block and its children """
+                source_key = source_block.scope_ids.usage_id
                 # Deterministically generate a new ID for this block 
-                new_block_id = dest_key.block_id[:10] + '-' + hashlib.sha1(str(orig_key).encode('utf-8')).hexdigest()[:10]
-                new_block_key = dest_key.context_key.make_usage_key(orig_key.block_type, new_block_id)
+                new_block_id = (
+                    dest_parent_key.block_id[:10] + '-' + hashlib.sha1(str(source_key).encode('utf-8')).hexdigest()[:10]
+                )
+                new_block_key = dest_parent_key.context_key.make_usage_key(source_key.block_type, new_block_id)
 
                 try:
                     new_block = self.store.get_item(new_block_key)
-                    if new_block.parent != dest_key:
+                    if new_block.parent != dest_parent_key:
                         raise ValueError(
-                            "Expected existing block {} to be a child of {}".format(new_block_key, dest_key)
+                            "Expected existing block {} to be a child of {}".format(new_block_key, dest_parent_key)
                         )
                 except ItemNotFoundError:
                     new_block = self.store.create_child(
                         user_id=self.user_id,
-                        parent_usage_key=dest_key,
-                        block_type=orig_key.block_type,
+                        parent_usage_key=dest_parent_key,
+                        block_type=source_key.block_type,
                         block_id=new_block_id,
                     )
-                for field_name, field in block.fields.items():
-                    if field_name in ('children', 'parent', 'content'):
-                        continue
-                    if field.is_set_on(block) or field.is_set_on(new_block):
-                        setattr(new_block, field_name, getattr(block, field_name))
-
-                # TODO: handle children recursively.
+                for field_name, field in source_block.fields.items():
+                    if field.scope not in (Scope.settings, Scope.content):
+                        continue  # Only copy authored field data
+                    if field.is_set_on(source_block) or field.is_set_on(new_block):
+                        setattr(new_block, field_name, getattr(source_block, field_name))
+                new_block.save()
+                self.store.update_item(new_block, self.user_id)
 
                 # TODO: handle static assets
 
-                new_block.save()
-                self.store.update_item(new_block, user_id=self.user_id)
+                # Recursively import children
+                if new_block.has_children:
+                    # Delete any children that the new block has since we'll be replacing them all anyways, and want to
+                    # Ensure that if a grandchild block was deleted from the source library it will get deleted from the
+                    # destination course during this update.
+                    for existing_child_key in new_block.children:
+                        self.store.delete_item(existing_child_key, self.user_id)
+                    # Now import the children
+                    for child in source_block.get_children():
+                        do_import(child, new_block_key)
 
-            # TODO: delete any out of date children
+                return new_block_key
+
+            # Now actually do the import, making each block in 'orig_blocks' become a child of dest_block
+            for block in orig_blocks:
+                new_block_id = do_import(block, dest_key)
+                child_ids_updated.add(new_block_id)
+            # Remove any existing children that are no longer wanted
+            existing_children_to_delete = set(dest_block.children) - child_ids_updated
+            for old_child_id in existing_children_to_delete:
+                self.store.delete_item(old_child_id, self.user_id)

--- a/common/lib/xmodule/xmodule/library_tools.py
+++ b/common/lib/xmodule/xmodule/library_tools.py
@@ -238,7 +238,9 @@ class LibraryToolsService(object):
                     new_block = self.store.get_item(new_block_key)
                     if new_block.parent != dest_parent_key:
                         raise ValueError(
-                            "Expected existing block {} to be a child of {}".format(new_block_key, dest_parent_key)
+                            "Expected existing block {} to be a child of {} but instead it's a child of {}".format(
+                                new_block_key, dest_parent_key, new_block.parent,
+                            )
                         )
                 except ItemNotFoundError:
                     new_block = self.store.create_child(
@@ -295,3 +297,7 @@ class LibraryToolsService(object):
             existing_children_to_delete = set(dest_block.children) - child_ids_updated
             for old_child_id in existing_children_to_delete:
                 self.store.delete_item(old_child_id, self.user_id)
+
+        # If this was called from a handler, it will save dest_block at the end, so we must update
+        # dest_block.children to avoid it saving the old value of children and deleting the new children.
+        dest_block.children = self.store.get_item(dest_key).children

--- a/common/lib/xmodule/xmodule/modulestore/split_mongo/caching_descriptor_system.py
+++ b/common/lib/xmodule/xmodule/modulestore/split_mongo/caching_descriptor_system.py
@@ -85,7 +85,7 @@ class CachingDescriptorSystem(MakoDescriptorSystem, EditInfoRuntimeMixin):
         self.module_data = module_data
         self.default_class = default_class
         self.local_modules = {}
-        self._services['library_tools'] = LibraryToolsService(modulestore)
+        self._services['library_tools'] = LibraryToolsService(modulestore, user_id=None)
 
     @lazy
     @contract(returns="dict(BlockKey: BlockKey)")

--- a/common/lib/xmodule/xmodule/modulestore/xml_importer.py
+++ b/common/lib/xmodule/xmodule/modulestore/xml_importer.py
@@ -826,13 +826,11 @@ def _update_and_import_module(
         # if library exists, update source_library_version and children
         # according to this existing library and library content block.
         if store.get_library(block.source_library_key):
-
             # Update library content block's children on draft branch
             with store.branch_setting(branch_setting=ModuleStoreEnum.Branch.draft_preferred):
-                LibraryToolsService(store).update_children(
+                LibraryToolsService(store, user_id).update_children(
                     block,
-                    user_id,
-                    version=block.source_library_version
+                    version=block.source_library_version,
                 )
 
             # Publish it if importing the course for branch setting published_only.

--- a/common/lib/xmodule/xmodule/tests/test_library_content.py
+++ b/common/lib/xmodule/xmodule/tests/test_library_content.py
@@ -33,7 +33,7 @@ class LibraryContentTest(MixedSplitTestCase):
     def setUp(self):
         super(LibraryContentTest, self).setUp()
 
-        self.tools = LibraryToolsService(self.store)
+        self.tools = LibraryToolsService(self.store, self.user_id)
         self.library = LibraryFactory.create(modulestore=self.store)
         self.lib_blocks = [
             self.make_block("html", self.library, data="Hello world from block {}".format(i))

--- a/common/lib/xmodule/xmodule/tests/test_library_tools.py
+++ b/common/lib/xmodule/xmodule/tests/test_library_tools.py
@@ -1,9 +1,7 @@
 """
 Tests for library tools service.
 """
-
-
-from mock import patch
+from unittest.mock import patch
 
 from xmodule.library_tools import LibraryToolsService
 from xmodule.modulestore.tests.factories import LibraryFactory
@@ -16,9 +14,8 @@ class LibraryToolsServiceTest(MixedSplitTestCase):
     """
 
     def setUp(self):
-        super(LibraryToolsServiceTest, self).setUp()
-
-        self.tools = LibraryToolsService(self.store)
+        super().setUp()
+        self.tools = LibraryToolsService(self.store, self.user_id)
 
     def test_list_available_libraries(self):
         """

--- a/lms/djangoapps/lms_xblock/runtime.py
+++ b/lms/djangoapps/lms_xblock/runtime.py
@@ -152,7 +152,7 @@ class LmsModuleSystem(ModuleSystem):  # pylint: disable=abstract-method
             services['completion'] = CompletionService(user=user, context_key=kwargs.get('course_id'))
         services['fs'] = xblock.reference.plugins.FSService()
         services['i18n'] = ModuleI18nService
-        services['library_tools'] = LibraryToolsService(store)
+        services['library_tools'] = LibraryToolsService(store, user_id=user.id if user else None)
         services['partitions'] = PartitionService(
             course_id=kwargs.get('course_id'),
             cache=request_cache_dict

--- a/openedx/core/djangoapps/content_libraries/permissions.py
+++ b/openedx/core/djangoapps/content_libraries/permissions.py
@@ -17,7 +17,7 @@ is_global_staff = is_user_active & rules.is_staff
 # Does the user have at least read permission for the specified library?
 has_explicit_read_permission_for_library = (
     ManyRelation(
-        'contentlibrarypermission',
+        'permission_grants',
         (Attribute('user', lambda user: user) | Relation('group', in_current_groups))
     )
     # We don't check 'access_level' here because all access levels grant read permission
@@ -25,7 +25,7 @@ has_explicit_read_permission_for_library = (
 # Does the user have at least author permission for the specified library?
 has_explicit_author_permission_for_library = (
     ManyRelation(
-        'contentlibrarypermission',
+        'permission_grants',
         (Attribute('user', lambda user: user) | Relation('group', in_current_groups)) & (
             Attribute('access_level', ContentLibraryPermission.AUTHOR_LEVEL) |
             Attribute('access_level', ContentLibraryPermission.ADMIN_LEVEL)
@@ -35,7 +35,7 @@ has_explicit_author_permission_for_library = (
 # Does the user have admin permission for the specified library?
 has_explicit_admin_permission_for_library = (
     ManyRelation(
-        'contentlibrarypermission',
+        'permission_grants',
         (Attribute('user', lambda user: user) | Relation('group', in_current_groups)) &
         Attribute('access_level', ContentLibraryPermission.ADMIN_LEVEL)
     )

--- a/openedx/core/djangoapps/xblock/learning_context/manager.py
+++ b/openedx/core/djangoapps/xblock/learning_context/manager.py
@@ -38,9 +38,11 @@ def get_learning_context_impl(key):
         context_type = key.CANONICAL_NAMESPACE  # e.g. 'lib'
     elif isinstance(key, UsageKeyV2):
         context_type = key.context_key.CANONICAL_NAMESPACE
-    else:
+    elif isinstance(key, OpaqueKey):
         # Maybe this is an older modulestore key etc.
         raise TypeError("Opaque key {} does not have a learning context.".format(key))
+    else:
+        raise TypeError("key '{}' is not an opaque key. You probably forgot [KeyType].from_string(...)".format(key))
 
     try:
         return _learning_context_cache[context_type]

--- a/openedx/core/djangoapps/xblock/learning_context/manager.py
+++ b/openedx/core/djangoapps/xblock/learning_context/manager.py
@@ -1,8 +1,7 @@
 """
 Helper methods for working with learning contexts
 """
-
-
+from opaque_keys import OpaqueKey
 from opaque_keys.edx.keys import LearningContextKey, UsageKeyV2
 
 from openedx.core.djangoapps.xblock.apps import get_xblock_app_config


### PR DESCRIPTION
This WIP code is a proof of concept, showing an XBlock that lets you select some specific blocks from a Blockstore-based content library and then will copy them into a [modulestore-based] course.

### Test instructions:
* Check this branch out; from `make studio-shell` run `pip install -e common/lib/xmodule/`
* Create some content in a blockstore-based content library. Note the IDs of a few blocks (e.g. `lb:edX:test:html:1`). Ideally use blocks that have children and static assets (such as images).
* Go into a course in Studio. In its advanced settings, add `library_sourced` to the list of advanced block types.
* In the "Unit Edit View" in Studio, find the green "Add New Component" buttons. Click Advanced > Library Sourced Content.
<img width="300" alt="Screen Shot 2020-06-27 at 3 20 37 PM" src="https://user-images.githubusercontent.com/945577/85933251-c8f8cb80-b889-11ea-9ce6-285abff3a844.png"> <img width="300" alt="Screen Shot 2020-06-27 at 3 20 41 PM" src="https://user-images.githubusercontent.com/945577/85933252-cb5b2580-b889-11ea-896c-ca7d32f5c94a.png">
* Click the "Edit" button
  <img width="952" alt="Screen Shot 2020-06-27 at 3 23 12 PM" src="https://user-images.githubusercontent.com/945577/85933273-22f99100-b88a-11ea-817a-c26a84740e28.png">
* As a JSON list, enter the Library XBlock IDs you wish to import into the course:
  <img width="1172" alt="Screen Shot 2020-06-27 at 3 24 08 PM" src="https://user-images.githubusercontent.com/945577/85933288-4a505e00-b88a-11ea-8726-fb7e4b2ccf84.png">
* Press Save
* You should now see the content has been copied into the course. Students won't see any trace of the "Library Sourced Content" block but instead will just see the imported block(s). Static assets such as images should be working correctly and will still be served from Blockstore.
    <img width="945" alt="Screen Shot 2020-06-27 at 3 52 41 PM" src="https://user-images.githubusercontent.com/945577/85933642-432b4f00-b88e-11ea-904d-862de2b09cc6.png">


### TODO:
* Hide the "move to" button - it will cause bugs if the new blocks are moved around in the course.
   <img width="962" alt="Screen Shot 2020-06-27 at 3 27 54 PM" src="https://user-images.githubusercontent.com/945577/85933340-d5315880-b88a-11ea-865b-04e298d1b69b.png">
* Write tests
* Nicer authoring UI - no JSON

### Other Notes
Note that once we get courses implemented in Blockstore as well I expect we won't use this block at all, so I haven't designed it to be forwards compatible in that sense. I expect that in Blockstore-based courses, the course outline will be a first-class object which can specify things like "Unit 15 should consist of these three blocks linked in from content library X, Unit 16 should have 2-5 XBlocks as returned by the adaptive engine, etc."