### PR TITLE
[WIP] Update messaging for certificates

### DIFF
--- a/lms/djangoapps/courseware/date_summary.py
+++ b/lms/djangoapps/courseware/date_summary.py
@@ -326,7 +326,8 @@ class CourseEndDate(DateSummary):
     def description(self):
         if self.current_time <= self.date:
             mode, is_active = CourseEnrollment.enrollment_mode_for_user(self.user, self.course_id)
-            if is_active and CourseMode.is_eligible_for_certificate(mode):
+            has_verified_mode = CourseMode.mode_for_course(self.course_id, CourseMode.VERIFIED)
+            if is_active and CourseMode.is_eligible_for_certificate(mode) and has_verified_mode:
                 return _('To earn a certificate, you must complete all requirements before this date.')
             else:
                 return _('After this date, course content will be archived.')


### PR DESCRIPTION
## [EDUCATOR-5299](https://openedx.atlassian.net/browse/EDUCATOR-5299)

Masters students who are enrolled in a course that does not offer certificates still see the messaging:

This course is ending in 1 day on Aug 30, 2020.
To earn a certificate, you must complete all requirements before this date.

This messaging is now limited to students who are enrolled in a track that is eligible for a certificate and only if the course also offers a verified mode. 