### PR TITLE
[BD-21] Enable annotation linting with edx-lint

### DIFF
--- a/lms/djangoapps/bulk_email/models.py
+++ b/lms/djangoapps/bulk_email/models.py
@@ -481,7 +481,7 @@ class BulkEmailFlag(ConfigurationModel):
 
     .. toggle_name: require_course_email_auth
     .. toggle_implementation: ConfigurationModel
-    .. toggle_default: True (enabled)
+    .. toggle_default: True
     .. toggle_description: If the flag is enabled, course-specific authorization is
       required, and the course_id is either not provided or not authorized, the feature
       is not available.

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -37,7 +37,7 @@ cffi==1.14.4              # via -r requirements/edx/../edx-sandbox/shared.txt, c
 chardet==4.0.0            # via -r requirements/edx/paver.txt, pysrt, requests
 chem==1.2.0               # via -r requirements/edx/base.in
 click==7.1.2              # via -r requirements/edx/../edx-sandbox/shared.txt, code-annotations, nltk, user-util
-code-annotations==1.0.0   # via edx-enterprise, edx-toggles
+code-annotations==1.0.2   # via edx-enterprise, edx-toggles
 contextlib2==0.6.0.post1  # via -r requirements/edx/base.in
 coreapi==2.3.3            # via drf-yasg
 coreschema==0.0.4         # via coreapi, drf-yasg

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -42,7 +42,7 @@ chardet==4.0.0            # via -r requirements/edx/testing.txt, diff-cover, pys
 chem==1.2.0               # via -r requirements/edx/testing.txt
 click-log==0.3.2          # via -r requirements/edx/testing.txt, edx-lint
 click==7.1.2              # via -r requirements/edx/development.in, -r requirements/edx/pip-tools.txt, -r requirements/edx/testing.txt, click-log, code-annotations, edx-lint, nltk, pip-tools, user-util
-code-annotations==1.0.0   # via -r requirements/edx/testing.txt, edx-enterprise, edx-toggles
+code-annotations==1.0.2   # via -r requirements/edx/testing.txt, edx-enterprise, edx-lint, edx-toggles
 contextlib2==0.6.0.post1  # via -r requirements/edx/testing.txt
 coreapi==2.3.3            # via -r requirements/edx/testing.txt, drf-yasg
 coreschema==0.0.4         # via -r requirements/edx/testing.txt, coreapi, drf-yasg
@@ -91,7 +91,7 @@ django-storages==1.8      # via -c requirements/edx/../constraints.txt, -r requi
 django-user-tasks==1.3.2  # via -r requirements/edx/testing.txt
 django-waffle==2.0.0      # via -r requirements/edx/testing.txt, edx-django-utils, edx-drf-extensions, edx-enterprise, edx-proctoring, edx-toggles
 django-webpack-loader==0.7.0  # via -r requirements/edx/testing.txt, edx-proctoring
-django==2.2.17            # via -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt, -r requirements/edx/testing.txt, code-annotations, django-appconf, django-classy-tags, django-config-models, django-cors-headers, django-crum, django-debug-toolbar, django-fernet-fields, django-filter, django-method-override, django-model-utils, django-mptt, django-multi-email-field, django-mysql, django-oauth-toolkit, django-pyfs, django-ratelimit-backend, django-sekizai, django-ses, django-splash, django-statici18n, django-storages, django-user-tasks, django-wiki, djangorestframework, drf-jwt, drf-yasg, edx-ace, edx-api-doc-tools, edx-bulk-grades, edx-celeryutils, edx-completion, edx-django-release-util, edx-django-sites-extensions, edx-django-utils, edx-drf-extensions, edx-enterprise, edx-event-routing-backends, edx-i18n-tools, edx-milestones, edx-opaque-keys, edx-organizations, edx-proctoring, edx-rbac, edx-search, edx-submissions, edx-toggles, edx-when, edxval, enmerkar, enmerkar-underscore, event-tracking, help-tokens, jsonfield2, lti-consumer-xblock, ora2, rest-condition, super-csv, xss-utils
+django==2.2.17            # via -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt, -r requirements/edx/testing.txt, code-annotations, django-appconf, django-classy-tags, django-config-models, django-cors-headers, django-crum, django-debug-toolbar, django-fernet-fields, django-filter, django-method-override, django-model-utils, django-mptt, django-multi-email-field, django-mysql, django-oauth-toolkit, django-pyfs, django-ratelimit-backend, django-sekizai, django-ses, django-splash, django-statici18n, django-storages, django-user-tasks, django-wiki, djangorestframework, drf-jwt, drf-yasg, edx-ace, edx-api-doc-tools, edx-bulk-grades, edx-celeryutils, edx-completion, edx-django-release-util, edx-django-sites-extensions, edx-django-utils, edx-drf-extensions, edx-enterprise, edx-event-routing-backends, edx-i18n-tools, edx-lint, edx-milestones, edx-opaque-keys, edx-organizations, edx-proctoring, edx-rbac, edx-search, edx-submissions, edx-toggles, edx-when, edxval, enmerkar, enmerkar-underscore, event-tracking, help-tokens, jsonfield2, lti-consumer-xblock, ora2, rest-condition, super-csv, xss-utils
 djangorestframework-xml==2.0.0  # via -r requirements/edx/testing.txt, edx-enterprise
 djangorestframework==3.12.2  # via -r requirements/edx/testing.txt, django-config-models, django-user-tasks, drf-jwt, drf-yasg, edx-api-doc-tools, edx-completion, edx-drf-extensions, edx-enterprise, edx-organizations, edx-proctoring, edx-submissions, ora2, rest-condition, super-csv
 docopt==0.6.2             # via -r requirements/edx/testing.txt, xmodule
@@ -112,7 +112,7 @@ edx-drf-extensions==6.4.0  # via -r requirements/edx/testing.txt, edx-completion
 edx-enterprise==3.17.10   # via -c requirements/edx/../constraints.txt, -r requirements/edx/testing.txt
 edx-event-routing-backends==4.0.1  # via -r requirements/edx/testing.txt
 edx-i18n-tools==0.5.3     # via -r requirements/edx/testing.txt, ora2
-edx-lint==1.6             # via -r requirements/edx/testing.txt
+edx-lint==3.0             # via -r requirements/edx/testing.txt
 edx-milestones==0.3.0     # via -r requirements/edx/testing.txt
 edx-opaque-keys[django]==2.1.1  # via -r requirements/edx/testing.txt, edx-bulk-grades, edx-ccx-keys, edx-completion, edx-drf-extensions, edx-enterprise, edx-milestones, edx-organizations, edx-proctoring, edx-user-state-client, edx-when, lti-consumer-xblock, xmodule
 edx-organizations==6.7.1  # via -r requirements/edx/testing.txt

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -41,7 +41,7 @@ chardet==4.0.0            # via -r requirements/edx/base.txt, -r requirements/ed
 chem==1.2.0               # via -r requirements/edx/base.txt
 click-log==0.3.2          # via edx-lint
 click==7.1.2              # via -r requirements/edx/base.txt, click-log, code-annotations, edx-lint, nltk, user-util
-code-annotations==1.0.0   # via -r requirements/edx/base.txt, -r requirements/edx/testing.in, edx-enterprise, edx-toggles
+code-annotations==1.0.2   # via -r requirements/edx/base.txt, -r requirements/edx/testing.in, edx-enterprise, edx-lint, edx-toggles
 contextlib2==0.6.0.post1  # via -r requirements/edx/base.txt
 coreapi==2.3.3            # via -r requirements/edx/base.txt, drf-yasg
 coreschema==0.0.4         # via -r requirements/edx/base.txt, coreapi, drf-yasg
@@ -109,7 +109,7 @@ edx-drf-extensions==6.4.0  # via -r requirements/edx/base.txt, edx-completion, e
 edx-enterprise==3.17.10   # via -c requirements/edx/../constraints.txt, -r requirements/edx/base.txt
 edx-event-routing-backends==4.0.1  # via -r requirements/edx/base.txt
 edx-i18n-tools==0.5.3     # via -r requirements/edx/base.txt, -r requirements/edx/testing.in, ora2
-edx-lint==1.6             # via -r requirements/edx/testing.in
+edx-lint==3.0             # via -r requirements/edx/testing.in
 edx-milestones==0.3.0     # via -r requirements/edx/base.txt
 edx-opaque-keys[django]==2.1.1  # via -r requirements/edx/base.txt, edx-bulk-grades, edx-ccx-keys, edx-completion, edx-drf-extensions, edx-enterprise, edx-milestones, edx-organizations, edx-proctoring, edx-user-state-client, edx-when, lti-consumer-xblock, xmodule
 edx-organizations==6.7.1  # via -r requirements/edx/base.txt


### PR DESCRIPTION
We upgrade edx-lint to use the latest feature toggle and annotation custom
linter. Note that we do not yet make use of code annotation linting, typically
run with `code_annotations --lint ...`.

Note that we also fix new linting errors detected by the new checkers.

cc @robrap 

This should be ready to review (provided CI is green)