### PR TITLE
Use fully-qualified edxnotes app name when checking if installed

### DIFF
--- a/common/lib/xmodule/xmodule/edxnotes_utils.py
+++ b/common/lib/xmodule/xmodule/edxnotes_utils.py
@@ -10,8 +10,8 @@ def edxnotes(cls):
     """
     Conditional decorator that loads edxnotes only when they exist.
     """
-    if "edxnotes" in sys.modules:
-        from edxnotes.decorators import edxnotes as notes
+    if "lms.djangoapps.edxnotes" in sys.modules:
+        from lms.djangoapps.edxnotes.decorators import edxnotes as notes
         return notes(cls)
     else:
         return cls


### PR DESCRIPTION
The edx-notes-api experienced a [drop in traffic early yesterday afternoon](https://files.derf.us/tycho-2020-09-24-14-14-25-5M8GcdNh.png) that indicates that the notes client on LMS is broken. Observing courseware in production and stage confirms this.

We think this may be related to https://github.com/edx/edx-platform/pull/24616

This is one attempt at fixing that.

The more heavy-handed version of this fix is here: https://github.com/edx/edx-platform/pull/25087