### PR TITLE
Upgrade xblock-poll from 1.10.0 to 1.10.2

### DIFF
--- a/requirements/edx/github.in
+++ b/requirements/edx/github.in
@@ -71,5 +71,5 @@ git+https://github.com/edx/django-ratelimit-backend.git@v2.0.1a5#egg=django-rate
 
 # Third Party XBlocks
 
-git+https://github.com/open-craft/xblock-poll@1efd04bd6e16252a20e39a7516f9b69a000ace24#egg=xblock-poll==1.10.0
+git+https://github.com/open-craft/xblock-poll@922cd36fb1c3cfe00b4ce03b19a13185d136447d#egg=xblock-poll==1.10.2
 git+https://github.com/edx-solutions/xblock-drag-and-drop-v2@v2.2.10#egg=xblock-drag-and-drop-v2==2.2.10


### PR DESCRIPTION
Pulls in:
* Translation corrections (1.10.1)
* Fix deprecated import, which is soon to be unsupported (1.10.2)

The package's diff: https://github.com/open-craft/xblock-poll/compare/v1.10.0...v1.10.2

This is a blocker for the [import shims removal](https://github.com/edx/edx-platform/pull/25932).