### PR TITLE
MB-714 | Fix log message when generating certificates

### DIFF
--- a/lms/djangoapps/certificates/api.py
+++ b/lms/djangoapps/certificates/api.py
@@ -208,7 +208,7 @@ def generate_user_certificates(student, course_key, course=None, insecure=False,
 
     if beta_testers_queryset.filter(username=student.username):
         message = u'Cancelling course certificate generation for user [{}] against course [{}], user is a Beta Tester.'
-        log.info(message.format(course_key, student.username))
+        log.info(message.format(student.username, course_key))
         return
 
     xqueue = XQueueCertInterface()

--- a/lms/djangoapps/instructor/tests/test_api.py
+++ b/lms/djangoapps/instructor/tests/test_api.py
@@ -1967,7 +1967,8 @@ class TestInstructorAPIBulkBetaEnrollment(SharedModuleStoreTestCase, LoginEnroll
         with LogCapture() as capture:
             message = u'Cancelling course certificate generation for user [{}] against course [{}], ' \
                       u'user is a Beta Tester.'
-            message = message.format(self.course.id, self.beta_tester.username)
+            message = message.format(self.beta_tester.username, self.course.id)
+
             generate_user_certificates(self.beta_tester, self.course.id, self.course)
             capture.check_present(('edx.certificate', 'INFO', message))
 


### PR DESCRIPTION
[MB-714]
- While investigating a certificate generation issue I happened to notice a log statement whose arguments were backwards