### PR TITLE
[BD-14] Improve schema support for content library indexes

### DIFF
--- a/openedx/core/djangoapps/content_libraries/management/commands/reindex_content_library.py
+++ b/openedx/core/djangoapps/content_libraries/management/commands/reindex_content_library.py
@@ -58,24 +58,68 @@ class Command(BaseCommand):
     def handle(self, *args, **options):
         if options['clear-all']:
             if options['force'] or query_yes_no(self.CONFIRMATION_PROMPT_CLEAR, default="no"):
-                logging.info("Removing all libraries from the index")
-                ContentLibraryIndexer.remove_all_items()
-                LibraryBlockIndexer.remove_all_items()
+                self.clear_all()
             return
 
         if options['all']:
             if options['force'] or query_yes_no(self.CONFIRMATION_PROMPT_ALL, default="no"):
                 logging.info("Indexing all libraries")
-                library_keys = [library.library_key for library in ContentLibrary.objects.all()]
+                library_ids = [str(library.library_key) for library in ContentLibrary.objects.all()]
+                self.index_libraries(library_ids, True)
             else:
                 return
         else:
-            logging.info("Indexing libraries: {}".format(options['library_ids']))
-            library_keys = list(map(LibraryLocatorV2.from_string, options['library_ids']))
+            self.index_libraries(options['library_ids'])
+            return
 
-        ContentLibraryIndexer.index_items(library_keys)
+    def clear_all(self):
+        """
+        Remove all library and block indexes
+        """
+        logging.info("Removing all xblocks from the index")
+        LibraryBlockIndexer.remove_all_items()
+        logging.info("Removing all libraries from the index")
+        ContentLibraryIndexer.remove_all_items()
 
-        for library_key in library_keys:
+    def index_libraries(self, library_ids, remove_stale_libraries=False):
+        """
+        Index the given libraries and their blocks
+        """
+        logging.info("Indexing libraries {}".format(', '.join(library_ids)))
+        ContentLibraryIndexer.index_items(library_ids)
+
+        for library_id in library_ids:
+            library_key = LibraryLocatorV2.from_string(library_id)
             ref = ContentLibrary.objects.get_by_key(library_key)
             lib_bundle = LibraryBundle(library_key, ref.bundle_uuid, draft_name=DRAFT_NAME)
-            LibraryBlockIndexer.index_items(lib_bundle.get_all_usages())
+            block_ids = {str(block) for block in lib_bundle.get_all_usages()}
+
+            if block_ids:
+                logging.info("Indexing library {}'s blocks: {}".format(library_id, ', '.join(block_ids)))
+                LibraryBlockIndexer.index_items(block_ids)
+
+            # Remove stale blocks from the library's index
+            indexed_blocks = LibraryBlockIndexer.get_items(filter_terms={'library_key': [library_id]})
+            indexed_block_ids = {block['id'] for block in indexed_blocks}
+            blocks_to_unindex = indexed_block_ids.difference(block_ids)
+
+            if blocks_to_unindex:
+                logging.info("Unindex library {}'s deleted blocks: {}".format(library_id, ', '.join(blocks_to_unindex)))
+                LibraryBlockIndexer.remove_items(blocks_to_unindex)
+
+        if remove_stale_libraries:
+            indexed_libraries = ContentLibraryIndexer.get_items(filter_terms={})
+            indexed_library_ids = {library['id'] for library in indexed_libraries}
+            libraries_to_unindex = indexed_library_ids.difference(library_ids)
+
+            if libraries_to_unindex:
+                logging.info("Unindex deleted libraries: {}".format(', '.join(libraries_to_unindex)))
+                ContentLibraryIndexer.remove_items(libraries_to_unindex)
+
+                for library_id in libraries_to_unindex:
+                    # Remove all library's blocks from the index
+                    indexed_blocks = LibraryBlockIndexer.get_items(filter_terms={'library_key': [library_id]})
+                    if indexed_blocks:
+                        logging.info("Unindex deleted library {}'s blocks: {}".format(library_id,
+                                                                                      ','.join(libraries_to_unindex)))
+                        LibraryBlockIndexer.remove_items([block['id'] for block in indexed_blocks])

--- a/openedx/core/djangoapps/content_libraries/management/commands/tests/test_reindex_content_libary.py
+++ b/openedx/core/djangoapps/content_libraries/management/commands/tests/test_reindex_content_libary.py
@@ -1,0 +1,106 @@
+"""
+Unittests for reindex_content_library management command
+"""
+
+from django.conf import settings
+from django.core.management import CommandError, call_command
+from django.test import TestCase
+from django.test.utils import override_settings
+from opaque_keys.edx.locator import LibraryLocatorV2, LibraryUsageLocatorV2
+from search.search_engine_base import SearchEngine
+
+from openedx.core.djangoapps.content_libraries.api import _lookup_usage_key
+from openedx.core.djangoapps.content_libraries.constants import DRAFT_NAME
+from openedx.core.djangoapps.content_libraries.libraries_index import ContentLibraryIndexer, LibraryBlockIndexer
+from openedx.core.djangoapps.content_libraries.models import ContentLibrary
+from openedx.core.djangoapps.content_libraries.tests.base import ContentLibrariesRestApiTest, elasticsearch_test
+from openedx.core.lib.blockstore_api import (
+    get_or_create_bundle_draft,
+    write_draft_file,
+)
+
+
+@override_settings(FEATURES={**settings.FEATURES, 'ENABLE_CONTENT_LIBRARY_INDEX': True})
+@elasticsearch_test
+class TestReindex(ContentLibrariesRestApiTest):
+    """
+    Tests for the reindex_content_library command
+    """
+    @elasticsearch_test
+    def setUp(self, *args, **kwargs):
+        super().setUp()
+        ContentLibraryIndexer.remove_all_items()
+        LibraryBlockIndexer.remove_all_items()
+        self.searcher = SearchEngine.get_search_engine(ContentLibraryIndexer.INDEX_NAME)
+
+        self.lib1 = self._create_library(slug="{}-1".format(self._testMethodName), title="Title 1")['id']
+        self.lib2 = self._create_library(slug="{}-2".format(self._testMethodName), title="Title 2")['id']
+        self.lib3 = self._create_library(slug="{}-3".format(self._testMethodName), title="Title 3")['id']
+
+        self.block1 = self._add_block_to_library(self.lib1, "problem", "problem1")['id']
+        self.block2 = self._add_block_to_library(self.lib1, "problem", "problem2")['id']
+        self.block3 = self._add_block_to_library(self.lib2, "problem", "problem3")['id']
+
+    def test_clear_all(self):
+        """
+        Test that --clear-all option removes all indexes
+        """
+        self.assertNotEqual(len(LibraryBlockIndexer.get_items(filter_terms={})), 0)
+        self.assertNotEqual(len(ContentLibraryIndexer.get_items(filter_terms={})), 0)
+        call_command("reindex_content_library", clear_all=True, force=True)
+        self.assertEqual(len(ContentLibraryIndexer.get_items(filter_terms={})), 0)
+        self.assertEqual(len(LibraryBlockIndexer.get_items(filter_terms={})), 0)
+
+    def test_specific_items(self):
+        """
+        Test that specifying libraries to index doesn't index any other libraries/blocks
+        """
+        call_command("reindex_content_library", clear_all=True, force=True)
+        call_command("reindex_content_library", self.lib1, force=True)
+        self.assertEqual(len(ContentLibraryIndexer.get_items([self.lib1, self.lib2, self.lib3])), 1)
+        self.assertEqual(len(LibraryBlockIndexer.get_items([self.block1, self.block2, self.block3])), 2)
+
+    def test_all_items(self):
+        """
+        Test that --all indexes all libraries and blocks
+        """
+        call_command("reindex_content_library", clear_all=True, force=True)
+        call_command("reindex_content_library", all=True, force=True)
+        self.assertEqual(len(ContentLibraryIndexer.get_items([self.lib1, self.lib2, self.lib3])), 3)
+        self.assertEqual(len(LibraryBlockIndexer.get_items([self.block1, self.block2, self.block3])), 3)
+
+    def test_stale_removal(self):
+        """
+        Test that reindexing also removes stale indexes whose sources no longer exist
+        """
+        library_key_1 = LibraryLocatorV2.from_string(self.lib1)
+        library_1 = ContentLibrary.objects.get_by_key(library_key_1)
+        library_key_2 = LibraryLocatorV2.from_string(self.lib2)
+        library_2 = ContentLibrary.objects.get_by_key(library_key_2)
+
+        self.assertEqual(len(ContentLibraryIndexer.get_items([self.lib1, self.lib2, self.lib3])), 3)
+        self.assertEqual(len(LibraryBlockIndexer.get_items([self.block1, self.block2, self.block3])), 3)
+
+        # Delete a block without triggering index removal
+        def_key, lib_bundle = _lookup_usage_key(LibraryUsageLocatorV2.from_string(self.block1))
+        draft_uuid = get_or_create_bundle_draft(def_key.bundle_uuid, DRAFT_NAME).uuid
+        write_draft_file(draft_uuid, 'problem/problem1/definition.xml', contents=None)
+        lib_bundle.cache.clear()
+
+        # Reindex library 1
+        call_command("reindex_content_library", self.lib1, force=True)
+        # Verify that stale block index got removed
+        self.assertEqual(len(ContentLibraryIndexer.get_items([self.lib1, self.lib2, self.lib3])), 3)
+        self.assertEqual(len(LibraryBlockIndexer.get_items([self.block1, self.block2, self.block3])), 2)
+
+        library_1.delete()
+        # Reindexing with --all causes stale library indexes to be removed
+        call_command("reindex_content_library", all=True, force=True)
+        self.assertEqual(len(ContentLibraryIndexer.get_items([self.lib1, self.lib2, self.lib3])), 2)
+        self.assertEqual(len(LibraryBlockIndexer.get_items([self.block1, self.block2, self.block3])), 1)
+
+        library_2.delete()
+        # Reindexing specific libs doesn't remove stale library indexes
+        call_command("reindex_content_library", self.lib3, force=True)
+        self.assertEqual(len(ContentLibraryIndexer.get_items([self.lib1, self.lib2, self.lib3])), 2)
+        self.assertEqual(len(LibraryBlockIndexer.get_items([self.block1, self.block2, self.block3])), 1)


### PR DESCRIPTION
The elasticsearch indexes of content libraries include a `schema_version` field to enforce strong schema, but there was no support for easy migrations (upgrading `schema_version`) while ensuring blue-green deployment (two versions of the code accessing the same data simultaneously).

This PR ensures that as long as schema updates are done in a backward compatible manner (similar to [how they are done in SQL models][1]), migrations can be performed automatically in a pipeline while ensuring that no version of the code breaks in case of a blue-green deployment.

To do this, we modify the get() function in this way:
- If existing data's `schema_version` >= current code's `schema_version` - We use the data as-is as it [should be compatible][1].
- If existing data's `schema_version` < current code's `schema_version` - We refresh the index, in-effect upgrading the schema and then proceed to use that data.

This also improves `reindex_content_library` management command so that executing `reindex_content_library --all --force` in a migration file can upgrade content libraries in-place without being destructive.

**JIRA Ticket**: [BLENDED-619][3], [Opencraft/SE-3298][2]

**Testing Instructions**:

- From the blockstore directory, run `make testserver` to start a test-specific instance.
- From `make studio-shell` run: `EDXAPP_ENABLE_ELASTICSEARCH_FOR_TESTS=1 EDXAPP_RUN_BLOCKSTORE_TESTS=1 python -Wd -m pytest --ds=cms.envs.test openedx/core/djangoapps/content_libraries/tests/test_content_libraries.py openedx/core/djangoapps/content_libraries/tests/test_libraries_index.py openedx/core/djangoapps/content_libraries/management/commands/tests/test_reindex_content_libary.py`

In addition, you can play with updating `SCHEMA_VERSION` (increase/decrease) of the indexes and doing `./manage.py cms reindex_content_library --all --force`, while verifying that the indexes work as expected.

**Reviewers**:

- [ ] @arbrandes 
- [ ] @kdmccormick

[1]: https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations
[2]: https://tasks.opencraft.com/browse/SE-3298
[3]: https://openedx.atlassian.net/browse/BLENDED-619

[BLENDED-619]: https://openedx.atlassian.net/browse/BLENDED-619