### PR TITLE
[BD-21] Document feature toggles

### DIFF
--- a/cms/djangoapps/contentstore/config/waffle.py
+++ b/cms/djangoapps/contentstore/config/waffle.py
@@ -50,7 +50,6 @@ SHOW_REVIEW_RULES_FLAG = CourseWaffleFlag(
 # .. toggle_implementation: WaffleFlag
 # .. toggle_default: False
 # .. toggle_description: Toggles the new micro-frontend-based implementation of the library authoring experience.
-# .. toggle_category: micro-frontend
 # .. toggle_use_cases: incremental_release, open_edx
 # .. toggle_creation_date: 2020-08-03
 # .. toggle_expiration_date: 2020-12-31

--- a/cms/djangoapps/contentstore/config/waffle.py
+++ b/cms/djangoapps/contentstore/config/waffle.py
@@ -50,7 +50,7 @@ SHOW_REVIEW_RULES_FLAG = CourseWaffleFlag(
 # .. toggle_implementation: WaffleFlag
 # .. toggle_default: False
 # .. toggle_description: Toggles the new micro-frontend-based implementation of the library authoring experience.
-# .. toggle_use_cases: incremental_release, open_edx
+# .. toggle_use_cases: temporary, open_edx
 # .. toggle_creation_date: 2020-08-03
 # .. toggle_target_removal_date: 2020-12-31
 # .. toggle_warnings: Also set settings.LIBRARY_AUTHORING_MICROFRONTEND_URL and ENABLE_LIBRARY_AUTHORING_MICROFRONTEND.

--- a/cms/djangoapps/contentstore/config/waffle.py
+++ b/cms/djangoapps/contentstore/config/waffle.py
@@ -55,7 +55,6 @@ SHOW_REVIEW_RULES_FLAG = CourseWaffleFlag(
 # .. toggle_expiration_date: 2020-12-31
 # .. toggle_warnings: Also set settings.LIBRARY_AUTHORING_MICROFRONTEND_URL and ENABLE_LIBRARY_AUTHORING_MICROFRONTEND.
 # .. toggle_tickets: https://openedx.atlassian.net/wiki/spaces/COMM/pages/1545011241/BD-14+Blockstore+Powered+Content+Libraries+Taxonomies
-# .. toggle_status: supported
 REDIRECT_TO_LIBRARY_AUTHORING_MICROFRONTEND = WaffleFlag(
     waffle_namespace=waffle_flags(),
     flag_name='library_authoring_mfe',

--- a/cms/djangoapps/contentstore/config/waffle.py
+++ b/cms/djangoapps/contentstore/config/waffle.py
@@ -52,7 +52,7 @@ SHOW_REVIEW_RULES_FLAG = CourseWaffleFlag(
 # .. toggle_description: Toggles the new micro-frontend-based implementation of the library authoring experience.
 # .. toggle_use_cases: incremental_release, open_edx
 # .. toggle_creation_date: 2020-08-03
-# .. toggle_expiration_date: 2020-12-31
+# .. toggle_target_removal_date: 2020-12-31
 # .. toggle_warnings: Also set settings.LIBRARY_AUTHORING_MICROFRONTEND_URL and ENABLE_LIBRARY_AUTHORING_MICROFRONTEND.
 # .. toggle_tickets: https://openedx.atlassian.net/wiki/spaces/COMM/pages/1545011241/BD-14+Blockstore+Powered+Content+Libraries+Taxonomies
 REDIRECT_TO_LIBRARY_AUTHORING_MICROFRONTEND = WaffleFlag(

--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -339,7 +339,6 @@ FEATURES = {
     # .. toggle_default: False
     # .. toggle_description: Set to True to enable changing a user password through django admin. This is disabled by
     #   default because enabling allows a method to bypass password policy.
-    # .. toggle_category: admin
     # .. toggle_use_cases: open_edx
     # .. toggle_creation_date: 2020-02-21
     # .. toggle_expiration_date: None
@@ -354,7 +353,6 @@ FEATURES = {
     # .. toggle_implementation: DjangoSetting
     # .. toggle_default: False
     # .. toggle_description: Set to True to enable team-based ORA submissions.
-    # .. toggle_category: ora
     # .. toggle_use_cases: incremental_release
     # .. toggle_creation_date: 2020-03-03
     # .. toggle_expiration_date: None
@@ -369,7 +367,6 @@ FEATURES = {
     # .. toggle_description: A "work-around" feature toggle meant to help in cases where some file uploads are not
     #   discoverable. If enabled, will iterate through all possible file key suffixes up to the max for displaying file
     #   metadata in staff assessments.
-    # .. toggle_category: ora
     # .. toggle_use_cases: graceful_degradation
     # .. toggle_creation_date: 2020-03-03
     # .. toggle_expiration_date: None
@@ -383,7 +380,6 @@ FEATURES = {
     # .. toggle_default: False
     # .. toggle_description: A "work-around" feature toggle meant to help in cases where some file uploads are not
     #   discoverable. If enabled, will pull file metadata from StudentModule.state for display in staff assessments.
-    # .. toggle_category: ora
     # .. toggle_use_cases: graceful_degradation
     # .. toggle_creation_date: 2020-03-03
     # .. toggle_expiration_date: None
@@ -400,7 +396,6 @@ FEATURES = {
     #      To disable, set to False.
     #      To enable with a custom support deadline, set to an ISO-8601 date string:
     #        eg: '2020-09-01'
-    # .. toggle_category: n/a
     # .. toggle_use_cases: incremental_release
     # .. toggle_creation_date: 2020-06-12
     # .. toggle_expiration_date: 2020-12-01
@@ -414,7 +409,6 @@ FEATURES = {
     # .. toggle_implementation: DjangoSetting
     # .. toggle_default: False
     # .. toggle_description: Set to True to enable the Library Authoring MFE
-    # .. toggle_category: micro-frontend
     # .. toggle_use_cases: incremental_release
     # .. toggle_creation_date: 2020-06-20
     # .. toggle_expiration_date: 2020-12-31
@@ -2273,7 +2267,6 @@ EDXAPP_PARSE_KEYS = {}
 # .. toggle_implementation: DjangoSetting
 # .. toggle_default: False
 # .. toggle_description: Toggle for removing the deprecated /signin url.
-# .. toggle_category: n/a
 # .. toggle_use_cases: incremental_release
 # .. toggle_creation_date: 2019-12-02
 # .. toggle_expiration_date: 2020-06-01
@@ -2286,7 +2279,6 @@ DISABLE_DEPRECATED_SIGNIN_URL = False
 # .. toggle_implementation: DjangoSetting
 # .. toggle_default: False
 # .. toggle_description: Toggle for removing the deprecated /signup url.
-# .. toggle_category: n/a
 # .. toggle_use_cases: incremental_release
 # .. toggle_creation_date: 2019-12-02
 # .. toggle_expiration_date: 2020-06-01

--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -303,8 +303,6 @@ FEATURES = {
     # Whether or not the dynamic EnrollmentTrackUserPartition should be registered.
     'ENABLE_ENROLLMENT_TRACK_USER_PARTITION': True,
 
-    # Whether to send an email for failed password reset attempts or not. This is mainly useful for notifying users
-    # that they don't have an account associated with email addresses they believe they've registered with.
     'ENABLE_PASSWORD_RESET_FAILURE_EMAIL': False,
 
     # Whether archived courses (courses with end dates in the past) should be

--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -341,9 +341,7 @@ FEATURES = {
     #   default because enabling allows a method to bypass password policy.
     # .. toggle_use_cases: open_edx
     # .. toggle_creation_date: 2020-02-21
-    # .. toggle_target_removal_date: None
     # .. toggle_tickets: 'https://github.com/edx/edx-platform/pull/21616'
-    # .. toggle_warnings: None
     'ENABLE_CHANGE_USER_PASSWORD_ADMIN': False,
 
     ### ORA Feature Flags ###
@@ -352,11 +350,11 @@ FEATURES = {
     # .. toggle_implementation: DjangoSetting
     # .. toggle_default: False
     # .. toggle_description: Set to True to enable team-based ORA submissions.
-    # .. toggle_use_cases: incremental_release
+    # .. toggle_use_cases: temporary
     # .. toggle_creation_date: 2020-03-03
     # .. toggle_target_removal_date: None
     # .. toggle_tickets: https://openedx.atlassian.net/browse/EDUCATOR-4951
-    # .. toggle_warnings: None
+    # .. toggle_warnings: This temporary feature toggle does not have a target removal date.
     'ENABLE_ORA_TEAM_SUBMISSIONS': False,
 
     # .. toggle_name: ENABLE_ORA_ALL_FILE_URLS
@@ -369,7 +367,7 @@ FEATURES = {
     # .. toggle_creation_date: 2020-03-03
     # .. toggle_target_removal_date: None
     # .. toggle_tickets: https://openedx.atlassian.net/browse/EDUCATOR-4951
-    # .. toggle_warnings: None
+    # .. toggle_warnings: This temporary feature toggle does not have a target removal date.
     'ENABLE_ORA_ALL_FILE_URLS': False,
 
     # .. toggle_name: ENABLE_ORA_USER_STATE_UPLOAD_DATA
@@ -381,7 +379,7 @@ FEATURES = {
     # .. toggle_creation_date: 2020-03-03
     # .. toggle_target_removal_date: None
     # .. toggle_tickets: https://openedx.atlassian.net/browse/EDUCATOR-4951
-    # .. toggle_warnings: None
+    # .. toggle_warnings: This temporary feature toggle does not have a target removal date.
     'ENABLE_ORA_USER_STATE_UPLOAD_DATA': False,
 
     # .. toggle_name: DEPRECATE_OLD_COURSE_KEYS_IN_STUDIO
@@ -392,7 +390,7 @@ FEATURES = {
     #      To disable, set to False.
     #      To enable with a custom support deadline, set to an ISO-8601 date string:
     #        eg: '2020-09-01'
-    # .. toggle_use_cases: incremental_release
+    # .. toggle_use_cases: temporary
     # .. toggle_creation_date: 2020-06-12
     # .. toggle_target_removal_date: 2020-12-01
     # .. toggle_warnings: This can be removed once support is removed for deprecated
@@ -404,7 +402,7 @@ FEATURES = {
     # .. toggle_implementation: DjangoSetting
     # .. toggle_default: False
     # .. toggle_description: Set to True to enable the Library Authoring MFE
-    # .. toggle_use_cases: incremental_release
+    # .. toggle_use_cases: temporary
     # .. toggle_creation_date: 2020-06-20
     # .. toggle_target_removal_date: 2020-12-31
     # .. toggle_tickets: https://openedx.atlassian.net/wiki/spaces/COMM/pages/1545011241/BD-14+Blockstore+Powered+Content+Libraries+Taxonomies
@@ -2261,7 +2259,7 @@ EDXAPP_PARSE_KEYS = {}
 # .. toggle_implementation: DjangoSetting
 # .. toggle_default: False
 # .. toggle_description: Toggle for removing the deprecated /signin url.
-# .. toggle_use_cases: incremental_release
+# .. toggle_use_cases: temporary
 # .. toggle_creation_date: 2019-12-02
 # .. toggle_target_removal_date: 2020-06-01
 # .. toggle_warnings: This url can be removed once it no longer has any real traffic.
@@ -2272,7 +2270,7 @@ DISABLE_DEPRECATED_SIGNIN_URL = False
 # .. toggle_implementation: DjangoSetting
 # .. toggle_default: False
 # .. toggle_description: Toggle for removing the deprecated /signup url.
-# .. toggle_use_cases: incremental_release
+# .. toggle_use_cases: temporary
 # .. toggle_creation_date: 2019-12-02
 # .. toggle_target_removal_date: 2020-06-01
 # .. toggle_warnings: This url can be removed once it no longer has any real traffic.

--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -170,9 +170,10 @@ FEATURES = {
     'ENABLE_DISCUSSION_SERVICE': True,
     'ENABLE_TEXTBOOK': True,
 
+    # When True, all courses will be active, regardless of start date
     # DO NOT SET TO True IN THIS FILE
     # Doing so will cause all courses to be released on production
-    'DISABLE_START_DATES': False,  # When True, all courses will be active, regardless of start date
+    'DISABLE_START_DATES': False,
 
     # email address for studio staff (eg to request course creation)
     'STUDIO_REQUEST_EMAIL': '',

--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -343,7 +343,6 @@ FEATURES = {
     # .. toggle_creation_date: 2020-02-21
     # .. toggle_expiration_date: None
     # .. toggle_tickets: 'https://github.com/edx/edx-platform/pull/21616'
-    # .. toggle_status: supported
     # .. toggle_warnings: None
     'ENABLE_CHANGE_USER_PASSWORD_ADMIN': False,
 
@@ -357,7 +356,6 @@ FEATURES = {
     # .. toggle_creation_date: 2020-03-03
     # .. toggle_expiration_date: None
     # .. toggle_tickets: https://openedx.atlassian.net/browse/EDUCATOR-4951
-    # .. toggle_status: supported
     # .. toggle_warnings: None
     'ENABLE_ORA_TEAM_SUBMISSIONS': False,
 
@@ -371,7 +369,6 @@ FEATURES = {
     # .. toggle_creation_date: 2020-03-03
     # .. toggle_expiration_date: None
     # .. toggle_tickets: https://openedx.atlassian.net/browse/EDUCATOR-4951
-    # .. toggle_status: supported
     # .. toggle_warnings: None
     'ENABLE_ORA_ALL_FILE_URLS': False,
 
@@ -384,7 +381,6 @@ FEATURES = {
     # .. toggle_creation_date: 2020-03-03
     # .. toggle_expiration_date: None
     # .. toggle_tickets: https://openedx.atlassian.net/browse/EDUCATOR-4951
-    # .. toggle_status: supported
     # .. toggle_warnings: None
     'ENABLE_ORA_USER_STATE_UPLOAD_DATA': False,
 
@@ -402,7 +398,6 @@ FEATURES = {
     # .. toggle_warnings: This can be removed once support is removed for deprecated
     #   course keys.
     # .. toggle_tickets: https://openedx.atlassian.net/browse/DEPR-58
-    # .. toggle_status: supported
     'DEPRECATE_OLD_COURSE_KEYS_IN_STUDIO': True,
 
     # .. toggle_name: ENABLE_LIBRARY_AUTHORING_MICROFRONTEND
@@ -413,7 +408,6 @@ FEATURES = {
     # .. toggle_creation_date: 2020-06-20
     # .. toggle_expiration_date: 2020-12-31
     # .. toggle_tickets: https://openedx.atlassian.net/wiki/spaces/COMM/pages/1545011241/BD-14+Blockstore+Powered+Content+Libraries+Taxonomies
-    # .. toggle_status: supported
     # .. toggle_warnings: Also set settings.LIBRARY_AUTHORING_MICROFRONTEND_URL and see
     #   REDIRECT_TO_LIBRARY_AUTHORING_MICROFRONTEND for rollout.
     'ENABLE_LIBRARY_AUTHORING_MICROFRONTEND': False,
@@ -2272,7 +2266,6 @@ EDXAPP_PARSE_KEYS = {}
 # .. toggle_expiration_date: 2020-06-01
 # .. toggle_warnings: This url can be removed once it no longer has any real traffic.
 # .. toggle_tickets: ARCH-1253
-# .. toggle_status: supported
 DISABLE_DEPRECATED_SIGNIN_URL = False
 
 # .. toggle_name: DISABLE_DEPRECATED_SIGNUP_URL
@@ -2284,7 +2277,6 @@ DISABLE_DEPRECATED_SIGNIN_URL = False
 # .. toggle_expiration_date: 2020-06-01
 # .. toggle_warnings: This url can be removed once it no longer has any real traffic.
 # .. toggle_tickets: ARCH-1253
-# .. toggle_status: supported
 DISABLE_DEPRECATED_SIGNUP_URL = False
 
 ##### LOGISTRATION RATE LIMIT SETTINGS #####

--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -341,7 +341,7 @@ FEATURES = {
     #   default because enabling allows a method to bypass password policy.
     # .. toggle_use_cases: open_edx
     # .. toggle_creation_date: 2020-02-21
-    # .. toggle_expiration_date: None
+    # .. toggle_target_removal_date: None
     # .. toggle_tickets: 'https://github.com/edx/edx-platform/pull/21616'
     # .. toggle_warnings: None
     'ENABLE_CHANGE_USER_PASSWORD_ADMIN': False,
@@ -354,7 +354,7 @@ FEATURES = {
     # .. toggle_description: Set to True to enable team-based ORA submissions.
     # .. toggle_use_cases: incremental_release
     # .. toggle_creation_date: 2020-03-03
-    # .. toggle_expiration_date: None
+    # .. toggle_target_removal_date: None
     # .. toggle_tickets: https://openedx.atlassian.net/browse/EDUCATOR-4951
     # .. toggle_warnings: None
     'ENABLE_ORA_TEAM_SUBMISSIONS': False,
@@ -367,7 +367,7 @@ FEATURES = {
     #   metadata in staff assessments.
     # .. toggle_use_cases: temporary
     # .. toggle_creation_date: 2020-03-03
-    # .. toggle_expiration_date: None
+    # .. toggle_target_removal_date: None
     # .. toggle_tickets: https://openedx.atlassian.net/browse/EDUCATOR-4951
     # .. toggle_warnings: None
     'ENABLE_ORA_ALL_FILE_URLS': False,
@@ -379,7 +379,7 @@ FEATURES = {
     #   discoverable. If enabled, will pull file metadata from StudentModule.state for display in staff assessments.
     # .. toggle_use_cases: temporary
     # .. toggle_creation_date: 2020-03-03
-    # .. toggle_expiration_date: None
+    # .. toggle_target_removal_date: None
     # .. toggle_tickets: https://openedx.atlassian.net/browse/EDUCATOR-4951
     # .. toggle_warnings: None
     'ENABLE_ORA_USER_STATE_UPLOAD_DATA': False,
@@ -394,7 +394,7 @@ FEATURES = {
     #        eg: '2020-09-01'
     # .. toggle_use_cases: incremental_release
     # .. toggle_creation_date: 2020-06-12
-    # .. toggle_expiration_date: 2020-12-01
+    # .. toggle_target_removal_date: 2020-12-01
     # .. toggle_warnings: This can be removed once support is removed for deprecated
     #   course keys.
     # .. toggle_tickets: https://openedx.atlassian.net/browse/DEPR-58
@@ -406,7 +406,7 @@ FEATURES = {
     # .. toggle_description: Set to True to enable the Library Authoring MFE
     # .. toggle_use_cases: incremental_release
     # .. toggle_creation_date: 2020-06-20
-    # .. toggle_expiration_date: 2020-12-31
+    # .. toggle_target_removal_date: 2020-12-31
     # .. toggle_tickets: https://openedx.atlassian.net/wiki/spaces/COMM/pages/1545011241/BD-14+Blockstore+Powered+Content+Libraries+Taxonomies
     # .. toggle_warnings: Also set settings.LIBRARY_AUTHORING_MICROFRONTEND_URL and see
     #   REDIRECT_TO_LIBRARY_AUTHORING_MICROFRONTEND for rollout.
@@ -2263,7 +2263,7 @@ EDXAPP_PARSE_KEYS = {}
 # .. toggle_description: Toggle for removing the deprecated /signin url.
 # .. toggle_use_cases: incremental_release
 # .. toggle_creation_date: 2019-12-02
-# .. toggle_expiration_date: 2020-06-01
+# .. toggle_target_removal_date: 2020-06-01
 # .. toggle_warnings: This url can be removed once it no longer has any real traffic.
 # .. toggle_tickets: ARCH-1253
 DISABLE_DEPRECATED_SIGNIN_URL = False
@@ -2274,7 +2274,7 @@ DISABLE_DEPRECATED_SIGNIN_URL = False
 # .. toggle_description: Toggle for removing the deprecated /signup url.
 # .. toggle_use_cases: incremental_release
 # .. toggle_creation_date: 2019-12-02
-# .. toggle_expiration_date: 2020-06-01
+# .. toggle_target_removal_date: 2020-06-01
 # .. toggle_warnings: This url can be removed once it no longer has any real traffic.
 # .. toggle_tickets: ARCH-1253
 DISABLE_DEPRECATED_SIGNUP_URL = False

--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -337,7 +337,8 @@ FEATURES = {
     # .. toggle_name: ENABLE_CHANGE_USER_PASSWORD_ADMIN
     # .. toggle_implementation: DjangoSetting
     # .. toggle_default: False
-    # .. toggle_description: Set to True to enable changing a user password through django admin. This is disabled by default because enabling allows a method to bypass password policy.
+    # .. toggle_description: Set to True to enable changing a user password through django admin. This is disabled by
+    #   default because enabling allows a method to bypass password policy.
     # .. toggle_category: admin
     # .. toggle_use_cases: open_edx
     # .. toggle_creation_date: 2020-02-21
@@ -366,8 +367,8 @@ FEATURES = {
     # .. toggle_implementation: DjangoSetting
     # .. toggle_default: False
     # .. toggle_description: A "work-around" feature toggle meant to help in cases where some file uploads are not
-    #      discoverable.  If enabled, will iterate through all possible file key suffixes up to the max for displaying
-    #      file metadata in staff assessments.
+    #   discoverable. If enabled, will iterate through all possible file key suffixes up to the max for displaying file
+    #   metadata in staff assessments.
     # .. toggle_category: ora
     # .. toggle_use_cases: graceful_degradation
     # .. toggle_creation_date: 2020-03-03
@@ -381,7 +382,7 @@ FEATURES = {
     # .. toggle_implementation: DjangoSetting
     # .. toggle_default: False
     # .. toggle_description: A "work-around" feature toggle meant to help in cases where some file uploads are not
-    #      discoverable.  If enabled, will pull file metadata from StudentModule.state for display in staff assessments.
+    #   discoverable. If enabled, will pull file metadata from StudentModule.state for display in staff assessments.
     # .. toggle_category: ora
     # .. toggle_use_cases: graceful_degradation
     # .. toggle_creation_date: 2020-03-03
@@ -403,7 +404,8 @@ FEATURES = {
     # .. toggle_use_cases: incremental_release
     # .. toggle_creation_date: 2020-06-12
     # .. toggle_expiration_date: 2020-12-01
-    # .. toggle_warnings: This can be removed once support is removed for deprecated course keys.
+    # .. toggle_warnings: This can be removed once support is removed for deprecated
+    #   course keys.
     # .. toggle_tickets: https://openedx.atlassian.net/browse/DEPR-58
     # .. toggle_status: supported
     'DEPRECATE_OLD_COURSE_KEYS_IN_STUDIO': True,
@@ -418,7 +420,8 @@ FEATURES = {
     # .. toggle_expiration_date: 2020-12-31
     # .. toggle_tickets: https://openedx.atlassian.net/wiki/spaces/COMM/pages/1545011241/BD-14+Blockstore+Powered+Content+Libraries+Taxonomies
     # .. toggle_status: supported
-    # .. toggle_warnings: Also set settings.LIBRARY_AUTHORING_MICROFRONTEND_URL and see REDIRECT_TO_LIBRARY_AUTHORING_MICROFRONTEND for rollout.
+    # .. toggle_warnings: Also set settings.LIBRARY_AUTHORING_MICROFRONTEND_URL and see
+    #   REDIRECT_TO_LIBRARY_AUTHORING_MICROFRONTEND for rollout.
     'ENABLE_LIBRARY_AUTHORING_MICROFRONTEND': False,
 }
 

--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -367,7 +367,7 @@ FEATURES = {
     # .. toggle_description: A "work-around" feature toggle meant to help in cases where some file uploads are not
     #   discoverable. If enabled, will iterate through all possible file key suffixes up to the max for displaying file
     #   metadata in staff assessments.
-    # .. toggle_use_cases: graceful_degradation
+    # .. toggle_use_cases: temporary
     # .. toggle_creation_date: 2020-03-03
     # .. toggle_expiration_date: None
     # .. toggle_tickets: https://openedx.atlassian.net/browse/EDUCATOR-4951
@@ -380,7 +380,7 @@ FEATURES = {
     # .. toggle_default: False
     # .. toggle_description: A "work-around" feature toggle meant to help in cases where some file uploads are not
     #   discoverable. If enabled, will pull file metadata from StudentModule.state for display in staff assessments.
-    # .. toggle_use_cases: graceful_degradation
+    # .. toggle_use_cases: temporary
     # .. toggle_creation_date: 2020-03-03
     # .. toggle_expiration_date: None
     # .. toggle_tickets: https://openedx.atlassian.net/browse/EDUCATOR-4951

--- a/doc.rst.j2
+++ b/doc.rst.j2
@@ -19,7 +19,6 @@ These are all of our well-documented feature toggles!
 {% if group.toggle_expiration_date != 'None' -%}
 * Expiration date: {{ group.toggle_expiration_date }}
 {% endif -%}
-* Category: {{ group.toggle_category }}
 {% if group.toggle_tickets != 'None' -%}
 * Tickets: {{ group.toggle_tickets }}
 {% endif -%}

--- a/doc.rst.j2
+++ b/doc.rst.j2
@@ -16,8 +16,8 @@ These are all of our well-documented feature toggles!
 {% if group.toggle_warnings != 'None' -%}
 * Warnings: {{ group.toggle_warnings }}
 {% endif -%}
-{% if group.toggle_expiration_date != 'None' -%}
-* Expiration date: {{ group.toggle_expiration_date }}
+{% if group.toggle_target_removal_date != 'None' -%}
+* Expiration date: {{ group.toggle_target_removal_date }}
 {% endif -%}
 {% if group.toggle_tickets != 'None' -%}
 * Tickets: {{ group.toggle_tickets }}

--- a/doc.rst.j2
+++ b/doc.rst.j2
@@ -11,7 +11,6 @@ These are all of our well-documented feature toggles!
 {{ group.toggle_description }}
 
 * Type: {{ group.toggle_type[0] }}
-* Status: {{ group.toggle_status }}
 * Use cases: {{ group.toggle_use_cases|join(", ") }}
 {% if group.toggle_warnings != 'None' -%}
 * Warnings: {{ group.toggle_warnings }}

--- a/lms/djangoapps/bulk_email/models.py
+++ b/lms/djangoapps/bulk_email/models.py
@@ -468,18 +468,6 @@ class CourseAuthorization(models.Model):
         return u"Course '{}': Instructor Email {}Enabled".format(text_type(self.course_id), not_en)
 
 
-# .. toggle_name: require_course_email_auth
-# .. toggle_implementation: ConfigurationModel
-# .. toggle_default: True (enabled)
-# .. toggle_description: If the flag is enabled, course-specific authorization is required, and the course_id is either
-# not provided or not authorixed, the feature is not available.
-# .. toggle_category: bulk email
-# .. toggle_use_cases:  open_edx
-# .. toggle_creation_date: 2016-05-05
-# .. toggle_expiration_date: None
-# .. toggle_warnings: None
-# .. toggle_tickets: None
-# .. toggle_status: supported
 @python_2_unicode_compatible
 class BulkEmailFlag(ConfigurationModel):
     """
@@ -490,6 +478,20 @@ class BulkEmailFlag(ConfigurationModel):
     2. Course-specific authorization not required, or course authorized to use bulk email.
 
     .. no_pii:
+
+    .. toggle_name: require_course_email_auth
+    .. toggle_implementation: ConfigurationModel
+    .. toggle_default: True (enabled)
+    .. toggle_description: If the flag is enabled, course-specific authorization is
+      required, and the course_id is either not provided or not authorized, the feature
+      is not available.
+    .. toggle_category: bulk email
+    .. toggle_use_cases:  open_edx
+    .. toggle_creation_date: 2016-05-05
+    .. toggle_expiration_date: None
+    .. toggle_warnings: None
+    .. toggle_tickets: None
+    .. toggle_status: supported
     """
     # boolean field 'enabled' inherited from parent ConfigurationModel
     require_course_email_auth = models.BooleanField(default=True)

--- a/lms/djangoapps/bulk_email/models.py
+++ b/lms/djangoapps/bulk_email/models.py
@@ -491,7 +491,6 @@ class BulkEmailFlag(ConfigurationModel):
     .. toggle_expiration_date: None
     .. toggle_warnings: None
     .. toggle_tickets: None
-    .. toggle_status: supported
     """
     # boolean field 'enabled' inherited from parent ConfigurationModel
     require_course_email_auth = models.BooleanField(default=True)

--- a/lms/djangoapps/bulk_email/models.py
+++ b/lms/djangoapps/bulk_email/models.py
@@ -488,7 +488,7 @@ class BulkEmailFlag(ConfigurationModel):
     .. toggle_category: bulk email
     .. toggle_use_cases:  open_edx
     .. toggle_creation_date: 2016-05-05
-    .. toggle_expiration_date: None
+    .. toggle_target_removal_date: None
     .. toggle_warnings: None
     .. toggle_tickets: None
     """

--- a/lms/djangoapps/bulk_email/models.py
+++ b/lms/djangoapps/bulk_email/models.py
@@ -485,12 +485,8 @@ class BulkEmailFlag(ConfigurationModel):
     .. toggle_description: If the flag is enabled, course-specific authorization is
       required, and the course_id is either not provided or not authorized, the feature
       is not available.
-    .. toggle_category: bulk email
     .. toggle_use_cases:  open_edx
     .. toggle_creation_date: 2016-05-05
-    .. toggle_target_removal_date: None
-    .. toggle_warnings: None
-    .. toggle_tickets: None
     """
     # boolean field 'enabled' inherited from parent ConfigurationModel
     require_course_email_auth = models.BooleanField(default=True)

--- a/lms/djangoapps/course_api/__init__.py
+++ b/lms/djangoapps/course_api/__init__.py
@@ -5,33 +5,29 @@ from openedx.core.djangoapps.waffle_utils import WaffleSwitch, WaffleSwitchNames
 
 WAFFLE_SWITCH_NAMESPACE = WaffleSwitchNamespace(name='course_list_api_rate_limit')
 
-"""
-.. toggle_name: course_list_api_rate_limit.rate_limit_2
-.. toggle_implementation: WaffleSwitch
-.. toggle_default: False
-.. toggle_description: Waffle switch to enable the throttling of 2 requests/minute to
-  the course API. For staff users, this limit is 10 requests/minute.
-.. toggle_category: course_api
-.. toggle_use_cases: open_edx
-.. toggle_creation_date: 2018-06-12
-.. toggle_expiration_date: None
-.. toggle_warnings: None
-.. toggle_tickets: https://openedx.atlassian.net/browse/LEARNER-5527
-.. toggle_status: supported
-"""
+# .. toggle_name: course_list_api_rate_limit.rate_limit_2
+# .. toggle_implementation: WaffleSwitch
+# .. toggle_default: False
+# .. toggle_description: Waffle switch to enable the throttling of 2 requests/minute to the course API. For staff
+#   users, this limit is 10 requests/minute.
+# .. toggle_category: course_api
+# .. toggle_use_cases: open_edx
+# .. toggle_creation_date: 2018-06-12
+# .. toggle_expiration_date: None
+# .. toggle_warnings: None
+# .. toggle_tickets: https://openedx.atlassian.net/browse/LEARNER-5527
+# .. toggle_status: supported
 USE_RATE_LIMIT_2_FOR_COURSE_LIST_API = WaffleSwitch(WAFFLE_SWITCH_NAMESPACE, 'rate_limit_2', __name__)
-"""
-.. toggle_name: course_list_api_rate_limit.rate_limit_10
-.. toggle_implementation: WaffleSwitch
-.. toggle_default: False
-.. toggle_description: Waffle switch to enable the throttling of 10 requests/minute to
-  the course API. For staff users, this limit is 20 requests/minute.
-.. toggle_category: course_api
-.. toggle_use_cases: open_edx
-.. toggle_creation_date: 2018-06-12
-.. toggle_expiration_date: None
-.. toggle_warnings: None
-.. toggle_tickets: https://openedx.atlassian.net/browse/LEARNER-5527
-.. toggle_status: supported
-"""
+# .. toggle_name: course_list_api_rate_limit.rate_limit_10
+# .. toggle_implementation: WaffleSwitch
+# .. toggle_default: False
+# .. toggle_description: Waffle switch to enable the throttling of 10 requests/minute to the course API. For staff
+#   users, this limit is 20 requests/minute.
+# .. toggle_category: course_api
+# .. toggle_use_cases: open_edx
+# .. toggle_creation_date: 2018-06-12
+# .. toggle_expiration_date: None
+# .. toggle_warnings: None
+# .. toggle_tickets: https://openedx.atlassian.net/browse/LEARNER-5527
+# .. toggle_status: supported
 USE_RATE_LIMIT_10_FOR_COURSE_LIST_API = WaffleSwitch(WAFFLE_SWITCH_NAMESPACE, 'rate_limit_10', __name__)

--- a/lms/djangoapps/course_api/__init__.py
+++ b/lms/djangoapps/course_api/__init__.py
@@ -5,5 +5,33 @@ from openedx.core.djangoapps.waffle_utils import WaffleSwitch, WaffleSwitchNames
 
 WAFFLE_SWITCH_NAMESPACE = WaffleSwitchNamespace(name='course_list_api_rate_limit')
 
+"""
+.. toggle_name: course_list_api_rate_limit.rate_limit_2
+.. toggle_implementation: WaffleSwitch
+.. toggle_default: False
+.. toggle_description: Waffle switch to enable the throttling of 2 requests/minute to
+  the course API. For staff users, this limit is 10 requests/minute.
+.. toggle_category: course_api
+.. toggle_use_cases: open_edx
+.. toggle_creation_date: 2018-06-12
+.. toggle_expiration_date: None
+.. toggle_warnings: None
+.. toggle_tickets: https://openedx.atlassian.net/browse/LEARNER-5527
+.. toggle_status: supported
+"""
 USE_RATE_LIMIT_2_FOR_COURSE_LIST_API = WaffleSwitch(WAFFLE_SWITCH_NAMESPACE, 'rate_limit_2', __name__)
+"""
+.. toggle_name: course_list_api_rate_limit.rate_limit_10
+.. toggle_implementation: WaffleSwitch
+.. toggle_default: False
+.. toggle_description: Waffle switch to enable the throttling of 10 requests/minute to
+  the course API. For staff users, this limit is 20 requests/minute.
+.. toggle_category: course_api
+.. toggle_use_cases: open_edx
+.. toggle_creation_date: 2018-06-12
+.. toggle_expiration_date: None
+.. toggle_warnings: None
+.. toggle_tickets: https://openedx.atlassian.net/browse/LEARNER-5527
+.. toggle_status: supported
+"""
 USE_RATE_LIMIT_10_FOR_COURSE_LIST_API = WaffleSwitch(WAFFLE_SWITCH_NAMESPACE, 'rate_limit_10', __name__)

--- a/lms/djangoapps/course_api/__init__.py
+++ b/lms/djangoapps/course_api/__init__.py
@@ -15,7 +15,6 @@ WAFFLE_SWITCH_NAMESPACE = WaffleSwitchNamespace(name='course_list_api_rate_limit
 # .. toggle_expiration_date: None
 # .. toggle_warnings: None
 # .. toggle_tickets: https://openedx.atlassian.net/browse/LEARNER-5527
-# .. toggle_status: supported
 USE_RATE_LIMIT_2_FOR_COURSE_LIST_API = WaffleSwitch(WAFFLE_SWITCH_NAMESPACE, 'rate_limit_2', __name__)
 # .. toggle_name: course_list_api_rate_limit.rate_limit_10
 # .. toggle_implementation: WaffleSwitch
@@ -27,5 +26,4 @@ USE_RATE_LIMIT_2_FOR_COURSE_LIST_API = WaffleSwitch(WAFFLE_SWITCH_NAMESPACE, 'ra
 # .. toggle_expiration_date: None
 # .. toggle_warnings: None
 # .. toggle_tickets: https://openedx.atlassian.net/browse/LEARNER-5527
-# .. toggle_status: supported
 USE_RATE_LIMIT_10_FOR_COURSE_LIST_API = WaffleSwitch(WAFFLE_SWITCH_NAMESPACE, 'rate_limit_10', __name__)

--- a/lms/djangoapps/course_api/__init__.py
+++ b/lms/djangoapps/course_api/__init__.py
@@ -10,10 +10,8 @@ WAFFLE_SWITCH_NAMESPACE = WaffleSwitchNamespace(name='course_list_api_rate_limit
 # .. toggle_default: False
 # .. toggle_description: Waffle switch to enable the throttling of 2 requests/minute to the course API. For staff
 #   users, this limit is 10 requests/minute.
-# .. toggle_use_cases: open_edx
+# .. toggle_use_cases: circuit_breaker
 # .. toggle_creation_date: 2018-06-12
-# .. toggle_target_removal_date: None
-# .. toggle_warnings: None
 # .. toggle_tickets: https://openedx.atlassian.net/browse/LEARNER-5527
 USE_RATE_LIMIT_2_FOR_COURSE_LIST_API = WaffleSwitch(WAFFLE_SWITCH_NAMESPACE, 'rate_limit_2', __name__)
 # .. toggle_name: course_list_api_rate_limit.rate_limit_10
@@ -21,9 +19,7 @@ USE_RATE_LIMIT_2_FOR_COURSE_LIST_API = WaffleSwitch(WAFFLE_SWITCH_NAMESPACE, 'ra
 # .. toggle_default: False
 # .. toggle_description: Waffle switch to enable the throttling of 10 requests/minute to the course API. For staff
 #   users, this limit is 20 requests/minute.
-# .. toggle_use_cases: open_edx
+# .. toggle_use_cases: circuit_breaker
 # .. toggle_creation_date: 2018-06-12
-# .. toggle_target_removal_date: None
-# .. toggle_warnings: None
 # .. toggle_tickets: https://openedx.atlassian.net/browse/LEARNER-5527
 USE_RATE_LIMIT_10_FOR_COURSE_LIST_API = WaffleSwitch(WAFFLE_SWITCH_NAMESPACE, 'rate_limit_10', __name__)

--- a/lms/djangoapps/course_api/__init__.py
+++ b/lms/djangoapps/course_api/__init__.py
@@ -12,7 +12,7 @@ WAFFLE_SWITCH_NAMESPACE = WaffleSwitchNamespace(name='course_list_api_rate_limit
 #   users, this limit is 10 requests/minute.
 # .. toggle_use_cases: open_edx
 # .. toggle_creation_date: 2018-06-12
-# .. toggle_expiration_date: None
+# .. toggle_target_removal_date: None
 # .. toggle_warnings: None
 # .. toggle_tickets: https://openedx.atlassian.net/browse/LEARNER-5527
 USE_RATE_LIMIT_2_FOR_COURSE_LIST_API = WaffleSwitch(WAFFLE_SWITCH_NAMESPACE, 'rate_limit_2', __name__)
@@ -23,7 +23,7 @@ USE_RATE_LIMIT_2_FOR_COURSE_LIST_API = WaffleSwitch(WAFFLE_SWITCH_NAMESPACE, 'ra
 #   users, this limit is 20 requests/minute.
 # .. toggle_use_cases: open_edx
 # .. toggle_creation_date: 2018-06-12
-# .. toggle_expiration_date: None
+# .. toggle_target_removal_date: None
 # .. toggle_warnings: None
 # .. toggle_tickets: https://openedx.atlassian.net/browse/LEARNER-5527
 USE_RATE_LIMIT_10_FOR_COURSE_LIST_API = WaffleSwitch(WAFFLE_SWITCH_NAMESPACE, 'rate_limit_10', __name__)

--- a/lms/djangoapps/course_api/__init__.py
+++ b/lms/djangoapps/course_api/__init__.py
@@ -10,7 +10,6 @@ WAFFLE_SWITCH_NAMESPACE = WaffleSwitchNamespace(name='course_list_api_rate_limit
 # .. toggle_default: False
 # .. toggle_description: Waffle switch to enable the throttling of 2 requests/minute to the course API. For staff
 #   users, this limit is 10 requests/minute.
-# .. toggle_category: course_api
 # .. toggle_use_cases: open_edx
 # .. toggle_creation_date: 2018-06-12
 # .. toggle_expiration_date: None
@@ -23,7 +22,6 @@ USE_RATE_LIMIT_2_FOR_COURSE_LIST_API = WaffleSwitch(WAFFLE_SWITCH_NAMESPACE, 'ra
 # .. toggle_default: False
 # .. toggle_description: Waffle switch to enable the throttling of 10 requests/minute to the course API. For staff
 #   users, this limit is 20 requests/minute.
-# .. toggle_category: course_api
 # .. toggle_use_cases: open_edx
 # .. toggle_creation_date: 2018-06-12
 # .. toggle_expiration_date: None

--- a/lms/djangoapps/course_api/blocks/toggles.py
+++ b/lms/djangoapps/course_api/blocks/toggles.py
@@ -8,19 +8,17 @@ from openedx.core.djangoapps.waffle_utils import CourseWaffleFlag, WaffleFlag, W
 
 COURSE_BLOCKS_API_NAMESPACE = WaffleFlagNamespace(name=u'course_blocks_api')
 
-"""
-.. toggle_name: course_blocks_api.hide_access_denials
-.. toggle_implementation: WaffleFlag
-.. toggle_default: False
-.. toggle_description: Waffle flag to hide access denial messages in the course blocks.
-.. toggle_category: course api
-.. toggle_use_cases: incremental_release, open_edx
-.. toggle_creation_date: ??
-.. toggle_expiration_date: None
-.. toggle_warnings: None
-.. toggle_tickets: ??
-.. toggle_status: supported
-"""
+# .. toggle_name: course_blocks_api.hide_access_denials
+# .. toggle_implementation: WaffleFlag
+# .. toggle_default: False
+# .. toggle_description: Waffle flag to hide access denial messages in the course blocks.
+# .. toggle_category: course api
+# .. toggle_use_cases: incremental_release, open_edx
+# .. toggle_creation_date: ??
+# .. toggle_expiration_date: None
+# .. toggle_warnings: None
+# .. toggle_tickets: ??
+# .. toggle_status: supported
 HIDE_ACCESS_DENIALS_FLAG = WaffleFlag(
     waffle_namespace=COURSE_BLOCKS_API_NAMESPACE,
     flag_name=u'hide_access_denials',

--- a/lms/djangoapps/course_api/blocks/toggles.py
+++ b/lms/djangoapps/course_api/blocks/toggles.py
@@ -8,18 +8,19 @@ from openedx.core.djangoapps.waffle_utils import CourseWaffleFlag, WaffleFlag, W
 
 COURSE_BLOCKS_API_NAMESPACE = WaffleFlagNamespace(name=u'course_blocks_api')
 
-# Waffle flag to hide access denial message.
-# .. toggle_name: course_blocks_api.hide_access_denials
-# .. toggle_implementation: WaffleFlag
-# .. toggle_default: False
-# .. toggle_description: ??
-# .. toggle_category: course api
-# .. toggle_use_cases: incremental_release, open_edx
-# .. toggle_creation_date: 2019-04-10
-# .. toggle_expiration_date: ??
-# .. toggle_warnings: ??
-# .. toggle_tickets: ??
-# .. toggle_status: ??
+"""
+.. toggle_name: course_blocks_api.hide_access_denials
+.. toggle_implementation: WaffleFlag
+.. toggle_default: False
+.. toggle_description: Waffle flag to hide access denial messages in the course blocks.
+.. toggle_category: course api
+.. toggle_use_cases: incremental_release, open_edx
+.. toggle_creation_date: ??
+.. toggle_expiration_date: None
+.. toggle_warnings: None
+.. toggle_tickets: ??
+.. toggle_status: supported
+"""
 HIDE_ACCESS_DENIALS_FLAG = WaffleFlag(
     waffle_namespace=COURSE_BLOCKS_API_NAMESPACE,
     flag_name=u'hide_access_denials',

--- a/lms/djangoapps/course_api/blocks/toggles.py
+++ b/lms/djangoapps/course_api/blocks/toggles.py
@@ -12,7 +12,6 @@ COURSE_BLOCKS_API_NAMESPACE = WaffleFlagNamespace(name=u'course_blocks_api')
 # .. toggle_implementation: WaffleFlag
 # .. toggle_default: False
 # .. toggle_description: Waffle flag to hide access denial messages in the course blocks.
-# .. toggle_category: course api
 # .. toggle_use_cases: incremental_release, open_edx
 # .. toggle_creation_date: ??
 # .. toggle_expiration_date: None

--- a/lms/djangoapps/course_api/blocks/toggles.py
+++ b/lms/djangoapps/course_api/blocks/toggles.py
@@ -3,7 +3,7 @@ Toggles for Course API.
 """
 
 
-from openedx.core.djangoapps.waffle_utils import CourseWaffleFlag, WaffleFlag, WaffleFlagNamespace
+from openedx.core.djangoapps.waffle_utils import WaffleFlag, WaffleFlagNamespace
 
 
 COURSE_BLOCKS_API_NAMESPACE = WaffleFlagNamespace(name=u'course_blocks_api')
@@ -12,11 +12,8 @@ COURSE_BLOCKS_API_NAMESPACE = WaffleFlagNamespace(name=u'course_blocks_api')
 # .. toggle_implementation: WaffleFlag
 # .. toggle_default: False
 # .. toggle_description: Waffle flag to hide access denial messages in the course blocks.
-# .. toggle_use_cases: incremental_release, open_edx
-# .. toggle_creation_date: ??
-# .. toggle_target_removal_date: None
-# .. toggle_warnings: None
-# .. toggle_tickets: ??
+# .. toggle_use_cases: temporary, open_edx
+# .. toggle_warnings: This temporary feature toggle does not have a target removal date.
 HIDE_ACCESS_DENIALS_FLAG = WaffleFlag(
     waffle_namespace=COURSE_BLOCKS_API_NAMESPACE,
     flag_name=u'hide_access_denials',

--- a/lms/djangoapps/course_api/blocks/toggles.py
+++ b/lms/djangoapps/course_api/blocks/toggles.py
@@ -17,7 +17,6 @@ COURSE_BLOCKS_API_NAMESPACE = WaffleFlagNamespace(name=u'course_blocks_api')
 # .. toggle_expiration_date: None
 # .. toggle_warnings: None
 # .. toggle_tickets: ??
-# .. toggle_status: supported
 HIDE_ACCESS_DENIALS_FLAG = WaffleFlag(
     waffle_namespace=COURSE_BLOCKS_API_NAMESPACE,
     flag_name=u'hide_access_denials',

--- a/lms/djangoapps/course_api/blocks/toggles.py
+++ b/lms/djangoapps/course_api/blocks/toggles.py
@@ -14,7 +14,7 @@ COURSE_BLOCKS_API_NAMESPACE = WaffleFlagNamespace(name=u'course_blocks_api')
 # .. toggle_description: Waffle flag to hide access denial messages in the course blocks.
 # .. toggle_use_cases: incremental_release, open_edx
 # .. toggle_creation_date: ??
-# .. toggle_expiration_date: None
+# .. toggle_target_removal_date: None
 # .. toggle_warnings: None
 # .. toggle_tickets: ??
 HIDE_ACCESS_DENIALS_FLAG = WaffleFlag(

--- a/lms/djangoapps/courseware/toggles.py
+++ b/lms/djangoapps/courseware/toggles.py
@@ -15,7 +15,7 @@ WAFFLE_FLAG_NAMESPACE = WaffleFlagNamespace(name='courseware')
 #   students for a new micro-frontend-based implementation of the courseware page.
 # .. toggle_use_cases: incremental_release, open_edx
 # .. toggle_creation_date: 2020-01-29
-# .. toggle_expiration_date: 2020-12-31
+# .. toggle_target_removal_date: 2020-12-31
 # .. toggle_warnings: Also set settings.LEARNING_MICROFRONTEND_URL and
 #   ENABLE_COURSEWARE_MICROFRONTEND.
 # .. toggle_tickets: TNL-7000
@@ -31,7 +31,7 @@ REDIRECT_TO_COURSEWARE_MICROFRONTEND = ExperimentWaffleFlag(
 #   courseware page.
 # .. toggle_use_cases: incremental_release, open_edx
 # .. toggle_creation_date: 2020-03-09
-# .. toggle_expiration_date: 2020-12-31
+# .. toggle_target_removal_date: 2020-12-31
 # .. toggle_warnings: Also set settings.LEARNING_MICROFRONTEND_URL and
 #   ENABLE_COURSEWARE_MICROFRONTEND.
 # .. toggle_tickets: TNL-6982

--- a/lms/djangoapps/courseware/toggles.py
+++ b/lms/djangoapps/courseware/toggles.py
@@ -19,7 +19,6 @@ WAFFLE_FLAG_NAMESPACE = WaffleFlagNamespace(name='courseware')
 # .. toggle_warnings: Also set settings.LEARNING_MICROFRONTEND_URL and
 #   ENABLE_COURSEWARE_MICROFRONTEND.
 # .. toggle_tickets: TNL-7000
-# .. toggle_status: supported
 REDIRECT_TO_COURSEWARE_MICROFRONTEND = ExperimentWaffleFlag(
     WAFFLE_FLAG_NAMESPACE, 'courseware_mfe', __name__, use_course_aware_bucketing=False
 )
@@ -36,7 +35,6 @@ REDIRECT_TO_COURSEWARE_MICROFRONTEND = ExperimentWaffleFlag(
 # .. toggle_warnings: Also set settings.LEARNING_MICROFRONTEND_URL and
 #   ENABLE_COURSEWARE_MICROFRONTEND.
 # .. toggle_tickets: TNL-6982
-# .. toggle_status: supported
 COURSEWARE_MICROFRONTEND_COURSE_TEAM_PREVIEW = CourseWaffleFlag(
     WAFFLE_FLAG_NAMESPACE, 'microfrontend_course_team_preview', __name__
 )

--- a/lms/djangoapps/courseware/toggles.py
+++ b/lms/djangoapps/courseware/toggles.py
@@ -11,12 +11,14 @@ WAFFLE_FLAG_NAMESPACE = WaffleFlagNamespace(name='courseware')
 # .. toggle_name: courseware.courseware_mfe
 # .. toggle_implementation: ExperimentWaffleFlag
 # .. toggle_default: False
-# .. toggle_description: Waffle flag to redirect to another learner profile experience. Supports staged rollout to students for a new micro-frontend-based implementation of the courseware page.
+# .. toggle_description: Waffle flag to redirect to another learner profile experience. Supports staged rollout to
+#   students for a new micro-frontend-based implementation of the courseware page.
 # .. toggle_category: micro-frontend
 # .. toggle_use_cases: incremental_release, open_edx
 # .. toggle_creation_date: 2020-01-29
 # .. toggle_expiration_date: 2020-12-31
-# .. toggle_warnings: Also set settings.LEARNING_MICROFRONTEND_URL and ENABLE_COURSEWARE_MICROFRONTEND.
+# .. toggle_warnings: Also set settings.LEARNING_MICROFRONTEND_URL and
+#   ENABLE_COURSEWARE_MICROFRONTEND.
 # .. toggle_tickets: TNL-7000
 # .. toggle_status: supported
 REDIRECT_TO_COURSEWARE_MICROFRONTEND = ExperimentWaffleFlag(
@@ -26,12 +28,15 @@ REDIRECT_TO_COURSEWARE_MICROFRONTEND = ExperimentWaffleFlag(
 # .. toggle_name: courseware.microfrontend_course_team_preview
 # .. toggle_implementation: CourseWaffleFlag
 # .. toggle_default: False
-# .. toggle_description: Waffle flag to display a link for the new learner experience to course teams without redirecting students. Supports staged rollout to course teams of a new micro-frontend-based implementation of the courseware page.
+# .. toggle_description: Waffle flag to display a link for the new learner experience to course teams without
+#   redirecting students. Supports staged rollout to course teams of a new micro-frontend-based implementation of the
+#   courseware page.
 # .. toggle_category: micro-frontend
 # .. toggle_use_cases: incremental_release, open_edx
 # .. toggle_creation_date: 2020-03-09
 # .. toggle_expiration_date: 2020-12-31
-# .. toggle_warnings: Also set settings.LEARNING_MICROFRONTEND_URL and ENABLE_COURSEWARE_MICROFRONTEND.
+# .. toggle_warnings: Also set settings.LEARNING_MICROFRONTEND_URL and
+#   ENABLE_COURSEWARE_MICROFRONTEND.
 # .. toggle_tickets: TNL-6982
 # .. toggle_status: supported
 COURSEWARE_MICROFRONTEND_COURSE_TEAM_PREVIEW = CourseWaffleFlag(

--- a/lms/djangoapps/courseware/toggles.py
+++ b/lms/djangoapps/courseware/toggles.py
@@ -13,7 +13,7 @@ WAFFLE_FLAG_NAMESPACE = WaffleFlagNamespace(name='courseware')
 # .. toggle_default: False
 # .. toggle_description: Waffle flag to redirect to another learner profile experience. Supports staged rollout to
 #   students for a new micro-frontend-based implementation of the courseware page.
-# .. toggle_use_cases: incremental_release, open_edx
+# .. toggle_use_cases: temporary, open_edx
 # .. toggle_creation_date: 2020-01-29
 # .. toggle_target_removal_date: 2020-12-31
 # .. toggle_warnings: Also set settings.LEARNING_MICROFRONTEND_URL and
@@ -29,7 +29,7 @@ REDIRECT_TO_COURSEWARE_MICROFRONTEND = ExperimentWaffleFlag(
 # .. toggle_description: Waffle flag to display a link for the new learner experience to course teams without
 #   redirecting students. Supports staged rollout to course teams of a new micro-frontend-based implementation of the
 #   courseware page.
-# .. toggle_use_cases: incremental_release, open_edx
+# .. toggle_use_cases: temporary, open_edx
 # .. toggle_creation_date: 2020-03-09
 # .. toggle_target_removal_date: 2020-12-31
 # .. toggle_warnings: Also set settings.LEARNING_MICROFRONTEND_URL and

--- a/lms/djangoapps/courseware/toggles.py
+++ b/lms/djangoapps/courseware/toggles.py
@@ -13,7 +13,6 @@ WAFFLE_FLAG_NAMESPACE = WaffleFlagNamespace(name='courseware')
 # .. toggle_default: False
 # .. toggle_description: Waffle flag to redirect to another learner profile experience. Supports staged rollout to
 #   students for a new micro-frontend-based implementation of the courseware page.
-# .. toggle_category: micro-frontend
 # .. toggle_use_cases: incremental_release, open_edx
 # .. toggle_creation_date: 2020-01-29
 # .. toggle_expiration_date: 2020-12-31
@@ -31,7 +30,6 @@ REDIRECT_TO_COURSEWARE_MICROFRONTEND = ExperimentWaffleFlag(
 # .. toggle_description: Waffle flag to display a link for the new learner experience to course teams without
 #   redirecting students. Supports staged rollout to course teams of a new micro-frontend-based implementation of the
 #   courseware page.
-# .. toggle_category: micro-frontend
 # .. toggle_use_cases: incremental_release, open_edx
 # .. toggle_creation_date: 2020-03-09
 # .. toggle_expiration_date: 2020-12-31

--- a/lms/djangoapps/courseware/toggles.py
+++ b/lms/djangoapps/courseware/toggles.py
@@ -8,11 +8,10 @@ from openedx.core.djangoapps.waffle_utils import CourseWaffleFlag, WaffleFlagNam
 # Namespace for courseware waffle flags.
 WAFFLE_FLAG_NAMESPACE = WaffleFlagNamespace(name='courseware')
 
-# Waffle flag to redirect to another learner profile experience.
 # .. toggle_name: courseware.courseware_mfe
 # .. toggle_implementation: ExperimentWaffleFlag
 # .. toggle_default: False
-# .. toggle_description: Supports staged rollout to students for a new micro-frontend-based implementation of the courseware page.
+# .. toggle_description: Waffle flag to redirect to another learner profile experience. Supports staged rollout to students for a new micro-frontend-based implementation of the courseware page.
 # .. toggle_category: micro-frontend
 # .. toggle_use_cases: incremental_release, open_edx
 # .. toggle_creation_date: 2020-01-29
@@ -24,12 +23,10 @@ REDIRECT_TO_COURSEWARE_MICROFRONTEND = ExperimentWaffleFlag(
     WAFFLE_FLAG_NAMESPACE, 'courseware_mfe', __name__, use_course_aware_bucketing=False
 )
 
-# Waffle flag to display a link for the new learner experience to course teams without redirecting students.
-#
 # .. toggle_name: courseware.microfrontend_course_team_preview
 # .. toggle_implementation: CourseWaffleFlag
 # .. toggle_default: False
-# .. toggle_description: Supports staged rollout to course teams of a new micro-frontend-based implementation of the courseware page.
+# .. toggle_description: Waffle flag to display a link for the new learner experience to course teams without redirecting students. Supports staged rollout to course teams of a new micro-frontend-based implementation of the courseware page.
 # .. toggle_category: micro-frontend
 # .. toggle_use_cases: incremental_release, open_edx
 # .. toggle_creation_date: 2020-03-09

--- a/lms/djangoapps/discussion/config/settings.py
+++ b/lms/djangoapps/discussion/config/settings.py
@@ -9,7 +9,6 @@ from django.conf import settings
 # .. toggle_description: Settings for forums/discussions to on/off daily digest
 #   feature. Set this to True if you want to enable users to subscribe and unsubscribe
 #   for daily digest. This setting enables deprecation of daily digest.
-# .. toggle_category: discussion
 # .. toggle_use_cases: open_edx
 # .. toggle_creation_date: 2020-03-09
 # .. toggle_expiration_date: None

--- a/lms/djangoapps/discussion/config/settings.py
+++ b/lms/djangoapps/discussion/config/settings.py
@@ -13,7 +13,6 @@ from django.conf import settings
 # .. toggle_creation_date: 2020-03-09
 # .. toggle_expiration_date: None
 # .. toggle_tickets: None
-# .. toggle_status: supported
 # .. toggle_warnings: None
 ENABLE_FORUM_DAILY_DIGEST = 'enable_forum_daily_digest'
 

--- a/lms/djangoapps/discussion/config/settings.py
+++ b/lms/djangoapps/discussion/config/settings.py
@@ -11,7 +11,7 @@ from django.conf import settings
 #   for daily digest. This setting enables deprecation of daily digest.
 # .. toggle_use_cases: open_edx
 # .. toggle_creation_date: 2020-03-09
-# .. toggle_expiration_date: None
+# .. toggle_target_removal_date: None
 # .. toggle_tickets: None
 # .. toggle_warnings: None
 ENABLE_FORUM_DAILY_DIGEST = 'enable_forum_daily_digest'

--- a/lms/djangoapps/discussion/config/settings.py
+++ b/lms/djangoapps/discussion/config/settings.py
@@ -11,9 +11,6 @@ from django.conf import settings
 #   for daily digest. This setting enables deprecation of daily digest.
 # .. toggle_use_cases: open_edx
 # .. toggle_creation_date: 2020-03-09
-# .. toggle_target_removal_date: None
-# .. toggle_tickets: None
-# .. toggle_warnings: None
 ENABLE_FORUM_DAILY_DIGEST = 'enable_forum_daily_digest'
 
 

--- a/lms/djangoapps/discussion/config/settings.py
+++ b/lms/djangoapps/discussion/config/settings.py
@@ -6,7 +6,9 @@ from django.conf import settings
 # .. toggle_name: FEATURES['ENABLE_FORUM_DAILY_DIGEST']
 # .. toggle_implementation: DjangoSetting
 # .. toggle_default: True
-# .. toggle_description: Settings for forums/discussions to on/off daily digest feature. Set this to True if you want to enable users to subscribe and unsubscribe for daily digest. This setting enables deprecation of daily digest.
+# .. toggle_description: Settings for forums/discussions to on/off daily digest
+#   feature. Set this to True if you want to enable users to subscribe and unsubscribe
+#   for daily digest. This setting enables deprecation of daily digest.
 # .. toggle_category: discussion
 # .. toggle_use_cases: open_edx
 # .. toggle_creation_date: 2020-03-09

--- a/lms/djangoapps/experiments/utils.py
+++ b/lms/djangoapps/experiments/utils.py
@@ -40,7 +40,7 @@ experiments_namespace = WaffleFlagNamespace(name=u'experiments')
 # .. toggle_description: Toggle for adding the current course's program information to user metadata
 # .. toggle_use_cases: temporary
 # .. toggle_creation_date: 2019-2-25
-# .. toggle_expiration_date: None
+# .. toggle_target_removal_date: None
 # .. toggle_warnings: None
 # .. toggle_tickets: REVEM-63, REVEM-198
 PROGRAM_INFO_FLAG = WaffleFlag(
@@ -55,7 +55,7 @@ PROGRAM_INFO_FLAG = WaffleFlag(
 # .. toggle_description: Toggle for adding info about each course to the dashboard metadata
 # .. toggle_use_cases: temporary
 # .. toggle_creation_date: 2019-3-28
-# .. toggle_expiration_date: None
+# .. toggle_target_removal_date: None
 # .. toggle_warnings: None
 # .. toggle_tickets: REVEM-118
 DASHBOARD_INFO_FLAG = WaffleFlag(experiments_namespace, u'add_dashboard_info', __name__)
@@ -68,7 +68,7 @@ DASHBOARD_INFO_FLAG = WaffleFlag(experiments_namespace, u'add_dashboard_info', _
 # .. toggle_description: Make sure upsell tracking JS works as expected.
 # .. toggle_use_cases: temporary
 # .. toggle_creation_date: 2020-7-7
-# .. toggle_expiration_date: None
+# .. toggle_target_removal_date: None
 # .. toggle_warnings: None
 # .. toggle_tickets: REV-1205
 UPSELL_TRACKING_FLAG = WaffleFlag(

--- a/lms/djangoapps/experiments/utils.py
+++ b/lms/djangoapps/experiments/utils.py
@@ -38,7 +38,7 @@ experiments_namespace = WaffleFlagNamespace(name=u'experiments')
 # .. toggle_implementation: WaffleFlag
 # .. toggle_default: False
 # .. toggle_description: Toggle for adding the current course's program information to user metadata
-# .. toggle_use_cases: monitored_rollout
+# .. toggle_use_cases: temporary
 # .. toggle_creation_date: 2019-2-25
 # .. toggle_expiration_date: None
 # .. toggle_warnings: None
@@ -54,7 +54,7 @@ PROGRAM_INFO_FLAG = WaffleFlag(
 # .. toggle_implementation: WaffleFlag
 # .. toggle_default: False
 # .. toggle_description: Toggle for adding info about each course to the dashboard metadata
-# .. toggle_use_cases: monitored_rollout
+# .. toggle_use_cases: temporary
 # .. toggle_creation_date: 2019-3-28
 # .. toggle_expiration_date: None
 # .. toggle_warnings: None
@@ -68,7 +68,7 @@ DASHBOARD_INFO_FLAG = WaffleFlag(experiments_namespace, u'add_dashboard_info', _
 # .. toggle_implementation: WaffleFlag
 # .. toggle_default: False
 # .. toggle_description: Make sure upsell tracking JS works as expected.
-# .. toggle_use_cases: monitored_rollout
+# .. toggle_use_cases: temporary
 # .. toggle_creation_date: 2020-7-7
 # .. toggle_expiration_date: None
 # .. toggle_warnings: None

--- a/lms/djangoapps/experiments/utils.py
+++ b/lms/djangoapps/experiments/utils.py
@@ -38,7 +38,6 @@ experiments_namespace = WaffleFlagNamespace(name=u'experiments')
 # .. toggle_implementation: WaffleFlag
 # .. toggle_default: False
 # .. toggle_description: Toggle for adding the current course's program information to user metadata
-# .. toggle_category: experiments
 # .. toggle_use_cases: monitored_rollout
 # .. toggle_creation_date: 2019-2-25
 # .. toggle_expiration_date: None
@@ -55,7 +54,6 @@ PROGRAM_INFO_FLAG = WaffleFlag(
 # .. toggle_implementation: WaffleFlag
 # .. toggle_default: False
 # .. toggle_description: Toggle for adding info about each course to the dashboard metadata
-# .. toggle_category: experiments
 # .. toggle_use_cases: monitored_rollout
 # .. toggle_creation_date: 2019-3-28
 # .. toggle_expiration_date: None
@@ -70,7 +68,6 @@ DASHBOARD_INFO_FLAG = WaffleFlag(experiments_namespace, u'add_dashboard_info', _
 # .. toggle_implementation: WaffleFlag
 # .. toggle_default: False
 # .. toggle_description: Make sure upsell tracking JS works as expected.
-# .. toggle_category: experiments
 # .. toggle_use_cases: monitored_rollout
 # .. toggle_creation_date: 2020-7-7
 # .. toggle_expiration_date: None

--- a/lms/djangoapps/experiments/utils.py
+++ b/lms/djangoapps/experiments/utils.py
@@ -41,8 +41,8 @@ experiments_namespace = WaffleFlagNamespace(name=u'experiments')
 # .. toggle_use_cases: temporary
 # .. toggle_creation_date: 2019-2-25
 # .. toggle_target_removal_date: None
-# .. toggle_warnings: None
 # .. toggle_tickets: REVEM-63, REVEM-198
+# .. toggle_warnings: This temporary feature toggle does not have a target removal date.
 PROGRAM_INFO_FLAG = WaffleFlag(
     waffle_namespace=experiments_namespace,
     flag_name=u'add_programs',
@@ -56,8 +56,8 @@ PROGRAM_INFO_FLAG = WaffleFlag(
 # .. toggle_use_cases: temporary
 # .. toggle_creation_date: 2019-3-28
 # .. toggle_target_removal_date: None
-# .. toggle_warnings: None
 # .. toggle_tickets: REVEM-118
+# .. toggle_warnings: This temporary feature toggle does not have a target removal date.
 DASHBOARD_INFO_FLAG = WaffleFlag(experiments_namespace, u'add_dashboard_info', __name__)
 # TODO END: clean up as part of REVEM-199 (End)
 
@@ -69,8 +69,8 @@ DASHBOARD_INFO_FLAG = WaffleFlag(experiments_namespace, u'add_dashboard_info', _
 # .. toggle_use_cases: temporary
 # .. toggle_creation_date: 2020-7-7
 # .. toggle_target_removal_date: None
-# .. toggle_warnings: None
 # .. toggle_tickets: REV-1205
+# .. toggle_warnings: This temporary feature toggle does not have a target removal date.
 UPSELL_TRACKING_FLAG = WaffleFlag(
     waffle_namespace=experiments_namespace,
     flag_name=u'add_upsell_tracking',

--- a/lms/djangoapps/experiments/utils.py
+++ b/lms/djangoapps/experiments/utils.py
@@ -43,7 +43,6 @@ experiments_namespace = WaffleFlagNamespace(name=u'experiments')
 # .. toggle_expiration_date: None
 # .. toggle_warnings: None
 # .. toggle_tickets: REVEM-63, REVEM-198
-# .. toggle_status: supported
 PROGRAM_INFO_FLAG = WaffleFlag(
     waffle_namespace=experiments_namespace,
     flag_name=u'add_programs',
@@ -59,7 +58,6 @@ PROGRAM_INFO_FLAG = WaffleFlag(
 # .. toggle_expiration_date: None
 # .. toggle_warnings: None
 # .. toggle_tickets: REVEM-118
-# .. toggle_status: supported
 DASHBOARD_INFO_FLAG = WaffleFlag(experiments_namespace, u'add_dashboard_info', __name__)
 # TODO END: clean up as part of REVEM-199 (End)
 
@@ -73,7 +71,6 @@ DASHBOARD_INFO_FLAG = WaffleFlag(experiments_namespace, u'add_dashboard_info', _
 # .. toggle_expiration_date: None
 # .. toggle_warnings: None
 # .. toggle_tickets: REV-1205
-# .. toggle_status: supported
 UPSELL_TRACKING_FLAG = WaffleFlag(
     waffle_namespace=experiments_namespace,
     flag_name=u'add_upsell_tracking',

--- a/lms/djangoapps/experiments/views_custom.py
+++ b/lms/djangoapps/experiments/views_custom.py
@@ -31,17 +31,17 @@ from student.models import CourseEnrollment
 from track import segment
 
 
-# .. feature_toggle_name: experiments.mobile_upsell_rev934
-# .. feature_toggle_type: flag
-# .. feature_toggle_default: False
-# .. feature_toggle_description: Toggle mobile upsell enabled
-# .. feature_toggle_category: experiments
-# .. feature_toggle_use_cases: monitored_rollout
-# .. feature_toggle_creation_date: 2019-09-05
-# .. feature_toggle_expiration_date: None
-# .. feature_toggle_warnings: None
-# .. feature_toggle_tickets: REV-934
-# .. feature_toggle_status: supported
+# .. toggle_name: experiments.mobile_upsell_rev934
+# .. toggle_type: flag
+# .. toggle_default: False
+# .. toggle_description: Toggle mobile upsell enabled
+# .. toggle_category: experiments
+# .. toggle_use_cases: temporary
+# .. toggle_creation_date: 2019-09-05
+# .. toggle_target_removal_date: None
+# .. toggle_warnings: None
+# .. toggle_tickets: REV-934
+# .. toggle_status: supported
 MOBILE_UPSELL_FLAG = WaffleFlag(
     waffle_namespace=WaffleFlagNamespace(name=u'experiments'),
     flag_name=u'mobile_upsell_rev934',

--- a/lms/djangoapps/experiments/views_custom.py
+++ b/lms/djangoapps/experiments/views_custom.py
@@ -35,13 +35,11 @@ from track import segment
 # .. toggle_type: flag
 # .. toggle_default: False
 # .. toggle_description: Toggle mobile upsell enabled
-# .. toggle_category: experiments
 # .. toggle_use_cases: temporary
 # .. toggle_creation_date: 2019-09-05
 # .. toggle_target_removal_date: None
-# .. toggle_warnings: None
 # .. toggle_tickets: REV-934
-# .. toggle_status: supported
+# .. toggle_warnings: This temporary feature toggle does not have a target removal date.
 MOBILE_UPSELL_FLAG = WaffleFlag(
     waffle_namespace=WaffleFlagNamespace(name=u'experiments'),
     flag_name=u'mobile_upsell_rev934',

--- a/lms/djangoapps/grades/api.py
+++ b/lms/djangoapps/grades/api.py
@@ -134,7 +134,7 @@ def undo_override_subsection_grade(user_id, course_key_or_id, usage_key_or_id, f
 
 
 def should_override_grade_on_rejected_exam(course_key_or_id):
-    """Convienence function to return the state of the CourseWaffleFlag REJECTED_EXAM_OVERRIDES_GRADE"""
+    """Convenience function to return the state of the CourseWaffleFlag REJECTED_EXAM_OVERRIDES_GRADE"""
     from .config.waffle import waffle_flags, REJECTED_EXAM_OVERRIDES_GRADE
     course_key = _get_key(course_key_or_id, CourseKey)
     return waffle_flags()[REJECTED_EXAM_OVERRIDES_GRADE].is_enabled(course_key)

--- a/lms/djangoapps/grades/config/models.py
+++ b/lms/djangoapps/grades/config/models.py
@@ -24,6 +24,19 @@ class PersistentGradesEnabledFlag(ConfigurationModel):
     feature to take effect.
 
     .. no_pii:
+
+    .. toggle_name: PersistentGradesEnabledFlag.enabled
+    .. toggle_implementation: ConfigurationModel
+    .. toggle_default: False
+    .. toggle_description: When enabled, grades are persisted. This means that PersistentCourseGrade objects are
+       created for student grades. In order for this to take effect, CoursePersistentGradesFlag objects must also be
+       created individually for each course. Alternatively, the PersistentGradesEnabledFlag.enabled_for_all_courses
+       waffle flag or the PERSISTENT_GRADES_ENABLED_FOR_ALL_TESTS feature flag can be set to True to enable this
+       feature for all courses.
+    .. toggle_use_cases: monitored_rollout
+    .. toggle_creation_date: 2016-08-26
+    .. toggle_tickets: https://github.com/edx/edx-platform/pull/13329
+    .. toggle_status: supported
     """
     # this field overrides course-specific settings to enable the feature for all courses
     enabled_for_all_courses = BooleanField(default=False)

--- a/lms/djangoapps/grades/config/models.py
+++ b/lms/djangoapps/grades/config/models.py
@@ -33,7 +33,7 @@ class PersistentGradesEnabledFlag(ConfigurationModel):
        created individually for each course. Alternatively, the PersistentGradesEnabledFlag.enabled_for_all_courses
        waffle flag or the PERSISTENT_GRADES_ENABLED_FOR_ALL_TESTS feature flag can be set to True to enable this
        feature for all courses.
-    .. toggle_use_cases: monitored_rollout
+    .. toggle_use_cases: temporary
     .. toggle_creation_date: 2016-08-26
     .. toggle_tickets: https://github.com/edx/edx-platform/pull/13329
     .. toggle_status: supported

--- a/lms/djangoapps/grades/config/models.py
+++ b/lms/djangoapps/grades/config/models.py
@@ -36,7 +36,6 @@ class PersistentGradesEnabledFlag(ConfigurationModel):
     .. toggle_use_cases: temporary
     .. toggle_creation_date: 2016-08-26
     .. toggle_tickets: https://github.com/edx/edx-platform/pull/13329
-    .. toggle_status: supported
     """
     # this field overrides course-specific settings to enable the feature for all courses
     enabled_for_all_courses = BooleanField(default=False)

--- a/lms/djangoapps/grades/config/waffle.py
+++ b/lms/djangoapps/grades/config/waffle.py
@@ -10,13 +10,73 @@ from openedx.core.djangoapps.waffle_utils import CourseWaffleFlag, WaffleFlagNam
 WAFFLE_NAMESPACE = u'grades'
 
 # Switches
+
+# .. toggle_name: grades.assume_zero_grade_if_absent
+# .. toggle_implementation: WaffleSwitch
+# .. toggle_default: False
+# .. toggle_description: When enabled, an absent grade is assumed to be zero. Alternatively, defining the
+#   `settings.FEATURES["ASSUME_ZERO_GRADE_IF_ABSENT_FOR_ALL_TESTS"]` feature flag in the LMS will enable this feature
+#   for all courses.
+# .. toggle_use_cases: open_edx
+# .. toggle_creation_date: 2017-04-11
+# .. toggle_tickets: https://github.com/edx/edx-platform/pull/14771
+# .. toggle_status: supported
+# .. toggle_warnings: This requires the PersistentGradesEnabledFlag to be enabled.
 ASSUME_ZERO_GRADE_IF_ABSENT = u'assume_zero_grade_if_absent'
+# .. toggle_name: grades.disable_regrade_on_policy_change
+# .. toggle_implementation: WaffleSwitch
+# .. toggle_default: False
+# .. toggle_description: When enabled, a change in grading policy will not trigger re-grading.
+# .. toggle_use_cases: open_edx
+# .. toggle_creation_date: 2017-08-03
+# .. toggle_tickets: https://github.com/edx/edx-platform/pull/15733
+# .. toggle_status: supported
 DISABLE_REGRADE_ON_POLICY_CHANGE = u'disable_regrade_on_policy_change'
 
 # Course Flags
+
+# .. toggle_name: grades.rejected_exam_overrides_grade
+# .. toggle_implementation: CourseWaffleFlag
+# .. toggle_default: False
+# .. toggle_description: When enabled, a rejected exam will trigger a grade override. Note that this flag is not used
+#   in edx-platform, but only in edx-proctoring.
+# .. toggle_use_cases: open_edx
+# .. toggle_creation_date: 2019-05-29
+# .. toggle_tickets: https://github.com/edx/edx-platform/pull/20719
+# .. toggle_status: supported
 REJECTED_EXAM_OVERRIDES_GRADE = u'rejected_exam_overrides_grade'
+# .. toggle_name: grades.rejected_exam_overrides_grade
+# .. toggle_implementation: CourseWaffleFlag
+# .. toggle_default: False
+# .. toggle_description: When enabled, grades can no longer be updated 30 days after a course has ended. Note that this
+#   is only valid for courses which actually have an end date.
+# .. toggle_use_cases: open_edx
+# .. toggle_creation_date: 2018-10-01
+# .. toggle_tickets: https://github.com/edx/edx-platform/pull/19026
+# .. toggle_status: supported
 ENFORCE_FREEZE_GRADE_AFTER_COURSE_END = u'enforce_freeze_grade_after_course_end'
+
+# .. toggle_name: grades.writable_gradebook
+# .. toggle_implementation: CourseWaffleFlag
+# .. toggle_default: False
+# .. toggle_description: When enabled, add GET/POST endpoints for updating gradebook entries in bulk. Also, a link to
+#   the writable gradebook is added to the instructor dashboard.
+# .. toggle_use_cases: open_edx
+# .. toggle_creation_date: 2018-10-03
+# .. toggle_tickets: https://github.com/edx/edx-platform/pull/19054
+# .. toggle_warnings: Enabling this requires that the `WRITABLE_GRADEBOOK_URL` setting be properly defined.
+# .. toggle_status: supported
 WRITABLE_GRADEBOOK = u'writable_gradebook'
+
+# .. toggle_name: grades.bulk_management
+# .. toggle_implementation: CourseWaffleFlag
+# .. toggle_default: False
+# .. toggle_description: When enabled, bulk features are visible for management in masters course. As far
+#   as we understand, this feature is now unused and obsolete.
+# .. toggle_use_cases: open_edx
+# .. toggle_creation_date: 2019-08-20
+# .. toggle_tickets: https://github.com/edx/edx-platform/pull/21389
+# .. toggle_status: supported
 BULK_MANAGEMENT = u'bulk_management'
 
 

--- a/lms/djangoapps/grades/config/waffle.py
+++ b/lms/djangoapps/grades/config/waffle.py
@@ -20,7 +20,6 @@ WAFFLE_NAMESPACE = u'grades'
 # .. toggle_use_cases: open_edx
 # .. toggle_creation_date: 2017-04-11
 # .. toggle_tickets: https://github.com/edx/edx-platform/pull/14771
-# .. toggle_status: supported
 # .. toggle_warnings: This requires the PersistentGradesEnabledFlag to be enabled.
 ASSUME_ZERO_GRADE_IF_ABSENT = u'assume_zero_grade_if_absent'
 # .. toggle_name: grades.disable_regrade_on_policy_change
@@ -30,7 +29,6 @@ ASSUME_ZERO_GRADE_IF_ABSENT = u'assume_zero_grade_if_absent'
 # .. toggle_use_cases: open_edx
 # .. toggle_creation_date: 2017-08-03
 # .. toggle_tickets: https://github.com/edx/edx-platform/pull/15733
-# .. toggle_status: supported
 DISABLE_REGRADE_ON_POLICY_CHANGE = u'disable_regrade_on_policy_change'
 
 # Course Flags
@@ -43,7 +41,6 @@ DISABLE_REGRADE_ON_POLICY_CHANGE = u'disable_regrade_on_policy_change'
 # .. toggle_use_cases: open_edx
 # .. toggle_creation_date: 2019-05-29
 # .. toggle_tickets: https://github.com/edx/edx-platform/pull/20719
-# .. toggle_status: supported
 REJECTED_EXAM_OVERRIDES_GRADE = u'rejected_exam_overrides_grade'
 # .. toggle_name: grades.rejected_exam_overrides_grade
 # .. toggle_implementation: CourseWaffleFlag
@@ -53,7 +50,6 @@ REJECTED_EXAM_OVERRIDES_GRADE = u'rejected_exam_overrides_grade'
 # .. toggle_use_cases: open_edx
 # .. toggle_creation_date: 2018-10-01
 # .. toggle_tickets: https://github.com/edx/edx-platform/pull/19026
-# .. toggle_status: supported
 ENFORCE_FREEZE_GRADE_AFTER_COURSE_END = u'enforce_freeze_grade_after_course_end'
 
 # .. toggle_name: grades.writable_gradebook
@@ -65,7 +61,6 @@ ENFORCE_FREEZE_GRADE_AFTER_COURSE_END = u'enforce_freeze_grade_after_course_end'
 # .. toggle_creation_date: 2018-10-03
 # .. toggle_tickets: https://github.com/edx/edx-platform/pull/19054
 # .. toggle_warnings: Enabling this requires that the `WRITABLE_GRADEBOOK_URL` setting be properly defined.
-# .. toggle_status: supported
 WRITABLE_GRADEBOOK = u'writable_gradebook'
 
 # .. toggle_name: grades.bulk_management
@@ -76,7 +71,6 @@ WRITABLE_GRADEBOOK = u'writable_gradebook'
 # .. toggle_use_cases: open_edx
 # .. toggle_creation_date: 2019-08-20
 # .. toggle_tickets: https://github.com/edx/edx-platform/pull/21389
-# .. toggle_status: supported
 BULK_MANAGEMENT = u'bulk_management'
 
 

--- a/lms/djangoapps/grades/services.py
+++ b/lms/djangoapps/grades/services.py
@@ -61,5 +61,5 @@ class GradesService(object):
         return api.undo_override_subsection_grade(user_id, course_key_or_id, usage_key_or_id, feature=feature)
 
     def should_override_grade_on_rejected_exam(self, course_key_or_id):
-        """Convienence function to return the state of the CourseWaffleFlag REJECTED_EXAM_OVERRIDES_GRADE"""
+        """Convenience function to return the state of the CourseWaffleFlag REJECTED_EXAM_OVERRIDES_GRADE"""
         return api.should_override_grade_on_rejected_exam(course_key_or_id)

--- a/lms/djangoapps/verify_student/toggles.py
+++ b/lms/djangoapps/verify_student/toggles.py
@@ -15,7 +15,7 @@ WAFFLE_FLAG_NAMESPACE = WaffleFlagNamespace(name='verify_student')
 #   implementation for ID verification.
 # .. toggle_use_cases: incremental_release, open_edx
 # .. toggle_creation_date: 2020-06-25
-# .. toggle_expiration_date: n/a
+# .. toggle_target_removal_date: n/a
 # .. toggle_warnings: n/a
 # .. toggle_tickets: PROD-1639
 USE_NEW_EMAIL_TEMPLATES = WaffleFlag(
@@ -36,7 +36,7 @@ def use_new_templates_for_id_verification_emails():
 # .. toggle_description: Supports staged rollout to students for the new IDV flow.
 # .. toggle_use_cases: incremental_release, open_edx
 # .. toggle_creation_date: 2020-07-09
-# .. toggle_expiration_date: n/a
+# .. toggle_target_removal_date: n/a
 # .. toggle_warnings: n/a
 # .. toggle_tickets: MST-318
 REDIRECT_TO_IDV_MICROFRONTEND = WaffleFlag(

--- a/lms/djangoapps/verify_student/toggles.py
+++ b/lms/djangoapps/verify_student/toggles.py
@@ -13,10 +13,10 @@ WAFFLE_FLAG_NAMESPACE = WaffleFlagNamespace(name='verify_student')
 # .. toggle_default: False
 # .. toggle_description: Supports staged rollout to students for a new email templates
 #   implementation for ID verification.
-# .. toggle_use_cases: incremental_release, open_edx
+# .. toggle_use_cases: temporary, open_edx
 # .. toggle_creation_date: 2020-06-25
-# .. toggle_target_removal_date: n/a
-# .. toggle_warnings: n/a
+# .. toggle_target_removal_date: None
+# .. toggle_warnings: This temporary feature toggle does not have a target removal date.
 # .. toggle_tickets: PROD-1639
 USE_NEW_EMAIL_TEMPLATES = WaffleFlag(
     waffle_namespace=WAFFLE_FLAG_NAMESPACE,
@@ -34,10 +34,10 @@ def use_new_templates_for_id_verification_emails():
 # .. toggle_implementation: WaffleFlag
 # .. toggle_default: False
 # .. toggle_description: Supports staged rollout to students for the new IDV flow.
-# .. toggle_use_cases: incremental_release, open_edx
+# .. toggle_use_cases: temporary, open_edx
 # .. toggle_creation_date: 2020-07-09
-# .. toggle_target_removal_date: n/a
-# .. toggle_warnings: n/a
+# .. toggle_target_removal_date: None
+# .. toggle_warnings: This temporary feature toggle does not have a target removal date.
 # .. toggle_tickets: MST-318
 REDIRECT_TO_IDV_MICROFRONTEND = WaffleFlag(
     waffle_namespace=WAFFLE_FLAG_NAMESPACE,

--- a/lms/djangoapps/verify_student/toggles.py
+++ b/lms/djangoapps/verify_student/toggles.py
@@ -18,7 +18,6 @@ WAFFLE_FLAG_NAMESPACE = WaffleFlagNamespace(name='verify_student')
 # .. toggle_expiration_date: n/a
 # .. toggle_warnings: n/a
 # .. toggle_tickets: PROD-1639
-# .. toggle_status: supported
 USE_NEW_EMAIL_TEMPLATES = WaffleFlag(
     waffle_namespace=WAFFLE_FLAG_NAMESPACE,
     flag_name='use_new_email_templates',
@@ -40,7 +39,6 @@ def use_new_templates_for_id_verification_emails():
 # .. toggle_expiration_date: n/a
 # .. toggle_warnings: n/a
 # .. toggle_tickets: MST-318
-# .. toggle_status: supported
 REDIRECT_TO_IDV_MICROFRONTEND = WaffleFlag(
     waffle_namespace=WAFFLE_FLAG_NAMESPACE,
     flag_name='redirect_to_idv_microfrontend',

--- a/lms/djangoapps/verify_student/toggles.py
+++ b/lms/djangoapps/verify_student/toggles.py
@@ -13,7 +13,6 @@ WAFFLE_FLAG_NAMESPACE = WaffleFlagNamespace(name='verify_student')
 # .. toggle_default: False
 # .. toggle_description: Supports staged rollout to students for a new email templates
 #   implementation for ID verification.
-# .. toggle_category: verify student
 # .. toggle_use_cases: incremental_release, open_edx
 # .. toggle_creation_date: 2020-06-25
 # .. toggle_expiration_date: n/a
@@ -36,7 +35,6 @@ def use_new_templates_for_id_verification_emails():
 # .. toggle_implementation: WaffleFlag
 # .. toggle_default: False
 # .. toggle_description: Supports staged rollout to students for the new IDV flow.
-# .. toggle_category: verify student
 # .. toggle_use_cases: incremental_release, open_edx
 # .. toggle_creation_date: 2020-07-09
 # .. toggle_expiration_date: n/a

--- a/lms/djangoapps/verify_student/toggles.py
+++ b/lms/djangoapps/verify_student/toggles.py
@@ -11,7 +11,8 @@ WAFFLE_FLAG_NAMESPACE = WaffleFlagNamespace(name='verify_student')
 # .. toggle_name: verify_student.use_new_email_templates
 # .. toggle_implementation: WaffleFlag
 # .. toggle_default: False
-# .. toggle_description: Supports staged rollout to students for a new email templates implementation for ID verification.
+# .. toggle_description: Supports staged rollout to students for a new email templates
+#   implementation for ID verification.
 # .. toggle_category: verify student
 # .. toggle_use_cases: incremental_release, open_edx
 # .. toggle_creation_date: 2020-06-25

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -100,42 +100,30 @@ FEATURES = {
     # this should remain off in production until digest notifications are online.
     'ENABLE_DISCUSSION_HOME_PANEL': False,
 
-    """
-    .. toggle_name: ENABLE_DISCUSSION_EMAIL_DIGEST
-    .. toggle_implementation: DjangoSetting
-    .. toggle_default: False
-    .. toggle_description: Set this to True if you want the discussion digest emails
-      enabled automatically for new users. This will be set on all new account
-      registrations.
-    .. toggle_category: admin
-    .. toggle_use_cases: open_edx
-    .. toggle_creation_date: 2014-08-19
-    .. toggle_expiration_date: None
-    .. toggle_warnings: It is not recommended to enable this feature if
-      ENABLE_DISCUSSION_HOME_PANEL is not enabled, since subscribers who receive
-      digests in that case will only be able to unsubscribe via links embedded
-      in their emails, and they will have no way to resubscribe.
-    .. toggle_tickets: https://github.com/edx/edx-platform/pull/4891
-    .. toggle_status: supported
-    """
+    # .. toggle_name: ENABLE_DISCUSSION_EMAIL_DIGEST
+    # .. toggle_implementation: DjangoSetting
+    # .. toggle_default: False
+    # .. toggle_description: Set this to True if you want the discussion digest emails enabled automatically for new users. This will be set on all new account registrations.
+    # .. toggle_category: admin
+    # .. toggle_use_cases: open_edx
+    # .. toggle_creation_date: 2014-08-19
+    # .. toggle_expiration_date: None
+    # .. toggle_warnings: It is not recommended to enable this feature if ENABLE_DISCUSSION_HOME_PANEL is not enabled, since subscribers who receive digests in that case will only be able to unsubscribe via links embedded in their emails, and they will have no way to resubscribe.
+    # .. toggle_tickets: https://github.com/edx/edx-platform/pull/4891
+    # .. toggle_status: supported
     'ENABLE_DISCUSSION_EMAIL_DIGEST': False,
 
-    """
-    .. toggle_name: ENABLE_UNICODE_USERNAME
-    .. toggle_implementation: DjangoSetting
-    .. toggle_default: False
-    .. toggle_description: Set this to True to allow unicode characters in username.
-      Enabling this will also automatically enable SOCIAL_AUTH_CLEAN_USERNAMES. When
-      this is enabled, usernames will have to match the regular expression defined by
-      USERNAME_REGEX_PARTIAL.
-    .. toggle_category: admin
-    .. toggle_use_cases: open_edx
-    .. toggle_creation_date: 2017-06-27
-    .. toggle_expiration_date: None
-    .. toggle_warnings: None
-    .. toggle_tickets: https://github.com/edx/edx-platform/pull/14729
-    .. toggle_status: supported
-    """
+    # toggle_name: ENABLE_UNICODE_USERNAME
+    # toggle_implementation: DjangoSetting
+    # toggle_default: False
+    # toggle_description: Set this to True to allow unicode characters in username. Enabling this will also automatically enable SOCIAL_AUTH_CLEAN_USERNAMES. When this is enabled, usernames will have to match the regular expression defined by USERNAME_REGEX_PARTIAL.
+    # toggle_category: admin
+    # toggle_use_cases: open_edx
+    # toggle_creation_date: 2017-06-27
+    # toggle_expiration_date: None
+    # toggle_warnings: None
+    # toggle_tickets: https://github.com/edx/edx-platform/pull/14729
+    # toggle_status: supported
     'ENABLE_UNICODE_USERNAME': False,
 
     'ENABLE_DJANGO_ADMIN_SITE': True,  # set true to enable django's admin site, even on prod (e.g. for course ops)
@@ -158,20 +146,17 @@ FEATURES = {
 
     'DISABLE_LOGIN_BUTTON': False,  # used in systems where login is automatic, eg MIT SSL
 
-    """
-    .. toggle_name: ENABLE_OAUTH2_PROVIDER
-    .. toggle_implementation: DjangoSetting
-    .. toggle_default: False
-    .. toggle_description: Enable this feature to allow this Open edX platform to be an
-      OAuth2 authentication provider. This is necessary to enable some other features,
-      such as the REST API for the mobile application.
-    .. toggle_category: admin
-    .. toggle_use_cases: monitored_rollout
-    .. toggle_creation_date: 2014-09-09
-    .. toggle_expiration_date: None
-    .. toggle_status: supported
-    .. toggle_warnings: None
-    """
+    # .. toggle_name: ENABLE_OAUTH2_PROVIDER
+    # .. toggle_implementation: DjangoSetting
+    # .. toggle_default: False
+    # .. toggle_description: Enable this feature to allow this Open edX platform to be an OAuth2 authentication
+    #   provider. This is necessary to enable some other features, such as the REST API for the mobile application.
+    # .. toggle_category: admin
+    # .. toggle_use_cases: monitored_rollout
+    # .. toggle_creation_date: 2014-09-09
+    # .. toggle_expiration_date: None
+    # .. toggle_status: supported
+    # .. toggle_warnings: None
     'ENABLE_OAUTH2_PROVIDER': False,
 
     # Allows to enable an API endpoint to serve XBlock view, used for example by external applications.
@@ -239,51 +224,39 @@ FEATURES = {
     # for acceptance and load testing
     'AUTOMATIC_AUTH_FOR_TESTING': False,
 
-    """
-    .. toggle_name: RESTRICT_AUTOMATIC_AUTH
-    .. toggle_implementation: DjangoSetting
-    .. toggle_default: True
-    .. toggle_description: Prevent auto auth from creating superusers or modifying
-    existing users. Auto auth is a mechanism where superusers can simply modify
-    attributes of other users by accessing the "/auto_auth url" with the right
-    querystring parameters.
-    .. toggle_category: admin
-    .. toggle_use_cases: open_edx
-    .. toggle_creation_date: 2018-05-07
-    .. toggle_expiration_date: None
-    .. toggle_tickets: https://openedx.atlassian.net/browse/TE-2545
-    .. toggle_status: supported
-    """
+    # .. toggle_name: RESTRICT_AUTOMATIC_AUTH
+    # .. toggle_implementation: DjangoSetting
+    # .. toggle_default: True
+    # .. toggle_description: Prevent auto auth from creating superusers or modifying existing users. Auto auth is a mechanism where superusers can simply modify attributes of other users by accessing the "/auto_auth url" with the right querystring parameters.
+    # .. toggle_category: admin
+    # .. toggle_use_cases: open_edx
+    # .. toggle_creation_date: 2018-05-07
+    # .. toggle_expiration_date: None
+    # .. toggle_tickets: https://openedx.atlassian.net/browse/TE-2545
+    # .. toggle_status: supported
     'RESTRICT_AUTOMATIC_AUTH': True,
 
-    """
-    .. toggle_name: ENABLE_LOGIN_MICROFRONTEND
-    .. toggle_implementation: DjangoSetting
-    .. toggle_default: False
-    .. toggle_description: Enable the login micro frontend.
-    .. toggle_category: admin
-    .. toggle_use_cases: open_edx
-    .. toggle_creation_date: 2018-05-07
-    .. toggle_expiration_date: None
-    .. toggle_warnings: The login MFE domain name should be listed in
-      LOGIN_REDIRECT_WHITELIST.
-    .. toggle_status: supported
-    """
+    # toggle_name: ENABLE_LOGIN_MICROFRONTEND
+    # toggle_implementation: DjangoSetting
+    # toggle_default: False
+    # toggle_description: Enable the login micro frontend.
+    # toggle_category: admin
+    # toggle_use_cases: open_edx
+    # toggle_creation_date: 2018-05-07
+    # toggle_expiration_date: None
+    # toggle_warnings: The login MFE domain name should be listed in LOGIN_REDIRECT_WHITELIST.
+    # toggle_status: supported
     'ENABLE_LOGIN_MICROFRONTEND': False,
 
-    """
-    .. toggle_name: SKIP_EMAIL_VALIDATION
-    .. toggle_implementation: DjangoSetting
-    .. toggle_default: False
-    .. toggle_description: Turn this on to skip sending emails for user validation.
-      Beware, as this leaves the door open to potential spam abuse.
-    .. toggle_category: admin
-    .. toggle_use_cases: open_edx
-    .. toggle_expiration_date: None
-    .. toggle_warnings: The login MFE domain name should be listed in
-      LOGIN_REDIRECT_WHITELIST.
-    .. toggle_status: supported
-    """
+    # toggle_name: SKIP_EMAIL_VALIDATION
+    # toggle_implementation: DjangoSetting
+    # toggle_default: False
+    # toggle_description: Turn this on to skip sending emails for user validation. Beware, as this leaves the door open to potential spam abuse.
+    # toggle_category: admin
+    # toggle_use_cases: open_edx
+    # toggle_expiration_date: None
+    # toggle_warnings: The login MFE domain name should be listed in LOGIN_REDIRECT_WHITELIST.
+    # toggle_status: supported
     'SKIP_EMAIL_VALIDATION': False,
 
     # Toggle the availability of the shopping cart page
@@ -326,23 +299,16 @@ FEATURES = {
     # defaults, so that we maintain current behavior
     'ALLOW_WIKI_ROOT_ACCESS': True,
 
-    """
-    .. toggle_name: ENABLE_THIRD_PARTY_AUTH
-    .. toggle_implementation: DjangoSetting
-    .. toggle_default: False
-    .. toggle_description: Turn on third-party auth. Disabled for now because full
-      implementations are not yet available. Remember to run
-      migrations if you enable this; we don't create tables by default. This feature
-      can be enabled on a per-site basis. When enabling this feature, remember to
-      define the allowed authentication backends with the AUTHENTICATION_BACKENDS
-      setting.
-    .. toggle_category: admin
-    .. toggle_use_cases: open_edx
-    .. toggle_creation_date: 2014-09-15
-    .. toggle_expiration_date: None
-    .. toggle_status: supported
-    .. toggle_warnings: None
-    """
+    # toggle_name: ENABLE_THIRD_PARTY_AUTH
+    # toggle_implementation: DjangoSetting
+    # toggle_default: False
+    # toggle_description: Turn on third-party auth. Disabled for now because full implementations are not yet available. Remember to run migrations if you enable this; we don't create tables by default. This feature can be enabled on a per-site basis. When enabling this feature, remember to define the allowed authentication backends with the AUTHENTICATION_BACKENDS setting.
+    # toggle_category: admin
+    # toggle_use_cases: open_edx
+    # toggle_creation_date: 2014-09-15
+    # toggle_expiration_date: None
+    # toggle_status: supported
+    # toggle_warnings: None
     'ENABLE_THIRD_PARTY_AUTH': False,
 
     # Toggle to enable alternate urls for marketing links
@@ -365,20 +331,17 @@ FEATURES = {
     # ENABLE_OAUTH2_PROVIDER to True
     'ENABLE_MOBILE_REST_API': False,
 
-    """
-    .. toggle_name: ENABLE_COMBINED_LOGIN_REGISTRATION_FOOTER
-    .. toggle_implementation: DjangoSetting
-    .. toggle_default: False
-    .. toggle_description: Display the standard footer in the login page. This feature
-      can be overridden by a site-specific configuration.
-    .. toggle_category: admin
-    .. toggle_use_cases: open_edx
-    .. toggle_creation_date: 2016-06-24
-    .. toggle_expiration_date: None
-    .. toggle_tickets: https://openedx.atlassian.net/browse/OSPR-1320
-    .. toggle_status: supported
-    .. toggle_warnings: None
-    """
+    # .. toggle_name: ENABLE_COMBINED_LOGIN_REGISTRATION_FOOTER
+    # .. toggle_implementation: DjangoSetting
+    # .. toggle_default: False
+    # .. toggle_description: Display the standard footer in the login page. This feature can be overridden by a site-specific configuration.
+    # .. toggle_category: admin
+    # .. toggle_use_cases: open_edx
+    # .. toggle_creation_date: 2016-06-24
+    # .. toggle_expiration_date: None
+    # .. toggle_tickets: https://openedx.atlassian.net/browse/OSPR-1320
+    # .. toggle_status: supported
+    # .. toggle_warnings: None
     'ENABLE_COMBINED_LOGIN_REGISTRATION_FOOTER': False,
 
     # Enable organizational email opt-in
@@ -478,20 +441,17 @@ FEATURES = {
     # Set this to False to facilitate cleaning up invalid xml from your modulestore.
     'ENABLE_XBLOCK_XML_VALIDATION': True,
 
-    """
-    .. toggle_name: ALLOW_PUBLIC_ACCOUNT_CREATION
-    .. toggle_implementation: DjangoSetting
-    .. toggle_default: True
-    .. toggle_description: Allow public account creation. If this is disabled, users
-      will no longer have access to the signup page.
-    .. toggle_category: admin
-    .. toggle_use_cases: open_edx
-    .. toggle_creation_date: 2017-04-12
-    .. toggle_expiration_date: None
-    .. toggle_tickets: https://openedx.atlassian.net/browse/YONK-513
-    .. toggle_status: supported
-    .. toggle_warnings: None
-    """
+    # .. toggle_name: ALLOW_PUBLIC_ACCOUNT_CREATION
+    # .. toggle_implementation: DjangoSetting
+    # .. toggle_default: True
+    # .. toggle_description: Allow public account creation. If this is disabled, users will no longer have access to the signup page.
+    # .. toggle_category: admin
+    # .. toggle_use_cases: open_edx
+    # .. toggle_creation_date: 2017-04-12
+    # .. toggle_expiration_date: None
+    # .. toggle_tickets: https://openedx.atlassian.net/browse/YONK-513
+    # .. toggle_status: supported
+    # .. toggle_warnings: None
     'ALLOW_PUBLIC_ACCOUNT_CREATION': True,
 
     # Enable footer banner for cookie consent.
@@ -520,23 +480,17 @@ FEATURES = {
     # Whether HTML XBlocks/XModules return HTML content with the Course Blocks API student_view_data
     'ENABLE_HTML_XBLOCK_STUDENT_VIEW_DATA': False,
 
-    """
-    .. toggle_name: ENABLE_CHANGE_USER_PASSWORD_ADMIN
-    .. toggle_implementation: DjangoSetting
-    .. toggle_default: False
-    .. toggle_description: Whether to send an email for failed password reset attempts
-      or not. This happens when a user asks for a password reset but they don't have an
-      account associated to their email. This is useful for notifying users that they
-      don't have an account associated with email addresses they believe they've
-      registered with. This setting can be overridden by a site-specific configuration.
-    .. toggle_category: admin
-    .. toggle_use_cases: open_edx
-    .. toggle_creation_date: 2017-07-20
-    .. toggle_expiration_date: None
-    .. toggle_tickets: https://openedx.atlassian.net/browse/OSPR-1832
-    .. toggle_status: supported
-    .. toggle_warnings: None
-    """
+    # .. toggle_name: ENABLE_CHANGE_USER_PASSWORD_ADMIN
+    # .. toggle_implementation: DjangoSetting
+    # .. toggle_default: False
+    # .. toggle_description: Whether to send an email for failed password reset attempts or not. This happens when a user asks for a password reset but they don't have an account associated to their email. This is useful for notifying users that they don't have an account associated with email addresses they believe they've registered with. This setting can be overridden by a site-specific configuration.
+    # .. toggle_category: admin
+    # .. toggle_use_cases: open_edx
+    # .. toggle_creation_date: 2017-07-20
+    # .. toggle_expiration_date: None
+    # .. toggle_tickets: https://openedx.atlassian.net/browse/OSPR-1832
+    # .. toggle_status: supported
+    # .. toggle_warnings: None
     'ENABLE_PASSWORD_RESET_FAILURE_EMAIL': False,
 
     # Sets the default browser support. For more information go to http://browser-update.org/customize.html

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -201,7 +201,7 @@ FEATURES = {
     # .. toggle_default: False
     # .. toggle_description: Enable this feature to allow this Open edX platform to be an OAuth2 authentication
     #   provider. This is necessary to enable some other features, such as the REST API for the mobile application.
-    # .. toggle_use_cases: monitored_rollout
+    # .. toggle_use_cases: temporary
     # .. toggle_creation_date: 2014-09-09
     # .. toggle_expiration_date: None
     # .. toggle_status: supported
@@ -712,7 +712,7 @@ FEATURES = {
     # .. toggle_description: A "work-around" feature toggle meant to help in cases where some file uploads are not
     #   discoverable.  If enabled, will iterate through all possible file key suffixes up to the max for displaying
     #  file metadata in staff assessments.
-    # .. toggle_use_cases: graceful_degradation
+    # .. toggle_use_cases: temporary
     # .. toggle_creation_date: 2020-03-03
     # .. toggle_expiration_date: None
     # .. toggle_tickets: https://openedx.atlassian.net/browse/EDUCATOR-4951
@@ -725,7 +725,7 @@ FEATURES = {
     # .. toggle_default: False
     # .. toggle_description: A "work-around" feature toggle meant to help in cases where some file uploads are not
     #   discoverable.  If enabled, will pull file metadata from StudentModule.state for display in staff assessments.
-    # .. toggle_use_cases: graceful_degradation
+    # .. toggle_use_cases: temporary
     # .. toggle_creation_date: 2020-03-03
     # .. toggle_expiration_date: None
     # .. toggle_tickets: https://openedx.atlassian.net/browse/EDUCATOR-4951

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -127,7 +127,20 @@ FEATURES = {
 
     'DISABLE_LOGIN_BUTTON': False,  # used in systems where login is automatic, eg MIT SSL
 
-    # Toggles OAuth2 authentication provider
+    """
+    .. toggle_name: ENABLE_OAUTH2_PROVIDER
+    .. toggle_implementation: DjangoSetting
+    .. toggle_default: False
+    .. toggle_description: Enable this feature to allow this Open edX platform to be an
+      OAuth2 authentication provider. This is necessary to enable some other features,
+      such as the REST API for the mobile application.
+    .. toggle_category: admin
+    .. toggle_use_cases: monitored_rollout
+    .. toggle_creation_date: 2014-09-09
+    .. toggle_expiration_date: None
+    .. toggle_status: supported
+    .. toggle_warnings: None
+    """
     'ENABLE_OAUTH2_PROVIDER': False,
 
     # Allows to enable an API endpoint to serve XBlock view, used for example by external applications.

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -89,7 +89,7 @@ FEATURES = {
     #   by course staff.
     # .. toggle_use_cases: ?
     # .. toggle_creation_date: 2015-09-04
-    # .. toggle_expiration_date: None
+    # .. toggle_target_removal_date: None
     # .. toggle_warnings: None
     # .. toggle_tickets: https://github.com/edx/edx-platform/pull/2425
     'DISPLAY_DEBUG_INFO_TO_STAFF': True,
@@ -104,7 +104,7 @@ FEATURES = {
     #   date.
     # .. toggle_use_cases: ?
     # .. toggle_creation_date: ?
-    # .. toggle_expiration_date: None
+    # .. toggle_target_removal_date: None
     # .. toggle_warnings: This will cause ALL courses to be immediately visible.
     # .. toggle_tickets: https://github.com/edx/edx-platform/pull/17913
     ## DO NOT SET TO True IN THIS FILE
@@ -121,7 +121,7 @@ FEATURES = {
     # .. toggle_description: Add PDF and HTML textbook tabs to the courseware.
     # .. toggle_use_cases: ?
     # .. toggle_creation_date: 2014-03-27
-    # .. toggle_expiration_date: None
+    # .. toggle_target_removal_date: None
     # .. toggle_warnings: None
     # .. toggle_tickets: https://github.com/edx/edx-platform/pull/3064
     'ENABLE_TEXTBOOK': True,
@@ -138,7 +138,7 @@ FEATURES = {
     #   registrations.
     # .. toggle_use_cases: open_edx
     # .. toggle_creation_date: 2014-08-19
-    # .. toggle_expiration_date: None
+    # .. toggle_target_removal_date: None
     # .. toggle_warnings: It is not recommended to enable this feature if
     #   ENABLE_DISCUSSION_HOME_PANEL is not enabled, since subscribers who receive
     #   digests in that case will only be able to unsubscribe via links embedded in
@@ -155,7 +155,7 @@ FEATURES = {
     # toggle_category: admin
     # toggle_use_cases: open_edx
     # toggle_creation_date: 2017-06-27
-    # toggle_expiration_date: None
+    # toggle_target_removal_date: None
     # toggle_warnings: None
     # toggle_tickets: https://github.com/edx/edx-platform/pull/14729
     # toggle_status: supported
@@ -171,7 +171,7 @@ FEATURES = {
     #   /course/{course_id}/masquerade url.
     # .. toggle_use_cases: ?
     # .. toggle_creation_date: 2013-04-13
-    # .. toggle_expiration_date: None
+    # .. toggle_target_removal_date: None
     # .. toggle_warnings: None
     # .. toggle_tickets: None
     'ENABLE_MASQUERADE': True,
@@ -184,7 +184,7 @@ FEATURES = {
     #   performant when there are more than 100 courses.
     # .. toggle_use_cases: open_edx
     # .. toggle_creation_date: 2013-12-12
-    # .. toggle_expiration_date: None
+    # .. toggle_target_removal_date: None
     # .. toggle_warnings: This feature is not supported anymore.
     # .. toggle_tickets: None
     'ENABLE_SYSADMIN_DASHBOARD': False,  # sysadmin dashboard, to see what courses are loaded, to delete & load courses
@@ -198,7 +198,7 @@ FEATURES = {
     #   provider. This is necessary to enable some other features, such as the REST API for the mobile application.
     # .. toggle_use_cases: temporary
     # .. toggle_creation_date: 2014-09-09
-    # .. toggle_expiration_date: None
+    # .. toggle_target_removal_date: None
     # .. toggle_warnings: None
     'ENABLE_OAUTH2_PROVIDER': False,
 
@@ -210,7 +210,7 @@ FEATURES = {
     #   https://github.com/edx-solutions/jquery-xblock
     # .. toggle_use_cases: ?
     # .. toggle_creation_date: 2014-03-14
-    # .. toggle_expiration_date: None
+    # .. toggle_target_removal_date: None
     # .. toggle_warnings: None
     # .. toggle_tickets: https://github.com/edx/edx-platform/pull/2968
     'ENABLE_XBLOCK_VIEW_ENDPOINT': False,
@@ -267,7 +267,7 @@ FEATURES = {
     #   allows verified certificates, like courses.edx.org.
     # .. toggle_use_cases: open_edx
     # .. toggle_creation_date: 2019-05-14
-    # .. toggle_expiration_date: None
+    # .. toggle_target_removal_date: None
     # .. toggle_tickets: https://openedx.atlassian.net/browse/PROD-269
     # .. toggle_warnings: ???
     'DISABLE_HONOR_CERTIFICATES': False,  # Toggle to disable honor certificates
@@ -286,7 +286,7 @@ FEATURES = {
     #   querystring parameters.
     # .. toggle_use_cases: open_edx
     # .. toggle_creation_date: 2018-05-07
-    # .. toggle_expiration_date: None
+    # .. toggle_target_removal_date: None
     # .. toggle_tickets: https://openedx.atlassian.net/browse/TE-2545
     'RESTRICT_AUTOMATIC_AUTH': True,
 
@@ -297,7 +297,7 @@ FEATURES = {
     # toggle_category: admin
     # toggle_use_cases: open_edx
     # toggle_creation_date: 2018-05-07
-    # toggle_expiration_date: None
+    # toggle_target_removal_date: None
     # toggle_warnings: The login MFE domain name should be listed in LOGIN_REDIRECT_WHITELIST.
     # toggle_status: supported
     'ENABLE_LOGIN_MICROFRONTEND': False,
@@ -309,7 +309,7 @@ FEATURES = {
     #   Beware, as this leaves the door open to potential spam abuse.
     # toggle_category: admin
     # toggle_use_cases: open_edx
-    # toggle_expiration_date: None
+    # toggle_target_removal_date: None
     # toggle_warnings: The login MFE domain name should be listed in LOGIN_REDIRECT_WHITELIST.
     # toggle_status: supported
     'SKIP_EMAIL_VALIDATION': False,
@@ -330,7 +330,7 @@ FEATURES = {
     #   cosmetic price is used when there is no registration price associated to the course.
     # .. toggle_use_cases: ?
     # .. toggle_creation_date: 2014-10-10
-    # .. toggle_expiration_date: None
+    # .. toggle_target_removal_date: None
     # .. toggle_warnings: None
     # .. toggle_tickets: https://github.com/edx/edx-platform/pull/6876
     'ENABLE_COSMETIC_DISPLAY_PRICE': False,
@@ -373,7 +373,7 @@ FEATURES = {
     # toggle_category: admin
     # toggle_use_cases: open_edx
     # toggle_creation_date: 2014-09-15
-    # toggle_expiration_date: None
+    # toggle_target_removal_date: None
     # toggle_status: supported
     # toggle_warnings: None
     'ENABLE_THIRD_PARTY_AUTH': False,
@@ -384,7 +384,7 @@ FEATURES = {
     # .. toggle_description: Toggle to enable alternate urls for marketing links.
     # .. toggle_use_cases: ?
     # .. toggle_creation_date: 2014-03-24
-    # .. toggle_expiration_date: None
+    # .. toggle_target_removal_date: None
     # .. toggle_warnings: When this is enabled, the MKTG_URLS setting should be defined.
     # .. toggle_tickets: ?
     'ENABLE_MKTG_SITE': False,
@@ -405,7 +405,7 @@ FEATURES = {
     #   by their start dates, latest first.
     # .. toggle_use_cases: ?
     # .. toggle_creation_date: 2015-03-27
-    # .. toggle_expiration_date: None
+    # .. toggle_target_removal_date: None
     # .. toggle_warnings: None
     # .. toggle_tickets: https://github.com/edx/edx-platform/pull/7548
     'ENABLE_COURSE_SORTING_BY_START_DATE': True,
@@ -418,7 +418,7 @@ FEATURES = {
     #   unified course tab (when the UNIFIED_COURSE_TAB_FLAG waffle is enabled).
     # .. toggle_use_cases: ?
     # .. toggle_creation_date: 2019-01-15
-    # .. toggle_expiration_date: None
+    # .. toggle_target_removal_date: None
     # .. toggle_warnings: None
     # .. toggle_tickets: https://github.com/edx/edx-platform/pull/19604
     'ENABLE_COURSE_HOME_REDIRECT': True,
@@ -434,7 +434,7 @@ FEATURES = {
     #   specific configuration.
     # .. toggle_use_cases: open_edx
     # .. toggle_creation_date: 2016-06-24
-    # .. toggle_expiration_date: None
+    # .. toggle_target_removal_date: None
     # .. toggle_tickets: https://openedx.atlassian.net/browse/OSPR-1320
     # .. toggle_warnings: None
     'ENABLE_COMBINED_LOGIN_REGISTRATION_FOOTER': False,
@@ -484,7 +484,7 @@ FEATURES = {
     #   license information to the courseware.
     # .. toggle_use_cases: ?
     # .. toggle_creation_date: 2015-05-14
-    # .. toggle_expiration_date: None
+    # .. toggle_target_removal_date: None
     # .. toggle_warnings: None
     # .. toggle_tickets: https://github.com/edx/edx-platform/pull/7315
     'LICENSING': False,
@@ -500,7 +500,7 @@ FEATURES = {
     #   navbar.
     # .. toggle_use_cases: ?
     # .. toggle_creation_date: 2015-04-23
-    # .. toggle_expiration_date: None
+    # .. toggle_target_removal_date: None
     # .. toggle_warnings: The COURSE_DISCOVERY_MEANINGS setting should be properly defined.
     # .. toggle_tickets: https://github.com/edx/edx-platform/pull/7845
     'ENABLE_COURSE_DISCOVERY': False,
@@ -526,7 +526,7 @@ FEATURES = {
     # .. toggle_description: Enable to use special exams, aka timed and proctored exams.
     # .. toggle_use_cases: ?
     # .. toggle_creation_date: 2015-09-04
-    # .. toggle_expiration_date: None
+    # .. toggle_target_removal_date: None
     # .. toggle_warnings: None
     # .. toggle_tickets: https://github.com/edx/edx-platform/pull/9744
     'ENABLE_SPECIAL_EXAMS': False,
@@ -555,7 +555,7 @@ FEATURES = {
     #   student activities to MySQL, in a separate database.
     # .. toggle_use_cases: ?
     # .. toggle_creation_date: ?
-    # .. toggle_expiration_date: None
+    # .. toggle_target_removal_date: None
     # .. toggle_warnings: Even though most Open edX instances run with a separate CSMH database, it may not always be
     #   the case. When disabling this feature flag, remember to remove "coursewarehistoryextended" from the
     #   INSTALLED_APPS and the "StudentModuleHistoryExtendedRouter" from the DATABASE_ROUTERS.
@@ -578,7 +578,7 @@ FEATURES = {
     #   the signup page.
     # .. toggle_use_cases: open_edx
     # .. toggle_creation_date: 2017-04-12
-    # .. toggle_expiration_date: None
+    # .. toggle_target_removal_date: None
     # .. toggle_tickets: https://openedx.atlassian.net/browse/YONK-513
     # .. toggle_warnings: None
     'ALLOW_PUBLIC_ACCOUNT_CREATION': True,
@@ -618,7 +618,7 @@ FEATURES = {
     #   with. This setting can be overridden by a site-specific configuration.
     # .. toggle_use_cases: open_edx
     # .. toggle_creation_date: 2017-07-20
-    # .. toggle_expiration_date: None
+    # .. toggle_target_removal_date: None
     # .. toggle_tickets: https://openedx.atlassian.net/browse/OSPR-1832
     # .. toggle_warnings: None
     'ENABLE_PASSWORD_RESET_FAILURE_EMAIL': False,
@@ -640,7 +640,7 @@ FEATURES = {
     #   default because enabling allows a method to bypass password policy.
     # .. toggle_use_cases: open_edx
     # .. toggle_creation_date: 2020-02-21
-    # .. toggle_expiration_date: None
+    # .. toggle_target_removal_date: None
     # .. toggle_tickets: 'https://github.com/edx/edx-platform/pull/21616'
     # .. toggle_warnings: None
     'ENABLE_CHANGE_USER_PASSWORD_ADMIN': False,
@@ -652,7 +652,7 @@ FEATURES = {
     #   REDIRECT_TO_COURSEWARE_MICROFRONTEND for course rollout)
     # .. toggle_use_cases: open_edx
     # .. toggle_creation_date: 2020-03-05
-    # .. toggle_expiration_date: None
+    # .. toggle_target_removal_date: None
     # .. toggle_tickets: 'https://github.com/edx/edx-platform/pull/23317'
     # .. toggle_warnings: Also set settings.LEARNING_MICROFRONTEND_URL and see REDIRECT_TO_COURSEWARE_MICROFRONTEND for
     #   rollout.
@@ -664,7 +664,7 @@ FEATURES = {
     # .. toggle_description: Supports staged rollout of a new micro-frontend-based implementation of the logistration.
     # .. toggle_use_cases: incremental_release, open_edx
     # .. toggle_creation_date: 2020-09-08
-    # .. toggle_expiration_date: None
+    # .. toggle_target_removal_date: None
     # .. toggle_tickets: 'https://github.com/edx/edx-platform/pull/24908'
     # .. toggle_warnings: Also set settings.ACCOUNT_MICROFRONTEND_URL and set REDIRECT_TO_ACCOUNT_MICROFRONTEND for rollout.
     'ENABLE_LOGISTRATION_MICROFRONTEND': False,
@@ -677,7 +677,7 @@ FEATURES = {
     # .. toggle_description: Set to True to enable team-based ORA submissions.
     # .. toggle_use_cases: incremental_release
     # .. toggle_creation_date: 2020-03-03
-    # .. toggle_expiration_date: None
+    # .. toggle_target_removal_date: None
     # .. toggle_tickets: https://openedx.atlassian.net/browse/EDUCATOR-4951
     # .. toggle_warnings: None
     'ENABLE_ORA_TEAM_SUBMISSIONS': False,
@@ -690,7 +690,7 @@ FEATURES = {
     #  file metadata in staff assessments.
     # .. toggle_use_cases: temporary
     # .. toggle_creation_date: 2020-03-03
-    # .. toggle_expiration_date: None
+    # .. toggle_target_removal_date: None
     # .. toggle_tickets: https://openedx.atlassian.net/browse/EDUCATOR-4951
     # .. toggle_warnings: None
     'ENABLE_ORA_ALL_FILE_URLS': False,
@@ -702,7 +702,7 @@ FEATURES = {
     #   discoverable.  If enabled, will pull file metadata from StudentModule.state for display in staff assessments.
     # .. toggle_use_cases: temporary
     # .. toggle_creation_date: 2020-03-03
-    # .. toggle_expiration_date: None
+    # .. toggle_target_removal_date: None
     # .. toggle_tickets: https://openedx.atlassian.net/browse/EDUCATOR-4951
     # .. toggle_warnings: None
     'ENABLE_ORA_USER_STATE_UPLOAD_DATA': False,
@@ -714,7 +714,7 @@ FEATURES = {
     #   report.
     # .. toggle_use_cases: incremental_release
     # .. toggle_creation_date: 2020-06-11
-    # .. toggle_expiration_date: None
+    # .. toggle_target_removal_date: None
     # .. toggle_tickets: https://openedx.atlassian.net/browse/TNL-7273
     # .. toggle_warnings: None
     'ENABLE_ORA_USERNAMES_ON_DATA_EXPORT': False,

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -238,8 +238,23 @@ FEATURES = {
     # defaults, so that we maintain current behavior
     'ALLOW_WIKI_ROOT_ACCESS': True,
 
-    # Turn on third-party auth. Disabled for now because full implementations are not yet available. Remember to run
-    # migrations if you enable this; we don't create tables by default.
+    """
+    .. toggle_name: ENABLE_THIRD_PARTY_AUTH
+    .. toggle_implementation: DjangoSetting
+    .. toggle_default: False
+    .. toggle_description: Turn on third-party auth. Disabled for now because full
+      implementations are not yet available. Remember to run
+      migrations if you enable this; we don't create tables by default. This feature
+      can be enabled on a per-site basis. When enabling this feature, remember to
+      define the allowed authentication backends with the AUTHENTICATION_BACKENDS
+      setting.
+    .. toggle_category: admin
+    .. toggle_use_cases: open_edx
+    .. toggle_creation_date: 2014-09-15
+    .. toggle_expiration_date: None
+    .. toggle_status: supported
+    .. toggle_warnings: None
+    """
     'ENABLE_THIRD_PARTY_AUTH': False,
 
     # Toggle to enable alternate urls for marketing links

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -85,7 +85,8 @@ FEATURES = {
     # .. toggle_name: DISPLAY_DEBUG_INFO_TO_STAFF
     # .. toggle_implementation: DjangoSetting
     # .. toggle_default: True
-    # .. toggle_description: Add a "Staff Debug" button to course modules for debugging by course staff.
+    # .. toggle_description: Add a "Staff Debug" button to course modules for debugging
+    #   by course staff.
     # .. toggle_use_cases: ?
     # .. toggle_creation_date: 2015-09-04
     # .. toggle_expiration_date: None
@@ -100,7 +101,8 @@ FEATURES = {
     # .. toggle_name: DISABLE_START_DATES
     # .. toggle_implementation: DjangoSetting
     # .. toggle_default: False
-    # .. toggle_description: When True, all courses will be active, regardless of start date.
+    # .. toggle_description: When True, all courses will be active, regardless of start
+    #   date.
     # .. toggle_use_cases: ?
     # .. toggle_creation_date: ?
     # .. toggle_expiration_date: None
@@ -134,12 +136,17 @@ FEATURES = {
     # .. toggle_name: ENABLE_DISCUSSION_EMAIL_DIGEST
     # .. toggle_implementation: DjangoSetting
     # .. toggle_default: False
-    # .. toggle_description: Set this to True if you want the discussion digest emails enabled automatically for new users. This will be set on all new account registrations.
+    # .. toggle_description: Set this to True if you want the discussion digest emails
+    #   enabled automatically for new users. This will be set on all new account
+    #   registrations.
     # .. toggle_category: admin
     # .. toggle_use_cases: open_edx
     # .. toggle_creation_date: 2014-08-19
     # .. toggle_expiration_date: None
-    # .. toggle_warnings: It is not recommended to enable this feature if ENABLE_DISCUSSION_HOME_PANEL is not enabled, since subscribers who receive digests in that case will only be able to unsubscribe via links embedded in their emails, and they will have no way to resubscribe.
+    # .. toggle_warnings: It is not recommended to enable this feature if
+    #   ENABLE_DISCUSSION_HOME_PANEL is not enabled, since subscribers who receive
+    #   digests in that case will only be able to unsubscribe via links embedded in
+    #   their emails, and they will have no way to resubscribe.
     # .. toggle_tickets: https://github.com/edx/edx-platform/pull/4891
     # .. toggle_status: supported
     'ENABLE_DISCUSSION_EMAIL_DIGEST': False,
@@ -147,7 +154,9 @@ FEATURES = {
     # toggle_name: ENABLE_UNICODE_USERNAME
     # toggle_implementation: DjangoSetting
     # toggle_default: False
-    # toggle_description: Set this to True to allow unicode characters in username. Enabling this will also automatically enable SOCIAL_AUTH_CLEAN_USERNAMES. When this is enabled, usernames will have to match the regular expression defined by USERNAME_REGEX_PARTIAL.
+    # toggle_description: Set this to True to allow unicode characters in username. Enabling this will also
+    #   automatically enable SOCIAL_AUTH_CLEAN_USERNAMES. When this is enabled, usernames will have to match the
+    #   regular expression defined by USERNAME_REGEX_PARTIAL.
     # toggle_category: admin
     # toggle_use_cases: open_edx
     # toggle_creation_date: 2017-06-27
@@ -163,7 +172,8 @@ FEATURES = {
     # .. toggle_name: ENABLE_MASQUERADE
     # .. toggle_implementation: DjangoSetting
     # .. toggle_default: True
-    # .. toggle_description: Allow course staff to change to student view of courseware by accessing the /course/{course_id}/masquerade url.
+    # .. toggle_description: Allow course staff to change to student view of courseware by accessing the
+    #   /course/{course_id}/masquerade url.
     # .. toggle_use_cases: ?
     # .. toggle_creation_date: 2013-04-13
     # .. toggle_expiration_date: None
@@ -175,7 +185,8 @@ FEATURES = {
     # .. toggle_name: ENABLE_SYSADMIN_DASHBOARD
     # .. toggle_implementation: DjangoSetting
     # .. toggle_default: False
-    # .. toggle_description: enables dashboard at /syadmin/ for django staff, for seeing overview of system status, for deleting and loading courses, for seeing log of git imports of courseware.
+    # .. toggle_description: enables dashboard at /syadmin/ for django staff, for seeing overview of system status, for
+    #   deleting and loading courses, for seeing log of git imports of courseware.
     # .. toggle_category: admin
     # .. toggle_use_cases: open_edx
     # .. toggle_creation_date: 2013-12-12
@@ -203,7 +214,9 @@ FEATURES = {
     # .. toggle_name: ENABLE_XBLOCK_VIEW_ENDPOINT
     # .. toggle_implementation: DjangoSetting
     # .. toggle_default: False
-    # .. toggle_description: Enable an API endpoint, named "xblock_view", to serve rendered XBlock views. This might be used by external applications. See for instance jquery-xblock (now unmaintained): https://github.com/edx-solutions/jquery-xblock
+    # .. toggle_description: Enable an API endpoint, named "xblock_view", to serve rendered XBlock views. This might be
+    #   used by external applications. See for instance jquery-xblock (now unmaintained):
+    #   https://github.com/edx-solutions/jquery-xblock
     # .. toggle_use_cases: ?
     # .. toggle_creation_date: 2014-03-14
     # .. toggle_expiration_date: None
@@ -212,13 +225,15 @@ FEATURES = {
     # .. toggle_status: supported
     'ENABLE_XBLOCK_VIEW_ENDPOINT': False,
 
-    # Allows to configure the LMS to provide CORS headers to serve requests from other domains
+    # Allows to configure the LMS to provide CORS headers to serve requests from other
+    # domains
     'ENABLE_CORS_HEADERS': False,
 
     # Can be turned off if course lists need to be hidden. Effects views and templates.
     'COURSES_ARE_BROWSABLE': True,
 
-    # Set to hide the courses list on the Learner Dashboard if they are not enrolled in any courses yet.
+    # Set to hide the courses list on the Learner Dashboard if they are not enrolled in
+    # any courses yet.
     'HIDE_DASHBOARD_COURSES_UNTIL_ACTIVATED': False,
 
     # Give a UI to show a student's submission history in a problem by the
@@ -258,7 +273,8 @@ FEATURES = {
     # .. toggle_name: DISABLE_HONOR_CERTIFICATES
     # .. toggle_implementation: DjangoSetting
     # .. toggle_default: False
-    # .. toggle_description: Set to True to disable honor certificates. Typically used when your installation only allows verified certificates, like courses.edx.org.
+    # .. toggle_description: Set to True to disable honor certificates. Typically used when your installation only
+    #   allows verified certificates, like courses.edx.org.
     # .. toggle_category: certificates
     # .. toggle_use_cases: open_edx
     # .. toggle_creation_date: 2019-05-14
@@ -276,7 +292,10 @@ FEATURES = {
     # .. toggle_name: RESTRICT_AUTOMATIC_AUTH
     # .. toggle_implementation: DjangoSetting
     # .. toggle_default: True
-    # .. toggle_description: Prevent auto auth from creating superusers or modifying existing users. Auto auth is a mechanism where superusers can simply modify attributes of other users by accessing the "/auto_auth url" with the right querystring parameters.
+    # .. toggle_description: Prevent auto auth from creating superusers or modifying existing users. Auto auth is a
+    #   mechanism where superusers can simply modify attributes of other users by accessing the "/auto_auth url" with
+    #   the right
+    #   querystring parameters.
     # .. toggle_category: admin
     # .. toggle_use_cases: open_edx
     # .. toggle_creation_date: 2018-05-07
@@ -300,7 +319,8 @@ FEATURES = {
     # toggle_name: SKIP_EMAIL_VALIDATION
     # toggle_implementation: DjangoSetting
     # toggle_default: False
-    # toggle_description: Turn this on to skip sending emails for user validation. Beware, as this leaves the door open to potential spam abuse.
+    # toggle_description: Turn this on to skip sending emails for user validation.
+    #   Beware, as this leaves the door open to potential spam abuse.
     # toggle_category: admin
     # toggle_use_cases: open_edx
     # toggle_expiration_date: None
@@ -320,7 +340,8 @@ FEATURES = {
     # .. toggle_name: ENABLE_COSMETIC_DISPLAY_PRICE
     # .. toggle_implementation: DjangoSetting
     # .. toggle_default: False
-    # .. toggle_description: Enable the display of "cosmetic_display_price", set in a course advanced settings. This cosmetic price is used when there is no registration price associated to the course.
+    # .. toggle_description: Enable the display of "cosmetic_display_price", set in a course advanced settings. This
+    #   cosmetic price is used when there is no registration price associated to the course.
     # .. toggle_use_cases: ?
     # .. toggle_creation_date: 2014-10-10
     # .. toggle_expiration_date: None
@@ -360,7 +381,10 @@ FEATURES = {
     # toggle_name: ENABLE_THIRD_PARTY_AUTH
     # toggle_implementation: DjangoSetting
     # toggle_default: False
-    # toggle_description: Turn on third-party auth. Disabled for now because full implementations are not yet available. Remember to run migrations if you enable this; we don't create tables by default. This feature can be enabled on a per-site basis. When enabling this feature, remember to define the allowed authentication backends with the AUTHENTICATION_BACKENDS setting.
+    # toggle_description: Turn on third-party auth. Disabled for now because full mplementations are not yet available.
+    #   Remember to run migrations if you enable this; we don't create tables by default. This feature can be enabled
+    #   on a per-site basis. When enabling this feature, remember to define the allowed authentication backends with
+    #   the AUTHENTICATION_BACKENDS setting.
     # toggle_category: admin
     # toggle_use_cases: open_edx
     # toggle_creation_date: 2014-09-15
@@ -392,7 +416,9 @@ FEATURES = {
     # .. toggle_name: ENABLE_COURSE_SORTING_BY_START_DATE
     # .. toggle_implementation: DjangoSetting
     # .. toggle_default: True
-    # .. toggle_description: When a user goes to the homepage ('/') the user sees the courses listed in the announcement dates order - this is default Open edX behavior. Set to True to change the course sorting behavior by their start dates, latest first.
+    # .. toggle_description: When a user goes to the homepage ('/') the user sees the courses listed in the
+    #   announcement dates order - this is default Open edX behavior. Set to True to change the course sorting behavior
+    #   by their start dates, latest first.
     # .. toggle_use_cases: ?
     # .. toggle_creation_date: 2015-03-27
     # .. toggle_expiration_date: None
@@ -404,7 +430,9 @@ FEATURES = {
     # .. toggle_name: ENABLE_COURSE_HOME_REDIRECT
     # .. toggle_implementation: DjangoSetting
     # .. toggle_default: True
-    # .. toggle_description: When enabled, along with the ENABLE_MKTG_SITE feature toggle, users who attempt to access a course "about" page will be redirected to the course home url. This url might be the course "info" page or the unified course tab (when the UNIFIED_COURSE_TAB_FLAG waffle is enabled).
+    # .. toggle_description: When enabled, along with the ENABLE_MKTG_SITE feature toggle, users who attempt to access a
+    #   course "about" page will be redirected to the course home url. This url might be the course "info" page or the
+    #   unified course tab (when the UNIFIED_COURSE_TAB_FLAG waffle is enabled).
     # .. toggle_use_cases: ?
     # .. toggle_creation_date: 2019-01-15
     # .. toggle_expiration_date: None
@@ -420,7 +448,8 @@ FEATURES = {
     # .. toggle_name: ENABLE_COMBINED_LOGIN_REGISTRATION_FOOTER
     # .. toggle_implementation: DjangoSetting
     # .. toggle_default: False
-    # .. toggle_description: Display the standard footer in the login page. This feature can be overridden by a site-specific configuration.
+    # .. toggle_description: Display the standard footer in the login page. This feature can be overridden by a site-
+    #   specific configuration.
     # .. toggle_category: admin
     # .. toggle_use_cases: open_edx
     # .. toggle_creation_date: 2016-06-24
@@ -471,7 +500,8 @@ FEATURES = {
     # .. toggle_name: LICENSING
     # .. toggle_implementation: DjangoSetting
     # .. toggle_default: False
-    # .. toggle_description: Toggle platform-wide course licensing. The course.license attribute is then used to append license information to the courseware.
+    # .. toggle_description: Toggle platform-wide course licensing. The course.license attribute is then used to append
+    #   license information to the courseware.
     # .. toggle_use_cases: ?
     # .. toggle_creation_date: 2015-05-14
     # .. toggle_expiration_date: None
@@ -486,7 +516,9 @@ FEATURES = {
     # .. toggle_name: ENABLE_COURSE_DISCOVERY
     # .. toggle_implementation: DjangoSetting
     # .. toggle_default: False
-    # .. toggle_description: Add a course search widget to the LMS for searching courses. When this is enabled, the latest courses are no longer displayed on the LMS landing page. Also, an "Explore Courses" item is added to the navbar.
+    # .. toggle_description: Add a course search widget to the LMS for searching courses. When this is enabled, the
+    #   latest courses are no longer displayed on the LMS landing page. Also, an "Explore Courses" item is added to the
+    #   navbar.
     # .. toggle_use_cases: ?
     # .. toggle_creation_date: 2015-04-23
     # .. toggle_expiration_date: None
@@ -542,11 +574,14 @@ FEATURES = {
     # .. toggle_name: ENABLE_CSMH_EXTENDED
     # .. toggle_implementation: DjangoSetting
     # .. toggle_default: True
-    # .. toggle_description: Write Courseware Student Module History (CSMH) to the extended table: this logs all student activities to MySQL, in a separate database.
+    # .. toggle_description: Write Courseware Student Module History (CSMH) to the extended table: this logs all
+    #   student activities to MySQL, in a separate database.
     # .. toggle_use_cases: ?
     # .. toggle_creation_date: ?
     # .. toggle_expiration_date: None
-    # .. toggle_warnings: Even though most Open edX instances run with a separate CSMH database, it may not always be the case. When disabling this feature flag, remember to remove "coursewarehistoryextended" from the INSTALLED_APPS and the "StudentModuleHistoryExtendedRouter" from the DATABASE_ROUTERS.
+    # .. toggle_warnings: Even though most Open edX instances run with a separate CSMH database, it may not always be
+    #   the case. When disabling this feature flag, remember to remove "coursewarehistoryextended" from the
+    #   INSTALLED_APPS and the "StudentModuleHistoryExtendedRouter" from the DATABASE_ROUTERS.
     # .. toggle_tickets: None
     # .. toggle_status: supported
     'ENABLE_CSMH_EXTENDED': True,
@@ -563,7 +598,8 @@ FEATURES = {
     # .. toggle_name: ALLOW_PUBLIC_ACCOUNT_CREATION
     # .. toggle_implementation: DjangoSetting
     # .. toggle_default: True
-    # .. toggle_description: Allow public account creation. If this is disabled, users will no longer have access to the signup page.
+    # .. toggle_description: Allow public account creation. If this is disabled, users will no longer have access to
+    #   the signup page.
     # .. toggle_category: admin
     # .. toggle_use_cases: open_edx
     # .. toggle_creation_date: 2017-04-12
@@ -602,7 +638,10 @@ FEATURES = {
     # .. toggle_name: ENABLE_CHANGE_USER_PASSWORD_ADMIN
     # .. toggle_implementation: DjangoSetting
     # .. toggle_default: False
-    # .. toggle_description: Whether to send an email for failed password reset attempts or not. This happens when a user asks for a password reset but they don't have an account associated to their email. This is useful for notifying users that they don't have an account associated with email addresses they believe they've registered with. This setting can be overridden by a site-specific configuration.
+    # .. toggle_description: Whether to send an email for failed password reset attempts or not. This happens when a
+    #   user asks for a password reset but they don't have an account associated to their email. This is useful for
+    #   notifying users that they don't have an account associated with email addresses they believe they've registered
+    #   with. This setting can be overridden by a site-specific configuration.
     # .. toggle_category: admin
     # .. toggle_use_cases: open_edx
     # .. toggle_creation_date: 2017-07-20
@@ -625,7 +664,8 @@ FEATURES = {
     # .. toggle_name: ENABLE_CHANGE_USER_PASSWORD_ADMIN
     # .. toggle_implementation: DjangoSetting
     # .. toggle_default: False
-    # .. toggle_description: Set to True to enable changing a user password through django admin. This is disabled by default because enabling allows a method to bypass password policy.
+    # .. toggle_description: Set to True to enable changing a user password through django admin. This is disabled by
+    #   default because enabling allows a method to bypass password policy.
     # .. toggle_category: admin
     # .. toggle_use_cases: open_edx
     # .. toggle_creation_date: 2020-02-21
@@ -638,14 +678,16 @@ FEATURES = {
     # .. toggle_name: ENABLE_COURSEWARE_MICROFRONTEND
     # .. toggle_implementation: DjangoSetting
     # .. toggle_default: False
-    # .. toggle_description: Set to True to enable the Courseware MFE at the platform level for global staff (see REDIRECT_TO_COURSEWARE_MICROFRONTEND for course rollout)
+    # .. toggle_description: Set to True to enable the Courseware MFE at the platform level for global staff (see
+    #   REDIRECT_TO_COURSEWARE_MICROFRONTEND for course rollout)
     # .. toggle_category: admin
     # .. toggle_use_cases: open_edx
     # .. toggle_creation_date: 2020-03-05
     # .. toggle_expiration_date: None
     # .. toggle_tickets: 'https://github.com/edx/edx-platform/pull/23317'
     # .. toggle_status: supported
-    # .. toggle_warnings: Also set settings.LEARNING_MICROFRONTEND_URL and see REDIRECT_TO_COURSEWARE_MICROFRONTEND for rollout.
+    # .. toggle_warnings: Also set settings.LEARNING_MICROFRONTEND_URL and see REDIRECT_TO_COURSEWARE_MICROFRONTEND for
+    #   rollout.
     'ENABLE_COURSEWARE_MICROFRONTEND': False,
 
     # .. toggle_name: ENABLE_LOGISTRATION_MICROFRONTEND
@@ -680,8 +722,8 @@ FEATURES = {
     # .. toggle_implementation: DjangoSetting
     # .. toggle_default: False
     # .. toggle_description: A "work-around" feature toggle meant to help in cases where some file uploads are not
-    #      discoverable.  If enabled, will iterate through all possible file key suffixes up to the max for displaying
-    #      file metadata in staff assessments.
+    #   discoverable.  If enabled, will iterate through all possible file key suffixes up to the max for displaying
+    #  file metadata in staff assessments.
     # .. toggle_category: ora
     # .. toggle_use_cases: graceful_degradation
     # .. toggle_creation_date: 2020-03-03
@@ -695,7 +737,7 @@ FEATURES = {
     # .. toggle_implementation: DjangoSetting
     # .. toggle_default: False
     # .. toggle_description: A "work-around" feature toggle meant to help in cases where some file uploads are not
-    #      discoverable.  If enabled, will pull file metadata from StudentModule.state for display in staff assessments.
+    #   discoverable.  If enabled, will pull file metadata from StudentModule.state for display in staff assessments.
     # .. toggle_category: ora
     # .. toggle_use_cases: graceful_degradation
     # .. toggle_creation_date: 2020-03-03
@@ -708,7 +750,8 @@ FEATURES = {
     # .. toggle_name: ENABLE_ORA_USERNAMES_ON_DATA_EXPORT
     # .. toggle_implementation: DjangoSetting
     # .. toggle_default: False
-    # .. toggle_description: Set to True to add deanonymized usernames to ORA data report.
+    # .. toggle_description: Set to True to add deanonymized usernames to ORA data
+    #   report.
     # .. toggle_category: ora
     # .. toggle_use_cases: incremental_release
     # .. toggle_creation_date: 2020-06-11

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -92,7 +92,6 @@ FEATURES = {
     # .. toggle_expiration_date: None
     # .. toggle_warnings: None
     # .. toggle_tickets: https://github.com/edx/edx-platform/pull/2425
-    # .. toggle_status: supported
     'DISPLAY_DEBUG_INFO_TO_STAFF': True,
     'DISPLAY_HISTOGRAMS_TO_STAFF': False,  # For large courses this slows down courseware access for staff.
 
@@ -108,7 +107,6 @@ FEATURES = {
     # .. toggle_expiration_date: None
     # .. toggle_warnings: This will cause ALL courses to be immediately visible.
     # .. toggle_tickets: https://github.com/edx/edx-platform/pull/17913
-    # .. toggle_status: supported
     ## DO NOT SET TO True IN THIS FILE
     ## Doing so will cause all courses to be released on production
     'DISABLE_START_DATES': False,
@@ -126,7 +124,6 @@ FEATURES = {
     # .. toggle_expiration_date: None
     # .. toggle_warnings: None
     # .. toggle_tickets: https://github.com/edx/edx-platform/pull/3064
-    # .. toggle_status: supported
     'ENABLE_TEXTBOOK': True,
 
     # discussion home panel, which includes a subscription on/off setting for discussion digest emails.
@@ -147,7 +144,6 @@ FEATURES = {
     #   digests in that case will only be able to unsubscribe via links embedded in
     #   their emails, and they will have no way to resubscribe.
     # .. toggle_tickets: https://github.com/edx/edx-platform/pull/4891
-    # .. toggle_status: supported
     'ENABLE_DISCUSSION_EMAIL_DIGEST': False,
 
     # toggle_name: ENABLE_UNICODE_USERNAME
@@ -178,20 +174,19 @@ FEATURES = {
     # .. toggle_expiration_date: None
     # .. toggle_warnings: None
     # .. toggle_tickets: None
-    # .. toggle_status: supported
     'ENABLE_MASQUERADE': True,
 
     # .. toggle_name: ENABLE_SYSADMIN_DASHBOARD
     # .. toggle_implementation: DjangoSetting
     # .. toggle_default: False
     # .. toggle_description: enables dashboard at /syadmin/ for django staff, for seeing overview of system status, for
-    #   deleting and loading courses, for seeing log of git imports of courseware.
+    #   deleting and loading courses, for seeing log of git imports of courseware. Note that some views are not
+    #   performant when there are more than 100 courses.
     # .. toggle_use_cases: open_edx
     # .. toggle_creation_date: 2013-12-12
     # .. toggle_expiration_date: None
-    # .. toggle_warnings: some views are not performant when there are more than 100 courses
+    # .. toggle_warnings: This feature is not supported anymore.
     # .. toggle_tickets: None
-    # .. toggle_status: unsupported
     'ENABLE_SYSADMIN_DASHBOARD': False,  # sysadmin dashboard, to see what courses are loaded, to delete & load courses
 
     'DISABLE_LOGIN_BUTTON': False,  # used in systems where login is automatic, eg MIT SSL
@@ -204,7 +199,6 @@ FEATURES = {
     # .. toggle_use_cases: temporary
     # .. toggle_creation_date: 2014-09-09
     # .. toggle_expiration_date: None
-    # .. toggle_status: supported
     # .. toggle_warnings: None
     'ENABLE_OAUTH2_PROVIDER': False,
 
@@ -219,7 +213,6 @@ FEATURES = {
     # .. toggle_expiration_date: None
     # .. toggle_warnings: None
     # .. toggle_tickets: https://github.com/edx/edx-platform/pull/2968
-    # .. toggle_status: supported
     'ENABLE_XBLOCK_VIEW_ENDPOINT': False,
 
     # Allows to configure the LMS to provide CORS headers to serve requests from other
@@ -276,7 +269,6 @@ FEATURES = {
     # .. toggle_creation_date: 2019-05-14
     # .. toggle_expiration_date: None
     # .. toggle_tickets: https://openedx.atlassian.net/browse/PROD-269
-    # .. toggle_status: supported
     # .. toggle_warnings: ???
     'DISABLE_HONOR_CERTIFICATES': False,  # Toggle to disable honor certificates
 
@@ -296,7 +288,6 @@ FEATURES = {
     # .. toggle_creation_date: 2018-05-07
     # .. toggle_expiration_date: None
     # .. toggle_tickets: https://openedx.atlassian.net/browse/TE-2545
-    # .. toggle_status: supported
     'RESTRICT_AUTOMATIC_AUTH': True,
 
     # toggle_name: ENABLE_LOGIN_MICROFRONTEND
@@ -342,7 +333,6 @@ FEATURES = {
     # .. toggle_expiration_date: None
     # .. toggle_warnings: None
     # .. toggle_tickets: https://github.com/edx/edx-platform/pull/6876
-    # .. toggle_status: supported
     'ENABLE_COSMETIC_DISPLAY_PRICE': False,
 
     # Automatically approve student identity verification attempts
@@ -397,7 +387,6 @@ FEATURES = {
     # .. toggle_expiration_date: None
     # .. toggle_warnings: When this is enabled, the MKTG_URLS setting should be defined.
     # .. toggle_tickets: ?
-    # .. toggle_status: supported
     'ENABLE_MKTG_SITE': False,
 
     # Prevent concurrent logins per user
@@ -419,7 +408,6 @@ FEATURES = {
     # .. toggle_expiration_date: None
     # .. toggle_warnings: None
     # .. toggle_tickets: https://github.com/edx/edx-platform/pull/7548
-    # .. toggle_status: supported
     'ENABLE_COURSE_SORTING_BY_START_DATE': True,
 
     # .. toggle_name: ENABLE_COURSE_HOME_REDIRECT
@@ -433,7 +421,6 @@ FEATURES = {
     # .. toggle_expiration_date: None
     # .. toggle_warnings: None
     # .. toggle_tickets: https://github.com/edx/edx-platform/pull/19604
-    # .. toggle_status: supported
     'ENABLE_COURSE_HOME_REDIRECT': True,
 
     # Expose Mobile REST API. Note that if you use this, you must also set
@@ -449,7 +436,6 @@ FEATURES = {
     # .. toggle_creation_date: 2016-06-24
     # .. toggle_expiration_date: None
     # .. toggle_tickets: https://openedx.atlassian.net/browse/OSPR-1320
-    # .. toggle_status: supported
     # .. toggle_warnings: None
     'ENABLE_COMBINED_LOGIN_REGISTRATION_FOOTER': False,
 
@@ -501,7 +487,6 @@ FEATURES = {
     # .. toggle_expiration_date: None
     # .. toggle_warnings: None
     # .. toggle_tickets: https://github.com/edx/edx-platform/pull/7315
-    # .. toggle_status: supported
     'LICENSING': False,
 
     # Certificates Web/HTML Views
@@ -518,7 +503,6 @@ FEATURES = {
     # .. toggle_expiration_date: None
     # .. toggle_warnings: The COURSE_DISCOVERY_MEANINGS setting should be properly defined.
     # .. toggle_tickets: https://github.com/edx/edx-platform/pull/7845
-    # .. toggle_status: supported
     'ENABLE_COURSE_DISCOVERY': False,
 
     # Setting for overriding default filtering facets for Course discovery
@@ -545,7 +529,6 @@ FEATURES = {
     # .. toggle_expiration_date: None
     # .. toggle_warnings: None
     # .. toggle_tickets: https://github.com/edx/edx-platform/pull/9744
-    # .. toggle_status: supported
     'ENABLE_SPECIAL_EXAMS': False,
 
     # Enable OpenBadge support. See the BADGR_* settings later in this file.
@@ -577,7 +560,6 @@ FEATURES = {
     #   the case. When disabling this feature flag, remember to remove "coursewarehistoryextended" from the
     #   INSTALLED_APPS and the "StudentModuleHistoryExtendedRouter" from the DATABASE_ROUTERS.
     # .. toggle_tickets: None
-    # .. toggle_status: supported
     'ENABLE_CSMH_EXTENDED': True,
 
     # Read from both the CSMH and CSMHE history tables.
@@ -598,7 +580,6 @@ FEATURES = {
     # .. toggle_creation_date: 2017-04-12
     # .. toggle_expiration_date: None
     # .. toggle_tickets: https://openedx.atlassian.net/browse/YONK-513
-    # .. toggle_status: supported
     # .. toggle_warnings: None
     'ALLOW_PUBLIC_ACCOUNT_CREATION': True,
 
@@ -639,7 +620,6 @@ FEATURES = {
     # .. toggle_creation_date: 2017-07-20
     # .. toggle_expiration_date: None
     # .. toggle_tickets: https://openedx.atlassian.net/browse/OSPR-1832
-    # .. toggle_status: supported
     # .. toggle_warnings: None
     'ENABLE_PASSWORD_RESET_FAILURE_EMAIL': False,
 
@@ -662,7 +642,6 @@ FEATURES = {
     # .. toggle_creation_date: 2020-02-21
     # .. toggle_expiration_date: None
     # .. toggle_tickets: 'https://github.com/edx/edx-platform/pull/21616'
-    # .. toggle_status: supported
     # .. toggle_warnings: None
     'ENABLE_CHANGE_USER_PASSWORD_ADMIN': False,
 
@@ -675,7 +654,6 @@ FEATURES = {
     # .. toggle_creation_date: 2020-03-05
     # .. toggle_expiration_date: None
     # .. toggle_tickets: 'https://github.com/edx/edx-platform/pull/23317'
-    # .. toggle_status: supported
     # .. toggle_warnings: Also set settings.LEARNING_MICROFRONTEND_URL and see REDIRECT_TO_COURSEWARE_MICROFRONTEND for
     #   rollout.
     'ENABLE_COURSEWARE_MICROFRONTEND': False,
@@ -688,7 +666,6 @@ FEATURES = {
     # .. toggle_creation_date: 2020-09-08
     # .. toggle_expiration_date: None
     # .. toggle_tickets: 'https://github.com/edx/edx-platform/pull/24908'
-    # .. toggle_status: supported
     # .. toggle_warnings: Also set settings.ACCOUNT_MICROFRONTEND_URL and set REDIRECT_TO_ACCOUNT_MICROFRONTEND for rollout.
     'ENABLE_LOGISTRATION_MICROFRONTEND': False,
 
@@ -702,7 +679,6 @@ FEATURES = {
     # .. toggle_creation_date: 2020-03-03
     # .. toggle_expiration_date: None
     # .. toggle_tickets: https://openedx.atlassian.net/browse/EDUCATOR-4951
-    # .. toggle_status: supported
     # .. toggle_warnings: None
     'ENABLE_ORA_TEAM_SUBMISSIONS': False,
 
@@ -716,7 +692,6 @@ FEATURES = {
     # .. toggle_creation_date: 2020-03-03
     # .. toggle_expiration_date: None
     # .. toggle_tickets: https://openedx.atlassian.net/browse/EDUCATOR-4951
-    # .. toggle_status: supported
     # .. toggle_warnings: None
     'ENABLE_ORA_ALL_FILE_URLS': False,
 
@@ -729,7 +704,6 @@ FEATURES = {
     # .. toggle_creation_date: 2020-03-03
     # .. toggle_expiration_date: None
     # .. toggle_tickets: https://openedx.atlassian.net/browse/EDUCATOR-4951
-    # .. toggle_status: supported
     # .. toggle_warnings: None
     'ENABLE_ORA_USER_STATE_UPLOAD_DATA': False,
 
@@ -742,7 +716,6 @@ FEATURES = {
     # .. toggle_creation_date: 2020-06-11
     # .. toggle_expiration_date: None
     # .. toggle_tickets: https://openedx.atlassian.net/browse/TNL-7273
-    # .. toggle_status: supported
     # .. toggle_warnings: None
     'ENABLE_ORA_USERNAMES_ON_DATA_EXPORT': False,
 }

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -100,12 +100,43 @@ FEATURES = {
     # this should remain off in production until digest notifications are online.
     'ENABLE_DISCUSSION_HOME_PANEL': False,
 
-    # Set this to True if you want the discussion digest emails enabled automatically for new users.
-    # This will be set on all new account registrations.
-    # It is not recommended to enable this feature if ENABLE_DISCUSSION_HOME_PANEL is not enabled, since
-    # subscribers who receive digests in that case will only be able to unsubscribe via links embedded
-    # in their emails, and they will have no way to resubscribe.
+    """
+    .. toggle_name: ENABLE_DISCUSSION_EMAIL_DIGEST
+    .. toggle_implementation: DjangoSetting
+    .. toggle_default: False
+    .. toggle_description: Set this to True if you want the discussion digest emails
+      enabled automatically for new users. This will be set on all new account
+      registrations.
+    .. toggle_category: admin
+    .. toggle_use_cases: open_edx
+    .. toggle_creation_date: 2014-08-19
+    .. toggle_expiration_date: None
+    .. toggle_warnings: It is not recommended to enable this feature if
+      ENABLE_DISCUSSION_HOME_PANEL is not enabled, since subscribers who receive
+      digests in that case will only be able to unsubscribe via links embedded
+      in their emails, and they will have no way to resubscribe.
+    .. toggle_tickets: https://github.com/edx/edx-platform/pull/4891
+    .. toggle_status: supported
+    """
     'ENABLE_DISCUSSION_EMAIL_DIGEST': False,
+
+    """
+    .. toggle_name: ENABLE_UNICODE_USERNAME
+    .. toggle_implementation: DjangoSetting
+    .. toggle_default: False
+    .. toggle_description: Set this to True to allow unicode characters in username.
+      Enabling this will also automatically enable SOCIAL_AUTH_CLEAN_USERNAMES. When
+      this is enabled, usernames will have to match the regular expression defined by
+      USERNAME_REGEX_PARTIAL.
+    .. toggle_category: admin
+    .. toggle_use_cases: open_edx
+    .. toggle_creation_date: 2017-06-27
+    .. toggle_expiration_date: None
+    .. toggle_warnings: None
+    .. toggle_tickets: https://github.com/edx/edx-platform/pull/14729
+    .. toggle_status: supported
+    """
+    'ENABLE_UNICODE_USERNAME': False,
 
     'ENABLE_DJANGO_ADMIN_SITE': True,  # set true to enable django's admin site, even on prod (e.g. for course ops)
     'ENABLE_LMS_MIGRATION': False,
@@ -208,8 +239,52 @@ FEATURES = {
     # for acceptance and load testing
     'AUTOMATIC_AUTH_FOR_TESTING': False,
 
-    # Prevent auto auth from creating superusers or modifying existing users
+    """
+    .. toggle_name: RESTRICT_AUTOMATIC_AUTH
+    .. toggle_implementation: DjangoSetting
+    .. toggle_default: True
+    .. toggle_description: Prevent auto auth from creating superusers or modifying
+    existing users. Auto auth is a mechanism where superusers can simply modify
+    attributes of other users by accessing the "/auto_auth url" with the right
+    querystring parameters.
+    .. toggle_category: admin
+    .. toggle_use_cases: open_edx
+    .. toggle_creation_date: 2018-05-07
+    .. toggle_expiration_date: None
+    .. toggle_tickets: https://openedx.atlassian.net/browse/TE-2545
+    .. toggle_status: supported
+    """
     'RESTRICT_AUTOMATIC_AUTH': True,
+
+    """
+    .. toggle_name: ENABLE_LOGIN_MICROFRONTEND
+    .. toggle_implementation: DjangoSetting
+    .. toggle_default: False
+    .. toggle_description: Enable the login micro frontend.
+    .. toggle_category: admin
+    .. toggle_use_cases: open_edx
+    .. toggle_creation_date: 2018-05-07
+    .. toggle_expiration_date: None
+    .. toggle_warnings: The login MFE domain name should be listed in
+      LOGIN_REDIRECT_WHITELIST.
+    .. toggle_status: supported
+    """
+    'ENABLE_LOGIN_MICROFRONTEND': False,
+
+    """
+    .. toggle_name: SKIP_EMAIL_VALIDATION
+    .. toggle_implementation: DjangoSetting
+    .. toggle_default: False
+    .. toggle_description: Turn this on to skip sending emails for user validation.
+      Beware, as this leaves the door open to potential spam abuse.
+    .. toggle_category: admin
+    .. toggle_use_cases: open_edx
+    .. toggle_expiration_date: None
+    .. toggle_warnings: The login MFE domain name should be listed in
+      LOGIN_REDIRECT_WHITELIST.
+    .. toggle_status: supported
+    """
+    'SKIP_EMAIL_VALIDATION': False,
 
     # Toggle the availability of the shopping cart page
     'ENABLE_SHOPPING_CART': False,
@@ -290,6 +365,20 @@ FEATURES = {
     # ENABLE_OAUTH2_PROVIDER to True
     'ENABLE_MOBILE_REST_API': False,
 
+    """
+    .. toggle_name: ENABLE_COMBINED_LOGIN_REGISTRATION_FOOTER
+    .. toggle_implementation: DjangoSetting
+    .. toggle_default: False
+    .. toggle_description: Display the standard footer in the login page. This feature
+      can be overridden by a site-specific configuration.
+    .. toggle_category: admin
+    .. toggle_use_cases: open_edx
+    .. toggle_creation_date: 2016-06-24
+    .. toggle_expiration_date: None
+    .. toggle_tickets: https://openedx.atlassian.net/browse/OSPR-1320
+    .. toggle_status: supported
+    .. toggle_warnings: None
+    """
     'ENABLE_COMBINED_LOGIN_REGISTRATION_FOOTER': False,
 
     # Enable organizational email opt-in
@@ -389,7 +478,20 @@ FEATURES = {
     # Set this to False to facilitate cleaning up invalid xml from your modulestore.
     'ENABLE_XBLOCK_XML_VALIDATION': True,
 
-    # Allow public account creation
+    """
+    .. toggle_name: ALLOW_PUBLIC_ACCOUNT_CREATION
+    .. toggle_implementation: DjangoSetting
+    .. toggle_default: True
+    .. toggle_description: Allow public account creation. If this is disabled, users
+      will no longer have access to the signup page.
+    .. toggle_category: admin
+    .. toggle_use_cases: open_edx
+    .. toggle_creation_date: 2017-04-12
+    .. toggle_expiration_date: None
+    .. toggle_tickets: https://openedx.atlassian.net/browse/YONK-513
+    .. toggle_status: supported
+    .. toggle_warnings: None
+    """
     'ALLOW_PUBLIC_ACCOUNT_CREATION': True,
 
     # Enable footer banner for cookie consent.
@@ -418,8 +520,23 @@ FEATURES = {
     # Whether HTML XBlocks/XModules return HTML content with the Course Blocks API student_view_data
     'ENABLE_HTML_XBLOCK_STUDENT_VIEW_DATA': False,
 
-    # Whether to send an email for failed password reset attempts or not. This is mainly useful for notifying users
-    # that they don't have an account associated with email addresses they believe they've registered with.
+    """
+    .. toggle_name: ENABLE_CHANGE_USER_PASSWORD_ADMIN
+    .. toggle_implementation: DjangoSetting
+    .. toggle_default: False
+    .. toggle_description: Whether to send an email for failed password reset attempts
+      or not. This happens when a user asks for a password reset but they don't have an
+      account associated to their email. This is useful for notifying users that they
+      don't have an account associated with email addresses they believe they've
+      registered with. This setting can be overridden by a site-specific configuration.
+    .. toggle_category: admin
+    .. toggle_use_cases: open_edx
+    .. toggle_creation_date: 2017-07-20
+    .. toggle_expiration_date: None
+    .. toggle_tickets: https://openedx.atlassian.net/browse/OSPR-1832
+    .. toggle_status: supported
+    .. toggle_warnings: None
+    """
     'ENABLE_PASSWORD_RESET_FAILURE_EMAIL': False,
 
     # Sets the default browser support. For more information go to http://browser-update.org/customize.html

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -82,18 +82,49 @@ IDA_LOGOUT_URI_LIST = []
 
 # Features
 FEATURES = {
+    # .. toggle_name: DISPLAY_DEBUG_INFO_TO_STAFF
+    # .. toggle_implementation: DjangoSetting
+    # .. toggle_default: True
+    # .. toggle_description: Add a "Staff Debug" button to course modules for debugging by course staff.
+    # .. toggle_use_cases: ?
+    # .. toggle_creation_date: 2015-09-04
+    # .. toggle_expiration_date: None
+    # .. toggle_warnings: None
+    # .. toggle_tickets: https://github.com/edx/edx-platform/pull/2425
+    # .. toggle_status: supported
     'DISPLAY_DEBUG_INFO_TO_STAFF': True,
     'DISPLAY_HISTOGRAMS_TO_STAFF': False,  # For large courses this slows down courseware access for staff.
 
     'REROUTE_ACTIVATION_EMAIL': False,  # nonempty string = address for all activation emails
 
+    # .. toggle_name: DISABLE_START_DATES
+    # .. toggle_implementation: DjangoSetting
+    # .. toggle_default: False
+    # .. toggle_description: When True, all courses will be active, regardless of start date.
+    # .. toggle_use_cases: ?
+    # .. toggle_creation_date: ?
+    # .. toggle_expiration_date: None
+    # .. toggle_warnings: This will cause ALL courses to be immediately visible.
+    # .. toggle_tickets: https://github.com/edx/edx-platform/pull/17913
+    # .. toggle_status: supported
     ## DO NOT SET TO True IN THIS FILE
     ## Doing so will cause all courses to be released on production
-    'DISABLE_START_DATES': False,  # When True, all courses will be active, regardless of start date
+    'DISABLE_START_DATES': False,
 
     # for consistency in user-experience, keep the value of the following 3 settings
     # in sync with the corresponding ones in cms/envs/common.py
     'ENABLE_DISCUSSION_SERVICE': True,
+
+    # .. toggle_name: ENABLE_TEXTBOOK
+    # .. toggle_implementation: DjangoSetting
+    # .. toggle_default: True
+    # .. toggle_description: Add PDF and HTML textbook tabs to the courseware.
+    # .. toggle_use_cases: ?
+    # .. toggle_creation_date: 2014-03-27
+    # .. toggle_expiration_date: None
+    # .. toggle_warnings: None
+    # .. toggle_tickets: https://github.com/edx/edx-platform/pull/3064
+    # .. toggle_status: supported
     'ENABLE_TEXTBOOK': True,
 
     # discussion home panel, which includes a subscription on/off setting for discussion digest emails.
@@ -129,7 +160,17 @@ FEATURES = {
     'ENABLE_DJANGO_ADMIN_SITE': True,  # set true to enable django's admin site, even on prod (e.g. for course ops)
     'ENABLE_LMS_MIGRATION': False,
 
-    'ENABLE_MASQUERADE': True,  # allow course staff to change to student view of courseware
+    # .. toggle_name: ENABLE_MASQUERADE
+    # .. toggle_implementation: DjangoSetting
+    # .. toggle_default: True
+    # .. toggle_description: Allow course staff to change to student view of courseware by accessing the /course/{course_id}/masquerade url.
+    # .. toggle_use_cases: ?
+    # .. toggle_creation_date: 2013-04-13
+    # .. toggle_expiration_date: None
+    # .. toggle_warnings: None
+    # .. toggle_tickets: None
+    # .. toggle_status: supported
+    'ENABLE_MASQUERADE': True,
 
     # .. toggle_name: ENABLE_SYSADMIN_DASHBOARD
     # .. toggle_implementation: DjangoSetting
@@ -159,8 +200,16 @@ FEATURES = {
     # .. toggle_warnings: None
     'ENABLE_OAUTH2_PROVIDER': False,
 
-    # Allows to enable an API endpoint to serve XBlock view, used for example by external applications.
-    # See jquey-xblock: https://github.com/edx-solutions/jquery-xblock
+    # .. toggle_name: ENABLE_XBLOCK_VIEW_ENDPOINT
+    # .. toggle_implementation: DjangoSetting
+    # .. toggle_default: False
+    # .. toggle_description: Enable an API endpoint, named "xblock_view", to serve rendered XBlock views. This might be used by external applications. See for instance jquery-xblock (now unmaintained): https://github.com/edx-solutions/jquery-xblock
+    # .. toggle_use_cases: ?
+    # .. toggle_creation_date: 2014-03-14
+    # .. toggle_expiration_date: None
+    # .. toggle_warnings: None
+    # .. toggle_tickets: https://github.com/edx/edx-platform/pull/2968
+    # .. toggle_status: supported
     'ENABLE_XBLOCK_VIEW_ENDPOINT': False,
 
     # Allows to configure the LMS to provide CORS headers to serve requests from other domains
@@ -268,7 +317,16 @@ FEATURES = {
     # Enable flow for payments for course registration (DIFFERENT from verified student flow)
     'ENABLE_PAID_COURSE_REGISTRATION': False,
 
-    # Enable the display of cosmetic course price display (set in course advanced settings)
+    # .. toggle_name: ENABLE_COSMETIC_DISPLAY_PRICE
+    # .. toggle_implementation: DjangoSetting
+    # .. toggle_default: False
+    # .. toggle_description: Enable the display of "cosmetic_display_price", set in a course advanced settings. This cosmetic price is used when there is no registration price associated to the course.
+    # .. toggle_use_cases: ?
+    # .. toggle_creation_date: 2014-10-10
+    # .. toggle_expiration_date: None
+    # .. toggle_warnings: None
+    # .. toggle_tickets: https://github.com/edx/edx-platform/pull/6876
+    # .. toggle_status: supported
     'ENABLE_COSMETIC_DISPLAY_PRICE': False,
 
     # Automatically approve student identity verification attempts
@@ -311,7 +369,16 @@ FEATURES = {
     # toggle_warnings: None
     'ENABLE_THIRD_PARTY_AUTH': False,
 
-    # Toggle to enable alternate urls for marketing links
+    # .. toggle_name: ENABLE_MKTG_SITE
+    # .. toggle_implementation: DjangoSetting
+    # .. toggle_default: False
+    # .. toggle_description: Toggle to enable alternate urls for marketing links.
+    # .. toggle_use_cases: ?
+    # .. toggle_creation_date: 2014-03-24
+    # .. toggle_expiration_date: None
+    # .. toggle_warnings: When this is enabled, the MKTG_URLS setting should be defined.
+    # .. toggle_tickets: ?
+    # .. toggle_status: supported
     'ENABLE_MKTG_SITE': False,
 
     # Prevent concurrent logins per user
@@ -322,10 +389,29 @@ FEATURES = {
     # False to not redirect the user
     'ALWAYS_REDIRECT_HOMEPAGE_TO_DASHBOARD_FOR_AUTHENTICATED_USER': True,
 
-    # When a user goes to the homepage ('/') the user sees the
-    # courses listed in the announcement dates order - this is default Open edX behavior.
-    # Set to True to change the course sorting behavior by their start dates, latest first.
+    # .. toggle_name: ENABLE_COURSE_SORTING_BY_START_DATE
+    # .. toggle_implementation: DjangoSetting
+    # .. toggle_default: True
+    # .. toggle_description: When a user goes to the homepage ('/') the user sees the courses listed in the announcement dates order - this is default Open edX behavior. Set to True to change the course sorting behavior by their start dates, latest first.
+    # .. toggle_use_cases: ?
+    # .. toggle_creation_date: 2015-03-27
+    # .. toggle_expiration_date: None
+    # .. toggle_warnings: None
+    # .. toggle_tickets: https://github.com/edx/edx-platform/pull/7548
+    # .. toggle_status: supported
     'ENABLE_COURSE_SORTING_BY_START_DATE': True,
+
+    # .. toggle_name: ENABLE_COURSE_HOME_REDIRECT
+    # .. toggle_implementation: DjangoSetting
+    # .. toggle_default: True
+    # .. toggle_description: When enabled, along with the ENABLE_MKTG_SITE feature toggle, users who attempt to access a course "about" page will be redirected to the course home url. This url might be the course "info" page or the unified course tab (when the UNIFIED_COURSE_TAB_FLAG waffle is enabled).
+    # .. toggle_use_cases: ?
+    # .. toggle_creation_date: 2019-01-15
+    # .. toggle_expiration_date: None
+    # .. toggle_warnings: None
+    # .. toggle_tickets: https://github.com/edx/edx-platform/pull/19604
+    # .. toggle_status: supported
+    'ENABLE_COURSE_HOME_REDIRECT': True,
 
     # Expose Mobile REST API. Note that if you use this, you must also set
     # ENABLE_OAUTH2_PROVIDER to True
@@ -382,13 +468,31 @@ FEATURES = {
     # log all information from cybersource callbacks
     'LOG_POSTPAY_CALLBACKS': True,
 
-    # Toggle platform-wide course licensing
+    # .. toggle_name: LICENSING
+    # .. toggle_implementation: DjangoSetting
+    # .. toggle_default: False
+    # .. toggle_description: Toggle platform-wide course licensing. The course.license attribute is then used to append license information to the courseware.
+    # .. toggle_use_cases: ?
+    # .. toggle_creation_date: 2015-05-14
+    # .. toggle_expiration_date: None
+    # .. toggle_warnings: None
+    # .. toggle_tickets: https://github.com/edx/edx-platform/pull/7315
+    # .. toggle_status: supported
     'LICENSING': False,
 
     # Certificates Web/HTML Views
     'CERTIFICATES_HTML_VIEW': False,
 
-    # Course discovery feature
+    # .. toggle_name: ENABLE_COURSE_DISCOVERY
+    # .. toggle_implementation: DjangoSetting
+    # .. toggle_default: False
+    # .. toggle_description: Add a course search widget to the LMS for searching courses. When this is enabled, the latest courses are no longer displayed on the LMS landing page. Also, an "Explore Courses" item is added to the navbar.
+    # .. toggle_use_cases: ?
+    # .. toggle_creation_date: 2015-04-23
+    # .. toggle_expiration_date: None
+    # .. toggle_warnings: The COURSE_DISCOVERY_MEANINGS setting should be properly defined.
+    # .. toggle_tickets: https://github.com/edx/edx-platform/pull/7845
+    # .. toggle_status: supported
     'ENABLE_COURSE_DISCOVERY': False,
 
     # Setting for overriding default filtering facets for Course discovery
@@ -406,7 +510,16 @@ FEATURES = {
     # How many seconds to show the bumper again, default is 7 days:
     'SHOW_BUMPER_PERIODICITY': 7 * 24 * 3600,
 
-    # Special Exams, aka Timed and Proctored Exams
+    # .. toggle_name: ENABLE_SPECIAL_EXAMS
+    # .. toggle_implementation: DjangoSetting
+    # .. toggle_default: False
+    # .. toggle_description: Enable to use special exams, aka timed and proctored exams.
+    # .. toggle_use_cases: ?
+    # .. toggle_creation_date: 2015-09-04
+    # .. toggle_expiration_date: None
+    # .. toggle_warnings: None
+    # .. toggle_tickets: https://github.com/edx/edx-platform/pull/9744
+    # .. toggle_status: supported
     'ENABLE_SPECIAL_EXAMS': False,
 
     # Enable OpenBadge support. See the BADGR_* settings later in this file.
@@ -426,10 +539,16 @@ FEATURES = {
     # Show the language selector in the footer
     'SHOW_FOOTER_LANGUAGE_SELECTOR': False,
 
-    # Write new CSM history to the extended table.
-    # This will eventually default to True and may be
-    # removed since all installs should have the separate
-    # extended history table.
+    # .. toggle_name: ENABLE_CSMH_EXTENDED
+    # .. toggle_implementation: DjangoSetting
+    # .. toggle_default: True
+    # .. toggle_description: Write Courseware Student Module History (CSMH) to the extended table: this logs all student activities to MySQL, in a separate database.
+    # .. toggle_use_cases: ?
+    # .. toggle_creation_date: ?
+    # .. toggle_expiration_date: None
+    # .. toggle_warnings: Even though most Open edX instances run with a separate CSMH database, it may not always be the case. When disabling this feature flag, remember to remove "coursewarehistoryextended" from the INSTALLED_APPS and the "StudentModuleHistoryExtendedRouter" from the DATABASE_ROUTERS.
+    # .. toggle_tickets: None
+    # .. toggle_status: supported
     'ENABLE_CSMH_EXTENDED': True,
 
     # Read from both the CSMH and CSMHE history tables.
@@ -2860,6 +2979,14 @@ DISABLE_ACCOUNT_ACTIVATION_REQUIREMENT_SWITCH = "verify_student_disable_account_
 
 ################ Enable credit eligibility feature ####################
 ENABLE_CREDIT_ELIGIBILITY = True
+# .. toggle_name: ENABLE_CREDIT_ELIGIBILITY
+# .. toggle_implementation: DjangoSetting
+# .. toggle_default: True
+# .. toggle_description: When enabled, it is possible to define a credit eligibility criteria in the CMS. A "Credit
+#   Eligibility" section then appears for those courses in the LMS.
+# .. toggle_use_cases: open_edx
+# .. toggle_creation_date: 2015-06-17
+# .. toggle_tickets: https://github.com/edx/edx-platform/pull/8550
 FEATURES['ENABLE_CREDIT_ELIGIBILITY'] = ENABLE_CREDIT_ELIGIBILITY
 
 ############# Cross-domain requests #################

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -139,7 +139,6 @@ FEATURES = {
     # .. toggle_description: Set this to True if you want the discussion digest emails
     #   enabled automatically for new users. This will be set on all new account
     #   registrations.
-    # .. toggle_category: admin
     # .. toggle_use_cases: open_edx
     # .. toggle_creation_date: 2014-08-19
     # .. toggle_expiration_date: None
@@ -187,7 +186,6 @@ FEATURES = {
     # .. toggle_default: False
     # .. toggle_description: enables dashboard at /syadmin/ for django staff, for seeing overview of system status, for
     #   deleting and loading courses, for seeing log of git imports of courseware.
-    # .. toggle_category: admin
     # .. toggle_use_cases: open_edx
     # .. toggle_creation_date: 2013-12-12
     # .. toggle_expiration_date: None
@@ -203,7 +201,6 @@ FEATURES = {
     # .. toggle_default: False
     # .. toggle_description: Enable this feature to allow this Open edX platform to be an OAuth2 authentication
     #   provider. This is necessary to enable some other features, such as the REST API for the mobile application.
-    # .. toggle_category: admin
     # .. toggle_use_cases: monitored_rollout
     # .. toggle_creation_date: 2014-09-09
     # .. toggle_expiration_date: None
@@ -275,7 +272,6 @@ FEATURES = {
     # .. toggle_default: False
     # .. toggle_description: Set to True to disable honor certificates. Typically used when your installation only
     #   allows verified certificates, like courses.edx.org.
-    # .. toggle_category: certificates
     # .. toggle_use_cases: open_edx
     # .. toggle_creation_date: 2019-05-14
     # .. toggle_expiration_date: None
@@ -296,7 +292,6 @@ FEATURES = {
     #   mechanism where superusers can simply modify attributes of other users by accessing the "/auto_auth url" with
     #   the right
     #   querystring parameters.
-    # .. toggle_category: admin
     # .. toggle_use_cases: open_edx
     # .. toggle_creation_date: 2018-05-07
     # .. toggle_expiration_date: None
@@ -450,7 +445,6 @@ FEATURES = {
     # .. toggle_default: False
     # .. toggle_description: Display the standard footer in the login page. This feature can be overridden by a site-
     #   specific configuration.
-    # .. toggle_category: admin
     # .. toggle_use_cases: open_edx
     # .. toggle_creation_date: 2016-06-24
     # .. toggle_expiration_date: None
@@ -600,7 +594,6 @@ FEATURES = {
     # .. toggle_default: True
     # .. toggle_description: Allow public account creation. If this is disabled, users will no longer have access to
     #   the signup page.
-    # .. toggle_category: admin
     # .. toggle_use_cases: open_edx
     # .. toggle_creation_date: 2017-04-12
     # .. toggle_expiration_date: None
@@ -642,7 +635,6 @@ FEATURES = {
     #   user asks for a password reset but they don't have an account associated to their email. This is useful for
     #   notifying users that they don't have an account associated with email addresses they believe they've registered
     #   with. This setting can be overridden by a site-specific configuration.
-    # .. toggle_category: admin
     # .. toggle_use_cases: open_edx
     # .. toggle_creation_date: 2017-07-20
     # .. toggle_expiration_date: None
@@ -666,7 +658,6 @@ FEATURES = {
     # .. toggle_default: False
     # .. toggle_description: Set to True to enable changing a user password through django admin. This is disabled by
     #   default because enabling allows a method to bypass password policy.
-    # .. toggle_category: admin
     # .. toggle_use_cases: open_edx
     # .. toggle_creation_date: 2020-02-21
     # .. toggle_expiration_date: None
@@ -680,7 +671,6 @@ FEATURES = {
     # .. toggle_default: False
     # .. toggle_description: Set to True to enable the Courseware MFE at the platform level for global staff (see
     #   REDIRECT_TO_COURSEWARE_MICROFRONTEND for course rollout)
-    # .. toggle_category: admin
     # .. toggle_use_cases: open_edx
     # .. toggle_creation_date: 2020-03-05
     # .. toggle_expiration_date: None
@@ -694,7 +684,6 @@ FEATURES = {
     # .. toggle_implementation: DjangoSetting
     # .. toggle_default: False
     # .. toggle_description: Supports staged rollout of a new micro-frontend-based implementation of the logistration.
-    # .. toggle_category: micro-frontend
     # .. toggle_use_cases: incremental_release, open_edx
     # .. toggle_creation_date: 2020-09-08
     # .. toggle_expiration_date: None
@@ -709,7 +698,6 @@ FEATURES = {
     # .. toggle_implementation: DjangoSetting
     # .. toggle_default: False
     # .. toggle_description: Set to True to enable team-based ORA submissions.
-    # .. toggle_category: ora
     # .. toggle_use_cases: incremental_release
     # .. toggle_creation_date: 2020-03-03
     # .. toggle_expiration_date: None
@@ -724,7 +712,6 @@ FEATURES = {
     # .. toggle_description: A "work-around" feature toggle meant to help in cases where some file uploads are not
     #   discoverable.  If enabled, will iterate through all possible file key suffixes up to the max for displaying
     #  file metadata in staff assessments.
-    # .. toggle_category: ora
     # .. toggle_use_cases: graceful_degradation
     # .. toggle_creation_date: 2020-03-03
     # .. toggle_expiration_date: None
@@ -738,7 +725,6 @@ FEATURES = {
     # .. toggle_default: False
     # .. toggle_description: A "work-around" feature toggle meant to help in cases where some file uploads are not
     #   discoverable.  If enabled, will pull file metadata from StudentModule.state for display in staff assessments.
-    # .. toggle_category: ora
     # .. toggle_use_cases: graceful_degradation
     # .. toggle_creation_date: 2020-03-03
     # .. toggle_expiration_date: None
@@ -752,7 +738,6 @@ FEATURES = {
     # .. toggle_default: False
     # .. toggle_description: Set to True to add deanonymized usernames to ORA data
     #   report.
-    # .. toggle_category: ora
     # .. toggle_use_cases: incremental_release
     # .. toggle_creation_date: 2020-06-11
     # .. toggle_expiration_date: None

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -87,10 +87,8 @@ FEATURES = {
     # .. toggle_default: True
     # .. toggle_description: Add a "Staff Debug" button to course modules for debugging
     #   by course staff.
-    # .. toggle_use_cases: ?
+    # .. toggle_use_cases: open_edx
     # .. toggle_creation_date: 2015-09-04
-    # .. toggle_target_removal_date: None
-    # .. toggle_warnings: None
     # .. toggle_tickets: https://github.com/edx/edx-platform/pull/2425
     'DISPLAY_DEBUG_INFO_TO_STAFF': True,
     'DISPLAY_HISTOGRAMS_TO_STAFF': False,  # For large courses this slows down courseware access for staff.
@@ -102,9 +100,7 @@ FEATURES = {
     # .. toggle_default: False
     # .. toggle_description: When True, all courses will be active, regardless of start
     #   date.
-    # .. toggle_use_cases: ?
-    # .. toggle_creation_date: ?
-    # .. toggle_target_removal_date: None
+    # .. toggle_use_cases: open_edx
     # .. toggle_warnings: This will cause ALL courses to be immediately visible.
     # .. toggle_tickets: https://github.com/edx/edx-platform/pull/17913
     ## DO NOT SET TO True IN THIS FILE
@@ -119,10 +115,8 @@ FEATURES = {
     # .. toggle_implementation: DjangoSetting
     # .. toggle_default: True
     # .. toggle_description: Add PDF and HTML textbook tabs to the courseware.
-    # .. toggle_use_cases: ?
+    # .. toggle_use_cases: open_edx
     # .. toggle_creation_date: 2014-03-27
-    # .. toggle_target_removal_date: None
-    # .. toggle_warnings: None
     # .. toggle_tickets: https://github.com/edx/edx-platform/pull/3064
     'ENABLE_TEXTBOOK': True,
 
@@ -138,27 +132,21 @@ FEATURES = {
     #   registrations.
     # .. toggle_use_cases: open_edx
     # .. toggle_creation_date: 2014-08-19
-    # .. toggle_target_removal_date: None
-    # .. toggle_warnings: It is not recommended to enable this feature if
-    #   ENABLE_DISCUSSION_HOME_PANEL is not enabled, since subscribers who receive
-    #   digests in that case will only be able to unsubscribe via links embedded in
+    # .. toggle_warnings: It is not recommended to enable this feature if ENABLE_DISCUSSION_HOME_PANEL is not enabled,
+    #   since subscribers who receive digests in that case will only be able to unsubscribe via links embedded in
     #   their emails, and they will have no way to resubscribe.
     # .. toggle_tickets: https://github.com/edx/edx-platform/pull/4891
     'ENABLE_DISCUSSION_EMAIL_DIGEST': False,
 
-    # toggle_name: ENABLE_UNICODE_USERNAME
-    # toggle_implementation: DjangoSetting
-    # toggle_default: False
-    # toggle_description: Set this to True to allow unicode characters in username. Enabling this will also
+    # .. toggle_name: ENABLE_UNICODE_USERNAME
+    # .. toggle_implementation: DjangoSetting
+    # .. toggle_default: False
+    # .. toggle_description: Set this to True to allow unicode characters in username. Enabling this will also
     #   automatically enable SOCIAL_AUTH_CLEAN_USERNAMES. When this is enabled, usernames will have to match the
     #   regular expression defined by USERNAME_REGEX_PARTIAL.
-    # toggle_category: admin
-    # toggle_use_cases: open_edx
-    # toggle_creation_date: 2017-06-27
-    # toggle_target_removal_date: None
-    # toggle_warnings: None
-    # toggle_tickets: https://github.com/edx/edx-platform/pull/14729
-    # toggle_status: supported
+    # .. toggle_use_cases: open_edx
+    # .. toggle_creation_date: 2017-06-27
+    # .. toggle_tickets: https://github.com/edx/edx-platform/pull/14729
     'ENABLE_UNICODE_USERNAME': False,
 
     'ENABLE_DJANGO_ADMIN_SITE': True,  # set true to enable django's admin site, even on prod (e.g. for course ops)
@@ -167,26 +155,19 @@ FEATURES = {
     # .. toggle_name: ENABLE_MASQUERADE
     # .. toggle_implementation: DjangoSetting
     # .. toggle_default: True
-    # .. toggle_description: Allow course staff to change to student view of courseware by accessing the
-    #   /course/{course_id}/masquerade url.
-    # .. toggle_use_cases: ?
+    # .. toggle_use_cases: open_edx
     # .. toggle_creation_date: 2013-04-13
-    # .. toggle_target_removal_date: None
-    # .. toggle_warnings: None
-    # .. toggle_tickets: None
     'ENABLE_MASQUERADE': True,
 
     # .. toggle_name: ENABLE_SYSADMIN_DASHBOARD
     # .. toggle_implementation: DjangoSetting
     # .. toggle_default: False
     # .. toggle_description: enables dashboard at /syadmin/ for django staff, for seeing overview of system status, for
-    #   deleting and loading courses, for seeing log of git imports of courseware. Note that some views are not
-    #   performant when there are more than 100 courses.
+    #   deleting and loading courses, for seeing log of git imports of courseware. Note that some views are noopen_edx
     # .. toggle_use_cases: open_edx
     # .. toggle_creation_date: 2013-12-12
     # .. toggle_target_removal_date: None
-    # .. toggle_warnings: This feature is not supported anymore.
-    # .. toggle_tickets: None
+    # .. toggle_warnings: This feature is not supported anymore and should have a target removal date.
     'ENABLE_SYSADMIN_DASHBOARD': False,  # sysadmin dashboard, to see what courses are loaded, to delete & load courses
 
     'DISABLE_LOGIN_BUTTON': False,  # used in systems where login is automatic, eg MIT SSL
@@ -199,7 +180,7 @@ FEATURES = {
     # .. toggle_use_cases: temporary
     # .. toggle_creation_date: 2014-09-09
     # .. toggle_target_removal_date: None
-    # .. toggle_warnings: None
+    # .. toggle_warnings: This temporary feature toggle does not have a target removal date.
     'ENABLE_OAUTH2_PROVIDER': False,
 
     # .. toggle_name: ENABLE_XBLOCK_VIEW_ENDPOINT
@@ -208,10 +189,8 @@ FEATURES = {
     # .. toggle_description: Enable an API endpoint, named "xblock_view", to serve rendered XBlock views. This might be
     #   used by external applications. See for instance jquery-xblock (now unmaintained):
     #   https://github.com/edx-solutions/jquery-xblock
-    # .. toggle_use_cases: ?
+    # .. toggle_use_cases: open_edx
     # .. toggle_creation_date: 2014-03-14
-    # .. toggle_target_removal_date: None
-    # .. toggle_warnings: None
     # .. toggle_tickets: https://github.com/edx/edx-platform/pull/2968
     'ENABLE_XBLOCK_VIEW_ENDPOINT': False,
 
@@ -267,9 +246,7 @@ FEATURES = {
     #   allows verified certificates, like courses.edx.org.
     # .. toggle_use_cases: open_edx
     # .. toggle_creation_date: 2019-05-14
-    # .. toggle_target_removal_date: None
     # .. toggle_tickets: https://openedx.atlassian.net/browse/PROD-269
-    # .. toggle_warnings: ???
     'DISABLE_HONOR_CERTIFICATES': False,  # Toggle to disable honor certificates
 
     'DISABLE_AUDIT_CERTIFICATES': False,  # Toggle to disable audit certificates
@@ -286,32 +263,25 @@ FEATURES = {
     #   querystring parameters.
     # .. toggle_use_cases: open_edx
     # .. toggle_creation_date: 2018-05-07
-    # .. toggle_target_removal_date: None
     # .. toggle_tickets: https://openedx.atlassian.net/browse/TE-2545
     'RESTRICT_AUTOMATIC_AUTH': True,
 
-    # toggle_name: ENABLE_LOGIN_MICROFRONTEND
-    # toggle_implementation: DjangoSetting
-    # toggle_default: False
-    # toggle_description: Enable the login micro frontend.
-    # toggle_category: admin
-    # toggle_use_cases: open_edx
-    # toggle_creation_date: 2018-05-07
-    # toggle_target_removal_date: None
-    # toggle_warnings: The login MFE domain name should be listed in LOGIN_REDIRECT_WHITELIST.
-    # toggle_status: supported
+    # .. toggle_name: ENABLE_LOGIN_MICROFRONTEND
+    # .. toggle_implementation: DjangoSetting
+    # .. toggle_default: False
+    # .. toggle_description: Enable the login micro frontend.
+    # .. toggle_use_cases: open_edx
+    # .. toggle_creation_date: 2018-05-07
+    # .. toggle_warnings: The login MFE domain name should be listed in LOGIN_REDIRECT_WHITELIST.
     'ENABLE_LOGIN_MICROFRONTEND': False,
 
-    # toggle_name: SKIP_EMAIL_VALIDATION
-    # toggle_implementation: DjangoSetting
-    # toggle_default: False
-    # toggle_description: Turn this on to skip sending emails for user validation.
+    # .. toggle_name: SKIP_EMAIL_VALIDATION
+    # .. toggle_implementation: DjangoSetting
+    # .. toggle_default: False
+    # .. toggle_description: Turn this on to skip sending emails for user validation.
     #   Beware, as this leaves the door open to potential spam abuse.
-    # toggle_category: admin
-    # toggle_use_cases: open_edx
-    # toggle_target_removal_date: None
-    # toggle_warnings: The login MFE domain name should be listed in LOGIN_REDIRECT_WHITELIST.
-    # toggle_status: supported
+    # .. toggle_use_cases: open_edx
+    # .. toggle_warnings: The login MFE domain name should be listed in LOGIN_REDIRECT_WHITELIST.
     'SKIP_EMAIL_VALIDATION': False,
 
     # Toggle the availability of the shopping cart page
@@ -328,11 +298,10 @@ FEATURES = {
     # .. toggle_default: False
     # .. toggle_description: Enable the display of "cosmetic_display_price", set in a course advanced settings. This
     #   cosmetic price is used when there is no registration price associated to the course.
-    # .. toggle_use_cases: ?
+    # .. toggle_use_cases: open_edx
     # .. toggle_creation_date: 2014-10-10
-    # .. toggle_target_removal_date: None
-    # .. toggle_warnings: None
     # .. toggle_tickets: https://github.com/edx/edx-platform/pull/6876
+    # .. toggle_warnings: The use case of this feature toggle is uncertain.
     'ENABLE_COSMETIC_DISPLAY_PRICE': False,
 
     # Automatically approve student identity verification attempts
@@ -363,30 +332,25 @@ FEATURES = {
     # defaults, so that we maintain current behavior
     'ALLOW_WIKI_ROOT_ACCESS': True,
 
-    # toggle_name: ENABLE_THIRD_PARTY_AUTH
-    # toggle_implementation: DjangoSetting
-    # toggle_default: False
-    # toggle_description: Turn on third-party auth. Disabled for now because full mplementations are not yet available.
-    #   Remember to run migrations if you enable this; we don't create tables by default. This feature can be enabled
-    #   on a per-site basis. When enabling this feature, remember to define the allowed authentication backends with
-    #   the AUTHENTICATION_BACKENDS setting.
-    # toggle_category: admin
-    # toggle_use_cases: open_edx
-    # toggle_creation_date: 2014-09-15
-    # toggle_target_removal_date: None
-    # toggle_status: supported
-    # toggle_warnings: None
+    # .. toggle_name: ENABLE_THIRD_PARTY_AUTH
+    # .. toggle_implementation: DjangoSetting
+    # .. toggle_default: False
+    # .. toggle_description: Turn on third-party auth. Disabled for now because full mplementations are not yet
+    #   available. Remember to run migrations if you enable this; we don't create tables by default. This feature can
+    #   be enabled on a per-site basis. When enabling this feature, remember to define the allowed authentication
+    #   backends with the AUTHENTICATION_BACKENDS setting.
+    # .. toggle_use_cases: open_edx
+    # .. toggle_creation_date: 2014-09-15
     'ENABLE_THIRD_PARTY_AUTH': False,
 
     # .. toggle_name: ENABLE_MKTG_SITE
     # .. toggle_implementation: DjangoSetting
     # .. toggle_default: False
     # .. toggle_description: Toggle to enable alternate urls for marketing links.
-    # .. toggle_use_cases: ?
+    # .. toggle_use_cases: open_edx
     # .. toggle_creation_date: 2014-03-24
-    # .. toggle_target_removal_date: None
-    # .. toggle_warnings: When this is enabled, the MKTG_URLS setting should be defined.
-    # .. toggle_tickets: ?
+    # .. toggle_warnings: When this is enabled, the MKTG_URLS setting should be defined. The use case of this feature
+    #   toggle is uncertain.
     'ENABLE_MKTG_SITE': False,
 
     # Prevent concurrent logins per user
@@ -403,10 +367,8 @@ FEATURES = {
     # .. toggle_description: When a user goes to the homepage ('/') the user sees the courses listed in the
     #   announcement dates order - this is default Open edX behavior. Set to True to change the course sorting behavior
     #   by their start dates, latest first.
-    # .. toggle_use_cases: ?
+    # .. toggle_use_cases: open_edx
     # .. toggle_creation_date: 2015-03-27
-    # .. toggle_target_removal_date: None
-    # .. toggle_warnings: None
     # .. toggle_tickets: https://github.com/edx/edx-platform/pull/7548
     'ENABLE_COURSE_SORTING_BY_START_DATE': True,
 
@@ -416,10 +378,8 @@ FEATURES = {
     # .. toggle_description: When enabled, along with the ENABLE_MKTG_SITE feature toggle, users who attempt to access a
     #   course "about" page will be redirected to the course home url. This url might be the course "info" page or the
     #   unified course tab (when the UNIFIED_COURSE_TAB_FLAG waffle is enabled).
-    # .. toggle_use_cases: ?
+    # .. toggle_use_cases: open_edx
     # .. toggle_creation_date: 2019-01-15
-    # .. toggle_target_removal_date: None
-    # .. toggle_warnings: None
     # .. toggle_tickets: https://github.com/edx/edx-platform/pull/19604
     'ENABLE_COURSE_HOME_REDIRECT': True,
 
@@ -434,9 +394,7 @@ FEATURES = {
     #   specific configuration.
     # .. toggle_use_cases: open_edx
     # .. toggle_creation_date: 2016-06-24
-    # .. toggle_target_removal_date: None
     # .. toggle_tickets: https://openedx.atlassian.net/browse/OSPR-1320
-    # .. toggle_warnings: None
     'ENABLE_COMBINED_LOGIN_REGISTRATION_FOOTER': False,
 
     # Enable organizational email opt-in
@@ -482,10 +440,8 @@ FEATURES = {
     # .. toggle_default: False
     # .. toggle_description: Toggle platform-wide course licensing. The course.license attribute is then used to append
     #   license information to the courseware.
-    # .. toggle_use_cases: ?
+    # .. toggle_use_cases: open_edx
     # .. toggle_creation_date: 2015-05-14
-    # .. toggle_target_removal_date: None
-    # .. toggle_warnings: None
     # .. toggle_tickets: https://github.com/edx/edx-platform/pull/7315
     'LICENSING': False,
 
@@ -498,9 +454,8 @@ FEATURES = {
     # .. toggle_description: Add a course search widget to the LMS for searching courses. When this is enabled, the
     #   latest courses are no longer displayed on the LMS landing page. Also, an "Explore Courses" item is added to the
     #   navbar.
-    # .. toggle_use_cases: ?
+    # .. toggle_use_cases: open_edx
     # .. toggle_creation_date: 2015-04-23
-    # .. toggle_target_removal_date: None
     # .. toggle_warnings: The COURSE_DISCOVERY_MEANINGS setting should be properly defined.
     # .. toggle_tickets: https://github.com/edx/edx-platform/pull/7845
     'ENABLE_COURSE_DISCOVERY': False,
@@ -524,10 +479,8 @@ FEATURES = {
     # .. toggle_implementation: DjangoSetting
     # .. toggle_default: False
     # .. toggle_description: Enable to use special exams, aka timed and proctored exams.
-    # .. toggle_use_cases: ?
+    # .. toggle_use_cases: open_edx
     # .. toggle_creation_date: 2015-09-04
-    # .. toggle_target_removal_date: None
-    # .. toggle_warnings: None
     # .. toggle_tickets: https://github.com/edx/edx-platform/pull/9744
     'ENABLE_SPECIAL_EXAMS': False,
 
@@ -553,13 +506,10 @@ FEATURES = {
     # .. toggle_default: True
     # .. toggle_description: Write Courseware Student Module History (CSMH) to the extended table: this logs all
     #   student activities to MySQL, in a separate database.
-    # .. toggle_use_cases: ?
-    # .. toggle_creation_date: ?
-    # .. toggle_target_removal_date: None
+    # .. toggle_use_cases: open_edx
     # .. toggle_warnings: Even though most Open edX instances run with a separate CSMH database, it may not always be
     #   the case. When disabling this feature flag, remember to remove "coursewarehistoryextended" from the
     #   INSTALLED_APPS and the "StudentModuleHistoryExtendedRouter" from the DATABASE_ROUTERS.
-    # .. toggle_tickets: None
     'ENABLE_CSMH_EXTENDED': True,
 
     # Read from both the CSMH and CSMHE history tables.
@@ -578,9 +528,7 @@ FEATURES = {
     #   the signup page.
     # .. toggle_use_cases: open_edx
     # .. toggle_creation_date: 2017-04-12
-    # .. toggle_target_removal_date: None
     # .. toggle_tickets: https://openedx.atlassian.net/browse/YONK-513
-    # .. toggle_warnings: None
     'ALLOW_PUBLIC_ACCOUNT_CREATION': True,
 
     # Enable footer banner for cookie consent.
@@ -618,9 +566,7 @@ FEATURES = {
     #   with. This setting can be overridden by a site-specific configuration.
     # .. toggle_use_cases: open_edx
     # .. toggle_creation_date: 2017-07-20
-    # .. toggle_target_removal_date: None
     # .. toggle_tickets: https://openedx.atlassian.net/browse/OSPR-1832
-    # .. toggle_warnings: None
     'ENABLE_PASSWORD_RESET_FAILURE_EMAIL': False,
 
     # Sets the default browser support. For more information go to http://browser-update.org/customize.html
@@ -640,9 +586,7 @@ FEATURES = {
     #   default because enabling allows a method to bypass password policy.
     # .. toggle_use_cases: open_edx
     # .. toggle_creation_date: 2020-02-21
-    # .. toggle_target_removal_date: None
     # .. toggle_tickets: 'https://github.com/edx/edx-platform/pull/21616'
-    # .. toggle_warnings: None
     'ENABLE_CHANGE_USER_PASSWORD_ADMIN': False,
 
     # .. toggle_name: ENABLE_COURSEWARE_MICROFRONTEND
@@ -652,7 +596,6 @@ FEATURES = {
     #   REDIRECT_TO_COURSEWARE_MICROFRONTEND for course rollout)
     # .. toggle_use_cases: open_edx
     # .. toggle_creation_date: 2020-03-05
-    # .. toggle_target_removal_date: None
     # .. toggle_tickets: 'https://github.com/edx/edx-platform/pull/23317'
     # .. toggle_warnings: Also set settings.LEARNING_MICROFRONTEND_URL and see REDIRECT_TO_COURSEWARE_MICROFRONTEND for
     #   rollout.
@@ -662,11 +605,12 @@ FEATURES = {
     # .. toggle_implementation: DjangoSetting
     # .. toggle_default: False
     # .. toggle_description: Supports staged rollout of a new micro-frontend-based implementation of the logistration.
-    # .. toggle_use_cases: incremental_release, open_edx
+    # .. toggle_use_cases: temporary, open_edx
     # .. toggle_creation_date: 2020-09-08
     # .. toggle_target_removal_date: None
     # .. toggle_tickets: 'https://github.com/edx/edx-platform/pull/24908'
-    # .. toggle_warnings: Also set settings.ACCOUNT_MICROFRONTEND_URL and set REDIRECT_TO_ACCOUNT_MICROFRONTEND for rollout.
+    # .. toggle_warnings: Also set settings.ACCOUNT_MICROFRONTEND_URL and set REDIRECT_TO_ACCOUNT_MICROFRONTEND for
+    #   rollout. This temporary feature toggle does not have a target removal date.
     'ENABLE_LOGISTRATION_MICROFRONTEND': False,
 
     ### ORA Feature Flags ###
@@ -675,11 +619,11 @@ FEATURES = {
     # .. toggle_implementation: DjangoSetting
     # .. toggle_default: False
     # .. toggle_description: Set to True to enable team-based ORA submissions.
-    # .. toggle_use_cases: incremental_release
+    # .. toggle_use_cases: temporary
     # .. toggle_creation_date: 2020-03-03
     # .. toggle_target_removal_date: None
     # .. toggle_tickets: https://openedx.atlassian.net/browse/EDUCATOR-4951
-    # .. toggle_warnings: None
+    # .. toggle_warnings: This temporary feature toggle does not have a target removal date.
     'ENABLE_ORA_TEAM_SUBMISSIONS': False,
 
     # .. toggle_name: ENABLE_ORA_ALL_FILE_URLS
@@ -692,7 +636,7 @@ FEATURES = {
     # .. toggle_creation_date: 2020-03-03
     # .. toggle_target_removal_date: None
     # .. toggle_tickets: https://openedx.atlassian.net/browse/EDUCATOR-4951
-    # .. toggle_warnings: None
+    # .. toggle_warnings: This temporary feature toggle does not have a target removal date.
     'ENABLE_ORA_ALL_FILE_URLS': False,
 
     # .. toggle_name: ENABLE_ORA_USER_STATE_UPLOAD_DATA
@@ -704,7 +648,7 @@ FEATURES = {
     # .. toggle_creation_date: 2020-03-03
     # .. toggle_target_removal_date: None
     # .. toggle_tickets: https://openedx.atlassian.net/browse/EDUCATOR-4951
-    # .. toggle_warnings: None
+    # .. toggle_warnings: This temporary feature toggle does not have a target removal date.
     'ENABLE_ORA_USER_STATE_UPLOAD_DATA': False,
 
     # .. toggle_name: ENABLE_ORA_USERNAMES_ON_DATA_EXPORT
@@ -712,11 +656,11 @@ FEATURES = {
     # .. toggle_default: False
     # .. toggle_description: Set to True to add deanonymized usernames to ORA data
     #   report.
-    # .. toggle_use_cases: incremental_release
+    # .. toggle_use_cases: temporary
     # .. toggle_creation_date: 2020-06-11
     # .. toggle_target_removal_date: None
     # .. toggle_tickets: https://openedx.atlassian.net/browse/TNL-7273
-    # .. toggle_warnings: None
+    # .. toggle_warnings: This temporary feature toggle does not have a target removal date.
     'ENABLE_ORA_USERNAMES_ON_DATA_EXPORT': False,
 }
 

--- a/openedx/core/djangoapps/user_api/accounts/toggles.py
+++ b/openedx/core/djangoapps/user_api/accounts/toggles.py
@@ -13,7 +13,7 @@ from openedx.core.djangoapps.waffle_utils import WaffleFlag
 # .. toggle_description: Supports staged rollout of a new micro-frontend-based implementation of the order history page.
 # .. toggle_use_cases: incremental_release, open_edx
 # .. toggle_creation_date: 2019-04-11
-# .. toggle_expiration_date: 2020-12-31
+# .. toggle_target_removal_date: 2020-12-31
 # .. toggle_warnings: Also set settings.ORDER_HISTORY_MICROFRONTEND_URL and site's
 #   ENABLE_ORDER_HISTORY_MICROFRONTEND.
 # .. toggle_tickets: DEPR-17
@@ -33,7 +33,7 @@ def should_redirect_to_order_history_microfrontend():
 # .. toggle_description: Supports staged rollout of a new micro-frontend-based implementation of the account page.
 # .. toggle_use_cases: incremental_release, open_edx
 # .. toggle_creation_date: 2019-04-30
-# .. toggle_expiration_date: 2020-12-31
+# .. toggle_target_removal_date: 2020-12-31
 # .. toggle_warnings: Also set settings.ACCOUNT_MICROFRONTEND_URL and site's ENABLE_ACCOUNT_MICROFRONTEND.
 # .. toggle_tickets: DEPR-17
 REDIRECT_TO_ACCOUNT_MICROFRONTEND = WaffleFlag('account', 'redirect_to_microfrontend', __name__)

--- a/openedx/core/djangoapps/user_api/accounts/toggles.py
+++ b/openedx/core/djangoapps/user_api/accounts/toggles.py
@@ -11,7 +11,7 @@ from openedx.core.djangoapps.waffle_utils import WaffleFlag
 # .. toggle_implementation: WaffleFlag
 # .. toggle_default: False
 # .. toggle_description: Supports staged rollout of a new micro-frontend-based implementation of the order history page.
-# .. toggle_use_cases: incremental_release, open_edx
+# .. toggle_use_cases: temporary, open_edx
 # .. toggle_creation_date: 2019-04-11
 # .. toggle_target_removal_date: 2020-12-31
 # .. toggle_warnings: Also set settings.ORDER_HISTORY_MICROFRONTEND_URL and site's
@@ -31,7 +31,7 @@ def should_redirect_to_order_history_microfrontend():
 # .. toggle_implementation: WaffleFlag
 # .. toggle_default: False
 # .. toggle_description: Supports staged rollout of a new micro-frontend-based implementation of the account page.
-# .. toggle_use_cases: incremental_release, open_edx
+# .. toggle_use_cases: temporary, open_edx
 # .. toggle_creation_date: 2019-04-30
 # .. toggle_target_removal_date: 2020-12-31
 # .. toggle_warnings: Also set settings.ACCOUNT_MICROFRONTEND_URL and site's ENABLE_ACCOUNT_MICROFRONTEND.

--- a/openedx/core/djangoapps/user_api/accounts/toggles.py
+++ b/openedx/core/djangoapps/user_api/accounts/toggles.py
@@ -17,7 +17,6 @@ from openedx.core.djangoapps.waffle_utils import WaffleFlag
 # .. toggle_warnings: Also set settings.ORDER_HISTORY_MICROFRONTEND_URL and site's
 #   ENABLE_ORDER_HISTORY_MICROFRONTEND.
 # .. toggle_tickets: DEPR-17
-# .. toggle_status: supported
 REDIRECT_TO_ORDER_HISTORY_MICROFRONTEND = WaffleFlag('order_history', 'redirect_to_microfrontend', __name__)
 
 
@@ -37,7 +36,6 @@ def should_redirect_to_order_history_microfrontend():
 # .. toggle_expiration_date: 2020-12-31
 # .. toggle_warnings: Also set settings.ACCOUNT_MICROFRONTEND_URL and site's ENABLE_ACCOUNT_MICROFRONTEND.
 # .. toggle_tickets: DEPR-17
-# .. toggle_status: supported
 REDIRECT_TO_ACCOUNT_MICROFRONTEND = WaffleFlag('account', 'redirect_to_microfrontend', __name__)
 
 

--- a/openedx/core/djangoapps/user_api/accounts/toggles.py
+++ b/openedx/core/djangoapps/user_api/accounts/toggles.py
@@ -11,7 +11,6 @@ from openedx.core.djangoapps.waffle_utils import WaffleFlag
 # .. toggle_implementation: WaffleFlag
 # .. toggle_default: False
 # .. toggle_description: Supports staged rollout of a new micro-frontend-based implementation of the order history page.
-# .. toggle_category: micro-frontend
 # .. toggle_use_cases: incremental_release, open_edx
 # .. toggle_creation_date: 2019-04-11
 # .. toggle_expiration_date: 2020-12-31
@@ -33,7 +32,6 @@ def should_redirect_to_order_history_microfrontend():
 # .. toggle_implementation: WaffleFlag
 # .. toggle_default: False
 # .. toggle_description: Supports staged rollout of a new micro-frontend-based implementation of the account page.
-# .. toggle_category: micro-frontend
 # .. toggle_use_cases: incremental_release, open_edx
 # .. toggle_creation_date: 2019-04-30
 # .. toggle_expiration_date: 2020-12-31

--- a/openedx/core/djangoapps/user_api/accounts/toggles.py
+++ b/openedx/core/djangoapps/user_api/accounts/toggles.py
@@ -15,7 +15,8 @@ from openedx.core.djangoapps.waffle_utils import WaffleFlag
 # .. toggle_use_cases: incremental_release, open_edx
 # .. toggle_creation_date: 2019-04-11
 # .. toggle_expiration_date: 2020-12-31
-# .. toggle_warnings: Also set settings.ORDER_HISTORY_MICROFRONTEND_URL and site's ENABLE_ORDER_HISTORY_MICROFRONTEND.
+# .. toggle_warnings: Also set settings.ORDER_HISTORY_MICROFRONTEND_URL and site's
+#   ENABLE_ORDER_HISTORY_MICROFRONTEND.
 # .. toggle_tickets: DEPR-17
 # .. toggle_status: supported
 REDIRECT_TO_ORDER_HISTORY_MICROFRONTEND = WaffleFlag('order_history', 'redirect_to_microfrontend', __name__)

--- a/openedx/core/djangoapps/user_authn/config/waffle.py
+++ b/openedx/core/djangoapps/user_authn/config/waffle.py
@@ -13,7 +13,6 @@ _WAFFLE_SWITCH_NAMESPACE = WaffleSwitchNamespace(name=_WAFFLE_NAMESPACE, log_pre
 # .. toggle_default: False
 # .. toggle_description: When enabled, users must be sign in using their allowed domain SSO account. This includes sign-
 #   ins to the Django admin dashboard at "/admin".
-# .. toggle_category: authn
 # .. toggle_use_cases: incremental_release
 # .. toggle_creation_date: 2019-11-20
 # .. toggle_expiration_date: 2020-01-31

--- a/openedx/core/djangoapps/user_authn/config/waffle.py
+++ b/openedx/core/djangoapps/user_authn/config/waffle.py
@@ -13,7 +13,7 @@ _WAFFLE_SWITCH_NAMESPACE = WaffleSwitchNamespace(name=_WAFFLE_NAMESPACE, log_pre
 # .. toggle_default: False
 # .. toggle_description: When enabled, users must be sign in using their allowed domain SSO account. This includes sign-
 #   ins to the Django admin dashboard at "/admin".
-# .. toggle_use_cases: incremental_release
+# .. toggle_use_cases: temporary
 # .. toggle_creation_date: 2019-11-20
 # .. toggle_target_removal_date: 2020-01-31
 # .. toggle_warnings: Requires THIRD_PARTY_AUTH_ONLY_DOMAIN to also be set.

--- a/openedx/core/djangoapps/user_authn/config/waffle.py
+++ b/openedx/core/djangoapps/user_authn/config/waffle.py
@@ -15,7 +15,7 @@ _WAFFLE_SWITCH_NAMESPACE = WaffleSwitchNamespace(name=_WAFFLE_NAMESPACE, log_pre
 #   ins to the Django admin dashboard at "/admin".
 # .. toggle_use_cases: incremental_release
 # .. toggle_creation_date: 2019-11-20
-# .. toggle_expiration_date: 2020-01-31
+# .. toggle_target_removal_date: 2020-01-31
 # .. toggle_warnings: Requires THIRD_PARTY_AUTH_ONLY_DOMAIN to also be set.
 # .. toggle_tickets: ENT-2461
 ENABLE_LOGIN_USING_THIRDPARTY_AUTH_ONLY = WaffleSwitch(

--- a/openedx/core/djangoapps/user_authn/config/waffle.py
+++ b/openedx/core/djangoapps/user_authn/config/waffle.py
@@ -18,7 +18,6 @@ _WAFFLE_SWITCH_NAMESPACE = WaffleSwitchNamespace(name=_WAFFLE_NAMESPACE, log_pre
 # .. toggle_expiration_date: 2020-01-31
 # .. toggle_warnings: Requires THIRD_PARTY_AUTH_ONLY_DOMAIN to also be set.
 # .. toggle_tickets: ENT-2461
-# .. toggle_status: supported
 ENABLE_LOGIN_USING_THIRDPARTY_AUTH_ONLY = WaffleSwitch(
     _WAFFLE_SWITCH_NAMESPACE,
     'enable_login_using_thirdparty_auth_only',

--- a/openedx/core/djangoapps/user_authn/config/waffle.py
+++ b/openedx/core/djangoapps/user_authn/config/waffle.py
@@ -8,20 +8,18 @@ from openedx.core.djangoapps.waffle_utils import WaffleSwitch, WaffleSwitchNames
 _WAFFLE_NAMESPACE = u'user_authn'
 _WAFFLE_SWITCH_NAMESPACE = WaffleSwitchNamespace(name=_WAFFLE_NAMESPACE, log_prefix=u'UserAuthN: ')
 
-"""
-.. toggle_name: user_authn.enable_login_using_thirdparty_auth_only
-.. toggle_implementation: WaffleSwitch
-.. toggle_default: False
-.. toggle_description: When enabled, users must be sign in using their allowed domain
-  SSO account. This includes sign-ins to the Django admin dashboard at "/admin".
-.. toggle_category: authn
-.. toggle_use_cases: incremental_release
-.. toggle_creation_date: 2019-11-20
-.. toggle_expiration_date: 2020-01-31
-.. toggle_warnings: Requires THIRD_PARTY_AUTH_ONLY_DOMAIN to also be set.
-.. toggle_tickets: ENT-2461
-.. toggle_status: supported
-"""
+# .. toggle_name: user_authn.enable_login_using_thirdparty_auth_only
+# .. toggle_implementation: WaffleSwitch
+# .. toggle_default: False
+# .. toggle_description: When enabled, users must be sign in using their allowed domain SSO account. This includes sign-
+#   ins to the Django admin dashboard at "/admin".
+# .. toggle_category: authn
+# .. toggle_use_cases: incremental_release
+# .. toggle_creation_date: 2019-11-20
+# .. toggle_expiration_date: 2020-01-31
+# .. toggle_warnings: Requires THIRD_PARTY_AUTH_ONLY_DOMAIN to also be set.
+# .. toggle_tickets: ENT-2461
+# .. toggle_status: supported
 ENABLE_LOGIN_USING_THIRDPARTY_AUTH_ONLY = WaffleSwitch(
     _WAFFLE_SWITCH_NAMESPACE,
     'enable_login_using_thirdparty_auth_only',

--- a/openedx/core/djangoapps/user_authn/config/waffle.py
+++ b/openedx/core/djangoapps/user_authn/config/waffle.py
@@ -8,17 +8,20 @@ from openedx.core.djangoapps.waffle_utils import WaffleSwitch, WaffleSwitchNames
 _WAFFLE_NAMESPACE = u'user_authn'
 _WAFFLE_SWITCH_NAMESPACE = WaffleSwitchNamespace(name=_WAFFLE_NAMESPACE, log_prefix=u'UserAuthN: ')
 
-# .. toggle_name: user_authn.enable_login_using_thirdparty_auth_only
-# .. toggle_implementation: WaffleSwitch
-# .. toggle_default: False
-# .. toggle_description: When enabled, users must be sign in using their allowed domain SSO account.
-# .. toggle_category: authn
-# .. toggle_use_cases: incremental_release
-# .. toggle_creation_date: 2019-11-20
-# .. toggle_expiration_date: 2020-01-31
-# .. toggle_warnings: Requires THIRD_PARTY_AUTH_ONLY_DOMAIN to also be set.
-# .. toggle_tickets: ENT-2461
-# .. toggle_status: supported
+"""
+.. toggle_name: user_authn.enable_login_using_thirdparty_auth_only
+.. toggle_implementation: WaffleSwitch
+.. toggle_default: False
+.. toggle_description: When enabled, users must be sign in using their allowed domain
+  SSO account. This includes sign-ins to the Django admin dashboard at "/admin".
+.. toggle_category: authn
+.. toggle_use_cases: incremental_release
+.. toggle_creation_date: 2019-11-20
+.. toggle_expiration_date: 2020-01-31
+.. toggle_warnings: Requires THIRD_PARTY_AUTH_ONLY_DOMAIN to also be set.
+.. toggle_tickets: ENT-2461
+.. toggle_status: supported
+"""
 ENABLE_LOGIN_USING_THIRDPARTY_AUTH_ONLY = WaffleSwitch(
     _WAFFLE_SWITCH_NAMESPACE,
     'enable_login_using_thirdparty_auth_only',

--- a/openedx/core/djangoapps/user_authn/views/register.py
+++ b/openedx/core/djangoapps/user_authn/views/register.py
@@ -105,7 +105,6 @@ REGISTER_USER = Signal(providing_args=["user", "registration"])
 # .. toggle_expiration_date: 2020-06-01
 # .. toggle_warnings: None
 # .. toggle_tickets: None
-# .. toggle_status: supported
 REGISTRATION_FAILURE_LOGGING_FLAG = WaffleFlag(
     waffle_namespace=WaffleFlagNamespace(name=u'registration'),
     flag_name=u'enable_failure_logging',

--- a/openedx/core/djangoapps/user_authn/views/register.py
+++ b/openedx/core/djangoapps/user_authn/views/register.py
@@ -100,7 +100,6 @@ REGISTER_USER = Signal(providing_args=["user", "registration"])
 # .. toggle_type: flag
 # .. toggle_default: False
 # .. toggle_description: Enable verbose logging of registration failure messages
-# .. toggle_category: registration
 # .. toggle_use_cases: monitored_rollout
 # .. toggle_creation_date: 2020-04-30
 # .. toggle_expiration_date: 2020-06-01

--- a/openedx/core/djangoapps/user_authn/views/register.py
+++ b/openedx/core/djangoapps/user_authn/views/register.py
@@ -96,17 +96,17 @@ REGISTRATION_UTM_CREATED_AT = 'registration_utm_created_at'
 REGISTER_USER = Signal(providing_args=["user", "registration"])
 
 
-# .. feature_toggle_name: registration.enable_failure_logging
-# .. feature_toggle_type: flag
-# .. feature_toggle_default: False
-# .. feature_toggle_description: Enable verbose logging of registration failure messages
-# .. feature_toggle_category: registration
-# .. feature_toggle_use_cases: monitored_rollout
-# .. feature_toggle_creation_date: 2020-04-30
-# .. feature_toggle_expiration_date: 2020-06-01
-# .. feature_toggle_warnings: None
-# .. feature_toggle_tickets: None
-# .. feature_toggle_status: supported
+# .. toggle_name: registration.enable_failure_logging
+# .. toggle_type: flag
+# .. toggle_default: False
+# .. toggle_description: Enable verbose logging of registration failure messages
+# .. toggle_category: registration
+# .. toggle_use_cases: monitored_rollout
+# .. toggle_creation_date: 2020-04-30
+# .. toggle_expiration_date: 2020-06-01
+# .. toggle_warnings: None
+# .. toggle_tickets: None
+# .. toggle_status: supported
 REGISTRATION_FAILURE_LOGGING_FLAG = WaffleFlag(
     waffle_namespace=WaffleFlagNamespace(name=u'registration'),
     flag_name=u'enable_failure_logging',

--- a/openedx/core/djangoapps/user_authn/views/register.py
+++ b/openedx/core/djangoapps/user_authn/views/register.py
@@ -102,7 +102,7 @@ REGISTER_USER = Signal(providing_args=["user", "registration"])
 # .. toggle_description: Enable verbose logging of registration failure messages
 # .. toggle_use_cases: temporary
 # .. toggle_creation_date: 2020-04-30
-# .. toggle_expiration_date: 2020-06-01
+# .. toggle_target_removal_date: 2020-06-01
 # .. toggle_warnings: None
 # .. toggle_tickets: None
 REGISTRATION_FAILURE_LOGGING_FLAG = WaffleFlag(

--- a/openedx/core/djangoapps/user_authn/views/register.py
+++ b/openedx/core/djangoapps/user_authn/views/register.py
@@ -103,8 +103,7 @@ REGISTER_USER = Signal(providing_args=["user", "registration"])
 # .. toggle_use_cases: temporary
 # .. toggle_creation_date: 2020-04-30
 # .. toggle_target_removal_date: 2020-06-01
-# .. toggle_warnings: None
-# .. toggle_tickets: None
+# .. toggle_warnings: This temporary feature toggle does not have a target removal date.
 REGISTRATION_FAILURE_LOGGING_FLAG = WaffleFlag(
     waffle_namespace=WaffleFlagNamespace(name=u'registration'),
     flag_name=u'enable_failure_logging',

--- a/openedx/core/djangoapps/user_authn/views/register.py
+++ b/openedx/core/djangoapps/user_authn/views/register.py
@@ -100,7 +100,7 @@ REGISTER_USER = Signal(providing_args=["user", "registration"])
 # .. toggle_type: flag
 # .. toggle_default: False
 # .. toggle_description: Enable verbose logging of registration failure messages
-# .. toggle_use_cases: monitored_rollout
+# .. toggle_use_cases: temporary
 # .. toggle_creation_date: 2020-04-30
 # .. toggle_expiration_date: 2020-06-01
 # .. toggle_warnings: None

--- a/openedx/core/djangoapps/video_config/models.py
+++ b/openedx/core/djangoapps/video_config/models.py
@@ -35,7 +35,6 @@ class HLSPlaybackEnabledFlag(ConfigurationModel):
     .. toggle_expiration_date: None
     .. toggle_warnings: None
     .. toggle_tickets: https://github.com/edx/edx-platform/pull/14924
-    .. toggle_status: supported
     """
     # this field overrides course-specific settings
     enabled_for_all_courses = BooleanField(default=False)
@@ -90,7 +89,6 @@ class CourseHLSPlaybackEnabledFlag(ConfigurationModel):
     .. toggle_expiration_date: None
     .. toggle_warnings: None
     .. toggle_tickets: https://github.com/edx/edx-platform/pull/14924
-    .. toggle_status: supported
     """
     KEY_FIELDS = ('course_id',)
 

--- a/openedx/core/djangoapps/video_config/models.py
+++ b/openedx/core/djangoapps/video_config/models.py
@@ -27,13 +27,9 @@ class HLSPlaybackEnabledFlag(ConfigurationModel):
     .. toggle_name: HLSPlaybackEnabledFlag.enabled_for_all_courses
     .. toggle_implementation: ConfigurationModel
     .. toggle_default: False
-    .. toggle_description: Add the "hls" profile to all displayed videos on the
-      platform.
-    .. toggle_category: video_config
+    .. toggle_description: Add the "hls" profile to all displayed videos on the platform.
     .. toggle_use_cases:  open_edx
     .. toggle_creation_date: 2017-04-19
-    .. toggle_target_removal_date: None
-    .. toggle_warnings: None
     .. toggle_tickets: https://github.com/edx/edx-platform/pull/14924
     """
     # this field overrides course-specific settings
@@ -81,13 +77,9 @@ class CourseHLSPlaybackEnabledFlag(ConfigurationModel):
     .. toggle_name: CourseHLSPlaybackEnabledFlag.course_id
     .. toggle_implementation: ConfigurationModel
     .. toggle_default: False
-    .. toggle_description: Add the "hls" profile to all displayed videos for a single
-      course.
-    .. toggle_category: video_config
+    .. toggle_description: Add the "hls" profile to all displayed videos for a single course.
     .. toggle_use_cases:  open_edx
     .. toggle_creation_date: 2017-04-19
-    .. toggle_target_removal_date: None
-    .. toggle_warnings: None
     .. toggle_tickets: https://github.com/edx/edx-platform/pull/14924
     """
     KEY_FIELDS = ('course_id',)

--- a/openedx/core/djangoapps/video_config/models.py
+++ b/openedx/core/djangoapps/video_config/models.py
@@ -32,7 +32,7 @@ class HLSPlaybackEnabledFlag(ConfigurationModel):
     .. toggle_category: video_config
     .. toggle_use_cases:  open_edx
     .. toggle_creation_date: 2017-04-19
-    .. toggle_expiration_date: None
+    .. toggle_target_removal_date: None
     .. toggle_warnings: None
     .. toggle_tickets: https://github.com/edx/edx-platform/pull/14924
     """
@@ -86,7 +86,7 @@ class CourseHLSPlaybackEnabledFlag(ConfigurationModel):
     .. toggle_category: video_config
     .. toggle_use_cases:  open_edx
     .. toggle_creation_date: 2017-04-19
-    .. toggle_expiration_date: None
+    .. toggle_target_removal_date: None
     .. toggle_warnings: None
     .. toggle_tickets: https://github.com/edx/edx-platform/pull/14924
     """

--- a/openedx/core/djangoapps/video_config/models.py
+++ b/openedx/core/djangoapps/video_config/models.py
@@ -23,6 +23,19 @@ class HLSPlaybackEnabledFlag(ConfigurationModel):
     take effect.
 
     .. no_pii:
+
+    .. toggle_name: HLSPlaybackEnabledFlag.enabled_for_all_courses
+    .. toggle_implementation: ConfigurationModel
+    .. toggle_default: False
+    .. toggle_description: Add the "hls" profile to all displayed videos on the
+      platform.
+    .. toggle_category: video_config
+    .. toggle_use_cases:  open_edx
+    .. toggle_creation_date: 2017-04-19
+    .. toggle_expiration_date: None
+    .. toggle_warnings: None
+    .. toggle_tickets: https://github.com/edx/edx-platform/pull/14924
+    .. toggle_status: supported
     """
     # this field overrides course-specific settings
     enabled_for_all_courses = BooleanField(default=False)
@@ -65,6 +78,19 @@ class CourseHLSPlaybackEnabledFlag(ConfigurationModel):
     enabled for this to take effect.
 
     .. no_pii:
+
+    .. toggle_name: CourseHLSPlaybackEnabledFlag.course_id
+    .. toggle_implementation: ConfigurationModel
+    .. toggle_default: False
+    .. toggle_description: Add the "hls" profile to all displayed videos for a single
+      course.
+    .. toggle_category: video_config
+    .. toggle_use_cases:  open_edx
+    .. toggle_creation_date: 2017-04-19
+    .. toggle_expiration_date: None
+    .. toggle_warnings: None
+    .. toggle_tickets: https://github.com/edx/edx-platform/pull/14924
+    .. toggle_status: supported
     """
     KEY_FIELDS = ('course_id',)
 

--- a/openedx/core/djangoapps/video_pipeline/api.py
+++ b/openedx/core/djangoapps/video_pipeline/api.py
@@ -9,7 +9,6 @@ from django.core.exceptions import ObjectDoesNotExist
 from oauth2_provider.models import Application
 from slumber.exceptions import HttpClientError
 
-from openedx.core.djangoapps.video_pipeline.config.waffle import ENABLE_VEM_PIPELINE, waffle_flags
 from openedx.core.djangoapps.video_pipeline.models import VEMPipelineIntegration, VideoPipelineIntegration
 from openedx.core.djangoapps.video_pipeline.utils import create_video_pipeline_api_client
 

--- a/openedx/core/djangoapps/video_pipeline/config/waffle.py
+++ b/openedx/core/djangoapps/video_pipeline/config/waffle.py
@@ -15,7 +15,7 @@ WAFFLE_NAMESPACE = 'videos'
 #   enabled, videos are no longer uploaded to YouTube as part of the video pipeline.
 # .. toggle_use_cases: open_edx
 # .. toggle_creation_date: 2018-08-03
-# .. toggle_expiration_date: None
+# .. toggle_target_removal_date: None
 # .. toggle_warnings: None
 # .. toggle_tickets: https://github.com/edx/edx-platform/pull/18765
 DEPRECATE_YOUTUBE = 'deprecate_youtube'
@@ -27,7 +27,7 @@ DEPRECATE_YOUTUBE = 'deprecate_youtube'
 #   development (probably?).
 # .. toggle_use_cases: open_edx
 # .. toggle_creation_date: 2020-03-12
-# .. toggle_expiration_date: None
+# .. toggle_target_removal_date: None
 # .. toggle_warnings: Enabling this feature requires that the ROLE_ARN,
 #   MFA_SERIAL_NUMBER, MFA_TOKEN settings are properly defined.
 # .. toggle_tickets: https://github.com/edx/edx-platform/pull/23375

--- a/openedx/core/djangoapps/video_pipeline/config/waffle.py
+++ b/openedx/core/djangoapps/video_pipeline/config/waffle.py
@@ -11,25 +11,22 @@ WAFFLE_NAMESPACE = 'videos'
 # .. toggle_name: videos.deprecate_youtube
 # .. toggle_implementation: WaffleFlag
 # .. toggle_default: False
-# .. toggle_description: Waffle flag telling whether youtube is deprecated. When
-#   enabled, videos are no longer uploaded to YouTube as part of the video pipeline.
+# .. toggle_description: Waffle flag telling whether youtube is deprecated. When enabled, videos are no longer uploaded
+#   to YouTube as part of the video pipeline.
 # .. toggle_use_cases: open_edx
 # .. toggle_creation_date: 2018-08-03
-# .. toggle_target_removal_date: None
-# .. toggle_warnings: None
 # .. toggle_tickets: https://github.com/edx/edx-platform/pull/18765
 DEPRECATE_YOUTUBE = 'deprecate_youtube'
 # .. toggle_name: videos.enable_devstack_video_uploads
 # .. toggle_implementation: WaffleFlag
 # .. toggle_default: False
-# .. toggle_description: When enabled, use Multi-Factor Authentication (MFA) for
-#   authenticating to AWS. These short-lived access tokens are well suited for
-#   development (probably?).
+# .. toggle_description: When enabled, use Multi-Factor Authentication (MFA) for authenticating to AWS. These short-
+#   lived access tokens are well suited for development (probably?). [At the time of annotation, the exact consequences
+#   of enabling this feature toggle are uncertain.]
 # .. toggle_use_cases: open_edx
 # .. toggle_creation_date: 2020-03-12
-# .. toggle_target_removal_date: None
-# .. toggle_warnings: Enabling this feature requires that the ROLE_ARN,
-#   MFA_SERIAL_NUMBER, MFA_TOKEN settings are properly defined.
+# .. toggle_warnings: Enabling this feature requires that the ROLE_ARN, MFA_SERIAL_NUMBER, MFA_TOKEN settings are
+#   properly defined.
 # .. toggle_tickets: https://github.com/edx/edx-platform/pull/23375
 ENABLE_DEVSTACK_VIDEO_UPLOADS = 'enable_devstack_video_uploads'
 ENABLE_VEM_PIPELINE = 'enable_vem_pipeline'

--- a/openedx/core/djangoapps/video_pipeline/config/waffle.py
+++ b/openedx/core/djangoapps/video_pipeline/config/waffle.py
@@ -8,8 +8,37 @@ from openedx.core.djangoapps.waffle_utils import CourseWaffleFlag, WaffleFlag, W
 # Videos Namespace
 WAFFLE_NAMESPACE = 'videos'
 
-# Waffle flag telling whether youtube is deprecated.
+"""
+.. toggle_name: videos.deprecate_youtube
+.. toggle_implementation: WaffleFlag
+.. toggle_default: False
+.. toggle_description: Waffle flag telling whether youtube is deprecated. When enabled,
+  videos are no longer uploaded to YouTube as part of the video pipeline.
+.. toggle_category: videos
+.. toggle_use_cases: open_edx
+.. toggle_creation_date: 2018-08-03
+.. toggle_expiration_date: None
+.. toggle_warnings: None
+.. toggle_tickets: https://github.com/edx/edx-platform/pull/18765
+.. toggle_status: supported
+"""
 DEPRECATE_YOUTUBE = 'deprecate_youtube'
+"""
+.. toggle_name: videos.enable_devstack_video_uploads
+.. toggle_implementation: WaffleFlag
+.. toggle_default: False
+.. toggle_description: When enabled, use Multi-Factor Authentication (MFA) for
+  authenticating to AWS. These short-lived access tokens are well suited for
+  development (probably?).
+.. toggle_category: videos
+.. toggle_use_cases: open_edx
+.. toggle_creation_date: 2020-03-12
+.. toggle_expiration_date: None
+.. toggle_warnings: Enabling this feature requires that the ROLE_ARN,
+  MFA_SERIAL_NUMBER, MFA_TOKEN settings are properly defined.
+.. toggle_tickets: https://github.com/edx/edx-platform/pull/23375
+.. toggle_status: supported
+"""
 ENABLE_DEVSTACK_VIDEO_UPLOADS = 'enable_devstack_video_uploads'
 ENABLE_VEM_PIPELINE = 'enable_vem_pipeline'
 

--- a/openedx/core/djangoapps/video_pipeline/config/waffle.py
+++ b/openedx/core/djangoapps/video_pipeline/config/waffle.py
@@ -13,7 +13,6 @@ WAFFLE_NAMESPACE = 'videos'
 # .. toggle_default: False
 # .. toggle_description: Waffle flag telling whether youtube is deprecated. When
 #   enabled, videos are no longer uploaded to YouTube as part of the video pipeline.
-# .. toggle_category: videos
 # .. toggle_use_cases: open_edx
 # .. toggle_creation_date: 2018-08-03
 # .. toggle_expiration_date: None
@@ -27,7 +26,6 @@ DEPRECATE_YOUTUBE = 'deprecate_youtube'
 # .. toggle_description: When enabled, use Multi-Factor Authentication (MFA) for
 #   authenticating to AWS. These short-lived access tokens are well suited for
 #   development (probably?).
-# .. toggle_category: videos
 # .. toggle_use_cases: open_edx
 # .. toggle_creation_date: 2020-03-12
 # .. toggle_expiration_date: None

--- a/openedx/core/djangoapps/video_pipeline/config/waffle.py
+++ b/openedx/core/djangoapps/video_pipeline/config/waffle.py
@@ -8,37 +8,33 @@ from openedx.core.djangoapps.waffle_utils import CourseWaffleFlag, WaffleFlag, W
 # Videos Namespace
 WAFFLE_NAMESPACE = 'videos'
 
-"""
-.. toggle_name: videos.deprecate_youtube
-.. toggle_implementation: WaffleFlag
-.. toggle_default: False
-.. toggle_description: Waffle flag telling whether youtube is deprecated. When enabled,
-  videos are no longer uploaded to YouTube as part of the video pipeline.
-.. toggle_category: videos
-.. toggle_use_cases: open_edx
-.. toggle_creation_date: 2018-08-03
-.. toggle_expiration_date: None
-.. toggle_warnings: None
-.. toggle_tickets: https://github.com/edx/edx-platform/pull/18765
-.. toggle_status: supported
-"""
+# .. toggle_name: videos.deprecate_youtube
+# .. toggle_implementation: WaffleFlag
+# .. toggle_default: False
+# .. toggle_description: Waffle flag telling whether youtube is deprecated. When
+#   enabled, videos are no longer uploaded to YouTube as part of the video pipeline.
+# .. toggle_category: videos
+# .. toggle_use_cases: open_edx
+# .. toggle_creation_date: 2018-08-03
+# .. toggle_expiration_date: None
+# .. toggle_warnings: None
+# .. toggle_tickets: https://github.com/edx/edx-platform/pull/18765
+# .. toggle_status: supported
 DEPRECATE_YOUTUBE = 'deprecate_youtube'
-"""
-.. toggle_name: videos.enable_devstack_video_uploads
-.. toggle_implementation: WaffleFlag
-.. toggle_default: False
-.. toggle_description: When enabled, use Multi-Factor Authentication (MFA) for
-  authenticating to AWS. These short-lived access tokens are well suited for
-  development (probably?).
-.. toggle_category: videos
-.. toggle_use_cases: open_edx
-.. toggle_creation_date: 2020-03-12
-.. toggle_expiration_date: None
-.. toggle_warnings: Enabling this feature requires that the ROLE_ARN,
-  MFA_SERIAL_NUMBER, MFA_TOKEN settings are properly defined.
-.. toggle_tickets: https://github.com/edx/edx-platform/pull/23375
-.. toggle_status: supported
-"""
+# .. toggle_name: videos.enable_devstack_video_uploads
+# .. toggle_implementation: WaffleFlag
+# .. toggle_default: False
+# .. toggle_description: When enabled, use Multi-Factor Authentication (MFA) for
+#   authenticating to AWS. These short-lived access tokens are well suited for
+#   development (probably?).
+# .. toggle_category: videos
+# .. toggle_use_cases: open_edx
+# .. toggle_creation_date: 2020-03-12
+# .. toggle_expiration_date: None
+# .. toggle_warnings: Enabling this feature requires that the ROLE_ARN,
+#   MFA_SERIAL_NUMBER, MFA_TOKEN settings are properly defined.
+# .. toggle_tickets: https://github.com/edx/edx-platform/pull/23375
+# .. toggle_status: supported
 ENABLE_DEVSTACK_VIDEO_UPLOADS = 'enable_devstack_video_uploads'
 ENABLE_VEM_PIPELINE = 'enable_vem_pipeline'
 

--- a/openedx/core/djangoapps/video_pipeline/config/waffle.py
+++ b/openedx/core/djangoapps/video_pipeline/config/waffle.py
@@ -18,7 +18,6 @@ WAFFLE_NAMESPACE = 'videos'
 # .. toggle_expiration_date: None
 # .. toggle_warnings: None
 # .. toggle_tickets: https://github.com/edx/edx-platform/pull/18765
-# .. toggle_status: supported
 DEPRECATE_YOUTUBE = 'deprecate_youtube'
 # .. toggle_name: videos.enable_devstack_video_uploads
 # .. toggle_implementation: WaffleFlag
@@ -32,7 +31,6 @@ DEPRECATE_YOUTUBE = 'deprecate_youtube'
 # .. toggle_warnings: Enabling this feature requires that the ROLE_ARN,
 #   MFA_SERIAL_NUMBER, MFA_TOKEN settings are properly defined.
 # .. toggle_tickets: https://github.com/edx/edx-platform/pull/23375
-# .. toggle_status: supported
 ENABLE_DEVSTACK_VIDEO_UPLOADS = 'enable_devstack_video_uploads'
 ENABLE_VEM_PIPELINE = 'enable_vem_pipeline'
 

--- a/openedx/core/djangoapps/video_pipeline/models.py
+++ b/openedx/core/djangoapps/video_pipeline/models.py
@@ -50,6 +50,19 @@ class VEMPipelineIntegration(ConfigurationModel):
     Manages configuration for connecting to the video encode manager service and using its API.
 
     .. no_pii:
+
+    .. toggle_name: VEMPipelineIntegration.enabled
+    .. toggle_implementation: ConfigurationModel
+    .. toggle_default: False
+    .. toggle_description: Send videos to the Video Encode Manager (VEM) as part of the
+      video pipeline.
+    .. toggle_category: video_pipeline
+    .. toggle_use_cases:  open_edx
+    .. toggle_creation_date: 2020-06-04
+    .. toggle_expiration_date: None
+    .. toggle_warnings: None
+    .. toggle_tickets: https://github.com/edx/edx-platform/pull/24093
+    .. toggle_status: supported
     """
     client_name = models.CharField(
         max_length=100,
@@ -80,9 +93,22 @@ class VEMPipelineIntegration(ConfigurationModel):
 @python_2_unicode_compatible
 class VideoUploadsEnabledByDefault(ConfigurationModel):
     """
-    Enables video uploads enabled By default feature across the platform.
+    Enables video uploads across the platform.
 
     .. no_pii:
+
+    .. toggle_name: VideoUploadsEnabledByDefault.enabled_for_all_courses
+    .. toggle_implementation: ConfigurationModel
+    .. toggle_default: False
+    .. toggle_description: Allow video uploads for all courses of the platform. This
+      enables the "Video Uploads" menu in the CMS.
+    .. toggle_category: video_pipeline
+    .. toggle_use_cases:  open_edx
+    .. toggle_creation_date: 2017-11-10
+    .. toggle_expiration_date: None
+    .. toggle_warnings: None
+    .. toggle_tickets: https://github.com/edx/edx-platform/pull/16536
+    .. toggle_status: supported
     """
     # this field overrides course-specific settings
     enabled_for_all_courses = models.BooleanField(default=False)
@@ -122,10 +148,22 @@ class VideoUploadsEnabledByDefault(ConfigurationModel):
 @python_2_unicode_compatible
 class CourseVideoUploadsEnabledByDefault(ConfigurationModel):
     """
-    Enables video uploads enabled by default feature for a specific course. Its global feature must be
-    enabled for this to take effect.
+    Enables video uploads for a specific course.
 
     .. no_pii:
+
+    .. toggle_name: CourseVideoUploadsEnabledByDefault.course_id
+    .. toggle_implementation: ConfigurationModel
+    .. toggle_default: False
+    .. toggle_description: Allow video uploads for a specific course. This enables the
+      "Video Uploads" menu in the CMS.
+    .. toggle_category: video_pipeline
+    .. toggle_use_cases:  open_edx
+    .. toggle_creation_date: 2017-11-10
+    .. toggle_expiration_date: None
+    .. toggle_warnings: None
+    .. toggle_tickets: https://github.com/edx/edx-platform/pull/16536
+    .. toggle_status: supported
     """
     KEY_FIELDS = ('course_id',)
 

--- a/openedx/core/djangoapps/video_pipeline/models.py
+++ b/openedx/core/djangoapps/video_pipeline/models.py
@@ -56,11 +56,8 @@ class VEMPipelineIntegration(ConfigurationModel):
     .. toggle_default: False
     .. toggle_description: Send videos to the Video Encode Manager (VEM) as part of the
       video pipeline.
-    .. toggle_category: video_pipeline
     .. toggle_use_cases:  open_edx
     .. toggle_creation_date: 2020-06-04
-    .. toggle_target_removal_date: None
-    .. toggle_warnings: None
     .. toggle_tickets: https://github.com/edx/edx-platform/pull/24093
     """
     client_name = models.CharField(
@@ -101,11 +98,8 @@ class VideoUploadsEnabledByDefault(ConfigurationModel):
     .. toggle_default: False
     .. toggle_description: Allow video uploads for all courses of the platform. This
       enables the "Video Uploads" menu in the CMS.
-    .. toggle_category: video_pipeline
     .. toggle_use_cases:  open_edx
     .. toggle_creation_date: 2017-11-10
-    .. toggle_target_removal_date: None
-    .. toggle_warnings: None
     .. toggle_tickets: https://github.com/edx/edx-platform/pull/16536
     """
     # this field overrides course-specific settings
@@ -155,11 +149,8 @@ class CourseVideoUploadsEnabledByDefault(ConfigurationModel):
     .. toggle_default: False
     .. toggle_description: Allow video uploads for a specific course. This enables the
       "Video Uploads" menu in the CMS.
-    .. toggle_category: video_pipeline
     .. toggle_use_cases:  open_edx
     .. toggle_creation_date: 2017-11-10
-    .. toggle_target_removal_date: None
-    .. toggle_warnings: None
     .. toggle_tickets: https://github.com/edx/edx-platform/pull/16536
     """
     KEY_FIELDS = ('course_id',)

--- a/openedx/core/djangoapps/video_pipeline/models.py
+++ b/openedx/core/djangoapps/video_pipeline/models.py
@@ -62,7 +62,6 @@ class VEMPipelineIntegration(ConfigurationModel):
     .. toggle_expiration_date: None
     .. toggle_warnings: None
     .. toggle_tickets: https://github.com/edx/edx-platform/pull/24093
-    .. toggle_status: supported
     """
     client_name = models.CharField(
         max_length=100,
@@ -108,7 +107,6 @@ class VideoUploadsEnabledByDefault(ConfigurationModel):
     .. toggle_expiration_date: None
     .. toggle_warnings: None
     .. toggle_tickets: https://github.com/edx/edx-platform/pull/16536
-    .. toggle_status: supported
     """
     # this field overrides course-specific settings
     enabled_for_all_courses = models.BooleanField(default=False)
@@ -163,7 +161,6 @@ class CourseVideoUploadsEnabledByDefault(ConfigurationModel):
     .. toggle_expiration_date: None
     .. toggle_warnings: None
     .. toggle_tickets: https://github.com/edx/edx-platform/pull/16536
-    .. toggle_status: supported
     """
     KEY_FIELDS = ('course_id',)
 

--- a/openedx/core/djangoapps/video_pipeline/models.py
+++ b/openedx/core/djangoapps/video_pipeline/models.py
@@ -59,7 +59,7 @@ class VEMPipelineIntegration(ConfigurationModel):
     .. toggle_category: video_pipeline
     .. toggle_use_cases:  open_edx
     .. toggle_creation_date: 2020-06-04
-    .. toggle_expiration_date: None
+    .. toggle_target_removal_date: None
     .. toggle_warnings: None
     .. toggle_tickets: https://github.com/edx/edx-platform/pull/24093
     """
@@ -104,7 +104,7 @@ class VideoUploadsEnabledByDefault(ConfigurationModel):
     .. toggle_category: video_pipeline
     .. toggle_use_cases:  open_edx
     .. toggle_creation_date: 2017-11-10
-    .. toggle_expiration_date: None
+    .. toggle_target_removal_date: None
     .. toggle_warnings: None
     .. toggle_tickets: https://github.com/edx/edx-platform/pull/16536
     """
@@ -158,7 +158,7 @@ class CourseVideoUploadsEnabledByDefault(ConfigurationModel):
     .. toggle_category: video_pipeline
     .. toggle_use_cases:  open_edx
     .. toggle_creation_date: 2017-11-10
-    .. toggle_expiration_date: None
+    .. toggle_target_removal_date: None
     .. toggle_warnings: None
     .. toggle_tickets: https://github.com/edx/edx-platform/pull/16536
     """

--- a/openedx/core/djangoapps/video_pipeline/tests/test_api.py
+++ b/openedx/core/djangoapps/video_pipeline/tests/test_api.py
@@ -7,14 +7,11 @@ import json
 import ddt
 from django.test.testcases import TestCase
 from mock import Mock, patch
-from opaque_keys.edx.locations import CourseLocator
 from slumber.exceptions import HttpClientError
 from student.tests.factories import UserFactory
 
 from openedx.core.djangoapps.video_pipeline.api import update_3rd_party_transcription_service_credentials
-from openedx.core.djangoapps.video_pipeline.config.waffle import ENABLE_VEM_PIPELINE, waffle_flags
 from openedx.core.djangoapps.video_pipeline.tests.mixins import VideoPipelineMixin
-from openedx.core.djangoapps.waffle_utils.testutils import override_waffle_flag
 
 
 @ddt.ddt

--- a/openedx/core/djangoapps/waffle_utils/__init__.py
+++ b/openedx/core/djangoapps/waffle_utils/__init__.py
@@ -381,7 +381,8 @@ def _get_waffle_flag_custom_metrics_set():
     # .. toggle_name: WAFFLE_FLAG_CUSTOM_METRICS
     # .. toggle_implementation: DjangoSetting
     # .. toggle_default: False
-    # .. toggle_description: A list of waffle flag to track with custom metrics having values of (True, False, or Both).
+    # .. toggle_description: A list of waffle flag to track with custom metrics having
+    #   values of (True, False, or Both).
     # .. toggle_category: monitoring
     # .. toggle_use_cases: opt_in
     # .. toggle_creation_date: 2020-06-17

--- a/openedx/core/djangoapps/waffle_utils/__init__.py
+++ b/openedx/core/djangoapps/waffle_utils/__init__.py
@@ -378,16 +378,16 @@ def _get_waffle_flag_custom_metrics_set():
     waffle_flag_custom_metrics = waffle_flag_custom_metrics if waffle_flag_custom_metrics else []
     return set(waffle_flag_custom_metrics)
 
-    # .. toggle_name: WAFFLE_FLAG_CUSTOM_METRICS
-    # .. toggle_implementation: DjangoSetting
-    # .. toggle_default: False
-    # .. toggle_description: A list of waffle flag to track with custom metrics having
-    #   values of (True, False, or Both).
-    # .. toggle_use_cases: opt_in
-    # .. toggle_creation_date: 2020-06-17
-    # .. toggle_target_removal_date: None
-    # .. toggle_tickets: None
-    # .. toggle_warnings: Intent is for temporary research (1 day - several weeks) of a flag's usage.
+# .. toggle_name: WAFFLE_FLAG_CUSTOM_METRICS
+# .. toggle_implementation: DjangoSetting
+# .. toggle_default: False
+# .. toggle_description: A list of waffle flag to track with custom metrics having
+#   values of (True, False, or Both).
+# .. toggle_use_cases: opt_in
+# .. toggle_creation_date: 2020-06-17
+# .. toggle_target_removal_date: None
+# .. toggle_tickets: None
+# .. toggle_warnings: Intent is for temporary research (1 day - several weeks) of a flag's usage.
 _WAFFLE_FLAG_CUSTOM_METRICS = 'WAFFLE_FLAG_CUSTOM_METRICS'
 
 # set of waffle flags that should be instrumented with custom metrics

--- a/openedx/core/djangoapps/waffle_utils/__init__.py
+++ b/openedx/core/djangoapps/waffle_utils/__init__.py
@@ -383,7 +383,6 @@ def _get_waffle_flag_custom_metrics_set():
     # .. toggle_default: False
     # .. toggle_description: A list of waffle flag to track with custom metrics having
     #   values of (True, False, or Both).
-    # .. toggle_category: monitoring
     # .. toggle_use_cases: opt_in
     # .. toggle_creation_date: 2020-06-17
     # .. toggle_expiration_date: None

--- a/openedx/core/djangoapps/waffle_utils/__init__.py
+++ b/openedx/core/djangoapps/waffle_utils/__init__.py
@@ -385,7 +385,7 @@ def _get_waffle_flag_custom_metrics_set():
     #   values of (True, False, or Both).
     # .. toggle_use_cases: opt_in
     # .. toggle_creation_date: 2020-06-17
-    # .. toggle_expiration_date: None
+    # .. toggle_target_removal_date: None
     # .. toggle_tickets: None
     # .. toggle_warnings: Intent is for temporary research (1 day - several weeks) of a flag's usage.
 _WAFFLE_FLAG_CUSTOM_METRICS = 'WAFFLE_FLAG_CUSTOM_METRICS'

--- a/openedx/core/djangoapps/waffle_utils/__init__.py
+++ b/openedx/core/djangoapps/waffle_utils/__init__.py
@@ -387,7 +387,6 @@ def _get_waffle_flag_custom_metrics_set():
     # .. toggle_creation_date: 2020-06-17
     # .. toggle_expiration_date: None
     # .. toggle_tickets: None
-    # .. toggle_status: supported
     # .. toggle_warnings: Intent is for temporary research (1 day - several weeks) of a flag's usage.
 _WAFFLE_FLAG_CUSTOM_METRICS = 'WAFFLE_FLAG_CUSTOM_METRICS'
 

--- a/openedx/core/djangoapps/waffle_utils/__init__.py
+++ b/openedx/core/djangoapps/waffle_utils/__init__.py
@@ -385,8 +385,6 @@ def _get_waffle_flag_custom_metrics_set():
 #   values of (True, False, or Both).
 # .. toggle_use_cases: opt_in
 # .. toggle_creation_date: 2020-06-17
-# .. toggle_target_removal_date: None
-# .. toggle_tickets: None
 # .. toggle_warnings: Intent is for temporary research (1 day - several weeks) of a flag's usage.
 _WAFFLE_FLAG_CUSTOM_METRICS = 'WAFFLE_FLAG_CUSTOM_METRICS'
 

--- a/openedx/features/course_duration_limits/models.py
+++ b/openedx/features/course_duration_limits/models.py
@@ -28,7 +28,7 @@ class CourseDurationLimitConfig(StackedConfigurationModel):
     .. toggle_category: ?
     .. toggle_use_cases: ?
     .. toggle_creation_date: 2018-11-02
-    .. toggle_expiration_date: None
+    .. toggle_target_removal_date: None
     .. toggle_warnings: None
     .. toggle_tickets: None
     """

--- a/openedx/features/course_duration_limits/models.py
+++ b/openedx/features/course_duration_limits/models.py
@@ -18,6 +18,21 @@ class CourseDurationLimitConfig(StackedConfigurationModel):
     Configuration to manage the Course Duration Limit facility.
 
     .. no_pii:
+
+    .. toggle_name: CourseDurationLimitConfig.enabled
+    .. toggle_implementation: ConfigurationModel
+    .. toggle_default: False
+    .. toggle_description: When enabled, users will have a limited time to complete and
+      audit the course. The exact duration is given by the "weeks_to_complete" course
+      detail. When enabled, it is necessary to also define the "enabled_as_of" flag:
+      only enrollments created after this date will be affected.
+    .. toggle_category: ?
+    .. toggle_use_cases: ?
+    .. toggle_creation_date: 2018-11-02
+    .. toggle_expiration_date: None
+    .. toggle_warnings: None
+    .. toggle_tickets: None
+    .. toggle_status: supported
     """
 
     STACKABLE_FIELDS = ('enabled', 'enabled_as_of')

--- a/openedx/features/course_duration_limits/models.py
+++ b/openedx/features/course_duration_limits/models.py
@@ -25,12 +25,8 @@ class CourseDurationLimitConfig(StackedConfigurationModel):
     .. toggle_description: When enabled, users will have a limited time to complete and audit the course. The exact
        duration is given by the "weeks_to_complete" course detail. When enabled, it is necessary to also define the
        "enabled_as_of" flag: only enrollments created after this date will be affected.
-    .. toggle_category: ?
-    .. toggle_use_cases: ?
+    .. toggle_use_cases: opt_in
     .. toggle_creation_date: 2018-11-02
-    .. toggle_target_removal_date: None
-    .. toggle_warnings: None
-    .. toggle_tickets: None
     """
 
     STACKABLE_FIELDS = ('enabled', 'enabled_as_of')

--- a/openedx/features/course_duration_limits/models.py
+++ b/openedx/features/course_duration_limits/models.py
@@ -31,7 +31,6 @@ class CourseDurationLimitConfig(StackedConfigurationModel):
     .. toggle_expiration_date: None
     .. toggle_warnings: None
     .. toggle_tickets: None
-    .. toggle_status: supported
     """
 
     STACKABLE_FIELDS = ('enabled', 'enabled_as_of')

--- a/openedx/features/course_duration_limits/models.py
+++ b/openedx/features/course_duration_limits/models.py
@@ -22,10 +22,9 @@ class CourseDurationLimitConfig(StackedConfigurationModel):
     .. toggle_name: CourseDurationLimitConfig.enabled
     .. toggle_implementation: ConfigurationModel
     .. toggle_default: False
-    .. toggle_description: When enabled, users will have a limited time to complete and
-      audit the course. The exact duration is given by the "weeks_to_complete" course
-      detail. When enabled, it is necessary to also define the "enabled_as_of" flag:
-      only enrollments created after this date will be affected.
+    .. toggle_description: When enabled, users will have a limited time to complete and audit the course. The exact
+       duration is given by the "weeks_to_complete" course detail. When enabled, it is necessary to also define the
+       "enabled_as_of" flag: only enrollments created after this date will be affected.
     .. toggle_category: ?
     .. toggle_use_cases: ?
     .. toggle_creation_date: 2018-11-02

--- a/openedx/features/course_experience/__init__.py
+++ b/openedx/features/course_experience/__init__.py
@@ -92,7 +92,7 @@ COURSE_PRE_START_ACCESS_FLAG = WaffleFlag(WAFFLE_FLAG_NAMESPACE, 'pre_start_acce
 # .. toggle_description: Used with our integration with CourseTalk to display reviews for a course.
 # .. toggle_use_cases: temporary
 # .. toggle_creation_date: 2017-06-19
-# .. toggle_expiration_date: ???
+# .. toggle_target_removal_date: ???
 # .. toggle_warnings: We are no longer integrating with CourseTalk, so this probably should be deprecated and the code
 #   for reviews should be removed.
 # .. toggle_tickets: DEPR-48
@@ -105,7 +105,7 @@ SHOW_REVIEWS_TOOL_FLAG = CourseWaffleFlag(WAFFLE_FLAG_NAMESPACE, 'show_reviews_t
 # .. toggle_description: Used to determine whether or not to use course goals for the particular course.
 # .. toggle_use_cases: opt_out, temporary
 # .. toggle_creation_date: 2017-09-11
-# .. toggle_expiration_date: ???
+# .. toggle_target_removal_date: ???
 # .. toggle_warnings: N/A
 # .. toggle_tickets: N/A
 ENABLE_COURSE_GOALS = CourseWaffleFlag(WAFFLE_FLAG_NAMESPACE, 'enable_course_goals', __name__)
@@ -123,7 +123,7 @@ UPGRADE_DEADLINE_MESSAGE = CourseWaffleFlag(WAFFLE_FLAG_NAMESPACE, 'upgrade_dead
 # .. toggle_description: Used to switch between 'welcome message' and 'latest update' on the course home page.
 # .. toggle_use_cases: opt_out
 # .. toggle_creation_date: 2017-09-11
-# .. toggle_expiration_date: ???
+# .. toggle_target_removal_date: ???
 # .. toggle_warnings: This is meant to be configured using waffle_utils course override only. Either do not create the
 #   actual waffle flag, or be sure to unset the flag even for Superusers.
 # .. toggle_tickets: N/A

--- a/openedx/features/course_experience/__init__.py
+++ b/openedx/features/course_experience/__init__.py
@@ -90,7 +90,6 @@ COURSE_PRE_START_ACCESS_FLAG = WaffleFlag(WAFFLE_FLAG_NAMESPACE, 'pre_start_acce
 # .. toggle_implementation: CourseWaffleFlag
 # .. toggle_default: False
 # .. toggle_description: Used with our integration with CourseTalk to display reviews for a course.
-# .. toggle_category: course_experience
 # .. toggle_use_cases: monitored_rollout
 # .. toggle_creation_date: 2017-06-19
 # .. toggle_expiration_date: ???
@@ -105,7 +104,6 @@ SHOW_REVIEWS_TOOL_FLAG = CourseWaffleFlag(WAFFLE_FLAG_NAMESPACE, 'show_reviews_t
 # .. toggle_implementation: CourseWaffleFlag
 # .. toggle_default: False
 # .. toggle_description: Used to determine whether or not to use course goals for the particular course.
-# .. toggle_category: course_experience
 # .. toggle_use_cases: opt_out, monitored_rollout
 # .. toggle_creation_date: 2017-09-11
 # .. toggle_expiration_date: ???
@@ -125,7 +123,6 @@ UPGRADE_DEADLINE_MESSAGE = CourseWaffleFlag(WAFFLE_FLAG_NAMESPACE, 'upgrade_dead
 # .. toggle_implementation: CourseWaffleFlag
 # .. toggle_default: False
 # .. toggle_description: Used to switch between 'welcome message' and 'latest update' on the course home page.
-# .. toggle_category: course_experience
 # .. toggle_use_cases: opt_out
 # .. toggle_creation_date: 2017-09-11
 # .. toggle_expiration_date: ???

--- a/openedx/features/course_experience/__init__.py
+++ b/openedx/features/course_experience/__init__.py
@@ -96,7 +96,6 @@ COURSE_PRE_START_ACCESS_FLAG = WaffleFlag(WAFFLE_FLAG_NAMESPACE, 'pre_start_acce
 # .. toggle_warnings: We are no longer integrating with CourseTalk, so this probably should be deprecated and the code
 #   for reviews should be removed.
 # .. toggle_tickets: DEPR-48
-# .. toggle_status: unsupported
 SHOW_REVIEWS_TOOL_FLAG = CourseWaffleFlag(WAFFLE_FLAG_NAMESPACE, 'show_reviews_tool', __name__)
 
 # Waffle flag to enable the setting of course goals.
@@ -109,7 +108,6 @@ SHOW_REVIEWS_TOOL_FLAG = CourseWaffleFlag(WAFFLE_FLAG_NAMESPACE, 'show_reviews_t
 # .. toggle_expiration_date: ???
 # .. toggle_warnings: N/A
 # .. toggle_tickets: N/A
-# .. toggle_status: supported
 ENABLE_COURSE_GOALS = CourseWaffleFlag(WAFFLE_FLAG_NAMESPACE, 'enable_course_goals', __name__)
 
 # Waffle flag to control the display of the hero
@@ -129,7 +127,6 @@ UPGRADE_DEADLINE_MESSAGE = CourseWaffleFlag(WAFFLE_FLAG_NAMESPACE, 'upgrade_dead
 # .. toggle_warnings: This is meant to be configured using waffle_utils course override only. Either do not create the
 #   actual waffle flag, or be sure to unset the flag even for Superusers.
 # .. toggle_tickets: N/A
-# .. toggle_status: supported
 LATEST_UPDATE_FLAG = CourseWaffleFlag(WAFFLE_FLAG_NAMESPACE, 'latest_update', __name__)
 
 # Waffle flag to enable anonymous access to a course

--- a/openedx/features/course_experience/__init__.py
+++ b/openedx/features/course_experience/__init__.py
@@ -94,7 +94,8 @@ COURSE_PRE_START_ACCESS_FLAG = WaffleFlag(WAFFLE_FLAG_NAMESPACE, 'pre_start_acce
 # .. toggle_use_cases: monitored_rollout
 # .. toggle_creation_date: 2017-06-19
 # .. toggle_expiration_date: ???
-# .. toggle_warnings: We are no longer integrating with CourseTalk, so this probably should be deprecated and the code for reviews should be removed.
+# .. toggle_warnings: We are no longer integrating with CourseTalk, so this probably should be deprecated and the code
+#   for reviews should be removed.
 # .. toggle_tickets: DEPR-48
 # .. toggle_status: unsupported
 SHOW_REVIEWS_TOOL_FLAG = CourseWaffleFlag(WAFFLE_FLAG_NAMESPACE, 'show_reviews_tool', __name__)
@@ -128,7 +129,8 @@ UPGRADE_DEADLINE_MESSAGE = CourseWaffleFlag(WAFFLE_FLAG_NAMESPACE, 'upgrade_dead
 # .. toggle_use_cases: opt_out
 # .. toggle_creation_date: 2017-09-11
 # .. toggle_expiration_date: ???
-# .. toggle_warnings: This is meant to be configured using waffle_utils course override only.  Either do not create the actual waffle flag, or be sure to unset the flag even for Superusers.
+# .. toggle_warnings: This is meant to be configured using waffle_utils course override only. Either do not create the
+#   actual waffle flag, or be sure to unset the flag even for Superusers.
 # .. toggle_tickets: N/A
 # .. toggle_status: supported
 LATEST_UPDATE_FLAG = CourseWaffleFlag(WAFFLE_FLAG_NAMESPACE, 'latest_update', __name__)

--- a/openedx/features/course_experience/__init__.py
+++ b/openedx/features/course_experience/__init__.py
@@ -90,7 +90,7 @@ COURSE_PRE_START_ACCESS_FLAG = WaffleFlag(WAFFLE_FLAG_NAMESPACE, 'pre_start_acce
 # .. toggle_implementation: CourseWaffleFlag
 # .. toggle_default: False
 # .. toggle_description: Used with our integration with CourseTalk to display reviews for a course.
-# .. toggle_use_cases: monitored_rollout
+# .. toggle_use_cases: temporary
 # .. toggle_creation_date: 2017-06-19
 # .. toggle_expiration_date: ???
 # .. toggle_warnings: We are no longer integrating with CourseTalk, so this probably should be deprecated and the code
@@ -104,7 +104,7 @@ SHOW_REVIEWS_TOOL_FLAG = CourseWaffleFlag(WAFFLE_FLAG_NAMESPACE, 'show_reviews_t
 # .. toggle_implementation: CourseWaffleFlag
 # .. toggle_default: False
 # .. toggle_description: Used to determine whether or not to use course goals for the particular course.
-# .. toggle_use_cases: opt_out, monitored_rollout
+# .. toggle_use_cases: opt_out, temporary
 # .. toggle_creation_date: 2017-09-11
 # .. toggle_expiration_date: ???
 # .. toggle_warnings: N/A

--- a/openedx/features/course_experience/__init__.py
+++ b/openedx/features/course_experience/__init__.py
@@ -92,9 +92,9 @@ COURSE_PRE_START_ACCESS_FLAG = WaffleFlag(WAFFLE_FLAG_NAMESPACE, 'pre_start_acce
 # .. toggle_description: Used with our integration with CourseTalk to display reviews for a course.
 # .. toggle_use_cases: temporary
 # .. toggle_creation_date: 2017-06-19
-# .. toggle_target_removal_date: ???
+# .. toggle_target_removal_date: None
 # .. toggle_warnings: We are no longer integrating with CourseTalk, so this probably should be deprecated and the code
-#   for reviews should be removed.
+#   for reviews should be removed. This temporary feature toggle should have a target removal date.
 # .. toggle_tickets: DEPR-48
 SHOW_REVIEWS_TOOL_FLAG = CourseWaffleFlag(WAFFLE_FLAG_NAMESPACE, 'show_reviews_tool', __name__)
 
@@ -105,9 +105,8 @@ SHOW_REVIEWS_TOOL_FLAG = CourseWaffleFlag(WAFFLE_FLAG_NAMESPACE, 'show_reviews_t
 # .. toggle_description: Used to determine whether or not to use course goals for the particular course.
 # .. toggle_use_cases: opt_out, temporary
 # .. toggle_creation_date: 2017-09-11
-# .. toggle_target_removal_date: ???
-# .. toggle_warnings: N/A
-# .. toggle_tickets: N/A
+# .. toggle_target_removal_date: None
+# .. toggle_warnings: This temporary feature toggle does not have a target removal date.
 ENABLE_COURSE_GOALS = CourseWaffleFlag(WAFFLE_FLAG_NAMESPACE, 'enable_course_goals', __name__)
 
 # Waffle flag to control the display of the hero
@@ -123,10 +122,8 @@ UPGRADE_DEADLINE_MESSAGE = CourseWaffleFlag(WAFFLE_FLAG_NAMESPACE, 'upgrade_dead
 # .. toggle_description: Used to switch between 'welcome message' and 'latest update' on the course home page.
 # .. toggle_use_cases: opt_out
 # .. toggle_creation_date: 2017-09-11
-# .. toggle_target_removal_date: ???
 # .. toggle_warnings: This is meant to be configured using waffle_utils course override only. Either do not create the
 #   actual waffle flag, or be sure to unset the flag even for Superusers.
-# .. toggle_tickets: N/A
 LATEST_UPDATE_FLAG = CourseWaffleFlag(WAFFLE_FLAG_NAMESPACE, 'latest_update', __name__)
 
 # Waffle flag to enable anonymous access to a course

--- a/openedx/features/course_experience/waffle.py
+++ b/openedx/features/course_experience/waffle.py
@@ -13,7 +13,6 @@ WAFFLE_NAMESPACE = u'course_experience'
 # .. toggle_implementation: CourseWaffleFlag
 # .. toggle_default: False
 # .. toggle_description: Used to determine whether to show custom HTML in the sidebar on the internal course about page.
-# .. toggle_category: course-experience
 # .. toggle_use_cases: open_edx
 # .. toggle_creation_date: 2018-01-26
 # .. toggle_expiration_date: ???

--- a/openedx/features/course_experience/waffle.py
+++ b/openedx/features/course_experience/waffle.py
@@ -15,9 +15,6 @@ WAFFLE_NAMESPACE = u'course_experience'
 # .. toggle_description: Used to determine whether to show custom HTML in the sidebar on the internal course about page.
 # .. toggle_use_cases: open_edx
 # .. toggle_creation_date: 2018-01-26
-# .. toggle_target_removal_date: ???
-# .. toggle_warnings: N/A
-# .. toggle_tickets: N/A
 ENABLE_COURSE_ABOUT_SIDEBAR_HTML = u'enable_about_sidebar_html'
 
 

--- a/openedx/features/course_experience/waffle.py
+++ b/openedx/features/course_experience/waffle.py
@@ -15,7 +15,7 @@ WAFFLE_NAMESPACE = u'course_experience'
 # .. toggle_description: Used to determine whether to show custom HTML in the sidebar on the internal course about page.
 # .. toggle_use_cases: open_edx
 # .. toggle_creation_date: 2018-01-26
-# .. toggle_expiration_date: ???
+# .. toggle_target_removal_date: ???
 # .. toggle_warnings: N/A
 # .. toggle_tickets: N/A
 ENABLE_COURSE_ABOUT_SIDEBAR_HTML = u'enable_about_sidebar_html'

--- a/openedx/features/course_experience/waffle.py
+++ b/openedx/features/course_experience/waffle.py
@@ -18,7 +18,6 @@ WAFFLE_NAMESPACE = u'course_experience'
 # .. toggle_expiration_date: ???
 # .. toggle_warnings: N/A
 # .. toggle_tickets: N/A
-# .. toggle_status: supported
 ENABLE_COURSE_ABOUT_SIDEBAR_HTML = u'enable_about_sidebar_html'
 
 

--- a/openedx/features/discounts/applicability.py
+++ b/openedx/features/discounts/applicability.py
@@ -30,13 +30,11 @@ from track import segment
 # .. toggle_type: flag
 # .. toggle_default: False
 # .. toggle_description: Toggle discounts always being disabled
-# .. toggle_category: discounts
 # .. toggle_use_cases: temporary
 # .. toggle_creation_date: 2019-4-16
 # .. toggle_target_removal_date: None
-# .. toggle_warnings: None
 # .. toggle_tickets: REVEM-282
-# .. toggle_status: supported
+# .. toggle_warnings: This temporary feature toggle does not have a target removal date.
 DISCOUNT_APPLICABILITY_FLAG = WaffleFlag(
     waffle_namespace=WaffleFlagNamespace(name=u'discounts'),
     flag_name=u'enable_discounting',

--- a/openedx/features/discounts/applicability.py
+++ b/openedx/features/discounts/applicability.py
@@ -26,17 +26,17 @@ from openedx.features.discounts.models import DiscountPercentageConfig, Discount
 from student.models import CourseEnrollment
 from track import segment
 
-# .. feature_toggle_name: discounts.enable_discounting
-# .. feature_toggle_type: flag
-# .. feature_toggle_default: False
-# .. feature_toggle_description: Toggle discounts always being disabled
-# .. feature_toggle_category: discounts
-# .. feature_toggle_use_cases: monitored_rollout
-# .. feature_toggle_creation_date: 2019-4-16
-# .. feature_toggle_expiration_date: None
-# .. feature_toggle_warnings: None
-# .. feature_toggle_tickets: REVEM-282
-# .. feature_toggle_status: supported
+# .. toggle_name: discounts.enable_discounting
+# .. toggle_type: flag
+# .. toggle_default: False
+# .. toggle_description: Toggle discounts always being disabled
+# .. toggle_category: discounts
+# .. toggle_use_cases: temporary
+# .. toggle_creation_date: 2019-4-16
+# .. toggle_target_removal_date: None
+# .. toggle_warnings: None
+# .. toggle_tickets: REVEM-282
+# .. toggle_status: supported
 DISCOUNT_APPLICABILITY_FLAG = WaffleFlag(
     waffle_namespace=WaffleFlagNamespace(name=u'discounts'),
     flag_name=u'enable_discounting',

--- a/openedx/features/learner_profile/toggles.py
+++ b/openedx/features/learner_profile/toggles.py
@@ -20,7 +20,6 @@ WAFFLE_FLAG_NAMESPACE = WaffleFlagNamespace(name='learner_profile')
 # .. toggle_expiration_date: 2020-12-31
 # .. toggle_warnings: Also set settings.PROFILE_MICROFRONTEND_URL and site's ENABLE_PROFILE_MICROFRONTEND.
 # .. toggle_tickets: DEPR-17
-# .. toggle_status: supported
 REDIRECT_TO_PROFILE_MICROFRONTEND = WaffleFlag(WAFFLE_FLAG_NAMESPACE, 'redirect_to_microfrontend', __name__)
 
 

--- a/openedx/features/learner_profile/toggles.py
+++ b/openedx/features/learner_profile/toggles.py
@@ -15,7 +15,7 @@ WAFFLE_FLAG_NAMESPACE = WaffleFlagNamespace(name='learner_profile')
 # .. toggle_implementation: WaffleFlag
 # .. toggle_default: False
 # .. toggle_description: Supports staged rollout of a new micro-frontend-based implementation of the profile page.
-# .. toggle_use_cases: incremental_release, open_edx
+# .. toggle_use_cases: temporary, open_edx
 # .. toggle_creation_date: 2019-02-19
 # .. toggle_target_removal_date: 2020-12-31
 # .. toggle_warnings: Also set settings.PROFILE_MICROFRONTEND_URL and site's ENABLE_PROFILE_MICROFRONTEND.

--- a/openedx/features/learner_profile/toggles.py
+++ b/openedx/features/learner_profile/toggles.py
@@ -15,7 +15,6 @@ WAFFLE_FLAG_NAMESPACE = WaffleFlagNamespace(name='learner_profile')
 # .. toggle_implementation: WaffleFlag
 # .. toggle_default: False
 # .. toggle_description: Supports staged rollout of a new micro-frontend-based implementation of the profile page.
-# .. toggle_category: micro-frontend
 # .. toggle_use_cases: incremental_release, open_edx
 # .. toggle_creation_date: 2019-02-19
 # .. toggle_expiration_date: 2020-12-31

--- a/openedx/features/learner_profile/toggles.py
+++ b/openedx/features/learner_profile/toggles.py
@@ -17,7 +17,7 @@ WAFFLE_FLAG_NAMESPACE = WaffleFlagNamespace(name='learner_profile')
 # .. toggle_description: Supports staged rollout of a new micro-frontend-based implementation of the profile page.
 # .. toggle_use_cases: incremental_release, open_edx
 # .. toggle_creation_date: 2019-02-19
-# .. toggle_expiration_date: 2020-12-31
+# .. toggle_target_removal_date: 2020-12-31
 # .. toggle_warnings: Also set settings.PROFILE_MICROFRONTEND_URL and site's ENABLE_PROFILE_MICROFRONTEND.
 # .. toggle_tickets: DEPR-17
 REDIRECT_TO_PROFILE_MICROFRONTEND = WaffleFlag(WAFFLE_FLAG_NAMESPACE, 'redirect_to_microfrontend', __name__)


### PR DESCRIPTION
In this PR, I progressively document feature toggles one application at a time, starting at the top of a list of high-priority applications.

To detect feature toggles, I grep the application code as follows:

    git grep --show-function -E "FEATURES|Waffle|Config|Switch" -- ./path/to/the/application

Although I generally have not too much trouble figuring out how feature flags are used, there are some annotation fields for which I do not quite understand how they should be used:

1. `.. toggle_use_cases`: should be one or more of incremental_release, launch_date, monitored_rollout, graceful_degradation, beta_testing, vip, opt_out, opt_in, open_edx. I have no idea what these values mean, so I just blindly set this annotation to "open_edx".
2. `.. toggle_category`: what should we use for this field? Should this be the name of the django app in which the feature toggle is defined (this is what I have done until now).

~~cc @robrap: no need for a thorough review right now. Maybe just check that I'm headed in the right direction?~~

I'll list here remaining questions I have about the feature toggles:
* `videos.enable_devstack_video_uploads`: I did not quite understand the point of this feature toggle. My interpretation is that short-lived authentication tokens are better suited for the devstack, but I have trouble understanding why.
* `lms/djangoapps/grades/config/waffle.py`: what are the use cases for these flags? (see [this comment](https://github.com/edx/edx-platform/pull/24815#discussion_r484554228))