### PR TITLE
Downgrade REDIRECT_TO_COURSEWARE_MICROFRONTEND to CourseWaffleFlag

### DIFF
--- a/common/djangoapps/student/tests/test_receivers.py
+++ b/common/djangoapps/student/tests/test_receivers.py
@@ -6,7 +6,6 @@ from lms.djangoapps.courseware.toggles import (
     COURSEWARE_MICROFRONTEND_PROGRESS_MILESTONES_FIRST_SECTION_CELEBRATION,
     REDIRECT_TO_COURSEWARE_MICROFRONTEND
 )
-from lms.djangoapps.experiments.testutils import override_experiment_waffle_flag
 from common.djangoapps.student.models import CourseEnrollmentCelebration
 from common.djangoapps.student.tests.factories import CourseEnrollmentFactory
 from xmodule.modulestore.tests.django_utils import SharedModuleStoreTestCase
@@ -16,7 +15,7 @@ class ReceiversTest(SharedModuleStoreTestCase):
     """
     Tests for dashboard utility functions
     """
-    @override_experiment_waffle_flag(REDIRECT_TO_COURSEWARE_MICROFRONTEND, active=True)
+    @override_waffle_flag(REDIRECT_TO_COURSEWARE_MICROFRONTEND, active=True)
     @override_waffle_flag(COURSEWARE_MICROFRONTEND_PROGRESS_MILESTONES, active=True)
     @override_waffle_flag(COURSEWARE_MICROFRONTEND_PROGRESS_MILESTONES_FIRST_SECTION_CELEBRATION, active=True)
     def test_celebration_created(self):

--- a/lms/djangoapps/courseware/tests/test_views.py
+++ b/lms/djangoapps/courseware/tests/test_views.py
@@ -3251,7 +3251,7 @@ class TestShowCoursewareMFE(TestCase):
         )
         for user, course_key, is_course_staff, preview_active, redirect_active in combos:
             with override_waffle_flag(COURSEWARE_MICROFRONTEND_COURSE_TEAM_PREVIEW, preview_active):
-                with override_experiment_waffle_flag(REDIRECT_TO_COURSEWARE_MICROFRONTEND, active=redirect_active):
+                with override_waffle_flag(REDIRECT_TO_COURSEWARE_MICROFRONTEND, active=redirect_active):
                     assert show_courseware_mfe_link(user, is_course_staff, course_key) is False
 
     @patch.dict(settings.FEATURES, {'ENABLE_COURSEWARE_MICROFRONTEND': True})
@@ -3271,14 +3271,14 @@ class TestShowCoursewareMFE(TestCase):
         )
         for user, is_course_staff, preview_active, redirect_active in old_mongo_combos:
             with override_waffle_flag(COURSEWARE_MICROFRONTEND_COURSE_TEAM_PREVIEW, preview_active):
-                with override_experiment_waffle_flag(REDIRECT_TO_COURSEWARE_MICROFRONTEND, active=redirect_active):
+                with override_waffle_flag(REDIRECT_TO_COURSEWARE_MICROFRONTEND, active=redirect_active):
                     assert show_courseware_mfe_link(user, is_course_staff, old_course_key) is False
 
         # We've checked all old-style course keys now, so we can test only the
         # new ones going forward. Now we check combinations of waffle flags and
         # user permissions...
         with override_waffle_flag(COURSEWARE_MICROFRONTEND_COURSE_TEAM_PREVIEW, True):
-            with override_experiment_waffle_flag(REDIRECT_TO_COURSEWARE_MICROFRONTEND, active=True):
+            with override_waffle_flag(REDIRECT_TO_COURSEWARE_MICROFRONTEND, active=True):
                 # (preview=on, redirect=on)
                 # Global and Course Staff can see the link.
                 self.assertTrue(show_courseware_mfe_link(global_staff_user, True, new_course_key))
@@ -3287,7 +3287,7 @@ class TestShowCoursewareMFE(TestCase):
 
                 # Regular users don't see the link.
                 self.assertFalse(show_courseware_mfe_link(regular_user, False, new_course_key))
-            with override_experiment_waffle_flag(REDIRECT_TO_COURSEWARE_MICROFRONTEND, active=False):
+            with override_waffle_flag(REDIRECT_TO_COURSEWARE_MICROFRONTEND, active=False):
                 # (preview=on, redirect=off)
                 # Global and Course Staff can see the link.
                 self.assertTrue(show_courseware_mfe_link(global_staff_user, True, new_course_key))
@@ -3298,7 +3298,7 @@ class TestShowCoursewareMFE(TestCase):
                 self.assertFalse(show_courseware_mfe_link(regular_user, False, new_course_key))
 
         with override_waffle_flag(COURSEWARE_MICROFRONTEND_COURSE_TEAM_PREVIEW, False):
-            with override_experiment_waffle_flag(REDIRECT_TO_COURSEWARE_MICROFRONTEND, active=True):
+            with override_waffle_flag(REDIRECT_TO_COURSEWARE_MICROFRONTEND, active=True):
                 # (preview=off, redirect=on)
                 # Global staff see the link anyway
                 self.assertTrue(show_courseware_mfe_link(global_staff_user, True, new_course_key))
@@ -3310,7 +3310,7 @@ class TestShowCoursewareMFE(TestCase):
 
                 # Regular users don't see the link.
                 self.assertFalse(show_courseware_mfe_link(regular_user, False, new_course_key))
-            with override_experiment_waffle_flag(REDIRECT_TO_COURSEWARE_MICROFRONTEND, active=False):
+            with override_waffle_flag(REDIRECT_TO_COURSEWARE_MICROFRONTEND, active=False):
                 # (preview=off, redirect=off)
                 # Global staff see the link anyway
                 self.assertTrue(show_courseware_mfe_link(global_staff_user, True, new_course_key))
@@ -3369,7 +3369,7 @@ class MFERedirectTests(BaseViewsTestCase):
         # learners will be redirected when the waffle flag is set
         lms_url, mfe_url = self._get_urls()
 
-        with override_experiment_waffle_flag(REDIRECT_TO_COURSEWARE_MICROFRONTEND, active=True):
+        with override_waffle_flag(REDIRECT_TO_COURSEWARE_MICROFRONTEND, active=True):
             assert self.client.get(lms_url).url == mfe_url
 
     def test_staff_no_redirect(self):
@@ -3381,14 +3381,14 @@ class MFERedirectTests(BaseViewsTestCase):
         self.client.login(username=course_staff.username, password='test')
 
         assert self.client.get(lms_url).status_code == 200
-        with override_experiment_waffle_flag(REDIRECT_TO_COURSEWARE_MICROFRONTEND, active=True):
+        with override_waffle_flag(REDIRECT_TO_COURSEWARE_MICROFRONTEND, active=True):
             assert self.client.get(lms_url).status_code == 200
 
         # global staff will never be redirected
         self._create_global_staff_user()
         assert self.client.get(lms_url).status_code == 200
 
-        with override_experiment_waffle_flag(REDIRECT_TO_COURSEWARE_MICROFRONTEND, active=True):
+        with override_waffle_flag(REDIRECT_TO_COURSEWARE_MICROFRONTEND, active=True):
             assert self.client.get(lms_url).status_code == 200
 
     def test_exam_no_redirect(self):
@@ -3398,5 +3398,5 @@ class MFERedirectTests(BaseViewsTestCase):
 
         lms_url, mfe_url = self._get_urls()
 
-        with override_experiment_waffle_flag(REDIRECT_TO_COURSEWARE_MICROFRONTEND, active=True):
+        with override_waffle_flag(REDIRECT_TO_COURSEWARE_MICROFRONTEND, active=True):
             assert self.client.get(lms_url).status_code == 200

--- a/lms/djangoapps/courseware/toggles.py
+++ b/lms/djangoapps/courseware/toggles.py
@@ -3,14 +3,13 @@ Toggles for courseware in-course experience.
 """
 
 from edx_toggles.toggles import LegacyWaffleFlagNamespace
-from lms.djangoapps.experiments.flags import ExperimentWaffleFlag
 from openedx.core.djangoapps.waffle_utils import CourseWaffleFlag
 
 # Namespace for courseware waffle flags.
 WAFFLE_FLAG_NAMESPACE = LegacyWaffleFlagNamespace(name='courseware')
 
 # .. toggle_name: courseware.courseware_mfe
-# .. toggle_implementation: ExperimentWaffleFlag
+# .. toggle_implementation: CourseWaffleFlag
 # .. toggle_default: False
 # .. toggle_description: Waffle flag to redirect to another learner profile experience. Supports staged rollout to
 #   students for a new micro-frontend-based implementation of the courseware page.
@@ -19,9 +18,9 @@ WAFFLE_FLAG_NAMESPACE = LegacyWaffleFlagNamespace(name='courseware')
 # .. toggle_target_removal_date: 2020-12-31
 # .. toggle_warnings: Also set settings.LEARNING_MICROFRONTEND_URL and
 #   ENABLE_COURSEWARE_MICROFRONTEND.
-# .. toggle_tickets: TNL-7000
-REDIRECT_TO_COURSEWARE_MICROFRONTEND = ExperimentWaffleFlag(
-    WAFFLE_FLAG_NAMESPACE, 'courseware_mfe', __name__, use_course_aware_bucketing=False
+# .. toggle_tickets: DEPR-109
+REDIRECT_TO_COURSEWARE_MICROFRONTEND = CourseWaffleFlag(
+    WAFFLE_FLAG_NAMESPACE, 'courseware_mfe', __name__
 )
 
 # .. toggle_name: courseware.microfrontend_course_team_preview
@@ -35,7 +34,7 @@ REDIRECT_TO_COURSEWARE_MICROFRONTEND = ExperimentWaffleFlag(
 # .. toggle_target_removal_date: 2020-12-31
 # .. toggle_warnings: Also set settings.LEARNING_MICROFRONTEND_URL and
 #   ENABLE_COURSEWARE_MICROFRONTEND.
-# .. toggle_tickets: TNL-6982
+# .. toggle_tickets: DEPR-109
 COURSEWARE_MICROFRONTEND_COURSE_TEAM_PREVIEW = CourseWaffleFlag(
     WAFFLE_FLAG_NAMESPACE, 'microfrontend_course_team_preview', __name__
 )
@@ -90,8 +89,8 @@ COURSEWARE_MICROFRONTEND_PROGRESS_MILESTONES_FIRST_SECTION_CELEBRATION = CourseW
 # .. toggle_implementation: CourseWaffleFlag
 # .. toggle_default: False
 # .. toggle_description: Waffle flag to toggle various enhancements to the proctoring experience, including but
-#   not limited to the display of learner facing proctoring information on the course outline, changes to the Proctortrack
-#   onboarding flow, changes to IDV (identity verification) requirements, etc.
+#   not limited to the display of learner facing proctoring information on the course outline, changes to the
+#   Proctortrack onboarding flow, changes to IDV (identity verification) requirements, etc.
 # .. toggle_use_cases: temporary
 # .. toggle_creation_date: 2020-10-07
 # .. toggle_target_removal_date: None

--- a/lms/djangoapps/courseware/views/index.py
+++ b/lms/djangoapps/courseware/views/index.py
@@ -640,13 +640,15 @@ def show_courseware_mfe_link(user, staff_access, course_key):
     if user.is_staff:
         return True
 
-    # If you have course staff access, you see this link if we've enabled the
-    # course team preview CourseWaffleFlag for this course *or* if we've turned
-    # on the redirect for your students.
-    mfe_enabled_for_course_team = COURSEWARE_MICROFRONTEND_COURSE_TEAM_PREVIEW.is_enabled(course_key)
-    mfe_enabled_for_course = REDIRECT_TO_COURSEWARE_MICROFRONTEND.is_enabled(course_key)
-
-    if staff_access and (mfe_enabled_for_course_team or mfe_enabled_for_course):
-        return True
+    # If you have course staff access, you can see this link if...
+    if staff_access:
+        # (a) we've turned on the redirect for your students, or...
+        mfe_enabled_for_course = REDIRECT_TO_COURSEWARE_MICROFRONTEND.is_enabled(course_key)
+        if mfe_enabled_for_course:
+            return True
+        # (b) we've enabled the course team preview.
+        mfe_enabled_for_course_team = COURSEWARE_MICROFRONTEND_COURSE_TEAM_PREVIEW.is_enabled(course_key)
+        if mfe_enabled_for_course_team:
+            return True
 
     return False

--- a/lms/djangoapps/courseware/views/index.py
+++ b/lms/djangoapps/courseware/views/index.py
@@ -41,10 +41,8 @@ from openedx.core.djangolib.markup import HTML, Text
 from openedx.features.course_experience import (
     COURSE_ENABLE_UNENROLLED_ACCESS_FLAG,
     DISABLE_COURSE_OUTLINE_PAGE_FLAG,
-    RELATIVE_DATES_FLAG,
     default_course_url_name
 )
-from openedx.features.course_experience.urls import COURSE_HOME_VIEW_NAME
 from openedx.features.course_experience.views.course_sock import CourseSockFragmentView
 from openedx.features.enterprise_support.api import data_sharing_consent_required
 from common.djangoapps.student.models import CourseEnrollment
@@ -55,7 +53,7 @@ from xmodule.x_module import PUBLIC_VIEW, STUDENT_VIEW
 
 from ..access import has_access
 from ..access_utils import check_public_access
-from ..courses import check_course_access_with_redirect, get_course_with_access, get_current_child, get_studio_url
+from ..courses import get_course_with_access, get_current_child, get_studio_url
 from ..entrance_exams import (
     course_has_entrance_exam,
     get_entrance_exam_content,

--- a/lms/djangoapps/courseware/views/index.py
+++ b/lms/djangoapps/courseware/views/index.py
@@ -644,9 +644,9 @@ def show_courseware_mfe_link(user, staff_access, course_key):
     # course team preview CourseWaffleFlag for this course *or* if we've turned
     # on the redirect for your students.
     mfe_enabled_for_course_team = COURSEWARE_MICROFRONTEND_COURSE_TEAM_PREVIEW.is_enabled(course_key)
-    mfe_experiment_enabled_for_course = REDIRECT_TO_COURSEWARE_MICROFRONTEND.is_experiment_on(course_key)
+    mfe_enabled_for_course = REDIRECT_TO_COURSEWARE_MICROFRONTEND.is_enabled(course_key)
 
-    if staff_access and (mfe_enabled_for_course_team or mfe_experiment_enabled_for_course):
+    if staff_access and (mfe_enabled_for_course_team or mfe_enabled_for_course):
         return True
 
     return False

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -638,7 +638,7 @@ FEATURES = {
     # .. toggle_use_cases: open_edx
     # .. toggle_creation_date: 2020-03-05
     # .. toggle_target_removal_date: None
-    # .. toggle_tickets: 'https://github.com/edx/edx-platform/pull/23317'
+    # .. toggle_tickets: DEPR-109
     # .. toggle_warnings: Also set settings.LEARNING_MICROFRONTEND_URL and see REDIRECT_TO_COURSEWARE_MICROFRONTEND for
     #   rollout.
     'ENABLE_COURSEWARE_MICROFRONTEND': False,


### PR DESCRIPTION
# The Change

The toggle was previously an ExperimentWaffleFlag,
which allows stable A/B testing but increases the toggle's
complexity. Since we do not plan an doing any more A/B
tests as part of the MFE rollout, we can 'downgrade' this
toggle to a CourseWaffleFlag, which still allows us to do
phased rollout and course-run-specific overrides.

Also, link to [DEPR-109](https://openedx.atlassian.net/browse/DEPR-109) in courseware toggle annotations.

[TNL-7505](https://openedx.atlassian.net/browse/TNL-7505)

# Rollout considerations

I tested that the holdback/redirect behavior still works locally.

## stage-edx

I've confirmed on that there are [no critical usages of the `.0` or `.1` bucket flags](https://courses-internal.stage.edx.org/admin/waffle/flag/?q=courseware_mfe). We still use `courseware_mfe.1`, which is fine, because once this change rolls out, the `.1` flag will be ignored and we'll look at the base `courseware_mfe` flag instead.

've confirmed on stage-edx that there are [no active course overrides referencing to the `.0` or `.1` bucket flags](https://courses-internal.stage.edx.org/admin/waffle_utils/waffleflagcourseoverridemodel/?o=-4&q=courseware_mfe).

## prod-edx

I've confirmed on that there are [no critical usages of the `.0` or `.1` bucket flags](https://courses-internal.edx.org/admin/waffle/flag/?q=courseware_mfe). We still use `courseware_mfe.1`, which is fine, because once this change rolls out, the `.1` flag will be ignored and we'll look at the base `courseware_mfe` flag instead.

I've confirmed on prod-edx that there are [no active course overrides referencing to the `.0` or `.1` bucket flags](https://courses-internal.edx.org/admin/waffle_utils/waffleflagcourseoverridemodel/?o=-4&q=courseware_mfe).

## prod-edge

I've confirmed on that nobody is using the [bucket flags](https://edge.edx.org/admin/waffle/flag/?q=courseware_mfe) or [course overrides thereof](https://edge.edx.org/admin/waffle_utils/waffleflagcourseoverridemodel/?o=-4&q=courseware_mfe).