### PR TITLE
[BD-21] Switch to edx-toggles classes and deprecate waffle override methods

### DIFF
--- a/cms/djangoapps/contentstore/config/waffle.py
+++ b/cms/djangoapps/contentstore/config/waffle.py
@@ -4,12 +4,8 @@ waffle switches for the contentstore app.
 """
 
 
-from openedx.core.djangoapps.waffle_utils import (
-    CourseWaffleFlag,
-    WaffleFlag,
-    WaffleFlagNamespace,
-    WaffleSwitchNamespace
-)
+from edx_toggles.toggles import WaffleFlag, WaffleFlagNamespace, WaffleSwitchNamespace
+from openedx.core.djangoapps.waffle_utils import CourseWaffleFlag
 
 # Namespace
 WAFFLE_NAMESPACE = u'studio'

--- a/cms/djangoapps/contentstore/tasks.py
+++ b/cms/djangoapps/contentstore/tasks.py
@@ -9,20 +9,16 @@ import os
 import shutil
 import tarfile
 from datetime import datetime
-from math import ceil
 from tempfile import NamedTemporaryFile, mkdtemp
 
 from ccx_keys.locator import CCXLocator
-from celery import group
 from celery.task import task
 from celery.utils.log import get_task_logger
-from celery_utils.persist_on_failure import LoggedPersistOnFailureTask
 from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.contrib.auth.models import User
 from django.core.exceptions import SuspiciousOperation
 from django.core.files import File
-from django.core.files.base import ContentFile
 from django.test import RequestFactory
 from django.utils.text import get_valid_filename
 from django.utils.translation import ugettext as _
@@ -32,7 +28,6 @@ from organizations.models import OrganizationCourse
 from path import Path as path
 from pytz import UTC
 from six import iteritems, text_type
-from six.moves import range
 from user_tasks.models import UserTaskArtifact, UserTaskStatus
 from user_tasks.tasks import UserTask
 
@@ -57,12 +52,6 @@ from xmodule.modulestore.django import modulestore
 from xmodule.modulestore.exceptions import DuplicateCourseError, ItemNotFoundError
 from xmodule.modulestore.xml_exporter import export_course_to_xml, export_library_to_xml
 from xmodule.modulestore.xml_importer import import_course_from_xml, import_library_from_xml
-from xmodule.video_module.transcripts_utils import (
-    Transcript,
-    TranscriptsGenerationException,
-    clean_video_id,
-    get_transcript_from_contentstore
-)
 
 User = get_user_model()
 

--- a/cms/djangoapps/contentstore/tests/test_course_settings.py
+++ b/cms/djangoapps/contentstore/tests/test_course_settings.py
@@ -15,6 +15,7 @@ from crum import set_current_request
 from django.conf import settings
 from django.test import RequestFactory
 from django.test.utils import override_settings
+from edx_toggles.toggles.testutils import override_waffle_flag
 from milestones.models import MilestoneRelationshipType
 from milestones.tests.utils import MilestonesTestCaseMixin
 from mock import Mock, patch
@@ -30,7 +31,6 @@ from cms.djangoapps.models.settings.course_metadata import CourseMetadata
 from cms.djangoapps.models.settings.encoder import CourseSettingsEncoder
 from cms.djangoapps.models.settings.waffle import MATERIAL_RECOMPUTE_ONLY_FLAG
 from course_modes.models import CourseMode
-from edx_toggles.toggles.testutils import override_waffle_flag
 from openedx.core.djangoapps.models.course_details import CourseDetails
 from student.roles import CourseInstructorRole, CourseStaffRole
 from student.tests.factories import UserFactory

--- a/cms/djangoapps/contentstore/tests/test_course_settings.py
+++ b/cms/djangoapps/contentstore/tests/test_course_settings.py
@@ -30,8 +30,8 @@ from cms.djangoapps.models.settings.course_metadata import CourseMetadata
 from cms.djangoapps.models.settings.encoder import CourseSettingsEncoder
 from cms.djangoapps.models.settings.waffle import MATERIAL_RECOMPUTE_ONLY_FLAG
 from course_modes.models import CourseMode
+from edx_toggles.toggles.testutils import override_waffle_flag
 from openedx.core.djangoapps.models.course_details import CourseDetails
-from openedx.core.djangoapps.waffle_utils.testutils import override_waffle_flag
 from student.roles import CourseInstructorRole, CourseStaffRole
 from student.tests.factories import UserFactory
 from util import milestones_helpers

--- a/cms/djangoapps/contentstore/views/course.py
+++ b/cms/djangoapps/contentstore/views/course.py
@@ -23,6 +23,7 @@ from django.urls import reverse
 from django.utils.translation import ugettext as _
 from django.views.decorators.csrf import ensure_csrf_cookie
 from django.views.decorators.http import require_GET, require_http_methods
+from edx_toggles.toggles import WaffleSwitchNamespace
 from milestones import api as milestones_api
 from opaque_keys import InvalidKeyError
 from opaque_keys.edx.keys import CourseKey
@@ -43,7 +44,6 @@ from openedx.core.djangoapps.credit.api import get_credit_requirements, is_credi
 from openedx.core.djangoapps.credit.tasks import update_credit_course_requirements
 from openedx.core.djangoapps.models.course_details import CourseDetails
 from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
-from openedx.core.djangoapps.waffle_utils import WaffleSwitchNamespace
 from openedx.core.djangolib.js_utils import dump_js_escaped_json
 from openedx.core.lib.course_tabs import CourseTabPluginManager
 from openedx.core.lib.courses import course_image_url

--- a/cms/djangoapps/contentstore/views/helpers.py
+++ b/cms/djangoapps/contentstore/views/helpers.py
@@ -2,7 +2,6 @@
 Helper methods for Studio views.
 """
 
-import hashlib
 from uuid import uuid4
 
 import six
@@ -17,7 +16,6 @@ from edxmako.shortcuts import render_to_string
 from openedx.core.toggles import ENTRANCE_EXAMS
 from xmodule.modulestore.django import modulestore
 from xmodule.tabs import StaticTab
-from xmodule.x_module import DEPRECATION_VSCOMPAT_EVENT
 
 from ..utils import reverse_course_url, reverse_library_url, reverse_usage_url
 

--- a/cms/djangoapps/contentstore/views/item.py
+++ b/cms/djangoapps/contentstore/views/item.py
@@ -21,6 +21,7 @@ from edx_proctoring.api import (
     get_exam_configuration_dashboard_url
 )
 from edx_proctoring.exceptions import ProctoredExamNotFoundException
+from edx_toggles.toggles import WaffleSwitch
 from help_tokens.core import HelpUrlExpert
 from opaque_keys.edx.keys import CourseKey
 from opaque_keys.edx.locator import LibraryUsageLocator
@@ -36,7 +37,6 @@ from cms.djangoapps.xblock_config.models import CourseEditLTIFieldsEnabledFlag
 from cms.lib.xblock.authoring_mixin import VISIBILITY_VIEW
 from edxmako.shortcuts import render_to_string
 from openedx.core.djangoapps.schedules.config import COURSE_UPDATE_WAFFLE_FLAG
-from openedx.core.djangoapps.waffle_utils import WaffleSwitch
 from openedx.core.lib.gating import api as gating_api
 from openedx.core.lib.xblock_utils import hash_resource, request_token, wrap_xblock, wrap_xblock_aside
 from static_replace import replace_static_urls

--- a/cms/djangoapps/contentstore/views/tests/test_course_index.py
+++ b/cms/djangoapps/contentstore/views/tests/test_course_index.py
@@ -23,7 +23,6 @@ from cms.djangoapps.contentstore.tests.utils import CourseTestCase
 from cms.djangoapps.contentstore.utils import add_instructor, reverse_course_url, reverse_usage_url
 from course_action_state.managers import CourseRerunUIStateManager
 from course_action_state.models import CourseRerunState
-from openedx.core.djangoapps.waffle_utils import WaffleSwitchNamespace
 from openedx.core.djangoapps.waffle_utils.testutils import WAFFLE_TABLES
 from student.auth import has_course_author_access
 from student.roles import CourseStaffRole, GlobalStaff, LibraryUserRole

--- a/cms/djangoapps/contentstore/views/tests/test_item.py
+++ b/cms/djangoapps/contentstore/views/tests/test_item.py
@@ -35,6 +35,7 @@ from cms.djangoapps.contentstore.tests.utils import CourseTestCase
 from cms.djangoapps.contentstore.utils import reverse_course_url, reverse_usage_url
 from cms.djangoapps.contentstore.views import item as item_module
 from lms_xblock.mixin import NONSENSICAL_ACCESS_RESTRICTION
+from openedx.core.djangoapps.waffle_utils.testutils import override_waffle_switch
 from student.tests.factories import UserFactory
 from xblock_django.models import XBlockConfiguration, XBlockStudioConfiguration, XBlockStudioConfigurationFlag
 from xblock_django.user_service import DjangoXBlockUserService
@@ -2666,7 +2667,7 @@ class TestXBlockInfo(ItemTest):
         self.course.highlights_enabled_for_messaging = True
         self.store.update_item(self.course, None)
         chapter = self.store.get_item(self.chapter.location)
-        with highlights_setting.override():
+        with override_waffle_switch(highlights_setting, active=True):
             chapter_xblock_info = create_xblock_info(chapter)
             course_xblock_info = create_xblock_info(self.course)
             self.assertTrue(chapter_xblock_info['highlights_enabled'])

--- a/cms/djangoapps/contentstore/views/tests/test_item.py
+++ b/cms/djangoapps/contentstore/views/tests/test_item.py
@@ -13,6 +13,7 @@ from django.test import TestCase
 from django.test.client import RequestFactory
 from django.urls import reverse
 from edx_proctoring.exceptions import ProctoredExamNotFoundException
+from edx_toggles.toggles.testutils import override_waffle_switch
 from mock import Mock, PropertyMock, patch
 from opaque_keys import InvalidKeyError
 from opaque_keys.edx.asides import AsideUsageKeyV2
@@ -35,7 +36,6 @@ from cms.djangoapps.contentstore.tests.utils import CourseTestCase
 from cms.djangoapps.contentstore.utils import reverse_course_url, reverse_usage_url
 from cms.djangoapps.contentstore.views import item as item_module
 from lms_xblock.mixin import NONSENSICAL_ACCESS_RESTRICTION
-from openedx.core.djangoapps.waffle_utils.testutils import override_waffle_switch
 from student.tests.factories import UserFactory
 from xblock_django.models import XBlockConfiguration, XBlockStudioConfiguration, XBlockStudioConfigurationFlag
 from xblock_django.user_service import DjangoXBlockUserService

--- a/cms/djangoapps/contentstore/views/tests/test_videos.py
+++ b/cms/djangoapps/contentstore/views/tests/test_videos.py
@@ -33,6 +33,7 @@ from waffle.testutils import override_flag
 from cms.djangoapps.contentstore.models import VideoUploadConfig
 from cms.djangoapps.contentstore.tests.utils import CourseTestCase
 from cms.djangoapps.contentstore.utils import reverse_course_url
+from edx_toggles.toggles.testutils import override_waffle_flag
 from openedx.core.djangoapps.profile_images.tests.helpers import make_image_file
 from openedx.core.djangoapps.video_pipeline.config.waffle import (
     DEPRECATE_YOUTUBE,
@@ -41,7 +42,6 @@ from openedx.core.djangoapps.video_pipeline.config.waffle import (
 )
 from openedx.core.djangoapps.video_pipeline.models import VEMPipelineIntegration
 from openedx.core.djangoapps.waffle_utils.models import WaffleFlagCourseOverrideModel
-from openedx.core.djangoapps.waffle_utils.testutils import override_waffle_flag
 from xmodule.modulestore.tests.factories import CourseFactory
 
 from ..videos import (

--- a/cms/djangoapps/contentstore/views/tests/test_videos.py
+++ b/cms/djangoapps/contentstore/views/tests/test_videos.py
@@ -9,7 +9,6 @@ import json
 import re
 from contextlib import contextmanager
 from datetime import datetime
-from functools import wraps
 
 import dateutil.parser
 import ddt
@@ -17,6 +16,8 @@ import pytz
 import six
 from django.conf import settings
 from django.test.utils import override_settings
+from edx_toggles.toggles import WaffleSwitch
+from edx_toggles.toggles.testutils import override_waffle_flag, override_waffle_switch
 from edxval.api import (
     create_or_update_transcript_preferences,
     create_or_update_video_transcript,
@@ -33,17 +34,13 @@ from waffle.testutils import override_flag
 from cms.djangoapps.contentstore.models import VideoUploadConfig
 from cms.djangoapps.contentstore.tests.utils import CourseTestCase
 from cms.djangoapps.contentstore.utils import reverse_course_url
-from edx_toggles.toggles.testutils import override_waffle_flag
 from openedx.core.djangoapps.profile_images.tests.helpers import make_image_file
 from openedx.core.djangoapps.video_pipeline.config.waffle import (
     DEPRECATE_YOUTUBE,
     ENABLE_DEVSTACK_VIDEO_UPLOADS,
     waffle_flags
 )
-from openedx.core.djangoapps.video_pipeline.models import VEMPipelineIntegration
-from openedx.core.djangoapps.waffle_utils import WaffleSwitch
 from openedx.core.djangoapps.waffle_utils.models import WaffleFlagCourseOverrideModel
-from openedx.core.djangoapps.waffle_utils.testutils import override_waffle_switch
 from xmodule.modulestore.tests.factories import CourseFactory
 
 from ..videos import (

--- a/cms/djangoapps/contentstore/views/videos.py
+++ b/cms/djangoapps/contentstore/views/videos.py
@@ -41,6 +41,7 @@ from edxval.api import (
 from opaque_keys.edx.keys import CourseKey
 from pytz import UTC
 
+from edx_toggles.toggles import WaffleFlagNamespace, WaffleSwitchNamespace
 from edxmako.shortcuts import render_to_response
 from openedx.core.djangoapps.video_config.models import VideoTranscriptEnabledFlag
 from openedx.core.djangoapps.video_pipeline.config.waffle import (
@@ -48,7 +49,7 @@ from openedx.core.djangoapps.video_pipeline.config.waffle import (
     ENABLE_DEVSTACK_VIDEO_UPLOADS,
     waffle_flags
 )
-from openedx.core.djangoapps.waffle_utils import CourseWaffleFlag, WaffleFlagNamespace, WaffleSwitchNamespace
+from openedx.core.djangoapps.waffle_utils import CourseWaffleFlag
 from util.json_request import JsonResponse, expect_json
 from xmodule.video_module.transcripts_utils import Transcript
 

--- a/common/djangoapps/student/__init__.py
+++ b/common/djangoapps/student/__init__.py
@@ -3,7 +3,7 @@ Student app helpers and settings
 """
 
 
-from openedx.core.djangoapps.waffle_utils import WaffleSwitchNamespace
+from edx_toggles.toggles import WaffleSwitchNamespace
 
 # Namespace for student app waffle switches
 STUDENT_WAFFLE_NAMESPACE = WaffleSwitchNamespace(name='student')

--- a/common/djangoapps/student/admin.py
+++ b/common/djangoapps/student/admin.py
@@ -22,12 +22,15 @@ from django.utils.translation import ugettext_lazy as _
 from opaque_keys import InvalidKeyError
 from opaque_keys.edx.keys import CourseKey
 
-from openedx.core.djangoapps.waffle_utils import WaffleSwitch
+from edx_toggles.toggles import WaffleSwitch
 from openedx.core.lib.courses import clean_course_id
 from student import STUDENT_WAFFLE_NAMESPACE
 from student.models import (
     AccountRecovery,
+    AccountRecoveryConfiguration,
     AllowedAuthUser,
+    BulkChangeEnrollmentConfiguration,
+    BulkUnenrollConfiguration,
     CourseAccessRole,
     CourseEnrollment,
     CourseEnrollmentAllowed,
@@ -40,10 +43,7 @@ from student.models import (
     RegistrationCookieConfiguration,
     UserAttribute,
     UserProfile,
-    UserTestGroup,
-    BulkUnenrollConfiguration,
-    AccountRecoveryConfiguration,
-    BulkChangeEnrollmentConfiguration
+    UserTestGroup
 )
 from student.roles import REGISTERED_ACCESS_ROLES
 from xmodule.modulestore.django import modulestore

--- a/common/djangoapps/student/tests/test_admin_views.py
+++ b/common/djangoapps/student/tests/test_admin_views.py
@@ -18,13 +18,14 @@ from django.utils.timezone import now
 from mock import Mock
 from pytz import UTC
 
-from student.admin import AllowedAuthUserForm, COURSE_ENROLLMENT_ADMIN_SWITCH, UserAdmin, CourseEnrollmentForm
+from openedx.core.djangoapps.content.course_overviews.tests.factories import CourseOverviewFactory
+from openedx.core.djangoapps.site_configuration.tests.mixins import SiteMixin
+from openedx.core.djangoapps.waffle_utils.testutils import override_waffle_switch
+from student.admin import COURSE_ENROLLMENT_ADMIN_SWITCH, AllowedAuthUserForm, CourseEnrollmentForm, UserAdmin
 from student.models import AllowedAuthUser, CourseEnrollment, LoginFailures
 from student.tests.factories import CourseEnrollmentFactory, UserFactory
 from xmodule.modulestore.tests.django_utils import SharedModuleStoreTestCase
 from xmodule.modulestore.tests.factories import CourseFactory
-from openedx.core.djangoapps.content.course_overviews.tests.factories import CourseOverviewFactory
-from openedx.core.djangoapps.site_configuration.tests.mixins import SiteMixin
 
 
 class AdminCourseRolesPageTest(SharedModuleStoreTestCase):
@@ -243,7 +244,7 @@ class CourseEnrollmentAdminTest(SharedModuleStoreTestCase):
         """
         Ensure CourseEnrollmentAdmin views can be enabled with the waffle switch.
         """
-        with COURSE_ENROLLMENT_ADMIN_SWITCH.override(active=True):
+        with override_waffle_switch(COURSE_ENROLLMENT_ADMIN_SWITCH, active=True):
             response = getattr(self.client, method)(url)
         self.assertEqual(response.status_code, 200)
 
@@ -257,7 +258,7 @@ class CourseEnrollmentAdminTest(SharedModuleStoreTestCase):
             course_id=self.course.id,  # pylint: disable=no-member
         )
         search_url = '{}?q={}'.format(reverse('admin:student_courseenrollment_changelist'), self.user.username)
-        with COURSE_ENROLLMENT_ADMIN_SWITCH.override(active=True):
+        with override_waffle_switch(COURSE_ENROLLMENT_ADMIN_SWITCH, active=True):
             response = self.client.get(search_url)
         self.assertEqual(response.status_code, 200)
 
@@ -283,7 +284,7 @@ class CourseEnrollmentAdminTest(SharedModuleStoreTestCase):
             'mode': self.course_enrollment.mode,
         }
 
-        with COURSE_ENROLLMENT_ADMIN_SWITCH.override(active=True):
+        with override_waffle_switch(COURSE_ENROLLMENT_ADMIN_SWITCH, active=True):
             response = self.client.post(
                 reverse('admin:student_courseenrollment_change', args=(self.course_enrollment.id, )),
                 data=data,
@@ -304,7 +305,7 @@ class CourseEnrollmentAdminTest(SharedModuleStoreTestCase):
             'mode': self.course_enrollment.mode,
         }
 
-        with COURSE_ENROLLMENT_ADMIN_SWITCH.override(active=True):
+        with override_waffle_switch(COURSE_ENROLLMENT_ADMIN_SWITCH, active=True):
             with self.assertRaises(ValidationError):
                 self.client.post(
                     reverse('admin:student_courseenrollment_change', args=(self.course_enrollment.id, )),

--- a/common/djangoapps/student/tests/test_admin_views.py
+++ b/common/djangoapps/student/tests/test_admin_views.py
@@ -15,17 +15,17 @@ from django.forms import ValidationError
 from django.test import TestCase, override_settings
 from django.urls import reverse
 from django.utils.timezone import now
+from edx_toggles.toggles.testutils import override_waffle_switch
 from mock import Mock
 from pytz import UTC
-
-from openedx.core.djangoapps.content.course_overviews.tests.factories import CourseOverviewFactory
-from openedx.core.djangoapps.site_configuration.tests.mixins import SiteMixin
-from openedx.core.djangoapps.waffle_utils.testutils import override_waffle_switch
 from student.admin import COURSE_ENROLLMENT_ADMIN_SWITCH, AllowedAuthUserForm, CourseEnrollmentForm, UserAdmin
 from student.models import AllowedAuthUser, CourseEnrollment, LoginFailures
 from student.tests.factories import CourseEnrollmentFactory, UserFactory
 from xmodule.modulestore.tests.django_utils import SharedModuleStoreTestCase
 from xmodule.modulestore.tests.factories import CourseFactory
+
+from openedx.core.djangoapps.content.course_overviews.tests.factories import CourseOverviewFactory
+from openedx.core.djangoapps.site_configuration.tests.mixins import SiteMixin
 
 
 class AdminCourseRolesPageTest(SharedModuleStoreTestCase):

--- a/common/djangoapps/student/tests/test_receivers.py
+++ b/common/djangoapps/student/tests/test_receivers.py
@@ -1,10 +1,11 @@
 """ Tests for student signal receivers. """
 
 from lms.djangoapps.courseware.toggles import (
-    REDIRECT_TO_COURSEWARE_MICROFRONTEND,
     COURSEWARE_MICROFRONTEND_PROGRESS_MILESTONES,
-    COURSEWARE_MICROFRONTEND_PROGRESS_MILESTONES_FIRST_SECTION_CELEBRATION
+    COURSEWARE_MICROFRONTEND_PROGRESS_MILESTONES_FIRST_SECTION_CELEBRATION,
+    REDIRECT_TO_COURSEWARE_MICROFRONTEND
 )
+from lms.djangoapps.experiments.testutils import override_experiment_waffle_flag
 from student.models import CourseEnrollmentCelebration
 from student.tests.factories import CourseEnrollmentFactory
 from xmodule.modulestore.tests.django_utils import SharedModuleStoreTestCase
@@ -14,7 +15,7 @@ class ReceiversTest(SharedModuleStoreTestCase):
     """
     Tests for dashboard utility functions
     """
-    @REDIRECT_TO_COURSEWARE_MICROFRONTEND.override(active=True)
+    @override_experiment_waffle_flag(REDIRECT_TO_COURSEWARE_MICROFRONTEND, active=True)
     @COURSEWARE_MICROFRONTEND_PROGRESS_MILESTONES.override(active=True)
     @COURSEWARE_MICROFRONTEND_PROGRESS_MILESTONES_FIRST_SECTION_CELEBRATION.override(active=True)
     def test_celebration_created(self):

--- a/common/djangoapps/student/tests/test_receivers.py
+++ b/common/djangoapps/student/tests/test_receivers.py
@@ -1,5 +1,6 @@
 """ Tests for student signal receivers. """
 
+from edx_toggles.toggles.testutils import override_waffle_flag
 from lms.djangoapps.courseware.toggles import (
     COURSEWARE_MICROFRONTEND_PROGRESS_MILESTONES,
     COURSEWARE_MICROFRONTEND_PROGRESS_MILESTONES_FIRST_SECTION_CELEBRATION,
@@ -16,8 +17,8 @@ class ReceiversTest(SharedModuleStoreTestCase):
     Tests for dashboard utility functions
     """
     @override_experiment_waffle_flag(REDIRECT_TO_COURSEWARE_MICROFRONTEND, active=True)
-    @COURSEWARE_MICROFRONTEND_PROGRESS_MILESTONES.override(active=True)
-    @COURSEWARE_MICROFRONTEND_PROGRESS_MILESTONES_FIRST_SECTION_CELEBRATION.override(active=True)
+    @override_waffle_flag(COURSEWARE_MICROFRONTEND_PROGRESS_MILESTONES, active=True)
+    @override_waffle_flag(COURSEWARE_MICROFRONTEND_PROGRESS_MILESTONES_FIRST_SECTION_CELEBRATION, active=True)
     def test_celebration_created(self):
         """ Test that we make celebration objects when enrollments are created """
         self.assertEqual(CourseEnrollmentCelebration.objects.count(), 0)

--- a/common/djangoapps/student/tests/test_views.py
+++ b/common/djangoapps/student/tests/test_views.py
@@ -17,6 +17,7 @@ from django.test import TestCase
 from django.test.utils import override_settings
 from django.urls import reverse
 from django.utils.timezone import now
+from edx_toggles.toggles.testutils import override_waffle_flag
 from milestones.tests.utils import MilestonesTestCaseMixin
 from mock import patch
 from opaque_keys import InvalidKeyError
@@ -25,7 +26,6 @@ from pyquery import PyQuery as pq
 from six.moves import range
 
 from course_modes.models import CourseMode
-from edx_toggles.toggles.testutils import override_waffle_flag
 from entitlements.tests.factories import CourseEntitlementFactory
 from lms.djangoapps.certificates.tests.factories import GeneratedCertificateFactory
 from openedx.core.djangoapps.catalog.tests.factories import ProgramFactory

--- a/common/djangoapps/student/tests/test_views.py
+++ b/common/djangoapps/student/tests/test_views.py
@@ -25,6 +25,7 @@ from pyquery import PyQuery as pq
 from six.moves import range
 
 from course_modes.models import CourseMode
+from edx_toggles.toggles.testutils import override_waffle_flag
 from entitlements.tests.factories import CourseEntitlementFactory
 from lms.djangoapps.certificates.tests.factories import GeneratedCertificateFactory
 from openedx.core.djangoapps.catalog.tests.factories import ProgramFactory
@@ -33,7 +34,6 @@ from openedx.core.djangoapps.content.course_overviews.tests.factories import Cou
 from openedx.core.djangoapps.schedules.config import COURSE_UPDATE_WAFFLE_FLAG
 from openedx.core.djangoapps.schedules.tests.factories import ScheduleFactory
 from openedx.core.djangoapps.site_configuration.tests.test_util import with_site_configuration_context
-from openedx.core.djangoapps.waffle_utils.testutils import override_waffle_flag
 from openedx.features.course_duration_limits.models import CourseDurationLimitConfig
 from openedx.features.course_experience.tests.views.helpers import add_course_mode
 from student.helpers import DISABLE_UNENROLL_CERT_STATES

--- a/common/djangoapps/student/views/dashboard.py
+++ b/common/djangoapps/student/views/dashboard.py
@@ -16,6 +16,7 @@ from django.utils.translation import ugettext as _
 from django.views.decorators.csrf import ensure_csrf_cookie
 from edx_django_utils import monitoring as monitoring_utils
 from edx_django_utils.plugins import get_plugins_view_context
+from edx_toggles.toggles import WaffleFlag, WaffleFlagNamespace
 from opaque_keys.edx.keys import CourseKey
 from pytz import UTC
 from six import iteritems, text_type
@@ -42,12 +43,10 @@ from openedx.core.djangoapps.programs.utils import ProgramDataExtender, ProgramP
 from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
 from openedx.core.djangoapps.user_api.accounts.utils import is_secondary_email_feature_enabled
 from openedx.core.djangoapps.util.maintenance_banner import add_maintenance_banner
-from openedx.core.djangoapps.waffle_utils import WaffleFlag, WaffleFlagNamespace
 from openedx.core.djangolib.markup import HTML, Text
-from openedx.features.enterprise_support.api import get_dashboard_consent_notification
 from openedx.features.enterprise_support.api import (
     get_dashboard_consent_notification,
-    get_enterprise_learner_portal_enabled_message,
+    get_enterprise_learner_portal_enabled_message
 )
 from student.api import COURSE_DASHBOARD_PLUGIN_VIEW_NAME
 from student.helpers import cert_info, check_verify_status_by_course, get_resume_urls_for_enrollments

--- a/common/lib/xmodule/xmodule/seq_module.py
+++ b/common/lib/xmodule/xmodule/seq_module.py
@@ -19,13 +19,12 @@ from pkg_resources import resource_string
 from pytz import UTC
 from six import text_type
 from web_fragments.fragment import Fragment
-
 from xblock.completable import XBlockCompletionMode
 from xblock.core import XBlock
 from xblock.exceptions import NoSuchServiceError
 from xblock.fields import Boolean, Integer, List, Scope, String
 
-from openedx.core.djangoapps.waffle_utils import WaffleFlag
+from edx_toggles.toggles import WaffleFlag
 from openedx.core.lib.graph_traversals import traverse_pre_order
 
 from .exceptions import NotFoundError

--- a/common/lib/xmodule/xmodule/tests/test_sequence.py
+++ b/common/lib/xmodule/xmodule/tests/test_sequence.py
@@ -16,7 +16,7 @@ from mock import Mock, patch
 from six.moves import range
 from web_fragments.fragment import Fragment
 
-from openedx.core.djangoapps.waffle_utils.testutils import override_waffle_flag
+from edx_toggles.toggles.testutils import override_waffle_flag
 from student.tests.factories import UserFactory
 from xmodule.seq_module import TIMED_EXAM_GATING_WAFFLE_FLAG, SequenceModule
 from xmodule.tests import get_test_system

--- a/lms/djangoapps/certificates/tests/test_signals.py
+++ b/lms/djangoapps/certificates/tests/test_signals.py
@@ -7,6 +7,11 @@ and disabling for instructor-paced courses.
 import ddt
 import mock
 import six
+from edx_toggles.toggles import WaffleSwitch
+from edx_toggles.toggles.testutils import override_waffle_switch
+from student.tests.factories import CourseEnrollmentFactory, UserFactory
+from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
+from xmodule.modulestore.tests.factories import CourseFactory
 
 from lms.djangoapps.certificates import api as certs_api
 from lms.djangoapps.certificates.models import (
@@ -20,11 +25,6 @@ from lms.djangoapps.grades.course_grade_factory import CourseGradeFactory
 from lms.djangoapps.grades.tests.utils import mock_passing_grade
 from lms.djangoapps.verify_student.models import IDVerificationAttempt, SoftwareSecurePhotoVerification
 from openedx.core.djangoapps.certificates.config import waffle
-from openedx.core.djangoapps.waffle_utils import WaffleSwitch
-from openedx.core.djangoapps.waffle_utils.testutils import override_waffle_switch
-from student.tests.factories import CourseEnrollmentFactory, UserFactory
-from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
-from xmodule.modulestore.tests.factories import CourseFactory
 
 AUTO_CERTIFICATE_GENERATION_SWITCH = WaffleSwitch(waffle.waffle(), waffle.AUTO_CERTIFICATE_GENERATION)
 

--- a/lms/djangoapps/certificates/tests/test_webview_views.py
+++ b/lms/djangoapps/certificates/tests/test_webview_views.py
@@ -14,7 +14,6 @@ from django.test.client import Client, RequestFactory
 from django.test.utils import override_settings
 from django.urls import reverse
 from mock import patch
-from urllib.parse import urlencode
 
 from course_modes.models import CourseMode
 from lms.djangoapps.badges.events.course_complete import get_completion_badge

--- a/lms/djangoapps/certificates/tests/test_webview_views.py
+++ b/lms/djangoapps/certificates/tests/test_webview_views.py
@@ -17,6 +17,7 @@ from mock import patch
 from urllib.parse import urlencode
 
 from course_modes.models import CourseMode
+from edx_toggles.toggles import WaffleSwitch
 from edx_toggles.toggles.testutils import override_waffle_switch
 from lms.djangoapps.badges.events.course_complete import get_completion_badge
 from lms.djangoapps.badges.tests.factories import (
@@ -46,7 +47,6 @@ from openedx.core.djangoapps.site_configuration.tests.test_util import (
     with_site_configuration,
     with_site_configuration_context
 )
-from openedx.core.djangoapps.waffle_utils import WaffleSwitch
 from openedx.core.djangolib.js_utils import js_escaped_string
 from openedx.core.djangolib.testing.utils import CacheIsolationTestCase
 from openedx.core.lib.tests.assertions.events import assert_event_matches

--- a/lms/djangoapps/course_api/__init__.py
+++ b/lms/djangoapps/course_api/__init__.py
@@ -1,7 +1,7 @@
 """ Course API """
 
 
-from openedx.core.djangoapps.waffle_utils import WaffleSwitch, WaffleSwitchNamespace
+from edx_toggles.toggles import WaffleSwitch, WaffleSwitchNamespace
 
 WAFFLE_SWITCH_NAMESPACE = WaffleSwitchNamespace(name='course_list_api_rate_limit')
 

--- a/lms/djangoapps/course_api/blocks/tests/test_api.py
+++ b/lms/djangoapps/course_api/blocks/tests/test_api.py
@@ -11,7 +11,8 @@ from django.test.client import RequestFactory
 from mock import patch
 
 from openedx.core.djangoapps.content.block_structure.api import clear_course_from_cache
-from openedx.core.djangoapps.content.block_structure.config import STORAGE_BACKING_FOR_CACHE, waffle
+from openedx.core.djangoapps.content.block_structure.config import STORAGE_BACKING_FOR_CACHE, waffle_switch
+from openedx.core.djangoapps.waffle_utils.testutils import override_waffle_switch
 from student.tests.factories import UserFactory
 from xmodule.modulestore import ModuleStoreEnum
 from xmodule.modulestore.tests.django_utils import SharedModuleStoreTestCase
@@ -229,7 +230,7 @@ class TestGetBlocksQueryCounts(TestGetBlocksQueryCountsBase):
     )
     @ddt.unpack
     def test_query_counts_cached(self, store_type, with_storage_backing):
-        with waffle().override(STORAGE_BACKING_FOR_CACHE, active=with_storage_backing):
+        with override_waffle_switch(waffle_switch(STORAGE_BACKING_FOR_CACHE), active=with_storage_backing):
             course = self._create_course(store_type)
             self._get_blocks(
                 course,
@@ -246,7 +247,7 @@ class TestGetBlocksQueryCounts(TestGetBlocksQueryCountsBase):
     @ddt.unpack
     def test_query_counts_uncached(self, store_type_tuple, with_storage_backing):
         store_type, expected_mongo_queries = store_type_tuple
-        with waffle().override(STORAGE_BACKING_FOR_CACHE, active=with_storage_backing):
+        with override_waffle_switch(waffle_switch(STORAGE_BACKING_FOR_CACHE), active=with_storage_backing):
             course = self._create_course(store_type)
             clear_course_from_cache(course.id)
 

--- a/lms/djangoapps/course_api/blocks/tests/test_api.py
+++ b/lms/djangoapps/course_api/blocks/tests/test_api.py
@@ -12,7 +12,6 @@ from mock import patch
 
 from openedx.core.djangoapps.content.block_structure.api import clear_course_from_cache
 from openedx.core.djangoapps.content.block_structure.config import STORAGE_BACKING_FOR_CACHE, waffle
-from openedx.core.djangoapps.waffle_utils.testutils import override_waffle_flag
 from student.tests.factories import UserFactory
 from xmodule.modulestore import ModuleStoreEnum
 from xmodule.modulestore.tests.django_utils import SharedModuleStoreTestCase

--- a/lms/djangoapps/course_api/blocks/tests/test_api.py
+++ b/lms/djangoapps/course_api/blocks/tests/test_api.py
@@ -8,16 +8,16 @@ from itertools import product
 import ddt
 import six
 from django.test.client import RequestFactory
+from edx_toggles.toggles.testutils import override_waffle_switch
 from mock import patch
-
-from openedx.core.djangoapps.content.block_structure.api import clear_course_from_cache
-from openedx.core.djangoapps.content.block_structure.config import STORAGE_BACKING_FOR_CACHE, waffle_switch
-from openedx.core.djangoapps.waffle_utils.testutils import override_waffle_switch
 from student.tests.factories import UserFactory
 from xmodule.modulestore import ModuleStoreEnum
 from xmodule.modulestore.tests.django_utils import SharedModuleStoreTestCase
 from xmodule.modulestore.tests.factories import SampleCourseFactory, check_mongo_calls
 from xmodule.modulestore.tests.sample_courses import BlockInfo
+
+from openedx.core.djangoapps.content.block_structure.api import clear_course_from_cache
+from openedx.core.djangoapps.content.block_structure.config import STORAGE_BACKING_FOR_CACHE, waffle_switch
 
 from ..api import get_blocks
 

--- a/lms/djangoapps/course_api/blocks/toggles.py
+++ b/lms/djangoapps/course_api/blocks/toggles.py
@@ -3,8 +3,7 @@ Toggles for Course API.
 """
 
 
-from openedx.core.djangoapps.waffle_utils import WaffleFlag, WaffleFlagNamespace
-
+from edx_toggles.toggles import WaffleFlag, WaffleFlagNamespace
 
 COURSE_BLOCKS_API_NAMESPACE = WaffleFlagNamespace(name=u'course_blocks_api')
 

--- a/lms/djangoapps/course_home_api/dates/v1/tests/test_views.py
+++ b/lms/djangoapps/course_home_api/dates/v1/tests/test_views.py
@@ -3,13 +3,14 @@ Tests for Dates Tab API in the Course Home API
 """
 
 from datetime import datetime
-import ddt
 
+import ddt
 from django.urls import reverse
 
 from course_modes.models import CourseMode
 from lms.djangoapps.course_home_api.tests.utils import BaseCourseHomeTests
 from lms.djangoapps.course_home_api.toggles import COURSE_HOME_MICROFRONTEND, COURSE_HOME_MICROFRONTEND_DATES_TAB
+from lms.djangoapps.experiments.testutils import override_experiment_waffle_flag
 from openedx.features.content_type_gating.models import ContentTypeGatingConfig
 from student.models import CourseEnrollment
 
@@ -24,7 +25,7 @@ class DatesTabTestViews(BaseCourseHomeTests):
         self.url = reverse('course-home-dates-tab', args=[self.course.id])
         ContentTypeGatingConfig.objects.create(enabled=True, enabled_as_of=datetime(2017, 1, 1))
 
-    @COURSE_HOME_MICROFRONTEND.override(active=True)
+    @override_experiment_waffle_flag(COURSE_HOME_MICROFRONTEND, active=True)
     @COURSE_HOME_MICROFRONTEND_DATES_TAB.override(active=True)
     @ddt.data(CourseMode.AUDIT, CourseMode.VERIFIED)
     def test_get_authenticated_enrolled_user(self, enrollment_mode):
@@ -37,28 +38,28 @@ class DatesTabTestViews(BaseCourseHomeTests):
         self.assertEqual(response.data.get('learner_is_full_access'), enrollment_mode == CourseMode.VERIFIED)
         self.assertTrue(all(block.get('learner_has_access') for block in date_blocks))
 
-    @COURSE_HOME_MICROFRONTEND.override(active=True)
+    @override_experiment_waffle_flag(COURSE_HOME_MICROFRONTEND, active=True)
     @COURSE_HOME_MICROFRONTEND_DATES_TAB.override(active=True)
     def test_get_authenticated_user_not_enrolled(self):
         response = self.client.get(self.url)
         self.assertEqual(response.status_code, 200)
         self.assertFalse(response.data.get('learner_is_full_access'))
 
-    @COURSE_HOME_MICROFRONTEND.override(active=True)
+    @override_experiment_waffle_flag(COURSE_HOME_MICROFRONTEND, active=True)
     @COURSE_HOME_MICROFRONTEND_DATES_TAB.override(active=True)
     def test_get_unauthenticated_user(self):
         self.client.logout()
         response = self.client.get(self.url)
         self.assertEqual(response.status_code, 401)
 
-    @COURSE_HOME_MICROFRONTEND.override(active=True)
+    @override_experiment_waffle_flag(COURSE_HOME_MICROFRONTEND, active=True)
     @COURSE_HOME_MICROFRONTEND_DATES_TAB.override(active=True)
     def test_get_unknown_course(self):
         url = reverse('course-home-dates-tab', args=['course-v1:unknown+course+2T2020'])
         response = self.client.get(url)
         self.assertEqual(response.status_code, 404)
 
-    @COURSE_HOME_MICROFRONTEND.override(active=True)
+    @override_experiment_waffle_flag(COURSE_HOME_MICROFRONTEND, active=True)
     @COURSE_HOME_MICROFRONTEND_DATES_TAB.override(active=True)
     def test_banner_data_is_returned(self):
         response = self.client.get(self.url)
@@ -68,7 +69,7 @@ class DatesTabTestViews(BaseCourseHomeTests):
         self.assertContains(response, 'content_type_gating_enabled')
         self.assertContains(response, 'verified_upgrade_link')
 
-    @COURSE_HOME_MICROFRONTEND.override(active=True)
+    @override_experiment_waffle_flag(COURSE_HOME_MICROFRONTEND, active=True)
     @COURSE_HOME_MICROFRONTEND_DATES_TAB.override(active=True)
     def test_masquerade(self):
         self.switch_to_staff()

--- a/lms/djangoapps/course_home_api/dates/v1/tests/test_views.py
+++ b/lms/djangoapps/course_home_api/dates/v1/tests/test_views.py
@@ -8,6 +8,7 @@ import ddt
 from django.urls import reverse
 
 from course_modes.models import CourseMode
+from edx_toggles.toggles.testutils import override_waffle_flag
 from lms.djangoapps.course_home_api.tests.utils import BaseCourseHomeTests
 from lms.djangoapps.course_home_api.toggles import COURSE_HOME_MICROFRONTEND, COURSE_HOME_MICROFRONTEND_DATES_TAB
 from lms.djangoapps.experiments.testutils import override_experiment_waffle_flag
@@ -26,7 +27,7 @@ class DatesTabTestViews(BaseCourseHomeTests):
         ContentTypeGatingConfig.objects.create(enabled=True, enabled_as_of=datetime(2017, 1, 1))
 
     @override_experiment_waffle_flag(COURSE_HOME_MICROFRONTEND, active=True)
-    @COURSE_HOME_MICROFRONTEND_DATES_TAB.override(active=True)
+    @override_waffle_flag(COURSE_HOME_MICROFRONTEND_DATES_TAB, active=True)
     @ddt.data(CourseMode.AUDIT, CourseMode.VERIFIED)
     def test_get_authenticated_enrolled_user(self, enrollment_mode):
         CourseEnrollment.enroll(self.user, self.course.id, enrollment_mode)
@@ -39,28 +40,28 @@ class DatesTabTestViews(BaseCourseHomeTests):
         self.assertTrue(all(block.get('learner_has_access') for block in date_blocks))
 
     @override_experiment_waffle_flag(COURSE_HOME_MICROFRONTEND, active=True)
-    @COURSE_HOME_MICROFRONTEND_DATES_TAB.override(active=True)
+    @override_waffle_flag(COURSE_HOME_MICROFRONTEND_DATES_TAB, active=True)
     def test_get_authenticated_user_not_enrolled(self):
         response = self.client.get(self.url)
         self.assertEqual(response.status_code, 200)
         self.assertFalse(response.data.get('learner_is_full_access'))
 
     @override_experiment_waffle_flag(COURSE_HOME_MICROFRONTEND, active=True)
-    @COURSE_HOME_MICROFRONTEND_DATES_TAB.override(active=True)
+    @override_waffle_flag(COURSE_HOME_MICROFRONTEND_DATES_TAB, active=True)
     def test_get_unauthenticated_user(self):
         self.client.logout()
         response = self.client.get(self.url)
         self.assertEqual(response.status_code, 401)
 
     @override_experiment_waffle_flag(COURSE_HOME_MICROFRONTEND, active=True)
-    @COURSE_HOME_MICROFRONTEND_DATES_TAB.override(active=True)
+    @override_waffle_flag(COURSE_HOME_MICROFRONTEND_DATES_TAB, active=True)
     def test_get_unknown_course(self):
         url = reverse('course-home-dates-tab', args=['course-v1:unknown+course+2T2020'])
         response = self.client.get(url)
         self.assertEqual(response.status_code, 404)
 
     @override_experiment_waffle_flag(COURSE_HOME_MICROFRONTEND, active=True)
-    @COURSE_HOME_MICROFRONTEND_DATES_TAB.override(active=True)
+    @override_waffle_flag(COURSE_HOME_MICROFRONTEND_DATES_TAB, active=True)
     def test_banner_data_is_returned(self):
         response = self.client.get(self.url)
         self.assertEqual(response.status_code, 200)
@@ -70,7 +71,7 @@ class DatesTabTestViews(BaseCourseHomeTests):
         self.assertContains(response, 'verified_upgrade_link')
 
     @override_experiment_waffle_flag(COURSE_HOME_MICROFRONTEND, active=True)
-    @COURSE_HOME_MICROFRONTEND_DATES_TAB.override(active=True)
+    @override_waffle_flag(COURSE_HOME_MICROFRONTEND_DATES_TAB, active=True)
     def test_masquerade(self):
         self.switch_to_staff()
         CourseEnrollment.enroll(self.user, self.course.id, 'audit')

--- a/lms/djangoapps/course_home_api/outline/v1/tests/test_views.py
+++ b/lms/djangoapps/course_home_api/outline/v1/tests/test_views.py
@@ -11,6 +11,7 @@ from django.urls import reverse
 from mock import Mock, patch
 
 from course_modes.models import CourseMode
+from edx_toggles.toggles.testutils import override_waffle_flag
 from lms.djangoapps.course_home_api.tests.utils import BaseCourseHomeTests
 from lms.djangoapps.course_home_api.toggles import COURSE_HOME_MICROFRONTEND, COURSE_HOME_MICROFRONTEND_OUTLINE_TAB
 from lms.djangoapps.experiments.testutils import override_experiment_waffle_flag
@@ -33,9 +34,9 @@ class OutlineTabTestViews(BaseCourseHomeTests):
         super().setUp()
         self.url = reverse('course-home-outline-tab', args=[self.course.id])
 
-    @ENABLE_COURSE_GOALS.override(active=True)
+    @override_waffle_flag(ENABLE_COURSE_GOALS, active=True)
     @override_experiment_waffle_flag(COURSE_HOME_MICROFRONTEND, active=True)
-    @COURSE_HOME_MICROFRONTEND_OUTLINE_TAB.override(active=True)
+    @override_waffle_flag(COURSE_HOME_MICROFRONTEND_OUTLINE_TAB, active=True)
     @ddt.data(CourseMode.AUDIT, CourseMode.VERIFIED)
     def test_get_authenticated_enrolled_user(self, enrollment_mode):
         CourseEnrollment.enroll(self.user, self.course.id, enrollment_mode)
@@ -68,7 +69,7 @@ class OutlineTabTestViews(BaseCourseHomeTests):
             self.assertIn('http://', resume_course_url)
 
     @override_experiment_waffle_flag(COURSE_HOME_MICROFRONTEND, active=True)
-    @COURSE_HOME_MICROFRONTEND_OUTLINE_TAB.override(active=True)
+    @override_waffle_flag(COURSE_HOME_MICROFRONTEND_OUTLINE_TAB, active=True)
     def test_get_authenticated_user_not_enrolled(self):
         response = self.client.get(self.url)
         self.assertEqual(response.status_code, 200)
@@ -86,14 +87,14 @@ class OutlineTabTestViews(BaseCourseHomeTests):
         self.assertTrue(all(block.get('date') for block in date_blocks))
 
     @override_experiment_waffle_flag(COURSE_HOME_MICROFRONTEND, active=True)
-    @COURSE_HOME_MICROFRONTEND_OUTLINE_TAB.override(active=True)
+    @override_waffle_flag(COURSE_HOME_MICROFRONTEND_OUTLINE_TAB, active=True)
     def test_get_unauthenticated_user(self):
         self.client.logout()
         response = self.client.get(self.url)
         self.assertEqual(response.status_code, 403)
 
     @override_experiment_waffle_flag(COURSE_HOME_MICROFRONTEND, active=True)
-    @COURSE_HOME_MICROFRONTEND_OUTLINE_TAB.override(active=True)
+    @override_waffle_flag(COURSE_HOME_MICROFRONTEND_OUTLINE_TAB, active=True)
     def test_masquerade(self):
         user = UserFactory()
         set_user_preference(user, 'time_zone', 'Asia/Tokyo')
@@ -109,22 +110,22 @@ class OutlineTabTestViews(BaseCourseHomeTests):
         self.assertEqual(self.client.get(self.url).data['dates_widget']['user_timezone'], 'Asia/Tokyo')
 
     @override_experiment_waffle_flag(COURSE_HOME_MICROFRONTEND, active=True)
-    @COURSE_HOME_MICROFRONTEND_OUTLINE_TAB.override(active=True)
-    @COURSE_ENABLE_UNENROLLED_ACCESS_FLAG.override()
+    @override_waffle_flag(COURSE_HOME_MICROFRONTEND_OUTLINE_TAB, active=True)
+    @override_waffle_flag(COURSE_ENABLE_UNENROLLED_ACCESS_FLAG, active=True)
     def test_handouts(self):
         CourseEnrollment.enroll(self.user, self.course.id)
         self.store.create_item(self.user.id, self.course.id, 'course_info', 'handouts', fields={'data': '<p>Hi</p>'})
         self.assertEqual(self.client.get(self.url).data['handouts_html'], '<p>Hi</p>')
 
     @override_experiment_waffle_flag(COURSE_HOME_MICROFRONTEND, active=True)
-    @COURSE_HOME_MICROFRONTEND_OUTLINE_TAB.override(active=True)
+    @override_waffle_flag(COURSE_HOME_MICROFRONTEND_OUTLINE_TAB, active=True)
     def test_get_unknown_course(self):
         url = reverse('course-home-outline-tab', args=['course-v1:unknown+course+2T2020'])
         response = self.client.get(url)
         self.assertEqual(response.status_code, 404)
 
     @override_experiment_waffle_flag(COURSE_HOME_MICROFRONTEND, active=True)
-    @COURSE_HOME_MICROFRONTEND_OUTLINE_TAB.override(active=False)
+    @override_waffle_flag(COURSE_HOME_MICROFRONTEND_OUTLINE_TAB, active=False)
     @ddt.data(CourseMode.AUDIT, CourseMode.VERIFIED)
     def test_waffle_flag_disabled(self, enrollment_mode):
         CourseEnrollment.enroll(self.user, self.course.id, enrollment_mode)
@@ -132,7 +133,7 @@ class OutlineTabTestViews(BaseCourseHomeTests):
         self.assertEqual(response.status_code, 404)
 
     @override_experiment_waffle_flag(COURSE_HOME_MICROFRONTEND, active=True)
-    @COURSE_HOME_MICROFRONTEND_OUTLINE_TAB.override(active=True)
+    @override_waffle_flag(COURSE_HOME_MICROFRONTEND_OUTLINE_TAB, active=True)
     @ddt.data(True, False)
     def test_welcome_message(self, welcome_message_is_dismissed):
         CourseEnrollment.enroll(self.user, self.course.id)
@@ -159,22 +160,22 @@ class OutlineTabTestViews(BaseCourseHomeTests):
         self.assertEqual(welcome_message_html, None if welcome_message_is_dismissed else '<p>Welcome</p>')
 
     @override_experiment_waffle_flag(COURSE_HOME_MICROFRONTEND, active=True)
-    @COURSE_HOME_MICROFRONTEND_OUTLINE_TAB.override(active=True)
+    @override_waffle_flag(COURSE_HOME_MICROFRONTEND_OUTLINE_TAB, active=True)
     @patch('lms.djangoapps.course_home_api.outline.v1.views.generate_offer_html', new=Mock(return_value='<p>Offer</p>'))
     def test_offer_html(self):
         CourseEnrollment.enroll(self.user, self.course.id)
         self.assertEqual(self.client.get(self.url).data['offer_html'], '<p>Offer</p>')
 
     @override_experiment_waffle_flag(COURSE_HOME_MICROFRONTEND, active=True)
-    @COURSE_HOME_MICROFRONTEND_OUTLINE_TAB.override(active=True)
+    @override_waffle_flag(COURSE_HOME_MICROFRONTEND_OUTLINE_TAB, active=True)
     @patch('lms.djangoapps.course_home_api.outline.v1.views.generate_course_expired_message', new=Mock(return_value='<p>Expired</p>'))
     def test_course_expired_html(self):
         CourseEnrollment.enroll(self.user, self.course.id)
         self.assertEqual(self.client.get(self.url).data['course_expired_html'], '<p>Expired</p>')
 
-    @ENABLE_COURSE_GOALS.override(active=True)
+    @override_waffle_flag(ENABLE_COURSE_GOALS, active=True)
     @override_experiment_waffle_flag(COURSE_HOME_MICROFRONTEND, active=True)
-    @COURSE_HOME_MICROFRONTEND_OUTLINE_TAB.override(active=True)
+    @override_waffle_flag(COURSE_HOME_MICROFRONTEND_OUTLINE_TAB, active=True)
     def test_post_course_goal(self):
         CourseEnrollment.enroll(self.user, self.course.id, CourseMode.AUDIT)
 
@@ -194,7 +195,7 @@ class OutlineTabTestViews(BaseCourseHomeTests):
         self.assertEqual(selected_goal['key'], 'certify')
 
     @override_experiment_waffle_flag(COURSE_HOME_MICROFRONTEND, active=True)
-    @COURSE_HOME_MICROFRONTEND_OUTLINE_TAB.override(active=True)
+    @override_waffle_flag(COURSE_HOME_MICROFRONTEND_OUTLINE_TAB, active=True)
     @patch.dict('django.conf.settings.FEATURES', {'ENABLE_SPECIAL_EXAMS': True})
     @patch('lms.djangoapps.course_api.blocks.transformers.milestones.get_attempt_status_summary')
     def test_proctored_exam(self, mock_summary):
@@ -238,7 +239,7 @@ class OutlineTabTestViews(BaseCourseHomeTests):
         self.assertEqual(exam_data['icon'], 'fa-foo-bar')
 
     @override_experiment_waffle_flag(COURSE_HOME_MICROFRONTEND, active=True)
-    @COURSE_HOME_MICROFRONTEND_OUTLINE_TAB.override(active=True)
+    @override_waffle_flag(COURSE_HOME_MICROFRONTEND_OUTLINE_TAB, active=True)
     def test_assignment(self):
         course = CourseFactory.create()
         with self.store.bulk_operations(course.id):
@@ -269,8 +270,8 @@ class OutlineTabTestViews(BaseCourseHomeTests):
         self.assertIsNone(ungraded_data['icon'])
 
     @override_experiment_waffle_flag(COURSE_HOME_MICROFRONTEND, active=True)
-    @COURSE_HOME_MICROFRONTEND_OUTLINE_TAB.override()
-    @COURSE_ENABLE_UNENROLLED_ACCESS_FLAG.override()
+    @override_waffle_flag(COURSE_HOME_MICROFRONTEND_OUTLINE_TAB, active=True)
+    @override_waffle_flag(COURSE_ENABLE_UNENROLLED_ACCESS_FLAG, active=True)
     @patch('lms.djangoapps.course_home_api.outline.v1.views.generate_offer_html', new=Mock(return_value='<p>Offer</p>'))
     @patch('lms.djangoapps.course_home_api.outline.v1.views.generate_course_expired_message', new=Mock(return_value='<p>Expired</p>'))
     @ddt.data(*itertools.product([True, False], [True, False],

--- a/lms/djangoapps/course_home_api/outline/v1/tests/test_views.py
+++ b/lms/djangoapps/course_home_api/outline/v1/tests/test_views.py
@@ -13,6 +13,7 @@ from mock import Mock, patch
 from course_modes.models import CourseMode
 from lms.djangoapps.course_home_api.tests.utils import BaseCourseHomeTests
 from lms.djangoapps.course_home_api.toggles import COURSE_HOME_MICROFRONTEND, COURSE_HOME_MICROFRONTEND_OUTLINE_TAB
+from lms.djangoapps.experiments.testutils import override_experiment_waffle_flag
 from openedx.core.djangoapps.user_api.preferences.api import set_user_preference
 from openedx.core.djangoapps.user_api.tests.factories import UserCourseTagFactory
 from openedx.features.course_experience import COURSE_ENABLE_UNENROLLED_ACCESS_FLAG, ENABLE_COURSE_GOALS
@@ -33,7 +34,7 @@ class OutlineTabTestViews(BaseCourseHomeTests):
         self.url = reverse('course-home-outline-tab', args=[self.course.id])
 
     @ENABLE_COURSE_GOALS.override(active=True)
-    @COURSE_HOME_MICROFRONTEND.override(active=True)
+    @override_experiment_waffle_flag(COURSE_HOME_MICROFRONTEND, active=True)
     @COURSE_HOME_MICROFRONTEND_OUTLINE_TAB.override(active=True)
     @ddt.data(CourseMode.AUDIT, CourseMode.VERIFIED)
     def test_get_authenticated_enrolled_user(self, enrollment_mode):
@@ -66,7 +67,7 @@ class OutlineTabTestViews(BaseCourseHomeTests):
         if resume_course_url:
             self.assertIn('http://', resume_course_url)
 
-    @COURSE_HOME_MICROFRONTEND.override(active=True)
+    @override_experiment_waffle_flag(COURSE_HOME_MICROFRONTEND, active=True)
     @COURSE_HOME_MICROFRONTEND_OUTLINE_TAB.override(active=True)
     def test_get_authenticated_user_not_enrolled(self):
         response = self.client.get(self.url)
@@ -84,14 +85,14 @@ class OutlineTabTestViews(BaseCourseHomeTests):
         self.assertTrue(all((block.get('title') != "") for block in date_blocks))
         self.assertTrue(all(block.get('date') for block in date_blocks))
 
-    @COURSE_HOME_MICROFRONTEND.override(active=True)
+    @override_experiment_waffle_flag(COURSE_HOME_MICROFRONTEND, active=True)
     @COURSE_HOME_MICROFRONTEND_OUTLINE_TAB.override(active=True)
     def test_get_unauthenticated_user(self):
         self.client.logout()
         response = self.client.get(self.url)
         self.assertEqual(response.status_code, 403)
 
-    @COURSE_HOME_MICROFRONTEND.override(active=True)
+    @override_experiment_waffle_flag(COURSE_HOME_MICROFRONTEND, active=True)
     @COURSE_HOME_MICROFRONTEND_OUTLINE_TAB.override(active=True)
     def test_masquerade(self):
         user = UserFactory()
@@ -107,7 +108,7 @@ class OutlineTabTestViews(BaseCourseHomeTests):
         self.update_masquerade(username=user.username)
         self.assertEqual(self.client.get(self.url).data['dates_widget']['user_timezone'], 'Asia/Tokyo')
 
-    @COURSE_HOME_MICROFRONTEND.override(active=True)
+    @override_experiment_waffle_flag(COURSE_HOME_MICROFRONTEND, active=True)
     @COURSE_HOME_MICROFRONTEND_OUTLINE_TAB.override(active=True)
     @COURSE_ENABLE_UNENROLLED_ACCESS_FLAG.override()
     def test_handouts(self):
@@ -115,14 +116,14 @@ class OutlineTabTestViews(BaseCourseHomeTests):
         self.store.create_item(self.user.id, self.course.id, 'course_info', 'handouts', fields={'data': '<p>Hi</p>'})
         self.assertEqual(self.client.get(self.url).data['handouts_html'], '<p>Hi</p>')
 
-    @COURSE_HOME_MICROFRONTEND.override(active=True)
+    @override_experiment_waffle_flag(COURSE_HOME_MICROFRONTEND, active=True)
     @COURSE_HOME_MICROFRONTEND_OUTLINE_TAB.override(active=True)
     def test_get_unknown_course(self):
         url = reverse('course-home-outline-tab', args=['course-v1:unknown+course+2T2020'])
         response = self.client.get(url)
         self.assertEqual(response.status_code, 404)
 
-    @COURSE_HOME_MICROFRONTEND.override(active=True)
+    @override_experiment_waffle_flag(COURSE_HOME_MICROFRONTEND, active=True)
     @COURSE_HOME_MICROFRONTEND_OUTLINE_TAB.override(active=False)
     @ddt.data(CourseMode.AUDIT, CourseMode.VERIFIED)
     def test_waffle_flag_disabled(self, enrollment_mode):
@@ -130,7 +131,7 @@ class OutlineTabTestViews(BaseCourseHomeTests):
         response = self.client.get(self.url)
         self.assertEqual(response.status_code, 404)
 
-    @COURSE_HOME_MICROFRONTEND.override(active=True)
+    @override_experiment_waffle_flag(COURSE_HOME_MICROFRONTEND, active=True)
     @COURSE_HOME_MICROFRONTEND_OUTLINE_TAB.override(active=True)
     @ddt.data(True, False)
     def test_welcome_message(self, welcome_message_is_dismissed):
@@ -157,14 +158,14 @@ class OutlineTabTestViews(BaseCourseHomeTests):
         welcome_message_html = self.client.get(self.url).data['welcome_message_html']
         self.assertEqual(welcome_message_html, None if welcome_message_is_dismissed else '<p>Welcome</p>')
 
-    @COURSE_HOME_MICROFRONTEND.override(active=True)
+    @override_experiment_waffle_flag(COURSE_HOME_MICROFRONTEND, active=True)
     @COURSE_HOME_MICROFRONTEND_OUTLINE_TAB.override(active=True)
     @patch('lms.djangoapps.course_home_api.outline.v1.views.generate_offer_html', new=Mock(return_value='<p>Offer</p>'))
     def test_offer_html(self):
         CourseEnrollment.enroll(self.user, self.course.id)
         self.assertEqual(self.client.get(self.url).data['offer_html'], '<p>Offer</p>')
 
-    @COURSE_HOME_MICROFRONTEND.override(active=True)
+    @override_experiment_waffle_flag(COURSE_HOME_MICROFRONTEND, active=True)
     @COURSE_HOME_MICROFRONTEND_OUTLINE_TAB.override(active=True)
     @patch('lms.djangoapps.course_home_api.outline.v1.views.generate_course_expired_message', new=Mock(return_value='<p>Expired</p>'))
     def test_course_expired_html(self):
@@ -172,7 +173,7 @@ class OutlineTabTestViews(BaseCourseHomeTests):
         self.assertEqual(self.client.get(self.url).data['course_expired_html'], '<p>Expired</p>')
 
     @ENABLE_COURSE_GOALS.override(active=True)
-    @COURSE_HOME_MICROFRONTEND.override(active=True)
+    @override_experiment_waffle_flag(COURSE_HOME_MICROFRONTEND, active=True)
     @COURSE_HOME_MICROFRONTEND_OUTLINE_TAB.override(active=True)
     def test_post_course_goal(self):
         CourseEnrollment.enroll(self.user, self.course.id, CourseMode.AUDIT)
@@ -192,7 +193,7 @@ class OutlineTabTestViews(BaseCourseHomeTests):
         self.assertIsNotNone(selected_goal)
         self.assertEqual(selected_goal['key'], 'certify')
 
-    @COURSE_HOME_MICROFRONTEND.override(active=True)
+    @override_experiment_waffle_flag(COURSE_HOME_MICROFRONTEND, active=True)
     @COURSE_HOME_MICROFRONTEND_OUTLINE_TAB.override(active=True)
     @patch.dict('django.conf.settings.FEATURES', {'ENABLE_SPECIAL_EXAMS': True})
     @patch('lms.djangoapps.course_api.blocks.transformers.milestones.get_attempt_status_summary')
@@ -236,7 +237,7 @@ class OutlineTabTestViews(BaseCourseHomeTests):
         self.assertIsNotNone(exam_data['due'])
         self.assertEqual(exam_data['icon'], 'fa-foo-bar')
 
-    @COURSE_HOME_MICROFRONTEND.override(active=True)
+    @override_experiment_waffle_flag(COURSE_HOME_MICROFRONTEND, active=True)
     @COURSE_HOME_MICROFRONTEND_OUTLINE_TAB.override(active=True)
     def test_assignment(self):
         course = CourseFactory.create()
@@ -267,7 +268,7 @@ class OutlineTabTestViews(BaseCourseHomeTests):
         self.assertEqual(ungraded_data['display_name'], 'Ungraded')
         self.assertIsNone(ungraded_data['icon'])
 
-    @COURSE_HOME_MICROFRONTEND.override()
+    @override_experiment_waffle_flag(COURSE_HOME_MICROFRONTEND, active=True)
     @COURSE_HOME_MICROFRONTEND_OUTLINE_TAB.override()
     @COURSE_ENABLE_UNENROLLED_ACCESS_FLAG.override()
     @patch('lms.djangoapps.course_home_api.outline.v1.views.generate_offer_html', new=Mock(return_value='<p>Offer</p>'))

--- a/lms/djangoapps/course_home_api/progress/v1/tests/test_views.py
+++ b/lms/djangoapps/course_home_api/progress/v1/tests/test_views.py
@@ -3,15 +3,14 @@ Tests for Progress Tab API in the Course Home API
 """
 
 import ddt
-
 from django.urls import reverse
 
 from course_modes.models import CourseMode
+from edx_toggles.toggles.testutils import override_waffle_flag
 from lms.djangoapps.course_home_api.tests.utils import BaseCourseHomeTests
 from lms.djangoapps.course_home_api.toggles import COURSE_HOME_MICROFRONTEND
 from lms.djangoapps.verify_student.models import ManualVerification
 from openedx.core.djangoapps.user_api.preferences.api import set_user_preference
-from openedx.core.djangoapps.waffle_utils.testutils import override_waffle_flag
 from student.models import CourseEnrollment
 from student.tests.factories import UserFactory
 

--- a/lms/djangoapps/course_home_api/toggles.py
+++ b/lms/djangoapps/course_home_api/toggles.py
@@ -2,8 +2,9 @@
 Toggles for course home experience.
 """
 
+from edx_toggles.toggles import WaffleFlagNamespace
 from lms.djangoapps.experiments.flags import ExperimentWaffleFlag
-from openedx.core.djangoapps.waffle_utils import CourseWaffleFlag, WaffleFlagNamespace
+from openedx.core.djangoapps.waffle_utils import CourseWaffleFlag
 
 WAFFLE_FLAG_NAMESPACE = WaffleFlagNamespace(name='course_home')
 

--- a/lms/djangoapps/courseware/tests/test_about.py
+++ b/lms/djangoapps/courseware/tests/test_about.py
@@ -19,8 +19,8 @@ from six import text_type
 from waffle.testutils import override_switch
 
 from course_modes.models import CourseMode
+from edx_toggles.toggles.testutils import override_waffle_flag
 from lms.djangoapps.ccx.tests.factories import CcxFactory
-from openedx.core.djangoapps.waffle_utils.testutils import override_waffle_flag
 from openedx.features.course_experience import COURSE_ENABLE_UNENROLLED_ACCESS_FLAG
 from openedx.features.course_experience.waffle import ENABLE_COURSE_ABOUT_SIDEBAR_HTML
 from openedx.features.course_experience.waffle import WAFFLE_NAMESPACE as COURSE_EXPERIENCE_WAFFLE_NAMESPACE

--- a/lms/djangoapps/courseware/tests/test_course_info.py
+++ b/lms/djangoapps/courseware/tests/test_course_info.py
@@ -14,16 +14,17 @@ from django.conf import settings
 from django.http import QueryDict
 from django.test.utils import override_settings
 from django.urls import reverse
-from pyquery import PyQuery as pq
+from edx_toggles.toggles.testutils import override_waffle_flag
 from six import text_type
 
 from lms.djangoapps.ccx.tests.factories import CcxFactory
 from openedx.core.djangoapps.self_paced.models import SelfPacedConfiguration
 from openedx.core.djangoapps.site_configuration.tests.test_util import with_site_configuration_context
-from openedx.core.djangoapps.waffle_utils.testutils import WAFFLE_TABLES, override_waffle_flag
+from openedx.core.djangoapps.waffle_utils.testutils import WAFFLE_TABLES
 from openedx.features.content_type_gating.models import ContentTypeGatingConfig
 from openedx.features.course_experience import DISABLE_UNIFIED_COURSE_TAB_FLAG
 from openedx.features.enterprise_support.tests.mixins.enterprise import EnterpriseTestConsentRequired
+from pyquery import PyQuery as pq
 from student.models import CourseEnrollment
 from student.tests.factories import AdminFactory
 from util.date_utils import strftime_localized

--- a/lms/djangoapps/courseware/tests/test_course_tools.py
+++ b/lms/djangoapps/courseware/tests/test_course_tools.py
@@ -12,13 +12,12 @@ from mock import patch
 
 from course_modes.models import CourseMode
 from course_modes.tests.factories import CourseModeFactory
-from lms.djangoapps.courseware.course_tools import FinancialAssistanceTool
-from lms.djangoapps.courseware.course_tools import VerifiedUpgradeTool
+from edx_toggles.toggles.testutils import override_waffle_flag
+from lms.djangoapps.courseware.course_tools import FinancialAssistanceTool, VerifiedUpgradeTool
 from lms.djangoapps.courseware.models import DynamicUpgradeDeadlineConfiguration
 from openedx.core.djangoapps.content.course_overviews.models import CourseOverview
 from openedx.core.djangoapps.schedules.config import CREATE_SCHEDULE_WAFFLE_FLAG
 from openedx.core.djangoapps.site_configuration.tests.factories import SiteFactory
-from openedx.core.djangoapps.waffle_utils.testutils import override_waffle_flag
 from student.tests.factories import CourseEnrollmentFactory, UserFactory
 from xmodule.modulestore.tests.django_utils import SharedModuleStoreTestCase
 from xmodule.modulestore.tests.factories import CourseFactory

--- a/lms/djangoapps/courseware/tests/test_date_summary.py
+++ b/lms/djangoapps/courseware/tests/test_date_summary.py
@@ -10,12 +10,14 @@ import waffle
 from django.contrib.messages.middleware import MessageMiddleware
 from django.test import RequestFactory
 from django.urls import reverse
-from freezegun import freeze_time
 from mock import patch
 from pytz import utc
 
 from course_modes.models import CourseMode
 from course_modes.tests.factories import CourseModeFactory
+from freezegun import freeze_time
+from lms.djangoapps.commerce.models import CommerceConfiguration
+from lms.djangoapps.course_home_api.toggles import COURSE_HOME_MICROFRONTEND, COURSE_HOME_MICROFRONTEND_DATES_TAB
 from lms.djangoapps.courseware.courses import get_course_date_blocks
 from lms.djangoapps.courseware.date_summary import (
     CertificateAvailableDate,
@@ -32,8 +34,7 @@ from lms.djangoapps.courseware.models import (
     DynamicUpgradeDeadlineConfiguration,
     OrgDynamicUpgradeDeadlineConfiguration
 )
-from lms.djangoapps.commerce.models import CommerceConfiguration
-from lms.djangoapps.course_home_api.toggles import COURSE_HOME_MICROFRONTEND, COURSE_HOME_MICROFRONTEND_DATES_TAB
+from lms.djangoapps.experiments.testutils import override_experiment_waffle_flag
 from lms.djangoapps.verify_student.models import VerificationDeadline
 from lms.djangoapps.verify_student.tests.factories import SoftwareSecurePhotoVerificationFactory
 from openedx.core.djangoapps.content.course_overviews.models import CourseOverview
@@ -44,7 +45,10 @@ from openedx.core.djangoapps.user_api.preferences.api import set_user_preference
 from openedx.core.djangoapps.waffle_utils.testutils import override_waffle_flag
 from openedx.features.course_duration_limits.models import CourseDurationLimitConfig
 from openedx.features.course_experience import (
-    RELATIVE_DATES_FLAG, DISABLE_UNIFIED_COURSE_TAB_FLAG, UPGRADE_DEADLINE_MESSAGE, CourseHomeMessages
+    DISABLE_UNIFIED_COURSE_TAB_FLAG,
+    RELATIVE_DATES_FLAG,
+    UPGRADE_DEADLINE_MESSAGE,
+    CourseHomeMessages
 )
 from student.tests.factories import TEST_PASSWORD, CourseEnrollmentFactory, UserFactory
 from xmodule.modulestore import ModuleStoreEnum
@@ -145,7 +149,7 @@ class CourseDateSummaryTest(SharedModuleStoreTestCase):
         CourseEnrollmentFactory(course_id=course.id, user=user, mode=CourseMode.VERIFIED)
         self.assert_block_types(course, user, expected_blocks)
 
-    @RELATIVE_DATES_FLAG.override(active=True)
+    @override_experiment_waffle_flag(RELATIVE_DATES_FLAG, active=True)
     def test_enabled_block_types_with_assignments(self):  # pylint: disable=too-many-statements
         """
         Creates a course with multiple subsections to test all of the different
@@ -300,7 +304,7 @@ class CourseDateSummaryTest(SharedModuleStoreTestCase):
                 for html_tag in assignment_title_html:
                     self.assertIn(html_tag, assignment_title)
 
-    @RELATIVE_DATES_FLAG.override(active=True)
+    @override_experiment_waffle_flag(RELATIVE_DATES_FLAG, active=True)
     @ddt.data(
         ([], 3),
         ([{
@@ -366,7 +370,7 @@ class CourseDateSummaryTest(SharedModuleStoreTestCase):
         blocks = get_course_date_blocks(course, user, request, include_past_dates=True)
         self.assertEqual(len(blocks), date_block_count)
 
-    @RELATIVE_DATES_FLAG.override(active=True)
+    @override_experiment_waffle_flag(RELATIVE_DATES_FLAG, active=True)
     def test_enabled_block_types_with_expired_course(self):
         course = create_course_run(days_till_start=-100)
         user = create_user()
@@ -543,7 +547,7 @@ class CourseDateSummaryTest(SharedModuleStoreTestCase):
         {'weeks_to_complete': 7},  # Weeks to complete > time til end (end date shown)
         {'weeks_to_complete': 4},  # Weeks to complete < time til end (end date not shown)
     )
-    @RELATIVE_DATES_FLAG.override(active=True)
+    @override_experiment_waffle_flag(RELATIVE_DATES_FLAG, active=True)
     def test_course_end_date_self_paced(self, cr_details):
         """
         In self-paced courses, the end date will now only show up if the learner
@@ -733,7 +737,7 @@ class CourseDateSummaryTest(SharedModuleStoreTestCase):
     )
     @ddt.unpack
     @override_waffle_flag(DISABLE_UNIFIED_COURSE_TAB_FLAG, active=False)
-    @RELATIVE_DATES_FLAG.override(active=True)
+    @override_experiment_waffle_flag(RELATIVE_DATES_FLAG, active=True)
     def test_dates_tab_link_render(self, url_name, mfe_active):
         """ The dates tab link should only show for enrolled or staff users """
         course = create_course_run()
@@ -751,7 +755,7 @@ class CourseDateSummaryTest(SharedModuleStoreTestCase):
         def assert_html_elements(assert_function, user):
             self.client.login(username=user.username, password=TEST_PASSWORD)
             if mfe_active:
-                with COURSE_HOME_MICROFRONTEND.override(active=True), \
+                with override_experiment_waffle_flag(COURSE_HOME_MICROFRONTEND, active=True), \
                      COURSE_HOME_MICROFRONTEND_DATES_TAB.override(active=True):
                     response = self.client.get(url, follow=True)
             else:

--- a/lms/djangoapps/courseware/tests/test_date_summary.py
+++ b/lms/djangoapps/courseware/tests/test_date_summary.py
@@ -10,6 +10,7 @@ import waffle
 from django.contrib.messages.middleware import MessageMiddleware
 from django.test import RequestFactory
 from django.urls import reverse
+from edx_toggles.toggles.testutils import override_waffle_flag
 from mock import patch
 from pytz import utc
 
@@ -42,7 +43,6 @@ from openedx.core.djangoapps.schedules.signals import CREATE_SCHEDULE_WAFFLE_FLA
 from openedx.core.djangoapps.self_paced.models import SelfPacedConfiguration
 from openedx.core.djangoapps.site_configuration.tests.factories import SiteFactory
 from openedx.core.djangoapps.user_api.preferences.api import set_user_preference
-from openedx.core.djangoapps.waffle_utils.testutils import override_waffle_flag
 from openedx.features.course_duration_limits.models import CourseDurationLimitConfig
 from openedx.features.course_experience import (
     DISABLE_UNIFIED_COURSE_TAB_FLAG,
@@ -756,7 +756,7 @@ class CourseDateSummaryTest(SharedModuleStoreTestCase):
             self.client.login(username=user.username, password=TEST_PASSWORD)
             if mfe_active:
                 with override_experiment_waffle_flag(COURSE_HOME_MICROFRONTEND, active=True), \
-                     COURSE_HOME_MICROFRONTEND_DATES_TAB.override(active=True):
+                     override_waffle_flag(COURSE_HOME_MICROFRONTEND_DATES_TAB, active=True):
                     response = self.client.get(url, follow=True)
             else:
                 response = self.client.get(url, follow=True)

--- a/lms/djangoapps/courseware/tests/test_entrance_exam.py
+++ b/lms/djangoapps/courseware/tests/test_entrance_exam.py
@@ -10,6 +10,7 @@ from milestones.tests.utils import MilestonesTestCaseMixin
 from mock import Mock, patch
 
 from capa.tests.response_xml_factory import MultipleChoiceResponseXMLFactory
+from edx_toggles.toggles.testutils import override_waffle_flag
 from lms.djangoapps.courseware.entrance_exams import (
     course_has_entrance_exam,
     get_entrance_exam_content,
@@ -20,7 +21,6 @@ from lms.djangoapps.courseware.model_data import FieldDataCache
 from lms.djangoapps.courseware.module_render import get_module, handle_xblock_callback, toc_for_course
 from lms.djangoapps.courseware.tests.factories import InstructorFactory, RequestFactoryNoCsrf, StaffFactory, UserFactory
 from lms.djangoapps.courseware.tests.helpers import LoginEnrollmentTestCase
-from openedx.core.djangoapps.waffle_utils.testutils import override_waffle_flag
 from openedx.core.djangolib.testing.utils import get_mock_request
 from openedx.features.course_experience import DISABLE_COURSE_OUTLINE_PAGE_FLAG, DISABLE_UNIFIED_COURSE_TAB_FLAG
 from student.models import CourseEnrollment

--- a/lms/djangoapps/courseware/tests/test_masquerade.py
+++ b/lms/djangoapps/courseware/tests/test_masquerade.py
@@ -19,7 +19,9 @@ from xblock.runtime import DictKeyValueStore
 
 from capa.tests.response_xml_factory import OptionResponseXMLFactory
 from lms.djangoapps.courseware.masquerade import (
-    CourseMasquerade, MasqueradingKeyValueStore, get_masquerading_user_group,
+    CourseMasquerade,
+    MasqueradingKeyValueStore,
+    get_masquerading_user_group
 )
 from lms.djangoapps.courseware.tests.factories import StaffFactory
 from lms.djangoapps.courseware.tests.helpers import LoginEnrollmentTestCase, MasqueradeMixin, masquerade_as_group_member

--- a/lms/djangoapps/courseware/tests/test_masquerade.py
+++ b/lms/djangoapps/courseware/tests/test_masquerade.py
@@ -13,6 +13,7 @@ import six
 from django.conf import settings
 from django.test import TestCase
 from django.urls import reverse
+from edx_toggles.toggles.testutils import override_waffle_flag
 from mock import patch
 from pytz import UTC
 from xblock.runtime import DictKeyValueStore
@@ -29,7 +30,6 @@ from lms.djangoapps.courseware.tests.test_submitting_problems import ProblemSubm
 from openedx.core.djangoapps.lang_pref import LANGUAGE_KEY
 from openedx.core.djangoapps.self_paced.models import SelfPacedConfiguration
 from openedx.core.djangoapps.user_api.preferences.api import get_user_preference, set_user_preference
-from openedx.core.djangoapps.waffle_utils.testutils import override_waffle_flag
 from openedx.features.course_experience import DISABLE_UNIFIED_COURSE_TAB_FLAG
 from student.models import CourseEnrollment
 from student.tests.factories import UserFactory

--- a/lms/djangoapps/courseware/tests/test_navigation.py
+++ b/lms/djangoapps/courseware/tests/test_navigation.py
@@ -12,9 +12,9 @@ from mock import patch
 from six import text_type
 from six.moves import range
 
+from edx_toggles.toggles.testutils import override_waffle_flag
 from lms.djangoapps.courseware.tests.factories import GlobalStaffFactory
 from lms.djangoapps.courseware.tests.helpers import LoginEnrollmentTestCase
-from openedx.core.djangoapps.waffle_utils.testutils import override_waffle_flag
 from openedx.features.course_experience import DISABLE_COURSE_OUTLINE_PAGE_FLAG
 from student.tests.factories import UserFactory
 from xmodule.modulestore.django import modulestore

--- a/lms/djangoapps/courseware/tests/test_tabs.py
+++ b/lms/djangoapps/courseware/tests/test_tabs.py
@@ -13,6 +13,7 @@ from mock import MagicMock, Mock, patch
 from six import text_type
 from six.moves import range
 
+from edx_toggles.toggles.testutils import override_waffle_flag
 from lms.djangoapps.courseware.courses import get_course_by_id
 from lms.djangoapps.courseware.tabs import (
     CourseInfoTab,
@@ -26,7 +27,6 @@ from lms.djangoapps.courseware.tabs import (
 from lms.djangoapps.courseware.tests.factories import InstructorFactory, StaffFactory
 from lms.djangoapps.courseware.tests.helpers import LoginEnrollmentTestCase
 from lms.djangoapps.courseware.views.views import StaticCourseTabView, get_static_tab_fragment
-from openedx.core.djangoapps.waffle_utils.testutils import override_waffle_flag
 from openedx.core.djangolib.testing.utils import get_mock_request
 from openedx.features.course_experience import DISABLE_UNIFIED_COURSE_TAB_FLAG
 from student.models import CourseEnrollment

--- a/lms/djangoapps/courseware/tests/test_views.py
+++ b/lms/djangoapps/courseware/tests/test_views.py
@@ -74,7 +74,7 @@ from openedx.core.djangoapps.content.course_overviews.models import CourseOvervi
 from openedx.core.djangoapps.crawlers.models import CrawlersConfig
 from openedx.core.djangoapps.credit.api import set_credit_requirements
 from openedx.core.djangoapps.credit.models import CreditCourse, CreditProvider
-from openedx.core.djangoapps.waffle_utils.testutils import WAFFLE_TABLES, override_waffle_flag
+from openedx.core.djangoapps.waffle_utils.testutils import WAFFLE_TABLES
 from openedx.core.djangolib.testing.utils import get_mock_request
 from openedx.core.lib.gating import api as gating_api
 from openedx.core.lib.url_utils import quote_slashes
@@ -1446,7 +1446,7 @@ class ProgressPageTests(ProgressPageBaseTests):
     def test_progress_queries(self, enable_waffle, initial, subsequent):
         ContentTypeGatingConfig.objects.create(enabled=True, enabled_as_of=datetime(2018, 1, 1))
         self.setup_course()
-        with override_waffle_flag(ASSUME_ZERO_GRADE_IF_ABSENT, active=enable_waffle):
+        with grades_waffle().override(ASSUME_ZERO_GRADE_IF_ABSENT, active=enable_waffle):
             with self.assertNumQueries(
                 initial, table_blacklist=QUERY_COUNT_TABLE_BLACKLIST
             ), check_mongo_calls(1):

--- a/lms/djangoapps/courseware/tests/test_views.py
+++ b/lms/djangoapps/courseware/tests/test_views.py
@@ -11,17 +11,10 @@ import unittest
 from datetime import datetime, timedelta
 from uuid import uuid4
 
+import ddt
 import six
-from markupsafe import escape
-from mock import MagicMock, PropertyMock, call, create_autospec, patch
-from pytz import UTC, utc
-from six import text_type
-from six.moves import range
-from six.moves.urllib.parse import quote, urlencode
-
 from completion.test_utils import CompletionWaffleTestMixin
 from crum import set_current_request
-import ddt
 from django.conf import settings
 from django.contrib.auth.models import AnonymousUser
 from django.http import Http404, HttpResponseBadRequest
@@ -30,17 +23,24 @@ from django.test.client import Client
 from django.test.utils import override_settings
 from django.urls import reverse, reverse_lazy
 from freezegun import freeze_time
+from markupsafe import escape
 from milestones.tests.utils import MilestonesTestCaseMixin
+from mock import MagicMock, PropertyMock, call, create_autospec, patch
 from opaque_keys.edx.keys import CourseKey, UsageKey
 from opaque_keys.edx.locator import BlockUsageLocator, CourseLocator
+from pytz import UTC, utc
+from six import text_type
+from six.moves import range
+from six.moves.urllib.parse import quote, urlencode
 from web_fragments.fragment import Fragment
 from xblock.core import XBlock
 from xblock.fields import Scope, String
-import lms.djangoapps.courseware.views.views as views
 
+import lms.djangoapps.courseware.views.views as views
 from capa.tests.response_xml_factory import MultipleChoiceResponseXMLFactory
 from course_modes.models import CourseMode
 from course_modes.tests.factories import CourseModeFactory
+from edx_toggles.toggles.testutils import override_waffle_flag
 from lms.djangoapps.certificates import api as certs_api
 from lms.djangoapps.certificates.models import (
     CertificateGenerationConfiguration,
@@ -63,6 +63,7 @@ from lms.djangoapps.courseware.toggles import (
 from lms.djangoapps.courseware.url_helpers import get_microfrontend_url, get_redirect_url
 from lms.djangoapps.courseware.user_state_client import DjangoXBlockUserStateClient
 from lms.djangoapps.courseware.views.index import show_courseware_mfe_link
+from lms.djangoapps.experiments.testutils import override_experiment_waffle_flag
 from lms.djangoapps.grades.config.waffle import ASSUME_ZERO_GRADE_IF_ABSENT
 from lms.djangoapps.grades.config.waffle import waffle as grades_waffle
 from lms.djangoapps.verify_student.models import VerificationDeadline
@@ -1445,7 +1446,7 @@ class ProgressPageTests(ProgressPageBaseTests):
     def test_progress_queries(self, enable_waffle, initial, subsequent):
         ContentTypeGatingConfig.objects.create(enabled=True, enabled_as_of=datetime(2018, 1, 1))
         self.setup_course()
-        with grades_waffle().override(ASSUME_ZERO_GRADE_IF_ABSENT, active=enable_waffle):
+        with override_waffle_flag(ASSUME_ZERO_GRADE_IF_ABSENT, active=enable_waffle):
             with self.assertNumQueries(
                 initial, table_blacklist=QUERY_COUNT_TABLE_BLACKLIST
             ), check_mongo_calls(1):
@@ -3135,7 +3136,7 @@ class DatesTabTestCase(ModuleStoreTestCase):
         response = self._get_response(self.course)
         self.assertEqual(response.status_code, 200)
 
-    @RELATIVE_DATES_FLAG.override(active=True)
+    @override_experiment_waffle_flag(RELATIVE_DATES_FLAG, active=True)
     @patch('edx_django_utils.monitoring.set_custom_attribute')
     def test_defaults(self, mock_set_custom_attribute):
         enrollment = CourseEnrollmentFactory(course_id=self.course.id, user=self.user, mode=CourseMode.VERIFIED)
@@ -3196,7 +3197,7 @@ class DatesTabTestCase(ModuleStoreTestCase):
             # Make sure the assignment type is rendered
             self.assertContains(response, 'Homework:')
 
-    @RELATIVE_DATES_FLAG.override(active=True)
+    @override_experiment_waffle_flag(RELATIVE_DATES_FLAG, active=True)
     def test_reset_deadlines_banner_displays(self):
         CourseEnrollmentFactory(course_id=self.course.id, user=self.user, mode=CourseMode.VERIFIED)
         now = datetime.now(utc)
@@ -3250,7 +3251,7 @@ class TestShowCoursewareMFE(TestCase):
         )
         for user, course_key, is_course_staff, preview_active, redirect_active in combos:
             with override_waffle_flag(COURSEWARE_MICROFRONTEND_COURSE_TEAM_PREVIEW, preview_active):
-                with REDIRECT_TO_COURSEWARE_MICROFRONTEND.override(active=redirect_active):
+                with override_experiment_waffle_flag(REDIRECT_TO_COURSEWARE_MICROFRONTEND, active=redirect_active):
                     assert show_courseware_mfe_link(user, is_course_staff, course_key) is False
 
     @patch.dict(settings.FEATURES, {'ENABLE_COURSEWARE_MICROFRONTEND': True})
@@ -3270,14 +3271,14 @@ class TestShowCoursewareMFE(TestCase):
         )
         for user, is_course_staff, preview_active, redirect_active in old_mongo_combos:
             with override_waffle_flag(COURSEWARE_MICROFRONTEND_COURSE_TEAM_PREVIEW, preview_active):
-                with REDIRECT_TO_COURSEWARE_MICROFRONTEND.override(active=redirect_active):
+                with override_experiment_waffle_flag(REDIRECT_TO_COURSEWARE_MICROFRONTEND, active=redirect_active):
                     assert show_courseware_mfe_link(user, is_course_staff, old_course_key) is False
 
         # We've checked all old-style course keys now, so we can test only the
         # new ones going forward. Now we check combinations of waffle flags and
         # user permissions...
         with override_waffle_flag(COURSEWARE_MICROFRONTEND_COURSE_TEAM_PREVIEW, True):
-            with REDIRECT_TO_COURSEWARE_MICROFRONTEND.override(active=True):
+            with override_experiment_waffle_flag(REDIRECT_TO_COURSEWARE_MICROFRONTEND, active=True):
                 # (preview=on, redirect=on)
                 # Global and Course Staff can see the link.
                 self.assertTrue(show_courseware_mfe_link(global_staff_user, True, new_course_key))
@@ -3286,7 +3287,7 @@ class TestShowCoursewareMFE(TestCase):
 
                 # Regular users don't see the link.
                 self.assertFalse(show_courseware_mfe_link(regular_user, False, new_course_key))
-            with REDIRECT_TO_COURSEWARE_MICROFRONTEND.override(active=False):
+            with override_experiment_waffle_flag(REDIRECT_TO_COURSEWARE_MICROFRONTEND, active=False):
                 # (preview=on, redirect=off)
                 # Global and Course Staff can see the link.
                 self.assertTrue(show_courseware_mfe_link(global_staff_user, True, new_course_key))
@@ -3297,7 +3298,7 @@ class TestShowCoursewareMFE(TestCase):
                 self.assertFalse(show_courseware_mfe_link(regular_user, False, new_course_key))
 
         with override_waffle_flag(COURSEWARE_MICROFRONTEND_COURSE_TEAM_PREVIEW, False):
-            with REDIRECT_TO_COURSEWARE_MICROFRONTEND.override(active=True):
+            with override_experiment_waffle_flag(REDIRECT_TO_COURSEWARE_MICROFRONTEND, active=True):
                 # (preview=off, redirect=on)
                 # Global staff see the link anyway
                 self.assertTrue(show_courseware_mfe_link(global_staff_user, True, new_course_key))
@@ -3309,7 +3310,7 @@ class TestShowCoursewareMFE(TestCase):
 
                 # Regular users don't see the link.
                 self.assertFalse(show_courseware_mfe_link(regular_user, False, new_course_key))
-            with REDIRECT_TO_COURSEWARE_MICROFRONTEND.override(active=False):
+            with override_experiment_waffle_flag(REDIRECT_TO_COURSEWARE_MICROFRONTEND, active=False):
                 # (preview=off, redirect=off)
                 # Global staff see the link anyway
                 self.assertTrue(show_courseware_mfe_link(global_staff_user, True, new_course_key))
@@ -3368,7 +3369,7 @@ class MFERedirectTests(BaseViewsTestCase):
         # learners will be redirected when the waffle flag is set
         lms_url, mfe_url = self._get_urls()
 
-        with REDIRECT_TO_COURSEWARE_MICROFRONTEND.override(active=True):
+        with override_experiment_waffle_flag(REDIRECT_TO_COURSEWARE_MICROFRONTEND, active=True):
             assert self.client.get(lms_url).url == mfe_url
 
     def test_staff_no_redirect(self):
@@ -3380,14 +3381,14 @@ class MFERedirectTests(BaseViewsTestCase):
         self.client.login(username=course_staff.username, password='test')
 
         assert self.client.get(lms_url).status_code == 200
-        with REDIRECT_TO_COURSEWARE_MICROFRONTEND.override(active=True):
+        with override_experiment_waffle_flag(REDIRECT_TO_COURSEWARE_MICROFRONTEND, active=True):
             assert self.client.get(lms_url).status_code == 200
 
         # global staff will never be redirected
         self._create_global_staff_user()
         assert self.client.get(lms_url).status_code == 200
 
-        with REDIRECT_TO_COURSEWARE_MICROFRONTEND.override(active=True):
+        with override_experiment_waffle_flag(REDIRECT_TO_COURSEWARE_MICROFRONTEND, active=True):
             assert self.client.get(lms_url).status_code == 200
 
     def test_exam_no_redirect(self):
@@ -3397,5 +3398,5 @@ class MFERedirectTests(BaseViewsTestCase):
 
         lms_url, mfe_url = self._get_urls()
 
-        with REDIRECT_TO_COURSEWARE_MICROFRONTEND.override(active=True):
+        with override_experiment_waffle_flag(REDIRECT_TO_COURSEWARE_MICROFRONTEND, active=True):
             assert self.client.get(lms_url).status_code == 200

--- a/lms/djangoapps/courseware/tests/test_views.py
+++ b/lms/djangoapps/courseware/tests/test_views.py
@@ -22,7 +22,7 @@ from django.test import RequestFactory, TestCase
 from django.test.client import Client
 from django.test.utils import override_settings
 from django.urls import reverse, reverse_lazy
-from freezegun import freeze_time
+from edx_toggles.toggles.testutils import override_waffle_flag, override_waffle_switch
 from markupsafe import escape
 from milestones.tests.utils import MilestonesTestCaseMixin
 from mock import MagicMock, PropertyMock, call, create_autospec, patch
@@ -40,7 +40,7 @@ import lms.djangoapps.courseware.views.views as views
 from capa.tests.response_xml_factory import MultipleChoiceResponseXMLFactory
 from course_modes.models import CourseMode
 from course_modes.tests.factories import CourseModeFactory
-from edx_toggles.toggles.testutils import override_waffle_flag
+from freezegun import freeze_time
 from lms.djangoapps.certificates import api as certs_api
 from lms.djangoapps.certificates.models import (
     CertificateGenerationConfiguration,
@@ -74,7 +74,7 @@ from openedx.core.djangoapps.content.course_overviews.models import CourseOvervi
 from openedx.core.djangoapps.crawlers.models import CrawlersConfig
 from openedx.core.djangoapps.credit.api import set_credit_requirements
 from openedx.core.djangoapps.credit.models import CreditCourse, CreditProvider
-from openedx.core.djangoapps.waffle_utils.testutils import WAFFLE_TABLES, override_waffle_switch
+from openedx.core.djangoapps.waffle_utils.testutils import WAFFLE_TABLES
 from openedx.core.djangolib.testing.utils import get_mock_request
 from openedx.core.lib.gating import api as gating_api
 from openedx.core.lib.url_utils import quote_slashes

--- a/lms/djangoapps/courseware/tests/test_views.py
+++ b/lms/djangoapps/courseware/tests/test_views.py
@@ -65,7 +65,7 @@ from lms.djangoapps.courseware.user_state_client import DjangoXBlockUserStateCli
 from lms.djangoapps.courseware.views.index import show_courseware_mfe_link
 from lms.djangoapps.experiments.testutils import override_experiment_waffle_flag
 from lms.djangoapps.grades.config.waffle import ASSUME_ZERO_GRADE_IF_ABSENT
-from lms.djangoapps.grades.config.waffle import waffle as grades_waffle
+from lms.djangoapps.grades.config.waffle import waffle_switch as grades_waffle_switch
 from lms.djangoapps.verify_student.models import VerificationDeadline
 from lms.djangoapps.verify_student.services import IDVerificationService
 from openedx.core.djangoapps.catalog.tests.factories import CourseFactory as CatalogCourseFactory
@@ -74,7 +74,7 @@ from openedx.core.djangoapps.content.course_overviews.models import CourseOvervi
 from openedx.core.djangoapps.crawlers.models import CrawlersConfig
 from openedx.core.djangoapps.credit.api import set_credit_requirements
 from openedx.core.djangoapps.credit.models import CreditCourse, CreditProvider
-from openedx.core.djangoapps.waffle_utils.testutils import WAFFLE_TABLES
+from openedx.core.djangoapps.waffle_utils.testutils import WAFFLE_TABLES, override_waffle_switch
 from openedx.core.djangolib.testing.utils import get_mock_request
 from openedx.core.lib.gating import api as gating_api
 from openedx.core.lib.url_utils import quote_slashes
@@ -1446,7 +1446,7 @@ class ProgressPageTests(ProgressPageBaseTests):
     def test_progress_queries(self, enable_waffle, initial, subsequent):
         ContentTypeGatingConfig.objects.create(enabled=True, enabled_as_of=datetime(2018, 1, 1))
         self.setup_course()
-        with grades_waffle().override(ASSUME_ZERO_GRADE_IF_ABSENT, active=enable_waffle):
+        with override_waffle_switch(grades_waffle_switch(ASSUME_ZERO_GRADE_IF_ABSENT), active=enable_waffle):
             with self.assertNumQueries(
                 initial, table_blacklist=QUERY_COUNT_TABLE_BLACKLIST
             ), check_mongo_calls(1):

--- a/lms/djangoapps/courseware/toggles.py
+++ b/lms/djangoapps/courseware/toggles.py
@@ -2,8 +2,9 @@
 Toggles for courseware in-course experience.
 """
 
+from edx_toggles.toggles import WaffleFlagNamespace
 from lms.djangoapps.experiments.flags import ExperimentWaffleFlag
-from openedx.core.djangoapps.waffle_utils import CourseWaffleFlag, WaffleFlagNamespace
+from openedx.core.djangoapps.waffle_utils import CourseWaffleFlag
 
 # Namespace for courseware waffle flags.
 WAFFLE_FLAG_NAMESPACE = WaffleFlagNamespace(name='courseware')

--- a/lms/djangoapps/courseware/views/index.py
+++ b/lms/djangoapps/courseware/views/index.py
@@ -8,7 +8,6 @@ View for Courseware Index
 import logging
 
 import six
-from six.moves import urllib
 from django.conf import settings
 from django.contrib.auth.views import redirect_to_login
 from django.db import transaction
@@ -22,8 +21,10 @@ from django.views.decorators.cache import cache_control
 from django.views.decorators.csrf import ensure_csrf_cookie
 from django.views.generic import View
 from edx_django_utils.monitoring import set_custom_attributes_for_course_key
+from edx_toggles.toggles import WaffleSwitchNamespace
 from opaque_keys import InvalidKeyError
 from opaque_keys.edx.keys import CourseKey, UsageKey
+from six.moves import urllib
 from web_fragments.fragment import Fragment
 
 from edxmako.shortcuts import render_to_response, render_to_string
@@ -36,13 +37,12 @@ from openedx.core.djangoapps.crawlers.models import CrawlersConfig
 from openedx.core.djangoapps.lang_pref import LANGUAGE_KEY
 from openedx.core.djangoapps.user_api.preferences.api import get_user_preference
 from openedx.core.djangoapps.util.user_messages import PageLevelMessages
-from openedx.core.djangoapps.waffle_utils import WaffleSwitchNamespace
 from openedx.core.djangolib.markup import HTML, Text
 from openedx.features.course_experience import (
     COURSE_ENABLE_UNENROLLED_ACCESS_FLAG,
     DISABLE_COURSE_OUTLINE_PAGE_FLAG,
-    default_course_url_name,
     RELATIVE_DATES_FLAG,
+    default_course_url_name
 )
 from openedx.features.course_experience.urls import COURSE_HOME_VIEW_NAME
 from openedx.features.course_experience.views.course_sock import CourseSockFragmentView
@@ -55,12 +55,7 @@ from xmodule.x_module import PUBLIC_VIEW, STUDENT_VIEW
 
 from ..access import has_access
 from ..access_utils import check_public_access
-from ..courses import (
-    check_course_access_with_redirect,
-    get_course_with_access,
-    get_current_child,
-    get_studio_url
-)
+from ..courses import check_course_access_with_redirect, get_course_with_access, get_current_child, get_studio_url
 from ..entrance_exams import (
     course_has_entrance_exam,
     get_entrance_exam_content,
@@ -71,14 +66,9 @@ from ..masquerade import check_content_start_date_for_masquerade_user, setup_mas
 from ..model_data import FieldDataCache
 from ..module_render import get_module_for_descriptor, toc_for_course
 from ..permissions import MASQUERADE_AS_STUDENT
-from ..toggles import (
-    COURSEWARE_MICROFRONTEND_COURSE_TEAM_PREVIEW,
-    REDIRECT_TO_COURSEWARE_MICROFRONTEND,
-)
+from ..toggles import COURSEWARE_MICROFRONTEND_COURSE_TEAM_PREVIEW, REDIRECT_TO_COURSEWARE_MICROFRONTEND
 from ..url_helpers import get_microfrontend_url
-
 from .views import CourseTabView
-
 
 log = logging.getLogger("edx.courseware.views.index")
 

--- a/lms/djangoapps/email_marketing/signals.py
+++ b/lms/djangoapps/email_marketing/signals.py
@@ -16,16 +16,20 @@ from six import text_type
 
 import third_party_auth
 from course_modes.models import CourseMode
-from .models import EmailMarketingConfiguration
-from lms.djangoapps.email_marketing.tasks import get_email_cookies_via_sailthru, update_user, update_user_email
+from edx_toggles.toggles import WaffleSwitchNamespace
+from lms.djangoapps.email_marketing.tasks import (
+    get_email_cookies_via_sailthru,
+    update_course_enrollment,
+    update_user,
+    update_user_email
+)
 from openedx.core.djangoapps.lang_pref import LANGUAGE_KEY
 from openedx.core.djangoapps.user_authn.cookies import CREATE_LOGON_COOKIE
 from openedx.core.djangoapps.user_authn.views.register import REGISTER_USER
-from openedx.core.djangoapps.waffle_utils import WaffleSwitchNamespace
 from student.signals import SAILTHRU_AUDIT_PURCHASE
 from util.model_utils import USER_FIELD_CHANGED
 
-from lms.djangoapps.email_marketing.tasks import update_course_enrollment
+from .models import EmailMarketingConfiguration
 
 log = logging.getLogger(__name__)
 

--- a/lms/djangoapps/email_marketing/tests/test_signals.py
+++ b/lms/djangoapps/email_marketing/tests/test_signals.py
@@ -7,6 +7,7 @@ import datetime
 import logging
 
 import ddt
+import six
 from django.conf import settings
 from django.contrib.auth.models import AnonymousUser
 from django.contrib.sites.models import Site
@@ -17,16 +18,8 @@ from mock import ANY, Mock, patch
 from opaque_keys.edx.keys import CourseKey
 from sailthru.sailthru_error import SailthruClientError
 from sailthru.sailthru_response import SailthruResponse
-import six
 from testfixtures import LogCapture
 
-from ..models import EmailMarketingConfiguration
-from ..signals import (
-    add_email_marketing_cookies,
-    email_marketing_register_user,
-    email_marketing_user_field_changed,
-    update_sailthru
-)
 from lms.djangoapps.email_marketing.tasks import (
     _create_user_list,
     _get_list_from_email_marketing_provider,
@@ -40,6 +33,14 @@ from openedx.core.djangoapps.lang_pref import LANGUAGE_KEY
 from student.models import Registration
 from student.tests.factories import CourseEnrollmentFactory, UserFactory, UserProfileFactory
 from util.json_request import JsonResponse
+
+from ..models import EmailMarketingConfiguration
+from ..signals import (
+    add_email_marketing_cookies,
+    email_marketing_register_user,
+    email_marketing_user_field_changed,
+    update_sailthru
+)
 
 log = logging.getLogger(__name__)
 
@@ -620,7 +621,7 @@ class SailthruTests(TestCase):
     @patch('sailthru.sailthru_client.SailthruClient.purchase')
     @patch('sailthru.sailthru_client.SailthruClient.api_get')
     @patch('sailthru.sailthru_client.SailthruClient.api_post')
-    @patch('openedx.core.djangoapps.waffle_utils.WaffleSwitchNamespace.is_enabled')
+    @patch('edx_toggles.toggles.WaffleSwitchNamespace.is_enabled')
     def test_update_course_enrollment_whitelabel(
             self,
             switch,
@@ -645,7 +646,7 @@ class SailthruTests(TestCase):
         update_sailthru(None, self.user, 'verified', self.course_id)
         self.assertFalse(mock_sailthru_purchase.called)
 
-    @patch('openedx.core.djangoapps.waffle_utils.WaffleSwitchNamespace.is_enabled')
+    @patch('edx_toggles.toggles.WaffleSwitchNamespace.is_enabled')
     @patch('sailthru.sailthru_client.SailthruClient.purchase')
     def test_purchase_is_not_invoked(self, mock_sailthru_purchase, switch):
         """Make sure purchase is not called in the following condition:
@@ -655,7 +656,7 @@ class SailthruTests(TestCase):
         update_sailthru(None, self.user, 'verified', self.course_id)
         self.assertFalse(mock_sailthru_purchase.called)
 
-    @patch('openedx.core.djangoapps.waffle_utils.WaffleSwitchNamespace.is_enabled')
+    @patch('edx_toggles.toggles.WaffleSwitchNamespace.is_enabled')
     @patch('sailthru.sailthru_client.SailthruClient.purchase')
     def test_encoding_is_working_for_email_contains_unicode(self, mock_sailthru_purchase, switch):
         """Make sure encoding is working for emails contains unicode characters

--- a/lms/djangoapps/experiments/flags.py
+++ b/lms/djangoapps/experiments/flags.py
@@ -49,18 +49,18 @@ class ExperimentWaffleFlag(CourseWaffleFlag):
 
     When writing tests involving an ExperimentWaffleFlag you must not use the
     override_waffle_flag utility. That will only turn the experiment on or off and won't
-    override bucketing. Instead use ExperimentWaffleFlag's override method which
+    override bucketing. Instead use override_experiment_waffle_flag function which
     will do both. Example:
 
-        with MY_EXPERIMENT_WAFFLE_FLAG.override(active=True, bucket=1):
+        from lms.djangoapps.experiments.testutils import override_experiment_waffle_flag
+        with @override_experiment_waffle_flag(MY_EXPERIMENT_WAFFLE_FLAG, active=True, bucket=1):
             ...
 
     or as a decorator:
 
-        @MY_EXPERIMENT_WAFFLE_FLAG.override(active=True, bucket=1)
+        @override_experiment_waffle_flag(MY_EXPERIMENT_WAFFLE_FLAG, active=True, bucket=1)
         def test_my_experiment(self):
             ...
-
     """
     def __init__(
             self,
@@ -259,14 +259,3 @@ class ExperimentWaffleFlag(CourseWaffleFlag):
         This disregards `.bucket_flags`.
         """
         return super().is_enabled(course_key)
-
-    @contextmanager
-    def override(self, active=True, bucket=1):  # pylint: disable=arguments-differ
-        # Let CourseWaffleFlag override the base waffle flag value
-        with super().override(active=active):
-            # Now override the experiment bucket value
-            from mock import patch
-            if not active:
-                bucket = 0
-            with patch.object(self, 'get_bucket', return_value=bucket):
-                yield

--- a/lms/djangoapps/experiments/tests/test_flags.py
+++ b/lms/djangoapps/experiments/tests/test_flags.py
@@ -11,13 +11,13 @@ from edx_django_utils.cache import RequestCache
 from mock import patch
 from opaque_keys.edx.keys import CourseKey
 
+from edx_toggles.toggles.testutils import override_waffle_flag
 from experiments.factories import ExperimentKeyValueFactory
 from experiments.flags import ExperimentWaffleFlag
 from lms.djangoapps.experiments.testutils import override_experiment_waffle_flag
 from openedx.core.djangoapps.site_configuration.tests.factories import SiteFactory
 from openedx.core.djangoapps.waffle_utils import CourseWaffleFlag
 from openedx.core.djangoapps.waffle_utils.models import WaffleFlagCourseOverrideModel
-from openedx.core.djangoapps.waffle_utils.testutils import override_waffle_flag
 from student.tests.factories import CourseEnrollmentFactory, UserFactory
 from xmodule.modulestore.tests.django_utils import SharedModuleStoreTestCase
 
@@ -105,7 +105,7 @@ class ExperimentWaffleFlagTests(SharedModuleStoreTestCase):
     @ddt.unpack
     def test_forcing_bucket(self, active, expected_bucket):
         bucket_flag = CourseWaffleFlag('experiments', 'test.0', __name__)
-        with bucket_flag.override(active=active):
+        with override_waffle_flag(bucket_flag, active=active):
             self.assertEqual(self.get_bucket(), expected_bucket)
 
     def test_tracking(self):

--- a/lms/djangoapps/experiments/tests/test_flags.py
+++ b/lms/djangoapps/experiments/tests/test_flags.py
@@ -2,9 +2,8 @@
 Tests for experimentation feature flags
 """
 
-import pytz
-
 import ddt
+import pytz
 from crum import set_current_request
 from dateutil import parser
 from django.test.client import RequestFactory
@@ -14,6 +13,7 @@ from opaque_keys.edx.keys import CourseKey
 
 from experiments.factories import ExperimentKeyValueFactory
 from experiments.flags import ExperimentWaffleFlag
+from lms.djangoapps.experiments.testutils import override_experiment_waffle_flag
 from openedx.core.djangoapps.site_configuration.tests.factories import SiteFactory
 from openedx.core.djangoapps.waffle_utils import CourseWaffleFlag
 from openedx.core.djangoapps.waffle_utils.models import WaffleFlagCourseOverrideModel
@@ -47,7 +47,7 @@ class ExperimentWaffleFlagTests(SharedModuleStoreTestCase):
         self.addCleanup(RequestCache.clear_all_namespaces)
 
     def get_bucket(self, track=False, active=True):
-        # Does not use ExperimentWaffleFlag.override, since that shortcuts get_bucket and we want to test internals
+        # Does not use override_experiment_waffle_flag, since that shortcuts get_bucket and we want to test internals
         with override_waffle_flag(self.flag, active):
             with override_waffle_flag(self.flag.bucket_flags[1], True):
                 return self.flag.get_bucket(course_key=self.key, track=track)
@@ -152,7 +152,7 @@ class ExperimentWaffleFlagTests(SharedModuleStoreTestCase):
     @ddt.unpack
     # Test the override method
     def test_override_method(self, active, bucket_override, expected_bucket):
-        with self.flag.override(active=active, bucket=bucket_override):
+        with override_experiment_waffle_flag(self.flag, active=active, bucket=bucket_override):
             self.assertEqual(self.flag.get_bucket(), expected_bucket)
             self.assertEqual(self.flag.is_experiment_on(), active)
 

--- a/lms/djangoapps/experiments/tests/test_views_custom.py
+++ b/lms/djangoapps/experiments/tests/test_views_custom.py
@@ -5,21 +5,19 @@ Tests for experimentation views
 
 from datetime import timedelta
 from uuid import uuid4
-import six
 
+import six
 from django.urls import reverse
 from django.utils.timezone import now
 from rest_framework.test import APITestCase
 
 from course_modes.models import CourseMode
 from course_modes.tests.factories import CourseModeFactory
+from edx_toggles.toggles.testutils import override_waffle_flag
 from lms.djangoapps.course_blocks.transformers.tests.helpers import ModuleStoreTestCase
-from student.tests.factories import CourseEnrollmentFactory, UserFactory
-
-from openedx.core.djangoapps.waffle_utils.testutils import override_waffle_flag
-from xmodule.modulestore.tests.factories import CourseFactory
-
 from lms.djangoapps.experiments.views_custom import MOBILE_UPSELL_FLAG
+from student.tests.factories import CourseEnrollmentFactory, UserFactory
+from xmodule.modulestore.tests.factories import CourseFactory
 
 CROSS_DOMAIN_REFERER = 'https://ecommerce.edx.org'
 

--- a/lms/djangoapps/experiments/testutils.py
+++ b/lms/djangoapps/experiments/testutils.py
@@ -1,0 +1,17 @@
+from contextlib import contextmanager
+
+from mock import patch
+
+from edx_toggles.toggles.testutils import override_waffle_flag
+
+
+@contextmanager
+def override_experiment_waffle_flag(flag, active=True, bucket=1):
+    """
+    Override both the base waffle flag and the experiment bucket value.
+    """
+    if not active:
+        bucket = 0
+    with override_waffle_flag(flag, active):
+        with patch.object(flag, "get_bucket", return_value=bucket):
+            yield

--- a/lms/djangoapps/experiments/utils.py
+++ b/lms/djangoapps/experiments/utils.py
@@ -11,16 +11,16 @@ from django.utils.timezone import now
 from opaque_keys import InvalidKeyError
 from opaque_keys.edx.keys import CourseKey
 
-from course_modes.models import format_course_price, get_cosmetic_verified_display_price, CourseMode
-from lms.djangoapps.courseware.access import has_staff_access_to_preview_mode
-from lms.djangoapps.courseware.utils import verified_upgrade_deadline_link, can_show_verified_upgrade
+from course_modes.models import CourseMode, format_course_price, get_cosmetic_verified_display_price
+from edx_toggles.toggles import WaffleFlag, WaffleFlagNamespace
 from entitlements.models import CourseEntitlement
 from lms.djangoapps.commerce.utils import EcommerceService
+from lms.djangoapps.courseware.access import has_staff_access_to_preview_mode
+from lms.djangoapps.courseware.utils import can_show_verified_upgrade, verified_upgrade_deadline_link
 from openedx.core.djangoapps.catalog.utils import get_programs
 from openedx.core.djangoapps.django_comment_common.models import Role
 from openedx.core.djangoapps.schedules.models import Schedule
-from openedx.core.djangoapps.waffle_utils import WaffleFlag, WaffleFlagNamespace
-from openedx.features.course_duration_limits.access import get_user_course_expiration_date, get_user_course_duration
+from openedx.features.course_duration_limits.access import get_user_course_duration, get_user_course_expiration_date
 from student.models import CourseEnrollment
 from xmodule.partitions.partitions_service import get_all_partitions_for_course, get_user_partition_groups
 

--- a/lms/djangoapps/experiments/views_custom.py
+++ b/lms/djangoapps/experiments/views_custom.py
@@ -6,9 +6,8 @@ The Discount API Views should return information about discounts that apply to t
 
 
 import six
-
-from django.utils.decorators import method_decorator
 from django.http import HttpResponseBadRequest
+from django.utils.decorators import method_decorator
 from edx_rest_framework_extensions.auth.jwt.authentication import JwtAuthentication
 from edx_rest_framework_extensions.auth.session.authentication import SessionAuthenticationAllowInactiveUser
 from opaque_keys import InvalidKeyError
@@ -16,20 +15,18 @@ from opaque_keys.edx.keys import CourseKey
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
+from course_modes.models import get_cosmetic_verified_display_price
+from edx_toggles.toggles import WaffleFlag, WaffleFlagNamespace
+from lms.djangoapps.commerce.utils import EcommerceService
+from lms.djangoapps.courseware.utils import can_show_verified_upgrade
+from lms.djangoapps.experiments.stable_bucketing import stable_bucketing_hash_group
 from openedx.core.djangoapps.content.course_overviews.models import CourseOverview
 from openedx.core.djangoapps.cors_csrf.decorators import ensure_csrf_cookie_cross_domain
-from openedx.core.djangoapps.waffle_utils import WaffleFlag, WaffleFlagNamespace
 from openedx.core.lib.api.authentication import BearerAuthenticationAllowInactiveUser
 from openedx.core.lib.api.permissions import ApiKeyHeaderPermissionIsAuthenticated
 from openedx.core.lib.api.view_utils import DeveloperErrorViewMixin
-
-from lms.djangoapps.courseware.utils import can_show_verified_upgrade
-from course_modes.models import get_cosmetic_verified_display_price
-from lms.djangoapps.commerce.utils import EcommerceService
-from lms.djangoapps.experiments.stable_bucketing import stable_bucketing_hash_group
 from student.models import CourseEnrollment
 from track import segment
-
 
 # .. toggle_name: experiments.mobile_upsell_rev934
 # .. toggle_type: flag

--- a/lms/djangoapps/grades/config/waffle.py
+++ b/lms/djangoapps/grades/config/waffle.py
@@ -4,12 +4,8 @@ waffle switches for the Grades app.
 """
 
 
-from openedx.core.djangoapps.waffle_utils import (
-    CourseWaffleFlag,
-    WaffleFlagNamespace,
-    WaffleSwitch,
-    WaffleSwitchNamespace
-)
+from edx_toggles.toggles import WaffleFlagNamespace, WaffleSwitch, WaffleSwitchNamespace
+from openedx.core.djangoapps.waffle_utils import CourseWaffleFlag
 
 # Namespace
 WAFFLE_NAMESPACE = u'grades'

--- a/lms/djangoapps/grades/config/waffle.py
+++ b/lms/djangoapps/grades/config/waffle.py
@@ -4,7 +4,12 @@ waffle switches for the Grades app.
 """
 
 
-from openedx.core.djangoapps.waffle_utils import CourseWaffleFlag, WaffleFlagNamespace, WaffleSwitchNamespace
+from openedx.core.djangoapps.waffle_utils import (
+    CourseWaffleFlag,
+    WaffleFlagNamespace,
+    WaffleSwitch,
+    WaffleSwitchNamespace
+)
 
 # Namespace
 WAFFLE_NAMESPACE = u'grades'
@@ -79,6 +84,16 @@ def waffle():
     Returns the namespaced, cached, audited Waffle class for Grades.
     """
     return WaffleSwitchNamespace(name=WAFFLE_NAMESPACE, log_prefix=u'Grades: ')
+
+
+def waffle_switch(name):
+    """
+    Return the corresponding namespaced waffle switch.
+
+    WARNING: do not replicate this pattern. Instead of declaring waffle switch names as strings, you should create
+    WaffleSwitch objects as top-level constants.
+    """
+    return WaffleSwitch(waffle(), name, module_name=__name__)
 
 
 def waffle_flags():

--- a/lms/djangoapps/grades/config/waffle.py
+++ b/lms/djangoapps/grades/config/waffle.py
@@ -84,6 +84,9 @@ def waffle():
 def waffle_flags():
     """
     Returns the namespaced, cached, audited Waffle flags dictionary for Grades.
+
+    WARNING: do not replicate this pattern. Instead of declaring waffle flag names as strings, you should create
+    WaffleFlag and CourseWaffleFlag objects as top-level constants.
     """
     namespace = WaffleFlagNamespace(name=WAFFLE_NAMESPACE, log_prefix=u'Grades: ')
     return {

--- a/lms/djangoapps/grades/rest_api/v1/tests/test_gradebook_views.py
+++ b/lms/djangoapps/grades/rest_api/v1/tests/test_gradebook_views.py
@@ -18,6 +18,7 @@ from rest_framework.test import APITestCase
 from six import text_type
 
 from course_modes.models import CourseMode
+from edx_toggles.toggles.testutils import override_waffle_flag
 from lms.djangoapps.certificates.models import CertificateStatuses, GeneratedCertificate
 from lms.djangoapps.courseware.tests.factories import InstructorFactory, StaffFactory
 from lms.djangoapps.grades.config.waffle import WRITABLE_GRADEBOOK, waffle_flags
@@ -36,7 +37,6 @@ from lms.djangoapps.grades.rest_api.v1.views import CourseEnrollmentPagination
 from lms.djangoapps.grades.subsection_grade import ReadSubsectionGrade
 from openedx.core.djangoapps.content.course_overviews.tests.factories import CourseOverviewFactory
 from openedx.core.djangoapps.course_groups.tests.helpers import CohortFactory
-from openedx.core.djangoapps.waffle_utils.testutils import override_waffle_flag
 from student.tests.factories import CourseEnrollmentFactory, UserFactory
 from xmodule.modulestore.tests.django_utils import TEST_DATA_SPLIT_MODULESTORE, SharedModuleStoreTestCase
 from xmodule.modulestore.tests.factories import CourseFactory, ItemFactory

--- a/lms/djangoapps/grades/tests/test_course_grade.py
+++ b/lms/djangoapps/grades/tests/test_course_grade.py
@@ -4,13 +4,14 @@ from crum import set_current_request
 from django.conf import settings
 from mock import patch
 
+from edx_toggles.toggles.testutils import override_waffle_switch
 from openedx.core.djangolib.testing.utils import get_mock_request
 from student.models import CourseEnrollment
 from student.tests.factories import UserFactory
 from xmodule.modulestore.tests.django_utils import SharedModuleStoreTestCase
 from xmodule.modulestore.tests.factories import CourseFactory, ItemFactory
 
-from ..config.waffle import ASSUME_ZERO_GRADE_IF_ABSENT, waffle
+from ..config.waffle import ASSUME_ZERO_GRADE_IF_ABSENT, waffle_switch
 from ..course_data import CourseData
 from ..course_grade import ZeroCourseGrade
 from ..course_grade_factory import CourseGradeFactory
@@ -31,7 +32,7 @@ class ZeroGradeTest(GradeTestBase):
         """
         Creates a ZeroCourseGrade and ensures it's empty.
         """
-        with waffle().override(ASSUME_ZERO_GRADE_IF_ABSENT, active=assume_zero_enabled):
+        with override_waffle_switch(waffle_switch(ASSUME_ZERO_GRADE_IF_ABSENT), active=assume_zero_enabled):
             course_data = CourseData(self.request.user, structure=self.course_structure)
             chapter_grades = ZeroCourseGrade(self.request.user, course_data).chapter_grades
             for chapter in chapter_grades:
@@ -46,7 +47,7 @@ class ZeroGradeTest(GradeTestBase):
         """
         Creates a zero course grade and ensures that null scores aren't included in the section problem scores.
         """
-        with waffle().override(ASSUME_ZERO_GRADE_IF_ABSENT, active=assume_zero_enabled):
+        with override_waffle_switch(waffle_switch(ASSUME_ZERO_GRADE_IF_ABSENT), active=assume_zero_enabled):
             with patch('lms.djangoapps.grades.subsection_grade.get_score', return_value=None):
                 course_data = CourseData(self.request.user, structure=self.course_structure)
                 chapter_grades = ZeroCourseGrade(self.request.user, course_data).chapter_grades

--- a/lms/djangoapps/grades/tests/test_course_grade_factory.py
+++ b/lms/djangoapps/grades/tests/test_course_grade_factory.py
@@ -9,7 +9,7 @@ import ddt
 from django.conf import settings
 from mock import patch
 from six import text_type
-
+from edx_toggles.toggles.testutils import override_waffle_switch
 from lms.djangoapps.courseware.access import has_access
 from lms.djangoapps.grades.config.tests.utils import persistent_grades_feature_flags
 from openedx.core.djangoapps.content.block_structure.factory import BlockStructureFactory
@@ -17,7 +17,7 @@ from student.tests.factories import UserFactory
 from xmodule.modulestore.tests.django_utils import SharedModuleStoreTestCase
 from xmodule.modulestore.tests.factories import CourseFactory
 
-from ..config.waffle import ASSUME_ZERO_GRADE_IF_ABSENT, waffle
+from ..config.waffle import ASSUME_ZERO_GRADE_IF_ABSENT, waffle_switch
 from ..course_grade import CourseGrade, ZeroCourseGrade
 from ..course_grade_factory import CourseGradeFactory
 from ..subsection_grade import ReadSubsectionGrade, ZeroSubsectionGrade
@@ -132,7 +132,7 @@ class TestCourseGradeFactory(GradeTestBase):
     @ddt.data(*itertools.product((True, False), (True, False)))
     @ddt.unpack
     def test_read_zero(self, assume_zero_enabled, create_if_needed):
-        with waffle().override(ASSUME_ZERO_GRADE_IF_ABSENT, active=assume_zero_enabled):
+        with override_waffle_switch(waffle_switch(ASSUME_ZERO_GRADE_IF_ABSENT), active=assume_zero_enabled):
             grade_factory = CourseGradeFactory()
             course_grade = grade_factory.read(self.request.user, self.course, create_if_needed=create_if_needed)
             if create_if_needed or assume_zero_enabled:

--- a/lms/djangoapps/grades/tests/test_tasks.py
+++ b/lms/djangoapps/grades/tests/test_tasks.py
@@ -17,6 +17,7 @@ from django.utils import timezone
 from mock import MagicMock, patch
 from six.moves import range
 
+from edx_toggles.toggles.testutils import override_waffle_flag
 from lms.djangoapps.grades import tasks
 from lms.djangoapps.grades.config.models import PersistentGradesEnabledFlag
 from lms.djangoapps.grades.config.waffle import ENFORCE_FREEZE_GRADE_AFTER_COURSE_END, waffle_flags
@@ -33,7 +34,6 @@ from lms.djangoapps.grades.tasks import (
     recalculate_subsection_grade_v3
 )
 from openedx.core.djangoapps.content.block_structure.exceptions import BlockStructureNotFound
-from openedx.core.djangoapps.waffle_utils.testutils import override_waffle_flag
 from student.models import CourseEnrollment, anonymous_id_for_user
 from student.tests.factories import UserFactory
 from track.event_transaction_utils import create_new_event_transaction_id, get_event_transaction_id

--- a/lms/djangoapps/instructor/tests/test_api.py
+++ b/lms/djangoapps/instructor/tests/test_api.py
@@ -36,6 +36,7 @@ from testfixtures import LogCapture
 from bulk_email.models import BulkEmailFlag, CourseEmail, CourseEmailTemplate
 from course_modes.models import CourseMode
 from course_modes.tests.factories import CourseModeFactory
+from edx_toggles.toggles.testutils import override_waffle_flag
 from lms.djangoapps.certificates.api import generate_user_certificates
 from lms.djangoapps.certificates.models import CertificateStatuses
 from lms.djangoapps.certificates.tests.factories import GeneratedCertificateFactory
@@ -68,7 +69,6 @@ from openedx.core.djangoapps.django_comment_common.utils import seed_permissions
 from openedx.core.djangoapps.schedules.tests.factories import ScheduleFactory
 from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
 from openedx.core.djangoapps.site_configuration.tests.mixins import SiteMixin
-from openedx.core.djangoapps.waffle_utils.testutils import override_waffle_flag
 from openedx.core.lib.teams_config import TeamsConfig
 from openedx.core.lib.xblock_utils import grade_histogram
 from openedx.features.course_experience import RELATIVE_DATES_FLAG

--- a/lms/djangoapps/instructor/tests/test_api.py
+++ b/lms/djangoapps/instructor/tests/test_api.py
@@ -36,6 +36,9 @@ from testfixtures import LogCapture
 from bulk_email.models import BulkEmailFlag, CourseEmail, CourseEmailTemplate
 from course_modes.models import CourseMode
 from course_modes.tests.factories import CourseModeFactory
+from lms.djangoapps.certificates.api import generate_user_certificates
+from lms.djangoapps.certificates.models import CertificateStatuses
+from lms.djangoapps.certificates.tests.factories import GeneratedCertificateFactory
 from lms.djangoapps.courseware.models import StudentModule
 from lms.djangoapps.courseware.tests.factories import (
     BetaTesterFactory,
@@ -45,9 +48,7 @@ from lms.djangoapps.courseware.tests.factories import (
     UserProfileFactory
 )
 from lms.djangoapps.courseware.tests.helpers import LoginEnrollmentTestCase
-from lms.djangoapps.certificates.api import generate_user_certificates
-from lms.djangoapps.certificates.models import CertificateStatuses
-from lms.djangoapps.certificates.tests.factories import GeneratedCertificateFactory
+from lms.djangoapps.experiments.testutils import override_experiment_waffle_flag
 from lms.djangoapps.instructor.tests.utils import FakeContentTask, FakeEmail, FakeEmailInfo
 from lms.djangoapps.instructor.views.api import (
     _split_input_list,
@@ -87,8 +88,11 @@ from student.models import (
     get_retired_username_by_username
 )
 from student.roles import (
-    CourseBetaTesterRole, CourseDataResearcherRole, CourseFinanceAdminRole,
-    CourseInstructorRole, CourseSalesAdminRole
+    CourseBetaTesterRole,
+    CourseDataResearcherRole,
+    CourseFinanceAdminRole,
+    CourseInstructorRole,
+    CourseSalesAdminRole
 )
 from student.tests.factories import AdminFactory, UserFactory
 from xmodule.fields import Date
@@ -3997,7 +4001,7 @@ class TestDueDateExtensions(SharedModuleStoreTestCase, LoginEnrollmentTestCase):
             get_extended_due(self.course, self.week3, self.user1)
         )
 
-    @RELATIVE_DATES_FLAG.override(True)
+    @override_experiment_waffle_flag(RELATIVE_DATES_FLAG, active=True)
     def test_reset_date(self):
         self.test_change_due_date()
         url = reverse('reset_due_date', kwargs={'course_id': text_type(self.course.id)})
@@ -4011,7 +4015,7 @@ class TestDueDateExtensions(SharedModuleStoreTestCase, LoginEnrollmentTestCase):
             get_extended_due(self.course, self.week1, self.user1)
         )
 
-    @RELATIVE_DATES_FLAG.override(True)
+    @override_experiment_waffle_flag(RELATIVE_DATES_FLAG, active=True)
     def test_reset_date_only_in_edx_when(self):
         # Start with a unit that only has a date in edx-when
         self.assertEqual(get_date_for_block(self.course, self.week3, self.user1), None)
@@ -4144,7 +4148,7 @@ class TestDueDateExtensionsDeletedDate(ModuleStoreTestCase, LoginEnrollmentTestC
         self.client.login(username=self.instructor.username, password='test')
         extract_dates(None, self.course.id)
 
-    @RELATIVE_DATES_FLAG.override(True)
+    @override_experiment_waffle_flag(RELATIVE_DATES_FLAG, active=True)
     def test_reset_extension_to_deleted_date(self):
         """
         Test that we can delete a due date extension after deleting the normal

--- a/lms/djangoapps/instructor/tests/views/test_instructor_dashboard.py
+++ b/lms/djangoapps/instructor/tests/views/test_instructor_dashboard.py
@@ -20,15 +20,15 @@ from six.moves import range
 
 from common.test.utils import XssTestMixin
 from course_modes.models import CourseMode
+from edx_toggles.toggles.testutils import override_waffle_flag
 from edxmako.shortcuts import render_to_response
 from lms.djangoapps.courseware.tabs import get_course_tab_list
 from lms.djangoapps.courseware.tests.factories import StaffFactory, StudentModuleFactory, UserFactory
 from lms.djangoapps.courseware.tests.helpers import LoginEnrollmentTestCase
 from lms.djangoapps.grades.config.waffle import WRITABLE_GRADEBOOK, waffle_flags
-from lms.djangoapps.instructor.views.gradebook_api import calculate_page_info
 from lms.djangoapps.instructor.toggles import DATA_DOWNLOAD_V2
+from lms.djangoapps.instructor.views.gradebook_api import calculate_page_info
 from openedx.core.djangoapps.site_configuration.models import SiteConfiguration
-from openedx.core.djangoapps.waffle_utils.testutils import override_waffle_flag
 from student.models import CourseEnrollment
 from student.roles import CourseFinanceAdminRole
 from student.tests.factories import AdminFactory, CourseAccessRoleFactory, CourseEnrollmentFactory

--- a/lms/djangoapps/instructor/toggles.py
+++ b/lms/djangoapps/instructor/toggles.py
@@ -2,7 +2,8 @@
 Waffle flags for instructor dashboard.
 """
 
-from openedx.core.djangoapps.waffle_utils import CourseWaffleFlag, WaffleFlagNamespace, WaffleFlag
+from edx_toggles.toggles import WaffleFlag, WaffleFlagNamespace
+from openedx.core.djangoapps.waffle_utils import CourseWaffleFlag
 
 WAFFLE_NAMESPACE = 'instructor'
 # Namespace for instructor waffle flags.

--- a/lms/djangoapps/instructor_task/config/waffle.py
+++ b/lms/djangoapps/instructor_task/config/waffle.py
@@ -3,7 +3,8 @@ This module contains various configuration settings via
 waffle switches for the instructor_task app.
 """
 
-from openedx.core.djangoapps.waffle_utils import CourseWaffleFlag, WaffleFlagNamespace, WaffleSwitchNamespace
+from edx_toggles.toggles import WaffleFlagNamespace, WaffleSwitchNamespace
+from openedx.core.djangoapps.waffle_utils import CourseWaffleFlag
 
 WAFFLE_NAMESPACE = 'instructor_task'
 INSTRUCTOR_TASK_WAFFLE_FLAG_NAMESPACE = WaffleFlagNamespace(name=WAFFLE_NAMESPACE)

--- a/lms/djangoapps/verify_student/toggles.py
+++ b/lms/djangoapps/verify_student/toggles.py
@@ -2,7 +2,7 @@
 Toggles for verify_student app
 """
 
-from openedx.core.djangoapps.waffle_utils import WaffleFlagNamespace, WaffleFlag
+from edx_toggles.toggles import WaffleFlag, WaffleFlagNamespace
 
 # Namespace for verify_students waffle flags.
 WAFFLE_FLAG_NAMESPACE = WaffleFlagNamespace(name='verify_student')

--- a/openedx/core/djangoapps/certificates/config/waffle.py
+++ b/openedx/core/djangoapps/certificates/config/waffle.py
@@ -4,7 +4,7 @@ waffle switches for the Certificates app.
 """
 
 
-from openedx.core.djangoapps.waffle_utils import WaffleSwitchNamespace
+from edx_toggles.toggles import WaffleSwitchNamespace
 
 # Namespace
 WAFFLE_NAMESPACE = u'certificates'

--- a/openedx/core/djangoapps/certificates/tests/test_api.py
+++ b/openedx/core/djangoapps/certificates/tests/test_api.py
@@ -7,15 +7,15 @@ from datetime import datetime, timedelta
 import ddt
 import pytz
 import waffle
-from django.test import TestCase
-
 from course_modes.models import CourseMode
+from django.test import TestCase
+from edx_toggles.toggles import WaffleSwitch
+from edx_toggles.toggles.testutils import override_waffle_switch
+from student.tests.factories import CourseEnrollmentFactory, UserFactory
+
 from openedx.core.djangoapps.certificates import api
 from openedx.core.djangoapps.certificates.config import waffle as certs_waffle
 from openedx.core.djangoapps.content.course_overviews.tests.factories import CourseOverviewFactory
-from openedx.core.djangoapps.waffle_utils import WaffleSwitch
-from openedx.core.djangoapps.waffle_utils.testutils import override_waffle_switch
-from student.tests.factories import CourseEnrollmentFactory, UserFactory
 
 
 # TODO: Copied from lms.djangoapps.certificates.models,

--- a/openedx/core/djangoapps/certificates/tests/test_api.py
+++ b/openedx/core/djangoapps/certificates/tests/test_api.py
@@ -13,6 +13,8 @@ from course_modes.models import CourseMode
 from openedx.core.djangoapps.certificates import api
 from openedx.core.djangoapps.certificates.config import waffle as certs_waffle
 from openedx.core.djangoapps.content.course_overviews.tests.factories import CourseOverviewFactory
+from openedx.core.djangoapps.waffle_utils import WaffleSwitch
+from openedx.core.djangoapps.waffle_utils.testutils import override_waffle_switch
 from student.tests.factories import CourseEnrollmentFactory, UserFactory
 
 
@@ -66,8 +68,8 @@ class MockGeneratedCertificate(object):
 @contextmanager
 def configure_waffle_namespace(feature_enabled):
     namespace = certs_waffle.waffle()
-
-    with namespace.override(certs_waffle.AUTO_CERTIFICATE_GENERATION, active=feature_enabled):
+    auto_certificate_generation_switch = WaffleSwitch(namespace, certs_waffle.AUTO_CERTIFICATE_GENERATION)
+    with override_waffle_switch(auto_certificate_generation_switch, active=feature_enabled):
         yield
 
 

--- a/openedx/core/djangoapps/content/block_structure/config/__init__.py
+++ b/openedx/core/djangoapps/content/block_structure/config/__init__.py
@@ -4,7 +4,7 @@ waffle switches for the Block Structure framework.
 """
 
 
-from openedx.core.djangoapps.waffle_utils import WaffleSwitchNamespace
+from openedx.core.djangoapps.waffle_utils import WaffleSwitch, WaffleSwitchNamespace
 from openedx.core.lib.cache_utils import request_cached
 
 from .models import BlockStructureConfiguration
@@ -23,6 +23,16 @@ def waffle():
     Returns the namespaced and cached Waffle class for BlockStructures.
     """
     return WaffleSwitchNamespace(name=WAFFLE_NAMESPACE, log_prefix=u'BlockStructure: ')
+
+
+def waffle_switch(name):
+    """
+    Return the waffle switch associated to this namespace.
+
+    WARNING: do not replicate this pattern. Instead of declaring waffle switch names as strings, you should create
+    WaffleSwitch objects as top-level constants.
+    """
+    return WaffleSwitch(waffle(), name, module_name=__name__)
 
 
 @request_cached()

--- a/openedx/core/djangoapps/content/block_structure/config/__init__.py
+++ b/openedx/core/djangoapps/content/block_structure/config/__init__.py
@@ -4,7 +4,7 @@ waffle switches for the Block Structure framework.
 """
 
 
-from openedx.core.djangoapps.waffle_utils import WaffleSwitch, WaffleSwitchNamespace
+from edx_toggles.toggles import WaffleSwitch, WaffleSwitchNamespace
 from openedx.core.lib.cache_utils import request_cached
 
 from .models import BlockStructureConfiguration

--- a/openedx/core/djangoapps/content/block_structure/management/commands/generate_course_blocks.py
+++ b/openedx/core/djangoapps/content/block_structure/management/commands/generate_course_blocks.py
@@ -133,7 +133,7 @@ class Command(BaseCommand):
         Generates course blocks for the given course_keys per the given options.
         """
         if options.get('with_storage'):
-            waffle().override_for_request(STORAGE_BACKING_FOR_CACHE)
+            waffle().set_request_cache_with_short_name(STORAGE_BACKING_FOR_CACHE, True)
 
         for course_key in course_keys:
             try:

--- a/openedx/core/djangoapps/content/block_structure/tasks.py
+++ b/openedx/core/djangoapps/content/block_structure/tasks.py
@@ -60,7 +60,7 @@ def _update_course_in_cache(self, **kwargs):
     Updates the course blocks (mongo -> BlockStructure) for the specified course.
     """
     if kwargs.get('with_storage'):
-        waffle().override_for_request(STORAGE_BACKING_FOR_CACHE)
+        waffle().set_request_cache_with_short_name(STORAGE_BACKING_FOR_CACHE, True)
     _call_and_retry_if_needed(self, api.update_course_in_cache, **kwargs)
 
 
@@ -89,7 +89,7 @@ def _get_course_in_cache(self, **kwargs):
     Gets the course blocks for the specified course, updating the cache if needed.
     """
     if kwargs.get('with_storage'):
-        waffle().override_for_request(STORAGE_BACKING_FOR_CACHE)
+        waffle().set_request_cache_with_short_name(STORAGE_BACKING_FOR_CACHE, True)
     _call_and_retry_if_needed(self, api.get_course_in_cache, **kwargs)
 
 

--- a/openedx/core/djangoapps/content/block_structure/tests/test_manager.py
+++ b/openedx/core/djangoapps/content/block_structure/tests/test_manager.py
@@ -6,8 +6,7 @@ Tests for manager.py
 import ddt
 import six
 from django.test import TestCase
-
-from openedx.core.djangoapps.waffle_utils.testutils import override_waffle_switch
+from edx_toggles.toggles.testutils import override_waffle_switch
 
 from ..block_structure import BlockStructureBlockData
 from ..config import RAISE_ERROR_WHEN_NOT_FOUND, STORAGE_BACKING_FOR_CACHE, waffle_switch

--- a/openedx/core/djangoapps/content/block_structure/tests/test_manager.py
+++ b/openedx/core/djangoapps/content/block_structure/tests/test_manager.py
@@ -7,8 +7,10 @@ import ddt
 import six
 from django.test import TestCase
 
+from openedx.core.djangoapps.waffle_utils.testutils import override_waffle_switch
+
 from ..block_structure import BlockStructureBlockData
-from ..config import RAISE_ERROR_WHEN_NOT_FOUND, STORAGE_BACKING_FOR_CACHE, waffle
+from ..config import RAISE_ERROR_WHEN_NOT_FOUND, STORAGE_BACKING_FOR_CACHE, waffle_switch
 from ..exceptions import BlockStructureNotFound, UsageKeyNotInBlockStructure
 from ..manager import BlockStructureManager
 from ..transformers import BlockStructureTransformers
@@ -178,14 +180,14 @@ class TestBlockStructureManager(UsageKeyFactoryMixin, ChildrenMapTestMixin, Test
         assert TestTransformer1.collect_call_count == 1
 
     def test_get_collected_error_raised(self):
-        with waffle().override(RAISE_ERROR_WHEN_NOT_FOUND, active=True):
+        with override_waffle_switch(waffle_switch(RAISE_ERROR_WHEN_NOT_FOUND), active=True):
             with mock_registered_transformers(self.registered_transformers):
                 with self.assertRaises(BlockStructureNotFound):
                     self.bs_manager.get_collected()
 
     @ddt.data(True, False)
     def test_update_collected_if_needed(self, with_storage_backing):
-        with waffle().override(STORAGE_BACKING_FOR_CACHE, active=with_storage_backing):
+        with override_waffle_switch(waffle_switch(STORAGE_BACKING_FOR_CACHE), active=with_storage_backing):
             with mock_registered_transformers(self.registered_transformers):
                 assert TestTransformer1.collect_call_count == 0
 

--- a/openedx/core/djangoapps/content/block_structure/tests/test_signals.py
+++ b/openedx/core/djangoapps/content/block_structure/tests/test_signals.py
@@ -7,12 +7,13 @@ import ddt
 from mock import patch
 from opaque_keys.edx.locator import CourseLocator, LibraryLocator
 
+from openedx.core.djangoapps.waffle_utils.testutils import override_waffle_switch
 from xmodule.modulestore.exceptions import ItemNotFoundError
 from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
 from xmodule.modulestore.tests.factories import CourseFactory
 
 from ..api import get_block_structure_manager
-from ..config import INVALIDATE_CACHE_ON_PUBLISH, waffle
+from ..config import INVALIDATE_CACHE_ON_PUBLISH, waffle_switch
 from ..signals import update_block_structure_on_course_publish
 from .helpers import is_course_in_block_structure_cache
 
@@ -56,7 +57,7 @@ class CourseBlocksSignalTest(ModuleStoreTestCase):
     def test_cache_invalidation(self, invalidate_cache_enabled, mock_bs_manager_clear):
         test_display_name = "Jedi 101"
 
-        with waffle().override(INVALIDATE_CACHE_ON_PUBLISH, active=invalidate_cache_enabled):
+        with override_waffle_switch(waffle_switch(INVALIDATE_CACHE_ON_PUBLISH), active=invalidate_cache_enabled):
             self.course.display_name = test_display_name
             self.store.update_item(self.course, self.user.id)
 

--- a/openedx/core/djangoapps/content/block_structure/tests/test_signals.py
+++ b/openedx/core/djangoapps/content/block_structure/tests/test_signals.py
@@ -4,10 +4,9 @@ Unit tests for the Course Blocks signals
 
 
 import ddt
+from edx_toggles.toggles.testutils import override_waffle_switch
 from mock import patch
 from opaque_keys.edx.locator import CourseLocator, LibraryLocator
-
-from openedx.core.djangoapps.waffle_utils.testutils import override_waffle_switch
 from xmodule.modulestore.exceptions import ItemNotFoundError
 from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
 from xmodule.modulestore.tests.factories import CourseFactory

--- a/openedx/core/djangoapps/content/block_structure/tests/test_store.py
+++ b/openedx/core/djangoapps/content/block_structure/tests/test_store.py
@@ -4,8 +4,8 @@ Tests for block_structure/cache.py
 
 
 import ddt
+from edx_toggles.toggles.testutils import override_waffle_switch
 
-from openedx.core.djangoapps.waffle_utils.testutils import override_waffle_switch
 from openedx.core.djangolib.testing.utils import CacheIsolationTestCase
 
 from ..config import STORAGE_BACKING_FOR_CACHE, waffle_switch

--- a/openedx/core/djangoapps/content/block_structure/tests/test_store.py
+++ b/openedx/core/djangoapps/content/block_structure/tests/test_store.py
@@ -5,9 +5,10 @@ Tests for block_structure/cache.py
 
 import ddt
 
+from openedx.core.djangoapps.waffle_utils.testutils import override_waffle_switch
 from openedx.core.djangolib.testing.utils import CacheIsolationTestCase
 
-from ..config import STORAGE_BACKING_FOR_CACHE, waffle
+from ..config import STORAGE_BACKING_FOR_CACHE, waffle_switch
 from ..config.models import BlockStructureConfiguration
 from ..exceptions import BlockStructureNotFound
 from ..store import BlockStructureStore
@@ -47,13 +48,13 @@ class TestBlockStructureStore(UsageKeyFactoryMixin, ChildrenMapTestMixin, CacheI
 
     @ddt.data(True, False)
     def test_get_none(self, with_storage_backing):
-        with waffle().override(STORAGE_BACKING_FOR_CACHE, active=with_storage_backing):
+        with override_waffle_switch(waffle_switch(STORAGE_BACKING_FOR_CACHE), active=with_storage_backing):
             with self.assertRaises(BlockStructureNotFound):
                 self.store.get(self.block_structure.root_block_usage_key)
 
     @ddt.data(True, False)
     def test_add_and_get(self, with_storage_backing):
-        with waffle().override(STORAGE_BACKING_FOR_CACHE, active=with_storage_backing):
+        with override_waffle_switch(waffle_switch(STORAGE_BACKING_FOR_CACHE), active=with_storage_backing):
             self.store.add(self.block_structure)
             stored_value = self.store.get(self.block_structure.root_block_usage_key)
             self.assertIsNotNone(stored_value)
@@ -61,7 +62,7 @@ class TestBlockStructureStore(UsageKeyFactoryMixin, ChildrenMapTestMixin, CacheI
 
     @ddt.data(True, False)
     def test_delete(self, with_storage_backing):
-        with waffle().override(STORAGE_BACKING_FOR_CACHE, active=with_storage_backing):
+        with override_waffle_switch(waffle_switch(STORAGE_BACKING_FOR_CACHE), active=with_storage_backing):
             self.store.add(self.block_structure)
             self.store.delete(self.block_structure.root_block_usage_key)
             with self.assertRaises(BlockStructureNotFound):
@@ -74,7 +75,7 @@ class TestBlockStructureStore(UsageKeyFactoryMixin, ChildrenMapTestMixin, CacheI
             self.store.get(self.block_structure.root_block_usage_key)
 
     def test_uncached_with_storage(self):
-        with waffle().override(STORAGE_BACKING_FOR_CACHE, active=True):
+        with override_waffle_switch(waffle_switch(STORAGE_BACKING_FOR_CACHE), active=True):
             self.store.add(self.block_structure)
             self.mock_cache.map.clear()
             stored_value = self.store.get(self.block_structure.root_block_usage_key)

--- a/openedx/core/djangoapps/content/learning_sequences/api/tests/test_outlines.py
+++ b/openedx/core/djangoapps/content/learning_sequences/api/tests/test_outlines.py
@@ -10,17 +10,15 @@ from edx_when.api import set_dates_for_course
 from opaque_keys.edx.keys import CourseKey, UsageKey
 from opaque_keys.edx.locator import BlockUsageLocator
 
+from edx_toggles.toggles.testutils import override_waffle_flag
 from lms.djangoapps.courseware.tests.factories import BetaTesterFactory
-from openedx.core.djangoapps.waffle_utils.testutils import override_waffle_flag
 from openedx.core.djangolib.testing.utils import CacheIsolationTestCase
 from openedx.features.course_experience import COURSE_ENABLE_UNENROLLED_ACCESS_FLAG
 from student.auth import user_has_role
 from student.models import CourseEnrollment
 from student.roles import CourseBetaTesterRole
 
-from ...data import (
-    CourseLearningSequenceData, CourseOutlineData, CourseSectionData, VisibilityData, CourseVisibility
-)
+from ...data import CourseLearningSequenceData, CourseOutlineData, CourseSectionData, CourseVisibility, VisibilityData
 from ..outlines import (
     get_course_outline,
     get_user_course_outline,

--- a/openedx/core/djangoapps/coursegraph/management/commands/tests/test_dump_to_neo4j.py
+++ b/openedx/core/djangoapps/coursegraph/management/commands/tests/test_dump_to_neo4j.py
@@ -10,6 +10,9 @@ import ddt
 import mock
 import six
 from django.core.management import call_command
+from edx_toggles.toggles.testutils import override_waffle_switch
+from xmodule.modulestore.tests.django_utils import SharedModuleStoreTestCase
+from xmodule.modulestore.tests.factories import CourseFactory, ItemFactory
 
 import openedx.core.djangoapps.content.block_structure.config as block_structure_config
 from openedx.core.djangoapps.content.block_structure.signals import update_block_structure_on_course_publish
@@ -22,10 +25,7 @@ from openedx.core.djangoapps.coursegraph.tasks import (
     should_dump_course,
     strip_branch_and_version
 )
-from openedx.core.djangoapps.waffle_utils.testutils import override_waffle_switch
 from openedx.core.djangolib.testing.utils import skip_unless_lms
-from xmodule.modulestore.tests.django_utils import SharedModuleStoreTestCase
-from xmodule.modulestore.tests.factories import CourseFactory, ItemFactory
 
 
 class TestDumpToNeo4jCommandBase(SharedModuleStoreTestCase):

--- a/openedx/core/djangoapps/coursegraph/management/commands/tests/test_dump_to_neo4j.py
+++ b/openedx/core/djangoapps/coursegraph/management/commands/tests/test_dump_to_neo4j.py
@@ -10,29 +10,22 @@ import ddt
 import mock
 import six
 from django.core.management import call_command
+
+import openedx.core.djangoapps.content.block_structure.config as block_structure_config
+from openedx.core.djangoapps.content.block_structure.signals import update_block_structure_on_course_publish
+from openedx.core.djangoapps.coursegraph.management.commands.dump_to_neo4j import ModuleStoreSerializer
+from openedx.core.djangoapps.coursegraph.management.commands.tests.utils import MockGraph, MockNodeSelector
+from openedx.core.djangoapps.coursegraph.tasks import (
+    coerce_types,
+    serialize_course,
+    serialize_item,
+    should_dump_course,
+    strip_branch_and_version
+)
+from openedx.core.djangoapps.waffle_utils.testutils import override_waffle_switch
+from openedx.core.djangolib.testing.utils import skip_unless_lms
 from xmodule.modulestore.tests.django_utils import SharedModuleStoreTestCase
 from xmodule.modulestore.tests.factories import CourseFactory, ItemFactory
-
-from openedx.core.djangolib.testing.utils import skip_unless_lms
-
-from openedx.core.djangoapps.coursegraph.management.commands.dump_to_neo4j import (
-    ModuleStoreSerializer
-)
-from openedx.core.djangoapps.coursegraph.management.commands.tests.utils import (
-    MockGraph,
-    MockNodeSelector,
-)
-from openedx.core.djangoapps.coursegraph.tasks import (
-    serialize_item,
-    serialize_course,
-    coerce_types,
-    should_dump_course,
-    strip_branch_and_version,
-)
-from openedx.core.djangoapps.content.block_structure.signals import (
-    update_block_structure_on_course_publish
-)
-import openedx.core.djangoapps.content.block_structure.config as block_structure_config
 
 
 class TestDumpToNeo4jCommandBase(SharedModuleStoreTestCase):
@@ -507,7 +500,9 @@ class TestModuleStoreSerializer(TestDumpToNeo4jCommandBase):
         self.assertEqual(len(submitted), len(self.course_strings))
 
         # simulate one of the courses being published
-        with block_structure_config.waffle().override(block_structure_config.STORAGE_BACKING_FOR_CACHE):
+        with override_waffle_switch(
+            block_structure_config.waffle_switch(block_structure_config.STORAGE_BACKING_FOR_CACHE), True
+        ):
             update_block_structure_on_course_publish(None, self.course.id)
 
         # make sure only the published course was dumped

--- a/openedx/core/djangoapps/models/config/waffle.py
+++ b/openedx/core/djangoapps/models/config/waffle.py
@@ -4,11 +4,8 @@ waffle switches for the course_details view.
 """
 
 
-from openedx.core.djangoapps.waffle_utils import (
-    CourseWaffleFlag,
-    WaffleFlagNamespace,
-    WaffleSwitchNamespace
-)
+from edx_toggles.toggles import WaffleFlagNamespace, WaffleSwitchNamespace
+from openedx.core.djangoapps.waffle_utils import CourseWaffleFlag
 
 COURSE_DETAIL_WAFFLE_NAMESPACE = 'course_detail'
 COURSE_DETAIL_WAFFLE_FLAG_NAMESPACE = WaffleFlagNamespace(name=COURSE_DETAIL_WAFFLE_NAMESPACE)

--- a/openedx/core/djangoapps/programs/__init__.py
+++ b/openedx/core/djangoapps/programs/__init__.py
@@ -10,7 +10,7 @@ this package should be kept small, thin, and stateless.
 """
 default_app_config = 'openedx.core.djangoapps.programs.apps.ProgramsConfig'
 
-from openedx.core.djangoapps.waffle_utils import WaffleSwitch, WaffleSwitchNamespace
+from edx_toggles.toggles import WaffleSwitch, WaffleSwitchNamespace
 
 PROGRAMS_WAFFLE_SWITCH_NAMESPACE = WaffleSwitchNamespace(name='programs')
 

--- a/openedx/core/djangoapps/schedules/config.py
+++ b/openedx/core/djangoapps/schedules/config.py
@@ -3,10 +3,8 @@ Contains configuration for schedules app
 """
 
 
-from openedx.core.djangoapps.waffle_utils import (
-    WaffleFlagNamespace, CourseWaffleFlag, WaffleFlag,
-    WaffleSwitch, WaffleSwitchNamespace,
-)
+from edx_toggles.toggles import WaffleFlag, WaffleFlagNamespace, WaffleSwitch, WaffleSwitchNamespace
+from openedx.core.djangoapps.waffle_utils import CourseWaffleFlag
 
 WAFFLE_FLAG_NAMESPACE = WaffleFlagNamespace(name='schedules')
 WAFFLE_SWITCH_NAMESPACE = WaffleSwitchNamespace(name='schedules')

--- a/openedx/core/djangoapps/schedules/management/commands/tests/test_send_course_update.py
+++ b/openedx/core/djangoapps/schedules/management/commands/tests/test_send_course_update.py
@@ -12,6 +12,7 @@ from edx_ace.utils.date import serialize
 from mock import patch
 from six.moves import range
 
+from edx_toggles.toggles.testutils import override_waffle_flag
 from openedx.core.djangoapps.schedules import resolvers, tasks
 from openedx.core.djangoapps.schedules.config import COURSE_UPDATE_WAFFLE_FLAG
 from openedx.core.djangoapps.schedules.management.commands import send_course_update as nudge
@@ -21,7 +22,6 @@ from openedx.core.djangoapps.schedules.management.commands.tests.send_email_base
 )
 from openedx.core.djangoapps.schedules.management.commands.tests.upsell_base import ScheduleUpsellTestMixin
 from openedx.core.djangoapps.schedules.models import ScheduleExperience
-from openedx.core.djangoapps.waffle_utils.testutils import override_waffle_flag
 from openedx.core.djangolib.testing.utils import skip_unless_lms
 from student.tests.factories import CourseEnrollmentFactory
 from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase

--- a/openedx/core/djangoapps/schedules/tests/test_content_highlights.py
+++ b/openedx/core/djangoapps/schedules/tests/test_content_highlights.py
@@ -3,12 +3,14 @@
 import datetime
 from unittest.mock import patch
 
+from edx_toggles.toggles.testutils import override_waffle_flag
 from openedx.core.djangoapps.schedules.config import COURSE_UPDATE_WAFFLE_FLAG
 from openedx.core.djangoapps.schedules.content_highlights import (
-    course_has_highlights, get_week_highlights, get_next_section_highlights,
+    course_has_highlights,
+    get_next_section_highlights,
+    get_week_highlights
 )
 from openedx.core.djangoapps.schedules.exceptions import CourseUpdateDoesNotExist
-from openedx.core.djangoapps.waffle_utils.testutils import override_waffle_flag
 from openedx.core.djangolib.testing.utils import skip_unless_lms
 from student.models import CourseEnrollment
 from student.tests.factories import UserFactory

--- a/openedx/core/djangoapps/schedules/tests/test_resolvers.py
+++ b/openedx/core/djangoapps/schedules/tests/test_resolvers.py
@@ -12,17 +12,17 @@ from django.test.utils import override_settings
 from testfixtures import LogCapture
 from waffle.testutils import override_switch
 
+from edx_toggles.toggles.testutils import override_waffle_flag
 from openedx.core.djangoapps.schedules.config import COURSE_UPDATE_WAFFLE_FLAG
 from openedx.core.djangoapps.schedules.models import Schedule
 from openedx.core.djangoapps.schedules.resolvers import (
     LOG,
     BinnedSchedulesBaseResolver,
-    CourseUpdateResolver,
     CourseNextSectionUpdate,
+    CourseUpdateResolver
 )
 from openedx.core.djangoapps.schedules.tests.factories import ScheduleConfigFactory
 from openedx.core.djangoapps.site_configuration.tests.factories import SiteConfigurationFactory, SiteFactory
-from openedx.core.djangoapps.waffle_utils.testutils import override_waffle_flag
 from openedx.core.djangolib.testing.utils import CacheIsolationMixin, skip_unless_lms
 from student.tests.factories import CourseEnrollmentFactory
 from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase

--- a/openedx/core/djangoapps/schedules/tests/test_signals.py
+++ b/openedx/core/djangoapps/schedules/tests/test_signals.py
@@ -7,13 +7,13 @@ import datetime
 
 import ddt
 import pytest
+from edx_toggles.toggles.testutils import override_waffle_flag
 from mock import patch
 from pytz import utc
 from testfixtures import LogCapture
 
 from course_modes.models import CourseMode
 from course_modes.tests.factories import CourseModeFactory
-from edx_toggles.toggles.testutils import override_waffle_flag
 from lms.djangoapps.courseware.models import DynamicUpgradeDeadlineConfiguration
 from openedx.core.djangoapps.schedules.models import ScheduleExperience
 from openedx.core.djangoapps.schedules.signals import CREATE_SCHEDULE_WAFFLE_FLAG, log

--- a/openedx/core/djangoapps/schedules/tests/test_signals.py
+++ b/openedx/core/djangoapps/schedules/tests/test_signals.py
@@ -7,23 +7,24 @@ import datetime
 
 import ddt
 import pytest
-from course_modes.models import CourseMode
-from course_modes.tests.factories import CourseModeFactory
 from mock import patch
 from pytz import utc
-from student.models import CourseEnrollment
-from student.tests.factories import CourseEnrollmentFactory
 from testfixtures import LogCapture
-from xmodule.modulestore import ModuleStoreEnum
-from xmodule.modulestore.tests.django_utils import SharedModuleStoreTestCase
-from xmodule.modulestore.tests.factories import CourseFactory
 
+from course_modes.models import CourseMode
+from course_modes.tests.factories import CourseModeFactory
+from edx_toggles.toggles.testutils import override_waffle_flag
 from lms.djangoapps.courseware.models import DynamicUpgradeDeadlineConfiguration
 from openedx.core.djangoapps.schedules.models import ScheduleExperience
 from openedx.core.djangoapps.schedules.signals import CREATE_SCHEDULE_WAFFLE_FLAG, log
 from openedx.core.djangoapps.site_configuration.tests.factories import SiteFactory
-from openedx.core.djangoapps.waffle_utils.testutils import override_waffle_flag
 from openedx.core.djangolib.testing.utils import skip_unless_lms
+from student.models import CourseEnrollment
+from student.tests.factories import CourseEnrollmentFactory
+from xmodule.modulestore import ModuleStoreEnum
+from xmodule.modulestore.tests.django_utils import SharedModuleStoreTestCase
+from xmodule.modulestore.tests.factories import CourseFactory
+
 from ..models import Schedule
 from ..tests.factories import ScheduleConfigFactory
 

--- a/openedx/core/djangoapps/user_api/accounts/tests/test_settings_views.py
+++ b/openedx/core/djangoapps/user_api/accounts/tests/test_settings_views.py
@@ -12,6 +12,7 @@ from django.test.utils import override_settings
 from django.urls import reverse
 from edx_rest_api_client import exceptions
 
+from edx_toggles.toggles.testutils import override_waffle_flag
 from lms.djangoapps.commerce.models import CommerceConfiguration
 from lms.djangoapps.commerce.tests import factories
 from lms.djangoapps.commerce.tests.mocks import mock_get_orders
@@ -23,11 +24,10 @@ from openedx.core.djangoapps.site_configuration.tests.mixins import SiteMixin
 from openedx.core.djangoapps.user_api.accounts.settings_views import account_settings_context, get_user_orders
 from openedx.core.djangoapps.user_api.accounts.toggles import REDIRECT_TO_ACCOUNT_MICROFRONTEND
 from openedx.core.djangoapps.user_api.tests.factories import UserPreferenceFactory
-from openedx.core.djangoapps.waffle_utils.testutils import override_waffle_flag
 from openedx.core.djangolib.testing.utils import skip_unless_lms
+from openedx.features.enterprise_support.utils import get_enterprise_readonly_account_fields
 from student.tests.factories import UserFactory
 from third_party_auth.tests.testutil import ThirdPartyAuthTestMixin
-from openedx.features.enterprise_support.utils import get_enterprise_readonly_account_fields
 
 
 @skip_unless_lms

--- a/openedx/core/djangoapps/user_api/accounts/toggles.py
+++ b/openedx/core/djangoapps/user_api/accounts/toggles.py
@@ -2,8 +2,8 @@
 Toggles for accounts related code.
 """
 
+from edx_toggles.toggles import WaffleFlag
 from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
-from openedx.core.djangoapps.waffle_utils import WaffleFlag
 
 # .. toggle_name: order_history.redirect_to_microfrontend
 # .. toggle_implementation: WaffleFlag

--- a/openedx/core/djangoapps/user_api/config/waffle.py
+++ b/openedx/core/djangoapps/user_api/config/waffle.py
@@ -5,7 +5,7 @@ Waffle flags and switches to change user API functionality.
 
 from django.utils.translation import ugettext_lazy as _
 
-from openedx.core.djangoapps.waffle_utils import WaffleSwitchNamespace
+from edx_toggles.toggles import WaffleSwitchNamespace
 
 SYSTEM_MAINTENANCE_MSG = _(u'System maintenance in progress. Please try again later.')
 WAFFLE_NAMESPACE = u'user_api'

--- a/openedx/core/djangoapps/user_authn/config/waffle.py
+++ b/openedx/core/djangoapps/user_authn/config/waffle.py
@@ -3,7 +3,7 @@ Waffle flags and switches for user authn.
 """
 
 
-from openedx.core.djangoapps.waffle_utils import WaffleSwitch, WaffleSwitchNamespace
+from edx_toggles.toggles import WaffleSwitch, WaffleSwitchNamespace
 
 _WAFFLE_NAMESPACE = u'user_authn'
 _WAFFLE_SWITCH_NAMESPACE = WaffleSwitchNamespace(name=_WAFFLE_NAMESPACE, log_prefix=u'UserAuthN: ')

--- a/openedx/core/djangoapps/user_authn/views/register.py
+++ b/openedx/core/djangoapps/user_authn/views/register.py
@@ -21,12 +21,11 @@ from django.utils.translation import get_language
 from django.utils.translation import ugettext as _
 from django.views.decorators.csrf import csrf_exempt, ensure_csrf_cookie
 from django.views.decorators.debug import sensitive_post_parameters
-from ipware.ip import get_ip
+from edx_toggles.toggles import WaffleFlag, WaffleFlagNamespace
 from pytz import UTC
 from ratelimit.decorators import ratelimit
 from requests import HTTPError
 from rest_framework.response import Response
-from rest_framework.throttling import AnonRateThrottle
 from rest_framework.views import APIView
 from six import text_type
 from social_core.exceptions import AuthAlreadyAssociated, AuthException
@@ -57,7 +56,6 @@ from openedx.core.djangoapps.user_authn.views.registration_form import (
     RegistrationFormFactory,
     get_registration_extension_form
 )
-from openedx.core.djangoapps.waffle_utils import WaffleFlag, WaffleFlagNamespace
 from student.helpers import (
     AccountValidationError,
     authenticate_new_user,

--- a/openedx/core/djangoapps/user_authn/views/tests/test_login.py
+++ b/openedx/core/djangoapps/user_authn/views/tests/test_login.py
@@ -18,7 +18,10 @@ from django.http import HttpResponse
 from django.test.client import Client
 from django.test.utils import override_settings
 from django.urls import NoReverseMatch, reverse
+from edx_toggles.toggles.testutils import override_waffle_switch
 from mock import patch
+from student.tests.factories import RegistrationFactory, UserFactory, UserProfileFactory
+from util.password_policy_validators import DEFAULT_MAX_PASSWORD_LENGTH
 
 from openedx.core.djangoapps.password_policy.compliance import (
     NonCompliantPasswordException,
@@ -32,12 +35,9 @@ from openedx.core.djangoapps.user_authn.views.login import (
     AllowedAuthUser,
     _check_user_auth_flow
 )
-from openedx.core.djangoapps.waffle_utils.testutils import override_waffle_switch
 from openedx.core.djangolib.testing.utils import CacheIsolationTestCase, skip_unless_lms
 from openedx.core.djangoapps.site_configuration.tests.mixins import SiteMixin
 from openedx.core.lib.api.test_utils import ApiTestCase
-from student.tests.factories import RegistrationFactory, UserFactory, UserProfileFactory
-from util.password_policy_validators import DEFAULT_MAX_PASSWORD_LENGTH
 
 
 @ddt.ddt

--- a/openedx/core/djangoapps/user_authn/views/tests/test_login.py
+++ b/openedx/core/djangoapps/user_authn/views/tests/test_login.py
@@ -26,12 +26,12 @@ from openedx.core.djangoapps.password_policy.compliance import (
 )
 from openedx.core.djangoapps.user_api.accounts import EMAIL_MIN_LENGTH, EMAIL_MAX_LENGTH
 from openedx.core.djangoapps.user_authn.cookies import jwt_cookies
+from openedx.core.djangoapps.user_authn.tests.utils import setup_login_oauth_client
 from openedx.core.djangoapps.user_authn.views.login import (
-    AllowedAuthUser,
     ENABLE_LOGIN_USING_THIRDPARTY_AUTH_ONLY,
+    AllowedAuthUser,
     _check_user_auth_flow
 )
-from openedx.core.djangoapps.user_authn.tests.utils import setup_login_oauth_client
 from openedx.core.djangolib.testing.utils import CacheIsolationTestCase, skip_unless_lms
 from openedx.core.djangoapps.site_configuration.tests.mixins import SiteMixin
 from openedx.core.lib.api.test_utils import ApiTestCase

--- a/openedx/core/djangoapps/user_authn/views/tests/test_login.py
+++ b/openedx/core/djangoapps/user_authn/views/tests/test_login.py
@@ -32,6 +32,7 @@ from openedx.core.djangoapps.user_authn.views.login import (
     AllowedAuthUser,
     _check_user_auth_flow
 )
+from openedx.core.djangoapps.waffle_utils.testutils import override_waffle_switch
 from openedx.core.djangolib.testing.utils import CacheIsolationTestCase, skip_unless_lms
 from openedx.core.djangoapps.site_configuration.tests.mixins import SiteMixin
 from openedx.core.lib.api.test_utils import ApiTestCase
@@ -725,7 +726,7 @@ class LoginTest(SiteMixin, CacheIsolationTestCase):
             'THIRD_PARTY_AUTH_ONLY_HINT': provider_tpa_hint,
         }
 
-        with ENABLE_LOGIN_USING_THIRDPARTY_AUTH_ONLY.override(switch_enabled):
+        with override_waffle_switch(ENABLE_LOGIN_USING_THIRDPARTY_AUTH_ONLY, switch_enabled):
             if not is_third_party_authenticated:
                 site = self.set_up_site(allowed_domain, default_site_configuration_values)
 
@@ -778,7 +779,7 @@ class LoginTest(SiteMixin, CacheIsolationTestCase):
             'THIRD_PARTY_AUTH_ONLY_HINT': provider_tpa_hint,
         }
 
-        with ENABLE_LOGIN_USING_THIRDPARTY_AUTH_ONLY.override(True):
+        with override_waffle_switch(ENABLE_LOGIN_USING_THIRDPARTY_AUTH_ONLY, True):
             site = self.set_up_site(allowed_domain, default_site_configuration_values)
 
             with self.assertLogs(level='WARN') as log:

--- a/openedx/core/djangoapps/user_authn/views/tests/test_logistration.py
+++ b/openedx/core/djangoapps/user_authn/views/tests/test_logistration.py
@@ -23,6 +23,7 @@ from pytz import UTC
 from six.moves.urllib.parse import urlencode  # pylint: disable=import-error
 
 from course_modes.models import CourseMode
+from edx_toggles.toggles.testutils import override_waffle_flag
 from lms.djangoapps.branding.api import get_privacy_url
 from openedx.core.djangoapps.site_configuration.tests.factories import SiteConfigurationFactory, SiteFactory
 from openedx.core.djangoapps.site_configuration.tests.mixins import SiteMixin

--- a/openedx/core/djangoapps/user_authn/views/tests/test_logistration.py
+++ b/openedx/core/djangoapps/user_authn/views/tests/test_logistration.py
@@ -4,6 +4,7 @@
 
 from datetime import datetime, timedelta
 from http.cookies import SimpleCookie
+from urllib.parse import urlencode
 
 import ddt
 import mock
@@ -20,12 +21,9 @@ from django.urls import reverse
 from django.utils.translation import ugettext as _
 from freezegun import freeze_time
 from pytz import UTC
-from six.moves.urllib.parse import urlencode  # pylint: disable=import-error
 
 from course_modes.models import CourseMode
-from edx_toggles.toggles.testutils import override_waffle_flag
 from lms.djangoapps.branding.api import get_privacy_url
-from openedx.core.djangoapps.site_configuration.tests.factories import SiteConfigurationFactory, SiteFactory
 from openedx.core.djangoapps.site_configuration.tests.mixins import SiteMixin
 from openedx.core.djangoapps.theming.tests.test_util import with_comprehensive_theme_context
 from openedx.core.djangoapps.user_authn.views.login_form import login_and_registration_form
@@ -125,7 +123,7 @@ class LoginAndRegistrationTest(ThirdPartyAuthTestMixin, UrlResetMixin, ModuleSto
         Test that rate limiting for logistration enpoints works as expected.
         """
         login_url = reverse('signin_user')
-        for i in range(5):
+        for _ in range(5):
             response = self.client.get(login_url)
             self.assertEqual(response.status_code, 200)
 

--- a/openedx/core/djangoapps/user_authn/views/tests/test_register.py
+++ b/openedx/core/djangoapps/user_authn/views/tests/test_register.py
@@ -21,6 +21,7 @@ from pytz import UTC
 from six.moves import range
 from social_django.models import Partial, UserSocialAuth
 
+from edx_toggles.toggles.testutils import override_waffle_flag
 from openedx.core.djangoapps.site_configuration.helpers import get_value
 from openedx.core.djangoapps.site_configuration.tests.test_util import with_site_configuration
 from openedx.core.djangoapps.user_api.accounts import (
@@ -49,7 +50,6 @@ from openedx.core.djangoapps.user_api.tests.test_constants import SORTED_COUNTRI
 from openedx.core.djangoapps.user_api.tests.test_helpers import TestCaseForm
 from openedx.core.djangoapps.user_api.tests.test_views import UserAPITestCase
 from openedx.core.djangoapps.user_authn.views.register import REGISTRATION_FAILURE_LOGGING_FLAG
-from openedx.core.djangoapps.waffle_utils.testutils import override_waffle_flag
 from openedx.core.djangolib.testing.utils import CacheIsolationTestCase, skip_unless_lms
 from openedx.core.lib.api import test_utils
 from student.helpers import authenticate_new_user

--- a/openedx/core/djangoapps/util/waffle.py
+++ b/openedx/core/djangoapps/util/waffle.py
@@ -3,7 +3,7 @@ Waffle flags and switches
 """
 
 
-from openedx.core.djangoapps.waffle_utils import WaffleSwitchNamespace
+from edx_toggles.toggles import WaffleSwitchNamespace
 
 WAFFLE_NAMESPACE = u'open_edx_util'
 

--- a/openedx/core/djangoapps/video_pipeline/config/waffle.py
+++ b/openedx/core/djangoapps/video_pipeline/config/waffle.py
@@ -3,7 +3,8 @@ This module contains configuration settings via waffle flags
 for the Video Pipeline app.
 """
 
-from openedx.core.djangoapps.waffle_utils import CourseWaffleFlag, WaffleFlag, WaffleFlagNamespace
+from edx_toggles.toggles import WaffleFlag, WaffleFlagNamespace
+from openedx.core.djangoapps.waffle_utils import CourseWaffleFlag
 
 # Videos Namespace
 WAFFLE_NAMESPACE = 'videos'

--- a/openedx/core/djangoapps/waffle_utils/__init__.py
+++ b/openedx/core/djangoapps/waffle_utils/__init__.py
@@ -7,8 +7,7 @@ from contextlib import contextmanager
 
 from opaque_keys.edx.keys import CourseKey
 
-from edx_toggles.toggles import WaffleFlag as BaseWaffleFlag
-from edx_toggles.toggles import WaffleFlagNamespace
+from edx_toggles.toggles import WaffleFlag, WaffleFlagNamespace
 from edx_toggles.toggles import WaffleSwitch as BaseWaffleSwitch
 from edx_toggles.toggles import WaffleSwitchNamespace as BaseWaffleSwitchNamespace
 
@@ -93,26 +92,6 @@ class WaffleSwitch(BaseWaffleSwitch):
         with self.waffle_namespace.override(self.switch_name, active):
             yield
 
-
-class WaffleFlag(BaseWaffleFlag):
-    """
-    Waffle flag class that implements custom override method.
-
-    This class should be removed in favour of edx_toggles.toggles.WaffleFlag once we get rid of the WaffleFlagNamespace
-    class and the `override` method.
-    """
-
-    @contextmanager
-    def override(self, active=True):
-        """
-        Shortcut method for `override_waffle_flag`.
-        """
-        # TODO We can move this import to the top of the file once this code is
-        # not all contained within the __init__ module.
-        from openedx.core.djangoapps.waffle_utils.testutils import override_waffle_flag
-
-        with override_waffle_flag(self, active):
-            yield
 
 
 class CourseWaffleFlag(WaffleFlag):

--- a/openedx/core/djangoapps/waffle_utils/__init__.py
+++ b/openedx/core/djangoapps/waffle_utils/__init__.py
@@ -6,7 +6,6 @@ import logging
 
 from opaque_keys.edx.keys import CourseKey
 
-# pylint: disable=unused-import
 from edx_toggles.toggles import WaffleFlag, WaffleFlagNamespace, WaffleSwitch, WaffleSwitchNamespace
 
 log = logging.getLogger(__name__)

--- a/openedx/core/djangoapps/waffle_utils/__init__.py
+++ b/openedx/core/djangoapps/waffle_utils/__init__.py
@@ -3,12 +3,122 @@ Extra utilities for waffle: most classes are defined in edx_toggles.toggles (htt
 we keep here some extra classes for usage within edx-platform. These classes cover course override use cases.
 """
 import logging
+import warnings
+from contextlib import contextmanager
 
+from edx_django_utils.monitoring import set_custom_attribute
+from edx_toggles.toggles import WaffleFlag as BaseWaffleFlag
+from edx_toggles.toggles import WaffleFlagNamespace as BaseWaffleFlagNamespace
+from edx_toggles.toggles import WaffleSwitch as BaseWaffleSwitch
+from edx_toggles.toggles import WaffleSwitchNamespace as BaseWaffleSwitchNamespace
 from opaque_keys.edx.keys import CourseKey
 
-from edx_toggles.toggles import WaffleFlag, WaffleFlagNamespace, WaffleSwitch, WaffleSwitchNamespace
-
 log = logging.getLogger(__name__)
+
+
+class WaffleSwitchNamespace(BaseWaffleSwitchNamespace):
+    """
+    Deprecated class: instead, use edx_toggles.toggles.WaffleSwitchNamespace.
+    """
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        warnings.warn(
+            (
+                "Importing WaffleSwitchNamespace from waffle_utils is deprecated. Instead, import from"
+                " edx_toggles.toggles."
+            ),
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        set_custom_attribute("deprecated_waffle_utils", "WaffleSwitchNamespace")
+
+    @contextmanager
+    def override(self, switch_name, active=True):
+        """
+        Deprecated method: instead, use edx_toggles.toggles.testutils.override_waffle_switch.
+        """
+        warnings.warn(
+            (
+                "WaffleSwitchNamespace.override is deprecated. Instead, use"
+                " edx_toggles.toggles.testutils.override_waffle_switch."
+            ),
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        set_custom_attribute(
+            "deprecated_waffle_utils", "WaffleSwitchNamespace.override"
+        )
+        from edx_toggles.toggles.testutils import override_waffle_switch
+
+        with override_waffle_switch(
+            BaseWaffleSwitch(self, switch_name, module_name=__name__), active
+        ):
+            yield
+
+
+class WaffleSwitch(BaseWaffleSwitch):
+    """
+    Deprecated class: instead, use edx_toggles.toggles.WaffleSwitch.
+    """
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        warnings.warn(
+            "Importing WaffleSwitch from waffle_utils is deprecated. Instead, import from edx_toggles.toggles.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        set_custom_attribute("deprecated_waffle_utils", "WaffleSwitch")
+
+
+class WaffleFlagNamespace(BaseWaffleFlagNamespace):
+    """
+    Deprecated class: instead, use edx_toggles.toggles.WaffleFlagNamespace.
+    """
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        warnings.warn(
+            "Importing WaffleFlagNamespace from waffle_utils is deprecated. Instead, import from edx_toggles.toggles.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        set_custom_attribute("deprecated_waffle_utils", "WaffleFlagNamespace")
+
+
+class WaffleFlag(BaseWaffleFlag):
+    """
+    Deprecated class: instead, use edx_toggles.toggles.WaffleFlag.
+    """
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        warnings.warn(
+            "Importing WaffleFlag from waffle_utils is deprecated. Instead, import from edx_toggles.toggles.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        set_custom_attribute("deprecated_waffle_utils", "WaffleFlag")
+
+    @contextmanager
+    def override(self, active=True):
+        """
+        Deprecated method: instead, use edx_toggles.toggles.testutils.override_waffle_flag.
+        """
+        warnings.warn(
+            (
+                "WaffleFlag.override is deprecated. Instead, use"
+                " edx_toggles.toggles.testutils.override_waffle_flag."
+            ),
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        set_custom_attribute("deprecated_waffle_utils", "WaffleFlag.override")
+        from edx_toggles.toggles.testutils import override_waffle_flag
+
+        with override_waffle_flag(self, active):
+            yield
 
 
 class CourseWaffleFlag(WaffleFlag):

--- a/openedx/core/djangoapps/waffle_utils/tests/test_init.py
+++ b/openedx/core/djangoapps/waffle_utils/tests/test_init.py
@@ -18,6 +18,7 @@ from waffle.testutils import override_flag
 from .. import (
     CourseWaffleFlag,
     WaffleFlagNamespace,
+    WaffleSwitchNamespace,
 )
 from ..models import WaffleFlagCourseOverrideModel
 
@@ -175,3 +176,14 @@ class TestCourseWaffleFlag(TestCase):
             self.assertEqual(mock_set_custom_attribute.call_count, 1)
         else:
             self.assertEqual(mock_set_custom_attribute.call_count, 0)
+
+
+class DeprecatedWaffleFlagTests(TestCase):
+    """
+    Tests for the deprecated waffle methods, including override and import paths.
+    """
+
+    def test_waffle_switch_namespace_override(self):
+        namespace = WaffleSwitchNamespace("namespace")
+        with namespace.override("waffle_switch1", True):
+            self.assertTrue(namespace.is_enabled("waffle_switch1"))

--- a/openedx/core/djangoapps/waffle_utils/tests/test_init.py
+++ b/openedx/core/djangoapps/waffle_utils/tests/test_init.py
@@ -7,7 +7,8 @@ import ddt
 from django.test import TestCase
 from django.test.client import RequestFactory
 from django.test.utils import override_settings
-# Note that we really shouldn't import from edx_toggles' internal API
+# TODO: we really shouldn't import from edx_toggles' internal API, but that's currently the only way to mock the
+# monitoring functions.
 import edx_toggles.toggles.internal.waffle
 from edx_django_utils.cache import RequestCache
 from mock import call, patch

--- a/openedx/core/djangoapps/waffle_utils/tests/test_views.py
+++ b/openedx/core/djangoapps/waffle_utils/tests/test_views.py
@@ -2,13 +2,13 @@
 Tests for waffle utils views.
 """
 from django.test import TestCase
+from edx_toggles.toggles.testutils import override_waffle_flag
 from rest_framework.test import APIRequestFactory
 from waffle.testutils import override_switch
 
 from student.tests.factories import UserFactory
 
-from .. import WaffleFlag, WaffleFlagNamespace, WaffleSwitch, WaffleSwitchNamespace
-from ..testutils import override_waffle_flag
+from .. import WaffleFlag, WaffleFlagNamespace
 from ..views import ToggleStateView
 
 TEST_WAFFLE_FLAG_NAMESPACE = WaffleFlagNamespace('test')

--- a/openedx/core/djangoapps/waffle_utils/testutils.py
+++ b/openedx/core/djangoapps/waffle_utils/testutils.py
@@ -5,7 +5,7 @@ Test utilities for waffle utilities.
 # Import from edx-toggles to preserve import paths
 # TODO: Deprecate and remove
 # pylint: disable=unused-import
-from edx_toggles.toggles.testutils import override_waffle_flag
+from edx_toggles.toggles.testutils import override_waffle_flag, override_waffle_switch
 
 # Can be used with FilteredQueryCountMixin.assertNumQueries() to blacklist
 # waffle tables. For example:

--- a/openedx/core/djangoapps/waffle_utils/testutils.py
+++ b/openedx/core/djangoapps/waffle_utils/testutils.py
@@ -2,11 +2,6 @@
 Test utilities for waffle utilities.
 """
 
-# Import from edx-toggles to preserve import paths
-# TODO: Deprecate and remove
-# pylint: disable=unused-import
-from edx_toggles.toggles.testutils import override_waffle_flag, override_waffle_switch
-
 # Can be used with FilteredQueryCountMixin.assertNumQueries() to blacklist
 # waffle tables. For example:
 #   QUERY_COUNT_TABLE_BLACKLIST = WAFFLE_TABLES

--- a/openedx/core/lib/request_utils.py
+++ b/openedx/core/lib/request_utils.py
@@ -12,8 +12,8 @@ from opaque_keys import InvalidKeyError
 from opaque_keys.edx.keys import CourseKey
 from six.moves.urllib.parse import urlparse
 
+from edx_toggles.toggles import WaffleFlag, WaffleFlagNamespace
 from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
-from openedx.core.djangoapps.waffle_utils import WaffleFlag, WaffleFlagNamespace
 
 # accommodates course api urls, excluding any course api routes that do not fall under v*/courses, such as v1/blocks.
 COURSE_REGEX = re.compile(r'^(.*?/courses/)(?!v[0-9]+/[^/]+){}'.format(settings.COURSE_ID_PATTERN))

--- a/openedx/core/tests/test_admin_view.py
+++ b/openedx/core/tests/test_admin_view.py
@@ -4,10 +4,12 @@ Tests that verify that the admin view loads.
 This is not inside a django app because it is a global property of the system.
 """
 
-from django.test import TestCase, Client
+from django.test import Client, TestCase
 from django.urls import reverse
-from student.tests.factories import UserFactory, TEST_PASSWORD
+
 from openedx.core.djangoapps.user_authn.views.login import ENABLE_LOGIN_USING_THIRDPARTY_AUTH_ONLY
+from openedx.core.djangoapps.waffle_utils.testutils import override_waffle_switch
+from student.tests.factories import TEST_PASSWORD, UserFactory
 
 
 class TestAdminView(TestCase):
@@ -37,10 +39,10 @@ class TestAdminView(TestCase):
         assert response.status_code == 302
 
     def test_admin_login_redirect(self):
-        with ENABLE_LOGIN_USING_THIRDPARTY_AUTH_ONLY.override(True):
+        with override_waffle_switch(ENABLE_LOGIN_USING_THIRDPARTY_AUTH_ONLY, True):
             response = self.client.get(reverse('admin:login'))
             assert response.url == '/login?next=/admin'
             assert response.status_code == 302
-        with ENABLE_LOGIN_USING_THIRDPARTY_AUTH_ONLY.override(False):
+        with override_waffle_switch(ENABLE_LOGIN_USING_THIRDPARTY_AUTH_ONLY, False):
             response = self.client.get(reverse('admin:login'))
             assert response.template_name == ['admin/login.html']

--- a/openedx/core/tests/test_admin_view.py
+++ b/openedx/core/tests/test_admin_view.py
@@ -6,10 +6,10 @@ This is not inside a django app because it is a global property of the system.
 
 from django.test import Client, TestCase
 from django.urls import reverse
+from edx_toggles.toggles.testutils import override_waffle_switch
+from student.tests.factories import TEST_PASSWORD, UserFactory
 
 from openedx.core.djangoapps.user_authn.views.login import ENABLE_LOGIN_USING_THIRDPARTY_AUTH_ONLY
-from openedx.core.djangoapps.waffle_utils.testutils import override_waffle_switch
-from student.tests.factories import TEST_PASSWORD, UserFactory
 
 
 class TestAdminView(TestCase):

--- a/openedx/features/calendar_sync/tests/test_plugins.py
+++ b/openedx/features/calendar_sync/tests/test_plugins.py
@@ -7,8 +7,8 @@ import crum
 import ddt
 from django.test import RequestFactory
 
+from edx_toggles.toggles.testutils import override_waffle_flag
 from lms.djangoapps.experiments.testutils import override_experiment_waffle_flag
-from openedx.core.djangoapps.waffle_utils.testutils import override_waffle_flag
 from openedx.features.calendar_sync.plugins import CalendarSyncToggleTool
 from openedx.features.course_experience import CALENDAR_SYNC_FLAG, RELATIVE_DATES_FLAG
 from xmodule.modulestore.tests.django_utils import CourseUserType, SharedModuleStoreTestCase

--- a/openedx/features/calendar_sync/tests/test_plugins.py
+++ b/openedx/features/calendar_sync/tests/test_plugins.py
@@ -7,12 +7,12 @@ import crum
 import ddt
 from django.test import RequestFactory
 
-from xmodule.modulestore.tests.django_utils import CourseUserType, SharedModuleStoreTestCase
-from xmodule.modulestore.tests.factories import CourseFactory
-
+from lms.djangoapps.experiments.testutils import override_experiment_waffle_flag
 from openedx.core.djangoapps.waffle_utils.testutils import override_waffle_flag
 from openedx.features.calendar_sync.plugins import CalendarSyncToggleTool
 from openedx.features.course_experience import CALENDAR_SYNC_FLAG, RELATIVE_DATES_FLAG
+from xmodule.modulestore.tests.django_utils import CourseUserType, SharedModuleStoreTestCase
+from xmodule.modulestore.tests.factories import CourseFactory
 
 
 @ddt.ddt
@@ -35,7 +35,7 @@ class TestCalendarSyncToggleTool(SharedModuleStoreTestCase):
     )
     @ddt.unpack
     @override_waffle_flag(CALENDAR_SYNC_FLAG, active=True)
-    @RELATIVE_DATES_FLAG.override(active=True)
+    @override_experiment_waffle_flag(RELATIVE_DATES_FLAG, active=True)
     def test_calendar_sync_toggle_tool_is_enabled(self, user_type, should_be_enabled):
         request = RequestFactory().request()
         request.user = self.create_user_for_course(self.course, user_type)

--- a/openedx/features/content_type_gating/tests/test_models.py
+++ b/openedx/features/content_type_gating/tests/test_models.py
@@ -11,10 +11,10 @@ from mock import Mock
 from opaque_keys.edx.locator import CourseLocator
 
 from course_modes.tests.factories import CourseModeFactory
+from edx_toggles.toggles.testutils import override_waffle_flag
 from openedx.core.djangoapps.config_model_utils.models import Provenance
 from openedx.core.djangoapps.content.course_overviews.tests.factories import CourseOverviewFactory
 from openedx.core.djangoapps.site_configuration.tests.factories import SiteConfigurationFactory
-from openedx.core.djangoapps.waffle_utils.testutils import override_waffle_flag
 from openedx.core.djangolib.testing.utils import CacheIsolationTestCase
 from openedx.features.content_type_gating.models import ContentTypeGatingConfig
 from student.tests.factories import CourseEnrollmentFactory, UserFactory

--- a/openedx/features/course_experience/__init__.py
+++ b/openedx/features/course_experience/__init__.py
@@ -6,9 +6,9 @@ from django.utils.translation import ugettext as _
 from edx_django_utils.monitoring import set_custom_attribute
 from waffle import flag_is_active
 
+from edx_toggles.toggles import WaffleFlag, WaffleFlagNamespace
 from lms.djangoapps.experiments.flags import ExperimentWaffleFlag
 from openedx.core.djangoapps.util.user_messages import UserMessageCollection
-from openedx.core.djangoapps.waffle_utils import WaffleFlag, WaffleFlagNamespace
 from openedx.core.djangoapps.waffle_utils import CourseWaffleFlag
 
 # Namespace for course experience waffle flags.

--- a/openedx/features/course_experience/tests/views/test_course_home.py
+++ b/openedx/features/course_experience/tests/views/test_course_home.py
@@ -20,12 +20,11 @@ from waffle.testutils import override_flag
 
 from course_modes.models import CourseMode
 from course_modes.tests.factories import CourseModeFactory
-from lms.djangoapps.courseware.tests.helpers import get_expiration_banner_text
+from edx_toggles.toggles.testutils import override_waffle_flag
 from experiments.models import ExperimentData
 from lms.djangoapps.commerce.models import CommerceConfiguration
 from lms.djangoapps.commerce.utils import EcommerceService
 from lms.djangoapps.course_goals.api import add_course_goal, remove_course_goal
-from lms.djangoapps.courseware.utils import verified_upgrade_deadline_link
 from lms.djangoapps.courseware.tests.factories import (
     BetaTesterFactory,
     GlobalStaffFactory,
@@ -34,9 +33,9 @@ from lms.djangoapps.courseware.tests.factories import (
     OrgStaffFactory,
     StaffFactory
 )
+from lms.djangoapps.courseware.tests.helpers import get_expiration_banner_text
+from lms.djangoapps.courseware.utils import verified_upgrade_deadline_link
 from lms.djangoapps.discussion.django_comment_client.tests.factories import RoleFactory
-from openedx.features.discounts.applicability import get_discount_expiration_date
-from openedx.features.discounts.utils import format_strikeout_price, REV1008_EXPERIMENT_ID
 from openedx.core.djangoapps.content.course_overviews.models import CourseOverview
 from openedx.core.djangoapps.dark_lang.models import DarkLangConfig
 from openedx.core.djangoapps.django_comment_common.models import (
@@ -55,6 +54,8 @@ from openedx.features.course_experience import (
     SHOW_REVIEWS_TOOL_FLAG,
     SHOW_UPGRADE_MSG_ON_COURSE_HOME
 )
+from openedx.features.discounts.applicability import get_discount_expiration_date
+from openedx.features.discounts.utils import REV1008_EXPERIMENT_ID, format_strikeout_price
 from student.models import CourseEnrollment, FBEEnrollmentExclusion
 from student.tests.factories import UserFactory
 from util.date_utils import strftime_localized
@@ -1021,7 +1022,7 @@ class CourseHomeFragmentViewTests(ModuleStoreTestCase):
     def test_upgrade_message_discount(self):
         CourseEnrollment.enroll(self.user, self.course.id, CourseMode.AUDIT)
 
-        with SHOW_UPGRADE_MSG_ON_COURSE_HOME.override(True):
+        with override_waffle_flag(SHOW_UPGRADE_MSG_ON_COURSE_HOME, True):
             response = self.client.get(self.url)
 
         self.assertContains(response, "<span>DISCOUNT_PRICE</span>")

--- a/openedx/features/course_experience/tests/views/test_course_home.py
+++ b/openedx/features/course_experience/tests/views/test_course_home.py
@@ -14,13 +14,13 @@ from django.http import QueryDict
 from django.urls import reverse
 from django.utils.http import urlquote_plus
 from django.utils.timezone import now
+from edx_toggles.toggles.testutils import override_waffle_flag
 from pytz import UTC
 from waffle.models import Flag
 from waffle.testutils import override_flag
 
 from course_modes.models import CourseMode
 from course_modes.tests.factories import CourseModeFactory
-from edx_toggles.toggles.testutils import override_waffle_flag
 from experiments.models import ExperimentData
 from lms.djangoapps.commerce.models import CommerceConfiguration
 from lms.djangoapps.commerce.utils import EcommerceService
@@ -45,7 +45,7 @@ from openedx.core.djangoapps.django_comment_common.models import (
     FORUM_ROLE_MODERATOR
 )
 from openedx.core.djangoapps.schedules.tests.factories import ScheduleFactory
-from openedx.core.djangoapps.waffle_utils.testutils import WAFFLE_TABLES, override_waffle_flag
+from openedx.core.djangoapps.waffle_utils.testutils import WAFFLE_TABLES
 from openedx.core.djangolib.markup import HTML
 from openedx.features.course_duration_limits.models import CourseDurationLimitConfig
 from openedx.features.course_experience import (
@@ -1020,6 +1020,7 @@ class CourseHomeFragmentViewTests(ModuleStoreTestCase):
         mock.Mock(return_value=(HTML("<span>DISCOUNT_PRICE</span>"), True))
     )
     def test_upgrade_message_discount(self):
+        # pylint: disable=no-member
         CourseEnrollment.enroll(self.user, self.course.id, CourseMode.AUDIT)
 
         with override_waffle_flag(SHOW_UPGRADE_MSG_ON_COURSE_HOME, True):

--- a/openedx/features/course_experience/tests/views/test_course_sock.py
+++ b/openedx/features/course_experience/tests/views/test_course_sock.py
@@ -3,13 +3,12 @@ Tests for course verification sock
 """
 
 
+import ddt
 import mock
 
-import ddt
-
 from course_modes.models import CourseMode
+from edx_toggles.toggles.testutils import override_waffle_flag
 from lms.djangoapps.commerce.models import CommerceConfiguration
-from openedx.core.djangoapps.waffle_utils.testutils import override_waffle_flag
 from openedx.core.djangolib.markup import HTML
 from openedx.features.course_experience import DISPLAY_COURSE_SOCK_FLAG
 from student.tests.factories import CourseEnrollmentFactory, UserFactory

--- a/openedx/features/course_experience/tests/views/test_course_sock.py
+++ b/openedx/features/course_experience/tests/views/test_course_sock.py
@@ -5,9 +5,9 @@ Tests for course verification sock
 
 import ddt
 import mock
+from edx_toggles.toggles.testutils import override_waffle_flag
 
 from course_modes.models import CourseMode
-from edx_toggles.toggles.testutils import override_waffle_flag
 from lms.djangoapps.commerce.models import CommerceConfiguration
 from openedx.core.djangolib.markup import HTML
 from openedx.features.course_experience import DISPLAY_COURSE_SOCK_FLAG

--- a/openedx/features/course_experience/tests/views/test_masquerade.py
+++ b/openedx/features/course_experience/tests/views/test_masquerade.py
@@ -2,8 +2,8 @@
 Tests for masquerading functionality on course_experience
 """
 
+from edx_toggles.toggles.testutils import override_waffle_flag
 from lms.djangoapps.courseware.tests.helpers import MasqueradeMixin
-from openedx.core.djangoapps.waffle_utils.testutils import override_waffle_flag
 from openedx.features.course_experience import DISPLAY_COURSE_SOCK_FLAG, SHOW_UPGRADE_MSG_ON_COURSE_HOME
 from student.roles import CourseStaffRole
 from student.tests.factories import CourseEnrollmentFactory, UserFactory

--- a/openedx/features/course_experience/waffle.py
+++ b/openedx/features/course_experience/waffle.py
@@ -3,7 +3,7 @@ Miscellaneous waffle switches that both LMS and Studio need to access
 """
 
 
-from openedx.core.djangoapps.waffle_utils import WaffleSwitchNamespace
+from edx_toggles.toggles import WaffleSwitchNamespace
 
 # Namespace
 WAFFLE_NAMESPACE = u'course_experience'

--- a/openedx/features/discounts/applicability.py
+++ b/openedx/features/discounts/applicability.py
@@ -12,16 +12,16 @@ not other discounts like coupons or enterprise/program offers configured in ecom
 
 from datetime import datetime, timedelta
 
+import pytz
 from crum import get_current_request, impersonate
 from django.utils import timezone
 from django.utils.dateparse import parse_datetime
-import pytz
+from edx_toggles.toggles import WaffleFlag, WaffleFlagNamespace
 
 from course_modes.models import CourseMode
 from entitlements.models import CourseEntitlement
 from experiments.models import ExperimentData
 from lms.djangoapps.experiments.stable_bucketing import stable_bucketing_hash_group
-from openedx.core.djangoapps.waffle_utils import WaffleFlag, WaffleFlagNamespace
 from openedx.features.discounts.models import DiscountPercentageConfig, DiscountRestrictionConfig
 from student.models import CourseEnrollment
 from track import segment

--- a/openedx/features/discounts/tests/test_applicability.py
+++ b/openedx/features/discounts/tests/test_applicability.py
@@ -14,10 +14,10 @@ from mock import Mock, patch
 
 from course_modes.models import CourseMode
 from course_modes.tests.factories import CourseModeFactory
+from edx_toggles.toggles.testutils import override_waffle_flag
 from entitlements.tests.factories import CourseEntitlementFactory
 from experiments.models import ExperimentData
 from openedx.core.djangoapps.content.course_overviews.models import CourseOverview
-from openedx.core.djangoapps.waffle_utils.testutils import override_waffle_flag
 from openedx.features.discounts.models import DiscountRestrictionConfig
 from openedx.features.discounts.utils import REV1008_EXPERIMENT_ID
 from student.tests.factories import CourseEnrollmentFactory, UserFactory

--- a/openedx/features/discounts/tests/test_applicability.py
+++ b/openedx/features/discounts/tests/test_applicability.py
@@ -9,12 +9,12 @@ import pytest
 import pytz
 from django.contrib.sites.models import Site
 from django.utils.timezone import now
+from edx_toggles.toggles.testutils import override_waffle_flag
 from enterprise.models import EnterpriseCustomer, EnterpriseCustomerUser
 from mock import Mock, patch
 
 from course_modes.models import CourseMode
 from course_modes.tests.factories import CourseModeFactory
-from edx_toggles.toggles.testutils import override_waffle_flag
 from entitlements.tests.factories import CourseEntitlementFactory
 from experiments.models import ExperimentData
 from openedx.core.djangoapps.content.course_overviews.models import CourseOverview

--- a/openedx/features/enterprise_support/tests/test_utils.py
+++ b/openedx/features/enterprise_support/tests/test_utils.py
@@ -3,19 +3,20 @@ Test the enterprise support utils.
 """
 
 import json
-import mock
-import ddt
 
+import ddt
+import mock
 from django.test import TestCase
 from django.test.utils import override_settings
 
+from edx_toggles.toggles.testutils import override_waffle_flag
 from openedx.core.djangolib.testing.utils import skip_unless_lms
-from openedx.core.djangoapps.waffle_utils.testutils import override_waffle_flag
-from openedx.features.enterprise_support.utils import ENTERPRISE_HEADER_LINKS, get_enterprise_learner_portal
 from openedx.features.enterprise_support.tests import FEATURES_WITH_ENTERPRISE_ENABLED
 from openedx.features.enterprise_support.tests.factories import (
-    EnterpriseCustomerBrandingConfigurationFactory, EnterpriseCustomerUserFactory,
+    EnterpriseCustomerBrandingConfigurationFactory,
+    EnterpriseCustomerUserFactory
 )
+from openedx.features.enterprise_support.utils import ENTERPRISE_HEADER_LINKS, get_enterprise_learner_portal
 from student.tests.factories import UserFactory
 
 

--- a/openedx/features/enterprise_support/utils.py
+++ b/openedx/features/enterprise_support/utils.py
@@ -10,8 +10,9 @@ from django.conf import settings
 from django.urls import NoReverseMatch, reverse
 from django.utils.translation import ugettext as _
 from edx_django_utils.cache import TieredCache, get_cache_key
+from edx_toggles.toggles import WaffleFlag
 from enterprise.api.v1.serializers import EnterpriseCustomerBrandingConfigurationSerializer
-from enterprise.models import EnterpriseCustomerUser, EnterpriseCustomer
+from enterprise.models import EnterpriseCustomer, EnterpriseCustomerUser
 from social_django.models import UserSocialAuth
 
 import third_party_auth
@@ -19,7 +20,6 @@ from lms.djangoapps.branding.api import get_privacy_url
 from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
 from openedx.core.djangoapps.user_authn.cookies import standard_cookie_settings
 from openedx.core.djangolib.markup import HTML, Text
-from openedx.core.djangoapps.waffle_utils import WaffleFlag
 from student.helpers import get_next_url_for_login_page
 
 ENTERPRISE_HEADER_LINKS = WaffleFlag('enterprise', 'enterprise_header_links', __name__)

--- a/openedx/features/learner_profile/tests/views/test_learner_profile.py
+++ b/openedx/features/learner_profile/tests/views/test_learner_profile.py
@@ -13,12 +13,12 @@ from django.urls import reverse
 from opaque_keys.edx.locator import CourseLocator
 
 from course_modes.models import CourseMode
+from edx_toggles.toggles.testutils import override_waffle_flag
 from lms.djangoapps.certificates.api import is_passing_status
 from lms.djangoapps.certificates.tests.factories import GeneratedCertificateFactory
 from lms.envs.test import CREDENTIALS_PUBLIC_SERVICE_URL
 from openedx.core.djangoapps.content.course_overviews.models import CourseOverview
 from openedx.core.djangoapps.site_configuration.tests.mixins import SiteMixin
-from openedx.core.djangoapps.waffle_utils.testutils import override_waffle_flag
 from openedx.features.learner_profile.toggles import REDIRECT_TO_PROFILE_MICROFRONTEND
 from openedx.features.learner_profile.views.learner_profile import learner_profile_context
 from student.tests.factories import CourseEnrollmentFactory, UserFactory

--- a/openedx/features/learner_profile/tests/views/test_learner_profile.py
+++ b/openedx/features/learner_profile/tests/views/test_learner_profile.py
@@ -10,10 +10,10 @@ from django.conf import settings
 from django.test import override_settings
 from django.test.client import RequestFactory
 from django.urls import reverse
+from edx_toggles.toggles.testutils import override_waffle_flag
 from opaque_keys.edx.locator import CourseLocator
 
 from course_modes.models import CourseMode
-from edx_toggles.toggles.testutils import override_waffle_flag
 from lms.djangoapps.certificates.api import is_passing_status
 from lms.djangoapps.certificates.tests.factories import GeneratedCertificateFactory
 from lms.envs.test import CREDENTIALS_PUBLIC_SERVICE_URL

--- a/openedx/features/learner_profile/toggles.py
+++ b/openedx/features/learner_profile/toggles.py
@@ -3,9 +3,8 @@ Toggles for Learner Profile page.
 """
 
 
+from edx_toggles.toggles import WaffleFlag, WaffleFlagNamespace
 from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
-from openedx.core.djangoapps.waffle_utils import WaffleFlag, WaffleFlagNamespace
-
 
 # Namespace for learner profile waffle flags.
 WAFFLE_FLAG_NAMESPACE = WaffleFlagNamespace(name='learner_profile')

--- a/openedx/features/personalized_learner_schedules/show_answer/tests/test_show_answer_override.py
+++ b/openedx/features/personalized_learner_schedules/show_answer/tests/test_show_answer_override.py
@@ -1,7 +1,6 @@
 """Tests for Show Answer overrides for self-paced courses."""
 
 import ddt
-
 from django.test import RequestFactory
 from django.test.utils import override_settings
 
@@ -9,6 +8,7 @@ from common.lib.xmodule.xmodule.capa_base import SHOWANSWER
 from lms.djangoapps.ccx.tests.test_overrides import inject_field_overrides
 from lms.djangoapps.courseware.model_data import FieldDataCache
 from lms.djangoapps.courseware.module_render import get_module
+from lms.djangoapps.experiments.testutils import override_experiment_waffle_flag
 from openedx.features.course_experience import RELATIVE_DATES_FLAG
 from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
 from xmodule.modulestore.tests.factories import CourseFactory
@@ -36,7 +36,7 @@ class ShowAnswerFieldOverrideTest(ModuleStoreTestCase):
 
     @ddt.data(True, False)
     def test_override_enabled_for(self, active):
-        with RELATIVE_DATES_FLAG.override(active=active):
+        with override_experiment_waffle_flag(RELATIVE_DATES_FLAG, active=active):
             # Instructor paced course will just have the default value
             ip_course = self.setup_course()
             course_module = self.get_course_module(ip_course)
@@ -63,7 +63,7 @@ class ShowAnswerFieldOverrideTest(ModuleStoreTestCase):
         (SHOWANSWER.ALWAYS, SHOWANSWER.ALWAYS),
     )
     @ddt.unpack
-    @RELATIVE_DATES_FLAG.override(active=True)
+    @override_experiment_waffle_flag(RELATIVE_DATES_FLAG, active=True)
     def test_get(self, initial_value, expected_final_value):
         course = self.setup_course(self_paced=True, showanswer=initial_value)
         course_module = self.get_course_module(course)

--- a/openedx/tests/completion_integration/test_models.py
+++ b/openedx/tests/completion_integration/test_models.py
@@ -10,9 +10,9 @@ from django.core.exceptions import ValidationError
 from django.test import TestCase
 from opaque_keys.edx.keys import CourseKey, UsageKey
 from six.moves import range, zip
+from student.tests.factories import CourseEnrollmentFactory, UserFactory
 
 from openedx.core.djangolib.testing.utils import skip_unless_lms
-from student.tests.factories import CourseEnrollmentFactory, UserFactory
 
 SELECT = 1
 UPDATE = 1

--- a/openedx/tests/completion_integration/test_views.py
+++ b/openedx/tests/completion_integration/test_views.py
@@ -5,11 +5,11 @@ Test models, managers, and validators.
 
 
 import ddt
+import six
 from completion import waffle
 from completion.test_utils import CompletionWaffleTestMixin
 from django.urls import reverse
 from rest_framework.test import APIClient
-import six
 
 from openedx.core.djangolib.testing.utils import skip_unless_lms
 from student.tests.factories import CourseEnrollmentFactory, UserFactory


### PR DESCRIPTION
This move is part of a migration from edx-platform's waffle_utils to edx-toggles. 

~~This depends on an edx-toggles PR: https://github.com/edx/edx-toggles/pull/75~~ Merged :heavy_check_mark: 
~~This depends~~ This does not depend anymore on edx/completion PR: https://github.com/edx/completion/pull/118

~~This is not yet ready for review.~~

TODO:
- ~~migrate WafleSwitch.override method~~
- ~~rebase on top of master once https://github.com/edx/edx-platform/pull/25286 is merged~~