### PR TITLE
ARCHBOM-1409 - Add django settings toggles to toggles endpoint.

### DIFF
--- a/openedx/core/djangoapps/waffle_utils/urls.py
+++ b/openedx/core/djangoapps/waffle_utils/urls.py
@@ -4,5 +4,5 @@ from django.conf.urls import url
 from openedx.core.djangoapps.waffle_utils.views import ToggleStateView
 
 urlpatterns = [
-    url(r'^state/', ToggleStateView.as_view(), name="toggle_state"),
+    url(r'^v0/state/', ToggleStateView.as_view(), name="toggle_state"),
 ]


### PR DESCRIPTION
https://openedx.atlassian.net/browse/ARCHBOM-1409 

Sample output:
``` 
"django_settings": [
        {
            "name": "STATIC_GRAB",
            "is_active": false
        },
        {
            "name": "DEBUG",
            "is_active": true
        },
        {
            "name": "CELERY_BROKER_USE_SSL",
            "is_active": false
        },
        {
            "name": "SIMPLE_WIKI_REQUIRE_LOGIN_VIEW",
            "is_active": false
        },
        {
            "name": "WIKI_ACCOUNT_HANDLING",
            "is_active": false
        },
        {
            "name": "CELERY_TRACK_STARTED",
            "is_active": true
        },
        {
            "name": "ACE_CHANNEL_SAILTHRU_DEBUG",
            "is_active": true
        },
        {
            "name": "SECURE_BROWSER_XSS_FILTER",
            "is_active": false
        },
        {
            "name": "CELERY_STORE_ERRORS_EVEN_IF_IGNORED",
            "is_active": true
        },
        {
            "name": "GENERATE_PROFILE_SCORES",
            "is_active": false
        },
        {
            "name": "EMAIL_USE_TLS",
            "is_active": false
        },
        {
            "name": "CORS_ORIGIN_ALLOW_ALL",
            "is_active": true
        },
        {
            "name": "SECURE_CONTENT_TYPE_NOSNIFF",
            "is_active": false
        },
        {
            "name": "USE_X_FORWARDED_PORT",
            "is_active": false
        },
        {
            "name": "ENV_TOKENS['CELERY_BROKER_USE_SSL']",
            "is_active": false
        },
        {
            "name": "ENV_TOKENS['ENABLE_COMPREHENSIVE_THEMING']",
            "is_active": false
        },
        {
            "name": "ENV_TOKENS['WIKI_ENABLED']",
            "is_active": true
        },
        {
            "name": "ENV_TOKENS['DEFAULT_MOBILE_AVAILABLE']",
            "is_active": false
        }
]
```