### PR TITLE
[BB-2924] Added a constant to help modify countries list in drop-down

### DIFF
--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -3938,3 +3938,11 @@ SUPPORT_HOW_TO_UNENROLL_LINK = ''
 
 ######################## Setting for content libraries ########################
 MAX_BLOCKS_PER_CONTENT_LIBRARY = 1000
+
+######################## Setting for django-countries ########################
+# django-countries provides an option to make the desired countries come up in
+# selection forms, if left empty countries will come up in ascending order as before.
+# This accepts a list of ISO3166-1 two letter country code, For example,
+# COUNTRIES_FIRST = ['SA', 'BH', 'QA'] will display these countries on top of the list
+# https://github.com/SmileyChris/django-countries#show-certain-countries-first
+COUNTRIES_FIRST = []


### PR DESCRIPTION
This change introduces a way to help to fill the form. With the constant, we
can specify the order of the countries that should come first. This will
reduce the chance of committing a mistake while selecting a country.
This is helpful when we know that majority of students is from these countries.

**Screenshots**: 
![image](https://user-images.githubusercontent.com/7670449/92711024-e2cc8980-f375-11ea-8658-f0dd11207f3f.png)


**Sandbox URL**: TBD 

**Testing instructions**:

1. Pull the changes from this branch
2. Start `LMS` by `make dev.up.lms`
3. Drop in the `LMS` shell with `make dev.shell.lms`
4. Open the `lms.yml` file `vim /edx/etc/lms.yml` in `LMS` shell
5. Add 
```
COUNTRIES_FIRST: ['SA', 'BH', 'QA', 'KW', 'AE', 'OM', 'YE', 'JO', 'IQ', 'ER', 'IL', 'IR', 'PS', 'EG', 'SY', 'LB', 'DJ', 'CY', 'ET', 'SD', 'AM']
```
in `lms.yml` file
6. Restart the server `make lms-restart`
4. Go to the register page, and click on the countries and region
5. You will see the selected countries come up

**Author notes and concerns**:

1. If this parameter left empty it doesn't have any effect on the current flow, only when it is set to the appropriate value 
Eg:

```
COUNTRIES_FIRST = ['SA', 'BH', 'QA', 'KW', 'AE', 'OM', 'YE', 'JO', 'IQ', 'ER', 'IL', 'IR', 'PS', 'EG', 'SY', 'LB', 'DJ', 'CY', 'ET', 'SD', 'AM']
```
Then it will give priority to these countries

**Reviewers**
- [x] @0x29a 
- [ ] @giovannicimolin 
- [ ] @bradenmacdonald 

**Settings**
```yaml
COUNTRIES_FIRST: ['SA', 'BH', 'QA', 'KW', 'AE', 'OM', 'YE', 'JO', 'IQ', 'ER', 'IL', 'IR', 'PS', 'EG', 'SY', 'LB', 'DJ', 'CY', 'ET', 'SD', 'AM']
```
