### PR TITLE
[TNL-7465] Upgrade bootstrap to 4.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2185,9 +2185,9 @@
       "dev": true
     },
     "bootstrap": {
-      "version": "4.0.0-beta.2",
-      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-4.0.0-beta.2.tgz",
-      "integrity": "sha512-DzGtdTlKbrMoGMpz0LigKSqJ+MgtFKxA791PU/q062OlRG0HybNZcTLH7rpDAmLS66Y3esN9yzKHLLbqa5UR3w=="
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-4.0.0.tgz",
+      "integrity": "sha512-gulJE5dGFo6Q61V/whS6VM4WIyrlydXfCgkE+Gxe5hjrJ8rXLLZlALq7zq2RPhOc45PSwQpJkrTnc2KgD6cvmA=="
     },
     "brace-expansion": {
       "version": "1.1.11",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "backbone": "1.4.0",
     "backbone-associations": "0.6.2",
     "backbone.paginator": "2.0.8",
-    "bootstrap": "4.0.0-beta.2",
+    "bootstrap": "4.0.0",
     "camelize": "1.0.0",
     "classnames": "2.2.5",
     "css-loader": "0.28.8",


### PR DESCRIPTION
[TNL-7465](https://openedx.atlassian.net/browse/TNL-7465)]

Upgrade from the beta to the 4.0.0 release. There are some [breaking changes in 4.0.0-beta2 to 4.0.0-beta3](https://getbootstrap.com/docs/4.0/migration/#beta-3-changes), but it doesn't look like anything on edx-platform is affects

Sandbox: https://abutterworth.sandbox.edx.org/ (should be up in by 7pm 9/14. Terminates 9/17)