### PR TITLE
disable escalation email requirement

### DIFF
--- a/cms/djangoapps/models/settings/course_metadata.py
+++ b/cms/djangoapps/models/settings/course_metadata.py
@@ -305,25 +305,27 @@ class CourseMetadata(object):
             errors.append({'message': message, 'model': proctoring_provider_model})
 
         # Require a valid escalation email if Proctortrack is chosen as the proctoring provider
-        escalation_email_model = settings_dict.get('proctoring_escalation_email')
-        if escalation_email_model:
-            escalation_email = escalation_email_model.get('value')
-        else:
-            escalation_email = descriptor.proctoring_escalation_email
+        # This requirement will be disabled until release of the new exam settings view
+        if settings.FEATURES.get('ENABLE_EXAM_SETTINGS_HTML_VIEW'):
+            escalation_email_model = settings_dict.get('proctoring_escalation_email')
+            if escalation_email_model:
+                escalation_email = escalation_email_model.get('value')
+            else:
+                escalation_email = descriptor.proctoring_escalation_email
 
-        missing_escalation_email_msg = 'Provider \'{provider}\' requires an exam escalation contact.'
-        if proctoring_provider_model and proctoring_provider_model.get('value') == 'proctortrack':
-            if not escalation_email:
-                message = missing_escalation_email_msg.format(provider=proctoring_provider_model.get('value'))
-                errors.append({'message': message, 'model': proctoring_provider_model})
+            missing_escalation_email_msg = 'Provider \'{provider}\' requires an exam escalation contact.'
+            if proctoring_provider_model and proctoring_provider_model.get('value') == 'proctortrack':
+                if not escalation_email:
+                    message = missing_escalation_email_msg.format(provider=proctoring_provider_model.get('value'))
+                    errors.append({'message': message, 'model': proctoring_provider_model})
 
-        if (
-            escalation_email_model and not proctoring_provider_model and
-            descriptor.proctoring_provider == 'proctortrack'
-        ):
-            if not escalation_email:
-                message = missing_escalation_email_msg.format(provider=descriptor.proctoring_provider)
-                errors.append({'message': message, 'model': escalation_email_model})
+            if (
+                escalation_email_model and not proctoring_provider_model and
+                descriptor.proctoring_provider == 'proctortrack'
+            ):
+                if not escalation_email:
+                    message = missing_escalation_email_msg.format(provider=descriptor.proctoring_provider)
+                    errors.append({'message': message, 'model': escalation_email_model})
 
         return errors
 


### PR DESCRIPTION
@edx/masters-devs-cosmonauts 

## [MST-329](https://openedx.atlassian.net/browse/MST-329)

Temporarily disables the requirement for an escalation email when Proctortrack is selected as a provider.  This feature is now tied to the django setting for rollout.