### PR TITLE
AA-225: Only consider scored items for past due assignments

### DIFF
--- a/common/lib/xmodule/xmodule/vertical_block.py
+++ b/common/lib/xmodule/xmodule/vertical_block.py
@@ -91,8 +91,8 @@ class VerticalBlock(SequenceFields, XModuleFields, StudioEditableBlock, XmlParse
                 'content': rendered_child.content
             })
 
-        completed = completion_service and completion_service.vertical_is_complete(self)
-        past_due = not completed and self.due and self.due < datetime.now(pytz.UTC)
+        completed = self.is_block_complete_for_assignments(completion_service)
+        past_due = completed is False and self.due and self.due < datetime.now(pytz.UTC)
         fragment_context = {
             'items': contents,
             'xblock_context': context,
@@ -224,3 +224,40 @@ class VerticalBlock(SequenceFields, XModuleFields, StudioEditableBlock, XmlParse
         xblock_body["content_type"] = "Sequence"
 
         return xblock_body
+
+    # So far, we only need this here. Move it somewhere more sensible if other bits of code want it too.
+    def is_block_complete_for_assignments(self, completion_service):
+        """
+        Considers a block complete only if all scored & graded leaf blocks are complete.
+
+        This is different from the normal `complete` flag because children of the block that are informative (like
+        readings or videos) do not count. We only care about actual homework content.
+
+        Compare with is_block_structure_complete_for_assignments in course_experience/utils.py, which does the same
+        calculation, but for a BlockStructure node and its children.
+
+        Returns:
+            True if complete
+            False if not
+            None if no assignments present or no completion info present (don't show any past-due or complete info)
+        """
+        if not completion_service or not completion_service.completion_tracking_enabled():
+            return None
+
+        children = completion_service.get_completable_children(self)
+        children_locations = [child.scope_ids.usage_id for child in children]
+        completions = completion_service.get_completions(children_locations)
+
+        all_complete = None
+        for child in children:
+            complete = completions[child.scope_ids.usage_id] == 1
+            graded = getattr(child, 'graded', False)
+            has_score = getattr(child, 'has_score', False)
+            weight = getattr(child, 'weight', 1)
+            scored = has_score and (weight is None or weight > 0)
+            if graded and scored:
+                if not complete:
+                    return False
+                all_complete = True
+
+        return all_complete

--- a/lms/djangoapps/courseware/courses.py
+++ b/lms/djangoapps/courseware/courses.py
@@ -3,7 +3,6 @@ Functions for accessing and displaying courses within the
 courseware.
 """
 
-
 import logging
 from collections import defaultdict, namedtuple
 from datetime import datetime
@@ -12,7 +11,6 @@ import pytz
 import six
 from crum import get_current_request
 from django.conf import settings
-from django.db.models import Prefetch
 from django.http import Http404, QueryDict
 from django.urls import reverse
 from django.utils.translation import ugettext as _
@@ -25,7 +23,6 @@ from six import text_type
 from openedx.core.lib.cache_utils import request_cached
 
 import branding
-from course_modes.models import CourseMode
 from lms.djangoapps.courseware.access import has_access
 from lms.djangoapps.courseware.access_response import (
     AuthenticationRequiredAccessError,
@@ -60,6 +57,7 @@ from openedx.core.djangoapps.site_configuration import helpers as configuration_
 from openedx.core.lib.api.view_utils import LazySequence
 from openedx.features.course_duration_limits.access import AuditExpiredError
 from openedx.features.course_experience import RELATIVE_DATES_FLAG
+from openedx.features.course_experience.utils import is_block_structure_complete_for_assignments
 from static_replace import replace_static_urls
 from survey.utils import SurveyRequiredAccessError, check_survey_required_and_unanswered
 from util.date_utils import strftime_localized
@@ -550,7 +548,7 @@ def get_course_assignments(course_key, user, include_access=False):
             if assignment_released:
                 url = reverse('jump_to', args=[course_key, subsection_key])
 
-            complete = block_data.get_xblock_field(subsection_key, 'complete', False)
+            complete = is_block_structure_complete_for_assignments(block_data, subsection_key)
             past_due = not complete and due < now
             assignments.append(_Assignment(
                 subsection_key, title, url, due, contains_gated_content, complete, past_due, assignment_type

--- a/lms/djangoapps/courseware/tests/test_courses.py
+++ b/lms/djangoapps/courseware/tests/test_courses.py
@@ -11,6 +11,8 @@ import ddt
 import mock
 import pytz
 import six
+from completion.models import BlockCompletion
+from completion.test_utils import CompletionWaffleTestMixin
 from crum import set_current_request
 from django.conf import settings
 from django.test.client import RequestFactory
@@ -25,6 +27,7 @@ from lms.djangoapps.courseware.courses import (
     get_cms_block_link,
     get_cms_course_link,
     get_course_about_section,
+    get_course_assignments,
     get_course_by_id,
     get_course_chapter_ids,
     get_course_info_section,
@@ -454,3 +457,26 @@ class TestGetCourseChapters(ModuleStoreTestCase):
             course_chapter_ids,
             [six.text_type(child) for child in course.children]
         )
+
+
+class TestGetCourseAssignments(CompletionWaffleTestMixin, ModuleStoreTestCase):
+    """
+    Tests for the `get_course_assignments` function.
+    """
+
+    def test_completion_ignores_non_scored_items(self):
+        """
+        Test that we treat a sequential with incomplete (but not scored) items (like a video maybe) as complete.
+        """
+        course = CourseFactory()
+        chapter = ItemFactory(parent=course, category='chapter', graded=True, due=datetime.datetime.now())
+        sequential = ItemFactory(parent=chapter, category='sequential')
+        problem = ItemFactory(parent=sequential, category='problem', has_score=True)
+        ItemFactory(parent=sequential, category='video', has_score=False)
+
+        self.override_waffle_switch(True)
+        BlockCompletion.objects.submit_completion(self.user, problem.location, 1)
+
+        assignments = get_course_assignments(course.location.context_key, self.user, None)
+        self.assertEqual(len(assignments), 1)
+        self.assertTrue(assignments[0].complete)

--- a/lms/djangoapps/courseware/tests/test_views.py
+++ b/lms/djangoapps/courseware/tests/test_views.py
@@ -3146,7 +3146,7 @@ class DatesTabTestCase(ModuleStoreTestCase):
                 format='Homework',
             )
             vertical = ItemFactory.create(category='vertical', parent_location=subsection.location)
-            ItemFactory.create(category='problem', parent_location=vertical.location)
+            ItemFactory.create(category='problem', parent_location=vertical.location, has_score=True)
 
         with patch('lms.djangoapps.courseware.views.views.get_enrollment') as mock_get_enrollment:
             mock_get_enrollment.return_value = {

--- a/openedx/features/course_experience/utils.py
+++ b/openedx/features/course_experience/utils.py
@@ -299,14 +299,30 @@ def dates_banner_should_display(course_key, user):
     for section_key in block_data.get_children(course_usage_key):
         for subsection_key in block_data.get_children(section_key):
             subsection_due_date = block_data.get_xblock_field(subsection_key, 'due', None)
-            if subsection_due_date and (
-                not block_data.get_xblock_field(subsection_key, 'complete', False)
-                and block_data.get_xblock_field(subsection_key, 'graded', False)
-                and subsection_due_date < timezone.now()
-            ):
-                # Display the banner if the due date for an incomplete graded subsection
-                # has passed
+            if (subsection_due_date and subsection_due_date < timezone.now() and
+                    not is_block_structure_complete_for_assignments(block_data, subsection_key)):
+                # Display the banner if the due date for an incomplete graded subsection has passed
                 return True, block_data.get_xblock_field(subsection_key, 'contains_gated_content', False)
 
     # Don't display the banner if there were no missed deadlines
     return False, False
+
+
+def is_block_structure_complete_for_assignments(block_data, block_key):
+    """
+    Considers a block complete only if all scored & graded leaf blocks are complete.
+
+    This is different from the normal `complete` flag because children of the block that are informative (like
+    readings or videos) do not count. We only care about actual homework content.
+    """
+    children = block_data.get_children(block_key)
+    if children:
+        return all(is_block_structure_complete_for_assignments(block_data, child_key) for child_key in children)
+
+    complete = block_data.get_xblock_field(block_key, 'complete', False)
+    graded = block_data.get_xblock_field(block_key, 'graded', False)
+    has_score = block_data.get_xblock_field(block_key, 'has_score', False)
+    weight = block_data.get_xblock_field(block_key, 'weight', 1)
+    scored = has_score and (weight is None or weight > 0)
+
+    return complete or not graded or not scored


### PR DESCRIPTION
When considering if an assignment is past due for the dates tab, only look at the scored and graded units in the subsection (i.e. ignore reading and video units).

This still leaves the "complete" field alone -- i.e. those subsections will still be left incomplete generally. But for assignment-focused tasks, they will instead be considered complete.

https://openedx.atlassian.net/browse/AA-225