### PR TITLE
fix: Fix KeyError in vertical_block

### DIFF
--- a/common/lib/xmodule/xmodule/vertical_block.py
+++ b/common/lib/xmodule/xmodule/vertical_block.py
@@ -66,7 +66,9 @@ class VerticalBlock(SequenceFields, XModuleFields, StudioEditableBlock, XmlParse
                     usage_key=self.location),  # pylint: disable=no-member
             if 'username' not in child_context:
                 user_service = self.runtime.service(self, 'user')
-                child_context['username'] = user_service.get_current_user().opt_attrs['edx-platform.username']
+                child_context['username'] = user_service.get_current_user().opt_attrs.get(
+                    'edx-platform.username'
+                )
 
         child_blocks = self.get_display_items()
 


### PR DESCRIPTION
This now mimics the way this is (safely) done in the sequence module [1].

## Description

- This _should_ hopefully address issues observed during the rollout of the Learning MFE, in courses with anonymous access enabled.

## Impact

- This affects anonymous access users in the Learning MFE.

## Testing instructions

- Attempt to access a course via the new Learning MFE with anonymous access enabled.

## Deadline

Rollout of phase v1.4 of the Learning MFE

## References
- [1] https://github.com/edx/edx-platform/blob/5f94a082ce1141d9214e83c152baa00186278ad3/common/lib/xmodule/xmodule/seq_module.py#L657-L658