### PR TITLE
MB-312 | Demographics modal bugfix

### DIFF
--- a/themes/edx.org/lms/static/js/demographics-collection.js
+++ b/themes/edx.org/lms/static/js/demographics-collection.js
@@ -1,0 +1,23 @@
+$(document).ready(function() {
+    'use strict';
+
+    $('#demographics-dismiss').click(function(event) {
+        event.preventDefault();
+        return $.ajax({
+            url: '/api/demographics/v1/demographics/status/',
+            type: 'PATCH',
+            headers: {
+                'X-CSRFToken': $.cookie('csrftoken')
+            },
+            dataType: 'json',
+            contentType: 'application/json',
+            data: JSON.stringify({
+                show_call_to_action: false
+            }),
+            context: this,
+            success: function() {
+                $('#demographics-banner-link').hide();
+            }
+        });
+    });
+});


### PR DESCRIPTION
[MB-312]
- Re-adding deleted JS file. Can't clean this up until after we cutover to using the new Demographics modal