### PR TITLE
SE-3690 New default logo is 150px wide

### DIFF
--- a/lms/templates/footer.html
+++ b/lms/templates/footer.html
@@ -72,7 +72,7 @@
             <div class="footer-about-openedx">
               <p>
                 <a href="${footer['openedx_link']['url']}">
-                  <img src="${footer['openedx_link']['image']}" alt="${footer['openedx_link']['title']}" width="140" />
+                  <img src="${footer['openedx_link']['image']}" alt="${footer['openedx_link']['title']}" width="150" />
                 </a>
               </p>
             </div>
@@ -151,7 +151,7 @@
       <div class="footer-about-openedx">
         <p>
           <a href="${footer['openedx_link']['url']}">
-            <img src="${footer['openedx_link']['image']}" alt="${footer['openedx_link']['title']}" width="140" />
+            <img src="${footer['openedx_link']['image']}" alt="${footer['openedx_link']['title']}" width="150" />
           </a>
         </p>
       </div>

--- a/themes/edx.org/lms/templates/footer.html
+++ b/themes/edx.org/lms/templates/footer.html
@@ -95,7 +95,7 @@
             % if not hide_openedx_link and hide_openedx_link != Undefined:
                   <div class="openedx-link">
                     <a href="${footer['openedx_link']['url']}" title="${footer['openedx_link']['title']}">
-                      <img alt="${footer['openedx_link']['title']}" src="${footer['openedx_link']['image']}" width="140">
+                      <img alt="${footer['openedx_link']['title']}" src="${footer['openedx_link']['image']}" width="150">
                     </a>
                   </div>
             % endif

--- a/themes/red-theme/lms/templates/footer.html
+++ b/themes/red-theme/lms/templates/footer.html
@@ -110,11 +110,11 @@ from openedx.core.djangolib.markup import HTML, Text
         <a href="http://openedx.org/">
           ## standard powered-by logo
           ## Translators: 'Open edX' is a brand, please keep this untranslated. See http://openedx.org for more information.
-          <img src="https://files.edx.org/openedx-logos/edx-openedx-logo-tag.png" alt="${_('Powered by Open edX')}" width="140" />
+          <img src="https://files.edx.org/openedx-logos/edx-openedx-logo-tag.png" alt="${_('Powered by Open edX')}" width="150" />
           ## greyscale logo for dark background
-          ## <img src="https://files.edx.org/openedx-logos/edx-openedx-logo-tag-light.png" alt="${_('Powered by Open edX')}" width="140" />
+          ## <img src="https://files.edx.org/openedx-logos/edx-openedx-logo-tag-light.png" alt="${_('Powered by Open edX')}" width="150" />
           ## greyscale logo for light background
-          ## <img src="https://files.edx.org/openedx-logos/edx-openedx-logo-tag-dark.png" alt="${_('Powered by Open edX')}" width="140" />
+          ## <img src="https://files.edx.org/openedx-logos/edx-openedx-logo-tag-dark.png" alt="${_('Powered by Open edX')}" width="150" />
         </a>
       </p>
     </div>


### PR DESCRIPTION
The new 'powered by Open edX' logo is wider than the original logo, so this should be updated in the default footers included with edx-platform.

https://github.com/edX/edX-platform/wiki/Powered-by-Open-edX-Logos

**JIRA tickets**: [OSPR-5308](https://openedx.atlassian.net/browse/OSPR-5308)

**Dependencies**: None

**Screenshots**: 

![1608076314](https://user-images.githubusercontent.com/9714796/102286593-8ab2ae00-3f88-11eb-9fd7-43efc78c08d7.png)


**Sandbox URL**: 

-    LMS: https://pr25889.sandbox.opencraft.hosting/
-    Studio: https://studio.pr25889.sandbox.opencraft.hosting/

(master sandboxes currently broken; please test locally)


**Merge deadline**: "None"

**Testing instructions**:

1. view the footer and verify that the new Powered by Open edX logo is displayed at the dimensions requested in https://github.com/edX/edX-platform/wiki/Powered-by-Open-edX-Logos


**Reviewers**:

- [ ] @mavidser 
- [ ] edX reviewer[s] TBD

**Settings**:

```yaml
```