### PR TITLE
[BD-29] [TNL-7228] Convert InvalidKeyError exception to NotFound

### DIFF
--- a/openedx/core/djangoapps/courseware_api/views.py
+++ b/openedx/core/djangoapps/courseware_api/views.py
@@ -11,7 +11,9 @@ from django.conf import settings
 from django.urls import reverse
 from edx_rest_framework_extensions.auth.jwt.authentication import JwtAuthentication
 from edx_rest_framework_extensions.auth.session.authentication import SessionAuthenticationAllowInactiveUser
+from opaque_keys import InvalidKeyError
 from opaque_keys.edx.keys import CourseKey, UsageKey
+from rest_framework.exceptions import NotFound
 from rest_framework.generics import RetrieveAPIView
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
@@ -332,7 +334,10 @@ class SequenceMetadata(DeveloperErrorViewMixin, APIView):
         """
         Return response to a GET request.
         """
-        usage_key = UsageKey.from_string(usage_key_string)
+        try:
+            usage_key = UsageKey.from_string(usage_key_string)
+        except InvalidKeyError:
+            raise NotFound("Invalid usage key: '{}'.".format(usage_key_string))
 
         sequence, _ = get_module_by_usage_id(
             self.request,


### PR DESCRIPTION
This PR fixes the execption in lms when accessing a blank course via the front-end-learning MFE.

**JIRA tickets**: https://tasks.opencraft.com/browse/BB-2596

**Merge deadline**: ASAP

**Testing instructions**:

1. Bring up a devstack with frontend-app-learning added to the servies (eg, add to DEFAULT_SERVICES) (*NOTE* https://github.com/edx/frontend-app-learning/pull/98 must not be applied as the fixed MFE will not send the invalid URL)
2. Create a course that does not contain any sections
3. Enroll in the course via the old experience (port 18000)
4. When on course info page, click on *View In The New Experience" (if not present, `http://localhost:2000/course/course-v1:<courseid>/` will work (unfixed MFE will redirect to null)
Both with and without this patch an error page is displayed. However, without this patch, the lms server throws an exception. With this patch, no exception is thrown.

**Author notes and concerns**: It appears the full fix for this issue is spread over repositories. This handles the main lms server side of the issue.


**Reviewers**
- [ ] @Agrendalath 
- [ ] edX reviewer[s] TBD
