### PR TITLE
[REV-1205] Add ecommerce event tracking to 4 course home links

### DIFF
--- a/lms/djangoapps/courseware/date_summary.py
+++ b/lms/djangoapps/courseware/date_summary.py
@@ -622,7 +622,7 @@ class VerifiedUpgradeDeadlineDate(DateSummary):
                     platform_name=settings.PLATFORM_NAME,
                     button_panel=HTML(
                         '<div class="message-actions">'
-                        '<a class="btn btn-upgrade"'
+                        '<a id="certificate_upsell" class="btn btn-upgrade"'
                         'data-creative="original_message" data-position="course_message"'
                         'href="{upgrade_url}">{upgrade_label}</a>'
                         '</div>'

--- a/openedx/features/course_experience/templates/course_experience/course-home-fragment.html
+++ b/openedx/features/course_experience/templates/course_experience/course-home-fragment.html
@@ -199,6 +199,8 @@ from openedx.features.course_experience.course_tools import HttpMethod
   var upgradeDateLink = $("#course_home_dates");
   var GreenUpgradeLink = $("#green_upgrade");
   var courseToolsUpgradeLink = $(document.querySelectorAll("[data-analytics-id='edx.tool.verified_upgrade']"));
+  var GreenUpgradeLink = $("#green_upgrade");
+  var certificateUpsellLink = $("#certificate_upsell");
 
     TrackECommerceEvents.trackUpsellClick(personalizedLearnerSchedulesLink, 'course_home_upgrade_shift_dates', {
       pageName: "course_home",
@@ -241,5 +243,11 @@ from openedx.features.course_experience.course_tools import HttpMethod
       linkType: "link",
       linkCategory: "(none)"
     });
+
+    TrackECommerceEvents.trackUpsellClick(certificateUpsellLink, 'course_home_certificate', {
+        pageName: "course_home",
+        linkType: "link",
+        linkCategory: "(none)"
+      });
 
 </%static:require_module_async> 

--- a/openedx/features/course_experience/templates/course_experience/course-home-fragment.html
+++ b/openedx/features/course_experience/templates/course_experience/course-home-fragment.html
@@ -144,7 +144,7 @@ from openedx.features.course_experience.course_tools import HttpMethod
                         <img src="https://courses.edx.org/static/images/edx-verified-mini-cert.png" alt="">
                         <div class="upgrade-container">
                             <p>
-                                <a class="btn-brand btn-upgrade"
+                                <a id="green_upgrade" class="btn-brand btn-upgrade"
                                    href="${upgrade_url}"
                                    data-creative="sidebarupsell"
                                    data-position="sidebar-message"
@@ -196,6 +196,9 @@ from openedx.features.course_experience.course_tools import HttpMethod
   var fbeLink = $("#FBE_banner");
   var welcomeLink = $("#welcome");
   var sockLink = $("#sock");
+  var upgradeDateLink = $("#course_home_dates");
+  var GreenUpgradeLink = $("#green_upgrade");
+  var courseToolsUpgradeLink = $(document.querySelectorAll("[data-analytics-id='edx.tool.verified_upgrade']"));
 
     TrackECommerceEvents.trackUpsellClick(personalizedLearnerSchedulesLink, 'course_home_upgrade_shift_dates', {
       pageName: "course_home",
@@ -221,4 +224,22 @@ from openedx.features.course_experience.course_tools import HttpMethod
       linkCategory: "green_upgrade"
     });
 
-</%static:require_module_async>
+    TrackECommerceEvents.trackUpsellClick(upgradeDateLink, 'course_home_dates', {
+      pageName: "course_home",
+      linkType: "link",
+      linkCategory: "(none)"
+    });
+
+    TrackECommerceEvents.trackUpsellClick(GreenUpgradeLink, 'course_home_green', {
+      pageName: "course_home",
+      linkType: "button",
+      linkCategory: "green_upgrade"
+    });
+
+    TrackECommerceEvents.trackUpsellClick(courseToolsUpgradeLink, 'course_home_course_tools', {
+      pageName: "course_home",
+      linkType: "link",
+      linkCategory: "(none)"
+    });
+
+</%static:require_module_async> 

--- a/openedx/features/course_experience/templates/course_experience/dates-summary.html
+++ b/openedx/features/course_experience/templates/course_experience/dates-summary.html
@@ -26,7 +26,7 @@ from django.utils.translation import ugettext as _
             % endif
             % if course_date.link and course_date.link_text:
                 <div class="date-summary-link">
-                    <a href="${course_date.link}">${course_date.link_text}</a>
+                    <a id="course_home_dates" href="${course_date.link}">${course_date.link_text}</a>
                 </div>
             % endif
         </div>

--- a/openedx/features/course_experience/tests/views/test_course_home.py
+++ b/openedx/features/course_experience/tests/views/test_course_home.py
@@ -981,7 +981,7 @@ class CourseHomeFragmentViewTests(ModuleStoreTestCase):
         response = self.client.get(self.url)
         self.assertContains(response, 'section-upgrade')
         url = EcommerceService().get_checkout_page_url(self.verified_mode.sku)
-        self.assertContains(response, '<a class="btn-brand btn-upgrade"')
+        self.assertContains(response, '<a id="green_upgrade" class="btn-brand btn-upgrade"')
         self.assertContains(response, url)
         self.assertContains(
             response,


### PR DESCRIPTION
PR #24338 has our POC baseline for upsell event tracking, including javascript module. We'll have tracking for 18 links all together, so we'll break this up into several pull requests to minimize risk. This PR includes three of the course home links:
course_home_dates
course_home_green
course_home_course_tools

Relevant Jira ticket:
https://openedx.atlassian.net/browse/REV-1205

The javascript to bind these three links all lives in course-home-fragment.html, with the same format just switching out the values for the links, link name, and linkCategory. Then I added link ID value for the first two links, and for the third we're using a different selector that is already in place.

Testing status for these links:
course_home_dates: tested event with console.log
course_home_green: tested event with console.log
course_home_course_tools: tested event with console.log

Here is some info on the link names, categories, and where/when they appear:
https://docs.google.com/document/d/13Fwl3x-XUDGwm73ftkiKgiruiK3wWnlHeQ3mVSl4q_8/edit?ts=5f0cc156