### PR TITLE
[BD-29] [TNL-7260] Move inaccessible_after_due to LearningSequence rather than CourseSectionSequence model

### DIFF
--- a/openedx/core/djangoapps/content/learning_sequences/api/outlines.py
+++ b/openedx/core/djangoapps/content/learning_sequences/api/outlines.py
@@ -75,7 +75,7 @@ def get_course_outline(course_key: CourseKey) -> CourseOutlineData:
         sequence_data = CourseLearningSequenceData(
             usage_key=sequence_model.usage_key,
             title=sequence_model.title,
-            inaccessible_after_due=sec_seq_model.inaccessible_after_due,
+            inaccessible_after_due=sequence_model.inaccessible_after_due,
             visibility=VisibilityData(
                 hide_from_toc=sec_seq_model.hide_from_toc,
                 visible_to_staff_only=sec_seq_model.visible_to_staff_only,
@@ -287,7 +287,10 @@ def _update_sequences(course_outline: CourseOutlineData, learning_context: Learn
             LearningSequence.objects.update_or_create(
                 learning_context=learning_context,
                 usage_key=sequence_data.usage_key,
-                defaults={'title': sequence_data.title}
+                defaults={
+                    'title': sequence_data.title,
+                    'inaccessible_after_due': sequence_data.inaccessible_after_due,
+                }
             )
     LearningSequence.objects \
         .filter(learning_context=learning_context) \
@@ -316,7 +319,6 @@ def _update_course_section_sequences(course_outline: CourseOutlineData, learning
                 sequence=sequence_models[sequence_data.usage_key],
                 defaults={
                     'ordering': ordering,
-                    'inaccessible_after_due': sequence_data.inaccessible_after_due,
                     'hide_from_toc': sequence_data.visibility.hide_from_toc,
                     'visible_to_staff_only': sequence_data.visibility.visible_to_staff_only,
                 },

--- a/openedx/core/djangoapps/content/learning_sequences/migrations/0002_learningsequence_inaccessible_after_due.py
+++ b/openedx/core/djangoapps/content/learning_sequences/migrations/0002_learningsequence_inaccessible_after_due.py
@@ -11,7 +11,7 @@ class Migration(migrations.Migration):
 
     operations = [
         migrations.AddField(
-            model_name='coursesectionsequence',
+            model_name='learningsequence',
             name='inaccessible_after_due',
             field=models.BooleanField(default=False),
         ),

--- a/openedx/core/djangoapps/content/learning_sequences/models.py
+++ b/openedx/core/djangoapps/content/learning_sequences/models.py
@@ -89,6 +89,9 @@ class LearningSequence(TimeStampedModel):
     # 270 long, meaning we wouldn't be able to make it indexed anyway in InnoDB.
     title = models.CharField(max_length=1000)
 
+    # Make the sequence inaccessible from the outline after the due date has passed
+    inaccessible_after_due = models.BooleanField(null=False, default=False)
+
     # Separate field for when this Sequence's content was last changed?
     class Meta:
         unique_together = [
@@ -167,9 +170,6 @@ class CourseSectionSequence(CourseContentVisibilityMixin, TimeStampedModel):
     )
     section = models.ForeignKey(CourseSection, on_delete=models.CASCADE)
     sequence = models.ForeignKey(LearningSequence, on_delete=models.CASCADE)
-
-    # Make the sequence inaccessible from the outline after the due date has passed
-    inaccessible_after_due = models.BooleanField(null=False, default=False)
 
     # Ordering, starts with 0, but global for the course. So if you had 200
     # sequences across 20 sections, the numbering here would be 0-199.


### PR DESCRIPTION
When this work was originally done, the `inaccessible_after_due` field was placed on the `CourseSectionSequence` model. This code updates it to `LearningSequence` by modifying the existing migration file. If you would prefer a new migration file, please let me know.

**JIRA tickets**: 
[OSPR-4840](https://openedx.atlassian.net/browse/OSPR-4840)
[TNL-7260](https://openedx.atlassian.net/browse/TNL-7260)

**Dependencies**: None

**Testing instructions**:

1. Pull the `open-craft:patrick/move_inaccessible_after_due_to_learning_sequence` branch locally and setup your local LMS.
2. Modify a unit in the Studio to have a due date in the past
3. Run `make lms-shell`
4. Run `python manage.py lms migrate learning_sequences`
5. Run `python manage.py lms update_course_outline <COURSE_KEY>`
6. Navigate to 
```
http://localhost:18000/api/learning_sequences/v1/course_outline/<COURSE_KEY>?user=verified
```
7. Look through the response for the unit that was marked with a due date in the past. It should have the `accessible` attribute set to `false`

**Author notes and concerns**:

**Reviewers**
- [ ] @xitij2000 
- [ ] edX reviewer[s] TBD