### PR TITLE
Django3.0 warnings fix

### DIFF
--- a/openedx/core/djangoapps/util/model_utils.py
+++ b/openedx/core/djangoapps/util/model_utils.py
@@ -23,5 +23,5 @@ class CreatorMixin(object):
         super(CreatorMixin, self).contribute_to_class(cls, name, *args, **kwargs)
         setattr(cls, name, Creator(self))
 
-    def from_db_value(self, value, expression, connection, context):
+    def from_db_value(self, value, expression, connection):
         return self.to_python(value)


### PR DESCRIPTION
https://openedx.atlassian.net/browse/BOM-1890

Remove the context parameter from CourseKeyField.from_db_value() [Old warnings link](https://build.testeng.edx.org/job/edx-platform-python-pipeline-pr/19523/warning_5freport_5fall_2ehtml/)

https://docs.djangoproject.com/en/dev/releases/3.0/#features-removed-in-3-0