### PR TITLE
Update Course Date Links

### DIFF
--- a/lms/djangoapps/courseware/date_summary.py
+++ b/lms/djangoapps/courseware/date_summary.py
@@ -430,7 +430,7 @@ class CourseAssignmentDate(DateSummary):
         """ Used to set the title_html and title properties for the assignment date block """
         if link:
             self.assignment_title_html = HTML(
-                '<a href="{assignment_link}">{assignment_title}</a>'
+                '<a href="{assignment_link}" class="btn btn-outline-primary">{assignment_title}</a>'
             ).format(assignment_link=link, assignment_title=title)
         self.assignment_title = title
 

--- a/lms/static/sass/features/_course-experience.scss
+++ b/lms/static/sass/features/_course-experience.scss
@@ -482,9 +482,9 @@
 
       .date-summary-link {
         font-weight: $font-semibold;
+        padding-top: 12px;
 
         a {
-          color: $link-color;
           font-size: 0.9rem;
         }
       }
@@ -498,10 +498,10 @@
 }
 
 .dates-tab-link {
-  padding: 16px 0 0 24px;
+  padding: 12px 0 0 24px;
 
   a {
-    font-weight: bold;
+    font-size: 0.9rem;
   }
 }
 

--- a/openedx/features/course_experience/templates/course_experience/course-dates-fragment.html
+++ b/openedx/features/course_experience/templates/course_experience/course-dates-fragment.html
@@ -15,7 +15,7 @@ from django.utils.translation import ugettext as _
     % endfor
     % if dates_tab_enabled:
         <div class="dates-tab-link">
-            <a href="${dates_tab_link}">View all course dates</a>
+            <a class="btn btn-outline-primary" href="${dates_tab_link}">View all course dates</a>
         </div>
     % endif
 % endif

--- a/openedx/features/course_experience/templates/course_experience/dates-summary.html
+++ b/openedx/features/course_experience/templates/course_experience/dates-summary.html
@@ -26,7 +26,7 @@ from django.utils.translation import ugettext as _
             % endif
             % if course_date.link and course_date.link_text:
                 <div class="date-summary-link">
-                    <a id="course_home_dates" href="${course_date.link}">${course_date.link_text}</a>
+                    <a id="course_home_dates" class="btn btn-outline-primary" href="${course_date.link}">${course_date.link_text}</a>
                 </div>
             % endif
         </div>


### PR DESCRIPTION
Branding: PR updates the course date links to `btn-outline-primary` elm. 

Related PR: https://github.com/edx/edx-themes/pull/642
[TNL-7679#](https://openedx.atlassian.net/browse/TNL-7679)

# Before edx.org:

<img width="348" alt="Screen Shot 2020-11-19 at 9 48 40 PM" src="https://user-images.githubusercontent.com/4252738/99696887-010ae000-2ab1-11eb-8539-22406b82ae82.png">


Before edx.org-next:
-
<img width="375" alt="Screen Shot 2020-11-19 at 9 49 26 PM" src="https://user-images.githubusercontent.com/4252738/99696990-1b44be00-2ab1-11eb-96a1-aff2470c5bb4.png">


# After edx.org: 

<img width="381" alt="Screen Shot 2020-11-25 at 2 34 38 AM" src="https://user-images.githubusercontent.com/4252738/100154131-f1333780-2ec6-11eb-9bee-44b3d0d37744.png">



# After edx.org-next:



<img width="386" alt="Screen Shot 2020-11-25 at 2 34 51 AM" src="https://user-images.githubusercontent.com/4252738/100154158-f98b7280-2ec6-11eb-9746-307a7ebc49a8.png">




