### PR TITLE
Force settings loading to run same as startup.py

### DIFF
--- a/cms/celery.py
+++ b/cms/celery.py
@@ -13,6 +13,9 @@ from django.conf import settings
 
 from openedx.core.lib.celery.routers import AlternateEnvironmentRouter
 
+# Force settings to run so that the python path is modified
+settings.INSTALLED_APPS  # pylint: disable=pointless-statement
+
 # set the default Django settings module for the 'celery' program.
 os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'proj.settings')
 

--- a/lms/celery.py
+++ b/lms/celery.py
@@ -13,6 +13,9 @@ from django.conf import settings
 
 from openedx.core.lib.celery.routers import AlternateEnvironmentRouter
 
+# Force settings to run so that the python path is modified
+settings.INSTALLED_APPS  # pylint: disable=pointless-statement
+
 # set the default Django settings module for the 'celery' program.
 os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'proj.settings')
 


### PR DESCRIPTION
When starting django we do this to make sure all path modifications get picked
up.  Do the same for celery as a part of startup.