### PR TITLE
Fix URL in forum notification post.

### DIFF
--- a/lms/djangoapps/discussion/tasks.py
+++ b/lms/djangoapps/discussion/tasks.py
@@ -167,10 +167,12 @@ def _build_message_context(context):  # lint-amnesty, pylint: disable=missing-fu
 
 
 def _get_thread_url(context):  # lint-amnesty, pylint: disable=missing-function-docstring
+    scheme = 'https' if settings.HTTPS == 'on' else 'http'
+    base_url = '{}://{}'.format(scheme, context['site'].domain)
     thread_content = {
         'type': 'thread',
         'course_id': context['course_id'],
         'commentable_id': context['thread_commentable_id'],
         'id': context['thread_id'],
     }
-    return urljoin(context['site'].domain, permalink(thread_content))
+    return urljoin(base_url, permalink(thread_content))

--- a/lms/djangoapps/discussion/tests/test_tasks.py
+++ b/lms/djangoapps/discussion/tests/test_tasks.py
@@ -212,7 +212,7 @@ class TaskTestCase(ModuleStoreTestCase):  # lint-amnesty, pylint: disable=missin
                 'thread_title': 'thread-title',
                 'thread_username': self.thread_author.username,
                 'thread_commentable_id': self.thread['commentable_id'],
-                'post_link': self.mock_permalink.return_value,
+                'post_link': 'https://{}{}'.format(site.domain, self.mock_permalink.return_value),
                 'site': site,
                 'site_id': site.id
             })


### PR DESCRIPTION
This fixes the URL to the discussion thread that is included in forum notification emails.

The problem was that in order for `urljoin` to return an absolute URL, the first argument needs to include the protocol. We were using `site.domain` which doesn't include the protocol.

`urljoin('my.domain.com', '/my/path')` returns `'/my/path'`. We have to makesure to use the full base url (starting with `http(s)://`) and not just the site's domain for generating the discussion thread URL.

**Test instructions**:

1. Login to LMS with a user account and navigate to discussions tab of a particular course that the user is enrolled in.
2. Enable the checkbox is selected in the Receive updates section of the discussion page.
3. Now add a new post but clicking on Add a Post button in the top of the page.
4. Logout and login with a second user account (you can use one of the [default accounts](https://openedx.atlassian.net/wiki/spaces/OXA/pages/157751033/What+are+the+default+accounts+and+passwords)).
5. Navigate to the dicussions tab of the previous course and click on All Discussions to see the post created earlier.
6. Post a reply on the thread.
7. Verify the first user receives the email notification and that the "View Discussion" link in the email is working and linking to the correct discussion.

**Sandbox URL**:

- https://pr25941.sandbox.opencraft.hosting

**Notes**:

This also requires the settings `enable_forum_notifications` to set to `true` in django admin `SiteConfiguration` object. See [instructions](https://edx.readthedocs.io/projects/edx-installing-configuring-and-running/en/latest/configuration/enable_discussion_notifications.html#enable-discussion-notifications) for more details. I enabled the setting on the sandbox.

**Reviewers**

- [ ] @pkulkark 
- [ ] edX reviewer[s] TBD