### PR TITLE
Removed Extra space in sidebar link text

### DIFF
--- a/openedx/features/course_experience/templates/course_experience/course-home-fragment.html
+++ b/openedx/features/course_experience/templates/course_experience/course-home-fragment.html
@@ -117,8 +117,7 @@ from openedx.features.course_experience.course_tools import HttpMethod
                             <li class="course-tool">
                                 % if course_tool.http_method == HttpMethod.GET:
                                     <a class="course-tool-link" data-analytics-id="${course_tool.analytics_id()}" href="${course_tool.url(course_key)}">
-                                        <span class="icon ${course_tool.icon_classes()}" aria-hidden="true"></span>
-                                        ${course_tool.title()}
+                                        <span class="icon ${course_tool.icon_classes()}" aria-hidden="true"></span>${course_tool.title()}
                                     </a>
                                 % elif course_tool.http_method == HttpMethod.POST:
                                     <form class="course-tool-form" action="${course_tool.url(course_key)}" method="post">
@@ -247,4 +246,4 @@ from openedx.features.course_experience.course_tools import HttpMethod
         linkCategory: "(none)"
       });
 
-</%static:require_module_async> 
+</%static:require_module_async>


### PR DESCRIPTION
This PR removes extra single space at the start of course tools links. This PR is part of [TNL-7710(https://openedx.atlassian.net/browse/TNL-7710) Task and this  [PR](https://github.com/edx/edx-themes/pull/652)


### Before
![6dee94f6-8e41-4b67-8aea-73bff266ce53](https://user-images.githubusercontent.com/26253150/100316421-4ca31980-2fdc-11eb-9bfa-7f6597a2df47.png)

### After
<img width="302" alt="Screenshot 2020-11-25 at 11 06 00 AM" src="https://user-images.githubusercontent.com/26253150/100316428-4f057380-2fdc-11eb-8867-a5f5d7bd655a.png">
