### PR TITLE
use VEM as sole pipeline for uploads and transcript credentials

### DIFF
--- a/cms/djangoapps/contentstore/views/helpers.py
+++ b/cms/djangoapps/contentstore/views/helpers.py
@@ -291,18 +291,3 @@ def is_item_in_course_tree(item):
         ancestor = ancestor.get_parent()
 
     return ancestor is not None
-
-
-def get_course_hash_value(course_key):
-    """
-    Returns a hash value for the given course key.
-
-    If course key is None, function returns an out of bound value which will
-    never satisfy the vem_enabled_courses_percentage condition
-    """
-    out_of_bound_value = 100
-    if course_key:
-        m = hashlib.md5(str(course_key).encode())
-        return int(m.hexdigest(), base=16) % 100
-
-    return out_of_bound_value

--- a/cms/djangoapps/contentstore/views/tests/test_videos.py
+++ b/cms/djangoapps/contentstore/views/tests/test_videos.py
@@ -502,49 +502,15 @@ class VideosHandlerTestCase(VideoUploadTestMixin, CourseTestCase):
 
     @patch('boto.s3.key.Key')
     @patch('boto.s3.connection.S3Connection')
-    @override_flag(waffle_flags()[ENABLE_VEM_PIPELINE].namespaced_flag_name, active=True)
-    def test_enable_vem_pipeline(self, mock_conn, mock_key):
+    def test_upload_to_vem_pipeline(self, mock_conn, mock_key):
         """
-        Test that if VEM pipeline is enabled, objects are uploaded to the correct s3 bucket
-        even if course_hash_value is bigger than vem_enabled_courses_percentage.
-        """
-        files = [{'file_name': 'first.mp4', 'content_type': 'video/mp4'}]
-        mock_key_instances = [
-            Mock(
-                generate_url=Mock(
-                    return_value='http://example.com/url_{}'.format(file_info['file_name'])
-                )
-            )
-            for file_info in files
-        ]
-        mock_key.side_effect = mock_key_instances
-
-        response = self.client.post(
-            self.url,
-            json.dumps({'files': files}),
-            content_type='application/json'
-        )
-
-        self.assertEqual(response.status_code, 200)
-        mock_conn.return_value.get_bucket.assert_called_once_with(
-            settings.VIDEO_UPLOAD_PIPELINE['VEM_S3_BUCKET'], validate=False  # pylint: disable=unsubscriptable-object
-        )
-
-    @patch('contentstore.views.videos.get_course_hash_value', Mock(return_value=50))
-    @patch('contentstore.views.videos.LOGGER')
-    @patch('boto.s3.key.Key')
-    @patch('boto.s3.connection.S3Connection')
-    def test_send_course_to_vem_pipeline(self, mock_conn, mock_key, mock_logger):
-        """
-        Test that if course hash value lies under the VEM config `vem_enabled_courses_percentage`
-        value, then video for that course is uploaded to VEM.
+        Test that every video upload is uploaded to VEM.
         """
         vem_pipeline_integration_defaults = {
             'enabled': True,
             'api_url': 'https://video-encode-manager.example.com/api/v1/',
             'service_username': 'vem_pipeline_service_user',
-            'client_name': 'vem_pipeline',
-            'vem_enabled_courses_percentage': 100
+            'client_name': 'vem_pipeline'
         }
         VEMPipelineIntegration.objects.create(**vem_pipeline_integration_defaults)
 
@@ -568,42 +534,6 @@ class VideosHandlerTestCase(VideoUploadTestMixin, CourseTestCase):
         self.assertEqual(response.status_code, 200)
         mock_conn.return_value.get_bucket.assert_called_once_with(
             settings.VIDEO_UPLOAD_PIPELINE['VEM_S3_BUCKET'], validate=False  # pylint: disable=unsubscriptable-object
-        )
-        mock_logger.info.assert_called_with('Uploading course: {} to VEM bucket.'.format(self.course.id))
-
-    @patch('contentstore.views.videos.get_course_hash_value', Mock(return_value=50))
-    @patch('boto.s3.key.Key')
-    @patch('boto.s3.connection.S3Connection')
-    def test_vem_pipeline_integration_not_enabled(self, mock_conn, mock_key):
-        """
-        Test that if VEMPipelineIntegration is not enabled and course override waffle flag is not
-        set to True, the video goes to VEDA bucket.
-        """
-        vem_pipeline_integration_defaults = {
-            'enabled': False, 'vem_enabled_courses_percentage': 100
-        }
-        VEMPipelineIntegration.objects.create(**vem_pipeline_integration_defaults)
-
-        files = [{'file_name': 'first.mp4', 'content_type': 'video/mp4'}]
-        mock_key_instances = [
-            Mock(
-                generate_url=Mock(
-                    return_value='http://example.com/url_{}'.format(file_info['file_name'])
-                )
-            )
-            for file_info in files
-        ]
-        mock_key.side_effect = mock_key_instances
-
-        response = self.client.post(
-            self.url,
-            json.dumps({'files': files}),
-            content_type='application/json'
-        )
-
-        self.assertEqual(response.status_code, 200)
-        mock_conn.return_value.get_bucket.assert_called_once_with(
-            settings.VIDEO_UPLOAD_PIPELINE['BUCKET'], validate=False  # pylint: disable=unsubscriptable-object
         )
 
     @override_settings(AWS_ACCESS_KEY_ID='test_key_id', AWS_SECRET_ACCESS_KEY='test_secret')

--- a/openedx/core/djangoapps/video_pipeline/api.py
+++ b/openedx/core/djangoapps/video_pipeline/api.py
@@ -9,8 +9,7 @@ from django.core.exceptions import ObjectDoesNotExist
 from oauth2_provider.models import Application
 from slumber.exceptions import HttpClientError
 
-from openedx.core.djangoapps.video_pipeline.config.waffle import ENABLE_VEM_PIPELINE, waffle_flags
-from openedx.core.djangoapps.video_pipeline.models import VEMPipelineIntegration, VideoPipelineIntegration
+from openedx.core.djangoapps.video_pipeline.models import VEMPipelineIntegration
 from openedx.core.djangoapps.video_pipeline.utils import create_video_pipeline_api_client
 
 log = logging.getLogger(__name__)
@@ -58,7 +57,7 @@ def send_transcript_credentials(pipeline_integration, credentials_payload):
 def update_3rd_party_transcription_service_credentials(**credentials_payload):
     """
     Updates the 3rd party transcription service's credentials. Credentials are updated
-    for all the enabled pipelines.
+    for VEM pipeline.
 
     Arguments:
         credentials_payload(dict): A payload containing org, provider and its credentials.
@@ -66,29 +65,15 @@ def update_3rd_party_transcription_service_credentials(**credentials_payload):
     Returns:
         A Boolean specifying whether the credentials were updated or not
         and an error response received from pipeline.
-
-    Note: If one of the pipeline fails to update the credentials, False is returned, meaning
-    that credentials were not updated and both calls should be tried again.
     """
     error_response, is_updated = {}, False
 
     vem_pipeline_integration = VEMPipelineIntegration.current()
-    veda_pipeline_integration = VideoPipelineIntegration.current()
 
     if vem_pipeline_integration.enabled:
         log.info('Sending transcript credentials to VEM for org: {} and provider: {}'.format(
             credentials_payload.get('org'), credentials_payload.get('provider')
         ))
         error_response, is_updated = send_transcript_credentials(vem_pipeline_integration, credentials_payload)
-        # If credentials update fail for VEM, return proper error message and discontinue to
-        # send credentials to VEDA because we are going to try it next time anyway
-        if not is_updated:
-            return error_response, is_updated
-
-    if veda_pipeline_integration.enabled:
-        log.info('Sending transcript credentials to VEDA for org: {} and provider: {}'.format(
-            credentials_payload.get('org'), credentials_payload.get('provider')
-        ))
-        error_response, is_updated = send_transcript_credentials(veda_pipeline_integration, credentials_payload)
 
     return error_response, is_updated

--- a/openedx/core/djangoapps/video_pipeline/forms.py
+++ b/openedx/core/djangoapps/video_pipeline/forms.py
@@ -4,7 +4,7 @@ Defines a form to provide validations for course-specific configuration.
 from django import forms
 
 from openedx.core.djangoapps.video_config.forms import CourseSpecificFlagAdminBaseForm
-from openedx.core.djangoapps.video_pipeline.models import CourseVideoUploadsEnabledByDefault
+from openedx.core.djangoapps.video_pipeline.models import CourseVideoUploadsEnabledByDefault, VEMPipelineIntegration
 
 
 class CourseVideoUploadsEnabledByDefaultAdminForm(CourseSpecificFlagAdminBaseForm):
@@ -21,12 +21,6 @@ class VEMPipelineIntegrationAdminForm(forms.ModelForm):
     """
     Form for VEM Pipeline Integration Admin class
     """
-
-    def clean_vem_enabled_courses_percentage(self):
-        """
-        Validates that vem_enabled_courses_percentage lies between 0 to 100.
-        """
-        vem_enabled_courses_percentage = self.cleaned_data['vem_enabled_courses_percentage']
-        if vem_enabled_courses_percentage < 0 or vem_enabled_courses_percentage > 100:
-            raise forms.ValidationError('Invalid percentage, the value must be between 0 and 100')
-        return vem_enabled_courses_percentage
+    class Meta(object):
+        model = VEMPipelineIntegration
+        fields = '__all__'

--- a/openedx/core/djangoapps/video_pipeline/models.py
+++ b/openedx/core/djangoapps/video_pipeline/models.py
@@ -72,11 +72,6 @@ class VEMPipelineIntegration(ConfigurationModel):
         help_text=_('Username created for VEM Integration, e.g. vem_service_user.')
     )
 
-    vem_enabled_courses_percentage = models.IntegerField(
-        default=0,
-        help_text=_('Percentage of courses allowed to use VEM pipeline')
-    )
-
     def get_service_user(self):
         User = get_user_model()  # pylint: disable=invalid-name
         return User.objects.get(username=self.service_username)

--- a/openedx/core/djangoapps/video_pipeline/tests/mixins.py
+++ b/openedx/core/djangoapps/video_pipeline/tests/mixins.py
@@ -11,13 +11,6 @@ class VideoPipelineMixin(object):
     """
     Utility for working with the video pipelines (VEDA and VEM) service during testing.
     """
-    veda_pipeline_integration_defaults = {
-        'enabled': True,
-        'api_url': 'https://video-pipeline.example.com/api/v1/',
-        'service_username': 'cms_veda_pipeline_service_user',
-        'client_name': 'veda_pipeline'
-    }
-
     vem_pipeline_integration_defaults = {
         'enabled': True,
         'api_url': 'https://video-encode-manager.example.com/api/v1/',
@@ -30,14 +23,6 @@ class VideoPipelineMixin(object):
                    'https://video-encode-manager.example.com/api/v1/logout ' \
                    'https://video-encode-manager.example.com/api/v1/redirect'
 
-    def create_video_pipeline_integration(self, **kwargs):
-        """
-        Creates a new `VideoPipelineIntegration` record with `veda_pipeline_integration_defaults`,
-        and it can be updated with any provided overrides.
-        """
-        fields = dict(self.veda_pipeline_integration_defaults, **kwargs)
-        return VideoPipelineIntegration.objects.create(**fields)
-
     def create_vem_pipeline_integration(self, **kwargs):
         """
         Creates a new `VEMPipelineIntegration` record with `vem_pipeline_integration_defaults`,
@@ -46,15 +31,15 @@ class VideoPipelineMixin(object):
         fields = dict(self.vem_pipeline_integration_defaults, **kwargs)
         return VEMPipelineIntegration.objects.create(**fields)
 
-    def create_video_pipeline_oauth_client(self, user, vem_enabled=False, **kwargs):
+    def create_video_pipeline_oauth_client(self, user, **kwargs):
         """
         Creates a new `Client` record with `video_pipeline_oauth_client_defaults`,
         and it can be updated with any provided overrides.
         """
         video_pipeline_oauth_client_defaults = {
-            'name': 'vem_pipeline' if vem_enabled else 'veda_pipeline',
+            'name': 'vem_pipeline',
             'redirect_uris': self.request_uris,
-            'client_id': 'vem_client_id' if vem_enabled else 'video_pipeline_client_id',
+            'client_id': 'vem_client_id',
             'client_secret': 'video_pipeline_client_secret',
             'client_type': Application.CLIENT_CONFIDENTIAL
         }

--- a/openedx/core/djangoapps/video_pipeline/tests/test_api.py
+++ b/openedx/core/djangoapps/video_pipeline/tests/test_api.py
@@ -24,18 +24,9 @@ class TestAPIUtils(VideoPipelineMixin, TestCase):
     """
     def setUp(self):
         """
-        Setup VEDA and VEM oauth clients.
+        Setup VEM oauth client.
         """
-        self.add_veda_client()
         self.add_vem_client()
-
-    def add_veda_client(self):
-        """
-        Creates a VEDA oauth client
-        """
-        self.veda_pipeline_integration = self.create_video_pipeline_integration()
-        self.veda_user = UserFactory(username=self.veda_pipeline_integration.service_username)
-        self.veda_oauth_client = self.create_video_pipeline_oauth_client(user=self.veda_user)
 
     def add_vem_client(self):
         """
@@ -43,37 +34,12 @@ class TestAPIUtils(VideoPipelineMixin, TestCase):
         """
         self.vem_pipeline_integration = self.create_vem_pipeline_integration()
         self.vem_user = UserFactory(username=self.vem_pipeline_integration.service_username)
-        self.vem_oauth_client = self.create_video_pipeline_oauth_client(user=self.vem_user, vem_enabled=True)
+        self.vem_oauth_client = self.create_video_pipeline_oauth_client(user=self.vem_user)
 
-    @patch('openedx.core.djangoapps.video_pipeline.api.log')
-    @patch('openedx.core.djangoapps.video_pipeline.utils.OAuthAPIClient')
-    def test_update_transcription_service_credentials_with_one_integration_disabled(self, mock_client, mock_logger):
+    def test_update_transcription_service_credentials_with_vem_disabled(self):
         """
-        Test that updating the credentials when one of the service integration is disabled, allows
-        the credentials to be updated for other pipeline.
+        Test updating the credentials when VEM is disabled.
         """
-        mock_client.request.return_value.ok = True
-        credentials_payload = {
-            'org': 'mit', 'provider': 'ABC Provider', 'api_key': '61c56a8d0'
-        }
-
-        self.veda_pipeline_integration.enabled = False
-        self.veda_pipeline_integration.save()
-        __, is_updated = update_3rd_party_transcription_service_credentials(**credentials_payload)
-        mock_logger.info.assert_called_with('Sending transcript credentials to VEM for org: {} and provider: {}'.format(
-            credentials_payload.get('org'), credentials_payload.get('provider')
-        ))
-        self.assertTrue(is_updated)
-
-    def test_update_transcription_service_credentials_with_both_integration_disabled(self):
-        """
-        Test updating the credentials when both service integration are disabled.
-        """
-        # Disabling VEDA
-        self.veda_pipeline_integration.enabled = False
-        self.veda_pipeline_integration.save()
-
-        # Disabling VEM
         self.vem_pipeline_integration.enabled = False
         self.vem_pipeline_integration.save()
 
@@ -117,9 +83,6 @@ class TestAPIUtils(VideoPipelineMixin, TestCase):
         self.assertTrue(is_updated)
 
         mock_logger.info.assert_any_call('Sending transcript credentials to VEM for org: {} and provider: {}'.format(
-            credentials_payload.get('org'), credentials_payload.get('provider')
-        ))
-        mock_logger.info.assert_any_call('Sending transcript credentials to VEDA for org: {} and provider: {}'.format(
             credentials_payload.get('org'), credentials_payload.get('provider')
         ))
 


### PR DESCRIPTION
### [PROD-1886](https://openedx.atlassian.net/browse/PROD-1886)

### Description
This PR is removing the options to send upload course videos and add/update transcript credentials in VEDA. All the uploads should go to VEM. Any conditional check deciding between VEM and VEDA has been removed.