### PR TITLE
[BD-05] [BB-3037] Convert ORA to pluggable app

### DIFF
--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -1637,11 +1637,6 @@ OPTIONAL_APPS = (
 
     # edx-ora2
     ('submissions', 'openedx.core.djangoapps.content.course_overviews.apps.CourseOverviewsConfig'),
-    ('openassessment', 'openedx.core.djangoapps.content.course_overviews.apps.CourseOverviewsConfig'),
-    ('openassessment.assessment', 'openedx.core.djangoapps.content.course_overviews.apps.CourseOverviewsConfig'),
-    ('openassessment.fileupload', 'openedx.core.djangoapps.content.course_overviews.apps.CourseOverviewsConfig'),
-    ('openassessment.workflow', 'openedx.core.djangoapps.content.course_overviews.apps.CourseOverviewsConfig'),
-    ('openassessment.xblock', 'openedx.core.djangoapps.content.course_overviews.apps.CourseOverviewsConfig'),
 
     # edxval
     ('edxval', 'openedx.core.djangoapps.content.course_overviews.apps.CourseOverviewsConfig'),

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -3344,11 +3344,6 @@ OPTIONAL_APPS = [
 
     # edx-ora2
     ('submissions', 'openedx.core.djangoapps.content.course_overviews.apps.CourseOverviewsConfig'),
-    ('openassessment', 'openedx.core.djangoapps.content.course_overviews.apps.CourseOverviewsConfig'),
-    ('openassessment.assessment', 'openedx.core.djangoapps.content.course_overviews.apps.CourseOverviewsConfig'),
-    ('openassessment.fileupload', 'openedx.core.djangoapps.content.course_overviews.apps.CourseOverviewsConfig'),
-    ('openassessment.workflow', 'openedx.core.djangoapps.content.course_overviews.apps.CourseOverviewsConfig'),
-    ('openassessment.xblock', 'openedx.core.djangoapps.content.course_overviews.apps.CourseOverviewsConfig'),
 
     # edxval
     ('edxval', 'openedx.core.djangoapps.content.course_overviews.apps.CourseOverviewsConfig'),

--- a/lms/urls.py
+++ b/lms/urls.py
@@ -210,10 +210,6 @@ if settings.FEATURES.get('ENABLE_OPENBADGES'):
         url(r'^api/badges/v1/', include(('lms.djangoapps.badges.api.urls', 'badges'), namespace='badges_api')),
     ]
 
-urlpatterns += [
-    url(r'^openassessment/fileupload/', include('openassessment.fileupload.urls')),
-]
-
 # sysadmin dashboard, to see what courses are loaded, to delete & load courses
 if settings.FEATURES.get('ENABLE_SYSADMIN_DASHBOARD'):
     urlpatterns += [

--- a/requirements/edx/base.in
+++ b/requirements/edx/base.in
@@ -162,4 +162,3 @@ XBlock                              # Courseware component architecture
 xblock-utils                        # Provides utilities used by the Discussion XBlock
 xss-utils                           # https://github.com/edx/edx-platform/pull/20633 Fix XSS via Translations
 enmerkar-underscore                 # Implements a underscore extractor for django-babel.
-


### PR DESCRIPTION
In https://github.com/edx/edx-ora2/pull/1515 we convert ORA into a pluggable Django app. This PR removes outdated references to load urls and apps from ORA since that's now done automatically by entry_points in the ORA package itself.

**Dependencies**: https://github.com/edx/edx-ora2/pull/1515

**Sandbox URL**: TBD - sandbox is being provisioned.

**Merge deadline**: None

**Testing instructions**:

1. Check out https://github.com/edx/edx-ora2/pull/1515
2. Install the package from the above link in the LMS & CMS
3. Check out this PR
4. Check ORA functionality thoroughly, making sure there are no errors or problems

**Reviewers**
- [ ] @giovannicimolin 