### PR TITLE
[REV-1205] update doc location comment to be more general

### DIFF
--- a/lms/static/js/commerce/track_ecommerce_events.js
+++ b/lms/static/js/commerce/track_ecommerce_events.js
@@ -1,7 +1,7 @@
 /**
  *
  * A library of helper functions to track ecommerce related events.
- * See here for the full list of upsell links and how to view these events in snowflake:
+ * See here for the full list of upsell links and how to view these events:
  * https://openedx.atlassian.net/wiki/spaces/RS/pages/1675100377/How+to+find+upsell+link+click+events
  */
 (function(define) {


### PR DESCRIPTION
For REV-1205, we added segment events for all of the various upsell links, and documented where these appear and how to see the events in snowflake. Suggested during feedback, I updated the function comment to include a link to this doc, so future devs can see everything in one shot rather than hunting across the various PRs from this ticket. Just removing "in snowflake" in case this changes down the road (would be reflected in the linked page)