### PR TITLE
replaced unittest assertions pytest assertions (4)

### DIFF
--- a/openedx/core/djangoapps/api_admin/api/v1/tests/test_views.py
+++ b/openedx/core/djangoapps/api_admin/api/v1/tests/test_views.py
@@ -47,8 +47,8 @@ class ApiAccessRequestViewTests(TestCase):
         Assert API response on `API Access Request` endpoint.
         """
         json_content = json.loads(api_response.content.decode('utf-8'))
-        self.assertEqual(api_response.status_code, 200)
-        self.assertEqual(json_content['count'], expected_results_count)
+        assert api_response.status_code == 200
+        assert json_content['count'] == expected_results_count
 
     def test_list_view_for_not_authenticated_user(self):
         """
@@ -66,7 +66,7 @@ class ApiAccessRequestViewTests(TestCase):
         self.client.logout()
 
         response = self.client.get(self.url)
-        self.assertEqual(response.status_code, 401)
+        assert response.status_code == 401
 
     def test_list_view_for_staff_user(self):
         """
@@ -94,5 +94,5 @@ class ApiAccessRequestViewTests(TestCase):
         self.update_user_and_re_login(is_staff=True)
 
         response = self.client.get(self.url + '?user__username={}'.format('non-existing-user-name'))
-        self.assertEqual(response.status_code, 200)
+        assert response.status_code == 200
         self._assert_api_access_request_response(api_response=response, expected_results_count=0)

--- a/openedx/core/djangoapps/api_admin/management/commands/tests/test_create_api_access_request.py
+++ b/openedx/core/djangoapps/api_admin/management/commands/tests/test_create_api_access_request.py
@@ -25,14 +25,8 @@ class TestCreateApiAccessRequest(TestCase):
         cls.user = UserFactory()
 
     def assert_models_exist(self, expect_request_exists, expect_config_exists):
-        self.assertEqual(
-            ApiAccessRequest.objects.filter(user=self.user).exists(),
-            expect_request_exists
-        )
-        self.assertEqual(
-            ApiAccessConfig.objects.filter(enabled=True).exists(),
-            expect_config_exists
-        )
+        assert ApiAccessRequest.objects.filter(user=self.user).exists() == expect_request_exists
+        assert ApiAccessConfig.objects.filter(enabled=True).exists() == expect_config_exists
 
     @ddt.data(False, True)
     def test_create_api_access_request(self, create_config):
@@ -45,14 +39,14 @@ class TestCreateApiAccessRequest(TestCase):
         self.assert_models_exist(False, False)
         call_command(self.command, self.user.username, create_config=True, disconnect_signals=True)
         self.assert_models_exist(True, True)
-        self.assertFalse(mock_send_new_pending_email.called)
+        assert not mock_send_new_pending_email.called
 
     @patch('openedx.core.djangoapps.api_admin.models._send_new_pending_email')
     def test_create_api_access_request_signals_connected(self, mock_send_new_pending_email):
         self.assert_models_exist(False, False)
         call_command(self.command, self.user.username, create_config=True, disconnect_signals=False)
         self.assert_models_exist(True, True)
-        self.assertTrue(mock_send_new_pending_email.called)
+        assert mock_send_new_pending_email.called
 
     def test_config_already_exists(self):
         ApiAccessConfig.objects.create(enabled=True)
@@ -125,12 +119,12 @@ class TestCreateApiAccessRequest(TestCase):
         )
         self.assert_models_exist(True, False)
         request = ApiAccessRequest.objects.get(user=self.user)
-        self.assertEqual(request.status, 'approved')
-        self.assertEqual(request.reason, 'whatever')
-        self.assertEqual(request.website, 'test-site.edx.horse')
+        assert request.status == 'approved'
+        assert request.reason == 'whatever'
+        assert request.website == 'test-site.edx.horse'
 
     def test_default_values(self):
         call_command(self.command, self.user.username)
         request = ApiAccessRequest.objects.get(user=self.user)
-        self.assertEqual(request.site, Site.objects.get_current())
-        self.assertEqual(request.status, ApiAccessRequest.APPROVED)
+        assert request.site == Site.objects.get_current()
+        assert request.status == ApiAccessRequest.APPROVED

--- a/openedx/core/djangoapps/api_admin/tests/test_forms.py
+++ b/openedx/core/djangoapps/api_admin/tests/test_forms.py
@@ -21,7 +21,7 @@ class ApiAccessFormTest(TestCase):
     @ddt.unpack
     def test_form_valid(self, data, is_valid):
         form = ApiAccessRequestForm(data)
-        self.assertEqual(form.is_valid(), is_valid)
+        assert form.is_valid() == is_valid
 
 
 @skip_unless_lms
@@ -43,8 +43,8 @@ class ViewersWidgetTest(TestCase):
             extra_formating=extra_formating,
         )
         output = self.widget.render(name=input_field_name, value=dummy_string_value)
-        self.assertEqual(expected_widget_html, output)
+        assert expected_widget_html == output
 
         dummy_list_value = ['staff', 'verified']
         output = self.widget.render(name=input_field_name, value=dummy_list_value)
-        self.assertEqual(expected_widget_html, output)
+        assert expected_widget_html == output

--- a/openedx/core/djangoapps/api_admin/tests/test_models.py
+++ b/openedx/core/djangoapps/api_admin/tests/test_models.py
@@ -3,6 +3,7 @@
 
 from smtplib import SMTPException
 
+import pytest
 import ddt
 import mock
 import six
@@ -27,21 +28,21 @@ class ApiAccessRequestTests(TestCase):
         self.request = ApiAccessRequestFactory(user=self.user)
 
     def test_default_status(self):
-        self.assertEqual(self.request.status, ApiAccessRequest.PENDING)
-        self.assertFalse(ApiAccessRequest.has_api_access(self.user))
+        assert self.request.status == ApiAccessRequest.PENDING
+        assert not ApiAccessRequest.has_api_access(self.user)
 
     def test_approve(self):
         self.request.approve()
-        self.assertEqual(self.request.status, ApiAccessRequest.APPROVED)
+        assert self.request.status == ApiAccessRequest.APPROVED
 
     def test_deny(self):
         self.request.deny()
-        self.assertEqual(self.request.status, ApiAccessRequest.DENIED)
+        assert self.request.status == ApiAccessRequest.DENIED
 
     def test_nonexistent_request(self):
         """Test that users who have not requested API access do not get it."""
         other_user = UserFactory()
-        self.assertFalse(ApiAccessRequest.has_api_access(other_user))
+        assert not ApiAccessRequest.has_api_access(other_user)
 
     @ddt.data(
         (ApiAccessRequest.PENDING, False),
@@ -52,46 +53,40 @@ class ApiAccessRequestTests(TestCase):
     def test_has_access(self, status, should_have_access):
         self.request.status = status
         self.request.save()
-        self.assertEqual(ApiAccessRequest.has_api_access(self.user), should_have_access)
+        assert ApiAccessRequest.has_api_access(self.user) == should_have_access
 
     def test_unique_per_user(self):
-        with self.assertRaises(IntegrityError):
+        with pytest.raises(IntegrityError):
             ApiAccessRequestFactory(user=self.user)
 
     def test_no_access(self):
         self.request.delete()
-        self.assertIsNone(ApiAccessRequest.api_access_status(self.user))
+        assert ApiAccessRequest.api_access_status(self.user) is None
 
     def test_unicode(self):
         request_unicode = six.text_type(self.request)
-        self.assertIn(self.request.website, request_unicode)
-        self.assertIn(self.request.status, request_unicode)
+        assert self.request.website in request_unicode
+        assert self.request.status in request_unicode
 
     def test_retire_user_success(self):
         retire_result = self.request.retire_user(self.user)
-        self.assertTrue(retire_result)
-        self.assertEqual(self.request.company_address, '')
-        self.assertEqual(self.request.company_name, '')
-        self.assertEqual(self.request.website, '')
-        self.assertEqual(self.request.reason, '')
+        assert retire_result
+        assert self.request.company_address == ''
+        assert self.request.company_name == ''
+        assert self.request.website == ''
+        assert self.request.reason == ''
 
     def test_retire_user_do_not_exist(self):
         user2 = UserFactory()
         retire_result = self.request.retire_user(user2)
-        self.assertFalse(retire_result)
+        assert not retire_result
 
 
 class ApiAccessConfigTests(TestCase):
 
     def test_unicode(self):
-        self.assertEqual(
-            six.text_type(ApiAccessConfig(enabled=True)),
-            u'ApiAccessConfig [enabled=True]'
-        )
-        self.assertEqual(
-            six.text_type(ApiAccessConfig(enabled=False)),
-            u'ApiAccessConfig [enabled=False]'
-        )
+        assert six.text_type(ApiAccessConfig(enabled=True)) == u'ApiAccessConfig [enabled=True]'
+        assert six.text_type(ApiAccessConfig(enabled=False)) == u'ApiAccessConfig [enabled=False]'
 
 
 @skip_unless_lms
@@ -110,7 +105,7 @@ class ApiAccessRequestSignalTests(TestCase):
                 self.api_access_request.save()
 
         mock_new_email.assert_called_once_with(self.api_access_request)
-        self.assertFalse(mock_decision_email.called)
+        assert not mock_decision_email.called
 
     def test_save_signal_success_decision_email(self):
         """ Verify that updating request status sends decision email and no new email. """
@@ -121,7 +116,7 @@ class ApiAccessRequestSignalTests(TestCase):
                 self.api_access_request.approve()
 
         mock_decision_email.assert_called_once_with(self.api_access_request)
-        self.assertFalse(mock_new_email.called)
+        assert not mock_new_email.called
 
     def test_save_signal_success_no_emails(self):
         """ Verify that updating request status again sends no emails. """
@@ -132,12 +127,12 @@ class ApiAccessRequestSignalTests(TestCase):
             with mock.patch(self.send_decision_email_function) as mock_decision_email:
                 self.api_access_request.deny()
 
-        self.assertFalse(mock_decision_email.called)
-        self.assertFalse(mock_new_email.called)
+        assert not mock_decision_email.called
+        assert not mock_new_email.called
 
     def test_save_signal_failure_email(self):
         """ Verify that saving still functions even on email errors. """
-        self.assertIsNone(self.api_access_request.id)
+        assert self.api_access_request.id is None
 
         mail_function = 'openedx.core.djangoapps.api_admin.models.send_mail'
         with mock.patch(mail_function, side_effect=SMTPException):
@@ -149,7 +144,7 @@ class ApiAccessRequestSignalTests(TestCase):
             u'Error sending API user notification email for request [%s].', self.api_access_request.id
         )
         # Verify object saved
-        self.assertIsNotNone(self.api_access_request.id)
+        assert self.api_access_request.id is not None
 
         with mock.patch(mail_function, side_effect=SMTPException):
             with mock.patch.object(model_log, 'exception') as mock_model_log_exception:
@@ -159,4 +154,4 @@ class ApiAccessRequestSignalTests(TestCase):
             u'Error sending API user notification email for request [%s].', self.api_access_request.id
         )
         # Verify object saved
-        self.assertEqual(self.api_access_request.status, ApiAccessRequest.APPROVED)
+        assert self.api_access_request.status == ApiAccessRequest.APPROVED

--- a/openedx/core/djangoapps/api_admin/tests/test_views.py
+++ b/openedx/core/djangoapps/api_admin/tests/test_views.py
@@ -48,13 +48,13 @@ class ApiRequestViewTest(ApiAdminTest):
     def test_get(self):
         """Verify that a logged-in can see the API request form."""
         response = self.client.get(self.url)
-        self.assertEqual(response.status_code, 200)
+        assert response.status_code == 200
 
     def test_get_anonymous(self):
         """Verify that users must be logged in to see the page."""
         self.client.logout()
         response = self.client.get(self.url)
-        self.assertEqual(response.status_code, 302)
+        assert response.status_code == 302
 
     def test_get_with_existing_request(self):
         """
@@ -72,12 +72,12 @@ class ApiRequestViewTest(ApiAdminTest):
         """
         self.assertRedirects(response, reverse('api_admin:api-status'))
         api_request = ApiAccessRequest.objects.get(user=self.user)
-        self.assertEqual(api_request.status, ApiAccessRequest.PENDING)
+        assert api_request.status == ApiAccessRequest.PENDING
         return api_request
 
     def test_post_valid(self):
         """Verify that a logged-in user can create an API request."""
-        self.assertFalse(ApiAccessRequest.objects.all().exists())
+        assert not ApiAccessRequest.objects.all().exists()
         response = self.client.post(self.url, VALID_DATA)
         self._assert_post_success(response)
 
@@ -86,20 +86,20 @@ class ApiRequestViewTest(ApiAdminTest):
         self.client.logout()
         response = self.client.post(self.url, VALID_DATA)
 
-        self.assertEqual(response.status_code, 302)
-        self.assertFalse(ApiAccessRequest.objects.all().exists())
+        assert response.status_code == 302
+        assert not ApiAccessRequest.objects.all().exists()
 
     def test_get_with_feature_disabled(self):
         """Verify that the view can be disabled via ApiAccessConfig."""
         ApiAccessConfig(enabled=False).save()
         response = self.client.get(self.url)
-        self.assertEqual(response.status_code, 404)
+        assert response.status_code == 404
 
     def test_post_with_feature_disabled(self):
         """Verify that the view can be disabled via ApiAccessConfig."""
         ApiAccessConfig(enabled=False).save()
         response = self.client.post(self.url)
-        self.assertEqual(response.status_code, 404)
+        assert response.status_code == 404
 
 
 @skip_unless_lms
@@ -155,13 +155,13 @@ class ApiRequestStatusViewTest(ApiAdminTest):
         """Verify that users must be logged in to see the page."""
         self.client.logout()
         response = self.client.get(self.url)
-        self.assertEqual(response.status_code, 302)
+        assert response.status_code == 302
 
     def test_get_with_feature_disabled(self):
         """Verify that the view can be disabled via ApiAccessConfig."""
         ApiAccessConfig(enabled=False).save()
         response = self.client.get(self.url)
-        self.assertEqual(response.status_code, 404)
+        assert response.status_code == 404
 
     @ddt.data(
         (ApiAccessRequest.APPROVED, True, True),
@@ -188,15 +188,15 @@ class ApiRequestStatusViewTest(ApiAdminTest):
         })
         applications = Application.objects.filter(user=self.user)
         if application_exists and new_application_created:
-            self.assertEqual(applications.count(), 1)
-            self.assertNotEqual(old_application, applications[0])
+            assert applications.count() == 1
+            assert old_application != applications[0]
         elif application_exists:
-            self.assertEqual(applications.count(), 1)
-            self.assertEqual(old_application, applications[0])
+            assert applications.count() == 1
+            assert old_application == applications[0]
         elif new_application_created:
-            self.assertEqual(applications.count(), 1)
+            assert applications.count() == 1
         else:
-            self.assertEqual(applications.count(), 0)
+            assert applications.count() == 0
 
     def test_post_with_errors(self):
         ApiAccessRequestFactory(user=self.user, status=ApiAccessRequest.APPROVED)
@@ -233,7 +233,7 @@ class CatalogTest(ApiAdminTest):
 
     def mock_catalog_endpoint(self, data, catalog_id=None, method=httpretty.GET, status_code=200):
         """ Mock the Course Catalog API's catalog endpoint. """
-        self.assertTrue(httpretty.is_enabled(), msg='httpretty must be enabled to mock Catalog API calls.')
+        assert httpretty.is_enabled(), 'httpretty must be enabled to mock Catalog API calls.'
 
         url = '{root}/catalogs/'.format(root=settings.COURSE_CATALOG_API_URL.rstrip('/'))
         if catalog_id:
@@ -259,7 +259,7 @@ class CatalogSearchViewTest(CatalogTest):
 
     def test_get(self):
         response = self.client.get(self.url)
-        self.assertEqual(response.status_code, 200)
+        assert response.status_code == 200
 
     @httpretty.activate
     def test_post(self):
@@ -295,7 +295,7 @@ class CatalogListViewTest(CatalogTest):
         """Verify that the view works when no catalogs are set up."""
         self.mock_catalog_endpoint({}, status_code=404)
         response = self.client.get(self.url)
-        self.assertEqual(response.status_code, 200)
+        assert response.status_code == 200
 
     @httpretty.activate
     def test_post(self):
@@ -307,7 +307,7 @@ class CatalogListViewTest(CatalogTest):
         catalog_id = 123
         self.mock_catalog_endpoint(dict(catalog_data, id=catalog_id), method=httpretty.POST)
         response = self.client.post(self.url, catalog_data)
-        self.assertEqual(httpretty.last_request().method, 'POST')
+        assert httpretty.last_request().method == 'POST'
         self.mock_catalog_endpoint(CatalogFactory().attributes, catalog_id=catalog_id)
         self.assertRedirects(response, reverse('api_admin:catalog-edit', kwargs={'catalog_id': catalog_id}))
 
@@ -320,9 +320,9 @@ class CatalogListViewTest(CatalogTest):
             'query': '*',
             'viewers': [self.catalog_user.username]
         })
-        self.assertEqual(response.status_code, 400)
+        assert response.status_code == 400
         # Assert that no POST was made to the catalog API
-        self.assertEqual(len([r for r in httpretty.httpretty.latest_requests if r.method == 'POST']), 0)
+        assert len([r for r in httpretty.httpretty.latest_requests if r.method == 'POST']) == 0
 
 
 @skip_unless_lms
@@ -351,12 +351,10 @@ class CatalogEditViewTest(CatalogTest):
         )
         response = self.client.post(self.url, {'delete-catalog': 'on'})
         self.assertRedirects(response, reverse('api_admin:catalog-search'))
-        self.assertEqual(httpretty.last_request().method, 'DELETE')
-        self.assertEqual(
-            httpretty.last_request().path,  # lint-amnesty, pylint: disable=no-member
-            '/api/v1/catalogs/{}/'.format(self.catalog.id)
-        )
-        self.assertEqual(len(httpretty.httpretty.latest_requests), 1)
+        assert httpretty.last_request().method == 'DELETE'  # lint-amnesty, pylint: disable=no-member
+        assert httpretty.last_request().path == \
+               '/api/v1/catalogs/{}/'.format(self.catalog.id)  # lint-amnesty, pylint: disable=no-member
+        assert len(httpretty.httpretty.latest_requests) == 1
 
     @httpretty.activate
     def test_edit(self):
@@ -371,9 +369,9 @@ class CatalogEditViewTest(CatalogTest):
         self.mock_catalog_endpoint(self.catalog.attributes, catalog_id=self.catalog.id)
         new_attributes = dict(self.catalog.attributes, **{'delete-catalog': 'off', 'name': ''})
         response = self.client.post(self.url, new_attributes)
-        self.assertEqual(response.status_code, 400)
+        assert response.status_code == 400
         # Assert that no PATCH was made to the Catalog API
-        self.assertEqual(len([r for r in httpretty.httpretty.latest_requests if r.method == 'PATCH']), 0)
+        assert len([r for r in httpretty.httpretty.latest_requests if r.method == 'PATCH']) == 0
 
 
 @skip_unless_lms
@@ -395,13 +393,10 @@ class CatalogPreviewViewTest(CatalogTest):
             content_type='application/json'
         )
         response = self.client.get(self.url, {'q': '*'})
-        self.assertEqual(response.status_code, 200)
-        self.assertEqual(json.loads(response.content.decode('utf-8')), data)
+        assert response.status_code == 200
+        assert json.loads(response.content.decode('utf-8')) == data
 
     def test_get_without_query(self):
         response = self.client.get(self.url)
-        self.assertEqual(response.status_code, 200)
-        self.assertEqual(
-            json.loads(response.content.decode('utf-8')),
-            {'count': 0, 'results': [], 'next': None, 'prev': None}
-        )
+        assert response.status_code == 200
+        assert json.loads(response.content.decode('utf-8')) == {'count': 0, 'results': [], 'next': None, 'prev': None}


### PR DESCRIPTION
## Description
This PR is using `codemod-unittest-to-pytest-asserts` to automatically replace `unittest` assertions with `pytest` 
for following module:
```
openedx/core/djangoapps/api_admin
```
assertions. I've used one of the forks (PR with changes: https://github.com/mraarif/codemod-unittest-to-pytest-asserts/pull/1) of this codemod that handles a few scenarios that seem to be missing in the upstream repo.
Relevant JIRA issue here: https://openedx.atlassian.net/browse/BOM-2294

