### PR TITLE
WIP: [SE-3439] Cache course details and blocks list

### DIFF
--- a/openedx/core/djangoapps/cache_toolbox/core.py
+++ b/openedx/core/djangoapps/cache_toolbox/core.py
@@ -97,7 +97,7 @@ def instance_key(model, instance_or_pk):
     """
     Returns the cache key for this (model, instance) pair.
     """
-    return '%s.%s:%d' % (
+    return '%s.%s:%s' % (
         model._meta.app_label,
         model._meta.model_name,
         getattr(instance_or_pk, 'pk', instance_or_pk),

--- a/openedx/core/djangoapps/content/course_overviews/models.py
+++ b/openedx/core/djangoapps/content/course_overviews/models.py
@@ -24,6 +24,7 @@ from six import text_type  # pylint: disable=ungrouped-imports
 from six.moves.urllib.parse import urlparse, urlunparse  # pylint: disable=import-error
 from simple_history.models import HistoricalRecords
 
+from openedx.core.djangoapps.cache_toolbox import cache_model
 from lms.djangoapps.discussion import django_comment_client
 from openedx.core.djangoapps.catalog.models import CatalogIntegration
 from openedx.core.djangoapps.lang_pref.api import get_closest_released_language
@@ -359,7 +360,7 @@ class CourseOverview(TimeStampedModel):
                 course from the module store.
         """
         try:
-            course_overview = cls.objects.select_related('image_set').get(id=course_id)
+            course_overview = cls.get_cached(course_id)
             if course_overview.version < cls.VERSION:
                 # Reload the overview from the modulestore to update the version
                 course_overview = cls.load_from_module_store(course_id)
@@ -859,6 +860,9 @@ class CourseOverview(TimeStampedModel):
     def __str__(self):
         """Represent ourselves with the course key."""
         return six.text_type(self.id)
+
+
+cache_model(CourseOverview)
 
 
 class CourseOverviewTab(models.Model):


### PR DESCRIPTION
Work in progress.

This pull request is about adding cache on the course details and xblocks list API endpoints.

**Discussions**: https://discuss.openedx.org/t/help-please-very-slow-load-time-10-seconds-for-courseware-on-sections-with-several-subsections-and-xblocks/2998/8

**Dependencies**: None

**Sandbox URL**: TBD - sandbox is being provisioned.

**Merge deadline**: None

**Testing instructions**:

tba

**Author notes and concerns**:

n/a

**Reviewers**
- [ ] (OpenCraft internal reviewer's GitHub username goes here)
- [ ] edX reviewer[s] TBD
