### PR TITLE
refactor: upgrade xblock-drag-and-drop-v2 to 2.3.2

### DIFF
--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -241,7 +241,7 @@ web-fragments==1.0.0      # via -r requirements/edx/base.in, crowdsourcehinter-x
 webencodings==0.5.1       # via bleach, html5lib
 webob==1.8.6              # via xblock, xmodule
 wrapt==1.11.2             # via -c requirements/edx/../constraints.txt, -r requirements/edx/paver.txt
-git+https://github.com/edx-solutions/xblock-drag-and-drop-v2@v2.2.10#egg=xblock-drag-and-drop-v2==2.2.10  # via -r requirements/edx/github.in
+git+https://github.com/edx-solutions/xblock-drag-and-drop-v2@v2.3.2#egg=xblock-drag-and-drop-v2==2.3.2  # via -r requirements/edx/github.in
 git+https://github.com/open-craft/xblock-poll@922cd36fb1c3cfe00b4ce03b19a13185d136447d#egg=xblock-poll==1.10.2  # via -r requirements/edx/github.in
 xblock-utils==2.1.2       # via -r requirements/edx/base.in, edx-sga, lti-consumer-xblock, staff-graded-xblock, xblock-drag-and-drop-v2, xblock-google-drive
 xblock==1.4.0             # via -r requirements/edx/base.in, acid-xblock, crowdsourcehinter-xblock, done-xblock, edx-completion, edx-sga, edx-user-state-client, edx-when, lti-consumer-xblock, ora2, rate-xblock, staff-graded-xblock, xblock-discussion, xblock-drag-and-drop-v2, xblock-google-drive, xblock-poll, xblock-utils

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -314,7 +314,7 @@ web-fragments==1.0.0      # via -r requirements/edx/testing.txt, crowdsourcehint
 webencodings==0.5.1       # via -r requirements/edx/testing.txt, bleach, html5lib
 webob==1.8.6              # via -r requirements/edx/testing.txt, xblock, xmodule
 wrapt==1.11.2             # via -c requirements/edx/../constraints.txt, -r requirements/edx/testing.txt, astroid
-git+https://github.com/edx-solutions/xblock-drag-and-drop-v2@v2.2.10#egg=xblock-drag-and-drop-v2==2.2.10  # via -r requirements/edx/testing.txt
+git+https://github.com/edx-solutions/xblock-drag-and-drop-v2@v2.3.2#egg=xblock-drag-and-drop-v2==2.3.2  # via -r requirements/edx/testing.txt
 git+https://github.com/open-craft/xblock-poll@922cd36fb1c3cfe00b4ce03b19a13185d136447d#egg=xblock-poll==1.10.2  # via -r requirements/edx/testing.txt
 xblock-utils==2.1.2       # via -r requirements/edx/testing.txt, edx-sga, lti-consumer-xblock, staff-graded-xblock, xblock-drag-and-drop-v2, xblock-google-drive
 xblock==1.4.0             # via -r requirements/edx/testing.txt, acid-xblock, crowdsourcehinter-xblock, done-xblock, edx-completion, edx-sga, edx-user-state-client, edx-when, lti-consumer-xblock, ora2, rate-xblock, staff-graded-xblock, xblock-discussion, xblock-drag-and-drop-v2, xblock-google-drive, xblock-poll, xblock-utils

--- a/requirements/edx/github.in
+++ b/requirements/edx/github.in
@@ -72,4 +72,4 @@ git+https://github.com/edx/django-ratelimit-backend.git@v2.0.1a5#egg=django-rate
 # Third Party XBlocks
 
 git+https://github.com/open-craft/xblock-poll@922cd36fb1c3cfe00b4ce03b19a13185d136447d#egg=xblock-poll==1.10.2
-git+https://github.com/edx-solutions/xblock-drag-and-drop-v2@v2.2.10#egg=xblock-drag-and-drop-v2==2.2.10
+git+https://github.com/edx-solutions/xblock-drag-and-drop-v2@v2.3.2#egg=xblock-drag-and-drop-v2==2.3.2

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -292,7 +292,7 @@ web-fragments==1.0.0      # via -r requirements/edx/base.txt, crowdsourcehinter-
 webencodings==0.5.1       # via -r requirements/edx/base.txt, bleach, html5lib
 webob==1.8.6              # via -r requirements/edx/base.txt, xblock, xmodule
 wrapt==1.11.2             # via -c requirements/edx/../constraints.txt, -r requirements/edx/base.txt, astroid
-git+https://github.com/edx-solutions/xblock-drag-and-drop-v2@v2.2.10#egg=xblock-drag-and-drop-v2==2.2.10  # via -r requirements/edx/base.txt
+git+https://github.com/edx-solutions/xblock-drag-and-drop-v2@v2.3.2#egg=xblock-drag-and-drop-v2==2.3.2  # via -r requirements/edx/base.txt
 git+https://github.com/open-craft/xblock-poll@922cd36fb1c3cfe00b4ce03b19a13185d136447d#egg=xblock-poll==1.10.2  # via -r requirements/edx/base.txt
 xblock-utils==2.1.2       # via -r requirements/edx/base.txt, edx-sga, lti-consumer-xblock, staff-graded-xblock, xblock-drag-and-drop-v2, xblock-google-drive
 xblock==1.4.0             # via -r requirements/edx/base.txt, acid-xblock, crowdsourcehinter-xblock, done-xblock, edx-completion, edx-sga, edx-user-state-client, edx-when, lti-consumer-xblock, ora2, rate-xblock, staff-graded-xblock, xblock-discussion, xblock-drag-and-drop-v2, xblock-google-drive, xblock-poll, xblock-utils


### PR DESCRIPTION
## Description

Previous version was 2.2.10.

Pulls in fix to deprecated import path, which
will soon be unsupported.

Incidentally pulls in:
* Make drag-and-drop indexable.
* Drop Python 2 support from drag-and-drop-v2.

Diff: https://github.com/edx-solutions/xblock-drag-and-drop-v2/compare/v2.2.10...v2.3.2

## Supporting information

Related to the [import shims removal](https://github.com/edx/edx-platform/pull/25932).

## Deadline

Sooner's better than later; this blocks the disabling of the import shims on production.

