### PR TITLE
[AA-613] Add contains_content_type_gated_content attribute to display items in the Sequence Metadata API.

### DIFF
--- a/common/lib/xmodule/xmodule/tests/test_sequence.py
+++ b/common/lib/xmodule/xmodule/tests/test_sequence.py
@@ -6,10 +6,11 @@ Tests for sequence module.
 
 import ast
 import json
-from datetime import timedelta
+from datetime import datetime, timedelta
 
 import ddt
 import six
+from django.test.utils import override_settings
 from django.utils.timezone import now
 from freezegun import freeze_time
 from mock import Mock, patch
@@ -18,6 +19,7 @@ from web_fragments.fragment import Fragment
 
 from edx_toggles.toggles.testutils import override_waffle_flag
 from common.djangoapps.student.tests.factories import UserFactory
+from openedx.features.content_type_gating.models import ContentTypeGatingConfig
 from xmodule.seq_module import TIMED_EXAM_GATING_WAFFLE_FLAG, SequenceModule
 from xmodule.tests import get_test_system
 from xmodule.tests.helpers import StubUserService
@@ -142,12 +144,13 @@ class SequenceBlockTestCase(XModuleXmlImportTest):
         seq_module = SequenceModule(runtime=Mock(position=2), descriptor=Mock(), scope_ids=Mock())
         self.assertEqual(seq_module.position, 2)  # matches position set in the runtime
 
+    @patch('xmodule.seq_module.SequenceModule._get_user', return_value=UserFactory.build())
     @ddt.unpack
     @ddt.data(
         {'view': STUDENT_VIEW},
         {'view': PUBLIC_VIEW},
     )
-    def test_render_student_view(self, view):
+    def test_render_student_view(self, mocked_user, view):  # pylint: disable=unused-argument
         html = self._get_rendered_view(
             self.sequence_3_1,
             extra_context=dict(next_url='NextSequential', prev_url='PrevSequential'),
@@ -160,8 +163,10 @@ class SequenceBlockTestCase(XModuleXmlImportTest):
         self.assertIn("'prev_url': 'PrevSequential'", html)
         self.assertNotIn("fa fa-check-circle check-circle is-hidden", html)
 
+    # pylint: disable=line-too-long
     @patch('xmodule.seq_module.SequenceModule._get_user', return_value=UserFactory.build())
-    def test_timed_exam_gating_waffle_flag(self, mocked_user):
+    @patch('xmodule.seq_module.SequenceModule.gate_entire_sequence_if_it_is_a_timed_exam_and_contains_content_type_gated_problems')
+    def test_timed_exam_gating_waffle_flag(self, mocked_function, mocked_user):  # pylint: disable=unused-argument
         """
         Verify the code inside the waffle flag is not executed with the flag off
         Verify the code inside the waffle flag is executed with the flag on
@@ -174,7 +179,7 @@ class SequenceBlockTestCase(XModuleXmlImportTest):
                 extra_context=dict(next_url='NextSequential', prev_url='PrevSequential'),
                 view=STUDENT_VIEW
             )
-            mocked_user.assert_not_called()
+            mocked_function.assert_not_called()
 
         with override_waffle_flag(TIMED_EXAM_GATING_WAFFLE_FLAG, active=True):
             self._get_rendered_view(
@@ -182,7 +187,7 @@ class SequenceBlockTestCase(XModuleXmlImportTest):
                 extra_context=dict(next_url='NextSequential', prev_url='PrevSequential'),
                 view=STUDENT_VIEW
             )
-            mocked_user.assert_called_once()
+            mocked_function.assert_called_once()
 
     @override_waffle_flag(TIMED_EXAM_GATING_WAFFLE_FLAG, active=True)
     @patch('xmodule.seq_module.SequenceModule._get_user', return_value=UserFactory.build())
@@ -243,27 +248,30 @@ class SequenceBlockTestCase(XModuleXmlImportTest):
         self.assertIn('NextSequential', view)
         self.assertIn('PrevSequential', view)
 
+    @patch('xmodule.seq_module.SequenceModule._get_user', return_value=UserFactory.build())
     @ddt.unpack
     @ddt.data(
         {'view': STUDENT_VIEW},
         {'view': PUBLIC_VIEW},
     )
-    def test_student_view_first_child(self, view):
+    def test_student_view_first_child(self, mocked_user, view):  # pylint: disable=unused-argument
         html = self._get_rendered_view(
             self.sequence_3_1, requested_child='first', view=view
         )
         self._assert_view_at_position(html, expected_position=1)
 
+    @patch('xmodule.seq_module.SequenceModule._get_user', return_value=UserFactory.build())
     @ddt.unpack
     @ddt.data(
         {'view': STUDENT_VIEW},
         {'view': PUBLIC_VIEW},
     )
-    def test_student_view_last_child(self, view):
+    def test_student_view_last_child(self, mocked_user, view):  # pylint: disable=unused-argument
         html = self._get_rendered_view(self.sequence_3_1, requested_child='last', view=view)
         self._assert_view_at_position(html, expected_position=3)
 
-    def test_tooltip(self):
+    @patch('xmodule.seq_module.SequenceModule._get_user', return_value=UserFactory.build())
+    def test_tooltip(self, mocked_user):  # pylint: disable=unused-argument
         html = self._get_rendered_view(self.sequence_3_1, requested_child=None)
         for child in self.sequence_3_1.children:
             self.assertIn("'page_title': '{}'".format(child.block_id), html)
@@ -437,7 +445,8 @@ class SequenceBlockTestCase(XModuleXmlImportTest):
         )
         self.assertIs(completion_return, None)
 
-    def test_handle_ajax_metadata(self):
+    @patch('xmodule.seq_module.SequenceModule._get_user', return_value=UserFactory.build())
+    def test_handle_ajax_metadata(self, mocked_user):  # pylint: disable=unused-argument
         """
         Test that the sequence metadata is returned from the
         metadata ajax handler.
@@ -449,6 +458,29 @@ class SequenceBlockTestCase(XModuleXmlImportTest):
         self.assertEqual(len(metadata['items']), 3)
         self.assertEqual(metadata['tag'], 'sequential')
         self.assertEqual(metadata['display_name'], self.sequence_3_1.display_name_with_default)
+
+    @patch('xmodule.seq_module.SequenceModule._get_user', return_value=UserFactory.build())
+    @override_settings(FIELD_OVERRIDE_PROVIDERS=(
+        'openedx.features.content_type_gating.field_override.ContentTypeGatingFieldOverride',
+    ))
+    def test_handle_ajax_metadata_content_type_gated_content(self, mocked_user):  # pylint: disable=unused-argument
+        """
+        The contains_content_type_gated_content field should reflect
+        whether the given item contains content type gated content
+        """
+        self.sequence_5_1.xmodule_runtime._services['bookmarks'] = None  # pylint: disable=protected-access
+        ContentTypeGatingConfig.objects.create(enabled=True, enabled_as_of=datetime(2018, 1, 1))
+        metadata = json.loads(self.sequence_5_1.handle_ajax('metadata', {}))
+        self.assertEqual(metadata['items'][0]['contains_content_type_gated_content'], False)
+
+        # When a block contains content type gated problems, set the contains_content_type_gated_content field
+        self.sequence_5_1.get_children()[0].get_children()[0].graded = True
+        self.sequence_5_1.runtime._services['content_type_gating'] = Mock(return_value=Mock(  # pylint: disable=protected-access
+            enabled_for_enrollment=Mock(return_value=True),
+            content_type_gate_for_block=Mock(return_value=Fragment('i_am_gated'))
+        ))
+        metadata = json.loads(self.sequence_5_1.handle_ajax('metadata', {}))
+        self.assertEqual(metadata['items'][0]['contains_content_type_gated_content'], True)
 
     def get_context_dict_from_string(self, data):
         """

--- a/lms/djangoapps/courseware/tests/test_views.py
+++ b/lms/djangoapps/courseware/tests/test_views.py
@@ -269,8 +269,8 @@ class IndexQueryTestCase(ModuleStoreTestCase):
     NUM_PROBLEMS = 20
 
     @ddt.data(
-        (ModuleStoreEnum.Type.mongo, 10, 171),
-        (ModuleStoreEnum.Type.split, 4, 167),
+        (ModuleStoreEnum.Type.mongo, 10, 174),
+        (ModuleStoreEnum.Type.split, 4, 170),
     )
     @ddt.unpack
     def test_index_query_counts(self, store_type, expected_mongo_query_count, expected_mysql_query_count):

--- a/lms/templates/seq_module.html
+++ b/lms/templates/seq_module.html
@@ -21,7 +21,7 @@
     </div>
   % endif
   % endif
-  % if not gated_sequence_fragment:
+  % if not gated_sequence_paywall:
   <div class="sequence-nav">
     <button class="sequence-nav-button button-previous">
       <span class="icon fa fa-chevron-prev" aria-hidden="true"></span>
@@ -103,11 +103,11 @@
   % if not exclude_units:
   % if gated_content['gated']:
     <%include file="_gated_content.html" args="prereq_url=gated_content['prereq_url'], prereq_section_name=gated_content['prereq_section_name'], gated_section_name=gated_content['gated_section_name']"/>
-  % elif gated_sequence_fragment:
+  % elif gated_sequence_paywall:
     <h2 class="hd hd-2 unit-title">
         ${sequence_name}<span class="sr">${_("Content Locked")}</span>
     </h2>
-    ${gated_sequence_fragment | n, decode.utf8}
+    ${gated_sequence_paywall | n, decode.utf8}
   % else:
   <div class="sr-is-focusable" tabindex="-1"></div>
 

--- a/openedx/core/djangoapps/courseware_api/views.py
+++ b/openedx/core/djangoapps/courseware_api/views.py
@@ -483,7 +483,8 @@ class SequenceMetadata(DeveloperErrorViewMixin, APIView):
             self.request,
             str(usage_key.course_key),
             str(usage_key),
-            disable_staff_debug_info=True)
+            disable_staff_debug_info=True,
+            will_recheck_access=True)
 
         view = STUDENT_VIEW
         if request.user.is_anonymous:


### PR DESCRIPTION
Relevant bug: https://openedx.atlassian.net/browse/AA-613 
(We were displaying the content gate for ungraded content and potentially other cases where content would not actually be content type gated)

The contains_content_type_gated_content is used to display the content type gating paywall in frontend-app-learning.
Also, refactors existing timed exam code that checks for content_type_gated_content in a sequence to make it try with the new code
Relevant frontend-app-learning PR that uses this field https://github.com/edx/frontend-app-learning/pull/349

For a call like the following, 
http://localhost:18000/api/courseware/sequence/block-v1:edX+DemoX+Demo_Course+type@sequential+block@basic_questions
set the contains_content_type_gated_content field on each item
<img width="650" alt="Screen Shot 2021-01-26 at 10 52 16 AM" src="https://user-images.githubusercontent.com/5958221/105871315-2d6a3d80-5fc7-11eb-869b-67f6c9a59cf3.png">
