### PR TITLE
[BD-04] Convert LTI XModule to XBlock. [SE-3640]

### DIFF
--- a/common/lib/xmodule/setup.py
+++ b/common/lib/xmodule/setup.py
@@ -18,7 +18,6 @@ XMODULES = [
     "videosequence = xmodule.seq_module:SequenceDescriptor",
     "custom_tag_template = xmodule.raw_module:RawDescriptor",
     "raw = xmodule.raw_module:RawDescriptor",
-    "lti = xmodule.lti_module:LTIDescriptor",
 ]
 XBLOCKS = [
     "about = xmodule.html_module:AboutBlock",
@@ -31,6 +30,7 @@ XBLOCKS = [
     "library = xmodule.library_root_xblock:LibraryRoot",
     "library_content = xmodule.library_content_module:LibraryContentBlock",
     "library_sourced = xmodule.library_sourced_block:LibrarySourcedBlock",
+    "lti = xmodule.lti_module:LTIBlock",
     "nonstaff_error = xmodule.error_module:NonStaffErrorBlock",
     "problem = xmodule.capa_module:ProblemBlock",
     "randomize = xmodule.randomize_module:RandomizeBlock",

--- a/common/lib/xmodule/xmodule/lti_2_util.py
+++ b/common/lib/xmodule/xmodule/lti_2_util.py
@@ -1,6 +1,6 @@
 """
 A mixin class for LTI 2.0 functionality.  This is really just done to refactor the code to
-keep the LTIModule class from getting too big
+keep the LTIBlock class from getting too big
 """
 
 
@@ -26,13 +26,12 @@ LTI_2_0_JSON_CONTENT_TYPE = 'application/vnd.ims.lis.v2.result+json'
 
 
 class LTIError(Exception):
-    """Error class for LTIModule and LTI20ModuleMixin"""
-    pass  # lint-amnesty, pylint: disable=unnecessary-pass
+    """Error class for LTIBlock and LTI20BlockMixin"""
 
 
-class LTI20ModuleMixin(object):
+class LTI20BlockMixin(object):
     """
-    This class MUST be mixed into LTIModule.  It does not do anything on its own.  It's just factored
+    This class MUST be mixed into LTIBlock.  It does not do anything on its own.  It's just factored
     out for modularity.
     """
 

--- a/common/lib/xmodule/xmodule/static_content.py
+++ b/common/lib/xmodule/xmodule/static_content.py
@@ -25,6 +25,7 @@ from xmodule.capa_module import ProblemBlock
 from xmodule.conditional_module import ConditionalBlock
 from xmodule.html_module import AboutBlock, CourseInfoBlock, HtmlBlock, StaticTabBlock
 from xmodule.library_content_module import LibraryContentBlock
+from xmodule.lti_module import LTIBlock
 from xmodule.word_cloud_module import WordCloudBlock
 from xmodule.x_module import XModuleDescriptor, HTMLSnippet
 
@@ -73,6 +74,7 @@ XBLOCK_CLASSES = [
     CourseInfoBlock,
     HtmlBlock,
     LibraryContentBlock,
+    LTIBlock,
     ProblemBlock,
     StaticTabBlock,
     VideoBlock,

--- a/common/lib/xmodule/xmodule/tests/test_lti20_unit.py
+++ b/common/lib/xmodule/xmodule/tests/test_lti20_unit.py
@@ -4,27 +4,30 @@
 
 import datetime
 import textwrap
+import unittest
 
 from mock import Mock
 from pytz import UTC
+from xblock.field_data import DictFieldData
 
 from xmodule.lti_2_util import LTIError
-from xmodule.lti_module import LTIDescriptor
+from xmodule.lti_module import LTIBlock
 
-from . import LogicTest
+from . import get_test_system
 
 
-class LTI20RESTResultServiceTest(LogicTest):
+class LTI20RESTResultServiceTest(unittest.TestCase):
     """Logic tests for LTI module. LTI2.0 REST ResultService"""
-    descriptor_class = LTIDescriptor
 
     def setUp(self):
         super(LTI20RESTResultServiceTest, self).setUp()  # lint-amnesty, pylint: disable=super-with-arguments
+        self.system = get_test_system()
         self.environ = {'wsgi.url_scheme': 'http', 'REQUEST_METHOD': 'POST'}
         self.system.get_real_user = Mock()
         self.system.publish = Mock()
         self.system.rebind_noauth_module_to_user = Mock()
-        self.user_id = self.xmodule.runtime.anonymous_student_id
+
+        self.xmodule = LTIBlock(self.system, DictFieldData({}), Mock())
         self.lti_id = self.xmodule.lti_id
         self.xmodule.due = None
         self.xmodule.graceperiod = None
@@ -35,8 +38,8 @@ class LTI20RESTResultServiceTest(LogicTest):
         mocked_course = Mock(name='mocked_course', lti_passports=['lti_id:test_client:test_secret'])
         modulestore = Mock(name='modulestore')
         modulestore.get_course.return_value = mocked_course
-        runtime = Mock(name='runtime', modulestore=modulestore)
-        self.xmodule.descriptor.runtime = runtime
+        runtime = Mock(name='runtime', modulestore=modulestore, anonymous_student_id='student')
+        self.xmodule.runtime = runtime
         self.xmodule.lti_id = "lti_id"
 
         test_cases = (  # (before sanitize, after sanitize)

--- a/lms/djangoapps/courseware/tests/test_lti_integration.py
+++ b/lms/djangoapps/courseware/tests/test_lti_integration.py
@@ -126,7 +126,7 @@ class TestLTI(BaseTestXmodule):
         self.assertEqual(generated_content.decode('utf-8'), expected_content)
 
 
-class TestLTIModuleListing(SharedModuleStoreTestCase):
+class TestLTIBlockListing(SharedModuleStoreTestCase):
     """
     a test for the rest endpoint that lists LTI modules in a course
     """
@@ -136,7 +136,7 @@ class TestLTIModuleListing(SharedModuleStoreTestCase):
 
     @classmethod
     def setUpClass(cls):
-        super(TestLTIModuleListing, cls).setUpClass()
+        super(TestLTIBlockListing, cls).setUpClass()
         cls.course = CourseFactory.create(display_name=cls.COURSE_NAME, number=cls.COURSE_SLUG)
         cls.chapter1 = ItemFactory.create(
             parent_location=cls.course.location,


### PR DESCRIPTION
Converts the LTI XModule into an XBlock.

Part of [XModule to XBlock Conversion work](https://openedx.atlassian.net/wiki/spaces/AC/pages/1472790755/XModule+to+XBlock+Conversion). 

**Testing instructions**:

* In a course Advanced Settings set the [`LTI Passport`](https://edx.readthedocs.io/projects/edx-partner-course-staff/en/latest/exercises_tools/lti_component.html#lti-authentication-information) setting to `[ "lti_sandbox:afb6ab1948219f9a9ae152fae6fd0e33:38ec672c1ef412d5d357ac36b468b796" ]`.
* In Advanced Settings, add `lti` to the `Advanced Module List`.
* Create an LTI component in the course. Set `LTI ID` to `lti_sandbox` and `LTI URL` to `https://pr25713.sandbox.opencraft.hosting/lti_provider/courses/course-v1:edX+DemoX+Demo_Course/block-v1:edX+DemoX+Demo_Course+type@vertical+block@54bb9b142c6c4c22afc62bcb628f0e68`. Publish it.
* A "View resource in a new window" button will show in the component. Interact with it in LMS and note its behavior.
* Can log into https://studio.pr25713.sandbox.opencraft.hosting/ with staff@example.com/edx in a different browser if need to  test with other components.
* Export the course.
* Checkout this branch.
* Run:
 ```
 make lms-shell
 pip install -e common/lib/xmodule
 exit
 // In case of webpack errors run make lms-static
 make lms-restart
 make studio-restart
 ```
* Check that the component behaves as expected in Studio and LMS.
* Import the course archive in a new course.
* Check that the component in the new course behaves as expected in Studio and LMS.

**MRO Analysis**:

Descriptor MRO | Module MRO | Block MRO | Notes
------------ | ------------- | ---------------- | ------------
<class 'xmodule.lti_module.LTIDescriptor'> | <class 'xmodule.lti_module.LTIModule'> | <class 'xmodule.lti_module.LTIBlock'> |
<class 'xmodule.lti_module.LTIFields'> | <class 'xmodule.lti_module.LTIFields'> | <class 'xmodule.lti_module.LTIFields'> |
 | <class 'xmodule.lti_2_util.LTI20ModuleMixin'> | <class 'xmodule.lti_2_util.LTI20ModuleMixin'> |
<class 'xmodule.editing_module.MetadataOnlyEditingDescriptor'> | | |
<class 'xmodule.raw_module.EmptyDataRawDescriptor'> | | | Doesn't have any attributes.
<class 'xmodule.raw_module.EmptyDataRawMixin'> | | <class 'xmodule.raw_module.EmptyDataRawMixin'> |
<class 'xmodule.xml_module.XmlDescriptor'> | | | Doesn't have any attributes.
<class 'xmodule.xml_module.XmlMixin'> | | <class 'xmodule.xml_module.XmlMixin'> |
<class 'xmodule.xml_module.XmlParserMixin'> | | <class 'xmodule.xml_module.XmlParserMixin'> |
<class 'xmodule.editing_module.XMLEditingDescriptor'> | | | Inherits from EditingDescriptor and only sets js/css for studio view which has been set on the LTIBlock directly.
<class 'xmodule.editing_module.EditingDescriptor'> | | | Doesn't have any attributes.
<class 'xmodule.editing_module.EditingMixin'> | | <class 'xmodule.editing_module.EditingMixin'> |
<class 'xmodule.editing_module.EditingFields'> | | <class 'xmodule.editing_module.EditingFields'> |
<class 'xmodule.mako_module.MakoModuleDescriptor'> | | | Inherits from (MakoTemplateBlockBase, XModuleDescriptor) and has the get_html() method which is not needed anymore.
<class 'xmodule.mako_module.MakoTemplateBlockBase'> | | <class 'xmodule.mako_module.MakoTemplateBlockBase'> |
<class 'xmodule.x_module.XModuleDescriptor'> | | |
<class 'xmodule.x_module.XModuleDescriptorToXBlockMixin'> | | <class 'xmodule.x_module.XModuleDescriptorToXBlockMixin'> |
 | <class 'xmodule.x_module.XModule'> | |
 | <class 'xmodule.x_module.XModuleToXBlockMixin'> | <class 'xmodule.x_module.XModuleToXBlockMixin'> |
<class 'xmodule.x_module.HTMLSnippet'> | <class 'xmodule.x_module.HTMLSnippet'> | <class 'xmodule.x_module.HTMLSnippet'> |
<class 'xmodule.x_module.ResourceTemplates'> | | <class 'xmodule.x_module.ResourceTemplates'> |
<class 'xmodule.x_module.XModuleMixin'> | <class 'xmodule.x_module.XModuleMixin'> | <class 'xmodule.x_module.XModuleMixin'> |
<class 'xmodule.x_module.XModuleFields'> | <class 'xmodule.x_module.XModuleFields'> | <class 'xmodule.x_module.XModuleFields'> |
<class 'xblock.core.XBlock'> | <class 'xblock.core.XBlock'> | <class 'xblock.core.XBlock'> |

**Reviewers**
- [ ] @eLRuLL 
- [ ] @ormsbee or @kdmccormick