### PR TITLE
Small PLS courseware banner fixes

### DIFF
--- a/lms/djangoapps/course_home_api/utils.py
+++ b/lms/djangoapps/course_home_api/utils.py
@@ -13,3 +13,11 @@ def get_microfrontend_url(course_key, view_name=None):
         mfe_link += '/{}'.format(view_name)
 
     return mfe_link
+
+
+def is_request_from_learning_mfe(request):
+    """
+    Returns whether the given request was made by the frontend-app-learning MFE.
+    """
+    return (settings.LEARNING_MICROFRONTEND_URL and
+            request.META.get('HTTP_REFERER', '').startswith(settings.LEARNING_MICROFRONTEND_URL))

--- a/lms/djangoapps/courseware/views/views.py
+++ b/lms/djangoapps/courseware/views/views.py
@@ -55,6 +55,7 @@ from lms.djangoapps.ccx.custom_exception import CCXLocatorValidationException
 from lms.djangoapps.certificates import api as certs_api
 from lms.djangoapps.certificates.models import CertificateStatuses
 from lms.djangoapps.commerce.utils import EcommerceService
+from lms.djangoapps.course_home_api.utils import is_request_from_learning_mfe
 from lms.djangoapps.courseware.access import has_access, has_ccx_coach_role
 from lms.djangoapps.courseware.access_utils import check_course_open_for_learner, check_public_access
 from lms.djangoapps.courseware.courses import (
@@ -1682,7 +1683,7 @@ def render_xblock(request, usage_key_string, check_if_enrolled=True):
             'web_app_course_url': reverse(COURSE_HOME_VIEW_NAME, args=[course.id]),
             'on_courseware_page': True,
             'verified_upgrade_link': verified_upgrade_deadline_link(request.user, course=course),
-            'is_learning_mfe': request.META.get('HTTP_REFERER', '').startswith(settings.LEARNING_MICROFRONTEND_URL),
+            'is_learning_mfe': is_request_from_learning_mfe(request),
             'is_mobile_app': is_request_from_mobile_app(request),
             'reset_deadlines_url': reverse(RESET_COURSE_DEADLINES_NAME),
         }

--- a/lms/templates/courseware/courseware-chromeless.html
+++ b/lms/templates/courseware/courseware-chromeless.html
@@ -11,7 +11,9 @@ from openedx.core.djangolib.js_utils import js_escaped_string
 <%def name="course_name()">
  <% return _("{course_number} Courseware").format(course_number=course.display_number_with_default) %>
 </%def>
-<%include file="/dates_banner.html" />
+% if is_mobile_app:
+  <%include file="/dates_banner.html" />
+% endif
 <%block name="bodyclass">view-in-course view-courseware courseware ${course.css_class or ''}</%block>
 <%block name="title"><title>
     % if section_title:

--- a/lms/templates/vert_module.html
+++ b/lms/templates/vert_module.html
@@ -30,8 +30,7 @@ from openedx.core.djangolib.markup import HTML
   <%include file='bookmark_button.html' args="bookmark_id=bookmark_id, is_bookmarked=bookmarked"/>
 % endif
 
-% if vertical_banner_ctas and not is_mobile_app:
-  ## We don't show any CTA banners on the mobile app yet, they need to handle these especially.
+% if vertical_banner_ctas:
   % for vertical_banner_cta in vertical_banner_ctas:
     <div class="banner-cta has-button">
       <div class="banner-cta-text">${vertical_banner_cta['description']}</div>

--- a/openedx/core/djangoapps/safe_sessions/tests/test_middleware.py
+++ b/openedx/core/djangoapps/safe_sessions/tests/test_middleware.py
@@ -306,10 +306,6 @@ class TestSafeSessionMiddleware(TestSafeSessionsLogMixin, TestCase):
     def test_error(self):
         self.verify_error(302)
 
-    def test_error_from_mobile_web_view(self):
-        self.request.path = '/xblock/block-v1:org+course+run+type@html+block@block_id'
-        self.verify_error(401)
-
     @override_settings(MOBILE_APP_USER_AGENT_REGEXES=[r'open edX Mobile App'])
     def test_error_from_mobile_app(self):
         self.request.META = {'HTTP_USER_AGENT': 'open edX Mobile App Version 2.1'}

--- a/openedx/core/lib/mobile_utils.py
+++ b/openedx/core/lib/mobile_utils.py
@@ -13,50 +13,14 @@ def is_request_from_mobile_app(request):
     Returns whether the given request was made by an open edX mobile app,
     either natively or through the mobile web view.
 
-    Note: The check for the user agent works only for mobile apps version 2.1
-    and higher.  Previous apps did not update their user agents to include the
-    distinguishing string.
-
-    The check for the web view is a temporary check that works for mobile apps
-    version 2.0 and higher.  See is_request_from_mobile_web_view for more
-    information.
-
     Args:
         request (HttpRequest)
     """
-    if is_request_from_mobile_web_view(request):
-        return True
-
     if getattr(settings, 'MOBILE_APP_USER_AGENT_REGEXES', None):
         user_agent = request.META.get('HTTP_USER_AGENT')
         if user_agent:
             for user_agent_regex in settings.MOBILE_APP_USER_AGENT_REGEXES:
                 if re.search(user_agent_regex, user_agent):
                     return True
-
-    return False
-
-
-PATHS_ACCESSED_BY_MOBILE_WITH_SESSION_COOKIES = [
-    r'^/xblock/{usage_key_string}$'.format(usage_key_string=settings.USAGE_KEY_PATTERN),
-]
-
-
-def is_request_from_mobile_web_view(request):
-    """
-    Returns whether the given request was made by an open edX mobile web
-    view using a session cookie.
-
-    Args:
-        request (HttpRequest)
-    """
-
-    # TODO (MA-1825): This is a TEMPORARY HACK until all of the version 2.0
-    # iOS mobile apps have updated.  The earlier versions didn't update their
-    # user agents so we are checking for the specific URLs that are
-    # accessed through the mobile web view.
-    for mobile_path in PATHS_ACCESSED_BY_MOBILE_WITH_SESSION_COOKIES:
-        if re.match(mobile_path, request.path):
-            return True
 
     return False

--- a/openedx/features/personalized_learner_schedules/call_to_action.py
+++ b/openedx/features/personalized_learner_schedules/call_to_action.py
@@ -1,7 +1,11 @@
 import logging
 
+from crum import get_current_request
 from django.urls import reverse
 from django.utils.translation import gettext as _
+
+from lms.djangoapps.course_home_api.utils import is_request_from_learning_mfe
+from openedx.core.lib.mobile_utils import is_request_from_mobile_app
 
 log = logging.getLogger(__name__)
 
@@ -34,6 +38,13 @@ class PersonalizedLearnerScheduleCallToAction:
         }]
         """
         ctas = []
+
+        # Some checks to disable PLS calls to action until these environments (mobile and MFE) support them natively
+        request = get_current_request()
+        is_mobile_app = request and is_request_from_mobile_app(request)
+        is_learning_mfe = request and is_request_from_learning_mfe(request)
+        if is_mobile_app or is_learning_mfe:
+            return []
 
         if category == self.CAPA_SUBMIT_DISABLED:
             # xblock is a capa problem, and the submit button is disabled. Check if it's because of a personalized


### PR DESCRIPTION
- Hide the submit-button CTA link to reset dates in the mobile app. They are working on their own solution.
- Don't show the dates_banner.html code in the courseware. It has new CTA banner support with updated wording.