### PR TITLE
ARCHBOM-1260: prep for code_owner for enterprise celery tasks

### DIFF
--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -35,7 +35,7 @@ drf-yasg<1.17.1
 # The team that owns this package will manually bump this package rather than having it pulled in automatically.
 # This is to allow them to better control its deployment and to do it in a process that works better
 # for them.
-edx-enterprise==3.12.2
+edx-enterprise==3.12.3
 
 # We expect v2.0.0 to introduce large breaking changes in the feature toggle API
 edx-toggles<2.0.0


### PR DESCRIPTION
Update enterprise constraint to 3.12.3 to get code_owner
monitoring for celery tasks with next `make upgrade`.

ARCHBOM-1260