### PR TITLE
[REV-1205] Add ecommerce event tracking to welcome banner upsell links 

### DIFF
--- a/lms/templates/courseware/courseware.html
+++ b/lms/templates/courseware/courseware.html
@@ -275,6 +275,7 @@ ${HTML(fragment.foot_html())}
 <%static:require_module_async module_name="js/commerce/track_ecommerce_events" class_name="TrackECommerceEvents">
 
   var fbeLink = $("#FBE_banner");
+  var welcomeLink = $("#welcome");
 
   TrackECommerceEvents.trackUpsellClick(fbeLink, 'in_course_audit_access_expires', {
       pageName: "in_course",
@@ -282,4 +283,10 @@ ${HTML(fragment.foot_html())}
       linkCategory: "FBE_banner"
   });
 
-</%static:require_module_async> 
+  TrackECommerceEvents.trackUpsellClick(welcomeLink, 'in_course_welcome', {
+      pageName: "in_course",
+      linkType: "link",
+      linkCategory: "welcome"
+  });
+
+</%static:require_module_async>

--- a/lms/templates/courseware/courseware.html
+++ b/lms/templates/courseware/courseware.html
@@ -276,6 +276,7 @@ ${HTML(fragment.foot_html())}
 
   var fbeLink = $("#FBE_banner");
   var welcomeLink = $("#welcome");
+  var accessDeniedUpsellLink = $("#accessDeniedUpsell");
 
   TrackECommerceEvents.trackUpsellClick(fbeLink, 'in_course_audit_access_expires', {
       pageName: "in_course",
@@ -287,6 +288,12 @@ ${HTML(fragment.foot_html())}
       pageName: "in_course",
       linkType: "link",
       linkCategory: "welcome"
+  });
+
+  TrackECommerceEvents.trackUpsellClick(accessDeniedUpsellLink, 'in_course_upgrade', {
+    pageName: "in_course",
+    linkType: "link",
+    linkCategory: "none"
   });
 
 </%static:require_module_async>

--- a/lms/templates/courseware/courseware.html
+++ b/lms/templates/courseware/courseware.html
@@ -293,7 +293,7 @@ ${HTML(fragment.foot_html())}
   TrackECommerceEvents.trackUpsellClick(accessDeniedUpsellLink, 'in_course_upgrade', {
     pageName: "in_course",
     linkType: "link",
-    linkCategory: "none"
+    linkCategory: "(none)"
   });
 
 </%static:require_module_async>

--- a/lms/templates/ux/reference/bootstrap/course-skeleton.html
+++ b/lms/templates/ux/reference/bootstrap/course-skeleton.html
@@ -77,14 +77,3 @@ from django.utils.translation import ugettext as _
     </div>
 </div>
 </%block>
-
-<%static:require_module_async module_name="js/commerce/track_ecommerce_events" class_name="TrackECommerceEvents">
-  var welcomeLink = $("#welcome");
-
-  TrackECommerceEvents.trackUpsellClick(welcomeLink, 'in_course_welcome', {
-      pageName: "in_course",
-      linkType: "link",
-      linkCategory: "welcome"
-  });
-
-</%static:require_module_async>

--- a/lms/templates/ux/reference/bootstrap/course-skeleton.html
+++ b/lms/templates/ux/reference/bootstrap/course-skeleton.html
@@ -77,3 +77,14 @@ from django.utils.translation import ugettext as _
     </div>
 </div>
 </%block>
+
+<%static:require_module_async module_name="js/commerce/track_ecommerce_events" class_name="TrackECommerceEvents">
+  var welcomeLink = $("#welcome");
+
+  TrackECommerceEvents.trackUpsellClick(welcomeLink, 'in_course_welcome', {
+      pageName: "in_course",
+      linkType: "link",
+      linkCategory: "welcome"
+  });
+
+</%static:require_module_async>

--- a/openedx/features/content_type_gating/templates/content_type_gating/access_denied_message.html
+++ b/openedx/features/content_type_gating/templates/content_type_gating/access_denied_message.html
@@ -11,7 +11,7 @@
         </span>
         {% if not mobile_app and ecommerce_checkout_link %}
         <span class="certDIV_1" style="">
-            <a href="{{ecommerce_checkout_link}}" class="certA_1">
+            <a id="accessDeniedUpsell" href="{{ecommerce_checkout_link}}" class="certA_1">
                 {% trans "Upgrade to unlock" as tmsg %}{{tmsg|force_escape}} ({{min_price}})
             </a>
         </span>

--- a/openedx/features/course_experience/templates/course_experience/course-home-fragment.html
+++ b/openedx/features/course_experience/templates/course_experience/course-home-fragment.html
@@ -194,6 +194,7 @@ from openedx.features.course_experience.course_tools import HttpMethod
 
   var personalizedLearnerSchedulesLink = $(".personalized_learner_schedules_button");
   var fbeLink = $("#FBE_banner");
+  var welcomeLink = $("#welcome");
 
     TrackECommerceEvents.trackUpsellClick(personalizedLearnerSchedulesLink, 'course_home_upgrade_shift_dates', {
       pageName: "course_home",
@@ -201,11 +202,16 @@ from openedx.features.course_experience.course_tools import HttpMethod
       linkCategory: "personalized_learner_schedules"
     });
 
-  TrackECommerceEvents.trackUpsellClick(fbeLink, 'course_home_audit_access_expires', {
+    TrackECommerceEvents.trackUpsellClick(fbeLink, 'course_home_audit_access_expires', {
       pageName: "course_home",
       linkType: "link",
       linkCategory: "FBE_banner"
-  });
+    });
 
+    TrackECommerceEvents.trackUpsellClick(welcomeLink, 'course_home_welcome', {
+      pageName: "course_home",
+      linkType: "link",
+      linkCategory: "welcome"
+    });
 
 </%static:require_module_async>

--- a/openedx/features/course_experience/tests/views/test_course_home.py
+++ b/openedx/features/course_experience/tests/views/test_course_home.py
@@ -442,7 +442,7 @@ class TestCourseHomePageAccess(CourseHomePageTestCase):
         bannerText = u'''<div class="first-purchase-offer-banner" role="note">
              <span class="first-purchase-offer-banner-bold">
              Upgrade by {discount_expiration_date} and save {percentage}% [{strikeout_price}]</span>
-             <br>Use code <b>EDXWELCOME</b> at checkout! <a href="{upgrade_link}">Upgrade Now</a>
+             <br>Use code <b>EDXWELCOME</b> at checkout! <a id="welcome" href="{upgrade_link}">Upgrade Now</a>
              </div>'''.format(
             discount_expiration_date=discount_expiration_date,
             percentage=percentage,

--- a/openedx/features/discounts/utils.py
+++ b/openedx/features/discounts/utils.py
@@ -123,7 +123,7 @@ def generate_offer_html(user, course):
                               u'{a_open}Upgrade Now{a_close}{div_close}')
 
             message_html = HTML(offer_message).format(
-                a_open=HTML(u'<a href="{upgrade_link}">').format(
+                a_open=HTML(u'<a id="welcome" href="{upgrade_link}">').format(
                     upgrade_link=verified_upgrade_deadline_link(user=user, course=course)
                 ),
                 a_close=HTML('</a>'),


### PR DESCRIPTION
PR #24338 has our proof-of-concept baseline for upsell event tracking, including javascript module. We'll have tracking for 18 links all together, so we'll break this up into several pull requests to minimize risk.

This PR includes the welcome links and a one-of-a-kind one:
course_home_welcome
in_course_welcome
in_course_upgrade 

Relevant Jira ticket:
https://openedx.atlassian.net/browse/REV-1205

Testing status for these links:
course_home_welcome: tested event with console.log
in_course_welcome:  tested event with console.log
in_course_upgrade:  tested event with console.log

Here is some info on the link names, categories, and where/when they appear:
https://docs.google.com/document/d/13Fwl3x-XUDGwm73ftkiKgiruiK3wWnlHeQ3mVSl4q_8/edit?ts=5f0cc156