### PR TITLE
Include common base contexts in user activation email

### DIFF
--- a/common/djangoapps/student/helpers.py
+++ b/common/djangoapps/student/helpers.py
@@ -31,6 +31,7 @@ from lms.djangoapps.grades.api import CourseGradeFactory
 from lms.djangoapps.verify_student.models import VerificationDeadline
 from lms.djangoapps.verify_student.services import IDVerificationService
 from lms.djangoapps.verify_student.utils import is_verification_expiring_soon, verification_for_datetime
+from openedx.core.djangoapps.ace_common.template_context import get_base_template_context
 from openedx.core.djangoapps.certificates.api import certificates_viewable_for_course
 from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
 from openedx.core.djangoapps.theming.helpers import get_themes
@@ -392,7 +393,8 @@ def generate_activation_email_context(user, registration):
         user (User): Currently logged-in user
         registration (Registration): Registration object for the currently logged-in user
     """
-    return {
+    context = get_base_template_context(None)
+    context.update({
         'name': user.profile.name,
         'key': registration.activation_key,
         'lms_url': configuration_helpers.get_value('LMS_ROOT_URL', settings.LMS_ROOT_URL),
@@ -401,7 +403,8 @@ def generate_activation_email_context(user, registration):
             'ACTIVATION_EMAIL_SUPPORT_LINK', settings.ACTIVATION_EMAIL_SUPPORT_LINK
         ) or settings.SUPPORT_SITE_LINK,
         'support_email': configuration_helpers.get_value('CONTACT_EMAIL', settings.CONTACT_EMAIL),
-    }
+    })
+    return context
 
 
 def create_or_set_user_attribute_created_on_site(user, site):

--- a/common/djangoapps/student/tests/test_tasks.py
+++ b/common/djangoapps/student/tests/test_tasks.py
@@ -33,6 +33,10 @@ class SendActivationEmailTestCase(TestCase):
         """
         Tests that attributes of the message are being filled correctly in compose_activation_email
         """
+        # Check that variables used by the base template are present in generated context
+        self.assertIn('platform_name', self.msg.context)
+        self.assertIn('contact_mailing_address', self.msg.context)
+        # Verify the presence of the activation-email specific attributes
         self.assertEqual(self.msg.recipient.username, self.student.username)
         self.assertEqual(self.msg.recipient.email_address, self.student.email)
         self.assertEqual(self.msg.context['routed_user'], self.student.username)


### PR DESCRIPTION
[`AccountActivation`](https://github.com/edx/edx-platform/blob/d435c0c29ee56c5010725723f9551da85d4a910e/common/djangoapps/student/views/management.py#L165) emails [extend the base email template](https://github.com/edx/edx-platform/blob/d435c0c29ee56c5010725723f9551da85d4a910e/common/templates/student/edx_ace/accountactivation/email/body.html#L1), but does not include the variables used by template, causing some items to be missing in the email. Eg - `contact_mailing_address`. This PR fixes that issue, so that any existing and future template variables used by the base template will also be present in the Activation email.

**JIRA tickets**: [OSPR-5077](https://openedx.atlassian.net/browse/OSPR-5077), [Opencraft internal/SE-3398](https://tasks.opencraft.com/browse/SE-3398)

**Testing instructions**:

1. Add a mailing address to settings
2. Sign up on an instance and observe that the mailing address is present in the mail

**Reviewers**
- [ ] @eLRuLL
- [ ] edX reviewer[s] TBD

**Settings**
```yaml
CONTACT_MAILING_ADDRESS: 'Testing address'
```