### PR TITLE
[MNG-1904] Fix: update new runtime's runtime.anonymous_student_id to store in DB

### DIFF
--- a/common/djangoapps/student/migrations/0039_anon_id_context.py
+++ b/common/djangoapps/student/migrations/0039_anon_id_context.py
@@ -1,0 +1,30 @@
+# Convert the student.models.AnonymousUserId.course_id field from CourseKey to
+# the more generic LearningContextKey.
+#
+# This migration does not produce any changes at the database level.
+
+from django.db import migrations
+import opaque_keys.edx.django.models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('student', '0038_auto_20201021_1256'),
+    ]
+
+    operations = [
+        migrations.SeparateDatabaseAndState(
+            # Do not actually make any changes to the database; the fields are identical string fields with the same
+            # database properties.
+            database_operations=[],
+            # But update the migrator's view of the field to reflect the new field type.
+            state_operations=[
+                migrations.AlterField(
+                    model_name='anonymoususerid',
+                    name='course_id',
+                    field=opaque_keys.edx.django.models.LearningContextKeyField(blank=True, db_index=True, max_length=255),
+                ),
+            ],
+        ),
+    ]

--- a/common/djangoapps/student/models.py
+++ b/common/djangoapps/student/models.py
@@ -46,7 +46,7 @@ from edx_django_utils.cache import RequestCache
 from edx_rest_api_client.exceptions import SlumberBaseException
 from eventtracking import tracker
 from model_utils.models import TimeStampedModel
-from opaque_keys.edx.django.models import CourseKeyField
+from opaque_keys.edx.django.models import CourseKeyField, LearningContextKeyField
 from opaque_keys.edx.keys import CourseKey
 from pytz import UTC
 from simple_history.models import HistoricalRecords
@@ -143,7 +143,7 @@ class AnonymousUserId(models.Model):
 
     user = models.ForeignKey(User, db_index=True, on_delete=models.CASCADE)
     anonymous_user_id = models.CharField(unique=True, max_length=32)
-    course_id = CourseKeyField(db_index=True, max_length=255, blank=True)
+    course_id = LearningContextKeyField(db_index=True, max_length=255, blank=True)
 
 
 def anonymous_id_for_user(user, course_id, save=True):

--- a/openedx/core/djangoapps/xblock/runtime/shims.py
+++ b/openedx/core/djangoapps/xblock/runtime/shims.py
@@ -3,7 +3,6 @@ Code to implement backwards compatibility
 """
 # pylint: disable=no-member
 
-import hashlib
 import warnings
 
 from django.conf import settings
@@ -12,9 +11,9 @@ from django.template import TemplateDoesNotExist
 from django.utils.functional import cached_property
 from fs.memoryfs import MemoryFS
 from openedx.core.djangoapps.xblock.apps import get_xblock_app_config
-import six
 
 from common.djangoapps.edxmako.shortcuts import render_to_string
+from common.djangoapps.student.models import anonymous_id_for_user
 
 
 class RuntimeShim(object):
@@ -71,19 +70,8 @@ class RuntimeShim(object):
             # really care since this user's XBlock data is ephemeral and is only
             # kept around for a day or two anyways.
             return self.user_id
-        #### TEMPORARY IMPLEMENTATION:
-        # TODO: Update student.models.AnonymousUserId to have a 'context_key'
-        # column instead of 'course_key' (no DB migration needed). Then change
-        # this to point to the existing student.models.anonymous_id_for_user
-        # code. (Or do we want a separate new table for the new runtime?)
-        # The reason we can't do this now is that ContextKey doesn't yet exist
-        # in the opaque-keys repo, so there is no working 'ContextKeyField'
-        # class in opaque-keys that accepts either old CourseKeys or new
-        # LearningContextKeys.
-        hasher = hashlib.md5()
-        hasher.update(settings.SECRET_KEY.encode('utf-8'))
-        hasher.update(six.text_type(self.user_id).encode('utf-8'))
-        digest = hasher.hexdigest()
+        context_key = self._active_block.scope_ids.usage_id.context_key
+        digest = anonymous_id_for_user(self.user, course_id=context_key)
         return digest
 
     @property


### PR DESCRIPTION
This addresses a longstanding TODO item to make [`runtime.anonymous_student_id` for content libraries v2](https://github.com/edx/edx-platform/blob/812cd504deb8458c835ac122029efc2d5364ef4e/openedx/core/djangoapps/xblock/runtime/shims.py#L61-L87) work [the same way](https://github.com/edx/edx-platform/blob/812cd504deb8458c835ac122029efc2d5364ef4e/common/djangoapps/student/models.py#L149-L196) as it does for XBlocks in regular courses, persisting the anonymous ID string to the database. This way, if `SECRET_KEY` is changed, existing anonymous IDs will continue to work unchanged.

This is a potentially breaking change for XBlocks in these blockstore-based libraries (v2 libraries), because the actual `anonymous_student_id` values generated are now different (old ones were based on only user ID and secret key but didn't also incorporate the "context key" into the hash as the new IDs do). But based on my searching for `anonymous_student_id` in the codebase, this should only affect capa problems using external code graders or Matlab code input, and I'm not aware of any such usage of the new runtime / libraries v2.


## Risks

There is a low risk that this change to `anonymous_student_id` causes issues for some LabXchange XBlocks (LabXchange being essentially the only user of the new runtime so far). Based on my code searching and manual testing, I don't believe `anonymous_student_id` is actually used meaningfully (they don't use external graders nor matlab input), so I don't expect any problems. However, if we wanted to be more conservative we could use a transition period where the existing IDs are stored into the table, before we change to the newer ID format

## Database migration

It has one, but it doesn't make any changes (no SQL); it's just a change to the django model.

## Testing

How I tested this change:

1. Used [Ramshackle](https://github.com/open-craft/ramshackle) to create a v2 content library with a multiple choice capa problem. Published it, then using the "Learn" tab, submitted an answer.
2. Then I made these changes, and refreshed the page. I verified using debug logging that the `anonymous_student_id` for that problem+user did change, but the previously submitted answer was still selected.
3. I ran the integration tests for libraries v2 as described at https://github.com/edx/blockstore/#running-integration-tests - they mostly passed and there were no issues related to this PR; however, a few failed in the CMS test suite because https://github.com/edx/edx-search/pull/104 seems to have introduced a breaking change to edx-search and nobody has yet updated the libraries code accordingly. I've asked my team to look into that.