### PR TITLE
MICROBA-572 | Fix banner styling

### DIFF
--- a/themes/edx.org/lms/static/sass/partials/lms/theme/_dashboard.scss
+++ b/themes/edx.org/lms/static/sass/partials/lms/theme/_dashboard.scss
@@ -196,59 +196,52 @@
         padding: 0;
       }
     }
+    .demographics-banner-icon {
+      height: 140px;
+    }
+    .demographics-banner-prompt {
+      font-size: 24px;
+      line-height: 24px;
+    }
+    .demographics-banner-btn {
+      color: #23419f;
+      border-radius: 20px;
+      font-size: 14px;
+      min-width: 150px;
+      /* Below are to override the overly-broad `button` selectors in lms/static/sass/shared/_forms.scss */
+      box-shadow: unset;
+      text-shadow: unset;
+      font: unset;
+      letter-spacing: unset;
+      background-image: unset;
 
-    .demographics-banner {
-      background-color: #23419f;
-      border-radius: 12px;
-      @media (min-width: 1200px) {
-        height: 64px;
-      }
-      .demographics-banner-icon {
-        height: 140px;
-      }
-      .demographics-banner-prompt {
+      .fa-thumbs-up {
         font-size: 24px;
-        line-height: 24px;
-      }
-      .demographics-banner-btn {
-        color: #23419f;
-        border-radius: 20px;
-        font-size: 14px;
-        min-width: 150px;
-        /* Below are to override the overly-broad `button` selectors in lms/static/sass/shared/_forms.scss */
-        box-shadow: unset;
-        text-shadow: unset;
-        font: unset;
-        letter-spacing: unset;
-        background-image: unset;
-
-        .fa-thumbs-up {
-          font-size: 24px;
-        }
       }
     }
-    .side-container {
-      .wrapper-coaching {
-        border: 1px solid $gray-500;
-        margin-bottom: $baseline * 0.5;
+  }
+  
+  .side-container {
+    .wrapper-coaching {
+      border: 1px solid $gray-500;
+      margin-bottom: $baseline * 0.5;
 
-        .coaching-signup {
-          padding: 20px;
+      .coaching-signup {
+        padding: 20px;
 
-          .coaching-prompt {
-            font-size: 20px;
-            line-height: 28px;
-            font-weight: bold;
-          }
+        .coaching-prompt {
+          font-size: 20px;
+          line-height: 28px;
+          font-weight: bold;
+        }
 
-          .coaching-link .btn-neutral {
-            display: block;
-            text-align: center;
-            margin: 20px 20px 0;
-            border-radius: 20px;
-            padding: 10px;
-            border: 1px solid theme-color("primary");
-          }
+        .coaching-link .btn-neutral {
+          display: block;
+          text-align: center;
+          margin: 20px 20px 0;
+          border-radius: 20px;
+          padding: 10px;
+          border: 1px solid theme-color("primary");
         }
       }
     }


### PR DESCRIPTION
[MICROBA-572]
- Fix nesting bug in scss
- Combine the two separate `demographics-banner` css declarations

I found two separate css/styling declarations for `demographics-banner`, each containing slightly different styling. I combined the two into a single css declaration. I also found a nesting issue that put the `side-container` styling _inside_ of the styling for the `demographics-banner`.

You can see the duplicate styling in the current version of the `_dashboard.css` file at [line 148 ](https://github.com/edx/edx-platform/blob/f27b5d22eeaeaf7aa85c3c706e324e3bc57d35f4/themes/edx.org/lms/static/sass/partials/lms/theme/_dashboard.scss#L148)and then again on [line 200](https://github.com/edx/edx-platform/blob/f27b5d22eeaeaf7aa85c3c706e324e3bc57d35f4/themes/edx.org/lms/static/sass/partials/lms/theme/_dashboard.scss#L200).

Afterwards, this appears to have restored our previous banner styling:
![image](https://user-images.githubusercontent.com/3229735/92644871-fc0c0200-f2b1-11ea-9034-e09d13433b52.png)


[MICROBA-572]: https://openedx.atlassian.net/browse/MICROBA-572