### PR TITLE
AA-219: Dates Tab behavior improvements

### DIFF
--- a/lms/djangoapps/courseware/tabs.py
+++ b/lms/djangoapps/courseware/tabs.py
@@ -13,7 +13,6 @@ from lms.djangoapps.courseware.access import has_access
 from lms.djangoapps.courseware.entrance_exams import user_can_skip_entrance_exam
 from lms.djangoapps.course_home_api.toggles import course_home_mfe_dates_tab_is_active
 from lms.djangoapps.course_home_api.utils import get_microfrontend_url
-from openedx.core.djangoapps.content.course_overviews.models import CourseOverview
 from openedx.core.lib.course_tabs import CourseTabPluginManager
 from openedx.features.course_experience import RELATIVE_DATES_FLAG, UNIFIED_COURSE_TAB_FLAG, default_course_url_name
 from student.models import CourseEnrollment
@@ -205,7 +204,7 @@ class LinkTab(CourseTab):
     """
     link_value = ''
 
-    def __init__(self, tab_dict=None, name=None, link=None):
+    def __init__(self, tab_dict=None, link=None):
         self.link_value = tab_dict['link'] if tab_dict else link
 
         def link_value_func(_course, _reverse_func):

--- a/lms/djangoapps/courseware/tests/test_tabs.py
+++ b/lms/djangoapps/courseware/tests/test_tabs.py
@@ -164,7 +164,6 @@ class TabTestCase(SharedModuleStoreTestCase):
         if for_authenticated_users_only:
             user = self.create_mock_user(is_staff=False, is_enrolled=False)
             self.assertEqual(expected_value, self.is_tab_enabled(tab, self.course, user))
-            assert False
         if not for_staff_only and not for_authenticated_users_only and not for_enrolled_users_only:
             user = AnonymousUser()
             self.assertEqual(expected_value, self.is_tab_enabled(tab, self.course, user))
@@ -903,9 +902,29 @@ class DiscussionLinkTestCase(TabTestCase):
 
 
 class DatesTabTestCase(TabListTestCase):
-    """Test cases for making sure no persisted dates tab is surfaced"""
+    """Test cases for dates tab"""
 
-    def test_singular_dates_tab(self):
+    @patch('lms.djangoapps.courseware.tabs.RELATIVE_DATES_FLAG')
+    @patch('student.models.CourseEnrollment.is_enrolled')
+    def test_dates_tab_disabled_if_unenrolled(self, is_enrolled, mock_flag):
+        mock_flag.is_enabled().return_value = True
+        tab = DatesTab({'type': DatesTab.type, 'name': 'dates'})
+
+        is_enrolled.return_value = False
+        unenrolled_user = self.create_mock_user(is_staff=False, is_enrolled=False)
+        self.assertFalse(self.is_tab_enabled(tab, self.course, unenrolled_user))
+
+        staff_user = self.create_mock_user(is_staff=True, is_enrolled=False)
+        self.assertTrue(self.is_tab_enabled(tab, self.course, staff_user))
+
+        is_enrolled.return_value = True
+        enrolled_user = self.create_mock_user(is_staff=False, is_enrolled=True)
+        self.assertTrue(self.is_tab_enabled(tab, self.course, enrolled_user))
+
+    @patch('lms.djangoapps.courseware.tabs.RELATIVE_DATES_FLAG')
+    def test_singular_dates_tab(self, mock_flag):
+        """Test cases for making sure no persisted dates tab is surfaced"""
+        mock_flag.is_enabled().return_value = True
         user = self.create_mock_user()
         self.course.tabs = self.all_valid_tab_list
         self.course.save()
@@ -918,11 +937,9 @@ class DatesTabTestCase(TabListTestCase):
         self.assertTrue(has_dates_tab)
 
         # Verify that there is only 1 'dates' tab in the returned result from get_course_tab_list()
-        with patch('lms.djangoapps.courseware.tabs.RELATIVE_DATES_FLAG') as mock_flag:
-            mock_flag.is_enabled().return_value = True
-            tabs = get_course_tab_list(user, self.course)
-            num_dates_tabs = 0
-            for tab in tabs:
-                if tab.type == 'dates':
-                    num_dates_tabs += 1
-            self.assertEqual(num_dates_tabs, 1)
+        tabs = get_course_tab_list(user, self.course)
+        num_dates_tabs = 0
+        for tab in tabs:
+            if tab.type == 'dates':
+                num_dates_tabs += 1
+        self.assertEqual(num_dates_tabs, 1)

--- a/lms/djangoapps/courseware/tests/test_views.py
+++ b/lms/djangoapps/courseware/tests/test_views.py
@@ -3098,8 +3098,36 @@ class DatesTabTestCase(ModuleStoreTestCase):
         ContentTypeGatingConfig.objects.create(enabled=True, enabled_as_of=datetime(2017, 1, 1))
 
     def _get_response(self, course):
-        """ Returns the HTML for the progress page """
+        """ Returns the HTML for the dates page """
         return self.client.get(reverse('dates', args=[six.text_type(course.id)]))
+
+    def test_tab_redirects_if_not_logged_in(self):
+        self.client.logout()
+        response = self._get_response(self.course)
+        self.assertEqual(response.status_code, 302)
+        self.assertIn('/login?next=/courses/', response.url)
+
+    def test_tab_redirects_if_not_enrolled_and_not_staff(self):
+        response = self._get_response(self.course)
+        self.assertEqual(response.status_code, 302)
+        # Beginning of redirect URL
+        self.assertIn('/courses/', response.url)
+        # End of redirect URL
+        self.assertIn('/course/', response.url)
+
+        # Now check staff users can see
+        self.user.is_staff = True
+        self.user.save()
+        response = self._get_response(self.course)
+        self.assertEqual(response.status_code, 200)
+
+        # Enrolled users can also see
+        self.client.logout()
+        enrolled_user = UserFactory()
+        CourseEnrollmentFactory(course_id=self.course.id, user=enrolled_user, mode=CourseMode.VERIFIED)
+        self.client.login(username=enrolled_user.username, password=TEST_PASSWORD)
+        response = self._get_response(self.course)
+        self.assertEqual(response.status_code, 200)
 
     @RELATIVE_DATES_FLAG.override(active=True)
     @patch('edx_django_utils.monitoring.set_custom_metric')

--- a/openedx/features/course_experience/templates/course_experience/course-dates-fragment.html
+++ b/openedx/features/course_experience/templates/course_experience/course-dates-fragment.html
@@ -13,9 +13,11 @@ from django.utils.translation import ugettext as _
     % for course_date_block in course_date_blocks:
         <%include file="dates-summary.html" args="course_date=course_date_block" />
     % endfor
-    <div class="dates-tab-link">
-        <a href="${dates_tab_link}">View all course dates</a>
-    </div>
+    % if user_enrolled:
+        <div class="dates-tab-link">
+            <a href="${dates_tab_link}">View all course dates</a>
+        </div>
+    % endif
 % endif
 
 <%static:require_module_async module_name="js/dateutil_factory" class_name="DateUtilFactory">


### PR DESCRIPTION
This switches the Dates Tab to be an enrolled tab allowing only
enrolled learners to view. Additionally, it will now redirect
logged out learners to the login page if they hit the Dates Tab directly.