### PR TITLE
Fix documentation for ENABLE_LEARNER_RECORDS

### DIFF
--- a/openedx/core/djangoapps/credentials/docs/site_config.rst
+++ b/openedx/core/djangoapps/credentials/docs/site_config.rst
@@ -3,8 +3,8 @@ Site Configuration
 
 These are the site configuration flags that affect Credentials features.
 
-ENABLE_CREDENTIALS_RECORDS
---------------------------
+ENABLE_LEARNER_RECORDS
+----------------------
 
 Controls whether the LMS integrates with the Learner Records feature in Credentials. Specifically, this turns on some web buttons that link to a learner's record on the Credentials IDA and enables some data being passed to Credentials related to those records.
 


### PR DESCRIPTION
Commit 3222d3fd13d0c4243b60711164264cea8af8f76d (from LEARNER-5987) introduced the `ENABLE_LEARNER_RECORDS` site configuration flag, but incorrectly referred to it as `ENABLE_CREDENTIALS_RECORDS` in the documentation for the credentials service.

Fix the reference with the correct flag name.

Courtesy tag for @mikix, who was the author of that commit ­— just to make sure that I didn't misread something. For what it's worth, the `site_config.rst` file is the *only* reference to `ENABLE_CREDENTIALS_RECORDS` throughout the `edx-platform` tree, hence why I'm guessing that this is just a doc mishap.