### PR TITLE
Update password reset subsite logo and show contact mailing address c…

### DIFF
--- a/openedx/core/djangoapps/ace_common/template_context.py
+++ b/openedx/core/djangoapps/ace_common/template_context.py
@@ -22,11 +22,15 @@ def get_base_template_context(site):
     except NoReverseMatch:
         dashboard_url = reverse('home')
 
+    logo_image_url = None
+    if settings.ENABLE_COMPREHENSIVE_THEMING:
+        logo_image_url = branding_api.get_logo_url()
+
     return {
         # Platform information
         'homepage_url': marketing_link('ROOT'),
         'dashboard_url': dashboard_url,
-        'logo_image_url': branding_api.get_logo_url(),
+        'logo_image_url': logo_image_url,
         'template_revision': getattr(settings, 'EDX_PLATFORM_REVISION', None),
         'platform_name': get_config_value_from_site_or_settings(
             'PLATFORM_NAME',

--- a/openedx/core/djangoapps/ace_common/template_context.py
+++ b/openedx/core/djangoapps/ace_common/template_context.py
@@ -7,6 +7,7 @@ from django.conf import settings
 from django.urls import NoReverseMatch, reverse
 
 from edxmako.shortcuts import marketing_link
+from branding import api as branding_api
 from openedx.core.djangoapps.theming.helpers import get_config_value_from_site_or_settings
 
 
@@ -25,6 +26,7 @@ def get_base_template_context(site):
         # Platform information
         'homepage_url': marketing_link('ROOT'),
         'dashboard_url': dashboard_url,
+        'logo_image_url': branding_api.get_logo_url(),
         'template_revision': getattr(settings, 'EDX_PLATFORM_REVISION', None),
         'platform_name': get_config_value_from_site_or_settings(
             'PLATFORM_NAME',

--- a/openedx/core/djangoapps/ace_common/templates/ace_common/edx_ace/common/base_body.html
+++ b/openedx/core/djangoapps/ace_common/templates/ace_common/edx_ace/common/base_body.html
@@ -61,9 +61,15 @@
                 <table role="presentation" width="100%" align="left" border="0" cellpadding="0" cellspacing="0">
                     <tr>
                         <td width="70">
-                            <a href="{% with_link_tracking homepage_url %}"><img
-                                    src="{% with_link_tracking logo_image_url %}" 
-                                    height="50" alt="{% filter force_escape %}{% blocktrans %}Go to {{ platform_name }} Home Page{% endblocktrans %}{% endfilter %}"/></a>
+                            {% if logo_image_url %}
+                                <a href="{% with_link_tracking homepage_url %}"><img
+                                        src="{% with_link_tracking logo_image_url %}" 
+                                        height="50" alt="{% filter force_escape %}{% blocktrans %}Go to {{ platform_name }} Home Page{% endblocktrans %}{% endfilter %}"/></a>
+                            {% else %}
+                                <a href="{% with_link_tracking homepage_url %}"><img
+                                    src="https://media.sailthru.com/595/1k1/8/o/599f355101b3f.png" width="70"
+                                    height="30" alt="{% filter force_escape %}{% blocktrans %}Go to {{ platform_name }} Home Page{% endblocktrans %}{% endfilter %}"/></a>
+                            {% endif %}
                         </td>
                         <td align="right" style="text-align: {{ LANGUAGE_BIDI|yesno:"left,right" }};">
                             <a class="login" href="{% with_link_tracking dashboard_url %}" style="color: #005686;">{%  trans "Sign In" %}</a>

--- a/openedx/core/djangoapps/ace_common/templates/ace_common/edx_ace/common/base_body.html
+++ b/openedx/core/djangoapps/ace_common/templates/ace_common/edx_ace/common/base_body.html
@@ -62,8 +62,8 @@
                     <tr>
                         <td width="70">
                             <a href="{% with_link_tracking homepage_url %}"><img
-                                    src="https://media.sailthru.com/595/1k1/8/o/599f355101b3f.png" width="70"
-                                    height="30" alt="{% filter force_escape %}{% blocktrans %}Go to {{ platform_name }} Home Page{% endblocktrans %}{% endfilter %}"/></a>
+                                    src="{% with_link_tracking logo_image_url %}" 
+                                    height="50" alt="{% filter force_escape %}{% blocktrans %}Go to {{ platform_name }} Home Page{% endblocktrans %}{% endfilter %}"/></a>
                         </td>
                         <td align="right" style="text-align: {{ LANGUAGE_BIDI|yesno:"left,right" }};">
                             <a class="login" href="{% with_link_tracking dashboard_url %}" style="color: #005686;">{%  trans "Sign In" %}</a>
@@ -173,8 +173,10 @@
                         <td>
                             &copy; {% now "Y" %} {{ platform_name }}, {% trans "All rights reserved" as tmsg %}{{ tmsg | force_escape }}.<br/>
                             <br/>
-                            {% trans "Our mailing address is" as tmsg %}{{ tmsg | force_escape }}:<br/>
-                            {{ contact_mailing_address }}
+                            {% if contact_mailing_address %}
+                                {% trans "Our mailing address is" as tmsg %}{{ tmsg | force_escape }}:<br/>
+                                {{ contact_mailing_address }}
+                            {% endif %}
                         </td>
                     </tr>
                     {% if unsubscribe_url %}


### PR DESCRIPTION
@pomegranited @jramnai I created this update to automatically update the comprehensive theming logos within the password reset emails and conditionally show the mailing address if defined in site configuration.

This is in response to https://discuss.openedx.org/t/how-to-change-edx-logo-and-sign-in-link-in-password-reset-email/172. I realize that you could also manually do this through template updates like the `red-theme` does here https://github.com/edx/edx-platform/tree/master/themes/red-theme/lms/templates/ace_common/edx_ace/common, however, I wanted this to be across all subsites without a theme update.

Let me know what you think about this change. The logo width was removed but height was left in be consistent across all subsites. This could change if we update the template pages for `ace_common` mentioned above though.