### PR TITLE
Bump edx-completion to version 3.2.4

### DIFF
--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -94,7 +94,7 @@ edx-api-doc-tools==1.3.1  # via -r requirements/edx/base.in
 edx-bulk-grades==0.7.0    # via -r requirements/edx/base.in, staff-graded-xblock
 edx-ccx-keys==1.1.0       # via -r requirements/edx/base.in
 edx-celeryutils==0.5.1    # via -r requirements/edx/base.in, super-csv
-edx-completion==3.2.3     # via -r requirements/edx/base.in
+edx-completion==3.2.4     # via -r requirements/edx/base.in
 edx-django-release-util==0.4.4  # via -r requirements/edx/base.in
 edx-django-sites-extensions==2.5.1  # via -r requirements/edx/base.in
 edx-django-utils==3.3.0   # via -r requirements/edx/base.in, django-config-models, edx-drf-extensions, edx-enterprise, edx-rest-api-client, edx-when

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -106,7 +106,7 @@ edx-api-doc-tools==1.3.1  # via -r requirements/edx/testing.txt
 edx-bulk-grades==0.7.0    # via -r requirements/edx/testing.txt, staff-graded-xblock
 edx-ccx-keys==1.1.0       # via -r requirements/edx/testing.txt
 edx-celeryutils==0.5.1    # via -r requirements/edx/testing.txt, super-csv
-edx-completion==3.2.3     # via -r requirements/edx/testing.txt
+edx-completion==3.2.4     # via -r requirements/edx/testing.txt
 edx-django-release-util==0.4.4  # via -r requirements/edx/testing.txt
 edx-django-sites-extensions==2.5.1  # via -r requirements/edx/testing.txt
 edx-django-utils==3.3.0   # via -r requirements/edx/testing.txt, django-config-models, edx-drf-extensions, edx-enterprise, edx-rest-api-client, edx-when

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -103,7 +103,7 @@ edx-api-doc-tools==1.3.1  # via -r requirements/edx/base.txt
 edx-bulk-grades==0.7.0    # via -r requirements/edx/base.txt, staff-graded-xblock
 edx-ccx-keys==1.1.0       # via -r requirements/edx/base.txt
 edx-celeryutils==0.5.1    # via -r requirements/edx/base.txt, super-csv
-edx-completion==3.2.3     # via -r requirements/edx/base.txt
+edx-completion==3.2.4     # via -r requirements/edx/base.txt
 edx-django-release-util==0.4.4  # via -r requirements/edx/base.txt
 edx-django-sites-extensions==2.5.1  # via -r requirements/edx/base.txt
 edx-django-utils==3.3.0   # via -r requirements/edx/base.txt, django-config-models, edx-drf-extensions, edx-enterprise, edx-rest-api-client, edx-when


### PR DESCRIPTION
https://pypi.org/project/edx-completion/3.2.4/

CC: @davidjoy @ormsbee This should resolve the underlying issue for the completion errors we often see.
I'd like to release/monitor this first before merging the earlier PR [1], but I think it's still worth merging anyway,
to reduce our strict dependence on the external app.

- [1] https://github.com/edx/edx-platform/pull/24552