### PR TITLE
Add error_code to AuthFailedError for password compliance 

### DIFF
--- a/openedx/core/djangoapps/user_authn/views/login.py
+++ b/openedx/core/djangoapps/user_authn/views/login.py
@@ -153,7 +153,7 @@ def _enforce_password_policy_compliance(request, user):
     except password_policy_compliance.NonCompliantPasswordException as e:
         send_password_reset_email_for_user(user, request)
         # Prevent the login attempt.
-        raise AuthFailedError(HTML(six.text_type(e)))
+        raise AuthFailedError(HTML(six.text_type(e)), error_code=e.__class__.__name__)
 
 
 def _log_and_raise_inactive_user_auth_error(unauthenticated_user):


### PR DESCRIPTION
Raises the AuthFailedError with the error_code inside it. This will be used on the logistration MFE.

Sample exception response:
```python
{
    'success': False, 
    'value': Markup('<strong>We recently changed our password requirements</strong><br/> '
                    'Your current password does not meet the new security requirements. We just sent a '
                    'password-reset message to the email address associated with this account. '
                    'Thank you for helping us keep your data safe.'), 
    'error_code': 'NonCompliantPasswordException'
}
```