### PR TITLE
Sends Post-password-change acknowledgment email

### DIFF
--- a/openedx/core/djangoapps/user_authn/message_types.py
+++ b/openedx/core/djangoapps/user_authn/message_types.py
@@ -2,13 +2,25 @@
 ACE message types for user_authn-related emails.
 """
 
-
 from openedx.core.djangoapps.ace_common.message import BaseMessageType
 
 
 class PasswordReset(BaseMessageType):
+    """
+    A message to the user with password reset link.
+    """
     def __init__(self, *args, **kwargs):
         super(PasswordReset, self).__init__(*args, **kwargs)
 
         # pylint: disable=unsupported-assignment-operation
+        self.options['transactional'] = True
+
+
+class PasswordResetSuccess(BaseMessageType):
+    """
+    A message to the user when the password rest was successful.
+    """
+
+    def __init__(self, *args, **kwargs):
+        super(PasswordResetSuccess, self).__init__(*args, **kwargs)
         self.options['transactional'] = True

--- a/openedx/core/djangoapps/user_authn/templates/user_authn/edx_ace/passwordresetsuccess/email/body.html
+++ b/openedx/core/djangoapps/user_authn/templates/user_authn/edx_ace/passwordresetsuccess/email/body.html
@@ -1,0 +1,31 @@
+{% extends 'ace_common/edx_ace/common/base_body.html' %}
+
+{% load i18n %}
+{% load static %}
+{% block content %}
+<table width="100%" align="left" border="0" cellpadding="0" cellspacing="0" role="presentation">
+    <tr>
+        <td>
+            <h1>
+                {% trans "Password Reset Success" as tmsg %}{{ tmsg | force_escape }}
+            </h1>
+            <p style="color: rgba(0,0,0,.75);">
+                {% filter force_escape %}
+                   {% blocktrans %}Hello {{ name }},{% endblocktrans %}
+                {% endfilter %}
+            </p>
+            <p style="color: rgba(0,0,0,.75);">
+                {% filter force_escape %}
+                {% blocktrans %}This is to confirm that you have successfully changed your password associated with {{ platform_name }} account. Please sign-in to your account.{% endblocktrans %}
+                {% endfilter %}
+                <br />
+            </p>
+
+                {% filter force_escape %}
+                {% blocktrans asvar course_cta_text %}Sign in{% endblocktrans %}
+                {% endfilter %}
+                {% include "ace_common/edx_ace/common/return_to_course_cta.html" with course_cta_text=course_cta_text course_cta_url=login_link %}
+        </td>
+    </tr>
+</table>
+{% endblock %}

--- a/openedx/core/djangoapps/user_authn/templates/user_authn/edx_ace/passwordresetsuccess/email/body.txt
+++ b/openedx/core/djangoapps/user_authn/templates/user_authn/edx_ace/passwordresetsuccess/email/body.txt
@@ -1,0 +1,6 @@
+{% load i18n %}{% autoescape off %}
+{% blocktrans %}Hello {{ name }}, {% endblocktrans %}
+{% blocktrans %}This is to confirm that you have successfully changed your password associated with {{ platform_name }} account. Please sign-in to your account.{% endblocktrans %}
+
+{{ login_link }}
+{% endautoescape %}

--- a/openedx/core/djangoapps/user_authn/templates/user_authn/edx_ace/passwordresetsuccess/email/from_name.txt
+++ b/openedx/core/djangoapps/user_authn/templates/user_authn/edx_ace/passwordresetsuccess/email/from_name.txt
@@ -1,0 +1,1 @@
+{{ platform_name }}

--- a/openedx/core/djangoapps/user_authn/templates/user_authn/edx_ace/passwordresetsuccess/email/head.html
+++ b/openedx/core/djangoapps/user_authn/templates/user_authn/edx_ace/passwordresetsuccess/email/head.html
@@ -1,0 +1,1 @@
+{% extends 'ace_common/edx_ace/common/base_head.html' %}

--- a/openedx/core/djangoapps/user_authn/templates/user_authn/edx_ace/passwordresetsuccess/email/subject.txt
+++ b/openedx/core/djangoapps/user_authn/templates/user_authn/edx_ace/passwordresetsuccess/email/subject.txt
@@ -1,0 +1,4 @@
+{% load i18n %}
+{% autoescape off %}
+{% blocktrans trimmed %}Password reset completed on {{ platform_name }}{% endblocktrans %}
+{% endautoescape %}


### PR DESCRIPTION
Sends Post-password-change acknowledgment email.

This PR adds a feature that when a user password change is successful, it sends the user an email letting him know about the change. 
[PROD-421](https://openedx.atlassian.net/browse/PROD-421)

<img width="632" alt="Screen Shot 2020-09-30 at 2 33 50 PM" src="https://user-images.githubusercontent.com/4252738/94668886-073ed480-032a-11eb-888c-3abeb378e79c.png">


Sandbox:
https://password-reset.sandbox.edx.org/