### PR TITLE
Fix bug in most recent verification on LMS dashboard

### DIFF
--- a/lms/djangoapps/verify_student/utils.py
+++ b/lms/djangoapps/verify_student/utils.py
@@ -86,9 +86,12 @@ def verification_for_datetime(deadline, candidates):
     # Otherwise, look for a verification that was in effect at the deadline,
     # preferring recent verifications.
     # If no such verification is found, implicitly return `None`
-    for verification in candidates:
-        if verification.active_at_datetime(deadline):
-            return verification
+    verifications_map = {
+        verification: getattr(verification, 'created_at')
+        for verification in candidates
+        if verification.active_at_datetime(deadline)
+    }
+    return max(verifications_map, key=lambda k: verifications_map[k]) if verifications_map else None
 
 
 def most_recent_verification(photo_id_verifications, sso_id_verifications, manual_id_verifications, most_recent_key):


### PR DESCRIPTION
When I read the docstring of `verification_for_datetime`, it states the following.

```Find a verification in a set that applied during a particular DateTime.

Verification is considered "active" during a DateTime if:
    1) The verification was created before the DateTime, and
    2) The verification is set to expire after the DateTime.

    Note that verification status is *not* considered here,
    just the start/expire dates.

    If multiple verifications were active at the deadline,
    returns the most recently created one.
```

The key thing to note here is that *If multiple verifications were active at the deadline,  returns the most recently created one.*

This PR updates the code to handle an edge case where multiple verifications were active during a course deadline, and it will return the most recently created verification. 


[MST-462](https://openedx.atlassian.net/browse/MST-462)