### PR TITLE
Upgrade lti-consumer-xblock

### DIFF
--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -108,3 +108,9 @@ zipp==1.0.0
 
 # Matplotlib 3.1 requires Python 3.6
 matplotlib<3.1
+
+# numpy 1.19 requires Python 3.6
+numpy<1.19
+
+# scipy 1.5 equires Python 3.6
+scipy<1.5

--- a/requirements/edx-sandbox/py35.txt
+++ b/requirements/edx-sandbox/py35.txt
@@ -20,7 +20,7 @@ matplotlib==2.2.4         # via -c requirements/edx-sandbox/../constraints.txt, 
 mpmath==1.1.0             # via sympy
 networkx==2.2             # via -r requirements/edx-sandbox/py35.in
 nltk==3.5                 # via -r requirements/edx-sandbox/shared.txt, chem
-numpy==1.16.5             # via -r requirements/edx-sandbox/py35.in, chem, matplotlib, openedx-calc, scipy
+numpy==1.16.5             # via -c requirements/edx-sandbox/../constraints.txt, -r requirements/edx-sandbox/py35.in, chem, matplotlib, openedx-calc, scipy
 openedx-calc==1.0.9       # via -r requirements/edx-sandbox/py35.in
 pycparser==2.20           # via -r requirements/edx-sandbox/shared.txt, cffi
 pyparsing==2.2.0          # via -r requirements/edx-sandbox/py35.in, chem, matplotlib, openedx-calc
@@ -28,7 +28,7 @@ python-dateutil==2.4.0    # via -c requirements/edx-sandbox/../constraints.txt, 
 pytz==2020.1              # via matplotlib
 random2==1.0.1            # via -r requirements/edx-sandbox/py35.in
 regex==2020.6.8           # via -r requirements/edx-sandbox/shared.txt, nltk
-scipy==1.2.1              # via -r requirements/edx-sandbox/py35.in, chem, openedx-calc
+scipy==1.2.1              # via -c requirements/edx-sandbox/../constraints.txt, -r requirements/edx-sandbox/py35.in, chem, openedx-calc
 six==1.15.0               # via -r requirements/edx-sandbox/shared.txt, chem, cryptography, cycler, matplotlib, openedx-calc, python-dateutil
 sympy==1.4                # via -r requirements/edx-sandbox/py35.in, symmath
 tqdm==4.47.0              # via -r requirements/edx-sandbox/shared.txt, nltk

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -145,7 +145,7 @@ lazy==1.4                 # via -r requirements/edx/paver.txt, acid-xblock, lti-
 lepl==5.1.3               # via rfc6266-parser
 libsass==0.10.0           # via -r requirements/edx/paver.txt, ora2
 loremipsum==1.0.5         # via ora2
-lti-consumer-xblock==1.4.2  # via -r requirements/edx/base.in
+lti-consumer-xblock==2.0.1.1  # via -r requirements/edx/base.in
 lxml==4.5.0               # via -c requirements/edx/../constraints.txt, -r requirements/edx/../edx-sandbox/shared.txt, capa, edxval, lti-consumer-xblock, ora2, safe-lxml, xblock, xmlsec
 mailsnake==1.6.4          # via -r requirements/edx/base.in
 mako==1.1.3               # via -r requirements/edx/base.in, acid-xblock, lti-consumer-xblock, xblock-google-drive, xblock-utils
@@ -162,7 +162,7 @@ mysqlclient==1.4.6        # via -r requirements/edx/base.in
 newrelic==5.14.1.144      # via -r requirements/edx/base.in, edx-django-utils
 nltk==3.5                 # via -r requirements/edx/../edx-sandbox/shared.txt, chem
 nodeenv==1.4.0            # via -r requirements/edx/base.in
-numpy==1.18.5             # via chem, openedx-calc, scipy
+numpy==1.18.5             # via -c requirements/edx/../constraints.txt, chem, openedx-calc, scipy
 oauthlib==3.0.1           # via -c requirements/edx/../constraints.txt, -r requirements/edx/base.in, django-oauth-toolkit, lti-consumer-xblock, requests-oauthlib, social-auth-core
 openedx-calc==1.0.9       # via -r requirements/edx/base.in
 ora2==2.8.6               # via -r requirements/edx/base.in
@@ -181,10 +181,10 @@ py2neo==3.1.2             # via -r requirements/edx/base.in
 pycontracts==1.8.12       # via -r requirements/edx/base.in, edx-user-state-client
 pycountry==19.8.18        # via -r requirements/edx/base.in
 pycparser==2.20           # via -r requirements/edx/../edx-sandbox/shared.txt, cffi
-pycryptodome==3.9.8       # via pdfminer.six
+pycryptodome==3.9.8       # via lti-consumer-xblock, pdfminer.six
 pycryptodomex==3.9.8      # via -r requirements/edx/base.in, edx-proctoring, pyjwkest
 pygments==2.6.1           # via -r requirements/edx/base.in
-pyjwkest==1.4.2           # via -r requirements/edx/base.in, edx-drf-extensions
+pyjwkest==1.4.2           # via -r requirements/edx/base.in, edx-drf-extensions, lti-consumer-xblock
 pyjwt==1.5.2              # via -r requirements/edx/base.in, drf-jwt, edx-rest-api-client, social-auth-core
 pymongo==3.10.1           # via -r requirements/edx/base.in, -r requirements/edx/paver.txt, edx-opaque-keys, event-tracking, mongodbproxy, mongoengine
 pynliner==0.8.0           # via -r requirements/edx/base.in
@@ -213,7 +213,7 @@ ruamel.yaml==0.16.10      # via drf-yasg
 rules==2.2                # via -r requirements/edx/base.in, edx-enterprise, edx-proctoring
 s3transfer==0.1.13        # via boto3
 sailthru-client==2.2.3    # via -r requirements/edx/base.in, edx-ace
-scipy==1.4.1              # via chem, openedx-calc
+scipy==1.4.1              # via -c requirements/edx/../constraints.txt, chem, openedx-calc
 semantic-version==2.8.5   # via edx-drf-extensions
 shapely==1.7.0            # via -r requirements/edx/base.in
 simplejson==3.17.0        # via -r requirements/edx/base.in, sailthru-client, super-csv, xblock-utils

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -176,7 +176,7 @@ lazy==1.4                 # via -r requirements/edx/testing.txt, acid-xblock, bo
 lepl==5.1.3               # via -r requirements/edx/testing.txt, rfc6266-parser
 libsass==0.10.0           # via -r requirements/edx/testing.txt, ora2
 loremipsum==1.0.5         # via -r requirements/edx/testing.txt, ora2
-lti-consumer-xblock==1.4.2  # via -r requirements/edx/testing.txt
+lti-consumer-xblock==2.0.1.1  # via -r requirements/edx/testing.txt
 lxml==4.5.0               # via -c requirements/edx/../constraints.txt, -r requirements/edx/testing.txt, capa, edxval, lti-consumer-xblock, ora2, pyquery, safe-lxml, xblock, xmlsec
 m2r==0.2.1                # via sphinxcontrib-openapi
 mailsnake==1.6.4          # via -r requirements/edx/testing.txt
@@ -197,7 +197,7 @@ mysqlclient==1.4.6        # via -r requirements/edx/testing.txt
 newrelic==5.14.1.144      # via -r requirements/edx/testing.txt, edx-django-utils
 nltk==3.5                 # via -r requirements/edx/testing.txt, chem
 nodeenv==1.4.0            # via -r requirements/edx/testing.txt
-numpy==1.18.5             # via -r requirements/edx/testing.txt, chem, openedx-calc, scipy
+numpy==1.18.5             # via -c requirements/edx/../constraints.txt, -r requirements/edx/testing.txt, chem, openedx-calc, scipy
 oauthlib==3.0.1           # via -c requirements/edx/../constraints.txt, -r requirements/edx/testing.txt, django-oauth-toolkit, lti-consumer-xblock, requests-oauthlib, social-auth-core
 openedx-calc==1.0.9       # via -r requirements/edx/testing.txt
 ora2==2.8.6               # via -r requirements/edx/testing.txt
@@ -221,11 +221,11 @@ pycodestyle==2.6.0        # via -r requirements/edx/testing.txt, flake8
 pycontracts==1.8.12       # via -r requirements/edx/testing.txt, edx-user-state-client
 pycountry==19.8.18        # via -r requirements/edx/testing.txt
 pycparser==2.20           # via -r requirements/edx/testing.txt, cffi
-pycryptodome==3.9.8       # via -r requirements/edx/testing.txt, pdfminer.six
+pycryptodome==3.9.8       # via -r requirements/edx/testing.txt, lti-consumer-xblock, pdfminer.six
 pycryptodomex==3.9.8      # via -r requirements/edx/testing.txt, edx-proctoring, pyjwkest
 pyflakes==2.2.0           # via -r requirements/edx/testing.txt, flake8
 pygments==2.6.1           # via -r requirements/edx/testing.txt, diff-cover, sphinx
-pyjwkest==1.4.2           # via -r requirements/edx/testing.txt, edx-drf-extensions
+pyjwkest==1.4.2           # via -r requirements/edx/testing.txt, edx-drf-extensions, lti-consumer-xblock
 pyjwt==1.5.2              # via -r requirements/edx/testing.txt, drf-jwt, edx-rest-api-client, social-auth-core
 pylint-celery==0.3        # via -r requirements/edx/testing.txt, edx-lint
 pylint-django==2.0.11     # via -r requirements/edx/testing.txt, edx-lint
@@ -271,7 +271,7 @@ ruamel.yaml==0.16.10      # via -r requirements/edx/testing.txt, drf-yasg
 rules==2.2                # via -r requirements/edx/testing.txt, edx-enterprise, edx-proctoring
 s3transfer==0.1.13        # via -r requirements/edx/testing.txt, boto3
 sailthru-client==2.2.3    # via -r requirements/edx/testing.txt, edx-ace
-scipy==1.4.1              # via -r requirements/edx/testing.txt, chem, openedx-calc
+scipy==1.4.1              # via -c requirements/edx/../constraints.txt, -r requirements/edx/testing.txt, chem, openedx-calc
 selenium==3.141.0         # via -r requirements/edx/testing.txt, bok-choy
 semantic-version==2.8.5   # via -r requirements/edx/testing.txt, edx-drf-extensions
 shapely==1.7.0            # via -r requirements/edx/testing.txt
@@ -304,7 +304,7 @@ testfixtures==6.14.1      # via -r requirements/edx/testing.txt, edx-enterprise
 text-unidecode==1.3       # via -r requirements/edx/testing.txt, faker, python-slugify
 toml==0.10.1              # via -r requirements/edx/testing.txt, tox
 tox-battery==0.6.1        # via -r requirements/edx/testing.txt
-tox==3.16.0               # via -r requirements/edx/testing.txt, tox-battery
+tox==3.16.1               # via -r requirements/edx/testing.txt, tox-battery
 tqdm==4.47.0              # via -r requirements/edx/testing.txt, nltk
 transifex-client==0.13.10  # via -r requirements/edx/testing.txt
 typed-ast==1.4.1          # via -r requirements/edx/testing.txt, astroid

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -170,7 +170,7 @@ lazy==1.4                 # via -r requirements/edx/base.txt, acid-xblock, bok-c
 lepl==5.1.3               # via -r requirements/edx/base.txt, rfc6266-parser
 libsass==0.10.0           # via -r requirements/edx/base.txt, ora2
 loremipsum==1.0.5         # via -r requirements/edx/base.txt, ora2
-lti-consumer-xblock==1.4.2  # via -r requirements/edx/base.txt
+lti-consumer-xblock==2.0.1.1  # via -r requirements/edx/base.txt
 lxml==4.5.0               # via -c requirements/edx/../constraints.txt, -r requirements/edx/base.txt, capa, edxval, lti-consumer-xblock, ora2, pyquery, safe-lxml, xblock, xmlsec
 mailsnake==1.6.4          # via -r requirements/edx/base.txt
 mako==1.1.3               # via -r requirements/edx/base.txt, acid-xblock, lti-consumer-xblock, xblock-google-drive, xblock-utils
@@ -189,7 +189,7 @@ mysqlclient==1.4.6        # via -r requirements/edx/base.txt
 newrelic==5.14.1.144      # via -r requirements/edx/base.txt, edx-django-utils
 nltk==3.5                 # via -r requirements/edx/base.txt, chem
 nodeenv==1.4.0            # via -r requirements/edx/base.txt
-numpy==1.18.5             # via -r requirements/edx/base.txt, chem, openedx-calc, scipy
+numpy==1.18.5             # via -c requirements/edx/../constraints.txt, -r requirements/edx/base.txt, chem, openedx-calc, scipy
 oauthlib==3.0.1           # via -c requirements/edx/../constraints.txt, -r requirements/edx/base.txt, django-oauth-toolkit, lti-consumer-xblock, requests-oauthlib, social-auth-core
 openedx-calc==1.0.9       # via -r requirements/edx/base.txt
 ora2==2.8.6               # via -r requirements/edx/base.txt
@@ -212,11 +212,11 @@ pycodestyle==2.6.0        # via -r requirements/edx/testing.in, flake8
 pycontracts==1.8.12       # via -r requirements/edx/base.txt, edx-user-state-client
 pycountry==19.8.18        # via -r requirements/edx/base.txt
 pycparser==2.20           # via -r requirements/edx/base.txt, cffi
-pycryptodome==3.9.8       # via -r requirements/edx/base.txt, pdfminer.six
+pycryptodome==3.9.8       # via -r requirements/edx/base.txt, lti-consumer-xblock, pdfminer.six
 pycryptodomex==3.9.8      # via -r requirements/edx/base.txt, edx-proctoring, pyjwkest
 pyflakes==2.2.0           # via flake8
 pygments==2.6.1           # via -r requirements/edx/base.txt, -r requirements/edx/coverage.txt, diff-cover
-pyjwkest==1.4.2           # via -r requirements/edx/base.txt, edx-drf-extensions
+pyjwkest==1.4.2           # via -r requirements/edx/base.txt, edx-drf-extensions, lti-consumer-xblock
 pyjwt==1.5.2              # via -r requirements/edx/base.txt, drf-jwt, edx-rest-api-client, social-auth-core
 pylint-celery==0.3        # via edx-lint
 pylint-django==2.0.11     # via edx-lint
@@ -260,7 +260,7 @@ ruamel.yaml==0.16.10      # via -r requirements/edx/base.txt, drf-yasg
 rules==2.2                # via -r requirements/edx/base.txt, edx-enterprise, edx-proctoring
 s3transfer==0.1.13        # via -r requirements/edx/base.txt, boto3
 sailthru-client==2.2.3    # via -r requirements/edx/base.txt, edx-ace
-scipy==1.4.1              # via -r requirements/edx/base.txt, chem, openedx-calc
+scipy==1.4.1              # via -c requirements/edx/../constraints.txt, -r requirements/edx/base.txt, chem, openedx-calc
 selenium==3.141.0         # via -r requirements/edx/testing.in, bok-choy
 semantic-version==2.8.5   # via -r requirements/edx/base.txt, edx-drf-extensions
 shapely==1.7.0            # via -r requirements/edx/base.txt
@@ -283,7 +283,7 @@ testfixtures==6.14.1      # via -r requirements/edx/base.txt, -r requirements/ed
 text-unidecode==1.3       # via -r requirements/edx/base.txt, faker, python-slugify
 toml==0.10.1              # via tox
 tox-battery==0.6.1        # via -r requirements/edx/testing.in
-tox==3.16.0               # via -r requirements/edx/testing.in, tox-battery
+tox==3.16.1               # via -r requirements/edx/testing.in, tox-battery
 tqdm==4.47.0              # via -r requirements/edx/base.txt, nltk
 transifex-client==0.13.10  # via -r requirements/edx/testing.in
 typed-ast==1.4.1          # via astroid


### PR DESCRIPTION
This adds support for LTI 1.3
To enable it, set `settings.FEATURES['LTI_1P3_ENABLED'] = True`

