### PR TITLE
Pin requirements to temporarily fix instructor task registration

### DIFF
--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -23,6 +23,10 @@ django-countries==5.5
 # Removes deprecated get_ip function, which we still use (ARCHBOM-1329 for unpinning)
 django-ipware<3.0.0
 
+# Pinning as a temporary fix to https://openedx.atlassian.net/browse/CR-2982, as per
+# https://github.com/edx/edx-platform/pull/25766
+django-model-utils==4.1.0
+
 # 2.0.0 dropped support for Python 3.5
 django-pipeline<2.0.0
 
@@ -36,6 +40,10 @@ drf-yasg<1.17.1
 # This is to allow them to better control its deployment and to do it in a process that works better
 # for them.
 edx-enterprise==3.13.5
+
+# Pinning as a temporary fix to https://openedx.atlassian.net/browse/CR-2982, as per
+# https://github.com/edx/edx-platform/pull/25766
+edx-submissions==3.2.2
 
 # We expect v2.0.0 to introduce large breaking changes in the feature toggle API
 edx-toggles<2.0.0
@@ -67,6 +75,10 @@ jsonfield2<3.1.0
 # kiwisolver 1.2.0 requires Python 3.6+
 kiwisolver<1.2.0
 
+# Pinning as a temporary fix to https://openedx.atlassian.net/browse/CR-2982, as per
+# https://github.com/edx/edx-platform/pull/25766
+lti-consumer-xblock==2.3
+
 # 4.5.1 introduced a bug when used together with xmlsec: https://bugs.launchpad.net/lxml/+bug/1880251
 # Tests passed, but hit a problem in stage
 lxml<4.5.1
@@ -88,6 +100,10 @@ oauthlib==3.0.1
 
 # django-auth-toolkit==1.3.3 requires oauthlib>=3.1.0 which is pinned because of test failures
 django-oauth-toolkit<=1.3.2
+
+# Pinning as a temporary fix to https://openedx.atlassian.net/browse/CR-2982, as per
+# https://github.com/edx/edx-platform/pull/25766
+ora2==2.12.1
 
 # path 13.2.0 drops support for Python 3.5
 path<13.2.0

--- a/requirements/edx-sandbox/py35.txt
+++ b/requirements/edx-sandbox/py35.txt
@@ -31,7 +31,7 @@ regex==2020.11.13         # via -r requirements/edx-sandbox/shared.txt, nltk
 scipy==1.2.1              # via -c requirements/edx-sandbox/../constraints.txt, -r requirements/edx-sandbox/py35.in, chem, openedx-calc
 six==1.15.0               # via -r requirements/edx-sandbox/shared.txt, chem, cryptography, cycler, matplotlib, openedx-calc, python-dateutil
 sympy==1.6.2              # via -c requirements/edx-sandbox/../constraints.txt, -r requirements/edx-sandbox/py35.in, symmath
-tqdm==4.54.0              # via -r requirements/edx-sandbox/shared.txt, nltk
+tqdm==4.54.1              # via -r requirements/edx-sandbox/shared.txt, nltk
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools

--- a/requirements/edx-sandbox/shared.txt
+++ b/requirements/edx-sandbox/shared.txt
@@ -13,4 +13,4 @@ nltk==3.5                 # via -r requirements/edx-sandbox/shared.in
 pycparser==2.20           # via cffi
 regex==2020.11.13         # via nltk
 six==1.15.0               # via cryptography
-tqdm==4.54.0              # via nltk
+tqdm==4.54.1              # via nltk

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -32,12 +32,12 @@ boto3==1.4.8              # via -r requirements/edx/base.in, django-ses, fs-s3fs
 boto==2.39.0              # via -r requirements/edx/base.in, edxval
 botocore==1.8.17          # via -r requirements/edx/base.in, boto3, s3transfer
 bridgekeeper==0.9         # via -r requirements/edx/base.in
-certifi==2020.11.8        # via -r requirements/edx/paver.txt, elasticsearch, requests
+certifi==2020.12.5        # via -r requirements/edx/paver.txt, elasticsearch, requests
 cffi==1.14.4              # via -r requirements/edx/../edx-sandbox/shared.txt, cryptography
 chardet==3.0.4            # via -r requirements/edx/paver.txt, pysrt, requests
 chem==1.2.0               # via -r requirements/edx/base.in
 click==7.1.2              # via -r requirements/edx/../edx-sandbox/shared.txt, code-annotations, nltk, user-util
-code-annotations==0.10.1  # via edx-enterprise, edx-toggles
+code-annotations==0.10.2  # via edx-enterprise, edx-toggles
 contextlib2==0.6.0.post1  # via -r requirements/edx/base.in
 coreapi==2.3.3            # via drf-yasg
 coreschema==0.0.4         # via coreapi, drf-yasg
@@ -60,7 +60,7 @@ django-filter==2.4.0      # via -r requirements/edx/base.in, edx-enterprise
 django-ipware==2.1.0      # via -c requirements/edx/../constraints.txt, -r requirements/edx/base.in, edx-enterprise, edx-proctoring
 django-js-asset==1.2.2    # via django-mptt
 django-method-override==1.0.4  # via -r requirements/edx/base.in
-django-model-utils==4.1.0  # via -r requirements/edx/base.in, django-user-tasks, edx-bulk-grades, edx-celeryutils, edx-completion, edx-enterprise, edx-milestones, edx-organizations, edx-proctoring, edx-rbac, edx-submissions, edx-when, edxval, ora2, super-csv
+django-model-utils==4.1.0  # via -c requirements/edx/../constraints.txt, -r requirements/edx/base.in, django-user-tasks, edx-bulk-grades, edx-celeryutils, edx-completion, edx-enterprise, edx-milestones, edx-organizations, edx-proctoring, edx-rbac, edx-submissions, edx-when, edxval, ora2, super-csv
 django-mptt==0.11.0       # via -r requirements/edx/base.in, django-wiki
 django-multi-email-field==0.6.2  # via edx-enterprise
 django-mysql==3.9.0       # via -r requirements/edx/base.in
@@ -96,7 +96,7 @@ edx-celeryutils==0.5.2    # via -r requirements/edx/base.in, super-csv
 edx-completion==4.0.0     # via -r requirements/edx/base.in
 edx-django-release-util==0.4.4  # via -r requirements/edx/base.in
 edx-django-sites-extensions==2.5.1  # via -r requirements/edx/base.in
-edx-django-utils==3.13.0  # via -r requirements/edx/base.in, django-config-models, edx-drf-extensions, edx-enterprise, edx-rest-api-client, edx-toggles, edx-when, ora2
+edx-django-utils==3.13.0  # via -r requirements/edx/base.in, django-config-models, edx-drf-extensions, edx-enterprise, edx-rest-api-client, edx-toggles, edx-when, ora2, super-csv
 edx-drf-extensions==6.2.0  # via -r requirements/edx/base.in, edx-completion, edx-enterprise, edx-organizations, edx-proctoring, edx-rbac, edx-when, edxval
 edx-enterprise==3.13.5    # via -c requirements/edx/../constraints.txt, -r requirements/edx/base.in
 edx-event-routing-backends==1.0.0  # via -r requirements/edx/base.in
@@ -110,7 +110,7 @@ edx-rbac==1.3.3           # via edx-enterprise
 edx-rest-api-client==5.2.1  # via -r requirements/edx/base.in, edx-enterprise, edx-proctoring
 edx-search==2.0.1         # via -r requirements/edx/base.in
 edx-sga==0.13.0           # via -r requirements/edx/base.in
-edx-submissions==3.2.2    # via -r requirements/edx/base.in, ora2
+edx-submissions==3.2.2    # via -c requirements/edx/../constraints.txt, -r requirements/edx/base.in, ora2
 edx-tincan-py35==0.0.9    # via edx-enterprise
 edx-toggles==1.2.0        # via -c requirements/edx/../constraints.txt, -r requirements/edx/base.in, edx-completion, ora2
 edx-user-state-client==1.2.0  # via -r requirements/edx/base.in
@@ -144,7 +144,7 @@ laboratory==1.0.2         # via -r requirements/edx/base.in
 lazy==1.4                 # via -r requirements/edx/paver.txt, acid-xblock, lti-consumer-xblock, ora2
 libsass==0.10.0           # via -r requirements/edx/paver.txt, ora2
 loremipsum==1.0.5         # via ora2
-lti-consumer-xblock==2.3  # via -r requirements/edx/base.in
+lti-consumer-xblock==2.3  # via -c requirements/edx/../constraints.txt, -r requirements/edx/base.in
 lxml==4.5.0               # via -c requirements/edx/../constraints.txt, -r requirements/edx/../edx-sandbox/shared.txt, capa, edxval, lti-consumer-xblock, ora2, safe-lxml, xblock, xmlsec
 mailsnake==1.6.4          # via -r requirements/edx/base.in
 mako==1.1.3               # via -r requirements/edx/base.in, acid-xblock, lti-consumer-xblock, xblock-google-drive, xblock-utils
@@ -163,7 +163,7 @@ nodeenv==1.5.0            # via -r requirements/edx/base.in
 numpy==1.18.5             # via -c requirements/edx/../constraints.txt, chem, openedx-calc, scipy
 oauthlib==3.0.1           # via -c requirements/edx/../constraints.txt, -r requirements/edx/base.in, django-oauth-toolkit, lti-consumer-xblock, requests-oauthlib, social-auth-core
 openedx-calc==1.0.9       # via -r requirements/edx/base.in
-ora2==2.12.1              # via -r requirements/edx/base.in
+ora2==2.12.1              # via -c requirements/edx/../constraints.txt, -r requirements/edx/base.in
 packaging==20.7           # via bleach, drf-yasg
 path.py==12.5.0           # via edx-enterprise, edx-i18n-tools, ora2, staff-graded-xblock, xmodule
 path==13.1.0              # via -c requirements/edx/../constraints.txt, -r requirements/edx/paver.txt, path.py
@@ -179,7 +179,7 @@ pycontracts==1.8.12       # via -r requirements/edx/base.in, edx-user-state-clie
 pycountry==20.7.3         # via -r requirements/edx/base.in
 pycparser==2.20           # via -r requirements/edx/../edx-sandbox/shared.txt, cffi
 pycryptodomex==3.9.9      # via -r requirements/edx/base.in, edx-proctoring, lti-consumer-xblock, pyjwkest
-pygments==2.7.2           # via -r requirements/edx/base.in
+pygments==2.7.3           # via -r requirements/edx/base.in
 pyjwkest==1.4.2           # via -r requirements/edx/base.in, edx-drf-extensions, lti-consumer-xblock
 pyjwt[crypto]==1.7.1      # via -r requirements/edx/base.in, drf-jwt, edx-rest-api-client, social-auth-core
 pymongo==3.10.1           # via -c requirements/edx/../constraints.txt, -r requirements/edx/base.in, -r requirements/edx/paver.txt, edx-opaque-keys, event-tracking, mongodbproxy, mongoengine
@@ -190,7 +190,7 @@ python-dateutil==2.4.0    # via -c requirements/edx/../constraints.txt, -r requi
 python-levenshtein==0.12.0  # via -r requirements/edx/base.in
 python-memcached==1.59    # via -r requirements/edx/paver.txt
 python-slugify==4.0.1     # via code-annotations
-python-swiftclient==3.10.1  # via ora2
+python-swiftclient==3.11.0  # via ora2
 python3-openid==3.2.0 ; python_version >= "3"  # via -r requirements/edx/base.in, social-auth-core
 python3-saml==1.9.0       # via -r requirements/edx/base.in
 pytz==2020.4              # via -r requirements/edx/base.in, babel, capa, celery, django, django-ses, edx-completion, edx-enterprise, edx-event-routing-backends, edx-proctoring, edx-submissions, edx-tincan-py35, event-tracking, fs, icalendar, ora2, xblock
@@ -222,19 +222,19 @@ soupsieve==2.0.1          # via beautifulsoup4
 sqlparse==0.4.1           # via -r requirements/edx/base.in, django
 staff-graded-xblock==1.1  # via -r requirements/edx/base.in
 stevedore==1.32.0         # via -c requirements/edx/../constraints.txt, -r requirements/edx/base.in, -r requirements/edx/paver.txt, code-annotations, edx-ace, edx-django-utils, edx-enterprise, edx-opaque-keys
-super-csv==1.0.2          # via -r requirements/edx/base.in, edx-bulk-grades
+super-csv==1.1.0          # via -r requirements/edx/base.in, edx-bulk-grades
 sympy==1.6.2              # via -c requirements/edx/../constraints.txt, symmath
 tableauserverclient==0.14.0  # via edx-enterprise
 testfixtures==6.15.0      # via edx-enterprise
 text-unidecode==1.3       # via python-slugify
-tqdm==4.54.0              # via -r requirements/edx/../edx-sandbox/shared.txt, nltk
+tqdm==4.54.1              # via -r requirements/edx/../edx-sandbox/shared.txt, nltk
 ua-parser==0.10.0         # via django-cookies-samesite
 unicodecsv==0.14.1        # via -r requirements/edx/base.in, edx-enterprise
 uritemplate==3.0.1        # via coreapi, drf-yasg
 urllib3==1.26.2           # via -r requirements/edx/paver.txt, elasticsearch, geoip2, requests
 user-util==0.3.1          # via -r requirements/edx/base.in
 vine==1.3.0               # via amqp, celery
-voluptuous==0.12.0        # via ora2
+voluptuous==0.12.1        # via ora2
 watchdog==0.10.4          # via -r requirements/edx/paver.txt
 web-fragments==0.3.2      # via -r requirements/edx/base.in, crowdsourcehinter-xblock, edx-sga, staff-graded-xblock, xblock, xblock-utils
 webencodings==0.5.1       # via bleach, html5lib

--- a/requirements/edx/coverage.txt
+++ b/requirements/edx/coverage.txt
@@ -13,5 +13,5 @@ jinja2==2.11.2            # via diff-cover, jinja2-pluralize
 markupsafe==1.1.1         # via jinja2
 more-itertools==8.6.0     # via zipp
 pluggy==0.13.1            # via diff-cover
-pygments==2.7.2           # via diff-cover
+pygments==2.7.3           # via diff-cover
 zipp==1.0.0               # via -c requirements/edx/../constraints.txt, importlib-metadata

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -36,13 +36,13 @@ boto3==1.4.8              # via -r requirements/edx/testing.txt, django-ses, fs-
 boto==2.39.0              # via -r requirements/edx/testing.txt, edxval
 botocore==1.8.17          # via -r requirements/edx/testing.txt, boto3, s3transfer
 bridgekeeper==0.9         # via -r requirements/edx/testing.txt
-certifi==2020.11.8        # via -r requirements/edx/testing.txt, elasticsearch, requests
+certifi==2020.12.5        # via -r requirements/edx/testing.txt, elasticsearch, requests
 cffi==1.14.4              # via -r requirements/edx/testing.txt, cryptography
 chardet==3.0.4            # via -r requirements/edx/testing.txt, pysrt, requests
 chem==1.2.0               # via -r requirements/edx/testing.txt
 click-log==0.3.2          # via -r requirements/edx/testing.txt, edx-lint
 click==7.1.2              # via -r requirements/edx/development.in, -r requirements/edx/pip-tools.txt, -r requirements/edx/testing.txt, click-log, code-annotations, edx-lint, nltk, pip-tools, user-util
-code-annotations==0.10.1  # via -r requirements/edx/testing.txt, edx-enterprise, edx-toggles
+code-annotations==0.10.2  # via -r requirements/edx/testing.txt, edx-enterprise, edx-toggles
 contextlib2==0.6.0.post1  # via -r requirements/edx/testing.txt
 coreapi==2.3.3            # via -r requirements/edx/testing.txt, drf-yasg
 coreschema==0.0.4         # via -r requirements/edx/testing.txt, coreapi, drf-yasg
@@ -66,12 +66,12 @@ django-cors-headers==2.5.3  # via -c requirements/edx/../constraints.txt, -r req
 django-countries==5.5     # via -c requirements/edx/../constraints.txt, -r requirements/edx/testing.txt, edx-enterprise
 django-crum==0.7.9        # via -r requirements/edx/testing.txt, edx-django-utils, edx-enterprise, edx-proctoring, edx-rbac, edx-toggles, super-csv
 django-debug-toolbar==3.2  # via -r requirements/edx/development.in
-django-fernet-fields==0.6  # via -r requirements/edx/testing.txt, edx-enterprise, edxval
+django-fernet-fields==0.6  # via -r requirements/edx/testing.txt, edx-enterprise, edx-event-routing-backends, edxval
 django-filter==2.4.0      # via -r requirements/edx/testing.txt, edx-enterprise
 django-ipware==2.1.0      # via -c requirements/edx/../constraints.txt, -r requirements/edx/testing.txt, edx-enterprise, edx-proctoring
 django-js-asset==1.2.2    # via -r requirements/edx/testing.txt, django-mptt
 django-method-override==1.0.4  # via -r requirements/edx/testing.txt
-django-model-utils==4.1.0  # via -r requirements/edx/testing.txt, django-user-tasks, edx-bulk-grades, edx-celeryutils, edx-completion, edx-enterprise, edx-milestones, edx-organizations, edx-proctoring, edx-rbac, edx-submissions, edx-when, edxval, ora2, super-csv
+django-model-utils==4.1.0  # via -c requirements/edx/../constraints.txt, -r requirements/edx/testing.txt, django-user-tasks, edx-bulk-grades, edx-celeryutils, edx-completion, edx-enterprise, edx-milestones, edx-organizations, edx-proctoring, edx-rbac, edx-submissions, edx-when, edxval, ora2, super-csv
 django-mptt==0.11.0       # via -r requirements/edx/testing.txt, django-wiki
 django-multi-email-field==0.6.2  # via -r requirements/edx/testing.txt, edx-enterprise
 django-mysql==3.9.0       # via -r requirements/edx/testing.txt
@@ -107,7 +107,7 @@ edx-celeryutils==0.5.2    # via -r requirements/edx/testing.txt, super-csv
 edx-completion==4.0.0     # via -r requirements/edx/testing.txt
 edx-django-release-util==0.4.4  # via -r requirements/edx/testing.txt
 edx-django-sites-extensions==2.5.1  # via -r requirements/edx/testing.txt
-edx-django-utils==3.13.0  # via -r requirements/edx/testing.txt, django-config-models, edx-drf-extensions, edx-enterprise, edx-rest-api-client, edx-toggles, edx-when, ora2
+edx-django-utils==3.13.0  # via -r requirements/edx/testing.txt, django-config-models, edx-drf-extensions, edx-enterprise, edx-rest-api-client, edx-toggles, edx-when, ora2, super-csv
 edx-drf-extensions==6.2.0  # via -r requirements/edx/testing.txt, edx-completion, edx-enterprise, edx-organizations, edx-proctoring, edx-rbac, edx-when, edxval
 edx-enterprise==3.13.5    # via -c requirements/edx/../constraints.txt, -r requirements/edx/testing.txt
 edx-event-routing-backends==1.0.0  # via -r requirements/edx/testing.txt
@@ -123,7 +123,7 @@ edx-rest-api-client==5.2.1  # via -r requirements/edx/testing.txt, edx-enterpris
 edx-search==2.0.1         # via -r requirements/edx/testing.txt
 edx-sga==0.13.0           # via -r requirements/edx/testing.txt
 edx-sphinx-theme==1.5.0   # via -r requirements/edx/development.in
-edx-submissions==3.2.2    # via -r requirements/edx/testing.txt, ora2
+edx-submissions==3.2.2    # via -c requirements/edx/../constraints.txt, -r requirements/edx/testing.txt, ora2
 edx-tincan-py35==0.0.9    # via -r requirements/edx/testing.txt, edx-enterprise
 edx-toggles==1.2.0        # via -c requirements/edx/../constraints.txt, -r requirements/edx/testing.txt, edx-completion, ora2
 edx-user-state-client==1.2.0  # via -r requirements/edx/testing.txt
@@ -173,7 +173,7 @@ lazy-object-proxy==1.4.3  # via -r requirements/edx/testing.txt, astroid
 lazy==1.4                 # via -r requirements/edx/testing.txt, acid-xblock, bok-choy, lti-consumer-xblock, ora2
 libsass==0.10.0           # via -r requirements/edx/testing.txt, ora2
 loremipsum==1.0.5         # via -r requirements/edx/testing.txt, ora2
-lti-consumer-xblock==2.3  # via -r requirements/edx/testing.txt
+lti-consumer-xblock==2.3  # via -c requirements/edx/../constraints.txt, -r requirements/edx/testing.txt
 lxml==4.5.0               # via -c requirements/edx/../constraints.txt, -r requirements/edx/testing.txt, capa, edxval, lti-consumer-xblock, ora2, pyquery, safe-lxml, xblock, xmlsec
 m2r==0.2.1                # via sphinxcontrib-openapi
 mailsnake==1.6.4          # via -r requirements/edx/testing.txt
@@ -196,7 +196,7 @@ nodeenv==1.5.0            # via -r requirements/edx/testing.txt
 numpy==1.18.5             # via -c requirements/edx/../constraints.txt, -r requirements/edx/testing.txt, chem, openedx-calc, scipy
 oauthlib==3.0.1           # via -c requirements/edx/../constraints.txt, -r requirements/edx/testing.txt, django-oauth-toolkit, lti-consumer-xblock, requests-oauthlib, social-auth-core
 openedx-calc==1.0.9       # via -r requirements/edx/testing.txt
-ora2==2.12.1              # via -r requirements/edx/testing.txt
+ora2==2.12.1              # via -c requirements/edx/../constraints.txt, -r requirements/edx/testing.txt
 packaging==20.7           # via -r requirements/edx/testing.txt, bleach, drf-yasg, pytest, sphinx, tox
 path.py==12.5.0           # via -r requirements/edx/testing.txt, edx-enterprise, edx-i18n-tools, ora2, staff-graded-xblock, xmodule
 path==13.1.0              # via -c requirements/edx/../constraints.txt, -r requirements/edx/testing.txt, path.py
@@ -216,7 +216,7 @@ pycontracts==1.8.12       # via -r requirements/edx/testing.txt, edx-user-state-
 pycountry==20.7.3         # via -r requirements/edx/testing.txt
 pycparser==2.20           # via -r requirements/edx/testing.txt, cffi
 pycryptodomex==3.9.9      # via -r requirements/edx/testing.txt, edx-proctoring, lti-consumer-xblock, pyjwkest
-pygments==2.7.2           # via -r requirements/edx/testing.txt, diff-cover, sphinx
+pygments==2.7.3           # via -r requirements/edx/testing.txt, diff-cover, sphinx
 pyjwkest==1.4.2           # via -r requirements/edx/testing.txt, edx-drf-extensions, lti-consumer-xblock
 pyjwt[crypto]==1.7.1      # via -r requirements/edx/testing.txt, drf-jwt, edx-rest-api-client, social-auth-core
 pylint-celery==0.3        # via -r requirements/edx/testing.txt, edx-lint
@@ -242,7 +242,7 @@ python-dateutil==2.4.0    # via -c requirements/edx/../constraints.txt, -r requi
 python-levenshtein==0.12.0  # via -r requirements/edx/testing.txt
 python-memcached==1.59    # via -r requirements/edx/testing.txt
 python-slugify==4.0.1     # via -r requirements/edx/testing.txt, code-annotations, transifex-client
-python-swiftclient==3.10.1  # via -r requirements/edx/testing.txt, ora2
+python-swiftclient==3.11.0  # via -r requirements/edx/testing.txt, ora2
 python3-openid==3.2.0 ; python_version >= "3"  # via -r requirements/edx/testing.txt, social-auth-core
 python3-saml==1.9.0       # via -r requirements/edx/testing.txt
 pytz==2020.4              # via -r requirements/edx/testing.txt, babel, capa, celery, django, django-ses, edx-completion, edx-enterprise, edx-event-routing-backends, edx-proctoring, edx-submissions, edx-tincan-py35, event-tracking, fs, icalendar, ora2, xblock
@@ -288,7 +288,7 @@ sphinxcontrib-serializinghtml==1.1.4  # via sphinx
 sqlparse==0.4.1           # via -r requirements/edx/testing.txt, django, django-debug-toolbar
 staff-graded-xblock==1.1  # via -r requirements/edx/testing.txt
 stevedore==1.32.0         # via -c requirements/edx/../constraints.txt, -r requirements/edx/testing.txt, code-annotations, edx-ace, edx-django-utils, edx-enterprise, edx-opaque-keys
-super-csv==1.0.2          # via -r requirements/edx/testing.txt, edx-bulk-grades
+super-csv==1.1.0          # via -r requirements/edx/testing.txt, edx-bulk-grades
 sympy==1.6.2              # via -c requirements/edx/../constraints.txt, -r requirements/edx/testing.txt, symmath
 tableauserverclient==0.14.0  # via -r requirements/edx/testing.txt, edx-enterprise
 testfixtures==6.15.0      # via -r requirements/edx/testing.txt, edx-enterprise
@@ -296,7 +296,7 @@ text-unidecode==1.3       # via -r requirements/edx/testing.txt, faker, python-s
 toml==0.10.2              # via -r requirements/edx/testing.txt, pytest, tox
 tox-battery==0.6.1        # via -r requirements/edx/testing.txt
 tox==3.20.1               # via -r requirements/edx/testing.txt, tox-battery
-tqdm==4.54.0              # via -r requirements/edx/testing.txt, nltk
+tqdm==4.54.1              # via -r requirements/edx/testing.txt, nltk
 transifex-client==0.14.2  # via -r requirements/edx/testing.txt
 ua-parser==0.10.0         # via -r requirements/edx/testing.txt, django-cookies-samesite
 unicodecsv==0.14.1        # via -r requirements/edx/testing.txt, edx-enterprise
@@ -305,8 +305,8 @@ uritemplate==3.0.1        # via -r requirements/edx/testing.txt, coreapi, drf-ya
 urllib3==1.26.2           # via -r requirements/edx/testing.txt, elasticsearch, geoip2, requests, selenium, transifex-client
 user-util==0.3.1          # via -r requirements/edx/testing.txt
 vine==1.3.0               # via -r requirements/edx/testing.txt, amqp, celery
-virtualenv==20.2.1        # via -r requirements/edx/testing.txt, tox
-voluptuous==0.12.0        # via -r requirements/edx/testing.txt, ora2
+virtualenv==20.2.2        # via -r requirements/edx/testing.txt, tox
+voluptuous==0.12.1        # via -r requirements/edx/testing.txt, ora2
 vulture==1.6              # via -c requirements/edx/../constraints.txt, -r requirements/edx/development.in
 watchdog==0.10.4          # via -r requirements/edx/testing.txt
 web-fragments==0.3.2      # via -r requirements/edx/testing.txt, crowdsourcehinter-xblock, edx-sga, staff-graded-xblock, xblock, xblock-utils

--- a/requirements/edx/doc.txt
+++ b/requirements/edx/doc.txt
@@ -6,10 +6,10 @@
 #
 alabaster==0.7.12         # via sphinx
 babel==2.9.0              # via sphinx
-certifi==2020.11.8        # via requests
+certifi==2020.12.5        # via requests
 chardet==3.0.4            # via requests
 click==7.1.2              # via code-annotations
-code-annotations==0.10.1  # via -r requirements/edx/doc.in
+code-annotations==0.10.2  # via -r requirements/edx/doc.in
 django==2.2.17            # via -c requirements/edx/../constraints.txt, code-annotations
 docutils==0.16            # via sphinx
 edx-sphinx-theme==1.5.0   # via -r requirements/edx/doc.in
@@ -21,7 +21,7 @@ jinja2==2.11.2            # via code-annotations, sphinx
 markupsafe==1.1.1         # via jinja2
 packaging==20.7           # via sphinx
 pbr==5.5.1                # via stevedore
-pygments==2.7.2           # via sphinx
+pygments==2.7.3           # via sphinx
 pyparsing==2.4.7          # via packaging
 python-slugify==4.0.1     # via code-annotations
 pytz==2020.4              # via babel, django

--- a/requirements/edx/paver.txt
+++ b/requirements/edx/paver.txt
@@ -4,7 +4,7 @@
 #
 #    make upgrade
 #
-certifi==2020.11.8        # via requests
+certifi==2020.12.5        # via requests
 chardet==3.0.4            # via requests
 edx-opaque-keys==2.1.1    # via -r requirements/edx/paver.in
 idna==2.10                # via requests

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -35,13 +35,13 @@ boto3==1.4.8              # via -r requirements/edx/base.txt, django-ses, fs-s3f
 boto==2.39.0              # via -r requirements/edx/base.txt, edxval
 botocore==1.8.17          # via -r requirements/edx/base.txt, boto3, s3transfer
 bridgekeeper==0.9         # via -r requirements/edx/base.txt
-certifi==2020.11.8        # via -r requirements/edx/base.txt, elasticsearch, requests
+certifi==2020.12.5        # via -r requirements/edx/base.txt, elasticsearch, requests
 cffi==1.14.4              # via -r requirements/edx/base.txt, cryptography
 chardet==3.0.4            # via -r requirements/edx/base.txt, pysrt, requests
 chem==1.2.0               # via -r requirements/edx/base.txt
 click-log==0.3.2          # via edx-lint
 click==7.1.2              # via -r requirements/edx/base.txt, click-log, code-annotations, edx-lint, nltk, user-util
-code-annotations==0.10.1  # via -r requirements/edx/base.txt, -r requirements/edx/testing.in, edx-enterprise, edx-toggles
+code-annotations==0.10.2  # via -r requirements/edx/base.txt, -r requirements/edx/testing.in, edx-enterprise, edx-toggles
 contextlib2==0.6.0.post1  # via -r requirements/edx/base.txt
 coreapi==2.3.3            # via -r requirements/edx/base.txt, drf-yasg
 coreschema==0.0.4         # via -r requirements/edx/base.txt, coreapi, drf-yasg
@@ -69,7 +69,7 @@ django-filter==2.4.0      # via -r requirements/edx/base.txt, edx-enterprise
 django-ipware==2.1.0      # via -c requirements/edx/../constraints.txt, -r requirements/edx/base.txt, edx-enterprise, edx-proctoring
 django-js-asset==1.2.2    # via -r requirements/edx/base.txt, django-mptt
 django-method-override==1.0.4  # via -r requirements/edx/base.txt
-django-model-utils==4.1.0  # via -r requirements/edx/base.txt, django-user-tasks, edx-bulk-grades, edx-celeryutils, edx-completion, edx-enterprise, edx-milestones, edx-organizations, edx-proctoring, edx-rbac, edx-submissions, edx-when, edxval, ora2, super-csv
+django-model-utils==4.1.0  # via -c requirements/edx/../constraints.txt, -r requirements/edx/base.txt, django-user-tasks, edx-bulk-grades, edx-celeryutils, edx-completion, edx-enterprise, edx-milestones, edx-organizations, edx-proctoring, edx-rbac, edx-submissions, edx-when, edxval, ora2, super-csv
 django-mptt==0.11.0       # via -r requirements/edx/base.txt, django-wiki
 django-multi-email-field==0.6.2  # via -r requirements/edx/base.txt, edx-enterprise
 django-mysql==3.9.0       # via -r requirements/edx/base.txt
@@ -104,9 +104,9 @@ edx-celeryutils==0.5.2    # via -r requirements/edx/base.txt, super-csv
 edx-completion==4.0.0     # via -r requirements/edx/base.txt
 edx-django-release-util==0.4.4  # via -r requirements/edx/base.txt
 edx-django-sites-extensions==2.5.1  # via -r requirements/edx/base.txt
-edx-django-utils==3.13.0  # via -r requirements/edx/base.txt, django-config-models, edx-drf-extensions, edx-enterprise, edx-rest-api-client, edx-toggles, edx-when, ora2
+edx-django-utils==3.13.0  # via -r requirements/edx/base.txt, django-config-models, edx-drf-extensions, edx-enterprise, edx-rest-api-client, edx-toggles, edx-when, ora2, super-csv
 edx-drf-extensions==6.2.0  # via -r requirements/edx/base.txt, edx-completion, edx-enterprise, edx-organizations, edx-proctoring, edx-rbac, edx-when, edxval
-edx-enterprise==3.13.5   # via -c requirements/edx/../constraints.txt, -r requirements/edx/base.txt
+edx-enterprise==3.13.5    # via -c requirements/edx/../constraints.txt, -r requirements/edx/base.txt
 edx-event-routing-backends==1.0.0  # via -r requirements/edx/base.txt
 edx-i18n-tools==0.5.3     # via -r requirements/edx/base.txt, -r requirements/edx/testing.in, ora2
 edx-lint==1.5.2           # via -r requirements/edx/testing.in
@@ -119,7 +119,7 @@ edx-rbac==1.3.3           # via -r requirements/edx/base.txt, edx-enterprise
 edx-rest-api-client==5.2.1  # via -r requirements/edx/base.txt, edx-enterprise, edx-proctoring
 edx-search==2.0.1         # via -r requirements/edx/base.txt
 edx-sga==0.13.0           # via -r requirements/edx/base.txt
-edx-submissions==3.2.2    # via -r requirements/edx/base.txt, ora2
+edx-submissions==3.2.2    # via -c requirements/edx/../constraints.txt, -r requirements/edx/base.txt, ora2
 edx-tincan-py35==0.0.9    # via -r requirements/edx/base.txt, edx-enterprise
 edx-toggles==1.2.0        # via -c requirements/edx/../constraints.txt, -r requirements/edx/base.txt, edx-completion, ora2
 edx-user-state-client==1.2.0  # via -r requirements/edx/base.txt
@@ -167,7 +167,7 @@ lazy-object-proxy==1.4.3  # via astroid
 lazy==1.4                 # via -r requirements/edx/base.txt, acid-xblock, bok-choy, lti-consumer-xblock, ora2
 libsass==0.10.0           # via -r requirements/edx/base.txt, ora2
 loremipsum==1.0.5         # via -r requirements/edx/base.txt, ora2
-lti-consumer-xblock==2.3  # via -r requirements/edx/base.txt
+lti-consumer-xblock==2.3  # via -c requirements/edx/../constraints.txt, -r requirements/edx/base.txt
 lxml==4.5.0               # via -c requirements/edx/../constraints.txt, -r requirements/edx/base.txt, capa, edxval, lti-consumer-xblock, ora2, pyquery, safe-lxml, xblock, xmlsec
 mailsnake==1.6.4          # via -r requirements/edx/base.txt
 mako==1.1.3               # via -r requirements/edx/base.txt, acid-xblock, lti-consumer-xblock, xblock-google-drive, xblock-utils
@@ -188,7 +188,7 @@ nodeenv==1.5.0            # via -r requirements/edx/base.txt
 numpy==1.18.5             # via -c requirements/edx/../constraints.txt, -r requirements/edx/base.txt, chem, openedx-calc, scipy
 oauthlib==3.0.1           # via -c requirements/edx/../constraints.txt, -r requirements/edx/base.txt, django-oauth-toolkit, lti-consumer-xblock, requests-oauthlib, social-auth-core
 openedx-calc==1.0.9       # via -r requirements/edx/base.txt
-ora2==2.12.1              # via -r requirements/edx/base.txt
+ora2==2.12.1              # via -c requirements/edx/../constraints.txt, -r requirements/edx/base.txt
 packaging==20.7           # via -r requirements/edx/base.txt, bleach, drf-yasg, pytest, tox
 path.py==12.5.0           # via -r requirements/edx/base.txt, edx-enterprise, edx-i18n-tools, ora2, staff-graded-xblock, xmodule
 path==13.1.0              # via -c requirements/edx/../constraints.txt, -r requirements/edx/base.txt, path.py
@@ -207,7 +207,7 @@ pycontracts==1.8.12       # via -r requirements/edx/base.txt, edx-user-state-cli
 pycountry==20.7.3         # via -r requirements/edx/base.txt
 pycparser==2.20           # via -r requirements/edx/base.txt, cffi
 pycryptodomex==3.9.9      # via -r requirements/edx/base.txt, edx-proctoring, lti-consumer-xblock, pyjwkest
-pygments==2.7.2           # via -r requirements/edx/base.txt, -r requirements/edx/coverage.txt, diff-cover
+pygments==2.7.3           # via -r requirements/edx/base.txt, -r requirements/edx/coverage.txt, diff-cover
 pyjwkest==1.4.2           # via -r requirements/edx/base.txt, edx-drf-extensions, lti-consumer-xblock
 pyjwt[crypto]==1.7.1      # via -r requirements/edx/base.txt, drf-jwt, edx-rest-api-client, social-auth-core
 pylint-celery==0.3        # via edx-lint
@@ -232,7 +232,7 @@ python-dateutil==2.4.0    # via -c requirements/edx/../constraints.txt, -r requi
 python-levenshtein==0.12.0  # via -r requirements/edx/base.txt
 python-memcached==1.59    # via -r requirements/edx/base.txt
 python-slugify==4.0.1     # via -r requirements/edx/base.txt, code-annotations, transifex-client
-python-swiftclient==3.10.1  # via -r requirements/edx/base.txt, ora2
+python-swiftclient==3.11.0  # via -r requirements/edx/base.txt, ora2
 python3-openid==3.2.0 ; python_version >= "3"  # via -r requirements/edx/base.txt, social-auth-core
 python3-saml==1.9.0       # via -r requirements/edx/base.txt
 pytz==2020.4              # via -r requirements/edx/base.txt, babel, capa, celery, django, django-ses, edx-completion, edx-enterprise, edx-event-routing-backends, edx-proctoring, edx-submissions, edx-tincan-py35, event-tracking, fs, icalendar, ora2, xblock
@@ -267,7 +267,7 @@ soupsieve==2.0.1          # via -r requirements/edx/base.txt, beautifulsoup4
 sqlparse==0.4.1           # via -r requirements/edx/base.txt, django
 staff-graded-xblock==1.1  # via -r requirements/edx/base.txt
 stevedore==1.32.0         # via -c requirements/edx/../constraints.txt, -r requirements/edx/base.txt, code-annotations, edx-ace, edx-django-utils, edx-enterprise, edx-opaque-keys
-super-csv==1.0.2          # via -r requirements/edx/base.txt, edx-bulk-grades
+super-csv==1.1.0          # via -r requirements/edx/base.txt, edx-bulk-grades
 sympy==1.6.2              # via -c requirements/edx/../constraints.txt, -r requirements/edx/base.txt, symmath
 tableauserverclient==0.14.0  # via -r requirements/edx/base.txt, edx-enterprise
 testfixtures==6.15.0      # via -r requirements/edx/base.txt, -r requirements/edx/testing.in, edx-enterprise
@@ -275,7 +275,7 @@ text-unidecode==1.3       # via -r requirements/edx/base.txt, faker, python-slug
 toml==0.10.2              # via pytest, tox
 tox-battery==0.6.1        # via -r requirements/edx/testing.in
 tox==3.20.1               # via -r requirements/edx/testing.in, tox-battery
-tqdm==4.54.0              # via -r requirements/edx/base.txt, nltk
+tqdm==4.54.1              # via -r requirements/edx/base.txt, nltk
 transifex-client==0.14.2  # via -r requirements/edx/testing.in
 ua-parser==0.10.0         # via -r requirements/edx/base.txt, django-cookies-samesite
 unicodecsv==0.14.1        # via -r requirements/edx/base.txt, edx-enterprise
@@ -284,8 +284,8 @@ uritemplate==3.0.1        # via -r requirements/edx/base.txt, coreapi, drf-yasg
 urllib3==1.26.2           # via -r requirements/edx/base.txt, elasticsearch, geoip2, requests, selenium, transifex-client
 user-util==0.3.1          # via -r requirements/edx/base.txt
 vine==1.3.0               # via -r requirements/edx/base.txt, amqp, celery
-virtualenv==20.2.1        # via tox
-voluptuous==0.12.0        # via -r requirements/edx/base.txt, ora2
+virtualenv==20.2.2        # via tox
+voluptuous==0.12.1        # via -r requirements/edx/base.txt, ora2
 watchdog==0.10.4          # via -r requirements/edx/base.txt
 web-fragments==0.3.2      # via -r requirements/edx/base.txt, crowdsourcehinter-xblock, edx-sga, staff-graded-xblock, xblock, xblock-utils
 webencodings==0.5.1       # via -r requirements/edx/base.txt, bleach, html5lib

--- a/scripts/xblock/requirements.txt
+++ b/scripts/xblock/requirements.txt
@@ -4,7 +4,7 @@
 #
 #    make upgrade
 #
-certifi==2020.11.8        # via requests
+certifi==2020.12.5        # via requests
 chardet==3.0.4            # via requests
 idna==2.10                # via requests
 requests==2.25.0          # via -r scripts/xblock/requirements.in


### PR DESCRIPTION
We ran into an issue where instructor tasks were not being registered with celery correctly, resulting in: https://openedx.atlassian.net/browse/CR-2982

The cause wasn’t clear, so we started reverting some recent, suspect PRs.  When we reverted #25746, the issue went away.

The revert PR was this one: https://github.com/edx/edx-platform/pull/25766

So that we can unpause our deployment pipelines, we’re temporarily pinning the versions of the four packages upgraded in #25746 so we can continue to investigate.