### PR TITLE
Replace 'multi_db = True' with 'databases = {alias for alias in connections}'

### DIFF
--- a/common/lib/xmodule/xmodule/modulestore/tests/django_utils.py
+++ b/common/lib/xmodule/xmodule/modulestore/tests/django_utils.py
@@ -12,6 +12,7 @@ from enum import Enum
 
 from django.conf import settings
 from django.contrib.auth.models import AnonymousUser, User
+from django.db import connections
 from django.test import TestCase
 from django.test.utils import override_settings
 from mock import patch
@@ -397,7 +398,7 @@ class SharedModuleStoreTestCase(
     for Django ORM models that will get cleaned up properly.
     """
     # Tell Django to clean out all databases, not just default
-    multi_db = True
+    databases = {alias for alias in connections}
 
     @classmethod
     @contextmanager
@@ -486,7 +487,7 @@ class ModuleStoreTestCase(
     CREATE_USER = True
 
     # Tell Django to clean out all databases, not just default
-    multi_db = True
+    databases = {alias for alias in connections}
 
     @classmethod
     def setUpClass(cls):

--- a/lms/djangoapps/ccx/tests/test_field_override_performance.py
+++ b/lms/djangoapps/ccx/tests/test_field_override_performance.py
@@ -16,6 +16,7 @@ from ccx_keys.locator import CCXLocator
 from django.conf import settings
 from django.contrib.messages.storage.fallback import FallbackStorage
 from django.core.cache import caches
+from django.db import connections
 from django.test.client import RequestFactory
 from django.test.utils import override_settings
 from edx_django_utils.cache import RequestCache
@@ -57,7 +58,7 @@ class FieldOverridePerformanceTestCase(FieldOverrideTestMixin, ProceduralCourseT
     """
     __test__ = False
     # Tell Django to clean out all databases, not just default
-    multi_db = True
+    databases = {alias for alias in connections}
 
     # TEST_DATA must be overridden by subclasses
     TEST_DATA = None

--- a/lms/djangoapps/courseware/tests/test_model_data.py
+++ b/lms/djangoapps/courseware/tests/test_model_data.py
@@ -6,7 +6,7 @@ Test for lms courseware app, module data (runtime data storage for XBlocks)
 import json
 from functools import partial
 
-from django.db import DatabaseError
+from django.db import connections, DatabaseError
 from django.test import TestCase
 from mock import Mock, patch
 from xblock.core import XBlock
@@ -105,7 +105,7 @@ class TestStudentModuleStorage(OtherUserFailureTestMixin, TestCase):
     other_key_factory = partial(DjangoKeyValueStore.Key, Scope.user_state, 2, location('usage_id'))  # user_id=2, not 1
     existing_field_name = "a_field"
     # Tell Django to clean out all databases, not just default
-    multi_db = True
+    databases = {alias for alias in connections}
 
     def setUp(self):
         super(TestStudentModuleStorage, self).setUp()
@@ -230,7 +230,7 @@ class TestStudentModuleStorage(OtherUserFailureTestMixin, TestCase):
 
 class TestMissingStudentModule(TestCase):
     # Tell Django to clean out all databases, not just default
-    multi_db = True
+    databases = {alias for alias in connections}
 
     def setUp(self):
         super(TestMissingStudentModule, self).setUp()

--- a/lms/djangoapps/courseware/tests/test_submitting_problems.py
+++ b/lms/djangoapps/courseware/tests/test_submitting_problems.py
@@ -14,6 +14,7 @@ import ddt
 import six
 from django.conf import settings
 from django.contrib.auth.models import User
+from django.db import connections
 from django.test import TestCase
 from django.test.client import RequestFactory
 from django.urls import reverse
@@ -139,7 +140,7 @@ class TestSubmittingProblems(ModuleStoreTestCase, LoginEnrollmentTestCase, Probl
     """
 
     # Tell Django to clean out all databases, not just default
-    multi_db = True
+    databases = {alias for alias in connections}
     # arbitrary constant
     COURSE_SLUG = "100"
     COURSE_NAME = "test_course"
@@ -342,7 +343,7 @@ class TestCourseGrader(TestSubmittingProblems):
     Suite of tests for the course grader.
     """
     # Tell Django to clean out all databases, not just default
-    multi_db = True
+    databases = {alias for alias in connections}
 
     def basic_setup(self, late=False, reset=False, showanswer=False):
         """
@@ -755,7 +756,7 @@ class TestCourseGrader(TestSubmittingProblems):
 class ProblemWithUploadedFilesTest(TestSubmittingProblems):
     """Tests of problems with uploaded files."""
     # Tell Django to clean out all databases, not just default
-    multi_db = True
+    databases = {alias for alias in connections}
 
     def setUp(self):
         super(ProblemWithUploadedFilesTest, self).setUp()
@@ -811,7 +812,7 @@ class TestPythonGradedResponse(TestSubmittingProblems):
     Check that we can submit a schematic and custom response, and it answers properly.
     """
     # Tell Django to clean out all databases, not just default
-    multi_db = True
+    databases = {alias for alias in connections}
 
     SCHEMATIC_SCRIPT = dedent("""
         # for a schematic response, submission[i] is the json representation

--- a/lms/djangoapps/courseware/tests/test_user_state_client.py
+++ b/lms/djangoapps/courseware/tests/test_user_state_client.py
@@ -6,6 +6,8 @@ defined in edx_user_state_client.
 
 from collections import defaultdict
 
+from django.db import connections
+
 from edx_user_state_client.tests import UserStateClientTestBase
 
 from lms.djangoapps.courseware.tests.factories import UserFactory
@@ -20,7 +22,7 @@ class TestDjangoUserStateClient(UserStateClientTestBase, ModuleStoreTestCase):
     """
     __test__ = True
     # Tell Django to clean out all databases, not just default
-    multi_db = True
+    databases = {alias for alias in connections}
 
     def _user(self, user_idx):
         return self.users[user_idx].username

--- a/lms/djangoapps/coursewarehistoryextended/tests.py
+++ b/lms/djangoapps/coursewarehistoryextended/tests.py
@@ -10,6 +10,7 @@ import json
 from unittest import skipUnless
 
 from django.conf import settings
+from django.db import connections
 from django.test import TestCase
 from mock import patch
 
@@ -21,7 +22,7 @@ from lms.djangoapps.courseware.tests.factories import StudentModuleFactory, cour
 class TestStudentModuleHistoryBackends(TestCase):
     """ Tests of data in CSMH and CSMHE """
     # Tell Django to clean out all databases, not just default
-    multi_db = True
+    databases = {alias for alias in connections}
 
     def setUp(self):
         super(TestStudentModuleHistoryBackends, self).setUp()

--- a/openedx/core/djangoapps/content_libraries/tests/test_runtime.py
+++ b/openedx/core/djangoapps/content_libraries/tests/test_runtime.py
@@ -5,6 +5,7 @@ Test the Blockstore-based XBlock runtime and content libraries together.
 import json
 
 from completion.test_utils import CompletionWaffleTestMixin
+from django.db import connections
 from django.test import TestCase, override_settings
 from organizations.models import Organization
 from rest_framework.test import APIClient
@@ -183,7 +184,7 @@ class ContentLibraryXBlockUserStateTest(ContentLibraryContentTestMixin, TestCase
     if the library allows direct learning.
     """
 
-    multi_db = True
+    databases = {alias for alias in connections}
 
     @XBlock.register_temp_plugin(UserStateTestBlock, UserStateTestBlock.BLOCK_TYPE)
     def test_default_values(self):


### PR DESCRIPTION
Squashes warnings like:
```
../venvs/edxapp/lib/python3.8/site-packages/django/test/testcases.py:887
lms/djangoapps/instructor_task/tests/test_tasks_helper.py::TestTeamStudentReport::test_team_column_no_teams
  /edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/django/test/testcases.py:887: RemovedInDjango31Warning: `TestCase.multi_db` is deprecated. Databases available during this test can be defined using lms.djangoapps.instructor_task.tests.test_tasks_helper.TestTeamStudentReport.databases.
    warnings.warn(msg, RemovedInDjango31Warning)
```

Check this ticket for details: https://code.djangoproject.com/ticket/29513

