### PR TITLE
AA-492: Adds research tracking event for reset deadlines

### DIFF
--- a/openedx/features/course_experience/api/v1/views.py
+++ b/openedx/features/course_experience/api/v1/views.py
@@ -7,6 +7,7 @@ from django.conf import settings
 from django.urls import reverse
 from django.utils.html import format_html
 from django.utils.translation import ugettext as _
+from eventtracking import tracker
 
 from rest_framework.decorators import api_view, authentication_classes, permission_classes
 from rest_framework.exceptions import APIException, ParseError
@@ -18,11 +19,12 @@ from edx_rest_framework_extensions.auth.jwt.authentication import JwtAuthenticat
 from edx_rest_framework_extensions.auth.session.authentication import SessionAuthenticationAllowInactiveUser
 from opaque_keys.edx.keys import CourseKey
 
+from lms.djangoapps.course_api.api import course_detail
 from lms.djangoapps.course_home_api.toggles import course_home_mfe_dates_tab_is_active
 from lms.djangoapps.course_home_api.utils import get_microfrontend_url
 from lms.djangoapps.courseware.access import has_access
 from lms.djangoapps.courseware.courses import get_course_with_access
-from lms.djangoapps.courseware.masquerade import setup_masquerade
+from lms.djangoapps.courseware.masquerade import is_masquerading, setup_masquerade
 
 from openedx.core.djangoapps.schedules.utils import reset_self_paced_schedule
 from openedx.core.lib.api.authentication import BearerAuthenticationAllowInactiveUser
@@ -48,22 +50,24 @@ def reset_course_deadlines(request):
     Set the start_date of a schedule to today, which in turn will adjust due dates for
     sequentials belonging to a self paced course
 
+    Request Parameters:
+        course_key: course key
+        research_event_data: any data that should be included in the research tracking event
+            Example: sending the location of where the reset deadlines banner (i.e. outline-tab)
+
     IMPORTANT NOTE: If updates are happening to the logic here, ALSO UPDATE the `reset_course_deadlines`
     function in common/djangoapps/util/views.py as well.
     """
     course_key = request.data.get('course_key', None)
+    research_event_data = request.data.get('research_event_data', {})
 
     # If body doesnt contain 'course_key', return 400 to client.
     if not course_key:
         raise ParseError(_("'course_key' is required."))
 
-    # If body contains params other than 'course_key', return 400 to client.
-    if len(request.data) > 1:
-        raise ParseError(_("Only 'course_key' is expected."))
-
     try:
         course_key = CourseKey.from_string(course_key)
-        _course_masquerade, user = setup_masquerade(
+        course_masquerade, user = setup_masquerade(
             request,
             course_key,
             has_access(request.user, 'staff', course_key)
@@ -72,6 +76,19 @@ def reset_course_deadlines(request):
         missed_deadlines, missed_gated_content = dates_banner_should_display(course_key, user)
         if missed_deadlines and not missed_gated_content:
             reset_self_paced_schedule(user, course_key)
+
+            course_overview = course_detail(request, user.username, course_key)
+            # For context here, research_event_data should already contain `location` indicating
+            # the page/location dates were reset from and could also contain `block_id` if reset
+            # within courseware.
+            research_event_data.update({
+                'courserun_key': str(course_key),
+                'is_masquerading': is_masquerading(user, course_key, course_masquerade),
+                'is_staff': has_access(user, 'staff', course_key).has_access,
+                'org_key': course_overview.display_org_with_default,
+                'user_id': user.id,
+            })
+            tracker.emit('edx.ui.lms.reset_deadlines.clicked', research_event_data)
 
         if course_home_mfe_dates_tab_is_active(course_key):
             body_link = get_microfrontend_url(course_key=str(course_key), view_name='dates')

--- a/openedx/features/course_experience/tests/views/test_course_outline.py
+++ b/openedx/features/course_experience/tests/views/test_course_outline.py
@@ -200,9 +200,8 @@ class TestCourseOutlinePage(SharedModuleStoreTestCase, MasqueradeMixin):
     @ddt.data(
         ([CourseMode.AUDIT, CourseMode.VERIFIED], CourseMode.AUDIT, False, True),
         ([CourseMode.AUDIT, CourseMode.VERIFIED], CourseMode.VERIFIED, False, True),
-        ([CourseMode.AUDIT, CourseMode.VERIFIED, CourseMode.MASTERS], CourseMode.MASTERS, False, True),
-        ([CourseMode.PROFESSIONAL], CourseMode.PROFESSIONAL, False, True),
-        ([CourseMode.AUDIT, CourseMode.VERIFIED], CourseMode.VERIFIED, True, False),
+        ([CourseMode.MASTERS], CourseMode.MASTERS, False, True),
+        ([CourseMode.PROFESSIONAL], CourseMode.PROFESSIONAL, True, True),  # staff accounts should also see the banner
     )
     @ddt.unpack
     def test_reset_course_deadlines_banner_shows_for_self_paced_course(

--- a/openedx/features/course_experience/utils.py
+++ b/openedx/features/course_experience/utils.py
@@ -281,13 +281,6 @@ def dates_banner_should_display(course_key, user):
     if not CourseEnrollment.is_enrolled(user, course_key):
         return False, False
 
-    # Don't display the banner for course staff
-    is_course_staff = bool(
-        user and course_overview and has_access(user, 'staff', course_overview, course_overview.id)
-    )
-    if is_course_staff:
-        return False, False
-
     # Don't display the banner if the course has ended
     if course_end_date and course_end_date < timezone.now():
         return False, False

--- a/openedx/features/personalized_learner_schedules/call_to_action.py
+++ b/openedx/features/personalized_learner_schedules/call_to_action.py
@@ -151,6 +151,10 @@ class PersonalizedLearnerScheduleCallToAction:
                     },
                     'url': '{}{}'.format(settings.LMS_ROOT_URL, reverse('course-experience-reset-course-deadlines')),
                 },
+                'research_event_data': {
+                    'block_id': str(xblock.location),
+                    'location': '{category}-view'.format(category=xblock.category),
+                },
             }
 
         return cta_data


### PR DESCRIPTION
<!--
Please give the pull request a short but descriptive title.
Use [conventional commits](https://www.conventionalcommits.org/) to separate and summarize commits logically.

Use this template as a guide. Omit sections that don't apply. You may link to information rather than copy it.
More details about the template are at https://github.com/edx/open-edx-proposals/pull/180
(link will be updated when that document merges)
-->

## Description

Adds research tracking event for reset deadlines
This PR also removes the exemption for staff from seeing the reset
deadlines banner (staff will now see the banner). Staff users would
still be unable to submit problems and wouldn't have a way of resetting
their deadlines while enrolled.

related to https://github.com/edx/frontend-app-learning/pull/355

Example payload for a tab (dates tab or outline tab):
```
{
    'location': 'dates-tab', 
    'courserun_key': 'course-v1:edX+DemoX+Demo_Course', 
    'is_masquerading': False, 
    'is_staff': True, 
    'org_key': 'edX', 
    'user_id': 3
}
```
Example payload for in courseware (Vertical/problem) WITH masquerading
```
{
    'block_id': 'block-v1:edX+DemoX+Demo_Course+type@problem+block@e6dc3b95f5004793a89cc740adc2356c', 
    'location': 'problem-view', 
    'courserun_key': 'course-v1:edX+DemoX+Demo_Course', 
    'is_masquerading': True, 
    'is_staff': False, 
    'org_key': 'edX', 
    'user_id': 7
}
```
Only new field is the block_id for the in courseware for ease of identifying exactly where it happened.

Other notes:
* is_masquerading refers to if the requesting user is currently masquerading
* is_staff refers to the enrollment user (i.e. if masquerading is happening, it refers to the masqueraded user).
* user_id also refers to the enrollment user