### PR TITLE
Fix Markdown errors on discussions tab 

### DIFF
--- a/lms/djangoapps/discussion/views.py
+++ b/lms/djangoapps/discussion/views.py
@@ -789,7 +789,7 @@ class DiscussionBoardFragmentView(EdxFragmentView):
         works in conjunction with the Django pipeline to ensure that in development mode
         the files are loaded individually, but in production just the single bundle is loaded.
         """
-        return list(set(self.get_js_dependencies('discussion_vendor')))
+        return list(dict.fromkeys(self.get_js_dependencies('discussion_vendor')))
 
     def js_dependencies(self):
         """


### PR DESCRIPTION
Discussions tab doesn't load correctly in recent devstack. It throws a js error:
```
Markdown.Editor.js:65 Uncaught ReferenceError: Markdown is not defined.
```

The following files should be loaded in order they are listed:
https://github.com/edx/edx-platform/blob/34634eb8e8230225e1711042570ad3bad4de099c/lms/envs/common.py#L1692-L1701

But casting to `set` here drops information about order:

https://github.com/edx/edx-platform/blob/084b4096626cf148d2a77871109856208736732d/lms/djangoapps/discussion/views.py#L783-L791

**Testing instructions**:

1. Install recent master devstack.
2. Enroll in demo course.
3. Open Discussions tab.
4. Do hard reloads until page throw `Markdown is not defined` error.
5. Checkout `edx-platform` to this branch.
6. Ensure that the issue is fixed.

**Reviewers**
- [ ] @shimulch 
- [x] edX reviewer[s] TBD