### PR TITLE
EDUCATOR-5167: Allow +/- 1 query in assertions

### DIFF
--- a/lms/djangoapps/discussion/tests/test_views.py
+++ b/lms/djangoapps/discussion/tests/test_views.py
@@ -447,22 +447,23 @@ class SingleThreadTestCase(ForumsEnableMixin, ModuleStoreTestCase):
             )
 
 
-class AllowOneLessInt(int):
+class AllowPlusOrMinusOneInt(int):
     """
     A workaround for the fact that assertNumQueries doesn't let you
     specify a range or any tolerance. An 'int' that is 'equal to' its value,
-    but also its value -  1
+    but also its value +/- 1
     """
 
     def __init__(self, value):
         super().__init__()
-        self.values = (value, value - 1)
+        self.value = value
+        self.values = (value, value - 1, value + 1)
 
     def __eq__(self, other):
         return other in self.values
 
     def __repr__(self):
-        return "{} or {}".format(*self.values)
+        return "({} +/- 1)".format(self.value)
 
 
 @ddt.ddt
@@ -543,9 +544,10 @@ class SingleThreadQueryCountTestCase(ForumsEnableMixin, ModuleStoreTestCase):
         # Test uncached first, then cached now that the cache is warm.
         cached_calls = [
             [num_uncached_mongo_calls, num_uncached_sql_queries],
-            # Sometimes there will be one fewer sql call than expected, because sometimes the call to
-            # CourseMode.modes_for_course gets cached and doesn't hit the DB. EDUCATOR-5167
-            [num_cached_mongo_calls, AllowOneLessInt(num_cached_sql_queries)],
+            # Sometimes there will be one more or fewer sql call than expected, because the call to
+            # CourseMode.modes_for_course sometimes does / doesn't get cached and does / doesn't hit the DB.
+            # EDUCATOR-5167
+            [num_cached_mongo_calls, AllowPlusOrMinusOneInt(num_cached_sql_queries)],
         ]
         for expected_mongo_calls, expected_sql_queries in cached_calls:
             with self.assertNumQueries(expected_sql_queries, table_blacklist=QUERY_COUNT_TABLE_BLACKLIST):


### PR DESCRIPTION
Sometimes tests fail for the opposite reason of my original PR, because the cache almost always hits, but very rarely it misses. Allow one query of leeway in either direction.