### PR TITLE
Add setting for erroring on deprecated imports

### DIFF
--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -2322,3 +2322,17 @@ LOGO_URL_PNG = None
 LOGO_TRADEMARK_URL = None
 FAVICON_URL = None
 DEFAULT_EMAIL_LOGO_URL = 'https://edx-cdn.org/v3/default/logo.png'
+
+# .. toggle_name: ERROR_ON_DEPRECATED_EDX_PLATFORM_IMPORTS
+# .. toggle_implementation: DjangoSetting
+# .. toggle_default: False
+# .. toggle_use_cases: rollout
+# .. toggle_creation_date: 2021-01-20
+# .. toggle_target_removal_date: 2021-01-27
+# .. toggle_tickets: https://github.com/edx/edx-platform/pull/25932
+# .. toggle_description: Whether to raise an exception where,
+#  normally, a DeprecatedEdxPlatformImportWarning would be raised.
+#  This will allow us to test dropping support for the deprecated
+#  import paths without yet removing all of the import_shims
+#  machinery.
+ERROR_ON_DEPRECATED_EDX_PLATFORM_IMPORTS = False

--- a/cms/envs/devstack.py
+++ b/cms/envs/devstack.py
@@ -240,3 +240,6 @@ CORS_ALLOW_HEADERS = corsheaders_default_headers + (
 ################### Special Exams (Proctoring) and Prereqs ###################
 FEATURES['ENABLE_SPECIAL_EXAMS'] = True
 FEATURES['ENABLE_PREREQUISITE_COURSES'] = True
+
+# Don't tolerate deprecated edx-platform import usage in devstack.
+ERROR_ON_DEPRECATED_EDX_PLATFORM_IMPORTS = True

--- a/cms/envs/test.py
+++ b/cms/envs/test.py
@@ -326,3 +326,6 @@ LOGISTRATION_RATELIMIT_RATE = '5/5m'
 LOGISTRATION_API_RATELIMIT = '5/m'
 
 REGISTRATION_VALIDATION_RATELIMIT = '5/minute'
+
+# Don't tolerate deprecated edx-platform import usage in tests.
+ERROR_ON_DEPRECATED_EDX_PLATFORM_IMPORTS = True

--- a/import_shims/warn.py
+++ b/import_shims/warn.py
@@ -7,6 +7,7 @@ See /docs/decisions/0007-sys-path-modification-removal.rst for details.
 
 import warnings
 
+from django.conf import settings
 from edx_django_utils.monitoring import set_custom_attribute
 
 
@@ -37,10 +38,30 @@ class DeprecatedEdxPlatformImportWarning(DeprecationWarning):
         ).format(self=self)
 
 
+class DeprecatedEdxPlatformImportError(Exception):
+    """
+    Error: An edx-platform module is being imported from an unsupported location.
+
+    See `DeprecatedEdxPlatformImportWarning` above for context.
+    """
+
+    def __init__(self, old_import, new_import):
+        super().__init__()
+        self.old_import = old_import
+        self.new_import = new_import
+
+    def __str__(self):
+        return (
+            "Importing {self.old_import} instead of {self.new_import} is deprecated"
+        ).format(self=self)
+
+
 def warn_deprecated_import(old_import, new_import):
     """
     Warn that a module is being imported from its old location.
     """
+    if settings.ERROR_ON_DEPRECATED_EDX_PLATFORM_IMPORTS:
+        raise DeprecatedEdxPlatformImportError(old_import, new_import)
     set_custom_attribute("deprecated_edx_platform_import", old_import)
     warnings.warn(
         DeprecatedEdxPlatformImportWarning(old_import, new_import),

--- a/lms/djangoapps/courseware/tests/test_views.py
+++ b/lms/djangoapps/courseware/tests/test_views.py
@@ -2523,7 +2523,8 @@ class TestIndexView(ModuleStoreTestCase):
                                        invitation_only, is_masters_only, expected_should_show_enroll_button):
         with patch('lms.djangoapps.courseware.views.views.course_open_for_self_enrollment') \
                 as patch_course_open_for_self_enrollment, \
-                patch('course_modes.models.CourseMode.is_masters_only') as patch_is_masters_only:
+                patch('common.djangoapps.course_modes.models.CourseMode.is_masters_only') \
+                as patch_is_masters_only:
             course = CourseFactory()
 
             patch_course_open_for_self_enrollment.return_value = course_open_for_self_enrollment

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -4179,3 +4179,17 @@ LOGO_URL_PNG = None
 LOGO_TRADEMARK_URL = None
 FAVICON_URL = None
 DEFAULT_EMAIL_LOGO_URL = 'https://edx-cdn.org/v3/default/logo.png'
+
+# .. toggle_name: ERROR_ON_DEPRECATED_EDX_PLATFORM_IMPORTS
+# .. toggle_implementation: DjangoSetting
+# .. toggle_default: False
+# .. toggle_use_cases: rollout
+# .. toggle_creation_date: 2021-01-20
+# .. toggle_target_removal_date: 2021-01-27
+# .. toggle_tickets: https://github.com/edx/edx-platform/pull/25932
+# .. toggle_description: Whether to raise an exception where,
+#  normally, a DeprecatedEdxPlatformImportWarning would be raised.
+#  This will allow us to test dropping support for the deprecated
+#  import paths without yet removing all of the import_shims
+#  machinery.
+ERROR_ON_DEPRECATED_EDX_PLATFORM_IMPORTS = False

--- a/lms/envs/devstack.py
+++ b/lms/envs/devstack.py
@@ -431,3 +431,6 @@ if os.path.isfile(join(dirname(abspath(__file__)), 'private.py')):
 ################### Special Exams (Proctoring) and Prereqs ###################
 FEATURES['ENABLE_SPECIAL_EXAMS'] = True
 FEATURES['ENABLE_PREREQUISITE_COURSES'] = True
+
+# Don't tolerate deprecated edx-platform import usage in devstack.
+ERROR_ON_DEPRECATED_EDX_PLATFORM_IMPORTS = True

--- a/lms/envs/test.py
+++ b/lms/envs/test.py
@@ -588,3 +588,6 @@ LOGISTRATION_RATELIMIT_RATE = '5/5m'
 LOGISTRATION_API_RATELIMIT = '5/m'
 
 REGISTRATION_VALIDATION_RATELIMIT = '5/minute'
+
+# Don't tolerate deprecated edx-platform import usage in tests.
+ERROR_ON_DEPRECATED_EDX_PLATFORM_IMPORTS = True

--- a/openedx/tests/settings.py
+++ b/openedx/tests/settings.py
@@ -133,3 +133,6 @@ RUN_BLOCKSTORE_TESTS = False
 SOFTWARE_SECURE_REQUEST_RETRY_DELAY = 60 * 60
 # Maximum of 6 retries before giving up.
 SOFTWARE_SECURE_RETRY_MAX_ATTEMPTS = 6
+
+# Don't tolerate deprecated edx-platform import usage in tests.
+ERROR_ON_DEPRECATED_EDX_PLATFORM_IMPORTS = True


### PR DESCRIPTION
```
Deprecated edx-platform import paths
(for example, `student` instead of
`common.djangoapps.student`) currently raise
warnings when used. We want to fully remove
support for those paths.

As an easily reversible way to initially remove
support, we add a new setting to LMS and Studio
called `ERROR_ON_DEPRECATED_EDX_PLATFORM_IMPORTS`,
defaulting to False. We set it to True for devstack
and will set it to True in Stage and Production
soon. If critical errors occur, we can easily
flip the setting back to False.
```
This approach is a safer, more easily-reversible first step before [fully removing the import shims](https://github.com/edx/edx-platform/pull/25932).

This PR on its own will not change anything. The corresponding internal PRs will turn on the errors for each environment:
* Stage: https://github.com/edx/edx-internal/pull/4227
* Prod: https://github.com/edx/edx-internal/pull/4226
* Edge: https://github.com/edx/edge-internal/pull/289
