### PR TITLE
Adding brand-edx.org as a dependency to edx-platform

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -39,6 +39,11 @@
         }
       }
     },
+    "@edx/brand-edx.org": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@edx/brand-edx.org/-/brand-edx.org-1.1.1.tgz",
+      "integrity": "sha512-jlJbeR1kLljgR1vED5ibGKFhVIWuHzRjdEMaCCCmAqKtcnmP3vGzCyb+NjlGcDvuJRvANT7Nq05+F0sfLbSY6A=="
+    },
     "@edx/edx-bootstrap": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/@edx/edx-bootstrap/-/edx-bootstrap-1.0.4.tgz",
@@ -574,7 +579,7 @@
     "aproba": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
-      "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw=="
+      "integrity": "sha1-aALmJk79GMeQobDVF/DyYnvyyUo="
     },
     "are-we-there-yet": {
       "version": "1.1.5",

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "edx",
   "version": "0.1.0",
   "dependencies": {
+    "@edx/brand-edx.org": "^1.1.1",
     "@edx/edx-bootstrap": "1.0.4",
     "@edx/edx-proctoring": "^1.5.0",
     "@edx/frontend-component-cookie-policy-banner": "1.0.0",


### PR DESCRIPTION
Adding [@edx/brand-edx.org](https://preview.npmjs.com/package/@edx/brand-edx.org) as a dependecy of edx-platfrom.

[TNL-7669](https://openedx.atlassian.net/browse/TNL-7669)

**Note:** this adds the dependency without the alias "@edx/brand". 