### PR TITLE
fix login cookie parse issue

### DIFF
--- a/lms/static/js/spec/student_account/utils_spec.js
+++ b/lms/static/js/spec/student_account/utils_spec.js
@@ -1,0 +1,25 @@
+define(['jquery', 'js/student_account/utils'],
+    function($, Utils) {
+        'use strict';
+        describe('edxUserCookie', function() {
+            var userInfo, user;
+
+            userInfo = {
+                version: 1,
+                username: 'local-test-user'
+            };
+
+            beforeEach(function() {
+                document.cookie = 'edx-user-info="' +
+                  '{\"version\": 1, \"username\": \"local-test-user\"}";'; // eslint-disable-line no-useless-escape
+            });
+
+            it('returns correct user information from cookie', function() {
+                spyOn(Utils, 'getHostname').and.returnValue('localhost');
+
+                user = Utils.userFromEdxUserCookie();
+                expect(user).toEqual(userInfo);
+            });
+        });
+    }
+);

--- a/lms/static/js/student_account/utils.js
+++ b/lms/static/js/student_account/utils.js
@@ -1,28 +1,36 @@
 (function(define) {
     'use strict';
     define(['jquery'], function($) {
-        var userFromEdxUserCookie = function() {
-            var hostname = window.location.hostname;
-            var isLocalhost = hostname.indexOf('localhost') >= 0;
-            var isStage = hostname.indexOf('stage') >= 0;
-            var edxUserCookie, prefix, user;
+        var edxUserCookieUtils = {
+            getHostname: function() {
+                return window.location.hostname;
+            },
 
-            if (isLocalhost) {
-                // localhost doesn't have prefixes
-                edxUserCookie = 'edx-user-info';
-            } else {
-                // does not take sandboxes into account
-                prefix = isStage ? 'stage' : 'prod';
-                edxUserCookie = prefix + '-edx-user-info';
+            userFromEdxUserCookie: function() {
+                var hostname = this.getHostname();
+                var isLocalhost = hostname.indexOf('localhost') >= 0;
+                var isStage = hostname.indexOf('stage') >= 0;
+                var cookie, edxUserCookie, prefix, user, userCookie;
+
+                if (isLocalhost) {
+                    // localhost doesn't have prefixes
+                    edxUserCookie = 'edx-user-info';
+                } else {
+                    // does not take sandboxes into account
+                    prefix = isStage ? 'stage' : 'prod';
+                    edxUserCookie = prefix + '-edx-user-info';
+                }
+
+                cookie = document.cookie.match('(^|;)\\s*' + edxUserCookie + '\\s*=\\s*([^;]+)');
+                userCookie = cookie ? cookie.pop() : $.cookie(edxUserCookie);
+
+                // returns the user object from cookie. Replaces '054' with ',' and removes '\'
+                user = userCookie.replace(/\\/g, '').replace(/054/g, ',');
+                user = user.substring(1, user.length - 1);
+                return JSON.parse(user);
             }
-            // returns the user object from cookie. Replaces '054' with ',' and removes '\'
-            user = $.cookie(edxUserCookie).replace(/\\/g, '').replace(/054/g, ',');
-            user = user.substring(1, user.length - 1);
-            return JSON.parse(user);
         };
 
-        return {
-            userFromEdxUserCookie: userFromEdxUserCookie
-        };
+        return edxUserCookieUtils;
     });
 }).call(this, define || RequireJS.define);

--- a/lms/static/lms/js/spec/main.js
+++ b/lms/static/lms/js/spec/main.js
@@ -775,6 +775,7 @@
         'js/spec/student_account/password_reset_spec.js',
         'js/spec/student_account/register_spec.js',
         'js/spec/student_account/shoppingcart_spec.js',
+        'js/spec/student_account/utils_spec.js',
         'js/spec/verify_student/image_input_spec.js',
         'js/spec/verify_student/make_payment_step_view_ab_testing_spec.js',
         'js/spec/verify_student/make_payment_step_view_spec.js',


### PR DESCRIPTION
The cookie value returned by `$.cookie()` is incomplete. The value returned by `$.cookie()` is truncated on the first occurrence of `?v=` 

The fix fetches the cookie value from document.cookie instead. 

code for parsing document.cookie taken from https://stackoverflow.com/a/25490531/10035855

Ticket: https://openedx.atlassian.net/browse/VAN-285