### PR TITLE
Fix pylint-ignore of import_shims directory

### DIFF
--- a/pylintrc
+++ b/pylintrc
@@ -72,7 +72,7 @@ ignore = ,.git,.tox,migrations,node_modules,.pycharm_helpers
 persistent = yes
 load-plugins = edx_lint.pylint,pylint_django,pylint_celery
 init-hook = "import sys; sys.path.extend(['import_shims/lms', 'import_shims/studio'])"
-ignore-patterns = **/import_shims/**/*.py
+ignore-patterns = import_shims/.*\.py
 
 [MESSAGES CONTROL]
 enable = 
@@ -465,4 +465,4 @@ int-import-graph =
 [EXCEPTIONS]
 overgeneral-exceptions = Exception
 
-# 09e2946a83274f8dccbac8e284d7b1cf381fa31b
+# 1e55086aa34f587a2c3b4e58eb8e68f69c617622

--- a/pylintrc_tweaks
+++ b/pylintrc_tweaks
@@ -5,7 +5,7 @@ ignore+ = ,.git,.tox,migrations,node_modules,.pycharm_helpers
 # It will be removed in an upcoming Open edX release.
 # See docs/decisions/0007-sys-path-modification-removal.rst
 init-hook="import sys; sys.path.extend(['import_shims/lms', 'import_shims/studio'])"
-ignore-patterns=**/import_shims/**/*.py
+ignore-patterns = import_shims/.*\.py
 
 [MESSAGES CONTROL]
 disable+ =


### PR DESCRIPTION
Seems that https://github.com/edx/edx-platform/pull/25477/commits/d61d77de264f3a32570a56b6f68c9fe74358f8ea broke local usage of pylint due to a bad regex for `ignore-patterns`