### PR TITLE
update devstack video upload authentication mechanism

### DIFF
--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -563,6 +563,7 @@ AWS_SES_REGION_NAME = 'us-east-1'
 AWS_SES_REGION_ENDPOINT = 'email.us-east-1.amazonaws.com'
 AWS_ACCESS_KEY_ID = None
 AWS_SECRET_ACCESS_KEY = None
+AWS_SECURITY_TOKEN = None
 AWS_QUERYSTRING_AUTH = False
 AWS_STORAGE_BUCKET_NAME = 'SET-ME-PLEASE (ex. bucket-name)'
 AWS_S3_CUSTOM_DOMAIN = 'SET-ME-PLEASE (ex. bucket-name.s3.amazonaws.com)'


### PR DESCRIPTION
### [PROD-2198](https://openedx.atlassian.net/browse/PROD-2198)

### Description

The logic for getting AWS credentials for devstack studio uploads is not applicable with [OneLogin assume role script](https://github.com/edx/edx-internal/blob/master/scripts/assume-role-onelogin.sh). The current code in the platform used STS assume the role to get the credentials and used the returned credentials to make S3 connection.

 However, the new script updates the credentials in `~/.aws/credentials` file and uses onelogin assume role mechanism. To make the upload mechanism compatible, django setting variables are being used. After the assume role and the credentials update in ~/.aws/credentials file, add/update the following setting variables in cms/envs/private.py file:

- AWS_ACCESS_KEY_ID
- AWS_SECRET_ACCESS_KEY
- AWS_SECURITY_TOKEN

For each variable, add the corresponding value from the credentials file. Once the studio service detects the change and restarts, the videos will start uploading to S3.