### PR TITLE
[TNL-7803] - Add text to new Edge logo

### DIFF
--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -2317,6 +2317,7 @@ VERIFY_STUDENT = {
 ORGANIZATIONS_AUTOCREATE = True
 
 ################# Settings for brand logos. #################
+LOGO_IMAGE_EXTRA_TEXT = ''
 LOGO_URL = None
 LOGO_URL_PNG = None
 LOGO_TRADEMARK_URL = None

--- a/cms/envs/production.py
+++ b/cms/envs/production.py
@@ -591,3 +591,5 @@ EXPLICIT_QUEUES = {
     'cms.djangoapps.contentstore.tasks.update_search_index': {
         'queue': UPDATE_SEARCH_INDEX_JOB_QUEUE},
 }
+
+LOGO_IMAGE_EXTRA_TEXT = ENV_TOKENS.get('LOGO_IMAGE_EXTRA_TEXT', '')

--- a/cms/templates/widgets/header.html
+++ b/cms/templates/widgets/header.html
@@ -16,7 +16,7 @@
         <a class="brand-link" href="/">
           <img class="brand-image" src="${static.url('images/studio-logo.png')}" alt="${settings.STUDIO_NAME}" />
             % if settings.LOGO_IMAGE_EXTRA_TEXT == 'edge':
-            <sub class="font-italic">edge</sub>
+            <span class="font-italic"> | EDGE</span>
             % endif
         </a>
       </h1>

--- a/cms/templates/widgets/header.html
+++ b/cms/templates/widgets/header.html
@@ -16,7 +16,7 @@
         <a class="brand-link" href="/">
           <img class="brand-image" src="${static.url('images/studio-logo.png')}" alt="${settings.STUDIO_NAME}" />
             % if settings.LOGO_IMAGE_EXTRA_TEXT == 'edge':
-            <span class="font-italic"> | EDGE</span>
+            <span class="font-italic"> <span class="tilted">|</span> EDGE</span>
             % endif
         </a>
       </h1>

--- a/cms/templates/widgets/header.html
+++ b/cms/templates/widgets/header.html
@@ -15,6 +15,9 @@
       <h1 class="branding">
         <a class="brand-link" href="/">
           <img class="brand-image" src="${static.url('images/studio-logo.png')}" alt="${settings.STUDIO_NAME}" />
+            % if settings.LOGO_IMAGE_EXTRA_TEXT == 'edge':
+            <sub class="font-italic">edge</sub>
+            % endif
         </a>
       </h1>
 


### PR DESCRIPTION
### [TNL-7803](https://openedx.atlassian.net/browse/TNL-7803)

Add text to Studio edge logo for new brand.

### Before

<img width="1341" alt="Screenshot 2021-01-18 at 2 37 01 PM" src="https://user-images.githubusercontent.com/30112155/104897879-bddac980-599a-11eb-8186-19ff17b03262.png">


###  After

<img width="1317" alt="Screenshot 2021-01-21 at 3 26 46 PM" src="https://user-images.githubusercontent.com/10988308/105339370-6b014c00-5bfe-11eb-9f3f-528da8658fd4.png">

