### PR TITLE
More codejail logging

### DIFF
--- a/lms/djangoapps/debug/views.py
+++ b/lms/djangoapps/debug/views.py
@@ -34,7 +34,12 @@ def run_python(request):
         py_code = c['code'] = request.POST.get('code')
         g = {}
         try:
-            safe_exec(py_code, g, limit_overrides_context="debug_run_python")
+            safe_exec(
+                code=py_code,
+                globals_dict=g,
+                slug="debug_run_python",
+                limit_overrides_context="debug_run_python",
+            )
         except Exception:   # pylint: disable=broad-except
             c['results'] = traceback.format_exc()
         else:

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -6,7 +6,7 @@
 #
 -e git+https://github.com/edx/acid-block.git@758855a67d2f12bd74db4d5e7a0862d6e65f079c#egg=acid-xblock  # via -r requirements/edx/github.in
 -e common/lib/capa  # via -r requirements/edx/local.in
--e git+https://github.com/edx/codejail.git@3.1.1#egg=codejail==3.1.1  # via -r requirements/edx/github.in
+-e git+https://github.com/edx/codejail.git@3.1.3#egg=codejail==3.1.3  # via -r requirements/edx/github.in
 -e git+https://github.com/edx/django-wiki.git@0.1.1#egg=django-wiki  # via -r requirements/edx/github.in
 -e git+https://github.com/edx/DoneXBlock.git@2.0.3#egg=done-xblock  # via -r requirements/edx/github.in
 -e git+https://github.com/jazkarta/edx-jsme.git@690dbf75441fa91c7c4899df0b83d77f7deb5458#egg=edx-jsme  # via -r requirements/edx/github.in

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -6,7 +6,7 @@
 #
 -e git+https://github.com/edx/acid-block.git@758855a67d2f12bd74db4d5e7a0862d6e65f079c#egg=acid-xblock  # via -r requirements/edx/testing.txt
 -e common/lib/capa  # via -r requirements/edx/testing.txt
--e git+https://github.com/edx/codejail.git@3.1.1#egg=codejail==3.1.1  # via -r requirements/edx/testing.txt
+-e git+https://github.com/edx/codejail.git@3.1.3#egg=codejail==3.1.3  # via -r requirements/edx/testing.txt
 -e git+https://github.com/edx/django-wiki.git@0.1.1#egg=django-wiki  # via -r requirements/edx/testing.txt
 -e git+https://github.com/edx/DoneXBlock.git@2.0.3#egg=done-xblock  # via -r requirements/edx/testing.txt
 -e git+https://github.com/jazkarta/edx-jsme.git@690dbf75441fa91c7c4899df0b83d77f7deb5458#egg=edx-jsme  # via -r requirements/edx/testing.txt

--- a/requirements/edx/github.in
+++ b/requirements/edx/github.in
@@ -63,7 +63,7 @@ git+https://github.com/edx/MongoDBProxy.git@d92bafe9888d2940f647a7b2b2383b29c752
 git+https://github.com/edx/django-ratelimit-backend.git@v2.0.1a5#egg=django-ratelimit-backend==2.0.1a5
 
 # Our libraries:
--e git+https://github.com/edx/codejail.git@3.1.1#egg=codejail==3.1.1
+-e git+https://github.com/edx/codejail.git@3.1.3#egg=codejail==3.1.3
 -e git+https://github.com/edx/acid-block.git@758855a67d2f12bd74db4d5e7a0862d6e65f079c#egg=acid-xblock
 -e git+https://github.com/edx/RateXBlock.git@2.0.1#egg=rate-xblock
 -e git+https://github.com/edx/DoneXBlock.git@2.0.3#egg=done-xblock

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -6,7 +6,7 @@
 #
 -e git+https://github.com/edx/acid-block.git@758855a67d2f12bd74db4d5e7a0862d6e65f079c#egg=acid-xblock  # via -r requirements/edx/base.txt
 -e common/lib/capa  # via -r requirements/edx/base.txt
--e git+https://github.com/edx/codejail.git@3.1.1#egg=codejail==3.1.1  # via -r requirements/edx/base.txt
+-e git+https://github.com/edx/codejail.git@3.1.3#egg=codejail==3.1.3  # via -r requirements/edx/base.txt
 -e git+https://github.com/edx/django-wiki.git@0.1.1#egg=django-wiki  # via -r requirements/edx/base.txt
 -e git+https://github.com/edx/DoneXBlock.git@2.0.3#egg=done-xblock  # via -r requirements/edx/base.txt
 -e git+https://github.com/jazkarta/edx-jsme.git@690dbf75441fa91c7c4899df0b83d77f7deb5458#egg=edx-jsme  # via -r requirements/edx/base.txt


### PR DESCRIPTION
Changes:
* Upgrades codejail from `3.1.1` to `3.1.3`, pulling in https://github.com/edx/codejail/pull/105 and https://github.com/edx/codejail/pull/106.
* Enables logging from the safe execution debuging view (https://courses.stage.edx.org/debug/run_python).

Merge blocked by https://github.com/edx/codejail/pull/106
Related to https://openedx.atlassian.net/browse/TNL-7649