### PR TITLE
move ENABLE_FORUM_DAILY_DIGEST default

### DIFF
--- a/lms/djangoapps/discussion/config/settings.py
+++ b/lms/djangoapps/discussion/config/settings.py
@@ -6,7 +6,7 @@ from django.conf import settings
 # .. toggle_name: FEATURES['ENABLE_FORUM_DAILY_DIGEST']
 # .. toggle_implementation: DjangoSetting
 # .. toggle_default: True
-# .. toggle_description: Set to True to enable forum notification features.
+# .. toggle_description: Settings for forums/discussions to on/off daily digest feature. Set this to True if you want to enable users to subscribe and unsubscribe for daily digest. This setting enables deprecation of daily digest.
 # .. toggle_category: discussion
 # .. toggle_use_cases: open_edx
 # .. toggle_creation_date: 2020-03-09
@@ -19,4 +19,4 @@ ENABLE_FORUM_DAILY_DIGEST = 'enable_forum_daily_digest'
 
 def is_forum_daily_digest_enabled():
     """Returns whether forum notification features should be visible"""
-    return settings.FEATURES.get('ENABLE_FORUM_DAILY_DIGEST')
+    return settings.FEATURES.get('ENABLE_FORUM_DAILY_DIGEST', True)

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -100,11 +100,6 @@ FEATURES = {
     # this should remain off in production until digest notifications are online.
     'ENABLE_DISCUSSION_HOME_PANEL': False,
 
-    # settings for forums/discussions to on/off daily digest feature. Set this to True if you want to
-    # enable the UI for the users to subscribe and unsubscribe for daily digest. This setting is the
-    # part of deprecation of daily digest in production.
-    'ENABLE_FORUM_DAILY_DIGEST': True,
-
     # Set this to True if you want the discussion digest emails enabled automatically for new users.
     # This will be set on all new account registrations.
     # It is not recommended to enable this feature if ENABLE_DISCUSSION_HOME_PANEL is not enabled, since


### PR DESCRIPTION
The default for ENABLE_FORUM_DAILY_DIGEST continues
to be True, but this moves the default from
common.py to code.

This is a follow-up to @nasthagiri's [past PR comment](https://github.com/edx/edx-platform/pull/24423#discussion_r452343937), and is hopefully both equivalent and preferred.