### PR TITLE
Set the Secure attribute on delete_logged_in_cookies

### DIFF
--- a/openedx/core/djangoapps/user_authn/cookies.py
+++ b/openedx/core/djangoapps/user_authn/cookies.py
@@ -64,7 +64,7 @@ def are_logged_in_cookies_set(request):
     ) and request.COOKIES[settings.EDXMKTG_LOGGED_IN_COOKIE_NAME]
 
 
-def delete_logged_in_cookies(response):
+def delete_logged_in_cookies(request, response):
     """
     Delete cookies indicating that the user is logged in.
     Arguments:
@@ -73,10 +73,13 @@ def delete_logged_in_cookies(response):
         HttpResponse
     """
     for cookie_name in ALL_LOGGED_IN_COOKIE_NAMES:
-        response.delete_cookie(
+        response.set_cookie(
             cookie_name,
+            max_age=0,
+            expires='Thu, 01-Jan-1970 00:00:00 GMT',
+            domain=settings.SESSION_COOKIE_DOMAIN,
             path='/',
-            domain=settings.SESSION_COOKIE_DOMAIN
+            secure=request.is_secure(),
         )
 
     return response

--- a/openedx/core/djangoapps/user_authn/tests/test_cookies.py
+++ b/openedx/core/djangoapps/user_authn/tests/test_cookies.py
@@ -122,7 +122,7 @@ class CookieTests(TestCase):
         self._copy_cookies_to_request(response, self.request)
         self.assertTrue(cookies_api.are_logged_in_cookies_set(self.request))
 
-        cookies_api.delete_logged_in_cookies(response)
+        cookies_api.delete_logged_in_cookies(self.request, response)
         self._copy_cookies_to_request(response, self.request)
         self.assertFalse(cookies_api.are_logged_in_cookies_set(self.request))
 

--- a/openedx/core/djangoapps/user_authn/views/logout.py
+++ b/openedx/core/djangoapps/user_authn/views/logout.py
@@ -79,7 +79,7 @@ class LogoutView(TemplateView):
         response = super(LogoutView, self).dispatch(request, *args, **kwargs)
 
         # Clear the cookie used by the edx.org marketing site
-        delete_logged_in_cookies(response)
+        delete_logged_in_cookies(request, response)
 
         return response
 


### PR DESCRIPTION
This matches the behaviour of `standard_cookie_settings()`:
https://github.com/edx/edx-platform/blob/78eae80e387ca6b24850906eb4603b03bf19ead5/openedx/core/djangoapps/user_authn/cookies.py#L85-L107

Concretely, if the cookies were set with the `Secure` attribute, and the `django-cookies-samesite` middleware did set the `SameSite` attribute too; but are tried to be cleared without it, the "deleted" cookies will be blocked by recent versions of Chrome, and remain on the user's browser.