### PR TITLE
remove unenroll button for masters enrollments

### DIFF
--- a/lms/static/sass/multicourse/_dashboard.scss
+++ b/lms/static/sass/multicourse/_dashboard.scss
@@ -263,6 +263,12 @@
               }
             }
 
+            .action-message {
+              min-width: ($baseline*20);
+              color: $gray-d1;
+              pointer-events: none;
+            }
+
             // UI: general actions dropdown layout
             .wrapper-action-more {
               display: inline-block;

--- a/lms/templates/dashboard.html
+++ b/lms/templates/dashboard.html
@@ -196,7 +196,8 @@ from student.models import CourseEnrollment
                 show_courseware_link = show_courseware_links_for.get(session_id, False)
                 cert_status = cert_statuses.get(session_id)
                 can_refund_entitlement = entitlement and entitlement.is_entitlement_refundable()
-                can_unenroll = (not cert_status) or cert_status.get('can_unenroll') if not unfulfilled_entitlement else False
+                partner_managed_enrollment = enrollment.mode == 'masters'
+                can_unenroll = False if partner_managed_enrollment else (not cert_status) or cert_status.get('can_unenroll') if not unfulfilled_entitlement else False
                 credit_status = credit_statuses.get(session_id)
                 course_mode_info = all_course_modes.get(session_id)
                 is_paid_course = True if entitlement else (session_id in enrolled_courses_either_paid)
@@ -207,7 +208,7 @@ from student.models import CourseEnrollment
                 course_overview = enrollment.course_overview
                 resume_button_url = resume_button_urls[dashboard_index]
               %>
-              <%include file='dashboard/_dashboard_course_listing.html' args='course_overview=course_overview, course_card_index=dashboard_index, enrollment=enrollment, is_unfulfilled_entitlement=is_unfulfilled_entitlement, is_fulfilled_entitlement=is_fulfilled_entitlement, entitlement=entitlement, entitlement_session=entitlement_session, entitlement_available_sessions=entitlement_available_sessions, entitlement_expiration_date=entitlement_expiration_date, entitlement_expired_at=entitlement_expired_at, show_courseware_link=show_courseware_link, cert_status=cert_status, can_refund_entitlement=can_refund_entitlement, can_unenroll=can_unenroll, credit_status=credit_status, show_email_settings=show_email_settings, course_mode_info=course_mode_info, is_paid_course=is_paid_course, verification_status=course_verification_status, course_requirements=course_requirements, dashboard_index=dashboard_index, share_settings=share_settings, user=user, related_programs=related_programs, display_course_modes_on_dashboard=display_course_modes_on_dashboard, show_consent_link=show_consent_link, enterprise_customer_name=enterprise_customer_name, resume_button_url=resume_button_url' />
+              <%include file='dashboard/_dashboard_course_listing.html' args='course_overview=course_overview, course_card_index=dashboard_index, enrollment=enrollment, is_unfulfilled_entitlement=is_unfulfilled_entitlement, is_fulfilled_entitlement=is_fulfilled_entitlement, entitlement=entitlement, entitlement_session=entitlement_session, entitlement_available_sessions=entitlement_available_sessions, entitlement_expiration_date=entitlement_expiration_date, entitlement_expired_at=entitlement_expired_at, show_courseware_link=show_courseware_link, cert_status=cert_status, can_refund_entitlement=can_refund_entitlement, can_unenroll=can_unenroll, credit_status=credit_status, show_email_settings=show_email_settings, course_mode_info=course_mode_info, is_paid_course=is_paid_course, verification_status=course_verification_status, course_requirements=course_requirements, dashboard_index=dashboard_index, share_settings=share_settings, user=user, related_programs=related_programs, display_course_modes_on_dashboard=display_course_modes_on_dashboard, show_consent_link=show_consent_link, enterprise_customer_name=enterprise_customer_name, resume_button_url=resume_button_url, partner_managed_enrollment=partner_managed_enrollment' />
             % endfor
             % if show_load_all_courses_link:
                 <br/>

--- a/lms/templates/dashboard/_dashboard_course_listing.html
+++ b/lms/templates/dashboard/_dashboard_course_listing.html
@@ -277,7 +277,7 @@ from util.course import get_link_for_about_page, get_encoded_course_sharing_utm_
                     % elif partner_managed_enrollment:
                       <li class="actions-item" id="actions-item-enrolled-by-partner-${dashboard_index}" role="menuitem">
                         <a class="action action-message action-unenroll-managed-enrollment">
-                          You are enrolled by your institution and you should reach out to your institution to drop this course.
+                          ${_('You are enrolled by your institution and you should reach out to your institution to drop this course.')}
                         </a>
                       </li>
                     % endif

--- a/lms/templates/dashboard/_dashboard_course_listing.html
+++ b/lms/templates/dashboard/_dashboard_course_listing.html
@@ -1,4 +1,4 @@
-<%page args="course_overview, enrollment, entitlement, entitlement_session, course_card_index, is_unfulfilled_entitlement, is_fulfilled_entitlement, entitlement_available_sessions, entitlement_expiration_date, entitlement_expired_at, show_courseware_link, cert_status, can_refund_entitlement, can_unenroll, credit_status, show_email_settings, course_mode_info, is_paid_course, verification_status, course_requirements, dashboard_index, share_settings, related_programs, display_course_modes_on_dashboard, show_consent_link, enterprise_customer_name, resume_button_url" expression_filter="h"/>
+<%page args="course_overview, enrollment, entitlement, entitlement_session, course_card_index, is_unfulfilled_entitlement, is_fulfilled_entitlement, entitlement_available_sessions, entitlement_expiration_date, entitlement_expired_at, show_courseware_link, cert_status, can_refund_entitlement, can_unenroll, credit_status, show_email_settings, course_mode_info, is_paid_course, verification_status, course_requirements, dashboard_index, share_settings, related_programs, display_course_modes_on_dashboard, show_consent_link, enterprise_customer_name, resume_button_url, partner_managed_enrollment" expression_filter="h"/>
 
 <%!
 import six
@@ -274,6 +274,12 @@ from util.course import get_link_for_about_page, get_encoded_course_sharing_utm_
                                 ${_('Unenroll')}
                               </a>
                         </li>
+                    % elif partner_managed_enrollment:
+                      <li class="actions-item" id="actions-item-enrolled-by-partner-${dashboard_index}" role="menuitem">
+                        <a class="action action-message action-unenroll-managed-enrollment">
+                          You are enrolled by your institution and you should reach out to your institution to drop this course.
+                        </a>
+                      </li>
                     % endif
                       <li class="actions-item" id="actions-item-email-settings-${dashboard_index}" role="menuitem">
                         % if show_email_settings:


### PR DESCRIPTION
### [MST-267](https://openedx.atlassian.net/browse/MST-267)

@edx/masters-devs-cosmonauts 

Replaces 'unenroll' with a message for enrollments managed through a partner university.

Example:
<img width="1428" alt="Screen Shot 2020-06-25 at 10 33 57 AM" src="https://user-images.githubusercontent.com/5661461/85740696-d5d1bf80-b6cf-11ea-8a81-8fddf1439609.png">
