### PR TITLE
[ENT-3315] Reduce calls to enterprise-learner endpoint by looking up data from db

### DIFF
--- a/lms/templates/header/navbar-logo-header.html
+++ b/lms/templates/header/navbar-logo-header.html
@@ -8,7 +8,6 @@ from django.urls import reverse
 from django.utils.translation import ugettext as _
 from lms.djangoapps.ccx.overrides import get_current_ccx
 from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
-from openedx.features.enterprise_support.api import get_enterprise_learner_data
 from openedx.features.enterprise_support.utils import get_enterprise_learner_generic_name, get_enterprise_learner_portals
 
 # App that handles subdomain specific branding

--- a/openedx/features/enterprise_support/tests/mixins/enterprise.py
+++ b/openedx/features/enterprise_support/tests/mixins/enterprise.py
@@ -142,6 +142,66 @@ class EnterpriseServiceMockMixin(object):
             required=False,
         )
 
+    def get_mock_enterprise_learner_results(
+            self,
+            entitlement_id=1,
+            learner_id=1,
+            enterprise_customer_uuid='cf246b88-d5f6-4908-a522-fc307e0b0c59',
+            enable_audit_enrollment=False,
+    ):
+        """
+        Helper function to format enterprise learner API response.
+        """
+        mock_results = [
+            {
+                'id': learner_id,
+                'enterprise_customer': {
+                    'uuid': enterprise_customer_uuid,
+                    'name': 'TestShib',
+                    'active': True,
+                    'site': {
+                        'domain': 'example.com',
+                        'name': 'example.com'
+                    },
+                    'enable_data_sharing_consent': True,
+                    'enforce_data_sharing_consent': 'at_login',
+                    'enable_audit_enrollment': enable_audit_enrollment,
+                    'branding_configuration': {
+                        'enterprise_customer': enterprise_customer_uuid,
+                        'logo': 'https://open.edx.org/sites/all/themes/edx_open/logo.png'
+                    },
+                    'enterprise_customer_entitlements': [
+                        {
+                            'enterprise_customer': enterprise_customer_uuid,
+                            'entitlement_id': entitlement_id
+                        }
+                    ],
+                    'replace_sensitive_sso_username': True,
+                },
+                'user_id': 5,
+                'user': {
+                    'username': 'verified',
+                    'first_name': '',
+                    'last_name': '',
+                    'email': 'verified@example.com',
+                    'is_staff': True,
+                    'is_active': True,
+                    'date_joined': '2016-09-01T19:18:26.026495Z'
+                },
+                'data_sharing_consent': [
+                    {
+                        "username": "verified",
+                        "enterprise_customer_uuid": enterprise_customer_uuid,
+                        "exists": True,
+                        "course_id": "course-v1:edX DemoX Demo_Course",
+                        "consent_provided": True,
+                        "consent_required": False
+                    }
+                ]
+            }
+        ]
+        return mock_results
+
     def mock_enterprise_learner_api(
             self,
             entitlement_id=1,
@@ -152,58 +212,14 @@ class EnterpriseServiceMockMixin(object):
         """
         Helper function to register enterprise learner API endpoint.
         """
+        results = self.get_mock_enterprise_learner_results(
+            entitlement_id, learner_id, enterprise_customer_uuid, enable_audit_enrollment
+        )
         enterprise_learner_api_response = {
             'count': 1,
             'num_pages': 1,
             'current_page': 1,
-            'results': [
-                {
-                    'id': learner_id,
-                    'enterprise_customer': {
-                        'uuid': enterprise_customer_uuid,
-                        'name': 'TestShib',
-                        'active': True,
-                        'site': {
-                            'domain': 'example.com',
-                            'name': 'example.com'
-                        },
-                        'enable_data_sharing_consent': True,
-                        'enforce_data_sharing_consent': 'at_login',
-                        'enable_audit_enrollment': enable_audit_enrollment,
-                        'branding_configuration': {
-                            'enterprise_customer': enterprise_customer_uuid,
-                            'logo': 'https://open.edx.org/sites/all/themes/edx_open/logo.png'
-                        },
-                        'enterprise_customer_entitlements': [
-                            {
-                                'enterprise_customer': enterprise_customer_uuid,
-                                'entitlement_id': entitlement_id
-                            }
-                        ],
-                        'replace_sensitive_sso_username': True,
-                    },
-                    'user_id': 5,
-                    'user': {
-                        'username': 'verified',
-                        'first_name': '',
-                        'last_name': '',
-                        'email': 'verified@example.com',
-                        'is_staff': True,
-                        'is_active': True,
-                        'date_joined': '2016-09-01T19:18:26.026495Z'
-                    },
-                    'data_sharing_consent': [
-                        {
-                            "username": "verified",
-                            "enterprise_customer_uuid": enterprise_customer_uuid,
-                            "exists": True,
-                            "course_id": "course-v1:edX DemoX Demo_Course",
-                            "consent_provided": True,
-                            "consent_required": False
-                        }
-                    ]
-                }
-            ],
+            'results': results,
             'next': None,
             'start': 0,
             'previous': None

--- a/openedx/features/enterprise_support/tests/test_api.py
+++ b/openedx/features/enterprise_support/tests/test_api.py
@@ -169,11 +169,13 @@ class TestEnterpriseApi(EnterpriseServiceMockMixin, CacheIsolationTestCase):
         self._assert_api_client_with_user(ConsentApiClient, mock_jwt_builder)
 
     @httpretty.activate
-    def test_consent_needed_for_course(self):
+    @mock.patch('openedx.features.enterprise_support.api.get_enterprise_learner_data_from_db')
+    def test_consent_needed_for_course(self, mock_get_enterprise_learner_data):
         user = UserFactory(username='janedoe')
         request = mock.MagicMock(session={}, user=user, site=SiteFactory(domain="example.com"))
         ec_uuid = 'cf246b88-d5f6-4908-a522-fc307e0b0c59'
         course_id = 'fake-course'
+        mock_get_enterprise_learner_data.return_value = self.get_mock_enterprise_learner_results()
         self.mock_enterprise_learner_api()
 
         # test not required consent for example non enterprise customer
@@ -219,7 +221,7 @@ class TestEnterpriseApi(EnterpriseServiceMockMixin, CacheIsolationTestCase):
         self.assertFalse(course_id in consent_required)
 
     @httpretty.activate
-    @mock.patch('openedx.features.enterprise_support.api.get_enterprise_learner_data')
+    @mock.patch('openedx.features.enterprise_support.api.get_enterprise_learner_data_from_db')
     @mock.patch('openedx.features.enterprise_support.api.EnterpriseCustomer')
     @mock.patch('openedx.features.enterprise_support.api.get_partial_pipeline')
     @mock.patch('openedx.features.enterprise_support.api.Registry')


### PR DESCRIPTION
Recently we've (inadvertently) introduced more calls to the enterprise-learner endpoint, and this has contributed to recent production incidents where these network calls were causing request queueing. This PR changes the calls to the enterprise-learner endpoint to querying the database directly to get the same results in-process.

**Test Instructions**
Both of these are known flows that (used to) hit the enterprise learner endpoint downstream.

Link a learner to a test enterprise that has the enterprise learner portal enabled. Log in as that learner and see that the notification banner still shows up. Check the lms logs to see that no calls were made to the enterprise-learner endpoint.

Manually enroll that learner in a course that is in the enterprise's catalog through django admin Manage Learners. Log in as that learner, click to access the course. Observe that the learner is properly directed to data sharing consent, and that no calls to the enterprise-learner endpoint were made in the lms logs.