### PR TITLE
Bypass calls to has_access() when listing courses

### DIFF
--- a/lms/djangoapps/course_api/api.py
+++ b/lms/djangoapps/course_api/api.py
@@ -188,8 +188,10 @@ def list_course_keys(request, username, role):
         filtered_course_keys = (
             CourseAccessRole.objects.filter(
                 user=user,
-                # Having the instructor role implies staff access. This fact was reverse-engineered from unit tests.
+                # Having the instructor role implies staff access.
                 role__in=['staff', 'instructor'],
+                # We need to check against CourseOverview so that we don't return any Libraries.
+                course_id__in=CourseOverview.objects.all(),
             )
             .exclude(course_id=CourseKeyField.Empty)
             .order_by('course_id')


### PR DESCRIPTION
When listing courses for which a user has "staff" level access, bypass
calls to has_access() and use a hopefully more performant and simpler
access pattern that uses only a single ORM query and far fewer LoC.

Caution: this short-circuit implementation does not handle org-level
access grants.