### PR TITLE
[BD-6] Upgrade packages [codejail]

### DIFF
--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -6,7 +6,7 @@
 #
 -e git+https://github.com/edx/acid-block.git@98aecba94ecbfa934e2d00262741c0ea9f557fc9#egg=acid-xblock  # via -r requirements/edx/github.in
 -e common/lib/capa  # via -r requirements/edx/local.in
--e git+https://github.com/edx/codejail.git@4127fc4bd5775cc72aee8d7f0a70e31405e22439#egg=codejail  # via -r requirements/edx/github.in
+-e git+https://github.com/edx/codejail.git@56abd45fcf68c6ab7b523768aa5991d6e04d8241#egg=codejail==3.0.0  # via -r requirements/edx/github.in
 -e git+https://github.com/edx/django-wiki.git@0.0.27#egg=django-wiki  # via -r requirements/edx/github.in
 -e git+https://github.com/edx/DoneXBlock.git@2.0.2#egg=done-xblock  # via -r requirements/edx/github.in
 -e git+https://github.com/jazkarta/edx-jsme.git@690dbf75441fa91c7c4899df0b83d77f7deb5458#egg=edx-jsme  # via -r requirements/edx/github.in
@@ -113,12 +113,12 @@ edx-sga==0.11.0           # via -r requirements/edx/base.in
 edx-submissions==3.1.11   # via -r requirements/edx/base.in, ora2
 edx-tincan-py35==0.0.5    # via edx-enterprise
 edx-user-state-client==1.2.0  # via -r requirements/edx/base.in
-edx-when==1.2.8           # via -r requirements/edx/base.in, edx-proctoring
+edx-when==1.2.9           # via -r requirements/edx/base.in, edx-proctoring
 edxval==1.3.8             # via -r requirements/edx/base.in
 elasticsearch==1.9.0      # via edx-search
 enmerkar-underscore==1.0.0  # via -r requirements/edx/base.in
 enmerkar==0.7.1           # via enmerkar-underscore
-event-tracking==0.3.2     # via -r requirements/edx/base.in, edx-proctoring, edx-search
+event-tracking==0.3.3     # via -r requirements/edx/base.in, edx-proctoring, edx-search
 fs-s3fs==0.1.8            # via -r requirements/edx/base.in, django-pyfs
 fs==2.0.18                # via -r requirements/edx/base.in, django-pyfs, fs-s3fs, xblock
 future==0.18.2            # via django-ses, edx-celeryutils, edx-enterprise, pycontracts, pyjwkest

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -6,7 +6,7 @@
 #
 -e git+https://github.com/edx/acid-block.git@98aecba94ecbfa934e2d00262741c0ea9f557fc9#egg=acid-xblock  # via -r requirements/edx/testing.txt
 -e common/lib/capa  # via -r requirements/edx/testing.txt
--e git+https://github.com/edx/codejail.git@4127fc4bd5775cc72aee8d7f0a70e31405e22439#egg=codejail  # via -r requirements/edx/testing.txt
+-e git+https://github.com/edx/codejail.git@56abd45fcf68c6ab7b523768aa5991d6e04d8241#egg=codejail==3.0.0  # via -r requirements/edx/testing.txt
 -e git+https://github.com/edx/django-wiki.git@0.0.27#egg=django-wiki  # via -r requirements/edx/testing.txt
 -e git+https://github.com/edx/DoneXBlock.git@2.0.2#egg=done-xblock  # via -r requirements/edx/testing.txt
 -e git+https://github.com/jazkarta/edx-jsme.git@690dbf75441fa91c7c4899df0b83d77f7deb5458#egg=edx-jsme  # via -r requirements/edx/testing.txt
@@ -127,12 +127,12 @@ edx-sphinx-theme==1.5.0   # via -r requirements/edx/development.in
 edx-submissions==3.1.11   # via -r requirements/edx/testing.txt, ora2
 edx-tincan-py35==0.0.5    # via -r requirements/edx/testing.txt, edx-enterprise
 edx-user-state-client==1.2.0  # via -r requirements/edx/testing.txt
-edx-when==1.2.8           # via -r requirements/edx/testing.txt, edx-proctoring
+edx-when==1.2.9           # via -r requirements/edx/testing.txt, edx-proctoring
 edxval==1.3.8             # via -r requirements/edx/testing.txt
 elasticsearch==1.9.0      # via -r requirements/edx/testing.txt, edx-search
 enmerkar-underscore==1.0.0  # via -r requirements/edx/testing.txt
 enmerkar==0.7.1           # via -r requirements/edx/testing.txt, enmerkar-underscore
-event-tracking==0.3.2     # via -r requirements/edx/testing.txt, edx-proctoring, edx-search
+event-tracking==0.3.3     # via -r requirements/edx/testing.txt, edx-proctoring, edx-search
 execnet==1.7.1            # via -r requirements/edx/testing.txt, pytest-xdist
 factory-boy==2.8.1        # via -c requirements/edx/../constraints.txt, -r requirements/edx/testing.txt
 faker==4.1.1              # via -r requirements/edx/testing.txt, factory-boy
@@ -243,8 +243,8 @@ pytest-django==3.8.0      # via -c requirements/edx/../constraints.txt, -r requi
 pytest-forked==1.2.0      # via -r requirements/edx/testing.txt, pytest-xdist
 pytest-json-report==1.2.1  # via -r requirements/edx/testing.txt
 pytest-metadata==1.8.0    # via -r requirements/edx/testing.txt, pytest-json-report
-pytest-randomly==3.4.0    # via -r requirements/edx/testing.txt
-pytest-xdist==1.32.0      # via -r requirements/edx/testing.txt
+pytest-randomly==3.4.1    # via -r requirements/edx/testing.txt
+pytest-xdist==1.33.0      # via -r requirements/edx/testing.txt
 pytest==5.3.5             # via -c requirements/edx/../constraints.txt, -r requirements/edx/testing.txt, pytest-attrib, pytest-cov, pytest-django, pytest-forked, pytest-json-report, pytest-metadata, pytest-randomly, pytest-xdist
 python-dateutil==2.4.0    # via -c requirements/edx/../constraints.txt, -r requirements/edx/testing.txt, analytics-python, botocore, edx-ace, edx-drf-extensions, edx-enterprise, edx-proctoring, faker, freezegun, icalendar, ora2, xblock
 python-levenshtein==0.12.0  # via -r requirements/edx/testing.txt
@@ -306,7 +306,7 @@ toml==0.10.1              # via -r requirements/edx/testing.txt, tox
 tox-battery==0.6.1        # via -r requirements/edx/testing.txt
 tox==3.16.1               # via -r requirements/edx/testing.txt, tox-battery
 tqdm==4.47.0              # via -r requirements/edx/testing.txt, nltk
-transifex-client==0.13.10  # via -r requirements/edx/testing.txt
+transifex-client==0.13.11  # via -r requirements/edx/testing.txt
 typed-ast==1.4.1          # via -r requirements/edx/testing.txt, astroid
 ua-parser==0.10.0         # via -r requirements/edx/testing.txt, django-cookies-samesite
 unicodecsv==0.14.1        # via -r requirements/edx/testing.txt, edx-enterprise

--- a/requirements/edx/github.in
+++ b/requirements/edx/github.in
@@ -59,7 +59,7 @@ git+https://github.com/edx/MongoDBProxy.git@d92bafe9888d2940f647a7b2b2383b29c752
 -e git+https://github.com/jazkarta/edx-jsme.git@690dbf75441fa91c7c4899df0b83d77f7deb5458#egg=edx-jsme
 
 # Our libraries:
--e git+https://github.com/edx/codejail.git@4127fc4bd5775cc72aee8d7f0a70e31405e22439#egg=codejail
+-e git+https://github.com/edx/codejail.git@56abd45fcf68c6ab7b523768aa5991d6e04d8241#egg=codejail==3.0.0
 -e git+https://github.com/edx/acid-block.git@98aecba94ecbfa934e2d00262741c0ea9f557fc9#egg=acid-xblock
 -e git+https://github.com/edx/RateXBlock.git@2.0#egg=rate-xblock
 -e git+https://github.com/edx/DoneXBlock.git@2.0.2#egg=done-xblock

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -6,7 +6,7 @@
 #
 -e git+https://github.com/edx/acid-block.git@98aecba94ecbfa934e2d00262741c0ea9f557fc9#egg=acid-xblock  # via -r requirements/edx/base.txt
 -e common/lib/capa  # via -r requirements/edx/base.txt
--e git+https://github.com/edx/codejail.git@4127fc4bd5775cc72aee8d7f0a70e31405e22439#egg=codejail  # via -r requirements/edx/base.txt
+-e git+https://github.com/edx/codejail.git@56abd45fcf68c6ab7b523768aa5991d6e04d8241#egg=codejail==3.0.0  # via -r requirements/edx/base.txt
 -e git+https://github.com/edx/django-wiki.git@0.0.27#egg=django-wiki  # via -r requirements/edx/base.txt
 -e git+https://github.com/edx/DoneXBlock.git@2.0.2#egg=done-xblock  # via -r requirements/edx/base.txt
 -e git+https://github.com/jazkarta/edx-jsme.git@690dbf75441fa91c7c4899df0b83d77f7deb5458#egg=edx-jsme  # via -r requirements/edx/base.txt
@@ -123,12 +123,12 @@ edx-sga==0.11.0           # via -r requirements/edx/base.txt
 edx-submissions==3.1.11   # via -r requirements/edx/base.txt, ora2
 edx-tincan-py35==0.0.5    # via -r requirements/edx/base.txt, edx-enterprise
 edx-user-state-client==1.2.0  # via -r requirements/edx/base.txt
-edx-when==1.2.8           # via -r requirements/edx/base.txt, edx-proctoring
+edx-when==1.2.9           # via -r requirements/edx/base.txt, edx-proctoring
 edxval==1.3.8             # via -r requirements/edx/base.txt
 elasticsearch==1.9.0      # via -r requirements/edx/base.txt, edx-search
 enmerkar-underscore==1.0.0  # via -r requirements/edx/base.txt
 enmerkar==0.7.1           # via -r requirements/edx/base.txt, enmerkar-underscore
-event-tracking==0.3.2     # via -r requirements/edx/base.txt, edx-proctoring, edx-search
+event-tracking==0.3.3     # via -r requirements/edx/base.txt, edx-proctoring, edx-search
 execnet==1.7.1            # via pytest-xdist
 factory-boy==2.8.1        # via -c requirements/edx/../constraints.txt, -r requirements/edx/testing.in
 faker==4.1.1              # via factory-boy
@@ -233,8 +233,8 @@ pytest-django==3.8.0      # via -c requirements/edx/../constraints.txt, -r requi
 pytest-forked==1.2.0      # via pytest-xdist
 pytest-json-report==1.2.1  # via -r requirements/edx/testing.in
 pytest-metadata==1.8.0    # via -r requirements/edx/testing.in, pytest-json-report
-pytest-randomly==3.4.0    # via -r requirements/edx/testing.in
-pytest-xdist==1.32.0      # via -r requirements/edx/testing.in
+pytest-randomly==3.4.1    # via -r requirements/edx/testing.in
+pytest-xdist==1.33.0      # via -r requirements/edx/testing.in
 pytest==5.3.5             # via -c requirements/edx/../constraints.txt, -r requirements/edx/testing.in, pytest-attrib, pytest-cov, pytest-django, pytest-forked, pytest-json-report, pytest-metadata, pytest-randomly, pytest-xdist
 python-dateutil==2.4.0    # via -c requirements/edx/../constraints.txt, -r requirements/edx/base.txt, analytics-python, botocore, edx-ace, edx-drf-extensions, edx-enterprise, edx-proctoring, faker, freezegun, icalendar, ora2, xblock
 python-levenshtein==0.12.0  # via -r requirements/edx/base.txt
@@ -285,7 +285,7 @@ toml==0.10.1              # via tox
 tox-battery==0.6.1        # via -r requirements/edx/testing.in
 tox==3.16.1               # via -r requirements/edx/testing.in, tox-battery
 tqdm==4.47.0              # via -r requirements/edx/base.txt, nltk
-transifex-client==0.13.10  # via -r requirements/edx/testing.in
+transifex-client==0.13.11  # via -r requirements/edx/testing.in
 typed-ast==1.4.1          # via astroid
 ua-parser==0.10.0         # via -r requirements/edx/base.txt, django-cookies-samesite
 unicodecsv==0.14.1        # via -r requirements/edx/base.txt, edx-enterprise


### PR DESCRIPTION
Upgrade codejail version, in order to use the version that supports python3.8

 https://github.com/edx/codejail/pull/90

## Reviewers
- [ ] @awais786 
- [ ] @feanil 