### PR TITLE
Add option to backfill org data as inactive

### DIFF
--- a/cms/djangoapps/contentstore/management/commands/tests/test_backfill_orgs_and_org_courses.py
+++ b/cms/djangoapps/contentstore/management/commands/tests/test_backfill_orgs_and_org_courses.py
@@ -117,26 +117,43 @@ class BackfillOrgsAndOrgCoursesTest(SharedModuleStoreTestCase):
             "command_line_args": [],
             "user_inputs": ["n"],
             "should_apply_changes": False,
+            "should_data_be_activated": True,
         },
         {
             "command_line_args": [],
             "user_inputs": ["x", "N"],
             "should_apply_changes": False,
+            "should_data_be_activated": True,
         },
         {
             "command_line_args": [],
             "user_inputs": ["", "", "YeS"],
             "should_apply_changes": True,
+            "should_data_be_activated": True,
+        },
+        {
+            "command_line_args": ["--inactive"],
+            "user_inputs": ["y"],
+            "should_apply_changes": True,
+            "should_data_be_activated": False,
         },
         {
             "command_line_args": ["--dry"],
             "user_inputs": [],
             "should_apply_changes": False,
+            "should_data_be_activated": True,
+        },
+        {
+            "command_line_args": ["--dry", "--inactive"],
+            "user_inputs": [],
+            "should_apply_changes": False,
+            "should_data_be_activated": False,
         },
         {
             "command_line_args": ["--apply"],
             "user_inputs": [],
             "should_apply_changes": True,
+            "should_data_be_activated": True,
         },
     )
     @ddt.unpack
@@ -161,6 +178,7 @@ class BackfillOrgsAndOrgCoursesTest(SharedModuleStoreTestCase):
             command_line_args,
             user_inputs,
             should_apply_changes,
+            should_data_be_activated,
     ):
         """
         Test that the command-line arguments and user input processing works as
@@ -184,31 +202,38 @@ class BackfillOrgsAndOrgCoursesTest(SharedModuleStoreTestCase):
             # then we expect one DRY bulk-add run *and* one REAL bulk-add run.
             assert mock_add_orgs.call_count == 2
             assert mock_add_org_courses.call_count == 2
-            assert mock_add_orgs.call_args_list[0].kwargs == {"dry_run": True}
-            assert mock_add_org_courses.call_args_list[0].kwargs == {"dry_run": True}
-            assert mock_add_orgs.call_args_list[1].kwargs == {"dry_run": False}
-            assert mock_add_org_courses.call_args_list[1].kwargs == {"dry_run": False}
+            assert mock_add_orgs.call_args_list[0].kwargs["dry_run"] is True
+            assert mock_add_org_courses.call_args_list[0].kwargs["dry_run"] is True
+            assert mock_add_orgs.call_args_list[1].kwargs["dry_run"] is False
+            assert mock_add_org_courses.call_args_list[1].kwargs["dry_run"] is False
         elif should_apply_changes:
             # If DID apply changes but the user WASN'T prompted,
             # then we expect just one REAL bulk-add run.
             assert mock_add_orgs.call_count == 1
             assert mock_add_org_courses.call_count == 1
-            assert mock_add_orgs.call_args.kwargs == {"dry_run": False}
-            assert mock_add_org_courses.call_args.kwargs == {"dry_run": False}
+            assert mock_add_orgs.call_args.kwargs["dry_run"] is False
+            assert mock_add_org_courses.call_args.kwargs["dry_run"] is False
         elif user_inputs:
             # If we DIDN'T apply changes but the user WAS prompted
             # then we expect just one DRY bulk-add run.
             assert mock_add_orgs.call_count == 1
             assert mock_add_org_courses.call_count == 1
-            assert mock_add_orgs.call_args.kwargs == {"dry_run": True}
-            assert mock_add_org_courses.call_args.kwargs == {"dry_run": True}
+            assert mock_add_orgs.call_args.kwargs["dry_run"] is True
+            assert mock_add_org_courses.call_args.kwargs["dry_run"] is True
         else:
             # Similarly, if we DIDN'T apply changes and the user WASN'T prompted
             # then we expect just one DRY bulk-add run.
             assert mock_add_orgs.call_count == 1
             assert mock_add_org_courses.call_count == 1
-            assert mock_add_orgs.call_args.kwargs == {"dry_run": True}
-            assert mock_add_org_courses.call_args.kwargs == {"dry_run": True}
+            assert mock_add_orgs.call_args.kwargs["dry_run"] is True
+            assert mock_add_org_courses.call_args.kwargs["dry_run"] is True
+
+        # Assert that the value of of the "active" kwarg is correct for all
+        # calls both bulk-add functions, whether or not they were dry runs.
+        for call in mock_add_orgs:
+            assert call.kwargs["activate"] == should_data_be_activated
+        for call in mock_add_org_courses:
+            assert call.kwargs["activate"] == should_data_be_activated
 
     def test_conflicting_arguments(self):
         """

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -103,7 +103,7 @@ edx-event-routing-backends==2.0.0  # via -r requirements/edx/base.in
 edx-i18n-tools==0.5.3     # via ora2
 edx-milestones==0.3.0     # via -r requirements/edx/base.in
 edx-opaque-keys[django]==2.1.1  # via -r requirements/edx/paver.txt, edx-bulk-grades, edx-ccx-keys, edx-completion, edx-drf-extensions, edx-enterprise, edx-milestones, edx-organizations, edx-proctoring, edx-user-state-client, edx-when, lti-consumer-xblock, xmodule
-edx-organizations==6.5.0  # via -r requirements/edx/base.in
+edx-organizations==6.6.0  # via -r requirements/edx/base.in
 edx-proctoring-proctortrack==1.0.5  # via -r requirements/edx/base.in
 edx-proctoring==2.5.5     # via -r requirements/edx/base.in, edx-proctoring-proctortrack
 edx-rbac==1.3.3           # via edx-enterprise

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -115,7 +115,7 @@ edx-i18n-tools==0.5.3     # via -r requirements/edx/testing.txt, ora2
 edx-lint==1.6             # via -r requirements/edx/testing.txt
 edx-milestones==0.3.0     # via -r requirements/edx/testing.txt
 edx-opaque-keys[django]==2.1.1  # via -r requirements/edx/testing.txt, edx-bulk-grades, edx-ccx-keys, edx-completion, edx-drf-extensions, edx-enterprise, edx-milestones, edx-organizations, edx-proctoring, edx-user-state-client, edx-when, lti-consumer-xblock, xmodule
-edx-organizations==6.5.0  # via -r requirements/edx/testing.txt
+edx-organizations==6.6.0  # via -r requirements/edx/testing.txt
 edx-proctoring-proctortrack==1.0.5  # via -r requirements/edx/testing.txt
 edx-proctoring==2.5.5     # via -r requirements/edx/testing.txt, edx-proctoring-proctortrack
 edx-rbac==1.3.3           # via -r requirements/edx/testing.txt, edx-enterprise

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -112,7 +112,7 @@ edx-i18n-tools==0.5.3     # via -r requirements/edx/base.txt, -r requirements/ed
 edx-lint==1.6             # via -r requirements/edx/testing.in
 edx-milestones==0.3.0     # via -r requirements/edx/base.txt
 edx-opaque-keys[django]==2.1.1  # via -r requirements/edx/base.txt, edx-bulk-grades, edx-ccx-keys, edx-completion, edx-drf-extensions, edx-enterprise, edx-milestones, edx-organizations, edx-proctoring, edx-user-state-client, edx-when, lti-consumer-xblock, xmodule
-edx-organizations==6.5.0  # via -r requirements/edx/base.txt
+edx-organizations==6.6.0  # via -r requirements/edx/base.txt
 edx-proctoring-proctortrack==1.0.5  # via -r requirements/edx/base.txt
 edx-proctoring==2.5.5     # via -r requirements/edx/base.txt, edx-proctoring-proctortrack
 edx-rbac==1.3.3           # via -r requirements/edx/base.txt, edx-enterprise


### PR DESCRIPTION
## Commit

Add an `--inactive` option to the
`bulk_add_orgs_and_org_courses` management
command, which causes the backfill to set
`active=False` on all rows created in the
Organization and OrganizationCourse tables.

This will lower the potential data
integrity risk to production systems
such as courses.edx.org.

Upgrade edx-organizations to 6.6.0

## More context

This PR is dependent on edx-organizations version 6.6.0, which will be released after [this edx-organizations PR merges](https://github.com/edx/edx-organizations/pull/157). See that PR for more context on this change.