### PR TITLE
[AA-497] Only set due dates on subsections that contain graded assignments with a score and a nonzero weight

### DIFF
--- a/openedx/core/djangoapps/course_date_signals/tests.py
+++ b/openedx/core/djangoapps/course_date_signals/tests.py
@@ -2,6 +2,8 @@ from datetime import timedelta
 import ddt
 from unittest.mock import patch
 
+from openedx.core.djangoapps.course_date_signals.handlers import _gather_graded_items, _has_assignment_blocks
+from xmodule.modulestore.django import modulestore
 from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
 from xmodule.modulestore.tests.factories import CourseFactory, ItemFactory
 from . import utils
@@ -40,3 +42,76 @@ class SelfPacedDueDatesTests(ModuleStoreTestCase):
             actual = [(idx, section.display_name, offset) for (idx, section, offset) in utils.spaced_out_sections(self.course)]
 
         self.assertEqual(actual, expected_sections)
+
+    def test_dates_for_ungraded_assignments(self):
+        """
+        _has_assignment_blocks should return true if the argument block
+        children leaf nodes include an assignment that is graded and scored
+        """
+        with modulestore().bulk_operations(self.course.id):
+            sequence = ItemFactory(parent=self.course, category="sequential")
+            vertical = ItemFactory(parent=sequence, category="vertical")
+            sequence = modulestore().get_item(sequence.location)
+            self.assertEqual(_has_assignment_blocks(sequence), False)
+
+            # Ungraded problems do not count as assignment blocks
+            ItemFactory.create(
+                parent=vertical,
+                category='problem',
+                graded=True,
+                weight=0,
+            )
+            sequence = modulestore().get_item(sequence.location)
+            self.assertEqual(_has_assignment_blocks(sequence), False)
+            ItemFactory.create(
+                parent=vertical,
+                category='problem',
+                graded=False,
+                weight=1,
+            )
+            sequence = modulestore().get_item(sequence.location)
+            self.assertEqual(_has_assignment_blocks(sequence), False)
+
+            # Method will return true after adding a graded, scored assignment block
+            ItemFactory.create(
+                parent=vertical,
+                category='problem',
+                graded=True,
+                weight=1,
+            )
+            sequence = modulestore().get_item(sequence.location)
+            self.assertEqual(_has_assignment_blocks(sequence), True)
+
+    def test_sequence_with_graded_and_ungraded_assignments(self):
+        """
+        _gather_graded_items should set a due date of None on ungraded problem blocks
+        even if the block has graded siblings in the sequence
+        """
+        with modulestore().bulk_operations(self.course.id):
+            sequence = ItemFactory(parent=self.course, category="sequential")
+            vertical = ItemFactory(parent=sequence, category="vertical")
+            sequence = modulestore().get_item(sequence.location)
+            ItemFactory.create(
+                parent=vertical,
+                category='problem',
+                graded=False,
+                weight=1,
+            )
+            ungraded_problem_2 = ItemFactory.create(
+                parent=vertical,
+                category='problem',
+                graded=True,
+                weight=0,
+            )
+            graded_problem_1 = ItemFactory.create(
+                parent=vertical,
+                category='problem',
+                graded=True,
+                weight=1,
+            )
+            expected_graded_items = [
+                (ungraded_problem_2.location, {'due': None}),
+                (graded_problem_1.location, {'due': 5}),
+            ]
+            sequence = modulestore().get_item(sequence.location)
+            self.assertCountEqual(_gather_graded_items(sequence, 5), expected_graded_items)

--- a/openedx/core/lib/graph_traversals.py
+++ b/openedx/core/lib/graph_traversals.py
@@ -333,3 +333,23 @@ def _traverse_generic(
             # Keep track of whether or not the node was yielded so we
             # know whether or not to yield its children.
             yield_results[current_node] = should_yield_node
+
+
+def leaf_filter(block):
+    """
+    Filter for traversals to find leaf blocks
+    """
+    return (
+        block.location.block_type not in ('chapter', 'sequential', 'vertical') and
+        len(block.get_children()) == 0
+    )
+
+
+def get_children(parent):
+    """
+    Function for traversals to get the children of a block
+    """
+    if parent.has_children:
+        return parent.get_children()
+    else:
+        return []


### PR DESCRIPTION
Previously we were only checking the graded attribute which doesn't fully account for ungraded assignments
https://openedx.atlassian.net/browse/AA-497

We do not want to show due dates on ungraded subsections.
On master:
<img width="944" alt="Screen Shot 2021-01-19 at 12 01 19 PM" src="https://user-images.githubusercontent.com/5958221/105068935-6ba7b000-5a4f-11eb-8640-74ed6fb4e582.png">
On the branch:
<img width="945" alt="Screen Shot 2021-01-19 at 12 07 05 PM" src="https://user-images.githubusercontent.com/5958221/105068932-6ba7b000-5a4f-11eb-95b0-2cd7e380c2ff.png">

Slack context:
https://edx-internal.slack.com/archives/G019J2RMNEA/p1610399175040400
Cale suggested during standup to make this change in studio rather than edx-when where I was making the change initially