### PR TITLE
[REV-1257] Add upsell tracking for upgrading all programs button on program dashboard

### DIFF
--- a/lms/static/js/learner_dashboard/views/program_details_view.js
+++ b/lms/static/js/learner_dashboard/views/program_details_view.js
@@ -11,6 +11,7 @@ import HeaderView from './program_header_view';
 import SidebarView from './program_details_sidebar_view';
 
 import pageTpl from '../../../templates/learner_dashboard/program_details_view.underscore';
+import trackECommerceEvents from '../../commerce/track_ecommerce_events';
 
 class ProgramDetailsView extends Backbone.View {
   constructor(options) {
@@ -43,6 +44,13 @@ class ProgramDetailsView extends Backbone.View {
     );
 
     this.render();
+
+    const $courseUpsellButton = $('#program_dashboard_course_upsell_all_button');
+    trackECommerceEvents.trackUpsellClick($courseUpsellButton, 'program_dashboard_program', {
+      linkType: 'button',
+      pageName: 'program_dashboard',
+      linkCategory: 'green_upgrade',
+    });
   }
 
   static getUrl(base, programData) {

--- a/lms/templates/learner_dashboard/program_details_view.underscore
+++ b/lms/templates/learner_dashboard/program_details_view.underscore
@@ -22,7 +22,7 @@
                 </div>
             <% } %>
             <% if (is_learner_eligible_for_one_click_purchase && (typeof is_mobile_only === 'undefined' || is_mobile_only === false)) { %>
-            <a href="<%- completeProgramURL %>" class="btn-brand btn cta-primary upgrade-button complete-program">
+            <a href="<%- completeProgramURL %>" class="btn-brand btn cta-primary upgrade-button complete-program" id="program_dashboard_course_upsell_all_button">
                 <%- gettext('Upgrade All Remaining Courses (')%>
                 <% if (discount_data.is_discounted) { %>
                     <span class='list-price'>


### PR DESCRIPTION
### What did we do?
Added upsell tracking to the course upgrade all button on the program dashboard

Relevant Jira Ticket: https://openedx.atlassian.net/browse/REV-1257

### Why are we doing this?
So we have a better understanding of when users are clicking our upsell links.

<img width="1128" alt="Screen Shot 2020-07-23 at 5 07 18 PM" src="https://user-images.githubusercontent.com/34042537/88341958-83a2af00-cd0c-11ea-860b-2eb07f69855d.png">

### Testing
This was tested locally with the one upsell all link on the page.
