### PR TITLE
Allow entitlements to be used past the enrollment date.

### DIFF
--- a/common/djangoapps/entitlements/tests/test_utils.py
+++ b/common/djangoapps/entitlements/tests/test_utils.py
@@ -102,18 +102,6 @@ class TestCourseRunFulfillableForEntitlement(ModuleStoreTestCase):
 
         assert not is_course_run_entitlement_fulfillable(course_overview.id, entitlement)
 
-    def test_course_run_not_fulfillable_enroll_period_ended(self):
-        course_overview = self.create_course(
-            start_from_now=-3,
-            end_from_now=2,
-            enrollment_start_from_now=-2,
-            enrollment_end_from_now=-1
-        )
-
-        entitlement = CourseEntitlementFactory.create(mode=CourseMode.VERIFIED)
-
-        assert not is_course_run_entitlement_fulfillable(course_overview.id, entitlement)
-
     def test_course_run_not_fulfillable_enrollment_start_in_future(self):
         course_overview = self.create_course(
             start_from_now=-3,
@@ -140,7 +128,7 @@ class TestCourseRunFulfillableForEntitlement(ModuleStoreTestCase):
 
         assert is_course_run_entitlement_fulfillable(course_overview.id, entitlement)
 
-    def test_course_run_fulfillable_enrollment_ended_upgrade_open(self):
+    def test_course_run_fulfillable_enrollment_ended_already_enrolled(self):
         course_overview = self.create_course(
             start_from_now=-3,
             end_from_now=2,
@@ -166,3 +154,15 @@ class TestCourseRunFulfillableForEntitlement(ModuleStoreTestCase):
         entitlement = CourseEntitlementFactory.create(mode=CourseMode.VERIFIED)
 
         assert not is_course_run_entitlement_fulfillable(course_overview.id, entitlement)
+
+    def test_course_run_fulfillable_enrollment_ended_upgrade_open(self):
+        course_overview = self.create_course(
+            start_from_now=-3,
+            end_from_now=2,
+            enrollment_start_from_now=-2,
+            enrollment_end_from_now=-1,
+        )
+
+        entitlement = CourseEntitlementFactory.create(mode=CourseMode.VERIFIED)
+
+        assert is_course_run_entitlement_fulfillable(course_overview.id, entitlement)

--- a/common/djangoapps/entitlements/utils.py
+++ b/common/djangoapps/entitlements/utils.py
@@ -48,13 +48,11 @@ def is_course_run_entitlement_fulfillable(
     run_end = course_overview.end
     is_running = run_start and (not run_end or (run_end and (run_end > compare_date)))
 
-    # Verify that the course run can currently be enrolled
+    # Verify that the course run can currently be enrolled, explicitly
+    # not checking for enrollment end date becasue course run is still
+    # fulfillable if enrollment has ended but VUD is in future
     enrollment_start = course_overview.enrollment_start
-    enrollment_end = course_overview.enrollment_end
-    can_enroll = (
-        (not enrollment_start or enrollment_start < compare_date)
-        and (not enrollment_end or enrollment_end > compare_date)
-    )
+    can_enroll = not enrollment_start or enrollment_start < compare_date
 
     # Is the user already enrolled in the Course Run
     is_enrolled = CourseEnrollment.is_enrolled(entitlement.user, course_run_key)

--- a/common/djangoapps/student/models.py
+++ b/common/djangoapps/student/models.py
@@ -1430,7 +1430,7 @@ class CourseEnrollment(models.Model):
                 )
 
     @classmethod
-    def enroll(cls, user, course_key, mode=None, check_access=False):
+    def enroll(cls, user, course_key, mode=None, check_access=False, can_upgrade=False):
         """
         Enroll a user in a course. This saves immediately.
 
@@ -1453,6 +1453,11 @@ class CourseEnrollment(models.Model):
                 The default is set to False to avoid breaking legacy code or
                 code with non-standard flows (ex. beta tester invitations), but
                 for any standard enrollment flow you probably want this to be True.
+
+        `can_upgrade`: if course is upgradeable, alow learners to enroll even
+                if enrollment is closed. This is a special case for entitlements
+                while selecting a session. The default is set to False to avoid
+                breaking the orignal course enroll code.
 
         Exceptions that can be raised: NonExistentCourseError,
         EnrollmentClosedError, CourseFullError, AlreadyEnrolledError.  All these
@@ -1477,7 +1482,7 @@ class CourseEnrollment(models.Model):
                 raise NonExistentCourseError
 
         if check_access:
-            if cls.is_enrollment_closed(user, course):
+            if cls.is_enrollment_closed(user, course) and not can_upgrade:
                 log.warning(
                     u"User %s failed to enroll in course %s because enrollment is closed",
                     user.username,


### PR DESCRIPTION
Allow entitlements to be used to upgrade to verified track past the course enrollment date and before the upgrade deadline

PROD-1497