### PR TITLE
[BB-3335] Fix flexbox not wrapping on mobile devices in preview menu

### DIFF
--- a/lms/templates/preview_menu.html
+++ b/lms/templates/preview_menu.html
@@ -52,7 +52,7 @@ show_preview_menu = course and can_masquerade and supports_preview_menu
             )
     %>
     <nav class="wrapper-preview-menu" aria-label="${_('Course View')}">
-        <div class="preview-menu" style="display: flex; align-items: center;">
+        <div class="preview-menu" style="display: flex; align-items: center; flex-wrap: wrap; justify-content: space-around;">
             <ol class="preview-actions" style="flex-grow: 1;">
                 <li class="action-preview">
                     <form action="#" class="action-preview-form" method="post">


### PR DESCRIPTION
We noticed that on Mobile Devices the "View in Studio" and "View in New Experience" buttons are smushed (See screenshot). This adds flexbox wrapping to fix the issue.

**JIRA tickets**: OSPR-5379

**Screenshots**: 
Before:
![Screenshot from 2021-01-20 17-10-38](https://user-images.githubusercontent.com/4214851/105759931-126fdd00-5f77-11eb-8f97-c98a7a00d111.png)

After:
![Screenshot from 2021-01-20 17-10-59](https://user-images.githubusercontent.com/4214851/105759944-1996eb00-5f77-11eb-9693-494e74b35b0a.png)

</details>

**Merge deadline**: None

**Testing instructions**:

1. Checkout this PR
2. Login to the LMS with a staff account
3. Check the preview menu functionality and verify the buttons wrap properly on various resolutions

**Reviewers**
- [ ] @lgp171188 