### PR TITLE
Fix a flaky test by freezing time in the right spot.

### DIFF
--- a/openedx/core/djangoapps/user_authn/views/tests/test_reset_password.py
+++ b/openedx/core/djangoapps/user_authn/views/tests/test_reset_password.py
@@ -191,14 +191,14 @@ class ResetPasswordTests(EventTestMixin, CacheIsolationTestCase):
         self.request_password_reset(200)
         # now reset the time to 1 min from now in future and change the email and
         # verify that it will allow another request from same IP
-        for status in [200, 403]:
-            reset_time = datetime.now(UTC) + timedelta(seconds=61)
-            with freeze_time(reset_time):
+        reset_time = datetime.now(UTC) + timedelta(seconds=61)
+        with freeze_time(reset_time):
+            for status in [200, 403]:
                 self.request_password_reset(status)
 
-        # Even changing the IP will not allow more than two requests for same email.
-        new_ip = "8.8.8.8"
-        self.request_password_reset(403, new_ip=new_ip)
+            # Even changing the IP will not allow more than two requests for same email.
+            new_ip = "8.8.8.8"
+            self.request_password_reset(403, new_ip=new_ip)
 
         cache.clear()
 


### PR DESCRIPTION
The test was only freezing time for the first two calls to password reset
which meant that sometimes the last call to reset password was far enough
in the future to not be affected by the rate limiting.

We move the freeze_time context manager to outside of all the password
reset calls to make things more reliable.