### PR TITLE
Handle zendesk_proxy AttributeError

### DIFF
--- a/openedx/core/djangoapps/zendesk_proxy/v1/views.py
+++ b/openedx/core/djangoapps/zendesk_proxy/v1/views.py
@@ -64,6 +64,9 @@ class ZendeskPassthroughView(APIView):
                 custom_fields=request.data['custom_fields'],
                 tags=request.data['tags']
             )
+        except AttributeError as attribute:
+            logger.error('Zendesk Proxy Bad Request AttributeError: %s', attribute)
+            return Response(status=status.HTTP_400_BAD_REQUEST)
         except KeyError as key:
             logger.error('Zendesk Proxy Bad Request KeyError: %s', key)
             return Response(status=status.HTTP_400_BAD_REQUEST)


### PR DESCRIPTION
I didn't dig further to see if there's an available recovery path;
would we ever want to submit the Zendesk ticket if they're an anonymous user (and have no valid/confirmed email on file)?