### PR TITLE
[SE-3248] Add progress_video event to video player

### DIFF
--- a/common/lib/xmodule/xmodule/js/spec/video/completion_spec.js
+++ b/common/lib/xmodule/xmodule/js/spec/video/completion_spec.js
@@ -1,7 +1,7 @@
 (function() {
     'use strict';
     describe('VideoPlayer completion', function() {
-        var state, oldOTBD, completionAjaxCall;
+        var state, oldOTBD, completionAjaxCall, time;
 
         beforeEach(function() {
             oldOTBD = window.onTouchBasedDevice;
@@ -66,6 +66,36 @@
             spyOn(state.completionHandler, 'markCompletion').and.callThrough();
             state.el.trigger('ended');
             expect(state.completionHandler.markCompletion).toHaveBeenCalled();
+        });
+
+        it('triggers progress', function(done) {
+            var duration = 0;
+            jasmine.waitUntil(function() {
+                duration = state.videoPlayer.duration();
+                return duration > 0;
+            }).then(function() {
+                spyOn(state.completionHandler, 'computeProgress').and.callThrough();
+                spyOn(state.completionHandler, 'triggerProgress').and.callThrough();
+                // 4 percents should be equivalent to 0
+                time = 4 * duration / 100;
+                state.el.trigger('timeupdate', time);
+                expect(state.completionHandler.computeProgress).toHaveBeenCalled();
+                expect(state.completionHandler.triggerProgress).toHaveBeenCalled();
+                state.completionHandler.computeProgress.calls.reset();
+                state.completionHandler.triggerProgress.calls.reset();
+                // 8 percents should be equivalent to 5
+                time = 8 * duration / 100;
+                state.el.trigger('timeupdate', time);
+                expect(state.completionHandler.computeProgress).toHaveBeenCalled();
+                expect(state.completionHandler.triggerProgress).toHaveBeenCalled();
+                state.completionHandler.computeProgress.calls.reset();
+                state.completionHandler.triggerProgress.calls.reset();
+                // Another timeupdate in the same 5-range should not trigger "triggerProgress"
+                time = 9 * duration / 100;
+                state.el.trigger('timeupdate', time);
+                expect(state.completionHandler.computeProgress).toHaveBeenCalled();
+                expect(state.completionHandler.triggerProgress).not.toHaveBeenCalled();
+            }).always(done);
         });
     });
 }).call(this);

--- a/common/lib/xmodule/xmodule/js/spec/video/video_events_plugin_spec.js
+++ b/common/lib/xmodule/xmodule/js/spec/video/video_events_plugin_spec.js
@@ -59,6 +59,16 @@ import '../helper.js'
             expect(state.videoEventsPlugin.emitPlayVideoEvent).toBeTruthy();
         });
 
+        it('can emit "progress_video" event', function() {
+            state.el.trigger('progress', [10]);
+            expect(Logger.log).toHaveBeenCalledWith('progress_video', {
+                id: 'id',
+                code: this.code,
+                percentage: 10,
+                duration: this.duration
+            });
+        });
+
         it('can emit "speed_change_video" event', function() {
             state.el.trigger('speedchange', ['2.0', '1.0']);
             expect(Logger.log).toHaveBeenCalledWith('speed_change_video', {
@@ -204,6 +214,7 @@ import '../helper.js'
                 skip: plugin.onSkip,
                 speedchange: plugin.onSpeedChange,
                 autoadvancechange: plugin.onAutoAdvanceChange,
+                progress: plugin.onProgress,
                 'language_menu:show': plugin.onShowLanguageMenu,
                 'language_menu:hide': plugin.onHideLanguageMenu,
                 'transcript:show': plugin.onShowTranscript,

--- a/common/lib/xmodule/xmodule/js/src/video/09_completion.js
+++ b/common/lib/xmodule/xmodule/js/src/video/09_completion.js
@@ -48,6 +48,7 @@
                 this.startTime = this.state.config.startTime;
                 this.endTime = this.state.config.endTime;
                 this.isEnabled = this.state.config.completionEnabled;
+                this.isProgressTrackingEnabled = this.state.config.progressTrackingEnabled;
                 if (this.endTime) {
                     this.completeAfterTime = this.calculateCompleteAfterTime(this.startTime, this.endTime);
                 }
@@ -113,7 +114,7 @@
                 }
 
                 // Duration may not be available at initialization time
-                if (duration) {
+                if (duration && this.isProgressTrackingEnabled) {
                     this.computeProgress(currentTime, duration);
                 }
 

--- a/common/lib/xmodule/xmodule/js/src/video/09_events_plugin.js
+++ b/common/lib/xmodule/xmodule/js/src/video/09_events_plugin.js
@@ -15,7 +15,8 @@
                 return new EventsPlugin(state, i18n, options);
             }
 
-            _.bindAll(this, 'onReady', 'onPlay', 'onPause', 'onEnded', 'onSeek',
+            // eslint-disable-next-line no-undef
+            _.bindAll(this, 'onReady', 'onPlay', 'onPause', 'onEnded', 'onSeek', 'onProgress',
             'onSpeedChange', 'onAutoAdvanceChange', 'onShowLanguageMenu', 'onHideLanguageMenu',
             'onSkip', 'onShowTranscript', 'onHideTranscript', 'onShowCaptions', 'onHideCaptions',
             'destroy');
@@ -46,6 +47,7 @@
                     skip: this.onSkip,
                     speedchange: this.onSpeedChange,
                     autoadvancechange: this.onAutoAdvanceChange,
+                    progress: this.onProgress,
                     'language_menu:show': this.onShowLanguageMenu,
                     'language_menu:hide': this.onHideLanguageMenu,
                     'transcript:show': this.onShowTranscript,
@@ -134,6 +136,10 @@
 
             onHideCaptions: function() {
                 this.log('edx.video.closed_captions.hidden', {current_time: this.getCurrentTime()});
+            },
+
+            onProgress: function(event, percentage) {
+                this.log('progress_video', {percentage: percentage});
             },
 
             getCurrentTime: function() {

--- a/common/lib/xmodule/xmodule/video_module/video_module.py
+++ b/common/lib/xmodule/xmodule/video_module/video_module.py
@@ -375,8 +375,10 @@ class VideoBlock(
         completion_service = self.runtime.service(self, 'completion')
         if completion_service:
             completion_enabled = completion_service.completion_tracking_enabled()
+            progress_tracking_enabled = completion_service.progress_tracking_enabled()
         else:
             completion_enabled = False
+            progress_tracking_enabled = False
 
         # This is the setting that controls whether the autoadvance button will be visible, not whether the
         # video will autoadvance or not.
@@ -418,6 +420,7 @@ class VideoBlock(
             'poster': poster,
             'prioritizeHls': self.prioritize_hls(self.youtube_streams, sources),
             'publishCompletionUrl': self.runtime.handler_url(self, 'publish_completion', '').rstrip('?'),
+            'progressTrackingEnabled': progress_tracking_enabled,
             # This is the server's guess at whether youtube is available for
             # this user, based on what was recorded the last time we saw the
             # user, and defaulting to True.


### PR DESCRIPTION
This pull request is about adding new events to video player about watching progression.

Related pull request to add the new flag: https://github.com/edx/completion/pull/141

**Dependencies**: None

**Screenshots**: None

**Sandbox URL**: 

- [LMS](https://pr25038.sandbox.opencraft.hosting/)
- [Studio](https://studio.pr25038.sandbox.opencraft.hosting/)

*Sandbox is being provisioned.*

**Merge deadline**: None

**Testing instructions**:

The `completion.enable_completion_tracking` should be enabled.
Should use this `edx-completion` branch: https://github.com/edx/completion/pull/141
And then enable the `completion. enable_progress_tracking_events` switch.

1. Create a video unit
2. Enroll into the course
3. Open the web inspector (network panel)
4. Watch the video
5. Check that events are being fired every decades

**Reviewers**
- [x] @nizarmah 
- [ ] edX reviewer[s] TBD