### PR TITLE
Update ports for decentralized devstack ARCHBOM-1447

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,10 +13,6 @@ lms/envs/private.py
 cms/envs/private.py
 # end-noclean
 
-# From Decentralized Devstack work. TODO clean up.
-requirements/edx/base_in_tree.txt
-requirements/edx/base_not_in_tree.txt
-
 ### Python artifacts
 *.pyc
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -87,12 +87,11 @@ COPY cms/devstack.yml /edx/etc/studio.yml
 # the requirements cache.
 COPY . .
 
-EXPOSE 18000
-
 FROM base as lms
 ENV SERVICE_VARIANT lms
 ENV DJANGO_SETTINGS_MODULE lms.envs.production
-CMD gunicorn -c /edx/app/edxapp/edx-platform/lms/docker_lms_gunicorn.py --name lms --bind=0.0.0.0:18000 --max-requests=1000 --access-logfile - lms.wsgi:application
+EXPOSE 8000
+CMD gunicorn -c /edx/app/edxapp/edx-platform/lms/docker_lms_gunicorn.py --name lms --bind=0.0.0.0:8000 --max-requests=1000 --access-logfile - lms.wsgi:application
 
 FROM lms as lms-newrelic
 RUN pip install newrelic
@@ -110,11 +109,12 @@ ENV DJANGO_SETTINGS_MODULE lms.envs.devstack_decentralized
 FROM base as studio
 ENV SERVICE_VARIANT cms
 ENV DJANGO_SETTINGS_MODULE cms.envs.production
-CMD gunicorn -c /edx/app/edxapp/edx-platform/cms/docker_cms_gunicorn.py --name cms --bind=0.0.0.0:8000 --max-requests=1000 --access-logfile - cms.wsgi:application
+EXPOSE 8010
+CMD gunicorn -c /edx/app/edxapp/edx-platform/cms/docker_cms_gunicorn.py --name cms --bind=0.0.0.0:8010 --max-requests=1000 --access-logfile - cms.wsgi:application
 
 FROM studio as studio-newrelic
 RUN pip install newrelic
-CMD newrelic-admin run-program gunicorn -c /edx/app/edxapp/edx-platform/cms/docker_cms_gunicorn.py --name cms --bind=0.0.0.0:8000 --max-requests=1000 --access-logfile - cms.wsgi:application
+CMD newrelic-admin run-program gunicorn -c /edx/app/edxapp/edx-platform/cms/docker_cms_gunicorn.py --name cms --bind=0.0.0.0:8010 --max-requests=1000 --access-logfile - cms.wsgi:application
 
 FROM studio as studio-devstack
 # TODO: This compiles static assets.

--- a/Makefile
+++ b/Makefile
@@ -105,10 +105,6 @@ upgrade: ## update the pip requirements files to use the latest releases satisfy
 	sed '/^[dD]jango==/d' requirements/edx/testing.txt > requirements/edx/testing.tmp
 	mv requirements/edx/testing.tmp requirements/edx/testing.txt
 
-split_requirements:
-	grep -E    "^-e (common|openedx|lms|cms|\.)" requirements/edx/base.txt > requirements/edx/base_in_tree.txt
-	grep -E -v "^-e (common|openedx|lms|cms|\.)(/| )" requirements/edx/base.txt > requirements/edx/base_not_in_tree.txt
-
 # These make targets currently only build LMS images.
 docker_build:
 	docker build . -f Dockerfile --target lms -t openedx/edx-platform

--- a/cms/devstack.yml
+++ b/cms/devstack.yml
@@ -96,7 +96,7 @@ CERTIFICATE_TEMPLATE_LANGUAGES:
     en: English
     es: Español
 CERT_QUEUE: certificates
-CMS_BASE: edx.devstack.studio:18010
+CMS_BASE: edx.devstack.studio:8010
 CODE_JAIL:
     limits:
         CPU: 1
@@ -191,7 +191,7 @@ DEFAULT_FILE_STORAGE: django.core.files.storage.FileSystemStorage
 DEFAULT_FROM_EMAIL: registration@example.com
 DEFAULT_JWT_ISSUER:
     AUDIENCE: lms-key
-    ISSUER: http://edx.devstack.lms:18000/oauth2
+    ISSUER: http://edx.devstack.lms:8000/oauth2
     SECRET_KEY: lms-secret
 DEFAULT_MOBILE_AVAILABLE: false
 DEFAULT_SITE_THEME: ''
@@ -230,7 +230,7 @@ EMAIL_HOST_USER: ''
 EMAIL_PORT: 25
 EMAIL_USE_TLS: false
 ENABLE_COMPREHENSIVE_THEMING: false
-ENTERPRISE_API_URL: http://edx.devstack.lms:18000/enterprise/api/v1
+ENTERPRISE_API_URL: http://edx.devstack.lms:8000/enterprise/api/v1
 ENTERPRISE_MARKETING_FOOTER_QUERY_PARAMS: {}
 ENTERPRISE_SERVICE_WORKER_USERNAME: enterprise_worker
 EVENT_TRACKING_SEGMENTIO_EMIT_WHITELIST: []
@@ -264,7 +264,7 @@ FEATURES:
     ENABLE_SYSADMIN_DASHBOARD: false
     ENABLE_THIRD_PARTY_AUTH: true
     ENABLE_VIDEO_UPLOAD_PIPELINE: false
-    PREVIEW_LMS_BASE: preview.localhost:18000
+    PREVIEW_LMS_BASE: preview.localhost:8000
     SHOW_FOOTER_LANGUAGE_SELECTOR: false
     SHOW_HEADER_LANGUAGE_SELECTOR: false
 FEEDBACK_SUBMISSION_EMAIL: ''
@@ -299,24 +299,24 @@ JWT_AUTH:
     JWT_AUTH_COOKIE_HEADER_PAYLOAD: edx-jwt-cookie-header-payload
     JWT_AUTH_COOKIE_SIGNATURE: edx-jwt-cookie-signature
     JWT_AUTH_REFRESH_COOKIE: edx-jwt-refresh-cookie
-    JWT_ISSUER: http://edx.devstack.lms:18000/oauth2
+    JWT_ISSUER: http://edx.devstack.lms:8000/oauth2
     JWT_ISSUERS:
     -   AUDIENCE: lms-key
-        ISSUER: http://edx.devstack.lms:18000/oauth2
+        ISSUER: http://edx.devstack.lms:8000/oauth2
         SECRET_KEY: lms-secret
     JWT_PRIVATE_SIGNING_JWK: None
     JWT_PUBLIC_SIGNING_JWK_SET: ''
     JWT_SECRET_KEY: lms-secret
     JWT_SIGNING_ALGORITHM: null
 JWT_EXPIRATION: 30
-JWT_ISSUER: http://edx.devstack.lms:18000/oauth2
+JWT_ISSUER: http://edx.devstack.lms:8000/oauth2
 JWT_PRIVATE_SIGNING_KEY: null
 LANGUAGE_CODE: en
 LANGUAGE_COOKIE: openedx-language-preference
-LEARNER_PORTAL_URL_ROOT: https://learner-portal-edx.devstack.lms:18000
-LMS_BASE: edx.devstack.lms:18000
-LMS_INTERNAL_ROOT_URL: http://edx.devstack.lms:18000
-LMS_ROOT_URL: http://edx.devstack.lms:18000
+LEARNER_PORTAL_URL_ROOT: https://learner-portal-edx.devstack.lms:8000
+LMS_BASE: edx.devstack.lms:8000
+LMS_INTERNAL_ROOT_URL: http://edx.devstack.lms:8000
+LMS_ROOT_URL: http://edx.devstack.lms:8000
 LOCAL_LOGLEVEL: INFO
 LOGGING_ENV: sandbox
 LOGIN_REDIRECT_WHITELIST: []

--- a/cms/envs/devstack_decentralized.py
+++ b/cms/envs/devstack_decentralized.py
@@ -19,7 +19,7 @@ DEFAULT_TEMPLATE_ENGINE['OPTIONS']['debug'] = DEBUG
 SITE_NAME = 'localhost:8001'
 HTTPS = 'off'
 
-CMS_BASE = 'localhost:18010'
+CMS_BASE = 'localhost:8010'
 
 ################################ LOGGERS ######################################
 
@@ -42,7 +42,7 @@ EMAIL_FILE_PATH = '/edx/src/ace_messages/'
 
 ################################# LMS INTEGRATION #############################
 
-LMS_BASE = 'localhost:18000'
+LMS_BASE = 'localhost:8000'
 LMS_ROOT_URL = 'http://{}'.format(LMS_BASE)
 FEATURES['PREVIEW_LMS_BASE'] = "preview." + LMS_BASE
 


### PR DESCRIPTION
Switch from the LMS ports we've historically used for NGINX to those used for gunicorn, and fix the Studio ports to match the ones we've historically used for its gunicorn service.  Also removed some leftover bits of the requirements hack.