### PR TITLE
Constrain cryptography to <3.3 because Python 3.5 support was dropped

### DIFF
--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -11,6 +11,9 @@
 # celery 5.0 has dropped python3.5 support.
 celery<5.0
 
+# cryptography 3.3 has dropped python3.5 support.
+cryptography<3.3
+
 # Stay on the latest LTS release of Django
 Django<2.3
 

--- a/requirements/edx-sandbox/py35.txt
+++ b/requirements/edx-sandbox/py35.txt
@@ -9,7 +9,7 @@ common/lib/symmath  # via -r requirements/edx-sandbox/py35.in
 cffi==1.14.4              # via -r requirements/edx-sandbox/shared.txt, cryptography
 chem==1.2.0               # via -r requirements/edx-sandbox/py35.in
 click==7.1.2              # via -r requirements/edx-sandbox/shared.txt, nltk
-cryptography==3.3.1       # via -r requirements/edx-sandbox/shared.txt
+cryptography==3.2.1       # via -c requirements/edx-sandbox/../constraints.txt, -r requirements/edx-sandbox/shared.txt
 cycler==0.10.0            # via matplotlib
 decorator==4.4.2          # via networkx
 joblib==0.14.1            # via -c requirements/edx-sandbox/../constraints.txt, -r requirements/edx-sandbox/shared.txt, nltk
@@ -20,7 +20,7 @@ matplotlib==2.2.4         # via -c requirements/edx-sandbox/../constraints.txt, 
 mpmath==1.1.0             # via sympy
 networkx==2.2             # via -r requirements/edx-sandbox/py35.in
 nltk==3.5                 # via -r requirements/edx-sandbox/shared.txt, chem
-numpy==1.16.5             # via -c requirements/edx-sandbox/../constraints.txt, -r requirements/edx-sandbox/py35.in, chem, matplotlib, openedx-calc, scipy
+numpy==1.16.5             # via -c requirements/edx-sandbox/../constraints.txt, -r requirements/edx-sandbox/py35.in, chem, matplotlib, openedx-calc
 openedx-calc==1.0.9       # via -r requirements/edx-sandbox/py35.in
 pycparser==2.20           # via -r requirements/edx-sandbox/shared.txt, cffi
 pyparsing==2.2.0          # via -r requirements/edx-sandbox/py35.in, chem, matplotlib, openedx-calc

--- a/requirements/edx-sandbox/shared.txt
+++ b/requirements/edx-sandbox/shared.txt
@@ -6,7 +6,7 @@
 #
 cffi==1.14.4              # via cryptography
 click==7.1.2              # via nltk
-cryptography==3.3.1       # via -r requirements/edx-sandbox/shared.in
+cryptography==3.2.1       # via -c requirements/edx-sandbox/../constraints.txt, -r requirements/edx-sandbox/shared.in
 joblib==0.14.1            # via -c requirements/edx-sandbox/../constraints.txt, nltk
 lxml==4.5.0               # via -c requirements/edx-sandbox/../constraints.txt, -r requirements/edx-sandbox/shared.in
 nltk==3.5                 # via -r requirements/edx-sandbox/shared.in

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -42,7 +42,7 @@ contextlib2==0.6.0.post1  # via -r requirements/edx/base.in
 coreapi==2.3.3            # via drf-yasg
 coreschema==0.0.4         # via coreapi, drf-yasg
 crowdsourcehinter-xblock==0.6  # via -r requirements/edx/base.in
-cryptography==3.3.1       # via -r requirements/edx/../edx-sandbox/shared.txt, django-fernet-fields, edx-enterprise, pyjwt, social-auth-core
+cryptography==3.2.1       # via -c requirements/edx/../constraints.txt, -r requirements/edx/../edx-sandbox/shared.txt, django-fernet-fields, edx-enterprise, pyjwt, social-auth-core
 cssutils==1.0.2           # via pynliner
 ddt==1.4.1                # via xblock-drag-and-drop-v2, xblock-poll
 decorator==4.4.2          # via pycontracts

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -49,7 +49,7 @@ coreschema==0.0.4         # via -r requirements/edx/testing.txt, coreapi, drf-ya
 coverage==5.3             # via -r requirements/edx/testing.txt, pytest-cov
 git+https://github.com/nedbat/coverage_pytest_plugin.git@29de030251471e200ff255eb9e549218cd60e872#egg=coverage_pytest_plugin==0.0  # via -r requirements/edx/testing.txt
 crowdsourcehinter-xblock==0.6  # via -r requirements/edx/testing.txt
-cryptography==3.3.1       # via -r requirements/edx/testing.txt, django-fernet-fields, edx-enterprise, pyjwt, social-auth-core
+cryptography==3.2.1       # via -c requirements/edx/../constraints.txt, -r requirements/edx/testing.txt, django-fernet-fields, edx-enterprise, pyjwt, social-auth-core
 cssselect==1.1.0          # via -r requirements/edx/testing.txt, pyquery
 cssutils==1.0.2           # via -r requirements/edx/testing.txt, pynliner
 ddt==1.4.1                # via -r requirements/edx/testing.txt, xblock-drag-and-drop-v2, xblock-poll

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -48,7 +48,7 @@ coreschema==0.0.4         # via -r requirements/edx/base.txt, coreapi, drf-yasg
 coverage==5.3             # via -r requirements/edx/coverage.txt, pytest-cov
 git+https://github.com/nedbat/coverage_pytest_plugin.git@29de030251471e200ff255eb9e549218cd60e872#egg=coverage_pytest_plugin==0.0  # via -r requirements/edx/testing.in
 crowdsourcehinter-xblock==0.6  # via -r requirements/edx/base.txt
-cryptography==3.3.1       # via -r requirements/edx/base.txt, django-fernet-fields, edx-enterprise, pyjwt, social-auth-core
+cryptography==3.2.1       # via -c requirements/edx/../constraints.txt, -r requirements/edx/base.txt, django-fernet-fields, edx-enterprise, pyjwt, social-auth-core
 cssselect==1.1.0          # via -r requirements/edx/testing.in, pyquery
 cssutils==1.0.2           # via -r requirements/edx/base.txt, pynliner
 ddt==1.4.1                # via -r requirements/edx/base.txt, -r requirements/edx/testing.in, xblock-drag-and-drop-v2, xblock-poll


### PR DESCRIPTION
We upgraded it here: https://github.com/edx/edx-platform/commit/3d797e12dfb1f6724b87b5c2f6356b04082fd9f5#diff-786d70866021f02a744cb1e02ecfa61f2ce4cf5e7c5968bdd84117c9adeb2218R12

This release drops Py3.5 support: https://pypi.org/project/cryptography/3.3/

Failing build_ami: https://gocd.tools.edx.org/go/tab/build/detail/build_edxapp_amis/2006/run_play/1/prod_edx

(will push an upgrade commit as soon as `make upgrade` finishes)