### PR TITLE
[REV-1205] Add ecommerce event tracking to PLS links (personalized learner schedules)

### DIFF
--- a/lms/templates/courseware/dates.html
+++ b/lms/templates/courseware/dates.html
@@ -95,3 +95,14 @@ from openedx.core.djangolib.markup import HTML, Text
 <%static:require_module_async module_name="js/dateutil_factory" class_name="DateUtilFactory">
     DateUtilFactory.transform(iterationKey=".localized_datetime");
 </%static:require_module_async>
+
+<%static:require_module_async module_name="js/commerce/track_ecommerce_events" class_name="TrackECommerceEvents">
+  var personalizedLearnerSchedulesLink = $(".personalized_learner_schedules_button");
+
+    TrackECommerceEvents.trackUpsellClick(personalizedLearnerSchedulesLink, 'dates_upgrade', {
+      pageName: "dates_tab",
+      linkType: "button",
+      linkCategory: "personalized_learner_schedules"
+    });
+
+</%static:require_module_async>

--- a/lms/templates/dates_banner.html
+++ b/lms/templates/dates_banner.html
@@ -52,7 +52,7 @@ additional_styling_class = 'on-mobile' if is_mobile_app else 'has-button'
         </div>
         % if not is_mobile_app:
             <div class="upgrade-button">
-                <a href="${verified_upgrade_link}">
+                <a class="personalized_learner_schedules_button" href="${verified_upgrade_link}">
                     <button type="button">
                         ${_('Upgrade to shift due dates')}
                     </button>
@@ -76,7 +76,7 @@ additional_styling_class = 'on-mobile' if is_mobile_app else 'has-button'
         </div>
         % if not is_mobile_app:
             <div class="upgrade-button">
-                <a href="${verified_upgrade_link}">
+                <a class="personalized_learner_schedules_button" href="${verified_upgrade_link}">
                     <button type="button">
                         ${_('Upgrade now')}
                     </button>

--- a/openedx/features/course_experience/templates/course_experience/course-home-fragment.html
+++ b/openedx/features/course_experience/templates/course_experience/course-home-fragment.html
@@ -189,3 +189,15 @@ from openedx.features.course_experience.course_tools import HttpMethod
 <%static:webpack entry="Enrollment">
     new CourseEnrollment('.enroll-btn', '${course_key | n, js_escaped_string}');
 </%static:webpack>
+
+<%static:require_module_async module_name="js/commerce/track_ecommerce_events" class_name="TrackECommerceEvents">
+
+  var personalizedLearnerSchedulesLink = $(".personalized_learner_schedules_button");
+
+    TrackECommerceEvents.trackUpsellClick(personalizedLearnerSchedulesLink, 'course_home_upgrade_shift_dates', {
+      pageName: "course_home",
+      linkType: "button",
+      linkCategory: "personalized_learner_schedules"
+    });
+
+</%static:require_module_async>


### PR DESCRIPTION
The following pull request has our POC baseline for upsell event tracking, including javascript module and one of the upsell links: #24338

We'll have tracking for 18 links all together, so we'll break this up into several pull requests to minimize risk. This PR includes the PLS links, which can appear on course home and the dates tab, link names:
course_home_upgrade_shift_dates
dates_upgrade

Relevant Jira ticket:
https://openedx.atlassian.net/browse/REV-1205

This link has two wording variations, so it appears twice in dates_banner.html. The change is adding class="personalized_learner_schedules" to those two links, and then adding javascript into the two "pages" where they can be displayed from, dates.html for the dates tab, and course-home-fragment.html for the course home page. That javascript is the same except for the two things that differ: the link name and the pageName values.

Testing status for these links:
course_home_upgrade_shift_dates: tested locally using console.log (segment events cannot be set up locally)
dates_upgrade: testing needed: tested locally using console.log (segment events cannot be set up locally)

(Note: this is a fresh version of PR 24518, minus extra merge commits)