### PR TITLE
Tracking logs: Treat null context same as missing context

### DIFF
--- a/common/djangoapps/track/views/segmentio.py
+++ b/common/djangoapps/track/views/segmentio.py
@@ -127,7 +127,7 @@ def track_segmentio_event(request):  # pylint: disable=too-many-statements
 
     # Start with the context provided by Segment in the "client" field if it exists
     # We should tightly control which fields actually get included in the event emitted.
-    segment_context = full_segment_event.get('context', {})
+    segment_context = full_segment_event.get('context') or {}
 
     # Build up the event context by parsing fields out of the event received from Segment
     context = {}


### PR DESCRIPTION
Should resolve the AttributeError on the line:
```python
   library_name = segment_context.get('library', ...
```
that occurs when `full_segment_event['context'] == None`.

This error is currently the #1 in LMS and is obscuring other errors.
_________________________________

I *think* this was the cause of the alert this morning; my NewRelic-fu isn't developed enough to be sure though.

I don't know whether this is the right fix. Maybe it's good to have that AttributeError yelling at us until we can find out why we are getting segment events with `None` as their context. I'm posting in hope of soliciting feedback.

~What do you think @stvstnfrd ?~

____________________________________

Update: This can't be the cause of the alert this morning, because it's owned by `platform-data-de`, and we still see the error spike even when filtering that DE's endpoints out of the query.