### PR TITLE
try to get learner's enterprise information from DB if there is no enterprise customer associated with sso provider id

### DIFF
--- a/openedx/features/enterprise_support/api.py
+++ b/openedx/features/enterprise_support/api.py
@@ -481,7 +481,7 @@ def enterprise_customer_uuid_for_request(request):
     else:
         enterprise_customer_uuid = _customer_uuid_from_query_param_cookies_or_session(request)
 
-    if enterprise_customer_uuid is _CACHE_MISS:
+    if enterprise_customer_uuid is _CACHE_MISS or enterprise_customer_uuid is None:
         if not request.user.is_authenticated:
             return None
 


### PR DESCRIPTION
ENT-3670