### PR TITLE
[REV-1226] Temporarily increase default throttle rates for service user

### DIFF
--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -2596,7 +2596,7 @@ REST_FRAMEWORK = {
     'URL_FORMAT_OVERRIDE': None,
     'DEFAULT_THROTTLE_RATES': {
         'user': '60/minute',
-        'service_user': '120/minute',
+        'service_user': '800/minute',
         'registration_validation': '30/minute',
     },
 }


### PR DESCRIPTION
Temporarily increase default throttle rates for service user to handle increased throughput against data sharing consent endpoint

https://openedx.atlassian.net/browse/REV-1226