### PR TITLE
Pin celery to 4.2 for incremental upgrade to latest version

### DIFF
--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -8,10 +8,9 @@
 # pin when possible.  Writing an issue against the offending project and
 # linking to it here is good.
 
-# We're not ready for Celery 4 yet, but 3.1.25+ are forward-compatible with it.
-# As of this writing, there's a 3.1.26.post2 with a very important bugfix
-# (although it is advertised in the changelog as 3.1.26.)
-celery>=3.1.25,<4.0.0
+# Incremental upgrade of celery to the latest version
+# celery 4.4 officially supports python 3.8
+celery<4.3
 
 # Stay on the latest LTS release of Django
 Django<2.3


### PR DESCRIPTION
The pin needs to be upgraded here first because it is using in `edx-enterprise` and then coming as a constraint from there