### PR TITLE
AA-454 and AA-470: Update language and bug fix for highlights

### DIFF
--- a/cms/static/js/views/modals/course_outline_modals.js
+++ b/cms/static/js/views/modals/course_outline_modals.js
@@ -273,7 +273,7 @@ define(['jquery', 'backbone', 'underscore', 'gettext', 'js/views/baseview',
         },
 
         getTitle: function() {
-            return gettext('Enable Weekly Highlight Emails');
+            return gettext('Enable Course Highlight Emails');
         },
 
         getIntroductionMessage: function() {

--- a/cms/templates/js/course-highlights-enable.underscore
+++ b/cms/templates/js/course-highlights-enable.underscore
@@ -1,6 +1,6 @@
 <div class="course-highlights-setting">
 <h2 id="highlights-enabled-label" class="status-highlights-enabled-label">
-  <%- gettext('Weekly Highlight Emails') %>
+  <%- gettext('Course Highlight Emails') %>
 </h2>
 <br>
 <% if (highlights_enabled_for_messaging) { %>

--- a/cms/templates/js/highlights-enable-editor.underscore
+++ b/cms/templates/js/highlights-enable-editor.underscore
@@ -1,7 +1,7 @@
 <p>
 <%- gettext(
-    'When you enable weekly highlight emails, learners ' +
-    'automatically receive weekly email messages for each section that ' +
+    'When you enable course highlight emails, learners ' +
+    'automatically receive email messages for each section that ' +
     'has highlights. You cannot disable highlights after you start ' +
     'sending them.'
 ) %>
@@ -10,7 +10,7 @@
 <% // xss-lint: disable=underscore-not-escaped %>
 <%= edx.HtmlUtils.interpolateHtml(
     gettext(
-        'Are you sure you want to enable weekly highlight emails? '
+        'Are you sure you want to enable course highlight emails? '
         + '{linkStart}Learn more.{linkEnd}'
     ),
     {

--- a/openedx/core/djangoapps/schedules/content_highlights.py
+++ b/openedx/core/djangoapps/schedules/content_highlights.py
@@ -1,5 +1,5 @@
 """
-Contains methods for accessing weekly course highlights. Weekly highlights is a
+Contains methods for accessing course highlights. Course highlights is a
 schedule experience built on the Schedules app.
 """
 

--- a/openedx/core/djangoapps/schedules/resolvers.py
+++ b/openedx/core/djangoapps/schedules/resolvers.py
@@ -471,6 +471,7 @@ class CourseNextSectionUpdate(PrefixedDebugLoggerMixin, RecipientResolver):
         schedules = Schedule.objects.select_related('enrollment').filter(
             self.experience_filter,
             active=True,
+            enrollment__is_active=True,
             enrollment__course_id=self.course_id,
             enrollment__user__is_active=True,
             start_date__gte=target_date - course_duration,


### PR DESCRIPTION
Since Course Highlights aren't necessarily weekly (self-paced courses),
update the language to be more generic. And then includes a bug fix to
not send highlights to learners after they have unenrolled from a course.

New text: 
![image](https://user-images.githubusercontent.com/12799718/101169065-41aa4380-35f1-11eb-8373-4a3ca6d526df.png)

Old text: 
<img width="713" alt="image" src="https://user-images.githubusercontent.com/12799718/101169094-4c64d880-35f1-11eb-9bb3-d68ef863a40b.png">

