### PR TITLE
Revert celery fork from requirements

### DIFF
--- a/requirements/edx/base.in
+++ b/requirements/edx/base.in
@@ -34,6 +34,7 @@ boto==2.39.0                        # Deprecated version of the AWS SDK; we shou
 boto3==1.4.8                        # Amazon Web Services SDK for Python
 botocore==1.8.17                    # via boto3, s3transfer
 bridgekeeper                        # Used for determining permissions for courseware.
+celery                              # Asynchronous task execution library
 chem                                # A helper library for chemistry calculations
 contextlib2                         # We need contextlib2.ExitStack so we can stop using contextlib.nested which doesn't exist in python 3
 crowdsourcehinter-xblock

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -6,7 +6,6 @@
 #
 -e git+https://github.com/edx/acid-block.git@758855a67d2f12bd74db4d5e7a0862d6e65f079c#egg=acid-xblock  # via -r requirements/edx/github.in
 -e common/lib/capa  # via -r requirements/edx/local.in
--e git+https://github.com/edx/celery.git@cb85b6ca26cad14fee494342e9c2782d81119223#egg=celery  # via -r requirements/edx/github.in
 -e git+https://github.com/edx/codejail.git@3.1.3#egg=codejail==3.1.3  # via -r requirements/edx/github.in
 -e git+https://github.com/edx/django-wiki.git@0.1.1#egg=django-wiki  # via -r requirements/edx/github.in
 -e git+https://github.com/edx/DoneXBlock.git@2.0.3#egg=done-xblock  # via -r requirements/edx/github.in
@@ -32,6 +31,7 @@ boto3==1.4.8              # via -r requirements/edx/base.in, django-ses, fs-s3fs
 boto==2.39.0              # via -r requirements/edx/base.in, edxval
 botocore==1.8.17          # via -r requirements/edx/base.in, boto3, s3transfer
 bridgekeeper==0.9         # via -r requirements/edx/base.in
+celery==4.4.7             # via -c requirements/edx/../constraints.txt, -r requirements/edx/base.in, django-celery-results, django-user-tasks, edx-celeryutils, edx-enterprise, event-tracking
 certifi==2020.12.5        # via -r requirements/edx/paver.txt, elasticsearch, requests
 cffi==1.14.4              # via -r requirements/edx/../edx-sandbox/shared.txt, cryptography
 chardet==3.0.4            # via -r requirements/edx/paver.txt, pysrt, requests
@@ -164,7 +164,7 @@ numpy==1.18.5             # via -c requirements/edx/../constraints.txt, chem, op
 oauthlib==3.0.1           # via -c requirements/edx/../constraints.txt, -r requirements/edx/base.in, django-oauth-toolkit, lti-consumer-xblock, requests-oauthlib, social-auth-core
 openedx-calc==1.0.9       # via -r requirements/edx/base.in
 ora2==2.13.3              # via -r requirements/edx/base.in
-packaging==20.7           # via bleach, drf-yasg
+packaging==20.8           # via bleach, drf-yasg
 path.py==12.5.0           # via edx-enterprise, edx-i18n-tools, ora2, staff-graded-xblock, xmodule
 path==13.1.0              # via -c requirements/edx/../constraints.txt, -r requirements/edx/paver.txt, path.py
 paver==1.3.4              # via -r requirements/edx/paver.txt

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -6,7 +6,6 @@
 #
 -e git+https://github.com/edx/acid-block.git@758855a67d2f12bd74db4d5e7a0862d6e65f079c#egg=acid-xblock  # via -r requirements/edx/testing.txt
 -e common/lib/capa  # via -r requirements/edx/testing.txt
--e git+https://github.com/edx/celery.git@cb85b6ca26cad14fee494342e9c2782d81119223#egg=celery  # via -r requirements/edx/testing.txt
 -e git+https://github.com/edx/codejail.git@3.1.3#egg=codejail==3.1.3  # via -r requirements/edx/testing.txt
 -e git+https://github.com/edx/django-wiki.git@0.1.1#egg=django-wiki  # via -r requirements/edx/testing.txt
 -e git+https://github.com/edx/DoneXBlock.git@2.0.3#egg=done-xblock  # via -r requirements/edx/testing.txt
@@ -36,6 +35,7 @@ boto3==1.4.8              # via -r requirements/edx/testing.txt, django-ses, fs-
 boto==2.39.0              # via -r requirements/edx/testing.txt, edxval
 botocore==1.8.17          # via -r requirements/edx/testing.txt, boto3, s3transfer
 bridgekeeper==0.9         # via -r requirements/edx/testing.txt
+celery==4.4.7             # via -c requirements/edx/../constraints.txt, -r requirements/edx/testing.txt, django-celery-results, django-user-tasks, edx-celeryutils, edx-enterprise, event-tracking
 certifi==2020.12.5        # via -r requirements/edx/testing.txt, elasticsearch, requests
 cffi==1.14.4              # via -r requirements/edx/testing.txt, cryptography
 chardet==3.0.4            # via -r requirements/edx/testing.txt, pysrt, requests
@@ -197,7 +197,7 @@ numpy==1.18.5             # via -c requirements/edx/../constraints.txt, -r requi
 oauthlib==3.0.1           # via -c requirements/edx/../constraints.txt, -r requirements/edx/testing.txt, django-oauth-toolkit, lti-consumer-xblock, requests-oauthlib, social-auth-core
 openedx-calc==1.0.9       # via -r requirements/edx/testing.txt
 ora2==2.13.3              # via -r requirements/edx/testing.txt
-packaging==20.7           # via -r requirements/edx/testing.txt, bleach, drf-yasg, pytest, sphinx, tox
+packaging==20.8           # via -r requirements/edx/testing.txt, bleach, drf-yasg, pytest, sphinx, tox
 path.py==12.5.0           # via -r requirements/edx/testing.txt, edx-enterprise, edx-i18n-tools, ora2, staff-graded-xblock, xmodule
 path==13.1.0              # via -c requirements/edx/../constraints.txt, -r requirements/edx/testing.txt, path.py
 paver==1.3.4              # via -r requirements/edx/testing.txt
@@ -209,7 +209,7 @@ pluggy==0.13.1            # via -r requirements/edx/testing.txt, diff-cover, pyt
 polib==1.1.0              # via -r requirements/edx/testing.txt, edx-i18n-tools
 psutil==5.7.3             # via -r requirements/edx/testing.txt, edx-django-utils, pytest-xdist
 py2neo==3.1.2             # via -r requirements/edx/testing.txt
-py==1.9.0                 # via -r requirements/edx/testing.txt, pytest, pytest-forked, tox
+py==1.10.0                # via -r requirements/edx/testing.txt, pytest, pytest-forked, tox
 pycodestyle==2.6.0        # via -r requirements/edx/testing.txt
 pycontracts==1.8.12       # via -r requirements/edx/testing.txt, edx-user-state-client
 pycountry==20.7.3         # via -r requirements/edx/testing.txt
@@ -236,7 +236,7 @@ pytest-json-report==1.2.4  # via -r requirements/edx/testing.txt
 pytest-metadata==1.8.0    # via -r requirements/edx/testing.txt, pytest-json-report
 pytest-randomly==3.5.0    # via -r requirements/edx/testing.txt
 pytest-xdist[psutil]==2.1.0  # via -r requirements/edx/testing.txt
-pytest==6.1.2             # via -r requirements/edx/testing.txt, pytest-attrib, pytest-cov, pytest-django, pytest-forked, pytest-json-report, pytest-metadata, pytest-randomly, pytest-xdist
+pytest==6.2.0             # via -r requirements/edx/testing.txt, pytest-attrib, pytest-cov, pytest-django, pytest-forked, pytest-json-report, pytest-metadata, pytest-randomly, pytest-xdist
 python-dateutil==2.4.0    # via -c requirements/edx/../constraints.txt, -r requirements/edx/testing.txt, analytics-python, botocore, edx-ace, edx-drf-extensions, edx-enterprise, edx-event-routing-backends, edx-proctoring, faker, freezegun, icalendar, ora2, xblock
 python-levenshtein==0.12.0  # via -r requirements/edx/testing.txt
 python-memcached==1.59    # via -r requirements/edx/testing.txt

--- a/requirements/edx/doc.txt
+++ b/requirements/edx/doc.txt
@@ -19,7 +19,7 @@ idna==2.10                # via requests
 imagesize==1.2.0          # via sphinx
 jinja2==2.11.2            # via code-annotations, sphinx
 markupsafe==1.1.1         # via jinja2
-packaging==20.7           # via sphinx
+packaging==20.8           # via sphinx
 pbr==5.5.1                # via stevedore
 pygments==2.7.3           # via sphinx
 pyparsing==2.4.7          # via packaging

--- a/requirements/edx/github.in
+++ b/requirements/edx/github.in
@@ -68,7 +68,6 @@ git+https://github.com/edx/django-ratelimit-backend.git@v2.0.1a5#egg=django-rate
 -e git+https://github.com/edx/RateXBlock.git@2.0.1#egg=rate-xblock
 -e git+https://github.com/edx/DoneXBlock.git@2.0.3#egg=done-xblock
 -e git+https://github.com/edx-solutions/xblock-google-drive.git@2d176468e33c0713c911b563f8f65f7cf232f5b6#egg=xblock-google-drive
--e git+https://github.com/edx/celery.git@cb85b6ca26cad14fee494342e9c2782d81119223#egg=celery
 
 # Third Party XBlocks
 

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -6,7 +6,6 @@
 #
 -e git+https://github.com/edx/acid-block.git@758855a67d2f12bd74db4d5e7a0862d6e65f079c#egg=acid-xblock  # via -r requirements/edx/base.txt
 -e common/lib/capa  # via -r requirements/edx/base.txt
--e git+https://github.com/edx/celery.git@cb85b6ca26cad14fee494342e9c2782d81119223#egg=celery  # via -r requirements/edx/base.txt
 -e git+https://github.com/edx/codejail.git@3.1.3#egg=codejail==3.1.3  # via -r requirements/edx/base.txt
 -e git+https://github.com/edx/django-wiki.git@0.1.1#egg=django-wiki  # via -r requirements/edx/base.txt
 -e git+https://github.com/edx/DoneXBlock.git@2.0.3#egg=done-xblock  # via -r requirements/edx/base.txt
@@ -35,6 +34,7 @@ boto3==1.4.8              # via -r requirements/edx/base.txt, django-ses, fs-s3f
 boto==2.39.0              # via -r requirements/edx/base.txt, edxval
 botocore==1.8.17          # via -r requirements/edx/base.txt, boto3, s3transfer
 bridgekeeper==0.9         # via -r requirements/edx/base.txt
+celery==4.4.7             # via -c requirements/edx/../constraints.txt, -r requirements/edx/base.txt, django-celery-results, django-user-tasks, edx-celeryutils, edx-enterprise, event-tracking
 certifi==2020.12.5        # via -r requirements/edx/base.txt, elasticsearch, requests
 cffi==1.14.4              # via -r requirements/edx/base.txt, cryptography
 chardet==3.0.4            # via -r requirements/edx/base.txt, pysrt, requests
@@ -189,7 +189,7 @@ numpy==1.18.5             # via -c requirements/edx/../constraints.txt, -r requi
 oauthlib==3.0.1           # via -c requirements/edx/../constraints.txt, -r requirements/edx/base.txt, django-oauth-toolkit, lti-consumer-xblock, requests-oauthlib, social-auth-core
 openedx-calc==1.0.9       # via -r requirements/edx/base.txt
 ora2==2.13.3              # via -r requirements/edx/base.txt
-packaging==20.7           # via -r requirements/edx/base.txt, bleach, drf-yasg, pytest, tox
+packaging==20.8           # via -r requirements/edx/base.txt, bleach, drf-yasg, pytest, tox
 path.py==12.5.0           # via -r requirements/edx/base.txt, edx-enterprise, edx-i18n-tools, ora2, staff-graded-xblock, xmodule
 path==13.1.0              # via -c requirements/edx/../constraints.txt, -r requirements/edx/base.txt, path.py
 paver==1.3.4              # via -r requirements/edx/base.txt
@@ -200,7 +200,7 @@ pluggy==0.13.1            # via -r requirements/edx/coverage.txt, diff-cover, py
 polib==1.1.0              # via -r requirements/edx/base.txt, -r requirements/edx/testing.in, edx-i18n-tools
 psutil==5.7.3             # via -r requirements/edx/base.txt, edx-django-utils, pytest-xdist
 py2neo==3.1.2             # via -r requirements/edx/base.txt
-py==1.9.0                 # via pytest, pytest-forked, tox
+py==1.10.0                # via pytest, pytest-forked, tox
 pycodestyle==2.6.0        # via -r requirements/edx/testing.in
 pycontracts==1.8.12       # via -r requirements/edx/base.txt, edx-user-state-client
 pycountry==20.7.3         # via -r requirements/edx/base.txt
@@ -226,7 +226,7 @@ pytest-json-report==1.2.4  # via -r requirements/edx/testing.in
 pytest-metadata==1.8.0    # via -r requirements/edx/testing.in, pytest-json-report
 pytest-randomly==3.5.0    # via -r requirements/edx/testing.in
 pytest-xdist[psutil]==2.1.0  # via -r requirements/edx/testing.in
-pytest==6.1.2             # via -r requirements/edx/testing.in, pytest-attrib, pytest-cov, pytest-django, pytest-forked, pytest-json-report, pytest-metadata, pytest-randomly, pytest-xdist
+pytest==6.2.0             # via -r requirements/edx/testing.in, pytest-attrib, pytest-cov, pytest-django, pytest-forked, pytest-json-report, pytest-metadata, pytest-randomly, pytest-xdist
 python-dateutil==2.4.0    # via -c requirements/edx/../constraints.txt, -r requirements/edx/base.txt, analytics-python, botocore, edx-ace, edx-drf-extensions, edx-enterprise, edx-event-routing-backends, edx-proctoring, faker, freezegun, icalendar, ora2, xblock
 python-levenshtein==0.12.0  # via -r requirements/edx/base.txt
 python-memcached==1.59    # via -r requirements/edx/base.txt


### PR DESCRIPTION
Reverting the changes made in https://github.com/edx/edx-platform/pull/25649 as those are not needed anymore.
Sandbox for this change: https://revertceleryfork.sandbox.edx.org/

http://revertceleryfork.sandbox.edx.org:5555/