### PR TITLE
Raise exception if both cms.celery and lms.celery are imported

### DIFF
--- a/cms/celery.py
+++ b/cms/celery.py
@@ -10,11 +10,15 @@ import os
 
 from celery import Celery
 
+from openedx.core.lib.celery import assert_celery_uninstantiated
 from openedx.core.lib.celery.routers import AlternateEnvironmentRouter
 
 # set the default Django settings module for the 'celery' program.
 os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'cms.envs.production')
 
+# Prevent instantiation of both CMS and LMS celery.
+# See assert_celery_uninstantiated for more details.
+assert_celery_uninstantiated('cms')
 APP = Celery('proj')
 
 APP.conf.task_protocol = 1

--- a/lms/celery.py
+++ b/lms/celery.py
@@ -10,11 +10,15 @@ import os
 
 from celery import Celery
 
+from openedx.core.lib.celery import assert_celery_uninstantiated
 from openedx.core.lib.celery.routers import AlternateEnvironmentRouter
 
 # set the default Django settings module for the 'celery' program.
 os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'lms.envs.production')
 
+# Prevent instantiation of both CMS and LMS celery.
+# See assert_celery_uninstantiated for more details.
+assert_celery_uninstantiated('lms')
 APP = Celery('proj')
 
 APP.conf.task_protocol = 1

--- a/openedx/core/lib/celery/__init__.py
+++ b/openedx/core/lib/celery/__init__.py
@@ -1,0 +1,24 @@
+import threading
+
+SINGLETON_LOCK = threading.Lock()
+# Variant of edxapp that we're running celery for. If None, celery has
+# not been instantiated; if a string ("lms" or "cms"), celery has been
+# instantiated for that variant.
+SINGLETON_VARIANT = None
+
+def assert_celery_uninstantiated(variant):
+    """
+    Raise if celery is already instantiated for the other variant of edxapp.
+
+    Specifically, raise if this function is called multiple times with
+    different variant values. Safe to call multiple times with same variant.
+    """
+    with SINGLETON_LOCK:
+        if SINGLETON_VARIANT is None:
+            SINGLETON_VARIANT = variant
+        elif SINGLETON_VARIANT != variant:
+            raise Exception(
+                f"Conflicting assertions for celery singleton; "
+                f"already asserted variant='{SINGLETON_VARIANT}', "
+                f"attempted to assert variant='{variant}'"
+            )

--- a/openedx/core/lib/celery/__init__.py
+++ b/openedx/core/lib/celery/__init__.py
@@ -1,3 +1,7 @@
+"""
+Common celery utilities.
+"""
+
 import threading
 
 SINGLETON_LOCK = threading.Lock()
@@ -6,6 +10,7 @@ SINGLETON_LOCK = threading.Lock()
 # instantiated for that variant.
 SINGLETON_VARIANT = None
 
+
 def assert_celery_uninstantiated(variant):
     """
     Raise if celery is already instantiated for the other variant of edxapp.
@@ -13,6 +18,7 @@ def assert_celery_uninstantiated(variant):
     Specifically, raise if this function is called multiple times with
     different variant values. Safe to call multiple times with same variant.
     """
+    global SINGLETON_VARIANT
     with SINGLETON_LOCK:
         if SINGLETON_VARIANT is None:
             SINGLETON_VARIANT = variant


### PR DESCRIPTION
In #25822 we protect against the case where *any* `cms.**` module is
imported by the running LMS process, causing cms.celery to be imported
and a second celery to be instantiated (leading to tasks being registered
to the wrong one and effectively lost).

This commit protects against the more restricted case of `cms.celery` or
`lms.celery` being imported explicitly, rather than implicitly by their
respective root `__init__.py`.