### PR TITLE
AA-282 course emails date sync

### DIFF
--- a/openedx/core/djangoapps/schedules/resolvers.py
+++ b/openedx/core/djangoapps/schedules/resolvers.py
@@ -468,7 +468,7 @@ class CourseNextSectionUpdate(PrefixedDebugLoggerMixin, RecipientResolver):
             enrollment = schedule.enrollment
             course = schedule.enrollment.course
             user = enrollment.user
-            start_date = schedule.start_date
+            start_date = max(filter(None, (schedule.start_date, course.start)))
             LOG.info(u'Received a schedule for user {} in course {} for date {}'.format(
                 user.username,
                 self.course_id,


### PR DESCRIPTION
- send course emails to users based on whichever date is later,
  sedule start date or course start date.  This addresses the
  scenario when a user enrolls in a self paced course before it
  has actually started.