### PR TITLE
MST-400 Always return the latest approved valid ID verification

### DIFF
--- a/lms/djangoapps/verify_student/models.py
+++ b/lms/djangoapps/verify_student/models.py
@@ -140,7 +140,7 @@ class IDVerificationAttempt(StatusModel):
 
         """
         return (
-            self.created_at < deadline and
+            self.created_at <= deadline and
             self.expiration_datetime > now()
         )
 
@@ -353,11 +353,11 @@ class PhotoVerification(IDVerificationAttempt):
         return self.error_msg
 
     @status_before_must_be("created")
-    def upload_face_image(self, img):
+    def upload_face_image(self, img_data):
         raise NotImplementedError
 
     @status_before_must_be("created")
-    def upload_photo_id_image(self, img):
+    def upload_photo_id_image(self, img_data):
         raise NotImplementedError
 
     @status_before_must_be("created")
@@ -390,7 +390,7 @@ class PhotoVerification(IDVerificationAttempt):
         # At any point prior to this, they can change their names via their
         # student dashboard. But at this point, we lock the value into the
         # attempt.
-        self.name = self.user.profile.name
+        self.name = self.user.profile.name  # pylint: disable=no-member
         self.status = self.STATUS.ready
         self.save()
 


### PR DESCRIPTION
@edx/masters-devs-cosmonauts Please review

With this PR, I am returning the latest approved ID verification regardless of the new attempt status. This means, if a learner have a valid non-expired approved IDV attempt, when they create a new attempt in `submitted` status, they will not be blocked from attempting proctoring exams.

This is the first PR of a series of PRs I am going to work on in this area.