### PR TITLE
BOM-1915 : Django3 deprecation warning fix in lms

### DIFF
--- a/lms/djangoapps/shoppingcart/admin.py
+++ b/lms/djangoapps/shoppingcart/admin.py
@@ -72,7 +72,7 @@ class CourseRegistrationCodeInvoiceItemInline(admin.StackedInline):
         'course_id',
     )
 
-    def has_add_permission(self, request):
+    def has_add_permission(self, request, obj=None):
         return False
 
 


### PR DESCRIPTION
Relevant JIRA : https://openedx.atlassian.net/browse/BOM-1915