### PR TITLE
AA-335: Avoid due dates for ORA subsections

### DIFF
--- a/lms/djangoapps/courseware/courses.py
+++ b/lms/djangoapps/courseware/courses.py
@@ -572,9 +572,8 @@ def get_course_assignments(course_key, user, include_access=False):
                         'start': block_data.get_xblock_field(descendent, 'submission_start'),
                         'required': True
                     }]
-                    valid_assessments = block_data.get_xblock_field(descendent, 'valid_assessments')
-                    print(valid_assessments)
 
+                    valid_assessments = block_data.get_xblock_field(descendent, 'valid_assessments')
                     if valid_assessments:
                         all_assessments.extend(valid_assessments)
 

--- a/lms/djangoapps/courseware/transformers.py
+++ b/lms/djangoapps/courseware/transformers.py
@@ -21,7 +21,7 @@ class OpenAssessmentDateTransformer(FilteringTransformerMixin, BlockStructureTra
         Unique identifier for the transformer's class;
         same identifier used in setup.py.
         """
-        return "content_type_gate"
+        return 'open_assessment_transformer'
 
     @classmethod
     def collect(cls, block_structure):

--- a/openedx/core/djangoapps/course_date_signals/handlers.py
+++ b/openedx/core/djangoapps/course_date_signals/handlers.py
@@ -38,6 +38,29 @@ def _field_values(fields, xblock):
     return result
 
 
+def _gather_graded_items(root, due):
+    items = [root]
+    has_non_ora_scored_content = False
+    collected_items = []
+    while items:
+        next_item = items.pop()
+        if next_item.graded:
+            # TODO: Once studio can manually set relative dates, we would need to manually check for them here
+            collected_items.append((next_item.location, {'due': due}))
+            # TODO: This is pretty gross, and should maybe be configurable in the future,
+            # especially if we find ourselves needing more exceptions.
+            has_non_ora_scored_content = (
+                has_non_ora_scored_content or
+                (next_item.has_score and next_item.category != 'openassessment')
+            )
+
+        items.extend(next_item.get_children())
+
+    if has_non_ora_scored_content:
+        return collected_items
+    return []
+
+
 def extract_dates_from_course(course):
     """
     Extract all dates from the supplied course.
@@ -53,26 +76,13 @@ def extract_dates_from_course(course):
             # Apply the same relative due date to all content inside a section,
             # unless that item already has a relative date set
             for _, section, weeks_to_complete in spaced_out_sections(course):
-                items = [section]
-                has_non_ora_scored_content = False
                 section_date_items = []
-                while items:
-                    next_item = items.pop()
-                    # TODO: This is pretty gross, and should maybe be configurable in the future,
-                    # especially if we find ourselves needing more exceptions.
-                    if next_item.graded:
-                        # TODO: Once studio can manually set relative dates,
-                        # we would need to manually check for them here
-                        section_date_items.append((next_item.location, {'due': weeks_to_complete}))
-                        has_non_ora_scored_content = (
-                            has_non_ora_scored_content or
-                            (next_item.has_score and next_item.category != 'openassessment')
-                        )
+                for subsection in section.get_children():
+                    section_date_items.extend(_gather_graded_items(subsection, weeks_to_complete))
 
-                    items.extend(next_item.get_children())
-
-                if has_non_ora_scored_content:
-                    date_items.extend(section_date_items)
+                if section_date_items and section.graded:
+                    date_items.append((section.location, weeks_to_complete))
+                date_items.extend(section_date_items)
     else:
         date_items = []
         store = modulestore()


### PR DESCRIPTION
Previously, we'd been avoiding PLS due dates for ORA *sections*. That is, if a section had only ORA content, we'd not set a PLS due date for anything in that section.

If any content in that section had non-ORA graded content however, we would set dates on all subsections, including the ORA one.

This resulted in some ORA-only subsections showing up twice on the dates tab. So this patch simply brings down the ORA-only check to a *subsection* level, not a section one.

Once deployed, we'll want to republish any affected courses.