### PR TITLE
changed instructor dashboard waffle type form course to legacy

### DIFF
--- a/lms/djangoapps/instructor/toggles.py
+++ b/lms/djangoapps/instructor/toggles.py
@@ -44,11 +44,11 @@ OPTIMISED_IS_SMALL_COURSE = LegacyWaffleFlag(
 )
 
 
-def data_download_v2_is_enabled(course_key):
+def data_download_v2_is_enabled():
     """
     check if data download v2 is enabled.
     """
-    return DATA_DOWNLOAD_V2.is_enabled(course_key)
+    return DATA_DOWNLOAD_V2.is_enabled()
 
 
 def use_optimised_is_small_course():

--- a/lms/djangoapps/instructor/toggles.py
+++ b/lms/djangoapps/instructor/toggles.py
@@ -19,8 +19,8 @@ WAFFLE_FLAG_NAMESPACE = LegacyWaffleFlagNamespace(name=WAFFLE_NAMESPACE)
 # .. toggle_target_removal_date: None
 # .. toggle_warnings: ??
 # .. toggle_tickets: PROD-1309
-DATA_DOWNLOAD_V2 = CourseWaffleFlag(
-    waffle_namespace=LegacyWaffleFlagNamespace(name=WAFFLE_NAMESPACE, log_prefix='instructor_dashboard: '),
+DATA_DOWNLOAD_V2 = LegacyWaffleFlag(
+    waffle_namespace=WAFFLE_FLAG_NAMESPACE,
     flag_name='enable_data_download_v2',
     module_name=__name__,
 )

--- a/lms/djangoapps/instructor/views/instructor_dashboard.py
+++ b/lms/djangoapps/instructor/views/instructor_dashboard.py
@@ -601,7 +601,7 @@ def _section_data_download(course, access):
         settings.FEATURES.get('ENABLE_SPECIAL_EXAMS', False) and
         course.enable_proctored_exams
     )
-    section_key = 'data_download_2' if data_download_v2_is_enabled(course_key) else 'data_download'
+    section_key = 'data_download_2' if data_download_v2_is_enabled() else 'data_download'
     section_data = {
         'section_key': section_key,
         'section_display_name': _('Data Download'),


### PR DESCRIPTION
This feature was implemented and tested on few courses a few days back, now instead of deprecating waffle changing it from course to legacy so incase of bugs feature can be rolled back easily. 