### PR TITLE
[BD-6] Fix invalid escape sequence deprecation warning.

### DIFF
--- a/openedx/core/process_warnings.py
+++ b/openedx/core/process_warnings.py
@@ -36,11 +36,11 @@ def seperate_warnings_by_location(warnings_data):
 
     # first create regex for each n file location
     warnings_locations = {
-        ".*/python\d\.\d/site-packages/.*\.py": "python",  # noqa pylint: disable=W1401
-        ".*/edx-platform/lms/.*\.py": "lms",  # noqa pylint: disable=W1401
-        ".*/edx-platform/openedx/.*\.py": "openedx",  # noqa pylint: disable=W1401
-        ".*/edx-platform/cms/.*\.py": "cms",  # noqa pylint: disable=W1401
-        ".*/edx-platform/common/.*\.py": "common",  # noqa pylint: disable=W1401
+        r".*/python\d\.\d/site-packages/.*\.py": "python",  # noqa pylint: disable=W1401
+        r".*/edx-platform/lms/.*\.py": "lms",  # noqa pylint: disable=W1401
+        r".*/edx-platform/openedx/.*\.py": "openedx",  # noqa pylint: disable=W1401
+        r".*/edx-platform/cms/.*\.py": "cms",  # noqa pylint: disable=W1401
+        r".*/edx-platform/common/.*\.py": "common",  # noqa pylint: disable=W1401
     }
 
     # separate into locations flow:
@@ -93,7 +93,7 @@ def read_warning_data(dir_path):
     # TODO(jinder): currently this is hard-coded in, maybe create a constants file with info
     # THINK(jinder): but creating file for one constant seems overkill
     warnings_file_name_regex = (
-        "pytest_warnings_?\d*\.json"  # noqa pylint: disable=W1401
+        r"pytest_warnings_?\d*\.json"  # noqa pylint: disable=W1401
     )
 
     # iterate through files_in_dir and see if they match our know file name pattern


### PR DESCRIPTION
That warning is thrown when the warnings are being processed, you can check that is the final part of the lms artifact: 

https://build.testeng.edx.org/job/edx-platform-python-3.8-python-pipeline-pr/80/artifact/lms-tests.log
```
 DeprecationWarning: invalid escape sequence \d
  ".*/python\d\.\d/site-packages/.*\.py": "python",  # noqa pylint: disable=W1401
```
After the change:
https://build.testeng.edx.org/job/edx-platform-python-3.8-python-pipeline-pr/83/artifact/lms-tests.log
#Reviewers 
- [ ] @awais786 
- [ ] @ericfab179 