### PR TITLE
Add more monitoring to the CourseIdListView

### DIFF
--- a/lms/djangoapps/course_api/serializers.py
+++ b/lms/djangoapps/course_api/serializers.py
@@ -3,7 +3,7 @@ Course API Serializers.  Representing course catalog data
 """
 
 
-from edx_django_utils.monitoring import function_trace
+from edx_django_utils import monitoring as monitoring_utils
 import six.moves.urllib.error
 import six.moves.urllib.parse
 import six.moves.urllib.request
@@ -129,6 +129,11 @@ class CourseKeySerializer(serializers.BaseSerializer):  # pylint:disable=abstrac
     Serializer that takes a CourseKey and serializes it to a string course_id.
     """
 
-    @function_trace('to_representation')
+    @monitoring_utils.function_trace('course_key_serializer_to_representation')
     def to_representation(self, instance):
+        # The function trace should be counting calls to this function, but I
+        # couldn't find it when I looked in any of the NR transaction traces,
+        # so I'm manually counting them using a custom metric:
+        monitoring_utils.increment('course_key_serializer_to_representation_call_count')
+
         return str(instance)

--- a/lms/djangoapps/course_api/views.py
+++ b/lms/djangoapps/course_api/views.py
@@ -381,3 +381,45 @@ class CourseIdListView(DeveloperErrorViewMixin, ListAPIView):
             form.cleaned_data['username'],
             role=form.cleaned_data['role'],
         )
+
+    @function_trace('paginate_queryset')
+    def paginate_queryset(self, *args, **kwargs):
+        """
+        No-op passthrough function purely for function-tracing (monitoring)
+        purposes.
+
+        This should be called once per GET request.
+        """
+        return super(CourseIdListView, self).paginate_queryset(*args, **kwargs)
+
+    @function_trace('get_paginated_response')
+    def get_paginated_response(self, *args, **kwargs):
+        """
+        No-op passthrough function purely for function-tracing (monitoring)
+        purposes.
+
+        This should be called only when the response is paginated. Two pages
+        means two GET requests and one function call per request. Otherwise, if
+        the whole response fits in one page, this function never gets called.
+        """
+        return super(CourseIdListView, self).get_paginated_response(*args, **kwargs)
+
+    @function_trace('filter_queryset')
+    def filter_queryset(self, *args, **kwargs):
+        """
+        No-op passthrough function purely for function-tracing (monitoring)
+        purposes.
+
+        This should be called once per GET request.
+        """
+        return super(CourseIdListView, self).filter_queryset(*args, **kwargs)
+
+    @function_trace('get_serializer')
+    def get_serializer(self, *args, **kwargs):
+        """
+        No-op passthrough function purely for function-tracing (monitoring)
+        purposes.
+
+        This should be called once per GET request.
+        """
+        return super(CourseIdListView, self).get_serializer(*args, **kwargs)


### PR DESCRIPTION
1. I added a manual counter to the to_representation() call so that I can actually verify that the response time is proportional to the count of returned courses.
2. I added traces to ALL other functions called by CourseIdListView.get by creating passthrough functions for each one and decorating them each with function_trace().