### PR TITLE
Implement IDV redirect to MFE

### DIFF
--- a/lms/djangoapps/courseware/date_summary.py
+++ b/lms/djangoapps/courseware/date_summary.py
@@ -655,10 +655,13 @@ class VerificationDeadlineDate(DateSummary):
         """Maps verification state to a tuple of link text and location."""
         return {
             'verification-deadline-passed': (_('Learn More'), ''),
-            'verification-deadline-retry': (_('Retry Verification'), reverse('verify_student_reverify')),
+            'verification-deadline-retry': (
+                _('Retry Verification'),
+                IDVerificationService.get_verify_location('verify_student_reverify'),
+            ),
             'verification-deadline-upcoming': (
                 _('Verify My Identity'),
-                reverse('verify_student_verify_now', args=(self.course_id,))
+                IDVerificationService.get_verify_location('verify_student_verify_now', self.course_id),
             )
         }
 

--- a/lms/djangoapps/verify_student/management/commands/send_verification_expiry_email.py
+++ b/lms/djangoapps/verify_student/management/commands/send_verification_expiry_email.py
@@ -22,6 +22,7 @@ from util.query import use_read_replica_if_available
 
 from lms.djangoapps.verify_student.message_types import VerificationExpiry
 from lms.djangoapps.verify_student.models import ManualVerification, SoftwareSecurePhotoVerification, SSOVerification
+from lms.djangoapps.verify_student.services import IDVerificationService
 from openedx.core.djangoapps.ace_common.template_context import get_base_template_context
 from openedx.core.djangoapps.lang_pref import LANGUAGE_KEY
 from openedx.core.djangoapps.user_api.preferences.api import get_user_preference
@@ -190,7 +191,7 @@ class Command(BaseCommand):
         message_context = get_base_template_context(site)
         message_context.update({
             'platform_name': settings.PLATFORM_NAME,
-            'lms_verification_link': '{}{}'.format(settings.LMS_ROOT_URL, reverse("verify_student_reverify")),
+            'lms_verification_link': IDVerificationService.email_reverify_url(),
             'help_center_link': settings.ID_VERIFICATION_SUPPORT_LINK
         })
 

--- a/lms/djangoapps/verify_student/toggles.py
+++ b/lms/djangoapps/verify_student/toggles.py
@@ -27,3 +27,25 @@ USE_NEW_EMAIL_TEMPLATES = WaffleFlag(
 
 def use_new_templates_for_id_verification_emails():
     return USE_NEW_EMAIL_TEMPLATES.is_enabled()
+
+
+# Waffle flag to redirect to the new IDV flow on the account microfrontend
+# .. toggle_name: verify_student.redirect_to_idv_microfrontend
+# .. toggle_implementation: WaffleFlag
+# .. toggle_default: False
+# .. toggle_description: Supports staged rollout to students for the new IDV flow.
+# .. toggle_category: verify student
+# .. toggle_use_cases: incremental_release, open_edx
+# .. toggle_creation_date: 2020-07-09
+# .. toggle_expiration_date: n/a
+# .. toggle_warnings: n/a
+# .. toggle_tickets: MST-318
+# .. toggle_status: supported
+REDIRECT_TO_IDV_MICROFRONTEND = WaffleFlag(
+    waffle_namespace=WAFFLE_FLAG_NAMESPACE,
+    flag_name='redirect_to_idv_microfrontend',
+)
+
+
+def redirect_to_idv_microfrontend():
+    return REDIRECT_TO_IDV_MICROFRONTEND.is_enabled()

--- a/lms/templates/dashboard/_dashboard_course_listing.html
+++ b/lms/templates/dashboard/_dashboard_course_listing.html
@@ -3,12 +3,14 @@
 <%!
 import six
 
+from django.conf import settings
 from django.utils.http import urlencode, urlquote_plus
 from django.utils.translation import ugettext as _
 from django.utils.translation import ungettext
 from django.urls import reverse
 from course_modes.models import CourseMode
 from course_modes.helpers import enrollment_mode_display
+from lms.djangoapps.verify_student.services import IDVerificationService
 from openedx.core.djangolib.js_utils import dump_js_escaped_json, js_escaped_string
 from openedx.core.djangolib.markup import HTML, Text
 from openedx.features.course_experience import course_home_url_name
@@ -26,7 +28,7 @@ from lms.djangoapps.experiments.utils import UPSELL_TRACKING_FLAG
 %>
 
 <%
-  reverify_link = reverse('verify_student_reverify')
+  reverify_link = IDVerificationService.get_verify_location('verify_student_reverify')
   cert_name_short = course_overview.cert_name_short
   if cert_name_short == "":
     cert_name_short = settings.CERT_NAME_SHORT
@@ -364,7 +366,7 @@ from lms.djangoapps.experiments.utils import UPSELL_TRACKING_FLAG
                 % endif
               </div>
               <div class="verification-cta">
-                <a href="${reverse('verify_student_verify_now', kwargs={'course_id': six.text_type(course_overview.id)})}" class="btn" data-course-id="${course_overview.id}">${_('Verify Now')}</a>
+                <a href="${IDVerificationService.get_verify_location('verify_student_verify_now', course_overview.id)}" class="btn" data-course-id="${course_overview.id}">${_('Verify Now')}</a>
               </div>
             % elif verification_status['status'] == VERIFY_STATUS_SUBMITTED:
               <h4 class="message-title">${_('You have submitted your verification information.')}</h4>
@@ -382,7 +384,7 @@ from lms.djangoapps.experiments.utils import UPSELL_TRACKING_FLAG
               ## Translators: start_link and end_link will be replaced with HTML tags;
               ## please do not translate these.
               <p class="message-copy">${Text(_('Your current verification will expire in {days} days. {start_link}Re-verify your identity now{end_link} using a webcam and a government-issued photo ID.')).format(
-                  start_link=HTML('<a href="{href}">').format(href=reverse('verify_student_reverify')),
+                  start_link=HTML('<a href="{href}">').format(href=IDVerificationService.get_verify_location('verify_student_reverify')),
                   end_link=HTML('</a>'),
                   days=settings.VERIFY_STUDENT.get("EXPIRING_SOON_WINDOW")
                 )}

--- a/lms/templates/dashboard/_dashboard_status_verification.html
+++ b/lms/templates/dashboard/_dashboard_status_verification.html
@@ -3,6 +3,7 @@
 <%!
 from django.urls import reverse
 from django.utils.translation import ugettext as _
+from lms.djangoapps.verify_student.services import IDVerificationService
 %>
 
 %if verification_display:
@@ -13,7 +14,7 @@ from django.utils.translation import ugettext as _
             %if verification_expiry:
                 <p class="status-note"><span><b>${_("Warning")}: </b></span><i>${_("Your photo verification expires on {verification_expiry}. Please be aware photo verification can take up to three days once initiated and you will not be able to earn a certificate or take a proctored exam until approved.").format(verification_expiry=verification_expiry)}</i></p>
                 <div class="btn-reverify">
-                    <a href="${reverse('verify_student_reverify')}" class="action action-reverify">${_("Resubmit Verification")}</a>
+                    <a href="${IDVerificationService.get_verify_location('verify_student_reverify')}" class="action action-reverify">${_("Resubmit Verification")}</a>
                 </div>
             %endif
         </li>
@@ -39,7 +40,7 @@ from django.utils.translation import ugettext as _
             %endif
             </p>
         <div class="btn-reverify">
-            <a href="${reverse('verify_student_reverify')}" class="action action-reverify">${_("Resubmit Verification")}</a>
+            <a href="${IDVerificationService.get_verify_location('verify_student_reverify')}" class="action action-reverify">${_("Resubmit Verification")}</a>
         </div>
         </li>
     %elif verification_status == 'expired':
@@ -48,7 +49,7 @@ from django.utils.translation import ugettext as _
             <p class="status-note">${_("Your verification has expired. To receive a verified certificate, you must submit a new photo of yourself and your government-issued photo ID before the verification deadline for your course.")}</p>
             <p class="status-note"><span><b>${_("Warning")}: </b></span><i>${_(" Please be aware photo verification can take up to three days once initiated and you will not be able to earn a certificate or take a proctored exam until approved.")}</i></p>
             <div class="btn-reverify">
-                <a href="${reverse('verify_student_reverify')}" class="action action-reverify">${_("Resubmit Verification")}</a>
+                <a href="${IDVerificationService.get_verify_location('verify_student_reverify')}" class="action action-reverify">${_("Resubmit Verification")}</a>
             </div>
         </li>
     %endif


### PR DESCRIPTION
[MST-282: IDV Redirect Back to Course When Starting IDV from Course Page](https://openedx.atlassian.net/browse/MST-282)

Waffle flag to redirect users to the new ID verification experience on the account microfrontend. There are several instances where the course run key needs to persist in the browser in order to redirect the user back to the origin course. These exist:

- Under course listings on the dashboard.
![Screen Shot 2020-07-09 at 11 51 14 AM](https://user-images.githubusercontent.com/10442143/87066351-6df79a80-c1e0-11ea-9a7b-56dc5a07d43b.png)
- In the `date_summary` section on the course page.
![Screen Shot 2020-07-09 at 11 51 55 AM](https://user-images.githubusercontent.com/10442143/87066499-ac8d5500-c1e0-11ea-8471-aac631d48afd.png)

This PR adds the waffle flag, along with a helper function to dynamically render those URLs based on whether it is active. If the course run key is needed, it is passed as a query string. I've also added a temporary redirect from the reverification view, in case the user accesses ID verification from ecommerce.