### PR TITLE
Add some tracing to the CourseListView endpoint

### DIFF
--- a/lms/djangoapps/course_api/api.py
+++ b/lms/djangoapps/course_api/api.py
@@ -3,6 +3,7 @@ Course API
 """
 import logging
 
+from edx_django_utils.monitoring import function_trace
 from edx_when.api import get_dates_for_course
 from django.conf import settings
 from django.contrib.auth.models import AnonymousUser, User
@@ -139,6 +140,7 @@ def list_courses(request, username, org=None, filter_=None, search_term=None):
     return course_qs
 
 
+@function_trace('list_course_keys')
 def list_course_keys(request, username, role):
     """
     Yield all available CourseKeys for the user having the given role.

--- a/lms/djangoapps/course_api/serializers.py
+++ b/lms/djangoapps/course_api/serializers.py
@@ -3,6 +3,7 @@ Course API Serializers.  Representing course catalog data
 """
 
 
+from edx_django_utils.monitoring import function_trace
 import six.moves.urllib.error
 import six.moves.urllib.parse
 import six.moves.urllib.request
@@ -127,5 +128,7 @@ class CourseKeySerializer(serializers.BaseSerializer):  # pylint:disable=abstrac
     """
     Serializer that takes a CourseKey and serializes it to a string course_id.
     """
+
+    @function_trace('to_representation')
     def to_representation(self, instance):
         return str(instance)

--- a/lms/djangoapps/course_api/views.py
+++ b/lms/djangoapps/course_api/views.py
@@ -5,6 +5,7 @@ Course API Views
 
 from django.core.exceptions import ValidationError
 from django.core.paginator import InvalidPage
+from edx_django_utils.monitoring import function_trace
 from edx_rest_framework_extensions.paginators import NamespacedPageNumberPagination
 from rest_framework.generics import ListAPIView, RetrieveAPIView
 from rest_framework.throttling import UserRateThrottle
@@ -172,6 +173,7 @@ class LazyPageNumberPagination(NamespacedPageNumberPagination):
 
     """
 
+    @function_trace('get_paginated_response')
     def get_paginated_response(self, data):
         # Clear the cached property values to recalculate the estimated count from the LazySequence
         del self.page.paginator.__dict__['count']
@@ -365,6 +367,7 @@ class CourseIdListView(DeveloperErrorViewMixin, ListAPIView):
     serializer_class = CourseKeySerializer
     throttle_classes = (CourseIdListUserThrottle,)
 
+    @function_trace('get_queryset')
     def get_queryset(self):
         """
         Returns CourseKeys for courses which the user has the provided role.


### PR DESCRIPTION
This is a low-effort attempt to understand what's taking this View so long to respond to GET requests.  It has been shown to take up to 126 seconds (see https://openedx.atlassian.net/browse/LEARNER-5527)!  In our case, insights calls it on behalf of users that belong to course teams, and for some of them it even takes 46 seconds according to New Relic traces.  NR doesn't trace as deep as we'd like by default, so this PR adds specific functions to trace.