### PR TITLE
fix: prevent a backbone fieldview race condition that can delete user input

### DIFF
--- a/lms/static/js/views/fields.js
+++ b/lms/static/js/views/fields.js
@@ -141,9 +141,9 @@
             },
 
             showSuccessMessage: function() {
-                var context,
+                var context = Date.now(),
                     successMessage = this.getMessage('success'),
-                    view;
+                    view = this;
 
                 this.showNotificationMessage(successMessage);
 
@@ -154,9 +154,6 @@
                     location.reload(true);
                 }
 
-                view = this;
-
-                context = Date.now();
                 this.lastSuccessMessageContext = context;
 
                 setTimeout(function() {
@@ -176,10 +173,10 @@
                     validationErrorMessage,
                     message;
                 if (xhr.status === 400) {
-                    errors = JSON.parse(xhr.responseText);
-                    validationErrorMessage = errors.field_errors[this.options.valueAttribute].user_message;
-                    message = HtmlUtils.joinHtml(this.indicators.validationError, validationErrorMessage);
                     try {
+                        errors = JSON.parse(xhr.responseText);
+                        validationErrorMessage = errors.field_errors[this.options.valueAttribute].user_message;
+                        message = HtmlUtils.joinHtml(this.indicators.validationError, validationErrorMessage);
                         this.showNotificationMessage(message);
                     } catch (error) {
                         this.showNotificationMessage(this.getMessage('error'));
@@ -210,21 +207,19 @@
             },
 
             saveAttributes: function(attributes, options) {
-                var view,
-                    defaultOptions;
+                var view = this;
+                var defaultOptions = {
+                    contentType: 'application/merge-patch+json',
+                    patch: true,
+                    wait: true,
+                    success: function() {
+                        view.saveSucceeded();
+                    },
+                    error: function(model, xhr) {
+                        view.showErrorMessage(xhr);
+                    }
+                };
                 if (this.persistChanges === true) {
-                    view = this;
-                    defaultOptions = {
-                        contentType: 'application/merge-patch+json',
-                        patch: true,
-                        wait: true,
-                        success: function() {
-                            view.saveSucceeded();
-                        },
-                        error: function(model, xhr) {
-                            view.showErrorMessage(xhr);
-                        }
-                    };
                     this.showInProgressMessage();
                     this.model.save(attributes, _.extend(defaultOptions, options));
                 }
@@ -487,8 +482,9 @@
             },
 
             displayValue: function(value) {
-                var option = this.optionForValue(value);
+                var option;
                 if (value) {
+                    option = this.optionForValue(value);
                     return (option ? option[1] : '');
                 } else {
                     return '';

--- a/lms/static/js/views/fields.js
+++ b/lms/static/js/views/fields.js
@@ -383,7 +383,16 @@
 
             updateValueInField: function() {
                 var value = (_.isUndefined(this.modelValue()) || _.isNull(this.modelValue())) ? '' : this.modelValue();
-                this.$('.u-field-value input').val(value);
+
+                var fieldHasFocus = (document.activeElement === this.$('.u-field-value input')[0]);
+                var fieldChanged = this.fieldValue() !== value;
+                if (fieldHasFocus && fieldChanged) {
+                    // Race conidtion between successive user-changed input
+                    // If user changed input after it was submitted before it was saved,
+                    // do nothing, it will be handled by normal finishEditing hooks.
+                } else {
+                    this.$('.u-field-value input').val(value);
+                }
             },
 
             saveValue: function() {
@@ -477,8 +486,20 @@
             },
 
             updateValueInField: function() {
+                var value;  // str
+                var fieldHasFocus;  //bool
+                var fieldChanged;  //bool
                 if (this.editable !== 'never') {
-                    this.$('.u-field-value select').val(this.modelValue() || '');
+                    value = this.modelValue() || '';
+                    fieldHasFocus = (document.activeElement === this.$('.u-field-value select')[0]);
+                    fieldChanged = this.fieldValue() !== value;
+                    if (fieldHasFocus && fieldChanged) {
+                        // Race conidtion between successive user-changed input
+                        // If user changed input after it was submitted before it was saved,
+                        // do nothing, it will be handled by normal finishEditing hooks.
+                    } else {
+                        this.$('.u-field-value select').val(value);
+                    }
                 }
 
                 var value = this.displayValue(this.modelValue() || '');

--- a/lms/static/js/views/fields.js
+++ b/lms/static/js/views/fields.js
@@ -111,7 +111,7 @@
             },
 
             showHelpMessage: function(message) {
-                var msg;
+                var msg = message;
                 if (_.isUndefined(message) || _.isNull(message)) {
                     msg = this.helpMessage;
                 }

--- a/lms/static/js/views/fields.js
+++ b/lms/static/js/views/fields.js
@@ -141,9 +141,9 @@
             },
 
             showSuccessMessage: function() {
-                var context = Date.now();
-                var successMessage = this.getMessage('success');
-                var view = this;
+                var context,
+                    successMessage = this.getMessage('success'),
+                    view;
 
                 this.showNotificationMessage(successMessage);
 
@@ -154,6 +154,9 @@
                     location.reload(true);
                 }
 
+                view = this;
+
+                context = Date.now();
                 this.lastSuccessMessageContext = context;
 
                 setTimeout(function() {
@@ -169,10 +172,13 @@
             },
 
             showErrorMessage: function(xhr) {
-                var errors = JSON.parse(xhr.responseText),
-                    validationErrorMessage = errors.field_errors[this.options.valueAttribute].user_message,
-                    message = HtmlUtils.joinHtml(this.indicators.validationError, validationErrorMessage);
+                var errors,
+                    validationErrorMessage,
+                    message;
                 if (xhr.status === 400) {
+                    errors = JSON.parse(xhr.responseText);
+                    validationErrorMessage = errors.field_errors[this.options.valueAttribute].user_message;
+                    message = HtmlUtils.joinHtml(this.indicators.validationError, validationErrorMessage);
                     try {
                         this.showNotificationMessage(message);
                     } catch (error) {
@@ -204,7 +210,10 @@
             },
 
             saveAttributes: function(attributes, options) {
-                var view = this,
+                var view,
+                    defaultOptions;
+                if (this.persistChanges === true) {
+                    view = this;
                     defaultOptions = {
                         contentType: 'application/merge-patch+json',
                         patch: true,
@@ -216,7 +225,6 @@
                             view.showErrorMessage(xhr);
                         }
                     };
-                if (this.persistChanges === true) {
                     this.showInProgressMessage();
                     this.model.save(attributes, _.extend(defaultOptions, options));
                 }

--- a/lms/static/js/views/fields.js
+++ b/lms/static/js/views/fields.js
@@ -1,5 +1,5 @@
 /* eslint no-underscore-dangle: [2, { "allow": ["_super"] }] */
-(function(define) {
+(function(define, undef) {
     'use strict';
     define([
         'gettext', 'jquery', 'underscore', 'backbone',
@@ -111,10 +111,12 @@
             },
 
             showHelpMessage: function(message) {
+                var msg;
+                if (_.isUndefined(message) || _.isNull(message)) {
+                    msg = this.helpMessage;
+                }
                 this.$('.u-field-message-notification').html('');
-                HtmlUtils.setHtml(this.$('.u-field-message-help'),
-                  (_.isUndefined(message) || _.isNull(message)) ? this.helpMessage : message
-                );
+                HtmlUtils.setHtml(this.$('.u-field-message-help'), msg);
             },
 
             getNotificationMessage: function() {
@@ -428,7 +430,7 @@
                     editable: this.editable,
                     title: this.options.title,
                     screenReaderTitle: this.options.screenReaderTitle || this.options.title,
-                    titleVisible: this.options.titleVisible !== undefined ? this.options.titleVisible : true,
+                    titleVisible: this.options.titleVisible !== undef ? this.options.titleVisible : true,
                     iconName: this.options.iconName,
                     showBlankOption: (!this.options.required || !this.modelValueIsSet()),
                     groupOptions: this.createGroupOptions(),

--- a/lms/static/js/views/fields.js
+++ b/lms/static/js/views/fields.js
@@ -391,11 +391,7 @@
 
                 var fieldHasFocus = (document.activeElement === this.$('.u-field-value input')[0]);
                 var fieldChanged = this.fieldValue() !== value;
-                if (fieldHasFocus && fieldChanged) {
-                    // Race conidtion between successive user-changed input
-                    // If user changed input after it was submitted before it was saved,
-                    // do nothing, it will be handled by normal finishEditing hooks.
-                } else {
+                if (!fieldHasFocus || !fieldChanged) {
                     this.$('.u-field-value input').val(value);
                 }
             },
@@ -499,11 +495,7 @@
                     value = this.modelValue() || '';
                     fieldHasFocus = (document.activeElement === this.$('.u-field-value select')[0]);
                     fieldChanged = this.fieldValue() !== value;
-                    if (fieldHasFocus && fieldChanged) {
-                        // Race conidtion between successive user-changed input
-                        // If user changed input after it was submitted before it was saved,
-                        // do nothing, it will be handled by normal finishEditing hooks.
-                    } else {
+                    if (!fieldHasFocus || !fieldChanged) {
                         this.$('.u-field-value select').val(value);
                     }
                 }

--- a/lms/static/js/views/fields.js
+++ b/lms/static/js/views/fields.js
@@ -1,3 +1,4 @@
+/* eslint no-underscore-dangle: [2, { "allow": ["_super"] }] */
 (function(define) {
     'use strict';
     define([
@@ -188,7 +189,7 @@
                 _.bindAll(this, 'saveAttributes', 'saveSucceeded', 'showDisplayMode', 'showEditMode',
                     'startEditing', 'finishEditing'
                 );
-                this.super(options);
+                this._super(options);
 
                 this.editable = _.isUndefined(this.options.editable) ? 'always' : this.options.editable;
                 this.$el.addClass('editable-' + this.editable);
@@ -290,7 +291,7 @@
             fieldTemplate: fieldReadOnlyTemplate,
 
             initialize: function(options) {
-                this.super(options);
+                this._super(options);
                 _.bindAll(this, 'render', 'fieldValue', 'updateValueInField');
                 this.listenTo(this.model, 'change:' + this.options.valueAttribute, this.updateValueInField);
             },
@@ -359,7 +360,7 @@
             },
 
             initialize: function(options) {
-                this.super(options);
+                this._super(options);
                 _.bindAll(this, 'render', 'fieldValue', 'updateValueInField', 'saveValue');
                 this.listenTo(this.model, 'change:' + this.options.valueAttribute, this.updateValueInField);
             },
@@ -415,7 +416,7 @@
             initialize: function(options) {
                 _.bindAll(this, 'render', 'optionForValue', 'fieldValue', 'displayValue', 'updateValueInField',
                     'saveValue', 'createGroupOptions');
-                this.super(options);
+                this._super(options);
 
                 this.listenTo(this.model, 'change:' + this.options.valueAttribute, this.updateValueInField);
             },
@@ -520,14 +521,14 @@
             },
 
             showDisplayMode: function(render) {
-                this.super(render);
+                this._super(render);
                 if (this.editable === 'toggle') {
                     this.$('.u-field-value a').focus();
                 }
             },
 
             showEditMode: function(render) {
-                this.super(render);
+                this._super(render);
                 if (this.editable === 'toggle') {
                     this.$('.u-field-value select').focus();
                 }
@@ -542,7 +543,7 @@
                     this.$('option[value=""]').remove();
                 }
 
-                this.super();
+                this._super();
             },
 
             disableField: function(disable) {
@@ -581,7 +582,7 @@
             initialize: function(options) {
                 _.bindAll(this, 'render', 'onKeyDown', 'adjustTextareaHeight', 'manageTextareaContentChange',
                     'fieldValue', 'saveValue', 'updateView');
-                this.super(options);
+                this._super(options);
                 this.listenTo(this.model, 'change:' + this.options.valueAttribute, this.updateView);
             },
 
@@ -657,7 +658,7 @@
             },
 
             modelValue: function() {
-                var value = this.super();
+                var value = this._super();
                 return value ? $.trim(value) : '';
             },
 
@@ -686,13 +687,13 @@
             },
 
             showEditMode: function(render) {
-                this.super(render);
+                this._super(render);
                 this.adjustTextareaHeight();
                 this.$('.u-field-value textarea').focus();
             },
 
             saveSucceeded: function() {
-                this.super();
+                this._super();
                 if (this.editable === 'toggle') {
                     this.showDisplayMode(true);
                     this.$('a').focus();
@@ -711,7 +712,7 @@
             },
 
             initialize: function(options) {
-                this.super(options);
+                this._super(options);
                 _.bindAll(this, 'render', 'linkClicked');
             },
 

--- a/lms/static/js/views/fields.js
+++ b/lms/static/js/views/fields.js
@@ -1,4 +1,4 @@
-/* eslint no-underscore-dangle: [2, { "allow": ["_super"] }] */
+/* eslint no-underscore-dangle: ["error", { "allow": ["_super"] }] */
 (function(define, undef) {
     'use strict';
     define([


### PR DESCRIPTION
    prevent a backbone fieldview race condition that can delete user input
    
    when the user is focused on an input, and the value of the input has
    changed from the model (user has typed), ignore round-trip field updates 
    because these would delete user input data.  This newly entered data will 
    be submitted normally on finishEditing

**JIRA tickets**: BB-3171

**Dependencies**: None

**Screenshots**: Visually Identical, modified-behavior prevents user-entered text in an html input tag from being deleted, which looks like normal form text entry with least astonishment.

**Merge deadline**: None, Originally Nov 12 (passed due)

**Testing instructions**:

Manual testing:
1. prepare a development environment such as devstack, detailed [here](https://github.com/edx/devstack) and [here](https://edx.readthedocs.io/projects/open-edx-devstack/en/latest/developing_on_named_release_branches.html?highlight=release)
1. checkout edx-platform with to the fix branch (github repo `open-craft/edx-platform`, branch `dylan@opencraft.com/lms-settings-race-condition`) this should be sufficient to load the code changes with devstack
2. register a demo student user with lms (lms port in devstack is `:18000` and the registration document_uri is `/register`), create/login to this account 
2. visit the modify account settings page (document_uri is `/account/settings`)
2. in your browser developer tools, you may need to disable network caching as this fix modifies static assets
3. Under lms /accounts/settings, focus an editable field, and rapidly submit then modify the value.  For example the username field.  I used xdotool to submit the following keystrokes: `sleep 2; xdotool key F Return BackSpace S` (when executing this shell command, a 2 second sleep gives time to manually alt-tab to focus on the webpage/input textbox before entering the test keystroke.  This can be done by hand, by similarly pressing `F<enter><backspace>S` rapidly enough.
If you were rapid enough to modify the text field before the network response (you can monitor the browser developer tools "network" tab to observing generated ajex request are still pending/in-flight when the keystroke is finished) we can observe: without the fix, the `F` suffix (to visually indicate undesired behavior) overwrites the `S` suffix (visually indicate desired behavior); with the fix: the `F` suffix is deleted and replaced by the `S` suffix and this edit stays in the input box after the previous `F` suffix is acknowledged by the server/ajax response.


This fix is also applied to DropDown widgets, due to requiring a physically harder keystroke, I used the utility `xdotool` to cause the dropdown submission/update to be fast enough with `sleep 2; xdotool key  Down Tab Shift_L+Tab Down Tab Shift_L+Tab Up Up`.  These fixes use the same branching logic in java script to disable overwriting user-changed input, (as in there are two copies of a small amount of nearly identical code in this PR, I'm open to converting it to a function, I don't have a good sense of preference for creating functions in backbone js contexts, I welcome your feedback).

my manual testing journal:
    manual testing:
      - [x] observed that normal page loads (lms /accounts/settings) do not trigger any race conditions on normal form population
      - [x] observed TextFieldView elements ignore the race condition by focusing (username) and entrying the keysequence "s<enter>s<enter>" rapidly
      - [x] observed DropdownFieldView elements ignore the race condition by focusing the "country" dropdown and using `xdotool` to rapidly enter the key sequence:
            sleep 2; xdotool key  Down Tab Shift_L+Tab Down Tab Shift_L+Tab Up Up


    manual tests attempted to use javascript to reproduce the race condition, I did not find an obvious or simple way to create the correct events to make this testing more synthetic, I am interested in ways to better automate these tests.
    
    the source ticket (tasks.opencraft.com) BB-3171 mentions this issue was identified by automated testing, I am not sure which automated test detects the issue, or if the test reproduces the issues consistently
    
Optionally, I used this patch to log the behavior during manual testing, this temporarily helped ensure events were submitted fast enough and behaved correctly
```
    ---- BEGING PATCH -----
    diff --git a/lms/static/js/views/fields.js b/lms/static/js/views/fields.js
    index a157910f9e..186b124f2e 100644
    --- a/lms/static/js/views/fields.js
    +++ b/lms/static/js/views/fields.js
    @@ -390,7 +390,9 @@
                         // Race conidtion between successive user-changed input
                         // If user changed input after it was submitted before it was saved,
                         // do nothing, it will be handled by normal finishEditing hooks.
    +                    console.log('TextareaFieldView: race condition ignored (new behavior)')
                     } else {
    +                    console.log('TextareaFieldView: no race condition (original behavior)')
                         this.$('.u-field-value input').val(value);
                     }
                 },
    @@ -494,8 +496,10 @@
                             // Race conidtion between successive user-changed input
                             // If user changed input after it was submitted before it was saved,
                             // do nothing, it will be handled by normal finishEditing hooks.
    +                        console.log('DropdownFieldView: race condition ignored (new behavior)')
                         } else {
                             this.$('.u-field-value select').val(value);
    +                        console.log('DropdownFieldView: no race condition (original behavior)')
                         }
                     }
    
    ----- END PATCH -----
```

**Author notes and concerns**:

2. There are currently no automated tests known by the author to exercise the broken or fixed behavior
3. The necessity to disable browser cache during development/testing indicates a fragile roll out.  Does it make sense to use a new namespace for the fixed javascript methods to ensure clean client side cache invalidation? My best guess is that backbone relies on fixed namespaces, a change to that may be very disruptive.
4. This behavior change required modifying a shared library, meaning this change as the potential to impact a huge number of input fields throughout the edx-platform.  No non-accounts/settings fields were tested, no discovery to identify impact has been done.  No discovery to identify if there are tests to exercise lms backbone FieldView use.
5. this was developed originally with edx/edx-platform:open-release/juniper.master and the backported to open-craft/edx-platform:opencraft-release/juniper.3, the modified file (lms/static/js/views/fields.js) has been unchanged for a very long time, but beware, I the author do not know the full story of the history or future of this file across major version/releases

**Reviewers**
- [x] @viadanna 
- [ ] edX reviewer[s] TBD

Hello, I'm a first time openedx contributor with OpenCraft, Thank You for, and I welcome, your feedback.  For example, because this is a bug-fix, it was unclear to me if I should open a Jira discussion in advance.  Thanks