### PR TITLE
fix: "Invalid type for parameter ContentType" error on js upload

### DIFF
--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -27,9 +27,6 @@ django-countries==5.5
 # Removes deprecated get_ip function, which we still use (ARCHBOM-1329 for unpinning)
 django-ipware<3.0.0
 
-# 2.0.0 dropped support for Python 3.5
-django-pipeline<2.0.0
-
 # django-storages version 1.9 drops support for boto storage backend.
 django-storages<1.9
 

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -66,7 +66,7 @@ django-multi-email-field==0.6.2  # via edx-enterprise
 django-mysql==3.11.1      # via -r requirements/edx/base.in
 django-oauth-toolkit==1.3.2  # via -c requirements/edx/../constraints.txt, -r requirements/edx/base.in
 django-object-actions==3.0.1  # via edx-enterprise
-django-pipeline==1.7.0    # via -c requirements/edx/../constraints.txt, -r requirements/edx/base.in
+django-pipeline==2.0.5    # via -c requirements/edx/../constraints.txt, -r requirements/edx/base.in
 django-pyfs==3.0          # via -r requirements/edx/base.in
 git+https://github.com/edx/django-ratelimit-backend.git@v2.0.1a5#egg=django-ratelimit-backend==2.0.1a5  # via -r requirements/edx/github.in
 django-ratelimit==3.0.1   # via -r requirements/edx/base.in

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -77,7 +77,7 @@ django-multi-email-field==0.6.2  # via -r requirements/edx/testing.txt, edx-ente
 django-mysql==3.11.1      # via -r requirements/edx/testing.txt
 django-oauth-toolkit==1.3.2  # via -c requirements/edx/../constraints.txt, -r requirements/edx/testing.txt
 django-object-actions==3.0.1  # via -r requirements/edx/testing.txt, edx-enterprise
-django-pipeline==1.7.0    # via -c requirements/edx/../constraints.txt, -r requirements/edx/testing.txt
+django-pipeline==2.0.5    # via -c requirements/edx/../constraints.txt, -r requirements/edx/testing.txt
 django-pyfs==3.0          # via -r requirements/edx/testing.txt
 git+https://github.com/edx/django-ratelimit-backend.git@v2.0.1a5#egg=django-ratelimit-backend==2.0.1a5  # via -r requirements/edx/testing.txt
 django-ratelimit==3.0.1   # via -r requirements/edx/testing.txt

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -75,7 +75,7 @@ django-multi-email-field==0.6.2  # via -r requirements/edx/base.txt, edx-enterpr
 django-mysql==3.11.1      # via -r requirements/edx/base.txt
 django-oauth-toolkit==1.3.2  # via -c requirements/edx/../constraints.txt, -r requirements/edx/base.txt
 django-object-actions==3.0.1  # via -r requirements/edx/base.txt, edx-enterprise
-django-pipeline==1.7.0    # via -c requirements/edx/../constraints.txt, -r requirements/edx/base.txt
+django-pipeline==2.0.5    # via -c requirements/edx/../constraints.txt, -r requirements/edx/base.txt
 django-pyfs==3.0          # via -r requirements/edx/base.txt
 git+https://github.com/edx/django-ratelimit-backend.git@v2.0.1a5#egg=django-ratelimit-backend==2.0.1a5  # via -r requirements/edx/base.txt
 django-ratelimit==3.0.1   # via -r requirements/edx/base.txt


### PR DESCRIPTION
We are affected by this issue:
https://github.com/jazzband/django-pipeline/pull/297#issuecomment-264416094

In particular, this occurs when trying to upload js assets to s3, such
as with the Scorm xblock:
https://github.com/overhangio/openedx-scorm-xblock/issues/16

This issue is resolved by upgrading django-pipeline to 2.0.3+, as the
fix was introduced here:
https://github.com/jazzband/django-pipeline/pull/715