### PR TITLE
[REV-1508] Add functionality to limit timed exam access behind waffle flag

### DIFF
--- a/lms/templates/seq_module.html
+++ b/lms/templates/seq_module.html
@@ -21,6 +21,7 @@
     </div>
   % endif
   % endif
+  % if not gated_sequence_fragment:
   <div class="sequence-nav">
     <button class="sequence-nav-button button-previous">
       <span class="icon fa fa-chevron-prev" aria-hidden="true"></span>
@@ -98,9 +99,15 @@
       </ol>
     </nav>
   </div>
+  % endif
   % if not exclude_units:
   % if gated_content['gated']:
     <%include file="_gated_content.html" args="prereq_url=gated_content['prereq_url'], prereq_section_name=gated_content['prereq_section_name'], gated_section_name=gated_content['gated_section_name']"/>
+  % elif gated_sequence_fragment:
+    <h2 class="hd hd-2 unit-title">
+        ${sequence_name}<span class="sr">${_("Content Locked")}</span>
+    </h2>
+    ${gated_sequence_fragment | n, decode.utf8}
   % else:
   <div class="sr-is-focusable" tabindex="-1"></div>
 


### PR DESCRIPTION
## What did we do?
Re-apply https://github.com/edx/edx-platform/pull/24214, but behind a waffle flag. The change gates timed exams for audit learners.

JIRA ticket: https://openedx.atlassian.net/browse/REV-1508

## Why are we doing this
We would like to limit access to timed exams to verified learners. However, some of the instructors would like to make their content free for all users, including graded content/timed exams (hence the Feature-Based Enrollment "FBE" exemption). As a result, we will be rolling the gated timed exams functionality out behind a waffle flag now, add the FBE exemption when we figure out how, and gradually turn the waffle flag on for everyone.

## Additional Notes
The code is adding the waffle flag check around just one part of the code, which is just setting the `gated_sequence_fragment` flag. By default, the `gated_sequence_fragment` flag is falsey and thus won't ever be triggered. Since that flag is defaulted to falsey and cannot be changed unless the waffle flag is on, there wasn't a need to add a waffle flag check to each one of the places that also checked for the `gated_sequence_fragment` flag (even though the waffle flag should be added for technical completeness). Happy to hear arguments for adding the other checks, though I may ask for assistance in completing the unit tests for those cases :) 