### PR TITLE
Pass course-run-specific resource limits to codejail

### DIFF
--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -911,6 +911,11 @@ CODE_JAIL = {
         # Needs to be non-zero so that jailed code can use it as their temp directory.(1MiB in bytes)
         'FSIZE': 1048576,
     },
+
+    # Overrides to default configurable 'limits' (above).
+    # Keys should be course run ids.
+    # Values should be dictionaries that look like 'limits'.
+    "limit_overrides": {},
 }
 
 # Some courses are allowed to run unsafe code. This is a list of regexes, one

--- a/common/lib/capa/capa/capa_problem.py
+++ b/common/lib/capa/capa/capa_problem.py
@@ -33,7 +33,7 @@ import capa.responsetypes as responsetypes
 import capa.xqueue_interface as xqueue_interface
 from capa.correctmap import CorrectMap
 from capa.safe_exec import safe_exec
-from capa.util import contextualize_text, convert_files_to_filenames
+from capa.util import contextualize_text, convert_files_to_filenames, get_course_id_from_capa_module
 from openedx.core.djangolib.markup import HTML, Text
 from openedx.core.lib.edx_six import get_gettext
 from xmodule.stringify import stringify_children
@@ -930,6 +930,9 @@ class LoncapaProblem(object):
                     python_path=python_path,
                     extra_files=extra_files,
                     cache=self.capa_system.cache,
+                    limit_overrides_context=get_course_id_from_capa_module(
+                        self.capa_module
+                    ),
                     slug=self.problem_id,
                     unsafely=self.capa_system.can_execute_unsafe_code(),
                 )

--- a/common/lib/capa/capa/responsetypes.py
+++ b/common/lib/capa/capa/responsetypes.py
@@ -57,6 +57,7 @@ from .util import (
     convert_files_to_filenames,
     default_tolerance,
     find_with_default,
+    get_course_id_from_capa_module,
     get_inner_html_from_xpath,
     is_list_of_files
 )
@@ -487,6 +488,9 @@ class LoncapaResponse(six.with_metaclass(abc.ABCMeta, object)):
                     globals_dict,
                     python_path=self.context['python_path'],
                     extra_files=self.context['extra_files'],
+                    limit_overrides_context=get_course_id_from_capa_module(
+                        self.capa_module
+                    ),
                     slug=self.id,
                     random_seed=self.context['seed'],
                     unsafely=self.capa_system.can_execute_unsafe_code(),

--- a/common/lib/capa/capa/safe_exec/safe_exec.py
+++ b/common/lib/capa/capa/safe_exec/safe_exec.py
@@ -86,6 +86,7 @@ def safe_exec(
     python_path=None,
     extra_files=None,
     cache=None,
+    limit_overrides_context=None,
     slug=None,
     unsafely=False,
 ):
@@ -109,11 +110,16 @@ def safe_exec(
     to cache the execution, taking into account the code, the values of the globals,
     and the random seed.
 
+    `limit_overrides_context` is an optional string to be used as a key on
+    the `settings.CODE_JAIL['limit_overrides']` dictionary in order to apply
+    context-specific overrides to the codejail execution limits.
+    If `limit_overrides_context` is omitted or not present in limit_overrides,
+    then use the default limits specified insettings.CODE_JAIL['limits'].
+
     `slug` is an arbitrary string, a description that's meaningful to the
     caller, that will be used in log messages.
 
     If `unsafely` is true, then the code will actually be executed without sandboxing.
-
     """
     # Check the cache for a previous result.
     if cache:
@@ -144,8 +150,12 @@ def safe_exec(
     # Run the code!  Results are side effects in globals_dict.
     try:
         exec_fn(
-            code_prolog + LAZY_IMPORTS + code, globals_dict,
-            python_path=python_path, extra_files=extra_files, slug=slug,
+            code_prolog + LAZY_IMPORTS + code,
+            globals_dict,
+            python_path=python_path,
+            extra_files=extra_files,
+            limit_overrides_context=limit_overrides_context,
+            slug=slug,
         )
     except SafeExecException as e:
         # Saving SafeExecException e in exception to be used later.

--- a/lms/djangoapps/debug/views.py
+++ b/lms/djangoapps/debug/views.py
@@ -17,7 +17,14 @@ from openedx.core.djangolib.markup import HTML
 @login_required
 @ensure_csrf_cookie
 def run_python(request):
-    """A page to allow testing the Python sandbox on a production server."""
+    """
+    A page to allow testing the Python sandbox on a production server.
+
+    Runs in the override context "debug_run_python", so resource limits with come first from:
+        CODE_JAIL['limit_overrides']['debug_run_python']
+    and then from:
+        CODE_JAIL['limits']
+    """
     if not request.user.is_staff:
         raise Http404
     c = {}
@@ -27,7 +34,7 @@ def run_python(request):
         py_code = c['code'] = request.POST.get('code')
         g = {}
         try:
-            safe_exec(py_code, g)
+            safe_exec(py_code, g, limit_overrides_context="debug_run_python")
         except Exception:   # pylint: disable=broad-except
             c['results'] = traceback.format_exc()
         else:

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -1282,6 +1282,12 @@ CODE_JAIL = {
         'REALTIME': 3,
         'PROXY': 0,
     },
+
+    # Overrides to default configurable 'limits' (above).
+    # Keys should be course run ids (or, in the special case of code running
+    # on the /debug/run_python page, the key is 'debug_run_python').
+    # Values should be dictionaries that look like 'limits'.
+    "limit_overrides": {},
 }
 
 # Some courses are allowed to run unsafe code. This is a list of regexes, one

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -6,7 +6,7 @@
 #
 -e git+https://github.com/edx/acid-block.git@758855a67d2f12bd74db4d5e7a0862d6e65f079c#egg=acid-xblock  # via -r requirements/edx/github.in
 -e common/lib/capa  # via -r requirements/edx/local.in
--e git+https://github.com/edx/codejail.git@ffec49bb09785fb688afc5d24714d4e43ae8449f#egg=codejail==3.0.1  # via -r requirements/edx/github.in
+-e git+https://github.com/edx/codejail.git@3.1.0#egg=codejail==3.1.0  # via -r requirements/edx/github.in
 -e git+https://github.com/edx/django-wiki.git@0.1.1#egg=django-wiki  # via -r requirements/edx/github.in
 -e git+https://github.com/edx/DoneXBlock.git@2.0.3#egg=done-xblock  # via -r requirements/edx/github.in
 -e git+https://github.com/jazkarta/edx-jsme.git@690dbf75441fa91c7c4899df0b83d77f7deb5458#egg=edx-jsme  # via -r requirements/edx/github.in

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -6,7 +6,7 @@
 #
 -e git+https://github.com/edx/acid-block.git@758855a67d2f12bd74db4d5e7a0862d6e65f079c#egg=acid-xblock  # via -r requirements/edx/testing.txt
 -e common/lib/capa  # via -r requirements/edx/testing.txt
--e git+https://github.com/edx/codejail.git@ffec49bb09785fb688afc5d24714d4e43ae8449f#egg=codejail==3.0.1  # via -r requirements/edx/testing.txt
+-e git+https://github.com/edx/codejail.git@3.1.0#egg=codejail==3.1.0  # via -r requirements/edx/testing.txt
 -e git+https://github.com/edx/django-wiki.git@0.1.1#egg=django-wiki  # via -r requirements/edx/testing.txt
 -e git+https://github.com/edx/DoneXBlock.git@2.0.3#egg=done-xblock  # via -r requirements/edx/testing.txt
 -e git+https://github.com/jazkarta/edx-jsme.git@690dbf75441fa91c7c4899df0b83d77f7deb5458#egg=edx-jsme  # via -r requirements/edx/testing.txt

--- a/requirements/edx/github.in
+++ b/requirements/edx/github.in
@@ -63,7 +63,7 @@ git+https://github.com/edx/MongoDBProxy.git@d92bafe9888d2940f647a7b2b2383b29c752
 git+https://github.com/edx/django-ratelimit-backend.git@v2.0.1a5#egg=django-ratelimit-backend==2.0.1a5
 
 # Our libraries:
--e git+https://github.com/edx/codejail.git@ffec49bb09785fb688afc5d24714d4e43ae8449f#egg=codejail==3.0.1
+-e git+https://github.com/edx/codejail.git@3.1.0#egg=codejail==3.1.0
 -e git+https://github.com/edx/acid-block.git@758855a67d2f12bd74db4d5e7a0862d6e65f079c#egg=acid-xblock
 -e git+https://github.com/edx/RateXBlock.git@2.0.1#egg=rate-xblock
 -e git+https://github.com/edx/DoneXBlock.git@2.0.3#egg=done-xblock

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -6,7 +6,7 @@
 #
 -e git+https://github.com/edx/acid-block.git@758855a67d2f12bd74db4d5e7a0862d6e65f079c#egg=acid-xblock  # via -r requirements/edx/base.txt
 -e common/lib/capa  # via -r requirements/edx/base.txt
--e git+https://github.com/edx/codejail.git@ffec49bb09785fb688afc5d24714d4e43ae8449f#egg=codejail==3.0.1  # via -r requirements/edx/base.txt
+-e git+https://github.com/edx/codejail.git@3.1.0#egg=codejail==3.1.0  # via -r requirements/edx/base.txt
 -e git+https://github.com/edx/django-wiki.git@0.1.1#egg=django-wiki  # via -r requirements/edx/base.txt
 -e git+https://github.com/edx/DoneXBlock.git@2.0.3#egg=done-xblock  # via -r requirements/edx/base.txt
 -e git+https://github.com/jazkarta/edx-jsme.git@690dbf75441fa91c7c4899df0b83d77f7deb5458#egg=edx-jsme  # via -r requirements/edx/base.txt


### PR DESCRIPTION
See the [preceding codejail PR](https://github.com/edx/codejail/pull/97) for more context.

Within the CAPA problem, we try to grab the course key off of the encompassing ProblemBlock, and pass it to `jail_code` as the `limit_overrides_context`.

### Links
* Customer request for root cause (codejail times out sometimes): https://openedx.atlassian.net/browse/CR-2519
* Customer request for a workaround for a specific course run: https://openedx.atlassian.net/browse/CR-2862
* TNL ticket for workaround: https://openedx.atlassian.net/browse/TNL-7649
* Codejail change (prerequesite to this): https://github.com/edx/codejail/pull/97
* Add limit overrides for specific course run: https://github.com/edx/edx-internal/pull/3562