### PR TITLE
add error message if advanced configuration json is invalid

### DIFF
--- a/cms/static/js/views/settings/advanced.js
+++ b/cms/static/js/views/settings/advanced.js
@@ -79,7 +79,7 @@ define(['js/views/validation',
                 });
                 cm.on('blur', function(mirror) {
                     var $wrapperElement, key, stringValue;
-                    $wrapperElement = $(mirror.getWrapperElement())
+                    $wrapperElement = $(mirror.getWrapperElement());
                     key = $wrapperElement.closest('.field-group').children('.key').attr('id');
                     stringValue = $.trim(mirror.getValue());
                     $(textarea).parent().children('label').removeClass('is-focused');

--- a/cms/static/js/views/settings/advanced.js
+++ b/cms/static/js/views/settings/advanced.js
@@ -73,10 +73,14 @@ define(['js/views/validation',
                 });
                 cm.on('focus', function(mirror) {
                     $(textarea).parent().children('label').addClass('is-focused');
+                    var wrapperElement = $(mirror.getWrapperElement())
+                    wrapperElement.removeClass('json-error');
+                    wrapperElement.siblings('.advanced-setting-json-error').hide();
                 });
                 cm.on('blur', function(mirror) {
                     $(textarea).parent().children('label').removeClass('is-focused');
-                    var key = $(mirror.getWrapperElement()).closest('.field-group').children('.key').attr('id');
+                    var wrapperElement = $(mirror.getWrapperElement())
+                    var key = wrapperElement.closest('.field-group').children('.key').attr('id');
                     var stringValue = $.trim(mirror.getValue());
                 // update CodeMirror to show the trimmed value.
                     mirror.setValue(stringValue);
@@ -104,6 +108,9 @@ define(['js/views/validation',
                         var modelVal = self.model.get(key);
                         modelVal.value = JSONValue;
                         self.model.set(key, modelVal);
+                    } else {
+                        wrapperElement.addClass('json-error');
+                        wrapperElement.siblings('.advanced-setting-json-error').show();
                     }
                 });
             },

--- a/cms/static/js/views/settings/advanced.js
+++ b/cms/static/js/views/settings/advanced.js
@@ -72,16 +72,17 @@ define(['js/views/validation',
                     }
                 });
                 cm.on('focus', function(mirror) {
+                    var $wrapperElement = $(mirror.getWrapperElement());
+                    $wrapperElement.removeClass('json-error');
+                    $wrapperElement.siblings('.advanced-setting-json-error').hide();
                     $(textarea).parent().children('label').addClass('is-focused');
-                    var wrapperElement = $(mirror.getWrapperElement())
-                    wrapperElement.removeClass('json-error');
-                    wrapperElement.siblings('.advanced-setting-json-error').hide();
                 });
                 cm.on('blur', function(mirror) {
+                    var $wrapperElement, key, stringValue;
+                    $wrapperElement = $(mirror.getWrapperElement())
+                    key = $wrapperElement.closest('.field-group').children('.key').attr('id');
+                    stringValue = $.trim(mirror.getValue());
                     $(textarea).parent().children('label').removeClass('is-focused');
-                    var wrapperElement = $(mirror.getWrapperElement())
-                    var key = wrapperElement.closest('.field-group').children('.key').attr('id');
-                    var stringValue = $.trim(mirror.getValue());
                 // update CodeMirror to show the trimmed value.
                     mirror.setValue(stringValue);
                     var JSONValue = undefined;
@@ -109,8 +110,8 @@ define(['js/views/validation',
                         modelVal.value = JSONValue;
                         self.model.set(key, modelVal);
                     } else {
-                        wrapperElement.addClass('json-error');
-                        wrapperElement.siblings('.advanced-setting-json-error').show();
+                        $wrapperElement.addClass('json-error');
+                        $wrapperElement.siblings('.advanced-setting-json-error').show();
                     }
                 });
             },

--- a/cms/static/sass/views/_settings.scss
+++ b/cms/static/sass/views/_settings.scss
@@ -1118,7 +1118,14 @@
             color: $pink;
           }
         }
-      }
+
+        .advanced-setting-json-error {
+            background: tint($error-red, 90%);
+            border: 1px solid $error-red;
+            margin: 5px 0;
+            padding: 5px 8px;
+        }
+    }
 
       .message-error {
         position: absolute;
@@ -1148,6 +1155,10 @@
           @include linear-gradient($paleYellow, tint($paleYellow, 90%));
 
           outline: 0;
+        }
+
+        &.json-error {
+            background: tint($error-red, 80%);
         }
 
         .CodeMirror-sizer {

--- a/cms/templates/js/advanced_entry.underscore
+++ b/cms/templates/js/advanced_entry.underscore
@@ -7,6 +7,7 @@
       <div class="field text value">
         <label class="sr" for="<%- valueUniqueId %>"><%- display_name %></label>
         <textarea class="json text" id="<%- valueUniqueId %>"><%- value %></textarea>
+        <div role="alert" class="advanced-setting-json-error" aria-invalid="true" hidden><%- gettext("Invalid JSON") %></div>
         <span class="tip tip-stacked"><%- help %></span>
       </div>
       <% if (deprecated) { %>


### PR DESCRIPTION
On the Advanced Settings page in studio, we validate json when the text box loses focus. If the json is invalid, we do nothing. 

We just ignore it, don't update it in the data model, and don't inform the user in any way. When they click the 'save changes' button, we send the existing value for thier invalid field, and nothing changes. When the page reloads, they see the original value again.  

This is a small change that colors the text input and pops up a box that tells the user that the JSON they've entered is invalid. We can't really help them with what's wrong, but telling them that what they typed isn't going to actually be updated seems like a small improvement.

![Screen Shot 2020-07-30 at 3 36 16 PM](https://user-images.githubusercontent.com/1639231/88966529-73458380-d27a-11ea-89b7-3c54dfee4090.png)
