### PR TITLE
Fully qualify remaining edxnotes imports

### DIFF
--- a/common/lib/xmodule/xmodule/edxnotes_utils.py
+++ b/common/lib/xmodule/xmodule/edxnotes_utils.py
@@ -10,8 +10,8 @@ def edxnotes(cls):
     """
     Conditional decorator that loads edxnotes only when they exist.
     """
-    if "edxnotes" in sys.modules:
-        from edxnotes.decorators import edxnotes as notes
+    if "lms.djangoapps.edxnotes" in sys.modules:
+        from lms.djangoapps.edxnotes.decorators import edxnotes as notes
         return notes(cls)
     else:
         return cls

--- a/lms/djangoapps/courseware/testutils.py
+++ b/lms/djangoapps/courseware/testutils.py
@@ -155,9 +155,9 @@ class RenderXBlockTestMixin(six.with_metaclass(ABCMeta, object)):
         return response
 
     @ddt.data(
-        ('vertical_block', ModuleStoreEnum.Type.mongo, 12),
+        ('vertical_block', ModuleStoreEnum.Type.mongo, 13),
         ('vertical_block', ModuleStoreEnum.Type.split, 6),
-        ('html_block', ModuleStoreEnum.Type.mongo, 13),
+        ('html_block', ModuleStoreEnum.Type.mongo, 14),
         ('html_block', ModuleStoreEnum.Type.split, 6),
     )
     @ddt.unpack
@@ -214,7 +214,7 @@ class RenderXBlockTestMixin(six.with_metaclass(ABCMeta, object)):
         Helper method used by test_success_enrolled_staff because one test
         class using this mixin has an increased number of mongo (only) queries.
         """
-        return 8
+        return 9
 
     def test_success_unenrolled_staff(self):
         self.setup_course()

--- a/lms/djangoapps/courseware/views/views.py
+++ b/lms/djangoapps/courseware/views/views.py
@@ -50,7 +50,7 @@ from web_fragments.fragment import Fragment
 import survey.views
 from course_modes.models import CourseMode, get_course_prices
 from edxmako.shortcuts import marketing_link, render_to_response, render_to_string
-from edxnotes.helpers import is_feature_enabled
+from lms.djangoapps.edxnotes.helpers import is_feature_enabled
 from lms.djangoapps.ccx.custom_exception import CCXLocatorValidationException
 from lms.djangoapps.certificates import api as certs_api
 from lms.djangoapps.certificates.models import CertificateStatuses

--- a/lms/djangoapps/edxnotes/api_urls.py
+++ b/lms/djangoapps/edxnotes/api_urls.py
@@ -5,7 +5,7 @@ API URLs for EdxNotes
 
 from django.conf.urls import url
 
-from edxnotes import views
+from lms.djangoapps.edxnotes import views
 
 urlpatterns = [
     url(r"^retire_user/$", views.RetireUserView.as_view(), name="edxnotes_retire_user"),

--- a/lms/djangoapps/edxnotes/helpers.py
+++ b/lms/djangoapps/edxnotes/helpers.py
@@ -23,8 +23,8 @@ from requests.exceptions import RequestException
 
 from lms.djangoapps.courseware.access import has_access
 from lms.djangoapps.courseware.courses import get_current_child
-from edxnotes.exceptions import EdxNotesParseError, EdxNotesServiceUnavailable
-from edxnotes.plugins import EdxNotesTab
+from lms.djangoapps.edxnotes.exceptions import EdxNotesParseError, EdxNotesServiceUnavailable
+from lms.djangoapps.edxnotes.plugins import EdxNotesTab
 from lms.lib.utils import get_parent_unit
 from openedx.core.djangoapps.oauth_dispatch.jwt import create_jwt_for_user
 from openedx.core.djangolib.markup import Text

--- a/lms/djangoapps/edxnotes/views.py
+++ b/lms/djangoapps/edxnotes/views.py
@@ -22,8 +22,8 @@ from lms.djangoapps.courseware.courses import get_course_with_access
 from lms.djangoapps.courseware.model_data import FieldDataCache
 from lms.djangoapps.courseware.module_render import get_module_for_descriptor
 from edxmako.shortcuts import render_to_response
-from edxnotes.exceptions import EdxNotesParseError, EdxNotesServiceUnavailable
-from edxnotes.helpers import (
+from lms.djangoapps.edxnotes.exceptions import EdxNotesParseError, EdxNotesServiceUnavailable
+from lms.djangoapps.edxnotes.helpers import (
     DEFAULT_PAGE,
     DEFAULT_PAGE_SIZE,
     NoteJSONEncoder,

--- a/lms/djangoapps/lti_provider/tests/test_views.py
+++ b/lms/djangoapps/lti_provider/tests/test_views.py
@@ -241,4 +241,4 @@ class LtiLaunchTestRender(LtiTestMixin, RenderXBlockTestMixin, ModuleStoreTestCa
         #   (5)-(8) calls related to the inherited user_partitions field.
         #   (9) edx_notes descriptor call to get_course
         """
-        return 8
+        return 9

--- a/lms/templates/courseware/courseware.html
+++ b/lms/templates/courseware/courseware.html
@@ -10,7 +10,7 @@ from django.conf import settings
 from django.urls import reverse
 from django.utils.translation import ugettext as _
 
-from edxnotes.helpers import is_feature_enabled as is_edxnotes_enabled
+from lms.djangoapps.edxnotes.helpers import is_feature_enabled as is_edxnotes_enabled
 from openedx.core.djangolib.js_utils import js_escaped_string
 from openedx.core.djangolib.markup import HTML
 from openedx.features.course_experience import course_home_page_title, COURSE_OUTLINE_PAGE_FLAG

--- a/lms/templates/edxnotes/edxnotes.html
+++ b/lms/templates/edxnotes/edxnotes.html
@@ -4,7 +4,7 @@
 <%def name="online_help_token()"><% return "notes" %></%def>
 <%!
 from django.utils.translation import ugettext as _
-from edxnotes.helpers import NoteJSONEncoder
+from lms.djangoapps.edxnotes.helpers import NoteJSONEncoder
 from openedx.core.djangolib.markup import HTML, Text
 from openedx.core.djangolib.js_utils import dump_js_escaped_json, js_escaped_string
 %>

--- a/lms/urls.py
+++ b/lms/urls.py
@@ -601,14 +601,14 @@ urlpatterns += [
         r'^courses/{}/edxnotes/'.format(
             settings.COURSE_ID_PATTERN,
         ),
-        include('edxnotes.urls'),
+        include('lms.djangoapps.edxnotes.urls'),
         name='edxnotes_endpoints',
     ),
 
     # Student Notes API
     url(
         r'^api/edxnotes/v1/',
-        include('edxnotes.api_urls'),
+        include('lms.djangoapps.edxnotes.api_urls'),
     ),
 
     # Branding API

--- a/openedx/core/djangoapps/courseware_api/views.py
+++ b/openedx/core/djangoapps/courseware_api/views.py
@@ -20,7 +20,7 @@ from rest_framework.response import Response
 from rest_framework.views import APIView
 
 from course_modes.models import CourseMode
-from edxnotes.helpers import is_feature_enabled
+from lms.djangoapps.edxnotes.helpers import is_feature_enabled
 from lms.djangoapps.course_api.api import course_detail
 from lms.djangoapps.courseware.access import has_access
 from lms.djangoapps.courseware.access_response import (


### PR DESCRIPTION
The edx-notes-api experienced a [drop in traffic early yesterday afternoon](https://files.derf.us/tycho-2020-09-24-14-14-25-5M8GcdNh.png) that indicates that the notes client on LMS is broken. Observing courseware in production and stage confirms this.

We think this may be related to https://github.com/edx/edx-platform/pull/24616

This is another attempt at fixing that by fast-tracking some of the import cleanup work we need to do eventually anyway.

A subset of this change that targets only the lines we think are most likely causing the change is here: https://github.com/edx/edx-platform/pull/25084