### PR TITLE
Clean up deprecated edx-platform imports of edxmako & util

### DIFF
--- a/cms/devstack.yml
+++ b/cms/devstack.yml
@@ -354,7 +354,7 @@ MODULESTORE:
                 OPTIONS:
                     default_class: xmodule.hidden_module.HiddenDescriptor
                     fs_root: /edx/var/edxapp/data
-                    render_template: edxmako.shortcuts.render_to_string
+                    render_template: common.djangoapps.edxmako.shortcuts.render_to_string
             -   DOC_STORE_CONFIG:
                     authsource: ''
                     collection: modulestore
@@ -374,7 +374,7 @@ MODULESTORE:
                 OPTIONS:
                     default_class: xmodule.hidden_module.HiddenDescriptor
                     fs_root: /edx/var/edxapp/data
-                    render_template: edxmako.shortcuts.render_to_string
+                    render_template: common.djangoapps.edxmako.shortcuts.render_to_string
 ORA2_FILE_PREFIX: default_env-default_deployment/ora2
 PARSE_KEYS: {}
 PARTNER_SUPPORT_EMAIL: ''

--- a/cms/envs/bok_choy.yml
+++ b/cms/envs/bok_choy.yml
@@ -108,7 +108,7 @@ MODULESTORE:
           fs_root: '** OVERRIDDEN **'
           host: [localhost]
           port: 27017
-          render_template: edxmako.shortcuts.render_to_string
+          render_template: common.djangoapps.edxmako.shortcuts.render_to_string
       - ENGINE: xmodule.modulestore.xml.XMLModuleStore
         NAME: xml
         OPTIONS: {data_dir: '** OVERRIDDEN **', default_class: xmodule.hidden_module.HiddenDescriptor}

--- a/cms/envs/bok_choy_docker.yml
+++ b/cms/envs/bok_choy_docker.yml
@@ -108,7 +108,7 @@ MODULESTORE:
           fs_root: '** OVERRIDDEN **'
           host: [edx.devstack.mongo]
           port: 27017
-          render_template: edxmako.shortcuts.render_to_string
+          render_template: common.djangoapps.edxmako.shortcuts.render_to_string
       - ENGINE: xmodule.modulestore.xml.XMLModuleStore
         NAME: xml
         OPTIONS: {data_dir: '** OVERRIDDEN **', default_class: xmodule.hidden_module.HiddenDescriptor}

--- a/lms/devstack.yml
+++ b/lms/devstack.yml
@@ -394,7 +394,7 @@ MODULESTORE:
                 OPTIONS:
                     default_class: xmodule.hidden_module.HiddenDescriptor
                     fs_root: /edx/var/edxapp/data
-                    render_template: edxmako.shortcuts.render_to_string
+                    render_template: common.djangoapps.edxmako.shortcuts.render_to_string
             -   DOC_STORE_CONFIG:
                     authsource: ''
                     collection: modulestore
@@ -414,7 +414,7 @@ MODULESTORE:
                 OPTIONS:
                     default_class: xmodule.hidden_module.HiddenDescriptor
                     fs_root: /edx/var/edxapp/data
-                    render_template: edxmako.shortcuts.render_to_string
+                    render_template: common.djangoapps.edxmako.shortcuts.render_to_string
 OAUTH_DELETE_EXPIRED: true
 OAUTH_ENFORCE_SECURE: false
 OAUTH_EXPIRE_CONFIDENTIAL_CLIENT_DAYS: 365

--- a/lms/djangoapps/verify_student/management/commands/populate_expiration_date.py
+++ b/lms/djangoapps/verify_student/management/commands/populate_expiration_date.py
@@ -12,7 +12,7 @@ from django.core.management.base import BaseCommand
 from django.db.models import F
 
 from lms.djangoapps.verify_student.models import SoftwareSecurePhotoVerification
-from util.query import use_read_replica_if_available
+from common.djangoapps.util.query import use_read_replica_if_available
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
Cleaning up a bunch of usages of deprecated imports `edxmako` and `util` in favor of `common.djangoapps.edxmako` and `common.djangoapps.util` across several repositories. These changes should have no functional effect other than squashing warnings.

This is part of the import-shims cleanup, which resulted from the sys.path-hack removal effort. See the [forum post](https://discuss.openedx.org/t/koa-will-change-how-edx-platform-code-is-imported/3610) for details.

All PRs in this cleanup effort:
* https://github.com/edx/configuration/pull/6173
* https://github.com/edx/edx-internal/pull/3729
* https://github.com/edx/edx-internal/pull/3801
* https://github.com/edx/edge-internal/pull/272
* https://github.com/edx/sandbox-internal/pull/113
* https://github.com/edx/edx-themes/pull/653
* https://github.com/edx/edx-microsite/pull/419
* https://github.com/edx/edx-documentation/pull/1892