### PR TITLE
Add user_tasks to LMS (for Django admin access).

### DIFF
--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -2751,6 +2751,13 @@ INSTALLED_APPS = [
 
     # Database-backed Organizations App (http://github.com/edx/edx-organizations)
     'organizations',
+
+    # management of user-triggered async tasks (course import/export, etc.)
+    # This is only used by Studio, but is being added here because the
+    # app-permissions script that assigns users to Django admin roles only runs
+    # in the LMS process at the moment, so anything that has Django admin access
+    # permissions needs to be listed as an LMS app or the script will fail.
+    'user_tasks',
 ]
 
 ######################### CSRF #########################################


### PR DESCRIPTION
The user_tasks app is used by Studio import/export and not used by
anything in the LMS. But because our app-permissions user/role
provisioning script invokes the LMS process, any app+permission
listed there must exist in the LMS or the provisioning fails. So
this commit adds the user_tasks app to the LMS list of installed
apps because it's a lot faster than getting app-permissions to do
the right thing.
