### PR TITLE
[BD-14] Changes for Libraries v2

### DIFF
--- a/cms/djangoapps/contentstore/config/waffle.py
+++ b/cms/djangoapps/contentstore/config/waffle.py
@@ -4,7 +4,12 @@ waffle switches for the contentstore app.
 """
 
 
-from openedx.core.djangoapps.waffle_utils import CourseWaffleFlag, WaffleFlagNamespace, WaffleSwitchNamespace
+from openedx.core.djangoapps.waffle_utils import (
+    CourseWaffleFlag,
+    WaffleFlag,
+    WaffleFlagNamespace,
+    WaffleSwitchNamespace,
+)
 
 # Namespace
 WAFFLE_NAMESPACE = u'studio'
@@ -41,4 +46,21 @@ ENABLE_CHECKLISTS_QUALITY = CourseWaffleFlag(
 SHOW_REVIEW_RULES_FLAG = CourseWaffleFlag(
     waffle_namespace=waffle_flags(),
     flag_name=u'show_review_rules',
+)
+
+# Waffle flag to redirect to the library authoring MFE.
+# .. toggle_name: contentstore.library_authoring_mfe
+# .. toggle_implementation: WaffleFlag
+# .. toggle_default: False
+# .. toggle_description: Toggles the new micro-frontend-based implementation of the library authoring experience.
+# .. toggle_category: micro-frontend
+# .. toggle_use_cases: incremental_release, open_edx
+# .. toggle_creation_date: 2020-08-03
+# .. toggle_expiration_date: 2020-12-31
+# .. toggle_warnings: Also set settings.LIBRARY_AUTHORING_MICROFRONTEND_URL and ENABLE_LIBRARY_AUTHORING_MICROFRONTEND.
+# .. toggle_tickets: https://openedx.atlassian.net/wiki/spaces/COMM/pages/1545011241/BD-14+Blockstore+Powered+Content+Libraries+Taxonomies
+# .. toggle_status: supported
+REDIRECT_TO_LIBRARY_AUTHORING_MICROFRONTEND = WaffleFlag(
+    waffle_namespace=waffle_flags(),
+    flag_name='library_authoring_mfe',
 )

--- a/cms/djangoapps/contentstore/views/course.py
+++ b/cms/djangoapps/contentstore/views/course.py
@@ -100,7 +100,12 @@ from xmodule.tabs import CourseTab, CourseTabList, InvalidTabsException
 
 from .component import ADVANCED_COMPONENT_TYPES
 from .item import create_xblock_info
-from .library import LIBRARIES_ENABLED, get_library_creator_status
+from .library import (
+    LIBRARY_AUTHORING_MICROFRONTEND_URL,
+    LIBRARIES_ENABLED,
+    get_library_creator_status,
+    should_redirect_to_library_authoring_mfe,
+)
 
 log = logging.getLogger(__name__)
 
@@ -554,8 +559,10 @@ def course_listing(request):
         u'archived_courses': archived_courses,
         u'in_process_course_actions': in_process_course_actions,
         u'libraries_enabled': LIBRARIES_ENABLED,
+        u'redirect_to_library_authoring_mfe': should_redirect_to_library_authoring_mfe(),
+        u'library_authoring_mfe_url': LIBRARY_AUTHORING_MICROFRONTEND_URL,
         u'libraries': [format_library_for_view(lib) for lib in libraries],
-        u'show_new_library_button': get_library_creator_status(user),
+        u'show_new_library_button': get_library_creator_status(user) and not should_redirect_to_library_authoring_mfe(),
         u'user': user,
         u'request_course_creator_url': reverse('request_course_creator'),
         u'course_creator_status': _get_course_creator_status(user),

--- a/cms/djangoapps/contentstore/views/library.py
+++ b/cms/djangoapps/contentstore/views/library.py
@@ -36,6 +36,8 @@ from xmodule.modulestore import ModuleStoreEnum
 from xmodule.modulestore.django import modulestore
 from xmodule.modulestore.exceptions import DuplicateCourseError
 
+from ..config.waffle import REDIRECT_TO_LIBRARY_AUTHORING_MICROFRONTEND
+
 from .component import CONTAINER_TEMPLATES, get_component_templates
 from .user import user_with_role
 
@@ -44,6 +46,21 @@ __all__ = ['library_handler', 'manage_library_users']
 log = logging.getLogger(__name__)
 
 LIBRARIES_ENABLED = settings.FEATURES.get('ENABLE_CONTENT_LIBRARIES', False)
+ENABLE_LIBRARY_AUTHORING_MICROFRONTEND = settings.FEATURES.get('ENABLE_LIBRARY_AUTHORING_MICROFRONTEND', False)
+LIBRARY_AUTHORING_MICROFRONTEND_URL = settings.LIBRARY_AUTHORING_MICROFRONTEND_URL
+
+
+def should_redirect_to_library_authoring_mfe():
+    """
+    Boolean helper method, returns whether or not to redirect to the Library
+    Authoring MFE based on settings and flags.
+    """
+
+    return (
+        ENABLE_LIBRARY_AUTHORING_MICROFRONTEND and
+        LIBRARY_AUTHORING_MICROFRONTEND_URL and
+        REDIRECT_TO_LIBRARY_AUTHORING_MICROFRONTEND.is_enabled()
+    )
 
 
 def get_library_creator_status(user):

--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -405,6 +405,19 @@ FEATURES = {
     # .. toggle_tickets: https://openedx.atlassian.net/browse/DEPR-58
     # .. toggle_status: supported
     'DEPRECATE_OLD_COURSE_KEYS_IN_STUDIO': True,
+
+    # .. toggle_name: ENABLE_LIBRARY_AUTHORING_MICROFRONTEND
+    # .. toggle_implementation: DjangoSetting
+    # .. toggle_default: False
+    # .. toggle_description: Set to True to enable the Library Authoring MFE
+    # .. toggle_category: micro-frontend
+    # .. toggle_use_cases: incremental_release
+    # .. toggle_creation_date: 2020-06-20
+    # .. toggle_expiration_date: 2020-12-31
+    # .. toggle_tickets: https://openedx.atlassian.net/wiki/spaces/COMM/pages/1545011241/BD-14+Blockstore+Powered+Content+Libraries+Taxonomies
+    # .. toggle_status: supported
+    # .. toggle_warnings: Also set settings.LIBRARY_AUTHORING_MICROFRONTEND_URL and see REDIRECT_TO_LIBRARY_AUTHORING_MICROFRONTEND for rollout.
+    'ENABLE_LIBRARY_AUTHORING_MICROFRONTEND': False,
 }
 
 ENABLE_JASMINE = False
@@ -415,6 +428,7 @@ IDA_LOGOUT_URI_LIST = []
 
 ############################# MICROFRONTENDS ###################################
 COURSE_AUTHORING_MICROFRONTEND_URL = None
+LIBRARY_AUTHORING_MICROFRONTEND_URL = None
 
 ############################# SOCIAL MEDIA SHARING #############################
 SOCIAL_SHARING_SETTINGS = {

--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -2098,13 +2098,12 @@ FINANCIAL_REPORTS = {
 ############# CORS headers for cross-domain requests #################
 if FEATURES.get('ENABLE_CORS_HEADERS'):
     CORS_ALLOW_CREDENTIALS = True
+    CORS_ORIGIN_WHITELIST = ()
+    CORS_ORIGIN_ALLOW_ALL = False
+    CORS_ALLOW_INSECURE = False
     CORS_ALLOW_HEADERS = corsheaders_default_headers + (
         'use-jwt-cookie',
     )
-
-CORS_ORIGIN_WHITELIST = []
-CORS_ORIGIN_ALLOW_ALL = False
-
 
 LOGIN_REDIRECT_WHITELIST = []
 

--- a/cms/envs/devstack.py
+++ b/cms/envs/devstack.py
@@ -145,6 +145,9 @@ FEATURES['ENABLE_CREATOR_GROUP'] = False
 ################### FRONTEND APPLICATION PUBLISHER URL ###################
 FEATURES['FRONTEND_APP_PUBLISHER_URL'] = 'http://localhost:18400'
 
+################### FRONTEND APPLICATION LIBRARY AUTHORING ###################
+LIBRARY_AUTHORING_MICROFRONTEND_URL = 'http://localhost:3001'
+
 ################################# DJANGO-REQUIRE ###############################
 
 # Whether to run django-require in debug mode.

--- a/cms/templates/index.html
+++ b/cms/templates/index.html
@@ -318,7 +318,11 @@ from openedx.core.djangolib.js_utils import (
         <li class="archived-courses-tab"><a>${_("Archived Courses")}</a></li>
         % endif
         % if libraries_enabled:
+        % if redirect_to_library_authoring_mfe:
+        <li><a href="${library_authoring_mfe_url}">${_("Libraries")}</a></li>
+        %else:
         <li class="libraries-tab"><a>${_("Libraries")}</a></li>
+        % endif
         % endif
       </ul>
       % endif

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -2778,12 +2778,11 @@ if FEATURES.get('ENABLE_CORS_HEADERS'):
     CORS_ALLOW_CREDENTIALS = True
     CORS_ORIGIN_WHITELIST = ()
     CORS_ORIGIN_ALLOW_ALL = False
+    CORS_ALLOW_INSECURE = False
     CORS_ALLOW_HEADERS = corsheaders_default_headers + (
         'use-jwt-cookie',
     )
 
-CORS_ORIGIN_WHITELIST = []
-CORS_ORIGIN_ALLOW_ALL = False
 # Default cache expiration for the cross-domain proxy HTML page.
 # This is a static page that can be iframed into an external page
 # to simulate cross-domain requests.


### PR DESCRIPTION
This PR herds in the changes required for Content Libraries v2 to work.

Testing this is best done as described in https://github.com/open-craft/frontend-app-library-authoring/pull/2.