### PR TITLE
Use the default autodiscovery instead of passing in the installed apps.

### DIFF
--- a/cms/celery.py
+++ b/cms/celery.py
@@ -22,7 +22,7 @@ APP.conf.task_protocol = 1
 # Using a string here means the worker will not have to
 # pickle the object when using Windows.
 APP.config_from_object('django.conf:settings')
-APP.autodiscover_tasks(lambda: settings.INSTALLED_APPS)
+APP.autodiscover_tasks()
 
 
 class Router(AlternateEnvironmentRouter):

--- a/lms/celery.py
+++ b/lms/celery.py
@@ -22,7 +22,7 @@ APP.conf.task_protocol = 1
 # Using a string here means the worker will not have to
 # pickle the object when using Windows.
 APP.config_from_object('django.conf:settings')
-APP.autodiscover_tasks(lambda: settings.INSTALLED_APPS)
+APP.autodiscover_tasks()
 
 
 class Router(AlternateEnvironmentRouter):


### PR DESCRIPTION
Passing in the INSTALLED_APPS lambda seems to result in some tasks for certain apps
like instructor_task and bulk_email to not get discovered properly.