### PR TITLE
[BD-21] Ensure we don't break unit tests by upgrading edx-completion

### DIFF
--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -43,6 +43,9 @@ edx-search<2.0.0
 # We expect v2.0.0 to introduce large breaking changes in the feature toggle API
 edx-toggles<2.0.0
 
+# We expect v4.0.0 to introduce breaking changes in the testing API
+edx-completion<4.0.0
+
 # Upgrading to 2.12.0 breaks several test classes due to API changes, need to update our code accordingly
 factory-boy==2.8.1
 


### PR DESCRIPTION
We expect edx-completion to break unit tests in v3.3.0, so here we make
sure that it does not get upgraded automatically.

cc @robrap 