### PR TITLE
REV-1564: add user-metadata API

### DIFF
--- a/common/djangoapps/student/views/dashboard.py
+++ b/common/djangoapps/student/views/dashboard.py
@@ -29,7 +29,7 @@ from edxmako.shortcuts import render_to_response, render_to_string
 from entitlements.models import CourseEntitlement
 from lms.djangoapps.commerce.utils import EcommerceService
 from lms.djangoapps.courseware.access import has_access
-from lms.djangoapps.experiments.utils import get_dashboard_course_info
+from lms.djangoapps.experiments.utils import get_dashboard_course_info, get_experiment_user_metadata_context
 from lms.djangoapps.verify_student.services import IDVerificationService
 from openedx.core.djangoapps.catalog.utils import (
     get_programs,
@@ -805,6 +805,13 @@ def student_dashboard(request):
     )
     context.update(context_from_plugins)
 
+    course = None
+    context.update(
+        get_experiment_user_metadata_context(
+            course,
+            user,
+        )
+    )
     if ecommerce_service.is_enabled(request.user):
         context.update({
             'use_ecommerce_payment_flow': True,

--- a/lms/djangoapps/experiments/permissions.py
+++ b/lms/djangoapps/experiments/permissions.py
@@ -29,3 +29,13 @@ class IsStaffOrOwner(permissions.IsStaffOrOwner):
 class IsStaffOrReadOnly(BasePermission):
     def has_permission(self, request, view):
         return request.user.is_staff or request.method in SAFE_METHODS
+
+
+class IsStaffOrReadOnlyForSelf(BasePermission):
+    """
+    Grants access to staff or to user reading info about their own user
+    """
+    def has_permission(self, request, view):
+        username = request.user.username
+        return request.user.is_staff or (request.method in SAFE_METHODS and (
+            username == request.parser_context['kwargs']['username']))

--- a/lms/djangoapps/experiments/tests/test_utils.py
+++ b/lms/djangoapps/experiments/tests/test_utils.py
@@ -2,21 +2,26 @@
 Tests of experiment functionality
 """
 
-
+from datetime import timedelta
 from decimal import Decimal
+from django.utils.timezone import now
 from unittest import TestCase
 
 from opaque_keys.edx.keys import CourseKey
-
+from lms.djangoapps.course_blocks.transformers.tests.helpers import ModuleStoreTestCase
+from lms.djangoapps.courseware import courses
 from lms.djangoapps.experiments.utils import (
     get_course_entitlement_price_and_sku,
+    get_experiment_user_metadata_context,
     get_program_price_and_skus,
     get_unenrolled_courses,
     is_enrolled_in_course_run
 )
+from student.tests.factories import CourseEnrollmentFactory, UserFactory
+from xmodule.modulestore.tests.factories import CourseFactory
 
 
-class ExperimentUtilsTests(TestCase):
+class ExperimentUtilsTests(ModuleStoreTestCase, TestCase):
     """
     Tests of experiment functionality
     """
@@ -116,3 +121,38 @@ class ExperimentUtilsTests(TestCase):
         self.assertEqual(2, len(skus))
         self.assertIn(self.run_a_sku, skus)
         self.assertIn(self.entitlement_a_sku, skus)
+
+    def test_get_experiment_user_metadata_context(self):
+        course = CourseFactory.create(start=now() - timedelta(days=30), pacing_type="instructor_paced", course_duration=None, upgrade_price='Free',
+                                      upgrade_link=None, enrollment_mode=None, audit_access_deadline=None, program_key_fields=None, schedule_start=None,
+                                      enrollment_time=None, dynamic_upgrade_deadline=None, course_upgrade_deadline=None, course_key_fields={'org': 'org.0', 'course': 'course_0', 'run': 'Run_0'})
+        user = UserFactory()
+        context = get_experiment_user_metadata_context(course, user)
+        CourseEnrollmentFactory(course_id=course.id, user=user)
+
+        user_metadata_expected_result = {'username': user.username,
+                                         'user_id': user.id,
+                                         'course_id': course.id,
+                                         'enrollment_mode': course.enrollment_mode,
+                                         'upgrade_link': course.upgrade_link,
+                                         'upgrade_price': course.upgrade_price,
+                                         'audit_access_deadline': course.audit_access_deadline,
+                                         'course_duration': course.course_duration,
+                                         'pacing_type': course.pacing_type,
+                                         'has_staff_access': False,
+                                         'forum_roles': [],
+                                         'partition_groups': {},
+                                         'has_non_audit_enrollments': False,
+                                         'program_key_fields': course.program_key_fields,
+                                         'email': user.email,
+                                         'schedule_start': course.schedule_start,
+                                         'enrollment_time': course.enrollment_time,
+                                         'course_start': course.start,
+                                         'course_end': course.end,
+                                         'dynamic_upgrade_deadline': course.dynamic_upgrade_deadline,
+                                         'course_upgrade_deadline': course.course_upgrade_deadline,
+                                         'course_key_fields': course.course_key_fields}
+
+        user_metadata = context.get('user_metadata')
+
+        self.assertTrue(user_metadata, user_metadata_expected_result)

--- a/lms/djangoapps/experiments/tests/test_views.py
+++ b/lms/djangoapps/experiments/tests/test_views.py
@@ -304,3 +304,13 @@ class ExperimentUserMetaDataViewTests(APITestCase, ModuleStoreTestCase):
         call_args = [user.username, course.id]
         response = self.client.get(reverse('api_experiments:user_metadata', args=call_args))
         self.assertEqual(response.status_code, 200)
+
+        call_args_with_bogus_user = ['bugsbunny', course.id]
+        response = self.client.get(reverse('api_experiments:user_metadata', args=call_args_with_bogus_user))
+        self.assertEqual(response.status_code, 404)
+        self.assertEqual(response.json()['message'], 'Provided user is not found')
+
+        call_args_with_bogus_course = [user.username, 'course-v1:edX+DemoX+Demo_BOGUS']
+        response = self.client.get(reverse('api_experiments:user_metadata', args=call_args_with_bogus_course))
+        self.assertEqual(response.status_code, 404)
+        self.assertEqual(response.json()['message'], 'Provided course is not found')

--- a/lms/djangoapps/experiments/tests/test_views.py
+++ b/lms/djangoapps/experiments/tests/test_views.py
@@ -319,6 +319,10 @@ class ExperimentUserMetaDataViewTests(APITestCase, ModuleStoreTestCase):
 
         response = self.client.get(reverse('api_experiments:user_metadata', args=call_args))
         self.assertEqual(response.status_code, 200)
+        self.assertTrue(response.json()['course_id'])
+        self.assertTrue(response.json()['user_id'])
+        self.assertEqual(response.json()['username'], lookup_user.username)
+        self.assertEqual(response.json()['email'], lookup_user.email)
 
     def test_UserMetaDataView_get_different_user(self):
         """ Request fails when not logged in for requested user or staff  """
@@ -335,8 +339,9 @@ class ExperimentUserMetaDataViewTests(APITestCase, ModuleStoreTestCase):
         lookup_course = CourseFactory.create(start=now() - timedelta(days=30))
         call_args = [lookup_user.username, lookup_course.id]
         self.client.login(username=lookup_user.username, password=UserFactory._DEFAULT_PASSWORD)
+        bogus_course_name = str(lookup_course.id) + '_FOOBAR'
 
-        call_args_with_bogus_course = [lookup_user.username, 'course-v1:edX+DemoX+Demo_BOGUS']
+        call_args_with_bogus_course = [lookup_user.username, bogus_course_name]
         response = self.client.get(reverse('api_experiments:user_metadata', args=call_args_with_bogus_course))
         self.assertEqual(response.status_code, 404)
         self.assertEqual(response.json()['message'], 'Provided course is not found')

--- a/lms/djangoapps/experiments/urls.py
+++ b/lms/djangoapps/experiments/urls.py
@@ -2,7 +2,7 @@
 Experimentation URLs
 """
 
-
+from django.conf import settings
 from django.conf.urls import include, url
 
 from . import routers, views, views_custom
@@ -14,4 +14,7 @@ router.register(r'key-value', views.ExperimentKeyValueViewSet, basename='key_val
 urlpatterns = [
     url(r'^v0/custom/REV-934/', views_custom.Rev934.as_view(), name='rev_934'),
     url(r'^v0/', include((router.urls, "api"), namespace='v0')),
+    url(r'^v0/custom/userMetadata/{username},{course_key}$'.format(
+        username=settings.USERNAME_PATTERN,
+        course_key=settings.COURSE_ID_PATTERN), views.UserMetaDataView.as_view(), name='user_metadata'),
 ]

--- a/lms/djangoapps/experiments/utils.py
+++ b/lms/djangoapps/experiments/utils.py
@@ -264,7 +264,7 @@ def get_dashboard_course_info(user, dashboard_enrollments):
 
 def get_experiment_user_metadata_context(course, user):
     """
-    Return a context dictionary with the keys used by the user_metadata.html.
+    Return a context dictionary with the keys used for Optimizely experiments, exposed via user_metadata.html
     """
     enrollment = None
     # TODO: clean up as part of REVO-28 (START)

--- a/lms/djangoapps/experiments/utils.py
+++ b/lms/djangoapps/experiments/utils.py
@@ -264,7 +264,8 @@ def get_dashboard_course_info(user, dashboard_enrollments):
 
 def get_experiment_user_metadata_context(course, user):
     """
-    Return a context dictionary with the keys used for Optimizely experiments, exposed via user_metadata.html
+    Return a context dictionary with the keys used for Optimizely experiments, exposed via user_metadata.html:
+    view from the DOM in those calling views using: JSON.parse($("#user-metadata").text());
     Most views call this function with both parameters, but student dashboard has only a user
     """
     enrollment = None

--- a/lms/djangoapps/experiments/utils.py
+++ b/lms/djangoapps/experiments/utils.py
@@ -410,10 +410,7 @@ def get_program_context(course, user_enrollments):
 # TODO: clean up as part of REVEM-199 (START)
 
 
-from opaque_keys.edx.keys import CourseKey
-import six
-
-def generate_processed_user_metadata(context, user, course, course_id): 
+def generate_processed_user_metadata(context, user, course, course_id):
     user_metadata = {
         key: context.get(key)
         for key in (

--- a/lms/djangoapps/experiments/utils.py
+++ b/lms/djangoapps/experiments/utils.py
@@ -408,3 +408,77 @@ def get_program_context(course, user_enrollments):
             }
     return program_key
 # TODO: clean up as part of REVEM-199 (START)
+
+
+from opaque_keys.edx.keys import CourseKey
+import six
+
+def generate_processed_user_metadata(context, user, course, course_id): 
+    user_metadata = {
+        key: context.get(key)
+        for key in (
+            'username',
+            'user_id',
+            'course_id',
+            'enrollment_mode',
+            'upgrade_link',
+            'upgrade_price',
+            'audit_access_deadline',
+            'course_duration',
+            'pacing_type',
+            'has_staff_access',
+            'forum_roles',
+            'partition_groups',
+            # TODO: clean up as part of REVO-28 (START)
+            'has_non_audit_enrollments',
+            # TODO: clean up as part of REVO-28 (END)
+            # TODO: clean up as part of REVEM-199 (START)
+            'program_key_fields',
+            # TODO: clean up as part of REVEM-199 (END)
+        )
+    }
+
+    if user:
+        user_metadata['username'] = user.username
+        user_metadata['user_id'] = user.id
+        if hasattr(user, 'email'):
+            user_metadata['email'] = user.email
+
+    for datekey in (
+            'schedule_start',
+            'enrollment_time',
+            'course_start',
+            'course_end',
+            'dynamic_upgrade_deadline',
+            'course_upgrade_deadline',
+            'audit_access_deadline',
+    ):
+        user_metadata[datekey] = (
+            context.get(datekey).isoformat() if context.get(datekey) else None
+        )
+
+    for timedeltakey in (
+        'course_duration',
+    ):
+        user_metadata[timedeltakey] = (
+            context.get(timedeltakey).total_seconds() if context.get(timedeltakey) else None
+        )
+
+    course_key = context.get('course_key')
+    if course and not course_key:
+        course_key = course.id
+
+    if course_key:
+        if isinstance(course_key, CourseKey):
+            user_metadata['course_key_fields'] = {
+                'org': course_key.org,
+                'course': course_key.course,
+                'run': course_key.run,
+            }
+
+            if not course_id:
+                user_metadata['course_id'] = six.text_type(course_key)
+        elif isinstance(course_key, six.string_types):
+            user_metadata['course_id'] = course_key
+
+    return user_metadata

--- a/lms/djangoapps/experiments/views.py
+++ b/lms/djangoapps/experiments/views.py
@@ -17,7 +17,7 @@ from util.json_request import JsonResponse
 from experiments import filters, serializers
 from experiments.models import ExperimentData, ExperimentKeyValue
 from experiments.permissions import IsStaffOrOwner, IsStaffOrReadOnly
-from experiments.utils import get_experiment_user_metadata_context, generate_processed_user_metadata
+from experiments.utils import get_experiment_user_metadata_context
 from openedx.core.djangoapps.cors_csrf.authentication import SessionAuthenticationCrossDomainCsrf
 from student.models import get_user_by_username_or_email
 
@@ -98,6 +98,6 @@ class UserMetaDataView(APIView):
         user = get_user_by_username_or_email(username)
         course_key = CourseKey.from_string(course_id)
         course = courses.get_course_by_id(course_key)
-        data = get_experiment_user_metadata_context(course, user)
-        processed_data = generate_processed_user_metadata(data, user, course, course_id)
-        return JsonResponse(processed_data)
+        context = get_experiment_user_metadata_context(course, user)
+        user_metadata = context.get('user_metadata')
+        return JsonResponse(user_metadata)

--- a/lms/djangoapps/experiments/views.py
+++ b/lms/djangoapps/experiments/views.py
@@ -102,6 +102,7 @@ class UserMetaDataView(APIView):
         try:
             user = get_user_by_username_or_email(username)
         except User.DoesNotExist:
+            # Note: this will only be seen by staff, for administrative de-bugging purposes
             message = "Provided user is not found"
             return JsonResponse({'message': message}, status=404)
 

--- a/lms/djangoapps/experiments/views.py
+++ b/lms/djangoapps/experiments/views.py
@@ -18,7 +18,7 @@ from util.json_request import JsonResponse
 
 from experiments import filters, serializers
 from experiments.models import ExperimentData, ExperimentKeyValue
-from experiments.permissions import IsStaffOrOwner, IsStaffOrReadOnly
+from experiments.permissions import IsStaffOrOwner, IsStaffOrReadOnly, IsStaffOrReadOnlyForSelf
 from experiments.utils import get_experiment_user_metadata_context
 from openedx.core.djangoapps.cors_csrf.authentication import SessionAuthenticationCrossDomainCsrf
 from student.models import get_user_by_username_or_email
@@ -95,7 +95,7 @@ class ExperimentKeyValueViewSet(viewsets.ModelViewSet):
 
 class UserMetaDataView(APIView):
     authentication_classes = (JwtAuthentication, ExperimentCrossDomainSessionAuth,)
-    permission_classes = (IsStaffOrReadOnly,)
+    permission_classes = (IsStaffOrReadOnlyForSelf,)
 
     def get(self, request, course_id=None, username=None):
         """ Return user-metadata for the given course and user """

--- a/lms/djangoapps/experiments/views.py
+++ b/lms/djangoapps/experiments/views.py
@@ -2,6 +2,7 @@
 Experimentation views
 """
 
+
 from django.contrib.auth import get_user_model
 from django.db import transaction
 from django_filters.rest_framework import DjangoFilterBackend
@@ -92,12 +93,13 @@ class ExperimentKeyValueViewSet(viewsets.ModelViewSet):
 
 
 class UserMetaDataView(APIView):
+    authentication_classes = (JwtAuthentication, ExperimentCrossDomainSessionAuth,)
+    permission_classes = (IsStaffOrReadOnly,)
 
     def get(self, request, course_id=None, username=None):
         """ Return user-metadata for the given course and user """
         user = get_user_by_username_or_email(username)
-        course_key = CourseKey.from_string(course_id)
-        course = courses.get_course_by_id(course_key)
+        course = courses.get_course_by_id(CourseKey.from_string(course_id))
         context = get_experiment_user_metadata_context(course, user)
         user_metadata = context.get('user_metadata')
         return JsonResponse(user_metadata)

--- a/lms/templates/experiments/user_metadata.html
+++ b/lms/templates/experiments/user_metadata.html
@@ -1,78 +1,13 @@
 <%page expression_filter="h"/>
 <%!
+from experiments.utils import generate_processed_user_metadata
 from openedx.core.djangolib.js_utils import dump_js_escaped_json
 from eventtracking import tracker
 from opaque_keys.edx.keys import CourseKey
 import six
 %>
 <%
-user_metadata = {
-    key: context.get(key)
-    for key in (
-        'username',
-        'user_id',
-        'course_id',
-        'enrollment_mode',
-        'upgrade_link',
-        'upgrade_price',
-        'audit_access_deadline',
-        'course_duration',
-        'pacing_type',
-        'has_staff_access',
-        'forum_roles',
-        'partition_groups',
-        # TODO: clean up as part of REVO-28 (START)
-        'has_non_audit_enrollments',
-        # TODO: clean up as part of REVO-28 (END)
-        # TODO: clean up as part of REVEM-199 (START)
-        'program_key_fields',
-        # TODO: clean up as part of REVEM-199 (END)
-    )
-}
-
-if user:
-    user_metadata['username'] = user.username
-    user_metadata['user_id'] = user.id
-    if hasattr(user, 'email'):
-        user_metadata['email'] = user.email
-
-for datekey in (
-        'schedule_start',
-        'enrollment_time',
-        'course_start',
-        'course_end',
-        'dynamic_upgrade_deadline',
-        'course_upgrade_deadline',
-        'audit_access_deadline',
-):
-    user_metadata[datekey] = (
-        context.get(datekey).isoformat() if context.get(datekey) else None
-    )
-
-for timedeltakey in (
-    'course_duration',
-):
-    user_metadata[timedeltakey] = (
-        context.get(timedeltakey).total_seconds() if context.get(timedeltakey) else None
-    )
-
-course_key = context.get('course_key')
-if course and not course_key:
-    course_key = course.id
-
-if course_key:
-    if isinstance(course_key, CourseKey):
-        user_metadata['course_key_fields'] = {
-            'org': course_key.org,
-            'course': course_key.course,
-            'run': course_key.run,
-        }
-
-        if not course_id:
-            user_metadata['course_id'] = six.text_type(course_key)
-    elif isinstance(course_key, six.string_types):
-        user_metadata['course_id'] = course_key
-
+user_metadata = generate_processed_user_metadata(context, user, course, course_id)
 %>
 <script type="application/json" id="user-metadata">
     ${user_metadata | n, dump_js_escaped_json}

--- a/lms/templates/experiments/user_metadata.html
+++ b/lms/templates/experiments/user_metadata.html
@@ -1,13 +1,12 @@
 <%page expression_filter="h"/>
 <%!
-from experiments.utils import generate_processed_user_metadata
 from openedx.core.djangolib.js_utils import dump_js_escaped_json
 from eventtracking import tracker
 from opaque_keys.edx.keys import CourseKey
 import six
 %>
 <%
-user_metadata = generate_processed_user_metadata(context, user, course, course_id)
+user_metadata = context.get('user_metadata')
 %>
 <script type="application/json" id="user-metadata">
     ${user_metadata | n, dump_js_escaped_json}


### PR DESCRIPTION
Our Optimizely experiments make use of values saved to the user-metadata DOM object, which isn't available in the new courseware MFE. We need an endpoint we can call with a course and user, and get back the same user-metadata values typically available in that DOM object. 

Changes in this PR to meet that goal:
Today the user-metadata fields are set in user_metadata.html and dumped into the page json. In this PR, I:
- move that logic into get_experiment_user_metadata_context() and save that user_metadata into the context
- update user_metadata.html to now just grab it from the context
- add an endpoint to call get_experiment_user_metadata_context and return its user-metadata value
- added primitive tests for the view and the updated function
- course_dashboard (which has a user but no selected course) makes a bare-bones version of user_metadata with just the user info. It was previously getting this from the code in user_metadata.html. Now that the logic lives in get_experiment_user_metadata_context, I've updated that view to call it and confirmed that the user-metadata is appearing on the various pages as before
- added a new permission level for this to use, so calls to this API will only return results if the requester logged in is staff or the same user we're getting data for (Optimizely will call on the logged-in user's behalf)

The next step when this is merged will be call this from Optimizely, which may involve authentication/permissions updates

Relevant ticket: https://openedx.atlassian.net/browse/REV-1564