### PR TITLE
Fix sidebar width on course about page when screen resolution less than 768px

### DIFF
--- a/lms/static/sass/multicourse/_course_about.scss
+++ b/lms/static/sass/multicourse/_course_about.scss
@@ -407,7 +407,7 @@
   }
 
   .course-sidebar {
-    @include media-breakpoint-up(dm) {
+    @include media-breakpoint-up(md) {
       box-sizing: border-box;
 
       @include float(left);


### PR DESCRIPTION
This is fix for sidebar width on course about page on resolutions less than 768px. (Attachment below). 

To check this - please open LMS on mobile phone or resize your browser and then go to the any course about page and scroll down. 

It's happened because of simple mistake in file `edx-platform/lms/static/sass/multicourse/_course_about.scss` on line 410. We just need to make correct media-breakpoint  rule - replace `dm` with `md`

![Снимок экрана 2021-01-13 в 16 32 57](https://user-images.githubusercontent.com/19806032/104466749-3d911e80-55be-11eb-8477-5cda5ab92e43.png)
