### PR TITLE
[MST-567] Encode course_id passed into IDV flow

### DIFF
--- a/lms/djangoapps/verify_student/services.py
+++ b/lms/djangoapps/verify_student/services.py
@@ -5,6 +5,7 @@ Implementation of abstraction layer for other parts of the system to make querie
 import logging
 from datetime import timedelta
 from itertools import chain
+from urllib.parse import quote
 
 from django.conf import settings
 from django.urls import reverse
@@ -238,5 +239,5 @@ class IDVerificationService(object):
         """
         location = '{}/id-verification'.format(settings.ACCOUNT_MICROFRONTEND_URL)
         if course_id:
-            location = location + '?course_id={}'.format(str(course_id))
+            location += '?course_id={}'.format(quote(str(course_id)))
         return location

--- a/lms/djangoapps/verify_student/tests/test_services.py
+++ b/lms/djangoapps/verify_student/tests/test_services.py
@@ -116,6 +116,31 @@ class TestIDVerificationService(ModuleStoreTestCase):
 
         self.assertEqual(expected_user_ids, verified_user_ids)
 
+    def test_get_verify_location_no_course_key(self):
+        """
+        Test for the path to the IDV flow with no course key given
+        """
+        path = IDVerificationService.get_verify_location()
+        expected_path = '{}/id-verification'.format(settings.ACCOUNT_MICROFRONTEND_URL)
+        self.assertEqual(path, expected_path)
+
+    def test_get_verify_location_from_course_id(self):
+        """
+        Test for the path to the IDV flow with a course ID
+        """
+        course = CourseFactory.create(org='Robot', number='999', display_name='Test Course')
+        path = IDVerificationService.get_verify_location(course.id)
+        expected_path = '{}/id-verification'.format(settings.ACCOUNT_MICROFRONTEND_URL)
+        self.assertEqual(path, expected_path + '?course_id=Robot/999/Test_Course')
+
+    def test_get_verify_location_from_string(self):
+        """
+        Test for the path to the IDV flow with a course key string
+        """
+        path = IDVerificationService.get_verify_location('course-v1:edX+DemoX+Demo_Course')
+        expected_path = '{}/id-verification'.format(settings.ACCOUNT_MICROFRONTEND_URL)
+        self.assertEqual(path, expected_path + '?course_id=course-v1%3AedX%2BDemoX%2BDemo_Course')
+
 
 @patch.dict(settings.VERIFY_STUDENT, FAKE_SETTINGS)
 @ddt.ddt


### PR DESCRIPTION
[MST-567](https://openedx.atlassian.net/browse/MST-567)

Related to https://github.com/edx/ecommerce/pull/3284 and https://github.com/edx/frontend-app-account/pull/360

Without encoding the course_id, `+` symbols in the query string are parsed into spaces when passed to the front end. IE `course-v1:edX+DemoX+Demo_Course` becomes `course-v1:edX DemoX Demo_Course`, causing a 400 error when the user tries to submit their ID verification photos.