### PR TITLE
Adding signals and receivers for assessment level reporting

### DIFF
--- a/lms/djangoapps/grades/subsection_grade_factory.py
+++ b/lms/djangoapps/grades/subsection_grade_factory.py
@@ -6,6 +6,7 @@ SubsectionGrade Factory Class
 from collections import OrderedDict
 from logging import getLogger
 
+from django.conf import settings
 from lazy import lazy
 from submissions import api as submissions_api
 
@@ -105,12 +106,13 @@ class SubsectionGradeFactory(object):
             )
             self._update_saved_subsection_grade(subsection.location, grade_model)
 
-            COURSE_ASSESSMENT_GRADE_CHANGED.send_robust(
-                sender=self,
-                user=self.student,
-                subsection_id=calculated_grade.location,
-                subsection_grade=calculated_grade.graded_total.earned
-            )
+            if settings.FEATURES.get('ENABLE_COURSE_ASSESSMENT_GRADE_CHANGE_SIGNAL'):
+                COURSE_ASSESSMENT_GRADE_CHANGED.send_robust(
+                    sender=self,
+                    user=self.student,
+                    subsection_id=calculated_grade.location,
+                    subsection_grade=calculated_grade.graded_total.earned
+                )
 
         return calculated_grade
 

--- a/lms/djangoapps/grades/subsection_grade_factory.py
+++ b/lms/djangoapps/grades/subsection_grade_factory.py
@@ -106,7 +106,7 @@ class SubsectionGradeFactory(object):
             self._update_saved_subsection_grade(subsection.location, grade_model)
 
             COURSE_ASSESSMENT_GRADE_CHANGED.send_robust(
-                sender=None,
+                sender=self,
                 user=self.student,
                 subsection_id=calculated_grade.location,
                 subsection_grade=calculated_grade.graded_total.earned

--- a/lms/djangoapps/grades/subsection_grade_factory.py
+++ b/lms/djangoapps/grades/subsection_grade_factory.py
@@ -9,6 +9,7 @@ from logging import getLogger
 from lazy import lazy
 from submissions import api as submissions_api
 
+from openedx.core.djangoapps.signals.signals import COURSE_ASSESSMENT_GRADE_CHANGED
 from lms.djangoapps.courseware.model_data import ScoresClient
 from lms.djangoapps.grades.config import assume_zero_if_absent, should_persist_grades
 from lms.djangoapps.grades.models import PersistentSubsectionGrade
@@ -103,6 +104,13 @@ class SubsectionGradeFactory(object):
                 force_update_subsections
             )
             self._update_saved_subsection_grade(subsection.location, grade_model)
+
+            COURSE_ASSESSMENT_GRADE_CHANGED.send_robust(
+                sender=None,
+                user=self.student,
+                subsection_id=calculated_grade.location,
+                subsection_grade=calculated_grade.graded_total.earned
+            )
 
         return calculated_grade
 

--- a/lms/djangoapps/grades/tests/test_subsection_grade_factory.py
+++ b/lms/djangoapps/grades/tests/test_subsection_grade_factory.py
@@ -49,6 +49,7 @@ class TestSubsectionGradeFactory(ProblemSubmissionTestMixin, GradeTestBase):
         self.assertIsInstance(grade, ZeroSubsectionGrade)
         self.assert_grade(grade, 0.0, 1.0)
 
+    @patch.dict(settings.FEATURES, {'ENABLE_COURSE_ASSESSMENT_GRADE_CHANGE_SIGNAL': True})
     def test_update(self):
         """
         Assuming the underlying score reporting methods work,

--- a/lms/djangoapps/grades/tests/test_subsection_grade_factory.py
+++ b/lms/djangoapps/grades/tests/test_subsection_grade_factory.py
@@ -55,8 +55,12 @@ class TestSubsectionGradeFactory(ProblemSubmissionTestMixin, GradeTestBase):
         test that the score is calculated properly.
         """
         with mock_get_score(1, 2):
-            grade = self.subsection_grade_factory.update(self.sequence)
+            with patch(
+                'openedx.core.djangoapps.signals.signals.COURSE_ASSESSMENT_GRADE_CHANGED.send_robust'
+            ) as mock_update_grades_signal:
+                grade = self.subsection_grade_factory.update(self.sequence)
         self.assert_grade(grade, 1, 2)
+        assert mock_update_grades_signal.called
 
     def test_write_only_if_engaged(self):
         """

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -692,6 +692,18 @@ FEATURES = {
     # .. toggle_tickets: https://openedx.atlassian.net/browse/TNL-7273
     # .. toggle_warnings: This temporary feature toggle does not have a target removal date.
     'ENABLE_ORA_USERNAMES_ON_DATA_EXPORT': False,
+
+    # .. toggle_name: ENABLE_COURSE_ASSESSMENT_GRADE_CHANGE_SIGNAL
+    # .. toggle_implementation: DjangoSetting
+    # .. toggle_default: False
+    # .. toggle_description: Set to True to start sending signals for assessment level grade updates. Notably, the only
+    #   handler of this signal at the time of this writing sends assessment updates to enterprise integrated channels.
+    # .. toggle_use_cases: temporary
+    # .. toggle_creation_date: 2020-12-09
+    # .. toggle_target_removal_date: 2021-02-01
+    # .. toggle_tickets: https://openedx.atlassian.net/browse/ENT-3818
+    # .. toggle_warnings: None.
+    'ENABLE_COURSE_ASSESSMENT_GRADE_CHANGE_SIGNAL': False,
 }
 
 # Specifies extra XBlock fields that should available when requested via the Course Blocks API

--- a/openedx/core/djangoapps/signals/signals.py
+++ b/openedx/core/djangoapps/signals/signals.py
@@ -17,6 +17,15 @@ COURSE_CERT_REVOKED = Signal(providing_args=["user", "course_key", "mode", "stat
 COURSE_CERT_DATE_CHANGE = Signal(providing_args=["course_key"])
 
 
+COURSE_ASSESSMENT_GRADE_CHANGED = Signal(
+    providing_args=[
+        'user',
+        'course_id',
+        'subsection_id',
+        'subsection_grade',
+    ]
+)
+
 # Signal that indicates that a user has passed a course.
 COURSE_GRADE_NOW_PASSED = Signal(
     providing_args=[

--- a/openedx/features/enterprise_support/tests/test_utils.py
+++ b/openedx/features/enterprise_support/tests/test_utils.py
@@ -450,11 +450,21 @@ class TestEnterpriseUtils(TestCase):
         assert '' == generic_name
 
     def test_is_enterprise_learner(self):
-        EnterpriseCustomerUserFactory.create(active=True, user_id=self.user.id)
-        self.assertTrue(is_enterprise_learner(self.user))
+        with mock.patch(
+            'django.core.cache.cache.set'
+        ) as mock_cache_set:
+            EnterpriseCustomerUserFactory.create(active=True, user_id=self.user.id)
+            self.assertTrue(is_enterprise_learner(self.user))
+
+        self.assertTrue(mock_cache_set.called)
 
     def test_is_enterprise_learner_no_enterprise_user(self):
-        self.assertFalse(is_enterprise_learner(self.user))
+        with mock.patch(
+            'django.core.cache.cache.set'
+        ) as mock_cache_set:
+            self.assertFalse(is_enterprise_learner(self.user))
+
+        self.assertFalse(mock_cache_set.called)
 
     @mock.patch('openedx.features.enterprise_support.utils.reverse')
     def test_get_enterprise_slug_login_url_no_reverse_match(self, mock_reverse):

--- a/openedx/features/enterprise_support/utils.py
+++ b/openedx/features/enterprise_support/utils.py
@@ -34,6 +34,13 @@ def get_data_consent_share_cache_key(user_id, course_id):
     return get_cache_key(type='data_sharing_consent_needed', user_id=user_id, course_id=course_id)
 
 
+def get_is_enterprise_cache_key(user_id):
+    """
+        Returns cache key for the enterprise learner validation method needed against user_id.
+    """
+    return get_cache_key(type='is_enterprise_learner', user_id=user_id)
+
+
 def clear_data_consent_share_cache(user_id, course_id):
     """
         clears data_sharing_consent_needed cache
@@ -394,7 +401,7 @@ def get_enterprise_learner_generic_name(request):
 
 def is_enterprise_learner(user):
     """
-    Check if the given user belongs to an enterprise.
+    Check if the given user belongs to an enterprise. Cache the value if an enterprise learner is found.
 
     Arguments:
         user (User): Django User object.
@@ -402,13 +409,13 @@ def is_enterprise_learner(user):
     Returns:
         (bool): True if given user is an enterprise learner.
     """
-    cached_is_enterprise_key = '{}:user_is_enterprise'.format(user.id)
+    cached_is_enterprise_key = get_is_enterprise_cache_key(user.id)
     if cache.get(cached_is_enterprise_key):
         return True
 
     if EnterpriseCustomerUser.objects.filter(user_id=user.id).exists():
         # Cache the enterprise user for one hour.
-        cache.set(cached_is_enterprise_key, True, expiry=3600)
+        cache.set(cached_is_enterprise_key, True, 3600)
         return True
     return False
 


### PR DESCRIPTION
Similar to course completion signals and receivers used by the integrated channels, we want to report when an enterprise learner has completed/updated their grade on a subsection, rather than the course as a whole.

[related Integrated channels PR](https://github.com/edx/edx-enterprise/pull/1048)

**Note**
This references a task added to a new version of the edx enterprise integrated channels which has not been released and as such, the version isn't bumped in this PR until discussed with team **Quokkas** about releases.   

this means that the build will fail until the enterprise version is bumped. 