### PR TITLE
[REV-1257] Add upsell tracking for program dashboard's courses

### DIFF
--- a/lms/static/js/commerce/track_ecommerce_events.js
+++ b/lms/static/js/commerce/track_ecommerce_events.js
@@ -10,7 +10,7 @@
             var eventAttrs = {linkName: linkName};
             var allowedAttrs = ['linkType', 'pageName', 'linkCategory'];
 
-            if (!window.analytics) {
+            if (!window.analytics || !window.analytics.trackLink) {
                 return;
             }
 

--- a/lms/static/js/commerce/track_ecommerce_events.js
+++ b/lms/static/js/commerce/track_ecommerce_events.js
@@ -31,4 +31,6 @@
 
         return TrackECommerceEvents;
     });
-}).call(this, define || RequireJS.define);
+}).call(this,
+    typeof define === 'function' && define.amd ? define : RequireJS.define
+);

--- a/lms/static/js/learner_dashboard/views/upgrade_message_view.js
+++ b/lms/static/js/learner_dashboard/views/upgrade_message_view.js
@@ -10,11 +10,12 @@ class UpgradeMessageView extends Backbone.View {
     this.messageTpl = HtmlUtils.template(upgradeMessageTpl);
     this.$el = options.$el;
     this.render();
-    var courseUpsellButtons = this.$el.find(".program_dashboard_course_upsell_button");
-    trackECommerceEvents.trackUpsellClick(courseUpsellButtons, "program_dashboard_course", {
-      linkType : "button",
-      pageName : "program_dashboard",
-      linkCategory : "green_upgrade"
+
+    const courseUpsellButtons = this.$el.find('.program_dashboard_course_upsell_button');
+    trackECommerceEvents.trackUpsellClick(courseUpsellButtons, 'program_dashboard_course', {
+      linkType: 'button',
+      pageName: 'program_dashboard',
+      linkCategory: 'green_upgrade',
     });
   }
 

--- a/lms/static/js/learner_dashboard/views/upgrade_message_view.js
+++ b/lms/static/js/learner_dashboard/views/upgrade_message_view.js
@@ -3,12 +3,19 @@ import Backbone from 'backbone';
 import HtmlUtils from 'edx-ui-toolkit/js/utils/html-utils';
 
 import upgradeMessageTpl from '../../../templates/learner_dashboard/upgrade_message.underscore';
+import trackECommerceEvents from '../../commerce/track_ecommerce_events';
 
 class UpgradeMessageView extends Backbone.View {
   initialize(options) {
     this.messageTpl = HtmlUtils.template(upgradeMessageTpl);
     this.$el = options.$el;
     this.render();
+    var courseUpsellButtons = this.$el.find(".program_dashboard_course_upsell_button");
+    trackECommerceEvents.trackUpsellClick(courseUpsellButtons, "program_dashboard_course", {
+      linkType : "button",
+      pageName : "program_dashboard",
+      linkCategory : "green_upgrade"
+    });
   }
 
   render() {

--- a/lms/templates/learner_dashboard/upgrade_message.underscore
+++ b/lms/templates/learner_dashboard/upgrade_message.underscore
@@ -5,7 +5,7 @@
 </div>
 <% if (typeof is_mobile_only === 'undefined' || is_mobile_only === false) { %>
 <div class="action col-12 md-col-4">
-    <a href="<%- upgrade_url %>" class="btn-brand btn cta-primary upgrade-button single-course-run program_dashboard_course_upsell_button"">
+    <a href="<%- upgrade_url %>" class="btn-brand btn cta-primary upgrade-button single-course-run program_dashboard_course_upsell_button">
         <%- gettext('Upgrade to Verified') %>
     <a>
 </div>

--- a/lms/templates/learner_dashboard/upgrade_message.underscore
+++ b/lms/templates/learner_dashboard/upgrade_message.underscore
@@ -5,7 +5,7 @@
 </div>
 <% if (typeof is_mobile_only === 'undefined' || is_mobile_only === false) { %>
 <div class="action col-12 md-col-4">
-    <a href="<%- upgrade_url %>" class="btn-brand btn cta-primary upgrade-button single-course-run">
+    <a href="<%- upgrade_url %>" class="btn-brand btn cta-primary upgrade-button single-course-run program_dashboard_course_upsell_button"">
         <%- gettext('Upgrade to Verified') %>
     <a>
 </div>


### PR DESCRIPTION
### What did we do?
Updated the track_ecommerce_events.js to allow imports into webpacked code
Added upsell tracking to the course upgrade buttons on the program dashboard

Relevant Jira Ticket: https://openedx.atlassian.net/browse/REV-1257

### Why are we doing this?
So we have a better understanding of when users are clicking our upsell links.

<img width="856" alt="Screen Shot 2020-07-22 at 4 56 58 PM" src="https://user-images.githubusercontent.com/34042537/88228011-80d88900-cc3c-11ea-99a2-80ca28f46b7b.png">

### Testing
This was tested locally with one course upsell link on the page.

### TODO
test this with two course upsell links on the page