### PR TITLE
[TSD] Adding FEATURES[‘ENABLE_EDXNOTES’] annotations

### DIFF
--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -225,9 +225,7 @@ FEATURES = {
     # Turn off Video Upload Pipeline through Studio, by default
     'ENABLE_VIDEO_UPLOAD_PIPELINE': False,
 
-    # let students save and manage their annotations
-    # for consistency in user-experience, keep the value of this feature flag
-    # in sync with the one in lms/envs/common.py
+    # See annotations in lms/envs/common.py for details.
     'ENABLE_EDXNOTES': False,
 
     # Toggle to enable coordination with the Publisher tool (keep in sync with lms/envs/common.py)

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -434,6 +434,17 @@ FEATURES = {
     'ENABLE_FOOTER_MOBILE_APP_LINKS': False,
 
     # Let students save and manage their annotations
+    # .. toggle_name: FEATURES['ENABLE_EDXNOTES']
+    # .. toggle_implementation: SettingToggle
+    # .. toggle_default: False
+    # .. toggle_description: This toggle enables the students to save and manage their annotations in the
+    #   course using the notes service. The bulk of the actual work in storing the notes is done by
+    #   a separate service (see the edx-notes-api repo).
+    # .. toggle_warnings: Requires the edx-notes-api service properly running and to have configured the django settings
+    #   EDXNOTES_INTERNAL_API and EDXNOTES_PUBLIC_API. If you update this setting, also update it in Studio.
+    # .. toggle_use_cases: open_edx
+    # .. toggle_creation_date: 2015-01-04
+    # .. toggle_tickets: https://github.com/edx/edx-platform/pull/6321
     'ENABLE_EDXNOTES': False,
 
     # Toggle to enable coordination with the Publisher tool (keep in sync with cms/envs/common.py)


### PR DESCRIPTION
## Description

Add FEATURES[‘ENABLE_EDXNOTES’] documentation has the purpose to give some information about annotations
related to that feature toggle. This documentation does not affect the behavior of the feature and only has
useful information for the edX community.

## Reference:

https://openedx.atlassian.net/wiki/spaces/OpenOPS/pages/26182212/How+to+Get+edX+Notes+Running
https://blog.lawrencemcdaniel.com/open-edx-notes/

## Supporting information

This is part of the doc-a-thon efforts.

## Testing instructions

It does not apply

## Deadline

None
