### PR TITLE
Course Blocks API: Return 403 instead of 500 for unknown courses

### DIFF
--- a/lms/djangoapps/course_api/blocks/permissions.py
+++ b/lms/djangoapps/course_api/blocks/permissions.py
@@ -8,6 +8,7 @@ from lms.djangoapps.courseware.access import has_access
 from lms.djangoapps.courseware.access_response import AccessResponse
 from lms.djangoapps.courseware.access_utils import ACCESS_DENIED, ACCESS_GRANTED, check_public_access
 from lms.djangoapps.courseware.courses import get_course
+from openedx.core.djangoapps.content.course_overviews.models import CourseOverview
 from common.djangoapps.student.models import CourseEnrollment
 from common.djangoapps.student.roles import CourseStaffRole
 from xmodule.course_module import COURSE_VISIBILITY_PUBLIC
@@ -39,15 +40,14 @@ def can_access_self_blocks(requesting_user: User, course_key: CourseKey) -> Acce
     )
     if user_is_enrolled_or_staff:
         return ACCESS_GRANTED
-    try:
-        return is_course_public(course_key)
-    except ValueError:
-        return ACCESS_DENIED
+    return is_course_public(course_key)
 
 
 def is_course_public(course_key: CourseKey) -> AccessResponse:
     """
     This checks if a course is publicly accessible or not.
     """
+    if not CourseOverview.course_exists(course_key):
+        return ACCESS_DENIED
     course = get_course(course_key, depth=0)
     return check_public_access(course, [COURSE_VISIBILITY_PUBLIC])

--- a/lms/djangoapps/course_api/blocks/tests/test_views.py
+++ b/lms/djangoapps/course_api/blocks/tests/test_views.py
@@ -395,7 +395,7 @@ class TestBlocksView(SharedModuleStoreTestCase):
         self.verify_response_with_requested_fields(response)
 
 
-class TestBlocksInCourseView(TestBlocksView):
+class TestBlocksInCourseView(TestBlocksView):  # pylint: disable=test-inherits-tests
     """
     Test class for BlocksInCourseView
     """
@@ -413,4 +413,9 @@ class TestBlocksInCourseView(TestBlocksView):
         self.verify_response(400, params={'course_id': 'invalid_course_id'})
 
     def test_non_existent_course(self):
+        self.verify_response(403, params={'course_id': str(CourseLocator('non', 'existent', 'course'))})
+
+    def test_non_existent_course_anonymous(self):
+        self.client.logout()
+        self.query_params['username'] = ''
         self.verify_response(403, params={'course_id': str(CourseLocator('non', 'existent', 'course'))})


### PR DESCRIPTION
Anonymous users (like crawlers) requesting non-existent courses should get 403, just like logged-in users do. They instead aised
a ValueError. This PR fixes that.

This is why the crawler with incorrectly-lowercase course keys is causing a ton of 5XXs instead of 4XXs.