### PR TITLE
SysAdmin: Added deprecation warning for Sysadmin Dashboard

### DIFF
--- a/lms/djangoapps/dashboard/sysadmin.py
+++ b/lms/djangoapps/dashboard/sysadmin.py
@@ -8,6 +8,7 @@ import json
 import logging
 import os
 import subprocess
+import warnings
 
 import mongoengine
 from django.conf import settings
@@ -51,6 +52,8 @@ class SysadminDashboardView(TemplateView):
         Initialize base sysadmin dashboard class with modulestore,
         modulestore_type and return msg
         """
+        # Deprecation log for Sysadmin Dashboard
+        warnings.warn("Sysadmin Dashboard is deprecated. See DEPR-118.", DeprecationWarning)
 
         self.def_ms = modulestore()
         self.msg = u''


### PR DESCRIPTION
Fixes https://github.com/mitodl/edx-platform/issues/195

**Description:**
This PR adds a warning log for SysAdmin deprecation when SysAdmin Dashboard is accessed.

**Testing Instructions:**
- Go to `/lms/envs/devstack.py` and set/add `FEATURES['ENABLE_SYSADMIN_DASHBOARD'] = True`
- Access Sysadmin dashboard and it should log a warning of deprecation