### PR TITLE
lock xblock version to 1.3.1

### DIFF
--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -124,3 +124,6 @@ geoip2<4.0.1
 
 # tests failing for pymongo==3.11
 pymongo<3.11
+
+# Tests are failing on 1.4.0 due to xblock indexing issues
+xblock==1.3.1


### PR DESCRIPTION
- Constraint xblock version to 1.3.1 as 1.4.0 is causing indexing tests to fail