### PR TITLE
Adjust height/width as per new logo.

### DIFF
--- a/openedx/core/djangoapps/ace_common/templates/ace_common/edx_ace/common/base_body.html
+++ b/openedx/core/djangoapps/ace_common/templates/ace_common/edx_ace/common/base_body.html
@@ -62,7 +62,7 @@
                     <tr>
                         <td width="70">
                             <a href="{% with_link_tracking homepage_url %}"><img
-                                    src="{{ logo_url }}" width="70"
+                                    src="{{ logo_url }}"
                                     height="30" alt="{% filter force_escape %}{% blocktrans %}Go to {{ platform_name }} Home Page{% endblocktrans %}{% endfilter %}"/></a>
                         </td>
                         <td align="right" style="text-align: {{ LANGUAGE_BIDI|yesno:"left,right" }};">


### PR DESCRIPTION
Height and Width are set on the logo image attribute which seems to work fine for the previous logo. The new logo doesn't look right with these dimensions, so needed to update them. 


Before edx.org: 
<img width="651" alt="Screen Shot 2020-12-09 at 2 44 07 PM" src="https://user-images.githubusercontent.com/4252738/101612922-ff3b9900-3a2c-11eb-8e5f-fd95ad6acd4d.png">

After edx.org:

<img width="614" alt="Screen Shot 2020-12-09 at 2 44 54 PM" src="https://user-images.githubusercontent.com/4252738/101613032-1c706780-3a2d-11eb-85d3-54c817651a18.png">

Posting edx.org-next images on the ticket. 

[TNL-7780](https://openedx.atlassian.net/browse/TNL-7780)