### PR TITLE
[TNL-7729] - Add check to discussion endpoints to secure API when discussions are blacked out.

### DIFF
--- a/lms/djangoapps/discussion/rest_api/exceptions.py
+++ b/lms/djangoapps/discussion/rest_api/exceptions.py
@@ -2,6 +2,7 @@
 
 
 from django.core.exceptions import ObjectDoesNotExist
+from rest_framework.exceptions import APIException
 
 
 class DiscussionDisabledError(ObjectDoesNotExist):
@@ -17,3 +18,9 @@ class ThreadNotFoundError(ObjectDoesNotExist):
 class CommentNotFoundError(ObjectDoesNotExist):
     """ Comment was not found. """
     pass  # lint-amnesty, pylint: disable=unnecessary-pass
+
+
+class DiscussionBlackOutException(APIException):
+    """ Discussions are in blackout period. """
+    status_code = 403
+    default_detail = 'Discussions are in blackout period.'

--- a/lms/djangoapps/discussion/rest_api/tests/test_utils.py
+++ b/lms/djangoapps/discussion/rest_api/tests/test_utils.py
@@ -1,0 +1,43 @@
+"""
+Tests for Discussion REST API utils.
+"""
+
+from datetime import datetime, timedelta
+
+from pytz import UTC
+
+from common.djangoapps.student.tests.factories import UserFactory, CourseEnrollmentFactory
+from common.lib.xmodule.xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
+from lms.djangoapps.discussion.django_comment_client.tests.factories import RoleFactory
+from lms.djangoapps.discussion.rest_api.utils import discussion_open_for_user
+from xmodule.modulestore.tests.factories import CourseFactory
+
+
+class DiscussionAPIUtilsTestCase(ModuleStoreTestCase):
+    """
+    Base test-case class for utils for Discussion REST API.
+    """
+    CREATE_USER = False
+
+    def setUp(self):
+        super(DiscussionAPIUtilsTestCase, self).setUp()     # lint-amnesty, pylint: disable=super-with-arguments
+
+        self.course = CourseFactory.create()
+        self.course.discussion_blackouts = [datetime.now(UTC) - timedelta(days=3),
+                                            datetime.now(UTC) + timedelta(days=3)]
+        self.student_role = RoleFactory(name='Student', course_id=self.course.id)
+        self.moderator_role = RoleFactory(name='Moderator', course_id=self.course.id)
+        self.community_ta_role = RoleFactory(name='Community TA', course_id=self.course.id)
+        self.student = UserFactory(username='student', email='student@edx.org')
+        self.student_enrollment = CourseEnrollmentFactory(user=self.student)
+        self.student_role.users.add(self.student)
+        self.moderator = UserFactory(username='moderator', email='staff@edx.org', is_staff=True)
+        self.moderator_enrollment = CourseEnrollmentFactory(user=self.moderator)
+        self.moderator_role.users.add(self.moderator)
+        self.community_ta = UserFactory(username='community_ta1', email='community_ta1@edx.org')
+        self.community_ta_role.users.add(self.community_ta)
+
+    def test_discussion_open_for_user(self):
+        self.assertFalse(discussion_open_for_user(self.course, self.student))
+        self.assertTrue(discussion_open_for_user(self.course, self.moderator))
+        self.assertTrue(discussion_open_for_user(self.course, self.community_ta))

--- a/lms/djangoapps/discussion/rest_api/utils.py
+++ b/lms/djangoapps/discussion/rest_api/utils.py
@@ -1,0 +1,16 @@
+"""
+Utils for discussion API.
+"""
+
+from lms.djangoapps.discussion.django_comment_client.utils import has_discussion_privileges
+
+
+def discussion_open_for_user(course, user):
+    """
+    Check if course discussion are open or not for user.
+
+    Arguments:
+            course: Course to check discussions for
+            user: User to check for privileges in course
+    """
+    return course.forum_posts_allowed or has_discussion_privileges(user, course.id)


### PR DESCRIPTION
### [TNL-7729](https://openedx.atlassian.net/browse/TNL-7729)

### Description

We are using the post API `/api/discussion/v1/threads/` to create a new post. The LMS is accepting the request and sending back success in the blackout duration instead of sending an error. This should be fixed on the LMS side, that irrespective of the client LMS should not create a new thread in blackout duration and returns an error.

A security concern here is that users can use the APIs directly to post new discussions, add responses or comments even in the blackout period.

Discussion endpoints those should follow blackout period:
1.  `/api/discussion/v1/threads/`
2. `/api/discussion/v1/comments/`

