### PR TITLE
send in-active user details on auth failure

### DIFF
--- a/common/djangoapps/third_party_auth/tests/specs/base.py
+++ b/common/djangoapps/third_party_auth/tests/specs/base.py
@@ -9,6 +9,7 @@ from contextlib import contextmanager
 
 import mock
 from django import test
+from django.conf import settings
 from django.contrib import auth
 from django.contrib.auth import models as auth_models
 from django.contrib.messages.storage import fallback
@@ -24,6 +25,7 @@ from lms.djangoapps.commerce.tests import TEST_API_URL
 from openedx.core.djangoapps.user_authn.views.login import login_user
 from openedx.core.djangoapps.user_authn.views.login_form import login_and_registration_form
 from openedx.core.djangoapps.user_authn.views.register import RegistrationView
+from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
 from openedx.core.djangoapps.site_configuration.tests.factories import SiteFactory
 from openedx.core.djangoapps.user_api.accounts.settings_views import account_settings_context
 from common.djangoapps.student import models as student_models
@@ -125,8 +127,14 @@ class HelperMixin(object):
         """Asserts failure on /login for inactive account looks right."""
         self.assertEqual(400, response.status_code)
         payload = json.loads(response.content.decode('utf-8'))
+        context = {
+            'platformName': configuration_helpers.get_value('PLATFORM_NAME', settings.PLATFORM_NAME),
+            'supportLink': configuration_helpers.get_value('SUPPORT_SITE_LINK', settings.SUPPORT_SITE_LINK)
+        }
+
         self.assertFalse(payload.get('success'))
         self.assertIn('inactive-user', payload.get('error_code'))
+        self.assertEqual(context, payload.get('context'))
 
     def assert_json_failure_response_is_missing_social_auth(self, response):
         """Asserts failure on /login for missing social auth looks right."""

--- a/openedx/core/djangoapps/user_authn/exceptions.py
+++ b/openedx/core/djangoapps/user_authn/exceptions.py
@@ -10,18 +10,19 @@ class AuthFailedError(Exception):
     message.
     """
     def __init__(
-        self, value=None, redirect=None, redirect_url=None, error_code=None
+        self, value=None, redirect=None, redirect_url=None, error_code=None, context={},
     ):
         super(AuthFailedError, self).__init__()
         self.value = Text(value)
         self.redirect = redirect
         self.redirect_url = redirect_url
         self.error_code = error_code
+        self.context = context
 
     def get_response(self):
         """ Returns a dict representation of the error. """
         resp = {'success': False}
-        for attr in ('value', 'redirect', 'redirect_url', 'error_code'):
+        for attr in ('value', 'redirect', 'redirect_url', 'error_code', 'context'):
             if self.__getattribute__(attr):
                 resp[attr] = self.__getattribute__(attr)
 

--- a/openedx/core/djangoapps/user_authn/views/login.py
+++ b/openedx/core/djangoapps/user_authn/views/login.py
@@ -175,7 +175,13 @@ def _log_and_raise_inactive_user_auth_error(unauthenticated_user):
     profile = UserProfile.objects.get(user=unauthenticated_user)
     compose_and_send_activation_email(unauthenticated_user, profile)
 
-    raise AuthFailedError(error_code='inactive-user')
+    raise AuthFailedError(
+        error_code='inactive-user',
+        context={
+            'platformName': configuration_helpers.get_value('PLATFORM_NAME', settings.PLATFORM_NAME),
+            'supportLink': configuration_helpers.get_value('SUPPORT_SITE_LINK', settings.SUPPORT_SITE_LINK)
+        }
+    )
 
 
 def _authenticate_first_party(request, unauthenticated_user, third_party_auth_requested):


### PR DESCRIPTION
Changes:
- Added context to `AuthFailedError` exception
- Send platform name, support link in context

<img width="479" alt="Screenshot 2020-12-22 at 12 55 02 PM" src="https://user-images.githubusercontent.com/40633976/102890524-62dab300-447e-11eb-94da-20e33de29657.png">

VAN-217: https://openedx.atlassian.net/browse/VAN-217