### PR TITLE
[BD-14] [SE-2939] Add ability to filter library blocks by type. Prevent changing types with unpublished changes.

### DIFF
--- a/openedx/core/djangoapps/content_libraries/libraries_index.py
+++ b/openedx/core/djangoapps/content_libraries/libraries_index.py
@@ -75,7 +75,6 @@ class SearchIndexerBase(ABC):
                 "schema_version": [cls.SCHEMA_VERSION],
                 **filter_terms,
             }
-
         if text_search:
             response = cls._perform_elastic_search(filter_terms, text_search)
         else:

--- a/openedx/core/djangoapps/content_libraries/tests/base.py
+++ b/openedx/core/djangoapps/content_libraries/tests/base.py
@@ -269,7 +269,7 @@ class ContentLibrariesRestApiTest(APITestCase):
             query_params_dict = {}
         return self._api(
             'get',
-            URL_LIB_BLOCKS.format(lib_key=lib_key) + '?' + urlencode(query_params_dict),
+            URL_LIB_BLOCKS.format(lib_key=lib_key) + '?' + urlencode(query_params_dict, doseq=True),
             None,
             expect_response
         )

--- a/openedx/core/djangoapps/content_libraries/views.py
+++ b/openedx/core/djangoapps/content_libraries/views.py
@@ -485,6 +485,12 @@ class LibraryBlocksView(APIView):
                 str,
                 description="The string used to filter libraries by searching in title, id, org, or description",
             ),
+            apidocs.query_parameter(
+                'block_type',
+                str,
+                description="The block type to search for. If omitted or blank, searches for all types. "
+                            "May be specified multiple times to match multiple types."
+            )
         ],
     )
     @convert_exceptions
@@ -494,9 +500,10 @@ class LibraryBlocksView(APIView):
         """
         key = LibraryLocatorV2.from_string(lib_key_str)
         text_search = request.query_params.get('text_search', None)
+        block_types = request.query_params.getlist('block_type') or None
 
         api.require_permission_for_library_key(key, request.user, permissions.CAN_VIEW_THIS_CONTENT_LIBRARY)
-        result = api.get_library_blocks(key, text_search=text_search)
+        result = api.get_library_blocks(key, text_search=text_search, block_types=block_types)
 
         # Verify `pagination` param to maintain compatibility with older
         # non pagination-aware clients


### PR DESCRIPTION
Adds the ability to filter v2 library blocks by block type. Also prevents switching the library type when there are unpublished changes/deletes, as this may cause consistency errors.

**Dependencies**: None

**Merge deadline**: Sooner's better than later.

**Testing instructions**:

1. Attempt to change the type of a library before you've published changes. Verify you are unable.
2. Filter blocks by type using the companion frontend PR here: https://github.com/edx/frontend-app-library-authoring/pull/19
3. Run the testing instructions in https://github.com/edx/edx-platform/pull/24510 to make sure nothing regressed.

**Reviewers**
- [ ] @arbrandes 
- [ ] @kdmccormick 
