### PR TITLE
[BD-14] Improve backfill_orgs_and_org_courses output formatting

### DIFF
--- a/cms/djangoapps/contentstore/management/commands/tests/test_backfill_orgs_and_org_courses.py
+++ b/cms/djangoapps/contentstore/management/commands/tests/test_backfill_orgs_and_org_courses.py
@@ -140,8 +140,20 @@ class BackfillOrgsAndOrgCoursesTest(SharedModuleStoreTestCase):
         },
     )
     @ddt.unpack
-    @patch.object(organizations_api, 'bulk_add_organizations')
-    @patch.object(organizations_api, 'bulk_add_organization_courses')
+    @patch.object(
+        # Mock out `bulk_add_organizations` to do nothing and return empty
+        # lists, indicating no organizations created or reactivated.
+        organizations_api,
+        'bulk_add_organizations',
+        return_value=([], []),
+    )
+    @patch.object(
+        # Mock out `bulk_add_organization_courses` to do nothing and return empty
+        # lists, indicating no linkages created or reactivated.
+        organizations_api,
+        'bulk_add_organization_courses',
+        return_value=([], []),
+    )
     def test_arguments_and_input(
             self,
             mock_add_orgs,


### PR DESCRIPTION
The output was previously surfaced via `log.info` calls. Given that the command is reporting on thousands of records, that ended up being very difficult to parse.

Instead, print one organization or org-course linkage per line.

Also, add example run of command with output to command class docstring.

Part of [TNL-7774](https://openedx.atlassian.net/browse/TNL-7774)