### PR TITLE
[TNL-7749] - Remove italic styling for warning msg on expired state for ID verification card (Rebrand).

### DIFF
--- a/lms/templates/dashboard/_dashboard_status_verification.html
+++ b/lms/templates/dashboard/_dashboard_status_verification.html
@@ -47,7 +47,7 @@ from lms.djangoapps.verify_student.services import IDVerificationService
         <li class="status status-verification is-denied">
             <span class="title status-title">${_("Current Verification Status: Expired")}</span>
             <p class="status-note">${_("Your verification has expired. To receive a verified certificate, you must submit a new photo of yourself and your government-issued photo ID before the verification deadline for your course.")}</p>
-            <p class="status-note"><span><b>${_("Warning")}: </b></span><i>${_(" Please be aware photo verification can take up to three days once initiated and you will not be able to earn a certificate or take a proctored exam until approved.")}</i></p>
+            <p class="status-note"><span><b>${_("Warning")}: </b></span>${_(" Please be aware photo verification can take up to three days once initiated and you will not be able to earn a certificate or take a proctored exam until approved.")}</p>
             <div class="btn-reverify">
                 <a href="${IDVerificationService.get_verify_location()}" class="action action-reverify">${_("Resubmit Verification")}</a>
             </div>


### PR DESCRIPTION
### [TNL-7749](https://openedx.atlassian.net/browse/TNL-7749)

Remove _italic_ styling on warning message font for `Expired` state on ID verification card.

**_Followup PR on [this](https://github.com/edx/edx-themes/pull/712) rebrand PR_**

### Verfifcation Status: Expired
#### Before (after initial brand fix)
![Screen Shot 2021-01-01 at 3 45 22 PM](https://user-images.githubusercontent.com/30112155/103437645-b356cb00-4c4b-11eb-97dc-1df4d7e01a3c.png)

#### After
![Screen Shot 2021-01-01 at 4 36 40 PM](https://user-images.githubusercontent.com/30112155/103437947-24e44880-4c4f-11eb-9591-4c13fcdb3639.png)

