### PR TITLE
Updated serializer to include receipt_id for verifications

### DIFF
--- a/openedx/core/djangoapps/user_api/serializers.py
+++ b/openedx/core/djangoapps/user_api/serializers.py
@@ -107,6 +107,7 @@ class IDVerificationDetailsSerializer(serializers.Serializer):
     expiration_datetime = serializers.DateTimeField()
     message = serializers.SerializerMethodField()
     updated_at = serializers.DateTimeField()
+    receipt_id = serializers.SerializerMethodField()
 
     def get_type(self, obj):
         if isinstance(obj, SoftwareSecurePhotoVerification):
@@ -123,3 +124,9 @@ class IDVerificationDetailsSerializer(serializers.Serializer):
             return obj.reason
         else:
             return ''
+
+    def get_receipt_id(self, obj):
+        if isinstance(obj, SoftwareSecurePhotoVerification):
+            return obj.receipt_id
+        else:
+            return None

--- a/openedx/core/djangoapps/user_api/verification_api/tests/test_views.py
+++ b/openedx/core/djangoapps/user_api/verification_api/tests/test_views.py
@@ -132,7 +132,8 @@ class VerificationsDetailsViewTests(VerificationStatusViewTestsMixin, TestCase):
             'status': self.photo_verification.status,
             'expiration_datetime': '{}Z'.format(kwargs.get('expected_expires').isoformat()),
             'message': '',
-            'updated_at': '{}Z'.format(self.CREATED_AT.isoformat())
+            'updated_at': '{}Z'.format(self.CREATED_AT.isoformat()),
+            'receipt_id': self.photo_verification.receipt_id,
         }]
 
     def test_multiple_verification_types(self):
@@ -157,6 +158,7 @@ class VerificationsDetailsViewTests(VerificationStatusViewTestsMixin, TestCase):
                 'expiration_datetime': '{}Z'.format(expected_expires.isoformat()),
                 'message': self.photo_verification.error_msg,
                 'updated_at': '{}Z'.format(self.CREATED_AT.isoformat()),
+                'receipt_id': self.photo_verification.receipt_id
             },
             {
                 'type': 'SSO',
@@ -164,6 +166,7 @@ class VerificationsDetailsViewTests(VerificationStatusViewTestsMixin, TestCase):
                 'expiration_datetime': '{}Z'.format(expected_expires.isoformat()),
                 'message': '',
                 'updated_at': '{}Z'.format(self.CREATED_AT.isoformat()),
+                'receipt_id': None,
             },
             {
                 'type': 'Manual',
@@ -171,6 +174,7 @@ class VerificationsDetailsViewTests(VerificationStatusViewTestsMixin, TestCase):
                 'expiration_datetime': '{}Z'.format(expected_expires.isoformat()),
                 'message': self.manual_verification.reason,
                 'updated_at': '{}Z'.format(self.CREATED_AT.isoformat()),
+                'receipt_id': None,
             },
         ]
         self.assertEqual(json.loads(response.content.decode('utf-8')), expected)
@@ -194,6 +198,7 @@ class VerificationsDetailsViewTests(VerificationStatusViewTestsMixin, TestCase):
                 'expiration_datetime': '{}Z'.format(expected_expires.isoformat()),
                 'message': self.photo_verification.error_msg,
                 'updated_at': '{}Z'.format(self.CREATED_AT.isoformat()),
+                'receipt_id': self.photo_verification.receipt_id,
             },
             {
                 'type': 'Software Secure',
@@ -201,6 +206,7 @@ class VerificationsDetailsViewTests(VerificationStatusViewTestsMixin, TestCase):
                 'expiration_datetime': '{}Z'.format(expected_expires.isoformat()),
                 'message': second_ss_photo_verification.error_msg,
                 'updated_at': '{}Z'.format(self.CREATED_AT.isoformat()),
+                'receipt_id': second_ss_photo_verification.receipt_id,
             },
             {
                 'type': 'SSO',
@@ -208,6 +214,7 @@ class VerificationsDetailsViewTests(VerificationStatusViewTestsMixin, TestCase):
                 'expiration_datetime': '{}Z'.format(expected_expires.isoformat()),
                 'message': '',
                 'updated_at': '{}Z'.format(self.CREATED_AT.isoformat()),
+                'receipt_id': None,
             },
         ]
         self.assertEqual(json.loads(response.content.decode('utf-8')), expected)


### PR DESCRIPTION
## [MST-564](https://openedx.atlassian.net/browse/MST-564)

@edx/masters-devs-cosmonauts 

Updates serializer for verifications endpoint, so that receipt IDs can be easily retrieved 