### PR TITLE
[SE-3530] Adds Boto3 support for Import/Export functionality

### DIFF
--- a/cms/djangoapps/contentstore/views/import_export.py
+++ b/cms/djangoapps/contentstore/views/import_export.py
@@ -27,6 +27,7 @@ from opaque_keys.edx.locator import LibraryLocator
 from path import Path as path
 from six import text_type
 from storages.backends.s3boto import S3BotoStorage
+from storages.backends.s3boto3 import S3Boto3Storage
 from user_tasks.conf import settings as user_tasks_settings
 from user_tasks.models import UserTaskArtifact, UserTaskStatus
 
@@ -381,6 +382,14 @@ def export_status_handler(request, course_key_string):
                 'response-content-disposition': disposition,
                 'response-content-encoding': 'application/octet-stream',
                 'response-content-type': 'application/x-tgz'
+            })
+        elif isinstance(artifact.file.storage, S3Boto3Storage):
+            filename = os.path.basename(artifact.file.name)
+            disposition = u'attachment; filename="{}"'.format(filename)
+            output_url = artifact.file.storage.url(artifact.file.name, parameters={
+                'ResponseContentDisposition': disposition,
+                'ResponseContentEncoding': 'application/octet-stream',
+                'ResponseContentType': 'application/x-tgz'
             })
         else:
             output_url = artifact.file.storage.url(artifact.file.name)


### PR DESCRIPTION
Fixes the file extension of an exported course from S3 when the Default File Storage is `storages.backends.s3boto3.S3Boto3Storage`, which right now by default outputs a `tar` file instead of `tar.gz`

**useful information**:
- https://forums.aws.amazon.com/thread.jspa?threadID=250926

**JIRA tickets**: SE-3530, OSPR-5125

**Testing instructions**:

1. Start an instance with `EDXAPP_DEFAULT_FILE_STORAGE: 'storages.backends.s3boto3.S3Boto3Storage'`
2. Go to a course inside studio as a staff user
3. Click on Tools -> Export
4. Export Course Content
5. Make sure the downloaded file has a `tar.gz` extension

**Reviewers**
- [x] @toxinu 
- [ ] @bradenmacdonald 

- - -
**Settings**
```yaml
EDXAPP_DEFAULT_FILE_STORAGE: storages.backends.s3boto3.S3Boto3Storage
configuration_source_repo_url: https://github.com/edx/configuration.git
configuration_version: 9e5cdd7738bec3d5a2f562f52aa9ac0601a926a8
```