### PR TITLE
Update base fontsize on progress page

### DIFF
--- a/lms/static/sass/base/_base.scss
+++ b/lms/static/sass/base/_base.scss
@@ -5,20 +5,21 @@
 //   overflow-y: scroll;
 // }
 
-html,
-body {
+html {
   font-family: $font-family-sans-serif;
   font-size: $font-size-base;
   font-style: normal;
   line-height: 1em;
-}
-
-html {
   background: theme-color("inverse");
+
 }
 
 body {
+  font-family: $font-family-sans-serif;
+  font-style: normal;
+  line-height: 1em;
   background: $body-bg;
+
 }
 
 // removing the outline on any element that we make programmatically focusable

--- a/lms/static/sass/base/_base.scss
+++ b/lms/static/sass/base/_base.scss
@@ -7,7 +7,6 @@
 
 html {
   font-family: $font-family-sans-serif;
-  font-size: $font-size-base;
   font-style: normal;
   line-height: 1em;
   background: theme-color("inverse");
@@ -17,6 +16,7 @@ html {
 body {
   font-family: $font-family-sans-serif;
   font-style: normal;
+  font-size: $font-size-base;
   line-height: 1em;
   background: $body-bg;
 


### PR DESCRIPTION
Currently, the HTML and body both assigned a font size of `font-size: 1.125rem`, due to which the body font-size is `20.25px` which is different from the courseware page. 
<img width="200" alt="Screen Shot 2020-12-10 at 1 17 41 AM" src="https://user-images.githubusercontent.com/4252738/101682536-8f0d3180-3a85-11eb-9887-74f8b4aa7911.png">
