### PR TITLE
Squash lms_initialization deprecated import warning

### DIFF
--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -2425,7 +2425,7 @@ INSTALLED_APPS = [
     'openedx.core.djangoapps.common_initialization.apps.CommonInitializationConfig',
 
     # LMS-specific Initialization
-    'lms_initialization.apps.LMSInitializationConfig',
+    'lms.djangoapps.lms_initialization.apps.LMSInitializationConfig',
 
     # Common views
     'openedx.core.djangoapps.common_views',


### PR DESCRIPTION
This helps us get rid of the following warnings:

```
2020-10-27 19:35:33,521 WARNING 128 [py.warnings] [user None] [ip None] warnings.py:109 - /edx/app/edxapp/venvs/edxapp/lib/python3.8/importlib/__init__.py:127: SysPathHackWarning: Importing 
lms_initialization instead of lms.djangoapps.lms_initialization is deprecated                                                                                                                 
2020-10-27 19:35:33,529 WARNING 128 [py.warnings] [user None] [ip None] warnings.py:109 - /edx/app/edxapp/venvs/edxapp/lib/python3.8/importlib/__init__.py:127: SysPathHackWarning: Importing 
lms_initialization.apps instead of lms.djangoapps.lms_initialization.apps is deprecated  
```