### PR TITLE
[TSD] Annotate comprehensive theming settings

### DIFF
--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -1881,16 +1881,28 @@ CREDIT_PROVIDER_TIMESTAMP_EXPIRATION = 15 * 60
 
 CREDIT_PROVIDER_SECRET_KEYS = {}
 
-# dir containing all themes
+# .. setting_name: COMPREHENSIVE_THEME_DIRS
+# .. setting_default: []
+# .. setting_description: See LMS annotation.
 COMPREHENSIVE_THEME_DIRS = []
 
-# Theme directory locale paths
+# .. setting_name: COMPREHENSIVE_THEME_LOCALE_PATHS
+# .. setting_default: []
+# .. setting_description: See LMS annotation.
+#   "COMPREHENSIVE_THEME_LOCALE_PATHS" : ["/edx/src/edx-themes/conf/locale"].
 COMPREHENSIVE_THEME_LOCALE_PATHS = []
 
-# Theme to use when no site or site theme is defined,
-# set to None if you want to use openedx theme
+# .. setting_name: DEFAULT_SITE_THEME
+# .. setting_default: None
+# .. setting_description: See LMS annotation.
 DEFAULT_SITE_THEME = None
 
+# .. toggle_name: ENABLE_COMPREHENSIVE_THEMING
+# .. toggle_implementation: DjangoSetting
+# .. toggle_default: False
+# .. toggle_description: See LMS annotation.
+# .. toggle_use_cases: open_edx
+# .. toggle_creation_date: 2016-06-30
 ENABLE_COMPREHENSIVE_THEMING = False
 
 ############################ Global Database Configuration #####################

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -4056,16 +4056,34 @@ PROGRAM_CERTIFICATES_ROUTING_KEY = 'edx.lms.core.default'
 # Default site to use if site matching request headers does not exist
 SITE_ID = 1
 
-# dir containing all themes
+# .. setting_name: COMPREHENSIVE_THEME_DIRS
+# .. setting_default: []
+# .. setting_description: A list of directories containing themes folders,
+#   each entry should be a full path to the directory containing the theme folder.
 COMPREHENSIVE_THEME_DIRS = []
 
-# Theme directory locale paths
+# .. setting_name: COMPREHENSIVE_THEME_LOCALE_PATHS
+# .. setting_default: []
+# .. setting_description: A list of the paths to themes locale directories e.g.
+#   "COMPREHENSIVE_THEME_LOCALE_PATHS" : ["/edx/src/edx-themes/conf/locale"].
 COMPREHENSIVE_THEME_LOCALE_PATHS = []
 
-# Theme to use when no site or site theme is defined,
-# set to None if you want to use openedx theme
+# .. setting_name: DEFAULT_SITE_THEME
+# .. setting_default: None
+# .. setting_description: Theme to use when no site or site theme is defined, for example
+#   "dark-theme". Set to None if you want to use openedx default theme.
+# .. setting_warning: The theme folder needs to be in 'edx-platform/themes' or define the path
+#   to the theme folder in COMPREHENSIVE_THEME_DIRS. To be effective, ENABLE_COMPREHENSIVE_THEMING
+#   has to be enabled.
 DEFAULT_SITE_THEME = None
 
+# .. toggle_name: ENABLE_COMPREHENSIVE_THEMING
+# .. toggle_implementation: DjangoSetting
+# .. toggle_default: False
+# .. toggle_description: When enabled, this toggle activates the use of the custom theme
+#   defined by DEFAULT_SITE_THEME.
+# .. toggle_use_cases: open_edx
+# .. toggle_creation_date: 2016-06-30
 ENABLE_COMPREHENSIVE_THEMING = False
 
 # API access management

--- a/openedx/core/djangoapps/theming/checks.py
+++ b/openedx/core/djangoapps/theming/checks.py
@@ -8,6 +8,7 @@ import os
 import six
 from django.conf import settings
 from django.core.checks import Error, Tags, register
+from edx_toggles.toggles import SettingToggle
 
 
 @register(Tags.compatibility)
@@ -24,7 +25,7 @@ def check_comprehensive_theme_settings(app_configs, **kwargs):  # lint-amnesty, 
     Returns:
         List of any Errors.
     """
-    if not getattr(settings, "ENABLE_COMPREHENSIVE_THEMING"):  # lint-amnesty, pylint: disable=literal-used-as-attribute
+    if not SettingToggle("ENABLE_COMPREHENSIVE_THEMING", default=False).is_enabled():
         # Only perform checks when comprehensive theming is enabled.
         return []
 

--- a/openedx/core/djangoapps/theming/helpers.py
+++ b/openedx/core/djangoapps/theming/helpers.py
@@ -13,6 +13,7 @@ from logging import getLogger
 import crum
 from django.conf import settings
 
+from edx_toggles.toggles import SettingToggle
 from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
 from openedx.core.djangoapps.theming.helpers_dirs import (
     Theme,
@@ -315,10 +316,12 @@ def is_comprehensive_theming_enabled():
     Returns:
          (bool): True if comprehensive theming is enabled else False
     """
-    if settings.ENABLE_COMPREHENSIVE_THEMING and current_request_has_associated_site_theme():
+    ENABLE_COMPREHENSIVE_THEMING = SettingToggle("ENABLE_COMPREHENSIVE_THEMING", default=False)
+
+    if ENABLE_COMPREHENSIVE_THEMING.is_enabled() and current_request_has_associated_site_theme():
         return True
 
-    return settings.ENABLE_COMPREHENSIVE_THEMING
+    return ENABLE_COMPREHENSIVE_THEMING.is_enabled()
 
 
 def get_config_value_from_site_or_settings(name, site=None, site_config_name=None):


### PR DESCRIPTION
## Description

This PRs adds annotations for the comprehensive theme settings:
- `ENABLE_COMPREHENSIVE_THEMING`
- `DEFAULT_SITE_THEME`
- `COMPREHENSIVE_THEME_DIRS`
- `COMPREHENSIVE_THEME_LOCALE_PATHS`

## Supporting information
This PR part of the doc-a-thon effort.

## Testing instructions
N/A

## Deadline
None