### PR TITLE
AA-385: Add in LinkedIn Add to Profile to courseware meta API

### DIFF
--- a/common/djangoapps/student/helpers.py
+++ b/common/djangoapps/student/helpers.py
@@ -33,7 +33,6 @@ from lms.djangoapps.verify_student.services import IDVerificationService
 from lms.djangoapps.verify_student.utils import is_verification_expiring_soon, verification_for_datetime
 from openedx.core.djangoapps.certificates.api import certificates_viewable_for_course
 from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
-from openedx.core.djangoapps.theming import helpers as theming_helpers
 from openedx.core.djangoapps.theming.helpers import get_themes
 from openedx.core.djangoapps.user_authn.utils import is_safe_login_or_logout_redirect
 from student.models import (
@@ -447,19 +446,12 @@ def cert_info(user, course_overview):
         course_overview (CourseOverview): A course.
 
     Returns:
-        dict: A dictionary with keys:
-            'status': one of 'generating', 'downloadable', 'notpassing', 'processing', 'restricted', 'unavailable', or
-                'certificate_earned_but_not_available'
-            'download_url': url, only present if show_download_url is True
-            'show_survey_button': bool
-            'survey_url': url, only if show_survey_button is True
-            'grade': if status is not 'processing'
-            'can_unenroll': if status allows for unenrollment
+        See _cert_info
     """
     return _cert_info(
         user,
         course_overview,
-        certificate_status_for_student(user, course_overview.id)
+        certificate_status_for_student(user, course_overview.id),
     )
 
 
@@ -470,6 +462,23 @@ def _cert_info(user, course_overview, cert_status):
     Arguments:
         user (User): A user.
         course_overview (CourseOverview): A course.
+        cert_status (dict): dictionary containing information about certificate status for the user
+
+    Returns:
+        dictionary containing:
+            'status': one of 'generating', 'downloadable', 'notpassing', 'restricted', 'auditing',
+                'processing', 'unverified', 'unavailable', or 'certificate_earned_but_not_available'
+            'show_survey_button': bool
+            'can_unenroll': if status allows for unenrollment
+
+        The dictionary may also contain:
+            'linked_in_url': url to add cert to LinkedIn profile
+            'survey_url': url, only if course_overview.end_of_course_survey_url is not None
+            'show_cert_web_view': bool if html web certs are enabled and there is an active web cert
+            'cert_web_view_url': url if html web certs are enabled and there is an active web cert
+            'download_url': url to download a cert
+            'grade': if status is in 'generating', 'downloadable', 'notpassing', 'restricted',
+                'auditing', or 'unverified'
     """
     # simplify the status for the template using this lookup table
     template_state = {
@@ -496,7 +505,7 @@ def _cert_info(user, course_overview, cert_status):
         return default_info
 
     status = template_state.get(cert_status['status'], default_status)
-    is_hidden_status = status in ('unavailable', 'processing', 'generating', 'notpassing', 'auditing')
+    is_hidden_status = status in ('processing', 'generating', 'notpassing', 'auditing')
 
     if (
         not certificates_viewable_for_course(course_overview) and
@@ -552,15 +561,9 @@ def _cert_info(user, course_overview, cert_status):
             # Clicking this button sends the user to LinkedIn where they
             # can add the certificate information to their profile.
             linkedin_config = LinkedInAddToProfileConfiguration.current()
-
-            # posting certificates to LinkedIn is not currently
-            # supported in White Labels
-            if linkedin_config.enabled and not theming_helpers.is_request_in_themed_site():
+            if linkedin_config.is_enabled():
                 status_dict['linked_in_url'] = linkedin_config.add_to_profile_url(
-                    course_overview.id,
-                    course_overview.display_name,
-                    cert_status.get('mode'),
-                    cert_status['download_url']
+                    course_overview.display_name, cert_status.get('mode'), cert_status['download_url'],
                 )
 
     if status in {'generating', 'downloadable', 'notpassing', 'restricted', 'auditing', 'unverified'}:

--- a/common/djangoapps/student/models.py
+++ b/common/djangoapps/student/models.py
@@ -16,10 +16,11 @@ import hashlib
 import json
 import logging
 import uuid
-from collections import OrderedDict, defaultdict, namedtuple
+from collections import defaultdict, namedtuple
 from datetime import datetime, timedelta
 from functools import total_ordering
 from importlib import import_module
+from urllib.parse import urlencode
 
 import six
 from config_models.models import ConfigurationModel
@@ -51,7 +52,6 @@ from pytz import UTC
 from simple_history.models import HistoricalRecords
 from six import text_type
 from six.moves import range
-from six.moves.urllib.parse import urlencode
 from slumber.exceptions import HttpClientError, HttpServerError
 from user_util import user_util
 
@@ -2527,23 +2527,21 @@ class LinkedInAddToProfileConfiguration(ConfigurationModel):
     """
     LinkedIn Add to Profile Configuration
 
-    This configuration enables the "Add to Profile" LinkedIn
-    button on the student dashboard.  The button appears when
-    users have a certificate available; when clicked,
-    users are sent to the LinkedIn site with a pre-filled
-    form allowing them to add the certificate to their
-    LinkedIn profile.
+    This configuration enables the 'Add to Profile' LinkedIn button. The button
+    appears when users have a certificate available; when clicked, users are sent
+    to the LinkedIn site with a pre-filled form allowing them to add the
+    certificate to their LinkedIn profile.
+
+    See https://addtoprofile.linkedin.com/ for documentation on parameters
 
     .. no_pii:
     """
 
     MODE_TO_CERT_NAME = {
-        "honor": _(u"{platform_name} Honor Code Certificate for {course_name}"),
-        "verified": _(u"{platform_name} Verified Certificate for {course_name}"),
-        "professional": _(u"{platform_name} Professional Certificate for {course_name}"),
-        "no-id-professional": _(
-            u"{platform_name} Professional Certificate for {course_name}"
-        ),
+        'honor': _('{platform_name} Honor Code Certificate for {course_name}'),
+        'verified': _('{platform_name} Verified Certificate for {course_name}'),
+        'professional': _('{platform_name} Professional Certificate for {course_name}'),
+        'no-id-professional': _('{platform_name} Professional Certificate for {course_name}'),
     }
 
     company_identifier = models.TextField(
@@ -2567,33 +2565,43 @@ class LinkedInAddToProfileConfiguration(ConfigurationModel):
         )
     )
 
-    def add_to_profile_url(self, course_key, course_name, cert_mode, cert_url, source="o", target="dashboard"):
-        """Construct the URL for the "add to profile" button.
+    def is_enabled(self, *key_fields):
+        """
+        Checks both the model itself and share_settings to see if LinkedIn Add to Profile is enabled
+        """
+        enabled = super().is_enabled(*key_fields)
+        share_settings = configuration_helpers.get_value('SOCIAL_SHARING_SETTINGS', settings.SOCIAL_SHARING_SETTINGS)
+        return share_settings.get('CERTIFICATE_LINKEDIN', enabled)
+
+    def add_to_profile_url(self, course_name, cert_mode, cert_url, certificate=None):
+        """
+        Construct the URL for the "add to profile" button. This will autofill the form based on
+        the params provided.
 
         Arguments:
-            course_key (CourseKey): The identifier for the course.
-            course_name (unicode): The display name of the course.
+            course_name (str): The display name of the course.
             cert_mode (str): The course mode of the user's certificate (e.g. "verified", "honor", "professional")
-            cert_url (str): The download URL for the certificate.
+            cert_url (str): The URL for the certificate.
 
         Keyword Arguments:
-            source (str): Either "o" (for onsite/UI), "e" (for emails), or "m" (for mobile)
-            target (str): An identifier for the occurrance of the button.
-
+            certificate (GeneratedCertificate): a GeneratedCertificate object for the user and course.
+                If provided, this function will also autofill the certId and issue date for the cert.
         """
-        company_identifier = configuration_helpers.get_value('LINKEDIN_COMPANY_ID', self.company_identifier)
-        params = OrderedDict([
-            ('_ed', company_identifier),
-            ('pfCertificationName', self._cert_name(course_name, cert_mode).encode('utf-8')),
-            ('pfCertificationUrl', cert_url),
-            ('source', source)
-        ])
+        params = {
+            'name': self._cert_name(course_name, cert_mode),
+            'certUrl': cert_url,
+        }
 
-        tracking_code = self._tracking_code(course_key, cert_mode, target)
-        if tracking_code is not None:
-            params['trk'] = tracking_code
+        params.update(self._organization_information())
 
-        return u'http://www.linkedin.com/profile/add?{params}'.format(
+        if certificate:
+            params.update({
+                'certId': certificate.verify_uuid,
+                'issueYear': certificate.created_date.year,
+                'issueMonth': certificate.created_date.month,
+            })
+
+        return 'https://www.linkedin.com/profile/add?startTask=CERTIFICATION_NAME&{params}'.format(
             params=urlencode(params)
         )
 
@@ -2608,10 +2616,7 @@ class LinkedInAddToProfileConfiguration(ConfigurationModel):
         Returns:
             str: The formatted string to display for the name field on the LinkedIn Add to Profile dialog.
         """
-        default_cert_name = self.MODE_TO_CERT_NAME.get(
-            cert_mode,
-            _(u"{platform_name} Certificate for {course_name}")
-        )
+        default_cert_name = self.MODE_TO_CERT_NAME.get(cert_mode, _('{platform_name} Certificate for {course_name}'))
         # Look for an override of the certificate name in the SOCIAL_SHARING_SETTINGS setting
         share_settings = configuration_helpers.get_value('SOCIAL_SHARING_SETTINGS', settings.SOCIAL_SHARING_SETTINGS)
         cert_name = share_settings.get('CERTIFICATE_LINKEDIN_MODE_TO_CERT_NAME', {}).get(cert_mode, default_cert_name)
@@ -2621,41 +2626,19 @@ class LinkedInAddToProfileConfiguration(ConfigurationModel):
             course_name=course_name
         )
 
-    def _tracking_code(self, course_key, cert_mode, target):
-        """Create a tracking code for the button.
-
-        Tracking codes are used by LinkedIn to collect
-        analytics about certifications users are adding
-        to their profiles.
-
-        The tracking code format is:
-            &trk=[partner name]-[certificate type]-[date]-[target field]
-
-        In our case, we're sending:
-            &trk=edx-{COURSE ID}_{COURSE MODE}-{TARGET}
-
-        If no partner code is configured, then this will
-        return None, indicating that tracking codes are disabled.
-
-        Arguments:
-
-            course_key (CourseKey): The identifier for the course.
-            cert_mode (str): The enrollment mode for the course.
-            target (str): Identifier for where the button is located.
+    def _organization_information(self):
+        """
+        Returns organization information for use in the URL parameters for add to profile.
 
         Returns:
-            unicode or None
-
+            dict: Either the organization ID on LinkedIn or the organization's name
+                Will be used to prefill the organization on the add to profile action.
         """
-        return (
-            u"{partner}-{course_key}_{cert_mode}-{target}".format(
-                partner=self.trk_partner_name,
-                course_key=text_type(course_key),
-                cert_mode=cert_mode,
-                target=target
-            )
-            if self.trk_partner_name else None
-        )
+        org_id = configuration_helpers.get_value('LINKEDIN_COMPANY_ID', self.company_identifier)
+        # Prefer organization ID per documentation at https://addtoprofile.linkedin.com/
+        if org_id:
+            return {'organizationId': org_id}
+        return {'organizationName': configuration_helpers.get_value('platform_name', settings.PLATFORM_NAME)}
 
 
 @python_2_unicode_compatible

--- a/common/djangoapps/student/tests/test_certificates.py
+++ b/common/djangoapps/student/tests/test_certificates.py
@@ -5,7 +5,6 @@ import datetime
 import unittest
 
 import ddt
-import mock
 from django.conf import settings
 from django.test.utils import override_settings
 from django.urls import reverse
@@ -15,8 +14,9 @@ from pytz import UTC
 from course_modes.models import CourseMode
 from lms.djangoapps.certificates.api import get_certificate_url
 from lms.djangoapps.certificates.models import CertificateStatuses
-from lms.djangoapps.certificates.tests.factories import GeneratedCertificateFactory
-from student.models import LinkedInAddToProfileConfiguration
+from lms.djangoapps.certificates.tests.factories import (
+    GeneratedCertificateFactory, LinkedInAddToProfileConfigurationFactory
+)
 from student.tests.factories import CourseEnrollmentFactory, UserFactory
 from xmodule.modulestore import ModuleStoreEnum
 from xmodule.modulestore.tests.django_utils import SharedModuleStoreTestCase
@@ -191,10 +191,12 @@ class CertificateDisplayTest(CertificateDisplayTestBase):
             u'do not have a current verified identity with {platform_name}'
             .format(platform_name=settings.PLATFORM_NAME))
 
-    def test_post_to_linkedin_invisibility(self):
+    def test_post_to_linkedin_visibility(self):
         """
         Verifies that the post certificate to linked button
         does not appear by default (when config is not set)
+        Then Verifies that the post certificate to linked button appears
+        as expected once a config is set
         """
         self._create_certificate('honor')
 
@@ -202,38 +204,9 @@ class CertificateDisplayTest(CertificateDisplayTestBase):
         # button should not be visible
         self._check_linkedin_visibility(False)
 
-    def test_post_to_linkedin_visibility(self):
-        """
-        Verifies that the post certificate to linked button appears
-        as expected
-        """
-        self._create_certificate('honor')
-
-        config = LinkedInAddToProfileConfiguration(
-            company_identifier='0_mC_o2MizqdtZEmkVXjH4eYwMj4DnkCWrZP_D9',
-            enabled=True
-        )
-        config.save()
-
+        LinkedInAddToProfileConfigurationFactory()
         # now we should see it
         self._check_linkedin_visibility(True)
-
-    @mock.patch("openedx.core.djangoapps.theming.helpers.is_request_in_themed_site", mock.Mock(return_value=True))
-    def test_post_to_linkedin_site_specific(self):
-        """
-        Verifies behavior for themed sites which disables the post to LinkedIn
-        feature (for now)
-        """
-        self._create_certificate('honor')
-
-        config = LinkedInAddToProfileConfiguration(
-            company_identifier='0_mC_o2MizqdtZEmkVXjH4eYwMj4DnkCWrZP_D9',
-            enabled=True
-        )
-        config.save()
-
-        # now we should not see it because we are in a themed site
-        self._check_linkedin_visibility(False)
 
 
 @ddt.ddt

--- a/common/djangoapps/student/tests/test_linkedin.py
+++ b/common/djangoapps/student/tests/test_linkedin.py
@@ -2,120 +2,101 @@
 """Tests for LinkedIn Add to Profile configuration. """
 
 
+from urllib.parse import quote
 import ddt
+
 from django.conf import settings
 from django.test import TestCase
-from opaque_keys.edx.locator import CourseLocator
-from six.moves.urllib.parse import quote, urlencode
 
+from lms.djangoapps.certificates.tests.factories import LinkedInAddToProfileConfigurationFactory
 from openedx.core.djangoapps.site_configuration.tests.test_util import with_site_configuration_context
-from student.models import LinkedInAddToProfileConfiguration
 
 
 @ddt.ddt
 class LinkedInAddToProfileUrlTests(TestCase):
     """Tests for URL generation of LinkedInAddToProfileConfig. """
 
-    COURSE_KEY = CourseLocator(org="edx", course="DemoX", run="Demo_Course")
-    COURSE_NAME = u"Test Course ☃"
-    CERT_URL = u"http://s3.edx/cert"
+    COURSE_NAME = 'Test Course ☃'
+    CERT_URL = 'http://s3.edx/cert'
     SITE_CONFIGURATION = {
         'SOCIAL_SHARING_SETTINGS': {
             'CERTIFICATE_LINKEDIN_MODE_TO_CERT_NAME': {
-                'honor': u'{platform_name} Honor Code Credential for {course_name}',
-                'verified': u'{platform_name} Verified Credential for {course_name}',
-                'professional': u'{platform_name} Professional Credential for {course_name}',
-                'no-id-professional': u'{platform_name} Professional Credential for {course_name}',
+                'honor': '{platform_name} Honor Code Credential for {course_name}',
+                'verified': '{platform_name} Verified Credential for {course_name}',
+                'professional': '{platform_name} Professional Credential for {course_name}',
+                'no-id-professional': '{platform_name} Professional Credential for {course_name}',
             }
         }
     }
 
     @ddt.data(
-        ('honor', u'Honor+Code+Certificate+for+Test+Course+%E2%98%83'),
-        ('verified', u'Verified+Certificate+for+Test+Course+%E2%98%83'),
-        ('professional', u'Professional+Certificate+for+Test+Course+%E2%98%83'),
-        ('default_mode', u'Certificate+for+Test+Course+%E2%98%83')
+        ('honor', 'Honor+Code+Certificate+for+Test+Course+%E2%98%83'),
+        ('verified', 'Verified+Certificate+for+Test+Course+%E2%98%83'),
+        ('professional', 'Professional+Certificate+for+Test+Course+%E2%98%83'),
+        ('default_mode', 'Certificate+for+Test+Course+%E2%98%83')
     )
     @ddt.unpack
     def test_linked_in_url(self, cert_mode, expected_cert_name):
-        config = LinkedInAddToProfileConfiguration(
-            company_identifier='0_mC_o2MizqdtZEmkVXjH4eYwMj4DnkCWrZP_D9',
-            enabled=True
-        )
+        config = LinkedInAddToProfileConfigurationFactory()
 
-        expected_url = (
-            'http://www.linkedin.com/profile/add'
-            '?_ed=0_mC_o2MizqdtZEmkVXjH4eYwMj4DnkCWrZP_D9&'
-            'pfCertificationName={platform_name}+{expected_cert_name}&'
-            'pfCertificationUrl=http%3A%2F%2Fs3.edx%2Fcert&'
-            'source=o'
-        ).format(
-            expected_cert_name=expected_cert_name,
-            platform_name=quote(settings.PLATFORM_NAME.encode('utf-8'))
-        )
+        # We can switch to this once edx-platform reaches Python 3.8
+        # expected_url = (
+        #     'https://www.linkedin.com/profile/add?startTask=CERTIFICATION_NAME&'
+        #     'name={platform}+{cert_name}&certUrl={cert_url}&'
+        #     'organizationId={company_identifier}'
+        # ).format(
+        #     platform=quote(settings.PLATFORM_NAME.encode('utf-8')),
+        #     cert_name=expected_cert_name,
+        #     cert_url=quote(self.CERT_URL, safe=''),
+        #     company_identifier=config.company_identifier,
+        # )
 
-        actual_url = config.add_to_profile_url(
-            self.COURSE_KEY,
-            self.COURSE_NAME,
-            cert_mode,
-            self.CERT_URL
-        )
+        actual_url = config.add_to_profile_url(self.COURSE_NAME, cert_mode, self.CERT_URL)
 
-        self.assertEqual(actual_url, expected_url)
+        # We can switch to this instead of the assertIn once edx-platform reaches Python 3.8
+        # There was a problem with dict ordering in the add_to_profile_url function that will go away then.
+        # self.assertEqual(actual_url, expected_url)
+
+        self.assertIn('https://www.linkedin.com/profile/add?startTask=CERTIFICATION_NAME', actual_url)
+        self.assertIn('&name={platform}+{cert_name}'.format(
+            platform=quote(settings.PLATFORM_NAME.encode('utf-8')), cert_name=expected_cert_name
+        ), actual_url)
+        self.assertIn('&certUrl={cert_url}'.format(cert_url=quote(self.CERT_URL, safe='')), actual_url)
+        self.assertIn('&organizationId={org_id}'.format(org_id=config.company_identifier), actual_url)
 
     @ddt.data(
-        ('honor', u'Honor+Code+Credential+for+Test+Course+%E2%98%83'),
-        ('verified', u'Verified+Credential+for+Test+Course+%E2%98%83'),
-        ('professional', u'Professional+Credential+for+Test+Course+%E2%98%83'),
-        ('no-id-professional', u'Professional+Credential+for+Test+Course+%E2%98%83'),
-        ('default_mode', u'Certificate+for+Test+Course+%E2%98%83')
+        ('honor', 'Honor+Code+Credential+for+Test+Course+%E2%98%83'),
+        ('verified', 'Verified+Credential+for+Test+Course+%E2%98%83'),
+        ('professional', 'Professional+Credential+for+Test+Course+%E2%98%83'),
+        ('no-id-professional', 'Professional+Credential+for+Test+Course+%E2%98%83'),
+        ('default_mode', 'Certificate+for+Test+Course+%E2%98%83')
     )
     @ddt.unpack
     def test_linked_in_url_with_cert_name_override(self, cert_mode, expected_cert_name):
-        config = LinkedInAddToProfileConfiguration(
-            company_identifier='0_mC_o2MizqdtZEmkVXjH4eYwMj4DnkCWrZP_D9',
-            enabled=True
-        )
+        config = LinkedInAddToProfileConfigurationFactory()
 
-        expected_url = (
-            'http://www.linkedin.com/profile/add'
-            '?_ed=0_mC_o2MizqdtZEmkVXjH4eYwMj4DnkCWrZP_D9&'
-            'pfCertificationName={platform_name}+{expected_cert_name}&'
-            'pfCertificationUrl=http%3A%2F%2Fs3.edx%2Fcert&'
-            'source=o'
-        ).format(
-            expected_cert_name=expected_cert_name,
-            platform_name=quote(settings.PLATFORM_NAME.encode('utf-8'))
-        )
+        # We can switch to this once edx-platform reaches Python 3.8
+        # expected_url = (
+        #     'https://www.linkedin.com/profile/add?startTask=CERTIFICATION_NAME&'
+        #     'name={platform}+{cert_name}&certUrl={cert_url}&'
+        #     'organizationId={company_identifier}'
+        # ).format(
+        #     platform=quote(settings.PLATFORM_NAME.encode('utf-8')),
+        #     cert_name=expected_cert_name,
+        #     cert_url=quote(self.CERT_URL, safe=''),
+        #     company_identifier=config.company_identifier,
+        # )
 
         with with_site_configuration_context(configuration=self.SITE_CONFIGURATION):
-            actual_url = config.add_to_profile_url(
-                self.COURSE_KEY,
-                self.COURSE_NAME,
-                cert_mode,
-                self.CERT_URL
-            )
+            actual_url = config.add_to_profile_url(self.COURSE_NAME, cert_mode, self.CERT_URL)
 
-            self.assertEqual(actual_url, expected_url)
+            # We can switch to this instead of the assertIn once edx-platform reaches Python 3.8
+            # There was a problem with dict ordering in the add_to_profile_url function that will go away then.
+            # self.assertEqual(actual_url, expected_url)
 
-    def test_linked_in_url_tracking_code(self):
-        config = LinkedInAddToProfileConfiguration(
-            company_identifier="abcd123",
-            trk_partner_name="edx",
-            enabled=True
-        )
-
-        expected_param = urlencode({
-            'trk': u'edx-{course_key}_honor-dashboard'.format(
-                course_key=self.COURSE_KEY
-            )
-        })
-
-        actual_url = config.add_to_profile_url(
-            self.COURSE_KEY,
-            self.COURSE_NAME,
-            'honor',
-            self.CERT_URL
-        )
-
-        self.assertIn(expected_param, actual_url)
+            self.assertIn('https://www.linkedin.com/profile/add?startTask=CERTIFICATION_NAME', actual_url)
+            self.assertIn('&name={platform}+{cert_name}'.format(
+                platform=quote(settings.PLATFORM_NAME.encode('utf-8')), cert_name=expected_cert_name
+            ), actual_url)
+            self.assertIn('&certUrl={cert_url}'.format(cert_url=quote(self.CERT_URL, safe='')), actual_url)
+            self.assertIn('&organizationId={org_id}'.format(org_id=config.company_identifier), actual_url)

--- a/lms/djangoapps/certificates/tests/factories.py
+++ b/lms/djangoapps/certificates/tests/factories.py
@@ -87,5 +87,4 @@ class LinkedInAddToProfileConfigurationFactory(DjangoModelFactory):
         model = LinkedInAddToProfileConfiguration
 
     enabled = True
-    company_identifier = "0_0dPSPyS070e0HsE9HNz_13_d11_"
-    trk_partner_name = 'unittest'
+    company_identifier = "1337"

--- a/lms/djangoapps/certificates/views/webview.py
+++ b/lms/djangoapps/certificates/views/webview.py
@@ -291,13 +291,9 @@ def _update_social_context(request, context, course, user, user_certificate, pla
     # Clicking this button sends the user to LinkedIn where they
     # can add the certificate information to their profile.
     linkedin_config = LinkedInAddToProfileConfiguration.current()
-    linkedin_share_enabled = share_settings.get('CERTIFICATE_LINKEDIN', linkedin_config.enabled)
-    if linkedin_share_enabled:
+    if linkedin_config.is_enabled():
         context['linked_in_url'] = linkedin_config.add_to_profile_url(
-            course.id,
-            course.display_name,
-            user_certificate.mode,
-            smart_str(share_url)
+            course.display_name, user_certificate.mode, smart_str(share_url), certificate=user_certificate
         )
 
 
@@ -348,7 +344,8 @@ def _get_user_certificate(request, user, course_key, course, preview_mode=None):
             user_certificate = GeneratedCertificate(
                 mode=preview_mode,
                 verify_uuid=six.text_type(uuid4().hex),
-                modified_date=modified_date
+                modified_date=modified_date,
+                created_date=datetime.now().date(),
             )
     elif certificates_viewable_for_course(course):
         # certificate is being viewed by learner or public

--- a/openedx/core/djangoapps/courseware_api/serializers.py
+++ b/openedx/core/djangoapps/courseware_api/serializers.py
@@ -95,6 +95,7 @@ class CourseInfoSerializer(serializers.Serializer):  # pylint: disable=abstract-
     course_exit_page_is_active = serializers.BooleanField()
     certificate_data = CertificateDataSerializer()
     verify_identity_url = AbsoluteURLField()
+    linkedin_add_to_profile_url = serializers.URLField()
 
     def __init__(self, *args, **kwargs):
         """

--- a/openedx/core/djangoapps/courseware_api/tests/test_views.py
+++ b/openedx/core/djangoapps/courseware_api/tests/test_views.py
@@ -3,13 +3,19 @@ Tests for courseware API
 """
 import unittest
 from datetime import datetime
+from urllib.parse import urlencode
 
 import ddt
 import mock
 from completion.test_utils import CompletionWaffleTestMixin, submit_completions_for_testing
 from django.conf import settings
+from django.test.client import RequestFactory
 from django.urls import reverse
 
+from lms.djangoapps.certificates.api import get_certificate_url
+from lms.djangoapps.certificates.tests.factories import (
+    GeneratedCertificateFactory, LinkedInAddToProfileConfigurationFactory
+)
 from lms.djangoapps.courseware.access_utils import ACCESS_DENIED, ACCESS_GRANTED
 from lms.djangoapps.courseware.tabs import ExternalLinkCourseTab
 from lms.djangoapps.courseware.tests.helpers import MasqueradeMixin
@@ -73,6 +79,7 @@ class CourseApiTestViews(BaseCoursewareTests):
             ExternalLinkCourseTab.load('external_link', name='Hidden', link='http://hidden.com', is_hidden=True)
         )
         cls.store.update_item(cls.course, cls.user.id)
+        LinkedInAddToProfileConfigurationFactory.create()
 
     @ddt.data(
         (True, None, ACCESS_DENIED),
@@ -82,6 +89,7 @@ class CourseApiTestViews(BaseCoursewareTests):
         (False, None, ACCESS_GRANTED),
     )
     @ddt.unpack
+    @mock.patch.dict('django.conf.settings.FEATURES', {'CERTIFICATES_HTML_VIEW': True})
     @mock.patch('openedx.core.djangoapps.courseware_api.views.CoursewareMeta.is_microfrontend_enabled_for_user')
     def test_course_metadata(self, logged_in, enrollment_mode, enable_anonymous, is_microfrontend_enabled_for_user):
         is_microfrontend_enabled_for_user.return_value = True
@@ -92,6 +100,14 @@ class CourseApiTestViews(BaseCoursewareTests):
                 self.client.logout()
             if enrollment_mode:
                 CourseEnrollment.enroll(self.user, self.course.id, enrollment_mode)
+            if enrollment_mode == 'verified':
+                cert = GeneratedCertificateFactory.create(
+                    user=self.user,
+                    course_id=self.course.id,
+                    status='downloadable',
+                    mode='verified',
+                )
+
             response = self.client.get(self.url)
             assert response.status_code == 200
             if enrollment_mode:
@@ -114,12 +130,32 @@ class CourseApiTestViews(BaseCoursewareTests):
                                               'The audit track does not include a certificate.')
                     assert response.data['certificate_data']['msg'] == expected_audit_message
                     assert response.data['verify_identity_url'] is None
+                    assert response.data['linkedin_add_to_profile_url'] is None
                 else:
-                    # Not testing certificate data for verified learner here. That is tested elsewhere
-                    assert response.data['certificate_data'] is None
+                    assert response.data['certificate_data']['cert_status'] == 'earned_but_not_available'
                     expected_verify_identity_url = reverse('verify_student_verify_now', args=[self.course.id])
                     # The response contains an absolute URL so this is only checking the path of the final
                     assert expected_verify_identity_url in response.data['verify_identity_url']
+
+                    request = RequestFactory().request()
+                    cert_url = get_certificate_url(course_id=self.course.id, uuid=cert.verify_uuid)
+                    linkedin_url_params = {
+                        'name': '{platform_name} Verified Certificate for {course_name}'.format(
+                            platform_name=settings.PLATFORM_NAME, course_name=self.course.display_name,
+                        ),
+                        'certUrl': request.build_absolute_uri(cert_url),
+                        # default value from the LinkedInAddToProfileConfigurationFactory company_identifier
+                        'organizationId': 1337,
+                        'certId': cert.verify_uuid,
+                        'issueYear': cert.created_date.year,
+                        'issueMonth': cert.created_date.month,
+                    }
+                    expected_linkedin_url = (
+                        'https://www.linkedin.com/profile/add?startTask=CERTIFICATION_NAME&{params}'.format(
+                            params=urlencode(linkedin_url_params)
+                        )
+                    )
+                    assert response.data['linkedin_add_to_profile_url'] == expected_linkedin_url
             elif enable_anonymous and not logged_in:
                 # multiple checks use this handler
                 check_public_access.assert_called()

--- a/openedx/core/djangoapps/user_authn/views/tests/test_login.py
+++ b/openedx/core/djangoapps/user_authn/views/tests/test_login.py
@@ -18,9 +18,7 @@ from django.http import HttpResponse
 from django.test.client import Client
 from django.test.utils import override_settings
 from django.urls import NoReverseMatch, reverse
-from freezegun import freeze_time
 from mock import patch
-from six.moves import range
 
 from openedx.core.djangoapps.password_policy.compliance import (
     NonCompliantPasswordException,


### PR DESCRIPTION
A major update to this function allows it to actually autofill the
certificate information again! I believe LinkedIn changed their API
and we never updated our end. This fixes that!