### PR TITLE
[SE-3949] remove absolute positioning to allow RTL scrolling

### DIFF
--- a/lms/static/sass/course/_gradebook.scss
+++ b/lms/static/sass/course/_gradebook.scss
@@ -129,9 +129,6 @@ div.gradebook-wrapper {
     }
 
     .grade-table {
-      position: absolute;
-      top: 0;
-      left: 0;
       width: 1000px;
       cursor: move;
 


### PR DESCRIPTION
This PR fixes RTL scrolling in grade books by removing the absolute positioning of grade-table which prevents scrolling if the direction is not LTR.

**Dependencies**: None

**Screenshots**: 

N/A

**Sandbox URL**: https://se-3949-3.stage.opencraft.hosting/

**Merge deadline**: None

**Testing instructions**:

0. Login at https://se-3949-3.stage.opencraft.hosting/login using the standard edx user/password
1. Open the [grade book](https://se-3949-3.stage.opencraft.hosting/courses/course-v1:edX+DemoX+Demo_Course/instructor/api/gradebook)
2. Validate the scrollbar can be scrolled

**Author notes and concerns**:

It is normal and expected if the scrollbar jumps to the right within the grade book after the rules are removed and the language is RTL.

**Reviewers**
- [ ] @pkulkark 