### PR TITLE
Updates bulk unenroll management command.

### DIFF
--- a/common/djangoapps/student/management/commands/bulk_unenroll.py
+++ b/common/djangoapps/student/management/commands/bulk_unenroll.py
@@ -46,7 +46,6 @@ class Command(BaseCommand):
 
     def handle(self, *args, **options):
         csv_path = options['csv_path']
-        import pdb;pdb.set_trace()
         self.commit = options['commit']
 
         if csv_path:

--- a/common/djangoapps/student/management/commands/bulk_unenroll.py
+++ b/common/djangoapps/student/management/commands/bulk_unenroll.py
@@ -22,20 +22,32 @@ class Command(BaseCommand):
     It expect that the data will be provided in a csv file format with
     first row being the header and columns will be either one of the
     following:
-    username,course-id
+    | username | course_id |
     OR
-    course-id
+    | course_id |
+
+    Example:
+            $ ... bulk_unenroll --csv_path=foo.csv
+            $ ... bulk_unenroll --csv_path=foo.csv --commit
     """
+    commit = False
 
     def add_arguments(self, parser):
-        parser.add_argument('-p', '--csv_path',
-                            metavar='csv_path',
-                            dest='csv_path',
-                            required=False,
-                            help='Path to CSV file.')
+        parser.add_argument(
+            '-p', '--csv_path',
+            metavar='csv_path',
+            dest='csv_path',
+            required=True,
+            help='Path to CSV file.')
+        parser.add_argument(
+            '--commit',
+            action='store_true',
+            help='Save the changes, without this flag only a dry run will be performed and nothing will be changed')
 
     def handle(self, *args, **options):
         csv_path = options['csv_path']
+        import pdb;pdb.set_trace()
+        self.commit = options['commit']
 
         if csv_path:
             with open(csv_path, 'rb') as csv_file:
@@ -67,7 +79,13 @@ class Command(BaseCommand):
         if username:
             enrollments = enrollments.filter(user__username=username)
 
-        for enrollment in enrollments:
-            enrollment.update_enrollment(is_active=False, skip_refund=True)
-            logger.info("User [{}] have been successfully unenrolled from the course: {}"
-                        .format(enrollment.user.username, course_key))
+        logger.info("Processing [{}] with [{}] enrollments.".format(course_id, enrollments.count()))
+
+        if self.commit:
+            for enrollment in enrollments:
+                enrollment.update_enrollment(is_active=False, skip_refund=True)
+                logger.info(
+                    "User [{}] have been successfully unenrolled from the course: {}".format(
+                        enrollment.user.username, course_key
+                    )
+                )

--- a/common/djangoapps/student/management/commands/bulk_unenroll.py
+++ b/common/djangoapps/student/management/commands/bulk_unenroll.py
@@ -37,7 +37,7 @@ class Command(BaseCommand):
             '-p', '--csv_path',
             metavar='csv_path',
             dest='csv_path',
-            required=True,
+            required=False,
             help='Path to CSV file.')
         parser.add_argument(
             '--commit',

--- a/common/djangoapps/student/management/tests/test_bulk_unenroll.py
+++ b/common/djangoapps/student/management/tests/test_bulk_unenroll.py
@@ -58,7 +58,7 @@ class BulkUnenrollTests(SharedModuleStoreTestCase):
             csv = self._write_test_csv(csv, lines=["amy,test_course\n"])
 
             with LogCapture(LOGGER_NAME) as log:
-                call_command("bulk_unenroll", "--csv_path={}".format(csv.name))
+                call_command("bulk_unenroll", "--csv_path={} --commit".format(csv.name))
                 expected_message = 'Invalid course id {}, skipping un-enrollement.'.\
                     format('test_course')
 
@@ -76,9 +76,25 @@ class BulkUnenrollTests(SharedModuleStoreTestCase):
         with NamedTemporaryFile() as csv:
             csv = self._write_test_csv(csv, lines=lines)
 
-            call_command("bulk_unenroll", "--csv_path={}".format(csv.name))
+            call_command("bulk_unenroll", "--csv_path={} --commit".format(csv.name))
             for enrollment in CourseEnrollment.objects.all():
                 self.assertEqual(enrollment.is_active, False)
+
+    def test_bulk_un_enroll_without_commit(self):
+        """
+        Verify the ability to dry-run the command.
+        """
+        lines = [
+            enrollment.user.username + "," +
+            str(enrollment.course.id) + "\n"
+            for enrollment in self.enrollments
+        ]
+        with NamedTemporaryFile() as csv:
+            csv = self._write_test_csv(csv, lines=lines)
+
+            call_command("bulk_unenroll", "--csv_path={}".format(csv.name))
+            for enrollment in CourseEnrollment.objects.all():
+                self.assertEqual(enrollment.is_active, True)
 
     def test_bulk_unenroll_from_config_model(self):
         """Verify users are unenrolled using the command."""
@@ -90,7 +106,7 @@ class BulkUnenrollTests(SharedModuleStoreTestCase):
         csv_file = SimpleUploadedFile(name='test.csv', content=lines.encode('utf-8'), content_type='text/csv')
         BulkUnenrollConfiguration.objects.create(enabled=True, csv_file=csv_file)
 
-        call_command("bulk_unenroll")
+        call_command("bulk_unenroll --commit")
         for enrollment in CourseEnrollment.objects.all():
             self.assertEqual(enrollment.is_active, False)
 
@@ -102,7 +118,7 @@ class BulkUnenrollTests(SharedModuleStoreTestCase):
         BulkUnenrollConfiguration.objects.create(enabled=True, csv_file=csv_file)
 
         with LogCapture(LOGGER_NAME) as log:
-            call_command("bulk_unenroll")
+            call_command("bulk_unenroll --commit")
             log.check(
                 (
                     LOGGER_NAME,


### PR DESCRIPTION
This PR Add the following:
- Ability to dry-run the management command without affecting the database.
- Log course id and number of enrollments before processing
- Update the relevant tests

PROD-2155