### PR TITLE
Undo renames of common.djangoapps tasks

### DIFF
--- a/common/djangoapps/entitlements/tasks.py
+++ b/common/djangoapps/entitlements/tasks.py
@@ -19,7 +19,12 @@ ROUTING_KEY = getattr(settings, 'ENTITLEMENTS_EXPIRATION_ROUTING_KEY', None)
 MAX_RETRIES = 11
 
 
-@task(bind=True, ignore_result=True, routing_key=ROUTING_KEY)
+@task(
+    bind=True,
+    ignore_result=True,
+    routing_key=ROUTING_KEY,
+    name='entitlements.expire_old_entitlements',
+)
 def expire_old_entitlements(self, start, end, logid='...'):
     """
     This task is designed to be called to process a bundle of entitlements

--- a/common/djangoapps/student/tasks.py
+++ b/common/djangoapps/student/tasks.py
@@ -19,7 +19,7 @@ from openedx.core.lib.celery.task_utils import emulate_http_request
 log = logging.getLogger('edx.celery.task')
 
 
-@task(bind=True)
+@task(bind=True, name='student.send_activation_email')
 def send_activation_email(self, msg_string, from_address=None):
     """
     Sending an activation email to the user.

--- a/common/djangoapps/third_party_auth/tasks.py
+++ b/common/djangoapps/third_party_auth/tasks.py
@@ -30,7 +30,7 @@ class MetadataParseError(Exception):
     pass
 
 
-@task(name='common.djangoapps.third_party_auth.fetch_saml_metadata')
+@task(name='third_party_auth.fetch_saml_metadata')
 def fetch_saml_metadata():
     """
     Fetch and store/update the metadata of all IdPs


### PR DESCRIPTION
When rolling out https://github.com/edx/edx-platform/pull/25477, we dropped hundreds of email activation tasks due to the renaming of `student.send_activation_email` to `common.djangoapps.student.send_activation_email`, and lost more when we rolled that PR back. This happens because of blue/green deployment: old workers are still online for a while after deploying, so there is a period of time when the task names are mismatched.

To prevent this from happening again, this will make it so the import changes don't change the names of any of the Celery tasks.