### PR TITLE
Correct logic on building marketing links.

### DIFF
--- a/common/djangoapps/edxmako/tests.py
+++ b/common/djangoapps/edxmako/tests.py
@@ -98,6 +98,21 @@ class ShortcutsTests(UrlResetMixin, TestCase):
             link = marketing_link('TOS')
             self.assertEqual(link, expected_link)
 
+    @unittest.skipUnless(settings.ROOT_URLCONF == 'lms.urls', 'Test only valid in lms')
+    def test_link_map_url_reverse(self):
+        url_link_map = {
+            'ABOUT': 'dashboard',
+            'BAD_URL': 'foobarbaz',
+        }
+
+        with patch.dict('django.conf.settings.FEATURES', {'ENABLE_MKTG_SITE': False}):
+            with override_settings(MKTG_URL_LINK_MAP=url_link_map):
+                link = marketing_link('ABOUT')
+                assert link == '/dashboard'
+
+                link = marketing_link('BAD_URL')
+                assert link == '#'
+
 
 class AddLookupTests(TestCase):
     """


### PR DESCRIPTION
The logic used to has a special case for edge in the hostname which
didn't really make sense. So instead we just check to see if the given
url starts with http and if it does we return it directly.  If it doesn't,
then we try to convert it to a valid url and return that.  If that fails
we return .