### PR TITLE
Fixed resume/view/archive course button colors

### DIFF
--- a/lms/static/sass/elements/_controls.scss
+++ b/lms/static/sass/elements/_controls.scss
@@ -345,17 +345,17 @@
 
   @extend %btn-primary;
 
-  border: 1px solid darken($action-primary-bg, 10%);
+  border: 1px solid darken($primary, 10%);
   border-radius: 3px;
   padding: 8px $baseline;
   background-color: transparent;
-  color: darken($action-primary-bg, 10%);
+  color: darken($primary, 10%);
   text-align: center;
 
   &:hover,
   &:focus {
     border: 1px solid transparent;
-    background-color: $action-primary-bg;
+    background-color: $primary;
     color: $action-primary-fg;
     text-decoration: none;
   }
@@ -372,7 +372,7 @@
   @extend %btn-pl-default-base;
 
   background-color: $action-primary-fg;
-  color: $action-primary-bg;
+  color: $primary;
 }
 
 %btn-pl-green-base {


### PR DESCRIPTION
Fix the color for the "Resume course", "View course" and "Archived course" buttons
Before:
<img width="189" alt="Screenshot 2020-11-17 at 6 59 13 PM" src="https://user-images.githubusercontent.com/10988308/99404284-42fb2100-290d-11eb-83c3-44c302b0255d.png">
<img width="187" alt="Screenshot 2020-11-17 at 6 59 19 PM" src="https://user-images.githubusercontent.com/10988308/99404290-44c4e480-290d-11eb-91cf-0e8cd911697d.png">
After:
<img width="188" alt="Screenshot 2020-11-17 at 7 45 33 PM" src="https://user-images.githubusercontent.com/10988308/99404462-79d13700-290d-11eb-88dd-067254ce337b.png">

<img width="185" alt="Screenshot 2020-11-17 at 7 43 59 PM" src="https://user-images.githubusercontent.com/10988308/99404341-53130080-290d-11eb-9747-1a241c58e985.png">
