### PR TITLE
[MICROBA-952] Updating CourseEntitlements Admin to make order_numbers readonly

### DIFF
--- a/common/djangoapps/entitlements/admin.py
+++ b/common/djangoapps/entitlements/admin.py
@@ -23,6 +23,7 @@ class CourseEntitlementAdmin(admin.ModelAdmin):
                     'enrollment_course_run',
                     'order_number')
     raw_id_fields = ('enrollment_course_run', 'user',)
+    readonly_fields = ['order_number']
     search_fields = ('user__username', 'uuid', 'course_uuid', 'mode', 'order_number')
 
 


### PR DESCRIPTION
## Description
The changes in this PR are to support updating Course Entitlements using the Django Admin. Course Entitlements created using the support tools are expected to have empty order numbers. This change allows an edit in the Django Admin to be saved while maintaining the Null state.

## Supporting information
https://openedx.atlassian.net/browse/MICROBA-952
