### PR TITLE
AA-509: Dates widget link styling

### DIFF
--- a/openedx/features/course_experience/templates/course_experience/dates-summary.html
+++ b/openedx/features/course_experience/templates/course_experience/dates-summary.html
@@ -26,7 +26,7 @@ from django.utils.translation import ugettext as _
             % endif
             % if course_date.link and course_date.link_text:
                 <div class="date-summary-link">
-                    <a id="course_home_dates" class="btn btn-outline-primary" href="${course_date.link}">${course_date.link_text}</a>
+                    <a id="course_home_dates" href="${course_date.link}">${course_date.link_text}</a>
                 </div>
             % endif
         </div>


### PR DESCRIPTION
Removed button styling from dates widget
<img width="1519" alt="Screen Shot 2020-12-11 at 5 03 02 PM" src="https://user-images.githubusercontent.com/25124041/101959154-c6d5bf80-3bd2-11eb-8331-99a5355da66c.png">
