### PR TITLE
Fix KeyError in v2 Libraries API

### DIFF
--- a/openedx/core/djangoapps/content_libraries/views.py
+++ b/openedx/core/djangoapps/content_libraries/views.py
@@ -158,10 +158,11 @@ class LibraryRootView(APIView):
         # definitions elsewhere.
         data['library_type'] = data.pop('type')
         data['library_license'] = data.pop('license')
+        key_data = data.pop("key")
         # Move "slug" out of the "key.slug" pseudo-field that the serializer added:
-        data["slug"] = data.pop("key")["slug"]
+        data["slug"] = key_data["slug"]
         # Get the organization short_name out of the "key.org" pseudo-field that the serializer added:
-        org_name = data["key"]["org"]
+        org_name = key_data["org"]
         try:
             ensure_organization(org_name)
         except InvalidOrganizationException:


### PR DESCRIPTION
A silly logic error in #25153 broke the creation of V2 libraries.

I had [moved the line `org_name = data["key"]["org"]`](https://github.com/edx/edx-platform/pull/25153/files#diff-aee1ed7cd71a9cbd5d28d029e3589f4391e7ecc0259178a20a48cbb4f752aea5L159-R164) downwards to make the organizations-related logic spatially closer, but that broke because I moved it below the line `data["slug"] = data.pop("key")["slug"]`, which removes `"key"` from `data`.

```
Dec  3 09:02:20 ip-10-3-16-30 [service_variant=cms][django.request][env:stage-edx-edxapp] ERROR [log.py:222] - Internal Server Error: /api/libraries/v2/
Traceback (most recent call last):
  File "/edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/django/core/handlers/exception.py", line 34, in inner
    response = get_response(request)
  File "/edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/django/core/handlers/base.py", line 115, in _get_response
    response = self.process_exception_by_middleware(e, request)
  File "/edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/django/core/handlers/base.py", line 113, in _get_response
    response = wrapped_callback(request, *callback_args, **callback_kwargs)
  File "/usr/lib/python3.8/contextlib.py", line 75, in inner
    return func(*args, **kwds)
  File "/edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/newrelic/hooks/framework_django.py", line 554, in wrapper
    return wrapped(*args, **kwargs)
  File "/edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/django/views/decorators/csrf.py", line 54, in wrapped_view
    return view_func(*args, **kwargs)
  File "/edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/django/views/generic/base.py", line 71, in view
    return self.dispatch(request, *args, **kwargs)
  File "/edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/newrelic/hooks/component_djangorestframework.py", line 60, in _nr_wrapper_APIView_dispatch_
    return wrapped(*args, **kwargs)
  File "/edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/rest_framework/views.py", line 495, in dispatch
    response = self.handle_exception(exc)
  File "/edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/newrelic/hooks/component_djangorestframework.py", line 67, in _handle_exception_wrapper
    return wrapped(*args, **kwargs)
  File "/edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/rest_framework/views.py", line 455, in handle_exception
    self.raise_uncaught_exception(exc)
  File "/edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/rest_framework/views.py", line 492, in dispatch
    response = handler(request, *args, **kwargs)
  File "/edx/app/edxapp/edx-platform/openedx/core/djangoapps/content_libraries/views.py", line 164, in post
    org_name = data["key"]["org"]
KeyError: 'key'
```

This wasn't caught by tests, as we skip all V2 Content Library tests in CI, since they require an external Blockstore service to be running. Moving Blockstore to be a Studio package will help make this situation better.