### PR TITLE
[BD-03] [TNL-7339] BB-2717 port xblock handler view to drf

### DIFF
--- a/cms/djangoapps/contentstore/views/item.py
+++ b/cms/djangoapps/contentstore/views/item.py
@@ -1,7 +1,5 @@
 """Views for items (modules)."""
 
-
-import hashlib
 import logging
 from collections import OrderedDict
 from datetime import datetime

--- a/cms/djangoapps/contentstore/views/item.py
+++ b/cms/djangoapps/contentstore/views/item.py
@@ -19,13 +19,11 @@ from edx_proctoring.api import (
     get_exam_configuration_dashboard_url
 )
 from edx_proctoring.exceptions import ProctoredExamNotFoundException
-from edx_rest_framework_extensions.auth.jwt.authentication import JwtAuthentication
 from help_tokens.core import HelpUrlExpert
 from opaque_keys.edx.keys import CourseKey
 from opaque_keys.edx.locator import LibraryUsageLocator
 from pytz import UTC
-from rest_framework.authentication import SessionAuthentication
-from rest_framework.decorators import api_view, authentication_classes, parser_classes
+from rest_framework.decorators import api_view, parser_classes
 from rest_framework.parsers import JSONParser
 
 from six import binary_type, text_type
@@ -61,7 +59,7 @@ from edxmako.shortcuts import render_to_string
 from models.settings.course_grading import CourseGradingModel
 from openedx.core.djangoapps.schedules.config import COURSE_UPDATE_WAFFLE_FLAG
 from openedx.core.djangoapps.waffle_utils import WaffleSwitch
-from openedx.core.lib.api.authentication import BearerAuthentication
+from openedx.core.lib.api.view_utils import view_auth_classes
 from openedx.core.lib.gating import api as gating_api
 from openedx.core.lib.xblock_utils import hash_resource, request_token, wrap_xblock, wrap_xblock_aside
 from static_replace import replace_static_urls
@@ -122,8 +120,8 @@ def _is_library_component_limit_reached(usage_key):
 
 
 @api_view(["DELETE", "GET", "PUT", "POST", "PATCH"])
-@authentication_classes([JwtAuthentication, BearerAuthentication, SessionAuthentication])
 @parser_classes([JSONParser])
+@view_auth_classes()
 def xblock_handler(request, usage_key_string):
     """
     The restful handler for xblock requests.

--- a/cms/djangoapps/contentstore/views/item.py
+++ b/cms/djangoapps/contentstore/views/item.py
@@ -30,6 +30,7 @@ from xblock.fields import Scope
 
 from cms.djangoapps.contentstore.config.waffle import SHOW_REVIEW_RULES_FLAG
 from cms.lib.xblock.authoring_mixin import VISIBILITY_VIEW
+from common.djangoapps.util.json_request import JsonResponse, expect_json
 from contentstore.utils import (
     ancestor_has_staff_lock,
     find_release_date_source,
@@ -60,7 +61,6 @@ from openedx.core.lib.xblock_utils import hash_resource, request_token, wrap_xbl
 from static_replace import replace_static_urls
 from student.auth import has_studio_read_access, has_studio_write_access
 from util.date_utils import get_default_time_display
-from util.json_request import JsonResponse, expect_json
 from util.milestones_helpers import is_entrance_exams_enabled
 from xblock_config.models import CourseEditLTIFieldsEnabledFlag
 from xblock_django.user_service import DjangoXBlockUserService


### PR DESCRIPTION
This PR makes changes to the `xblock_handler` view authentication methods, in order to use the token-based authentication schemes provided by django-rest-framework. This view needs to support token-based authentication to integrate with an upcoming micro-frontend.

**JIRA tickets**: https://tasks.opencraft.com/browse/BB-2717

**Merge deadline**: "None" 

**Testing instructions**:
The following assumes a provisioned devstack with the code from this PR.

1. Go to http://localhost:18000/_o/applications/ to create an OAuth application
1. Select "Client Type: confidential" and "Authorization grant type: resource owner password based" to create the application. Take note of `client_id` and `client_secret`
1. On the shell:

```
export CLIENT_ID="<client_id>"
export CLIENT_SECRET="<client_secret>"
curl -X POST -d "grant_type=password&username=edx&password=edx" -u"$CLIENT_ID:$CLIENT_SECRET" http://localhost:18000/_o/token/
```

This should return you the authentication info json with "access_token". Store the token on $ACCESS_TOKEN.

``` 
curl 'http://localhost:18010/xblock/block-v1:edX+DemoX+Demo_Course+type@openassessment+block@d94af2e426024dc59403cf7b32be1ff6/studio_view?_=1596813377695' -H 'Accept: application/json' -H 'Authorization: Bearer $ACCESS_TOKEN'
```

You should receive a response with a JSON representation of the file. An invalid value from `$ACCESS_TOKEN` should return a `401 Unauthorized response`

**Author notes and concerns**:

1. The only changes relate to the decorators used to call the `xblock_handler` view to get proper authentication method. This PR does not focus on adding more functionality from django-rest-framework (such as serializers for data parsing and validation). 

**Reviewers**
- [x] @viadanna 

