### PR TITLE
Juniper: Downgrade pycontracts to 1.8.12

### DIFF
--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -182,7 +182,7 @@ pkgconfig==1.5.1          # via xmlsec
 polib==1.1.0              # via edx-i18n-tools
 psutil==1.2.1             # via -r requirements/edx/paver.txt, edx-django-utils
 py2neo==3.1.2             # via -r requirements/edx/base.in
-pycontracts==1.8.14       # via -r requirements/edx/base.in, edx-user-state-client
+pycontracts==1.8.12       # via -r requirements/edx/base.in, edx-user-state-client
 pycountry==19.8.18        # via -r requirements/edx/base.in
 pycparser==2.20           # via -r requirements/edx/../edx-sandbox/shared.txt, cffi
 pycryptodome==3.9.7       # via pdfminer.six

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -221,7 +221,7 @@ psutil==1.2.1             # via -r requirements/edx/testing.txt, edx-django-util
 py2neo==3.1.2             # via -r requirements/edx/testing.txt
 py==1.8.1                 # via -r requirements/edx/testing.txt, pytest, tox
 pycodestyle==2.6.0        # via -r requirements/edx/testing.txt, flake8
-pycontracts==1.8.14       # via -r requirements/edx/testing.txt, edx-user-state-client
+pycontracts==1.8.12       # via -r requirements/edx/testing.txt, edx-user-state-client
 pycountry==19.8.18        # via -r requirements/edx/testing.txt
 pycparser==2.20           # via -r requirements/edx/testing.txt, cffi
 pycryptodome==3.9.7       # via -r requirements/edx/testing.txt, pdfminer.six

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -212,7 +212,7 @@ psutil==1.2.1             # via -r requirements/edx/base.txt, edx-django-utils
 py2neo==3.1.2             # via -r requirements/edx/base.txt
 py==1.8.1                 # via pytest, tox
 pycodestyle==2.6.0        # via -r requirements/edx/testing.in, flake8
-pycontracts==1.8.14       # via -r requirements/edx/base.txt, edx-user-state-client
+pycontracts==1.8.12       # via -r requirements/edx/base.txt, edx-user-state-client
 pycountry==19.8.18        # via -r requirements/edx/base.txt
 pycparser==2.20           # via -r requirements/edx/base.txt, cffi
 pycryptodome==3.9.7       # via -r requirements/edx/base.txt, pdfminer.six


### PR DESCRIPTION
They seem to have removed 1.8.14 from pypi.

Cherrypick from https://github.com/edx/edx-platform/pull/24351