### PR TITLE
Don't install instructor_task for common testing.

### DIFF
--- a/lms/djangoapps/instructor_task/apps.py
+++ b/lms/djangoapps/instructor_task/apps.py
@@ -12,5 +12,4 @@ class InstructorTaskConfig(AppConfig):
     name = u'lms.djangoapps.instructor_task'
 
     def ready(self):
-        # noinspection PyUnresolvedReferences
-        from . import tasks  # pylint: disable=unused-import
+        pass

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -2233,7 +2233,10 @@ DEBUG_TOOLBAR_PATCH_SETTINGS = False
 # Celery's task autodiscovery won't find tasks nested in a tasks package.
 # Tasks are only registered when the module they are defined in is imported.
 CELERY_IMPORTS = (
-    'poll.tasks'
+    'poll.tasks',
+    'lms.djangoapps.instructor_task.tasks',
+    'lms.djangoapps.bulk_email.tasks',
+    'openedx.core.djangoapps.bookmarks.tasks',
 )
 
 # Message configuration

--- a/openedx/tests/settings.py
+++ b/openedx/tests/settings.py
@@ -71,6 +71,7 @@ INSTALLED_APPS = (
     'openedx.core.djangoapps.bookmarks.apps.BookmarksConfig',
     'edxval',
     'lms.djangoapps.courseware',
+    'lms.djangoapps.instructor_task',
     'student',
     'openedx.core.djangoapps.site_configuration',
     'lms.djangoapps.grades.apps.GradesConfig',

--- a/openedx/tests/settings.py
+++ b/openedx/tests/settings.py
@@ -71,7 +71,6 @@ INSTALLED_APPS = (
     'openedx.core.djangoapps.bookmarks.apps.BookmarksConfig',
     'edxval',
     'lms.djangoapps.courseware',
-    'lms.djangoapps.instructor_task',
     'student',
     'openedx.core.djangoapps.site_configuration',
     'lms.djangoapps.grades.apps.GradesConfig',


### PR DESCRIPTION
We shouldn't need to access the instructor tasks and load them as a
part of the common testing.  Loading it here now that we load the
tasks.py module as a part of setting up this app causes a bunch of
downstream apps to be loaded.  None of which should be need for
common testing.