### PR TITLE
Branding: Update boder-left on Progress page

### DIFF
--- a/lms/static/sass/course/_auto-cert.scss
+++ b/lms/static/sass/course/_auto-cert.scss
@@ -13,7 +13,7 @@
   .auto-cert-message {
     margin: $baseline 0;
     padding: $baseline;
-    border-left: 3px solid $m-blue-d1;
+    border-left: 3px solid $primary;
     background: $gray-l5;
 
     .has-actions {


### PR DESCRIPTION
Before:
<img width="1126" alt="Screen Shot 2020-11-17 at 7 56 34 PM" src="https://user-images.githubusercontent.com/4252738/99407736-4395b680-2911-11eb-801b-b4b6e9348de3.png">



After:
<img width="1143" alt="Screen Shot 2020-11-17 at 8 13 19 PM" src="https://user-images.githubusercontent.com/4252738/99407823-59a37700-2911-11eb-8040-38a0d2820835.png">

[TNL-7681](https://openedx.atlassian.net/browse/TNL-7681)
