### PR TITLE
[BB-3306] Customizable Certificate Date Format

### DIFF
--- a/lms/djangoapps/certificates/views/webview.py
+++ b/lms/djangoapps/certificates/views/webview.py
@@ -108,11 +108,7 @@ def _update_certificate_context(context, course, user_certificate, platform_name
 
     # Translators:  The format of the date includes the full name of the month
     date = display_date_for_certificate(course, user_certificate)
-    context['certificate_date_issued'] = _(u'{month} {day}, {year}').format(
-        month=strftime_localized(date, "%B"),
-        day=date.day,
-        year=date.year
-    )
+    context['certificate_date_issued'] = strftime_localized(date, settings.CERTIFICATE_DATE_FORMAT)
 
     # Translators:  This text represents the verification of the certificate
     context['document_meta_description'] = _(u'This is a valid {platform_name} certificate for {user_name}, '

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -1047,6 +1047,10 @@ DJFS = {
     'url_root': '/static/django-pyfs',
 }
 
+# Set certificate issued date format. It supports all formats supported by
+# `common.djangoapps.util.date_utils.strftime_localized`.
+CERTIFICATE_DATE_FORMAT = "%B %-d, %Y"
+
 ### Dark code. Should be enabled in local settings for devel.
 
 ENABLE_MULTICOURSE = False  # set to False to disable multicourse display (see lib.util.views.edXhome)


### PR DESCRIPTION
The current way of defining Certificate Date Format doesn't allow easy override. That sometimes leads to code drift when trying to [customize](https://github.com/edx/edx-platform/commit/f360a39cfa03f53458540a0acd4fbe997865a97c). This PR introduces a new setting ``CERTIFICATE_DATE_FORMAT``, which allows easy customization of date format in certificate.

**JIRA tickets**: https://tasks.opencraft.com/browse/BB-3306

~~**Discussions**:~~

**Dependencies**: None

~~**Screenshots**:~~

~~**Sandbox URL**:~~

**Merge deadline**: None

**Testing instructions**:

1. In your local devstack check certificate date format.
2. Clone this PR on local devstack.
3. To enable certificate, add a new [HTML View Configuration](https://edx.readthedocs.io/projects/edx-installing-configuring-and-running/en/latest/configuration/enable_certificates.html#configure-course-certificates-for-your-open-edx-instance) from ``/admin/certificates/certificatehtmlviewconfiguration/``. Make sure to mark it as enabled.
4. Check if your course has appropriate ``Course Mode`` here - ``/admin/course_modes/coursemode/``. If you are testing with ``course-v1:edX+DemoX+Demo_Course``, it should be fine.
5. Go to Studio and set up the certificate. For example, go to ``http://localhost:18010/certificates/course-v1:edX+DemoX+Demo_Course``, and click the ``Setup Your Certificate`` button.
6. Fill up the form with dummy info and click ``Create``.
7. You should see a ``Preview Certificate`` button.
8. The date of our interest can be seen at the bottom right corner of the certificate - ``Issued On:``
3. Check that certificates Issued date format.
4. Override ``CERTIFICATE_DATE_FORMAT`` with new date format. The format string should be supported by [strftime_localized](https://github.com/edx/edx-platform/blob/master/common/djangoapps/util/date_utils.py#L105)
5. Check the certificate to observe the change.

**Author notes and concerns**:
N/A

**Reviewers**
- [x] @farhaanbukhsh 
- [ ] edX reviewer[s] TBD