### PR TITLE
pinned edx-bulk-grades to avoid migration error.

### DIFF
--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -140,3 +140,6 @@ Sphinx==3.3.0
 
 # incremental upgrade approach
 djangorestframework==3.10.3
+
+# latest edx-bulk-grades==0.8.5 is giving migration error.
+edx-bulk-grades<0.8.5


### PR DESCRIPTION
latest edx-bulk-grades==0.8.5 is giving migration error.


https://build.testeng.edx.org/job/edx-platform-accessibility-pr/79711/console

```
21:56:34 Running migrations:
21:56:34   Applying bulk_grades.0003_drop_djcelery_tables...Traceback (most recent call last):
21:56:34   File "/home/jenkins/edx-venv-3.8/edx-venv/lib/python3.8/site-packages/django/db/backends/utils.py", line 82, in _execute
21:56:34     return self.cursor.execute(sql)
21:56:34   File "/home/jenkins/edx-venv-3.8/edx-venv/lib/python3.8/site-packages/django/db/backends/mysql/base.py", line 71, in execute
21:56:34     return self.cursor.execute(query, args)
21:56:34   File "/home/jenkins/edx-venv-3.8/edx-venv/lib/python3.8/site-packages/MySQLdb/cursors.py", line 206, in execute
21:56:34     res = self._query(query)
21:56:34   File "/home/jenkins/edx-venv-3.8/edx-venv/lib/python3.8/site-packages/MySQLdb/cursors.py", line 319, in _query
21:56:34     db.query(q)
21:56:34   File "/home/jenkins/edx-venv-3.8/edx-venv/lib/python3.8/site-packages/MySQLdb/connections.py", line 259, in query
21:56:34     _mysql.connection.query(self, query)
21:56:34 MySQLdb._exceptions.IntegrityError: (1217, 'Cannot delete or update a parent row: a foreign key constraint fails')
21:56:34 
```