### PR TITLE
[BTR-39] Upgrade django-user-tasks and edx-enterprise

### DIFF
--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -35,7 +35,7 @@ drf-yasg<1.17.1
 # The team that owns this package will manually bump this package rather than having it pulled in automatically.
 # This is to allow them to better control its deployment and to do it in a process that works better
 # for them.
-edx-enterprise==3.11.1
+edx-enterprise==3.13.0
 
 # v2 requires the ES7 upgrade work to be complete
 edx-search<2.0.0

--- a/requirements/edx-sandbox/py35.txt
+++ b/requirements/edx-sandbox/py35.txt
@@ -4,8 +4,8 @@
 #
 #    make upgrade
 #
-common/lib/sandbox-packages  # via -r requirements/edx-sandbox/py35.in
-common/lib/symmath  # via -r requirements/edx-sandbox/py35.in
+-e file:///edx/app/edxapp/edx-platform/common/lib/sandbox-packages  # via -r requirements/edx-sandbox/py35.in
+-e file:///edx/app/edxapp/edx-platform/common/lib/symmath  # via -r requirements/edx-sandbox/py35.in
 cffi==1.14.3              # via -r requirements/edx-sandbox/shared.txt, cryptography
 chem==1.2.0               # via -r requirements/edx-sandbox/py35.in
 click==7.1.2              # via -r requirements/edx-sandbox/shared.txt, nltk
@@ -20,7 +20,7 @@ matplotlib==2.2.4         # via -c requirements/edx-sandbox/../constraints.txt, 
 mpmath==1.1.0             # via sympy
 networkx==2.2             # via -r requirements/edx-sandbox/py35.in
 nltk==3.5                 # via -r requirements/edx-sandbox/shared.txt, chem
-numpy==1.16.5             # via -c requirements/edx-sandbox/../constraints.txt, -r requirements/edx-sandbox/py35.in, chem, matplotlib, openedx-calc, scipy
+numpy==1.16.5             # via -c requirements/edx-sandbox/../constraints.txt, -r requirements/edx-sandbox/py35.in, chem, matplotlib, openedx-calc
 openedx-calc==1.0.9       # via -r requirements/edx-sandbox/py35.in
 pycparser==2.20           # via -r requirements/edx-sandbox/shared.txt, cffi
 pyparsing==2.2.0          # via -r requirements/edx-sandbox/py35.in, chem, matplotlib, openedx-calc

--- a/requirements/edx-sandbox/py35.txt
+++ b/requirements/edx-sandbox/py35.txt
@@ -4,8 +4,8 @@
 #
 #    make upgrade
 #
--e file:///edx/app/edxapp/edx-platform/common/lib/sandbox-packages  # via -r requirements/edx-sandbox/py35.in
--e file:///edx/app/edxapp/edx-platform/common/lib/symmath  # via -r requirements/edx-sandbox/py35.in
+common/lib/sandbox-packages  # via -r requirements/edx-sandbox/py35.in
+common/lib/symmath  # via -r requirements/edx-sandbox/py35.in
 cffi==1.14.3              # via -r requirements/edx-sandbox/shared.txt, cryptography
 chem==1.2.0               # via -r requirements/edx-sandbox/py35.in
 click==7.1.2              # via -r requirements/edx-sandbox/shared.txt, nltk

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -77,7 +77,7 @@ django-simple-history==2.12.0  # via -r requirements/edx/base.in, edx-enterprise
 django-splash==0.2.9      # via -r requirements/edx/base.in
 django-statici18n==2.0.1  # via -r requirements/edx/base.in
 django-storages==1.8      # via -c requirements/edx/../constraints.txt, -r requirements/edx/base.in, edxval
-django-user-tasks==1.3.0  # via -r requirements/edx/base.in
+django-user-tasks==1.3.1  # via -r requirements/edx/base.in
 django-waffle==2.0.0      # via -r requirements/edx/base.in, edx-django-utils, edx-drf-extensions, edx-enterprise, edx-proctoring, edx-toggles
 django-webpack-loader==0.7.0  # via -r requirements/edx/base.in, edx-proctoring
 django==2.2.17            # via -c requirements/edx/../constraints.txt, -r requirements/edx/base.in, code-annotations, django-appconf, django-classy-tags, django-config-models, django-cors-headers, django-crum, django-fernet-fields, django-filter, django-method-override, django-model-utils, django-mptt, django-multi-email-field, django-mysql, django-oauth-toolkit, django-pyfs, django-ratelimit-backend, django-sekizai, django-ses, django-splash, django-statici18n, django-storages, django-user-tasks, django-wiki, drf-jwt, drf-yasg, edx-ace, edx-api-doc-tools, edx-bulk-grades, edx-celeryutils, edx-completion, edx-django-release-util, edx-django-sites-extensions, edx-django-utils, edx-drf-extensions, edx-enterprise, edx-i18n-tools, edx-milestones, edx-opaque-keys, edx-organizations, edx-proctoring, edx-rbac, edx-search, edx-submissions, edx-toggles, edx-when, edxval, enmerkar, enmerkar-underscore, event-tracking, help-tokens, jsonfield2, lti-consumer-xblock, ora2, rest-condition, super-csv, xss-utils
@@ -129,7 +129,6 @@ help-tokens==1.1.2        # via -r requirements/edx/base.in
 html5lib==1.1             # via -r requirements/edx/base.in, ora2
 icalendar==4.0.7          # via -r requirements/edx/base.in
 idna==2.10                # via -r requirements/edx/paver.txt, requests
-importlib-metadata==1.7.0  # via -c requirements/edx/../constraints.txt, -r requirements/edx/paver.txt, kombu, path
 inflection==0.5.1         # via drf-yasg
 ipaddress==1.0.23         # via -r requirements/edx/base.in
 isodate==0.6.0            # via python3-saml
@@ -155,7 +154,6 @@ maxminddb==1.5.4          # via -c requirements/edx/../constraints.txt, geoip2
 mock==3.0.5               # via -c requirements/edx/../constraints.txt, -r requirements/edx/paver.txt, xblock-drag-and-drop-v2, xblock-poll
 git+https://github.com/edx/MongoDBProxy.git@d92bafe9888d2940f647a7b2b2383b29c752f35a#egg=MongoDBProxy==0.1.0+edx.2  # via -r requirements/edx/github.in
 mongoengine==0.20.0       # via -r requirements/edx/base.in
-more-itertools==8.6.0     # via -r requirements/edx/paver.txt, zipp
 mpmath==1.1.0             # via sympy
 mysqlclient==2.0.1        # via -r requirements/edx/base.in
 newrelic==5.22.1.152      # via -r requirements/edx/base.in, edx-django-utils
@@ -247,7 +245,6 @@ xblock-utils==2.1.1       # via -r requirements/edx/base.in, edx-sga, lti-consum
 xblock==1.4.0             # via -r requirements/edx/base.in, acid-xblock, crowdsourcehinter-xblock, done-xblock, edx-completion, edx-sga, edx-user-state-client, edx-when, lti-consumer-xblock, ora2, rate-xblock, staff-graded-xblock, xblock-discussion, xblock-drag-and-drop-v2, xblock-google-drive, xblock-poll, xblock-utils
 xmlsec==1.3.9             # via python3-saml
 xss-utils==0.1.3          # via -r requirements/edx/base.in
-zipp==1.0.0               # via -c requirements/edx/../constraints.txt, -r requirements/edx/paver.txt, importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -96,9 +96,9 @@ edx-celeryutils==0.5.2    # via -r requirements/edx/base.in, super-csv
 edx-completion==3.2.5     # via -c requirements/edx/../constraints.txt, -r requirements/edx/base.in
 edx-django-release-util==0.4.4  # via -r requirements/edx/base.in
 edx-django-sites-extensions==2.5.1  # via -r requirements/edx/base.in
-edx-django-utils==3.11.0  # via -r requirements/edx/base.in, django-config-models, edx-drf-extensions, edx-enterprise, edx-rest-api-client, edx-toggles, edx-when
+edx-django-utils==3.13.0  # via -r requirements/edx/base.in, django-config-models, edx-drf-extensions, edx-enterprise, edx-rest-api-client, edx-toggles, edx-when
 edx-drf-extensions==6.2.0  # via -r requirements/edx/base.in, edx-completion, edx-enterprise, edx-organizations, edx-proctoring, edx-rbac, edx-when, edxval
-edx-enterprise==3.11.1    # via -c requirements/edx/../constraints.txt, -r requirements/edx/base.in
+edx-enterprise==3.13.0    # via -c requirements/edx/../constraints.txt, -r requirements/edx/base.in
 edx-i18n-tools==0.5.3     # via ora2
 edx-milestones==0.3.0     # via -r requirements/edx/base.in
 edx-opaque-keys[django]==2.1.1  # via -r requirements/edx/paver.txt, edx-bulk-grades, edx-ccx-keys, edx-completion, edx-drf-extensions, edx-enterprise, edx-milestones, edx-organizations, edx-proctoring, edx-user-state-client, edx-when, lti-consumer-xblock, xmodule

--- a/requirements/edx/coverage.txt
+++ b/requirements/edx/coverage.txt
@@ -6,7 +6,7 @@
 #
 coverage==5.3             # via -r requirements/edx/coverage.in
 diff-cover==4.0.1         # via -r requirements/edx/coverage.in
-importlib-metadata==1.7.0  # via -c requirements/edx/../constraints.txt, inflect, pluggy
+importlib-metadata==1.7.0  # via -c requirements/edx/../constraints.txt, inflect
 inflect==3.0.2            # via -c requirements/edx/../constraints.txt, jinja2-pluralize
 jinja2-pluralize==0.3.0   # via diff-cover
 jinja2==2.11.2            # via diff-cover, jinja2-pluralize

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -107,9 +107,9 @@ edx-celeryutils==0.5.2    # via -r requirements/edx/testing.txt, super-csv
 edx-completion==3.2.5     # via -c requirements/edx/../constraints.txt, -r requirements/edx/testing.txt
 edx-django-release-util==0.4.4  # via -r requirements/edx/testing.txt
 edx-django-sites-extensions==2.5.1  # via -r requirements/edx/testing.txt
-edx-django-utils==3.11.0  # via -r requirements/edx/testing.txt, django-config-models, edx-drf-extensions, edx-enterprise, edx-rest-api-client, edx-toggles, edx-when
+edx-django-utils==3.13.0  # via -r requirements/edx/testing.txt, django-config-models, edx-drf-extensions, edx-enterprise, edx-rest-api-client, edx-toggles, edx-when
 edx-drf-extensions==6.2.0  # via -r requirements/edx/testing.txt, edx-completion, edx-enterprise, edx-organizations, edx-proctoring, edx-rbac, edx-when, edxval
-edx-enterprise==3.11.1    # via -c requirements/edx/../constraints.txt, -r requirements/edx/testing.txt
+edx-enterprise==3.13.0    # via -c requirements/edx/../constraints.txt, -r requirements/edx/testing.txt
 edx-i18n-tools==0.5.3     # via -r requirements/edx/testing.txt, ora2
 edx-lint==1.5.2           # via -r requirements/edx/testing.txt
 edx-milestones==0.3.0     # via -r requirements/edx/testing.txt

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -88,7 +88,7 @@ django-simple-history==2.12.0  # via -r requirements/edx/testing.txt, edx-enterp
 django-splash==0.2.9      # via -r requirements/edx/testing.txt
 django-statici18n==2.0.1  # via -r requirements/edx/testing.txt
 django-storages==1.8      # via -c requirements/edx/../constraints.txt, -r requirements/edx/testing.txt, edxval
-django-user-tasks==1.3.0  # via -r requirements/edx/testing.txt
+django-user-tasks==1.3.1  # via -r requirements/edx/testing.txt
 django-waffle==2.0.0      # via -r requirements/edx/testing.txt, edx-django-utils, edx-drf-extensions, edx-enterprise, edx-proctoring, edx-toggles
 django-webpack-loader==0.7.0  # via -r requirements/edx/testing.txt, edx-proctoring
 django==2.2.17            # via -c requirements/edx/../constraints.txt, -r requirements/edx/testing.txt, code-annotations, django-appconf, django-classy-tags, django-config-models, django-cors-headers, django-crum, django-debug-toolbar, django-fernet-fields, django-filter, django-method-override, django-model-utils, django-mptt, django-multi-email-field, django-mysql, django-oauth-toolkit, django-pyfs, django-ratelimit-backend, django-sekizai, django-ses, django-splash, django-statici18n, django-storages, django-user-tasks, django-wiki, drf-jwt, drf-yasg, edx-ace, edx-api-doc-tools, edx-bulk-grades, edx-celeryutils, edx-completion, edx-django-release-util, edx-django-sites-extensions, edx-django-utils, edx-drf-extensions, edx-enterprise, edx-i18n-tools, edx-milestones, edx-opaque-keys, edx-organizations, edx-proctoring, edx-rbac, edx-search, edx-submissions, edx-toggles, edx-when, edxval, enmerkar, enmerkar-underscore, event-tracking, help-tokens, jsonfield2, lti-consumer-xblock, ora2, rest-condition, super-csv, xss-utils
@@ -151,8 +151,7 @@ httpretty==0.9.7          # via -c requirements/edx/../constraints.txt, -r requi
 icalendar==4.0.7          # via -r requirements/edx/testing.txt
 idna==2.10                # via -r requirements/edx/testing.txt, requests
 imagesize==1.2.0          # via sphinx
-importlib-metadata==1.7.0  # via -c requirements/edx/../constraints.txt, -r requirements/edx/testing.txt, inflect, jsonschema, kombu, path, pluggy, pytest, pytest-randomly, tox, virtualenv
-importlib-resources==3.2.1  # via -r requirements/edx/testing.txt, virtualenv
+importlib-metadata==1.7.0  # via -c requirements/edx/../constraints.txt, -r requirements/edx/testing.txt, inflect
 inflect==3.0.2            # via -c requirements/edx/../constraints.txt, -r requirements/edx/testing.txt, jinja2-pluralize
 inflection==0.5.1         # via -r requirements/edx/testing.txt, drf-yasg
 iniconfig==1.1.1          # via -r requirements/edx/testing.txt, pytest
@@ -200,7 +199,6 @@ ora2==2.11.5              # via -r requirements/edx/testing.txt
 packaging==20.4           # via -r requirements/edx/testing.txt, bleach, drf-yasg, pytest, sphinx, tox
 path.py==12.5.0           # via -r requirements/edx/testing.txt, edx-enterprise, edx-i18n-tools, ora2, staff-graded-xblock, xmodule
 path==13.1.0              # via -c requirements/edx/../constraints.txt, -r requirements/edx/testing.txt, path.py
-pathlib2==2.3.5           # via -r requirements/edx/testing.txt, pytest
 pathtools==0.1.2          # via -r requirements/edx/testing.txt, watchdog
 paver==1.3.4              # via -r requirements/edx/testing.txt
 pbr==5.5.1                # via -r requirements/edx/testing.txt, stevedore
@@ -268,7 +266,7 @@ semantic-version==2.8.5   # via -r requirements/edx/testing.txt, edx-drf-extensi
 shapely==1.7.1            # via -r requirements/edx/testing.txt
 simplejson==3.17.2        # via -r requirements/edx/testing.txt, sailthru-client, super-csv, xblock-utils
 singledispatch==3.4.0.3   # via -r requirements/edx/testing.txt
-six==1.15.0               # via -r requirements/edx/pip-tools.txt, -r requirements/edx/testing.txt, analytics-python, astroid, bleach, bok-choy, chem, codejail, crowdsourcehinter-xblock, cryptography, django-countries, django-simple-history, django-wiki, drf-yasg, edx-ace, edx-bulk-grades, edx-ccx-keys, edx-django-release-util, edx-drf-extensions, edx-enterprise, edx-i18n-tools, edx-lint, edx-milestones, edx-opaque-keys, edx-rbac, edx-search, edx-sphinx-theme, event-tracking, freezegun, fs, fs-s3fs, help-tokens, html5lib, httpretty, isodate, jsonschema, libsass, mock, openedx-calc, packaging, pathlib2, paver, pip-tools, pycontracts, pyjwkest, python-dateutil, python-memcached, python-swiftclient, singledispatch, social-auth-app-django, social-auth-core, sphinxcontrib-httpdomain, stevedore, tox, transifex-client, virtualenv, xblock
+six==1.15.0               # via -r requirements/edx/pip-tools.txt, -r requirements/edx/testing.txt, analytics-python, astroid, bleach, bok-choy, chem, codejail, crowdsourcehinter-xblock, cryptography, django-countries, django-simple-history, django-wiki, drf-yasg, edx-ace, edx-bulk-grades, edx-ccx-keys, edx-django-release-util, edx-drf-extensions, edx-enterprise, edx-i18n-tools, edx-lint, edx-milestones, edx-opaque-keys, edx-rbac, edx-search, edx-sphinx-theme, event-tracking, freezegun, fs, fs-s3fs, help-tokens, html5lib, httpretty, isodate, jsonschema, libsass, mock, openedx-calc, packaging, paver, pip-tools, pycontracts, pyjwkest, python-dateutil, python-memcached, python-swiftclient, singledispatch, social-auth-app-django, social-auth-core, sphinxcontrib-httpdomain, stevedore, tox, transifex-client, virtualenv, xblock
 slumber==0.7.1            # via -r requirements/edx/testing.txt, edx-bulk-grades, edx-enterprise, edx-rest-api-client
 smmap==3.0.4              # via -r requirements/edx/testing.txt, gitdb
 snowballstemmer==2.0.0    # via sphinx
@@ -299,7 +297,6 @@ tox-battery==0.6.1        # via -r requirements/edx/testing.txt
 tox==3.20.1               # via -r requirements/edx/testing.txt, tox-battery
 tqdm==4.51.0              # via -r requirements/edx/testing.txt, nltk
 transifex-client==0.14.1  # via -r requirements/edx/testing.txt
-typed-ast==1.4.1          # via -r requirements/edx/testing.txt, astroid
 ua-parser==0.10.0         # via -r requirements/edx/testing.txt, django-cookies-samesite
 unicodecsv==0.14.1        # via -r requirements/edx/testing.txt, edx-enterprise
 unidiff==0.6.0            # via -r requirements/edx/testing.txt, coverage-pytest-plugin
@@ -321,7 +318,7 @@ xblock-utils==2.1.1       # via -r requirements/edx/testing.txt, edx-sga, lti-co
 xblock==1.4.0             # via -r requirements/edx/testing.txt, acid-xblock, crowdsourcehinter-xblock, done-xblock, edx-completion, edx-sga, edx-user-state-client, edx-when, lti-consumer-xblock, ora2, rate-xblock, staff-graded-xblock, xblock-discussion, xblock-drag-and-drop-v2, xblock-google-drive, xblock-poll, xblock-utils
 xmlsec==1.3.9             # via -r requirements/edx/testing.txt, python3-saml
 xss-utils==0.1.3          # via -r requirements/edx/testing.txt
-zipp==1.0.0               # via -c requirements/edx/../constraints.txt, -r requirements/edx/testing.txt, importlib-metadata, importlib-resources
+zipp==1.0.0               # via -c requirements/edx/../constraints.txt, -r requirements/edx/testing.txt, importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools

--- a/requirements/edx/paver.txt
+++ b/requirements/edx/paver.txt
@@ -8,12 +8,10 @@ certifi==2020.11.8        # via requests
 chardet==3.0.4            # via requests
 edx-opaque-keys==2.1.1    # via -r requirements/edx/paver.in
 idna==2.10                # via requests
-importlib-metadata==1.7.0  # via -c requirements/edx/../constraints.txt, path
 lazy==1.4                 # via -r requirements/edx/paver.in
 libsass==0.10.0           # via -r requirements/edx/paver.in
 markupsafe==1.1.1         # via -r requirements/edx/paver.in
 mock==3.0.5               # via -c requirements/edx/../constraints.txt, -r requirements/edx/paver.in
-more-itertools==8.6.0     # via zipp
 path==13.1.0              # via -c requirements/edx/../constraints.txt, -r requirements/edx/paver.in
 pathtools==0.1.2          # via watchdog
 paver==1.3.4              # via -r requirements/edx/paver.in
@@ -27,4 +25,3 @@ stevedore==1.32.0         # via -c requirements/edx/../constraints.txt, -r requi
 urllib3==1.26.1           # via requests
 watchdog==0.10.3          # via -r requirements/edx/paver.in
 wrapt==1.11.2             # via -c requirements/edx/../constraints.txt, -r requirements/edx/paver.in
-zipp==1.0.0               # via -c requirements/edx/../constraints.txt, importlib-metadata

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -86,7 +86,7 @@ django-simple-history==2.12.0  # via -r requirements/edx/base.txt, edx-enterpris
 django-splash==0.2.9      # via -r requirements/edx/base.txt
 django-statici18n==2.0.1  # via -r requirements/edx/base.txt
 django-storages==1.8      # via -c requirements/edx/../constraints.txt, -r requirements/edx/base.txt, edxval
-django-user-tasks==1.3.0  # via -r requirements/edx/base.txt
+django-user-tasks==1.3.1  # via -r requirements/edx/base.txt
 django-waffle==2.0.0      # via -r requirements/edx/base.txt, edx-django-utils, edx-drf-extensions, edx-enterprise, edx-proctoring, edx-toggles
 django-webpack-loader==0.7.0  # via -r requirements/edx/base.txt, edx-proctoring
 djangorestframework-xml==2.0.0  # via -r requirements/edx/base.txt, edx-enterprise
@@ -146,8 +146,7 @@ html5lib==1.1             # via -r requirements/edx/base.txt, ora2
 httpretty==0.9.7          # via -c requirements/edx/../constraints.txt, -r requirements/edx/testing.in
 icalendar==4.0.7          # via -r requirements/edx/base.txt
 idna==2.10                # via -r requirements/edx/base.txt, requests
-importlib-metadata==1.7.0  # via -c requirements/edx/../constraints.txt, -r requirements/edx/base.txt, -r requirements/edx/coverage.txt, inflect, kombu, path, pluggy, pytest, pytest-randomly, tox, virtualenv
-importlib-resources==3.2.1  # via virtualenv
+importlib-metadata==1.7.0  # via -c requirements/edx/../constraints.txt, -r requirements/edx/coverage.txt, inflect
 inflect==3.0.2            # via -c requirements/edx/../constraints.txt, -r requirements/edx/coverage.txt, jinja2-pluralize
 inflection==0.5.1         # via -r requirements/edx/base.txt, drf-yasg
 iniconfig==1.1.1          # via pytest
@@ -179,7 +178,7 @@ mccabe==0.6.1             # via pylint
 mock==3.0.5               # via -c requirements/edx/../constraints.txt, -r requirements/edx/base.txt, xblock-drag-and-drop-v2, xblock-poll
 git+https://github.com/edx/MongoDBProxy.git@d92bafe9888d2940f647a7b2b2383b29c752f35a#egg=MongoDBProxy==0.1.0+edx.2  # via -r requirements/edx/base.txt
 mongoengine==0.20.0       # via -r requirements/edx/base.txt
-more-itertools==8.6.0     # via -r requirements/edx/base.txt, -r requirements/edx/coverage.txt, zipp
+more-itertools==8.6.0     # via -r requirements/edx/coverage.txt, zipp
 mpmath==1.1.0             # via -r requirements/edx/base.txt, sympy
 mysqlclient==2.0.1        # via -r requirements/edx/base.txt
 newrelic==5.22.1.152      # via -r requirements/edx/base.txt, edx-django-utils
@@ -192,7 +191,6 @@ ora2==2.11.5              # via -r requirements/edx/base.txt
 packaging==20.4           # via -r requirements/edx/base.txt, bleach, drf-yasg, pytest, tox
 path.py==12.5.0           # via -r requirements/edx/base.txt, edx-enterprise, edx-i18n-tools, ora2, staff-graded-xblock, xmodule
 path==13.1.0              # via -c requirements/edx/../constraints.txt, -r requirements/edx/base.txt, path.py
-pathlib2==2.3.5           # via pytest
 pathtools==0.1.2          # via -r requirements/edx/base.txt, watchdog
 paver==1.3.4              # via -r requirements/edx/base.txt
 pbr==5.5.1                # via -r requirements/edx/base.txt, stevedore
@@ -257,7 +255,7 @@ semantic-version==2.8.5   # via -r requirements/edx/base.txt, edx-drf-extensions
 shapely==1.7.1            # via -r requirements/edx/base.txt
 simplejson==3.17.2        # via -r requirements/edx/base.txt, sailthru-client, super-csv, xblock-utils
 singledispatch==3.4.0.3   # via -r requirements/edx/testing.in
-six==1.15.0               # via -r requirements/edx/base.txt, analytics-python, astroid, bleach, bok-choy, chem, codejail, crowdsourcehinter-xblock, cryptography, django-countries, django-simple-history, django-wiki, drf-yasg, edx-ace, edx-bulk-grades, edx-ccx-keys, edx-django-release-util, edx-drf-extensions, edx-enterprise, edx-i18n-tools, edx-lint, edx-milestones, edx-opaque-keys, edx-rbac, edx-search, event-tracking, freezegun, fs, fs-s3fs, help-tokens, html5lib, httpretty, isodate, libsass, mock, openedx-calc, packaging, pathlib2, paver, pycontracts, pyjwkest, python-dateutil, python-memcached, python-swiftclient, singledispatch, social-auth-app-django, social-auth-core, stevedore, tox, transifex-client, virtualenv, xblock
+six==1.15.0               # via -r requirements/edx/base.txt, analytics-python, astroid, bleach, bok-choy, chem, codejail, crowdsourcehinter-xblock, cryptography, django-countries, django-simple-history, django-wiki, drf-yasg, edx-ace, edx-bulk-grades, edx-ccx-keys, edx-django-release-util, edx-drf-extensions, edx-enterprise, edx-i18n-tools, edx-lint, edx-milestones, edx-opaque-keys, edx-rbac, edx-search, event-tracking, freezegun, fs, fs-s3fs, help-tokens, html5lib, httpretty, isodate, libsass, mock, openedx-calc, packaging, paver, pycontracts, pyjwkest, python-dateutil, python-memcached, python-swiftclient, singledispatch, social-auth-app-django, social-auth-core, stevedore, tox, transifex-client, virtualenv, xblock
 slumber==0.7.1            # via -r requirements/edx/base.txt, edx-bulk-grades, edx-enterprise, edx-rest-api-client
 smmap==3.0.4              # via gitdb
 social-auth-app-django==4.0.0  # via -r requirements/edx/base.txt
@@ -278,7 +276,6 @@ tox-battery==0.6.1        # via -r requirements/edx/testing.in
 tox==3.20.1               # via -r requirements/edx/testing.in, tox-battery
 tqdm==4.51.0              # via -r requirements/edx/base.txt, nltk
 transifex-client==0.14.1  # via -r requirements/edx/testing.in
-typed-ast==1.4.1          # via astroid
 ua-parser==0.10.0         # via -r requirements/edx/base.txt, django-cookies-samesite
 unicodecsv==0.14.1        # via -r requirements/edx/base.txt, edx-enterprise
 unidiff==0.6.0            # via -r requirements/edx/testing.in, coverage-pytest-plugin
@@ -299,7 +296,7 @@ xblock-utils==2.1.1       # via -r requirements/edx/base.txt, edx-sga, lti-consu
 xblock==1.4.0             # via -r requirements/edx/base.txt, acid-xblock, crowdsourcehinter-xblock, done-xblock, edx-completion, edx-sga, edx-user-state-client, edx-when, lti-consumer-xblock, ora2, rate-xblock, staff-graded-xblock, xblock-discussion, xblock-drag-and-drop-v2, xblock-google-drive, xblock-poll, xblock-utils
 xmlsec==1.3.9             # via -r requirements/edx/base.txt, python3-saml
 xss-utils==0.1.3          # via -r requirements/edx/base.txt
-zipp==1.0.0               # via -c requirements/edx/../constraints.txt, -r requirements/edx/base.txt, -r requirements/edx/coverage.txt, importlib-metadata, importlib-resources
+zipp==1.0.0               # via -c requirements/edx/../constraints.txt, -r requirements/edx/coverage.txt, importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -104,9 +104,9 @@ edx-celeryutils==0.5.2    # via -r requirements/edx/base.txt, super-csv
 edx-completion==3.2.5     # via -c requirements/edx/../constraints.txt, -r requirements/edx/base.txt
 edx-django-release-util==0.4.4  # via -r requirements/edx/base.txt
 edx-django-sites-extensions==2.5.1  # via -r requirements/edx/base.txt
-edx-django-utils==3.11.0  # via -r requirements/edx/base.txt, django-config-models, edx-drf-extensions, edx-enterprise, edx-rest-api-client, edx-toggles, edx-when
+edx-django-utils==3.13.0  # via -r requirements/edx/base.txt, django-config-models, edx-drf-extensions, edx-enterprise, edx-rest-api-client, edx-toggles, edx-when
 edx-drf-extensions==6.2.0  # via -r requirements/edx/base.txt, edx-completion, edx-enterprise, edx-organizations, edx-proctoring, edx-rbac, edx-when, edxval
-edx-enterprise==3.11.1    # via -c requirements/edx/../constraints.txt, -r requirements/edx/base.txt
+edx-enterprise==3.13.0    # via -c requirements/edx/../constraints.txt, -r requirements/edx/base.txt
 edx-i18n-tools==0.5.3     # via -r requirements/edx/base.txt, -r requirements/edx/testing.in, ora2
 edx-lint==1.5.2           # via -r requirements/edx/testing.in
 edx-milestones==0.3.0     # via -r requirements/edx/base.txt


### PR DESCRIPTION
In this PR I upgraded `django-user-tasks` to version `1.3.1` and `edx-enterprise` to version `3.13.0`. These versions squash many warnings.

For `django-user-tasks`:
1. I found the oldest version that includes commit from https://github.com/edx/django-user-tasks/pull/97
2. `make compile-requirements COMPILE_OPTS="--upgrade-package django-user-tasks==1.3.1"`.

For `edx-enterprise`:
1. I found the oldest version that includes commit from https://github.com/edx/edx-enterprise/pull/1052
2. Updated constraint.
3. `make compile-requirements COMPILE_OPTS="--upgrade-package edx-enterprise==3.13.0"`.

To include squash from `staff-graded-xblock` (https://github.com/edx/staff_graded-xblock/pull/29), we need to release a new version of this package.
