### PR TITLE
[BD-14] BlockLimitReachedError should returns a 400 response instead of 500

### DIFF
--- a/openedx/core/djangoapps/content_libraries/tests/test_content_libraries.py
+++ b/openedx/core/djangoapps/content_libraries/tests/test_content_libraries.py
@@ -454,8 +454,6 @@ class ContentLibrariesTest(ContentLibrariesRestApiTest):
             lib_id = lib["id"]
             block_data = self._add_block_to_library(lib_id, "unit", "unit1")
             # Second block should throw error
-            with self.assertRaises(BlockLimitReachedError):
-                self._add_block_to_library(lib_id, "problem", "problem1")
+            self._add_block_to_library(lib_id, "problem", "problem1", expect_response=400)
             # Also check that limit applies to child blocks too
-            with self.assertRaises(BlockLimitReachedError):
-                self._add_block_to_library(lib_id, "html", "html1", parent_block=block_data["id"])
+            self._add_block_to_library(lib_id, "html", "html1", parent_block=block_data['id'], expect_response=400)

--- a/openedx/core/djangoapps/content_libraries/views.py
+++ b/openedx/core/djangoapps/content_libraries/views.py
@@ -58,6 +58,9 @@ def convert_exceptions(fn):
         except api.InvalidNameError as exc:
             log.exception(str(exc))
             raise ValidationError(str(exc))
+        except api.BlockLimitReachedError as exc:
+            log.exception(str(exc))
+            raise ValidationError(str(exc))
     return wrapped_fn
 
 


### PR DESCRIPTION
Exceeding library limits returns an opaque 500 Server Error - convert it into a 400 error which can be read by the API clients.

**JIRA Ticket:** [BLENDED-551](https://openedx.atlassian.net/browse/BLENDED-551), [Opencraft/SE-3078](https://tasks.opencraft.com/browse/SE-3078)

**Testing instructions:**

This PR changes a blockstore based API, which is not part of the devstack yet. To test this:
- From the blockstore directory, run `make testserver` to start a test-specific instance. 
- From `make studio-shell` run: `EDXAPP_RUN_BLOCKSTORE_TESTS=1 python -Wd -m pytest --ds=cms.envs.test openedx/core/djangoapps/content_libraries/tests/ cms/djangoapps/contentstore/views/tests/`

**Reviewers**
- [ ] @arbrandes  
- [ ] edX reviewer[s]