### PR TITLE
Revert "Only instantiate one celery app per process."

### DIFF
--- a/cms/__init__.py
+++ b/cms/__init__.py
@@ -5,7 +5,7 @@ registration and discovery can work correctly.
 Import sorting is intentionally disabled in this module.
 isort:skip_file
 """
-import os
+
 
 # We monkey patch Kombu's entrypoints listing because scanning through this
 # accounts for the majority of LMS/Studio startup time for tests, and we don't
@@ -20,5 +20,4 @@ kombu.utils.entrypoints = lambda namespace: iter([])
 
 # This will make sure the app is always imported when
 # Django starts so that shared_task will use this app.
-if os.environ.get('SERVICE_VARIANT', 'cms').startswith('cms'):
-    from .celery import APP as CELERY_APP
+from .celery import APP as CELERY_APP

--- a/lms/__init__.py
+++ b/lms/__init__.py
@@ -2,7 +2,6 @@
 Celery needs to be loaded when the cms modules are so that task
 registration and discovery can work correctly.
 """
-import os
 
 # We monkey patch Kombu's entrypoints listing because scanning through this
 # accounts for the majority of LMS/Studio startup time for tests, and we don't
@@ -17,5 +16,4 @@ kombu.utils.entrypoints = lambda namespace: iter([])
 
 # This will make sure the app is always imported when
 # Django starts so that shared_task will use this app.
-if os.environ.get('SERVICE_VARIANT', 'lms').startswith('lms'):
-    from .celery import APP as CELERY_APP
+from .celery import APP as CELERY_APP


### PR DESCRIPTION
Reverts edx/edx-platform#25822 due to a shared library that
pulls in the LMS celery app for a task decorator, breaking the
CMS. PR for fixing that: https://github.com/mitodl/edx-sga/pull/288