### PR TITLE
[BD-29] TNL-7303 Add course license details to Courseware API

### DIFF
--- a/openedx/core/djangoapps/courseware_api/serializers.py
+++ b/openedx/core/djangoapps/courseware_api/serializers.py
@@ -69,6 +69,7 @@ class CourseInfoSerializer(serializers.Serializer):  # pylint: disable=abstract-
     enrollment_start = serializers.DateTimeField()
     enrollment_end = serializers.DateTimeField()
     id = serializers.CharField()  # pylint: disable=invalid-name
+    license = serializers.CharField()
     media = _CourseApiMediaCollectionSerializer(source='*')
     name = serializers.CharField(source='display_name_with_default_escaped')
     number = serializers.CharField(source='display_number_with_default')

--- a/openedx/core/djangoapps/courseware_api/views.py
+++ b/openedx/core/djangoapps/courseware_api/views.py
@@ -20,7 +20,7 @@ from course_modes.models import CourseMode
 from edxnotes.helpers import is_feature_enabled
 from lms.djangoapps.course_api.api import course_detail
 from lms.djangoapps.courseware.access import has_access
-from lms.djangoapps.courseware.courses import check_course_access
+from lms.djangoapps.courseware.courses import check_course_access, get_course_by_id
 from lms.djangoapps.courseware.masquerade import setup_masquerade
 from lms.djangoapps.courseware.module_render import get_module_by_usage_id
 from lms.djangoapps.courseware.tabs import get_course_tab_list
@@ -99,6 +99,11 @@ class CoursewareMeta:
     def can_show_upgrade_sock(self):
         can_show = can_show_verified_upgrade(self.effective_user, self.enrollment_object)
         return can_show
+
+    @property
+    def license(self):
+        course = get_course_by_id(self.course_key)
+        return course.license
 
     @property
     def can_load_courseware(self):


### PR DESCRIPTION
Add course license details to Courseware API

**JIRA tickets**: 
BD-29
[TNL-7303](https://openedx.atlassian.net/browse/TNL-7303)
[OSPR-4794](https://openedx.atlassian.net/browse/OSPR-4794)
[BLENDED-391](https://openedx.atlassian.net/browse/BLENDED-391)

**Dependencies**: None

**Sandbox URL**: TBD - sandbox is being provisioned.

**Merge deadline**:
Prior to https://github.com/edx/frontend-app-learning/pull/103

**Testing instructions**:

1. Pull the `open-craft:patrick/BB-2678-tnl-7303-add-course-license-details-to-course-l` branch locally and setup your local LMS.
2. Create a course in Studio
3. Edit the course, and select Settings > Schedule & Details
4. Set a license at the bottom of the page
5. Navigate to the following URL in your browser
```
http://localhost:18000/api/courseware/course/<COURSE_ID>
```
6. Examine the response for the `license` attribute

**Reviewers**
- [ ] @Agrendalath 
- [ ] edX reviewer[s] TBD