### PR TITLE
mroytman/mst 345 proctoring escalation email empty

### DIFF
--- a/cms/djangoapps/contentstore/docs/decisions/0001-validation-at-course-save.rst
+++ b/cms/djangoapps/contentstore/docs/decisions/0001-validation-at-course-save.rst
@@ -1,0 +1,65 @@
+========================================
+OEP-0001: Data Validation at Course Save
+========================================
+
+.. list-table::
+   :widths: 25 75
+
+   * - OEP
+     - :doc:`OEP-XXXX </oeps/oep-XXXX-YYYY-ZZZZ>`
+
+       * <XXXX is the next available OEP number>
+       * <YYYY is the abbreviated Type: proc | bp | arch>
+       * <ZZZZ is a brief (< 5 words) version of the title>
+   * - Title
+     - <OEP title>
+   * - Last Modified
+     - <date string, in YYYY-MM-DD format>
+   * - Authors
+     - <list of authors' real names and optionally, email addresses>
+   * - Arbiter
+     - <Arbiter's real name and email address>
+   * - Status
+     - <Draft | Under Review | Deferred | Accepted | Rejected | Withdrawn | Final | Replaced>
+   * - Type
+     - <Architecture | Best Practice | Process>
+   * - Created
+     - <date created on, in YYYY-MM-DD format>
+   * - Review Period
+     - <start - target end dates for review>
+
+Context
+-------
+Data validation in the Django Rest Framework "is performed entirely on the serializer class". Doing validation at
+the serializer level provides a few key advantages, such as making the data validation code easier to understand and 
+reason about.
+
+The Advanced Settings view is a Django view that allows reading and writing course metadata to the modulestore. These data
+proctored exam settings (e.g. "enable proctored exams", "proctoring provider", etc.). This view leverages the CourseMetadata class
+to read from and write to the modulestore. The CourseMetada class supports data validation in the validate_and_update_from_json method.
+The results of calling this method can be saved to the database.
+
+We are adding a Django Rest Framework REST API that exposes an endpoint for reading and writing proctored 
+exam settings to the modulestore. This REST API will be used by the course-authoring MFE to support a new
+Proctored Exam Settings page.
+
+Decision
+--------
+
+We will not implement additional validation 
+
+Consequences
+------------
+
+This section describes the resulting context, after applying the decision.
+All consequences should be listed here, not just the "positive" ones. A particular
+decision may have positive, negative, and neutral consequences, but all of them
+affect the team and project in the future.
+
+References
+----------
+
+List any additional references here that would be useful to the future reader.
+See `Documenting Architecture Decisions`_ for further input.
+
+.. _Documenting Architecture Decisions: http://thinkrelevance.com/blog/2011/11/15/documenting-architecture-decisions

--- a/cms/djangoapps/contentstore/rest_api/v1/serializers.py
+++ b/cms/djangoapps/contentstore/rest_api/v1/serializers.py
@@ -12,7 +12,7 @@ class ProctoredExamSettingsSerializer(serializers.Serializer):
     enable_proctored_exams = serializers.BooleanField()
     allow_proctoring_opt_out = serializers.BooleanField()
     proctoring_provider = serializers.CharField()
-    proctoring_escalation_email = serializers.CharField(allow_blank=True)
+    proctoring_escalation_email = serializers.CharField(required=False, allow_null=True)
     create_zendesk_tickets = serializers.BooleanField()
 
 
@@ -21,4 +21,3 @@ class ProctoredExamConfigurationSerializer(serializers.Serializer):
     proctored_exam_settings = ProctoredExamSettingsSerializer()
     available_proctoring_providers = serializers.ChoiceField(get_available_providers())
     course_start_date = serializers.DateTimeField()
-    is_staff = serializers.BooleanField()

--- a/cms/djangoapps/contentstore/rest_api/v1/tests/test_views.py
+++ b/cms/djangoapps/contentstore/rest_api/v1/tests/test_views.py
@@ -98,7 +98,6 @@ class ProctoringExamSettingsGetTests(ProctoringExamSettingsTestMixin, ModuleStor
             },
             'course_start_date': '2030-01-01T00:00:00Z',
             'available_proctoring_providers': ['null'],
-            'is_staff': user.is_staff,
         }
 
     def make_request(self, course_id=None, data=None):
@@ -196,7 +195,7 @@ class ProctoringExamSettingsPostTests(ProctoringExamSettingsTestMixin, ModuleSto
         data = self.get_request_data(
             enable_proctored_exams=True,
             proctoring_provider='test_proctoring_provider',
-            proctoring_escalation_email=''
+            proctoring_escalation_email=None
         )
         response = self.make_request(data=data)
 

--- a/cms/djangoapps/contentstore/rest_api/v1/views.py
+++ b/cms/djangoapps/contentstore/rest_api/v1/views.py
@@ -60,7 +60,6 @@ class ProctoredExamSettingsView(APIView):
                 "proctortrack"
             ],
             "course_start_date": "2013-02-05T05:00:00Z",
-            "is_staff": true
         }
 
     ------------------------------------------------------------------------------------
@@ -100,7 +99,6 @@ class ProctoredExamSettingsView(APIView):
             data['proctored_exam_settings'] = proctored_exam_settings
             data['available_proctoring_providers'] = get_available_providers()
             data['course_start_date'] = course_metadata['start'].get('value')
-            data['is_staff'] = request.user.is_staff
 
             serializer = ProctoredExamConfigurationSerializer(data)
 


### PR DESCRIPTION
[MST-345](https://openedx.atlassian.net/browse/MST-345)

* Change `proctoring_escalation_email` serializer field to not be required. This allows us to make POST requests against this endpoint, omitting the `proctoring_escalation_email` when it makes sense (e.g. for software_secure).
* Change `proctoring_escalation_email` serializer field to allow nulls instead of allowing blanks. Blank is an invalid email value, whereas null represents no email set, which is our valid default.

This bug is fixed by this pull request and this [pull request](https://github.com/edx/frontend-app-course-authoring/pull/26) in the course-authoring MFE.