### PR TITLE
Register pytest mongo marker to avoid warning.

### DIFF
--- a/common/lib/pytest.ini
+++ b/common/lib/pytest.ini
@@ -8,6 +8,8 @@ filterwarnings =
     default
     ignore:No request passed to the backend, unable to rate-limit:UserWarning
     ignore::xblock.exceptions.FieldDataDeprecationWarning
+markers =
+    mongo
 norecursedirs = .cache
 python_classes =
 python_files = tests.py test_*.py tests_*.py *_tests.py __init__.py


### PR DESCRIPTION
This registers the custom pytest marker that's used in one of the tests to avoid a warning.

See https://docs.pytest.org/en/stable/mark.html#registering-marks

**Test instructions**:

This change only affects tests so it's enough to verify that the tests pass and that `PytestUnknownMarkWarning` is no longer printed during test execution.

Compare test output with this change: https://build.testeng.edx.org/job/edx-platform-python-pipeline-pr/24078/consoleFull
to the output without the change, for example: https://build.testeng.edx.org/job/edx-platform-python-pipeline-master/4706/consoleFull