### PR TITLE
MST-334 Make sure the CSRF hooks are in INSTALLED_APPS on Studio

### DIFF
--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -1328,6 +1328,10 @@ INSTALLED_APPS = [
     # API access administration
     'openedx.core.djangoapps.api_admin',
 
+    # CORS and cross-domain CSRF
+    'corsheaders',
+    'openedx.core.djangoapps.cors_csrf',
+
     # History tables
     'simple_history',
 
@@ -1485,6 +1489,9 @@ INSTALLED_APPS = [
     # DRF filters
     'django_filters',
     'cms.djangoapps.api',
+
+    # edx-drf-extensions
+    'csrf.apps.CsrfAppConfig',  # Enables frontend apps to retrieve CSRF tokens.
 
     # Entitlements, used in openedx tests
     'entitlements',


### PR DESCRIPTION
@edx/masters-devs-cosmonauts Please review
This is a follow up to the CORS config PR at https://github.com/edx/edx-platform/pull/24571, so CSRF tokens can be recognized on studio API call from another domain.