### PR TITLE
Add programs celery tasks to Studio workers

### DIFF
--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -1220,6 +1220,7 @@ CELERY_IMPORTS = (
     'cms.djangoapps.contentstore.tasks',
     'openedx.core.djangoapps.bookmarks.tasks',
     'openedx.core.djangoapps.ccxcon.tasks',
+    'openedx.core.djangoapps.programs.tasks.v1.tasks',
 )
 
 # Message configuration


### PR DESCRIPTION
following forward to work done in PROD-1230

Prompted by observing this message when trying to kick off some fresh celery tasks.
```
Received unregistered task of type 'openedx.core.djangoapps.programs.tasks.v1.tasks.update_certificate_visible_date_on_course_update'.
The message has been ignored and discarded.
Did you remember to import the module containing this task?
Or maybe you are using relative imports?
Please see http://bit.ly/gLye1c for more information.
```

JIRA:CR-2581