### PR TITLE
log grade policy changes

### DIFF
--- a/cms/djangoapps/contentstore/signals/handlers.py
+++ b/cms/djangoapps/contentstore/signals/handlers.py
@@ -34,6 +34,8 @@ def locked(expiry_seconds, key):
             if cache.add(cache_key, "true", expiry_seconds):
                 log.info(u'Locking task in cache with key: %s for %s seconds', cache_key, expiry_seconds)
                 return func(*args, **kwargs)
+            else:
+                log.info('Task with key %s already exists in cache', cache_key)
         return wrapper
     return task_decorator
 

--- a/cms/djangoapps/models/settings/course_grading.py
+++ b/cms/djangoapps/models/settings/course_grading.py
@@ -92,12 +92,11 @@ class CourseGradingModel(object):
         descriptor = modulestore().get_course(course_key)
         new_grading_policy_hash = six.text_type(hash_grading_policy(descriptor.grading_policy))
         log.info(
-            "Updated course grading policy for course %s from %s to %s. fire_signal = %s" % (
-                six.text_type(course_key),
-                previous_grading_policy_hash,
-                new_grading_policy_hash,
-                fire_signal
-            )
+            "Updated course grading policy for course %s from %s to %s. fire_signal = %s",
+            six.text_type(course_key),
+            previous_grading_policy_hash,
+            new_grading_policy_hash,
+            fire_signal
         )
 
         if fire_signal:
@@ -178,12 +177,11 @@ class CourseGradingModel(object):
         descriptor = modulestore().get_course(course_key)
         new_grading_policy_hash = six.text_type(hash_grading_policy(descriptor.grading_policy))
         log.info(
-            "Updated grader for course %s. Grading policy has changed from %s to %s. fire_signal = %s" % (
-                six.text_type(course_key),
-                previous_grading_policy_hash,
-                new_grading_policy_hash,
-                fire_signal
-            )
+            "Updated grader for course %s. Grading policy has changed from %s to %s. fire_signal = %s",
+            six.text_type(course_key),
+            previous_grading_policy_hash,
+            new_grading_policy_hash,
+            fire_signal
         )
         if fire_signal:
             _grading_event_and_signal(course_key, user.id)


### PR DESCRIPTION
I wanted to add some logging after doing the research for https://openedx.atlassian.net/browse/EDUCATOR-5352. This is that logging.

I'm fairly sure that the issue is not actually with fire_signal, and instead is due to the `@locked`, but hey, more logs never hurt anyone
@edx/masters-devs-gta 
## Note ##
I also removed `update_from_json_selective` because I realized that it is no longer ever used