### PR TITLE
Added setting to manage from_email address

### DIFF
--- a/lms/djangoapps/bulk_email/tasks.py
+++ b/lms/djangoapps/bulk_email/tasks.py
@@ -42,6 +42,7 @@ from common.djangoapps.util.date_utils import get_default_time_display
 from common.djangoapps.util.string_utils import _has_non_ascii_characters
 from lms.djangoapps.branding.api import get_logo_url_for_email
 from lms.djangoapps.bulk_email.api import get_unsubscribed_link
+from lms.djangoapps.bulk_email.toggles import is_email_use_default_from_bulk_enabled
 from lms.djangoapps.bulk_email.models import CourseEmail, Optout
 from lms.djangoapps.courseware.courses import get_course
 from lms.djangoapps.instructor_task.models import InstructorTask
@@ -494,9 +495,13 @@ def _send_course_email(entry_id, email_id, to_list, global_email_context, subtas
     course_title = global_email_context['course_title']
     course_language = global_email_context['course_language']
 
-    # use the email from address in the CourseEmail, if it is present, otherwise compute it
-    from_addr = course_email.from_addr if course_email.from_addr else \
-        _get_source_address(course_email.course_id, course_title, course_language)
+    # If EMAIL_USE_DEFAULT_FROM_FOR_BULK is True, use the default email from address.
+    # Otherwise compute a custom from address
+    if is_email_use_default_from_bulk_enabled():
+        from_addr = settings.DEFAULT_FROM_EMAIL
+    else:
+        # use the email from address in the CourseEmail, if it is present, otherwise compute it.
+        from_addr = course_email.from_addr or _get_source_address(course_email.course_id, course_title, course_language)
 
     # use the CourseEmailTemplate that was associated with the CourseEmail
     course_email_template = course_email.get_template()

--- a/lms/djangoapps/bulk_email/tests/test_email.py
+++ b/lms/djangoapps/bulk_email/tests/test_email.py
@@ -287,6 +287,24 @@ class TestEmailSendFromDashboardMockedHtmlToText(EmailSendFromDashboardTestCase)
         assert len(mail.outbox) == (1 + len(self.staff))
         assert len([e.to[0] for e in mail.outbox]) == len([self.instructor.email] + [s.email for s in self.staff])
 
+    @override_settings(DEFAULT_FROM_EMAIL='test@example.com', EMAIL_USE_DEFAULT_FROM_FOR_BULK=True)
+    def test_email_from_address(self):
+        """
+        Make sure the from_address should be the DEFAULT_FROM_EMAIL when corresponding flag is enabled.
+        """
+        test_email = {
+            'action': 'Send email',
+            'send_to': '["staff"]',
+            'subject': 'test subject for staff',
+            'message': 'test message for subject'
+        }
+        self.client.post(self.send_mail_url, test_email)
+        from_email = mail.outbox[0].from_email
+        self.assertEqual(
+            from_email,
+            'test@example.com'
+        )
+
     def test_send_to_cohort(self):
         """
         Make sure email sent to a cohort goes there.

--- a/lms/djangoapps/bulk_email/toggles.py
+++ b/lms/djangoapps/bulk_email/toggles.py
@@ -1,0 +1,18 @@
+"""
+Toggles for bulk_email app
+"""
+
+from edx_toggles.toggles import SettingToggle
+
+
+# .. toggle_name: bulk_email.EMAIL_USE_DEFAULT_FROM_FOR_BULK
+# .. toggle_implementation: DjangoSetting
+# .. toggle_default: False
+# .. toggle_description: If True, use the same DEFAULT_FROM_EMAIL as the from_addr for all bulk email, to avoid issues with spam filtering
+# .. toggle_use_cases: open_edx
+# .. toggle_creation_date: 2020-10-01
+# .. toggle_tickets: OSPR-4957
+
+
+def is_email_use_default_from_bulk_enabled():
+    return SettingToggle("EMAIL_USE_DEFAULT_FROM_FOR_BULK", default=False).is_enabled()


### PR DESCRIPTION
Fixes mitodl#133

[Ref#pull-133](https://github.com/mitodl/edx-platform/pull/113)

Recent changes in spam filtering have caused bulk emails generated from within LMS to get erroneously labeled as spam. Apparently, the from_addr is dynamically generated by prepending the course number and name to the configured email and that's causing issues with the spam filter.

I added a setting that can be configured in order for those interested in just using the default configured email address as the from_addr to save them from dealing with issues with spam filtering as they would now need to only whitelist a single address.