### PR TITLE
Implement kill-switch for the Learning MFE

### DIFF
--- a/lms/djangoapps/courseware/access_response.py
+++ b/lms/djangoapps/courseware/access_response.py
@@ -236,3 +236,14 @@ class AuthenticationRequiredAccessError(AccessError):
         developer_message = u"User must be authenticated to view the course"
         user_message = _(u"You must be logged in to see this course")
         super(AuthenticationRequiredAccessError, self).__init__(error_code, developer_message, user_message)
+
+
+class CoursewareMicrofrontendDisabledAccessError(AccessError):
+    """
+    Access denied because the courseware micro-frontend is disabled for this user.
+    """
+    def __init__(self):
+        error_code = 'microfrontend_disabled'
+        developer_message = u'Micro-frontend is disabled for this user'
+        user_message = _(u'Please view your course in the existing experience')
+        super(CoursewareMicrofrontendDisabledAccessError, self).__init__(error_code, developer_message, user_message)

--- a/openedx/core/djangoapps/courseware_api/tests/test_views.py
+++ b/openedx/core/djangoapps/courseware_api/tests/test_views.py
@@ -81,7 +81,9 @@ class CourseApiTestViews(BaseCoursewareTests):
         (False, None, ACCESS_GRANTED),
     )
     @ddt.unpack
-    def test_course_metadata(self, logged_in, enrollment_mode, enable_anonymous):
+    @mock.patch('openedx.core.djangoapps.courseware_api.views.CoursewareMeta.is_microfrontend_enabled_for_user')
+    def test_course_metadata(self, logged_in, enrollment_mode, enable_anonymous, is_microfrontend_enabled_for_user):
+        is_microfrontend_enabled_for_user.return_value = True
         check_public_access = mock.Mock()
         check_public_access.return_value = enable_anonymous
         with mock.patch('lms.djangoapps.courseware.access_utils.check_public_access', check_public_access):


### PR DESCRIPTION
by overriding `can_load_courseware` if the MFE is disabled for the user

If the user would be allowed to see the courseware MFE
(`can_load_courseware`), we check whether the MFE is disabled for them,
based on global settings, course settings (mongo courses), or their
particular bucketing in our `ExperimentWaffleFlag`.

If we determine they shouldn’t be allowed to see it, we return a new
`CoursewareMicrofrontendDisabledAccessError` access response, which the
MFE will use to know it should redirect to the old LMS experience.

Fixes: TNL-7362
Co-authored-by: stvn