### PR TITLE
Squashing some naive datetime warnings

### DIFF
--- a/openedx/features/course_duration_limits/tests/test_models.py
+++ b/openedx/features/course_duration_limits/tests/test_models.py
@@ -182,13 +182,13 @@ class TestCourseDurationLimitConfig(CacheIsolationTestCase):
     def test_all_current_course_configs(self):
         # Set up test objects
         for global_setting in (True, False, None):
-            CourseDurationLimitConfig.objects.create(enabled=global_setting, enabled_as_of=datetime(2018, 1, 1))
+            CourseDurationLimitConfig.objects.create(enabled=global_setting, enabled_as_of=datetime(2018, 1, 1, tzinfo=pytz.UTC))
             for site_setting in (True, False, None):
                 test_site_cfg = SiteConfigurationFactory.create(
                     site_values={'course_org_filter': []}
                 )
                 CourseDurationLimitConfig.objects.create(
-                    site=test_site_cfg.site, enabled=site_setting, enabled_as_of=datetime(2018, 1, 1)
+                    site=test_site_cfg.site, enabled=site_setting, enabled_as_of=datetime(2018, 1, 1, tzinfo=pytz.UTC)
                 )
 
                 for org_setting in (True, False, None):
@@ -197,7 +197,7 @@ class TestCourseDurationLimitConfig(CacheIsolationTestCase):
                     test_site_cfg.save()
 
                     CourseDurationLimitConfig.objects.create(
-                        org=test_org, enabled=org_setting, enabled_as_of=datetime(2018, 1, 1)
+                        org=test_org, enabled=org_setting, enabled_as_of=datetime(2018, 1, 1, tzinfo=pytz.UTC)
                     )
 
                     for course_setting in (True, False, None):
@@ -206,7 +206,7 @@ class TestCourseDurationLimitConfig(CacheIsolationTestCase):
                             id=CourseLocator(test_org, 'test_course', 'run-{}'.format(course_setting))
                         )
                         CourseDurationLimitConfig.objects.create(
-                            course=test_course, enabled=course_setting, enabled_as_of=datetime(2018, 1, 1)
+                            course=test_course, enabled=course_setting, enabled_as_of=datetime(2018, 1, 1, tzinfo=pytz.UTC)
                         )
 
             with self.assertNumQueries(4):
@@ -241,7 +241,7 @@ class TestCourseDurationLimitConfig(CacheIsolationTestCase):
         )
 
     def test_caching_global(self):
-        global_config = CourseDurationLimitConfig(enabled=True, enabled_as_of=datetime(2018, 1, 1))
+        global_config = CourseDurationLimitConfig(enabled=True, enabled_as_of=datetime(2018, 1, 1, tzinfo=pytz.UTC))
         global_config.save()
 
         RequestCache.clear_all_namespaces()
@@ -267,7 +267,7 @@ class TestCourseDurationLimitConfig(CacheIsolationTestCase):
 
     def test_caching_site(self):
         site_cfg = SiteConfigurationFactory()
-        site_config = CourseDurationLimitConfig(site=site_cfg.site, enabled=True, enabled_as_of=datetime(2018, 1, 1))
+        site_config = CourseDurationLimitConfig(site=site_cfg.site, enabled=True, enabled_as_of=datetime(2018, 1, 1, tzinfo=pytz.UTC))
         site_config.save()
 
         RequestCache.clear_all_namespaces()
@@ -291,7 +291,7 @@ class TestCourseDurationLimitConfig(CacheIsolationTestCase):
         with self.assertNumQueries(1):
             self.assertFalse(CourseDurationLimitConfig.current(site=site_cfg.site).enabled)
 
-        global_config = CourseDurationLimitConfig(enabled=True, enabled_as_of=datetime(2018, 1, 1))
+        global_config = CourseDurationLimitConfig(enabled=True, enabled_as_of=datetime(2018, 1, 1, tzinfo=pytz.UTC))
         global_config.save()
 
         RequestCache.clear_all_namespaces()
@@ -305,7 +305,7 @@ class TestCourseDurationLimitConfig(CacheIsolationTestCase):
         site_cfg = SiteConfigurationFactory.create(
             site_values={'course_org_filter': course.org}
         )
-        org_config = CourseDurationLimitConfig(org=course.org, enabled=True, enabled_as_of=datetime(2018, 1, 1))
+        org_config = CourseDurationLimitConfig(org=course.org, enabled=True, enabled_as_of=datetime(2018, 1, 1, tzinfo=pytz.UTC))
         org_config.save()
 
         RequestCache.clear_all_namespaces()
@@ -329,7 +329,7 @@ class TestCourseDurationLimitConfig(CacheIsolationTestCase):
         with self.assertNumQueries(2):
             self.assertFalse(CourseDurationLimitConfig.current(org=course.org).enabled)
 
-        global_config = CourseDurationLimitConfig(enabled=True, enabled_as_of=datetime(2018, 1, 1))
+        global_config = CourseDurationLimitConfig(enabled=True, enabled_as_of=datetime(2018, 1, 1, tzinfo=pytz.UTC))
         global_config.save()
 
         RequestCache.clear_all_namespaces()
@@ -338,7 +338,7 @@ class TestCourseDurationLimitConfig(CacheIsolationTestCase):
         with self.assertNumQueries(0):
             self.assertFalse(CourseDurationLimitConfig.current(org=course.org).enabled)
 
-        site_config = CourseDurationLimitConfig(site=site_cfg.site, enabled=True, enabled_as_of=datetime(2018, 1, 1))
+        site_config = CourseDurationLimitConfig(site=site_cfg.site, enabled=True, enabled_as_of=datetime(2018, 1, 1, tzinfo=pytz.UTC))
         site_config.save()
 
         RequestCache.clear_all_namespaces()
@@ -352,7 +352,7 @@ class TestCourseDurationLimitConfig(CacheIsolationTestCase):
         site_cfg = SiteConfigurationFactory.create(
             site_values={'course_org_filter': course.org}
         )
-        course_config = CourseDurationLimitConfig(course=course, enabled=True, enabled_as_of=datetime(2018, 1, 1))
+        course_config = CourseDurationLimitConfig(course=course, enabled=True, enabled_as_of=datetime(2018, 1, 1, tzinfo=pytz.UTC))
         course_config.save()
 
         RequestCache.clear_all_namespaces()
@@ -376,7 +376,7 @@ class TestCourseDurationLimitConfig(CacheIsolationTestCase):
         with self.assertNumQueries(2):
             self.assertFalse(CourseDurationLimitConfig.current(course_key=course.id).enabled)
 
-        global_config = CourseDurationLimitConfig(enabled=True, enabled_as_of=datetime(2018, 1, 1))
+        global_config = CourseDurationLimitConfig(enabled=True, enabled_as_of=datetime(2018, 1, 1, tzinfo=pytz.UTC))
         global_config.save()
 
         RequestCache.clear_all_namespaces()
@@ -385,7 +385,7 @@ class TestCourseDurationLimitConfig(CacheIsolationTestCase):
         with self.assertNumQueries(0):
             self.assertFalse(CourseDurationLimitConfig.current(course_key=course.id).enabled)
 
-        site_config = CourseDurationLimitConfig(site=site_cfg.site, enabled=True, enabled_as_of=datetime(2018, 1, 1))
+        site_config = CourseDurationLimitConfig(site=site_cfg.site, enabled=True, enabled_as_of=datetime(2018, 1, 1, tzinfo=pytz.UTC))
         site_config.save()
 
         RequestCache.clear_all_namespaces()
@@ -394,7 +394,7 @@ class TestCourseDurationLimitConfig(CacheIsolationTestCase):
         with self.assertNumQueries(0):
             self.assertFalse(CourseDurationLimitConfig.current(course_key=course.id).enabled)
 
-        org_config = CourseDurationLimitConfig(org=course.org, enabled=True, enabled_as_of=datetime(2018, 1, 1))
+        org_config = CourseDurationLimitConfig(org=course.org, enabled=True, enabled_as_of=datetime(2018, 1, 1, tzinfo=pytz.UTC))
         org_config.save()
 
         RequestCache.clear_all_namespaces()

--- a/openedx/features/course_experience/tests/views/test_course_home.py
+++ b/openedx/features/course_experience/tests/views/test_course_home.py
@@ -202,7 +202,7 @@ class TestCourseHomePage(CourseHomePageTestCase):
         """
         Verify that the view's query count doesn't regress.
         """
-        CourseDurationLimitConfig.objects.create(enabled=True, enabled_as_of=datetime(2018, 1, 1))
+        CourseDurationLimitConfig.objects.create(enabled=True, enabled_as_of=datetime(2018, 1, 1, tzinfo=UTC))
         # Pre-fetch the view to populate any caches
         course_home_url(self.course)
 
@@ -560,7 +560,7 @@ class TestCourseHomePageAccess(CourseHomePageTestCase):
         Ensure that a user accessing an expired course sees a redirect to
         the student dashboard, not a 404.
         """
-        CourseDurationLimitConfig.objects.create(enabled=True, enabled_as_of=datetime(2010, 1, 1))
+        CourseDurationLimitConfig.objects.create(enabled=True, enabled_as_of=datetime(2010, 1, 1, tzinfo=UTC))
         course = CourseFactory.create(start=THREE_YEARS_AGO)
         url = course_home_url(course)
 
@@ -596,7 +596,7 @@ class TestCourseHomePageAccess(CourseHomePageTestCase):
         Ensure that a user accessing a course with an expired upgrade deadline
         will still see the course expiration banner without the upgrade related text.
         """
-        past = datetime(2010, 1, 1)
+        past = datetime(2010, 1, 1, tzinfo=UTC)
         CourseDurationLimitConfig.objects.create(enabled=True, enabled_as_of=past)
         course = CourseFactory.create(start=now() - timedelta(days=10))
         CourseModeFactory.create(course_id=course.id, mode_slug=CourseMode.AUDIT)
@@ -616,7 +616,7 @@ class TestCourseHomePageAccess(CourseHomePageTestCase):
         Verify that enrolled users are NOT shown the course expiration banner and can
         access the course home page if course audit only
         """
-        CourseDurationLimitConfig.objects.create(enabled=True, enabled_as_of=datetime(2010, 1, 1))
+        CourseDurationLimitConfig.objects.create(enabled=True, enabled_as_of=datetime(2010, 1, 1, tzinfo=UTC))
         audit_only_course = CourseFactory.create()
         self.create_user_for_course(audit_only_course, CourseUserType.ENROLLED)
         response = self.client.get(course_home_url(audit_only_course))
@@ -630,7 +630,7 @@ class TestCourseHomePageAccess(CourseHomePageTestCase):
         Ensure that a user accessing an expired course that is in the holdback
         does not get redirected to the student dashboard, not a 404.
         """
-        CourseDurationLimitConfig.objects.create(enabled=True, enabled_as_of=datetime(2010, 1, 1))
+        CourseDurationLimitConfig.objects.create(enabled=True, enabled_as_of=datetime(2010, 1, 1, tzinfo=UTC))
 
         course = CourseFactory.create(start=THREE_YEARS_AGO)
         url = course_home_url(course)
@@ -757,7 +757,7 @@ class TestCourseHomePageAccess(CourseHomePageTestCase):
         config = CourseDurationLimitConfig(
             course=CourseOverview.get_from_id(self.course.id),
             enabled=True,
-            enabled_as_of=datetime(2018, 1, 1)
+            enabled_as_of=datetime(2018, 1, 1, tzinfo=UTC)
         )
         config.save()
 
@@ -790,7 +790,7 @@ class TestCourseHomePageAccess(CourseHomePageTestCase):
         config = CourseDurationLimitConfig(
             course=CourseOverview.get_from_id(self.course.id),
             enabled=True,
-            enabled_as_of=datetime(2018, 1, 1)
+            enabled_as_of=datetime(2018, 1, 1, tzinfo=UTC)
         )
         config.save()
         url = course_home_url(self.course)
@@ -815,7 +815,7 @@ class TestCourseHomePageAccess(CourseHomePageTestCase):
         config = CourseDurationLimitConfig(
             course=CourseOverview.get_from_id(self.course.id),
             enabled=True,
-            enabled_as_of=datetime(2018, 1, 1)
+            enabled_as_of=datetime(2018, 1, 1, tzinfo=UTC)
         )
         config.save()
         url = course_home_url(self.course)

--- a/openedx/features/course_experience/tests/views/test_course_outline.py
+++ b/openedx/features/course_experience/tests/views/test_course_outline.py
@@ -20,6 +20,7 @@ from milestones.tests.utils import MilestonesTestCaseMixin
 from mock import Mock, patch
 from opaque_keys.edx.keys import CourseKey, UsageKey
 from pyquery import PyQuery as pq
+from pytz import UTC
 from six import text_type
 from waffle.models import Switch
 from waffle.testutils import override_switch
@@ -214,7 +215,7 @@ class TestCourseOutlinePage(SharedModuleStoreTestCase, MasqueradeMixin):
     ):
         ContentTypeGatingConfig.objects.create(
             enabled=True,
-            enabled_as_of=datetime.datetime(2017, 1, 1),
+            enabled_as_of=datetime.datetime(2017, 1, 1, tzinfo=UTC),
         )
         course = self.courses[0]
         for mode in course_modes:

--- a/openedx/features/course_experience/tests/views/test_course_updates.py
+++ b/openedx/features/course_experience/tests/views/test_course_updates.py
@@ -5,6 +5,7 @@ Tests for the course updates page.
 from datetime import datetime
 
 from django.urls import reverse
+from pytz import UTC
 
 from openedx.core.djangoapps.waffle_utils.testutils import WAFFLE_TABLES
 from openedx.features.content_type_gating.models import ContentTypeGatingConfig
@@ -40,7 +41,7 @@ class TestCourseUpdatesPage(BaseCourseUpdatesTestCase):
         self.assertContains(response, 'Second Message')
 
     def test_queries(self):
-        ContentTypeGatingConfig.objects.create(enabled=True, enabled_as_of=datetime(2018, 1, 1))
+        ContentTypeGatingConfig.objects.create(enabled=True, enabled_as_of=datetime(2018, 1, 1, tzinfo=UTC))
         self.create_course_update('First Message')
 
         # Pre-fetch the view to populate any caches


### PR DESCRIPTION
for my "squash a warning, earn a badge!" cred. squashes an incredible... 19 warnings 😛 

I chose this because I noticed inconsistincies in the files about how datetimes were treated, and copied the format the other datetimes used (adding `tzinfo=UTC` to the datetimes)

in `course_duration_limits`
<pre>
openedx/features/course_duration_limits/tests/test_models.py::TestCourseDurationLimitConfig::test_caching_org
openedx/features/course_duration_limits/tests/test_models.py::TestCourseDurationLimitConfig::test_all_current_course_configs
openedx/features/course_duration_limits/tests/test_models.py::TestCourseDurationLimitConfig::test_caching_global
openedx/features/course_duration_limits/tests/test_models.py::TestCourseDurationLimitConfig::test_caching_site
openedx/features/course_duration_limits/tests/test_models.py::TestCourseDurationLimitConfig::test_caching_course
  /edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/django/db/models/fields/__init__.py:1424: RuntimeWarning: DateTimeField CourseDurationLimitConfig.enabled_as_of received a naive datetime (2018-01-01 00:00:00) while time zone support is active.
    warnings.warn("DateTimeField %s received a naive datetime (%s)"
</pre>

in `course_experience`
<pre>
openedx/features/course_experience/tests/views/test_course_home.py::TestCourseHomePage::test_queries
openedx/features/course_experience/tests/views/test_course_home.py::TestCourseHomePageAccess::test_course_messaging_for_staff
openedx/features/course_experience/tests/views/test_course_home.py::TestCourseHomePageAccess::test_course_expiration_banner_with_unicode
openedx/features/course_experience/tests/views/test_course_home.py::TestCourseHomePageAccess::test_course_messaging
  /edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/django/db/models/fields/__init__.py:1424: RuntimeWarning: DateTimeField CourseDurationLimitConfig.enabled_as_of received a naive datetime (2018-01-01 00:00:00) while time zone support is active.
    warnings.warn("DateTimeField %s received a naive datetime (%s)"

openedx/features/course_experience/tests/views/test_course_home.py::TestCourseHomePageAccess::test_expired_course
openedx/features/course_experience/tests/views/test_course_home.py::TestCourseHomePageAccess::test_audit_only_not_expired
openedx/features/course_experience/tests/views/test_course_home.py::TestCourseHomePageAccess::test_expiration_banner_with_expired_upgrade_deadline
openedx/features/course_experience/tests/views/test_course_home.py::TestCourseHomePageAccess::test_expired_course_in_holdback
  /edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/django/db/models/fields/__init__.py:1424: RuntimeWarning: DateTimeField CourseDurationLimitConfig.enabled_as_of received a naive datetime (2010-01-01 00:00:00) while time zone support is active.
    warnings.warn("DateTimeField %s received a naive datetime (%s)"

openedx/features/course_experience/tests/views/test_course_home.py::TestCourseHomePageAccess::test_expiration_banner_with_expired_upgrade_deadline
  /edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/django/db/models/fields/__init__.py:1424: RuntimeWarning: DateTimeField CourseMode._expiration_datetime received a naive datetime (2010-01-01 00:00:00) while time zone support is active.
    warnings.warn("DateTimeField %s received a naive datetime (%s)"

openedx/features/course_experience/tests/views/test_course_home.py::TestCourseHomePageAccess::test_expiration_banner_with_expired_upgrade_deadline
  /edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/django/db/models/fields/__init__.py:1424: RuntimeWarning: DateTimeField HistoricalCourseMode._expiration_datetime received a naive datetime (2010-01-01 00:00:00) while time zone support is active.
    warnings.warn("DateTimeField %s received a naive datetime (%s)"

openedx/features/course_experience/tests/views/test_course_updates.py::TestCourseUpdatesPage::test_queries
  /edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/django/db/models/fields/__init__.py:1424: RuntimeWarning: DateTimeField ContentTypeGatingConfig.enabled_as_of received a naive datetime (2018-01-01 00:00:00) while time zone support is active.
    warnings.warn("DateTimeField %s received a naive datetime (%s)"
</pre>