### PR TITLE
Squashes CourseWaffleFlag waffle_utils.WaffleFlag deprecation warning

### DIFF
--- a/openedx/core/djangoapps/waffle_utils/__init__.py
+++ b/openedx/core/djangoapps/waffle_utils/__init__.py
@@ -121,7 +121,7 @@ class WaffleFlag(BaseWaffleFlag):
             yield
 
 
-class CourseWaffleFlag(WaffleFlag):
+class CourseWaffleFlag(BaseWaffleFlag):
     """
     Represents a single waffle flag that can be forced on/off for a course. This class should be used instead of
     WaffleFlag when in the context of a course.


### PR DESCRIPTION
A new `waffle_utils.WaffleFlag` deprecation warning appeared when running the following line in the devstack.
```python
./manage.py lms shell
```

The deprecation warning is a result of [this commit, *Re-introduce waffle classes (with deprecation warnings)*](https://github.com/edx/edx-platform/commit/c9c11364596186a077d00f448710c5f20dc62685).

It seems like when that commit was added, and this line was removed:
```diff
- from edx_toggles.toggles import WaffleFlag, WaffleFlagNamespace, WaffleSwitch, WaffleSwitchNamespace
```
The warning started showing because `CourseWaffleFlag` is now inheriting the `waffle_utils.WaffleFlag` instead of `edx_toggles.toggles.WaffleFlag`.

I thought at first that I might have to move the `CourseWaffleFlag` to [edx/edx-toggles](https://github.com/edx/edx-toggles) repository. Howevever, once I checked that repository, and the file containing the `WaffleFlag` class, I noticed the following comments:
> Send waffle flag value to monitoring. We keep this method such that it can be called by child classes (such as **edx-platform's waffle_utils.CourseWaffleFlag**), but it should not be considered a stable API.
> 
> 
> 
> The value Both would mean that the flag had both a True and False value at different times during the transaction. This is most likely due to happen in WaffleFlag child classes, such as **edx-platform's waffle_utils.CourseWaffleFlag**.
> 
> 
*The comments mentioned above can be [found in this python file](https://github.com/edx/edx-toggles/blob/master/edx_toggles/toggles/internal/waffle.py)*

So, it seems like the `CourseWaffleFlag` is intended to be in the edx-platform's `waffle_utils.CourseWaffleFlag`, which is why I set the parent class to `BaseWaffleFlag` (which is `edx_toggles.toggles.WaffleFlag`).

**JIRA tickets**: [OSPR-5108](https://openedx.atlassian.net/browse/OSPR-5108)

**Testing instructions**:

- Running `./manage.py lms shell` and making sure the warning doesn't show up for `CourseWaffleFlag` usages.
- Checking Jenkins build status

**Author notes and concerns**:

- After reading the PR description, please let me know if you'd like me to move the `CourseWaffleFlag` to the [edx/edx-toggles](https://github.com/edx/edx-toggles) repository.