### PR TITLE
[TSD] Add toggle annotations for [‘WIKI_ANONYMOUS']

### DIFF
--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -440,7 +440,8 @@ FEATURES = {
     # .. toggle_description: The edxnotes app is responsible for displaying parts of the Notes UI to students in different parts
     #   of the LMS, as well as figuring out whether Notes is enabled for a particular situation.
     #   The bulk of the actual work in storing the notes is done by a separate service (see the edx-notes-api repo).
-    # .. toggle_warnings: Requires the edx-notes-api service properly running and to have configured the django settings as well
+    # .. toggle_warnings: Requires the edx-notes-api service properly running and to have configured the django settings
+    #   EDXNOTES_INTERNAL_API and EDXNOTES_PUBLIC_API
     # .. toggle_use_cases: open_edx
     # .. toggle_creation_date: None
     # .. toggle_tickets: None

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -439,7 +439,7 @@ FEATURES = {
     # .. toggle_default: False
     # .. toggle_description: This toggle enables the students to save and manage their annotations in the
     #   course using the notes service. The bulk of the actual work in storing the notes is done by
-    #   by a separate service(see the edx-notes-api repo)
+    #   by a separate service(see the edx-notes-api repo).
     # .. toggle_warnings: Requires the edx-notes-api service properly running and to have configured the django settings
     #   EDXNOTES_INTERNAL_API and EDXNOTES_PUBLIC_API
     # .. toggle_use_cases: open_edx

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -437,9 +437,9 @@ FEATURES = {
     # .. toggle_name: FEATURES['ENABLE_EDXNOTES']
     # .. toggle_implementation: SettingToggle
     # .. toggle_default: False
-    # .. toggle_description: The edxnotes app is responsible for displaying parts of the Notes UI to students in different parts
-    #   of the LMS, as well as figuring out whether Notes is enabled for a particular situation.
-    #   The bulk of the actual work in storing the notes is done by a separate service (see the edx-notes-api repo).
+    # .. toggle_description: This toggle enables the students to save and manage their annotations in the
+    #   course using the notes service. The bulk of the actual work in storing the notes is done by
+    #   by a separate service(see the edx-notes-api repo)
     # .. toggle_warnings: Requires the edx-notes-api service properly running and to have configured the django settings
     #   EDXNOTES_INTERNAL_API and EDXNOTES_PUBLIC_API
     # .. toggle_use_cases: open_edx

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -434,6 +434,16 @@ FEATURES = {
     'ENABLE_FOOTER_MOBILE_APP_LINKS': False,
 
     # Let students save and manage their annotations
+    # .. toggle_name: FEATURES['ENABLE_EDXNOTES']
+    # .. toggle_implementation: SettingToggle
+    # .. toggle_default: False
+    # .. toggle_description: The edxnotes app is responsible for displaying parts of the Notes UI to students in different parts 
+    #   of the LMS, as well as figuring out whether Notes is enabled for a particular situation. The bulk of the actual work in 
+    #   storing the notes is done by a separate service (see the edx-notes-api repo).
+    # .. toggle_warnings: Requires the edx-notes-api service properly running and to have configured the django settings as well
+    # .. toggle_use_cases: open_edx
+    # .. toggle_creation_date: None
+    # .. toggle_tickets: None
     'ENABLE_EDXNOTES': False,
 
     # Toggle to enable coordination with the Publisher tool (keep in sync with cms/envs/common.py)

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -1592,7 +1592,7 @@ from lms.djangoapps.course_wiki import settings as course_wiki_settings  # pylin
 # .. toggle_name: WIKI_ACCOUNT_HANDLING
 # .. toggle_implementation: Django setting
 # .. toggle_default: True
-# .. toggle_description: This setting allows the access to Sign up, login and     logout views.
+# .. toggle_description: This setting allows the access to Sign up, login and logout views.
 # .. toggle_warnings: Turn to False only if you have your own account handling
 # .. toggle_use_cases: open_edx
 # .. toggle_creation_date: None

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -1600,6 +1600,14 @@ from lms.djangoapps.course_wiki import settings as course_wiki_settings  # pylin
 WIKI_ACCOUNT_HANDLING = False
 WIKI_EDITOR = 'lms.djangoapps.course_wiki.editors.CodeMirror'
 WIKI_SHOW_MAX_CHILDREN = 0  # We don't use the little menu that shows children of an article in the breadcrumb
+# .. toggle_name: WIKI_ANONYMOUS
+# .. toggle_implementation: Django setting
+# .. toggle_default: True
+# .. toggle_description: This setting treats none logged in users as the ¨other¨ user group.
+# .. toggle_warnings: In False it doesn´t allow to access anonymous users.
+# .. toggle_use_cases: open_edx
+# .. toggle_creation_date: None
+# .. toggle_tickets: None
 WIKI_ANONYMOUS = False  # Don't allow anonymous access until the styling is figured out
 
 WIKI_CAN_DELETE = course_wiki_settings.CAN_DELETE

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -438,8 +438,8 @@ FEATURES = {
     # .. toggle_implementation: SettingToggle
     # .. toggle_default: False
     # .. toggle_description: The edxnotes app is responsible for displaying parts of the Notes UI to students in different parts
-    #   of the LMS, as well as figuring out whether Notes is enabled for a particular situation. The bulk of the actual work in
-    #   storing the notes is done by a separate service (see the edx-notes-api repo).
+    #   of the LMS, as well as figuring out whether Notes is enabled for a particular situation.
+    #   The bulk of the actual work in storing the notes is done by a separate service (see the edx-notes-api repo).
     # .. toggle_warnings: Requires the edx-notes-api service properly running and to have configured the django settings as well
     # .. toggle_use_cases: open_edx
     # .. toggle_creation_date: None

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -1589,6 +1589,14 @@ SIMPLE_WIKI_REQUIRE_LOGIN_VIEW = False
 ################################# WIKI ###################################
 from lms.djangoapps.course_wiki import settings as course_wiki_settings  # pylint: disable=wrong-import-position
 
+# .. toggle_name: WIKI_ACCOUNT_HANDLING
+# .. toggle_implementation: Django setting
+# .. toggle_default: True
+# .. toggle_description: This setting allows the access to Sign up, login and     logout views.
+# .. toggle_warnings: Turn to False only if you have your own account handling
+# .. toggle_use_cases: open_edx
+# .. toggle_creation_date: None
+# .. toggle_tickets: None
 WIKI_ACCOUNT_HANDLING = False
 WIKI_EDITOR = 'lms.djangoapps.course_wiki.editors.CodeMirror'
 WIKI_SHOW_MAX_CHILDREN = 0  # We don't use the little menu that shows children of an article in the breadcrumb

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -437,8 +437,8 @@ FEATURES = {
     # .. toggle_name: FEATURES['ENABLE_EDXNOTES']
     # .. toggle_implementation: SettingToggle
     # .. toggle_default: False
-    # .. toggle_description: The edxnotes app is responsible for displaying parts of the Notes UI to students in different parts 
-    #   of the LMS, as well as figuring out whether Notes is enabled for a particular situation. The bulk of the actual work in 
+    # .. toggle_description: The edxnotes app is responsible for displaying parts of the Notes UI to students in different parts
+    #   of the LMS, as well as figuring out whether Notes is enabled for a particular situation. The bulk of the actual work in
     #   storing the notes is done by a separate service (see the edx-notes-api repo).
     # .. toggle_warnings: Requires the edx-notes-api service properly running and to have configured the django settings as well
     # .. toggle_use_cases: open_edx


### PR DESCRIPTION
## Description

Add [‘WIKI_ANONYMOUS’] toggle annotations has the purpose to give some information
related with this django setting. This documentation does not affect the behavior of the setting and only has
useful information for edX community.

## Reference
https://github.com/edx/django-wiki/blob/edx_release/wiki/conf/settings.py
