### PR TITLE
Default to expiry_date for older software secure photo verifications

### DIFF
--- a/lms/djangoapps/verify_student/models.py
+++ b/lms/djangoapps/verify_student/models.py
@@ -647,6 +647,13 @@ class SoftwareSecurePhotoVerification(PhotoVerification):
     # to notify for expired verification is already sent.
     expiry_email_date = models.DateTimeField(null=True, blank=True, db_index=True)
 
+    @property
+    def expiration_datetime(self):
+        """Use expiry_date for older entries if it still exists."""
+        if self.expiry_date:
+            return self.expiry_date
+        return super(SoftwareSecurePhotoVerification, self).expiration_datetime
+
     @classmethod
     def get_initial_verification(cls, user, earliest_allowed_date=None):
         """Get initial verification for a user with the 'photo_id_key'.

--- a/lms/djangoapps/verify_student/tests/test_models.py
+++ b/lms/djangoapps/verify_student/tests/test_models.py
@@ -396,6 +396,25 @@ class TestPhotoVerification(TestVerificationBase, MockS3BotoMixin, ModuleStoreTe
             verification.created_at + timedelta(days=FAKE_SETTINGS["DAYS_GOOD_FOR"])
         )
 
+    def test_deprecated_expiry_date(self):
+        """
+        Test `expiration_datetime` returns `expiry_date` if it is not null.
+        """
+        user = UserFactory.create()
+        with freeze_time(now()):
+            verification = SoftwareSecurePhotoVerification(user=user)
+            # First, assert that expiration_date is set correctly
+            self.assertEqual(
+                verification.expiration_datetime,
+                now() + timedelta(days=FAKE_SETTINGS["DAYS_GOOD_FOR"])
+            )
+            verification.expiry_date = now() + timedelta(days=10)
+            # Then, assert that expiration_datetime favors expiry_date's value if set
+            self.assertEqual(
+                verification.expiration_datetime,
+                now() + timedelta(days=10)
+            )
+
 
 class SSOVerificationTest(TestVerificationBase):
     """


### PR DESCRIPTION
In https://github.com/edx/edx-platform/pull/25568, a new field `expiration_date` was introduced to create a single source of truth for ID verification expiration dates, which is automatically set to be 365 days from when an entry is created. However, older entries should still use the deprecated field `expiry_date` until they are backfilled with the correct `expiration_date`.