### PR TITLE
Correct DemoX Code Grader solution

### DIFF
--- a/common/test/data/manual-testing-complete/problem/c2ee6e8917fe4c97ac99d7b616ff0b89.xml
+++ b/common/test/data/manual-testing-complete/problem/c2ee6e8917fe4c97ac99d7b616ff0b89.xml
@@ -73,7 +73,7 @@ while abs(balance) &gt; .02:
 
 # When the while loop terminates, we know we have 
 #  our answer!
-print ( "Lowest Payment:" + str( round(payment, 2) ) )
+print ( "Lowest Payment:", str( round(payment, 2) ) )
 </answer_display>
       <grader_payload>
 {"grader": "ps02/bisect/grade_bisect.py"}

--- a/common/test/data/manual-testing-complete/problem/c2ee6e8917fe4c97ac99d7b616ff0b89.xml
+++ b/common/test/data/manual-testing-complete/problem/c2ee6e8917fe4c97ac99d7b616ff0b89.xml
@@ -73,7 +73,7 @@ while abs(balance) &gt; .02:
 
 # When the while loop terminates, we know we have 
 #  our answer!
-print "Lowest Payment:", round(payment, 2)
+print ( "Lowest Payment:" + str( round(payment, 2) ) )
 </answer_display>
       <grader_payload>
 {"grader": "ps02/bisect/grade_bisect.py"}


### PR DESCRIPTION
the Show Answer button displays an answer that returns a SyntaxError:
invalid syntax

this commit corrects the print call by wrapping the int with str() for
proper type conversion and concatenates the sub strings inside parens