### PR TITLE
Django3.0 warnings {% load staticfiles %} is deprecated

### DIFF
--- a/lms/templates/logout.html
+++ b/lms/templates/logout.html
@@ -1,5 +1,5 @@
 {% extends "main_django.html" %}
-{% load i18n staticfiles %}
+{% load i18n static %}
 {% load django_markup %}
 
 {% block title %}{% trans "Signed Out" as tmsg %}{{ tmsg | force_escape }} | {{ block.super }}{% endblock %}

--- a/lms/templates/main_django.html
+++ b/lms/templates/main_django.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-{% load sekizai_tags i18n configuration theme_pipeline optional_include staticfiles %}
+{% load sekizai_tags i18n configuration theme_pipeline optional_include static %}
 <html lang="{{LANGUAGE_CODE}}">
 <head>
   <meta charset="UTF-8">

--- a/lms/templates/wiki/base.html
+++ b/lms/templates/wiki/base.html
@@ -1,6 +1,6 @@
 {% extends "main_django.html" %}
 {% with online_help_token="wiki" %}
-{% load theme_pipeline %}{% load sekizai_tags i18n configuration %}{% load staticfiles %}
+{% load theme_pipeline %}{% load sekizai_tags i18n configuration %}{% load static %}
 
 {% block title %}
   {% block pagetitle %}{% endblock %} | {% trans "Wiki" as tmsg%}{{tmsg|force_escape}} | {% platform_name %}


### PR DESCRIPTION
Part1: it has usage at several places so doing it in small prs.

https://openedx.atlassian.net/browse/BOM-1895
{% load staticfiles %} is deprecated in favor of {% load static %}.

https://docs.djangoproject.com/en/2.2/releases/2.1/#features-deprecated-in-2-1
https://docs.djangoproject.com/en/dev/releases/3.0/#features-removed-in-3-0