### PR TITLE
Add --summary-format=json option to XSS linter

### DIFF
--- a/scripts/xsslint/xsslint/main.py
+++ b/scripts/xsslint/xsslint/main.py
@@ -152,6 +152,11 @@ def main():
         help='Display the totals for each rule.'
     )
     parser.add_argument(
+        '--summary-format', dest='summary_format',
+        choices=['eslint', 'json'], default='eslint',
+        help='Choose the display format for the summary.'
+    )
+    parser.add_argument(
         '--verbose', dest='verbose', action='store_true',
         help='Print multiple lines where possible for additional context of violations.'
     )
@@ -166,6 +171,7 @@ def main():
     options = {
         'list_files': args.list_files,
         'rule_totals': args.rule_totals,
+        'summary_format': args.summary_format,
         'verbose': args.verbose,
         'skip_dirs': getattr(config, 'SKIP_DIRS', ())
     }

--- a/scripts/xsslint/xsslint/reporting.py
+++ b/scripts/xsslint/xsslint/reporting.py
@@ -3,6 +3,7 @@ Utility classes for reporting linter results.
 """
 
 
+import json
 import os
 import re
 
@@ -275,17 +276,43 @@ class SummaryResults(object):
 
         """
         if options['list_files'] is False:
-            if options['rule_totals']:
-                max_rule_id_len = max(len(rule_id) for rule_id in self.totals_by_rule)
-                print("", file=out)
-                for rule_id in sorted(self.totals_by_rule.keys()):
-                    padding = " " * (max_rule_id_len - len(rule_id))
-                    print("{}: {}{} violations".format(rule_id, padding, self.totals_by_rule[rule_id]), file=out)
-                print("", file=out)
+            if options['summary_format'] == 'json':
+                self._print_json_format(options, out)
+            else:
+                self._print_eslint_format(options, out)
 
-            # matches output of eslint for simplicity
+    def _print_eslint_format(self, options, out):
+        """
+        Implementation of print_results with eslint-style output.
+        """
+        if options['rule_totals']:
+            max_rule_id_len = max(len(rule_id) for rule_id in self.totals_by_rule)
             print("", file=out)
-            print("{} violations total".format(self.total_violations), file=out)
+            for rule_id in sorted(self.totals_by_rule.keys()):
+                padding = " " * (max_rule_id_len - len(rule_id))
+                print("{}: {}{} violations".format(rule_id, padding, self.totals_by_rule[rule_id]), file=out)
+            print("", file=out)
+
+        # matches output of eslint for simplicity
+        print("", file=out)
+        print("{} violations total".format(self.total_violations), file=out)
+
+    def _print_json_format(self, options, out):
+        """
+        Implementation of print_results with JSON output.
+        """
+        print("", file=out)
+        print("Violation counts:", file=out)
+        data = {'rules': self.totals_by_rule}
+        if options['rule_totals']:
+            data['total'] = self.total_violations
+        json.dump(data, fp=out, indent=4, sort_keys=True)
+        print("", file=out)
+        print(
+            "If you've fixed some XSS issues and these numbers have gone down, "
+            "you can use this to update scripts/xsslint_thresholds.json",
+            file=out
+        )
 
 
 class FileResults(object):


### PR DESCRIPTION
This will simplify updating of the linter thresholds file after XSS linter
violations are addressed.