### PR TITLE
add constraint for edx-search<2.0.0

### DIFF
--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -37,6 +37,9 @@ drf-yasg<1.17.1
 # for them.
 edx-enterprise==3.9.6
 
+# v2 requires the ES7 upgrade work to be complete
+edx-search<2.0.0
+
 # Upgrading to 2.12.0 breaks several test classes due to API changes, need to update our code accordingly
 factory-boy==2.8.1
 


### PR DESCRIPTION
constraining edx-search because 2.0.0 requires
ES7 upgrade work to be complete.