### PR TITLE
AA-275: Persist Masquerade User staff status

### DIFF
--- a/lms/djangoapps/course_home_api/course_metadata/v1/serializers.py
+++ b/lms/djangoapps/course_home_api/course_metadata/v1/serializers.py
@@ -30,10 +30,11 @@ class CourseHomeMetadataSerializer(serializers.Serializer):
     Serializer for the Course Home Course Metadata
     """
     course_id = serializers.CharField()
+    is_enrolled = serializers.BooleanField()
+    is_self_paced = serializers.BooleanField()
     is_staff = serializers.BooleanField()
     number = serializers.CharField()
     org = serializers.CharField()
+    original_user_is_staff = serializers.BooleanField()
     tabs = CourseTabSerializer(many=True)
     title = serializers.CharField()
-    is_self_paced = serializers.BooleanField()
-    is_enrolled = serializers.BooleanField()

--- a/lms/djangoapps/course_home_api/course_metadata/v1/views.py
+++ b/lms/djangoapps/course_home_api/course_metadata/v1/views.py
@@ -33,6 +33,9 @@ class CourseHomeMetadataView(RetrieveAPIView):
         is_enrolled: (bool) Indicates if the user is enrolled in the course
         is_self_paced: (bool) Indicates if the course is self paced
         is_staff: (bool) Indicates if the user is staff
+        original_user_is_staff: (bool) Indicates if the original user has staff access
+            Used for when masquerading to distinguish between the original requesting user
+            and the user being masqueraded as.
         number: (str) The Course's number
         org: (str) The Course's organization
         tabs: List of Course Tabs to display. They are serialized as:
@@ -52,6 +55,7 @@ class CourseHomeMetadataView(RetrieveAPIView):
     def get(self, request, *args, **kwargs):
         course_key_string = kwargs.get('course_key_string')
         course_key = CourseKey.from_string(course_key_string)
+        original_user_is_staff = has_access(request.user, 'staff', course_key).has_access
 
         _, request.user = setup_masquerade(
             request,
@@ -66,6 +70,7 @@ class CourseHomeMetadataView(RetrieveAPIView):
         data = {
             'course_id': course.id,
             'is_staff': has_access(request.user, 'staff', course_key).has_access,
+            'original_user_is_staff': original_user_is_staff,
             'number': course.display_number_with_default,
             'org': course.display_org_with_default,
             'tabs': get_course_tab_list(request.user, course),

--- a/openedx/core/djangoapps/courseware_api/serializers.py
+++ b/openedx/core/djangoapps/courseware_api/serializers.py
@@ -84,6 +84,7 @@ class CourseInfoSerializer(serializers.Serializer):  # pylint: disable=abstract-
     tabs = serializers.ListField()
     verified_mode = serializers.DictField()
     show_calculator = serializers.BooleanField()
+    original_user_is_staff = serializers.BooleanField()
     is_staff = serializers.BooleanField()
     can_load_courseware = serializers.DictField()
     notes = serializers.DictField()


### PR DESCRIPTION
We need both the original user's staff status as well as
the staff status of the user being masqueraded as.