### PR TITLE
Add canvas to apps list so migrations can run

### DIFF
--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -1658,6 +1658,7 @@ OPTIONAL_APPS = (
     ('consent', None),
     ('integrated_channels.integrated_channel', None),
     ('integrated_channels.degreed', None),
+    ('integrated_channels.canvas', None),
     ('integrated_channels.sap_success_factors', None),
     ('integrated_channels.xapi', None),
     ('integrated_channels.cornerstone', None),

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -3175,6 +3175,7 @@ OPTIONAL_APPS = [
     ('consent', None),
     ('integrated_channels.integrated_channel', None),
     ('integrated_channels.degreed', None),
+    ('integrated_channels.canvas', None),
     ('integrated_channels.sap_success_factors', None),
     ('integrated_channels.cornerstone', None),
     ('integrated_channels.xapi', None),


### PR DESCRIPTION
I am not totally sure this is correct. But I want to pause, discuss before I proceed with step 3 of renaming column

This is related to workstream under  ENT-3293 and its parent where I have been trying to rename the field 'key' to 'client_id' in canvas models.

I just realized that for my rename of fields to even migrate, canvas has to be in the apps list, no? So this PR just does that

This needs to be done before the release 3.4.39 or higher or edx-enterprise is consumed 

so this blocks release of edx-enterprise 3.4.39 into platform, ENT-3293 I think
