### PR TITLE
Added app.py to mobile_api to resolve migration issue

### DIFF
--- a/lms/djangoapps/mobile_api/apps.py
+++ b/lms/djangoapps/mobile_api/apps.py
@@ -1,0 +1,14 @@
+"""
+Configuration for the mobile_api Django application.
+"""
+
+
+from django.apps import AppConfig
+
+
+class MobileApiConfig(AppConfig):
+    """
+    Configuration class for the mobile_api Django application.
+    """
+    name = 'lms.djangoapps.mobile_api'
+    verbose_name = "Mobile API"

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -2589,7 +2589,7 @@ INSTALLED_APPS = [
     'django_countries',
 
     # edX Mobile API
-    'mobile_api',
+    'lms.djangoapps.mobile_api.apps.MobileApiConfig',
     'social_django',
 
     # Surveys


### PR DESCRIPTION
In sandbox, mobile_api related tables are not being created because of missing app.py file and configurations.