### PR TITLE
Fix Sign-In button for Studio on Devstack

### DIFF
--- a/cms/envs/devstack.py
+++ b/cms/envs/devstack.py
@@ -230,3 +230,8 @@ CORS_ORIGIN_ALLOW_ALL = True
 CORS_ALLOW_HEADERS = corsheaders_default_headers + (
     'use-jwt-cookie',
 )
+
+######################### FRONTEND LMS URLs #########################
+FRONTEND_LOGIN_URL = 'http://localhost:18000/login'
+FRONTEND_LOGOUT_URL = 'http://localhost:18000/logout'
+FRONTEND_REGISTER_URL = 'http://localhost:18000/register'


### PR DESCRIPTION
`FRONTEND_LOGIN_URL` was formerly set to `'http://edx.devstack.lms:18000/login'`, which caused Studio sign-in to hang for me.

It was set in `cms/envs/common.py` via the derived-settings mechanism. This PR instead just explicitly sets it to `'http://localhost:18000/login'` in `cms/envs/devstack.py`.

cc @muhammad-ammar 