### PR TITLE
Revert "Add cookie size monitoring New Relic metrics."

### DIFF
--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -658,9 +658,6 @@ MIDDLEWARE = [
     'edx_django_utils.cache.middleware.RequestCacheMiddleware',
     'edx_django_utils.monitoring.MonitoringMemoryMiddleware',
 
-    # Cookie monitoring
-    'openedx.core.lib.request_utils.CookieMonitoringMiddleware',
-
     'openedx.core.djangoapps.header_control.middleware.HeaderControlMiddleware',
     'django.middleware.cache.UpdateCacheMiddleware',
     'django.middleware.common.CommonMiddleware',

--- a/lms/djangoapps/course_api/tests/test_views.py
+++ b/lms/djangoapps/course_api/tests/test_views.py
@@ -396,7 +396,7 @@ class CourseListSearchViewTest(CourseApiTestViewMixin, ModuleStoreTestCase, Sear
         self.setup_user(self.audit_user)
 
         # These query counts were found empirically
-        query_counts = [54, 46, 46, 46, 46, 46, 46, 46, 46, 46, 16]
+        query_counts = [53, 45, 45, 45, 45, 45, 45, 45, 45, 45, 15]
         ordered_course_ids = sorted([str(cid) for cid in (course_ids + [c.id for c in self.courses])])
 
         self.clear_caches()

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -1692,9 +1692,6 @@ MIDDLEWARE = [
     # Generate code ownership attributes. Keep this immediately after RequestCacheMiddleware.
     'edx_django_utils.monitoring.CodeOwnerMonitoringMiddleware',
 
-    # Cookie monitoring
-    'openedx.core.lib.request_utils.CookieMonitoringMiddleware',
-
     'lms.djangoapps.mobile_api.middleware.AppVersionUpgrade',
     'openedx.core.djangoapps.header_control.middleware.HeaderControlMiddleware',
     'lms.djangoapps.discussion.django_comment_client.middleware.AjaxExceptionMiddleware',

--- a/openedx/core/djangoapps/bookmarks/tests/test_views.py
+++ b/openedx/core/djangoapps/bookmarks/tests/test_views.py
@@ -271,7 +271,7 @@ class BookmarksListViewTests(BookmarksViewsTestsBase):
         self.assertEqual(response.data['developer_message'], u'Parameter usage_id not provided.')
 
         # Send empty data dictionary.
-        with self.assertNumQueries(9):  # No queries for bookmark table.
+        with self.assertNumQueries(8):  # No queries for bookmark table.
             response = self.send_post(
                 client=self.client,
                 url=reverse('bookmarks'),

--- a/openedx/core/djangoapps/user_api/accounts/tests/test_views.py
+++ b/openedx/core/djangoapps/user_api/accounts/tests/test_views.py
@@ -176,7 +176,7 @@ class TestOwnUsernameAPI(CacheIsolationTestCase, UserAPITestCase):
         Test that a client (logged in) can get her own username.
         """
         self.client.login(username=self.user.username, password=TEST_PASSWORD)
-        self._verify_get_own_username(17)
+        self._verify_get_own_username(16)
 
     def test_get_username_inactive(self):
         """
@@ -186,7 +186,7 @@ class TestOwnUsernameAPI(CacheIsolationTestCase, UserAPITestCase):
         self.client.login(username=self.user.username, password=TEST_PASSWORD)
         self.user.is_active = False
         self.user.save()
-        self._verify_get_own_username(17)
+        self._verify_get_own_username(16)
 
     def test_get_username_not_logged_in(self):
         """
@@ -195,7 +195,7 @@ class TestOwnUsernameAPI(CacheIsolationTestCase, UserAPITestCase):
         """
 
         # verify that the endpoint is inaccessible when not logged in
-        self._verify_get_own_username(13, expected_status=401)
+        self._verify_get_own_username(12, expected_status=401)
 
 
 @ddt.ddt
@@ -358,7 +358,7 @@ class TestAccountsAPI(CacheIsolationTestCase, UserAPITestCase):
         """
         self.different_client.login(username=self.different_user.username, password=TEST_PASSWORD)
         self.create_mock_profile(self.user)
-        with self.assertNumQueries(24):
+        with self.assertNumQueries(23):
             response = self.send_get(self.different_client)
         self._verify_full_shareable_account_response(response, account_privacy=ALL_USERS_VISIBILITY)
 
@@ -373,7 +373,7 @@ class TestAccountsAPI(CacheIsolationTestCase, UserAPITestCase):
         """
         self.different_client.login(username=self.different_user.username, password=TEST_PASSWORD)
         self.create_mock_profile(self.user)
-        with self.assertNumQueries(24):
+        with self.assertNumQueries(23):
             response = self.send_get(self.different_client)
         self._verify_private_account_response(response)
 
@@ -518,7 +518,7 @@ class TestAccountsAPI(CacheIsolationTestCase, UserAPITestCase):
             self.assertEqual(False, data["accomplishments_shared"])
 
         self.client.login(username=self.user.username, password=TEST_PASSWORD)
-        verify_get_own_information(22)
+        verify_get_own_information(21)
 
         # Now make sure that the user can get the same information, even if not active
         self.user.is_active = False
@@ -538,7 +538,7 @@ class TestAccountsAPI(CacheIsolationTestCase, UserAPITestCase):
         legacy_profile.save()
 
         self.client.login(username=self.user.username, password=TEST_PASSWORD)
-        with self.assertNumQueries(22):
+        with self.assertNumQueries(21):
             response = self.send_get(self.client)
         for empty_field in ("level_of_education", "gender", "country", "state", "bio",):
             self.assertIsNone(response.data[empty_field])

--- a/openedx/core/lib/request_utils.py
+++ b/openedx/core/lib/request_utils.py
@@ -8,6 +8,8 @@ from django.test.client import RequestFactory
 from opaque_keys import InvalidKeyError
 from opaque_keys.edx.keys import CourseKey
 
+from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
+
 
 # accommodates course api urls, excluding any course api routes that do not fall under v*/courses, such as v1/blocks.
 COURSE_REGEX = re.compile(r'^(.*?/courses/)(?!v[0-9]+/[^/]+){}'.format(settings.COURSE_ID_PATTERN))

--- a/openedx/core/lib/request_utils.py
+++ b/openedx/core/lib/request_utils.py
@@ -1,26 +1,16 @@
 """ Utility functions related to HTTP requests """
-
-import logging
 import re
-
 import crum
+from urllib.parse import urlparse
+
 from django.conf import settings
 from django.test.client import RequestFactory
-from django.utils.deprecation import MiddlewareMixin
-from edx_django_utils.monitoring import set_custom_attribute
 from opaque_keys import InvalidKeyError
 from opaque_keys.edx.keys import CourseKey
-from six.moves.urllib.parse import urlparse
 
-from edx_toggles.toggles import LegacyWaffleFlag, LegacyWaffleFlagNamespace
-from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
 
 # accommodates course api urls, excluding any course api routes that do not fall under v*/courses, such as v1/blocks.
 COURSE_REGEX = re.compile(r'^(.*?/courses/)(?!v[0-9]+/[^/]+){}'.format(settings.COURSE_ID_PATTERN))
-
-WAFFLE_FLAG_NAMESPACE = LegacyWaffleFlagNamespace(name='request_utils')
-CAPTURE_COOKIE_SIZES = LegacyWaffleFlag(WAFFLE_FLAG_NAMESPACE, 'capture_cookie_sizes', __name__)
-log = logging.getLogger(__name__)
 
 
 def get_request_or_stub():
@@ -89,32 +79,3 @@ def course_id_from_url(url):
         return CourseKey.from_string(course_id)
     except InvalidKeyError:
         return None
-
-
-class CookieMonitoringMiddleware(MiddlewareMixin):
-    """
-    Middleware for monitoring the size and growth of all our cookies, to see if
-    we're running into browser limits.
-    """
-    def process_request(self, request):
-        """
-        Emit custom attributes for cookie size values for every cookie we have.
-
-        Don't log contents of cookies because that might cause a security issue.
-        We just want to see if any cookies are growing out of control.
-        """
-        if not CAPTURE_COOKIE_SIZES.is_enabled():
-            return
-
-        cookie_names_to_size = {
-            name: len(value)
-            for name, value in request.COOKIES.items()
-        }
-        for name, size in cookie_names_to_size.items():
-            attribute_name = 'cookies.{}.size'.format(name)
-            set_custom_attribute(attribute_name, size)
-            log.debug(u'%s = %d', attribute_name, size)
-
-        total_cookie_size = sum(cookie_names_to_size.values())
-        set_custom_attribute('cookies_total_size', total_cookie_size)
-        log.debug(u'cookies_total_size = %d', total_cookie_size)


### PR DESCRIPTION
This reverts commit 76620e0bf2449fea05ffd9477f705284fe1adfc8.

Reasons for this revert:

1. This was originally added for production debugging issues and was
   not the right track for figuring out what was going on.
2. This has been disabled for a while now (the flag is swithed off).
3. Nobody outside of edx.org has probably even heard of this, so it's
   just useless cruft lying around.
4. It *may* be related to odd bursts in memcached latency that we've
   been seeing on occasion.
5. When cookies get too large, that manifests itself by 400 errors
   at the nginx level, and has been a result of the abuse of domain
   level cookies when hitting subdomains of the LMS. In those cases,
   we don't get to Python code anyway.
