### PR TITLE
AA-131: Allow anonymous users through course home MFE

### DIFF
--- a/common/lib/xmodule/xmodule/seq_module.py
+++ b/common/lib/xmodule/xmodule/seq_module.py
@@ -224,7 +224,7 @@ class SequenceModule(SequenceFields, ProctoringFields, XModule):
         progress = reduce(Progress.add_counts, progresses, None)
         return progress
 
-    def handle_ajax(self, dispatch, data):  # TODO: bounds checking
+    def handle_ajax(self, dispatch, data, view=STUDENT_VIEW):  # TODO: bounds checking
         ''' get = request.POST instance '''
         if dispatch == 'goto_position':
             # set position to default value if either 'position' argument not
@@ -263,7 +263,7 @@ class SequenceModule(SequenceFields, ProctoringFields, XModule):
                 else:
                     # check if prerequisite has been met
                     prereq_met, prereq_meta_info = self._compute_is_prereq_met(True)
-            meta = self._get_render_metadata(context, display_items, prereq_met, prereq_meta_info, banner_text, STUDENT_VIEW)
+            meta = self._get_render_metadata(context, display_items, prereq_met, prereq_meta_info, banner_text, view)
             meta['display_name'] = self.display_name_with_default
             meta['format'] = getattr(self, 'format', '')
             return json.dumps(meta)

--- a/lms/djangoapps/course_home_api/outline/v1/tests/test_views.py
+++ b/lms/djangoapps/course_home_api/outline/v1/tests/test_views.py
@@ -96,7 +96,18 @@ class OutlineTabTestViews(BaseCourseHomeTests):
     def test_get_unauthenticated_user(self):
         self.client.logout()
         response = self.client.get(self.url)
-        self.assertEqual(response.status_code, 403)
+        self.assertEqual(response.status_code, 200)
+
+        course_blocks = response.data.get('course_blocks')
+        self.assertEqual(course_blocks, None)
+
+        course_tools = response.data.get('course_tools')
+        self.assertEqual(len(course_tools), 0)
+
+        dates_widget = response.data.get('dates_widget')
+        self.assertTrue(dates_widget)
+        date_blocks = dates_widget.get('course_date_blocks')
+        self.assertEqual(len(date_blocks), 0)
 
     @override_experiment_waffle_flag(COURSE_HOME_MICROFRONTEND, active=True)
     @override_waffle_flag(COURSE_HOME_MICROFRONTEND_OUTLINE_TAB, active=True)

--- a/lms/djangoapps/courseware/courses.py
+++ b/lms/djangoapps/courseware/courses.py
@@ -525,6 +525,8 @@ def get_course_assignments(course_key, user, include_access=False):
     Each returned object is a namedtuple with fields: title, url, date, contains_gated_content, complete, past_due,
     assignment_type
     """
+    if not user.id:
+        return []
     store = modulestore()
     course_usage_key = store.make_course_usage_key(course_key)
     block_data = get_course_blocks(user, course_usage_key, allow_start_dates_in_future=True, include_completion=True)

--- a/lms/djangoapps/courseware/views/views.py
+++ b/lms/djangoapps/courseware/views/views.py
@@ -55,7 +55,8 @@ from lms.djangoapps.ccx.custom_exception import CCXLocatorValidationException
 from lms.djangoapps.certificates import api as certs_api
 from lms.djangoapps.certificates.models import CertificateStatuses
 from lms.djangoapps.commerce.utils import EcommerceService
-from lms.djangoapps.course_home_api.utils import is_request_from_learning_mfe
+from lms.djangoapps.course_home_api.toggles import course_home_mfe_dates_tab_is_active
+from lms.djangoapps.course_home_api.utils import get_microfrontend_url, is_request_from_learning_mfe
 from lms.djangoapps.courseware.access import has_access, has_ccx_coach_role
 from lms.djangoapps.courseware.access_utils import check_course_open_for_learner, check_public_access
 from lms.djangoapps.courseware.courses import (
@@ -643,7 +644,8 @@ class CourseTabView(EdxFragmentView):
                             register_label=_("register"),
                             current_url=urlquote_plus(request.path),
                         ),
-                    )
+                    ),
+                    once_only=True
                 )
             else:
                 PageLevelMessages.register_warning_message(
@@ -1010,6 +1012,9 @@ def dates(request, course_id):
     from lms.urls import COURSE_DATES_NAME, RESET_COURSE_DEADLINES_NAME
 
     course_key = CourseKey.from_string(course_id)
+    if course_home_mfe_dates_tab_is_active(course_key) and not request.user.is_staff:
+        microfrontend_url = get_microfrontend_url(course_key=course_key, view_name=COURSE_DATES_NAME)
+        raise Redirect(microfrontend_url)
 
     # Enable NR tracing for this view based on course
     monitoring_utils.set_custom_attribute('course_id', text_type(course_key))
@@ -1617,7 +1622,7 @@ def render_xblock(request, usage_key_string, check_if_enrolled=True):
     Returns an HttpResponse with HTML content for the xBlock with the given usage_key.
     The returned HTML is a chromeless rendering of the xBlock (excluding content of the containing courseware).
     """
-    from lms.urls import COURSE_DATES_NAME, RESET_COURSE_DEADLINES_NAME
+    from lms.urls import RESET_COURSE_DEADLINES_NAME
     from openedx.features.course_experience.urls import COURSE_HOME_VIEW_NAME
 
     usage_key = UsageKey.from_string(usage_key_string)
@@ -1626,7 +1631,7 @@ def render_xblock(request, usage_key_string, check_if_enrolled=True):
     course_key = usage_key.course_key
 
     requested_view = request.GET.get('view', 'student_view')
-    if requested_view != 'student_view':
+    if requested_view != 'student_view' and requested_view != 'public_view':
         return HttpResponseBadRequest(
             u"Rendering of the xblock view '{}' is not supported.".format(bleach.clean(requested_view, strip=True))
         )
@@ -1659,7 +1664,7 @@ def render_xblock(request, usage_key_string, check_if_enrolled=True):
         missed_deadlines, missed_gated_content = dates_banner_should_display(course_key, request.user)
 
         context = {
-            'fragment': block.render('student_view', context=student_view_context),
+            'fragment': block.render(requested_view, context=student_view_context),
             'course': course,
             'disable_accordion': True,
             'allow_iframing': True,

--- a/lms/djangoapps/experiments/stable_bucketing.py
+++ b/lms/djangoapps/experiments/stable_bucketing.py
@@ -12,7 +12,7 @@ import hashlib
 import re
 
 
-def stable_bucketing_hash_group(group_name, group_count, username):
+def stable_bucketing_hash_group(group_name, group_count, user):
     """
     Return the bucket that a user should be in for a given stable bucketing assignment.
 
@@ -22,11 +22,14 @@ def stable_bucketing_hash_group(group_name, group_count, username):
     Arguments:
         group_name: The name of the grouping/experiment.
         group_count: How many groups to bucket users into.
-        username: The username of the user being bucketed.
+        user: The user being bucketed.
     """
+    # We need username for stable bucketing and id for tracking, so just skip anonymous (not-logged-in) users
+    if not user or not user.id:
+        return 0
     hasher = hashlib.md5()
     hasher.update(group_name.encode('utf-8'))
-    hasher.update(username.encode('utf-8'))
+    hasher.update(user.username.encode('utf-8'))
     hash_str = hasher.hexdigest()
 
     return int(re.sub('[8-9a-f]', '1', re.sub('[0-7]', '0', hash_str)), 2) % group_count

--- a/lms/djangoapps/experiments/views_custom.py
+++ b/lms/djangoapps/experiments/views_custom.py
@@ -138,7 +138,7 @@ class Rev934(DeveloperErrorViewMixin, APIView):
         upgrade_price = six.text_type(get_cosmetic_verified_display_price(course))
         could_upsell = bool(user_upsell and basket_url)
 
-        bucket = stable_bucketing_hash_group(MOBILE_UPSELL_EXPERIMENT, 2, user.username)
+        bucket = stable_bucketing_hash_group(MOBILE_UPSELL_EXPERIMENT, 2, user)
 
         if could_upsell and hasattr(request, 'session') and MOBILE_UPSELL_EXPERIMENT not in request.session:
             properties = {

--- a/openedx/core/djangoapps/courseware_api/views.py
+++ b/openedx/core/djangoapps/courseware_api/views.py
@@ -47,6 +47,7 @@ from common.djangoapps.student.models import (
 )
 from xmodule.modulestore.django import modulestore
 from xmodule.modulestore.search import path_to_location
+from xmodule.x_module import PUBLIC_VIEW, STUDENT_VIEW
 
 from .serializers import CourseInfoSerializer
 from .utils import serialize_upgrade_info
@@ -483,7 +484,12 @@ class SequenceMetadata(DeveloperErrorViewMixin, APIView):
             str(usage_key.course_key),
             str(usage_key),
             disable_staff_debug_info=True)
-        return Response(json.loads(sequence.handle_ajax('metadata', None)))
+
+        view = STUDENT_VIEW
+        if request.user.is_anonymous:
+            view = PUBLIC_VIEW
+
+        return Response(json.loads(sequence.handle_ajax('metadata', None, view=view)))
 
 
 class Resume(DeveloperErrorViewMixin, APIView):

--- a/openedx/features/course_experience/views/course_dates.py
+++ b/openedx/features/course_experience/views/course_dates.py
@@ -12,7 +12,6 @@ from django.utils.translation import get_language_bidi
 from opaque_keys.edx.keys import CourseKey
 from web_fragments.fragment import Fragment
 
-from lms.djangoapps.courseware.access import has_access
 from lms.djangoapps.courseware.courses import get_course_date_blocks, get_course_with_access
 from lms.djangoapps.courseware.tabs import DatesTab
 from lms.djangoapps.course_home_api.toggles import course_home_mfe_dates_tab_is_active

--- a/openedx/features/course_experience/views/course_home.py
+++ b/openedx/features/course_experience/views/course_home.py
@@ -14,16 +14,17 @@ from django.views.decorators.csrf import ensure_csrf_cookie
 from opaque_keys.edx.keys import CourseKey
 from web_fragments.fragment import Fragment
 
+from lms.djangoapps.course_home_api.toggles import course_home_mfe_outline_tab_is_active
+from lms.djangoapps.course_home_api.utils import get_microfrontend_url
 from lms.djangoapps.courseware.access import has_access
 from lms.djangoapps.courseware.courses import can_self_enroll_in_course, get_course_info_section, get_course_with_access
-from lms.djangoapps.commerce.utils import EcommerceService
 from lms.djangoapps.course_goals.api import (
     get_course_goal,
     get_course_goal_options,
     get_goal_api_url,
     has_course_goal_permission
 )
-from lms.djangoapps.courseware.exceptions import CourseAccessRedirect
+from lms.djangoapps.courseware.exceptions import CourseAccessRedirect, Redirect
 from lms.djangoapps.courseware.utils import can_show_verified_upgrade, verified_upgrade_deadline_link
 from lms.djangoapps.courseware.views.views import CourseTabView
 from lms.djangoapps.courseware.toggles import COURSEWARE_PROCTORING_IMPROVEMENTS
@@ -70,6 +71,9 @@ class CourseHomeView(CourseTabView):
 
     def render_to_fragment(self, request, course=None, tab=None, **kwargs):
         course_id = six.text_type(course.id)
+        if course_home_mfe_outline_tab_is_active(course.id) and not request.user.is_staff:
+            microfrontend_url = get_microfrontend_url(course_key=course_id, view_name="home")
+            raise Redirect(microfrontend_url)
         home_fragment_view = CourseHomeFragmentView()
         return home_fragment_view.render_to_fragment(request, course_id=course_id, **kwargs)
 

--- a/openedx/features/discounts/applicability.py
+++ b/openedx/features/discounts/applicability.py
@@ -150,7 +150,7 @@ def _is_in_holdback_and_bucket(user):
         return False
 
     # Holdback is 10%
-    bucket = stable_bucketing_hash_group(DISCOUNT_APPLICABILITY_HOLDBACK, 10, user.username)
+    bucket = stable_bucketing_hash_group(DISCOUNT_APPLICABILITY_HOLDBACK, 10, user)
 
     request = get_current_request()
     if hasattr(request, 'session') and DISCOUNT_APPLICABILITY_HOLDBACK not in request.session:


### PR DESCRIPTION
- Refactored MFE Outline Tab API to retrieve the appropriate amount of data for anonymous or unenrolled users, accounting for public outlines
- Updated ExperimentWaffleFlag to allow anonymous users
- Updated LMS Dates and Outline tab views to redirect to MFE if flag is enabled
- Updated courseware API to retrieve PUBLIC_VIEW when user is anonymous