### PR TITLE
Begin warning about sys.path hacks for cms/ as well & fix a bunch of imports

### DIFF
--- a/cms/djangoapps/api/urls.py
+++ b/cms/djangoapps/api/urls.py
@@ -5,7 +5,6 @@ URLs for the Studio API app
 
 from django.conf.urls import include, url
 
-
 app_name = 'cms.djangoapps.api'
 
 urlpatterns = [

--- a/cms/djangoapps/api/v1/serializers/course_runs.py
+++ b/cms/djangoapps/api/v1/serializers/course_runs.py
@@ -12,8 +12,8 @@ from opaque_keys import InvalidKeyError
 from rest_framework import serializers
 from rest_framework.fields import empty
 
-from cms.djangoapps.contentstore.views.course import create_new_course, get_course_and_check_access, rerun_course
 from cms.djangoapps.contentstore.views.assets import update_course_run_asset
+from cms.djangoapps.contentstore.views.course import create_new_course, get_course_and_check_access, rerun_course
 from openedx.core.lib.courses import course_image_url
 from student.models import CourseAccessRole
 from xmodule.modulestore.django import modulestore

--- a/cms/djangoapps/api/v1/serializers/course_runs.py
+++ b/cms/djangoapps/api/v1/serializers/course_runs.py
@@ -13,7 +13,7 @@ from rest_framework import serializers
 from rest_framework.fields import empty
 
 from cms.djangoapps.contentstore.views.course import create_new_course, get_course_and_check_access, rerun_course
-from contentstore.views.assets import update_course_run_asset
+from cms.djangoapps.contentstore.views.assets import update_course_run_asset
 from openedx.core.lib.courses import course_image_url
 from student.models import CourseAccessRole
 from xmodule.modulestore.django import modulestore

--- a/cms/djangoapps/api/v1/views/course_runs.py
+++ b/cms/djangoapps/api/v1/views/course_runs.py
@@ -10,7 +10,7 @@ from rest_framework.authentication import SessionAuthentication
 from rest_framework.decorators import action
 from rest_framework.response import Response
 
-from contentstore.views.course import _accessible_courses_iter, get_course_and_check_access
+from cms.djangoapps.contentstore.views.course import _accessible_courses_iter, get_course_and_check_access
 
 from ..serializers.course_runs import (
     CourseRunCreateSerializer,

--- a/cms/djangoapps/cms_user_tasks/apps.py
+++ b/cms/djangoapps/cms_user_tasks/apps.py
@@ -11,7 +11,7 @@ class CmsUserTasksConfig(AppConfig):
     """
     Application Configuration for cms_user_tasks.
     """
-    name = u'cms_user_tasks'
+    name = u'cms.djangoapps.cms_user_tasks'
 
     def ready(self):
         """

--- a/cms/djangoapps/cms_user_tasks/signals.py
+++ b/cms/djangoapps/cms_user_tasks/signals.py
@@ -5,12 +5,11 @@ Receivers of signals sent from django-user-tasks
 
 import logging
 
-from django.urls import reverse
 from django.dispatch import receiver
+from django.urls import reverse
+from six.moves.urllib.parse import urljoin
 from user_tasks.models import UserTaskArtifact
 from user_tasks.signals import user_task_stopped
-
-from six.moves.urllib.parse import urljoin
 
 from .tasks import send_task_complete_email
 

--- a/cms/djangoapps/cms_user_tasks/tests.py
+++ b/cms/djangoapps/cms_user_tasks/tests.py
@@ -221,16 +221,16 @@ class TestUserTaskStopped(APITestCase):
         with mock.patch('django.core.mail.send_mail') as mock_exception:
             mock_exception.side_effect = NoAuthHandlerFound()
 
-            with mock.patch('cms_user_tasks.tasks.send_task_complete_email.retry') as mock_retry:
+            with mock.patch('cms.djangoapps.cms_user_tasks.tasks.send_task_complete_email.retry') as mock_retry:
                 user_task_stopped.send(sender=UserTaskStatus, status=self.status)
                 self.assertTrue(mock_retry.called)
 
     def test_queue_email_failure(self):
-        logger = logging.getLogger("cms_user_tasks.signals")
+        logger = logging.getLogger("cms.djangoapps.cms_user_tasks.signals")
         hdlr = MockLoggingHandler(level="DEBUG")
         logger.addHandler(hdlr)
 
-        with mock.patch('cms_user_tasks.tasks.send_task_complete_email.delay') as mock_delay:
+        with mock.patch('cms.djangoapps.cms_user_tasks.tasks.send_task_complete_email.delay') as mock_delay:
             mock_delay.side_effect = NoAuthHandlerFound()
             user_task_stopped.send(sender=UserTaskStatus, status=self.status)
             self.assertTrue(mock_delay.called)

--- a/cms/djangoapps/cms_user_tasks/tests.py
+++ b/cms/djangoapps/cms_user_tasks/tests.py
@@ -11,8 +11,8 @@ from boto.exception import NoAuthHandlerFound
 from django.conf import settings
 from django.contrib.auth.models import User
 from django.core import mail
-from django.urls import reverse
 from django.test import override_settings
+from django.urls import reverse
 from rest_framework.test import APITestCase
 from user_tasks.models import UserTaskArtifact, UserTaskStatus
 from user_tasks.serializers import ArtifactSerializer, StatusSerializer

--- a/cms/djangoapps/contentstore/api/views/course_quality.py
+++ b/cms/djangoapps/contentstore/api/views/course_quality.py
@@ -8,7 +8,7 @@ from rest_framework.generics import GenericAPIView
 from rest_framework.response import Response
 from scipy import stats
 
-from contentstore.views.item import highlights_setting
+from cms.djangoapps.contentstore.views.item import highlights_setting
 from openedx.core.lib.api.view_utils import DeveloperErrorViewMixin, view_auth_classes
 from openedx.core.lib.cache_utils import request_cached
 from openedx.core.lib.graph_traversals import traverse_pre_order

--- a/cms/djangoapps/contentstore/api/views/course_validation.py
+++ b/cms/djangoapps/contentstore/api/views/course_validation.py
@@ -6,8 +6,8 @@ from pytz import UTC
 from rest_framework.generics import GenericAPIView
 from rest_framework.response import Response
 
-from contentstore.course_info_model import get_course_updates
 from cms.djangoapps.contentstore.views.certificates import CertificateManager
+from contentstore.course_info_model import get_course_updates
 from openedx.core.lib.api.view_utils import DeveloperErrorViewMixin, view_auth_classes
 from xmodule.course_metadata_utils import DEFAULT_GRADING_POLICY
 from xmodule.modulestore.django import modulestore

--- a/cms/djangoapps/contentstore/api/views/course_validation.py
+++ b/cms/djangoapps/contentstore/api/views/course_validation.py
@@ -7,7 +7,7 @@ from rest_framework.generics import GenericAPIView
 from rest_framework.response import Response
 
 from contentstore.course_info_model import get_course_updates
-from contentstore.views.certificates import CertificateManager
+from cms.djangoapps.contentstore.views.certificates import CertificateManager
 from openedx.core.lib.api.view_utils import DeveloperErrorViewMixin, view_auth_classes
 from xmodule.course_metadata_utils import DEFAULT_GRADING_POLICY
 from xmodule.modulestore.django import modulestore

--- a/cms/djangoapps/contentstore/apps.py
+++ b/cms/djangoapps/contentstore/apps.py
@@ -12,7 +12,7 @@ class ContentstoreConfig(AppConfig):
     """
     Application Configuration for Contentstore.
     """
-    name = u'contentstore'
+    name = u'cms.djangoapps.contentstore'
 
     def ready(self):
         """

--- a/cms/djangoapps/contentstore/config/waffle.py
+++ b/cms/djangoapps/contentstore/config/waffle.py
@@ -8,7 +8,7 @@ from openedx.core.djangoapps.waffle_utils import (
     CourseWaffleFlag,
     WaffleFlag,
     WaffleFlagNamespace,
-    WaffleSwitchNamespace,
+    WaffleSwitchNamespace
 )
 
 # Namespace

--- a/cms/djangoapps/contentstore/courseware_index.py
+++ b/cms/djangoapps/contentstore/courseware_index.py
@@ -5,8 +5,6 @@ import re
 from abc import ABCMeta, abstractmethod
 from datetime import timedelta
 
-from contentstore.course_group_config import GroupConfiguration
-from course_modes.models import CourseMode
 from django.conf import settings
 from django.urls import resolve
 from django.utils.translation import ugettext as _
@@ -14,11 +12,13 @@ from django.utils.translation import ugettext_lazy
 from eventtracking import tracker
 from search.search_engine_base import SearchEngine
 from six import add_metaclass, string_types, text_type
+
+from contentstore.course_group_config import GroupConfiguration
+from course_modes.models import CourseMode
+from openedx.core.lib.courses import course_image_url
 from xmodule.annotator_mixin import html_to_text
 from xmodule.library_tools import normalize_key_for_search
 from xmodule.modulestore import ModuleStoreEnum
-
-from openedx.core.lib.courses import course_image_url
 
 # REINDEX_AGE is the default amount of time that we look back for changes
 # that might have happened. If we are provided with a time at which the

--- a/cms/djangoapps/contentstore/management/commands/create_course.py
+++ b/cms/djangoapps/contentstore/management/commands/create_course.py
@@ -10,7 +10,7 @@ from django.core.management.base import BaseCommand, CommandError
 from six import text_type
 
 from contentstore.management.commands.utils import user_from_str
-from contentstore.views.course import create_new_course_in_store
+from cms.djangoapps.contentstore.views.course import create_new_course_in_store
 from xmodule.modulestore import ModuleStoreEnum
 from xmodule.modulestore.exceptions import DuplicateCourseError
 

--- a/cms/djangoapps/contentstore/management/commands/create_course.py
+++ b/cms/djangoapps/contentstore/management/commands/create_course.py
@@ -9,8 +9,8 @@ from django.contrib.auth.models import User
 from django.core.management.base import BaseCommand, CommandError
 from six import text_type
 
-from contentstore.management.commands.utils import user_from_str
 from cms.djangoapps.contentstore.views.course import create_new_course_in_store
+from contentstore.management.commands.utils import user_from_str
 from xmodule.modulestore import ModuleStoreEnum
 from xmodule.modulestore.exceptions import DuplicateCourseError
 

--- a/cms/djangoapps/contentstore/management/commands/delete_orphans.py
+++ b/cms/djangoapps/contentstore/management/commands/delete_orphans.py
@@ -5,7 +5,7 @@ from django.core.management.base import BaseCommand, CommandError
 from opaque_keys import InvalidKeyError
 from opaque_keys.edx.keys import CourseKey
 
-from contentstore.views.item import _delete_orphans
+from cms.djangoapps.contentstore.views.item import _delete_orphans
 from xmodule.modulestore import ModuleStoreEnum
 
 

--- a/cms/djangoapps/contentstore/management/commands/edit_course_tabs.py
+++ b/cms/djangoapps/contentstore/management/commands/edit_course_tabs.py
@@ -11,7 +11,7 @@
 from django.core.management.base import BaseCommand, CommandError
 from opaque_keys.edx.keys import CourseKey
 
-from contentstore.views import tabs
+from cms.djangoapps.contentstore.views import tabs
 from lms.djangoapps.courseware.courses import get_course_by_id
 
 from .prompt import query_yes_no

--- a/cms/djangoapps/contentstore/management/commands/generate_courses.py
+++ b/cms/djangoapps/contentstore/management/commands/generate_courses.py
@@ -11,7 +11,7 @@ from django.core.management.base import BaseCommand, CommandError
 from six import text_type
 
 from contentstore.management.commands.utils import user_from_str
-from contentstore.views.course import create_new_course_in_store
+from cms.djangoapps.contentstore.views.course import create_new_course_in_store
 from openedx.core.djangoapps.credit.models import CreditProvider
 from xmodule.course_module import CourseFields
 from xmodule.fields import Date

--- a/cms/djangoapps/contentstore/management/commands/generate_courses.py
+++ b/cms/djangoapps/contentstore/management/commands/generate_courses.py
@@ -10,8 +10,8 @@ from django.contrib.auth.models import User
 from django.core.management.base import BaseCommand, CommandError
 from six import text_type
 
-from contentstore.management.commands.utils import user_from_str
 from cms.djangoapps.contentstore.views.course import create_new_course_in_store
+from contentstore.management.commands.utils import user_from_str
 from openedx.core.djangoapps.credit.models import CreditProvider
 from xmodule.course_module import CourseFields
 from xmodule.fields import Date

--- a/cms/djangoapps/contentstore/management/commands/sync_courses.py
+++ b/cms/djangoapps/contentstore/management/commands/sync_courses.py
@@ -11,7 +11,7 @@ from opaque_keys.edx.keys import CourseKey
 from six import text_type
 
 from contentstore.management.commands.utils import user_from_str
-from contentstore.views.course import create_new_course_in_store
+from cms.djangoapps.contentstore.views.course import create_new_course_in_store
 from openedx.core.djangoapps.catalog.utils import get_course_runs
 from xmodule.modulestore import ModuleStoreEnum
 from xmodule.modulestore.exceptions import DuplicateCourseError

--- a/cms/djangoapps/contentstore/management/commands/sync_courses.py
+++ b/cms/djangoapps/contentstore/management/commands/sync_courses.py
@@ -10,8 +10,8 @@ from django.core.management.base import BaseCommand, CommandError
 from opaque_keys.edx.keys import CourseKey
 from six import text_type
 
-from contentstore.management.commands.utils import user_from_str
 from cms.djangoapps.contentstore.views.course import create_new_course_in_store
+from contentstore.management.commands.utils import user_from_str
 from openedx.core.djangoapps.catalog.utils import get_course_runs
 from xmodule.modulestore import ModuleStoreEnum
 from xmodule.modulestore.exceptions import DuplicateCourseError

--- a/cms/djangoapps/contentstore/management/commands/tests/test_create_course.py
+++ b/cms/djangoapps/contentstore/management/commands/tests/test_create_course.py
@@ -3,12 +3,11 @@ Unittests for creating a course in an chosen modulestore
 """
 
 
-from six import StringIO
-
 import ddt
 import six
 from django.core.management import CommandError, call_command
 from django.test import TestCase
+from six import StringIO
 
 from xmodule.modulestore import ModuleStoreEnum
 from xmodule.modulestore.django import modulestore

--- a/cms/djangoapps/contentstore/management/commands/tests/test_delete_course.py
+++ b/cms/djangoapps/contentstore/management/commands/tests/test_delete_course.py
@@ -20,7 +20,7 @@ class DeleteCourseTests(ModuleStoreTestCase):
     Test for course deleting functionality of the 'delete_course' command
     """
     MODULESTORE = TEST_DATA_SPLIT_MODULESTORE
-    YESNO_PATCH_LOCATION = 'contentstore.management.commands.delete_course.query_yes_no'
+    YESNO_PATCH_LOCATION = 'cms.djangoapps.contentstore.management.commands.delete_course.query_yes_no'
 
     def test_invalid_course_key(self):
         course_run_key = 'foo/TestX/TS01/2015_Q7'

--- a/cms/djangoapps/contentstore/management/commands/tests/test_force_publish.py
+++ b/cms/djangoapps/contentstore/management/commands/tests/test_force_publish.py
@@ -107,7 +107,7 @@ class TestForcePublishModifications(ModuleStoreTestCase):
         # verify that draft and publish point to different versions
         self.assertNotEqual(draft_version, published_version)
 
-        with mock.patch('contentstore.management.commands.force_publish.query_yes_no') as patched_yes_no:
+        with mock.patch('cms.djangoapps.contentstore.management.commands.force_publish.query_yes_no') as patched_yes_no:
             patched_yes_no.return_value = True
 
             # force publish course

--- a/cms/djangoapps/contentstore/management/commands/tests/test_generate_courses.py
+++ b/cms/djangoapps/contentstore/management/commands/tests/test_generate_courses.py
@@ -19,7 +19,7 @@ class TestGenerateCourses(ModuleStoreTestCase):
     Unit tests for creating a course in split store via command line
     """
 
-    @mock.patch('contentstore.management.commands.generate_courses.logger')
+    @mock.patch('cms.djangoapps.contentstore.management.commands.generate_courses.logger')
     def test_generate_course_in_stores(self, mock_logger):
         """
         Test that a course is created successfully
@@ -56,7 +56,7 @@ class TestGenerateCourses(ModuleStoreTestCase):
             arg = json.dumps(settings)
             call_command("generate_courses", arg)
 
-    @mock.patch('contentstore.management.commands.generate_courses.logger')
+    @mock.patch('cms.djangoapps.contentstore.management.commands.generate_courses.logger')
     @ddt.data("organization", "number", "run", "fields")
     def test_missing_course_settings(self, setting, mock_logger):
         """
@@ -74,7 +74,7 @@ class TestGenerateCourses(ModuleStoreTestCase):
         call_command("generate_courses", arg)
         mock_logger.warning.assert_any_call("Course json is missing " + setting)
 
-    @mock.patch('contentstore.management.commands.generate_courses.logger')
+    @mock.patch('cms.djangoapps.contentstore.management.commands.generate_courses.logger')
     def test_invalid_user(self, mock_logger):
         """
         Test that providing an invalid user in the course JSON will result in the appropriate error message
@@ -90,7 +90,7 @@ class TestGenerateCourses(ModuleStoreTestCase):
         call_command("generate_courses", arg)
         mock_logger.warning.assert_any_call("invalid_user user does not exist")
 
-    @mock.patch('contentstore.management.commands.generate_courses.logger')
+    @mock.patch('cms.djangoapps.contentstore.management.commands.generate_courses.logger')
     def test_missing_display_name(self, mock_logger):
         """
         Test that missing required display_name in JSON object will result in the appropriate error message
@@ -106,7 +106,7 @@ class TestGenerateCourses(ModuleStoreTestCase):
         call_command("generate_courses", arg)
         mock_logger.warning.assert_any_call("Fields json is missing display_name")
 
-    @mock.patch('contentstore.management.commands.generate_courses.logger')
+    @mock.patch('cms.djangoapps.contentstore.management.commands.generate_courses.logger')
     def test_invalid_course_field(self, mock_logger):
         """
         Test that an invalid course field will result in the appropriate message
@@ -122,7 +122,7 @@ class TestGenerateCourses(ModuleStoreTestCase):
         call_command("generate_courses", arg)
         mock_logger.info.assert_any_call((u'invalid_field') + "is not a valid CourseField")
 
-    @mock.patch('contentstore.management.commands.generate_courses.logger')
+    @mock.patch('cms.djangoapps.contentstore.management.commands.generate_courses.logger')
     def test_invalid_date_setting(self, mock_logger):
         """
         Test that an invalid date json will result in the appropriate message
@@ -138,7 +138,7 @@ class TestGenerateCourses(ModuleStoreTestCase):
         call_command("generate_courses", arg)
         mock_logger.info.assert_any_call("The date string could not be parsed for announcement")
 
-    @mock.patch('contentstore.management.commands.generate_courses.logger')
+    @mock.patch('cms.djangoapps.contentstore.management.commands.generate_courses.logger')
     def test_invalid_course_tab_list_setting(self, mock_logger):
         """
         Test that an invalid course tab list json will result in the appropriate message
@@ -154,7 +154,7 @@ class TestGenerateCourses(ModuleStoreTestCase):
         call_command("generate_courses", arg)
         mock_logger.info.assert_any_call("The course tab list string could not be parsed for tabs")
 
-    @mock.patch('contentstore.management.commands.generate_courses.logger')
+    @mock.patch('cms.djangoapps.contentstore.management.commands.generate_courses.logger')
     @ddt.data("mobile_available", "enable_proctored_exams")
     def test_missing_course_fields(self, field, mock_logger):
         """

--- a/cms/djangoapps/contentstore/management/commands/tests/test_migrate_to_split.py
+++ b/cms/djangoapps/contentstore/management/commands/tests/test_migrate_to_split.py
@@ -4,7 +4,6 @@ Unittests for migrating a course to split mongo
 
 
 import six
-
 from django.core.management import CommandError, call_command
 from django.test import TestCase
 

--- a/cms/djangoapps/contentstore/management/commands/tests/test_reindex_courses.py
+++ b/cms/djangoapps/contentstore/management/commands/tests/test_reindex_courses.py
@@ -36,9 +36,9 @@ class TestReindexCourse(ModuleStoreTestCase):
             org="test", course="course2", display_name="run1"
         )
 
-    REINDEX_PATH_LOCATION = 'contentstore.management.commands.reindex_course.CoursewareSearchIndexer.do_course_reindex'
-    MODULESTORE_PATCH_LOCATION = 'contentstore.management.commands.reindex_course.modulestore'
-    YESNO_PATCH_LOCATION = 'contentstore.management.commands.reindex_course.query_yes_no'
+    REINDEX_PATH_LOCATION = 'cms.djangoapps.contentstore.management.commands.reindex_course.CoursewareSearchIndexer.do_course_reindex'
+    MODULESTORE_PATCH_LOCATION = 'cms.djangoapps.contentstore.management.commands.reindex_course.modulestore'
+    YESNO_PATCH_LOCATION = 'cms.djangoapps.contentstore.management.commands.reindex_course.query_yes_no'
 
     def _get_lib_key(self, library):
         """ Get's library key as it is passed to indexer """

--- a/cms/djangoapps/contentstore/management/commands/tests/test_reindex_courses.py
+++ b/cms/djangoapps/contentstore/management/commands/tests/test_reindex_courses.py
@@ -36,7 +36,9 @@ class TestReindexCourse(ModuleStoreTestCase):
             org="test", course="course2", display_name="run1"
         )
 
-    REINDEX_PATH_LOCATION = 'cms.djangoapps.contentstore.management.commands.reindex_course.CoursewareSearchIndexer.do_course_reindex'
+    REINDEX_PATH_LOCATION = (
+        'cms.djangoapps.contentstore.management.commands.reindex_course.CoursewareSearchIndexer.do_course_reindex'
+    )
     MODULESTORE_PATCH_LOCATION = 'cms.djangoapps.contentstore.management.commands.reindex_course.modulestore'
     YESNO_PATCH_LOCATION = 'cms.djangoapps.contentstore.management.commands.reindex_course.query_yes_no'
 

--- a/cms/djangoapps/contentstore/management/commands/tests/test_reindex_courses.py
+++ b/cms/djangoapps/contentstore/management/commands/tests/test_reindex_courses.py
@@ -3,8 +3,8 @@
 
 import ddt
 import mock
-from django.core.management import CommandError, call_command
 import six
+from django.core.management import CommandError, call_command
 from six import text_type
 
 from contentstore.courseware_index import SearchIndexingError

--- a/cms/djangoapps/contentstore/management/commands/tests/test_reindex_library.py
+++ b/cms/djangoapps/contentstore/management/commands/tests/test_reindex_library.py
@@ -36,9 +36,9 @@ class TestReindexLibrary(ModuleStoreTestCase):
             org="test", course="course2", display_name="run1", default_store=ModuleStoreEnum.Type.split
         )
 
-    REINDEX_PATH_LOCATION = 'contentstore.management.commands.reindex_library.LibrarySearchIndexer.do_library_reindex'
-    MODULESTORE_PATCH_LOCATION = 'contentstore.management.commands.reindex_library.modulestore'
-    YESNO_PATCH_LOCATION = 'contentstore.management.commands.reindex_library.query_yes_no'
+    REINDEX_PATH_LOCATION = 'cms.djangoapps.contentstore.management.commands.reindex_library.LibrarySearchIndexer.do_library_reindex'
+    MODULESTORE_PATCH_LOCATION = 'cms.djangoapps.contentstore.management.commands.reindex_library.modulestore'
+    YESNO_PATCH_LOCATION = 'cms.djangoapps.contentstore.management.commands.reindex_library.query_yes_no'
 
     def _get_lib_key(self, library):
         """ Get's library key as it is passed to indexer """

--- a/cms/djangoapps/contentstore/management/commands/tests/test_reindex_library.py
+++ b/cms/djangoapps/contentstore/management/commands/tests/test_reindex_library.py
@@ -36,7 +36,9 @@ class TestReindexLibrary(ModuleStoreTestCase):
             org="test", course="course2", display_name="run1", default_store=ModuleStoreEnum.Type.split
         )
 
-    REINDEX_PATH_LOCATION = 'cms.djangoapps.contentstore.management.commands.reindex_library.LibrarySearchIndexer.do_library_reindex'
+    REINDEX_PATH_LOCATION = (
+        'cms.djangoapps.contentstore.management.commands.reindex_library.LibrarySearchIndexer.do_library_reindex'
+    )
     MODULESTORE_PATCH_LOCATION = 'cms.djangoapps.contentstore.management.commands.reindex_library.modulestore'
     YESNO_PATCH_LOCATION = 'cms.djangoapps.contentstore.management.commands.reindex_library.query_yes_no'
 

--- a/cms/djangoapps/contentstore/management/commands/tests/test_sync_courses.py
+++ b/cms/djangoapps/contentstore/management/commands/tests/test_sync_courses.py
@@ -14,7 +14,7 @@ from xmodule.modulestore import ModuleStoreEnum
 from xmodule.modulestore.django import modulestore
 from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
 
-COMMAND_MODULE = 'contentstore.management.commands.sync_courses'
+COMMAND_MODULE = 'cms.djangoapps.contentstore.management.commands.sync_courses'
 
 
 @mock.patch(COMMAND_MODULE + '.get_course_runs')

--- a/cms/djangoapps/contentstore/management/commands/tests/test_sync_courses.py
+++ b/cms/djangoapps/contentstore/management/commands/tests/test_sync_courses.py
@@ -6,7 +6,7 @@ from django.core.management import call_command
 from opaque_keys.edx.keys import CourseKey
 from testfixtures import LogCapture
 
-from contentstore.views.course import create_new_course_in_store
+from cms.djangoapps.contentstore.views.course import create_new_course_in_store
 from openedx.core.djangoapps.catalog.tests.factories import CourseRunFactory
 from openedx.core.djangoapps.content.course_overviews.models import CourseOverview
 from student.tests.factories import UserFactory

--- a/cms/djangoapps/contentstore/proctoring.py
+++ b/cms/djangoapps/contentstore/proctoring.py
@@ -18,9 +18,10 @@ from edx_proctoring.api import (
 )
 from edx_proctoring.exceptions import ProctoredExamNotFoundException, ProctoredExamReviewPolicyNotFoundException
 
-from .views.helpers import is_item_in_course_tree
 from xmodule.modulestore.django import modulestore
 from xmodule.modulestore.exceptions import ItemNotFoundError
+
+from .views.helpers import is_item_in_course_tree
 
 log = logging.getLogger(__name__)
 

--- a/cms/djangoapps/contentstore/proctoring.py
+++ b/cms/djangoapps/contentstore/proctoring.py
@@ -18,7 +18,7 @@ from edx_proctoring.api import (
 )
 from edx_proctoring.exceptions import ProctoredExamNotFoundException, ProctoredExamReviewPolicyNotFoundException
 
-from contentstore.views.helpers import is_item_in_course_tree
+from .views.helpers import is_item_in_course_tree
 from xmodule.modulestore.django import modulestore
 from xmodule.modulestore.exceptions import ItemNotFoundError
 

--- a/cms/djangoapps/contentstore/rest_api/urls.py
+++ b/cms/djangoapps/contentstore/rest_api/urls.py
@@ -3,6 +3,7 @@ Contentstore API URLs.
 """
 
 from django.urls import include, re_path
+
 from .v1 import urls as v1_urls
 
 app_name = 'cms.djangoapps.contentstore'

--- a/cms/djangoapps/contentstore/rest_api/v1/tests/test_views.py
+++ b/cms/djangoapps/contentstore/rest_api/v1/tests/test_views.py
@@ -2,12 +2,11 @@
 Unit tests for Contentstore views.
 """
 
-from django.urls import reverse
 from django.test.utils import override_settings
-
+from django.urls import reverse
+from opaque_keys.edx.keys import CourseKey
 from rest_framework import status
 from rest_framework.test import APITestCase
-from opaque_keys.edx.keys import CourseKey
 
 from lms.djangoapps.courseware.tests.factories import GlobalStaffFactory, InstructorFactory
 from student.tests.factories import UserFactory

--- a/cms/djangoapps/contentstore/rest_api/v1/urls.py
+++ b/cms/djangoapps/contentstore/rest_api/v1/urls.py
@@ -2,8 +2,9 @@
 
 from django.urls import re_path
 
-from . import views
 from openedx.core.constants import COURSE_ID_PATTERN
+
+from . import views
 
 app_name = 'v1'
 

--- a/cms/djangoapps/contentstore/rest_api/v1/views.py
+++ b/cms/djangoapps/contentstore/rest_api/v1/views.py
@@ -7,17 +7,16 @@ from rest_framework.exceptions import NotFound
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
-from common.lib.xmodule.xmodule.course_module import get_available_providers
 from cms.djangoapps.contentstore.views.course import get_course_and_check_access
+from common.lib.xmodule.xmodule.course_module import get_available_providers
+from contentstore.rest_api.v1.serializers import (
+    LimitedProctoredExamSettingsSerializer,
+    ProctoredExamConfigurationSerializer,
+    ProctoredExamSettingsSerializer
+)
 from models.settings.course_metadata import CourseMetadata
 from openedx.core.lib.api.view_utils import view_auth_classes
 from xmodule.modulestore.django import modulestore
-
-from contentstore.rest_api.v1.serializers import (
-    ProctoredExamConfigurationSerializer,
-    ProctoredExamSettingsSerializer,
-    LimitedProctoredExamSettingsSerializer,
-)
 
 
 @view_auth_classes()

--- a/cms/djangoapps/contentstore/rest_api/v1/views.py
+++ b/cms/djangoapps/contentstore/rest_api/v1/views.py
@@ -8,7 +8,7 @@ from rest_framework.response import Response
 from rest_framework.views import APIView
 
 from common.lib.xmodule.xmodule.course_module import get_available_providers
-from contentstore.views.course import get_course_and_check_access
+from cms.djangoapps.contentstore.views.course import get_course_and_check_access
 from models.settings.course_metadata import CourseMetadata
 from openedx.core.lib.api.view_utils import view_auth_classes
 from xmodule.modulestore.django import modulestore

--- a/cms/djangoapps/contentstore/tasks.py
+++ b/cms/djangoapps/contentstore/tasks.py
@@ -449,7 +449,7 @@ def import_olx(self, user_id, course_key_string, archive_path, archive_name, lan
             if courselike_module.entrance_exam_enabled:
                 fake_request = RequestFactory().get(u'/')
                 fake_request.user = user
-                from contentstore.views.entrance_exam import remove_entrance_exam_milestone_reference
+                from .views.entrance_exam import remove_entrance_exam_milestone_reference
                 # TODO: Is this really ok?  Seems dangerous for a live course
                 remove_entrance_exam_milestone_reference(fake_request, courselike_key)
                 LOGGER.info(
@@ -549,6 +549,6 @@ def import_olx(self, user_id, course_key_string, archive_path, archive_name, lan
 
                 metadata = {u'entrance_exam_id': text_type(entrance_exam_chapter.location)}
                 CourseMetadata.update_from_dict(metadata, course, user)
-                from contentstore.views.entrance_exam import add_entrance_exam_milestone
+                from .views.entrance_exam import add_entrance_exam_milestone
                 add_entrance_exam_milestone(course.id, entrance_exam_chapter)
                 LOGGER.info(u'Course %s Entrance exam imported', course.id)

--- a/cms/djangoapps/contentstore/tasks.py
+++ b/cms/djangoapps/contentstore/tasks.py
@@ -12,11 +12,11 @@ from datetime import datetime
 from math import ceil
 from tempfile import NamedTemporaryFile, mkdtemp
 
+from ccx_keys.locator import CCXLocator
 from celery import group
 from celery.task import task
 from celery.utils.log import get_task_logger
 from celery_utils.persist_on_failure import LoggedPersistOnFailureTask
-from ccx_keys.locator import CCXLocator
 from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.contrib.auth.models import User

--- a/cms/djangoapps/contentstore/tests/test_contentstore.py
+++ b/cms/djangoapps/contentstore/tests/test_contentstore.py
@@ -33,7 +33,7 @@ from waffle.testutils import override_switch
 from contentstore.config import waffle
 from contentstore.tests.utils import AjaxEnabledTestClient, CourseTestCase, get_url, parse_json
 from contentstore.utils import delete_course, reverse_course_url, reverse_url
-from contentstore.views.component import ADVANCED_COMPONENT_TYPES
+from cms.djangoapps.contentstore.views.component import ADVANCED_COMPONENT_TYPES
 from course_action_state.managers import CourseActionStateItemNotFoundError
 from course_action_state.models import CourseRerunState, CourseRerunUIStateManager
 from openedx.core.djangoapps.django_comment_common.utils import are_permissions_roles_seeded

--- a/cms/djangoapps/contentstore/tests/test_contentstore.py
+++ b/cms/djangoapps/contentstore/tests/test_contentstore.py
@@ -30,10 +30,10 @@ from six import text_type
 from six.moves import range
 from waffle.testutils import override_switch
 
+from cms.djangoapps.contentstore.views.component import ADVANCED_COMPONENT_TYPES
 from contentstore.config import waffle
 from contentstore.tests.utils import AjaxEnabledTestClient, CourseTestCase, get_url, parse_json
 from contentstore.utils import delete_course, reverse_course_url, reverse_url
-from cms.djangoapps.contentstore.views.component import ADVANCED_COMPONENT_TYPES
 from course_action_state.managers import CourseActionStateItemNotFoundError
 from course_action_state.models import CourseRerunState, CourseRerunUIStateManager
 from openedx.core.djangoapps.django_comment_common.utils import are_permissions_roles_seeded

--- a/cms/djangoapps/contentstore/tests/test_course_listing.py
+++ b/cms/djangoapps/contentstore/tests/test_course_listing.py
@@ -16,7 +16,7 @@ from six.moves import range
 
 from contentstore.tests.utils import AjaxEnabledTestClient
 from contentstore.utils import delete_course
-from contentstore.views.course import (
+from cms.djangoapps.contentstore.views.course import (
     AccessListFallback,
     _accessible_courses_iter_for_tests,
     _accessible_courses_list_from_groups,

--- a/cms/djangoapps/contentstore/tests/test_course_listing.py
+++ b/cms/djangoapps/contentstore/tests/test_course_listing.py
@@ -14,8 +14,6 @@ from mock import Mock, patch
 from opaque_keys.edx.locations import CourseLocator
 from six.moves import range
 
-from contentstore.tests.utils import AjaxEnabledTestClient
-from contentstore.utils import delete_course
 from cms.djangoapps.contentstore.views.course import (
     AccessListFallback,
     _accessible_courses_iter_for_tests,
@@ -23,6 +21,8 @@ from cms.djangoapps.contentstore.views.course import (
     _accessible_courses_summary_iter,
     get_courses_accessible_to_user
 )
+from contentstore.tests.utils import AjaxEnabledTestClient
+from contentstore.utils import delete_course
 from course_action_state.models import CourseRerunState
 from student.roles import (
     CourseInstructorRole,

--- a/cms/djangoapps/contentstore/tests/test_course_settings.py
+++ b/cms/djangoapps/contentstore/tests/test_course_settings.py
@@ -20,12 +20,12 @@ from milestones.tests.utils import MilestonesTestCaseMixin
 from mock import Mock, patch
 from pytz import UTC
 
-from contentstore.utils import reverse_course_url, reverse_usage_url
+from cms.djangoapps.contentstore.utils import reverse_course_url, reverse_usage_url
 from course_modes.models import CourseMode
-from models.settings.course_grading import GRADING_POLICY_CHANGED_EVENT_TYPE, CourseGradingModel, hash_grading_policy
-from models.settings.course_metadata import CourseMetadata
-from models.settings.encoder import CourseSettingsEncoder
-from models.settings.waffle import MATERIAL_RECOMPUTE_ONLY_FLAG
+from cms.djangoapps.models.settings.course_grading import GRADING_POLICY_CHANGED_EVENT_TYPE, CourseGradingModel, hash_grading_policy
+from cms.djangoapps.models.settings.course_metadata import CourseMetadata
+from cms.djangoapps.models.settings.encoder import CourseSettingsEncoder
+from cms.djangoapps.models.settings.waffle import MATERIAL_RECOMPUTE_ONLY_FLAG
 from openedx.core.djangoapps.models.course_details import CourseDetails
 from openedx.core.djangoapps.waffle_utils.testutils import override_waffle_flag
 from student.roles import CourseInstructorRole, CourseStaffRole

--- a/cms/djangoapps/contentstore/tests/test_course_settings.py
+++ b/cms/djangoapps/contentstore/tests/test_course_settings.py
@@ -511,8 +511,8 @@ class CourseGradingTest(CourseTestCase):
             self.assertDictEqual(grader, subgrader, str(i) + "th graders not equal")
 
     @mock.patch('track.event_transaction_utils.uuid4')
-    @mock.patch('models.settings.course_grading.tracker')
-    @mock.patch('contentstore.signals.signals.GRADING_POLICY_CHANGED.send')
+    @mock.patch('cms.djangoapps.models.settings.course_grading.tracker')
+    @mock.patch('cms.djangoapps.contentstore.signals.signals.GRADING_POLICY_CHANGED.send')
     @ddt.data(ModuleStoreEnum.Type.mongo, ModuleStoreEnum.Type.split)
     def test_update_from_json(self, store, send_signal, tracker, uuid):
         uuid.return_value = "mockUUID"
@@ -648,8 +648,8 @@ class CourseGradingTest(CourseTestCase):
         self.assertTrue(result)
 
     @mock.patch('track.event_transaction_utils.uuid4')
-    @mock.patch('models.settings.course_grading.tracker')
-    @mock.patch('contentstore.signals.signals.GRADING_POLICY_CHANGED.send')
+    @mock.patch('cms.djangoapps.models.settings.course_grading.tracker')
+    @mock.patch('cms.djangoapps.contentstore.signals.signals.GRADING_POLICY_CHANGED.send')
     def test_update_grader_from_json(self, send_signal, tracker, uuid):
         uuid.return_value = 'mockUUID'
         test_grader = CourseGradingModel.fetch(self.course.id)
@@ -693,7 +693,7 @@ class CourseGradingTest(CourseTestCase):
         ], any_order=True)
 
     @mock.patch('track.event_transaction_utils.uuid4')
-    @mock.patch('models.settings.course_grading.tracker')
+    @mock.patch('cms.djangoapps.models.settings.course_grading.tracker')
     def test_update_cutoffs_from_json(self, tracker, uuid):
         uuid.return_value = 'mockUUID'
         test_grader = CourseGradingModel.fetch(self.course.id)
@@ -754,8 +754,8 @@ class CourseGradingTest(CourseTestCase):
         self.assertEqual(None, altered_grader.grace_period, "Delete grace period")
 
     @mock.patch('track.event_transaction_utils.uuid4')
-    @mock.patch('models.settings.course_grading.tracker')
-    @mock.patch('contentstore.signals.signals.GRADING_POLICY_CHANGED.send')
+    @mock.patch('cms.djangoapps.models.settings.course_grading.tracker')
+    @mock.patch('cms.djangoapps.contentstore.signals.signals.GRADING_POLICY_CHANGED.send')
     def test_update_section_grader_type(self, send_signal, tracker, uuid):
         uuid.return_value = 'mockUUID'
         # Get the descriptor and the section_grader_type and assert they are the default values
@@ -834,7 +834,7 @@ class CourseGradingTest(CourseTestCase):
         grader_sample = self._model_from_url(grader_type_url_base + '/1')
         self.assertEqual(grader_sample, whole_model['graders'][1])
 
-    @mock.patch('contentstore.signals.signals.GRADING_POLICY_CHANGED.send')
+    @mock.patch('cms.djangoapps.contentstore.signals.signals.GRADING_POLICY_CHANGED.send')
     def test_add_delete_grader(self, send_signal):
         grader_type_url_base = get_url(self.course.id, 'grading_handler')
         original_model = self._model_from_url(grader_type_url_base)

--- a/cms/djangoapps/contentstore/tests/test_course_settings.py
+++ b/cms/djangoapps/contentstore/tests/test_course_settings.py
@@ -21,11 +21,15 @@ from mock import Mock, patch
 from pytz import UTC
 
 from cms.djangoapps.contentstore.utils import reverse_course_url, reverse_usage_url
-from course_modes.models import CourseMode
-from cms.djangoapps.models.settings.course_grading import GRADING_POLICY_CHANGED_EVENT_TYPE, CourseGradingModel, hash_grading_policy
+from cms.djangoapps.models.settings.course_grading import (
+    GRADING_POLICY_CHANGED_EVENT_TYPE,
+    CourseGradingModel,
+    hash_grading_policy
+)
 from cms.djangoapps.models.settings.course_metadata import CourseMetadata
 from cms.djangoapps.models.settings.encoder import CourseSettingsEncoder
 from cms.djangoapps.models.settings.waffle import MATERIAL_RECOMPUTE_ONLY_FLAG
+from course_modes.models import CourseMode
 from openedx.core.djangoapps.models.course_details import CourseDetails
 from openedx.core.djangoapps.waffle_utils.testutils import override_waffle_flag
 from student.roles import CourseInstructorRole, CourseStaffRole

--- a/cms/djangoapps/contentstore/tests/test_courseware_index.py
+++ b/cms/djangoapps/contentstore/tests/test_courseware_index.py
@@ -56,7 +56,6 @@ from xmodule.partitions.partitions import UserPartition
 from xmodule.tests import DATA_DIR
 from xmodule.x_module import XModuleMixin
 
-
 COURSE_CHILD_STRUCTURE = {
     "course": "chapter",
     "chapter": "sequential",

--- a/cms/djangoapps/contentstore/tests/test_courseware_index.py
+++ b/cms/djangoapps/contentstore/tests/test_courseware_index.py
@@ -762,7 +762,7 @@ class TestTaskExecution(SharedModuleStoreTestCase):
         # as it encounters a CCX key. If that isn't working properly, it will
         # fall through to the normal indexing and raise an exception because
         # there is no data or backing course behind the course key.
-        with patch('contentstore.courseware_index.CoursewareSearchIndexer.index') as mock_index:
+        with patch('cms.djangoapps.contentstore.courseware_index.CoursewareSearchIndexer.index') as mock_index:
             self.assertIsNone(
                 update_search_index(
                     "ccx-v1:OpenEdX+FAKECOURSE+FAKERUN+ccx@1", "2020-09-28T16:41:57.150796"

--- a/cms/djangoapps/contentstore/tests/test_gating.py
+++ b/cms/djangoapps/contentstore/tests/test_gating.py
@@ -45,8 +45,8 @@ class TestHandleItemDeleted(ModuleStoreTestCase, MilestonesTestCaseMixin):
         gating_api.add_prerequisite(self.course.id, self.open_seq.location)
         gating_api.set_required_content(self.course.id, self.gated_seq.location, self.open_seq.location, 100, 100)
 
-    @patch('contentstore.signals.handlers.gating_api.set_required_content')
-    @patch('contentstore.signals.handlers.gating_api.remove_prerequisite')
+    @patch('cms.djangoapps.contentstore.signals.handlers.gating_api.set_required_content')
+    @patch('cms.djangoapps.contentstore.signals.handlers.gating_api.remove_prerequisite')
     def test_chapter_deleted(self, mock_remove_prereq, mock_set_required):
         """ Test gating milestone data is cleanup up when course content item is deleted """
         handle_item_deleted(usage_key=self.chapter.location, user_id=0)
@@ -55,8 +55,8 @@ class TestHandleItemDeleted(ModuleStoreTestCase, MilestonesTestCaseMixin):
             self.open_seq.location.course_key, self.open_seq.location, None, None, None
         )
 
-    @patch('contentstore.signals.handlers.gating_api.set_required_content')
-    @patch('contentstore.signals.handlers.gating_api.remove_prerequisite')
+    @patch('cms.djangoapps.contentstore.signals.handlers.gating_api.set_required_content')
+    @patch('cms.djangoapps.contentstore.signals.handlers.gating_api.remove_prerequisite')
     def test_sequential_deleted(self, mock_remove_prereq, mock_set_required):
         """ Test gating milestone data is cleanup up when course content item is deleted """
         handle_item_deleted(usage_key=self.open_seq.location, user_id=0)

--- a/cms/djangoapps/contentstore/tests/test_i18n.py
+++ b/cms/djangoapps/contentstore/tests/test_i18n.py
@@ -13,7 +13,7 @@ from django.utils import translation
 from django.utils.translation import get_language
 
 from contentstore.tests.utils import AjaxEnabledTestClient
-from contentstore.views.preview import _preview_module_system
+from cms.djangoapps.contentstore.views.preview import _preview_module_system
 from openedx.core.lib.edx_six import get_gettext
 from xmodule.modulestore.django import ModuleI18nService
 from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase

--- a/cms/djangoapps/contentstore/tests/test_i18n.py
+++ b/cms/djangoapps/contentstore/tests/test_i18n.py
@@ -12,8 +12,8 @@ from django.contrib.auth.models import User
 from django.utils import translation
 from django.utils.translation import get_language
 
-from contentstore.tests.utils import AjaxEnabledTestClient
 from cms.djangoapps.contentstore.views.preview import _preview_module_system
+from contentstore.tests.utils import AjaxEnabledTestClient
 from openedx.core.lib.edx_six import get_gettext
 from xmodule.modulestore.django import ModuleI18nService
 from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase

--- a/cms/djangoapps/contentstore/tests/test_libraries.py
+++ b/cms/djangoapps/contentstore/tests/test_libraries.py
@@ -12,9 +12,9 @@ from six.moves import range
 
 from contentstore.tests.utils import AjaxEnabledTestClient, parse_json
 from contentstore.utils import reverse_library_url, reverse_url, reverse_usage_url
-from contentstore.views.item import _duplicate_item
-from contentstore.views.preview import _load_preview_module
-from contentstore.views.tests.test_library import LIBRARY_REST_URL
+from cms.djangoapps.contentstore.views.item import _duplicate_item
+from cms.djangoapps.contentstore.views.preview import _load_preview_module
+from cms.djangoapps.contentstore.views.tests.test_library import LIBRARY_REST_URL
 from course_creators.views import add_user_with_status_granted
 from student import auth
 from student.auth import has_studio_read_access, has_studio_write_access

--- a/cms/djangoapps/contentstore/tests/test_libraries.py
+++ b/cms/djangoapps/contentstore/tests/test_libraries.py
@@ -10,11 +10,11 @@ from mock import Mock, patch
 from opaque_keys.edx.locator import CourseKey, LibraryLocator
 from six.moves import range
 
-from contentstore.tests.utils import AjaxEnabledTestClient, parse_json
-from contentstore.utils import reverse_library_url, reverse_url, reverse_usage_url
 from cms.djangoapps.contentstore.views.item import _duplicate_item
 from cms.djangoapps.contentstore.views.preview import _load_preview_module
 from cms.djangoapps.contentstore.views.tests.test_library import LIBRARY_REST_URL
+from contentstore.tests.utils import AjaxEnabledTestClient, parse_json
+from contentstore.utils import reverse_library_url, reverse_url, reverse_usage_url
 from course_creators.views import add_user_with_status_granted
 from student import auth
 from student.auth import has_studio_read_access, has_studio_write_access

--- a/cms/djangoapps/contentstore/tests/test_request_event.py
+++ b/cms/djangoapps/contentstore/tests/test_request_event.py
@@ -5,7 +5,7 @@ from django.test import TestCase
 from django.urls import reverse
 from six import unichr
 
-from contentstore.views.helpers import event as cms_user_track
+from cms.djangoapps.contentstore.views.helpers import event as cms_user_track
 
 
 class CMSLogTest(TestCase):

--- a/cms/djangoapps/contentstore/tests/test_tasks.py
+++ b/cms/djangoapps/contentstore/tests/test_tasks.py
@@ -53,7 +53,7 @@ class ExportCourseTestCase(CourseTestCase):
         output = artifacts[0]
         self.assertEqual(output.name, 'Output')
 
-    @mock.patch('contentstore.tasks.export_course_to_xml', side_effect=side_effect_exception)
+    @mock.patch('cms.djangoapps.contentstore.tasks.export_course_to_xml', side_effect=side_effect_exception)
     def test_exception(self, mock_export):  # pylint: disable=unused-argument
         """
         The export task should fail gracefully if an exception is thrown

--- a/cms/djangoapps/contentstore/tests/test_video_utils.py
+++ b/cms/djangoapps/contentstore/tests/test_video_utils.py
@@ -272,7 +272,7 @@ class ScrapeVideoThumbnailsTestCase(CourseTestCase):
         )
     )
     @override_settings(AWS_ACCESS_KEY_ID='test_key_id', AWS_SECRET_ACCESS_KEY='test_secret')
-    @patch('contentstore.video_utils.LOGGER')
+    @patch('cms.djangoapps.contentstore.video_utils.LOGGER')
     @patch('requests.get')
     @ddt.unpack
     def test_scrape_youtube_thumbnail_logging(
@@ -332,8 +332,8 @@ class ScrapeVideoThumbnailsTestCase(CourseTestCase):
             )
         ),
     )
-    @patch('contentstore.video_utils.LOGGER')
-    @patch('contentstore.video_utils.download_youtube_video_thumbnail')
+    @patch('cms.djangoapps.contentstore.video_utils.LOGGER')
+    @patch('cms.djangoapps.contentstore.video_utils.download_youtube_video_thumbnail')
     @ddt.unpack
     def test_no_video_thumbnail_downloaded(
         self,

--- a/cms/djangoapps/contentstore/utils.py
+++ b/cms/djangoapps/contentstore/utils.py
@@ -19,8 +19,8 @@ from six import text_type
 
 from openedx.core.djangoapps.django_comment_common.models import assign_default_role
 from openedx.core.djangoapps.django_comment_common.utils import seed_permissions_roles
-from openedx.core.djangoapps.site_configuration.models import SiteConfiguration
 from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
+from openedx.core.djangoapps.site_configuration.models import SiteConfiguration
 from openedx.features.content_type_gating.models import ContentTypeGatingConfig
 from openedx.features.content_type_gating.partitions import CONTENT_TYPE_GATING_SCHEME
 from student import auth

--- a/cms/djangoapps/contentstore/views/assets.py
+++ b/cms/djangoapps/contentstore/views/assets.py
@@ -19,7 +19,7 @@ from opaque_keys.edx.keys import AssetKey, CourseKey
 from pymongo import ASCENDING, DESCENDING
 from six import text_type
 
-from contentstore.views.exception import AssetNotFoundException, AssetSizeTooLargeException
+from .exception import AssetNotFoundException, AssetSizeTooLargeException
 from edxmako.shortcuts import render_to_response
 from openedx.core.djangoapps.contentserver.caching import del_cached_content
 from student.auth import has_course_author_access

--- a/cms/djangoapps/contentstore/views/assets.py
+++ b/cms/djangoapps/contentstore/views/assets.py
@@ -19,7 +19,6 @@ from opaque_keys.edx.keys import AssetKey, CourseKey
 from pymongo import ASCENDING, DESCENDING
 from six import text_type
 
-from .exception import AssetNotFoundException, AssetSizeTooLargeException
 from edxmako.shortcuts import render_to_response
 from openedx.core.djangoapps.contentserver.caching import del_cached_content
 from student.auth import has_course_author_access
@@ -32,6 +31,7 @@ from xmodule.modulestore.django import modulestore
 from xmodule.modulestore.exceptions import ItemNotFoundError
 
 from ..utils import reverse_course_url
+from .exception import AssetNotFoundException, AssetSizeTooLargeException
 
 __all__ = ['assets_handler']
 

--- a/cms/djangoapps/contentstore/views/certificates.py
+++ b/cms/djangoapps/contentstore/views/certificates.py
@@ -39,13 +39,6 @@ from opaque_keys import InvalidKeyError
 from opaque_keys.edx.keys import AssetKey, CourseKey
 from six import text_type
 
-from ..utils import (
-    get_lms_link_for_certificate_web_view,
-    reverse_course_url,
-    get_proctored_exam_settings_url
-)
-from .assets import delete_asset
-from .exception import AssetNotFoundException
 from course_modes.models import CourseMode
 from edxmako.shortcuts import render_to_response
 from student.auth import has_studio_write_access
@@ -54,6 +47,10 @@ from util.db import MYSQL_MAX_INT, generate_int_id
 from util.json_request import JsonResponse
 from xmodule.modulestore import EdxJSONEncoder
 from xmodule.modulestore.django import modulestore
+
+from ..utils import get_lms_link_for_certificate_web_view, get_proctored_exam_settings_url, reverse_course_url
+from .assets import delete_asset
+from .exception import AssetNotFoundException
 
 CERTIFICATE_SCHEMA_VERSION = 1
 CERTIFICATE_MINIMUM_ID = 100

--- a/cms/djangoapps/contentstore/views/certificates.py
+++ b/cms/djangoapps/contentstore/views/certificates.py
@@ -39,13 +39,13 @@ from opaque_keys import InvalidKeyError
 from opaque_keys.edx.keys import AssetKey, CourseKey
 from six import text_type
 
-from contentstore.utils import (
+from ..utils import (
     get_lms_link_for_certificate_web_view,
     reverse_course_url,
     get_proctored_exam_settings_url
 )
-from contentstore.views.assets import delete_asset
-from contentstore.views.exception import AssetNotFoundException
+from .assets import delete_asset
+from .exception import AssetNotFoundException
 from course_modes.models import CourseMode
 from edxmako.shortcuts import render_to_response
 from student.auth import has_studio_write_access

--- a/cms/djangoapps/contentstore/views/component.py
+++ b/cms/djangoapps/contentstore/views/component.py
@@ -21,9 +21,9 @@ from xblock.exceptions import NoSuchHandlerError
 from xblock.plugin import PluginMissingError
 from xblock.runtime import Mixologist
 
-from contentstore.utils import get_lms_link_for_item, get_sibling_urls, reverse_course_url
-from contentstore.views.helpers import get_parent_xblock, is_unit, xblock_type_display_name
-from contentstore.views.item import StudioEditModuleRuntime, add_container_page_publishing_info, create_xblock_info
+from ..utils import get_lms_link_for_item, get_sibling_urls, reverse_course_url
+from .helpers import get_parent_xblock, is_unit, xblock_type_display_name
+from .item import StudioEditModuleRuntime, add_container_page_publishing_info, create_xblock_info
 from edxmako.shortcuts import render_to_response
 from openedx.core.lib.xblock_utils import get_aside_from_xblock, is_xblock_aside
 from student.auth import has_course_author_access

--- a/cms/djangoapps/contentstore/views/component.py
+++ b/cms/djangoapps/contentstore/views/component.py
@@ -21,9 +21,6 @@ from xblock.exceptions import NoSuchHandlerError
 from xblock.plugin import PluginMissingError
 from xblock.runtime import Mixologist
 
-from ..utils import get_lms_link_for_item, get_sibling_urls, reverse_course_url
-from .helpers import get_parent_xblock, is_unit, xblock_type_display_name
-from .item import StudioEditModuleRuntime, add_container_page_publishing_info, create_xblock_info
 from edxmako.shortcuts import render_to_response
 from openedx.core.lib.xblock_utils import get_aside_from_xblock, is_xblock_aside
 from student.auth import has_course_author_access
@@ -31,6 +28,10 @@ from xblock_django.api import authorable_xblocks, disabled_xblocks
 from xblock_django.models import XBlockStudioConfigurationFlag
 from xmodule.modulestore.django import modulestore
 from xmodule.modulestore.exceptions import ItemNotFoundError
+
+from ..utils import get_lms_link_for_item, get_sibling_urls, reverse_course_url
+from .helpers import get_parent_xblock, is_unit, xblock_type_display_name
+from .item import StudioEditModuleRuntime, add_container_page_publishing_info, create_xblock_info
 
 __all__ = [
     'container_handler',

--- a/cms/djangoapps/contentstore/views/course.py
+++ b/cms/djangoapps/contentstore/views/course.py
@@ -30,28 +30,6 @@ from opaque_keys.edx.locator import BlockUsageLocator
 from six import text_type
 from six.moves import filter
 
-from ..course_group_config import (
-    COHORT_SCHEME,
-    ENROLLMENT_SCHEME,
-    RANDOM_SCHEME,
-    GroupConfiguration,
-    GroupConfigurationsValidationError
-)
-from ..course_info_model import delete_course_update, get_course_updates, update_course_updates
-from ..courseware_index import CoursewareSearchIndexer, SearchIndexingError
-from ..tasks import rerun_course as rerun_course_task
-from ..utils import (
-    add_instructor,
-    get_lms_link_for_item,
-    get_proctored_exam_settings_url,
-    initialize_permissions,
-    remove_all_instructors,
-    reverse_course_url,
-    reverse_library_url,
-    reverse_url,
-    reverse_usage_url
-)
-from .entrance_exam import create_entrance_exam, delete_entrance_exam, update_entrance_exam
 from course_action_state.managers import CourseActionStateItemNotFoundError
 from course_action_state.models import CourseRerunState, CourseRerunUIStateManager
 from course_creators.views import add_user_with_status_unrequested, get_course_creator_status
@@ -98,13 +76,35 @@ from xmodule.modulestore.exceptions import DuplicateCourseError, ItemNotFoundErr
 from xmodule.partitions.partitions import UserPartition
 from xmodule.tabs import CourseTab, CourseTabList, InvalidTabsException
 
+from ..course_group_config import (
+    COHORT_SCHEME,
+    ENROLLMENT_SCHEME,
+    RANDOM_SCHEME,
+    GroupConfiguration,
+    GroupConfigurationsValidationError
+)
+from ..course_info_model import delete_course_update, get_course_updates, update_course_updates
+from ..courseware_index import CoursewareSearchIndexer, SearchIndexingError
+from ..tasks import rerun_course as rerun_course_task
+from ..utils import (
+    add_instructor,
+    get_lms_link_for_item,
+    get_proctored_exam_settings_url,
+    initialize_permissions,
+    remove_all_instructors,
+    reverse_course_url,
+    reverse_library_url,
+    reverse_url,
+    reverse_usage_url
+)
 from .component import ADVANCED_COMPONENT_TYPES
+from .entrance_exam import create_entrance_exam, delete_entrance_exam, update_entrance_exam
 from .item import create_xblock_info
 from .library import (
-    LIBRARY_AUTHORING_MICROFRONTEND_URL,
     LIBRARIES_ENABLED,
+    LIBRARY_AUTHORING_MICROFRONTEND_URL,
     get_library_creator_status,
-    should_redirect_to_library_authoring_mfe,
+    should_redirect_to_library_authoring_mfe
 )
 
 log = logging.getLogger(__name__)

--- a/cms/djangoapps/contentstore/views/course.py
+++ b/cms/djangoapps/contentstore/views/course.py
@@ -30,17 +30,17 @@ from opaque_keys.edx.locator import BlockUsageLocator
 from six import text_type
 from six.moves import filter
 
-from contentstore.course_group_config import (
+from ..course_group_config import (
     COHORT_SCHEME,
     ENROLLMENT_SCHEME,
     RANDOM_SCHEME,
     GroupConfiguration,
     GroupConfigurationsValidationError
 )
-from contentstore.course_info_model import delete_course_update, get_course_updates, update_course_updates
-from contentstore.courseware_index import CoursewareSearchIndexer, SearchIndexingError
-from contentstore.tasks import rerun_course as rerun_course_task
-from contentstore.utils import (
+from ..course_info_model import delete_course_update, get_course_updates, update_course_updates
+from ..courseware_index import CoursewareSearchIndexer, SearchIndexingError
+from ..tasks import rerun_course as rerun_course_task
+from ..utils import (
     add_instructor,
     get_lms_link_for_item,
     get_proctored_exam_settings_url,
@@ -51,7 +51,7 @@ from contentstore.utils import (
     reverse_url,
     reverse_usage_url
 )
-from contentstore.views.entrance_exam import create_entrance_exam, delete_entrance_exam, update_entrance_exam
+from .entrance_exam import create_entrance_exam, delete_entrance_exam, update_entrance_exam
 from course_action_state.managers import CourseActionStateItemNotFoundError
 from course_action_state.models import CourseRerunState, CourseRerunUIStateManager
 from course_creators.views import add_user_with_status_unrequested, get_course_creator_status

--- a/cms/djangoapps/contentstore/views/entrance_exam.py
+++ b/cms/djangoapps/contentstore/views/entrance_exam.py
@@ -16,14 +16,15 @@ from django.views.decorators.csrf import ensure_csrf_cookie
 from opaque_keys import InvalidKeyError
 from opaque_keys.edx.keys import CourseKey, UsageKey
 
-from .helpers import create_xblock, remove_entrance_exam_graders
-from .item import delete_item
 from models.settings.course_metadata import CourseMetadata
 from openedx.core.djangolib.js_utils import dump_js_escaped_json
 from student.auth import has_course_author_access
 from util import milestones_helpers
 from xmodule.modulestore.django import modulestore
 from xmodule.modulestore.exceptions import ItemNotFoundError
+
+from .helpers import create_xblock, remove_entrance_exam_graders
+from .item import delete_item
 
 __all__ = ['entrance_exam', ]
 

--- a/cms/djangoapps/contentstore/views/entrance_exam.py
+++ b/cms/djangoapps/contentstore/views/entrance_exam.py
@@ -16,8 +16,8 @@ from django.views.decorators.csrf import ensure_csrf_cookie
 from opaque_keys import InvalidKeyError
 from opaque_keys.edx.keys import CourseKey, UsageKey
 
-from contentstore.views.helpers import create_xblock, remove_entrance_exam_graders
-from contentstore.views.item import delete_item
+from .helpers import create_xblock, remove_entrance_exam_graders
+from .item import delete_item
 from models.settings.course_metadata import CourseMetadata
 from openedx.core.djangolib.js_utils import dump_js_escaped_json
 from student.auth import has_course_author_access

--- a/cms/djangoapps/contentstore/views/export_git.py
+++ b/cms/djangoapps/contentstore/views/export_git.py
@@ -13,7 +13,7 @@ from django.utils.translation import ugettext as _
 from django.views.decorators.csrf import ensure_csrf_cookie
 from opaque_keys.edx.keys import CourseKey
 
-import contentstore.git_export_utils as git_export_utils
+import cms.djangoapps.contentstore.git_export_utils as git_export_utils
 from edxmako.shortcuts import render_to_response
 from student.auth import has_course_author_access
 from xmodule.modulestore.django import modulestore

--- a/cms/djangoapps/contentstore/views/helpers.py
+++ b/cms/djangoapps/contentstore/views/helpers.py
@@ -12,7 +12,7 @@ from django.utils.translation import ugettext as _
 from opaque_keys.edx.keys import UsageKey
 from xblock.core import XBlock
 
-from contentstore.utils import reverse_course_url, reverse_library_url, reverse_usage_url
+from ..utils import reverse_course_url, reverse_library_url, reverse_usage_url
 from edxmako.shortcuts import render_to_string
 from models.settings.course_grading import CourseGradingModel
 from util.milestones_helpers import is_entrance_exams_enabled

--- a/cms/djangoapps/contentstore/views/helpers.py
+++ b/cms/djangoapps/contentstore/views/helpers.py
@@ -3,22 +3,23 @@ Helper methods for Studio views.
 """
 
 import hashlib
-import six
 from uuid import uuid4
 
+import six
 from django.conf import settings
 from django.http import HttpResponse
 from django.utils.translation import ugettext as _
 from opaque_keys.edx.keys import UsageKey
 from xblock.core import XBlock
 
-from ..utils import reverse_course_url, reverse_library_url, reverse_usage_url
 from edxmako.shortcuts import render_to_string
 from models.settings.course_grading import CourseGradingModel
 from util.milestones_helpers import is_entrance_exams_enabled
 from xmodule.modulestore.django import modulestore
 from xmodule.tabs import StaticTab
 from xmodule.x_module import DEPRECATION_VSCOMPAT_EVENT
+
+from ..utils import reverse_course_url, reverse_library_url, reverse_usage_url
 
 __all__ = ['event']
 

--- a/cms/djangoapps/contentstore/views/import_export.py
+++ b/cms/djangoapps/contentstore/views/import_export.py
@@ -30,9 +30,9 @@ from storages.backends.s3boto import S3BotoStorage
 from user_tasks.conf import settings as user_tasks_settings
 from user_tasks.models import UserTaskArtifact, UserTaskStatus
 
-from contentstore.storage import course_import_export_storage
-from contentstore.tasks import CourseExportTask, CourseImportTask, export_olx, import_olx
-from contentstore.utils import reverse_course_url, reverse_library_url
+from ..storage import course_import_export_storage
+from ..tasks import CourseExportTask, CourseImportTask, export_olx, import_olx
+from ..utils import reverse_course_url, reverse_library_url
 from edxmako.shortcuts import render_to_response
 from student.auth import has_course_author_access
 from util.json_request import JsonResponse

--- a/cms/djangoapps/contentstore/views/import_export.py
+++ b/cms/djangoapps/contentstore/views/import_export.py
@@ -30,14 +30,15 @@ from storages.backends.s3boto import S3BotoStorage
 from user_tasks.conf import settings as user_tasks_settings
 from user_tasks.models import UserTaskArtifact, UserTaskStatus
 
-from ..storage import course_import_export_storage
-from ..tasks import CourseExportTask, CourseImportTask, export_olx, import_olx
-from ..utils import reverse_course_url, reverse_library_url
 from edxmako.shortcuts import render_to_response
 from student.auth import has_course_author_access
 from util.json_request import JsonResponse
 from util.views import ensure_valid_course_key
 from xmodule.modulestore.django import modulestore
+
+from ..storage import course_import_export_storage
+from ..tasks import CourseExportTask, CourseImportTask, export_olx, import_olx
+from ..utils import reverse_course_url, reverse_library_url
 
 __all__ = [
     'import_handler', 'import_status_handler',

--- a/cms/djangoapps/contentstore/views/item.py
+++ b/cms/djangoapps/contentstore/views/item.py
@@ -32,27 +32,6 @@ from xblock.fields import Scope
 
 from cms.djangoapps.contentstore.config.waffle import SHOW_REVIEW_RULES_FLAG
 from cms.lib.xblock.authoring_mixin import VISIBILITY_VIEW
-from ..utils import (
-    ancestor_has_staff_lock,
-    find_release_date_source,
-    find_staff_lock_source,
-    get_split_group_display_name,
-    get_user_partition_info,
-    get_visibility_partition_info,
-    has_children_visible_to_specific_partition_groups,
-    is_currently_visible_to_students,
-    is_self_paced
-)
-from .helpers import (
-    create_xblock,
-    get_parent_xblock,
-    is_unit,
-    usage_key_with_run,
-    xblock_primary_child_category,
-    xblock_studio_url,
-    xblock_type_display_name
-)
-from .preview import get_preview_fragment
 from edxmako.shortcuts import render_to_string
 from models.settings.course_grading import CourseGradingModel
 from openedx.core.djangoapps.schedules.config import COURSE_UPDATE_WAFFLE_FLAG
@@ -76,6 +55,28 @@ from xmodule.modulestore.inheritance import own_metadata
 from xmodule.services import ConfigurationService, SettingsService, TeamsConfigurationService
 from xmodule.tabs import CourseTabList
 from xmodule.x_module import AUTHOR_VIEW, PREVIEW_VIEWS, STUDENT_VIEW, STUDIO_VIEW
+
+from ..utils import (
+    ancestor_has_staff_lock,
+    find_release_date_source,
+    find_staff_lock_source,
+    get_split_group_display_name,
+    get_user_partition_info,
+    get_visibility_partition_info,
+    has_children_visible_to_specific_partition_groups,
+    is_currently_visible_to_students,
+    is_self_paced
+)
+from .helpers import (
+    create_xblock,
+    get_parent_xblock,
+    is_unit,
+    usage_key_with_run,
+    xblock_primary_child_category,
+    xblock_studio_url,
+    xblock_type_display_name
+)
+from .preview import get_preview_fragment
 
 __all__ = [
     'orphan_handler', 'xblock_handler', 'xblock_view_handler', 'xblock_outline_handler', 'xblock_container_handler'

--- a/cms/djangoapps/contentstore/views/item.py
+++ b/cms/djangoapps/contentstore/views/item.py
@@ -32,7 +32,7 @@ from xblock.fields import Scope
 
 from cms.djangoapps.contentstore.config.waffle import SHOW_REVIEW_RULES_FLAG
 from cms.lib.xblock.authoring_mixin import VISIBILITY_VIEW
-from contentstore.utils import (
+from ..utils import (
     ancestor_has_staff_lock,
     find_release_date_source,
     find_staff_lock_source,
@@ -43,7 +43,7 @@ from contentstore.utils import (
     is_currently_visible_to_students,
     is_self_paced
 )
-from contentstore.views.helpers import (
+from .helpers import (
     create_xblock,
     get_parent_xblock,
     is_unit,
@@ -52,7 +52,7 @@ from contentstore.views.helpers import (
     xblock_studio_url,
     xblock_type_display_name
 )
-from contentstore.views.preview import get_preview_fragment
+from .preview import get_preview_fragment
 from edxmako.shortcuts import render_to_string
 from models.settings.course_grading import CourseGradingModel
 from openedx.core.djangoapps.schedules.config import COURSE_UPDATE_WAFFLE_FLAG

--- a/cms/djangoapps/contentstore/views/library.py
+++ b/cms/djangoapps/contentstore/views/library.py
@@ -19,8 +19,8 @@ from opaque_keys.edx.keys import CourseKey
 from opaque_keys.edx.locator import LibraryLocator, LibraryUsageLocator
 from six import text_type
 
-from contentstore.utils import add_instructor, reverse_library_url
-from contentstore.views.item import create_xblock_info
+from ..utils import add_instructor, reverse_library_url
+from .item import create_xblock_info
 from course_creators.views import get_course_creator_status
 from edxmako.shortcuts import render_to_response
 from student.auth import (

--- a/cms/djangoapps/contentstore/views/library.py
+++ b/cms/djangoapps/contentstore/views/library.py
@@ -19,8 +19,6 @@ from opaque_keys.edx.keys import CourseKey
 from opaque_keys.edx.locator import LibraryLocator, LibraryUsageLocator
 from six import text_type
 
-from ..utils import add_instructor, reverse_library_url
-from .item import create_xblock_info
 from course_creators.views import get_course_creator_status
 from edxmako.shortcuts import render_to_response
 from student.auth import (
@@ -37,8 +35,9 @@ from xmodule.modulestore.django import modulestore
 from xmodule.modulestore.exceptions import DuplicateCourseError
 
 from ..config.waffle import REDIRECT_TO_LIBRARY_AUTHORING_MICROFRONTEND
-
+from ..utils import add_instructor, reverse_library_url
 from .component import CONTAINER_TEMPLATES, get_component_templates
+from .item import create_xblock_info
 from .user import user_with_role
 
 __all__ = ['library_handler', 'manage_library_users']

--- a/cms/djangoapps/contentstore/views/preview.py
+++ b/cms/djangoapps/contentstore/views/preview.py
@@ -2,12 +2,12 @@
 
 import logging
 from functools import partial
-import six
 
+import six
 from django.conf import settings
 from django.contrib.auth.decorators import login_required
-from django.urls import reverse
 from django.http import Http404, HttpResponseBadRequest
+from django.urls import reverse
 from django.utils.translation import ugettext as _
 from django.views.decorators.clickjacking import xframe_options_exempt
 from opaque_keys.edx.keys import UsageKey
@@ -18,8 +18,6 @@ from xblock.runtime import KvsFieldData
 
 import static_replace
 from cms.lib.xblock.field_data import CmsFieldData
-from ..utils import get_visibility_partition_info
-from .access import get_user_role
 from edxmako.shortcuts import render_to_string
 from lms.djangoapps.lms_xblock.field_data import LmsFieldData
 from openedx.core.lib.license import wrap_with_license
@@ -31,7 +29,6 @@ from openedx.core.lib.xblock_utils import (
     wrap_xblock_aside,
     xblock_local_resource_url
 )
-from xmodule.util.sandboxing import can_execute_unsafe_code, get_python_lib_zip
 from xblock_config.models import StudioConfig
 from xblock_django.user_service import DjangoXBlockUserService
 from xmodule.contentstore.django import contentstore
@@ -41,9 +38,12 @@ from xmodule.modulestore.django import ModuleI18nService, modulestore
 from xmodule.partitions.partitions_service import PartitionService
 from xmodule.services import SettingsService
 from xmodule.studio_editable import has_author_view
+from xmodule.util.sandboxing import can_execute_unsafe_code, get_python_lib_zip
 from xmodule.util.xmodule_django import add_webpack_to_fragment
 from xmodule.x_module import AUTHOR_VIEW, PREVIEW_VIEWS, STUDENT_VIEW, ModuleSystem, XModule, XModuleDescriptor
 
+from ..utils import get_visibility_partition_info
+from .access import get_user_role
 from .helpers import render_from_lms
 from .session_kv_store import SessionKeyValueStore
 

--- a/cms/djangoapps/contentstore/views/preview.py
+++ b/cms/djangoapps/contentstore/views/preview.py
@@ -18,8 +18,8 @@ from xblock.runtime import KvsFieldData
 
 import static_replace
 from cms.lib.xblock.field_data import CmsFieldData
-from contentstore.utils import get_visibility_partition_info
-from contentstore.views.access import get_user_role
+from ..utils import get_visibility_partition_info
+from .access import get_user_role
 from edxmako.shortcuts import render_to_string
 from lms.djangoapps.lms_xblock.field_data import LmsFieldData
 from openedx.core.lib.license import wrap_with_license

--- a/cms/djangoapps/contentstore/views/public.py
+++ b/cms/djangoapps/contentstore/views/public.py
@@ -8,7 +8,7 @@ from django.shortcuts import redirect
 from django.utils.http import urlquote_plus
 from waffle.decorators import waffle_switch
 
-from contentstore.config import waffle
+from ..config import waffle
 from edxmako.shortcuts import render_to_response
 
 __all__ = ['register_redirect_to_lms', 'login_redirect_to_lms', 'howitworks', 'accessibility']

--- a/cms/djangoapps/contentstore/views/public.py
+++ b/cms/djangoapps/contentstore/views/public.py
@@ -8,8 +8,9 @@ from django.shortcuts import redirect
 from django.utils.http import urlquote_plus
 from waffle.decorators import waffle_switch
 
-from ..config import waffle
 from edxmako.shortcuts import render_to_response
+
+from ..config import waffle
 
 __all__ = ['register_redirect_to_lms', 'login_redirect_to_lms', 'howitworks', 'accessibility']
 

--- a/cms/djangoapps/contentstore/views/tests/test_access.py
+++ b/cms/djangoapps/contentstore/views/tests/test_access.py
@@ -7,7 +7,7 @@ from django.contrib.auth.models import User
 from django.test import TestCase
 from opaque_keys.edx.locator import CourseLocator
 
-from contentstore.views.access import get_user_role
+from ..access import get_user_role
 from student.auth import add_users
 from student.roles import CourseInstructorRole, CourseStaffRole
 from student.tests.factories import AdminFactory

--- a/cms/djangoapps/contentstore/views/tests/test_access.py
+++ b/cms/djangoapps/contentstore/views/tests/test_access.py
@@ -7,10 +7,11 @@ from django.contrib.auth.models import User
 from django.test import TestCase
 from opaque_keys.edx.locator import CourseLocator
 
-from ..access import get_user_role
 from student.auth import add_users
 from student.roles import CourseInstructorRole, CourseStaffRole
 from student.tests.factories import AdminFactory
+
+from ..access import get_user_role
 
 
 class RolesTest(TestCase):

--- a/cms/djangoapps/contentstore/views/tests/test_assets.py
+++ b/cms/djangoapps/contentstore/views/tests/test_assets.py
@@ -359,7 +359,7 @@ class UploadTestCase(AssetsTestCase):
         (MAX_FILE_SIZE, "justequals.file.test", 200),
         (MAX_FILE_SIZE + 90, "large.file.test", 413),
     )
-    @mock.patch('contentstore.views.assets.get_file_size')
+    @mock.patch('cms.djangoapps.contentstore.views.assets.get_file_size')
     def test_file_size(self, case, get_file_size):
         max_file_size, name, status_code = case
 

--- a/cms/djangoapps/contentstore/views/tests/test_assets.py
+++ b/cms/djangoapps/contentstore/views/tests/test_assets.py
@@ -18,9 +18,9 @@ from opaque_keys.edx.locator import CourseLocator
 from PIL import Image
 from pytz import UTC
 
-from contentstore.tests.utils import CourseTestCase
-from contentstore.utils import reverse_course_url
-from contentstore.views import assets
+from cms.djangoapps.contentstore.tests.utils import CourseTestCase
+from cms.djangoapps.contentstore.utils import reverse_course_url
+from cms.djangoapps.contentstore.views import assets
 from static_replace import replace_static_urls
 from xmodule.assetstore import AssetMetadata
 from xmodule.contentstore.content import StaticContent

--- a/cms/djangoapps/contentstore/views/tests/test_certificates.py
+++ b/cms/djangoapps/contentstore/views/tests/test_certificates.py
@@ -211,7 +211,7 @@ class CertificatesListHandlerTestCase(
         """
         Set up CertificatesListHandlerTestCase.
         """
-        super(CertificatesListHandlerTestCase, self).setUp('contentstore.views.certificates.tracker')
+        super(CertificatesListHandlerTestCase, self).setUp('cms.djangoapps.contentstore.views.certificates.tracker')
         self.reset_urls()
 
     def _url(self):
@@ -436,7 +436,7 @@ class CertificatesDetailHandlerTestCase(
         """
         Set up CertificatesDetailHandlerTestCase.
         """
-        super(CertificatesDetailHandlerTestCase, self).setUp('contentstore.views.certificates.tracker')
+        super(CertificatesDetailHandlerTestCase, self).setUp('cms.djangoapps.contentstore.views.certificates.tracker')
         self.reset_urls()
 
     def _url(self, cid=-1):

--- a/cms/djangoapps/contentstore/views/tests/test_certificates.py
+++ b/cms/djangoapps/contentstore/views/tests/test_certificates.py
@@ -18,7 +18,6 @@ from six.moves import range
 
 from cms.djangoapps.contentstore.tests.utils import CourseTestCase
 from cms.djangoapps.contentstore.utils import get_lms_link_for_certificate_web_view, reverse_course_url
-from ..certificates import CERTIFICATE_SCHEMA_VERSION, CertificateManager
 from course_modes.tests.factories import CourseModeFactory
 from student.models import CourseEnrollment
 from student.roles import CourseInstructorRole, CourseStaffRole
@@ -27,6 +26,8 @@ from util.testing import EventTestMixin, UrlResetMixin
 from xmodule.contentstore.content import StaticContent
 from xmodule.contentstore.django import contentstore
 from xmodule.exceptions import NotFoundError
+
+from ..certificates import CERTIFICATE_SCHEMA_VERSION, CertificateManager
 
 FEATURES_WITH_CERTS_ENABLED = settings.FEATURES.copy()
 FEATURES_WITH_CERTS_ENABLED['CERTIFICATES_HTML_VIEW'] = True

--- a/cms/djangoapps/contentstore/views/tests/test_certificates.py
+++ b/cms/djangoapps/contentstore/views/tests/test_certificates.py
@@ -16,9 +16,9 @@ from django.test.utils import override_settings
 from opaque_keys.edx.keys import AssetKey
 from six.moves import range
 
-from contentstore.tests.utils import CourseTestCase
-from contentstore.utils import get_lms_link_for_certificate_web_view, reverse_course_url
-from contentstore.views.certificates import CERTIFICATE_SCHEMA_VERSION, CertificateManager
+from cms.djangoapps.contentstore.tests.utils import CourseTestCase
+from cms.djangoapps.contentstore.utils import get_lms_link_for_certificate_web_view, reverse_course_url
+from ..certificates import CERTIFICATE_SCHEMA_VERSION, CertificateManager
 from course_modes.tests.factories import CourseModeFactory
 from student.models import CourseEnrollment
 from student.roles import CourseInstructorRole, CourseStaffRole

--- a/cms/djangoapps/contentstore/views/tests/test_container_page.py
+++ b/cms/djangoapps/contentstore/views/tests/test_container_page.py
@@ -205,7 +205,10 @@ class ContainerPageTestCase(StudioPageTestCase, LibraryTestCase):
         empty_child_container = self._create_item(self.vertical.location, 'split_test', 'Split Test')
         self.validate_preview_html(empty_child_container, self.reorderable_child_view, can_add=False)
 
-    @patch('cms.djangoapps.contentstore.views.component.render_to_response', Mock(return_value=Mock(status_code=200, content='')))
+    @patch(
+        'cms.djangoapps.contentstore.views.component.render_to_response',
+        Mock(return_value=Mock(status_code=200, content=''))
+    )
     def test_container_page_with_valid_and_invalid_usage_key_string(self):
         """
         Check that invalid 'usage_key_string' raises Http404.

--- a/cms/djangoapps/contentstore/views/tests/test_container_page.py
+++ b/cms/djangoapps/contentstore/views/tests/test_container_page.py
@@ -13,9 +13,9 @@ from django.utils import http
 from mock import Mock, patch
 from pytz import UTC
 
-import contentstore.views.component as views
-from contentstore.tests.test_libraries import LibraryTestCase
-from contentstore.views.tests.utils import StudioPageTestCase
+import cms.djangoapps.contentstore.views.component as views
+from cms.djangoapps.contentstore.tests.test_libraries import LibraryTestCase
+from .utils import StudioPageTestCase
 from xmodule.modulestore import ModuleStoreEnum
 from xmodule.modulestore.django import modulestore
 from xmodule.modulestore.tests.factories import CourseFactory, ItemFactory

--- a/cms/djangoapps/contentstore/views/tests/test_container_page.py
+++ b/cms/djangoapps/contentstore/views/tests/test_container_page.py
@@ -15,10 +15,11 @@ from pytz import UTC
 
 import cms.djangoapps.contentstore.views.component as views
 from cms.djangoapps.contentstore.tests.test_libraries import LibraryTestCase
-from .utils import StudioPageTestCase
 from xmodule.modulestore import ModuleStoreEnum
 from xmodule.modulestore.django import modulestore
 from xmodule.modulestore.tests.factories import CourseFactory, ItemFactory
+
+from .utils import StudioPageTestCase
 
 
 class ContainerPageTestCase(StudioPageTestCase, LibraryTestCase):

--- a/cms/djangoapps/contentstore/views/tests/test_container_page.py
+++ b/cms/djangoapps/contentstore/views/tests/test_container_page.py
@@ -205,7 +205,7 @@ class ContainerPageTestCase(StudioPageTestCase, LibraryTestCase):
         empty_child_container = self._create_item(self.vertical.location, 'split_test', 'Split Test')
         self.validate_preview_html(empty_child_container, self.reorderable_child_view, can_add=False)
 
-    @patch('contentstore.views.component.render_to_response', Mock(return_value=Mock(status_code=200, content='')))
+    @patch('cms.djangoapps.contentstore.views.component.render_to_response', Mock(return_value=Mock(status_code=200, content='')))
     def test_container_page_with_valid_and_invalid_usage_key_string(self):
         """
         Check that invalid 'usage_key_string' raises Http404.

--- a/cms/djangoapps/contentstore/views/tests/test_course_index.py
+++ b/cms/djangoapps/contentstore/views/tests/test_course_index.py
@@ -23,13 +23,6 @@ from cms.djangoapps.contentstore.config.waffle import WAFFLE_NAMESPACE as STUDIO
 from cms.djangoapps.contentstore.courseware_index import CoursewareSearchIndexer, SearchIndexingError
 from cms.djangoapps.contentstore.tests.utils import CourseTestCase
 from cms.djangoapps.contentstore.utils import add_instructor, reverse_course_url, reverse_usage_url
-from ..course import WAFFLE_NAMESPACE as COURSE_WAFFLE_NAMESPACE
-from ..course import (
-    _deprecated_blocks_info,
-    course_outline_initial_state,
-    reindex_course_and_check_access
-)
-from ..item import VisibilityState, create_xblock_info
 from course_action_state.managers import CourseRerunUIStateManager
 from course_action_state.models import CourseRerunState
 from openedx.core.djangoapps.waffle_utils import WaffleSwitchNamespace
@@ -39,6 +32,10 @@ from student.tests.factories import UserFactory
 from xmodule.modulestore.django import modulestore
 from xmodule.modulestore.exceptions import ItemNotFoundError
 from xmodule.modulestore.tests.factories import CourseFactory, ItemFactory, LibraryFactory, check_mongo_calls
+
+from ..course import WAFFLE_NAMESPACE as COURSE_WAFFLE_NAMESPACE
+from ..course import _deprecated_blocks_info, course_outline_initial_state, reindex_course_and_check_access
+from ..item import VisibilityState, create_xblock_info
 
 
 class TestCourseIndex(CourseTestCase):

--- a/cms/djangoapps/contentstore/views/tests/test_course_index.py
+++ b/cms/djangoapps/contentstore/views/tests/test_course_index.py
@@ -19,17 +19,17 @@ from edx_django_utils.monitoring.middleware import _DEFAULT_NAMESPACE as DJANGO_
 from opaque_keys.edx.locator import CourseLocator
 from search.api import perform_search
 
-from contentstore.config.waffle import WAFFLE_NAMESPACE as STUDIO_WAFFLE_NAMESPACE
-from contentstore.courseware_index import CoursewareSearchIndexer, SearchIndexingError
-from contentstore.tests.utils import CourseTestCase
-from contentstore.utils import add_instructor, reverse_course_url, reverse_usage_url
-from contentstore.views.course import WAFFLE_NAMESPACE as COURSE_WAFFLE_NAMESPACE
-from contentstore.views.course import (
+from cms.djangoapps.contentstore.config.waffle import WAFFLE_NAMESPACE as STUDIO_WAFFLE_NAMESPACE
+from cms.djangoapps.contentstore.courseware_index import CoursewareSearchIndexer, SearchIndexingError
+from cms.djangoapps.contentstore.tests.utils import CourseTestCase
+from cms.djangoapps.contentstore.utils import add_instructor, reverse_course_url, reverse_usage_url
+from ..course import WAFFLE_NAMESPACE as COURSE_WAFFLE_NAMESPACE
+from ..course import (
     _deprecated_blocks_info,
     course_outline_initial_state,
     reindex_course_and_check_access
 )
-from contentstore.views.item import VisibilityState, create_xblock_info
+from ..item import VisibilityState, create_xblock_info
 from course_action_state.managers import CourseRerunUIStateManager
 from course_action_state.models import CourseRerunState
 from openedx.core.djangoapps.waffle_utils import WaffleSwitchNamespace

--- a/cms/djangoapps/contentstore/views/tests/test_course_updates.py
+++ b/cms/djangoapps/contentstore/views/tests/test_course_updates.py
@@ -9,8 +9,8 @@ from django.test.utils import override_settings
 from mock import patch
 from opaque_keys.edx.keys import UsageKey
 
-from contentstore.tests.test_course_settings import CourseTestCase
-from contentstore.utils import reverse_course_url, reverse_usage_url
+from cms.djangoapps.contentstore.tests.test_course_settings import CourseTestCase
+from cms.djangoapps.contentstore.utils import reverse_course_url, reverse_usage_url
 from openedx.core.lib.xblock_utils import get_course_update_items
 from xmodule.modulestore.django import modulestore
 

--- a/cms/djangoapps/contentstore/views/tests/test_credit_eligibility.py
+++ b/cms/djangoapps/contentstore/views/tests/test_credit_eligibility.py
@@ -6,8 +6,8 @@ Unit tests for credit eligibility UI in Studio.
 import mock
 import six
 
-from contentstore.tests.utils import CourseTestCase
-from contentstore.utils import reverse_course_url
+from cms.djangoapps.contentstore.tests.utils import CourseTestCase
+from cms.djangoapps.contentstore.utils import reverse_course_url
 from openedx.core.djangoapps.credit.api import get_credit_requirements
 from openedx.core.djangoapps.credit.models import CreditCourse
 from openedx.core.djangoapps.credit.signals import on_course_publish

--- a/cms/djangoapps/contentstore/views/tests/test_entrance_exam.py
+++ b/cms/djangoapps/contentstore/views/tests/test_entrance_exam.py
@@ -13,16 +13,16 @@ from milestones.tests.utils import MilestonesTestCaseMixin
 from mock import patch
 from opaque_keys.edx.keys import UsageKey
 
-from contentstore.tests.utils import AjaxEnabledTestClient, CourseTestCase
-from contentstore.utils import reverse_url
-from contentstore.views.entrance_exam import (
+from cms.djangoapps.contentstore.tests.utils import AjaxEnabledTestClient, CourseTestCase
+from cms.djangoapps.contentstore.utils import reverse_url
+from ..entrance_exam import (
     add_entrance_exam_milestone,
     create_entrance_exam,
     delete_entrance_exam,
     remove_entrance_exam_milestone_reference,
     update_entrance_exam
 )
-from contentstore.views.helpers import GRADER_TYPES, create_xblock
+from ..helpers import GRADER_TYPES, create_xblock
 from models.settings.course_grading import CourseGradingModel
 from models.settings.course_metadata import CourseMetadata
 from student.tests.factories import UserFactory

--- a/cms/djangoapps/contentstore/views/tests/test_entrance_exam.py
+++ b/cms/djangoapps/contentstore/views/tests/test_entrance_exam.py
@@ -15,6 +15,12 @@ from opaque_keys.edx.keys import UsageKey
 
 from cms.djangoapps.contentstore.tests.utils import AjaxEnabledTestClient, CourseTestCase
 from cms.djangoapps.contentstore.utils import reverse_url
+from models.settings.course_grading import CourseGradingModel
+from models.settings.course_metadata import CourseMetadata
+from student.tests.factories import UserFactory
+from util import milestones_helpers
+from xmodule.modulestore.django import modulestore
+
 from ..entrance_exam import (
     add_entrance_exam_milestone,
     create_entrance_exam,
@@ -23,11 +29,6 @@ from ..entrance_exam import (
     update_entrance_exam
 )
 from ..helpers import GRADER_TYPES, create_xblock
-from models.settings.course_grading import CourseGradingModel
-from models.settings.course_metadata import CourseMetadata
-from student.tests.factories import UserFactory
-from util import milestones_helpers
-from xmodule.modulestore.django import modulestore
 
 
 @patch.dict(settings.FEATURES, {'ENTRANCE_EXAMS': True})

--- a/cms/djangoapps/contentstore/views/tests/test_exam_settings_view.py
+++ b/cms/djangoapps/contentstore/views/tests/test_exam_settings_view.py
@@ -6,7 +6,6 @@ Exam Settings View Tests
 
 import ddt
 import lxml
-
 from django.conf import settings
 from django.test.utils import override_settings
 

--- a/cms/djangoapps/contentstore/views/tests/test_exam_settings_view.py
+++ b/cms/djangoapps/contentstore/views/tests/test_exam_settings_view.py
@@ -10,8 +10,8 @@ import lxml
 from django.conf import settings
 from django.test.utils import override_settings
 
-from contentstore.tests.utils import CourseTestCase
-from contentstore.utils import reverse_course_url
+from cms.djangoapps.contentstore.tests.utils import CourseTestCase
+from cms.djangoapps.contentstore.utils import reverse_course_url
 from util.testing import UrlResetMixin
 
 FEATURES_WITH_CERTS_ENABLED = settings.FEATURES.copy()

--- a/cms/djangoapps/contentstore/views/tests/test_gating.py
+++ b/cms/djangoapps/contentstore/views/tests/test_gating.py
@@ -9,9 +9,9 @@ import ddt
 import six
 from mock import patch
 
-from contentstore.tests.utils import CourseTestCase
-from contentstore.utils import reverse_usage_url
-from contentstore.views.item import VisibilityState
+from cms.djangoapps.contentstore.tests.utils import CourseTestCase
+from cms.djangoapps.contentstore.utils import reverse_usage_url
+from ..item import VisibilityState
 from openedx.core.lib.gating.api import GATING_NAMESPACE_QUALIFIER
 from xmodule.modulestore.tests.django_utils import TEST_DATA_SPLIT_MODULESTORE
 from xmodule.modulestore.tests.factories import ItemFactory

--- a/cms/djangoapps/contentstore/views/tests/test_gating.py
+++ b/cms/djangoapps/contentstore/views/tests/test_gating.py
@@ -11,10 +11,11 @@ from mock import patch
 
 from cms.djangoapps.contentstore.tests.utils import CourseTestCase
 from cms.djangoapps.contentstore.utils import reverse_usage_url
-from ..item import VisibilityState
 from openedx.core.lib.gating.api import GATING_NAMESPACE_QUALIFIER
 from xmodule.modulestore.tests.django_utils import TEST_DATA_SPLIT_MODULESTORE
 from xmodule.modulestore.tests.factories import ItemFactory
+
+from ..item import VisibilityState
 
 
 @ddt.ddt

--- a/cms/djangoapps/contentstore/views/tests/test_gating.py
+++ b/cms/djangoapps/contentstore/views/tests/test_gating.py
@@ -57,7 +57,7 @@ class TestSubsectionGating(CourseTestCase):
         )
         self.seq2_url = reverse_usage_url('xblock_handler', self.seq2.location)
 
-    @patch('contentstore.views.item.gating_api.add_prerequisite')
+    @patch('cms.djangoapps.contentstore.views.item.gating_api.add_prerequisite')
     def test_add_prerequisite(self, mock_add_prereq):
         """
         Test adding a subsection as a prerequisite
@@ -69,7 +69,7 @@ class TestSubsectionGating(CourseTestCase):
         )
         mock_add_prereq.assert_called_with(self.course.id, self.seq1.location)
 
-    @patch('contentstore.views.item.gating_api.remove_prerequisite')
+    @patch('cms.djangoapps.contentstore.views.item.gating_api.remove_prerequisite')
     def test_remove_prerequisite(self, mock_remove_prereq):
         """
         Test removing a subsection as a prerequisite
@@ -81,7 +81,7 @@ class TestSubsectionGating(CourseTestCase):
         )
         mock_remove_prereq.assert_called_with(self.seq1.location)
 
-    @patch('contentstore.views.item.gating_api.set_required_content')
+    @patch('cms.djangoapps.contentstore.views.item.gating_api.set_required_content')
     def test_add_gate(self, mock_set_required_content):
         """
         Test adding a gated subsection
@@ -100,7 +100,7 @@ class TestSubsectionGating(CourseTestCase):
             '100'
         )
 
-    @patch('contentstore.views.item.gating_api.set_required_content')
+    @patch('cms.djangoapps.contentstore.views.item.gating_api.set_required_content')
     def test_remove_gate(self, mock_set_required_content):
         """
         Test removing a gated subsection
@@ -118,9 +118,9 @@ class TestSubsectionGating(CourseTestCase):
             ''
         )
 
-    @patch('contentstore.views.item.gating_api.get_prerequisites')
-    @patch('contentstore.views.item.gating_api.get_required_content')
-    @patch('contentstore.views.item.gating_api.is_prerequisite')
+    @patch('cms.djangoapps.contentstore.views.item.gating_api.get_prerequisites')
+    @patch('cms.djangoapps.contentstore.views.item.gating_api.get_required_content')
+    @patch('cms.djangoapps.contentstore.views.item.gating_api.is_prerequisite')
     @ddt.data(
         (90, None),
         (None, 90),
@@ -147,8 +147,8 @@ class TestSubsectionGating(CourseTestCase):
         self.assertEqual(resp['prereq_min_completion'], min_completion)
         self.assertEqual(resp['visibility_state'], VisibilityState.gated)
 
-    @patch('contentstore.signals.handlers.gating_api.set_required_content')
-    @patch('contentstore.signals.handlers.gating_api.remove_prerequisite')
+    @patch('cms.djangoapps.contentstore.signals.handlers.gating_api.set_required_content')
+    @patch('cms.djangoapps.contentstore.signals.handlers.gating_api.remove_prerequisite')
     def test_delete_item_signal_handler_called(self, mock_remove_prereq, mock_set_required):
         seq3 = ItemFactory.create(
             parent_location=self.chapter.location,

--- a/cms/djangoapps/contentstore/views/tests/test_group_configurations.py
+++ b/cms/djangoapps/contentstore/views/tests/test_group_configurations.py
@@ -13,7 +13,11 @@ import six
 from mock import patch
 from six.moves import range
 
-from cms.djangoapps.contentstore.course_group_config import CONTENT_GROUP_CONFIGURATION_NAME, ENROLLMENT_SCHEME, GroupConfiguration
+from cms.djangoapps.contentstore.course_group_config import (
+    CONTENT_GROUP_CONFIGURATION_NAME,
+    ENROLLMENT_SCHEME,
+    GroupConfiguration
+)
 from cms.djangoapps.contentstore.tests.utils import CourseTestCase
 from cms.djangoapps.contentstore.utils import reverse_course_url, reverse_usage_url
 from openedx.features.content_type_gating.helpers import CONTENT_GATING_PARTITION_ID

--- a/cms/djangoapps/contentstore/views/tests/test_group_configurations.py
+++ b/cms/djangoapps/contentstore/views/tests/test_group_configurations.py
@@ -13,9 +13,9 @@ import six
 from mock import patch
 from six.moves import range
 
-from contentstore.course_group_config import CONTENT_GROUP_CONFIGURATION_NAME, ENROLLMENT_SCHEME, GroupConfiguration
-from contentstore.tests.utils import CourseTestCase
-from contentstore.utils import reverse_course_url, reverse_usage_url
+from cms.djangoapps.contentstore.course_group_config import CONTENT_GROUP_CONFIGURATION_NAME, ENROLLMENT_SCHEME, GroupConfiguration
+from cms.djangoapps.contentstore.tests.utils import CourseTestCase
+from cms.djangoapps.contentstore.utils import reverse_course_url, reverse_usage_url
 from openedx.features.content_type_gating.helpers import CONTENT_GATING_PARTITION_ID
 from openedx.features.content_type_gating.partitions import CONTENT_TYPE_GATING_SCHEME
 from xmodule.modulestore import ModuleStoreEnum

--- a/cms/djangoapps/contentstore/views/tests/test_header_menu.py
+++ b/cms/djangoapps/contentstore/views/tests/test_header_menu.py
@@ -8,8 +8,8 @@ Course Header Menu Tests.
 from django.conf import settings
 from django.test.utils import override_settings
 
-from contentstore.tests.utils import CourseTestCase
-from contentstore.utils import reverse_course_url
+from cms.djangoapps.contentstore.tests.utils import CourseTestCase
+from cms.djangoapps.contentstore.utils import reverse_course_url
 from util.testing import UrlResetMixin
 
 FEATURES_WITH_CERTS_ENABLED = settings.FEATURES.copy()

--- a/cms/djangoapps/contentstore/views/tests/test_helpers.py
+++ b/cms/djangoapps/contentstore/views/tests/test_helpers.py
@@ -7,8 +7,9 @@ import six
 from django.utils import http
 
 from cms.djangoapps.contentstore.tests.utils import CourseTestCase
-from ..helpers import xblock_studio_url, xblock_type_display_name
 from xmodule.modulestore.tests.factories import ItemFactory, LibraryFactory
+
+from ..helpers import xblock_studio_url, xblock_type_display_name
 
 
 class HelpersTestCase(CourseTestCase):

--- a/cms/djangoapps/contentstore/views/tests/test_helpers.py
+++ b/cms/djangoapps/contentstore/views/tests/test_helpers.py
@@ -6,8 +6,8 @@ Unit tests for helpers.py.
 import six
 from django.utils import http
 
-from contentstore.tests.utils import CourseTestCase
-from contentstore.views.helpers import xblock_studio_url, xblock_type_display_name
+from cms.djangoapps.contentstore.tests.utils import CourseTestCase
+from ..helpers import xblock_studio_url, xblock_type_display_name
 from xmodule.modulestore.tests.factories import ItemFactory, LibraryFactory
 
 

--- a/cms/djangoapps/contentstore/views/tests/test_import_export.py
+++ b/cms/djangoapps/contentstore/views/tests/test_import_export.py
@@ -26,9 +26,9 @@ from six.moves import zip
 from storages.backends.s3boto import S3BotoStorage
 from user_tasks.models import UserTaskStatus
 
-from contentstore.tests.test_libraries import LibraryTestCase
-from contentstore.tests.utils import CourseTestCase
-from contentstore.utils import reverse_course_url
+from cms.djangoapps.contentstore.tests.test_libraries import LibraryTestCase
+from cms.djangoapps.contentstore.tests.utils import CourseTestCase
+from cms.djangoapps.contentstore.utils import reverse_course_url
 from models.settings.course_metadata import CourseMetadata
 from openedx.core.lib.extract_tar import safetar_extractall
 from student import auth

--- a/cms/djangoapps/contentstore/views/tests/test_import_export.py
+++ b/cms/djangoapps/contentstore/views/tests/test_import_export.py
@@ -786,7 +786,7 @@ class ExportTestCase(CourseTestCase):
         mock_artifact.file.storage.url.return_value = file_url
         return mock_artifact
 
-    @patch('contentstore.views.import_export._latest_task_status')
+    @patch('cms.djangoapps.contentstore.views.import_export._latest_task_status')
     @patch('user_tasks.models.UserTaskArtifact.objects.get')
     def test_export_status_handler_other(
         self,
@@ -806,7 +806,7 @@ class ExportTestCase(CourseTestCase):
         result = json.loads(resp.content.decode('utf-8'))
         self.assertEqual(result['ExportOutput'], '/path/to/testfile.tar.gz')
 
-    @patch('contentstore.views.import_export._latest_task_status')
+    @patch('cms.djangoapps.contentstore.views.import_export._latest_task_status')
     @patch('user_tasks.models.UserTaskArtifact.objects.get')
     def test_export_status_handler_s3(
         self,
@@ -826,7 +826,7 @@ class ExportTestCase(CourseTestCase):
         result = json.loads(resp.content.decode('utf-8'))
         self.assertEqual(result['ExportOutput'], '/s3/file/path/testfile.tar.gz')
 
-    @patch('contentstore.views.import_export._latest_task_status')
+    @patch('cms.djangoapps.contentstore.views.import_export._latest_task_status')
     @patch('user_tasks.models.UserTaskArtifact.objects.get')
     def test_export_status_handler_filesystem(
         self,

--- a/cms/djangoapps/contentstore/views/tests/test_item.py
+++ b/cms/djangoapps/contentstore/views/tests/test_item.py
@@ -31,11 +31,11 @@ from xblock.runtime import DictKeyValueStore, KvsFieldData
 from xblock.test.tools import TestRuntime
 from xblock.validation import ValidationMessage
 
-from contentstore.tests.utils import CourseTestCase
-from contentstore.utils import reverse_course_url, reverse_usage_url
-from contentstore.views import item as item_module
-from contentstore.views.component import component_handler, get_component_templates
-from contentstore.views.item import (
+from cms.djangoapps.contentstore.tests.utils import CourseTestCase
+from cms.djangoapps.contentstore.utils import reverse_course_url, reverse_usage_url
+from cms.djangoapps.contentstore.views import item as item_module
+from ..component import component_handler, get_component_templates
+from ..item import (
     ALWAYS,
     VisibilityState,
     _get_module_info,

--- a/cms/djangoapps/contentstore/views/tests/test_item.py
+++ b/cms/djangoapps/contentstore/views/tests/test_item.py
@@ -34,17 +34,6 @@ from xblock.validation import ValidationMessage
 from cms.djangoapps.contentstore.tests.utils import CourseTestCase
 from cms.djangoapps.contentstore.utils import reverse_course_url, reverse_usage_url
 from cms.djangoapps.contentstore.views import item as item_module
-from ..component import component_handler, get_component_templates
-from ..item import (
-    ALWAYS,
-    VisibilityState,
-    _get_module_info,
-    _get_source_index,
-    _xblock_type_and_display_name,
-    add_container_page_publishing_info,
-    create_xblock_info,
-    highlights_setting
-)
 from lms_xblock.mixin import NONSENSICAL_ACCESS_RESTRICTION
 from student.tests.factories import UserFactory
 from xblock_django.models import XBlockConfiguration, XBlockStudioConfiguration, XBlockStudioConfigurationFlag
@@ -64,6 +53,18 @@ from xmodule.partitions.partitions import (
 )
 from xmodule.partitions.tests.test_partitions import MockPartitionService
 from xmodule.x_module import STUDENT_VIEW, STUDIO_VIEW
+
+from ..component import component_handler, get_component_templates
+from ..item import (
+    ALWAYS,
+    VisibilityState,
+    _get_module_info,
+    _get_source_index,
+    _xblock_type_and_display_name,
+    add_container_page_publishing_info,
+    create_xblock_info,
+    highlights_setting
+)
 
 
 class AsideTest(XBlockAside):

--- a/cms/djangoapps/contentstore/views/tests/test_item.py
+++ b/cms/djangoapps/contentstore/views/tests/test_item.py
@@ -332,7 +332,7 @@ class GetItemTest(ItemTest):
         """
         Tests that valid paging is passed along to underlying block
         """
-        with patch('contentstore.views.item.get_preview_fragment') as patched_get_preview_fragment:
+        with patch('cms.djangoapps.contentstore.views.item.get_preview_fragment') as patched_get_preview_fragment:
             retval = Mock()
             type(retval).content = PropertyMock(return_value="Some content")
             type(retval).resources = PropertyMock(return_value=[])
@@ -1235,7 +1235,7 @@ class TestMoveItem(ItemTest):
         validation = html.validate()
         self.assertEqual(len(validation.messages), 0)
 
-    @patch('contentstore.views.item.log')
+    @patch('cms.djangoapps.contentstore.views.item.log')
     def test_move_logging(self, mock_logger):
         """
         Test logging when an item is successfully moved.
@@ -2147,7 +2147,7 @@ class TestComponentHandler(TestCase):
 
         self.request_factory = RequestFactory()
 
-        patcher = patch('contentstore.views.component.modulestore')
+        patcher = patch('cms.djangoapps.contentstore.views.component.modulestore')
         self.modulestore = patcher.start()
         self.addCleanup(patcher.stop)
 
@@ -2219,12 +2219,12 @@ class TestComponentHandler(TestCase):
         self.descriptor.handle = create_response
 
         with patch(
-            'contentstore.views.component.is_xblock_aside',
+            'cms.djangoapps.contentstore.views.component.is_xblock_aside',
             return_value=is_xblock_aside
         ), patch(
-            'contentstore.views.component.get_aside_from_xblock'
+            'cms.djangoapps.contentstore.views.component.get_aside_from_xblock'
         ) as mocked_get_aside_from_xblock, patch(
-            "contentstore.views.component.webob_to_django_response"
+            "cms.djangoapps.contentstore.views.component.webob_to_django_response"
         ) as mocked_webob_to_django_response:
             component_handler(
                 self.request,

--- a/cms/djangoapps/contentstore/views/tests/test_library.py
+++ b/cms/djangoapps/contentstore/views/tests/test_library.py
@@ -14,10 +14,10 @@ from opaque_keys.edx.locator import CourseKey, LibraryLocator
 from six import binary_type, text_type
 from six.moves import range
 
-from contentstore.tests.utils import AjaxEnabledTestClient, CourseTestCase, parse_json
-from contentstore.utils import reverse_course_url, reverse_library_url
-from contentstore.views.component import get_component_templates
-from contentstore.views.library import get_library_creator_status
+from cms.djangoapps.contentstore.tests.utils import AjaxEnabledTestClient, CourseTestCase, parse_json
+from cms.djangoapps.contentstore.utils import reverse_course_url, reverse_library_url
+from ..component import get_component_templates
+from ..library import get_library_creator_status
 from course_creators.views import add_user_with_status_granted as grant_course_creator_status
 from student.roles import LibraryUserRole
 from xmodule.modulestore.tests.factories import LibraryFactory

--- a/cms/djangoapps/contentstore/views/tests/test_library.py
+++ b/cms/djangoapps/contentstore/views/tests/test_library.py
@@ -16,11 +16,12 @@ from six.moves import range
 
 from cms.djangoapps.contentstore.tests.utils import AjaxEnabledTestClient, CourseTestCase, parse_json
 from cms.djangoapps.contentstore.utils import reverse_course_url, reverse_library_url
-from ..component import get_component_templates
-from ..library import get_library_creator_status
 from course_creators.views import add_user_with_status_granted as grant_course_creator_status
 from student.roles import LibraryUserRole
 from xmodule.modulestore.tests.factories import LibraryFactory
+
+from ..component import get_component_templates
+from ..library import get_library_creator_status
 
 LIBRARY_REST_URL = '/library/'  # URL for GET/POST requests involving libraries
 

--- a/cms/djangoapps/contentstore/views/tests/test_library.py
+++ b/cms/djangoapps/contentstore/views/tests/test_library.py
@@ -48,23 +48,23 @@ class UnitTestLibraries(CourseTestCase):
     ######################################################
     # Tests for /library/ - list and create libraries:
 
-    @mock.patch("contentstore.views.library.LIBRARIES_ENABLED", False)
+    @mock.patch("cms.djangoapps.contentstore.views.library.LIBRARIES_ENABLED", False)
     def test_library_creator_status_libraries_not_enabled(self):
         _, nostaff_user = self.create_non_staff_authed_user_client()
         self.assertEqual(get_library_creator_status(nostaff_user), False)
 
-    @mock.patch("contentstore.views.library.LIBRARIES_ENABLED", True)
+    @mock.patch("cms.djangoapps.contentstore.views.library.LIBRARIES_ENABLED", True)
     def test_library_creator_status_with_is_staff_user(self):
         self.assertEqual(get_library_creator_status(self.user), True)
 
-    @mock.patch("contentstore.views.library.LIBRARIES_ENABLED", True)
+    @mock.patch("cms.djangoapps.contentstore.views.library.LIBRARIES_ENABLED", True)
     def test_library_creator_status_with_course_creator_role(self):
         _, nostaff_user = self.create_non_staff_authed_user_client()
         with mock.patch.dict('django.conf.settings.FEATURES', {"ENABLE_CREATOR_GROUP": True}):
             grant_course_creator_status(self.user, nostaff_user)
             self.assertEqual(get_library_creator_status(nostaff_user), True)
 
-    @mock.patch("contentstore.views.library.LIBRARIES_ENABLED", True)
+    @mock.patch("cms.djangoapps.contentstore.views.library.LIBRARIES_ENABLED", True)
     def test_library_creator_status_with_no_course_creator_role(self):
         _, nostaff_user = self.create_non_staff_authed_user_client()
         self.assertEqual(get_library_creator_status(nostaff_user), True)
@@ -83,7 +83,7 @@ class UnitTestLibraries(CourseTestCase):
         Ensure that the setting DISABLE_LIBRARY_CREATION overrides DISABLE_COURSE_CREATION as expected.
         """
         _, nostaff_user = self.create_non_staff_authed_user_client()
-        with mock.patch("contentstore.views.library.LIBRARIES_ENABLED", True):
+        with mock.patch("cms.djangoapps.contentstore.views.library.LIBRARIES_ENABLED", True):
             with mock.patch.dict(
                 "django.conf.settings.FEATURES",
                 {
@@ -94,7 +94,7 @@ class UnitTestLibraries(CourseTestCase):
                 self.assertEqual(get_library_creator_status(nostaff_user), expected_status)
 
     @mock.patch.dict('django.conf.settings.FEATURES', {'DISABLE_COURSE_CREATION': True})
-    @mock.patch("contentstore.views.library.LIBRARIES_ENABLED", True)
+    @mock.patch("cms.djangoapps.contentstore.views.library.LIBRARIES_ENABLED", True)
     def test_library_creator_status_with_no_course_creator_role_and_disabled_nonstaff_course_creation(self):
         """
         Ensure that `DISABLE_COURSE_CREATION` feature works with libraries as well.
@@ -110,7 +110,7 @@ class UnitTestLibraries(CourseTestCase):
         self.assertEqual(get_response.status_code, 200)
         self.assertEqual(post_response.status_code, 403)
 
-    @patch("contentstore.views.library.LIBRARIES_ENABLED", False)
+    @patch("cms.djangoapps.contentstore.views.library.LIBRARIES_ENABLED", False)
     def test_with_libraries_disabled(self):
         """
         The library URLs should return 404 if libraries are disabled.

--- a/cms/djangoapps/contentstore/views/tests/test_preview.py
+++ b/cms/djangoapps/contentstore/views/tests/test_preview.py
@@ -12,7 +12,6 @@ from django.test.client import Client, RequestFactory
 from xblock.core import XBlock, XBlockAside
 
 from cms.djangoapps.contentstore.utils import reverse_usage_url
-from ..preview import _preview_module_system, get_preview_fragment
 from student.tests.factories import UserFactory
 from xblock_config.models import StudioConfig
 from xmodule.modulestore import ModuleStoreEnum
@@ -20,6 +19,8 @@ from xmodule.modulestore.django import modulestore
 from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
 from xmodule.modulestore.tests.factories import CourseFactory, ItemFactory
 from xmodule.modulestore.tests.test_asides import AsideTestType
+
+from ..preview import _preview_module_system, get_preview_fragment
 
 
 @ddt.ddt

--- a/cms/djangoapps/contentstore/views/tests/test_preview.py
+++ b/cms/djangoapps/contentstore/views/tests/test_preview.py
@@ -11,8 +11,8 @@ import six
 from django.test.client import Client, RequestFactory
 from xblock.core import XBlock, XBlockAside
 
-from contentstore.utils import reverse_usage_url
-from contentstore.views.preview import _preview_module_system, get_preview_fragment
+from cms.djangoapps.contentstore.utils import reverse_usage_url
+from ..preview import _preview_module_system, get_preview_fragment
 from student.tests.factories import UserFactory
 from xblock_config.models import StudioConfig
 from xmodule.modulestore import ModuleStoreEnum

--- a/cms/djangoapps/contentstore/views/tests/test_tabs.py
+++ b/cms/djangoapps/contentstore/views/tests/test_tabs.py
@@ -3,9 +3,9 @@
 
 import json
 
-from contentstore.tests.utils import CourseTestCase
-from contentstore.utils import reverse_course_url
-from contentstore.views import tabs
+from cms.djangoapps.contentstore.tests.utils import CourseTestCase
+from cms.djangoapps.contentstore.utils import reverse_course_url
+from cms.djangoapps.contentstore.views import tabs
 from xmodule.modulestore.django import modulestore
 from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
 from xmodule.modulestore.tests.factories import CourseFactory, ItemFactory

--- a/cms/djangoapps/contentstore/views/tests/test_textbooks.py
+++ b/cms/djangoapps/contentstore/views/tests/test_textbooks.py
@@ -6,6 +6,7 @@ from unittest import TestCase
 
 from cms.djangoapps.contentstore.tests.utils import CourseTestCase
 from cms.djangoapps.contentstore.utils import reverse_course_url
+
 from ..course import TextbookValidationError, validate_textbook_json, validate_textbooks_json
 
 

--- a/cms/djangoapps/contentstore/views/tests/test_textbooks.py
+++ b/cms/djangoapps/contentstore/views/tests/test_textbooks.py
@@ -4,9 +4,9 @@
 import json
 from unittest import TestCase
 
-from contentstore.tests.utils import CourseTestCase
-from contentstore.utils import reverse_course_url
-from contentstore.views.course import TextbookValidationError, validate_textbook_json, validate_textbooks_json
+from cms.djangoapps.contentstore.tests.utils import CourseTestCase
+from cms.djangoapps.contentstore.utils import reverse_course_url
+from ..course import TextbookValidationError, validate_textbook_json, validate_textbooks_json
 
 
 class TextbookIndexTestCase(CourseTestCase):

--- a/cms/djangoapps/contentstore/views/tests/test_transcript_settings.py
+++ b/cms/djangoapps/contentstore/views/tests/test_transcript_settings.py
@@ -13,9 +13,10 @@ from mock import ANY, Mock, patch
 
 from cms.djangoapps.contentstore.tests.utils import CourseTestCase
 from cms.djangoapps.contentstore.utils import reverse_course_url
-from ..transcript_settings import TranscriptionProviderErrorType, validate_transcript_credentials
 from openedx.core.djangoapps.profile_images.tests.helpers import make_image_file
 from student.roles import CourseStaffRole
+
+from ..transcript_settings import TranscriptionProviderErrorType, validate_transcript_credentials
 
 
 @ddt.ddt

--- a/cms/djangoapps/contentstore/views/tests/test_transcript_settings.py
+++ b/cms/djangoapps/contentstore/views/tests/test_transcript_settings.py
@@ -302,7 +302,10 @@ class TranscriptUploadTest(CourseTestCase):
         self.assertEqual(response.status_code, 405)
 
     @patch('cms.djangoapps.contentstore.views.transcript_settings.create_or_update_video_transcript')
-    @patch('cms.djangoapps.contentstore.views.transcript_settings.get_available_transcript_languages', Mock(return_value=['en']))
+    @patch(
+        'cms.djangoapps.contentstore.views.transcript_settings.get_available_transcript_languages',
+        Mock(return_value=['en']),
+    )
     def test_transcript_upload_handler(self, mock_create_or_update_video_transcript):
         """
         Tests that transcript upload handler works as expected.
@@ -364,7 +367,10 @@ class TranscriptUploadTest(CourseTestCase):
         )
     )
     @ddt.unpack
-    @patch('cms.djangoapps.contentstore.views.transcript_settings.get_available_transcript_languages', Mock(return_value=['en']))
+    @patch(
+        'cms.djangoapps.contentstore.views.transcript_settings.get_available_transcript_languages',
+        Mock(return_value=['en']),
+    )
     def test_transcript_upload_handler_missing_attrs(self, request_payload, expected_error_message):
         """
         Tests the transcript upload handler when the required attributes are missing.
@@ -374,7 +380,10 @@ class TranscriptUploadTest(CourseTestCase):
         self.assertEqual(response.status_code, 400)
         self.assertEqual(json.loads(response.content.decode('utf-8'))['error'], expected_error_message)
 
-    @patch('cms.djangoapps.contentstore.views.transcript_settings.get_available_transcript_languages', Mock(return_value=['en', 'es']))
+    @patch(
+        'cms.djangoapps.contentstore.views.transcript_settings.get_available_transcript_languages',
+        Mock(return_value=['en', 'es'])
+    )
     def test_transcript_upload_handler_existing_transcript(self):
         """
         Tests that upload handler do not update transcript's language if a transcript
@@ -393,7 +402,10 @@ class TranscriptUploadTest(CourseTestCase):
             u'A transcript with the "es" language code already exists.'
         )
 
-    @patch('cms.djangoapps.contentstore.views.transcript_settings.get_available_transcript_languages', Mock(return_value=['en']))
+    @patch(
+        'cms.djangoapps.contentstore.views.transcript_settings.get_available_transcript_languages',
+        Mock(return_value=['en']),
+    )
     def test_transcript_upload_handler_with_image(self):
         """
         Tests the transcript upload handler with an image file.
@@ -417,7 +429,10 @@ class TranscriptUploadTest(CourseTestCase):
                 u'There is a problem with this transcript file. Try to upload a different file.'
             )
 
-    @patch('cms.djangoapps.contentstore.views.transcript_settings.get_available_transcript_languages', Mock(return_value=['en']))
+    @patch(
+        'cms.djangoapps.contentstore.views.transcript_settings.get_available_transcript_languages',
+        Mock(return_value=['en']),
+    )
     def test_transcript_upload_handler_with_invalid_transcript(self):
         """
         Tests the transcript upload handler with an invalid transcript file.

--- a/cms/djangoapps/contentstore/views/tests/test_transcript_settings.py
+++ b/cms/djangoapps/contentstore/views/tests/test_transcript_settings.py
@@ -92,7 +92,7 @@ class TranscriptCredentialsTest(CourseTestCase):
         )
     )
     @ddt.unpack
-    @patch('contentstore.views.transcript_settings.update_3rd_party_transcription_service_credentials')
+    @patch('cms.djangoapps.contentstore.views.transcript_settings.update_3rd_party_transcription_service_credentials')
     def test_transcript_credentials_handler(self, request_payload, update_credentials_response, expected_status_code,
                                             expected_response, mock_update_credentials):
         """
@@ -209,7 +209,7 @@ class TranscriptDownloadTest(CourseTestCase):
         response = self.client.post(self.view_url, content_type='application/json')
         self.assertEqual(response.status_code, 405)
 
-    @patch('contentstore.views.transcript_settings.get_video_transcript_data')
+    @patch('cms.djangoapps.contentstore.views.transcript_settings.get_video_transcript_data')
     def test_transcript_download_handler(self, mock_get_video_transcript_data):
         """
         Tests that transcript download handler works as expected.
@@ -301,8 +301,8 @@ class TranscriptUploadTest(CourseTestCase):
         response = self.client.get(self.view_url, content_type='application/json')
         self.assertEqual(response.status_code, 405)
 
-    @patch('contentstore.views.transcript_settings.create_or_update_video_transcript')
-    @patch('contentstore.views.transcript_settings.get_available_transcript_languages', Mock(return_value=['en']))
+    @patch('cms.djangoapps.contentstore.views.transcript_settings.create_or_update_video_transcript')
+    @patch('cms.djangoapps.contentstore.views.transcript_settings.get_available_transcript_languages', Mock(return_value=['en']))
     def test_transcript_upload_handler(self, mock_create_or_update_video_transcript):
         """
         Tests that transcript upload handler works as expected.
@@ -364,7 +364,7 @@ class TranscriptUploadTest(CourseTestCase):
         )
     )
     @ddt.unpack
-    @patch('contentstore.views.transcript_settings.get_available_transcript_languages', Mock(return_value=['en']))
+    @patch('cms.djangoapps.contentstore.views.transcript_settings.get_available_transcript_languages', Mock(return_value=['en']))
     def test_transcript_upload_handler_missing_attrs(self, request_payload, expected_error_message):
         """
         Tests the transcript upload handler when the required attributes are missing.
@@ -374,7 +374,7 @@ class TranscriptUploadTest(CourseTestCase):
         self.assertEqual(response.status_code, 400)
         self.assertEqual(json.loads(response.content.decode('utf-8'))['error'], expected_error_message)
 
-    @patch('contentstore.views.transcript_settings.get_available_transcript_languages', Mock(return_value=['en', 'es']))
+    @patch('cms.djangoapps.contentstore.views.transcript_settings.get_available_transcript_languages', Mock(return_value=['en', 'es']))
     def test_transcript_upload_handler_existing_transcript(self):
         """
         Tests that upload handler do not update transcript's language if a transcript
@@ -393,7 +393,7 @@ class TranscriptUploadTest(CourseTestCase):
             u'A transcript with the "es" language code already exists.'
         )
 
-    @patch('contentstore.views.transcript_settings.get_available_transcript_languages', Mock(return_value=['en']))
+    @patch('cms.djangoapps.contentstore.views.transcript_settings.get_available_transcript_languages', Mock(return_value=['en']))
     def test_transcript_upload_handler_with_image(self):
         """
         Tests the transcript upload handler with an image file.
@@ -417,7 +417,7 @@ class TranscriptUploadTest(CourseTestCase):
                 u'There is a problem with this transcript file. Try to upload a different file.'
             )
 
-    @patch('contentstore.views.transcript_settings.get_available_transcript_languages', Mock(return_value=['en']))
+    @patch('cms.djangoapps.contentstore.views.transcript_settings.get_available_transcript_languages', Mock(return_value=['en']))
     def test_transcript_upload_handler_with_invalid_transcript(self):
         """
         Tests the transcript upload handler with an invalid transcript file.

--- a/cms/djangoapps/contentstore/views/tests/test_transcript_settings.py
+++ b/cms/djangoapps/contentstore/views/tests/test_transcript_settings.py
@@ -11,9 +11,9 @@ from django.urls import reverse
 from edxval import api
 from mock import ANY, Mock, patch
 
-from contentstore.tests.utils import CourseTestCase
-from contentstore.utils import reverse_course_url
-from contentstore.views.transcript_settings import TranscriptionProviderErrorType, validate_transcript_credentials
+from cms.djangoapps.contentstore.tests.utils import CourseTestCase
+from cms.djangoapps.contentstore.utils import reverse_course_url
+from ..transcript_settings import TranscriptionProviderErrorType, validate_transcript_credentials
 from openedx.core.djangoapps.profile_images.tests.helpers import make_image_file
 from student.roles import CourseStaffRole
 

--- a/cms/djangoapps/contentstore/views/tests/test_transcripts.py
+++ b/cms/djangoapps/contentstore/views/tests/test_transcripts.py
@@ -624,7 +624,10 @@ class TestRenameTranscripts(BaseTranscripts):
 
 
 @ddt.ddt
-@patch('cms.djangoapps.contentstore.views.transcripts_ajax.download_youtube_subs', Mock(return_value=SJSON_TRANSCRIPT_CONTENT))
+@patch(
+    'cms.djangoapps.contentstore.views.transcripts_ajax.download_youtube_subs',
+    Mock(return_value=SJSON_TRANSCRIPT_CONTENT)
+)
 class TestReplaceTranscripts(BaseTranscripts):
     """
     Tests for '/transcripts/replace' endpoint.
@@ -735,7 +738,8 @@ class TestReplaceTranscripts(BaseTranscripts):
         Verify that replace transcript fails if YouTube does not have transcript for the given youtube id.
         """
         error_message = u'YT ID not found.'
-        with patch('cms.djangoapps.contentstore.views.transcripts_ajax.download_youtube_subs') as mock_download_youtube_subs:
+        patch_path = 'cms.djangoapps.contentstore.views.transcripts_ajax.download_youtube_subs'
+        with patch(patch_path) as mock_download_youtube_subs:
             mock_download_youtube_subs.side_effect = GetTranscriptsFromYouTubeException(error_message)
             response = self.replace_transcript(locator=self.video_usage_key, youtube_id='non-existent-yt-id')
             self.assertContains(response, text=error_message, status_code=400)

--- a/cms/djangoapps/contentstore/views/tests/test_transcripts.py
+++ b/cms/djangoapps/contentstore/views/tests/test_transcripts.py
@@ -624,7 +624,7 @@ class TestRenameTranscripts(BaseTranscripts):
 
 
 @ddt.ddt
-@patch('contentstore.views.transcripts_ajax.download_youtube_subs', Mock(return_value=SJSON_TRANSCRIPT_CONTENT))
+@patch('cms.djangoapps.contentstore.views.transcripts_ajax.download_youtube_subs', Mock(return_value=SJSON_TRANSCRIPT_CONTENT))
 class TestReplaceTranscripts(BaseTranscripts):
     """
     Tests for '/transcripts/replace' endpoint.
@@ -735,7 +735,7 @@ class TestReplaceTranscripts(BaseTranscripts):
         Verify that replace transcript fails if YouTube does not have transcript for the given youtube id.
         """
         error_message = u'YT ID not found.'
-        with patch('contentstore.views.transcripts_ajax.download_youtube_subs') as mock_download_youtube_subs:
+        with patch('cms.djangoapps.contentstore.views.transcripts_ajax.download_youtube_subs') as mock_download_youtube_subs:
             mock_download_youtube_subs.side_effect = GetTranscriptsFromYouTubeException(error_message)
             response = self.replace_transcript(locator=self.video_usage_key, youtube_id='non-existent-yt-id')
             self.assertContains(response, text=error_message, status_code=400)

--- a/cms/djangoapps/contentstore/views/tests/test_transcripts.py
+++ b/cms/djangoapps/contentstore/views/tests/test_transcripts.py
@@ -17,7 +17,7 @@ from edxval.api import create_video
 from mock import Mock, patch
 from opaque_keys.edx.keys import UsageKey
 
-from contentstore.tests.utils import CourseTestCase, mock_requests_get
+from cms.djangoapps.contentstore.tests.utils import CourseTestCase, mock_requests_get
 from openedx.core.djangoapps.contentserver.caching import del_cached_content
 from xmodule.contentstore.content import StaticContent
 from xmodule.contentstore.django import contentstore

--- a/cms/djangoapps/contentstore/views/tests/test_unit_page.py
+++ b/cms/djangoapps/contentstore/views/tests/test_unit_page.py
@@ -3,7 +3,7 @@ Unit tests for the unit page.
 """
 
 
-from contentstore.views.tests.utils import StudioPageTestCase
+from .utils import StudioPageTestCase
 from xmodule.modulestore.django import modulestore
 from xmodule.modulestore.tests.factories import ItemFactory
 from xmodule.x_module import STUDENT_VIEW

--- a/cms/djangoapps/contentstore/views/tests/test_unit_page.py
+++ b/cms/djangoapps/contentstore/views/tests/test_unit_page.py
@@ -3,10 +3,11 @@ Unit tests for the unit page.
 """
 
 
-from .utils import StudioPageTestCase
 from xmodule.modulestore.django import modulestore
 from xmodule.modulestore.tests.factories import ItemFactory
 from xmodule.x_module import STUDENT_VIEW
+
+from .utils import StudioPageTestCase
 
 
 class UnitPageTestCase(StudioPageTestCase):

--- a/cms/djangoapps/contentstore/views/tests/test_user.py
+++ b/cms/djangoapps/contentstore/views/tests/test_user.py
@@ -7,8 +7,8 @@ import json
 
 from django.contrib.auth.models import User
 
-from contentstore.tests.utils import CourseTestCase
-from contentstore.utils import reverse_course_url
+from cms.djangoapps.contentstore.tests.utils import CourseTestCase
+from cms.djangoapps.contentstore.utils import reverse_course_url
 from student import auth
 from student.models import CourseEnrollment
 from student.roles import CourseInstructorRole, CourseStaffRole

--- a/cms/djangoapps/contentstore/views/tests/test_videos.py
+++ b/cms/djangoapps/contentstore/views/tests/test_videos.py
@@ -784,7 +784,7 @@ class VideosHandlerTestCase(VideoUploadTestMixin, CourseTestCase):
         # Test should fail if video not found
         self.assertEqual(True, False, 'Invalid edx_video_id')
 
-    @patch('contentstore.views.videos.LOGGER')
+    @patch('cms.djangoapps.contentstore.views.videos.LOGGER')
     def test_video_status_update_request(self, mock_logger):
         """
         Verifies that video status update request works as expected.
@@ -1432,7 +1432,7 @@ class TranscriptPreferencesTestCase(VideoUploadTestBase, CourseTestCase):
     @override_settings(AWS_ACCESS_KEY_ID='test_key_id', AWS_SECRET_ACCESS_KEY='test_secret')
     @patch('boto.s3.key.Key')
     @patch('boto.s3.connection.S3Connection')
-    @patch('contentstore.views.videos.get_transcript_preferences')
+    @patch('cms.djangoapps.contentstore.views.videos.get_transcript_preferences')
     def test_transcript_preferences_metadata(self, transcript_preferences, is_video_transcript_enabled,
                                              mock_transcript_preferences, mock_conn, mock_key):
         """

--- a/cms/djangoapps/contentstore/views/tests/test_videos.py
+++ b/cms/djangoapps/contentstore/views/tests/test_videos.py
@@ -30,10 +30,10 @@ from mock import Mock, patch
 from six import StringIO
 from waffle.testutils import override_flag
 
-from contentstore.models import VideoUploadConfig
-from contentstore.tests.utils import CourseTestCase
-from contentstore.utils import reverse_course_url
-from contentstore.views.videos import (
+from cms.djangoapps.contentstore.models import VideoUploadConfig
+from cms.djangoapps.contentstore.tests.utils import CourseTestCase
+from cms.djangoapps.contentstore.utils import reverse_course_url
+from ..videos import (
     ENABLE_VIDEO_UPLOAD_PAGINATION,
     KEY_EXPIRATION_IN_SECONDS,
     VIDEO_IMAGE_UPLOAD_ENABLED,

--- a/cms/djangoapps/contentstore/views/tests/test_videos.py
+++ b/cms/djangoapps/contentstore/views/tests/test_videos.py
@@ -33,6 +33,17 @@ from waffle.testutils import override_flag
 from cms.djangoapps.contentstore.models import VideoUploadConfig
 from cms.djangoapps.contentstore.tests.utils import CourseTestCase
 from cms.djangoapps.contentstore.utils import reverse_course_url
+from openedx.core.djangoapps.profile_images.tests.helpers import make_image_file
+from openedx.core.djangoapps.video_pipeline.config.waffle import (
+    DEPRECATE_YOUTUBE,
+    ENABLE_DEVSTACK_VIDEO_UPLOADS,
+    waffle_flags
+)
+from openedx.core.djangoapps.video_pipeline.models import VEMPipelineIntegration
+from openedx.core.djangoapps.waffle_utils.models import WaffleFlagCourseOverrideModel
+from openedx.core.djangoapps.waffle_utils.testutils import override_waffle_flag
+from xmodule.modulestore.tests.factories import CourseFactory
+
 from ..videos import (
     ENABLE_VIDEO_UPLOAD_PAGINATION,
     KEY_EXPIRATION_IN_SECONDS,
@@ -44,16 +55,6 @@ from ..videos import (
     _get_default_video_image_url,
     convert_video_status
 )
-from openedx.core.djangoapps.profile_images.tests.helpers import make_image_file
-from openedx.core.djangoapps.video_pipeline.config.waffle import (
-    DEPRECATE_YOUTUBE,
-    ENABLE_DEVSTACK_VIDEO_UPLOADS,
-    waffle_flags
-)
-from openedx.core.djangoapps.video_pipeline.models import VEMPipelineIntegration
-from openedx.core.djangoapps.waffle_utils.models import WaffleFlagCourseOverrideModel
-from openedx.core.djangoapps.waffle_utils.testutils import override_waffle_flag
-from xmodule.modulestore.tests.factories import CourseFactory
 
 
 def override_switch(switch, active):

--- a/cms/djangoapps/contentstore/views/tests/utils.py
+++ b/cms/djangoapps/contentstore/views/tests/utils.py
@@ -6,8 +6,9 @@ Utilities for view tests.
 import json
 
 from cms.djangoapps.contentstore.tests.utils import CourseTestCase
-from ..helpers import xblock_studio_url
 from xmodule.modulestore.tests.factories import ItemFactory
+
+from ..helpers import xblock_studio_url
 
 
 class StudioPageTestCase(CourseTestCase):

--- a/cms/djangoapps/contentstore/views/tests/utils.py
+++ b/cms/djangoapps/contentstore/views/tests/utils.py
@@ -5,8 +5,8 @@ Utilities for view tests.
 
 import json
 
-from contentstore.tests.utils import CourseTestCase
-from contentstore.views.helpers import xblock_studio_url
+from cms.djangoapps.contentstore.tests.utils import CourseTestCase
+from ..helpers import xblock_studio_url
 from xmodule.modulestore.tests.factories import ItemFactory
 
 

--- a/cms/djangoapps/contentstore/views/transcript_settings.py
+++ b/cms/djangoapps/contentstore/views/transcript_settings.py
@@ -11,9 +11,6 @@ from django.core.files.base import ContentFile
 from django.http import HttpResponse, HttpResponseNotFound
 from django.utils.translation import ugettext as _
 from django.views.decorators.http import require_GET, require_http_methods, require_POST
-from opaque_keys.edx.keys import CourseKey
-
-from .videos import TranscriptProvider
 from edxval.api import (
     create_or_update_video_transcript,
     delete_video_transcript,
@@ -22,11 +19,15 @@ from edxval.api import (
     get_video_transcript_data,
     update_transcript_credentials_state_for_org
 )
+from opaque_keys.edx.keys import CourseKey
+
 from openedx.core.djangoapps.video_config.models import VideoTranscriptEnabledFlag
 from openedx.core.djangoapps.video_pipeline.api import update_3rd_party_transcription_service_credentials
 from student.auth import has_studio_write_access
 from util.json_request import JsonResponse, expect_json
 from xmodule.video_module.transcripts_utils import Transcript, TranscriptsGenerationException
+
+from .videos import TranscriptProvider
 
 __all__ = [
     'transcript_credentials_handler',

--- a/cms/djangoapps/contentstore/views/transcript_settings.py
+++ b/cms/djangoapps/contentstore/views/transcript_settings.py
@@ -13,7 +13,7 @@ from django.utils.translation import ugettext as _
 from django.views.decorators.http import require_GET, require_http_methods, require_POST
 from opaque_keys.edx.keys import CourseKey
 
-from contentstore.views.videos import TranscriptProvider
+from .videos import TranscriptProvider
 from edxval.api import (
     create_or_update_video_transcript,
     delete_video_transcript,

--- a/cms/djangoapps/contentstore/views/videos.py
+++ b/cms/djangoapps/contentstore/views/videos.py
@@ -41,9 +41,9 @@ from edxval.api import (
 from opaque_keys.edx.keys import CourseKey
 from pytz import UTC
 
-from contentstore.models import VideoUploadConfig
-from contentstore.utils import reverse_course_url
-from contentstore.video_utils import validate_video_image
+from ..models import VideoUploadConfig
+from ..utils import reverse_course_url
+from ..video_utils import validate_video_image
 from edxmako.shortcuts import render_to_response
 from openedx.core.djangoapps.video_config.models import VideoTranscriptEnabledFlag
 from openedx.core.djangoapps.video_pipeline.config.waffle import (

--- a/cms/djangoapps/contentstore/views/videos.py
+++ b/cms/djangoapps/contentstore/views/videos.py
@@ -5,11 +5,11 @@ Views related to the video upload feature
 
 import codecs
 import csv
+import io
 import json
 import logging
 from contextlib import closing
 from datetime import datetime, timedelta
-import io
 from uuid import uuid4
 
 import six
@@ -41,9 +41,6 @@ from edxval.api import (
 from opaque_keys.edx.keys import CourseKey
 from pytz import UTC
 
-from ..models import VideoUploadConfig
-from ..utils import reverse_course_url
-from ..video_utils import validate_video_image
 from edxmako.shortcuts import render_to_response
 from openedx.core.djangoapps.video_config.models import VideoTranscriptEnabledFlag
 from openedx.core.djangoapps.video_pipeline.config.waffle import (
@@ -55,6 +52,9 @@ from openedx.core.djangoapps.waffle_utils import CourseWaffleFlag, WaffleFlagNam
 from util.json_request import JsonResponse, expect_json
 from xmodule.video_module.transcripts_utils import Transcript
 
+from ..models import VideoUploadConfig
+from ..utils import reverse_course_url
+from ..video_utils import validate_video_image
 from .course import get_course_and_check_access
 
 __all__ = [

--- a/cms/djangoapps/course_creators/apps.py
+++ b/cms/djangoapps/course_creators/apps.py
@@ -1,0 +1,12 @@
+"""
+Configuration for app to store information about whether or not Studio users have
+course creation privileges.
+"""
+
+
+from django.apps import AppConfig
+
+
+class CourseCreatorsConfig(AppConfig):
+    name = 'cms.djangoapps.course_creators'
+    verbose_name = 'Course Creators'

--- a/cms/djangoapps/course_creators/tests/test_admin.py
+++ b/cms/djangoapps/course_creators/tests/test_admin.py
@@ -48,7 +48,7 @@ class CourseCreatorAdminTest(TestCase):
             "STUDIO_REQUEST_EMAIL": self.studio_request_email
         }
 
-    @mock.patch('course_creators.admin.render_to_string', mock.Mock(side_effect=mock_render_to_string, autospec=True))
+    @mock.patch('cms.djangoapps.course_creators.admin.render_to_string', mock.Mock(side_effect=mock_render_to_string, autospec=True))
     @mock.patch('django.contrib.auth.models.User.email_user')
     def test_change_status(self, email_user):
         """
@@ -92,7 +92,7 @@ class CourseCreatorAdminTest(TestCase):
 
             change_state_and_verify_email(CourseCreator.DENIED, False)
 
-    @mock.patch('course_creators.admin.render_to_string', mock.Mock(side_effect=mock_render_to_string, autospec=True))
+    @mock.patch('cms.djangoapps.course_creators.admin.render_to_string', mock.Mock(side_effect=mock_render_to_string, autospec=True))
     def test_mail_admin_on_pending(self):
         """
         Tests that the admin account is notified when a user is in the 'pending' state.

--- a/cms/djangoapps/course_creators/tests/test_admin.py
+++ b/cms/djangoapps/course_creators/tests/test_admin.py
@@ -48,7 +48,10 @@ class CourseCreatorAdminTest(TestCase):
             "STUDIO_REQUEST_EMAIL": self.studio_request_email
         }
 
-    @mock.patch('cms.djangoapps.course_creators.admin.render_to_string', mock.Mock(side_effect=mock_render_to_string, autospec=True))
+    @mock.patch(
+        'cms.djangoapps.course_creators.admin.render_to_string',
+        mock.Mock(side_effect=mock_render_to_string, autospec=True)
+    )
     @mock.patch('django.contrib.auth.models.User.email_user')
     def test_change_status(self, email_user):
         """
@@ -92,7 +95,10 @@ class CourseCreatorAdminTest(TestCase):
 
             change_state_and_verify_email(CourseCreator.DENIED, False)
 
-    @mock.patch('cms.djangoapps.course_creators.admin.render_to_string', mock.Mock(side_effect=mock_render_to_string, autospec=True))
+    @mock.patch(
+        'cms.djangoapps.course_creators.admin.render_to_string',
+        mock.Mock(side_effect=mock_render_to_string, autospec=True)
+    )
     def test_mail_admin_on_pending(self):
         """
         Tests that the admin account is notified when a user is in the 'pending' state.

--- a/cms/djangoapps/maintenance/apps.py
+++ b/cms/djangoapps/maintenance/apps.py
@@ -1,0 +1,11 @@
+"""
+Configuration for Studio Maintenance application
+"""
+
+
+from django.apps import AppConfig
+
+
+class MaintenanceConfig(AppConfig):
+    name = 'cms.djangoapps.maintenance'
+    verbose_name = 'Maintenance'

--- a/cms/djangoapps/models/settings/course_grading.py
+++ b/cms/djangoapps/models/settings/course_grading.py
@@ -11,9 +11,9 @@ import six
 from eventtracking import tracker
 
 from contentstore.signals.signals import GRADING_POLICY_CHANGED
+from models.settings.waffle import material_recompute_only
 from track.event_transaction_utils import create_new_event_transaction_id
 from xmodule.modulestore.django import modulestore
-from models.settings.waffle import material_recompute_only
 
 log = logging.getLogger(__name__)
 

--- a/cms/djangoapps/models/settings/course_metadata.py
+++ b/cms/djangoapps/models/settings/course_metadata.py
@@ -4,18 +4,19 @@ Django module for Course Metadata class -- manages advanced settings and related
 
 
 from datetime import datetime
+
+import pytz
 import six
 from crum import get_current_user
-from django.core.exceptions import ValidationError
 from django.conf import settings
+from django.core.exceptions import ValidationError
 from django.utils.translation import ugettext as _
-import pytz
 from six import text_type
 from xblock.fields import Scope
 
+from openedx.core.lib.teams_config import TeamsetType
 from openedx.features.course_experience import COURSE_ENABLE_UNENROLLED_ACCESS_FLAG
 from student.roles import GlobalStaff
-from openedx.core.lib.teams_config import TeamsetType
 from xblock_django.models import XBlockStudioConfigurationFlag
 from xmodule.modulestore.django import modulestore
 

--- a/cms/djangoapps/models/settings/waffle.py
+++ b/cms/djangoapps/models/settings/waffle.py
@@ -3,7 +3,6 @@ Togglable settings for Course Grading behavior
 """
 from openedx.core.djangoapps.waffle_utils import CourseWaffleFlag
 
-
 WAFFLE_NAMESPACE = 'grades'
 
 # edx/edx-platform feature

--- a/cms/djangoapps/xblock_config/apps.py
+++ b/cms/djangoapps/xblock_config/apps.py
@@ -13,7 +13,7 @@ class XBlockConfig(AppConfig):
     """
     Default configuration for the "xblock_config" Django application.
     """
-    name = u'xblock_config'
+    name = u'cms.djangoapps.xblock_config'
     verbose_name = u'XBlock Configuration'
 
     def ready(self):

--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -1354,19 +1354,19 @@ INSTALLED_APPS = [
     'openedx.core.djangoapps.video_pipeline',
 
     # For CMS
-    'contentstore.apps.ContentstoreConfig',
+    'cms.djangoapps.contentstore.apps.ContentstoreConfig',
 
     'openedx.core.djangoapps.contentserver',
-    'course_creators',
+    'cms.djangoapps.course_creators',
     'student.apps.StudentConfig',  # misleading name due to sharing with lms
     'openedx.core.djangoapps.course_groups',  # not used in cms (yet), but tests run
-    'xblock_config.apps.XBlockConfig',
+    'cms.djangoapps.xblock_config.apps.XBlockConfig',
 
     # New (Blockstore-based) XBlock runtime
     'openedx.core.djangoapps.xblock.apps.StudioXBlockAppConfig',
 
     # Maintenance tools
-    'maintenance',
+    'cms.djangoapps.maintenance',
     'openedx.core.djangoapps.util.apps.UtilConfig',
 
     # Tracking
@@ -1478,7 +1478,7 @@ INSTALLED_APPS = [
     'user_tasks',
 
     # CMS specific user task handling
-    'cms_user_tasks.apps.CmsUserTasksConfig',
+    'cms.djangoapps.cms_user_tasks.apps.CmsUserTasksConfig',
 
     # Unusual migrations
     'database_fixups',

--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -456,8 +456,11 @@ COURSES_ROOT = ENV_ROOT / "data"
 
 GITHUB_REPO_ROOT = ENV_ROOT / "data"
 
+# TODO: Is this next line necessary?
 sys.path.append(REPO_ROOT)
-sys.path.append(PROJECT_ROOT / 'djangoapps')
+# TODO: The next two path modifications will be removed in an upcoming Open edX release.
+# See docs/decisions/0007-sys-path-modification-removal.rst
+sys.path.append(REPO_ROOT / 'sys_path_hacks' / 'cms')
 sys.path.append(COMMON_ROOT / 'djangoapps')
 
 # For geolocation ip database

--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -1357,7 +1357,7 @@ INSTALLED_APPS = [
     'cms.djangoapps.contentstore.apps.ContentstoreConfig',
 
     'openedx.core.djangoapps.contentserver',
-    'cms.djangoapps.course_creators',
+    'cms.djangoapps.course_creators.apps.CourseCreatorsConfig',
     'student.apps.StudentConfig',  # misleading name due to sharing with lms
     'openedx.core.djangoapps.course_groups',  # not used in cms (yet), but tests run
     'cms.djangoapps.xblock_config.apps.XBlockConfig',
@@ -1366,7 +1366,7 @@ INSTALLED_APPS = [
     'openedx.core.djangoapps.xblock.apps.StudioXBlockAppConfig',
 
     # Maintenance tools
-    'cms.djangoapps.maintenance',
+    'cms.djangoapps.maintenance.apps.MaintenanceConfig',
     'openedx.core.djangoapps.util.apps.UtilConfig',
 
     # Tracking
@@ -1492,7 +1492,7 @@ INSTALLED_APPS = [
 
     # DRF filters
     'django_filters',
-    'cms.djangoapps.api',
+    'cms.djangoapps.api.apps.ApiConfig',
 
     # edx-drf-extensions
     'csrf.apps.CsrfAppConfig',  # Enables frontend apps to retrieve CSRF tokens.

--- a/cms/envs/production.py
+++ b/cms/envs/production.py
@@ -344,7 +344,7 @@ else:
 COURSE_IMPORT_EXPORT_BUCKET = ENV_TOKENS.get('COURSE_IMPORT_EXPORT_BUCKET', '')
 
 if COURSE_IMPORT_EXPORT_BUCKET:
-    COURSE_IMPORT_EXPORT_STORAGE = 'contentstore.storage.ImportExportS3Storage'
+    COURSE_IMPORT_EXPORT_STORAGE = 'cms.djangoapps.contentstore.storage.ImportExportS3Storage'
 else:
     COURSE_IMPORT_EXPORT_STORAGE = DEFAULT_FILE_STORAGE
 

--- a/cms/lib/xblock/tagging/test.py
+++ b/cms/lib/xblock/tagging/test.py
@@ -21,7 +21,7 @@ from cms.lib.xblock.tagging import StructuredTagsAside
 from cms.lib.xblock.tagging.models import TagAvailableValues, TagCategories
 from contentstore.tests.utils import AjaxEnabledTestClient
 from contentstore.utils import reverse_usage_url
-from contentstore.views.preview import get_preview_fragment
+from cms.djangoapps.contentstore.views.preview import get_preview_fragment
 from student.tests.factories import UserFactory
 from xblock_config.models import StudioConfig
 from xmodule.modulestore import ModuleStoreEnum

--- a/cms/templates/container.html
+++ b/cms/templates/container.html
@@ -11,7 +11,7 @@ else:
 <%!
 from django.utils.translation import ugettext as _
 
-from contentstore.views.helpers import xblock_studio_url, xblock_type_display_name
+from cms.djangoapps.contentstore.views.helpers import xblock_studio_url, xblock_type_display_name
 from openedx.core.djangolib.js_utils import (
     dump_js_escaped_json, js_escaped_string
 )

--- a/cms/templates/library.html
+++ b/cms/templates/library.html
@@ -4,7 +4,7 @@
     <% return "content_libraries" %>
 </%def>
 <%!
-from contentstore.views.helpers import xblock_studio_url, xblock_type_display_name
+from cms.djangoapps.contentstore.views.helpers import xblock_studio_url, xblock_type_display_name
 from django.utils.translation import ugettext as _
 from openedx.core.djangolib.js_utils import dump_js_escaped_json
 from openedx.core.djangolib.markup import HTML, Text

--- a/cms/templates/studio_xblock_wrapper.html
+++ b/cms/templates/studio_xblock_wrapper.html
@@ -1,7 +1,7 @@
 <%page expression_filter="h"/>
 <%!
 from django.utils.translation import ugettext as _
-from contentstore.views.helpers import xblock_studio_url
+from cms.djangoapps.contentstore.views.helpers import xblock_studio_url
 from contentstore.utils import is_visible_to_specific_partition_groups
 from lms.lib.utils import is_unit
 from openedx.core.djangolib.js_utils import (

--- a/cms/urls.py
+++ b/cms/urls.py
@@ -10,7 +10,7 @@ from django.utils.translation import ugettext_lazy as _
 from edx_api_doc_tools import make_docs_urls
 from ratelimitbackend import admin
 
-import contentstore.views
+from cms.djangoapps.contentstore import views as contentstore_views
 import openedx.core.djangoapps.common_views.xblock
 import openedx.core.djangoapps.debug.views
 import openedx.core.djangoapps.lang_pref.views
@@ -30,8 +30,8 @@ if password_policy_compliance.should_enforce_compliance_on_login():
 # Custom error pages
 # These are used by Django to render these error codes. Do not remove.
 # pylint: disable=invalid-name
-handler404 = contentstore.views.render_404
-handler500 = contentstore.views.render_500
+handler404 = contentstore_views.render_404
+handler500 = contentstore_views.render_500
 
 # Pattern to match a course key or a library key
 COURSELIKE_KEY_PATTERN = r'(?P<course_key_string>({}|{}))'.format(
@@ -44,25 +44,25 @@ LIBRARY_KEY_PATTERN = r'(?P<library_key_string>library-v1:[^/+]+\+[^/+]+)'
 urlpatterns = [
     url(r'', include('openedx.core.djangoapps.user_authn.urls_common')),
     url(r'', include('student.urls')),
-    url(r'^transcripts/upload$', contentstore.views.upload_transcripts, name='upload_transcripts'),
-    url(r'^transcripts/download$', contentstore.views.download_transcripts, name='download_transcripts'),
-    url(r'^transcripts/check$', contentstore.views.check_transcripts, name='check_transcripts'),
-    url(r'^transcripts/choose$', contentstore.views.choose_transcripts, name='choose_transcripts'),
-    url(r'^transcripts/replace$', contentstore.views.replace_transcripts, name='replace_transcripts'),
-    url(r'^transcripts/rename$', contentstore.views.rename_transcripts, name='rename_transcripts'),
+    url(r'^transcripts/upload$', contentstore_views.upload_transcripts, name='upload_transcripts'),
+    url(r'^transcripts/download$', contentstore_views.download_transcripts, name='download_transcripts'),
+    url(r'^transcripts/check$', contentstore_views.check_transcripts, name='check_transcripts'),
+    url(r'^transcripts/choose$', contentstore_views.choose_transcripts, name='choose_transcripts'),
+    url(r'^transcripts/replace$', contentstore_views.replace_transcripts, name='replace_transcripts'),
+    url(r'^transcripts/rename$', contentstore_views.rename_transcripts, name='rename_transcripts'),
     url(r'^preview/xblock/(?P<usage_key_string>.*?)/handler/(?P<handler>[^/]*)(?:/(?P<suffix>.*))?$',
-        contentstore.views.preview_handler, name='preview_handler'),
+        contentstore_views.preview_handler, name='preview_handler'),
     url(r'^xblock/(?P<usage_key_string>.*?)/handler/(?P<handler>[^/]*)(?:/(?P<suffix>.*))?$',
-        contentstore.views.component_handler, name='component_handler'),
+        contentstore_views.component_handler, name='component_handler'),
     url(r'^xblock/resource/(?P<block_type>[^/]*)/(?P<uri>.*)$',
         openedx.core.djangoapps.common_views.xblock.xblock_resource, name='xblock_resource_url'),
     url(r'', include('openedx.core.djangoapps.xblock.rest_api.urls', namespace='xblock_api')),
-    url(r'^not_found$', contentstore.views.not_found, name='not_found'),
-    url(r'^server_error$', contentstore.views.server_error, name='server_error'),
+    url(r'^not_found$', contentstore_views.not_found, name='not_found'),
+    url(r'^server_error$', contentstore_views.server_error, name='server_error'),
     url(r'^organizations$', OrganizationListView.as_view(), name='organizations'),
 
     # noop to squelch ajax errors
-    url(r'^event$', contentstore.views.event, name='event'),
+    url(r'^event$', contentstore_views.event, name='event'),
     url(r'^heartbeat', include('openedx.core.djangoapps.heartbeat.urls')),
     url(r'^i18n/', include('django.conf.urls.i18n')),
 
@@ -83,110 +83,110 @@ urlpatterns = [
     url(r'^api/', include('cms.djangoapps.api.urls', namespace='api')),
 
     # restful api
-    url(r'^$', contentstore.views.howitworks, name='homepage'),
-    url(r'^howitworks$', contentstore.views.howitworks, name='howitworks'),
-    url(r'^signin_redirect_to_lms$', contentstore.views.login_redirect_to_lms, name='login_redirect_to_lms'),
-    url(r'^request_course_creator$', contentstore.views.request_course_creator, name='request_course_creator'),
+    url(r'^$', contentstore_views.howitworks, name='homepage'),
+    url(r'^howitworks$', contentstore_views.howitworks, name='howitworks'),
+    url(r'^signin_redirect_to_lms$', contentstore_views.login_redirect_to_lms, name='login_redirect_to_lms'),
+    url(r'^request_course_creator$', contentstore_views.request_course_creator, name='request_course_creator'),
     url(r'^course_team/{}(?:/(?P<email>.+))?$'.format(COURSELIKE_KEY_PATTERN),
-        contentstore.views.course_team_handler, name='course_team_handler'),
-    url(r'^course_info/{}$'.format(settings.COURSE_KEY_PATTERN), contentstore.views.course_info_handler,
+        contentstore_views.course_team_handler, name='course_team_handler'),
+    url(r'^course_info/{}$'.format(settings.COURSE_KEY_PATTERN), contentstore_views.course_info_handler,
         name='course_info_handler'),
     url(r'^course_info_update/{}/(?P<provided_id>\d+)?$'.format(settings.COURSE_KEY_PATTERN),
-        contentstore.views.course_info_update_handler, name='course_info_update_handler'
+        contentstore_views.course_info_update_handler, name='course_info_update_handler'
         ),
-    url(r'^home/?$', contentstore.views.course_listing, name='home'),
+    url(r'^home/?$', contentstore_views.course_listing, name='home'),
     url(r'^course/{}/search_reindex?$'.format(settings.COURSE_KEY_PATTERN),
-        contentstore.views.course_search_index_handler,
+        contentstore_views.course_search_index_handler,
         name='course_search_index_handler'
         ),
-    url(r'^course/{}?$'.format(settings.COURSE_KEY_PATTERN), contentstore.views.course_handler, name='course_handler'),
+    url(r'^course/{}?$'.format(settings.COURSE_KEY_PATTERN), contentstore_views.course_handler, name='course_handler'),
 
     url(r'^checklists/{}?$'.format(settings.COURSE_KEY_PATTERN),
-        contentstore.views.checklists_handler,
+        contentstore_views.checklists_handler,
         name='checklists_handler'),
 
     url(r'^course_notifications/{}/(?P<action_state_id>\d+)?$'.format(settings.COURSE_KEY_PATTERN),
-        contentstore.views.course_notifications_handler,
+        contentstore_views.course_notifications_handler,
         name='course_notifications_handler'),
-    url(r'^course_rerun/{}$'.format(settings.COURSE_KEY_PATTERN), contentstore.views.course_rerun_handler,
+    url(r'^course_rerun/{}$'.format(settings.COURSE_KEY_PATTERN), contentstore_views.course_rerun_handler,
         name='course_rerun_handler'),
-    url(r'^container/{}$'.format(settings.USAGE_KEY_PATTERN), contentstore.views.container_handler,
+    url(r'^container/{}$'.format(settings.USAGE_KEY_PATTERN), contentstore_views.container_handler,
         name='container_handler'),
-    url(r'^orphan/{}$'.format(settings.COURSE_KEY_PATTERN), contentstore.views.orphan_handler,
+    url(r'^orphan/{}$'.format(settings.COURSE_KEY_PATTERN), contentstore_views.orphan_handler,
         name='orphan_handler'),
     url(r'^assets/{}/{}?$'.format(settings.COURSE_KEY_PATTERN, settings.ASSET_KEY_PATTERN),
-        contentstore.views.assets_handler,
+        contentstore_views.assets_handler,
         name='assets_handler'),
-    url(r'^import/{}$'.format(COURSELIKE_KEY_PATTERN), contentstore.views.import_handler,
+    url(r'^import/{}$'.format(COURSELIKE_KEY_PATTERN), contentstore_views.import_handler,
         name='import_handler'),
     url(r'^import_status/{}/(?P<filename>.+)$'.format(COURSELIKE_KEY_PATTERN),
-        contentstore.views.import_status_handler, name='import_status_handler'),
+        contentstore_views.import_status_handler, name='import_status_handler'),
     # rest api for course import/export
     url(r'^api/courses/',
         include('cms.djangoapps.contentstore.api.urls', namespace='courses_api')
         ),
-    url(r'^export/{}$'.format(COURSELIKE_KEY_PATTERN), contentstore.views.export_handler,
+    url(r'^export/{}$'.format(COURSELIKE_KEY_PATTERN), contentstore_views.export_handler,
         name='export_handler'),
-    url(r'^export_output/{}$'.format(COURSELIKE_KEY_PATTERN), contentstore.views.export_output_handler,
+    url(r'^export_output/{}$'.format(COURSELIKE_KEY_PATTERN), contentstore_views.export_output_handler,
         name='export_output_handler'),
-    url(r'^export_status/{}$'.format(COURSELIKE_KEY_PATTERN), contentstore.views.export_status_handler,
+    url(r'^export_status/{}$'.format(COURSELIKE_KEY_PATTERN), contentstore_views.export_status_handler,
         name='export_status_handler'),
-    url(r'^xblock/outline/{}$'.format(settings.USAGE_KEY_PATTERN), contentstore.views.xblock_outline_handler,
+    url(r'^xblock/outline/{}$'.format(settings.USAGE_KEY_PATTERN), contentstore_views.xblock_outline_handler,
         name='xblock_outline_handler'),
-    url(r'^xblock/container/{}$'.format(settings.USAGE_KEY_PATTERN), contentstore.views.xblock_container_handler,
+    url(r'^xblock/container/{}$'.format(settings.USAGE_KEY_PATTERN), contentstore_views.xblock_container_handler,
         name='xblock_container_handler'),
-    url(r'^xblock/{}/(?P<view_name>[^/]+)$'.format(settings.USAGE_KEY_PATTERN), contentstore.views.xblock_view_handler,
+    url(r'^xblock/{}/(?P<view_name>[^/]+)$'.format(settings.USAGE_KEY_PATTERN), contentstore_views.xblock_view_handler,
         name='xblock_view_handler'),
-    url(r'^xblock/{}?$'.format(settings.USAGE_KEY_PATTERN), contentstore.views.xblock_handler,
+    url(r'^xblock/{}?$'.format(settings.USAGE_KEY_PATTERN), contentstore_views.xblock_handler,
         name='xblock_handler'),
-    url(r'^tabs/{}$'.format(settings.COURSE_KEY_PATTERN), contentstore.views.tabs_handler,
+    url(r'^tabs/{}$'.format(settings.COURSE_KEY_PATTERN), contentstore_views.tabs_handler,
         name='tabs_handler'),
-    url(r'^settings/details/{}$'.format(settings.COURSE_KEY_PATTERN), contentstore.views.settings_handler,
+    url(r'^settings/details/{}$'.format(settings.COURSE_KEY_PATTERN), contentstore_views.settings_handler,
         name='settings_handler'),
     url(r'^settings/grading/{}(/)?(?P<grader_index>\d+)?$'.format(settings.COURSE_KEY_PATTERN),
-        contentstore.views.grading_handler, name='grading_handler'),
-    url(r'^settings/advanced/{}$'.format(settings.COURSE_KEY_PATTERN), contentstore.views.advanced_settings_handler,
+        contentstore_views.grading_handler, name='grading_handler'),
+    url(r'^settings/advanced/{}$'.format(settings.COURSE_KEY_PATTERN), contentstore_views.advanced_settings_handler,
         name='advanced_settings_handler'),
-    url(r'^textbooks/{}$'.format(settings.COURSE_KEY_PATTERN), contentstore.views.textbooks_list_handler,
+    url(r'^textbooks/{}$'.format(settings.COURSE_KEY_PATTERN), contentstore_views.textbooks_list_handler,
         name='textbooks_list_handler'),
     url(r'^textbooks/{}/(?P<textbook_id>\d[^/]*)$'.format(settings.COURSE_KEY_PATTERN),
-        contentstore.views.textbooks_detail_handler, name='textbooks_detail_handler'),
+        contentstore_views.textbooks_detail_handler, name='textbooks_detail_handler'),
     url(r'^videos/{}(?:/(?P<edx_video_id>[-\w]+))?$'.format(settings.COURSE_KEY_PATTERN),
-        contentstore.views.videos_handler, name='videos_handler'),
+        contentstore_views.videos_handler, name='videos_handler'),
     url(r'^video_images/{}(?:/(?P<edx_video_id>[-\w]+))?$'.format(settings.COURSE_KEY_PATTERN),
-        contentstore.views.video_images_handler, name='video_images_handler'),
+        contentstore_views.video_images_handler, name='video_images_handler'),
     url(r'^transcript_preferences/{}$'.format(settings.COURSE_KEY_PATTERN),
-        contentstore.views.transcript_preferences_handler, name='transcript_preferences_handler'),
+        contentstore_views.transcript_preferences_handler, name='transcript_preferences_handler'),
     url(r'^transcript_credentials/{}$'.format(settings.COURSE_KEY_PATTERN),
-        contentstore.views.transcript_credentials_handler, name='transcript_credentials_handler'),
-    url(r'^transcript_download/$', contentstore.views.transcript_download_handler, name='transcript_download_handler'),
-    url(r'^transcript_upload/$', contentstore.views.transcript_upload_handler, name='transcript_upload_handler'),
+        contentstore_views.transcript_credentials_handler, name='transcript_credentials_handler'),
+    url(r'^transcript_download/$', contentstore_views.transcript_download_handler, name='transcript_download_handler'),
+    url(r'^transcript_upload/$', contentstore_views.transcript_upload_handler, name='transcript_upload_handler'),
     url(r'^transcript_delete/{}(?:/(?P<edx_video_id>[-\w]+))?(?:/(?P<language_code>[^/]*))?$'.format(
         settings.COURSE_KEY_PATTERN
-    ), contentstore.views.transcript_delete_handler, name='transcript_delete_handler'),
+    ), contentstore_views.transcript_delete_handler, name='transcript_delete_handler'),
     url(r'^video_encodings_download/{}$'.format(settings.COURSE_KEY_PATTERN),
-        contentstore.views.video_encodings_download, name='video_encodings_download'),
+        contentstore_views.video_encodings_download, name='video_encodings_download'),
     url(r'^group_configurations/{}$'.format(settings.COURSE_KEY_PATTERN),
-        contentstore.views.group_configurations_list_handler,
+        contentstore_views.group_configurations_list_handler,
         name='group_configurations_list_handler'),
     url(r'^group_configurations/{}/(?P<group_configuration_id>\d+)(/)?(?P<group_id>\d+)?$'.format(
-        settings.COURSE_KEY_PATTERN), contentstore.views.group_configurations_detail_handler,
+        settings.COURSE_KEY_PATTERN), contentstore_views.group_configurations_detail_handler,
         name='group_configurations_detail_handler'),
     url(r'^api/val/v0/', include('edxval.urls')),
     url(r'^api/tasks/v0/', include('user_tasks.urls')),
-    url(r'^accessibility$', contentstore.views.accessibility, name='accessibility'),
+    url(r'^accessibility$', contentstore_views.accessibility, name='accessibility'),
 ]
 
 if not settings.DISABLE_DEPRECATED_SIGNIN_URL:
     # TODO: Remove deprecated signin url when traffic proves it is no longer in use
     urlpatterns += [
-        url(r'^signin$', contentstore.views.login_redirect_to_lms),
+        url(r'^signin$', contentstore_views.login_redirect_to_lms),
     ]
 
 if not settings.DISABLE_DEPRECATED_SIGNUP_URL:
     # TODO: Remove deprecated signup url when traffic proves it is no longer in use
     urlpatterns += [
-        url(r'^signup$', contentstore.views.register_redirect_to_lms, name='register_redirect_to_lms'),
+        url(r'^signup$', contentstore_views.register_redirect_to_lms, name='register_redirect_to_lms'),
     ]
 
 JS_INFO_DICT = {
@@ -198,15 +198,15 @@ JS_INFO_DICT = {
 if settings.FEATURES.get('ENABLE_CONTENT_LIBRARIES'):
     urlpatterns += [
         url(r'^library/{}?$'.format(LIBRARY_KEY_PATTERN),
-            contentstore.views.library_handler, name='library_handler'),
+            contentstore_views.library_handler, name='library_handler'),
         url(r'^library/{}/team/$'.format(LIBRARY_KEY_PATTERN),
-            contentstore.views.manage_library_users, name='manage_library_users'),
+            contentstore_views.manage_library_users, name='manage_library_users'),
     ]
 
 if settings.FEATURES.get('ENABLE_EXPORT_GIT'):
     urlpatterns += [
         url(r'^export_git/{}$'.format(settings.COURSE_KEY_PATTERN),
-            contentstore.views.export_git,
+            contentstore_views.export_git,
             name='export_git')
     ]
 
@@ -223,11 +223,11 @@ urlpatterns.append(url(r'^admin/', admin.site.urls))
 # enable entrance exams
 if settings.FEATURES.get('ENTRANCE_EXAMS'):
     urlpatterns.append(url(r'^course/{}/entrance_exam/?$'.format(settings.COURSE_KEY_PATTERN),
-                       contentstore.views.entrance_exam))
+                       contentstore_views.entrance_exam))
 
 # Enable Web/HTML Certificates
 if settings.FEATURES.get('CERTIFICATES_HTML_VIEW'):
-    from contentstore.views.certificates import (
+    from cms.djangoapps.contentstore.views.certificates import (
         certificate_activation_handler,
         signatory_detail_handler,
         certificates_detail_handler,

--- a/cms/urls_dev.py
+++ b/cms/urls_dev.py
@@ -7,7 +7,7 @@ development mode; otherwise, it is ignored.
 
 from django.conf.urls import url
 
-from contentstore.views.dev import dev_mode
+from cms.djangoapps.contentstore.views.dev import dev_mode
 
 urlpatterns = [
     url(r'^dev_mode$', dev_mode, name='dev_mode'),

--- a/docs/decisions/0007-sys-path-modification-removal.rst
+++ b/docs/decisions/0007-sys-path-modification-removal.rst
@@ -26,9 +26,9 @@ This deprecation will take place in the following steps:
 
 1. Add a new folder (``sys_path_hacks``) to isolate the code used for deprecation warnings.
 
-2. For every module importable using the ``sys.path`` style (for instance, ``courseware``), duplicate that module structure into the ``sys_path_hacks/lms`` (or ``sys_path_hacks/studio``) directory. Each file in that directory should do a wild-card import of the corresponding ``lms.djangoapps.`` module, and should log a warning indicating where it was imported from. For example, in ``sys_path_hacks/lms/courseware/views/views.py``, it will wild-card import ``from lms.djangoapps.courseware.views.views import *``. The ``sys_path_hacks/clean.sh`` script will generate these files.
+2. For every module importable using the ``sys.path`` style (for instance, ``courseware``), duplicate that module structure into the corresponding ``sys_path_hacks/[lms|cms|common]/`` directory. Each file in that directory should do a wild-card import of the corresponding ``[lms|cms|common].djangoapps.`` module, and should log a warning indicating where it was imported from. For example, in ``sys_path_hacks/lms/courseware/views/views.py``, it will wild-card import ``from lms.djangoapps.courseware.views.views import *``. The ``sys_path_hacks/un_sys_path.sh`` script will generate these files.
 
-3. The ``sys.path`` modification will be changed to point to ``sys_path_hacks/lms``, rather than ``lms/djangoapps``. At this point, any code that references the modules directly will trigger warnings with logging about where the imports were coming from (to drive future cleanup efforts). The warnings will be instances of ``SysPathHackWarning`` (subclass of ``DeprecationWarning``).
+3. The ``sys.path`` modifications will be changed to point to ``sys_path_hacks/[lms|cms|common]/``, rather than ``[lms|cms|common]/djangoapps``. At this point, any code that references the modules directly will trigger warnings with logging about where the imports were coming from (to drive future cleanup efforts). The warnings will be instances of ``SysPathHackWarning`` (subclass of ``DeprecationWarning``).
 
 4. Fix all instances where the ``sys.path``-based modules were ``patch``-ed in unit tests, as those patches no longer work.
 

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -714,8 +714,10 @@ NODE_MODULES_ROOT = REPO_ROOT / "node_modules"
 
 DATA_DIR = COURSES_ROOT
 
-# TODO: Remove the rest of the sys.path modification here and in cms/envs/common.py
+# TODO: Is this next line necessary?
 sys.path.append(REPO_ROOT)
+# TODO: The next two path modifications will be removed in an upcoming Open edX release.
+# See docs/decisions/0007-sys-path-modification-removal.rst
 sys.path.append(REPO_ROOT / 'sys_path_hacks' / 'lms')
 sys.path.append(COMMON_ROOT / 'djangoapps')
 

--- a/pylintrc
+++ b/pylintrc
@@ -71,7 +71,7 @@
 ignore = ,.git,.tox,migrations,node_modules,.pycharm_helpers
 persistent = yes
 load-plugins = edx_lint.pylint,pylint_django,pylint_celery
-init-hook = "import sys; sys.path.extend(['sys_path_hacks/lms', 'cms/djangoapps', 'common/djangoapps'])"
+init-hook = "import sys; sys.path.extend(['sys_path_hacks/lms', 'sys_path_hacks/cms', 'common/djangoapps'])"
 
 [MESSAGES CONTROL]
 enable = 
@@ -464,4 +464,4 @@ int-import-graph =
 [EXCEPTIONS]
 overgeneral-exceptions = Exception
 
-# 7bfb536a0940715cbd9013a31f37e8c2fc09f16c
+# 24f667b6b38051d9f018f83fa71e9cc9a06fe9d0

--- a/pylintrc_tweaks
+++ b/pylintrc_tweaks
@@ -1,7 +1,7 @@
 # pylintrc tweaks for use with edx_lint.
 [MASTER]
 ignore+ = ,.git,.tox,migrations,node_modules,.pycharm_helpers
-init-hook="import sys; sys.path.extend(['sys_path_hacks/lms', 'cms/djangoapps', 'common/djangoapps'])"
+init-hook="import sys; sys.path.extend(['sys_path_hacks/lms', 'sys_path_hacks/cms', 'common/djangoapps'])"
 
 [MESSAGES CONTROL]
 disable+ =

--- a/sys_path_hacks/cms/api/__init__.py
+++ b/sys_path_hacks/cms/api/__init__.py
@@ -1,0 +1,5 @@
+from sys_path_hacks.warn import warn_deprecated_import
+
+warn_deprecated_import('cms.djangoapps', 'api')
+
+from cms.djangoapps.api import *

--- a/sys_path_hacks/cms/api/apps.py
+++ b/sys_path_hacks/cms/api/apps.py
@@ -1,0 +1,5 @@
+from sys_path_hacks.warn import warn_deprecated_import
+
+warn_deprecated_import('cms.djangoapps', 'api.apps')
+
+from cms.djangoapps.api.apps import *

--- a/sys_path_hacks/cms/api/urls.py
+++ b/sys_path_hacks/cms/api/urls.py
@@ -1,0 +1,5 @@
+from sys_path_hacks.warn import warn_deprecated_import
+
+warn_deprecated_import('cms.djangoapps', 'api.urls')
+
+from cms.djangoapps.api.urls import *

--- a/sys_path_hacks/cms/api/v1/__init__.py
+++ b/sys_path_hacks/cms/api/v1/__init__.py
@@ -1,0 +1,5 @@
+from sys_path_hacks.warn import warn_deprecated_import
+
+warn_deprecated_import('cms.djangoapps', 'api.v1')
+
+from cms.djangoapps.api.v1 import *

--- a/sys_path_hacks/cms/api/v1/serializers/__init__.py
+++ b/sys_path_hacks/cms/api/v1/serializers/__init__.py
@@ -1,0 +1,5 @@
+from sys_path_hacks.warn import warn_deprecated_import
+
+warn_deprecated_import('cms.djangoapps', 'api.v1.serializers')
+
+from cms.djangoapps.api.v1.serializers import *

--- a/sys_path_hacks/cms/api/v1/serializers/course_runs.py
+++ b/sys_path_hacks/cms/api/v1/serializers/course_runs.py
@@ -1,0 +1,5 @@
+from sys_path_hacks.warn import warn_deprecated_import
+
+warn_deprecated_import('cms.djangoapps', 'api.v1.serializers.course_runs')
+
+from cms.djangoapps.api.v1.serializers.course_runs import *

--- a/sys_path_hacks/cms/api/v1/tests/__init__.py
+++ b/sys_path_hacks/cms/api/v1/tests/__init__.py
@@ -1,0 +1,5 @@
+from sys_path_hacks.warn import warn_deprecated_import
+
+warn_deprecated_import('cms.djangoapps', 'api.v1.tests')
+
+from cms.djangoapps.api.v1.tests import *

--- a/sys_path_hacks/cms/api/v1/tests/test_serializers/__init__.py
+++ b/sys_path_hacks/cms/api/v1/tests/test_serializers/__init__.py
@@ -1,0 +1,5 @@
+from sys_path_hacks.warn import warn_deprecated_import
+
+warn_deprecated_import('cms.djangoapps', 'api.v1.tests.test_serializers')
+
+from cms.djangoapps.api.v1.tests.test_serializers import *

--- a/sys_path_hacks/cms/api/v1/tests/test_serializers/test_course_runs.py
+++ b/sys_path_hacks/cms/api/v1/tests/test_serializers/test_course_runs.py
@@ -1,0 +1,5 @@
+from sys_path_hacks.warn import warn_deprecated_import
+
+warn_deprecated_import('cms.djangoapps', 'api.v1.tests.test_serializers.test_course_runs')
+
+from cms.djangoapps.api.v1.tests.test_serializers.test_course_runs import *

--- a/sys_path_hacks/cms/api/v1/tests/test_views/__init__.py
+++ b/sys_path_hacks/cms/api/v1/tests/test_views/__init__.py
@@ -1,0 +1,5 @@
+from sys_path_hacks.warn import warn_deprecated_import
+
+warn_deprecated_import('cms.djangoapps', 'api.v1.tests.test_views')
+
+from cms.djangoapps.api.v1.tests.test_views import *

--- a/sys_path_hacks/cms/api/v1/tests/test_views/test_course_runs.py
+++ b/sys_path_hacks/cms/api/v1/tests/test_views/test_course_runs.py
@@ -1,0 +1,5 @@
+from sys_path_hacks.warn import warn_deprecated_import
+
+warn_deprecated_import('cms.djangoapps', 'api.v1.tests.test_views.test_course_runs')
+
+from cms.djangoapps.api.v1.tests.test_views.test_course_runs import *

--- a/sys_path_hacks/cms/api/v1/tests/utils.py
+++ b/sys_path_hacks/cms/api/v1/tests/utils.py
@@ -1,0 +1,5 @@
+from sys_path_hacks.warn import warn_deprecated_import
+
+warn_deprecated_import('cms.djangoapps', 'api.v1.tests.utils')
+
+from cms.djangoapps.api.v1.tests.utils import *

--- a/sys_path_hacks/cms/api/v1/urls.py
+++ b/sys_path_hacks/cms/api/v1/urls.py
@@ -1,0 +1,5 @@
+from sys_path_hacks.warn import warn_deprecated_import
+
+warn_deprecated_import('cms.djangoapps', 'api.v1.urls')
+
+from cms.djangoapps.api.v1.urls import *

--- a/sys_path_hacks/cms/api/v1/views/__init__.py
+++ b/sys_path_hacks/cms/api/v1/views/__init__.py
@@ -1,0 +1,5 @@
+from sys_path_hacks.warn import warn_deprecated_import
+
+warn_deprecated_import('cms.djangoapps', 'api.v1.views')
+
+from cms.djangoapps.api.v1.views import *

--- a/sys_path_hacks/cms/api/v1/views/course_runs.py
+++ b/sys_path_hacks/cms/api/v1/views/course_runs.py
@@ -1,0 +1,5 @@
+from sys_path_hacks.warn import warn_deprecated_import
+
+warn_deprecated_import('cms.djangoapps', 'api.v1.views.course_runs')
+
+from cms.djangoapps.api.v1.views.course_runs import *

--- a/sys_path_hacks/cms/cms_user_tasks/__init__.py
+++ b/sys_path_hacks/cms/cms_user_tasks/__init__.py
@@ -1,0 +1,5 @@
+from sys_path_hacks.warn import warn_deprecated_import
+
+warn_deprecated_import('cms.djangoapps', 'cms_user_tasks')
+
+from cms.djangoapps.cms_user_tasks import *

--- a/sys_path_hacks/cms/cms_user_tasks/apps.py
+++ b/sys_path_hacks/cms/cms_user_tasks/apps.py
@@ -1,0 +1,5 @@
+from sys_path_hacks.warn import warn_deprecated_import
+
+warn_deprecated_import('cms.djangoapps', 'cms_user_tasks.apps')
+
+from cms.djangoapps.cms_user_tasks.apps import *

--- a/sys_path_hacks/cms/cms_user_tasks/signals.py
+++ b/sys_path_hacks/cms/cms_user_tasks/signals.py
@@ -1,0 +1,5 @@
+from sys_path_hacks.warn import warn_deprecated_import
+
+warn_deprecated_import('cms.djangoapps', 'cms_user_tasks.signals')
+
+from cms.djangoapps.cms_user_tasks.signals import *

--- a/sys_path_hacks/cms/cms_user_tasks/tasks.py
+++ b/sys_path_hacks/cms/cms_user_tasks/tasks.py
@@ -1,0 +1,5 @@
+from sys_path_hacks.warn import warn_deprecated_import
+
+warn_deprecated_import('cms.djangoapps', 'cms_user_tasks.tasks')
+
+from cms.djangoapps.cms_user_tasks.tasks import *

--- a/sys_path_hacks/cms/cms_user_tasks/tests.py
+++ b/sys_path_hacks/cms/cms_user_tasks/tests.py
@@ -1,0 +1,5 @@
+from sys_path_hacks.warn import warn_deprecated_import
+
+warn_deprecated_import('cms.djangoapps', 'cms_user_tasks.tests')
+
+from cms.djangoapps.cms_user_tasks.tests import *

--- a/sys_path_hacks/cms/contentstore/__init__.py
+++ b/sys_path_hacks/cms/contentstore/__init__.py
@@ -1,0 +1,5 @@
+from sys_path_hacks.warn import warn_deprecated_import
+
+warn_deprecated_import('cms.djangoapps', 'contentstore')
+
+from cms.djangoapps.contentstore import *

--- a/sys_path_hacks/cms/contentstore/admin.py
+++ b/sys_path_hacks/cms/contentstore/admin.py
@@ -1,0 +1,5 @@
+from sys_path_hacks.warn import warn_deprecated_import
+
+warn_deprecated_import('cms.djangoapps', 'contentstore.admin')
+
+from cms.djangoapps.contentstore.admin import *

--- a/sys_path_hacks/cms/contentstore/api/__init__.py
+++ b/sys_path_hacks/cms/contentstore/api/__init__.py
@@ -1,0 +1,5 @@
+from sys_path_hacks.warn import warn_deprecated_import
+
+warn_deprecated_import('cms.djangoapps', 'contentstore.api')
+
+from cms.djangoapps.contentstore.api import *

--- a/sys_path_hacks/cms/contentstore/api/tests/__init__.py
+++ b/sys_path_hacks/cms/contentstore/api/tests/__init__.py
@@ -1,0 +1,5 @@
+from sys_path_hacks.warn import warn_deprecated_import
+
+warn_deprecated_import('cms.djangoapps', 'contentstore.api.tests')
+
+from cms.djangoapps.contentstore.api.tests import *

--- a/sys_path_hacks/cms/contentstore/api/tests/base.py
+++ b/sys_path_hacks/cms/contentstore/api/tests/base.py
@@ -1,0 +1,5 @@
+from sys_path_hacks.warn import warn_deprecated_import
+
+warn_deprecated_import('cms.djangoapps', 'contentstore.api.tests.base')
+
+from cms.djangoapps.contentstore.api.tests.base import *

--- a/sys_path_hacks/cms/contentstore/api/tests/test_import.py
+++ b/sys_path_hacks/cms/contentstore/api/tests/test_import.py
@@ -1,0 +1,5 @@
+from sys_path_hacks.warn import warn_deprecated_import
+
+warn_deprecated_import('cms.djangoapps', 'contentstore.api.tests.test_import')
+
+from cms.djangoapps.contentstore.api.tests.test_import import *

--- a/sys_path_hacks/cms/contentstore/api/tests/test_quality.py
+++ b/sys_path_hacks/cms/contentstore/api/tests/test_quality.py
@@ -1,0 +1,5 @@
+from sys_path_hacks.warn import warn_deprecated_import
+
+warn_deprecated_import('cms.djangoapps', 'contentstore.api.tests.test_quality')
+
+from cms.djangoapps.contentstore.api.tests.test_quality import *

--- a/sys_path_hacks/cms/contentstore/api/tests/test_validation.py
+++ b/sys_path_hacks/cms/contentstore/api/tests/test_validation.py
@@ -1,0 +1,5 @@
+from sys_path_hacks.warn import warn_deprecated_import
+
+warn_deprecated_import('cms.djangoapps', 'contentstore.api.tests.test_validation')
+
+from cms.djangoapps.contentstore.api.tests.test_validation import *

--- a/sys_path_hacks/cms/contentstore/api/urls.py
+++ b/sys_path_hacks/cms/contentstore/api/urls.py
@@ -1,0 +1,5 @@
+from sys_path_hacks.warn import warn_deprecated_import
+
+warn_deprecated_import('cms.djangoapps', 'contentstore.api.urls')
+
+from cms.djangoapps.contentstore.api.urls import *

--- a/sys_path_hacks/cms/contentstore/api/views/__init__.py
+++ b/sys_path_hacks/cms/contentstore/api/views/__init__.py
@@ -1,0 +1,5 @@
+from sys_path_hacks.warn import warn_deprecated_import
+
+warn_deprecated_import('cms.djangoapps', 'contentstore.api.views')
+
+from cms.djangoapps.contentstore.api.views import *

--- a/sys_path_hacks/cms/contentstore/api/views/course_import.py
+++ b/sys_path_hacks/cms/contentstore/api/views/course_import.py
@@ -1,0 +1,5 @@
+from sys_path_hacks.warn import warn_deprecated_import
+
+warn_deprecated_import('cms.djangoapps', 'contentstore.api.views.course_import')
+
+from cms.djangoapps.contentstore.api.views.course_import import *

--- a/sys_path_hacks/cms/contentstore/api/views/course_quality.py
+++ b/sys_path_hacks/cms/contentstore/api/views/course_quality.py
@@ -1,0 +1,5 @@
+from sys_path_hacks.warn import warn_deprecated_import
+
+warn_deprecated_import('cms.djangoapps', 'contentstore.api.views.course_quality')
+
+from cms.djangoapps.contentstore.api.views.course_quality import *

--- a/sys_path_hacks/cms/contentstore/api/views/course_validation.py
+++ b/sys_path_hacks/cms/contentstore/api/views/course_validation.py
@@ -1,0 +1,5 @@
+from sys_path_hacks.warn import warn_deprecated_import
+
+warn_deprecated_import('cms.djangoapps', 'contentstore.api.views.course_validation')
+
+from cms.djangoapps.contentstore.api.views.course_validation import *

--- a/sys_path_hacks/cms/contentstore/api/views/utils.py
+++ b/sys_path_hacks/cms/contentstore/api/views/utils.py
@@ -1,0 +1,5 @@
+from sys_path_hacks.warn import warn_deprecated_import
+
+warn_deprecated_import('cms.djangoapps', 'contentstore.api.views.utils')
+
+from cms.djangoapps.contentstore.api.views.utils import *

--- a/sys_path_hacks/cms/contentstore/apps.py
+++ b/sys_path_hacks/cms/contentstore/apps.py
@@ -1,0 +1,5 @@
+from sys_path_hacks.warn import warn_deprecated_import
+
+warn_deprecated_import('cms.djangoapps', 'contentstore.apps')
+
+from cms.djangoapps.contentstore.apps import *

--- a/sys_path_hacks/cms/contentstore/config/__init__.py
+++ b/sys_path_hacks/cms/contentstore/config/__init__.py
@@ -1,0 +1,5 @@
+from sys_path_hacks.warn import warn_deprecated_import
+
+warn_deprecated_import('cms.djangoapps', 'contentstore.config')
+
+from cms.djangoapps.contentstore.config import *

--- a/sys_path_hacks/cms/contentstore/config/tests/__init__.py
+++ b/sys_path_hacks/cms/contentstore/config/tests/__init__.py
@@ -1,0 +1,5 @@
+from sys_path_hacks.warn import warn_deprecated_import
+
+warn_deprecated_import('cms.djangoapps', 'contentstore.config.tests')
+
+from cms.djangoapps.contentstore.config.tests import *

--- a/sys_path_hacks/cms/contentstore/config/waffle.py
+++ b/sys_path_hacks/cms/contentstore/config/waffle.py
@@ -1,0 +1,5 @@
+from sys_path_hacks.warn import warn_deprecated_import
+
+warn_deprecated_import('cms.djangoapps', 'contentstore.config.waffle')
+
+from cms.djangoapps.contentstore.config.waffle import *

--- a/sys_path_hacks/cms/contentstore/config/waffle_utils.py
+++ b/sys_path_hacks/cms/contentstore/config/waffle_utils.py
@@ -1,0 +1,5 @@
+from sys_path_hacks.warn import warn_deprecated_import
+
+warn_deprecated_import('cms.djangoapps', 'contentstore.config.waffle_utils')
+
+from cms.djangoapps.contentstore.config.waffle_utils import *

--- a/sys_path_hacks/cms/contentstore/course_group_config.py
+++ b/sys_path_hacks/cms/contentstore/course_group_config.py
@@ -1,0 +1,5 @@
+from sys_path_hacks.warn import warn_deprecated_import
+
+warn_deprecated_import('cms.djangoapps', 'contentstore.course_group_config')
+
+from cms.djangoapps.contentstore.course_group_config import *

--- a/sys_path_hacks/cms/contentstore/course_info_model.py
+++ b/sys_path_hacks/cms/contentstore/course_info_model.py
@@ -1,0 +1,5 @@
+from sys_path_hacks.warn import warn_deprecated_import
+
+warn_deprecated_import('cms.djangoapps', 'contentstore.course_info_model')
+
+from cms.djangoapps.contentstore.course_info_model import *

--- a/sys_path_hacks/cms/contentstore/courseware_index.py
+++ b/sys_path_hacks/cms/contentstore/courseware_index.py
@@ -1,0 +1,5 @@
+from sys_path_hacks.warn import warn_deprecated_import
+
+warn_deprecated_import('cms.djangoapps', 'contentstore.courseware_index')
+
+from cms.djangoapps.contentstore.courseware_index import *

--- a/sys_path_hacks/cms/contentstore/debug_file_uploader.py
+++ b/sys_path_hacks/cms/contentstore/debug_file_uploader.py
@@ -1,0 +1,5 @@
+from sys_path_hacks.warn import warn_deprecated_import
+
+warn_deprecated_import('cms.djangoapps', 'contentstore.debug_file_uploader')
+
+from cms.djangoapps.contentstore.debug_file_uploader import *

--- a/sys_path_hacks/cms/contentstore/git_export_utils.py
+++ b/sys_path_hacks/cms/contentstore/git_export_utils.py
@@ -1,0 +1,5 @@
+from sys_path_hacks.warn import warn_deprecated_import
+
+warn_deprecated_import('cms.djangoapps', 'contentstore.git_export_utils')
+
+from cms.djangoapps.contentstore.git_export_utils import *

--- a/sys_path_hacks/cms/contentstore/management/__init__.py
+++ b/sys_path_hacks/cms/contentstore/management/__init__.py
@@ -1,0 +1,5 @@
+from sys_path_hacks.warn import warn_deprecated_import
+
+warn_deprecated_import('cms.djangoapps', 'contentstore.management')
+
+from cms.djangoapps.contentstore.management import *

--- a/sys_path_hacks/cms/contentstore/management/commands/__init__.py
+++ b/sys_path_hacks/cms/contentstore/management/commands/__init__.py
@@ -1,0 +1,5 @@
+from sys_path_hacks.warn import warn_deprecated_import
+
+warn_deprecated_import('cms.djangoapps', 'contentstore.management.commands')
+
+from cms.djangoapps.contentstore.management.commands import *

--- a/sys_path_hacks/cms/contentstore/management/commands/clean_cert_name.py
+++ b/sys_path_hacks/cms/contentstore/management/commands/clean_cert_name.py
@@ -1,0 +1,5 @@
+from sys_path_hacks.warn import warn_deprecated_import
+
+warn_deprecated_import('cms.djangoapps', 'contentstore.management.commands.clean_cert_name')
+
+from cms.djangoapps.contentstore.management.commands.clean_cert_name import *

--- a/sys_path_hacks/cms/contentstore/management/commands/cleanup_assets.py
+++ b/sys_path_hacks/cms/contentstore/management/commands/cleanup_assets.py
@@ -1,0 +1,5 @@
+from sys_path_hacks.warn import warn_deprecated_import
+
+warn_deprecated_import('cms.djangoapps', 'contentstore.management.commands.cleanup_assets')
+
+from cms.djangoapps.contentstore.management.commands.cleanup_assets import *

--- a/sys_path_hacks/cms/contentstore/management/commands/create_course.py
+++ b/sys_path_hacks/cms/contentstore/management/commands/create_course.py
@@ -1,0 +1,5 @@
+from sys_path_hacks.warn import warn_deprecated_import
+
+warn_deprecated_import('cms.djangoapps', 'contentstore.management.commands.create_course')
+
+from cms.djangoapps.contentstore.management.commands.create_course import *

--- a/sys_path_hacks/cms/contentstore/management/commands/delete_course.py
+++ b/sys_path_hacks/cms/contentstore/management/commands/delete_course.py
@@ -1,0 +1,5 @@
+from sys_path_hacks.warn import warn_deprecated_import
+
+warn_deprecated_import('cms.djangoapps', 'contentstore.management.commands.delete_course')
+
+from cms.djangoapps.contentstore.management.commands.delete_course import *

--- a/sys_path_hacks/cms/contentstore/management/commands/delete_orphans.py
+++ b/sys_path_hacks/cms/contentstore/management/commands/delete_orphans.py
@@ -1,0 +1,5 @@
+from sys_path_hacks.warn import warn_deprecated_import
+
+warn_deprecated_import('cms.djangoapps', 'contentstore.management.commands.delete_orphans')
+
+from cms.djangoapps.contentstore.management.commands.delete_orphans import *

--- a/sys_path_hacks/cms/contentstore/management/commands/edit_course_tabs.py
+++ b/sys_path_hacks/cms/contentstore/management/commands/edit_course_tabs.py
@@ -1,0 +1,5 @@
+from sys_path_hacks.warn import warn_deprecated_import
+
+warn_deprecated_import('cms.djangoapps', 'contentstore.management.commands.edit_course_tabs')
+
+from cms.djangoapps.contentstore.management.commands.edit_course_tabs import *

--- a/sys_path_hacks/cms/contentstore/management/commands/empty_asset_trashcan.py
+++ b/sys_path_hacks/cms/contentstore/management/commands/empty_asset_trashcan.py
@@ -1,0 +1,5 @@
+from sys_path_hacks.warn import warn_deprecated_import
+
+warn_deprecated_import('cms.djangoapps', 'contentstore.management.commands.empty_asset_trashcan')
+
+from cms.djangoapps.contentstore.management.commands.empty_asset_trashcan import *

--- a/sys_path_hacks/cms/contentstore/management/commands/export.py
+++ b/sys_path_hacks/cms/contentstore/management/commands/export.py
@@ -1,0 +1,5 @@
+from sys_path_hacks.warn import warn_deprecated_import
+
+warn_deprecated_import('cms.djangoapps', 'contentstore.management.commands.export')
+
+from cms.djangoapps.contentstore.management.commands.export import *

--- a/sys_path_hacks/cms/contentstore/management/commands/export_all_courses.py
+++ b/sys_path_hacks/cms/contentstore/management/commands/export_all_courses.py
@@ -1,0 +1,5 @@
+from sys_path_hacks.warn import warn_deprecated_import
+
+warn_deprecated_import('cms.djangoapps', 'contentstore.management.commands.export_all_courses')
+
+from cms.djangoapps.contentstore.management.commands.export_all_courses import *

--- a/sys_path_hacks/cms/contentstore/management/commands/export_content_library.py
+++ b/sys_path_hacks/cms/contentstore/management/commands/export_content_library.py
@@ -1,0 +1,5 @@
+from sys_path_hacks.warn import warn_deprecated_import
+
+warn_deprecated_import('cms.djangoapps', 'contentstore.management.commands.export_content_library')
+
+from cms.djangoapps.contentstore.management.commands.export_content_library import *

--- a/sys_path_hacks/cms/contentstore/management/commands/export_olx.py
+++ b/sys_path_hacks/cms/contentstore/management/commands/export_olx.py
@@ -1,0 +1,5 @@
+from sys_path_hacks.warn import warn_deprecated_import
+
+warn_deprecated_import('cms.djangoapps', 'contentstore.management.commands.export_olx')
+
+from cms.djangoapps.contentstore.management.commands.export_olx import *

--- a/sys_path_hacks/cms/contentstore/management/commands/fix_not_found.py
+++ b/sys_path_hacks/cms/contentstore/management/commands/fix_not_found.py
@@ -1,0 +1,5 @@
+from sys_path_hacks.warn import warn_deprecated_import
+
+warn_deprecated_import('cms.djangoapps', 'contentstore.management.commands.fix_not_found')
+
+from cms.djangoapps.contentstore.management.commands.fix_not_found import *

--- a/sys_path_hacks/cms/contentstore/management/commands/force_publish.py
+++ b/sys_path_hacks/cms/contentstore/management/commands/force_publish.py
@@ -1,0 +1,5 @@
+from sys_path_hacks.warn import warn_deprecated_import
+
+warn_deprecated_import('cms.djangoapps', 'contentstore.management.commands.force_publish')
+
+from cms.djangoapps.contentstore.management.commands.force_publish import *

--- a/sys_path_hacks/cms/contentstore/management/commands/generate_courses.py
+++ b/sys_path_hacks/cms/contentstore/management/commands/generate_courses.py
@@ -1,0 +1,5 @@
+from sys_path_hacks.warn import warn_deprecated_import
+
+warn_deprecated_import('cms.djangoapps', 'contentstore.management.commands.generate_courses')
+
+from cms.djangoapps.contentstore.management.commands.generate_courses import *

--- a/sys_path_hacks/cms/contentstore/management/commands/git_export.py
+++ b/sys_path_hacks/cms/contentstore/management/commands/git_export.py
@@ -1,0 +1,5 @@
+from sys_path_hacks.warn import warn_deprecated_import
+
+warn_deprecated_import('cms.djangoapps', 'contentstore.management.commands.git_export')
+
+from cms.djangoapps.contentstore.management.commands.git_export import *

--- a/sys_path_hacks/cms/contentstore/management/commands/import_content_library.py
+++ b/sys_path_hacks/cms/contentstore/management/commands/import_content_library.py
@@ -1,0 +1,5 @@
+from sys_path_hacks.warn import warn_deprecated_import
+
+warn_deprecated_import('cms.djangoapps', 'contentstore.management.commands.import_content_library')
+
+from cms.djangoapps.contentstore.management.commands.import_content_library import *

--- a/sys_path_hacks/cms/contentstore/management/commands/migrate_to_split.py
+++ b/sys_path_hacks/cms/contentstore/management/commands/migrate_to_split.py
@@ -1,0 +1,5 @@
+from sys_path_hacks.warn import warn_deprecated_import
+
+warn_deprecated_import('cms.djangoapps', 'contentstore.management.commands.migrate_to_split')
+
+from cms.djangoapps.contentstore.management.commands.migrate_to_split import *

--- a/sys_path_hacks/cms/contentstore/management/commands/prompt.py
+++ b/sys_path_hacks/cms/contentstore/management/commands/prompt.py
@@ -1,0 +1,5 @@
+from sys_path_hacks.warn import warn_deprecated_import
+
+warn_deprecated_import('cms.djangoapps', 'contentstore.management.commands.prompt')
+
+from cms.djangoapps.contentstore.management.commands.prompt import *

--- a/sys_path_hacks/cms/contentstore/management/commands/reindex_course.py
+++ b/sys_path_hacks/cms/contentstore/management/commands/reindex_course.py
@@ -1,0 +1,5 @@
+from sys_path_hacks.warn import warn_deprecated_import
+
+warn_deprecated_import('cms.djangoapps', 'contentstore.management.commands.reindex_course')
+
+from cms.djangoapps.contentstore.management.commands.reindex_course import *

--- a/sys_path_hacks/cms/contentstore/management/commands/reindex_library.py
+++ b/sys_path_hacks/cms/contentstore/management/commands/reindex_library.py
@@ -1,0 +1,5 @@
+from sys_path_hacks.warn import warn_deprecated_import
+
+warn_deprecated_import('cms.djangoapps', 'contentstore.management.commands.reindex_library')
+
+from cms.djangoapps.contentstore.management.commands.reindex_library import *

--- a/sys_path_hacks/cms/contentstore/management/commands/restore_asset_from_trashcan.py
+++ b/sys_path_hacks/cms/contentstore/management/commands/restore_asset_from_trashcan.py
@@ -1,0 +1,5 @@
+from sys_path_hacks.warn import warn_deprecated_import
+
+warn_deprecated_import('cms.djangoapps', 'contentstore.management.commands.restore_asset_from_trashcan')
+
+from cms.djangoapps.contentstore.management.commands.restore_asset_from_trashcan import *

--- a/sys_path_hacks/cms/contentstore/management/commands/sync_courses.py
+++ b/sys_path_hacks/cms/contentstore/management/commands/sync_courses.py
@@ -1,0 +1,5 @@
+from sys_path_hacks.warn import warn_deprecated_import
+
+warn_deprecated_import('cms.djangoapps', 'contentstore.management.commands.sync_courses')
+
+from cms.djangoapps.contentstore.management.commands.sync_courses import *

--- a/sys_path_hacks/cms/contentstore/management/commands/tests/__init__.py
+++ b/sys_path_hacks/cms/contentstore/management/commands/tests/__init__.py
@@ -1,0 +1,5 @@
+from sys_path_hacks.warn import warn_deprecated_import
+
+warn_deprecated_import('cms.djangoapps', 'contentstore.management.commands.tests')
+
+from cms.djangoapps.contentstore.management.commands.tests import *

--- a/sys_path_hacks/cms/contentstore/management/commands/tests/test_cleanup_assets.py
+++ b/sys_path_hacks/cms/contentstore/management/commands/tests/test_cleanup_assets.py
@@ -1,0 +1,5 @@
+from sys_path_hacks.warn import warn_deprecated_import
+
+warn_deprecated_import('cms.djangoapps', 'contentstore.management.commands.tests.test_cleanup_assets')
+
+from cms.djangoapps.contentstore.management.commands.tests.test_cleanup_assets import *

--- a/sys_path_hacks/cms/contentstore/management/commands/tests/test_create_course.py
+++ b/sys_path_hacks/cms/contentstore/management/commands/tests/test_create_course.py
@@ -1,0 +1,5 @@
+from sys_path_hacks.warn import warn_deprecated_import
+
+warn_deprecated_import('cms.djangoapps', 'contentstore.management.commands.tests.test_create_course')
+
+from cms.djangoapps.contentstore.management.commands.tests.test_create_course import *

--- a/sys_path_hacks/cms/contentstore/management/commands/tests/test_delete_course.py
+++ b/sys_path_hacks/cms/contentstore/management/commands/tests/test_delete_course.py
@@ -1,0 +1,5 @@
+from sys_path_hacks.warn import warn_deprecated_import
+
+warn_deprecated_import('cms.djangoapps', 'contentstore.management.commands.tests.test_delete_course')
+
+from cms.djangoapps.contentstore.management.commands.tests.test_delete_course import *

--- a/sys_path_hacks/cms/contentstore/management/commands/tests/test_delete_orphans.py
+++ b/sys_path_hacks/cms/contentstore/management/commands/tests/test_delete_orphans.py
@@ -1,0 +1,5 @@
+from sys_path_hacks.warn import warn_deprecated_import
+
+warn_deprecated_import('cms.djangoapps', 'contentstore.management.commands.tests.test_delete_orphans')
+
+from cms.djangoapps.contentstore.management.commands.tests.test_delete_orphans import *

--- a/sys_path_hacks/cms/contentstore/management/commands/tests/test_export.py
+++ b/sys_path_hacks/cms/contentstore/management/commands/tests/test_export.py
@@ -1,0 +1,5 @@
+from sys_path_hacks.warn import warn_deprecated_import
+
+warn_deprecated_import('cms.djangoapps', 'contentstore.management.commands.tests.test_export')
+
+from cms.djangoapps.contentstore.management.commands.tests.test_export import *

--- a/sys_path_hacks/cms/contentstore/management/commands/tests/test_export_all_courses.py
+++ b/sys_path_hacks/cms/contentstore/management/commands/tests/test_export_all_courses.py
@@ -1,0 +1,5 @@
+from sys_path_hacks.warn import warn_deprecated_import
+
+warn_deprecated_import('cms.djangoapps', 'contentstore.management.commands.tests.test_export_all_courses')
+
+from cms.djangoapps.contentstore.management.commands.tests.test_export_all_courses import *

--- a/sys_path_hacks/cms/contentstore/management/commands/tests/test_export_olx.py
+++ b/sys_path_hacks/cms/contentstore/management/commands/tests/test_export_olx.py
@@ -1,0 +1,5 @@
+from sys_path_hacks.warn import warn_deprecated_import
+
+warn_deprecated_import('cms.djangoapps', 'contentstore.management.commands.tests.test_export_olx')
+
+from cms.djangoapps.contentstore.management.commands.tests.test_export_olx import *

--- a/sys_path_hacks/cms/contentstore/management/commands/tests/test_fix_not_found.py
+++ b/sys_path_hacks/cms/contentstore/management/commands/tests/test_fix_not_found.py
@@ -1,0 +1,5 @@
+from sys_path_hacks.warn import warn_deprecated_import
+
+warn_deprecated_import('cms.djangoapps', 'contentstore.management.commands.tests.test_fix_not_found')
+
+from cms.djangoapps.contentstore.management.commands.tests.test_fix_not_found import *

--- a/sys_path_hacks/cms/contentstore/management/commands/tests/test_force_publish.py
+++ b/sys_path_hacks/cms/contentstore/management/commands/tests/test_force_publish.py
@@ -1,0 +1,5 @@
+from sys_path_hacks.warn import warn_deprecated_import
+
+warn_deprecated_import('cms.djangoapps', 'contentstore.management.commands.tests.test_force_publish')
+
+from cms.djangoapps.contentstore.management.commands.tests.test_force_publish import *

--- a/sys_path_hacks/cms/contentstore/management/commands/tests/test_generate_courses.py
+++ b/sys_path_hacks/cms/contentstore/management/commands/tests/test_generate_courses.py
@@ -1,0 +1,5 @@
+from sys_path_hacks.warn import warn_deprecated_import
+
+warn_deprecated_import('cms.djangoapps', 'contentstore.management.commands.tests.test_generate_courses')
+
+from cms.djangoapps.contentstore.management.commands.tests.test_generate_courses import *

--- a/sys_path_hacks/cms/contentstore/management/commands/tests/test_git_export.py
+++ b/sys_path_hacks/cms/contentstore/management/commands/tests/test_git_export.py
@@ -1,0 +1,5 @@
+from sys_path_hacks.warn import warn_deprecated_import
+
+warn_deprecated_import('cms.djangoapps', 'contentstore.management.commands.tests.test_git_export')
+
+from cms.djangoapps.contentstore.management.commands.tests.test_git_export import *

--- a/sys_path_hacks/cms/contentstore/management/commands/tests/test_import.py
+++ b/sys_path_hacks/cms/contentstore/management/commands/tests/test_import.py
@@ -1,0 +1,5 @@
+from sys_path_hacks.warn import warn_deprecated_import
+
+warn_deprecated_import('cms.djangoapps', 'contentstore.management.commands.tests.test_import')
+
+from cms.djangoapps.contentstore.management.commands.tests.test_import import *

--- a/sys_path_hacks/cms/contentstore/management/commands/tests/test_migrate_to_split.py
+++ b/sys_path_hacks/cms/contentstore/management/commands/tests/test_migrate_to_split.py
@@ -1,0 +1,5 @@
+from sys_path_hacks.warn import warn_deprecated_import
+
+warn_deprecated_import('cms.djangoapps', 'contentstore.management.commands.tests.test_migrate_to_split')
+
+from cms.djangoapps.contentstore.management.commands.tests.test_migrate_to_split import *

--- a/sys_path_hacks/cms/contentstore/management/commands/tests/test_reindex_courses.py
+++ b/sys_path_hacks/cms/contentstore/management/commands/tests/test_reindex_courses.py
@@ -1,0 +1,5 @@
+from sys_path_hacks.warn import warn_deprecated_import
+
+warn_deprecated_import('cms.djangoapps', 'contentstore.management.commands.tests.test_reindex_courses')
+
+from cms.djangoapps.contentstore.management.commands.tests.test_reindex_courses import *

--- a/sys_path_hacks/cms/contentstore/management/commands/tests/test_reindex_library.py
+++ b/sys_path_hacks/cms/contentstore/management/commands/tests/test_reindex_library.py
@@ -1,0 +1,5 @@
+from sys_path_hacks.warn import warn_deprecated_import
+
+warn_deprecated_import('cms.djangoapps', 'contentstore.management.commands.tests.test_reindex_library')
+
+from cms.djangoapps.contentstore.management.commands.tests.test_reindex_library import *

--- a/sys_path_hacks/cms/contentstore/management/commands/tests/test_sync_courses.py
+++ b/sys_path_hacks/cms/contentstore/management/commands/tests/test_sync_courses.py
@@ -1,0 +1,5 @@
+from sys_path_hacks.warn import warn_deprecated_import
+
+warn_deprecated_import('cms.djangoapps', 'contentstore.management.commands.tests.test_sync_courses')
+
+from cms.djangoapps.contentstore.management.commands.tests.test_sync_courses import *

--- a/sys_path_hacks/cms/contentstore/management/commands/utils.py
+++ b/sys_path_hacks/cms/contentstore/management/commands/utils.py
@@ -1,0 +1,5 @@
+from sys_path_hacks.warn import warn_deprecated_import
+
+warn_deprecated_import('cms.djangoapps', 'contentstore.management.commands.utils')
+
+from cms.djangoapps.contentstore.management.commands.utils import *

--- a/sys_path_hacks/cms/contentstore/management/commands/xlint.py
+++ b/sys_path_hacks/cms/contentstore/management/commands/xlint.py
@@ -1,0 +1,5 @@
+from sys_path_hacks.warn import warn_deprecated_import
+
+warn_deprecated_import('cms.djangoapps', 'contentstore.management.commands.xlint')
+
+from cms.djangoapps.contentstore.management.commands.xlint import *

--- a/sys_path_hacks/cms/contentstore/models.py
+++ b/sys_path_hacks/cms/contentstore/models.py
@@ -1,0 +1,5 @@
+from sys_path_hacks.warn import warn_deprecated_import
+
+warn_deprecated_import('cms.djangoapps', 'contentstore.models')
+
+from cms.djangoapps.contentstore.models import *

--- a/sys_path_hacks/cms/contentstore/proctoring.py
+++ b/sys_path_hacks/cms/contentstore/proctoring.py
@@ -1,0 +1,5 @@
+from sys_path_hacks.warn import warn_deprecated_import
+
+warn_deprecated_import('cms.djangoapps', 'contentstore.proctoring')
+
+from cms.djangoapps.contentstore.proctoring import *

--- a/sys_path_hacks/cms/contentstore/rest_api/__init__.py
+++ b/sys_path_hacks/cms/contentstore/rest_api/__init__.py
@@ -1,0 +1,5 @@
+from sys_path_hacks.warn import warn_deprecated_import
+
+warn_deprecated_import('cms.djangoapps', 'contentstore.rest_api')
+
+from cms.djangoapps.contentstore.rest_api import *

--- a/sys_path_hacks/cms/contentstore/rest_api/urls.py
+++ b/sys_path_hacks/cms/contentstore/rest_api/urls.py
@@ -1,0 +1,5 @@
+from sys_path_hacks.warn import warn_deprecated_import
+
+warn_deprecated_import('cms.djangoapps', 'contentstore.rest_api.urls')
+
+from cms.djangoapps.contentstore.rest_api.urls import *

--- a/sys_path_hacks/cms/contentstore/rest_api/v1/serializers.py
+++ b/sys_path_hacks/cms/contentstore/rest_api/v1/serializers.py
@@ -1,0 +1,5 @@
+from sys_path_hacks.warn import warn_deprecated_import
+
+warn_deprecated_import('cms.djangoapps', 'contentstore.rest_api.v1.serializers')
+
+from cms.djangoapps.contentstore.rest_api.v1.serializers import *

--- a/sys_path_hacks/cms/contentstore/rest_api/v1/tests/__init__.py
+++ b/sys_path_hacks/cms/contentstore/rest_api/v1/tests/__init__.py
@@ -1,0 +1,5 @@
+from sys_path_hacks.warn import warn_deprecated_import
+
+warn_deprecated_import('cms.djangoapps', 'contentstore.rest_api.v1.tests')
+
+from cms.djangoapps.contentstore.rest_api.v1.tests import *

--- a/sys_path_hacks/cms/contentstore/rest_api/v1/tests/test_views.py
+++ b/sys_path_hacks/cms/contentstore/rest_api/v1/tests/test_views.py
@@ -1,0 +1,5 @@
+from sys_path_hacks.warn import warn_deprecated_import
+
+warn_deprecated_import('cms.djangoapps', 'contentstore.rest_api.v1.tests.test_views')
+
+from cms.djangoapps.contentstore.rest_api.v1.tests.test_views import *

--- a/sys_path_hacks/cms/contentstore/rest_api/v1/urls.py
+++ b/sys_path_hacks/cms/contentstore/rest_api/v1/urls.py
@@ -1,0 +1,5 @@
+from sys_path_hacks.warn import warn_deprecated_import
+
+warn_deprecated_import('cms.djangoapps', 'contentstore.rest_api.v1.urls')
+
+from cms.djangoapps.contentstore.rest_api.v1.urls import *

--- a/sys_path_hacks/cms/contentstore/rest_api/v1/views.py
+++ b/sys_path_hacks/cms/contentstore/rest_api/v1/views.py
@@ -1,0 +1,5 @@
+from sys_path_hacks.warn import warn_deprecated_import
+
+warn_deprecated_import('cms.djangoapps', 'contentstore.rest_api.v1.views')
+
+from cms.djangoapps.contentstore.rest_api.v1.views import *

--- a/sys_path_hacks/cms/contentstore/rules.py
+++ b/sys_path_hacks/cms/contentstore/rules.py
@@ -1,0 +1,5 @@
+from sys_path_hacks.warn import warn_deprecated_import
+
+warn_deprecated_import('cms.djangoapps', 'contentstore.rules')
+
+from cms.djangoapps.contentstore.rules import *

--- a/sys_path_hacks/cms/contentstore/signals/__init__.py
+++ b/sys_path_hacks/cms/contentstore/signals/__init__.py
@@ -1,0 +1,5 @@
+from sys_path_hacks.warn import warn_deprecated_import
+
+warn_deprecated_import('cms.djangoapps', 'contentstore.signals')
+
+from cms.djangoapps.contentstore.signals import *

--- a/sys_path_hacks/cms/contentstore/signals/handlers.py
+++ b/sys_path_hacks/cms/contentstore/signals/handlers.py
@@ -1,0 +1,5 @@
+from sys_path_hacks.warn import warn_deprecated_import
+
+warn_deprecated_import('cms.djangoapps', 'contentstore.signals.handlers')
+
+from cms.djangoapps.contentstore.signals.handlers import *

--- a/sys_path_hacks/cms/contentstore/signals/signals.py
+++ b/sys_path_hacks/cms/contentstore/signals/signals.py
@@ -1,0 +1,5 @@
+from sys_path_hacks.warn import warn_deprecated_import
+
+warn_deprecated_import('cms.djangoapps', 'contentstore.signals.signals')
+
+from cms.djangoapps.contentstore.signals.signals import *

--- a/sys_path_hacks/cms/contentstore/storage.py
+++ b/sys_path_hacks/cms/contentstore/storage.py
@@ -1,0 +1,5 @@
+from sys_path_hacks.warn import warn_deprecated_import
+
+warn_deprecated_import('cms.djangoapps', 'contentstore.storage')
+
+from cms.djangoapps.contentstore.storage import *

--- a/sys_path_hacks/cms/contentstore/tasks.py
+++ b/sys_path_hacks/cms/contentstore/tasks.py
@@ -1,0 +1,5 @@
+from sys_path_hacks.warn import warn_deprecated_import
+
+warn_deprecated_import('cms.djangoapps', 'contentstore.tasks')
+
+from cms.djangoapps.contentstore.tasks import *

--- a/sys_path_hacks/cms/contentstore/tests/__init__.py
+++ b/sys_path_hacks/cms/contentstore/tests/__init__.py
@@ -1,0 +1,5 @@
+from sys_path_hacks.warn import warn_deprecated_import
+
+warn_deprecated_import('cms.djangoapps', 'contentstore.tests')
+
+from cms.djangoapps.contentstore.tests import *

--- a/sys_path_hacks/cms/contentstore/tests/test_clone_course.py
+++ b/sys_path_hacks/cms/contentstore/tests/test_clone_course.py
@@ -1,0 +1,5 @@
+from sys_path_hacks.warn import warn_deprecated_import
+
+warn_deprecated_import('cms.djangoapps', 'contentstore.tests.test_clone_course')
+
+from cms.djangoapps.contentstore.tests.test_clone_course import *

--- a/sys_path_hacks/cms/contentstore/tests/test_contentstore.py
+++ b/sys_path_hacks/cms/contentstore/tests/test_contentstore.py
@@ -1,0 +1,5 @@
+from sys_path_hacks.warn import warn_deprecated_import
+
+warn_deprecated_import('cms.djangoapps', 'contentstore.tests.test_contentstore')
+
+from cms.djangoapps.contentstore.tests.test_contentstore import *

--- a/sys_path_hacks/cms/contentstore/tests/test_core_caching.py
+++ b/sys_path_hacks/cms/contentstore/tests/test_core_caching.py
@@ -1,0 +1,5 @@
+from sys_path_hacks.warn import warn_deprecated_import
+
+warn_deprecated_import('cms.djangoapps', 'contentstore.tests.test_core_caching')
+
+from cms.djangoapps.contentstore.tests.test_core_caching import *

--- a/sys_path_hacks/cms/contentstore/tests/test_course_create_rerun.py
+++ b/sys_path_hacks/cms/contentstore/tests/test_course_create_rerun.py
@@ -1,0 +1,5 @@
+from sys_path_hacks.warn import warn_deprecated_import
+
+warn_deprecated_import('cms.djangoapps', 'contentstore.tests.test_course_create_rerun')
+
+from cms.djangoapps.contentstore.tests.test_course_create_rerun import *

--- a/sys_path_hacks/cms/contentstore/tests/test_course_listing.py
+++ b/sys_path_hacks/cms/contentstore/tests/test_course_listing.py
@@ -1,0 +1,5 @@
+from sys_path_hacks.warn import warn_deprecated_import
+
+warn_deprecated_import('cms.djangoapps', 'contentstore.tests.test_course_listing')
+
+from cms.djangoapps.contentstore.tests.test_course_listing import *

--- a/sys_path_hacks/cms/contentstore/tests/test_course_settings.py
+++ b/sys_path_hacks/cms/contentstore/tests/test_course_settings.py
@@ -1,0 +1,5 @@
+from sys_path_hacks.warn import warn_deprecated_import
+
+warn_deprecated_import('cms.djangoapps', 'contentstore.tests.test_course_settings')
+
+from cms.djangoapps.contentstore.tests.test_course_settings import *

--- a/sys_path_hacks/cms/contentstore/tests/test_courseware_index.py
+++ b/sys_path_hacks/cms/contentstore/tests/test_courseware_index.py
@@ -1,0 +1,5 @@
+from sys_path_hacks.warn import warn_deprecated_import
+
+warn_deprecated_import('cms.djangoapps', 'contentstore.tests.test_courseware_index')
+
+from cms.djangoapps.contentstore.tests.test_courseware_index import *

--- a/sys_path_hacks/cms/contentstore/tests/test_crud.py
+++ b/sys_path_hacks/cms/contentstore/tests/test_crud.py
@@ -1,0 +1,5 @@
+from sys_path_hacks.warn import warn_deprecated_import
+
+warn_deprecated_import('cms.djangoapps', 'contentstore.tests.test_crud')
+
+from cms.djangoapps.contentstore.tests.test_crud import *

--- a/sys_path_hacks/cms/contentstore/tests/test_export_git.py
+++ b/sys_path_hacks/cms/contentstore/tests/test_export_git.py
@@ -1,0 +1,5 @@
+from sys_path_hacks.warn import warn_deprecated_import
+
+warn_deprecated_import('cms.djangoapps', 'contentstore.tests.test_export_git')
+
+from cms.djangoapps.contentstore.tests.test_export_git import *

--- a/sys_path_hacks/cms/contentstore/tests/test_gating.py
+++ b/sys_path_hacks/cms/contentstore/tests/test_gating.py
@@ -1,0 +1,5 @@
+from sys_path_hacks.warn import warn_deprecated_import
+
+warn_deprecated_import('cms.djangoapps', 'contentstore.tests.test_gating')
+
+from cms.djangoapps.contentstore.tests.test_gating import *

--- a/sys_path_hacks/cms/contentstore/tests/test_i18n.py
+++ b/sys_path_hacks/cms/contentstore/tests/test_i18n.py
@@ -1,0 +1,5 @@
+from sys_path_hacks.warn import warn_deprecated_import
+
+warn_deprecated_import('cms.djangoapps', 'contentstore.tests.test_i18n')
+
+from cms.djangoapps.contentstore.tests.test_i18n import *

--- a/sys_path_hacks/cms/contentstore/tests/test_import.py
+++ b/sys_path_hacks/cms/contentstore/tests/test_import.py
@@ -1,0 +1,5 @@
+from sys_path_hacks.warn import warn_deprecated_import
+
+warn_deprecated_import('cms.djangoapps', 'contentstore.tests.test_import')
+
+from cms.djangoapps.contentstore.tests.test_import import *

--- a/sys_path_hacks/cms/contentstore/tests/test_import_draft_order.py
+++ b/sys_path_hacks/cms/contentstore/tests/test_import_draft_order.py
@@ -1,0 +1,5 @@
+from sys_path_hacks.warn import warn_deprecated_import
+
+warn_deprecated_import('cms.djangoapps', 'contentstore.tests.test_import_draft_order')
+
+from cms.djangoapps.contentstore.tests.test_import_draft_order import *

--- a/sys_path_hacks/cms/contentstore/tests/test_import_pure_xblock.py
+++ b/sys_path_hacks/cms/contentstore/tests/test_import_pure_xblock.py
@@ -1,0 +1,5 @@
+from sys_path_hacks.warn import warn_deprecated_import
+
+warn_deprecated_import('cms.djangoapps', 'contentstore.tests.test_import_pure_xblock')
+
+from cms.djangoapps.contentstore.tests.test_import_pure_xblock import *

--- a/sys_path_hacks/cms/contentstore/tests/test_libraries.py
+++ b/sys_path_hacks/cms/contentstore/tests/test_libraries.py
@@ -1,0 +1,5 @@
+from sys_path_hacks.warn import warn_deprecated_import
+
+warn_deprecated_import('cms.djangoapps', 'contentstore.tests.test_libraries')
+
+from cms.djangoapps.contentstore.tests.test_libraries import *

--- a/sys_path_hacks/cms/contentstore/tests/test_orphan.py
+++ b/sys_path_hacks/cms/contentstore/tests/test_orphan.py
@@ -1,0 +1,5 @@
+from sys_path_hacks.warn import warn_deprecated_import
+
+warn_deprecated_import('cms.djangoapps', 'contentstore.tests.test_orphan')
+
+from cms.djangoapps.contentstore.tests.test_orphan import *

--- a/sys_path_hacks/cms/contentstore/tests/test_permissions.py
+++ b/sys_path_hacks/cms/contentstore/tests/test_permissions.py
@@ -1,0 +1,5 @@
+from sys_path_hacks.warn import warn_deprecated_import
+
+warn_deprecated_import('cms.djangoapps', 'contentstore.tests.test_permissions')
+
+from cms.djangoapps.contentstore.tests.test_permissions import *

--- a/sys_path_hacks/cms/contentstore/tests/test_proctoring.py
+++ b/sys_path_hacks/cms/contentstore/tests/test_proctoring.py
@@ -1,0 +1,5 @@
+from sys_path_hacks.warn import warn_deprecated_import
+
+warn_deprecated_import('cms.djangoapps', 'contentstore.tests.test_proctoring')
+
+from cms.djangoapps.contentstore.tests.test_proctoring import *

--- a/sys_path_hacks/cms/contentstore/tests/test_request_event.py
+++ b/sys_path_hacks/cms/contentstore/tests/test_request_event.py
@@ -1,0 +1,5 @@
+from sys_path_hacks.warn import warn_deprecated_import
+
+warn_deprecated_import('cms.djangoapps', 'contentstore.tests.test_request_event')
+
+from cms.djangoapps.contentstore.tests.test_request_event import *

--- a/sys_path_hacks/cms/contentstore/tests/test_signals.py
+++ b/sys_path_hacks/cms/contentstore/tests/test_signals.py
@@ -1,0 +1,5 @@
+from sys_path_hacks.warn import warn_deprecated_import
+
+warn_deprecated_import('cms.djangoapps', 'contentstore.tests.test_signals')
+
+from cms.djangoapps.contentstore.tests.test_signals import *

--- a/sys_path_hacks/cms/contentstore/tests/test_tasks.py
+++ b/sys_path_hacks/cms/contentstore/tests/test_tasks.py
@@ -1,0 +1,5 @@
+from sys_path_hacks.warn import warn_deprecated_import
+
+warn_deprecated_import('cms.djangoapps', 'contentstore.tests.test_tasks')
+
+from cms.djangoapps.contentstore.tests.test_tasks import *

--- a/sys_path_hacks/cms/contentstore/tests/test_transcripts_utils.py
+++ b/sys_path_hacks/cms/contentstore/tests/test_transcripts_utils.py
@@ -1,0 +1,5 @@
+from sys_path_hacks.warn import warn_deprecated_import
+
+warn_deprecated_import('cms.djangoapps', 'contentstore.tests.test_transcripts_utils')
+
+from cms.djangoapps.contentstore.tests.test_transcripts_utils import *

--- a/sys_path_hacks/cms/contentstore/tests/test_users_default_role.py
+++ b/sys_path_hacks/cms/contentstore/tests/test_users_default_role.py
@@ -1,0 +1,5 @@
+from sys_path_hacks.warn import warn_deprecated_import
+
+warn_deprecated_import('cms.djangoapps', 'contentstore.tests.test_users_default_role')
+
+from cms.djangoapps.contentstore.tests.test_users_default_role import *

--- a/sys_path_hacks/cms/contentstore/tests/test_utils.py
+++ b/sys_path_hacks/cms/contentstore/tests/test_utils.py
@@ -1,0 +1,5 @@
+from sys_path_hacks.warn import warn_deprecated_import
+
+warn_deprecated_import('cms.djangoapps', 'contentstore.tests.test_utils')
+
+from cms.djangoapps.contentstore.tests.test_utils import *

--- a/sys_path_hacks/cms/contentstore/tests/test_video_utils.py
+++ b/sys_path_hacks/cms/contentstore/tests/test_video_utils.py
@@ -1,0 +1,5 @@
+from sys_path_hacks.warn import warn_deprecated_import
+
+warn_deprecated_import('cms.djangoapps', 'contentstore.tests.test_video_utils')
+
+from cms.djangoapps.contentstore.tests.test_video_utils import *

--- a/sys_path_hacks/cms/contentstore/tests/tests.py
+++ b/sys_path_hacks/cms/contentstore/tests/tests.py
@@ -1,0 +1,5 @@
+from sys_path_hacks.warn import warn_deprecated_import
+
+warn_deprecated_import('cms.djangoapps', 'contentstore.tests.tests')
+
+from cms.djangoapps.contentstore.tests.tests import *

--- a/sys_path_hacks/cms/contentstore/tests/utils.py
+++ b/sys_path_hacks/cms/contentstore/tests/utils.py
@@ -1,0 +1,5 @@
+from sys_path_hacks.warn import warn_deprecated_import
+
+warn_deprecated_import('cms.djangoapps', 'contentstore.tests.utils')
+
+from cms.djangoapps.contentstore.tests.utils import *

--- a/sys_path_hacks/cms/contentstore/utils.py
+++ b/sys_path_hacks/cms/contentstore/utils.py
@@ -1,0 +1,5 @@
+from sys_path_hacks.warn import warn_deprecated_import
+
+warn_deprecated_import('cms.djangoapps', 'contentstore.utils')
+
+from cms.djangoapps.contentstore.utils import *

--- a/sys_path_hacks/cms/contentstore/video_utils.py
+++ b/sys_path_hacks/cms/contentstore/video_utils.py
@@ -1,0 +1,5 @@
+from sys_path_hacks.warn import warn_deprecated_import
+
+warn_deprecated_import('cms.djangoapps', 'contentstore.video_utils')
+
+from cms.djangoapps.contentstore.video_utils import *

--- a/sys_path_hacks/cms/contentstore/views/__init__.py
+++ b/sys_path_hacks/cms/contentstore/views/__init__.py
@@ -1,0 +1,5 @@
+from sys_path_hacks.warn import warn_deprecated_import
+
+warn_deprecated_import('cms.djangoapps', 'contentstore.views')
+
+from cms.djangoapps.contentstore.views import *

--- a/sys_path_hacks/cms/contentstore/views/access.py
+++ b/sys_path_hacks/cms/contentstore/views/access.py
@@ -1,0 +1,5 @@
+from sys_path_hacks.warn import warn_deprecated_import
+
+warn_deprecated_import('cms.djangoapps', 'contentstore.views.access')
+
+from cms.djangoapps.contentstore.views.access import *

--- a/sys_path_hacks/cms/contentstore/views/assets.py
+++ b/sys_path_hacks/cms/contentstore/views/assets.py
@@ -1,0 +1,5 @@
+from sys_path_hacks.warn import warn_deprecated_import
+
+warn_deprecated_import('cms.djangoapps', 'contentstore.views.assets')
+
+from cms.djangoapps.contentstore.views.assets import *

--- a/sys_path_hacks/cms/contentstore/views/certificates.py
+++ b/sys_path_hacks/cms/contentstore/views/certificates.py
@@ -1,0 +1,5 @@
+from sys_path_hacks.warn import warn_deprecated_import
+
+warn_deprecated_import('cms.djangoapps', 'contentstore.views.certificates')
+
+from cms.djangoapps.contentstore.views.certificates import *

--- a/sys_path_hacks/cms/contentstore/views/checklists.py
+++ b/sys_path_hacks/cms/contentstore/views/checklists.py
@@ -1,0 +1,5 @@
+from sys_path_hacks.warn import warn_deprecated_import
+
+warn_deprecated_import('cms.djangoapps', 'contentstore.views.checklists')
+
+from cms.djangoapps.contentstore.views.checklists import *

--- a/sys_path_hacks/cms/contentstore/views/component.py
+++ b/sys_path_hacks/cms/contentstore/views/component.py
@@ -1,0 +1,5 @@
+from sys_path_hacks.warn import warn_deprecated_import
+
+warn_deprecated_import('cms.djangoapps', 'contentstore.views.component')
+
+from cms.djangoapps.contentstore.views.component import *

--- a/sys_path_hacks/cms/contentstore/views/course.py
+++ b/sys_path_hacks/cms/contentstore/views/course.py
@@ -1,0 +1,5 @@
+from sys_path_hacks.warn import warn_deprecated_import
+
+warn_deprecated_import('cms.djangoapps', 'contentstore.views.course')
+
+from cms.djangoapps.contentstore.views.course import *

--- a/sys_path_hacks/cms/contentstore/views/dev.py
+++ b/sys_path_hacks/cms/contentstore/views/dev.py
@@ -1,0 +1,5 @@
+from sys_path_hacks.warn import warn_deprecated_import
+
+warn_deprecated_import('cms.djangoapps', 'contentstore.views.dev')
+
+from cms.djangoapps.contentstore.views.dev import *

--- a/sys_path_hacks/cms/contentstore/views/entrance_exam.py
+++ b/sys_path_hacks/cms/contentstore/views/entrance_exam.py
@@ -1,0 +1,5 @@
+from sys_path_hacks.warn import warn_deprecated_import
+
+warn_deprecated_import('cms.djangoapps', 'contentstore.views.entrance_exam')
+
+from cms.djangoapps.contentstore.views.entrance_exam import *

--- a/sys_path_hacks/cms/contentstore/views/error.py
+++ b/sys_path_hacks/cms/contentstore/views/error.py
@@ -1,0 +1,5 @@
+from sys_path_hacks.warn import warn_deprecated_import
+
+warn_deprecated_import('cms.djangoapps', 'contentstore.views.error')
+
+from cms.djangoapps.contentstore.views.error import *

--- a/sys_path_hacks/cms/contentstore/views/exception.py
+++ b/sys_path_hacks/cms/contentstore/views/exception.py
@@ -1,0 +1,5 @@
+from sys_path_hacks.warn import warn_deprecated_import
+
+warn_deprecated_import('cms.djangoapps', 'contentstore.views.exception')
+
+from cms.djangoapps.contentstore.views.exception import *

--- a/sys_path_hacks/cms/contentstore/views/export_git.py
+++ b/sys_path_hacks/cms/contentstore/views/export_git.py
@@ -1,0 +1,5 @@
+from sys_path_hacks.warn import warn_deprecated_import
+
+warn_deprecated_import('cms.djangoapps', 'contentstore.views.export_git')
+
+from cms.djangoapps.contentstore.views.export_git import *

--- a/sys_path_hacks/cms/contentstore/views/helpers.py
+++ b/sys_path_hacks/cms/contentstore/views/helpers.py
@@ -1,0 +1,5 @@
+from sys_path_hacks.warn import warn_deprecated_import
+
+warn_deprecated_import('cms.djangoapps', 'contentstore.views.helpers')
+
+from cms.djangoapps.contentstore.views.helpers import *

--- a/sys_path_hacks/cms/contentstore/views/import_export.py
+++ b/sys_path_hacks/cms/contentstore/views/import_export.py
@@ -1,0 +1,5 @@
+from sys_path_hacks.warn import warn_deprecated_import
+
+warn_deprecated_import('cms.djangoapps', 'contentstore.views.import_export')
+
+from cms.djangoapps.contentstore.views.import_export import *

--- a/sys_path_hacks/cms/contentstore/views/item.py
+++ b/sys_path_hacks/cms/contentstore/views/item.py
@@ -1,0 +1,5 @@
+from sys_path_hacks.warn import warn_deprecated_import
+
+warn_deprecated_import('cms.djangoapps', 'contentstore.views.item')
+
+from cms.djangoapps.contentstore.views.item import *

--- a/sys_path_hacks/cms/contentstore/views/library.py
+++ b/sys_path_hacks/cms/contentstore/views/library.py
@@ -1,0 +1,5 @@
+from sys_path_hacks.warn import warn_deprecated_import
+
+warn_deprecated_import('cms.djangoapps', 'contentstore.views.library')
+
+from cms.djangoapps.contentstore.views.library import *

--- a/sys_path_hacks/cms/contentstore/views/organization.py
+++ b/sys_path_hacks/cms/contentstore/views/organization.py
@@ -1,0 +1,5 @@
+from sys_path_hacks.warn import warn_deprecated_import
+
+warn_deprecated_import('cms.djangoapps', 'contentstore.views.organization')
+
+from cms.djangoapps.contentstore.views.organization import *

--- a/sys_path_hacks/cms/contentstore/views/preview.py
+++ b/sys_path_hacks/cms/contentstore/views/preview.py
@@ -1,0 +1,5 @@
+from sys_path_hacks.warn import warn_deprecated_import
+
+warn_deprecated_import('cms.djangoapps', 'contentstore.views.preview')
+
+from cms.djangoapps.contentstore.views.preview import *

--- a/sys_path_hacks/cms/contentstore/views/public.py
+++ b/sys_path_hacks/cms/contentstore/views/public.py
@@ -1,0 +1,5 @@
+from sys_path_hacks.warn import warn_deprecated_import
+
+warn_deprecated_import('cms.djangoapps', 'contentstore.views.public')
+
+from cms.djangoapps.contentstore.views.public import *

--- a/sys_path_hacks/cms/contentstore/views/session_kv_store.py
+++ b/sys_path_hacks/cms/contentstore/views/session_kv_store.py
@@ -1,0 +1,5 @@
+from sys_path_hacks.warn import warn_deprecated_import
+
+warn_deprecated_import('cms.djangoapps', 'contentstore.views.session_kv_store')
+
+from cms.djangoapps.contentstore.views.session_kv_store import *

--- a/sys_path_hacks/cms/contentstore/views/tabs.py
+++ b/sys_path_hacks/cms/contentstore/views/tabs.py
@@ -1,0 +1,5 @@
+from sys_path_hacks.warn import warn_deprecated_import
+
+warn_deprecated_import('cms.djangoapps', 'contentstore.views.tabs')
+
+from cms.djangoapps.contentstore.views.tabs import *

--- a/sys_path_hacks/cms/contentstore/views/tests/__init__.py
+++ b/sys_path_hacks/cms/contentstore/views/tests/__init__.py
@@ -1,0 +1,5 @@
+from sys_path_hacks.warn import warn_deprecated_import
+
+warn_deprecated_import('cms.djangoapps', 'contentstore.views.tests')
+
+from cms.djangoapps.contentstore.views.tests import *

--- a/sys_path_hacks/cms/contentstore/views/tests/test_access.py
+++ b/sys_path_hacks/cms/contentstore/views/tests/test_access.py
@@ -1,0 +1,5 @@
+from sys_path_hacks.warn import warn_deprecated_import
+
+warn_deprecated_import('cms.djangoapps', 'contentstore.views.tests.test_access')
+
+from cms.djangoapps.contentstore.views.tests.test_access import *

--- a/sys_path_hacks/cms/contentstore/views/tests/test_assets.py
+++ b/sys_path_hacks/cms/contentstore/views/tests/test_assets.py
@@ -1,0 +1,5 @@
+from sys_path_hacks.warn import warn_deprecated_import
+
+warn_deprecated_import('cms.djangoapps', 'contentstore.views.tests.test_assets')
+
+from cms.djangoapps.contentstore.views.tests.test_assets import *

--- a/sys_path_hacks/cms/contentstore/views/tests/test_certificates.py
+++ b/sys_path_hacks/cms/contentstore/views/tests/test_certificates.py
@@ -1,0 +1,5 @@
+from sys_path_hacks.warn import warn_deprecated_import
+
+warn_deprecated_import('cms.djangoapps', 'contentstore.views.tests.test_certificates')
+
+from cms.djangoapps.contentstore.views.tests.test_certificates import *

--- a/sys_path_hacks/cms/contentstore/views/tests/test_container_page.py
+++ b/sys_path_hacks/cms/contentstore/views/tests/test_container_page.py
@@ -1,0 +1,5 @@
+from sys_path_hacks.warn import warn_deprecated_import
+
+warn_deprecated_import('cms.djangoapps', 'contentstore.views.tests.test_container_page')
+
+from cms.djangoapps.contentstore.views.tests.test_container_page import *

--- a/sys_path_hacks/cms/contentstore/views/tests/test_course_index.py
+++ b/sys_path_hacks/cms/contentstore/views/tests/test_course_index.py
@@ -1,0 +1,5 @@
+from sys_path_hacks.warn import warn_deprecated_import
+
+warn_deprecated_import('cms.djangoapps', 'contentstore.views.tests.test_course_index')
+
+from cms.djangoapps.contentstore.views.tests.test_course_index import *

--- a/sys_path_hacks/cms/contentstore/views/tests/test_course_updates.py
+++ b/sys_path_hacks/cms/contentstore/views/tests/test_course_updates.py
@@ -1,0 +1,5 @@
+from sys_path_hacks.warn import warn_deprecated_import
+
+warn_deprecated_import('cms.djangoapps', 'contentstore.views.tests.test_course_updates')
+
+from cms.djangoapps.contentstore.views.tests.test_course_updates import *

--- a/sys_path_hacks/cms/contentstore/views/tests/test_credit_eligibility.py
+++ b/sys_path_hacks/cms/contentstore/views/tests/test_credit_eligibility.py
@@ -1,0 +1,5 @@
+from sys_path_hacks.warn import warn_deprecated_import
+
+warn_deprecated_import('cms.djangoapps', 'contentstore.views.tests.test_credit_eligibility')
+
+from cms.djangoapps.contentstore.views.tests.test_credit_eligibility import *

--- a/sys_path_hacks/cms/contentstore/views/tests/test_entrance_exam.py
+++ b/sys_path_hacks/cms/contentstore/views/tests/test_entrance_exam.py
@@ -1,0 +1,5 @@
+from sys_path_hacks.warn import warn_deprecated_import
+
+warn_deprecated_import('cms.djangoapps', 'contentstore.views.tests.test_entrance_exam')
+
+from cms.djangoapps.contentstore.views.tests.test_entrance_exam import *

--- a/sys_path_hacks/cms/contentstore/views/tests/test_exam_settings_view.py
+++ b/sys_path_hacks/cms/contentstore/views/tests/test_exam_settings_view.py
@@ -1,0 +1,5 @@
+from sys_path_hacks.warn import warn_deprecated_import
+
+warn_deprecated_import('cms.djangoapps', 'contentstore.views.tests.test_exam_settings_view')
+
+from cms.djangoapps.contentstore.views.tests.test_exam_settings_view import *

--- a/sys_path_hacks/cms/contentstore/views/tests/test_gating.py
+++ b/sys_path_hacks/cms/contentstore/views/tests/test_gating.py
@@ -1,0 +1,5 @@
+from sys_path_hacks.warn import warn_deprecated_import
+
+warn_deprecated_import('cms.djangoapps', 'contentstore.views.tests.test_gating')
+
+from cms.djangoapps.contentstore.views.tests.test_gating import *

--- a/sys_path_hacks/cms/contentstore/views/tests/test_group_configurations.py
+++ b/sys_path_hacks/cms/contentstore/views/tests/test_group_configurations.py
@@ -1,0 +1,5 @@
+from sys_path_hacks.warn import warn_deprecated_import
+
+warn_deprecated_import('cms.djangoapps', 'contentstore.views.tests.test_group_configurations')
+
+from cms.djangoapps.contentstore.views.tests.test_group_configurations import *

--- a/sys_path_hacks/cms/contentstore/views/tests/test_header_menu.py
+++ b/sys_path_hacks/cms/contentstore/views/tests/test_header_menu.py
@@ -1,0 +1,5 @@
+from sys_path_hacks.warn import warn_deprecated_import
+
+warn_deprecated_import('cms.djangoapps', 'contentstore.views.tests.test_header_menu')
+
+from cms.djangoapps.contentstore.views.tests.test_header_menu import *

--- a/sys_path_hacks/cms/contentstore/views/tests/test_helpers.py
+++ b/sys_path_hacks/cms/contentstore/views/tests/test_helpers.py
@@ -1,0 +1,5 @@
+from sys_path_hacks.warn import warn_deprecated_import
+
+warn_deprecated_import('cms.djangoapps', 'contentstore.views.tests.test_helpers')
+
+from cms.djangoapps.contentstore.views.tests.test_helpers import *

--- a/sys_path_hacks/cms/contentstore/views/tests/test_import_export.py
+++ b/sys_path_hacks/cms/contentstore/views/tests/test_import_export.py
@@ -1,0 +1,5 @@
+from sys_path_hacks.warn import warn_deprecated_import
+
+warn_deprecated_import('cms.djangoapps', 'contentstore.views.tests.test_import_export')
+
+from cms.djangoapps.contentstore.views.tests.test_import_export import *

--- a/sys_path_hacks/cms/contentstore/views/tests/test_item.py
+++ b/sys_path_hacks/cms/contentstore/views/tests/test_item.py
@@ -1,0 +1,5 @@
+from sys_path_hacks.warn import warn_deprecated_import
+
+warn_deprecated_import('cms.djangoapps', 'contentstore.views.tests.test_item')
+
+from cms.djangoapps.contentstore.views.tests.test_item import *

--- a/sys_path_hacks/cms/contentstore/views/tests/test_library.py
+++ b/sys_path_hacks/cms/contentstore/views/tests/test_library.py
@@ -1,0 +1,5 @@
+from sys_path_hacks.warn import warn_deprecated_import
+
+warn_deprecated_import('cms.djangoapps', 'contentstore.views.tests.test_library')
+
+from cms.djangoapps.contentstore.views.tests.test_library import *

--- a/sys_path_hacks/cms/contentstore/views/tests/test_organizations.py
+++ b/sys_path_hacks/cms/contentstore/views/tests/test_organizations.py
@@ -1,0 +1,5 @@
+from sys_path_hacks.warn import warn_deprecated_import
+
+warn_deprecated_import('cms.djangoapps', 'contentstore.views.tests.test_organizations')
+
+from cms.djangoapps.contentstore.views.tests.test_organizations import *

--- a/sys_path_hacks/cms/contentstore/views/tests/test_preview.py
+++ b/sys_path_hacks/cms/contentstore/views/tests/test_preview.py
@@ -1,0 +1,5 @@
+from sys_path_hacks.warn import warn_deprecated_import
+
+warn_deprecated_import('cms.djangoapps', 'contentstore.views.tests.test_preview')
+
+from cms.djangoapps.contentstore.views.tests.test_preview import *

--- a/sys_path_hacks/cms/contentstore/views/tests/test_tabs.py
+++ b/sys_path_hacks/cms/contentstore/views/tests/test_tabs.py
@@ -1,0 +1,5 @@
+from sys_path_hacks.warn import warn_deprecated_import
+
+warn_deprecated_import('cms.djangoapps', 'contentstore.views.tests.test_tabs')
+
+from cms.djangoapps.contentstore.views.tests.test_tabs import *

--- a/sys_path_hacks/cms/contentstore/views/tests/test_textbooks.py
+++ b/sys_path_hacks/cms/contentstore/views/tests/test_textbooks.py
@@ -1,0 +1,5 @@
+from sys_path_hacks.warn import warn_deprecated_import
+
+warn_deprecated_import('cms.djangoapps', 'contentstore.views.tests.test_textbooks')
+
+from cms.djangoapps.contentstore.views.tests.test_textbooks import *

--- a/sys_path_hacks/cms/contentstore/views/tests/test_transcript_settings.py
+++ b/sys_path_hacks/cms/contentstore/views/tests/test_transcript_settings.py
@@ -1,0 +1,5 @@
+from sys_path_hacks.warn import warn_deprecated_import
+
+warn_deprecated_import('cms.djangoapps', 'contentstore.views.tests.test_transcript_settings')
+
+from cms.djangoapps.contentstore.views.tests.test_transcript_settings import *

--- a/sys_path_hacks/cms/contentstore/views/tests/test_transcripts.py
+++ b/sys_path_hacks/cms/contentstore/views/tests/test_transcripts.py
@@ -1,0 +1,5 @@
+from sys_path_hacks.warn import warn_deprecated_import
+
+warn_deprecated_import('cms.djangoapps', 'contentstore.views.tests.test_transcripts')
+
+from cms.djangoapps.contentstore.views.tests.test_transcripts import *

--- a/sys_path_hacks/cms/contentstore/views/tests/test_unit_page.py
+++ b/sys_path_hacks/cms/contentstore/views/tests/test_unit_page.py
@@ -1,0 +1,5 @@
+from sys_path_hacks.warn import warn_deprecated_import
+
+warn_deprecated_import('cms.djangoapps', 'contentstore.views.tests.test_unit_page')
+
+from cms.djangoapps.contentstore.views.tests.test_unit_page import *

--- a/sys_path_hacks/cms/contentstore/views/tests/test_user.py
+++ b/sys_path_hacks/cms/contentstore/views/tests/test_user.py
@@ -1,0 +1,5 @@
+from sys_path_hacks.warn import warn_deprecated_import
+
+warn_deprecated_import('cms.djangoapps', 'contentstore.views.tests.test_user')
+
+from cms.djangoapps.contentstore.views.tests.test_user import *

--- a/sys_path_hacks/cms/contentstore/views/tests/test_videos.py
+++ b/sys_path_hacks/cms/contentstore/views/tests/test_videos.py
@@ -1,0 +1,5 @@
+from sys_path_hacks.warn import warn_deprecated_import
+
+warn_deprecated_import('cms.djangoapps', 'contentstore.views.tests.test_videos')
+
+from cms.djangoapps.contentstore.views.tests.test_videos import *

--- a/sys_path_hacks/cms/contentstore/views/tests/utils.py
+++ b/sys_path_hacks/cms/contentstore/views/tests/utils.py
@@ -1,0 +1,5 @@
+from sys_path_hacks.warn import warn_deprecated_import
+
+warn_deprecated_import('cms.djangoapps', 'contentstore.views.tests.utils')
+
+from cms.djangoapps.contentstore.views.tests.utils import *

--- a/sys_path_hacks/cms/contentstore/views/transcript_settings.py
+++ b/sys_path_hacks/cms/contentstore/views/transcript_settings.py
@@ -1,0 +1,5 @@
+from sys_path_hacks.warn import warn_deprecated_import
+
+warn_deprecated_import('cms.djangoapps', 'contentstore.views.transcript_settings')
+
+from cms.djangoapps.contentstore.views.transcript_settings import *

--- a/sys_path_hacks/cms/contentstore/views/transcripts_ajax.py
+++ b/sys_path_hacks/cms/contentstore/views/transcripts_ajax.py
@@ -1,0 +1,5 @@
+from sys_path_hacks.warn import warn_deprecated_import
+
+warn_deprecated_import('cms.djangoapps', 'contentstore.views.transcripts_ajax')
+
+from cms.djangoapps.contentstore.views.transcripts_ajax import *

--- a/sys_path_hacks/cms/contentstore/views/user.py
+++ b/sys_path_hacks/cms/contentstore/views/user.py
@@ -1,0 +1,5 @@
+from sys_path_hacks.warn import warn_deprecated_import
+
+warn_deprecated_import('cms.djangoapps', 'contentstore.views.user')
+
+from cms.djangoapps.contentstore.views.user import *

--- a/sys_path_hacks/cms/contentstore/views/videos.py
+++ b/sys_path_hacks/cms/contentstore/views/videos.py
@@ -1,0 +1,5 @@
+from sys_path_hacks.warn import warn_deprecated_import
+
+warn_deprecated_import('cms.djangoapps', 'contentstore.views.videos')
+
+from cms.djangoapps.contentstore.views.videos import *

--- a/sys_path_hacks/cms/course_creators/__init__.py
+++ b/sys_path_hacks/cms/course_creators/__init__.py
@@ -1,0 +1,5 @@
+from sys_path_hacks.warn import warn_deprecated_import
+
+warn_deprecated_import('cms.djangoapps', 'course_creators')
+
+from cms.djangoapps.course_creators import *

--- a/sys_path_hacks/cms/course_creators/admin.py
+++ b/sys_path_hacks/cms/course_creators/admin.py
@@ -1,0 +1,5 @@
+from sys_path_hacks.warn import warn_deprecated_import
+
+warn_deprecated_import('cms.djangoapps', 'course_creators.admin')
+
+from cms.djangoapps.course_creators.admin import *

--- a/sys_path_hacks/cms/course_creators/apps.py
+++ b/sys_path_hacks/cms/course_creators/apps.py
@@ -1,0 +1,5 @@
+from sys_path_hacks.warn import warn_deprecated_import
+
+warn_deprecated_import('cms.djangoapps', 'course_creators.apps')
+
+from cms.djangoapps.course_creators.apps import *

--- a/sys_path_hacks/cms/course_creators/models.py
+++ b/sys_path_hacks/cms/course_creators/models.py
@@ -1,0 +1,5 @@
+from sys_path_hacks.warn import warn_deprecated_import
+
+warn_deprecated_import('cms.djangoapps', 'course_creators.models')
+
+from cms.djangoapps.course_creators.models import *

--- a/sys_path_hacks/cms/course_creators/tests/__init__.py
+++ b/sys_path_hacks/cms/course_creators/tests/__init__.py
@@ -1,0 +1,5 @@
+from sys_path_hacks.warn import warn_deprecated_import
+
+warn_deprecated_import('cms.djangoapps', 'course_creators.tests')
+
+from cms.djangoapps.course_creators.tests import *

--- a/sys_path_hacks/cms/course_creators/tests/test_admin.py
+++ b/sys_path_hacks/cms/course_creators/tests/test_admin.py
@@ -1,0 +1,5 @@
+from sys_path_hacks.warn import warn_deprecated_import
+
+warn_deprecated_import('cms.djangoapps', 'course_creators.tests.test_admin')
+
+from cms.djangoapps.course_creators.tests.test_admin import *

--- a/sys_path_hacks/cms/course_creators/tests/test_views.py
+++ b/sys_path_hacks/cms/course_creators/tests/test_views.py
@@ -1,0 +1,5 @@
+from sys_path_hacks.warn import warn_deprecated_import
+
+warn_deprecated_import('cms.djangoapps', 'course_creators.tests.test_views')
+
+from cms.djangoapps.course_creators.tests.test_views import *

--- a/sys_path_hacks/cms/course_creators/views.py
+++ b/sys_path_hacks/cms/course_creators/views.py
@@ -1,0 +1,5 @@
+from sys_path_hacks.warn import warn_deprecated_import
+
+warn_deprecated_import('cms.djangoapps', 'course_creators.views')
+
+from cms.djangoapps.course_creators.views import *

--- a/sys_path_hacks/cms/maintenance/__init__.py
+++ b/sys_path_hacks/cms/maintenance/__init__.py
@@ -1,0 +1,5 @@
+from sys_path_hacks.warn import warn_deprecated_import
+
+warn_deprecated_import('cms.djangoapps', 'maintenance')
+
+from cms.djangoapps.maintenance import *

--- a/sys_path_hacks/cms/maintenance/apps.py
+++ b/sys_path_hacks/cms/maintenance/apps.py
@@ -1,0 +1,5 @@
+from sys_path_hacks.warn import warn_deprecated_import
+
+warn_deprecated_import('cms.djangoapps', 'maintenance.apps')
+
+from cms.djangoapps.maintenance.apps import *

--- a/sys_path_hacks/cms/maintenance/tests.py
+++ b/sys_path_hacks/cms/maintenance/tests.py
@@ -1,0 +1,5 @@
+from sys_path_hacks.warn import warn_deprecated_import
+
+warn_deprecated_import('cms.djangoapps', 'maintenance.tests')
+
+from cms.djangoapps.maintenance.tests import *

--- a/sys_path_hacks/cms/maintenance/urls.py
+++ b/sys_path_hacks/cms/maintenance/urls.py
@@ -1,0 +1,5 @@
+from sys_path_hacks.warn import warn_deprecated_import
+
+warn_deprecated_import('cms.djangoapps', 'maintenance.urls')
+
+from cms.djangoapps.maintenance.urls import *

--- a/sys_path_hacks/cms/maintenance/views.py
+++ b/sys_path_hacks/cms/maintenance/views.py
@@ -1,0 +1,5 @@
+from sys_path_hacks.warn import warn_deprecated_import
+
+warn_deprecated_import('cms.djangoapps', 'maintenance.views')
+
+from cms.djangoapps.maintenance.views import *

--- a/sys_path_hacks/cms/models/__init__.py
+++ b/sys_path_hacks/cms/models/__init__.py
@@ -1,0 +1,5 @@
+from sys_path_hacks.warn import warn_deprecated_import
+
+warn_deprecated_import('cms.djangoapps', 'models')
+
+from cms.djangoapps.models import *

--- a/sys_path_hacks/cms/models/settings/__init__.py
+++ b/sys_path_hacks/cms/models/settings/__init__.py
@@ -1,0 +1,5 @@
+from sys_path_hacks.warn import warn_deprecated_import
+
+warn_deprecated_import('cms.djangoapps', 'models.settings')
+
+from cms.djangoapps.models.settings import *

--- a/sys_path_hacks/cms/models/settings/course_grading.py
+++ b/sys_path_hacks/cms/models/settings/course_grading.py
@@ -1,0 +1,5 @@
+from sys_path_hacks.warn import warn_deprecated_import
+
+warn_deprecated_import('cms.djangoapps', 'models.settings.course_grading')
+
+from cms.djangoapps.models.settings.course_grading import *

--- a/sys_path_hacks/cms/models/settings/course_metadata.py
+++ b/sys_path_hacks/cms/models/settings/course_metadata.py
@@ -1,0 +1,5 @@
+from sys_path_hacks.warn import warn_deprecated_import
+
+warn_deprecated_import('cms.djangoapps', 'models.settings.course_metadata')
+
+from cms.djangoapps.models.settings.course_metadata import *

--- a/sys_path_hacks/cms/models/settings/encoder.py
+++ b/sys_path_hacks/cms/models/settings/encoder.py
@@ -1,0 +1,5 @@
+from sys_path_hacks.warn import warn_deprecated_import
+
+warn_deprecated_import('cms.djangoapps', 'models.settings.encoder')
+
+from cms.djangoapps.models.settings.encoder import *

--- a/sys_path_hacks/cms/models/settings/tests/test_settings.py
+++ b/sys_path_hacks/cms/models/settings/tests/test_settings.py
@@ -1,0 +1,5 @@
+from sys_path_hacks.warn import warn_deprecated_import
+
+warn_deprecated_import('cms.djangoapps', 'models.settings.tests.test_settings')
+
+from cms.djangoapps.models.settings.tests.test_settings import *

--- a/sys_path_hacks/cms/models/settings/waffle.py
+++ b/sys_path_hacks/cms/models/settings/waffle.py
@@ -1,0 +1,5 @@
+from sys_path_hacks.warn import warn_deprecated_import
+
+warn_deprecated_import('cms.djangoapps', 'models.settings.waffle')
+
+from cms.djangoapps.models.settings.waffle import *

--- a/sys_path_hacks/cms/pipeline_js/__init__.py
+++ b/sys_path_hacks/cms/pipeline_js/__init__.py
@@ -1,0 +1,5 @@
+from sys_path_hacks.warn import warn_deprecated_import
+
+warn_deprecated_import('cms.djangoapps', 'pipeline_js')
+
+from cms.djangoapps.pipeline_js import *

--- a/sys_path_hacks/cms/pipeline_js/utils.py
+++ b/sys_path_hacks/cms/pipeline_js/utils.py
@@ -1,0 +1,5 @@
+from sys_path_hacks.warn import warn_deprecated_import
+
+warn_deprecated_import('cms.djangoapps', 'pipeline_js.utils')
+
+from cms.djangoapps.pipeline_js.utils import *

--- a/sys_path_hacks/cms/xblock_config/__init__.py
+++ b/sys_path_hacks/cms/xblock_config/__init__.py
@@ -1,0 +1,5 @@
+from sys_path_hacks.warn import warn_deprecated_import
+
+warn_deprecated_import('cms.djangoapps', 'xblock_config')
+
+from cms.djangoapps.xblock_config import *

--- a/sys_path_hacks/cms/xblock_config/admin.py
+++ b/sys_path_hacks/cms/xblock_config/admin.py
@@ -1,0 +1,5 @@
+from sys_path_hacks.warn import warn_deprecated_import
+
+warn_deprecated_import('cms.djangoapps', 'xblock_config.admin')
+
+from cms.djangoapps.xblock_config.admin import *

--- a/sys_path_hacks/cms/xblock_config/apps.py
+++ b/sys_path_hacks/cms/xblock_config/apps.py
@@ -1,0 +1,5 @@
+from sys_path_hacks.warn import warn_deprecated_import
+
+warn_deprecated_import('cms.djangoapps', 'xblock_config.apps')
+
+from cms.djangoapps.xblock_config.apps import *

--- a/sys_path_hacks/cms/xblock_config/forms.py
+++ b/sys_path_hacks/cms/xblock_config/forms.py
@@ -1,0 +1,5 @@
+from sys_path_hacks.warn import warn_deprecated_import
+
+warn_deprecated_import('cms.djangoapps', 'xblock_config.forms')
+
+from cms.djangoapps.xblock_config.forms import *

--- a/sys_path_hacks/cms/xblock_config/models.py
+++ b/sys_path_hacks/cms/xblock_config/models.py
@@ -1,0 +1,5 @@
+from sys_path_hacks.warn import warn_deprecated_import
+
+warn_deprecated_import('cms.djangoapps', 'xblock_config.models')
+
+from cms.djangoapps.xblock_config.models import *

--- a/sys_path_hacks/cms/xblock_config/tests/__init__.py
+++ b/sys_path_hacks/cms/xblock_config/tests/__init__.py
@@ -1,0 +1,5 @@
+from sys_path_hacks.warn import warn_deprecated_import
+
+warn_deprecated_import('cms.djangoapps', 'xblock_config.tests')
+
+from cms.djangoapps.xblock_config.tests import *

--- a/sys_path_hacks/cms/xblock_config/tests/test_models.py
+++ b/sys_path_hacks/cms/xblock_config/tests/test_models.py
@@ -1,0 +1,5 @@
+from sys_path_hacks.warn import warn_deprecated_import
+
+warn_deprecated_import('cms.djangoapps', 'xblock_config.tests.test_models')
+
+from cms.djangoapps.xblock_config.tests.test_models import *

--- a/sys_path_hacks/un_sys_path.sh
+++ b/sys_path_hacks/un_sys_path.sh
@@ -5,7 +5,7 @@
 #   ....
 #   ~/edx-platform>
 
-# Shellchecks recommends using search/replace instead of sed. It's fine as is.
+# Shellcheck recommends using search/replace instead of sed. It's fine as is.
 # shellcheck disable=SC2001
 
 set -e
@@ -21,6 +21,10 @@ for path in $(find "${TARGET}/djangoapps/" -name '*.py' | grep -v migrations); d
     if [[ "$path" == "lms/djangoapps/courseware/management/commands/import.py" ]]; then
         # Skip this file because its name is problematic for the sys path hack.
         # We've gone to prod with this excluded, and it hasn't been a problem.
+        continue
+    fi
+    if [[ "$path" == "cms/djangoapps/contentstore/management/commands/import.py" ]]; then
+        # Also skip this file because its name is problematic for the sys path hack.
         continue
     fi
     new_path=$(echo "$path" | sed "s#${TARGET}/djangoapps/#sys_path_hacks/${TARGET}/#")


### PR DESCRIPTION
## Overview

This PR brings the work of https://github.com/edx/edx-platform/pull/24616 to the in the `cms/djangoapps` packages. 

The overarching purpose of this: We want to remove the modification of `sys.path`--the Python module search path--from edx-platform, as it is confusing for both developers and, more critically, many tools that we might like to use to de-BOMify edx-platform such as `import-linter`. This means that all instances of `from my_cms_app.x import y` will need to be replaced with `from cms.djangoapps.my_cms_app.x import y`. See [Cale's ADR](https://github.com/edx/edx-platform/blob/master/docs/decisions/0007-sys-path-modification-removal.rst) for more details. 

Generally speaking, this just does tofor`cms/djangoapps` what https://github.com/edx/edx-platform/pull/24616 PR did for `lms/djangoapps`. After this merges, `common/djangoapps` will be the only folder subject to the original sys.path injection.

This PR is best reviewed commit-by-commit.

## Commits

### Switch cms/ sys.path modification to use sys_path_hacks/

Instead of appending `cms/djangoapps` to sys.path, we append `sys_path_hacks/cms` to sys.path. The `sys_path_hacks/cms` structure will mirror the `cms/djangoapps` directory structure, except that each module just warns that a deprecated import style is being used and then wildcard-imports the actual module in `cms/djangoapps/`.

Generally speaking, this change is a no-op, aside from the dozens of new `SysPathHackWarnings` it will generate. Functionally, some things break with the `sys_path_hacks/` directory approach, specifically those that involve:
* App names.
* `@patch`
* `__init__.py`s that wildcard-import in the contents of their modules to create a flat interface.

These three cases are resolved by the other commits in this PR. The rest of the deprecated imports can be handled in later PRs.

### Generate sys_path_hacks/ modules for cms/djangoapps

This runs the `sys_path_hacks/un_sys_path.sh cms` script to populate `sys_path_hacks`. I've put it in its own commit as it's largely unintereting.

### Identify all cms djangoapps using 'cms.djangoapps.{app_name}'

As previously stated, Django app "names" don't get translated by the `sys_path_hacks` shim, so we need to identify all apps using the fully-qualified names.

### Patch 'cms.djangoapps.{app_name}...' instead of '{app_name}...'

Patches also don't play nice with the `sys_path_hacks` shim, so we update all unit tests to patch using the fully-qualified names.

### Fix imports of contentstore.* within cms/djangoapps/contentstore/views

The module `cms.djangoapps/views.__init__` uses wildcard imports to pull in modules from all its sub-packages, which is cool, but doesn't work through `sys_path_hacks/`. So, within `cms.djangoapps.contentstore.views`, we switch everything to either fully-qualified (`from cms.djangoapps.my_cms_app...`) imports or relative (`from ..views...`) imports, both of which work fine.

### Fix imports of contentstore.views.* within all of cms/

Same reasoning as above, except now we are fixing all imports *of* `cms.djangoapps.contentstore.views`.

### Fully prefix cms.djangoapps.* imports in test_course_settings

This seemed to fix some tests failures. Not exactly sure why it's necessary, but I don't see a reason to revert it. Probably another weird case with patching.

### Break lines that are now too long because of full app names

Lines got longer; fix the ones >=120 chars.

### Sort all imports in cms/djangoapps/ 

Use `isort --recursive cms/djangoapps/` to fix all the imports that are now in a silly order.