### PR TITLE
Update the Open edX logo urls

### DIFF
--- a/cms/templates/widgets/footer.html
+++ b/cms/templates/widgets/footer.html
@@ -56,7 +56,7 @@ from openedx.core.djangolib.markup import HTML, Text
 
       <div class="footer-about-openedx">
         <a href="https://open.edx.org" title="${_("Powered by Open edX")}">
-          <img alt="${_("Powered by Open edX")}" src="https://files.edx.org/openedx-logos/edx-openedx-logo-tag.png">
+          <img alt="${_("Powered by Open edX")}" src="https://files.edx.org/openedx-logos/open-edx-logo-tag.png">
         </a>
       </div>
     </div>

--- a/lms/djangoapps/branding/tests/test_api.py
+++ b/lms/djangoapps/branding/tests/test_api.py
@@ -157,7 +157,7 @@ class TestFooter(TestCase):
             'logo_image': 'https://edx.org/static/images/logo.png',
             'openedx_link': {
                 'url': 'https://open.edx.org',
-                'image': 'https://files.edx.org/openedx-logos/edx-openedx-logo-tag.png',
+                'image': 'https://files.edx.org/openedx-logos/open-edx-logo-tag.png',
                 'title': 'Powered by Open edX'
             },
             'edx_org_link': {

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -1641,10 +1641,10 @@ FOOTER_OPENEDX_URL = "https://open.edx.org"
 # We use logo images served from files.edx.org so we can (roughly) track
 # how many OpenEdX installations are running.
 # Site operators can choose from these logo options:
-# * https://files.edx.org/openedx-logos/edx-openedx-logo-tag.png
-# * https://files.edx.org/openedx-logos/edx-openedx-logo-tag-light.png"
-# * https://files.edx.org/openedx-logos/edx-openedx-logo-tag-dark.png
-FOOTER_OPENEDX_LOGO_IMAGE = "https://files.edx.org/openedx-logos/edx-openedx-logo-tag.png"
+# * https://files.edx.org/openedx-logos/open-edx-logo-tag.png
+# * https://files.edx.org/openedx-logos/open-edx-logo-tag-light.png"
+# * https://files.edx.org/openedx-logos/open-edx-logo-tag-dark.png
+FOOTER_OPENEDX_LOGO_IMAGE = "https://files.edx.org/openedx-logos/open-edx-logo-tag.png"
 
 # This is just a placeholder image.
 # Site operators can customize this with their organization's image.

--- a/lms/templates/footer.html
+++ b/lms/templates/footer.html
@@ -72,7 +72,7 @@
             <div class="footer-about-openedx">
               <p>
                 <a href="${footer['openedx_link']['url']}">
-                  <img src="${footer['openedx_link']['image']}" alt="${footer['openedx_link']['title']}" width="140" />
+                  <img src="${footer['openedx_link']['image']}" alt="${footer['openedx_link']['title']}" width="175" />
                 </a>
               </p>
             </div>
@@ -151,7 +151,7 @@
       <div class="footer-about-openedx">
         <p>
           <a href="${footer['openedx_link']['url']}">
-            <img src="${footer['openedx_link']['image']}" alt="${footer['openedx_link']['title']}" width="140" />
+            <img src="${footer['openedx_link']['image']}" alt="${footer['openedx_link']['title']}" width="175" />
           </a>
         </p>
       </div>

--- a/themes/edx.org/lms/templates/footer.html
+++ b/themes/edx.org/lms/templates/footer.html
@@ -95,7 +95,7 @@
             % if not hide_openedx_link and hide_openedx_link != Undefined:
                   <div class="openedx-link">
                     <a href="${footer['openedx_link']['url']}" title="${footer['openedx_link']['title']}">
-                      <img alt="${footer['openedx_link']['title']}" src="${footer['openedx_link']['image']}" width="140">
+                      <img alt="${footer['openedx_link']['title']}" src="${footer['openedx_link']['image']}" width="175">
                     </a>
                   </div>
             % endif

--- a/themes/red-theme/lms/templates/footer.html
+++ b/themes/red-theme/lms/templates/footer.html
@@ -110,11 +110,9 @@ from openedx.core.djangolib.markup import HTML, Text
         <a href="http://openedx.org/">
           ## standard powered-by logo
           ## Translators: 'Open edX' is a brand, please keep this untranslated. See http://openedx.org for more information.
-          <img src="https://files.edx.org/openedx-logos/edx-openedx-logo-tag.png" alt="${_('Powered by Open edX')}" width="140" />
-          ## greyscale logo for dark background
-          ## <img src="https://files.edx.org/openedx-logos/edx-openedx-logo-tag-light.png" alt="${_('Powered by Open edX')}" width="140" />
-          ## greyscale logo for light background
-          ## <img src="https://files.edx.org/openedx-logos/edx-openedx-logo-tag-dark.png" alt="${_('Powered by Open edX')}" width="140" />
+          <img src="https://files.edx.org/openedx-logos/open-edx-logo-tag.png" alt="${_('Powered by Open edX')}" width="175" />
+          ## white logo for dark background
+          ## <img src="https://files.edx.org/openedx-logos/open-edx-logo-tag-dark.png" alt="${_('Powered by Open edX')}" width="175" />
         </a>
       </p>
     </div>


### PR DESCRIPTION
The old URLs now serve the new logo, but at the old pixel size.  These
URLs serve the new logo at a natural pixel size.