### PR TITLE
Format blackout dates to match rest of Discussions API.

### DIFF
--- a/lms/djangoapps/discussion/rest_api/tests/test_api.py
+++ b/lms/djangoapps/discussion/rest_api/tests/test_api.py
@@ -179,8 +179,8 @@ class GetCourseTestBlackouts(ForumsEnableMixin, UrlResetMixin, ModuleStoreTestCa
         self.assertEqual(
             result["blackouts"],
             [
-                {"start": "2015-06-09T00:00:00+00:00", "end": "2015-06-10T00:00:00+00:00"},
-                {"start": "2015-06-11T00:00:00+00:00", "end": "2015-06-12T00:00:00+00:00"},
+                {"start": "2015-06-09T00:00:00Z", "end": "2015-06-10T00:00:00Z"},
+                {"start": "2015-06-11T00:00:00Z", "end": "2015-06-12T00:00:00Z"},
             ]
         )
 


### PR DESCRIPTION
Technically, both "2020-10-20T23:59:00Z" and "2020-10-20T23:59:00+00:00"
are ISO-8601 compliant, though the latter is preferred. The Discussions
API uses the "Z" notation for almost all its dates, except for the
course blackout dates (those times when students aren't allowed to post
anything because it would threaten exam integrity). That's because the
blackout dates are manually formatted using datetime.isoformat().

As best as I can tell, we've always passed back the "+00:00" for the
blackout dates. But at some point, this broke the expectations of the
mobile apps, which expect the "+Z" format, like the rest of the API.
This commit changes the blackout dates to be returned in +Z format when
the blackout datetimes are specified by the user in UTC (which is almost
always the case–I suspect the mobile clients would break if the dates
were specified in other timezones anyhow).
