### PR TITLE
EDUCATOR-5150: prevent max_team_size from exceeding 500

### DIFF
--- a/cms/djangoapps/models/settings/course_metadata.py
+++ b/cms/djangoapps/models/settings/course_metadata.py
@@ -295,9 +295,13 @@ class CourseMetadata(object):
             return errors
 
         proposed_max_team_size = json_value.get('max_team_size')
-        if proposed_max_team_size != '' and proposed_max_team_size is not None and proposed_max_team_size <= 0:
-            message = 'max_team_size must be greater than zero'
-            errors.append({'key': 'teams_configuration', 'message': message, 'model': teams_configuration_model})
+        if proposed_max_team_size != '' and proposed_max_team_size is not None:
+            if proposed_max_team_size <= 0:
+                message = 'max_team_size must be greater than zero'
+                errors.append({'key': 'teams_configuration', 'message': message, 'model': teams_configuration_model})
+            elif proposed_max_team_size > 500:
+                message = 'max_team_size cannot be greater than 500'
+                errors.append({'key': 'teams_configuration', 'message': message, 'model': teams_configuration_model})
 
         proposed_topics = json_value.get('topics')
 
@@ -343,8 +347,11 @@ class CourseMetadata(object):
             if teamset_type not in valid_teamset_types:
                 error_list.append('type ' + teamset_type + " is invalid")
         max_team_size = topic_settings.get('max_team_size', {})
-        if max_team_size and max_team_size <= 0:
-            error_list.append('max_team_size must be greater than zero')
+        if max_team_size:
+            if max_team_size <= 0:
+                error_list.append('max_team_size must be greater than zero')
+            elif max_team_size > 500:
+                error_list.append('max_team_size cannot be greater than 500')
         teamset_id = topic_settings.get('id', {})
         if not teamset_id:
             error_list.append('id attribute must not be empty')

--- a/cms/djangoapps/models/settings/tests/test_settings.py
+++ b/cms/djangoapps/models/settings/tests/test_settings.py
@@ -359,6 +359,40 @@ config_block_no_global_max_team_size = {
     }
 }
 
+config_block_course_max_team_size = {
+    "teams_configuration": {
+        "value": {
+            "max_team_size": 501,
+            "topics": [
+                {
+                    "max_team_size": 500,
+                    "name": "Topic 1 Name",
+                    "id": "topic_1_id",
+                    "description": "Topic 1 desc",
+                    "type": "public_managed"
+                },
+            ]
+        }
+    }
+}
+
+config_block_teamset_max_team_size = {
+    "teams_configuration": {
+        "value": {
+            "max_team_size": 500,
+            "topics": [
+                {
+                    "max_team_size": 501,
+                    "name": "Topic 1 Name",
+                    "id": "topic_1_id",
+                    "description": "Topic 1 desc",
+                    "type": "public_managed"
+                },
+            ]
+        }
+    }
+}
+
 
 @ddt.ddt
 class TeamsConfigurationTests(unittest.TestCase):
@@ -378,7 +412,9 @@ class TeamsConfigurationTests(unittest.TestCase):
         (config_block_missing_name, {'name attribute must not be empty'}),
         (config_block_extra_attribute, {'extra keys: foo'}),
         (config_block_unrecognized_teamset_type, {'type foo is invalid'}),
-        (config_block_no_global_max_team_size, set())
+        (config_block_no_global_max_team_size, set()),
+        (config_block_course_max_team_size, {'max_team_size cannot be greater than 500'}),
+        (config_block_teamset_max_team_size, {'max_team_size cannot be greater than 500'})
     )
     @ddt.unpack
     def test_team_settings(self, config_block, error_message):


### PR DESCRIPTION
[EDUCATOR-5150](https://openedx.atlassian.net/browse/EDUCATOR-5150)

When checking for teams_configuration validity, make sure no max_team_size value is greater than 500.

@edx/masters-devs-gta 