### PR TITLE
Fix profile image URLs for image storage on non-public S3 buckets

### DIFF
--- a/openedx/core/djangoapps/user_api/accounts/image_helpers.py
+++ b/openedx/core/djangoapps/user_api/accounts/image_helpers.py
@@ -55,7 +55,12 @@ def _get_profile_image_urls(name, storage, file_extension=PROFILE_IMAGE_FILE_EXT
         url = storage.url(
             _get_profile_image_filename(name, size, file_extension=file_extension)
         )
-        return '{}?v={}'.format(url, version) if version is not None else url
+        # Return the URL, with the "v" parameter added as its query
+        # string with "?v=". If the original URL already includes a
+        # query string (such as signed S3 URLs), append to the query
+        # string with "&v=" instead.
+        separator = '&' if '?' in url else '?'
+        return '{}{}v={}'.format(url, separator, version) if version is not None else url
 
     return {size_display_name: _make_url(size) for size_display_name, size in settings.PROFILE_IMAGE_SIZES_MAP.items()}
 


### PR DESCRIPTION
Cherry-pick of 26281cbe36ae999f01d24af4cebf62874c3ba76d (#24395) into Juniper.