### PR TITLE
Devstack: Allow login redirection from LMS to several MFEs

### DIFF
--- a/lms/envs/devstack.py
+++ b/lms/envs/devstack.py
@@ -275,8 +275,20 @@ CORS_ALLOW_HEADERS = corsheaders_default_headers + (
 
 LOGIN_REDIRECT_WHITELIST = [
     CMS_BASE,
-    ENTERPRISE_LEARNER_PORTAL_NETLOC,
-    ENTERPRISE_ADMIN_PORTAL_NETLOC,
+    # Allow redirection to all micro-frontends.
+    # Please add your MFE if is not already listed here.
+    # Note: For this to work, the MFE must set BASE_URL in its .env.development to:
+    #   BASE_URL=http://localhost:$PORT
+    # as opposed to:
+    #   BASE_URL=localhost:$PORT
+    'localhost:1976',  # frontend-app-program-console
+    'localhost:1994',  # frontend-app-gradebook
+    'localhost:2000',  # frontend-app-learning
+    'localhost:2001',  # frontend-app-course-authoring
+    'localhost:3001',  # frontend-app-library-authoring
+    'localhost:18400',  # frontend-app-publisher
+    ENTERPRISE_LEARNER_PORTAL_NETLOC,  # frontend-app-learner-portal-enterprise
+    ENTERPRISE_ADMIN_PORTAL_NETLOC,  # frontend-app-admin-portal
 ]
 
 ###################### JWTs ######################


### PR DESCRIPTION
Currently, when you try to log in to an MFE in Devstack, the log in succeeds but it refuses to redirect you back to the MFE. If you navigate to the MFE after logging in, you will see that you have been logged in, but it's annoying and is inconsistent from the Production experience.

There are two reasons it fails currently:
1. The MFEs are not in the `LOGIN_REDIRECT_WHITELIST`. This PR fixes that for all MFEs in Devstack (because I can easily find their port numbers :). Owners of other MFEs can feel free to add themselves to this list.
2. The MFEs have their `BASE_URL` set without the protocol (e.g. `localhost:1994` instead of `http://localhost:1994`) causing them to parse incorrectly in our confirm-redirect-is-safe logic. I have PRs to fix that issue for a few repos:
   * https://github.com/edx/frontend-template-application/pull/268
   * https://github.com/edx/frontend-app-library-authoring/pull/6
   * https://github.com/edx/frontend-app-learning/pull/189
   * https://github.com/edx/frontend-platform/pull/104