### PR TITLE
Fix imports, remove unused import

### DIFF
--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -658,7 +658,7 @@ MIDDLEWARE = [
 
     # A newer and safer request cache.
     'edx_django_utils.cache.middleware.RequestCacheMiddleware',
-    'edx_django_utils.monitoring.middleware.MonitoringMemoryMiddleware',
+    'edx_django_utils.monitoring.MonitoringMemoryMiddleware',
 
     # Cookie monitoring
     'openedx.core.lib.request_utils.CookieMonitoringMiddleware',

--- a/lms/djangoapps/verify_student/management/commands/tests/test_populate_expiration_date.py
+++ b/lms/djangoapps/verify_student/management/commands/tests/test_populate_expiration_date.py
@@ -15,7 +15,7 @@ from testfixtures import LogCapture
 from common.test.utils import MockS3BotoMixin
 from lms.djangoapps.verify_student.models import SoftwareSecurePhotoVerification
 from lms.djangoapps.verify_student.tests.test_models import FAKE_SETTINGS, mock_software_secure_post
-from student.tests.factories import UserFactory
+from common.djangoapps.student.tests.factories import UserFactory
 
 LOGGER_NAME = 'lms.djangoapps.verify_student.management.commands.populate_expiration_date'
 

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -1678,10 +1678,10 @@ MIDDLEWARE = [
 
     # A newer and safer request cache.
     'edx_django_utils.cache.middleware.RequestCacheMiddleware',
-    'edx_django_utils.monitoring.middleware.CachedCustomMonitoringMiddleware',
+    'edx_django_utils.monitoring.CachedCustomMonitoringMiddleware',
 
     # Generate code ownership attributes. Keep this immediately after RequestCacheMiddleware.
-    'edx_django_utils.monitoring.code_owner.middleware.CodeOwnerMonitoringMiddleware',
+    'edx_django_utils.monitoring.CodeOwnerMonitoringMiddleware',
 
     # Cookie monitoring
     'openedx.core.lib.request_utils.CookieMonitoringMiddleware',

--- a/openedx/core/djangoapps/content/learning_sequences/api/processors/content_gating.py
+++ b/openedx/core/djangoapps/content/learning_sequences/api/processors/content_gating.py
@@ -3,8 +3,8 @@ from datetime import datetime
 
 from django.contrib.auth import get_user_model
 from opaque_keys.edx.keys import CourseKey
-from student.models import EntranceExamConfiguration
-from util import milestones_helpers
+from common.djangoapps.student.models import EntranceExamConfiguration
+from common.djangoapps.util import milestones_helpers
 
 from .base import OutlineProcessor
 

--- a/openedx/core/djangoapps/content/learning_sequences/api/processors/milestones.py
+++ b/openedx/core/djangoapps/content/learning_sequences/api/processors/milestones.py
@@ -2,7 +2,7 @@ import logging
 
 from django.contrib.auth import get_user_model
 from opaque_keys.edx.keys import CourseKey
-from util import milestones_helpers
+from common.djangoapps.util import milestones_helpers
 
 from .base import OutlineProcessor
 

--- a/openedx/core/djangoapps/user_authn/cookies.py
+++ b/openedx/core/djangoapps/user_authn/cookies.py
@@ -22,8 +22,7 @@ from openedx.core.djangoapps.oauth_dispatch.api import create_dot_access_token
 from openedx.core.djangoapps.oauth_dispatch.jwt import create_jwt_from_token
 from openedx.core.djangoapps.user_api.accounts.utils import retrieve_last_sitewide_block_completed
 from openedx.core.djangoapps.user_authn.exceptions import AuthFailedError
-from student.models import CourseEnrollment
-from util.json_request import JsonResponse
+from common.djangoapps.util.json_request import JsonResponse
 
 
 log = logging.getLogger(__name__)


### PR DESCRIPTION
A few minor warnings fixed, and one unused import removed.

1. `./manage.py lms shell -c "print('hello')"`

```
2020-11-19 09:36:40,680 WARNING 2788 [py.warnings] [user None] [ip None] warnings.py:109 - /edx/app/edxapp/edx-platform/openedx/core/djangoapps/user_authn/cookies.py:25: DeprecatedEdxPlatformImportWarning: Importing student.models instead of common.djangoapps.student.models is deprecated
  from student.models import CourseEnrollment

2020-11-19 09:36:40,680 WARNING 2788 [py.warnings] [user None] [ip None] warnings.py:109 - /edx/app/edxapp/edx-platform/openedx/core/djangoapps/user_authn/cookies.py:26: DeprecatedEdxPlatformImportWarning: Importing util.json_request instead of common.djangoapps.util.json_request is deprecated
  from util.json_request import JsonResponse
```

2. `python manage.py lms migrate`

```
2020-11-19 09:52:25,431 WARNING 2969 [py.warnings] [user None] [ip None] warnings.py:109 - /edx/app/edxapp/edx-platform/openedx/core/djangoapps/content/learning_sequences/api/processors/content_gating.py:7: DeprecatedEdxPlatformImportWarning: Importing util.milestones_helpers instead of common.djangoapps.util.milestones_helpers is deprecated
  from util import milestones_helpers
```

3. `pytest --pdbcls pudb.debugger:Debugger --pdb --capture=no lms/djangoapps/instructor_task`:

```
lms/djangoapps/instructor_task/tests/test_tasks_helper.py: 20 warnings
lms/djangoapps/instructor_task/tests/test_integration.py: 20 warnings
  /edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/edx_django_utils/monitoring/code_owner/middleware.py:23: DeprecationWarning: Use 'edx_django_utils.monitoring.CodeOwnerMonitoringMiddleware' in place of 'edx_django_utils.monitoring.code_owner.middleware.CodeOwnerMonitoringMiddleware'.
    warnings.warn(msg, DeprecationWarning)
```

and

```
lms/djangoapps/instructor_task/tests/test_tasks_helper.py: 20 warnings
lms/djangoapps/instructor_task/tests/test_integration.py: 20 warnings
  /edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/edx_django_utils/monitoring/middleware.py:23: DeprecationWarning: Use 'edx_django_utils.monitoring.CachedCustomMonitoringMiddleware' in place of 'edx_django_utils.monitoring.middleware.CachedCustomMonitoringMiddleware'.
    warnings.warn(msg, DeprecationWarning)
```