### PR TITLE
ARCHBOM-1584: use unreleased edx-django-utils branch

### DIFF
--- a/cms/djangoapps/contentstore/views/tests/test_course_index.py
+++ b/cms/djangoapps/contentstore/views/tests/test_course_index.py
@@ -15,17 +15,16 @@ from django.conf import settings
 from django.core.exceptions import PermissionDenied
 from django.test.utils import override_settings
 from django.utils.translation import ugettext as _
-from edx_django_utils.monitoring.middleware import _DEFAULT_NAMESPACE as DJANGO_UTILS_NAMESPACE
 from opaque_keys.edx.locator import CourseLocator
 from search.api import perform_search
 
-from cms.djangoapps.contentstore.config.waffle import WAFFLE_NAMESPACE as STUDIO_WAFFLE_NAMESPACE
 from cms.djangoapps.contentstore.courseware_index import CoursewareSearchIndexer, SearchIndexingError
 from cms.djangoapps.contentstore.tests.utils import CourseTestCase
 from cms.djangoapps.contentstore.utils import add_instructor, reverse_course_url, reverse_usage_url
 from course_action_state.managers import CourseRerunUIStateManager
 from course_action_state.models import CourseRerunState
 from openedx.core.djangoapps.waffle_utils import WaffleSwitchNamespace
+from openedx.core.djangoapps.waffle_utils.testutils import WAFFLE_TABLES
 from student.auth import has_course_author_access
 from student.roles import CourseStaffRole, GlobalStaff, LibraryUserRole
 from student.tests.factories import UserFactory
@@ -33,9 +32,10 @@ from xmodule.modulestore.django import modulestore
 from xmodule.modulestore.exceptions import ItemNotFoundError
 from xmodule.modulestore.tests.factories import CourseFactory, ItemFactory, LibraryFactory, check_mongo_calls
 
-from ..course import WAFFLE_NAMESPACE as COURSE_WAFFLE_NAMESPACE
 from ..course import _deprecated_blocks_info, course_outline_initial_state, reindex_course_and_check_access
 from ..item import VisibilityState, create_xblock_info
+
+QUERY_COUNT_TABLE_BLACKLIST = WAFFLE_TABLES
 
 
 class TestCourseIndex(CourseTestCase):
@@ -362,17 +362,11 @@ class TestCourseIndexArchived(CourseTestCase):
         for course in (self.course, self.active_course, self.archived_course):
             CourseStaffRole(course.id).add_users(self.staff)
 
-        # Make sure we've cached data which could change the query counts
-        # depending on test execution order
-        WaffleSwitchNamespace(name=COURSE_WAFFLE_NAMESPACE).is_enabled(u'enable_global_staff_optimization')
-        WaffleSwitchNamespace(name=STUDIO_WAFFLE_NAMESPACE).is_enabled(u'enable_policy_page')
-        WaffleSwitchNamespace(name=DJANGO_UTILS_NAMESPACE).is_enabled(u'enable_memory_middleware')
-
     def check_index_page_with_query_count(self, separate_archived_courses, org, mongo_queries, sql_queries):
         """
         Checks the index page, and ensures the number of database queries is as expected.
         """
-        with self.assertNumQueries(sql_queries):
+        with self.assertNumQueries(sql_queries, table_blacklist=QUERY_COUNT_TABLE_BLACKLIST):
             with check_mongo_calls(mongo_queries):
                 self.check_index_page(separate_archived_courses=separate_archived_courses, org=org)
 

--- a/cms/djangoapps/contentstore/views/tests/test_course_index.py
+++ b/cms/djangoapps/contentstore/views/tests/test_course_index.py
@@ -389,13 +389,13 @@ class TestCourseIndexArchived(CourseTestCase):
 
     @ddt.data(
         # Staff user has course staff access
-        (True, 'staff', None, 3, 19),
-        (False, 'staff', None, 3, 19),
+        (True, 'staff', None, 3, 18),
+        (False, 'staff', None, 3, 18),
         # Base user has global staff access
-        (True, 'user', ORG, 3, 19),
-        (False, 'user', ORG, 3, 19),
-        (True, 'user', None, 3, 19),
-        (False, 'user', None, 3, 19),
+        (True, 'user', ORG, 3, 18),
+        (False, 'user', ORG, 3, 18),
+        (True, 'user', None, 3, 18),
+        (False, 'user', None, 3, 18),
     )
     @ddt.unpack
     def test_separate_archived_courses(self, separate_archived_courses, username, org, mongo_queries, sql_queries):

--- a/openedx/core/djangoapps/waffle_utils/tests/test_views.py
+++ b/openedx/core/djangoapps/waffle_utils/tests/test_views.py
@@ -2,8 +2,6 @@
 Tests for waffle utils views.
 """
 from django.test import TestCase
-from edx_django_utils.monitoring.code_owner import utils as code_owner_utils
-from mock import patch
 from rest_framework.test import APIRequestFactory
 from waffle.testutils import override_switch
 
@@ -50,8 +48,7 @@ class ToggleStateViewTests(TestCase):
     def test_code_owners_without_module_information(self):
         # Create a waffle flag without any associated module_name
         waffle_flag = WaffleFlag(TEST_WAFFLE_FLAG_NAMESPACE, "flag2", module_name=None)
-        with patch.object(code_owner_utils, "get_code_owner_mappings", return_value={}):
-            response = self._get_toggle_state_response(is_staff=True)
+        response = self._get_toggle_state_response(is_staff=True)
 
         result = [
             flag for flag in response.data["waffle_flags"] if flag["name"] == waffle_flag.name

--- a/requirements/edx-sandbox/py35.txt
+++ b/requirements/edx-sandbox/py35.txt
@@ -20,7 +20,7 @@ matplotlib==2.2.4         # via -c requirements/edx-sandbox/../constraints.txt, 
 mpmath==1.1.0             # via sympy
 networkx==2.2             # via -r requirements/edx-sandbox/py35.in
 nltk==3.5                 # via -r requirements/edx-sandbox/shared.txt, chem
-numpy==1.16.5             # via -c requirements/edx-sandbox/../constraints.txt, -r requirements/edx-sandbox/py35.in, chem, matplotlib, openedx-calc, scipy
+numpy==1.16.5             # via -c requirements/edx-sandbox/../constraints.txt, -r requirements/edx-sandbox/py35.in, chem, matplotlib, openedx-calc
 openedx-calc==1.0.9       # via -r requirements/edx-sandbox/py35.in
 pycparser==2.20           # via -r requirements/edx-sandbox/shared.txt, cffi
 pyparsing==2.2.0          # via -r requirements/edx-sandbox/py35.in, chem, matplotlib, openedx-calc

--- a/requirements/edx/base.in
+++ b/requirements/edx/base.in
@@ -78,7 +78,6 @@ edx-celeryutils
 edx-completion
 edx-django-release-util             # Release utils for the edx release pipeline
 edx-django-sites-extensions
-edx-django-utils>=3.8.0             # Utilities for cache, monitoring, and plugins; 3.8.0+ for set_custom_attribute method
 edx-drf-extensions
 edx-enterprise
 edx-milestones

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -10,6 +10,7 @@
 -e git+https://github.com/edx/django-wiki.git@0.1.1#egg=django-wiki  # via -r requirements/edx/github.in
 -e git+https://github.com/edx/DoneXBlock.git@2.0.3#egg=done-xblock  # via -r requirements/edx/github.in
 -e git+https://github.com/jazkarta/edx-jsme.git@690dbf75441fa91c7c4899df0b83d77f7deb5458#egg=edx-jsme  # via -r requirements/edx/github.in
+-e git+https://github.com/edx/edx-django-utils.git@robrap/ARCHBOM-1584-add-monitoring-internal#egg=edx_django_utils  # via -r requirements/edx/github.in
 -e .  # via -r requirements/edx/local.in
 -e git+https://github.com/edx/RateXBlock.git@2.0.1#egg=rate-xblock  # via -r requirements/edx/github.in
 -e common/lib/safe_lxml  # via -r requirements/edx/local.in
@@ -96,7 +97,6 @@ edx-celeryutils==0.5.2    # via -r requirements/edx/base.in, super-csv
 edx-completion==3.2.4     # via -r requirements/edx/base.in
 edx-django-release-util==0.4.4  # via -r requirements/edx/base.in
 edx-django-sites-extensions==2.5.1  # via -r requirements/edx/base.in
-edx-django-utils==3.10.0  # via -r requirements/edx/base.in, django-config-models, edx-drf-extensions, edx-enterprise, edx-rest-api-client, edx-toggles, edx-when
 edx-drf-extensions==6.2.0  # via -r requirements/edx/base.in, edx-completion, edx-enterprise, edx-organizations, edx-proctoring, edx-rbac, edx-when, edxval
 edx-enterprise==3.10.0    # via -c requirements/edx/../constraints.txt, -r requirements/edx/base.in
 edx-i18n-tools==0.5.3     # via ora2
@@ -111,7 +111,7 @@ edx-search==1.4.1         # via -c requirements/edx/../constraints.txt, -r requi
 edx-sga==0.13.0           # via -r requirements/edx/base.in
 edx-submissions==3.2.2    # via -r requirements/edx/base.in, ora2
 edx-tincan-py35==0.0.9    # via edx-enterprise
-edx-toggles==1.1.1        # via -r requirements/edx/base.in
+edx-toggles==1.1.1        # via -c requirements/edx/../constraints.txt, -r requirements/edx/base.in
 edx-user-state-client==1.2.0  # via -r requirements/edx/base.in
 edx-when==1.3.0           # via -r requirements/edx/base.in, edx-proctoring
 edxval==1.4.2             # via -r requirements/edx/base.in
@@ -129,7 +129,6 @@ help-tokens==1.1.2        # via -r requirements/edx/base.in
 html5lib==1.1             # via -r requirements/edx/base.in, ora2
 icalendar==4.0.7          # via -r requirements/edx/base.in
 idna==2.10                # via -r requirements/edx/paver.txt, requests
-importlib-metadata==1.7.0  # via -c requirements/edx/../constraints.txt, -r requirements/edx/paver.txt, kombu, path
 inflection==0.5.1         # via drf-yasg
 ipaddress==1.0.23         # via -r requirements/edx/base.in
 isodate==0.6.0            # via python3-saml
@@ -155,7 +154,6 @@ maxminddb==1.5.4          # via -c requirements/edx/../constraints.txt, geoip2
 mock==3.0.5               # via -c requirements/edx/../constraints.txt, -r requirements/edx/paver.txt, xblock-drag-and-drop-v2, xblock-poll
 git+https://github.com/edx/MongoDBProxy.git@d92bafe9888d2940f647a7b2b2383b29c752f35a#egg=MongoDBProxy==0.1.0+edx.2  # via -r requirements/edx/github.in
 mongoengine==0.20.0       # via -r requirements/edx/base.in
-more-itertools==8.5.0     # via -r requirements/edx/paver.txt, zipp
 mpmath==1.1.0             # via sympy
 mysqlclient==2.0.1        # via -r requirements/edx/base.in
 newrelic==5.22.1.152      # via -r requirements/edx/base.in, edx-django-utils
@@ -247,7 +245,6 @@ xblock-utils==2.1.1       # via -r requirements/edx/base.in, edx-sga, lti-consum
 xblock==1.4.0             # via -r requirements/edx/base.in, acid-xblock, crowdsourcehinter-xblock, done-xblock, edx-completion, edx-sga, edx-user-state-client, edx-when, lti-consumer-xblock, ora2, rate-xblock, staff-graded-xblock, xblock-discussion, xblock-drag-and-drop-v2, xblock-google-drive, xblock-poll, xblock-utils
 xmlsec==1.3.9             # via python3-saml
 xss-utils==0.1.3          # via -r requirements/edx/base.in
-zipp==1.0.0               # via -c requirements/edx/../constraints.txt, -r requirements/edx/paver.txt, importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools

--- a/requirements/edx/coverage.txt
+++ b/requirements/edx/coverage.txt
@@ -6,7 +6,7 @@
 #
 coverage==5.3             # via -r requirements/edx/coverage.in
 diff-cover==4.0.1         # via -r requirements/edx/coverage.in
-importlib-metadata==1.7.0  # via -c requirements/edx/../constraints.txt, inflect, pluggy
+importlib-metadata==1.7.0  # via -c requirements/edx/../constraints.txt, inflect
 inflect==3.0.2            # via -c requirements/edx/../constraints.txt, jinja2-pluralize
 jinja2-pluralize==0.3.0   # via diff-cover
 jinja2==2.11.2            # via diff-cover, jinja2-pluralize

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -10,6 +10,7 @@
 -e git+https://github.com/edx/django-wiki.git@0.1.1#egg=django-wiki  # via -r requirements/edx/testing.txt
 -e git+https://github.com/edx/DoneXBlock.git@2.0.3#egg=done-xblock  # via -r requirements/edx/testing.txt
 -e git+https://github.com/jazkarta/edx-jsme.git@690dbf75441fa91c7c4899df0b83d77f7deb5458#egg=edx-jsme  # via -r requirements/edx/testing.txt
+-e git+https://github.com/edx/edx-django-utils.git@robrap/ARCHBOM-1584-add-monitoring-internal#egg=edx_django_utils  # via -r requirements/edx/testing.txt
 -e .  # via -r requirements/edx/testing.txt
 -e git+https://github.com/edx/RateXBlock.git@2.0.1#egg=rate-xblock  # via -r requirements/edx/testing.txt
 -e common/lib/safe_lxml  # via -r requirements/edx/testing.txt
@@ -107,7 +108,6 @@ edx-celeryutils==0.5.2    # via -r requirements/edx/testing.txt, super-csv
 edx-completion==3.2.4     # via -r requirements/edx/testing.txt
 edx-django-release-util==0.4.4  # via -r requirements/edx/testing.txt
 edx-django-sites-extensions==2.5.1  # via -r requirements/edx/testing.txt
-edx-django-utils==3.10.0  # via -r requirements/edx/testing.txt, django-config-models, edx-drf-extensions, edx-enterprise, edx-rest-api-client, edx-toggles, edx-when
 edx-drf-extensions==6.2.0  # via -r requirements/edx/testing.txt, edx-completion, edx-enterprise, edx-organizations, edx-proctoring, edx-rbac, edx-when, edxval
 edx-enterprise==3.10.0    # via -c requirements/edx/../constraints.txt, -r requirements/edx/testing.txt
 edx-i18n-tools==0.5.3     # via -r requirements/edx/testing.txt, ora2
@@ -124,7 +124,7 @@ edx-sga==0.13.0           # via -r requirements/edx/testing.txt
 edx-sphinx-theme==1.5.0   # via -r requirements/edx/development.in
 edx-submissions==3.2.2    # via -r requirements/edx/testing.txt, ora2
 edx-tincan-py35==0.0.9    # via -r requirements/edx/testing.txt, edx-enterprise
-edx-toggles==1.1.1        # via -r requirements/edx/testing.txt
+edx-toggles==1.1.1        # via -c requirements/edx/../constraints.txt, -r requirements/edx/testing.txt
 edx-user-state-client==1.2.0  # via -r requirements/edx/testing.txt
 edx-when==1.3.0           # via -r requirements/edx/testing.txt, edx-proctoring
 edxval==1.4.2             # via -r requirements/edx/testing.txt
@@ -151,8 +151,7 @@ httpretty==0.9.7          # via -c requirements/edx/../constraints.txt, -r requi
 icalendar==4.0.7          # via -r requirements/edx/testing.txt
 idna==2.10                # via -r requirements/edx/testing.txt, requests
 imagesize==1.2.0          # via sphinx
-importlib-metadata==1.7.0  # via -c requirements/edx/../constraints.txt, -r requirements/edx/testing.txt, inflect, jsonschema, kombu, path, pluggy, pytest, pytest-randomly, tox, virtualenv
-importlib-resources==3.2.1  # via -r requirements/edx/testing.txt, virtualenv
+importlib-metadata==1.7.0  # via -c requirements/edx/../constraints.txt, -r requirements/edx/testing.txt, inflect
 inflect==3.0.2            # via -c requirements/edx/../constraints.txt, -r requirements/edx/testing.txt, jinja2-pluralize
 inflection==0.5.1         # via -r requirements/edx/testing.txt, drf-yasg
 iniconfig==1.1.1          # via -r requirements/edx/testing.txt, pytest
@@ -200,7 +199,6 @@ ora2==2.10.3              # via -r requirements/edx/testing.txt
 packaging==20.4           # via -r requirements/edx/testing.txt, bleach, drf-yasg, pytest, sphinx, tox
 path.py==12.5.0           # via -r requirements/edx/testing.txt, edx-enterprise, edx-i18n-tools, ora2, staff-graded-xblock, xmodule
 path==13.1.0              # via -c requirements/edx/../constraints.txt, -r requirements/edx/testing.txt, path.py
-pathlib2==2.3.5           # via -r requirements/edx/testing.txt, pytest
 pathtools==0.1.2          # via -r requirements/edx/testing.txt, watchdog
 paver==1.3.4              # via -r requirements/edx/testing.txt
 pbr==5.5.1                # via -r requirements/edx/testing.txt, stevedore
@@ -268,7 +266,7 @@ semantic-version==2.8.5   # via -r requirements/edx/testing.txt, edx-drf-extensi
 shapely==1.7.1            # via -r requirements/edx/testing.txt
 simplejson==3.17.2        # via -r requirements/edx/testing.txt, sailthru-client, super-csv, xblock-utils
 singledispatch==3.4.0.3   # via -r requirements/edx/testing.txt
-six==1.15.0               # via -r requirements/edx/pip-tools.txt, -r requirements/edx/testing.txt, analytics-python, astroid, bleach, bok-choy, chem, crowdsourcehinter-xblock, cryptography, django-countries, django-simple-history, django-wiki, drf-yasg, edx-ace, edx-bulk-grades, edx-ccx-keys, edx-django-release-util, edx-drf-extensions, edx-enterprise, edx-i18n-tools, edx-lint, edx-milestones, edx-opaque-keys, edx-rbac, edx-search, edx-sphinx-theme, event-tracking, freezegun, fs, fs-s3fs, help-tokens, html5lib, httpretty, isodate, jsonschema, libsass, mock, openedx-calc, packaging, pathlib2, paver, pip-tools, pycontracts, pyjwkest, python-dateutil, python-memcached, python-swiftclient, singledispatch, social-auth-app-django, social-auth-core, sphinxcontrib-httpdomain, stevedore, tox, transifex-client, virtualenv, xblock
+six==1.15.0               # via -r requirements/edx/pip-tools.txt, -r requirements/edx/testing.txt, analytics-python, astroid, bleach, bok-choy, chem, crowdsourcehinter-xblock, cryptography, django-countries, django-simple-history, django-wiki, drf-yasg, edx-ace, edx-bulk-grades, edx-ccx-keys, edx-django-release-util, edx-drf-extensions, edx-enterprise, edx-i18n-tools, edx-lint, edx-milestones, edx-opaque-keys, edx-rbac, edx-search, edx-sphinx-theme, event-tracking, freezegun, fs, fs-s3fs, help-tokens, html5lib, httpretty, isodate, jsonschema, libsass, mock, openedx-calc, packaging, paver, pip-tools, pycontracts, pyjwkest, python-dateutil, python-memcached, python-swiftclient, singledispatch, social-auth-app-django, social-auth-core, sphinxcontrib-httpdomain, stevedore, tox, transifex-client, virtualenv, xblock
 slumber==0.7.1            # via -r requirements/edx/testing.txt, edx-bulk-grades, edx-enterprise, edx-rest-api-client
 smmap==3.0.4              # via -r requirements/edx/testing.txt, gitdb
 snowballstemmer==2.0.0    # via sphinx
@@ -299,7 +297,6 @@ tox-battery==0.6.1        # via -r requirements/edx/testing.txt
 tox==3.20.1               # via -r requirements/edx/testing.txt, tox-battery
 tqdm==4.51.0              # via -r requirements/edx/testing.txt, nltk
 transifex-client==0.14.1  # via -r requirements/edx/testing.txt
-typed-ast==1.4.1          # via -r requirements/edx/testing.txt, astroid
 ua-parser==0.10.0         # via -r requirements/edx/testing.txt, django-cookies-samesite
 unicodecsv==0.14.1        # via -r requirements/edx/testing.txt, edx-enterprise
 unidiff==0.6.0            # via -r requirements/edx/testing.txt, coverage-pytest-plugin
@@ -321,7 +318,7 @@ xblock-utils==2.1.1       # via -r requirements/edx/testing.txt, edx-sga, lti-co
 xblock==1.4.0             # via -r requirements/edx/testing.txt, acid-xblock, crowdsourcehinter-xblock, done-xblock, edx-completion, edx-sga, edx-user-state-client, edx-when, lti-consumer-xblock, ora2, rate-xblock, staff-graded-xblock, xblock-discussion, xblock-drag-and-drop-v2, xblock-google-drive, xblock-poll, xblock-utils
 xmlsec==1.3.9             # via -r requirements/edx/testing.txt, python3-saml
 xss-utils==0.1.3          # via -r requirements/edx/testing.txt
-zipp==1.0.0               # via -c requirements/edx/../constraints.txt, -r requirements/edx/testing.txt, importlib-metadata, importlib-resources
+zipp==1.0.0               # via -c requirements/edx/../constraints.txt, -r requirements/edx/testing.txt, importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools

--- a/requirements/edx/github.in
+++ b/requirements/edx/github.in
@@ -53,6 +53,8 @@
 
 # Python libraries to install directly from github
 
+-e git+https://github.com/edx/edx-django-utils.git@robrap/ARCHBOM-1584-add-monitoring-internal#egg=edx_django_utils
+
 # Third-party:
 -e git+https://github.com/edx/django-wiki.git@0.1.1#egg=django-wiki
 git+https://github.com/edx/MongoDBProxy.git@d92bafe9888d2940f647a7b2b2383b29c752f35a#egg=MongoDBProxy==0.1.0+edx.2

--- a/requirements/edx/paver.txt
+++ b/requirements/edx/paver.txt
@@ -8,12 +8,10 @@ certifi==2020.6.20        # via requests
 chardet==3.0.4            # via requests
 edx-opaque-keys==2.1.1    # via -r requirements/edx/paver.in
 idna==2.10                # via requests
-importlib-metadata==1.7.0  # via -c requirements/edx/../constraints.txt, path
 lazy==1.4                 # via -r requirements/edx/paver.in
 libsass==0.10.0           # via -r requirements/edx/paver.in
 markupsafe==1.1.1         # via -r requirements/edx/paver.in
 mock==3.0.5               # via -c requirements/edx/../constraints.txt, -r requirements/edx/paver.in
-more-itertools==8.5.0     # via zipp
 path==13.1.0              # via -c requirements/edx/../constraints.txt, -r requirements/edx/paver.in
 pathtools==0.1.2          # via watchdog
 paver==1.3.4              # via -r requirements/edx/paver.in
@@ -27,4 +25,3 @@ stevedore==1.32.0         # via -c requirements/edx/../constraints.txt, -r requi
 urllib3==1.25.11          # via requests
 watchdog==0.10.3          # via -r requirements/edx/paver.in
 wrapt==1.11.2             # via -c requirements/edx/../constraints.txt, -r requirements/edx/paver.in
-zipp==1.0.0               # via -c requirements/edx/../constraints.txt, importlib-metadata

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -10,6 +10,7 @@
 -e git+https://github.com/edx/django-wiki.git@0.1.1#egg=django-wiki  # via -r requirements/edx/base.txt
 -e git+https://github.com/edx/DoneXBlock.git@2.0.3#egg=done-xblock  # via -r requirements/edx/base.txt
 -e git+https://github.com/jazkarta/edx-jsme.git@690dbf75441fa91c7c4899df0b83d77f7deb5458#egg=edx-jsme  # via -r requirements/edx/base.txt
+-e git+https://github.com/edx/edx-django-utils.git@robrap/ARCHBOM-1584-add-monitoring-internal#egg=edx_django_utils  # via -r requirements/edx/base.txt
 -e .  # via -r requirements/edx/base.txt
 -e git+https://github.com/edx/RateXBlock.git@2.0.1#egg=rate-xblock  # via -r requirements/edx/base.txt
 -e common/lib/safe_lxml  # via -r requirements/edx/base.txt
@@ -104,7 +105,6 @@ edx-celeryutils==0.5.2    # via -r requirements/edx/base.txt, super-csv
 edx-completion==3.2.4     # via -r requirements/edx/base.txt
 edx-django-release-util==0.4.4  # via -r requirements/edx/base.txt
 edx-django-sites-extensions==2.5.1  # via -r requirements/edx/base.txt
-edx-django-utils==3.10.0  # via -r requirements/edx/base.txt, django-config-models, edx-drf-extensions, edx-enterprise, edx-rest-api-client, edx-toggles, edx-when
 edx-drf-extensions==6.2.0  # via -r requirements/edx/base.txt, edx-completion, edx-enterprise, edx-organizations, edx-proctoring, edx-rbac, edx-when, edxval
 edx-enterprise==3.10.0    # via -c requirements/edx/../constraints.txt, -r requirements/edx/base.txt
 edx-i18n-tools==0.5.3     # via -r requirements/edx/base.txt, -r requirements/edx/testing.in, ora2
@@ -120,7 +120,7 @@ edx-search==1.4.1         # via -c requirements/edx/../constraints.txt, -r requi
 edx-sga==0.13.0           # via -r requirements/edx/base.txt
 edx-submissions==3.2.2    # via -r requirements/edx/base.txt, ora2
 edx-tincan-py35==0.0.9    # via -r requirements/edx/base.txt, edx-enterprise
-edx-toggles==1.1.1        # via -r requirements/edx/base.txt
+edx-toggles==1.1.1        # via -c requirements/edx/../constraints.txt, -r requirements/edx/base.txt
 edx-user-state-client==1.2.0  # via -r requirements/edx/base.txt
 edx-when==1.3.0           # via -r requirements/edx/base.txt, edx-proctoring
 edxval==1.4.2             # via -r requirements/edx/base.txt
@@ -146,8 +146,7 @@ html5lib==1.1             # via -r requirements/edx/base.txt, ora2
 httpretty==0.9.7          # via -c requirements/edx/../constraints.txt, -r requirements/edx/testing.in
 icalendar==4.0.7          # via -r requirements/edx/base.txt
 idna==2.10                # via -r requirements/edx/base.txt, requests
-importlib-metadata==1.7.0  # via -c requirements/edx/../constraints.txt, -r requirements/edx/base.txt, -r requirements/edx/coverage.txt, inflect, kombu, path, pluggy, pytest, pytest-randomly, tox, virtualenv
-importlib-resources==3.2.1  # via virtualenv
+importlib-metadata==1.7.0  # via -c requirements/edx/../constraints.txt, -r requirements/edx/coverage.txt, inflect
 inflect==3.0.2            # via -c requirements/edx/../constraints.txt, -r requirements/edx/coverage.txt, jinja2-pluralize
 inflection==0.5.1         # via -r requirements/edx/base.txt, drf-yasg
 iniconfig==1.1.1          # via pytest
@@ -179,7 +178,7 @@ mccabe==0.6.1             # via pylint
 mock==3.0.5               # via -c requirements/edx/../constraints.txt, -r requirements/edx/base.txt, xblock-drag-and-drop-v2, xblock-poll
 git+https://github.com/edx/MongoDBProxy.git@d92bafe9888d2940f647a7b2b2383b29c752f35a#egg=MongoDBProxy==0.1.0+edx.2  # via -r requirements/edx/base.txt
 mongoengine==0.20.0       # via -r requirements/edx/base.txt
-more-itertools==8.5.0     # via -r requirements/edx/base.txt, -r requirements/edx/coverage.txt, zipp
+more-itertools==8.5.0     # via -r requirements/edx/coverage.txt, zipp
 mpmath==1.1.0             # via -r requirements/edx/base.txt, sympy
 mysqlclient==2.0.1        # via -r requirements/edx/base.txt
 newrelic==5.22.1.152      # via -r requirements/edx/base.txt, edx-django-utils
@@ -192,7 +191,6 @@ ora2==2.10.3              # via -r requirements/edx/base.txt
 packaging==20.4           # via -r requirements/edx/base.txt, bleach, drf-yasg, pytest, tox
 path.py==12.5.0           # via -r requirements/edx/base.txt, edx-enterprise, edx-i18n-tools, ora2, staff-graded-xblock, xmodule
 path==13.1.0              # via -c requirements/edx/../constraints.txt, -r requirements/edx/base.txt, path.py
-pathlib2==2.3.5           # via pytest
 pathtools==0.1.2          # via -r requirements/edx/base.txt, watchdog
 paver==1.3.4              # via -r requirements/edx/base.txt
 pbr==5.5.1                # via -r requirements/edx/base.txt, stevedore
@@ -257,7 +255,7 @@ semantic-version==2.8.5   # via -r requirements/edx/base.txt, edx-drf-extensions
 shapely==1.7.1            # via -r requirements/edx/base.txt
 simplejson==3.17.2        # via -r requirements/edx/base.txt, sailthru-client, super-csv, xblock-utils
 singledispatch==3.4.0.3   # via -r requirements/edx/testing.in
-six==1.15.0               # via -r requirements/edx/base.txt, analytics-python, astroid, bleach, bok-choy, chem, crowdsourcehinter-xblock, cryptography, django-countries, django-simple-history, django-wiki, drf-yasg, edx-ace, edx-bulk-grades, edx-ccx-keys, edx-django-release-util, edx-drf-extensions, edx-enterprise, edx-i18n-tools, edx-lint, edx-milestones, edx-opaque-keys, edx-rbac, edx-search, event-tracking, freezegun, fs, fs-s3fs, help-tokens, html5lib, httpretty, isodate, libsass, mock, openedx-calc, packaging, pathlib2, paver, pycontracts, pyjwkest, python-dateutil, python-memcached, python-swiftclient, singledispatch, social-auth-app-django, social-auth-core, stevedore, tox, transifex-client, virtualenv, xblock
+six==1.15.0               # via -r requirements/edx/base.txt, analytics-python, astroid, bleach, bok-choy, chem, crowdsourcehinter-xblock, cryptography, django-countries, django-simple-history, django-wiki, drf-yasg, edx-ace, edx-bulk-grades, edx-ccx-keys, edx-django-release-util, edx-drf-extensions, edx-enterprise, edx-i18n-tools, edx-lint, edx-milestones, edx-opaque-keys, edx-rbac, edx-search, event-tracking, freezegun, fs, fs-s3fs, help-tokens, html5lib, httpretty, isodate, libsass, mock, openedx-calc, packaging, paver, pycontracts, pyjwkest, python-dateutil, python-memcached, python-swiftclient, singledispatch, social-auth-app-django, social-auth-core, stevedore, tox, transifex-client, virtualenv, xblock
 slumber==0.7.1            # via -r requirements/edx/base.txt, edx-bulk-grades, edx-enterprise, edx-rest-api-client
 smmap==3.0.4              # via gitdb
 social-auth-app-django==4.0.0  # via -r requirements/edx/base.txt
@@ -278,7 +276,6 @@ tox-battery==0.6.1        # via -r requirements/edx/testing.in
 tox==3.20.1               # via -r requirements/edx/testing.in, tox-battery
 tqdm==4.51.0              # via -r requirements/edx/base.txt, nltk
 transifex-client==0.14.1  # via -r requirements/edx/testing.in
-typed-ast==1.4.1          # via astroid
 ua-parser==0.10.0         # via -r requirements/edx/base.txt, django-cookies-samesite
 unicodecsv==0.14.1        # via -r requirements/edx/base.txt, edx-enterprise
 unidiff==0.6.0            # via -r requirements/edx/testing.in, coverage-pytest-plugin
@@ -299,7 +296,7 @@ xblock-utils==2.1.1       # via -r requirements/edx/base.txt, edx-sga, lti-consu
 xblock==1.4.0             # via -r requirements/edx/base.txt, acid-xblock, crowdsourcehinter-xblock, done-xblock, edx-completion, edx-sga, edx-user-state-client, edx-when, lti-consumer-xblock, ora2, rate-xblock, staff-graded-xblock, xblock-discussion, xblock-drag-and-drop-v2, xblock-google-drive, xblock-poll, xblock-utils
 xmlsec==1.3.9             # via -r requirements/edx/base.txt, python3-saml
 xss-utils==0.1.3          # via -r requirements/edx/base.txt
-zipp==1.0.0               # via -c requirements/edx/../constraints.txt, -r requirements/edx/base.txt, -r requirements/edx/coverage.txt, importlib-metadata, importlib-resources
+zipp==1.0.0               # via -c requirements/edx/../constraints.txt, -r requirements/edx/coverage.txt, importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools


### PR DESCRIPTION
Testing edx-django-utils PR: https://github.com/edx/edx-django-utils/pull/70

Note: It turns out that a commit on this branch may need to be merged before the refactor can land, because a test was using a private variable.