### PR TITLE
[TNL-7771][LX-1409][SE-3764] sets blockstore values timeouts to avoid S3 links Expiration

### DIFF
--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -2214,6 +2214,9 @@ BLOCKSTORE_API_URL = 'http://localhost:18250/api/v1/'
 # in the blockstore-based XBlock runtime
 XBLOCK_RUNTIME_V2_EPHEMERAL_DATA_CACHE = 'default'
 
+# Blockstore data could contain S3 links, so this should be lower than Blockstore's AWS_QUERYSTRING_EXPIRE
+BLOCKSTORE_BUNDLE_CACHE_TIMEOUT = 169200
+
 ###################### LEARNER PORTAL ################################
 LEARNER_PORTAL_URL_ROOT = 'https://learner-portal-localhost:18000'
 

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -4131,6 +4131,9 @@ BLOCKSTORE_API_URL = 'http://localhost:18250/api/v1/'
 # in the blockstore-based XBlock runtime
 XBLOCK_RUNTIME_V2_EPHEMERAL_DATA_CACHE = 'default'
 
+# Blockstore data could contain S3 links, so this should be lower than Blockstore's AWS_QUERYSTRING_EXPIRE
+BLOCKSTORE_BUNDLE_CACHE_TIMEOUT = 169200
+
 ######################### MICROSITE ###############################
 MICROSITE_ROOT_DIR = '/edx/app/edxapp/edx-microsite'
 MICROSITE_CONFIGURATION = {}

--- a/openedx/core/djangolib/blockstore_cache.py
+++ b/openedx/core/djangolib/blockstore_cache.py
@@ -12,6 +12,7 @@ and won't find the now-invalid cached data.
 from datetime import datetime
 from uuid import UUID
 
+from django.conf import settings
 from django.core.cache import caches, InvalidCacheBackendError
 from pytz import UTC
 import requests
@@ -81,7 +82,7 @@ class BundleCache(object):
         """
         assert isinstance(key_parts, (list, tuple))
         full_key = _get_versioned_cache_key(self.bundle_uuid, self.draft_name, key_parts)
-        return cache.set(full_key, value, timeout=None)
+        return cache.set(full_key, value, timeout=settings.BLOCKSTORE_BUNDLE_CACHE_TIMEOUT)
 
     def clear(self):
         """


### PR DESCRIPTION
Fixes the `BundleStorageError` exception and avoids S3 links from blockstore to expire. They were being cached in the `get_bundle_draft_files_cached` method.

**JIRA tickets**: LX-1409, SE-3764, TNL-7771

**Reviewers**
- [ ] @bradenmacdonald 
- [ ] @kdmccormick 