### PR TITLE
Pin edx-enterprise until bug in new releases is fixed ARCHBOM-1324

### DIFF
--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -40,6 +40,9 @@ drf-yasg<1.17.1
 # drf-jwt 1.15.0 contains a migration that breaks on MySQL: https://github.com/Styria-Digital/django-rest-framework-jwt/issues/40
 drf-jwt==1.14.0
 
+# 3.3.15 is failing with `AttributeError: 'Settings' object has no attribute 'COURSE_CATALOG_URL_ROOT'`
+edx-enterprise==3.3.13
+
 # Upgrading to 2.12.0 breaks several test classes due to API changes, need to update our code accordingly
 factory-boy==2.8.1
 

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -40,6 +40,9 @@ drf-yasg<1.17.1
 # drf-jwt 1.15.0 contains a migration that breaks on MySQL: https://github.com/Styria-Digital/django-rest-framework-jwt/issues/40
 drf-jwt==1.14.0
 
+# Tests are failing with 3.2.2: https://build.testeng.edx.org/job/edx-platform-python-pipeline-pr/19138/
+edx-completion==3.2.1
+
 # 3.3.15 is failing with `AttributeError: 'Settings' object has no attribute 'COURSE_CATALOG_URL_ROOT'`
 edx-enterprise==3.3.13
 

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -93,13 +93,13 @@ edx-analytics-data-api-client==0.16.1  # via -r requirements/edx/base.in
 edx-api-doc-tools==1.3.1  # via -r requirements/edx/base.in
 edx-bulk-grades==0.7.0    # via -r requirements/edx/base.in, staff-graded-xblock
 edx-ccx-keys==1.1.0       # via -r requirements/edx/base.in
-edx-celeryutils==0.5.0    # via -r requirements/edx/base.in, super-csv
-edx-completion==3.2.1     # via -r requirements/edx/base.in
+edx-celeryutils==0.5.1    # via -r requirements/edx/base.in, super-csv
+edx-completion==3.2.2     # via -r requirements/edx/base.in
 edx-django-release-util==0.4.4  # via -r requirements/edx/base.in
 edx-django-sites-extensions==2.5.1  # via -r requirements/edx/base.in
 edx-django-utils==3.2.3   # via -r requirements/edx/base.in, django-config-models, edx-drf-extensions, edx-enterprise, edx-rest-api-client, edx-when
 edx-drf-extensions==6.1.0  # via -r requirements/edx/base.in, edx-completion, edx-enterprise, edx-organizations, edx-proctoring, edx-rbac, edx-when, edxval
-edx-enterprise==3.3.13    # via -r requirements/edx/base.in
+edx-enterprise==3.3.13    # via -c requirements/edx/../constraints.txt, -r requirements/edx/base.in
 edx-i18n-tools==0.5.3     # via ora2
 edx-milestones==0.3.0     # via -r requirements/edx/base.in
 edx-opaque-keys[django]==2.1.0  # via -r requirements/edx/paver.txt, edx-bulk-grades, edx-ccx-keys, edx-completion, edx-drf-extensions, edx-enterprise, edx-milestones, edx-organizations, edx-proctoring, edx-user-state-client, edx-when, xmodule

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -94,7 +94,7 @@ edx-api-doc-tools==1.3.1  # via -r requirements/edx/base.in
 edx-bulk-grades==0.7.0    # via -r requirements/edx/base.in, staff-graded-xblock
 edx-ccx-keys==1.1.0       # via -r requirements/edx/base.in
 edx-celeryutils==0.5.1    # via -r requirements/edx/base.in, super-csv
-edx-completion==3.2.2     # via -r requirements/edx/base.in
+edx-completion==3.2.1     # via -c requirements/edx/../constraints.txt, -r requirements/edx/base.in
 edx-django-release-util==0.4.4  # via -r requirements/edx/base.in
 edx-django-sites-extensions==2.5.1  # via -r requirements/edx/base.in
 edx-django-utils==3.2.3   # via -r requirements/edx/base.in, django-config-models, edx-drf-extensions, edx-enterprise, edx-rest-api-client, edx-when

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -105,15 +105,15 @@ edx-analytics-data-api-client==0.16.1  # via -r requirements/edx/testing.txt
 edx-api-doc-tools==1.3.1  # via -r requirements/edx/testing.txt
 edx-bulk-grades==0.7.0    # via -r requirements/edx/testing.txt, staff-graded-xblock
 edx-ccx-keys==1.1.0       # via -r requirements/edx/testing.txt
-edx-celeryutils==0.5.0    # via -r requirements/edx/testing.txt, super-csv
-edx-completion==3.2.1     # via -r requirements/edx/testing.txt
+edx-celeryutils==0.5.1    # via -r requirements/edx/testing.txt, super-csv
+edx-completion==3.2.2     # via -r requirements/edx/testing.txt
 edx-django-release-util==0.4.4  # via -r requirements/edx/testing.txt
 edx-django-sites-extensions==2.5.1  # via -r requirements/edx/testing.txt
 edx-django-utils==3.2.3   # via -r requirements/edx/testing.txt, django-config-models, edx-drf-extensions, edx-enterprise, edx-rest-api-client, edx-when
 edx-drf-extensions==6.1.0  # via -r requirements/edx/testing.txt, edx-completion, edx-enterprise, edx-organizations, edx-proctoring, edx-rbac, edx-when, edxval
-edx-enterprise==3.3.13    # via -r requirements/edx/testing.txt
+edx-enterprise==3.3.13    # via -c requirements/edx/../constraints.txt, -r requirements/edx/testing.txt
 edx-i18n-tools==0.5.3     # via -r requirements/edx/testing.txt, ora2
-edx-lint==1.4.1           # via -r requirements/edx/testing.txt
+edx-lint==1.5.0           # via -r requirements/edx/testing.txt
 edx-milestones==0.3.0     # via -r requirements/edx/testing.txt
 edx-opaque-keys[django]==2.1.0  # via -r requirements/edx/testing.txt, edx-bulk-grades, edx-ccx-keys, edx-completion, edx-drf-extensions, edx-enterprise, edx-milestones, edx-organizations, edx-proctoring, edx-user-state-client, edx-when, xmodule
 edx-organizations==5.2.0  # via -r requirements/edx/testing.txt
@@ -230,7 +230,7 @@ pyjwt==1.5.2              # via -r requirements/edx/testing.txt, drf-jwt, edx-re
 pylint-celery==0.3        # via -r requirements/edx/testing.txt, edx-lint
 pylint-django==2.0.11     # via -r requirements/edx/testing.txt, edx-lint
 pylint-plugin-utils==0.6  # via -r requirements/edx/testing.txt, pylint-celery, pylint-django
-pylint==2.4.2             # via -r requirements/edx/testing.txt, edx-lint, pylint-celery, pylint-django, pylint-plugin-utils
+pylint==2.4.4             # via -r requirements/edx/testing.txt, edx-lint, pylint-celery, pylint-django, pylint-plugin-utils
 pymongo==3.10.1           # via -r requirements/edx/testing.txt, edx-opaque-keys, event-tracking, mongodbproxy, mongoengine
 pynliner==0.8.0           # via -r requirements/edx/testing.txt
 pyparsing==2.4.7          # via -r requirements/edx/testing.txt, chem, openedx-calc, packaging, pycontracts
@@ -310,7 +310,7 @@ transifex-client==0.13.10  # via -r requirements/edx/testing.txt
 typed-ast==1.4.1          # via -r requirements/edx/testing.txt, astroid
 ua-parser==0.10.0         # via -r requirements/edx/testing.txt, django-cookies-samesite
 unicodecsv==0.14.1        # via -r requirements/edx/testing.txt, edx-enterprise
-unidiff==0.6.0            # via -r requirements/edx/testing.txt
+unidiff==0.6.0            # via -r requirements/edx/testing.txt, coverage-pytest-plugin
 uritemplate==3.0.1        # via -r requirements/edx/testing.txt, coreapi, drf-yasg
 urllib3==1.25.9           # via -r requirements/edx/testing.txt, elasticsearch, geoip2, requests, selenium, transifex-client
 user-util==0.2            # via -r requirements/edx/testing.txt

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -106,7 +106,7 @@ edx-api-doc-tools==1.3.1  # via -r requirements/edx/testing.txt
 edx-bulk-grades==0.7.0    # via -r requirements/edx/testing.txt, staff-graded-xblock
 edx-ccx-keys==1.1.0       # via -r requirements/edx/testing.txt
 edx-celeryutils==0.5.1    # via -r requirements/edx/testing.txt, super-csv
-edx-completion==3.2.2     # via -r requirements/edx/testing.txt
+edx-completion==3.2.1     # via -c requirements/edx/../constraints.txt, -r requirements/edx/testing.txt
 edx-django-release-util==0.4.4  # via -r requirements/edx/testing.txt
 edx-django-sites-extensions==2.5.1  # via -r requirements/edx/testing.txt
 edx-django-utils==3.2.3   # via -r requirements/edx/testing.txt, django-config-models, edx-drf-extensions, edx-enterprise, edx-rest-api-client, edx-when

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -102,15 +102,15 @@ edx-analytics-data-api-client==0.16.1  # via -r requirements/edx/base.txt
 edx-api-doc-tools==1.3.1  # via -r requirements/edx/base.txt
 edx-bulk-grades==0.7.0    # via -r requirements/edx/base.txt, staff-graded-xblock
 edx-ccx-keys==1.1.0       # via -r requirements/edx/base.txt
-edx-celeryutils==0.5.0    # via -r requirements/edx/base.txt, super-csv
-edx-completion==3.2.1     # via -r requirements/edx/base.txt
+edx-celeryutils==0.5.1    # via -r requirements/edx/base.txt, super-csv
+edx-completion==3.2.2     # via -r requirements/edx/base.txt
 edx-django-release-util==0.4.4  # via -r requirements/edx/base.txt
 edx-django-sites-extensions==2.5.1  # via -r requirements/edx/base.txt
 edx-django-utils==3.2.3   # via -r requirements/edx/base.txt, django-config-models, edx-drf-extensions, edx-enterprise, edx-rest-api-client, edx-when
 edx-drf-extensions==6.1.0  # via -r requirements/edx/base.txt, edx-completion, edx-enterprise, edx-organizations, edx-proctoring, edx-rbac, edx-when, edxval
-edx-enterprise==3.3.13    # via -r requirements/edx/base.txt
+edx-enterprise==3.3.13    # via -c requirements/edx/../constraints.txt, -r requirements/edx/base.txt
 edx-i18n-tools==0.5.3     # via -r requirements/edx/base.txt, -r requirements/edx/testing.in, ora2
-edx-lint==1.4.1           # via -r requirements/edx/testing.in
+edx-lint==1.5.0           # via -r requirements/edx/testing.in
 edx-milestones==0.3.0     # via -r requirements/edx/base.txt
 edx-opaque-keys[django]==2.1.0  # via -r requirements/edx/base.txt, edx-bulk-grades, edx-ccx-keys, edx-completion, edx-drf-extensions, edx-enterprise, edx-milestones, edx-organizations, edx-proctoring, edx-user-state-client, edx-when, xmodule
 edx-organizations==5.2.0  # via -r requirements/edx/base.txt
@@ -221,7 +221,7 @@ pyjwt==1.5.2              # via -r requirements/edx/base.txt, drf-jwt, edx-rest-
 pylint-celery==0.3        # via edx-lint
 pylint-django==2.0.11     # via edx-lint
 pylint-plugin-utils==0.6  # via pylint-celery, pylint-django
-pylint==2.4.2             # via edx-lint, pylint-celery, pylint-django, pylint-plugin-utils
+pylint==2.4.4             # via edx-lint, pylint-celery, pylint-django, pylint-plugin-utils
 pymongo==3.10.1           # via -r requirements/edx/base.txt, edx-opaque-keys, event-tracking, mongodbproxy, mongoengine
 pynliner==0.8.0           # via -r requirements/edx/base.txt
 pyparsing==2.4.7          # via -r requirements/edx/base.txt, chem, openedx-calc, packaging, pycontracts
@@ -289,7 +289,7 @@ transifex-client==0.13.10  # via -r requirements/edx/testing.in
 typed-ast==1.4.1          # via astroid
 ua-parser==0.10.0         # via -r requirements/edx/base.txt, django-cookies-samesite
 unicodecsv==0.14.1        # via -r requirements/edx/base.txt, edx-enterprise
-unidiff==0.6.0            # via -r requirements/edx/testing.in
+unidiff==0.6.0            # via -r requirements/edx/testing.in, coverage-pytest-plugin
 uritemplate==3.0.1        # via -r requirements/edx/base.txt, coreapi, drf-yasg
 urllib3==1.25.9           # via -r requirements/edx/base.txt, elasticsearch, geoip2, requests, selenium, transifex-client
 user-util==0.2            # via -r requirements/edx/base.txt

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -103,7 +103,7 @@ edx-api-doc-tools==1.3.1  # via -r requirements/edx/base.txt
 edx-bulk-grades==0.7.0    # via -r requirements/edx/base.txt, staff-graded-xblock
 edx-ccx-keys==1.1.0       # via -r requirements/edx/base.txt
 edx-celeryutils==0.5.1    # via -r requirements/edx/base.txt, super-csv
-edx-completion==3.2.2     # via -r requirements/edx/base.txt
+edx-completion==3.2.1     # via -c requirements/edx/../constraints.txt, -r requirements/edx/base.txt
 edx-django-release-util==0.4.4  # via -r requirements/edx/base.txt
 edx-django-sites-extensions==2.5.1  # via -r requirements/edx/base.txt
 edx-django-utils==3.2.3   # via -r requirements/edx/base.txt, django-config-models, edx-drf-extensions, edx-enterprise, edx-rest-api-client, edx-when


### PR DESCRIPTION
The new releases end up importing code in Studio that relies on an LMS-only setting.  Pinning until resolved.

Also pinning edx-completion until the test failures in https://github.com/edx/edx-platform/pull/24365 get resolved.