### PR TITLE
Devstack: Revert back to not validating orgs of new courses

### DIFF
--- a/cms/envs/devstack.py
+++ b/cms/envs/devstack.py
@@ -118,7 +118,12 @@ def should_show_debug_toolbar(request):
 FEATURES['MILESTONES_APP'] = True
 
 ########################### ORGANIZATIONS #################################
-FEATURES['ORGANIZATIONS_APP'] = True
+# This is disabled for Devstack Studio for developer convenience.
+# If it were enabled, then users would not be able to create course runs
+# with any arbritrary org slug -- they would have to first make sure that
+# the organization exists in the Organization table.
+# Note that some production environments (such as studio.edx.org) do enable this flag.
+FEATURES['ORGANIZATIONS_APP'] = False
 
 ################################ ENTRANCE EXAMS ################################
 FEATURES['ENTRANCE_EXAMS'] = True


### PR DESCRIPTION
```
This change was originally made in preparation for a BD-14
change that would enable database-backed organizations
across Open edX. Since then, we've figured out a way
of rolling out database-backed organizations without
mandating that organization slugs in new courses are
validated. So, this puts devstack back to where it was before,
with ORGANIZATIONS_APP==True for LMS on devstack and
ORGANIZATIONS_APP==False for Studio on devstack.

From a developer perspective, this means that course
runs can again be created in Studio with any org slug.
```

Effectively reverts https://github.com/edx/edx-platform/pull/24820
Related to [TNL-7425](https://openedx.atlassian.net/browse/TNL-7425)