### PR TITLE
Allow entitlements to be used past course has ended.

### DIFF
--- a/common/djangoapps/entitlements/tests/test_utils.py
+++ b/common/djangoapps/entitlements/tests/test_utils.py
@@ -155,14 +155,15 @@ class TestCourseRunFulfillableForEntitlement(ModuleStoreTestCase):
 
         assert not is_course_run_entitlement_fulfillable(course_overview.id, entitlement)
 
-    def test_course_run_fulfillable_enrollment_ended_upgrade_open(self):
+    def test_course_run_fulfillable_already_enrolled_course_ended(self):
         course_overview = self.create_course(
             start_from_now=-3,
-            end_from_now=2,
+            end_from_now=-1,
             enrollment_start_from_now=-2,
             enrollment_end_from_now=-1,
         )
 
         entitlement = CourseEntitlementFactory.create(mode=CourseMode.VERIFIED)
+        CourseEnrollmentFactory.create(user=entitlement.user, course_id=course_overview.id)
 
         assert is_course_run_entitlement_fulfillable(course_overview.id, entitlement)

--- a/lms/static/js/learner_dashboard/spec/course_card_view_spec.js
+++ b/lms/static/js/learner_dashboard/spec/course_card_view_spec.js
@@ -169,7 +169,7 @@ describe('Course Card View', () => {
       );
   });
 
-  it('should show a message if an there is an upcoming course run', () => {
+  it('should show a message if there is an upcoming course run', () => {
     course.course_runs[0].is_enrollment_open = false;
 
     setupView(course, false);

--- a/lms/static/js/learner_dashboard/views/course_card_view.js
+++ b/lms/static/js/learner_dashboard/views/course_card_view.js
@@ -46,7 +46,9 @@ class CourseCardView extends Backbone.View {
     const $upgradeMessage = this.$('.upgrade-message');
     const $certStatus = this.$('.certificate-status');
     const $expiredNotification = this.$('.expired-notification');
+    const courseKey = this.model.get('course_run_key');
     const expired = this.model.get('expired');
+    const canUpgrade = this.model.get('upgrade_url') && !(expired === true);
     const courseUUID = this.model.get('uuid');
     const containerSelector = `#course-${courseUUID}`;
 
@@ -72,8 +74,7 @@ class CourseCardView extends Backbone.View {
         enterCourseBtn: `${containerSelector} .view-course-button`,
         availableSessions: JSON.stringify(this.model.get('course_runs')),
         entitlementUUID: this.entitlement.uuid,
-        currentSessionId: this.model.isEnrolledInSession() ?
-                                 this.model.get('course_run_key') : null,
+        currentSessionId: this.model.isEnrolledInSession() && !canUpgrade ? courseKey : null,
         enrollUrl: this.model.get('enroll_url'),
         courseHomeUrl: this.model.get('course_url'),
         expiredAt: this.entitlement.expired_at,
@@ -81,7 +82,7 @@ class CourseCardView extends Backbone.View {
       });
     }
 
-    if (this.model.get('upgrade_url') && !(expired === true)) {
+    if (canUpgrade) {
       this.upgradeMessage = new UpgradeMessageView({
         $el: $upgradeMessage,
         model: this.model,

--- a/lms/static/js/learner_dashboard/views/course_entitlement_view.js
+++ b/lms/static/js/learner_dashboard/views/course_entitlement_view.js
@@ -141,7 +141,8 @@ class CourseEntitlementView extends Backbone.View {
     this.trackSessionChange(eventPage, eventAction, prevSession);
 
     // With a containing backbone view, we can simply re-render the parent card
-    if (this.$parentEl) {
+    if (this.$parentEl &&
+        this.courseCardModel.get('course_run_key') !== this.currentSessionSelection) {
       this.courseCardModel.updateCourseRun(this.currentSessionSelection);
       return;
     }
@@ -388,6 +389,7 @@ class CourseEntitlementView extends Backbone.View {
     sessionData.forEach((session) => {
       Object.assign(session, {
         enrollment_end: CourseEntitlementView.formatDate(session.enrollment_end, dateFormat),
+        session_id: session.session_id ? session.session_id : session.key,
         session_dates: this.courseCardModel.formatDateString({
           start_date: CourseEntitlementView.formatDate(session.start, dateFormat),
           advertised_start: session.advertised_start,

--- a/openedx/core/djangoapps/catalog/tests/test_utils.py
+++ b/openedx/core/djangoapps/catalog/tests/test_utils.py
@@ -655,14 +655,19 @@ class TestSessionEntitlement(CatalogIntegrationMixin, TestCase):
     def test_unpublished_sessions_for_entitlement(self, mock_get_edx_api_data):
         """
         Test unpublished course runs are not part of visible session entitlements when the user
-        is not enrolled.
+        is not enrolled and upgrade deadline is passed.
         """
         catalog_course_run = CourseRunFactory.create(status=COURSE_UNPUBLISHED)
         catalog_course = CourseFactory(course_runs=[catalog_course_run])
         mock_get_edx_api_data.return_value = catalog_course
         course_key = CourseKey.from_string(catalog_course_run.get('key'))
         course_overview = CourseOverviewFactory.create(id=course_key, start=self.tomorrow)
-        CourseModeFactory.create(mode_slug=CourseMode.VERIFIED, min_price=100, course_id=course_overview.id)
+        CourseModeFactory.create(
+            mode_slug=CourseMode.VERIFIED,
+            min_price=100,
+            course_id=course_overview.id,
+            expiration_datetime=now() - timedelta(days=1)
+        )
         entitlement = CourseEntitlementFactory(
             user=self.user, mode=CourseMode.VERIFIED
         )

--- a/openedx/core/djangoapps/catalog/utils.py
+++ b/openedx/core/djangoapps/catalog/utils.py
@@ -553,9 +553,7 @@ def get_fulfillable_course_runs_for_entitlement(entitlement, course_runs):
             # User is enrolled in the course so we should include it in the list of enrollable sessions always
             # this will ensure it is available for the UI
             enrollable_sessions.append(course_run)
-        elif (course_run.get('status') == COURSE_PUBLISHED and not
-                is_enrolled_in_mode and
-                is_course_run_entitlement_fulfillable(course_id, entitlement, search_time)):
+        elif not is_enrolled_in_mode and is_course_run_entitlement_fulfillable(course_id, entitlement, search_time):
             enrollable_sessions.append(course_run)
 
     enrollable_sessions.sort(key=lambda session: session.get('start'))


### PR DESCRIPTION
Allow entitlements to be used past the course has ended but upgrade deadline is still in future for already enrolled learners.

Entitlements should be able to be applied past the enrollment end date and regardless of publication status as long as the learner is enrolled already and as long as the VUD has not passed. Basically, if a learner can use a credit card to upgrade, they should be able to use their entitlement.

Learners who have not already enrolled should not be able to see the course run if the enrollment start date has not been reached, the enrollment end date has passed, or it’s not published yet.

PROD-1497
