### PR TITLE
Update tests as per new eventtracking release

### DIFF
--- a/common/djangoapps/track/tests/__init__.py
+++ b/common/djangoapps/track/tests/__init__.py
@@ -6,7 +6,7 @@ from datetime import datetime
 from django.test import TestCase
 from django.test.utils import override_settings
 from eventtracking import tracker
-from eventtracking.django import DjangoTracker
+from eventtracking.django.django_tracker import DjangoTracker
 from freezegun import freeze_time
 from pytz import UTC
 

--- a/common/djangoapps/track/tests/test_segment.py
+++ b/common/djangoapps/track/tests/test_segment.py
@@ -5,7 +5,7 @@ import ddt
 from django.test import TestCase
 from django.test.utils import override_settings
 from eventtracking import tracker
-from eventtracking.django import DjangoTracker
+from eventtracking.django.django_tracker import DjangoTracker
 from mock import patch, sentinel
 
 from track import segment


### PR DESCRIPTION
## PR description

We need to make this change in the tests once the [PR](https://github.com/edx/event-tracking/pull/56) for event-tracking update has been merged and new version is released.

**TODO**:
- Update app version in the requirements once there is a release tag for event-tracking.