### PR TITLE
Exposing waffle flag for proctoring info panel

### DIFF
--- a/openedx/features/course_experience/templates/course_experience/course-home-fragment.html
+++ b/openedx/features/course_experience/templates/course_experience/course-home-fragment.html
@@ -84,6 +84,9 @@ from openedx.features.course_experience.course_tools import HttpMethod
             % endif
         </div>
         <aside class="page-content-secondary course-sidebar">
+            % if show_proctoring_info_panel:
+                <div class="proctoring-info-panel" data-course-id="${course_key}"></div>
+            % endif
             % if has_goal_permission:
                 <div class="section section-goals ${'' if current_goal else 'hidden'}">
                     <div class="current-goal-container">
@@ -247,4 +250,4 @@ from openedx.features.course_experience.course_tools import HttpMethod
         linkCategory: "(none)"
       });
 
-</%static:require_module_async> 
+</%static:require_module_async>

--- a/openedx/features/course_experience/views/course_home.py
+++ b/openedx/features/course_experience/views/course_home.py
@@ -26,6 +26,7 @@ from lms.djangoapps.course_goals.api import (
 from lms.djangoapps.courseware.exceptions import CourseAccessRedirect
 from lms.djangoapps.courseware.utils import can_show_verified_upgrade, verified_upgrade_deadline_link
 from lms.djangoapps.courseware.views.views import CourseTabView
+from lms.djangoapps.courseware.toggles import COURSEWARE_PROCTORING_IMPROVEMENTS
 from openedx.core.djangoapps.content.course_overviews.models import CourseOverview
 from openedx.core.djangoapps.plugin_api.views import EdxFragmentView
 from openedx.core.djangoapps.util.maintenance_banner import add_maintenance_banner
@@ -243,6 +244,7 @@ class CourseHomeFragmentView(EdxFragmentView):
             'upgrade_url': upgrade_url,
             'has_discount': has_discount,
             'show_search': show_search,
+            'show_proctoring_info_panel': COURSEWARE_PROCTORING_IMPROVEMENTS.is_enabled(course_key),
         }
         html = render_to_string('course_experience/course-home-fragment.html', context)
         return Fragment(html)


### PR DESCRIPTION
## [MST-517](https://openedx.atlassian.net/browse/MST-517)

Pass the waffle flag into the `course-home-fragment.html` template to show proctoring info panel only when the waffle flag is enabled.