### PR TITLE
Increase logging verbosity on update_search_index task

### DIFF
--- a/cms/djangoapps/contentstore/tasks.py
+++ b/cms/djangoapps/contentstore/tasks.py
@@ -190,7 +190,13 @@ def update_search_index(course_id, triggered_time_isoformat):
         CoursewareSearchIndexer.index(modulestore(), course_key, triggered_at=(_parse_time(triggered_time_isoformat)))
 
     except SearchIndexingError as exc:
-        LOGGER.error(u'Search indexing error for complete course %s - %s', course_id, text_type(exc))
+        error_list = exc.error_list
+        LOGGER.error(
+            u"Search indexing error for complete course %s - %s - %s",
+            course_id,
+            text_type(exc),
+            error_list,
+        )
     else:
         LOGGER.debug(u'Search indexing successful for complete course %s', course_id)
 


### PR DESCRIPTION
to gain insight into CR-3119/TNL-7866.
We know that one or more errors are occuring during this job, but it's
not obvious what these errors are.