### PR TITLE
BOM-2269 & BOM-2276 - Add Pylint amnesty for Bulk Enroll and Course Blocks,Goals and Home API

### DIFF
--- a/lms/djangoapps/bulk_enroll/serializers.py
+++ b/lms/djangoapps/bulk_enroll/serializers.py
@@ -11,7 +11,7 @@ from six.moves import zip
 from openedx.core.djangoapps.course_groups.cohorts import is_cohort_exists
 
 
-class StringListField(serializers.ListField):
+class StringListField(serializers.ListField):  # lint-amnesty, pylint: disable=missing-class-docstring
     def to_internal_value(self, data):
         if not data:
             return []
@@ -20,7 +20,7 @@ class StringListField(serializers.ListField):
         return data.split(',')
 
 
-class BulkEnrollmentSerializer(serializers.Serializer):
+class BulkEnrollmentSerializer(serializers.Serializer):  # lint-amnesty, pylint: disable=abstract-method
     """Serializes enrollment information for a collection of students/emails.
 
     This is mainly useful for implementing validation when performing bulk enrollment operations.
@@ -47,7 +47,7 @@ class BulkEnrollmentSerializer(serializers.Serializer):
             try:
                 CourseKey.from_string(course)
             except InvalidKeyError:
-                raise serializers.ValidationError(u"Course key not valid: {}".format(course))
+                raise serializers.ValidationError(u"Course key not valid: {}".format(course))  # lint-amnesty, pylint: disable=raise-missing-from
         return value
 
     def validate(self, attrs):

--- a/lms/djangoapps/bulk_enroll/tests/test_views.py
+++ b/lms/djangoapps/bulk_enroll/tests/test_views.py
@@ -8,7 +8,7 @@ import json
 import ddt
 import six
 from django.conf import settings
-from django.contrib.auth.models import User
+from django.contrib.auth.models import User  # lint-amnesty, pylint: disable=imported-auth-user
 from django.core import mail
 from django.test.utils import override_settings
 from django.urls import reverse
@@ -21,7 +21,7 @@ from lms.djangoapps.courseware.tests.helpers import LoginEnrollmentTestCase
 from openedx.core.djangoapps.course_groups.cohorts import get_cohort_id
 from openedx.core.djangoapps.course_groups.tests.helpers import config_course_cohorts
 from openedx.core.djangoapps.site_configuration.helpers import get_value as get_site_value
-from common.djangoapps.student.models import ENROLLED_TO_UNENROLLED, UNENROLLED_TO_ENROLLED, CourseEnrollment, ManualEnrollmentAudit
+from common.djangoapps.student.models import ENROLLED_TO_UNENROLLED, UNENROLLED_TO_ENROLLED, CourseEnrollment, ManualEnrollmentAudit  # lint-amnesty, pylint: disable=line-too-long
 from common.djangoapps.student.tests.factories import UserFactory
 from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
 from xmodule.modulestore.tests.factories import CourseFactory
@@ -40,7 +40,7 @@ class BulkEnrollmentTest(ModuleStoreTestCase, LoginEnrollmentTestCase, APITestCa
 
     def setUp(self):
         """ Create a course and user, then log in. """
-        super(BulkEnrollmentTest, self).setUp()
+        super(BulkEnrollmentTest, self).setUp()  # lint-amnesty, pylint: disable=super-with-arguments
 
         self.view = BulkEnrollView.as_view()
         self.request_factory = APIRequestFactory()

--- a/lms/djangoapps/bulk_enroll/views.py
+++ b/lms/djangoapps/bulk_enroll/views.py
@@ -72,9 +72,9 @@ class BulkEnrollView(APIView):
     permission_classes = (IsStaff,)
     throttle_classes = (EnrollmentUserThrottle,)
 
-    def post(self, request):
+    def post(self, request):  # lint-amnesty, pylint: disable=missing-function-docstring
         serializer = BulkEnrollmentSerializer(data=request.data)
-        if serializer.is_valid():
+        if serializer.is_valid():  # lint-amnesty, pylint: disable=too-many-nested-blocks
             # Setting the content type to be form data makes Django Rest Framework v3.6.3 treat all passed JSON data as
             # POST parameters. This is necessary because this request is forwarded on to the student_update_enrollment
             # view, which requires all of the parameters to be passed in via POST parameters.

--- a/lms/djangoapps/course_blocks/__init__.py
+++ b/lms/djangoapps/course_blocks/__init__.py
@@ -1,4 +1,4 @@
-"""
+"""  # lint-amnesty, pylint: disable=django-not-configured
 The Course Blocks app, built upon the Block Cache framework in
 openedx.core.djangoapps.content.block_structure, is a higher layer django app in LMS that
 provides additional context of Courses and Users (via usage_info.py) with

--- a/lms/djangoapps/course_blocks/transformers/tests/helpers.py
+++ b/lms/djangoapps/course_blocks/transformers/tests/helpers.py
@@ -26,7 +26,7 @@ class TransformerRegistryTestMixin(object):
     TRANSFORMER_CLASS_TO_TEST as a registered transformer.
     """
     def setUp(self):
-        super(TransformerRegistryTestMixin, self).setUp()
+        super(TransformerRegistryTestMixin, self).setUp()  # lint-amnesty, pylint: disable=super-with-arguments
         self.patcher = patch(
             'openedx.core.djangoapps.content.block_structure.transformer_registry.'
             'TransformerRegistry.get_registered_transformers'
@@ -48,7 +48,7 @@ class CourseStructureTestCase(TransformerRegistryTestMixin, ModuleStoreTestCase)
         """
         Create users.
         """
-        super(CourseStructureTestCase, self).setUp()
+        super(CourseStructureTestCase, self).setUp()  # lint-amnesty, pylint: disable=super-with-arguments
         # Set up users.
         self.password = 'test'
         self.user = UserFactory.create(password=self.password)
@@ -199,7 +199,7 @@ class CourseStructureTestCase(TransformerRegistryTestMixin, ModuleStoreTestCase)
         Returns: set[UsageKey]
         """
         xblocks = (blocks[ref] for ref in refs)
-        return set([xblock.location for xblock in xblocks])
+        return set([xblock.location for xblock in xblocks])  # lint-amnesty, pylint: disable=consider-using-set-comprehension
 
 
 class BlockParentsMapTestCase(TransformerRegistryTestMixin, ModuleStoreTestCase):
@@ -221,7 +221,7 @@ class BlockParentsMapTestCase(TransformerRegistryTestMixin, ModuleStoreTestCase)
     parents_map = [[], [0], [0], [1], [1], [2], [2, 4]]
 
     def setUp(self):
-        super(BlockParentsMapTestCase, self).setUp()
+        super(BlockParentsMapTestCase, self).setUp()  # lint-amnesty, pylint: disable=super-with-arguments
 
         # create the course
         self.course = CourseFactory.create()

--- a/lms/djangoapps/course_blocks/transformers/tests/test_library_content.py
+++ b/lms/djangoapps/course_blocks/transformers/tests/test_library_content.py
@@ -36,7 +36,7 @@ class ContentLibraryTransformerTestCase(CourseStructureTestCase):
         """
         Setup course structure and create user for content library transformer test.
         """
-        super(ContentLibraryTransformerTestCase, self).setUp()
+        super(ContentLibraryTransformerTestCase, self).setUp()  # lint-amnesty, pylint: disable=super-with-arguments
 
         # Build course.
         self.course_hierarchy = self.get_course_hierarchy()
@@ -180,7 +180,7 @@ class ContentLibraryOrderTransformerTestCase(CourseStructureTestCase):
         """
         Setup course structure and create user for content library order transformer test.
         """
-        super(ContentLibraryOrderTransformerTestCase, self).setUp()
+        super(ContentLibraryOrderTransformerTestCase, self).setUp()  # lint-amnesty, pylint: disable=super-with-arguments
         self.course_hierarchy = self.get_course_hierarchy()
         self.blocks = self.build_course(self.course_hierarchy)
         self.course = self.blocks['course']

--- a/lms/djangoapps/course_blocks/transformers/tests/test_load_override_data.py
+++ b/lms/djangoapps/course_blocks/transformers/tests/test_load_override_data.py
@@ -40,7 +40,7 @@ class TestOverrideDataTransformer(ModuleStoreTestCase):
         cls.learner2 = UserFactory.create()
 
     def setUp(self):
-        super(TestOverrideDataTransformer, self).setUp()
+        super(TestOverrideDataTransformer, self).setUp()  # lint-amnesty, pylint: disable=super-with-arguments
         self.course_key = ToyCourseFactory.create().id
         self.course_usage_key = self.store.make_course_usage_key(self.course_key)
         self.block_structure = BlockStructureFactory.create_from_modulestore(self.course_usage_key, self.store)

--- a/lms/djangoapps/course_blocks/transformers/tests/test_split_test.py
+++ b/lms/djangoapps/course_blocks/transformers/tests/test_split_test.py
@@ -29,7 +29,7 @@ class SplitTestTransformerTestCase(CourseStructureTestCase):
         """
         Setup course structure and create user for split test transformer test.
         """
-        super(SplitTestTransformerTestCase, self).setUp()
+        super(SplitTestTransformerTestCase, self).setUp()  # lint-amnesty, pylint: disable=super-with-arguments
 
         # Set up user partitions and groups.
         self.groups = [Group(0, 'Group 0'), Group(1, 'Group 1'), Group(2, 'Group 2')]

--- a/lms/djangoapps/course_blocks/transformers/tests/test_start_date.py
+++ b/lms/djangoapps/course_blocks/transformers/tests/test_start_date.py
@@ -50,7 +50,7 @@ class StartDateTransformerTestCase(BlockParentsMapTestCase):
                 return DEFAULT_START_DATE
 
     def setUp(self):
-        super(StartDateTransformerTestCase, self).setUp()
+        super(StartDateTransformerTestCase, self).setUp()  # lint-amnesty, pylint: disable=super-with-arguments
         self.beta_user = BetaTesterFactory(course_key=self.course.id, username='beta_tester', password=self.password)
         course = self.get_block(0)
         course.days_early_for_beta = 33

--- a/lms/djangoapps/course_blocks/transformers/tests/test_user_partitions.py
+++ b/lms/djangoapps/course_blocks/transformers/tests/test_user_partitions.py
@@ -287,7 +287,7 @@ class MergedGroupAccessTestData(UserPartitionTestMixin, CourseStructureTestCase)
         Setup course structure and create user for user partition
         transformer test.
         """
-        super(MergedGroupAccessTestData, self).setUp()
+        super(MergedGroupAccessTestData, self).setUp()  # lint-amnesty, pylint: disable=super-with-arguments
 
         # Set up multiple user partitions and groups.
         self.setup_groups_partitions(num_user_partitions=3)

--- a/lms/djangoapps/course_blocks/transformers/user_partitions.py
+++ b/lms/djangoapps/course_blocks/transformers/user_partitions.py
@@ -3,10 +3,10 @@ User Partitions Transformer
 """
 
 
-import six
+import six  # lint-amnesty, pylint: disable=unused-import
 
 from lms.djangoapps.courseware.access import has_access
-from openedx.core.djangoapps.content.block_structure.transformer import (
+from openedx.core.djangoapps.content.block_structure.transformer import (  # lint-amnesty, pylint: disable=unused-import
     BlockStructureTransformer,
     FilteringTransformerMixin
 )

--- a/lms/djangoapps/course_goals/api.py
+++ b/lms/djangoapps/course_goals/api.py
@@ -85,7 +85,7 @@ def get_course_goal_options():
     Returns the valid options for goal keys, mapped to their translated
     strings, as defined by theCourseGoal model.
     """
-    return {goal_key: goal_text for goal_key, goal_text in models.GOAL_KEY_CHOICES}
+    return {goal_key: goal_text for goal_key, goal_text in models.GOAL_KEY_CHOICES}  # lint-amnesty, pylint: disable=unnecessary-comprehension
 
 
 def get_course_goal_text(goal_key):

--- a/lms/djangoapps/course_goals/handlers.py
+++ b/lms/djangoapps/course_goals/handlers.py
@@ -7,7 +7,7 @@ import six
 from django.db import models
 from django.dispatch import receiver
 
-import six
+import six  # lint-amnesty, pylint: disable=reimported
 from common.djangoapps.course_modes.models import CourseMode
 from common.djangoapps.student.models import CourseEnrollment
 

--- a/lms/djangoapps/course_goals/models.py
+++ b/lms/djangoapps/course_goals/models.py
@@ -3,7 +3,7 @@ Course Goals Models
 """
 
 
-from django.contrib.auth.models import User
+from django.contrib.auth.models import User  # lint-amnesty, pylint: disable=imported-auth-user
 from django.db import models
 from django.utils.encoding import python_2_unicode_compatible
 from django.utils.translation import ugettext_lazy as _

--- a/lms/djangoapps/course_goals/tests/test_api.py
+++ b/lms/djangoapps/course_goals/tests/test_api.py
@@ -4,7 +4,7 @@ Unit tests for course_goals.api methods.
 
 
 import mock
-from django.contrib.auth.models import User
+from django.contrib.auth.models import User  # lint-amnesty, pylint: disable=imported-auth-user
 from django.test.utils import override_settings
 from django.urls import reverse
 from rest_framework.test import APIClient
@@ -27,7 +27,7 @@ class TestCourseGoalsAPI(EventTrackingTestCase, SharedModuleStoreTestCase):
 
     def setUp(self):
         # Create a course with a verified track
-        super(TestCourseGoalsAPI, self).setUp()
+        super(TestCourseGoalsAPI, self).setUp()  # lint-amnesty, pylint: disable=super-with-arguments
         self.course = CourseFactory.create(emit_signals=True)
 
         self.user = User.objects.create_user('john', 'lennon@thebeatles.com', 'password')

--- a/lms/djangoapps/course_goals/views.py
+++ b/lms/djangoapps/course_goals/views.py
@@ -58,7 +58,7 @@ class CourseGoalViewSet(viewsets.ModelViewSet):
     serializer_class = CourseGoalSerializer
 
     # Another version of this endpoint exists in ../course_home_api/outline/v1/views.py
-    def create(self, post_data):
+    def create(self, post_data):  # lint-amnesty, pylint: disable=arguments-differ
         """ Create a new goal if one does not exist, otherwise update the existing goal. """
         # Ensure goal_key is valid
         goal_options = get_course_goal_options()
@@ -105,11 +105,11 @@ class CourseGoalViewSet(viewsets.ModelViewSet):
             'goal_text': str(goal_options[goal_key]),
             'is_unsure': goal_key == GOAL_KEY_CHOICES.unsure,
         }
-        return JsonResponse(data, content_type="application/json", status=(200 if goal else 201))
+        return JsonResponse(data, content_type="application/json", status=(200 if goal else 201))  # lint-amnesty, pylint: disable=redundant-content-type-for-json-response
 
 
 @receiver(post_save, sender=CourseGoal, dispatch_uid="emit_course_goals_event")
-def emit_course_goal_event(sender, instance, **kwargs):
+def emit_course_goal_event(sender, instance, **kwargs):  # lint-amnesty, pylint: disable=unused-argument
     """Emit events for both tracking logs and for Segment."""
     name = 'edx.course.goal.added' if kwargs.get('created', False) else 'edx.course.goal.updated'
     tracker.emit(

--- a/lms/djangoapps/course_home_api/dates/v1/tests/test_views.py
+++ b/lms/djangoapps/course_home_api/dates/v1/tests/test_views.py
@@ -8,7 +8,7 @@ import ddt
 from django.urls import reverse
 
 from common.djangoapps.course_modes.models import CourseMode
-from edx_toggles.toggles.testutils import override_waffle_flag
+from edx_toggles.toggles.testutils import override_waffle_flag  # lint-amnesty, pylint: disable=wrong-import-order
 from lms.djangoapps.course_home_api.tests.utils import BaseCourseHomeTests
 from lms.djangoapps.course_home_api.toggles import COURSE_HOME_MICROFRONTEND, COURSE_HOME_MICROFRONTEND_DATES_TAB
 from lms.djangoapps.experiments.testutils import override_experiment_waffle_flag

--- a/lms/djangoapps/course_home_api/tests/utils.py
+++ b/lms/djangoapps/course_home_api/tests/utils.py
@@ -12,7 +12,7 @@ from common.djangoapps.course_modes.tests.factories import CourseModeFactory
 from lms.djangoapps.courseware.tests.helpers import MasqueradeMixin
 from lms.djangoapps.verify_student.models import VerificationDeadline
 from openedx.core.djangoapps.content.course_overviews.tests.factories import CourseOverviewFactory
-from xmodule.modulestore.tests.django_utils import TEST_DATA_SPLIT_MODULESTORE, ModuleStoreTestCase
+from xmodule.modulestore.tests.django_utils import TEST_DATA_SPLIT_MODULESTORE, ModuleStoreTestCase  # lint-amnesty, pylint: disable=unused-import
 from xmodule.modulestore.tests.factories import CourseFactory, ItemFactory
 
 


### PR DESCRIPTION
In this PR we are adding pylint amnesty for existing warnings and failures in bul_enroll, course_blocks, and home_api apps.

Relevant JIRAs :
https://openedx.atlassian.net/browse/BOM-2269
https://openedx.atlassian.net/browse/BOM-2276