### PR TITLE
[BD-21] Start waffle namespace deprecation process

### DIFF
--- a/cms/djangoapps/contentstore/config/waffle.py
+++ b/cms/djangoapps/contentstore/config/waffle.py
@@ -4,7 +4,7 @@ waffle switches for the contentstore app.
 """
 
 
-from edx_toggles.toggles import WaffleFlag, WaffleFlagNamespace, WaffleSwitchNamespace
+from edx_toggles.toggles import LegacyWaffleFlag, LegacyWaffleFlagNamespace, LegacyWaffleSwitchNamespace
 from openedx.core.djangoapps.waffle_utils import CourseWaffleFlag
 
 # Namespace
@@ -18,14 +18,14 @@ def waffle():
     """
     Returns the namespaced, cached, audited Waffle Switch class for Studio pages.
     """
-    return WaffleSwitchNamespace(name=WAFFLE_NAMESPACE, log_prefix=u'Studio: ')
+    return LegacyWaffleSwitchNamespace(name=WAFFLE_NAMESPACE, log_prefix=u'Studio: ')
 
 
 def waffle_flags():
     """
     Returns the namespaced, cached, audited Waffle Flag class for Studio pages.
     """
-    return WaffleFlagNamespace(name=WAFFLE_NAMESPACE, log_prefix=u'Studio: ')
+    return LegacyWaffleFlagNamespace(name=WAFFLE_NAMESPACE, log_prefix=u'Studio: ')
 
 
 # TODO: After removing this flag, add a migration to remove waffle flag in a follow-up deployment.
@@ -51,7 +51,7 @@ SHOW_REVIEW_RULES_FLAG = CourseWaffleFlag(
 # .. toggle_target_removal_date: 2020-12-31
 # .. toggle_warnings: Also set settings.LIBRARY_AUTHORING_MICROFRONTEND_URL and ENABLE_LIBRARY_AUTHORING_MICROFRONTEND.
 # .. toggle_tickets: https://openedx.atlassian.net/wiki/spaces/COMM/pages/1545011241/BD-14+Blockstore+Powered+Content+Libraries+Taxonomies
-REDIRECT_TO_LIBRARY_AUTHORING_MICROFRONTEND = WaffleFlag(
+REDIRECT_TO_LIBRARY_AUTHORING_MICROFRONTEND = LegacyWaffleFlag(
     waffle_namespace=waffle_flags(),
     flag_name='library_authoring_mfe',
     module_name=__name__,

--- a/cms/djangoapps/contentstore/views/course.py
+++ b/cms/djangoapps/contentstore/views/course.py
@@ -23,7 +23,7 @@ from django.urls import reverse
 from django.utils.translation import ugettext as _
 from django.views.decorators.csrf import ensure_csrf_cookie
 from django.views.decorators.http import require_GET, require_http_methods
-from edx_toggles.toggles import WaffleSwitchNamespace
+from edx_toggles.toggles import LegacyWaffleSwitchNamespace
 from milestones import api as milestones_api
 from opaque_keys import InvalidKeyError
 from opaque_keys.edx.keys import CourseKey
@@ -511,7 +511,7 @@ def course_listing(request):
     """
 
     optimization_enabled = GlobalStaff().has_user(request.user) and \
-        WaffleSwitchNamespace(name=WAFFLE_NAMESPACE).is_enabled(u'enable_global_staff_optimization')
+        LegacyWaffleSwitchNamespace(name=WAFFLE_NAMESPACE).is_enabled(u'enable_global_staff_optimization')
 
     org = request.GET.get('org', '') if optimization_enabled else None
     courses_iter, in_process_course_actions = get_courses_accessible_to_user(request, org)

--- a/cms/djangoapps/contentstore/views/item.py
+++ b/cms/djangoapps/contentstore/views/item.py
@@ -21,7 +21,7 @@ from edx_proctoring.api import (
     get_exam_configuration_dashboard_url
 )
 from edx_proctoring.exceptions import ProctoredExamNotFoundException
-from edx_toggles.toggles import WaffleSwitch
+from edx_toggles.toggles import LegacyWaffleSwitch
 from help_tokens.core import HelpUrlExpert
 from opaque_keys.edx.keys import CourseKey
 from opaque_keys.edx.locator import LibraryUsageLocator
@@ -91,7 +91,7 @@ NEVER = lambda x: False
 ALWAYS = lambda x: True
 
 
-highlights_setting = WaffleSwitch('dynamic_pacing', 'studio_course_update', __name__)
+highlights_setting = LegacyWaffleSwitch('dynamic_pacing', 'studio_course_update', __name__)
 
 
 def _filter_entrance_exam_grader(graders):

--- a/cms/djangoapps/contentstore/views/tests/test_videos.py
+++ b/cms/djangoapps/contentstore/views/tests/test_videos.py
@@ -16,7 +16,7 @@ import pytz
 import six
 from django.conf import settings
 from django.test.utils import override_settings
-from edx_toggles.toggles import WaffleSwitch
+from edx_toggles.toggles import LegacyWaffleSwitch
 from edx_toggles.toggles.testutils import override_waffle_flag, override_waffle_switch
 from edxval.api import (
     create_or_update_transcript_preferences,
@@ -54,7 +54,7 @@ from ..videos import (
     convert_video_status
 )
 
-VIDEO_IMAGE_UPLOAD_ENABLED_SWITCH = WaffleSwitch(WAFFLE_SWITCHES, VIDEO_IMAGE_UPLOAD_ENABLED)
+VIDEO_IMAGE_UPLOAD_ENABLED_SWITCH = LegacyWaffleSwitch(WAFFLE_SWITCHES, VIDEO_IMAGE_UPLOAD_ENABLED)
 
 
 class VideoUploadTestBase(object):

--- a/cms/djangoapps/contentstore/views/videos.py
+++ b/cms/djangoapps/contentstore/views/videos.py
@@ -44,7 +44,7 @@ from rest_framework import status as rest_status
 from rest_framework.decorators import api_view
 from rest_framework.response import Response
 
-from edx_toggles.toggles import WaffleFlagNamespace, WaffleSwitchNamespace
+from edx_toggles.toggles import LegacyWaffleFlagNamespace, LegacyWaffleSwitchNamespace
 from common.djangoapps.edxmako.shortcuts import render_to_response
 from openedx.core.djangoapps.video_config.models import VideoTranscriptEnabledFlag
 from openedx.core.djangoapps.video_pipeline.config.waffle import (
@@ -74,13 +74,13 @@ LOGGER = logging.getLogger(__name__)
 
 # Waffle switches namespace for videos
 WAFFLE_NAMESPACE = 'videos'
-WAFFLE_SWITCHES = WaffleSwitchNamespace(name=WAFFLE_NAMESPACE)
+WAFFLE_SWITCHES = LegacyWaffleSwitchNamespace(name=WAFFLE_NAMESPACE)
 
 # Waffle switch for enabling/disabling video image upload feature
 VIDEO_IMAGE_UPLOAD_ENABLED = 'video_image_upload_enabled'
 
 # Waffle flag namespace for studio
-WAFFLE_STUDIO_FLAG_NAMESPACE = WaffleFlagNamespace(name=u'studio')
+WAFFLE_STUDIO_FLAG_NAMESPACE = LegacyWaffleFlagNamespace(name=u'studio')
 
 ENABLE_VIDEO_UPLOAD_PAGINATION = CourseWaffleFlag(
     waffle_namespace=WAFFLE_STUDIO_FLAG_NAMESPACE,

--- a/common/djangoapps/student/__init__.py
+++ b/common/djangoapps/student/__init__.py
@@ -3,7 +3,7 @@ Student app helpers and settings
 """
 
 
-from edx_toggles.toggles import WaffleSwitchNamespace
+from edx_toggles.toggles import LegacyWaffleSwitchNamespace
 
 # Namespace for student app waffle switches
-STUDENT_WAFFLE_NAMESPACE = WaffleSwitchNamespace(name='student')
+STUDENT_WAFFLE_NAMESPACE = LegacyWaffleSwitchNamespace(name='student')

--- a/common/djangoapps/student/admin.py
+++ b/common/djangoapps/student/admin.py
@@ -22,7 +22,7 @@ from django.utils.translation import ugettext_lazy as _
 from opaque_keys import InvalidKeyError
 from opaque_keys.edx.keys import CourseKey
 
-from edx_toggles.toggles import WaffleSwitch
+from edx_toggles.toggles import LegacyWaffleSwitch
 from openedx.core.lib.courses import clean_course_id
 from common.djangoapps.student import STUDENT_WAFFLE_NAMESPACE
 from common.djangoapps.student.models import (
@@ -53,7 +53,7 @@ User = get_user_model()  # pylint:disable=invalid-name
 # This switch exists because the CourseEnrollment admin views make DB queries that impact performance.
 # In a large enough deployment of Open edX, this is enough to cause a site outage.
 # See https://openedx.atlassian.net/browse/OPS-2943
-COURSE_ENROLLMENT_ADMIN_SWITCH = WaffleSwitch(STUDENT_WAFFLE_NAMESPACE, 'courseenrollment_admin', __name__)
+COURSE_ENROLLMENT_ADMIN_SWITCH = LegacyWaffleSwitch(STUDENT_WAFFLE_NAMESPACE, 'courseenrollment_admin', __name__)
 
 
 class _Check(object):

--- a/common/djangoapps/student/views/dashboard.py
+++ b/common/djangoapps/student/views/dashboard.py
@@ -16,7 +16,7 @@ from django.utils.translation import ugettext as _
 from django.views.decorators.csrf import ensure_csrf_cookie
 from edx_django_utils import monitoring as monitoring_utils
 from edx_django_utils.plugins import get_plugins_view_context
-from edx_toggles.toggles import WaffleFlag, WaffleFlagNamespace
+from edx_toggles.toggles import LegacyWaffleFlag, LegacyWaffleFlagNamespace
 from opaque_keys.edx.keys import CourseKey
 from pytz import UTC
 from six import iteritems, text_type
@@ -62,7 +62,7 @@ from xmodule.modulestore.django import modulestore
 
 log = logging.getLogger("edx.student")
 
-experiments_namespace = WaffleFlagNamespace(name=u'student.experiments')
+experiments_namespace = LegacyWaffleFlagNamespace(name=u'student.experiments')
 
 
 def get_org_black_and_whitelist_for_site():
@@ -638,7 +638,7 @@ def student_dashboard(request):
     inverted_programs = meter.invert_programs()
 
     urls, programs_data = {}, {}
-    bundles_on_dashboard_flag = WaffleFlag(experiments_namespace, u'bundles_on_dashboard', __name__)
+    bundles_on_dashboard_flag = LegacyWaffleFlag(experiments_namespace, u'bundles_on_dashboard', __name__)
 
     # TODO: Delete this code and the relevant HTML code after testing LEARNER-3072 is complete
     if bundles_on_dashboard_flag.is_enabled() and inverted_programs and list(inverted_programs.items()):

--- a/common/lib/xmodule/xmodule/seq_module.py
+++ b/common/lib/xmodule/xmodule/seq_module.py
@@ -23,7 +23,7 @@ from xblock.core import XBlock
 from xblock.exceptions import NoSuchServiceError
 from xblock.fields import Boolean, Integer, List, Scope, String
 
-from edx_toggles.toggles import WaffleFlag
+from edx_toggles.toggles import LegacyWaffleFlag
 from openedx.core.lib.graph_traversals import traverse_pre_order
 
 from .exceptions import NotFoundError
@@ -48,7 +48,7 @@ class_priority = ['video', 'problem']
 #  `django.utils.translation.ugettext_noop` because Django cannot be imported in this file
 _ = lambda text: text
 
-TIMED_EXAM_GATING_WAFFLE_FLAG = WaffleFlag(
+TIMED_EXAM_GATING_WAFFLE_FLAG = LegacyWaffleFlag(
     waffle_namespace="xmodule",
     flag_name=u'rev_1377_rollout',
     module_name=__name__,

--- a/lms/djangoapps/certificates/tests/test_signals.py
+++ b/lms/djangoapps/certificates/tests/test_signals.py
@@ -7,7 +7,7 @@ and disabling for instructor-paced courses.
 import ddt
 import mock
 import six
-from edx_toggles.toggles import WaffleSwitch
+from edx_toggles.toggles import LegacyWaffleSwitch
 from edx_toggles.toggles.testutils import override_waffle_switch
 from common.djangoapps.student.tests.factories import CourseEnrollmentFactory, UserFactory
 from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
@@ -26,7 +26,7 @@ from lms.djangoapps.grades.tests.utils import mock_passing_grade
 from lms.djangoapps.verify_student.models import IDVerificationAttempt, SoftwareSecurePhotoVerification
 from openedx.core.djangoapps.certificates.config import waffle
 
-AUTO_CERTIFICATE_GENERATION_SWITCH = WaffleSwitch(waffle.waffle(), waffle.AUTO_CERTIFICATE_GENERATION)
+AUTO_CERTIFICATE_GENERATION_SWITCH = LegacyWaffleSwitch(waffle.waffle(), waffle.AUTO_CERTIFICATE_GENERATION)
 
 
 class SelfGeneratedCertsSignalTest(ModuleStoreTestCase):

--- a/lms/djangoapps/certificates/tests/test_webview_views.py
+++ b/lms/djangoapps/certificates/tests/test_webview_views.py
@@ -18,7 +18,7 @@ from mock import patch
 from organizations import api as organizations_api
 
 from common.djangoapps.course_modes.models import CourseMode
-from edx_toggles.toggles import WaffleSwitch
+from edx_toggles.toggles import LegacyWaffleSwitch
 from edx_toggles.toggles.testutils import override_waffle_switch
 from lms.djangoapps.badges.events.course_complete import get_completion_badge
 from lms.djangoapps.badges.tests.factories import (
@@ -58,7 +58,7 @@ from common.djangoapps.util.date_utils import strftime_localized
 from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
 from xmodule.modulestore.tests.factories import CourseFactory
 
-AUTO_CERTIFICATE_GENERATION_SWITCH = WaffleSwitch(waffle.waffle(), waffle.AUTO_CERTIFICATE_GENERATION)
+AUTO_CERTIFICATE_GENERATION_SWITCH = LegacyWaffleSwitch(waffle.waffle(), waffle.AUTO_CERTIFICATE_GENERATION)
 FEATURES_WITH_CERTS_ENABLED = settings.FEATURES.copy()
 FEATURES_WITH_CERTS_ENABLED['CERTIFICATES_HTML_VIEW'] = True
 FEATURES_WITH_BADGES_ENABLED = FEATURES_WITH_CERTS_ENABLED.copy()

--- a/lms/djangoapps/course_api/__init__.py
+++ b/lms/djangoapps/course_api/__init__.py
@@ -1,9 +1,9 @@
 """ Course API """
 
 
-from edx_toggles.toggles import WaffleSwitch, WaffleSwitchNamespace
+from edx_toggles.toggles import LegacyWaffleSwitch, LegacyWaffleSwitchNamespace
 
-WAFFLE_SWITCH_NAMESPACE = WaffleSwitchNamespace(name='course_list_api_rate_limit')
+WAFFLE_SWITCH_NAMESPACE = LegacyWaffleSwitchNamespace(name='course_list_api_rate_limit')
 
 # .. toggle_name: course_list_api_rate_limit.rate_limit_2
 # .. toggle_implementation: WaffleSwitch
@@ -15,7 +15,7 @@ WAFFLE_SWITCH_NAMESPACE = WaffleSwitchNamespace(name='course_list_api_rate_limit
 # .. toggle_target_removal_date: None
 # .. toggle_warnings: None
 # .. toggle_tickets: https://openedx.atlassian.net/browse/LEARNER-5527
-USE_RATE_LIMIT_2_FOR_COURSE_LIST_API = WaffleSwitch(WAFFLE_SWITCH_NAMESPACE, 'rate_limit_2', __name__)
+USE_RATE_LIMIT_2_FOR_COURSE_LIST_API = LegacyWaffleSwitch(WAFFLE_SWITCH_NAMESPACE, 'rate_limit_2', __name__)
 # .. toggle_name: course_list_api_rate_limit.rate_limit_10
 # .. toggle_implementation: WaffleSwitch
 # .. toggle_default: False
@@ -26,4 +26,4 @@ USE_RATE_LIMIT_2_FOR_COURSE_LIST_API = WaffleSwitch(WAFFLE_SWITCH_NAMESPACE, 'ra
 # .. toggle_target_removal_date: None
 # .. toggle_warnings: None
 # .. toggle_tickets: https://openedx.atlassian.net/browse/LEARNER-5527
-USE_RATE_LIMIT_10_FOR_COURSE_LIST_API = WaffleSwitch(WAFFLE_SWITCH_NAMESPACE, 'rate_limit_10', __name__)
+USE_RATE_LIMIT_10_FOR_COURSE_LIST_API = LegacyWaffleSwitch(WAFFLE_SWITCH_NAMESPACE, 'rate_limit_10', __name__)

--- a/lms/djangoapps/course_api/blocks/toggles.py
+++ b/lms/djangoapps/course_api/blocks/toggles.py
@@ -3,9 +3,9 @@ Toggles for Course API.
 """
 
 
-from edx_toggles.toggles import WaffleFlag, WaffleFlagNamespace
+from edx_toggles.toggles import LegacyWaffleFlag, LegacyWaffleFlagNamespace
 
-COURSE_BLOCKS_API_NAMESPACE = WaffleFlagNamespace(name=u'course_blocks_api')
+COURSE_BLOCKS_API_NAMESPACE = LegacyWaffleFlagNamespace(name=u'course_blocks_api')
 
 # .. toggle_name: course_blocks_api.hide_access_denials
 # .. toggle_implementation: WaffleFlag
@@ -16,7 +16,7 @@ COURSE_BLOCKS_API_NAMESPACE = WaffleFlagNamespace(name=u'course_blocks_api')
 # .. toggle_target_removal_date: None
 # .. toggle_warnings: This temporary feature toggle does not have a target removal date.
 # .. toggle_tickets: None
-HIDE_ACCESS_DENIALS_FLAG = WaffleFlag(
+HIDE_ACCESS_DENIALS_FLAG = LegacyWaffleFlag(
     waffle_namespace=COURSE_BLOCKS_API_NAMESPACE,
     flag_name=u'hide_access_denials',
     module_name=__name__,

--- a/lms/djangoapps/course_home_api/toggles.py
+++ b/lms/djangoapps/course_home_api/toggles.py
@@ -2,11 +2,11 @@
 Toggles for course home experience.
 """
 
-from edx_toggles.toggles import WaffleFlagNamespace
+from edx_toggles.toggles import LegacyWaffleFlagNamespace
 from lms.djangoapps.experiments.flags import ExperimentWaffleFlag
 from openedx.core.djangoapps.waffle_utils import CourseWaffleFlag
 
-WAFFLE_FLAG_NAMESPACE = WaffleFlagNamespace(name='course_home')
+WAFFLE_FLAG_NAMESPACE = LegacyWaffleFlagNamespace(name='course_home')
 
 COURSE_HOME_MICROFRONTEND = ExperimentWaffleFlag(WAFFLE_FLAG_NAMESPACE, 'course_home_mfe', __name__)
 

--- a/lms/djangoapps/courseware/module_render.py
+++ b/lms/djangoapps/courseware/module_render.py
@@ -11,7 +11,7 @@ from collections import OrderedDict
 from functools import partial
 
 import six
-from completion import waffle as completion_waffle
+from completion.waffle import ENABLE_COMPLETION_TRACKING_SWITCH
 from completion.models import BlockCompletion
 from django.conf import settings
 from django.contrib.auth.models import User
@@ -536,7 +536,7 @@ def get_module_system_for_user(
         handlers = {
             'grade': handle_grade_event,
         }
-        if completion_waffle.waffle().is_enabled(completion_waffle.ENABLE_COMPLETION_TRACKING):
+        if ENABLE_COMPLETION_TRACKING_SWITCH.is_enabled():
             handlers.update({
                 'completion': handle_completion_event,
                 'progress': handle_deprecated_progress_event,
@@ -567,7 +567,7 @@ def get_module_system_for_user(
         """
         Submit a completion object for the block.
         """
-        if not completion_waffle.waffle().is_enabled(completion_waffle.ENABLE_COMPLETION_TRACKING):
+        if not ENABLE_COMPLETION_TRACKING_SWITCH.is_enabled():
             raise Http404
         else:
             BlockCompletion.objects.submit_completion(
@@ -601,7 +601,7 @@ def get_module_system_for_user(
         edx-solutions.  New XBlocks should not emit these events, but instead
         emit completion events directly.
         """
-        if not completion_waffle.waffle().is_enabled(completion_waffle.ENABLE_COMPLETION_TRACKING):
+        if not ENABLE_COMPLETION_TRACKING_SWITCH.is_enabled():
             raise Http404
         else:
             requested_user_id = event.get('user_id', user.id)

--- a/lms/djangoapps/courseware/tests/test_module_render.py
+++ b/lms/djangoapps/courseware/tests/test_module_render.py
@@ -15,7 +15,7 @@ import pytz
 import six
 from bson import ObjectId
 from capa.tests.response_xml_factory import OptionResponseXMLFactory
-from completion import waffle as completion_waffle
+from completion.waffle import ENABLE_COMPLETION_TRACKING_SWITCH
 from completion.models import BlockCompletion
 from common.djangoapps.course_modes.models import CourseMode
 from django.conf import settings
@@ -82,7 +82,6 @@ from xmodule.lti_module import LTIDescriptor
 from xmodule.modulestore import ModuleStoreEnum
 from xmodule.modulestore.django import modulestore
 from xmodule.modulestore.tests.django_utils import (
-    TEST_DATA_MIXED_MODULESTORE,
     ModuleStoreTestCase,
     SharedModuleStoreTestCase
 )
@@ -93,11 +92,6 @@ from xmodule.x_module import STUDENT_VIEW, CombinedSystem, XModule, XModuleDescr
 
 
 TEST_DATA_DIR = settings.COMMON_TEST_DATA_ROOT
-
-# pylint: disable=feature-toggle-needs-doc
-ENABLE_COMPLETION_TRACKING_SWITCH = LegacyWaffleSwitch(
-    completion_waffle.waffle(), completion_waffle.ENABLE_COMPLETION_TRACKING, __name__
-)
 
 
 @XBlock.needs("field-data")

--- a/lms/djangoapps/courseware/tests/test_module_render.py
+++ b/lms/djangoapps/courseware/tests/test_module_render.py
@@ -28,7 +28,7 @@ from django.urls import reverse
 from edx_proctoring.api import create_exam, create_exam_attempt, update_attempt_status
 from edx_proctoring.runtime import set_runtime_service
 from edx_proctoring.tests.test_services import MockCertificateService, MockCreditService, MockGradesService
-from edx_toggles.toggles import WaffleSwitch
+from edx_toggles.toggles import LegacyWaffleSwitch
 from edx_toggles.toggles.testutils import override_waffle_switch
 from edx_when.field_data import DateLookupFieldData
 from freezegun import freeze_time
@@ -95,7 +95,7 @@ from xmodule.x_module import STUDENT_VIEW, CombinedSystem, XModule, XModuleDescr
 TEST_DATA_DIR = settings.COMMON_TEST_DATA_ROOT
 
 # pylint: disable=feature-toggle-needs-doc
-ENABLE_COMPLETION_TRACKING_SWITCH = WaffleSwitch(
+ENABLE_COMPLETION_TRACKING_SWITCH = LegacyWaffleSwitch(
     completion_waffle.waffle(), completion_waffle.ENABLE_COMPLETION_TRACKING, __name__
 )
 

--- a/lms/djangoapps/courseware/toggles.py
+++ b/lms/djangoapps/courseware/toggles.py
@@ -2,12 +2,12 @@
 Toggles for courseware in-course experience.
 """
 
-from edx_toggles.toggles import WaffleFlagNamespace
+from edx_toggles.toggles import LegacyWaffleFlagNamespace
 from lms.djangoapps.experiments.flags import ExperimentWaffleFlag
 from openedx.core.djangoapps.waffle_utils import CourseWaffleFlag
 
 # Namespace for courseware waffle flags.
-WAFFLE_FLAG_NAMESPACE = WaffleFlagNamespace(name='courseware')
+WAFFLE_FLAG_NAMESPACE = LegacyWaffleFlagNamespace(name='courseware')
 
 # .. toggle_name: courseware.courseware_mfe
 # .. toggle_implementation: ExperimentWaffleFlag

--- a/lms/djangoapps/courseware/views/index.py
+++ b/lms/djangoapps/courseware/views/index.py
@@ -21,7 +21,7 @@ from django.views.decorators.cache import cache_control
 from django.views.decorators.csrf import ensure_csrf_cookie
 from django.views.generic import View
 from edx_django_utils.monitoring import set_custom_attributes_for_course_key
-from edx_toggles.toggles import WaffleSwitchNamespace
+from edx_toggles.toggles import LegacyWaffleSwitchNamespace
 from opaque_keys import InvalidKeyError
 from opaque_keys.edx.keys import CourseKey, UsageKey
 from six.moves import urllib
@@ -441,7 +441,7 @@ class CoursewareIndex(View):
             'xqa_server': settings.FEATURES.get('XQA_SERVER', "http://your_xqa_server.com"),
             'bookmarks_api_url': reverse('bookmarks'),
             'language_preference': self._get_language_preference(),
-            'disable_optimizely': not WaffleSwitchNamespace('RET').is_enabled('enable_optimizely_in_courseware'),
+            'disable_optimizely': not LegacyWaffleSwitchNamespace('RET').is_enabled('enable_optimizely_in_courseware'),
             'section_title': None,
             'sequence_title': None,
             'disable_accordion': not DISABLE_COURSE_OUTLINE_PAGE_FLAG.is_enabled(self.course.id),

--- a/lms/djangoapps/email_marketing/signals.py
+++ b/lms/djangoapps/email_marketing/signals.py
@@ -16,7 +16,7 @@ from six import text_type
 
 from common.djangoapps import third_party_auth
 from common.djangoapps.course_modes.models import CourseMode
-from edx_toggles.toggles import WaffleSwitchNamespace
+from edx_toggles.toggles import LegacyWaffleSwitchNamespace
 from lms.djangoapps.email_marketing.tasks import (
     get_email_cookies_via_sailthru,
     update_course_enrollment,
@@ -40,7 +40,7 @@ CHANGED_FIELDNAMES = ['username', 'is_active', 'name', 'gender', 'education',
                       'country', LANGUAGE_KEY]
 
 WAFFLE_NAMESPACE = 'sailthru'
-WAFFLE_SWITCHES = WaffleSwitchNamespace(name=WAFFLE_NAMESPACE)
+WAFFLE_SWITCHES = LegacyWaffleSwitchNamespace(name=WAFFLE_NAMESPACE)
 
 SAILTHRU_AUDIT_PURCHASE_ENABLED = 'audit_purchase_enabled'
 

--- a/lms/djangoapps/email_marketing/tests/test_signals.py
+++ b/lms/djangoapps/email_marketing/tests/test_signals.py
@@ -625,7 +625,7 @@ class SailthruTests(TestCase):
     @patch('sailthru.sailthru_client.SailthruClient.purchase')
     @patch('sailthru.sailthru_client.SailthruClient.api_get')
     @patch('sailthru.sailthru_client.SailthruClient.api_post')
-    @patch('edx_toggles.toggles.WaffleSwitchNamespace.is_enabled')
+    @patch('edx_toggles.toggles.LegacyWaffleSwitchNamespace.is_enabled')
     def test_update_course_enrollment_whitelabel(
             self,
             switch,
@@ -650,7 +650,7 @@ class SailthruTests(TestCase):
         update_sailthru(None, self.user, 'verified', self.course_id)
         self.assertFalse(mock_sailthru_purchase.called)
 
-    @patch('edx_toggles.toggles.WaffleSwitchNamespace.is_enabled')
+    @patch('edx_toggles.toggles.LegacyWaffleSwitchNamespace.is_enabled')
     @patch('sailthru.sailthru_client.SailthruClient.purchase')
     def test_purchase_is_not_invoked(self, mock_sailthru_purchase, switch):
         """Make sure purchase is not called in the following condition:
@@ -660,7 +660,7 @@ class SailthruTests(TestCase):
         update_sailthru(None, self.user, 'verified', self.course_id)
         self.assertFalse(mock_sailthru_purchase.called)
 
-    @patch('edx_toggles.toggles.WaffleSwitchNamespace.is_enabled')
+    @patch('edx_toggles.toggles.LegacyWaffleSwitchNamespace.is_enabled')
     @patch('sailthru.sailthru_client.SailthruClient.purchase')
     def test_encoding_is_working_for_email_contains_unicode(self, mock_sailthru_purchase, switch):
         """Make sure encoding is working for emails contains unicode characters

--- a/lms/djangoapps/experiments/flags.py
+++ b/lms/djangoapps/experiments/flags.py
@@ -4,7 +4,6 @@ Feature flag support for experiments
 
 import datetime
 import logging
-from contextlib import contextmanager
 
 import dateutil
 import pytz
@@ -62,6 +61,7 @@ class ExperimentWaffleFlag(CourseWaffleFlag):
         def test_my_experiment(self):
             ...
     """
+
     def __init__(
             self,
             waffle_namespace,
@@ -80,6 +80,33 @@ class ExperimentWaffleFlag(CourseWaffleFlag):
             for bucket in range(num_buckets)
         ]
         self.use_course_aware_bucketing = use_course_aware_bucketing
+
+    @property
+    def _app_label(self):
+        """
+        By convention, the app label associated to an experiment waffle flag is the dotted prefix of the flag name. For
+        example: if the flag name is "grades.my.experiment.waffle.flag", then the `_app_label` will be "grades".
+        This app label replaces what was formerly known as the waffle flag namespace.
+        """
+        return self._split_name[0]
+
+    @property
+    def _experiment_name(self):
+        """
+        By convention, the app label associated to an experiment waffle flag is the first dotted suffix of the flag
+        name. For example: if the flag name name is "grades.my.experiment.waffle.flag", then the `_experiment_name`
+        will be "my.experiment.waffle.flag".
+        """
+        return self._split_name[1]
+
+    @property
+    def _split_name(self):
+        """
+        Return the flag name prefix (before the first dot) and suffix. This raises a ValueError if the flag does not
+        contain a dot ".".
+        """
+        prefix, suffix = self.name.split(".", maxsplit=1)
+        return prefix, suffix
 
     def _cache_bucket(self, key, value):
         request_cache = RequestCache('experiments')
@@ -178,7 +205,7 @@ class ExperimentWaffleFlag(CourseWaffleFlag):
         # If we are using course-aware bucketing, then also append that course key
         # to `bucketing_group_name`, such that users can be hashed into different
         # buckets for different course-runs.
-        experiment_name = bucketing_group_name = self.namespaced_flag_name
+        experiment_name = bucketing_group_name = self.name
         if course_key:
             experiment_name += ".{}".format(course_key)
         if course_key and self.use_course_aware_bucketing:
@@ -225,8 +252,8 @@ class ExperimentWaffleFlag(CourseWaffleFlag):
                 event_name='edx.bi.experiment.user.bucketed',
                 properties={
                     'site': request.site.domain,
-                    'app_label': self.waffle_namespace.name,
-                    'experiment': self.flag_name,
+                    'app_label': self._app_label,
+                    'experiment': self._experiment_name,
                     'course_id': str(course_key) if course_key else None,
                     'bucket': bucket,
                     'is_staff': user.is_staff,

--- a/lms/djangoapps/experiments/tests/test_flags.py
+++ b/lms/djangoapps/experiments/tests/test_flags.py
@@ -156,6 +156,15 @@ class ExperimentWaffleFlagTests(SharedModuleStoreTestCase):
             self.assertEqual(self.flag.get_bucket(), expected_bucket)
             self.assertEqual(self.flag.is_experiment_on(), active)
 
+    def test_app_label_experiment_name(self):
+        # pylint: disable=protected-access
+        self.assertEqual("experiments", self.flag._app_label)
+        self.assertEqual("test", self.flag._experiment_name)
+
+        flag = ExperimentWaffleFlag("namespace", "flag.name", __name__)
+        self.assertEqual("namespace", flag._app_label)
+        self.assertEqual("flag.name", flag._experiment_name)
+
 
 class ExperimentWaffleFlagCourseAwarenessTest(SharedModuleStoreTestCase):
     """

--- a/lms/djangoapps/experiments/utils.py
+++ b/lms/djangoapps/experiments/utils.py
@@ -12,7 +12,7 @@ from opaque_keys import InvalidKeyError
 from opaque_keys.edx.keys import CourseKey
 
 from common.djangoapps.course_modes.models import format_course_price, get_cosmetic_verified_display_price, CourseMode
-from edx_toggles.toggles import WaffleFlag, WaffleFlagNamespace
+from edx_toggles.toggles import LegacyWaffleFlag, LegacyWaffleFlagNamespace
 from common.djangoapps.entitlements.models import CourseEntitlement
 from lms.djangoapps.commerce.utils import EcommerceService
 from lms.djangoapps.courseware.access import has_staff_access_to_preview_mode
@@ -31,7 +31,7 @@ logger = logging.getLogger(__name__)
 
 
 # TODO: clean up as part of REVEM-199 (START)
-experiments_namespace = WaffleFlagNamespace(name=u'experiments')
+experiments_namespace = LegacyWaffleFlagNamespace(name=u'experiments')
 
 # .. toggle_name: experiments.add_programs
 # .. toggle_implementation: WaffleFlag
@@ -42,7 +42,7 @@ experiments_namespace = WaffleFlagNamespace(name=u'experiments')
 # .. toggle_target_removal_date: None
 # .. toggle_tickets: REVEM-63, REVEM-198
 # .. toggle_warnings: This temporary feature toggle does not have a target removal date.
-PROGRAM_INFO_FLAG = WaffleFlag(
+PROGRAM_INFO_FLAG = LegacyWaffleFlag(
     waffle_namespace=experiments_namespace,
     flag_name=u'add_programs',
     module_name=__name__,
@@ -57,7 +57,7 @@ PROGRAM_INFO_FLAG = WaffleFlag(
 # .. toggle_target_removal_date: None
 # .. toggle_tickets: REVEM-118
 # .. toggle_warnings: This temporary feature toggle does not have a target removal date.
-DASHBOARD_INFO_FLAG = WaffleFlag(experiments_namespace, u'add_dashboard_info', __name__)
+DASHBOARD_INFO_FLAG = LegacyWaffleFlag(experiments_namespace, u'add_dashboard_info', __name__)
 # TODO END: clean up as part of REVEM-199 (End)
 
 # TODO: Clean up as part of REV-1205 (START)
@@ -70,7 +70,7 @@ DASHBOARD_INFO_FLAG = WaffleFlag(experiments_namespace, u'add_dashboard_info', _
 # .. toggle_target_removal_date: None
 # .. toggle_tickets: REV-1205
 # .. toggle_warnings: This temporary feature toggle does not have a target removal date.
-UPSELL_TRACKING_FLAG = WaffleFlag(
+UPSELL_TRACKING_FLAG = LegacyWaffleFlag(
     waffle_namespace=experiments_namespace,
     flag_name=u'add_upsell_tracking',
     module_name=__name__,

--- a/lms/djangoapps/experiments/views_custom.py
+++ b/lms/djangoapps/experiments/views_custom.py
@@ -16,7 +16,7 @@ from rest_framework.response import Response
 from rest_framework.views import APIView
 
 from common.djangoapps.course_modes.models import get_cosmetic_verified_display_price
-from edx_toggles.toggles import WaffleFlag, WaffleFlagNamespace
+from edx_toggles.toggles import LegacyWaffleFlag, LegacyWaffleFlagNamespace
 from lms.djangoapps.commerce.utils import EcommerceService
 from lms.djangoapps.courseware.utils import can_show_verified_upgrade
 from lms.djangoapps.experiments.stable_bucketing import stable_bucketing_hash_group
@@ -37,8 +37,8 @@ from common.djangoapps.track import segment
 # .. toggle_target_removal_date: None
 # .. toggle_tickets: REV-934
 # .. toggle_warnings: This temporary feature toggle does not have a target removal date.
-MOBILE_UPSELL_FLAG = WaffleFlag(
-    waffle_namespace=WaffleFlagNamespace(name=u'experiments'),
+MOBILE_UPSELL_FLAG = LegacyWaffleFlag(
+    waffle_namespace=LegacyWaffleFlagNamespace(name=u'experiments'),
     flag_name=u'mobile_upsell_rev934',
     module_name=__name__,
 )

--- a/lms/djangoapps/gating/tests/test_integration.py
+++ b/lms/djangoapps/gating/tests/test_integration.py
@@ -4,7 +4,7 @@ Integration tests for gated content.
 
 
 import ddt
-from completion import waffle as completion_waffle
+from completion.waffle import ENABLE_COMPLETION_TRACKING_SWITCH
 from crum import set_current_request
 from edx_django_utils.cache import RequestCache
 from edx_toggles.toggles.testutils import override_waffle_switch
@@ -182,7 +182,7 @@ class TestGatedContent(MilestonesTestCaseMixin, SharedModuleStoreTestCase):
         self.assert_access_to_gated_content(self.staff_user)
 
     def test_gated_content_always_in_grades(self):
-        with override_waffle_switch(completion_waffle.ENABLE_COMPLETION_TRACKING_SWITCH, True):
+        with override_waffle_switch(ENABLE_COMPLETION_TRACKING_SWITCH, True):
             # start with a grade from a non-gated subsection
             answer_problem(self.course, self.request, self.prob3, 10, 10)
 
@@ -204,7 +204,7 @@ class TestGatedContent(MilestonesTestCaseMixin, SharedModuleStoreTestCase):
     def test_ungating_when_fulfilled(self, earned, max_possible, result):
         self.assert_user_has_prereq_milestone(self.non_staff_user, expected_has_milestone=False)
         self.assert_access_to_gated_content(self.non_staff_user)
-        with override_waffle_switch(completion_waffle.ENABLE_COMPLETION_TRACKING_SWITCH, True):
+        with override_waffle_switch(ENABLE_COMPLETION_TRACKING_SWITCH, True):
             answer_problem(self.course, self.request, self.gating_prob1, earned, max_possible)
 
             self.assert_user_has_prereq_milestone(self.non_staff_user, expected_has_milestone=result)

--- a/lms/djangoapps/grades/config/waffle.py
+++ b/lms/djangoapps/grades/config/waffle.py
@@ -4,7 +4,7 @@ waffle switches for the Grades app.
 """
 
 
-from edx_toggles.toggles import WaffleFlagNamespace, WaffleSwitch, WaffleSwitchNamespace
+from edx_toggles.toggles import LegacyWaffleFlagNamespace, LegacyWaffleSwitch, LegacyWaffleSwitchNamespace
 from openedx.core.djangoapps.waffle_utils import CourseWaffleFlag
 
 # Namespace
@@ -89,7 +89,7 @@ def waffle():
     """
     Returns the namespaced, cached, audited Waffle class for Grades.
     """
-    return WaffleSwitchNamespace(name=WAFFLE_NAMESPACE, log_prefix=u'Grades: ')
+    return LegacyWaffleSwitchNamespace(name=WAFFLE_NAMESPACE, log_prefix=u'Grades: ')
 
 
 def waffle_switch(name):
@@ -97,9 +97,9 @@ def waffle_switch(name):
     Return the corresponding namespaced waffle switch.
 
     WARNING: do not replicate this pattern. Instead of declaring waffle switch names as strings, you should create
-    WaffleSwitch objects as top-level constants.
+    LegacyWaffleSwitch objects as top-level constants.
     """
-    return WaffleSwitch(waffle(), name, module_name=__name__)
+    return LegacyWaffleSwitch(waffle(), name, module_name=__name__)
 
 
 def waffle_flags():
@@ -107,9 +107,9 @@ def waffle_flags():
     Returns the namespaced, cached, audited Waffle flags dictionary for Grades.
 
     WARNING: do not replicate this pattern. Instead of declaring waffle flag names as strings, you should create
-    WaffleFlag and CourseWaffleFlag objects as top-level constants.
+    LegacyWaffleFlag and CourseWaffleFlag objects as top-level constants.
     """
-    namespace = WaffleFlagNamespace(name=WAFFLE_NAMESPACE, log_prefix=u'Grades: ')
+    namespace = LegacyWaffleFlagNamespace(name=WAFFLE_NAMESPACE, log_prefix=u'Grades: ')
     return {
         # By default, enable rejected exam grade overrides. Can be disabled on a course-by-course basis.
         # TODO: After removing this flag, add a migration to remove waffle flag in a follow-up deployment.

--- a/lms/djangoapps/instructor/toggles.py
+++ b/lms/djangoapps/instructor/toggles.py
@@ -2,12 +2,12 @@
 Waffle flags for instructor dashboard.
 """
 
-from edx_toggles.toggles import WaffleFlag, WaffleFlagNamespace
+from edx_toggles.toggles import LegacyWaffleFlag, LegacyWaffleFlagNamespace
 from openedx.core.djangoapps.waffle_utils import CourseWaffleFlag
 
 WAFFLE_NAMESPACE = 'instructor'
 # Namespace for instructor waffle flags.
-WAFFLE_FLAG_NAMESPACE = WaffleFlagNamespace(name=WAFFLE_NAMESPACE)
+WAFFLE_FLAG_NAMESPACE = LegacyWaffleFlagNamespace(name=WAFFLE_NAMESPACE)
 
 # Waffle flag enable new data download UI on specific course.
 # .. toggle_name: instructor.enable_data_download_v2
@@ -20,7 +20,7 @@ WAFFLE_FLAG_NAMESPACE = WaffleFlagNamespace(name=WAFFLE_NAMESPACE)
 # .. toggle_warnings: ??
 # .. toggle_tickets: PROD-1309
 DATA_DOWNLOAD_V2 = CourseWaffleFlag(
-    waffle_namespace=WaffleFlagNamespace(name=WAFFLE_NAMESPACE, log_prefix='instructor_dashboard: '),
+    waffle_namespace=LegacyWaffleFlagNamespace(name=WAFFLE_NAMESPACE, log_prefix='instructor_dashboard: '),
     flag_name='enable_data_download_v2',
 )
 
@@ -36,7 +36,7 @@ DATA_DOWNLOAD_V2 = CourseWaffleFlag(
 # .. toggle_warnings: n/a
 # .. toggle_tickets: PROD-1740
 # .. toggle_status: supported
-OPTIMISED_IS_SMALL_COURSE = WaffleFlag(
+OPTIMISED_IS_SMALL_COURSE = LegacyWaffleFlag(
     waffle_namespace=WAFFLE_FLAG_NAMESPACE,
     flag_name='optimised_is_small_course',
 )

--- a/lms/djangoapps/instructor_task/config/waffle.py
+++ b/lms/djangoapps/instructor_task/config/waffle.py
@@ -3,12 +3,12 @@ This module contains various configuration settings via
 waffle switches for the instructor_task app.
 """
 
-from edx_toggles.toggles import WaffleFlagNamespace, WaffleSwitchNamespace
+from edx_toggles.toggles import LegacyWaffleFlagNamespace, LegacyWaffleSwitchNamespace
 from openedx.core.djangoapps.waffle_utils import CourseWaffleFlag
 
 WAFFLE_NAMESPACE = 'instructor_task'
-INSTRUCTOR_TASK_WAFFLE_FLAG_NAMESPACE = WaffleFlagNamespace(name=WAFFLE_NAMESPACE)
-WAFFLE_SWITCHES = WaffleSwitchNamespace(name=WAFFLE_NAMESPACE)
+INSTRUCTOR_TASK_WAFFLE_FLAG_NAMESPACE = LegacyWaffleFlagNamespace(name=WAFFLE_NAMESPACE)
+WAFFLE_SWITCHES = LegacyWaffleSwitchNamespace(name=WAFFLE_NAMESPACE)
 
 # Waffle switches
 OPTIMIZE_GET_LEARNERS_FOR_COURSE = 'optimize_get_learners_for_course'

--- a/lms/djangoapps/teams/toggles.py
+++ b/lms/djangoapps/teams/toggles.py
@@ -34,7 +34,7 @@ def are_team_submissions_enabled(course_key):
     ):
         return True
 
-    # TODO: this behaviour differs from edx-ora2, where the WaffleSwitch overrides the setting.
+    # TODO: this behaviour differs from edx-ora2, where the LegacyWaffleSwitch overrides the setting.
     # https://github.com/edx/edx-ora2/blob/ac502d8301cb987c9885aaefbaeddaf456c13fb9/openassessment/xblock/config_mixin.py#L96
 
     if TEAM_SUBMISSIONS_FEATURE.is_enabled():

--- a/lms/djangoapps/verify_student/toggles.py
+++ b/lms/djangoapps/verify_student/toggles.py
@@ -2,10 +2,10 @@
 Toggles for verify_student app
 """
 
-from edx_toggles.toggles import WaffleFlag, WaffleFlagNamespace
+from edx_toggles.toggles import LegacyWaffleFlag, LegacyWaffleFlagNamespace
 
 # Namespace for verify_students waffle flags.
-WAFFLE_FLAG_NAMESPACE = WaffleFlagNamespace(name='verify_student')
+WAFFLE_FLAG_NAMESPACE = LegacyWaffleFlagNamespace(name='verify_student')
 
 # Waffle flag to use new email templates for sending ID verification emails.
 # .. toggle_name: verify_student.use_new_email_templates
@@ -18,7 +18,7 @@ WAFFLE_FLAG_NAMESPACE = WaffleFlagNamespace(name='verify_student')
 # .. toggle_target_removal_date: None
 # .. toggle_warnings: This temporary feature toggle does not have a target removal date.
 # .. toggle_tickets: PROD-1639
-USE_NEW_EMAIL_TEMPLATES = WaffleFlag(
+USE_NEW_EMAIL_TEMPLATES = LegacyWaffleFlag(
     waffle_namespace=WAFFLE_FLAG_NAMESPACE,
     flag_name='use_new_email_templates',
     module_name=__name__,

--- a/openedx/core/djangoapps/certificates/config/waffle.py
+++ b/openedx/core/djangoapps/certificates/config/waffle.py
@@ -4,7 +4,7 @@ waffle switches for the Certificates app.
 """
 
 
-from edx_toggles.toggles import WaffleSwitchNamespace
+from edx_toggles.toggles import LegacyWaffleSwitchNamespace
 
 # Namespace
 WAFFLE_NAMESPACE = u'certificates'
@@ -17,4 +17,4 @@ def waffle():
     """
     Returns the namespaced, cached, audited Waffle class for Certificates.
     """
-    return WaffleSwitchNamespace(name=WAFFLE_NAMESPACE, log_prefix=u'Certificates: ')
+    return LegacyWaffleSwitchNamespace(name=WAFFLE_NAMESPACE, log_prefix=u'Certificates: ')

--- a/openedx/core/djangoapps/certificates/tests/test_api.py
+++ b/openedx/core/djangoapps/certificates/tests/test_api.py
@@ -8,7 +8,7 @@ import ddt
 import pytz
 import waffle
 from django.test import TestCase
-from edx_toggles.toggles import WaffleSwitch
+from edx_toggles.toggles import LegacyWaffleSwitch
 from edx_toggles.toggles.testutils import override_waffle_switch
 
 from common.djangoapps.course_modes.models import CourseMode
@@ -68,7 +68,7 @@ class MockGeneratedCertificate(object):
 @contextmanager
 def configure_waffle_namespace(feature_enabled):
     namespace = certs_waffle.waffle()
-    auto_certificate_generation_switch = WaffleSwitch(namespace, certs_waffle.AUTO_CERTIFICATE_GENERATION)
+    auto_certificate_generation_switch = LegacyWaffleSwitch(namespace, certs_waffle.AUTO_CERTIFICATE_GENERATION)
     with override_waffle_switch(auto_certificate_generation_switch, active=feature_enabled):
         yield
 

--- a/openedx/core/djangoapps/content/block_structure/config/__init__.py
+++ b/openedx/core/djangoapps/content/block_structure/config/__init__.py
@@ -4,7 +4,7 @@ waffle switches for the Block Structure framework.
 """
 
 
-from edx_toggles.toggles import WaffleSwitch, WaffleSwitchNamespace
+from edx_toggles.toggles import LegacyWaffleSwitch, LegacyWaffleSwitchNamespace
 from openedx.core.lib.cache_utils import request_cached
 
 from .models import BlockStructureConfiguration
@@ -22,7 +22,7 @@ def waffle():
     """
     Returns the namespaced and cached Waffle class for BlockStructures.
     """
-    return WaffleSwitchNamespace(name=WAFFLE_NAMESPACE, log_prefix=u'BlockStructure: ')
+    return LegacyWaffleSwitchNamespace(name=WAFFLE_NAMESPACE, log_prefix=u'BlockStructure: ')
 
 
 def waffle_switch(name):
@@ -30,9 +30,9 @@ def waffle_switch(name):
     Return the waffle switch associated to this namespace.
 
     WARNING: do not replicate this pattern. Instead of declaring waffle switch names as strings, you should create
-    WaffleSwitch objects as top-level constants.
+    LegacyWaffleSwitch objects as top-level constants.
     """
-    return WaffleSwitch(waffle(), name, module_name=__name__)
+    return LegacyWaffleSwitch(waffle(), name, module_name=__name__)
 
 
 @request_cached()

--- a/openedx/core/djangoapps/models/config/waffle.py
+++ b/openedx/core/djangoapps/models/config/waffle.py
@@ -4,12 +4,12 @@ waffle switches for the course_details view.
 """
 
 
-from edx_toggles.toggles import WaffleFlagNamespace, WaffleSwitchNamespace
+from edx_toggles.toggles import LegacyWaffleFlagNamespace, LegacyWaffleSwitchNamespace
 from openedx.core.djangoapps.waffle_utils import CourseWaffleFlag
 
 COURSE_DETAIL_WAFFLE_NAMESPACE = 'course_detail'
-COURSE_DETAIL_WAFFLE_FLAG_NAMESPACE = WaffleFlagNamespace(name=COURSE_DETAIL_WAFFLE_NAMESPACE)
-WAFFLE_SWITCHES = WaffleSwitchNamespace(name=COURSE_DETAIL_WAFFLE_NAMESPACE)
+COURSE_DETAIL_WAFFLE_FLAG_NAMESPACE = LegacyWaffleFlagNamespace(name=COURSE_DETAIL_WAFFLE_NAMESPACE)
+WAFFLE_SWITCHES = LegacyWaffleSwitchNamespace(name=COURSE_DETAIL_WAFFLE_NAMESPACE)
 
 # Course Override Flag
 COURSE_DETAIL_UPDATE_CERTIFICATE_DATE = u'course_detail_update_certificate_date'

--- a/openedx/core/djangoapps/programs/__init__.py
+++ b/openedx/core/djangoapps/programs/__init__.py
@@ -10,12 +10,12 @@ this package should be kept small, thin, and stateless.
 """
 default_app_config = 'openedx.core.djangoapps.programs.apps.ProgramsConfig'
 
-from edx_toggles.toggles import WaffleSwitch, WaffleSwitchNamespace
+from edx_toggles.toggles import LegacyWaffleSwitch, LegacyWaffleSwitchNamespace
 
-PROGRAMS_WAFFLE_SWITCH_NAMESPACE = WaffleSwitchNamespace(name='programs')
+PROGRAMS_WAFFLE_SWITCH_NAMESPACE = LegacyWaffleSwitchNamespace(name='programs')
 
 # This is meant to be enabled until https://openedx.atlassian.net/browse/LEARNER-5573 needs to be resolved
-ALWAYS_CALCULATE_PROGRAM_PRICE_AS_ANONYMOUS_USER = WaffleSwitch(
+ALWAYS_CALCULATE_PROGRAM_PRICE_AS_ANONYMOUS_USER = LegacyWaffleSwitch(
     PROGRAMS_WAFFLE_SWITCH_NAMESPACE,
     'always_calculate_program_price_as_anonymous_user',
     __name__

--- a/openedx/core/djangoapps/schedules/config.py
+++ b/openedx/core/djangoapps/schedules/config.py
@@ -3,11 +3,11 @@ Contains configuration for schedules app
 """
 
 
-from edx_toggles.toggles import WaffleFlag, WaffleFlagNamespace, WaffleSwitch, WaffleSwitchNamespace
+from edx_toggles.toggles import LegacyWaffleFlag, LegacyWaffleFlagNamespace, LegacyWaffleSwitch, LegacyWaffleSwitchNamespace
 from openedx.core.djangoapps.waffle_utils import CourseWaffleFlag
 
-WAFFLE_FLAG_NAMESPACE = WaffleFlagNamespace(name='schedules')
-WAFFLE_SWITCH_NAMESPACE = WaffleSwitchNamespace(name='schedules')
+WAFFLE_FLAG_NAMESPACE = LegacyWaffleFlagNamespace(name='schedules')
+WAFFLE_SWITCH_NAMESPACE = LegacyWaffleSwitchNamespace(name='schedules')
 
 CREATE_SCHEDULE_WAFFLE_FLAG = CourseWaffleFlag(
     waffle_namespace=WAFFLE_FLAG_NAMESPACE,
@@ -21,9 +21,9 @@ COURSE_UPDATE_WAFFLE_FLAG = CourseWaffleFlag(
     module_name=__name__,
 )
 
-DEBUG_MESSAGE_WAFFLE_FLAG = WaffleFlag(WAFFLE_FLAG_NAMESPACE, 'enable_debugging', __name__)
+DEBUG_MESSAGE_WAFFLE_FLAG = LegacyWaffleFlag(WAFFLE_FLAG_NAMESPACE, 'enable_debugging', __name__)
 
-COURSE_UPDATE_SHOW_UNSUBSCRIBE_WAFFLE_SWITCH = WaffleSwitch(
+COURSE_UPDATE_SHOW_UNSUBSCRIBE_WAFFLE_SWITCH = LegacyWaffleSwitch(
     WAFFLE_SWITCH_NAMESPACE,
     'course_update_show_unsubscribe',
     __name__

--- a/openedx/core/djangoapps/schedules/config.py
+++ b/openedx/core/djangoapps/schedules/config.py
@@ -3,7 +3,13 @@ Contains configuration for schedules app
 """
 
 
-from edx_toggles.toggles import LegacyWaffleFlag, LegacyWaffleFlagNamespace, LegacyWaffleSwitch, LegacyWaffleSwitchNamespace
+from edx_toggles.toggles import (
+    LegacyWaffleFlag,
+    LegacyWaffleFlagNamespace,
+    LegacyWaffleSwitch,
+    LegacyWaffleSwitchNamespace
+)
+
 from openedx.core.djangoapps.waffle_utils import CourseWaffleFlag
 
 WAFFLE_FLAG_NAMESPACE = LegacyWaffleFlagNamespace(name='schedules')

--- a/openedx/core/djangoapps/user_api/accounts/toggles.py
+++ b/openedx/core/djangoapps/user_api/accounts/toggles.py
@@ -2,7 +2,7 @@
 Toggles for accounts related code.
 """
 
-from edx_toggles.toggles import WaffleFlag
+from edx_toggles.toggles import LegacyWaffleFlag
 from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
 
 # .. toggle_name: order_history.redirect_to_microfrontend
@@ -15,7 +15,7 @@ from openedx.core.djangoapps.site_configuration import helpers as configuration_
 # .. toggle_warnings: Also set settings.ORDER_HISTORY_MICROFRONTEND_URL and site's
 #   ENABLE_ORDER_HISTORY_MICROFRONTEND.
 # .. toggle_tickets: DEPR-17
-REDIRECT_TO_ORDER_HISTORY_MICROFRONTEND = WaffleFlag('order_history', 'redirect_to_microfrontend', __name__)
+REDIRECT_TO_ORDER_HISTORY_MICROFRONTEND = LegacyWaffleFlag('order_history', 'redirect_to_microfrontend', __name__)
 
 
 def should_redirect_to_order_history_microfrontend():
@@ -34,7 +34,7 @@ def should_redirect_to_order_history_microfrontend():
 # .. toggle_target_removal_date: 2020-12-31
 # .. toggle_warnings: Also set settings.ACCOUNT_MICROFRONTEND_URL and site's ENABLE_ACCOUNT_MICROFRONTEND.
 # .. toggle_tickets: DEPR-17
-REDIRECT_TO_ACCOUNT_MICROFRONTEND = WaffleFlag('account', 'redirect_to_microfrontend', __name__)
+REDIRECT_TO_ACCOUNT_MICROFRONTEND = LegacyWaffleFlag('account', 'redirect_to_microfrontend', __name__)
 
 
 def should_redirect_to_account_microfrontend():

--- a/openedx/core/djangoapps/user_api/accounts/utils.py
+++ b/openedx/core/djangoapps/user_api/accounts/utils.py
@@ -6,7 +6,7 @@ Utility methods for the account settings.
 import re
 
 import waffle
-from completion import waffle as completion_waffle
+from completion.waffle import ENABLE_COMPLETION_TRACKING_SWITCH
 from completion.models import BlockCompletion
 from django.conf import settings
 from django.utils.translation import ugettext as _
@@ -118,7 +118,7 @@ def retrieve_last_sitewide_block_completed(user):
     :return: block_lms_url
 
     """
-    if not completion_waffle.waffle().is_enabled(completion_waffle.ENABLE_COMPLETION_TRACKING):
+    if not ENABLE_COMPLETION_TRACKING_SWITCH.is_enabled():
         return
 
     latest_completions_by_course = BlockCompletion.latest_blocks_completed_all_courses(user)

--- a/openedx/core/djangoapps/user_api/config/waffle.py
+++ b/openedx/core/djangoapps/user_api/config/waffle.py
@@ -5,7 +5,7 @@ Waffle flags and switches to change user API functionality.
 
 from django.utils.translation import ugettext_lazy as _
 
-from edx_toggles.toggles import WaffleSwitchNamespace
+from edx_toggles.toggles import LegacyWaffleSwitchNamespace
 
 SYSTEM_MAINTENANCE_MSG = _(u'System maintenance in progress. Please try again later.')
 WAFFLE_NAMESPACE = u'user_api'
@@ -18,4 +18,4 @@ def waffle():
     """
     Returns the namespaced, cached, audited Waffle class for user_api.
     """
-    return WaffleSwitchNamespace(name=WAFFLE_NAMESPACE, log_prefix=u'UserAPI: ')
+    return LegacyWaffleSwitchNamespace(name=WAFFLE_NAMESPACE, log_prefix=u'UserAPI: ')

--- a/openedx/core/djangoapps/user_authn/config/waffle.py
+++ b/openedx/core/djangoapps/user_authn/config/waffle.py
@@ -3,10 +3,10 @@ Waffle flags and switches for user authn.
 """
 
 
-from edx_toggles.toggles import WaffleSwitch, WaffleSwitchNamespace
+from edx_toggles.toggles import LegacyWaffleSwitch, LegacyWaffleSwitchNamespace
 
 _WAFFLE_NAMESPACE = u'user_authn'
-_WAFFLE_SWITCH_NAMESPACE = WaffleSwitchNamespace(name=_WAFFLE_NAMESPACE, log_prefix=u'UserAuthN: ')
+_WAFFLE_SWITCH_NAMESPACE = LegacyWaffleSwitchNamespace(name=_WAFFLE_NAMESPACE, log_prefix=u'UserAuthN: ')
 
 # .. toggle_name: user_authn.enable_login_using_thirdparty_auth_only
 # .. toggle_implementation: WaffleSwitch
@@ -18,7 +18,7 @@ _WAFFLE_SWITCH_NAMESPACE = WaffleSwitchNamespace(name=_WAFFLE_NAMESPACE, log_pre
 # .. toggle_target_removal_date: 2020-01-31
 # .. toggle_warnings: Requires THIRD_PARTY_AUTH_ONLY_DOMAIN to also be set.
 # .. toggle_tickets: ENT-2461
-ENABLE_LOGIN_USING_THIRDPARTY_AUTH_ONLY = WaffleSwitch(
+ENABLE_LOGIN_USING_THIRDPARTY_AUTH_ONLY = LegacyWaffleSwitch(
     _WAFFLE_SWITCH_NAMESPACE,
     'enable_login_using_thirdparty_auth_only',
     __name__

--- a/openedx/core/djangoapps/user_authn/views/register.py
+++ b/openedx/core/djangoapps/user_authn/views/register.py
@@ -21,7 +21,7 @@ from django.utils.translation import get_language
 from django.utils.translation import ugettext as _
 from django.views.decorators.csrf import csrf_exempt, ensure_csrf_cookie
 from django.views.decorators.debug import sensitive_post_parameters
-from edx_toggles.toggles import WaffleFlag, WaffleFlagNamespace
+from edx_toggles.toggles import LegacyWaffleFlag, LegacyWaffleFlagNamespace
 from pytz import UTC
 from ratelimit.decorators import ratelimit
 from requests import HTTPError
@@ -104,8 +104,8 @@ REGISTER_USER = Signal(providing_args=["user", "registration"])
 # .. toggle_target_removal_date: 2020-06-01
 # .. toggle_warnings: This temporary feature toggle does not have a target removal date.
 # .. toggle_tickets: None
-REGISTRATION_FAILURE_LOGGING_FLAG = WaffleFlag(
-    waffle_namespace=WaffleFlagNamespace(name=u'registration'),
+REGISTRATION_FAILURE_LOGGING_FLAG = LegacyWaffleFlag(
+    waffle_namespace=LegacyWaffleFlagNamespace(name=u'registration'),
     flag_name=u'enable_failure_logging',
     module_name=__name__,
 )

--- a/openedx/core/djangoapps/util/waffle.py
+++ b/openedx/core/djangoapps/util/waffle.py
@@ -3,7 +3,7 @@ Waffle flags and switches
 """
 
 
-from edx_toggles.toggles import WaffleSwitchNamespace
+from edx_toggles.toggles import LegacyWaffleSwitchNamespace
 
 WAFFLE_NAMESPACE = u'open_edx_util'
 
@@ -15,4 +15,4 @@ def waffle():
     """
     Returns the namespaced, cached, audited Waffle class for open_edx_util.
     """
-    return WaffleSwitchNamespace(name=WAFFLE_NAMESPACE, log_prefix=u'OpenEdX Util: ')
+    return LegacyWaffleSwitchNamespace(name=WAFFLE_NAMESPACE, log_prefix=u'OpenEdX Util: ')

--- a/openedx/core/djangoapps/video_pipeline/config/waffle.py
+++ b/openedx/core/djangoapps/video_pipeline/config/waffle.py
@@ -3,7 +3,7 @@ This module contains configuration settings via waffle flags
 for the Video Pipeline app.
 """
 
-from edx_toggles.toggles import WaffleFlag, WaffleFlagNamespace
+from edx_toggles.toggles import LegacyWaffleFlag, LegacyWaffleFlagNamespace
 from openedx.core.djangoapps.waffle_utils import CourseWaffleFlag
 
 # Videos Namespace
@@ -40,14 +40,14 @@ def waffle_flags():
     """
     Returns the namespaced, cached, audited Waffle flags dictionary for Videos.
     """
-    namespace = WaffleFlagNamespace(name=WAFFLE_NAMESPACE, log_prefix=u'Videos: ')
+    namespace = LegacyWaffleFlagNamespace(name=WAFFLE_NAMESPACE, log_prefix=u'Videos: ')
     return {
         DEPRECATE_YOUTUBE: CourseWaffleFlag(
             waffle_namespace=namespace,
             flag_name=DEPRECATE_YOUTUBE,
             module_name=__name__,
         ),
-        ENABLE_DEVSTACK_VIDEO_UPLOADS: WaffleFlag(
+        ENABLE_DEVSTACK_VIDEO_UPLOADS: LegacyWaffleFlag(
             waffle_namespace=namespace,
             flag_name=ENABLE_DEVSTACK_VIDEO_UPLOADS,
             module_name=__name__,

--- a/openedx/core/djangoapps/waffle_utils/__init__.py
+++ b/openedx/core/djangoapps/waffle_utils/__init__.py
@@ -131,7 +131,7 @@ class WaffleFlag(LegacyWaffleFlag):
             yield
 
 
-class CourseWaffleFlag(BaseWaffleFlag):
+class CourseWaffleFlag(LegacyWaffleFlag):
     """
     Represents a single waffle flag that can be forced on/off for a course. This class should be used instead of
     WaffleFlag when in the context of a course.
@@ -165,13 +165,13 @@ class CourseWaffleFlag(BaseWaffleFlag):
         from .models import WaffleFlagCourseOverrideModel
 
         cache_key = "{}.{}".format(self.namespaced_flag_name, str(course_key))
-        course_override = self._cached_flags.get(cache_key)
+        course_override = self.cached_flags().get(cache_key)
 
         if course_override is None:
             course_override = WaffleFlagCourseOverrideModel.override_value(
                 self.namespaced_flag_name, course_key
             )
-            self._cached_flags[cache_key] = course_override
+            self.cached_flags()[cache_key] = course_override
 
         if course_override == WaffleFlagCourseOverrideModel.ALL_CHOICES.on:
             return True
@@ -196,7 +196,6 @@ class CourseWaffleFlag(BaseWaffleFlag):
             )
         is_enabled_for_course = self._get_course_override_value(course_key)
         if is_enabled_for_course is not None:
-            # pylint: disable=protected-access
-            self.waffle_namespace._monitor_value(self.flag_name, is_enabled_for_course)
+            self.set_monitor_value(is_enabled_for_course)
             return is_enabled_for_course
         return super().is_enabled()

--- a/openedx/core/djangoapps/waffle_utils/views.py
+++ b/openedx/core/djangoapps/waffle_utils/views.py
@@ -49,8 +49,7 @@ class ToggleStateView(views.APIView):
         """
         waffle_switch_instances = WaffleSwitch.get_instances()
         for switch_instance in waffle_switch_instances:
-            switch_name = switch_instance.namespaced_switch_name
-            switch = self._get_or_create_toggle_response(switches_dict, switch_name)
+            switch = self._get_or_create_toggle_response(switches_dict, switch_instance.name)
             self._add_toggle_instance_details(switch, switch_instance)
 
     def _add_waffle_switch_state(self, switches_dict):
@@ -98,8 +97,7 @@ class ToggleStateView(views.APIView):
         """
         waffle_flag_instances = WaffleFlag.get_instances()
         for flag_instance in waffle_flag_instances:
-            flag_name = flag_instance.namespaced_flag_name
-            flag = self._get_or_create_toggle_response(flags_dict, flag_name)
+            flag = self._get_or_create_toggle_response(flags_dict, flag_instance.name)
             self._add_toggle_instance_details(flag, flag_instance)
 
     def _add_toggle_instance_details(self, toggle, toggle_instance):

--- a/openedx/core/djangoapps/xblock/runtime/runtime.py
+++ b/openedx/core/djangoapps/xblock/runtime/runtime.py
@@ -5,7 +5,7 @@ Common base classes for all new XBlock runtimes.
 import logging
 
 import crum
-from completion import waffle as completion_waffle
+from completion.waffle import ENABLE_COMPLETION_TRACKING_SWITCH
 from completion.models import BlockCompletion
 from completion.services import CompletionService
 from django.contrib.auth import get_user_model
@@ -183,7 +183,7 @@ class XBlockRuntime(RuntimeShim, Runtime):
         """
         Submit a completion object for the block.
         """
-        if not completion_waffle.waffle().is_enabled(completion_waffle.ENABLE_COMPLETION_TRACKING):
+        if not ENABLE_COMPLETION_TRACKING_SWITCH.is_enabled():
             return
         BlockCompletion.objects.submit_completion(
             user=self.user,

--- a/openedx/core/lib/request_utils.py
+++ b/openedx/core/lib/request_utils.py
@@ -12,14 +12,14 @@ from opaque_keys import InvalidKeyError
 from opaque_keys.edx.keys import CourseKey
 from six.moves.urllib.parse import urlparse
 
-from edx_toggles.toggles import WaffleFlag, WaffleFlagNamespace
+from edx_toggles.toggles import LegacyWaffleFlag, LegacyWaffleFlagNamespace
 from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
 
 # accommodates course api urls, excluding any course api routes that do not fall under v*/courses, such as v1/blocks.
 COURSE_REGEX = re.compile(r'^(.*?/courses/)(?!v[0-9]+/[^/]+){}'.format(settings.COURSE_ID_PATTERN))
 
-WAFFLE_FLAG_NAMESPACE = WaffleFlagNamespace(name='request_utils')
-CAPTURE_COOKIE_SIZES = WaffleFlag(WAFFLE_FLAG_NAMESPACE, 'capture_cookie_sizes', __name__)
+WAFFLE_FLAG_NAMESPACE = LegacyWaffleFlagNamespace(name='request_utils')
+CAPTURE_COOKIE_SIZES = LegacyWaffleFlag(WAFFLE_FLAG_NAMESPACE, 'capture_cookie_sizes', __name__)
 log = logging.getLogger(__name__)
 
 

--- a/openedx/features/course_experience/__init__.py
+++ b/openedx/features/course_experience/__init__.py
@@ -6,15 +6,15 @@ from django.utils.translation import ugettext as _
 from edx_django_utils.monitoring import set_custom_attribute
 from waffle import flag_is_active
 
-from edx_toggles.toggles import WaffleFlag, WaffleFlagNamespace
+from edx_toggles.toggles import LegacyWaffleFlag, LegacyWaffleFlagNamespace
 from lms.djangoapps.experiments.flags import ExperimentWaffleFlag
 from openedx.core.djangoapps.util.user_messages import UserMessageCollection
 from openedx.core.djangoapps.waffle_utils import CourseWaffleFlag
 
 # Namespace for course experience waffle flags.
-WAFFLE_FLAG_NAMESPACE = WaffleFlagNamespace(name='course_experience')
+WAFFLE_FLAG_NAMESPACE = LegacyWaffleFlagNamespace(name='course_experience')
 
-COURSE_EXPERIENCE_WAFFLE_FLAG_NAMESPACE = WaffleFlagNamespace(name='course_experience')
+COURSE_EXPERIENCE_WAFFLE_FLAG_NAMESPACE = LegacyWaffleFlagNamespace(name='course_experience')
 
 # Waffle flag to disable the separate course outline page and full width content.
 DISABLE_COURSE_OUTLINE_PAGE_FLAG = CourseWaffleFlag(
@@ -30,7 +30,7 @@ DISABLE_UNIFIED_COURSE_TAB_FLAG = CourseWaffleFlag(
 DISPLAY_COURSE_SOCK_FLAG = CourseWaffleFlag(WAFFLE_FLAG_NAMESPACE, 'display_course_sock', __name__)
 
 # Waffle flag to let learners access a course before its start date.
-COURSE_PRE_START_ACCESS_FLAG = WaffleFlag(WAFFLE_FLAG_NAMESPACE, 'pre_start_access', __name__)
+COURSE_PRE_START_ACCESS_FLAG = LegacyWaffleFlag(WAFFLE_FLAG_NAMESPACE, 'pre_start_access', __name__)
 
 # Waffle flag to enable the setting of course goals.
 # .. toggle_name: course_experience.enable_course_goals
@@ -65,7 +65,7 @@ UPGRADE_DEADLINE_MESSAGE = CourseWaffleFlag(WAFFLE_FLAG_NAMESPACE, 'upgrade_dead
 LATEST_UPDATE_FLAG = CourseWaffleFlag(WAFFLE_FLAG_NAMESPACE, 'latest_update', __name__)
 
 # Waffle flag to enable anonymous access to a course
-SEO_WAFFLE_FLAG_NAMESPACE = WaffleFlagNamespace(name='seo')
+SEO_WAFFLE_FLAG_NAMESPACE = LegacyWaffleFlagNamespace(name='seo')
 COURSE_ENABLE_UNENROLLED_ACCESS_FLAG = CourseWaffleFlag(
     SEO_WAFFLE_FLAG_NAMESPACE,
     'enable_anonymous_courseware_access',

--- a/openedx/features/course_experience/tests/views/test_course_home.py
+++ b/openedx/features/course_experience/tests/views/test_course_home.py
@@ -951,9 +951,9 @@ class CourseHomeFragmentViewTests(ModuleStoreTestCase):
         self.user = UserFactory()
         self.client.login(username=self.user.username, password=TEST_PASSWORD)
 
-        name = SHOW_UPGRADE_MSG_ON_COURSE_HOME.waffle_namespace._namespaced_name(
-            SHOW_UPGRADE_MSG_ON_COURSE_HOME.flag_name)
-        self.flag, __ = Flag.objects.update_or_create(name=name, defaults={'everyone': True})
+        self.flag, __ = Flag.objects.update_or_create(
+            name=SHOW_UPGRADE_MSG_ON_COURSE_HOME.name, defaults={'everyone': True}
+        )
 
     def assert_upgrade_message_not_displayed(self):
         response = self.client.get(self.url)

--- a/openedx/features/course_experience/tests/views/test_course_outline.py
+++ b/openedx/features/course_experience/tests/views/test_course_outline.py
@@ -720,6 +720,7 @@ class TestCourseOutlineResumeCourse(SharedModuleStoreTestCase, CompletionWaffleT
         switch_name = ENABLE_COMPLETION_TRACKING_SWITCH.name
         switch, _ = Switch.objects.get_or_create(name=switch_name)
 
+        # pylint: disable=protected-access
         self.assertEqual(switch.created, view._completion_data_collection_start())
 
         switch.delete()

--- a/openedx/features/course_experience/tests/views/test_course_outline.py
+++ b/openedx/features/course_experience/tests/views/test_course_outline.py
@@ -4,18 +4,18 @@ Tests for the Course Outline view and supporting views.
 
 
 import datetime
-import json
 import re
 
 import ddt
 import six
-from completion import waffle
+from completion.waffle import ENABLE_COMPLETION_TRACKING_SWITCH
 from completion.models import BlockCompletion
 from completion.test_utils import CompletionWaffleTestMixin
 from django.contrib.sites.models import Site
 from django.test import RequestFactory, override_settings
 from django.urls import reverse
 from django.utils import timezone
+from edx_toggles.toggles.testutils import override_waffle_switch
 from milestones.tests.utils import MilestonesTestCaseMixin
 from mock import Mock, patch
 from opaque_keys.edx.keys import CourseKey, UsageKey
@@ -23,7 +23,6 @@ from pyquery import PyQuery as pq
 from pytz import UTC
 from six import text_type
 from waffle.models import Switch
-from waffle.testutils import override_switch
 
 from common.djangoapps.course_modes.models import CourseMode
 from common.djangoapps.course_modes.tests.factories import CourseModeFactory
@@ -514,12 +513,7 @@ class TestCourseOutlineResumeCourse(SharedModuleStoreTestCase, CompletionWaffleT
         )
         self.assertEqual(200, self.client.get(last_accessed_url).status_code)
 
-    @override_switch(
-        '{}.{}'.format(
-            waffle.WAFFLE_NAMESPACE, waffle.ENABLE_COMPLETION_TRACKING
-        ),
-        active=True
-    )
+    @override_waffle_switch(ENABLE_COMPLETION_TRACKING_SWITCH, active=True)
     def complete_sequential(self, course, sequential):
         """
         Completes provided sequential.
@@ -688,12 +682,7 @@ class TestCourseOutlineResumeCourse(SharedModuleStoreTestCase, CompletionWaffleT
         content = pq(response.content)
         self.assertTrue(content('.action-resume-course').attr('href').endswith('/course/' + course.url_name))
 
-    @override_switch(
-        '{}.{}'.format(
-            waffle.WAFFLE_NAMESPACE, waffle.ENABLE_COMPLETION_TRACKING
-        ),
-        active=True
-    )
+    @override_waffle_switch(ENABLE_COMPLETION_TRACKING_SWITCH, active=True)
     def test_course_outline_auto_open(self):
         """
         Tests that the course outline auto-opens to the first subsection
@@ -728,9 +717,7 @@ class TestCourseOutlineResumeCourse(SharedModuleStoreTestCase, CompletionWaffleT
         time of the waffle switch that enables completion data tracking.
         """
         view = CourseOutlineFragmentView()
-        switches = waffle.waffle()
-        # pylint: disable=protected-access
-        switch_name = switches._namespaced_name(waffle.ENABLE_COMPLETION_TRACKING)
+        switch_name = ENABLE_COMPLETION_TRACKING_SWITCH.name
         switch, _ = Switch.objects.get_or_create(name=switch_name)
 
         self.assertEqual(switch.created, view._completion_data_collection_start())

--- a/openedx/features/course_experience/views/course_outline.py
+++ b/openedx/features/course_experience/views/course_outline.py
@@ -7,7 +7,7 @@ import datetime
 import re
 import six
 
-from completion import waffle as completion_waffle
+from completion.waffle import ENABLE_COMPLETION_TRACKING_SWITCH
 from django.contrib.auth.models import User
 from django.db.models import Q
 from django.shortcuts import redirect
@@ -167,7 +167,7 @@ class CourseOutlineFragmentView(EdxFragmentView):
         Returns the date that the ENABLE_COMPLETION_TRACKING waffle switch was enabled.
         """
         # pylint: disable=protected-access
-        switch_name = completion_waffle.waffle()._namespaced_name(completion_waffle.ENABLE_COMPLETION_TRACKING)
+        switch_name = completion_waffle.ENABLE_COMPLETION_TRACKING_SWITCH.name
         try:
             return Switch.objects.get(name=switch_name).created
         except Switch.DoesNotExist:

--- a/openedx/features/course_experience/views/course_outline.py
+++ b/openedx/features/course_experience/views/course_outline.py
@@ -166,10 +166,8 @@ class CourseOutlineFragmentView(EdxFragmentView):
         """
         Returns the date that the ENABLE_COMPLETION_TRACKING waffle switch was enabled.
         """
-        # pylint: disable=protected-access
-        switch_name = completion_waffle.ENABLE_COMPLETION_TRACKING_SWITCH.name
         try:
-            return Switch.objects.get(name=switch_name).created
+            return Switch.objects.get(name=ENABLE_COMPLETION_TRACKING_SWITCH.name).created
         except Switch.DoesNotExist:
             return DEFAULT_COMPLETION_TRACKING_START
 

--- a/openedx/features/course_experience/waffle.py
+++ b/openedx/features/course_experience/waffle.py
@@ -3,7 +3,7 @@ Miscellaneous waffle switches that both LMS and Studio need to access
 """
 
 
-from edx_toggles.toggles import WaffleSwitchNamespace
+from edx_toggles.toggles import LegacyWaffleSwitchNamespace
 
 # Namespace
 WAFFLE_NAMESPACE = u'course_experience'
@@ -25,4 +25,4 @@ def waffle():
     """
     Returns the namespaced, cached, audited shared Waffle Switch class.
     """
-    return WaffleSwitchNamespace(name=WAFFLE_NAMESPACE, log_prefix=u'Course Experience: ')
+    return LegacyWaffleSwitchNamespace(name=WAFFLE_NAMESPACE, log_prefix=u'Course Experience: ')

--- a/openedx/features/discounts/applicability.py
+++ b/openedx/features/discounts/applicability.py
@@ -16,7 +16,7 @@ import pytz
 from crum import get_current_request, impersonate
 from django.utils import timezone
 from django.utils.dateparse import parse_datetime
-from edx_toggles.toggles import WaffleFlag, WaffleFlagNamespace
+from edx_toggles.toggles import LegacyWaffleFlag, LegacyWaffleFlagNamespace
 
 from common.djangoapps.course_modes.models import CourseMode
 from common.djangoapps.entitlements.models import CourseEntitlement
@@ -35,8 +35,8 @@ from common.djangoapps.track import segment
 # .. toggle_target_removal_date: None
 # .. toggle_tickets: REVEM-282
 # .. toggle_warnings: This temporary feature toggle does not have a target removal date.
-DISCOUNT_APPLICABILITY_FLAG = WaffleFlag(
-    waffle_namespace=WaffleFlagNamespace(name=u'discounts'),
+DISCOUNT_APPLICABILITY_FLAG = LegacyWaffleFlag(
+    waffle_namespace=LegacyWaffleFlagNamespace(name=u'discounts'),
     flag_name=u'enable_discounting',
     module_name=__name__,
 )

--- a/openedx/features/enterprise_support/utils.py
+++ b/openedx/features/enterprise_support/utils.py
@@ -10,7 +10,7 @@ from django.conf import settings
 from django.urls import NoReverseMatch, reverse
 from django.utils.translation import ugettext as _
 from edx_django_utils.cache import TieredCache, get_cache_key
-from edx_toggles.toggles import WaffleFlag
+from edx_toggles.toggles import LegacyWaffleFlag
 from enterprise.api.v1.serializers import EnterpriseCustomerBrandingConfigurationSerializer
 from enterprise.models import EnterpriseCustomer, EnterpriseCustomerUser
 from social_django.models import UserSocialAuth
@@ -22,7 +22,7 @@ from openedx.core.djangoapps.user_authn.cookies import standard_cookie_settings
 from openedx.core.djangolib.markup import HTML, Text
 from common.djangoapps.student.helpers import get_next_url_for_login_page
 
-ENTERPRISE_HEADER_LINKS = WaffleFlag('enterprise', 'enterprise_header_links', __name__)
+ENTERPRISE_HEADER_LINKS = LegacyWaffleFlag('enterprise', 'enterprise_header_links', __name__)
 
 
 def get_data_consent_share_cache_key(user_id, course_id):

--- a/openedx/features/learner_profile/toggles.py
+++ b/openedx/features/learner_profile/toggles.py
@@ -3,11 +3,11 @@ Toggles for Learner Profile page.
 """
 
 
-from edx_toggles.toggles import WaffleFlag, WaffleFlagNamespace
+from edx_toggles.toggles import LegacyWaffleFlag, LegacyWaffleFlagNamespace
 from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
 
 # Namespace for learner profile waffle flags.
-WAFFLE_FLAG_NAMESPACE = WaffleFlagNamespace(name='learner_profile')
+WAFFLE_FLAG_NAMESPACE = LegacyWaffleFlagNamespace(name='learner_profile')
 
 # Waffle flag to redirect to another learner profile experience.
 # .. toggle_name: learner_profile.redirect_to_microfrontend
@@ -19,7 +19,7 @@ WAFFLE_FLAG_NAMESPACE = WaffleFlagNamespace(name='learner_profile')
 # .. toggle_target_removal_date: 2020-12-31
 # .. toggle_warnings: Also set settings.PROFILE_MICROFRONTEND_URL and site's ENABLE_PROFILE_MICROFRONTEND.
 # .. toggle_tickets: DEPR-17
-REDIRECT_TO_PROFILE_MICROFRONTEND = WaffleFlag(WAFFLE_FLAG_NAMESPACE, 'redirect_to_microfrontend', __name__)
+REDIRECT_TO_PROFILE_MICROFRONTEND = LegacyWaffleFlag(WAFFLE_FLAG_NAMESPACE, 'redirect_to_microfrontend', __name__)
 
 
 def should_redirect_to_profile_microfrontend():

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -40,9 +40,6 @@ edx-enterprise==3.12.3
 # We expect v2.0.0 to introduce large breaking changes in the feature toggle API
 edx-toggles<2.0.0
 
-# We expect v4.0.0 to introduce breaking changes in the testing API
-edx-completion<4.0.0
-
 # Upgrading to 2.12.0 breaks several test classes due to API changes, need to update our code accordingly
 factory-boy==2.8.1
 

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -93,7 +93,7 @@ edx-api-doc-tools==1.4.0  # via -r requirements/edx/base.in
 edx-bulk-grades==0.8.2    # via -r requirements/edx/base.in, staff-graded-xblock
 edx-ccx-keys==1.1.0       # via -r requirements/edx/base.in
 edx-celeryutils==0.5.2    # via -r requirements/edx/base.in, super-csv
-edx-completion==3.2.5     # via -c requirements/edx/../constraints.txt, -r requirements/edx/base.in
+edx-completion==4.0.0     # via -r requirements/edx/base.in
 edx-django-release-util==0.4.4  # via -r requirements/edx/base.in
 edx-django-sites-extensions==2.5.1  # via -r requirements/edx/base.in
 edx-django-utils==3.13.0  # via -r requirements/edx/base.in, django-config-models, edx-drf-extensions, edx-enterprise, edx-rest-api-client, edx-toggles, edx-when, ora2, super-csv

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -104,7 +104,7 @@ edx-api-doc-tools==1.4.0  # via -r requirements/edx/testing.txt
 edx-bulk-grades==0.8.2    # via -r requirements/edx/testing.txt, staff-graded-xblock
 edx-ccx-keys==1.1.0       # via -r requirements/edx/testing.txt
 edx-celeryutils==0.5.2    # via -r requirements/edx/testing.txt, super-csv
-edx-completion==3.2.5     # via -c requirements/edx/../constraints.txt, -r requirements/edx/testing.txt
+edx-completion==4.0.0     # via -r requirements/edx/testing.txt
 edx-django-release-util==0.4.4  # via -r requirements/edx/testing.txt
 edx-django-sites-extensions==2.5.1  # via -r requirements/edx/testing.txt
 edx-django-utils==3.13.0  # via -r requirements/edx/testing.txt, django-config-models, edx-drf-extensions, edx-enterprise, edx-rest-api-client, edx-toggles, edx-when, ora2, super-csv

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -101,7 +101,7 @@ edx-api-doc-tools==1.4.0  # via -r requirements/edx/base.txt
 edx-bulk-grades==0.8.2    # via -r requirements/edx/base.txt, staff-graded-xblock
 edx-ccx-keys==1.1.0       # via -r requirements/edx/base.txt
 edx-celeryutils==0.5.2    # via -r requirements/edx/base.txt, super-csv
-edx-completion==3.2.5     # via -c requirements/edx/../constraints.txt, -r requirements/edx/base.txt
+edx-completion==4.0.0     # via -r requirements/edx/base.txt
 edx-django-release-util==0.4.4  # via -r requirements/edx/base.txt
 edx-django-sites-extensions==2.5.1  # via -r requirements/edx/base.txt
 edx-django-utils==3.13.0  # via -r requirements/edx/base.txt, django-config-models, edx-drf-extensions, edx-enterprise, edx-rest-api-client, edx-toggles, edx-when, ora2, super-csv


### PR DESCRIPTION
We switch to the forward-compatible Waffle API from `edx_toggles.toggles.__future__`, in anticipation of the upgrade to edx-toggles==2.0.0; this upgrade will deprecate the WaffleFlagNamespace and WaffleSwitchNamespace classes. The legacy classes are already available from edx-toggles, so we make use of them. In the future, we will upgrade to the newer waffle classes one module at a time.

This PR depends on the following PRs:

1. ~~https://github.com/edx/edx-toggles/pull/80~~ (we no longer need to upgrade to edx-toggles==2.0.0)
2. https://github.com/edx/completion/pull/120 (merged)

This is ready for review @robrap.