### PR TITLE
[BD-21] test compatiblity with edx toggles==1.2.0

### DIFF
--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -111,7 +111,7 @@ edx-search==1.4.1         # via -c requirements/edx/../constraints.txt, -r requi
 edx-sga==0.13.0           # via -r requirements/edx/base.in
 edx-submissions==3.2.2    # via -r requirements/edx/base.in, ora2
 edx-tincan-py35==0.0.9    # via edx-enterprise
-edx-toggles==1.1.1        # via -c requirements/edx/../constraints.txt, -r requirements/edx/base.in
+git+https://github.com/regisb/edx-toggles.git@regisb/deprecate-namespaces-backward-compatible#egg=edx-toggles==1.2.0        # via -c requirements/edx/../constraints.txt, -r requirements/edx/base.in
 edx-user-state-client==1.2.0  # via -r requirements/edx/base.in
 edx-when==1.3.0           # via -r requirements/edx/base.in, edx-proctoring
 edxval==1.4.2             # via -r requirements/edx/base.in

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -124,7 +124,7 @@ edx-sga==0.13.0           # via -r requirements/edx/testing.txt
 edx-sphinx-theme==1.5.0   # via -r requirements/edx/development.in
 edx-submissions==3.2.2    # via -r requirements/edx/testing.txt, ora2
 edx-tincan-py35==0.0.9    # via -r requirements/edx/testing.txt, edx-enterprise
-edx-toggles==1.1.1        # via -c requirements/edx/../constraints.txt, -r requirements/edx/testing.txt
+git+https://github.com/regisb/edx-toggles.git@regisb/deprecate-namespaces-backward-compatible#egg=edx-toggles==1.2.0        # via -c requirements/edx/../constraints.txt, -r requirements/edx/testing.txt
 edx-user-state-client==1.2.0  # via -r requirements/edx/testing.txt
 edx-when==1.3.0           # via -r requirements/edx/testing.txt, edx-proctoring
 edxval==1.4.2             # via -r requirements/edx/testing.txt

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -120,7 +120,7 @@ edx-search==1.4.1         # via -c requirements/edx/../constraints.txt, -r requi
 edx-sga==0.13.0           # via -r requirements/edx/base.txt
 edx-submissions==3.2.2    # via -r requirements/edx/base.txt, ora2
 edx-tincan-py35==0.0.9    # via -r requirements/edx/base.txt, edx-enterprise
-edx-toggles==1.1.1        # via -c requirements/edx/../constraints.txt, -r requirements/edx/base.txt
+git+https://github.com/regisb/edx-toggles.git@regisb/deprecate-namespaces-backward-compatible#egg=edx-toggles==1.2.0        # via -c requirements/edx/../constraints.txt, -r requirements/edx/base.txt
 edx-user-state-client==1.2.0  # via -r requirements/edx/base.txt
 edx-when==1.3.0           # via -r requirements/edx/base.txt, edx-proctoring
 edxval==1.4.2             # via -r requirements/edx/base.txt


### PR DESCRIPTION
This PR is for testing edx-platform compatibility with https://github.com/edx/edx-toggles/pull/81#issuecomment-723269839 (Waffle namespace deprecation).

It is rebased on top of https://github.com/edx/edx-platform/pull/25546

cc @robrap 