### PR TITLE
[MST-570] Create runtime api to return active enrollments by course

### DIFF
--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -2574,7 +2574,7 @@ INSTALLED_APPS = [
     'common.djangoapps.course_modes.apps.CourseModesConfig',
 
     # Enrollment API
-    'openedx.core.djangoapps.enrollments',
+    'openedx.core.djangoapps.enrollments.apps.EnrollmentsConfig',
 
     # Entitlement API
     'common.djangoapps.entitlements.apps.EntitlementsConfig',

--- a/openedx/core/djangoapps/enrollments/apps.py
+++ b/openedx/core/djangoapps/enrollments/apps.py
@@ -1,0 +1,26 @@
+
+"""
+Enrollments Application Configuration
+
+Signal handlers are connected here.
+"""
+
+
+from django.apps import AppConfig
+from django.conf import settings
+from edx_proctoring.runtime import set_runtime_service
+
+
+class EnrollmentsConfig(AppConfig):
+    """
+    Application Configuration for Enrollments.
+    """
+    name = u'openedx.core.djangoapps.enrollments'
+
+    def ready(self):
+        """
+        Connect handlers to fetch enrollments.
+        """
+        if settings.FEATURES.get('ENABLE_SPECIAL_EXAMS'):
+            from .services import EnrollmentsService
+            set_runtime_service('enrollments', EnrollmentsService())

--- a/openedx/core/djangoapps/enrollments/services.py
+++ b/openedx/core/djangoapps/enrollments/services.py
@@ -1,0 +1,20 @@
+"""
+Enrollments Service
+"""
+
+
+from common.djangoapps.student.models import CourseEnrollment
+
+
+class EnrollmentsService(object):
+    """
+    Enrollments service
+
+    Provides functions related to course enrollments
+    """
+
+    def get_active_enrollments_by_course(self, course_id):
+        """
+        Returns a list of active enrollments for a course
+        """
+        return list(CourseEnrollment.objects.filter(course_id=course_id, is_active=True))

--- a/openedx/core/djangoapps/enrollments/tests/test_services.py
+++ b/openedx/core/djangoapps/enrollments/tests/test_services.py
@@ -1,0 +1,56 @@
+"""
+Enrollments Service Tests
+"""
+
+
+from common.djangoapps.course_modes.models import CourseMode
+from common.djangoapps.course_modes.tests.factories import CourseModeFactory
+from common.djangoapps.student.models import CourseEnrollment
+from common.djangoapps.student.tests.factories import UserFactory
+from openedx.core.djangoapps.enrollments.services import EnrollmentsService
+from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
+from xmodule.modulestore.tests.factories import CourseFactory
+
+
+class EnrollmentsServiceTests(ModuleStoreTestCase):
+    """
+    Tests for Enrollments Service
+    """
+    def setUp(self):
+        super().setUp()
+        self.service = EnrollmentsService()
+        self.course = CourseFactory.create()
+        self.course_modes = [CourseMode.HONOR, CourseMode.VERIFIED, CourseMode.AUDIT]
+        for x in range(3):
+            CourseModeFactory.create(mode_slug=self.course_modes[x], course_id=self.course.id)
+            user = UserFactory(username='user{}'.format(x))
+            CourseEnrollment.enroll(user, self.course.id, mode=self.course_modes[x])
+
+    def test_get_active_enrollments_by_course(self):
+        """
+        Test that it returns a list of active enrollments
+        """
+        enrollments = self.service.get_active_enrollments_by_course(self.course.id)
+        self.assertEqual(len(enrollments), 3)
+        # At minimum, the function should return the user and mode tied to each enrollment
+        for x in range(3):
+            self.assertEqual(enrollments[x].user.username, 'user{}'.format(x))
+            self.assertEqual(enrollments[x].mode, self.course_modes[x])
+
+    def test_get_active_enrollments_by_course_ignore_inactive(self):
+        """
+        Test that inactive enrollments are ignored
+        """
+        inactive_enrollment = CourseEnrollment.objects.get(course_id=self.course.id, user__username='user0')
+        inactive_enrollment.is_active = False
+        inactive_enrollment.save()
+        enrollments = self.service.get_active_enrollments_by_course(self.course.id)
+        self.assertEqual(len(enrollments), 2)
+
+    def test_get_active_enrollments_no_enrollments(self):
+        """
+        Test that an empty list is returned if a course has no enrollments
+        """
+        new_course = CourseFactory()
+        enrollments = self.service.get_active_enrollments_by_course(new_course.id)  # pylint: disable=no-member
+        self.assertEqual(len(enrollments), 0)


### PR DESCRIPTION
@edx/masters-devs-cosmonauts 

[MST-570](https://openedx.atlassian.net/browse/MST-570)

Add a runtime service for edx-proctoring, with a function that returns a list of all active enrollments for a given course id.