### PR TITLE
AA-279: Add course-expired html to the course-home outline API

### DIFF
--- a/lms/djangoapps/course_home_api/outline/v1/serializers.py
+++ b/lms/djangoapps/course_home_api/outline/v1/serializers.py
@@ -67,6 +67,7 @@ class OutlineTabSerializer(serializers.Serializer):
     Serializer for the Outline Tab
     """
     course_blocks = CourseBlockSerializer()
+    course_expired_html = serializers.CharField()
     course_tools = CourseToolSerializer(many=True)
     dates_widget = DatesWidgetSerializer()
     enroll_alert = EnrollAlertSerializer()

--- a/lms/djangoapps/course_home_api/outline/v1/tests/test_views.py
+++ b/lms/djangoapps/course_home_api/outline/v1/tests/test_views.py
@@ -4,6 +4,7 @@ Tests for Outline Tab API in the Course Home API
 
 import ddt
 from django.urls import reverse
+from mock import patch
 
 from course_modes.models import CourseMode
 from lms.djangoapps.course_home_api.tests.utils import BaseCourseHomeTests
@@ -148,3 +149,19 @@ class OutlineTabTestViews(BaseCourseHomeTests):
         )
         welcome_message_html = self.client.get(self.url).data['welcome_message_html']
         self.assertEqual(welcome_message_html, None if welcome_message_is_dismissed else '<p>Welcome</p>')
+
+    @COURSE_HOME_MICROFRONTEND.override(active=True)
+    @COURSE_HOME_MICROFRONTEND_OUTLINE_TAB.override(active=True)
+    def test_offer_html(self):
+        with patch('lms.djangoapps.course_home_api.outline.v1.views.generate_offer_html') as gen_html:
+            html = '<div>Offer HTML</div>'
+            gen_html.return_value = html
+            self.assertEqual(self.client.get(self.url).data['offer_html'], html)
+
+    @COURSE_HOME_MICROFRONTEND.override(active=True)
+    @COURSE_HOME_MICROFRONTEND_OUTLINE_TAB.override(active=True)
+    def test_course_expired_html(self):
+        with patch('lms.djangoapps.course_home_api.outline.v1.views.generate_course_expired_message') as gen_html:
+            html = '<div>Course expired HTML</div>'
+            gen_html.return_value = html
+            self.assertEqual(self.client.get(self.url).data['course_expired_html'], html)

--- a/lms/djangoapps/course_home_api/outline/v1/views.py
+++ b/lms/djangoapps/course_home_api/outline/v1/views.py
@@ -28,6 +28,7 @@ from lms.djangoapps.courseware.masquerade import setup_masquerade
 from openedx.core.djangoapps.content.block_structure.transformers import BlockStructureTransformers
 from openedx.core.djangoapps.content.course_overviews.models import CourseOverview
 from openedx.core.djangoapps.user_api.course_tag.api import get_course_tag, set_course_tag
+from openedx.features.course_duration_limits.access import generate_course_expired_message
 from openedx.features.course_experience import COURSE_ENABLE_UNENROLLED_ACCESS_FLAG, LATEST_UPDATE_FLAG
 from openedx.features.course_experience.course_tools import CourseToolsPluginManager
 from openedx.features.course_experience.views.latest_update import LatestUpdateFragmentView
@@ -120,8 +121,9 @@ class OutlineTabView(RetrieveAPIView):
         show_handouts = show_enrolled or allow_public
         handouts_html = get_course_info_section(request, request.user, course, 'handouts') if show_handouts else ''
 
-        # TODO: TNL-7185 Legacy: Refactor to return the offer data and format the message in the MFE
+        # TODO: TNL-7185 Legacy: Refactor to return the offer & expired data and format the message in the MFE
         offer_html = generate_offer_html(request.user, course_overview)
+        course_expired_html = generate_course_expired_message(request.user, course_overview)
 
         welcome_message_html = None
         if get_course_tag(request.user, course_key, PREFERENCE_KEY) != 'False':
@@ -169,6 +171,7 @@ class OutlineTabView(RetrieveAPIView):
 
         data = {
             'course_blocks': course_blocks,
+            'course_expired_html': course_expired_html,
             'course_tools': course_tools,
             'dates_widget': dates_widget,
             'enroll_alert': enroll_alert,


### PR DESCRIPTION
This will let the learning MFE render it on the outline tab (like it already does on the courseware tab).