### PR TITLE
Add masquerade as specific student support for MFE

### DIFF
--- a/lms/djangoapps/courseware/masquerade.py
+++ b/lms/djangoapps/courseware/masquerade.py
@@ -103,7 +103,7 @@ class MasqueradeView(View):
                 'course_key': course_key_string,
                 'group_id': course.group_id,
                 'role': course.role,
-                'user_name': course.user_name or ' ',
+                'user_name': course.user_name or None,
                 'user_partition_id': course.user_partition_id,
             },
             'available': [

--- a/lms/djangoapps/courseware/masquerade.py
+++ b/lms/djangoapps/courseware/masquerade.py
@@ -69,6 +69,23 @@ class CourseMasquerade(object):
         """
         self.__init__(**state)
 
+    def get_active_group_name(self, available):
+        """
+        Lookup the active group name, from available options
+
+        Returns: the corresponding group name, if exists,
+            else, return None
+        """
+        if not (self.group_id and self.user_partition_id):
+            return None
+        for group in available:
+            if (
+                self.group_id == group.get('group_id') and
+                self.user_partition_id == group.get('user_partition_id')
+            ):
+                return group.get('name')
+        return None
+
 
 @method_decorator(login_required, name='dispatch')
 class MasqueradeView(View):
@@ -128,6 +145,7 @@ class MasqueradeView(View):
                     }
                     for group in partition.groups
                 ])
+        data['active']['group_name'] = course.get_active_group_name(data['available'])
         return JsonResponse(data)
 
     @method_decorator(expect_json)

--- a/lms/djangoapps/courseware/masquerade.py
+++ b/lms/djangoapps/courseware/masquerade.py
@@ -158,7 +158,7 @@ class MasqueradeView(View):
                 return JsonResponse({
                     'success': False,
                     'error': _(
-                        u'There is no user with the username or email address u"{user_identifier}" '
+                        u'There is no user with the username or email address "{user_identifier}" '
                         'enrolled in this course.'
                     ).format(
                         user_identifier=user_name,


### PR DESCRIPTION
Release notes:
1. deploy this first
  - there should be no change to the user experience
    - this gets the supporting code in place, but does not enable it
2. then deploy the MFE [1]
  - the new "You are masquerading as" alerts now show up in UI
    - new UI support is now available, but the feature is still "disabled"
3. last, deploy the follow-up platform PR [2] 
  - the "Specific student" option will now show up and function
    - the LMS now reports the feature as enabled and the frontend picks it up automagically

## References
- [1] https://github.com/edx/edx-platform/pull/24455
- [2] https://github.com/edx/frontend-app-learning/pull/106
- [3] https://github.com/edx/edx-platform/pull/24703