### PR TITLE
[REV-1205] Add upsell tracking to verified/no SKU courses on the dashboard

### DIFF
--- a/lms/templates/dashboard/_dashboard_course_listing.html
+++ b/lms/templates/dashboard/_dashboard_course_listing.html
@@ -416,7 +416,7 @@ from lms.djangoapps.experiments.utils import UPSELL_TRACKING_FLAG
                 % if use_ecommerce_payment_flow and course_mode_info['verified_sku']:
                   <a class="action action-upgrade track_course_dashboard_green_button" href="${ecommerce_payment_page}?sku=${course_mode_info['verified_sku']}">
                 % else:
-                  <a class="action action-upgrade" href="${reverse('verify_student_upgrade_and_verify', kwargs={'course_id': six.text_type(course_overview.id)})}" data-course-id="${course_overview.id}" data-user="${user.username}">
+                  <a class="action action-upgrade track_course_dashboard_green_button" href="${reverse('verify_student_upgrade_and_verify', kwargs={'course_id': six.text_type(course_overview.id)})}" data-course-id="${course_overview.id}" data-user="${user.username}">
                 % endif
                     <span class="action-upgrade-icon" aria-hidden="true"></span>
                   <span class="wrapper-copy">


### PR DESCRIPTION
### What did we do?
Add the tracking class to the upsell button on the course dashboard for courses that are verified but have no SKUs.

### Why are we doing this?
So we can have better data on when upsell links get clicked.

### How did we test?
Locally:
1. clone an existing course 
2. go to the lms admin & make it a Verified course but deleted the SKU
3. refresh the course dashboard + confirm that that link is generated by the else part of the if claus
4. green button should appear (visually it looks the same as the case where the course has the SKU)
5. in the JS console, `$(".track_course_dashboard_green_button").length` would turn up 2 (instead of the 1 if the class wasn't added)
<img width="753" alt="Screen Shot 2020-07-20 at 2 55 52 PM" src="https://user-images.githubusercontent.com/34042537/87975219-53070f00-ca99-11ea-8e23-5251bd2264d4.png">

To test this in production, find a course in the read replica in this state > enroll in it > refresh the course dashboard > green button should track the click.

Query to find classes in this state: ```select *  from course_modes_coursemode where sku is null and mode_slug='Verified';```

Existing courses in production (this appears to be a very minor edge case):
DelftX/CTB3365USx/2T2015 
HarvardX/CS50x_3/2015T1 
course-v1:edX+victor101+2017Run
course-v1:edX+RevModel101+2018 
course-v1:StanfordOnline+test101+3T2019