### PR TITLE
Serve assets using static storage

### DIFF
--- a/openedx/features/content_type_gating/templates/content_type_gating/access_denied_message.html
+++ b/openedx/features/content_type_gating/templates/content_type_gating/access_denied_message.html
@@ -17,5 +17,6 @@
         </span>
         {% endif %}
     </div>
-    <img src="/static/images/edx-verified-mini-cert.png">
+    <img src="{% static 'images/edx-verified-mini-cert.png' %}"
+         alt="{% trans 'Example of a verified certificate' as tmsg %}{{ tmsg | force_escape }}">
 </div>

--- a/openedx/features/course_experience/templates/course_experience/course-home-fragment.html
+++ b/openedx/features/course_experience/templates/course_experience/course-home-fragment.html
@@ -140,7 +140,9 @@ from openedx.features.course_experience.course_tools import HttpMethod
             % if upgrade_url and upgrade_price:
                 <div class="section section-upgrade course-home-sidebar-upgrade ${'discount' if has_discount else 'no-discount'}">
                     <h3 class="hd hd-6">${_("Pursue a verified certificate")}</h3>
-                        <img src="https://courses.edx.org/static/images/edx-verified-mini-cert.png" alt="">
+                        <img src="${static.url('images/edx-verified-mini-cert.png')}"
+                             alt="${_('Sample verified certificate with your name, the course title, the logo of the institution and the signatures of the instructors for this course.')}" />
+
                         <div class="upgrade-container">
                             <p>
                                 <a id="green_upgrade" class="btn-brand btn-upgrade"


### PR DESCRIPTION
This PR updates the way these static assets are served to enable them for overriding in comprehensive theming. 
This isn't the right way to get the static URL for the image, because it won't include the MD5 hash, and hence it won't be cached.

For now, this doesn't change anything on prod, spinning sandbox for review.

Tested on Sandbox: 
https://awaisdar001.sandbox.edx.org/courses/course-v1:edX+DemoX+Demo_Course/course/

Also tested on edx.org-next:
https://awaisdar001.sandbox.edx.org/courses/course-v1:edX+DemoX+Demo_Course/courseware/interactive_demonstrations/basic_questions/?site_theme=edx.org-next


https://awaisdar001.sandbox.edx.org/courses/course-v1:edX+DemoX+Demo_Course/course/?site_theme=edx.org-next


## Course Dates Upgrade: 

<img width="411" alt="Screen Shot 2020-12-11 at 10 20 22 PM" src="https://user-images.githubusercontent.com/4252738/101934206-1205c780-3bff-11eb-97cb-ddfb6c407f77.png">

## Course Sock: 

<img width="1351" alt="Screen Shot 2020-12-11 at 10 20 45 PM" src="https://user-images.githubusercontent.com/4252738/101934238-1fbb4d00-3bff-11eb-85fe-0d2b3a61b68a.png">

 ## Feature based enrollment. 
<img width="1139" alt="Screen Shot 2020-12-11 at 10 21 02 PM" src="https://user-images.githubusercontent.com/4252738/101934273-2b0e7880-3bff-11eb-9157-0d05b1daa608.png">

FYI -- | @marcotuts | @sethmccann |