### PR TITLE
[TNL-7820] - remove important rule for links on hover.

### DIFF
--- a/lms/static/sass/course/base/_base.scss
+++ b/lms/static/sass/course/base/_base.scss
@@ -72,7 +72,7 @@ table {
 a {
   &:hover,
   &:focus {
-    text-decoration: none !important;
+    text-decoration: none;
   }
 
   @media print {


### PR DESCRIPTION
### [TNL-7820](https://openedx.atlassian.net/browse/TNL-7878)

Remove `!important` rule that is overriding the link hover state CSS.


### Before Fix

#### Normal State
![Screen Shot 2021-01-11 at 2 20 48 PM](https://user-images.githubusercontent.com/30112155/104164720-2a454e00-541a-11eb-90e5-ec8146968131.png)

#### Hover State (_all links in screenshot are in hover state_)
![Screen Shot 2021-01-11 at 2 20 21 PM](https://user-images.githubusercontent.com/30112155/104164874-64165480-541a-11eb-8d36-0eb8c5bc94d7.png)

### After Fix

#### Normal State

![Screen Shot 2021-01-11 at 2 20 48 PM](https://user-images.githubusercontent.com/30112155/104164720-2a454e00-541a-11eb-90e5-ec8146968131.png)


#### Hover State (_all links in screenshot are in hover state_)

![Screen Shot 2021-01-11 at 2 31 44 PM](https://user-images.githubusercontent.com/30112155/104164732-2f0a0200-541a-11eb-887e-e9fdb84beb10.png)
