### PR TITLE
Fix double-wrapped exception in capa/inputtypes.py

### DIFF
--- a/common/lib/capa/capa/inputtypes.py
+++ b/common/lib/capa/capa/inputtypes.py
@@ -258,7 +258,6 @@ class InputTypeBase(object):
             # Something went wrong: add xml to message, but keep the traceback
             msg = u"Error in xml '{x}': {err} ".format(
                 x=etree.tostring(xml), err=text_type(err))
-            msg = Exception(msg)
             six.reraise(Exception, Exception(msg), sys.exc_info()[2])
 
     @classmethod


### PR DESCRIPTION
(accidentally introduced in 07df64eb8cf0e5ab5a63c8ab338838284c22f593 last year)