### PR TITLE
Patch IDV emails approved

### DIFF
--- a/lms/djangoapps/verify_student/views.py
+++ b/lms/djangoapps/verify_student/views.py
@@ -1155,7 +1155,7 @@ def results_callback(request):
         )
 
         if use_new_templates_for_id_verification_emails():
-            context = {'user_id': user, 'expiry_date': expiry_date.strftime("%m/%d/%Y")}
+            context = {'user': user, 'expiry_date': expiry_date.strftime("%m/%d/%Y")}
             send_verification_approved_email(context=context)
         else:
             verification_status_email_vars['expiry_date'] = expiry_date.strftime("%m/%d/%Y")


### PR DESCRIPTION
[send_verification_approved_email](https://github.com/edx/edx-platform/blob/master/lms/djangoapps/verify_student/emails.py#L47) accepts `user` in its context. so this PR changes they `user_id` to `user`. 

https://rpm.newrelic.com/accounts/88178/applications/3343327/filterable_errors#/show/1e49dc28-bc47-11ea-87aa-0242ac11000b_8076_15834/stack_trace?top_facet=transactionUiName&primary_facet=error.class&barchart=barchart

https://github.com/edx/edx-platform/pull/24254