### PR TITLE
Added self paced in mobile api enrolment api

### DIFF
--- a/lms/djangoapps/mobile_api/users/serializers.py
+++ b/lms/djangoapps/mobile_api/users/serializers.py
@@ -80,6 +80,8 @@ class CourseOverviewField(serializers.RelatedField):
             # field present in case API parsers expect it, but this API is now
             # removed.
             'video_outline': None,
+
+            'is_self_paced': course_overview.self_paced
         }
 
 

--- a/openedx/core/djangoapps/enrollments/serializers.py
+++ b/openedx/core/djangoapps/enrollments/serializers.py
@@ -44,7 +44,6 @@ class CourseSerializer(serializers.Serializer):  # pylint: disable=abstract-meth
     course_end = serializers.DateTimeField(source="end", format=None)
     invite_only = serializers.BooleanField(source="invitation_only")
     course_modes = serializers.SerializerMethodField()
-    self_paced = serializers.BooleanField()
 
     class Meta(object):
         # For disambiguating within the drf-yasg swagger schema


### PR DESCRIPTION
Added self paced in mobile enrolment api

It was mistakenly added in generic enrollment api([Pull request](https://github.com/edx/edx-platform/pull/26120))
JIRA ticket: https://openedx.atlassian.net/browse/LEARNER-8097

I have moved this flag from generic api to mobile api.

LEARNER-8194