### PR TITLE
AA-383: add verified mode info to course_home outline API

### DIFF
--- a/lms/djangoapps/course_home_api/dates/v1/views.py
+++ b/lms/djangoapps/course_home_api/dates/v1/views.py
@@ -20,7 +20,6 @@ from lms.djangoapps.courseware.masquerade import setup_masquerade
 from lms.djangoapps.course_home_api.dates.v1.serializers import DatesTabSerializer
 from lms.djangoapps.course_home_api.toggles import course_home_mfe_dates_tab_is_active
 from openedx.core.lib.api.authentication import BearerAuthenticationAllowInactiveUser
-from openedx.features.course_experience.utils import dates_banner_should_display
 from openedx.features.content_type_gating.models import ContentTypeGatingConfig
 
 

--- a/lms/djangoapps/course_home_api/mixins.py
+++ b/lms/djangoapps/course_home_api/mixins.py
@@ -3,13 +3,13 @@
 Course Home Mixins.
 """
 
-
+from opaque_keys.edx.keys import CourseKey
 from rest_framework import serializers
 
-from opaque_keys.edx.keys import CourseKey
-
-from lms.djangoapps.courseware.date_summary import verified_upgrade_deadline_link
+from lms.djangoapps.courseware.utils import verified_upgrade_deadline_link
+from openedx.core.djangoapps.courseware_api.utils import serialize_upgrade_info
 from openedx.features.content_type_gating.models import ContentTypeGatingConfig
+from openedx.features.course_experience import DISPLAY_COURSE_SOCK_FLAG
 from openedx.features.course_experience.utils import dates_banner_should_display
 
 
@@ -42,3 +42,24 @@ class DatesBannerSerializerMixin(serializers.Serializer):
             )
             info['verified_upgrade_link'] = verified_upgrade_deadline_link(request.user, course_id=course_key)
         return info
+
+
+class VerifiedModeSerializerMixin(serializers.Serializer):
+    """
+    Serializer Mixin for displaying verified mode upgrade information.
+
+    Requires 'course_overview', 'enrollment', and 'request' from self.context.
+    """
+    can_show_upgrade_sock = serializers.SerializerMethodField()
+    verified_mode = serializers.SerializerMethodField()
+
+    def get_can_show_upgrade_sock(self, _):
+        course_overview = self.context['course_overview']
+        return DISPLAY_COURSE_SOCK_FLAG.is_enabled(course_overview.id)
+
+    def get_verified_mode(self, _):
+        """Return verified mode information, or None."""
+        course_overview = self.context['course_overview']
+        enrollment = self.context['enrollment']
+        request = self.context['request']
+        return serialize_upgrade_info(request.user, course_overview, enrollment)

--- a/lms/djangoapps/course_home_api/outline/v1/serializers.py
+++ b/lms/djangoapps/course_home_api/outline/v1/serializers.py
@@ -6,7 +6,7 @@ from django.utils.translation import ngettext
 from rest_framework import serializers
 
 from lms.djangoapps.course_home_api.dates.v1.serializers import DateSummarySerializer
-from lms.djangoapps.course_home_api.mixins import DatesBannerSerializerMixin
+from lms.djangoapps.course_home_api.mixins import DatesBannerSerializerMixin, VerifiedModeSerializerMixin
 
 
 class CourseBlockSerializer(serializers.Serializer):
@@ -74,8 +74,8 @@ class CourseToolSerializer(serializers.Serializer):
     url = serializers.SerializerMethodField()
 
     def get_url(self, tool):
-        course_key = self.context.get('course_key')
-        url = tool.url(course_key)
+        course_overview = self.context.get('course_overview')
+        url = tool.url(course_overview.id)
         request = self.context.get('request')
         return request.build_absolute_uri(url)
 
@@ -105,7 +105,7 @@ class ResumeCourseSerializer(serializers.Serializer):
     url = serializers.URLField()
 
 
-class OutlineTabSerializer(DatesBannerSerializerMixin, serializers.Serializer):
+class OutlineTabSerializer(DatesBannerSerializerMixin, VerifiedModeSerializerMixin, serializers.Serializer):
     """
     Serializer for the Outline Tab
     """

--- a/lms/djangoapps/course_home_api/outline/v1/views.py
+++ b/lms/djangoapps/course_home_api/outline/v1/views.py
@@ -256,8 +256,9 @@ class OutlineTabView(RetrieveAPIView):
             'welcome_message_html': welcome_message_html or None,
         }
         context = self.get_serializer_context()
-        context['course_key'] = course_key
+        context['course_overview'] = course_overview
         context['enable_links'] = show_enrolled or allow_public
+        context['enrollment'] = enrollment
         serializer = self.get_serializer_class()(data, context=context)
 
         return Response(serializer.data)

--- a/lms/djangoapps/course_home_api/tests/utils.py
+++ b/lms/djangoapps/course_home_api/tests/utils.py
@@ -41,7 +41,9 @@ class BaseCourseHomeTests(ModuleStoreTestCase, MasqueradeMixin):
         CourseModeFactory(
             course_id=self.course.id,
             mode_slug=CourseMode.VERIFIED,
-            expiration_datetime=datetime(2028, 1, 1)
+            expiration_datetime=datetime(2028, 1, 1),
+            min_price=149,
+            sku='ABCD1234',
         )
         VerificationDeadline.objects.create(course_key=self.course.id, deadline=datetime(2028, 1, 1))
 

--- a/openedx/core/djangoapps/courseware_api/utils.py
+++ b/openedx/core/djangoapps/courseware_api/utils.py
@@ -1,0 +1,29 @@
+"""
+Courseware API Mixins.
+"""
+
+from babel.numbers import get_currency_symbol
+
+from common.djangoapps.course_modes.models import CourseMode
+from lms.djangoapps.courseware.utils import can_show_verified_upgrade, verified_upgrade_deadline_link
+from openedx.features.course_duration_limits.access import get_user_course_expiration_date
+
+
+def serialize_upgrade_info(user, course_overview, enrollment):
+    """
+    Return verified mode upgrade information, or None.
+
+    This is used in a few API views to provide consistent upgrade info to frontends.
+    """
+    if not can_show_verified_upgrade(user, enrollment):
+        return None
+
+    mode = CourseMode.verified_mode_for_course(course=course_overview)
+    return {
+        'access_expiration_date': get_user_course_expiration_date(user, course_overview),
+        'currency': mode.currency.upper(),
+        'currency_symbol': get_currency_symbol(mode.currency.upper()),
+        'price': mode.min_price,
+        'sku': mode.sku,
+        'upgrade_url': verified_upgrade_deadline_link(user, course_overview),
+    }


### PR DESCRIPTION
Adds can_show_course_sock and verified_mode values to the outline API serialization. And adds a utility method to generate the verified_mode dictionary, shared with the courseware API.

Related to https://github.com/edx/frontend-app-learning/pull/289