### PR TITLE
extract a learners active enterprise existing details

### DIFF
--- a/openedx/features/enterprise_support/api.py
+++ b/openedx/features/enterprise_support/api.py
@@ -572,7 +572,12 @@ def consent_needed_for_course(request, user, course_id, enrollment_exists=False)
         )
     else:
         client = ConsentApiClient(user=request.user)
-        current_enterprise_uuid = enterprise_customer_uuid_for_request(request)
+
+        current_enterprise_uuid = None
+        learner_active_enterprise = get_learner_active_enterprise(enterprise_learner_details)
+        if learner_active_enterprise:
+            current_enterprise_uuid = learner_active_enterprise['uuid']
+
         consent_needed = any(
             str(current_enterprise_uuid) == str(learner['enterprise_customer']['uuid'])
             and Site.objects.get(domain=learner['enterprise_customer']['site']['domain']) == request.site
@@ -596,8 +601,7 @@ def consent_needed_for_course(request, user, course_id, enrollment_exists=False)
 
             if str(current_enterprise_uuid) not in enterprises:
                 LOGGER.info(  # pragma: no cover
-                    '[ENTERPRISE DSC] Consent requirement failed due to enterprise mismatch. '
-                    'USER: [%s], CurrentEnterprise: [%s], LearnerEnterprises: [%s]',
+                    '[ENTERPRISE DSC] Enterprise mismatch. USER: [%s], CurrentEnterprise: [%s], UserEnterprises: [%s]',
                     user.username,
                     current_enterprise_uuid,
                     enterprises
@@ -606,8 +610,7 @@ def consent_needed_for_course(request, user, course_id, enrollment_exists=False)
                 domains = [learner['enterprise_customer']['site']['domain'] for learner in enterprise_learner_details]
                 if not Site.objects.filter(domain__in=domains).filter(id=request.site.id).exists():
                     LOGGER.info(  # pragma: no cover
-                        '[ENTERPRISE DSC] Consent requirement failed due to site mismatch. '
-                        'USER: [%s], RequestSite: [%s], LearnerEnterpriseDomains: [%s]',
+                        '[ENTERPRISE DSC] Site mismatch. USER: [%s], RequestSite: [%s], LearnerEnterpriseDomains: [%s]',
                         user.username,
                         request.site,
                         domains
@@ -903,3 +906,16 @@ def unlink_enterprise_user_from_idp(request, user, idp_backend_name):
                     )
             except (EnterpriseCustomerUser.DoesNotExist, PendingEnterpriseCustomerUser.DoesNotExist):
                 pass
+
+
+def get_learner_active_enterprise(learner_enterprise_details):
+    """
+    Return a learners active enterprise.
+    """
+    learner_active_enterprise = None
+    for learner_enterprise_detail in learner_enterprise_details:
+        if learner_enterprise_detail['active']:
+            learner_active_enterprise = learner_enterprise_detail['enterprise_customer']
+            break
+
+    return learner_active_enterprise

--- a/openedx/features/enterprise_support/tests/mixins/enterprise.py
+++ b/openedx/features/enterprise_support/tests/mixins/enterprise.py
@@ -178,6 +178,7 @@ class EnterpriseServiceMockMixin(object):
                     ],
                     'replace_sensitive_sso_username': True,
                 },
+                'active': True,
                 'user_id': 5,
                 'user': {
                     'username': 'verified',


### PR DESCRIPTION
**Description:** We already have learner's enterprise details so we can get learner's active enterprise from those details rather than calling `enterprise_customer_uuid_for_request`

**JIRA:** [ENT-3670](https://openedx.atlassian.net/browse/ENT-3670)