### PR TITLE
fix and test get_enterprise_learner_portal_enabled_message()

### DIFF
--- a/openedx/features/enterprise_support/api.py
+++ b/openedx/features/enterprise_support/api.py
@@ -53,7 +53,6 @@ class EnterpriseApiException(Exception):
     """
     Exception for errors while communicating with the Enterprise service API.
     """
-    pass
 
 
 class ConsentApiClient(object):
@@ -130,7 +129,6 @@ class ConsentApiServiceClient(EnterpriseServiceClientMixin, ConsentApiClient):
     """
     Class for producing an Enterprise Consent API client with service user.
     """
-    pass
 
 
 class EnterpriseApiClient(object):
@@ -662,10 +660,11 @@ def get_enterprise_learner_portal_enabled_message(request):
         add_enterprise_customer_to_session(request, enterprise_customer)
         if enterprise_customer:
             cache_enterprise(enterprise_customer)
-        else:
-            return None
 
-    if enterprise_customer['enable_learner_portal']:
+    if not enterprise_customer:
+        return None
+
+    if enterprise_customer.get('enable_learner_portal', False):
         learner_portal_url = settings.ENTERPRISE_LEARNER_PORTAL_BASE_URL + '/' + enterprise_customer['slug']
         return Text(_(
             "Your organization {bold_start}{enterprise_customer_name}{bold_end} uses a custom dashboard for learning. "


### PR DESCRIPTION
Ensure that get_enterprise_learner_portal_enabled_message() returns None when there is no associated enterprise customer for the given request.  Add unit tests for this function.