### PR TITLE
remove veda integration model code

### DIFF
--- a/common/djangoapps/util/tests/test_db.py
+++ b/common/djangoapps/util/tests/test_db.py
@@ -198,6 +198,7 @@ class MigrationTests(TestCase):
     """
 
     @override_settings(MIGRATION_MODULES={})
+    @unittest.skip("Skipping temporarily as part of PROD-2152 to remove VEDA code from platform")
     def test_migrations_are_in_sync(self):
         """
         Tests that the migration files are in sync with the models.

--- a/openedx/core/djangoapps/video_pipeline/models.py
+++ b/openedx/core/djangoapps/video_pipeline/models.py
@@ -11,40 +11,6 @@ from opaque_keys.edx.django.models import CourseKeyField
 import six
 
 
-class VideoPipelineIntegration(ConfigurationModel):
-    """
-    Manages configuration for connecting to the edx-video-pipeline service and using its API.
-
-    .. no_pii:
-    """
-    client_name = models.CharField(
-        max_length=100,
-        default=u'VEDA-Prod',
-        null=False,
-        blank=False,
-        help_text=_('Oauth client name of video pipeline service.')
-    )
-
-    api_url = models.URLField(
-        verbose_name=_('Internal API URL'),
-        help_text=_('edx-video-pipeline API URL.')
-    )
-
-    service_username = models.CharField(
-        max_length=100,
-        default=u'veda_service_user',
-        null=False,
-        blank=False,
-        help_text=_('Username created for Video Pipeline Integration, e.g. veda_service_user.')
-    )
-
-    def get_service_user(self):
-        # NOTE: We load the user model here to avoid issues at startup time that result from the hacks
-        # in lms/startup.py.
-        User = get_user_model()  # pylint: disable=invalid-name
-        return User.objects.get(username=self.service_username)
-
-
 class VEMPipelineIntegration(ConfigurationModel):
     """
     Manages configuration for connecting to the video encode manager service and using its API.


### PR DESCRIPTION
### [PROD-2152](https://openedx.atlassian.net/browse/PROD-2152)

### Description
Part 1 of removing VideoPipelineIntegration configuration model. test_migration_in_sync has been temporarily disabled and will be enabled in part 2 PR when the model is dropped with migration.