### PR TITLE
ARCHBOM-1429/ARCHBOM-1366:  add course overrides and computed_status

### DIFF
--- a/openedx/core/djangoapps/waffle_utils/tests/test_views.py
+++ b/openedx/core/djangoapps/waffle_utils/tests/test_views.py
@@ -15,6 +15,9 @@ TEST_WAFFLE_FLAG_NAMESPACE = WaffleFlagNamespace('test')
 TEST_WAFFLE_FLAG = WaffleFlag(TEST_WAFFLE_FLAG_NAMESPACE, 'flag')
 
 
+# TODO: Missing coverage for:
+# - course overrides
+# - computed_status
 class ToggleStateViewTests(TestCase):
 
     def test_success_for_staff(self):


### PR DESCRIPTION
Adds the following additions to the toggle state endpoint:

- course override data from CourseWaffleFlag.
- computed_status for waffle flags (accounting for
course overrides when applicable), and waffle switches.

Note: the waffle switch computed_status will make more
sense when we include WaffleSwitch instances that don't
have any data in the database.

ARCHBOM-1429
ARCHBOM-1366

**Note:** The structure of override data is different that originally documented in [ARCHBOM-1407](https://openedx.atlassian.net/browse/ARCHBOM-1407).

Example output:
```
{
  "waffle_flags": [
    {
      "name": "course_experience.course_outline_page",
      "everyone": "yes",
      "created": "2020-08-13 21:47:12+00:00",
      "modified": "2020-08-13 21:47:27.138121+00:00",
      "course_overrides": [
        {
          "course_id": "course-v1:edX+DemoX+Demo_Course",
          "force": "off",
          "modified": "2020-08-13 21:29:47.873906+00:00",
          "created": "2020-07-30 20:52:58.773446+00:00"
        }
      ],
      "computed_status": "both"
    },
    {
      "name": "grades.writable_gradebook",
      "everyone": "yes",
      "created": "2020-06-23 18:05:40.597510+00:00",
      "modified": "2020-06-23 18:05:40.597527+00:00",
      "computed_status": "on"
    },
    {
      "name": "studio.enable_checklists_quality",
      "everyone": "unknown",
      "note": "A note",
      "created": "2020-06-22 20:59:15+00:00",
      "modified": "2020-08-11 21:22:11.583589+00:00",
      "computed_status": "both"
    }
  ],
  "waffle_switches": [
    {
      "name": "user_authn.update_login_user_error_status_code",
      "is_active": "false",
      "created": "2019-11-21 21:59:06+00:00",
      "modified": "2020-08-13 21:45:05.717497+00:00",
      "computed_status": "off"
    }
  ]
}
```