### PR TITLE
[TSD] adds settings annotations for XBLOCK_FIELD_DATA_WRAPPERS

### DIFF
--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -1200,7 +1200,9 @@ XBLOCK_MIXINS = (LmsBlockMixin, InheritanceMixin, XModuleMixin, EditInfoMixin)
 # Allow any XBlock in the LMS
 XBLOCK_SELECT_FUNCTION = prefer_xmodules
 
-# Paths to wrapper methods which should be applied to every XBlock's FieldData.
+# .. setting_name: XBLOCK_FIELD_DATA_WRAPPERS
+# .. setting_default: ()
+# .. setting_description: Paths to wrapper methods which should be applied to every XBlock's FieldData.
 XBLOCK_FIELD_DATA_WRAPPERS = ()
 
 XBLOCK_FS_STORAGE_BUCKET = None


### PR DESCRIPTION
Settings Variable: `XBLOCK_FIELD_DATA_WRAPPERS`

Very straightforward, the settings variable already contained a description. Here is where this variable is being used, so please double check, settings description makes sense:

- https://github.com/edx/edx-platform/blob/master/common/lib/xmodule/xmodule/modulestore/mongo/base.py#L325
- https://github.com/edx/edx-platform/blob/master/common/lib/xmodule/xmodule/modulestore/split_mongo/caching_descriptor_system.py#L279