### PR TITLE
fix update assets

### DIFF
--- a/common/lib/xmodule/xmodule/course_module.py
+++ b/common/lib/xmodule/xmodule/course_module.py
@@ -49,7 +49,8 @@ DEFAULT_COURSE_VISIBILITY_IN_CATALOG = getattr(
 )
 
 DEFAULT_MOBILE_AVAILABLE = getattr(settings, 'DEFAULT_MOBILE_AVAILABLE', False)
-EXAM_SETTINGS_HTML_VIEW_ENABLED = settings.FEATURES.get('ENABLE_EXAM_SETTINGS_HTML_VIEW', False)
+# Note: updating assets does not have settings defined, so using `getattr`.
+EXAM_SETTINGS_HTML_VIEW_ENABLED = getattr(settings, 'FEATURES', {}).get('ENABLE_EXAM_SETTINGS_HTML_VIEW', False)
 
 COURSE_VISIBILITY_PRIVATE = 'private'
 COURSE_VISIBILITY_PUBLIC_OUTLINE = 'public_outline'


### PR DESCRIPTION
An xmodule file that is loaded during update_assets,
which doesn't load settings, was referring to the FEATURES setting
without checking if it existed.