### PR TITLE
Use verbose output when validating new translations

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -53,7 +53,7 @@ pull_translations: ## pull translations from Transifex
 	i18n_tool generate
 	git clean -fdX conf/locale/rtl
 	git clean -fdX conf/locale/eo
-	i18n_tool validate
+	i18n_tool validate --verbose
 	paver i18n_compilejs
 
 


### PR DESCRIPTION
When running "make pull_translations", this will print any validation errors on the console, rather than stuffing them into a .prob file.

This helps when looking at failing jenkins log files.