### PR TITLE
ARCHBOM-1495: replace deprecated RequestMetricsMiddleware

### DIFF
--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -725,7 +725,7 @@ MIDDLEWARE = [
     'edx_django_utils.cache.middleware.TieredCacheMiddleware',
 
     # Outputs monitoring metrics for a request.
-    'edx_rest_framework_extensions.middleware.RequestMetricsMiddleware',
+    'edx_rest_framework_extensions.middleware.RequestCustomAttributesMiddleware',
 
     'edx_rest_framework_extensions.auth.jwt.middleware.EnsureJWTAuthSettingsMiddleware',
 

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -1764,7 +1764,7 @@ MIDDLEWARE = [
     'edx_django_utils.cache.middleware.TieredCacheMiddleware',
 
     # Outputs monitoring metrics for a request.
-    'edx_rest_framework_extensions.middleware.RequestMetricsMiddleware',
+    'edx_rest_framework_extensions.middleware.RequestCustomAttributesMiddleware',
 
     'edx_rest_framework_extensions.auth.jwt.middleware.EnsureJWTAuthSettingsMiddleware',
 


### PR DESCRIPTION
Replace deprecated RequestMetricsMiddleware with
renamed version RequestCustomAttributesMiddleware.

ARCHBOM-1495

Note: This will require edx-platform to have edx-drf-extensions>=6.2.0 to pass.