### PR TITLE
Adding collected structure to the course grade read

### DIFF
--- a/lms/djangoapps/grades/rest_api/v1/gradebook_views.py
+++ b/lms/djangoapps/grades/rest_api/v1/gradebook_views.py
@@ -530,8 +530,11 @@ class GradebookView(GradeViewMixin, PaginatedAPIView):
 
         if request.GET.get('username'):
             with self._get_user_or_raise(request, course_key) as grade_user:
-                course_grade = CourseGradeFactory().read(grade_user, course)
-
+                course_grade = CourseGradeFactory().read(
+                    grade_user,
+                    course,
+                    collected_block_structure=course_data.collected_structure
+                )
             entry = self._gradebook_entry(grade_user, course, graded_subsections, course_grade)
             serializer = StudentGradebookEntrySerializer(entry)
             return Response(serializer.data)


### PR DESCRIPTION
When the `/api/grades/v1/gradebook/` endpoint is hit, specifically with the query parameter `username`, we are attempting to collect the subsection breakdown of a course grade which has been read without a `collected_block_structure`. When  accessing a course grade's subsection grades, we expect the `collected_block_structure` to be an available dictionary within the Course Grade object, and as such throw a `TypeError: 'NoneType' object is not subscriptable` error. 

**Solution:** include the collected block structure when reading the course grade object.