### PR TITLE
[PROD-2052] - Fix issue with transcript dropdown.

### DIFF
--- a/cms/static/js/views/video/translations_editor.js
+++ b/cms/static/js/views/video/translations_editor.js
@@ -133,7 +133,7 @@ function($, _, HtmlUtils, TranscriptUtils, AbstractEditor, ViewUtils, FileUpload
                     value: value,
                     url: self.model.get('urlRoot')
                 }));
-                HtmlUtils.append($html, dropdown.clone().val(newLang));
+                HtmlUtils.prepend($html, HtmlUtils.HTML(dropdown.clone().val(newLang)));
                 frag.appendChild($html[0]);
             });
 


### PR DESCRIPTION
### [PROD-2052](https://openedx.atlassian.net/browse/PROD-2052)

### Description
#### Partners unable to upload transcripts in alternate languages.
This issue blocks course teams from uploading a full set of transcripts (needed for accessibility) or easily manipulating existing ones.  I believe it is a general platform issue.
We've had three partners report this issue since 6:00 PM EST, 8/12. 

##### To reproduce: 
1. Create a video component in Studio. 
2. Click Edit -> Advanced --> Transcript Languages +Add

##### Expect 
A drop-down menu with a list of languages appears. After selecting language, an "upload" popup appears where one can upload a file.

##### Observe
No menu appears, unexpected text [Object object] appears on screen. User is blocked from adding transcript.