### PR TITLE
Update Masquerade text color for specific learner

### DIFF
--- a/lms/static/sass/course/layout/_courseware_preview.scss
+++ b/lms/static/sass/course/layout/_courseware_preview.scss
@@ -56,6 +56,7 @@ $proctoring-banner-text-size: 14px;
   }
 
   .preview-specific-student-notice {
+    color: $inverse;
     margin-top: ($baseline/2);
     font-size: 90%;
   }


### PR DESCRIPTION
Ensure that while masquerading as a specific learner you can view the text telling you what learner is being previewed.
## Before edx.org:
![image-2020-11-17-16-21-10-800](https://user-images.githubusercontent.com/4252738/100440643-070f4b00-30c7-11eb-8d3b-3bce04df7797.png)




## After edx.org
<img width="1237" alt="Screen Shot 2020-11-27 at 3 40 25 PM" src="https://user-images.githubusercontent.com/4252738/100440543-e1824180-30c6-11eb-9184-476351653997.png">

### Before edx.org-next
<img width="1384" alt="Screen Shot 2020-11-30 at 9 36 56 PM" src="https://user-images.githubusercontent.com/4252738/100637030-35ee2100-3354-11eb-8c1b-8ed536b4ff98.png">


## After edx.org-next

<img width="1204" alt="Screen Shot 2020-11-27 at 3 40 03 PM" src="https://user-images.githubusercontent.com/4252738/100440519-d3342580-30c6-11eb-9a02-45d3cc8ae4df.png">

