### PR TITLE
Revert "Bucket users regardless of enrollment in courseware MFE experiment

### DIFF
--- a/common/djangoapps/student/signals/receivers.py
+++ b/common/djangoapps/student/signals/receivers.py
@@ -59,7 +59,7 @@ def create_course_enrollment_celebration(sender, instance, created, **kwargs):
 
     # The UI for celebrations is only supported on the MFE right now, so don't turn on
     # celebrations unless this enrollment's course is MFE-enabled.
-    if not REDIRECT_TO_COURSEWARE_MICROFRONTEND.is_enabled():
+    if not REDIRECT_TO_COURSEWARE_MICROFRONTEND.is_enabled(instance.course_id):
         return
 
     try:

--- a/lms/djangoapps/courseware/views/index.py
+++ b/lms/djangoapps/courseware/views/index.py
@@ -198,7 +198,7 @@ class CoursewareIndex(View):
         if getattr(self.section, 'is_time_limited', False):
             return
         # ALLOW: when flag set for course
-        if REDIRECT_TO_COURSEWARE_MICROFRONTEND.is_enabled():
+        if REDIRECT_TO_COURSEWARE_MICROFRONTEND.is_enabled(self.course_key):
             raise Redirect(self.microfrontend_url)
 
     @property
@@ -654,7 +654,7 @@ def show_courseware_mfe_link(user, staff_access, course_key):
     # course team preview CourseWaffleFlag for this course *or* if we've turned
     # on the redirect for your students.
     mfe_enabled_for_course_team = COURSEWARE_MICROFRONTEND_COURSE_TEAM_PREVIEW.is_enabled(course_key)
-    mfe_experiment_enabled_for_course = REDIRECT_TO_COURSEWARE_MICROFRONTEND.is_experiment_on()
+    mfe_experiment_enabled_for_course = REDIRECT_TO_COURSEWARE_MICROFRONTEND.is_experiment_on(course_key)
 
     if staff_access and (mfe_enabled_for_course_team or mfe_experiment_enabled_for_course):
         return True


### PR DESCRIPTION
@edx/teaching-and-learning 
https://openedx.atlassian.net/browse/TNL-7405

This reverts https://github.com/edx/edx-platform/pull/24617.

Omitting the course_key argument to ExperimentWaffleFlag.is_enabled causes a 500 when the underlying experiment flag is enabled.

Whatever the solution ends up being, I'd like to merge this now in order to unblock Support and I from diagnosing https://openedx.atlassian.net/browse/TNL-7400.

