### PR TITLE
Add logs in get_problem_responses

### DIFF
--- a/lms/djangoapps/instructor/static/instructor/ProblemBrowser/data/actions/problemResponses.js
+++ b/lms/djangoapps/instructor/static/instructor/ProblemBrowser/data/actions/problemResponses.js
@@ -79,7 +79,7 @@ const createProblemResponsesReportTask = (
     })
     .then(
       json => dispatch(getTaskStatus(taskStatusEndpoint, json.task_id)),
-      () => dispatch(problemResponsesFailure(gettext('Unable to submit request to generate report.'))),
+      err => dispatch(problemResponsesFailure(gettext('Unable to submit request to generate report.'))), // eslint-disable-line no-unused-vars
     );
 };
 

--- a/lms/djangoapps/instructor/views/api.py
+++ b/lms/djangoapps/instructor/views/api.py
@@ -1055,6 +1055,7 @@ def get_problem_responses(request, course_id):
         for problem_location in problem_locations.split(','):
             problem_key = UsageKey.from_string(problem_location).map_into_course(course_key)
     except InvalidKeyError:
+        log.exception("ProblemResponsesError: Location: %s", problem_locations)
         return JsonResponseBadRequest(_("Could not find problem with this location."))
 
     task = task_api.submit_calculate_problem_responses_csv(


### PR DESCRIPTION
Adding error logs in get_problem_responses for the investigation purposes.

[CR-2577](https://openedx.atlassian.net/browse/CR-2577)

FYI -- @xitij2000 

Error Screenshot:

<img width="1108" alt="Screen Shot 2020-08-24 at 4 17 47 PM" src="https://user-images.githubusercontent.com/4252738/91039090-5c017800-e625-11ea-985c-4a8e4b2f3ab1.png">

Sample Output for err:
`InvalidKeyError("<class 'opaque_keys.edx.locator.BlockUsageLocator'>: ",)`
![image](https://user-images.githubusercontent.com/52413434/91055139-b4447400-e63d-11ea-85e4-fd04cd96bfb5.png)
