### PR TITLE
[SE-3989] - Fixes for Blockstore integration tests.

### DIFF
--- a/openedx/core/djangoapps/content_libraries/libraries_index.py
+++ b/openedx/core/djangoapps/content_libraries/libraries_index.py
@@ -33,7 +33,6 @@ class SearchIndexerBase(ABC):
     Abstract Base Class for implementing library search indexers.
     """
     INDEX_NAME = None
-    DOCUMENT_TYPE = None
     ENABLE_INDEXING_KEY = None
     SCHEMA_VERSION = 0
     SEARCH_KWARGS = {
@@ -56,7 +55,7 @@ class SearchIndexerBase(ABC):
         """
         searcher = SearchEngine.get_search_engine(cls.INDEX_NAME)
         items = [cls.get_item_definition(item) for item in items]
-        return searcher.index(cls.DOCUMENT_TYPE, items, **cls.SEARCH_KWARGS)
+        return searcher.index(items, **cls.SEARCH_KWARGS)
 
     @classmethod
     def get_items(cls, ids=None, filter_terms=None, text_search=None):
@@ -79,7 +78,7 @@ class SearchIndexerBase(ABC):
             response = cls._perform_elastic_search(filter_terms, text_search)
         else:
             searcher = SearchEngine.get_search_engine(cls.INDEX_NAME)
-            response = searcher.search(doc_type=cls.DOCUMENT_TYPE, field_dictionary=filter_terms, size=MAX_SIZE)
+            response = searcher.search(field_dictionary=filter_terms, size=MAX_SIZE)
 
         response = [result["data"] for result in response["results"]]
         return sorted(response, key=lambda i: i["id"])
@@ -91,7 +90,7 @@ class SearchIndexerBase(ABC):
         """
         searcher = SearchEngine.get_search_engine(cls.INDEX_NAME)
         ids_str = [str(i) for i in ids]
-        searcher.remove(cls.DOCUMENT_TYPE, ids_str, **cls.SEARCH_KWARGS)
+        searcher.remove(ids_str, **cls.SEARCH_KWARGS)
 
     @classmethod
     def remove_all_items(cls):
@@ -99,9 +98,9 @@ class SearchIndexerBase(ABC):
         Remove all items from the index
         """
         searcher = SearchEngine.get_search_engine(cls.INDEX_NAME)
-        response = searcher.search(doc_type=cls.DOCUMENT_TYPE, filter_dictionary={}, size=MAX_SIZE)
+        response = searcher.search(filter_dictionary={}, size=MAX_SIZE)
         ids = [result["data"]["id"] for result in response["results"]]
-        searcher.remove(cls.DOCUMENT_TYPE, ids, **cls.SEARCH_KWARGS)
+        searcher.remove(ids, **cls.SEARCH_KWARGS)
 
     @classmethod
     def indexing_is_enabled(cls):
@@ -117,7 +116,6 @@ class SearchIndexerBase(ABC):
         """
         searcher = SearchEngine.get_search_engine(cls.INDEX_NAME)
         return _translate_hits(searcher._es.search(  # pylint: disable=protected-access
-            doc_type=cls.DOCUMENT_TYPE,
             index=searcher.index_name,
             body=cls.build_elastic_query(filter_terms, text_search),
             size=MAX_SIZE
@@ -130,7 +128,7 @@ class SearchIndexerBase(ABC):
         """
         # Remove reserved characters (and ") from the text to prevent unexpected errors.
         text_search_normalised = text_search.translate(text_search.maketrans('', '', RESERVED_CHARACTERS + '"'))
-        text_search_normalised = text_search.replace('-', ' ')
+        text_search_normalised = text_search_normalised.replace('-', ' ')
         # Wrap with asterix to enable partial matches
         text_search_normalised = "*{}*".format(text_search_normalised)
         terms = [
@@ -143,32 +141,19 @@ class SearchIndexerBase(ABC):
         ]
         return {
             'query': {
-                'filtered': {
-                    'query': {
-                        'bool': {
-                            'should': [
-                                {
-                                    'query_string': {
-                                        'query': text_search_normalised,
-                                        "fields": ["content.*"],
-                                        "minimum_should_match": "100%",
-                                    },
-                                },
-                                # Add a special wildcard search for id, as it contains a ":" character which is
-                                # filtered out in query_string
-                                {
-                                    'wildcard': {
-                                        'id': {
-                                            'value': '*{}*'.format(text_search),
-                                        }
-                                    },
-                                },
-                            ],
+                'bool': {
+                    'must': [
+                        {
+                            'query_string': {
+                                'query': text_search_normalised,
+                                "fields": ["content.*"],
+                                'minimum_should_match': '100%',
+                            },
                         },
-                    },
+                    ],
                     'filter': {
                         'bool': {
-                            'must': terms
+                            'must': terms,
                         }
                     }
                 },
@@ -183,7 +168,6 @@ class ContentLibraryIndexer(SearchIndexerBase):
 
     INDEX_NAME = "content_library_index"
     ENABLE_INDEXING_KEY = "ENABLE_CONTENT_LIBRARY_INDEX"
-    DOCUMENT_TYPE = "content_library"
     SCHEMA_VERSION = 0
 
     @classmethod
@@ -212,7 +196,7 @@ class ContentLibraryIndexer(SearchIndexerBase):
             "last_published": last_published_str,
             "has_unpublished_changes": has_unpublished_changes,
             "has_unpublished_deletes": has_unpublished_deletes,
-            # only 'content' field is analyzed by elastisearch, and allows text-search
+            # only 'content' field is analyzed by elasticsearch, and allows text-search
             "content": {
                 "id": str(item),
                 "title": bundle_metadata.title,
@@ -226,9 +210,8 @@ class LibraryBlockIndexer(SearchIndexerBase):
     Class to perform indexing on the XBlocks in content libraries.
     """
 
-    INDEX_NAME = "content_library_index"
+    INDEX_NAME = "content_library_block_index"
     ENABLE_INDEXING_KEY = "ENABLE_CONTENT_LIBRARY_INDEX"
-    DOCUMENT_TYPE = "content_library_block"
     SCHEMA_VERSION = 0
 
     @classmethod

--- a/openedx/core/djangoapps/content_libraries/tests/base.py
+++ b/openedx/core/djangoapps/content_libraries/tests/base.py
@@ -68,7 +68,6 @@ def elasticsearch_test(func):
         def mock_perform(cls, filter_terms, text_search):
             # pylint: disable=no-member
             return SearchEngine.get_search_engine(cls.INDEX_NAME).search(
-                doc_type=cls.DOCUMENT_TYPE,
                 field_dictionary=filter_terms,
                 query_string=text_search,
                 size=MAX_SIZE


### PR DESCRIPTION
## Description

This pull request repairs the integration tests for Blockstore/Libraries v2 by changing updating relevant code to be compatible with the latest version of `edx-search`.

It's not known how long these tests have been broken because they are not run by Jenkins. The breakage appears to have been caused in: https://github.com/edx/edx-search/pull/104

CC: @Golub-Sergey @bradenmacdonald 

## Jira Ticket
https://openedx.atlassian.net/browse/OSPR-5578

## Testing instructions

Set up Blockstore, and run `make testserver` to launch the testserver. Then, in `devstack` run `make studio-shell` and run these commands, **one at a time** so you can easily see if any failed:

```
EDXAPP_TEST_ELASTICSEARCH_HOST=edx.devstack.elasticsearch7 EDXAPP_ENABLE_ELASTICSEARCH_FOR_TESTS=0 EDXAPP_RUN_BLOCKSTORE_TESTS=1 python -Wd -m pytest --ds=cms.envs.test openedx/core/lib/blockstore_api/ openedx/core/djangolib/tests/test_blockstore_cache.py openedx/core/djangoapps/content_libraries/tests/
EDXAPP_TEST_ELASTICSEARCH_HOST=edx.devstack.elasticsearch7 EDXAPP_ENABLE_ELASTICSEARCH_FOR_TESTS=0 EDXAPP_RUN_BLOCKSTORE_TESTS=1 python -Wd -m pytest --ds=lms.envs.test openedx/core/lib/blockstore_api/ openedx/core/djangolib/tests/test_blockstore_cache.py openedx/core/djangoapps/content_libraries/tests/
EDXAPP_TEST_ELASTICSEARCH_HOST=edx.devstack.elasticsearch7 EDXAPP_ENABLE_ELASTICSEARCH_FOR_TESTS=1 EDXAPP_RUN_BLOCKSTORE_TESTS=1 python -Wd -m pytest --ds=cms.envs.test openedx/core/lib/blockstore_api/ openedx/core/djangolib/tests/test_blockstore_cache.py openedx/core/djangoapps/content_libraries/tests/
EDXAPP_TEST_ELASTICSEARCH_HOST=edx.devstack.elasticsearch7 EDXAPP_ENABLE_ELASTICSEARCH_FOR_TESTS=1 EDXAPP_RUN_BLOCKSTORE_TESTS=1 python -Wd -m pytest --ds=lms.envs.test openedx/core/lib/blockstore_api/ openedx/core/djangolib/tests/test_blockstore_cache.py openedx/core/djangoapps/content_libraries/tests/

```

Note that the above are two lines more than the Blockstore integration test instructions mention. I'm not sure if it should be in the documentation there, but two codepaths exist in testing, and I needed to toggle using real elasticsearch to ensure they were both followed.

## Deadline
I'm not sure-- it's unclear to me if this has broken anything in production, but I have to assume it has. Sooner is better.

## Other information

The changes which broke the integration test removed the need for specifying the document type to every operation on the search index. This seems to have assumed that a feature of `edx-search`, allowing multiple document types, was never used, and so could be eliminated.

Unfortunately, the library indexes **DID** use this feature, and because the integration tests aren't run automatically, this escaped the notice of the devs who made this change. This means to make the tests pass, and search to work as expected, I've had to create an additional index.

I don't know the full implications of having done so. I can only imagine it will mean a time-consuming reindex for someone down the line when this is merged. I also don't know if it will mean a lot of duplicated data between the indexes. Any further information and context is appreciated.

## Reviewers
- [x] @arbrandes 
- [ ] @bradenmacdonald 
