### PR TITLE
Add ability to manually fail instructor tasks in batches.

### DIFF
--- a/lms/djangoapps/instructor_task/admin.py
+++ b/lms/djangoapps/instructor_task/admin.py
@@ -5,8 +5,6 @@ This will mostly involve searching by course_id or task_id and manually failing
 a task.
 
 """
-
-
 from config_models.admin import ConfigurationModelAdmin
 from django.contrib import admin
 
@@ -14,9 +12,21 @@ from .config.models import GradeReportSetting
 from .models import InstructorTask
 
 
+def mark_tasks_as_failed(modeladmin, request, queryset):
+    queryset.update(
+        task_state='FAILURE',
+        task_output='{}',
+        task_key='dummy_task_key',
+    )
+
+mark_tasks_as_failed.short_description = "Mark Tasks as Failed"
+
+
 class InstructorTaskAdmin(admin.ModelAdmin):
+    actions = [mark_tasks_as_failed]
     list_display = [
         'task_id',
+        'task_state',
         'task_type',
         'course_id',
         'username',


### PR DESCRIPTION
When an InstructorTask is stuck in QUEUING (say if there was a problem with celery), the support team needs to manually intervene and mark the task as "FAILED" so that new tasks of that type can be created for that course. This is usually done one at a time, but sometimes a bug or outage might cause many tasks to fail at once, making recovery extremely cumbersome. This commit adds the ability to do this process in batches.

![before](https://user-images.githubusercontent.com/41625/97392262-b7ffab80-18b7-11eb-9e78-a625ac38a44b.png)

![after](https://user-images.githubusercontent.com/41625/97392275-bdf58c80-18b7-11eb-9fb4-6af0734ef47c.png)
