### PR TITLE
Updated URLs to course-authoring MFE

### DIFF
--- a/cms/djangoapps/contentstore/utils.py
+++ b/cms/djangoapps/contentstore/utils.py
@@ -20,6 +20,7 @@ from six import text_type
 from openedx.core.djangoapps.django_comment_common.models import assign_default_role
 from openedx.core.djangoapps.django_comment_common.utils import seed_permissions_roles
 from openedx.core.djangoapps.site_configuration.models import SiteConfiguration
+from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
 from openedx.features.content_type_gating.models import ContentTypeGatingConfig
 from openedx.features.content_type_gating.partitions import CONTENT_TYPE_GATING_SCHEME
 from student import auth
@@ -156,6 +157,21 @@ def get_lms_link_for_certificate_web_view(user_id, course_key, mode):
         course_id=six.text_type(course_key),
         mode=mode
     )
+
+
+def get_proctored_exam_settings_url(course_module):
+    """
+    Gets course authoring microfrontend URL for links to proctored exam settings page
+    """
+    course_authoring_microfrontend_url = ''
+
+    if settings.FEATURES.get('ENABLE_EXAM_SETTINGS_HTML_VIEW'):
+        course_authoring_microfrontend_url = configuration_helpers.get_value_for_org(
+            course_module.location.org,
+            'COURSE_AUTHORING_MICROFRONTEND_URL',
+            settings.COURSE_AUTHORING_MICROFRONTEND_URL
+        )
+    return course_authoring_microfrontend_url
 
 
 # pylint: disable=invalid-name

--- a/cms/djangoapps/contentstore/views/certificates.py
+++ b/cms/djangoapps/contentstore/views/certificates.py
@@ -39,6 +39,7 @@ from opaque_keys import InvalidKeyError
 from opaque_keys.edx.keys import AssetKey, CourseKey
 from six import text_type
 
+from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
 from contentstore.utils import get_lms_link_for_certificate_web_view, reverse_course_url
 from contentstore.views.assets import delete_asset
 from contentstore.views.exception import AssetNotFoundException
@@ -416,6 +417,15 @@ def certificates_list_handler(request, course_key_string):
 
             is_active, certificates = CertificateManager.is_activated(course)
 
+            course_authoring_microfrontend_url = ''
+
+            if settings.FEATURES.get('ENABLE_EXAM_SETTINGS_HTML_VIEW'):
+                course_authoring_microfrontend_url = configuration_helpers.get_value_for_org(
+                    course.location.org,
+                    'COURSE_AUTHORING_MICROFRONTEND_URL',
+                    settings.COURSE_AUTHORING_MICROFRONTEND_URL
+                )
+
             return render_to_response('certificates.html', {
                 'context_course': course,
                 'certificate_url': certificate_url,
@@ -427,7 +437,8 @@ def certificates_list_handler(request, course_key_string):
                 'certificate_web_view_url': certificate_web_view_url,
                 'is_active': is_active,
                 'is_global_staff': GlobalStaff().has_user(request.user),
-                'certificate_activation_handler_url': activation_handler_url
+                'certificate_activation_handler_url': activation_handler_url,
+                'course_authoring_microfrontend_url': course_authoring_microfrontend_url,
             })
         elif "application/json" in request.META.get('HTTP_ACCEPT'):
             # Retrieve the list of certificates for the specified course

--- a/cms/djangoapps/contentstore/views/certificates.py
+++ b/cms/djangoapps/contentstore/views/certificates.py
@@ -40,7 +40,11 @@ from opaque_keys.edx.keys import AssetKey, CourseKey
 from six import text_type
 
 from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
-from contentstore.utils import get_lms_link_for_certificate_web_view, reverse_course_url
+from contentstore.utils import (
+    get_lms_link_for_certificate_web_view,
+    reverse_course_url,
+    get_proctored_exam_settings_url
+)
 from contentstore.views.assets import delete_asset
 from contentstore.views.exception import AssetNotFoundException
 from course_modes.models import CourseMode
@@ -417,14 +421,7 @@ def certificates_list_handler(request, course_key_string):
 
             is_active, certificates = CertificateManager.is_activated(course)
 
-            course_authoring_microfrontend_url = ''
-
-            if settings.FEATURES.get('ENABLE_EXAM_SETTINGS_HTML_VIEW'):
-                course_authoring_microfrontend_url = configuration_helpers.get_value_for_org(
-                    course.location.org,
-                    'COURSE_AUTHORING_MICROFRONTEND_URL',
-                    settings.COURSE_AUTHORING_MICROFRONTEND_URL
-                )
+            course_authoring_microfrontend_url = get_proctored_exam_settings_url(course)
 
             return render_to_response('certificates.html', {
                 'context_course': course,

--- a/cms/djangoapps/contentstore/views/certificates.py
+++ b/cms/djangoapps/contentstore/views/certificates.py
@@ -39,7 +39,6 @@ from opaque_keys import InvalidKeyError
 from opaque_keys.edx.keys import AssetKey, CourseKey
 from six import text_type
 
-from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
 from contentstore.utils import (
     get_lms_link_for_certificate_web_view,
     reverse_course_url,

--- a/cms/djangoapps/contentstore/views/course.py
+++ b/cms/djangoapps/contentstore/views/course.py
@@ -43,6 +43,7 @@ from contentstore.tasks import rerun_course as rerun_course_task
 from contentstore.utils import (
     add_instructor,
     get_lms_link_for_item,
+    get_proctored_exam_settings_url,
     initialize_permissions,
     remove_all_instructors,
     reverse_course_url,
@@ -608,21 +609,6 @@ def _deprecated_blocks_info(course_module, deprecated_block_types):
     return data
 
 
-def _get_proctored_exam_settings_url(course_module):
-    """
-    Gets course authoring microfrontend URL for links to proctored exam settings page
-    """
-    course_authoring_microfrontend_url = ''
-
-    if settings.FEATURES.get('ENABLE_EXAM_SETTINGS_HTML_VIEW'):
-        course_authoring_microfrontend_url = configuration_helpers.get_value_for_org(
-            course_module.location.org,
-            'COURSE_AUTHORING_MICROFRONTEND_URL',
-            settings.COURSE_AUTHORING_MICROFRONTEND_URL
-        )
-    return course_authoring_microfrontend_url
-
-
 @login_required
 @ensure_csrf_cookie
 def course_index(request, course_key):
@@ -668,7 +654,7 @@ def course_index(request, course_key):
             settings.FEATURES.get('FRONTEND_APP_PUBLISHER_URL', False)
         )
 
-        course_authoring_microfrontend_url = _get_proctored_exam_settings_url(course_module)
+        course_authoring_microfrontend_url = get_proctored_exam_settings_url(course_module)
 
         return render_to_response('course_outline.html', {
             'language_code': request.LANGUAGE_CODE,
@@ -1100,7 +1086,7 @@ def settings_handler(request, course_key_string):
             upgrade_deadline = (verified_mode and verified_mode.expiration_datetime and
                                 verified_mode.expiration_datetime.isoformat())
 
-            course_authoring_microfrontend_url = _get_proctored_exam_settings_url(course_module)
+            course_authoring_microfrontend_url = get_proctored_exam_settings_url(course_module)
 
             settings_context = {
                 'context_course': course_module,
@@ -1240,7 +1226,7 @@ def grading_handler(request, course_key_string, grader_index=None):
         if 'text/html' in request.META.get('HTTP_ACCEPT', '') and request.method == 'GET':
             course_details = CourseGradingModel.fetch(course_key)
 
-            course_authoring_microfrontend_url = _get_proctored_exam_settings_url(course_module)
+            course_authoring_microfrontend_url = get_proctored_exam_settings_url(course_module)
 
             return render_to_response('settings_graders.html', {
                 'context_course': course_module,
@@ -1346,7 +1332,7 @@ def advanced_settings_handler(request, course_key_string):
                 settings.FEATURES.get('ENABLE_PUBLISHER', False)
             )
 
-            course_authoring_microfrontend_url = _get_proctored_exam_settings_url(course_module)
+            course_authoring_microfrontend_url = get_proctored_exam_settings_url(course_module)
 
             return render_to_response('settings_advanced.html', {
                 'context_course': course_module,
@@ -1698,7 +1684,7 @@ def group_configurations_list_handler(request, course_key_string):
             if not has_content_groups:
                 displayable_partitions.append(GroupConfiguration.get_or_create_content_group(store, course))
 
-            course_authoring_microfrontend_url = _get_proctored_exam_settings_url(course)
+            course_authoring_microfrontend_url = get_proctored_exam_settings_url(course)
 
             return render_to_response('group_configurations.html', {
                 'context_course': course,

--- a/cms/djangoapps/contentstore/views/course.py
+++ b/cms/djangoapps/contentstore/views/course.py
@@ -608,6 +608,21 @@ def _deprecated_blocks_info(course_module, deprecated_block_types):
     return data
 
 
+def _get_proctored_exam_settings_url(course_module):
+    """
+    Gets course authoring microfrontend URL for links to proctored exam settings page
+    """
+    course_authoring_microfrontend_url = ''
+
+    if settings.FEATURES.get('ENABLE_EXAM_SETTINGS_HTML_VIEW'):
+        course_authoring_microfrontend_url = configuration_helpers.get_value_for_org(
+            course_module.location.org,
+            'COURSE_AUTHORING_MICROFRONTEND_URL',
+            settings.COURSE_AUTHORING_MICROFRONTEND_URL
+        )
+    return course_authoring_microfrontend_url
+
+
 @login_required
 @ensure_csrf_cookie
 def course_index(request, course_key):
@@ -653,6 +668,8 @@ def course_index(request, course_key):
             settings.FEATURES.get('FRONTEND_APP_PUBLISHER_URL', False)
         )
 
+        course_authoring_microfrontend_url = _get_proctored_exam_settings_url(course_module)
+
         return render_to_response('course_outline.html', {
             'language_code': request.LANGUAGE_CODE,
             'context_course': course_module,
@@ -673,6 +690,7 @@ def course_index(request, course_key):
                 },
             ) if current_action else None,
             'frontend_app_publisher_url': frontend_app_publisher_url,
+            'course_authoring_microfrontend_url': course_authoring_microfrontend_url,
         })
 
 
@@ -1082,6 +1100,8 @@ def settings_handler(request, course_key_string):
             upgrade_deadline = (verified_mode and verified_mode.expiration_datetime and
                                 verified_mode.expiration_datetime.isoformat())
 
+            course_authoring_microfrontend_url = _get_proctored_exam_settings_url(course_module)
+
             settings_context = {
                 'context_course': course_module,
                 'course_locator': course_key,
@@ -1105,6 +1125,7 @@ def settings_handler(request, course_key_string):
                 'is_entrance_exams_enabled': is_entrance_exams_enabled(),
                 'enable_extended_course_details': enable_extended_course_details,
                 'upgrade_deadline': upgrade_deadline,
+                'course_authoring_microfrontend_url': course_authoring_microfrontend_url,
             }
             if is_prerequisite_courses_enabled():
                 courses, in_process_course_actions = get_courses_accessible_to_user(request)
@@ -1219,12 +1240,15 @@ def grading_handler(request, course_key_string, grader_index=None):
         if 'text/html' in request.META.get('HTTP_ACCEPT', '') and request.method == 'GET':
             course_details = CourseGradingModel.fetch(course_key)
 
+            course_authoring_microfrontend_url = _get_proctored_exam_settings_url(course_module)
+
             return render_to_response('settings_graders.html', {
                 'context_course': course_module,
                 'course_locator': course_key,
                 'course_details': course_details,
                 'grading_url': reverse_course_url('grading_handler', course_key),
                 'is_credit_course': is_credit_course(course_key),
+                'course_authoring_microfrontend_url': course_authoring_microfrontend_url,
             })
         elif 'application/json' in request.META.get('HTTP_ACCEPT', ''):
             if request.method == 'GET':
@@ -1322,11 +1346,14 @@ def advanced_settings_handler(request, course_key_string):
                 settings.FEATURES.get('ENABLE_PUBLISHER', False)
             )
 
+            course_authoring_microfrontend_url = _get_proctored_exam_settings_url(course_module)
+
             return render_to_response('settings_advanced.html', {
                 'context_course': course_module,
                 'advanced_dict': advanced_dict,
                 'advanced_settings_url': reverse_course_url('advanced_settings_handler', course_key),
                 'publisher_enabled': publisher_enabled,
+                'course_authoring_microfrontend_url': course_authoring_microfrontend_url,
 
             })
         elif 'application/json' in request.META.get('HTTP_ACCEPT', ''):
@@ -1671,6 +1698,8 @@ def group_configurations_list_handler(request, course_key_string):
             if not has_content_groups:
                 displayable_partitions.append(GroupConfiguration.get_or_create_content_group(store, course))
 
+            course_authoring_microfrontend_url = _get_proctored_exam_settings_url(course)
+
             return render_to_response('group_configurations.html', {
                 'context_course': course,
                 'group_configuration_url': group_configuration_url,
@@ -1678,7 +1707,8 @@ def group_configurations_list_handler(request, course_key_string):
                 'experiment_group_configurations': experiment_group_configurations,
                 'should_show_experiment_groups': should_show_experiment_groups,
                 'all_group_configurations': displayable_partitions,
-                'should_show_enrollment_track': should_show_enrollment_track
+                'should_show_enrollment_track': should_show_enrollment_track,
+                'course_authoring_microfrontend_url': course_authoring_microfrontend_url,
             })
         elif "application/json" in request.META.get('HTTP_ACCEPT'):
             if request.method == 'POST':

--- a/cms/envs/test.py
+++ b/cms/envs/test.py
@@ -135,7 +135,7 @@ LMS_BASE = "localhost:8000"
 LMS_ROOT_URL = "http://{}".format(LMS_BASE)
 FEATURES['PREVIEW_LMS_BASE'] = "preview.localhost"
 
-COURSE_AUTHORING_MICROFRONTEND_URL = "http://course-authoring-mfe/"
+COURSE_AUTHORING_MICROFRONTEND_URL = "http://course-authoring-mfe"
 
 CACHES = {
     # This is the cache used for most things. Askbot will not work without a

--- a/cms/templates/certificates.html
+++ b/cms/templates/certificates.html
@@ -9,6 +9,8 @@ from openedx.core.djangolib.markup import HTML, Text
 from openedx.core.djangolib.js_utils import (
     dump_js_escaped_json, js_escaped_string
 )
+import six
+from six.moves.urllib.parse import quote
 %>
 
 <%block name="title">${_("Course Certificates")}</%block>
@@ -102,13 +104,11 @@ CMS.User.isGlobalStaff = '${is_global_staff | n, js_escaped_string}'=='True' ? t
         <div class="bit">
         % if context_course:
           <%
+            url_encoded_course_id = quote(six.text_type(context_course.id).encode('utf-8'), safe='')
             details_url = utils.reverse_course_url('settings_handler', context_course.id)
             grading_url = utils.reverse_course_url('grading_handler', context_course.id)
             course_team_url = utils.reverse_course_url('course_team_handler', context_course.id)
             advanced_settings_url = utils.reverse_course_url('advanced_settings_handler', context_course.id)
-            exams_url = ''
-            if settings.FEATURES.get('ENABLE_EXAM_SETTINGS_HTML_VIEW'):
-                exams_url = settings.COURSE_AUTHORING_MICROFRONTEND_URL
           %>
         <h2 class="title-3">${_("Other Course Settings")}</h2>
           <nav class="nav-related" aria-label="${_('Other Course Settings')}">
@@ -118,8 +118,8 @@ CMS.User.isGlobalStaff = '${is_global_staff | n, js_escaped_string}'=='True' ? t
               <li class="nav-item"><a href="${course_team_url}">${_("Course Team")}</a></li>
               <li class="nav-item"><a href="${advanced_settings_url}">${_("Advanced Settings")}</a></li>
               <li class="nav-item"><a href="${utils.reverse_course_url('group_configurations_list_handler', context_course.id)}">${_("Group Configurations")}</a></li>
-              % if exams_url:
-                <li class="nav-item"><a href="${exams_url}">${_("Proctored Exam Settings")}</a></li>
+              % if course_authoring_microfrontend_url:
+                <li class="nav-item"><a href="${course_authoring_microfrontend_url}/proctored-exam-settings/${url_encoded_course_id}">${_("Proctored Exam Settings")}</a></li>
               % endif
             </ul>
           </nav>

--- a/cms/templates/group_configurations.html
+++ b/cms/templates/group_configurations.html
@@ -11,6 +11,8 @@ from openedx.core.djangolib.js_utils import (
     dump_js_escaped_json, js_escaped_string
 )
 from openedx.core.djangolib.markup import HTML, Text
+import six
+from six.moves.urllib.parse import quote
 %>
 
 <%block name="title">${_("Group Configurations")}</%block>
@@ -113,13 +115,11 @@ from openedx.core.djangolib.markup import HTML, Text
       <div class="bit">
       % if context_course:
         <%
+          url_encoded_course_id = quote(six.text_type(context_course.id).encode('utf-8'), safe='')
           details_url = utils.reverse_course_url('settings_handler', context_course.id)
           grading_url = utils.reverse_course_url('grading_handler', context_course.id)
           course_team_url = utils.reverse_course_url('course_team_handler', context_course.id)
           advanced_settings_url = utils.reverse_course_url('advanced_settings_handler', context_course.id)
-          exams_url = ''
-          if settings.FEATURES.get('ENABLE_EXAM_SETTINGS_HTML_VIEW'):
-            exams_url = settings.COURSE_AUTHORING_MICROFRONTEND_URL
         %>
       <h3 class="title-3">${_("Other Course Settings")}</h3>
         <nav class="nav-related" aria-label="${_('Other Course Settings')}">
@@ -128,8 +128,8 @@ from openedx.core.djangolib.markup import HTML, Text
             <li class="nav-item"><a href="${grading_url}">${_("Grading")}</a></li>
             <li class="nav-item"><a href="${course_team_url}">${_("Course Team")}</a></li>
             <li class="nav-item"><a href="${advanced_settings_url}">${_("Advanced Settings")}</a></li>
-            % if exams_url:
-              <li class="nav-item"><a href="${exams_url}">${_("Proctored Exam Settings")}</a></li>
+            % if course_authoring_microfrontend_url:
+              <li class="nav-item"><a href="${course_authoring_microfrontend_url}/proctored-exam-settings/${url_encoded_course_id}">${_("Proctored Exam Settings")}</a></li>
             % endif
           </ul>
         </nav>

--- a/cms/templates/settings.html
+++ b/cms/templates/settings.html
@@ -13,6 +13,8 @@
       dump_js_escaped_json, js_escaped_string
   )
   from openedx.core.djangolib.markup import HTML, Text
+  import six
+  from six.moves.urllib.parse import quote
   from six.moves.urllib import parse as urllib
 %>
 
@@ -655,12 +657,10 @@ CMS.URL.UPLOAD_ASSET = '${upload_asset_url | n, js_escaped_string}'
      <div class="bit">
      % if context_course:
           <%
+            url_encoded_course_id = quote(six.text_type(context_course.id).encode('utf-8'), safe='')
             course_team_url = utils.reverse_course_url('course_team_handler', context_course.id)
             grading_config_url = utils.reverse_course_url('grading_handler', context_course.id)
             advanced_config_url = utils.reverse_course_url('advanced_settings_handler', context_course.id)
-            exams_url = ''
-            if settings.FEATURES.get('ENABLE_EXAM_SETTINGS_HTML_VIEW'):
-                exams_url = settings.COURSE_AUTHORING_MICROFRONTEND_URL
           %>
         <h3 class="title-3">${_("Other Course Settings")}</h3>
         <nav class="nav-related" aria-label="${_('Other Course Settings')}">
@@ -669,8 +669,8 @@ CMS.URL.UPLOAD_ASSET = '${upload_asset_url | n, js_escaped_string}'
             <li class="nav-item"><a href="${course_team_url}">${_("Course Team")}</a></li>
             <li class="nav-item"><a href="${utils.reverse_course_url('group_configurations_list_handler', context_course.id)}">${_("Group Configurations")}</a></li>
             <li class="nav-item"><a href="${advanced_config_url}">${_("Advanced Settings")}</a></li>
-            % if exams_url:
-              <li class="nav-item"><a href="${exams_url}">${_("Proctored Exam Settings")}</a></li>
+            % if course_authoring_microfrontend_url:
+              <li class="nav-item"><a href="${course_authoring_microfrontend_url}/proctored-exam-settings/${url_encoded_course_id}">${_("Proctored Exam Settings")}</a></li>
             % endif
           </ul>
         </nav>

--- a/cms/templates/settings_advanced.html
+++ b/cms/templates/settings_advanced.html
@@ -3,6 +3,8 @@
 <%def name="online_help_token()"><% return "advanced" %></%def>
 <%namespace name='static' file='static_content.html'/>
 <%!
+  import six
+  from six.moves.urllib.parse import quote
   from django.utils.translation import ugettext as _
   from contentstore import utils
   from openedx.core.djangolib.js_utils import (
@@ -95,12 +97,10 @@
       <div class="bit">
       % if context_course:
         <%
+          url_encoded_course_id = quote(six.text_type(context_course.id).encode('utf-8'), safe='')
           details_url = utils.reverse_course_url('settings_handler', context_course.id)
           grading_url = utils.reverse_course_url('grading_handler', context_course.id)
           course_team_url = utils.reverse_course_url('course_team_handler', context_course.id)
-          exams_url = ''
-          if settings.FEATURES.get('ENABLE_EXAM_SETTINGS_HTML_VIEW'):
-            exams_url = settings.COURSE_AUTHORING_MICROFRONTEND_URL
         %>
       <h3 class="title-3">${_("Other Course Settings")}</h3>
         <nav class="nav-related" aria-label="${_('Other Course Settings')}">
@@ -109,8 +109,8 @@
             <li class="nav-item"><a href="${grading_url}">${_("Grading")}</a></li>
             <li class="nav-item"><a href="${course_team_url}">${_("Course Team")}</a></li>
             <li class="nav-item"><a href="${utils.reverse_course_url('group_configurations_list_handler', context_course.id)}">${_("Group Configurations")}</a></li>
-            % if exams_url:
-              <li class="nav-item"><a href="${exams_url}">${_("Proctored Exam Settings")}</a></li>
+            % if course_authoring_microfrontend_url:
+              <li class="nav-item"><a href="${course_authoring_microfrontend_url}/proctored-exam-settings/${url_encoded_course_id}">${_("Proctored Exam Settings")}</a></li>
             % endif
           </ul>
         </nav>

--- a/cms/templates/settings_graders.html
+++ b/cms/templates/settings_graders.html
@@ -6,6 +6,8 @@
 
 <%namespace name='static' file='static_content.html'/>
 <%!
+  import six
+  from six.moves.urllib.parse import quote
   import json
   from contentstore import utils
   from django.utils.translation import ugettext as _
@@ -152,12 +154,10 @@
       <div class="bit">
       % if context_course:
         <%
+          url_encoded_course_id = quote(six.text_type(context_course.id).encode('utf-8'), safe='')
           detailed_settings_url = utils.reverse_course_url('settings_handler', context_course.id)
           course_team_url = utils.reverse_course_url('course_team_handler', context_course.id)
           advanced_settings_url = utils.reverse_course_url('advanced_settings_handler', context_course.id)
-          exams_url = ''
-          if settings.FEATURES.get('ENABLE_EXAM_SETTINGS_HTML_VIEW'):
-            exams_url = settings.COURSE_AUTHORING_MICROFRONTEND_URL
         %>
         <h3 class="title-3">${_("Other Course Settings")}</h3>
         <nav class="nav-related" aria-label="${_('Other Course Settings')}">
@@ -166,8 +166,8 @@
             <li class="nav-item"><a href="${course_team_url}">${_("Course Team")}</a></li>
             <li class="nav-item"><a href="${utils.reverse_course_url('group_configurations_list_handler', context_course.id)}">${_("Group Configurations")}</a></li>
             <li class="nav-item"><a href="${advanced_settings_url}">${_("Advanced Settings")}</a></li>
-            % if exams_url:
-              <li class="nav-item"><a href="${exams_url}">${_("Proctored Exam Settings")}</a></li>
+            % if course_authoring_microfrontend_url:
+              <li class="nav-item"><a href="${course_authoring_microfrontend_url}/proctored-exam-settings/${url_encoded_course_id}">${_("Proctored Exam Settings")}</a></li>
             % endif
           </ul>
         </nav>

--- a/cms/templates/widgets/header.html
+++ b/cms/templates/widgets/header.html
@@ -37,9 +37,6 @@
             certificates_url = ''
             if settings.FEATURES.get("CERTIFICATES_HTML_VIEW") and context_course.cert_html_view_enabled:
                 certificates_url = reverse('certificates_list_handler', kwargs={'course_key_string': six.text_type(course_key)})
-            exams_url = ''
-            if settings.FEATURES.get("ENABLE_EXAM_SETTINGS_HTML_VIEW"):
-                exams_url = settings.COURSE_AUTHORING_MICROFRONTEND_URL
             checklists_url = reverse('checklists_handler', kwargs={'course_key_string': six.text_type(course_key)})
 
       %>
@@ -103,9 +100,9 @@
                   <li class="nav-item nav-course-settings-group-configurations">
                     <a href="${reverse('group_configurations_list_handler', kwargs={'course_key_string': six.text_type(course_key)})}">${_("Group Configurations")}</a>
                   </li>
-                  % if exams_url:
+                  % if course_authoring_microfrontend_url:
                   <li class="nav-item nav-course-settings-exams">
-                    <a href="${exams_url}">${_("Proctored Exam Settings")}</a>
+                    <a href="${course_authoring_microfrontend_url}/proctored-exam-settings/${url_encoded_course_key}">${_("Proctored Exam Settings")}</a>
                   </li>
                   % endif
                   <li class="nav-item nav-course-settings-advanced">


### PR DESCRIPTION
## [MST-314](https://openedx.atlassian.net/browse/MST-314)

Links to the course-authoring MFE had to have updated URLs to account for the new URL scheme. The process of getting the base of the URL was also moved to the backend, because the MFE URL base is defined in a config file. The tests that cover this code were a part of this [PR](https://github.com/edx/edx-platform/pull/24405), and I do not believe they need to be updated as the logic remains the same. 

The links to the MFE are also still hidden behind the Django settings `ENABLE_EXAM_SETTINGS_HTML_VIEW`.