### PR TITLE
AA-503: Add id verification status into API

### DIFF
--- a/openedx/core/djangoapps/courseware_api/serializers.py
+++ b/openedx/core/djangoapps/courseware_api/serializers.py
@@ -112,6 +112,7 @@ class CourseInfoSerializer(serializers.Serializer):  # pylint: disable=abstract-
     course_exit_page_is_active = serializers.BooleanField()
     certificate_data = CertificateDataSerializer()
     verify_identity_url = AbsoluteURLField()
+    verification_status = serializers.CharField()
     linkedin_add_to_profile_url = serializers.URLField()
 
     def __init__(self, *args, **kwargs):

--- a/openedx/core/djangoapps/courseware_api/tests/test_views.py
+++ b/openedx/core/djangoapps/courseware_api/tests/test_views.py
@@ -130,12 +130,14 @@ class CourseApiTestViews(BaseCoursewareTests):
                                               'The audit track does not include a certificate.')
                     assert response.data['certificate_data']['msg'] == expected_audit_message
                     assert response.data['verify_identity_url'] is None
+                    assert response.data['verification_status'] is 'none'
                     assert response.data['linkedin_add_to_profile_url'] is None
                 else:
                     assert response.data['certificate_data']['cert_status'] == 'earned_but_not_available'
                     expected_verify_identity_url = reverse('verify_student_verify_now', args=[self.course.id])
                     # The response contains an absolute URL so this is only checking the path of the final
                     assert expected_verify_identity_url in response.data['verify_identity_url']
+                    assert response.data['verification_status'] is 'none'
 
                     request = RequestFactory().request()
                     cert_url = get_certificate_url(course_id=self.course.id, uuid=cert.verify_uuid)

--- a/openedx/core/djangoapps/courseware_api/views.py
+++ b/openedx/core/djangoapps/courseware_api/views.py
@@ -258,6 +258,17 @@ class CoursewareMeta:
                 return IDVerificationService.get_verify_location('verify_student_verify_now', self.course_key)
 
     @property
+    def verification_status(self):
+        """
+        Returns a String of the verification status of learner.
+        """
+        if self.enrollment_object and self.enrollment_object.mode in CourseMode.VERIFIED_MODES:
+            return IDVerificationService.user_status(self.effective_user)['status']
+        # I know this looks weird (and is), but this is just so it is inline with what the
+        # IDVerificationService.user_status method would return before a verification was created
+        return 'none'
+
+    @property
     def linkedin_add_to_profile_url(self):
         """
         Returns a URL to add a certificate to a LinkedIn profile (will autofill fields).


### PR DESCRIPTION
This will be used for the Course Exit experience to improve our
messaging for learners in the 'pending' state