### PR TITLE
Displays escalation email on Special Exams tab

### DIFF
--- a/lms/djangoapps/instructor/tests/test_proctoring.py
+++ b/lms/djangoapps/instructor/tests/test_proctoring.py
@@ -2,7 +2,6 @@
 Unit tests for Edx Proctoring feature flag in new instructor dashboard.
 """
 
-
 import ddt
 from django.apps import apps
 from django.conf import settings
@@ -50,6 +49,16 @@ class TestProctoringDashboardViews(SharedModuleStoreTestCase):
         """
         self.course = CourseFactory.create(enable_proctored_exams=enable_proctored_exams,
                                            enable_timed_exams=enable_timed_exams)
+        self.setup_course_url(self.course)
+
+    def setup_course_with_proctoring_backend(self, proctoring_provider, escalation_email):
+        """
+        Create course based on proctoring provider and escalation email values
+        """
+        self.course = CourseFactory.create(enable_proctored_exams=True,
+                                           enable_timed_exams=True,
+                                           proctoring_provider=proctoring_provider,
+                                           proctoring_escalation_email=escalation_email)
         self.setup_course_url(self.course)
 
     @ddt.data(
@@ -127,6 +136,47 @@ class TestProctoringDashboardViews(SharedModuleStoreTestCase):
         self.instructor.save()
         self._assert_proctoring_tab_available(False)
 
+    @patch.dict(settings.PROCTORING_BACKENDS,
+                {
+                    'DEFAULT': 'test_proctoring_provider',
+                    'test_proctoring_provider': {},
+                    'proctortrack': {}
+                },
+                )
+    @ddt.data(
+        ('test_proctoring_provider', None),
+        ('test_proctoring_provider', 'foo@bar.com')
+    )
+    @ddt.unpack
+    def test_non_proctortrack_provider(self, proctoring_provider, escalation_email):
+        """
+        Escalation email will not be visible if proctortrack is not the proctoring provider, with or without
+        escalation email provided.
+        """
+        self.setup_course_with_proctoring_backend(proctoring_provider, escalation_email)
+
+        self.instructor.is_staff = True
+        self.instructor.save()
+        self._assert_escalation_email_available(False)
+
+    @patch.dict(settings.PROCTORING_BACKENDS,
+                {
+                    'DEFAULT': 'test_proctoring_provider',
+                    'test_proctoring_provider': {},
+                    'proctortrack': {}
+                },
+                )
+    def test_proctortrack_provider_with_email(self):
+        """
+        Escalation email will be visible if proctortrack is the proctoring provider, and there
+        is an escalation email provided.
+        """
+        self.setup_course_with_proctoring_backend('proctortrack', 'foo@bar.com')
+
+        self.instructor.is_staff = True
+        self.instructor.save()
+        self._assert_escalation_email_available(True)
+
     def test_review_dashboard(self):
         """
         The exam review dashboard will appear for backends that support the feature
@@ -157,3 +207,11 @@ class TestProctoringDashboardViews(SharedModuleStoreTestCase):
         response = self.client.get(self.url)
         func(self.proctoring_link, response.content.decode('utf-8'))
         func('proctoring-wrapper', response.content.decode('utf-8'))
+
+    def _assert_escalation_email_available(self, available):
+        """
+        Asserts that escalation email is/is not available for logged in user
+        """
+        func = self.assertIn if available else self.assertNotIn
+        response = self.client.get(self.url)
+        func('escalation-email-container', response.content.decode('utf-8'))

--- a/lms/djangoapps/instructor/tests/test_proctoring.py
+++ b/lms/djangoapps/instructor/tests/test_proctoring.py
@@ -6,11 +6,11 @@ import ddt
 from django.apps import apps
 from django.conf import settings
 from django.urls import reverse
-from edx_proctoring.api import create_exam
-from edx_proctoring.backends.tests.test_backend import TestBackendProvider
 from mock import patch
 from six import text_type
 
+from edx_proctoring.api import create_exam
+from edx_proctoring.backends.tests.test_backend import TestBackendProvider
 from student.roles import CourseInstructorRole, CourseStaffRole
 from student.tests.factories import AdminFactory
 from xmodule.modulestore.tests.django_utils import SharedModuleStoreTestCase
@@ -56,9 +56,9 @@ class TestProctoringDashboardViews(SharedModuleStoreTestCase):
         Create course based on proctoring provider and escalation email values
         """
         course = CourseFactory.create(enable_proctored_exams=True,
-                                           enable_timed_exams=True,
-                                           proctoring_provider=proctoring_provider,
-                                           proctoring_escalation_email=escalation_email)
+                                      enable_timed_exams=True,
+                                      proctoring_provider=proctoring_provider,
+                                      proctoring_escalation_email=escalation_email)
         self.setup_course_url(course)
 
     @ddt.data(

--- a/lms/djangoapps/instructor/tests/test_proctoring.py
+++ b/lms/djangoapps/instructor/tests/test_proctoring.py
@@ -55,11 +55,11 @@ class TestProctoringDashboardViews(SharedModuleStoreTestCase):
         """
         Create course based on proctoring provider and escalation email values
         """
-        self.course = CourseFactory.create(enable_proctored_exams=True,
+        course = CourseFactory.create(enable_proctored_exams=True,
                                            enable_timed_exams=True,
                                            proctoring_provider=proctoring_provider,
                                            proctoring_escalation_email=escalation_email)
-        self.setup_course_url(self.course)
+        self.setup_course_url(course)
 
     @ddt.data(
         (True, False),

--- a/lms/djangoapps/instructor/views/instructor_dashboard.py
+++ b/lms/djangoapps/instructor/views/instructor_dashboard.py
@@ -342,6 +342,11 @@ def _section_e_commerce(course, access, paid_mode, coupons_enabled, reports_enab
 def _section_special_exams(course, access):
     """ Provide data for the corresponding dashboard section """
     course_key = six.text_type(course.id)
+    proctoring_provider = six.text_type(course.proctoring_provider)
+    if proctoring_provider == 'proctortrack':
+        escalation_email = six.text_type(course.proctoring_escalation_email)
+    else:
+        escalation_email = None
     from edx_proctoring.api import is_backend_dashboard_available
 
     section_data = {
@@ -349,6 +354,7 @@ def _section_special_exams(course, access):
         'section_display_name': _('Special Exams'),
         'access': access,
         'course_id': course_key,
+        'escalation_email': escalation_email,
         'show_dashboard': is_backend_dashboard_available(course_key),
     }
     return section_data

--- a/lms/djangoapps/instructor/views/instructor_dashboard.py
+++ b/lms/djangoapps/instructor/views/instructor_dashboard.py
@@ -342,11 +342,10 @@ def _section_e_commerce(course, access, paid_mode, coupons_enabled, reports_enab
 def _section_special_exams(course, access):
     """ Provide data for the corresponding dashboard section """
     course_key = six.text_type(course.id)
-    proctoring_provider = six.text_type(course.proctoring_provider)
+    proctoring_provider = course.proctoring_provider
+    escalation_email = None
     if proctoring_provider == 'proctortrack':
-        escalation_email = six.text_type(course.proctoring_escalation_email)
-    else:
-        escalation_email = None
+        escalation_email = course.proctoring_escalation_email
     from edx_proctoring.api import is_backend_dashboard_available
 
     section_data = {

--- a/lms/templates/instructor/instructor_dashboard_2/special_exams.html
+++ b/lms/templates/instructor/instructor_dashboard_2/special_exams.html
@@ -6,7 +6,7 @@ import pytz
 %>
 <div class="proctoring-wrapper">
   % if section_data.get('escalation_email'):
-  <h6 class = "hd hd-6">${_('Proctortrack Escalation Email:')} ${ section_data['escalation_email'] }</h6>
+  <h6 class = "hd hd-6 escalation-email-container">${_('Proctortrack Escalation Email:')} ${ section_data['escalation_email'] }</h6>
   % endif
   <div id="proctoring-accordion">
     <div class="wrap">

--- a/lms/templates/instructor/instructor_dashboard_2/special_exams.html
+++ b/lms/templates/instructor/instructor_dashboard_2/special_exams.html
@@ -5,6 +5,9 @@ from datetime import datetime, timedelta
 import pytz
 %>
 <div class="proctoring-wrapper">
+  % if section_data['escalation_email']:
+  <h6 class = "hd hd-6">${_('Proctortrack Escalation Email:')} ${ section_data['escalation_email'] }</h6>
+  % endif
   <div id="proctoring-accordion">
     <div class="wrap">
        <h3 class="hd hd-3">${_('Allowance Section')}</h3>

--- a/lms/templates/instructor/instructor_dashboard_2/special_exams.html
+++ b/lms/templates/instructor/instructor_dashboard_2/special_exams.html
@@ -5,7 +5,7 @@ from datetime import datetime, timedelta
 import pytz
 %>
 <div class="proctoring-wrapper">
-  % if section_data['escalation_email']:
+  % if section_data.get('escalation_email'):
   <h6 class = "hd hd-6">${_('Proctortrack Escalation Email:')} ${ section_data['escalation_email'] }</h6>
   % endif
   <div id="proctoring-accordion">


### PR DESCRIPTION
## [MST-274](https://openedx.atlassian.net/browse/MST-274)

Displays escalation email only if proctortrack is the proctoring provider and an escalation email has been set. 

For example:
![proctortrack_with_email](https://user-images.githubusercontent.com/46360176/85788540-29a5ce00-b6fb-11ea-9a2f-df9e9028b070.png)

If proctortrack is not the provider, even if an escalation email has been set, the page will still look like this:
![no_proctortrack](https://user-images.githubusercontent.com/46360176/85788695-5ce85d00-b6fb-11ea-927d-7ccb4f8e64eb.png)
