### PR TITLE
Pin ORA to 2.10.3

### DIFF
--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -130,3 +130,7 @@ pymongo<3.11
 
 # vulture 2.0 requires Python >= 3.6
 vulture<2.0
+
+# ORA is fixing some deployment errors so this is here temporarily to stop
+# the daily requirements update from breaking things
+ora2==2.10.3  


### PR DESCRIPTION
So that daily requirements updates doesn't break things until we've fixed them for good