### PR TITLE
Add ratelimitbackend into the INSTALLED_APPS array 

### DIFF
--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -2566,6 +2566,8 @@ INSTALLED_APPS = [
 
     # Learning Sequence Navigation
     'openedx.core.djangoapps.content.learning_sequences.apps.LearningSequencesConfig',
+
+    'ratelimitbackend',
 ]
 
 ######################### CSRF #########################################

--- a/requirements/edx/base.in
+++ b/requirements/edx/base.in
@@ -58,7 +58,6 @@ django-oauth-toolkit                # Provides oAuth2 capabilities for Django
 django-pipeline
 django-pyfs
 django-ratelimit
-django-ratelimit-backend
 django-require
 django-sekizai
 django-ses

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -69,7 +69,7 @@ django-oauth-toolkit==1.3.2  # via -r requirements/edx/base.in
 django-object-actions==2.0.0  # via edx-enterprise
 django-pipeline==1.7.0    # via -c requirements/edx/../constraints.txt, -r requirements/edx/base.in
 django-pyfs==2.2          # via -r requirements/edx/base.in
-django-ratelimit-backend==2.0  # via -r requirements/edx/base.in
+git+https://github.com/edx/django-ratelimit-backend.git@v2.0.1a2#egg=django-ratelimit-backend==2.0.1  # via -r requirements/edx/github.in
 django-ratelimit==3.0.0   # via -r requirements/edx/base.in
 django-require==1.0.11    # via -r requirements/edx/base.in
 django-sekizai==1.1.0     # via -r requirements/edx/base.in, django-wiki

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -81,7 +81,7 @@ django-oauth-toolkit==1.3.2  # via -r requirements/edx/testing.txt
 django-object-actions==2.0.0  # via -r requirements/edx/testing.txt, edx-enterprise
 django-pipeline==1.7.0    # via -c requirements/edx/../constraints.txt, -r requirements/edx/testing.txt
 django-pyfs==2.2          # via -r requirements/edx/testing.txt
-django-ratelimit-backend==2.0  # via -r requirements/edx/testing.txt
+git+https://github.com/edx/django-ratelimit-backend.git@v2.0.1a2#egg=django-ratelimit-backend==2.0.1  # via -r requirements/edx/testing.txt
 django-ratelimit==3.0.0   # via -r requirements/edx/testing.txt
 django-require==1.0.11    # via -r requirements/edx/testing.txt
 django-sekizai==1.1.0     # via -r requirements/edx/testing.txt, django-wiki

--- a/requirements/edx/github.in
+++ b/requirements/edx/github.in
@@ -57,6 +57,9 @@
 -e git+https://github.com/edx/django-wiki.git@0.0.27#egg=django-wiki
 git+https://github.com/edx/MongoDBProxy.git@d92bafe9888d2940f647a7b2b2383b29c752f35a#egg=MongoDBProxy==0.1.0+edx.2
 -e git+https://github.com/jazkarta/edx-jsme.git@690dbf75441fa91c7c4899df0b83d77f7deb5458#egg=edx-jsme
+# This is a temporary fork until https://github.com/brutasse/django-ratelimit-backend/pull/50 is merged
+# back into the upstream code.
+-e git+https://github.com/edx/django-ratelimit-backend.git@v2.0.1a2#egg=django-ratelimit-backend==2.0.1
 
 # Our libraries:
 -e git+https://github.com/edx/codejail.git@ffec49bb09785fb688afc5d24714d4e43ae8449f#egg=codejail==3.0.1

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -79,7 +79,7 @@ django-oauth-toolkit==1.3.2  # via -r requirements/edx/base.txt
 django-object-actions==2.0.0  # via -r requirements/edx/base.txt, edx-enterprise
 django-pipeline==1.7.0    # via -c requirements/edx/../constraints.txt, -r requirements/edx/base.txt
 django-pyfs==2.2          # via -r requirements/edx/base.txt
-django-ratelimit-backend==2.0  # via -r requirements/edx/base.txt
+git+https://github.com/edx/django-ratelimit-backend.git@v2.0.1a2#egg=django-ratelimit-backend==2.0.1  # via -r requirements/edx/base.txt
 django-ratelimit==3.0.0   # via -r requirements/edx/base.txt
 django-require==1.0.11    # via -r requirements/edx/base.txt
 django-sekizai==1.1.0     # via -r requirements/edx/base.txt, django-wiki


### PR DESCRIPTION
To resolve the devstack errors, we needed to adjust how the `ratelimitbackend` library is registering its custom django admin site.