### PR TITLE
add get_team_by_team_id to teams service

### DIFF
--- a/lms/djangoapps/teams/api.py
+++ b/lms/djangoapps/teams/api.py
@@ -51,6 +51,17 @@ ORGANIZATION_PROTECTED_MODES = (
 )
 
 
+def get_team_by_team_id(team_id):
+    """
+    API Function to lookup team object by team_id, which is globally unique.
+    If there is no such team, return None.
+    """
+    try:
+        return CourseTeam.objects.get(team_id=team_id)
+    except CourseTeam.DoesNotExist:
+        return None
+
+
 def get_team_by_discussion(discussion_id):
     """
     This is a function to get team object by the discussion_id passed in.

--- a/lms/djangoapps/teams/services.py
+++ b/lms/djangoapps/teams/services.py
@@ -6,9 +6,14 @@ from django.urls import reverse
 
 class TeamsService(object):
     """ Functions to provide teams functionality to XBlocks"""
+
     def get_team(self, user, course_id, topic_id):
         from . import api
         return api.get_team_for_user_course_topic(user, course_id, topic_id)
+
+    def get_team_by_team_id(self, team_id):
+        from . import api
+        return api.get_team_by_team_id(team_id)
 
     def get_team_detail_url(self, team):
         """ Returns the url to the detail view for the given team """

--- a/lms/djangoapps/teams/tests/test_api.py
+++ b/lms/djangoapps/teams/tests/test_api.py
@@ -102,6 +102,13 @@ class PythonAPITests(SharedModuleStoreTestCase):
         cls.team1a.add_user(cls.user4)
         cls.team2a.add_user(cls.user4)
 
+    def test_get_team_by_team_id_non_existence(self):
+        self.assertIsNone(teams_api.get_team_by_team_id('DO_NOT_EXIST'))
+
+    def test_get_team_by_team_id_exists(self):
+        team = teams_api.get_team_by_team_id(self.team1.team_id)
+        self.assertEqual(team, self.team1)
+
     def test_get_team_by_discussion_non_existence(self):
         self.assertIsNone(teams_api.get_team_by_discussion('DO_NOT_EXIST'))
 

--- a/lms/djangoapps/teams/tests/test_services.py
+++ b/lms/djangoapps/teams/tests/test_services.py
@@ -25,6 +25,13 @@ class TeamsServiceTests(ModuleStoreTestCase):
         CourseEnrollmentFactory.create(user=self.user, course_id=self.course_key)
         self.team.add_user(self.user)
 
+    def test_get_team_by_team_id(self):
+        team = self.service.get_team_by_team_id('NONEXISTANCE')
+        self.assertIsNone(team)
+
+        team = self.service.get_team_by_team_id(self.team.team_id)
+        self.assertEqual(team, self.team)
+
     def test_get_team(self):
         user_team = self.service.get_team(self.user, self.course_key, self.team.topic_id)
         self.assertEqual(user_team, self.team)


### PR DESCRIPTION
This is for https://openedx.atlassian.net/browse/EDUCATOR-5207

Add a function to the Teams Service to look up a team by `team_id` 🎊 

@edx/masters-devs-gta 