### PR TITLE
Cleanup unused CONFIG_ROOT variable and dead code.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -56,7 +56,6 @@ COPY . /edx/app/edx-platform/edx-platform
 
 ENV PATH /edx/app/edx-platform/nodeenv/bin:${PATH}
 ENV PATH ./node_modules/.bin:${PATH}
-ENV CONFIG_ROOT /edx/etc/
 ENV PATH /edx/app/edx-platform/edx-platform/bin:${PATH}
 ENV SETTINGS production
 

--- a/cms/envs/bok_choy.py
+++ b/cms/envs/bok_choy.py
@@ -28,11 +28,11 @@ from openedx.core.release import RELEASE_LINE
 # This is a convenience for ensuring (a) that we can consistently find the files
 # and (b) that the files are the same in Jenkins as in local dev.
 os.environ['SERVICE_VARIANT'] = 'bok_choy_docker' if 'BOK_CHOY_HOSTNAME' in os.environ else 'bok_choy'
-os.environ['CONFIG_ROOT'] = path(__file__).abspath().dirname()
+CONFIG_ROOT = path(__file__).abspath().dirname()
 os.environ['STUDIO_CFG'] = str.format("{config_root}/{service_variant}.yml",
-                                      config_root=os.environ['CONFIG_ROOT'],
+                                      config_root=CONFIG_ROOT,
                                       service_variant=os.environ['SERVICE_VARIANT'])
-os.environ['REVISION_CFG'] = "{config_root}/revisions.yml".format(config_root=os.environ['CONFIG_ROOT'])
+os.environ['REVISION_CFG'] = "{config_root}/revisions.yml".format(config_root=CONFIG_ROOT)
 
 from .production import *  # pylint: disable=wildcard-import, unused-wildcard-import, wrong-import-position
 

--- a/cms/envs/production.py
+++ b/cms/envs/production.py
@@ -97,11 +97,6 @@ EDX_PLATFORM_REVISION = REVISION_CONFIG.get('EDX_PLATFORM_REVISION', EDX_PLATFOR
 # configuration files are read during startup.
 SERVICE_VARIANT = os.environ.get('SERVICE_VARIANT', None)
 
-# CONFIG_ROOT specifies the directory where the JSON configuration
-# files are expected to be found. If not specified, use the project
-# directory.
-CONFIG_ROOT = path(os.environ.get('CONFIG_ROOT', ENV_ROOT))
-
 # CONFIG_PREFIX specifies the prefix of the JSON configuration files,
 # based on the service variant. If no variant is use, don't use a
 # prefix.

--- a/lms/envs/bok_choy.py
+++ b/lms/envs/bok_choy.py
@@ -32,10 +32,9 @@ TEST_ROOT = CONFIG_ROOT.dirname().dirname() / "test_root"
 # This is a convenience for ensuring (a) that we can consistently find the files
 # and (b) that the files are the same in Jenkins as in local dev.
 os.environ['SERVICE_VARIANT'] = 'bok_choy_docker' if 'BOK_CHOY_HOSTNAME' in os.environ else 'bok_choy'
-os.environ['CONFIG_ROOT'] = CONFIG_ROOT
 os.environ['LMS_CFG'] = str.format("{config_root}/{service_variant}.yml",
-                                   config_root=os.environ['CONFIG_ROOT'], service_variant=os.environ['SERVICE_VARIANT'])
-os.environ['REVISION_CFG'] = "{config_root}/revisions.yml".format(config_root=os.environ['CONFIG_ROOT'])
+                                   config_root=CONFIG_ROOT, service_variant=os.environ['SERVICE_VARIANT'])
+os.environ['REVISION_CFG'] = "{config_root}/revisions.yml".format(config_root=CONFIG_ROOT)
 
 from .production import *  # pylint: disable=wildcard-import, unused-wildcard-import, wrong-import-position
 

--- a/lms/envs/production.py
+++ b/lms/envs/production.py
@@ -109,11 +109,6 @@ EDX_PLATFORM_REVISION = REVISION_CONFIG.get('EDX_PLATFORM_REVISION', EDX_PLATFOR
 # configuration files are read during startup.
 SERVICE_VARIANT = os.environ.get('SERVICE_VARIANT', None)
 
-# CONFIG_ROOT specifies the directory where the JSON configuration
-# files are expected to be found. If not specified, use the project
-# directory.
-CONFIG_ROOT = path(os.environ.get('CONFIG_ROOT', ENV_ROOT))
-
 # CONFIG_PREFIX specifies the prefix of the JSON configuration files,
 # based on the service variant. If no variant is use, don't use a
 # prefix.


### PR DESCRIPTION
From what I've gleaned, CONFIG_FILE (and LMS_CFG and STUDIO_CFG
environment variables) supercedes CONFIG_ROOT.  There's no code anymore
that reads the value of the CONFIG_ROOT django setting, and in turn the
CONFIG_ROOT environment variable.

Tangentially related to DENG-369