### PR TITLE
Unpin django-pytest now that pytest has upgraded to 5.4.0 and later

### DIFF
--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -91,10 +91,6 @@ path<13.2.0
 # ARCHBOM-1141: pip-tools upgrade requires pip upgrade
 pip-tools<5.0.0
 
-# pytest-django 3.9.0 has a fix for pytest 5.4.0+ that breaks cleanup after failed tests in earlier pytest versions
-# https://github.com/pytest-dev/pytest-django/issues/824
-pytest-django<3.9.0
-
 # Upgrading to 2.5.3 on 2020-01-03 triggered "'tzlocal' object has no attribute '_std_offset'" errors in production
 python-dateutil==2.4.0
 

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -165,7 +165,7 @@ nodeenv==1.4.0            # via -r requirements/edx/base.in
 numpy==1.18.5             # via -c requirements/edx/../constraints.txt, chem, openedx-calc, scipy
 oauthlib==3.0.1           # via -c requirements/edx/../constraints.txt, -r requirements/edx/base.in, django-oauth-toolkit, lti-consumer-xblock, requests-oauthlib, social-auth-core
 openedx-calc==1.0.9       # via -r requirements/edx/base.in
-ora2==2.8.9               # via -r requirements/edx/base.in
+ora2==2.8.12              # via -r requirements/edx/base.in
 packaging==20.4           # via bleach, drf-yasg
 path.py==12.5.0           # via edx-enterprise, edx-i18n-tools, ora2, staff-graded-xblock, xmodule
 path==13.1.0              # via -c requirements/edx/../constraints.txt, -r requirements/edx/paver.txt, path.py

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -197,7 +197,7 @@ nodeenv==1.4.0            # via -r requirements/edx/testing.txt
 numpy==1.18.5             # via -c requirements/edx/../constraints.txt, -r requirements/edx/testing.txt, chem, openedx-calc, scipy
 oauthlib==3.0.1           # via -c requirements/edx/../constraints.txt, -r requirements/edx/testing.txt, django-oauth-toolkit, lti-consumer-xblock, requests-oauthlib, social-auth-core
 openedx-calc==1.0.9       # via -r requirements/edx/testing.txt
-ora2==2.8.9               # via -r requirements/edx/testing.txt
+ora2==2.8.12              # via -r requirements/edx/testing.txt
 packaging==20.4           # via -r requirements/edx/testing.txt, bleach, drf-yasg, pytest, sphinx, tox
 path.py==12.5.0           # via -r requirements/edx/testing.txt, edx-enterprise, edx-i18n-tools, ora2, staff-graded-xblock, xmodule
 path==13.1.0              # via -c requirements/edx/../constraints.txt, -r requirements/edx/testing.txt, path.py
@@ -234,7 +234,7 @@ pyrsistent==0.16.0        # via jsonschema
 pysrt==1.1.2              # via -r requirements/edx/testing.txt, edxval
 pytest-attrib==0.1.3      # via -r requirements/edx/testing.txt
 pytest-cov==2.10.0        # via -r requirements/edx/testing.txt
-pytest-django==3.8.0      # via -c requirements/edx/../constraints.txt, -r requirements/edx/testing.txt
+pytest-django==3.9.0      # via -r requirements/edx/testing.txt
 pytest-forked==1.3.0      # via -r requirements/edx/testing.txt, pytest-xdist
 pytest-json-report==1.2.1  # via -r requirements/edx/testing.txt
 pytest-metadata==1.8.0    # via -r requirements/edx/testing.txt, pytest-json-report

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -189,7 +189,7 @@ nodeenv==1.4.0            # via -r requirements/edx/base.txt
 numpy==1.18.5             # via -c requirements/edx/../constraints.txt, -r requirements/edx/base.txt, chem, openedx-calc, scipy
 oauthlib==3.0.1           # via -c requirements/edx/../constraints.txt, -r requirements/edx/base.txt, django-oauth-toolkit, lti-consumer-xblock, requests-oauthlib, social-auth-core
 openedx-calc==1.0.9       # via -r requirements/edx/base.txt
-ora2==2.8.9               # via -r requirements/edx/base.txt
+ora2==2.8.12              # via -r requirements/edx/base.txt
 packaging==20.4           # via -r requirements/edx/base.txt, bleach, drf-yasg, pytest, tox
 path.py==12.5.0           # via -r requirements/edx/base.txt, edx-enterprise, edx-i18n-tools, ora2, staff-graded-xblock, xmodule
 path==13.1.0              # via -c requirements/edx/../constraints.txt, -r requirements/edx/base.txt, path.py
@@ -224,7 +224,7 @@ pyquery==1.4.1            # via -r requirements/edx/testing.in
 pysrt==1.1.2              # via -r requirements/edx/base.txt, edxval
 pytest-attrib==0.1.3      # via -r requirements/edx/testing.in
 pytest-cov==2.10.0        # via -r requirements/edx/testing.in
-pytest-django==3.8.0      # via -c requirements/edx/../constraints.txt, -r requirements/edx/testing.in
+pytest-django==3.9.0      # via -r requirements/edx/testing.in
 pytest-forked==1.3.0      # via pytest-xdist
 pytest-json-report==1.2.1  # via -r requirements/edx/testing.in
 pytest-metadata==1.8.0    # via -r requirements/edx/testing.in, pytest-json-report


### PR DESCRIPTION
- Originally pinned in PR #23566
- pytest was unpinned in PR #24717 and upgraded to v6+