### PR TITLE
Fix certificate sass assets collection for comprehensive themes

### DIFF
--- a/pavelib/assets.py
+++ b/pavelib/assets.py
@@ -194,6 +194,17 @@ def get_theme_sass_dirs(system, theme_dir):
             ],
         })
 
+        # now compile theme sass files for certificate
+        if system == 'lms':
+            dirs.append({
+                "sass_source_dir": theme_dir / system / "static" / "certificates" / "sass",
+                "css_destination_dir": theme_dir / system / "static" / "certificates" / "css",
+                "lookup_paths": [
+                    sass_dir / "partials",
+                    sass_dir
+                ],
+            })
+
     return dirs
 
 

--- a/pavelib/assets.py
+++ b/pavelib/assets.py
@@ -167,6 +167,8 @@ def get_theme_sass_dirs(system, theme_dir):
     system_sass_dir = path(system) / "static" / "sass"
     sass_dir = theme_dir / system / "static" / "sass"
     css_dir = theme_dir / system / "static" / "css"
+    certs_sass_dir = theme_dir / system / "static" / "certificates" / "sass"
+    certs_css_dir = theme_dir / system / "static" / "certificates" / "css"
 
     dependencies = SASS_LOOKUP_DEPENDENCIES.get(system, [])
     if sass_dir.isdir():
@@ -197,8 +199,8 @@ def get_theme_sass_dirs(system, theme_dir):
         # now compile theme sass files for certificate
         if system == 'lms':
             dirs.append({
-                "sass_source_dir": theme_dir / system / "static" / "certificates" / "sass",
-                "css_destination_dir": theme_dir / system / "static" / "certificates" / "css",
+                "sass_source_dir": certs_sass_dir,
+                "css_destination_dir": certs_css_dir,
                 "lookup_paths": [
                     sass_dir / "partials",
                     sass_dir

--- a/pavelib/paver_tests/test_assets.py
+++ b/pavelib/paver_tests/test_assets.py
@@ -252,6 +252,7 @@ class TestPaverWatchAssetTasks(TestCase):
         self.expected_sass_directories.extend([
             path(TEST_THEME_DIR) / 'lms/static/sass',
             path(TEST_THEME_DIR) / 'lms/static/sass/partials',
+            path(TEST_THEME_DIR) / 'lms/static/certificates/sass',
             path(TEST_THEME_DIR) / 'cms/static/sass',
             path(TEST_THEME_DIR) / 'cms/static/sass/partials',
         ])


### PR DESCRIPTION
This change includes the directory where sass files for certificates are located within each comprehensive theme directory: lms/static/certificates/sass. This directory is used by the `paver update_assets` command.