### PR TITLE
Fix hiding of completion/bookmark indicators in legacy courseware

### DIFF
--- a/common/static/sass/_mixins.scss
+++ b/common/static/sass/_mixins.scss
@@ -388,7 +388,7 @@
 }
 
 .is-hidden {
-  display: none;
+  display: none !important;
 }
 
 // +Content - No List - Extends

--- a/lms/static/sass/base/_base.scss
+++ b/lms/static/sass/base/_base.scss
@@ -251,7 +251,7 @@ mark {
 
 // UI - is hidden
 .is-hidden {
-  display: none;
+  display: none !important;
 }
 
 // UI - is deprecated


### PR DESCRIPTION
In the edx.org-next theme, the completion green check-
marks and the little bookmark icons were appearing on every
single unit. This was because a fontawesome CSS rule
in the new theme was overriding the `display: none`,
as set by `.is-hidden`, to be `display: inline-block`.

The fix is to add `!important` to a couple definitions
of `.is-hidden`. Definitely somewhat hacky, but this is
SCSS that we plan to deprecate at some point anyway.

https://openedx.atlassian.net/browse/TNL-7823