### PR TITLE
[BD-4] Convert Annotatable XModule to XBlock. [SE-3640]

### DIFF
--- a/common/lib/xmodule/setup.py
+++ b/common/lib/xmodule/setup.py
@@ -20,13 +20,13 @@ XMODULES = [
     "videodev = xmodule.backcompat_module:TranslateCustomTagDescriptor",
     "videosequence = xmodule.seq_module:SequenceDescriptor",
     "custom_tag_template = xmodule.raw_module:RawDescriptor",
-    "annotatable = xmodule.annotatable_module:AnnotatableDescriptor",
     "hidden = xmodule.hidden_module:HiddenDescriptor",
     "raw = xmodule.raw_module:RawDescriptor",
     "lti = xmodule.lti_module:LTIDescriptor",
 ]
 XBLOCKS = [
     "about = xmodule.html_module:AboutBlock",
+    "annotatable = xmodule.annotatable_module:AnnotatableBlock",
     "conditional = xmodule.conditional_module:ConditionalBlock",
     "course_info = xmodule.html_module:CourseInfoBlock",
     "html = xmodule.html_module:HtmlBlock",

--- a/common/lib/xmodule/xmodule/static_content.py
+++ b/common/lib/xmodule/xmodule/static_content.py
@@ -20,6 +20,7 @@ import six
 from docopt import docopt
 from path import Path as path
 
+from xmodule.annotatable_module import AnnotatableBlock
 from xmodule.capa_module import ProblemBlock
 from xmodule.conditional_module import ConditionalBlock
 from xmodule.html_module import AboutBlock, CourseInfoBlock, HtmlBlock, StaticTabBlock
@@ -67,6 +68,7 @@ class VideoBlock(HTMLSnippet):
 # Should only be used for XModules being converted to XBlocks.
 XBLOCK_CLASSES = [
     AboutBlock,
+    AnnotatableBlock,
     ConditionalBlock,
     CourseInfoBlock,
     HtmlBlock,

--- a/common/lib/xmodule/xmodule/tests/test_annotatable_module.py
+++ b/common/lib/xmodule/xmodule/tests/test_annotatable_module.py
@@ -9,12 +9,12 @@ from opaque_keys.edx.locator import BlockUsageLocator, CourseLocator
 from xblock.field_data import DictFieldData
 from xblock.fields import ScopeIds
 
-from xmodule.annotatable_module import AnnotatableModule
+from xmodule.annotatable_module import AnnotatableBlock
 
 from . import get_test_system
 
 
-class AnnotatableModuleTestCase(unittest.TestCase):
+class AnnotatableBlockTestCase(unittest.TestCase):
     sample_xml = '''
         <annotatable display_name="Iliad">
             <instructions>Read the text.</instructions>
@@ -33,9 +33,8 @@ class AnnotatableModuleTestCase(unittest.TestCase):
     '''
 
     def setUp(self):
-        super(AnnotatableModuleTestCase, self).setUp()
-        self.annotatable = AnnotatableModule(
-            Mock(),
+        super().setUp()
+        self.annotatable = AnnotatableBlock(
             get_test_system(),
             DictFieldData({'data': self.sample_xml}),
             ScopeIds(None, None, None, BlockUsageLocator(CourseLocator('org', 'course', 'run'), 'category', 'name'))
@@ -68,7 +67,7 @@ class AnnotatableModuleTestCase(unittest.TestCase):
     def test_annotation_class_attr_with_valid_highlight(self):
         xml = '<annotation title="x" body="y" problem="0" highlight="{highlight}">test</annotation>'
 
-        for color in self.annotatable.highlight_colors:
+        for color in self.annotatable.HIGHLIGHT_COLORS:
             el = etree.fromstring(xml.format(highlight=color))
             value = 'annotatable-span highlight highlight-{highlight}'.format(highlight=color)
 

--- a/common/lib/xmodule/xmodule/tests/test_xblock_wrappers.py
+++ b/common/lib/xmodule/xmodule/tests/test_xblock_wrappers.py
@@ -30,7 +30,7 @@ from xblock.core import XBlock
 from xblock.field_data import DictFieldData
 from xblock.fields import ScopeIds
 
-from xmodule.annotatable_module import AnnotatableDescriptor
+from xmodule.annotatable_module import AnnotatableBlock
 from xmodule.conditional_module import ConditionalBlock
 from xmodule.course_module import CourseDescriptor
 from xmodule.html_module import HtmlBlock
@@ -55,7 +55,7 @@ from xmodule.x_module import (
 # to a list of sample field values to test with.
 # TODO: Add more types of sample data
 LEAF_XMODULES = {
-    AnnotatableDescriptor: [{}],
+    AnnotatableBlock: [{}],
     HtmlBlock: [{}],
     PollDescriptor: [{'display_name': 'Poll Display Name'}],
     WordCloudBlock: [{}],

--- a/lms/templates/annotatable.html
+++ b/lms/templates/annotatable.html
@@ -3,7 +3,7 @@
 <div class="annotatable-wrapper">
 	<div class="annotatable-header">
 		% if display_name is not UNDEFINED and display_name is not None:
-		  <h3 class="hd hd-3 annotatable-title">${display_name}</h3>
+		  <h3 class="hd hd-3 annotatable-title">${display_name | h}</h3>
 		% endif
     </div>
 


### PR DESCRIPTION
Converts the Annotatable XModule into an XBlock.

Part of [XModule to XBlock Conversion work](https://openedx.atlassian.net/wiki/spaces/AC/pages/1472790755/XModule+to+XBlock+Conversion). 

**Testing instructions**:

1. Create an Annotatable component in Studio and test it out. Docs are available [here](https://edx.readthedocs.io/projects/edx-partner-course-staff/en/latest/exercises_tools/annotation.html).
2. Interact with it in LMS.
3. Checkout this branch and set it up:

```
make lms-shell
pip install -e common/lib/xmodule
NO_PREREQ_INSTALL=1 paver update_assets
exit
make lms-restart

make studio-shell
pip install -e common/lib/xmodule
NO_PREREQ_INSTALL=1 paver update_assets
exit
make studio-restart
```

4. Check that the UI and behavior of the Annotatable XBlock is the same in both Studio and LMS.

Descriptor MRO | Module MRO | Block MRO | Notes
------------ | ------------- | ---------------- | ------------
<class 'xmodule.annotatable_module.AnnotatableDescriptor'> | <class 'xmodule.annotatable_module.AnnotatableModule'> | <class 'xmodule.annotatable_module.AnnotatableBlock'> |
<class 'xmodule.annotatable_module.AnnotatableFields'> | <class 'xmodule.annotatable_module.AnnotatableFields'> | - | Merged into the block class.
<class 'xmodule.raw_module.RawDescriptor'> | - | - | Doesn't have any attributes.
<class 'xmodule.raw_module.RawMixin'> | | <class 'xmodule.raw_module.RawMixin'> |
<class 'xmodule.xml_module.XmlDescriptor'> | - | - | Doesn't have any attributes.
<class 'xmodule.xml_module.XmlMixin'> | | <class 'xmodule.xml_module.XmlMixin'> |
<class 'xmodule.xml_module.XmlParserMixin'> | - | <class 'xmodule.xml_module.XmlParserMixin'> |
<class 'xmodule.editing_module.XMLEditingDescriptor'> | - | - | Inherits from EditingDescriptor and only sets js/css for studio view which has been set on the AnnotatableBlock directly.
<class 'xmodule.editing_module.EditingDescriptor'> | - | - | Doesn't have any attributes.
<class 'xmodule.editing_module.EditingMixin'> | - | <class 'xmodule.editing_module.EditingMixin'> |
<class 'xmodule.editing_module.EditingFields'> | - | <class 'xmodule.editing_module.EditingFields'> |
<class 'xmodule.mako_module.MakoModuleDescriptor'> | - | - | Inherits from (MakoTemplateBlockBase, XModuleDescriptor) and has the get_html() method which has been implemented in the XBlock.
<class 'xmodule.mako_module.MakoTemplateBlockBase'> | - | <class 'xmodule.mako_module.MakoTemplateBlockBase'> |
<class 'xmodule.x_module.XModuleDescriptor'> | - | - |
<class 'xmodule.x_module.XModuleDescriptorToXBlockMixin'> | - | <class 'xmodule.x_module.XModuleDescriptorToXBlockMixin'> |
– | <class 'xmodule.x_module.XModule'> | - |
– | <class 'xmodule.x_module.XModuleToXBlockMixin'> | <class 'xmodule.x_module.XModuleToXBlockMixin'> |
<class 'xmodule.x_module.HTMLSnippet'> | <class 'xmodule.x_module.HTMLSnippet'> | <class 'xmodule.x_module.HTMLSnippet'> |
<class 'xmodule.x_module.ResourceTemplates'> | - | <class 'xmodule.x_module.ResourceTemplates'> |
<class 'xmodule.x_module.XModuleMixin'> | <class 'xmodule.x_module.XModuleMixin'> | <class 'xmodule.x_module.XModuleMixin'> |
<class 'xmodule.x_module.XModuleFields'> | <class 'xmodule.x_module.XModuleFields'> | <class 'xmodule.x_module.XModuleFields'> |
<class 'xblock.core.XBlock'> | <class 'xblock.core.XBlock'> | <class 'xblock.core.XBlock'> |
