### PR TITLE
Add option to disable the help link in the navbar

### DIFF
--- a/cms/templates/widgets/header.html
+++ b/cms/templates/widgets/header.html
@@ -236,9 +236,11 @@
       <nav class="nav-account nav-is-signedin nav-dd ui-right" aria-label="${_('Account')}">
         <h2 class="sr-only">${_("Account Navigation")}</h2>
         <ol>
-          <li class="nav-item nav-account-help">
-            <h3 class="title"><span class="label"><a href="${get_online_help_info(online_help_token)['doc_url']}" title="${_('Contextual Online Help')}" rel="noopener" target="_blank">${_("Help")}</a></span></h3>
-          </li>
+          % if settings.FEATURES.get('ENABLE_HELP_LINK'):
+            <li class="nav-item nav-account-help">
+              <h3 class="title"><span class="label"><a href="${get_online_help_info(online_help_token)['doc_url']}" title="${_('Contextual Online Help')}" rel="noopener" target="_blank">${_("Help")}</a></span></h3>
+            </li>
+          % endif
           <li class="nav-item nav-account-user">
             <%include file="user_dropdown.html" args="online_help_token=online_help_token" />
           </li>

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -263,6 +263,17 @@ FEATURES = {
     # .. toggle_tickets: https://github.com/edx/edx-platform/pull/1073
     'COURSES_ARE_BROWSABLE': True,
 
+    # Can be turned off to disable the help link in the navbar
+    # .. toggle_name: FEATURES['ENABLE_HELP_LINK']
+    # .. toggle_implementation: DjangoSetting
+    # .. toggle_default: True
+    # .. toggle_description: When True, a help link is displayed on the main navbar. Set False to hide it.
+    # .. toggle_use_cases: open_edx
+    # .. toggle_creation_date: 2021-03-05
+    # .. toggle_tickets: https://github.com/edx/edx-platform/pull/26106
+    'ENABLE_HELP_LINK': True,
+
+
     # .. toggle_name: FEATURES['HIDE_DASHBOARD_COURSES_UNTIL_ACTIVATED']
     # .. toggle_implementation: DjangoSetting
     # .. toggle_default: False

--- a/lms/templates/header/navbar-authenticated.html
+++ b/lms/templates/header/navbar-authenticated.html
@@ -14,6 +14,7 @@ from openedx.core.djangoapps.site_configuration import helpers as configuration_
   show_explore_courses = settings.FEATURES.get('COURSES_ARE_BROWSABLE')
   show_sysadmin_dashboard = settings.FEATURES.get('ENABLE_SYSADMIN_DASHBOARD','') and user.is_staff
   self.real_user = getattr(user, 'real_user', user)
+  enable_help_link = settings.FEATURES.get('ENABLE_HELP_LINK')
 
   support_link = configuration_helpers.get_value('SUPPORT_SITE_LINK', settings.SUPPORT_SITE_LINK)
   doc_link = get_online_help_info(online_help_token)['doc_url']
@@ -60,9 +61,11 @@ from openedx.core.djangoapps.site_configuration import helpers as configuration_
     % endif
   </div>
   <div class="secondary">
-    <div class="mobile-nav-item hidden-mobile nav-item">
-      <a class="help-link" href="${help_link}" rel="noopener" target="_blank">${_("Help")}</a>
-    </div>
+    % if enable_help_link:
+      <div class="mobile-nav-item hidden-mobile nav-item">
+        <a class="help-link" href="${help_link}" rel="noopener" target="_blank">${_("Help")}</a>
+      </div>
+    % endif
     <%include file="user_dropdown.html"/>
   </div>
 </div>

--- a/lms/templates/navigation/bootstrap/navbar-authenticated.html
+++ b/lms/templates/navigation/bootstrap/navbar-authenticated.html
@@ -57,12 +57,14 @@ from django.utils.translation import ugettext as _
   </ul>
 
   <ul class="navbar-nav navbar-right">
-    <li class="nav-item mt-2 nav-item-open-collapsed">
-      <a href="${get_online_help_info(online_help_token)['doc_url']}"
-      rel="noopener" 
-      target="_blank"
-       class="nav-link">${_("Help")}</a>
-    </li>
+    % if settings.FEATURES.get('ENABLE_HELP_LINK'):
+      <li class="nav-item mt-2 nav-item-open-collapsed">
+        <a href="${get_online_help_info(online_help_token)['doc_url']}"
+        rel="noopener"
+        target="_blank"
+         class="nav-link">${_("Help")}</a>
+      </li>
+    % endif
 
     <%include file="../../user_dropdown.html"/>
   </ul>

--- a/lms/templates/navigation/navbar-authenticated.html
+++ b/lms/templates/navigation/navbar-authenticated.html
@@ -41,7 +41,9 @@ from django.utils.translation import ugettext as _
 
 <%include file="../user_dropdown.html"/>
 
-<a href="${get_online_help_info(online_help_token)['doc_url']}"
-        rel="noopener"
-         target="_blank"
-         class="doc-link">${_("Help")}</a>
+% if settings.FEATURES.get('ENABLE_HELP_LINK'):
+  <a href="${get_online_help_info(online_help_token)['doc_url']}"
+          rel="noopener"
+           target="_blank"
+           class="doc-link">${_("Help")}</a>
+% endif

--- a/themes/edx.org/lms/templates/header/navbar-authenticated.html
+++ b/themes/edx.org/lms/templates/header/navbar-authenticated.html
@@ -14,6 +14,7 @@ from openedx.core.djangoapps.site_configuration import helpers as configuration_
   show_explore_courses = settings.FEATURES.get('COURSES_ARE_BROWSABLE')
   show_sysadmin_dashboard = settings.FEATURES.get('ENABLE_SYSADMIN_DASHBOARD','') and user.is_staff
   self.real_user = getattr(user, 'real_user', user)
+  enable_help_link = settings.FEATURES.get('ENABLE_HELP_LINK')
 %>
 
 <div class="nav-links">
@@ -58,13 +59,15 @@ from openedx.core.djangoapps.site_configuration import helpers as configuration_
 
   </div>
   <div class="secondary">
-    <div class="mobile-nav-item hidden-mobile nav-item">
-      % if online_help_token == "instructor":
-        <a class="help-link" href="${get_online_help_info(online_help_token)['doc_url']}" rel="noopener" target="_blank">${_("Help")}</a>
-      % else:
-        <a class="help-link" href="${configuration_helpers.get_value('SUPPORT_SITE_LINK', settings.SUPPORT_SITE_LINK)}" rel="noopener" target="_blank">${_("Help")}</a>
-      % endif
-    </div>
+    % if enable_help_link:
+      <div class="mobile-nav-item hidden-mobile nav-item">
+        % if online_help_token == "instructor":
+          <a class="help-link" href="${get_online_help_info(online_help_token)['doc_url']}" rel="noopener" target="_blank">${_("Help")}</a>
+        % else:
+          <a class="help-link" href="${configuration_helpers.get_value('SUPPORT_SITE_LINK', settings.SUPPORT_SITE_LINK)}" rel="noopener" target="_blank">${_("Help")}</a>
+        % endif
+      </div>
+    % endif
     <%include file="user_dropdown.html"/>
   </div>
 </div>


### PR DESCRIPTION
This PR adds a feature flag to disable the help link from the navbar

**JIRA tickets**: [Opencraft/SE-3685](https://tasks.opencraft.com/browse/SE-3685)

**Sandbox URL**: https://mavidser.stage.opencraft.hosting/

**Testing instructions**:

1. Set `settings.FEATURES.ENABLE_HELP_LINK` to `False`, and confirm that the 'Help' link from the navbar disappears

**Reviewers**
- [ ] @pkulkark 
- [ ] edX reviewer[s] TBD