### PR TITLE
RFC: Consolidate MFE redirect logic

### DIFF
--- a/lms/djangoapps/courseware/toggles.py
+++ b/lms/djangoapps/courseware/toggles.py
@@ -37,11 +37,3 @@ REDIRECT_TO_COURSEWARE_MICROFRONTEND = ExperimentWaffleFlag(WAFFLE_FLAG_NAMESPAC
 # .. toggle_tickets: TNL-6982
 # .. toggle_status: supported
 COURSEWARE_MICROFRONTEND_COURSE_TEAM_PREVIEW = CourseWaffleFlag(WAFFLE_FLAG_NAMESPACE, 'microfrontend_course_team_preview')
-
-
-def should_redirect_to_courseware_microfrontend(course_key):
-    return (
-        settings.FEATURES.get('ENABLE_COURSEWARE_MICROFRONTEND') and
-        (not course_key.deprecated) and  # Old Mongo courses not supported
-        REDIRECT_TO_COURSEWARE_MICROFRONTEND.is_enabled(course_key)
-    )


### PR DESCRIPTION
Its ripe for confusion to have this logic split between two separate
methods. This consolidation should make things easier to understand and
hopefully, less issue prone.

We don't really benefit from having two methods here anyway, as one is
_only_ ever called by the other.

It's also misleading that the second helper, in `toggles.py`, _also_
checks the FEATURE flag, as well as the waffle flag.