### PR TITLE
[BD-21] Upgrade edx-toggles to 2.0.0

### DIFF
--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -38,9 +38,6 @@ django-storages<1.9
 # for them.
 edx-enterprise==3.17.2
 
-# We expect v2.0.0 to introduce large breaking changes in the feature toggle API
-edx-toggles<2.0.0
-
 # Upgrading to 2.12.0 breaks several test classes due to API changes, need to update our code accordingly
 factory-boy==2.8.1
 

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -112,7 +112,7 @@ edx-search==2.0.1         # via -r requirements/edx/base.in
 edx-sga==0.13.1           # via -r requirements/edx/base.in
 edx-submissions==3.2.3    # via -r requirements/edx/base.in, ora2
 edx-tincan-py35==0.0.9    # via edx-enterprise
-edx-toggles==1.2.2        # via -c requirements/edx/../constraints.txt, -r requirements/edx/base.in, edx-completion, edx-event-routing-backends, edxval, ora2
+edx-toggles==2.0.0        # via -r requirements/edx/base.in, edx-completion, edx-event-routing-backends, edxval, ora2
 edx-user-state-client==1.2.0  # via -r requirements/edx/base.in
 edx-when==1.3.0           # via -r requirements/edx/base.in, edx-proctoring
 edxval==1.4.5             # via -r requirements/edx/base.in

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -125,7 +125,7 @@ edx-sga==0.13.1           # via -r requirements/edx/testing.txt
 edx-sphinx-theme==1.6.0   # via -r requirements/edx/development.in
 edx-submissions==3.2.3    # via -r requirements/edx/testing.txt, ora2
 edx-tincan-py35==0.0.9    # via -r requirements/edx/testing.txt, edx-enterprise
-edx-toggles==1.2.2        # via -c requirements/edx/../constraints.txt, -r requirements/edx/testing.txt, edx-completion, edx-event-routing-backends, edxval, ora2
+edx-toggles==2.0.0        # via -c requirements/edx/../constraints.txt, -r requirements/edx/testing.txt, edx-completion, edx-event-routing-backends, edxval, ora2
 edx-user-state-client==1.2.0  # via -r requirements/edx/testing.txt
 edx-when==1.3.0           # via -r requirements/edx/testing.txt, edx-proctoring
 edxval==1.4.5             # via -r requirements/edx/testing.txt

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -121,7 +121,7 @@ edx-search==2.0.1         # via -r requirements/edx/base.txt
 edx-sga==0.13.1           # via -r requirements/edx/base.txt
 edx-submissions==3.2.3    # via -r requirements/edx/base.txt, ora2
 edx-tincan-py35==0.0.9    # via -r requirements/edx/base.txt, edx-enterprise
-edx-toggles==1.2.2        # via -c requirements/edx/../constraints.txt, -r requirements/edx/base.txt, edx-completion, edx-event-routing-backends, edxval, ora2
+edx-toggles==2.0.0        # via -c requirements/edx/../constraints.txt, -r requirements/edx/base.txt, edx-completion, edx-event-routing-backends, edxval, ora2
 edx-user-state-client==1.2.0  # via -r requirements/edx/base.txt
 edx-when==1.3.0           # via -r requirements/edx/base.txt, edx-proctoring
 edxval==1.4.5             # via -r requirements/edx/base.txt


### PR DESCRIPTION
2.0.0 introduces a backward-compatible WaffleFlag/Switch API. Existing toggles
that use the LegacyWaffle* classes should migrate to the new Waffle* classes.

cc @robrap 