### PR TITLE
[BD-21] Simplify hack to obtain waffle module names

### DIFF
--- a/cms/djangoapps/contentstore/config/waffle.py
+++ b/cms/djangoapps/contentstore/config/waffle.py
@@ -36,11 +36,13 @@ def waffle_flags():
 ENABLE_CHECKLISTS_QUALITY = CourseWaffleFlag(
     waffle_namespace=waffle_flags(),
     flag_name=u'enable_checklists_quality',
+    module_name=__name__,
 )
 
 SHOW_REVIEW_RULES_FLAG = CourseWaffleFlag(
     waffle_namespace=waffle_flags(),
     flag_name=u'show_review_rules',
+    module_name=__name__,
 )
 
 # Waffle flag to redirect to the library authoring MFE.
@@ -58,4 +60,5 @@ SHOW_REVIEW_RULES_FLAG = CourseWaffleFlag(
 REDIRECT_TO_LIBRARY_AUTHORING_MICROFRONTEND = WaffleFlag(
     waffle_namespace=waffle_flags(),
     flag_name='library_authoring_mfe',
+    module_name=__name__,
 )

--- a/cms/djangoapps/contentstore/views/item.py
+++ b/cms/djangoapps/contentstore/views/item.py
@@ -90,7 +90,7 @@ NEVER = lambda x: False
 ALWAYS = lambda x: True
 
 
-highlights_setting = WaffleSwitch(u'dynamic_pacing', u'studio_course_update')
+highlights_setting = WaffleSwitch('dynamic_pacing', 'studio_course_update', __name__)
 
 
 def _filter_entrance_exam_grader(graders):

--- a/cms/djangoapps/contentstore/views/videos.py
+++ b/cms/djangoapps/contentstore/views/videos.py
@@ -81,6 +81,7 @@ WAFFLE_STUDIO_FLAG_NAMESPACE = WaffleFlagNamespace(name=u'studio')
 ENABLE_VIDEO_UPLOAD_PAGINATION = CourseWaffleFlag(
     waffle_namespace=WAFFLE_STUDIO_FLAG_NAMESPACE,
     flag_name=u'enable_video_upload_pagination',
+    module_name=__name__,
 )
 # Default expiration, in seconds, of one-time URLs used for uploading videos.
 KEY_EXPIRATION_IN_SECONDS = 86400

--- a/cms/djangoapps/models/settings/waffle.py
+++ b/cms/djangoapps/models/settings/waffle.py
@@ -12,6 +12,7 @@ MATERIAL_RECOMPUTE_ONLY = 'MATERIAL_RECOMPUTE_ONLY'
 MATERIAL_RECOMPUTE_ONLY_FLAG = CourseWaffleFlag(
     waffle_namespace=WAFFLE_NAMESPACE,
     flag_name=MATERIAL_RECOMPUTE_ONLY,
+    module_name=__name__,
 )
 
 

--- a/common/djangoapps/student/admin.py
+++ b/common/djangoapps/student/admin.py
@@ -53,7 +53,7 @@ User = get_user_model()  # pylint:disable=invalid-name
 # This switch exists because the CourseEnrollment admin views make DB queries that impact performance.
 # In a large enough deployment of Open edX, this is enough to cause a site outage.
 # See https://openedx.atlassian.net/browse/OPS-2943
-COURSE_ENROLLMENT_ADMIN_SWITCH = WaffleSwitch(STUDENT_WAFFLE_NAMESPACE, 'courseenrollment_admin')
+COURSE_ENROLLMENT_ADMIN_SWITCH = WaffleSwitch(STUDENT_WAFFLE_NAMESPACE, 'courseenrollment_admin', __name__)
 
 
 class _Check(object):

--- a/common/djangoapps/student/views/dashboard.py
+++ b/common/djangoapps/student/views/dashboard.py
@@ -640,7 +640,7 @@ def student_dashboard(request):
     inverted_programs = meter.invert_programs()
 
     urls, programs_data = {}, {}
-    bundles_on_dashboard_flag = WaffleFlag(experiments_namespace, u'bundles_on_dashboard')
+    bundles_on_dashboard_flag = WaffleFlag(experiments_namespace, u'bundles_on_dashboard', __name__)
 
     # TODO: Delete this code and the relevant HTML code after testing LEARNER-3072 is complete
     if bundles_on_dashboard_flag.is_enabled() and inverted_programs and list(inverted_programs.items()):

--- a/lms/djangoapps/course_api/__init__.py
+++ b/lms/djangoapps/course_api/__init__.py
@@ -5,5 +5,5 @@ from openedx.core.djangoapps.waffle_utils import WaffleSwitch, WaffleSwitchNames
 
 WAFFLE_SWITCH_NAMESPACE = WaffleSwitchNamespace(name='course_list_api_rate_limit')
 
-USE_RATE_LIMIT_2_FOR_COURSE_LIST_API = WaffleSwitch(WAFFLE_SWITCH_NAMESPACE, 'rate_limit_2')
-USE_RATE_LIMIT_10_FOR_COURSE_LIST_API = WaffleSwitch(WAFFLE_SWITCH_NAMESPACE, 'rate_limit_10')
+USE_RATE_LIMIT_2_FOR_COURSE_LIST_API = WaffleSwitch(WAFFLE_SWITCH_NAMESPACE, 'rate_limit_2', __name__)
+USE_RATE_LIMIT_10_FOR_COURSE_LIST_API = WaffleSwitch(WAFFLE_SWITCH_NAMESPACE, 'rate_limit_10', __name__)

--- a/lms/djangoapps/course_api/blocks/toggles.py
+++ b/lms/djangoapps/course_api/blocks/toggles.py
@@ -23,4 +23,5 @@ COURSE_BLOCKS_API_NAMESPACE = WaffleFlagNamespace(name=u'course_blocks_api')
 HIDE_ACCESS_DENIALS_FLAG = WaffleFlag(
     waffle_namespace=COURSE_BLOCKS_API_NAMESPACE,
     flag_name=u'hide_access_denials',
+    module_name=__name__,
 )

--- a/lms/djangoapps/course_home_api/toggles.py
+++ b/lms/djangoapps/course_home_api/toggles.py
@@ -7,11 +7,11 @@ from openedx.core.djangoapps.waffle_utils import CourseWaffleFlag, WaffleFlagNam
 
 WAFFLE_FLAG_NAMESPACE = WaffleFlagNamespace(name='course_home')
 
-COURSE_HOME_MICROFRONTEND = ExperimentWaffleFlag(WAFFLE_FLAG_NAMESPACE, 'course_home_mfe')
+COURSE_HOME_MICROFRONTEND = ExperimentWaffleFlag(WAFFLE_FLAG_NAMESPACE, 'course_home_mfe', __name__)
 
-COURSE_HOME_MICROFRONTEND_DATES_TAB = CourseWaffleFlag(WAFFLE_FLAG_NAMESPACE, 'course_home_mfe_dates_tab')
+COURSE_HOME_MICROFRONTEND_DATES_TAB = CourseWaffleFlag(WAFFLE_FLAG_NAMESPACE, 'course_home_mfe_dates_tab', __name__)
 
-COURSE_HOME_MICROFRONTEND_OUTLINE_TAB = CourseWaffleFlag(WAFFLE_FLAG_NAMESPACE, 'course_home_mfe_outline_tab')
+COURSE_HOME_MICROFRONTEND_OUTLINE_TAB = CourseWaffleFlag(WAFFLE_FLAG_NAMESPACE, 'course_home_mfe_outline_tab', __name__)
 
 
 def course_home_mfe_dates_tab_is_active(course_key):

--- a/lms/djangoapps/courseware/toggles.py
+++ b/lms/djangoapps/courseware/toggles.py
@@ -2,7 +2,6 @@
 Toggles for courseware in-course experience.
 """
 
-from django.conf import settings
 from lms.djangoapps.experiments.flags import ExperimentWaffleFlag
 from openedx.core.djangoapps.waffle_utils import CourseWaffleFlag, WaffleFlagNamespace
 
@@ -22,7 +21,7 @@ WAFFLE_FLAG_NAMESPACE = WaffleFlagNamespace(name='courseware')
 # .. toggle_tickets: TNL-7000
 # .. toggle_status: supported
 REDIRECT_TO_COURSEWARE_MICROFRONTEND = ExperimentWaffleFlag(
-    WAFFLE_FLAG_NAMESPACE, 'courseware_mfe', use_course_aware_bucketing=False
+    WAFFLE_FLAG_NAMESPACE, 'courseware_mfe', __name__, use_course_aware_bucketing=False
 )
 
 # Waffle flag to display a link for the new learner experience to course teams without redirecting students.
@@ -38,4 +37,6 @@ REDIRECT_TO_COURSEWARE_MICROFRONTEND = ExperimentWaffleFlag(
 # .. toggle_warnings: Also set settings.LEARNING_MICROFRONTEND_URL and ENABLE_COURSEWARE_MICROFRONTEND.
 # .. toggle_tickets: TNL-6982
 # .. toggle_status: supported
-COURSEWARE_MICROFRONTEND_COURSE_TEAM_PREVIEW = CourseWaffleFlag(WAFFLE_FLAG_NAMESPACE, 'microfrontend_course_team_preview')
+COURSEWARE_MICROFRONTEND_COURSE_TEAM_PREVIEW = CourseWaffleFlag(
+    WAFFLE_FLAG_NAMESPACE, 'microfrontend_course_team_preview', __name__
+)

--- a/lms/djangoapps/experiments/flags.py
+++ b/lms/djangoapps/experiments/flags.py
@@ -66,16 +66,17 @@ class ExperimentWaffleFlag(CourseWaffleFlag):
             self,
             waffle_namespace,
             flag_name,
+            module_name,
             num_buckets=2,
             experiment_id=None,
             use_course_aware_bucketing=True,
             **kwargs
     ):
-        super().__init__(waffle_namespace, flag_name, **kwargs)
+        super().__init__(waffle_namespace, flag_name, module_name, **kwargs)
         self.num_buckets = num_buckets
         self.experiment_id = experiment_id
         self.bucket_flags = [
-            CourseWaffleFlag(waffle_namespace, '{}.{}'.format(flag_name, bucket))
+            CourseWaffleFlag(waffle_namespace, '{}.{}'.format(flag_name, bucket), module_name)
             for bucket in range(num_buckets)
         ]
         self.use_course_aware_bucketing = use_course_aware_bucketing

--- a/lms/djangoapps/experiments/tests/test_flags.py
+++ b/lms/djangoapps/experiments/tests/test_flags.py
@@ -37,7 +37,7 @@ class ExperimentWaffleFlagTests(SharedModuleStoreTestCase):
         self.addCleanup(set_current_request, None)
         set_current_request(self.request)
 
-        self.flag = ExperimentWaffleFlag('experiments', 'test', num_buckets=2, experiment_id=0)
+        self.flag = ExperimentWaffleFlag('experiments', 'test', __name__, num_buckets=2, experiment_id=0)
         self.key = CourseKey.from_string('a/b/c')
 
         bucket_patch = patch('experiments.flags.stable_bucketing_hash_group', return_value=1)
@@ -104,7 +104,7 @@ class ExperimentWaffleFlagTests(SharedModuleStoreTestCase):
     )
     @ddt.unpack
     def test_forcing_bucket(self, active, expected_bucket):
-        bucket_flag = CourseWaffleFlag('experiments', 'test.0')
+        bucket_flag = CourseWaffleFlag('experiments', 'test.0', __name__)
         with bucket_flag.override(active=active):
             self.assertEqual(self.get_bucket(), expected_bucket)
 
@@ -163,14 +163,14 @@ class ExperimentWaffleFlagCourseAwarenessTest(SharedModuleStoreTestCase):
     ExperimentWaffleFlag class.
     """
     course_aware_flag = ExperimentWaffleFlag(
-        'exp', 'aware', num_buckets=20, use_course_aware_bucketing=True,
+        'exp', 'aware', __name__, num_buckets=20, use_course_aware_bucketing=True,
     )
-    course_aware_subflag = CourseWaffleFlag('exp', 'aware.1')
+    course_aware_subflag = CourseWaffleFlag('exp', 'aware.1', __name__)
 
     course_unaware_flag = ExperimentWaffleFlag(
-        'exp', 'unaware', num_buckets=20, use_course_aware_bucketing=False,
+        'exp', 'unaware', __name__, num_buckets=20, use_course_aware_bucketing=False,
     )
-    course_unaware_subflag = CourseWaffleFlag('exp', 'unaware.1')
+    course_unaware_subflag = CourseWaffleFlag('exp', 'unaware.1', __name__)
 
     course_key_1 = CourseKey.from_string("x/y/1")
     course_key_2 = CourseKey.from_string("x/y/22")

--- a/lms/djangoapps/experiments/utils.py
+++ b/lms/djangoapps/experiments/utils.py
@@ -48,6 +48,7 @@ experiments_namespace = WaffleFlagNamespace(name=u'experiments')
 PROGRAM_INFO_FLAG = WaffleFlag(
     waffle_namespace=experiments_namespace,
     flag_name=u'add_programs',
+    module_name=__name__,
 )
 
 # .. toggle_name: experiments.add_dashboard_info
@@ -61,7 +62,7 @@ PROGRAM_INFO_FLAG = WaffleFlag(
 # .. toggle_warnings: None
 # .. toggle_tickets: REVEM-118
 # .. toggle_status: supported
-DASHBOARD_INFO_FLAG = WaffleFlag(experiments_namespace, u'add_dashboard_info')
+DASHBOARD_INFO_FLAG = WaffleFlag(experiments_namespace, u'add_dashboard_info', __name__)
 # TODO END: clean up as part of REVEM-199 (End)
 
 # TODO: Clean up as part of REV-1205 (START)
@@ -78,7 +79,8 @@ DASHBOARD_INFO_FLAG = WaffleFlag(experiments_namespace, u'add_dashboard_info')
 # .. toggle_status: supported
 UPSELL_TRACKING_FLAG = WaffleFlag(
     waffle_namespace=experiments_namespace,
-    flag_name=u'add_upsell_tracking'
+    flag_name=u'add_upsell_tracking',
+    module_name=__name__,
 )
 # TODO END: Clean up as part of REV-1205 (End)
 

--- a/lms/djangoapps/experiments/views_custom.py
+++ b/lms/djangoapps/experiments/views_custom.py
@@ -45,6 +45,7 @@ from track import segment
 MOBILE_UPSELL_FLAG = WaffleFlag(
     waffle_namespace=WaffleFlagNamespace(name=u'experiments'),
     flag_name=u'mobile_upsell_rev934',
+    module_name=__name__,
 )
 MOBILE_UPSELL_EXPERIMENT = 'mobile_upsell_experiment'
 

--- a/lms/djangoapps/grades/config/waffle.py
+++ b/lms/djangoapps/grades/config/waffle.py
@@ -38,21 +38,25 @@ def waffle_flags():
         REJECTED_EXAM_OVERRIDES_GRADE: CourseWaffleFlag(
             namespace,
             REJECTED_EXAM_OVERRIDES_GRADE,
+            __name__,
         ),
         # TODO: After removing this flag, add a migration to remove waffle flag in a follow-up deployment.
         ENFORCE_FREEZE_GRADE_AFTER_COURSE_END: CourseWaffleFlag(
             namespace,
             ENFORCE_FREEZE_GRADE_AFTER_COURSE_END,
+            __name__,
         ),
         # Have this course override flag so we can selectively turn off the gradebook for courses.
         # TODO: After removing this flag, add a migration to remove waffle flag in a follow-up deployment.
         WRITABLE_GRADEBOOK: CourseWaffleFlag(
             namespace,
             WRITABLE_GRADEBOOK,
+            __name__,
         ),
         BULK_MANAGEMENT: CourseWaffleFlag(
             namespace,
             BULK_MANAGEMENT,
+            __name__,
         ),
     }
 

--- a/lms/djangoapps/instructor_task/config/waffle.py
+++ b/lms/djangoapps/instructor_task/config/waffle.py
@@ -25,10 +25,12 @@ def waffle_flags():
         GENERATE_PROBLEM_GRADE_REPORT_VERIFIED_ONLY: CourseWaffleFlag(
             waffle_namespace=INSTRUCTOR_TASK_WAFFLE_FLAG_NAMESPACE,
             flag_name=GENERATE_PROBLEM_GRADE_REPORT_VERIFIED_ONLY,
+            module_name=__name__,
         ),
         GENERATE_COURSE_GRADE_REPORT_VERIFIED_ONLY: CourseWaffleFlag(
             waffle_namespace=INSTRUCTOR_TASK_WAFFLE_FLAG_NAMESPACE,
             flag_name=GENERATE_COURSE_GRADE_REPORT_VERIFIED_ONLY,
+            module_name=__name__,
         ),
     }
 

--- a/lms/djangoapps/teams/waffle.py
+++ b/lms/djangoapps/teams/waffle.py
@@ -10,17 +10,17 @@ WAFFLE_NAMESPACE = 'openresponseassessment'
 TEAM_SUBMISSIONS_FLAG = 'team_submissions'
 
 # edx/edx-platform feature
-TEAM_SUBMISISONS_FEATURE = 'ENABLE_ORA_TEAM_SUBMISSIONS'
+TEAM_SUBMISSIONS_FEATURE = 'ENABLE_ORA_TEAM_SUBMISSIONS'
 
 
 def are_team_submissions_enabled(course_key):
     """
     Checks to see if the CourseWaffleFlag or Django setting for team submissions is enabled
     """
-    if CourseWaffleFlag(WAFFLE_NAMESPACE, TEAM_SUBMISSIONS_FLAG).is_enabled(course_key):
+    if CourseWaffleFlag(WAFFLE_NAMESPACE, TEAM_SUBMISSIONS_FLAG, __name__).is_enabled(course_key):
         return True
 
-    if settings.FEATURES.get(TEAM_SUBMISISONS_FEATURE, False):
+    if settings.FEATURES.get(TEAM_SUBMISSIONS_FEATURE, False):
         return True
 
     return False

--- a/lms/djangoapps/verify_student/toggles.py
+++ b/lms/djangoapps/verify_student/toggles.py
@@ -22,6 +22,7 @@ WAFFLE_FLAG_NAMESPACE = WaffleFlagNamespace(name='verify_student')
 USE_NEW_EMAIL_TEMPLATES = WaffleFlag(
     waffle_namespace=WAFFLE_FLAG_NAMESPACE,
     flag_name='use_new_email_templates',
+    module_name=__name__,
 )
 
 
@@ -44,6 +45,7 @@ def use_new_templates_for_id_verification_emails():
 REDIRECT_TO_IDV_MICROFRONTEND = WaffleFlag(
     waffle_namespace=WAFFLE_FLAG_NAMESPACE,
     flag_name='redirect_to_idv_microfrontend',
+    module_name=__name__,
 )
 
 

--- a/openedx/core/djangoapps/models/config/waffle.py
+++ b/openedx/core/djangoapps/models/config/waffle.py
@@ -26,6 +26,7 @@ def waffle_flags():
         COURSE_DETAIL_UPDATE_CERTIFICATE_DATE: CourseWaffleFlag(
             waffle_namespace=COURSE_DETAIL_WAFFLE_NAMESPACE,
             flag_name=COURSE_DETAIL_UPDATE_CERTIFICATE_DATE,
+            module_name=__name__,
         )
     }
 

--- a/openedx/core/djangoapps/programs/__init__.py
+++ b/openedx/core/djangoapps/programs/__init__.py
@@ -16,4 +16,7 @@ PROGRAMS_WAFFLE_SWITCH_NAMESPACE = WaffleSwitchNamespace(name='programs')
 
 # This is meant to be enabled until https://openedx.atlassian.net/browse/LEARNER-5573 needs to be resolved
 ALWAYS_CALCULATE_PROGRAM_PRICE_AS_ANONYMOUS_USER = WaffleSwitch(
-    PROGRAMS_WAFFLE_SWITCH_NAMESPACE, 'always_calculate_program_price_as_anonymous_user')
+    PROGRAMS_WAFFLE_SWITCH_NAMESPACE,
+    'always_calculate_program_price_as_anonymous_user',
+    __name__
+)

--- a/openedx/core/djangoapps/schedules/config.py
+++ b/openedx/core/djangoapps/schedules/config.py
@@ -8,19 +8,25 @@ from openedx.core.djangoapps.waffle_utils import (
     WaffleSwitch, WaffleSwitchNamespace,
 )
 
-WAFFLE_FLAG_NAMESPACE = WaffleFlagNamespace(name=u'schedules')
-WAFFLE_SWITCH_NAMESPACE = WaffleSwitchNamespace(name=u'schedules')
+WAFFLE_FLAG_NAMESPACE = WaffleFlagNamespace(name='schedules')
+WAFFLE_SWITCH_NAMESPACE = WaffleSwitchNamespace(name='schedules')
 
 CREATE_SCHEDULE_WAFFLE_FLAG = CourseWaffleFlag(
     waffle_namespace=WAFFLE_FLAG_NAMESPACE,
-    flag_name=u'create_schedules_for_course',
+    flag_name='create_schedules_for_course',
+    module_name=__name__,
 )
 
 COURSE_UPDATE_WAFFLE_FLAG = CourseWaffleFlag(
     waffle_namespace=WAFFLE_FLAG_NAMESPACE,
-    flag_name=u'send_updates_for_course',
+    flag_name='send_updates_for_course',
+    module_name=__name__,
 )
 
-DEBUG_MESSAGE_WAFFLE_FLAG = WaffleFlag(WAFFLE_FLAG_NAMESPACE, u'enable_debugging')
+DEBUG_MESSAGE_WAFFLE_FLAG = WaffleFlag(WAFFLE_FLAG_NAMESPACE, 'enable_debugging', __name__)
 
-COURSE_UPDATE_SHOW_UNSUBSCRIBE_WAFFLE_SWITCH = WaffleSwitch(WAFFLE_SWITCH_NAMESPACE, u'course_update_show_unsubscribe')
+COURSE_UPDATE_SHOW_UNSUBSCRIBE_WAFFLE_SWITCH = WaffleSwitch(
+    WAFFLE_SWITCH_NAMESPACE,
+    'course_update_show_unsubscribe',
+    __name__
+)

--- a/openedx/core/djangoapps/user_api/accounts/toggles.py
+++ b/openedx/core/djangoapps/user_api/accounts/toggles.py
@@ -18,7 +18,7 @@ from openedx.core.djangoapps.waffle_utils import WaffleFlag
 # .. toggle_warnings: Also set settings.ORDER_HISTORY_MICROFRONTEND_URL and site's ENABLE_ORDER_HISTORY_MICROFRONTEND.
 # .. toggle_tickets: DEPR-17
 # .. toggle_status: supported
-REDIRECT_TO_ORDER_HISTORY_MICROFRONTEND = WaffleFlag('order_history', 'redirect_to_microfrontend')
+REDIRECT_TO_ORDER_HISTORY_MICROFRONTEND = WaffleFlag('order_history', 'redirect_to_microfrontend', __name__)
 
 
 def should_redirect_to_order_history_microfrontend():
@@ -39,7 +39,7 @@ def should_redirect_to_order_history_microfrontend():
 # .. toggle_warnings: Also set settings.ACCOUNT_MICROFRONTEND_URL and site's ENABLE_ACCOUNT_MICROFRONTEND.
 # .. toggle_tickets: DEPR-17
 # .. toggle_status: supported
-REDIRECT_TO_ACCOUNT_MICROFRONTEND = WaffleFlag('account', 'redirect_to_microfrontend')
+REDIRECT_TO_ACCOUNT_MICROFRONTEND = WaffleFlag('account', 'redirect_to_microfrontend', __name__)
 
 
 def should_redirect_to_account_microfrontend():

--- a/openedx/core/djangoapps/user_authn/config/waffle.py
+++ b/openedx/core/djangoapps/user_authn/config/waffle.py
@@ -20,5 +20,7 @@ _WAFFLE_SWITCH_NAMESPACE = WaffleSwitchNamespace(name=_WAFFLE_NAMESPACE, log_pre
 # .. toggle_tickets: ENT-2461
 # .. toggle_status: supported
 ENABLE_LOGIN_USING_THIRDPARTY_AUTH_ONLY = WaffleSwitch(
-    _WAFFLE_SWITCH_NAMESPACE, 'enable_login_using_thirdparty_auth_only'
+    _WAFFLE_SWITCH_NAMESPACE,
+    'enable_login_using_thirdparty_auth_only',
+    __name__
 )

--- a/openedx/core/djangoapps/user_authn/views/register.py
+++ b/openedx/core/djangoapps/user_authn/views/register.py
@@ -110,6 +110,7 @@ REGISTER_USER = Signal(providing_args=["user", "registration"])
 REGISTRATION_FAILURE_LOGGING_FLAG = WaffleFlag(
     waffle_namespace=WaffleFlagNamespace(name=u'registration'),
     flag_name=u'enable_failure_logging',
+    module_name=__name__,
 )
 REAL_IP_KEY = 'openedx.core.djangoapps.util.ratelimit.real_ip'
 

--- a/openedx/core/djangoapps/video_pipeline/config/waffle.py
+++ b/openedx/core/djangoapps/video_pipeline/config/waffle.py
@@ -22,14 +22,17 @@ def waffle_flags():
     return {
         DEPRECATE_YOUTUBE: CourseWaffleFlag(
             waffle_namespace=namespace,
-            flag_name=DEPRECATE_YOUTUBE
+            flag_name=DEPRECATE_YOUTUBE,
+            module_name=__name__,
         ),
         ENABLE_DEVSTACK_VIDEO_UPLOADS: WaffleFlag(
             waffle_namespace=namespace,
             flag_name=ENABLE_DEVSTACK_VIDEO_UPLOADS,
+            module_name=__name__,
         ),
         ENABLE_VEM_PIPELINE: CourseWaffleFlag(
             waffle_namespace=namespace,
             flag_name=ENABLE_VEM_PIPELINE,
+            module_name=__name__,
         )
     }

--- a/openedx/core/djangoapps/waffle_utils/tests/test_init.py
+++ b/openedx/core/djangoapps/waffle_utils/tests/test_init.py
@@ -37,7 +37,7 @@ class TestCourseWaffleFlag(TestCase):
     TEST_COURSE_KEY = CourseKey.from_string("edX/DemoX/Demo_Course")
     TEST_COURSE_2_KEY = CourseKey.from_string("edX/DemoX/Demo_Course_2")
     TEST_NAMESPACE = WaffleFlagNamespace(NAMESPACE_NAME)
-    TEST_COURSE_FLAG = CourseWaffleFlag(TEST_NAMESPACE, FLAG_NAME)
+    TEST_COURSE_FLAG = CourseWaffleFlag(TEST_NAMESPACE, FLAG_NAME, __name__)
 
     def setUp(self):
         super(TestCourseWaffleFlag, self).setUp()
@@ -101,6 +101,7 @@ class TestCourseWaffleFlag(TestCase):
         test_course_flag = CourseWaffleFlag(
             self.TEST_NAMESPACE,
             self.FLAG_NAME,
+            __name__,
         )
 
         with patch(
@@ -134,6 +135,7 @@ class TestCourseWaffleFlag(TestCase):
         test_course_flag = CourseWaffleFlag(
             self.TEST_NAMESPACE,
             self.FLAG_NAME,
+            __name__,
         )
         self.assertEqual(test_course_flag.is_enabled(self.TEST_COURSE_KEY), False)
 
@@ -145,6 +147,7 @@ class TestCourseWaffleFlag(TestCase):
         test_course_flag = CourseWaffleFlag(
             self.TEST_NAMESPACE,
             self.FLAG_NAME,
+            __name__,
         )
         with override_flag(self.NAMESPACED_FLAG_NAME, active=True):
             self.assertEqual(test_course_flag.is_enabled(self.TEST_COURSE_KEY), True)
@@ -161,9 +164,9 @@ class TestCourseWaffleFlag(TestCase):
                 'openedx.core.djangoapps.waffle_utils._WAFFLE_FLAG_CUSTOM_METRIC_SET',
                 _get_waffle_flag_custom_metrics_set(),
             ):
-                test_course_flag = CourseWaffleFlag(self.TEST_NAMESPACE, self.FLAG_NAME)
+                test_course_flag = CourseWaffleFlag(self.TEST_NAMESPACE, self.FLAG_NAME, __name__)
                 test_course_flag.is_enabled(self.TEST_COURSE_KEY)
-                test_course_flag_2 = CourseWaffleFlag(self.TEST_NAMESPACE, self.FLAG_2_NAME)
+                test_course_flag_2 = CourseWaffleFlag(self.TEST_NAMESPACE, self.FLAG_2_NAME, __name__)
                 test_course_flag_2.is_enabled(self.TEST_COURSE_KEY)
 
         self.assertEqual(mock_set_custom_metric.call_count, data['expected_count'])
@@ -186,7 +189,7 @@ class TestWaffleSwitch(TestCase):
     NAMESPACE_NAME = "test_namespace"
     WAFFLE_SWITCH_NAME = "test_switch_name"
     TEST_NAMESPACE = WaffleSwitchNamespace(NAMESPACE_NAME)
-    WAFFLE_SWITCH = WaffleSwitch(TEST_NAMESPACE, WAFFLE_SWITCH_NAME)
+    WAFFLE_SWITCH = WaffleSwitch(TEST_NAMESPACE, WAFFLE_SWITCH_NAME, __name__)
 
     def test_namespaced_switch_name(self):
         """

--- a/openedx/core/djangoapps/waffle_utils/tests/test_testutils.py
+++ b/openedx/core/djangoapps/waffle_utils/tests/test_testutils.py
@@ -24,7 +24,7 @@ class OverrideWaffleFlagTests(TestCase):
 
     TEST_COURSE_KEY = CourseKey.from_string("edX/DemoX/Demo_Course")
     TEST_NAMESPACE = WaffleFlagNamespace(NAMESPACE_NAME)
-    TEST_COURSE_FLAG = CourseWaffleFlag(TEST_NAMESPACE, FLAG_NAME)
+    TEST_COURSE_FLAG = CourseWaffleFlag(TEST_NAMESPACE, FLAG_NAME, __name__)
 
     def setUp(self):
         super(OverrideWaffleFlagTests, self).setUp()

--- a/openedx/core/djangoapps/waffle_utils/tests/test_views.py
+++ b/openedx/core/djangoapps/waffle_utils/tests/test_views.py
@@ -12,7 +12,7 @@ from ..views import ToggleStateView
 from ..testutils import override_waffle_flag
 
 TEST_WAFFLE_FLAG_NAMESPACE = WaffleFlagNamespace('test')
-TEST_WAFFLE_FLAG = WaffleFlag(TEST_WAFFLE_FLAG_NAMESPACE, 'flag')
+TEST_WAFFLE_FLAG = WaffleFlag(TEST_WAFFLE_FLAG_NAMESPACE, 'flag', __name__)
 
 
 # TODO: Missing coverage for:

--- a/openedx/core/lib/request_utils.py
+++ b/openedx/core/lib/request_utils.py
@@ -23,7 +23,7 @@ except ImportError:
 COURSE_REGEX = re.compile(r'^(.*?/courses/)(?!v[0-9]+/[^/]+){}'.format(settings.COURSE_ID_PATTERN))
 
 WAFFLE_FLAG_NAMESPACE = WaffleFlagNamespace(name='request_utils')
-CAPTURE_COOKIE_SIZES = WaffleFlag(WAFFLE_FLAG_NAMESPACE, 'capture_cookie_sizes')
+CAPTURE_COOKIE_SIZES = WaffleFlag(WAFFLE_FLAG_NAMESPACE, 'capture_cookie_sizes', __name__)
 log = logging.getLogger(__name__)
 
 

--- a/openedx/features/course_experience/__init__.py
+++ b/openedx/features/course_experience/__init__.py
@@ -72,18 +72,18 @@ DEFAULT_TRUE_WAFFLE_FLAG_NAMESPACE = DefaultTrueWaffleFlagNamespace(name='course
 # Waffle flag to enable the separate course outline page and full width content.
 # NOTE: The special namespace makes the default True and skips checking course overrides.
 # TODO: TNL-7061: Perform the actual clean-up required to remove this flag.
-COURSE_OUTLINE_PAGE_FLAG = CourseWaffleFlag(DEFAULT_TRUE_WAFFLE_FLAG_NAMESPACE, 'course_outline_page')
+COURSE_OUTLINE_PAGE_FLAG = CourseWaffleFlag(DEFAULT_TRUE_WAFFLE_FLAG_NAMESPACE, 'course_outline_page', __name__)
 
 # Waffle flag to enable a single unified "Course" tab.
 # NOTE: The special namespace makes the default True and skips checking course overrides.
 # TODO: TNL-7061: Perform the actual clean-up required to remove this flag.
-UNIFIED_COURSE_TAB_FLAG = CourseWaffleFlag(DEFAULT_TRUE_WAFFLE_FLAG_NAMESPACE, 'unified_course_tab')
+UNIFIED_COURSE_TAB_FLAG = CourseWaffleFlag(DEFAULT_TRUE_WAFFLE_FLAG_NAMESPACE, 'unified_course_tab', __name__)
 
 # Waffle flag to enable the sock on the footer of the home and courseware pages.
-DISPLAY_COURSE_SOCK_FLAG = CourseWaffleFlag(WAFFLE_FLAG_NAMESPACE, 'display_course_sock')
+DISPLAY_COURSE_SOCK_FLAG = CourseWaffleFlag(WAFFLE_FLAG_NAMESPACE, 'display_course_sock', __name__)
 
 # Waffle flag to let learners access a course before its start date.
-COURSE_PRE_START_ACCESS_FLAG = WaffleFlag(WAFFLE_FLAG_NAMESPACE, 'pre_start_access')
+COURSE_PRE_START_ACCESS_FLAG = WaffleFlag(WAFFLE_FLAG_NAMESPACE, 'pre_start_access', __name__)
 
 # Waffle flag to enable a review page link from the unified home page.
 # .. toggle_name: course_experience.show_reviews_tool
@@ -97,7 +97,7 @@ COURSE_PRE_START_ACCESS_FLAG = WaffleFlag(WAFFLE_FLAG_NAMESPACE, 'pre_start_acce
 # .. toggle_warnings: We are no longer integrating with CourseTalk, so this probably should be deprecated and the code for reviews should be removed.
 # .. toggle_tickets: DEPR-48
 # .. toggle_status: unsupported
-SHOW_REVIEWS_TOOL_FLAG = CourseWaffleFlag(WAFFLE_FLAG_NAMESPACE, 'show_reviews_tool')
+SHOW_REVIEWS_TOOL_FLAG = CourseWaffleFlag(WAFFLE_FLAG_NAMESPACE, 'show_reviews_tool', __name__)
 
 # Waffle flag to enable the setting of course goals.
 # .. toggle_name: course_experience.enable_course_goals
@@ -111,13 +111,13 @@ SHOW_REVIEWS_TOOL_FLAG = CourseWaffleFlag(WAFFLE_FLAG_NAMESPACE, 'show_reviews_t
 # .. toggle_warnings: N/A
 # .. toggle_tickets: N/A
 # .. toggle_status: supported
-ENABLE_COURSE_GOALS = CourseWaffleFlag(WAFFLE_FLAG_NAMESPACE, 'enable_course_goals')
+ENABLE_COURSE_GOALS = CourseWaffleFlag(WAFFLE_FLAG_NAMESPACE, 'enable_course_goals', __name__)
 
 # Waffle flag to control the display of the hero
-SHOW_UPGRADE_MSG_ON_COURSE_HOME = CourseWaffleFlag(WAFFLE_FLAG_NAMESPACE, 'show_upgrade_msg_on_course_home')
+SHOW_UPGRADE_MSG_ON_COURSE_HOME = CourseWaffleFlag(WAFFLE_FLAG_NAMESPACE, 'show_upgrade_msg_on_course_home', __name__)
 
 # Waffle flag to control the display of the upgrade deadline message
-UPGRADE_DEADLINE_MESSAGE = CourseWaffleFlag(WAFFLE_FLAG_NAMESPACE, 'upgrade_deadline_message')
+UPGRADE_DEADLINE_MESSAGE = CourseWaffleFlag(WAFFLE_FLAG_NAMESPACE, 'upgrade_deadline_message', __name__)
 
 # Waffle flag to switch between the 'welcome message' and 'latest update' on the course home page.
 # .. toggle_name: course_experience.latest_update
@@ -131,17 +131,21 @@ UPGRADE_DEADLINE_MESSAGE = CourseWaffleFlag(WAFFLE_FLAG_NAMESPACE, 'upgrade_dead
 # .. toggle_warnings: This is meant to be configured using waffle_utils course override only.  Either do not create the actual waffle flag, or be sure to unset the flag even for Superusers.
 # .. toggle_tickets: N/A
 # .. toggle_status: supported
-LATEST_UPDATE_FLAG = CourseWaffleFlag(WAFFLE_FLAG_NAMESPACE, 'latest_update')
+LATEST_UPDATE_FLAG = CourseWaffleFlag(WAFFLE_FLAG_NAMESPACE, 'latest_update', __name__)
 
 # Waffle flag to enable anonymous access to a course
 SEO_WAFFLE_FLAG_NAMESPACE = WaffleFlagNamespace(name='seo')
-COURSE_ENABLE_UNENROLLED_ACCESS_FLAG = CourseWaffleFlag(SEO_WAFFLE_FLAG_NAMESPACE, 'enable_anonymous_courseware_access')
+COURSE_ENABLE_UNENROLLED_ACCESS_FLAG = CourseWaffleFlag(
+    SEO_WAFFLE_FLAG_NAMESPACE,
+    'enable_anonymous_courseware_access',
+    __name__,
+)
 
 # Waffle flag to enable relative dates for course content
-RELATIVE_DATES_FLAG = ExperimentWaffleFlag(WAFFLE_FLAG_NAMESPACE, 'relative_dates', experiment_id=17)
+RELATIVE_DATES_FLAG = ExperimentWaffleFlag(WAFFLE_FLAG_NAMESPACE, 'relative_dates', __name__, experiment_id=17)
 
 # Waffle flag to enable user calendar syncing
-CALENDAR_SYNC_FLAG = CourseWaffleFlag(WAFFLE_FLAG_NAMESPACE, 'calendar_sync')
+CALENDAR_SYNC_FLAG = CourseWaffleFlag(WAFFLE_FLAG_NAMESPACE, 'calendar_sync', __name__)
 
 
 def course_home_page_title(course):  # pylint: disable=unused-argument

--- a/openedx/features/discounts/applicability.py
+++ b/openedx/features/discounts/applicability.py
@@ -40,6 +40,7 @@ from track import segment
 DISCOUNT_APPLICABILITY_FLAG = WaffleFlag(
     waffle_namespace=WaffleFlagNamespace(name=u'discounts'),
     flag_name=u'enable_discounting',
+    module_name=__name__,
 )
 
 DISCOUNT_APPLICABILITY_HOLDBACK = 'first_purchase_discount_holdback'

--- a/openedx/features/enterprise_support/utils.py
+++ b/openedx/features/enterprise_support/utils.py
@@ -21,7 +21,7 @@ from openedx.core.djangolib.markup import HTML, Text
 from openedx.core.djangoapps.waffle_utils import WaffleFlag
 from student.helpers import get_next_url_for_login_page
 
-ENTERPRISE_HEADER_LINKS = WaffleFlag('enterprise', 'enterprise_header_links')
+ENTERPRISE_HEADER_LINKS = WaffleFlag('enterprise', 'enterprise_header_links', __name__)
 
 
 def get_data_consent_share_cache_key(user_id, course_id):

--- a/openedx/features/learner_profile/toggles.py
+++ b/openedx/features/learner_profile/toggles.py
@@ -22,7 +22,7 @@ WAFFLE_FLAG_NAMESPACE = WaffleFlagNamespace(name='learner_profile')
 # .. toggle_warnings: Also set settings.PROFILE_MICROFRONTEND_URL and site's ENABLE_PROFILE_MICROFRONTEND.
 # .. toggle_tickets: DEPR-17
 # .. toggle_status: supported
-REDIRECT_TO_PROFILE_MICROFRONTEND = WaffleFlag(WAFFLE_FLAG_NAMESPACE, 'redirect_to_microfrontend')
+REDIRECT_TO_PROFILE_MICROFRONTEND = WaffleFlag(WAFFLE_FLAG_NAMESPACE, 'redirect_to_microfrontend', __name__)
 
 
 def should_redirect_to_profile_microfrontend():


### PR DESCRIPTION
Instead of going up the stacktrace to find the module names of waffle
flags and switches, we manually pass the module __name__ whenever the
flag is created. This is similar to `logging.getLogger(__name__)`
standard behaviour.

Note that the module name is normally only required to view the list of
existing waffle flags and switches. The module name should not be
necessary to verify if a flag is enabled. Thus, maybe it would make
sense to create a `add` class methor similar to:

    class WaffleFlag:
        @classmethod
        def add(cls, namespace, flag, module):
            instance = cls(namespace, flag)
            cls._class_instances.add((instance, module))

cc @robrap 