### PR TITLE
remove users listing and staff listing download csv from the sysadmin

### DIFF
--- a/lms/djangoapps/dashboard/decisions/0001-sysadmin-dashboard.rst
+++ b/lms/djangoapps/dashboard/decisions/0001-sysadmin-dashboard.rst
@@ -30,8 +30,7 @@ edX installations using Shibboleth and certificate-based authentication.
 The courses tabs manages adding/updating courses from git, deleting courses, and provides course listing information,
 including commit hash, date and author for course imported from git.
 
-The Staffing tab provides a view of staffing and enrollment in courses that include an option to download the data
-as a csv.
+The Staffing tab provides a view of staffing and enrollment in courses.
 
 The Gitlogs tab provides a view into the import log of courses from git repositories. It is convenient for allowing
 course teams to see what may be wrong wit their xml. This is the only view that allows permits access by course

--- a/lms/djangoapps/dashboard/decisions/0002-deprecate-sysadmin-dashboard-adr.rst
+++ b/lms/djangoapps/dashboard/decisions/0002-deprecate-sysadmin-dashboard-adr.rst
@@ -31,7 +31,7 @@ would need to be added and/or moved into the cms application
 
 3. Delete a course
 
-   https://github.com/edx/edx-platform/blob/master/lms/djangoapps/dashboard/sysadmin.py#L383-L408
+   https://github.com/edx/edx-platform/blob/b4556a4bec/lms/djangoapps/dashboard/sysadmin.py#L344-L369
 
 
 These APIs can be removed entirely, as they are adequately covered by existing functionality:
@@ -43,7 +43,7 @@ These APIs can be removed entirely, as they are adequately covered by existing f
 
 2. Staffing and Enrollment
 
-   https://github.com/edx/edx-platform/blob/master/lms/djangoapps/dashboard/sysadmin.py#L419-L477
+   https://github.com/edx/edx-platform/blob/b4556a4bec/lms/djangoapps/dashboard/sysadmin.py#L380-L413
 
    This functionality may be redundant to features in the Insights application.
 

--- a/lms/templates/sysadmin_dashboard.html
+++ b/lms/templates/sysadmin_dashboard.html
@@ -91,11 +91,6 @@ textarea {
     </div>
 
 	<hr />
-    <p>
-      <button type="submit" name="action" value="download_users" style="width: 350px;">
-		${_('Download list of all users (csv file)')}
-	  </button>
-    </p>
 
     <p>
     <button type="submit" name="action" value="repair_eamap" style="width: 350px;">
@@ -111,12 +106,6 @@ textarea {
 
 <p>${_("Go to each individual course's Instructor dashboard to manage course enrollment.")}</p>
 <hr />
-
-<h3>${_('Manage course staff and instructors')}</h3><br/>
-<form name="action" method="POST">
-  <input type="hidden" name="csrfmiddlewaretoken" value="${ csrf_token }" />
-  <button type="submit" name="action" value="get_staff_csv">${_('Download staff and instructor list (csv file)')}</button>
-</form>
 
 %endif
 


### PR DESCRIPTION
fixes [BTR-22](https://openedx.atlassian.net/jira/software/projects/BTR/boards/641?selectedIssue=BTR-22)
fixes https://github.com/mitodl/edx-platform/issues/190

Sysadmin dashboard changes
- Remove users listing download CSV from Users tab
- Remove staff and instructors listing download CSV from Staff and Enrollments tab

### Testing instructions
Add `FEATURES['ENABLE_SYSADMIN_DASHBOARD'] = True` to `/lms/envs/devstack.py`

### Screenshots

**Now**

<img width="1285" alt="Screenshot 2020-10-29 at 13 37 05" src="https://user-images.githubusercontent.com/4043989/97544801-ed0d1a80-19eb-11eb-8c15-8d975458656d.png">
<img width="1247" alt="Screenshot 2020-10-29 at 13 37 19" src="https://user-images.githubusercontent.com/4043989/97544804-ee3e4780-19eb-11eb-913d-41dbd148690d.png">

**Before**

<img width="1224" alt="Screenshot 2020-10-29 at 13 42 09" src="https://user-images.githubusercontent.com/4043989/97545321-a5d35980-19ec-11eb-8a7d-6295482229d5.png">
<img width="1211" alt="Screenshot 2020-10-29 at 13 42 22" src="https://user-images.githubusercontent.com/4043989/97545327-a966e080-19ec-11eb-9bfa-7a72d4807be8.png">
