### PR TITLE
Fix "last submission time" parsing issue

### DIFF
--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -48,8 +48,6 @@ django-oauth-toolkit<=1.3.2
 # ARCHBOM-1141: pip-tools upgrade requires pip upgrade
 pip-tools<6.0
 
-# Upgrading to 2.5.3 on 2020-01-03 triggered "'tzlocal' object has no attribute '_std_offset'" errors in production
-python-dateutil==2.4.0
 # matplotlib>=3.4.0 requires python-dateutil>=2.7
 matplotlib<3.4.0
 

--- a/requirements/edx-sandbox/py35.txt
+++ b/requirements/edx-sandbox/py35.txt
@@ -62,7 +62,6 @@ numpy==1.16.5
     #   chem
     #   matplotlib
     #   openedx-calc
-    #   scipy
 openedx-calc==1.0.9
     # via -r requirements/edx-sandbox/py35.in
 pycparser==2.20
@@ -74,9 +73,7 @@ pyparsing==2.2.0
     #   matplotlib
     #   openedx-calc
 python-dateutil==2.4.0
-    # via
-    #   -c requirements/edx-sandbox/../constraints.txt
-    #   matplotlib
+    # via matplotlib
 pytz==2021.1
     # via matplotlib
 random2==1.0.1

--- a/requirements/edx-sandbox/py38.txt
+++ b/requirements/edx-sandbox/py38.txt
@@ -66,9 +66,7 @@ pyparsing==2.4.7
     #   matplotlib
     #   openedx-calc
 python-dateutil==2.4.0
-    # via
-    #   -c requirements/edx-sandbox/../constraints.txt
-    #   matplotlib
+    # via matplotlib
 random2==1.0.1
     # via -r requirements/edx-sandbox/py38.in
 regex==2021.4.4

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -763,9 +763,8 @@ pysrt==1.1.2
     # via
     #   -r requirements/edx/base.in
     #   edxval
-python-dateutil==2.4.0
+python-dateutil==2.8.1
     # via
-    #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/base.in
     #   analytics-python
     #   botocore

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -1065,9 +1065,8 @@ pytest==6.2.4
     #   pytest-metadata
     #   pytest-randomly
     #   pytest-xdist
-python-dateutil==2.4.0
+python-dateutil==2.8.1
     # via
-    #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/testing.txt
     #   analytics-python
     #   botocore

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -1006,9 +1006,8 @@ pytest==6.2.4
     #   pytest-metadata
     #   pytest-randomly
     #   pytest-xdist
-python-dateutil==2.4.0
+python-dateutil==2.8.1
     # via
-    #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/base.txt
     #   analytics-python
     #   botocore


### PR DESCRIPTION
We are affected by the following python-dateutil issue:
https://github.com/dateutil/dateutil/issues/163

The symptoms are described here:
https://openedx.atlassian.net/jira/software/projects/BTR/boards/641?selectedIssue=BTR-25

In a nutshell: when creating an exercise with a 10 seconds answer delay
on a server that is configured with a non-UTC tzdata (but UTC TIME_ZONE
django setting), students are faced with error messages stating that
they have to wait 4h 59min 50s.

The deeper issue is that dateutil incorrectly parses the datetime
object. This issue is resolved by simply upgrading python-dateutil.

I realise that dateutil was constrained to an older version before. We
will have to see whether this change causes production errors.

This is ready for review.