### PR TITLE
Enable keeping some request history in the debug toolbar.

### DIFF
--- a/cms/envs/devstack.py
+++ b/cms/envs/devstack.py
@@ -94,6 +94,7 @@ DEBUG_TOOLBAR_PANELS = (
     'debug_toolbar.panels.signals.SignalsPanel',
     'debug_toolbar.panels.logging.LoggingPanel',
     'debug_toolbar.panels.profiling.ProfilingPanel',
+    'debug_toolbar.panels.history.HistoryPanel',
 )
 
 DEBUG_TOOLBAR_CONFIG = {

--- a/lms/envs/devstack.py
+++ b/lms/envs/devstack.py
@@ -93,6 +93,7 @@ DEBUG_TOOLBAR_PANELS = (
     'debug_toolbar.panels.sql.SQLPanel',
     'debug_toolbar.panels.signals.SignalsPanel',
     'debug_toolbar.panels.logging.LoggingPanel',
+    'debug_toolbar.panels.history.HistoryPanel',
     # ProfilingPanel has been intentionally removed for default devstack.py
     # runtimes for performance reasons. If you wish to re-enable it in your
     # local development environment, please create a new settings file


### PR DESCRIPTION
This makes it easire to debug things like POST requests that would
otherwise not be easily debugged during development.