### PR TITLE
Squash a regex warning

### DIFF
--- a/common/djangoapps/static_replace/__init__.py
+++ b/common/djangoapps/static_replace/__init__.py
@@ -23,8 +23,7 @@ def _url_replace_regex(prefix):
     To anyone contemplating making this more complicated:
     http://xkcd.com/1171/
     """
-    return u"""
-        (?x)                      # flags=re.VERBOSE
+    return """(?x)                # flags=re.VERBOSE
         (?P<quote>\\\\?['"])      # the opening quotes
         (?P<prefix>{prefix})      # the prefix
         (?P<rest>.*?)             # everything else in the url


### PR DESCRIPTION
Namely:
```
warnings.py:109 - /edx/app/edxapp/edx-platform/common/djangoapps/static_replace/__init__.py:76: DeprecationWarning: Flags not at the start of the expression '\n        (?x)       ' (truncated)
```