### PR TITLE
Make DeprecatedEdxPlatformImportError derive ImportError

### DIFF
--- a/import_shims/warn.py
+++ b/import_shims/warn.py
@@ -38,7 +38,7 @@ class DeprecatedEdxPlatformImportWarning(DeprecationWarning):
         ).format(self=self)
 
 
-class DeprecatedEdxPlatformImportError(Exception):
+class DeprecatedEdxPlatformImportError(ImportError):
     """
     Error: An edx-platform module is being imported from an unsupported location.
 


### PR DESCRIPTION
```
The latter was previously NOT a subclass of the
former. This was intentional, because I wanted to
make sure that code of the form:

try:
    from <deprecated_path> import X
except ImportError:
    X = None

failed *loudly* instead of silently.

Now that the import strictness has been on Stage
for a bit, and we have reasonably verified that all
such imports have been fixed, we must make
`DeprecatedEdxPlatformImportError` a subclass of
`ImportError`.

Not doing so is messing up
a signal handler in Django User Tasks that uses
`try: ... except ImportError: ...` as a way of
registering tasks, expecting to get ImportErrors
on tasks whose names are not importable. By
raising an incompatible error class, we are breaking
that signal hander.
```

Here is the [Django User Tasks conditional import block](https://github.com/edx/django-user-tasks/blob/0f9bcb6b94f2ac2124c615983c4af49fee853374/user_tasks/signals.py#L31-L34) that the `DeprecatedEdxPlatformImportErrors` are currently breaking for certain unlucky tasks whose names look like old import paths. 

For example, [`entitlements.expire_old_enrollments`](https://github.com/edx/edx-platform/blob/ff87c45de853607f1137dc19182bce8e32f4e43d/common/djangoapps/entitlements/tasks.py#L25) was never a valid import path, but the `entitlements` prefix is making it raise `EdxPlatformDeprecatedImportError` instead of `ImportError`, which is breaking the logic in Django User Tasks. The obvious fix (aside from changing a bunch of task names, which I'd rather not do) is to make `EdxPlatformDeprecatedImportError` a subclass of `ImportError`.

_This is related to the [import shims removal](https://github.com/edx/edx-platform/pull/25932)_