### PR TITLE
MST-418 retire program_enrollments external_user_key with hashed value

### DIFF
--- a/lms/djangoapps/program_enrollments/models.py
+++ b/lms/djangoapps/program_enrollments/models.py
@@ -3,7 +3,7 @@
 Django model specifications for the Program Enrollments API
 """
 
-
+from django.conf import settings
 from django.contrib.auth.models import User
 from django.core.exceptions import ValidationError
 from django.db import models
@@ -11,6 +11,7 @@ from django.utils.translation import ugettext_lazy as _
 from model_utils.models import TimeStampedModel
 from opaque_keys.edx.django.models import CourseKeyField
 from simple_history.models import HistoricalRecords
+from user_util import user_util
 
 from student.models import CourseEnrollment
 
@@ -70,9 +71,14 @@ class ProgramEnrollment(TimeStampedModel):
             return False
 
         for enrollment in enrollments:
-            enrollment.historical_records.update(external_user_key=None)
+            retired_external_key = user_util.get_retired_external_key(
+                enrollment.external_user_key,
+                settings.RETIRED_USER_SALTS,
+            )
+            enrollment.historical_records.update(external_user_key=retired_external_key)
+            enrollment.external_user_key = retired_external_key
+            enrollment.save()
 
-        enrollments.update(external_user_key=None)
         return True
 
     def __str__(self):

--- a/lms/djangoapps/program_enrollments/tests/test_models.py
+++ b/lms/djangoapps/program_enrollments/tests/test_models.py
@@ -100,11 +100,19 @@ class ProgramEnrollmentModelTests(TestCase):
         self.enrollment.refresh_from_db()
 
         # Ensure those values are retired
-        self.assertEqual(self.enrollment.external_user_key, None)
+        self.assertTrue(
+            self.enrollment.external_user_key.startswith(
+                'retired_external_key'
+            )
+        )
 
         self.assertTrue(self.enrollment.historical_records.all())
         for record in self.enrollment.historical_records.all():
-            self.assertEqual(record.external_user_key, None)
+            self.assertTrue(
+                record.external_user_key.startswith(
+                    'retired_external_key'
+                )
+            )
 
 
 @ddt.ddt

--- a/lms/djangoapps/program_enrollments/tests/test_signals.py
+++ b/lms/djangoapps/program_enrollments/tests/test_signals.py
@@ -34,14 +34,14 @@ class ProgramEnrollmentRetireSignalTests(ModuleStoreTestCase):
     Test the _listen_for_lms_retire signal
     """
 
-    def create_enrollment_and_history(self, user=None):
+    def create_enrollment_and_history(self, user=None, external_user_key='defaultExternalKey'):
         """
         Create ProgramEnrollment and several History entries
         """
         if user:
-            enrollment = ProgramEnrollmentFactory(user=user)
+            enrollment = ProgramEnrollmentFactory(user=user, external_user_key=external_user_key)
         else:
-            enrollment = ProgramEnrollmentFactory()
+            enrollment = ProgramEnrollmentFactory(external_user_key=external_user_key)
         for status in ['pending', 'suspended', 'canceled', 'enrolled']:
             enrollment.status = status
             enrollment.save()
@@ -52,9 +52,11 @@ class ProgramEnrollmentRetireSignalTests(ModuleStoreTestCase):
         Assert that for the enrollment and all histories, external key is None
         """
         enrollment.refresh_from_db()
-        self.assertIsNone(enrollment.external_user_key)
+        self.assertIsNotNone(enrollment.external_user_key)
+        self.assertTrue(enrollment.external_user_key.startswith('retired_external_key'))
         for history_record in enrollment.historical_records.all():
-            self.assertIsNone(history_record.external_user_key)
+            self.assertIsNotNone(history_record.external_user_key)
+            self.assertTrue(history_record.external_user_key.startswith('retired_external_key'))
 
     def test_retire_enrollment(self):
         """

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -233,7 +233,7 @@ ua-parser==0.10.0         # via django-cookies-samesite
 unicodecsv==0.14.1        # via -r requirements/edx/base.in, edx-enterprise
 uritemplate==3.0.1        # via coreapi, drf-yasg
 urllib3==1.25.10          # via -r requirements/edx/paver.txt, elasticsearch, geoip2, requests
-user-util==0.2            # via -r requirements/edx/base.in
+user-util==0.3.1          # via -r requirements/edx/base.in
 voluptuous==0.11.7        # via ora2
 watchdog==0.10.3          # via -r requirements/edx/paver.txt
 web-fragments==0.3.2      # via -r requirements/edx/base.in, crowdsourcehinter-xblock, staff-graded-xblock, xblock, xblock-utils

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -305,7 +305,7 @@ unicodecsv==0.14.1        # via -r requirements/edx/testing.txt, edx-enterprise
 unidiff==0.6.0            # via -r requirements/edx/testing.txt, coverage-pytest-plugin
 uritemplate==3.0.1        # via -r requirements/edx/testing.txt, coreapi, drf-yasg
 urllib3==1.25.10          # via -r requirements/edx/testing.txt, elasticsearch, geoip2, requests, selenium, transifex-client
-user-util==0.2            # via -r requirements/edx/testing.txt
+user-util==0.3.1          # via -r requirements/edx/testing.txt
 virtualenv==20.0.31       # via -r requirements/edx/testing.txt, tox
 voluptuous==0.11.7        # via -r requirements/edx/testing.txt, ora2
 vulture==1.6              # via -c requirements/edx/../constraints.txt, -r requirements/edx/development.in

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -284,7 +284,7 @@ unicodecsv==0.14.1        # via -r requirements/edx/base.txt, edx-enterprise
 unidiff==0.6.0            # via -r requirements/edx/testing.in, coverage-pytest-plugin
 uritemplate==3.0.1        # via -r requirements/edx/base.txt, coreapi, drf-yasg
 urllib3==1.25.10          # via -r requirements/edx/base.txt, elasticsearch, geoip2, requests, selenium, transifex-client
-user-util==0.2            # via -r requirements/edx/base.txt
+user-util==0.3.1          # via -r requirements/edx/base.txt
 virtualenv==20.0.31       # via tox
 voluptuous==0.11.7        # via -r requirements/edx/base.txt, ora2
 watchdog==0.10.3          # via -r requirements/edx/base.txt


### PR DESCRIPTION
Currently, the external_user_key value is set to None. This causes download error on registrar.

This change will update the value of the external_user_key to a retired value with hash, instead of setting it to None.

We are to expose the retired value to partners.

@edx/masters-devs-cosmonauts Please review.