### PR TITLE
Fixing assert_has_calls() failure due to order difference

### DIFF
--- a/cms/djangoapps/contentstore/tests/test_course_settings.py
+++ b/cms/djangoapps/contentstore/tests/test_course_settings.py
@@ -619,7 +619,7 @@ class CourseGradingTest(CourseTestCase):
                     'event_transaction_type': 'edx.grades.grading_policy_changed',
                 }
             ) for policy_hash in {grading_policy_1, grading_policy_2, grading_policy_3}
-        ])
+        ], any_order=True)
 
     @mock.patch('track.event_transaction_utils.uuid4')
     @mock.patch('models.settings.course_grading.tracker')


### PR DESCRIPTION
https://openedx.atlassian.net/browse/BOM-1811

assert_has_calls() failing due to  different order of specified calls.
if any_order is true then the calls can be in any order,
but they must all appear in mock_calls.

https://docs.python.org/3/library/unittest.mock.html#unittest.mock.Mock.assert_has_calls