### PR TITLE
AA-278: Add offer html to the course-home API

### DIFF
--- a/lms/djangoapps/course_home_api/outline/v1/serializers.py
+++ b/lms/djangoapps/course_home_api/outline/v1/serializers.py
@@ -71,4 +71,5 @@ class OutlineTabSerializer(serializers.Serializer):
     dates_widget = DatesWidgetSerializer()
     enroll_alert = EnrollAlertSerializer()
     handouts_html = serializers.CharField()
+    offer_html = serializers.CharField()
     welcome_message_html = serializers.CharField()

--- a/openedx/features/course_experience/tests/views/test_course_home.py
+++ b/openedx/features/course_experience/tests/views/test_course_home.py
@@ -440,8 +440,8 @@ class TestCourseHomePageAccess(CourseHomePageTestCase):
         discount_expiration_date = get_discount_expiration_date(user, self.course).strftime(u'%B %d')
         upgrade_link = verified_upgrade_deadline_link(user=user, course=self.course)
         bannerText = u'''<div class="first-purchase-offer-banner" role="note">
-             <span class="first-purchase-offer-banner-bold">
-             Upgrade by {discount_expiration_date} and save {percentage}% [{strikeout_price}]</span>
+             <span class="first-purchase-offer-banner-bold"><b>
+             Upgrade by {discount_expiration_date} and save {percentage}% [{strikeout_price}]</b></span>
              <br>Use code <b>EDXWELCOME</b> at checkout! <a id="welcome" href="{upgrade_link}">Upgrade Now</a>
              </div>'''.format(
             discount_expiration_date=discount_expiration_date,

--- a/openedx/features/discounts/tests/test_utils.py
+++ b/openedx/features/discounts/tests/test_utils.py
@@ -38,7 +38,7 @@ class TestStrikeoutPrice(TestCase):
             content, has_discount = utils.format_strikeout_price(Mock(name='user'), Mock(name='course'))
 
         assert six.text_type(content) == (
-            u"<span class='sr'>"
+            u"<span class='sr-only'>"
             u"Original price: <span class='price original'>{original_price}</span>, discount price: "
             u"</span>"
             u"<span class='price discount'>{discount_price}</span> "

--- a/openedx/features/discounts/utils.py
+++ b/openedx/features/discounts/utils.py
@@ -87,7 +87,7 @@ def format_strikeout_price(user, course, base_price=None, check_for_discount=Tru
             )).format(
                 original_price=original_price,
                 formatted_discount_price=formatted_discount_price,
-                s_sr=HTML("<span class='sr'>"),
+                s_sr=HTML("<span class='sr-only'>"),
                 s_op=HTML("<span class='price original'>"),
                 e_p=HTML("</span>"),
                 e_sr=HTML("</span>"),
@@ -133,11 +133,11 @@ def generate_offer_html(user, course):
                 br=HTML('<br>'),
                 banner_open=HTML(
                     '<div class="first-purchase-offer-banner" role="note">'
-                    '<span class="first-purchase-offer-banner-bold">'
+                    '<span class="first-purchase-offer-banner-bold"><b>'
                 ),
                 discount_expiration_date=discount_expiration_date.strftime(u'%B %d'),
                 percentage=discount_percentage(course),
-                span_close=HTML('</span>'),
+                span_close=HTML('</b></span>'),
                 div_close=HTML('</div>'),
                 strikeout_price=HTML(format_strikeout_price(user, course, check_for_discount=False)[0])
             )


### PR DESCRIPTION
This is for the frontend-app-learning MFE to consume and show an alert when offer_html is defined.

I've also tweaked that html a bit to work better in an environment that doesn't have LMS's exact css.