### PR TITLE
add course_import_failure newRelic custom attribute for better alerting conditions in import flow

### DIFF
--- a/common/lib/xmodule/xmodule/modulestore/xml.py
+++ b/common/lib/xmodule/xmodule/modulestore/xml.py
@@ -16,6 +16,7 @@ from importlib import import_module
 
 import six
 from django.utils.encoding import python_2_unicode_compatible
+from edx_django_utils.monitoring import set_custom_attribute
 from fs.osfs import OSFS
 from lazy import lazy
 from lxml import etree
@@ -382,6 +383,7 @@ class XMLModuleStore(ModuleStoreReadBase):
             msg = "ERROR: Failed to load courselike '{0}': {1}".format(
                 course_dir.encode("utf-8"), six.text_type(exc)
             )
+            set_custom_attribute('course_import_failure', "Courselike load failure: {}".format(msg))
             log.exception(msg)
             errorlog.tracker(msg)
             self.errored_courses[course_dir] = errorlog

--- a/common/lib/xmodule/xmodule/modulestore/xml_importer.py
+++ b/common/lib/xmodule/xmodule/modulestore/xml_importer.py
@@ -32,6 +32,7 @@ from abc import abstractmethod
 
 import six
 import xblock
+from edx_django_utils.monitoring import set_custom_attribute
 from lxml import etree
 from opaque_keys.edx.keys import UsageKey
 from opaque_keys.edx.locator import LibraryLocator
@@ -173,9 +174,9 @@ class StaticContentImporter:
         try:
             self.static_content_store.save(content)
         except Exception as err:
-            log.exception(u'Error importing {0}, error={1}'.format(
-                file_subpath, err
-            ))
+            msg = "Error importing {0}, error={1}".format(file_subpath, err)
+            log.exception(msg)
+            set_custom_attribute('course_import_failure', "Static Content Save Failure: {}".format(msg))
 
         return file_subpath, asset_key
 
@@ -493,7 +494,9 @@ class ImportManager(object):
                     runtime=courselike.runtime,
                 )
             except Exception:
-                log.error('failed to import module location %s', leftover)
+                msg = 'failed to import module location {}'.format(leftover)
+                log.error(msg)
+                set_custom_attribute('course_import_failure', "Module Load failure: {}".format(msg))
                 raise
 
     def run_imports(self):


### PR DESCRIPTION
### Description
Add course_import_failure custom attribute that will be added for some course import failures. The purpose of adding this attr is to get the failure data in newRelic and add better reports