### PR TITLE
AA-324: Mobile API fixes

### DIFF
--- a/lms/djangoapps/mobile_api/mobile_platform.py
+++ b/lms/djangoapps/mobile_api/mobile_platform.py
@@ -63,7 +63,7 @@ class IOS(MobilePlatform):
 
 class Android(MobilePlatform):
     """ Android platform """
-    USER_AGENT_REGEX = (r'Dalvik/[.0-9]+ \(Linux; U; Android [.0-9]+; (.*) Build/[0-9a-zA-Z]*\) '
+    USER_AGENT_REGEX = (r'Dalvik/[.0-9]+ \(Linux; U; Android [.0-9]+; (.*) (Build|MIUI)/[0-9a-zA-Z-.]*\) '
                         r'(.*)/(?P<version>[0-9]+.[0-9]+.[0-9]+(\.[0-9a-zA-Z]*)?)')
     NAME = u"Android"
 

--- a/lms/djangoapps/mobile_api/tests/test_mobile_platform.py
+++ b/lms/djangoapps/mobile_api/tests/test_mobile_platform.py
@@ -23,9 +23,10 @@ class TestMobilePlatform(TestCase):
         ("edX/org.edx.mobile (3.3.3.test; OS Version 9.2 (Build 13C75))", "iOS", "3.3.3.test"),
         ("edX/org.test-domain.mobile (0.1.5; OS Version 9.2 (Build 13C75))", "iOS", "0.1.5"),
         ("Dalvik/2.1.0 (Linux; U; Android 5.1; Nexus 5 Build/LMY47I) edX/org.edx.mobile/1.1.1", "Android", "1.1.1"),
-        ("Dalvik/2.1.0 (Linux; U; Android 5.1; Nexus 5 Build/LMY47I) edX/org.edx.mobile/2.2.2", "Android", "2.2.2"),
-        ("Dalvik/2.1.0 (Linux; U; Android 5.1; Nexus 5 Build/LMY47I) edX/org.edx.mobile/3.3.3", "Android", "3.3.3"),
         ("Dalvik/2.1.0 (Linux; U; Android 5.1; Nexus 5 Build/LMY47I) edX/org.edx.mobile/3.3.3.X", "Android", "3.3.3.X"),
+        ("Dalvik/2.1.0 (Linux; U; Android 9; MI 6 MIUI/V11.0.3.0.PCAMIXM) edX/org.edx.mobile/2.17.1", "Android", "2.17.1"),
+        ("Dalvik/2.1.0 (Linux; U; Android 9; JKM-AL00a Build/HUAWEIJKM-AL00a) edX/org.edx.mobile/2.8.1", "Android", "2.8.1"),
+        ("Dalvik/2.1.0 (Linux; U; Android 8.1.0; CPH1803 Build/OPM1.171019.026) edX/org.edx.mobile/2.18.1", "Android", "2.18.1"),
     )
     @ddt.unpack
     def test_platform_instance(self, user_agent, platform_name, version):


### PR DESCRIPTION
This updates the Android user agent regex to accept both
Build or MIUI and for "-" and "." to be allowed in that same
part of the user agent