### PR TITLE
add missing app blackboard

### DIFF
--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -1662,6 +1662,7 @@ OPTIONAL_APPS = (
     ('integrated_channels.sap_success_factors', None),
     ('integrated_channels.xapi', None),
     ('integrated_channels.cornerstone', None),
+    ('integrated_channels.blackboard', None),
     ('integrated_channels.canvas', None),
     ('integrated_channels.moodle', None),
 )

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -3348,6 +3348,7 @@ OPTIONAL_APPS = [
     ('integrated_channels.sap_success_factors', None),
     ('integrated_channels.cornerstone', None),
     ('integrated_channels.xapi', None),
+    ('integrated_channels.blackboard', None),
     ('integrated_channels.canvas', None),
     ('integrated_channels.moodle', None),
 


### PR DESCRIPTION
This failed builds due to prior merge https://github.com/edx/edx-platform/pull/25215 where I did not add the app to platform, while merging in the new channel, but added urls that were registered to django