### PR TITLE
Check sequence-level gating in render_xblock (TNL-7636)

### DIFF
--- a/cms/envs/devstack.py
+++ b/cms/envs/devstack.py
@@ -236,3 +236,7 @@ CORS_ORIGIN_ALLOW_ALL = True
 CORS_ALLOW_HEADERS = corsheaders_default_headers + (
     'use-jwt-cookie',
 )
+
+################### Special Exams (Proctoring) and Prereqs ###################
+FEATURES['ENABLE_SPECIAL_EXAMS'] = True
+FEATURES['ENABLE_PREREQUISITE_COURSES'] = True

--- a/lms/envs/devstack.py
+++ b/lms/envs/devstack.py
@@ -427,3 +427,7 @@ if os.path.isfile(join(dirname(abspath(__file__)), 'private.py')):
 # Uncomment the lines below if you'd like to see SQL statements in your devstack LMS log.
 # LOGGING['handlers']['console']['level'] = 'DEBUG'
 # LOGGING['loggers']['django.db.backends'] = {'handlers': ['console'], 'level': 'DEBUG', 'propagate': False}
+
+################### Special Exams (Proctoring) and Prereqs ###################
+FEATURES['ENABLE_SPECIAL_EXAMS'] = True
+FEATURES['ENABLE_PREREQUISITE_COURSES'] = True


### PR DESCRIPTION
There is certain gating logic around pre-reqs, timed exams, etc. that happen at the SequenceModule level, and should be respected when rendering descendant XBlocks (like individual problems) that are in that Sequence. Rather than do a risky refactoring, I'm keeping that logic where it is and having the render_xblock view climb up through the ancestor list to call the SequenceModule for that gating information.

We do _not_ check all descendants (so cousin leaf nodes in the sequence) for cotent-type-based restrictions because sequences can become very large (esp. when content libraries are used), and there is a performance overhead.

If the enclosing sequence is gated in some way, we redirect to the render_xblock view for that sequence, where hopefully some useful messaging will be available. This is a stopgap. That redirect should never happen because we should never be calling the leaf XBlock for a sequence that is restricted in the MFE. But if somehow we get there anyway, either by bug or by intrepid user fiddling, it's better to redirect somewhere that an error _might_ be surfaced rather than just failing.

This PR also enables timed exams in devstack.