### PR TITLE
Upgrade XBlock

### DIFF
--- a/cms/djangoapps/contentstore/courseware_index.py
+++ b/cms/djangoapps/contentstore/courseware_index.py
@@ -178,8 +178,7 @@ class SearchIndexerBase(object, metaclass=ABCMeta):
             Returns:
             item_content_groups - content groups assigned to indexed item
             """
-            is_indexable = hasattr(item, "index_dictionary")
-            item_index_dictionary = item.index_dictionary() if is_indexable else None
+            item_index_dictionary = item.index_dictionary()
             # if it's not indexable and it does not have children, then ignore
             if not item_index_dictionary and not item.has_children:
                 return

--- a/cms/djangoapps/contentstore/tests/test_courseware_index.py
+++ b/cms/djangoapps/contentstore/tests/test_courseware_index.py
@@ -56,9 +56,6 @@ from xmodule.tests import DATA_DIR
 from xmodule.x_module import XModuleMixin
 
 
-class NonIndexableXBlock(XBlock):
-    """XBlock for testing indexibility"""
-
 COURSE_CHILD_STRUCTURE = {
     "course": "chapter",
     "chapter": "sequential",
@@ -353,33 +350,6 @@ class TestCoursewareSearchIndexer(MixedWithOptionsTestCase):
         response = self.search()
         self.assertEqual(response["total"], 3)
 
-    @XBlock.register_temp_plugin(NonIndexableXBlock)
-    def _test_not_indexable(self, store):
-        """ test not indexable items """
-        # Publish the vertical to start with
-        self.publish_item(store, self.vertical.location)
-        self.reindex_course(store)
-        response = self.search()
-        self.assertEqual(response["total"], 4)
-
-        # Add a non-indexable item
-        ItemFactory.create(
-            parent_location=self.vertical.location,
-            category="nonindexablexblock",
-            display_name="Some other content",
-            publish_item=False,
-            modulestore=store,
-        )
-        self.reindex_course(store)
-        response = self.search()
-        self.assertEqual(response["total"], 4)
-
-        # even after publishing, we should not find the non-indexable item
-        self.publish_item(store, self.vertical.location)
-        self.reindex_course(store)
-        response = self.search()
-        self.assertEqual(response["total"], 4)
-
     def _test_start_date_propagation(self, store):
         """ make sure that the start date is applied at the right level """
         early_date = self.course.start
@@ -565,10 +535,6 @@ class TestCoursewareSearchIndexer(MixedWithOptionsTestCase):
     @ddt.data(*WORKS_WITH_STORES)
     def test_deleting_item(self, store_type):
         self._perform_test_using_store(store_type, self._test_deleting_item)
-
-    @ddt.data(*WORKS_WITH_STORES)
-    def test_not_indexable(self, store_type):
-        self._perform_test_using_store(store_type, self._test_not_indexable)
 
     @ddt.data(*WORKS_WITH_STORES)
     def test_start_date_propagation(self, store_type):
@@ -903,25 +869,6 @@ class TestLibrarySearchIndexer(MixedWithOptionsTestCase):
         response = self.search()
         self.assertEqual(response["total"], 1)
 
-    @XBlock.register_temp_plugin(NonIndexableXBlock)
-    def _test_not_indexable(self, store):
-        """ test not indexable items """
-        self.reindex_library(store)
-        response = self.search()
-        self.assertEqual(response["total"], 2)
-
-        # Add a non-indexable item
-        ItemFactory.create(
-            parent_location=self.library.location,
-            category="nonindexablexblock",
-            display_name="Assessment",
-            publish_item=False,
-            modulestore=store,
-        )
-        self.reindex_library(store)
-        response = self.search()
-        self.assertEqual(response["total"], 2)
-
     @patch('django.conf.settings.SEARCH_ENGINE', None)
     def _test_search_disabled(self, store):
         """ if search setting has it as off, confirm that nothing is indexed """
@@ -949,10 +896,6 @@ class TestLibrarySearchIndexer(MixedWithOptionsTestCase):
     @ddt.data(*WORKS_WITH_STORES)
     def test_deleting_item(self, store_type):
         self._perform_test_using_store(store_type, self._test_deleting_item)
-
-    @ddt.data(*WORKS_WITH_STORES)
-    def test_not_indexable(self, store_type):
-        self._perform_test_using_store(store_type, self._test_not_indexable)
 
     @ddt.data(*WORKS_WITH_STORES)
     def test_search_disabled(self, store_type):

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -125,5 +125,3 @@ geoip2<4.0.1
 # tests failing for pymongo==3.11
 pymongo<3.11
 
-# Tests are failing on 1.4.0 due to xblock indexing issues
-xblock==1.3.1

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -245,7 +245,7 @@ wrapt==1.11.2             # via -c requirements/edx/../constraints.txt, -r requi
 git+https://github.com/edx-solutions/xblock-drag-and-drop-v2@v2.2.10#egg=xblock-drag-and-drop-v2==2.2.10  # via -r requirements/edx/github.in
 git+https://github.com/open-craft/xblock-poll@da2d8fd21791a7af128595cf82bee83ee579e00f#egg=xblock-poll==1.9.6  # via -r requirements/edx/github.in
 xblock-utils==2.1.1       # via -r requirements/edx/base.in, edx-sga, lti-consumer-xblock, staff-graded-xblock, xblock-drag-and-drop-v2, xblock-google-drive
-xblock==1.3.1             # via -c requirements/edx/../constraints.txt, -r requirements/edx/base.in, acid-xblock, crowdsourcehinter-xblock, done-xblock, edx-completion, edx-sga, edx-user-state-client, edx-when, lti-consumer-xblock, ora2, rate-xblock, staff-graded-xblock, xblock-discussion, xblock-drag-and-drop-v2, xblock-google-drive, xblock-poll, xblock-utils
+xblock==1.4.0             # via -r requirements/edx/base.in, acid-xblock, crowdsourcehinter-xblock, done-xblock, edx-completion, edx-sga, edx-user-state-client, edx-when, lti-consumer-xblock, ora2, rate-xblock, staff-graded-xblock, xblock-discussion, xblock-drag-and-drop-v2, xblock-google-drive, xblock-poll, xblock-utils
 xmlsec==1.3.8             # via python3-saml
 xss-utils==0.1.3          # via -r requirements/edx/base.in
 zipp==1.0.0               # via -c requirements/edx/../constraints.txt, -r requirements/edx/paver.txt, importlib-metadata

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -319,7 +319,7 @@ wrapt==1.11.2             # via -c requirements/edx/../constraints.txt, -r requi
 git+https://github.com/edx-solutions/xblock-drag-and-drop-v2@v2.2.10#egg=xblock-drag-and-drop-v2==2.2.10  # via -r requirements/edx/testing.txt
 git+https://github.com/open-craft/xblock-poll@da2d8fd21791a7af128595cf82bee83ee579e00f#egg=xblock-poll==1.9.6  # via -r requirements/edx/testing.txt
 xblock-utils==2.1.1       # via -r requirements/edx/testing.txt, edx-sga, lti-consumer-xblock, staff-graded-xblock, xblock-drag-and-drop-v2, xblock-google-drive
-xblock==1.3.1             # via -c requirements/edx/../constraints.txt, -r requirements/edx/testing.txt, acid-xblock, crowdsourcehinter-xblock, done-xblock, edx-completion, edx-sga, edx-user-state-client, edx-when, lti-consumer-xblock, ora2, rate-xblock, staff-graded-xblock, xblock-discussion, xblock-drag-and-drop-v2, xblock-google-drive, xblock-poll, xblock-utils
+xblock==1.4.0             # via -r requirements/edx/testing.txt, acid-xblock, crowdsourcehinter-xblock, done-xblock, edx-completion, edx-sga, edx-user-state-client, edx-when, lti-consumer-xblock, ora2, rate-xblock, staff-graded-xblock, xblock-discussion, xblock-drag-and-drop-v2, xblock-google-drive, xblock-poll, xblock-utils
 xmlsec==1.3.8             # via -r requirements/edx/testing.txt, python3-saml
 xss-utils==0.1.3          # via -r requirements/edx/testing.txt
 zipp==1.0.0               # via -c requirements/edx/../constraints.txt, -r requirements/edx/testing.txt, importlib-metadata, importlib-resources

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -297,7 +297,7 @@ wrapt==1.11.2             # via -c requirements/edx/../constraints.txt, -r requi
 git+https://github.com/edx-solutions/xblock-drag-and-drop-v2@v2.2.10#egg=xblock-drag-and-drop-v2==2.2.10  # via -r requirements/edx/base.txt
 git+https://github.com/open-craft/xblock-poll@da2d8fd21791a7af128595cf82bee83ee579e00f#egg=xblock-poll==1.9.6  # via -r requirements/edx/base.txt
 xblock-utils==2.1.1       # via -r requirements/edx/base.txt, edx-sga, lti-consumer-xblock, staff-graded-xblock, xblock-drag-and-drop-v2, xblock-google-drive
-xblock==1.3.1             # via -c requirements/edx/../constraints.txt, -r requirements/edx/base.txt, acid-xblock, crowdsourcehinter-xblock, done-xblock, edx-completion, edx-sga, edx-user-state-client, edx-when, lti-consumer-xblock, ora2, rate-xblock, staff-graded-xblock, xblock-discussion, xblock-drag-and-drop-v2, xblock-google-drive, xblock-poll, xblock-utils
+xblock==1.4.0             # via -r requirements/edx/base.txt, acid-xblock, crowdsourcehinter-xblock, done-xblock, edx-completion, edx-sga, edx-user-state-client, edx-when, lti-consumer-xblock, ora2, rate-xblock, staff-graded-xblock, xblock-discussion, xblock-drag-and-drop-v2, xblock-google-drive, xblock-poll, xblock-utils
 xmlsec==1.3.8             # via -r requirements/edx/base.txt, python3-saml
 xss-utils==0.1.3          # via -r requirements/edx/base.txt
 zipp==1.0.0               # via -c requirements/edx/../constraints.txt, -r requirements/edx/base.txt, -r requirements/edx/coverage.txt, importlib-metadata, importlib-resources


### PR DESCRIPTION
This upgrades XBlock, which now contains a default index_dictionary method.

As a result, the test for non-indexable XBlocks needed to be modified to use a slightly
different way of checking whether an XBlock is not indexable.
In practice, no XBlocks will be non-indexable, unless the explicitly override index_dictionary
to return None