### PR TITLE
[REV-1205] Add ecommerce event tracking to course sock and track selection upsell links

### DIFF
--- a/lms/templates/course_modes/_upgrade_button.html
+++ b/lms/templates/course_modes/_upgrade_button.html
@@ -10,10 +10,10 @@ from openedx.core.djangolib.markup import HTML, Text
 <li class="action action-select">
     <input type="hidden" name="contribution" value="${price_before_discount or min_price}" />
     % if content_gating_enabled or course_duration_limit_enabled:
-        <button id="track_sel_upgrade" type="submit" name="verified_mode">
+        <button id="track_selection_upgrade" type="submit" name="verified_mode">
             <span>${_('Pursue the Verified Track')}</span>
     % else:
-        <button id="track_sel_upgrade" type="submit" name="verified_mode">
+        <button id="track_selection_upgrade" type="submit" name="verified_mode">
             <span>${_('Pursue a Verified Certificate')}</span>
     % endif
         % if price_before_discount:
@@ -25,7 +25,7 @@ from openedx.core.djangolib.markup import HTML, Text
 </li>
 
 <%static:require_module_async module_name="js/commerce/track_ecommerce_events" class_name="TrackECommerceEvents">
-var upgradeLink = $("#track_sel_upgrade");
+var upgradeLink = $("#track_selection_upgrade");
 
 TrackECommerceEvents.trackUpsellClick(upgradeLink, 'track_selection', {
     pageName: "track_selection",

--- a/lms/templates/course_modes/_upgrade_button.html
+++ b/lms/templates/course_modes/_upgrade_button.html
@@ -10,10 +10,10 @@ from openedx.core.djangolib.markup import HTML, Text
 <li class="action action-select">
     <input type="hidden" name="contribution" value="${price_before_discount or min_price}" />
     % if content_gating_enabled or course_duration_limit_enabled:
-        <button type="submit" name="verified_mode">
+        <button id="track_sel_upgrade" type="submit" name="verified_mode">
             <span>${_('Pursue the Verified Track')}</span>
     % else:
-        <button type="submit" name="verified_mode">
+        <button id="track_sel_upgrade" type="submit" name="verified_mode">
             <span>${_('Pursue a Verified Certificate')}</span>
     % endif
         % if price_before_discount:
@@ -23,3 +23,14 @@ from openedx.core.djangolib.markup import HTML, Text
         % endif
         </button>
 </li>
+
+<%static:require_module_async module_name="js/commerce/track_ecommerce_events" class_name="TrackECommerceEvents">
+var upgradeLink = $("#track_sel_upgrade");
+
+TrackECommerceEvents.trackUpsellClick(upgradeLink, 'track_selection', {
+    pageName: "track_selection",
+    linkType: "button",
+    linkCategory: "(none)"
+});
+
+</%static:require_module_async> 

--- a/lms/templates/courseware/courseware.html
+++ b/lms/templates/courseware/courseware.html
@@ -277,6 +277,7 @@ ${HTML(fragment.foot_html())}
   var fbeLink = $("#FBE_banner");
   var welcomeLink = $("#welcome");
   var accessDeniedUpsellLink = $("#accessDeniedUpsell");
+  var sockLink = $("#sock");
 
   TrackECommerceEvents.trackUpsellClick(fbeLink, 'in_course_audit_access_expires', {
       pageName: "in_course",
@@ -294,6 +295,12 @@ ${HTML(fragment.foot_html())}
     pageName: "in_course",
     linkType: "link",
     linkCategory: "(none)"
+  });
+
+  TrackECommerceEvents.trackUpsellClick(sockLink, 'in_course_sock', {
+      pageName: "in_course",
+      linkType: "button",
+      linkCategory: "green_upgrade"
   });
 
 </%static:require_module_async>

--- a/openedx/features/course_experience/templates/course_experience/course-home-fragment.html
+++ b/openedx/features/course_experience/templates/course_experience/course-home-fragment.html
@@ -195,6 +195,7 @@ from openedx.features.course_experience.course_tools import HttpMethod
   var personalizedLearnerSchedulesLink = $(".personalized_learner_schedules_button");
   var fbeLink = $("#FBE_banner");
   var welcomeLink = $("#welcome");
+  var sockLink = $("#sock");
 
     TrackECommerceEvents.trackUpsellClick(personalizedLearnerSchedulesLink, 'course_home_upgrade_shift_dates', {
       pageName: "course_home",
@@ -212,6 +213,12 @@ from openedx.features.course_experience.course_tools import HttpMethod
       pageName: "course_home",
       linkType: "link",
       linkCategory: "welcome"
+    });
+
+    TrackECommerceEvents.trackUpsellClick(sockLink, 'course_home_sock', {
+      pageName: "course_home",
+      linkType: "button",
+      linkCategory: "green_upgrade"
     });
 
 </%static:require_module_async>

--- a/openedx/features/course_experience/templates/course_experience/course-sock-fragment.html
+++ b/openedx/features/course_experience/templates/course_experience/course-sock-fragment.html
@@ -58,7 +58,7 @@ from openedx.features.course_experience import DISPLAY_COURSE_SOCK_FLAG
                     </div>
                 % endif
                 <img class="mini-cert" alt="Example Certificate Image" src="${static.url('course_experience/images/verified-cert.png')}"/>
-                <a href="${upgrade_url}">
+                <a id="sock" href="${upgrade_url}">
                     <div class="btn btn-upgrade stuck-top focusable action-upgrade-certificate" data-creative="original_sock" data-position="sock">
                         ${Text(_('Upgrade ({course_price})')).format(course_price=HTML(course_price))}
                     </div>

--- a/themes/edx.org/lms/templates/course_modes/_upgrade_button.html
+++ b/themes/edx.org/lms/templates/course_modes/_upgrade_button.html
@@ -30,7 +30,7 @@ var upgradeLink = $("#track_sel_upgrade");
 TrackECommerceEvents.trackUpsellClick(upgradeLink, 'track_selection', {
     pageName: "track_selection",
     linkType: "button",
-    linkCategory: "none"
+    linkCategory: "(none)"
 });
 
 </%static:require_module_async> 

--- a/themes/edx.org/lms/templates/course_modes/_upgrade_button.html
+++ b/themes/edx.org/lms/templates/course_modes/_upgrade_button.html
@@ -10,10 +10,10 @@ from openedx.core.djangolib.markup import HTML, Text
 <li class="action action-select">
     <input type="hidden" name="contribution" value="${price_before_discount or min_price}" />
     % if content_gating_enabled or course_duration_limit_enabled:
-        <button id="track_sel_upgrade" type="submit" name="verified_mode">
+        <button id="track_selection_upgrade" type="submit" name="verified_mode">
             <span>${_('Pursue the Verified Track')}</span>
     % else:
-        <button id="track_sel_upgrade" type="submit" name="verified_mode">
+        <button id="track_selection_upgrade" type="submit" name="verified_mode">
             <span>${_('Pursue a Verified Certificate')}</span>
     % endif
         % if price_before_discount:
@@ -25,7 +25,7 @@ from openedx.core.djangolib.markup import HTML, Text
 </li>
 
 <%static:require_module_async module_name="js/commerce/track_ecommerce_events" class_name="TrackECommerceEvents">
-var upgradeLink = $("#track_sel_upgrade");
+var upgradeLink = $("#track_selection_upgrade");
 
 TrackECommerceEvents.trackUpsellClick(upgradeLink, 'track_selection', {
     pageName: "track_selection",

--- a/themes/edx.org/lms/templates/course_modes/_upgrade_button.html
+++ b/themes/edx.org/lms/templates/course_modes/_upgrade_button.html
@@ -10,10 +10,10 @@ from openedx.core.djangolib.markup import HTML, Text
 <li class="action action-select">
     <input type="hidden" name="contribution" value="${price_before_discount or min_price}" />
     % if content_gating_enabled or course_duration_limit_enabled:
-        <button type="submit" name="verified_mode">
+        <button id="track_sel_upgrade" type="submit" name="verified_mode">
             <span>${_('Pursue the Verified Track')}</span>
     % else:
-        <button type="submit" name="verified_mode">
+        <button id="track_sel_upgrade" type="submit" name="verified_mode">
             <span>${_('Pursue a Verified Certificate')}</span>
     % endif
         % if price_before_discount:
@@ -23,3 +23,14 @@ from openedx.core.djangolib.markup import HTML, Text
         % endif
         </button>
 </li>
+
+<%static:require_module_async module_name="js/commerce/track_ecommerce_events" class_name="TrackECommerceEvents">
+var upgradeLink = $("#track_sel_upgrade");
+
+TrackECommerceEvents.trackUpsellClick(upgradeLink, 'track_selection', {
+    pageName: "track_selection",
+    linkType: "button",
+    linkCategory: "none"
+});
+
+</%static:require_module_async> 


### PR DESCRIPTION
PR #24338 has our proof-of-concept baseline for upsell event tracking, including javascript module. We'll have tracking for 18 links all together, so we'll break this up into several pull requests to minimize risk. This PR includes:
- track selection (2 files) 
- sock links on course home and in-course (3 files) 

Relevant Jira ticket:
https://openedx.atlassian.net/browse/REV-1205

Testing status for these links:
track_selection: tested event with console.log
course_home_sock: tested event with console.log
in_course_sock: tested event with console.log

Note: track selection duplicated links so you'll see that done twice: one for our site (themes/edx.org), one for open edX (lms/templates)

Here is some info on the link names, categories, and where/when they appear:
https://docs.google.com/document/d/13Fwl3x-XUDGwm73ftkiKgiruiK3wWnlHeQ3mVSl4q_8/edit?ts=5f0cc156