### PR TITLE
Add more cookie logging code.

### DIFF
--- a/openedx/core/lib/request_utils.py
+++ b/openedx/core/lib/request_utils.py
@@ -152,11 +152,8 @@ class CookieMonitoringMiddleware(MiddlewareMixin):
             max_group_cookie_name = max_cookie_name
             max_group_cookie_size = max_cookie_size
 
-        for name, size in cookie_names_to_size.items():
-            attribute_name = 'cookies.{}.size'.format(name)
-            set_custom_attribute(attribute_name, size)
-            log.debug(u'%s = %d', attribute_name, size)
-
+        # Only log the groups because adding an arbitrary number of individual cookies pushes too many
+        # metrics into NR and results in other metrics getting dropped potentially.
         for name, size in cookie_groups_to_size.items():
             attribute_name = 'cookies.{}.group.size'.format(name)
             set_custom_attribute(attribute_name, size)

--- a/openedx/core/lib/tests/test_request_utils.py
+++ b/openedx/core/lib/tests/test_request_utils.py
@@ -114,14 +114,6 @@ class RequestUtilTestCase(unittest.TestCase):
         middleware.process_request(mock_request)
 
         mock_set_custom_attribute.assert_has_calls([
-            call('cookies.a.size', 100),
-            call('cookies._b.size', 13),
-            call('cookies._c_.size', 13),
-            call('cookies.a.b.size', 10),
-            call('cookies.a.c.size', 10),
-            call('cookies.b..size', 13),
-            call('cookies.b_a.size', 15),
-            call('cookies.b_c.size', 15),
             call('cookies.a.group.size', 20),
             call('cookies.b.group.size', 43),
             call('cookies.max.name', 'a'),
@@ -149,9 +141,6 @@ class RequestUtilTestCase(unittest.TestCase):
         middleware.process_request(mock_request)
 
         mock_set_custom_attribute.assert_has_calls([
-            call('cookies.a.size', 10),
-            call('cookies.b_a.size', 15),
-            call('cookies.b_c.size', 20),
             call('cookies.b.group.size', 35),
             call('cookies.max.name', 'b_c'),
             call('cookies.max.size', 20),

--- a/openedx/core/lib/tests/test_request_utils.py
+++ b/openedx/core/lib/tests/test_request_utils.py
@@ -8,13 +8,11 @@ from django.conf import settings
 from django.core.exceptions import SuspiciousOperation
 from django.test.client import RequestFactory
 
-from edx_toggles.toggles.testutils import override_waffle_flag
 from openedx.core.lib.request_utils import (
     get_request_or_stub,
     course_id_from_url,
     safe_get_host,
     CookieMonitoringMiddleware,
-    CAPTURE_COOKIE_SIZES,
 )
 
 
@@ -114,14 +112,25 @@ class RequestUtilTestCase(unittest.TestCase):
         middleware.process_request(mock_request)
 
         mock_set_custom_attribute.assert_has_calls([
-            call('cookies.a.group.size', 20),
-            call('cookies.b.group.size', 43),
+            call('cookies.1.name', 'a'),
+            call('cookies.1.size', 100),
+            call('cookies.2.name', 'b_a'),
+            call('cookies.2.size', 15),
+            call('cookies.3.name', 'b_c'),
+            call('cookies.3.size', 15),
+            call('cookies.4.name', '_b'),
+            call('cookies.4.size', 13),
+            call('cookies.5.name', '_c_'),
+            call('cookies.5.size', 13),
+            call('cookies.group.1.name', 'b'),
+            call('cookies.group.1.size', 43),
+            call('cookies.group.2.name', 'a'),
+            call('cookies.group.2.size', 20),
             call('cookies.max.name', 'a'),
             call('cookies.max.size', 100),
-            # Test that single cookie is also treated as a group for max calculations.
             call('cookies.max.group.name', 'a'),
             call('cookies.max.group.size', 100),
-            call('cookies_total_size', 189)
+            call('cookies_total_size', 189),
         ])
 
     @patch("openedx.core.lib.request_utils.CAPTURE_COOKIE_SIZES")
@@ -141,7 +150,14 @@ class RequestUtilTestCase(unittest.TestCase):
         middleware.process_request(mock_request)
 
         mock_set_custom_attribute.assert_has_calls([
-            call('cookies.b.group.size', 35),
+            call('cookies.1.name', 'b_c'),
+            call('cookies.1.size', 20),
+            call('cookies.2.name', 'b_a'),
+            call('cookies.2.size', 15),
+            call('cookies.3.name', 'a'),
+            call('cookies.3.size', 10),
+            call('cookies.group.1.name', 'b'),
+            call('cookies.group.1.size', 35),
             call('cookies.max.name', 'b_c'),
             call('cookies.max.size', 20),
             call('cookies.max.group.name', 'b'),


### PR DESCRIPTION
We want to be able to easily figure out what our biggest cookies are and we
want to also group cookies by prefix because certain services create multiple
cookies and then put unique identifiers in the cookie name.

For example braze cookie names use the following pattern:
    ab.storage.<userId>
    ab.storage.<deviceId>
    ab.storage.<sessionId>

In this case we want to group all the `ab` cookies together so we can see
their total size.

New attributes:

* `cookies.<group_prefix>.group.size`: The size of a group of cookies. For example
	the sum of the size of all braze cookies would be the value of the
	`cookies.ab.group.size` attribute.
* `cookies.max.name`: The name of the largest cookie sent by the user.
* `cookies.max.size`: The size of the largest cookie sent by the user.
* `cookies.max.group.name`: The name of the largest group of cookies. A single cookie
	counts as a group of one for this calculation.
* `cookies.max.group.size`: The sum total size of all the cookies in the largest group.