### PR TITLE
[DO-NOT-MERGE] Remove LMS->indirect->CMS import chain

### DIFF
--- a/cms/djangoapps/contentstore/tests/test_signals.py
+++ b/cms/djangoapps/contentstore/tests/test_signals.py
@@ -46,13 +46,21 @@ class LockedTest(ModuleStoreTestCase):
             add_mock.assert_called_once_with(cache_key, "true", GRADING_POLICY_COUNTDOWN_SECONDS)
 
 
-class CourseOverviewSignalsTestCase(ModuleStoreTestCase):
+@ddt.ddt
+class CourseDeletedTestCase(ModuleStoreTestCase):
     """
-    Tests for CourseOverview signals.
+    Tests for course_deleted signals and side-effects
     """
     ENABLED_SIGNALS = ['course_deleted']
     TODAY = datetime.datetime.utcnow()
     NEXT_WEEK = TODAY + datetime.timedelta(days=7)
+
+    def setUp(self):
+        """
+        Add a student & teacher
+        """
+        super(CourseDeletedTestCase, self).setUp()
+        self.student = UserFactory()
 
     @ddt.data(ModuleStoreEnum.Type.mongo, ModuleStoreEnum.Type.split)
     def test_cache_invalidation(self, modulestore_type):

--- a/cms/djangoapps/contentstore/tests/test_signals.py
+++ b/cms/djangoapps/contentstore/tests/test_signals.py
@@ -114,6 +114,7 @@ class CourseDeletedTestCase(ModuleStoreTestCase):
         Create good courses, courses that won't load, and deleted courses which still have
         roles. Test course listing.
         """
+        # pylint: disable=protected-access
         mongo_store = modulestore()._get_modulestore_by_type(ModuleStoreEnum.Type.mongo)
         good_location = mongo_store.make_course_key('testOrg', 'testCourse', 'RunBabyRun')
         self._create_course_with_access_groups(good_location, default_store=ModuleStoreEnum.Type.mongo)

--- a/cms/djangoapps/contentstore/tests/test_signals.py
+++ b/cms/djangoapps/contentstore/tests/test_signals.py
@@ -1,13 +1,18 @@
 """Tests for verifying availability of resources for locking"""
 
 
+import datetime
 import ddt
 import six
 from mock import Mock, patch
 
 from cms.djangoapps.contentstore.signals.handlers import GRADING_POLICY_COUNTDOWN_SECONDS, handle_grading_policy_changed
 from common.djangoapps.student.models import CourseEnrollment
+from common.djangoapps.student.views import get_course_enrollments
 from common.djangoapps.student.tests.factories import UserFactory
+from openedx.core.djangoapps.content.course_overviews.models import CourseOverview
+from xmodule.modulestore import ModuleStoreEnum
+from xmodule.modulestore.django import modulestore
 from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
 from xmodule.modulestore.tests.factories import CourseFactory
 
@@ -39,3 +44,75 @@ class LockedTest(ModuleStoreTestCase):
         self.assertEqual(lock_available, compute_grades_async_mock.called)
         if lock_available:
             add_mock.assert_called_once_with(cache_key, "true", GRADING_POLICY_COUNTDOWN_SECONDS)
+
+
+class CourseOverviewSignalsTestCase(ModuleStoreTestCase):
+    """
+    Tests for CourseOverview signals.
+    """
+    ENABLED_SIGNALS = ['course_deleted']
+    TODAY = datetime.datetime.utcnow()
+    NEXT_WEEK = TODAY + datetime.timedelta(days=7)
+
+    @ddt.data(ModuleStoreEnum.Type.mongo, ModuleStoreEnum.Type.split)
+    def test_cache_invalidation(self, modulestore_type):
+        """
+        Tests that when a course is published or deleted, the corresponding
+        course_overview is removed from the cache.
+
+        Arguments:
+            modulestore_type (ModuleStoreEnum.Type): type of store to create the
+                course in.
+        """
+        with self.store.default_store(modulestore_type):
+            # Create a course where mobile_available is True.
+            course = CourseFactory.create(mobile_available=True, default_store=modulestore_type)
+            course_overview_1 = CourseOverview.get_from_id(course.id)
+            self.assertTrue(course_overview_1.mobile_available)
+
+            # Set mobile_available to False and update the course.
+            # This fires a course_published signal, which should be caught in signals.py, which should in turn
+            # delete the corresponding CourseOverview from the cache.
+            course.mobile_available = False
+            with self.store.branch_setting(ModuleStoreEnum.Branch.draft_preferred):
+                self.store.update_item(course, ModuleStoreEnum.UserID.test)
+
+            # Make sure that when we load the CourseOverview again, mobile_available is updated.
+            course_overview_2 = CourseOverview.get_from_id(course.id)
+            self.assertFalse(course_overview_2.mobile_available)
+
+            # Verify that when the course is deleted, the corresponding CourseOverview is deleted as well.
+            with self.assertRaises(CourseOverview.DoesNotExist):
+                self.store.delete_course(course.id, ModuleStoreEnum.UserID.test)
+                CourseOverview.get_from_id(course.id)
+
+    def _create_course_with_access_groups(self, course_location, metadata=None, default_store=None):
+        """
+        Create dummy course with 'CourseFactory' and enroll the student
+        """
+        metadata = {} if not metadata else metadata
+        course = CourseFactory.create(
+            org=course_location.org,
+            number=course_location.course,
+            run=course_location.run,
+            metadata=metadata,
+            default_store=default_store
+        )
+        CourseEnrollment.enroll(self.student, course.id)
+        return course
+
+    def test_course_listing_errored_deleted_courses(self):
+        """
+        Create good courses, courses that won't load, and deleted courses which still have
+        roles. Test course listing.
+        """
+        mongo_store = modulestore()._get_modulestore_by_type(ModuleStoreEnum.Type.mongo)
+        good_location = mongo_store.make_course_key('testOrg', 'testCourse', 'RunBabyRun')
+        self._create_course_with_access_groups(good_location, default_store=ModuleStoreEnum.Type.mongo)
+
+        course_location = mongo_store.make_course_key('testOrg', 'doomedCourse', 'RunBabyRun')
+        self._create_course_with_access_groups(course_location, default_store=ModuleStoreEnum.Type.mongo)
+        mongo_store.delete_course(course_location, ModuleStoreEnum.UserID.test)
+        courses_list = list(get_course_enrollments(self.student, None, []))
+        self.assertEqual(len(courses_list), 1, courses_list)
+        self.assertEqual(courses_list[0].course_id, good_location)

--- a/cms/djangoapps/contentstore/tests/test_signals.py
+++ b/cms/djangoapps/contentstore/tests/test_signals.py
@@ -51,7 +51,10 @@ class CourseDeletedTestCase(ModuleStoreTestCase):
     """
     Tests for course_deleted signals and side-effects
     """
-    ENABLED_SIGNALS = ['course_deleted']
+    ENABLED_SIGNALS = [
+        'course_deleted',
+        'course_published',
+    ]
     TODAY = datetime.datetime.utcnow()
     NEXT_WEEK = TODAY + datetime.timedelta(days=7)
 

--- a/common/djangoapps/student/tests/test_course_listing.py
+++ b/common/djangoapps/student/tests/test_course_listing.py
@@ -120,24 +120,6 @@ class TestCourseListing(ModuleStoreTestCase, MilestonesTestCaseMixin):
             courses_list = list(get_course_enrollments(self.student, None, []))
             self.assertEqual(courses_list, [])
 
-    def test_course_listing_errored_deleted_courses(self):
-        """
-        Create good courses, courses that won't load, and deleted courses which still have
-        roles. Test course listing.
-        """
-        mongo_store = modulestore()._get_modulestore_by_type(ModuleStoreEnum.Type.mongo)
-
-        good_location = mongo_store.make_course_key('testOrg', 'testCourse', 'RunBabyRun')
-        self._create_course_with_access_groups(good_location, default_store=ModuleStoreEnum.Type.mongo)
-
-        course_location = mongo_store.make_course_key('testOrg', 'doomedCourse', 'RunBabyRun')
-        self._create_course_with_access_groups(course_location, default_store=ModuleStoreEnum.Type.mongo)
-        mongo_store.delete_course(course_location, ModuleStoreEnum.UserID.test)
-
-        courses_list = list(get_course_enrollments(self.student, None, []))
-        self.assertEqual(len(courses_list), 1, courses_list)
-        self.assertEqual(courses_list[0].course_id, good_location)
-
     @mock.patch.dict("django.conf.settings.FEATURES", {'ENABLE_PREREQUISITE_COURSES': True})
     def test_course_listing_has_pre_requisite_courses(self):
         """

--- a/openedx/core/djangoapps/content/course_overviews/signals.py
+++ b/openedx/core/djangoapps/content/course_overviews/signals.py
@@ -33,19 +33,6 @@ def _listen_for_course_publish(sender, course_key, **kwargs):  # pylint: disable
     _check_for_course_changes(previous_course_overview, updated_course_overview)
 
 
-@receiver(SignalHandler.course_deleted)
-def _listen_for_course_delete(sender, course_key, **kwargs):  # pylint: disable=unused-argument
-    """
-    Catches the signal that a course has been deleted from Studio and
-    invalidates the corresponding CourseOverview cache entry if one exists.
-    """
-    CourseOverview.objects.filter(id=course_key).delete()
-    # import CourseAboutSearchIndexer inline due to cyclic import
-    from cms.djangoapps.contentstore.courseware_index import CourseAboutSearchIndexer
-    # Delete course entry from Course About Search_index
-    CourseAboutSearchIndexer.remove_deleted_items(course_key)
-
-
 def _check_for_course_changes(previous_course_overview, updated_course_overview):
     if previous_course_overview:
         _check_for_course_date_changes(previous_course_overview, updated_course_overview)

--- a/openedx/core/djangoapps/content/course_overviews/tests/test_signals.py
+++ b/openedx/core/djangoapps/content/course_overviews/tests/test_signals.py
@@ -37,39 +37,6 @@ class CourseOverviewSignalsTestCase(ModuleStoreTestCase):
         with check_mongo_calls(0):
             CourseOverview.get_from_id(course.id)
 
-    @ddt.data(ModuleStoreEnum.Type.mongo, ModuleStoreEnum.Type.split)
-    def test_cache_invalidation(self, modulestore_type):
-        """
-        Tests that when a course is published or deleted, the corresponding
-        course_overview is removed from the cache.
-
-        Arguments:
-            modulestore_type (ModuleStoreEnum.Type): type of store to create the
-                course in.
-        """
-        with self.store.default_store(modulestore_type):
-
-            # Create a course where mobile_available is True.
-            course = CourseFactory.create(mobile_available=True, default_store=modulestore_type)
-            course_overview_1 = CourseOverview.get_from_id(course.id)
-            self.assertTrue(course_overview_1.mobile_available)
-
-            # Set mobile_available to False and update the course.
-            # This fires a course_published signal, which should be caught in signals.py, which should in turn
-            # delete the corresponding CourseOverview from the cache.
-            course.mobile_available = False
-            with self.store.branch_setting(ModuleStoreEnum.Branch.draft_preferred):
-                self.store.update_item(course, ModuleStoreEnum.UserID.test)
-
-            # Make sure that when we load the CourseOverview again, mobile_available is updated.
-            course_overview_2 = CourseOverview.get_from_id(course.id)
-            self.assertFalse(course_overview_2.mobile_available)
-
-            # Verify that when the course is deleted, the corresponding CourseOverview is deleted as well.
-            with self.assertRaises(CourseOverview.DoesNotExist):
-                self.store.delete_course(course.id, ModuleStoreEnum.UserID.test)
-                CourseOverview.get_from_id(course.id)
-
     def assert_changed_signal_sent(self, field_name, initial_value, changed_value, mock_signal):
         course = CourseFactory.create(emit_signals=True, **{field_name: initial_value})
 


### PR DESCRIPTION
This signal handler listens for a signal from CMS
and handles it with common/shared code,
so it makes sense to live in CMS.