### PR TITLE
Replace @task decorator with @shared_task in openedx

### DIFF
--- a/openedx/core/djangoapps/bookmarks/tasks.py
+++ b/openedx/core/djangoapps/bookmarks/tasks.py
@@ -6,7 +6,7 @@ Tasks for bookmarks.
 import logging
 
 import six
-from celery.task import task
+from celery import shared_task
 from django.db import transaction
 from edx_django_utils.monitoring import set_code_owner_attribute
 from opaque_keys.edx.keys import CourseKey
@@ -145,7 +145,7 @@ def _update_xblocks_cache(course_key):
                 update_block_cache_if_needed(block_cache, block_data)
 
 
-@task(name=u'openedx.core.djangoapps.bookmarks.tasks.update_xblocks_cache')
+@shared_task(name=u'openedx.core.djangoapps.bookmarks.tasks.update_xblocks_cache')
 @set_code_owner_attribute
 def update_xblocks_cache(course_id):
     """

--- a/openedx/core/djangoapps/ccxcon/tasks.py
+++ b/openedx/core/djangoapps/ccxcon/tasks.py
@@ -3,7 +3,7 @@ This file contains celery tasks for ccxcon
 """
 
 
-from celery.task import task
+from celery import shared_task
 from celery.utils.log import get_task_logger
 from edx_django_utils.monitoring import set_code_owner_attribute
 from opaque_keys.edx.keys import CourseKey
@@ -14,7 +14,7 @@ from openedx.core.djangoapps.ccxcon import api
 log = get_task_logger(__name__)
 
 
-@task(name='openedx.core.djangoapps.ccxcon.tasks.update_ccxcon')
+@shared_task(name='openedx.core.djangoapps.ccxcon.tasks.update_ccxcon')
 @set_code_owner_attribute
 def update_ccxcon(course_id, cur_retry=0):
     """

--- a/openedx/core/djangoapps/content/block_structure/tasks.py
+++ b/openedx/core/djangoapps/content/block_structure/tasks.py
@@ -5,7 +5,7 @@ Asynchronous tasks related to the Course Blocks sub-application.
 
 import logging
 
-from celery.task import task
+from celery import shared_task
 from django.conf import settings
 from edx_django_utils.monitoring import set_code_owner_attribute
 from edxval.api import ValInternalError
@@ -28,7 +28,7 @@ def block_structure_task(**kwargs):
     """
     Decorator for block structure tasks.
     """
-    return task(
+    return shared_task(
         default_retry_delay=settings.BLOCK_STRUCTURES_SETTINGS['TASK_DEFAULT_RETRY_DELAY'],
         max_retries=settings.BLOCK_STRUCTURES_SETTINGS['TASK_MAX_RETRIES'],
         bind=True,

--- a/openedx/core/djangoapps/content/course_overviews/tasks.py
+++ b/openedx/core/djangoapps/content/course_overviews/tasks.py
@@ -3,7 +3,7 @@
 import logging
 
 import six
-from celery import task
+from celery import shared_task
 from celery_utils.persist_on_failure import LoggedPersistOnFailureTask
 from django.conf import settings
 from edx_django_utils.monitoring import set_code_owner_attribute
@@ -59,7 +59,7 @@ def enqueue_async_course_overview_update_tasks(
         )
 
 
-@task(base=LoggedPersistOnFailureTask)
+@shared_task(base=LoggedPersistOnFailureTask)
 @set_code_owner_attribute
 def async_course_overview_update(*args, **kwargs):
     course_keys = [CourseKey.from_string(arg) for arg in args]

--- a/openedx/core/djangoapps/coursegraph/tasks.py
+++ b/openedx/core/djangoapps/coursegraph/tasks.py
@@ -6,7 +6,7 @@ neo4j, a graph database.
 
 import logging
 
-from celery import task
+from celery import shared_task
 from django.conf import settings  # lint-amnesty, pylint: disable=unused-import
 from django.utils import six, timezone
 from edx_django_utils.cache import RequestCache
@@ -247,7 +247,7 @@ def should_dump_course(course_key, graph):
     return last_this_command_was_run < course_last_published_date
 
 
-@task
+@shared_task
 @set_code_owner_attribute
 def dump_course_to_neo4j(course_key_string, credentials):
     """

--- a/openedx/core/djangoapps/credentials/tasks/v1/tasks.py
+++ b/openedx/core/djangoapps/credentials/tasks/v1/tasks.py
@@ -3,7 +3,7 @@ This file contains celery tasks for credentials-related functionality.
 """
 
 
-from celery import task
+from celery import shared_task
 from celery.utils.log import get_task_logger
 from django.conf import settings
 from django.contrib.auth.models import User  # lint-amnesty, pylint: disable=imported-auth-user
@@ -21,7 +21,7 @@ logger = get_task_logger(__name__)
 MAX_RETRIES = 11
 
 
-@task(bind=True, ignore_result=True)
+@shared_task(bind=True, ignore_result=True)
 @set_code_owner_attribute
 def send_grade_to_credentials(self, username, course_run_key, verified, letter_grade, percent_grade):
     """ Celery task to notify the Credentials IDA of a grade change via POST. """

--- a/openedx/core/djangoapps/credit/tasks.py
+++ b/openedx/core/djangoapps/credit/tasks.py
@@ -4,7 +4,7 @@ This file contains celery tasks for credit course views.
 
 
 import six
-from celery import task
+from celery import shared_task
 from celery.utils.log import get_task_logger
 from django.conf import settings
 from edx_django_utils.monitoring import set_code_owner_attribute
@@ -20,7 +20,7 @@ from xmodule.modulestore.exceptions import ItemNotFoundError
 LOGGER = get_task_logger(__name__)
 
 
-@task(default_retry_delay=settings.CREDIT_TASK_DEFAULT_RETRY_DELAY, max_retries=settings.CREDIT_TASK_MAX_RETRIES)
+@shared_task(default_retry_delay=settings.CREDIT_TASK_DEFAULT_RETRY_DELAY, max_retries=settings.CREDIT_TASK_MAX_RETRIES)
 @set_code_owner_attribute
 def update_credit_course_requirements(course_id):
     """

--- a/openedx/core/djangoapps/heartbeat/tasks.py
+++ b/openedx/core/djangoapps/heartbeat/tasks.py
@@ -3,11 +3,11 @@ A trivial task for health checks
 """
 
 
-from celery.task import task
+from celery import shared_task
 from edx_django_utils.monitoring import set_code_owner_attribute
 
 
-@task
+@shared_task
 @set_code_owner_attribute
 def sample_task():
     return True

--- a/openedx/core/djangoapps/programs/tasks.py
+++ b/openedx/core/djangoapps/programs/tasks.py
@@ -3,7 +3,7 @@ This file contains celery tasks for programs-related functionality.
 """
 
 
-from celery import task
+from celery import shared_task
 from celery.exceptions import MaxRetriesExceededError
 from celery.utils.log import get_task_logger
 from django.conf import settings
@@ -121,7 +121,7 @@ def award_program_certificate(client, username, program_uuid, visible_date):
     })
 
 
-@task(bind=True, ignore_result=True)
+@shared_task(bind=True, ignore_result=True)
 @set_code_owner_attribute
 def award_program_certificates(self, username):  # lint-amnesty, pylint: disable=too-many-statements
     """
@@ -284,7 +284,7 @@ def post_course_certificate(client, username, certificate, visible_date):
     })
 
 
-@task(bind=True, ignore_result=True)
+@shared_task(bind=True, ignore_result=True)
 @set_code_owner_attribute
 def award_course_certificate(self, username, course_run_key):
     """
@@ -399,7 +399,7 @@ def revoke_program_certificate(client, username, program_uuid):
     })
 
 
-@task(bind=True, ignore_result=True)
+@shared_task(bind=True, ignore_result=True)
 @set_code_owner_attribute
 def revoke_program_certificates(self, username, course_key):
     """
@@ -523,7 +523,7 @@ def revoke_program_certificates(self, username, course_key):
     LOGGER.info(u'Successfully completed the task revoke_program_certificates for username %s', username)
 
 
-@task(bind=True, ignore_result=True)
+@shared_task(bind=True, ignore_result=True)
 @set_code_owner_attribute
 def update_certificate_visible_date_on_course_update(self, course_key):
     """

--- a/openedx/core/djangoapps/schedules/tasks.py
+++ b/openedx/core/djangoapps/schedules/tasks.py
@@ -5,7 +5,7 @@ import logging
 import six
 from six.moves import range
 
-from celery import task, current_app
+from celery import shared_task, current_app
 from celery_utils.logged_task import LoggedTask
 from celery_utils.persist_on_failure import LoggedPersistOnFailureTask
 from django.conf import settings
@@ -46,7 +46,7 @@ COURSE_UPDATE_LOG_PREFIX = 'Course Update'
 COURSE_NEXT_SECTION_UPDATE_LOG_PREFIX = 'Course Next Section Update'
 
 
-@task(base=LoggedPersistOnFailureTask, bind=True, default_retry_delay=30)
+@shared_task(base=LoggedPersistOnFailureTask, bind=True, default_retry_delay=30)
 @set_code_owner_attribute
 def update_course_schedules(self, **kwargs):
     course_key = CourseKey.from_string(kwargs['course_id'])
@@ -150,7 +150,7 @@ class BinnedScheduleMessageBaseTask(ScheduleMessageBaseTask):
         raise NotImplementedError
 
 
-@task(base=LoggedTask, ignore_result=True)
+@shared_task(base=LoggedTask, ignore_result=True)
 @set_code_owner_attribute
 def _recurring_nudge_schedule_send(site_id, msg_str):
     _schedule_send(
@@ -161,7 +161,7 @@ def _recurring_nudge_schedule_send(site_id, msg_str):
     )
 
 
-@task(base=LoggedTask, ignore_result=True)
+@shared_task(base=LoggedTask, ignore_result=True)
 @set_code_owner_attribute
 def _upgrade_reminder_schedule_send(site_id, msg_str):
     _schedule_send(
@@ -172,7 +172,7 @@ def _upgrade_reminder_schedule_send(site_id, msg_str):
     )
 
 
-@task(base=LoggedTask, ignore_result=True)
+@shared_task(base=LoggedTask, ignore_result=True)
 @set_code_owner_attribute
 def _course_update_schedule_send(site_id, msg_str):
     _schedule_send(

--- a/openedx/core/djangoapps/util/tests/test_signals.py
+++ b/openedx/core/djangoapps/util/tests/test_signals.py
@@ -4,7 +4,7 @@
 from unittest import TestCase
 from pytest import mark
 
-from celery.task import task
+from celery import shared_task
 from django.test.utils import override_settings
 from edx_django_utils.cache import RequestCache
 
@@ -17,7 +17,7 @@ class TestClearRequestCache(TestCase):
     def _get_cache(self):
         return RequestCache("TestClearRequestCache")
 
-    @task
+    @shared_task
     def _dummy_task(self):
         """ A task that adds stuff to the request cache. """
         self._get_cache().set("cache_key", "blah blah")

--- a/openedx/core/djangoapps/verified_track_content/tasks.py
+++ b/openedx/core/djangoapps/verified_track_content/tasks.py
@@ -5,7 +5,7 @@ Celery task for Automatic Verifed Track Cohorting MVP feature.
 
 import six
 
-from celery.task import task
+from celery import shared_task
 from celery.utils.log import get_task_logger
 from django.contrib.auth.models import User  # lint-amnesty, pylint: disable=imported-auth-user
 from edx_django_utils.monitoring import set_code_owner_attribute
@@ -17,7 +17,7 @@ from common.djangoapps.student.models import CourseEnrollment, CourseMode
 LOGGER = get_task_logger(__name__)
 
 
-@task(bind=True, default_retry_delay=60, max_retries=2)
+@shared_task(bind=True, default_retry_delay=60, max_retries=2)
 @set_code_owner_attribute
 def sync_cohort_with_mode(self, course_id, user_id, verified_cohort_name, default_cohort_name):
     """

--- a/openedx/features/enterprise_support/tasks.py
+++ b/openedx/features/enterprise_support/tasks.py
@@ -5,7 +5,7 @@ Tasks for Enterprise.
 
 import logging
 
-from celery import task
+from celery import shared_task
 from edx_django_utils.monitoring import set_code_owner_attribute
 
 from enterprise.models import EnterpriseCourseEnrollment
@@ -14,7 +14,7 @@ from openedx.features.enterprise_support.utils import clear_data_consent_share_c
 log = logging.getLogger('edx.celery.task')
 
 
-@task(name=u'openedx.features.enterprise_support.tasks.clear_enterprise_customer_data_consent_share_cache')
+@shared_task(name=u'openedx.features.enterprise_support.tasks.clear_enterprise_customer_data_consent_share_cache')
 @set_code_owner_attribute
 def clear_enterprise_customer_data_consent_share_cache(enterprise_customer_uuid):
     """


### PR DESCRIPTION
This is the third and the last episode of converting the `@task` decorator with `@shared_task` in edx-platform. In this PR we refactored in `openedx`'s task modules

JIRA: https://openedx.atlassian.net/browse/BOM-2179