### PR TITLE
Update Edge footer logo height

### DIFF
--- a/lms/static/sass/bootstrap/_footer.scss
+++ b/lms/static/sass/bootstrap/_footer.scss
@@ -31,6 +31,11 @@
         }
       }
     }
+    .wrapper-logo {
+      img {
+        height: $header-logo-height * 1.05;
+      }
+    }
 
     .legal-nav {
       padding: 0;


### PR DESCRIPTION
Edge uses a different logo when the user is not signed in, that needs a height attribute set. 