### PR TITLE
[REV-1262] Skip enrolling already enrolled users on changes to the user

### DIFF
--- a/common/djangoapps/student/models.py
+++ b/common/djangoapps/student/models.py
@@ -740,7 +740,7 @@ def user_post_save_callback(sender, **kwargs):
     """
     When a user is modified and either its `is_active` state or email address
     is changed, and the user is, in fact, active, then check to see if there
-    are any courses that it needs to be automatically enrolled in.
+    are any courses that it needs to be automatically enrolled in and enroll them if needed.
 
     Additionally, emit analytics events after saving the User.
     """
@@ -755,8 +755,10 @@ def user_post_save_callback(sender, **kwargs):
             for cea in ceas:
                 # skip enrolling already enrolled users
                 if CourseEnrollment.is_enrolled(user, cea.course_id):
-                    # link the CEA to the user if the user didn't exist at the time the email address
-                    # was sent to the user
+                    # Link the CEA to the user if the CEA isn't already linked to the user
+                    # (e.g. the user was invited to a course but hadn't activated the account yet)
+                    # This is to prevent students from changing e-mails and
+                    # enrolling many accounts through the same e-mail.
                     if not cea.user:
                         cea.user = user
                         cea.save()

--- a/common/djangoapps/student/tests/test_models.py
+++ b/common/djangoapps/student/tests/test_models.py
@@ -407,7 +407,13 @@ class TestAccountRecovery(TestCase):
 
 @ddt.ddt
 class TestUserPostSaveCallback(SharedModuleStoreTestCase):
+    """
+    Tests for the user post save callback.
+    These tests are to ensure that user activation auto-enrolls invited users into courses without
+    changing any existing course mode states.
+    """
     def setUp(self):
+        super(TestUserPostSaveCallback, self).setUp()
         self.course = CourseFactory.create()
 
     @ddt.data(*(set(CourseMode.ALL_MODES) - set(CourseMode.AUDIT_MODES)))

--- a/common/djangoapps/student/tests/test_models.py
+++ b/common/djangoapps/student/tests/test_models.py
@@ -404,58 +404,112 @@ class TestAccountRecovery(TestCase):
         # Assert that there is no longer an AccountRecovery record for this user
         assert len(AccountRecovery.objects.filter(user_id=user.id)) == 0
 
+
+@ddt.ddt
 class TestUserPostSaveCallback(SharedModuleStoreTestCase):
     def setUp(self):
-        # self.client.login(username=self.instructor.username, password='test')
         self.course = CourseFactory.create()
 
-        self.enrolled_student = UserFactory(
-            username='EnrolledStudent',
-            first_name='Enrolled',
-            last_name='Student',
-            email='robot-allowed@robot.org',
-            is_active = False
+    @ddt.data(*(set(CourseMode.ALL_MODES) - set(CourseMode.AUDIT_MODES)))
+    def test_paid_user_not_downgraded_on_activation(self, mode):
+        """
+        Make sure that students who are already enrolled + have paid do not get downgraded to audit mode
+        when their account is activated.
+        """
+        # fixture
+        student = self._set_up_invited_student(
+            course=self.course,
+            active=False,
+            course_mode=mode
         )
-        CourseEnrollment.enroll(
-            self.enrolled_student,
-            self.course.id
-        )
-        self.notenrolled_student = UserFactory(username='NotEnrolledStudent', first_name='NotEnrolled',
-                                               last_name='Student')
 
-        # Create invited, but not registered, user
-        cea = CourseEnrollmentAllowed(email='robot-allowed@robot.org', course_id=self.course.id, auto_enroll=True)
-        cea.save()
-        self.allowed_email = 'robot-allowed@robot.org'
-
-        self.notregistered_email = 'robot-not-an-email-yet@robot.org'
-        self.assertEqual(User.objects.filter(email=self.notregistered_email).count(), 0)
-
-    def test_verified_user_not_downgraded_on_activation(self):
-        # setup the test state
-        course_enrollment = CourseEnrollment.objects.get(
-            user=self.enrolled_student, course_id=self.course.id
-        )
-        # make this enrollment "verified"
-        course_enrollment.mode = u'verified'
-        course_enrollment.save()
-        self.assertEqual(course_enrollment.mode, u'verified')
-
-        # run the change
-        self.enrolled_student.is_active = True
-        self.enrolled_student.save()
+        # trigger the post_save callback
+        student.is_active = True
+        student.save()
 
         # reload values from the database + make sure they are in the expected state
-        course_enrollment = CourseEnrollment.objects.get(
-            user=self.enrolled_student, course_id=self.course.id
+        actual_course_enrollment = CourseEnrollment.objects.get(user=student, course_id=self.course.id)
+        actual_student = User.objects.get(email=student.email)
+        actual_cea = CourseEnrollmentAllowed.objects.get(email=student.email)
+
+        self.assertEqual(actual_course_enrollment.mode, mode)
+        self.assertEqual(actual_student.is_active, True)
+        self.assertEqual(actual_cea.user, student)
+
+    def test_not_enrolled_student_is_enrolled(self):
+        """
+        Make sure that invited students who are not enrolled become enrolled when their account is activated.
+        They should be enrolled in the course in audit mode.
+        """
+        # fixture
+        student = self._set_up_invited_student(
+            course=self.course,
+            active=False,
+            enrolled=False
         )
-        student = User.objects.get(email=self.enrolled_student.email)
-        cea = CourseEnrollmentAllowed.objects.get(email=self.enrolled_student.email)
 
-        self.assertEqual(course_enrollment.mode, u"verified")
-        self.assertEqual(student.is_active, True)
-        self.assertEqual(cea.user, self.enrolled_student)
+        # trigger the post_save callback
+        student.is_active = True
+        student.save()
 
-# TODO: test case for adding additional course modes
-# TODO: test case for not enrolled
-# TODO: test case for changed email
+        # reload values from the database + make sure they are in the expected state
+        actual_course_enrollment = CourseEnrollment.objects.get(user=student, course_id=self.course.id)
+        actual_student = User.objects.get(email=student.email)
+        actual_cea = CourseEnrollmentAllowed.objects.get(email=student.email)
+
+        self.assertEqual(actual_course_enrollment.mode, u"audit")
+        self.assertEqual(actual_student.is_active, True)
+        self.assertEqual(actual_cea.user, student)
+
+    def test_verified_student_not_downgraded_when_changing_email(self):
+        """
+        Make sure that verified students do not get downgrade if they are active + changing their email.
+        """
+        # fixture
+        student = self._set_up_invited_student(
+            course=self.course,
+            active=True,
+            course_mode=u'verified'
+        )
+        old_email = student.email
+
+        # trigger the post_save callback
+        student.email = "foobar" + old_email
+        student.save()
+
+        # reload values from the database + make sure they are in the expected state
+        actual_course_enrollment = CourseEnrollment.objects.get(user=student, course_id=self.course.id)
+        actual_student = User.objects.get(email=student.email)
+
+        self.assertEqual(actual_course_enrollment.mode, u"verified")
+        self.assertEqual(actual_student.is_active, True)
+
+    def _set_up_invited_student(self, course, active=False, enrolled=True, course_mode=''):
+        """
+        Helper function to create a user in the right state, invite them into the course, and update their
+        course mode if needed.
+        """
+        email = 'robot@robot.org'
+        user = UserFactory(
+            username='somestudent',
+            first_name='Student',
+            last_name='Person',
+            email=email,
+            is_active=active
+        )
+
+        # invite the user to the course
+        cea = CourseEnrollmentAllowed(email=email, course_id=course.id, auto_enroll=True)
+        cea.save()
+
+        if enrolled:
+            CourseEnrollment.enroll(user, course.id)
+
+            if course_mode:
+                course_enrollment = CourseEnrollment.objects.get(
+                    user=user, course_id=self.course.id
+                )
+                course_enrollment.mode = course_mode
+                course_enrollment.save()
+
+        return user


### PR DESCRIPTION
## What are we doing?
Skip auto-enrolling users if they are already enrolled in their auto-enroll enabled courses. We're specifically targeting when the user first activates their account, but the post_save hook runs anytime the user changes  (though our code only runs when the email or user account activation status changes).

## Why are we doing this?
To prevent downgrading users from paid course modes to audit/free course modes when they activate their account.

Ticket: https://openedx.atlassian.net/browse/REV-1262

Replication steps: https://openedx.atlassian.net/browse/REV-1262?focusedCommentId=500485

Other potential solutions considered + discarded: https://openedx.atlassian.net/browse/REV-1262?focusedCommentId=500762

## How was this tested?
Unit tests
Manual local testing