### PR TITLE
SE-3149 Fix the theme compilation issue in juniper

### DIFF
--- a/common/lib/xmodule/xmodule/static_content.py
+++ b/common/lib/xmodule/xmodule/static_content.py
@@ -74,7 +74,7 @@ XBLOCK_CLASSES = [
 
 def write_module_styles(output_root):
     """Write all registered XModule css, sass, and scss files to output root."""
-    return _write_styles('.xmodule_display', output_root, _list_modules(), 'get_preview_view_css')
+    return _write_styles('.xmodule_display', output_root, sorted(_list_modules(), key=str), 'get_preview_view_css')
 
 
 def write_module_js(output_root):
@@ -152,7 +152,8 @@ def _write_styles(selector, output_root, classes, css_attribute):
         "@import 'bourbon/bourbon';",
         "@import 'lms/theme/variables';",
     ]
-    for class_, fragment_names in css_imports.items():
+    for class_, fragment_names in sorted(css_imports.items()):
+        fragment_names = sorted(fragment_names)
         module_styles_lines.append("""{selector}.xmodule_{class_} {{""".format(
             class_=class_, selector=selector
         ))

--- a/openedx/core/djangoapps/theming/storage.py
+++ b/openedx/core/djangoapps/theming/storage.py
@@ -10,7 +10,7 @@ import re
 
 from django.conf import settings
 from django.contrib.staticfiles.finders import find
-from django.contrib.staticfiles.storage import CachedFilesMixin, StaticFilesStorage
+from django.contrib.staticfiles.storage import ManifestFilesMixin, StaticFilesStorage
 from django.utils._os import safe_join
 from django.utils.six.moves.urllib.parse import (  # pylint: disable=no-name-in-module, import-error
     unquote,
@@ -110,10 +110,10 @@ class ThemeStorage(ThemeMixin, StaticFilesStorage):
     pass
 
 
-class ThemeCachedFilesMixin(CachedFilesMixin):
+class ThemeManifestFilesMixin(ManifestFilesMixin):
     """
-    Comprehensive theme aware CachedFilesMixin.
-    Main purpose of subclassing CachedFilesMixin is to override the following methods.
+    Comprehensive theme aware ManifestFilesMixin.
+    Main purpose of subclassing ManifestFilesMixin is to override the following methods.
     1 - _url
     2 - url_converter
 
@@ -177,11 +177,11 @@ class ThemeCachedFilesMixin(CachedFilesMixin):
         See the class docstring for more info.
         """
         processed_asset_name = self._processed_asset_name(name)
-        return super(ThemeCachedFilesMixin, self)._url(hashed_name_func, processed_asset_name, force, hashed_files)
+        return super(ThemeManifestFilesMixin, self)._url(hashed_name_func, processed_asset_name, force, hashed_files)
 
     def url_converter(self, name, hashed_files, template=None):
         """
-        This is an override of url_converter from CachedFilesMixin.
+        This is an override of url_converter from ManifestFilesMixin.
         It changes one line near the end of the method (see the NOTE) in order
         to return absolute urls instead of relative urls.  This behavior is
         necessary for theme overrides, as we get 404 on assets with relative

--- a/openedx/core/storage.py
+++ b/openedx/core/storage.py
@@ -12,7 +12,7 @@ from pipeline.storage import NonPackagingMixin
 from require.storage import OptimizedFilesMixin
 from storages.backends.s3boto3 import S3Boto3Storage
 
-from openedx.core.djangoapps.theming.storage import ThemeCachedFilesMixin, ThemePipelineMixin, ThemeMixin
+from openedx.core.djangoapps.theming.storage import ThemeManifestFilesMixin, ThemePipelineMixin, ThemeMixin
 
 
 class PipelineForgivingMixin(object):
@@ -44,7 +44,7 @@ class ProductionMixin(
         PipelineForgivingMixin,
         OptimizedFilesMixin,
         ThemePipelineMixin,
-        ThemeCachedFilesMixin,
+        ThemeManifestFilesMixin,
         ThemeMixin,
 ):
     """


### PR DESCRIPTION
`CachedStaticFilesStorage` is deprecated in Django 2.2. It's plugin model i.e. `CachedFilesMixin` was being used in theme asset compilation. This was leading to inconsistent theme asset compilation and would lead to failures if more than one instance is used for load-balancing. This PR replaces the deprecated `CachedFilesMixin` with `ManifestFilesMixin`. It also fixes the order of the modules used in compilation.

**Jira Tickets:** [OSPR-4966](https://openedx.atlassian.net/browse/OSPR-4966)

**Dependecies:** None

**Sandbox URL:** TBD - sandbox is being provisioned

**Merge deadline:** None

**Testing Instructions:**
1. Spawn a new edX juniper instance and check the css files generated in /edx/var/edxapp/staticfiles/css.
2. Run `paver update_assets` command and recheck that no new css files are generated in /edx/var/edxapp/staticfiles/css.
3. Spawn multiple instances and add to load-balancer. Verify that the assets are getting loaded correctly.

**Reviewers:**
- [ ] @Kelketek 
- [ ]  edX reviewer[s] TBD