### PR TITLE
Turn on enterprise integration in devstack settings.

### DIFF
--- a/lms/envs/devstack.py
+++ b/lms/envs/devstack.py
@@ -362,15 +362,14 @@ CREDENTIALS_SERVICE_USERNAME = 'credentials_worker'
 COURSE_CATALOG_URL_ROOT = 'http://edx.devstack.discovery:18381'
 COURSE_CATALOG_API_URL = '{}/api/v1'.format(COURSE_CATALOG_URL_ROOT)
 
-# Uncomment the lines below if you'd like to see SQL statements in your devstack LMS log.
-# LOGGING['handlers']['console']['level'] = 'DEBUG'
-# LOGGING['loggers']['django.db.backends'] = {'handlers': ['console'], 'level': 'DEBUG', 'propagate': False}
-
+# Enable enterprise integration so that we can include enterprise System-wide
+# role logic without having to manipulate private settings.
+FEATURES['ENABLE_ENTERPRISE_INTEGRATION'] = True
 SYSTEM_WIDE_ROLE_CLASSES = os.environ.get("SYSTEM_WIDE_ROLE_CLASSES", SYSTEM_WIDE_ROLE_CLASSES)
-SYSTEM_WIDE_ROLE_CLASSES.extend(['system_wide_roles.SystemWideRoleAssignment'])
-
-if FEATURES['ENABLE_ENTERPRISE_INTEGRATION']:
-    SYSTEM_WIDE_ROLE_CLASSES.extend(['enterprise.SystemWideEnterpriseUserRoleAssignment'])
+SYSTEM_WIDE_ROLE_CLASSES.extend([
+    'system_wide_roles.SystemWideRoleAssignment',
+    'enterprise.SystemWideEnterpriseUserRoleAssignment',
+])
 
 # List of enterprise customer uuids to exclude from transition to use of enterprise-catalog
 ENTERPRISE_CUSTOMERS_EXCLUDED_FROM_CATALOG = ()
@@ -398,3 +397,7 @@ if os.path.isfile(join(dirname(abspath(__file__)), 'private.py')):
 # ]
 # TEMPLATES[1]["DIRS"] = _make_mako_template_dirs
 # derive_settings(__name__)
+
+# Uncomment the lines below if you'd like to see SQL statements in your devstack LMS log.
+# LOGGING['handlers']['console']['level'] = 'DEBUG'
+# LOGGING['loggers']['django.db.backends'] = {'handlers': ['console'], 'level': 'DEBUG', 'propagate': False}


### PR DESCRIPTION
We are first-class citizens, and we demand respect! :p

Primary outcome of this PR: enterprise devs no longer have to include logic in their `private.py` settings files to include an important class that dictates whether roles are transferred between systems in JWTs.