### PR TITLE
add json validation step to advanced settings save

### DIFF
--- a/cms/static/js/views/settings/advanced.js
+++ b/cms/static/js/views/settings/advanced.js
@@ -120,8 +120,8 @@ define(['js/views/validation',
                         JSON.parse(stringValue);
                     } catch (e) {
                         jsonValidationErrors.push({
-                            key,
-                            message: "Incorrectly formatted JSON",
+                            key: key,
+                            message: 'Incorrectly formatted JSON',
                             model: {display_name: displayName}
                         });
                     }
@@ -162,7 +162,7 @@ define(['js/views/validation',
                 var self = this;
                 err_modal = new ValidationErrorModal();
                 err_modal.setContent(content);
-                err_modal.setResetCallback(function() {self.revertView()});
+                err_modal.setResetCallback(function() { self.revertView(); });
                 err_modal.show();
             },
             revertView: function() {

--- a/cms/static/js/views/settings/advanced.js
+++ b/cms/static/js/views/settings/advanced.js
@@ -147,23 +147,24 @@ define(['js/views/validation',
                     },
                     silent: true,
                     error: function(model, response, options) {
-                        var json_response;
+                        var jsonResponse;
 
                 /* Check that the server came back with a bad request error*/
                         if (response.status === 400) {
-                            json_response = $.parseJSON(response.responseText);
-                            self.showErrorModal(json_response);
+                            jsonResponse = $.parseJSON(response.responseText);
+                            self.showErrorModal(jsonResponse);
                         }
                     }
                 });
             },
             showErrorModal: function(content) {
                 /* initialize and show validation error modal */
-                var self = this;
-                err_modal = new ValidationErrorModal();
-                err_modal.setContent(content);
-                err_modal.setResetCallback(function() { self.revertView(); });
-                err_modal.show();
+                var self, errModal;
+                self = this;
+                errModal = new ValidationErrorModal();
+                errModal.setContent(content);
+                errModal.setResetCallback(function() { self.revertView(); });
+                errModal.show();
             },
             revertView: function() {
                 var self = this;


### PR DESCRIPTION
When the save button is clicked in the advanced settings page, before making the request to save the values, check if the input values are valid JSON, and if they aren't, display a validation error modal before saving.

We need to check the actual codemirror display values, since the textinputs are only used for setting up the codemirror, and the validation on line 104 prevents the advanced settings model from having any invalid json values.

![Error message](https://user-images.githubusercontent.com/1639231/94194710-0f0cfd80-fe80-11ea-8a45-3e1952a28909.png)

https://openedx.atlassian.net/browse/EDUCATOR-5349
@edx/masters-devs-gta 