### PR TITLE
Show discount deadline in a timezone-aware way

### DIFF
--- a/lms/djangoapps/courseware/tests/helpers.py
+++ b/lms/djangoapps/courseware/tests/helpers.py
@@ -27,10 +27,9 @@ from lms.djangoapps.courseware.masquerade import setup_masquerade
 from lms.djangoapps.lms_xblock.field_data import LmsFieldData
 from openedx.core.djangoapps.content.course_overviews.models import CourseOverview
 from openedx.core.lib.url_utils import quote_slashes
-from openedx.features.course_duration_limits.access import EXPIRATION_DATE_FORMAT_STR
 from common.djangoapps.student.models import CourseEnrollment, Registration
 from common.djangoapps.student.tests.factories import CourseEnrollmentFactory, UserFactory
-from common.djangoapps.util.date_utils import strftime_localized
+from common.djangoapps.util.date_utils import strftime_localized_html
 from xmodule.modulestore.django import modulestore
 from xmodule.modulestore.tests.django_utils import TEST_DATA_MONGO_MODULESTORE, ModuleStoreTestCase
 from xmodule.modulestore.tests.factories import CourseFactory, ItemFactory
@@ -423,19 +422,9 @@ def get_expiration_banner_text(user, course, language='en'):
     if upgrade_deadline is None or now() < upgrade_deadline:
         upgrade_deadline = enrollment.course_upgrade_deadline
 
-    date_string = u'<span class="localized-datetime" data-format="shortDate" data-timezone="None" \
-        data-datetime="{formatted_date}" data-language="{language}">{formatted_date_localized}</span>'
-    formatted_expiration_date = date_string.format(
-        language=language,
-        formatted_date=expiration_date.isoformat(),
-        formatted_date_localized=strftime_localized(expiration_date, EXPIRATION_DATE_FORMAT_STR)
-    )
+    formatted_expiration_date = strftime_localized_html(expiration_date, 'SHORT_DATE')
     if upgrade_deadline:
-        formatted_upgrade_deadline = date_string.format(
-            language=language,
-            formatted_date=upgrade_deadline.isoformat(),
-            formatted_date_localized=strftime_localized(upgrade_deadline, EXPIRATION_DATE_FORMAT_STR)
-        )
+        formatted_upgrade_deadline = strftime_localized_html(upgrade_deadline, 'SHORT_DATE')
 
         bannerText = u'<strong>Audit Access Expires {expiration_date}</strong><br>\
                      You lose all access to this course, including your progress, on {expiration_date}.\

--- a/openedx/features/course_duration_limits/tests/test_access.py
+++ b/openedx/features/course_duration_limits/tests/test_access.py
@@ -39,7 +39,7 @@ class TestAccess(CacheIsolationTestCase):
 
     def assertDateInMessage(self, date, message):
         # First, check that the formatted version is in there
-        self.assertIn(strftime_localized(date, '%b %-d, %Y'), message)
+        self.assertIn(strftime_localized(date, 'SHORT_DATE'), message)
 
         # But also that the machine-readable version is in there
         self.assertIn('data-datetime="%s"' % date.isoformat(), message)

--- a/openedx/features/course_experience/tests/views/test_course_home.py
+++ b/openedx/features/course_experience/tests/views/test_course_home.py
@@ -21,6 +21,7 @@ from waffle.testutils import override_flag
 
 from common.djangoapps.course_modes.models import CourseMode
 from common.djangoapps.course_modes.tests.factories import CourseModeFactory
+from common.djangoapps.util.date_utils import strftime_localized_html
 from lms.djangoapps.experiments.models import ExperimentData
 from lms.djangoapps.commerce.models import CommerceConfiguration
 from lms.djangoapps.commerce.utils import EcommerceService
@@ -37,7 +38,6 @@ from lms.djangoapps.courseware.tests.helpers import get_expiration_banner_text
 from lms.djangoapps.courseware.utils import verified_upgrade_deadline_link
 from lms.djangoapps.discussion.django_comment_client.tests.factories import RoleFactory
 from openedx.core.djangoapps.content.course_overviews.models import CourseOverview
-from openedx.core.djangoapps.dark_lang.models import DarkLangConfig
 from openedx.core.djangoapps.django_comment_common.models import (
     FORUM_ROLE_ADMINISTRATOR,
     FORUM_ROLE_COMMUNITY_TA,
@@ -414,19 +414,19 @@ class TestCourseHomePageAccess(CourseHomePageTestCase):
         user = self.create_user_for_course(self.course, CourseUserType.ENROLLED)
         now_time = datetime.now(tz=UTC).strftime(u"%Y-%m-%d %H:%M:%S%z")
         ExperimentData.objects.create(
-            user=user, experiment_id=REV1008_EXPERIMENT_ID, key=str(self.course), value=now_time
+            user=user, experiment_id=REV1008_EXPERIMENT_ID, key=str(self.course.id), value=now_time
         )
         self.client.login(username=user.username, password=self.TEST_PASSWORD)
         url = course_home_url(self.course)
         response = self.client.get(url)
-        discount_expiration_date = get_discount_expiration_date(user, self.course).strftime(u'%B %d')
+        expiration_date = strftime_localized_html(get_discount_expiration_date(user, self.course), 'SHORT_DATE')
         upgrade_link = verified_upgrade_deadline_link(user=user, course=self.course)
         bannerText = u'''<div class="first-purchase-offer-banner" role="note">
              <span class="first-purchase-offer-banner-bold"><b>
              Upgrade by {discount_expiration_date} and save {percentage}% [{strikeout_price}]</b></span>
              <br>Use code <b>EDXWELCOME</b> at checkout! <a id="welcome" href="{upgrade_link}">Upgrade Now</a>
              </div>'''.format(
-            discount_expiration_date=discount_expiration_date,
+            discount_expiration_date=expiration_date,
             percentage=percentage,
             strikeout_price=HTML(format_strikeout_price(user, self.course)[0]),
             upgrade_link=upgrade_link
@@ -577,7 +577,7 @@ class TestCourseHomePageAccess(CourseHomePageTestCase):
 
         response = self.client.get(url)
 
-        expiration_date = strftime_localized(course.start + timedelta(weeks=4) + timedelta(days=1), u'%b %-d, %Y')
+        expiration_date = strftime_localized(course.start + timedelta(weeks=4) + timedelta(days=1), 'SHORT_DATE')
         expected_params = QueryDict(mutable=True)
         course_name = CourseOverview.get_from_id(course.id).display_name_with_default
         expected_params['access_response_error'] = u'Access to {run} expired on {expiration_date}'.format(
@@ -798,46 +798,6 @@ class TestCourseHomePageAccess(CourseHomePageTestCase):
         response = self.client.get(url)
         bannerText = get_expiration_banner_text(self.staff_user, self.course)
         self.assertNotContains(response, bannerText, html=True)
-
-    @mock.patch("common.djangoapps.util.date_utils.strftime_localized")
-    @mock.patch("openedx.features.course_duration_limits.access.get_date_string")
-    def test_course_expiration_banner_with_unicode(self, mock_strftime_localized, mock_get_date_string):
-        """
-        Ensure that switching to other languages that have unicode in their
-        date representations will not cause the course home page to 404.
-        """
-        fake_unicode_start_time = u"üñîçø∂é_ßtå®t_tîµé"
-        mock_strftime_localized.return_value = fake_unicode_start_time
-        date_string = u'<span class="localized-datetime" data-format="shortDate" \
-        data-datetime="{formatted_date}" data-language="{language}">{formatted_date_localized}</span>'
-        mock_get_date_string.return_value = date_string
-
-        config = CourseDurationLimitConfig(
-            course=CourseOverview.get_from_id(self.course.id),
-            enabled=True,
-            enabled_as_of=datetime(2018, 1, 1, tzinfo=UTC)
-        )
-        config.save()
-        url = course_home_url(self.course)
-        user = self.create_user_for_course(self.course, CourseUserType.UNENROLLED)
-        CourseEnrollment.enroll(user, self.course.id)
-
-        language = 'eo'
-        DarkLangConfig(
-            released_languages=language,
-            changed_by=user,
-            enabled=True
-        ).save()
-
-        response = self.client.get(url, HTTP_ACCEPT_LANGUAGE=language)
-        self.assertEqual(response.status_code, 200)
-        self.assertEqual(response['Content-Language'], language)
-
-        # Check that if the string is incorrectly not marked as unicode we still get the error
-        with mock.patch("openedx.features.course_duration_limits.access.get_date_string",
-                        return_value=date_string.encode('utf-8')):
-            response = self.client.get(url, HTTP_ACCEPT_LANGUAGE=language)
-            self.assertEqual(response.status_code, 500)
 
     @override_waffle_flag(COURSE_PRE_START_ACCESS_FLAG, active=True)
     @override_waffle_flag(ENABLE_COURSE_GOALS, active=True)

--- a/openedx/features/discounts/applicability.py
+++ b/openedx/features/discounts/applicability.py
@@ -64,7 +64,7 @@ def get_discount_expiration_date(user, course):
 
     time_limit_start = None
     try:
-        saw_banner = ExperimentData.objects.get(user=user, experiment_id=REV1008_EXPERIMENT_ID, key=str(course))
+        saw_banner = ExperimentData.objects.get(user=user, experiment_id=REV1008_EXPERIMENT_ID, key=str(course.id))
         time_limit_start = parse_datetime(saw_banner.value)
     except ExperimentData.DoesNotExist:
         return None

--- a/openedx/features/discounts/tests/test_applicability.py
+++ b/openedx/features/discounts/tests/test_applicability.py
@@ -42,7 +42,7 @@ class TestApplicability(ModuleStoreTestCase):
         CourseModeFactory.create(course_id=self.course.id, mode_slug='verified')
         now_time = datetime.now(tz=pytz.UTC).strftime(u"%Y-%m-%d %H:%M:%S%z")
         ExperimentData.objects.create(
-            user=self.user, experiment_id=REV1008_EXPERIMENT_ID, key=str(self.course), value=now_time
+            user=self.user, experiment_id=REV1008_EXPERIMENT_ID, key=str(self.course.id), value=now_time
         )
 
         holdback_patcher = patch(

--- a/openedx/features/discounts/utils.py
+++ b/openedx/features/discounts/utils.py
@@ -12,6 +12,7 @@ from edx_django_utils.cache import RequestCache
 from web_fragments.fragment import Fragment
 
 from common.djangoapps.course_modes.models import format_course_price, get_course_prices
+from common.djangoapps.util.date_utils import strftime_localized_html
 from lms.djangoapps.experiments.models import ExperimentData
 from lms.djangoapps.courseware.utils import verified_upgrade_deadline_link
 from openedx.core.djangoapps.content.course_overviews.models import CourseOverview
@@ -184,7 +185,7 @@ def generate_offer_html(user, course):
             '<div class="first-purchase-offer-banner" role="note">'
             '<span class="first-purchase-offer-banner-bold"><b>'
         ),
-        discount_expiration_date=data['expiration_date'].strftime('%B %d'),
+        discount_expiration_date=strftime_localized_html(data['expiration_date'], 'SHORT_DATE'),
         percentage=data['percentage'],
         span_close=HTML('</b></span>'),
         div_close=HTML('</div>'),


### PR DESCRIPTION
Also, fix it and the access expiration deadline to not hardcode the date presentation in an American way.