### PR TITLE
Added self paced in course serializer

### DIFF
--- a/openedx/core/djangoapps/enrollments/serializers.py
+++ b/openedx/core/djangoapps/enrollments/serializers.py
@@ -44,6 +44,7 @@ class CourseSerializer(serializers.Serializer):  # pylint: disable=abstract-meth
     course_end = serializers.DateTimeField(source="end", format=None)
     invite_only = serializers.BooleanField(source="invitation_only")
     course_modes = serializers.SerializerMethodField()
+    self_paced = serializers.BooleanField()
 
     class Meta(object):
         # For disambiguating within the drf-yasg swagger schema


### PR DESCRIPTION
Added self paced in course serializer
Mobile side communicates with a limited set of apis and none of them returns whether course is self paced or not.
We found enrollment api as the most relevant place where we can embed course pace in course details attribute.

LEARNER-8097