### PR TITLE
[TSD] adds annotations for XBLOCK_RUNTIME_V2_EPHEMERAL_DATA_CACHE

### DIFF
--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -4149,8 +4149,7 @@ BLOCKSTORE_API_URL = 'http://localhost:18250/api/v1/'
 
 # .. setting_name: XBLOCK_RUNTIME_V2_EPHEMERAL_DATA_CACHE
 # .. setting_default: default
-# .. setting_description: Which of django's caches to use for storing anonymous user state for XBlocks
-#     in the blockstore-based XBlock runtime
+# .. setting_description: The django cache key of the cache to use for storing anonymous user state for XBlocks.
 XBLOCK_RUNTIME_V2_EPHEMERAL_DATA_CACHE = 'default'
 
 # Blockstore data could contain S3 links, so this should be lower than Blockstore's AWS_QUERYSTRING_EXPIRE

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -4146,8 +4146,11 @@ MAILCHIMP_NEW_USER_LIST_ID = ""
 ########################## BLOCKSTORE #####################################
 BLOCKSTORE_PUBLIC_URL_ROOT = 'http://localhost:18250'
 BLOCKSTORE_API_URL = 'http://localhost:18250/api/v1/'
-# Which of django's caches to use for storing anonymous user state for XBlocks
-# in the blockstore-based XBlock runtime
+
+# .. setting_name: XBLOCK_RUNTIME_V2_EPHEMERAL_DATA_CACHE
+# .. setting_default: default
+# .. setting_description: Which of django's caches to use for storing anonymous user state for XBlocks
+#     in the blockstore-based XBlock runtime
 XBLOCK_RUNTIME_V2_EPHEMERAL_DATA_CACHE = 'default'
 
 # Blockstore data could contain S3 links, so this should be lower than Blockstore's AWS_QUERYSTRING_EXPIRE


### PR DESCRIPTION
settings variable: `XBLOCK_RUNTIME_V2_EPHEMERAL_DATA_CACHE`

The previous comment was pretty accurate, this must be a django cache key

usage: https://github.com/edx/edx-platform/blob/master/openedx/core/djangoapps/xblock/runtime/ephemeral_field_data.py#L47