### PR TITLE
Bump django-config-models to 2.1.1

### DIFF
--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -50,7 +50,7 @@ defusedxml==0.6.0         # via -r requirements/edx/base.in, djangorestframework
 django-appconf==1.0.4     # via -r requirements/edx/base.in, django-statici18n
 django-celery-results==2.0.1  # via -r requirements/edx/base.in
 django-classy-tags==2.0.0  # via django-sekizai
-django-config-models==2.1.0  # via -r requirements/edx/base.in, edx-enterprise, edx-event-routing-backends
+django-config-models==2.1.1  # via -r requirements/edx/base.in, edx-enterprise, edx-event-routing-backends
 django-cookies-samesite==0.8.0  # via -r requirements/edx/base.in
 django-cors-headers==2.5.3  # via -c requirements/edx/../constraints.txt, -r requirements/edx/base.in
 django-countries==5.5     # via -c requirements/edx/../constraints.txt, -r requirements/edx/base.in, edx-enterprise

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -60,7 +60,7 @@ distlib==0.3.1            # via -r requirements/edx/testing.txt, virtualenv
 django-appconf==1.0.4     # via -r requirements/edx/testing.txt, django-statici18n
 django-celery-results==2.0.1  # via -r requirements/edx/testing.txt
 django-classy-tags==2.0.0  # via -r requirements/edx/testing.txt, django-sekizai
-django-config-models==2.1.0  # via -r requirements/edx/testing.txt, edx-enterprise, edx-event-routing-backends
+django-config-models==2.1.1  # via -r requirements/edx/testing.txt, edx-enterprise, edx-event-routing-backends
 django-cookies-samesite==0.8.0  # via -r requirements/edx/testing.txt
 django-cors-headers==2.5.3  # via -c requirements/edx/../constraints.txt, -r requirements/edx/testing.txt
 django-countries==5.5     # via -c requirements/edx/../constraints.txt, -r requirements/edx/testing.txt, edx-enterprise

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -59,7 +59,7 @@ distlib==0.3.1            # via virtualenv
 django-appconf==1.0.4     # via -r requirements/edx/base.txt, django-statici18n
 django-celery-results==2.0.1  # via -r requirements/edx/base.txt
 django-classy-tags==2.0.0  # via -r requirements/edx/base.txt, django-sekizai
-django-config-models==2.1.0  # via -r requirements/edx/base.txt, edx-enterprise, edx-event-routing-backends
+django-config-models==2.1.1  # via -r requirements/edx/base.txt, edx-enterprise, edx-event-routing-backends
 django-cookies-samesite==0.8.0  # via -r requirements/edx/base.txt
 django-cors-headers==2.5.3  # via -c requirements/edx/../constraints.txt, -r requirements/edx/base.txt
 django-countries==5.5     # via -c requirements/edx/../constraints.txt, -r requirements/edx/base.txt, edx-enterprise


### PR DESCRIPTION


## Description

Bump django-config-models to 2.1.1

Pulls in a fix for a deprecated import of
`util.memcache.safe_key`.

## Supporting information

See https://github.com/edx/django-config-models/pull/113

Related to the [import shims removal](https://github.com/edx/edx-platform/pull/25932).

## Testing instructions

N/A

## Deadline

ASAP, it's breaking master.

## Other information

N/A
