### PR TITLE
Test edx-sga on Python 3.8

### DIFF
--- a/requirements/edx/base.in
+++ b/requirements/edx/base.in
@@ -87,7 +87,7 @@ edx-proctoring>=2.0.1
 edx-proctoring-proctortrack==1.0.5  # Intentionally and permanently pinned to ensure code changes are reviewed
 edx-rest-api-client
 edx-search
-edx-sga
+-e git+https://github.com/mzulqarnain1/edx-sga.git@437a3d58fe882fd0b7536f895f835564c4db08d7#egg=edx-sga==1.0
 edx-submissions
 edx-toggles                         # Feature toggles management
 edx-user-state-client

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -109,7 +109,7 @@ edx-proctoring==2.5.1     # via -r requirements/edx/base.in, edx-proctoring-proc
 edx-rbac==1.3.3           # via edx-enterprise
 edx-rest-api-client==5.2.1  # via -r requirements/edx/base.in, edx-enterprise, edx-proctoring
 edx-search==2.0.1         # via -r requirements/edx/base.in
-edx-sga==0.13.1           # via -r requirements/edx/base.in
+-e git+https://github.com/mzulqarnain1/edx-sga.git@437a3d58fe882fd0b7536f895f835564c4db08d7#egg=edx-sga==1.0
 edx-submissions==3.2.3    # via -r requirements/edx/base.in, ora2
 edx-tincan-py35==0.0.9    # via edx-enterprise
 edx-toggles==1.2.0        # via -c requirements/edx/../constraints.txt, -r requirements/edx/base.in, edx-completion, ora2

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -121,7 +121,7 @@ edx-proctoring==2.5.1     # via -r requirements/edx/testing.txt, edx-proctoring-
 edx-rbac==1.3.3           # via -r requirements/edx/testing.txt, edx-enterprise
 edx-rest-api-client==5.2.1  # via -r requirements/edx/testing.txt, edx-enterprise, edx-proctoring
 edx-search==2.0.1         # via -r requirements/edx/testing.txt
-edx-sga==0.13.1           # via -r requirements/edx/testing.txt
+-e git+https://github.com/mzulqarnain1/edx-sga.git@437a3d58fe882fd0b7536f895f835564c4db08d7#egg=edx-sga==1.0
 edx-sphinx-theme==1.5.0   # via -r requirements/edx/development.in
 edx-submissions==3.2.3    # via -r requirements/edx/testing.txt, ora2
 edx-tincan-py35==0.0.9    # via -r requirements/edx/testing.txt, edx-enterprise

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -118,7 +118,7 @@ edx-proctoring==2.5.1     # via -r requirements/edx/base.txt, edx-proctoring-pro
 edx-rbac==1.3.3           # via -r requirements/edx/base.txt, edx-enterprise
 edx-rest-api-client==5.2.1  # via -r requirements/edx/base.txt, edx-enterprise, edx-proctoring
 edx-search==2.0.1         # via -r requirements/edx/base.txt
-edx-sga==0.13.1           # via -r requirements/edx/base.txt
+-e git+https://github.com/mzulqarnain1/edx-sga.git@437a3d58fe882fd0b7536f895f835564c4db08d7#egg=edx-sga==1.0
 edx-submissions==3.2.3    # via -r requirements/edx/base.txt, ora2
 edx-tincan-py35==0.0.9    # via -r requirements/edx/base.txt, edx-enterprise
 edx-toggles==1.2.0        # via -c requirements/edx/../constraints.txt, -r requirements/edx/base.txt, edx-completion, ora2


### PR DESCRIPTION
Testing changes in this PR https://github.com/mitodl/edx-sga/pull/290 in which we upgraded `edx-sga` to use Python 3.8.