### PR TITLE
disable xsslint on program_header_view

### DIFF
--- a/lms/templates/learner_dashboard/program_header_view.underscore
+++ b/lms/templates/learner_dashboard/program_header_view.underscore
@@ -1,6 +1,7 @@
 <div class="program-details-header">
     <div class="meta-info grid-container">
         <% if (logo) { %>
+            <% // xss-lint: disable=underscore-not-escaped %>
             <span aria-label="<%- gettext(programData.type) %>" class="<%- programData.type.toLowerCase() %> program-details-icon"><%= logo %></span>
         <% } %>
         <h2 class="hd-1 program-title"><%- programData.title %></h2>


### PR DESCRIPTION
## [PROD-1599](https://openedx.atlassian.net/browse/PROD-1599)

This xss vulnerability Line 4: **underscore-not-escaped** `<span aria-label="<%- gettext(programData.type) %>" class="<%- programData.type.toLowerCase() %> program-details-icon"><%= logo %></span>` can be disabled since it's not valid and escaping it will also cause problems.