### PR TITLE
[nomerge] Test build of "Use full names for lms.djangoapps imports" without import shim

### DIFF
--- a/cms/djangoapps/contentstore/views/tests/test_item.py
+++ b/cms/djangoapps/contentstore/views/tests/test_item.py
@@ -35,7 +35,7 @@ from xblock.validation import ValidationMessage
 from cms.djangoapps.contentstore.tests.utils import CourseTestCase
 from cms.djangoapps.contentstore.utils import reverse_course_url, reverse_usage_url
 from cms.djangoapps.contentstore.views import item as item_module
-from lms_xblock.mixin import NONSENSICAL_ACCESS_RESTRICTION
+from lms.djangoapps.lms_xblock.mixin import NONSENSICAL_ACCESS_RESTRICTION
 from student.tests.factories import UserFactory
 from xblock_django.models import XBlockConfiguration, XBlockStudioConfiguration, XBlockStudioConfigurationFlag
 from xblock_django.user_service import DjangoXBlockUserService

--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -449,7 +449,7 @@ GITHUB_REPO_ROOT = ENV_ROOT / "data"
 sys.path.append(REPO_ROOT)
 # TODO: The next two path modifications will be removed in an upcoming Open edX release.
 # See docs/decisions/0007-sys-path-modification-removal.rst
-sys.path.append(REPO_ROOT / 'import_shims' / 'studio')
+# sys.path.append(REPO_ROOT / 'import_shims' / 'studio')
 sys.path.append(COMMON_ROOT / 'djangoapps')
 
 # For geolocation ip database

--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -1395,7 +1395,7 @@ INSTALLED_APPS = [
     # User preferences
     'wiki',
     'django_notify',
-    'course_wiki',  # Our customizations
+    'lms.djangoapps.course_wiki',  # Our customizations
     'mptt',
     'sekizai',
     'openedx.core.djangoapps.user_api',
@@ -1441,7 +1441,7 @@ INSTALLED_APPS = [
     'openedx.core.djangoapps.oauth_dispatch.apps.OAuthDispatchAppConfig',
     'lms.djangoapps.courseware',
     'lms.djangoapps.coursewarehistoryextended',
-    'survey.apps.SurveyConfig',
+    'lms.djangoapps.survey.apps.SurveyConfig',
     'lms.djangoapps.verify_student.apps.VerifyStudentConfig',
     'completion',
 

--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -43,7 +43,6 @@ When refering to XBlocks, we use the entry-point name. For example,
 import importlib.util
 import os
 import sys
-import warnings
 
 from corsheaders.defaults import default_headers as corsheaders_default_headers
 from datetime import timedelta
@@ -117,7 +116,6 @@ from lms.envs.common import (
 from path import Path as path
 from django.urls import reverse_lazy
 
-from import_shims.warn import DeprecatedEdxPlatformImportWarning
 from lms.djangoapps.lms_xblock.mixin import LmsBlockMixin
 from cms.lib.xblock.authoring_mixin import AuthoringMixin
 from xmodule.modulestore.edit_info import EditInfoMixin
@@ -130,13 +128,6 @@ from openedx.core.lib.derived import derived, derived_collection_entry
 from openedx.core.release import doc_version
 
 # pylint: enable=useless-suppression
-
-# Filter out DeprecatedEdxPlatformImportWarning instances for now.
-# We will want these to be generally visible eventually, but while there
-# are still a very high number of them, silencing them will be better for
-# developer experience.
-# See /docs/decisions/0007-sys-path-modification-removal.rst for details.
-warnings.filterwarnings("ignore", category=DeprecatedEdxPlatformImportWarning)
 
 ################ Enable credit eligibility feature ####################
 ENABLE_CREDIT_ELIGIBILITY = True

--- a/common/djangoapps/student/migrations/0001_squashed_0031_auto_20200317_1122.py
+++ b/common/djangoapps/student/migrations/0001_squashed_0031_auto_20200317_1122.py
@@ -12,7 +12,7 @@ import opaque_keys.edx.django.models
 import simple_history.models
 from django.conf import settings
 from django.db import migrations, models
-from experiments.models import ExperimentData
+from lms.djangoapps.experiments.models import ExperimentData
 from student.models import CourseEnrollment, FBEEnrollmentExclusion
 
 import openedx.core.djangolib.model_mixins

--- a/common/djangoapps/student/migrations/0025_auto_20191101_1846.py
+++ b/common/djangoapps/student/migrations/0025_auto_20191101_1846.py
@@ -4,7 +4,7 @@
 
 from django.db import migrations
 
-from experiments.models import ExperimentData
+from lms.djangoapps.experiments.models import ExperimentData
 from openedx.features.course_duration_limits.config import EXPERIMENT_DATA_HOLDBACK_KEY, EXPERIMENT_ID
 from student.models import CourseEnrollment, FBEEnrollmentExclusion
 

--- a/common/djangoapps/student/tests/test_bulk_email_settings.py
+++ b/common/djangoapps/student/tests/test_bulk_email_settings.py
@@ -13,8 +13,8 @@ from django.urls import reverse
 
 # This import is for an lms djangoapp.
 # Its testcases are only run under lms.
-from bulk_email.api import is_bulk_email_feature_enabled
-from bulk_email.models import BulkEmailFlag, CourseAuthorization
+from lms.djangoapps.bulk_email.api import is_bulk_email_feature_enabled
+from lms.djangoapps.bulk_email.models import BulkEmailFlag, CourseAuthorization
 from student.tests.factories import CourseEnrollmentFactory, UserFactory
 from xmodule.modulestore.tests.django_utils import SharedModuleStoreTestCase
 from xmodule.modulestore.tests.factories import CourseFactory

--- a/common/djangoapps/student/views/dashboard.py
+++ b/common/djangoapps/student/views/dashboard.py
@@ -22,8 +22,8 @@ from pytz import UTC
 from six import iteritems, text_type
 
 import track.views
-from bulk_email.api import is_bulk_email_feature_enabled
-from bulk_email.models import Optout
+from lms.djangoapps.bulk_email.api import is_bulk_email_feature_enabled
+from lms.djangoapps.bulk_email.models import Optout
 from course_modes.models import CourseMode
 from edxmako.shortcuts import render_to_response, render_to_string
 from entitlements.models import CourseEntitlement

--- a/common/djangoapps/student/views/management.py
+++ b/common/djangoapps/student/views/management.py
@@ -37,7 +37,7 @@ from pytz import UTC
 from six import text_type
 
 import track.views
-from bulk_email.models import Optout
+from lms.djangoapps.bulk_email.models import Optout
 from course_modes.models import CourseMode
 from lms.djangoapps.courseware.courses import get_courses, sort_by_announcement, sort_by_start_date
 from edxmako.shortcuts import marketing_link, render_to_response, render_to_string

--- a/common/lib/xmodule/xmodule/video_module/video_module.py
+++ b/common/lib/xmodule/xmodule/video_module/video_module.py
@@ -95,7 +95,7 @@ except ImportError:
     edxval_api = None
 
 try:
-    from branding.models import BrandingInfoConfig
+    from lms.djangoapps.branding.models import BrandingInfoConfig
 except ImportError:
     BrandingInfoConfig = None
 

--- a/lms/djangoapps/badges/admin.py
+++ b/lms/djangoapps/badges/admin.py
@@ -6,7 +6,7 @@ Admin registration for Badge Models
 from config_models.admin import ConfigurationModelAdmin
 from django.contrib import admin
 
-from badges.models import BadgeClass, CourseCompleteImageConfiguration, CourseEventBadgesConfiguration
+from lms.djangoapps.badges.models import BadgeClass, CourseCompleteImageConfiguration, CourseEventBadgesConfiguration
 
 admin.site.register(CourseCompleteImageConfiguration)
 admin.site.register(BadgeClass)

--- a/lms/djangoapps/badges/api/serializers.py
+++ b/lms/djangoapps/badges/api/serializers.py
@@ -5,7 +5,7 @@ Serializers for Badges
 
 from rest_framework import serializers
 
-from badges.models import BadgeAssertion, BadgeClass
+from lms.djangoapps.badges.models import BadgeAssertion, BadgeClass
 
 
 class BadgeClassSerializer(serializers.ModelSerializer):

--- a/lms/djangoapps/badges/api/tests.py
+++ b/lms/djangoapps/badges/api/tests.py
@@ -9,7 +9,7 @@ from django.conf import settings
 from django.test.utils import override_settings
 from six.moves import range
 
-from badges.tests.factories import BadgeAssertionFactory, BadgeClassFactory, RandomBadgeClassFactory
+from lms.djangoapps.badges.tests.factories import BadgeAssertionFactory, BadgeClassFactory, RandomBadgeClassFactory
 from openedx.core.lib.api.test_utils import ApiTestCase
 from student.tests.factories import UserFactory
 from util.testing import UrlResetMixin

--- a/lms/djangoapps/badges/api/views.py
+++ b/lms/djangoapps/badges/api/views.py
@@ -10,7 +10,7 @@ from opaque_keys.edx.keys import CourseKey
 from rest_framework import generics
 from rest_framework.exceptions import APIException
 
-from badges.models import BadgeAssertion
+from lms.djangoapps.badges.models import BadgeAssertion
 from openedx.core.djangoapps.user_api.permissions import is_field_shared_factory
 from openedx.core.lib.api.authentication import BearerAuthenticationAllowInactiveUser
 

--- a/lms/djangoapps/badges/backends/badgr.py
+++ b/lms/djangoapps/badges/backends/badgr.py
@@ -15,8 +15,8 @@ from eventtracking import tracker
 from lazy import lazy
 from requests.packages.urllib3.exceptions import HTTPError
 
-from badges.backends.base import BadgeBackend
-from badges.models import BadgeAssertion
+from lms.djangoapps.badges.backends.base import BadgeBackend
+from lms.djangoapps.badges.models import BadgeAssertion
 
 MAX_SLUG_LENGTH = 255
 LOGGER = logging.getLogger(__name__)

--- a/lms/djangoapps/badges/backends/tests/test_badgr_backend.py
+++ b/lms/djangoapps/badges/backends/tests/test_badgr_backend.py
@@ -12,9 +12,9 @@ from django.test.utils import override_settings
 from lazy.lazy import lazy
 from mock import Mock, call, patch
 
-from badges.backends.badgr import BadgrBackend
-from badges.models import BadgeAssertion
-from badges.tests.factories import BadgeClassFactory
+from lms.djangoapps.badges.backends.badgr import BadgrBackend
+from lms.djangoapps.badges.models import BadgeAssertion
+from lms.djangoapps.badges.tests.factories import BadgeClassFactory
 from openedx.core.lib.tests.assertions.events import assert_event_matches
 from student.tests.factories import CourseEnrollmentFactory, UserFactory
 from track.tests import EventTrackingTestCase

--- a/lms/djangoapps/badges/events/course_complete.py
+++ b/lms/djangoapps/badges/events/course_complete.py
@@ -12,8 +12,8 @@ from django.urls import reverse
 from django.utils.text import slugify
 from django.utils.translation import ugettext_lazy as _
 
-from badges.models import BadgeAssertion, BadgeClass, CourseCompleteImageConfiguration
-from badges.utils import requires_badges_enabled, site_prefix
+from lms.djangoapps.badges.models import BadgeAssertion, BadgeClass, CourseCompleteImageConfiguration
+from lms.djangoapps.badges.utils import requires_badges_enabled, site_prefix
 from xmodule.modulestore.django import modulestore
 
 

--- a/lms/djangoapps/badges/events/course_meta.py
+++ b/lms/djangoapps/badges/events/course_meta.py
@@ -4,8 +4,8 @@ as enrolling in a certain number, completing a certain number, or completing a s
 """
 
 
-from badges.models import BadgeClass, CourseEventBadgesConfiguration
-from badges.utils import requires_badges_enabled
+from lms.djangoapps.badges.models import BadgeClass, CourseEventBadgesConfiguration
+from lms.djangoapps.badges.utils import requires_badges_enabled
 
 
 def award_badge(config, count, user):

--- a/lms/djangoapps/badges/events/tests/test_course_complete.py
+++ b/lms/djangoapps/badges/events/tests/test_course_complete.py
@@ -4,7 +4,7 @@ Tests for the course completion helper functions.
 from datetime import datetime
 from uuid import uuid4
 
-from badges.events import course_complete
+from lms.djangoapps.badges.events import course_complete
 from lms.djangoapps.certificates.models import GeneratedCertificate
 from student.tests.factories import UserFactory
 from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase

--- a/lms/djangoapps/badges/events/tests/test_course_meta.py
+++ b/lms/djangoapps/badges/events/tests/test_course_meta.py
@@ -10,7 +10,7 @@ from django.conf import settings
 from django.test.utils import override_settings
 from mock import patch
 
-from badges.tests.factories import CourseEventBadgesConfigurationFactory, RandomBadgeClassFactory
+from lms.djangoapps.badges.tests.factories import CourseEventBadgesConfigurationFactory, RandomBadgeClassFactory
 from lms.djangoapps.certificates.models import CertificateStatuses, GeneratedCertificate
 from student.models import CourseEnrollment
 from student.tests.factories import UserFactory

--- a/lms/djangoapps/badges/migrations/0001_initial.py
+++ b/lms/djangoapps/badges/migrations/0001_initial.py
@@ -8,7 +8,7 @@ from django.db import migrations, models
 from model_utils import fields
 from opaque_keys.edx.django.models import CourseKeyField
 
-import badges.models
+from lms.djangoapps.badges import models as badges_models
 
 
 class Migration(migrations.Migration):
@@ -34,14 +34,14 @@ class Migration(migrations.Migration):
             name='BadgeClass',
             fields=[
                 ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
-                ('slug', models.SlugField(max_length=255, validators=[badges.models.validate_lowercase])),
-                ('issuing_component', models.SlugField(default=u'', blank=True, validators=[badges.models.validate_lowercase])),
+                ('slug', models.SlugField(max_length=255, validators=[badges_models.validate_lowercase])),
+                ('issuing_component', models.SlugField(default=u'', blank=True, validators=[badges_models.validate_lowercase])),
                 ('display_name', models.CharField(max_length=255)),
                 ('course_id', CourseKeyField(default=None, max_length=255, blank=True)),
                 ('description', models.TextField()),
                 ('criteria', models.TextField()),
                 ('mode', models.CharField(default=u'', max_length=100, blank=True)),
-                ('image', models.ImageField(upload_to=u'badge_classes', validators=[badges.models.validate_badge_image])),
+                ('image', models.ImageField(upload_to=u'badge_classes', validators=[badges_models.validate_badge_image])),
             ],
         ),
         migrations.CreateModel(
@@ -49,7 +49,7 @@ class Migration(migrations.Migration):
             fields=[
                 ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
                 ('mode', models.CharField(help_text='The course mode for this badge image. For example, "verified" or "honor".', unique=True, max_length=125)),
-                ('icon', models.ImageField(help_text='Badge images must be square PNG files. The file size should be under 250KB.', upload_to=u'course_complete_badges', validators=[badges.models.validate_badge_image])),
+                ('icon', models.ImageField(help_text='Badge images must be square PNG files. The file size should be under 250KB.', upload_to=u'course_complete_badges', validators=[badges_models.validate_badge_image])),
                 ('default', models.BooleanField(default=False, help_text='Set this value to True if you want this image to be the default image for any course modes that do not have a specified badge image. You can have only one default image.')),
             ],
         ),

--- a/lms/djangoapps/badges/migrations/0002_data__migrate_assertions.py
+++ b/lms/djangoapps/badges/migrations/0002_data__migrate_assertions.py
@@ -16,7 +16,7 @@ def forwards(apps, schema_editor):
     """
     from django.core.files.base import ContentFile
     from xmodule.modulestore.django import modulestore
-    from badges.events import course_complete
+    from lms.djangoapps.badges.events import course_complete
     db_alias = schema_editor.connection.alias
     # This will need to be changed if badges/certificates get moved out of the default db for some reason.
     if db_alias != 'default':

--- a/lms/djangoapps/badges/models.py
+++ b/lms/djangoapps/badges/models.py
@@ -20,7 +20,7 @@ from opaque_keys import InvalidKeyError
 from opaque_keys.edx.django.models import CourseKeyField
 from opaque_keys.edx.keys import CourseKey
 
-from badges.utils import deserialize_count_specs
+from lms.djangoapps.badges.utils import deserialize_count_specs
 from openedx.core.djangolib.markup import HTML, Text
 from xmodule.modulestore.django import modulestore
 

--- a/lms/djangoapps/badges/service.py
+++ b/lms/djangoapps/badges/service.py
@@ -3,7 +3,7 @@ Badging service for XBlocks
 """
 
 
-from badges.models import BadgeClass
+from lms.djangoapps.badges.models import BadgeClass
 
 
 class BadgingService(object):

--- a/lms/djangoapps/badges/tests/factories.py
+++ b/lms/djangoapps/badges/tests/factories.py
@@ -10,7 +10,7 @@ from django.core.files.base import ContentFile
 from factory import DjangoModelFactory
 from factory.django import ImageField
 
-from badges.models import BadgeAssertion, BadgeClass, CourseCompleteImageConfiguration, CourseEventBadgesConfiguration
+from lms.djangoapps.badges.models import BadgeAssertion, BadgeClass, CourseCompleteImageConfiguration, CourseEventBadgesConfiguration
 from student.tests.factories import UserFactory
 
 

--- a/lms/djangoapps/badges/tests/test_models.py
+++ b/lms/djangoapps/badges/tests/test_models.py
@@ -13,14 +13,14 @@ from mock import Mock, patch
 from path import Path
 from six.moves import range
 
-from badges.models import (
+from lms.djangoapps.badges.models import (
     BadgeAssertion,
     BadgeClass,
     CourseBadgesDisabledError,
     CourseCompleteImageConfiguration,
     validate_badge_image
 )
-from badges.tests.factories import BadgeAssertionFactory, BadgeClassFactory, RandomBadgeClassFactory
+from lms.djangoapps.badges.tests.factories import BadgeAssertionFactory, BadgeClassFactory, RandomBadgeClassFactory
 from lms.djangoapps.certificates.tests.test_models import TEST_DATA_ROOT
 from student.tests.factories import UserFactory
 from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase

--- a/lms/djangoapps/branding/api.py
+++ b/lms/djangoapps/branding/api.py
@@ -23,7 +23,7 @@ from django.urls import reverse
 from django.utils.translation import ugettext as _
 from six.moves.urllib.parse import urljoin
 
-from branding.models import BrandingApiConfig
+from lms.djangoapps.branding.models import BrandingApiConfig
 from edxmako.shortcuts import marketing_link
 from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
 

--- a/lms/djangoapps/branding/api_urls.py
+++ b/lms/djangoapps/branding/api_urls.py
@@ -5,7 +5,7 @@ Branding API endpoint urls.
 
 from django.conf.urls import url
 
-from branding.views import footer
+from lms.djangoapps.branding.views import footer
 
 urlpatterns = [
     url(r"^footer$", footer, name="branding_footer"),

--- a/lms/djangoapps/branding/tests/test_api.py
+++ b/lms/djangoapps/branding/tests/test_api.py
@@ -31,7 +31,7 @@ class TestHeader(TestCase):
         # load, which can cause other tests to fail.  To ensure that this change
         # doesn't affect other tests, we patch the `url()` method directly instead.
         cdn_url = "http://cdn.example.com/static/image.png"
-        with mock.patch('branding.api.staticfiles_storage.url', return_value=cdn_url):
+        with mock.patch('lms.djangoapps.branding.api.staticfiles_storage.url', return_value=cdn_url):
             logo_url = get_logo_url()
 
         self.assertEqual(logo_url, cdn_url)

--- a/lms/djangoapps/branding/tests/test_models.py
+++ b/lms/djangoapps/branding/tests/test_models.py
@@ -6,7 +6,7 @@ Tests for the Video Branding configuration.
 from django.core.exceptions import ValidationError
 from django.test import TestCase
 
-from branding.models import BrandingInfoConfig
+from lms.djangoapps.branding.models import BrandingInfoConfig
 
 
 class BrandingInfoConfigTest(TestCase):

--- a/lms/djangoapps/branding/tests/test_page.py
+++ b/lms/djangoapps/branding/tests/test_page.py
@@ -16,7 +16,7 @@ from milestones.tests.utils import MilestonesTestCaseMixin
 from mock import Mock, patch
 from pytz import UTC
 
-from branding.views import index
+from lms.djangoapps.branding.views import index
 from lms.djangoapps.courseware.tests.helpers import LoginEnrollmentTestCase
 from edxmako.shortcuts import render_to_response
 from openedx.core.djangoapps.site_configuration.tests.mixins import SiteMixin

--- a/lms/djangoapps/branding/tests/test_views.py
+++ b/lms/djangoapps/branding/tests/test_views.py
@@ -12,7 +12,7 @@ from django.contrib.auth.models import User
 from django.test import TestCase
 from django.urls import reverse
 
-from branding.models import BrandingApiConfig
+from lms.djangoapps.branding.models import BrandingApiConfig
 from openedx.core.djangoapps.dark_lang.models import DarkLangConfig
 from openedx.core.djangoapps.lang_pref.api import released_languages
 from openedx.core.djangoapps.site_configuration.tests.mixins import SiteMixin
@@ -114,7 +114,7 @@ class TestFooter(CacheIsolationTestCase):
         # load, which can cause other tests to fail.  To ensure that this change
         # doesn't affect other tests, we patch the `url()` method directly instead.
         cdn_url = "http://cdn.example.com/static/image.png"
-        with mock.patch('branding.api.staticfiles_storage.url', return_value=cdn_url):
+        with mock.patch('lms.djangoapps.branding.api.staticfiles_storage.url', return_value=cdn_url):
             resp = self._get_footer()
 
         self.assertEqual(resp.status_code, 200)

--- a/lms/djangoapps/branding/views.py
+++ b/lms/djangoapps/branding/views.py
@@ -16,7 +16,7 @@ from django.utils.translation.trans_real import get_supported_language_variant
 from django.views.decorators.cache import cache_control
 from django.views.decorators.csrf import ensure_csrf_cookie
 
-import branding.api as branding_api
+import lms.djangoapps.branding.api as branding_api
 import lms.djangoapps.courseware.views.views as courseware_views
 import student.views
 from edxmako.shortcuts import marketing_link, render_to_response

--- a/lms/djangoapps/bulk_email/admin.py
+++ b/lms/djangoapps/bulk_email/admin.py
@@ -6,8 +6,8 @@ Django admin page for bulk email models
 from config_models.admin import ConfigurationModelAdmin
 from django.contrib import admin
 
-from bulk_email.forms import CourseAuthorizationAdminForm, CourseEmailTemplateForm
-from bulk_email.models import BulkEmailFlag, CourseAuthorization, CourseEmail, CourseEmailTemplate, Optout
+from lms.djangoapps.bulk_email.forms import CourseAuthorizationAdminForm, CourseEmailTemplateForm
+from lms.djangoapps.bulk_email.models import BulkEmailFlag, CourseAuthorization, CourseEmail, CourseEmailTemplate, Optout
 
 
 class CourseEmailAdmin(admin.ModelAdmin):

--- a/lms/djangoapps/bulk_email/api.py
+++ b/lms/djangoapps/bulk_email/api.py
@@ -9,7 +9,7 @@ Python APIs exposed by the bulk_email app to other in-process apps.
 from django.conf import settings
 from django.urls import reverse
 
-from bulk_email.models_api import (
+from lms.djangoapps.bulk_email.models_api import (
     is_bulk_email_enabled_for_course,
     is_bulk_email_feature_enabled,
     is_user_opted_out_for_course

--- a/lms/djangoapps/bulk_email/forms.py
+++ b/lms/djangoapps/bulk_email/forms.py
@@ -8,7 +8,7 @@ import logging
 from django import forms
 from django.core.exceptions import ValidationError
 
-from bulk_email.models import COURSE_EMAIL_MESSAGE_BODY_TAG, CourseAuthorization, CourseEmailTemplate
+from lms.djangoapps.bulk_email.models import COURSE_EMAIL_MESSAGE_BODY_TAG, CourseAuthorization, CourseEmailTemplate
 from openedx.core.lib.courses import clean_course_id
 
 log = logging.getLogger(__name__)

--- a/lms/djangoapps/bulk_email/migrations/0005_move_target_data.py
+++ b/lms/djangoapps/bulk_email/migrations/0005_move_target_data.py
@@ -4,7 +4,7 @@
 from django.db import migrations, models
 from django.db.utils import DatabaseError
 
-from bulk_email.models import EMAIL_TARGETS, SEND_TO_MYSELF
+from lms.djangoapps.bulk_email.models import EMAIL_TARGETS, SEND_TO_MYSELF
 
 
 def to_option_to_targets(apps, schema_editor):

--- a/lms/djangoapps/bulk_email/models_api.py
+++ b/lms/djangoapps/bulk_email/models_api.py
@@ -3,7 +3,7 @@ Provides Python APIs exposed from Bulk Email models.
 """
 
 
-from bulk_email.models import BulkEmailFlag, CourseAuthorization, Optout
+from lms.djangoapps.bulk_email.models import BulkEmailFlag, CourseAuthorization, Optout
 
 
 def is_user_opted_out_for_course(user, course_id):

--- a/lms/djangoapps/bulk_email/policies.py
+++ b/lms/djangoapps/bulk_email/policies.py
@@ -5,7 +5,7 @@ from edx_ace.channel import ChannelType
 from edx_ace.policy import Policy, PolicyResult
 from opaque_keys.edx.keys import CourseKey
 
-from bulk_email.models import Optout
+from lms.djangoapps.bulk_email.models import Optout
 
 
 class CourseEmailOptout(Policy):

--- a/lms/djangoapps/bulk_email/tasks.py
+++ b/lms/djangoapps/bulk_email/tasks.py
@@ -40,8 +40,8 @@ from django.utils.translation import ugettext as _
 from markupsafe import escape
 from six import text_type
 
-from bulk_email.models import CourseEmail, Optout
-from bulk_email.api import get_unsubscribed_link
+from lms.djangoapps.bulk_email.models import CourseEmail, Optout
+from lms.djangoapps.bulk_email.api import get_unsubscribed_link
 from lms.djangoapps.courseware.courses import get_course
 from lms.djangoapps.instructor_task.models import InstructorTask
 from lms.djangoapps.instructor_task.subtasks import (

--- a/lms/djangoapps/bulk_email/tests/test_course_optout.py
+++ b/lms/djangoapps/bulk_email/tests/test_course_optout.py
@@ -16,8 +16,8 @@ from edx_ace.recipient import Recipient
 from mock import Mock, patch
 from six import text_type
 
-from bulk_email.models import BulkEmailFlag
-from bulk_email.policies import CourseEmailOptout
+from lms.djangoapps.bulk_email.models import BulkEmailFlag
+from lms.djangoapps.bulk_email.policies import CourseEmailOptout
 from student.models import CourseEnrollment
 from student.tests.factories import AdminFactory, CourseEnrollmentFactory, UserFactory
 from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase

--- a/lms/djangoapps/bulk_email/tests/test_forms.py
+++ b/lms/djangoapps/bulk_email/tests/test_forms.py
@@ -7,9 +7,9 @@ Unit tests for bulk-email-related forms.
 from opaque_keys.edx.locator import CourseLocator
 from six import text_type
 
-from bulk_email.api import is_bulk_email_feature_enabled
-from bulk_email.forms import CourseAuthorizationAdminForm, CourseEmailTemplateForm
-from bulk_email.models import BulkEmailFlag, CourseEmailTemplate
+from lms.djangoapps.bulk_email.api import is_bulk_email_feature_enabled
+from lms.djangoapps.bulk_email.forms import CourseAuthorizationAdminForm, CourseEmailTemplateForm
+from lms.djangoapps.bulk_email.models import BulkEmailFlag, CourseEmailTemplate
 from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
 from xmodule.modulestore.tests.factories import CourseFactory
 

--- a/lms/djangoapps/bulk_email/tests/test_models.py
+++ b/lms/djangoapps/bulk_email/tests/test_models.py
@@ -12,8 +12,8 @@ from mock import Mock, patch
 from opaque_keys.edx.keys import CourseKey
 from pytz import UTC
 
-from bulk_email.api import is_bulk_email_feature_enabled
-from bulk_email.models import (
+from lms.djangoapps.bulk_email.api import is_bulk_email_feature_enabled
+from lms.djangoapps.bulk_email.models import (
     SEND_TO_COHORT,
     SEND_TO_STAFF,
     SEND_TO_TRACK,

--- a/lms/djangoapps/bulk_email/tests/test_signals.py
+++ b/lms/djangoapps/bulk_email/tests/test_signals.py
@@ -11,8 +11,8 @@ from django.urls import reverse
 from mock import Mock, patch
 from six import text_type
 
-from bulk_email.models import BulkEmailFlag, Optout
-from bulk_email.signals import force_optout_all
+from lms.djangoapps.bulk_email.models import BulkEmailFlag, Optout
+from lms.djangoapps.bulk_email.signals import force_optout_all
 from student.tests.factories import AdminFactory, CourseEnrollmentFactory, UserFactory
 from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
 from xmodule.modulestore.tests.factories import CourseFactory

--- a/lms/djangoapps/bulk_email/tests/test_views.py
+++ b/lms/djangoapps/bulk_email/tests/test_views.py
@@ -9,8 +9,8 @@ from django.test.client import RequestFactory
 from django.test.utils import override_settings
 from django.urls import reverse
 
-from bulk_email.models import Optout
-from bulk_email.views import opt_out_email_updates
+from lms.djangoapps.bulk_email.models import Optout
+from lms.djangoapps.bulk_email.views import opt_out_email_updates
 from six import text_type
 
 from lms.djangoapps.discussion.notification_prefs.views import UsernameCipher

--- a/lms/djangoapps/bulk_email/views.py
+++ b/lms/djangoapps/bulk_email/views.py
@@ -10,7 +10,7 @@ from six import text_type
 from django.contrib.auth.models import User
 from django.http import Http404
 
-from bulk_email.models import Optout
+from lms.djangoapps.bulk_email.models import Optout
 from lms.djangoapps.courseware.courses import get_course_by_id
 from edxmako.shortcuts import render_to_response
 from lms.djangoapps.discussion.notification_prefs.views import (

--- a/lms/djangoapps/bulk_enroll/tests/test_views.py
+++ b/lms/djangoapps/bulk_enroll/tests/test_views.py
@@ -15,8 +15,8 @@ from django.urls import reverse
 from opaque_keys.edx.keys import CourseKey
 from rest_framework.test import APIRequestFactory, APITestCase, force_authenticate
 
-from bulk_enroll.serializers import BulkEnrollmentSerializer
-from bulk_enroll.views import BulkEnrollView
+from lms.djangoapps.bulk_enroll.serializers import BulkEnrollmentSerializer
+from lms.djangoapps.bulk_enroll.views import BulkEnrollView
 from lms.djangoapps.courseware.tests.helpers import LoginEnrollmentTestCase
 from openedx.core.djangoapps.course_groups.cohorts import get_cohort_id
 from openedx.core.djangoapps.course_groups.tests.helpers import config_course_cohorts

--- a/lms/djangoapps/bulk_enroll/views.py
+++ b/lms/djangoapps/bulk_enroll/views.py
@@ -13,7 +13,7 @@ from rest_framework.response import Response
 from rest_framework.views import APIView
 from six.moves import zip_longest
 
-from bulk_enroll.serializers import BulkEnrollmentSerializer
+from lms.djangoapps.bulk_enroll.serializers import BulkEnrollmentSerializer
 from lms.djangoapps.instructor.views.api import students_update_enrollment
 from openedx.core.djangoapps.course_groups.cohorts import add_user_to_cohort, get_cohort_by_name
 from openedx.core.djangoapps.course_groups.models import CourseUserGroup

--- a/lms/djangoapps/ccx/tests/test_field_override_performance.py
+++ b/lms/djangoapps/ccx/tests/test_field_override_performance.py
@@ -213,7 +213,7 @@ class FieldOverridePerformanceTestCase(FieldOverrideTestMixin, ProceduralCourseT
 
         providers = {
             'no_overrides': (),
-            'ccx': ('ccx.overrides.CustomCoursesForEdxOverrideProvider',)
+            'ccx': ('lms.djangoapps.ccx.overrides.CustomCoursesForEdxOverrideProvider',)
         }
         if overrides == 'no_overrides' and view_as_ccx:
             pytest.skip("Can't view a ccx course if field overrides are disabled.")

--- a/lms/djangoapps/ccx/tests/test_overrides.py
+++ b/lms/djangoapps/ccx/tests/test_overrides.py
@@ -27,7 +27,7 @@ from xmodule.modulestore.tests.factories import CourseFactory, ItemFactory
 
 @override_settings(
     XBLOCK_FIELD_DATA_WRAPPERS=['lms.djangoapps.courseware.field_overrides:OverrideModulestoreFieldData.wrap'],
-    MODULESTORE_FIELD_OVERRIDE_PROVIDERS=['ccx.overrides.CustomCoursesForEdxOverrideProvider'],
+    MODULESTORE_FIELD_OVERRIDE_PROVIDERS=['lms.djangoapps.ccx.overrides.CustomCoursesForEdxOverrideProvider'],
 )
 class TestFieldOverrides(FieldOverrideTestMixin, SharedModuleStoreTestCase):
     """
@@ -71,7 +71,7 @@ class TestFieldOverrides(FieldOverrideTestMixin, SharedModuleStoreTestCase):
             coach=AdminFactory.create())
         ccx.save()
 
-        patch = mock.patch('ccx.overrides.get_current_ccx')
+        patch = mock.patch('lms.djangoapps.ccx.overrides.get_current_ccx')
         self.get_ccx = get_ccx = patch.start()
         get_ccx.return_value = ccx
         self.addCleanup(patch.stop)

--- a/lms/djangoapps/ccx/tests/test_views.py
+++ b/lms/djangoapps/ccx/tests/test_views.py
@@ -171,7 +171,7 @@ class TestAdminAccessCoachDashboard(CcxTestCase, LoginEnrollmentTestCase):
 
 @override_settings(
     XBLOCK_FIELD_DATA_WRAPPERS=['lms.djangoapps.courseware.field_overrides:OverrideModulestoreFieldData.wrap'],
-    MODULESTORE_FIELD_OVERRIDE_PROVIDERS=['ccx.overrides.CustomCoursesForEdxOverrideProvider'],
+    MODULESTORE_FIELD_OVERRIDE_PROVIDERS=['lms.djangoapps.ccx.overrides.CustomCoursesForEdxOverrideProvider'],
 )
 class TestCCXProgressChanges(CcxTestCase, LoginEnrollmentTestCase):
     """
@@ -236,7 +236,7 @@ class TestCCXProgressChanges(CcxTestCase, LoginEnrollmentTestCase):
         progress_page_due_date = section.due.strftime(u"%Y-%m-%d %H:%M")
         self.assertEqual(progress_page_due_date, due)
 
-    @patch('ccx.views.render_to_response', intercept_renderer)
+    @patch('lms.djangoapps.ccx.views.render_to_response', intercept_renderer)
     @patch('lms.djangoapps.courseware.views.views.render_to_response', intercept_renderer)
     @patch.dict('django.conf.settings.FEATURES', {'CUSTOM_COURSES_EDX': True})
     def test_edit_schedule(self):
@@ -285,7 +285,7 @@ class TestCCXProgressChanges(CcxTestCase, LoginEnrollmentTestCase):
 
 @override_settings(
     XBLOCK_FIELD_DATA_WRAPPERS=['lms.djangoapps.courseware.field_overrides:OverrideModulestoreFieldData.wrap'],
-    MODULESTORE_FIELD_OVERRIDE_PROVIDERS=['ccx.overrides.CustomCoursesForEdxOverrideProvider'],
+    MODULESTORE_FIELD_OVERRIDE_PROVIDERS=['lms.djangoapps.ccx.overrides.CustomCoursesForEdxOverrideProvider'],
 )
 @ddt.ddt
 class TestCoachDashboard(CcxTestCase, LoginEnrollmentTestCase):
@@ -471,8 +471,8 @@ class TestCoachDashboard(CcxTestCase, LoginEnrollmentTestCase):
                     self.assertEqual(get_date(ccx, unit, 'start', parent_node=subsection), self.mooc_start)
                     self.assertEqual(get_date(ccx, unit, 'due', parent_node=subsection), self.mooc_due)
 
-    @patch('ccx.views.render_to_response', intercept_renderer)
-    @patch('ccx.views.TODAY')
+    @patch('lms.djangoapps.ccx.views.render_to_response', intercept_renderer)
+    @patch('lms.djangoapps.ccx.views.TODAY')
     def test_edit_schedule(self, today):
         """
         Get CCX schedule, modify it, save it.
@@ -550,7 +550,7 @@ class TestCoachDashboard(CcxTestCase, LoginEnrollmentTestCase):
         self.assertEqual(policy['GRADER'][3]['type'], 'Final Exam')
         self.assertEqual(policy['GRADER'][3]['min_count'], 0)
 
-    @patch('ccx.views.render_to_response', intercept_renderer)
+    @patch('lms.djangoapps.ccx.views.render_to_response', intercept_renderer)
     def test_save_without_min_count(self):
         """
         POST grading policy without min_count field.
@@ -929,8 +929,8 @@ class TestCoachDashboardSchedule(CcxTestCase, LoginEnrollmentTestCase, ModuleSto
         node.visible_to_staff_only = True
         self.mstore.update_item(node, self.coach.id)
 
-    @patch('ccx.views.render_to_response', intercept_renderer)
-    @patch('ccx.views.TODAY')
+    @patch('lms.djangoapps.ccx.views.render_to_response', intercept_renderer)
+    @patch('lms.djangoapps.ccx.views.TODAY')
     def test_get_ccx_schedule(self, today):
         """
         Gets CCX schedule and checks number of blocks in it.
@@ -982,7 +982,7 @@ def patched_get_children(self, usage_key_filter=None):
 
 @override_settings(
     XBLOCK_FIELD_DATA_WRAPPERS=['lms.djangoapps.courseware.field_overrides:OverrideModulestoreFieldData.wrap'],
-    MODULESTORE_FIELD_OVERRIDE_PROVIDERS=['ccx.overrides.CustomCoursesForEdxOverrideProvider'],
+    MODULESTORE_FIELD_OVERRIDE_PROVIDERS=['lms.djangoapps.ccx.overrides.CustomCoursesForEdxOverrideProvider'],
 )
 @patch('xmodule.x_module.XModuleMixin.get_children', patched_get_children, spec=True)
 class TestCCXGrades(FieldOverrideTestMixin, SharedModuleStoreTestCase, LoginEnrollmentTestCase):
@@ -1069,7 +1069,7 @@ class TestCCXGrades(FieldOverrideTestMixin, SharedModuleStoreTestCase, LoginEnro
             course_key=self.ccx_key
         )
 
-    @patch('ccx.views.render_to_response', intercept_renderer)
+    @patch('lms.djangoapps.ccx.views.render_to_response', intercept_renderer)
     @patch('lms.djangoapps.instructor.views.gradebook_api.MAX_STUDENTS_PER_PAGE_GRADE_BOOK', 1)
     def test_gradebook(self):
         self.course.enable_ccx = True

--- a/lms/djangoapps/certificates/api.py
+++ b/lms/djangoapps/certificates/api.py
@@ -16,7 +16,7 @@ from eventtracking import tracker
 from opaque_keys.edx.django.models import CourseKeyField
 from opaque_keys.edx.keys import CourseKey
 
-from branding import api as branding_api
+from lms.djangoapps.branding import api as branding_api
 from lms.djangoapps.certificates.models import (
     CertificateGenerationConfiguration,
     CertificateGenerationCourseSetting,

--- a/lms/djangoapps/certificates/management/commands/regenerate_user.py
+++ b/lms/djangoapps/certificates/management/commands/regenerate_user.py
@@ -9,8 +9,8 @@ from django.core.management.base import BaseCommand
 from opaque_keys.edx.keys import CourseKey
 from six import text_type
 
-from badges.events.course_complete import get_completion_badge
-from badges.utils import badges_enabled
+from lms.djangoapps.badges.events.course_complete import get_completion_badge
+from lms.djangoapps.badges.utils import badges_enabled
 from lms.djangoapps.certificates.api import regenerate_user_certificates
 from xmodule.modulestore.django import modulestore
 

--- a/lms/djangoapps/certificates/migrations/0001_initial.py
+++ b/lms/djangoapps/certificates/migrations/0001_initial.py
@@ -9,7 +9,7 @@ from django.conf import settings
 from django.db import migrations, models
 from opaque_keys.edx.django.models import CourseKeyField
 
-from badges.models import validate_badge_image
+from lms.djangoapps.badges.models import validate_badge_image
 from lms.djangoapps.certificates import models as cert_models
 
 

--- a/lms/djangoapps/certificates/models.py
+++ b/lms/djangoapps/certificates/models.py
@@ -69,8 +69,8 @@ from model_utils.models import TimeStampedModel
 from opaque_keys.edx.django.models import CourseKeyField
 from simple_history.models import HistoricalRecords
 
-from badges.events.course_complete import course_badge_check
-from badges.events.course_meta import completion_check, course_group_check
+from lms.djangoapps.badges.events.course_complete import course_badge_check
+from lms.djangoapps.badges.events.course_meta import completion_check, course_group_check
 from course_modes.models import CourseMode
 from lms.djangoapps.instructor_task.models import InstructorTask
 from openedx.core.djangoapps.content.course_overviews.models import CourseOverview

--- a/lms/djangoapps/certificates/tests/test_cert_management.py
+++ b/lms/djangoapps/certificates/tests/test_cert_management.py
@@ -10,9 +10,9 @@ from opaque_keys.edx.locator import CourseLocator
 from six import text_type
 from six.moves import range
 
-from badges.events.course_complete import get_completion_badge
-from badges.models import BadgeAssertion
-from badges.tests.factories import BadgeAssertionFactory, CourseCompleteImageConfigurationFactory
+from lms.djangoapps.badges.events.course_complete import get_completion_badge
+from lms.djangoapps.badges.models import BadgeAssertion
+from lms.djangoapps.badges.tests.factories import BadgeAssertionFactory, CourseCompleteImageConfigurationFactory
 from course_modes.models import CourseMode
 from lms.djangoapps.certificates.models import CertificateStatuses, GeneratedCertificate
 from lms.djangoapps.grades.tests.utils import mock_passing_grade

--- a/lms/djangoapps/certificates/tests/tests.py
+++ b/lms/djangoapps/certificates/tests/tests.py
@@ -12,7 +12,7 @@ from milestones.tests.utils import MilestonesTestCaseMixin
 from mock import patch
 from pytz import UTC
 
-from badges.tests.factories import CourseCompleteImageConfigurationFactory
+from lms.djangoapps.badges.tests.factories import CourseCompleteImageConfigurationFactory
 from lms.djangoapps.certificates.models import (
     CertificateStatuses,
     GeneratedCertificate,
@@ -215,7 +215,7 @@ class CertificatesModelTest(ModuleStoreTestCase, MilestonesTestCaseMixin):
         self.assertEqual(completed_milestones[0]['namespace'], six.text_type(pre_requisite_course.id))
 
     @patch.dict(settings.FEATURES, {'ENABLE_OPENBADGES': True})
-    @patch('badges.backends.badgr.BadgrBackend', spec=True)
+    @patch('lms.djangoapps.badges.backends.badgr.BadgrBackend', spec=True)
     def test_badge_callback(self, handler):
         student = UserFactory()
         course = CourseFactory.create(org='edx', number='998', display_name='Test Course', issue_badges=True)

--- a/lms/djangoapps/certificates/views/webview.py
+++ b/lms/djangoapps/certificates/views/webview.py
@@ -21,8 +21,8 @@ from eventtracking import tracker
 from opaque_keys import InvalidKeyError
 from opaque_keys.edx.keys import CourseKey
 
-from badges.events.course_complete import get_completion_badge
-from badges.utils import badges_enabled
+from lms.djangoapps.badges.events.course_complete import get_completion_badge
+from lms.djangoapps.badges.utils import badges_enabled
 from edxmako.shortcuts import render_to_response
 from edxmako.template import Template
 from lms.djangoapps.certificates.api import (

--- a/lms/djangoapps/course_api/blocks/tests/test_views.py
+++ b/lms/djangoapps/course_api/blocks/tests/test_views.py
@@ -181,7 +181,7 @@ class TestBlocksView(SharedModuleStoreTestCase):
         self.query_params['username'] = ''
         self.verify_response(403)
 
-    @mock.patch("course_api.blocks.forms.permissions.is_course_public", Mock(return_value=True))
+    @mock.patch("lms.djangoapps.course_api.blocks.forms.permissions.is_course_public", Mock(return_value=True))
     def test_not_authenticated_public_course_with_other_username(self):
         """
         Verify behaviour when accessing course blocks of a public course for another user anonymously.
@@ -189,7 +189,7 @@ class TestBlocksView(SharedModuleStoreTestCase):
         self.client.logout()
         self.verify_response(403)
 
-    @mock.patch("course_api.blocks.forms.permissions.is_course_public", Mock(return_value=True))
+    @mock.patch("lms.djangoapps.course_api.blocks.forms.permissions.is_course_public", Mock(return_value=True))
     def test_not_authenticated_public_course_with_all_blocks(self):
         """
         Verify behaviour when accessing all course blocks of a public course anonymously.
@@ -199,7 +199,7 @@ class TestBlocksView(SharedModuleStoreTestCase):
         self.query_params['all_blocks'] = True
         self.verify_response(403)
 
-    @mock.patch("course_api.blocks.forms.permissions.is_course_public", Mock(return_value=True))
+    @mock.patch("lms.djangoapps.course_api.blocks.forms.permissions.is_course_public", Mock(return_value=True))
     def test_not_authenticated_public_course_with_blank_username(self):
         """
         Verify behaviour when accessing course blocks of a public course for anonymous user anonymously.
@@ -215,7 +215,7 @@ class TestBlocksView(SharedModuleStoreTestCase):
         CourseEnrollment.unenroll(self.user, self.course_key)
         self.verify_response(403)
 
-    @mock.patch("course_api.blocks.forms.permissions.is_course_public", Mock(return_value=True))
+    @mock.patch("lms.djangoapps.course_api.blocks.forms.permissions.is_course_public", Mock(return_value=True))
     def test_not_enrolled_public_course(self):
         """
         Verify behaviour when accessing course blocks for a public course as a user not enrolled in course.
@@ -224,7 +224,7 @@ class TestBlocksView(SharedModuleStoreTestCase):
         CourseEnrollment.unenroll(self.user, self.course_key)
         self.verify_response(cacheable=True)
 
-    @mock.patch("course_api.blocks.forms.permissions.is_course_public", Mock(return_value=True))
+    @mock.patch("lms.djangoapps.course_api.blocks.forms.permissions.is_course_public", Mock(return_value=True))
     def test_public_course_all_blocks_and_empty_username(self):
         """
         Verify behaviour when specifying both all_blocks and username='', and ensure the response is not cached.

--- a/lms/djangoapps/course_api/blocks/transformers/tests/test_milestones.py
+++ b/lms/djangoapps/course_api/blocks/transformers/tests/test_milestones.py
@@ -8,7 +8,7 @@ import six
 from milestones.tests.utils import MilestonesTestCaseMixin
 from mock import Mock, patch
 
-from gating import api as lms_gating_api
+from lms.djangoapps.gating import api as lms_gating_api
 from lms.djangoapps.course_blocks.api import get_course_blocks
 from lms.djangoapps.course_blocks.transformers.tests.helpers import CourseStructureTestCase
 from openedx.core.djangoapps.content.block_structure.transformers import BlockStructureTransformers

--- a/lms/djangoapps/course_api/urls.py
+++ b/lms/djangoapps/course_api/urls.py
@@ -12,5 +12,5 @@ urlpatterns = [
     url(r'^v1/courses/$', CourseListView.as_view(), name="course-list"),
     url(r'^v1/courses/{}'.format(settings.COURSE_KEY_PATTERN), CourseDetailView.as_view(), name="course-detail"),
     url(r'^v1/course_ids/$', CourseIdListView.as_view(), name="course-id-list"),
-    url(r'', include('course_api.blocks.urls'))
+    url(r'', include('lms.djangoapps.course_api.blocks.urls'))
 ]

--- a/lms/djangoapps/course_wiki/plugins/markdownedx/__init__.py
+++ b/lms/djangoapps/course_wiki/plugins/markdownedx/__init__.py
@@ -1,4 +1,4 @@
 # Make sure wiki_plugin.py gets run.
 
 
-from course_wiki.plugins.markdownedx.wiki_plugin import ExtendMarkdownPlugin
+from lms.djangoapps.course_wiki.plugins.markdownedx.wiki_plugin import ExtendMarkdownPlugin

--- a/lms/djangoapps/course_wiki/plugins/markdownedx/wiki_plugin.py
+++ b/lms/djangoapps/course_wiki/plugins/markdownedx/wiki_plugin.py
@@ -4,7 +4,7 @@
 from wiki.core.plugins import registry as plugin_registry
 from wiki.core.plugins.base import BasePlugin
 
-from course_wiki.plugins.markdownedx import mdx_mathjax, mdx_video
+from lms.djangoapps.course_wiki.plugins.markdownedx import mdx_mathjax, mdx_video
 
 
 class ExtendMarkdownPlugin(BasePlugin):

--- a/lms/djangoapps/course_wiki/settings.py
+++ b/lms/djangoapps/course_wiki/settings.py
@@ -4,7 +4,7 @@ a user has on an article.
 """
 
 
-from course_wiki.utils import user_is_article_course_staff
+from lms.djangoapps.course_wiki.utils import user_is_article_course_staff
 
 
 def CAN_DELETE(article, user):  # pylint: disable=invalid-name

--- a/lms/djangoapps/course_wiki/tests/test_access.py
+++ b/lms/djangoapps/course_wiki/tests/test_access.py
@@ -6,9 +6,9 @@ Tests for wiki permissions
 from django.contrib.auth.models import Group
 from wiki.models import URLPath
 
-from course_wiki import settings
-from course_wiki.utils import course_wiki_slug, user_is_article_course_staff
-from course_wiki.views import get_or_create_root
+from lms.djangoapps.course_wiki import settings
+from lms.djangoapps.course_wiki.utils import course_wiki_slug, user_is_article_course_staff
+from lms.djangoapps.course_wiki.views import get_or_create_root
 from lms.djangoapps.courseware.tests.factories import InstructorFactory, StaffFactory
 from student.tests.factories import UserFactory
 from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase

--- a/lms/djangoapps/course_wiki/tests/test_comprehensive_theming.py
+++ b/lms/djangoapps/course_wiki/tests/test_comprehensive_theming.py
@@ -8,7 +8,7 @@ from unittest import skip
 from django.test.client import Client
 from wiki.models import URLPath
 
-from course_wiki.views import get_or_create_root
+from lms.djangoapps.course_wiki.views import get_or_create_root
 from lms.djangoapps.courseware.tests.factories import InstructorFactory
 from openedx.core.djangoapps.theming.tests.test_util import with_comprehensive_theme
 from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase

--- a/lms/djangoapps/course_wiki/tests/test_middleware.py
+++ b/lms/djangoapps/course_wiki/tests/test_middleware.py
@@ -6,7 +6,7 @@ Tests for wiki middleware.
 from django.test.client import Client
 from wiki.models import URLPath
 
-from course_wiki.views import get_or_create_root
+from lms.djangoapps.course_wiki.views import get_or_create_root
 from lms.djangoapps.courseware.tests.factories import InstructorFactory
 from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
 from xmodule.modulestore.tests.factories import CourseFactory

--- a/lms/djangoapps/course_wiki/views.py
+++ b/lms/djangoapps/course_wiki/views.py
@@ -13,7 +13,7 @@ from opaque_keys.edx.keys import CourseKey
 from wiki.core.exceptions import NoRootURL
 from wiki.models import Article, URLPath
 
-from course_wiki.utils import course_wiki_slug
+from lms.djangoapps.course_wiki.utils import course_wiki_slug
 from lms.djangoapps.courseware.courses import get_course_by_id
 from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
 from openedx.core.djangolib.markup import Text

--- a/lms/djangoapps/courseware/access.py
+++ b/lms/djangoapps/courseware/access.py
@@ -43,7 +43,7 @@ from lms.djangoapps.courseware.access_utils import (
 from lms.djangoapps.courseware.masquerade import get_masquerade_role, is_masquerading_as_student
 from lms.djangoapps.ccx.custom_exception import CCXLocatorValidationException
 from lms.djangoapps.ccx.models import CustomCourseForEdX
-from mobile_api.models import IgnoreMobileAvailableFlagConfig
+from lms.djangoapps.mobile_api.models import IgnoreMobileAvailableFlagConfig
 from openedx.core.djangoapps.content.course_overviews.models import CourseOverview
 from openedx.features.course_duration_limits.access import check_course_expired
 from student import auth

--- a/lms/djangoapps/courseware/courses.py
+++ b/lms/djangoapps/courseware/courses.py
@@ -60,7 +60,7 @@ from openedx.features.course_duration_limits.access import AuditExpiredError
 from openedx.features.course_experience import RELATIVE_DATES_FLAG
 from openedx.features.course_experience.utils import is_block_structure_complete_for_assignments
 from static_replace import replace_static_urls
-from survey.utils import SurveyRequiredAccessError, check_survey_required_and_unanswered
+from lms.djangoapps.survey.utils import SurveyRequiredAccessError, check_survey_required_and_unanswered
 from util.date_utils import strftime_localized
 from xmodule.modulestore.django import modulestore
 from xmodule.modulestore.exceptions import ItemNotFoundError

--- a/lms/djangoapps/courseware/courses.py
+++ b/lms/djangoapps/courseware/courses.py
@@ -23,7 +23,7 @@ from six import text_type
 
 from openedx.core.lib.cache_utils import request_cached
 
-import branding
+from lms.djangoapps import branding
 from lms.djangoapps.courseware.access import has_access
 from lms.djangoapps.courseware.access_response import (
     AuthenticationRequiredAccessError,

--- a/lms/djangoapps/courseware/tests/test_course_survey.py
+++ b/lms/djangoapps/courseware/tests/test_course_survey.py
@@ -13,7 +13,7 @@ from six.moves import range
 
 from common.test.utils import XssTestMixin
 from lms.djangoapps.courseware.tests.helpers import LoginEnrollmentTestCase
-from survey.models import SurveyAnswer, SurveyForm
+from lms.djangoapps.survey.models import SurveyAnswer, SurveyForm
 from xmodule.modulestore.tests.django_utils import SharedModuleStoreTestCase
 from xmodule.modulestore.tests.factories import CourseFactory
 

--- a/lms/djangoapps/courseware/tests/test_discussion_xblock.py
+++ b/lms/djangoapps/courseware/tests/test_discussion_xblock.py
@@ -18,7 +18,7 @@ from six.moves import range
 from web_fragments.fragment import Fragment
 from xblock.field_data import DictFieldData
 
-from course_api.blocks.tests.helpers import deserialize_usage_key
+from lms.djangoapps.course_api.blocks.tests.helpers import deserialize_usage_key
 from lms.djangoapps.courseware.module_render import get_module_for_descriptor_internal
 from lms.djangoapps.courseware.tests.helpers import XModuleRenderingTestBase
 from student.tests.factories import CourseEnrollmentFactory, UserFactory

--- a/lms/djangoapps/courseware/tests/test_field_overrides.py
+++ b/lms/djangoapps/courseware/tests/test_field_overrides.py
@@ -59,7 +59,7 @@ class OverrideFieldBase(SharedModuleStoreTestCase):
 
 
 @override_settings(FIELD_OVERRIDE_PROVIDERS=(
-    'courseware.tests.test_field_overrides.TestOverrideProvider',))
+    'lms.djangoapps.courseware.tests.test_field_overrides.TestOverrideProvider',))
 class OverrideFieldDataTests(OverrideFieldBase):
     """
     Tests for `OverrideFieldData`.
@@ -152,7 +152,7 @@ class ResolveDottedTests(unittest.TestCase):
 
     def test_bad_sub_import(self):
         with self.assertRaises(ImportError):
-            resolve_dotted('courseware.tests.test_foo')
+            resolve_dotted('lms.djangoapps.courseware.tests.test_foo')
 
     def test_bad_import(self):
         with self.assertRaises(ImportError):
@@ -160,7 +160,7 @@ class ResolveDottedTests(unittest.TestCase):
 
     def test_import_something_that_isnt_already_loaded(self):
         self.assertEqual(
-            resolve_dotted('courseware.tests.animport.SOMENAME'),
+            resolve_dotted('lms.djangoapps.courseware.tests.animport.SOMENAME'),
             'bar'
         )
 

--- a/lms/djangoapps/courseware/tests/test_module_render.py
+++ b/lms/djangoapps/courseware/tests/test_module_render.py
@@ -39,8 +39,6 @@ from opaque_keys.edx.keys import CourseKey, UsageKey
 from pyquery import PyQuery
 from six import text_type
 from six.moves import range
-from student.models import CourseEnrollment, anonymous_id_for_user
-from verify_student.tests.factories import SoftwareSecurePhotoVerificationFactory
 from web_fragments.fragment import Fragment
 from xblock.completable import CompletableXBlockMixin
 from xblock.core import XBlock, XBlockAside
@@ -48,21 +46,6 @@ from xblock.field_data import FieldData
 from xblock.fields import ScopeIds
 from xblock.runtime import DictKeyValueStore, KvsFieldData, Runtime
 from xblock.test.tools import TestRuntime
-from xblock_django.models import XBlockConfiguration
-from xmodule.capa_module import ProblemBlock
-from xmodule.html_module import AboutBlock, CourseInfoBlock, HtmlBlock, StaticTabBlock
-from xmodule.lti_module import LTIDescriptor
-from xmodule.modulestore import ModuleStoreEnum
-from xmodule.modulestore.django import modulestore
-from xmodule.modulestore.tests.django_utils import (
-    TEST_DATA_MIXED_MODULESTORE,
-    ModuleStoreTestCase,
-    SharedModuleStoreTestCase
-)
-from xmodule.modulestore.tests.factories import CourseFactory, ItemFactory, ToyCourseFactory, check_mongo_calls
-from xmodule.modulestore.tests.test_asides import AsideTestType
-from xmodule.video_module import VideoBlock
-from xmodule.x_module import STUDENT_VIEW, CombinedSystem, XModule, XModuleDescriptor
 
 from lms.djangoapps.courseware import module_render as render
 from lms.djangoapps.courseware.access_response import AccessResponse
@@ -88,6 +71,24 @@ from openedx.core.djangoapps.oauth_dispatch.tests.factories import AccessTokenFa
 from openedx.core.lib.courses import course_image_url
 from openedx.core.lib.gating import api as gating_api
 from openedx.core.lib.url_utils import quote_slashes
+from student.models import CourseEnrollment, anonymous_id_for_user
+from lms.djangoapps.verify_student.tests.factories import SoftwareSecurePhotoVerificationFactory
+from xblock_django.models import XBlockConfiguration
+from xmodule.capa_module import ProblemBlock
+from xmodule.html_module import AboutBlock, CourseInfoBlock, HtmlBlock, StaticTabBlock
+from xmodule.lti_module import LTIDescriptor
+from xmodule.modulestore import ModuleStoreEnum
+from xmodule.modulestore.django import modulestore
+from xmodule.modulestore.tests.django_utils import (
+    TEST_DATA_MIXED_MODULESTORE,
+    ModuleStoreTestCase,
+    SharedModuleStoreTestCase
+)
+from xmodule.modulestore.tests.factories import CourseFactory, ItemFactory, ToyCourseFactory, check_mongo_calls
+from xmodule.modulestore.tests.test_asides import AsideTestType
+from xmodule.video_module import VideoBlock
+from xmodule.x_module import STUDENT_VIEW, CombinedSystem, XModule, XModuleDescriptor
+
 
 TEST_DATA_DIR = settings.COMMON_TEST_DATA_ROOT
 

--- a/lms/djangoapps/courseware/tests/test_module_render.py
+++ b/lms/djangoapps/courseware/tests/test_module_render.py
@@ -859,7 +859,7 @@ class TestHandleXBlockCallback(SharedModuleStoreTestCase, LoginEnrollmentTestCas
         request.user = self.mock_user
 
         with patch(
-            'courseware.module_render.is_xblock_aside',
+            'lms.djangoapps.courseware.module_render.is_xblock_aside',
             return_value=True
         ), self.assertRaises(Http404):
             render.handle_xblock_callback(

--- a/lms/djangoapps/courseware/views/views.py
+++ b/lms/djangoapps/courseware/views/views.py
@@ -47,7 +47,7 @@ from rest_framework.throttling import UserRateThrottle
 from six import text_type
 from web_fragments.fragment import Fragment
 
-import survey.views
+from lms.djangoapps.survey import views as survey_views
 from course_modes.models import CourseMode, get_course_prices
 from edxmako.shortcuts import marketing_link, render_to_response, render_to_string
 from lms.djangoapps.edxnotes.helpers import is_feature_enabled
@@ -1516,7 +1516,7 @@ def course_survey(request, course_id):
     if not course.course_survey_name:
         return redirect(redirect_url)
 
-    return survey.views.view_student_survey(
+    return survey_views.view_student_survey(
         request.user,
         course.course_survey_name,
         course=course,

--- a/lms/djangoapps/dashboard/git_import.py
+++ b/lms/djangoapps/dashboard/git_import.py
@@ -18,7 +18,7 @@ from django.utils.translation import ugettext_lazy as _
 from opaque_keys.edx.locator import CourseLocator
 from six import StringIO
 
-from dashboard.models import CourseImportLog
+from lms.djangoapps.dashboard.models import CourseImportLog
 from xmodule.util.sandboxing import DEFAULT_PYTHON_LIB_FILENAME
 
 log = logging.getLogger(__name__)

--- a/lms/djangoapps/dashboard/management/commands/git_add_course.py
+++ b/lms/djangoapps/dashboard/management/commands/git_add_course.py
@@ -8,8 +8,7 @@ import logging
 from django.core.management.base import BaseCommand, CommandError
 from django.utils.translation import ugettext as _
 
-import dashboard.git_import
-from dashboard.git_import import GitImportError
+from lms.djangoapps.dashboard import git_import
 from xmodule.modulestore.django import modulestore
 from xmodule.modulestore.xml import XMLModuleStore
 
@@ -50,6 +49,6 @@ class Command(BaseCommand):
             branch = options['repository_branch']
 
         try:
-            dashboard.git_import.add_repo(options['repository_url'], rdir_arg, branch)
-        except GitImportError as ex:
+            git_import.add_repo(options['repository_url'], rdir_arg, branch)
+        except git_import.GitImportError as ex:
             raise CommandError(str(ex))

--- a/lms/djangoapps/dashboard/management/commands/tests/test_git_add_course.py
+++ b/lms/djangoapps/dashboard/management/commands/tests/test_git_add_course.py
@@ -18,8 +18,8 @@ from django.test.utils import override_settings
 from opaque_keys.edx.keys import CourseKey
 from six import StringIO
 
-import dashboard.git_import as git_import
-from dashboard.git_import import (
+import lms.djangoapps.dashboard.git_import as git_import
+from lms.djangoapps.dashboard.git_import import (
     GitImportError,
     GitImportErrorBadRepo,
     GitImportErrorCannotPull,

--- a/lms/djangoapps/dashboard/sysadmin.py
+++ b/lms/djangoapps/dashboard/sysadmin.py
@@ -28,10 +28,10 @@ from opaque_keys.edx.keys import CourseKey
 from path import Path as path
 from six import StringIO, text_type
 
-import dashboard.git_import as git_import
+import lms.djangoapps.dashboard.git_import as git_import
 import track.views
-from dashboard.git_import import GitImportError
-from dashboard.models import CourseImportLog
+from lms.djangoapps.dashboard.git_import import GitImportError
+from lms.djangoapps.dashboard.models import CourseImportLog
 from edxmako.shortcuts import render_to_response
 from lms.djangoapps.courseware.courses import get_course_by_id
 from openedx.core.djangolib.markup import HTML
@@ -297,7 +297,7 @@ class Courses(SysadminDashboardView):
         import_log_handler.setLevel(logging.DEBUG)
 
         logger_names = ['xmodule.modulestore.xml_importer',
-                        'dashboard.git_import',
+                        'lms.djangoapps.dashboard.git_import',
                         'xmodule.modulestore.xml',
                         'xmodule.seq_module', ]
         loggers = []

--- a/lms/djangoapps/dashboard/tests/test_sysadmin.py
+++ b/lms/djangoapps/dashboard/tests/test_sysadmin.py
@@ -21,8 +21,8 @@ from pytz import UTC
 from six import text_type
 from six.moves import range
 
-from dashboard.git_import import GitImportErrorNoDir
-from dashboard.models import CourseImportLog
+from lms.djangoapps.dashboard.git_import import GitImportErrorNoDir
+from lms.djangoapps.dashboard.models import CourseImportLog
 from openedx.core.djangolib.markup import Text
 from student.roles import CourseStaffRole, GlobalStaff
 from student.tests.factories import UserFactory

--- a/lms/djangoapps/discussion/django_comment_client/tests/test_utils.py
+++ b/lms/djangoapps/discussion/django_comment_client/tests/test_utils.py
@@ -1316,7 +1316,7 @@ class DiscussionTabTestCase(ModuleStoreTestCase):
             self.assertTrue(self.discussion_tab_present(self.enrolled_user))
             self.assertFalse(self.discussion_tab_present(self.unenrolled_user))
 
-    @mock.patch('ccx.overrides.get_current_ccx')
+    @mock.patch('lms.djangoapps.ccx.overrides.get_current_ccx')
     def test_tab_settings(self, mock_get_ccx):
         mock_get_ccx.return_value = True
         with self.settings(FEATURES={'ENABLE_DISCUSSION_SERVICE': False}):

--- a/lms/djangoapps/discussion/plugins.py
+++ b/lms/djangoapps/discussion/plugins.py
@@ -20,7 +20,7 @@ class DiscussionTab(TabFragmentViewMixin, EnrolledTab):
     title = ugettext_noop('Discussion')
     priority = None
     view_name = 'forum_form_discussion'
-    fragment_view_name = 'discussion.views.DiscussionBoardFragmentView'
+    fragment_view_name = 'lms.djangoapps.discussion.views.DiscussionBoardFragmentView'
     is_hideable = settings.FEATURES.get('ALLOW_HIDING_DISCUSSION_TAB', False)
     is_default = False
     body_class = 'discussion'

--- a/lms/djangoapps/discussion/rest_api/views.py
+++ b/lms/djangoapps/discussion/rest_api/views.py
@@ -19,7 +19,7 @@ from rest_framework.views import APIView
 from rest_framework.viewsets import ViewSet
 from six import text_type
 
-from discussion.views import get_divided_discussions
+from lms.djangoapps.discussion.views import get_divided_discussions
 from lms.djangoapps.instructor.access import update_forum_role
 from lms.djangoapps.discussion.django_comment_client.utils import available_division_schemes
 from lms.djangoapps.discussion.rest_api.api import (

--- a/lms/djangoapps/email_marketing/admin.py
+++ b/lms/djangoapps/email_marketing/admin.py
@@ -4,6 +4,6 @@
 from config_models.admin import ConfigurationModelAdmin
 from django.contrib import admin
 
-from email_marketing.models import EmailMarketingConfiguration
+from .models import EmailMarketingConfiguration
 
 admin.site.register(EmailMarketingConfiguration, ConfigurationModelAdmin)

--- a/lms/djangoapps/email_marketing/tasks.py
+++ b/lms/djangoapps/email_marketing/tasks.py
@@ -14,7 +14,7 @@ from django.core.cache import cache
 from sailthru.sailthru_client import SailthruClient
 from sailthru.sailthru_error import SailthruClientError
 
-from email_marketing.models import EmailMarketingConfiguration
+from .models import EmailMarketingConfiguration
 
 log = logging.getLogger(__name__)
 SAILTHRU_LIST_CACHE_KEY = "email.marketing.cache"

--- a/lms/djangoapps/experiments/factories.py
+++ b/lms/djangoapps/experiments/factories.py
@@ -6,7 +6,7 @@ Experimentation factories
 import factory
 import factory.fuzzy
 
-from experiments.models import ExperimentData, ExperimentKeyValue
+from lms.djangoapps.experiments.models import ExperimentData, ExperimentKeyValue
 from student.tests.factories import UserFactory
 
 

--- a/lms/djangoapps/experiments/filters.py
+++ b/lms/djangoapps/experiments/filters.py
@@ -5,7 +5,7 @@ Experimentation filters
 
 import django_filters
 
-from experiments.models import ExperimentData, ExperimentKeyValue
+from lms.djangoapps.experiments.models import ExperimentData, ExperimentKeyValue
 
 
 class ExperimentDataFilter(django_filters.FilterSet):

--- a/lms/djangoapps/experiments/flags.py
+++ b/lms/djangoapps/experiments/flags.py
@@ -11,7 +11,7 @@ import pytz
 from crum import get_current_request
 from edx_django_utils.cache import RequestCache
 
-from experiments.stable_bucketing import stable_bucketing_hash_group
+from lms.djangoapps.experiments.stable_bucketing import stable_bucketing_hash_group
 from openedx.core.djangoapps.waffle_utils import CourseWaffleFlag
 from track import segment
 
@@ -155,7 +155,7 @@ class ExperimentWaffleFlag(CourseWaffleFlag):
         """
         # Keep some imports in here, because this class is commonly used at a module level, and we want to avoid
         # circular imports for any models.
-        from experiments.models import ExperimentKeyValue
+        from lms.djangoapps.experiments.models import ExperimentKeyValue
         from lms.djangoapps.courseware.masquerade import get_specific_masquerading_user
 
         request = get_current_request()

--- a/lms/djangoapps/experiments/tests/test_flags.py
+++ b/lms/djangoapps/experiments/tests/test_flags.py
@@ -12,9 +12,9 @@ from mock import patch
 from opaque_keys.edx.keys import CourseKey
 
 from edx_toggles.toggles.testutils import override_waffle_flag
-from experiments.factories import ExperimentKeyValueFactory
-from experiments.flags import ExperimentWaffleFlag
 from lms.djangoapps.experiments.testutils import override_experiment_waffle_flag
+from lms.djangoapps.experiments.factories import ExperimentKeyValueFactory
+from lms.djangoapps.experiments.flags import ExperimentWaffleFlag
 from openedx.core.djangoapps.site_configuration.tests.factories import SiteFactory
 from openedx.core.djangoapps.waffle_utils import CourseWaffleFlag
 from openedx.core.djangoapps.waffle_utils.models import WaffleFlagCourseOverrideModel

--- a/lms/djangoapps/experiments/tests/test_views.py
+++ b/lms/djangoapps/experiments/tests/test_views.py
@@ -15,9 +15,9 @@ from django.urls import reverse
 from mock import patch
 from rest_framework.test import APITestCase
 
-from experiments.factories import ExperimentDataFactory, ExperimentKeyValueFactory
-from experiments.models import ExperimentData, ExperimentKeyValue
-from experiments.serializers import ExperimentDataSerializer
+from lms.djangoapps.experiments.factories import ExperimentDataFactory, ExperimentKeyValueFactory
+from lms.djangoapps.experiments.models import ExperimentData, ExperimentKeyValue
+from lms.djangoapps.experiments.serializers import ExperimentDataSerializer
 from student.tests.factories import UserFactory
 
 CROSS_DOMAIN_REFERER = 'https://ecommerce.edx.org'

--- a/lms/djangoapps/experiments/views.py
+++ b/lms/djangoapps/experiments/views.py
@@ -11,9 +11,9 @@ from edx_rest_framework_extensions.auth.session.authentication import SessionAut
 from rest_framework import permissions, viewsets
 from rest_framework.response import Response
 
-from experiments import filters, serializers
-from experiments.models import ExperimentData, ExperimentKeyValue
-from experiments.permissions import IsStaffOrOwner, IsStaffOrReadOnly
+from lms.djangoapps.experiments import filters, serializers
+from lms.djangoapps.experiments.models import ExperimentData, ExperimentKeyValue
+from lms.djangoapps.experiments.permissions import IsStaffOrOwner, IsStaffOrReadOnly
 from openedx.core.djangoapps.cors_csrf.authentication import SessionAuthenticationCrossDomainCsrf
 
 User = get_user_model()  # pylint: disable=invalid-name

--- a/lms/djangoapps/gating/apps.py
+++ b/lms/djangoapps/gating/apps.py
@@ -14,4 +14,4 @@ class GatingConfig(AppConfig):
 
     def ready(self):
         # Import signals to wire up the signal handlers contained within
-        from gating import signals  # pylint: disable=unused-import
+        from lms.djangoapps.gating import signals  # pylint: disable=unused-import

--- a/lms/djangoapps/gating/tasks.py
+++ b/lms/djangoapps/gating/tasks.py
@@ -10,7 +10,7 @@ from celery import task
 from django.contrib.auth.models import User
 from opaque_keys.edx.keys import CourseKey, UsageKey
 
-from gating import api as gating_api
+from lms.djangoapps.gating import api as gating_api
 from lms.djangoapps.course_blocks.api import get_course_blocks
 from xmodule.modulestore.django import modulestore
 

--- a/lms/djangoapps/gating/tests/test_api.py
+++ b/lms/djangoapps/gating/tests/test_api.py
@@ -9,7 +9,7 @@ from milestones.tests.utils import MilestonesTestCaseMixin
 from mock import Mock, patch
 
 from lms.djangoapps.courseware.tests.helpers import LoginEnrollmentTestCase
-from gating.api import evaluate_prerequisite
+from lms.djangoapps.gating.api import evaluate_prerequisite
 from openedx.core.lib.gating import api as gating_api
 from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
 from xmodule.modulestore.tests.factories import CourseFactory, ItemFactory

--- a/lms/djangoapps/gating/tests/test_signals.py
+++ b/lms/djangoapps/gating/tests/test_signals.py
@@ -5,7 +5,7 @@ Unit tests for gating.signals module
 
 from mock import Mock, patch
 
-from gating.signals import evaluate_subsection_gated_milestones
+from lms.djangoapps.gating.signals import evaluate_subsection_gated_milestones
 from student.tests.factories import UserFactory
 from xmodule.modulestore.django import modulestore
 from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase

--- a/lms/djangoapps/grades/rest_api/urls.py
+++ b/lms/djangoapps/grades/rest_api/urls.py
@@ -8,5 +8,5 @@ from django.conf.urls import include, url
 app_name = 'lms.djangoapps.grades'
 
 urlpatterns = [
-    url(r'^v1/', include('grades.rest_api.v1.urls', namespace='v1'))
+    url(r'^v1/', include('lms.djangoapps.grades.rest_api.v1.urls', namespace='v1'))
 ]

--- a/lms/djangoapps/instructor/tests/test_api.py
+++ b/lms/djangoapps/instructor/tests/test_api.py
@@ -33,7 +33,7 @@ from six import text_type, unichr
 from six.moves import range, zip
 from testfixtures import LogCapture
 
-from bulk_email.models import BulkEmailFlag, CourseEmail, CourseEmailTemplate
+from lms.djangoapps.bulk_email.models import BulkEmailFlag, CourseEmail, CourseEmailTemplate
 from course_modes.models import CourseMode
 from course_modes.tests.factories import CourseModeFactory
 from edx_toggles.toggles.testutils import override_waffle_flag

--- a/lms/djangoapps/instructor/tests/test_email.py
+++ b/lms/djangoapps/instructor/tests/test_email.py
@@ -10,8 +10,8 @@ from django.urls import reverse
 from opaque_keys.edx.keys import CourseKey
 from six import text_type
 
-from bulk_email.api import is_bulk_email_enabled_for_course, is_bulk_email_feature_enabled
-from bulk_email.models import BulkEmailFlag, CourseAuthorization
+from lms.djangoapps.bulk_email.api import is_bulk_email_enabled_for_course, is_bulk_email_feature_enabled
+from lms.djangoapps.bulk_email.models import BulkEmailFlag, CourseAuthorization
 from student.tests.factories import AdminFactory
 from xmodule.modulestore.tests.django_utils import TEST_DATA_MIXED_MODULESTORE, SharedModuleStoreTestCase
 from xmodule.modulestore.tests.factories import CourseFactory

--- a/lms/djangoapps/instructor/tests/test_enrollment.py
+++ b/lms/djangoapps/instructor/tests/test_enrollment.py
@@ -21,8 +21,8 @@ from submissions import api as sub_api
 
 from capa.tests.response_xml_factory import MultipleChoiceResponseXMLFactory
 from lms.djangoapps.courseware.models import StudentModule
-from grades.subsection_grade_factory import SubsectionGradeFactory
-from grades.tests.utils import answer_problem
+from lms.djangoapps.grades.subsection_grade_factory import SubsectionGradeFactory
+from lms.djangoapps.grades.tests.utils import answer_problem
 from lms.djangoapps.ccx.tests.factories import CcxFactory
 from lms.djangoapps.course_blocks.api import get_course_blocks
 from lms.djangoapps.instructor.enrollment import (

--- a/lms/djangoapps/instructor/views/api.py
+++ b/lms/djangoapps/instructor/views/api.py
@@ -46,8 +46,8 @@ from submissions import api as sub_api  # installed from the edx-submissions rep
 import instructor_analytics.basic
 import instructor_analytics.csvs
 import instructor_analytics.distributions
-from bulk_email.api import is_bulk_email_feature_enabled
-from bulk_email.models import CourseEmail
+from lms.djangoapps.bulk_email.api import is_bulk_email_feature_enabled
+from lms.djangoapps.bulk_email.models import CourseEmail
 from course_modes.models import CourseMode
 from lms.djangoapps.certificates import api as certs_api
 from lms.djangoapps.certificates.models import (

--- a/lms/djangoapps/instructor/views/api.py
+++ b/lms/djangoapps/instructor/views/api.py
@@ -43,9 +43,9 @@ from six import text_type
 from six.moves import map, range
 from submissions import api as sub_api  # installed from the edx-submissions repository
 
-import instructor_analytics.basic
-import instructor_analytics.csvs
-import instructor_analytics.distributions
+from lms.djangoapps.instructor_analytics import basic as instructor_analytics_basic
+from lms.djangoapps.instructor_analytics import csvs as instructor_analytics_csvs
+from lms.djangoapps.instructor_analytics import distributions as instructor_analytics_distributions
 from lms.djangoapps.bulk_email.api import is_bulk_email_feature_enabled
 from lms.djangoapps.bulk_email.models import CourseEmail
 from course_modes.models import CourseMode
@@ -1079,7 +1079,7 @@ def get_grading_config(request, course_id):
     # )
     course = get_course_by_id(course_id)
 
-    grading_config_summary = instructor_analytics.basic.dump_grading_context(course)
+    grading_config_summary = instructor_analytics_basic.dump_grading_context(course)
 
     response_payload = {
         'course_id': text_type(course_id),
@@ -1111,10 +1111,10 @@ def get_issued_certificates(request, course_id):
         ('total_issued_certificate', _('Total Certificates Issued')),
         ('report_run_date', _('Date Report Run'))
     ]
-    certificates_data = instructor_analytics.basic.issued_certificates(course_key, query_features)
+    certificates_data = instructor_analytics_basic.issued_certificates(course_key, query_features)
     if csv_required.lower() == 'true':
-        __, data_rows = instructor_analytics.csvs.format_dictlist(certificates_data, query_features)
-        return instructor_analytics.csvs.create_csv_response(
+        __, data_rows = instructor_analytics_csvs.format_dictlist(certificates_data, query_features)
+        return instructor_analytics_csvs.create_csv_response(
             'issued_certificates.csv',
             [col_header for __, col_header in query_features_names],
             data_rows
@@ -1146,7 +1146,7 @@ def get_students_features(request, course_id, csv=False):  # pylint: disable=red
     course_key = CourseKey.from_string(course_id)
     course = get_course_by_id(course_key)
     report_type = _('enrolled learner profile')
-    available_features = instructor_analytics.basic.AVAILABLE_FEATURES
+    available_features = instructor_analytics_basic.AVAILABLE_FEATURES
 
     # Allow for sites to be able to define additional columns.
     # Note that adding additional columns has the potential to break
@@ -1203,7 +1203,7 @@ def get_students_features(request, course_id, csv=False):  # pylint: disable=red
     query_features_names['country'] = _('Country')
 
     if not csv:
-        student_data = instructor_analytics.basic.enrolled_students_features(course_key, query_features)
+        student_data = instructor_analytics_basic.enrolled_students_features(course_key, query_features)
         response_payload = {
             'course_id': six.text_type(course_key),
             'students': student_data,

--- a/lms/djangoapps/instructor/views/instructor_dashboard.py
+++ b/lms/djangoapps/instructor/views/instructor_dashboard.py
@@ -29,7 +29,7 @@ from six.moves.urllib.parse import urljoin
 from xblock.field_data import DictFieldData
 from xblock.fields import ScopeIds
 
-from bulk_email.api import is_bulk_email_feature_enabled
+from lms.djangoapps.bulk_email.api import is_bulk_email_feature_enabled
 from course_modes.models import CourseMode, CourseModesArchive
 from edxmako.shortcuts import render_to_response
 from lms.djangoapps.certificates import api as certs_api

--- a/lms/djangoapps/instructor/views/instructor_task_helpers.py
+++ b/lms/djangoapps/instructor/views/instructor_task_helpers.py
@@ -11,7 +11,7 @@ import six
 from django.utils.translation import ugettext as _
 from django.utils.translation import ungettext
 
-from bulk_email.models import CourseEmail
+from lms.djangoapps.bulk_email.models import CourseEmail
 from lms.djangoapps.instructor_task.views import get_task_completion_info
 from util.date_utils import get_default_time_display
 

--- a/lms/djangoapps/instructor_task/api.py
+++ b/lms/djangoapps/instructor_task/api.py
@@ -14,7 +14,7 @@ from collections import Counter
 import six
 from celery.states import READY_STATES
 
-from bulk_email.models import CourseEmail
+from lms.djangoapps.bulk_email.models import CourseEmail
 from lms.djangoapps.certificates.models import CertificateGenerationHistory
 from lms.djangoapps.instructor_task.api_helper import (
     check_arguments_for_overriding,

--- a/lms/djangoapps/instructor_task/tasks.py
+++ b/lms/djangoapps/instructor_task/tasks.py
@@ -20,7 +20,6 @@ of the query for traversing StudentModule objects.
 
 """
 
-
 import logging
 from functools import partial
 

--- a/lms/djangoapps/instructor_task/tasks_helper/grades.py
+++ b/lms/djangoapps/instructor_task/tasks_helper/grades.py
@@ -10,7 +10,7 @@ from time import time
 
 import re
 import six
-from course_blocks.api import get_course_blocks
+from lms.djangoapps.course_blocks.api import get_course_blocks
 from django.conf import settings
 from django.contrib.auth import get_user_model
 from lazy import lazy

--- a/lms/djangoapps/instructor_task/tasks_helper/misc.py
+++ b/lms/djangoapps/instructor_task/tasks_helper/misc.py
@@ -28,7 +28,7 @@ from lms.djangoapps.instructor_analytics.basic import get_proctored_exam_results
 from lms.djangoapps.instructor_analytics.csvs import format_dictlist
 from openedx.core.djangoapps.course_groups.cohorts import add_user_to_cohort
 from openedx.core.djangoapps.course_groups.models import CourseUserGroup
-from survey.models import SurveyAnswer
+from lms.djangoapps.survey.models import SurveyAnswer
 from util.file import UniversalNewlineIterator
 
 from .runner import TaskProgress

--- a/lms/djangoapps/instructor_task/tests/test_api.py
+++ b/lms/djangoapps/instructor_task/tests/test_api.py
@@ -8,7 +8,7 @@ from celery.states import FAILURE
 from mock import MagicMock, Mock, patch
 from six.moves import range
 
-from bulk_email.models import SEND_TO_LEARNERS, SEND_TO_MYSELF, SEND_TO_STAFF, CourseEmail
+from lms.djangoapps.bulk_email.models import SEND_TO_LEARNERS, SEND_TO_MYSELF, SEND_TO_STAFF, CourseEmail
 from common.test.utils import normalize_repr
 from lms.djangoapps.courseware.tests.factories import UserFactory
 from lms.djangoapps.certificates.models import CertificateGenerationHistory, CertificateStatuses

--- a/lms/djangoapps/instructor_task/tests/test_tasks_helper.py
+++ b/lms/djangoapps/instructor_task/tests/test_tasks_helper.py
@@ -77,7 +77,7 @@ from openedx.core.djangoapps.util.testing import ContentGroupTestCase, TestCondi
 from openedx.core.lib.teams_config import TeamsConfig
 from student.models import ALLOWEDTOENROLL_TO_ENROLLED, CourseEnrollment, CourseEnrollmentAllowed, ManualEnrollmentAudit
 from student.tests.factories import CourseEnrollmentFactory, UserFactory
-from survey.models import SurveyAnswer, SurveyForm
+from lms.djangoapps.survey.models import SurveyAnswer, SurveyForm
 from xmodule.modulestore import ModuleStoreEnum
 from xmodule.modulestore.tests.django_utils import SharedModuleStoreTestCase
 from xmodule.modulestore.tests.factories import CourseFactory, ItemFactory, check_mongo_calls

--- a/lms/djangoapps/lms_xblock/runtime.py
+++ b/lms/djangoapps/lms_xblock/runtime.py
@@ -10,8 +10,8 @@ from django.conf import settings
 from django.urls import reverse
 from edx_django_utils.cache import DEFAULT_REQUEST_CACHE
 
-from badges.service import BadgingService
-from badges.utils import badges_enabled
+from lms.djangoapps.badges.service import BadgingService
+from lms.djangoapps.badges.utils import badges_enabled
 from lms.djangoapps.lms_xblock.models import XBlockAsidesConfig
 from lms.djangoapps.teams.services import TeamsService
 from openedx.core.djangoapps.user_api.course_tag import api as user_course_tag_api

--- a/lms/djangoapps/lms_xblock/test/test_runtime.py
+++ b/lms/djangoapps/lms_xblock/test/test_runtime.py
@@ -13,8 +13,8 @@ from six.moves.urllib.parse import urlparse
 from xblock.exceptions import NoSuchServiceError
 from xblock.fields import ScopeIds
 
-from badges.tests.factories import BadgeClassFactory
-from badges.tests.test_models import get_image
+from lms.djangoapps.badges.tests.factories import BadgeClassFactory
+from lms.djangoapps.badges.tests.test_models import get_image
 from lms.djangoapps.lms_xblock.runtime import LmsModuleSystem
 from student.tests.factories import UserFactory
 from xmodule.modulestore.django import ModuleI18nService

--- a/lms/djangoapps/lti_provider/management/commands/tests/test_resend_lti_scores.py
+++ b/lms/djangoapps/lti_provider/management/commands/tests/test_resend_lti_scores.py
@@ -8,8 +8,8 @@ from django.test import TestCase
 from mock import patch
 from opaque_keys.edx.keys import CourseKey, UsageKey
 
-from lti_provider.management.commands import resend_lti_scores
-from lti_provider.models import GradedAssignment, LtiConsumer, OutcomeService
+from lms.djangoapps.lti_provider.management.commands import resend_lti_scores
+from lms.djangoapps.lti_provider.models import GradedAssignment, LtiConsumer, OutcomeService
 from student.tests.factories import UserFactory
 from xmodule.modulestore.tests.django_utils import SharedModuleStoreTestCase
 from xmodule.modulestore.tests.utils import TEST_DATA_DIR
@@ -100,7 +100,7 @@ class CommandExecutionTestCase(SharedModuleStoreTestCase):
         """
         cmd = resend_lti_scores.Command()
         self._configure_lti(UsageKey.from_string(self.lti_block))
-        with patch(u'lti_provider.outcomes.send_score_update') as mock_update:
+        with patch('lms.djangoapps.lti_provider.outcomes.send_score_update') as mock_update:
             cmd.handle(*args, **kwargs)
             return mock_update.called
 

--- a/lms/djangoapps/lti_provider/outcomes.py
+++ b/lms/djangoapps/lti_provider/outcomes.py
@@ -13,7 +13,7 @@ from lxml import etree
 from lxml.builder import ElementMaker
 from requests.exceptions import RequestException
 
-from lti_provider.models import GradedAssignment, OutcomeService
+from lms.djangoapps.lti_provider.models import GradedAssignment, OutcomeService
 
 log = logging.getLogger("edx.lti_provider")
 

--- a/lms/djangoapps/lti_provider/tasks.py
+++ b/lms/djangoapps/lti_provider/tasks.py
@@ -8,16 +8,16 @@ import logging
 from django.contrib.auth.models import User
 from opaque_keys.edx.keys import CourseKey
 
-import lti_provider.outcomes as outcomes
+import lms.djangoapps.lti_provider.outcomes as outcomes
 from lms import CELERY_APP
 from lms.djangoapps.grades.api import CourseGradeFactory
-from lti_provider.models import GradedAssignment
+from lms.djangoapps.lti_provider.models import GradedAssignment
 from xmodule.modulestore.django import modulestore
 
 log = logging.getLogger(__name__)
 
 
-@CELERY_APP.task(name='lti_provider.tasks.send_composite_outcome')
+@CELERY_APP.task(name='lms.djangoapps.lti_provider.tasks.send_composite_outcome')
 def send_composite_outcome(user_id, course_id, assignment_id, version):
     """
     Calculate and transmit the score for a composite module (such as a

--- a/lms/djangoapps/lti_provider/tests/test_outcomes.py
+++ b/lms/djangoapps/lti_provider/tests/test_outcomes.py
@@ -8,8 +8,8 @@ from lxml import etree
 from mock import ANY, MagicMock, patch
 from opaque_keys.edx.locator import BlockUsageLocator, CourseLocator
 
-import lti_provider.outcomes as outcomes
-from lti_provider.models import GradedAssignment, LtiConsumer, OutcomeService
+import lms.djangoapps.lti_provider.outcomes as outcomes
+from lms.djangoapps.lti_provider.models import GradedAssignment, LtiConsumer, OutcomeService
 from student.tests.factories import UserFactory
 from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
 from xmodule.modulestore.tests.factories import CourseFactory, ItemFactory, check_mongo_calls

--- a/lms/djangoapps/lti_provider/tests/test_signature_validator.py
+++ b/lms/djangoapps/lti_provider/tests/test_signature_validator.py
@@ -8,8 +8,8 @@ from django.test import TestCase
 from django.test.client import RequestFactory
 from mock import patch
 
-from lti_provider.models import LtiConsumer
-from lti_provider.signature_validator import SignatureValidator
+from lms.djangoapps.lti_provider.models import LtiConsumer
+from lms.djangoapps.lti_provider.signature_validator import SignatureValidator
 
 
 def get_lti_consumer():

--- a/lms/djangoapps/lti_provider/tests/test_tasks.py
+++ b/lms/djangoapps/lti_provider/tests/test_tasks.py
@@ -9,8 +9,8 @@ from django.test import TestCase
 from mock import MagicMock, patch
 from opaque_keys.edx.locator import BlockUsageLocator, CourseLocator
 
-import lti_provider.tasks as tasks
-from lti_provider.models import GradedAssignment, LtiConsumer, OutcomeService
+import lms.djangoapps.lti_provider.tasks as tasks
+from lms.djangoapps.lti_provider.models import GradedAssignment, LtiConsumer, OutcomeService
 from student.tests.factories import UserFactory
 
 
@@ -54,7 +54,7 @@ class BaseOutcomeTest(TestCase):
         self.assignment.save()
 
         self.send_score_update_mock = self.setup_patch(
-            'lti_provider.outcomes.send_score_update', None
+            'lms.djangoapps.lti_provider.outcomes.send_score_update', None
         )
 
     def setup_patch(self, function_name, return_value):
@@ -105,12 +105,12 @@ class SendCompositeOutcomeTest(BaseOutcomeTest):
         )
         self.course_grade = MagicMock()
         self.course_grade_mock = self.setup_patch(
-            'lti_provider.tasks.CourseGradeFactory.read', self.course_grade
+            'lms.djangoapps.lti_provider.tasks.CourseGradeFactory.read', self.course_grade
         )
         self.module_store = MagicMock()
         self.module_store.get_item = MagicMock(return_value=self.descriptor)
         self.check_result_mock = self.setup_patch(
-            'lti_provider.tasks.modulestore',
+            'lms.djangoapps.lti_provider.tasks.modulestore',
             self.module_store
         )
 

--- a/lms/djangoapps/lti_provider/tests/test_views.py
+++ b/lms/djangoapps/lti_provider/tests/test_views.py
@@ -11,7 +11,7 @@ from mock import MagicMock, patch
 from opaque_keys.edx.locator import BlockUsageLocator, CourseLocator
 
 from lms.djangoapps.courseware.testutils import RenderXBlockTestMixin
-from lti_provider import models, views
+from lms.djangoapps.lti_provider import models, views
 from student.tests.factories import UserFactory
 from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
 

--- a/lms/djangoapps/lti_provider/urls.py
+++ b/lms/djangoapps/lti_provider/urls.py
@@ -6,7 +6,7 @@ LTI Provider API endpoint urls.
 from django.conf import settings
 from django.conf.urls import url
 
-from lti_provider import views
+from lms.djangoapps.lti_provider import views
 
 urlpatterns = [
     url(

--- a/lms/djangoapps/lti_provider/users.py
+++ b/lms/djangoapps/lti_provider/users.py
@@ -15,7 +15,7 @@ from django.core.exceptions import PermissionDenied
 from django.db import IntegrityError, transaction
 from six.moves import range
 
-from lti_provider.models import LtiUser
+from lms.djangoapps.lti_provider.models import LtiUser
 from student.models import UserProfile
 
 

--- a/lms/djangoapps/lti_provider/views.py
+++ b/lms/djangoapps/lti_provider/views.py
@@ -12,10 +12,10 @@ from django.views.decorators.csrf import csrf_exempt
 from opaque_keys import InvalidKeyError
 from opaque_keys.edx.keys import CourseKey, UsageKey
 
-from lti_provider.models import LtiConsumer
-from lti_provider.outcomes import store_outcome_parameters
-from lti_provider.signature_validator import SignatureValidator
-from lti_provider.users import authenticate_lti_user
+from lms.djangoapps.lti_provider.models import LtiConsumer
+from lms.djangoapps.lti_provider.outcomes import store_outcome_parameters
+from lms.djangoapps.lti_provider.signature_validator import SignatureValidator
+from lms.djangoapps.lti_provider.users import authenticate_lti_user
 from openedx.core.lib.url_utils import unquote_slashes
 from util.views import add_p3p_header
 

--- a/lms/djangoapps/mobile_api/course_info/tests.py
+++ b/lms/djangoapps/mobile_api/course_info/tests.py
@@ -8,8 +8,8 @@ from django.conf import settings
 from milestones.tests.utils import MilestonesTestCaseMixin
 from six.moves import range
 
-from mobile_api.testutils import MobileAPITestCase, MobileAuthTestMixin, MobileCourseAccessTestMixin
-from mobile_api.utils import API_V1, API_V05
+from lms.djangoapps.mobile_api.testutils import MobileAPITestCase, MobileAuthTestMixin, MobileCourseAccessTestMixin
+from lms.djangoapps.mobile_api.utils import API_V1, API_V05
 from xmodule.html_module import CourseInfoBlock
 from xmodule.modulestore import ModuleStoreEnum
 from xmodule.modulestore.django import modulestore

--- a/lms/djangoapps/mobile_api/middleware.py
+++ b/lms/djangoapps/mobile_api/middleware.py
@@ -12,9 +12,9 @@ from django.utils.deprecation import MiddlewareMixin
 from pytz import UTC
 import six
 
-from mobile_api.mobile_platform import MobilePlatform
-from mobile_api.models import AppVersionConfig
-from mobile_api.utils import parsed_version
+from lms.djangoapps.mobile_api.mobile_platform import MobilePlatform
+from lms.djangoapps.mobile_api.models import AppVersionConfig
+from lms.djangoapps.mobile_api.utils import parsed_version
 from openedx.core.lib.cache_utils import get_cache
 from openedx.core.lib.mobile_utils import is_request_from_mobile_app
 

--- a/lms/djangoapps/mobile_api/tests/test_middleware.py
+++ b/lms/djangoapps/mobile_api/tests/test_middleware.py
@@ -11,8 +11,8 @@ from django.core.cache import caches
 from django.http import HttpRequest, HttpResponse
 from pytz import UTC
 
-from mobile_api.middleware import AppVersionUpgrade
-from mobile_api.models import AppVersionConfig
+from lms.djangoapps.mobile_api.middleware import AppVersionUpgrade
+from lms.djangoapps.mobile_api.models import AppVersionConfig
 from openedx.core.djangolib.testing.utils import CacheIsolationTestCase
 
 

--- a/lms/djangoapps/mobile_api/tests/test_mobile_platform.py
+++ b/lms/djangoapps/mobile_api/tests/test_mobile_platform.py
@@ -6,7 +6,7 @@ Tests for Platform against Mobile App Request
 import ddt
 from django.test import TestCase
 
-from mobile_api.mobile_platform import MobilePlatform
+from lms.djangoapps.mobile_api.mobile_platform import MobilePlatform
 
 
 @ddt.ddt

--- a/lms/djangoapps/mobile_api/tests/test_model.py
+++ b/lms/djangoapps/mobile_api/tests/test_model.py
@@ -9,7 +9,7 @@ import ddt
 from django.test import TestCase
 from pytz import UTC
 
-from mobile_api.models import AppVersionConfig, MobileApiConfig
+from lms.djangoapps.mobile_api.models import AppVersionConfig, MobileApiConfig
 
 
 @ddt.ddt

--- a/lms/djangoapps/mobile_api/testutils.py
+++ b/lms/djangoapps/mobile_api/testutils.py
@@ -26,9 +26,9 @@ from rest_framework.test import APITestCase
 
 from lms.djangoapps.courseware.access_response import MobileAvailabilityError, StartDateError, VisibilityError
 from lms.djangoapps.courseware.tests.factories import UserFactory
-from mobile_api.models import IgnoreMobileAvailableFlagConfig
-from mobile_api.tests.test_milestones import MobileAPIMilestonesMixin
-from mobile_api.utils import API_V1
+from lms.djangoapps.mobile_api.models import IgnoreMobileAvailableFlagConfig
+from lms.djangoapps.mobile_api.tests.test_milestones import MobileAPIMilestonesMixin
+from lms.djangoapps.mobile_api.utils import API_V1
 from student import auth
 from student.models import CourseEnrollment
 from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase

--- a/lms/djangoapps/mobile_api/urls.py
+++ b/lms/djangoapps/mobile_api/urls.py
@@ -8,7 +8,7 @@ from django.conf.urls import include, url
 from .users.views import my_user_info
 
 urlpatterns = [
-    url(r'^users/', include('mobile_api.users.urls')),
+    url(r'^users/', include('lms.djangoapps.mobile_api.users.urls')),
     url(r'^my_user_info', my_user_info, name='user-info'),
-    url(r'^course_info/', include('mobile_api.course_info.urls')),
+    url(r'^course_info/', include('lms.djangoapps.mobile_api.course_info.urls')),
 ]

--- a/lms/djangoapps/mobile_api/users/tests.py
+++ b/lms/djangoapps/mobile_api/users/tests.py
@@ -24,13 +24,13 @@ from lms.djangoapps.certificates.api import generate_user_certificates
 from lms.djangoapps.certificates.models import CertificateStatuses
 from lms.djangoapps.certificates.tests.factories import GeneratedCertificateFactory
 from lms.djangoapps.grades.tests.utils import mock_passing_grade
-from mobile_api.testutils import (
+from lms.djangoapps.mobile_api.testutils import (
     MobileAPITestCase,
     MobileAuthTestMixin,
     MobileAuthUserTestMixin,
     MobileCourseAccessTestMixin
 )
-from mobile_api.utils import API_V1, API_V05
+from lms.djangoapps.mobile_api.utils import API_V1, API_V05
 from openedx.core.djangoapps.schedules.tests.factories import ScheduleFactory
 from openedx.core.lib.courses import course_image_url
 from openedx.features.course_duration_limits.models import CourseDurationLimitConfig

--- a/lms/djangoapps/mobile_api/users/views.py
+++ b/lms/djangoapps/mobile_api/users/views.py
@@ -22,7 +22,7 @@ from lms.djangoapps.courseware.model_data import FieldDataCache
 from lms.djangoapps.courseware.module_render import get_module_for_descriptor
 from lms.djangoapps.courseware.views.index import save_positions_recursively_up
 from lms.djangoapps.courseware.access_utils import ACCESS_GRANTED
-from mobile_api.utils import API_V05
+from lms.djangoapps.mobile_api.utils import API_V05
 from openedx.features.course_duration_limits.access import check_course_expired
 from student.models import CourseEnrollment, User
 from xmodule.modulestore.django import modulestore

--- a/lms/djangoapps/program_enrollments/rest_api/v1/tests/test_views.py
+++ b/lms/djangoapps/program_enrollments/rest_api/v1/tests/test_views.py
@@ -24,7 +24,7 @@ from six import text_type
 from six.moves import range, zip
 from social_django.models import UserSocialAuth
 
-from bulk_email.models import BulkEmailFlag, Optout
+from lms.djangoapps.bulk_email.models import BulkEmailFlag, Optout
 from course_modes.models import CourseMode
 from lms.djangoapps.certificates.models import CertificateStatuses
 from lms.djangoapps.certificates.tests.factories import GeneratedCertificateFactory

--- a/lms/djangoapps/rss_proxy/admin.py
+++ b/lms/djangoapps/rss_proxy/admin.py
@@ -5,6 +5,6 @@ Admin module for the rss_proxy djangoapp.
 
 from django.contrib import admin
 
-from rss_proxy.models import WhitelistedRssUrl
+from lms.djangoapps.rss_proxy.models import WhitelistedRssUrl
 
 admin.site.register(WhitelistedRssUrl)

--- a/lms/djangoapps/rss_proxy/tests/test_models.py
+++ b/lms/djangoapps/rss_proxy/tests/test_models.py
@@ -6,7 +6,7 @@ Tests for the rss_proxy models
 import six
 from django.test import TestCase
 
-from rss_proxy.models import WhitelistedRssUrl
+from lms.djangoapps.rss_proxy.models import WhitelistedRssUrl
 
 
 class WhitelistedRssUrlTests(TestCase):

--- a/lms/djangoapps/rss_proxy/tests/test_views.py
+++ b/lms/djangoapps/rss_proxy/tests/test_views.py
@@ -7,7 +7,7 @@ from django.test import TestCase
 from django.urls import reverse
 from mock import Mock, patch
 
-from rss_proxy.models import WhitelistedRssUrl
+from lms.djangoapps.rss_proxy.models import WhitelistedRssUrl
 
 
 class RssProxyViewTests(TestCase):
@@ -39,7 +39,7 @@ class RssProxyViewTests(TestCase):
         WhitelistedRssUrl.objects.create(url=self.whitelisted_url1)
         WhitelistedRssUrl.objects.create(url=self.whitelisted_url2)
 
-    @patch('rss_proxy.views.requests.get')
+    @patch('lms.djangoapps.rss_proxy.views.requests.get')
     def test_proxy_with_whitelisted_url(self, mock_requests_get):
         """
         Test the proxy view with a whitelisted URL
@@ -50,7 +50,7 @@ class RssProxyViewTests(TestCase):
         self.assertEqual(resp['Content-Type'], 'application/xml')
         self.assertEqual(resp.content.decode('utf-8'), self.rss)
 
-    @patch('rss_proxy.views.requests.get')
+    @patch('lms.djangoapps.rss_proxy.views.requests.get')
     def test_proxy_with_whitelisted_url_404(self, mock_requests_get):
         """
         Test the proxy view with a whitelisted URL that is not found

--- a/lms/djangoapps/rss_proxy/views.py
+++ b/lms/djangoapps/rss_proxy/views.py
@@ -8,7 +8,7 @@ from django.conf import settings
 from django.core.cache import cache
 from django.http import HttpResponse, HttpResponseNotFound
 
-from rss_proxy.models import WhitelistedRssUrl
+from lms.djangoapps.rss_proxy.models import WhitelistedRssUrl
 
 CACHE_KEY_RSS = "rss_proxy.{url}"
 

--- a/lms/djangoapps/static_template_view/urls.py
+++ b/lms/djangoapps/static_template_view/urls.py
@@ -6,7 +6,7 @@ URLs for static_template_view app
 from django.conf import settings
 from django.conf.urls import url
 
-from static_template_view import views
+from lms.djangoapps.static_template_view import views
 
 urlpatterns = [
     # Semi-static views (these need to be rendered and have the login bar, but don't change)

--- a/lms/djangoapps/support/views/certificate.py
+++ b/lms/djangoapps/support/views/certificate.py
@@ -8,7 +8,7 @@ from django.views.generic import View
 from six.moves.urllib.parse import quote_plus, unquote
 
 from edxmako.shortcuts import render_to_response
-from support.decorators import require_support_permission
+from lms.djangoapps.support.decorators import require_support_permission
 
 
 class CertificatesSupportView(View):

--- a/lms/djangoapps/support/views/index.py
+++ b/lms/djangoapps/support/views/index.py
@@ -7,7 +7,7 @@ from django.urls import reverse_lazy
 from django.utils.translation import ugettext_lazy as _
 
 from edxmako.shortcuts import render_to_response
-from support.decorators import require_support_permission
+from lms.djangoapps.support.decorators import require_support_permission
 
 SUPPORT_INDEX_URLS = [
     {

--- a/lms/djangoapps/survey/admin.py
+++ b/lms/djangoapps/survey/admin.py
@@ -6,7 +6,7 @@ Provide accessors to these models via the Django Admin pages
 from django import forms
 from django.contrib import admin
 
-from survey.models import SurveyForm
+from lms.djangoapps.survey.models import SurveyForm
 
 
 class SurveyFormAdminForm(forms.ModelForm):

--- a/lms/djangoapps/survey/models.py
+++ b/lms/djangoapps/survey/models.py
@@ -15,7 +15,7 @@ from opaque_keys.edx.django.models import CourseKeyField
 
 from openedx.core.djangolib.markup import HTML
 from student.models import User
-from survey.exceptions import SurveyFormNameAlreadyExists, SurveyFormNotFound
+from lms.djangoapps.survey.exceptions import SurveyFormNameAlreadyExists, SurveyFormNotFound
 
 log = logging.getLogger("edx.survey")
 

--- a/lms/djangoapps/survey/signals.py
+++ b/lms/djangoapps/survey/signals.py
@@ -6,7 +6,7 @@ Signal handlers for the survey app
 from django.dispatch.dispatcher import receiver
 
 from openedx.core.djangoapps.user_api.accounts.signals import USER_RETIRE_LMS_MISC
-from survey.models import SurveyAnswer
+from lms.djangoapps.survey.models import SurveyAnswer
 
 
 @receiver(USER_RETIRE_LMS_MISC)

--- a/lms/djangoapps/survey/tests/factories.py
+++ b/lms/djangoapps/survey/tests/factories.py
@@ -1,7 +1,7 @@
 import factory
 
 from student.tests.factories import UserFactory
-from survey.models import SurveyAnswer, SurveyForm
+from lms.djangoapps.survey.models import SurveyAnswer, SurveyForm
 
 
 class SurveyFormFactory(factory.DjangoModelFactory):

--- a/lms/djangoapps/survey/tests/test_models.py
+++ b/lms/djangoapps/survey/tests/test_models.py
@@ -12,8 +12,8 @@ from django.core.exceptions import ValidationError
 from django.test import TestCase
 from django.test.client import Client
 
-from survey.exceptions import SurveyFormNameAlreadyExists, SurveyFormNotFound
-from survey.models import SurveyAnswer, SurveyForm
+from lms.djangoapps.survey.exceptions import SurveyFormNameAlreadyExists, SurveyFormNotFound
+from lms.djangoapps.survey.models import SurveyAnswer, SurveyForm
 
 
 @ddt.ddt

--- a/lms/djangoapps/survey/tests/test_signals.py
+++ b/lms/djangoapps/survey/tests/test_signals.py
@@ -6,8 +6,8 @@ Test signal handlers for the survey app
 from lms.djangoapps.survey.signals import _listen_for_lms_retire
 from openedx.core.djangoapps.user_api.accounts.tests.retirement_helpers import fake_completed_retirement
 from student.tests.factories import UserFactory
-from survey.models import SurveyAnswer
-from survey.tests.factories import SurveyAnswerFactory
+from lms.djangoapps.survey.models import SurveyAnswer
+from lms.djangoapps.survey.tests.factories import SurveyAnswerFactory
 from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
 
 

--- a/lms/djangoapps/survey/tests/test_utils.py
+++ b/lms/djangoapps/survey/tests/test_utils.py
@@ -8,8 +8,8 @@ from collections import OrderedDict
 from django.contrib.auth.models import User
 from django.test.client import Client
 
-from survey.models import SurveyForm
-from survey.utils import check_survey_required_and_unanswered, is_survey_required_for_course
+from lms.djangoapps.survey.models import SurveyForm
+from lms.djangoapps.survey.utils import check_survey_required_and_unanswered, is_survey_required_for_course
 from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
 from xmodule.modulestore.tests.factories import CourseFactory
 

--- a/lms/djangoapps/survey/tests/test_views.py
+++ b/lms/djangoapps/survey/tests/test_views.py
@@ -11,7 +11,7 @@ from django.test.client import Client
 from django.urls import reverse
 
 from student.tests.factories import UserFactory
-from survey.models import SurveyAnswer, SurveyForm
+from lms.djangoapps.survey.models import SurveyAnswer, SurveyForm
 from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
 from xmodule.modulestore.tests.factories import CourseFactory
 

--- a/lms/djangoapps/survey/urls.py
+++ b/lms/djangoapps/survey/urls.py
@@ -5,7 +5,7 @@ URL mappings for the Survey feature
 
 from django.conf.urls import url
 
-from survey import views
+from lms.djangoapps.survey import views
 
 urlpatterns = [
     url(r'^(?P<survey_name>[0-9A-Za-z]+)/$', views.view_survey, name='view_survey'),

--- a/lms/djangoapps/survey/utils.py
+++ b/lms/djangoapps/survey/utils.py
@@ -7,7 +7,7 @@ from django.utils.translation import ugettext as _
 from lms.djangoapps.courseware.access import has_access
 from lms.djangoapps.courseware.access_response import AccessError
 from lms.djangoapps.courseware.access_utils import ACCESS_GRANTED
-from survey.models import SurveyAnswer, SurveyForm
+from lms.djangoapps.survey.models import SurveyAnswer, SurveyForm
 
 
 class SurveyRequiredAccessError(AccessError):

--- a/lms/djangoapps/survey/views.py
+++ b/lms/djangoapps/survey/views.py
@@ -16,7 +16,7 @@ from opaque_keys.edx.keys import CourseKey
 
 from edxmako.shortcuts import render_to_response
 from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
-from survey.models import SurveyForm
+from lms.djangoapps.survey.models import SurveyForm
 
 log = logging.getLogger("edx.survey")
 

--- a/lms/djangoapps/verify_student/tests/test_models.py
+++ b/lms/djangoapps/verify_student/tests/test_models.py
@@ -22,7 +22,7 @@ from lms.djangoapps.verify_student.models import (
     VerificationException
 )
 from student.tests.factories import UserFactory
-from verify_student.tests import TestVerificationBase
+from lms.djangoapps.verify_student.tests import TestVerificationBase
 from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
 
 FAKE_SETTINGS = {

--- a/lms/djangoapps/verify_student/tests/test_tasks.py
+++ b/lms/djangoapps/verify_student/tests/test_tasks.py
@@ -5,8 +5,8 @@ from django.conf import settings
 from mock import patch
 
 from common.test.utils import MockS3BotoMixin
-from verify_student.tests import TestVerificationBase
-from verify_student.tests.test_models import FAKE_SETTINGS, mock_software_secure_post_unavailable
+from lms.djangoapps.verify_student.tests import TestVerificationBase
+from lms.djangoapps.verify_student.tests.test_models import FAKE_SETTINGS, mock_software_secure_post_unavailable
 from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
 
 LOGGER_NAME = 'lms.djangoapps.verify_student.tasks'

--- a/lms/djangoapps/verify_student/tests/test_views.py
+++ b/lms/djangoapps/verify_student/tests/test_views.py
@@ -39,7 +39,7 @@ from openedx.core.djangoapps.user_api.accounts.api import get_account_settings
 from student.models import CourseEnrollment
 from student.tests.factories import CourseEnrollmentFactory, UserFactory
 from util.testing import UrlResetMixin
-from verify_student.tests import TestVerificationBase
+from lms.djangoapps.verify_student.tests import TestVerificationBase
 from xmodule.modulestore import ModuleStoreEnum
 from xmodule.modulestore.django import modulestore
 from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -509,8 +509,8 @@ FEATURES = {
     #   student activities to MySQL, in a separate database.
     # .. toggle_use_cases: open_edx
     # .. toggle_warnings: Even though most Open edX instances run with a separate CSMH database, it may not always be
-    #   the case. When disabling this feature flag, remember to remove "coursewarehistoryextended" from the
-    #   INSTALLED_APPS and the "StudentModuleHistoryExtendedRouter" from the DATABASE_ROUTERS.
+    #   the case. When disabling this feature flag, remember to remove "lms.djangoapps.coursewarehistoryextended"
+    #   from the INSTALLED_APPS and the "StudentModuleHistoryExtendedRouter" from the DATABASE_ROUTERS.
     'ENABLE_CSMH_EXTENDED': True,
 
     # Read from both the CSMH and CSMHE history tables.
@@ -847,7 +847,7 @@ TPA_PROVIDER_SUSTAINED_THROTTLE = '50/hr'
 
 ################################## TEMPLATE CONFIGURATION #####################################
 # Mako templating
-import tempfile  # pylint: disable=wrong-import-order
+import tempfile  # pylint: disable=wrong-import-position,wrong-import-order
 MAKO_MODULE_DIR = os.path.join(tempfile.gettempdir(), 'mako_lms')
 MAKO_TEMPLATE_DIRS_BASE = [
     PROJECT_ROOT / 'templates',
@@ -897,7 +897,7 @@ CONTEXT_PROCESSORS = [
     'openedx.core.djangoapps.site_configuration.context_processors.configuration_context',
 
     # Mobile App processor (Detects if request is from the mobile app)
-    'mobile_api.context_processor.is_from_mobile_app'
+    'lms.djangoapps.mobile_api.context_processor.is_from_mobile_app'
 ]
 
 # Django templating
@@ -1529,10 +1529,10 @@ SIMPLE_WIKI_REQUIRE_LOGIN_EDIT = True
 SIMPLE_WIKI_REQUIRE_LOGIN_VIEW = False
 
 ################################# WIKI ###################################
-from course_wiki import settings as course_wiki_settings
+from lms.djangoapps.course_wiki import settings as course_wiki_settings  # pylint: disable=wrong-import-position
 
 WIKI_ACCOUNT_HANDLING = False
-WIKI_EDITOR = 'course_wiki.editors.CodeMirror'
+WIKI_EDITOR = 'lms.djangoapps.course_wiki.editors.CodeMirror'
 WIKI_SHOW_MAX_CHILDREN = 0  # We don't use the little menu that shows children of an article in the breadcrumb
 WIKI_ANONYMOUS = False  # Don't allow anonymous access until the styling is figured out
 
@@ -1646,7 +1646,7 @@ MIDDLEWARE = [
     # Cookie monitoring
     'openedx.core.lib.request_utils.CookieMonitoringMiddleware',
 
-    'mobile_api.middleware.AppVersionUpgrade',
+    'lms.djangoapps.mobile_api.middleware.AppVersionUpgrade',
     'openedx.core.djangoapps.header_control.middleware.HeaderControlMiddleware',
     'lms.djangoapps.discussion.django_comment_client.middleware.AjaxExceptionMiddleware',
     'django.middleware.common.CommonMiddleware',
@@ -1718,7 +1718,7 @@ MIDDLEWARE = [
     'lms.djangoapps.courseware.middleware.CacheCourseIdMiddleware',
     'lms.djangoapps.courseware.middleware.RedirectMiddleware',
 
-    'course_wiki.middleware.WikiAccessMiddleware',
+    'lms.djangoapps.course_wiki.middleware.WikiAccessMiddleware',
 
     'openedx.core.djangoapps.theming.middleware.CurrentSiteThemeMiddleware',
 
@@ -1770,7 +1770,7 @@ STATICFILES_FINDERS = [
     'pipeline.finders.PipelineFinder',
 ]
 
-from openedx.core.lib.rooted_paths import rooted_glob
+from openedx.core.lib.rooted_paths import rooted_glob  # pylint: disable=wrong-import-position
 
 courseware_js = [
     'js/ajax-error.js',
@@ -2562,7 +2562,7 @@ INSTALLED_APPS = [
     'social_django',
 
     # Surveys
-    'survey.apps.SurveyConfig',
+    'lms.djangoapps.survey.apps.SurveyConfig',
 
     'lms.djangoapps.lms_xblock.apps.LMSXBlockConfig',
 
@@ -2576,7 +2576,7 @@ INSTALLED_APPS = [
     'openedx.core.djangoapps.coursegraph.apps.CoursegraphConfig',
 
     # Mailchimp Syncing
-    'mailing',
+    'lms.djangoapps.mailing',
 
     # CORS and cross-domain CSRF
     'corsheaders',
@@ -2607,7 +2607,7 @@ INSTALLED_APPS = [
     'milestones',
 
     # Gating of course content
-    'gating.apps.GatingConfig',
+    'lms.djangoapps.gating.apps.GatingConfig',
 
     # Static i18n support
     'statici18n',
@@ -2619,7 +2619,7 @@ INSTALLED_APPS = [
     'openedx.core.djangoapps.verified_track_content',
 
     # Learner's dashboard
-    'learner_dashboard',
+    'lms.djangoapps.learner_dashboard',
 
     # Needed whether or not enabled, due to migrations
     'lms.djangoapps.badges.apps.BadgesConfig',
@@ -2628,7 +2628,7 @@ INSTALLED_APPS = [
     'django_sites_extensions',
 
     # Email marketing integration
-    'email_marketing.apps.EmailMarketingConfig',
+    'lms.djangoapps.email_marketing.apps.EmailMarketingConfig',
 
     # additional release utilities to ease automation
     'release_util',
@@ -2980,7 +2980,7 @@ CERT_NAME_LONG = "Certificate of Achievement"
 
 #################### OpenBadges Settings #######################
 
-BADGING_BACKEND = 'badges.backends.badgr.BadgrBackend'
+BADGING_BACKEND = 'lms.djangoapps.badges.backends.badgr.BadgrBackend'
 
 # Be sure to set up images for course modes using the BadgeImageConfiguration model in the certificates app.
 BADGR_API_TOKEN = None
@@ -4043,9 +4043,8 @@ SYSTEM_WIDE_ROLE_CLASSES = []
 
 ############## Plugin Django Apps #########################
 
-from edx_django_utils.plugins import get_plugin_apps, add_plugins
-# pylint: disable=wrong-import-position, wrong-import-order
-from openedx.core.djangoapps.plugins.constants import ProjectType, SettingsType
+from edx_django_utils.plugins import get_plugin_apps, add_plugins  # pylint: disable=wrong-import-position,wrong-import-order
+from openedx.core.djangoapps.plugins.constants import ProjectType, SettingsType  # pylint: disable=wrong-import-position
 INSTALLED_APPS.extend(get_plugin_apps(ProjectType.LMS))
 add_plugins(__name__, ProjectType.LMS, SettingsType.COMMON)
 

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -32,7 +32,6 @@ Longer TODO:
 import importlib.util
 import sys
 import os
-import warnings
 
 from corsheaders.defaults import default_headers as corsheaders_default_headers
 from path import Path as path
@@ -46,7 +45,6 @@ from enterprise.constants import (
     ENTERPRISE_OPERATOR_ROLE
 )
 
-from import_shims.warn import DeprecatedEdxPlatformImportWarning
 from openedx.core.constants import COURSE_KEY_REGEX, COURSE_KEY_PATTERN, COURSE_ID_PATTERN
 from openedx.core.djangoapps.theming.helpers_dirs import (
     get_themes_unchecked,
@@ -55,13 +53,6 @@ from openedx.core.djangoapps.theming.helpers_dirs import (
 from openedx.core.lib.derived import derived, derived_collection_entry
 from openedx.core.release import doc_version
 from lms.djangoapps.lms_xblock.mixin import LmsBlockMixin
-
-# Filter out DeprecatedEdxPlatformImportWarning instances for now.
-# We will want these to be generally visible eventually, but while there
-# are still a very high number of them, silencing them will be better for
-# developer experience.
-# See /docs/decisions/0007-sys-path-modification-removal.rst for details.
-warnings.filterwarnings("ignore", category=DeprecatedEdxPlatformImportWarning)
 
 ################################### FEATURES ###################################
 # .. setting_name: PLATFORM_NAME

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -706,7 +706,7 @@ DATA_DIR = COURSES_ROOT
 sys.path.append(REPO_ROOT)
 # TODO: The next two path modifications will be removed in an upcoming Open edX release.
 # See docs/decisions/0007-sys-path-modification-removal.rst
-sys.path.append(REPO_ROOT / 'import_shims' / 'lms')
+# sys.path.append(REPO_ROOT / 'import_shims' / 'lms')
 sys.path.append(COMMON_ROOT / 'djangoapps')
 
 # For Node.js

--- a/lms/envs/test.py
+++ b/lms/envs/test.py
@@ -465,8 +465,8 @@ PROFILE_IMAGE_MIN_BYTES = 100
 
 # Enable the LTI provider feature for testing
 FEATURES['ENABLE_LTI_PROVIDER'] = True
-INSTALLED_APPS.append('lti_provider.apps.LtiProviderConfig')
-AUTHENTICATION_BACKENDS.append('lti_provider.users.LtiBackend')
+INSTALLED_APPS.append('lms.djangoapps.lti_provider.apps.LtiProviderConfig')
+AUTHENTICATION_BACKENDS.append('lms.djangoapps.lti_provider.users.LtiBackend')
 
 # ORGANIZATIONS
 FEATURES['ORGANIZATIONS_APP'] = True

--- a/lms/lib/xblock/test/test_mixin.py
+++ b/lms/lib/xblock/test/test_mixin.py
@@ -6,7 +6,7 @@ Tests of the LMS XBlock Mixin
 import ddt
 from xblock.validation import ValidationMessage
 
-from lms_xblock.mixin import (
+from lms.djangoapps.lms_xblock.mixin import (
     INVALID_USER_PARTITION_GROUP_VALIDATION_COMPONENT,
     INVALID_USER_PARTITION_GROUP_VALIDATION_UNIT,
     INVALID_USER_PARTITION_VALIDATION_COMPONENT,

--- a/lms/templates/footer.html
+++ b/lms/templates/footer.html
@@ -3,7 +3,7 @@
 <%!
   from django.urls import reverse
   from django.utils.translation import ugettext as _
-  from branding.api import get_footer
+  from lms.djangoapps.branding.api import get_footer
   from openedx.core.djangoapps.lang_pref.api import footer_language_selector_is_enabled
 %>
 <% footer = get_footer(is_secure=is_secure) %>

--- a/lms/templates/header/brand.html
+++ b/lms/templates/header/brand.html
@@ -10,7 +10,7 @@ from django.utils.translation import ugettext as _
 from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
 
 # App that handles subdomain specific branding
-from branding import api as branding_api
+from lms.djangoapps.branding import api as branding_api
 %>
 
 <h1 class="hd logo-header navbar-brand">

--- a/lms/templates/header/header.html
+++ b/lms/templates/header/header.html
@@ -13,7 +13,7 @@ from lms.djangoapps.ccx.overrides import get_current_ccx
 from openedx.core.djangolib.markup import HTML, Text
 
 # App that handles subdomain specific branding
-from branding import api as branding_api
+from lms.djangoapps.branding import api as branding_api
 from openedx.core.djangoapps.lang_pref.api import header_language_selector_is_enabled, released_languages
 from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
 

--- a/lms/templates/header/navbar-logo-header.html
+++ b/lms/templates/header/navbar-logo-header.html
@@ -11,7 +11,7 @@ from openedx.core.djangoapps.site_configuration import helpers as configuration_
 from openedx.features.enterprise_support.utils import get_enterprise_learner_generic_name, get_enterprise_learner_portal
 
 # App that handles subdomain specific branding
-from branding import api as branding_api
+from lms.djangoapps.branding import api as branding_api
 %>
 
 <%

--- a/lms/templates/main.html
+++ b/lms/templates/main.html
@@ -15,7 +15,7 @@
 <% online_help_token = self.online_help_token() if hasattr(self, 'online_help_token') else None %>
 <%!
 import six
-from branding import api as branding_api
+from lms.djangoapps.branding import api as branding_api
 from django.urls import reverse
 from django.utils.http import urlquote_plus
 from django.utils.translation import ugettext as _

--- a/lms/templates/navigation/bootstrap/navbar-logo-header.html
+++ b/lms/templates/navigation/bootstrap/navbar-logo-header.html
@@ -7,7 +7,7 @@
 from django.utils.translation import ugettext as _
 
 # App that handles subdomain specific branding
-from branding import api as branding_api
+from lms.djangoapps.branding import api as branding_api
 %>
 
 <a class="navbar-brand" href="${marketing_link('ROOT')}">

--- a/lms/templates/navigation/navbar-logo-header.html
+++ b/lms/templates/navigation/navbar-logo-header.html
@@ -10,7 +10,7 @@ from lms.djangoapps.ccx.overrides import get_current_ccx
 from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
 
 # App that handles subdomain specific branding
-from branding import api as branding_api
+from lms.djangoapps.branding import api as branding_api
 %>
 
 <h1 class="hd logo-header">

--- a/lms/templates/navigation/navigation.html
+++ b/lms/templates/navigation/navigation.html
@@ -16,7 +16,7 @@ from lms.djangoapps.ccx.overrides import get_current_ccx
 from openedx.core.djangolib.markup import HTML, Text
 
 # App that handles subdomain specific branding
-from branding import api as branding_api
+from lms.djangoapps.branding import api as branding_api
 from openedx.core.djangoapps.lang_pref.api import header_language_selector_is_enabled, released_languages
 %>
 

--- a/lms/urls.py
+++ b/lms/urls.py
@@ -104,7 +104,7 @@ urlpatterns = [
     url(r'', include('track.urls')),
 
     # Static template view endpoints like blog, faq, etc.
-    url(r'', include('static_template_view.urls')),
+    url(r'', include('lms.djangoapps.static_template_view.urls')),
 
     url(r'^heartbeat', include('openedx.core.djangoapps.heartbeat.urls')),
 
@@ -124,7 +124,7 @@ urlpatterns = [
     url(r'^search/', include('search.urls')),
 
     # Course API
-    url(r'^api/courses/', include('course_api.urls')),
+    url(r'^api/courses/', include('lms.djangoapps.course_api.urls')),
 
     # User API endpoints
     url(r'^api/user/', include('openedx.core.djangoapps.user_api.urls')),
@@ -139,10 +139,16 @@ urlpatterns = [
     # independently of courseware. https://github.com/edx/edx-val
     url(r'^api/val/v0/', include('edxval.urls')),
 
-    url(r'^api/commerce/', include(('commerce.api.urls', 'lms.djangoapps.commerce'), namespace='commerce_api')),
+    url(
+        r'^api/commerce/',
+        include(
+            ('lms.djangoapps.commerce.api.urls', 'lms.djangoapps.commerce'),
+            namespace='commerce_api',
+        ),
+    ),
     url(r'^api/credit/', include('openedx.core.djangoapps.credit.urls')),
     url(r'^api/toggles/', include('openedx.core.djangoapps.waffle_utils.urls')),
-    url(r'^rss_proxy/', include('rss_proxy.urls')),
+    url(r'^rss_proxy/', include('lms.djangoapps.rss_proxy.urls')),
     url(r'^api/organizations/', include('organizations.urls', namespace='organizations')),
 
     url(r'^catalog/', include(('openedx.core.djangoapps.catalog.urls', 'openedx.core.djangoapps.catalog'),
@@ -169,20 +175,26 @@ urlpatterns = [
     url(r'^api-admin/', include(('openedx.core.djangoapps.api_admin.urls', 'openedx.core.djangoapps.api_admin'),
                                 namespace='api_admin')),
 
-    url(r'^dashboard/', include('learner_dashboard.urls')),
-    url(r'^api/experiments/', include(('experiments.urls', 'lms.djangoapps.experiments'), namespace='api_experiments')),
+    url(r'^dashboard/', include('lms.djangoapps.learner_dashboard.urls')),
+    url(
+        r'^api/experiments/',
+        include(
+            ('lms.djangoapps.experiments.urls', 'lms.djangoapps.experiments'),
+            namespace='api_experiments',
+        ),
+    ),
     url(r'^api/discounts/', include(('openedx.features.discounts.urls', 'openedx.features.discounts'),
                                     namespace='api_discounts')),
 ]
 
 if settings.FEATURES.get('ENABLE_MOBILE_REST_API'):
     urlpatterns += [
-        url(r'^api/mobile/(?P<api_version>v(1|0.5))/', include('mobile_api.urls')),
+        url(r'^api/mobile/(?P<api_version>v(1|0.5))/', include('lms.djangoapps.mobile_api.urls')),
     ]
 
 if settings.FEATURES.get('ENABLE_OPENBADGES'):
     urlpatterns += [
-        url(r'^api/badges/v1/', include(('badges.api.urls', 'badges'), namespace='badges_api')),
+        url(r'^api/badges/v1/', include(('lms.djangoapps.badges.api.urls', 'badges'), namespace='badges_api')),
     ]
 
 urlpatterns += [
@@ -192,11 +204,11 @@ urlpatterns += [
 # sysadmin dashboard, to see what courses are loaded, to delete & load courses
 if settings.FEATURES.get('ENABLE_SYSADMIN_DASHBOARD'):
     urlpatterns += [
-        url(r'^sysadmin/', include('dashboard.sysadmin_urls')),
+        url(r'^sysadmin/', include('lms.djangoapps.dashboard.sysadmin_urls')),
     ]
 
 urlpatterns += [
-    url(r'^support/', include('support.urls')),
+    url(r'^support/', include('lms.djangoapps.support.urls')),
 ]
 
 # Favicon
@@ -611,7 +623,7 @@ urlpatterns += [
     # Branding API
     url(
         r'^api/branding/v1/',
-        include('branding.api_urls')
+        include('lms.djangoapps.branding.api_urls')
     ),
 
     # Course experience
@@ -694,7 +706,7 @@ if settings.FEATURES.get('ENABLE_DISCUSSION_SERVICE'):
     urlpatterns += [
         url(
             r'^api/discussion/',
-            include('discussion.rest_api.urls')
+            include('lms.djangoapps.discussion.rest_api.urls')
         ),
         url(
             r'^courses/{}/discussion/'.format(
@@ -708,7 +720,7 @@ if is_forum_daily_digest_enabled():
     urlpatterns += notification_prefs_urls
 
 urlpatterns += [
-    url(r'^bulk_email/', include('bulk_email.urls')),
+    url(r'^bulk_email/', include('lms.djangoapps.bulk_email.urls')),
 ]
 
 urlpatterns += [
@@ -764,7 +776,7 @@ if settings.DEBUG or settings.FEATURES.get('ENABLE_DJANGO_ADMIN_SITE'):
 
 if configuration_helpers.get_value('ENABLE_BULK_ENROLLMENT_VIEW', settings.FEATURES.get('ENABLE_BULK_ENROLLMENT_VIEW')):
     urlpatterns += [
-        url(r'^api/bulk_enroll/v1/', include('bulk_enroll.urls')),
+        url(r'^api/bulk_enroll/v1/', include('lms.djangoapps.bulk_enroll.urls')),
     ]
 
 # Course goals
@@ -784,7 +796,7 @@ if settings.FEATURES.get('EMBARGO'):
 
 # Survey Djangoapp
 urlpatterns += [
-    url(r'^survey/', include('survey.urls')),
+    url(r'^survey/', include('lms.djangoapps.survey.urls')),
 ]
 
 if settings.FEATURES.get('ENABLE_OAUTH2_PROVIDER'):
@@ -870,7 +882,7 @@ urlpatterns += [
 if settings.FEATURES.get('CUSTOM_COURSES_EDX'):
     urlpatterns += [
         url(r'^courses/{}/'.format(settings.COURSE_ID_PATTERN),
-            include('ccx.urls')),
+            include('lms.djangoapps.ccx.urls')),
         url(r'^api/ccx/', include(('lms.djangoapps.ccx.api.urls', 'lms.djangoapps.ccx'), namespace='ccx_api')),
     ]
 

--- a/openedx/features/content_type_gating/tests/test_access.py
+++ b/openedx/features/content_type_gating/tests/test_access.py
@@ -18,7 +18,7 @@ from django.contrib.auth.models import User
 from mock import patch, Mock
 from pyquery import PyQuery as pq
 
-from course_api.blocks.api import get_blocks
+from lms.djangoapps.course_api.blocks.api import get_blocks
 from course_modes.tests.factories import CourseModeFactory
 from lms.djangoapps.courseware.module_render import load_single_xblock
 from lms.djangoapps.courseware.tests.factories import (

--- a/openedx/features/course_experience/tests/views/test_course_home.py
+++ b/openedx/features/course_experience/tests/views/test_course_home.py
@@ -21,7 +21,7 @@ from waffle.testutils import override_flag
 
 from course_modes.models import CourseMode
 from course_modes.tests.factories import CourseModeFactory
-from experiments.models import ExperimentData
+from lms.djangoapps.experiments.models import ExperimentData
 from lms.djangoapps.commerce.models import CommerceConfiguration
 from lms.djangoapps.commerce.utils import EcommerceService
 from lms.djangoapps.course_goals.api import add_course_goal, remove_course_goal

--- a/openedx/features/course_experience/tests/views/test_course_outline.py
+++ b/openedx/features/course_experience/tests/views/test_course_outline.py
@@ -26,8 +26,8 @@ from waffle.testutils import override_switch
 
 from course_modes.models import CourseMode
 from course_modes.tests.factories import CourseModeFactory
-from gating import api as lms_gating_api
 from lms.djangoapps.course_api.blocks.transformers.milestones import MilestonesAndSpecialExamsTransformer
+from lms.djangoapps.gating import api as lms_gating_api
 from lms.djangoapps.courseware.tests.factories import StaffFactory
 from lms.djangoapps.courseware.tests.helpers import MasqueradeMixin
 from lms.djangoapps.experiments.testutils import override_experiment_waffle_flag

--- a/openedx/features/discounts/applicability.py
+++ b/openedx/features/discounts/applicability.py
@@ -20,7 +20,7 @@ from edx_toggles.toggles import WaffleFlag, WaffleFlagNamespace
 
 from course_modes.models import CourseMode
 from entitlements.models import CourseEntitlement
-from experiments.models import ExperimentData
+from lms.djangoapps.experiments.models import ExperimentData
 from lms.djangoapps.experiments.stable_bucketing import stable_bucketing_hash_group
 from openedx.features.discounts.models import DiscountPercentageConfig, DiscountRestrictionConfig
 from student.models import CourseEnrollment

--- a/openedx/features/discounts/tests/test_applicability.py
+++ b/openedx/features/discounts/tests/test_applicability.py
@@ -16,7 +16,7 @@ from mock import Mock, patch
 from course_modes.models import CourseMode
 from course_modes.tests.factories import CourseModeFactory
 from entitlements.tests.factories import CourseEntitlementFactory
-from experiments.models import ExperimentData
+from lms.djangoapps.experiments.models import ExperimentData
 from openedx.core.djangoapps.content.course_overviews.models import CourseOverview
 from openedx.features.discounts.models import DiscountRestrictionConfig
 from openedx.features.discounts.utils import REV1008_EXPERIMENT_ID

--- a/openedx/features/discounts/utils.py
+++ b/openedx/features/discounts/utils.py
@@ -12,7 +12,7 @@ from edx_django_utils.cache import RequestCache
 from web_fragments.fragment import Fragment
 
 from course_modes.models import format_course_price, get_course_prices
-from experiments.models import ExperimentData
+from lms.djangoapps.experiments.models import ExperimentData
 from lms.djangoapps.courseware.utils import verified_upgrade_deadline_link
 from openedx.core.djangoapps.content.course_overviews.models import CourseOverview
 from openedx.core.djangolib.markup import HTML, Text

--- a/openedx/features/discounts/views.py
+++ b/openedx/features/discounts/views.py
@@ -16,7 +16,7 @@ from rest_framework.permissions import IsAdminUser
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
-from experiments.models import ExperimentData
+from lms.djangoapps.experiments.models import ExperimentData
 from openedx.core.djangoapps.content.course_overviews.models import CourseOverview
 from openedx.core.djangoapps.cors_csrf.decorators import ensure_csrf_cookie_cross_domain
 from openedx.core.djangoapps.oauth_dispatch.jwt import create_jwt_for_user

--- a/openedx/features/learner_profile/views/learner_profile.py
+++ b/openedx/features/learner_profile/views/learner_profile.py
@@ -12,7 +12,7 @@ from django.utils.translation import ugettext as _
 from django.views.decorators.http import require_http_methods
 from django_countries import countries
 
-from badges.utils import badges_enabled
+from lms.djangoapps.badges.utils import badges_enabled
 from edxmako.shortcuts import marketing_link
 from openedx.core.djangoapps.credentials.utils import get_credentials_records_url
 from openedx.core.djangoapps.programs.models import ProgramsApiConfig

--- a/openedx/tests/settings.py
+++ b/openedx/tests/settings.py
@@ -13,7 +13,7 @@ from path import Path
 # TODO: Remove the rest of the sys.path modification here and in (cms|lms)/envs/common.py
 REPO_ROOT = Path(__file__).abspath().dirname().dirname().dirname()  # /edx-platform/
 sys.path.append(REPO_ROOT / 'common' / 'djangoapps')
-sys.path.append(REPO_ROOT / 'import_shims' / 'lms')
+# sys.path.append(REPO_ROOT / 'import_shims' / 'lms')
 
 ALL_LANGUAGES = []
 

--- a/pylintrc
+++ b/pylintrc
@@ -71,7 +71,7 @@
 ignore = ,.git,.tox,migrations,node_modules,.pycharm_helpers
 persistent = yes
 load-plugins = edx_lint.pylint,pylint_django,pylint_celery
-init-hook = "import sys; sys.path.extend(['import_shims/lms', 'import_shims/studio', 'common/djangoapps'])"
+init-hook = "import sys; sys.path.extend(['common/djangoapps'])"
 
 [MESSAGES CONTROL]
 enable = 

--- a/themes/edx.org/lms/templates/footer.html
+++ b/themes/edx.org/lms/templates/footer.html
@@ -4,7 +4,7 @@
   import datetime
 
   from django.utils.translation import ugettext as _
-  from branding.api import get_footer
+  from lms.djangoapps.branding.api import get_footer
   from openedx.core.djangoapps.lang_pref.api import footer_language_selector_is_enabled
 %>
 <% footer = get_footer(is_secure=is_secure, language=language) %>


### PR DESCRIPTION
I am curious whether LMS tests would pass on https://github.com/edx/edx-platform/pull/25401 if the import shims were to be removed.