### PR TITLE
[TSD] adds annotations for XBLOCK_SETTINGS

### DIFF
--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -1207,6 +1207,10 @@ XBLOCK_FIELD_DATA_WRAPPERS = ()
 
 XBLOCK_FS_STORAGE_BUCKET = None
 XBLOCK_FS_STORAGE_PREFIX = None
+
+# .. setting_name: XBLOCK_SETTINGS
+# .. setting_default: {}
+# .. setting_description: Dictionary containing server-wide configuration of XBlocks on a per-type basis
 XBLOCK_SETTINGS = {}
 
 ############# ModuleStore Configuration ##########

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -1210,7 +1210,10 @@ XBLOCK_FS_STORAGE_PREFIX = None
 
 # .. setting_name: XBLOCK_SETTINGS
 # .. setting_default: {}
-# .. setting_description: Dictionary containing server-wide configuration of XBlocks on a per-type basis
+# .. setting_description: Dictionary containing server-wide configuration of XBlocks on a per-type basis.
+#     By default, keys should match the XBlock `block_settings_key` attribute/property. If the attribute/property
+#     is not defined, use the XBlock class name. Check `common.lib.xmodule.xmodule.services.SettingsService`
+#     for more reference.
 XBLOCK_SETTINGS = {}
 
 ############# ModuleStore Configuration ##########


### PR DESCRIPTION
Settings Variable: `XBLOCK_SETTINGS`

Variable usage inside [SettingsService](https://github.com/edx/edx-platform/blob/master/common/lib/xmodule/xmodule/services.py#L13)