### PR TITLE
Use `node` for running node.js tests, not `nodejs`

### DIFF
--- a/pavelib/paver_tests/test_js_test.py
+++ b/pavelib/paver_tests/test_js_test.py
@@ -119,7 +119,7 @@ class TestPaverJavaScriptTestTasks(PaverTestCase):
         expected_messages.append(self.EXPECTED_INSTALL_NPM_ASSETS_COMMAND)
 
         command_template = (
-            'nodejs --max_old_space_size=4096 node_modules/.bin/karma start {options}'
+            'node --max_old_space_size=4096 node_modules/.bin/karma start {options}'
         )
 
         for suite in suites:

--- a/pavelib/quality.py
+++ b/pavelib/quality.py
@@ -331,7 +331,7 @@ def run_eslint(options):
     violations_limit = int(getattr(options, 'limit', -1))
 
     sh(
-        "nodejs --max_old_space_size=4096 node_modules/.bin/eslint "
+        "node --max_old_space_size=4096 node_modules/.bin/eslint "
         "--ext .js --ext .jsx --format=compact . | tee {eslint_report}".format(
             eslint_report=eslint_report
         ),

--- a/pavelib/utils/test/suites/js_suite.py
+++ b/pavelib/utils/test/suites/js_suite.py
@@ -77,7 +77,7 @@ class JsTestSubSuite(TestSuite):
         Run the tests using karma runner.
         """
         cmd = [
-            "nodejs",
+            "node",
             "--max_old_space_size=4096",
             "node_modules/.bin/karma",
             "start",


### PR DESCRIPTION
This should solve the problem of getting `nodejs: not found` when
running `paver test_js_run -s lms` in lms-shell, which cropped up in
the past few days.

I don't know why this stopped working recently, but I don't have `nodejs`
on my recently re-created devstack, and some people with an older devstack
have both. Maybe a recent node.js release got rid of an alias.