### PR TITLE
Unpin pytest and allow upgrade past 5.4.0 all the way to 6.0.1

### DIFF
--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -91,9 +91,6 @@ path<13.2.0
 # ARCHBOM-1141: pip-tools upgrade requires pip upgrade
 pip-tools<5.0.0
 
-# BOM-1430: pytest 5.4.0 breaks reporting sometimes: https://github.com/pytest-dev/pytest/issues/6925
-pytest<5.4.0
-
 # pytest-django 3.9.0 has a fix for pytest 5.4.0+ that breaks cleanup after failed tests in earlier pytest versions
 # https://github.com/pytest-dev/pytest-django/issues/824
 pytest-django<3.9.0

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -155,6 +155,7 @@ importlib-metadata==1.7.0  # via -r requirements/edx/testing.txt, inflect, jsons
 importlib-resources==3.0.0  # via -r requirements/edx/testing.txt, virtualenv
 inflect==3.0.2            # via -c requirements/edx/../constraints.txt, -r requirements/edx/testing.txt, jinja2-pluralize
 inflection==0.5.0         # via -r requirements/edx/testing.txt, drf-yasg
+iniconfig==1.0.1          # via -r requirements/edx/testing.txt, pytest
 ipaddress==1.0.23         # via -r requirements/edx/testing.txt
 isodate==0.6.0            # via -r requirements/edx/testing.txt, python3-saml
 isort==4.3.21             # via -c requirements/edx/../constraints.txt, -r requirements/edx/testing.txt, pylint
@@ -239,7 +240,7 @@ pytest-json-report==1.2.1  # via -r requirements/edx/testing.txt
 pytest-metadata==1.8.0    # via -r requirements/edx/testing.txt, pytest-json-report
 pytest-randomly==3.4.1    # via -r requirements/edx/testing.txt
 pytest-xdist==1.34.0      # via -r requirements/edx/testing.txt
-pytest==5.3.5             # via -c requirements/edx/../constraints.txt, -r requirements/edx/testing.txt, pytest-attrib, pytest-cov, pytest-django, pytest-forked, pytest-json-report, pytest-metadata, pytest-randomly, pytest-xdist
+pytest==6.0.1             # via -r requirements/edx/testing.txt, pytest-attrib, pytest-cov, pytest-django, pytest-forked, pytest-json-report, pytest-metadata, pytest-randomly, pytest-xdist
 python-dateutil==2.4.0    # via -c requirements/edx/../constraints.txt, -r requirements/edx/testing.txt, analytics-python, botocore, edx-ace, edx-drf-extensions, edx-enterprise, edx-proctoring, faker, freezegun, icalendar, ora2, xblock
 python-levenshtein==0.12.0  # via -r requirements/edx/testing.txt
 python-memcached==1.59    # via -r requirements/edx/testing.txt
@@ -295,7 +296,7 @@ super-csv==0.9.9          # via -r requirements/edx/testing.txt, edx-bulk-grades
 sympy==1.6.1              # via -r requirements/edx/testing.txt, symmath
 testfixtures==6.14.1      # via -r requirements/edx/testing.txt, edx-enterprise
 text-unidecode==1.3       # via -r requirements/edx/testing.txt, faker, python-slugify
-toml==0.10.1              # via -r requirements/edx/testing.txt, tox
+toml==0.10.1              # via -r requirements/edx/testing.txt, pytest, tox
 tox-battery==0.6.1        # via -r requirements/edx/testing.txt
 tox==3.18.1               # via -r requirements/edx/testing.txt, tox-battery
 tqdm==4.48.2              # via -r requirements/edx/testing.txt, nltk
@@ -311,7 +312,6 @@ virtualenv==20.0.30       # via -r requirements/edx/testing.txt, tox
 voluptuous==0.11.7        # via -r requirements/edx/testing.txt, ora2
 vulture==1.6              # via -r requirements/edx/development.in
 watchdog==0.10.3          # via -r requirements/edx/testing.txt
-wcwidth==0.2.5            # via -r requirements/edx/testing.txt, pytest
 web-fragments==0.3.2      # via -r requirements/edx/testing.txt, crowdsourcehinter-xblock, staff-graded-xblock, xblock, xblock-utils
 webencodings==0.5.1       # via -r requirements/edx/testing.txt, bleach, html5lib
 webob==1.8.6              # via -r requirements/edx/testing.txt, xblock, xmodule

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -150,6 +150,7 @@ importlib-metadata==1.7.0  # via -r requirements/edx/base.txt, -r requirements/e
 importlib-resources==3.0.0  # via virtualenv
 inflect==3.0.2            # via -c requirements/edx/../constraints.txt, -r requirements/edx/coverage.txt, jinja2-pluralize
 inflection==0.5.0         # via -r requirements/edx/base.txt, drf-yasg
+iniconfig==1.0.1          # via pytest
 ipaddress==1.0.23         # via -r requirements/edx/base.txt
 isodate==0.6.0            # via -r requirements/edx/base.txt, python3-saml
 isort==4.3.21             # via -c requirements/edx/../constraints.txt, -r requirements/edx/testing.in, pylint
@@ -229,7 +230,7 @@ pytest-json-report==1.2.1  # via -r requirements/edx/testing.in
 pytest-metadata==1.8.0    # via -r requirements/edx/testing.in, pytest-json-report
 pytest-randomly==3.4.1    # via -r requirements/edx/testing.in
 pytest-xdist==1.34.0      # via -r requirements/edx/testing.in
-pytest==5.3.5             # via -c requirements/edx/../constraints.txt, -r requirements/edx/testing.in, pytest-attrib, pytest-cov, pytest-django, pytest-forked, pytest-json-report, pytest-metadata, pytest-randomly, pytest-xdist
+pytest==6.0.1             # via -r requirements/edx/testing.in, pytest-attrib, pytest-cov, pytest-django, pytest-forked, pytest-json-report, pytest-metadata, pytest-randomly, pytest-xdist
 python-dateutil==2.4.0    # via -c requirements/edx/../constraints.txt, -r requirements/edx/base.txt, analytics-python, botocore, edx-ace, edx-drf-extensions, edx-enterprise, edx-proctoring, faker, freezegun, icalendar, ora2, xblock
 python-levenshtein==0.12.0  # via -r requirements/edx/base.txt
 python-memcached==1.59    # via -r requirements/edx/base.txt
@@ -274,7 +275,7 @@ super-csv==0.9.9          # via -r requirements/edx/base.txt, edx-bulk-grades
 sympy==1.6.1              # via -r requirements/edx/base.txt, symmath
 testfixtures==6.14.1      # via -r requirements/edx/base.txt, -r requirements/edx/testing.in, edx-enterprise
 text-unidecode==1.3       # via -r requirements/edx/base.txt, faker, python-slugify
-toml==0.10.1              # via tox
+toml==0.10.1              # via pytest, tox
 tox-battery==0.6.1        # via -r requirements/edx/testing.in
 tox==3.18.1               # via -r requirements/edx/testing.in, tox-battery
 tqdm==4.48.2              # via -r requirements/edx/base.txt, nltk
@@ -289,7 +290,6 @@ user-util==0.2            # via -r requirements/edx/base.txt
 virtualenv==20.0.30       # via tox
 voluptuous==0.11.7        # via -r requirements/edx/base.txt, ora2
 watchdog==0.10.3          # via -r requirements/edx/base.txt
-wcwidth==0.2.5            # via pytest
 web-fragments==0.3.2      # via -r requirements/edx/base.txt, crowdsourcehinter-xblock, staff-graded-xblock, xblock, xblock-utils
 webencodings==0.5.1       # via -r requirements/edx/base.txt, bleach, html5lib
 webob==1.8.6              # via -r requirements/edx/base.txt, xblock, xmodule


### PR DESCRIPTION
This was pinned in PR #23533 for intermittent breakage in pytest reporting (https://github.com/pytest-dev/pytest/issues/6925) but that seems to have since been fixed.