### PR TITLE
Fix dashboard coaching redirect

### DIFF
--- a/themes/edx.org/lms/templates/dashboard/_dashboard_course_resume.html
+++ b/themes/edx.org/lms/templates/dashboard/_dashboard_course_resume.html
@@ -26,14 +26,15 @@ MICROBACHELORS_SLUG = 'microbachelors'
   </a>
 % else:
   <%
+    redirected_course_target = course_target
     account_mfe_url = getattr(settings, 'ACCOUNT_MICROFRONTEND_URL', '') or ''
     show_coaching_consent_form = plugins.get("coaching", {}).get("show_coaching_consent_form")
     if related_programs and account_mfe_url != '' and show_coaching_consent_form:
       for program in related_programs:
         if program.get('type_attrs', {}).get('slug') == MICROBACHELORS_SLUG:
-          course_target = "%s/coaching_consent?next=%s" % (account_mfe_url, getattr(settings, 'LMS_ROOT_URL', '') + course_target)
+          redirected_course_target = "%s/coaching_consent?next=%s" % (account_mfe_url, getattr(settings, 'LMS_ROOT_URL', '') + course_target)
   %>
-  <a href="${course_target}"
+  <a href="${redirected_course_target}"
       class="course-target-link enter-course ${'hidden' if is_unfulfilled_entitlement else ''}"
       data-course-key="${enrollment.course_id}">
     ${_('View Course')}


### PR DESCRIPTION
<!--
Please give the pull request a short but descriptive title.
Use [conventional commits](https://www.conventionalcommits.org/) to separate and summarize commits logically.

Use this template as a guide. Omit sections that don't apply. You may link to information rather than copy it.
More details about the template are at https://github.com/edx/open-edx-proposals/pull/180
(link will be updated when that document merges)
-->

## Description

This fixes a variable-reuse-in-a-loop bug that caused nested URLs for coaching redirects in the dashboard

## Supporting information
MICROBA-969

## Testing instructions

Please provide detailed step-by-step instructions for testing this change.

## Deadline

"None" if there's no rush, or provide a specific date or event (and reason) if there is one.

## Other information

Include anything else that will help reviewers and consumers understand the change.
- Does this change depend on other changes elsewhere?
- Any special concerns or limitations? For example: deprecations, migrations, security, or accessibility.
