### PR TITLE
Revert "Python Requirements Update"

### DIFF
--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -113,12 +113,12 @@ edx-sga==0.11.0           # via -r requirements/edx/base.in
 edx-submissions==3.1.11   # via -r requirements/edx/base.in, ora2
 edx-tincan-py35==0.0.5    # via edx-enterprise
 edx-user-state-client==1.2.0  # via -r requirements/edx/base.in
-edx-when==1.2.9           # via -r requirements/edx/base.in, edx-proctoring
+edx-when==1.2.8           # via -r requirements/edx/base.in, edx-proctoring
 edxval==1.3.8             # via -r requirements/edx/base.in
 elasticsearch==1.9.0      # via edx-search
 enmerkar-underscore==1.0.0  # via -r requirements/edx/base.in
 enmerkar==0.7.1           # via enmerkar-underscore
-event-tracking==0.3.3     # via -r requirements/edx/base.in, edx-proctoring, edx-search
+event-tracking==0.3.2     # via -r requirements/edx/base.in, edx-proctoring, edx-search
 fs-s3fs==0.1.8            # via -r requirements/edx/base.in, django-pyfs
 fs==2.0.18                # via -r requirements/edx/base.in, django-pyfs, fs-s3fs, xblock
 future==0.18.2            # via django-ses, edx-celeryutils, edx-enterprise, pycontracts, pyjwkest

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -127,12 +127,12 @@ edx-sphinx-theme==1.5.0   # via -r requirements/edx/development.in
 edx-submissions==3.1.11   # via -r requirements/edx/testing.txt, ora2
 edx-tincan-py35==0.0.5    # via -r requirements/edx/testing.txt, edx-enterprise
 edx-user-state-client==1.2.0  # via -r requirements/edx/testing.txt
-edx-when==1.2.9           # via -r requirements/edx/testing.txt, edx-proctoring
+edx-when==1.2.8           # via -r requirements/edx/testing.txt, edx-proctoring
 edxval==1.3.8             # via -r requirements/edx/testing.txt
 elasticsearch==1.9.0      # via -r requirements/edx/testing.txt, edx-search
 enmerkar-underscore==1.0.0  # via -r requirements/edx/testing.txt
 enmerkar==0.7.1           # via -r requirements/edx/testing.txt, enmerkar-underscore
-event-tracking==0.3.3     # via -r requirements/edx/testing.txt, edx-proctoring, edx-search
+event-tracking==0.3.2     # via -r requirements/edx/testing.txt, edx-proctoring, edx-search
 execnet==1.7.1            # via -r requirements/edx/testing.txt, pytest-xdist
 factory-boy==2.8.1        # via -c requirements/edx/../constraints.txt, -r requirements/edx/testing.txt
 faker==4.1.1              # via -r requirements/edx/testing.txt, factory-boy
@@ -244,7 +244,7 @@ pytest-forked==1.2.0      # via -r requirements/edx/testing.txt, pytest-xdist
 pytest-json-report==1.2.1  # via -r requirements/edx/testing.txt
 pytest-metadata==1.8.0    # via -r requirements/edx/testing.txt, pytest-json-report
 pytest-randomly==3.4.0    # via -r requirements/edx/testing.txt
-pytest-xdist==1.33.0      # via -r requirements/edx/testing.txt
+pytest-xdist==1.32.0      # via -r requirements/edx/testing.txt
 pytest==5.3.5             # via -c requirements/edx/../constraints.txt, -r requirements/edx/testing.txt, pytest-attrib, pytest-cov, pytest-django, pytest-forked, pytest-json-report, pytest-metadata, pytest-randomly, pytest-xdist
 python-dateutil==2.4.0    # via -c requirements/edx/../constraints.txt, -r requirements/edx/testing.txt, analytics-python, botocore, edx-ace, edx-drf-extensions, edx-enterprise, edx-proctoring, faker, freezegun, icalendar, ora2, xblock
 python-levenshtein==0.12.0  # via -r requirements/edx/testing.txt
@@ -306,7 +306,7 @@ toml==0.10.1              # via -r requirements/edx/testing.txt, tox
 tox-battery==0.6.1        # via -r requirements/edx/testing.txt
 tox==3.16.1               # via -r requirements/edx/testing.txt, tox-battery
 tqdm==4.47.0              # via -r requirements/edx/testing.txt, nltk
-transifex-client==0.13.11  # via -r requirements/edx/testing.txt
+transifex-client==0.13.10  # via -r requirements/edx/testing.txt
 typed-ast==1.4.1          # via -r requirements/edx/testing.txt, astroid
 ua-parser==0.10.0         # via -r requirements/edx/testing.txt, django-cookies-samesite
 unicodecsv==0.14.1        # via -r requirements/edx/testing.txt, edx-enterprise

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -123,12 +123,12 @@ edx-sga==0.11.0           # via -r requirements/edx/base.txt
 edx-submissions==3.1.11   # via -r requirements/edx/base.txt, ora2
 edx-tincan-py35==0.0.5    # via -r requirements/edx/base.txt, edx-enterprise
 edx-user-state-client==1.2.0  # via -r requirements/edx/base.txt
-edx-when==1.2.9           # via -r requirements/edx/base.txt, edx-proctoring
+edx-when==1.2.8           # via -r requirements/edx/base.txt, edx-proctoring
 edxval==1.3.8             # via -r requirements/edx/base.txt
 elasticsearch==1.9.0      # via -r requirements/edx/base.txt, edx-search
 enmerkar-underscore==1.0.0  # via -r requirements/edx/base.txt
 enmerkar==0.7.1           # via -r requirements/edx/base.txt, enmerkar-underscore
-event-tracking==0.3.3     # via -r requirements/edx/base.txt, edx-proctoring, edx-search
+event-tracking==0.3.2     # via -r requirements/edx/base.txt, edx-proctoring, edx-search
 execnet==1.7.1            # via pytest-xdist
 factory-boy==2.8.1        # via -c requirements/edx/../constraints.txt, -r requirements/edx/testing.in
 faker==4.1.1              # via factory-boy
@@ -234,7 +234,7 @@ pytest-forked==1.2.0      # via pytest-xdist
 pytest-json-report==1.2.1  # via -r requirements/edx/testing.in
 pytest-metadata==1.8.0    # via -r requirements/edx/testing.in, pytest-json-report
 pytest-randomly==3.4.0    # via -r requirements/edx/testing.in
-pytest-xdist==1.33.0      # via -r requirements/edx/testing.in
+pytest-xdist==1.32.0      # via -r requirements/edx/testing.in
 pytest==5.3.5             # via -c requirements/edx/../constraints.txt, -r requirements/edx/testing.in, pytest-attrib, pytest-cov, pytest-django, pytest-forked, pytest-json-report, pytest-metadata, pytest-randomly, pytest-xdist
 python-dateutil==2.4.0    # via -c requirements/edx/../constraints.txt, -r requirements/edx/base.txt, analytics-python, botocore, edx-ace, edx-drf-extensions, edx-enterprise, edx-proctoring, faker, freezegun, icalendar, ora2, xblock
 python-levenshtein==0.12.0  # via -r requirements/edx/base.txt
@@ -285,7 +285,7 @@ toml==0.10.1              # via tox
 tox-battery==0.6.1        # via -r requirements/edx/testing.in
 tox==3.16.1               # via -r requirements/edx/testing.in, tox-battery
 tqdm==4.47.0              # via -r requirements/edx/base.txt, nltk
-transifex-client==0.13.11  # via -r requirements/edx/testing.in
+transifex-client==0.13.10  # via -r requirements/edx/testing.in
 typed-ast==1.4.1          # via astroid
 ua-parser==0.10.0         # via -r requirements/edx/base.txt, django-cookies-samesite
 unicodecsv==0.14.1        # via -r requirements/edx/base.txt, edx-enterprise


### PR DESCRIPTION
Reverts edx/edx-platform#24445

This broke requirements installation while building for production:

```
    ERROR: Command errored out with exit status 1:
     command: /edx/app/edxapp/venvs/edxapp/bin/python3.5 -c 'import sys, setuptools, tokenize; sys.argv[0] = '"'"'/tmp/pip-install-r8v5w8e2/beautifulsoup/setup.py'"'"'; __file__='"'"'/tmp/pip-install-r8v5w8e2/beautifulsoup/setup.py'"'"';f=getattr(tokenize, '"'"'open'"'"', open)(__file__);code=f.read().replace('"'"'\r\n'"'"', '"'"'\n'"'"');f.close();exec(compile(code, __file__, '"'"'exec'"'"'))' egg_info --egg-base /tmp/pip-install-r8v5w8e2/beautifulsoup/pip-egg-info
         cwd: /tmp/pip-install-r8v5w8e2/beautifulsoup/
    Complete output (6 lines):
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/tmp/pip-install-r8v5w8e2/beautifulsoup/setup.py", line 22
        print "Unit tests have failed!"
                                      ^
    SyntaxError: Missing parentheses in call to 'print'
    ----------------------------------------
ERROR: Command errored out with exit status 1: python setup.py egg_info Check the logs for full command output.
WARNING: You are using pip version 20.0.2; however, version 20.1.1 is available.
You should consider upgrading via the '/edx/app/edxapp/venvs/edxapp/bin/python3.5 -m pip install --upgrade pip' command.
```

It's not clear exactly how this is happening but it started when this commit merged so reverting it for now.