### PR TITLE
EDUCATOR-5300 - advanced team settings validation

### DIFF
--- a/cms/djangoapps/models/settings/course_metadata.py
+++ b/cms/djangoapps/models/settings/course_metadata.py
@@ -295,8 +295,8 @@ class CourseMetadata(object):
             return errors
 
         proposed_max_team_size = json_value.get('max_team_size')
-
-        if proposed_max_team_size != '' and proposed_max_team_size <= 0:
+        import pdb; pdb.set_trace()
+        if proposed_max_team_size != '' and proposed_max_team_size is not None and proposed_max_team_size <= 0:
             message = 'max_team_size must be greater than zero'
             errors.append({'key': 'teams_configuration', 'message': message, 'model': teams_configuration_model})
 

--- a/cms/djangoapps/models/settings/course_metadata.py
+++ b/cms/djangoapps/models/settings/course_metadata.py
@@ -287,6 +287,8 @@ class CourseMetadata(object):
         """
         errors = []
         teams_configuration_model = settings_dict.get('teams_configuration', {})
+        if teams_configuration_model == {}:
+            return errors
         proposed_topics = teams_configuration_model.get('value').get('topics')
 
         proposed_max_team_size = teams_configuration_model.get('value').get('max_team_size')

--- a/cms/djangoapps/models/settings/course_metadata.py
+++ b/cms/djangoapps/models/settings/course_metadata.py
@@ -313,7 +313,7 @@ class CourseMetadata(object):
         proposed_topic_dupe_ids = {x for x in proposed_topic_ids if proposed_topic_ids.count(x) > 1}
         if len(proposed_topic_dupe_ids) > 0:
             message = 'duplicate ids: ' + ','.join(proposed_topic_dupe_ids)
-            errors.append({'key': 'team_settings', 'message': message, 'model': teams_configuration_model})
+            errors.append({'key': 'teams_configuration', 'message': message, 'model': teams_configuration_model})
 
         for proposed_topic in proposed_topics:
             topic_validation_errors = cls.validate_single_topic(proposed_topic)

--- a/cms/djangoapps/models/settings/course_metadata.py
+++ b/cms/djangoapps/models/settings/course_metadata.py
@@ -295,7 +295,6 @@ class CourseMetadata(object):
             return errors
 
         proposed_max_team_size = json_value.get('max_team_size')
-        import pdb; pdb.set_trace()
         if proposed_max_team_size != '' and proposed_max_team_size is not None and proposed_max_team_size <= 0:
             message = 'max_team_size must be greater than zero'
             errors.append({'key': 'teams_configuration', 'message': message, 'model': teams_configuration_model})

--- a/cms/djangoapps/models/settings/tests/test_settings.py
+++ b/cms/djangoapps/models/settings/tests/test_settings.py
@@ -321,6 +321,44 @@ config_block_unrecognized_teamset_type = {
     }
 }
 
+config_block_no_global_max_team_size = {
+    "teams_configuration": {
+        "value": {
+            "topics": [
+                {
+                    "max_team_size": 5,
+                    "name": "Topic 1 Name",
+                    "id": "topic_1_id",
+                    "description": "Topic 1 desc",
+                    "type": "public_managed"
+                },
+                {
+                    "id": "topic_2_id",
+                    "name": "Topic 2 Name",
+                    "description": "Topic 2 desc"
+                },
+                {
+                    "id": "topic_3_id",
+                    "name": "Topic 3 Name",
+                    "description": "Topic 3 desc"
+                },
+                {
+                    "id": "private_topic_1_id",
+                    "type": "private_managed",
+                    "description": "Private Topic 1 desc",
+                    "name": "Private Topic 1 Name"
+                },
+                {
+                    "id": "private_topic_2_id",
+                    "type": "private_managed",
+                    "description": "Private Topic 2 desc",
+                    "name": "Private Topic 2 Name"
+                }
+            ]
+        }
+    }
+}
+
 
 @ddt.ddt
 class TeamsConfigurationTests(unittest.TestCase):
@@ -339,7 +377,8 @@ class TeamsConfigurationTests(unittest.TestCase):
         ),
         (config_block_missing_name, {'name attribute must not be empty'}),
         (config_block_extra_attribute, {'extra keys: foo'}),
-        (config_block_unrecognized_teamset_type, {'type foo is invalid'})
+        (config_block_unrecognized_teamset_type, {'type foo is invalid'}),
+        (config_block_no_global_max_team_size, set())
     )
     @ddt.unpack
     def test_team_settings(self, config_block, error_message):

--- a/cms/djangoapps/models/settings/tests/test_settings.py
+++ b/cms/djangoapps/models/settings/tests/test_settings.py
@@ -8,7 +8,7 @@ import ddt
 
 from cms.djangoapps.models.settings.course_metadata import CourseMetadata
 
-working_cofing_block = {
+working_config_block = {
     "teams_configuration": {
         "value": {
             "max_team_size": 4,
@@ -47,7 +47,7 @@ working_cofing_block = {
     }
 }
 
-cofing_block_negative_team_size = {
+config_block_negative_team_size = {
     "teams_configuration": {
         "value": {
             "max_team_size": -1,
@@ -86,7 +86,7 @@ cofing_block_negative_team_size = {
     }
 }
 
-cofing_block_negative_local_team_size = {
+config_block_negative_local_team_size = {
     "teams_configuration": {
         "value": {
             "max_team_size": 2,
@@ -125,7 +125,7 @@ cofing_block_negative_local_team_size = {
     }
 }
 
-cofing_block_duplicate_id = {
+config_block_duplicate_id = {
     "teams_configuration": {
         "value": {
             "max_team_size": 2,
@@ -164,7 +164,7 @@ cofing_block_duplicate_id = {
     }
 }
 
-cofing_block_negative_team_size_dupe_id = {
+config_block_negative_team_size_dupe_id = {
     "teams_configuration": {
         "value": {
             "max_team_size": 2,
@@ -203,7 +203,7 @@ cofing_block_negative_team_size_dupe_id = {
     }
 }
 
-cofing_block_missing_name = {
+config_block_missing_name = {
     "teams_configuration": {
         "value": {
             "max_team_size": 2,
@@ -242,7 +242,7 @@ cofing_block_missing_name = {
     }
 }
 
-cofing_block_extra_attribute = {
+config_block_extra_attribute = {
     "teams_configuration": {
         "value": {
             "max_team_size": 2,
@@ -282,6 +282,45 @@ cofing_block_extra_attribute = {
     }
 }
 
+config_block_unrecognized_teamset_type = {
+    "teams_configuration": {
+        "value": {
+            "max_team_size": 2,
+            "team_sets": [
+                {
+                    "max_team_size": 4,
+                    "name": "Topic 1 name",
+                    "id": "topic_1_id",
+                    "description": "Topic 1 desc",
+                    "type": "foo",
+                },
+                {
+                    "id": "topic_2_id",
+                    "name": "Topic 2 Name",
+                    "description": "Topic 2 desc"
+                },
+                {
+                    "id": "topic_3_id",
+                    "name": "Topic 3 Name",
+                    "description": "Topic 3 desc"
+                },
+                {
+                    "id": "private_topic_1_id",
+                    "type": "private_managed",
+                    "description": "Private Topic 1 desc",
+                    "name": "Private Topic 1 Name"
+                },
+                {
+                    "id": "private_topic_2_id",
+                    "type": "private_managed",
+                    "description": "Private Topic 2 desc",
+                    "name": "Private Topic 2 Name"
+                }
+            ]
+        }
+    }
+}
+
 
 @ddt.ddt
 class TeamsConfigurationTests(unittest.TestCase):
@@ -290,15 +329,22 @@ class TeamsConfigurationTests(unittest.TestCase):
     """
 
     @ddt.data(
-        (working_cofing_block, 0),
-        (cofing_block_negative_team_size, 1),
-        (cofing_block_negative_local_team_size, 1),
-        (cofing_block_duplicate_id, 1),
-        (cofing_block_negative_team_size_dupe_id, 2),
-        (cofing_block_missing_name, 1),
-        (cofing_block_extra_attribute, 1)
+        (working_config_block, set()),
+        (config_block_negative_team_size, {'max_team_size must be greater than zero'}),
+        (config_block_negative_local_team_size, {'max_team_size must be greater than zero'}),
+        (config_block_duplicate_id, {'duplicate ids: topic_1_id'}),
+        (
+            config_block_negative_team_size_dupe_id,
+            {'duplicate ids: topic_2_id', 'max_team_size must be greater than zero'}
+        ),
+        (config_block_missing_name, {'name attribute must not be empty'}),
+        (config_block_extra_attribute, {'extra keys: foo'}),
+        (config_block_unrecognized_teamset_type, {'type foo is invalid'})
     )
     @ddt.unpack
-    def test_team_settings(self, config_block, number_of_errors):
+    def test_team_settings(self, config_block, error_message):
         result = CourseMetadata.validate_team_settings(config_block)
-        self.assertEqual(len(result), number_of_errors)
+        self.assertEqual(len(result), len(error_message))
+        if len(error_message) > 0:
+            for res in result:
+                self.assertIn(res['message'], error_message)

--- a/cms/djangoapps/models/settings/tests/test_settings.py
+++ b/cms/djangoapps/models/settings/tests/test_settings.py
@@ -1,0 +1,304 @@
+"""
+Tests for the advanced settings
+"""
+
+import unittest
+
+import ddt
+
+from cms.djangoapps.models.settings.course_metadata import CourseMetadata
+
+working_cofing_block = {
+    "teams_configuration": {
+        "value": {
+            "max_team_size": 4,
+            "topics": [
+                {
+                    "max_team_size": 5,
+                    "name": "Topic 1 Name",
+                    "id": "topic_1_id",
+                    "description": "Topic 1 desc",
+                    "type": "public_managed"
+                },
+                {
+                    "id": "topic_2_id",
+                    "name": "Topic 2 Name",
+                    "description": "Topic 2 desc"
+                },
+                {
+                    "id": "topic_3_id",
+                    "name": "Topic 3 Name",
+                    "description": "Topic 3 desc"
+                },
+                {
+                    "id": "private_topic_1_id",
+                    "type": "private_managed",
+                    "description": "Private Topic 1 desc",
+                    "name": "Private Topic 1 Name"
+                },
+                {
+                    "id": "private_topic_2_id",
+                    "type": "private_managed",
+                    "description": "Private Topic 2 desc",
+                    "name": "Private Topic 2 Name"
+                }
+            ]
+        }
+    }
+}
+
+cofing_block_negative_team_size = {
+    "teams_configuration": {
+        "value": {
+            "max_team_size": -1,
+            "topics": [
+                {
+                    "max_team_size": 5,
+                    "name": "Topic 1 Name",
+                    "id": "topic_1_id",
+                    "description": "Topic 1 desc",
+                    "type": "public_managed"
+                },
+                {
+                    "id": "topic_2_id",
+                    "name": "Topic 2 Name",
+                    "description": "Topic 2 desc"
+                },
+                {
+                    "id": "topic_3_id",
+                    "name": "Topic 3 Name",
+                    "description": "Topic 3 desc"
+                },
+                {
+                    "id": "private_topic_1_id",
+                    "type": "private_managed",
+                    "description": "Private Topic 1 desc",
+                    "name": "Private Topic 1 Name"
+                },
+                {
+                    "id": "private_topic_2_id",
+                    "type": "private_managed",
+                    "description": "Private Topic 2 desc",
+                    "name": "Private Topic 2 Name"
+                }
+            ]
+        }
+    }
+}
+
+cofing_block_negative_local_team_size = {
+    "teams_configuration": {
+        "value": {
+            "max_team_size": 2,
+            "topics": [
+                {
+                    "max_team_size": -4,
+                    "name": "Topic 1 Name",
+                    "id": "topic_1_id",
+                    "description": "Topic 1 desc",
+                    "type": "public_managed"
+                },
+                {
+                    "id": "topic_2_id",
+                    "name": "Topic 2 Name",
+                    "description": "Topic 2 desc"
+                },
+                {
+                    "id": "topic_3_id",
+                    "name": "Topic 3 Name",
+                    "description": "Topic 3 desc"
+                },
+                {
+                    "id": "private_topic_1_id",
+                    "type": "private_managed",
+                    "description": "Private Topic 1 desc",
+                    "name": "Private Topic 1 Name"
+                },
+                {
+                    "id": "private_topic_2_id",
+                    "type": "private_managed",
+                    "description": "Private Topic 2 desc",
+                    "name": "Private Topic 2 Name"
+                }
+            ]
+        }
+    }
+}
+
+cofing_block_duplicate_id = {
+    "teams_configuration": {
+        "value": {
+            "max_team_size": 2,
+            "topics": [
+                {
+                    "max_team_size": 4,
+                    "name": "Topic 1 Name",
+                    "id": "topic_1_id",
+                    "description": "Topic 1 desc",
+                    "type": "public_managed"
+                },
+                {
+                    "id": "topic_1_id",
+                    "name": "Topic 2 Name",
+                    "description": "Topic 2 desc"
+                },
+                {
+                    "id": "topic_3_id",
+                    "name": "Topic 3 Name",
+                    "description": "Topic 3 desc"
+                },
+                {
+                    "id": "private_topic_1_id",
+                    "type": "private_managed",
+                    "description": "Private Topic 1 desc",
+                    "name": "Private Topic 1 Name"
+                },
+                {
+                    "id": "private_topic_2_id",
+                    "type": "private_managed",
+                    "description": "Private Topic 2 desc",
+                    "name": "Private Topic 2 Name"
+                }
+            ]
+        }
+    }
+}
+
+cofing_block_negative_team_size_dupe_id = {
+    "teams_configuration": {
+        "value": {
+            "max_team_size": 2,
+            "topics": [
+                {
+                    "max_team_size": -4,
+                    "name": "Topic 1 Name",
+                    "id": "topic_1_id",
+                    "description": "Topic 1 desc",
+                    "type": "public_managed"
+                },
+                {
+                    "id": "topic_2_id",
+                    "name": "Topic 2 Name",
+                    "description": "Topic 2 desc"
+                },
+                {
+                    "id": "topic_2_id",
+                    "name": "Topic 3 Name",
+                    "description": "Topic 3 desc"
+                },
+                {
+                    "id": "private_topic_1_id",
+                    "type": "private_managed",
+                    "description": "Private Topic 1 desc",
+                    "name": "Private Topic 1 Name"
+                },
+                {
+                    "id": "private_topic_2_id",
+                    "type": "private_managed",
+                    "description": "Private Topic 2 desc",
+                    "name": "Private Topic 2 Name"
+                }
+            ]
+        }
+    }
+}
+
+cofing_block_missing_name = {
+    "teams_configuration": {
+        "value": {
+            "max_team_size": 2,
+            "topics": [
+                {
+                    "max_team_size": 4,
+                    "name": "",
+                    "id": "topic_1_id",
+                    "description": "Topic 1 desc",
+                    "type": "public_managed"
+                },
+                {
+                    "id": "topic_2_id",
+                    "name": "Topic 2 Name",
+                    "description": "Topic 2 desc"
+                },
+                {
+                    "id": "topic_3_id",
+                    "name": "Topic 3 Name",
+                    "description": "Topic 3 desc"
+                },
+                {
+                    "id": "private_topic_1_id",
+                    "type": "private_managed",
+                    "description": "Private Topic 1 desc",
+                    "name": "Private Topic 1 Name"
+                },
+                {
+                    "id": "private_topic_2_id",
+                    "type": "private_managed",
+                    "description": "Private Topic 2 desc",
+                    "name": "Private Topic 2 Name"
+                }
+            ]
+        }
+    }
+}
+
+cofing_block_extra_attribute = {
+    "teams_configuration": {
+        "value": {
+            "max_team_size": 2,
+            "topics": [
+                {
+                    "max_team_size": 4,
+                    "name": "Topic 1 name",
+                    "id": "topic_1_id",
+                    "description": "Topic 1 desc",
+                    "type": "public_managed",
+                    "foo": "bar"
+                },
+                {
+                    "id": "topic_2_id",
+                    "name": "Topic 2 Name",
+                    "description": "Topic 2 desc"
+                },
+                {
+                    "id": "topic_3_id",
+                    "name": "Topic 3 Name",
+                    "description": "Topic 3 desc"
+                },
+                {
+                    "id": "private_topic_1_id",
+                    "type": "private_managed",
+                    "description": "Private Topic 1 desc",
+                    "name": "Private Topic 1 Name"
+                },
+                {
+                    "id": "private_topic_2_id",
+                    "type": "private_managed",
+                    "description": "Private Topic 2 desc",
+                    "name": "Private Topic 2 Name"
+                }
+            ]
+        }
+    }
+}
+
+
+@ddt.ddt
+class TeamsConfigurationTests(unittest.TestCase):
+    """
+    Test class for advanced settings of teams
+    """
+
+    @ddt.data(
+        (working_cofing_block, 0),
+        (cofing_block_negative_team_size, 1),
+        (cofing_block_negative_local_team_size, 1),
+        (cofing_block_duplicate_id, 1),
+        (cofing_block_negative_team_size_dupe_id, 2),
+        (cofing_block_missing_name, 1),
+        (cofing_block_extra_attribute, 1)
+    )
+    @ddt.unpack
+    def test_team_settings(self, config_block, number_of_errors):
+        result = CourseMetadata.validate_team_settings(config_block)
+        self.assertEqual(len(result), number_of_errors)


### PR DESCRIPTION
Add backend validation to team settings to capture various invalid conditions as outlined in the ticket.
Added new unit tests to cover those conditions.

[EDUCATOR-5300](https://openedx.atlassian.net/browse/EDUCATOR-5300)

@edx/masters-devs-gta 