### PR TITLE
feat: associates user by email for oauth when tpa is required

### DIFF
--- a/common/djangoapps/third_party_auth/pipeline.py
+++ b/common/djangoapps/third_party_auth/pipeline.py
@@ -79,7 +79,6 @@ from django.urls import reverse
 from edx_django_utils.monitoring import set_custom_attribute
 from social_core.exceptions import AuthException
 from social_core.pipeline import partial
-from social_core.pipeline.social_auth import associate_by_email
 from social_core.utils import module_member, slugify
 
 from common.djangoapps import third_party_auth
@@ -90,9 +89,12 @@ from openedx.core.djangoapps.site_configuration import helpers as configuration_
 from openedx.core.djangoapps.user_api import accounts
 from openedx.core.djangoapps.user_api.accounts.utils import is_multiple_sso_accounts_association_to_saml_user_enabled
 from openedx.core.djangoapps.user_authn import cookies as user_authn_cookies
+from openedx.core.djangoapps.user_authn.toggles import is_require_third_party_auth_enabled
 from common.djangoapps.third_party_auth.utils import (
+    get_associated_user_by_email_response,
     get_user_from_email,
     is_enterprise_customer_user,
+    is_oauth_provider,
     is_saml_provider,
     user_exists,
 )
@@ -735,16 +737,30 @@ def associate_by_email_if_login_api(auth_entry, backend, details, user, current_
     if auth_entry == AUTH_ENTRY_LOGIN_API:
         # Temporary custom attribute to help ensure there is no usage.
         set_custom_attribute('deprecated_auth_entry_login_api', True)
-        association_response = associate_by_email(backend, details, user, *args, **kwargs)
-        if (
-            association_response and
-            association_response.get('user') and
-            association_response['user'].is_active
-        ):
-            # Only return the user matched by email if their email has been activated.
-            # Otherwise, an illegitimate user can create an account with another user's
-            # email address and the legitimate user would now login to the illegitimate
-            # account.
+
+        association_response, user_is_active = get_associated_user_by_email_response(
+            backend, details, user, *args, **kwargs)
+
+        if user_is_active:
+            return association_response
+
+
+@partial.partial
+def associate_by_email_if_oauth(auth_entry, backend, details, user, strategy, *args, **kwargs):
+    """
+    This pipeline step associates the current social auth with the user with the
+    same email address in the database.  It defers to the social library's associate_by_email
+    implementation, which verifies that only a single database user is associated with the email.
+
+    This association is done ONLY if the user entered the pipeline belongs to Oauth provider and
+    `ENABLE_REQUIRE_THIRD_PARTY_AUTH` is enabled.
+    """
+
+    if is_require_third_party_auth_enabled() and is_oauth_provider(backend.name, **kwargs):
+        association_response, user_is_active = get_associated_user_by_email_response(
+            backend, details, user, *args, **kwargs)
+
+        if user_is_active:
             return association_response
 
 
@@ -786,23 +802,10 @@ def associate_by_email_if_saml(auth_entry, backend, details, user, strategy, *ar
             if enterprise_customer_user:
                 # this is python social auth pipeline default method to automatically associate social accounts
                 # if the email already matches a user account.
-                association_response = associate_by_email(backend, details, user, *args, **kwargs)
+                association_response, user_is_active = get_associated_user_by_email_response(
+                    backend, details, user, *args, **kwargs)
 
-                if (
-                    association_response and
-                    association_response.get('user') and
-                    association_response['user'].is_active
-                ):
-                    # Only return the user matched by email if their email has been activated.
-                    # Otherwise, an illegitimate user can create an account with another user's
-                    # email address and the legitimate user would now login to the illegitimate
-                    # account.
-                    return association_response
-                elif (
-                    association_response and
-                    association_response.get('user') and
-                    not association_response['user'].is_active
-                ):
+                if not user_is_active:
                     logger.info(
                         '[Multiple_SSO_SAML_Accounts_Association_to_User] User association account is not'
                         ' active: User Email: {email}, User ID: {user_id}, Provider ID: {provider_id},'
@@ -814,6 +817,8 @@ def associate_by_email_if_saml(auth_entry, backend, details, user, strategy, *ar
                         )
                     )
                     return None
+
+                return association_response
 
         except Exception as ex:  # pylint: disable=broad-except
             logger.exception('[Multiple_SSO_SAML_Accounts_Association_to_User] Error in'

--- a/common/djangoapps/third_party_auth/settings.py
+++ b/common/djangoapps/third_party_auth/settings.py
@@ -55,6 +55,7 @@ def apply_settings(django_settings):
         'social_core.pipeline.social_auth.social_user',
         'common.djangoapps.third_party_auth.pipeline.associate_by_email_if_login_api',
         'common.djangoapps.third_party_auth.pipeline.associate_by_email_if_saml',
+        'common.djangoapps.third_party_auth.pipeline.associate_by_email_if_oauth',
         'common.djangoapps.third_party_auth.pipeline.get_username',
         'common.djangoapps.third_party_auth.pipeline.set_pipeline_timeout',
         'common.djangoapps.third_party_auth.pipeline.ensure_user_information',

--- a/common/djangoapps/third_party_auth/tests/specs/test_azuread.py
+++ b/common/djangoapps/third_party_auth/tests/specs/test_azuread.py
@@ -7,6 +7,10 @@ from common.djangoapps.third_party_auth.tests.specs import base
 class AzureADOauth2IntegrationTest(base.Oauth2IntegrationTest):  # lint-amnesty, pylint: disable=test-inherits-tests
     """Integration tests for Azure Active Directory / Microsoft Account provider."""
 
+    PROVIDER_NAME = "azure"
+    PROVIDER_BACKEND = "azure-oauth2"
+    PROVIDER_ID = "oa2-azure-oauth2"
+
     def setUp(self):
         super().setUp()
         self.provider = self.configure_azure_ad_provider(

--- a/common/djangoapps/third_party_auth/tests/specs/test_google.py
+++ b/common/djangoapps/third_party_auth/tests/specs/test_google.py
@@ -19,6 +19,10 @@ from common.djangoapps.third_party_auth.tests.specs import base
 class GoogleOauth2IntegrationTest(base.Oauth2IntegrationTest):  # lint-amnesty, pylint: disable=test-inherits-tests
     """Integration tests for provider.GoogleOauth2."""
 
+    PROVIDER_NAME = "google"
+    PROVIDER_BACKEND = "google-oauth2"
+    PROVIDER_ID = "oa2-google-oauth2"
+
     def setUp(self):
         super().setUp()
         self.provider = self.configure_google_provider(

--- a/common/djangoapps/third_party_auth/tests/specs/test_linkedin.py
+++ b/common/djangoapps/third_party_auth/tests/specs/test_linkedin.py
@@ -16,6 +16,10 @@ def get_localized_name(name):
 class LinkedInOauth2IntegrationTest(base.Oauth2IntegrationTest):  # lint-amnesty, pylint: disable=test-inherits-tests
     """Integration tests for provider.LinkedInOauth2."""
 
+    PROVIDER_NAME = "linkedin"
+    PROVIDER_BACKEND = "linkedin-oauth2"
+    PROVIDER_ID = "oa2-linkedin-oauth2"
+
     def setUp(self):
         super().setUp()
         self.provider = self.configure_linkedin_provider(

--- a/common/djangoapps/third_party_auth/tests/specs/test_twitter.py
+++ b/common/djangoapps/third_party_auth/tests/specs/test_twitter.py
@@ -10,6 +10,10 @@ from common.djangoapps.third_party_auth.tests.specs import base
 class TwitterIntegrationTest(base.Oauth2IntegrationTest):  # lint-amnesty, pylint: disable=test-inherits-tests
     """Integration tests for Twitter backend."""
 
+    PROVIDER_NAME = "twitter"
+    PROVIDER_BACKEND = "twitter-oauth2"
+    PROVIDER_ID = "oa2-twitter-oauth2"
+
     def setUp(self):
         super().setUp()
         self.provider = self.configure_twitter_provider(

--- a/common/djangoapps/third_party_auth/tests/test_utils.py
+++ b/common/djangoapps/third_party_auth/tests/test_utils.py
@@ -4,14 +4,19 @@ Tests for third_party_auth utility functions.
 
 
 import unittest
+from unittest import mock
+from unittest.mock import MagicMock
 
+import ddt
 from django.conf import settings
 
 from common.djangoapps.student.tests.factories import UserFactory
 from common.djangoapps.third_party_auth.tests.testutil import TestCase
 from common.djangoapps.third_party_auth.utils import (
+    get_associated_user_by_email_response,
     get_user_from_email,
     is_enterprise_customer_user,
+    is_oauth_provider,
     user_exists,
     convert_saml_slug_provider_id,
 )
@@ -21,6 +26,7 @@ from openedx.features.enterprise_support.tests.factories import (
 )
 
 
+@ddt.ddt
 @unittest.skipUnless(settings.ROOT_URLCONF == 'lms.urls', 'Test only valid in lms')
 class TestUtils(TestCase):
     """
@@ -77,3 +83,48 @@ class TestUtils(TestCase):
 
         assert is_enterprise_customer_user('the-provider', user)
         assert not is_enterprise_customer_user('the-provider', other_user)
+
+    @ddt.data(
+        ('saml-farkle', False),
+        ('oa2-fergus', True),
+        ('oa2-felicia', True),
+    )
+    @ddt.unpack
+    def test_is_oauth_provider(self, provider_id, oauth_provider):
+        """
+        Tests if the backend name is that of an auth provider or not
+        """
+        with mock.patch(
+            'common.djangoapps.third_party_auth.utils.provider.Registry.get_from_pipeline'
+        ) as get_from_pipeline:
+            get_from_pipeline.return_value.provider_id = provider_id
+
+            self.assertEqual(is_oauth_provider('backend_name'), oauth_provider)
+
+    @ddt.data(
+        (None, False),
+        (None, False),
+        ('The Muffin Man', True),
+        ('Gingerbread Man', False),
+    )
+    @ddt.unpack
+    def test_get_associated_user_by_email_response(self, user, user_is_active):
+        """
+        Tests if an association response is returned for a user
+        """
+        with mock.patch(
+            'common.djangoapps.third_party_auth.utils.associate_by_email',
+            side_effect=lambda _b, _d, u, *_a, **_k: {'user': u} if u else None,
+        ):
+            mock_user = MagicMock(return_value=user)
+            mock_user.is_active = user_is_active
+
+            association_response, user_is_active_resonse = get_associated_user_by_email_response(
+                backend=None, details=None, user=mock_user)
+
+            if association_response:
+                self.assertEqual(association_response['user'](), user)
+                self.assertEqual(user_is_active_resonse, user_is_active)
+            else:
+                self.assertIsNone(association_response)
+                self.assertFalse(user_is_active_resonse)


### PR DESCRIPTION
## Description

Currently, in the edX platform, if you try to login with an SSO account using the login form, a username is generated for you based on the email that is used with the SSO provider.

The username is generated using the pipeline `third_party_auth.pipeline.get_username`.

If the username already exists in the platform, you run into a small conflict which sends you back to the login form and requests the following:
![image](https://user-images.githubusercontent.com/5631091/109410595-f82d8280-79ac-11eb-854f-d60339e9fd9b.png)

It basically requests that you link your edX account and your SSO account.

However, sometimes we would want the edX account and SSO account to be associated by email. There's already a special pipeline available in the platform for that, `third_party_auth.pipeline.associate_by_email_if_login_api`. Sadly, however, it is only available for a certain entry method of authentication, called `login_api`.

~~So in order to start associating the edX account and SSO account by email, this pull request adds a waffle switch.~~

~~**Update:** After a lot of reading through the code and investigation, it seems like the `login_api` auth entry is no longer used. Accordingly, I took the liberty of removing said pipeline and replacing it with something that seemed useful. Now the pipeline runs whenever third party authentication is required.~~

**Update**: After @waheedahmed's [findings](https://github.com/edx/edx-platform/pull/25935#pullrequestreview-611983769), which is that `login_api` is in fact still used, and @zamanafzal's [request](https://github.com/edx/edx-platform/pull/25935#discussion_r595030485), which is to make the functionality specific to Oauth providers, a new pipeline was added to associate the user by email **only when the following conditions are met**:
* The social auth provider is an Oauth2 provider
* The `ENABLE_REQUIRE_THIRD_PARTY_AUTH` is enabled

## Supporting information

* **JIRA tickets**: SE-3816, [OSPR-5312](https://openedx.atlassian.net/browse/OSPR-5312)
* **Sandbox URL**:
  * Default Behavior:
    * LMS: https://pr25935-default.sandbox.opencraft.hosting/
    * Studio: https://studio.pr25935-default.sandbox.opencraft.hosting/
  * New Behavior:
    * LMS: https://pr25935.sandbox.opencraft.hosting/
    * Studio: https://studio.pr25935.sandbox.opencraft.hosting/

## Testing instructions

### Preparation

Please send an email to `nizar` at `opencraft.com`, requesting to be added as a test user to the Google SSO used for this sandbox.

**You need a Google Account, because you'll be using the same email address when registering through the form and through the SSO.**

### Reproducing the problem

#### Logging in with the SSO

Login with the Google SSO over at the sandbox with [default behavior](https://pr25935-default.sandbox.opencraft.hosting/)

#### Removing Social Auth Record

Sign in as `staff`:`edx` into the [django admin](https://pr25935-default.sandbox.opencraft.hosting/admin) and delete the [user social auth](https://pr25935-default.sandbox.opencraft.hosting/admin/social_django/usersocialauth) for your user.

#### Logging in with the SSO, again...

Login, again, with the Google SSO over at the sandbox with [default behavior](https://pr25935-default.sandbox.opencraft.hosting/). After doing that, you should receive a similar screenshot
![image](https://user-images.githubusercontent.com/5631091/109410595-f82d8280-79ac-11eb-854f-d60339e9fd9b.png)

### Testing the fix

#### Logging in with the SSO

Login with the Google SSO over at the sandbox with [default behavior](https://pr25935.sandbox.opencraft.hosting/)

#### Removing Social Auth Record

Sign in as `staff`:`edx` into the [django admin](https://pr25935.sandbox.opencraft.hosting/admin) and delete the [user social auth](https://pr25935.sandbox.opencraft.hosting/admin/social_django/usersocialauth) for your user.

#### Logging in with the SSO, again...

Login, again, with the Google SSO over at the sandbox with [default behavior](https://pr25935.sandbox.opencraft.hosting/). After that, you should be able to directly login 😃 

**Settings**
```yaml
EDXAPP_LMS_ENV_EXTRA:
  ENABLE_REQUIRE_THIRD_PARTY_AUTH: true
```