### PR TITLE
[Provisional] Access Control Backends plugins

### DIFF
--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -77,6 +77,8 @@ from lms.envs.common import (
     HEARTBEAT_CELERY_TIMEOUT,
     HEARTBEAT_CELERY_ROUTING_KEY,
 
+    ACCESS_CONTROL_BACKENDS,
+
     # Default site to use if no site exists matching request headers
     SITE_ID,
 

--- a/lms/djangoapps/courseware/access.py
+++ b/lms/djangoapps/courseware/access.py
@@ -43,6 +43,7 @@ from lms.djangoapps.courseware.access_utils import (
 from lms.djangoapps.courseware.masquerade import get_masquerade_role, is_masquerading_as_student
 from lms.djangoapps.ccx.custom_exception import CCXLocatorValidationException
 from lms.djangoapps.ccx.models import CustomCourseForEdX
+from lms.djangoapps.courseware.access_control_backends import access_control_backends
 from mobile_api.models import IgnoreMobileAvailableFlagConfig
 from openedx.core.djangoapps.content.course_overviews.models import CourseOverview
 from openedx.features.course_duration_limits.access import check_course_expired
@@ -414,7 +415,12 @@ def _has_access_course(user, action, courselike):
         'see_about_page': can_see_about_page,
     }
 
-    return _dispatch(checkers, action, user, courselike)
+    return access_control_backends.query(
+        action='course.{action}'.format(action=action),
+        user=user,
+        resource=courselike,
+        default_has_access=_dispatch(checkers, action, user, courselike),
+    )
 
 
 def _has_access_error_desc(user, action, descriptor, course_key):

--- a/lms/djangoapps/courseware/access_control_backends.py
+++ b/lms/djangoapps/courseware/access_control_backends.py
@@ -1,0 +1,107 @@
+"""
+A plugin system for customizing access control in the platform.
+"""
+from importlib import import_module
+from lazy import lazy
+import logging
+import six
+
+from django.conf import settings
+
+log = logging.getLogger(__name__)
+
+
+class AccessControlBackends(object):
+    """
+    The access control backend service object.
+
+    Meant to be instantiated by this module, so use the `access_control_backends` object.
+    """
+    SUPPORTED_ACTIONS = {
+        'course.load',
+        'course.load_mobile',
+        'course.enroll',
+        'course.see_exists',
+        'course.staff',
+        'course.instructor',
+        'course.see_in_catalog',
+        'course.see_about_page',
+    }
+    UNSUPPORTED_ERROR_FMT = '`AccessControlBackends` does not support the action `{action}` yet'.format
+
+    @lazy
+    def backends(self):
+        """
+        Parse the access control backends settings and resolve the backend functions.
+
+        :return: a dictionary with the following format: {
+            ACTION_NAME: {
+                "FUNC": BACKEND_FUNCTION,
+                "OPTIONS": BACKEND_OPTIONS_DICT,
+            },
+            ANOTHER_ACTION_NAME: ...,
+        }
+        """
+        backends = settings.ACCESS_CONTROL_BACKENDS
+        resolved_backends = {}
+        for action, backend in six.iteritems(backends):
+            if action not in self.SUPPORTED_ACTIONS:
+                raise NotImplementedError(self.UNSUPPORTED_ERROR_FMT(action=action))
+
+            path = backend['NAME']
+            options = backend.get('OPTIONS', {})
+            try:
+                module, func_name = path.split(':', 1)
+                module = import_module(module)
+                func = getattr(module, func_name)
+                resolved_backends[action] = {
+                    'FUNC': func,
+                    'OPTIONS': options,
+                }
+            except Exception:
+                log.exception(
+                    'Something went wrong in reading the ACCESS_CONTROL_BACKENDS settings for `{action}`.'.format(
+                        action=action,
+                    )
+                )
+                raise
+
+        return resolved_backends
+
+    def query(self, action, user, resource, default_has_access):
+        """
+        Invoke an Access Control Backend.
+
+        :param action: currently supporting the course access actions in SUPPORTED_ACTIONS.
+        :param user: The User model object.
+        :param resource: The course/resource ID.
+        :param default_has_access: AccessResponse The default access response object by Open edX.
+        :return: AccessResponse: ACCESS_GRANTED or ACCESS_DENIED whether the
+                                 `user` can perform the `action` on the `resource` or not.
+        """
+        if action not in self.SUPPORTED_ACTIONS:
+            raise NotImplementedError(self.UNSUPPORTED_ERROR_FMT(action=action))
+
+        backend = self.backends.get(action)
+
+        if backend:
+            try:
+                backend_func = backend['FUNC']
+                return backend_func(
+                    user=user,
+                    resource=resource,
+                    default_has_access=default_has_access,
+                    options=backend['OPTIONS'],
+                )
+            except Exception:
+                log.exception(
+                    'Something went wrong in querying the access control backend for `{action}`.'.format(
+                        action=action,
+                    )
+                )
+                raise
+
+        return default_has_access
+
+
+access_control_backends = AccessControlBackends()

--- a/lms/djangoapps/courseware/tests/test_access_control_backends.py
+++ b/lms/djangoapps/courseware/tests/test_access_control_backends.py
@@ -1,0 +1,228 @@
+"""
+Test cases for the pluggable access control system.
+"""
+import datetime
+import ddt
+from mock import patch, Mock
+import pytest
+import pytz
+
+from django.conf import settings
+from django.test.utils import override_settings
+from django.test import TestCase
+from opaque_keys.edx.locator import CourseLocator
+
+from lms.djangoapps.courseware.access_utils import (
+    ACCESS_DENIED,
+    ACCESS_GRANTED,
+)
+import lms.djangoapps.courseware.access as access
+from lms.djangoapps.courseware.access_control_backends import (
+    access_control_backends,
+    AccessControlBackends,
+)
+from student.tests.factories import CourseEnrollmentAllowedFactory, UserFactory
+from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
+
+
+@ddt.ddt
+class AccessControlBackendsTests(TestCase):
+    """
+    Tests for the AccessControlBackends class.
+    """
+
+    def setUp(self):
+        """
+        Instantiate a new AccessControlBackends object.
+        """
+        self.acl_backends = AccessControlBackends()
+
+    def test_sanity_check(self):
+        """
+        Check that the settings are empty by default as well as no default backends are found.
+        """
+        assert settings.ACCESS_CONTROL_BACKENDS == {}
+        assert self.acl_backends.backends == {}
+
+    @ddt.data(
+        {
+            'first_config': {
+                'course.see_in_catalog': {
+                    'NAME': 'lms.lib:see_in_catalog_backend',
+                }
+            },
+            'second_config': {},
+            'expected_count': 1,
+        },
+        {
+            'first_config': {},
+            'second_config': {
+                'course.see_in_catalog': {
+                    'NAME': 'lms.lib:see_in_catalog_backend',
+                }
+            },
+            'expected_count': 0,
+        }
+    )
+    @ddt.unpack
+    @patch('lms.lib.see_in_catalog_backend', Mock(), create=True)
+    def test_backends_cache(self, first_config, second_config, expected_count):
+        """
+        Check the `@lazy` attribute behaviour.
+
+        Ensures that the first use backend property loads the configuration.
+        The second use of the property should use the cached results instead of re-reading the configs.
+        """
+        with override_settings(ACCESS_CONTROL_BACKENDS=first_config):
+            assert len(self.acl_backends.backends) == expected_count, 'Should read the correct configs'
+
+        with override_settings(ACCESS_CONTROL_BACKENDS=second_config):
+            assert len(self.acl_backends.backends) == expected_count, 'Should not read the configs but use the cache'
+
+    @override_settings(ACCESS_CONTROL_BACKENDS={
+        'course.see_in_catalog': {
+            'NAME': 'lms.lib:see_in_catalog_backend',
+            'OPTIONS': {
+                'dummy_option': 500,
+            },
+        }
+    })
+    @patch('lms.lib.see_in_catalog_backend', create=True)
+    def test_settings_with_options(self, mock_backend):
+        """
+        Test the happy scenario for a backend with options.
+        """
+        assert self.acl_backends.backends == {
+            'course.see_in_catalog': {
+                'FUNC': mock_backend,
+                'OPTIONS': {
+                    'dummy_option': 500,
+                },
+            }
+        }
+
+    @override_settings(ACCESS_CONTROL_BACKENDS={
+        'course.see_in_catalog': {
+            'NAME': 'lms.lib:see_in_catalog_backend',
+        }
+    })
+    @patch('lms.djangoapps.courseware.access_control_backends.log')
+    def test_settings_with_missing_function(self, mock_log):
+        """
+        Check that the system fails explicitly on a missing function.
+        """
+        with pytest.raises(AttributeError):
+            _ = self.acl_backends.backends
+        mock_log.exception.assert_called_with(
+            'Something went wrong in reading the ACCESS_CONTROL_BACKENDS settings for `course.see_in_catalog`.'
+        )
+
+    @override_settings(ACCESS_CONTROL_BACKENDS={
+        'studio.create_course': {
+            'NAME': 'lms.lib:see_in_catalog_backend',
+        }
+    })
+    def test_settings_with_unknown_actions(self):
+        """
+        Ensure only supported actions can be used.
+
+        SUPPORTED_ACTIONS can be extended whenever needed.
+        """
+        with pytest.raises(NotImplementedError) as e:
+            _ = self.acl_backends.backends
+        assert e.match('`AccessControlBackends` does not support the action `studio.create_course` yet')
+
+    @override_settings(ACCESS_CONTROL_BACKENDS={
+        'course.enroll': {
+            'NAME': 'lms.lib:enroll_backend',
+            'OPTIONS': {
+                'dummy_option': 500,
+            },
+        }
+    })
+    @ddt.data(True, False)
+    def test_query_existing_backend(self, return_value):
+        """
+        Test a correctly working backend.
+        """
+        with patch('lms.lib.enroll_backend', create=True, return_value=return_value) as mock_backend:
+            assert not mock_backend.call_count
+            course = Mock()
+            user = Mock()
+            has_access = self.acl_backends.query('course.enroll', user, course, True)
+            assert has_access == return_value
+            mock_backend.assert_called_once_with(
+                user=user,
+                resource=course,
+                default_has_access=True,
+                options={
+                    'dummy_option': 500,
+                },
+            )
+
+    @override_settings(ACCESS_CONTROL_BACKENDS={})
+    @ddt.data(True, False)
+    def test_query_missing_backend(self, default_has_access):
+        """
+        Ensure that the `default_has_access` is used when querying an action without a plugged-in backend.
+        """
+        course = Mock()
+        user = Mock()
+        assert default_has_access == self.acl_backends.query('course.enroll', user, course, default_has_access)
+
+    @override_settings(ACCESS_CONTROL_BACKENDS={
+        'course.load': {
+            'NAME': 'lms.djangoapps.courseware.access_control_backends:load_backend',
+        }
+    })
+    @patch('lms.djangoapps.courseware.access_control_backends.load_backend', Mock(
+        side_effect=ArithmeticError('Dividing by zero!')),
+        create=True,
+    )
+    @patch('lms.djangoapps.courseware.access_control_backends.log')
+    def test_query_broken_backend(self, mock_log):
+        """
+        Ensure a broken backend fails explicitly.
+        """
+        course = Mock()
+        user = Mock()
+        with pytest.raises(ArithmeticError):
+            self.acl_backends.query('course.load', user, course, True)
+        mock_log.exception.assert_called_once_with(
+            'Something went wrong in querying the access control backend for `course.load`.'
+        )
+
+
+@ddt.ddt
+class AccessWithACLBackendsTestCase(ModuleStoreTestCase):
+    """
+    Integration tests for `access._has_access_course`.
+    """
+
+    def setUp(self):
+        """
+        Set up tests environment.
+        """
+        tomorrow = datetime.datetime.now(pytz.utc) + datetime.timedelta(days=1)
+        self.user = UserFactory.create()
+        self.course = Mock(
+            enrollment_domain='',
+            enrollment_end=tomorrow,
+            enrollment_start=tomorrow,
+            id=CourseLocator('edX', 'test', '2012_Fall'),
+        )
+        CourseEnrollmentAllowedFactory(email=self.user.email, course_id=self.course.id)
+
+    def test_has_access_with_no_acl_backends(self):
+        """
+        Ensure that the `access._has_access_course` queries the Access Control Backends.
+        """
+        assert access._has_access_course(self.user, 'enroll', self.course).has_access
+
+    @ddt.data(ACCESS_GRANTED, ACCESS_DENIED)
+    def test_has_access_with_acl_backends(self, backend_access):
+        """
+        Ensure that the `access._has_access_course` queries the Access Control Backends.
+        """
+        with patch.object(access_control_backends, 'query', Mock(return_value=backend_access)):
+            assert access._has_access_course(self.user, 'enroll', self.course) == backend_access

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -972,6 +972,8 @@ AUTHENTICATION_BACKENDS = [
 STUDENT_FILEUPLOAD_MAX_SIZE = 4 * 1000 * 1000  # 4 MB
 MAX_FILEUPLOADS_PER_INPUT = 20
 
+ACCESS_CONTROL_BACKENDS = {}
+
 # Set request limits for maximum size of a request body and maximum number of GET/POST parameters. (>=Django 1.10)
 # Limits are currently disabled - but can be used for finer-grained denial-of-service protection.
 DATA_UPLOAD_MAX_MEMORY_SIZE = None

--- a/lms/envs/production.py
+++ b/lms/envs/production.py
@@ -199,6 +199,8 @@ REGISTRATION_EMAIL_PATTERNS_ALLOWED = ENV_TOKENS.get('REGISTRATION_EMAIL_PATTERN
 LMS_ROOT_URL = ENV_TOKENS.get('LMS_ROOT_URL')
 LMS_INTERNAL_ROOT_URL = ENV_TOKENS.get('LMS_INTERNAL_ROOT_URL', LMS_ROOT_URL)
 
+ACCESS_CONTROL_BACKENDS = ENV_TOKENS.get('ACCESS_CONTROL_BACKENDS', {})
+
 # List of logout URIs for each IDA that the learner should be logged out of when they logout of the LMS. Only applies to
 # IDA for which the social auth flow uses DOT (Django OAuth Toolkit).
 IDA_LOGOUT_URI_LIST = ENV_TOKENS.get('IDA_LOGOUT_URI_LIST', [])


### PR DESCRIPTION
## Summary

In late 2019 I’ve [proposed a method to customize the access control](https://discuss.openedx.org/t/pluggable-access-control-both-viewing-and-enrolling-in-a-course/803) in Open edX via plugins. This proposal is concerned about augmenting the course `load` and `enroll` permissions by providing django app and registering it using the Django settings.

## Provisional status of this pull request
Due to timeline complexities, we've chosen to build a Hawthorn-specific implementation that made no use of [Birdgekeeper](https://bridgekeeper.readthedocs.io/) which was introduced in [OEP-09](https://open-edx-proposals.readthedocs.io/en/latest/oep-0009-bp-permissions.html#motivation) and the [permissions ADR](https://github.com/edx/edx-platform/blob/master/lms/djangoapps/courseware/docs/decisions/0003-permissions-via-bridgekeeper.rst).

Due to the timeline issues above the work was merged in our fork: https://github.com/appsembler/edx-platform/pull/491 which enabled us to make the [course-access-groups plugin](https://github.com/appsembler/course-access-groups).

I'm opening this pull request to probe the tests and try to see if it works on Juniper.

## Next steps
I've opened a thread to discuss how can we streamline the extension point possibly in relation with Bridgekeeper. Let's discuss this on the following topic:

 - [Juniper update for: Pluggable access control ](https://discuss.openedx.org/t/juniper-update-for-pluggable-access-control/3391)