### PR TITLE
Fixed Alert issue in library editor

### DIFF
--- a/common/lib/xmodule/xmodule/library_content_module.py
+++ b/common/lib/xmodule/xmodule/library_content_module.py
@@ -11,6 +11,7 @@ from copy import copy
 from gettext import ngettext
 
 import six
+import bleach
 from lazy import lazy
 from lxml import etree
 from opaque_keys.edx.locator import LibraryLocator
@@ -623,7 +624,7 @@ class LibraryContentBlock(
         lib_tools = self.runtime.service(self, 'library_tools')
         user_perms = self.runtime.service(self, 'studio_user_permissions')
         all_libraries = [
-            (key, name) for key, name in lib_tools.list_available_libraries()
+            (key, bleach.clean(name)) for key, name in lib_tools.list_available_libraries()
             if user_perms.can_read(key) or self.source_library_id == six.text_type(key)
         ]
         all_libraries.sort(key=lambda entry: entry[1])  # Sort by name


### PR DESCRIPTION
### [TNL-7606](https://openedx.atlassian.net/browse/TNL-7606) ,  [TNL-7600](https://openedx.atlassian.net/browse/TNL-7600)

There is a Library that is added to test if JS works in its name. So whenever the user tries to edit library content it shows an alert in the browser "studio.edx.org says 1".

This PR fixes this issue by sanitizing library name property so it will strip script tags so js inside it cannot be executed.


![image](https://user-images.githubusercontent.com/26253150/97271252-2578f100-1852-11eb-90ec-119e1f5afcda.png)



