### PR TITLE
[BD-6] Remove usage of enum34, since we are already in python>=3.4

### DIFF
--- a/pavelib/prereqs.py
+++ b/pavelib/prereqs.py
@@ -197,6 +197,7 @@ PACKAGES_TO_UNINSTALL = [
     "django-storages",
     "django-oauth2-provider",       # Because now it's called edx-django-oauth2-provider.
     "edx-oauth2-provider",          # Because it moved from github to pypi
+    "enum34",                       # Because enum34 is not needed in python>3.4
     "i18n-tools",                   # Because now it's called edx-i18n-tools
     "moto",                         # Because we no longer use it and it conflicts with recent jsondiff versions
     "python-saml",                  # Because python3-saml shares the same directory name

--- a/requirements/edx-sandbox/base.txt
+++ b/requirements/edx-sandbox/base.txt
@@ -15,7 +15,6 @@ cffi==1.13.2
 git+https://github.com/edx/openedx-chem.git@ff4e3a03d3c7610e47a9af08eb648d8aabe2eb18#egg=chem==1.0.0
 cryptography==2.8
 cycler==0.10.0            # via matplotlib
-enum34==1.1.6
 ipaddress==1.0.23
 kiwisolver==1.1.0         # via matplotlib
 lxml==3.8.0

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -114,11 +114,10 @@ edx-submissions==3.1.11   # via -r requirements/edx/base.in, ora2
 edx-tincan-py35==0.0.5    # via edx-enterprise
 edx-user-state-client==1.2.0  # via -r requirements/edx/base.in
 edx-when==1.2.8           # via -r requirements/edx/base.in, edx-proctoring
-edxval==1.3.7             # via -r requirements/edx/base.in
+edxval==1.3.8             # via -r requirements/edx/base.in
 elasticsearch==1.9.0      # via edx-search
 enmerkar-underscore==1.0.0  # via -r requirements/edx/base.in
 enmerkar==0.7.1           # via enmerkar-underscore
-enum34==1.1.10            # via edxval
 event-tracking==0.3.2     # via -r requirements/edx/base.in, edx-proctoring, edx-search
 fs-s3fs==0.1.8            # via -r requirements/edx/base.in, django-pyfs
 fs==2.0.18                # via -r requirements/edx/base.in, django-pyfs, fs-s3fs, xblock

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -127,11 +127,10 @@ edx-submissions==3.1.11   # via -r requirements/edx/testing.txt, ora2
 edx-tincan-py35==0.0.5    # via -r requirements/edx/testing.txt, edx-enterprise
 edx-user-state-client==1.2.0  # via -r requirements/edx/testing.txt
 edx-when==1.2.8           # via -r requirements/edx/testing.txt, edx-proctoring
-edxval==1.3.7             # via -r requirements/edx/testing.txt
+edxval==1.3.8             # via -r requirements/edx/testing.txt
 elasticsearch==1.9.0      # via -r requirements/edx/testing.txt, edx-search
 enmerkar-underscore==1.0.0  # via -r requirements/edx/testing.txt
 enmerkar==0.7.1           # via -r requirements/edx/testing.txt, enmerkar-underscore
-enum34==1.1.10            # via -r requirements/edx/testing.txt, edxval
 event-tracking==0.3.2     # via -r requirements/edx/testing.txt, edx-proctoring, edx-search
 execnet==1.7.1            # via -r requirements/edx/testing.txt, pytest-xdist
 factory-boy==2.8.1        # via -c requirements/edx/../constraints.txt, -r requirements/edx/testing.txt

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -123,11 +123,10 @@ edx-submissions==3.1.11   # via -r requirements/edx/base.txt, ora2
 edx-tincan-py35==0.0.5    # via -r requirements/edx/base.txt, edx-enterprise
 edx-user-state-client==1.2.0  # via -r requirements/edx/base.txt
 edx-when==1.2.8           # via -r requirements/edx/base.txt, edx-proctoring
-edxval==1.3.7             # via -r requirements/edx/base.txt
+edxval==1.3.8             # via -r requirements/edx/base.txt
 elasticsearch==1.9.0      # via -r requirements/edx/base.txt, edx-search
 enmerkar-underscore==1.0.0  # via -r requirements/edx/base.txt
 enmerkar==0.7.1           # via -r requirements/edx/base.txt, enmerkar-underscore
-enum34==1.1.10            # via -r requirements/edx/base.txt, edxval
 event-tracking==0.3.2     # via -r requirements/edx/base.txt, edx-proctoring, edx-search
 execnet==1.7.1            # via pytest-xdist
 factory-boy==2.8.1        # via -c requirements/edx/../constraints.txt, -r requirements/edx/testing.in


### PR DESCRIPTION
enum34 is causing problems in python3.8 tests of edx-platform because it has incompatibility with recent versions of python, the error the error happens while importing the re module in these python versions.

This library is a backport of enum of python3.4 made for python<3.4, therefore is not needed anymore.

edx-val was updated to remove that dependency: https://github.com/edx/edx-val/pull/245

## Reviewers
- [ ] @awais786 
- [ ] @ericfab179 
