### PR TITLE
Enable ORGANIZATIONS_APP for devstack Studio

### DIFF
--- a/cms/envs/devstack.py
+++ b/cms/envs/devstack.py
@@ -117,6 +117,8 @@ def should_show_debug_toolbar(request):
 ################################ MILESTONES ################################
 FEATURES['MILESTONES_APP'] = True
 
+########################### ORGANIZATIONS #################################
+FEATURES['ORGANIZATIONS_APP'] = True
 
 ################################ ENTRANCE EXAMS ################################
 FEATURES['ENTRANCE_EXAMS'] = True

--- a/lms/envs/devstack.py
+++ b/lms/envs/devstack.py
@@ -162,7 +162,7 @@ FEATURES['PREVENT_CONCURRENT_LOGINS'] = False
 ########################### Milestones #################################
 FEATURES['MILESTONES_APP'] = True
 
-########################### Milestones #################################
+########################### Organizations #################################
 FEATURES['ORGANIZATIONS_APP'] = True
 
 ########################### Entrance Exams #################################


### PR DESCRIPTION
```
It is already enabled in devstack LMS, stage LMS/Studio,
and prod LMS/Studio.

However, it is currently disabled in edge LMS/Studio,
and as far as I know, sandbox LMS/Studio as well as the
default Open edX LMS/Studio.

We would like to move towards enabling it globally by
default, and enabling it in devstack Studio would be
a first step towards that.
```

This came up in our [BD-14] sync with @arbrandes .

@ormsbee @nasthagiri , can one of you review?