### PR TITLE
updating all the tests!

### DIFF
--- a/common/djangoapps/third_party_auth/saml_configuration/tests/test_saml_configuration.py
+++ b/common/djangoapps/third_party_auth/saml_configuration/tests/test_saml_configuration.py
@@ -11,7 +11,7 @@ from rest_framework import status
 from rest_framework.test import APITestCase
 from third_party_auth.models import SAMLConfiguration
 from third_party_auth.tests import testutil
-
+from third_party_auth.tests.utils import skip_unless_thirdpartyauth
 SAML_CONFIGURATIONS = [
     {
         'site': 1,
@@ -45,7 +45,7 @@ PRIV_CONFIGURATIONS = [
 TEST_PASSWORD = 'testpwd'
 
 
-@unittest.skipUnless(testutil.AUTH_FEATURE_ENABLED, testutil.AUTH_FEATURES_KEY + ' not enabled')
+@skip_unless_thirdpartyauth()
 class SAMLConfigurationTests(APITestCase):
     """
     API Tests for SAMLConfiguration objects retrieval.

--- a/common/djangoapps/third_party_auth/samlproviderconfig/tests/test_samlproviderconfig.py
+++ b/common/djangoapps/third_party_auth/samlproviderconfig/tests/test_samlproviderconfig.py
@@ -17,6 +17,7 @@ from enterprise.constants import ENTERPRISE_ADMIN_ROLE, ENTERPRISE_LEARNER_ROLE
 from third_party_auth.tests.samlutils import set_jwt_cookie
 from third_party_auth.models import SAMLProviderConfig, SAMLConfiguration
 from third_party_auth.tests import testutil
+from third_party_auth.tests.utils import skip_unless_thirdpartyauth
 from third_party_auth.utils import convert_saml_slug_provider_id
 
 # country here refers to the URN provided by a user's IDP
@@ -41,7 +42,7 @@ ENTERPRISE_ID = str(uuid4())
 ENTERPRISE_ID_NON_EXISTENT = str(uuid4())
 
 
-@unittest.skipUnless(testutil.AUTH_FEATURE_ENABLED, testutil.AUTH_FEATURES_KEY + ' not enabled')
+@skip_unless_thirdpartyauth()
 class SAMLProviderConfigTests(APITestCase):
     """
     API Tests for SAMLProviderConfig REST endpoints

--- a/common/djangoapps/third_party_auth/samlproviderdata/tests/test_samlproviderdata.py
+++ b/common/djangoapps/third_party_auth/samlproviderdata/tests/test_samlproviderdata.py
@@ -16,6 +16,7 @@ from enterprise.constants import ENTERPRISE_ADMIN_ROLE, ENTERPRISE_LEARNER_ROLE
 from third_party_auth.tests import testutil
 from third_party_auth.models import SAMLProviderData, SAMLProviderConfig
 from third_party_auth.tests.samlutils import set_jwt_cookie
+from third_party_auth.tests.utils import skip_unless_thirdpartyauth
 from third_party_auth.utils import convert_saml_slug_provider_id
 
 SINGLE_PROVIDER_CONFIG = {
@@ -43,7 +44,7 @@ ENTERPRISE_ID = str(uuid4())
 BAD_ENTERPRISE_ID = str(uuid4())
 
 
-@unittest.skipUnless(testutil.AUTH_FEATURE_ENABLED, testutil.AUTH_FEATURES_KEY + ' not enabled')
+@skip_unless_thirdpartyauth()
 class SAMLProviderDataTests(APITestCase):
     """
         API Tests for SAMLProviderConfig REST endpoints

--- a/common/djangoapps/third_party_auth/tests/specs/test_generic.py
+++ b/common/djangoapps/third_party_auth/tests/specs/test_generic.py
@@ -5,11 +5,11 @@ Use the 'Dummy' auth provider for generic integration tests of third_party_auth.
 
 import unittest
 from third_party_auth.tests import testutil
-
+from third_party_auth.tests.utils import skip_unless_thirdpartyauth
 from .base import IntegrationTestMixin
 
 
-@unittest.skipUnless(testutil.AUTH_FEATURE_ENABLED, testutil.AUTH_FEATURES_KEY + ' not enabled')
+@skip_unless_thirdpartyauth()
 class GenericIntegrationTest(IntegrationTestMixin, testutil.TestCase):
     """
     Basic integration tests of third_party_auth using Dummy provider

--- a/common/djangoapps/third_party_auth/tests/specs/test_testshib.py
+++ b/common/djangoapps/third_party_auth/tests/specs/test_testshib.py
@@ -142,7 +142,7 @@ class SamlIntegrationTestUtilities(object):
 
 
 @ddt.ddt
-@unittest.skipUnless(testutil.AUTH_FEATURE_ENABLED, testutil.AUTH_FEATURES_KEY + ' not enabled')
+@utils.skip_unless_thirdpartyauth()
 class TestShibIntegrationTest(SamlIntegrationTestUtilities, IntegrationTestMixin, testutil.SAMLTestCase):
     """
     TestShib provider Integration Test, to test SAML functionality
@@ -375,7 +375,7 @@ class TestShibIntegrationTest(SamlIntegrationTestUtilities, IntegrationTestMixin
             self._test_return_login(previous_session_timed_out=True)
 
 
-@unittest.skipUnless(testutil.AUTH_FEATURE_ENABLED, testutil.AUTH_FEATURES_KEY + ' not enabled')
+@utils.skip_unless_thirdpartyauth()
 class SuccessFactorsIntegrationTest(SamlIntegrationTestUtilities, IntegrationTestMixin, testutil.SAMLTestCase):
     """
     Test basic SAML capability using the TestShib details, and then check that we're able

--- a/common/djangoapps/third_party_auth/tests/test_admin.py
+++ b/common/djangoapps/third_party_auth/tests/test_admin.py
@@ -14,10 +14,11 @@ from student.tests.factories import UserFactory
 from third_party_auth.admin import OAuth2ProviderConfigAdmin
 from third_party_auth.models import OAuth2ProviderConfig
 from third_party_auth.tests import testutil
+from third_party_auth.tests.utils import skip_unless_thirdpartyauth
 
 
 # This is necessary because cms does not implement third party auth
-@unittest.skipUnless(testutil.AUTH_FEATURE_ENABLED, testutil.AUTH_FEATURES_KEY + ' not enabled')
+@skip_unless_thirdpartyauth()
 class Oauth2ProviderConfigAdminTest(testutil.TestCase):
     """
     Tests for oauth2 provider config admin

--- a/common/djangoapps/third_party_auth/tests/test_decorators.py
+++ b/common/djangoapps/third_party_auth/tests/test_decorators.py
@@ -12,6 +12,7 @@ from django.test import RequestFactory
 
 from third_party_auth.decorators import xframe_allow_whitelisted
 from third_party_auth.tests.testutil import TestCase
+from third_party_auth.tests.utils import skip_unless_thirdpartyauth
 
 
 @xframe_allow_whitelisted
@@ -20,11 +21,7 @@ def mock_view(_request):
     return HttpResponse()
 
 
-# remove this decorator once third_party_auth is enabled in CMS
-@unittest.skipIf(
-    'third_party_auth' not in settings.INSTALLED_APPS,
-    'third_party_auth is not currently installed in CMS'
-)
+@skip_unless_thirdpartyauth()
 @ddt.ddt
 class TestXFrameWhitelistDecorator(TestCase):
     """ Test the xframe_allow_whitelisted decorator. """

--- a/common/djangoapps/third_party_auth/tests/test_identityserver3.py
+++ b/common/djangoapps/third_party_auth/tests/test_identityserver3.py
@@ -6,9 +6,10 @@ import ddt
 import unittest
 from third_party_auth.identityserver3 import IdentityServer3
 from third_party_auth.tests import testutil
+from third_party_auth.tests.utils import skip_unless_thirdpartyauth
 
 
-@unittest.skipUnless(testutil.AUTH_FEATURE_ENABLED, testutil.AUTH_FEATURES_KEY + ' not enabled')
+@skip_unless_thirdpartyauth()
 @ddt.ddt
 class IdentityServer3Test(testutil.TestCase):
     """

--- a/common/djangoapps/third_party_auth/tests/test_pipeline.py
+++ b/common/djangoapps/third_party_auth/tests/test_pipeline.py
@@ -12,9 +12,10 @@ from third_party_auth.tests import testutil
 from third_party_auth.tests.specs.base import IntegrationTestMixin
 from third_party_auth.tests.specs.test_testshib import SamlIntegrationTestUtilities
 from third_party_auth.tests.testutil import simulate_running_pipeline
+from third_party_auth.tests.utils import skip_unless_thirdpartyauth
 
 
-@unittest.skipUnless(testutil.AUTH_FEATURE_ENABLED, testutil.AUTH_FEATURES_KEY + ' not enabled')
+@skip_unless_thirdpartyauth()
 @ddt.ddt
 class ProviderUserStateTestCase(testutil.TestCase):
     """Tests ProviderUserState behavior."""
@@ -54,7 +55,7 @@ class ProviderUserStateTestCase(testutil.TestCase):
             self.assertEqual(idp_config['logout_url'], logout_url)
 
 
-@unittest.skipUnless(testutil.AUTH_FEATURE_ENABLED, testutil.AUTH_FEATURES_KEY + ' not enabled')
+@skip_unless_thirdpartyauth()
 @ddt.ddt
 class PipelineOverridesTest(SamlIntegrationTestUtilities, IntegrationTestMixin, testutil.SAMLTestCase):
     """

--- a/common/djangoapps/third_party_auth/tests/test_pipeline_integration.py
+++ b/common/djangoapps/third_party_auth/tests/test_pipeline_integration.py
@@ -16,12 +16,13 @@ from lms.djangoapps.verify_student.models import SSOVerification
 from student.tests.factories import UserFactory
 from third_party_auth import pipeline, provider
 from third_party_auth.tests import testutil
-
+from third_party_auth.tests.utils import skip_unless_thirdpartyauth
 # Get Django User model by reference from python-social-auth. Not a type
 # constant, pylint.
 User = social_models.DjangoStorage.user.user_model()  # pylint: disable=invalid-name
 
 
+@skip_unless_thirdpartyauth()
 class TestCase(testutil.TestCase, test.TestCase):
     """Base test case."""
 
@@ -30,7 +31,6 @@ class TestCase(testutil.TestCase, test.TestCase):
         self.enabled_provider = self.configure_google_provider(enabled=True)
 
 
-@unittest.skipUnless(testutil.AUTH_FEATURE_ENABLED, testutil.AUTH_FEATURES_KEY + ' not enabled')
 class GetAuthenticatedUserTestCase(TestCase):
     """Tests for get_authenticated_user."""
 
@@ -71,12 +71,12 @@ class GetAuthenticatedUserTestCase(TestCase):
         self.assertEqual(self.enabled_provider.get_authentication_backend(), user.backend)
 
 
-@unittest.skipUnless(testutil.AUTH_FEATURE_ENABLED, testutil.AUTH_FEATURES_KEY + ' not enabled')
-class GetProviderUserStatesTestCase(testutil.TestCase, test.TestCase):
+class GetProviderUserStatesTestCase(TestCase):
     """Tests generation of ProviderUserStates."""
 
     def setUp(self):
         super(GetProviderUserStatesTestCase, self).setUp()
+        self.configure_google_provider(enabled=False)
         self.user = social_models.DjangoStorage.user.create_user(username='username', password='password')
 
     def test_returns_empty_list_if_no_enabled_providers(self):
@@ -147,7 +147,6 @@ class GetProviderUserStatesTestCase(testutil.TestCase, test.TestCase):
         self.assertEqual(self.user, linkedin_state.user)
 
 
-@unittest.skipUnless(testutil.AUTH_FEATURE_ENABLED, testutil.AUTH_FEATURES_KEY + ' not enabled')
 class UrlFormationTestCase(TestCase):
     """Tests formation of URLs for pipeline hook points."""
 
@@ -213,8 +212,7 @@ class UrlFormationTestCase(TestCase):
             pipeline.get_complete_url(provider_id)
 
 
-@unittest.skipUnless(testutil.AUTH_FEATURE_ENABLED, testutil.AUTH_FEATURES_KEY + ' not enabled')
-class TestPipelineUtilityFunctions(TestCase, test.TestCase):
+class TestPipelineUtilityFunctions(TestCase):
     """
     Test some of the isolated utility functions in the pipeline
     """
@@ -304,9 +302,8 @@ class TestPipelineUtilityFunctions(TestCase, test.TestCase):
         self.assertNotIn('third_party_auth_quarantined_modules', request.session)
 
 
-@unittest.skipUnless(testutil.AUTH_FEATURE_ENABLED, testutil.AUTH_FEATURES_KEY + ' not enabled')
 @ddt.ddt
-class EnsureUserInformationTestCase(testutil.TestCase, test.TestCase):
+class EnsureUserInformationTestCase(TestCase):
     """Tests ensuring that we have the necessary user information to proceed with the pipeline."""
 
     def setUp(self):
@@ -386,8 +383,7 @@ class EnsureUserInformationTestCase(testutil.TestCase, test.TestCase):
                     assert response.url == expected_redirect_url
 
 
-@unittest.skipUnless(testutil.AUTH_FEATURE_ENABLED, testutil.AUTH_FEATURES_KEY + ' not enabled')
-class UserDetailsForceSyncTestCase(testutil.TestCase, test.TestCase):
+class UserDetailsForceSyncTestCase(TestCase):
     """Tests to ensure learner profile data is properly synced if the provider requires it."""
 
     def setUp(self):
@@ -491,8 +487,7 @@ class UserDetailsForceSyncTestCase(testutil.TestCase, test.TestCase):
         assert len(mail.outbox) == 1
 
 
-@unittest.skipUnless(testutil.AUTH_FEATURE_ENABLED, testutil.AUTH_FEATURES_KEY + ' not enabled')
-class SetIDVerificationStatusTestCase(testutil.TestCase, test.TestCase):
+class SetIDVerificationStatusTestCase(TestCase):
     """Tests to ensure SSO ID Verification for the user is set if the provider requires it."""
 
     def setUp(self):

--- a/common/djangoapps/third_party_auth/tests/test_provider.py
+++ b/common/djangoapps/third_party_auth/tests/test_provider.py
@@ -12,12 +12,12 @@ from mock import Mock, patch
 from openedx.core.djangoapps.site_configuration.tests.test_util import with_site_configuration
 from third_party_auth import provider
 from third_party_auth.tests import testutil
-
+from third_party_auth.tests.utils import skip_unless_thirdpartyauth
 SITE_DOMAIN_A = 'professionalx.example.com'
 SITE_DOMAIN_B = 'somethingelse.example.com'
 
 
-@unittest.skipUnless(testutil.AUTH_FEATURE_ENABLED, testutil.AUTH_FEATURES_KEY + ' not enabled')
+@skip_unless_thirdpartyauth()
 class RegistryTest(testutil.TestCase):
     """Tests registry discovery and operation."""
 

--- a/common/djangoapps/third_party_auth/tests/test_settings.py
+++ b/common/djangoapps/third_party_auth/tests/test_settings.py
@@ -6,7 +6,7 @@ import unittest
 from mock import patch
 from third_party_auth import provider, settings
 from third_party_auth.tests import testutil
-
+from third_party_auth.tests.utils import skip_unless_thirdpartyauth
 _ORIGINAL_AUTHENTICATION_BACKENDS = ['first_authentication_backend']
 _ORIGINAL_INSTALLED_APPS = ['first_installed_app']
 _ORIGINAL_MIDDLEWARE_CLASSES = ['first_middleware_class']
@@ -43,7 +43,7 @@ class SettingsUnitTest(testutil.TestCase):
         settings.apply_settings(self.settings)
         self.assertEqual(['auth_entry', 'next'], self.settings.FIELDS_STORED_IN_SESSION)
 
-    @unittest.skipUnless(testutil.AUTH_FEATURE_ENABLED, testutil.AUTH_FEATURES_KEY + ' not enabled')
+    @skip_unless_thirdpartyauth()
     def test_apply_settings_enables_no_providers_by_default(self):
         # Providers are only enabled via ConfigurationModels in the database
         settings.apply_settings(self.settings)

--- a/common/djangoapps/third_party_auth/tests/utils.py
+++ b/common/djangoapps/third_party_auth/tests/utils.py
@@ -3,6 +3,7 @@
 
 import json
 from base64 import b64encode
+from unittest import skip
 
 import httpretty
 from onelogin.saml2.utils import OneLogin_Saml2_Utils
@@ -13,7 +14,7 @@ from social_django.models import Partial, UserSocialAuth
 
 from student.tests.factories import UserFactory
 
-from .testutil import ThirdPartyAuthTestMixin
+from .testutil import ThirdPartyAuthTestMixin, AUTH_FEATURE_ENABLED, AUTH_FEATURES_KEY
 
 
 @httpretty.activate
@@ -139,3 +140,12 @@ def prepare_saml_response_from_xml(xml, relay_state='testshib'):
         relay_state=OneLogin_Saml2_Utils.escape_url(relay_state),
         saml_response=OneLogin_Saml2_Utils.escape_url(b64encoded_xml)
     )
+
+
+def skip_unless_thirdpartyauth():
+    """
+    Wraps unittest.skip in consistent logic to skip certain third_party_auth tests in CMS.
+    """
+    if AUTH_FEATURE_ENABLED:
+        return lambda func: func
+    return skip("%s not enabled" % AUTH_FEATURES_KEY)


### PR DESCRIPTION
- This PR creates a unified decorator that determines whether to skip third_party_auth tests based on a feature flag or not (aka whether we are running tests for cms or lms).
- It also updates all third_party_auth tests that previously had a decorator skipping the test based on this feature flag OR whether the app was installed.
- I also had to fix a couple of tests that were needlessly importing base classes instead of using the "TestCase" class they defined in the test files.

I ran all tests locally both with LMS and CMS to verify functionality still worked as expected.

Style checks may fail in CI though and will fix as needed.