### PR TITLE
MST-331 Add cors header configs to CMS so it can be turned on

### DIFF
--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -43,6 +43,7 @@ When refering to XBlocks, we use the entry-point name. For example,
 import importlib.util
 import os
 import sys
+from corsheaders.defaults import default_headers as corsheaders_default_headers
 from datetime import timedelta
 import lms.envs.common
 # Although this module itself may not use these imported variables, other dependent modules may.
@@ -660,8 +661,15 @@ MIDDLEWARE = [
     'openedx.core.djangoapps.header_control.middleware.HeaderControlMiddleware',
     'django.middleware.cache.UpdateCacheMiddleware',
     'django.middleware.common.CommonMiddleware',
+
+    # CORS and CSRF
     'django.middleware.csrf.CsrfViewMiddleware',
+    'corsheaders.middleware.CorsMiddleware',
+    'openedx.core.djangoapps.cors_csrf.middleware.CorsCSRFMiddleware',
+    'openedx.core.djangoapps.cors_csrf.middleware.CsrfCrossDomainCookieMiddleware',
     'django.contrib.sites.middleware.CurrentSiteMiddleware',
+
+    # JWT auth
     'edx_rest_framework_extensions.auth.jwt.middleware.JwtAuthCookieMiddleware',
 
     # Allows us to define redirects via Django admin
@@ -2079,8 +2087,16 @@ FINANCIAL_REPORTS = {
     'ROOT_PATH': 'sandbox',
 }
 
+############# CORS headers for cross-domain requests #################
+if FEATURES.get('ENABLE_CORS_HEADERS'):
+    CORS_ALLOW_CREDENTIALS = True
+    CORS_ALLOW_HEADERS = corsheaders_default_headers + (
+        'use-jwt-cookie',
+    )
+
 CORS_ORIGIN_WHITELIST = []
 CORS_ORIGIN_ALLOW_ALL = False
+
 
 LOGIN_REDIRECT_WHITELIST = []
 

--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -661,13 +661,13 @@ MIDDLEWARE = [
     'openedx.core.djangoapps.header_control.middleware.HeaderControlMiddleware',
     'django.middleware.cache.UpdateCacheMiddleware',
     'django.middleware.common.CommonMiddleware',
+    'django.contrib.sites.middleware.CurrentSiteMiddleware',
 
     # CORS and CSRF
     'django.middleware.csrf.CsrfViewMiddleware',
     'corsheaders.middleware.CorsMiddleware',
     'openedx.core.djangoapps.cors_csrf.middleware.CorsCSRFMiddleware',
     'openedx.core.djangoapps.cors_csrf.middleware.CsrfCrossDomainCookieMiddleware',
-    'django.contrib.sites.middleware.CurrentSiteMiddleware',
 
     # JWT auth
     'edx_rest_framework_extensions.auth.jwt.middleware.JwtAuthCookieMiddleware',

--- a/cms/envs/devstack.py
+++ b/cms/envs/devstack.py
@@ -218,7 +218,6 @@ if os.path.isfile(join(dirname(abspath(__file__)), 'private.py')):
 ############# CORS headers for cross-domain requests #################
 FEATURES['ENABLE_CORS_HEADERS'] = True
 CORS_ALLOW_CREDENTIALS = True
-CORS_ORIGIN_WHITELIST = ()
 CORS_ORIGIN_ALLOW_ALL = True
 CORS_ALLOW_HEADERS = corsheaders_default_headers + (
     'use-jwt-cookie',

--- a/cms/envs/devstack.py
+++ b/cms/envs/devstack.py
@@ -5,6 +5,7 @@ Specific overrides to the base prod settings to make development easier.
 
 import logging
 from os.path import abspath, dirname, join
+from corsheaders.defaults import default_headers as corsheaders_default_headers
 
 from .production import *  # pylint: disable=wildcard-import, unused-wildcard-import
 
@@ -213,3 +214,12 @@ SECRET_KEY = '85920908f28904ed733fe576320db18cabd7b6cd'
 # See if the developer has any local overrides.
 if os.path.isfile(join(dirname(abspath(__file__)), 'private.py')):
     from .private import *  # pylint: disable=import-error,wildcard-import
+
+############# CORS headers for cross-domain requests #################
+FEATURES['ENABLE_CORS_HEADERS'] = True
+CORS_ALLOW_CREDENTIALS = True
+CORS_ORIGIN_WHITELIST = ()
+CORS_ORIGIN_ALLOW_ALL = True
+CORS_ALLOW_HEADERS = corsheaders_default_headers + (
+    'use-jwt-cookie',
+)

--- a/cms/envs/production.py
+++ b/cms/envs/production.py
@@ -12,6 +12,7 @@ import copy
 import os
 import yaml
 
+from corsheaders.defaults import default_headers as corsheaders_default_headers
 from django.core.exceptions import ImproperlyConfigured
 from django.urls import reverse_lazy
 from path import Path as path
@@ -543,3 +544,13 @@ plugin_settings.add_plugins(__name__, plugin_constants.ProjectType.CMS, plugin_c
 ########################## Derive Any Derived Settings  #######################
 
 derive_settings(__name__)
+
+############# CORS headers for cross-domain requests #################
+if FEATURES.get('ENABLE_CORS_HEADERS'):
+    CORS_ALLOW_CREDENTIALS = True
+    CORS_ORIGIN_WHITELIST = ENV_TOKENS.get('CORS_ORIGIN_WHITELIST', ())
+    CORS_ORIGIN_ALLOW_ALL = ENV_TOKENS.get('CORS_ORIGIN_ALLOW_ALL', False)
+    CORS_ALLOW_INSECURE = ENV_TOKENS.get('CORS_ALLOW_INSECURE', False)
+    CORS_ALLOW_HEADERS = corsheaders_default_headers + (
+        'use-jwt-cookie',
+    )


### PR DESCRIPTION
@edx/masters-devs-cosmonauts and @kdmccormick Please help review.
This is the PR to allow CMS to provide API to MFE like course-authoring. Without this change, the course authoring MFE would encounter CORS denial.
Once this is merged, we can turn on CORS with whitelist on remote configs for stage and prod.