### PR TITLE
[TNL-7361] - Restrict Instructor Tab from masquerading user with student role.

### DIFF
--- a/lms/templates/courseware/course_navigation.html
+++ b/lms/templates/courseware/course_navigation.html
@@ -44,19 +44,23 @@ if course is not None:
                     <%
                     tab_is_active = tab.tab_id in (active_page, default_tab)
                     %>
-                    <li class="nav-item ${'active' if tab_is_active else ''}">
-                        <a href="${tab.link_func(course, reverse)}" class="nav-link">
-                            ${_(tab.name)}
-                            % if tab_is_active:
-                                <span class="sr-only">, ${_('current location')}</span>
-                            %endif
-                            % if tab_image:
-                                ## Translators: 'needs attention' is an alternative string for the
-                                ## notification image that indicates the tab "needs attention".
-                                <img src="${tab_image}" alt="${_('needs attention')}" />
-                            %endif
-                        </a>
-                    </li>
+                        % if masquerade is not None and masquerade.role == 'student' and tab.name == 'Instructor':
+                            <% continue %>
+                        % else:
+                            <li class="nav-item ${'active' if tab_is_active else ''}">
+                                <a href="${tab.link_func(course, reverse)}" class="nav-link">
+                                    ${_(tab.name)}
+                                    % if tab_is_active:
+                                        <span class="sr-only">, ${_('current location')}</span>
+                                    %endif
+                                    % if tab_image:
+                                        ## Translators: 'needs attention' is an alternative string for the
+                                        ## notification image that indicates the tab "needs attention".
+                                        <img src="${tab_image}" alt="${_('needs attention')}" />
+                                    %endif
+                                </a>
+                            </li>
+                        %endif
                 % endfor
             </ul>
         </nav>


### PR DESCRIPTION
### [TNL-7361](https://openedx.atlassian.net/browse/TNL-7361)

#### Description
The instructor tab was visible to all forms of users when masquerading. This PR is created to address this issue and restrict masquerading users with the role `student` from viewing the instruction tab.


#### Masquerading as Staff
![Screen Shot 2021-01-13 at 4 55 01 PM](https://user-images.githubusercontent.com/30112155/104449071-daa08700-55bf-11eb-9044-a541c604ee91.png)


#### Masquerading as Student
![Screen Shot 2021-01-13 at 4 54 38 PM](https://user-images.githubusercontent.com/30112155/104449068-d83e2d00-55bf-11eb-8f3c-bd073e9bbfcc.png)
