### PR TITLE
[TSD] Add toggle annotations for WIKI settings

### DIFF
--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -1074,6 +1074,15 @@ DJFS = {
 
 ENABLE_MULTICOURSE = False  # set to False to disable multicourse display (see lib.util.views.edXhome)
 
+# .. toggle_name: WIKI_ENABLED
+# .. toggle_implementation: Django setting
+# .. toggle_default: True
+# .. toggle_description: This setting allows us to have a collaborative tool to contribute or 
+#   modify content of course related materials.
+# .. toggle_warnings: In some cases you may want to disable it in deployment envs.
+# .. toggle_use_cases: open_edx
+# .. toggle_creation_date: None
+# .. toggle_tickets: None
 WIKI_ENABLED = True
 
 ###

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -440,7 +440,8 @@ FEATURES = {
     # .. toggle_description: The edxnotes app is responsible for displaying parts of the Notes UI to students in different parts
     #   of the LMS, as well as figuring out whether Notes is enabled for a particular situation.
     #   The bulk of the actual work in storing the notes is done by a separate service (see the edx-notes-api repo).
-    # .. toggle_warnings: Requires the edx-notes-api service properly running and to have configured the django settings as well
+    # .. toggle_warnings: Requires the edx-notes-api service properly running and to have configured the django settings
+    #   EDXNOTES_INTERNAL_API and EDXNOTES_PUBLIC_API
     # .. toggle_use_cases: open_edx
     # .. toggle_creation_date: None
     # .. toggle_tickets: None

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -1623,7 +1623,15 @@ WIKI_CAN_DELETE = course_wiki_settings.CAN_DELETE
 WIKI_CAN_MODERATE = course_wiki_settings.CAN_MODERATE
 WIKI_CAN_CHANGE_PERMISSIONS = course_wiki_settings.CAN_CHANGE_PERMISSIONS
 WIKI_CAN_ASSIGN = course_wiki_settings.CAN_ASSIGN
-
+# .. toggle_name: WIKI_USE_BOOTSTRAP_SELECT_WIDGET
+# .. toggle_implementation: Django setting
+# .. toggle_default: True
+# .. toggle_description: This setting allows you to use bootstrap and you can switch off 
+#   if you are not using it.
+# .. toggle_warnings: None
+# .. toggle_use_cases: open_edx
+# .. toggle_creation_date: None
+# .. toggle_tickets: None
 WIKI_USE_BOOTSTRAP_SELECT_WIDGET = False
 WIKI_LINK_LIVE_LOOKUPS = False
 WIKI_LINK_DEFAULT_LEVEL = 2

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -439,7 +439,7 @@ FEATURES = {
     # .. toggle_default: False
     # .. toggle_description: This toggle enables the students to save and manage their annotations in the
     #   course using the notes service. The bulk of the actual work in storing the notes is done by
-    #   by a separate service(see the edx-notes-api repo)
+    #   by a separate service(see the edx-notes-api repo).
     # .. toggle_warnings: Requires the edx-notes-api service properly running and to have configured the django settings
     #   EDXNOTES_INTERNAL_API and EDXNOTES_PUBLIC_API
     # .. toggle_use_cases: open_edx

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -434,17 +434,6 @@ FEATURES = {
     'ENABLE_FOOTER_MOBILE_APP_LINKS': False,
 
     # Let students save and manage their annotations
-    # .. toggle_name: FEATURES['ENABLE_EDXNOTES']
-    # .. toggle_implementation: SettingToggle
-    # .. toggle_default: False
-    # .. toggle_description: This toggle enables the students to save and manage their annotations in the
-    #   course using the notes service. The bulk of the actual work in storing the notes is done by
-    #   by a separate service(see the edx-notes-api repo).
-    # .. toggle_warnings: Requires the edx-notes-api service properly running and to have configured the django settings
-    #   EDXNOTES_INTERNAL_API and EDXNOTES_PUBLIC_API
-    # .. toggle_use_cases: open_edx
-    # .. toggle_creation_date: None
-    # .. toggle_tickets: None
     'ENABLE_EDXNOTES': False,
 
     # Toggle to enable coordination with the Publisher tool (keep in sync with cms/envs/common.py)
@@ -1075,14 +1064,12 @@ DJFS = {
 ENABLE_MULTICOURSE = False  # set to False to disable multicourse display (see lib.util.views.edXhome)
 
 # .. toggle_name: WIKI_ENABLED
-# .. toggle_implementation: Django setting
+# .. toggle_implementation: DjangoSetting
 # .. toggle_default: True
 # .. toggle_description: This setting allows us to have a collaborative tool to contribute or
 #   modify content of course related materials.
-# .. toggle_warnings: In some cases you may want to disable it in deployment envs.
 # .. toggle_use_cases: open_edx
-# .. toggle_creation_date: None
-# .. toggle_tickets: None
+# .. toggle_creation_date: 2012-07-13
 WIKI_ENABLED = True
 
 ###
@@ -1599,39 +1586,40 @@ SIMPLE_WIKI_REQUIRE_LOGIN_VIEW = False
 from lms.djangoapps.course_wiki import settings as course_wiki_settings  # pylint: disable=wrong-import-position
 
 # .. toggle_name: WIKI_ACCOUNT_HANDLING
-# .. toggle_implementation: Django setting
-# .. toggle_default: True
-# .. toggle_description: This setting allows the access to Sign up, login and logout views.
+# .. toggle_implementation: DjangoSetting
+# .. toggle_default: False
+# .. toggle_description: We recommend you leave this as 'False' for an Open edX installation
+#   to get the proper behavior for register, login and logout. For the original docs see:
+#   https://github.com/edx/django-wiki/blob/edx_release/wiki/conf/settings.py
 # .. toggle_warnings: Turn to False only if you have your own account handling
 # .. toggle_use_cases: open_edx
 # .. toggle_creation_date: None
-# .. toggle_tickets: None
 WIKI_ACCOUNT_HANDLING = False
 WIKI_EDITOR = 'lms.djangoapps.course_wiki.editors.CodeMirror'
 WIKI_SHOW_MAX_CHILDREN = 0  # We don't use the little menu that shows children of an article in the breadcrumb
 # .. toggle_name: WIKI_ANONYMOUS
-# .. toggle_implementation: Django setting
-# .. toggle_default: True
-# .. toggle_description: This setting treats none logged in users as the ¨other¨ user group.
-# .. toggle_warnings: In False it doesn´t allow to access anonymous users.
+# .. toggle_implementation: DjangoSetting
+# .. toggle_default: False
+# .. toggle_description: Enabling this allows access to anonymous users.
+#   For the original docs, see:
+#   https://github.com/edx/django-wiki/blob/edx_release/wiki/conf/settings.py
+# .. toggle_warnings: Setting allow anonymous access to `True` may have styling issues.
 # .. toggle_use_cases: open_edx
 # .. toggle_creation_date: None
-# .. toggle_tickets: None
-WIKI_ANONYMOUS = False  # Don't allow anonymous access until the styling is figured out
+WIKI_ANONYMOUS = False
 
 WIKI_CAN_DELETE = course_wiki_settings.CAN_DELETE
 WIKI_CAN_MODERATE = course_wiki_settings.CAN_MODERATE
 WIKI_CAN_CHANGE_PERMISSIONS = course_wiki_settings.CAN_CHANGE_PERMISSIONS
 WIKI_CAN_ASSIGN = course_wiki_settings.CAN_ASSIGN
 # .. toggle_name: WIKI_USE_BOOTSTRAP_SELECT_WIDGET
-# .. toggle_implementation: Django setting
-# .. toggle_default: True
-# .. toggle_description: This setting allows you to use bootstrap and you can switch off
-#   if you are not using it.
-# .. toggle_warnings: None
+# .. toggle_implementation: DjangoSetting
+# .. toggle_default: False
+# .. toggle_description: Enabling this will use the bootstrap select widget.
+#   For the original docs, see:
+#   https://github.com/edx/django-wiki/blob/edx_release/wiki/conf/settings.py
 # .. toggle_use_cases: open_edx
 # .. toggle_creation_date: None
-# .. toggle_tickets: None
 WIKI_USE_BOOTSTRAP_SELECT_WIDGET = False
 WIKI_LINK_LIVE_LOOKUPS = False
 WIKI_LINK_DEFAULT_LEVEL = 2

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -437,9 +437,9 @@ FEATURES = {
     # .. toggle_name: FEATURES['ENABLE_EDXNOTES']
     # .. toggle_implementation: SettingToggle
     # .. toggle_default: False
-    # .. toggle_description: The edxnotes app is responsible for displaying parts of the Notes UI to students in different parts
-    #   of the LMS, as well as figuring out whether Notes is enabled for a particular situation.
-    #   The bulk of the actual work in storing the notes is done by a separate service (see the edx-notes-api repo).
+    # .. toggle_description: This toggle enables the students to save and manage their annotations in the
+    #   course using the notes service. The bulk of the actual work in storing the notes is done by
+    #   by a separate service(see the edx-notes-api repo)
     # .. toggle_warnings: Requires the edx-notes-api service properly running and to have configured the django settings
     #   EDXNOTES_INTERNAL_API and EDXNOTES_PUBLIC_API
     # .. toggle_use_cases: open_edx

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -434,6 +434,16 @@ FEATURES = {
     'ENABLE_FOOTER_MOBILE_APP_LINKS': False,
 
     # Let students save and manage their annotations
+    # .. toggle_name: FEATURES['ENABLE_EDXNOTES']
+    # .. toggle_implementation: SettingToggle
+    # .. toggle_default: False
+    # .. toggle_description: The edxnotes app is responsible for displaying parts of the Notes UI to students in different parts 
+    #   of the LMS, as well as figuring out whether Notes is enabled for a particular situation. The bulk of the actual work in 
+    #   storing the notes is done by a separate service (see the edx-notes-api repo).
+    # .. toggle_warnings: Requires the edx-notes-api service properly running and to have configured the django settings as well
+    # .. toggle_use_cases: open_edx
+    # .. toggle_creation_date: None
+    # .. toggle_tickets: None
     'ENABLE_EDXNOTES': False,
 
     # Toggle to enable coordination with the Publisher tool (keep in sync with cms/envs/common.py)

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -1592,7 +1592,7 @@ from lms.djangoapps.course_wiki import settings as course_wiki_settings  # pylin
 # .. toggle_name: WIKI_ACCOUNT_HANDLING
 # .. toggle_implementation: Django setting
 # .. toggle_default: True
-# .. toggle_description: This setting allows the access to Sign up, login and     logout views.
+# .. toggle_description: This setting allows the access to Sign up, login and logout views.
 # .. toggle_warnings: Turn to False only if you have your own account handling
 # .. toggle_use_cases: open_edx
 # .. toggle_creation_date: None

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -1077,7 +1077,7 @@ ENABLE_MULTICOURSE = False  # set to False to disable multicourse display (see l
 # .. toggle_name: WIKI_ENABLED
 # .. toggle_implementation: Django setting
 # .. toggle_default: True
-# .. toggle_description: This setting allows us to have a collaborative tool to contribute or 
+# .. toggle_description: This setting allows us to have a collaborative tool to contribute or
 #   modify content of course related materials.
 # .. toggle_warnings: In some cases you may want to disable it in deployment envs.
 # .. toggle_use_cases: open_edx
@@ -1626,7 +1626,7 @@ WIKI_CAN_ASSIGN = course_wiki_settings.CAN_ASSIGN
 # .. toggle_name: WIKI_USE_BOOTSTRAP_SELECT_WIDGET
 # .. toggle_implementation: Django setting
 # .. toggle_default: True
-# .. toggle_description: This setting allows you to use bootstrap and you can switch off 
+# .. toggle_description: This setting allows you to use bootstrap and you can switch off
 #   if you are not using it.
 # .. toggle_warnings: None
 # .. toggle_use_cases: open_edx

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -1600,6 +1600,14 @@ from lms.djangoapps.course_wiki import settings as course_wiki_settings  # pylin
 WIKI_ACCOUNT_HANDLING = False
 WIKI_EDITOR = 'lms.djangoapps.course_wiki.editors.CodeMirror'
 WIKI_SHOW_MAX_CHILDREN = 0  # We don't use the little menu that shows children of an article in the breadcrumb
+# .. toggle_name: WIKI_ANONYMOUS
+# .. toggle_implementation: Django setting
+# .. toggle_default: True
+# .. toggle_description: This setting treats none logged in users as the ¨other¨ user group.
+# .. toggle_warnings: In False it doesn´t allow to access anonymous users.
+# .. toggle_use_cases: open_edx
+# .. toggle_creation_date: None
+# .. toggle_tickets: None
 WIKI_ANONYMOUS = False  # Don't allow anonymous access until the styling is figured out
 
 WIKI_CAN_DELETE = course_wiki_settings.CAN_DELETE

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -438,8 +438,8 @@ FEATURES = {
     # .. toggle_implementation: SettingToggle
     # .. toggle_default: False
     # .. toggle_description: The edxnotes app is responsible for displaying parts of the Notes UI to students in different parts
-    #   of the LMS, as well as figuring out whether Notes is enabled for a particular situation. The bulk of the actual work in
-    #   storing the notes is done by a separate service (see the edx-notes-api repo).
+    #   of the LMS, as well as figuring out whether Notes is enabled for a particular situation.
+    #   The bulk of the actual work in storing the notes is done by a separate service (see the edx-notes-api repo).
     # .. toggle_warnings: Requires the edx-notes-api service properly running and to have configured the django settings as well
     # .. toggle_use_cases: open_edx
     # .. toggle_creation_date: None

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -1589,6 +1589,14 @@ SIMPLE_WIKI_REQUIRE_LOGIN_VIEW = False
 ################################# WIKI ###################################
 from lms.djangoapps.course_wiki import settings as course_wiki_settings  # pylint: disable=wrong-import-position
 
+# .. toggle_name: WIKI_ACCOUNT_HANDLING
+# .. toggle_implementation: Django setting
+# .. toggle_default: True
+# .. toggle_description: This setting allows the access to Sign up, login and     logout views.
+# .. toggle_warnings: Turn to False only if you have your own account handling
+# .. toggle_use_cases: open_edx
+# .. toggle_creation_date: None
+# .. toggle_tickets: None
 WIKI_ACCOUNT_HANDLING = False
 WIKI_EDITOR = 'lms.djangoapps.course_wiki.editors.CodeMirror'
 WIKI_SHOW_MAX_CHILDREN = 0  # We don't use the little menu that shows children of an article in the breadcrumb

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -437,8 +437,8 @@ FEATURES = {
     # .. toggle_name: FEATURES['ENABLE_EDXNOTES']
     # .. toggle_implementation: SettingToggle
     # .. toggle_default: False
-    # .. toggle_description: The edxnotes app is responsible for displaying parts of the Notes UI to students in different parts 
-    #   of the LMS, as well as figuring out whether Notes is enabled for a particular situation. The bulk of the actual work in 
+    # .. toggle_description: The edxnotes app is responsible for displaying parts of the Notes UI to students in different parts
+    #   of the LMS, as well as figuring out whether Notes is enabled for a particular situation. The bulk of the actual work in
     #   storing the notes is done by a separate service (see the edx-notes-api repo).
     # .. toggle_warnings: Requires the edx-notes-api service properly running and to have configured the django settings as well
     # .. toggle_use_cases: open_edx


### PR DESCRIPTION
## Description

Add toggle annotations for some wiki settings has the purpose to give some information
related with this django setting. This documentation does not affect the behavior of the setting and only has
useful information for edX community.

WIKI settings list:
- WIKI_ACCOUNT_HANDLING
- WIKI_ANONYMOUS
- WIKI_ENABLED
- WIKI_LINK_LINE_LOOKUPS

## Reference
https://github.com/edx/django-wiki/blob/edx_release/wiki/conf/settings.py

