### PR TITLE
[BD-18] Disable django debug toolbar when running e2e tests

### DIFF
--- a/cms/envs/devstack.py
+++ b/cms/envs/devstack.py
@@ -108,7 +108,8 @@ DEBUG_TOOLBAR_CONFIG = {
 
 def should_show_debug_toolbar(request):
     # We always want the toolbar on devstack unless running tests from another Docker container
-    if request.get_host().startswith('edx.devstack.studio:'):
+    hostname = request.get_host()
+    if hostname.startswith('edx.devstack.studio:') or hostname.startswith('studio.devstack.edx:'):
         return False
     return True
 

--- a/lms/envs/devstack.py
+++ b/lms/envs/devstack.py
@@ -105,7 +105,8 @@ DEBUG_TOOLBAR_CONFIG = {
 
 def should_show_debug_toolbar(request):
     # We always want the toolbar on devstack unless running tests from another Docker container
-    if request.get_host().startswith('edx.devstack.lms:'):
+    hostname = request.get_host()
+    if hostname.startswith('edx.devstack.lms:') or hostname.startswith('lms.devstack.edx:'):
         return False
     return True
 


### PR DESCRIPTION
Changes to disable django debug toolbar when running e2e tests on devstack.