### PR TITLE
Change data-language format to ISO639-1

### DIFF
--- a/lms/djangoapps/courseware/date_summary.py
+++ b/lms/djangoapps/courseware/date_summary.py
@@ -194,7 +194,7 @@ class DateSummary(object):
 
         Note: this returns a span that will be localized on the client.
         """
-        locale = to_locale(get_language())
+        locale = get_language()
         user_timezone = user_timezone_locale_prefs(crum.get_current_request())['user_timezone']
         return HTML(
             u'<span class="date localized-datetime" data-format="{date_format}" data-datetime="{date_time}"'


### PR DESCRIPTION
data-language property should be an ISO 639-1 language code (e.g. 'en-US', 'fa-IR')
otherwise `DateUtils.localize` would not do its job.
Check [this document](https://ui-toolkit.edx.org/utilities/date-utils/) under `DateUtils.localize`'s required parameters.
