### PR TITLE
AA-496: Don't show reset deadlines banner if no graded problem is pas…

### DIFF
--- a/common/lib/xmodule/xmodule/util/misc.py
+++ b/common/lib/xmodule/xmodule/util/misc.py
@@ -99,3 +99,14 @@ def get_default_short_labeler(course):
         default_labelers[assignment_type]['index'] += 1
         return labeler(index)
     return default_labeler
+
+
+def is_xblock_an_assignment(xblock):
+    """
+    Takes in a leaf xblock and returns a boolean if the xblock is an assignment.
+    """
+    graded = getattr(xblock, 'graded', False)
+    has_score = getattr(xblock, 'has_score', False)
+    weight = getattr(xblock, 'weight', 1)
+    scored = has_score and (weight is None or weight > 0)
+    return graded and scored

--- a/common/lib/xmodule/xmodule/vertical_block.py
+++ b/common/lib/xmodule/xmodule/vertical_block.py
@@ -12,6 +12,8 @@ import pytz
 import six
 from lxml import etree
 from web_fragments.fragment import Fragment
+
+from common.lib.xmodule.xmodule.util.misc import is_xblock_an_assignment
 from xblock.core import XBlock
 from xmodule.mako_module import MakoTemplateBlockBase
 from xmodule.progress import Progress
@@ -257,11 +259,7 @@ class VerticalBlock(SequenceFields, XModuleFields, StudioEditableBlock, XmlParse
         all_complete = None
         for child in children:
             complete = completions[child.scope_ids.usage_id] == 1
-            graded = getattr(child, 'graded', False)
-            has_score = getattr(child, 'has_score', False)
-            weight = getattr(child, 'weight', 1)
-            scored = has_score and (weight is None or weight > 0)
-            if graded and scored:
+            if is_xblock_an_assignment(child):
                 if not complete:
                     return False
                 all_complete = True


### PR DESCRIPTION
…t due

When determining completion status to show on the vertical, we take
into account if the problems are graded and scored (have a score
and weight). Now we take that into account in regards to showing the
banner inside the vertical too