### PR TITLE
Always import task packages by absolute paths

### DIFF
--- a/lms/djangoapps/bulk_email/tests/test_email.py
+++ b/lms/djangoapps/bulk_email/tests/test_email.py
@@ -22,7 +22,7 @@ from markupsafe import escape
 from mock import Mock, patch
 
 from ..models import BulkEmailFlag, Optout
-from ..tasks import _get_course_email_context, _get_source_address
+from lms.djangoapps.bulk_email.tasks import _get_course_email_context, _get_source_address
 from course_modes.models import CourseMode
 
 from lms.djangoapps.courseware.tests.factories import InstructorFactory, StaffFactory

--- a/lms/djangoapps/bulk_email/tests/test_err_handling.py
+++ b/lms/djangoapps/bulk_email/tests/test_err_handling.py
@@ -19,8 +19,8 @@ from opaque_keys.edx.locator import CourseLocator
 from six import text_type
 from six.moves import range
 
-from bulk_email.models import SEND_TO_MYSELF, BulkEmailFlag, CourseEmail
-from bulk_email.tasks import perform_delegate_email_batches, send_course_email
+from lms.djangoapps.bulk_email.models import SEND_TO_MYSELF, BulkEmailFlag, CourseEmail
+from lms.djangoapps.bulk_email.tasks import perform_delegate_email_batches, send_course_email
 from lms.djangoapps.instructor_task.exceptions import DuplicateTaskException
 from lms.djangoapps.instructor_task.models import InstructorTask
 from lms.djangoapps.instructor_task.subtasks import (

--- a/lms/djangoapps/bulk_email/tests/test_tasks.py
+++ b/lms/djangoapps/bulk_email/tests/test_tasks.py
@@ -33,7 +33,7 @@ from opaque_keys.edx.locator import CourseLocator
 from six.moves import range
 
 from ..models import SEND_TO_LEARNERS, SEND_TO_MYSELF, SEND_TO_STAFF, CourseEmail, Optout
-from ..tasks import _get_course_email_context
+from lms.djangoapps.bulk_email.tasks import _get_course_email_context
 from lms.djangoapps.instructor_task.models import InstructorTask
 from lms.djangoapps.instructor_task.subtasks import SubtaskStatus, update_subtask_status
 from lms.djangoapps.instructor_task.tasks import send_bulk_course_email

--- a/lms/djangoapps/email_marketing/signals.py
+++ b/lms/djangoapps/email_marketing/signals.py
@@ -25,7 +25,7 @@ from openedx.core.djangoapps.waffle_utils import WaffleSwitchNamespace
 from student.signals import SAILTHRU_AUDIT_PURCHASE
 from util.model_utils import USER_FIELD_CHANGED
 
-from .tasks import update_course_enrollment
+from lms.djangoapps.email_marketing.tasks import update_course_enrollment
 
 log = logging.getLogger(__name__)
 

--- a/lms/djangoapps/email_marketing/tests/test_signals.py
+++ b/lms/djangoapps/email_marketing/tests/test_signals.py
@@ -27,7 +27,7 @@ from ..signals import (
     email_marketing_user_field_changed,
     update_sailthru
 )
-from ..tasks import (
+from lms.djangoapps.email_marketing.tasks import (
     _create_user_list,
     _get_list_from_email_marketing_provider,
     _get_or_create_user_list,

--- a/lms/djangoapps/gating/signals.py
+++ b/lms/djangoapps/gating/signals.py
@@ -8,8 +8,8 @@ from completion.models import BlockCompletion
 from django.db import models
 from django.dispatch import receiver
 
-from gating import api as gating_api
-from gating.tasks import task_evaluate_subsection_completion_milestones
+from lms.djangoapps.gating import api as gating_api
+from lms.djangoapps.gating.tasks import task_evaluate_subsection_completion_milestones
 from lms.djangoapps.grades.api import signals as grades_signals
 from openedx.core.djangoapps.signals.signals import COURSE_GRADE_CHANGED
 

--- a/lms/djangoapps/grades/management/commands/compute_grades.py
+++ b/lms/djangoapps/grades/management/commands/compute_grades.py
@@ -12,7 +12,7 @@ from lms.djangoapps.grades.config.models import ComputeGradesSetting
 from openedx.core.lib.command_utils import get_mutually_exclusive_required_option, parse_course_keys
 from xmodule.modulestore.django import modulestore
 
-from ... import tasks
+from lms.djangoapps.grades import tasks
 
 log = logging.getLogger(__name__)
 

--- a/lms/djangoapps/grades/signals/handlers.py
+++ b/lms/djangoapps/grades/signals/handlers.py
@@ -24,7 +24,7 @@ from .. import events
 from ..constants import ScoreDatabaseTableEnum
 from ..course_grade_factory import CourseGradeFactory
 from ..scores import weighted_score
-from ..tasks import (
+from lms.djangoapps.grades.tasks import (
     RECALCULATE_GRADE_DELAY_SECONDS,
     recalculate_course_and_subsection_grades_for_user,
     recalculate_subsection_grade_v3

--- a/lms/djangoapps/instructor_task/tasks.py
+++ b/lms/djangoapps/instructor_task/tasks.py
@@ -28,7 +28,7 @@ from celery import task
 from django.conf import settings
 from django.utils.translation import ugettext_noop
 
-from bulk_email.tasks import perform_delegate_email_batches
+from lms.djangoapps.bulk_email.tasks import perform_delegate_email_batches
 from lms.djangoapps.instructor_task.tasks_base import BaseInstructorTask
 from lms.djangoapps.instructor_task.tasks_helper.certs import generate_students_certificates
 from lms.djangoapps.instructor_task.tasks_helper.enrollments import (

--- a/lms/djangoapps/lti_provider/management/commands/resend_lti_scores.py
+++ b/lms/djangoapps/lti_provider/management/commands/resend_lti_scores.py
@@ -9,8 +9,8 @@ import six
 from django.core.management import BaseCommand
 from opaque_keys.edx.keys import CourseKey
 
-from lti_provider import tasks
-from lti_provider.models import GradedAssignment
+from lms.djangoapps.lti_provider import tasks
+from lms.djangoapps.lti_provider.models import GradedAssignment
 
 
 class Command(BaseCommand):

--- a/lms/djangoapps/lti_provider/signals.py
+++ b/lms/djangoapps/lti_provider/signals.py
@@ -8,11 +8,11 @@ from django.conf import settings
 from django.dispatch import receiver
 from opaque_keys.edx.keys import LearningContextKey
 
-import lti_provider.outcomes as outcomes
+import lms.djangoapps.lti_provider.outcomes as outcomes
 from lms.djangoapps.grades.api import signals as grades_signals
-from lti_provider.views import parse_course_and_usage_keys
+from lms.djangoapps.lti_provider.views import parse_course_and_usage_keys
 from xmodule.modulestore.django import modulestore
-from .tasks import send_composite_outcome, send_leaf_outcome
+from lms.djangoapps.lti_provider.tasks import send_composite_outcome, send_leaf_outcome
 
 log = logging.getLogger(__name__)
 

--- a/lms/djangoapps/program_enrollments/apps.py
+++ b/lms/djangoapps/program_enrollments/apps.py
@@ -30,5 +30,5 @@ class ProgramEnrollmentsConfig(AppConfig):
         """
         Connect handlers to signals.
         """
-        from . import signals  # pylint: disable=unused-import
-        from . import tasks    # pylint: disable=unused-import
+        from lms.djangoapps.program_enrollments import signals  # pylint: disable=unused-import
+        from lms.djangoapps.program_enrollments import tasks    # pylint: disable=unused-import

--- a/lms/djangoapps/program_enrollments/management/commands/expire_waiting_enrollments.py
+++ b/lms/djangoapps/program_enrollments/management/commands/expire_waiting_enrollments.py
@@ -5,7 +5,7 @@ import logging
 
 from django.core.management.base import BaseCommand
 
-from ... import tasks
+from lms.djangoapps.program_enrollments import tasks
 
 logger = logging.getLogger(__name__)
 

--- a/lms/djangoapps/verify_student/apps.py
+++ b/lms/djangoapps/verify_student/apps.py
@@ -17,5 +17,5 @@ class VerifyStudentConfig(AppConfig):
         """
         Connect signal handlers.
         """
-        from . import signals  # pylint: disable=unused-import
-        from . import tasks    # pylint: disable=unused-import
+        from lms.djangoapps.verify_student import signals  # pylint: disable=unused-import
+        from lms.djangoapps.verify_student import tasks    # pylint: disable=unused-import

--- a/openedx/core/djangoapps/coursegraph/apps.py
+++ b/openedx/core/djangoapps/coursegraph/apps.py
@@ -14,4 +14,4 @@ class CoursegraphConfig(AppConfig):
     """
     name = 'openedx.core.djangoapps.coursegraph'
 
-    from . import tasks
+    from openedx.core.djangoapps.coursegraph import tasks

--- a/openedx/core/djangoapps/credentials/apps.py
+++ b/openedx/core/djangoapps/credentials/apps.py
@@ -44,4 +44,4 @@ class CredentialsConfig(AppConfig):
 
     def ready(self):
         # Register celery workers
-        from .tasks.v1 import tasks  # pylint: disable=unused-variable
+        from openedx.core.djangoapps.credentials.tasks.v1 import tasks  # pylint: disable=unused-variable

--- a/openedx/core/djangoapps/credentials/tests/test_tasks.py
+++ b/openedx/core/djangoapps/credentials/tests/test_tasks.py
@@ -10,7 +10,7 @@ from django.test import TestCase, override_settings
 from openedx.core.djangolib.testing.utils import skip_unless_lms
 from student.tests.factories import UserFactory
 
-from ..tasks.v1 import tasks
+from openedx.core.djangoapps.credentials.tasks.v1 import tasks
 
 TASKS_MODULE = 'openedx.core.djangoapps.credentials.tasks.v1.tasks'
 

--- a/openedx/features/enterprise_support/signals.py
+++ b/openedx/features/enterprise_support/signals.py
@@ -13,7 +13,7 @@ from django.dispatch import receiver
 from enterprise.models import EnterpriseCourseEnrollment, EnterpriseCustomer, EnterpriseCustomerUser
 from integrated_channels.integrated_channel.tasks import transmit_single_learner_data
 
-from email_marketing.tasks import update_user
+from lms.djangoapps.email_marketing.tasks import update_user
 from openedx.core.djangoapps.commerce.utils import ecommerce_api_client
 from openedx.core.djangoapps.signals.signals import COURSE_GRADE_NOW_PASSED
 from openedx.features.enterprise_support.api import enterprise_enabled


### PR DESCRIPTION
This follows the recommendation in the Celery documentation so as to
not confuse automatic task name generation.

Docs: https://docs.celeryproject.org/en/stable/userguide/tasks.html#automatic-naming-and-relative-imports