### PR TITLE
[SE-3520] Cherry pick of Consolidate get_transcript methods

### DIFF
--- a/common/lib/xmodule/xmodule/video_module/video_module.py
+++ b/common/lib/xmodule/xmodule/video_module/video_module.py
@@ -56,7 +56,7 @@ from .transcripts_utils import (
     VideoTranscriptsMixin,
     clean_video_id,
     get_html5_ids,
-    get_transcript_for_video,
+    get_transcript,
     subs_filename
 )
 from .video_handlers import VideoStudentViewHandlers, VideoStudioViewHandlers
@@ -597,12 +597,7 @@ class VideoBlock(
         possible_sub_ids = [self.sub, self.youtube_id_1_0] + get_html5_ids(self.html5_sources)
         for sub_id in possible_sub_ids:
             try:
-                get_transcript_for_video(
-                    self.location,
-                    subs_id=sub_id,
-                    file_name=sub_id,
-                    language=u'en'
-                )
+                _, sub_id, _ = get_transcript(self, lang=u'en', output_format=Transcript.TXT)
                 transcripts_info['transcripts'] = dict(transcripts_info['transcripts'], en=sub_id)
                 break
             except NotFoundError:
@@ -1033,10 +1028,7 @@ class VideoBlock(
         def _update_transcript_for_index(language=None):
             """ Find video transcript - if not found, don't update index """
             try:
-                transcripts = self.get_transcripts_info()
-                transcript = self.get_transcript(
-                    transcripts, transcript_format='txt', lang=language
-                )[0].replace("\n", " ")
+                transcript = get_transcript(self, lang=language, output_format=Transcript.TXT)[0].replace("\n", " ")
                 transcript_index_name = "transcript_{}".format(language if language else self.transcript_language)
                 video_body.update({transcript_index_name: transcript})
             except NotFoundError:


### PR DESCRIPTION
There were two get_transcript methods. The broken one that was being
used (VideoTranscriptsMixin.get_transcript) is stripped out here - it
has been superseded by transcripts_utils.get_transcript. The latter
includes support for blockstore and VAL, while the former did not.

This fixes the `AttributeError: 'LibraryLocatorV2' object has no
attribute 'make_asset_key'` error seen when attempting to load a
transcript from a video through the xblock api when the video had the
transcript stored in blockstore.

Note that if you were previously using video.get_transcript, you should
now use `transcripts_utils.get_transcript(video, ...)`, and note that
the returned 'filename' will be prefixed with the language code, as
other `get_transcript*` functions already do.

**Screenshots**: N/A

**Sandbox URL**: https://studio.pr280.sandbox.stage.opencraft.hosting/

**Testing instructions**:

1. Login with edx
2. Create a course
3. Using course tools, import the course export "course.revit-structure.tar.gz" you can find in the task attachments
4. Check that transcript is available

**Author notes and concerns**:

1. This fix is a cherry-pick of 34516b96602480b1b5d8c37de5393b2ad7a32952

**Reviewers**
- [ ] (OpenCraft internal reviewer's GitHub username goes here)
- [ ] edX Reviewer