### PR TITLE
Change gendered language to gender-neutral 'they/them/their'

### DIFF
--- a/cms/djangoapps/contentstore/views/user.py
+++ b/cms/djangoapps/contentstore/views/user.py
@@ -161,7 +161,7 @@ def _course_team_user(request, course_key, email):
     # can't modify an inactive user but can remove it
     if not (user.is_active or new_role is None):
         msg = {
-            "error": _(u'User {email} has registered but has not yet activated his/her account.').format(email=email),
+            "error": _(u'User {email} has registered but has not yet activated their account.').format(email=email),
         }
         return JsonResponse(msg, 400)
 

--- a/common/djangoapps/student/tests/test_activate_account.py
+++ b/common/djangoapps/student/tests/test_activate_account.py
@@ -85,7 +85,7 @@ class TestActivateAccount(TestCase):
         """
         Verify that account correct activation message is displayed.
 
-        If logged in user has not activated his/her account, make sure that an
+        If logged in user has not activated their account, make sure that an
         account activation message is displayed on dashboard sidebar.
         """
         # Log in with test user.

--- a/common/djangoapps/student/tests/test_verification_status.py
+++ b/common/djangoapps/student/tests/test_verification_status.py
@@ -249,7 +249,7 @@ class TestCourseVerificationStatus(UrlResetMixin, ModuleStoreTestCase):
         attempt.mark_ready()
         attempt.submit()
 
-        # Expect that learner has submitted photos for reverfication and his/her
+        # Expect that learner has submitted photos for reverfication and their
         # previous verification is set to expired soon.
         self._assert_course_verification_status(VERIFY_STATUS_RESUBMITTED)
 

--- a/common/djangoapps/student/views/dashboard.py
+++ b/common/djangoapps/student/views/dashboard.py
@@ -156,7 +156,7 @@ def _create_recent_enrollment_message(course_enrollments, course_modes):
 
 def get_course_enrollments(user, org_whitelist, org_blacklist, course_limit=None):
     """
-    Given a user, return a filtered set of his or her course enrollments.
+    Given a user, return a filtered set of their course enrollments.
 
     Arguments:
         user (User): the user in question.
@@ -195,7 +195,7 @@ def get_course_enrollments(user, org_whitelist, org_blacklist, course_limit=None
 
 def get_filtered_course_entitlements(user, org_whitelist, org_blacklist):
     """
-    Given a user, return a filtered set of his or her course entitlements.
+    Given a user, return a filtered set of their course entitlements.
 
     Arguments:
         user (User): the user in question.
@@ -428,7 +428,7 @@ def _credit_statuses(user, course_enrollments):
                 status["error"] = True
                 log.error(
                     u"Could not find credit provider associated with credit enrollment "
-                    u"for user %s in course %s.  The user will not be able to see his or her "
+                    u"for user %s in course %s.  The user will not be able to see their "
                     u"credit request status on the student dashboard.  This attribute should "
                     u"have been set when the user purchased credit in the course.",
                     user.id, course_key
@@ -443,7 +443,7 @@ def _credit_statuses(user, course_enrollments):
                     status["error"] = True
                     log.error(
                         u"Could not find credit provider info for [%s] in [%s]. The user will not "
-                        u"be able to see his or her credit request status on the student dashboard.",
+                        u"be able to see their credit request status on the student dashboard.",
                         provider_id, provider_info_by_id
                     )
 

--- a/common/lib/xmodule/xmodule/js/src/video/06_video_progress_slider.js
+++ b/common/lib/xmodule/xmodule/js/src/video/06_video_progress_slider.js
@@ -287,7 +287,7 @@ function() {
     // the title attribute of the slider know to "video ended", and focusing
     // on it. The screen reader will read the attr text.
     //
-    // The user can then tab his way forward, landing on the next control
+    // The user can then tab their way forward, landing on the next control
     // element, the Play button.
     //
     // @param params  -  object with property `end`. If set to true, the

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -2527,7 +2527,7 @@ paths:
         \ named by the 'user' GET\nparameter. If the username does not match that\
         \ of the currently logged in user, only\ncourses for which the currently logged\
         \ in user has the Staff or Admin role are listed.\nAs a result, a course team\
-        \ member can find out which of his or her own courses a particular\nlearner\
+        \ member can find out which of their own courses a particular\nlearner\
         \ is enrolled in.\n\nOnly the Staff or Admin role (granted on the Django administrative\
         \ console as the staff\nor instructor permission) in individual courses gives\
         \ the requesting user access to\nenrollment data. Permissions granted at the\

--- a/lms/djangoapps/branding/views.py
+++ b/lms/djangoapps/branding/views.py
@@ -37,7 +37,7 @@ def index(request):
     """
     if request.user.is_authenticated:
         # Only redirect to dashboard if user has
-        # courses in his/her dashboard. Otherwise UX is a bit cryptic.
+        # courses in their dashboard. Otherwise UX is a bit cryptic.
         # In this case, we want to have the user stay on a course catalog
         # page to make it easier to browse for courses (and register)
         if configuration_helpers.get_value(

--- a/lms/djangoapps/ccx/utils.py
+++ b/lms/djangoapps/ccx/utils.py
@@ -293,7 +293,7 @@ def ccx_course(ccx_locator):
 
 def assign_staff_role_to_ccx(ccx_locator, user, master_course_id):
     """
-    Check if user has ccx_coach role on master course then assign him staff role on ccx only
+    Check if user has ccx_coach role on master course then assign them staff role on ccx only
     if role is not already assigned. Because of this coach can open dashboard from master course
     as well as ccx.
     :param ccx_locator: CCX key

--- a/lms/djangoapps/certificates/queue.py
+++ b/lms/djangoapps/certificates/queue.py
@@ -78,7 +78,7 @@ class XQueueCertInterface(object):
 
        del_cert:   Delete an existing certificate
                    For a user that already has a certificate
-                   this will delete his cert.
+                   this will delete their cert.
 
     """
 

--- a/lms/djangoapps/courseware/tests/test_about.py
+++ b/lms/djangoapps/courseware/tests/test_about.py
@@ -485,7 +485,7 @@ class CourseAboutTestCaseCCX(SharedModuleStoreTestCase, LoginEnrollmentTestCase)
     def test_redirect_to_dashboard_unenrolled_ccx(self):
         """
         Assert that when unenrolled user tries to access CCX do not allow the user to self-register.
-        Redirect him to his student dashboard
+        Redirect them to their student dashboard
         """
 
         # create ccx

--- a/lms/djangoapps/courseware/tests/test_course_info.py
+++ b/lms/djangoapps/courseware/tests/test_course_info.py
@@ -337,8 +337,8 @@ class CourseInfoTestCaseCCX(SharedModuleStoreTestCase, LoginEnrollmentTestCase):
 
     def test_redirect_to_dashboard_unenrolled_ccx(self):
         """
-        Assert that when unenroll student tries to access ccx do not allow him self-register.
-        Redirect him to his student dashboard
+        Assert that when unenroll student tries to access ccx do not allow them self-register.
+        Redirect them to their student dashboard
         """
         # create ccx
         ccx = CcxFactory(course_id=self.course.id, coach=self.coach)

--- a/lms/djangoapps/discussion/django_comment_client/base/tests.py
+++ b/lms/djangoapps/discussion/django_comment_client/base/tests.py
@@ -1517,7 +1517,7 @@ class TeamsPermissionsTestCase(ForumsEnableMixin, UrlResetMixin, SharedModuleSto
         self.client.login(username=user.username, password=self.password)
 
     @ddt.data(
-        # student_in_team will be able to update his own post, regardless of team membership
+        # student_in_team will be able to update their own post, regardless of team membership
         ('student_in_team', 'student_in_team', 'team_commentable_id', 200, CourseDiscussionSettings.NONE),
         ('student_in_team', 'student_in_team', 'course_commentable_id', 200, CourseDiscussionSettings.NONE),
         # students can only update their own posts

--- a/lms/djangoapps/support/views/certificate.py
+++ b/lms/djangoapps/support/views/certificate.py
@@ -20,8 +20,8 @@ class CertificatesSupportView(View):
     such as:
 
     * The user's name was spelled incorrectly.
-    * The user later earned a higher grade and wants it on his/her certificate and dashboard.
-    * The user accidentally received an honor code certificate because his/her
+    * The user later earned a higher grade and wants it on their certificate and dashboard.
+    * The user accidentally received an honor code certificate because their
         verification expired before certs were generated.
 
     Most of the heavy lifting is performed client-side through API

--- a/lms/djangoapps/verify_student/message_types.py
+++ b/lms/djangoapps/verify_student/message_types.py
@@ -16,7 +16,7 @@ class VerificationExpiry(BaseMessageType):
 
 class VerificationApproved(BaseMessageType):
     """
-    A message to the learner when his ID verification has been approved.
+    A message to the learner when their ID verification has been approved.
     """
     APP_LABEL = 'verify_student'
     Name = 'verificationapproved'
@@ -28,7 +28,7 @@ class VerificationApproved(BaseMessageType):
 
 class VerificationSubmitted(BaseMessageType):
     """
-    A confirmation message to the learner when his ID verification has been submitted.
+    A confirmation message to the learner when their ID verification has been submitted.
     """
     APP_LABEL = 'verify_student'
     Name = 'verificationsubmitted'

--- a/lms/djangoapps/verify_student/views.py
+++ b/lms/djangoapps/verify_student/views.py
@@ -508,7 +508,7 @@ class PayAndVerifyView(View):
 
         if user_is_trying_to_pay and self._get_user_active_status(user) and not already_paid:
             # If the user is trying to pay, has activated their account, and the ecommerce service
-            # is enabled redirect him to the ecommerce checkout page.
+            # is enabled redirect them to the ecommerce checkout page.
             ecommerce_service = EcommerceService()
             if ecommerce_service.is_enabled(user):
                 url = ecommerce_service.get_checkout_page_url(

--- a/openedx/core/djangoapps/credit/api/eligibility.py
+++ b/openedx/core/djangoapps/credit/api/eligibility.py
@@ -260,7 +260,7 @@ def set_credit_requirement_status(user, course_key, req_namespace, req_name, sta
                 u'Could not update credit requirement in course "%s" '
                 u'with namespace "%s" and name "%s" '
                 u'because the requirement does not exist. '
-                u'The user "%s" should have had his/her status updated to "%s".'
+                u'The user "%s" should have had their status updated to "%s".'
             ),
             six.text_type(course_key), req_namespace, req_name, user.username, status
         )

--- a/openedx/core/djangoapps/enrollments/views.py
+++ b/openedx/core/djangoapps/enrollments/views.py
@@ -628,7 +628,7 @@ class EnrollmentListView(APIView, ApiKeyPermissionMixIn):
         Returns a list for the currently logged in user, or for the user named by the 'user' GET
         parameter. If the username does not match that of the currently logged in user, only
         courses for which the currently logged in user has the Staff or Admin role are listed.
-        As a result, a course team member can find out which of his or her own courses a particular
+        As a result, a course team member can find out which of their own courses a particular
         learner is enrolled in.
 
         Only the Staff or Admin role (granted on the Django administrative console as the staff


### PR DESCRIPTION
There was one user-facing string with gendered language, as well as a number of comments/docstrings throughout the codebase.

per https://openedx.atlassian.net/browse/TNL-7560