### PR TITLE
Suppress PII from discussion/forum

### DIFF
--- a/common/static/common/templates/discussion/templates.underscore
+++ b/common/static/common/templates/discussion/templates.underscore
@@ -59,7 +59,7 @@
         <% } %>
         <div class="post-header-content">
             <h<%- startHeader %> class="post-title"><%- title %></h<%- startHeader%>>
-            <p class="posted-details">
+            <p data-hj-suppress class="posted-details">
             <%
             var timeAgoHtml = interpolate(
                 '<span class="timeago" title="%(created_at)s">%(created_at)s</span>',
@@ -174,7 +174,7 @@
 </script>
 <script aria-hidden="true" type="text/template" id="thread-response-show-template">
 <header class="response-header">
-  <div class="response-header-content">
+  <div data-hj-suppress class="response-header-content">
     <%= HtmlUtils.HTML(author_display) %>
     <p class="posted-details">
         <span class="timeago" title="<%= HtmlUtils.HTML(created_at) %>"><%= HtmlUtils.HTML(created_at) %></span>

--- a/lms/djangoapps/discussion/templates/discussion/discussion_profile_page.html
+++ b/lms/djangoapps/discussion/templates/discussion/discussion_profile_page.html
@@ -48,7 +48,7 @@ from openedx.core.djangolib.js_utils import dump_js_escaped_json, js_escaped_str
             <div>
                 <h2 class="discussion-profile-title">${_("Discussion")}</h2>
                 <%def name="span(num)"><span class="discussion-count">${num}</span></%def>
-                <span class="user-name"><a href="${learner_profile_page_url}">${django_user.username}</a></span>
+                <span data-hj-suppress class="user-name"><a href="${learner_profile_page_url}">${django_user.username}</a></span>
                 <span class="discussion-profile-info">
                     <span class="user-roles">${", ".join(_(role_name) for role_name in django_user_roles)}</span>
                 </span>


### PR DESCRIPTION
Suppression done for **username** information in discussion tab and xmodule used inside the course content.

Ticket: [VAN-53](https://openedx.atlassian.net/browse/VAN-53)

-----


Hotjar is a behavior analytics tool that analyses website use, providing feedback through tools such as heatmaps, session recordings, and surveys. Before we enable hotjar we have to suppress all PII and sensitive information so that screen recorder doesn’t capture it. Adding a `data-hj-suppress` attribute around the sensitive data marks the field as suppressed for hotjar and shows asterisks instead of text.
<img width="733" alt="Screenshot 2020-09-16 at 10 03 02 AM" src="https://user-images.githubusercontent.com/40633976/93294490-10955080-f804-11ea-9d39-dff3458741fa.png">