### PR TITLE
[REV-1205] Add ecommerce event tracking to course dashboard upgrade button

### DIFF
--- a/lms/djangoapps/experiments/utils.py
+++ b/lms/djangoapps/experiments/utils.py
@@ -48,7 +48,6 @@ experiments_namespace = WaffleFlagNamespace(name=u'experiments')
 PROGRAM_INFO_FLAG = WaffleFlag(
     waffle_namespace=experiments_namespace,
     flag_name=u'add_programs',
-    flag_undefined_default=False
 )
 
 # .. toggle_name: experiments.add_dashboard_info
@@ -62,9 +61,7 @@ PROGRAM_INFO_FLAG = WaffleFlag(
 # .. toggle_warnings: None
 # .. toggle_tickets: REVEM-118
 # .. toggle_status: supported
-DASHBOARD_INFO_FLAG = WaffleFlag(experiments_namespace,
-                                 u'add_dashboard_info',
-                                 flag_undefined_default=False)
+DASHBOARD_INFO_FLAG = WaffleFlag(experiments_namespace, u'add_dashboard_info')
 # TODO END: clean up as part of REVEM-199 (End)
 
 # TODO: Clean up as part of REV-1205 (START)
@@ -81,8 +78,7 @@ DASHBOARD_INFO_FLAG = WaffleFlag(experiments_namespace,
 # .. toggle_status: supported
 UPSELL_TRACKING_FLAG = WaffleFlag(
     waffle_namespace=experiments_namespace,
-    flag_name=u'add_upsell_tracking',
-    flag_undefined_default=False
+    flag_name=u'add_upsell_tracking'
 )
 # TODO END: Clean up as part of REV-1205 (End)
 

--- a/lms/djangoapps/experiments/utils.py
+++ b/lms/djangoapps/experiments/utils.py
@@ -67,6 +67,25 @@ DASHBOARD_INFO_FLAG = WaffleFlag(experiments_namespace,
                                  flag_undefined_default=False)
 # TODO END: clean up as part of REVEM-199 (End)
 
+# TODO: Clean up as part of REV-1205 (START)
+# .. toggle_name: experiments.add_upsell_tracking
+# .. toggle_implementation: WaffleFlag
+# .. toggle_default: False
+# .. toggle_description: Make sure upsell tracking JS works as expected.
+# .. toggle_category: experiments
+# .. toggle_use_cases: monitored_rollout
+# .. toggle_creation_date: 2020-7-7
+# .. toggle_expiration_date: None
+# .. toggle_warnings: None
+# .. toggle_tickets: REV-1205
+# .. toggle_status: supported
+UPSELL_TRACKING_FLAG = WaffleFlag(
+    waffle_namespace=experiments_namespace,
+    flag_name=u'add_upsell_tracking',
+    flag_undefined_default=False
+)
+# TODO END: Clean up as part of REV-1205 (End)
+
 
 def check_and_get_upgrade_link_and_date(user, enrollment=None, course=None):
     """

--- a/lms/static/js/commerce/track_ecommerce_events.js
+++ b/lms/static/js/commerce/track_ecommerce_events.js
@@ -23,9 +23,9 @@
                 Object.keys(optionalAttrs).length > 0
             ) {
                 var allowedAttrs = ["courseId", "pageName"];
-                allowedAttrs.map(
-                    allowedAttr => eventAttrs[allowedAttr] = optionalAttrs[allowedAttr]
-                );
+                allowedAttrs.map(function(allowedAttr) {
+                    eventAttrs[allowedAttr] = optionalAttrs[allowedAttr];
+                });
             }
     
             window.analytics.track("edx.bi.ecommerce.upsell_links_clicked", eventAttrs);

--- a/lms/static/js/commerce/track_ecommerce_events.js
+++ b/lms/static/js/commerce/track_ecommerce_events.js
@@ -1,0 +1,40 @@
+/**
+ *
+ * A library of helper functions to track ecommerce related events. 
+ *
+ */
+
+(function(define) {
+    'use strict';
+
+    define([
+        'jquery'
+    ], function($) {
+        var trackUpsellClick = function(linkName, optionalAttrs) {
+            if (!window.analytics) {
+                return;
+            }
+    
+            var eventAttrs = { "linkName": linkName };
+
+            if (
+                typeof optionalAttrs !== 'undefined' &&
+                optionalAttrs !== null &&
+                Object.keys(optionalAttrs).length > 0
+            ) {
+                var allowedAttrs = ["courseId", "pageName"];
+                allowedAttrs.map(
+                    allowedAttr => eventAttrs[allowedAttr] = optionalAttrs[allowedAttr]
+                );
+            }
+    
+            window.analytics.track("edx.bi.ecommerce.upsell_links_clicked", eventAttrs);
+        };
+        
+        var TrackECommerceEvents = {
+            trackUpsellClick: trackUpsellClick,
+        };
+
+        return TrackECommerceEvents;
+    });
+}).call(this, define || RequireJS.define);

--- a/lms/static/js/commerce/track_ecommerce_events.js
+++ b/lms/static/js/commerce/track_ecommerce_events.js
@@ -6,7 +6,7 @@
 (function(define) {
     'use strict';
     define([], function() {
-        var trackUpsellClick = function(linkName, optionalAttrs) {
+        var trackUpsellClick = function(elt, linkName, optionalAttrs) {
             var eventAttrs = {linkName: linkName};
             var allowedAttrs = ['linkType', 'pageName', 'linkCategory'];
 
@@ -24,7 +24,7 @@
                 });
             }
 
-            window.analytics.track('edx.bi.ecommerce.upsell_links_clicked', eventAttrs);
+            window.analytics.trackLink(elt, 'edx.bi.ecommerce.upsell_links_clicked', eventAttrs);
         };
 
         var TrackECommerceEvents = {trackUpsellClick: trackUpsellClick};

--- a/lms/static/js/commerce/track_ecommerce_events.js
+++ b/lms/static/js/commerce/track_ecommerce_events.js
@@ -8,7 +8,7 @@
     define([], function() {
         var trackUpsellClick = function(linkName, optionalAttrs) {
             var eventAttrs = {linkName: linkName};
-            var allowedAttrs = ['courseId', 'pageName'];
+            var allowedAttrs = ['linkType', 'pageName', 'linkCategory'];
 
             if (!window.analytics) {
                 return;

--- a/lms/static/js/commerce/track_ecommerce_events.js
+++ b/lms/static/js/commerce/track_ecommerce_events.js
@@ -1,39 +1,33 @@
 /**
  *
- * A library of helper functions to track ecommerce related events. 
+ * A library of helper functions to track ecommerce related events.
  *
  */
-
 (function(define) {
     'use strict';
-
-    define([
-        'jquery'
-    ], function($) {
+    define([], function() {
         var trackUpsellClick = function(linkName, optionalAttrs) {
+            var eventAttrs = {linkName: linkName};
+            var allowedAttrs = ['courseId', 'pageName'];
+
             if (!window.analytics) {
                 return;
             }
-    
-            var eventAttrs = { "linkName": linkName };
 
             if (
                 typeof optionalAttrs !== 'undefined' &&
                 optionalAttrs !== null &&
                 Object.keys(optionalAttrs).length > 0
             ) {
-                var allowedAttrs = ["courseId", "pageName"];
-                allowedAttrs.map(function(allowedAttr) {
+                allowedAttrs.forEach(function(allowedAttr) {
                     eventAttrs[allowedAttr] = optionalAttrs[allowedAttr];
                 });
             }
-    
-            window.analytics.track("edx.bi.ecommerce.upsell_links_clicked", eventAttrs);
+
+            window.analytics.track('edx.bi.ecommerce.upsell_links_clicked', eventAttrs);
         };
-        
-        var TrackECommerceEvents = {
-            trackUpsellClick: trackUpsellClick,
-        };
+
+        var TrackECommerceEvents = {trackUpsellClick: trackUpsellClick};
 
         return TrackECommerceEvents;
     });

--- a/lms/templates/dashboard/_dashboard_course_listing.html
+++ b/lms/templates/dashboard/_dashboard_course_listing.html
@@ -411,7 +411,7 @@ from util.course import get_link_for_about_page, get_encoded_course_sharing_utm_
               </p>
               <div class="action-upgrade-container">
                 % if use_ecommerce_payment_flow and course_mode_info['verified_sku']:
-                  <a class="action action-upgrade" href="${ecommerce_payment_page}?sku=${course_mode_info['verified_sku']}">
+                  <a id="ecommerce_upgrade_link" class="action action-upgrade" href="${ecommerce_payment_page}?sku=${course_mode_info['verified_sku']}">
                 % else:
                   <a class="action action-upgrade" href="${reverse('verify_student_upgrade_and_verify', kwargs={'course_id': six.text_type(course_overview.id)})}" data-course-id="${course_overview.id}" data-user="${user.username}">
                 % endif
@@ -453,4 +453,18 @@ from util.course import get_link_for_about_page, get_encoded_course_sharing_utm_
 
 <%static:require_module_async module_name="js/dateutil_factory" class_name="DateUtilFactory">
     DateUtilFactory.transform(iterationKey=".localized-datetime");
+</%static:require_module_async>
+
+
+<%static:require_module_async module_name="js/commerce/track_ecommerce_events" class_name="TrackECommerceEvents">
+  var link = $("#ecommerce_upgrade_link");
+  var event = function() {
+    TrackECommerceEvents.trackUpsellClick('course_dashboard_green', {
+      pageName: "course_dashboard",
+      linkType: "button",
+      linkCategory: "green_upgrade"
+    });
+  }
+
+  link.off('click').on('click', event);
 </%static:require_module_async>

--- a/lms/templates/dashboard/_dashboard_course_listing.html
+++ b/lms/templates/dashboard/_dashboard_course_listing.html
@@ -458,13 +458,12 @@ from util.course import get_link_for_about_page, get_encoded_course_sharing_utm_
 
 <%static:require_module_async module_name="js/commerce/track_ecommerce_events" class_name="TrackECommerceEvents">
   var link = $("#ecommerce_upgrade_link");
-  var event = function() {
+  function trackEvent() {
     TrackECommerceEvents.trackUpsellClick('course_dashboard_green', {
       pageName: "course_dashboard",
       linkType: "button",
       linkCategory: "green_upgrade"
     });
   }
-
-  link.off('click').on('click', event);
+  link.unbind('click.ecommerce_link').bind('click.ecommerce_link', trackEvent);
 </%static:require_module_async>

--- a/lms/templates/dashboard/_dashboard_course_listing.html
+++ b/lms/templates/dashboard/_dashboard_course_listing.html
@@ -455,15 +455,15 @@ from util.course import get_link_for_about_page, get_encoded_course_sharing_utm_
     DateUtilFactory.transform(iterationKey=".localized-datetime");
 </%static:require_module_async>
 
-
 <%static:require_module_async module_name="js/commerce/track_ecommerce_events" class_name="TrackECommerceEvents">
-  var link = $("#ecommerce_upgrade_link");
-  function trackEvent() {
-    TrackECommerceEvents.trackUpsellClick('course_dashboard_green', {
+  if (window.loadedECommerceEvents === undefined) {
+    window.loadedECommerceEvents = true;
+
+    TrackECommerceEvents.trackUpsellClick($("#ecommerce_upgrade_link"), 'course_dashboard_green', {
       pageName: "course_dashboard",
       linkType: "button",
       linkCategory: "green_upgrade"
     });
   }
-  link.unbind('click.ecommerce_link').bind('click.ecommerce_link', trackEvent);
+
 </%static:require_module_async>

--- a/lms/templates/dashboard/_dashboard_course_listing.html
+++ b/lms/templates/dashboard/_dashboard_course_listing.html
@@ -22,6 +22,7 @@ from student.helpers import (
   DISABLE_UNENROLL_CERT_STATES,
 )
 from util.course import get_link_for_about_page, get_encoded_course_sharing_utm_params
+from lms.djangoapps.experiments.utils import UPSELL_TRACKING_FLAG
 %>
 
 <%
@@ -455,15 +456,17 @@ from util.course import get_link_for_about_page, get_encoded_course_sharing_utm_
     DateUtilFactory.transform(iterationKey=".localized-datetime");
 </%static:require_module_async>
 
-<%static:require_module_async module_name="js/commerce/track_ecommerce_events" class_name="TrackECommerceEvents">
-  if (window.loadedECommerceEvents === undefined) {
-    window.loadedECommerceEvents = true;
+% if UPSELL_TRACKING_FLAG.is_enabled():
+    <%static:require_module_async module_name="js/commerce/track_ecommerce_events" class_name="TrackECommerceEvents">
+      if (window.loadedECommerceEvents === undefined) {
+        window.loadedECommerceEvents = true;
 
-    TrackECommerceEvents.trackUpsellClick($("#ecommerce_upgrade_link"), 'course_dashboard_green', {
-      pageName: "course_dashboard",
-      linkType: "button",
-      linkCategory: "green_upgrade"
-    });
-  }
+        TrackECommerceEvents.trackUpsellClick($("#ecommerce_upgrade_link"), 'course_dashboard_green', {
+          pageName: "course_dashboard",
+          linkType: "button",
+          linkCategory: "green_upgrade"
+        });
+      }
 
-</%static:require_module_async>
+    </%static:require_module_async>
+%endif


### PR DESCRIPTION
### What did we do?
1. Create a Javascript function to log upsell events to
2. Attach the eventing to the course dashboard upsell button (see screenshot below)

<img width="837" alt="Screen Shot 2020-06-26 at 12 18 41 PM" src="https://user-images.githubusercontent.com/34042537/85878864-629b7c80-b7a7-11ea-806d-058c3ff1e504.png">

### Why are we doing this?
The revenue squad is looking for more insight into which buttons users are clicking to get to the checkout page.

### Testing
Testing was done locally with `console.log` replacing the analytics call. In the interest of moving this PR forward to unblock the rest of the eventing ticket + this code existing in the old platform frontend that will be moved in the near future anyways, we're opting to not add unit tests.

### Rollout
The JS for the eventing is gated behind a waffle flag, so it should be safe to release + nothing should break as the waffle flag would not exist/default to false and the JS would not show up on the page (to my understanding at least).

1. Merge this PR
2. Add waffle flag in Staging admin
3. Turn on waffle flag in Staging for JJ/Diane - test to make sure we're logging to Segment as intended + no JSEs
4. Turn on waffle flag in Production for JJ/Diane - test to make sure we're logging to Segment as intended + no JSEs 
5. Turn on waffle flag in Production for everyone - wait to make sure no spike in errors
6. Remove waffle flag from code 
7. Remove waffle flag from Staging/Production admin