### PR TITLE
MICROBA-487 Add button class to CTA to remove text-decoration on hover

### DIFF
--- a/themes/edx.org/lms/templates/dashboard.html
+++ b/themes/edx.org/lms/templates/dashboard.html
@@ -151,7 +151,7 @@ from student.models import CourseEnrollment
     account_mfe_url = getattr(settings, 'ACCOUNT_MICROFRONTEND_URL', '') or ''
   %>
   % if display_demographics_banner:
-    <a href="${account_mfe_url}#demographics-information">
+    <a class="btn" href="${account_mfe_url}#demographics-information">
       <div
         class="demographics-banner d-flex justify-content-left align-items-center flex-column flex-lg-row py-1 px-4 mb-2 mb-lg-4">
         <img class="demographics-banner-icon d-none d-lg-inline-block" src="${static.url('edx.org/images/quote_prompt.png')}" alt="" aria-hidden="true">


### PR DESCRIPTION
The call to action in the dashboard (prompting users to fill out demographics information on the account page) was underlining text on hover. This fixes that.

<img width="2282" alt="Screen Shot 2020-07-23 at 1 54 09 PM" src="https://user-images.githubusercontent.com/26205183/88321317-f4d26a00-ccec-11ea-95e7-503cbde599c4.png">

[MICROBA-487](https://openedx.atlassian.net/browse/MICROBA-487)