### PR TITLE
Prevent an unbound local variable exception in enterprise_support.api…

### DIFF
--- a/openedx/features/enterprise_support/api.py
+++ b/openedx/features/enterprise_support/api.py
@@ -471,6 +471,7 @@ def enterprise_customer_uuid_for_request(request):
     if enterprise_customer_uuid is _CACHE_MISS and request.user.is_authenticated:
         # If there's no way to get an Enterprise UUID for the request, check to see
         # if there's already an Enterprise attached to the requesting user on the backend.
+        enterprise_customer = None
         learner_data = get_enterprise_learner_data_from_db(request.user)
         if learner_data:
             enterprise_customer = learner_data[0]['enterprise_customer']

--- a/openedx/features/enterprise_support/tests/factories.py
+++ b/openedx/features/enterprise_support/tests/factories.py
@@ -9,7 +9,11 @@ import factory
 from faker import Factory as FakerFactory
 
 from enterprise.models import (
-    EnterpriseCourseEnrollment, EnterpriseCustomer, EnterpriseCustomerBrandingConfiguration, EnterpriseCustomerUser,
+    EnterpriseCourseEnrollment,
+    EnterpriseCustomer,
+    EnterpriseCustomerBrandingConfiguration,
+    EnterpriseCustomerIdentityProvider,
+    EnterpriseCustomerUser,
 )
 from openedx.core.djangoapps.site_configuration.tests.factories import SiteFactory
 
@@ -91,7 +95,23 @@ class EnterpriseCustomerBrandingConfigurationFactory(factory.django.DjangoModelF
 
         model = EnterpriseCustomerBrandingConfiguration
 
-    logo = FAKER.image_url()
-    primary_color = FAKER.color()
-    secondary_color = FAKER.color()
-    tertiary_color = FAKER.color()
+    logo = FAKER.image_url()  # pylint: disable=no-member
+    primary_color = FAKER.color()  # pylint: disable=no-member
+    secondary_color = FAKER.color()  # pylint: disable=no-member
+    tertiary_color = FAKER.color()  # pylint: disable=no-member
+
+
+class EnterpriseCustomerIdentityProviderFactory(factory.django.DjangoModelFactory):
+    """
+    EnterpriseCustomerIdentityProvider factory.
+    """
+
+    class Meta(object):
+        """
+        Meta for EnterpriseCustomerIdentityProviderFactory.
+        """
+
+        model = EnterpriseCustomerIdentityProvider
+
+    enterprise_customer = factory.SubFactory(EnterpriseCustomerFactory)
+    provider_id = factory.LazyAttribute(lambda x: FAKER.slug())  # pylint: disable=no-member


### PR DESCRIPTION
….  Add more unit tests for same.

Meant to clean up an error that arose from the implementation of https://openedx.atlassian.net/browse/ENT-3367