### PR TITLE
Put settings import back because it's used here.

### DIFF
--- a/cms/celery.py
+++ b/cms/celery.py
@@ -13,7 +13,7 @@ from celery import Celery
 from openedx.core.lib.celery.routers import AlternateEnvironmentRouter
 
 # set the default Django settings module for the 'celery' program.
-os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'proj.settings')
+os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'cms.envs.production')
 
 APP = Celery('proj')
 
@@ -22,6 +22,10 @@ APP.conf.task_protocol = 1
 # pickle the object when using Windows.
 APP.config_from_object('django.conf:settings')
 APP.autodiscover_tasks()
+
+# Import after autodiscovery has had a chance to connect to the import_module signal
+# so celery doesn't miss any apps getting installed.
+from django.conf import settings  # pylint: disable=wrong-import-position,wrong-import-order
 
 
 class Router(AlternateEnvironmentRouter):


### PR DESCRIPTION
But change the order so that celery is loaded first.