### PR TITLE
Use AppConfigs to ensure task discovery in bulk_email, ccxcon, bookmarks

### DIFF
--- a/lms/djangoapps/bulk_email/apps.py
+++ b/lms/djangoapps/bulk_email/apps.py
@@ -6,3 +6,9 @@ class BulkEmailConfig(AppConfig):
     Application Configuration for bulk_email.
     """
     name = u'lms.djangoapps.bulk_email'
+
+    def ready(self):
+        """
+        Ensure tasks are registered and signals connected.
+        """
+        from . import signals, tasks  # pylint: disable=unused-import

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -2477,7 +2477,7 @@ INSTALLED_APPS = [
     'lms.djangoapps.dashboard',
     'lms.djangoapps.instructor_task',
     'openedx.core.djangoapps.course_groups',
-    'lms.djangoapps.bulk_email',
+    'lms.djangoapps.bulk_email.apps.BulkEmailConfig',
     'lms.djangoapps.branding',
 
     # New (Blockstore-based) XBlock runtime

--- a/openedx/core/djangoapps/bookmarks/apps.py
+++ b/openedx/core/djangoapps/bookmarks/apps.py
@@ -34,5 +34,5 @@ class BookmarksConfig(AppConfig):
     }
 
     def ready(self):
-        # Register the signals handled by bookmarks.
-        from . import signals
+        # Register the signals handled and tasks dispatched by bookmarks.
+        from . import signals, tasks

--- a/openedx/core/djangoapps/ccxcon/apps.py
+++ b/openedx/core/djangoapps/ccxcon/apps.py
@@ -11,4 +11,4 @@ class CCXConnectorConfig(AppConfig):
     verbose_name = "CCX Connector"
 
     def ready(self):
-        from . import signals
+        from . import signals, tasks


### PR DESCRIPTION
```
This intends to further fix issues where some Celery tasks are
not being registered. We'd previously relied on auto-discovery
of many Celery tasks, but since the Celery 4 upgrade, it seems
that we need to explicitly ensure that `tasks.py` modules are
loaded by Celery workers.

We do this by:
* making sure an AppConfig subclass is declared in `apps.py` of each app,
* making sure it defines a `ready` method that imports `.tasks`, and
* making sure that INSTALLED_APPS points to the AppConfig subclass OR
  making sure that the app is installed as a Django app plugin via the
  AppConfig subclass.
```

For `bulk_email`, we fix its AppConfig and point INSTALLED_APPS at it.

For `ccxcon`, which is added to INSTALLED_APPS in cms/envs/production.py, we just need to fix its AppConfig.

For `ccxcon`, which is added to INSTALLED_APPS via the Django plugin framework, we just need to fix its AppConfig.

Previous PR: https://github.com/edx/edx-platform/pull/25441

https://openedx.atlassian.net/browse/TNL-7652