### PR TITLE
Per the documentation, name should be the full python path to the mod…

### DIFF
--- a/lms/djangoapps/email_marketing/apps.py
+++ b/lms/djangoapps/email_marketing/apps.py
@@ -10,7 +10,7 @@ class EmailMarketingConfig(AppConfig):
     """
     Configuration class for the email_marketing Django application.
     """
-    name = 'email_marketing'
+    name = 'lms.djangoapps.email_marketing'
     verbose_name = "Email Marketing"
 
     def ready(self):

--- a/lms/djangoapps/gating/apps.py
+++ b/lms/djangoapps/gating/apps.py
@@ -10,7 +10,7 @@ class GatingConfig(AppConfig):
     """
     Django AppConfig class for the gating app
     """
-    name = 'gating'
+    name = 'lms.djangoapps.gating'
 
     def ready(self):
         # Import signals to wire up the signal handlers contained within

--- a/lms/djangoapps/lms_initialization/apps.py
+++ b/lms/djangoapps/lms_initialization/apps.py
@@ -15,7 +15,7 @@ class LMSInitializationConfig(AppConfig):
     """
     Application Configuration for lms_initialization.
     """
-    name = 'lms_initialization'
+    name = 'lms.djangoapps.lms_initialization'
     verbose_name = 'LMS Initialization'
 
     def ready(self):

--- a/lms/djangoapps/survey/apps.py
+++ b/lms/djangoapps/survey/apps.py
@@ -10,7 +10,7 @@ class SurveyConfig(AppConfig):
     """
     Application Configuration for survey.
     """
-    name = 'survey'
+    name = 'lms.djangoapps.survey'
     verbose_name = 'Student Surveys'
 
     def ready(self):


### PR DESCRIPTION
…ule.

https://docs.djangoproject.com/en/2.2/ref/applications/#django.apps.AppConfig.name

These packages were mis-named after the sys.path fixes.