### PR TITLE
Changes that enable the modernization of Analytics Exporter

### DIFF
--- a/cms/djangoapps/contentstore/management/commands/export_olx.py
+++ b/cms/djangoapps/contentstore/management/commands/export_olx.py
@@ -60,13 +60,19 @@ class Command(BaseCommand):
 
         export_course_to_tarfile(course_key, filename)
 
-        results = self._get_results(filename) if pipe_results else ''
+        results = self._get_results(filename) if pipe_results else b''
 
-        self.stdout.write(results, ending="")
+        # results is of type bytes, so we must write the underlying buffer directly.
+        self.stdout.buffer.write(results)
 
     def _get_results(self, filename):
-        """Load results from file"""
-        with open(filename, 'rb') as f:  # pylint: disable=open-builtin
+        """
+        Load results from file.
+
+        Returns:
+            bytes: bytestring of file contents.
+        """
+        with open(filename, 'rb') as f:
             results = f.read()
             os.remove(filename)
         return results

--- a/cms/envs/analytics_exporter.py
+++ b/cms/envs/analytics_exporter.py
@@ -1,0 +1,13 @@
+"""
+Settings for running management commands for the Analytics Exporter.
+
+The Analytics Exporter jobs run edxapp management commands using production
+settings and configuration, however they currently DO NOT use edxapp production
+environments (such as edxapp Amazon AMIs or Docker images) where theme files
+get installed.  As a result we must disable comprehensive theming or else
+startup checks from the theming app will throw an error due to missing themes.
+"""
+
+from .production import *  # pylint: disable=wildcard-import, unused-wildcard-import
+
+ENABLE_COMPREHENSIVE_THEMING = False

--- a/lms/envs/analytics_exporter.py
+++ b/lms/envs/analytics_exporter.py
@@ -1,0 +1,13 @@
+"""
+Settings for running management commands for the Analytics Exporter.
+
+The Analytics Exporter jobs run edxapp management commands using production
+settings and configuration, however they currently DO NOT use edxapp production
+environments (such as edxapp Amazon AMIs or Docker images) where theme files
+get installed.  As a result we must disable comprehensive theming or else
+startup checks from the theming app will throw an error due to missing themes.
+"""
+
+from .production import *  # pylint: disable=wildcard-import, unused-wildcard-import
+
+ENABLE_COMPREHENSIVE_THEMING = False

--- a/openedx/core/djangoapps/theming/helpers_dirs.py
+++ b/openedx/core/djangoapps/theming/helpers_dirs.py
@@ -10,7 +10,7 @@ from django.utils.encoding import python_2_unicode_compatible
 from path import Path
 
 
-def get_theme_base_dirs_from_settings(theme_dirs=None):
+def get_theme_base_dirs_from_settings(theme_base_dirs=None):
     """
     Return base directories that contains all the themes.
 
@@ -18,41 +18,54 @@ def get_theme_base_dirs_from_settings(theme_dirs=None):
         >> get_theme_base_dirs_from_settings('/edx/app/ecommerce/ecommerce/themes')
         ['/edx/app/ecommerce/ecommerce/themes']
 
+    Args:
+        themes_base_dirs (list of str): Paths to themes base directories.
+
     Returns:
          (List of Paths): Base theme directory paths
     """
-    theme_base_dirs = []
-    if theme_dirs:
-        theme_base_dirs.extend([Path(theme_dir) for theme_dir in theme_dirs])
-    return theme_base_dirs
+    theme_base_dirs_paths = []
+    if theme_base_dirs:
+        theme_base_dirs_paths.extend([Path(theme_base_dir) for theme_base_dir in theme_base_dirs])
+    return theme_base_dirs_paths
 
 
-def get_themes_unchecked(themes_dirs, project_root=None):
+def get_themes_unchecked(themes_base_dirs, project_root=None):
     """
     Returns a list of all themes known to the system.
 
     Args:
-        themes_dirs (list): Paths to themes base directory
+        themes_base_dirs (list of str / list of Path): Paths to themes base directories.
         project_root (str): (optional) Path to project root
     Returns:
-        List of themes known to the system.
+        (list of Theme): List of themes known to the system.
     """
-    themes_base_dirs = [Path(themes_dir) for themes_dir in themes_dirs]
+    # Convert base dirs to Path objects
+    themes_base_dirs = [Path(themes_base_dir) for themes_base_dir in themes_base_dirs]
     # pick only directories and discard files in themes directory
     themes = []
-    for themes_dir in themes_base_dirs:
-        themes.extend([Theme(name, name, themes_dir, project_root) for name in get_theme_dirs(themes_dir)])
+    for themes_base_dir in themes_base_dirs:
+        themes.extend([Theme(name, name, themes_base_dir, project_root) for name in get_theme_dirs(themes_base_dir)])
 
     return themes
 
 
-def get_theme_dirs(themes_dir=None):
+def get_theme_dirs(themes_base_dir=None):
     """
-    Returns theme dirs in given dirs
+    Get all the theme dirs directly under a given base dir.
+
     Args:
-        themes_dir (Path): base dir that contains themes.
+        themes_base_dir (Path): base dir that contains themes.
+    Returns:
+        List of theme dir names (relative to the base dir) or empty list if the base themes dir does not exist or there
+        are no containing theme dirs.
     """
-    return [_dir for _dir in os.listdir(themes_dir) if is_theme_dir(themes_dir / _dir)]
+    try:
+        themes_base_dir_listing = os.listdir(themes_base_dir)
+    except FileNotFoundError:
+        themes_base_dir_listing = []
+
+    return [_dir for _dir in themes_base_dir_listing if is_theme_dir(themes_base_dir / _dir)]
 
 
 def is_theme_dir(_dir):


### PR DESCRIPTION
Three commits that make it possible for DE's "Analytics Exporter" job to run the latest edx-platform version instead of a 2 year old branch of edx-platform.
 
```
commit fce015e08cf884aa40bb17c08986300671469c2a
Author: Troy Sankey <tsankey@edx.org>
Date:   Thu Sep 10 15:36:04 2020 -0400

    Create new analytics_exporter.py settings
    
    These new settings files are intended to be used by the Analytics
    Exporter automation managed by the DE team.  The Analytics Exporter must
    be able to simply clone edx-platform, install requirements, fetch
    remote-config, then just run management commands without needing to run
    any ansible or pull down any docker/AMI images.  Since the theming app
    includes a check that fails if the themes base dir cannot be found, and
    that check runs on app startup, we must disable the app.
    
    DENG-379

commit 26276c796d6b6a0106004c6ac9a6900179a5aadf
Author: Troy Sankey <tsankey@edx.org>
Date:   Thu Sep 10 11:27:31 2020 -0400

    export_olx management command: write bytes to stdout correctly
    
    This must have been broken ever since we upgraded from Python 2 to 3.
    
    DENG-379

commit e8ea73c652c08d12e298000fdb9a42ac42c14686
Author: Troy Sankey <tsankey@edx.org>
Date:   Wed Sep 9 16:09:28 2020 -0400

    Do not crash unexpectedly when looking for a file.
    
    This function to search for themes dirs needs to be able to recover
    gracefully if the base dirs do not exist.  This is NOT the app check,
    it's just a themes collector---the app check will *properly* report an
    error if the base dir does not exist.
    
    DENG-379
```

Testing
---

I ran a test of Analytics Exporter against one org that was previously consistently failing all export_olx calls, and now they succeed (with the exception of edge because that's blocked by https://openedx.atlassian.net/browse/PSRE-262

http://jenkins.analytics.edx.org/job/test-analytics-exporter-worker/12/console