### PR TITLE
import task decorator from celery APP instance in CMS

### DIFF
--- a/cms/djangoapps/cms_user_tasks/tasks.py
+++ b/cms/djangoapps/cms_user_tasks/tasks.py
@@ -5,7 +5,7 @@ Celery tasks used by cms_user_tasks
 
 from boto.exception import NoAuthHandlerFound
 from celery.exceptions import MaxRetriesExceededError
-from celery.task import shared_task
+from celery import shared_task
 from celery.utils.log import get_task_logger
 from django.conf import settings
 from django.core import mail

--- a/cms/djangoapps/cms_user_tasks/tasks.py
+++ b/cms/djangoapps/cms_user_tasks/tasks.py
@@ -5,6 +5,7 @@ Celery tasks used by cms_user_tasks
 
 from boto.exception import NoAuthHandlerFound
 from celery.exceptions import MaxRetriesExceededError
+from celery.task import shared_task
 from celery.utils.log import get_task_logger
 from django.conf import settings
 from django.core import mail
@@ -12,14 +13,13 @@ from edx_django_utils.monitoring import set_code_owner_attribute
 
 from common.djangoapps.edxmako.shortcuts import render_to_string
 from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
-from openedx.core.lib.celery import APP
 
 LOGGER = get_task_logger(__name__)
 TASK_COMPLETE_EMAIL_MAX_RETRIES = 3
 TASK_COMPLETE_EMAIL_TIMEOUT = 60
 
 
-@APP.task(bind=True)
+@shared_task(bind=True)
 @set_code_owner_attribute
 def send_task_complete_email(self, task_name, task_state_text, dest_addr, detail_url):
     """

--- a/cms/djangoapps/cms_user_tasks/tasks.py
+++ b/cms/djangoapps/cms_user_tasks/tasks.py
@@ -5,7 +5,6 @@ Celery tasks used by cms_user_tasks
 
 from boto.exception import NoAuthHandlerFound
 from celery.exceptions import MaxRetriesExceededError
-from celery.task import task
 from celery.utils.log import get_task_logger
 from django.conf import settings
 from django.core import mail
@@ -13,13 +12,14 @@ from edx_django_utils.monitoring import set_code_owner_attribute
 
 from common.djangoapps.edxmako.shortcuts import render_to_string
 from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
+from openedx.core.lib.celery import APP
 
 LOGGER = get_task_logger(__name__)
 TASK_COMPLETE_EMAIL_MAX_RETRIES = 3
 TASK_COMPLETE_EMAIL_TIMEOUT = 60
 
 
-@task(bind=True)
+@APP.task(bind=True)
 @set_code_owner_attribute
 def send_task_complete_email(self, task_name, task_state_text, dest_addr, detail_url):
     """

--- a/cms/djangoapps/contentstore/tasks.py
+++ b/cms/djangoapps/contentstore/tasks.py
@@ -12,7 +12,6 @@ from datetime import datetime
 from tempfile import NamedTemporaryFile, mkdtemp
 
 from ccx_keys.locator import CCXLocator
-from celery.task import task
 from celery.utils.log import get_task_logger
 from django.conf import settings
 from django.contrib.auth import get_user_model
@@ -43,6 +42,7 @@ from cms.djangoapps.contentstore.utils import initialize_permissions, reverse_us
 from cms.djangoapps.models.settings.course_metadata import CourseMetadata
 from common.djangoapps.course_action_state.models import CourseRerunState
 from openedx.core.djangoapps.embargo.models import CountryAccessRule, RestrictedCourse
+from openedx.core.lib.celery import APP
 from openedx.core.lib.extract_tar import safetar_extractall
 from common.djangoapps.student.auth import has_course_author_access
 from xmodule.contentstore.django import contentstore
@@ -83,7 +83,7 @@ def clone_instance(instance, field_values):
     return instance
 
 
-@task
+@APP.task
 @set_code_owner_attribute
 def rerun_course(source_course_key_string, destination_course_key_string, user_id, fields=None):
     """
@@ -170,7 +170,7 @@ def _parse_time(time_isoformat):
     ).replace(tzinfo=UTC)
 
 
-@task
+@APP.task
 @set_code_owner_attribute
 def update_search_index(course_id, triggered_time_isoformat):
     """ Updates course search index. """
@@ -195,7 +195,7 @@ def update_search_index(course_id, triggered_time_isoformat):
         LOGGER.debug(u'Search indexing successful for complete course %s', course_id)
 
 
-@task
+@APP.task
 @set_code_owner_attribute
 def update_library_index(library_id, triggered_time_isoformat):
     """ Updates course search index. """
@@ -241,7 +241,7 @@ class CourseExportTask(UserTask):  # pylint: disable=abstract-method
         return u'Export of {}'.format(key)
 
 
-@task(base=CourseExportTask, bind=True)
+@APP.task(base=CourseExportTask, bind=True)
 # Note: The decorator @set_code_owner_attribute could not be used because
 #   the implementation of this task breaks with any additional decorators.
 def export_olx(self, user_id, course_key_string, language):
@@ -376,7 +376,7 @@ class CourseImportTask(UserTask):  # pylint: disable=abstract-method
         return u'Import of {} from {}'.format(key, filename)
 
 
-@task(base=CourseImportTask, bind=True)
+@APP.task(base=CourseImportTask, bind=True)
 # Note: The decorator @set_code_owner_attribute could not be used because
 #   the implementation of this task breaks with any additional decorators.
 def import_olx(self, user_id, course_key_string, archive_path, archive_name, language):

--- a/cms/djangoapps/contentstore/tasks.py
+++ b/cms/djangoapps/contentstore/tasks.py
@@ -12,6 +12,7 @@ from datetime import datetime
 from tempfile import NamedTemporaryFile, mkdtemp
 
 from ccx_keys.locator import CCXLocator
+from celery.task import shared_task
 from celery.utils.log import get_task_logger
 from django.conf import settings
 from django.contrib.auth import get_user_model
@@ -42,7 +43,6 @@ from cms.djangoapps.contentstore.utils import initialize_permissions, reverse_us
 from cms.djangoapps.models.settings.course_metadata import CourseMetadata
 from common.djangoapps.course_action_state.models import CourseRerunState
 from openedx.core.djangoapps.embargo.models import CountryAccessRule, RestrictedCourse
-from openedx.core.lib.celery import APP
 from openedx.core.lib.extract_tar import safetar_extractall
 from common.djangoapps.student.auth import has_course_author_access
 from xmodule.contentstore.django import contentstore
@@ -83,7 +83,7 @@ def clone_instance(instance, field_values):
     return instance
 
 
-@APP.task
+@shared_task
 @set_code_owner_attribute
 def rerun_course(source_course_key_string, destination_course_key_string, user_id, fields=None):
     """
@@ -170,7 +170,7 @@ def _parse_time(time_isoformat):
     ).replace(tzinfo=UTC)
 
 
-@APP.task
+@shared_task
 @set_code_owner_attribute
 def update_search_index(course_id, triggered_time_isoformat):
     """ Updates course search index. """
@@ -195,7 +195,7 @@ def update_search_index(course_id, triggered_time_isoformat):
         LOGGER.debug(u'Search indexing successful for complete course %s', course_id)
 
 
-@APP.task
+@shared_task
 @set_code_owner_attribute
 def update_library_index(library_id, triggered_time_isoformat):
     """ Updates course search index. """
@@ -241,7 +241,7 @@ class CourseExportTask(UserTask):  # pylint: disable=abstract-method
         return u'Export of {}'.format(key)
 
 
-@APP.task(base=CourseExportTask, bind=True)
+@shared_task(base=CourseExportTask, bind=True)
 # Note: The decorator @set_code_owner_attribute could not be used because
 #   the implementation of this task breaks with any additional decorators.
 def export_olx(self, user_id, course_key_string, language):
@@ -376,7 +376,7 @@ class CourseImportTask(UserTask):  # pylint: disable=abstract-method
         return u'Import of {} from {}'.format(key, filename)
 
 
-@APP.task(base=CourseImportTask, bind=True)
+@shared_task(base=CourseImportTask, bind=True)
 # Note: The decorator @set_code_owner_attribute could not be used because
 #   the implementation of this task breaks with any additional decorators.
 def import_olx(self, user_id, course_key_string, archive_path, archive_name, language):

--- a/cms/djangoapps/contentstore/tasks.py
+++ b/cms/djangoapps/contentstore/tasks.py
@@ -12,7 +12,7 @@ from datetime import datetime
 from tempfile import NamedTemporaryFile, mkdtemp
 
 from ccx_keys.locator import CCXLocator
-from celery.task import shared_task
+from celery import shared_task
 from celery.utils.log import get_task_logger
 from django.conf import settings
 from django.contrib.auth import get_user_model

--- a/common/djangoapps/entitlements/tasks.py
+++ b/common/djangoapps/entitlements/tasks.py
@@ -3,7 +3,7 @@ This file contains celery tasks for entitlements-related functionality.
 """
 
 
-from celery import task
+from celery import shared_task
 from celery.utils.log import get_task_logger
 from django.conf import settings
 from edx_django_utils.monitoring import set_code_owner_attribute
@@ -19,7 +19,7 @@ LOGGER = get_task_logger(__name__)
 MAX_RETRIES = 11
 
 
-@task(
+@shared_task(
     bind=True,
     ignore_result=True,
     name='entitlements.expire_old_entitlements',

--- a/common/djangoapps/student/tasks.py
+++ b/common/djangoapps/student/tasks.py
@@ -6,7 +6,7 @@ This file contains celery tasks for sending email
 import logging
 
 from celery.exceptions import MaxRetriesExceededError
-from celery.task import task
+from celery import shared_task
 from django.conf import settings
 from django.contrib.auth.models import User
 from django.contrib.sites.models import Site
@@ -20,7 +20,7 @@ from openedx.core.lib.celery.task_utils import emulate_http_request
 log = logging.getLogger('edx.celery.task')
 
 
-@task(bind=True, name='student.send_activation_email')
+@shared_task(bind=True, name='student.send_activation_email')
 @set_code_owner_attribute
 def send_activation_email(self, msg_string, from_address=None):
     """

--- a/common/djangoapps/third_party_auth/tasks.py
+++ b/common/djangoapps/third_party_auth/tasks.py
@@ -10,7 +10,7 @@ import logging
 import dateutil.parser
 import pytz
 import requests
-from celery.task import task
+from celery import shared_task
 from django.utils.timezone import now
 from edx_django_utils.monitoring import set_code_owner_attribute
 from lxml import etree
@@ -31,7 +31,7 @@ class MetadataParseError(Exception):
     pass
 
 
-@task(name='third_party_auth.fetch_saml_metadata')
+@shared_task(name='third_party_auth.fetch_saml_metadata')
 @set_code_owner_attribute
 def fetch_saml_metadata():
     """

--- a/common/lib/xmodule/xmodule/modulestore/django.py
+++ b/common/lib/xmodule/xmodule/modulestore/django.py
@@ -138,7 +138,7 @@ class SignalHandler(object):
     To listen for a signal, do the following::
 
         from django.dispatch import receiver
-        from celery.task import task
+        from celery import shared_task
         from edx_django_utils.monitoring import set_code_owner_attribute
         from xmodule.modulestore.django import modulestore, SignalHandler
 

--- a/common/lib/xmodule/xmodule/modulestore/django.py
+++ b/common/lib/xmodule/xmodule/modulestore/django.py
@@ -146,7 +146,7 @@ class SignalHandler(object):
         def listen_for_course_publish(sender, course_key, **kwargs):
             do_my_expensive_update.delay(course_key)
 
-        @task()
+        @shared_task()
         @set_code_owner_attribute
         def do_my_expensive_update(course_key):
             # ...


### PR DESCRIPTION
This is the second episode of converting the `@task` decorator with `@shared_task` in edx-platform. In this PR we focused on `cms` and `common` task modules

**JIRA:** https://openedx.atlassian.net/browse/BOM-2179