### PR TITLE
[BD-10] [DEPR-92] Remove pattern library of pavelib folder

### DIFF
--- a/pavelib/assets.py
+++ b/pavelib/assets.py
@@ -43,7 +43,6 @@ COMMON_LOOKUP_PATHS = [
     path("common/static/sass"),
     path('node_modules/@edx'),
     path('node_modules'),
-    path('node_modules/edx-pattern-library/node_modules'),
 ]
 
 # A list of NPM installed libraries that should be copied into the common

--- a/pavelib/paver_tests/test_assets.py
+++ b/pavelib/paver_tests/test_assets.py
@@ -208,7 +208,6 @@ class TestPaverWatchAssetTasks(TestCase):
             path('common/static'),
             path('node_modules/@edx'),
             path('node_modules'),
-            path('node_modules/edx-pattern-library/node_modules'),
             path('lms/static/sass/partials'),
             path('lms/static/sass'),
             path('lms/static/certificates/sass'),


### PR DESCRIPTION
@abutterworth
Ticket on jira:https://openedx.atlassian.net/browse/DEPR-92
Remove the use of pattern library from pavelib folder.