### PR TITLE
Extend expiration of  DEPRECATE_OLD_COURSE_KEYS_IN_STUDIO toggle

### DIFF
--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -400,7 +400,7 @@ FEATURES = {
     # .. toggle_category: n/a
     # .. toggle_use_cases: incremental_release
     # .. toggle_creation_date: 2020-06-12
-    # .. toggle_expiration_date: 2020-09-01
+    # .. toggle_expiration_date: 2020-12-01
     # .. toggle_warnings: This can be removed once support is removed for deprecated course keys.
     # .. toggle_tickets: https://openedx.atlassian.net/browse/DEPR-58
     # .. toggle_status: supported


### PR DESCRIPTION
This PR just extends the expiration of the *feature toggle* controlling the deprecation message to Dec 1. We want the feature toggle to exist until the latest end-of-support date for old courses, which is Dec 1 (Edge).

The other two PRs are where we actually set the feature toggles the their new value.

cc @marcotuts 
https://openedx.atlassian.net/browse/TNL-7423

**All PRs:**
* https://github.com/edx/edx-platform/pull/24804
* https://github.com/edx/edx-internal/pull/2862
* https://github.com/edx/edge-internal/pull/254