### PR TITLE
Add new password reset endpoint for logistration MFE.

### DIFF
--- a/openedx/core/djangoapps/user_authn/urls_common.py
+++ b/openedx/core/djangoapps/user_authn/urls_common.py
@@ -63,9 +63,17 @@ urlpatterns = [
         name='password_reset_confirm',
     ),
     url(r'^account/password$', password_reset.password_change_request_handler, name='password_change_request'),
+
+    # logistration MFE flow
     url(r'^user_api/v1/account/password_reset/token/validate/$', password_reset.password_reset_token_validate,
         name="user_api_password_reset_token_validate"),
 
+    # logistration MFE reset flow
+    url(
+        r'^password/reset/(?P<uidb36>[0-9A-Za-z]+)-(?P<token>.+)/$',
+        password_reset.password_reset_logistration,
+        name='logistration_password_reset',
+    ),
 ]
 
 # password reset django views (see above for password reset views)


### PR DESCRIPTION
Current password reset views have too much extra logic, which is not needed for our logistration MFE usage.
Secondly existing implementation uses backend template rendering for success or other user messages. As now the rendering and messaging is moved to client side, we need to avoid getting rendered templates to be available to our frontend.

VAN-88