### PR TITLE
update hls.js to latest version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -579,7 +579,7 @@
     "aproba": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
-      "integrity": "sha1-aALmJk79GMeQobDVF/DyYnvyyUo="
+      "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw=="
     },
     "are-we-there-yet": {
       "version": "1.1.5",
@@ -6302,12 +6302,19 @@
       }
     },
     "hls.js": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/hls.js/-/hls.js-0.9.0.tgz",
-      "integrity": "sha512-YFklk/07BAIEZpI6V1HqjJ4VPOO7zLGcrgzJiiyp9HXK/KH7JDWZylNjT+hn52gfyhqzmagLpJoMXNATgsMBcw==",
+      "version": "0.14.17",
+      "resolved": "https://registry.npmjs.org/hls.js/-/hls.js-0.14.17.tgz",
+      "integrity": "sha512-25A7+m6qqp6UVkuzUQ//VVh2EEOPYlOBg32ypr34bcPO7liBMOkKFvbjbCBfiPAOTA/7BSx1Dujft3Th57WyFg==",
       "requires": {
-        "string.prototype.endswith": "^0.2.0",
-        "url-toolkit": "^2.1.2"
+        "eventemitter3": "^4.0.3",
+        "url-toolkit": "^2.1.6"
+      },
+      "dependencies": {
+        "eventemitter3": {
+          "version": "4.0.7",
+          "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
+          "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw=="
+        }
       }
     },
     "hmac-drbg": {
@@ -13546,11 +13553,6 @@
         "strip-ansi": "^3.0.0"
       }
     },
-    "string.prototype.endswith": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/string.prototype.endswith/-/string.prototype.endswith-0.2.0.tgz",
-      "integrity": "sha1-oZwg3uUamHd+mkfhDwm+OTubunU="
-    },
     "string_decoder": {
       "version": "0.10.31",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
@@ -15075,9 +15077,9 @@
       }
     },
     "url-toolkit": {
-      "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/url-toolkit/-/url-toolkit-2.1.4.tgz",
-      "integrity": "sha512-jAzm/85zNFfkW5Do/37GeGC7uGXBMMawToVdcf5SIpc+x9TmZDrRIUuLRPcvDMfqtt3m8VmDrYhCWh4UbsQLyg=="
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/url-toolkit/-/url-toolkit-2.2.1.tgz",
+      "integrity": "sha512-8+DzgrtDZYZGhHaAop5WGVghMdCfOLGbhcArsJD0qDll71FXa7EeKxi2hilPIscn2nwMz4PRjML32Sz4JTN0Xw=="
     },
     "use": {
       "version": "3.1.1",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "extract-text-webpack-plugin": "2.1.2",
     "file-loader": "1.1.6",
     "font-awesome": "4.7.0",
-    "hls.js": "0.9.0",
+    "hls.js": "0.14.17",
     "imports-loader": "0.7.1",
     "jquery": "2.2.4",
     "jquery-migrate": "1.4.1",


### PR DESCRIPTION
### [TNL-7766](https://openedx.atlassian.net/browse/TNL-7766)

### Description
 hls.js version in the platform is very old and there have been [numerous updates](https://github.com/video-dev/hls.js/releases) to fix bugs and improve the performance. This PR doesn't necessarily relate to TNL-7766 but given the intermittent video freezes being encountered, the latest version of hls.js **may** fix them(due to several upgrades and bug fixes done till the latest version). This PR is updating hls.js to the latest stable version available. Sandbox link has been added in the description with an HLS video added in the test course.
 
Sandbox: https://pr25886.sandbox.edx.org/
auth: margaret, hamilton