### PR TITLE
Hide search boxes in private team-sets for non-privileged users

### DIFF
--- a/lms/djangoapps/teams/static/teams/js/spec/views/team_profile_header_actions_spec.js
+++ b/lms/djangoapps/teams/static/teams/js/spec/views/team_profile_header_actions_spec.js
@@ -45,9 +45,10 @@ define([
                     }),
                     topicOptions = typeof topicMaxTeamSize !== 'undefined' ?
                         {max_team_size: topicMaxTeamSize} : {},
-                    topic = isInstructorManagedTopic ?
-                        TeamSpecHelpers.createMockInstructorManagedTopic(topicOptions) :
-                        TeamSpecHelpers.createMockTopic(topicOptions);
+                    topic;
+
+                topicOptions.type = isInstructorManagedTopic ? 'public_managed' : 'open';
+                topic = TeamSpecHelpers.createMockTopic(topicOptions);
 
                 return new TeamProfileHeaderActionsView(
                     {

--- a/lms/djangoapps/teams/static/teams/js/spec/views/team_profile_spec.js
+++ b/lms/djangoapps/teams/static/teams/js/spec/views/team_profile_spec.js
@@ -51,7 +51,7 @@ define([
                 context: options.context || TeamSpecHelpers.testContext,
                 model: teamModel,
                 topic: isInstructorManagedTopic ?
-                    TeamSpecHelpers.createMockInstructorManagedTopic() :
+                    TeamSpecHelpers.createMockTopic({type: 'public_managed'}) :
                     TeamSpecHelpers.createMockTopic(),
                 setFocusToHeaderFunc: function() {
                     $('.teams-content').focus();

--- a/lms/djangoapps/teams/static/teams/js/spec/views/teams_tab_spec.js
+++ b/lms/djangoapps/teams/static/teams/js/spec/views/teams_tab_spec.js
@@ -388,38 +388,11 @@ define([
             it('does not show a search box in private team-sets for non-privileged users', function() {
                 teamsTabView = createTeamsTabView({
                     topics: {
-                        count: 1,
-                        num_pages: 1,
-                        current_page: 1,
-                        start: 0,
-                        results: {
-                            id: TeamSpecHelpers.testPrivateTopicID,
-                            name: 'Test Private Topic 1',
-                            description: 'Test private topic description 1',
-                            type: 'private_managed',
-                            team_count: 0
-                        }
+                        results: TeamSpecHelpers.createMockPrivateTopic()
                     },
-                    hasOpenTopic: false,
-                    hasManagedTopic: true,
                     userInfo: TeamSpecHelpers.createMockUserInfo({
                         privileged: false,
-                        staff: false,
-                        team_memberships_data: {
-                            user: {username: TeamSpecHelpers.testUser},
-                            team: [
-                                {
-                                    name: 'team',
-                                    id: 'id',
-                                    language: 'en',
-                                    country: ['US'],
-                                    membership: [],
-                                    last_activity_at: '',
-                                    topic_id: 'topic_id',
-                                    url: 'api/team/v0/teams/id'
-                                }
-                            ]
-                        }
+                        staff: false
                     })
                 });
 
@@ -438,38 +411,11 @@ define([
             it('shows a search box in private team-sets for privileged users', function() {
                 teamsTabView = createTeamsTabView({
                     topics: {
-                        count: 1,
-                        num_pages: 1,
-                        current_page: 1,
-                        start: 0,
-                        results: {
-                            id: TeamSpecHelpers.testPrivateTopicID,
-                            name: 'Test Private Topic 1',
-                            description: 'Test private topic description 1',
-                            type: 'private_managed',
-                            team_count: 0
-                        }
+                        results: TeamSpecHelpers.createMockPrivateTopic()
                     },
-                    hasOpenTopic: false,
-                    hasManagedTopic: true,
                     userInfo: TeamSpecHelpers.createMockUserInfo({
                         privileged: true,
-                        staff: true,
-                        team_memberships_data: {
-                            user: {username: TeamSpecHelpers.testUser},
-                            team: [
-                                {
-                                    name: 'team',
-                                    id: 'id',
-                                    language: 'en',
-                                    country: ['US'],
-                                    membership: [],
-                                    last_activity_at: '',
-                                    topic_id: 'topic_id',
-                                    url: 'api/team/v0/teams/id'
-                                }
-                            ]
-                        }
+                        staff: true
                     })
                 });
 

--- a/lms/djangoapps/teams/static/teams/js/spec/views/teams_tab_spec.js
+++ b/lms/djangoapps/teams/static/teams/js/spec/views/teams_tab_spec.js
@@ -313,7 +313,7 @@ define([
                 AjaxHelpers.expectNoRequests(requests);
             };
 
-            beforeEach(function() {
+            var setUpTopicTab = function() {
                 teamsTabView = createTeamsTabView();
                 teamsTabView.browseTopic(TeamSpecHelpers.testTopicID);
                 verifyTeamsRequest({
@@ -322,15 +322,17 @@ define([
                 });
                 AjaxHelpers.respondWithJson(requests, {});
                 AjaxHelpers.respondWithJson(requests, { count: 0 });
-            });
+            };
 
             it('can search teams', function() {
+                setUpTopicTab();
                 performSearch();
                 expect(teamsTabView.$('.page-title').text()).toBe('Team Search');
                 expect(teamsTabView.$('.page-description').text()).toBe('Showing results for "foo"');
             });
 
             it('can clear a search', function() {
+                setUpTopicTab();
                 // Perform a search
                 performSearch();
 
@@ -348,6 +350,7 @@ define([
             });
 
             it('can navigate back to all teams from a search', function() {
+                setUpTopicTab();
                 // Perform a search
                 performSearch();
 
@@ -365,6 +368,7 @@ define([
             });
 
             it('does not switch to showing results when the search returns an error', function() {
+                setUpTopicTab();
                 // Perform a search but respond with a 500
                 teamsTabView.$('.search-field').val('foo');
                 teamsTabView.$('.action-search').click();
@@ -374,6 +378,111 @@ define([
                 expect(teamsTabView.$('.page-title').text()).toBe('Test Topic 1');
                 expect(teamsTabView.$('.page-description').text()).toBe('Test description 1');
                 expect(teamsTabView.$('.search-field').val(), 'foo');
+            });
+
+            it('shows a search box in non-private team-sets', function() {
+                setUpTopicTab();
+                expect(teamsTabView.$('.search-field')).toExist();
+            });
+
+            it('does not show a search box in private team-sets for non-privileged users', function() {
+                teamsTabView = createTeamsTabView({
+                    topics: {
+                        count: 1,
+                        num_pages: 1,
+                        current_page: 1,
+                        start: 0,
+                        results: {
+                            id: TeamSpecHelpers.testPrivateTopicID,
+                            name: 'Test Private Topic 1',
+                            description: 'Test private topic description 1',
+                            type: 'private_managed',
+                            team_count: 0
+                        }
+                    },
+                    hasOpenTopic: false,
+                    hasManagedTopic: true,
+                    userInfo: TeamSpecHelpers.createMockUserInfo({
+                        privileged: false,
+                        staff: false,
+                        team_memberships_data: {
+                            user: {username: TeamSpecHelpers.testUser},
+                            team: [
+                                {
+                                    name: 'team',
+                                    id: 'id',
+                                    language: 'en',
+                                    country: ['US'],
+                                    membership: [],
+                                    last_activity_at: '',
+                                    topic_id: 'topic_id',
+                                    url: 'api/team/v0/teams/id'
+                                }
+                            ]
+                        }
+                    })
+                });
+
+                teamsTabView.browseTopic(TeamSpecHelpers.testPrivateTopicID);
+
+                verifyTeamsRequest({
+                    topic_id: TeamSpecHelpers.testPrivateTopicID,
+                    order_by: 'last_activity_at',
+                    text_search: ''
+                });
+                AjaxHelpers.respondWithJson(requests, {});
+
+                expect(teamsTabView.$('.search-field')).not.toExist();
+            });
+
+            it('shows a search box in private team-sets for privileged users', function() {
+                teamsTabView = createTeamsTabView({
+                    topics: {
+                        count: 1,
+                        num_pages: 1,
+                        current_page: 1,
+                        start: 0,
+                        results: {
+                            id: TeamSpecHelpers.testPrivateTopicID,
+                            name: 'Test Private Topic 1',
+                            description: 'Test private topic description 1',
+                            type: 'private_managed',
+                            team_count: 0
+                        }
+                    },
+                    hasOpenTopic: false,
+                    hasManagedTopic: true,
+                    userInfo: TeamSpecHelpers.createMockUserInfo({
+                        privileged: true,
+                        staff: true,
+                        team_memberships_data: {
+                            user: {username: TeamSpecHelpers.testUser},
+                            team: [
+                                {
+                                    name: 'team',
+                                    id: 'id',
+                                    language: 'en',
+                                    country: ['US'],
+                                    membership: [],
+                                    last_activity_at: '',
+                                    topic_id: 'topic_id',
+                                    url: 'api/team/v0/teams/id'
+                                }
+                            ]
+                        }
+                    })
+                });
+
+                teamsTabView.browseTopic(TeamSpecHelpers.testPrivateTopicID);
+
+                verifyTeamsRequest({
+                    topic_id: TeamSpecHelpers.testPrivateTopicID,
+                    order_by: 'last_activity_at',
+                    text_search: ''
+                });
+                AjaxHelpers.respondWithJson(requests, {});
+
+                expect(teamsTabView.$('.search-field')).toExist();
             });
         });
     });

--- a/lms/djangoapps/teams/static/teams/js/spec/views/teams_tab_spec.js
+++ b/lms/djangoapps/teams/static/teams/js/spec/views/teams_tab_spec.js
@@ -388,18 +388,13 @@ define([
             it('does not show a search box in private team-sets for non-privileged users', function() {
                 teamsTabView = createTeamsTabView({
                     topics: {
-                        results: TeamSpecHelpers.createMockPrivateTopic()
-                    },
-                    userInfo: TeamSpecHelpers.createMockUserInfo({
-                        privileged: false,
-                        staff: false
-                    })
+                        results: TeamSpecHelpers.createMockTopic({type: 'private_managed'})
+                    }
                 });
 
-                teamsTabView.browseTopic(TeamSpecHelpers.testPrivateTopicID);
+                teamsTabView.browseTopic(TeamSpecHelpers.testTopicID);
 
                 verifyTeamsRequest({
-                    topic_id: TeamSpecHelpers.testPrivateTopicID,
                     order_by: 'last_activity_at',
                     text_search: ''
                 });
@@ -411,7 +406,7 @@ define([
             it('shows a search box in private team-sets for privileged users', function() {
                 teamsTabView = createTeamsTabView({
                     topics: {
-                        results: TeamSpecHelpers.createMockPrivateTopic()
+                        results: TeamSpecHelpers.createMockTopic({type: 'private_managed'})
                     },
                     userInfo: TeamSpecHelpers.createMockUserInfo({
                         privileged: true,
@@ -419,10 +414,9 @@ define([
                     })
                 });
 
-                teamsTabView.browseTopic(TeamSpecHelpers.testPrivateTopicID);
+                teamsTabView.browseTopic(TeamSpecHelpers.testTopicID);
 
                 verifyTeamsRequest({
-                    topic_id: TeamSpecHelpers.testPrivateTopicID,
                     order_by: 'last_activity_at',
                     text_search: ''
                 });

--- a/lms/djangoapps/teams/static/teams/js/spec/views/topic_teams_spec.js
+++ b/lms/djangoapps/teams/static/teams/js/spec/views/topic_teams_spec.js
@@ -38,7 +38,7 @@ define([
             topicTeamsView = new TopicTeamsView({
                 el: '.teams-container',
                 model: isInstructorManagedTopic ?
-                    TeamSpecHelpers.createMockInstructorManagedTopic() : TeamSpecHelpers.createMockTopic(),
+                    TeamSpecHelpers.createMockTopic({type: 'public_managed'}) : TeamSpecHelpers.createMockTopic(),
                 collection: options.teams || TeamSpecHelpers.createMockTeams({results: []}),
                 context: _.extend({}, TeamSpecHelpers.testContext, options)
             });

--- a/lms/djangoapps/teams/static/teams/js/spec_helpers/team_spec_helpers.js
+++ b/lms/djangoapps/teams/static/teams/js/spec_helpers/team_spec_helpers.js
@@ -8,12 +8,14 @@ define([
     'use strict';
     var createMockPostResponse, createMockDiscussionResponse, createAnnotatedContentInfo, createMockThreadResponse,
         createMockTopicData, createMockTopicCollection, createMockTopic, createMockInstructorManagedTopic,
+        createMockPrivateTopic,
         createMockContext,
         testContext,
         testCourseID = 'course/1',
         testUser = 'testUser',
         testTopicID = 'test-topic-1',
         testInstructorManagedTopicID = 'test-instructor-managed-topic-1',
+        testPrivateTopicID = 'enigma',
         testTeamDiscussionID = '12345',
         teamEvents = _.clone(Backbone.Events),
         testCountries = [
@@ -277,6 +279,18 @@ define([
         ));
     };
 
+    createMockPrivateTopic = function(options) {
+        return new TopicModel(_.extend(
+            {
+                id: testPrivateTopicID,
+                name: 'Test Private Topic 1',
+                description: 'Test private topic description 1',
+                type: 'private_managed'
+            },
+            options
+        ));
+    };
+
     testContext = {
         courseID: testCourseID,
         topics: {
@@ -333,6 +347,7 @@ define([
         testCourseID: testCourseID,
         testUser: testUser,
         testTopicID: testTopicID,
+        testPrivateTopicID: testPrivateTopicID,
         testCountries: testCountries,
         testLanguages: testLanguages,
         testTeamDiscussionID: testTeamDiscussionID,
@@ -345,6 +360,7 @@ define([
         createMockContext: createMockContext,
         createMockTopic: createMockTopic,
         createMockInstructorManagedTopic: createMockInstructorManagedTopic,
+        createMockPrivateTopic: createMockPrivateTopic,
         createMockPostResponse: createMockPostResponse,
         createMockDiscussionResponse: createMockDiscussionResponse,
         createAnnotatedContentInfo: createAnnotatedContentInfo,

--- a/lms/djangoapps/teams/static/teams/js/spec_helpers/team_spec_helpers.js
+++ b/lms/djangoapps/teams/static/teams/js/spec_helpers/team_spec_helpers.js
@@ -8,14 +8,12 @@ define([
     'use strict';
     var createMockPostResponse, createMockDiscussionResponse, createAnnotatedContentInfo, createMockThreadResponse,
         createMockTopicData, createMockTopicCollection, createMockTopic, createMockInstructorManagedTopic,
-        createMockPrivateTopic,
         createMockContext,
         testContext,
         testCourseID = 'course/1',
         testUser = 'testUser',
         testTopicID = 'test-topic-1',
         testInstructorManagedTopicID = 'test-instructor-managed-topic-1',
-        testPrivateTopicID = 'enigma',
         testTeamDiscussionID = '12345',
         teamEvents = _.clone(Backbone.Events),
         testCountries = [
@@ -279,18 +277,6 @@ define([
         ));
     };
 
-    createMockPrivateTopic = function(options) {
-        return _.extend(
-            {
-                id: testPrivateTopicID,
-                name: 'Test Private Topic 1',
-                description: 'Test private topic description 1',
-                type: 'private_managed'
-            },
-            options
-        );
-    };
-
     testContext = {
         courseID: testCourseID,
         topics: {
@@ -347,7 +333,6 @@ define([
         testCourseID: testCourseID,
         testUser: testUser,
         testTopicID: testTopicID,
-        testPrivateTopicID: testPrivateTopicID,
         testCountries: testCountries,
         testLanguages: testLanguages,
         testTeamDiscussionID: testTeamDiscussionID,
@@ -360,7 +345,6 @@ define([
         createMockContext: createMockContext,
         createMockTopic: createMockTopic,
         createMockInstructorManagedTopic: createMockInstructorManagedTopic,
-        createMockPrivateTopic: createMockPrivateTopic,
         createMockPostResponse: createMockPostResponse,
         createMockDiscussionResponse: createMockDiscussionResponse,
         createAnnotatedContentInfo: createAnnotatedContentInfo,

--- a/lms/djangoapps/teams/static/teams/js/spec_helpers/team_spec_helpers.js
+++ b/lms/djangoapps/teams/static/teams/js/spec_helpers/team_spec_helpers.js
@@ -7,13 +7,12 @@ define([
 ], function(Backbone, _, TeamCollection, TopicCollection, TopicModel) {
     'use strict';
     var createMockPostResponse, createMockDiscussionResponse, createAnnotatedContentInfo, createMockThreadResponse,
-        createMockTopicData, createMockTopicCollection, createMockTopic, createMockInstructorManagedTopic,
+        createMockTopicData, createMockTopicCollection, createMockTopic,
         createMockContext,
         testContext,
         testCourseID = 'course/1',
         testUser = 'testUser',
         testTopicID = 'test-topic-1',
-        testInstructorManagedTopicID = 'test-instructor-managed-topic-1',
         testTeamDiscussionID = '12345',
         teamEvents = _.clone(Backbone.Events),
         testCountries = [
@@ -265,18 +264,6 @@ define([
         ));
     };
 
-    createMockInstructorManagedTopic = function(options) {
-        return new TopicModel(_.extend(
-            {
-                id: testInstructorManagedTopicID,
-                name: 'Test Instructor Managed Topic 1',
-                description: 'Test instructor managed topic description 1',
-                type: 'public_managed'
-            },
-            options
-        ));
-    };
-
     testContext = {
         courseID: testCourseID,
         topics: {
@@ -344,7 +331,6 @@ define([
         createMockUserInfo: createMockUserInfo,
         createMockContext: createMockContext,
         createMockTopic: createMockTopic,
-        createMockInstructorManagedTopic: createMockInstructorManagedTopic,
         createMockPostResponse: createMockPostResponse,
         createMockDiscussionResponse: createMockDiscussionResponse,
         createAnnotatedContentInfo: createAnnotatedContentInfo,

--- a/lms/djangoapps/teams/static/teams/js/spec_helpers/team_spec_helpers.js
+++ b/lms/djangoapps/teams/static/teams/js/spec_helpers/team_spec_helpers.js
@@ -280,7 +280,7 @@ define([
     };
 
     createMockPrivateTopic = function(options) {
-        return new TopicModel(_.extend(
+        return _.extend(
             {
                 id: testPrivateTopicID,
                 name: 'Test Private Topic 1',
@@ -288,7 +288,7 @@ define([
                 type: 'private_managed'
             },
             options
-        ));
+        );
     };
 
     testContext = {

--- a/lms/djangoapps/teams/static/teams/js/views/teams_tab.js
+++ b/lms/djangoapps/teams/static/teams/js/views/teams_tab.js
@@ -387,11 +387,12 @@
                             collection: collection,
                             showSortControls: options.showSortControls
                         }),
-                        searchFieldView = new SearchFieldView({
-                            type: 'teams',
-                            label: gettext('Search teams'),
-                            collection: collection
-                        }),
+                        searchFieldView = this.shouldShowSearch(topic) ?
+                            new SearchFieldView({
+                                type: 'teams',
+                                label: gettext('Search teams'),
+                                collection: collection
+                            }) : null,
                         viewWithHeader = this.createViewWithHeader({
                             subject: topic,
                             mainView: teamsView,
@@ -502,6 +503,13 @@
 
                 shouldSeeBrowseTab: function() {
                     return this.context.hasOpenTopic || this.context.hasPublicManagedTopic;
+                },
+
+                shouldShowSearch: function(topic) {
+                    if (topic && topic.get('type') === 'private_managed') {
+                        return this.context.userInfo.privileged || this.context.userInfo.staff;
+                    }
+                    return true;
                 },
 
                 getTeamsTabViewDescription: function() {


### PR DESCRIPTION
**TL;DR -** hide search boxes in private team-sets for non-privileged users.

JIRA: [EDUCATOR-5107](https://openedx.atlassian.net/browse/EDUCATOR-5107)

In a course, when a topic/team-set is configured to `type="private_managed"` in Studio > Settings > Advanced Settings > Team Configuration, students within a team-set should only see the team they are a member of. The presence of a search box in these team-sets could therefore be confusing for students so it is now hidden.

Staff, and privileged users (instructors, TAs, etc.) should be able to see a larger subset of teams w/in the private team-set so we continue to show the search box.

![Screen Shot 2020-07-09 at 18 47 41](https://user-images.githubusercontent.com/12944465/87098278-ed06c600-c214-11ea-9b64-55d600fa9fbe.png)