### PR TITLE
In the LMS, bookmarks associated to deleted units are not deleted

### DIFF
--- a/cms/djangoapps/contentstore/views/item.py
+++ b/cms/djangoapps/contentstore/views/item.py
@@ -39,6 +39,7 @@ from common.djangoapps.edxmako.shortcuts import render_to_string
 from openedx.core.djangoapps.schedules.config import COURSE_UPDATE_WAFFLE_FLAG
 from openedx.core.lib.gating import api as gating_api
 from openedx.core.lib.xblock_utils import hash_resource, request_token, wrap_xblock, wrap_xblock_aside
+from openedx.core.djangoapps.bookmarks import api as bookmarks_api
 from common.djangoapps.static_replace import replace_static_urls
 from common.djangoapps.student.auth import has_studio_read_access, has_studio_write_access
 from openedx.core.toggles import ENTRANCE_EXAMS
@@ -987,6 +988,8 @@ def _delete_item(usage_key, user):
             course.tabs = [tab for tab in existing_tabs if tab.get('url_slug') != usage_key.block_id]
             store.update_item(course, user.id)
 
+        # Delete user bookmarks
+        bookmarks_api.delete_bookmarks(usage_key)
         store.delete_item(usage_key, user.id)
 
 

--- a/openedx/core/djangoapps/bookmarks/api.py
+++ b/openedx/core/djangoapps/bookmarks/api.py
@@ -159,6 +159,35 @@ def delete_bookmark(user, usage_key):
     _track_event('edx.bookmark.removed', bookmark)
 
 
+def delete_bookmarks(usage_key):
+    """
+    Delete all bookmarks for usage_key.
+
+    Arguments:
+        usage_key (UsageKey): The usage_key of the bookmarks.
+    """
+    units_keys = []
+
+    if usage_key.block_type == 'vertical':
+        units_keys.append(usage_key)
+    else:
+        # NOTE: Get all children for deleted block
+        descriptor = modulestore().get_item(usage_key)
+        for child in descriptor.get_children():
+            if usage_key.block_type == 'chapter':
+                units_keys += [unit.location for unit in child.get_children()]
+            else:
+                units_keys.append(child.location)
+
+    bookmarks = Bookmark.objects.filter(usage_key__in=units_keys)
+
+    # Emit removed bookmard event
+    for bookmark in bookmarks:
+        _track_event('edx.bookmark.removed', bookmark)
+
+    bookmarks.delete()
+
+
 def _track_event(event_name, bookmark):
     """
     Emit events for a bookmark.

--- a/openedx/core/djangoapps/bookmarks/tests/test_models.py
+++ b/openedx/core/djangoapps/bookmarks/tests/test_models.py
@@ -112,6 +112,24 @@ class BookmarksTestsBase(ModuleStoreTestCase):
                 'usage_key': self.sequential_2.location,
             }),
         )
+        self.bookmark_3 = BookmarkFactory.create(
+            user=self.user,
+            course_key=self.course_id,
+            usage_key=self.vertical_3.location,
+            xblock_cache=XBlockCache.create({
+                'display_name': self.vertical_3.display_name,
+                'usage_key': self.vertical_3.location,
+            }),
+        )
+        self.bookmark_4 = BookmarkFactory.create(
+            user=self.user,
+            course_key=self.course_id,
+            usage_key=self.chapter_2.location,
+            xblock_cache=XBlockCache.create({
+                'display_name': self.chapter_2.display_name,
+                'usage_key': self.chapter_2.location,
+            }),
+        )
 
         self.other_course = CourseFactory.create(display_name='An Introduction to API Testing 2')
 

--- a/openedx/core/djangoapps/bookmarks/tests/test_services.py
+++ b/openedx/core/djangoapps/bookmarks/tests/test_services.py
@@ -29,9 +29,11 @@ class BookmarksServiceTests(BookmarksTestsBase):
         with self.assertNumQueries(1):
             bookmarks_data = self.bookmark_service.bookmarks(course_key=self.course.id)
 
-        self.assertEqual(len(bookmarks_data), 2)
-        self.assert_bookmark_data_is_valid(self.bookmark_2, bookmarks_data[0])
-        self.assert_bookmark_data_is_valid(self.bookmark_1, bookmarks_data[1])
+        self.assertEqual(len(bookmarks_data), 4)
+        self.assert_bookmark_data_is_valid(self.bookmark_4, bookmarks_data[0])
+        self.assert_bookmark_data_is_valid(self.bookmark_3, bookmarks_data[1])
+        self.assert_bookmark_data_is_valid(self.bookmark_2, bookmarks_data[2])
+        self.assert_bookmark_data_is_valid(self.bookmark_1, bookmarks_data[3])
 
     def test_is_bookmarked(self):
         """

--- a/openedx/core/djangoapps/bookmarks/tests/test_tasks.py
+++ b/openedx/core/djangoapps/bookmarks/tests/test_tasks.py
@@ -147,7 +147,7 @@ class XBlockCacheTaskTests(BookmarksTestsBase):
                     )
 
     @ddt.data(
-        ('course', 47),
+        ('course', 36),
         ('other_course', 34)
     )
     @ddt.unpack

--- a/openedx/core/djangoapps/bookmarks/tests/test_views.py
+++ b/openedx/core/djangoapps/bookmarks/tests/test_views.py
@@ -191,16 +191,18 @@ class BookmarksListViewTests(BookmarksViewsTestsBase):
             url=reverse('bookmarks')
         )
         bookmarks_data = response.data['results']
-        self.assertEqual(len(bookmarks_data), 3)
+        self.assertEqual(len(bookmarks_data), 5)
         self.assert_bookmark_data_is_valid(self.other_bookmark_1, bookmarks_data[0])
-        self.assert_bookmark_data_is_valid(self.bookmark_2, bookmarks_data[1])
-        self.assert_bookmark_data_is_valid(self.bookmark_1, bookmarks_data[2])
+        self.assert_bookmark_data_is_valid(self.bookmark_4, bookmarks_data[1])
+        self.assert_bookmark_data_is_valid(self.bookmark_3, bookmarks_data[2])
+        self.assert_bookmark_data_is_valid(self.bookmark_2, bookmarks_data[3])
+        self.assert_bookmark_data_is_valid(self.bookmark_1, bookmarks_data[4])
 
         self.assert_bookmark_event_emitted(
             mock_tracker,
             event_name='edx.bookmark.listed',
             list_type='all_courses',
-            bookmarks_count=3,
+            bookmarks_count=5,
             page_size=10,
             page_number=1
         )
@@ -230,16 +232,16 @@ class BookmarksListViewTests(BookmarksViewsTestsBase):
         response = self.send_post(
             client=self.client,
             url=reverse('bookmarks'),
-            data={'usage_id': six.text_type(self.vertical_3.location)}
+            data={'usage_id': six.text_type(self.vertical_2.location)}
         )
 
         # Assert Newly created bookmark.
-        self.assertEqual(response.data['id'], '%s,%s' % (self.user.username, six.text_type(self.vertical_3.location)))
+        self.assertEqual(response.data['id'], '%s,%s' % (self.user.username, six.text_type(self.vertical_2.location)))
         self.assertEqual(response.data['course_id'], self.course_id)
-        self.assertEqual(response.data['usage_id'], six.text_type(self.vertical_3.location))
+        self.assertEqual(response.data['usage_id'], six.text_type(self.vertical_2.location))
         self.assertIsNotNone(response.data['created'])
         self.assertEqual(len(response.data['path']), 2)
-        self.assertEqual(response.data['display_name'], self.vertical_3.display_name)
+        self.assertEqual(response.data['display_name'], self.vertical_2.display_name)
 
     def test_post_bookmark_with_invalid_data(self):
         """
@@ -334,9 +336,9 @@ class BookmarksListViewTests(BookmarksViewsTestsBase):
     @patch('eventtracking.tracker.emit')
     @ddt.unpack
     @ddt.data(
-        {'page_size': -1, 'expected_bookmarks_count': 2, 'expected_page_size': 10, 'expected_page_number': 1},
-        {'page_size': 0, 'expected_bookmarks_count': 2, 'expected_page_size': 10, 'expected_page_number': 1},
-        {'page_size': 999, 'expected_bookmarks_count': 2, 'expected_page_size': 100, 'expected_page_number': 1}
+        {'page_size': -1, 'expected_bookmarks_count': 4, 'expected_page_size': 10, 'expected_page_number': 1},
+        {'page_size': 0, 'expected_bookmarks_count': 4, 'expected_page_size': 10, 'expected_page_number': 1},
+        {'page_size': 999, 'expected_bookmarks_count': 4, 'expected_page_size': 100, 'expected_page_number': 1}
     )
     def test_listed_event_for_different_page_size_values(self, mock_tracker, page_size, expected_bookmarks_count,
                                                          expected_page_size, expected_page_number):
@@ -364,7 +366,7 @@ class BookmarksListViewTests(BookmarksViewsTestsBase):
             mock_tracker,
             event_name='edx.bookmark.listed',
             list_type='all_courses',
-            bookmarks_count=3,
+            bookmarks_count=5,
             page_size=2,
             page_number=2
         )
@@ -482,7 +484,7 @@ class BookmarksDetailViewTests(BookmarksViewsTestsBase):
         query_parameters = 'course_id={}'.format(six.moves.urllib.parse.quote(self.course_id))
         response = self.send_get(client=self.client, url=reverse('bookmarks'), query_parameters=query_parameters)
         bookmarks_data = response.data['results']
-        self.assertEqual(len(bookmarks_data), 2)
+        self.assertEqual(len(bookmarks_data), 4)
 
         self.send_delete(
             client=self.client,
@@ -494,7 +496,7 @@ class BookmarksDetailViewTests(BookmarksViewsTestsBase):
         response = self.send_get(client=self.client, url=reverse('bookmarks'), query_parameters=query_parameters)
         bookmarks_data = response.data['results']
 
-        self.assertEqual(len(bookmarks_data), 1)
+        self.assertEqual(len(bookmarks_data), 3)
 
     def test_delete_bookmark_that_belongs_to_other_user(self):
         """


### PR DESCRIPTION
**STR:**
- Login to LMS by Learner
- Open any course
- Add some unit to bookmark
- Delete it unit by staff
- Check "Bookmarks"

![image1(1)](https://user-images.githubusercontent.com/877401/99404581-77aeae80-28f4-11eb-9af2-f9b0573422ab.png)
![image2(1)](https://user-images.githubusercontent.com/877401/99404603-809f8000-28f4-11eb-9cc5-491905030cd3.png)



**AR:**
- Bookmarks for deleted Units are still present
- Click on Bookmart leads to non existing page
<img width="1229" alt="image-20201112-174210" src="https://user-images.githubusercontent.com/877401/99403454-281bb300-28f3-11eb-98c0-5374b66e12ee.png">


**ER:**
- Only bookmarks for existent Units are present

Link to Jira [ticket](https://openedx.atlassian.net/browse/BTR-21)

