### PR TITLE
[BD-05] [TNL-7308] Add ORA Zipped File Download for Submission Text + Attached Files

### DIFF
--- a/lms/djangoapps/instructor/views/api.py
+++ b/lms/djangoapps/instructor/views/api.py
@@ -2055,6 +2055,28 @@ def export_ora2_data(request, course_id):
 @cache_control(no_cache=True, no_store=True, must_revalidate=True)
 @require_course_permission(permissions.CAN_RESEARCH)
 @common_exceptions_400
+def export_ora2_submission_files(request, course_id):
+    """
+    Pushes a Celery task which will download and compress all submission
+    files (texts, attachments) into a zip archive.
+    """
+    course_key = CourseKey.from_string(course_id)
+
+    task_api.submit_export_ora2_submission_files(request, course_key)
+
+    return JsonResponse({
+        "status": _(
+            "Attachments archive is being created."
+        )
+    })
+
+
+@transaction.non_atomic_requests
+@require_POST
+@ensure_csrf_cookie
+@cache_control(no_cache=True, no_store=True, must_revalidate=True)
+@require_course_permission(permissions.CAN_RESEARCH)
+@common_exceptions_400
 def calculate_grades_csv(request, course_id):
     """
     AlreadyRunningError is raised if the course's grades are already being updated.

--- a/lms/djangoapps/instructor/views/api_urls.py
+++ b/lms/djangoapps/instructor/views/api_urls.py
@@ -54,6 +54,9 @@ urlpatterns = [
     url(r'^get_course_survey_results$', api.get_course_survey_results, name='get_course_survey_results'),
     url(r'^export_ora2_data', api.export_ora2_data, name='export_ora2_data'),
 
+    url(r'^export_ora2_submission_files', api.export_ora2_submission_files,
+        name='export_ora2_submission_files'),
+
     # spoc gradebook
     url(r'^gradebook$', gradebook_api.spoc_gradebook, name='spoc_gradebook'),
 

--- a/lms/djangoapps/instructor/views/instructor_dashboard.py
+++ b/lms/djangoapps/instructor/views/instructor_dashboard.py
@@ -628,6 +628,9 @@ def _section_data_download(course, access):
             'get_course_survey_results', kwargs={'course_id': six.text_type(course_key)}
         ),
         'export_ora2_data_url': reverse('export_ora2_data', kwargs={'course_id': six.text_type(course_key)}),
+        'export_ora2_submission_files_url': reverse(
+            'export_ora2_submission_files', kwargs={'course_id': six.text_type(course_key)}
+        ),
     }
     if not access.get('data_researcher'):
         section_data['is_hidden'] = True

--- a/lms/djangoapps/instructor_task/api.py
+++ b/lms/djangoapps/instructor_task/api.py
@@ -35,6 +35,7 @@ from lms.djangoapps.instructor_task.tasks import (
     course_survey_report_csv,
     delete_problem_state,
     export_ora2_data,
+    export_ora2_submission_files,
     generate_certificates,
     override_problem_score,
     proctored_exam_results_csv,
@@ -444,6 +445,19 @@ def submit_export_ora2_data(request, course_key):
     """
     task_type = 'export_ora2_data'
     task_class = export_ora2_data
+    task_input = {}
+    task_key = ''
+
+    return submit_task(request, task_type, task_class, course_key, task_input, task_key)
+
+
+def submit_export_ora2_submission_files(request, course_key):
+    """
+    Submits a task to download and compress all submissions
+    files (texts, attachments) for given course.
+    """
+    task_type = 'export_ora2_submission_files'
+    task_class = export_ora2_submission_files
     task_input = {}
     task_key = ''
 

--- a/lms/djangoapps/instructor_task/models.py
+++ b/lms/djangoapps/instructor_task/models.py
@@ -280,9 +280,14 @@ class DjangoStorageReportStore(ReportStore):
         """
         path = self.path_to(course_id, filename)
         # See https://github.com/boto/boto/issues/2868
-        # Boto doesn't play nice with unicod in python3
+        # Boto doesn't play nice with unicode in python3
         if not six.PY2:
-            buff = ContentFile(buff.read().encode('utf-8'))
+            buff_contents = buff.read()
+
+            if not isinstance(buff_contents, bytes):
+                buff_contents = buff_contents.encode('utf-8')
+
+            buff = ContentFile(buff_contents)
 
         self.storage.save(path, buff)
 

--- a/lms/djangoapps/instructor_task/tasks.py
+++ b/lms/djangoapps/instructor_task/tasks.py
@@ -40,6 +40,7 @@ from lms.djangoapps.instructor_task.tasks_helper.misc import (
     cohort_students_and_upload,
     upload_course_survey_report,
     upload_ora2_data,
+    upload_ora2_submission_files,
     upload_proctored_exam_results_report
 )
 from lms.djangoapps.instructor_task.tasks_helper.module_state import (
@@ -291,4 +292,15 @@ def export_ora2_data(entry_id, xmodule_instance_args):
     """
     action_name = ugettext_noop('generated')
     task_fn = partial(upload_ora2_data, xmodule_instance_args)
+    return run_main_task(entry_id, task_fn, action_name)
+
+
+@task(base=BaseInstructorTask)
+def export_ora2_submission_files(entry_id, xmodule_instance_args):
+    """
+    Download all submission files, generate csv downloads list,
+    put all this into zip archive and push it to S3.
+    """
+    action_name = ugettext_noop('compressed')
+    task_fn = partial(upload_ora2_submission_files, xmodule_instance_args)
     return run_main_task(entry_id, task_fn, action_name)

--- a/lms/djangoapps/instructor_task/tasks_helper/misc.py
+++ b/lms/djangoapps/instructor_task/tasks_helper/misc.py
@@ -7,16 +7,21 @@ running state of a course.
 
 import logging
 from collections import OrderedDict
+from contextlib import contextmanager
 from datetime import datetime
+from io import StringIO
+from tempfile import TemporaryFile
 from time import time
+from zipfile import ZipFile
 import csv
+import os
 import unicodecsv
 import six
 
 from django.contrib.auth.models import User
 from django.core.exceptions import ValidationError
 from django.core.files.storage import DefaultStorage
-from openassessment.data import OraAggregateData
+from openassessment.data import OraAggregateData, OraDownloadData
 from pytz import UTC
 
 from lms.djangoapps.instructor_analytics.basic import get_proctored_exam_results
@@ -27,7 +32,12 @@ from survey.models import SurveyAnswer
 from util.file import UniversalNewlineIterator
 
 from .runner import TaskProgress
-from .utils import UPDATE_STATUS_FAILED, UPDATE_STATUS_SUCCEEDED, upload_csv_to_report_store
+from .utils import (
+    UPDATE_STATUS_FAILED,
+    UPDATE_STATUS_SUCCEEDED,
+    upload_csv_to_report_store,
+    upload_zip_to_report_store,
+)
 
 # define different loggers for use within tasks and on client side
 TASK_LOG = logging.getLogger('edx.celery.task')
@@ -336,6 +346,111 @@ def upload_ora2_data(
     upload_csv_to_report_store(rows, 'ORA_data', course_id, start_date)
 
     curr_step = {'step': 'Finalizing ORA data report'}
+    task_progress.update_task_state(extra_meta=curr_step)
+    TASK_LOG.info(u'%s, Task type: %s, Upload complete.', task_info_string, action_name)
+
+    return UPDATE_STATUS_SUCCEEDED
+
+
+def _task_step(task_progress, task_info_string, action_name):
+    """
+    Returns a context manager, that logs error and updates TaskProgress
+    filures counter in case inner block throws an exception.
+    """
+
+    @contextmanager
+    def _step_context_manager(step_description, exception_text, step_error_description):
+        curr_step = {'step': step_description}
+        TASK_LOG.info(
+            '%s, Task type: %s, Current step: %s',
+            task_info_string,
+            action_name,
+            curr_step,
+        )
+
+        task_progress.update_task_state(extra_meta=curr_step)
+
+        try:
+            yield
+
+        # Update progress to failed regardless of error type
+        except Exception:  # pylint: disable=broad-except
+            TASK_LOG.exception(exception_text)
+            task_progress.failed = 1
+
+            task_progress.update_task_state(extra_meta={'step': step_error_description})
+
+    return _step_context_manager
+
+
+def upload_ora2_submission_files(
+    _xmodule_instance_args, _entry_id, course_id, _task_input, action_name
+):
+    """
+    Creates zip archive with submission files in three steps:
+
+    1. Collect all files information using ORA download helper.
+    2. Download all submission attachments, put them in temporary zip
+        file along with submission texts and csv downloads list.
+    3. Upload zip file into reports storage.
+    """
+
+    start_time = time()
+    start_date = datetime.now(UTC)
+
+    num_attempted = 1
+    num_total = 1
+
+    fmt = 'Task: {task_id}, InstructorTask ID: {entry_id}, Course: {course_id}, Input: {task_input}'
+    task_info_string = fmt.format(
+        task_id=_xmodule_instance_args.get('task_id') if _xmodule_instance_args is not None else None,
+        entry_id=_entry_id,
+        course_id=course_id,
+        task_input=_task_input
+    )
+    TASK_LOG.info(u'%s, Task type: %s, Starting task execution', task_info_string, action_name)
+
+    task_progress = TaskProgress(action_name, num_total, start_time)
+    task_progress.attempted = num_attempted
+
+    step_manager = _task_step(task_progress, task_info_string, action_name)
+
+    submission_files_data = None
+    with step_manager(
+        'Collecting attachments data',
+        'Failed to get ORA submissions attachments data.',
+        'Error while collecting data',
+    ):
+        submission_files_data = OraDownloadData.collect_ora2_submission_files(course_id)
+
+    if submission_files_data is None:
+        return UPDATE_STATUS_FAILED
+
+    with TemporaryFile('rb+') as zip_file:
+        compressed = None
+        with step_manager(
+            'Downloading and compressing attachments files',
+            'Failed to download and compress submissions attachments.',
+            'Error while downloading and compressing submissions attachments',
+        ):
+            compressed = OraDownloadData.create_zip_with_attachments(zip_file, course_id, submission_files_data)
+
+        if compressed is None:
+            return UPDATE_STATUS_FAILED
+
+        zip_filename = None
+        with step_manager(
+            'Uploading zip file to storage',
+            'Failed to upload zip file to storage.',
+            'Error while uploading zip file to storage',
+        ):
+            zip_filename = upload_zip_to_report_store(zip_file, 'submission_files', course_id, start_date),
+
+        if not zip_filename:
+            return UPDATE_STATUS_FAILED
+
+    task_progress.succeeded = 1
+    curr_step = {'step': 'Finalizing attachments extracting'}
     task_progress.update_task_state(extra_meta=curr_step)
     TASK_LOG.info(u'%s, Task type: %s, Upload complete.', task_info_string, action_name)
 

--- a/lms/djangoapps/instructor_task/tasks_helper/utils.py
+++ b/lms/djangoapps/instructor_task/tasks_helper/utils.py
@@ -49,6 +49,23 @@ def upload_csv_to_report_store(rows, csv_name, course_id, timestamp, config_name
     return report_name, report_path
 
 
+def upload_zip_to_report_store(file, zip_name, course_id, timestamp, config_name='GRADES_DOWNLOAD'):
+    """
+    Upload given file buffer as a zip file using ReportStore.
+    """
+    report_store = ReportStore.from_config(config_name)
+
+    report_name = u"{course_prefix}_{zip_name}_{timestamp_str}.zip".format(
+        course_prefix=course_filename_prefix_generator(course_id),
+        zip_name=zip_name,
+        timestamp_str=timestamp.strftime("%Y-%m-%d-%H%M")
+    )
+
+    report_store.store(course_id, report_name, file)
+    tracker_emit(zip_name)
+    return report_name
+
+
 def tracker_emit(report_name):
     """
     Emits a 'report.requested' event for the given report.

--- a/lms/djangoapps/instructor_task/tests/test_api.py
+++ b/lms/djangoapps/instructor_task/tests/test_api.py
@@ -27,6 +27,7 @@ from lms.djangoapps.instructor_task.api import (
     submit_delete_entrance_exam_state_for_student,
     submit_delete_problem_state_for_all_students,
     submit_export_ora2_data,
+    submit_export_ora2_submission_files,
     submit_override_score,
     submit_rescore_entrance_exam_for_student,
     submit_rescore_problem_for_all_students,
@@ -36,7 +37,7 @@ from lms.djangoapps.instructor_task.api import (
 )
 from lms.djangoapps.instructor_task.api_helper import AlreadyRunningError, QueueConnectionError
 from lms.djangoapps.instructor_task.models import PROGRESS, InstructorTask
-from lms.djangoapps.instructor_task.tasks import export_ora2_data
+from lms.djangoapps.instructor_task.tasks import export_ora2_data, export_ora2_submission_files
 from lms.djangoapps.instructor_task.tests.test_base import (
     TEST_COURSE_KEY,
     InstructorTaskCourseTestCase,
@@ -281,6 +282,22 @@ class InstructorTaskCourseSubmitTest(TestReportMixin, InstructorTaskCourseTestCa
 
             mock_submit_task.assert_called_once_with(
                 request, 'export_ora2_data', export_ora2_data, self.course.id, {}, '')
+
+    def test_submit_export_ora2_submission_files(self):
+        request = self.create_task_request(self.instructor)
+
+        with patch('lms.djangoapps.instructor_task.api.submit_task') as mock_submit_task:
+            mock_submit_task.return_value = MagicMock()
+            submit_export_ora2_submission_files(request, self.course.id)
+
+            mock_submit_task.assert_called_once_with(
+                request,
+                'export_ora2_submission_files',
+                export_ora2_submission_files,
+                self.course.id,
+                {},
+                ''
+            )
 
     def test_submit_generate_certs_students(self):
         """

--- a/lms/djangoapps/instructor_task/tests/test_tasks.py
+++ b/lms/djangoapps/instructor_task/tests/test_tasks.py
@@ -25,6 +25,7 @@ from lms.djangoapps.instructor_task.models import InstructorTask
 from lms.djangoapps.instructor_task.tasks import (
     delete_problem_state,
     export_ora2_data,
+    export_ora2_submission_files,
     generate_certificates,
     override_problem_score,
     rescore_problem,
@@ -678,6 +679,36 @@ class TestOra2ResponsesInstructorTask(TestInstructorTasks):
         with patch('lms.djangoapps.instructor_task.tasks.run_main_task') as mock_main_task:
             export_ora2_data(task_entry.id, task_xmodule_args)
             action_name = ugettext_noop('generated')
+
+            assert mock_main_task.call_count == 1
+            args = mock_main_task.call_args[0]
+            assert args[0] == task_entry.id
+            assert callable(args[1])
+            assert args[2] == action_name
+
+
+class TestOra2ExportSubmissionFilesInstructorTask(TestInstructorTasks):
+    """Tests instructor task that exports ora2 submission files archive."""
+
+    def test_ora2_missing_current_task(self):
+        self._test_missing_current_task(export_ora2_submission_files)
+
+    def test_ora2_with_failure(self):
+        self._test_run_with_failure(export_ora2_submission_files, 'We expected this to fail')
+
+    def test_ora2_with_long_error_msg(self):
+        self._test_run_with_long_error_msg(export_ora2_submission_files)
+
+    def test_ora2_with_short_error_msg(self):
+        self._test_run_with_short_error_msg(export_ora2_submission_files)
+
+    def test_ora2_runs_task(self):
+        task_entry = self._create_input_entry()
+        task_xmodule_args = self._get_xmodule_instance_args()
+
+        with patch('lms.djangoapps.instructor_task.tasks.run_main_task') as mock_main_task:
+            export_ora2_submission_files(task_entry.id, task_xmodule_args)
+            action_name = ugettext_noop('compressed')
 
             assert mock_main_task.call_count == 1
             args = mock_main_task.call_args[0]

--- a/lms/templates/instructor/instructor_dashboard_2/data_download.html
+++ b/lms/templates/instructor/instructor_dashboard_2/data_download.html
@@ -94,6 +94,11 @@ from openedx.core.djangolib.markup import HTML, Text
       <input type="button" name="problem-grade-report" class="async-report-btn" value="${_("Generate Problem Grade Report")}" data-endpoint="${ section_data['problem_grade_report_url'] }"/>
       <input type="button" name="export-ora2-data" class="async-report-btn" value="${_("Generate ORA Data Report")}" data-endpoint="${ section_data['export_ora2_data_url'] }"/>
     </p>
+
+    <p>${_("Click to generate a ZIP file that contains all submission texts and attachments.")}</p>
+
+    <p><input type="button" name="export-ora2-data" class="async-report-btn" value="${_("Generate Submission Files Archive")}" data-endpoint="${ section_data['export_ora2_submission_files_url'] }"/></p>
+
   %endif
 
     <div class="request-response msg msg-confirm copy" id="report-request-response"></div>


### PR DESCRIPTION
This PR adds new button to the course instructor dashboard:
![Screenshot_2020-07-22_16-54-29](https://user-images.githubusercontent.com/18251194/88185094-30f9c200-cc3c-11ea-9662-737517b699d4.png)

Click on this button spawns a task, which downloads all submission files (texts and attachments), puts them into zip archive and uploads it to reports storage.

Structure of generated zip file:
```
.
└── CourseId
    ├── BlockId1
    │   ├── StudentId1
    │   │   ├── attachments
    │   │   │   ├── SomeFile1
    │   │   │   └── SomeFile2
    │   │   ├── part_0.txt
    │   │   └── part_1.txt
    │   └── StudentId2
    │       ├── part_0.txt
    │       └── part_1.txt
    ├── BlockId2
    │   └── StudentId3
    │       ├── attachments
    │       │   └── SomeFile4
    │       └── part_0.txt
    └── downloads.csv
```

Where `downloads.csv` is a list of all downloaded files with their metadata: description, size, etc.

**JIRA tickets**:
- [TNL-7308](https://openedx.atlassian.net/browse/TNL-7308)
- [BLENDED-474](https://openedx.atlassian.net/browse/BLENDED-474)

**Dependencies**:
This PR depends on https://github.com/edx/edx-ora2/pull/1453

**Sandbox URL**: https://pr24541.sandbox.opencraft.hosting

**Merge deadline**: None

**Testing instructions**:

(_skip if you're testing with sandbox_) To test this, you need to install ORA with related change:
1. Go to `$devstack_root/src`. 
1. Clone OpenCraft's ORA repo here:
    ```
    git clone https://github.com/open-craft/edx-ora2
    ```
1. Switch cloned ORA to branch with new aggregate method:
   ```
   cd edx-ora2 & git checkout 0x29a/bb2651/ora_zipped_data
   ```
1. Go back to `$devstack_root/src`.
1. Install the ORA in the platform containers: 
    ```
    # From the devstack folder $devstack_root/devstack:
    make lms-shell
    > pip install -e /edx/src/edx-ora2
    # Then exit the shell and run
    make studio-shell
    > pip install -e /edx/src/edx-ora2
    ```

(_skip if you're testing with sandbox_) After you installed ORA with related changes, you need to switch `edx-platform` to new branch:
1. Go to `$devstack_root/edx-platform`
1. Add new remote:
    ```
    git remote add opencraft https://github.com/open-craft/edx-platform.git
    ```
1. Fetch branch with changes:
    ```
    git fetch opencraft 0x29a/bb2651/ora_zipped_data
    ```
1. Switch repo to this branch:
    ```
    git checkout 0x29a/bb2651/ora_zipped_data
    ```

    Platform should restart automatically, but if not, do that manually. And now you should see new button in instructors dashboard.

Now you need to prepare some data to be exported:

1. Add ORA block to existing course via studio. Before publishing it, adjust its settings to require only 1 peer assessment and require attachments:
![Screenshot_2020-07-20_13-30-06](https://user-images.githubusercontent.com/18251194/87928261-3238bc80-ca8d-11ea-8bcb-7f74086d815b.png)
![Screenshot_2020-07-20_13-30-25](https://user-images.githubusercontent.com/18251194/87928270-349b1680-ca8d-11ea-9b9b-b17925eaeef8.png)


1. Add a few answers with attachments.
1. Click on download button:
![Screenshot_2020-07-22_16-54-29](https://user-images.githubusercontent.com/18251194/88185094-30f9c200-cc3c-11ea-9662-737517b699d4.png)
1. Soon you should see new report at the bottom of dashboard:
![Screenshot_2020-07-22_16-54-44](https://user-images.githubusercontent.com/18251194/88185226-5d154300-cc3c-11ea-945d-d83193db0bb0.png)

1. This report should contain all submission attachments with `.csv` file describing each download.
Example of CSV: [downloads.csv.zip](https://github.com/edx/edx-platform/files/4947136/downloads.csv.zip)


**Reviewers**
- [ ] @xitij2000 
- [ ] edX reviewer[s] TBD
