### PR TITLE
[REV-1205] Replace tracking selectors for course_dashboard_green button

### DIFF
--- a/lms/templates/dashboard/_dashboard_course_listing.html
+++ b/lms/templates/dashboard/_dashboard_course_listing.html
@@ -412,7 +412,7 @@ from lms.djangoapps.experiments.utils import UPSELL_TRACKING_FLAG
               </p>
               <div class="action-upgrade-container">
                 % if use_ecommerce_payment_flow and course_mode_info['verified_sku']:
-                  <a id="ecommerce_upgrade_link" class="action action-upgrade" href="${ecommerce_payment_page}?sku=${course_mode_info['verified_sku']}">
+                  <a class="action action-upgrade track_course_dashboard_green_button" href="${ecommerce_payment_page}?sku=${course_mode_info['verified_sku']}">
                 % else:
                   <a class="action action-upgrade" href="${reverse('verify_student_upgrade_and_verify', kwargs={'course_id': six.text_type(course_overview.id)})}" data-course-id="${course_overview.id}" data-user="${user.username}">
                 % endif
@@ -461,7 +461,7 @@ from lms.djangoapps.experiments.utils import UPSELL_TRACKING_FLAG
       if (window.loadedECommerceEvents === undefined) {
         window.loadedECommerceEvents = true;
 
-        TrackECommerceEvents.trackUpsellClick($("#ecommerce_upgrade_link"), 'course_dashboard_green', {
+        TrackECommerceEvents.trackUpsellClick($(".track_course_dashboard_green_button"), 'course_dashboard_green', {
           pageName: "course_dashboard",
           linkType: "button",
           linkCategory: "green_upgrade"


### PR DESCRIPTION
### What did we do?
Replaced the id selector used for tracking the course_dashboard_green button with a class selector instead.

### Why did we do it?
It's possible to have the same green upsell button on the course dashboard page if you have multiple courses that have the verified option. We want to track all green button clicks on that page, not just the first button's clicks. Note that we don't need to know which class the button click was for (this info may be added in a subsequent PR, depending on UX/data needs). See screenshot below:

<img width="743" alt="Screen Shot 2020-07-09 at 1 20 04 PM" src="https://user-images.githubusercontent.com/34042537/87328528-9b578780-c503-11ea-973e-eb6add31f80b.png">
