### PR TITLE
Rename some tasks to match new import paths

### DIFF
--- a/common/djangoapps/entitlements/tasks.py
+++ b/common/djangoapps/entitlements/tasks.py
@@ -19,11 +19,7 @@ LOGGER = get_task_logger(__name__)
 MAX_RETRIES = 11
 
 
-@shared_task(
-    bind=True,
-    ignore_result=True,
-    name='entitlements.expire_old_entitlements',
-)
+@shared_task(bind=True, ignore_result=True)
 @set_code_owner_attribute
 def expire_old_entitlements(self, start, end, logid='...'):
     """

--- a/common/djangoapps/student/tasks.py
+++ b/common/djangoapps/student/tasks.py
@@ -20,9 +20,13 @@ from openedx.core.lib.celery.task_utils import emulate_http_request
 log = logging.getLogger('edx.celery.task')
 
 
-@shared_task(bind=True, name='student.send_activation_email')
+# This is a task function that is in the process of being renamed.
+# In order to avoid dropping tasks during deployment, we have to register it twice,
+# once under each name. This allows us to cut from one name to the other safely.
+# Once we have fully switched to the new name, we can go back to registering
+# this task function with a simple decorator.
 @set_code_owner_attribute
-def send_activation_email(self, msg_string, from_address=None):
+def _send_activation_email(self, msg_string, from_address=None):
     """
     Sending an activation email to the user.
     """
@@ -67,3 +71,15 @@ def send_activation_email(self, msg_string, from_address=None):
             dest_addr,
         )
         raise Exception
+
+
+_OLD_TASK_NAME = 'student.send_activation_email'
+_NEW_TASK_NAME = 'common.djangoapps.student.tasks.send_activation_email'
+
+
+# Register task under both its old and new names,
+# but expose only the old-named task for invocation.
+# -> Next step: Once we deploy and teach Celery workers the new name,
+#    set `send_activation_email` to the new-named task.
+send_activation_email = shared_task(bind=True, name=_OLD_TASK_NAME)(_send_activation_email)
+shared_task(bind=True, name=_NEW_TASK_NAME)(_send_activation_email)

--- a/common/djangoapps/third_party_auth/tasks.py
+++ b/common/djangoapps/third_party_auth/tasks.py
@@ -31,7 +31,7 @@ class MetadataParseError(Exception):
     pass
 
 
-@shared_task(name='third_party_auth.fetch_saml_metadata')
+@shared_task
 @set_code_owner_attribute
 def fetch_saml_metadata():
     """


### PR DESCRIPTION
## Description

From the commit message:
```
Several tasks are explicitly named as (or like)
their old, deprecated import path.

The issue here is that django-user-tasks listens for task
invocations, and attempts to import the task based on its name.
If the task name is completely wrong, user-tasks will catch
the ImportError and move on.
If the task is a valid *deprecated* import, though, then
user-tasks will choke on the raised `DeprecatedEdxPlatformImportError`.

Thus, we must rename three tasks to their new full path:
1. entitlements.expire_old_enrollments
2. third_party_auth.fetch_saml_metadata
3. student.send_activation_email

The first two are run daily, and so are safe to be
renamed in place.

The third task must be renamed using an expand-contract
pattern; otherwise, we would drop hundreds of tasks
during the App vs. Worker out-of-sync version window
that happens at deployments.
This commit is the expand phase.
```

Two PRs will follow this:
* After at least one deployment, switch to using the `common.djangoapps.student.tasks.send_activation_email` task instead of `student.send_activation_email`. (https://github.com/edx/edx-platform/pull/26328)
* After one more deployment, stop registering the name `student.send_activation_email` at all. Just have a simple `@shared_task(bind=True)` decorator on top of `def send_activation_email(...)`. (https://github.com/edx/edx-platform/pull/26320)

## Supporting information

_This is related to the [import shims removal](https://github.com/edx/edx-platform/pull/25932)_ See that PR for more context.

## Testing instructions

Check registered tasks. Note that we expect the email task to be registered twice (once under its old name, once under its new name), and the other two tasks each registered once (under their new names)
```
> make lms-shell
>> ./manage.py lms shell
>>> from lms.celery import APP
>>> print(*(
        task for task in APP.tasks if task.split('.')[-1] in {
            'send_activation_email', 'expire_old_entitlements', 'fetch_saml_metadata'
        }
    ), sep="\n")
# Expected:
#   common.djangoapps.entitlements.tasks.expire_old_entitlements
#   student.send_activation_email
#   common.djangoapps.student.tasks.send_activation_email
#   common.djangoapps.third_party_auth.tasks.fetch_saml_metadata
```

## Deadline

Not today (Friday 1/29). I will not be around to monitor it properly.

However, I'd like to merge early next week, ideally, in order to cut down on the `DeprecatedEdxPlatformImportErrors` on stage and the `DeprecatedEdxPlatformImportWarnings on prod. This will help me observe and pinpoint any remaining old import usages more easily.

## Other Information

This PR is an alternate approach to the fix proposed here: https://github.com/edx/edx-platform/pull/26195

I believe this PR is a better approach because:
* By keeping `DeprecatedEdxPlatformImportError` disjoint from `ImportError`, we maintain our ability to watch for `try: import X ; except ImportError: X = None`, where X is a deprecated import path. This pattern is prevalent in edx-platform package repositories, and was the main source of deprecated imports after the initial clean-up of edx-platform was complete.
* If we choose to leave this infrastructure in place for Lilac, then benefit described above will apply to the community as well.
* It's best to have these task names consistent with the rest of those in the platform, anyway.

It is worth noting that the breakage in django-user-tasks doesn't actually seem to break the `send_activation_email` task at least. I was able to create a new account on Stage and activate that account, even though I observed it raise a `DeprecatedEdxPlatformImportError` in Splunk.