### PR TITLE
Fix courserun_key name to properly be picked up by snowflake

### DIFF
--- a/lms/static/js/learner_dashboard/views/unenroll_view.js
+++ b/lms/static/js/learner_dashboard/views/unenroll_view.js
@@ -47,7 +47,7 @@ class UnenrollView extends Backbone.View {
         category: 'user-engagement',
         label: reason,
         displayName: 'v1',
-        courserunKey,
+        course_id: courserunKey,
       });
     }
     this.$('.slide1').addClass('hidden');


### PR DESCRIPTION
I named the key wrong in the properties of the event, this (hopefully) fixes it.