### PR TITLE
ENT-3160 Automate association to customer on SAMLProviderConfig creation

### DIFF
--- a/common/djangoapps/third_party_auth/samlproviderconfig/tests/test_samlproviderconfig.py
+++ b/common/djangoapps/third_party_auth/samlproviderconfig/tests/test_samlproviderconfig.py
@@ -100,6 +100,12 @@ class SAMLProviderConfigTests(APITestCase):
         """
         GET auth/saml/v0/provider_config/?enterprise_customer_uuid=valid-but-nonexistent-uuid
         """
+
+        # the user must actually be authorized for this enterprise
+        # since we are testing auth passes but association to samlproviderconfig is not found
+        set_jwt_cookie(self.client, self.user, [(ENTERPRISE_ADMIN_ROLE, ENTERPRISE_ID_NON_EXISTENT)])
+        self.client.force_authenticate(user=self.user)
+
         urlbase = reverse('saml_provider_config-list')
         query_kwargs = {'enterprise_customer_uuid': ENTERPRISE_ID_NON_EXISTENT}
         url = '{}?{}'.format(urlbase, urlencode(query_kwargs))
@@ -107,7 +113,7 @@ class SAMLProviderConfigTests(APITestCase):
 
         response = self.client.get(url, format='json')
 
-        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
         self.assertEqual(SAMLProviderConfig.objects.count(), orig_count)
 
     def test_create_one_config(self):

--- a/common/djangoapps/third_party_auth/samlproviderconfig/views.py
+++ b/common/djangoapps/third_party_auth/samlproviderconfig/views.py
@@ -89,18 +89,18 @@ class SAMLProviderConfigViewSet(PermissionRequiredMixin, SAMLProviderMixin, view
         Process POST /auth/saml/v0/provider_config/ {postData}
         """
 
-        # Create the samlproviderconfig model first
-        serializer = self.get_serializer(data=request.data)
-        serializer.is_valid(raise_exception=True)
-        self.perform_create(serializer)
-
-        # Associate the enterprise customer with the provider
         customer_uuid = self.requested_enterprise_uuid
         try:
             enterprise_customer = EnterpriseCustomer.objects.get(pk=customer_uuid)
         except EnterpriseCustomer.DoesNotExist:
             raise ValidationError('Enterprise customer not found at uuid: {}'.format(customer_uuid))
 
+        # Create the samlproviderconfig model first
+        serializer = self.get_serializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+        self.perform_create(serializer)
+
+        # Associate the enterprise customer with the provider
         association_obj = EnterpriseCustomerIdentityProvider(
             enterprise_customer=enterprise_customer,
             provider_id=serializer.data['slug']

--- a/common/djangoapps/third_party_auth/samlproviderconfig/views.py
+++ b/common/djangoapps/third_party_auth/samlproviderconfig/views.py
@@ -5,11 +5,12 @@ Viewset for auth/saml/v0/samlproviderconfig
 from django.shortcuts import get_object_or_404
 from edx_rbac.mixins import PermissionRequiredMixin
 from edx_rest_framework_extensions.auth.jwt.authentication import JwtAuthentication
-from rest_framework import permissions, viewsets
+from rest_framework import permissions, viewsets, status
+from rest_framework.response import Response
 from rest_framework.authentication import SessionAuthentication
-from rest_framework.exceptions import ParseError
+from rest_framework.exceptions import ParseError, ValidationError
 
-from enterprise.models import EnterpriseCustomerIdentityProvider
+from enterprise.models import EnterpriseCustomerIdentityProvider, EnterpriseCustomer
 from third_party_auth.utils import validate_uuid4_string
 
 from ..models import SAMLProviderConfig
@@ -56,7 +57,7 @@ class SAMLProviderConfigViewSet(PermissionRequiredMixin, SAMLProviderMixin, view
             EnterpriseCustomerIdentityProvider,
             enterprise_customer__uuid=self.requested_enterprise_uuid
         )
-        return SAMLProviderConfig.objects.filter(pk=enterprise_customer_idp.provider_id)
+        return SAMLProviderConfig.objects.filter(slug=enterprise_customer_idp.provider_id)
 
     @property
     def requested_enterprise_uuid(self):
@@ -82,3 +83,30 @@ class SAMLProviderConfigViewSet(PermissionRequiredMixin, SAMLProviderMixin, view
         can access these endpoints, we have to sort out the operator role use case
         """
         return self.requested_enterprise_uuid
+
+    def create(self, request, *args, **kwargs):
+        """
+        Process POST /auth/saml/v0/provider_config/ {postData}
+        """
+
+        # Create the samlproviderconfig model first
+        serializer = self.get_serializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+        self.perform_create(serializer)
+
+        # Associate the enterprise customer with the provider
+        customer_uuid = self.requested_enterprise_uuid
+        try:
+            enterprise_customer = EnterpriseCustomer.objects.get(pk=customer_uuid)
+        except EnterpriseCustomer.DoesNotExist:
+            raise ValidationError('Enterprise customer not found at uuid: {}'.format(customer_uuid))
+
+        print(serializer.data)
+        association_obj = EnterpriseCustomerIdentityProvider(
+            enterprise_customer = enterprise_customer,
+            provider_id = serializer.data['slug']
+        )
+        association_obj.save()
+
+        headers = self.get_success_headers(serializer.data)
+        return Response(serializer.data, status=status.HTTP_201_CREATED, headers=headers)

--- a/common/djangoapps/third_party_auth/samlproviderconfig/views.py
+++ b/common/djangoapps/third_party_auth/samlproviderconfig/views.py
@@ -101,7 +101,6 @@ class SAMLProviderConfigViewSet(PermissionRequiredMixin, SAMLProviderMixin, view
         except EnterpriseCustomer.DoesNotExist:
             raise ValidationError('Enterprise customer not found at uuid: {}'.format(customer_uuid))
 
-        print(serializer.data)
         association_obj = EnterpriseCustomerIdentityProvider(
             enterprise_customer=enterprise_customer,
             provider_id=serializer.data['slug']

--- a/common/djangoapps/third_party_auth/samlproviderconfig/views.py
+++ b/common/djangoapps/third_party_auth/samlproviderconfig/views.py
@@ -103,8 +103,8 @@ class SAMLProviderConfigViewSet(PermissionRequiredMixin, SAMLProviderMixin, view
 
         print(serializer.data)
         association_obj = EnterpriseCustomerIdentityProvider(
-            enterprise_customer = enterprise_customer,
-            provider_id = serializer.data['slug']
+            enterprise_customer=enterprise_customer,
+            provider_id=serializer.data['slug']
         )
         association_obj.save()
 


### PR DESCRIPTION
Needed so that every time a new SAMLProviderConfig is created using the POST auth/saml/v0/provider_config/ api, the enterprise_customer_uuid in the post body is associated with this newly created SAMLProviderconfig