### PR TITLE
VAN-3: Add mechanism to enable logistration MFE

### DIFF
--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -430,6 +430,19 @@ FEATURES = {
     # .. toggle_warnings: Also set settings.LEARNING_MICROFRONTEND_URL and see REDIRECT_TO_COURSEWARE_MICROFRONTEND for rollout.
     'ENABLE_COURSEWARE_MICROFRONTEND': False,
 
+    # .. toggle_name: ENABLE_LOGISTRATION_MICROFRONTEND
+    # .. toggle_implementation: DjangoSetting
+    # .. toggle_default: False
+    # .. toggle_description: Supports staged rollout of a new micro-frontend-based implementation of the logistration.
+    # .. toggle_category: micro-frontend
+    # .. toggle_use_cases: incremental_release, open_edx
+    # .. toggle_creation_date: 2020-09-08
+    # .. toggle_expiration_date: None
+    # .. toggle_tickets: 'https://github.com/edx/edx-platform/pull/24908'
+    # .. toggle_status: supported
+    # .. toggle_warnings: Also set settings.ACCOUNT_MICROFRONTEND_URL and set REDIRECT_TO_ACCOUNT_MICROFRONTEND for rollout.
+    'ENABLE_LOGISTRATION_MICROFRONTEND': False,
+
     ### ORA Feature Flags ###
 
     # .. toggle_name: ENABLE_ORA_TEAM_SUBMISSIONS

--- a/lms/templates/header/navbar-not-authenticated.html
+++ b/lms/templates/header/navbar-not-authenticated.html
@@ -6,9 +6,12 @@
 <%namespace file='../main.html' import="login_query"/>
 
 <%!
+from django.conf import settings
 from django.urls import reverse
 from django.utils.translation import ugettext as _
 from six import text_type
+
+from openedx.core.djangoapps.user_api.accounts.toggles import should_redirect_to_logistration_mircrofrontend
 %>
 
 <%
@@ -17,6 +20,7 @@ from six import text_type
   allows_login = not settings.FEATURES['DISABLE_LOGIN_BUTTON'] and not combined_login_and_register
   can_discover_courses = settings.FEATURES.get('ENABLE_COURSE_DISCOVERY')
   allow_public_account_creation = static.get_value('ALLOW_PUBLIC_ACCOUNT_CREATION', settings.FEATURES.get('ALLOW_PUBLIC_ACCOUNT_CREATION'))
+  should_redirect_to_logistration_mfe = should_redirect_to_logistration_mircrofrontend()
 %>
 <nav class="nav-links" aria-label=${_("Supplemental Links")}>
   <div class="main">
@@ -45,13 +49,25 @@ from six import text_type
     <div>
       % if allows_login:
         % if allow_public_account_creation:
+          % if should_redirect_to_logistration_mfe:
             <div class="mobile-nav-item hidden-mobile nav-item">
-              <a class="register-btn btn" href="/register${login_query()}">${_("Register")}</a>
+                <a class="register-btn btn" href="${settings.ACCOUNT_MICROFRONTEND_URL}/register${login_query()}">${_("Register")}</a>
             </div>
+          % else:
+            <div class="mobile-nav-item hidden-mobile nav-item">
+                <a class="register-btn btn" href="/register${login_query()}">${_("Register")}</a>
+            </div>
+          % endif
         % endif
+        % if should_redirect_to_logistration_mfe:
           <div class="mobile-nav-item hidden-mobile nav-item">
-            <a class="sign-in-btn btn" href="/login${login_query()}">${_("Sign in")}</a>
+              <a class="sign-in-btn btn" href="${settings.ACCOUNT_MICROFRONTEND_URL}/login${login_query()}">${_("Sign in")}</a>
           </div>
+        % else:
+          <div class="mobile-nav-item hidden-mobile nav-item">
+              <a class="sign-in-btn btn" href="/login${login_query()}">${_("Sign in")}</a>
+          </div>
+        % endif
       % endif
     </div>
   </div>

--- a/openedx/core/djangoapps/user_api/accounts/toggles.py
+++ b/openedx/core/djangoapps/user_api/accounts/toggles.py
@@ -2,6 +2,7 @@
 Toggles for accounts related code.
 """
 
+from django.conf import settings
 
 from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
 from openedx.core.djangoapps.waffle_utils import WaffleFlag
@@ -45,4 +46,11 @@ def should_redirect_to_account_microfrontend():
     return (
         configuration_helpers.get_value('ENABLE_ACCOUNT_MICROFRONTEND') and
         REDIRECT_TO_ACCOUNT_MICROFRONTEND.is_enabled()
+    )
+
+
+def should_redirect_to_logistration_mircrofrontend():
+    return (
+        should_redirect_to_account_microfrontend() and
+        settings.FEATURES.get('ENABLE_LOGISTRATION_MICROFRONTEND')
     )

--- a/openedx/core/djangoapps/user_authn/views/login.py
+++ b/openedx/core/djangoapps/user_authn/views/login.py
@@ -31,6 +31,7 @@ from rest_framework.views import APIView
 from edxmako.shortcuts import render_to_response
 from openedx.core.djangoapps.password_policy import compliance as password_policy_compliance
 from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
+from openedx.core.djangoapps.user_api.accounts.toggles import should_redirect_to_logistration_mircrofrontend
 from openedx.core.djangoapps.user_authn.views.login_form import get_login_session_form
 from openedx.core.djangoapps.user_authn.cookies import refresh_jwt_cookies, set_logged_in_cookies
 from openedx.core.djangoapps.user_authn.exceptions import AuthFailedError
@@ -479,7 +480,7 @@ def login_user(request):
         if is_user_third_party_authenticated:
             running_pipeline = pipeline.get(request)
             redirect_url = pipeline.get_complete_url(backend_name=running_pipeline['backend'])
-        elif settings.FEATURES.get('ENABLE_LOGIN_MICROFRONTEND'):
+        elif should_redirect_to_logistration_mircrofrontend():
             redirect_url = get_next_url_for_login_page(request)
 
         response = JsonResponse({

--- a/openedx/core/djangoapps/user_authn/views/login_form.py
+++ b/openedx/core/djangoapps/user_authn/views/login_form.py
@@ -18,6 +18,7 @@ import third_party_auth
 from edxmako.shortcuts import render_to_response
 from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
 from openedx.core.djangoapps.user_api import accounts
+from openedx.core.djangoapps.user_api.accounts.toggles import should_redirect_to_logistration_mircrofrontend
 from openedx.core.djangoapps.user_api.accounts.utils import (
     is_multiple_user_enterprises_feature_enabled,
     is_secondary_email_feature_enabled
@@ -180,6 +181,15 @@ def login_and_registration_form(request, initial_mode="login"):
                     initial_mode = "hinted_login"
         except (KeyError, ValueError, IndexError) as ex:
             log.exception(u"Unknown tpa_hint provider: %s", ex)
+
+    # Redirect to logistration MFE if it is enabled
+    if should_redirect_to_logistration_mircrofrontend():
+        query_params = request.GET.urlencode()
+        url_path = '/{}{}'.format(
+            initial_mode,
+            '?' + query_params if query_params else ''
+        )
+        return redirect(settings.ACCOUNT_MICROFRONTEND_URL + url_path)
 
     # Account activation message
     account_activation_messages = [

--- a/openedx/core/djangoapps/user_authn/views/tests/test_login.py
+++ b/openedx/core/djangoapps/user_authn/views/tests/test_login.py
@@ -27,6 +27,7 @@ from openedx.core.djangoapps.password_policy.compliance import (
     NonCompliantPasswordWarning
 )
 from openedx.core.djangoapps.user_api.accounts import EMAIL_MIN_LENGTH, EMAIL_MAX_LENGTH
+from openedx.core.djangoapps.user_api.accounts.toggles import REDIRECT_TO_ACCOUNT_MICROFRONTEND
 from openedx.core.djangoapps.user_authn.cookies import jwt_cookies
 from openedx.core.djangoapps.user_authn.views.login import (
     AllowedAuthUser,
@@ -36,6 +37,7 @@ from openedx.core.djangoapps.user_authn.views.login import (
 from openedx.core.djangoapps.user_authn.tests.utils import setup_login_oauth_client
 from openedx.core.djangolib.testing.utils import CacheIsolationTestCase, skip_unless_lms
 from openedx.core.djangoapps.site_configuration.tests.mixins import SiteMixin
+from openedx.core.djangoapps.waffle_utils.testutils import override_waffle_flag
 from openedx.core.lib.api.test_utils import ApiTestCase
 from student.tests.factories import RegistrationFactory, UserFactory, UserProfileFactory
 from util.password_policy_validators import DEFAULT_MAX_PASSWORD_LENGTH
@@ -81,7 +83,7 @@ class LoginTest(SiteMixin, CacheIsolationTestCase):
         self._assert_audit_log(mock_audit_log, 'info', [u'Login success', self.user_email])
 
     FEATURES_WITH_LOGIN_MFE_ENABLED = settings.FEATURES.copy()
-    FEATURES_WITH_LOGIN_MFE_ENABLED['ENABLE_LOGIN_MICROFRONTEND'] = True
+    FEATURES_WITH_LOGIN_MFE_ENABLED['ENABLE_LOGISTRATION_MICROFRONTEND'] = True
 
     @ddt.data(
         # Default redirect is dashboard.
@@ -146,17 +148,22 @@ class LoginTest(SiteMixin, CacheIsolationTestCase):
     @override_settings(FEATURES=FEATURES_WITH_LOGIN_MFE_ENABLED)
     @skip_unless_lms
     def test_login_success_with_redirect(self, next_url, course_id, expected_redirect):
+        site_domain = 'example.org'
+        self.set_up_site(site_domain, {'ENABLE_ACCOUNT_MICROFRONTEND': True})
         post_params = {}
+
         if next_url:
             post_params['next'] = next_url
         if course_id:
             post_params['course_id'] = course_id
-        response, _ = self._login_response(
-            self.user_email,
-            self.password,
-            extra_post_params=post_params,
-            HTTP_ACCEPT='*/*',
-        )
+
+        with override_waffle_flag(REDIRECT_TO_ACCOUNT_MICROFRONTEND, active=True):
+            response, _ = self._login_response(
+                self.user_email,
+                self.password,
+                extra_post_params=post_params,
+                HTTP_ACCEPT='*/*',
+            )
         self._assert_response(response, success=True)
         self._assert_redirect_url(response, expected_redirect)
 

--- a/themes/edx.org/lms/templates/header/navbar-not-authenticated.html
+++ b/themes/edx.org/lms/templates/header/navbar-not-authenticated.html
@@ -21,13 +21,25 @@ from six import text_type
     <div>
       % if allows_login:
         % if allow_public_account_creation:
+          % if should_redirect_to_logistration_mfe:
+            <div class="mobile-nav-item hidden-mobile nav-item">
+                <a class="register-btn btn" href="${settings.ACCOUNT_MICROFRONTEND_URL}/register${login_query()}">${_("Register")}</a>
+            </div>
+          % else:
+            <div class="mobile-nav-item hidden-mobile nav-item">
+                <a class="register-btn btn" href="/register${login_query()}">${_("Register")}</a>
+            </div>
+          % endif
+        % endif
+        % if should_redirect_to_logistration_mfe:
           <div class="mobile-nav-item hidden-mobile nav-item">
-            <a class="register-btn btn" href="/register${login_query()}">${_("Register")}</a>
+              <a class="sign-in-btn btn" href="${settings.ACCOUNT_MICROFRONTEND_URL}/login${login_query()}">${_("Sign in")}</a>
+          </div>
+        % else:
+          <div class="mobile-nav-item hidden-mobile nav-item">
+              <a class="sign-in-btn btn" href="/login${login_query()}">${_("Sign in")}</a>
           </div>
         % endif
-          <div class="mobile-nav-item hidden-mobile nav-item">
-            <a class="sign-in-btn btn" href="/login${login_query()}">${_("Sign in")}</a>
-          </div>
       % endif
     </div>
   </div>


### PR DESCRIPTION
Add a toggle that in conjunction with `REDIRECT_TO_ACCOUNT_MICROFRONTEND` enables or disables logistration MFE.

Notes:
- Added setting variable `LOGISTRATION_MICROFRONTEND_URL` to point to logistration url (which for now is same as `ACCOUNT_MICROFRONTEND_URL` as the code will be part of Accounts MFE)
- Added feature setting `ENABLE_LOGIN_MICROFRONTEND` 

Ticket: [VAN-3](https://openedx.atlassian.net/browse/VAN-3)