### PR TITLE
MICROBA-934 Trigger allowlist certificate generation from signals

### DIFF
--- a/lms/djangoapps/certificates/tasks.py
+++ b/lms/djangoapps/certificates/tasks.py
@@ -2,7 +2,6 @@
 Tasks that generate a course certificate for a user
 """
 
-
 from logging import getLogger
 
 from celery import shared_task
@@ -16,6 +15,7 @@ from lms.djangoapps.certificates.generation import generate_allowlist_certificat
 from lms.djangoapps.verify_student.services import IDVerificationService
 
 logger = getLogger(__name__)
+CERTIFICATE_DELAY_SECONDS = 2
 
 
 @shared_task(base=LoggedPersistOnFailureTask, bind=True, default_retry_delay=30, max_retries=2)

--- a/lms/djangoapps/certificates/tests/test_generation_handler.py
+++ b/lms/djangoapps/certificates/tests/test_generation_handler.py
@@ -14,12 +14,19 @@ from xmodule.modulestore.tests.factories import CourseFactory
 
 from common.djangoapps.student.tests.factories import CourseEnrollmentFactory, UserFactory
 from lms.djangoapps.certificates.generation_handler import CERTIFICATES_USE_ALLOWLIST
-from lms.djangoapps.certificates.generation_handler import _is_using_certificate_allowlist, \
-    _can_generate_allowlist_certificate_for_status, generate_allowlist_certificate_task, \
-    can_generate_allowlist_certificate
+from lms.djangoapps.certificates.generation_handler import (
+    _can_generate_allowlist_certificate_for_status,
+    _is_using_certificate_allowlist,
+    can_generate_allowlist_certificate,
+    generate_allowlist_certificate_task,
+    is_using_certificate_allowlist_and_is_on_allowlist
+)
 from lms.djangoapps.certificates.models import GeneratedCertificate, CertificateStatuses
-from lms.djangoapps.certificates.tests.factories import CertificateWhitelistFactory, GeneratedCertificateFactory, \
+from lms.djangoapps.certificates.tests.factories import (
+    CertificateWhitelistFactory,
+    GeneratedCertificateFactory,
     CertificateInvalidationFactory
+)
 from openedx.core.djangoapps.certificates.config import waffle
 
 log = logging.getLogger(__name__)
@@ -69,6 +76,33 @@ class AllowlistTests(ModuleStoreTestCase):
         Test the allowlist flag without the override
         """
         self.assertFalse(_is_using_certificate_allowlist(self.course_run_key))
+
+    def test_is_using_allowlist_and_is_on_list(self):
+        """
+        Test the allowlist flag and the presence of the user on the list
+        """
+        self.assertTrue(is_using_certificate_allowlist_and_is_on_allowlist(self.user, self.course_run_key))
+
+    @override_waffle_flag(CERTIFICATES_USE_ALLOWLIST, active=False)
+    def test_is_using_allowlist_and_is_on_list_with_flag_off(self):
+        """
+        Test the allowlist flag and the presence of the user on the list when the flag is off
+        """
+        self.assertFalse(is_using_certificate_allowlist_and_is_on_allowlist(self.user, self.course_run_key))
+
+    def test_is_using_allowlist_and_is_on_list_true(self):
+        """
+        Test the allowlist flag and the presence of the user on the list when the user is not on the list
+        """
+        u = UserFactory()
+        CourseEnrollmentFactory(
+            user=u,
+            course_id=self.course_run_key,
+            is_active=True,
+            mode="verified",
+        )
+        CertificateWhitelistFactory.create(course_id=self.course_run_key, user=u, whitelist=False)
+        self.assertFalse(is_using_certificate_allowlist_and_is_on_allowlist(u, self.course_run_key))
 
     @ddt.data(
         (CertificateStatuses.deleted, True),

--- a/lms/djangoapps/certificates/tests/test_signals.py
+++ b/lms/djangoapps/certificates/tests/test_signals.py
@@ -8,19 +8,22 @@ import ddt
 import mock
 import six
 from edx_toggles.toggles import LegacyWaffleSwitch
+from edx_toggles.toggles.testutils import override_waffle_flag
 from edx_toggles.toggles.testutils import override_waffle_switch
-from common.djangoapps.student.tests.factories import CourseEnrollmentFactory, UserFactory
 from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
 from xmodule.modulestore.tests.factories import CourseFactory
 
+from common.djangoapps.student.tests.factories import CourseEnrollmentFactory, UserFactory
 from lms.djangoapps.certificates import api as certs_api
+from lms.djangoapps.certificates.generation_handler import CERTIFICATES_USE_ALLOWLIST
 from lms.djangoapps.certificates.models import (
     CertificateGenerationConfiguration,
     CertificateStatuses,
     CertificateWhitelist,
     GeneratedCertificate
 )
-from lms.djangoapps.certificates.signals import CERTIFICATE_DELAY_SECONDS, fire_ungenerated_certificate_task
+from lms.djangoapps.certificates.signals import fire_ungenerated_certificate_task
+from lms.djangoapps.certificates.tasks import CERTIFICATE_DELAY_SECONDS
 from lms.djangoapps.grades.course_grade_factory import CourseGradeFactory
 from lms.djangoapps.grades.tests.utils import mock_passing_grade
 from lms.djangoapps.verify_student.models import IDVerificationAttempt, SoftwareSecurePhotoVerification
@@ -134,6 +137,57 @@ class WhitelistGeneratedCertificatesTest(ModuleStoreTestCase):
                         'course_key': six.text_type(self.ip_course.id),
                     }
                 )
+
+    @override_waffle_flag(CERTIFICATES_USE_ALLOWLIST, active=True)
+    def test_fire_task_allowlist_enabled(self):
+        """
+        Test that the allowlist generation is invoked if the allowlist is enabled for a user on the list
+        """
+        with mock.patch(
+            'lms.djangoapps.certificates.signals.generate_certificate.apply_async',
+            return_value=None
+        ) as mock_generate_certificate_apply_async:
+            with mock.patch(
+                'lms.djangoapps.certificates.signals.generate_allowlist_certificate_task',
+                return_value=None
+            ) as mock_generate_allowlist_task:
+                CertificateWhitelist.objects.create(
+                    user=self.user,
+                    course_id=self.ip_course.id,
+                    whitelist=True
+                )
+
+                fire_ungenerated_certificate_task(self.user, self.ip_course.id)
+                mock_generate_certificate_apply_async.assert_not_called()
+                mock_generate_allowlist_task.assert_called_with(self.user, self.ip_course.id)
+
+    def test_fire_task_allowlist_disabled(self):
+        """
+        Test that the normal logic is followed if the allowlist is disabled for a user on the list
+        """
+        with mock.patch(
+            'lms.djangoapps.certificates.signals.generate_certificate.apply_async',
+            return_value=None
+        ) as mock_generate_certificate_apply_async:
+            with mock.patch(
+                'lms.djangoapps.certificates.signals.generate_allowlist_certificate_task',
+                return_value=None
+            ) as mock_generate_allowlist_task:
+                CertificateWhitelist.objects.create(
+                    user=self.user,
+                    course_id=self.ip_course.id,
+                    whitelist=True
+                )
+
+                fire_ungenerated_certificate_task(self.user, self.ip_course.id)
+                mock_generate_certificate_apply_async.assert_called_with(
+                    countdown=CERTIFICATE_DELAY_SECONDS,
+                    kwargs={
+                        'student': six.text_type(self.user.id),
+                        'course_key': six.text_type(self.ip_course.id),
+                    }
+                )
+                mock_generate_allowlist_task.assert_not_called()
 
 
 class PassingGradeCertsTest(ModuleStoreTestCase):


### PR DESCRIPTION
Trigger allowlist certificate generation from signals. 

The _CERTIFICATE_DELAY_SECONDS_ constant was moved to fix a circular import issue.