### PR TITLE
Update Facebook color.

### DIFF
--- a/lms/static/sass/partials/lms/theme/_variables-v1.scss
+++ b/lms/static/sass/partials/lms/theme/_variables-v1.scss
@@ -186,7 +186,7 @@ $ui-notification-height: ($baseline*10);
 
 // social platforms
 $twitter-blue: #55acee;
-$facebook-blue: #4267b2;
+$facebook-blue: #1877F2;
 $facebook-focus-blue: #29487d;
 $linkedin-blue: #0077b5;
 $google-blue: #4285f4;


### PR DESCRIPTION
Updated Facebook SSO button color according to their brand guidelines.

VAN-296

<img width="648" alt="Screenshot 2021-01-22 at 5 27 42 PM" src="https://user-images.githubusercontent.com/2851134/105491292-e5ea6580-5cd7-11eb-86f2-4212f99ae04d.png">
