### PR TITLE
[MST-575] Enable timed exams by default

### DIFF
--- a/common/lib/xmodule/xmodule/course_module.py
+++ b/common/lib/xmodule/xmodule/course_module.py
@@ -51,6 +51,7 @@ DEFAULT_COURSE_VISIBILITY_IN_CATALOG = getattr(
 DEFAULT_MOBILE_AVAILABLE = getattr(settings, 'DEFAULT_MOBILE_AVAILABLE', False)
 # Note: updating assets does not have settings defined, so using `getattr`.
 EXAM_SETTINGS_HTML_VIEW_ENABLED = getattr(settings, 'FEATURES', {}).get('ENABLE_EXAM_SETTINGS_HTML_VIEW', False)
+SPECIAL_EXAMS_ENABLED = getattr(settings, 'FEATURES', {}).get('ENABLE_SPECIAL_EXAMS', False)
 
 COURSE_VISIBILITY_PRIVATE = 'private'
 COURSE_VISIBILITY_PUBLIC_OUTLINE = 'public_outline'
@@ -918,7 +919,7 @@ class CourseFields(object):
             "Enter true or false. If this value is true, timed exams are enabled in your course. "
             "Regardless of this setting, timed exams are enabled if Enable Proctored Exams is set to true."
         ),
-        default=False,
+        default=SPECIAL_EXAMS_ENABLED,
         scope=Scope.settings,
         deprecated=EXAM_SETTINGS_HTML_VIEW_ENABLED
     )

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -105,7 +105,7 @@ edx-milestones==0.3.0     # via -r requirements/edx/base.in
 edx-opaque-keys[django]==2.1.1  # via -r requirements/edx/paver.txt, edx-bulk-grades, edx-ccx-keys, edx-completion, edx-drf-extensions, edx-enterprise, edx-milestones, edx-organizations, edx-proctoring, edx-user-state-client, edx-when, lti-consumer-xblock, xmodule
 edx-organizations==6.5.0  # via -r requirements/edx/base.in
 edx-proctoring-proctortrack==1.0.5  # via -r requirements/edx/base.in
-edx-proctoring==2.5.3     # via -r requirements/edx/base.in, edx-proctoring-proctortrack
+edx-proctoring==2.5.4     # via -r requirements/edx/base.in, edx-proctoring-proctortrack
 edx-rbac==1.3.3           # via edx-enterprise
 edx-rest-api-client==5.2.2  # via -r requirements/edx/base.in, edx-enterprise, edx-proctoring
 edx-search==2.0.1         # via -r requirements/edx/base.in

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -117,7 +117,7 @@ edx-milestones==0.3.0     # via -r requirements/edx/testing.txt
 edx-opaque-keys[django]==2.1.1  # via -r requirements/edx/testing.txt, edx-bulk-grades, edx-ccx-keys, edx-completion, edx-drf-extensions, edx-enterprise, edx-milestones, edx-organizations, edx-proctoring, edx-user-state-client, edx-when, lti-consumer-xblock, xmodule
 edx-organizations==6.5.0  # via -r requirements/edx/testing.txt
 edx-proctoring-proctortrack==1.0.5  # via -r requirements/edx/testing.txt
-edx-proctoring==2.5.3     # via -r requirements/edx/testing.txt, edx-proctoring-proctortrack
+edx-proctoring==2.5.4     # via -r requirements/edx/testing.txt, edx-proctoring-proctortrack
 edx-rbac==1.3.3           # via -r requirements/edx/testing.txt, edx-enterprise
 edx-rest-api-client==5.2.2  # via -r requirements/edx/testing.txt, edx-enterprise, edx-proctoring
 edx-search==2.0.1         # via -r requirements/edx/testing.txt

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -114,7 +114,7 @@ edx-milestones==0.3.0     # via -r requirements/edx/base.txt
 edx-opaque-keys[django]==2.1.1  # via -r requirements/edx/base.txt, edx-bulk-grades, edx-ccx-keys, edx-completion, edx-drf-extensions, edx-enterprise, edx-milestones, edx-organizations, edx-proctoring, edx-user-state-client, edx-when, lti-consumer-xblock, xmodule
 edx-organizations==6.5.0  # via -r requirements/edx/base.txt
 edx-proctoring-proctortrack==1.0.5  # via -r requirements/edx/base.txt
-edx-proctoring==2.5.3     # via -r requirements/edx/base.txt, edx-proctoring-proctortrack
+edx-proctoring==2.5.4     # via -r requirements/edx/base.txt, edx-proctoring-proctortrack
 edx-rbac==1.3.3           # via -r requirements/edx/base.txt, edx-enterprise
 edx-rest-api-client==5.2.2  # via -r requirements/edx/base.txt, edx-enterprise, edx-proctoring
 edx-search==2.0.1         # via -r requirements/edx/base.txt


### PR DESCRIPTION
[MST-575](https://openedx.atlassian.net/browse/MST-575)

Timed exams are now enabled by default if the `ENABLE_SPECIAL_EXAMS` feature flag is set to `True`.