### PR TITLE
SysAdmin: Removed external authentication map repair button from User Tab

### DIFF
--- a/lms/djangoapps/dashboard/decisions/0001-sysadmin-dashboard.rst
+++ b/lms/djangoapps/dashboard/decisions/0001-sysadmin-dashboard.rst
@@ -24,8 +24,7 @@ Decision
 --------
 
 The users tab provides Web based user management (create and delete user accounts), a listing of courses loaded,
-and user statistics. There is also a button to repair the external authentication map, a task relevant to open
-edX installations using Shibboleth and certificate-based authentication.
+and user statistics.
 
 The courses tabs manages adding/updating courses from git, deleting courses, and provides course listing information,
 including commit hash, date and author for course imported from git.

--- a/lms/templates/sysadmin_dashboard.html
+++ b/lms/templates/sysadmin_dashboard.html
@@ -97,12 +97,6 @@ textarea {
 	  </button>
     </p>
 
-    <p>
-    <button type="submit" name="action" value="repair_eamap" style="width: 350px;">
-	  ${_('Check and repair external authentication map')}
-	</button>
-    </p>
-
     <hr width="40%" style="align:left">
 	</form>
  %endif


### PR DESCRIPTION
fixes https://github.com/mitodl/edx-platform/issues/193

This PR removes `Check and repair external authentication map` button from Sysadmin's User tab. The backend code for this functionality was already removed here https://github.com/edx/edx-platform/commit/2c149ca6be5f97484a52aa267e340e0eba72acf3.

**Testing Instructions:**
1. In codebase, go to `/lms/envs/devstack.py` and set/add `FEATURES['ENABLE_SYSADMIN_DASHBOARD'] = True`
2. On your browser, go to `/sysadmin` and select `Users` tab

Screenshot **(New)**:
<img width="1243" alt="Screenshot 2020-11-04 at 1 53 25 PM" src="https://user-images.githubusercontent.com/34372316/98092098-1d4f3000-1ea8-11eb-9faf-c3b110e0e221.png">

Screenshot **(Old)**:
<img width="1260" alt="Screenshot 2020-11-04 at 1 54 10 PM" src="https://user-images.githubusercontent.com/34372316/98092147-2cce7900-1ea8-11eb-9717-cb899daa8135.png">
