### PR TITLE
BOM-1982 : Unpin django-ipware

### DIFF
--- a/common/djangoapps/course_modes/views.py
+++ b/common/djangoapps/course_modes/views.py
@@ -21,7 +21,7 @@ from django.utils.translation import get_language, to_locale
 from django.utils.translation import ugettext as _
 from django.views.generic.base import View
 from edx_django_utils.monitoring.utils import increment
-from ipware.ip import get_ip
+from ipware.ip import get_client_ip
 from opaque_keys.edx.keys import CourseKey
 from six import text_type
 
@@ -90,7 +90,7 @@ class ChooseModeView(View):
         embargo_redirect = embargo_api.redirect_if_blocked(
             course_key,
             user=request.user,
-            ip_address=get_ip(request),
+            ip_address=get_client_ip(request)[0],
             url=request.path
         )
         if embargo_redirect:

--- a/common/djangoapps/student/views/management.py
+++ b/common/djangoapps/student/views/management.py
@@ -29,7 +29,7 @@ from edx_ace import ace
 from edx_ace.recipient import Recipient
 from edx_django_utils import monitoring as monitoring_utils
 from eventtracking import tracker
-from ipware.ip import get_ip
+from ipware.ip import get_client_ip
 # Note that this lives in LMS, so this dependency should be refactored.
 from opaque_keys import InvalidKeyError
 from opaque_keys.edx.keys import CourseKey
@@ -340,7 +340,7 @@ def change_enrollment(request, check_access=True):
         # or if the user is enrolling in a country in which the course
         # is not available.
         redirect_url = embargo_api.redirect_if_blocked(
-            course_id, user=user, ip_address=get_ip(request),
+            course_id, user=user, ip_address=get_client_ip(request)[0],
             url=request.path
         )
         if redirect_url:

--- a/common/djangoapps/track/middleware.py
+++ b/common/djangoapps/track/middleware.py
@@ -16,7 +16,7 @@ import six
 from django.conf import settings
 from django.utils.deprecation import MiddlewareMixin
 from eventtracking import tracker
-from ipware.ip import get_ip
+from ipware.ip import get_client_ip
 
 from common.djangoapps.track import contexts, views
 
@@ -229,7 +229,7 @@ class TrackMiddleware(MiddlewareMixin):
 
     def get_request_ip_address(self, request):
         """Gets the IP address of the request"""
-        ip_address = get_ip(request)
+        ip_address = get_client_ip(request)[0]
         if ip_address is not None:
             return ip_address
         else:

--- a/common/djangoapps/track/views/__init__.py
+++ b/common/djangoapps/track/views/__init__.py
@@ -6,7 +6,7 @@ import six
 from django.contrib.auth.models import User  # lint-amnesty, pylint: disable=imported-auth-user
 from django.http import HttpResponse
 from eventtracking import tracker as eventtracker
-from ipware.ip import get_ip
+from ipware.ip import get_client_ip
 
 from common.djangoapps.track import contexts, shim, tracker
 
@@ -22,7 +22,7 @@ def _get_request_header(request, header_name, default=''):
 def _get_request_ip(request, default=''):
     """Helper method to get IP from a request's META dict, if present."""
     if request is not None and hasattr(request, 'META'):
-        return get_ip(request)
+        return get_client_ip(request)[0]
     else:
         return default
 

--- a/lms/djangoapps/courseware/views/views.py
+++ b/lms/djangoapps/courseware/views/views.py
@@ -34,7 +34,7 @@ from django.views.decorators.http import require_GET, require_http_methods, requ
 from django.views.generic import View
 from edx_django_utils import monitoring as monitoring_utils
 from edx_django_utils.monitoring import set_custom_attribute, set_custom_attributes_for_course_key
-from ipware.ip import get_ip
+from ipware.ip import get_client_ip
 from markupsafe import escape
 from opaque_keys import InvalidKeyError
 from opaque_keys.edx.keys import CourseKey, UsageKey
@@ -1911,7 +1911,7 @@ def financial_assistance_request(request):
         goals = data['goals']
         effort = data['effort']
         marketing_permission = data['mktg-permission']
-        ip_address = get_ip(request)
+        ip_address = get_client_ip(request)[0]
     except ValueError:
         # Thrown if JSON parsing fails
         return HttpResponseBadRequest(u'Could not parse request JSON.')

--- a/lms/djangoapps/verify_student/views.py
+++ b/lms/djangoapps/verify_student/views.py
@@ -23,7 +23,7 @@ from django.views.decorators.csrf import csrf_exempt
 from django.views.decorators.http import require_POST
 from django.views.generic.base import View
 from edx_rest_api_client.exceptions import SlumberBaseException
-from ipware.ip import get_ip
+from ipware.ip import get_client_ip
 from opaque_keys.edx.keys import CourseKey
 from rest_framework.response import Response
 from rest_framework.views import APIView
@@ -243,7 +243,7 @@ class PayAndVerifyView(View):
         redirect_url = embargo_api.redirect_if_blocked(
             course_key,
             user=request.user,
-            ip_address=get_ip(request),
+            ip_address=get_client_ip(request)[0],
             url=request.path
         )
         if redirect_url:

--- a/openedx/core/djangoapps/embargo/api.py
+++ b/openedx/core/djangoapps/embargo/api.py
@@ -10,7 +10,7 @@ import logging
 
 from django.conf import settings
 from django.core.cache import cache
-from ipware.ip import get_ip
+from ipware.ip import get_client_ip
 from rest_framework import status
 from rest_framework.response import Response
 
@@ -197,7 +197,7 @@ def get_embargo_response(request, course_id, user):
 
     """
     redirect_url = redirect_if_blocked(
-        course_id, user=user, ip_address=get_ip(request), url=request.path)
+        course_id, user=user, ip_address=get_client_ip(request)[0], url=request.path)
     if redirect_url:
         return Response(
             status=status.HTTP_403_FORBIDDEN,

--- a/openedx/core/djangoapps/embargo/middleware.py
+++ b/openedx/core/djangoapps/embargo/middleware.py
@@ -34,7 +34,7 @@ from django.core.exceptions import MiddlewareNotUsed
 from django.urls import reverse
 from django.utils.deprecation import MiddlewareMixin
 from django.shortcuts import redirect
-from ipware.ip import get_ip
+from ipware.ip import get_client_ip
 
 from openedx.core.lib.request_utils import course_id_from_url
 
@@ -83,7 +83,7 @@ class EmbargoMiddleware(MiddlewareMixin):
             if pattern.match(request.path) is not None:
                 return None
 
-        ip_address = get_ip(request)
+        ip_address = get_client_ip(request)[0]
         ip_filter = IPFilter.current()
 
         if ip_filter.enabled and ip_address in ip_filter.blacklist_ips:

--- a/openedx/core/djangoapps/geoinfo/middleware.py
+++ b/openedx/core/djangoapps/geoinfo/middleware.py
@@ -9,14 +9,13 @@ Usage:
 decorator `django.utils.decorators.decorator_from_middleware(middleware_class)`
 
 """
-
-
 import logging
 import geoip2.database
 
 from django.conf import settings
 from django.utils.deprecation import MiddlewareMixin
-from ipware.ip import get_real_ip
+from ipware.ip import get_client_ip
+from ipware.utils import is_public_ip
 
 log = logging.getLogger(__name__)
 
@@ -31,13 +30,13 @@ class CountryMiddleware(MiddlewareMixin):
 
         Store country code in session.
         """
-        new_ip_address = get_real_ip(request)
+        new_ip_address = get_client_ip(request)[0]
         old_ip_address = request.session.get('ip_address', None)
 
         if not new_ip_address and old_ip_address:
             del request.session['ip_address']
             del request.session['country_code']
-        elif new_ip_address != old_ip_address:
+        elif new_ip_address != old_ip_address and is_public_ip(new_ip_address):
             reader = geoip2.database.Reader(settings.GEOIP_PATH)
             try:
                 response = reader.country(new_ip_address)

--- a/openedx/core/djangoapps/geoinfo/tests/test_middleware.py
+++ b/openedx/core/djangoapps/geoinfo/tests/test_middleware.py
@@ -107,20 +107,6 @@ class CountryMiddlewareTests(TestCase):
         assert 'CN' == request.session.get('country_code')
         assert '117.79.83.100' == request.session.get('ip_address')
 
-    def test_ip_address_is_none(self):
-        # IP address is not defined in request.
-        request = self.request_factory.get('/somewhere')
-        request.user = self.anonymous_user
-        # Run process_request to set up the session in the request
-        # to be able to override it.
-        self.session_middleware.process_request(request)
-        request.session['country_code'] = 'CN'
-        request.session['ip_address'] = '117.79.83.1'
-        self.country_middleware.process_request(request)
-        # No country code exists after request processing.
-        assert 'country_code' not in request.session
-        assert 'ip_address' not in request.session
-
     def test_ip_address_is_ipv6(self):
         request = self.request_factory.get(
             '/somewhere',

--- a/openedx/core/djangoapps/util/ratelimit.py
+++ b/openedx/core/djangoapps/util/ratelimit.py
@@ -1,15 +1,13 @@
 """
 Code to get ip from request.
 """
-
-
 from uuid import uuid4
 
-from ipware.ip import get_ip
+from ipware.ip import get_client_ip
 
 
 def real_ip(group, request):  # pylint: disable=unused-argument
-    return get_ip(request)
+    return get_client_ip(request)[0]
 
 
 def request_post_email(group, request) -> str:  # pylint: disable=unused-argument

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -24,9 +24,6 @@ django-cors-headers<3.0.0
 # It seems like django-countries > 5.5 may cause performance issues for us.
 django-countries==5.5
 
-# Removes deprecated get_ip function, which we still use (ARCHBOM-1329 for unpinning)
-django-ipware<3.0.0
-
 # django-storages version 1.9 drops support for boto storage backend.
 django-storages<1.9
 
@@ -34,7 +31,7 @@ django-storages<1.9
 # The team that owns this package will manually bump this package rather than having it pulled in automatically.
 # This is to allow them to better control its deployment and to do it in a process that works better
 # for them.
-edx-enterprise==3.17.40
+edx-enterprise==3.17.41
 
 # Upgrading to 2.12.0 breaks several test classes due to API changes, need to update our code accordingly
 factory-boy==2.8.1

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -58,7 +58,7 @@ django-countries==5.5     # via -c requirements/edx/../constraints.txt, -r requi
 django-crum==0.7.9        # via -r requirements/edx/base.in, edx-django-utils, edx-enterprise, edx-proctoring, edx-rbac, edx-toggles, super-csv
 django-fernet-fields==0.6  # via -r requirements/edx/base.in, edx-enterprise, edx-event-routing-backends, edxval
 django-filter==2.4.0      # via -r requirements/edx/base.in, edx-enterprise, lti-consumer-xblock
-django-ipware==2.1.0      # via -c requirements/edx/../constraints.txt, -r requirements/edx/base.in, edx-enterprise, edx-proctoring
+django-ipware==3.0.2      # via -c requirements/edx/../constraints.txt, -r requirements/edx/base.in, edx-enterprise, edx-proctoring
 django-js-asset==1.2.2    # via django-mptt
 django-method-override==1.0.4  # via -r requirements/edx/base.in
 django-model-utils==4.1.1  # via -r requirements/edx/base.in, django-user-tasks, edx-bulk-grades, edx-celeryutils, edx-completion, edx-enterprise, edx-milestones, edx-organizations, edx-proctoring, edx-rbac, edx-submissions, edx-when, edxval, ora2, super-csv
@@ -99,7 +99,7 @@ edx-django-release-util==1.0.0  # via -r requirements/edx/base.in
 edx-django-sites-extensions==3.0.0  # via -r requirements/edx/base.in
 edx-django-utils==3.13.0  # via -r requirements/edx/base.in, django-config-models, edx-drf-extensions, edx-enterprise, edx-rest-api-client, edx-toggles, edx-when, ora2, super-csv
 edx-drf-extensions==6.5.0  # via -r requirements/edx/base.in, edx-completion, edx-enterprise, edx-organizations, edx-proctoring, edx-rbac, edx-when, edxval
-edx-enterprise==3.17.40   # via -c requirements/edx/../constraints.txt, -r requirements/edx/base.in
+edx-enterprise==3.17.41   # via -c requirements/edx/../constraints.txt, -r requirements/edx/base.in
 edx-event-routing-backends==4.0.1  # via -r requirements/edx/base.in
 edx-i18n-tools==0.5.3     # via ora2
 edx-milestones==0.3.0     # via -r requirements/edx/base.in

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -69,7 +69,7 @@ django-crum==0.7.9        # via -r requirements/edx/testing.txt, edx-django-util
 django-debug-toolbar==3.2  # via -r requirements/edx/development.in
 django-fernet-fields==0.6  # via -r requirements/edx/testing.txt, edx-enterprise, edx-event-routing-backends, edxval
 django-filter==2.4.0      # via -r requirements/edx/testing.txt, edx-enterprise, lti-consumer-xblock
-django-ipware==2.1.0      # via -c requirements/edx/../constraints.txt, -r requirements/edx/testing.txt, edx-enterprise, edx-proctoring
+django-ipware==3.0.2      # via -c requirements/edx/../constraints.txt, -r requirements/edx/testing.txt, edx-enterprise, edx-proctoring
 django-js-asset==1.2.2    # via -r requirements/edx/testing.txt, django-mptt
 django-method-override==1.0.4  # via -r requirements/edx/testing.txt
 django-model-utils==4.1.1  # via -r requirements/edx/testing.txt, django-user-tasks, edx-bulk-grades, edx-celeryutils, edx-completion, edx-enterprise, edx-milestones, edx-organizations, edx-proctoring, edx-rbac, edx-submissions, edx-when, edxval, ora2, super-csv
@@ -110,7 +110,7 @@ edx-django-release-util==1.0.0  # via -r requirements/edx/testing.txt
 edx-django-sites-extensions==3.0.0  # via -r requirements/edx/testing.txt
 edx-django-utils==3.13.0  # via -r requirements/edx/testing.txt, django-config-models, edx-drf-extensions, edx-enterprise, edx-rest-api-client, edx-toggles, edx-when, ora2, super-csv
 edx-drf-extensions==6.5.0  # via -r requirements/edx/testing.txt, edx-completion, edx-enterprise, edx-organizations, edx-proctoring, edx-rbac, edx-when, edxval
-edx-enterprise==3.17.40   # via -c requirements/edx/../constraints.txt, -r requirements/edx/testing.txt
+edx-enterprise==3.17.41   # via -c requirements/edx/../constraints.txt, -r requirements/edx/testing.txt
 edx-event-routing-backends==4.0.1  # via -r requirements/edx/testing.txt
 edx-i18n-tools==0.5.3     # via -r requirements/edx/testing.txt, ora2
 edx-lint==4.0.1           # via -r requirements/edx/testing.txt

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -67,7 +67,7 @@ django-countries==5.5     # via -c requirements/edx/../constraints.txt, -r requi
 django-crum==0.7.9        # via -r requirements/edx/base.txt, edx-django-utils, edx-enterprise, edx-proctoring, edx-rbac, edx-toggles, super-csv
 django-fernet-fields==0.6  # via -r requirements/edx/base.txt, edx-enterprise, edx-event-routing-backends, edxval
 django-filter==2.4.0      # via -r requirements/edx/base.txt, edx-enterprise, lti-consumer-xblock
-django-ipware==2.1.0      # via -c requirements/edx/../constraints.txt, -r requirements/edx/base.txt, edx-enterprise, edx-proctoring
+django-ipware==3.0.2      # via -c requirements/edx/../constraints.txt, -r requirements/edx/base.txt, edx-enterprise, edx-proctoring
 django-js-asset==1.2.2    # via -r requirements/edx/base.txt, django-mptt
 django-method-override==1.0.4  # via -r requirements/edx/base.txt
 django-model-utils==4.1.1  # via -r requirements/edx/base.txt, django-user-tasks, edx-bulk-grades, edx-celeryutils, edx-completion, edx-enterprise, edx-milestones, edx-organizations, edx-proctoring, edx-rbac, edx-submissions, edx-when, edxval, ora2, super-csv
@@ -107,7 +107,7 @@ edx-django-release-util==1.0.0  # via -r requirements/edx/base.txt
 edx-django-sites-extensions==3.0.0  # via -r requirements/edx/base.txt
 edx-django-utils==3.13.0  # via -r requirements/edx/base.txt, django-config-models, edx-drf-extensions, edx-enterprise, edx-rest-api-client, edx-toggles, edx-when, ora2, super-csv
 edx-drf-extensions==6.5.0  # via -r requirements/edx/base.txt, edx-completion, edx-enterprise, edx-organizations, edx-proctoring, edx-rbac, edx-when, edxval
-edx-enterprise==3.17.40   # via -c requirements/edx/../constraints.txt, -r requirements/edx/base.txt
+edx-enterprise==3.17.41   # via -c requirements/edx/../constraints.txt, -r requirements/edx/base.txt
 edx-event-routing-backends==4.0.1  # via -r requirements/edx/base.txt
 edx-i18n-tools==0.5.3     # via -r requirements/edx/base.txt, -r requirements/edx/testing.in, ora2
 edx-lint==4.0.1           # via -r requirements/edx/testing.in


### PR DESCRIPTION
Relevant JIRA : https://openedx.atlassian.net/browse/BOM-1982

First review the Enterprise PR [here](https://github.com/edx/edx-enterprise/pull/936), after enterprise is merged is released, will update the enterprise version here and merge


django-ipware added new method in this [commit](https://github.com/un33k/django-ipware/commit/ab0c69f78a20e5873bcb63f9023e8837580dd076#diff-2f34c0414bdaeea55adb995d48b4321335afde5b02bffb6d15e020433cf8760dR5)

This [issue](https://github.com/un33k/django-ipware/issues/45) contains information about the latest method name and its usage details. 
This old platform [PR](https://github.com/edx/edx-platform/pull/18874) also has some useful info.

Both issue and PR created by same dev while upgrading django-ipware in platform.


https://github.com/un33k/django-ipware#notice
