### PR TITLE
Adding lynx to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,6 +36,7 @@ RUN apt-get update && \
     libxml2-dev \
     libxmlsec1-dev \
     libxslt1-dev \
+    # lynx: Required by https://github.com/edx/edx-platform/blob/b489a4ecb122/openedx/core/lib/html_to_text.py#L16
     lynx \
     ntp \
     pkg-config \

--- a/Dockerfile
+++ b/Dockerfile
@@ -36,6 +36,7 @@ RUN apt-get update && \
     libxml2-dev \
     libxmlsec1-dev \
     libxslt1-dev \
+    lynx \
     ntp \
     pkg-config \
     python3-dev \


### PR DESCRIPTION
lynx is required for emails, and is not installed in the Dockerfile currently

https://github.com/edx/edx-platform/blob/b489a4ecb12252099b1d249e588158ff038187a1/openedx/core/lib/html_to_text.py#L16