### PR TITLE
[REV-1205] Add doc location comment so future devs can easily find it 

### DIFF
--- a/lms/static/js/commerce/track_ecommerce_events.js
+++ b/lms/static/js/commerce/track_ecommerce_events.js
@@ -1,7 +1,7 @@
 /**
  *
  * A library of helper functions to track ecommerce related events.
- * See here for the full list of upsell links and how to view these events in snowflake: 
+ * See here for the full list of upsell links and how to view these events in snowflake:
  * https://openedx.atlassian.net/wiki/spaces/RS/pages/1675100377/How+to+find+upsell+link+click+events
  */
 (function(define) {

--- a/lms/static/js/commerce/track_ecommerce_events.js
+++ b/lms/static/js/commerce/track_ecommerce_events.js
@@ -1,7 +1,8 @@
 /**
  *
  * A library of helper functions to track ecommerce related events.
- *
+ * See here for the full list of upsell links and how to view these events in snowflake: 
+ * https://openedx.atlassian.net/wiki/spaces/RS/pages/1675100377/How+to+find+upsell+link+click+events
  */
 (function(define) {
     'use strict';


### PR DESCRIPTION
For REV-1205, we added segment events for all of the various upsell links, and documented where these appear and how to see the events in snowflake.  Suggested during feedback, I'm updating the function comment to include a link to this doc, so future devs can see everything in one shot rather than hunting across the various PRs from this ticket. 

