### PR TITLE
[BTR-53] [BB-3502] Misuse of urljoin in Gradebook URL from Instructor Panel

### DIFF
--- a/lms/djangoapps/instructor/tests/views/test_instructor_dashboard.py
+++ b/lms/djangoapps/instructor/tests/views/test_instructor_dashboard.py
@@ -330,13 +330,36 @@ class TestInstructorDashboard(ModuleStoreTestCase, LoginEnrollmentTestCase, XssT
     )
     def test_staff_can_see_writable_gradebook(self):
         """
-        Test that, when the writable gradebook featue is enabled, a staff member can see it.
+        Test that, when the writable gradebook feature is enabled and
+        deployed in another domain, a staff member can see it.
         """
         waffle_flag = waffle_flags()[WRITABLE_GRADEBOOK]
         with override_waffle_flag(waffle_flag, active=True):
             response = self.client.get(self.url)
 
         expected_gradebook_url = 'http://gradebook.local.edx.org/{}'.format(self.course.id)
+        self.assertContains(response, expected_gradebook_url)
+        self.assertContains(response, 'View Gradebook')
+
+    GRADEBOOK_LEARNER_COUNT_MESSAGE = (
+        'Note: This feature is available only to courses with a small number ' +
+        'of enrolled learners.'
+    )
+
+    @patch(
+        'lms.djangoapps.instructor.views.instructor_dashboard.settings.WRITABLE_GRADEBOOK_URL',
+        settings.LMS_ROOT_URL + '/gradebook'
+    )
+    def test_staff_can_see_writable_gradebook_as_subdirectory(self):
+        """
+        Test that, when the writable gradebook feature is enabled and
+        deployed in a subdirectory, a staff member can see it.
+        """
+        waffle_flag = waffle_flags()[WRITABLE_GRADEBOOK]
+        with override_waffle_flag(waffle_flag, active=True):
+            response = self.client.get(self.url)
+
+        expected_gradebook_url = '{}/{}'.format(settings.WRITABLE_GRADEBOOK_URL, self.course.id)
         self.assertContains(response, expected_gradebook_url)
         self.assertContains(response, 'View Gradebook')
 

--- a/lms/djangoapps/instructor/views/instructor_dashboard.py
+++ b/lms/djangoapps/instructor/views/instructor_dashboard.py
@@ -571,7 +571,7 @@ def _section_student_admin(course, access):
         'spoc_gradebook_url': reverse('spoc_gradebook', kwargs={'course_id': six.text_type(course_key)}),
     }
     if is_writable_gradebook_enabled(course_key) and settings.WRITABLE_GRADEBOOK_URL:
-        section_data['writable_gradebook_url'] = urljoin(settings.WRITABLE_GRADEBOOK_URL, '/' + text_type(course_key))
+        section_data['writable_gradebook_url'] = '{}/{}'.format(settings.WRITABLE_GRADEBOOK_URL, text_type(course_key))
     return section_data
 
 


### PR DESCRIPTION
When the Gradebook MFE is deployed on a subdirectory, `urljoin` returns the wrong link on Instructor Dashboard.

**JIRA tickets**: OSPR-5358 [BTR-53](https://openedx.atlassian.net/browse/BTR-53)

**Discussions**: Background: https://github.com/edx/configuration/pull/6171#discussion_r549190558

The frontend-app-gradebook doesn't use the /gradebook/ path out of the box (or any other). The present issue is specified as "the Gradebook link [stops] working if Gradebooks are deployed using the subdirectory mechanism," based on the linked [discussion](https://github.com/edx/configuration/pull/6171#discussion_r549190558). From this method's [code](https://github.com/edx/edx-platform/commit/66ed41dcd2fc650e1e7f02aa89147d6f1749ece2) and its [unit test](https://github.com/edx/edx-platform/blob/66ed41dcd2fc650e1e7f02aa89147d6f1749ece2/lms/djangoapps/instructor/tests/views/test_instructor_dashboard.py#L230), the frontend-app-gradebook should be hosted at `WRITABLE_GRADEBOOK_URL`. I believe these test cases (based on the `mfe_deployer` role in configuration/master) should pass

```

    WRITABLE_GRADEBOOK_URL = https://MFE_BASE/gradebook
    WRITABLE_GRADEBOOK_URL = https://MFE_BASE
    WRITABLE_GRADEBOOK_URL = https://any.domain.really
```
Using `.format` instead of `urljoin` works nicely, and it's also applied on some [important edx-platform code](https://github.com/edx/edx-platform/blob/e6c7b6fd603815bf9486dbfd814b68d65169aadc/lms/djangoapps/courseware/courses.py#L738) with similar behavior.

**Dependencies**: None

**Screenshots**: See "Testing instructions"

**Sandbox URL**:  [Sandbox](https://pr26046.sandbox.opencraft.hosting/courses/course-v1:edX+DemoX+Demo_Course/instructor#view-student_admin). You can use `staff@example.com` to access the Demo Course's Instructor panel. This instance was deployed with [configuration's master branch](https://github.com/edx/configuration/tree/master) 

**Merge deadline**: None

**Testing instructions**:

- Deploy a devstack using `master`
- Set up a course and an admin account if there isn't one.
- Enable Gradebook MFE using the instructions [here](https://github.com/edx/frontend-app-gradebook#configuring-for-local-use-in-edx-platform). 
- This will have you set `WRITABLE_GRADEBOOK_URL: 'http://localhost:1994'` on `/edx/etc/lms.yml`, but because we want the MFE on a subdirectory, **let's set it to `http://localhost:1800/gradebooks`** (this is based on how the [MFE deploy role on configuration does it](https://github.com/eduNEXT/configuration/blob/master/playbooks/roles/mfe_deployer/README.rst)).
- Go to your course's instructor panel as `staff@example.com` or similar.
- Check the link. Note the URL, it's missing `/gradebooks/`

![broken](https://user-images.githubusercontent.com/33784039/104757010-e5c7f400-5732-11eb-8c98-f48837574b3b.png)


**After applying the fix**: 

![fixed](https://user-images.githubusercontent.com/33784039/104755747-3b030600-5731-11eb-9501-59d6d917d08a.png)
------

**Author notes and concerns**: None.

**Reviewers**
- [x] @farhaanbukhsh 
- [ ] edX reviewer[s] TBD