### PR TITLE
Update celery task discovery config.

### DIFF
--- a/cms/celery.py
+++ b/cms/celery.py
@@ -9,7 +9,6 @@ Taken from: https://celery.readthedocs.org/en/latest/django/first-steps-with-dja
 import os
 
 from celery import Celery
-from django.conf import settings
 
 from openedx.core.lib.celery.routers import AlternateEnvironmentRouter
 

--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -1213,13 +1213,6 @@ WEBPACK_CONFIG_PATH = 'webpack.prod.config.js'
 
 ################################# CELERY ######################################
 
-# Auto discover tasks fails to detect contentstore tasks
-CELERY_IMPORTS = (
-    'cms.djangoapps.contentstore.tasks',
-    'openedx.core.djangoapps.bookmarks.tasks',
-    'openedx.core.djangoapps.ccxcon.tasks',
-)
-
 # Message configuration
 
 CELERY_TASK_SERIALIZER = 'json'

--- a/lms/celery.py
+++ b/lms/celery.py
@@ -9,12 +9,11 @@ Taken from: https://celery.readthedocs.org/en/latest/django/first-steps-with-dja
 import os
 
 from celery import Celery
-from django.conf import settings
 
 from openedx.core.lib.celery.routers import AlternateEnvironmentRouter
 
 # set the default Django settings module for the 'celery' program.
-os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'proj.settings')
+os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'lms.envs.production')
 
 APP = Celery('proj')
 

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -2230,15 +2230,6 @@ DEBUG_TOOLBAR_PATCH_SETTINGS = False
 
 ################################# CELERY ######################################
 
-# Celery's task autodiscovery won't find tasks nested in a tasks package.
-# Tasks are only registered when the module they are defined in is imported.
-CELERY_IMPORTS = (
-    'poll.tasks',
-    'lms.djangoapps.instructor_task.tasks',
-    'lms.djangoapps.bulk_email.tasks',
-    'openedx.core.djangoapps.bookmarks.tasks',
-)
-
 # Message configuration
 
 CELERY_TASK_SERIALIZER = 'json'


### PR DESCRIPTION
Update the celery startup code to more closely match the docs.  We believe some of these imports are causeing circulare
dependencies that are causing race conditions in task discovery.  Since all django apps should be loaded using the
django fixup in celery 4, we shouldn't need these other overrides.

https://github.com/celery/celery/blob/v4.4.7/celery/fixups/django.py
https://docs.celeryproject.org/en/v4.4.7/django/first-steps-with-django.html#using-celery-with-django