### PR TITLE
EDUCATOR-5240: LMS Returns 500 when requesting grade override history for a Subsection a Course Staff does not have access to

### DIFF
--- a/lms/djangoapps/grades/rest_api/serializers.py
+++ b/lms/djangoapps/grades/rest_api/serializers.py
@@ -102,6 +102,8 @@ class SubsectionGradeResponseSerializer(serializers.Serializer):
     """
     Serializer for subsection grade response.
     """
+    success = serializers.BooleanField()
+    error_message = serializers.CharField(required=False)
     subsection_id = serializers.CharField()
     user_id = serializers.IntegerField()
     course_id = serializers.CharField()

--- a/lms/djangoapps/grades/rest_api/v1/gradebook_views.py
+++ b/lms/djangoapps/grades/rest_api/v1/gradebook_views.py
@@ -13,6 +13,7 @@ from django.contrib.auth import get_user_model
 from django.core.cache import cache
 from django.db.models import Case, Exists, F, OuterRef, When, Q
 from django.urls import reverse
+from django.utils.translation import ugettext_lazy as _
 from opaque_keys import InvalidKeyError
 from opaque_keys.edx.keys import CourseKey, UsageKey
 from rest_framework import status
@@ -1107,7 +1108,7 @@ class SubsectionGradeView(GradeViewMixin, APIView):
         course_structure = get_course_blocks(student, usage_key)
         if usage_key not in course_structure:
             raise SubsectionUnavailableToUserException(
-                "Cannot override subsection grade: subsection is not available for target user."
+                _("Cannot override subsection grade: subsection is not available for target user.")
             )
         subsection_grade_factory = SubsectionGradeFactory(student, course_structure=course_structure)
         grade = subsection_grade_factory.create(course_structure[usage_key], read_only=True, force_calculate=True)

--- a/lms/djangoapps/grades/rest_api/v1/gradebook_views.py
+++ b/lms/djangoapps/grades/rest_api/v1/gradebook_views.py
@@ -1108,7 +1108,7 @@ class SubsectionGradeView(GradeViewMixin, APIView):
         course_structure = get_course_blocks(student, usage_key)
         if usage_key not in course_structure:
             raise SubsectionUnavailableToUserException(
-                _("Cannot override subsection grade: subsection is not available for target user.")
+                _("Cannot override subsection grade: subsection is not available for target learner.")
             )
         subsection_grade_factory = SubsectionGradeFactory(student, course_structure=course_structure)
         grade = subsection_grade_factory.create(course_structure[usage_key], read_only=True, force_calculate=True)

--- a/lms/djangoapps/grades/rest_api/v1/tests/test_gradebook_views.py
+++ b/lms/djangoapps/grades/rest_api/v1/tests/test_gradebook_views.py
@@ -1969,7 +1969,23 @@ class SubsectionGradeViewTest(GradebookViewTestBase):
             display_name='Unreleased Section',
         )
 
-        with self.assertRaises(ValueError):
-            resp = self.client.get(
-                self.get_url(subsection_id=unreleased_subsection.location)
-            )
+        resp = self.client.get(
+            self.get_url(subsection_id=unreleased_subsection.location)
+        )
+
+        expected_data = {
+            'success': False,
+            'error_message': "Cannot override subsection grade: subsection is not available for target user.",
+            'original_grade': OrderedDict([
+                ('earned_all', 0.0),
+                ('possible_all', 0.0),
+                ('earned_graded', 0.0),
+                ('possible_graded', 0.0)
+            ]),
+            'user_id': self.user_id,
+            'override': None,
+            'course_id': text_type(self.usage_key.course_key),
+            'subsection_id': text_type(unreleased_subsection.location),
+            'history': []
+        }
+        self.assertEqual(expected_data, resp.data)

--- a/lms/djangoapps/grades/rest_api/v1/tests/test_gradebook_views.py
+++ b/lms/djangoapps/grades/rest_api/v1/tests/test_gradebook_views.py
@@ -1952,3 +1952,19 @@ class SubsectionGradeViewTest(GradebookViewTestBase):
         )
 
         self.assertEqual(status.HTTP_403_FORBIDDEN, resp.status_code)
+
+    @patch.dict('django.conf.settings.FEATURES', {'DISABLE_START_DATES': False})
+    def test_get_override_for_unreleased_block(self):
+        self.login_course_staff()
+        unreleased_subsection = ItemFactory.create(
+            parent_location=self.chapter_1.location,
+            category='sequential',
+            graded=True,
+            start=datetime(2999, 1, 1, tzinfo=UTC),  # arbitrary future date
+            display_name='Unreleased Section',
+        )
+
+        with self.assertRaises(ValueError):
+            resp = self.client.get(
+                self.get_url(subsection_id=unreleased_subsection.location)
+            )

--- a/lms/djangoapps/grades/rest_api/v1/tests/test_gradebook_views.py
+++ b/lms/djangoapps/grades/rest_api/v1/tests/test_gradebook_views.py
@@ -1706,6 +1706,7 @@ class SubsectionGradeViewTest(GradebookViewTestBase):
         )
 
         expected_data = {
+            'success': True,
             'original_grade': OrderedDict([
                 ('earned_all', 1.0),
                 ('possible_all', 2.0),
@@ -1733,6 +1734,7 @@ class SubsectionGradeViewTest(GradebookViewTestBase):
         )
 
         expected_data = {
+            'success': True,
             'original_grade': OrderedDict([
                 ('earned_all', 6.0),
                 ('possible_all', 12.0),
@@ -1770,6 +1772,7 @@ class SubsectionGradeViewTest(GradebookViewTestBase):
         )
 
         expected_data = {
+            'success': True,
             'original_grade': OrderedDict([
                 ('earned_all', 6.0),
                 ('possible_all', 12.0),
@@ -1827,6 +1830,7 @@ class SubsectionGradeViewTest(GradebookViewTestBase):
         )
 
         expected_data = {
+            'success': True,
             'original_grade': OrderedDict([
                 ('earned_all', 6.0),
                 ('possible_all', 12.0),
@@ -1928,6 +1932,7 @@ class SubsectionGradeViewTest(GradebookViewTestBase):
             self.get_url(subsection_id=self.usage_key, user_id=other_user.id)
         )
         expected_data = {
+            'success': True,
             'original_grade': OrderedDict([
                 ('earned_all', 0.0),
                 ('possible_all', 0.0),

--- a/lms/djangoapps/grades/rest_api/v1/tests/test_gradebook_views.py
+++ b/lms/djangoapps/grades/rest_api/v1/tests/test_gradebook_views.py
@@ -1975,7 +1975,7 @@ class SubsectionGradeViewTest(GradebookViewTestBase):
 
         expected_data = {
             'success': False,
-            'error_message': "Cannot override subsection grade: subsection is not available for target user.",
+            'error_message': "Cannot override subsection grade: subsection is not available for target learner.",
             'original_grade': OrderedDict([
                 ('earned_all', 0.0),
                 ('possible_all', 0.0),


### PR DESCRIPTION
When we requested grade override info for a subsection that a user did not have visibility to (specifically, in this case, because the subsection had not yet started) we would raise a 500 error because a ValueError would be raised when we passed an empty coursestructure into SubsectionGradeFactory's  constructor.

I changed the return value of the grade override history endpoint to return two additional values:
 - `success`: True if the request succeeded and we got grade overrides, False if there was some sort of expected error
- `error_message`: only included if `success` is False, a message describing what the problem is, that will be shown to users.

Added a check in `_get_grade_data_for_not_attempted_assignment()` to check for the empty course_data case, and if we're in that situation, raise an `SubsectionUnavailableToUserException` with the error message.  If we do in the future want to add in more descriptive messages about why the block is unavailable, we can just raise the exception with different messages.

- [x] Run message by Sapana 

@edx/masters-devs-gta 