### PR TITLE
Revert "Sets default X-Frame-Options for login and registration forms to environment setting"

### DIFF
--- a/common/djangoapps/third_party_auth/decorators.py
+++ b/common/djangoapps/third_party_auth/decorators.py
@@ -17,13 +17,13 @@ from common.djangoapps.third_party_auth.provider import Registry
 def xframe_allow_whitelisted(view_func):
     """
     Modifies a view function so that its response has the X-Frame-Options HTTP header
-    set to `settings.X_FRAME_OPTIONS` if the request HTTP referrer is not from a whitelisted hostname.
+    set to 'DENY' if the request HTTP referrer is not from a whitelisted hostname.
     """
 
     def wrapped_view(request, *args, **kwargs):
         """ Modify the response with the correct X-Frame-Options. """
         resp = view_func(request, *args, **kwargs)
-        x_frame_option = settings.X_FRAME_OPTIONS
+        x_frame_option = 'DENY'
         if settings.FEATURES['ENABLE_THIRD_PARTY_AUTH']:
             referer = request.META.get('HTTP_REFERER')
             if referer is not None:


### PR DESCRIPTION
Reverts edx/edx-platform#25338

Queuing up the the revert PR in case this is the cause of the 502s we're seeing on some logins.