### PR TITLE
EDUCATOR-5039

### DIFF
--- a/cms/djangoapps/contentstore/tests/test_course_settings.py
+++ b/cms/djangoapps/contentstore/tests/test_course_settings.py
@@ -519,9 +519,9 @@ class CourseGradingTest(CourseTestCase):
         uuid.return_value = "mockUUID"
         self.course = CourseFactory.create(default_store=store)
         test_grader = CourseGradingModel.fetch(self.course.id)
+        # there should be no event raised after this call, since nothing got modified
         altered_grader = CourseGradingModel.update_from_json(self.course.id, test_grader.__dict__, self.user)
         self.assertDictEqual(test_grader.__dict__, altered_grader.__dict__, "Noop update")
-        grading_policy_1 = self._grading_policy_hash_for_course()
         test_grader.graders[0]['weight'] = test_grader.graders[0].get('weight') * 2
         altered_grader = CourseGradingModel.update_from_json(self.course.id, test_grader.__dict__, self.user)
         self.assertDictEqual(test_grader.__dict__, altered_grader.__dict__, "Weight[0] * 2")
@@ -549,10 +549,8 @@ class CourseGradingTest(CourseTestCase):
         # one for each of the calls to update_from_json()
         send_signal.assert_has_calls([
             # pylint: disable=line-too-long
-            mock.call(sender=CourseGradingModel, user_id=self.user.id, course_key=self.course.id, grading_policy_hash=grading_policy_1),
             mock.call(sender=CourseGradingModel, user_id=self.user.id, course_key=self.course.id, grading_policy_hash=grading_policy_2),
             mock.call(sender=CourseGradingModel, user_id=self.user.id, course_key=self.course.id, grading_policy_hash=grading_policy_3),
-            mock.call(sender=CourseGradingModel, user_id=self.user.id, course_key=self.course.id, grading_policy_hash=grading_policy_4),
             mock.call(sender=CourseGradingModel, user_id=self.user.id, course_key=self.course.id, grading_policy_hash=grading_policy_4),
             # pylint: enable=line-too-long
         ])
@@ -570,9 +568,57 @@ class CourseGradingTest(CourseTestCase):
                     'event_transaction_id': 'mockUUID',
                 }
             ) for policy_hash in (
-                grading_policy_1, grading_policy_2, grading_policy_3, grading_policy_4, grading_policy_4
+                grading_policy_2, grading_policy_3, grading_policy_4
             )
         ])
+
+    @ddt.data(ModuleStoreEnum.Type.mongo, ModuleStoreEnum.Type.split)
+    def test_must_fire_grading_event_and_signal_multiple_type(self, store):
+        """
+        Verifies that 'must_fire_grading_event_and_signal' ignores (returns False) if we modify
+        short_label and or name
+        use test_must_fire_grading_event_and_signal_multiple_type_2_split to run this test only
+        """
+        self.course = CourseFactory.create(default_store=store)
+        # .raw_grader approximates what our UI sends down. It uses decimal representation of percent
+        # without it, the  weights would be percentages
+        raw_grader_list = modulestore().get_course(self.course.id).raw_grader
+        course_grading_model = CourseGradingModel.fetch(self.course.id)
+        raw_grader_list[0]['type'] += '_foo'
+        raw_grader_list[0]['short_label'] += '_foo'
+        raw_grader_list[2]['type'] += '_foo'
+        raw_grader_list[3]['type'] += '_foo'
+
+        result = CourseGradingModel.must_fire_grading_event_and_signal(
+            raw_grader_list,
+            modulestore().get_course(self.course.id),
+            course_grading_model.__dict__
+        )
+        self.assertFalse(result)
+
+    @ddt.data(ModuleStoreEnum.Type.mongo, ModuleStoreEnum.Type.split)
+    def test_must_fire_grading_event_and_signal_return_true(self, store):
+        """
+        Verifies that 'must_fire_grading_event_and_signal' ignores (returns False) if we modify
+        short_label and or name
+        use _2_split suffix to run this test only
+        """
+        self.course = CourseFactory.create(default_store=store)
+        # .raw_grader approximates what our UI sends down. It uses decimal representation of percent
+        # without it, the  weights would be percentages
+        raw_grader_list = modulestore().get_course(self.course.id).raw_grader
+        course_grading_model = CourseGradingModel.fetch(self.course.id)
+        raw_grader_list[0]['weight'] *= 2
+        raw_grader_list[0]['short_label'] += '_foo'
+        raw_grader_list[2]['type'] += '_foo'
+        raw_grader_list[3]['type'] += '_foo'
+
+        result = CourseGradingModel.must_fire_grading_event_and_signal(
+            raw_grader_list,
+            modulestore().get_course(self.course.id),
+            course_grading_model.__dict__
+        )
+        self.assertTrue(result)
 
     @mock.patch('track.event_transaction_utils.uuid4')
     @mock.patch('models.settings.course_grading.tracker')

--- a/cms/djangoapps/models/settings/course_grading.py
+++ b/cms/djangoapps/models/settings/course_grading.py
@@ -12,7 +12,7 @@ from eventtracking import tracker
 from contentstore.signals.signals import GRADING_POLICY_CHANGED
 from track.event_transaction_utils import create_new_event_transaction_id
 from xmodule.modulestore.django import modulestore
-from .waffle import material_recompute_only
+from models.settings.waffle import material_recompute_only
 
 GRADING_POLICY_CHANGED_EVENT_TYPE = 'edx.grades.grading_policy_changed'
 
@@ -67,36 +67,11 @@ class CourseGradingModel(object):
         Decode the json into CourseGradingModel and save any changes. Returns the modified model.
         Probably not the usual path for updates as it's too coarse grained.
         """
-
-        if material_recompute_only(course_key):
-            return CourseGradingModel.update_from_json_selective(course_key, jsondict, user)
-        else:
-            descriptor = modulestore().get_course(course_key)
-
-            graders_parsed = [CourseGradingModel.parse_grader(jsonele) for jsonele in jsondict['graders']]
-            descriptor.raw_grader = graders_parsed
-            descriptor.grade_cutoffs = jsondict['grade_cutoffs']
-
-            modulestore().update_item(descriptor, user.id)
-
-            CourseGradingModel.update_grace_period_from_json(course_key, jsondict['grace_period'], user)
-
-            CourseGradingModel.update_minimum_grade_credit_from_json(course_key, jsondict['minimum_grade_credit'], user)
-            _grading_event_and_signal(course_key, user.id)
-
-            return CourseGradingModel.fetch(course_key)
-
-    @staticmethod
-    def update_from_json_selective(course_key, jsondict, user):
-        """
-        New version that doesn't fire change events when only name or short name are changed.
-        Decode the json into CourseGradingModel and save any changes. Returns the modified model.
-        Probably not the usual path for updates as it's too coarse grained.
-        """
         descriptor = modulestore().get_course(course_key)
 
         graders_parsed = [CourseGradingModel.parse_grader(jsonele) for jsonele in jsondict['graders']]
         fire_signal = CourseGradingModel.must_fire_grading_event_and_signal(
+            course_key,
             graders_parsed,
             descriptor,
             jsondict
@@ -115,7 +90,36 @@ class CourseGradingModel(object):
         return CourseGradingModel.fetch(course_key)
 
     @staticmethod
-    def must_fire_grading_event_and_signal(proposed_grader_settings, course_from_module_store, jsondict):
+    def update_from_json_selective(course_key, jsondict, user):
+        """
+        New version that doesn't fire change events when only name or short name are changed.
+        Decode the json into CourseGradingModel and save any changes. Returns the modified model.
+        Probably not the usual path for updates as it's too coarse grained.
+        """
+        descriptor = modulestore().get_course(course_key)
+
+        graders_parsed = [CourseGradingModel.parse_grader(jsonele) for jsonele in jsondict['graders']]
+        fire_signal = CourseGradingModel.must_fire_grading_event_and_signal(
+            course_key,
+            graders_parsed,
+            descriptor,
+            jsondict
+        )
+        descriptor.raw_grader = graders_parsed
+        descriptor.grade_cutoffs = jsondict['grade_cutoffs']
+
+        modulestore().update_item(descriptor, user.id)
+
+        CourseGradingModel.update_grace_period_from_json(course_key, jsondict['grace_period'], user)
+
+        CourseGradingModel.update_minimum_grade_credit_from_json(course_key, jsondict['minimum_grade_credit'], user)
+        if fire_signal:
+            _grading_event_and_signal(course_key, user.id)
+
+        return CourseGradingModel.fetch(course_key)
+
+    @staticmethod
+    def must_fire_grading_event_and_signal(course_key, proposed_grader_settings, course_from_modulestore, jsondict):
         """
         Detects if substantive enough changes were made to the proposed grader settings to warrant the firing of
         _grading_event_and_sngal
@@ -123,16 +127,39 @@ class CourseGradingModel(object):
             drop_count, weight, min_count
             An assignment type was added or removed
         """
-        if course_from_module_store.grade_cutoffs != jsondict['grade_cutoffs'] or \
-                len(proposed_grader_settings) != len(course_from_module_store.raw_grader):
+        if course_from_modulestore.grade_cutoffs != jsondict['grade_cutoffs'] or \
+                len(proposed_grader_settings) != len(course_from_modulestore.raw_grader):
             return True
 
         # because grading policy lists remain in the same order, we can do a single loop
-        for i in range(len(course_from_module_store.raw_grader)):
-            if course_from_module_store.raw_grader[i]['drop_count'] != proposed_grader_settings[i]['drop_count'] or \
-                    course_from_module_store.raw_grader[i]['weight'] != proposed_grader_settings[i]['weight'] or \
-                    course_from_module_store.raw_grader[i]['min_count'] != proposed_grader_settings[i]['min_count']:
+        for i in range(len(course_from_modulestore.raw_grader)):
+            if CourseGradingModel.must_fire_grading_event_and_signal_single_grader(
+                course_key,
+                proposed_grader_settings[i],
+                course_from_modulestore.raw_grader[i]
+            ):
                 return True
+        return False
+
+    @staticmethod
+    def must_fire_grading_event_and_signal_single_grader(
+        course_key,
+        proposed_grader_settings,
+        existing_grader_settings
+    ):
+        """
+        Detects changes in an individual grader vs an entire grading policy
+         Detects if substantive enough changes were made to the proposed grader settings to warrant the firing of
+        _grading_event_and_sngal
+        Substantive changes mean the following values were changed:
+            drop_count, weight, min_count
+        """
+        if not material_recompute_only(course_key):
+            return True
+        if existing_grader_settings['drop_count'] != proposed_grader_settings['drop_count'] or \
+                existing_grader_settings['weight'] != proposed_grader_settings['weight'] or \
+                existing_grader_settings['min_count'] != proposed_grader_settings['min_count']:
+            return True
         return False
 
     @staticmethod
@@ -147,13 +174,20 @@ class CourseGradingModel(object):
         index = int(grader.get('id', len(descriptor.raw_grader)))
         grader = CourseGradingModel.parse_grader(grader)
 
+        fire_signal = True
         if index < len(descriptor.raw_grader):
+            fire_signal = CourseGradingModel.must_fire_grading_event_and_signal_single_grader(
+                course_key,
+                grader,
+                descriptor.raw_grader[index]
+            )
             descriptor.raw_grader[index] = grader
         else:
             descriptor.raw_grader.append(grader)
 
         modulestore().update_item(descriptor, user.id)
-        _grading_event_and_signal(course_key, user.id)
+        if fire_signal:
+            _grading_event_and_signal(course_key, user.id)
 
         return CourseGradingModel.jsonize_grader(index, descriptor.raw_grader[index])
 

--- a/cms/djangoapps/models/settings/waffle.py
+++ b/cms/djangoapps/models/settings/waffle.py
@@ -1,0 +1,19 @@
+"""
+Togglable settings for Course Grading behavior
+"""
+from openedx.core.djangoapps.waffle_utils import CourseWaffleFlag
+
+
+WAFFLE_NAMESPACE = 'grades'
+
+# edx/edx-platform feature
+MATERIAL_RECOMPUTE_ONLY = 'MATERIAL_RECOMPUTE_ONLY'
+
+
+def material_recompute_only(course_key):
+    """
+    Checks to see if the CourseWaffleFlag or Django setting for material recomputer only is enabled
+    """
+    if CourseWaffleFlag(WAFFLE_NAMESPACE, MATERIAL_RECOMPUTE_ONLY).is_enabled(course_key):
+        return True
+    return False

--- a/cms/djangoapps/models/settings/waffle.py
+++ b/cms/djangoapps/models/settings/waffle.py
@@ -9,11 +9,16 @@ WAFFLE_NAMESPACE = 'grades'
 # edx/edx-platform feature
 MATERIAL_RECOMPUTE_ONLY = 'MATERIAL_RECOMPUTE_ONLY'
 
+MATERIAL_RECOMPUTE_ONLY_FLAG = CourseWaffleFlag(
+    waffle_namespace=WAFFLE_NAMESPACE,
+    flag_name=MATERIAL_RECOMPUTE_ONLY,
+)
+
 
 def material_recompute_only(course_key):
     """
     Checks to see if the CourseWaffleFlag or Django setting for material recomputer only is enabled
     """
-    if CourseWaffleFlag(WAFFLE_NAMESPACE, MATERIAL_RECOMPUTE_ONLY).is_enabled(course_key):
+    if MATERIAL_RECOMPUTE_ONLY_FLAG.is_enabled(course_key):
         return True
     return False


### PR DESCRIPTION
[JIRA](https://openedx.atlassian.net/browse/EDUCATOR-5039)
We were recomputing grades even when non-material changes were made. To avoid database thrashing and increase performance, this pr ignores non-material (name only) changes when it comes to grade recomputation.
Because grading is an important area, I am adding a course waffle flag, so this features **MUST BE TURNED ON** for a course, for now.
@edx/masters-devs-gta 