### PR TITLE
[BD-14] Ensure new content libraries map to valid organizations 

### DIFF
--- a/cms/djangoapps/contentstore/views/tests/test_library.py
+++ b/cms/djangoapps/contentstore/views/tests/test_library.py
@@ -11,7 +11,7 @@ from django.conf import settings
 from django.urls import reverse
 from mock import patch
 from opaque_keys.edx.locator import CourseKey, LibraryLocator
-from six import binary_type, text_type
+from six import text_type
 from six.moves import range
 
 from cms.djangoapps.contentstore.tests.utils import AjaxEnabledTestClient, CourseTestCase, parse_json
@@ -125,7 +125,7 @@ class UnitTestLibraries(CourseTestCase):
         """
         # Create some more libraries
         libraries = [LibraryFactory.create() for _ in range(3)]
-        lib_dict = dict([(lib.location.library_key, lib) for lib in libraries])
+        lib_dict = {lib.location.library_key: lib for lib in libraries}
 
         response = self.client.get_json(LIBRARY_REST_URL)
         self.assertEqual(response.status_code, 200)
@@ -308,7 +308,11 @@ class UnitTestLibraries(CourseTestCase):
         lib.save()
 
         problem_type_templates = next(
-            (component['templates'] for component in get_component_templates(lib, library=True) if component['type'] == 'problem'),
+            (
+                component['templates']
+                for component in get_component_templates(lib, library=True)
+                if component['type'] == 'problem'
+            ),
             []
         )
         # Each problem template has a category which shows whether problem is a 'problem'

--- a/cms/djangoapps/contentstore/views/tests/test_library.py
+++ b/cms/djangoapps/contentstore/views/tests/test_library.py
@@ -8,8 +8,11 @@ More important high-level tests are in contentstore/tests/test_libraries.py
 import ddt
 import mock
 from django.conf import settings
+from django.test.utils import override_settings
 from django.urls import reverse
 from mock import patch
+from organizations.api import get_organization_by_short_name
+from organizations.exceptions import InvalidOrganizationException
 from opaque_keys.edx.locator import CourseKey, LibraryLocator
 from six import text_type
 from six.moves import range
@@ -226,6 +229,41 @@ class UnitTestLibraries(CourseTestCase):
         })
         self.assertIn('already a library defined', parse_json(response)['ErrMsg'])
         self.assertEqual(response.status_code, 400)
+
+    @override_settings(ORGANIZATIONS_AUTOCREATE=True)
+    def test_library_with_unknown_organization_autocreation(self):
+        """
+        Test that when automatic organization creation is enabled,
+        creating a content library with an unknown organization auto-creates
+        said organization.
+        """
+        with self.assertRaises(InvalidOrganizationException):
+            get_organization_by_short_name("org_xyz")
+        response = self.client.ajax_post(LIBRARY_REST_URL, {
+            'org': "org_xyz",
+            'library': "org_test_lib",
+            'display_name': "This library's organization doesn't exist... yet.",
+        })
+        assert response.status_code == 200
+        assert get_organization_by_short_name("org_xyz")
+
+    @override_settings(ORGANIZATIONS_AUTOCREATE=False)
+    def test_library_with_unknown_organization_validation_error(self):
+        """
+        Test that when automatic organization creation is disabled,
+        creating a content library with an unknown organization raises an error.
+        """
+        with self.assertRaises(InvalidOrganizationException):
+            get_organization_by_short_name("org_xyz")
+        response = self.client.ajax_post(LIBRARY_REST_URL, {
+            'org': "org_xyz",
+            'library': "org_test_lib",
+            'display_name': "This library's organization doesn't exist!",
+        })
+        assert response.status_code == 400
+        assert "'org_xyz' is not a valid organization identifier" in parse_json(response)['ErrMsg']
+        with self.assertRaises(InvalidOrganizationException):
+            get_organization_by_short_name("org_xyz")
 
     ######################################################
     # Tests for /library/:lib_key/ - get a specific library as JSON or HTML editing view


### PR DESCRIPTION
If `ORGANIZATIONS_AUTOCREATE`, this will create a new
org in the case that the organization is missing.

If `!ORGANIZATIONS_AUTOCREATE`, this will raise a
validation error in the case that the organization is
missing.

(Also, fix some trivial pylint violations in test_library.py. This is in its own commit.)

________________

This was originally meant to be part of [Migrate all environments to use database-backed organizations](https://github.com/edx/edx-platform/pull/25153), which made this change for course runs and V2 content libraries, but I missed it for V1 content libraries. This PR fixes that.

There is a partner-facing change in this PR: on edx.org and stage.edx.org (but not edge.edx.org), partners can no longer specify arbitrary organization keys when creating libraries. That change was communicated to Support in [this write-up on the global organizations rollout](https://openedx.atlassian.net/wiki/spaces/AC/pages/2103083026/Global+roll-out+of+database-backed+Organizations).

Part of [TNL-7646](https://openedx.atlassian.net/browse/TNL-7646)