### PR TITLE
[REV-1510] Gate sequence if it is a timed exam and contains content type gated problems

### DIFF
--- a/common/lib/xmodule/xmodule/seq_module.py
+++ b/common/lib/xmodule/xmodule/seq_module.py
@@ -331,15 +331,15 @@ class SequenceModule(SequenceFields, ProctoringFields, XModule):
                 # Other than the outer function here
                 return (
                     block.location.block_type not in ('chapter', 'sequential', 'vertical') and
-                    len(getattr(block, 'children', [])) == 0
+                    not block.has_children
                 )
 
             def get_children(parent):
                 # This function is used to get the children of a block in the traversal below
-                if not hasattr(parent, 'children'):
-                    return []
-                else:
+                if parent.has_children:
                     return parent.get_children()
+                else:
+                    return []
 
             # If any block inside a timed exam has been gated by content type gating
             # then gate the entire sequence.

--- a/common/lib/xmodule/xmodule/seq_module.py
+++ b/common/lib/xmodule/xmodule/seq_module.py
@@ -287,6 +287,7 @@ class SequenceModule(SequenceFields, ProctoringFields, XModule):
         prereq_met = True
         prereq_meta_info = {}
 
+
         if TIMED_EXAM_GATING_WAFFLE_FLAG.is_enabled():
             # Content type gating for FBE previously only gated individual blocks
             # This was an issue because audit learners could start a timed exam and then be unable to complete the exam

--- a/common/lib/xmodule/xmodule/tests/test_sequence.py
+++ b/common/lib/xmodule/xmodule/tests/test_sequence.py
@@ -14,7 +14,9 @@ from django.utils.timezone import now
 from freezegun import freeze_time
 from mock import Mock, patch
 from six.moves import range
+from web_fragments.fragment import Fragment
 
+from lms.djangoapps.courseware.access_response import AccessResponse
 from openedx.core.djangoapps.waffle_utils.testutils import override_waffle_flag
 from student.tests.factories import UserFactory
 from xmodule.seq_module import TIMED_EXAM_GATING_WAFFLE_FLAG, SequenceModule
@@ -76,10 +78,12 @@ class SequenceBlockTestCase(XModuleXmlImportTest):
         for _ in range(3):
             xml.VerticalFactory.build(parent=sequence_3_1)
 
-        xml.SequenceFactory.build(
+        sequence_5_1 = xml.SequenceFactory.build(
             parent=chapter_5,
             is_time_limited=str(True)
         )
+        vertical_5_1 = xml.VerticalFactory.build(parent=sequence_5_1)
+        xml.ProblemFactory.build(parent=vertical_5_1)
 
         return course
 
@@ -180,6 +184,63 @@ class SequenceBlockTestCase(XModuleXmlImportTest):
                 view=STUDENT_VIEW
             )
             mocked_user.assert_called_once()
+
+    @override_waffle_flag(TIMED_EXAM_GATING_WAFFLE_FLAG, active=True)
+    @patch('xmodule.seq_module.User.objects.get', return_value=UserFactory.build())
+    @patch('openedx.features.content_type_gating.models.ContentTypeGatingConfig.enabled_for_enrollment',
+           return_value=True)
+    def test_that_timed_sequence_gating_respects_access_configurations(self, mocked_user, mocked_config):  # pylint: disable=unused-argument
+        """
+        Verify that if a time limited sequence contains content type gated problems, we gate the sequence
+        Verify that if a time limited sequence contains gated problems, but not due to content type gating,
+        then sequence is not gated
+        Verify that if all problems in a time limited sequence can be accessed, the sequence is not gated
+        """
+        # the one problem in this sequence needs to have graded set to true in order to test content type gating
+        self.sequence_5_1.get_children()[0].get_children()[0].graded = True
+        gated_fragment = Fragment('i_am_gated')
+
+        # When a time limited sequence contains content type gated problems, the sequence itself is gated
+        content_gating_error = AccessResponse(False, error_code="incorrect_user_group", user_fragment=gated_fragment)
+        with patch.object(SequenceModule, '_has_access_check', return_value=content_gating_error):
+            view = self._get_rendered_view(
+                self.sequence_5_1,
+                extra_context=dict(next_url='NextSequential', prev_url='PrevSequential'),
+                view=STUDENT_VIEW
+            )
+            self.assertIn('i_am_gated', view)
+            # check a few elements to ensure the correct page was loaded
+            self.assertIn("seq_module.html", view)
+            self.assertIn('NextSequential', view)
+            self.assertIn('PrevSequential', view)
+
+        # When a time limited sequence contains inaccessible problems for reasons other than content type gating
+        # the sequence is not gated, because handling these cases was out of scope for this ticket
+        some_other_error = AccessResponse(False, error_code="some_other_error", user_fragment=gated_fragment)
+        with patch.object(SequenceModule, '_has_access_check', return_value=some_other_error):
+            view = self._get_rendered_view(
+                self.sequence_5_1,
+                extra_context=dict(next_url='NextSequential', prev_url='PrevSequential'),
+                view=STUDENT_VIEW
+            )
+            self.assertNotIn('i_am_gated', view)
+            # check a few elements to ensure the correct page was loaded
+            self.assertIn("seq_module.html", view)
+            self.assertIn('NextSequential', view)
+            self.assertIn('PrevSequential', view)
+
+        # When all problems inside a time limited sequence can be accessed, the sequence is not gated
+        with patch.object(SequenceModule, '_has_access_check', return_value=AccessResponse(True)):
+            view = self._get_rendered_view(
+                self.sequence_5_1,
+                extra_context=dict(next_url='NextSequential', prev_url='PrevSequential'),
+                view=STUDENT_VIEW
+            )
+            self.assertNotIn('i_am_gated', view)
+            # check a few elements to ensure the correct page was loaded
+            self.assertIn("seq_module.html", view)
+            self.assertIn('NextSequential', view)
+            self.assertIn('PrevSequential', view)
 
     @ddt.unpack
     @ddt.data(

--- a/lms/djangoapps/courseware/module_render.py
+++ b/lms/djangoapps/courseware/module_render.py
@@ -87,6 +87,7 @@ from openedx.core.lib.xblock_utils import request_token as xblock_request_token
 from openedx.core.lib.xblock_utils import wrap_xblock
 from openedx.features.course_duration_limits.access import course_expiration_wrapper
 from openedx.features.discounts.utils import offer_banner_wrapper
+from openedx.features.content_type_gating.services import ContentTypeGatingService
 from student.models import anonymous_id_for_user, user_by_anonymous_id
 from student.roles import CourseBetaTesterRole
 from track import contexts
@@ -821,6 +822,7 @@ def get_module_system_for_user(
             'gating': GatingService(),
             'grade_utils': GradesUtilService(course_id=course_id),
             'user_state': UserStateService(),
+            'content_type_gating': ContentTypeGatingService(),
         },
         get_user_role=lambda: get_user_role(user, course_id),
         descriptor_runtime=descriptor._runtime,  # pylint: disable=protected-access

--- a/openedx/features/content_type_gating/services.py
+++ b/openedx/features/content_type_gating/services.py
@@ -1,0 +1,32 @@
+"""
+Content Type Gating service.
+"""
+
+from lms.djangoapps.courseware.access import has_access
+from openedx.features.content_type_gating.models import ContentTypeGatingConfig
+
+
+class ContentTypeGatingService(object):
+    """
+    Content Type Gating uses Block Transformers to gate sections of the course outline
+    and field overrides to gate course content.
+    This service was created as a helper class for handling timed exams that contain content type gated problems.
+    """
+    def enabled_for_enrollment(self, **kwargs):
+        """
+        Returns whether content type gating is enabled for a given user/course pair
+        """
+        return ContentTypeGatingConfig.enabled_for_enrollment(**kwargs)
+
+    def content_type_gate_for_block(self, user, block, course_id):
+        """
+        Returns a Fragment of the content type gate (if any) that would appear for a given block
+        """
+        problem_eligible_for_content_gating = (getattr(block, 'graded', False) and
+                                               block.has_score and
+                                               getattr(block, 'weight', 0) != 0)
+        if problem_eligible_for_content_gating:
+            access = has_access(user, 'load', block, course_id)
+            if (not access and access.error_code == 'incorrect_user_group'):
+                return access.user_fragment
+            return None


### PR DESCRIPTION
https://openedx.atlassian.net/browse/REV-1510

Summary:
Feature based enrollments (FBE) was released with a bug where audit users could start a timed exam without being able to complete it because the graded problems could be gated by content type gating (a sub-feature of FBE).
Earlier, I released a fix for this bug, which did not account for the case where course authors override content type gating and allow audit users access to problems within a timed exam.
The fix was reverted. This adds back that fix with the adjustment that we also check has_access for all the problems in a sequence. If any of the problems in a time limited sequence are gated by content type gating, then we gate the sequence.

What it looks like when a timed exam is not gated:
<img width="1408" alt="Screen Shot 2020-09-29 at 3 53 03 PM" src="https://user-images.githubusercontent.com/5958221/94937647-d8e20600-049d-11eb-9823-20b1d8bd84c8.png">

Configurations for which the timed exam is not gated:
1. Group access for units containing content that would have been gated is overriden at the unit level
<img width="893" alt="Screen Shot 2020-09-29 at 3 54 01 PM" src="https://user-images.githubusercontent.com/5958221/94937296-640ecc00-049d-11eb-8900-2a69828b413d.png">

2. Group access for blocks that would have been gated is overriden at the block level
<img width="575" alt="Screen Shot 2020-09-25 at 10 03 41 AM" src="https://user-images.githubusercontent.com/5958221/94937677-e5fef500-049d-11eb-8470-06b1eeb4ec58.png">



What it looks like when the timed exam is gated:
<img width="1415" alt="Screen Shot 2020-09-29 at 3 33 06 PM" src="https://user-images.githubusercontent.com/5958221/94937643-d7b0d900-049d-11eb-97f2-ea60c0ba2905.png">

This will occur If a sequence contains any units with gated problems and the access has not been overridden at the unit or block level:
<img width="917" alt="Screen Shot 2020-09-29 at 3 56 33 PM" src="https://user-images.githubusercontent.com/5958221/94937302-6709bc80-049d-11eb-8abf-6fee179d8e18.png">