### PR TITLE
Fix build: use @shared_task for update_outline_from_modulestore_task

### DIFF
--- a/cms/djangoapps/contentstore/tasks.py
+++ b/cms/djangoapps/contentstore/tasks.py
@@ -563,7 +563,8 @@ def import_olx(self, user_id, course_key_string, archive_path, archive_name, lan
                 LOGGER.info(u'Course %s Entrance exam imported', course.id)
 
 
-@task(name='cms.djangoapps.contentstore.tasks.update_outline_from_modulestore_task')
+@shared_task
+@set_code_owner_attribute
 def update_outline_from_modulestore_task(course_key_str):
     """
     Celery task that creates a learning_sequence course outline.


### PR DESCRIPTION
## Description

Update to make update_outline_from_modulestore_task use @shared_task and @set_code_owner_attribute.

This was necessary because I merged #26145 without rebasing to the latest master and broke the build when the `task` import was removed in favor of `shared_task`.

## Testing instructions

N/A – the build should start working again.

## Deadline

ASAP, as it blocks release.