### PR TITLE
[BD-03] Add get/is_enabled helpers for discussions plugins

### DIFF
--- a/openedx/core/djangoapps/discussions/models.py
+++ b/openedx/core/djangoapps/discussions/models.py
@@ -1,6 +1,8 @@
 """
 Provide django models to back the discussions app
 """
+from __future__ import annotations
+
 from django.core.exceptions import ValidationError
 from django.db import models
 from django.utils.translation import ugettext_lazy as _
@@ -75,8 +77,16 @@ class DiscussionsConfiguration(TimeStampedModel):
 
         Default to False, if no configuration exists
         """
+        configuration = cls.get(context_key)
+        return configuration.enabled
+
+    @classmethod
+    def get(cls, context_key) -> cls:
+        """
+        Lookup a model by context_key
+        """
         try:
             configuration = cls.objects.get(context_key=context_key)
         except cls.DoesNotExist:
-            return False
-        return configuration.enabled
+            configuration = cls(context_key=context_key, enabled=False)
+        return configuration

--- a/openedx/core/djangoapps/discussions/models.py
+++ b/openedx/core/djangoapps/discussions/models.py
@@ -67,3 +67,16 @@ class DiscussionsConfiguration(TimeStampedModel):
             provider=self.provider_type,
             enabled=self.enabled,
         )
+
+    @classmethod
+    def is_enabled(cls, context_key) -> bool:
+        """
+        Check if there is an active configuration for a given course key
+
+        Default to False, if no configuration exists
+        """
+        try:
+            configuration = cls.objects.get(context_key=context_key)
+        except cls.DoesNotExist:
+            return False
+        return configuration.enabled

--- a/openedx/core/djangoapps/discussions/tests/test_models.py
+++ b/openedx/core/djangoapps/discussions/tests/test_models.py
@@ -103,3 +103,36 @@ class DiscussionsConfigurationModelTest(TestCase):
         """
         is_enabled = DiscussionsConfiguration.is_enabled(self.course_key_with_values)
         assert not is_enabled
+
+    def test_get_nonexistent(self):
+        """
+        Assert we get an "empty" model back for nonexistent records
+        """
+        configuration = DiscussionsConfiguration.get(self.course_key_without_config)
+        assert configuration is not None
+        assert not configuration.enabled
+        assert not configuration.lti_configuration
+        assert not configuration.plugin_configuration
+        assert not configuration.provider_type
+
+    def test_get_defaults(self):
+        """
+        Assert we can lookup a record with default values
+        """
+        configuration = DiscussionsConfiguration.get(self.course_key_with_defaults)
+        assert configuration is not None
+        assert configuration.enabled
+        assert not configuration.lti_configuration
+        assert not configuration.plugin_configuration
+        assert not configuration.provider_type
+
+    def test_get_explicit(self):
+        """
+        Assert we can lookup a record with explicitly-set values
+        """
+        configuration = DiscussionsConfiguration.get(self.course_key_with_values)
+        assert configuration is not None
+        assert not configuration.enabled
+        assert not configuration.lti_configuration
+        assert configuration.plugin_configuration
+        assert configuration.provider_type == 'cs_comments_service'

--- a/openedx/core/djangoapps/discussions/tests/test_models.py
+++ b/openedx/core/djangoapps/discussions/tests/test_models.py
@@ -82,3 +82,24 @@ class DiscussionsConfigurationModelTest(TestCase):
         assert configuration.lti_configuration is None
         assert configuration.plugin_configuration['url'] == 'http://localhost'
         assert configuration.provider_type == 'cs_comments_service'
+
+    def test_is_enabled_nonexistent(self):
+        """
+        Assert that discussions are disabled, when no configuration exists
+        """
+        is_enabled = DiscussionsConfiguration.is_enabled(self.course_key_without_config)
+        assert not is_enabled
+
+    def test_is_enabled_default(self):
+        """
+        Assert that discussions are enabled by default, when a configuration exists
+        """
+        is_enabled = DiscussionsConfiguration.is_enabled(self.course_key_with_defaults)
+        assert is_enabled
+
+    def test_is_enabled_explicit(self):
+        """
+        Assert that discussions can be explitly disabled
+        """
+        is_enabled = DiscussionsConfiguration.is_enabled(self.course_key_with_values)
+        assert not is_enabled


### PR DESCRIPTION
@xitij2000 I looked at the helper functions you wrote in https://github.com/edx/edx-platform/pull/25910 (thanks!) and extracted them here for broad use.

- `DiscussionsConfiguration.is_enabled(context_key)`
-  `DiscussionsConfiguration.get(context_key)`

I added some extra error handling:
- The get method never returns `None` nor throws a `DoesNotExist` exception; it returns an "empty" model with `enabled=False`
- `is_enabled` wraps the new `get` method, so it gets the error handling for free

And I threw in some basic test coverage.

Assuming this seems generally useful, we can pull it in too.