### PR TITLE
Extend expiration of DEPRECATE_OLD_COURSE_KEYS_IN_STUDIO toggle

### DIFF
--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -386,7 +386,7 @@ FEATURES = {
     #        eg: '2020-09-01'
     # .. toggle_use_cases: temporary
     # .. toggle_creation_date: 2020-06-12
-    # .. toggle_target_removal_date: 2020-12-01
+    # .. toggle_target_removal_date: 2021-04-01
     # .. toggle_warnings: This can be removed once support is removed for deprecated
     #   course keys.
     # .. toggle_tickets: https://openedx.atlassian.net/browse/DEPR-58


### PR DESCRIPTION

## Description

This PR just extends the expiration of the feature toggle controlling the Old Mongo deprecation message to Apr 1. We want the feature toggle to exist until the latest end-of-support date for old courses, which is Apr 1 (Edge).

The other two PRs are where we actually set the feature toggles the their new value.

## Other information

See prior art at https://github.com/edx/edx-platform/pull/24804
See TNL ticket https://openedx.atlassian.net/browse/TNL-7932

Also see:
* https://github.com/edx/edx-internal/pull/4340
* https://github.com/edx/edge-internal/pull/300