### PR TITLE
Fixed social icons color

### DIFF
--- a/lms/static/sass/shared/_footer-edx.scss
+++ b/lms/static/sass/shared/_footer-edx.scss
@@ -6,7 +6,7 @@
 @import 'bootstrap/scss/variables';
 @import 'bootstrap/scss/mixins/breakpoints';
 
-$edx-footer-link-color: $link-color;
+$edx-footer-link-color: $primary;
 $edx-footer-bg-color: rgb(252, 252, 252);
 
 // Aggressively scoped for Drupal


### PR DESCRIPTION
This PR fixes the theme color on the edx footer social icons.

Before:
<img width="1367" alt="Screenshot 2020-11-13 at 7 28 09 PM" src="https://user-images.githubusercontent.com/10988308/99083594-91e04800-25e7-11eb-8544-4d98458f1673.png">

After:
<img width="1264" alt="Screenshot 2020-11-13 at 7 31 05 PM" src="https://user-images.githubusercontent.com/10988308/99083619-9a388300-25e7-11eb-9f4d-8c69099e1397.png">

FYI: @saadyousafarbi / @awaisdar001 
