### PR TITLE
Load celery-specific AppConfigs for bulk_email, instructor_task.

### DIFF
--- a/lms/djangoapps/bulk_email/apps.py
+++ b/lms/djangoapps/bulk_email/apps.py
@@ -6,3 +6,16 @@ class BulkEmailConfig(AppConfig):
     Application Configuration for bulk_email.
     """
     name = u'lms.djangoapps.bulk_email'
+
+
+class BulkEmailCeleryConfig(AppConfig):
+    """
+    Celery-specific App config to force the loading of tasks.
+
+    This will break tests if loaded as the normal AppConfig in INSTALLED_APPS
+    outside of celery.
+    """
+    def ready(self):
+        # noinspection PyUnresolvedReferences
+        super().ready()
+        from . import tasks  # pylint: disable=unused-import

--- a/lms/djangoapps/instructor_task/apps.py
+++ b/lms/djangoapps/instructor_task/apps.py
@@ -11,5 +11,15 @@ class InstructorTaskConfig(AppConfig):
     """
     name = u'lms.djangoapps.instructor_task'
 
+
+class InstructorTaskCeleryConfig(InstructorTaskConfig):
+    """
+    Celery-specific App config to force the loading of tasks.
+
+    This will break tests if loaded as the normal AppConfig in INSTALLED_APPS
+    outside of celery.
+    """
     def ready(self):
-        pass
+        # noinspection PyUnresolvedReferences
+        super().ready()
+        from . import tasks  # pylint: disable=unused-import


### PR DESCRIPTION
This is a mitigation taken to address a startup race condition. Celery's
autodiscover_tasks() _usually_ works, but sometimes does not find the tasks
for these two apps. It's not clear at this point why this is. Using app
configs that explicitly load the tasks in their ready() will fix it, but at
the expense of breaking our common/lib tests and forcing us to import a bunch
of stuff into it. So in order to guarantee loading while not borking tests, we
have a separate set of AppConfigs that we only call when starting up as a
celery worker.

If you ever feel that this is no longer necessary and remove this, be sure to
alert on "Received unregistered task" messages in the logs to detect
regressions. This affects a small percentage of celery workers on startup, so
you may only see breakage hours after it hits prod.

Also see TNL-7652.