### PR TITLE
Don't use "/logout" as the next-url for login

### DIFF
--- a/lms/templates/main.html
+++ b/lms/templates/main.html
@@ -217,5 +217,5 @@ from pipeline_mako import render_require_js_path_overrides
 <%def name="login_query()">${
   u"?next={next}".format(
     next=urlquote_plus(login_redirect_url if login_redirect_url else request.path)
-  ) if (login_redirect_url or request) else ""
+  ) if (login_redirect_url or (request and not request.path.startswith("/logout"))) else ""
 }</%def>


### PR DESCRIPTION
If /logout is the current page, redirecting back there after logging in
makes the whole exercise pointless.