### PR TITLE
Make Blocks API and Dates mobile views non-atomic.

### DIFF
--- a/lms/djangoapps/course_api/blocks/views.py
+++ b/lms/djangoapps/course_api/blocks/views.py
@@ -5,7 +5,9 @@ CourseBlocks API views
 
 import six
 from django.core.exceptions import ValidationError
+from django.db import transaction
 from django.http import Http404
+from django.utils.decorators import method_decorator
 from opaque_keys import InvalidKeyError
 from opaque_keys.edx.keys import CourseKey
 from rest_framework.generics import ListAPIView
@@ -21,6 +23,7 @@ from .forms import BlockListGetForm
 
 
 @view_auth_classes()
+@method_decorator(transaction.non_atomic_requests, name='dispatch')
 class BlocksView(DeveloperErrorViewMixin, ListAPIView):
     """
     **Use Case**

--- a/openedx/features/course_experience/views/course_dates.py
+++ b/openedx/features/course_experience/views/course_dates.py
@@ -3,9 +3,11 @@ Fragment for rendering the course dates sidebar.
 """
 
 
+from django.db import transaction
 from django.http import Http404
 from django.template.loader import render_to_string
 from django.urls import reverse
+from django.utils.decorators import method_decorator
 from django.utils.translation import get_language_bidi
 from opaque_keys.edx.keys import CourseKey
 from web_fragments.fragment import Fragment
@@ -47,6 +49,7 @@ class CourseDatesFragmentView(EdxFragmentView):
         return dates_fragment
 
 
+@method_decorator(transaction.non_atomic_requests, name='dispatch')
 class CourseDatesFragmentMobileView(CourseDatesFragmentView):
     """
     A course dates fragment to show dates on mobile apps.


### PR DESCRIPTION
These are expensive, read-only web requests. Unfortunately, middleware adds writes, and we currently run with view-level
transactions enabled by default. Holding those long transactions open has caused extra load on the database and been our largest sources of django.db.utils:OperationError exceptions.

This has been particularly noticeable as we start deploying the new Courseware MFE, which uses the BlocksInCourseView more frequently.