### PR TITLE
[BD-21] Fix deprecated waffle usage

### DIFF
--- a/cms/djangoapps/contentstore/migrations/0005_add_enable_checklists_quality_waffle_flag.py
+++ b/cms/djangoapps/contentstore/migrations/0005_add_enable_checklists_quality_waffle_flag.py
@@ -9,7 +9,7 @@ from cms.djangoapps.contentstore.config.waffle import ENABLE_CHECKLISTS_QUALITY
 def create_flag(apps, schema_editor):
     Flag = apps.get_model('waffle', 'Flag')
     # Replacement for flag_undefined_default=True on flag definition
-    Flag.objects.get_or_create(name=ENABLE_CHECKLISTS_QUALITY.namespaced_flag_name, defaults={'everyone': True})
+    Flag.objects.get_or_create(name=ENABLE_CHECKLISTS_QUALITY.name, defaults={'everyone': True})
 
 
 class Migration(migrations.Migration):

--- a/cms/djangoapps/contentstore/views/tests/test_videos.py
+++ b/cms/djangoapps/contentstore/views/tests/test_videos.py
@@ -548,7 +548,7 @@ class VideosHandlerTestCase(VideoUploadTestMixin, VideoUploadPostTestsMixin, Cou
     @override_settings(AWS_ACCESS_KEY_ID='test_key_id', AWS_SECRET_ACCESS_KEY='test_secret', AWS_SECURITY_TOKEN='token')
     @patch('boto.s3.key.Key')
     @patch('boto.s3.connection.S3Connection')
-    @override_flag(waffle_flags()[ENABLE_DEVSTACK_VIDEO_UPLOADS].namespaced_flag_name, active=True)
+    @override_flag(waffle_flags()[ENABLE_DEVSTACK_VIDEO_UPLOADS].name, active=True)
     def test_devstack_upload_connection(self, mock_conn, mock_key):
         files = [{'file_name': 'first.mp4', 'content_type': 'video/mp4'}]
         mock_key_instances = [
@@ -655,7 +655,7 @@ class VideosHandlerTestCase(VideoUploadTestMixin, VideoUploadPostTestsMixin, Cou
 
         DEPRECATE_YOUTUBE_FLAG = waffle_flags()[DEPRECATE_YOUTUBE]
         with patch.object(WaffleFlagCourseOverrideModel, 'override_value', return_value=data['course_override']):
-            with override_flag(DEPRECATE_YOUTUBE_FLAG.namespaced_flag_name, active=data['global_waffle']):
+            with override_flag(DEPRECATE_YOUTUBE_FLAG.name, active=data['global_waffle']):
                 response = self.client.post(
                     self.url,
                     json.dumps({'files': [file_data]}),

--- a/lms/djangoapps/courseware/tests/test_video_mongo.py
+++ b/lms/djangoapps/courseware/tests/test_video_mongo.py
@@ -1200,7 +1200,7 @@ class TestGetHtmlMethod(BaseTestVideoXBlock):
         )
         DEPRECATE_YOUTUBE_FLAG = waffle_flags()[DEPRECATE_YOUTUBE]
         with patch.object(WaffleFlagCourseOverrideModel, 'override_value', return_value=data['course_override']):
-            with override_flag(DEPRECATE_YOUTUBE_FLAG.namespaced_flag_name, active=data['waffle_enabled']):
+            with override_flag(DEPRECATE_YOUTUBE_FLAG.name, active=data['waffle_enabled']):
                 self.initialize_block(data=video_xml, metadata=metadata)
                 context = self.item_descriptor.render(STUDENT_VIEW).content
                 self.assertIn(u'"prioritizeHls": {}'.format(data['result']), context)

--- a/lms/djangoapps/grades/migrations/0018_add_waffle_flag_defaults.py
+++ b/lms/djangoapps/grades/migrations/0018_add_waffle_flag_defaults.py
@@ -15,13 +15,13 @@ def create_flag(apps, schema_editor):
     Flag = apps.get_model('waffle', 'Flag')
     # Replacement for flag_undefined_default=True on flag definition
     Flag.objects.get_or_create(
-        name=waffle_flags()[REJECTED_EXAM_OVERRIDES_GRADE].namespaced_flag_name, defaults={'everyone': True}
+        name=waffle_flags()[REJECTED_EXAM_OVERRIDES_GRADE].name, defaults={'everyone': True}
     )
     Flag.objects.get_or_create(
-        name=waffle_flags()[ENFORCE_FREEZE_GRADE_AFTER_COURSE_END].namespaced_flag_name, defaults={'everyone': True}
+        name=waffle_flags()[ENFORCE_FREEZE_GRADE_AFTER_COURSE_END].name, defaults={'everyone': True}
     )
     Flag.objects.get_or_create(
-        name=waffle_flags()[WRITABLE_GRADEBOOK].namespaced_flag_name, defaults={'everyone': True}
+        name=waffle_flags()[WRITABLE_GRADEBOOK].name, defaults={'everyone': True}
     )
 
 

--- a/lms/djangoapps/instructor/toggles.py
+++ b/lms/djangoapps/instructor/toggles.py
@@ -22,6 +22,7 @@ WAFFLE_FLAG_NAMESPACE = LegacyWaffleFlagNamespace(name=WAFFLE_NAMESPACE)
 DATA_DOWNLOAD_V2 = CourseWaffleFlag(
     waffle_namespace=LegacyWaffleFlagNamespace(name=WAFFLE_NAMESPACE, log_prefix='instructor_dashboard: '),
     flag_name='enable_data_download_v2',
+    module_name=__name__,
 )
 
 # Waffle flag to use optimised is_small_course.
@@ -39,6 +40,7 @@ DATA_DOWNLOAD_V2 = CourseWaffleFlag(
 OPTIMISED_IS_SMALL_COURSE = LegacyWaffleFlag(
     waffle_namespace=WAFFLE_FLAG_NAMESPACE,
     flag_name='optimised_is_small_course',
+    module_name=__name__,
 )
 
 

--- a/openedx/core/djangoapps/waffle_utils/__init__.py
+++ b/openedx/core/djangoapps/waffle_utils/__init__.py
@@ -164,12 +164,12 @@ class CourseWaffleFlag(LegacyWaffleFlag):
         # Import is placed here to avoid model import at project startup.
         from .models import WaffleFlagCourseOverrideModel
 
-        cache_key = "{}.{}".format(self.namespaced_flag_name, str(course_key))
+        cache_key = "{}.{}".format(self.name, str(course_key))
         course_override = self.cached_flags().get(cache_key)
 
         if course_override is None:
             course_override = WaffleFlagCourseOverrideModel.override_value(
-                self.namespaced_flag_name, course_key
+                self.name, course_key
             )
             self.cached_flags()[cache_key] = course_override
 

--- a/openedx/features/course_experience/tests/views/test_course_home.py
+++ b/openedx/features/course_experience/tests/views/test_course_home.py
@@ -225,7 +225,7 @@ class TestCourseHomePage(CourseHomePageTestCase):
         self.assertRedirects(response, '/dashboard?notlive=Jan+01%2C+2030')
 
         # With the Waffle flag enabled, the course should be visible
-        with override_flag(COURSE_PRE_START_ACCESS_FLAG.namespaced_flag_name, True):
+        with override_flag(COURSE_PRE_START_ACCESS_FLAG.name, True):
             url = course_home_url(future_course)
             response = self.client.get(url)
             self.assertEqual(response.status_code, 200)


### PR DESCRIPTION
* Get rid of calls to `WaffleFlag.namespaced_flag_name`
* Become forward-compatible by adding missing `module_name` argument from some waffle objects.

This is now ready for review (provided tests pass).

cc @robrap 