### PR TITLE
replaced unittest assertions pytest assertions (2)

### DIFF
--- a/openedx/core/djangoapps/auth_exchange/tests/mixins.py
+++ b/openedx/core/djangoapps/auth_exchange/tests/mixins.py
@@ -60,7 +60,7 @@ class DOTAdapterMixin(object):
         request.session = {}
         view = DOTAccessTokenExchangeView.as_view()
         response = view(request, backend='facebook')
-        self.assertEqual(response.status_code, 400)
+        assert response.status_code == 400
 
     @expectedFailure
     def test_single_access_token(self):

--- a/openedx/core/djangoapps/auth_exchange/tests/test_forms.py
+++ b/openedx/core/djangoapps/auth_exchange/tests/test_forms.py
@@ -39,17 +39,14 @@ class AccessTokenExchangeFormTest(AccessTokenExchangeTestMixin):
 
     def _assert_error(self, data, expected_error, expected_error_description):
         form = AccessTokenExchangeForm(request=self.request, oauth2_adapter=self.oauth2_adapter, data=data)
-        self.assertEqual(
-            form.errors,
-            {"error": expected_error, "error_description": expected_error_description}
-        )
+        assert form.errors == {'error': expected_error, 'error_description': expected_error_description}
 
     def _assert_success(self, data, expected_scopes):
         form = AccessTokenExchangeForm(request=self.request, oauth2_adapter=self.oauth2_adapter, data=data)
-        self.assertTrue(form.is_valid())
-        self.assertEqual(form.cleaned_data["user"], self.user)
-        self.assertEqual(form.cleaned_data["client"], self.oauth_client)
-        self.assertEqual(set(form.cleaned_data["scope"]), set(expected_scopes))
+        assert form.is_valid()
+        assert form.cleaned_data['user'] == self.user
+        assert form.cleaned_data['client'] == self.oauth_client
+        assert set(form.cleaned_data['scope']) == set(expected_scopes)
 
 
 # This is necessary because cms does not implement third party auth


### PR DESCRIPTION
## Description
This PR is using `codemod-unittest-to-pytest-asserts` to automatically replace `unittest` assertions with `pytest` 
for following module:
```
openedx/core/djangoapps/auth_exchange
```
assertions. I've used one of the forks (PR with changes: https://github.com/mraarif/codemod-unittest-to-pytest-asserts/pull/1) of this codemod that handles a few scenarios that seem to be missing in the upstream repo.
Relevant JIRA issue here: https://openedx.atlassian.net/browse/BOM-2291