### PR TITLE
MICROBA-605 | Adjust demographics modal button style

### DIFF
--- a/themes/edx.org/lms/static/sass/partials/lms/theme/_dashboard.scss
+++ b/themes/edx.org/lms/static/sass/partials/lms/theme/_dashboard.scss
@@ -79,6 +79,7 @@
       text-shadow: none;
       letter-spacing: normal;
       margin: 5px 0 5px 0;
+      box-shadow: none;
 
       &.blue {
         background-color: #23419f;


### PR DESCRIPTION
[MICROBA-605]
- Remove box-shadow on buttons in Demographics modal

It looks like this button was inheriting a box-shadow from some other piece of CSS? I explicitly removed the box-shadow. I received Kevin's approval for the style. 

Prior to my changes:
![image](https://user-images.githubusercontent.com/3229735/94578882-367c1580-0246-11eb-9c5f-1e8a4ffba33c.png)

Afterwards:
![image](https://user-images.githubusercontent.com/3229735/94579110-73480c80-0246-11eb-836d-83d0cef5d4a9.png)


[MICROBA-605]: https://openedx.atlassian.net/browse/MICROBA-605