### PR TITLE
TNL-7185: Send data, not rendered HTML to the learning MFE

### DIFF
--- a/lms/djangoapps/course_home_api/outline/v1/serializers.py
+++ b/lms/djangoapps/course_home_api/outline/v1/serializers.py
@@ -109,6 +109,7 @@ class OutlineTabSerializer(DatesBannerSerializerMixin, VerifiedModeSerializerMix
     """
     Serializer for the Outline Tab
     """
+    access_expiration = serializers.DictField()
     course_blocks = CourseBlockSerializer()
     course_expired_html = serializers.CharField()
     course_goals = CourseGoalsSerializer()
@@ -117,6 +118,7 @@ class OutlineTabSerializer(DatesBannerSerializerMixin, VerifiedModeSerializerMix
     enroll_alert = EnrollAlertSerializer()
     handouts_html = serializers.CharField()
     has_ended = serializers.BooleanField()
+    offer = serializers.DictField()
     offer_html = serializers.CharField()
     resume_course = ResumeCourseSerializer()
     welcome_message_html = serializers.CharField()

--- a/lms/djangoapps/courseware/tests/test_views.py
+++ b/lms/djangoapps/courseware/tests/test_views.py
@@ -269,8 +269,8 @@ class IndexQueryTestCase(ModuleStoreTestCase):
     NUM_PROBLEMS = 20
 
     @ddt.data(
-        (ModuleStoreEnum.Type.mongo, 10, 171),
-        (ModuleStoreEnum.Type.split, 4, 167),
+        (ModuleStoreEnum.Type.mongo, 10, 173),
+        (ModuleStoreEnum.Type.split, 4, 169),
     )
     @ddt.unpack
     def test_index_query_counts(self, store_type, expected_mongo_query_count, expected_mysql_query_count):

--- a/openedx/core/djangoapps/courseware_api/serializers.py
+++ b/openedx/core/djangoapps/courseware_api/serializers.py
@@ -78,11 +78,13 @@ class CourseInfoSerializer(serializers.Serializer):  # pylint: disable=abstract-
     Compare this with CourseDetailSerializer.
     """
 
+    access_expiration = serializers.DictField()
     can_show_upgrade_sock = serializers.BooleanField()
     content_type_gating_enabled = serializers.BooleanField()
     course_expired_message = serializers.CharField()
     effort = serializers.CharField()
     end = serializers.DateTimeField()
+    enrollment = serializers.DictField()
     enrollment_start = serializers.DateTimeField()
     enrollment_end = serializers.DateTimeField()
     id = serializers.CharField()  # pylint: disable=invalid-name
@@ -90,6 +92,7 @@ class CourseInfoSerializer(serializers.Serializer):  # pylint: disable=abstract-
     media = _CourseApiMediaCollectionSerializer(source='*')
     name = serializers.CharField(source='display_name_with_default_escaped')
     number = serializers.CharField(source='display_number_with_default')
+    offer = serializers.DictField()
     offer_html = serializers.CharField()
     org = serializers.CharField(source='display_org_with_default')
     related_programs = CourseProgramSerializer(many=True)
@@ -98,8 +101,8 @@ class CourseInfoSerializer(serializers.Serializer):  # pylint: disable=abstract-
     start_display = serializers.CharField()
     start_type = serializers.CharField()
     pacing = serializers.CharField()
-    enrollment = serializers.DictField()
     tabs = serializers.ListField()
+    user_timezone = serializers.CharField()
     verified_mode = serializers.DictField()
     show_calculator = serializers.BooleanField()
     original_user_is_staff = serializers.BooleanField()

--- a/openedx/features/course_experience/tests/views/test_course_home.py
+++ b/openedx/features/course_experience/tests/views/test_course_home.py
@@ -208,7 +208,7 @@ class TestCourseHomePage(CourseHomePageTestCase):
 
         # Fetch the view and verify the query counts
         # TODO: decrease query count as part of REVO-28
-        with self.assertNumQueries(73, table_blacklist=QUERY_COUNT_TABLE_BLACKLIST):
+        with self.assertNumQueries(75, table_blacklist=QUERY_COUNT_TABLE_BLACKLIST):
             with check_mongo_calls(4):
                 url = course_home_url(self.course)
                 self.client.get(url)
@@ -428,7 +428,7 @@ class TestCourseHomePageAccess(CourseHomePageTestCase):
              </div>'''.format(
             discount_expiration_date=discount_expiration_date,
             percentage=percentage,
-            strikeout_price=HTML(format_strikeout_price(user, self.course, check_for_discount=False)[0]),
+            strikeout_price=HTML(format_strikeout_price(user, self.course)[0]),
             upgrade_link=upgrade_link
         )
 

--- a/openedx/features/discounts/tests/test_utils.py
+++ b/openedx/features/discounts/tests/test_utils.py
@@ -1,11 +1,21 @@
 """
 Tests of the openedx.features.discounts.utils module.
 """
-from unittest import TestCase
 from mock import patch, Mock
-import six
 
 import ddt
+import six
+from django.contrib.auth.models import AnonymousUser
+from django.test import TestCase
+from django.utils.translation import override as override_lang
+from edx_toggles.toggles.testutils import override_waffle_flag
+
+from common.djangoapps.course_modes.models import CourseMode
+from common.djangoapps.course_modes.tests.factories import CourseModeFactory
+from common.djangoapps.student.models import CourseEnrollment
+from common.djangoapps.student.tests.factories import UserFactory
+from openedx.core.djangoapps.content.course_overviews.tests.factories import CourseOverviewFactory
+from openedx.features.discounts.applicability import DISCOUNT_APPLICABILITY_FLAG, get_discount_expiration_date
 
 from .. import utils
 
@@ -45,3 +55,39 @@ class TestStrikeoutPrice(TestCase):
             u"<del aria-hidden='true'><span class='price original'>{original_price}</span></del>"
         ).format(original_price=formatted_base_price, discount_price=final_price)
         assert has_discount
+
+
+@override_waffle_flag(DISCOUNT_APPLICABILITY_FLAG, active=True)
+class TestOfferData(TestCase):
+    """
+    Tests of the generate_offer_data call.
+    """
+    def setUp(self):
+        super().setUp()
+
+        self.user = UserFactory()
+        self.overview = CourseOverviewFactory()
+        CourseModeFactory(course_id=self.overview.id, mode_slug=CourseMode.AUDIT)
+        CourseModeFactory(course_id=self.overview.id, mode_slug=CourseMode.VERIFIED, min_price=149)
+        CourseEnrollment.enroll(self.user, self.overview.id, CourseMode.AUDIT)
+
+    def test_happy_path(self):
+        self.assertEqual(utils.generate_offer_data(self.user, self.overview), {
+            'code': 'EDXWELCOME',
+            'expiration_date': get_discount_expiration_date(self.user, self.overview),
+            'original_price': '$149',
+            'discounted_price': '$126.65',
+            'percentage': 15,
+            'upgrade_url': '/dashboard',
+        })
+
+    def test_spanish_code(self):
+        with override_lang('es-419'):
+            self.assertEqual(utils.generate_offer_data(self.user, self.overview)['code'], 'BIENVENIDOAEDX')
+
+    def test_anonymous(self):
+        self.assertIsNone(utils.generate_offer_data(AnonymousUser(), self.overview))
+
+    @patch('openedx.features.discounts.utils.can_receive_discount', return_value=False)
+    def test_no_discount(self, _mock):
+        self.assertIsNone(utils.generate_offer_data(self.user, self.overview))

--- a/openedx/features/discounts/utils.py
+++ b/openedx/features/discounts/utils.py
@@ -29,7 +29,7 @@ def offer_banner_wrapper(user, block, view, frag, context):  # pylint: disable=W
     A wrapper that prepends the First Purchase Discount banner if
     the user hasn't upgraded yet.
     """
-    if block.category != "vertical":
+    if block.category != 'vertical':
         return frag
 
     offer_banner_fragment = get_first_purchase_offer_banner_fragment_from_key(
@@ -50,52 +50,111 @@ def offer_banner_wrapper(user, block, view, frag, context):  # pylint: disable=W
     return offer_banner_fragment
 
 
-def format_strikeout_price(user, course, base_price=None, check_for_discount=True):
+def _get_discount_prices(user, course, assume_discount=False):
+    """
+    Return a tuple of (original, discounted, percentage)
+
+    If assume_discount is True, we do not check if a discount applies and just go ahead with discount math anyway.
+
+    Each returned price is a string with appropriate currency formatting added already.
+    discounted and percentage will be returned as None if no discount is applicable.
+    """
+    base_price = get_course_prices(course, verified_only=True)[0]
+    can_discount = assume_discount or can_receive_discount(user, course)
+
+    if can_discount:
+        percentage = discount_percentage(course)
+
+        discounted_price = base_price * ((100.0 - percentage) / 100)
+        if discounted_price:  # leave 0 prices alone, as format_course_price below will adjust to 'Free'
+            if discounted_price == int(discounted_price):
+                discounted_price = '{:0.0f}'.format(discounted_price)
+            else:
+                discounted_price = '{:0.2f}'.format(discounted_price)
+
+        return format_course_price(base_price), format_course_price(discounted_price), percentage
+    else:
+        return format_course_price(base_price), None, None
+
+
+def generate_offer_data(user, course):
+    """
+    Create a dictionary of information about the current discount offer.
+
+    Used by serializers to pass onto frontends and by the LMS locally to generate HTML for template rendering.
+
+    Returns a dictionary of data, or None if no offer is applicable.
+    """
+    if not user or not course or user.is_anonymous:
+        return None
+
+    ExperimentData.objects.get_or_create(
+        user=user, experiment_id=REV1008_EXPERIMENT_ID, key=str(course),
+        defaults={
+            'value': datetime.now(tz=pytz.UTC).strftime('%Y-%m-%d %H:%M:%S%z'),
+        },
+    )
+
+    expiration_date = get_discount_expiration_date(user, course)
+    if not expiration_date:
+        return None
+
+    if not can_receive_discount(user, course, discount_expiration_date=expiration_date):
+        return None
+
+    original, discounted, percentage = _get_discount_prices(user, course, assume_discount=True)
+
+    return {
+        'code': 'BIENVENIDOAEDX' if get_language() == 'es-419' else 'EDXWELCOME',
+        'expiration_date': expiration_date,
+        'original_price': original,
+        'discounted_price': discounted,
+        'percentage': percentage,
+        'upgrade_url': verified_upgrade_deadline_link(user, course=course),
+    }
+
+
+def _format_discounted_price(original_price, discount_price):
+    """Helper method that returns HTML containing a strikeout price with discount."""
+    # Separate out this string because it has a lot of syntax but no actual information for
+    # translators to translate
+    formatted_discount_price = HTML(
+        '{s_dp}{discount_price}{e_p} {s_st}{s_op}{original_price}{e_p}{e_st}'
+    ).format(
+        original_price=original_price,
+        discount_price=discount_price,
+        s_op=HTML("<span class='price original'>"),
+        s_dp=HTML("<span class='price discount'>"),
+        s_st=HTML("<del aria-hidden='true'>"),
+        e_p=HTML('</span>'),
+        e_st=HTML('</del>'),
+    )
+
+    return (
+        HTML(_(
+            '{s_sr}Original price: {s_op}{original_price}{e_p}, discount price: {e_sr}{formatted_discount_price}'
+        )).format(
+            original_price=original_price,
+            formatted_discount_price=formatted_discount_price,
+            s_sr=HTML("<span class='sr-only'>"),
+            s_op=HTML("<span class='price original'>"),
+            e_p=HTML('</span>'),
+            e_sr=HTML('</span>'),
+        )
+    )
+
+
+def format_strikeout_price(user, course):
     """
     Return a formatted price, including a struck-out original price if a discount applies, and also
         whether a discount was applied, as the tuple (formatted_price, has_discount).
     """
-    if base_price is None:
-        base_price = get_course_prices(course, verified_only=True)[0]
+    original_price, discounted_price, _ = _get_discount_prices(user, course)
 
-    original_price = format_course_price(base_price)
-
-    if not check_for_discount or can_receive_discount(user, course):
-        discount_price = base_price * ((100.0 - discount_percentage(course)) / 100)
-        if discount_price == int(discount_price):
-            discount_price = format_course_price("{:0.0f}".format(discount_price))
-        else:
-            discount_price = format_course_price("{:0.2f}".format(discount_price))
-
-        # Separate out this string because it has a lot of syntax but no actual information for
-        # translators to translate
-        formatted_discount_price = HTML(
-            u"{s_dp}{discount_price}{e_p} {s_st}{s_op}{original_price}{e_p}{e_st}"
-        ).format(
-            original_price=original_price,
-            discount_price=discount_price,
-            s_op=HTML("<span class='price original'>"),
-            s_dp=HTML("<span class='price discount'>"),
-            s_st=HTML("<del aria-hidden='true'>"),
-            e_p=HTML("</span>"),
-            e_st=HTML("</del>"),
-        )
-
-        return (
-            HTML(_(
-                u"{s_sr}Original price: {s_op}{original_price}{e_p}, discount price: {e_sr}{formatted_discount_price}"
-            )).format(
-                original_price=original_price,
-                formatted_discount_price=formatted_discount_price,
-                s_sr=HTML("<span class='sr-only'>"),
-                s_op=HTML("<span class='price original'>"),
-                e_p=HTML("</span>"),
-                e_sr=HTML("</span>"),
-            ),
-            True
-        )
+    if discounted_price is None:
+        return HTML("<span class='price'>{}</span>").format(original_price), False
     else:
-        return (HTML(u"<span class='price'>{}</span>").format(original_price), False)
+        return _format_discounted_price(original_price, discounted_price), True
 
 
 def generate_offer_html(user, course):
@@ -105,44 +164,33 @@ def generate_offer_html(user, course):
     Returns a openedx.core.djangolib.markup.HTML object, or None if the user
     should not be shown an offer message.
     """
-    if user and not user.is_anonymous and course:
-        now = datetime.now(tz=pytz.UTC).strftime(u"%Y-%m-%d %H:%M:%S%z")
-        saw_banner = ExperimentData.objects.filter(
-            user=user, experiment_id=REV1008_EXPERIMENT_ID, key=str(course)
-        )
-        if not saw_banner:
-            ExperimentData.objects.create(
-                user=user, experiment_id=REV1008_EXPERIMENT_ID, key=str(course), value=now
-            )
-        discount_expiration_date = get_discount_expiration_date(user, course)
-        if (discount_expiration_date and
-                can_receive_discount(user=user, course=course, discount_expiration_date=discount_expiration_date)):
-            # Translator: xgettext:no-python-format
-            offer_message = _(u'{banner_open} Upgrade by {discount_expiration_date} and save {percentage}% '
-                              u'[{strikeout_price}]{span_close}{br}Use code {b_open}{code}{b_close} at checkout! '
-                              u'{a_open}Upgrade Now{a_close}{div_close}')
+    data = generate_offer_data(user, course)
+    if not data:
+        return None
 
-            message_html = HTML(offer_message).format(
-                a_open=HTML(u'<a id="welcome" href="{upgrade_link}">').format(
-                    upgrade_link=verified_upgrade_deadline_link(user=user, course=course)
-                ),
-                a_close=HTML('</a>'),
-                b_open=HTML('<b>'),
-                code=Text('BIENVENIDOAEDX') if get_language() == 'es-419' else Text('EDXWELCOME'),
-                b_close=HTML('</b>'),
-                br=HTML('<br>'),
-                banner_open=HTML(
-                    '<div class="first-purchase-offer-banner" role="note">'
-                    '<span class="first-purchase-offer-banner-bold"><b>'
-                ),
-                discount_expiration_date=discount_expiration_date.strftime(u'%B %d'),
-                percentage=discount_percentage(course),
-                span_close=HTML('</b></span>'),
-                div_close=HTML('</div>'),
-                strikeout_price=HTML(format_strikeout_price(user, course, check_for_discount=False)[0])
-            )
-            return message_html
-    return None
+    # Translator: xgettext:no-python-format
+    offer_message = _('{banner_open} Upgrade by {discount_expiration_date} and save {percentage}% '
+                      '[{strikeout_price}]{span_close}{br}Use code {b_open}{code}{b_close} at checkout! '
+                      '{a_open}Upgrade Now{a_close}{div_close}')
+
+    message_html = HTML(offer_message).format(
+        a_open=HTML('<a id="welcome" href="{upgrade_link}">').format(upgrade_link=data['upgrade_url']),
+        a_close=HTML('</a>'),
+        b_open=HTML('<b>'),
+        code=Text(data['code']),
+        b_close=HTML('</b>'),
+        br=HTML('<br>'),
+        banner_open=HTML(
+            '<div class="first-purchase-offer-banner" role="note">'
+            '<span class="first-purchase-offer-banner-bold"><b>'
+        ),
+        discount_expiration_date=data['expiration_date'].strftime('%B %d'),
+        percentage=data['percentage'],
+        span_close=HTML('</b></span>'),
+        div_close=HTML('</div>'),
+        strikeout_price=_format_discounted_price(data['original_price'], data['discounted_price']),
+    )
+    return message_html
 
 
 def get_first_purchase_offer_banner_fragment(user, course):
@@ -166,7 +214,7 @@ def get_first_purchase_offer_banner_fragment_from_key(user, course_key):
     shouldn't show a first purchase offer message for this user.
     """
     request_cache = RequestCache('get_first_purchase_offer_banner_fragment_from_key')
-    cache_key = u'html:{},{}'.format(user.id, course_key)
+    cache_key = 'html:{},{}'.format(user.id, course_key)
     cache_response = request_cache.get_cached_response(cache_key)
     if cache_response.is_found:
         cached_html = cache_response.value


### PR DESCRIPTION
Specifically, send data versions of course_expired_message and offer_html.

The rendered HTML is still being sent for now, until the learning MFE is updated to consume the data objects.

https://openedx.atlassian.net/browse/TNL-7185

Related to https://github.com/edx/frontend-app-learning/pull/306