### PR TITLE
[BD-21] WIP Upgrade edx-lint to lint code annotations

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -91,14 +91,14 @@ REQ_FILES = \
 
 compile-requirements: export CUSTOM_COMPILE_COMMAND=make upgrade
 compile-requirements: ## Re-compile *.in requirements to *.txt
-	@ export REBUILD='--rebuild'; \
-	for f in $(REQ_FILES); do \
-		echo ; \
-		echo "== $$f ===============================" ; \
-		echo "pip-compile -v --no-emit-trusted-host --no-index $$REBUILD ${COMPILE_OPTS} -o $$f.txt $$f.in"; \
-		pip-compile -v --no-emit-trusted-host --no-index $$REBUILD ${COMPILE_OPTS} -o $$f.txt $$f.in || exit 1; \
-		export REBUILD=''; \
-	done
+	# @ export REBUILD='--rebuild'; \
+	# for f in $(REQ_FILES); do \
+	# 	echo ; \
+	# 	echo "== $$f ===============================" ; \
+	# 	echo "pip-compile -v --no-emit-trusted-host --no-index $$REBUILD ${COMPILE_OPTS} -o $$f.txt $$f.in"; \
+	# 	pip-compile -v --no-emit-trusted-host --no-index $$REBUILD ${COMPILE_OPTS} -o $$f.txt $$f.in || exit 1; \
+	# 	export REBUILD=''; \
+	# done
 	# Post process all of the files generated above to work around open pip-tools issues
 	scripts/post-pip-compile.sh $(REQ_FILES:=.txt)
 	# Let tox control the Django version for tests
@@ -130,4 +130,3 @@ docker_push: docker_tag docker_auth ## push to docker hub
 	docker push "openedx/edx-platform:${GITHUB_SHA}-newrelic"
 	docker push 'openedx/edx-platform:latest-devstack'
 	docker push "openedx/edx-platform:${GITHUB_SHA}-devstack"
-

--- a/requirements/edx-sandbox/py35.txt
+++ b/requirements/edx-sandbox/py35.txt
@@ -20,7 +20,7 @@ matplotlib==2.2.4         # via -c requirements/edx-sandbox/../constraints.txt, 
 mpmath==1.1.0             # via sympy
 networkx==2.2             # via -r requirements/edx-sandbox/py35.in
 nltk==3.5                 # via -r requirements/edx-sandbox/shared.txt, chem
-numpy==1.16.5             # via -c requirements/edx-sandbox/../constraints.txt, -r requirements/edx-sandbox/py35.in, chem, matplotlib, openedx-calc, scipy
+numpy==1.16.5             # via -c requirements/edx-sandbox/../constraints.txt, -r requirements/edx-sandbox/py35.in, chem, matplotlib, openedx-calc
 openedx-calc==1.0.9       # via -r requirements/edx-sandbox/py35.in
 pycparser==2.20           # via -r requirements/edx-sandbox/shared.txt, cffi
 pyparsing==2.2.0          # via -r requirements/edx-sandbox/py35.in, chem, matplotlib, openedx-calc

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -37,7 +37,7 @@ cffi==1.14.4              # via -r requirements/edx/../edx-sandbox/shared.txt, c
 chardet==4.0.0            # via -r requirements/edx/paver.txt, pysrt, requests
 chem==1.2.0               # via -r requirements/edx/base.in
 click==7.1.2              # via -r requirements/edx/../edx-sandbox/shared.txt, code-annotations, nltk, user-util
-code-annotations==1.0.2   # via edx-enterprise, edx-toggles
+code-annotations==1.1.0   # via edx-enterprise, edx-toggles
 contextlib2==0.6.0.post1  # via -r requirements/edx/base.in
 coreapi==2.3.3            # via drf-yasg
 coreschema==0.0.4         # via coreapi, drf-yasg

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -42,7 +42,7 @@ chardet==4.0.0            # via -r requirements/edx/testing.txt, diff-cover, pys
 chem==1.2.0               # via -r requirements/edx/testing.txt
 click-log==0.3.2          # via -r requirements/edx/testing.txt, edx-lint
 click==7.1.2              # via -r requirements/edx/development.in, -r requirements/edx/pip-tools.txt, -r requirements/edx/testing.txt, click-log, code-annotations, edx-lint, nltk, pip-tools, user-util
-code-annotations==1.0.2   # via -r requirements/edx/testing.txt, edx-enterprise, edx-lint, edx-toggles
+code-annotations==1.1.0   # via -r requirements/edx/testing.txt, edx-enterprise, edx-lint, edx-toggles
 contextlib2==0.6.0.post1  # via -r requirements/edx/testing.txt
 coreapi==2.3.3            # via -r requirements/edx/testing.txt, drf-yasg
 coreschema==0.0.4         # via -r requirements/edx/testing.txt, coreapi, drf-yasg
@@ -112,7 +112,7 @@ edx-drf-extensions==6.4.0  # via -r requirements/edx/testing.txt, edx-completion
 edx-enterprise==3.17.14   # via -c requirements/edx/../constraints.txt, -r requirements/edx/testing.txt
 edx-event-routing-backends==4.0.1  # via -r requirements/edx/testing.txt
 edx-i18n-tools==0.5.3     # via -r requirements/edx/testing.txt, ora2
-edx-lint==3.0.2           # via -r requirements/edx/testing.txt
+git+https://github.com/regisb/edx-lint.git@regisb/generic-code-annotations-errors#egg=edx-lint==4.0.0  # via -r requirements/edx/testing.txt
 edx-milestones==0.3.0     # via -r requirements/edx/testing.txt
 edx-opaque-keys[django]==2.2.0  # via -r requirements/edx/testing.txt, edx-bulk-grades, edx-ccx-keys, edx-completion, edx-drf-extensions, edx-enterprise, edx-milestones, edx-organizations, edx-proctoring, edx-user-state-client, edx-when, lti-consumer-xblock, xmodule
 edx-organizations==6.8.0  # via -r requirements/edx/testing.txt

--- a/requirements/edx/doc.txt
+++ b/requirements/edx/doc.txt
@@ -9,7 +9,7 @@ babel==2.9.0              # via sphinx
 certifi==2020.12.5        # via requests
 chardet==4.0.0            # via requests
 click==7.1.2              # via code-annotations
-code-annotations==1.0.2   # via -r requirements/edx/doc.in
+code-annotations==1.1.0  # via -r requirements/edx/doc.in
 django==2.2.17            # via -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt, code-annotations
 docutils==0.16            # via sphinx
 edx-sphinx-theme==1.6.1   # via -r requirements/edx/doc.in

--- a/requirements/edx/testing.in
+++ b/requirements/edx/testing.in
@@ -23,7 +23,7 @@ code-annotations          # Perform code annotation checking, such as for PII an
 cssselect                 # Used to extract HTML fragments via CSS selectors in 2 test cases and pyquery
 ddt                       # Run a test case multiple times with different input; used in many, many of our tests
 edx-i18n-tools>=0.4.6     # Commands for developers and translators to extract, compile and validate translations
-edx-lint                  # pylint extensions for Open edX repositories
+git+https://github.com/regisb/edx-lint.git@regisb/generic-code-annotations-errors#egg=edx-lint==4.0.0                  # pylint extensions for Open edX repositories
 factory-boy               # Library for creating test fixtures, used in many tests
 # Pinning the freezegun version because 0.3.13 is causing failures which have also been reported on the git repo by public.
 freezegun                 # Allows tests to mock the output of assorted datetime module functions

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -41,7 +41,7 @@ chardet==4.0.0            # via -r requirements/edx/base.txt, -r requirements/ed
 chem==1.2.0               # via -r requirements/edx/base.txt
 click-log==0.3.2          # via edx-lint
 click==7.1.2              # via -r requirements/edx/base.txt, click-log, code-annotations, edx-lint, nltk, user-util
-code-annotations==1.0.2   # via -r requirements/edx/base.txt, -r requirements/edx/testing.in, edx-enterprise, edx-lint, edx-toggles
+code-annotations==1.1.0   # via -r requirements/edx/base.txt, -r requirements/edx/testing.in, edx-enterprise, edx-lint, edx-toggles
 contextlib2==0.6.0.post1  # via -r requirements/edx/base.txt
 coreapi==2.3.3            # via -r requirements/edx/base.txt, drf-yasg
 coreschema==0.0.4         # via -r requirements/edx/base.txt, coreapi, drf-yasg
@@ -109,7 +109,7 @@ edx-drf-extensions==6.4.0  # via -r requirements/edx/base.txt, edx-completion, e
 edx-enterprise==3.17.14   # via -c requirements/edx/../constraints.txt, -r requirements/edx/base.txt
 edx-event-routing-backends==4.0.1  # via -r requirements/edx/base.txt
 edx-i18n-tools==0.5.3     # via -r requirements/edx/base.txt, -r requirements/edx/testing.in, ora2
-edx-lint==3.0.2           # via -r requirements/edx/testing.in
+git+https://github.com/regisb/edx-lint.git@regisb/generic-code-annotations-errors#egg=edx-lint==4.0.0  # via -r requirements/edx/testing.in
 edx-milestones==0.3.0     # via -r requirements/edx/base.txt
 edx-opaque-keys[django]==2.2.0  # via -r requirements/edx/base.txt, edx-bulk-grades, edx-ccx-keys, edx-completion, edx-drf-extensions, edx-enterprise, edx-milestones, edx-organizations, edx-proctoring, edx-user-state-client, edx-when, lti-consumer-xblock, xmodule
 edx-organizations==6.8.0  # via -r requirements/edx/base.txt


### PR DESCRIPTION
<!--
Please give the pull request a short but descriptive title.
Use [conventional commits](https://www.conventionalcommits.org/) to separate and summarize commits logically.

Use this template as a guide. Omit sections that don't apply. You may link to information rather than copy it.
More details about the template are at https://github.com/edx/open-edx-proposals/pull/180
(link will be updated when that document merges)
-->

## Description

Install edx-lint from this PR: https://github.com/edx/edx-lint/pull/140
This should expose code annotation errors thanks to pylint.

## Supporting information

https://openedx.atlassian.net/wiki/spaces/COMM/pages/1596358943/BD-21+Toggles+Settings+Documentation

## Testing instructions

Let's run CI and see what annotation failures are detected.

## Deadline

Hopefully, before the end of the doc-a-thon.


cc @robrap 