### PR TITLE
AA-501: Use hidden blocks to determine past due status

### DIFF
--- a/common/lib/xmodule/xmodule/tests/test_vertical.py
+++ b/common/lib/xmodule/xmodule/tests/test_vertical.py
@@ -196,6 +196,22 @@ class VerticalBlockTestCase(BaseVerticalBlockTest):
             self.assertIn("'completed': None", html)
             self.assertIn("'past_due': False", html)
 
+    @ddt.data(True, False)
+    def test_render_access_denied_blocks(self, has_access_error):
+        """ Tests access denied blocks are not rendered when hide_access_error_blocks is True """
+        self.module_system._services['bookmarks'] = Mock()
+        self.module_system._services['user'] = StubUserService()
+        self.vertical.due = datetime.now(pytz.UTC) + timedelta(days=-1)
+        self.problem_block.has_access_error = has_access_error
+
+        context = {'username': self.username, 'hide_access_error_blocks': True}
+        html = self.module_system.render(self.vertical, STUDENT_VIEW, context).content
+
+        if has_access_error:
+            self.assertNotIn(self.test_problem, html)
+        else:
+            self.assertIn(self.test_problem, html)
+
     @ddt.unpack
     @ddt.data(
         (True, 0.9, True),

--- a/common/lib/xmodule/xmodule/vertical_block.py
+++ b/common/lib/xmodule/xmodule/vertical_block.py
@@ -81,6 +81,8 @@ class VerticalBlock(SequenceFields, XModuleFields, StudioEditableBlock, XmlParse
 
         # pylint: disable=no-member
         for child in child_blocks:
+            if context.get('hide_access_error_blocks') and getattr(child, 'has_access_error', False):
+                continue
             child_block_context = copy(child_context)
             if child in list(child_blocks_to_complete_on_view):
                 child_block_context['wrap_xblock_data'] = {

--- a/lms/djangoapps/commerce/api/v1/tests/test_views.py
+++ b/lms/djangoapps/commerce/api/v1/tests/test_views.py
@@ -175,8 +175,9 @@ class CourseRetrieveUpdateViewTests(CourseApiViewTestMixin, ModuleStoreTestCase)
         self.assertIsNone(VerificationDeadline.deadline_for_course(self.course.id))
 
         # Generate the expected data
-        verification_deadline = datetime(year=2030, month=12, day=31, tzinfo=pytz.utc)
-        expiration_datetime = datetime.now(pytz.utc)
+        now = datetime.now(pytz.utc)
+        verification_deadline = now + timedelta(days=1)
+        expiration_datetime = now
         response, expected = self._get_update_response_and_expected_data(expiration_datetime, verification_deadline)
 
         # Sanity check: The API should return HTTP status 200 for updates

--- a/lms/djangoapps/courseware/module_render.py
+++ b/lms/djangoapps/courseware/module_render.py
@@ -3,7 +3,6 @@ Module rendering
 """
 
 
-import hashlib
 import json
 import logging
 import textwrap
@@ -917,6 +916,7 @@ def get_module_for_descriptor_internal(user, descriptor, student_data, course_id
             and (access.user_message or access.user_fragment)
         )
         if access or caller_will_handle_access_error:
+            descriptor.has_access_error = bool(caller_will_handle_access_error)
             return descriptor
         return None
     return descriptor
@@ -1074,7 +1074,8 @@ def handle_xblock_callback(request, course_id, usage_id, handler, suffix=None):
         return _invoke_xblock_handler(request, course_id, usage_id, handler, suffix, course=course)
 
 
-def get_module_by_usage_id(request, course_id, usage_id, disable_staff_debug_info=False, course=None):
+def get_module_by_usage_id(request, course_id, usage_id, disable_staff_debug_info=False, course=None,
+                           will_recheck_access=False):
     """
     Gets a module instance based on its `usage_id` in a course, for a given request/user
 
@@ -1126,7 +1127,8 @@ def get_module_by_usage_id(request, course_id, usage_id, disable_staff_debug_inf
         field_data_cache,
         usage_key.course_key,
         disable_staff_debug_info=disable_staff_debug_info,
-        course=course
+        course=course,
+        will_recheck_access=will_recheck_access,
     )
     if instance is None:
         # Either permissions just changed, or someone is trying to be clever


### PR DESCRIPTION
Blocks that were hidden by access checks would not be used when
calculating past due status for a unit. This adds in a check to
still look at those blocks, but will maintain not rendering them
when being accessed via the MFE