### PR TITLE
When masquerading in courseware API, reset the request user

### DIFF
--- a/openedx/core/djangoapps/courseware_api/views.py
+++ b/openedx/core/djangoapps/courseware_api/views.py
@@ -72,6 +72,7 @@ class CoursewareMeta:
             course_key,
             staff_access=self.original_user_is_staff,
         )
+        self.request.user = self.effective_user
         self.is_staff = has_access(self.effective_user, 'staff', self.overview).has_access
         self.enrollment_object = CourseEnrollment.get_enrollment(self.effective_user, self.course_key,
                                                                  select_related=['celebration'])


### PR DESCRIPTION
It's important that request.user be set as the effective user, because waffle flags and bits of code around the place look at it.

This should make masquerading more accurate to what the learner sees.