### PR TITLE
Bug fix for content library import+export management commands 

### DIFF
--- a/cms/djangoapps/contentstore/management/commands/export_content_library.py
+++ b/cms/djangoapps/contentstore/management/commands/export_content_library.py
@@ -61,6 +61,6 @@ class Command(BaseCommand):
                 filename = prefix + suffix
                 target = os.path.join(dest_path, filename)
                 tarball.file.seek(0)
-                with open(target, 'w') as f:
+                with open(target, 'wb') as f:
                     shutil.copyfileobj(tarball.file, f)
                 print(u'Library "{0}" exported to "{1}"'.format(library.location.library_key, target))

--- a/cms/djangoapps/contentstore/management/commands/import_content_library.py
+++ b/cms/djangoapps/contentstore/management/commands/import_content_library.py
@@ -44,13 +44,13 @@ class Command(BaseCommand):
         username = options['owner_username']
 
         data_root = Path(settings.GITHUB_REPO_ROOT)
-        subdir = base64.urlsafe_b64encode(os.path.basename(archive_path))
+        subdir = base64.urlsafe_b64encode(os.path.basename(archive_path).encode('utf-8')).decode('utf-8')
         course_dir = data_root / subdir
 
         # Extract library archive
         tar_file = tarfile.open(archive_path)
         try:
-            safetar_extractall(tar_file, course_dir.encode('utf-8'))
+            safetar_extractall(tar_file, course_dir)
         except SuspiciousOperation as exc:
             raise CommandError(u'\n=== Course import {0}: Unsafe tar file - {1}\n'.format(archive_path, exc.args[0]))
         finally:


### PR DESCRIPTION
### Description
This PR fixes buggy Studio management commands:
* `export_content_library` 
* `import_content_library`

### Background
1. ` export_content_library` command has a file encoding issue. It has been fixed by opening file in binary mode.
2. `import_content_library` command has a string path encoding issue. It has been fixed by using `.encode()` and `decode()` in the right places.

**Studio Updates:** The commands above are working normally

**LMS Updates:** None

### Testing:
Run commands on an existing library with id `<library_id>`. Save it in `/tmp` and import it using `staff` user as owner:
```
./manage.py cms export_content_library <library_id> /tmp
./manage.py cms export_content_library /tmp/<library_id>.tar.gz staff
```