### PR TITLE
Fix support link empty bug

### DIFF
--- a/openedx/core/djangoapps/user_authn/views/login.py
+++ b/openedx/core/djangoapps/user_authn/views/login.py
@@ -180,7 +180,7 @@ def _log_and_raise_inactive_user_auth_error(unauthenticated_user):
         error_code='inactive-user',
         context={
             'platformName': configuration_helpers.get_value('PLATFORM_NAME', settings.PLATFORM_NAME),
-            'supportLink': configuration_helpers.get_value('SUPPORT_SITE_LINK', settings.SUPPORT_SITE_LINK)
+            'supportLink': configuration_helpers.get_value('SUPPORT_SITE_LINK', settings.SUPPORT_SITE_LINK) or ''
         }
     )
 


### PR DESCRIPTION
If support link is not sent, configuration helper returns empty dictionary instead of string. This causes issue on frontend when it tries to set href using this link.