### PR TITLE
AA-226: Adding Authentication classes to endpoints for mobile use

### DIFF
--- a/lms/djangoapps/course_home_api/dates/v1/tests/test_views.py
+++ b/lms/djangoapps/course_home_api/dates/v1/tests/test_views.py
@@ -48,7 +48,7 @@ class DatesTabTestViews(BaseCourseHomeTests):
     def test_get_unauthenticated_user(self):
         self.client.logout()
         response = self.client.get(self.url)
-        self.assertEqual(response.status_code, 403)
+        self.assertEqual(response.status_code, 401)
 
     @COURSE_HOME_MICROFRONTEND.override(active=True)
     @COURSE_HOME_MICROFRONTEND_DATES_TAB.override(active=True)

--- a/lms/djangoapps/course_home_api/dates/v1/views.py
+++ b/lms/djangoapps/course_home_api/dates/v1/views.py
@@ -8,6 +8,8 @@ from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
 
 from edx_django_utils import monitoring as monitoring_utils
+from edx_rest_framework_extensions.auth.jwt.authentication import JwtAuthentication
+from edx_rest_framework_extensions.auth.session.authentication import SessionAuthenticationAllowInactiveUser
 from opaque_keys.edx.keys import CourseKey
 
 from lms.djangoapps.courseware.access import has_access
@@ -17,6 +19,7 @@ from lms.djangoapps.courseware.date_summary import TodaysDate, verified_upgrade_
 from lms.djangoapps.courseware.masquerade import setup_masquerade
 from lms.djangoapps.course_home_api.dates.v1.serializers import DatesTabSerializer
 from lms.djangoapps.course_home_api.toggles import course_home_mfe_dates_tab_is_active
+from openedx.core.lib.api.authentication import BearerAuthenticationAllowInactiveUser
 from openedx.features.course_experience.utils import dates_banner_should_display
 from openedx.features.content_type_gating.models import ContentTypeGatingConfig
 
@@ -52,10 +55,15 @@ class DatesTabView(RetrieveAPIView):
     **Returns**
 
         * 200 on success with above fields.
-        * 403 if the user is not authenticated.
+        * 401 if the user is not authenticated.
         * 404 if the course is not available or cannot be seen.
     """
 
+    authentication_classes = (
+        JwtAuthentication,
+        BearerAuthenticationAllowInactiveUser,
+        SessionAuthenticationAllowInactiveUser,
+    )
     permission_classes = (IsAuthenticated,)
     serializer_class = DatesTabSerializer
 

--- a/openedx/features/course_experience/api/v1/tests/test_views.py
+++ b/openedx/features/course_experience/api/v1/tests/test_views.py
@@ -29,3 +29,8 @@ class ResetCourseDeadlinesViewTests(BaseCourseHomeTests):
             reverse('course-experience-reset-course-deadlines'), {'course_key': self.course.id, 'invalid': 'value'}
         )
         self.assertEqual(response.status_code, 400)
+
+    def test_post_unauthenticated_user(self):
+        self.client.logout()
+        response = self.client.post(reverse('course-experience-reset-course-deadlines'), {'course_key': self.course.id})
+        self.assertEqual(response.status_code, 401)

--- a/openedx/features/course_experience/api/v1/views.py
+++ b/openedx/features/course_experience/api/v1/views.py
@@ -1,9 +1,13 @@
-from rest_framework.decorators import api_view, permission_classes
+from rest_framework.decorators import api_view, authentication_classes, permission_classes
 from rest_framework.exceptions import APIException, ParseError
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
 
+from edx_rest_framework_extensions.auth.jwt.authentication import JwtAuthentication
+from edx_rest_framework_extensions.auth.session.authentication import SessionAuthenticationAllowInactiveUser
+
 from openedx.core.djangoapps.schedules.utils import reset_self_paced_schedule
+from openedx.core.lib.api.authentication import BearerAuthenticationAllowInactiveUser
 
 
 class UnableToResetDeadlines(APIException):
@@ -12,8 +16,11 @@ class UnableToResetDeadlines(APIException):
     default_code = 'unable_to_reset_deadlines'
 
 
-@permission_classes((IsAuthenticated,))
 @api_view(['POST'])
+@authentication_classes((
+    JwtAuthentication, BearerAuthenticationAllowInactiveUser, SessionAuthenticationAllowInactiveUser,
+))
+@permission_classes((IsAuthenticated,))
 def reset_course_deadlines(request):
     course_key = request.data.get('course_key', None)
 


### PR DESCRIPTION
The class BearerAuthenticationAllowInactiveUser is needed for the
mobile app to authenticate. The other Auth classes are to support
the standard work flows.