### PR TITLE
Fix issue with `SameSite=None` cookies from being blocked when `django_cookies_samesite.middleware.CookiesSameSite` is enabled for `devstack_docker` environment.

### DIFF
--- a/lms/envs/devstack.py
+++ b/lms/envs/devstack.py
@@ -396,6 +396,12 @@ if FEATURES.get('ENABLE_ENTERPRISE_INTEGRATION'):
 ENTERPRISE_CUSTOMERS_EXCLUDED_FROM_CATALOG = ()
 
 #####################################################################
+
+# django-session-cookie middleware
+DCS_SESSION_COOKIE_SAMESITE = 'Lax'
+DCS_SESSION_COOKIE_SAMESITE_FORCE_ALL = True
+
+#####################################################################
 # See if the developer has any local overrides.
 if os.path.isfile(join(dirname(abspath(__file__)), 'private.py')):
     from .private import *  # pylint: disable=import-error,wildcard-import


### PR DESCRIPTION
This is a fix for `devstack_docker` default value set to `Lax` for `DCS_SESSION_COOKIE_SAMESITE`. It was defaulting to `SameSite=None` which requires a secure site which `localhost` site does not by default.

Setting this `SameSite` cookie attribute to something other than `None` will continue to allow login to the LMS for `devstack_docker` environment.

Regards to #23671 and https://discuss.openedx.org/t/lti-xblock-and-samesite/759/16