### PR TITLE
[BD-21] Upgrade edx-completion and fix corresponding unit tests

### DIFF
--- a/lms/djangoapps/gating/tests/test_integration.py
+++ b/lms/djangoapps/gating/tests/test_integration.py
@@ -7,6 +7,7 @@ import ddt
 from completion import waffle as completion_waffle
 from crum import set_current_request
 from edx_django_utils.cache import RequestCache
+from edx_toggles.toggles.testutils import override_waffle_switch
 from milestones import api as milestones_api
 from milestones.tests.utils import MilestonesTestCaseMixin
 
@@ -181,7 +182,7 @@ class TestGatedContent(MilestonesTestCaseMixin, SharedModuleStoreTestCase):
         self.assert_access_to_gated_content(self.staff_user)
 
     def test_gated_content_always_in_grades(self):
-        with completion_waffle.waffle().override(completion_waffle.ENABLE_COMPLETION_TRACKING, True):
+        with override_waffle_switch(completion_waffle.ENABLE_COMPLETION_TRACKING_SWITCH, True):
             # start with a grade from a non-gated subsection
             answer_problem(self.course, self.request, self.prob3, 10, 10)
 
@@ -203,7 +204,7 @@ class TestGatedContent(MilestonesTestCaseMixin, SharedModuleStoreTestCase):
     def test_ungating_when_fulfilled(self, earned, max_possible, result):
         self.assert_user_has_prereq_milestone(self.non_staff_user, expected_has_milestone=False)
         self.assert_access_to_gated_content(self.non_staff_user)
-        with completion_waffle.waffle().override(completion_waffle.ENABLE_COMPLETION_TRACKING, True):
+        with override_waffle_switch(completion_waffle.ENABLE_COMPLETION_TRACKING_SWITCH, True):
             answer_problem(self.course, self.request, self.gating_prob1, earned, max_possible)
 
             self.assert_user_has_prereq_milestone(self.non_staff_user, expected_has_milestone=result)

--- a/openedx/tests/completion_integration/test_models.py
+++ b/openedx/tests/completion_integration/test_models.py
@@ -4,15 +4,17 @@ Test models, managers, and validators.
 
 
 import six
-from completion import models, waffle
+from completion import models
 from completion.test_utils import CompletionWaffleTestMixin, submit_completions_for_testing
+from completion.waffle import ENABLE_COMPLETION_TRACKING_SWITCH
 from django.core.exceptions import ValidationError
 from django.test import TestCase
+from edx_toggles.toggles.testutils import override_waffle_switch
 from opaque_keys.edx.keys import CourseKey, UsageKey
 from six.moves import range, zip
-from student.tests.factories import CourseEnrollmentFactory, UserFactory
 
 from openedx.core.djangolib.testing.utils import skip_unless_lms
+from student.tests.factories import CourseEnrollmentFactory, UserFactory
 
 SELECT = 1
 UPDATE = 1
@@ -165,7 +167,7 @@ class SubmitBatchCompletionTestCase(CompletionWaffleTestMixin, TestCase):
         self.assertEqual(models.BlockCompletion.objects.last().completion, 1.0)
 
     def test_submit_batch_completion_without_waffle(self):
-        with waffle.waffle().override(waffle.ENABLE_COMPLETION_TRACKING, False):
+        with override_waffle_switch(ENABLE_COMPLETION_TRACKING_SWITCH, False):
             with self.assertRaises(RuntimeError):
                 blocks = [(self.block_key, 1.0)]
                 models.BlockCompletion.objects.submit_batch_completion(self.user, blocks)

--- a/openedx/tests/completion_integration/test_views.py
+++ b/openedx/tests/completion_integration/test_views.py
@@ -6,9 +6,10 @@ Test models, managers, and validators.
 
 import ddt
 import six
-from completion import waffle
 from completion.test_utils import CompletionWaffleTestMixin
+from completion.waffle import ENABLE_COMPLETION_TRACKING_SWITCH
 from django.urls import reverse
+from edx_toggles.toggles.testutils import override_waffle_switch
 from rest_framework.test import APIClient
 
 from openedx.core.djangolib.testing.utils import skip_unless_lms
@@ -81,7 +82,7 @@ class CompletionBatchTestCase(CompletionWaffleTestMixin, ModuleStoreTestCase):
         """
         Test response when the waffle switch is disabled (default).
         """
-        with waffle.waffle().override(waffle.ENABLE_COMPLETION_TRACKING, False):
+        with override_waffle_switch(ENABLE_COMPLETION_TRACKING_SWITCH, False):
             response = self.client.post(self.url, {'username': self.ENROLLED_USERNAME}, format='json')
         self.assertEqual(response.data, {
             "detail":

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -93,7 +93,7 @@ edx-api-doc-tools==1.4.0  # via -r requirements/edx/base.in
 edx-bulk-grades==0.8.2    # via -r requirements/edx/base.in, staff-graded-xblock
 edx-ccx-keys==1.1.0       # via -r requirements/edx/base.in
 edx-celeryutils==0.5.2    # via -r requirements/edx/base.in, super-csv
-edx-completion==3.2.4     # via -r requirements/edx/base.in
+edx-completion==3.2.5     # via -r requirements/edx/base.in
 edx-django-release-util==0.4.4  # via -r requirements/edx/base.in
 edx-django-sites-extensions==2.5.1  # via -r requirements/edx/base.in
 edx-django-utils==3.11.0  # via -r requirements/edx/base.in, django-config-models, edx-drf-extensions, edx-enterprise, edx-rest-api-client, edx-toggles, edx-when

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -104,7 +104,7 @@ edx-api-doc-tools==1.4.0  # via -r requirements/edx/testing.txt
 edx-bulk-grades==0.8.2    # via -r requirements/edx/testing.txt, staff-graded-xblock
 edx-ccx-keys==1.1.0       # via -r requirements/edx/testing.txt
 edx-celeryutils==0.5.2    # via -r requirements/edx/testing.txt, super-csv
-edx-completion==3.2.4     # via -r requirements/edx/testing.txt
+edx-completion==3.2.5     # via -r requirements/edx/testing.txt
 edx-django-release-util==0.4.4  # via -r requirements/edx/testing.txt
 edx-django-sites-extensions==2.5.1  # via -r requirements/edx/testing.txt
 edx-django-utils==3.11.0  # via -r requirements/edx/testing.txt, django-config-models, edx-drf-extensions, edx-enterprise, edx-rest-api-client, edx-toggles, edx-when

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -101,7 +101,7 @@ edx-api-doc-tools==1.4.0  # via -r requirements/edx/base.txt
 edx-bulk-grades==0.8.2    # via -r requirements/edx/base.txt, staff-graded-xblock
 edx-ccx-keys==1.1.0       # via -r requirements/edx/base.txt
 edx-celeryutils==0.5.2    # via -r requirements/edx/base.txt, super-csv
-edx-completion==3.2.4     # via -r requirements/edx/base.txt
+edx-completion==3.2.5     # via -r requirements/edx/base.txt
 edx-django-release-util==0.4.4  # via -r requirements/edx/base.txt
 edx-django-sites-extensions==2.5.1  # via -r requirements/edx/base.txt
 edx-django-utils==3.11.0  # via -r requirements/edx/base.txt, django-config-models, edx-drf-extensions, edx-enterprise, edx-rest-api-client, edx-toggles, edx-when


### PR DESCRIPTION
Some tests were still relying on deprecated
WaffleSwitchNamespace.override method, which was working before because
we were importing WaffleSwitchNamespace from waffle_utils.__init__. This
no longer works after we import WaffleSwitchNamespace from edx-toggles.

This should fix the requirements auto-upgrade: https://github.com/edx/edx-platform/pull/25544

cc @robrap 