### PR TITLE
[BTR-38] [BB-3269] Add openassessment url to CMS

### DIFF
--- a/cms/urls.py
+++ b/cms/urls.py
@@ -198,6 +198,10 @@ JS_INFO_DICT = {
     'packages': ('openassessment',),
 }
 
+urlpatterns += [
+    url(r'^openassessment/fileupload/', include('openassessment.fileupload.urls')),
+]
+
 if settings.FEATURES.get('ENABLE_CONTENT_LIBRARIES'):
     urlpatterns += [
         url(r'^library/{}?$'.format(LIBRARY_KEY_PATTERN),


### PR DESCRIPTION
This change helps to check the preview of file upload in
open assessment xblock in the studio.

**JIRA tickets**:  [BTR-38](https://openedx.atlassian.net/browse/BTR-38)

~**Screenshots**: Always include screenshots if there is any change to the UI. Can be useful for people that are not reviewer but want to know what's going on.~

~**Sandbox URL**: TBD - sandbox is being provisioned (if needed).~

**Testing instructions**:

* Get the master devstack running
* Sign in to studio
* In the demo course add a unit
* Add open assessment block to it by `Problem--> Advance --> Open Response Assessment`
* In ORA click on the `Edit --> Settings --> File Uploads Response` and change it to `Required`
* Also mark `Multiple File Upload` to true and save the settings
* Drop in your studio shell using `make dev.shell.studio`
* Open the studio.yml file `vim /edx/etc/studio.yml`
* Add  
```
ORA2_FILE_PREFIX: default_env-default_deployment/ora2
ORA2_FILEUPLOAD_CACHE_NAME: 'default'
ORA2_FILEUPLOAD_ROOT: '/edx/var/ora2/'
ORA2_FILEUPLOAD_BACKEND: 'django'
```
* Now `make studio-restart`
* Try uploading a file in the studio and it will fail, giving you the error that URL cannot be reversed.
* Now checkout to this branch and do the same after restarting the server, you will see the error is gone.


**Author notes and concerns**:

While debugging it I found another bug with `filesystem` backend which I will be dealing with another issue.

**Reviewers**
- [x] @0x29a 
- [ ] edx-reviewer