### PR TITLE
Upgrade to edx-organizations 6.0.0. Makes short_name unique

### DIFF
--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -102,7 +102,7 @@ edx-enterprise==3.11.1    # via -c requirements/edx/../constraints.txt, -r requi
 edx-i18n-tools==0.5.3     # via ora2
 edx-milestones==0.3.0     # via -r requirements/edx/base.in
 edx-opaque-keys[django]==2.1.1  # via -r requirements/edx/paver.txt, edx-bulk-grades, edx-ccx-keys, edx-completion, edx-drf-extensions, edx-enterprise, edx-milestones, edx-organizations, edx-proctoring, edx-user-state-client, edx-when, lti-consumer-xblock, xmodule
-edx-organizations==5.3.0  # via -r requirements/edx/base.in
+edx-organizations==6.0.0  # via -r requirements/edx/base.in
 edx-proctoring-proctortrack==1.0.5  # via -r requirements/edx/base.in
 edx-proctoring==2.4.8     # via -r requirements/edx/base.in, edx-proctoring-proctortrack
 edx-rbac==1.3.3           # via edx-enterprise

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -114,7 +114,7 @@ edx-i18n-tools==0.5.3     # via -r requirements/edx/testing.txt, ora2
 edx-lint==1.5.2           # via -r requirements/edx/testing.txt
 edx-milestones==0.3.0     # via -r requirements/edx/testing.txt
 edx-opaque-keys[django]==2.1.1  # via -r requirements/edx/testing.txt, edx-bulk-grades, edx-ccx-keys, edx-completion, edx-drf-extensions, edx-enterprise, edx-milestones, edx-organizations, edx-proctoring, edx-user-state-client, edx-when, lti-consumer-xblock, xmodule
-edx-organizations==5.3.0  # via -r requirements/edx/testing.txt
+edx-organizations==6.0.0  # via -r requirements/edx/testing.txt
 edx-proctoring-proctortrack==1.0.5  # via -r requirements/edx/testing.txt
 edx-proctoring==2.4.8     # via -r requirements/edx/testing.txt, edx-proctoring-proctortrack
 edx-rbac==1.3.3           # via -r requirements/edx/testing.txt, edx-enterprise

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -111,7 +111,7 @@ edx-i18n-tools==0.5.3     # via -r requirements/edx/base.txt, -r requirements/ed
 edx-lint==1.5.2           # via -r requirements/edx/testing.in
 edx-milestones==0.3.0     # via -r requirements/edx/base.txt
 edx-opaque-keys[django]==2.1.1  # via -r requirements/edx/base.txt, edx-bulk-grades, edx-ccx-keys, edx-completion, edx-drf-extensions, edx-enterprise, edx-milestones, edx-organizations, edx-proctoring, edx-user-state-client, edx-when, lti-consumer-xblock, xmodule
-edx-organizations==5.3.0  # via -r requirements/edx/base.txt
+edx-organizations==6.0.0  # via -r requirements/edx/base.txt
 edx-proctoring-proctortrack==1.0.5  # via -r requirements/edx/base.txt
 edx-proctoring==2.4.8     # via -r requirements/edx/base.txt, edx-proctoring-proctortrack
 edx-rbac==1.3.3           # via -r requirements/edx/base.txt, edx-enterprise


### PR DESCRIPTION
This upgrades edx-organizations from 5.3.0 to 6.0.0,
the notable change being the addition of a uniqueness
constraint on `Organization.short_name`.

Release: https://github.com/edx/edx-organizations/releases/tag/6.0.0
Changeset:  https://github.com/edx/edx-organizations/compare/5.3.0...6.0.0
Related edx-organizations PR: https://github.com/edx/edx-organizations/pull/141

https://openedx.atlassian.net/browse/TNL-7645