### PR TITLE
AA-322: Adding priority to Dates Tab order

### DIFF
--- a/lms/djangoapps/courseware/tabs.py
+++ b/lms/djangoapps/courseware/tabs.py
@@ -319,6 +319,7 @@ class DatesTab(EnrolledTab):
     type = "dates"
     title = ugettext_noop(
         "Dates")  # We don't have the user in this context, so we don't want to translate it at this level.
+    priority = 50
     view_name = "dates"
     is_dynamic = True
 
@@ -374,6 +375,12 @@ def get_course_tab_list(user, course):
 
     # Add in any dynamic tabs, i.e. those that are not persisted
     course_tab_list += _get_dynamic_tabs(course, user)
+    # Sorting here because although the CourseTabPluginManager.get_tab_types function
+    # does do sorting on priority, we only use it for getting the dynamic tabs.
+    # We can't switch this function to just use the CourseTabPluginManager without
+    # further investigation since CourseTabList.iterate_displayable returns
+    # Static Tabs that are not returned by the CourseTabPluginManager.
+    course_tab_list.sort(key=lambda tab: tab.priority or float('inf'))
     return course_tab_list
 
 

--- a/lms/djangoapps/courseware/tests/test_tabs.py
+++ b/lms/djangoapps/courseware/tests/test_tabs.py
@@ -778,7 +778,12 @@ class CourseInfoTabTestCase(TabTestCase):
     def test_default_tab(self):
         # Verify that the course info tab is the first tab
         tabs = get_course_tab_list(self.user, self.course)
-        self.assertEqual(tabs[0].type, 'course_info')
+        # So I know this means course_info is not the first tab, but it is going to be
+        # retired soon (https://openedx.atlassian.net/browse/TNL-7061) and also it has
+        # a lower priority than courseware so seems odd that it would ever be first.
+        # As such, I feel comfortable updating this test so it passes until it is removed
+        # as part of the linked ticket
+        self.assertEqual(tabs[1].type, 'course_info')
 
     @override_waffle_flag(UNIFIED_COURSE_TAB_FLAG, active=True)
     def test_default_tab_for_new_course_experience(self):


### PR DESCRIPTION
This also starts taking priority into account for all tabs, and
not just dynamic tabs via the CourseTabPluginManager (see comments
in the code for more detail)