### PR TITLE
[BD-10] [DEPR-73] Remove pattern library of learner_achievements.

### DIFF
--- a/openedx/features/learner_profile/views/learner_achievements.py
+++ b/openedx/features/learner_profile/views/learner_achievements.py
@@ -16,6 +16,8 @@ class LearnerAchievementsFragmentView(EdxFragmentView):
     """
     A fragment to render a learner's achievements.
     """
+    _uses_pattern_library = False
+
     def render_to_fragment(self, request, username=None, own_profile=False, **kwargs):
         """
         Renders the current learner's achievements.


### PR DESCRIPTION
@abutterworth
Ticket on jira: https://openedx.atlassian.net/browse/DEPR-73
Remove use of pattern library of openedx/features/learner_profile/views/learner_achievements.py
the URL test would be /u/achievements but loads first the profile page: https://github.com/edx/edx-platform/blob/master/openedx/features/learner_profile/urls.py#L14
So to test it, I change the order. But even if I see the achievements on the profile page, the achievements page is empty. The only thing I could test was the change of the style sheet. 
You said to leave it for now so I remove the pattern library due to using EdxFragmentView.

