### PR TITLE
[REV-1205] Add ecommerce event tracking to course sock and track selection upsell links

### DIFF
--- a/lms/templates/course_modes/_upgrade_button.html
+++ b/lms/templates/course_modes/_upgrade_button.html
@@ -10,10 +10,10 @@ from openedx.core.djangolib.markup import HTML, Text
 <li class="action action-select">
     <input type="hidden" name="contribution" value="${price_before_discount or min_price}" />
     % if content_gating_enabled or course_duration_limit_enabled:
-        <button type="submit" name="verified_mode">
+        <button id="track_sel_upgrade" type="submit" name="verified_mode">
             <span>${_('Pursue the Verified Track')}</span>
     % else:
-        <button type="submit" name="verified_mode">
+        <button id="track_sel_upgrade" type="submit" name="verified_mode">
             <span>${_('Pursue a Verified Certificate')}</span>
     % endif
         % if price_before_discount:
@@ -23,3 +23,14 @@ from openedx.core.djangolib.markup import HTML, Text
         % endif
         </button>
 </li>
+
+<%static:require_module_async module_name="js/commerce/track_ecommerce_events" class_name="TrackECommerceEvents">
+var upgradeLink = $("#track_sel_upgrade");
+
+TrackECommerceEvents.trackUpsellClick(upgradeLink, 'track_selection', {
+    pageName: "track_selection",
+    linkType: "button",
+    linkCategory: "(none)"
+});
+
+</%static:require_module_async> 

--- a/lms/templates/ux/reference/bootstrap/course-skeleton.html
+++ b/lms/templates/ux/reference/bootstrap/course-skeleton.html
@@ -77,3 +77,13 @@ from django.utils.translation import ugettext as _
     </div>
 </div>
 </%block>
+
+<%static:require_module_async module_name="js/commerce/track_ecommerce_events" class_name="TrackECommerceEvents">
+  var sockLink = $("#sock");
+  TrackECommerceEvents.trackUpsellClick(sockLink, 'in_course_sock', {
+      pageName: "in_course",
+      linkType: "button",
+      linkCategory: "sock"
+  });
+
+</%static:require_module_async>

--- a/openedx/features/course_experience/templates/course_experience/course-sock-fragment.html
+++ b/openedx/features/course_experience/templates/course_experience/course-sock-fragment.html
@@ -58,7 +58,7 @@ from openedx.features.course_experience import DISPLAY_COURSE_SOCK_FLAG
                     </div>
                 % endif
                 <img class="mini-cert" alt="Example Certificate Image" src="${static.url('course_experience/images/verified-cert.png')}"/>
-                <a href="${upgrade_url}">
+                <a id="sock" href="${upgrade_url}">
                     <div class="btn btn-upgrade stuck-top focusable action-upgrade-certificate" data-creative="original_sock" data-position="sock">
                         ${Text(_('Upgrade ({course_price})')).format(course_price=HTML(course_price))}
                     </div>

--- a/themes/edx.org/lms/templates/course_modes/_upgrade_button.html
+++ b/themes/edx.org/lms/templates/course_modes/_upgrade_button.html
@@ -10,10 +10,10 @@ from openedx.core.djangolib.markup import HTML, Text
 <li class="action action-select">
     <input type="hidden" name="contribution" value="${price_before_discount or min_price}" />
     % if content_gating_enabled or course_duration_limit_enabled:
-        <button type="submit" name="verified_mode">
+        <button id="track_sel_upgrade" type="submit" name="verified_mode">
             <span>${_('Pursue the Verified Track')}</span>
     % else:
-        <button type="submit" name="verified_mode">
+        <button id="track_sel_upgrade" type="submit" name="verified_mode">
             <span>${_('Pursue a Verified Certificate')}</span>
     % endif
         % if price_before_discount:
@@ -23,3 +23,14 @@ from openedx.core.djangolib.markup import HTML, Text
         % endif
         </button>
 </li>
+
+<%static:require_module_async module_name="js/commerce/track_ecommerce_events" class_name="TrackECommerceEvents">
+var upgradeLink = $("#track_sel_upgrade");
+
+  TrackECommerceEvents.trackUpsellClick(upgradeLink, 'track_selection', {
+    pageName: "track_selection",
+    linkType: "button",
+    linkCategory: "none"
+  });
+
+</%static:require_module_async> 

--- a/themes/edx.org/lms/templates/course_modes/_upgrade_button.html
+++ b/themes/edx.org/lms/templates/course_modes/_upgrade_button.html
@@ -27,6 +27,7 @@ from openedx.core.djangolib.markup import HTML, Text
 <%static:require_module_async module_name="js/commerce/track_ecommerce_events" class_name="TrackECommerceEvents">
 var upgradeLink = $("#track_sel_upgrade");
 
+function trackUpgradeEvent() {
   TrackECommerceEvents.trackUpsellClick(upgradeLink, 'track_selection', {
     pageName: "track_selection",
     linkType: "button",

--- a/themes/edx.org/lms/templates/course_modes/_upgrade_button.html
+++ b/themes/edx.org/lms/templates/course_modes/_upgrade_button.html
@@ -27,11 +27,10 @@ from openedx.core.djangolib.markup import HTML, Text
 <%static:require_module_async module_name="js/commerce/track_ecommerce_events" class_name="TrackECommerceEvents">
 var upgradeLink = $("#track_sel_upgrade");
 
-function trackUpgradeEvent() {
-  TrackECommerceEvents.trackUpsellClick(upgradeLink, 'track_selection', {
+TrackECommerceEvents.trackUpsellClick(upgradeLink, 'track_selection', {
     pageName: "track_selection",
     linkType: "button",
     linkCategory: "none"
-  });
+});
 
 </%static:require_module_async> 


### PR DESCRIPTION
PR #24338 has our POC baseline for upsell event tracking, including javascript module. We'll have tracking for 18 links all together, so we'll break this up into several pull requests to minimize risk. This PR includes:
track selection (2 files) aka "track_selection" (all tests passed with only these updates)
sock links (3 files) aka "course_home_sock" and "in_course_sock" (these introduced 403 error on 4 tests)

Relevant Jira ticket:
https://openedx.atlassian.net/browse/REV-1205

Testing status for these links:
track_selection: tested event with console.log
course_home_sock: tested event with console.log
in_course_sock: wasn't able to test locally yet; confirmed the same id="sock" on the button, but page in test course has some difference interfering with reaching tracking function