### PR TITLE
Update @edx/brand-edx.org to v1.1.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -40,9 +40,9 @@
       }
     },
     "@edx/brand-edx.org": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@edx/brand-edx.org/-/brand-edx.org-1.1.1.tgz",
-      "integrity": "sha512-jlJbeR1kLljgR1vED5ibGKFhVIWuHzRjdEMaCCCmAqKtcnmP3vGzCyb+NjlGcDvuJRvANT7Nq05+F0sfLbSY6A=="
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@edx/brand-edx.org/-/brand-edx.org-1.1.2.tgz",
+      "integrity": "sha512-lW0JcTMCbbtL+ckSzXytzDIX3lmR2w1huapICklaDrY9U8sL8CIu9t2BT+7t2Fq4ZM78jcx5+Ct0c3qMskNmcw=="
     },
     "@edx/edx-bootstrap": {
       "version": "1.0.4",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "edx",
   "version": "0.1.0",
   "dependencies": {
-    "@edx/brand-edx.org": "^1.1.1",
+    "@edx/brand-edx.org": "^1.1.2",
     "@edx/edx-bootstrap": "1.0.4",
     "@edx/edx-proctoring": "^1.5.0",
     "@edx/frontend-component-cookie-policy-banner": "1.0.0",


### PR DESCRIPTION
The new theme is in `v1.1.2` of the brand-edx.org package. It looks like the `edx-platform` is using an older version. let's update to the latest version and teams should work from there.


FYI -- @abutterworth @marcotuts 
