### PR TITLE
[BD-14] [SE-2931] Adjust user access API endpoints for Libraries v2

### DIFF
--- a/openedx/core/djangoapps/content_libraries/serializers.py
+++ b/openedx/core/djangoapps/content_libraries/serializers.py
@@ -57,12 +57,21 @@ class ContentLibraryPermissionLevelSerializer(serializers.Serializer):
     access_level = serializers.ChoiceField(choices=ContentLibraryPermission.ACCESS_LEVEL_CHOICES)
 
 
+class ContentLibraryAddPermissionByEmailSerializer(serializers.Serializer):
+    """
+    Serializer for adding a new user and granting their access level via their email address.
+    """
+    access_level = serializers.ChoiceField(choices=ContentLibraryPermission.ACCESS_LEVEL_CHOICES)
+    email = serializers.EmailField()
+
+
 class ContentLibraryPermissionSerializer(ContentLibraryPermissionLevelSerializer):
     """
     Serializer for a ContentLibraryPermission object, which grants either a user
     or a group permission to view a content library.
     """
-    user_id = serializers.IntegerField(source="user.id", allow_null=True)
+    email = serializers.EmailField(source="user.email", read_only=True, default=None)
+    username = serializers.CharField(source="user.username", read_only=True, default=None)
     group_name = serializers.CharField(source="group.name", allow_null=True, allow_blank=False, default=None)
 
 

--- a/openedx/core/djangoapps/content_libraries/tests/base.py
+++ b/openedx/core/djangoapps/content_libraries/tests/base.py
@@ -30,7 +30,7 @@ URL_LIB_LINKS = URL_LIB_DETAIL + 'links/'  # Get the list of links in this libra
 URL_LIB_COMMIT = URL_LIB_DETAIL + 'commit/'  # Commit (POST) or revert (DELETE) all pending changes to this library
 URL_LIB_BLOCKS = URL_LIB_DETAIL + 'blocks/'  # Get the list of XBlocks in this library, or add a new one
 URL_LIB_TEAM = URL_LIB_DETAIL + 'team/'  # Get the list of users/groups authorized to use this library
-URL_LIB_TEAM_USER = URL_LIB_TEAM + 'user/{user_id}/'  # Add/edit/remove a user's permission to use this library
+URL_LIB_TEAM_USER = URL_LIB_TEAM + 'user/{username}/'  # Add/edit/remove a user's permission to use this library
 URL_LIB_TEAM_GROUP = URL_LIB_TEAM + 'group/{group_name}/'  # Add/edit/remove a group's permission to use this library
 URL_LIB_BLOCK = URL_PREFIX + 'blocks/{block_key}/'  # Get data about a block, or delete it
 URL_LIB_BLOCK_OLX = URL_LIB_BLOCK + 'olx/'  # Get or set the OLX of the specified XBlock
@@ -225,13 +225,25 @@ class ContentLibrariesRestApiTest(APITestCase):
         """ Get the list of users/groups authorized to use this library """
         return self._api('get', URL_LIB_TEAM.format(lib_key=lib_key), None, expect_response)
 
-    def _set_user_access_level(self, lib_key, user_id, access_level, expect_response=200):
+    def _get_user_access_level(self, lib_key, username, expect_response=200):
+        """ Fetch a user's access level """
+        url = URL_LIB_TEAM_USER.format(lib_key=lib_key, username=username)
+        return self._api('get', url, None, expect_response)
+
+    def _add_user_by_email(self, lib_key, email, access_level, expect_response=200):
+        """ Add a user of a specified permission level by their email address. """
+        url = URL_LIB_TEAM.format(lib_key=lib_key)
+        return self._api('post', url, {"access_level": access_level, "email": email}, expect_response)
+
+    def _set_user_access_level(self, lib_key, username, access_level, expect_response=200):
         """ Change the specified user's access level """
-        url = URL_LIB_TEAM_USER.format(lib_key=lib_key, user_id=user_id)
-        if access_level is None:
-            return self._api('delete', url, None, expect_response)
-        else:
-            return self._api('put', url, {"access_level": access_level}, expect_response)
+        url = URL_LIB_TEAM_USER.format(lib_key=lib_key, username=username)
+        return self._api('put', url, {"access_level": access_level}, expect_response)
+
+    def _remove_user_access(self, lib_key, username, expect_response=200):
+        """ Should effectively be the same as the above with access_level=None, but using the delete HTTP verb. """
+        url = URL_LIB_TEAM_USER.format(lib_key=lib_key, username=username)
+        return self._api('delete', url, None, expect_response)
 
     def _set_group_access_level(self, lib_key, group_name, access_level, expect_response=200):
         """ Change the specified group's access level """

--- a/openedx/core/djangoapps/content_libraries/urls.py
+++ b/openedx/core/djangoapps/content_libraries/urls.py
@@ -31,7 +31,7 @@ urlpatterns = [
             # Get the list of users/groups who have permission to view/edit/administer this library:
             url(r'^team/$', views.LibraryTeamView.as_view()),
             # Add/Edit (PUT) or remove (DELETE) a user's permission to use this library
-            url(r'^team/user/(?P<user_id>\d+)/$', views.LibraryTeamUserView.as_view()),
+            url(r'^team/user/(?P<username>[^/]+)/$', views.LibraryTeamUserView.as_view()),
             # Add/Edit (PUT) or remove (DELETE) a group's permission to use this library
             url(r'^team/group/(?P<group_name>[^/]+)/$', views.LibraryTeamGroupView.as_view()),
         ])),


### PR DESCRIPTION
For easy review, see this version of the PR which only contains relevant changes: https://github.com/open-craft/edx-platform/pull/247

This pull requests tweaks the API endpoints for user access management based on what was learned implementing the frontend for it-- namely, it adds the ability to add a user via email, and adds relevent information to the team API call that was missing and which there was no obvious way to gain otherwise (there does not appear to be a publicly documented API for how to get user information by user ID, and even if there were, a separate request would likely have to be done for each user otherwise.)

**Discussions**: https://docs.google.com/document/d/1hRrSmWWlGHhi-bh9AIlpSuLtJFnn2GpavNe8OQxthbE/

**Dependencies**: https://github.com/edx/edx-platform/pull/24510 . The frontend part of this PR is at https://github.com/open-craft/frontend-app-library-authoring/pull/2, but the code and tests can be verified independently.

**Merge deadline**: No hard deadling, but sooner is better than later.

**Testing instructions**: Follow the steps in https://github.com/edx/edx-platform/pull/24510 to set up and test, but use this branch instead.

**Reviewers**
- [ ] @mavidser
- [ ] edX reviewer[s] TBD