### PR TITLE
AA-454: Reenable CourseUpdateResolver for Instructor-paced Courses

### DIFF
--- a/openedx/core/djangoapps/schedules/management/commands/send_course_next_section_update.py
+++ b/openedx/core/djangoapps/schedules/management/commands/send_course_next_section_update.py
@@ -14,7 +14,7 @@ from openedx.core.djangoapps.schedules.tasks import ScheduleCourseNextSectionUpd
 
 class Command(SendEmailBaseCommand):
     """
-    Command to send Schedule course updates
+    Command to send Schedule course updates for Self-paced Courses
     """
     help = dedent(__doc__).strip()
     async_send_task = ScheduleCourseNextSectionUpdate

--- a/openedx/core/djangoapps/schedules/management/commands/send_course_update.py
+++ b/openedx/core/djangoapps/schedules/management/commands/send_course_update.py
@@ -12,7 +12,7 @@ from openedx.core.djangoapps.schedules.tasks import ScheduleCourseUpdate
 
 class Command(SendEmailBaseCommand):
     """
-    Command to send Schedule course updates
+    Command to send Schedule course updates for Instructor-paced Courses
     """
     help = dedent(__doc__).strip()
     async_send_task = ScheduleCourseUpdate

--- a/openedx/core/djangoapps/schedules/tests/test_resolvers.py
+++ b/openedx/core/djangoapps/schedules/tests/test_resolvers.py
@@ -103,7 +103,7 @@ class TestCourseUpdateResolver(SchedulesResolverTestMixin, ModuleStoreTestCase):
     """
     def setUp(self):
         super().setUp()
-        self.course = CourseFactory.create(highlights_enabled_for_messaging=True, self_paced=True)
+        self.course = CourseFactory.create(highlights_enabled_for_messaging=True)
         with self.store.bulk_operations(self.course.id):
             ItemFactory.create(parent=self.course, category='chapter', highlights=['good stuff'])
 
@@ -145,7 +145,7 @@ class TestCourseUpdateResolver(SchedulesResolverTestMixin, ModuleStoreTestCase):
             'week_highlights': ['good stuff'],
             'week_num': 1,
         }
-        self.assertEqual(schedules, [(self.user, None, expected_context, True)])
+        self.assertEqual(schedules, [(self.user, None, expected_context)])
 
     @override_waffle_flag(COURSE_UPDATE_WAFFLE_FLAG, True)
     @override_switch('schedules.course_update_show_unsubscribe', True)
@@ -235,7 +235,7 @@ class TestCourseNextSectionUpdateResolver(SchedulesResolverTestMixin, ModuleStor
             'week_highlights': ['good stuff 2'],
             'week_num': 2,
         }
-        self.assertEqual(schedules, [(self.user, None, expected_context, True)])
+        self.assertEqual(schedules, [(self.user, None, expected_context)])
 
     @override_waffle_flag(COURSE_UPDATE_WAFFLE_FLAG, True)
     @override_switch('schedules.course_update_show_unsubscribe', True)


### PR DESCRIPTION
When CourseNextSectionUpdate was created, it incorporated Personalized
Learner Schedules logic which didn't take into account release dates of
content and was only intended for self-paced courses that always have
all content released. This caused a bug where instructor-paced courses
could receive an update about content that had not been released yet.

This PR turns the CourseUpdateResolver back on for instructor-paced
courses so they can go back to receiving weekly highlights. Related to https://github.com/edx/edx-internal/pull/3770