### PR TITLE
Add edx_sga to our code_owners mappings.

### DIFF
--- a/lms/djangoapps/monitoring/scripts/generate_code_owner_mappings.py
+++ b/lms/djangoapps/monitoring/scripts/generate_code_owner_mappings.py
@@ -49,6 +49,7 @@ THIRD_PARTY_APPS = {
     'simple_history': 'https://github.com/treyhunner/django-simple-history',
     'social_django': 'https://github.com/python-social-auth/social-app-django',
     'corsheaders': 'https://github.com/adamchainz/django-cors-headers',
+    'edx_sga': 'https://github.com/mitodl/edx-sga',
 }
 
 


### PR DESCRIPTION
Is this the correct way to resolve this? I don't see other XBlocks listed, but I guess other XBlocks aren't using celery.