### PR TITLE
[BD-04] [SE-3708] Convert HiddenDescriptor to an XBlock. 

### DIFF
--- a/common/lib/xmodule/setup.py
+++ b/common/lib/xmodule/setup.py
@@ -17,7 +17,6 @@ XMODULES = [
     "videodev = xmodule.backcompat_module:TranslateCustomTagDescriptor",
     "videosequence = xmodule.seq_module:SequenceDescriptor",
     "custom_tag_template = xmodule.raw_module:RawDescriptor",
-    "hidden = xmodule.hidden_module:HiddenDescriptor",
     "raw = xmodule.raw_module:RawDescriptor",
     "lti = xmodule.lti_module:LTIDescriptor",
 ]
@@ -27,6 +26,7 @@ XBLOCKS = [
     "conditional = xmodule.conditional_module:ConditionalBlock",
     "course_info = xmodule.html_module:CourseInfoBlock",
     "error = xmodule.error_module:ErrorBlock",
+    "hidden = xmodule.hidden_module:HiddenDescriptor",
     "html = xmodule.html_module:HtmlBlock",
     "library = xmodule.library_root_xblock:LibraryRoot",
     "library_content = xmodule.library_content_module:LibraryContentBlock",

--- a/common/lib/xmodule/xmodule/hidden_module.py
+++ b/common/lib/xmodule/xmodule/hidden_module.py
@@ -1,20 +1,61 @@
+"""
+The Hidden XBlock.
+"""
+
+from web_fragments.fragment import Fragment
+from xblock.core import XBlock
+from xmodule.raw_module import RawMixin
+from xmodule.xml_module import XmlMixin
+from xmodule.x_module import (
+    XModuleDescriptorToXBlockMixin,
+    XModuleMixin,
+    XModuleToXBlockMixin,
+)
 
 
-from xmodule.raw_module import RawDescriptor
-from xmodule.x_module import XModule
+@XBlock.needs("i18n")
+class HiddenDescriptor(
+    RawMixin,
+    XmlMixin,
+    XModuleDescriptorToXBlockMixin,
+    XModuleToXBlockMixin,
+    XModuleMixin,
+):
+    """
+    XBlock class loaded by the runtime when another XBlock type has been disabled
+    or an unknown XBlock type is included in a course import.
 
-
-class HiddenModule(XModule):
-
+    The class name includes 'Descriptor' because this used to be an XModule and the class path is specified in the
+    modulestore config in a number of places.
+    """
     HIDDEN = True
+    has_author_view = True
 
-    def get_html(self):
-        if self.system.user_is_staff:
-            return u"ERROR: This module is unknown--students will not see it at all"
-        else:
-            return u""
-
-
-class HiddenDescriptor(RawDescriptor):
-    module_class = HiddenModule
     resources_dir = None
+
+    def author_view(self, _context):
+        """
+        Return the author view.
+        """
+        fragment = Fragment()
+        _ = self.runtime.service(self, "i18n").ugettext
+        content = _(
+            'ERROR: "{block_type}" is an unknown component type. This component will be hidden in LMS.'
+        ).format(block_type=self.scope_ids.block_type)
+        fragment.add_content(content)
+        return fragment
+
+    def studio_view(self, _context):
+        """
+        Return the studio view.
+        """
+        # User should not be able to edit unknown types.
+        fragment = Fragment()
+        return fragment
+
+    def student_view(self, _context):
+        """
+        Return the student view.
+        """
+        fragment = Fragment()
+        return fragment

--- a/openedx/core/lib/xblock_utils/__init__.py
+++ b/openedx/core/lib/xblock_utils/__init__.py
@@ -33,7 +33,10 @@ from common.djangoapps.edxmako.shortcuts import render_to_string
 from xmodule.seq_module import SequenceModule
 from xmodule.util.xmodule_django import add_webpack_to_fragment
 from xmodule.vertical_block import VerticalBlock
-from xmodule.x_module import PREVIEW_VIEWS, STUDIO_VIEW, XModule, XModuleDescriptor, shim_xmodule_js
+from xmodule.x_module import (
+    PREVIEW_VIEWS, STUDENT_VIEW, STUDIO_VIEW,
+    XModule, XModuleDescriptor, shim_xmodule_js,
+)
 
 log = logging.getLogger(__name__)
 
@@ -110,6 +113,9 @@ def wrap_xblock(
         )
     ]
 
+    if view == STUDENT_VIEW and getattr(block, 'HIDDEN', False):
+        css_classes.append('is-hidden')
+
     if isinstance(block, (XModule, XModuleDescriptor)) or getattr(block, 'uses_xmodule_styles_setup', False):
         if view in PREVIEW_VIEWS:
             # The block is acting as an XModule
@@ -117,9 +123,6 @@ def wrap_xblock(
         elif view == STUDIO_VIEW:
             # The block is acting as an XModuleDescriptor
             css_classes.append('xmodule_edit')
-
-        if getattr(block, 'HIDDEN', False):
-            css_classes.append('is-hidden')
 
         css_classes.append('xmodule_' + markupsafe.escape(class_name))
 


### PR DESCRIPTION
Converts the Hidden XModule into an XBlock.

Part of [XModule to XBlock Conversion work](https://openedx.atlassian.net/wiki/spaces/AC/pages/1472790755/XModule+to+XBlock+Conversion). 

**Testing instructions**:
* Create a course and import this archive: [course.hidden-block.tar.gz](https://github.com/edx/edx-platform/files/5797819/course.hidden-block.tar.gz). It has two units one with a published video and one with a draft video.
* Check that both videos are viewable in Studio and the published video is viewable in LMS.
* Go to http://localhost:18010/admin/xblock_django/xblockconfiguration/ and create an entry with name `video` and leave it disabled.
* In Studio you should see this now:
![image](https://user-images.githubusercontent.com/5305552/104226932-643e4080-546a-11eb-8d07-0631b0bb982d.png)
* In LMS the published video should be hidden:
![image](https://user-images.githubusercontent.com/5305552/104226906-5983ab80-546a-11eb-91aa-5163932e3af9.png)
* Export the course. The `video/` and `drafts/video` directory will be missing.
* Cherry-pick the commit in this PR. In the `make lms-shell` and `make studio-shell` run `pip install -e common/lib/xmodule` and then do `make lms-restart` and `make studio-restart`.
* In Studio you should see this now:
![image](https://user-images.githubusercontent.com/5305552/104226388-88e5e880-5469-11eb-8329-cf0095e3632d.png)
* In LMS the published video should be hidden as before.
* In http://localhost:18010/admin/xblock_django/xblockconfiguration/ update the entry for `video` to enabled.
* Check that both videos are viewable in Studio and the published video is viewable in LMS.
* In common/lib/xmodule/setup.py comment out the entry for `video`.
* In the `make lms-shell` and `make studio-shell` run `pip install -e common/lib/xmodule` and then do `make lms-restart` and `make studio-restart`.
* Check that in Studio and LMS, the result is as before (video is not visible).
* Export the course. The `video/` and `drafts/video` directory will be missing.
* In common/lib/xmodule/setup.py uncomment the entry for `video`. Also remove it from `COMPONENT_TYPES ` https://github.com/edx/edx-platform/blob/e339cc1/cms/djangoapps/contentstore/views/component.py#L44 otherwise Studio will throw a `PluginMissingError` when trying to render the list of components which can be added on the Unit edit page. This is not needed when uninstalling any XBlock types which are not in this list.
* In the `make lms-shell` and `make studio-shell` run `pip install -e common/lib/xmodule` and then do `make lms-restart` and `make studio-restart`.
* Check that both videos are viewable in Studio and the published video is viewable in LMS.