### PR TITLE
Fix query string being passed into IDV flow

### DIFF
--- a/lms/djangoapps/verify_student/services.py
+++ b/lms/djangoapps/verify_student/services.py
@@ -238,5 +238,5 @@ class IDVerificationService(object):
         """
         location = '{}/id-verification'.format(settings.ACCOUNT_MICROFRONTEND_URL)
         if course_id:
-            location = location + '?{}'.format(str(course_id))
+            location = location + '?course_id={}'.format(str(course_id))
         return location


### PR DESCRIPTION
There was a discrepancy between the course_id being passed into the IDV flow, and the value received on the front end, preventing users from submitting their IDV photos. This should fix that error.