### PR TITLE
[BD-21] Fix monitored values of CourseWaffleFlag objects

### DIFF
--- a/openedx/core/djangoapps/waffle_utils/__init__.py
+++ b/openedx/core/djangoapps/waffle_utils/__init__.py
@@ -190,7 +190,7 @@ class CourseWaffleFlag(BaseWaffleFlag):
         if is_enabled_for_course is not None:
             # pylint: disable=protected-access
             self.waffle_namespace._monitor_value(
-                self.namespaced_flag_name, is_enabled_for_course
+                self.flag_name, is_enabled_for_course
             )
             return is_enabled_for_course
         return super().is_enabled()


### PR DESCRIPTION
The monitored value was being twice namespaced, resulting in incorrect
names, such as "schedules.schedules.send_updates_for_course".

cc @robrap 

This should be ready for review (assuming tests are green).