### PR TITLE
Upgrade codejail from 3.1.0 to 3.1.1 for improved logging

### DIFF
--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -6,7 +6,7 @@
 #
 -e git+https://github.com/edx/acid-block.git@758855a67d2f12bd74db4d5e7a0862d6e65f079c#egg=acid-xblock  # via -r requirements/edx/github.in
 -e common/lib/capa  # via -r requirements/edx/local.in
--e git+https://github.com/edx/codejail.git@3.1.0#egg=codejail==3.1.0  # via -r requirements/edx/github.in
+-e git+https://github.com/edx/codejail.git@3.1.1#egg=codejail==3.1.1  # via -r requirements/edx/github.in
 -e git+https://github.com/edx/django-wiki.git@0.1.1#egg=django-wiki  # via -r requirements/edx/github.in
 -e git+https://github.com/edx/DoneXBlock.git@2.0.3#egg=done-xblock  # via -r requirements/edx/github.in
 -e git+https://github.com/jazkarta/edx-jsme.git@690dbf75441fa91c7c4899df0b83d77f7deb5458#egg=edx-jsme  # via -r requirements/edx/github.in

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -6,7 +6,7 @@
 #
 -e git+https://github.com/edx/acid-block.git@758855a67d2f12bd74db4d5e7a0862d6e65f079c#egg=acid-xblock  # via -r requirements/edx/testing.txt
 -e common/lib/capa  # via -r requirements/edx/testing.txt
--e git+https://github.com/edx/codejail.git@3.1.0#egg=codejail==3.1.0  # via -r requirements/edx/testing.txt
+-e git+https://github.com/edx/codejail.git@3.1.1#egg=codejail==3.1.1  # via -r requirements/edx/testing.txt
 -e git+https://github.com/edx/django-wiki.git@0.1.1#egg=django-wiki  # via -r requirements/edx/testing.txt
 -e git+https://github.com/edx/DoneXBlock.git@2.0.3#egg=done-xblock  # via -r requirements/edx/testing.txt
 -e git+https://github.com/jazkarta/edx-jsme.git@690dbf75441fa91c7c4899df0b83d77f7deb5458#egg=edx-jsme  # via -r requirements/edx/testing.txt

--- a/requirements/edx/github.in
+++ b/requirements/edx/github.in
@@ -63,7 +63,7 @@ git+https://github.com/edx/MongoDBProxy.git@d92bafe9888d2940f647a7b2b2383b29c752
 git+https://github.com/edx/django-ratelimit-backend.git@v2.0.1a5#egg=django-ratelimit-backend==2.0.1a5
 
 # Our libraries:
--e git+https://github.com/edx/codejail.git@3.1.0#egg=codejail==3.1.0
+-e git+https://github.com/edx/codejail.git@3.1.1#egg=codejail==3.1.1
 -e git+https://github.com/edx/acid-block.git@758855a67d2f12bd74db4d5e7a0862d6e65f079c#egg=acid-xblock
 -e git+https://github.com/edx/RateXBlock.git@2.0.1#egg=rate-xblock
 -e git+https://github.com/edx/DoneXBlock.git@2.0.3#egg=done-xblock

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -6,7 +6,7 @@
 #
 -e git+https://github.com/edx/acid-block.git@758855a67d2f12bd74db4d5e7a0862d6e65f079c#egg=acid-xblock  # via -r requirements/edx/base.txt
 -e common/lib/capa  # via -r requirements/edx/base.txt
--e git+https://github.com/edx/codejail.git@3.1.0#egg=codejail==3.1.0  # via -r requirements/edx/base.txt
+-e git+https://github.com/edx/codejail.git@3.1.1#egg=codejail==3.1.1  # via -r requirements/edx/base.txt
 -e git+https://github.com/edx/django-wiki.git@0.1.1#egg=django-wiki  # via -r requirements/edx/base.txt
 -e git+https://github.com/edx/DoneXBlock.git@2.0.3#egg=done-xblock  # via -r requirements/edx/base.txt
 -e git+https://github.com/jazkarta/edx-jsme.git@690dbf75441fa91c7c4899df0b83d77f7deb5458#egg=edx-jsme  # via -r requirements/edx/base.txt


### PR DESCRIPTION
```
We are curious whether async jail_code calls on Celery workers
have different resource limit configurations than synchronous
calls on LMS/Studio. We suspect it may be different
because codejail is configured via a Django Middleware, which
may not be initialized for Celery workers.
```

[Codejail diff, for reference](https://github.com/edx/codejail/compare/3.1.0...3.1.1)

### Dependency: codejail PR
https://github.com/edx/codejail/pull/103 [merged]

### Ticktes
https://openedx.atlassian.net/browse/TNL-7649
https://openedx.atlassian.net/browse/CR-2862