### PR TITLE
Fix EmailMarketingConfig name

### DIFF
--- a/lms/djangoapps/email_marketing/apps.py
+++ b/lms/djangoapps/email_marketing/apps.py
@@ -10,7 +10,7 @@ class EmailMarketingConfig(AppConfig):
     """
     Configuration class for the email_marketing Django application.
     """
-    name = 'email_marketing'
+    name = 'lms.djangoapps.email_marketing'
     verbose_name = "Email Marketing"
 
     def ready(self):


### PR DESCRIPTION
I faced an issue with native OpenEdX installation. Basically, Django fails to find migrations for `email_marketing` application because it has invalid `name`. All applications in `lms/djangoapps` have name in following format: `lms.djangoapps.<app_name>`.

It's fairly easy to check if your installation affected, just run following:
```sh
python manage.py lms showmigrations
```
You should see:
```
...
email_marketing
 (no migrations)
```
which is wrong and makes impossible to use devstack after installation.


With change from this PR, output should be:
```
...
 [ ] 0001_initial
 [ ] 0002_auto_20160623_1656
 [ ] 0003_auto_20160715_1145
 [ ] 0004_emailmarketingconfiguration_welcome_email_send_delay
 [ ] 0005_emailmarketingconfiguration_user_registration_cookie_timeout_delay
 [ ] 0006_auto_20170711_0615
 [ ] 0007_auto_20170809_0653
 [ ] 0008_auto_20170809_0539
 [ ] 0009_remove_emailmarketingconfiguration_sailthru_activation_template
 [ ] 0010_auto_20180425_0800
``` 

I see one more PR that can be related to this issue: https://github.com/edx/edx-platform/pull/25098, but I tried changes from it and they don't solve this issue.