### PR TITLE
Fixing SSO only accounts login

### DIFF
--- a/common/djangoapps/third_party_auth/pipeline.py
+++ b/common/djangoapps/third_party_auth/pipeline.py
@@ -674,7 +674,7 @@ def set_logged_in_cookies(backend=None, user=None, strategy=None, auth_entry=Non
 
     """
     if not is_api(auth_entry) and user is not None and user.is_authenticated:
-        if not user.has_usable_password():
+        if not user.is_active:
             msg = "Your account is disabled"
             return JsonResponse(msg, status=403)
         request = strategy.request if strategy else None


### PR DESCRIPTION
#### Related Ticket
https://github.com/mitodl/edx-platform/issues/207

#### Description
The current Implementation in edX is blocking SSO only account logins. This PR will fix the issue by enhancing the validation check in the authentication pipeline.