### PR TITLE
Make optional checkbox text small.

### DIFF
--- a/lms/static/sass/views/_login-register.scss
+++ b/lms/static/sass/views/_login-register.scss
@@ -320,6 +320,10 @@ ul.fa-ul{
       width: calc(50% - 10px);
     }
 
+    .label-text-small {
+      font-size: small;
+    }
+
     /** FROM _accounts.scss - start **/
     label,
     input,
@@ -434,7 +438,7 @@ ul.fa-ul{
         display: inline;
         width: auto;
         height: auto;
-        margin-right: ($baseline/4);
+        margin-right: 0px;
 
         & + label {
           display: inline;

--- a/lms/templates/student_account/register.underscore
+++ b/lms/templates/student_account/register.underscore
@@ -56,7 +56,7 @@
     <div class="form-field checkbox-optional_fields_toggle">
         <input type="checkbox" id="toggle_optional_fields" class="input-block checkbox"">
         <label for="toggle_optional_fields">
-            <span class="label-text">
+            <span class="label-text-small">
                 <%- gettext("Support education research by providing additional information") %>
             </span>
         </label>


### PR DESCRIPTION
This would make the checkbox text appear consistent with tos/honor code text.
<img width="819" alt="Screen Shot 2020-12-08 at 3 03 03 AM" src="https://user-images.githubusercontent.com/373677/101412151-eaafb180-3903-11eb-8931-c5a262452dc7.png">

Part of VAN-170.
