### PR TITLE
Remove maxlength attribute from register password field.

### DIFF
--- a/lms/templates/student_account/form_field.underscore
+++ b/lms/templates/student_account/form_field.underscore
@@ -98,7 +98,7 @@
             aria-describedby="<%- form %>-<%- name %>-desc <%- form %>-<%- name %>-validation-error"
             <% } %>
             <% if ( restrictions.min_length ) { %> minlength="<%- restrictions.min_length %>"<% } %>
-            <% if ( restrictions.max_length ) { %> maxlength="<%- restrictions.max_length %>"<% } %>
+            <% if ( restrictions.max_length && type !== 'password' ) { %> maxlength="<%- restrictions.max_length %>"<% } %>
             <% if ( restrictions.readonly )   { %> readonly <% } %>
             <% if ( required ) { %> required<% } %>
             <% if ( typeof errorMessages !== 'undefined' ) {


### PR DESCRIPTION
Pasting a longer password than allowed limit silently truncated to the max value, resulting in creating an account with a password user is unaware of because no validation error occurs.

VAN-86