### PR TITLE
[TNL-7680] - fixing border bottom for button in sequence bar.

### DIFF
--- a/common/lib/xmodule/xmodule/css/sequence/display.scss
+++ b/common/lib/xmodule/xmodule/css/sequence/display.scss
@@ -322,7 +322,7 @@ $seq-nav-height: 50px;
     }
 
     @include media-breakpoint-up(sm) {
-      border-bottom: 3px solid $seq-nav-link-color;
+      border-bottom: 3px solid $primary;
       background-color: theme-color("inverse");
 
       .icon {


### PR DESCRIPTION
### [TNL-7680](https://openedx.atlassian.net/browse/TNL-7680)

#### Fix issue with the theme on sequence-nav bar buttons.

_note: the Previous button is in hover state and the book icon with highlighted bottom border is the active selected button_

### Before Fix
<img width="452" alt="Screen Shot 2020-11-18 at 10 52 43 PM" src="https://user-images.githubusercontent.com/30112155/99568130-df4a2400-29f0-11eb-9fd3-27d25602f7f9.png">

### After Fix
<img width="485" alt="Screen Shot 2020-11-18 at 10 46 26 PM" src="https://user-images.githubusercontent.com/30112155/99568119-dc4f3380-29f0-11eb-9461-dcbb87c004f6.png">

FYI -- @awaisdar001 @asadazam93 
